### PR TITLE
[doc] Remove non-working command to disable push

### DIFF
--- a/doc/ug/github_notes.md
+++ b/doc/ug/github_notes.md
@@ -54,6 +54,7 @@ $ cd <where the repo should go>
 $ git clone https://github.com/$GITHUB_USER/opentitan.git
 $ cd opentitan
 $ git remote add upstream https://github.com/lowRISC/opentitan.git
+$ git fetch upstream
 $ git remote -v
 ```
 


### PR DESCRIPTION
When calling this command I get on git 2.23.0:

```
$ git remote set-url --push upstream disabled
Error: repository disabled/opentitan doesn't exist
```

Most likely git didn't check the remote URL in previous versions, but it
does now.