### PR TITLE
[gpio dv] Multiple fixes and updates in gpio verif env

### DIFF
--- a/hw/dv/sv/common_ifs/pins_if.sv
+++ b/hw/dv/sv/common_ifs/pins_if.sv
@@ -73,9 +73,9 @@ interface pins_if #(
   // make connections
   generate
     for (genvar i = 0; i < Width; i++) begin : each_pin
-      assign (pull0, pull1) pins_int[i] = pins_pd[i] ? 1'b0 :
-                                          pins_pu[i] ? 1'b1 : 1'bz;
-      assign pins[i] = pins_oe[i] ? pins_o[i] : pins_int[i];
+      assign pins_int[i] = pins_pd[i] ? 1'b0 :
+                           pins_pu[i] ? 1'b1 : 1'bz;
+      assign (pull0, pull1) pins[i] = pins_oe[i] ? pins_o[i] : pins_int[i];
     end
   endgenerate
 

--- a/hw/ip/gpio/dv/Makefile
+++ b/hw/ip/gpio/dv/Makefile
@@ -30,9 +30,9 @@ ifeq (${TEST_NAME},gpio_sanity)
   UVM_TEST_SEQ   = gpio_sanity_vseq
 endif
 
-ifeq (${TEST_NAME},gpio_sanity_no_pullup)
+ifeq (${TEST_NAME},gpio_sanity_no_pullup_pulldown)
   UVM_TEST_SEQ   = gpio_sanity_vseq
-  RUN_OPTS      += +active_high_pullup=0
+  RUN_OPTS      += +no_pullup_pulldown=1
 endif
 
 ifeq (${TEST_NAME},gpio_intr_test)
@@ -49,6 +49,7 @@ endif
 ifeq (${TEST_NAME},gpio_csr_rw)
   UVM_TEST_SEQ   = gpio_common_vseq
   RUN_OPTS      += +csr_rw
+  RUN_OPTS      += +do_clear_all_interrupts=0
   RUN_OPTS      += +en_scb=0
 endif
 
@@ -61,6 +62,7 @@ endif
 ifeq (${TEST_NAME},gpio_csr_aliasing)
   UVM_TEST_SEQ   = gpio_common_vseq
   RUN_OPTS      += +csr_aliasing
+  RUN_OPTS      += +do_clear_all_interrupts=0
   RUN_OPTS      += +en_scb=0
 endif
 
@@ -68,9 +70,9 @@ ifeq ($(TEST_NAME),gpio_random_dout_din)
   UVM_TEST_SEQ   = gpio_random_dout_din_vseq
 endif
 
-ifeq ($(TEST_NAME),gpio_random_dout_din_no_pullup)
+ifeq ($(TEST_NAME),gpio_random_dout_din_no_pullup_pulldown)
   UVM_TEST_SEQ   = gpio_random_dout_din_vseq
-  RUN_OPTS      += +active_high_pullup=0
+  RUN_OPTS      += +no_pullup_pulldown=1
 endif
 
 ifeq ($(TEST_NAME),gpio_dout_din_regs_random_rw)
@@ -91,6 +93,11 @@ ifeq ($(TEST_NAME),gpio_intr_with_filter_rand_intr_event)
   UVM_TEST_SEQ   = gpio_intr_with_filter_rand_intr_event_vseq
   RUN_OPTS      += +en_scb=0
   RUN_OPTS      += +zero_delays=1
+  RUN_OPTS      += +do_clear_all_interrupts=0
+endif
+
+ifeq ($(TEST_NAME),gpio_random_long_reg_writes_reg_reads)
+  UVM_TEST_SEQ   = gpio_random_long_reg_writes_reg_reads_vseq
   RUN_OPTS      += +do_clear_all_interrupts=0
 endif
 

--- a/hw/ip/gpio/dv/env/gpio_env_cfg.sv
+++ b/hw/ip/gpio/dv/env/gpio_env_cfg.sv
@@ -4,24 +4,26 @@
 
 class gpio_env_cfg extends cip_base_env_cfg #(.RAL_T(gpio_reg_block));
 
-  bit      active_high_pullup = 1'b1;
-  gpio_vif gpio_vif;
+  // flag to indicate if weak pullup has been introduced on gpio
+  // By default, weak pull up is always present
+  rand bit pullup_en;
+  // flag to indicate if weak pulldown has been introduced on gpio
+  rand bit pulldown_en;
+  // gpio virtual interface
+  gpio_vif      gpio_vif;
+
+  constraint pullup_pulldown_en_c {
+    (pullup_en ^ pulldown_en) == 1'b1;
+  }
 
   `uvm_object_utils(gpio_env_cfg)
-
   `uvm_object_new
 
   virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1,
                                    bit [TL_AW-1:0] csr_addr_map_size = 2048);
     super.initialize();
-    // TODO-Remove plusarg check from here, as it is already
-    // checked from tb module
-    if ($value$plusargs("active_high_pullup=%0b", active_high_pullup)) begin
-      `uvm_info(`gfn, $sformatf("active_high_pullup plusarg value = %0b", active_high_pullup),
-                UVM_HIGH)
-    end
     // set num_interrupts & num_alerts which will be used to create coverage and more
     num_interrupts = ral.intr_state.get_n_used_bits();
-  endfunction
+  endfunction : initialize
 
 endclass

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_base_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_base_vseq.sv
@@ -17,6 +17,34 @@ class gpio_base_vseq extends cip_base_vseq #(
   `uvm_object_utils(gpio_base_vseq)
 
   `uvm_object_new
+  virtual task dut_init(string reset_kind = "HARD");
+    // Check for weak pullup or weak pulldown requirement
+    if (cfg.pullup_en) begin
+      cfg.gpio_vif.set_pullup_en({NUM_GPIOS{1'b1}});
+      `uvm_info(`gfn, "weak pullup applied to gpio's", UVM_HIGH)
+    end else if (cfg.pulldown_en) begin
+      cfg.gpio_vif.set_pulldown_en({NUM_GPIOS{1'b1}});
+      `uvm_info(`gfn, "weak pulldown applied to gpio's", UVM_HIGH)
+    end
+    super.dut_init(reset_kind);
+  endtask : dut_init
+
+  // Function: set_gpio_pulls
+  // This function is meant to override gpio pullup or pulldown value
+  // from extended sequence.
+  // Note: This function does not check whether only one of 'pu' and 'pd' is passed 1.
+  //       If we pass both pu and pd to be 1, gpio pullup will be used.
+  protected function set_gpio_pulls(bit pu = 1'b1, bit pd = 1'b0);
+    bit no_pullup_pulldown;
+    cfg.pullup_en   = pu;
+    cfg.pulldown_en = pd;
+    if ($value$plusargs("no_pullup_pulldown=%0b", no_pullup_pulldown)) begin
+      if (no_pullup_pulldown == 1'b1) begin
+        cfg.pullup_en   = 1'b0;
+        cfg.pulldown_en = 1'b0;
+      end
+    end
+  endfunction
 
   task pre_start();
     super.pre_start();

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_intr_with_filter_rand_intr_event_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_intr_with_filter_rand_intr_event_vseq.sv
@@ -34,7 +34,7 @@ class gpio_intr_with_filter_rand_intr_event_vseq extends gpio_base_vseq;
   task body();
     bit [NUM_GPIOS-1:0] gpio_i;
     bit [TL_DW-1:0] gpio_filter_value;
-    bit [NUM_GPIOS-1:0] stable_value = (cfg.active_high_pullup) ? {NUM_GPIOS{1'b1}} : '0;
+    bit [NUM_GPIOS-1:0] stable_value = (cfg.pullup_en) ? {NUM_GPIOS{1'b1}} : '0;
     bit [TL_DW-1:0] crnt_intr_status;
     `uvm_info(`gfn, $sformatf("num_trans = %0d", num_trans), UVM_HIGH)
     // Wait for FILTER_CYCLES to make sure that we start

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_random_dout_din_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_random_dout_din_vseq.sv
@@ -21,6 +21,13 @@ class gpio_random_dout_din_vseq extends gpio_base_vseq;
   `uvm_object_utils(gpio_random_dout_din_vseq)
   `uvm_object_new
 
+  virtual task dut_init(string reset_kind = "HARD");
+    // Continue using randomized value by default, unless plusarg
+    // no_pullup_pulldown is passed to have no pullup/pulldown
+    set_gpio_pulls(.pu(cfg.pullup_en), .pd(cfg.pulldown_en));
+    super.dut_init(reset_kind);
+  endtask: dut_init
+
   task body();
     `uvm_info(`gfn, $sformatf("num_trans = %0d", num_trans), UVM_HIGH)
     for (uint tr_num = 0; tr_num < num_trans; tr_num++) begin

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_random_long_reg_writes_reg_reads_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_random_long_reg_writes_reg_reads_vseq.sv
@@ -1,0 +1,182 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// class : gpio_random_long_reg_writes_reg_reads_vseq
+// This gpio random test sequence performs random no. of iteration such that
+// each iteration will do either of the following operations:
+//   (i) drives random gpio input data values such that none of the gpios become
+//       unknown value
+//  (ii) writes any of gpio registers except for CTRL_EN_INPUT_FILTER and
+//       INTR_TEST registers
+// (iii) reads any of gpio registers except for CTRL_EN_INPUT_FILTER and
+//       INTR_TEST registers
+class gpio_random_long_reg_writes_reg_reads_vseq extends gpio_base_vseq;
+
+  // predicted value of DATA_OUT rtl implementation register
+  bit [NUM_GPIOS-1:0] data_out;
+  // predicted updated value of DATA_OE rtl implementation register
+  bit [NUM_GPIOS-1:0] data_oe;
+
+  constraint num_trans_c {
+    num_trans inside {[20:200]};
+  }
+
+  `uvm_object_utils(gpio_random_long_reg_writes_reg_reads_vseq)
+  `uvm_object_new
+
+  task body();
+    // gpio pins_if pins_o value to drive
+    bit [NUM_GPIOS-1:0] gpio_i;
+    // gpio pins_if pins_oe value to drive
+    bit [NUM_GPIOS-1:0] gpio_i_oen;
+    `uvm_info(`gfn, $sformatf("num_trans = %0d", num_trans), UVM_HIGH)
+
+    // Wait for minimum 1 clock cycle initially to avoid reading of data_in
+    // immediately as the first iteration after reset, while data_in prediction
+    // is still being processed
+    cfg.clk_rst_vif.wait_clks(1);
+
+    for (uint tr_num = 0; tr_num < num_trans; tr_num++) begin
+      string msg_id = {`gfn, $sformatf(" Transaction-%0d", tr_num)};
+
+      `DV_CHECK_MEMBER_RANDOMIZE_FATAL(delay)
+      cfg.clk_rst_vif.wait_clks(delay);
+
+      randcase
+        // drive new gpio data in
+        1: begin
+          `DV_CHECK_STD_RANDOMIZE_FATAL(gpio_i)
+          `DV_CHECK_STD_RANDOMIZE_FATAL(gpio_i_oen)
+          `uvm_info(msg_id, $sformatf("drive random value 0x%0h on gpio_i", gpio_i), UVM_HIGH)
+          `uvm_info(msg_id, $sformatf("drive random value 0x%0h on gpio_i_oen", gpio_i_oen), UVM_HIGH)
+
+          // drive gpio_vif after setting all output enables to 0's
+          cfg.gpio_vif.pins_oe = gpio_i_oen;
+          cfg.gpio_vif.pins_o = gpio_i;
+          // Wait for one clock cycle for us to read data_in reg reliably
+          cfg.clk_rst_vif.wait_clks(1);
+        end
+        // long reg write
+        1: begin
+          uint no_of_reg_wr;
+          `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(no_of_reg_wr, no_of_reg_wr inside {[10:50]};)
+          `uvm_info(msg_id, $sformatf("performing long write with %0d transactions",
+                                      no_of_reg_wr), UVM_HIGH)
+          repeat (no_of_reg_wr) begin
+            gpio_reg_wr(.gpio_if_pins_o_val(gpio_i), .gpio_if_pins_oe_val(gpio_i_oen));
+          end
+        end
+        // long reg read
+        1: begin
+          uint no_of_reg_rd;
+          `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(no_of_reg_rd, no_of_reg_rd inside {[10:50]};)
+          `uvm_info(msg_id, $sformatf("performing long read with %0d transactions",
+                                      no_of_reg_rd), UVM_HIGH)
+          repeat (no_of_reg_rd) gpio_reg_rd();
+        end
+      endcase
+
+      `uvm_info(msg_id, "End of Transaction", UVM_HIGH)
+
+    end // end for
+
+  endtask : body
+
+  // Task: gpio_reg_wr
+  task gpio_reg_wr(bit [NUM_GPIOS-1:0] gpio_if_pins_o_val,
+                   bit [NUM_GPIOS-1:0] gpio_if_pins_oe_val);
+    bit [TL_DW-1:0] csr_wr_value;
+
+    `DV_CHECK_STD_RANDOMIZE_FATAL(csr_wr_value)
+    randcase
+      1: begin
+        // Writing to DATA_IN reg
+        csr_wr(.csr(ral.data_in), .value(csr_wr_value));
+      end
+      1: begin
+        csr_wr(.csr(ral.direct_out), .value(csr_wr_value));
+      end
+      1: begin
+        csr_wr(.csr(ral.masked_out_lower), .value(csr_wr_value));
+      end
+      1: begin
+        csr_wr(.csr(ral.masked_out_upper), .value(csr_wr_value));
+      end
+      1: begin
+        csr_wr(.csr(ral.direct_oe), .value(csr_wr_value));
+      end
+      1: begin
+        csr_wr(.csr(ral.masked_oe_lower), .value(csr_wr_value));
+      end
+      1: begin
+        csr_wr(.csr(ral.masked_oe_upper), .value(csr_wr_value));
+      end
+      1: begin
+        csr_wr(.csr(ral.intr_enable), .value(csr_wr_value));
+      end
+      1: begin
+        csr_wr(.csr(ral.intr_state), .value(csr_wr_value));
+      end
+      1: begin
+        csr_wr(.csr(ral.intr_ctrl_en_falling), .value(csr_wr_value));
+      end
+      1: begin
+        csr_wr(.csr(ral.intr_ctrl_en_rising), .value(csr_wr_value));
+      end
+      1: begin
+        csr_wr(.csr(ral.intr_ctrl_en_lvllow), .value(csr_wr_value));
+      end
+      1: begin
+        csr_wr(.csr(ral.intr_ctrl_en_lvlhigh), .value(csr_wr_value));
+      end
+    endcase
+  endtask : gpio_reg_wr
+
+  // Task: gpio_reg_rd
+  task gpio_reg_rd();
+    bit [TL_DW-1:0] csr_rd_value;
+    randcase
+      5: begin
+        csr_rd(.ptr(ral.data_in), .value(csr_rd_value));
+      end
+      1: begin
+        csr_rd(.ptr(ral.direct_out), .value(csr_rd_value));
+      end
+      1: begin
+        csr_rd(.ptr(ral.masked_out_lower), .value(csr_rd_value));
+      end
+      1: begin
+        csr_rd(.ptr(ral.masked_out_upper), .value(csr_rd_value));
+      end
+      1: begin
+        csr_rd(.ptr(ral.direct_oe), .value(csr_rd_value));
+      end
+      1: begin
+        csr_rd(.ptr(ral.masked_oe_lower), .value(csr_rd_value));
+      end
+      1: begin
+        csr_rd(.ptr(ral.masked_oe_upper), .value(csr_rd_value));
+      end
+      1: begin
+        csr_rd(.ptr(ral.intr_enable), .value(csr_rd_value));
+      end
+      5: begin
+        csr_rd(.ptr(ral.intr_state), .value(csr_rd_value));
+      end
+      1: begin
+        csr_rd(.ptr(ral.intr_ctrl_en_falling), .value(csr_rd_value));
+      end
+      1: begin
+        csr_rd(.ptr(ral.intr_ctrl_en_rising), .value(csr_rd_value));
+      end
+      1: begin
+        csr_rd(.ptr(ral.intr_ctrl_en_lvllow), .value(csr_rd_value));
+      end
+      1: begin
+        csr_rd(.ptr(ral.intr_ctrl_en_lvlhigh), .value(csr_rd_value));
+      end
+    endcase
+  endtask : gpio_reg_rd
+
+endclass : gpio_random_long_reg_writes_reg_reads_vseq

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_vseq_list.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_vseq_list.sv
@@ -10,3 +10,4 @@
 `include "gpio_intr_rand_pgm_vseq.sv"
 `include "gpio_rand_intr_trigger_vseq.sv"
 `include "gpio_intr_with_filter_rand_intr_event_vseq.sv"
+`include "gpio_random_long_reg_writes_reg_reads_vseq.sv"

--- a/hw/ip/gpio/dv/tb/tb.sv
+++ b/hw/ip/gpio/dv/tb/tb.sv
@@ -23,7 +23,6 @@ module tb;
   wire [NUM_GPIOS-1:0] gpio_intr;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
   wire [NUM_MAX_ALERTS-1:0] alerts;
-  bit active_high_pullup = 1'b1;
 
   // interfaces
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
@@ -54,8 +53,7 @@ module tb;
   assign gpio_i = gpio_pins[NUM_GPIOS-1:0];
   generate
     for (genvar i = 0; i < NUM_GPIOS; i++) begin : each_gpio
-      assign (pull0, pull1) gpio_pins[i] =
-          gpio_oe[i] ? gpio_o[i] : ((active_high_pullup == 1'b1) ? 1'b1 : 1'bz);
+      assign gpio_pins[i] = gpio_oe[i] ? gpio_o[i] : 1'bz;
     end
   endgenerate
 
@@ -67,10 +65,6 @@ module tb;
     uvm_config_db#(alerts_vif)::set(null, "*.env", "alerts_vif", alerts_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
     uvm_config_db#(virtual pins_if #(NUM_GPIOS))::set(null, "*.env", "gpio_vif", gpio_if);
-    if ($value$plusargs("active_high_pullup=%0b", active_high_pullup)) begin
-      `uvm_info("tb", $sformatf("active_high_pullup plusarg value = %0b", active_high_pullup),
-                UVM_HIGH)
-    end
     $timeformat(-12, 0, " ps", 12);
     run_test();
   end


### PR DESCRIPTION
    1.  gpio_env_pkg.sv: Cleanup
    2.  pins_if.sv: Apply pullup/pulldown on pins rather than pins_int
        By doing this, we can model gpio inout functionality correctly
    3.  tb.sv: Remove logic for weak pullup/pulldown and related plusargs
        Now that we are using pins_if functions for this, modify generate
        block logic to allow muxing between gpio output and input
    4.  gpio_env_cfg.sv: Weak pullup/pulldown random variables with default
        constraint to have only one of them as value 1
    5.  gpio_common_vseq.sv: Fixes for gpio csr tests
    6.  gpio_intr_with_filter_rand_intr_event_vseq.sv: Cleanup
    7.  gpio_random_long_reg_writes_reg_reads_vseq.sv:
        New test sequence for "long reg writes and long reg reads" for gpio
    8.  gpio_scoreboard.sv: Check for pullup/pulldown effect based on pins_if
        pins_pu and pins_pd values, rather than cfg member values
        Updated checker to triggerr only when some real gpio activity is seen
    9.  Makefile: Rename active_high_pullup to weak_pullup_en
    10. gpio_sanity_vseq.sv: Re-use base sequence member delay
        Allow delay value 0 as scoreboard is capable of evaluating data_in
        correctly even for that case. Remove check inside sequence as
        scoreboard already checks for correctness of data_in upon reading it
    11. gpio_base_vseq.sv: Sequence based control for gpio pullup/pulldown
    12. gpio_vseq_list.sv: Add new sequence in compilation