### PR TITLE
[util] Actually skip merge commits in commit lint

### DIFF
--- a/util/lint_commits.py
+++ b/util/lint_commits.py
@@ -126,6 +126,8 @@ def main():
         is_merge = len(commit.parents) > 1
         if is_merge and args.no_merges:
             print("Skipping merge commit.")
+            continue
+
         if not lint_commit(commit):
             lint_successful = False
 


### PR DESCRIPTION
Python apparently isn't able to do natural language processing: only
printing a statement that a commit is skipped isn't sufficient, an
explicit `continue` is required; adding that.

(And no, that's not a silly mistake of mine.)