### PR TITLE
[lint] Remove unused localparam

### DIFF
--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_top.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_top.sv
@@ -27,7 +27,6 @@ module flash_ctrl_reg_top (
   localparam AW = 7;
   localparam DW = 32;
   localparam DBW = DW/8;                    // Byte Width
-  localparam logic [$clog2($clog2(DBW)+1)-1:0] FSZ = $clog2(DBW); // Full Size 2^(FSZ) = DBW;
 
   // register signals
   logic           reg_we;

--- a/hw/ip/gpio/rtl/gpio_reg_top.sv
+++ b/hw/ip/gpio/rtl/gpio_reg_top.sv
@@ -22,7 +22,6 @@ module gpio_reg_top (
   localparam AW = 6;
   localparam DW = 32;
   localparam DBW = DW/8;                    // Byte Width
-  localparam logic [$clog2($clog2(DBW)+1)-1:0] FSZ = $clog2(DBW); // Full Size 2^(FSZ) = DBW;
 
   // register signals
   logic           reg_we;

--- a/hw/ip/hmac/rtl/hmac_reg_top.sv
+++ b/hw/ip/hmac/rtl/hmac_reg_top.sv
@@ -27,7 +27,6 @@ module hmac_reg_top (
   localparam AW = 12;
   localparam DW = 32;
   localparam DBW = DW/8;                    // Byte Width
-  localparam logic [$clog2($clog2(DBW)+1)-1:0] FSZ = $clog2(DBW); // Full Size 2^(FSZ) = DBW;
 
   // register signals
   logic           reg_we;

--- a/hw/ip/rv_plic/rtl/rv_plic_reg_top.sv
+++ b/hw/ip/rv_plic/rtl/rv_plic_reg_top.sv
@@ -22,7 +22,6 @@ module rv_plic_reg_top (
   localparam AW = 9;
   localparam DW = 32;
   localparam DBW = DW/8;                    // Byte Width
-  localparam logic [$clog2($clog2(DBW)+1)-1:0] FSZ = $clog2(DBW); // Full Size 2^(FSZ) = DBW;
 
   // register signals
   logic           reg_we;

--- a/hw/ip/rv_timer/rtl/rv_timer_reg_top.sv
+++ b/hw/ip/rv_timer/rtl/rv_timer_reg_top.sv
@@ -22,7 +22,6 @@ module rv_timer_reg_top (
   localparam AW = 9;
   localparam DW = 32;
   localparam DBW = DW/8;                    // Byte Width
-  localparam logic [$clog2($clog2(DBW)+1)-1:0] FSZ = $clog2(DBW); // Full Size 2^(FSZ) = DBW;
 
   // register signals
   logic           reg_we;

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -27,7 +27,6 @@ module spi_device_reg_top (
   localparam AW = 12;
   localparam DW = 32;
   localparam DBW = DW/8;                    // Byte Width
-  localparam logic [$clog2($clog2(DBW)+1)-1:0] FSZ = $clog2(DBW); // Full Size 2^(FSZ) = DBW;
 
   // register signals
   logic           reg_we;

--- a/hw/ip/uart/rtl/uart_reg_top.sv
+++ b/hw/ip/uart/rtl/uart_reg_top.sv
@@ -22,7 +22,6 @@ module uart_reg_top (
   localparam AW = 6;
   localparam DW = 32;
   localparam DBW = DW/8;                    // Byte Width
-  localparam logic [$clog2($clog2(DBW)+1)-1:0] FSZ = $clog2(DBW); // Full Size 2^(FSZ) = DBW;
 
   // register signals
   logic           reg_we;

--- a/hw/ip/usbuart/rtl/usbuart_reg_top.sv
+++ b/hw/ip/usbuart/rtl/usbuart_reg_top.sv
@@ -22,7 +22,6 @@ module usbuart_reg_top (
   localparam AW = 6;
   localparam DW = 32;
   localparam DBW = DW/8;                    // Byte Width
-  localparam logic [$clog2($clog2(DBW)+1)-1:0] FSZ = $clog2(DBW); // Full Size 2^(FSZ) = DBW;
 
   // register signals
   logic           reg_we;

--- a/hw/top_earlgrey/rtl/rv_plic_reg_top.sv
+++ b/hw/top_earlgrey/rtl/rv_plic_reg_top.sv
@@ -22,7 +22,6 @@ module rv_plic_reg_top (
   localparam AW = 9;
   localparam DW = 32;
   localparam DBW = DW/8;                    // Byte Width
-  localparam logic [$clog2($clog2(DBW)+1)-1:0] FSZ = $clog2(DBW); // Full Size 2^(FSZ) = DBW;
 
   // register signals
   logic           reg_we;

--- a/util/reggen/reg_top.tpl.sv
+++ b/util/reggen/reg_top.tpl.sv
@@ -33,7 +33,6 @@ module ${block.name}_reg_top (
   localparam AW = ${block.addr_width};
   localparam DW = ${block.width};
   localparam DBW = DW/8;                    // Byte Width
-  localparam logic [$clog2($clog2(DBW)+1)-1:0] FSZ = $clog2(DBW); // Full Size 2^(FSZ) = DBW;
 
   // register signals
   logic           reg_we;


### PR DESCRIPTION
FSZ is not used in reg_top anymore. So it is removed from the template
and IP reg_tops are re-generated.