### PR TITLE
[hw/formal] Update LEC script for vendor dirs

### DIFF
--- a/hw/formal/rtl_diff.do
+++ b/hw/formal/rtl_diff.do
@@ -14,7 +14,7 @@ read design -golden -sv09 \
   ../../../../ip/prim/rtl/prim_assert.sv \
   ../../../../top_earlgrey/rtl/*_pkg.sv \
   ../../../../ip/*/rtl/*_pkg.sv \
-  ../../../../vendor/*/src/*_pkg.sv \
+  ../../../../vendor/*/*/*_pkg.sv \
   $LEC_GOLDEN
 
 // read revised design
@@ -22,7 +22,7 @@ read design -revised -sv09 \
   ../../../../ip/prim/rtl/prim_assert.sv \
   ../../../../top_earlgrey/rtl/*_pkg.sv \
   ../../../../ip/*/rtl/*_pkg.sv \
-  ../../../../vendor/*/src/*_pkg.sv \
+  ../../../../vendor/*/*/*_pkg.sv \
   $LEC_REVISED
 
 //-----------------------------------------------------------------


### PR DESCRIPTION
Updates include:
- There are packages inside vendor/*/rtl and vendor/*/src, updated the LEC script accordingly.
- For ibex, two additional macros (VERILATOR and RVFI) need to be defined.