### PR TITLE
[hw/ip] use blocking assignment in clock gate

### DIFF
--- a/hw/ip/prim_generic/rtl/prim_generic_clock_gating.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_clock_gating.sv
@@ -15,7 +15,7 @@ module prim_generic_clock_gating (
   logic en_latch;
   always_latch begin
     if (!clk_i) begin
-      en_latch <= en_i | test_en_i;
+      en_latch = en_i | test_en_i;
     end
   end
   assign clk_o = en_latch & clk_i;


### PR DESCRIPTION
Because Conformal LEC tool crashes when non-blocking assignments are used in always_latch, replaced the assignment by blocking assignment.
This change is also consistent with vendor/lowrisc_ibex/rtl/ibex_register_file_latch.sv, which uses blocking assignment inside always_latch block.
Note: we probably should do the same change to the three "prim_clock_gating.sv" modules in vendor/lowrisc_ibex/examples and vendor/lowrist_ibex/dv.