### PR TITLE
[hw/formal] Disable a few more assertions to improve runtime

### DIFF
--- a/hw/formal/fpv.tcl
+++ b/hw/formal/fpv.tcl
@@ -19,7 +19,7 @@ analyze -sv09 \
 elaborate -top $env(FPV_TOP)
 
 #-------------------------------------------------------------------------
-# specify clock(s) and reset(s0
+# specify clock(s) and reset(s)
 #-------------------------------------------------------------------------
 
 # select primary clock and reset condition (use ! for active-low reset)


### PR DESCRIPTION
This is to improve runtime of JasperGold. Without disabling these additional assertions a few blocks will have prohibitive runtimes of several hours.