### PR TITLE
[dv/tl_agent] fixed wrong inclusion of tl_if.sv

### DIFF
--- a/hw/dv/sv/tl_agent/tl_agent.core
+++ b/hw/dv/sv/tl_agent/tl_agent.core
@@ -11,13 +11,13 @@ filesets:
       - lowrisc:tlul:headers:0.1
       - lowrisc:dv:mem_model
     files:
+      - tl_if.sv    
       - tl_agent_pkg.sv
       - tl_if_connect_macros.svh: {is_include_file: true}
       - tl_agent_cfg.sv: {is_include_file: true}
       - tl_agent.sv: {is_include_file: true}
       - tl_device_driver.sv: {is_include_file: true}
       - tl_host_driver.sv: {is_include_file: true}
-      - tl_if.sv: {is_include_file: true}
       - tl_monitor.sv: {is_include_file: true}
       - tl_reg_adapter.sv: {is_include_file: true}
       - tl_seq_item.sv: {is_include_file: true}

--- a/hw/dv/sv/tl_agent/tl_agent_pkg.sv
+++ b/hw/dv/sv/tl_agent/tl_agent_pkg.sv
@@ -3,8 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-`include "tl_if.sv"
-
 package tl_agent_pkg;
   // dep packages
   import uvm_pkg::*;


### PR DESCRIPTION
the tl_if was included directly in the file instead of via fusesoc.
this can cause problems moving on if someone else try to use the interface