### PR TITLE
[gpio dv] Scoreboard updates to compare against correct(latched) reg read data

### DIFF
--- a/hw/ip/gpio/dv/env/gpio_env_pkg.sv
+++ b/hw/ip/gpio/dv/env/gpio_env_pkg.sv
@@ -17,9 +17,9 @@ package gpio_env_pkg;
   `include "dv_macros.svh"
 
   // no. of gpio pins
-  parameter NUM_GPIOS     = 32;
+  parameter uint NUM_GPIOS     = 32;
   // no. of cycles for noise filter
-  parameter FILTER_CYCLES = 16;
+  parameter uint FILTER_CYCLES = 16;
 
   typedef virtual pins_if #(NUM_GPIOS) gpio_vif;
   typedef class gpio_env_cfg;
@@ -27,15 +27,22 @@ package gpio_env_pkg;
   typedef cip_base_virtual_sequencer #(gpio_env_cfg, gpio_env_cov) gpio_virtual_sequencer;
 
   // structure to indicate gpio pin transition and type of transition
-  // transition: 1-yes, 0-no
-  // rose_or_fell: 1-rising edge transition, 0-falling edge transition
-  typedef struct packed { bit transition; bit rose_or_fell; } gpio_transition;
+  // transition_occurred: 1-yes, 0-no
+  // is_rising_edge: 1-rising edge transition, 0-falling edge transition
+  typedef struct packed {
+    bit transition_occurred;
+    bit is_rising_edge;
+  } gpio_transition_t;
 
   // structure to indicate whether or not register update is due for particular gpio register
-  // need_update: 1-update is due, 0-update is not due
+  // needs_update: 1-update is due, 0-update is not due
   // reg_value: value to be updated when update is due
-  typedef struct packed { bit need_update; bit [TL_DW-1:0] reg_value; } gpio_reg_update_due;
-  // functions
+  // eval_time: time stamp of event, which triggered interrupt update
+  typedef struct packed {
+    bit needs_update;
+    bit [TL_DW-1:0] reg_value;
+    time eval_time;
+  } gpio_reg_update_due_t;
 
   // package sources
   `include "gpio_reg_block.sv"

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_rand_intr_trigger_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_rand_intr_trigger_vseq.sv
@@ -38,33 +38,45 @@ class gpio_rand_intr_trigger_vseq extends gpio_base_vseq;
       //   (i) toggle gpio_i input at random intervals
       //  (ii) inject random read on gpio "intr_state" register
       begin
-        uint rd_period;
         uint cnt_gpio_tgl;
         bit gpio_tgl_cycle_done;
         `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(cnt_gpio_tgl, cnt_gpio_tgl inside {[5:20]};)
-        `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(rd_period, rd_period inside {[2:20]};)
         fork
           begin : gpio_in_data_drive
             for (uint iter = 0; iter < cnt_gpio_tgl; iter++) begin
               bit [TL_DW-1:0] gpio_i;
               bit [TL_DW-1:0] data_in;
+              int delay_before_gpio_change;
               `DV_CHECK_STD_RANDOMIZE_FATAL(gpio_i)
+              `uvm_info(msg_id, $sformatf("Driving new gpio value 0x%0h", gpio_i), UVM_HIGH)
               cfg.gpio_vif.drive(gpio_i);
-              cfg.clk_rst_vif.wait_clks(1);
-              // read data_in register
-              csr_rd(.ptr(ral.data_in), .value(data_in));
+              `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(delay_before_gpio_change,
+                                                 delay_before_gpio_change inside {[1:5]};)
+              cfg.clk_rst_vif.wait_clks(delay_before_gpio_change);
             end
             gpio_tgl_cycle_done = 1'b1;
           end
           begin : periodic_intr_state_rd_check
             do begin
-              bit [TL_DW-1:0] intr_state;
+              uint rd_period;
+              bit [TL_DW-1:0] reg_rd_data;
+              `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(rd_period, rd_period inside {[2:20]};)
               cfg.clk_rst_vif.wait_clks(rd_period);
-              // read intr_state register
-              csr_rd(.ptr(ral.intr_state), .value(intr_state));
+              `uvm_info(msg_id, $sformatf("Reading intr_state after %0d more clock cycles",
+                                          rd_period), UVM_HIGH)
+              randcase
+                1: begin
+                  csr_rd(.ptr(ral.data_in), .value(reg_rd_data));
+                end
+                9: begin
+                  csr_rd(.ptr(ral.intr_state), .value(reg_rd_data));
+                end
+              endcase
               // Randomly clear random set of interrupt state register bits
               if ($urandom_range(0, 1)) begin
                 `DV_CHECK_RANDOMIZE_FATAL(ral.intr_state)
+                `uvm_info(msg_id, $sformatf("Writing value 0x%0h to intr_state",
+                          ral.intr_state.get()), UVM_HIGH)
                 csr_update(ral.intr_state);
               end
             end


### PR DESCRIPTION
1. gpio_env_pkg.sv: Updated structure gpio_reg_update_due definition
2. gpio_scoreboard.sv: rtl provides latched values as register read data
   updated prediction for data_in and intr_state registers to match this
   This update makes scoreboard much more reliable and roust for random
   stimulus.
3. gpio_intr_with_filter_rand_intr_event_vseq.sv: Delay intr_state read to
   account for rtl delay
4. gpio_rand_intr_trigger_vseq.sv: Updated to provide more meaningful random
   stimulus that can hit corner cases for intrrupt updates, clearing and
   read back