### PR TITLE
[hw/ip] Resolve TODOs inside bind files

### DIFF
--- a/hw/ip/tlul/common.core
+++ b/hw/ip/tlul/common.core
@@ -14,6 +14,7 @@ filesets:
       - rtl/tlul_fifo_sync.sv
       - rtl/tlul_fifo_async.sv
       - rtl/tlul_assert.sv
+      - rtl/tlul_assert_multiple.sv
     file_type: systemVerilogSource
 
 targets:

--- a/hw/ip/tlul/dv/tb/tlul_socket_1n_bind.sv
+++ b/hw/ip/tlul/dv/tb/tlul_socket_1n_bind.sv
@@ -11,13 +11,11 @@ module tlul_socket_1n_bind;
     .d2h    (tl_h_o)
   );
 
-  // TODO(NilsGraf): because there are N of these tl_d_* interfaces, need to create
-  // a new module tlul_assert_multiple, which instantiates N tlul_assert modules
-  bind tlul_socket_1n tlul_assert tlul_assert_device (
+  bind tlul_socket_1n tlul_assert_multiple #(N) tlul_assert_device (
     .clk_i,
     .rst_ni,
-    .h2d    (tl_d_o[0]),
-    .d2h    (tl_d_i[0])
+    .h2d    (tl_d_o),
+    .d2h    (tl_d_i)
   );
 
 endmodule

--- a/hw/ip/tlul/dv/tb/tlul_socket_m1_bind.sv
+++ b/hw/ip/tlul/dv/tb/tlul_socket_m1_bind.sv
@@ -4,13 +4,11 @@
 
 module tlul_socket_m1_bind;
 
-  // TODO(NilsGraf): because there are M of these tl_h_* interfaces, need to create
-  // a new module tlul_assert_multiple, which instantiates N tlul_assert modules
-  bind tlul_socket_m1 tlul_assert tlul_assert_host (
+  bind tlul_socket_m1 tlul_assert_multiple #(M) tlul_assert_host (
     .clk_i,
     .rst_ni,
-    .h2d    (tl_h_i[0]),
-    .d2h    (tl_h_o[0])
+    .h2d    (tl_h_i),
+    .d2h    (tl_h_o)
   );
 
   bind tlul_socket_m1 tlul_assert tlul_assert_device (

--- a/hw/ip/tlul/dv/tb/xbar_main_bind.sv
+++ b/hw/ip/tlul/dv/tb/xbar_main_bind.sv
@@ -75,6 +75,18 @@ module xbar_main_bind;
     .h2d    (tl_flash_ctrl_o),
     .d2h    (tl_flash_ctrl_i)
   );
+  bind xbar_main tlul_assert tlul_assert_device_rv_timer (
+    .clk_i  (clk_main_i),
+    .rst_ni (rst_main_ni),
+    .h2d    (tl_rv_timer_o),
+    .d2h    (tl_rv_timer_i)
+  );
+  bind xbar_main tlul_assert tlul_assert_device_hmac (
+    .clk_i  (clk_main_i),
+    .rst_ni (rst_main_ni),
+    .h2d    (tl_hmac_o),
+    .d2h    (tl_hmac_i)
+  );
   bind xbar_main tlul_assert tlul_assert_device_plic (
     .clk_i  (clk_main_i),
     .rst_ni (rst_main_ni),

--- a/hw/ip/tlul/rtl/tlul_assert_multiple.sv
+++ b/hw/ip/tlul/rtl/tlul_assert_multiple.sv
@@ -1,0 +1,28 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Protocol checker for multiple TL-UL ports
+
+module tlul_assert_multiple #(
+  parameter N = 2
+) (
+  input clk_i,
+  input rst_ni,
+
+  // tile link ports
+  input tlul_pkg::tl_h2d_t h2d [N],
+  input tlul_pkg::tl_d2h_t d2h [N]
+);
+
+  // instantiate N tlul_assert modules
+  for (genvar ii = 0; ii < N; ii++) begin : gen_assert
+    tlul_assert tlul_assert (
+      .clk_i,
+      .rst_ni,
+      // TL-UL ports
+      .h2d (h2d[ii]),
+      .d2h (d2h[ii])
+    );
+  end
+endmodule


### PR DESCRIPTION
Changes include:
- Add tlul_assert_multiple.sv, which instantiates multiple TL-UL protocol checkers
- Update tlul_socket_1n and m1 bind files to use tlul_assert_multiple