### PR TITLE
[rv_timer/dv] Enhancement to cfg_update_on_fly seq

### DIFF
--- a/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_cfg_update_on_fly_vseq.sv
+++ b/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_cfg_update_on_fly_vseq.sv
@@ -4,11 +4,14 @@
 
 // This sequence update timer configuration while its active/running, this
 // includes updating mtime, mtimecmp. Randomly step and prescale updated
-// after disabling timer.
+// after disabling timer. This seq also exercise upating timer cfg multiple
+// times when timer is close to expire (1 prescale before).
 
 class rv_timer_cfg_update_on_fly_vseq extends rv_timer_sanity_vseq;
   `uvm_object_utils(rv_timer_cfg_update_on_fly_vseq)
   `uvm_object_new
+
+  rand bit upd_cfg_in_end;
 
   // Defing min clocks to have room to update timer cfg
   uint64 min_clks_until_expiry = 10_000;
@@ -17,8 +20,8 @@ class rv_timer_cfg_update_on_fly_vseq extends rv_timer_sanity_vseq;
     solve prescale before ticks;
     foreach (ticks[i]) {
       if (en_harts[i]) {
-        (ticks[i] * prescale[i]) <= max_clks_until_expiry;
-        (ticks[i] * prescale[i]) >= min_clks_until_expiry;
+        (ticks[i] * (prescale[i] + 1)) <= max_clks_until_expiry;
+        (ticks[i] * (prescale[i] + 1)) >= min_clks_until_expiry;
       }
     }
   }
@@ -38,7 +41,7 @@ class rv_timer_cfg_update_on_fly_vseq extends rv_timer_sanity_vseq;
         for (int timer = 0; timer < NUM_TIMERS; timer++) begin
           int    num_clks;
           uint   read_data;
-          uint64 mtime_diff;
+          bit timer_at_min_max_val;
 
           `DV_CHECK_RANDOMIZE_FATAL(this)
 
@@ -48,58 +51,83 @@ class rv_timer_cfg_update_on_fly_vseq extends rv_timer_sanity_vseq;
           // enable timers
           cfg_timer(.hart(hart), .timer(timer), .enable(1'b1));
 
-          // Wait for random num of clks before updating timer cfg
-          num_clks = calculate_num_clks(hart, timer);
-          status_read_for_clks(.hart(hart), .clks($urandom_range((num_clks / 10), (num_clks / 2))));
+          repeat (upd_cfg_in_end ? $urandom_range(4, 8) : 1) begin
 
-          // update timer cfg
-          if ($urandom_range(0, 1)) begin
-            // update either step or prescale
-            if ($urandom_range(0, 1)) begin
-              `uvm_info(`gfn, "Updating timer step value", UVM_LOW)
-              step[hart] = $urandom_range(1, max_step);
+            // Wait and read intr status for clks before updating timer cfg
+            num_clks = calculate_num_clks(hart, timer);
+            if (upd_cfg_in_end) begin
+              num_clks -= prescale[hart] + 4;
             end
             else begin
-              `uvm_info(`gfn, "Updating timer prescale value", UVM_LOW)
-              prescale[hart] = $urandom_range(1, max_prescale);
+              num_clks = $urandom_range((num_clks / 10), (num_clks / 2));
             end
-            // disable timer, update cfg, re enable timer
-            cfg_timer(.hart(hart), .timer(timer), .enable(1'b0));
-            cfg_hart(.hart(hart), .prescale(prescale[hart]), .step(step[hart]));
-            cfg_timer(.hart(hart), .timer(timer), .enable(1'b1));
-          end
+            status_read_for_clks(.hart(hart), .clks(num_clks));
 
-          if ($urandom_range(0, 1)) begin
-            `uvm_info(`gfn, "Updating timer compare value", UVM_LOW)
-            mtime_diff = compare_val[hart][timer] - timer_val[hart];
-            if ($urandom_range(0, 1)) begin
-              compare_val[hart][timer] += $urandom_range((mtime_diff / 20), mtime_diff);
+            // update timer cfg (step/prescale)
+            if (!upd_cfg_in_end & $urandom_range(0, 1)) begin
+              // update either step or prescale
+              if ($urandom_range(0, 1)) begin
+                `uvm_info(`gfn, "Updating timer step value", UVM_LOW)
+                step[hart] = $urandom_range(1, max_step);
+              end
+              else begin
+                `uvm_info(`gfn, "Updating timer prescale value", UVM_LOW)
+                prescale[hart] = $urandom_range(0, max_prescale);
+              end
+              // disable timer, update cfg, re enable timer
+              cfg_timer(.hart(hart), .timer(timer), .enable(1'b0));
+              cfg_hart(.hart(hart), .prescale(prescale[hart]), .step(step[hart]));
+              cfg_timer(.hart(hart), .timer(timer), .enable(1'b1));
+            end
+
+            // update timer and compare reg
+            // bypass updating timer and compare reg if values are close to
+            // zero or max and may get overflow or empty after random update
+            // max_compare_val is calculated using max random value added to
+            // compare_val without overflowing with below randomization which is
+            // ((1 << 64)-1) - (max_step_value*300) = 'hFFFFFFFFFFFED52B
+            // min_timer_val is calculated using max random value subtracted from
+            // timer_val with below randomiztion which is (max_step_value*300) = 'h12AD4
+            if ((compare_val[hart][timer] >= 'hFFFFFFFFFFFED52B) |
+                (timer_val[hart] <= 'h12AD4)) begin
+              timer_at_min_max_val = 1'b1;
+              break;
             end
             else begin
-              compare_val[hart][timer] -= $urandom_range((mtime_diff / 20), (mtime_diff / 4));
+              uint64 mtime_diff;
+              `uvm_info(`gfn, "Updating timer and compare reg", UVM_LOW)
+              mtime_diff = compare_val[hart][timer] - timer_val[hart];
+              if (upd_cfg_in_end | $urandom_range(0, 1)) begin
+                compare_val[hart][timer] += step[hart] * $urandom_range(30, 300);
+              end
+              else begin
+                compare_val[hart][timer] -= $urandom_range((mtime_diff / 20), (mtime_diff / 4));
+              end
+              set_compare_val(.hart(hart), .timer(timer), .val(compare_val[hart][timer]));
+
+              mtime_diff = compare_val[hart][timer] - timer_val[hart];
+              if (!upd_cfg_in_end | $urandom_range(0, 1)) begin
+                timer_val[hart] += $urandom_range((mtime_diff / 20), (mtime_diff / 4));
+              end
+              else begin
+                timer_val[hart] -= step[hart] * $urandom_range(30, 300);
+              end
+              set_timer_val(.hart(hart), .val(timer_val[hart]));
             end
-            set_compare_val(.hart(hart), .timer(timer), .val(compare_val[hart][timer]));
+            // Read timer val reg to get latest value of timer for calc of num_clks
+            read_timer_val_reg(.hart(hart), .mtime_val(timer_val[hart]));
           end
 
-          if ($urandom_range(0, 1)) begin
-            `uvm_info(`gfn, "Updating timer value", UVM_LOW)
-            mtime_diff = compare_val[hart][timer] - timer_val[hart];
-            if ($urandom_range(0, 1)) begin
-              timer_val[hart] += $urandom_range((mtime_diff / 20), (mtime_diff / 4));
-            end
-            else begin
-              timer_val[hart] -= $urandom_range((mtime_diff / 20), mtime_diff);
-            end
-            set_timer_val(.hart(hart), .val(timer_val[hart]));
-          end
-
-          // Read timer val reg to get latest value of timer for calc of num_clks
-          read_timer_val_reg(.hart(hart), .mtime_val(timer_val[hart]));
-          num_clks = calculate_num_clks(hart, timer);
+          // check for no intr asserted
+          read_intr_status_reg(.hart(hart), .status_val(read_data));
+          `DV_CHECK_EQ(read_data, 0)
 
           // random read till for clks = (num_clks - (prescale[hart] + 4))
-          // Subtract prescale to avoid having reg read and timer expire in same time
-          status_read_for_clks(.hart(hart), .clks(num_clks - (prescale[hart] + 4)));
+          // Subtract prescale to avoid having reg read and timer expire at same time
+          if (!(upd_cfg_in_end & timer_at_min_max_val)) begin
+            num_clks = calculate_num_clks(hart, timer);
+            status_read_for_clks(.hart(hart), .clks(num_clks - (prescale[hart] + 4)));
+          end
 
           // wait for (prescale[*] + 5) to let timer expire as per new cfg,
           // one clock extra to avoid race condition btw scoreboard predict and seq reg read

--- a/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_common_vseq.sv
+++ b/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_common_vseq.sv
@@ -23,12 +23,9 @@ class rv_timer_common_vseq extends rv_timer_base_vseq;
       // prevent timer from being enabled
       csr_excl.add_excl({scope, ".", "ctrl.active*"}, CsrExclWrite);
 
-      // TODO: issue lowrisc/opentitan#48
+      // intr_test csr is WO which - it reads back 0s, plus it affects the intr_state csr
       csr_excl.add_excl({scope, ".", "intr_test*"}, CsrExclWrite);
     end
-
-    // TODO: issue lowrisc/opentitan#48
-    csr_excl.add_excl({scope, ".", "intr_state*"}, CsrExclCheck);
   endfunction
 
 endclass

--- a/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_sanity_vseq.sv
+++ b/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_sanity_vseq.sv
@@ -42,7 +42,7 @@ class rv_timer_sanity_vseq extends rv_timer_base_vseq;
   constraint prescale_c {
     solve en_harts before prescale;
     foreach (prescale[i]) {
-      if (en_harts[i])  prescale[i] inside {[1:max_prescale]};
+      if (en_harts[i])  prescale[i] inside {[0:max_prescale]};
       else              prescale[i] == 0;
     }
   }


### PR DESCRIPTION
1. rv_timer_cfg_update_on_fly_vseq: Added support to update timer cfg
close to timer expiry
2. rv_timer_sanity_vseq: update constraint val range
3. cip_base_vseq: Optimize run_intr_test and clear_all_interrupts tasks
4. rv_timer_common_vseq: Deleted exclusion as issue is fixed