### PR TITLE
[hw/formal] Fix rtl_diff_all for rv_plic

### DIFF
--- a/hw/formal/rtl_diff_all
+++ b/hw/formal/rtl_diff_all
@@ -46,9 +46,10 @@ for block in "${blocks[@]}" ; do
     block_full="../${block}/rtl/${block}.sv"
   elif [ $block == "usb_fs_nb_pe" ]; then
     block_full="../ip/usbfs_nb_pe/rtl/${block}.sv"
-    # TODO: perhaps rename usb_fs_* modules to usbfs_*
   elif [[ $block =~ "tlul" ]]; then
     block_full="../ip/tlul/rtl/${block}.sv"
+  elif [[ $block == "rv_plic" ]]; then
+    block_full="../top_earlgrey/rtl/${block}.sv"
   else
     block_full="../ip/${block}/rtl/${block}.sv"
   fi


### PR DESCRIPTION
Now using rv_plic.sv from top_earlgrey directory.