### PR TITLE
[sw/lib] Merge flash_ctrl from boot_rom into lib

### DIFF
--- a/sw/lib/common.h
+++ b/sw/lib/common.h
@@ -30,6 +30,8 @@ static const unsigned long UART_BAUD_RATE = 230400;
 #define SETBIT(val, bit) (val | 1 << bit)
 #define CLRBIT(val, bit) (val & ~(1 << bit))
 
+#define ARRAYSIZE(x) (sizeof(x) / sizeof(x[0]))
+
 /* Hamming weight */
 #define BITLENGTH_1(X) ((X) - (((X) >> 1) & 0x55555555))
 #define BITLENGTH_2(X) (((X)&0x33333333) + (((X) >> 2) & 0x33333333))

--- a/sw/lib/flash_ctrl.c
+++ b/sw/lib/flash_ctrl.c
@@ -1,164 +1,153 @@
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-
 #include "flash_ctrl.h"
 
-#include <stdint.h>
-
 #include "common.h"
+#include "flash_ctrl_regs.h"
 
-static uint32_t get_clr_err(void) {
-  uint32_t err_status;
+#define FLASH_CTRL0_BASE_ADDR 0x40030000
 
-  // extract error status
-  err_status =
-      REG32(FLASH_CTRL_INTR_STATE(0)) & (0x1 << FLASH_CTRL_INTR_STATE_OP_ERROR);
+typedef enum flash_op {
+  FLASH_READ = 0,
+  FLASH_PROG = 1,
+  FLASH_ERASE = 2
+} flash_op_t;
 
-  // clear error if set
-  REG32(FLASH_CTRL_INTR_STATE(0)) = err_status;
+typedef enum erase_type {
+  FLASH_PAGE_ERASE = 0,
+  FLASH_BANK_ERASE = 1
+} erase_type_t;
 
-  // return status
-  return err_status;
+/* Wait for flash command to complete and set ACK in controller */
+static inline void wait_done_and_ack(void) {
+  while ((REG32(FLASH_CTRL_OP_STATUS(0)) & (1 << FLASH_CTRL_OP_STATUS_DONE)) ==
+         0) {
+  }
+  REG32(FLASH_CTRL_OP_STATUS(0)) = 0;
 }
 
-// flash initialization done
-void wait_flash_init(void) {
+void flash_init_block(void) {
   while ((REG32(FLASH_CTRL_STATUS(0)) & (1 << FLASH_CTRL_STATUS_INIT_WIP)) >
          0) {
   }
 }
 
-// wait for flash done and ack
-void wait_done_and_ack(void) {
-  while ((REG32(FLASH_CTRL_OP_STATUS(0)) & (1 << FLASH_CTRL_OP_STATUS_DONE)) ==
-         0)
-    ;
-
-  REG32(FLASH_CTRL_OP_STATUS(0)) = 0;
+/* Return status error and clear internal status register */
+static int get_clr_err(void) {
+  uint32_t err_status =
+      REG32(FLASH_CTRL_INTR_STATE(0)) & (0x1 << FLASH_CTRL_INTR_STATE_OP_ERROR);
+  REG32(FLASH_CTRL_INTR_STATE(0)) = err_status;
+  return err_status;
 }
 
-// setup flash prog
-void setup_flash_prog(uint32_t addr, uint32_t num) {
-  uint32_t val;
-
-  val = FlashProg << FLASH_CTRL_CONTROL_OP_OFFSET |
-        (num - 1) << FLASH_CTRL_CONTROL_NUM_OFFSET |
-        0x1 << FLASH_CTRL_CONTROL_START;
-
-  REG32(FLASH_CTRL_ADDR(0)) = addr;
-
-  REG32(FLASH_CTRL_CONTROL(0)) = val;
-}
-
-// program data
-uint32_t prog_flash(uint32_t addr, uint32_t num, uint32_t *data) {
-  uint32_t i = 0;
-
-  // setup flash programming
-  setup_flash_prog(addr, num);
-
-  // beginning filling up the fifo
-  for (i = 0; i < num; i++) {
-    REG32(FLASH_CTRL_PROG_FIFO(0)) = *data;
-    data++;
+int flash_check_empty(void) {
+  uint32_t mask = -1u;
+  uint32_t *p = (uint32_t *)FLASH_MEM_BASE_ADDR;
+  // TODO: Update range to cover entire flash. Limited now to one bank while
+  // we debu initialization.
+  for (; p < (uint32_t *)(FLASH_MEM_BASE_ADDR + FLASH_BANK_SZ);) {
+    mask &= *p++;
+    mask &= *p++;
+    mask &= *p++;
+    mask &= *p++;
+    mask &= *p++;
+    mask &= *p++;
+    mask &= *p++;
+    mask &= *p++;
+    if (mask != -1u) {
+      return 0;
+    }
   }
+  return 1;
+}
 
-  // wait for operation finish
+int flash_bank_erase(bank_index_t idx) {
+  REG32(FLASH_CTRL_MP_BANK_CFG(0)) =
+      0x1 << ((idx == FLASH_BANK_0) ? FLASH_CTRL_MP_BANK_CFG_ERASE_EN0
+                                    : FLASH_CTRL_MP_BANK_CFG_ERASE_EN1);
+
+  // TODO: Add timeout conditions and add error codes.
+  REG32(FLASH_CTRL_ADDR(0)) = (idx == FLASH_BANK_0)
+                                  ? FLASH_MEM_BASE_ADDR
+                                  : (FLASH_MEM_BASE_ADDR + FLASH_BANK_SZ);
+  REG32(FLASH_CTRL_CONTROL(0)) =
+      (FLASH_ERASE << FLASH_CTRL_CONTROL_OP_OFFSET |
+       FLASH_BANK_ERASE << FLASH_CTRL_CONTROL_ERASE_SEL |
+       0x1 << FLASH_CTRL_CONTROL_START);
   wait_done_and_ack();
 
-  // return error status
+  REG32(FLASH_CTRL_MP_BANK_CFG(0)) =
+      0x0 << ((idx == FLASH_BANK_0) ? FLASH_CTRL_MP_BANK_CFG_ERASE_EN0
+                                    : FLASH_CTRL_MP_BANK_CFG_ERASE_EN1);
   return get_clr_err();
 }
 
-// read data
-uint32_t read_flash(uint32_t addr, uint32_t num, uint32_t *data) {
-  uint32_t val;
-  uint32_t i = 0;
-
-  // kick off flash operation
-  val = FlashRead << FLASH_CTRL_CONTROL_OP_OFFSET |
-        (num - 1) << FLASH_CTRL_CONTROL_NUM_OFFSET |
-        0x1 << FLASH_CTRL_CONTROL_START;
-
+int flash_page_erase(uint32_t addr) {
   REG32(FLASH_CTRL_ADDR(0)) = addr;
+  REG32(FLASH_CTRL_CONTROL(0)) = FLASH_ERASE << FLASH_CTRL_CONTROL_OP_OFFSET |
+                                 FLASH_PAGE_ERASE
+                                     << FLASH_CTRL_CONTROL_ERASE_SEL |
+                                 0x1 << FLASH_CTRL_CONTROL_START;
+  wait_done_and_ack();
+  return get_clr_err();
+}
 
-  REG32(FLASH_CTRL_CONTROL(0)) = val;
+static int flash_write_internal(uint32_t addr, const uint32_t *data,
+                                uint32_t size) {
+  // TODO: Do we need to select bank as part of the write?
+  // TODO: Update with address alignment requirements.
+  REG32(FLASH_CTRL_ADDR(0)) = addr;
+  REG32(FLASH_CTRL_CONTROL(0)) = (FLASH_PROG << FLASH_CTRL_CONTROL_OP_OFFSET |
+                                  (size - 1) << FLASH_CTRL_CONTROL_NUM_OFFSET |
+                                  0x1 << FLASH_CTRL_CONTROL_START);
+  for (int i = 0; i < size; ++i) {
+    REG32(FLASH_CTRL_PROG_FIFO(0)) = data[i];
+  }
+  wait_done_and_ack();
+  return get_clr_err();
+}
 
-  while (i < num) {
-    // if not empty, read a word
+int flash_write(uint32_t addr, const uint32_t *data, uint32_t size) {
+  // TODO: Breakdown into FIFO chunks if needed.
+  return flash_write_internal(addr, data, size);
+}
+
+int flash_read(uint32_t addr, uint32_t size, uint32_t *data) {
+  REG32(FLASH_CTRL_ADDR(0)) = addr;
+  REG32(FLASH_CTRL_CONTROL(0)) = FLASH_READ << FLASH_CTRL_CONTROL_OP_OFFSET |
+                                 (size - 1) << FLASH_CTRL_CONTROL_NUM_OFFSET |
+                                 0x1 << FLASH_CTRL_CONTROL_START;
+  for (uint32_t i = 0; i < size;) {
     if (((REG32(FLASH_CTRL_STATUS(0)) >> FLASH_CTRL_STATUS_RD_EMPTY) & 0x1) ==
         0) {
       *data++ = REG32(FLASH_CTRL_RD_FIFO(0));
       i++;
     }
   }
-
-  // wait for operation finish
   wait_done_and_ack();
-
-  // return error status
   return get_clr_err();
 }
 
-// page erase flash
-// wrap down to closest down to page boundary
-uint32_t page_erase(uint32_t addr) {
-  uint32_t val;
-  uint32_t data[ERASE_CHECK_WORDS];
-  uint32_t verify_rounds;
-  uint32_t error;
-
-  error = 0;
-  verify_rounds = WORDS_PER_PAGE / ERASE_CHECK_WORDS;
-
-  // kick off flash operation
-  val = FlashErase << FLASH_CTRL_CONTROL_OP_OFFSET |
-        PageErase << FLASH_CTRL_CONTROL_ERASE_SEL |
-        0x1 << FLASH_CTRL_CONTROL_START;
-
-  REG32(FLASH_CTRL_ADDR(0)) = addr;
-
-  REG32(FLASH_CTRL_CONTROL(0)) = val;
-
-  // wait for operation finish
-  wait_done_and_ack();
-
-  error += get_clr_err();
-
-  // verify erase
-  for (uint32_t i = 0; i < verify_rounds; i++) {
-    error += read_flash(addr + i * ERASE_CHECK_WORDS * BYTES_PER_WORD,
-                        ERASE_CHECK_WORDS, data);
-
-    for (uint32_t j = 0; j < ERASE_CHECK_WORDS; j++) {
-      if (data[i] != 0xFFFFFFFF) {
-        REG32(FLASH_CTRL_SCRATCH(0)) = data[i];
-
-        // re-init array
-        data[i] = 0;
-        error++;
-      }
-    }
-  }
-
-  // return error status
-  return error;
-}
-
-void flash_default_region(uint32_t rd_en, uint32_t prog_en, uint32_t erase_en) {
+void flash_default_region_access(bool rd_en, bool prog_en, bool erase_en) {
   REG32(FLASH_CTRL_DEFAULT_REGION(0)) =
       rd_en << FLASH_CTRL_DEFAULT_REGION_RD_EN |
       prog_en << FLASH_CTRL_DEFAULT_REGION_PROG_EN |
       erase_en << FLASH_CTRL_DEFAULT_REGION_ERASE_EN;
 }
 
-void flash_cfg_region(mp_region_t region_cfg) {
-  REG32(FLASH_CTRL_MP_REGION_CFG0(0) + region_cfg.num * 4) =
-      region_cfg.base << FLASH_CTRL_MP_REGION_CFG0_BASE0_OFFSET |
-      region_cfg.size << FLASH_CTRL_MP_REGION_CFG0_SIZE0_OFFSET |
-      region_cfg.rd_en << FLASH_CTRL_MP_REGION_CFG0_RD_EN0 |
-      region_cfg.prog_en << FLASH_CTRL_MP_REGION_CFG0_PROG_EN0 |
-      region_cfg.erase_en << FLASH_CTRL_MP_REGION_CFG0_ERASE_EN0 |
+void flash_cfg_region(const mp_region_t *region_cfg) {
+  REG32(FLASH_CTRL_MP_REGION_CFG0(0) + region_cfg->num * 4) =
+      region_cfg->base << FLASH_CTRL_MP_REGION_CFG0_BASE0_OFFSET |
+      region_cfg->size << FLASH_CTRL_MP_REGION_CFG0_SIZE0_OFFSET |
+      region_cfg->rd_en << FLASH_CTRL_MP_REGION_CFG0_RD_EN0 |
+      region_cfg->prog_en << FLASH_CTRL_MP_REGION_CFG0_PROG_EN0 |
+      region_cfg->erase_en << FLASH_CTRL_MP_REGION_CFG0_ERASE_EN0 |
       0x1 << FLASH_CTRL_MP_REGION_CFG0_EN0;
 }
+
+void flash_write_scratch_reg(uint32_t value) {
+  REG32(FLASH_CTRL_SCRATCH(0)) = value;
+}
+
+uint32_t flash_read_scratch_reg(void) { return REG32(FLASH_CTRL_SCRATCH(0)); }

--- a/sw/lib/flash_ctrl.h
+++ b/sw/lib/flash_ctrl.h
@@ -2,42 +2,94 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef _FLASH_H_
-#define _FLASH_H_
+#ifndef _F_FLASH_CTRL_H__
+#define _F_FLASH_CTRL_H__
 
+#include <stdbool.h>
 #include <stdint.h>
 
-#include "flash_ctrl_regs.h"
+/**
+ * Flash bank IDs
+ */
+typedef enum bank_index { FLASH_BANK_0 = 0, FLASH_BANK_1 = 1 } bank_index_t;
 
-#define FLASH_CTRL0_BASE_ADDR 0x40030000
-#define WORDS_PER_PAGE 256
-#define ERASE_CHECK_WORDS 16
-#define BYTES_PER_WORD 4
-
-typedef enum flash_op {
-  FlashRead = 0,
-  FlashProg = 1,
-  FlashErase = 2
-} flash_op_t;
-
-typedef enum erase_type { PageErase = 0, BankErase = 1 } erase_type_t;
-
+/**
+ * Memory protection configuration options.
+ */
 typedef struct mp_region {
-  uint32_t num;  // which region to program
+  /** Which region to program. */
+  uint32_t num;
+  /** Region offset. */
   uint32_t base;
+  /** Region config size. */
   uint32_t size;
+  /** Read enable flag. */
   uint32_t rd_en;
+  /** Program enable flag. */
   uint32_t prog_en;
+  /** Erase enable flag. */
   uint32_t erase_en;
 } mp_region_t;
 
-void wait_flash_init(void);
-void wait_done_and_ack(void);
-void setup_flash_prog(uint32_t addr, uint32_t num);
-uint32_t prog_flash(uint32_t addr, uint32_t num, uint32_t *data);
-uint32_t read_flash(uint32_t addr, uint32_t num, uint32_t *data);
-uint32_t page_erase(uint32_t addr);
-void flash_default_region(uint32_t rd_en, uint32_t prog_en, uint32_t erase_en);
-void flash_cfg_region(mp_region_t region_cfg);
+/**
+ * Block until flash is initialized.
+ */
+void flash_init_block(void);
 
-#endif
+/**
+ * Returns 1 if flash is empty, otherwise 0.
+ */
+int flash_check_empty(void);
+
+/*
+ * Erase flash bank |bank_idx|. Blocks until erase is complete.
+ *
+ * @param idx Flash bank index.
+ * @return Non zero on failure.
+ */
+int flash_bank_erase(bank_index_t idx);
+int flash_page_erase(uint32_t addr);
+
+/**
+ * Write |data| at |addr| offset with |size| in 4B words
+ *
+ * @param addr Flash address 32bit aligned.
+ * @param data Data to write.
+ * @param size Number of 4B words to write from |data| buffer.
+ * @return Non zero on failure.
+ */
+int flash_write(uint32_t addr, const uint32_t *data, uint32_t size);
+
+/**
+ * Read |size| 4B words and write result to |data|.
+ *
+ * @param addr Read start address.
+ * @param size Number of 4B words to read.
+ * @param data Output buffer.
+ * @return Non zero on failure.
+ */
+int flash_read(uint32_t addr, uint32_t size, uint32_t *data);
+
+/**
+ * Set flash controller default permissions.
+ *
+ * @param rd_end Read enable.
+ * @param prog_en Write enable.
+ * @param erase_en Erase enable.
+ */
+void flash_default_region_access(bool rd_en, bool prog_en, bool erase_en);
+
+/**
+ * Configure memory protection region.
+ *
+ * @param region_cfg Region configuration.
+ */
+void flash_cfg_region(const mp_region_t *region_cfg);
+
+/** Write value to flash scratch register */
+void flash_write_scratch_reg(uint32_t value);
+
+/** Read scratch register */
+uint32_t flash_read_scratch_reg(void);
+
+#endif  // _F_FLASH_CTRL_H__

--- a/sw/tests/flash_ctrl/Makefile
+++ b/sw/tests/flash_ctrl/Makefile
@@ -4,8 +4,8 @@
 #
 # Generate a baremetal application for the microcontroller
 
-NAME         = hello_flash
-SRCS         = hello_flash.c
+NAME         = flash_test
+SRCS         = flash_test.c
 PROGRAM_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
 include ${PROGRAM_DIR}/../../exts/common/options.mk


### PR DESCRIPTION
This is the first commit in a series of changes to move the boot_rom device interface function modules into the lib folder.

List of changes: 

* Updated sw/lib/flash_ctrl.c to follow API naming conventions from
  boot_rom.
* Added Doxygen doc strings.
* Updated enums to use DEFINE_FORMAT.
* Renamed sw/tests/hello_flash/hello_flash.c as
  sw/tests/flash_ctrl/flash_test.c.
* Updated flash_test.c to use new flash_ctrl API.