### PR TITLE
[dv] Fix xcelium compile errors

### DIFF
--- a/hw/dv/sv/tl_agent/tl_device_driver.sv
+++ b/hw/dv/sv/tl_agent/tl_device_driver.sv
@@ -64,7 +64,7 @@ class tl_device_driver extends uvm_driver#(tl_seq_item);
       end else begin
         d_valid_delay = $urandom_range(cfg.d_valid_delay_min, cfg.d_valid_delay_max);
       end
-      repeat (d_valid_delay) @(vif.host_cb);
+      repeat (d_valid_delay) @(vif.device_cb);
       vif.device_cb.d2h.d_valid  <= 1'b1;
       vif.device_cb.d2h.d_opcode <= tlul_pkg::tl_d_op_e'(rsp.d_opcode);
       vif.device_cb.d2h.d_data   <= rsp.d_data;

--- a/hw/dv/sv/tl_agent/tl_if.sv
+++ b/hw/dv/sv/tl_agent/tl_if.sv
@@ -7,8 +7,10 @@
 // ---------------------------------------------
 interface tl_if(input clk, input rst_n);
 
-  tlul_pkg::tl_h2d_t h2d; // req
-  tlul_pkg::tl_d2h_t d2h; // rsp
+  wire tlul_pkg::tl_h2d_t h2d; // req
+  wire tlul_pkg::tl_d2h_t d2h; // rsp
+  modport dut_host_mp(output h2d, input d2h);
+  modport dut_device_mp(input h2d, output d2h);
 
   clocking host_cb @(posedge clk);
     input  rst_n;

--- a/hw/dv/sv/uart_agent/uart_if.sv
+++ b/hw/dv/sv/uart_agent/uart_if.sv
@@ -4,7 +4,7 @@
 //
 interface uart_if #(time UartDefaultClkPeriodNs = 104166.667ns) ();
   logic uart_rx;
-  logic uart_tx;
+  wire uart_tx;
   logic uart_tx_en;
 
   // generate local clk
@@ -13,11 +13,6 @@ interface uart_if #(time UartDefaultClkPeriodNs = 104166.667ns) ();
   int   uart_tx_clk_pulses = 0;
   bit   uart_rx_clk = 1'b1;
   int   uart_rx_clk_pulses = 0;
-
-  clocking drv_tx_cb @(posedge uart_tx_clk);
-    output uart_tx;
-  endclocking
-  modport drv_tx_mp(clocking drv_tx_cb);
 
   clocking mon_tx_cb @(negedge uart_tx_clk);
     input  #10ns uart_tx;


### PR DESCRIPTION
Fix issue #117 
1. use wire struct in tl_if
2. change uart_tx to wire
3. fix tl_device_driver hierarchy path typo