### PR TITLE
[dv] Update DV top level C target rules

### DIFF
--- a/hw/dv/tools/rules.mk
+++ b/hw/dv/tools/rules.mk
@@ -48,16 +48,15 @@ ifneq (${CAPP_NAME},)
 	# Recursive make calls
 	make distclean -C ${SW_DIR}/boot_rom
 	make -C ${SW_DIR}/boot_rom
-	make distclean -C ${SW_DIR}/tests/${CAPP_NAME} MAKEFLAGS=$(CAPP_BUILD_OPTS)
-	make -C ${PRJ_DIR}/sw/tests/${CAPP_NAME} MAKEFLAGS=$(CAPP_BUILD_OPTS) \
+	make distclean -C ${SW_DIR}/${CAPP_DIR} MAKEFLAGS=$(CAPP_BUILD_OPTS)
+	make -C ${SW_DIR}/${CAPP_DIR} MAKEFLAGS=$(CAPP_BUILD_OPTS) \
 	PROGRAM_CFLAGS=$(PROGRAM_CFLAGS)
 
 	# Copy outputs over to run area
 	cp $(SW_DIR)/boot_rom/boot_rom.vmem ${RUN_DIR}/rom.vmem
-	cp ${SW_DIR}/tests/${CAPP_NAME}/${CAPP_NAME}.vmem ${RUN_DIR}/main.vmem
-	cp ${SW_DIR}/tests/${CAPP_NAME}/${CAPP_NAME}.dis ${RUN_DIR}/main.dis
-	cp ${SW_DIR}/tests/${CAPP_NAME}/${CAPP_NAME}.map ${RUN_DIR}/main.map
-
+	cp ${SW_DIR}/${CAPP_DIR}/${CAPP_NAME}.vmem ${RUN_DIR}/main.vmem
+	cp ${SW_DIR}/${CAPP_DIR}/${CAPP_NAME}.dis ${RUN_DIR}/main.dis
+	cp ${SW_DIR}/${CAPP_DIR}/${CAPP_NAME}.map ${RUN_DIR}/main.map
 endif
 
 simulate: capp

--- a/hw/top_earlgrey/dv/Makefile
+++ b/hw/top_earlgrey/dv/Makefile
@@ -28,25 +28,30 @@ UVM_TEST        ?= chip_base_test
 UVM_TEST_SEQ    ?= chip_base_vseq
 
 ifeq (${TEST_NAME},chip_sanity)
+  CAPP_DIR       = examples/hello_world
   CAPP_NAME      = hello_world
 endif
 
-ifeq (${TEST_NAME},chip_sanity_flash)
-  CAPP_NAME      = hello_flash
+ifeq (${TEST_NAME},chip_flash_test)
+  CAPP_DIR       = tests/flash_ctrl
+  CAPP_NAME      = flash_test
   RUN_OPTS      += +cpu_test_timeout_ns=15000000
 endif
 
-ifeq (${TEST_NAME},chip_sanity_hmac)
-  CAPP_NAME      = sanity_hmac
+ifeq (${TEST_NAME},chip_sha256_test)
+  CAPP_DIR       = tests/hmac
+  CAPP_NAME      = sha256_test
   RUN_OPTS      += +cpu_test_timeout_ns=4000000
 endif
 
-ifeq (${TEST_NAME},chip_sanity_timer)
-  CAPP_NAME      = sanity_timer
+ifeq (${TEST_NAME},chip_rv_timer_test)
+  CAPP_DIR       = tests/rv_timer
+  CAPP_NAME      = rv_timer_test
   RUN_OPTS      += +cpu_test_timeout_ns=4000000
 endif
 
 ifeq (${TEST_NAME},coremark)
+  CAPP_DIR         = coremark
   CAPP_NAME        = coremark
   RUN_OPTS        += +cpu_test_timeout_ns=20000000
   CAPP_BUILD_OPTS += ITERATIONS=1


### PR DESCRIPTION
Update top level DV rules to point to new CAPP locations. Since the
test names will not always match the directory name, add CAPP_DIR to
set the CAPP directory name.