### PR TITLE
[sw/lib] Merge spi_device from boot_rom.

### DIFF
--- a/sw/lib/spi_device.h
+++ b/sw/lib/spi_device.h
@@ -5,31 +5,34 @@
 #ifndef _SPI_DEVICE_H_
 #define _SPI_DEVICE_H_
 
-#include <stddef.h>
+#include <stdint.h>
 
-#include "common.h"
-
-#define SPI_DEVICE0_BASE_ADDR 0x40020000
-
-#include "spi_device_regs.h"
-
-#define SPID_SRAM_ADDR SPI_DEVICE_BUFFER(0)
-#define SPID_RXF_BASE 0x000
-#define SPID_RXF_SIZE 0x400
-#define SPID_TXF_BASE 0x600
-#define SPID_TXF_SIZE 0x200
-
-#define SPID_SRAM_SIZE (0x800)
-
-/* Note: these will correctly remove the phase bit */
-#define READ32_RXFPTR(P) \
-  REG32(SPID_SRAM_ADDR + SPID_RXF_BASE + ((P) & (SPID_RXF_SIZE - 1)))
-
-#define ACCESS32_TXFPTR(P) \
-  REG32(SPID_SRAM_ADDR + SPID_TXF_BASE + ((P) & ((SPID_TXF_SIZE - 1) & ~0x3)))
-
+/**
+ * Init SPI Device
+ *
+ * Configure registers, RXF_ADDR, TXF_ADDR, CTRL.TIMER_V
+ */
 void spid_init(void);
-size_t spid_send(void *data, size_t len_bytes);
-size_t spid_read_nb(void *data, size_t len);
+
+/**
+ * Send data over SPI
+ *
+ * @param data pointer to buffer of uint_8 to send
+ * @param len_bytes number of bytes to send
+ * @return number of bytes actually sent (<len if no space in the fifo)
+ */
+uint32_t spid_send(void *data, uint32_t len_bytes);
+
+/**
+ * Read the amount of the data from SRAM RX FIFO
+ *
+ * If remained data is smaller than length, it returns only up to data.
+ */
+uint32_t spid_read_nb(void *data, uint32_t len);
+
+/**
+ * Returns the number of bytes available to read on the RX buffer
+ */
+uint32_t spid_bytes_available(void);
 
 #endif /* _SPI_DEVICE_H_ */


### PR DESCRIPTION
Merge spi_device code from boot_rom into sw/lib folder. The boot_rom
version of spi_device contains Doxygen docstrings in the header, and
also hides implementation details from the interface.

TEST=Manually build examples/* and tests/* targets.