### PR TITLE
Temporary fix to scanmode_i

### DIFF
--- a/hw/top_earlgrey/rtl/top_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_asic.sv
@@ -54,7 +54,9 @@ module top_earlgrey_asic (
 
     .cio_gpio_gpio_p2d_i       (cio_gpio_p2d),
     .cio_gpio_gpio_d2p_o       (cio_gpio_d2p),
-    .cio_gpio_gpio_en_d2p_o    (cio_gpio_en_d2p)
+    .cio_gpio_gpio_en_d2p_o    (cio_gpio_en_d2p),
+
+    .scanmode_i           (1'b0)
   );
 
   // pad control


### PR DESCRIPTION
top_earlgrey now checks for scanmode being known.  It is not clear at the
momemnt where and what hierarchy level scanmode should be generated, so for
now stay consistent with FPGA and tie it off at the simulation wrapper