### PR TITLE
Add 1 to the reqfifo depth

### DIFF
--- a/hw/ip/tlul/rtl/tlul_adapter_sram.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_sram.sv
@@ -145,7 +145,12 @@ module tlul_adapter_sram #(
   prim_fifo_sync #(
     .Width  (ReqFifoWidth),
     .Pass   (1'b0),
-    .Depth  (Outstanding)
+  // The oustanding+1 allows the reqfifo to absorb back to back transactions
+  // without any wait states.  Alternatively, the depth can be kept as
+  // oustanding as long as the outgoing ready is qualified with the acceptance
+  // of the response in the same cycle.  Doing so however creates a path from
+  // ready_i to ready_o, which may not be desireable.
+    .Depth  (Outstanding+1'b1)
   ) u_reqfifo (
     .clk_i,
     .rst_ni,


### PR DESCRIPTION
In the best case, sram can complete a transaction immediately on the next cycle.
When this happens, the adapter should immediately accept the next transaction.
However, if the reqfifo is sized to the same depth as the outstanding capacity,
it is not able to do so without creating a response -> request timing path.

As a result, an extra entry is added to the request fifo to handle this case.

The response fifo is not sized up as it can work as a passthrough fifo and
will not back-pressure on back to back responses unless the host is unwilling
to accept a response.