### PR TITLE
[gpio dv] Add +do_clear_all_interrupts=0 for gpio interrupt tests

### DIFF
--- a/hw/ip/gpio/dv/Makefile
+++ b/hw/ip/gpio/dv/Makefile
@@ -79,16 +79,19 @@ endif
 
 ifeq ($(TEST_NAME),gpio_intr_rand_pgm)
   UVM_TEST_SEQ   = gpio_intr_rand_pgm_vseq
+  RUN_OPTS      += +do_clear_all_interrupts=0
 endif
 
 ifeq ($(TEST_NAME),gpio_rand_intr_trigger)
   UVM_TEST_SEQ   = gpio_rand_intr_trigger_vseq
+  RUN_OPTS      += +do_clear_all_interrupts=0
 endif
 
 ifeq ($(TEST_NAME),gpio_intr_with_filter_rand_intr_event)
   UVM_TEST_SEQ   = gpio_intr_with_filter_rand_intr_event_vseq
   RUN_OPTS      += +en_scb=0
   RUN_OPTS      += +zero_delays=1
+  RUN_OPTS      += +do_clear_all_interrupts=0
 endif
 
 ####################################################################################################


### PR DESCRIPTION
In case of GPIO interrupt tests, there may be active interrupt events while
calling post_start() of virtual sequence. So, clearing INTR_STATE does not
assure that we will read it back as 0.