### PR TITLE
Verilator mem load

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -113,7 +113,7 @@ stages:
     - bash: |
         sudo apt-get install -y python3 python3-pip build-essential srecord python3-setuptools zlib1g-dev libusb-1.0 \
           && sudo pip3 install -r python-requirements.txt \
-          && sudo apt-get install git make autoconf g++ flex bison curl
+          && sudo apt-get install -y git make autoconf g++ flex bison curl libelf-dev
       displayName: 'Install dependencies'
     - bash: |
         set -e

--- a/doc/ug/getting_started_verilator.md
+++ b/doc/ug/getting_started_verilator.md
@@ -35,13 +35,16 @@ $ make -C sw SIM=1 SW_DIR=examples/hello_world SW_BUILD_DIR=${SW_BUILD_DIR} clea
 ```
 
 Now the simulation can be run.
-The program listed after `--rominit` and `--flashinit` are loaded into the system's respective memories and start executing immediately.
+The programs listed after `--meminit` are loaded into the system's memories, as defined by the argument, and start executing immediately.
+The format for the option `--meminit` follows the scheme `name,file[,type]`, in which `name` specifies the memory, `file` the path to the program built in the previous step and the optional `type` to set a specific file type for the program.
+Possible options for `type` are `elf` and `vmem`.
+Available memories can be printed by using `--meminit list` or the short version `-m list`.
 
 ```console
 $ cd $REPO_TOP
 $ build/lowrisc_systems_top_earlgrey_verilator_0.1/sim-verilator/Vtop_earlgrey_verilator \
-  --rominit=${ROM_BUILD_DIR}/rom.vmem \
-  --flashinit=${SW_BUILD_DIR}/sw.vmem
+  --meminit=rom,${ROM_BUILD_DIR}/rom.elf \
+  --meminit=flash,${SW_BUILD_DIR}/sw.elf
 ```
 
 To stop the simulation press CTRL-c.

--- a/doc/ug/quickstart.md
+++ b/doc/ug/quickstart.md
@@ -11,10 +11,10 @@ Build the simulator and the software and then run the simulation
 ```console
 $ cd $REPO_TOP
 $ fusesoc --cores-root . sim --build-only lowrisc:systems:top_earlgrey_verilator
-$ make SIM=1 -C sw/boot_rom clean all
-$ make SIM=1 -C sw/examples/hello_world clean all
-$ build/lowrisc_systems_top_earlgrey_verilator_0.1/sim-verilator/Vtop_earlgrey_verilator --rominit=sw/boot_rom/boot_rom.vmem \
-$ --flashinit=sw/examples/hello_world/hello_world.vmem
+$ make -C sw SIM=1 SW_DIR=boot_rom clean all
+$ make -C sw SIM=1 SW_DIR=examples/hello_world clean all
+$ build/lowrisc_systems_top_earlgrey_verilator_0.1/sim-verilator/Vtop_earlgrey_verilator --meminit=rom,sw/boot_rom/rom.elf \
+$ --meminit=flash,sw/examples/hello_world/sw.elf
 ```
 
 See the [getting started](getting_started_verilator.md) for a complete guide.
@@ -29,8 +29,8 @@ Build the software and the bitstream and then program the board
 
 ```console
 $ cd $REPO_TOP
-$ make -C sw/boot_rom clean all
-$ make -C sw/examples/hello_world clean all
+$ make -C sw SW_DIR=boot_rom clean all
+$ make -C sw SW_DIR=examples/hello_world clean all
 $ . /tools/xilinx/Vivado/2018.3/settings64.sh
 $ fusesoc --cores-root . build lowrisc:systems:top_earlgrey_nexysvideo
 $ fusesoc --cores-root . pgm lowrisc:systems:top_earlgrey_nexysvideo:0.1

--- a/hw/ip/prim_generic/rtl/prim_generic_ram_1p.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_ram_1p.sv
@@ -64,12 +64,25 @@ module prim_generic_ram_1p #(
   end
 
   `ifdef VERILATOR
+    // Task for loading 'mem' with SystemVerilog system task readmemh
     export "DPI-C" task simutil_verilator_memload;
+    // Function for setting a specific element in 'mem'
+    export "DPI-C" function simutil_verilator_set_mem;
 
     task simutil_verilator_memload;
       input string file;
       $readmemh(file, mem);
     endtask
+
+    function int simutil_verilator_set_mem(input int index,
+      input logic[Width-1:0] val);
+      if (index < Depth) begin
+        mem[index] = val;
+        return 1;
+      end else begin
+        return 0;
+      end
+    endfunction
   `endif
 
   `ifdef SRAM_INIT_FILE

--- a/hw/ip/prim_generic/rtl/prim_generic_rom.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_rom.sv
@@ -44,12 +44,25 @@ module prim_generic_rom #(
   `endif // VERILATOR
 
   `ifdef VERILATOR
+    // Task for loading 'mem' with SystemVerilog system task readmemh
     export "DPI-C" task simutil_verilator_memload;
+    // Function for setting a specific element in 'mem'
+    export "DPI-C" function simutil_verilator_set_mem;
 
     task simutil_verilator_memload;
       input string file;
       $readmemh(file, mem);
     endtask
+
+    function int simutil_verilator_set_mem(input int index,
+      input logic[Width-1:0] val);
+      if (index < Depth) begin
+        mem[index] = val;
+        return 1;
+      end else begin
+        return 0;
+      end
+    endfunction
   `endif
 
   `ifdef ROM_INIT_FILE

--- a/hw/top_earlgrey/top_earlgrey_verilator.cc
+++ b/hw/top_earlgrey/top_earlgrey_verilator.cc
@@ -60,6 +60,25 @@ int main(int argc, char **argv) {
 
   SetupSignalHandler();
 
+  // Initialize ROM
+  simctrl->RegisterMemoryArea(
+      "rom",
+      "TOP.top_earlgrey_verilator.top_earlgrey.u_rom_rom"
+      ".gen_mem_generic.u_impl_generic");
+
+  // Initialize Ram
+  simctrl->RegisterMemoryArea(
+      "ram",
+      "TOP.top_earlgrey_verilator.top_earlgrey.u_ram1p_ram_main"
+      ".gen_mem_generic.u_impl_generic");
+
+  simctrl->RegisterMemoryArea(
+      "flash",
+      "TOP.top_earlgrey_verilator.top_earlgrey.u_flash_eflash."
+      "gen_flash_banks[0].u_flash.gen_flash.u_impl_generic.u_mem.gen_mem_"
+      "generic.u_impl_"
+      "generic");
+
   if (!simctrl->ParseCommandArgs(argc, argv, retcode)) {
     goto free_return;
   }
@@ -73,27 +92,6 @@ int main(int argc, char **argv) {
               << std::endl
               << "$ kill -USR1 " << getpid() << std::endl;
   }
-
-  // Initialize ROM
-  simctrl->InitRom(
-      "TOP.top_earlgrey_verilator.top_earlgrey.u_rom_rom"
-      ".gen_mem_generic.u_impl_generic");
-
-  // Initialize Ram
-  simctrl->InitRam(
-      "TOP.top_earlgrey_verilator.top_earlgrey.u_ram1p_ram_main"
-      ".gen_mem_generic.u_impl_generic");
-
-  // Initialize Flash
-  //  simctrl->InitFlash(
-  //      "TOP.top_earlgrey_verilator.top_earlgrey.u_flash_eflash.gen_flash."
-  //      "u_impl_generic.gen_flash_banks[0].u_impl_generic.gen_mem_generic.u_impl_"
-  //      "generic");
-  simctrl->InitFlash(
-      "TOP.top_earlgrey_verilator.top_earlgrey.u_flash_eflash."
-      "gen_flash_banks[0].u_flash.gen_flash.u_impl_generic.u_mem.gen_mem_"
-      "generic.u_impl_"
-      "generic");
 
   simctrl->Run();
   simctrl->PrintStatistics();

--- a/hw/top_earlgrey/top_earlgrey_verilator.core
+++ b/hw/top_earlgrey/top_earlgrey_verilator.core
@@ -55,7 +55,7 @@ targets:
 #   Optimization levels have a large impact on the runtime performance of the
 #   simulation model. -O2 and -O3 are pretty similar, -Os is slower than -O2/-O3
           - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=top_earlgrey_verilator -g -O2"'
-          - '-LDFLAGS "-pthread -lutil"'
+          - '-LDFLAGS "-pthread -lutil -lelf"'
           - "-Wall"
           - "-Wno-PINCONNECTEMPTY"
           # XXX: Cleanup all warnings and remove this option


### PR DESCRIPTION
Support for loading elf files into verilator simulation as seen in #3 
This will enable the usage of elf files as well as supporting the original vmem files.
The interface of specifying the file changes with this PR. I only saw references of the simulation usage in the documentation, please do comment if I missed to update usages in other places.