### PR TITLE
[dv/common] Added JOB_OPTS

### DIFF
--- a/hw/dv/tools/Makefile
+++ b/hw/dv/tools/Makefile
@@ -32,7 +32,9 @@ RUN_DIR           := ${RUN_PATH}/${RUN_LOC}
 
 SW_DIR            := ${PRJ_DIR}/sw
 
-
+JOB_OPTS          ?=
+BUILD_JOB_OPTS    ?= $(JOB_OPTS)
+RUN_JOB_OPTS      ?= $(JOB_OPTS)
 
 # limit run directories upto a limit specified below
 RUN_DIR_LIMIT     ?= 5

--- a/hw/dv/tools/rules.mk
+++ b/hw/dv/tools/rules.mk
@@ -27,7 +27,7 @@ gen_sv_flist: pre_compile
 	cd ${BUILD_DIR} && ${SV_FLIST_GEN_TOOL} ${SV_FLIST_GEN_OPTS}
 
 compile: gen_sv_flist
-	cd ${SV_FLIST_GEN_DIR} && ${SIMCC} ${BUILD_OPTS} ${CL_BUILD_OPTS}
+	$(BUILD_JOB_OPTS) cd ${SV_FLIST_GEN_DIR} && ${SIMCC} ${BUILD_OPTS} ${CL_BUILD_OPTS}
 
 post_compile: compile
 
@@ -61,7 +61,7 @@ ifneq (${CAPP_NAME},)
 endif
 
 simulate: capp
-	cd ${RUN_DIR} && ${SIMX} ${RUN_OPTS} ${CL_RUN_OPTS}
+	$(RUN_JOB_OPTS) cd ${RUN_DIR} && ${SIMX} ${RUN_OPTS} ${CL_RUN_OPTS}
 
 post_run: simulate
 


### PR DESCRIPTION
- use JOB_OPTS on the command line to prepend the build and run commands
with job / lsf options
- use BUILD_JOB_OPTS and RUN_JOB_OPTS separately in case there are
different requirements for build / run