### PR TITLE
[docgen] Add support for subsubsection (% section3)

### DIFF
--- a/util/docgen/lowrisc_renderer.py
+++ b/util/docgen/lowrisc_renderer.py
@@ -341,6 +341,12 @@ class LowriscRenderer(mathjax.MathJaxRenderer):
             self.toc.append((3, token.text, id))
             return html_data.section_template.format(
                 cls="subsection_heading", id=id, inner=token.text)
+        if token.type == "section3":
+            # TODO should token.text get parsed to allow markdown in it?
+            id = self.id_from_inner(token.text)
+            self.toc.append((4, token.text, id))
+            return html_data.section_template.format(
+                cls="subsubsection_heading", id=id, inner=token.text)
         if token.type == "doctree":
             md_paths = []
             return_string = ''

--- a/util/docgen/md_html.css
+++ b/util/docgen/md_html.css
@@ -11,7 +11,7 @@
   font-size: 16px;
   word-wrap: break-word;
   width: 80%;
-  margin-left:auto; 
+  margin-left:auto;
   margin-right:auto;
 }
 
@@ -107,7 +107,7 @@ table.section_heading td {
 table.subsection_heading {
     border: 2px solid black;
     width: 100%;
-    font-size: 110%;
+    font-size: 120%;
     background-color:white;
     text-align:center;
     vertical-align:middle;
@@ -118,6 +118,30 @@ table.subsection_heading {
 table.subsection_heading tr,
 table.subsection_heading td {
     border: 1px solid black;
+    width: 100%;
+    background-color:white;
+    border: 0px;
+    float: center;
+}
+
+table.subsubsection_heading {
+    border: 1px ;
+    border-style: solid;
+    border-color: darkgray;
+    width: 100%;
+    font-size: 100%;
+    background-color:white;
+    text-align:center;
+    vertical-align:middle;
+    font-family: serif;
+    display: table;
+}
+
+table.subsubsection_heading tr,
+table.subsubsection_heading td {
+    border: 1px;
+    border-style: solid;
+    border-color: darkgray;
     width: 100%;
     background-color:white;
     border: 0px;


### PR DESCRIPTION
I've found that an additional level of sections would be quite useful for longer specs, hence I added that functionality to docgen. Let me know if this violates some sort of design guidelines...