### PR TITLE
Reduce default flash read to 1 cycle

### DIFF
--- a/hw/ip/prim_generic/rtl/prim_generic_flash.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_flash.sv
@@ -37,7 +37,7 @@ module prim_generic_flash #(
 );
 
   // Emulated flash macro values
-  localparam int ReadCycles = 2;
+  localparam int ReadCycles = 1;
   localparam int ProgCycles = 50;
   localparam int PgEraseCycles = 200;
   localparam int BkEraseCycles = 2000;


### PR DESCRIPTION
Data returns immediately in the next cycle after request is accepted.
In the future, if there is an icache, the default timing will be increased