### PR TITLE
[sw/tests/hmac] Switch to flash_ctrl scratch API.

### DIFF
--- a/sw/tests/hmac/sha256_test.c
+++ b/sw/tests/hmac/sha256_test.c
@@ -32,7 +32,7 @@ int main(int argc, char **argv) {
 
   for (uint32_t i = 0; i < 8; i++) {
     if (digest[i] != test.digest[i]) {
-      REG32(FLASH_CTRL_SCRATCH(0)) = digest[i];
+      flash_write_scratch_reg(digest[i]);
       error++;
       break;
     }


### PR DESCRIPTION
flash_ctrl does not longer expose register interface.