### PR TITLE
[sw/boot_rom] Fix boot_rom Makefile

### DIFF
--- a/sw/boot_rom/Makefile
+++ b/sw/boot_rom/Makefile
@@ -6,7 +6,7 @@
 
 NAME          = boot_rom
 SRCS          = bootstrap.c boot_rom.c
-LINKER_SCRIPT = link.ld
+LINKER_SCRIPT = rom_link.ld
 CRT_SRCS      =
 EXT_ASMS      = crt0.S
 


### PR DESCRIPTION
Merge error caused linker file to be set incorrectly.