### PR TITLE
[tlul] return AccessAckData for Get even if error happens.

### DIFF
--- a/hw/ip/tlul/rtl/tlul_adapter_reg.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_reg.sv
@@ -74,7 +74,8 @@ module tlul_adapter_reg import tlul_pkg::*; #(
     end else if (a_ack) begin
       reqid <= tl_i.a_source;
       reqsz <= tl_i.a_size;
-      rspop <= (re_o) ? AccessAckData : AccessAck ;
+      // Return AccessAckData regardless of error
+      rspop <= (rd_req) ? AccessAckData : AccessAck ;
     end
   end
 


### PR DESCRIPTION
TL-UL spec shows the flow graph that the device responses as
AccessAckData for Get. Current logic returns AccessAck if error inside
`tlul_adapter_reg` occurs. Now it returns AccessAckData opcode in D
channel.