### PR TITLE
[tlul/reg] Remove opcode checker from tlul_adapter_reg

### DIFF
--- a/hw/ip/tlul/rtl/tlul_adapter_reg.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_reg.sv
@@ -39,7 +39,6 @@ module tlul_adapter_reg import tlul_pkg::*; #(
 
   logic addr_align_err;     // Size and alignment
   logic malformed_meta_err; // User signal format error or unsupported
-  logic opcode_err;         // opcode isn't supported
 
   logic [IW-1:0]  reqid;
   logic [SZW-1:0] reqsz;
@@ -103,7 +102,7 @@ module tlul_adapter_reg import tlul_pkg::*; #(
   };
 
   //= Error Handling ==========================================================
-  assign err_internal = addr_align_err | malformed_meta_err | opcode_err ;
+  assign err_internal = addr_align_err | malformed_meta_err ;
 
   // malformed_meta_err
   //    Raised if not supported feature is turned on or user signal has malformed
@@ -138,12 +137,6 @@ module tlul_adapter_reg import tlul_pkg::*; #(
       addr_align_err = 1'b0;
     end
   end
-
-  // opcode_err
-  //    Register interface and TL-UL only supports PutPartialData, PutFullData, Get
-  //    Rasies an error if not.
-  assign opcode_err = a_ack & ~(wr_req | rd_req);
-
 
   `ASSERT_INIT(MatchedWidthAssert, RegDw == top_pkg::TL_DW)
 


### PR DESCRIPTION
Remove unnecessary error checking logic from adater_reg. Revise
tlul_assert.sv to meet TL-UL specification (but adding more restrictive)

This is related to #236 