### PR TITLE
[doc/hmac] Revised MSG_FIFO to byte-write enabled.

### DIFF
--- a/hw/ip/hmac/doc/hmac.hjson
+++ b/hw/ip/hmac/doc/hmac.hjson
@@ -157,10 +157,10 @@
     { window: {
         name: "MSG_FIFO"
         items: "512"      // 2kB
-        swaccess: "wo"
+        swaccess: "wo",
+        byte-write: "true",
         desc: '''Message FIFO. Any address starts from offset 0x800 to 0xFFF
-              updates MSG FIFO entry. This version only supports word-aligned
-              write.
+              updates MSG FIFO entry.
               '''
       }
     }


### PR DESCRIPTION
Removed the sentence from previous design (without prim_packer)