### PR TITLE
[reggen] Add Parameter list to the hjson format

### DIFF
--- a/hw/ip/rv_timer/doc/rv_timer.hjson
+++ b/hw/ip/rv_timer/doc/rv_timer.hjson
@@ -15,13 +15,25 @@
       desc: "raised if the timer 0_0 expired (mtimecmp >= mtime)"
     },
   ],
+  param_list: [
+    { name: "N_HARTS",
+      desc: "Number of harts",
+      type: "int",
+      default: "1"
+    },
+    { name: "N_TIMERS",
+      desc: "Number of timers per Hart",
+      type: "int",
+      default: "1"
+    }
+  ],
   no_auto_intr_regs: "true",
   regwidth: "32",
   registers: [
     { multireg: {
         name: "CTRL",
         desc: "Control register",
-        count: 1,
+        count: "N_HARTS",
         cname: "TIMER",
         swaccess: "rw",
         hwaccess: "hro",
@@ -75,7 +87,7 @@
     { multireg: {
         name: "INTR_ENABLE0",
         desc: "Interrupt Enable",
-        count: 1,
+        count: "N_TIMERS",
         cname: "TIMER",
         swaccess: "rw",
         hwaccess: "hro",
@@ -87,7 +99,7 @@
     { multireg: {
         name: "INTR_STATE0",
         desc: "Interrupt Status",
-        count: 1,
+        count: "N_TIMERS",
         cname: "TIMER",
         swaccess: "rw1c",
         hwaccess: "hrw",
@@ -99,7 +111,7 @@
     { multireg: {
         name: "INTR_TEST0",
         desc: "Interrupt test register",
-        count: 1,
+        count: "N_TIMERS",
         cname: "TIMER",
         swaccess: "wo",
         hwaccess: "hro",

--- a/hw/ip/rv_timer/doc/rv_timer.tpl.hjson
+++ b/hw/ip/rv_timer/doc/rv_timer.tpl.hjson
@@ -22,13 +22,25 @@
 % endfor
 % endfor
   ],
+  param_list: [
+    { name: "N_HARTS",
+      desc: "Number of harts",
+      type: "int",
+      default: "${harts}"
+    },
+    { name: "N_TIMERS",
+      desc: "Number of timers per Hart",
+      type: "int",
+      default: "${timers}"
+    }
+  ],
   no_auto_intr_regs: "true",
   regwidth: "32",
   registers: [
     { multireg: {
         name: "CTRL",
         desc: "Control register",
-        count: ${harts},
+        count: "N_HARTS",
         cname: "TIMER",
         swaccess: "rw",
         hwaccess: "hro",
@@ -85,7 +97,7 @@
     { multireg: {
         name: "INTR_ENABLE${i}",
         desc: "Interrupt Enable",
-        count: ${timers},
+        count: "N_TIMERS",
         cname: "TIMER",
         swaccess: "rw",
         hwaccess: "hro",
@@ -97,7 +109,7 @@
     { multireg: {
         name: "INTR_STATE${i}",
         desc: "Interrupt Status",
-        count: ${timers},
+        count: "N_TIMERS",
         cname: "TIMER",
         swaccess: "rw1c",
         hwaccess: "hrw",
@@ -109,7 +121,7 @@
     { multireg: {
         name: "INTR_TEST${i}",
         desc: "Interrupt test register",
-        count: ${timers},
+        count: "N_TIMERS",
         cname: "TIMER",
         swaccess: "wo",
         hwaccess: "hro",

--- a/hw/ip/rv_timer/rtl/rv_timer_reg_pkg.sv
+++ b/hw/ip/rv_timer/rtl/rv_timer_reg_pkg.sv
@@ -6,6 +6,10 @@
 
 package rv_timer_reg_pkg;
 
+  // Param list
+  localparam int N_HARTS = 1;
+  localparam int N_TIMERS = 1;
+
 // Register to internal design logic
 typedef struct packed {
 

--- a/util/reggen/gen_rtl.py
+++ b/util/reggen/gen_rtl.py
@@ -89,6 +89,7 @@ class Block():
     regs = []
     wins = []
     blocks = []
+    params = []
 
     def __init__(self):
         self.width = 32
@@ -98,6 +99,7 @@ class Block():
         self.regs = []
         self.wins = []
         self.blocks = []
+        self.params = []
 
 
 def escape_name(name):
@@ -207,6 +209,8 @@ def json_to_reg(obj):
         )
 
     log.info("Data Width is set to %d bits", block.width)
+
+    block.params = obj["param_list"] if "param_list" in obj else []
 
     for r in obj["registers"]:
         # Check if any exception condition hit

--- a/util/reggen/reg_pkg.tpl.sv
+++ b/util/reggen/reg_pkg.tpl.sv
@@ -9,6 +9,13 @@
   max_regs_char = len("{}".format(num_regs-1))
 %>\
 package ${block.name}_reg_pkg;
+% if len(block.params) != 0:
+
+  // Param list
+% endif
+% for param in block.params:
+  localparam ${param["type"]} ${param["name"]} = ${param["default"]};
+% endfor
 
 // Register to internal design logic
 typedef struct packed {


### PR DESCRIPTION
- add `param_list` in IP configuration
- The parameter name can be used in `multireg["count"]` field
- `param_list` is added to the register package

This is related to #30 #47