### PR TITLE
[reggen] Refactor reggen, add "local" to param

### DIFF
--- a/hw/ip/hmac/doc/hmac.hjson
+++ b/hw/ip/hmac/doc/hmac.hjson
@@ -17,6 +17,14 @@
   ],
   alert_list: [
   ],
+  param_list: [
+    { name:    "NumWords",
+      type:    "int",
+      default: "8",
+      desc:    "Number of words for digest/ key",
+      local:   "true"
+    }
+  ],
   regwidth: "32",
   registers: [
     { name: "CFG",
@@ -112,7 +120,7 @@
               Order of the secret key is:
               key[255:0] = {KEY0, KEY1, KEY2, ... , KEY7};
               ''',
-        count: "8",
+        count: "NumWords",
         cname: "HMAC",
         swaccess: "wo",
         hwaccess: "hrw",
@@ -124,7 +132,7 @@
     { multireg: {
         name: "DIGEST",
         desc: "Digest output. If HMAC is disabled, the register shows result of SHA256",
-        count: "8",
+        count: "NumWords",
         cname: "HMAC",
         swaccess: "ro",
         hwaccess: "hwo",

--- a/hw/ip/hmac/rtl/hmac_reg_pkg.sv
+++ b/hw/ip/hmac/rtl/hmac_reg_pkg.sv
@@ -7,8 +7,7 @@
 package hmac_reg_pkg;
 
   // Param list
-  localparam int KEY = 8;
-  localparam int DIGEST = 8;
+  localparam int NumWords = 8;
 
 // Register to internal design logic
 typedef struct packed {

--- a/hw/ip/rv_plic/doc/rv_plic.hjson
+++ b/hw/ip/rv_plic/doc/rv_plic.hjson
@@ -13,12 +13,26 @@
   clock_primary: "clk_fixed",
   bus_device: "tlul",
 
+  param_list: [
+    { name: "NumSrc",
+      desc: "Number of interrupt sources",
+      type: "int",
+      default: "32",
+      local: "true"
+    },
+    { name: "NumTarget",
+      desc: "Number of Targets (Harts)",
+      type: "int",
+      default: "1",
+      local: "true",
+    },
+  ],
   regwidth: "32",
   registers: [
     { multireg: {
         name: "IP",
         desc: "Interrupt Pending",
-        count: 32,
+        count: "NumSrc",
         cname: "RV_PLIC",
         swaccess: "ro",
         hwaccess: "hwo",
@@ -30,7 +44,7 @@
     { multireg: {
         name: "LE",
         desc: "Interrupt Source mode. 0: Level, 1: Edge-triggered",
-        count: 32,
+        count: "NumSrc",
         cname: "RV_PLIC",
         swaccess: "rw",
         hwaccess: "hro",
@@ -299,7 +313,7 @@
     { multireg: {
         name: "IE0",
         desc: "Interrupt Enable for Target 0",
-        count: 32,
+        count: "NumSrc",
         cname: "RV_PLIC",
         swaccess: "rw",
         hwaccess: "hro",

--- a/hw/ip/rv_plic/doc/rv_plic.tpl.hjson
+++ b/hw/ip/rv_plic/doc/rv_plic.tpl.hjson
@@ -13,12 +13,26 @@
   clock_primary: "clk_fixed",
   bus_device: "tlul",
 
+  param_list: [
+    { name: "NumSrc",
+      desc: "Number of interrupt sources",
+      type: "int",
+      default: "${src}",
+      local: "true"
+    },
+    { name: "NumTarget",
+      desc: "Number of Targets (Harts)",
+      type: "int",
+      default: "${target}",
+      local: "true",
+    },
+  ],
   regwidth: "32",
   registers: [
     { multireg: {
         name: "IP",
         desc: "Interrupt Pending",
-        count: ${src},
+        count: "NumSrc",
         cname: "RV_PLIC",
         swaccess: "ro",
         hwaccess: "hwo",
@@ -30,7 +44,7 @@
     { multireg: {
         name: "LE",
         desc: "Interrupt Source mode. 0: Level, 1: Edge-triggered",
-        count: ${src},
+        count: "NumSrc",
         cname: "RV_PLIC",
         swaccess: "rw",
         hwaccess: "hro",
@@ -54,7 +68,7 @@
     { multireg: {
         name: "IE${i}",
         desc: "Interrupt Enable for Target ${i}",
-        count: ${src},
+        count: "NumSrc",
         cname: "RV_PLIC",
         swaccess: "rw",
         hwaccess: "hro",

--- a/hw/ip/rv_plic/rtl/rv_plic_reg_pkg.sv
+++ b/hw/ip/rv_plic/rtl/rv_plic_reg_pkg.sv
@@ -7,9 +7,8 @@
 package rv_plic_reg_pkg;
 
   // Param list
-  localparam int IP = 32;
-  localparam int LE = 32;
-  localparam int IE0 = 32;
+  localparam int NumSrc = 32;
+  localparam int NumTarget = 1;
 
 // Register to internal design logic
 typedef struct packed {

--- a/hw/top_earlgrey/doc/rv_plic.hjson
+++ b/hw/top_earlgrey/doc/rv_plic.hjson
@@ -21,12 +21,26 @@
   clock_primary: "clk_fixed",
   bus_device: "tlul",
 
+  param_list: [
+    { name: "NumSrc",
+      desc: "Number of interrupt sources",
+      type: "int",
+      default: "54",
+      local: "true"
+    },
+    { name: "NumTarget",
+      desc: "Number of Targets (Harts)",
+      type: "int",
+      default: "1",
+      local: "true",
+    },
+  ],
   regwidth: "32",
   registers: [
     { multireg: {
         name: "IP",
         desc: "Interrupt Pending",
-        count: 54,
+        count: "NumSrc",
         cname: "RV_PLIC",
         swaccess: "ro",
         hwaccess: "hwo",
@@ -38,7 +52,7 @@
     { multireg: {
         name: "LE",
         desc: "Interrupt Source mode. 0: Level, 1: Edge-triggered",
-        count: 54,
+        count: "NumSrc",
         cname: "RV_PLIC",
         swaccess: "rw",
         hwaccess: "hro",
@@ -483,7 +497,7 @@
     { multireg: {
         name: "IE0",
         desc: "Interrupt Enable for Target 0",
-        count: 54,
+        count: "NumSrc",
         cname: "RV_PLIC",
         swaccess: "rw",
         hwaccess: "hro",

--- a/hw/top_earlgrey/rtl/rv_plic_reg_pkg.sv
+++ b/hw/top_earlgrey/rtl/rv_plic_reg_pkg.sv
@@ -7,9 +7,8 @@
 package rv_plic_reg_pkg;
 
   // Param list
-  localparam int IP = 54;
-  localparam int LE = 54;
-  localparam int IE0 = 54;
+  localparam int NumSrc = 54;
+  localparam int NumTarget = 1;
 
 // Register to internal design logic
 typedef struct packed {

--- a/util/reggen/data.py
+++ b/util/reggen/data.py
@@ -1,0 +1,103 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+from .field_enums import HwAccess, SwAccess, SwRdAccess, SwWrAccess
+
+
+class Field():
+    """Field in a register.
+
+    Field class contains necessary info to generate RTL code.
+    It has two additional (tool generated) feidls, swrdaccess and swwraccess,
+    which represent read and write type. This makes RTL generation code simpler.
+    """
+    name = ""  # required
+    msb = 31  # required
+    lsb = 0  # required
+    resval = 0  # optional
+    swaccess = SwAccess.NONE  # optional
+    swrdaccess = SwRdAccess.NONE
+    swwraccess = SwWrAccess.NONE
+    hwaccess = HwAccess.HRO
+    hwqe = False
+    hwre = False
+
+    def __init__(self):
+        self.name = ""  # required
+        self.msb = 31  # required
+        self.lsb = 0  # required
+        self.resval = 0  # optional
+        self.swaccess = SwAccess.NONE  # optional
+        self.swrdaccess = SwRdAccess.NONE
+        self.swwraccess = SwWrAccess.NONE
+        self.hwaccess = HwAccess.HRO
+        self.hwqe = False
+        self.hwre = False
+
+
+class Reg():
+    name = ""
+    offset = 0
+    hwqe = False
+    hwre = False
+    hwext = False  # External register
+    resval = 0
+    dvrights = "RO"  # Used by UVM REG only
+    regwen = ""
+    fields = []
+    width = 0  # indicate register size
+
+    def __init__(self):
+        self.name = ""
+        self.offset = 0
+        self.hwqe = False
+        self.hwre = False
+        self.hwext = False  # External register
+        self.resval = 0
+        self.dvrights = "RO"  # Used by UVM REG only
+        self.regwen = ""
+        self.fields = []
+        self.width = 0
+
+
+class MultiReg(Reg):
+    param = ""
+    regs = []
+
+    def __init__(self):
+        super.__init__(self)
+        self.param = ""
+        self.regs = []
+
+
+class Window():
+    base_addr = 0
+    limit_addr = 0
+    n_bits = 0
+
+    def __init__(self):
+        self.base_addr = 0
+        self.limit_addr = 0
+        self.n_bits = 0
+
+
+class Block():
+    width = 32
+    addr_width = 12
+    base_addr = 0
+    name = ""
+    regs = []
+    wins = []
+    blocks = []
+    params = []
+
+    def __init__(self):
+        self.width = 32
+        self.addr_width = 12
+        self.base_addr = 0
+        self.name = ""
+        self.regs = []
+        self.wins = []
+        self.blocks = []
+        self.params = []

--- a/util/reggen/gen_dv.py
+++ b/util/reggen/gen_dv.py
@@ -12,7 +12,8 @@ from mako.template import Template
 from pkg_resources import resource_filename
 
 from .field_enums import HwAccess, SwAccess, SwRdAccess, SwWrAccess
-from .gen_rtl import Block, Field, Register, Window, json_to_reg
+from .gen_rtl import json_to_reg
+from .data import *
 
 
 # function get block class name
@@ -57,8 +58,7 @@ def gen_ral(block, outdir):
     # Generate pkg.sv with block name
     with open(outdir + "/" + block.name + "_reg_block.sv", 'w') as fout:
         fout.write(
-            uvm_reg_tpl.render(
-                block=block,
-                HwAccess=HwAccess,
-                SwRdAccess=SwRdAccess,
-                SwWrAccess=SwWrAccess))
+            uvm_reg_tpl.render(block=block,
+                               HwAccess=HwAccess,
+                               SwRdAccess=SwRdAccess,
+                               SwWrAccess=SwWrAccess))

--- a/util/reggen/gen_rtl.py
+++ b/util/reggen/gen_rtl.py
@@ -12,94 +12,7 @@ from mako.template import Template
 from pkg_resources import resource_filename
 
 from .field_enums import HwAccess, SwAccess, SwRdAccess, SwWrAccess
-
-
-class Field():
-    """Field in a register.
-
-    Field class contains necessary info to generate RTL code.
-    It has two additional (tool generated) feidls, swrdaccess and swwraccess,
-    which represent read and write type. This makes RTL generation code simpler.
-    """
-    name = ""  # required
-    msb = 31  # required
-    lsb = 0  # required
-    resval = 0  # optional
-    swaccess = SwAccess.NONE  # optional
-    swrdaccess = SwRdAccess.NONE
-    swwraccess = SwWrAccess.NONE
-    hwaccess = HwAccess.HRO
-    hwqe = False
-    hwre = False
-
-    def __init__(self):
-        self.name = ""  # required
-        self.msb = 31  # required
-        self.lsb = 0  # required
-        self.resval = 0  # optional
-        self.swaccess = SwAccess.NONE  # optional
-        self.swrdaccess = SwRdAccess.NONE
-        self.swwraccess = SwWrAccess.NONE
-        self.hwaccess = HwAccess.HRO
-        self.hwqe = False
-        self.hwre = False
-
-
-class Register():
-    name = ""
-    offset = 0
-    hwqe = False
-    hwre = False
-    hwext = False  # External register
-    resval = 0
-    dvrights = "RO"  # Used by UVM REG only
-    regwen = ""
-    fields = []
-    width = 0  # indicate register size
-
-    def __init__(self):
-        self.name = ""
-        self.offset = 0
-        self.hwqe = False
-        self.hwre = False
-        self.hwext = False  # External register
-        self.resval = 0
-        self.dvrights = "RO"  # Used by UVM REG only
-        self.regwen = ""
-        self.fields = []
-        self.width = 0
-
-
-class Window():
-    base_addr = 0
-    limit_addr = 0
-    n_bits = 0
-
-    def __init__(self):
-        self.base_addr = 0
-        self.limit_addr = 0
-        self.n_bits = 0
-
-
-class Block():
-    width = 32
-    addr_width = 12
-    base_addr = 0
-    name = ""
-    regs = []
-    wins = []
-    blocks = []
-    params = []
-
-    def __init__(self):
-        self.width = 32
-        self.addr_width = 12
-        self.base_addr = 0
-        self.name = ""
-        self.regs = []
-        self.wins = []
-        self.blocks = []
-        self.params = []
+from .data import *
 
 
 def escape_name(name):
@@ -145,7 +58,7 @@ def parse_reg(obj):
     """Convert OrderedDict register into Register class
     """
 
-    reg = Register()
+    reg = Reg()
     reg.name = escape_name(obj['name'])
     reg.offset = obj["genoffset"]
     reg.fields = []

--- a/util/reggen/reg_pkg.tpl.sv
+++ b/util/reggen/reg_pkg.tpl.sv
@@ -13,7 +13,7 @@ package ${block.name}_reg_pkg;
 
   // Param list
 % endif
-% for param in block.params:
+% for param in [p for p in block.params if p["local"] == "true"]:
   localparam ${param["type"]} ${param["name"]} = ${param["default"]};
 % endfor
 

--- a/util/reggen/reg_top.tpl.sv
+++ b/util/reggen/reg_top.tpl.sv
@@ -9,9 +9,10 @@
   num_dsp  = num_wins + 1
   num_regs = len(block.regs)
   max_regs_char = len("{}".format(num_regs-1))
+  params = [p for p in block.params if p["local"] == "false"]
 %>
 
-module ${block.name}_reg_top (
+module ${block.name}_reg_top ${print_param(params)}(
   input clk_i,
   input rst_ni,
 
@@ -462,5 +463,15 @@ ${msb}\
         reg_rdata_next[${str_bits_sv(msb,lsb)}] = ${sig_name}_qs;
 % else:
         reg_rdata_next[${str_bits_sv(msb,lsb)}] = '0;
+% endif
+</%def>\
+<%def name="print_param(params)">\
+<% num_params = len(params) %>\
+% if num_params != 0:
+#(
+% for i,p in enumerate(params):
+  parameter ${p["type"]} ${p["name"]} = ${p["default"]}${"," if i != num_params-1 else ""}
+% endfor
+) \
 % endif
 </%def>\

--- a/util/reggen/validate.py
+++ b/util/reggen/validate.py
@@ -52,7 +52,8 @@ def check_count(top, mreg, err_prefix):
             "name": mreg["name"],
             "type": "int",
             "default": mcount,
-            "desc": "auto added parameter"
+            "desc": "auto added parameter",
+            "local": "true"
         })
         log.info("Parameter {} is added".format(mreg["name"]))
         # Replace count integer to parameter
@@ -138,7 +139,23 @@ def check_lp(obj, x, err_prefix):
         # TODO: Check if PascalCase or ALL_CAPS
         if not "type" in y:
             y["type"] = "int"
-        if not "default" in y:
+
+        if "local" in y:
+            local, ierr = check_bool(y["local"], err_prefix + " local")
+            if ierr:
+                error += 1
+                y["local"] = "true"
+        else:
+            y["local"] = "true"
+
+        if "default" in y:
+            if y["type"][:3] == "int":
+                default, ierr = check_int(y["default"],
+                                          err_prefix + " default")
+                if ierr:
+                    error += 1
+                    y["default"] = "1"
+        else:
             if y["type"][:3] == "int":
                 y["default"] = "1"
             elif y["type"] == "string":
@@ -307,6 +324,7 @@ lp_optional = {
     'desc': ['s', "description of the item"],
     'type': ['s', "item type. int by default"],
     'default': ['s', "item default value"],
+    'local': ['pb', "to be localparam"],
 }
 
 # Registers list may have embedded keys


### PR DESCRIPTION
- Moved data structure into `util/reggen/data.py`
- add `local` field in `param_list`
  + if `local` is false, it creates parameter in reg_top.sv
- Revised HMAC, RV_PLIC to use parameter

This is related to #30 #270 