### PR TITLE
[prim_pad_wrapper] Add generic/xilinx pad wrapper

### DIFF
--- a/hw/ip/prim/abstract/prim_pad_wrapper.sv
+++ b/hw/ip/prim/abstract/prim_pad_wrapper.sv
@@ -1,0 +1,46 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// TODO: This module is a hard-coded stopgap to select an implementation of an
+// "abstract module". This module is to be replaced by generated code.
+
+// prim_pad_wrapper using the generic implementation
+module prim_pad_wrapper #(
+  parameter              Impl   = "generic",
+  parameter int unsigned AttrDw = 7
+) (
+  inout  wire        inout_io, // bidirectional pad
+  output logic       in_o,     // input data
+  input              out_i,    // output data
+  input              oe_i,     // output enable
+  // additional attributes
+  input [AttrDw-1:0] attr_i
+);
+
+  // The generic implementation is NOT synthesizable
+  if (Impl == "generic") begin : gen_pad_generic
+    prim_generic_pad_wrapper #(
+      .AttrDw(AttrDw)
+    ) i_pad_wrapper (
+      .inout_io,
+      .in_o,
+      .out_i,
+      .oe_i,
+      .attr_i
+    );
+  end else if (Impl == "xilinx") begin : gen_pad_xilinx
+    prim_xilinx_pad_wrapper #(
+      .AttrDw(AttrDw)
+    ) i_pad_wrapper (
+      .inout_io,
+      .in_o,
+      .out_i,
+      .oe_i,
+      .attr_i
+    );
+  end else begin : gen_failure
+    // TODO: Find code that works across tools and causes a compile failure
+  end
+
+endmodule : prim_pad_wrapper

--- a/hw/ip/prim/prim_pad_wrapper.core
+++ b/hw/ip/prim/prim_pad_wrapper.core
@@ -1,0 +1,21 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:pad_wrapper"
+description: "prim"
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:prim_generic:pad_wrapper
+      - lowrisc:prim_xilinx:pad_wrapper
+      - lowrisc:prim:assert
+    files:
+      - abstract/prim_pad_wrapper.sv
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_rtl

--- a/hw/ip/prim_generic/prim_generic_pad_wrapper.core
+++ b/hw/ip/prim_generic/prim_generic_pad_wrapper.core
@@ -1,0 +1,17 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim_generic:pad_wrapper"
+description: "Technology-independent pad wrapper implementation (for sim only!)"
+filesets:
+  files_rtl:
+    files:
+      - rtl/prim_generic_pad_wrapper.sv
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_rtl

--- a/hw/ip/prim_generic/rtl/prim_generic_pad_wrapper.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_pad_wrapper.sv
@@ -1,0 +1,50 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Generic, technology independent pad wrapper. This is NOT synthesizable!
+
+
+module prim_generic_pad_wrapper #(
+  parameter int unsigned AttrDw = 7
+) (
+  inout wire         inout_io, // bidirectional pad
+  output logic       in_o,     // input data
+  input              out_i,    // output data
+  input              oe_i,     // output enable
+  // additional attributes {drive strength, keeper, pull-up, pull-down, open-drain, invert}
+  input [AttrDw-1:0] attr_i
+);
+
+  // get pad attributes
+  logic kp, pu, pd, od, inv;
+  typedef enum logic {STRONG = 1'b0, WEAK = 1'b1} drv_e;
+  drv_e drv;
+  assign {drv, kp, pu, pd, od, inv} = attr_i[6:0];
+
+  // input inversion
+  assign in_o     = inv ^ inout_io;
+
+  // virtual open drain emulation
+  logic oe, out;
+  assign out      = out_i ^ inv;
+  assign oe       = oe_i & ((od & ~out) | ~od);
+
+// driving strength attributes are not supported by verilator
+`ifdef VERILATOR
+  assign inout_io = (oe) ? out : 1'bz;
+`else
+  // different driver types
+  assign (strong0, strong1) inout_io = (oe && drv == STRONG) ? out : 1'bz;
+  assign (pull0, pull1)     inout_io = (oe && drv == WEAK)   ? out : 1'bz;
+  // pullup / pulldown termination
+  assign (highz0, weak1)    inout_io = pu;
+  assign (weak0, highz1)    inout_io = ~pd;
+  // fake trireg emulation
+  assign (weak0, weak1)     inout_io = (kp) ? inout_io : 1'bz;
+`endif
+
+  // assertions
+  `ASSERT_INIT(AttrDwCheck_A, AttrDw >= 7)
+
+endmodule : prim_generic_pad_wrapper

--- a/hw/ip/prim_xilinx/prim_xilinx_pad_wrapper.core
+++ b/hw/ip/prim_xilinx/prim_xilinx_pad_wrapper.core
@@ -1,0 +1,17 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim_xilinx:pad_wrapper"
+description: "prim"
+filesets:
+  files_rtl:
+    files:
+      - rtl/prim_xilinx_pad_wrapper.sv
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_rtl

--- a/hw/ip/prim_xilinx/rtl/prim_xilinx_pad_wrapper.sv
+++ b/hw/ip/prim_xilinx/rtl/prim_xilinx_pad_wrapper.sv
@@ -1,0 +1,35 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Inferrable, bidirectional IO buffer for FPGAs. Implements inversion and
+// virtual open drain feature.
+
+
+module prim_xilinx_pad_wrapper #(
+  parameter int unsigned AttrDw = 2
+) (
+  inout wire         inout_io, // bidirectional pad
+  output logic       in_o,     // input data
+  input              out_i,    // output data
+  input              oe_i,     // output enable
+  // additional attributes
+  input [AttrDw-1:0] attr_i
+);
+
+  // get pad attributes
+  logic od, inv;
+  assign {od, inv} = attr_i[1:0];
+
+  // input inversion
+  assign in_o     = inv ^ inout_io;
+
+  // virtual open drain emulation
+  logic oe, out;
+  assign out      = out_i ^ inv;
+  assign oe       = oe_i & ((od & ~out) | ~od);
+
+  // driver
+  assign inout_io = (oe) ? out : 1'bz;
+
+endmodule : prim_xilinx_pad_wrapper


### PR DESCRIPTION
Proposal for the prim pad wrapper. I've put all pad attributes into a parameterizable vector now.

TBD whether the simulation model `prim_generic_pad_wrapper` needs to be able to simulate all pin attributes.