### PR TITLE
[dv] sw build dependency

### DIFF
--- a/hw/dv/tools/rules.mk
+++ b/hw/dv/tools/rules.mk
@@ -44,8 +44,11 @@ pre_run:
 	/bin/bash ${MAKE_ROOT}/run_dir_limiter ${RUN_PATH} ${RUN_DIR_LIMIT}
 	env > ${RUN_DIR}/env_vars
 
+# TODO: The rm -rf SW_BUILD_DIR below is necessary because currently
+#       sw build dependency does not appear to be fully working with the DV flow
+#       This should be investigated later or replaced with the new build system
 sw_build: pre_run
-ifneq (${SW_NAME},)
+	rm -rf ${SW_BUILD_DIR};
 	mkdir -p ${SW_BUILD_DIR}
 	$(MAKE) -C $(SW_ROOT_DIR) \
 	  SW_DIR=boot_rom \
@@ -56,7 +59,7 @@ ifneq (${SW_NAME},)
 	  SW_NAME=$(SW_NAME) \
 	  SW_BUILD_DIR=$(SW_BUILD_DIR)/sw \
 	  MAKEFLAGS="$(SW_OPTS)"
-endif
+
 
 simulate: sw_build
 	$(RUN_JOB_OPTS) cd ${RUN_DIR} && ${SIMX} ${RUN_OPTS} ${CL_RUN_OPTS}


### PR DESCRIPTION
If a header is changed, the current make flow does not rebuild
In sw_build for dv then, always remove the build directory before
starting.