### PR TITLE
[gpio dv] First set of functional coverage for gpio

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env_cov.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env_cov.sv
@@ -5,12 +5,31 @@
 // put these covergoups outside the class in order to create them anywhere after get cfg object
 // if more than one interrupt/alert registers, these can be reused
 // in extended cov class, better to have the covergroup inside the class and create in new function
-covergroup intr_covergroup (uint num_interrupts) with function sample(uint intr, bit intr_en);
+covergroup intr_covergroup (uint num_interrupts) with function sample(uint intr,
+                                                                      bit intr_en,
+                                                                      bit intr_state);
   cp_intr: coverpoint intr {
     bins all_values[] = {[0:num_interrupts-1]};
   }
   cp_intr_en: coverpoint intr_en;
-  cross cp_intr, cp_intr_en;
+  cp_intr_state: coverpoint intr_state;
+  cross cp_intr, cp_intr_en, cp_intr_state;
+endgroup
+
+covergroup intr_test_covergroup (uint num_interrupts) with function sample(uint intr,
+                                                                           bit intr_test,
+                                                                           bit intr_en,
+                                                                           bit intr_state);
+  cp_intr: coverpoint intr {
+    bins all_values[] = {[0:num_interrupts-1]};
+  }
+  cp_intr_test: coverpoint intr_test;
+  cp_intr_en: coverpoint intr_en;
+  cp_intr_state: coverpoint intr_state;
+  cross cp_intr, cp_intr_test, cp_intr_en, cp_intr_state {
+    illegal_bins test_0_state_1 = binsof(cp_intr_test) intersect {0} &&
+                                  binsof(cp_intr_state) intersect {1};
+  }
 endgroup
 
 covergroup alert_covergroup (uint num_alerts) with function sample(uint alert);
@@ -22,15 +41,19 @@ endgroup
 class cip_base_env_cov #(type CFG_T = cip_base_env_cfg) extends dv_base_env_cov #(CFG_T);
   `uvm_component_param_utils(cip_base_env_cov #(CFG_T))
 
-  intr_covergroup  intr_cg;
-  alert_covergroup alert_cg;
+  intr_covergroup      intr_cg;
+  intr_test_covergroup intr_test_cg;
+  alert_covergroup     alert_cg;
 
   `uvm_component_new
 
   virtual function void build_phase(uvm_phase phase);
     super.build_phase(phase);
-    if (cfg.num_interrupts != 0) intr_cg  = new(cfg.num_interrupts);
-    if (cfg.num_alerts     != 0) alert_cg = new(cfg.num_alerts);
+    if (cfg.num_interrupts != 0) begin
+      intr_cg       = new(cfg.num_interrupts);
+      intr_test_cg  = new(cfg.num_interrupts);
+    end
+    if (cfg.num_alerts != 0) alert_cg = new(cfg.num_alerts);
   endfunction
 
 endclass

--- a/hw/ip/gpio/dv/env/gpio_env_cfg.sv
+++ b/hw/ip/gpio/dv/env/gpio_env_cfg.sv
@@ -10,10 +10,10 @@ class gpio_env_cfg extends cip_base_env_cfg #(.RAL_T(gpio_reg_block));
   // flag to indicate if weak pulldown has been introduced on gpio
   rand bit pulldown_en;
   // gpio virtual interface
-  gpio_vif      gpio_vif;
+  gpio_vif gpio_vif;
 
   constraint pullup_pulldown_en_c {
-    (pullup_en ^ pulldown_en) == 1'b1;
+    pullup_en ^ pulldown_en;
   }
 
   `uvm_object_utils(gpio_env_cfg)

--- a/hw/ip/gpio/dv/env/gpio_env_cov.sv
+++ b/hw/ip/gpio/dv/env/gpio_env_cov.sv
@@ -2,12 +2,65 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+// Generic covergroup definitions
+covergroup gpio_generic_cg(string name) with function sample(bit value);
+  option.per_instance = 1;
+  option.name = name;
+  cp_value: coverpoint value;
+  cp_transitions: coverpoint value {
+    bins rising  = (0 => 1);
+    bins falling = (1 => 0);
+  }
+endgroup : gpio_generic_cg
+
+covergroup gpio_intr_type_en_state_cg(string name) with function sample(bit intr_type,
+                                                                        bit intr_en,
+                                                                        bit intr_state);
+  option.per_instance = 1;
+  option.name = name;
+  cp_cross_intr_type_en_state: cross intr_type, intr_en, intr_state {
+    ignore_bins intr_type_disabled = binsof(intr_type) intersect {0};
+  }
+endgroup : gpio_intr_type_en_state_cg
+
 class gpio_env_cov extends cip_base_env_cov #(.CFG_T(gpio_env_cfg));
   `uvm_component_utils(gpio_env_cov)
 
+  // Per pin coverage for values '0' and '1' and transitions
+  gpio_generic_cg gpio_pin_values_cg[NUM_GPIOS];
+  // Interrupt State (Interrupt bit getting set and cleared)
+  gpio_generic_cg intr_state_cg[TL_DW];
+  // Interrupt Control Enable registers' values
+  gpio_generic_cg intr_ctrl_en_rising_cg[TL_DW];
+  gpio_generic_cg intr_ctrl_en_falling_cg[TL_DW];
+  gpio_generic_cg intr_ctrl_en_lvlhigh_cg[TL_DW];
+  gpio_generic_cg intr_ctrl_en_lvllow_cg[TL_DW];
+  // Different gpio interrupt types' occurrences
+  gpio_intr_type_en_state_cg rising_edge_intr_event_cg[TL_DW];
+  gpio_intr_type_en_state_cg falling_edge_intr_event_cg[TL_DW];
+  gpio_intr_type_en_state_cg lvlhigh_intr_event_cg[TL_DW];
+  gpio_intr_type_en_state_cg lvllow_intr_event_cg[TL_DW];
+
   function new(string name, uvm_component parent);
     super.new(name, parent);
-    // add more covergroup here
+    // Create coverage for each gpio pin value
+    foreach (gpio_pin_values_cg[each_pin]) begin
+      gpio_pin_values_cg [each_pin] = new($sformatf("gpio_pin-%0d", each_pin));
+    end
+    // Create coverage for interrupt control policies and state
+    for (uint each_bit = 0; each_bit < TL_DW; each_bit++) begin
+      intr_state_cg[each_bit] = new($sformatf("intr_state_cg%0d", each_bit));
+      intr_ctrl_en_rising_cg[each_bit] = new($sformatf("intr_ctrl_en_rising_cg%0d", each_bit));
+      intr_ctrl_en_falling_cg[each_bit] = new($sformatf("intr_ctrl_en_falling_cg%0d", each_bit));
+      intr_ctrl_en_lvlhigh_cg[each_bit] = new($sformatf("intr_ctrl_en_lvlhigh_cg%0d", each_bit));
+      intr_ctrl_en_lvllow_cg [each_bit] = new($sformatf("intr_ctrl_en_lvllow_cg%0d", each_bit));
+      rising_edge_intr_event_cg[each_bit] = new($sformatf("rising_edge_intr_event_cg%0d",
+                                                           each_bit));
+      falling_edge_intr_event_cg[each_bit] = new($sformatf("falling_edge_intr_event_cg%0d",
+                                                           each_bit));
+      lvlhigh_intr_event_cg[each_bit] = new($sformatf("lvlhigh_intr_event_cg%0d", each_bit));
+      lvllow_intr_event_cg[each_bit] = new($sformatf("lvllow_intr_event_cg%0d", each_bit));
+    end
   endfunction : new
 
 endclass

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_random_long_reg_writes_reg_reads_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_random_long_reg_writes_reg_reads_vseq.sv
@@ -49,7 +49,8 @@ class gpio_random_long_reg_writes_reg_reads_vseq extends gpio_base_vseq;
           `DV_CHECK_STD_RANDOMIZE_FATAL(gpio_i)
           `DV_CHECK_STD_RANDOMIZE_FATAL(gpio_i_oen)
           `uvm_info(msg_id, $sformatf("drive random value 0x%0h on gpio_i", gpio_i), UVM_HIGH)
-          `uvm_info(msg_id, $sformatf("drive random value 0x%0h on gpio_i_oen", gpio_i_oen), UVM_HIGH)
+          `uvm_info(msg_id, $sformatf("drive random value 0x%0h on gpio_i_oen", gpio_i_oen),
+                    UVM_HIGH)
 
           // drive gpio_vif after setting all output enables to 0's
           cfg.gpio_vif.pins_oe = gpio_i_oen;

--- a/hw/ip/uart/dv/env/uart_scoreboard.sv
+++ b/hw/ip/uart/dv/env/uart_scoreboard.sv
@@ -324,7 +324,7 @@ class uart_scoreboard extends cip_base_scoreboard #(.CFG_T(uart_env_cfg),
           do_read_check = 1'b0;
           foreach (intr_exp[i]) begin
             intr = i; // cast to enum to get interrupt name
-            if (cfg.en_cov) cov.intr_cg.sample(intr, intr_en[intr]);
+            if (cfg.en_cov) cov.intr_cg.sample(intr, intr_en[intr], intr_exp[intr]);
             // don't check it when it's in ignored period
             if (intr inside {TxWatermark, TxOverflow}) begin // TX interrupts
               if (is_in_ignored_period(UartTx)) continue;


### PR DESCRIPTION
1. cip_base_env_cov.sv: Update common interrupt covergroup to include intr_state
2. gpio_env_cov.sv: Some functional coverage for gpio pin activity and interrupts
3. gpio_scoreboard.sv: Sampling of implemented coverage
4. uart_scoreboard.sv: Updated sampling of interrupt covergroup