### PR TITLE
Revert multireg regwen for bank cfg

### DIFF
--- a/hw/ip/flash_ctrl/doc/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/doc/flash_ctrl.hjson
@@ -248,36 +248,33 @@
       ]
     },
 
-    { multireg: {
-        cname: "FLASH_CTRL",
-        name: "BANK_CFG_REGWEN"
-        desc: "Bank configuration registers configuration enable.",
-        count: "NumBanks",
-        swaccess: "rw0c",
-        hwaccess: "none",
-        fields: [
-            { bits: "0",
-              name: "BANK",
-              resval: "1"
-              desc: "Bank register write enable.  Once set to 0, it can longer be configured to 1",
-              enum: [
-                { value: "0",
-                  name: "Bank locked",
-                  desc: '''
-                    Bank can no longer be configured until next reset
-                    '''
-                },
-                { value: "1",
-                  name: "Bank enabled",
-                  desc: '''
-                    Bank can be configured
-                    '''
-                },
-              ]
-            },
-        ],
-      },
+    { name: "BANK_CFG_REGWEN"
+      desc: "Bank configuration registers configuration enable.",
+      swaccess: "rw0c",
+      hwaccess: "none",
+      fields: [
+          { bits: "0",
+            name: "BANK",
+            resval: "1"
+            desc: "Bank register write enable.  Once set to 0, it can longer be configured to 1",
+            enum: [
+              { value: "0",
+                name: "Bank locked",
+                desc: '''
+                  Bank can no longer be configured until next reset
+                  '''
+              },
+              { value: "1",
+                name: "Bank enabled",
+                desc: '''
+                  Bank can be configured
+                  '''
+              },
+            ]
+          },
+      ],
     },
+
 
     { multireg: {
         cname: "FLASH_CTRL",
@@ -286,8 +283,7 @@
         count: "NumBanks",
         swaccess: "rw",
         hwaccess: "hro",
-        regwen: "BANK_CFG_REGWEN_BANK"
-        regwen_incr: "true",
+        regwen: "BANK_CFG_REGWEN"
         fields: [
             { bits: "1",
               name: "ERASE_EN",

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_reg_block.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_reg_block.sv
@@ -1301,8 +1301,7 @@ endclass : flash_ctrl_reg_default_region
 // Class: flash_ctrl_reg_bank_cfg_regwen
 class flash_ctrl_reg_bank_cfg_regwen extends dv_base_reg;
   // fields
-  rand dv_base_reg_field bank0;
-  rand dv_base_reg_field bank1;
+  rand dv_base_reg_field bank;
 
   `uvm_object_utils(flash_ctrl_reg_bank_cfg_regwen)
 
@@ -1314,22 +1313,11 @@ class flash_ctrl_reg_bank_cfg_regwen extends dv_base_reg;
 
   virtual function void build();
     // create fields
-    bank0 = dv_base_reg_field::type_id::create("bank0");
-    bank0.configure(
+    bank = dv_base_reg_field::type_id::create("bank");
+    bank.configure(
       .parent(this),
       .size(1),
       .lsb_pos(0),
-      .access("W0C"),
-      .volatile(1),
-      .reset(1),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    bank1 = dv_base_reg_field::type_id::create("bank1");
-    bank1.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(1),
       .access("W0C"),
       .volatile(1),
       .reset(1),

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_top.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_top.sv
@@ -363,12 +363,9 @@ module flash_ctrl_reg_top (
   logic default_region_erase_en_qs;
   logic default_region_erase_en_wd;
   logic default_region_erase_en_we;
-  logic bank_cfg_regwen_bank0_qs;
-  logic bank_cfg_regwen_bank0_wd;
-  logic bank_cfg_regwen_bank0_we;
-  logic bank_cfg_regwen_bank1_qs;
-  logic bank_cfg_regwen_bank1_wd;
-  logic bank_cfg_regwen_bank1_we;
+  logic bank_cfg_regwen_qs;
+  logic bank_cfg_regwen_wd;
+  logic bank_cfg_regwen_we;
   logic mp_bank_cfg_erase_en0_qs;
   logic mp_bank_cfg_erase_en0_wd;
   logic mp_bank_cfg_erase_en0_we;
@@ -2529,18 +2526,17 @@ module flash_ctrl_reg_top (
 
   // R[bank_cfg_regwen]: V(False)
 
-  //   F[bank0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SWACCESS("W0C"),
     .RESVAL  (1'h1)
-  ) u_bank_cfg_regwen_bank0 (
+  ) u_bank_cfg_regwen (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (bank_cfg_regwen_bank0_we),
-    .wd     (bank_cfg_regwen_bank0_wd),
+    .we     (bank_cfg_regwen_we),
+    .wd     (bank_cfg_regwen_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2551,33 +2547,7 @@ module flash_ctrl_reg_top (
     .q      (),
 
     // to register interface (read)
-    .qs     (bank_cfg_regwen_bank0_qs)
-  );
-
-
-  //   F[bank1]: 1:1
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("W0C"),
-    .RESVAL  (1'h1)
-  ) u_bank_cfg_regwen_bank1 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (bank_cfg_regwen_bank1_we),
-    .wd     (bank_cfg_regwen_bank1_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (bank_cfg_regwen_bank1_qs)
+    .qs     (bank_cfg_regwen_qs)
   );
 
 
@@ -2593,7 +2563,7 @@ module flash_ctrl_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mp_bank_cfg_erase_en0_we & bank_cfg_regwen_bank_qs),
+    .we     (mp_bank_cfg_erase_en0_we & bank_cfg_regwen_qs),
     .wd     (mp_bank_cfg_erase_en0_wd),
 
     // from internal hardware
@@ -2619,7 +2589,7 @@ module flash_ctrl_reg_top (
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mp_bank_cfg_erase_en1_we & bank_cfg_regwen_bank_qs),
+    .we     (mp_bank_cfg_erase_en1_we & bank_cfg_regwen_qs),
     .wd     (mp_bank_cfg_erase_en1_wd),
 
     // from internal hardware
@@ -3181,11 +3151,8 @@ module flash_ctrl_reg_top (
   assign default_region_erase_en_we = addr_hit[14] & reg_we & ~wr_err;
   assign default_region_erase_en_wd = reg_wdata[2];
 
-  assign bank_cfg_regwen_bank0_we = addr_hit[15] & reg_we & ~wr_err;
-  assign bank_cfg_regwen_bank0_wd = reg_wdata[0];
-
-  assign bank_cfg_regwen_bank1_we = addr_hit[15] & reg_we & ~wr_err;
-  assign bank_cfg_regwen_bank1_wd = reg_wdata[1];
+  assign bank_cfg_regwen_we = addr_hit[15] & reg_we & ~wr_err;
+  assign bank_cfg_regwen_wd = reg_wdata[0];
 
   assign mp_bank_cfg_erase_en0_we = addr_hit[16] & reg_we & ~wr_err;
   assign mp_bank_cfg_erase_en0_wd = reg_wdata[1];
@@ -3355,8 +3322,7 @@ module flash_ctrl_reg_top (
       end
 
       addr_hit[15]: begin
-        reg_rdata_next[0] = bank_cfg_regwen_bank0_qs;
-        reg_rdata_next[1] = bank_cfg_regwen_bank1_qs;
+        reg_rdata_next[0] = bank_cfg_regwen_qs;
       end
 
       addr_hit[16]: begin

--- a/hw/ip/flash_ctrl/sw/flash_ctrl_regs.h
+++ b/hw/ip/flash_ctrl/sw/flash_ctrl_regs.h
@@ -160,8 +160,7 @@
 
 // Bank configuration registers configuration enable.
 #define FLASH_CTRL_BANK_CFG_REGWEN(id) (FLASH_CTRL##id##_BASE_ADDR + 0x3c)
-#define FLASH_CTRL_BANK_CFG_REGWEN_BANK0 0
-#define FLASH_CTRL_BANK_CFG_REGWEN_BANK1 1
+#define FLASH_CTRL_BANK_CFG_REGWEN_BANK 0
 
 // Memory protect bank configuration
 #define FLASH_CTRL_MP_BANK_CFG(id) (FLASH_CTRL##id##_BASE_ADDR + 0x40)


### PR DESCRIPTION
Multireg does not currently support a different regwen per 'field'
since it is obviously meant for reg granularity.

Need to discuss later if this function is desired, or if there
should be an option to stop fields from compacting in multireg