### PR TITLE
[sw, flash_ctrl] Various flash fixes

### DIFF
--- a/hw/ip/flash_ctrl/doc/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/doc/flash_ctrl.hjson
@@ -275,7 +275,6 @@
       ],
     },
 
-
     { multireg: {
         cname: "FLASH_CTRL",
         name: "MP_BANK_CFG",
@@ -285,7 +284,7 @@
         hwaccess: "hro",
         regwen: "BANK_CFG_REGWEN"
         fields: [
-            { bits: "1",
+            { bits: "0",
               name: "ERASE_EN",
               desc: '''
                 Bank wide erase enable

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_reg_block.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_reg_block.sv
@@ -1348,7 +1348,7 @@ class flash_ctrl_reg_mp_bank_cfg extends dv_base_reg;
     erase_en0.configure(
       .parent(this),
       .size(1),
-      .lsb_pos(1),
+      .lsb_pos(0),
       .access("RW"),
       .volatile(0),
       .reset(0),
@@ -1359,7 +1359,7 @@ class flash_ctrl_reg_mp_bank_cfg extends dv_base_reg;
     erase_en1.configure(
       .parent(this),
       .size(1),
-      .lsb_pos(2),
+      .lsb_pos(1),
       .access("RW"),
       .volatile(0),
       .reset(0),

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_top.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_top.sv
@@ -2567,7 +2567,7 @@ module flash_ctrl_reg_top (
   // Subregister 0 of Multireg mp_bank_cfg
   // R[mp_bank_cfg]: V(False)
 
-  // F[erase_en0]: 1:1
+  // F[erase_en0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
@@ -2593,7 +2593,7 @@ module flash_ctrl_reg_top (
   );
 
 
-  // F[erase_en1]: 2:2
+  // F[erase_en1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
@@ -3171,10 +3171,10 @@ module flash_ctrl_reg_top (
   assign bank_cfg_regwen_wd = reg_wdata[0];
 
   assign mp_bank_cfg_erase_en0_we = addr_hit[16] & reg_we & ~wr_err;
-  assign mp_bank_cfg_erase_en0_wd = reg_wdata[1];
+  assign mp_bank_cfg_erase_en0_wd = reg_wdata[0];
 
   assign mp_bank_cfg_erase_en1_we = addr_hit[16] & reg_we & ~wr_err;
-  assign mp_bank_cfg_erase_en1_wd = reg_wdata[2];
+  assign mp_bank_cfg_erase_en1_wd = reg_wdata[1];
 
   assign op_status_done_we = addr_hit[17] & reg_we & ~wr_err;
   assign op_status_done_wd = reg_wdata[0];
@@ -3342,8 +3342,8 @@ module flash_ctrl_reg_top (
       end
 
       addr_hit[16]: begin
-        reg_rdata_next[1] = mp_bank_cfg_erase_en0_qs;
-        reg_rdata_next[2] = mp_bank_cfg_erase_en1_qs;
+        reg_rdata_next[0] = mp_bank_cfg_erase_en0_qs;
+        reg_rdata_next[1] = mp_bank_cfg_erase_en1_qs;
       end
 
       addr_hit[17]: begin

--- a/hw/ip/flash_ctrl/sw/flash_ctrl_regs.h
+++ b/hw/ip/flash_ctrl/sw/flash_ctrl_regs.h
@@ -164,8 +164,8 @@
 
 // Memory protect bank configuration
 #define FLASH_CTRL_MP_BANK_CFG(id) (FLASH_CTRL##id##_BASE_ADDR + 0x40)
-#define FLASH_CTRL_MP_BANK_CFG_ERASE_EN0 1
-#define FLASH_CTRL_MP_BANK_CFG_ERASE_EN1 2
+#define FLASH_CTRL_MP_BANK_CFG_ERASE_EN0 0
+#define FLASH_CTRL_MP_BANK_CFG_ERASE_EN1 1
 
 // Flash Operation Status
 #define FLASH_CTRL_OP_STATUS(id) (FLASH_CTRL##id##_BASE_ADDR + 0x44)

--- a/hw/top_earlgrey/dv/env/chip_reg_block.sv
+++ b/hw/top_earlgrey/dv/env/chip_reg_block.sv
@@ -186,7 +186,6 @@ typedef class chip_mem_ram_main;
 typedef class chip_mem_eflash;
 typedef class chip_reg_block;
 
-
 // Block: spi_device
 // Class: spi_device_reg_intr_state
 class spi_device_reg_intr_state extends dv_base_reg;
@@ -1074,7 +1073,6 @@ class spi_device_reg_block extends dv_base_reg_block;
   endfunction : build
 
 endclass : spi_device_reg_block
-
 // Block: flash_ctrl
 // Class: flash_ctrl_reg_intr_state
 class flash_ctrl_reg_intr_state extends dv_base_reg;
@@ -2392,7 +2390,7 @@ class flash_ctrl_reg_mp_bank_cfg extends dv_base_reg;
     erase_en0.configure(
       .parent(this),
       .size(1),
-      .lsb_pos(1),
+      .lsb_pos(0),
       .access("RW"),
       .volatile(0),
       .reset(0),
@@ -2403,7 +2401,7 @@ class flash_ctrl_reg_mp_bank_cfg extends dv_base_reg;
     erase_en1.configure(
       .parent(this),
       .size(1),
-      .lsb_pos(2),
+      .lsb_pos(1),
       .access("RW"),
       .volatile(0),
       .reset(0),
@@ -2844,7 +2842,6 @@ class flash_ctrl_reg_block extends dv_base_reg_block;
   endfunction : build
 
 endclass : flash_ctrl_reg_block
-
 // Block: rv_timer
 // Class: rv_timer_reg_ctrl
 class rv_timer_reg_ctrl extends dv_base_reg;
@@ -3213,7 +3210,6 @@ class rv_timer_reg_block extends dv_base_reg_block;
   endfunction : build
 
 endclass : rv_timer_reg_block
-
 // Block: gpio
 // Class: gpio_reg_intr_state
 class gpio_reg_intr_state extends dv_base_reg;
@@ -3840,7 +3836,6 @@ class gpio_reg_block extends dv_base_reg_block;
   endfunction : build
 
 endclass : gpio_reg_block
-
 // Block: hmac
 // Class: hmac_reg_intr_state
 class hmac_reg_intr_state extends dv_base_reg;
@@ -4921,7 +4916,6 @@ class hmac_reg_block extends dv_base_reg_block;
   endfunction : build
 
 endclass : hmac_reg_block
-
 // Block: uart
 // Class: uart_reg_intr_state
 class uart_reg_intr_state extends dv_base_reg;
@@ -5869,7 +5863,6 @@ class uart_reg_block extends dv_base_reg_block;
   endfunction : build
 
 endclass : uart_reg_block
-
 // Block: rv_plic
 // Class: rv_plic_reg_ip0
 class rv_plic_reg_ip0 extends dv_base_reg;
@@ -10096,7 +10089,6 @@ class rv_plic_reg_block extends dv_base_reg_block;
   endfunction : build
 
 endclass : rv_plic_reg_block
-
 // Block: chip
 // Class: chip_mem_rom
 class chip_mem_rom extends dv_base_mem;

--- a/sw/lib/flash_ctrl.h
+++ b/sw/lib/flash_ctrl.h
@@ -71,6 +71,11 @@ int flash_write(uint32_t addr, const uint32_t *data, uint32_t size);
 int flash_read(uint32_t addr, uint32_t size, uint32_t *data);
 
 /**
+ * Configure bank erase enable
+ */
+void flash_cfg_bank_erase(bank_index_t bank, bool erase_en);
+
+/**
  * Set flash controller default permissions.
  *
  * @param rd_end Read enable.

--- a/sw/tests/flash_ctrl/flash_test.c
+++ b/sw/tests/flash_ctrl/flash_test.c
@@ -66,6 +66,8 @@ int main(int argc, char **argv) {
   flash_init_block();
 
   // enable all access
+  flash_cfg_bank_erase(FLASH_BANK_0, /*erase_en=*/true);
+  flash_cfg_bank_erase(FLASH_BANK_1, /*erase_en=*/true);
   flash_default_region_access(1, 1, 1);
   break_on_error(flash_page_erase(bank1_addr));
   flash_write_scratch_reg(0xFACEDEAD);
@@ -80,7 +82,7 @@ int main(int argc, char **argv) {
   // do 4K programming
   // employ the live programming method where overall payload >> flash fifo size
   for (i = 0; i < ARRAYSIZE(prog_array); i++) {
-    prog_array[i] = i + (i % 2) ? 0xA5A5A5A5 : 0x5A5A5A5A;
+    prog_array[i] = (i % 2) ? 0xA5A5A5A5 : 0x5A5A5A5A;
   }
 
   for (iteration = 0; iteration < 2; iteration++) {
@@ -153,6 +155,9 @@ int main(int argc, char **argv) {
       break_on_error(1);
     }
   }
+
+  flash_cfg_bank_erase(FLASH_BANK_0, /*erase_en=*/false);
+  flash_cfg_bank_erase(FLASH_BANK_1, /*erase_en=*/false);
 
   // cleanly terminate execution
   uart_send_str("PASS!\r\n");


### PR DESCRIPTION
- fix BANK_CFG multireg field offset
- add flash_cfg_bank_erase


I am not sure what I was thinking earlier... completely forgot there are other uses of flash_cfg_bank_erase.
Anyways, here it is