### PR TITLE
[regtool] Attempt to fix regtool crash

### DIFF
--- a/util/reggen/validate.py
+++ b/util/reggen/validate.py
@@ -1305,23 +1305,24 @@ def validate(regs, **kwargs):
     #   Assumed param list is already validated in above `check_keys` function
     if "param_list" in regs and len(regs["param_list"]) != 0:
         for p in params:
-            tokens = p.split('=')
-            if len(tokens) != 2:
-                error += 1
-                log.error("Parameter format isn't correct. {}".format(p))
-            key, value = tokens[0], tokens[1]
-            param, err = search_param(regs["param_list"], key)
-            if err != 0:
-                error += err
-                continue
+            if p:
+                tokens = p.split('=')
+                if len(tokens) != 2:
+                    error += 1
+                    log.error("Parameter format isn't correct. {}".format(p))
+                key, value = tokens[0], tokens[1]
+                param, err = search_param(regs["param_list"], key)
+                if err != 0:
+                    error += err
+                    continue
 
-            value, err = check_int(
-                value, component + " param[{}]".format(param["name"]))
-            if err != 0:
-                error += err
-                continue
+                value, err = check_int(
+                    value, component + " param[{}]".format(param["name"]))
+                if err != 0:
+                    error += err
+                    continue
 
-            param["default"] = value
+                param["default"] = value
 
     if "scan" in regs:
         scan, err = check_bool(regs["scan"], component + " scan")

--- a/util/regtool.py
+++ b/util/regtool.py
@@ -82,6 +82,7 @@ def main():
     parser.add_argument('--param',
                         '-p',
                         type=str,
+                        default="",
                         help='''Change the Parameter values.
                                 Only integer value is supported.
                                 You can add multiple param arguments.


### PR DESCRIPTION
The regtool crashes when no parameters are specified on the command line. This patch fixes the problem by adding a default and skipping empty parameter lists in validate.py