### PR TITLE
Fix fusesoc dependency breakage using python-requirements.txt

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -99,7 +99,7 @@ stages:
     steps:
     - bash: |
         sudo apt-get install -y python3 python3-pip build-essential srecord python3-setuptools zlib1g-dev libusb-1.0 \
-          && sudo pip3 install -r python-requirements.txt && sudo pip3 uninstall attrs -y && sudo pip3 install attrs==19.1.0
+          && sudo pip3 install -r python-requirements.txt
       displayName: 'Install dependencies'
     - bash: |
         export TOOLCHAIN_PATH="${TOOLCHAIN_PATH}"
@@ -113,7 +113,6 @@ stages:
     - bash: |
         sudo apt-get install -y python3 python3-pip build-essential srecord python3-setuptools zlib1g-dev libusb-1.0 \
           && sudo pip3 install -r python-requirements.txt \
-          && sudo pip3 uninstall attrs -y && sudo pip3 install attrs==19.1.0 \
           && sudo apt-get install git make autoconf g++ flex bison curl
       displayName: 'Install dependencies'
     - bash: |
@@ -151,8 +150,7 @@ stages:
     steps:
     - bash: |
         sudo apt-get install -y python3 python3-pip build-essential srecord python3-setuptools zlib1g-dev libusb-1.0 \
-          && sudo pip3 install -r python-requirements.txt \
-          && sudo pip3 uninstall attrs -y && sudo pip3 install attrs==19.1.0
+          && sudo pip3 install -r python-requirements.txt
       displayName: 'Install dependencies'
     - bash: |
         set -e

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -17,3 +17,8 @@ git+https://github.com/olofk/ipyxact.git@master
 
 # Development version of edalize until all our changes are upstream
 git+https://github.com/lowRISC/edalize.git@ot
+
+# Pin attrs version to workaround
+# https://github.com/enthought/sat-solver/issues/270
+# Tracked in https://github.com/lowRISC/opentitan/issues/305
+attrs==19.1.0


### PR DESCRIPTION
In #302, azure-pipelines.yml was modified to ensure that attrs 19.1.0 is
installed. This is because 19.2.0 breaks FuseSoC via the simplesat
dependency (see https://github.com/enthought/sat-solver/issues/270).
While the edits to azure-pipelines.yml fixed CI, users following the
getting started guide are still going to run into this issue. This
commit addresses the problem in an alternative way - by specifying the
version of attrs to use in python-requirements.txt.

Introducing a constraints.txt could have advantages, but that is more
intrusive and would require further doc updates. I feel that would be
overkill for a quick fix workaround that we hope to remove quite
rapidly.

This patch intends to be a quick fix - hopefully upstream simplesat will be fixed soon, or alternatively we can depend on a forked simplesat repo that contains the fix.