### PR TITLE
[dv] Use 2 top opts in BUILD_OPTS

### DIFF
--- a/hw/dv/tools/Makefile
+++ b/hw/dv/tools/Makefile
@@ -45,6 +45,7 @@ BUILD_LOG         ?= ${BUILD_DIR}/build.log
 RUN_LOG           ?= ${RUN_DIR}/run.log
 UVM_VERBOSITY     ?= UVM_LOW
 
+TOPS              ?= tb ${DUT_TOP}_bind
 ####################################################################################################
 ## Options for SV build / C build / simulation run                                                ##
 ## CL_ prefix represents command line versions of these options - they should be empty and only   ##
@@ -52,7 +53,7 @@ UVM_VERBOSITY     ?= UVM_LOW
 ####################################################################################################
 # BUILD_OPTS are passed to the simulator during the SV testbench compile step
 CL_BUILD_OPTS     +=
-BUILD_OPTS        +=
+BUILD_OPTS        += $(addprefix -top , $(TOPS))
 
 # RUN_OPTS are passed to the simulation executable that is invoked to run the simulation
 CL_RUN_OPTS       +=

--- a/hw/dv/tools/rules.mk
+++ b/hw/dv/tools/rules.mk
@@ -3,6 +3,8 @@
 ## Licensed under the Apache License, Version 2.0, see LICENSE for details.                       ##
 ## SPDX-License-Identifier: Apache-2.0                                                            ##
 ####################################################################################################
+.DEFAULT_GOAL := all
+
 all: build run
 
 ########################


### PR DESCRIPTION
XCelium requires to specify all the tops.
Default tops are tb ${DUT_TOP}_bind