### PR TITLE
[pinmux/fpv] Add FPV testbench for pinmux

### DIFF
--- a/hw/formal/formal.core
+++ b/hw/formal/formal.core
@@ -22,6 +22,7 @@ filesets:
       - lowrisc:tlul:adapter_sram
       - lowrisc:tlul:socket_1n
       - lowrisc:tlul:socket_m1
+      - lowrisc:fpv:pinmux_fpv
 
 targets:
   sim:

--- a/hw/formal/fpv_all
+++ b/hw/formal/fpv_all
@@ -30,6 +30,7 @@ declare -a blocks=(
   "prim_alert_rxtx_tb"
   "prim_alert_rxtx_async_tb"
   "prim_esc_rxtx_tb"
+  "pinmux_tb"
 )
 
 #-------------------------------------------------------------------------

--- a/hw/ip/pinmux/fpv/pinmux_fpv.core
+++ b/hw/ip/pinmux/fpv/pinmux_fpv.core
@@ -1,0 +1,23 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:fpv:pinmux_fpv:0.1"
+description: "PIINMUX FPV target"
+filesets:
+  files_fpv:
+    depend:
+      - lowrisc:ip:pinmux
+    files:
+      - tb/pinmux_tb.sv
+      - tb/pinmux_bind.sv
+      - vip/pinmux_assert.sv
+    file_type: systemVerilogSource
+
+targets:
+  default: &default_target
+    toplevel:
+      - tb/pinmux_tb.sv
+    filesets:
+      - files_fpv
+    default_tool: jg

--- a/hw/ip/pinmux/fpv/tb/pinmux_bind.sv
+++ b/hw/ip/pinmux/fpv/tb/pinmux_bind.sv
@@ -1,0 +1,12 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+module pinmux_bind;
+
+  bind pinmux pinmux_assert i_pinmux_assert (
+    .*
+  );
+
+endmodule : pinmux_bind

--- a/hw/ip/pinmux/fpv/tb/pinmux_tb.sv
+++ b/hw/ip/pinmux/fpv/tb/pinmux_tb.sv
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Testbench module for pinmux. Intended to use with a formal tool.
+
+module pinmux_tb (
+  input                                         clk_i,
+  input                                         rst_ni,
+  input  tlul_pkg::tl_h2d_t                     tl_i,
+  output tlul_pkg::tl_d2h_t                     tl_o,
+  input        [pinmux_reg_pkg::NPeriphOut-1:0] periph_to_mio_i,
+  input        [pinmux_reg_pkg::NPeriphOut-1:0] periph_to_mio_oe_i,
+  output logic [pinmux_reg_pkg::NPeriphIn-1:0]  mio_to_periph_o,
+  output logic [pinmux_reg_pkg::NMioPads-1:0]   mio_out_o,
+  output logic [pinmux_reg_pkg::NMioPads-1:0]   mio_oe_o,
+  input        [pinmux_reg_pkg::NMioPads-1:0]   mio_in_i
+);
+
+  pinmux i_pinmux (
+    .clk_i              ,
+    .rst_ni             ,
+    .tl_i               ,
+    .tl_o               ,
+    .periph_to_mio_i    ,
+    .periph_to_mio_oe_i ,
+    .mio_to_periph_o    ,
+    .mio_out_o          ,
+    .mio_oe_o           ,
+    .mio_in_i
+  );
+
+endmodule : pinmux_tb

--- a/hw/ip/pinmux/fpv/vip/pinmux_assert.sv
+++ b/hw/ip/pinmux/fpv/vip/pinmux_assert.sv
@@ -1,0 +1,56 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Assertions for pinmux. Intended to use with a formal tool.
+
+module pinmux_assert (
+  input                                  clk_i,
+  input                                  rst_ni,
+  input tlul_pkg::tl_h2d_t               tl_i,
+  input tlul_pkg::tl_d2h_t               tl_o,
+  input [pinmux_reg_pkg::NPeriphOut-1:0] periph_to_mio_i,
+  input [pinmux_reg_pkg::NPeriphOut-1:0] periph_to_mio_oe_i,
+  input [pinmux_reg_pkg::NPeriphIn-1:0]  mio_to_periph_o,
+  input [pinmux_reg_pkg::NMioPads-1:0]   mio_out_o,
+  input [pinmux_reg_pkg::NMioPads-1:0]   mio_oe_o,
+  input [pinmux_reg_pkg::NMioPads-1:0]   mio_in_i
+);
+
+  //////////////////////////////////////////////////////
+  // Input Mux
+  //////////////////////////////////////////////////////
+
+  for (genvar k = 0; k < pinmux_reg_pkg::NPeriphIn; k++) begin : gen_periph_in
+    `ASSERT(InSel0_A, reg2hw.periph_insel[k].q == 0 |->
+        mio_to_periph_o[k] == 1'b0, clk_i, !rst_ni)
+    `ASSERT(InSel1_A, reg2hw.periph_insel[k].q == 1 |->
+        mio_to_periph_o[k] == 1'b1, clk_i, !rst_ni)
+    `ASSERT(InSelN_A, reg2hw.periph_insel[k].q > 1  |->
+        mio_to_periph_o[k] == mio_in_i[reg2hw.periph_insel[k].q - 2], clk_i, !rst_ni)
+  end
+
+  //////////////////////////////////////////////////////
+  // Output Mux
+  //////////////////////////////////////////////////////
+
+  for (genvar k = 0; k < pinmux_reg_pkg::NMioPads; k++) begin : gen_mio_out
+    `ASSERT(OutSel0_A, reg2hw.mio_outsel[k].q == 0 |->
+        mio_out_o[k] == 1'b0, clk_i, !rst_ni)
+    `ASSERT(OutSel1_A, reg2hw.mio_outsel[k].q == 1 |->
+        mio_out_o[k] == 1'b1, clk_i, !rst_ni)
+    `ASSERT(OutSel2_A, reg2hw.mio_outsel[k].q == 2 |->
+        mio_out_o[k] == 1'b0, clk_i, !rst_ni)
+    `ASSERT(OutSelN_A, reg2hw.mio_outsel[k].q > 2  |->
+        mio_out_o[k] == periph_to_mio_i[reg2hw.mio_outsel[k].q - 3], clk_i, !rst_ni)
+    `ASSERT(OutSelOe0_A, reg2hw.mio_outsel[k].q == 0 |->
+        mio_oe_o[k] == 1'b1, clk_i, !rst_ni)
+    `ASSERT(OutSelOe1_A, reg2hw.mio_outsel[k].q == 1 |->
+        mio_oe_o[k] == 1'b1, clk_i, !rst_ni)
+    `ASSERT(OutSelOe2_A, reg2hw.mio_outsel[k].q == 2 |->
+        mio_oe_o[k] == 1'b0, clk_i, !rst_ni)
+    `ASSERT(OutSelOeN_A, reg2hw.mio_outsel[k].q > 2  |->
+        mio_oe_o[k] == periph_to_mio_oe_i[reg2hw.mio_outsel[k].q - 3], clk_i, !rst_ni)
+  end
+
+endmodule : pinmux_assert

--- a/hw/ip/pinmux/rtl/pinmux.sv
+++ b/hw/ip/pinmux/rtl/pinmux.sv
@@ -48,7 +48,7 @@ module pinmux (
     // index using configured insel
     assign mio_to_periph_o[k] = data_mux[reg2hw.periph_insel[k].q];
     // disallow undefined entries
-    `ASSUME(InSelRange_A, reg2hw.periph_insel[k].q < pinmux_reg_pkg::NMioPads + 2, clk_i, rst_ni)
+    `ASSUME(InSelRange_A, reg2hw.periph_insel[k].q < pinmux_reg_pkg::NMioPads + 2, clk_i, !rst_ni)
   end
 
   //////////////////////////////////////////////////////
@@ -65,7 +65,7 @@ module pinmux (
     assign mio_out_o[k] = data_mux[reg2hw.mio_outsel[k].q];
     assign mio_oe_o[k]  = oe_mux[reg2hw.mio_outsel[k].q];
     // disallow undefined entries
-    `ASSUME(OutSelRange_A, reg2hw.mio_outsel[k].q < pinmux_reg_pkg::NPeriphOut + 3, clk_i, rst_ni)
+    `ASSUME(OutSelRange_A, reg2hw.mio_outsel[k].q < pinmux_reg_pkg::NPeriphOut + 3, clk_i, !rst_ni)
   end
 
 endmodule : pinmux


### PR DESCRIPTION
This adds an initial FPV testbench for the pinmux that tests its basic properties.