### PR TITLE
[topgen] Renaming top_earlgrey to _core

### DIFF
--- a/hw/Makefile
+++ b/hw/Makefile
@@ -43,7 +43,7 @@ $(ips_reg):
 $(tops_gen):
 	$(eval $@_TOP := $(strip $(foreach top,$(TOPS),$(findstring $(top),$@))))
 	${PRJ_DIR}/util/topgen.py -t ${PRJ_DIR}/hw/$($@_TOP)/doc/$($@_TOP).hjson \
-		--tpl ${PRJ_DIR}/hw/$($@_TOP)/doc/$($@_TOP).tpl.sv \
+		--tpl ${PRJ_DIR}/hw/$($@_TOP)/doc/ \
 		-o ${PRJ_DIR}/hw/$($@_TOP)/
 	${PRJ_DIR}/util/topgen.py -t ${PRJ_DIR}/hw/$($@_TOP)/doc/$($@_TOP).hjson \
 		-r -o ${PRJ_DIR}/hw/$($@_TOP)/dv/env/

--- a/hw/top_earlgrey/doc/top_earlgrey.tpl.sv
+++ b/hw/top_earlgrey/doc/top_earlgrey.tpl.sv
@@ -2,455 +2,67 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-<% import re
+<%
+import re
 %>\
-module top_earlgrey #(
+module top_${top["name"]} #(
   parameter bit IbexPipeLine = 0
 ) (
-  // Clock and Reset
-  input               clk_i,
-  input               rst_ni,
-
-  // JTAG interface
-  input               jtag_tck_i,
-  input               jtag_tms_i,
-  input               jtag_trst_ni,
-  input               jtag_td_i,
-  output              jtag_td_o,
-
+);
 % for m in top["module"]:
   // ${m["name"]}
 %     for p_in in m["available_input_list"] + m["available_inout_list"]:
           ## assume it passed validate and have available input list always
 %         if "width" in p_in and int(p_in["width"]) != 1:
-  input  [${int(p_in["width"])-1}:0] cio_${m["name"]}_${p_in["name"]}_p2d_i,
+  logic [${int(p_in["width"])-1}:0] ${m["name"]}_${p_in["name"]}_p2d;
 %         else:
-  input  cio_${m["name"]}_${p_in["name"]}_p2d_i,
+  logic ${m["name"]}_${p_in["name"]}_p2d;
 %         endif
 %     endfor
 %     for p_out in m["available_output_list"] + m["available_inout_list"]:
           ## assume it passed validate and have available output list always
 %         if "width" in p_out and int(p_out["width"]) != 1:
-  output [${int(p_out["width"])-1}:0] cio_${m["name"]}_${p_out["name"]}_d2p_o,
-  output [${int(p_out["width"])-1}:0] cio_${m["name"]}_${p_out["name"]}_en_d2p_o,
+  logic [${int(p_out["width"])-1}:0] ${m["name"]}_${p_out["name"]}_d2p;
+  logic [${int(p_out["width"])-1}:0] ${m["name"]}_${p_out["name"]}_en_d2p;
 %         else:
-  output cio_${m["name"]}_${p_out["name"]}_d2p_o,
-  output cio_${m["name"]}_${p_out["name"]}_en_d2p_o,
+  logic ${m["name"]}_${p_out["name"]}_d2p;
+  logic ${m["name"]}_${p_out["name"]}_en_d2p;
 %         endif
 %     endfor
 % endfor
 
   input               scanmode_i  // 1 for Scan
-);
 
-  import tlul_pkg::*;
-  import top_pkg::*;
-  import tl_main_pkg::*;
-  import flash_ctrl_pkg::*;
+  // Top instantiation
+  top_${top["name"]}_core #(
+    .IbexPipeLine (IbexPipeLine)
+  ) u_core (
+    .clk_i          (           ),
+    .rst_ni         (           ),
 
-  tl_h2d_t  tl_corei_h_h2d;
-  tl_d2h_t  tl_corei_h_d2h;
+    // JTAG
+    .jtag_tck_i     (           ),
+    .jtag_tms_i     (           ),
+    .jtag_trst_ni   (           ),
+    .jtag_td_i      (           ),
+    .jtag_td_o      (           ),
 
-  tl_h2d_t  tl_cored_h_h2d;
-  tl_d2h_t  tl_cored_h_d2h;
-
-  tl_h2d_t  tl_dm_sba_h_h2d;
-  tl_d2h_t  tl_dm_sba_h_d2h;
-
-  tl_h2d_t  tl_debug_mem_d_h2d;
-  tl_d2h_t  tl_debug_mem_d_d2h;
-
-## TL-UL device port declaration
+    // Module CIO
 % for m in top["module"]:
-%     if not m["bus_device"] in ["none", ""]:
-  tl_h2d_t  tl_${m["name"]}_d_h2d;
-  tl_d2h_t  tl_${m["name"]}_d_d2h;
-%     endif
-%     if not m["bus_host"] in ["none", ""]:
-  tl_h2d_t  tl_${m["name"]}_h_h2d;
-  tl_d2h_t  tl_${m["name"]}_h_d2h;
-%     endif
-% endfor
-
-% for m in top["memory"]:
-  tl_h2d_t tl_${m["name"]}_d_h2d;
-  tl_d2h_t tl_${m["name"]}_d_d2h;
-% endfor
-<%
-  interrupt_num = sum([x["width"] if "width" in x else 1 for x in top["interrupt"]])
-%>\
-  logic [${interrupt_num-1}:0]  intr_vector;
-  // Interrupt source list
-% for m in top["module"]:
-    % for intr in m["interrupt_list"] if "interrupt_list" in m else []:
-        % if "width" in intr and int(intr["width"]) != 1:
-  logic [${int(intr["width"])-1}:0] intr_${m["name"]}_${intr["name"]};
-        % else:
-  logic intr_${m["name"]}_${intr["name"]};
-        % endif
-    % endfor
-% endfor
-
-
-  logic [0:0]   irq_plic;
-  logic [${(interrupt_num).bit_length()-1}:0] irq_id[1];
-  logic [0:0]   msip;
-
-  // Non-debug module reset == reset for everything except for the debug module
-  // and the logic required to access it.
-  logic ndmreset_n;
-  logic ndmreset_from_dm;
-  assign ndmreset_n = (scanmode_i) ? rst_ni : ~ndmreset_from_dm & rst_ni;
-
-  logic debug_req;
-
-  // processor core
-  rv_core_ibex #(
-    .MHPMCounterNum      (8),
-    .MHPMCounterWidth    (40),
-    .RV32E               (0),
-    .RV32M               (1),
-    .DmHaltAddr          (ADDR_SPACE_DEBUG_MEM + dm::HaltAddress),
-    .DmExceptionAddr     (ADDR_SPACE_DEBUG_MEM + dm::ExceptionAddress),
-    .PipeLine            (IbexPipeLine)
-  ) core (
-    // clock and reset
-    .clk_i                (clk_i),
-    .rst_ni               (ndmreset_n),
-    .test_en_i            (1'b0),
-    // static pinning
-    .hart_id_i            (32'b0),
-    .boot_addr_i          (ADDR_SPACE_ROM),
-    // TL-UL buses
-    .tl_i_o               (tl_corei_h_h2d),
-    .tl_i_i               (tl_corei_h_d2h),
-    .tl_d_o               (tl_cored_h_h2d),
-    .tl_d_i               (tl_cored_h_d2h),
-    // interrupts
-    .irq_software_i       (msip),
-    .irq_timer_i          (intr_rv_timer_timer_expired_0_0),
-    .irq_external_i       (irq_plic),
-    .irq_fast_i           (15'b0),// PLIC handles all peripheral interrupts
-    .irq_nm_i             (1'b0),// TODO - add and connect alert responder
-    // debug interface
-    .debug_req_i          (debug_req),
-    // CPU control signals
-    .fetch_enable_i       (1'b1),
-    .core_sleep_o         ()
-  );
-
-  // Debug Module (RISC-V Debug Spec 0.13)
-  //
-
-  rv_dm #(
-    .NrHarts     (  1),
-    .IdcodeValue (32'h00000001) // Temporary value
-                                // xxxx             version
-                                // xxxxxxxxxxxxxxxx part number
-                                // xxxxxxxxxxx      manufacturer id
-                                // 1                required by standard
-  ) u_dm_top (
-    .clk_i         (clk_i),
-    .rst_ni        (rst_ni),
-    .testmode_i    (1'b0),
-    .ndmreset_o    (ndmreset_from_dm),
-    .dmactive_o    (),
-    .debug_req_o   (debug_req),
-    .unavailable_i (1'b0),
-
-    // bus device with debug memory (for execution-based debug)
-    .tl_d_i        (tl_debug_mem_d_h2d),
-    .tl_d_o        (tl_debug_mem_d_d2h),
-
-    // bus host (for system bus accesses, SBA)
-    .tl_h_o        (tl_dm_sba_h_h2d),
-    .tl_h_i        (tl_dm_sba_h_d2h),
-
-    //JTAG
-    .tck_i            (jtag_tck_i),
-    .tms_i            (jtag_tms_i),
-    .trst_ni          (jtag_trst_ni),
-    .td_i             (jtag_td_i),
-    .td_o             (jtag_td_o),
-    .tdo_oe_o         (       )
-  );
-
-## Memory Instantiation
-% for m in top["memory"]:
-  % if m["type"] == "ram_1p":
-<%
-     data_width = int(top["datawidth"])
-     dw_byte = data_width // 8
-     addr_width = ((int(m["size"], 0) // dw_byte) -1).bit_length()
-     sram_depth = (int(m["size"], 0) // dw_byte)
-%>\
-  // sram device
-  logic        ${m["name"]}_req;
-  logic        ${m["name"]}_we;
-  logic [${addr_width-1}:0] ${m["name"]}_addr;
-  logic [${data_width-1}:0] ${m["name"]}_wdata;
-  logic [${data_width-1}:0] ${m["name"]}_wmask;
-  logic [${data_width-1}:0] ${m["name"]}_rdata;
-  logic        ${m["name"]}_rvalid;
-
-  tlul_adapter_sram #(
-    .SramAw(${addr_width}),
-    .SramDw(${data_width}),
-    .Outstanding(1)
-  ) tl_adapter_${m["name"]} (
-    .clk_i,
-    .rst_ni   (ndmreset_n),
-
-    .tl_i     (tl_${m["name"]}_d_h2d),
-    .tl_o     (tl_${m["name"]}_d_d2h),
-
-    .req_o    (${m["name"]}_req),
-    .gnt_i    (1'b1), // Always grant as only one requester exists
-    .we_o     (${m["name"]}_we),
-    .addr_o   (${m["name"]}_addr),
-    .wdata_o  (${m["name"]}_wdata),
-    .wmask_o  (${m["name"]}_wmask),
-    .rdata_i  (${m["name"]}_rdata),
-    .rvalid_i (${m["name"]}_rvalid),
-    .rerror_i (2'b00)
-  );
-
-  ## TODO: Instantiate ram_1p model using RAMGEN (currently not available)
-  prim_ram_1p #(
-    .Width(${data_width}),
-    .Depth(${sram_depth}),
-    .DataBitsPerMask(${int(data_width/4)})
-  ) u_ram1p_${m["name"]} (
-    .clk_i,
-    .rst_ni   (ndmreset_n),
-
-    .req_i    (${m["name"]}_req),
-    .write_i  (${m["name"]}_we),
-    .addr_i   (${m["name"]}_addr),
-    .wdata_i  (${m["name"]}_wdata),
-    .wmask_i  (${m["name"]}_wmask),
-    .rvalid_o (${m["name"]}_rvalid),
-    .rdata_o  (${m["name"]}_rdata)
-  );
-  % elif m["type"] == "rom":
-<%
-     data_width = int(top["datawidth"])
-     dw_byte = data_width // 8
-     addr_width = ((int(m["size"], 0) // dw_byte) -1).bit_length()
-     rom_depth = (int(m["size"], 0) // dw_byte)
-%>\
-  // ROM device
-  logic        ${m["name"]}_req;
-  logic [${addr_width-1}:0] ${m["name"]}_addr;
-  logic [${data_width-1}:0] ${m["name"]}_rdata;
-  logic        ${m["name"]}_rvalid;
-
-  tlul_adapter_sram #(
-    .SramAw(${addr_width}),
-    .SramDw(${data_width}),
-    .Outstanding(1),
-    .ErrOnWrite(1)
-  ) tl_adapter_${m["name"]} (
-    .clk_i,
-    .rst_ni   (ndmreset_n),
-
-    .tl_i     (tl_${m["name"]}_d_h2d),
-    .tl_o     (tl_${m["name"]}_d_d2h),
-
-    .req_o    (${m["name"]}_req),
-    .gnt_i    (1'b1), // Always grant as only one requester exists
-    .we_o     (),
-    .addr_o   (${m["name"]}_addr),
-    .wdata_o  (),
-    .wmask_o  (),
-    .rdata_i  (${m["name"]}_rdata),
-    .rvalid_i (${m["name"]}_rvalid),
-    .rerror_i (2'b00)
-  );
-
-  ## TODO: Replace emulated ROM to real ROM in ASIC SoC
-  prim_rom #(
-    .Width(${data_width}),
-    .Depth(${rom_depth})
-  ) u_rom_${m["name"]} (
-    .clk_i,
-    .rst_ni   (ndmreset_n),
-    .cs_i     (${m["name"]}_req),
-    .addr_i   (${m["name"]}_addr),
-    .dout_o   (${m["name"]}_rdata),
-    .dvalid_o (${m["name"]}_rvalid)
-  );
-
-  % elif m["type"] == "eflash":
-
-  // flash controller to eflash communication
-  flash_c2m_t flash_c2m;
-  flash_m2c_t flash_m2c;
-
-  // host to flash communication
-  logic flash_host_req;
-  logic flash_host_req_rdy;
-  logic flash_host_req_done;
-  logic [FLASH_DW-1:0] flash_host_rdata;
-  logic [FLASH_AW-1:0] flash_host_addr;
-
-  tlul_adapter_sram #(
-    .SramAw(FLASH_AW),
-    .SramDw(FLASH_DW),
-    .Outstanding(1),
-    .ByteAccess(0),
-    .ErrOnWrite(1)
-  ) tl_adapter_${m["name"]} (
-    .clk_i,
-    .rst_ni     (ndmreset_n),
-
-    .tl_i       (tl_${m["name"]}_d_h2d),
-    .tl_o       (tl_${m["name"]}_d_d2h),
-
-    .req_o    (flash_host_req),
-    .gnt_i    (flash_host_req_rdy),
-    .we_o     (),
-    .addr_o   (flash_host_addr),
-    .wdata_o  (),
-    .wmask_o  (),
-    .rdata_i  (flash_host_rdata),
-    .rvalid_i (flash_host_req_done),
-    .rerror_i (2'b00)
-  );
-
-  flash_phy #(
-    .NumBanks(FLASH_BANKS),
-    .PagesPerBank(FLASH_PAGES_PER_BANK),
-    .WordsPerPage(FLASH_WORDS_PER_PAGE),
-    .DataWidth(${data_width})
-  ) u_flash_${m["name"]} (
-    .clk_i,
-    .rst_ni,
-    .host_req_i      (flash_host_req),
-    .host_addr_i     (flash_host_addr),
-    .host_req_rdy_o  (flash_host_req_rdy),
-    .host_req_done_o (flash_host_req_done),
-    .host_rdata_o    (flash_host_rdata),
-    .flash_ctrl_i    (flash_c2m),
-    .flash_ctrl_o    (flash_m2c)
-  );
-
-  % else:
-    // flash memory is embedded within controller
-  % endif
-% endfor
-
-## Peripheral Instantiation
-% for m in top["module"]:
-  % if "parameter" in m:
-  ${m["type"]} #(
-    % for k, v in m["parameter"].items():
-        % if loop.last:
-    .${k}(${parameterize(v)})
-        % else:
-    .${k}(${parameterize(v)}),
-        % endif
-    % endfor
-  ) ${m["name"]} (
-  % else:
-  ${m["type"]} ${m["name"]} (
-  % endif
-    % if not "bus_host" in m or m["bus_host"] in ["none", ""]:
-          ## Assume TL-UL
-      .tl_i (tl_${m["name"]}_d_h2d),
-      .tl_o (tl_${m["name"]}_d_d2h),
-    % else:
-      .tl_d_i (tl_${m["name"]}_d_h2d),
-      .tl_d_o (tl_${m["name"]}_d_d2h),
-      .tl_h_o (tl_${m["name"]}_h_h2d),
-      .tl_h_i (tl_${m["name"]}_h_d2h),
-    % endif
-    ## CIO
-    ## TODO: Find a way to handle `scanmode`. It is not cio_ but top-level signal
+    // ${m["name"]}
     % for p_in in m["available_input_list"] + m["available_inout_list"]:
-        ## assume it passed validate and have available input list always
-      .cio_${p_in["name"]}_i (cio_${m["name"]}_${p_in["name"]}_p2d_i),
+          ## assume it passed validate and have available input list always
+    .cio_${m["name"]}_${p_in["name"]}_p2d_i (${m["name"]}_${p_in["name"]}_p2d),
     % endfor
-    % for p_in in m["available_output_list"] + m["available_inout_list"]:
-        ## assume it passed validate and have available output list always
-      .cio_${p_in["name"]}_o    (cio_${m["name"]}_${p_in["name"]}_d2p_o),
-      .cio_${p_in["name"]}_en_o (cio_${m["name"]}_${p_in["name"]}_en_d2p_o),
+    % for p_out in m["available_output_list"] + m["available_inout_list"]:
+          ## assume it passed validate and have available output list always
+    .cio_${m["name"]}_${p_out["name"]}_d2p_o    (${m["name"]}_${p_out["name"]}_d2p),
+    .cio_${m["name"]}_${p_out["name"]}_en_d2p_o (${m["name"]}_${p_out["name"]}_en_d2p),
     % endfor
-    % for intr in m["interrupt_list"] if "interrupt_list" in m else []:
-      .intr_${intr["name"]}_o (intr_${m["name"]}_${intr["name"]}),
-    % endfor
-    % if m["type"] == "flash_ctrl":
-      .flash_o(flash_c2m),
-      .flash_i(flash_m2c),
-    % endif
-    % if m["type"] == "rv_plic":
-      .intr_src_i (intr_vector),
-      .irq_o      (irq_plic),
-      .irq_id_o   (irq_id),
-      .msip_o     (msip),
-    % endif
-    % if m["scan"] == "true":
-      .scanmode_i   (scanmode_i),
-    % endif
-      .clk_i(${"clk_i" if m["clock"] == "main" else "clk_"+ m["clock"] + "_i"}),
-      .rst_ni(${"ndmreset_n" if m["clock"] == "main" else "rst_" + m["clock"] + "_ni"})
-  );
-
 % endfor
-  // interrupt assignments
-  assign intr_vector = {
-  % for intr in top["interrupt"][::-1]:
-    % if loop.last:
-      intr_${intr["name"]}
-    % else:
-      intr_${intr["name"]},
-    % endif
-  % endfor
-  };
 
-  // TL-UL Crossbar
-  logic clk_main;
-  logic ndmreset_sync_main_n;   // ndmreset synchronized to clk_main
-
-  assign clk_main = clk_i;
-  assign ndmreset_sync_main_n = ndmreset_n;
-
-% for xbar in top["xbar"]:
-<%
-  name_len = max([len(x["name"]) for x in xbar["nodes"]]);
-%>\
-  xbar_${xbar["name"]} u_xbar_${xbar["name"]} (
-  % for clock in xbar["clocks"]:
-    ## TODO: How we can handle the reset?
-    .clk_${clock}_i  (clk_${clock}),
-    .rst_${clock}_ni (ndmreset_sync_${clock}_n),
-  % endfor
-
-  % for node in xbar["nodes"]:
-    % if node["type"] == "device":
-    .tl_${(node["name"]+"_o").ljust(name_len+2)} (tl_${node["name"]}_d_h2d),
-    .tl_${(node["name"]+"_i").ljust(name_len+2)} (tl_${node["name"]}_d_d2h),
-    % elif node["type"] == "host":
-    .tl_${(node["name"]+"_i").ljust(name_len+2)} (tl_${node["name"]}_h_h2d),
-    .tl_${(node["name"]+"_o").ljust(name_len+2)} (tl_${node["name"]}_h_d2h),
-    % endif
-  % endfor
-
-    .scanmode_i
-% endfor
+    .scanmode_i()
   );
-
-  // make sure scanmode_i is never X (including during reset)
-  `ASSERT_KNOWN(scanmodeKnown, scanmode_i, clk_i, 0)
 
 endmodule
-<%def name="parameterize(v)">\
-    ## value type
-    ## if it is integer, or bit'{h|d|b} digit, just put without quote
-    ## else return with quote
-    % if re.match('(\d+\'[hdb]\s*[0-9a-f_A-F]+|[0-9]+)',v) == None:
-"${v}"\
-    % else:
-${v}\
-    % endif
-</%def>\
+

--- a/hw/top_earlgrey/doc/top_earlgrey_core.tpl.sv
+++ b/hw/top_earlgrey/doc/top_earlgrey_core.tpl.sv
@@ -1,0 +1,457 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+<%
+import re
+%>\
+module top_${top["name"]}_core #(
+  parameter bit IbexPipeLine = 0
+) (
+  // Clock and Reset
+  input               clk_i,
+  input               rst_ni,
+
+  // JTAG interface
+  input               jtag_tck_i,
+  input               jtag_tms_i,
+  input               jtag_trst_ni,
+  input               jtag_td_i,
+  output              jtag_td_o,
+
+% for m in top["module"]:
+  // ${m["name"]}
+%     for p_in in m["available_input_list"] + m["available_inout_list"]:
+          ## assume it passed validate and have available input list always
+%         if "width" in p_in and int(p_in["width"]) != 1:
+  input  [${int(p_in["width"])-1}:0] cio_${m["name"]}_${p_in["name"]}_p2d_i,
+%         else:
+  input  cio_${m["name"]}_${p_in["name"]}_p2d_i,
+%         endif
+%     endfor
+%     for p_out in m["available_output_list"] + m["available_inout_list"]:
+          ## assume it passed validate and have available output list always
+%         if "width" in p_out and int(p_out["width"]) != 1:
+  output [${int(p_out["width"])-1}:0] cio_${m["name"]}_${p_out["name"]}_d2p_o,
+  output [${int(p_out["width"])-1}:0] cio_${m["name"]}_${p_out["name"]}_en_d2p_o,
+%         else:
+  output cio_${m["name"]}_${p_out["name"]}_d2p_o,
+  output cio_${m["name"]}_${p_out["name"]}_en_d2p_o,
+%         endif
+%     endfor
+% endfor
+
+  input               scanmode_i  // 1 for Scan
+);
+
+  import tlul_pkg::*;
+  import top_pkg::*;
+  import tl_main_pkg::*;
+  import flash_ctrl_pkg::*;
+
+  tl_h2d_t  tl_corei_h_h2d;
+  tl_d2h_t  tl_corei_h_d2h;
+
+  tl_h2d_t  tl_cored_h_h2d;
+  tl_d2h_t  tl_cored_h_d2h;
+
+  tl_h2d_t  tl_dm_sba_h_h2d;
+  tl_d2h_t  tl_dm_sba_h_d2h;
+
+  tl_h2d_t  tl_debug_mem_d_h2d;
+  tl_d2h_t  tl_debug_mem_d_d2h;
+
+## TL-UL device port declaration
+% for m in top["module"]:
+%     if not m["bus_device"] in ["none", ""]:
+  tl_h2d_t  tl_${m["name"]}_d_h2d;
+  tl_d2h_t  tl_${m["name"]}_d_d2h;
+%     endif
+%     if not m["bus_host"] in ["none", ""]:
+  tl_h2d_t  tl_${m["name"]}_h_h2d;
+  tl_d2h_t  tl_${m["name"]}_h_d2h;
+%     endif
+% endfor
+
+% for m in top["memory"]:
+  tl_h2d_t tl_${m["name"]}_d_h2d;
+  tl_d2h_t tl_${m["name"]}_d_d2h;
+% endfor
+<%
+  interrupt_num = sum([x["width"] if "width" in x else 1 for x in top["interrupt"]])
+%>\
+  logic [${interrupt_num-1}:0]  intr_vector;
+  // Interrupt source list
+% for m in top["module"]:
+    % for intr in m["interrupt_list"] if "interrupt_list" in m else []:
+        % if "width" in intr and int(intr["width"]) != 1:
+  logic [${int(intr["width"])-1}:0] intr_${m["name"]}_${intr["name"]};
+        % else:
+  logic intr_${m["name"]}_${intr["name"]};
+        % endif
+    % endfor
+% endfor
+
+
+  logic [0:0]   irq_plic;
+  logic [${(interrupt_num).bit_length()-1}:0] irq_id[1];
+  logic [0:0]   msip;
+
+  // Non-debug module reset == reset for everything except for the debug module
+  // and the logic required to access it.
+  logic ndmreset_n;
+  logic ndmreset_from_dm;
+  assign ndmreset_n = (scanmode_i) ? rst_ni : ~ndmreset_from_dm & rst_ni;
+
+  logic debug_req;
+
+  // processor core
+  rv_core_ibex #(
+    .MHPMCounterNum      (8),
+    .MHPMCounterWidth    (40),
+    .RV32E               (0),
+    .RV32M               (1),
+    .DmHaltAddr          (ADDR_SPACE_DEBUG_MEM + dm::HaltAddress),
+    .DmExceptionAddr     (ADDR_SPACE_DEBUG_MEM + dm::ExceptionAddress),
+    .PipeLine            (IbexPipeLine)
+  ) core (
+    // clock and reset
+    .clk_i                (clk_i),
+    .rst_ni               (ndmreset_n),
+    .test_en_i            (1'b0),
+    // static pinning
+    .hart_id_i            (32'b0),
+    .boot_addr_i          (ADDR_SPACE_ROM),
+    // TL-UL buses
+    .tl_i_o               (tl_corei_h_h2d),
+    .tl_i_i               (tl_corei_h_d2h),
+    .tl_d_o               (tl_cored_h_h2d),
+    .tl_d_i               (tl_cored_h_d2h),
+    // interrupts
+    .irq_software_i       (msip),
+    .irq_timer_i          (intr_rv_timer_timer_expired_0_0),
+    .irq_external_i       (irq_plic),
+    .irq_fast_i           (15'b0),// PLIC handles all peripheral interrupts
+    .irq_nm_i             (1'b0),// TODO - add and connect alert responder
+    // debug interface
+    .debug_req_i          (debug_req),
+    // CPU control signals
+    .fetch_enable_i       (1'b1),
+    .core_sleep_o         ()
+  );
+
+  // Debug Module (RISC-V Debug Spec 0.13)
+  //
+
+  rv_dm #(
+    .NrHarts     (  1),
+    .IdcodeValue (32'h00000001) // Temporary value
+                                // xxxx             version
+                                // xxxxxxxxxxxxxxxx part number
+                                // xxxxxxxxxxx      manufacturer id
+                                // 1                required by standard
+  ) u_dm_top (
+    .clk_i         (clk_i),
+    .rst_ni        (rst_ni),
+    .testmode_i    (1'b0),
+    .ndmreset_o    (ndmreset_from_dm),
+    .dmactive_o    (),
+    .debug_req_o   (debug_req),
+    .unavailable_i (1'b0),
+
+    // bus device with debug memory (for execution-based debug)
+    .tl_d_i        (tl_debug_mem_d_h2d),
+    .tl_d_o        (tl_debug_mem_d_d2h),
+
+    // bus host (for system bus accesses, SBA)
+    .tl_h_o        (tl_dm_sba_h_h2d),
+    .tl_h_i        (tl_dm_sba_h_d2h),
+
+    //JTAG
+    .tck_i            (jtag_tck_i),
+    .tms_i            (jtag_tms_i),
+    .trst_ni          (jtag_trst_ni),
+    .td_i             (jtag_td_i),
+    .td_o             (jtag_td_o),
+    .tdo_oe_o         (       )
+  );
+
+## Memory Instantiation
+% for m in top["memory"]:
+  % if m["type"] == "ram_1p":
+<%
+     data_width = int(top["datawidth"])
+     dw_byte = data_width // 8
+     addr_width = ((int(m["size"], 0) // dw_byte) -1).bit_length()
+     sram_depth = (int(m["size"], 0) // dw_byte)
+%>\
+  // sram device
+  logic        ${m["name"]}_req;
+  logic        ${m["name"]}_we;
+  logic [${addr_width-1}:0] ${m["name"]}_addr;
+  logic [${data_width-1}:0] ${m["name"]}_wdata;
+  logic [${data_width-1}:0] ${m["name"]}_wmask;
+  logic [${data_width-1}:0] ${m["name"]}_rdata;
+  logic        ${m["name"]}_rvalid;
+
+  tlul_adapter_sram #(
+    .SramAw(${addr_width}),
+    .SramDw(${data_width}),
+    .Outstanding(1)
+  ) tl_adapter_${m["name"]} (
+    .clk_i,
+    .rst_ni   (ndmreset_n),
+
+    .tl_i     (tl_${m["name"]}_d_h2d),
+    .tl_o     (tl_${m["name"]}_d_d2h),
+
+    .req_o    (${m["name"]}_req),
+    .gnt_i    (1'b1), // Always grant as only one requester exists
+    .we_o     (${m["name"]}_we),
+    .addr_o   (${m["name"]}_addr),
+    .wdata_o  (${m["name"]}_wdata),
+    .wmask_o  (${m["name"]}_wmask),
+    .rdata_i  (${m["name"]}_rdata),
+    .rvalid_i (${m["name"]}_rvalid),
+    .rerror_i (2'b00)
+  );
+
+  ## TODO: Instantiate ram_1p model using RAMGEN (currently not available)
+  prim_ram_1p #(
+    .Width(${data_width}),
+    .Depth(${sram_depth}),
+    .DataBitsPerMask(${int(data_width/4)})
+  ) u_ram1p_${m["name"]} (
+    .clk_i,
+    .rst_ni   (ndmreset_n),
+
+    .req_i    (${m["name"]}_req),
+    .write_i  (${m["name"]}_we),
+    .addr_i   (${m["name"]}_addr),
+    .wdata_i  (${m["name"]}_wdata),
+    .wmask_i  (${m["name"]}_wmask),
+    .rvalid_o (${m["name"]}_rvalid),
+    .rdata_o  (${m["name"]}_rdata)
+  );
+  % elif m["type"] == "rom":
+<%
+     data_width = int(top["datawidth"])
+     dw_byte = data_width // 8
+     addr_width = ((int(m["size"], 0) // dw_byte) -1).bit_length()
+     rom_depth = (int(m["size"], 0) // dw_byte)
+%>\
+  // ROM device
+  logic        ${m["name"]}_req;
+  logic [${addr_width-1}:0] ${m["name"]}_addr;
+  logic [${data_width-1}:0] ${m["name"]}_rdata;
+  logic        ${m["name"]}_rvalid;
+
+  tlul_adapter_sram #(
+    .SramAw(${addr_width}),
+    .SramDw(${data_width}),
+    .Outstanding(1),
+    .ErrOnWrite(1)
+  ) tl_adapter_${m["name"]} (
+    .clk_i,
+    .rst_ni   (ndmreset_n),
+
+    .tl_i     (tl_${m["name"]}_d_h2d),
+    .tl_o     (tl_${m["name"]}_d_d2h),
+
+    .req_o    (${m["name"]}_req),
+    .gnt_i    (1'b1), // Always grant as only one requester exists
+    .we_o     (),
+    .addr_o   (${m["name"]}_addr),
+    .wdata_o  (),
+    .wmask_o  (),
+    .rdata_i  (${m["name"]}_rdata),
+    .rvalid_i (${m["name"]}_rvalid),
+    .rerror_i (2'b00)
+  );
+
+  ## TODO: Replace emulated ROM to real ROM in ASIC SoC
+  prim_rom #(
+    .Width(${data_width}),
+    .Depth(${rom_depth})
+  ) u_rom_${m["name"]} (
+    .clk_i,
+    .rst_ni   (ndmreset_n),
+    .cs_i     (${m["name"]}_req),
+    .addr_i   (${m["name"]}_addr),
+    .dout_o   (${m["name"]}_rdata),
+    .dvalid_o (${m["name"]}_rvalid)
+  );
+
+  % elif m["type"] == "eflash":
+
+  // flash controller to eflash communication
+  flash_c2m_t flash_c2m;
+  flash_m2c_t flash_m2c;
+
+  // host to flash communication
+  logic flash_host_req;
+  logic flash_host_req_rdy;
+  logic flash_host_req_done;
+  logic [FLASH_DW-1:0] flash_host_rdata;
+  logic [FLASH_AW-1:0] flash_host_addr;
+
+  tlul_adapter_sram #(
+    .SramAw(FLASH_AW),
+    .SramDw(FLASH_DW),
+    .Outstanding(1),
+    .ByteAccess(0),
+    .ErrOnWrite(1)
+  ) tl_adapter_${m["name"]} (
+    .clk_i,
+    .rst_ni     (ndmreset_n),
+
+    .tl_i       (tl_${m["name"]}_d_h2d),
+    .tl_o       (tl_${m["name"]}_d_d2h),
+
+    .req_o    (flash_host_req),
+    .gnt_i    (flash_host_req_rdy),
+    .we_o     (),
+    .addr_o   (flash_host_addr),
+    .wdata_o  (),
+    .wmask_o  (),
+    .rdata_i  (flash_host_rdata),
+    .rvalid_i (flash_host_req_done),
+    .rerror_i (2'b00)
+  );
+
+  flash_phy #(
+    .NumBanks(FLASH_BANKS),
+    .PagesPerBank(FLASH_PAGES_PER_BANK),
+    .WordsPerPage(FLASH_WORDS_PER_PAGE),
+    .DataWidth(${data_width})
+  ) u_flash_${m["name"]} (
+    .clk_i,
+    .rst_ni,
+    .host_req_i      (flash_host_req),
+    .host_addr_i     (flash_host_addr),
+    .host_req_rdy_o  (flash_host_req_rdy),
+    .host_req_done_o (flash_host_req_done),
+    .host_rdata_o    (flash_host_rdata),
+    .flash_ctrl_i    (flash_c2m),
+    .flash_ctrl_o    (flash_m2c)
+  );
+
+  % else:
+    // flash memory is embedded within controller
+  % endif
+% endfor
+
+## Peripheral Instantiation
+% for m in top["module"]:
+  % if "parameter" in m:
+  ${m["type"]} #(
+    % for k, v in m["parameter"].items():
+        % if loop.last:
+    .${k}(${parameterize(v)})
+        % else:
+    .${k}(${parameterize(v)}),
+        % endif
+    % endfor
+  ) ${m["name"]} (
+  % else:
+  ${m["type"]} ${m["name"]} (
+  % endif
+    % if not "bus_host" in m or m["bus_host"] in ["none", ""]:
+          ## Assume TL-UL
+      .tl_i (tl_${m["name"]}_d_h2d),
+      .tl_o (tl_${m["name"]}_d_d2h),
+    % else:
+      .tl_d_i (tl_${m["name"]}_d_h2d),
+      .tl_d_o (tl_${m["name"]}_d_d2h),
+      .tl_h_o (tl_${m["name"]}_h_h2d),
+      .tl_h_i (tl_${m["name"]}_h_d2h),
+    % endif
+    ## CIO
+    ## TODO: Find a way to handle `scanmode`. It is not cio_ but top-level signal
+    % for p_in in m["available_input_list"] + m["available_inout_list"]:
+        ## assume it passed validate and have available input list always
+      .cio_${p_in["name"]}_i (cio_${m["name"]}_${p_in["name"]}_p2d_i),
+    % endfor
+    % for p_in in m["available_output_list"] + m["available_inout_list"]:
+        ## assume it passed validate and have available output list always
+      .cio_${p_in["name"]}_o    (cio_${m["name"]}_${p_in["name"]}_d2p_o),
+      .cio_${p_in["name"]}_en_o (cio_${m["name"]}_${p_in["name"]}_en_d2p_o),
+    % endfor
+    % for intr in m["interrupt_list"] if "interrupt_list" in m else []:
+      .intr_${intr["name"]}_o (intr_${m["name"]}_${intr["name"]}),
+    % endfor
+    % if m["type"] == "flash_ctrl":
+      .flash_o(flash_c2m),
+      .flash_i(flash_m2c),
+    % endif
+    % if m["type"] == "rv_plic":
+      .intr_src_i (intr_vector),
+      .irq_o      (irq_plic),
+      .irq_id_o   (irq_id),
+      .msip_o     (msip),
+    % endif
+    % if m["scan"] == "true":
+      .scanmode_i   (scanmode_i),
+    % endif
+      .clk_i(${"clk_i" if m["clock"] == "main" else "clk_"+ m["clock"] + "_i"}),
+      .rst_ni(${"ndmreset_n" if m["clock"] == "main" else "rst_" + m["clock"] + "_ni"})
+  );
+
+% endfor
+  // interrupt assignments
+  assign intr_vector = {
+  % for intr in top["interrupt"][::-1]:
+    % if loop.last:
+      intr_${intr["name"]}
+    % else:
+      intr_${intr["name"]},
+    % endif
+  % endfor
+  };
+
+  // TL-UL Crossbar
+  logic clk_main;
+  logic ndmreset_sync_main_n;   // ndmreset synchronized to clk_main
+
+  assign clk_main = clk_i;
+  assign ndmreset_sync_main_n = ndmreset_n;
+
+% for xbar in top["xbar"]:
+<%
+  name_len = max([len(x["name"]) for x in xbar["nodes"]]);
+%>\
+  xbar_${xbar["name"]} u_xbar_${xbar["name"]} (
+  % for clock in xbar["clocks"]:
+    ## TODO: How we can handle the reset?
+    .clk_${clock}_i  (clk_${clock}),
+    .rst_${clock}_ni (ndmreset_sync_${clock}_n),
+  % endfor
+
+  % for node in xbar["nodes"]:
+    % if node["type"] == "device":
+    .tl_${(node["name"]+"_o").ljust(name_len+2)} (tl_${node["name"]}_d_h2d),
+    .tl_${(node["name"]+"_i").ljust(name_len+2)} (tl_${node["name"]}_d_d2h),
+    % elif node["type"] == "host":
+    .tl_${(node["name"]+"_i").ljust(name_len+2)} (tl_${node["name"]}_h_h2d),
+    .tl_${(node["name"]+"_o").ljust(name_len+2)} (tl_${node["name"]}_h_d2h),
+    % endif
+  % endfor
+
+    .scanmode_i
+% endfor
+  );
+
+  // make sure scanmode_i is never X (including during reset)
+  `ASSERT_KNOWN(scanmodeKnown, scanmode_i, clk_i, 0)
+
+endmodule
+<%def name="parameterize(v)">\
+    ## value type
+    ## if it is integer, or bit'{h|d|b} digit, just put without quote
+    ## else return with quote
+    % if re.match('(\d+\'[hdb]\s*[0-9a-f_A-F]+|[0-9]+)',v) == None:
+"${v}"\
+    % else:
+${v}\
+    % endif
+</%def>\

--- a/hw/top_earlgrey/rtl/top_earlgrey.f
+++ b/hw/top_earlgrey/rtl/top_earlgrey.f
@@ -1,3 +1,4 @@
 ../rtl/tl_main_pkg.sv
 ../rtl/tlul_xbar.sv
+../rtl/top_earlgrey_core.sv
 ../rtl/top_earlgrey.sv

--- a/hw/top_earlgrey/rtl/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey.sv
@@ -5,494 +5,64 @@
 module top_earlgrey #(
   parameter bit IbexPipeLine = 0
 ) (
-  // Clock and Reset
-  input               clk_i,
-  input               rst_ni,
-
-  // JTAG interface
-  input               jtag_tck_i,
-  input               jtag_tms_i,
-  input               jtag_trst_ni,
-  input               jtag_td_i,
-  output              jtag_td_o,
-
+);
   // uart
-  input  cio_uart_rx_p2d_i,
-  output cio_uart_tx_d2p_o,
-  output cio_uart_tx_en_d2p_o,
+  logic uart_rx_p2d;
+  logic uart_tx_d2p;
+  logic uart_tx_en_d2p;
   // gpio
-  input  [31:0] cio_gpio_gpio_p2d_i,
-  output [31:0] cio_gpio_gpio_d2p_o,
-  output [31:0] cio_gpio_gpio_en_d2p_o,
+  logic [31:0] gpio_gpio_p2d;
+  logic [31:0] gpio_gpio_d2p;
+  logic [31:0] gpio_gpio_en_d2p;
   // spi_device
-  input  cio_spi_device_sck_p2d_i,
-  input  cio_spi_device_csb_p2d_i,
-  input  cio_spi_device_mosi_p2d_i,
-  output cio_spi_device_miso_d2p_o,
-  output cio_spi_device_miso_en_d2p_o,
+  logic spi_device_sck_p2d;
+  logic spi_device_csb_p2d;
+  logic spi_device_mosi_p2d;
+  logic spi_device_miso_d2p;
+  logic spi_device_miso_en_d2p;
   // flash_ctrl
   // rv_timer
   // hmac
   // rv_plic
 
   input               scanmode_i  // 1 for Scan
-);
 
-  import tlul_pkg::*;
-  import top_pkg::*;
-  import tl_main_pkg::*;
-  import flash_ctrl_pkg::*;
+  // Top instantiation
+  top_earlgrey_core #(
+    .IbexPipeLine (IbexPipeLine)
+  ) u_core (
+    .clk_i          (           ),
+    .rst_ni         (           ),
 
-  tl_h2d_t  tl_corei_h_h2d;
-  tl_d2h_t  tl_corei_h_d2h;
+    // JTAG
+    .jtag_tck_i     (           ),
+    .jtag_tms_i     (           ),
+    .jtag_trst_ni   (           ),
+    .jtag_td_i      (           ),
+    .jtag_td_o      (           ),
 
-  tl_h2d_t  tl_cored_h_h2d;
-  tl_d2h_t  tl_cored_h_d2h;
+    // Module CIO
+    // uart
+    .cio_uart_rx_p2d_i (uart_rx_p2d),
+    .cio_uart_tx_d2p_o    (uart_tx_d2p),
+    .cio_uart_tx_en_d2p_o (uart_tx_en_d2p),
+    // gpio
+    .cio_gpio_gpio_p2d_i (gpio_gpio_p2d),
+    .cio_gpio_gpio_d2p_o    (gpio_gpio_d2p),
+    .cio_gpio_gpio_en_d2p_o (gpio_gpio_en_d2p),
+    // spi_device
+    .cio_spi_device_sck_p2d_i (spi_device_sck_p2d),
+    .cio_spi_device_csb_p2d_i (spi_device_csb_p2d),
+    .cio_spi_device_mosi_p2d_i (spi_device_mosi_p2d),
+    .cio_spi_device_miso_d2p_o    (spi_device_miso_d2p),
+    .cio_spi_device_miso_en_d2p_o (spi_device_miso_en_d2p),
+    // flash_ctrl
+    // rv_timer
+    // hmac
+    // rv_plic
 
-  tl_h2d_t  tl_dm_sba_h_h2d;
-  tl_d2h_t  tl_dm_sba_h_d2h;
-
-  tl_h2d_t  tl_debug_mem_d_h2d;
-  tl_d2h_t  tl_debug_mem_d_d2h;
-
-  tl_h2d_t  tl_uart_d_h2d;
-  tl_d2h_t  tl_uart_d_d2h;
-  tl_h2d_t  tl_gpio_d_h2d;
-  tl_d2h_t  tl_gpio_d_d2h;
-  tl_h2d_t  tl_spi_device_d_h2d;
-  tl_d2h_t  tl_spi_device_d_d2h;
-  tl_h2d_t  tl_flash_ctrl_d_h2d;
-  tl_d2h_t  tl_flash_ctrl_d_d2h;
-  tl_h2d_t  tl_rv_timer_d_h2d;
-  tl_d2h_t  tl_rv_timer_d_d2h;
-  tl_h2d_t  tl_hmac_d_h2d;
-  tl_d2h_t  tl_hmac_d_d2h;
-  tl_h2d_t  tl_rv_plic_d_h2d;
-  tl_d2h_t  tl_rv_plic_d_d2h;
-
-  tl_h2d_t tl_rom_d_h2d;
-  tl_d2h_t tl_rom_d_d2h;
-  tl_h2d_t tl_ram_main_d_h2d;
-  tl_d2h_t tl_ram_main_d_d2h;
-  tl_h2d_t tl_eflash_d_h2d;
-  tl_d2h_t tl_eflash_d_d2h;
-  logic [53:0]  intr_vector;
-  // Interrupt source list
-  logic intr_uart_tx_watermark;
-  logic intr_uart_rx_watermark;
-  logic intr_uart_tx_overflow;
-  logic intr_uart_rx_overflow;
-  logic intr_uart_rx_frame_err;
-  logic intr_uart_rx_break_err;
-  logic intr_uart_rx_timeout;
-  logic intr_uart_rx_parity_err;
-  logic [31:0] intr_gpio_gpio;
-  logic intr_spi_device_rxf;
-  logic intr_spi_device_rxlvl;
-  logic intr_spi_device_txlvl;
-  logic intr_spi_device_rxerr;
-  logic intr_spi_device_rxoverflow;
-  logic intr_spi_device_txunderflow;
-  logic intr_flash_ctrl_prog_empty;
-  logic intr_flash_ctrl_prog_lvl;
-  logic intr_flash_ctrl_rd_full;
-  logic intr_flash_ctrl_rd_lvl;
-  logic intr_flash_ctrl_op_done;
-  logic intr_flash_ctrl_op_error;
-  logic intr_rv_timer_timer_expired_0_0;
-  logic intr_hmac_hmac_done;
-  logic intr_hmac_fifo_full;
-
-
-  logic [0:0]   irq_plic;
-  logic [5:0] irq_id[1];
-  logic [0:0]   msip;
-
-  // Non-debug module reset == reset for everything except for the debug module
-  // and the logic required to access it.
-  logic ndmreset_n;
-  logic ndmreset_from_dm;
-  assign ndmreset_n = (scanmode_i) ? rst_ni : ~ndmreset_from_dm & rst_ni;
-
-  logic debug_req;
-
-  // processor core
-  rv_core_ibex #(
-    .MHPMCounterNum      (8),
-    .MHPMCounterWidth    (40),
-    .RV32E               (0),
-    .RV32M               (1),
-    .DmHaltAddr          (ADDR_SPACE_DEBUG_MEM + dm::HaltAddress),
-    .DmExceptionAddr     (ADDR_SPACE_DEBUG_MEM + dm::ExceptionAddress),
-    .PipeLine            (IbexPipeLine)
-  ) core (
-    // clock and reset
-    .clk_i                (clk_i),
-    .rst_ni               (ndmreset_n),
-    .test_en_i            (1'b0),
-    // static pinning
-    .hart_id_i            (32'b0),
-    .boot_addr_i          (ADDR_SPACE_ROM),
-    // TL-UL buses
-    .tl_i_o               (tl_corei_h_h2d),
-    .tl_i_i               (tl_corei_h_d2h),
-    .tl_d_o               (tl_cored_h_h2d),
-    .tl_d_i               (tl_cored_h_d2h),
-    // interrupts
-    .irq_software_i       (msip),
-    .irq_timer_i          (intr_rv_timer_timer_expired_0_0),
-    .irq_external_i       (irq_plic),
-    .irq_fast_i           (15'b0),// PLIC handles all peripheral interrupts
-    .irq_nm_i             (1'b0),// TODO - add and connect alert responder
-    // debug interface
-    .debug_req_i          (debug_req),
-    // CPU control signals
-    .fetch_enable_i       (1'b1),
-    .core_sleep_o         ()
+    .scanmode_i()
   );
-
-  // Debug Module (RISC-V Debug Spec 0.13)
-  //
-
-  rv_dm #(
-    .NrHarts     (  1),
-    .IdcodeValue (32'h00000001) // Temporary value
-                                // xxxx             version
-                                // xxxxxxxxxxxxxxxx part number
-                                // xxxxxxxxxxx      manufacturer id
-                                // 1                required by standard
-  ) u_dm_top (
-    .clk_i         (clk_i),
-    .rst_ni        (rst_ni),
-    .testmode_i    (1'b0),
-    .ndmreset_o    (ndmreset_from_dm),
-    .dmactive_o    (),
-    .debug_req_o   (debug_req),
-    .unavailable_i (1'b0),
-
-    // bus device with debug memory (for execution-based debug)
-    .tl_d_i        (tl_debug_mem_d_h2d),
-    .tl_d_o        (tl_debug_mem_d_d2h),
-
-    // bus host (for system bus accesses, SBA)
-    .tl_h_o        (tl_dm_sba_h_h2d),
-    .tl_h_i        (tl_dm_sba_h_d2h),
-
-    //JTAG
-    .tck_i            (jtag_tck_i),
-    .tms_i            (jtag_tms_i),
-    .trst_ni          (jtag_trst_ni),
-    .td_i             (jtag_td_i),
-    .td_o             (jtag_td_o),
-    .tdo_oe_o         (       )
-  );
-
-  // ROM device
-  logic        rom_req;
-  logic [10:0] rom_addr;
-  logic [31:0] rom_rdata;
-  logic        rom_rvalid;
-
-  tlul_adapter_sram #(
-    .SramAw(11),
-    .SramDw(32),
-    .Outstanding(1),
-    .ErrOnWrite(1)
-  ) tl_adapter_rom (
-    .clk_i,
-    .rst_ni   (ndmreset_n),
-
-    .tl_i     (tl_rom_d_h2d),
-    .tl_o     (tl_rom_d_d2h),
-
-    .req_o    (rom_req),
-    .gnt_i    (1'b1), // Always grant as only one requester exists
-    .we_o     (),
-    .addr_o   (rom_addr),
-    .wdata_o  (),
-    .wmask_o  (),
-    .rdata_i  (rom_rdata),
-    .rvalid_i (rom_rvalid),
-    .rerror_i (2'b00)
-  );
-
-  prim_rom #(
-    .Width(32),
-    .Depth(2048)
-  ) u_rom_rom (
-    .clk_i,
-    .rst_ni   (ndmreset_n),
-    .cs_i     (rom_req),
-    .addr_i   (rom_addr),
-    .dout_o   (rom_rdata),
-    .dvalid_o (rom_rvalid)
-  );
-
-  // sram device
-  logic        ram_main_req;
-  logic        ram_main_we;
-  logic [13:0] ram_main_addr;
-  logic [31:0] ram_main_wdata;
-  logic [31:0] ram_main_wmask;
-  logic [31:0] ram_main_rdata;
-  logic        ram_main_rvalid;
-
-  tlul_adapter_sram #(
-    .SramAw(14),
-    .SramDw(32),
-    .Outstanding(1)
-  ) tl_adapter_ram_main (
-    .clk_i,
-    .rst_ni   (ndmreset_n),
-
-    .tl_i     (tl_ram_main_d_h2d),
-    .tl_o     (tl_ram_main_d_d2h),
-
-    .req_o    (ram_main_req),
-    .gnt_i    (1'b1), // Always grant as only one requester exists
-    .we_o     (ram_main_we),
-    .addr_o   (ram_main_addr),
-    .wdata_o  (ram_main_wdata),
-    .wmask_o  (ram_main_wmask),
-    .rdata_i  (ram_main_rdata),
-    .rvalid_i (ram_main_rvalid),
-    .rerror_i (2'b00)
-  );
-
-  prim_ram_1p #(
-    .Width(32),
-    .Depth(16384),
-    .DataBitsPerMask(8)
-  ) u_ram1p_ram_main (
-    .clk_i,
-    .rst_ni   (ndmreset_n),
-
-    .req_i    (ram_main_req),
-    .write_i  (ram_main_we),
-    .addr_i   (ram_main_addr),
-    .wdata_i  (ram_main_wdata),
-    .wmask_i  (ram_main_wmask),
-    .rvalid_o (ram_main_rvalid),
-    .rdata_o  (ram_main_rdata)
-  );
-
-  // flash controller to eflash communication
-  flash_c2m_t flash_c2m;
-  flash_m2c_t flash_m2c;
-
-  // host to flash communication
-  logic flash_host_req;
-  logic flash_host_req_rdy;
-  logic flash_host_req_done;
-  logic [FLASH_DW-1:0] flash_host_rdata;
-  logic [FLASH_AW-1:0] flash_host_addr;
-
-  tlul_adapter_sram #(
-    .SramAw(FLASH_AW),
-    .SramDw(FLASH_DW),
-    .Outstanding(1),
-    .ByteAccess(0),
-    .ErrOnWrite(1)
-  ) tl_adapter_eflash (
-    .clk_i,
-    .rst_ni     (ndmreset_n),
-
-    .tl_i       (tl_eflash_d_h2d),
-    .tl_o       (tl_eflash_d_d2h),
-
-    .req_o    (flash_host_req),
-    .gnt_i    (flash_host_req_rdy),
-    .we_o     (),
-    .addr_o   (flash_host_addr),
-    .wdata_o  (),
-    .wmask_o  (),
-    .rdata_i  (flash_host_rdata),
-    .rvalid_i (flash_host_req_done),
-    .rerror_i (2'b00)
-  );
-
-  flash_phy #(
-    .NumBanks(FLASH_BANKS),
-    .PagesPerBank(FLASH_PAGES_PER_BANK),
-    .WordsPerPage(FLASH_WORDS_PER_PAGE),
-    .DataWidth(32)
-  ) u_flash_eflash (
-    .clk_i,
-    .rst_ni,
-    .host_req_i      (flash_host_req),
-    .host_addr_i     (flash_host_addr),
-    .host_req_rdy_o  (flash_host_req_rdy),
-    .host_req_done_o (flash_host_req_done),
-    .host_rdata_o    (flash_host_rdata),
-    .flash_ctrl_i    (flash_c2m),
-    .flash_ctrl_o    (flash_m2c)
-  );
-
-
-  uart uart (
-      .tl_i (tl_uart_d_h2d),
-      .tl_o (tl_uart_d_d2h),
-      .cio_rx_i (cio_uart_rx_p2d_i),
-      .cio_tx_o    (cio_uart_tx_d2p_o),
-      .cio_tx_en_o (cio_uart_tx_en_d2p_o),
-      .intr_tx_watermark_o (intr_uart_tx_watermark),
-      .intr_rx_watermark_o (intr_uart_rx_watermark),
-      .intr_tx_overflow_o (intr_uart_tx_overflow),
-      .intr_rx_overflow_o (intr_uart_rx_overflow),
-      .intr_rx_frame_err_o (intr_uart_rx_frame_err),
-      .intr_rx_break_err_o (intr_uart_rx_break_err),
-      .intr_rx_timeout_o (intr_uart_rx_timeout),
-      .intr_rx_parity_err_o (intr_uart_rx_parity_err),
-      .clk_i(clk_i),
-      .rst_ni(ndmreset_n)
-  );
-
-  gpio gpio (
-      .tl_i (tl_gpio_d_h2d),
-      .tl_o (tl_gpio_d_d2h),
-      .cio_gpio_i (cio_gpio_gpio_p2d_i),
-      .cio_gpio_o    (cio_gpio_gpio_d2p_o),
-      .cio_gpio_en_o (cio_gpio_gpio_en_d2p_o),
-      .intr_gpio_o (intr_gpio_gpio),
-      .clk_i(clk_i),
-      .rst_ni(ndmreset_n)
-  );
-
-  spi_device spi_device (
-      .tl_i (tl_spi_device_d_h2d),
-      .tl_o (tl_spi_device_d_d2h),
-      .cio_sck_i (cio_spi_device_sck_p2d_i),
-      .cio_csb_i (cio_spi_device_csb_p2d_i),
-      .cio_mosi_i (cio_spi_device_mosi_p2d_i),
-      .cio_miso_o    (cio_spi_device_miso_d2p_o),
-      .cio_miso_en_o (cio_spi_device_miso_en_d2p_o),
-      .intr_rxf_o (intr_spi_device_rxf),
-      .intr_rxlvl_o (intr_spi_device_rxlvl),
-      .intr_txlvl_o (intr_spi_device_txlvl),
-      .intr_rxerr_o (intr_spi_device_rxerr),
-      .intr_rxoverflow_o (intr_spi_device_rxoverflow),
-      .intr_txunderflow_o (intr_spi_device_txunderflow),
-      .scanmode_i   (scanmode_i),
-      .clk_i(clk_i),
-      .rst_ni(ndmreset_n)
-  );
-
-  flash_ctrl flash_ctrl (
-      .tl_i (tl_flash_ctrl_d_h2d),
-      .tl_o (tl_flash_ctrl_d_d2h),
-      .intr_prog_empty_o (intr_flash_ctrl_prog_empty),
-      .intr_prog_lvl_o (intr_flash_ctrl_prog_lvl),
-      .intr_rd_full_o (intr_flash_ctrl_rd_full),
-      .intr_rd_lvl_o (intr_flash_ctrl_rd_lvl),
-      .intr_op_done_o (intr_flash_ctrl_op_done),
-      .intr_op_error_o (intr_flash_ctrl_op_error),
-      .flash_o(flash_c2m),
-      .flash_i(flash_m2c),
-      .clk_i(clk_i),
-      .rst_ni(ndmreset_n)
-  );
-
-  rv_timer rv_timer (
-      .tl_i (tl_rv_timer_d_h2d),
-      .tl_o (tl_rv_timer_d_d2h),
-      .intr_timer_expired_0_0_o (intr_rv_timer_timer_expired_0_0),
-      .clk_i(clk_i),
-      .rst_ni(ndmreset_n)
-  );
-
-  hmac hmac (
-      .tl_i (tl_hmac_d_h2d),
-      .tl_o (tl_hmac_d_d2h),
-      .intr_hmac_done_o (intr_hmac_hmac_done),
-      .intr_fifo_full_o (intr_hmac_fifo_full),
-      .clk_i(clk_i),
-      .rst_ni(ndmreset_n)
-  );
-
-  rv_plic #(
-    .FIND_MAX("MATRIX")
-  ) rv_plic (
-      .tl_i (tl_rv_plic_d_h2d),
-      .tl_o (tl_rv_plic_d_d2h),
-      .intr_src_i (intr_vector),
-      .irq_o      (irq_plic),
-      .irq_id_o   (irq_id),
-      .msip_o     (msip),
-      .clk_i(clk_i),
-      .rst_ni(ndmreset_n)
-  );
-
-  // interrupt assignments
-  assign intr_vector = {
-      intr_hmac_fifo_full,
-      intr_hmac_hmac_done,
-      intr_flash_ctrl_op_error,
-      intr_flash_ctrl_op_done,
-      intr_flash_ctrl_rd_lvl,
-      intr_flash_ctrl_rd_full,
-      intr_flash_ctrl_prog_lvl,
-      intr_flash_ctrl_prog_empty,
-      intr_spi_device_txunderflow,
-      intr_spi_device_rxoverflow,
-      intr_spi_device_rxerr,
-      intr_spi_device_txlvl,
-      intr_spi_device_rxlvl,
-      intr_spi_device_rxf,
-      intr_uart_rx_parity_err,
-      intr_uart_rx_timeout,
-      intr_uart_rx_break_err,
-      intr_uart_rx_frame_err,
-      intr_uart_rx_overflow,
-      intr_uart_tx_overflow,
-      intr_uart_rx_watermark,
-      intr_uart_tx_watermark,
-      intr_gpio_gpio
-  };
-
-  // TL-UL Crossbar
-  logic clk_main;
-  logic ndmreset_sync_main_n;   // ndmreset synchronized to clk_main
-
-  assign clk_main = clk_i;
-  assign ndmreset_sync_main_n = ndmreset_n;
-
-  xbar_main u_xbar_main (
-    .clk_main_i  (clk_main),
-    .rst_main_ni (ndmreset_sync_main_n),
-
-    .tl_corei_i      (tl_corei_h_h2d),
-    .tl_corei_o      (tl_corei_h_d2h),
-    .tl_cored_i      (tl_cored_h_h2d),
-    .tl_cored_o      (tl_cored_h_d2h),
-    .tl_dm_sba_i     (tl_dm_sba_h_h2d),
-    .tl_dm_sba_o     (tl_dm_sba_h_d2h),
-    .tl_rom_o        (tl_rom_d_h2d),
-    .tl_rom_i        (tl_rom_d_d2h),
-    .tl_debug_mem_o  (tl_debug_mem_d_h2d),
-    .tl_debug_mem_i  (tl_debug_mem_d_d2h),
-    .tl_ram_main_o   (tl_ram_main_d_h2d),
-    .tl_ram_main_i   (tl_ram_main_d_d2h),
-    .tl_eflash_o     (tl_eflash_d_h2d),
-    .tl_eflash_i     (tl_eflash_d_d2h),
-    .tl_uart_o       (tl_uart_d_h2d),
-    .tl_uart_i       (tl_uart_d_d2h),
-    .tl_gpio_o       (tl_gpio_d_h2d),
-    .tl_gpio_i       (tl_gpio_d_d2h),
-    .tl_spi_device_o (tl_spi_device_d_h2d),
-    .tl_spi_device_i (tl_spi_device_d_d2h),
-    .tl_flash_ctrl_o (tl_flash_ctrl_d_h2d),
-    .tl_flash_ctrl_i (tl_flash_ctrl_d_d2h),
-    .tl_rv_timer_o   (tl_rv_timer_d_h2d),
-    .tl_rv_timer_i   (tl_rv_timer_d_d2h),
-    .tl_hmac_o       (tl_hmac_d_h2d),
-    .tl_hmac_i       (tl_hmac_d_d2h),
-    .tl_rv_plic_o    (tl_rv_plic_d_h2d),
-    .tl_rv_plic_i    (tl_rv_plic_d_d2h),
-
-    .scanmode_i
-  );
-
-  // make sure scanmode_i is never X (including during reset)
-  `ASSERT_KNOWN(scanmodeKnown, scanmode_i, clk_i, 0)
 
 endmodule
+

--- a/hw/top_earlgrey/rtl/top_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_asic.sv
@@ -38,7 +38,7 @@ module top_earlgrey_asic (
   logic cio_uart_rx_p2d, cio_uart_tx_d2p, cio_uart_tx_en_d2p;
 
   // Top-level design
-  top_earlgrey top_earlgrey (
+  top_earlgrey_core top_earlgrey (
     .clk_i                (IO_CLK),
     .rst_ni               (IO_RST_N),
 

--- a/hw/top_earlgrey/rtl/top_earlgrey_core.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_core.sv
@@ -1,0 +1,498 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+module top_earlgrey_core #(
+  parameter bit IbexPipeLine = 0
+) (
+  // Clock and Reset
+  input               clk_i,
+  input               rst_ni,
+
+  // JTAG interface
+  input               jtag_tck_i,
+  input               jtag_tms_i,
+  input               jtag_trst_ni,
+  input               jtag_td_i,
+  output              jtag_td_o,
+
+  // uart
+  input  cio_uart_rx_p2d_i,
+  output cio_uart_tx_d2p_o,
+  output cio_uart_tx_en_d2p_o,
+  // gpio
+  input  [31:0] cio_gpio_gpio_p2d_i,
+  output [31:0] cio_gpio_gpio_d2p_o,
+  output [31:0] cio_gpio_gpio_en_d2p_o,
+  // spi_device
+  input  cio_spi_device_sck_p2d_i,
+  input  cio_spi_device_csb_p2d_i,
+  input  cio_spi_device_mosi_p2d_i,
+  output cio_spi_device_miso_d2p_o,
+  output cio_spi_device_miso_en_d2p_o,
+  // flash_ctrl
+  // rv_timer
+  // hmac
+  // rv_plic
+
+  input               scanmode_i  // 1 for Scan
+);
+
+  import tlul_pkg::*;
+  import top_pkg::*;
+  import tl_main_pkg::*;
+  import flash_ctrl_pkg::*;
+
+  tl_h2d_t  tl_corei_h_h2d;
+  tl_d2h_t  tl_corei_h_d2h;
+
+  tl_h2d_t  tl_cored_h_h2d;
+  tl_d2h_t  tl_cored_h_d2h;
+
+  tl_h2d_t  tl_dm_sba_h_h2d;
+  tl_d2h_t  tl_dm_sba_h_d2h;
+
+  tl_h2d_t  tl_debug_mem_d_h2d;
+  tl_d2h_t  tl_debug_mem_d_d2h;
+
+  tl_h2d_t  tl_uart_d_h2d;
+  tl_d2h_t  tl_uart_d_d2h;
+  tl_h2d_t  tl_gpio_d_h2d;
+  tl_d2h_t  tl_gpio_d_d2h;
+  tl_h2d_t  tl_spi_device_d_h2d;
+  tl_d2h_t  tl_spi_device_d_d2h;
+  tl_h2d_t  tl_flash_ctrl_d_h2d;
+  tl_d2h_t  tl_flash_ctrl_d_d2h;
+  tl_h2d_t  tl_rv_timer_d_h2d;
+  tl_d2h_t  tl_rv_timer_d_d2h;
+  tl_h2d_t  tl_hmac_d_h2d;
+  tl_d2h_t  tl_hmac_d_d2h;
+  tl_h2d_t  tl_rv_plic_d_h2d;
+  tl_d2h_t  tl_rv_plic_d_d2h;
+
+  tl_h2d_t tl_rom_d_h2d;
+  tl_d2h_t tl_rom_d_d2h;
+  tl_h2d_t tl_ram_main_d_h2d;
+  tl_d2h_t tl_ram_main_d_d2h;
+  tl_h2d_t tl_eflash_d_h2d;
+  tl_d2h_t tl_eflash_d_d2h;
+  logic [53:0]  intr_vector;
+  // Interrupt source list
+  logic intr_uart_tx_watermark;
+  logic intr_uart_rx_watermark;
+  logic intr_uart_tx_overflow;
+  logic intr_uart_rx_overflow;
+  logic intr_uart_rx_frame_err;
+  logic intr_uart_rx_break_err;
+  logic intr_uart_rx_timeout;
+  logic intr_uart_rx_parity_err;
+  logic [31:0] intr_gpio_gpio;
+  logic intr_spi_device_rxf;
+  logic intr_spi_device_rxlvl;
+  logic intr_spi_device_txlvl;
+  logic intr_spi_device_rxerr;
+  logic intr_spi_device_rxoverflow;
+  logic intr_spi_device_txunderflow;
+  logic intr_flash_ctrl_prog_empty;
+  logic intr_flash_ctrl_prog_lvl;
+  logic intr_flash_ctrl_rd_full;
+  logic intr_flash_ctrl_rd_lvl;
+  logic intr_flash_ctrl_op_done;
+  logic intr_flash_ctrl_op_error;
+  logic intr_rv_timer_timer_expired_0_0;
+  logic intr_hmac_hmac_done;
+  logic intr_hmac_fifo_full;
+
+
+  logic [0:0]   irq_plic;
+  logic [5:0] irq_id[1];
+  logic [0:0]   msip;
+
+  // Non-debug module reset == reset for everything except for the debug module
+  // and the logic required to access it.
+  logic ndmreset_n;
+  logic ndmreset_from_dm;
+  assign ndmreset_n = (scanmode_i) ? rst_ni : ~ndmreset_from_dm & rst_ni;
+
+  logic debug_req;
+
+  // processor core
+  rv_core_ibex #(
+    .MHPMCounterNum      (8),
+    .MHPMCounterWidth    (40),
+    .RV32E               (0),
+    .RV32M               (1),
+    .DmHaltAddr          (ADDR_SPACE_DEBUG_MEM + dm::HaltAddress),
+    .DmExceptionAddr     (ADDR_SPACE_DEBUG_MEM + dm::ExceptionAddress),
+    .PipeLine            (IbexPipeLine)
+  ) core (
+    // clock and reset
+    .clk_i                (clk_i),
+    .rst_ni               (ndmreset_n),
+    .test_en_i            (1'b0),
+    // static pinning
+    .hart_id_i            (32'b0),
+    .boot_addr_i          (ADDR_SPACE_ROM),
+    // TL-UL buses
+    .tl_i_o               (tl_corei_h_h2d),
+    .tl_i_i               (tl_corei_h_d2h),
+    .tl_d_o               (tl_cored_h_h2d),
+    .tl_d_i               (tl_cored_h_d2h),
+    // interrupts
+    .irq_software_i       (msip),
+    .irq_timer_i          (intr_rv_timer_timer_expired_0_0),
+    .irq_external_i       (irq_plic),
+    .irq_fast_i           (15'b0),// PLIC handles all peripheral interrupts
+    .irq_nm_i             (1'b0),// TODO - add and connect alert responder
+    // debug interface
+    .debug_req_i          (debug_req),
+    // CPU control signals
+    .fetch_enable_i       (1'b1),
+    .core_sleep_o         ()
+  );
+
+  // Debug Module (RISC-V Debug Spec 0.13)
+  //
+
+  rv_dm #(
+    .NrHarts     (  1),
+    .IdcodeValue (32'h00000001) // Temporary value
+                                // xxxx             version
+                                // xxxxxxxxxxxxxxxx part number
+                                // xxxxxxxxxxx      manufacturer id
+                                // 1                required by standard
+  ) u_dm_top (
+    .clk_i         (clk_i),
+    .rst_ni        (rst_ni),
+    .testmode_i    (1'b0),
+    .ndmreset_o    (ndmreset_from_dm),
+    .dmactive_o    (),
+    .debug_req_o   (debug_req),
+    .unavailable_i (1'b0),
+
+    // bus device with debug memory (for execution-based debug)
+    .tl_d_i        (tl_debug_mem_d_h2d),
+    .tl_d_o        (tl_debug_mem_d_d2h),
+
+    // bus host (for system bus accesses, SBA)
+    .tl_h_o        (tl_dm_sba_h_h2d),
+    .tl_h_i        (tl_dm_sba_h_d2h),
+
+    //JTAG
+    .tck_i            (jtag_tck_i),
+    .tms_i            (jtag_tms_i),
+    .trst_ni          (jtag_trst_ni),
+    .td_i             (jtag_td_i),
+    .td_o             (jtag_td_o),
+    .tdo_oe_o         (       )
+  );
+
+  // ROM device
+  logic        rom_req;
+  logic [10:0] rom_addr;
+  logic [31:0] rom_rdata;
+  logic        rom_rvalid;
+
+  tlul_adapter_sram #(
+    .SramAw(11),
+    .SramDw(32),
+    .Outstanding(1),
+    .ErrOnWrite(1)
+  ) tl_adapter_rom (
+    .clk_i,
+    .rst_ni   (ndmreset_n),
+
+    .tl_i     (tl_rom_d_h2d),
+    .tl_o     (tl_rom_d_d2h),
+
+    .req_o    (rom_req),
+    .gnt_i    (1'b1), // Always grant as only one requester exists
+    .we_o     (),
+    .addr_o   (rom_addr),
+    .wdata_o  (),
+    .wmask_o  (),
+    .rdata_i  (rom_rdata),
+    .rvalid_i (rom_rvalid),
+    .rerror_i (2'b00)
+  );
+
+  prim_rom #(
+    .Width(32),
+    .Depth(2048)
+  ) u_rom_rom (
+    .clk_i,
+    .rst_ni   (ndmreset_n),
+    .cs_i     (rom_req),
+    .addr_i   (rom_addr),
+    .dout_o   (rom_rdata),
+    .dvalid_o (rom_rvalid)
+  );
+
+  // sram device
+  logic        ram_main_req;
+  logic        ram_main_we;
+  logic [13:0] ram_main_addr;
+  logic [31:0] ram_main_wdata;
+  logic [31:0] ram_main_wmask;
+  logic [31:0] ram_main_rdata;
+  logic        ram_main_rvalid;
+
+  tlul_adapter_sram #(
+    .SramAw(14),
+    .SramDw(32),
+    .Outstanding(1)
+  ) tl_adapter_ram_main (
+    .clk_i,
+    .rst_ni   (ndmreset_n),
+
+    .tl_i     (tl_ram_main_d_h2d),
+    .tl_o     (tl_ram_main_d_d2h),
+
+    .req_o    (ram_main_req),
+    .gnt_i    (1'b1), // Always grant as only one requester exists
+    .we_o     (ram_main_we),
+    .addr_o   (ram_main_addr),
+    .wdata_o  (ram_main_wdata),
+    .wmask_o  (ram_main_wmask),
+    .rdata_i  (ram_main_rdata),
+    .rvalid_i (ram_main_rvalid),
+    .rerror_i (2'b00)
+  );
+
+  prim_ram_1p #(
+    .Width(32),
+    .Depth(16384),
+    .DataBitsPerMask(8)
+  ) u_ram1p_ram_main (
+    .clk_i,
+    .rst_ni   (ndmreset_n),
+
+    .req_i    (ram_main_req),
+    .write_i  (ram_main_we),
+    .addr_i   (ram_main_addr),
+    .wdata_i  (ram_main_wdata),
+    .wmask_i  (ram_main_wmask),
+    .rvalid_o (ram_main_rvalid),
+    .rdata_o  (ram_main_rdata)
+  );
+
+  // flash controller to eflash communication
+  flash_c2m_t flash_c2m;
+  flash_m2c_t flash_m2c;
+
+  // host to flash communication
+  logic flash_host_req;
+  logic flash_host_req_rdy;
+  logic flash_host_req_done;
+  logic [FLASH_DW-1:0] flash_host_rdata;
+  logic [FLASH_AW-1:0] flash_host_addr;
+
+  tlul_adapter_sram #(
+    .SramAw(FLASH_AW),
+    .SramDw(FLASH_DW),
+    .Outstanding(1),
+    .ByteAccess(0),
+    .ErrOnWrite(1)
+  ) tl_adapter_eflash (
+    .clk_i,
+    .rst_ni     (ndmreset_n),
+
+    .tl_i       (tl_eflash_d_h2d),
+    .tl_o       (tl_eflash_d_d2h),
+
+    .req_o    (flash_host_req),
+    .gnt_i    (flash_host_req_rdy),
+    .we_o     (),
+    .addr_o   (flash_host_addr),
+    .wdata_o  (),
+    .wmask_o  (),
+    .rdata_i  (flash_host_rdata),
+    .rvalid_i (flash_host_req_done),
+    .rerror_i (2'b00)
+  );
+
+  flash_phy #(
+    .NumBanks(FLASH_BANKS),
+    .PagesPerBank(FLASH_PAGES_PER_BANK),
+    .WordsPerPage(FLASH_WORDS_PER_PAGE),
+    .DataWidth(32)
+  ) u_flash_eflash (
+    .clk_i,
+    .rst_ni,
+    .host_req_i      (flash_host_req),
+    .host_addr_i     (flash_host_addr),
+    .host_req_rdy_o  (flash_host_req_rdy),
+    .host_req_done_o (flash_host_req_done),
+    .host_rdata_o    (flash_host_rdata),
+    .flash_ctrl_i    (flash_c2m),
+    .flash_ctrl_o    (flash_m2c)
+  );
+
+
+  uart uart (
+      .tl_i (tl_uart_d_h2d),
+      .tl_o (tl_uart_d_d2h),
+      .cio_rx_i (cio_uart_rx_p2d_i),
+      .cio_tx_o    (cio_uart_tx_d2p_o),
+      .cio_tx_en_o (cio_uart_tx_en_d2p_o),
+      .intr_tx_watermark_o (intr_uart_tx_watermark),
+      .intr_rx_watermark_o (intr_uart_rx_watermark),
+      .intr_tx_overflow_o (intr_uart_tx_overflow),
+      .intr_rx_overflow_o (intr_uart_rx_overflow),
+      .intr_rx_frame_err_o (intr_uart_rx_frame_err),
+      .intr_rx_break_err_o (intr_uart_rx_break_err),
+      .intr_rx_timeout_o (intr_uart_rx_timeout),
+      .intr_rx_parity_err_o (intr_uart_rx_parity_err),
+      .clk_i(clk_i),
+      .rst_ni(ndmreset_n)
+  );
+
+  gpio gpio (
+      .tl_i (tl_gpio_d_h2d),
+      .tl_o (tl_gpio_d_d2h),
+      .cio_gpio_i (cio_gpio_gpio_p2d_i),
+      .cio_gpio_o    (cio_gpio_gpio_d2p_o),
+      .cio_gpio_en_o (cio_gpio_gpio_en_d2p_o),
+      .intr_gpio_o (intr_gpio_gpio),
+      .clk_i(clk_i),
+      .rst_ni(ndmreset_n)
+  );
+
+  spi_device spi_device (
+      .tl_i (tl_spi_device_d_h2d),
+      .tl_o (tl_spi_device_d_d2h),
+      .cio_sck_i (cio_spi_device_sck_p2d_i),
+      .cio_csb_i (cio_spi_device_csb_p2d_i),
+      .cio_mosi_i (cio_spi_device_mosi_p2d_i),
+      .cio_miso_o    (cio_spi_device_miso_d2p_o),
+      .cio_miso_en_o (cio_spi_device_miso_en_d2p_o),
+      .intr_rxf_o (intr_spi_device_rxf),
+      .intr_rxlvl_o (intr_spi_device_rxlvl),
+      .intr_txlvl_o (intr_spi_device_txlvl),
+      .intr_rxerr_o (intr_spi_device_rxerr),
+      .intr_rxoverflow_o (intr_spi_device_rxoverflow),
+      .intr_txunderflow_o (intr_spi_device_txunderflow),
+      .scanmode_i   (scanmode_i),
+      .clk_i(clk_i),
+      .rst_ni(ndmreset_n)
+  );
+
+  flash_ctrl flash_ctrl (
+      .tl_i (tl_flash_ctrl_d_h2d),
+      .tl_o (tl_flash_ctrl_d_d2h),
+      .intr_prog_empty_o (intr_flash_ctrl_prog_empty),
+      .intr_prog_lvl_o (intr_flash_ctrl_prog_lvl),
+      .intr_rd_full_o (intr_flash_ctrl_rd_full),
+      .intr_rd_lvl_o (intr_flash_ctrl_rd_lvl),
+      .intr_op_done_o (intr_flash_ctrl_op_done),
+      .intr_op_error_o (intr_flash_ctrl_op_error),
+      .flash_o(flash_c2m),
+      .flash_i(flash_m2c),
+      .clk_i(clk_i),
+      .rst_ni(ndmreset_n)
+  );
+
+  rv_timer rv_timer (
+      .tl_i (tl_rv_timer_d_h2d),
+      .tl_o (tl_rv_timer_d_d2h),
+      .intr_timer_expired_0_0_o (intr_rv_timer_timer_expired_0_0),
+      .clk_i(clk_i),
+      .rst_ni(ndmreset_n)
+  );
+
+  hmac hmac (
+      .tl_i (tl_hmac_d_h2d),
+      .tl_o (tl_hmac_d_d2h),
+      .intr_hmac_done_o (intr_hmac_hmac_done),
+      .intr_fifo_full_o (intr_hmac_fifo_full),
+      .clk_i(clk_i),
+      .rst_ni(ndmreset_n)
+  );
+
+  rv_plic #(
+    .FIND_MAX("MATRIX")
+  ) rv_plic (
+      .tl_i (tl_rv_plic_d_h2d),
+      .tl_o (tl_rv_plic_d_d2h),
+      .intr_src_i (intr_vector),
+      .irq_o      (irq_plic),
+      .irq_id_o   (irq_id),
+      .msip_o     (msip),
+      .clk_i(clk_i),
+      .rst_ni(ndmreset_n)
+  );
+
+  // interrupt assignments
+  assign intr_vector = {
+      intr_hmac_fifo_full,
+      intr_hmac_hmac_done,
+      intr_flash_ctrl_op_error,
+      intr_flash_ctrl_op_done,
+      intr_flash_ctrl_rd_lvl,
+      intr_flash_ctrl_rd_full,
+      intr_flash_ctrl_prog_lvl,
+      intr_flash_ctrl_prog_empty,
+      intr_spi_device_txunderflow,
+      intr_spi_device_rxoverflow,
+      intr_spi_device_rxerr,
+      intr_spi_device_txlvl,
+      intr_spi_device_rxlvl,
+      intr_spi_device_rxf,
+      intr_uart_rx_parity_err,
+      intr_uart_rx_timeout,
+      intr_uart_rx_break_err,
+      intr_uart_rx_frame_err,
+      intr_uart_rx_overflow,
+      intr_uart_tx_overflow,
+      intr_uart_rx_watermark,
+      intr_uart_tx_watermark,
+      intr_gpio_gpio
+  };
+
+  // TL-UL Crossbar
+  logic clk_main;
+  logic ndmreset_sync_main_n;   // ndmreset synchronized to clk_main
+
+  assign clk_main = clk_i;
+  assign ndmreset_sync_main_n = ndmreset_n;
+
+  xbar_main u_xbar_main (
+    .clk_main_i  (clk_main),
+    .rst_main_ni (ndmreset_sync_main_n),
+
+    .tl_corei_i      (tl_corei_h_h2d),
+    .tl_corei_o      (tl_corei_h_d2h),
+    .tl_cored_i      (tl_cored_h_h2d),
+    .tl_cored_o      (tl_cored_h_d2h),
+    .tl_dm_sba_i     (tl_dm_sba_h_h2d),
+    .tl_dm_sba_o     (tl_dm_sba_h_d2h),
+    .tl_rom_o        (tl_rom_d_h2d),
+    .tl_rom_i        (tl_rom_d_d2h),
+    .tl_debug_mem_o  (tl_debug_mem_d_h2d),
+    .tl_debug_mem_i  (tl_debug_mem_d_d2h),
+    .tl_ram_main_o   (tl_ram_main_d_h2d),
+    .tl_ram_main_i   (tl_ram_main_d_d2h),
+    .tl_eflash_o     (tl_eflash_d_h2d),
+    .tl_eflash_i     (tl_eflash_d_d2h),
+    .tl_uart_o       (tl_uart_d_h2d),
+    .tl_uart_i       (tl_uart_d_d2h),
+    .tl_gpio_o       (tl_gpio_d_h2d),
+    .tl_gpio_i       (tl_gpio_d_d2h),
+    .tl_spi_device_o (tl_spi_device_d_h2d),
+    .tl_spi_device_i (tl_spi_device_d_d2h),
+    .tl_flash_ctrl_o (tl_flash_ctrl_d_h2d),
+    .tl_flash_ctrl_i (tl_flash_ctrl_d_d2h),
+    .tl_rv_timer_o   (tl_rv_timer_d_h2d),
+    .tl_rv_timer_i   (tl_rv_timer_d_d2h),
+    .tl_hmac_o       (tl_hmac_d_h2d),
+    .tl_hmac_i       (tl_hmac_d_d2h),
+    .tl_rv_plic_o    (tl_rv_plic_d_h2d),
+    .tl_rv_plic_i    (tl_rv_plic_d_d2h),
+
+    .scanmode_i
+  );
+
+  // make sure scanmode_i is never X (including during reset)
+  `ASSERT_KNOWN(scanmodeKnown, scanmode_i, clk_i, 0)
+
+endmodule

--- a/hw/top_earlgrey/rtl/top_earlgrey_nexysvideo.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_nexysvideo.sv
@@ -46,7 +46,7 @@ module top_earlgrey_nexysvideo (
   logic cio_jtag_trst_n_p2d, cio_jtag_srst_n_p2d;
 
   // Top-level design
-  top_earlgrey #(
+  top_earlgrey_core #(
     .IbexPipeLine(1)
   ) top_earlgrey (
     .clk_i                        (clk_sys),

--- a/hw/top_earlgrey/rtl/top_earlgrey_verilator.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_verilator.sv
@@ -21,7 +21,7 @@ module top_earlgrey_verilator (
   logic IO_JTCK, IO_JTMS, IO_JTRST_N, IO_JTDI, IO_JTDO;
 
   // Top-level design
-  top_earlgrey top_earlgrey (
+  top_earlgrey_core top_earlgrey (
     .clk_i                        (clk_i),
     .rst_ni                       (rst_ni),
 

--- a/hw/top_earlgrey/top_earlgrey.core
+++ b/hw/top_earlgrey/top_earlgrey.core
@@ -28,7 +28,7 @@ filesets:
       - rtl/rv_plic_reg_top.sv
       - rtl/rv_plic.sv
       - rtl/padctl.sv
-      - rtl/top_earlgrey.sv
+      - rtl/top_earlgrey_core.sv
     file_type: systemVerilogSource
 
 parameters:
@@ -43,9 +43,9 @@ targets:
   default: &default_target
     filesets:
       - files_rtl_generic
-    toplevel: top_earlgrey
+    toplevel: top_earlgrey_core
   sim:
     default_tool: icarus
     filesets:
       - files_rtl_generic
-    toplevel: top_earlgrey
+    toplevel: top_earlgrey_core

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -172,7 +172,11 @@ def main():
                         '-t',
                         required=True,
                         help="`top_{name}.hjson` file.")
-    parser.add_argument('--tpl', '-c', help="`top_{name}.tpl.sv` file.")
+    parser.add_argument(
+        '--tpl',
+        '-c',
+        help=
+        "The directory having top_{name}_core.tpl.sv and top_{name}.tpl.sv.")
     parser.add_argument(
         '--outdir',
         '-o',
@@ -288,6 +292,8 @@ def main():
         hjson_dir = Path(args.topcfg).parent
         ips.append(hjson_dir / 'rv_plic.hjson')
 
+        # TODO: Add generated pinmux hjson to ips here
+
         # load hjson and pass validate from reggen
         try:
             ip_objs = []
@@ -357,13 +363,21 @@ def main():
     top_name = completecfg["name"]
 
     if not args.no_top or args.top_only:
+        tpl_path = Path(args.tpl)
+        core_tplpath = tpl_path / ("top_%s_core.tpl.sv" % (top_name))
+        top_tplpath = tpl_path / ("top_%s.tpl.sv" % (top_name))
+        out_core = generate_rtl(completecfg, str(core_tplpath))
+        out_top = generate_rtl(completecfg, str(top_tplpath))
+
         rtl_path = out_path / 'rtl'
         rtl_path.mkdir(parents=True, exist_ok=True)
-        rtl_filepath = rtl_path / ("top_%s.sv" % (top_name))
-        out_rtl = generate_rtl(completecfg, args.tpl)
+        core_path = rtl_path / ("top_%s_core.sv" % top_name)
+        top_path = rtl_path / ("top_%s.sv" % top_name)
 
-        with rtl_filepath.open(mode='w', encoding='UTF-8') as fout:
-            fout.write(out_rtl)
+        with core_path.open(mode='w', encoding='UTF-8') as fout:
+            fout.write(out_core)
+        with top_path.open(mode='w', encoding='UTF-8') as fout:
+            fout.write(out_top)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR addresses #295. `top_earlgrey.tpl.sv` is renamed to
`top_earlgrey_core.tpl.sv` and its generated file accordingly.

The plan is to have common CHIP_TOP module rather than having multiple
CHIP_TOP as seen in current revision. It has been having `_asic`,
`_verilator`, and `_nexysvideo` CHIP_TOP modules.

Current PR doesn't solve this issue yet. It just creates
`top_earlgrey.sv` that instantiating `top_earlgrey_core` module. More
will come after PINMUX/PADS are implemented in the top ( see #314 as a
first step to the goal) and porting the implementations from each
CHIP_TOP to `top_earlgrey.sv`.

The DPI interface inside `_verilator` will be moved to `dv/` directory
so that it could be compatible to others.

CC: @weicaiyang @sriyerg @sjgitty 