### PR TITLE
[hw] Update default make target

### DIFF
--- a/hw/Makefile
+++ b/hw/Makefile
@@ -20,7 +20,7 @@ ips_reg = $(addsuffix _reg, $(IPS))
 
 tops_gen = $(addsuffix _gen,$(TOPS))
 
-all: $(ips_reg)
+all: $(ips_reg) $(tops_gen)
 
 regs: $(ips_reg)
 
@@ -44,8 +44,8 @@ $(tops_gen):
 	$(eval $@_TOP := $(strip $(foreach top,$(TOPS),$(findstring $(top),$@))))
 	${PRJ_DIR}/util/topgen.py -t ${PRJ_DIR}/hw/$($@_TOP)/doc/$($@_TOP).hjson \
 		--tpl ${PRJ_DIR}/hw/$($@_TOP)/doc/$($@_TOP).tpl.sv \
-		-o ${PRJ_DIR}/hw/$($@_TOP)/ -v
+		-o ${PRJ_DIR}/hw/$($@_TOP)/
 	${PRJ_DIR}/util/topgen.py -t ${PRJ_DIR}/hw/$($@_TOP)/doc/$($@_TOP).hjson \
-		-r -o ${PRJ_DIR}/hw/$($@_TOP)/dv/env/ -v
+		-r -o ${PRJ_DIR}/hw/$($@_TOP)/dv/env/
 
 .PHONY: all $(ips_reg) $(tops_gen)


### PR DESCRIPTION
Include `tops_gen` target in default `all` target.
Disable the verbose output.