### PR TITLE
[sw] C messaging APIs 

### DIFF
--- a/hw/dv/tools/rules.mk
+++ b/hw/dv/tools/rules.mk
@@ -48,10 +48,12 @@ sw_build: pre_run
 ifneq (${SW_NAME},)
 	mkdir -p ${SW_BUILD_DIR}
 	$(MAKE) -C $(SW_ROOT_DIR) \
+	  TARGET=dv \
 	  SW_DIR=boot_rom \
 	  SW_BUILD_DIR=$(SW_BUILD_DIR)/rom \
 	  MAKEFLAGS="$(SW_OPTS)"
 	$(MAKE) -C $(SW_ROOT_DIR) \
+	  TARGET=dv \
 	  SW_DIR=$(SW_DIR) \
 	  SW_NAME=$(SW_NAME) \
 	  SW_BUILD_DIR=$(SW_BUILD_DIR)/sw \

--- a/sw/Makefile
+++ b/sw/Makefile
@@ -11,6 +11,8 @@
 ##               SW_SRCS to be built for that SW test.                                            ##
 ## SW_NAME:      This is the name of the SW test begin run. Optional if SW_DIR name (last dir) is ##
 ##               the same as the SW test name.                                                    ##
+## TARGET:       Target for which the sw is cross-compiled - dv|fpga|verilator|silicon, etc       ##
+##               By default, no TARGET is selected.
 ##                                                                                                ##
 ## Optional variables:                                                                            ##
 ## SW_BUILD_DIR: This is the output location for generating all sources                           ##
@@ -23,11 +25,15 @@
 SW_ROOT_DIR   := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 SW_DIR        ?= examples/hello_world
 
+# SW build targets
+TARGET        ?=
+
 # sources
 STANDALONE_SW ?= 0
 include ${SW_DIR}/srcs.mk
 include exts/common/srcs.mk
 include lib/srcs.mk
+include util/srcs.mk
 
 # common options and rules
 include opts.mk

--- a/sw/boot_rom/boot_rom.c
+++ b/sw/boot_rom/boot_rom.c
@@ -7,6 +7,7 @@
 #include "common.h"
 #include "flash_ctrl.h"
 #include "gpio.h"
+#include "msg.h"
 #include "spi_device.h"
 #include "uart.h"
 
@@ -26,14 +27,12 @@ int main(int argc, char **argv) {
 
   int rv = bootstrap();
   if (rv) {
-    uart_send_str("Bootstrap failed with status code: ");
-    uart_send_uint(rv, 32);
-    uart_send_str("\r\n");
+    MSG_ERROR("Bootstrap failed with status code: %d\n", rv);
     // Currently the only way to recover is by a hard reset.
     return rv;
   }
 
-  uart_send_str("Jump!\r\n");
+  MSG_INFO("Jump!\n");
   while (!uart_tx_empty()) {
   }
   try_launch();

--- a/sw/opts.mk
+++ b/sw/opts.mk
@@ -16,7 +16,6 @@
 SW_NAME       ?= $(notdir $(SW_DIR))
 SW_SRCS       += $(CRT_SRCS)
 SW_OBJS       += $(addprefix $(SW_BUILD_DIR)/, $(addsuffix .o, $(basename $(notdir $(SW_SRCS)))))
-SW_PPOS       += $(SW_OBJS:.o=.ppo)
 SW_DEPS       ?= lib
 SW_BUILD_DIR  ?= $(SW_ROOT_DIR)/$(SW_DIR)
 
@@ -25,7 +24,6 @@ LIB_DIR       ?= $(SW_ROOT_DIR)/lib
 LIB_TARGET    ?= $(LIB_BUILD_DIR)/lib${LIB_NAME}.a
 LIB_SRCS      +=
 LIB_OBJS      += $(addprefix $(LIB_BUILD_DIR)/, $(addsuffix .o, $(basename $(notdir $(LIB_SRCS)))))
-LIB_PPOS      += $(LIB_OBJS:.o=.ppo)
 LIB_BUILD_DIR ?= $(SW_BUILD_DIR)/lib
 
 DEPS          += $(SW_OBJS:%.o=%.d) $(LIB_OBJS:%.o=%.d)
@@ -61,6 +59,7 @@ RV_TOOLS      ?= /tools/riscv/bin
 # ARCH = rv32im # to disable compressed instructions
 ARCH           = rv32imc
 CC             = ${RV_TOOLS}/riscv32-unknown-elf-gcc
+CPP            = $(subst gcc,cpp,$(wordlist 1,1,$(CC)))
 AR             = $(subst gcc,ar,$(wordlist 1,1,$(CC)))
 AS             = $(subst gcc,as,$(wordlist 1,1,$(CC)))
 LD             = $(subst gcc,ld,$(wordlist 1,1,$(CC)))
@@ -70,9 +69,22 @@ OBJDUMP        = $(subst gcc,objdump,$(wordlist 1,1,$(CC)))
 CFLAGS        += -march=$(ARCH) -mabi=ilp32 -static -mcmodel=medany -Wall -g -Os \
                  -fvisibility=hidden -nostdlib -nostartfiles $(SW_FLAGS)
 ARFLAGS        = rc
+OBJCOPY_FLAGS +=
 
 # conditional flags
 SIM ?= 0
-ifeq ($(SIM),1)
+ifeq ($(SIM), 1)
   CFLAGS      += -DSIMULATION
 endif
+
+ifeq ($(TARGET), dv)
+  CFLAGS      += -DDV_SIM
+endif
+
+ifeq ($(TARGET), fpga)
+  CFLAGS      += -DFPGA_SIM
+endif
+
+# msg flow
+MSG_FLOW      ?= uart
+

--- a/sw/rules.mk
+++ b/sw/rules.mk
@@ -22,7 +22,7 @@ gen_dir:
 standalone: $(SW_DEPS)
 	$(STANDALONE_CMD)
 
-$(LIB_TARGET): $(GEN_HEADER_OUTPUTS) $(LIB_PPOS) $(LIB_OBJS)
+$(LIB_TARGET): $(GEN_HEADER_OUTPUTS) $(LIB_OBJS)
 	$(AR) $(ARFLAGS) $@ $(LIB_OBJS)
 
 lib: $(LIB_TARGET)
@@ -37,17 +37,17 @@ lib: $(LIB_TARGET)
 	srec_cat $^ -binary -offset 0x0 -byte-swap 4 -o $@ -vmem
 
 %.bin: %.elf
-	$(OBJCOPY) -O binary $^ $@
+	$(OBJCOPY) -O binary $(OBJCOPY_FLAGS) $^ $@
 
 %.dis: %.elf
-	$(OBJDUMP) -SD $^ > $@
+	$(OBJDUMP) -SDhl $^ > $@
 
 # link & generate elf
-%.elf %.map: $(SW_DEPS) $(SW_PPOS) $(SW_OBJS) $(LINKER_SCRIPT)
+%.elf %.map: $(SW_DEPS) $(SW_OBJS) $(LINKER_SCRIPT)
 	$(CC) $(CFLAGS) $(LINK_OPTS) -o $@
 
 # compile sw sources
-# TOOD: figure out a way to 'templatise' .o/.ppo ruleset for each dir containing srcs
+# TOOD: figure out a way to 'templatise' .o/.c ruleset for each dir containing srcs
 
 $(SW_BUILD_DIR)/%.o: $(SW_DIR)/$$*.c
 	$(CC) $(CFLAGS) -MMD -c $(INCS) -o $@ $<
@@ -55,35 +55,17 @@ $(SW_BUILD_DIR)/%.o: $(SW_DIR)/$$*.c
 $(SW_BUILD_DIR)/%.o: $(SW_DIR)/$$*.S
 	$(CC) $(CFLAGS) -MMD -c $(INCS) -o $@ $<
 
-$(SW_BUILD_DIR)/%.ppo: $(SW_DIR)/$$*.c
-	$(CC) $(CFLAGS) -E -MMD -c $(INCS) -o $@ $<
-
-$(SW_BUILD_DIR)/%.ppo: $(SW_DIR)/$$*.S
-	$(CC) $(CFLAGS) -E -MMD -c $(INCS) -o $@ $<
-
 $(SW_BUILD_DIR)/%.o: $(LIB_DIR)/$$*.c
 	$(CC) $(CFLAGS) -MMD -c $(INCS) -o $@ $<
 
 $(SW_BUILD_DIR)/%.o: $(LIB_DIR)/$$*.S
 	$(CC) $(CFLAGS) -MMD -c $(INCS) -o $@ $<
 
-$(SW_BUILD_DIR)/%.ppo: $(LIB_DIR)/$$*.c
-	$(CC) $(CFLAGS) -E -MMD -c $(INCS) -o $@ $<
-
-$(SW_BUILD_DIR)/%.ppo: $(LIB_DIR)/$$*.S
-	$(CC) $(CFLAGS) -E -MMD -c $(INCS) -o $@ $<
-
 $(SW_BUILD_DIR)/%.o: $(EXT_COMMON_DIR)/$$*.c
 	$(CC) $(CFLAGS) -MMD -c $(INCS) -o $@ $<
 
 $(SW_BUILD_DIR)/%.o: $(EXT_COMMON_DIR)/$$*.S
 	$(CC) $(CFLAGS) -MMD -c $(INCS) -o $@ $<
-
-$(SW_BUILD_DIR)/%.ppo: $(EXT_COMMON_DIR)/$$*.c
-	$(CC) $(CFLAGS) -E -MMD -c $(INCS) -o $@ $<
-
-$(SW_BUILD_DIR)/%.ppo: $(EXT_COMMON_DIR)/$$*.S
-	$(CC) $(CFLAGS) -E -MMD -c $(INCS) -o $@ $<
 
 # compile lib sources
 $(LIB_BUILD_DIR)/%.o: $(LIB_DIR)/$$*.c
@@ -92,23 +74,17 @@ $(LIB_BUILD_DIR)/%.o: $(LIB_DIR)/$$*.c
 $(LIB_BUILD_DIR)/%.o: $(LIB_DIR)/$$*.S
 	$(CC) $(CFLAGS) -MMD -c $(INCS) -o $@ $<
 
-$(LIB_BUILD_DIR)/%.ppo: $(LIB_DIR)/$$*.c
-	$(CC) $(CFLAGS) -E -MMD -c $(INCS) -o $@ $<
-
-$(LIB_BUILD_DIR)/%.ppo: $(LIB_DIR)/$$*.S
-	$(CC) $(CFLAGS) -E -MMD -c $(INCS) -o $@ $<
-
 $(LIB_BUILD_DIR)/%.o: $(EXT_COMMON_DIR)/$$*.c
 	$(CC) $(CFLAGS) -MMD -c $(INCS) -o $@ $<
 
 $(LIB_BUILD_DIR)/%.o: $(EXT_COMMON_DIR)/$$*.S
 	$(CC) $(CFLAGS) -MMD -c $(INCS) -o $@ $<
 
-$(LIB_BUILD_DIR)/%.ppo: $(EXT_COMMON_DIR)/$$*.c
-	$(CC) $(CFLAGS) -E -MMD -c $(INCS) -o $@ $<
+$(LIB_BUILD_DIR)/%.o: $(UTIL_DIR)/$$*.c
+	$(CC) $(CFLAGS) -MMD -c $(INCS) -o $@ $<
 
-$(LIB_BUILD_DIR)/%.ppo: $(EXT_COMMON_DIR)/$$*.S
-	$(CC) $(CFLAGS) -E -MMD -c $(INCS) -o $@ $<
+$(LIB_BUILD_DIR)/%.o: $(UTIL_DIR)/$$*.S
+	$(CC) $(CFLAGS) -MMD -c $(INCS) -o $@ $<
 
 # regtool
 $(LIB_BUILD_DIR)/%_regs.h: $(SW_ROOT_DIR)/../hw/ip/$$*/doc/$$*.hjson
@@ -125,8 +101,8 @@ $(LIB_BUILD_DIR)/chip_info.h: $(INFOTOOL)
 
 # clean sources
 clean:
-	-$(RM) -r $(LIB_OBJS) $(LIB_PPOS) $(SW_OBJS) $(SW_PPOS) $(DEPS) \
-	          $(GEN_HEADER_OUTPUTS) $(IMG_OUTPUTS) $(LIB_TARGET) ${SW_BUILD_DIR}/env_vars
+	-$(RM) -r $(GEN_HEADER_OUTPUTS) $(LIB_OBJS) $(SW_OBJS) $(DEPS) \
+	          $(IMG_OUTPUTS) $(LIB_TARGET) ${SW_BUILD_DIR}/env_vars
 
 distclean: clean
 

--- a/sw/util/msg.h
+++ b/sw/util/msg.h
@@ -1,0 +1,174 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef _MSG_H_
+#define _MSG_H_
+
+#include "msg_impl.h"
+
+/**
+ * The APIs below for printing msgs in SW take a formatted string with variable
+ * number of arguments. The APIs are designed to provide a way for attaching the
+ * msg type, verbosity, file name and the line number information along with the
+ * msg to provide an easier path to debug. These parameters form the msg header
+ * which is prepended to the actual msg being printed. The following provides a
+ * brief description for these:
+ *
+ *  msg_type:     severity of the msg: info, warning, error or fatal This is
+ *                indicated using MSG_TYPE_* set of macros which are set to
+ *                empty strings by default.
+ *
+ *  verbosity:    (applicable only to info msgs) none, low, medium, high, full
+ *                and debug. Based on desired verbosity, visibility of certain
+ *                msgs can be turned off. This is expected to be done externally
+ *                (for example, if the print msgs go to a log, the desired
+ *                verbosity msgs can be greped and filtered out). This is
+ *                indicated using the MSG_VERB_* set of macros which are set to
+ *                empty strings by default.
+ *
+ *  file name:    name of the file using __FILE__
+ *
+ *  line number:  line where the print originated using __LINE__
+ *
+ * Printing the final msg
+ * Once the header is constructed, another API is invoked that takes header
+ * and the formatted msg as arg and prints the whole msg using the desired
+ * implementation. This is provided by the MSG_PRINT() macro.
+ *
+ * All of these macros defined in this file can be overridden to customize the
+ * flow based on the desired requirement. This is done in the msg_impl.h header
+ * file, placed in sw/util/msg_<impl> directory. The correct msg_impl.h is
+ * selected by the build system which resolves the dependency based on the
+ * target.
+ */
+
+/** Generic msg print APIs
+ *
+ * The following are a set of msg print APIs available for use in OpenTitan SW.
+ * These are implemented as macros so that based on need, it could expand to a
+ * function call or another macro invocation.
+ *
+ * @param fmt: formatted string msg that take variable # of args
+ * @param ...: # of args passed to fmt
+ */
+// print an info msg with no verbosity
+#ifndef MSG_INFO
+#warning MSG_INFO undefined: it will result in vacuous invocation
+#define MSG_INFO(fmt, ...)
+#endif
+
+// print an info msg with low verbosity
+#ifndef MSG_INFO_LOW
+#warning MSG_INFO_LOW undefined: it will result in vacuous invocation
+#define MSG_INFO_LOW(fmt, ...)
+#endif
+
+// print an info msg with medium verbosity
+#ifndef MSG_INFO_MEDIUM
+#warning MSG_INFO_MEDIUM undefined: it will result in vacuous invocation
+#define MSG_INFO_MEDIUM(fmt, ...)
+#endif
+
+// print an info msg with high verbosity
+#ifndef MSG_INFO_HIGH
+#warning MSG_INFO_HIGH undefined: it will result in vacuous invocation
+#define MSG_INFO_HIGH(fmt, ...)
+#endif
+
+// print an info msg with full verbosity
+#ifndef MSG_INFO_FULL
+#warning MSG_INFO_FULL undefined: it will result in vacuous invocation
+#define MSG_INFO_FULL(fmt, ...)
+#endif
+
+// print an info msg with debug verbosity
+#ifndef MSG_INFO_DEBUG
+#warning MSG_INFO_DEBUG undefined: it will result in vacuous invocation
+#define MSG_INFO_DEBUG(fmt, ...)
+#endif
+
+// print a warning msg
+#ifndef MSG_WARNING
+#warning MSG_WARNING undefined: it will result in vacuous invocation
+#define MSG_WARNING(fmt, ...)
+#endif
+
+// print an error msg
+#ifndef MSG_ERROR
+#warning MSG_ERROR undefined: it will result in vacuous invocation
+#define MSG_ERROR(fmt, ...)
+#endif
+
+// print a fatal error msg
+#ifndef MSG_FATAL
+#warning MSG_FATAL undefined: it will result in vacuous invocation
+#define MSG_FATAL(fmt, ...)
+#endif
+
+/** Msg type and verbosity string constants (used to construct msg header)
+ *
+ * These are strings used to construct the msg header.
+ */
+
+#ifndef MSG_TYPE_INFO
+#define MSG_TYPE_INFO ""
+#endif
+
+#ifndef MSG_TYPE_WARNING
+#define MSG_TYPE_WARNING ""
+#endif
+
+#ifndef MSG_TYPE_ERROR
+#define MSG_TYPE_ERROR ""
+#endif
+
+#ifndef MSG_TYPE_FATAL
+#define MSG_TYPE_FATAL ""
+#endif
+
+#ifndef MSG_VERB_NONE
+#define MSG_VERB_NONE ""
+#endif
+
+#ifndef MSG_VERB_LOW
+#define MSG_VERB_LOW ""
+#endif
+
+#ifndef MSG_VERB_MEDIUM
+#define MSG_VERB_MEDIUM ""
+#endif
+
+#ifndef MSG_VERB_HIGH
+#define MSG_VERB_HIGH ""
+#endif
+
+#ifndef MSG_VERB_FULL
+#define MSG_VERB_FULL ""
+#endif
+
+#ifndef MSG_VERB_DEBUG
+#define MSG_VERB_DEBUG ""
+#endif
+
+/** Msg header macro
+ *
+ * This macro provides a way to construct the header string using the above
+ * string constants. This is implementation specific.
+ */
+#ifndef MSG_HEADER
+#define MSG_HEADER(msg_type, verbosity)
+#endif
+
+/** Msg print macro
+ *
+ * The generic msg print APIs above are expected to call this underneath and
+ * provide a way to suppliment the msg being printed with a header. This is
+ * implementation specific.
+ */
+#ifndef MSG_PRINT
+#warning MSG_PRINT undefined: it will result in vacuous invocation
+#define MSG_PRINT(msg_header, fmt, ...)
+#endif
+
+#endif  // _MSG_H_

--- a/sw/util/msg_print.c
+++ b/sw/util/msg_print.c
@@ -1,0 +1,109 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "msg_print.h"
+
+#include <stdarg.h>
+
+static void _print_digit(void (*output)(char), unsigned int d) {
+  output("0123456789ABCDEF"[d]);
+}
+
+static void _print_hex(void (*output)(char), unsigned int byte) {
+  _print_digit(output, (byte >> 4) & 15);
+  _print_digit(output, byte & 15);
+}
+
+static void _print_num(void (*output)(char), int w, unsigned int n,
+                       unsigned int base) {
+  if (--w > 0 || n >= base) {
+    _print_num(output, w, n / base, base);
+  }
+  _print_digit(output, n % base);
+}
+
+void msg_print(void (*output)(char), const char *fmt, ...) {
+  char ch;
+  va_list va;
+
+  va_start(va, fmt);
+  while ((ch = *fmt) != '\0') {
+    ++fmt;
+    if (ch != '%') {
+      if (ch == '\n') {
+        output('\r');
+      }
+      output(ch);
+    } else {
+      int w = 0;
+      while ((ch = *fmt) != '\0') {
+        ++fmt;
+        if (ch >= '0' && ch <= '9') {
+          w = w * 10 + (ch - '0');
+          continue;
+        } else {
+          switch (ch) {
+            case '\0':
+            case '%': {
+              output('%');
+            } break;
+            case 'd': {
+              unsigned int n = va_arg(va, unsigned int);
+              if ((int)n < 0) {
+                output('-');
+                n = -n;
+              }
+              _print_num(output, w, n, 10);
+            } break;
+            case 'x':
+            case 'X': {
+              unsigned int n = va_arg(va, unsigned int);
+              if (ch == 'X') {
+                w = 8;
+                // TODO: fixme
+                // n = bswap(n);
+              }
+              _print_num(output, w, n, 16);
+            } break;
+            case 'u': {
+              unsigned int n = va_arg(va, unsigned int);
+              _print_num(output, w, n, 10);
+            } break;
+            case 's': {
+              const char *s = va_arg(va, const char *);
+              while (*s) {
+                output(*s++);
+              }
+            } break;
+            case 'c': {
+              char c = va_arg(va, int);
+              output(c);
+            } break;
+            case 'h': {  // little endian hex dump
+              int cnt = va_arg(va, int);
+              unsigned char *p = va_arg(va, unsigned char *);
+              while (cnt--) {
+                _print_hex(output, *p++);
+              }
+            } break;
+            case 'H': {  // big endian hex dump
+              int cnt = va_arg(va, int);
+              unsigned char *p = va_arg(va, unsigned char *);
+              p += cnt;
+              while (cnt--) {
+                _print_hex(output, *--p);
+              }
+            } break;
+            default: {  // unknown format
+              output('%');
+              output(ch);
+            } break;
+          }
+          break;
+        }
+      }
+    }
+  }
+  va_end(va);
+}

--- a/sw/util/msg_print.h
+++ b/sw/util/msg_print.h
@@ -1,0 +1,31 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef _MSG_PRINT_H_
+#define _MSG_PRINT_H_
+
+#include "common.h"
+
+/** Generic msg print function that takes variable # of args to print msgs via
+ * real hardware
+ *
+ * Function uses a formatted string as input with variable number of args.
+ * This function is used for real SW builds (not DV). This function takes a
+ * function pointer (which itself takes a single char arg as input) as an arg to
+ * print (write) the whole msg string char by char using the real HW IOs.
+ *
+ * To ensure portability of code across different platforms (DV simulations,
+ * FPGA based emulations with  production SW, simulations using Verilator,
+ * etc.), DO NOT CALL THIS FUNCTION DIRECTLY! Instead please use the generic msg
+ * print APIs defined in msg_api.h.
+ *
+ * @param output:     function pointer that takes single char input and 'prints'
+ *                    it via real HW such as UART.
+ * @param fmt:        actual formatted msg string (printf style)
+ * @param ...:        variable # of args passed to the formatted msg (NOTE: use
+ *                    of only integer-like type specifiers are recommended)
+ */
+void msg_print(void (*output)(char), const char *fmt, ...);
+
+#endif  // _MSG_PRINT_H_

--- a/sw/util/msg_uart/msg_impl.h
+++ b/sw/util/msg_uart/msg_impl.h
@@ -1,0 +1,73 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef _MSG_IMPL_H
+#define _MSG_IMPL_H
+
+#include "msg_print.h"
+#include "uart.h"
+
+#define _xstr(a) _str(a)
+#define _str(a) #a
+#define VA_ARGS(...) , ##__VA_ARGS__
+
+/** msg types
+ *
+ */
+#define MSG_TYPE_INFO "INFO"
+#define MSG_TYPE_WARNING "WARNING"
+#define MSG_TYPE_ERROR "ERROR"
+#define MSG_TYPE_FATAL "FATAL"
+
+/** set msg_header string with type, verbosity, file and line
+ *
+ * This macro sets the msg_header to
+ * TYPE[VERBOSITY] (file:line):
+ * or
+ * TYPE[VERBOSITY]: if MSG_HEADER_INCL_FILE_LINE flag is not set
+ */
+#ifdef MSG_HEADER_INCL_FILE_LINE
+#define MSG_HEADER(msg_type, verbosity) \
+  msg_type verbosity " (" __FILE__ ":" _xstr(__LINE__) "): "
+#else
+#define MSG_HEADER(msg_type, verbosity) msg_type verbosity ": "
+#endif
+
+/** print msgs via UART
+ *
+ * calls msg_print() function to process formatted string and insert args
+ * uses UART to pring msg string character by character
+ * Do not invoke this macro directly; use  the standard
+ */
+#define MSG_PRINT(msg_header, fmt, ...) \
+  msg_print(uart_send_char, msg_header fmt VA_ARGS(__VA_ARGS__));
+
+#define MSG_INFO(fmt, ...) \
+  MSG_PRINT(MSG_HEADER(MSG_TYPE_INFO, MSG_VERB_NONE), fmt, __VA_ARGS__)
+
+#define MSG_INFO_LOW(fmt, ...) \
+  MSG_PRINT(MSG_HEADER(MSG_TYPE_INFO, MSG_VERB_LOW), fmt, __VA_ARGS__)
+
+#define MSG_INFO_MEDIUM(fmt, ...) \
+  MSG_PRINT(MSG_HEADER(MSG_TYPE_INFO, MSG_VERB_MEDIUM), fmt, __VA_ARGS__)
+
+#define MSG_INFO_HIGH(fmt, ...) \
+  MSG_PRINT(MSG_HEADER(MSG_TYPE_INFO, MSG_VERB_HIGH), fmt, __VA_ARGS__)
+
+#define MSG_INFO_FULL(fmt, ...) \
+  MSG_PRINT(MSG_HEADER(MSG_TYPE_INFO, MSG_VERB_FULL), fmt, __VA_ARGS__)
+
+#define MSG_INFO_DEBUG(fmt, ...) \
+  MSG_PRINT(MSG_HEADER(MSG_TYPE_INFO, MSG_VERB_DEBUG), fmt, __VA_ARGS__)
+
+#define MSG_WARNING(fmt, ...) \
+  MSG_PRINT(MSG_HEADER(MSG_TYPE_WARNING, ""), fmt, __VA_ARGS__)
+
+#define MSG_ERROR(fmt, ...) \
+  MSG_PRINT(MSG_HEADER(MSG_TYPE_ERROR, ""), fmt, __VA_ARGS__)
+
+#define MSG_FATAL(fmt, ...) \
+  MSG_PRINT(MSG_HEADER(MSG_TYPE_FATAL, ""), fmt, __VA_ARGS__)
+
+#endif  // _MSG_IMPL_H

--- a/sw/util/srcs.mk
+++ b/sw/util/srcs.mk
@@ -1,0 +1,11 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+UTIL_DIR            ?= $(SW_ROOT_DIR)/util
+MSG_FLOW_DIR        ?= $(UTIL_DIR)/msg_$(MSG_FLOW)
+INCS                += -I$(UTIL_DIR) -I$(MSG_FLOW_DIR)
+
+LIB_UTIL_LOC_SRCS   += msg_print.c
+
+LIB_SRCS            += $(addprefix $(UTIL_DIR)/, $(LIB_UTIL_LOC_SRCS))


### PR DESCRIPTION
- provide a generic set of APIs to print msgs
- provide ability to attach severity (msg type) and verbosity to msgs
- provide ability to attach a header to the msg underneath
  - privide ability to construct the header based on severity, verbosity
    file and line number for ease of debug

- provide a generic msg_print() function that can parse a formatted string and
take variable number of args

- provide implementation specific APIs in
sw/util/msg_uart/msg_api_impl.h to do the prints via UART

- PR #259 is being split into 2 parts to make the review easier
- this PR focuses on providing a high level API and 'typical' SW
implementation of it using UART
- Subsequent PR will focus on DV specific implementation