### PR TITLE
Remove named todos

### DIFF
--- a/hw/dv/sv/common_ifs/clk_rst_if.sv
+++ b/hw/dv/sv/common_ifs/clk_rst_if.sv
@@ -142,7 +142,7 @@ interface clk_rst_if #(
   endfunction
 
   // apply reset with specified scheme
-  // TODO(sriyerg) make this enum?
+  // TODO make this enum?
   // rst_n_scheme
   // 0 - fullly synchronous reset - it is asserted and deasserted on clock edges
   // 1 - async assert, sync dessert (default)

--- a/hw/dv/sv/csr_utils/csr_excl_item.sv
+++ b/hw/dv/sv/csr_utils/csr_excl_item.sv
@@ -44,7 +44,7 @@ class csr_excl_item extends uvm_object;
       blk = csr.get_parent();
       if (has_excl(blk.`gfn, csr_excl_type)) return 1'b1;
     end
-    // TODO(sriyerg): check if any parent in the hierarchy above is excluded
+    // TODO: check if any parent in the hierarchy above is excluded
     // check if obj is excluded
     return (has_excl(obj.`gfn, csr_excl_type));
   endfunction

--- a/hw/dv/sv/csr_utils/csr_seq_lib.sv
+++ b/hw/dv/sv/csr_utils/csr_seq_lib.sv
@@ -74,7 +74,7 @@ class csr_base_seq extends uvm_reg_sequence #(uvm_sequence #(uvm_reg_item));
     int   chunk_size;
 
     // extract all csrs from the model
-    // TODO(sriyerg): add and use function here instead that allows pre filtering csrs
+    // TODO: add and use function here instead that allows pre filtering csrs
     all_csrs.delete();
     foreach (models[i]) begin
       models[i].get_registers(all_csrs);

--- a/hw/dv/sv/dv_lib/dv_base_test.sv
+++ b/hw/dv/sv/dv_lib/dv_base_test.sv
@@ -51,7 +51,7 @@ class dv_base_test #(type CFG_T = dv_base_env_cfg,
     if (run_test_seq) begin
       run_seq(test_seq_s, phase);
     end
-    // TODO(sriyerg): add hook for end of test checking
+    // TODO: add hook for end of test checking
   endtask : run_phase
 
   virtual task run_seq(string test_seq_s, uvm_phase phase);
@@ -69,7 +69,7 @@ class dv_base_test #(type CFG_T = dv_base_env_cfg,
     `uvm_info(`gfn, {"finished vseq ", test_seq_s}, UVM_MEDIUM)
   endtask
 
-  // TODO(sriyerg): add default report_phase implementation
+  // TODO: add default report_phase implementation
 
 endclass : dv_base_test
 

--- a/hw/dv/sv/tl_agent/tl_monitor.sv
+++ b/hw/dv/sv/tl_agent/tl_monitor.sv
@@ -6,7 +6,7 @@
 // ---------------------------------------------
 // TileLink interface monitor
 // ---------------------------------------------
-// TODO(taliu): Implement protocl check in the monitor
+// TODO: Implement protocl check in the monitor
 
 class tl_monitor extends uvm_monitor;
 

--- a/hw/formal/fpv.tcl
+++ b/hw/formal/fpv.tcl
@@ -105,7 +105,7 @@ assume -from_assert -remove_original {sram2tlul.validNotReady*}
 assume -from_assert -remove_original -regexp {^\w*\.scanmodeKnown}
 
 #-------------------------------------------------------------------------
-# TODO(cindychip): eventually remove below assert disable lines
+# TODO: eventually remove below assert disable lines
 # To reduce prohibitive runtimes, below assertions are simply turned off for now
 #-------------------------------------------------------------------------
 

--- a/hw/ip/rv_core_ibex/dv/tb/core_ibex_tb_top.sv
+++ b/hw/ip/rv_core_ibex/dv/tb/core_ibex_tb_top.sv
@@ -14,7 +14,7 @@ module core_ibex_tb_top;
 
   clk_if ibex_clk_if(.clk(clk));
 
-  // TODO(taliu) Resolve the tied-off ports
+  // TODO Resolve the tied-off ports
   // The interrupt and debug interface ports might be changed to RISC-V compliant interface, these
   // interfaces will be connected after design is ready.
   rv_core_ibex dut(

--- a/hw/ip/rv_core_ibex/dv/tests/core_ibex_base_test.sv
+++ b/hw/ip/rv_core_ibex/dv/tests/core_ibex_base_test.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// TODO(taliu) extend this class with the common base test
+// TODO extend this class with the common base test
 class core_ibex_base_test extends uvm_test;
 
   core_ibex_env                   env;
@@ -73,7 +73,7 @@ class core_ibex_base_test extends uvm_test;
   endfunction
 
   virtual task wait_for_test_done();
-    // TODO(taliu): We need a consistent approach to determine the test is completed for both
+    // TODO: We need a consistent approach to determine the test is completed for both
     // random instruction test and firmware based test. For example, it could be done by writing to
     // a specific memory location of the test signature. Right now the random instruction generator
     // use ecall instruction to indicate the end of the program. It could be changed to align with

--- a/hw/ip/trial1/rtl/trial1_reg_top.sv
+++ b/hw/ip/trial1/rtl/trial1_reg_top.sv
@@ -48,7 +48,7 @@ module trial1_reg_top (
   assign tl_reg_h2d = tl_i;
   assign tl_o       = tl_reg_d2h;
 
-  // TODO(eunchan): Fix it after bus interface is finalized
+  // TODO: Fix it after bus interface is finalized
   assign reg_we = tl_reg_h2d.a_valid && tl_reg_d2h.a_ready &&
                   ((tl_reg_h2d.a_opcode == tlul_pkg::PutFullData) ||
                    (tl_reg_h2d.a_opcode == tlul_pkg::PutPartialData));
@@ -89,8 +89,8 @@ module trial1_reg_top (
       end
     end
   end
-  // TODO(eunchan): Revise Register Interface logic after REG INTF finalized
-  // TODO(eunchan): Make concrete scenario
+  // TODO: Revise Register Interface logic after REG INTF finalized
+  // TODO: Make concrete scenario
   //    1. Write: No response, so that it can guarantee a request completes a clock after we
   //              It means, bus_reg_ready doesn't have to be lowered.
   //    2. Read: response. So bus_reg_ready should assert after reg_bus_valid & reg_bus_ready

--- a/hw/ip/usbdev/rtl/usbdev_reg_top.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_top.sv
@@ -93,7 +93,7 @@ module usbdev_reg_top (
     end
   end
 
-  // TODO(eunchan): Fix it after bus interface is finalized
+  // TODO: Fix it after bus interface is finalized
   assign reg_we = tl_reg_h2d.a_valid && tl_reg_d2h.a_ready &&
                   ((tl_reg_h2d.a_opcode == tlul_pkg::PutFullData) ||
                    (tl_reg_h2d.a_opcode == tlul_pkg::PutPartialData));
@@ -134,8 +134,8 @@ module usbdev_reg_top (
       end
     end
   end
-  // TODO(eunchan): Revise Register Interface logic after REG INTF finalized
-  // TODO(eunchan): Make concrete scenario
+  // TODO: Revise Register Interface logic after REG INTF finalized
+  // TODO: Make concrete scenario
   //    1. Write: No response, so that it can guarantee a request completes a clock after we
   //              It means, bus_reg_ready doesn't have to be lowered.
   //    2. Read: response. So bus_reg_ready should assert after reg_bus_valid & reg_bus_ready

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -44,7 +44,7 @@ class chip_base_vseq extends dv_base_vseq #(
   endtask
 
   // routine to backdoor load cpu test hex image and bring the cpu out of reset (if required)
-  // TODO(sriyerg): for future implementation
+  // TODO: for future implementation
   virtual task cpu_init();
     cfg.mem_bkdr_vifs[Rom].load_mem_from_file(cfg.rom_image);
     cfg.mem_bkdr_vifs[FlashBank0].set_mem();
@@ -74,7 +74,7 @@ class chip_base_vseq extends dv_base_vseq #(
   endtask : body
 
   // maintain a specific memory location for cpu test status
-  // TODO(sriyerg): using gpio for now - need to use mem loc instead
+  // TODO: using gpio for now - need to use mem loc instead
   // TODO: need to more cpu monitoring logic to separate uvm component
   virtual task monitor_cpu_state();
     fork
@@ -113,7 +113,7 @@ class chip_base_vseq extends dv_base_vseq #(
         fork
           begin: timeout_thread
             #(timeout_ns * 1ns);
-            // TODO(sriyerg): uncomment after c framework is in place
+            // TODO: uncomment after c framework is in place
             // `uvm_fatal(`gfn, $sformatf("timeout occurred - in cpu test state %0s",
             //                             cpu_test_state.name()))
           end: timeout_thread

--- a/sw/lib/usbdev.c
+++ b/sw/lib/usbdev.c
@@ -146,7 +146,7 @@ void usbdev_poll(usbdev_ctx_t *ctx) {
         istate & ~((1 << USBDEV_INTR_STATE_PKT_RECEIVED) |
                    (1 << USBDEV_INTR_STATE_PKT_SENT));
   }
-  // TODO(mdhayter) - clean this up
+  // TODO - clean this up
   // Frame ticks every 1ms, use to flush data every 16ms
   // (faster in DPI but this seems to work ok)
   // At reset frame count is 0, compare to 1 so no calls before SOF received
@@ -163,7 +163,7 @@ void usbdev_poll(usbdev_ctx_t *ctx) {
   } else {
     ctx->flushed = 0;
   }
-  // TODO(mdhater) Errors? What Errors?
+  // TODO Errors? What Errors?
 }
 
 void usbdev_set_deviceid(usbdev_ctx_t *ctx, int deviceid) {

--- a/sw/lib/usbdev.h
+++ b/sw/lib/usbdev.h
@@ -66,7 +66,7 @@ uint32_t *usbdev_buf_idtoaddr(usbdev_ctx_t *ctx, usbbufid_t buf);
  * Copy from memory into a buffer, referencing by buffer ID
  *
  * Implementation restriction: from must be 4-byte aligned
- * TODO(mdhayer) remove restriction
+ * TODO remove restriction
  *
  * @param ctx usbdev context pointer
  * @param buf buffer ID to copy to

--- a/util/build_docs.py
+++ b/util/build_docs.py
@@ -38,7 +38,7 @@ STATIC_ASSET_EXTENSIONS = [
 HJSON_EXTENSIONS = ['.hjson']
 
 # Configurations
-# TODO(eunchan): Move to config.yaml
+# TODO: Move to config.yaml
 SRCTREE_TOP = Path(__file__).parent.joinpath('..').resolve()
 config = {
     # Toplevel source directory

--- a/util/reggen/gen_rtl.py
+++ b/util/reggen/gen_rtl.py
@@ -97,7 +97,7 @@ def parse_reg(obj):
                 reg.fields.append(field)
                 reg.width = max(reg.width, field.msb + 1)
 
-        # TODO(eunchan): Field bitfield overlapping check
+        # TODO: Field bitfield overlapping check
         log.info("R[0x%04x]: %s ", reg.offset, reg.name)
         for f in reg.fields:
             log.info("  F[%2d:%2d]: %s", f.msb, f.lsb, f.name)


### PR DESCRIPTION
Following the discussion in #345 this commit removes the names from the TODO lines.
I created one commit for each, @sriyerg @taoliug @cindychip @eunchan @mdhayter, so each can easily check if there is a need for an issue for the TODO.
After each has approved the PR I will rebase the commit so only one commit will go in.