### PR TITLE
[reggen] Add 3 byte writes to r.width >= 16 < 24

### DIFF
--- a/hw/ip/alert_handler/rtl/alert_handler_reg_pkg.sv
+++ b/hw/ip/alert_handler/rtl/alert_handler_reg_pkg.sv
@@ -543,7 +543,7 @@ typedef struct packed {
     4'b 0001, // index[ 1] ALERT_HANDLER_INTR_ENABLE
     4'b 0001, // index[ 2] ALERT_HANDLER_INTR_TEST
     4'b 0001, // index[ 3] ALERT_HANDLER_REGEN
-    4'b 1111, // index[ 4] ALERT_HANDLER_PING_TIMEOUT_CYC
+    4'b 0111, // index[ 4] ALERT_HANDLER_PING_TIMEOUT_CYC
     4'b 0001, // index[ 5] ALERT_HANDLER_ALERT_EN
     4'b 0001, // index[ 6] ALERT_HANDLER_ALERT_CLASS
     4'b 0001, // index[ 7] ALERT_HANDLER_ALERT_CAUSE

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
@@ -302,7 +302,7 @@ typedef struct packed {
     4'b 0001, // index[15] FLASH_CTRL_BANK_CFG_REGWEN
     4'b 0001, // index[16] FLASH_CTRL_MP_BANK_CFG
     4'b 0001, // index[17] FLASH_CTRL_OP_STATUS
-    4'b 1111, // index[18] FLASH_CTRL_STATUS
+    4'b 0111, // index[18] FLASH_CTRL_STATUS
     4'b 1111, // index[19] FLASH_CTRL_SCRATCH
     4'b 0011  // index[20] FLASH_CTRL_FIFO_LVL
   };

--- a/hw/ip/padctrl/rtl/padctrl_reg_pkg.sv
+++ b/hw/ip/padctrl/rtl/padctrl_reg_pkg.sv
@@ -59,11 +59,11 @@ typedef struct packed {
   // Register width information to check illegal writes
   localparam logic [3:0] PADCTRL_PERMIT [6] = '{
     4'b 0001, // index[0] PADCTRL_REGEN
-    4'b 1111, // index[1] PADCTRL_DIO_PADS
+    4'b 0111, // index[1] PADCTRL_DIO_PADS
     4'b 1111, // index[2] PADCTRL_MIO_PADS0
     4'b 1111, // index[3] PADCTRL_MIO_PADS1
     4'b 1111, // index[4] PADCTRL_MIO_PADS2
-    4'b 1111  // index[5] PADCTRL_MIO_PADS3
+    4'b 0111  // index[5] PADCTRL_MIO_PADS3
   };
 endpackage
 

--- a/hw/ip/rv_timer/rtl/rv_timer_reg_pkg.sv
+++ b/hw/ip/rv_timer/rtl/rv_timer_reg_pkg.sv
@@ -108,7 +108,7 @@ typedef struct packed {
   // Register width information to check illegal writes
   localparam logic [3:0] RV_TIMER_PERMIT [9] = '{
     4'b 0001, // index[0] RV_TIMER_CTRL
-    4'b 1111, // index[1] RV_TIMER_CFG0
+    4'b 0111, // index[1] RV_TIMER_CFG0
     4'b 1111, // index[2] RV_TIMER_TIMER_V_LOWER0
     4'b 1111, // index[3] RV_TIMER_TIMER_V_UPPER0
     4'b 1111, // index[4] RV_TIMER_COMPARE_LOWER0_0

--- a/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
@@ -256,10 +256,10 @@ typedef struct packed {
     4'b 0001, // index[ 0] SPI_DEVICE_INTR_STATE
     4'b 0001, // index[ 1] SPI_DEVICE_INTR_ENABLE
     4'b 0001, // index[ 2] SPI_DEVICE_INTR_TEST
-    4'b 1111, // index[ 3] SPI_DEVICE_CONTROL
+    4'b 0111, // index[ 3] SPI_DEVICE_CONTROL
     4'b 0011, // index[ 4] SPI_DEVICE_CFG
     4'b 1111, // index[ 5] SPI_DEVICE_FIFO_LEVEL
-    4'b 1111, // index[ 6] SPI_DEVICE_ASYNC_FIFO_LEVEL
+    4'b 0111, // index[ 6] SPI_DEVICE_ASYNC_FIFO_LEVEL
     4'b 0001, // index[ 7] SPI_DEVICE_STATUS
     4'b 1111, // index[ 8] SPI_DEVICE_RXF_PTR
     4'b 1111, // index[ 9] SPI_DEVICE_TXF_PTR

--- a/hw/ip/uart/rtl/uart_reg_pkg.sv
+++ b/hw/ip/uart/rtl/uart_reg_pkg.sv
@@ -322,7 +322,7 @@ typedef struct packed {
     4'b 0001, // index[ 5] UART_RDATA
     4'b 0001, // index[ 6] UART_WDATA
     4'b 0001, // index[ 7] UART_FIFO_CTRL
-    4'b 1111, // index[ 8] UART_FIFO_STATUS
+    4'b 0111, // index[ 8] UART_FIFO_STATUS
     4'b 0001, // index[ 9] UART_OVRD
     4'b 0011, // index[10] UART_VAL
     4'b 1111  // index[11] UART_TIMEOUT_CTRL

--- a/hw/ip/usbuart/rtl/usbuart_reg_pkg.sv
+++ b/hw/ip/usbuart/rtl/usbuart_reg_pkg.sv
@@ -330,12 +330,12 @@ typedef struct packed {
     4'b 0001, // index[ 5] USBUART_RDATA
     4'b 0001, // index[ 6] USBUART_WDATA
     4'b 0001, // index[ 7] USBUART_FIFO_CTRL
-    4'b 1111, // index[ 8] USBUART_FIFO_STATUS
+    4'b 0111, // index[ 8] USBUART_FIFO_STATUS
     4'b 0001, // index[ 9] USBUART_OVRD
     4'b 0011, // index[10] USBUART_VAL
     4'b 1111, // index[11] USBUART_TIMEOUT_CTRL
-    4'b 1111, // index[12] USBUART_USBSTAT
-    4'b 1111  // index[13] USBUART_USBPARAM
+    4'b 0111, // index[12] USBUART_USBSTAT
+    4'b 0111  // index[13] USBUART_USBPARAM
   };
 endpackage
 

--- a/hw/top_earlgrey/rtl/rv_plic_reg_pkg.sv
+++ b/hw/top_earlgrey/rtl/rv_plic_reg_pkg.sv
@@ -355,9 +355,9 @@ typedef struct packed {
   // Register width information to check illegal writes
   localparam logic [3:0] RV_PLIC_PERMIT [63] = '{
     4'b 1111, // index[ 0] RV_PLIC_IP0
-    4'b 1111, // index[ 1] RV_PLIC_IP1
+    4'b 0111, // index[ 1] RV_PLIC_IP1
     4'b 1111, // index[ 2] RV_PLIC_LE0
-    4'b 1111, // index[ 3] RV_PLIC_LE1
+    4'b 0111, // index[ 3] RV_PLIC_LE1
     4'b 0001, // index[ 4] RV_PLIC_PRIO0
     4'b 0001, // index[ 5] RV_PLIC_PRIO1
     4'b 0001, // index[ 6] RV_PLIC_PRIO2
@@ -413,7 +413,7 @@ typedef struct packed {
     4'b 0001, // index[56] RV_PLIC_PRIO52
     4'b 0001, // index[57] RV_PLIC_PRIO53
     4'b 1111, // index[58] RV_PLIC_IE00
-    4'b 1111, // index[59] RV_PLIC_IE01
+    4'b 0111, // index[59] RV_PLIC_IE01
     4'b 0001, // index[60] RV_PLIC_THRESHOLD0
     4'b 0001, // index[61] RV_PLIC_CC0
     4'b 0001  // index[62] RV_PLIC_MSIP0

--- a/util/reggen/reg_pkg.tpl.sv
+++ b/util/reggen/reg_pkg.tpl.sv
@@ -207,8 +207,10 @@ typedef struct packed {
   localparam logic [3:0] ${block.name.upper()}_PERMIT [${block.get_n_regs_flat()}] = '{
 % for i,r in enumerate(block.get_regs_flat()):
 <% index_str = "{}".format(i).rjust(max_regs_char) %>\
-  % if r.width > 16:
+  % if r.width > 24:
     4'b 1111${" " if i == num_regs-1 else ","} // index[${index_str}] ${block.name.upper()}_${r.name.upper()}
+  % elif r.width > 16:
+    4'b 0111${" " if i == num_regs-1 else ","} // index[${index_str}] ${block.name.upper()}_${r.name.upper()}
   % elif r.width > 8:
     4'b 0011${" " if i == num_regs-1 else ","} // index[${index_str}] ${block.name.upper()}_${r.name.upper()}
   % else:


### PR DESCRIPTION
This is related to #236.

Even Ibex doesn't support 3 byte write, reggen shouldn't care. Now it
supports 3byte writes (4'b0111).

CC: @cindychip 