### PR TITLE
[site] Site serving skeleton and scripts

### DIFF
--- a/site/landing/.gitignore
+++ b/site/landing/.gitignore
@@ -1,0 +1,2 @@
+public/
+resources/

--- a/site/landing/README.md
+++ b/site/landing/README.md
@@ -1,0 +1,22 @@
+# Site Infrastructure
+This directory contains the scripts and configuration required to update the [opentitan.org][ot] public-facing website.
+
+# Dependencies
+These scripts require that you have [hugo][install-hugo] and [gcloud][install-gcloud] installed and that your gcloud is configured with the correct GCP project.
+The production site project can be selected with:
+
+```
+gcloud config set project gold-hybrid-255313
+```
+
+# Serving Locally
+To serve the site locally run the `serve.sh` script, which will build and serve the site on [localhost:1313](http://localhost:1313), automatically rebuilding pages when they are changed.
+
+# Deploying
+To deploy the site use the `deploy.sh` script.
+Specify the environment (either `public` or `staging`) as the first argument to choose between the two environments.
+The script takes care of flushing the CDN cache to make sure changes are visible as quickly as possible.
+
+[install-gcloud]: https://cloud.google.com/sdk/install
+[install-hugo]: https://github.com/gohugoio/hugo#choose-how-to-install
+[ot]: https://opentitan.org

--- a/site/landing/config.toml
+++ b/site/landing/config.toml
@@ -1,0 +1,12 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+[[deployment.targets]]
+name = "staging"
+URL = "gs://gold-hybrid-255313-staging"
+
+[[deployment.targets]]
+name = "public"
+URL = "gs://gold-hybrid-255313"
+googleCloudCDNOrigin = "opentitan-dot-org"

--- a/site/landing/deploy.sh
+++ b/site/landing/deploy.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+TARGET=$1
+
+case "${TARGET}" in
+  "public" | "staging")
+    ;;
+
+  *)
+    echo "You must specify either \"public\" or \"staging\""
+    exit 1
+    ;;
+esac
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd $DIR
+rm -rf public
+
+hugo --minify
+hugo deploy --target "${TARGET}" --confirm --verbose --maxDeletes -1
+
+if [ "${TARGET}" = "public" ]; then
+  # TODO: The ability to invalidate a Cloud CDN cache is pending in upstream
+  # hugo.  Once it's landed this can be rolled into the hugo configuration.
+  gcloud compute url-maps invalidate-cdn-cache "opentitan-dot-org" --path="/*" \
+    --async
+fi

--- a/site/landing/redirector/Dockerfile
+++ b/site/landing/redirector/Dockerfile
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+FROM nginx
+
+RUN rm /etc/nginx/conf.d/default.conf
+COPY redirector.conf /etc/nginx/conf.d/

--- a/site/landing/redirector/README.md
+++ b/site/landing/redirector/README.md
@@ -1,0 +1,9 @@
+# `redirector`
+The redirector container is a minimal nginx deployment that is responsible for upgrading HTTP connections to HTTPS via a redirect and for redirecting requests to the top-level domain if they arrive on a subdomain (like www).
+
+# Deploying
+To rebuild and deploy the redirector instance group use the `deploy-public.sh` script.
+Note that it can take a while for the instance group to catch up with the update, and then up to twelve hours for the CDN cache to expire.
+We cannot invalidate the CDN immediately after issuing the rolling-update request to the instance group because the operation will take time to complete.
+
+If you need to do a faster push: wait until the rolling restart is complete and manually invalidate the CDN.

--- a/site/landing/redirector/deploy-public.sh
+++ b/site/landing/redirector/deploy-public.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+gcloud builds submit --tag gcr.io/gold-hybrid-255313/redirector .
+gcloud compute instance-groups managed rolling-action replace \
+  --max-surge=3 --max-unavailable=1 --region=us-central1 \
+  opentitan-dot-org-redirector

--- a/site/landing/redirector/redirector.conf
+++ b/site/landing/redirector/redirector.conf
@@ -1,0 +1,16 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+server {
+  listen 80;
+  server_name opentitan.org www.opentitan.org;
+  add_header Cache-Control "public, max-age=21600";
+  return 301 https://opentitan.org$request_uri;
+}
+
+server {
+  listen 80 default_server;
+  server_name _;
+  return 444;
+}

--- a/site/landing/serve.sh
+++ b/site/landing/serve.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+hugo --minify -D server


### PR DESCRIPTION
Add a skeleton hugo configuration that contains deployment targets for
updating the public and staging websites.  Also add the docker source
and scripts for updating the redirector container, which is responsible
for moving incoming HTTP requests to HTTPS.