### PR TITLE
[tlul] Add inactive lane mask checker for Get

### DIFF
--- a/hw/ip/tlul/rtl/tlul_err.sv
+++ b/hw/ip/tlul/rtl/tlul_err.sv
@@ -83,7 +83,7 @@ module tlul_err import tlul_pkg::*; (
   end
 
   assign a_config_allowed = addr_sz_chk
-                          & (op_get | mask_chk)
+                          & mask_chk
                           & (op_get | op_partial | fulldata_chk) ;
 
   // Only 32 bit data width for current tlul_err


### PR DESCRIPTION
Get also requires to conform `a_mask` inactive lane to be 0.
Now, the condition for Get is also added

CC: @weicaiyang 