### PR TITLE
[doc] document HW stages, update references

### DIFF
--- a/doc/ug/design.md
+++ b/doc/ug/design.md
@@ -5,7 +5,7 @@ When in conflict, quality must win, and thus we aim to create a final design pro
 
 ## Language and Tool Selection
 
-Starting with the language, the strategy is to use the SystemVerilog language, restricted to a feature set described by our
+Starting with the language, the strategy is to use the SystemVerilog language, restricted to a feature set described by the lowRISC
 [Verilog Style Guide](https://github.com/lowRISC/style-guides/blob/master/VerilogCodingStyle.md).
 All IP should be developed and delivered under the feature set described by this style guide.
 Inconsistencies or lack of clarity within the style guide should be solved by filing and helping close an issue on the style guide in the
@@ -13,7 +13,7 @@ Inconsistencies or lack of clarity within the style guide should be solved by fi
 
 For professional tooling, the team has chosen several industry-grade tools for its design signoff process.
 Wherever possible we attempt to remain tool-agnostic, but we must choose a selection of tools as our ground truth for our own confidence of signoff-level assurances.
-As a project we promote other open source methodologies and work towards a future where these are signoff-grade.
+As a project we promote other open source methodologies and work towards a future where these are signoff-grade as well.
 The discussions on how the design tools are used and which ones are chosen are given below in separate sections.
 
 ## Comportability and the Importance of Architectural Conformity
@@ -28,35 +28,37 @@ TODO: briefly discuss key architectural decisions, and how we came to the conclu
 *   Bus strategy
 *   Reset strategy
 
-## Defining Design Complete: milestones and tracking
+## Defining Design Complete: stages and tracking
 
 Designs within the OpenTitan project come in a variety of completion status levels.
-Some designs are “tapeout ready” while others are still a work in progress.
+Some designs are "tapeout ready" while others are still a work in progress.
 Understanding the status of a design is important to gauge the confidence in its advertised feature set.
-To that end, we’ve designated a spectrum of design milestones in the *OpenTitan IP project tracking* &lt;Coming Soon&rt; document.
-This document defines the design milestones and references where one can find the current status of each of the designs in the repository.
+To that end, we've designated a spectrum of design stages in the [OpenTitan Hardware Development Stages](hw_stages.md) document.
+This document defines the design stages and references where one can find the current status of each of the designs in the repository.
 
 ## Documentation
 
 Documentation is a critical part of any design methodology.
 Within the OpenTitan project there are two important tooling components to efficient and effective documentation.
+
 The first is the [docgen](../../util/docgen/README.md) tool, which converts an annotated markdown file into a rendered HTML file (including this document).
 See the linked docgen specification for information about the annotations and how to use it to create enhanced auto-generated additions to standard Markdown files.
+
 The second is the [reggen](../rm/register_tool.md) register tool that helps define the methodology and description language for specifying hardware registers.
 These descriptions are fed into docgen through annotations and ensure that the technical specifications for the IP are accurate and up to date with the hardware being built.
 
 Underlying and critical to this tooling is the human-written content that goes into the source markdown and register descriptions.
-Clarity and consistency is key, and we will add guidelines for technical specification documentation flow. (TODO).
+Clarity and consistency is key.
+See the [Markdown Style Guide](../rm/markdown_usage_style.md) for details and guidelines on the description language.
 
 ## Usage of Register Tool
 
 One design element that is prime for consistent definitions and usages is in the area of register definitions.
-Registers are critical, being at the intersection of hardware and software, where uniformity can reduce confusion and increase reusability.
-The [register tool](../rm/register_tool.md) used within OpenTitan is custom for the project’s needs, but flexible to add new features as they arise.
+Registers are critical, being at the intersection of hardware and software, where uniformity can reduce confusion and increase re-usability.
+The [register tool](../rm/register_tool.md) used within OpenTitan is custom for the project's needs, but flexible to add new features as they arise.
 It attempts to stay lightweight yet solve most of the needs in this space.
 The description language (using HJSON format) described within that specification also details other features described in the
 [Comportability Specification](../rm/comportability_specification.md).
-See those two specifications as well as the [Markdown Style Guide](../rm/markdown_usage_style.md) for details on the tool and the description language.
 
 ## Linting Methodology
 
@@ -68,7 +70,7 @@ Running lint is faster than running a simulation.
 The tool [AscentLint](https://www.realintent.com/rtl-linting-ascent-lint) from the company Real Intent was chosen for this project.
 It has the benefit of fast execution times, and provides a list of concise lint errors and warnings.
 It is understandable that not all partner members will have access to this tool.
-The project will use AscentLint as its linting sign-off tool, and results will be shared in some form through continuous integration build results, published tool outputs, pre-submit checks, and/or linting summaries of tool output (final decision TBD).
+The project will use AscentLint as its linting sign-off tool, and results will be shared in some form through continuous integration build results, published tool outputs, pre-submit checks, and/or linting summaries of tool output (TODO: publication details).
 For partners without access to this tool, the recommendation is to run their code through whatever linting tool they have available at their disposal before creating a design Pull Request, then work with the maintainers of the linting sign-off methodology to close linting errors.
 (TODO: decide on available pre-submit linting options).
 Linting errors and warnings can be closed by fixing the code in question (preferred), or waiving the error.
@@ -77,15 +79,15 @@ Due to the proprietary nature of this particular linting tool, content towards r
 In the current state of the project, all lint scripts, policy files, and waivers are **not** provided, but are being kept privately until we can suggest a workable open source solution.
 When this methodology is finalized the details will be given here. (TODO)
 See the [Linting README](../../hw/lint/README.md) for details on how the tool is being run internally.
-This shows the methodology that we are aiming to release in a fully open manner, but for now is being run, with results shared among partner members.
+This shows the methodology that we are aiming to release in a fully open manner, but for now is being run internally, with results shared among partner members.
 
-Goals for linting closure per design milestone are given in the *OpenTitan IP project tracking* &lt;Coming Soon&gt; document.
+Goals for linting closure per design milestone are given in the [OpenTitan Development Stages](hw_stages.md) document.
 
 ## Assertion Methodology
 
 The creation and maintenance of assertions within RTL design code is an essential way to get feedback if a design is being used improperly.
-Common examples include asserting that a full FIFO should never be written to, a state machine doesn’t receive an input while in a particular state, or two signals should remain mutually exclusive.
-Usually these will eventually result in a downstream error (incorrect data, bus collisions, etc) but early feedback at the first point of inconsistency gives designers and verifiers alike fast access to easier debug.
+Common examples include asserting that a full FIFO should never be written to, a state machine doesn't receive an input while in a particular state, or two signals should remain mutually exclusive.
+Often these will eventually result in a downstream error (incorrect data, bus collisions, etc.), but early feedback at the first point of inconsistency gives designers and verifiers alike fast access to easier debug.
 
 Within OpenTitan we attempt to maintain uniformity in assertion style and syntax using SystemVerilog Assertions and a list of common macros.
 An overview of the included macros and how to use them is given in this
@@ -97,27 +99,27 @@ from the company Cadence.
 ## CDC Methodology
 
 Logic designs that have signals that cross from one clock domain to another unrelated clock domain are notorious for introducing hard to debug problems.
-The reason is that design verification, with its constant and unrealistic timing relationships on signals, does not represent the variability and uncertainty of real world systems.
-For this reason, maintaining a robust Clock Domain Crossing verification strategy ("CDC methodology") is critical to the success of any mutli-clock design.
+The reason is that design verification, with its constant and idealized timing relationships on signals, does not represent the variability and uncertainty of real world systems.
+For this reason, maintaining a robust Clock Domain Crossing verification strategy ("CDC methodology") is critical to the success of any multi-clock design.
 
 Our general strategy is threefold:
 maintain a list of proven domain crossing submodules;
 enforce the usage of these submodules;
 use a production-worthy tool to check all signals within the design conform to correct crossing rules.
-This *CDC Methodology document* &lt;Coming Soon&gt; gives details on the submodules, discusses the tool chosen and how to run it, and explains more rationale for the designs chosen.
+The *CDC Methodology document* (TODO:Coming Soon) gives details on the submodules and explains more rationale for the designs chosen.
 
 The tool chosen for this program is
 [Meridian]([https://www.realintent.com/clock-domain-crossing-meridian-cdc](https://www.realintent.com/clock-domain-crossing-meridian-cdc))
 from RealIntent.
 It is a sign-off-grade CDC checking tool that provides the features needed for CDC assurance.
 It is understandable that not all partner members will have access to this tool.
-The project will use it as its sign-off tool, and results will be shared in some form (final decision TBD).
+The project will use it as its sign-off tool, and results will be shared in some form (TODO: final decision).
 CDC checking errors can be closed by fixing the code in question (preferred), or waiving the error.
-All CDC waivers will be reviewed as part of the Pull Request review process.
-See the *CDC README* &lt;Coming Soon&gt; for details on how to run the tool if you have a Meridian license.
+CDC waivers should be reviewed as part of the Pull Request review process.
+See the *CDC README* (TODO:Coming Soon) for details on how to run the tool if you have a Meridian license.
 
 Similar to the linting tool, due to the proprietary nature of the CDC tool, some content towards running the tool can not be checked in in an open source repository.
-For those items, the tool provider will be giving us a method to check in encrypted content that still allows for full functionality without exposing their tool’s feature set.
+For those items, the tool provider will be giving us a method to check in encrypted content that still allows for full functionality without exposing their tool's feature set.
 When this methodology is finalized the details will be given here. (TODO)
 
 ## DFT
@@ -157,9 +159,9 @@ Until that time, all generated files (see for example the output files from the
 [register generation tool](../rm/register_tool.md))
 are checked in.
 There is a master build file in the repository under `hw/Makefile` that builds all of the `regtool` content.
-This is used by an Azure Pipelines presubmit check script to ensure that the source files produce a generated file that is identical to the one being submitted.
+This is used by an Azure Pipelines pre-submit check script to ensure that the source files produce a generated file that is identical to the one being submitted.
 
 ## Getting Started with a Design
 
 The process for getting started with a design involves many steps, including getting clarity on its purpose, its feature set, ownership assignments, documentation, etc.
-These are discussed in the *Getting Started with a Design* &lt;Coming Soon&gt; document that is still being developed.
+These are discussed in the *Getting Started with a Design* (TODO) document that is still being developed.

--- a/doc/ug/hw_stages.md
+++ b/doc/ug/hw_stages.md
@@ -1,0 +1,176 @@
+# OpenTitan Hardware Development Stages
+
+## Document Goals
+
+This document describes development stages for hardware within the OpenTitan program.
+This includes design and verification stages meant to give a high-level view of the status of a design.
+OpenTitan being an open-source program aimed at a high quality silicon release, the intent is to find a balance between the rigor of a heavy tapeout process and the more fluid workings of an open source development.
+
+This document also serves as a guide to the *hardware design dashboard* (TODO: link), which gives the status of all of the designs in the OpenTitan repository.
+
+This document aims to mostly give a more defined structure to the process that is already followed.
+Proper versioning of RTL designs is a complex topic.
+This document proposes a sensible path forwards, but this may be revisited as we gain further experience and get more feedback.
+
+
+## Life Stages
+
+The stages listed here are created to give insight into where a design is in its life from specification to silicon-ready signoff.
+At the moment, this is strictly limited to a hardware design, but could be expanded to other components of development within OpenTitan.
+Transitions between these stages are decided by the Technical Committee via the RFC process.
+
+The first life stage is **Specification**.
+The proposed design is written up and submitted through the *RFC process* (TODO: link).
+Depending on the complexity of the design and the guidance of the Technical Committee, it is possible a single design might require multiple RFCs.
+For example, a first RFC for the rationale, feature list, and a rough overview; followed by a more detailed RFC to get approval for the draft technical specification.
+As part of the specification process, the design author might reach out for feedback from a smaller group of reviewers while formulating an RFC proposal.
+RFCs are always shared with the wider OpenTitan community prior to vote by the Technical Committee.
+However, wherever there is potentially sensitive material from a future certification standpoint it should be passed through the security review team.
+Once the specification has been shared with the OpenTitan audience and sufficient review has been completed, this phase is exited.
+
+The next life stage is **Development**.
+The hardware IP is being developed in GitHub, the specification is converted to markdown, and design and verification planning is underway.
+This is a long phase expected to last until a more formal review is requested for full completion signoff.
+When in Development phase, the stage tracking of the design and verification milestones are valid.
+See those sections that follow for details there.
+To exit this stage, a signoff process review must occur.
+See the section on signoff for details.
+
+The final life stage is **Signed Off**.
+At this point, a design is frozen and not expected to be updated.
+There are exceptions if post-signoff bugs are found, in which case the stage returns to Active and the version number is not updated.
+Feature requests towards a signed-off design requires review and approval by the Technical Committee.
+Once accepted, it results in creating a new version and return a design to the appropriate life stage, based upon the size of the change.
+See the _Versioning_ section of the document for more discussion.
+Signed off fully-functioning (read: not buggy) designs stay in the Signoff stage as an available complete IP, with an associated revision ID.
+
+
+| **Stage** | **Name** | **Definition** |
+| --- | --- | --- |
+| L0 | Specification | Specification is being written, is in review process |
+| L1 | Development | Design is in development in GitHub, possibly integrated in top level |
+| L2 | Signed Off | Design has been frozen at version number, signed off, available for tapeout |
+
+We may later evaluate adding a **Silicon Proven** stage, after deciding criteria for a tapeout to qualify as proven.
+
+
+## Hardware Design Stages
+
+The following development milestones are for hardware peripheral designs, i.e. SystemVerilog RTL development.
+They are similar to typical chip design milestones, but less rigid in the movement from one stage to the next.
+The metric here is the quality bar and feature completeness of the design.
+
+The first design stage is **Initial Work**.
+This indicates the period of time between the Specification life stage and the RTL being functional enough to pass sanity checks.
+The RTL is still in progress, registers being defined, etc.
+Once the device has passed a basic sanity check, has the lint flow setup, has the registers completely defined, it has completed the Initial Work stage.
+
+The second design stage is **Functional**.
+In this stage, the design is functional but not complete.
+Once all of the features in the specification are implemented, it has completed this stage.
+
+The third design stage is **Feature Complete**.
+In this phase, no changes are expected on the design except for bug fixes.
+Once all bugs have fixed, lint and CDC violations cleaned up, the design moves into its final stage: **Design Complete**.
+
+| **Stage** | **Name** | **Definition** |
+| --- | --- | --- |
+| D0 | Initial Work | RTL being developed, not functional |
+| D1 | Functional | <ul> <li>Feature set finalized, spec complete <li>CSRs identified; RTL/DV/SW collateral generated <li>SW interface automation completed <li>Clock(s)/reset(s) connected to all sub modules <li>Lint run setup <li>Ports Frozen </ul> |
+| D2 | Feature Complete | <ul> <li>Full Feature Complete: all features implemented.  <li>Feature frozen </ul> |
+| D3 | Design Complete | <ul> <li>Lint/CDC clean, waivers reviewed <li>Design optimization for power and/or performance complete </ul> |
+
+## Hardware Verification Stages
+
+The following development milestones are for hardware peripheral verification work.
+They are similar to typical chip verification milestones, but less rigid in the movement from one stage to the next.
+The metric here is the progress towards testing completion and proof of testing coverage.
+
+The first verification stage is **Initial Work**.
+This indicates the period of time between the beginning of verification planning and the testbench up and running.
+The testbench is still being created, scoreboards implemented, test plan being written, nightly regressions running, etc.
+Once the verification environment is available for writing tests, with a test plan written, it has completed the Initial Work stage.
+
+The second verification stage is **Under Test**.
+In this stage, the verification environment is available but not tests in the test plan are completed.
+Once all of the items in the test plan are implemented, it exits this stage.
+
+The third verification stage is **Testing Complete**.
+In this phase, no changes are expected on the testplan, no changes expected on the testbench, and no new tests are expected except to complete full coverage of the design.
+Once all coverage metrics have been met, waivers checked, the verification moves into its final stage: **Verification Complete**.
+
+| **Stage** | **Name** | **Definition** |
+| --- | --- | --- |
+| V0 | Initial Work | Testbench being developed, not functional; test plan being written |
+| V1 | Under Test | <li>DV Plan Complete: <ul> <li>Verification Plan: verification strategy, intent, details of DV environment (with diagrams): TB, BFMs, checkers, scoreboard, interfaces, coverage objects <li>Detailed test plan, including test descriptions, and priorities <li>Identify list of assertions: interfaces, functionalities <li>Reviewed with designer </ul> <li>Nightly regression setup </ul> |
+| V2 | Testing Complete | <ul> <li>All planned tests written <li>All assertions written and enabled </ul> |
+| V3 | Verification Complete | <ul> <li>DV coverage closure, reach 100% coverage, with exclusions written and reviewed with designers <li>Review assertions, regression and coverage with designers <li>Regression clean with random seeds <li>No unaddressed design bugs </ul> |
+
+## Signoff Review
+
+At the end of the final design and verification phase, the IP block should be proposed to the Technical Committee as ready for sign-off.
+This will be done by submitting an RFC (possibly following a suggested template).
+The Technical Committee may decide to nominate individuals to evaluate the codebase and make a recommendation or may review directly.
+Generally, this process would involve:
+
+*   Specification and RTL are re-reviewed for readability, consistency, and code coverage standards
+*   All design items are complete, reviewed against committed specification
+*   All lint and CDC errors and warnings are waived, waivers reviewed
+*   Test plan is re-reviewed for completeness
+*   All test items are confirmed complete
+*   All code coverage items are completed or waived
+*   Performance requirements are reviewed, performance metrics met
+*   Software interface (DIF) files are completed, tested, and signed off by software representative
+
+The process will be refined by the Technical Committee as necessary.
+
+## Indicating Stages and Making Transitions
+
+Stages are indicated via a text file checked into the GitHub and thus transitions can be reviewed through the standard pull request process.
+Transitions for Design and Verification stages are _self-nominated_ in the sense that the design or verification owner can modify the text file and submit a pull request (PR) to transition the stage.
+In this manner other reviewers can challenge the transition in the standard pull request review process.
+These transitions should be done in their own PR (i.e. not interspersed with other changes), and the PR summary and commit message should give any necessary detail on how the transition criteria have been met, as well as any other notes useful for a reviewer.
+
+The content below shows a proposal for the project file that contains the stage information.
+The final content, location, and name of that file will be updated in this space soon. (TODO)
+
+`file: gpio.prj.hjson`
+
+```hjson
+{
+  name: "gpio",
+  version: 1.0,
+  life_stage: "L1",
+  design_stage: "D2",
+  verification_stage: "V1",
+}
+```
+
+## Versioning
+
+The _Version_ of a design element indicates its progress towards its _final feature set for expected product_.
+Typically all designs are expected to simply be in 1.0 version, but there are reasons for exceptions.
+Designs which have a specification towards an _intermediate goal_ where it is useful to drive towards this goal are indicated as a 0.5 version.
+There are many times where this is useful: when the intermediate goal is a beneficial subset of functionality to enable other development; when the final feature set is not known but a sufficient set is ready for development; when the final feature set is postponed until a future date, but owners are keen to get the design started; etc.
+In essence, the 0.5 designation indicates that it is understood that the stage metrics are temporary pending a final feature set.
+Rarely will a 0.5 design be taken past Feature Complete and Testing Complete stages.
+An exception is as proof of concept to show what a signoff process looks like for a design that has modifications expected in the future.
+
+Once a design has completed all stages for a 1.0 feature set, the Signoff process intends to end all development for that design.
+Its Life Stage should transition to Signoff after the review process, and no more modifications should be made.
+A Git tag could be used to christen this completion.
+
+After signoff, three events could cause a change.
+Possibility 1: If a bug is found in top-level testing, software development, etc., the design should stay in its current revision (assumedly 1.0) but revert in design and/or verification staging until the bug is fixed and a new signoff process occurs, followed by a new tag to replace the previous one.
+Possibility 2: if a small collection of new features are requested, a new version increment of 0.1 would be created, and the design and verification stages would be reset.
+The expectation is that this would create its life as a newly tracked revision number, while the previous (assumedly 1.0) version retains its status.
+Possibility 3: if enough new features are requested to greatly change the spirit of the design, a new version increment of 1.0 would be created in a fashion similar to above.
+This would require a new RFC process, and thus the Life Stage would start again as L0 - Specification.
+
+**Note** the thinking on versioning is still early and is likely to be refined with time.
+
+## Reporting of Stages
+
+The stages are reported externally via a script-generated table exposed on the external website.
+This status will be a summary of all `prj.hjson` files of all designs in the system.
+The link to that table is here (TODO: link).

--- a/doc/ug/index.md
+++ b/doc/ug/index.md
@@ -9,21 +9,22 @@
   * [Getting started on FPGAs](getting_started_fpga.md)
     * [Obtaining an FPGA board](fpga_boards.md)
     * [Installing Xilinx Vivado](install_instructions.md#xilinx-vivado)
-  * *Getting started with a design* &lt;Coming Soon&gt;
-  * *Getting started with verification* &lt;Coming Soon&gt;
+  * *Getting started with a design* (TODO)
+  * *Getting started with verification* (TODO)
 * [Work with hardware code in external repositories](vendor_hw.md)
+* [Hardware Development Stages](hw_stages.md)
 * [Design Methodology](design.md)
-  * Importance of Verilog Style Guide
-  * Explanation of Comportability concept
-  * Milestones and Tracking
+  * Language and Tool Selection
+  * Comportability and the Importance of Architectural Conformity
+  * Defining Design Complete: stages and tracking
   * Documentation
-  * Register Tool Usage
+  * Usage of Register Tool
   * Linting Methodology
   * Assertions Methodology
   * CDC Methodology
   * DFT
   * Generated Code
-* *Verification Methodology* &lt;Coming Soon&gt;
+* *Verification Methodology* (TODO)
   * Verification strategy overview
   * How do we define Verification completion
     * Current verification status of IP and definition of milestones
@@ -33,7 +34,7 @@
   * Code coverage output
     * How do we report status
   * Overview of in-tree helper classes, test benches, etc.
-* *Validation Methodology* &lt;Coming Soon&gt;
+* *Validation Methodology* (TODO)
   * How to download bit stream
   * What tests exist today
   * How to run tests


### PR DESCRIPTION
Adding the HW development stages document that we ratified in Standards
Meeting. There is still time for refinement, but would like to get this in as the
baseline that has been agreed upon. I believe the DV team members are
reviewing the stage transition criteria; that could be a PR request on top of
this with a new proposal.

Also updating the index to point to this, and design.md to refer to it.