### PR TITLE
[doc] remove non-ASCII characters

### DIFF
--- a/doc/project.md
+++ b/doc/project.md
@@ -6,9 +6,9 @@ Open source strategy; History; Who are we?; Etc (more deep from the intro paragr
 ## OpenTitan project governance
 
 &lt;Governance.
-Keep the “garden” healthy;
+Keep the "garden" healthy;
 Corp partners;
-Technical ‘code owners’ etc;
+Technical 'code owners' etc;
 How to get commit permission / acceptance;
 How are PRs accepted; what is the process by which things are allowed / rejected;
 partner criteria;
@@ -21,7 +21,7 @@ License policy / CLA&gt;
 ## How to get involved
 
 &lt;Just brief points as to how to start out;
-“My company just signed up, how do I figure out what to work on and who to talk to?”;
+"My company just signed up, how do I figure out what to work on and who to talk to?";
 link to getting started user guides;
 Team drive (for internal/confidential docs) vs github, mailing list vs chat, etc.&gt;
 
@@ -29,7 +29,7 @@ Team drive (for internal/confidential docs) vs github, mailing list vs chat, etc
 
 &lt;Maturity standards - what they are;
 Articulate maturity/quality level per IP (could vary across different IPs);
-Different “support” expectation;
+Different "support" expectation;
 How we maintain quality;
 possible reference to certification;
 Process to ensure logical security of included IP;

--- a/doc/rm/register_tool.md
+++ b/doc/rm/register_tool.md
@@ -112,14 +112,14 @@ Putting these together an unaligned 60 byte window (15 32-bit words) could follo
 
 
 ```hjson
-	{skipto: "0x200"}
-	{name: "aligned_reg" ... }
-	{window: {
+    {skipto: "0x200"}
+    {name: "aligned_reg" ... }
+    {window: {
          name: "unaligned_win"
          items: "15"
-		 noalign: "True"
-		 unusual: "True"
-		 byte-write: "True"
+         noalign: "True"
+         unusual: "True"
+         byte-write: "True"
          swaccess: "rw"
          desc: '''
                A 60 byte window that slots in after the register.
@@ -321,7 +321,7 @@ For example, if the termination of the TL-UL bus is a memory that handles byte a
 
 The definition of what exactly is in each register type is described in this section.
 As shown above, the maximally featured register has inputs and outputs to/from both the bus interface side of the design as well as the hardware interface side.
-Some register types don’t require all of these inputs and outputs.
+Some register types don't require all of these inputs and outputs.
 For instance, a read-only register does not require write data from the bus interface (this is configured by the `SWACCESS` parameter to the `prim_subreg` module).
 The maximally defined inputs to this register block (termed the `subreg` from here forward) are given in the table below.
 Note that these are instantiated per field, not per register, so the width is the width of the field.
@@ -417,7 +417,7 @@ The connectivity to the hardware struct bundles are a function of the `hwaccess`
 In this diagram, the maximum connection for subreg_rw is shown.
 Coming in from the left (bus) are the software write enable and write data, which has the highest priority in modifying the register contents.
 These are present for all RW types.
-The “final answer” for the register content is stored in the subreg module, and presented to the peripheral hardware as the output `q` and to bus reads as the output `qs`.
+The "final answer" for the register content is stored in the subreg module, and presented to the peripheral hardware as the output `q` and to bus reads as the output `qs`.
 Optionally, if the `hwaccess` attribute allows writes from the hardware, the hardware can present updated values in the form of data enable (`de`) and update data (`d`).
 If the data enable is true, the register content is updated with the update data.
 If both software and hardware request an update in the same clock cycle (i.e. both `de` and `we` are true), the software updated value is used, as shown in the diagram.
@@ -425,9 +425,9 @@ If both software and hardware request an update in the same clock cycle (i.e. bo
 The `hwaccess` attribute value does not change the contents of the subreg, but the connections are potentially modified.
 The attribute `hwaccess` has four potential values, as shown earlier in the document: `hrw, hro, hwo, none`.
 A `hwaccess` value of `hrw` means that the hardware wants the ability to update the register content (i.e. needs connection to `d` and `de`), as well as see the updated output (`q`).
-`hwo` doesn’t care about the output `q`, but wants to update the register value.
+`hwo` doesn't care about the output `q`, but wants to update the register value.
 This is the default for registers marked for software read-only access.
-`hro` conversely indicates the hardware doesn’t need to update the content, but just wants to see the value written by software.
+`hro` conversely indicates the hardware doesn't need to update the content, but just wants to see the value written by software.
 This is the default for fields where the software access is read-write or write-only.
 Finally an attribute value of `none` asks for no interface to the hardware, and might be used for things like scratch registers or DV test registers where only software can modify the value, or informational registers like version numbers that are read-only by the software.
 
@@ -503,13 +503,13 @@ q <= (de ? d : q) & (we ? ~wd : '1)
 ```
 
 In this description if the hardware is writing, its value is sent to the logic that potentially clears that value or the stored value.
-So if the hardware accidentally clears fields that the software hasn’t cleared yet, there is a risk that events will not be seen by software.
+So if the hardware accidentally clears fields that the software hasn't cleared yet, there is a risk that events will not be seen by software.
 The recommendation is that the hardware feed the `q` value back into `d`, only setting bits with new events.
-Then there will be no “collision” between hardware setting events and software clearing events.
-The HW could have chosen to simply treat `d` and `de` as set-only, but the preference is to leave the `subreg` simple and allow the hardware to do either “the right thing” or whatever it feels is appropriate for its needs.
+Then there will be no "collision" between hardware setting events and software clearing events.
+The HW could have chosen to simply treat `d` and `de` as set-only, but the preference is to leave the `subreg` simple and allow the hardware to do either "the right thing" or whatever it feels is appropriate for its needs.
 (Perhaps it is a feature to clear all events in the hardware.)
 
-The one “conflict” that is common and worth mentioning is `RW1C` on an interrupt vector.
+The one "conflict" that is common and worth mentioning is `RW1C` on an interrupt vector.
 This is the typical scenario where hardware sets bits (representing an interrupt event), and software clears bits (indicating the event has been handled).
 The assumption is that between the hardware setting and software clearing, **software has cleaned up whatever caused the event in the first place**.
 But if the event is still true (the HW `d` input is still `1`) then the clear should still have effect for one cycle in order to create a new interrupt edge.

--- a/doc/rm/verilog_coding_style.md
+++ b/doc/rm/verilog_coding_style.md
@@ -2149,7 +2149,7 @@ Refer to the main text body for explanations examples, and exceptions.
 *   Sequential logic must use **non-blocking** assignments
 *   Combinational blocks must use **blocking** assignments
 *   Use of latches is discouraged, use flip-flops when possible
-*   Explicitly specify don’t cares (`X`) when safe to do so.
+*   Explicitly specify don't cares (`X`) when safe to do so.
 *   Prefer `assign` statements wherever practical.
 *   Use `unique case` and always define a `default` case
 *   Use available signed arithmetic constructs wherever signed arithmetic is used

--- a/hw/formal/README.md
+++ b/hw/formal/README.md
@@ -55,7 +55,7 @@ descriptive, which will help during debug.
 *   The second argument is the assertion property.
 *   The last two arguments specify the clock and reset signals (active-high
 reset).
-*   Note that this macro doesn’t support a custom error message (such as the
+*   Note that this macro doesn't support a custom error message (such as the
 $error message in the previous section). However, the macro will print out the
 property name and the entire property code such as `req |-> ack`.
 
@@ -82,7 +82,7 @@ that a FIFO is empty at the end of each sim.
 Assert that a concurrent property never happens.
 
 ### `ASSERT_KNOWN(name, signal, clk, rst)
-Assert that `signal` has a known value after reset, where “known” refers to
+Assert that `signal` has a known value after reset, where "known" refers to
 a value that is not X.
 
 ### More Macros and Examples
@@ -119,7 +119,7 @@ used for assertion properties.
   <tr>
    <td>$stable()
    </td>
-   <td>True if the value of expression didn’t change
+   <td>True if the value of expression didn't change
    </td>
   </tr>
   <tr>
@@ -155,7 +155,7 @@ used for assertion properties.
   <tr>
    <td>$isunknown()
    </td>
-   <td>True if any bit in the expression is ‘X’ or ‘Z'
+   <td>True if any bit in the expression is 'X' or 'Z'
    </td>
   </tr>
 </table>
@@ -185,13 +185,13 @@ Below table lists useful operators that can be used for assertion properties.
   <tr>
    <td>|->
    </td>
-   <td>“Overlapping” implication (same cycle)
+   <td>"Overlapping" implication (same cycle)
    </td>
   </tr>
   <tr>
    <td>|=>
    </td>
-   <td>“Non-overlapping” implication (next cycle)
+   <td>"Non-overlapping" implication (next cycle)
      <br /> <code>a |=> b</code> is equivalent to <code>a |-> ##1 b</code>
    </td>
   </tr>
@@ -271,6 +271,6 @@ influence for "u_sha2.u_pad.shaf_ren".
 ## References
 *   [SVA Basics](https://www.systemverilog.io/sva-basics)
 *   [SVA Tutorial](https://www.doulos.com/knowhow/sysverilog/tutorial/assertions/)
-*   “SystemVerilog Assertions Design Tricks and SVA Bind Files,” SNUG 2009,
+*   "SystemVerilog Assertions Design Tricks and SVA Bind Files", SNUG 2009,
 Clifford E. Cummings,
 [paper](http://www.sunburst-design.com/papers/CummingsSNUG2009SJ_SVA_Bind.pdf)

--- a/hw/ip/aes/doc/aes.hjson
+++ b/hw/ip/aes/doc/aes.hjson
@@ -88,10 +88,10 @@
         resval: "1",
         hwaccess: "hrw",
         desc:  '''
-          3-bit one-hot field to select AES key length: 128 bit (3’b001), 192 bit (3’b010)
-          or 256 bit (3’b100). Invalid input values, i.e., value with multiple bits set,
-          value 3’b000, and value 3’b010 in case 192-bit keys are not supported (because
-          disabled at compile time) are mapped to 3’b001.
+          3-bit one-hot field to select AES key length: 128 bit (3'b001), 192 bit (3'b010)
+          or 256 bit (3'b100). Invalid input values, i.e., value with multiple bits set,
+          value 3'b000, and value 3'b010 in case 192-bit keys are not supported (because
+          disabled at compile time) are mapped to 3'b001.
         '''
       }
       { bits: "4",

--- a/hw/ip/alert_handler/doc/alert_handler.md
+++ b/hw/ip/alert_handler/doc/alert_handler.md
@@ -26,31 +26,31 @@ sources, where NAlerts is a function of the requirements of the peripherals
 response from each source to ensure proper wiring
 
 - Register locking on all configuration registers
-	- Once locked, can not be modified by software
+    - Once locked, can not be modified by software
 
 - Register-based assignment of alert to alert-class
-	- Four classes, can be individually disabled.
-	- Each class generates one interrupt.
-	- Disambiguation history for software to determine which alert caused the
-	class interrupt.
-	- Each class has configurable response time for escalation.
-	- Disable allows for ignoring alerts, should only be used in cases when
-	alerts are faulty. Undesirable access is enforced by locking the register
-	state after initial configuration.
+    - Four classes, can be individually disabled.
+    - Each class generates one interrupt.
+    - Disambiguation history for software to determine which alert caused the
+    class interrupt.
+    - Each class has configurable response time for escalation.
+    - Disable allows for ignoring alerts, should only be used in cases when
+    alerts are faulty. Undesirable access is enforced by locking the register
+    state after initial configuration.
 
 - Register-based escalation controls
-	- Number of alerts in class before escalation
-	- Timeout for unhandled alert IRQs can also trigger escalation
-	- Configurable escalation enables for 4 escalation signals
-		- Could map to NMI, wipe secrets signal, lower permission, chip reset,
-		 etc.
-		- Escalation signals differentially-signaled with heartbeat, should
-		 trigger response if differential or heartbeat failure at destination
-	* Configurable time in cycles between each escalation level
+    - Number of alerts in class before escalation
+    - Timeout for unhandled alert IRQs can also trigger escalation
+    - Configurable escalation enables for 4 escalation signals
+        - Could map to NMI, wipe secrets signal, lower permission, chip reset,
+         etc.
+        - Escalation signals differentially-signaled with heartbeat, should
+         trigger response if differential or heartbeat failure at destination
+    * Configurable time in cycles between each escalation level
 
 - Two locally sourced hardware alerts
-	- Differential signaling from a source has failed
-	- Ping response from a source has failed
+    - Differential signaling from a source has failed
+    - Ping response from a source has failed
 
 
 {{% section2 Description }}
@@ -544,7 +544,7 @@ predetermined definition of an escalation signal, that is left to the
 top-level integration. Examples could be processor Non Maskable Interrupt (NMI),
 permission lowering, secret wiping, chip reset, etc. Typically the assumption
 is that escalation level 0 is the first to trigger, followed by 1, 2, and then
-3, emulating a "fuse" that is lit that can’t be stopped once the first triggers
+3, emulating a "fuse" that is lit that can't be stopped once the first triggers
 (this is however not a requirement). See register section for discussion of
 counter clearing and register locking to determine the finality of accumulation
 triggers.
@@ -802,7 +802,7 @@ will just be acknowledged with `ping_ok_o` in case `esc_en_i` is already
 asserted. An ongoing ping sequence will be aborted immediately.
 
 
-{{% section1 Programmer’s Guide }}
+{{% section1 Programmer's Guide }}
 
 
 {{% section2 Power-up and Reset Considerations }}
@@ -810,7 +810,7 @@ asserted. An ongoing ping sequence will be aborted immediately.
 False alerts during power-up and reset are not possible since the alerts are
 disabled by default, and need to be configured and locked in by the firmware.
 
-The ping timer won’t start until initial configuration is over and the registers
+The ping timer won't start until initial configuration is over and the registers
 are locked in.
 
 
@@ -887,7 +887,7 @@ the following steps:
    the system. Each cause register contains a sticky bit that is set by the
    incoming alert, and is clearable with a write by software. This should only
    be cleared after software has cleared the event trigger, if applicable. It is
-   possible that the event requires no clearing (e.g. a parity error), or can’t
+   possible that the event requires no clearing (e.g. a parity error), or can't
    be cleared (a breach in the metal mesh protecting the chip).
 
    Note that in the rare case when multiple events are triggered at or about the

--- a/hw/ip/padctrl/doc/padctrl.md
+++ b/hw/ip/padctrl/doc/padctrl.md
@@ -55,7 +55,7 @@ Note that the chip-level `padctrl` module also contains the pads for clock and r
 {{% section2 Parameters }}
 
 The following table lists the main parameters used throughout the `padctrl` design.
-Note that the `padctrl` modules are generated based on the system configuration, and hence these parameters are placed into a package as “localparams”.
+Note that the `padctrl` modules are generated based on the system configuration, and hence these parameters are placed into a package as "localparams".
 
 Localparam     | Default (Max)         | Description
 ---------------|-----------------------|---------------
@@ -103,7 +103,7 @@ Parameter      | Default (Max)         | Description
 ---------------|-----------------------|---------------
 AttrDw         | 6 (-)                 | Width of the pad attribute vector.
 
-Note that the pad wrapper may implement a “virtual” open drain termination, where standard bidirectional pads are employed, but instead of driving the output high for a logic 1 the pad is put into tristate mode.
+Note that the pad wrapper may implement a "virtual" open drain termination, where standard bidirectional pads are employed, but instead of driving the output high for a logic 1 the pad is put into tristate mode.
 
 Signal             | Direction  | Type  | Description                         | Mandatory
 -------------------|------------|-------|-------------------------------------|--------------------

--- a/hw/ip/pinmux/doc/pinmux.md
+++ b/hw/ip/pinmux/doc/pinmux.md
@@ -75,7 +75,7 @@ Additional details about the signal names and parameters is given in the tables 
 {{% section2 Parameters }}
 
 The following table lists the main parameters used throughout the `pinmux` design.
-Note that the pinmux is generated based on the system configuration, and hence these parameters are placed into a package as “localparams”.
+Note that the pinmux is generated based on the system configuration, and hence these parameters are placed into a package as "localparams".
 
 Localparam     | Default (Max)         | Description
 ---------------|-----------------------|---------------

--- a/hw/ip/rv_plic/doc/rv_plic.md
+++ b/hw/ip/rv_plic/doc/rv_plic.md
@@ -40,7 +40,7 @@ The RV_PLIC is compatible with any RISC-V core implementing the RISC-V privilege
 Each interrupt source has a unique ID assigned based upon its bit position
 within the input `intr_src_i`. ID counting ranges from 1 to N, the number of
 interrupt sources. `intr_src_i[i]` bit has an ID of `i+1`. This ID is used when
-targets “claim” the interrupt and to “complete” the interrupt event.
+targets "claim" the interrupt and to "complete" the interrupt event.
 
 ### Priority and Threshold
 
@@ -90,7 +90,7 @@ lowest ID.
 
 After an interrupt is claimed, the interrupt pending (`IP`) bit of the interrupt
 source is cleared, regardless of the status of the `intr_src_i` input value.
-Until a target “completes” the interrupt, it won't be re-set if a new event
+Until a target "completes" the interrupt, it won't be re-set if a new event
 for the interrupt occurs. A target completes the interrupt by writing the ID of
 the interrupt to the !!CC register. The write event is forwarded to the Gateway
 logic, which resets the interrupt status to accept new interrupt event. The

--- a/hw/ip/tlul/doc/TlulProtocolChecker.md
+++ b/hw/ip/tlul/doc/TlulProtocolChecker.md
@@ -65,7 +65,7 @@ spec section 6.2.
 as follows: 2<sup>a_size</sup> must equal $countones(a_mask). See spec section
 4.6.
 <p>
-<strong>aKnown</strong>: Make sure it’s not X when a_valid is high.
+<strong>aKnown</strong>: Make sure it's not X when a_valid is high.
    </td>
   </tr>
   <tr>
@@ -74,7 +74,7 @@ as follows: 2<sup>a_size</sup> must equal $countones(a_mask). See spec section
    <td><strong>onlyOnePendingReqPerSourceID</strong>: There should be no more
 than one pending request per each source ID. See spec section 5.4.
 <p>
-<strong>aKnown</strong>: Make sure it’s not X when a_valid is high.
+<strong>aKnown</strong>: Make sure it's not X when a_valid is high.
    </td>
   </tr>
   <tr>
@@ -83,7 +83,7 @@ than one pending request per each source ID. See spec section 5.4.
    <td><strong>addressAlignedToSize</strong>: a_address must be aligned to
 a_size: a_address & ((1 << a_size) - 1) == 0. See spec section 4.6.
 <p>
-<strong>aKnown: </strong>Make sure it’s not X when a_valid is high.
+<strong>aKnown: </strong>Make sure it's not X when a_valid is high.
    </td>
   </tr>
   <tr>
@@ -94,7 +94,7 @@ and PutFullData (but not for PutPartialData). See spec sections 4.6 and 6.2.
 <p>
 <strong>sizeMatchesMask</strong>: See a_size above.
 <p>
-<strong>aKnown: </strong>Make sure it’s not X when a_valid is high.
+<strong>aKnown: </strong>Make sure it's not X when a_valid is high.
    </td>
   </tr>
   <tr>
@@ -108,19 +108,19 @@ corresponding a_mask bits are 0, can be X. See spec section 4.6.
   <tr>
    <td>a_user
    </td>
-   <td><strong>aKnown: </strong>Make sure it’s not X when a_valid is high.
+   <td><strong>aKnown: </strong>Make sure it's not X when a_valid is high.
    </td>
   </tr>
   <tr>
    <td>a_valid
    </td>
-   <td><strong>aKnown</strong>: Make sure it’s not X (except during reset).
+   <td><strong>aKnown</strong>: Make sure it's not X (except during reset).
    </td>
   </tr>
   <tr>
    <td>a_ready
    </td>
-   <td><strong>aReadyKnown</strong>: Make sure it’s not X (except during
+   <td><strong>aReadyKnown</strong>: Make sure it's not X (except during
 reset).
    </td>
   </tr>
@@ -169,13 +169,13 @@ been a corresponding request with the same source ID value. See spec section
 <strong>noOutstandingReqsAtEndOfSim</strong>: Make sure that there are no
 outstanding requests at the end of the simulation.
 <p>
-<strong>dKnown</strong>: Make sure it’s not X when d_valid is high.
+<strong>dKnown</strong>: Make sure it's not X when d_valid is high.
    </td>
   </tr>
   <tr>
    <td>d_sink
    </td>
-   <td><strong>dKnown</strong>: Make sure it’s not X when d_valid is high.
+   <td><strong>dKnown</strong>: Make sure it's not X when d_valid is high.
    </td>
   </tr>
   <tr>
@@ -189,25 +189,25 @@ can be X. See spec section 4.6.
   <tr>
    <td>d_error
    </td>
-   <td><strong>dKnown: </strong>Make sure it’s not X when d_valid is high.
+   <td><strong>dKnown: </strong>Make sure it's not X when d_valid is high.
    </td>
   </tr>
   <tr>
    <td>d_user
    </td>
-   <td><strong>dKnown: </strong>Make sure it’s not X when d_valid is high.
+   <td><strong>dKnown: </strong>Make sure it's not X when d_valid is high.
    </td>
   </tr>
   <tr>
    <td>d_valid
    </td>
-   <td><strong>dKnown</strong>: Make sure it’s not X (except during reset).
+   <td><strong>dKnown</strong>: Make sure it's not X (except during reset).
    </td>
   </tr>
   <tr>
    <td>d_ready
    </td>
-   <td><strong>dReadyKnown: </strong>Make sure it’s not X (except during
+   <td><strong>dReadyKnown: </strong>Make sure it's not X (except during
 reset).
    </td>
   </tr>

--- a/hw/top_earlgrey/doc/top_earlgrey.md
+++ b/hw/top_earlgrey/doc/top_earlgrey.md
@@ -85,7 +85,7 @@ It also feeds into the document generation to ensure that the chosen address loc
 | `IO_SHCS`   | output | SPI host chip select |
 | `IO_SHDI`   | output | SPI host input data |
 | `IO_SHDO`   | input  | SPI host output data |
-| `MIO_00` .. `MIO_23` | inout  | Multiplexible pins available for input or output connections with peripheral units’ (UART, GPIO, etc.) IO |
+| `MIO_00` .. `MIO_23` | inout  | Multiplexible pins available for input or output connections with peripheral units' (UART, GPIO, etc.) IO |
 
 {{% section2 Design Details }}
 
@@ -159,14 +159,14 @@ This is part of the *Secure Boot Process* that will be detailed in a security se
 
 Earl Grey contains 512kB of emulated embedded-flash (e-flash) memory for code storage.
 This is intended to house the boot loader mentioned above, as well as the operating system and application that layers on top.
-For the 0.5 version the expectation is that the operating system will be very lightweight, and the “application” will be simple proof of concept code to show that the chip can do.
+For the 0.5 version the expectation is that the operating system will be very lightweight, and the "application" will be simple proof of concept code to show that the chip can do.
 One example will be validation code that tests the validity and stability of the full chip environment itself.
 
 Embedded-flash is the intended technology for a silicon design implementing the full OpenTitan device.
 It has interesting and challenging parameters that are unique to the technology that the silicon is implemented in.
 Earl Grey, as an FPGA-only proof of concept, will model these parameters in its emulation of the memory in order to prepare for the replacement with the silicon flash macros that will come.
 This includes the read-speeds, the page-sized erase and program interfaces, the two-bank update scheme, and the non-volatile nature of the memory.
-Since by definition these details can’t be finalized until a silicon technology node is chosen, these can only be emulated in the FPGA environment.
+Since by definition these details can't be finalized until a silicon technology node is chosen, these can only be emulated in the FPGA environment.
 We will choose parameters that are considered roughly equivalent of the state of the art embedded-flash macros on the market today.
 
 Details on how e-flash memory is used by software will be detailed in the Secure Boot Process and Software sections that follow.
@@ -185,7 +185,7 @@ The base address of the ROM, Flash, and SRAM are given in the address map sectio
 
 ### Peripherals
 
-Earl Grey contains a suite of “peripherals”, or subservient execution units connected to the Ibex processor by means of a bus interconnect.
+Earl Grey contains a suite of "peripherals", or subservient execution units connected to the Ibex processor by means of a bus interconnect.
 Each of these peripherals follows an interface scheme dictated in the
 [Comportability Specification.](../../../doc/rm/comportability_specification.md)
 This specification details how the processor communicates with the peripheral (via TLUL interconnect); how the peripheral communicates with the chip IO (via fixed or multiplexable IO); how the peripheral communicates with the processor (interrupts); and how the peripheral communicates security events (via alerts).
@@ -250,7 +250,7 @@ For SPI passthrough timing reasons, the SPI device pins will be hardwired to Ear
 ##### SPI host
 
 In addition to the SPI passthrough functionality (see below), the SPI host is able to originate SPI transactions as directed by software.
-This functionality will require addressing modes, as well as “generic transfer” where the data is simply sent as contained packets by the host hardware state machine.
+This functionality will require addressing modes, as well as "generic transfer" where the data is simply sent as contained packets by the host hardware state machine.
 The specification for SPI host is not defined at this time, and will depend upon conversations with the software team which are still in development.
 Only single-mode functionality is expected at this time.
 
@@ -261,7 +261,7 @@ For SPI passthrough timing reasons, the SPI host pins will be hardwired to Earl 
 One primary feature of the 0.5 release is to develop at least rudimentary SPI Passthrough functionality.
 This feature allows Earl Grey to interpose on SPI, watching transactions coming in to the SPI device port, and passing them on to the SPI host port.
 The involvement of the SPI device and host components (working together) requires logic to inspect the activities of the SPI transfer, and potentially modify them on the way out, with minimal latency impact.
-This is implemented with a simple MUX between the device and host pins to select either the inbound device traffic, or pre-created “safe” content.
+This is implemented with a simple MUX between the device and host pins to select either the inbound device traffic, or pre-created "safe" content.
 The MUX is simple, but the selection of it requires inspection logic and a lookup table to determine safe and unsafe behavior, as well as the replacement safe transaction.
 The specification for this functionality will be created in conjunction with systems designers who are using similar behavior in products today.
 The goal is for this subset of functionality provide enough proving ground to a) show the direction of the concept; b) test out software interfaces with the system to be developed around it.
@@ -293,12 +293,12 @@ is the primary
 and decryption mechanism used in OpenTitan protocols.
 AES runs with key sizes of 128b, 192b, or 256b.
 The module can select encryption or decryption of data that arrives in 16 byte quantities to be encrypted or decrypted independently of other data
-(“[ECB mode](https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#ECB)").
+("[ECB mode](https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#ECB)").
 Other modes (say
 [CTR mode](https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#CTR),
 [CBC mode](https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#CBC),
 etc) can be implemented in software on top of the results of ECB, though future versions of this AES IP will likely add such overlayed modes in hardware to improve performance and increase security (risk of secret exposure).
-For this version, all data transfer is “front door” in the sense that key and data material is passed into the module via register writes.
+For this version, all data transfer is "front door" in the sense that key and data material is passed into the module via register writes.
 Future versions will have provisions for private transfer of key and data material to reduce exposure from potentially untrusted local firmware.
 This version does not attempt to add any side-channel or fault-injection resistance into the design.
 Future versions will begin to add in such countermeasures.
@@ -318,7 +318,7 @@ family of hashing algorithms, where the digest (or hash output) is of 256b lengt
 The data is sent into the SHA peripheral after declaring the beginning of a hash request (effectively zeroing out the internal state to initial conditions), 32b at a time.
 Once all data has been sent, the user can indicate the completion of the hash request (with optional partial-word final write).
 The peripheral will produce the hash result available for register read by the user.
-All data transfer is “front door” in the sense that it is passed into the module via register writes.
+All data transfer is "front door" in the sense that it is passed into the module via register writes.
 Future versions will have provisions for private transfer of data to reduce exposure from potentially untrusted local firmware.
 This version does not attempt to add any side-channel or fault-injection resistance into the design.
 Future versions will begin to add in such countermeasures.
@@ -401,7 +401,7 @@ If the time is beyond a configurable duration, then the manager raises the respo
 These responses are not described in further detail at this time, but the basics of the configuration methods will be designed in this version of the alert manager.
 
 In addition, signaling exists between the alert manager and each peripheral to ensure that all monitors are active.
-This “heartbeat check” requests a response from the alert senders over the same wires to ensure that their reporting mechanism has not itself been compromised.
+This "heartbeat check" requests a response from the alert senders over the same wires to ensure that their reporting mechanism has not itself been compromised.
 More details about the alert manager will come in an independent alert manager specification.
 
 ##### TRNG (aspirational)


### PR DESCRIPTION
This is what a fix for #403 would look like. I'm not touching the license files
that were evidently copied over and have non-ASCII content.