### PR TITLE
Remove pinned attrs version from python-requirements.txt

### DIFF
--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -17,8 +17,3 @@ git+https://github.com/olofk/ipyxact.git@master
 
 # Development version of edalize until all our changes are upstream
 git+https://github.com/lowRISC/edalize.git@ot
-
-# Pin attrs version to workaround
-# https://github.com/enthought/sat-solver/issues/270
-# Tracked in https://github.com/lowRISC/opentitan/issues/305
-attrs==19.1.0


### PR DESCRIPTION
Fixes #305.

simplesat (required by fusesoc) was broken by an update to the attrs
library. Now simplesat 0.8.2 has been released which fixes the issue, we
can remove the explicit pinning of the old attrs version.