### PR TITLE
[CI] Update to latest toolchain build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ variables:
   VERILATOR_PATH: /opt/buildcache/verilator/$(VERILATOR_VERSION)
   TOOLCHAIN_PATH: /opt/buildcache/riscv
   # Release tag from https://github.com/lowRISC/lowrisc-toolchains/releases
-  TOOLCHAIN_VERSION: 20190827-2
+  TOOLCHAIN_VERSION: 20191010-1
 
 trigger:
   # Combine builds on master as long as another build is running


### PR DESCRIPTION
This toolchain build is significantly different from the previous one:
the toolchain is now built with crosstool-NG (instead of the SiFive
custom Makefile flow). The most significant changes are:
- GCC 9.2
- Better compatibility between distributions: the toolchain now works
  on non-Ubuntu/Debian distributions. (That's not a problem in CI, but
  for some of our collaborators on their local machines.)