### PR TITLE
[uart] Condition of Overflow

### DIFF
--- a/hw/ip/uart/rtl/uart_core.sv
+++ b/hw/ip/uart/rtl/uart_core.sv
@@ -346,7 +346,7 @@ module uart_core (
     end
   end
 
-  assign event_rx_overflow  = rx_valid & ~rx_fifo_wready;
+  assign event_rx_overflow  = rx_fifo_wvalid & ~rx_fifo_wready;
   assign event_tx_overflow  = reg2hw.wdata.qe & ~tx_fifo_wready;
   assign event_rx_break_err = break_err && (break_st == BRK_CHK);
 


### PR DESCRIPTION
Previous overflow interrupt didn't consider frame error or parity error.
If a frame error or a parity error occurs, the logic doesn't push a
entry into rx fifo. So it shouldn't trigger overflow at that time.

Reported by @weicaiyang (Thanks!)