### PR TITLE
[rv_timer/dv] Add Functional Coverage

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/cip_base_vseq.sv
@@ -319,7 +319,7 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
       test_index.shuffle();
       foreach (test_index[i]) begin
         bit [TL_DW-1:0] wr_data;
-        wr_data = $urandom_range(1, ((1 << intr_enable_csrs[test_index[i]].get_n_used_bits()) - 1));
+        wr_data = $urandom_range(0, ((1 << intr_enable_csrs[test_index[i]].get_n_used_bits()) - 1));
         intr_enable_val.insert(test_index[i], wr_data);
         csr_wr(.csr(intr_enable_csrs[test_index[i]]), .value(wr_data));
       end

--- a/hw/ip/rv_timer/dv/env/rv_timer_env_cfg.sv
+++ b/hw/ip/rv_timer/dv/env/rv_timer_env_cfg.sv
@@ -9,8 +9,8 @@ class rv_timer_env_cfg extends cip_base_env_cfg #(.RAL_T(rv_timer_reg_block));
   virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1,
                                    bit [TL_AW-1:0] csr_addr_map_size = 2048);
     super.initialize();
-    // TODO set num_interrupts correctly
-    num_interrupts = ral.intr_state0.get_n_used_bits();
+    // set num_interrupts
+    num_interrupts = NUM_HARTS * NUM_TIMERS;
   endfunction
 
 endclass

--- a/hw/ip/rv_timer/dv/env/rv_timer_env_cov.sv
+++ b/hw/ip/rv_timer/dv/env/rv_timer_env_cov.sv
@@ -2,12 +2,78 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+// TODO - We are enclosing covergroups inside class so that we can
+// take avoid tool limitation of not allowing arrays of covergroup
+// Refer to Issue#375 for more details
+// class for wrapping timer config covergroup
+class rv_timer_cfg_cov_obj extends uvm_object;
+  `uvm_object_utils(rv_timer_cfg_cov_obj)
+
+  // Covergroup: cfg_cg
+  // timer config covergroup definition
+  covergroup cfg_cg(string name) with function sample(bit [7:0]  step,
+                                                      bit [11:0] prescale,
+                                                      uint64 mtime,
+                                                      uint64 mtime_cmp);
+    cp_step: coverpoint step {
+      bins step_all_val[] = {[0:$]};
+    }
+    cp_prescale: coverpoint prescale {
+      option.auto_bin_max = 256;
+    }
+    cp_mtime: coverpoint mtime {
+      option.auto_bin_max = 50;
+    }
+    cp_mtime_cmp: coverpoint mtime_cmp {
+      option.auto_bin_max = 50;
+    }
+  endgroup : cfg_cg
+
+  function new(string name="rv_timer_cfg_cov");
+    super.new(name);
+    cfg_cg = new(name);
+  endfunction : new
+endclass : rv_timer_cfg_cov_obj
+
+// class for wrapping all timers active in one Hart covergroup
+class rv_timer_ctrl_reg_cov_obj extends uvm_object;
+  `uvm_object_utils(rv_timer_ctrl_reg_cov_obj)
+
+  // Covergroup: timer_active_cg
+  // all timer in one hart covergroup definition
+  covergroup timer_active_cg(string name) with function sample(bit [31:0] value);
+    cp_active_timers: coverpoint value {
+      bins all_timers_active[] = {{NUM_TIMERS{1'b1}}};
+    }
+  endgroup : timer_active_cg
+
+  function new(string name="rv_timer_ctrl_reg_cov");
+    super.new(name);
+    timer_active_cg = new(name);
+  endfunction : new
+endclass : rv_timer_ctrl_reg_cov_obj
+
 class rv_timer_env_cov extends cip_base_env_cov #(.CFG_T(rv_timer_env_cfg));
   `uvm_component_utils(rv_timer_env_cov)
 
+  rv_timer_cfg_cov_obj      cfg_values_cov_obj[NUM_HARTS*NUM_TIMERS];
+  rv_timer_ctrl_reg_cov_obj ctrl_reg_cov_obj[NUM_HARTS];
+  dv_base_generic_cov_obj   rv_timer_prescale_values_cov_obj[NUM_HARTS][12];
+
   function new(string name, uvm_component parent);
     super.new(name, parent);
-    // add more covergroup here
+    //Create cfg coverage for each timer
+    foreach (cfg_values_cov_obj[timer]) begin
+      cfg_values_cov_obj[timer] = new($sformatf("rv_timer-%0d", timer));
+    end
+    //Create toggle coverage for each prescale bit
+    foreach (rv_timer_prescale_values_cov_obj[timer, bit_num]) begin
+      rv_timer_prescale_values_cov_obj[timer][bit_num] = new($sformatf("rv_timer-%0d-prescale-%0d", timer, bit_num));
+    end
+    //Create all timers active coverage for each hart
+    foreach (ctrl_reg_cov_obj[hart]) begin
+      ctrl_reg_cov_obj[hart] = new($sformatf("hart_%0d_all_timer_active", hart));
+    end
   endfunction : new
 
 endclass

--- a/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_base_vseq.sv
+++ b/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_base_vseq.sv
@@ -110,7 +110,7 @@ class rv_timer_base_vseq extends cip_base_vseq #(
   virtual task cfg_interrupt(int hart = 0, int timer = 0, bit enable = 1'b1);
     uvm_reg       intr_en_rg;
     uvm_reg_field timer_intr_en_fld;
-    int           intr_pin_idx = hart * NUM_HARTS + timer;
+    int           intr_pin_idx = hart * NUM_TIMERS + timer;
     `DV_CHECK_LT_FATAL(hart, NUM_HARTS)
     `DV_CHECK_LT_FATAL(timer, NUM_TIMERS)
     intr_en_rg = ral.get_reg_by_name($sformatf("intr_enable%0d", hart));
@@ -129,7 +129,7 @@ class rv_timer_base_vseq extends cip_base_vseq #(
   virtual task check_interrupt(int hart = 0, int timer = 0, bit exp_intr_state, bit exp_intr_pin);
     uvm_reg       intr_state_rg;
     uvm_reg_field timer_intr_state_fld;
-    int           intr_pin_idx = hart * NUM_HARTS + timer;
+    int           intr_pin_idx = hart * NUM_TIMERS + timer;
     `DV_CHECK_LT_FATAL(hart, NUM_HARTS)
     `DV_CHECK_LT_FATAL(timer, NUM_TIMERS)
     intr_state_rg = ral.get_reg_by_name($sformatf("intr_state%0d", hart));

--- a/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_disabled_vseq.sv
+++ b/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_disabled_vseq.sv
@@ -31,7 +31,7 @@ class rv_timer_disabled_vseq extends rv_timer_sanity_vseq;
               fork
                 begin
                   // wait for num clks required to expect interrupt
-                  int    intr_pin_idx = a_i * NUM_HARTS + a_j;
+                  int    intr_pin_idx = a_i * NUM_TIMERS + a_j;
                   uint64 mtime_diff   = compare_val[a_i][a_j] - timer_val[a_i];
                   int    num_clks     = ((mtime_diff / step[a_i]) + 1) * (prescale[a_i] +1) + 1;
                   cfg.clk_rst_vif.wait_clks(num_clks);


### PR DESCRIPTION
1.rv_timer_env_cov: Defined covergroups
2.rv_timer_scoreboard: Sampling of covergroups
3.rv_timer_env_cfg: Removed TODO, Set num_interrupts=num timers
4.cip_base_vseq: intr_test- updated intr_enable random range
5.rv_timer_base_vseq, rv_timer_disabled_vseq: Corrected intr_pin cal