### PR TITLE
[gpio] Assert Known for outputs

### DIFF
--- a/hw/ip/gpio/rtl/gpio.sv
+++ b/hw/ip/gpio/rtl/gpio.sv
@@ -134,4 +134,9 @@ module gpio (
     .devmode_i  (1'b1)
   );
 
+  // Assert Known: Outputs
+  `ASSERT_KNOWN(intrGpioKnown, intr_gpio_o, clk_i, !rst_ni)
+  `ASSERT_KNOWN(CioGpioEnOKnown, cio_gpio_en_o, clk_i, !rst_ni)
+  `ASSERT_KNOWN(CioGpioOKnown, cio_gpio_o, clk_i, !rst_ni)
+
 endmodule


### PR DESCRIPTION
Known assertions are added to make sure the outputs of GPIO have known
value.

Exception: other than interrupts, output port can be unknown if output
enable is de-asserted.

This is related to #405