### PR TITLE
[fpga] Fixes to fpga tools inferring ROM

### DIFF
--- a/hw/ip/prim/abstract/prim_rom.sv
+++ b/hw/ip/prim/abstract/prim_rom.sv
@@ -19,7 +19,8 @@ module prim_rom #(
   if (Impl == "generic") begin: gen_mem_generic
     prim_generic_rom #(
       .Width(Width),
-      .Depth(Depth)
+      .Depth(Depth),
+      .Init(1)
     ) u_impl_generic (
       .clk_i,
       .rst_ni,
@@ -29,15 +30,23 @@ module prim_rom #(
       .dvalid_o
     );
   end else if (Impl == "xilinx") begin: gen_rom_xilinx
-    prim_xilinx_rom #(
+    // For fpga synthesis, a ram is still used to ensure the tools can properly infer
+    // BRAM
+    prim_generic_ram_1p #(
       .Width(Width),
-      .Depth(Depth)
-    ) u_impl_generic (
+      .Depth(Depth),
+      .DataBitsPerMask(1),
+      .Init(1)
+    ) u_impl_xilinx (
       .clk_i,
+      .rst_ni,
+      .req_i(cs_i),
+      .write_i(1'b0),
       .addr_i,
-      .cs_i,
-      .dout_o,
-      .dvalid_o
+      .wdata_i(Width'(0)),
+      .wmask_i(1'b0),
+      .rvalid_o(dvalid_o),
+      .rdata_o(dout_o)
     );
   end else begin : gen_rom_unsupported_impl
     // TODO: Find code that works across tools and causes a compile failure

--- a/hw/ip/prim_generic/rtl/prim_generic_ram_1p.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_ram_1p.sv
@@ -8,6 +8,7 @@ module prim_generic_ram_1p #(
   parameter int Width           = 32, // bit
   parameter int Depth           = 128,
   parameter int DataBitsPerMask = 1, // Number of data bits per bit of write mask
+  parameter bit Init            = 0, // Initialize memory contents
   localparam int Aw             = $clog2(Depth)  // derived parameter
 ) (
   input clk_i,
@@ -72,6 +73,7 @@ module prim_generic_ram_1p #(
     endtask
   `endif
 
+  if (Init) begin : gen_init_memory
   `ifdef SRAM_INIT_FILE
       localparam MEM_FILE = `"`SRAM_INIT_FILE`";
     initial
@@ -80,4 +82,5 @@ module prim_generic_ram_1p #(
       $readmemh(MEM_FILE, mem);
     end
   `endif
+  end
 endmodule

--- a/hw/ip/prim_generic/rtl/prim_generic_rom.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_rom.sv
@@ -5,7 +5,8 @@
 module prim_generic_rom #(
   parameter  int Width     = 32,
   parameter  int Depth     = 2048, // 8kB default
-  parameter  int Aw        = $clog2(Depth)
+  parameter  int Aw        = $clog2(Depth),
+  parameter  bit Init      = 0
 ) (
   input                        clk_i,
   input                        rst_ni,
@@ -15,7 +16,7 @@ module prim_generic_rom #(
   output logic                 dvalid_o
 );
 
-  logic [Width-1:0] mem [Depth];
+ logic [Width-1:0] mem [Depth];
 
   always_ff @(posedge clk_i) begin
     if (cs_i) begin
@@ -52,6 +53,7 @@ module prim_generic_rom #(
     endtask
   `endif
 
+  if (Init) begin : gen_init_memory
   `ifdef ROM_INIT_FILEE
 
     localparam MEM_FILE = `"`ROM_INIT_FILE`";
@@ -60,4 +62,5 @@ module prim_generic_rom #(
       $readmemh(MEM_FILE, mem);
     end
   `endif
+  end
 endmodule

--- a/hw/top_earlgrey/doc/top_earlgrey.tpl.sv
+++ b/hw/top_earlgrey/doc/top_earlgrey.tpl.sv
@@ -5,7 +5,9 @@
 <% import re
 %>\
 module top_${top["name"]} #(
-  parameter bit IbexPipeLine = 0
+  parameter bit IbexPipeLine = 0,
+  parameter     Impl = "generic"
+
 ) (
   // Clock and Reset
   input               clk_i,
@@ -298,7 +300,8 @@ module top_${top["name"]} #(
   ## TODO: Replace emulated ROM to real ROM in ASIC SoC
   prim_rom #(
     .Width(${data_width}),
-    .Depth(${rom_depth})
+    .Depth(${rom_depth}),
+    .Impl(Impl)
   ) u_rom_${m["name"]} (
     .clk_i,
     % for key in resets:

--- a/hw/top_earlgrey/rtl/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey.sv
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module top_earlgrey #(
-  parameter bit IbexPipeLine = 0
+  parameter bit IbexPipeLine = 0,
+  parameter     Impl = "generic"
 ) (
   // Clock and Reset
   input               clk_i,
@@ -232,7 +233,8 @@ module top_earlgrey #(
 
   prim_rom #(
     .Width(32),
-    .Depth(2048)
+    .Depth(2048),
+    .Impl(Impl)
   ) u_rom_rom (
     .clk_i,
     .rst_ni   (sys_rst_n),

--- a/hw/top_earlgrey/rtl/top_earlgrey_nexysvideo.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_nexysvideo.sv
@@ -47,7 +47,8 @@ module top_earlgrey_nexysvideo (
 
   // Top-level design
   top_earlgrey #(
-    .IbexPipeLine(1)
+    .IbexPipeLine(1),
+    .Impl("xilinx")
   ) top_earlgrey (
     .clk_i                        (clk_sys),
     .rst_ni                       (rst_sys_n),

--- a/hw/top_earlgrey/top_earlgrey_nexysvideo.core
+++ b/hw/top_earlgrey/top_earlgrey_nexysvideo.core
@@ -26,10 +26,10 @@ parameters:
   # XXX: The VMEM file should be added to the sources of the Vivado project to
   # make the Vivado dependency tracking work. However this requires changes to
   # fusesoc first.
-  ROM_INIT_FILE:
+  SRAM_INIT_FILE:
     datatype: str
     description: SRAM initialization file in vmem hex format
-    default: "../../../../../sw/boot_rom/boot_rom.vmem"
+    default: "../../../../../sw/boot_rom/rom.vmem"
     paramtype: vlogdefine
   PRIM_DEFAULT_IMPL:
     datatype: str
@@ -44,7 +44,7 @@ targets:
       - files_constraints
     toplevel: top_earlgrey_nexysvideo
     parameters:
-      - ROM_INIT_FILE
+      - SRAM_INIT_FILE
       - PRIM_DEFAULT_IMPL=xilinx
     tools:
       vivado:


### PR DESCRIPTION
Related to #422

prim_rom now selects either ROM or RAM based on implementation target
It also is able to choose whether the selected memory should be init.

The init memory file is still global, that will be solved with a separate
PR.