### PR TITLE
[dv, uvmdvgen] fixes for issue 434

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env.sv
@@ -29,10 +29,12 @@ class cip_base_env #(type CFG_T               = cip_base_env_cfg,
     end
 
     // get vifs
-    if (!uvm_config_db#(intr_vif)::get(this, "", "intr_vif", cfg.intr_vif)) begin
+    if (!uvm_config_db#(intr_vif)::get(this, "", "intr_vif", cfg.intr_vif) &&
+        cfg.num_interrupts > 0) begin
       `uvm_fatal(get_full_name(), "failed to get intr_vif from uvm_config_db")
     end
-    if (!uvm_config_db#(alerts_vif)::get(this, "", "alerts_vif", cfg.alerts_vif)) begin
+    if (!uvm_config_db#(alerts_vif)::get(this, "", "alerts_vif", cfg.alerts_vif) &&
+        cfg.num_alerts > 0) begin
       `uvm_fatal(get_full_name(), "failed to get alerts_vif from uvm_config_db")
     end
     if (!uvm_config_db#(devmode_vif)::get(this, "", "devmode_vif", cfg.devmode_vif)) begin

--- a/util/uvmdvgen.py
+++ b/util/uvmdvgen.py
@@ -52,6 +52,20 @@ def main():
     )
 
     parser.add_argument(
+        "-hi",
+        "--has_interrupts",
+        default=False,
+        action='store_true',
+        help="""CIP has interrupts. Create interrupts interface in tb""")
+
+    parser.add_argument(
+        "-ha",
+        "--has_alerts",
+        default=False,
+        action='store_true',
+        help="""CIP has alerts. Create alerts interface in tb""")
+
+    parser.add_argument(
         "-ea",
         "--env_agents",
         nargs="+",
@@ -91,6 +105,8 @@ def main():
         if not args.env_agents: args.env_agents = []
         gen_env.gen_env(args.name, \
                         args.is_cip, \
+                        args.has_interrupts, \
+                        args.has_alerts, \
                         args.env_agents, \
                         args.env_outdir)
 

--- a/util/uvmdvgen/base_test.sv.tpl
+++ b/util/uvmdvgen/base_test.sv.tpl
@@ -2,10 +2,15 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+% if is_cip:
+class ${name}_base_test extends cip_base_test #(
+% else:
 class ${name}_base_test extends dv_base_test #(
+% endif
     .ENV_T(${name}_env),
     .CFG_T(${name}_env_cfg)
   );
+
   `uvm_component_utils(${name}_base_test)
   `uvm_component_new
 

--- a/util/uvmdvgen/env_cfg.sv.tpl
+++ b/util/uvmdvgen/env_cfg.sv.tpl
@@ -30,9 +30,14 @@ class ${name}_env_cfg extends dv_base_env_cfg #(.RAL_T(${name}_reg_block));
 % endfor
 % if is_cip:
 
-    // set num_interrupts & num_alerts which will be used to create coverage and more
-    num_interrupts = ral.intr_state.get_n_used_bits();
-    num_alerts = 0;
+    // set num_interrupts & num_alerts
+    begin
+      uvm_reg rg = ral.get_reg_by_name("intr_state");
+      if (rg != null) begin
+        num_interrupts = ral.intr_state.get_n_used_bits();
+      end
+      num_alerts = 0;
+    end
 % endif
   endfunction
 

--- a/util/uvmdvgen/env_pkg.sv.tpl
+++ b/util/uvmdvgen/env_pkg.sv.tpl
@@ -26,24 +26,6 @@ package ${name}_env_pkg;
   parameter uint ADDR_MAP_SIZE   = ;
 
   // types
-% if env_agents == []:
-  // forward declare classes to allow typedefs below
-  typedef class ${name}_env_cfg;
-  typedef class ${name}_env_cov;
-
-% endif
-% if env_agents == [] and is_cip:
-  // reuse cip_base_virtual_seqeuencer as is with the right parameter set
-  typedef class cip_base_virtual_sequencer #(
-% elif env_agents == [] and not is_cip:
-  // reuse dv_base_virtual_seqeuencer as is with the right parameter set
-  typedef class dv_base_virtual_sequencer #(
-% endif
-% if env_agents == []:
-      .CFG_T(${name}_env_cfg),
-      .COV_T(${name}_env_cov)
-  ) ${name}_virtual_sequencer;
-% endif
 
   // functions
 
@@ -51,9 +33,7 @@ package ${name}_env_pkg;
   `include "${name}_reg_block.sv"
   `include "${name}_env_cfg.sv"
   `include "${name}_env_cov.sv"
-% if env_agents != []:
   `include "${name}_virtual_sequencer.sv"
-% endif
   `include "${name}_scoreboard.sv"
   `include "${name}_env.sv"
   `include "${name}_vseq_list.sv"

--- a/util/uvmdvgen/gen_env.py
+++ b/util/uvmdvgen/gen_env.py
@@ -10,7 +10,7 @@ from mako.template import Template
 from pkg_resources import resource_filename
 
 
-def gen_env(name, is_cip, env_agents, root_dir):
+def gen_env(name, is_cip, has_interrupts, has_alerts, env_agents, root_dir):
     # yapf: disable
     # 4-tuple - sub-path, ip name, class name, file ext
     env_srcs = [('env',         name + '_', 'env_cfg',            '.sv'),
@@ -41,8 +41,6 @@ def gen_env(name, is_cip, env_agents, root_dir):
         src = tup[2]
         src_suffix = tup[3]
 
-        if env_agents == [] and src == "virtual_sequencer": continue
-
         ftpl = src + src_suffix + '.tpl'
         fname = src_prefix + src + src_suffix
 
@@ -53,7 +51,11 @@ def gen_env(name, is_cip, env_agents, root_dir):
         with open(path_dir + "/" + fname, 'w') as fout:
             try:
                 fout.write(
-                    tpl.render(name=name, is_cip=is_cip,
-                               env_agents=env_agents))
+                    tpl.render(
+                        name=name,
+                        is_cip=is_cip,
+                        has_interrupts=has_interrupts,
+                        has_alerts=has_alerts,
+                        env_agents=env_agents))
             except:
                 log.error(exceptions.text_error_template().render())

--- a/util/uvmdvgen/tb.sv.tpl
+++ b/util/uvmdvgen/tb.sv.tpl
@@ -15,15 +15,23 @@ module tb;
 
   wire clk, rst_n;
 % if is_cip:
+% if has_interrupts:
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
+% endif
+% if has_alerts:
   wire [NUM_MAX_ALERTS-1:0] alerts;
+% endif
 % endif
 
   // interfaces
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
 % if is_cip:
+% if has_interrupts:
   pins_if #(NUM_MAX_INTERRUPTS) intr_if(interrupts);
+% endif
+% if has_alerts:
   pins_if #(NUM_MAX_ALERTS) alerts_if(alerts);
+% endif
   pins_if #(1) devmode_if();
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
 % endif
@@ -52,8 +60,12 @@ module tb;
     clk_rst_if.set_active();
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
 % if is_cip:
+% if has_interrupts:
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
+% endif
+% if has_alerts:
     uvm_config_db#(alerts_vif)::set(null, "*.env", "alerts_vif", alerts_if);
+% endif
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
     uvm_config_db#(tlul_assert_vif)::set(null, "*.env", "tlul_assert_vif",
                                          tb.dut.tlul_assert_host);


### PR DESCRIPTION
- fixed base test to extend from cip_base_test if cip
- added -hi and -ha switches to indicate if interrupts / alerts are to
  be created in the testbench
- removed typedef for virtual sequencer if there are no agents (always create it)