### PR TITLE
[dv] Fix xcelium compile errors

### DIFF
--- a/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
+++ b/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
@@ -55,8 +55,9 @@ class dv_base_env_cfg #(type RAL_T = dv_base_reg_block) extends uvm_object;
       `DV_CHECK_EQ_FATAL(is_aligned, 1'b1)
     end else begin
       // base address needs to be aligned to csr_addr_map_size
-      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(this.csr_base_addr,
-                                         ~|(this.csr_base_addr & (this.csr_addr_map_size - 1));)
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(csr_base_addr,
+                                         ~|(csr_base_addr & (csr_addr_map_size - 1));)
+      this.csr_base_addr = csr_base_addr;
     end
     // build the ral model
     if (has_ral) begin

--- a/hw/dv/sv/sw_msg_monitor_if/sw_msg_monitor_if.sv
+++ b/hw/dv/sv/sw_msg_monitor_if/sw_msg_monitor_if.sv
@@ -125,8 +125,11 @@ interface sw_msg_monitor_if #(
 
   // function to add the msg dat files
   function automatic void add_sw_msg_data_files(string img_name, string img_file);
+    sw_msg_data_file_t sw_msg_data_file;
     if (_ready) msg_fatal(.msg("this function cannot be called after calling ready()"));
-    sw_msg_data_files.push_back({name:img_name, file:img_file});
+    sw_msg_data_file.name = img_name;
+    sw_msg_data_file.file = img_file;
+    sw_msg_data_files.push_back(sw_msg_data_file);
   endfunction
 
   // signal to indicate all monitor is good to go - all initializations are done

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -35,17 +35,13 @@ class chip_env_cfg extends dv_base_env_cfg #(.RAL_T(chip_reg_block));
 
   `uvm_object_new
 
-  // chip csr base address starts at 0
-  constraint csr_base_addr_c {
-    csr_base_addr == 0;
-  }
-
-  virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1,
+  // TODO review value for csr_base_addr, csr_addr_map_size
+  virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = 0,
                                    bit [TL_AW-1:0] csr_addr_map_size = 2048);
 
     chip_mem_e mems[] = {Rom, FlashBank0, FlashBank1};
 
-    super.initialize();
+    super.initialize(csr_base_addr, csr_addr_map_size);
     // create uart agent config obj
     m_uart_agent_cfg = uart_agent_cfg::type_id::create("m_uart_agent_cfg");
     m_uart_agent_cfg.en_tx_monitor = 1'b0;

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -9,6 +9,7 @@ module tb;
   import tl_agent_pkg::*;
   import chip_env_pkg::*;
   import top_pkg::*;
+  import chip_test_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"


### PR DESCRIPTION
1. std:randomize can be only used for local variable
2. fix top TB compile errors