### PR TITLE
[dv/uvmdvgen] Correct typo and hierarchical path of tlul_assert

### DIFF
--- a/hw/dv/sv/dv_lib/dv_base_vseq.sv
+++ b/hw/dv/sv/dv_lib/dv_base_vseq.sv
@@ -76,7 +76,7 @@ class dv_base_vseq #(type RAL_T               = dv_base_reg_block,
   endtask
 
   // function to add csr exclusions of the given type using the csr_excl_item item
-  // arg csr_test_type: this the the type of csr test run - we may way aditional exclusions
+  // arg csr_test_type: this the the type of csr test run - we may want additional exclusions
   // depending on what test seq we are running
   // arg csr_excl: this is the csr exclusion object that maintains the list of exclusions
   // the same object handle is to be passed to csr sequences in csr_seq_lib so that they can query

--- a/util/uvmdvgen/bind.sv.tpl
+++ b/util/uvmdvgen/bind.sv.tpl
@@ -5,7 +5,7 @@
 module ${name}_bind;
 % if is_cip:
 
-  bind ${name} tlul_assert tlul_assert (
+  bind ${name} tlul_assert tlul_assert_host (
     .clk_i,
     .rst_ni,
     .h2d  (tl_i),


### PR DESCRIPTION
The assertion bind file names the `tlul_assert` instance `tlul_assert`, hence this did not compile out of the box as the hierarchical path pointed to `tb.dut.tlul_assert_host`.