### PR TITLE
[dv gpio] Updates related to coverage, gpio weak pull and warnings' cleanup

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env_cov.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env_cov.sv
@@ -5,9 +5,9 @@
 // put these covergoups outside the class in order to create them anywhere after get cfg object
 // if more than one interrupt/alert registers, these can be reused
 // in extended cov class, better to have the covergroup inside the class and create in new function
-covergroup intr_covergroup (uint num_interrupts) with function sample(uint intr,
-                                                                      bit intr_en,
-                                                                      bit intr_state);
+covergroup intr_cg (uint num_interrupts) with function sample(uint intr,
+                                                              bit intr_en,
+                                                              bit intr_state);
   cp_intr: coverpoint intr {
     bins all_values[] = {[0:num_interrupts-1]};
   }
@@ -16,10 +16,10 @@ covergroup intr_covergroup (uint num_interrupts) with function sample(uint intr,
   cross cp_intr, cp_intr_en, cp_intr_state;
 endgroup
 
-covergroup intr_test_covergroup (uint num_interrupts) with function sample(uint intr,
-                                                                           bit intr_test,
-                                                                           bit intr_en,
-                                                                           bit intr_state);
+covergroup intr_test_cg (uint num_interrupts) with function sample(uint intr,
+                                                                   bit intr_test,
+                                                                   bit intr_en,
+                                                                   bit intr_state);
   cp_intr: coverpoint intr {
     bins all_values[] = {[0:num_interrupts-1]};
   }
@@ -34,7 +34,7 @@ covergroup intr_test_covergroup (uint num_interrupts) with function sample(uint 
   }
 endgroup
 
-covergroup intr_pins_covergroup (uint num_interrupts) with function sample(uint intr_pin, bit intr_pin_value);
+covergroup intr_pins_cg (uint num_interrupts) with function sample(uint intr_pin, bit intr_pin_value);
   cp_intr_pin: coverpoint intr_pin {
     bins all_pins[] = {[0:num_interrupts-1]};
   }
@@ -45,7 +45,7 @@ covergroup intr_pins_covergroup (uint num_interrupts) with function sample(uint 
   cp_intr_pins_all_values: cross cp_intr_pin, cp_intr_pin_value;
 endgroup
 
-covergroup alert_covergroup (uint num_alerts) with function sample(uint alert);
+covergroup alert_cg (uint num_alerts) with function sample(uint alert);
   cp_alert: coverpoint alert {
     bins all_values[] = {[0:num_alerts-1]};
   }
@@ -54,10 +54,14 @@ endgroup
 class cip_base_env_cov #(type CFG_T = cip_base_env_cfg) extends dv_base_env_cov #(CFG_T);
   `uvm_component_param_utils(cip_base_env_cov #(CFG_T))
 
-  intr_covergroup      intr_cg;
-  intr_test_covergroup intr_test_cg;
-  intr_pins_covergroup intr_pins_cg;
-  alert_covergroup     alert_cg;
+  intr_cg        intr_cg;
+  intr_test_cg   intr_test_cg;
+  intr_pins_cg   intr_pins_cg;
+  alert_cg       alert_cg;
+  // Coverage for sticky interrupt functionality described in CIP specification
+  // As some interrupts are non-sticky, this covergroup should be populated on "as and when needed" basis
+  // in extended <ip>_env_cov class for interrupt types that are sticky
+  dv_base_generic_cov_obj sticky_intr_cov[string];
 
   `uvm_component_new
 

--- a/hw/dv/sv/common_ifs/pins_if.sv
+++ b/hw/dv/sv/common_ifs/pins_if.sv
@@ -75,7 +75,14 @@ interface pins_if #(
     for (genvar i = 0; i < Width; i++) begin : each_pin
       assign pins_int[i] = pins_pd[i] ? 1'b0 :
                            pins_pu[i] ? 1'b1 : 1'bz;
-      assign (pull0, pull1) pins[i] = pins_oe[i] ? pins_o[i] : pins_int[i];
+      // If output enable is 1, strong driver assigns pin to 'value to be driven out';
+      // the external strong driver can still affect pin, if exists.
+      // Else if output enable is 0, weak pullup or pulldown is applied to pin.
+      // By doing this, we make sure that weak pullup or pulldown does not override
+      // any 'x' value on pin, that may result due to conflicting values
+      // between 'value to be driven out' and the external driver's value.
+      assign pins[i] = pins_oe[i] ? pins_o[i] : 1'bz;
+      assign (pull0, pull1) pins[i] = ~pins_oe[i] ? pins_int[i] : 1'bz;
     end
   endgenerate
 

--- a/hw/dv/sv/dv_lib/dv_base_env_cov.sv
+++ b/hw/dv/sv/dv_lib/dv_base_env_cov.sv
@@ -5,25 +5,24 @@
 // TODO - We are enclosing generic covergroups inside class so that we can
 // take avoid tool limitation of not allowing arrays of covergroup
 // Refer to Issue#375 for more details
-class dv_base_generic_cov_obj extends uvm_object;
-  `uvm_object_utils(dv_base_generic_cov_obj)
+class dv_base_generic_cov_obj;
 
   // Covergroup: bit_toggle_cg
   // Generic covergroup definition
-  covergroup bit_toggle_cg(string name) with function sample(bit value);
+  covergroup bit_toggle_cg(string name, bit toggle_cov_en = 1) with function sample(bit value);
     option.per_instance = 1;
     option.name = name;
     cp_value: coverpoint value;
     cp_transitions: coverpoint value {
+      option.weight = toggle_cov_en;
       bins rising  = (0 => 1);
       bins falling = (1 => 0);
     }
   endgroup : bit_toggle_cg
 
   // Function: new
-  function new(string name="dv_base_generic_cov_obj");
-    super.new(name);
-    bit_toggle_cg = new(name);
+  function new(string name = "dv_base_generic_cov_obj", bit toggle_cov_en = 1);
+    bit_toggle_cg = new(name, toggle_cov_en);
   endfunction : new
 
   // Function: sample

--- a/hw/dv/sv/dv_utils/dv_macros.svh
+++ b/hw/dv/sv/dv_utils/dv_macros.svh
@@ -184,7 +184,7 @@
 
 // Shorthand for common std::randomize(foo) with { } + fatal check
 `ifndef DV_CHECK_STD_RANDOMIZE_WITH_FATAL
-  `define DV_CHECK_STD_RANDOMIZE_WITH_FATAL(VAR_, WITH_C_,MSG_="Randomization failed!",ID_=`gfn) \
+  `define DV_CHECK_STD_RANDOMIZE_WITH_FATAL(VAR_, WITH_C_, MSG_="Randomization failed!",ID_=`gfn) \
     `DV_CHECK_FATAL(std::randomize(VAR_) with {WITH_C_}, MSG_, ID_)
 `endif
 

--- a/hw/dv/sv/mem_model/mem_model.sv
+++ b/hw/dv/sv/mem_model/mem_model.sv
@@ -24,7 +24,7 @@ class mem_model #(int AddrWidth = top_pkg::TL_AW,
                 $sformatf("Read Mem  : Addr[0x%0h], Data[0x%0h]", addr, data), UVM_HIGH)
     end
     else begin
-      std::randomize(data);
+      `DV_CHECK_STD_RANDOMIZE_FATAL(data)
       `uvm_error(get_full_name(), $sformatf("read to uninitialzed addr 0x%0h", addr))
     end
     return data;

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_intr_with_filter_rand_intr_event_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_intr_with_filter_rand_intr_event_vseq.sv
@@ -155,7 +155,7 @@ class gpio_intr_with_filter_rand_intr_event_vseq extends gpio_base_vseq;
                   1: csr_rd_check(.ptr(ral.data_in), .compare_value(expected_value_data_in));
                 endcase
               end
-              while(num_cycles_elapsed < (FILTER_CYCLES -2));
+              while (num_cycles_elapsed < (FILTER_CYCLES -2));
             end // csr_rd_and_check
           join // end fork..join
         end // csr_read_and_check

--- a/hw/ip/gpio/dv/tb/tb.sv
+++ b/hw/ip/gpio/dv/tb/tb.sv
@@ -16,6 +16,7 @@ module tb;
   `include "dv_macros.svh"
 
   wire clk, rst_n;
+  wire devmode;
   wire [NUM_GPIOS-1:0] gpio_pins;
   wire [NUM_GPIOS-1:0] gpio_i;
   wire [NUM_GPIOS-1:0] gpio_o;
@@ -28,7 +29,7 @@ module tb;
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
   pins_if #(NUM_MAX_INTERRUPTS) intr_if(.pins(interrupts));
   pins_if #(NUM_MAX_ALERTS) alerts_if(.pins(alerts));
-  pins_if #(1) devmode_if();
+  pins_if #(1) devmode_if(.pins(devmode));
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
   pins_if #(NUM_GPIOS) gpio_if(.pins(gpio_pins));
 

--- a/hw/ip/hmac/dv/tb/tb.sv
+++ b/hw/ip/hmac/dv/tb/tb.sv
@@ -15,6 +15,7 @@ module tb;
   `include "dv_macros.svh"
 
   wire clk, rst_n;
+  wire devmode;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
   wire [NUM_MAX_ALERTS-1:0] alerts;
 
@@ -25,7 +26,7 @@ module tb;
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
   pins_if #(NUM_MAX_INTERRUPTS) intr_if(.pins(interrupts));
   pins_if #(NUM_MAX_ALERTS) alerts_if(.pins(alerts));
-  pins_if #(1) devmode_if();
+  pins_if #(1) devmode_if(devmode);
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
 
   // dut

--- a/hw/ip/i2c/dv/tb/tb.sv
+++ b/hw/ip/i2c/dv/tb/tb.sv
@@ -14,6 +14,7 @@ module tb;
   `include "dv_macros.svh"
 
   wire clk, rst_n;
+  wire devmode;
   wire intr_fmt_watermark;
   wire intr_rx_watermark;
   wire intr_fmt_overflow;
@@ -30,7 +31,7 @@ module tb;
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
   pins_if #(NUM_MAX_INTERRUPTS) intr_if(interrupts);
   pins_if #(NUM_MAX_ALERTS) alerts_if(alerts);
-  pins_if #(1) devmode_if();
+  pins_if #(1) devmode_if(devmode);
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
   i2c_if i2c_if();
 

--- a/hw/ip/rv_timer/dv/tb/tb.sv
+++ b/hw/ip/rv_timer/dv/tb/tb.sv
@@ -15,6 +15,7 @@ module tb;
   `include "dv_macros.svh"
 
   wire clk, rst_n;
+  wire devmode;
   wire [NUM_HARTS-1:0][NUM_TIMERS-1:0] intr_timer_expired;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
   wire [NUM_MAX_ALERTS-1:0] alerts;
@@ -23,7 +24,7 @@ module tb;
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
   pins_if #(NUM_MAX_INTERRUPTS) intr_if(.pins(interrupts));
   pins_if #(NUM_MAX_ALERTS) alerts_if(.pins(alerts));
-  pins_if #(1) devmode_if();
+  pins_if #(1) devmode_if(devmode);
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
 
   // dut

--- a/hw/ip/spi_device/dv/tb/tb.sv
+++ b/hw/ip/spi_device/dv/tb/tb.sv
@@ -15,6 +15,7 @@ module tb;
   `include "dv_macros.svh"
 
   wire clk, rst_n;
+  wire devmode;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
   wire [NUM_MAX_ALERTS-1:0] alerts;
 
@@ -33,7 +34,7 @@ module tb;
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
   pins_if #(NUM_MAX_INTERRUPTS) intr_if(.pins(interrupts));
   pins_if #(NUM_MAX_ALERTS) alerts_if(.pins(alerts));
-  pins_if #(1) devmode_if();
+  pins_if #(1) devmode_if(devmode);
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
   spi_if spi_if(.rst_n(rst_n));
 

--- a/hw/ip/uart/dv/tb/tb.sv
+++ b/hw/ip/uart/dv/tb/tb.sv
@@ -15,6 +15,7 @@ module tb;
   `include "dv_macros.svh"
 
   wire clk, rst_n;
+  wire devmode;
   wire intr_tx_watermark;
   wire intr_rx_watermark;
   wire intr_tx_overflow;
@@ -30,7 +31,7 @@ module tb;
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
   pins_if #(NUM_MAX_INTERRUPTS) intr_if(interrupts);
   pins_if #(NUM_MAX_ALERTS) alerts_if(alerts);
-  pins_if #(1) devmode_if();
+  pins_if #(1) devmode_if(devmode);
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
   uart_if uart_if();
 


### PR DESCRIPTION
1. cip_base_env_cov.sv: covergroup for the case in which interrupt state is
   cleared and then set again due to active interrupt event
2. pins_if.sv: Modified the way weak pull up/down is implemented to avoid
   overriding 'x' with 0/1, when there are multiple conflicting drivers
3. */tb.tb.sv: Connect implict wire devmode to connect to devmode_if pins port
4. gpio_env_cov.sv: cross coverage involving *out* and *oe* registers along
   with data_in registers
5. gpio_scoreboard.sv: Sampling for new covergroups
6. mem_model.sv: Fix compile warning