### PR TITLE
[tlul] Revise full data check.

### DIFF
--- a/hw/ip/tlul/rtl/tlul_err.sv
+++ b/hw/ip/tlul/rtl/tlul_err.sv
@@ -52,7 +52,7 @@ module tlul_err import tlul_pkg::*; (
         'h0: begin // 1 Byte
           addr_sz_chk  = 1'b1;
           mask_chk     = ~|(tl_i.a_mask & ~mask);
-          fulldata_chk = mask_chk;
+          fulldata_chk = |(tl_i.a_mask & mask);
         end
 
         'h1: begin // 2 Byte


### PR DESCRIPTION
If `a_mask` is `0h` for 1 byte write, `tlul_err` did not raise an error
for PutFullData command. It is fixed to check a_mask with mask signal.

This is related to #236