### PR TITLE
[doc] Add project tracking files for pinmux, padctrl and alert_handler

### DIFF
--- a/hw/ip/alert_handler/doc/alert_handler.prj.hjson
+++ b/hw/ip/alert_handler/doc/alert_handler.prj.hjson
@@ -1,0 +1,7 @@
+{
+  name: "alert_handler",
+  version: 0.5,
+  life_stage: "L1",
+  design_stage: "D2",
+  verification_stage: "V0",
+}

--- a/hw/ip/padctrl/doc/padctrl.prj.hjson
+++ b/hw/ip/padctrl/doc/padctrl.prj.hjson
@@ -1,0 +1,7 @@
+{
+  name: "padctrl",
+  version: 0.5,
+  life_stage: "L1",
+  design_stage: "D2",
+  verification_stage: "V0",
+}

--- a/hw/ip/pinmux/doc/pinmux.prj.hjson
+++ b/hw/ip/pinmux/doc/pinmux.prj.hjson
@@ -1,0 +1,7 @@
+{
+  name: "pinmux",
+  version: 0.5,
+  life_stage: "L1",
+  design_stage: "D2",
+  verification_stage: "V0",
+}


### PR DESCRIPTION
I added the prj files for these modules. Let me know what you think about the stages. DV is a bit more than V0 on all these IPs, but I haven't written the corresponding testplans yet, so they cannot be V1.

 Is `/doc/` the right subfolder to place these files?