### PR TITLE
WIP [aes/rtl] Switch state array type

### DIFF
--- a/hw/ip/aes/rtl/aes_pkg.sv
+++ b/hw/ip/aes/rtl/aes_pkg.sv
@@ -73,4 +73,11 @@ function logic [7:0] aes_mul4(input logic [7:0] in);
   aes_mul4 = aes_mul2(aes_mul2(in));
 endfunction
 
+// Circular byte shift to the left
+function logic [31:0] aes_circ_byte_shift(input logic [31:0] in, int shift);
+  int s = shift % 4;
+  aes_circ_byte_shift = {in[8*((3-s)%4) +: 8], in[8*((2-s)%4) +: 8],
+                         in[8*((1-s)%4) +: 8], in[8*((0-s)%4) +: 8]};
+endfunction
+
 endpackage


### PR DESCRIPTION
Currently, the AES unit uses an unpacked array of type `logic [7:0] state [16]` to represent the internal state. This array type is well supported by tools, easy to understand, and directly relates to the `unsigned char state[16]` type used inside the C model.

However, unpacked array types also have disadvantages: They cannot be used as function outputs directly. As a consequence, some parts of the RTL are more verbose than strictly needed. In addition, if the one-dimensional array would be represented by a two-dim matrix (actually a 3D packed array), direct access to rows and columns of the state matrix would be allowed, which could further simplify the design.

This PR, currently Work-in-Progress, is used to draft the changes required to switch to a 2D packed array of bytes for representing the state.