### PR TITLE
[dv/csr_utils] Add more info to CSR error message and fix typos

### DIFF
--- a/hw/dv/sv/csr_utils/csr_seq_lib.sv
+++ b/hw/dv/sv/csr_utils/csr_seq_lib.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // CSR suite of sequences that do writes and reads to csrs
-// includes hw_reset, rw, bit_bash and alising tests for csrs, and mem_walk for uvm_mems
+// includes hw_reset, rw, bit_bash and aliasing tests for csrs, and mem_walk for uvm_mems
 // TODO: when mem backdoor is implemented, add uvm_mem_access_seq for backdoor rd
 // The sequences perform csr writes and reads and follow the standard csr test suite. If external
 // checker is enabled, then the external entity is required to update the mirrored value on

--- a/hw/dv/sv/csr_utils/csr_utils_pkg.sv
+++ b/hw/dv/sv/csr_utils/csr_utils_pkg.sv
@@ -337,7 +337,8 @@ package csr_utils_pkg;
             if (compare) begin
               obs = obs & compare_mask;
               exp = (compare_vs_ral ? exp : compare_value) & compare_mask;
-              `DV_CHECK_EQ(obs, exp, err_msg, error, msg_id)
+              `DV_CHECK_EQ(obs, exp, {"Regname: ", ptr.get_full_name(), " ", err_msg},
+                    error, msg_id)
             end
             decrement_outstanding_access();
           end

--- a/util/uvmdvgen/Makefile.tpl
+++ b/util/uvmdvgen/Makefile.tpl
@@ -3,7 +3,7 @@ ${'## Copyright lowRISC contributors.                                           
 ${'## Licensed under the Apache License, Version 2.0, see LICENSE for details.                       ##'}
 ${'## SPDX-License-Identifier: Apache-2.0                                                            ##'}
 ${'####################################################################################################'}
-${'## Entry point test Makefile forr building and running tests.                                     ##'}
+${'## Entry point test Makefile for building and running tests.                                      ##'}
 ${'## These are generic set of option groups that apply to all testbenches.                          ##'}
 ${'## This flow requires the following options to be set:                                            ##'}
 ${'## DV_DIR       - current dv directory that contains the test Makefile                            ##'}


### PR DESCRIPTION
This adds the register name to the error message, as shown in the following example:
```
UVM_ERROR @   7323457 ps: (csr_utils_pkg.sv:340) [csr_utils::csr_rd_check] Check failed obs == exp (1 [0x1] vs 0 [0x0]) Regname: ral.intr_state.classb 
```
I find that this makes debugging CSR checks somewhat easier when running on the command line only.
