### PR TITLE
[alert_handler] Small updates in alert handler logic and docu

### DIFF
--- a/hw/ip/alert_handler/doc/alert_handler.md
+++ b/hw/ip/alert_handler/doc/alert_handler.md
@@ -918,6 +918,11 @@ the interrupt as follows:
       class A interrupt state bit also clears and stops the interrupt timeout
       counter (if enabled).
 
+Note that testing interrupts by writing to the interrupt test registers does
+also trigger the internal interrupt timeout (if enabled), since the interrupt
+state is used as enable signal for the timer. However, alert accumulation will
+not be triggered by this testing mechanism.
+
 
 {{% section1 Additional Notes}}
 

--- a/hw/ip/alert_handler/rtl/alert_handler.sv
+++ b/hw/ip/alert_handler/rtl/alert_handler.sv
@@ -138,10 +138,10 @@ module alert_handler (
       .clk_i,
       .rst_ni,
       .clr_i        ( reg2hw_wrap.class_clr[k]          ),
-      .trig_i       ( hw2reg_wrap.class_trig[k]         ),
+      .class_trig_i ( hw2reg_wrap.class_trig[k]         ),
       .thresh_i     ( reg2hw_wrap.class_accum_thresh[k] ),
-      .cnt_o        ( hw2reg_wrap.class_accum_cnt[k]    ),
-      .trig_o       ( class_accum_trig[k]               )
+      .accu_cnt_o   ( hw2reg_wrap.class_accum_cnt[k]    ),
+      .accu_trig_o  ( class_accum_trig[k]               )
     );
 
     alert_handler_esc_timer i_esc_timer (

--- a/hw/ip/alert_handler/rtl/alert_handler_accu.sv
+++ b/hw/ip/alert_handler/rtl/alert_handler_accu.sv
@@ -4,7 +4,7 @@
 //
 // This module accumulates incoming alert triggers. Once the current accumulator
 // value is greater or equal the accumulator threshold, the next occurence of
-// trig_i will trigger escalation.
+// class_trig_i will trigger escalation.
 //
 // Note that the accumulator is implemented using a saturation counter which
 // does not wrap around.
@@ -13,22 +13,22 @@
 module alert_handler_accu (
   input                                   clk_i,
   input                                   rst_ni,
-  input                                   clr_i,     // clear the accumulator
-  input                                   trig_i,    // increments the accu
-  input        [alert_pkg::AccuCntDw-1:0] thresh_i,  // escalation trigger threshold
-  output logic [alert_pkg::AccuCntDw-1:0] cnt_o,     // output of current accu value
-  output logic                            trig_o     // escalation trigger output
+  input                                   clr_i,        // clear the accumulator
+  input                                   class_trig_i, // increments the accu
+  input        [alert_pkg::AccuCntDw-1:0] thresh_i,     // escalation trigger threshold
+  output logic [alert_pkg::AccuCntDw-1:0] accu_cnt_o,   // output of current accu value
+  output logic                            accu_trig_o   // escalation trigger output
 );
 
   logic [alert_pkg::AccuCntDw-1:0] accu_d, accu_q;
 
-  assign accu_d = (clr_i)                ? '0            : // clear
-                  (trig_i && !(&accu_q)) ? accu_q + 1'b1 : // saturate counter at maximum
-                                           accu_q;
+  assign accu_d = (clr_i)                      ? '0            : // clear
+                  (class_trig_i && !(&accu_q)) ? accu_q + 1'b1 : // saturate counter at maximum
+                                                 accu_q;
 
-  assign trig_o = (accu_q >= thresh_i) & trig_i;
+  assign accu_trig_o = (accu_q >= thresh_i) & class_trig_i;
 
-  assign cnt_o = accu_q;
+  assign accu_cnt_o = accu_q;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs
     if (!rst_ni) begin

--- a/hw/ip/alert_handler/rtl/alert_handler_esc_timer.sv
+++ b/hw/ip/alert_handler/rtl/alert_handler_esc_timer.sv
@@ -238,12 +238,12 @@ module alert_handler_esc_timer (
   `ASSERT(CheckAccumTrig1,  accum_trig_i && state_q == alert_pkg::Timeout && en_i |=>
       state_q == alert_pkg::Phase0, clk_i, !rst_ni)
   // Check if timeout correctly captured
-  `ASSERT(CheckTimeout0, !accum_trig_i && state_q == alert_pkg::Idle && timeout_en_i && en_i |=>
-      state_q == alert_pkg::Timeout, clk_i, !rst_ni)
-  `ASSERT(CheckTimeout1, !accum_trig_i && state_q == alert_pkg::Timeout && timeout_en_i |=>
-      state_q == alert_pkg::Timeout, clk_i, !rst_ni)
-  `ASSERT(CheckTimeout2, !accum_trig_i && state_q == alert_pkg::Timeout && !timeout_en_i |=>
-      state_q == alert_pkg::Idle, clk_i, !rst_ni)
+  `ASSERT(CheckTimeout0, state_q == alert_pkg::Idle && timeout_en_i && en_i && !cnt_ge |=>
+      state_q == alert_pkg::Timeout, clk_i, !rst_ni || accum_trig_i)
+  `ASSERT(CheckTimeout1, state_q == alert_pkg::Timeout && timeout_en_i  |=>
+      state_q == alert_pkg::Timeout, clk_i, !rst_ni || accum_trig_i)
+  `ASSERT(CheckTimeout2, state_q == alert_pkg::Timeout && !timeout_en_i |=>
+      state_q == alert_pkg::Idle, clk_i, !rst_ni || accum_trig_i)
   // Check if timeout correctly triggers escalation
   `ASSERT(CheckTimeoutTrig, state_q == alert_pkg::Timeout && timeout_en_i &&
       cnt_q == timeout_cyc_i |=> state_q == alert_pkg::Phase0, clk_i, !rst_ni)

--- a/hw/ip/alert_handler/rtl/alert_handler_reg_wrap.sv
+++ b/hw/ip/alert_handler/rtl/alert_handler_reg_wrap.sv
@@ -46,7 +46,7 @@ module alert_handler_reg_wrap (
     prim_intr_hw #(
       .Width(1)
     ) i_irq_classa (
-      .event_intr_i           ( hw2reg_wrap.class_trig[0] & reg2hw_wrap.class_en[0] ),
+      .event_intr_i           ( hw2reg_wrap.class_trig[0]    ),
       .reg2hw_intr_enable_q_i ( reg2hw.intr_enable.classa.q  ),
       .reg2hw_intr_test_q_i   ( reg2hw.intr_test.classa.q    ),
       .reg2hw_intr_test_qe_i  ( reg2hw.intr_test.classa.qe   ),
@@ -59,7 +59,7 @@ module alert_handler_reg_wrap (
     prim_intr_hw #(
       .Width(1)
     ) i_irq_classb (
-      .event_intr_i           ( hw2reg_wrap.class_trig[1] & reg2hw_wrap.class_en[1] ),
+      .event_intr_i           ( hw2reg_wrap.class_trig[1]    ),
       .reg2hw_intr_enable_q_i ( reg2hw.intr_enable.classb.q  ),
       .reg2hw_intr_test_q_i   ( reg2hw.intr_test.classb.q    ),
       .reg2hw_intr_test_qe_i  ( reg2hw.intr_test.classb.qe   ),
@@ -72,7 +72,7 @@ module alert_handler_reg_wrap (
     prim_intr_hw #(
       .Width(1)
     ) i_irq_classc (
-      .event_intr_i           ( hw2reg_wrap.class_trig[2] & reg2hw_wrap.class_en[2] ),
+      .event_intr_i           ( hw2reg_wrap.class_trig[2]    ),
       .reg2hw_intr_enable_q_i ( reg2hw.intr_enable.classc.q  ),
       .reg2hw_intr_test_q_i   ( reg2hw.intr_test.classc.q    ),
       .reg2hw_intr_test_qe_i  ( reg2hw.intr_test.classc.qe   ),
@@ -85,7 +85,7 @@ module alert_handler_reg_wrap (
     prim_intr_hw #(
       .Width(1)
     ) i_irq_classd (
-      .event_intr_i           ( hw2reg_wrap.class_trig[3] & reg2hw_wrap.class_en[3] ),
+      .event_intr_i           ( hw2reg_wrap.class_trig[3]    ),
       .reg2hw_intr_enable_q_i ( reg2hw.intr_enable.classd.q  ),
       .reg2hw_intr_test_q_i   ( reg2hw.intr_test.classd.q    ),
       .reg2hw_intr_test_qe_i  ( reg2hw.intr_test.classd.qe   ),


### PR DESCRIPTION
This PR introduces a few small changes in the alert handler. In particular:

- Some redundant signal qualifiers are deleted, and some signals are renamed for clarity
- Some assertions related to interrupt timeouts had to be corrected
- A paragraph on side effects of interrupt tests has been added to the docu
