### PR TITLE
[pinmux] Switch to correct parameter in regfile template

### DIFF
--- a/hw/ip/pinmux/doc/pinmux.tpl.hjson
+++ b/hw/ip/pinmux/doc/pinmux.tpl.hjson
@@ -54,7 +54,7 @@
 # inputs
     { multireg: { name:     "PERIPH_INSEL",
                   desc:     "Mux select for peripheral inputs.",
-                  count:    "NPeriphOut",
+                  count:    "NPeriphIn",
                   swaccess: "rw",
                   hwaccess: "hro",
                   regwen:   "REGEN",


### PR DESCRIPTION
The PERIPH_INSEL CSR had the wrong count parameter in its hjson
specification. This commit corrects that and sets the parameter
to `NPeriphIn`.