### PR TITLE
[dv/hmac] add datapath stress test

### DIFF
--- a/hw/ip/hmac/dv/Makefile
+++ b/hw/ip/hmac/dv/Makefile
@@ -39,6 +39,11 @@ ifeq (${TEST_NAME},hmac_back_pressure)
   RUN_OPTS      += +zero_delays=1
 endif
 
+ifeq (${TEST_NAME},hmac_datapath_stress)
+  UVM_TEST_SEQ   = hmac_datapath_stress_vseq
+  RUN_OPTS      += +zero_delays=1
+endif
+
 ifeq (${TEST_NAME},hmac_burst_wr)
   UVM_TEST_SEQ   = hmac_burst_wr_vseq
 endif

--- a/hw/ip/hmac/dv/env/hmac_env_pkg.sv
+++ b/hw/ip/hmac/dv/env/hmac_env_pkg.sv
@@ -26,6 +26,7 @@ package hmac_env_pkg;
   parameter uint32 HMAC_MSG_FIFO_SIZE        = 2048;
   parameter uint32 HMAC_MSG_FIFO_BASE        = 32'h800;
   parameter uint32 HMAC_MSG_FIFO_LAST_ADDR   = HMAC_MSG_FIFO_BASE + HMAC_MSG_FIFO_SIZE - 1;
+  parameter uint32 HMAC_HASH_SIZE            = 64;
   // 48 cycles of hashing, 16 cycles to rd next 16 words, 1 cycle to update digest
   parameter uint32 HMAC_MSG_PROCESS_CYCLES   = 65;
   // 80 cycles for hmac key padding

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_datapath_stress_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_datapath_stress_vseq.sv
@@ -1,0 +1,30 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// datapath_stress sequence will generate all message with size 1 and hmac_en
+// thus will have 2 hashes (one for key, one for msg) with the shortest message required
+// TODO: potentially use DV to check throughput here
+
+class hmac_datapath_stress_vseq extends hmac_sanity_vseq;
+  `uvm_object_utils(hmac_datapath_stress_vseq)
+  `uvm_object_new
+
+  rand int msg_size_base;
+
+  constraint msg_size_base_c {
+    msg_size_base dist {
+        0       :/1,
+        [1:156] :/1
+    };
+  }
+
+  constraint msg_c {
+    msg.size() == 1 + msg_size_base * HMAC_HASH_SIZE;
+  }
+
+  constraint hmac_en_c {
+    hmac_en == 1;
+  }
+
+endclass : hmac_datapath_stress_vseq

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_stress_all_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_stress_all_vseq.sv
@@ -14,6 +14,7 @@ class hmac_stress_all_vseq extends hmac_base_vseq;
                           "hmac_back_pressure_vseq",
                           "hmac_burst_wr_vseq",
                           "hmac_common_vseq", // for intr_test
+                          "hmac_datapath_stress_vseq",
                           "hmac_long_msg_vseq",
                           "hmac_test_vectors_sha_vseq",
                           "hmac_test_vectors_hmac_vseq"};

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_vseq_list.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_vseq_list.sv
@@ -10,5 +10,6 @@
 `include "hmac_back_pressure_vseq.sv"
 `include "hmac_burst_wr_vseq.sv"
 `include "hmac_common_vseq.sv"
+`include "hmac_datapath_stress_vseq.sv"
 `include "hmac_stress_all_vseq.sv"
 `include "hmac_reset_vseq.sv"


### PR DESCRIPTION
Datapath stress test uses the least amount of message for 2 hash cycles.
Thus the sequence always enable hmac with msg length = 1 byte.
Add the datapath stress test to stress_all_vseq