### PR TITLE
[uart/dv] Fix corner case for tx_empty

### DIFF
--- a/hw/ip/uart/dv/env/seq_lib/uart_tx_rx_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_tx_rx_vseq.sv
@@ -70,6 +70,10 @@ class uart_tx_rx_vseq extends uart_base_vseq;
   task pre_start();
     super.pre_start();
     num_trans.rand_mode(0);
+    // dly to send a_valid is controlled in uart vseq level. Don't add additional delay in tl
+    // driver as it may make tl happens at ignore period
+    cfg.m_tl_agent_cfg.a_valid_delay_min = 0;
+    cfg.m_tl_agent_cfg.a_valid_delay_max = 0;
   endtask
 
   task body();

--- a/hw/ip/uart/dv/env/uart_scoreboard.sv
+++ b/hw/ip/uart/dv/env/uart_scoreboard.sv
@@ -270,7 +270,7 @@ class uart_scoreboard extends cip_base_scoreboard #(.CFG_T(uart_env_cfg),
               end
 
               // when tx_q.size = 1 and it's at last 2 cycles, can't predict if txempty is set
-              if (!(tx_enabled && tx_q_size_at_addr_phase == 1
+              if (!(tx_enabled && tx_q_size_at_addr_phase inside {0, 1}
                     && is_in_ignored_period(UartTx))) begin
                 `DV_CHECK_EQ(get_field_val(ral.status.txempty, item.d_data), tx_empty_exp,
                     $sformatf("check tx_empty fail: uart_tx_clk_pulses = %0d, tx_q.size = %0d",


### PR DESCRIPTION
1. ignore checking tx_empty at last 2 cycles when txlvl is 0 or 1
2. make no delay on a_valid in tl_host_driver as we control delay in seq