### PR TITLE
[dv/common] optimize csr_partial read

### DIFF
--- a/hw/dv/sv/tl_agent/tl_reg_adapter.sv
+++ b/hw/dv/sv/tl_agent/tl_reg_adapter.sv
@@ -16,39 +16,29 @@ class tl_reg_adapter #(type ITEM_T = tl_seq_item) extends uvm_reg_adapter;
   endfunction : new
 
   function uvm_sequence_item reg2bus(const ref uvm_reg_bus_op rw);
-    ITEM_T  reg_item;
+    ITEM_T reg_item;
     reg_item = ITEM_T::type_id::create("reg_item");
 
-    // tlul support partial rd but follow protocol standards
-    // TODO: this code assumes TLUL data is always 32 bits wide, can explore more generic solution
-    // TODO: seq_item level implemented constraints, so the constraints below could be optimized
+    // TODO: add a knob to contrl the randomization in case TLUL implementation changes and does
+    // not support partial read/write
+    // randomize CSR partial or full read
+    // for partial read DUT always return the entire 4 bytes bus data
+    // if CSR full read (all bytes are enabled), randomly select full or partial read
+    // if CSR field read, will do a partial read if protocal allows by setting a_mask to byte_en
     if (rw.kind == UVM_READ) begin
-      reg_item.a_opcode = tlul_pkg::Get;
-      case ($countones(rw.byte_en))
-        3, 4: begin // no partial rd
-          reg_item.a_mask = 'hf;
-          reg_item.a_addr = rw.addr;
-        end
-        1: begin // partial rd 1 byte
-          reg_item.a_mask = rw.byte_en;
-          reg_item.a_addr = rw.addr + $clog2(rw.byte_en);
-        end
-        2: begin
-          if (rw.byte_en == 'b0110) begin // no partial rd
-            reg_item.a_mask = 'hf;
-            reg_item.a_addr = rw.addr;
-          end else begin // partial rd 2 bytes
-            reg_item.a_mask = rw.byte_en;
-            reg_item.a_addr = (rw.byte_en == 'b0011) ? rw.addr : rw.addr + 2;
-          end
-        end
-        default: begin
-          `uvm_fatal(`gtn, $sformatf("invalid byte_en value = 0x%0h", rw.byte_en));
-        end
-      endcase
-      reg_item.a_size = $clog2($countones(reg_item.a_mask));
-    end
-    else begin // randomize CSR partial or full write
+      if (rw.byte_en == '1) begin // csr full read
+        `DV_CHECK_RANDOMIZE_WITH_FATAL(reg_item,
+            a_opcode          == tlul_pkg::Get;
+            a_addr[TL_AW-1:2] == rw.addr[TL_AW-1:2];
+            a_mask dist {'1         :/ 1,
+                         [1:('1-1)] :/ 1};)
+      end else begin // csr field read
+        `DV_CHECK_RANDOMIZE_WITH_FATAL(reg_item,
+            a_opcode          == tlul_pkg::Get;
+            a_addr[TL_AW-1:2] == rw.addr[TL_AW-1:2];
+            a_mask            == rw.byte_en;)
+      end
+    end else begin // randomize CSR partial or full write
       // Actual width of the CSR may be < TL_DW bits depending on fields and their widths
       // In that case, the transaction size in bytes and partial write mask need to be at least as
       // wide as the CSR to be a valid transaction. Otherwise, the DUT can return an error response


### PR DESCRIPTION
Since seq_item has build in constraints for tlul protocol, reg2bus
function does not need to reconstraint for the field again.
In this commit CSR full read will be randomized to full or partial read,
CSR field read will keep its mask value and randomize the rest of the
fields.