### PR TITLE
[rv_dm/lint] Remove unused port

### DIFF
--- a/hw/ip/rv_dm/rtl/rv_dm.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm.sv
@@ -111,7 +111,6 @@ module rv_dm #(
   ) i_dm_csrs (
     .clk_i                   ( clk_i                 ),
     .rst_ni                  ( rst_ni                ),
-    .testmode_i              ( testmode_i            ),
     .dmi_rst_ni              ( dmi_rst_n             ),
     .dmi_req_valid_i         ( dmi_req_valid         ),
     .dmi_req_ready_o         ( dmi_req_ready         ),


### PR DESCRIPTION
This will be needed, once the cleaned up DM is upstream.