### PR TITLE
[top,tlgen] WIP fabric multi-clock support

### DIFF
--- a/hw/top_earlgrey/doc/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/doc/autogen/top_earlgrey.gen.hjson
@@ -15,6 +15,10 @@
       name: main
       freq: "100000000"
     }
+    {
+      name: fixed
+      freq: "100000000"
+    }
   ]
   resets:
   [
@@ -29,10 +33,16 @@
       clk: main
     }
     {
+      name: sys_fixed
+      type: leaf
+      root: sys
+      clk: fixed
+    }
+    {
       name: spi_device
       type: leaf
       root: sys
-      clk: main
+      clk: fixed
     }
   ]
   num_cores: "1"
@@ -43,11 +53,11 @@
       type: uart
       clock_connections:
       {
-        clk_i: main
+        clk_i: fixed
       }
       reset_connections:
       {
-        rst_ni: sys
+        rst_ni: sys_fixed
       }
       base_addr: 0x40000000
       size: 0x1000
@@ -120,11 +130,11 @@
       type: gpio
       clock_connections:
       {
-        clk_i: main
+        clk_i: fixed
       }
       reset_connections:
       {
-        rst_ni: sys
+        rst_ni: sys_fixed
       }
       base_addr: 0x40010000
       size: 0x1000
@@ -155,7 +165,7 @@
       type: spi_device
       clock_connections:
       {
-        clk_i: main
+        clk_i: fixed
       }
       reset_connections:
       {
@@ -285,11 +295,11 @@
       type: rv_timer
       clock_connections:
       {
-        clk_i: main
+        clk_i: fixed
       }
       reset_connections:
       {
-        rst_ni: sys
+        rst_ni: sys_fixed
       }
       base_addr: 0x40080000
       size: 0x1000
@@ -420,11 +430,13 @@
       clock_connections:
       {
         clk_main_i: main
+        clk_fixed_i: fixed
       }
-      reset: sys
+      reset: rst_main_ni
       reset_connections:
       {
         rst_main_ni: sys
+        rst_fixed_ni: sys_fixed
       }
       connections:
       {
@@ -468,7 +480,8 @@
         {
           name: corei
           type: host
-          clock: main
+          clock: clk_main_i
+          reset: rst_main_ni
           pipeline: "false"
           inst_type: rv_core_ibex
           pipeline_byp: "true"
@@ -476,7 +489,8 @@
         {
           name: cored
           type: host
-          clock: main
+          clock: clk_main_i
+          reset: rst_main_ni
           pipeline: "false"
           inst_type: rv_core_ibex
           pipeline_byp: "true"
@@ -484,7 +498,8 @@
         {
           name: dm_sba
           type: host
-          clock: main
+          clock: clk_main_i
+          reset: rst_main_ni
           pipeline_byp: "false"
           inst_type: rv_dm
           pipeline: "true"
@@ -492,7 +507,8 @@
         {
           name: rom
           type: device
-          clock: main
+          clock: clk_main_i
+          reset: rst_main_ni
           pipeline: "false"
           inst_type: rom
           base_addr: 0x00008000
@@ -502,7 +518,8 @@
         {
           name: debug_mem
           type: device
-          clock: main
+          clock: clk_main_i
+          reset: rst_main_ni
           pipeline_byp: "false"
           inst_type: rv_dm
           base_addr: 0x1A110000
@@ -512,7 +529,8 @@
         {
           name: ram_main
           type: device
-          clock: main
+          clock: clk_main_i
+          reset: rst_main_ni
           pipeline: "false"
           inst_type: ram_1p
           base_addr: 0x10000000
@@ -522,7 +540,8 @@
         {
           name: eflash
           type: device
-          clock: main
+          clock: clk_main_i
+          reset: rst_main_ni
           pipeline: "false"
           inst_type: eflash
           base_addr: 0x20000000
@@ -532,7 +551,8 @@
         {
           name: uart
           type: device
-          clock: main
+          clock: clk_fixed_i
+          reset: rst_fixed_ni
           pipeline_byp: "false"
           inst_type: uart
           base_addr: 0x40000000
@@ -542,7 +562,8 @@
         {
           name: gpio
           type: device
-          clock: main
+          clock: clk_fixed_i
+          reset: rst_fixed_ni
           pipeline_byp: "false"
           inst_type: gpio
           base_addr: 0x40010000
@@ -552,7 +573,8 @@
         {
           name: spi_device
           type: device
-          clock: main
+          clock: clk_fixed_i
+          reset: rst_fixed_ni
           pipeline_byp: "false"
           inst_type: spi_device
           base_addr: 0x40020000
@@ -562,7 +584,8 @@
         {
           name: flash_ctrl
           type: device
-          clock: main
+          clock: clk_main_i
+          reset: rst_main_ni
           pipeline_byp: "false"
           inst_type: flash_ctrl
           base_addr: 0x40030000
@@ -572,7 +595,8 @@
         {
           name: rv_timer
           type: device
-          clock: main
+          clock: clk_fixed_i
+          reset: rst_fixed_ni
           pipeline_byp: "false"
           inst_type: rv_timer
           base_addr: 0x40080000
@@ -582,7 +606,8 @@
         {
           name: hmac
           type: device
-          clock: main
+          clock: clk_main_i
+          reset: rst_main_ni
           pipeline_byp: "false"
           inst_type: hmac
           base_addr: 0x40120000
@@ -592,7 +617,8 @@
         {
           name: rv_plic
           type: device
-          clock: main
+          clock: clk_main_i
+          reset: rst_main_ni
           inst_type: rv_plic
           base_addr: 0x40090000
           size_byte: 0x1000
@@ -600,7 +626,7 @@
           pipeline: "true"
         }
       ]
-      clock: main
+      clock: clk_main_i
     }
   ]
   interrupt_module:

--- a/hw/top_earlgrey/doc/top_earlgrey.hjson
+++ b/hw/top_earlgrey/doc/top_earlgrey.hjson
@@ -10,6 +10,7 @@
 
   clocks: [
     { name: "main", freq: "100000000" }
+    { name: "fixed", freq: "100000000" }
   ]
 
   // Reset attributes
@@ -20,7 +21,8 @@
   resets: [
     { name: "lc", type: "root", clk: "main"}
     { name: "sys", type: "root", clk: "main"}
-    { name: "spi_device", type: "leaf", root: "sys", clk: "main"}
+    { name: "sys_fixed", type: "leaf", root: "sys", clk: "fixed"}
+    { name: "spi_device", type: "leaf", root: "sys", clk: "fixed"}
   ]
 
   // Number of cores: used in rv_plic and timer
@@ -37,25 +39,25 @@
       // clock connections defines the port to top level clock connection
       // the ip.hjson will declare the clock port names
       // If none are defined at ip.hjson, clk_i is used by default
-      clock_connections: {clk_i: "main"},
+      clock_connections: {clk_i: "fixed"},
 
       // reset connections defines the port to top level reset connection
       // the ip.hjson will declare the reset port names
       // If none are defined at ip.hjson, rst_ni is used by default
-      reset_connections: {rst_ni: "sys"},
+      reset_connections: {rst_ni: "sys_fixed"},
 
       base_addr: "0x40000000",
     },
     { name: "gpio",
       type: "gpio",
-      clock_connections: {clk_i: "main"},
-      reset_connections: {rst_ni: "sys"},
+      clock_connections: {clk_i: "fixed"},
+      reset_connections: {rst_ni: "sys_fixed"},
       base_addr: "0x40010000",
     }
 
     { name: "spi_device",
       type: "spi_device",
-      clock_connections: {clk_i: "main"},
+      clock_connections: {clk_i: "fixed"},
       reset_connections: {rst_ni: "spi_device"},
       base_addr: "0x40020000",
     },
@@ -67,8 +69,8 @@
     },
     { name: "rv_timer",
       type: "rv_timer",
-      clock_connections: {clk_i: "main"},
-      reset_connections: {rst_ni: "sys"},
+      clock_connections: {clk_i: "fixed"},
+      reset_connections: {rst_ni: "sys_fixed"},
       base_addr: "0x40080000",
     },
     { name: "hmac",
@@ -122,9 +124,9 @@
   // Assume xbar.hjson is located in the same directory of top.hjson
   xbar: [
     { name: "main",
-      clock_connections: {clk_main_i: "main"},
+      clock_connections: {clk_main_i: "main", clk_fixed_i: "fixed"},
       reset: "sys",
-      reset_connections: {rst_main_ni: "sys"}
+      reset_connections: {rst_main_ni: "sys", rst_fixed_ni: "sys_fixed"}
     },
   ],
 

--- a/hw/top_earlgrey/doc/xbar_main.hjson
+++ b/hw/top_earlgrey/doc/xbar_main.hjson
@@ -1,84 +1,97 @@
 { name: "main",
   type: "xbar",
-  clock: "main",
   clock_primary: "clk_main_i", // Main clock, used in sockets
+  other_clock_list: [ "clk_fixed_i" ] // Secondary clocks used by specific nodes
   reset_primary: "rst_main_ni", // Main reset, used in sockets
+  other_reset_list: [ "rst_fixed_ni" ] // Secondary clocks used by specific nodes
 
   nodes: [
     { name:  "corei",
       type:  "host",
-      clock: "main",
-
+      clock: "clk_main_i",
+      reset: "rst_main_ni",
       pipeline: "false"
 
     },
     { name:  "cored",
       type:  "host",
-      clock: "main",
-
+      clock: "clk_main_i",
+      reset: "rst_main_ni",
       pipeline: "false"
 
     },
     { name:  "dm_sba", // DM
       type:  "host",
-      clock: "main",
-
+      clock: "clk_main_i",
+      reset: "rst_main_ni",
       pipeline_byp: "false"
 
     },
     { name:      "rom",
       type:      "device",
-      clock:     "main",
+      clock:     "clk_main_i",
+      reset:     "rst_main_ni",
       pipeline:  "false",
     },
     { name:      "debug_mem",
       type:      "device",
       clock:     "main",
+      clock:     "clk_main_i",
+      reset:     "rst_main_ni",
       pipeline_byp: "false"
     },
     { name:      "ram_main",
       type:      "device",
-      clock:     "main",
+      clock:     "clk_main_i",
+      reset:     "rst_main_ni",
       pipeline:  "false",
     },
     { name:      "eflash",
       type:      "device",
-      clock:     "main",
+      clock:     "clk_main_i",
+      reset:     "rst_main_ni",
       pipeline:  "false",
     },
     { name:      "uart",
       type:      "device",
-      clock:     "main",
+      clock:     "clk_fixed_i",
+      reset:     "rst_fixed_ni",
       pipeline_byp: "false"
     },
     { name:      "gpio",
       type:      "device",
-      clock:     "main",
+      clock:     "clk_fixed_i",
+      reset:     "rst_fixed_ni",
       pipeline_byp: "false"
     },
     { name:      "spi_device",
       type:      "device",
-      clock:     "main",
+      clock:     "clk_fixed_i",
+      reset:     "rst_fixed_ni",
       pipeline_byp: "false"
     },
     { name:      "flash_ctrl",
       type:      "device",
-      clock:     "main",
+      clock:     "clk_main_i",
+      reset:     "rst_main_ni",
       pipeline_byp: "false"
     },
     { name:      "rv_timer",
       type:      "device",
-      clock:     "main",
+      clock:     "clk_fixed_i",
+      reset:     "rst_fixed_ni",
       pipeline_byp: "false"
     },
     { name:      "hmac",
       type:      "device",
-      clock:     "main"
+      clock:     "clk_main_i",
+      reset:     "rst_main_ni",
       pipeline_byp: "false"
     },
     { name:      "rv_plic",
       type:      "device",
-      clock:     "main",
+      clock:     "clk_main_i",
+      reset:     "rst_main_ni",
       inst_type: "rv_plic",
       base_addr: "0x40090000",
       size_byte: "0x1000",

--- a/hw/top_earlgrey/ip/xbar/doc/autogen/xbar_main.gen.hjson
+++ b/hw/top_earlgrey/ip/xbar/doc/autogen/xbar_main.gen.hjson
@@ -11,11 +11,13 @@
   clock_connections:
   {
     clk_main_i: main
+    clk_fixed_i: fixed
   }
-  reset: sys
+  reset: rst_main_ni
   reset_connections:
   {
     rst_main_ni: sys
+    rst_fixed_ni: sys_fixed
   }
   connections:
   {
@@ -59,7 +61,8 @@
     {
       name: corei
       type: host
-      clock: main
+      clock: clk_main_i
+      reset: rst_main_ni
       pipeline: "false"
       inst_type: rv_core_ibex
       pipeline_byp: "true"
@@ -67,7 +70,8 @@
     {
       name: cored
       type: host
-      clock: main
+      clock: clk_main_i
+      reset: rst_main_ni
       pipeline: "false"
       inst_type: rv_core_ibex
       pipeline_byp: "true"
@@ -75,7 +79,8 @@
     {
       name: dm_sba
       type: host
-      clock: main
+      clock: clk_main_i
+      reset: rst_main_ni
       pipeline_byp: "false"
       inst_type: rv_dm
       pipeline: "true"
@@ -83,7 +88,8 @@
     {
       name: rom
       type: device
-      clock: main
+      clock: clk_main_i
+      reset: rst_main_ni
       pipeline: "false"
       inst_type: rom
       base_addr: 0x00008000
@@ -93,7 +99,8 @@
     {
       name: debug_mem
       type: device
-      clock: main
+      clock: clk_main_i
+      reset: rst_main_ni
       pipeline_byp: "false"
       inst_type: rv_dm
       base_addr: 0x1A110000
@@ -103,7 +110,8 @@
     {
       name: ram_main
       type: device
-      clock: main
+      clock: clk_main_i
+      reset: rst_main_ni
       pipeline: "false"
       inst_type: ram_1p
       base_addr: 0x10000000
@@ -113,7 +121,8 @@
     {
       name: eflash
       type: device
-      clock: main
+      clock: clk_main_i
+      reset: rst_main_ni
       pipeline: "false"
       inst_type: eflash
       base_addr: 0x20000000
@@ -123,7 +132,8 @@
     {
       name: uart
       type: device
-      clock: main
+      clock: clk_fixed_i
+      reset: rst_fixed_ni
       pipeline_byp: "false"
       inst_type: uart
       base_addr: 0x40000000
@@ -133,7 +143,8 @@
     {
       name: gpio
       type: device
-      clock: main
+      clock: clk_fixed_i
+      reset: rst_fixed_ni
       pipeline_byp: "false"
       inst_type: gpio
       base_addr: 0x40010000
@@ -143,7 +154,8 @@
     {
       name: spi_device
       type: device
-      clock: main
+      clock: clk_fixed_i
+      reset: rst_fixed_ni
       pipeline_byp: "false"
       inst_type: spi_device
       base_addr: 0x40020000
@@ -153,7 +165,8 @@
     {
       name: flash_ctrl
       type: device
-      clock: main
+      clock: clk_main_i
+      reset: rst_main_ni
       pipeline_byp: "false"
       inst_type: flash_ctrl
       base_addr: 0x40030000
@@ -163,7 +176,8 @@
     {
       name: rv_timer
       type: device
-      clock: main
+      clock: clk_fixed_i
+      reset: rst_fixed_ni
       pipeline_byp: "false"
       inst_type: rv_timer
       base_addr: 0x40080000
@@ -173,7 +187,8 @@
     {
       name: hmac
       type: device
-      clock: main
+      clock: clk_main_i
+      reset: rst_main_ni
       pipeline_byp: "false"
       inst_type: hmac
       base_addr: 0x40120000
@@ -183,7 +198,8 @@
     {
       name: rv_plic
       type: device
-      clock: main
+      clock: clk_main_i
+      reset: rst_main_ni
       inst_type: rv_plic
       base_addr: 0x40090000
       size_byte: 0x1000
@@ -191,5 +207,5 @@
       pipeline: "true"
     }
   ]
-  clock: main
+  clock: clk_main_i
 }

--- a/hw/top_earlgrey/ip/xbar/dv/autogen/xbar_main_bind.sv
+++ b/hw/top_earlgrey/ip/xbar/dv/autogen/xbar_main_bind.sv
@@ -7,88 +7,88 @@ module xbar_main_bind;
 
   // Host interfaces
   bind xbar_main tlul_assert tlul_assert_host_corei (
-    .clk_i  (clk_main_i),
-    .rst_ni (rst_main_ni),
+    .clk_i  (clk_clk_main_i_i),
+    .rst_ni (rst_clk_main_i_ni),
     .h2d    (tl_corei_i),
     .d2h    (tl_corei_o)
   );
   bind xbar_main tlul_assert tlul_assert_host_cored (
-    .clk_i  (clk_main_i),
-    .rst_ni (rst_main_ni),
+    .clk_i  (clk_clk_main_i_i),
+    .rst_ni (rst_clk_main_i_ni),
     .h2d    (tl_cored_i),
     .d2h    (tl_cored_o)
   );
   bind xbar_main tlul_assert tlul_assert_host_dm_sba (
-    .clk_i  (clk_main_i),
-    .rst_ni (rst_main_ni),
+    .clk_i  (clk_clk_main_i_i),
+    .rst_ni (rst_clk_main_i_ni),
     .h2d    (tl_dm_sba_i),
     .d2h    (tl_dm_sba_o)
   );
 
   // Device interfaces
   bind xbar_main tlul_assert tlul_assert_device_rom (
-    .clk_i  (clk_main_i),
-    .rst_ni (rst_main_ni),
+    .clk_i  (clk_clk_main_i_i),
+    .rst_ni (rst_clk_main_i_ni),
     .h2d    (tl_rom_o),
     .d2h    (tl_rom_i)
   );
   bind xbar_main tlul_assert tlul_assert_device_debug_mem (
-    .clk_i  (clk_main_i),
-    .rst_ni (rst_main_ni),
+    .clk_i  (clk_clk_main_i_i),
+    .rst_ni (rst_clk_main_i_ni),
     .h2d    (tl_debug_mem_o),
     .d2h    (tl_debug_mem_i)
   );
   bind xbar_main tlul_assert tlul_assert_device_ram_main (
-    .clk_i  (clk_main_i),
-    .rst_ni (rst_main_ni),
+    .clk_i  (clk_clk_main_i_i),
+    .rst_ni (rst_clk_main_i_ni),
     .h2d    (tl_ram_main_o),
     .d2h    (tl_ram_main_i)
   );
   bind xbar_main tlul_assert tlul_assert_device_eflash (
-    .clk_i  (clk_main_i),
-    .rst_ni (rst_main_ni),
+    .clk_i  (clk_clk_main_i_i),
+    .rst_ni (rst_clk_main_i_ni),
     .h2d    (tl_eflash_o),
     .d2h    (tl_eflash_i)
   );
   bind xbar_main tlul_assert tlul_assert_device_uart (
-    .clk_i  (clk_main_i),
-    .rst_ni (rst_main_ni),
+    .clk_i  (clk_clk_fixed_i_i),
+    .rst_ni (rst_clk_fixed_i_ni),
     .h2d    (tl_uart_o),
     .d2h    (tl_uart_i)
   );
   bind xbar_main tlul_assert tlul_assert_device_gpio (
-    .clk_i  (clk_main_i),
-    .rst_ni (rst_main_ni),
+    .clk_i  (clk_clk_fixed_i_i),
+    .rst_ni (rst_clk_fixed_i_ni),
     .h2d    (tl_gpio_o),
     .d2h    (tl_gpio_i)
   );
   bind xbar_main tlul_assert tlul_assert_device_spi_device (
-    .clk_i  (clk_main_i),
-    .rst_ni (rst_main_ni),
+    .clk_i  (clk_clk_fixed_i_i),
+    .rst_ni (rst_clk_fixed_i_ni),
     .h2d    (tl_spi_device_o),
     .d2h    (tl_spi_device_i)
   );
   bind xbar_main tlul_assert tlul_assert_device_flash_ctrl (
-    .clk_i  (clk_main_i),
-    .rst_ni (rst_main_ni),
+    .clk_i  (clk_clk_main_i_i),
+    .rst_ni (rst_clk_main_i_ni),
     .h2d    (tl_flash_ctrl_o),
     .d2h    (tl_flash_ctrl_i)
   );
   bind xbar_main tlul_assert tlul_assert_device_rv_timer (
-    .clk_i  (clk_main_i),
-    .rst_ni (rst_main_ni),
+    .clk_i  (clk_clk_fixed_i_i),
+    .rst_ni (rst_clk_fixed_i_ni),
     .h2d    (tl_rv_timer_o),
     .d2h    (tl_rv_timer_i)
   );
   bind xbar_main tlul_assert tlul_assert_device_hmac (
-    .clk_i  (clk_main_i),
-    .rst_ni (rst_main_ni),
+    .clk_i  (clk_clk_main_i_i),
+    .rst_ni (rst_clk_main_i_ni),
     .h2d    (tl_hmac_o),
     .d2h    (tl_hmac_i)
   );
   bind xbar_main tlul_assert tlul_assert_device_rv_plic (
-    .clk_i  (clk_main_i),
-    .rst_ni (rst_main_ni),
+    .clk_i  (clk_clk_main_i_i),
+    .rst_ni (rst_clk_main_i_ni),
     .h2d    (tl_rv_plic_o),
     .d2h    (tl_rv_plic_i)
   );

--- a/hw/top_earlgrey/ip/xbar/rtl/autogen/xbar_main.sv
+++ b/hw/top_earlgrey/ip/xbar/rtl/autogen/xbar_main.sv
@@ -26,46 +26,56 @@
 //       -> ram_main
 //     -> sm1_18
 //       -> eflash
-//     -> sm1_20
-//       -> uart
 //     -> sm1_21
-//       -> gpio
-//     -> sm1_22
-//       -> spi_device
+//       -> asf_20
+//         -> uart
 //     -> sm1_23
-//       -> flash_ctrl
-//     -> sm1_24
-//       -> rv_timer
+//       -> asf_22
+//         -> gpio
 //     -> sm1_25
-//       -> hmac
+//       -> asf_24
+//         -> spi_device
 //     -> sm1_26
+//       -> flash_ctrl
+//     -> sm1_28
+//       -> asf_27
+//         -> rv_timer
+//     -> sm1_29
+//       -> hmac
+//     -> sm1_30
 //       -> rv_plic
 // dm_sba
-//   -> s1n_27
+//   -> s1n_31
 //     -> sm1_15
 //       -> rom
 //     -> sm1_17
 //       -> ram_main
 //     -> sm1_18
 //       -> eflash
-//     -> sm1_20
-//       -> uart
 //     -> sm1_21
-//       -> gpio
-//     -> sm1_22
-//       -> spi_device
+//       -> asf_20
+//         -> uart
 //     -> sm1_23
-//       -> flash_ctrl
-//     -> sm1_24
-//       -> rv_timer
+//       -> asf_22
+//         -> gpio
 //     -> sm1_25
-//       -> hmac
+//       -> asf_24
+//         -> spi_device
 //     -> sm1_26
+//       -> flash_ctrl
+//     -> sm1_28
+//       -> asf_27
+//         -> rv_timer
+//     -> sm1_29
+//       -> hmac
+//     -> sm1_30
 //       -> rv_plic
 
 module xbar_main (
   input clk_main_i,
+  input clk_fixed_i,
   input rst_main_ni,
+  input rst_fixed_ni,
 
   // Host interfaces
   input  tlul_pkg::tl_h2d_t tl_corei_i,
@@ -153,12 +163,10 @@ module xbar_main (
   // Create steering signal
   logic [3:0] dev_sel_s1n_19;
 
-
-  tl_h2d_t tl_sm1_20_us_h2d [2];
-  tl_d2h_t tl_sm1_20_us_d2h [2];
-
-  tl_h2d_t tl_sm1_20_ds_h2d ;
-  tl_d2h_t tl_sm1_20_ds_d2h ;
+  tl_h2d_t tl_asf_20_us_h2d ;
+  tl_d2h_t tl_asf_20_us_d2h ;
+  tl_h2d_t tl_asf_20_ds_h2d ;
+  tl_d2h_t tl_asf_20_ds_d2h ;
 
 
   tl_h2d_t tl_sm1_21_us_h2d [2];
@@ -167,12 +175,10 @@ module xbar_main (
   tl_h2d_t tl_sm1_21_ds_h2d ;
   tl_d2h_t tl_sm1_21_ds_d2h ;
 
-
-  tl_h2d_t tl_sm1_22_us_h2d [2];
-  tl_d2h_t tl_sm1_22_us_d2h [2];
-
-  tl_h2d_t tl_sm1_22_ds_h2d ;
-  tl_d2h_t tl_sm1_22_ds_d2h ;
+  tl_h2d_t tl_asf_22_us_h2d ;
+  tl_d2h_t tl_asf_22_us_d2h ;
+  tl_h2d_t tl_asf_22_ds_h2d ;
+  tl_d2h_t tl_asf_22_ds_d2h ;
 
 
   tl_h2d_t tl_sm1_23_us_h2d [2];
@@ -181,12 +187,10 @@ module xbar_main (
   tl_h2d_t tl_sm1_23_ds_h2d ;
   tl_d2h_t tl_sm1_23_ds_d2h ;
 
-
-  tl_h2d_t tl_sm1_24_us_h2d [2];
-  tl_d2h_t tl_sm1_24_us_d2h [2];
-
-  tl_h2d_t tl_sm1_24_ds_h2d ;
-  tl_d2h_t tl_sm1_24_ds_d2h ;
+  tl_h2d_t tl_asf_24_us_h2d ;
+  tl_d2h_t tl_asf_24_us_d2h ;
+  tl_h2d_t tl_asf_24_ds_h2d ;
+  tl_d2h_t tl_asf_24_ds_d2h ;
 
 
   tl_h2d_t tl_sm1_25_us_h2d [2];
@@ -202,15 +206,41 @@ module xbar_main (
   tl_h2d_t tl_sm1_26_ds_h2d ;
   tl_d2h_t tl_sm1_26_ds_d2h ;
 
-  tl_h2d_t tl_s1n_27_us_h2d ;
-  tl_d2h_t tl_s1n_27_us_d2h ;
+  tl_h2d_t tl_asf_27_us_h2d ;
+  tl_d2h_t tl_asf_27_us_d2h ;
+  tl_h2d_t tl_asf_27_ds_h2d ;
+  tl_d2h_t tl_asf_27_ds_d2h ;
 
 
-  tl_h2d_t tl_s1n_27_ds_h2d [10];
-  tl_d2h_t tl_s1n_27_ds_d2h [10];
+  tl_h2d_t tl_sm1_28_us_h2d [2];
+  tl_d2h_t tl_sm1_28_us_d2h [2];
+
+  tl_h2d_t tl_sm1_28_ds_h2d ;
+  tl_d2h_t tl_sm1_28_ds_d2h ;
+
+
+  tl_h2d_t tl_sm1_29_us_h2d [2];
+  tl_d2h_t tl_sm1_29_us_d2h [2];
+
+  tl_h2d_t tl_sm1_29_ds_h2d ;
+  tl_d2h_t tl_sm1_29_ds_d2h ;
+
+
+  tl_h2d_t tl_sm1_30_us_h2d [2];
+  tl_d2h_t tl_sm1_30_us_d2h [2];
+
+  tl_h2d_t tl_sm1_30_ds_h2d ;
+  tl_d2h_t tl_sm1_30_ds_d2h ;
+
+  tl_h2d_t tl_s1n_31_us_h2d ;
+  tl_d2h_t tl_s1n_31_us_d2h ;
+
+
+  tl_h2d_t tl_s1n_31_ds_h2d [10];
+  tl_d2h_t tl_s1n_31_ds_d2h [10];
 
   // Create steering signal
-  logic [3:0] dev_sel_s1n_27;
+  logic [3:0] dev_sel_s1n_31;
 
 
 
@@ -238,56 +268,56 @@ module xbar_main (
   assign tl_sm1_18_us_h2d[1] = tl_s1n_19_ds_h2d[3];
   assign tl_s1n_19_ds_d2h[3] = tl_sm1_18_us_d2h[1];
 
-  assign tl_sm1_20_us_h2d[0] = tl_s1n_19_ds_h2d[4];
-  assign tl_s1n_19_ds_d2h[4] = tl_sm1_20_us_d2h[0];
+  assign tl_sm1_21_us_h2d[0] = tl_s1n_19_ds_h2d[4];
+  assign tl_s1n_19_ds_d2h[4] = tl_sm1_21_us_d2h[0];
 
-  assign tl_sm1_21_us_h2d[0] = tl_s1n_19_ds_h2d[5];
-  assign tl_s1n_19_ds_d2h[5] = tl_sm1_21_us_d2h[0];
+  assign tl_sm1_23_us_h2d[0] = tl_s1n_19_ds_h2d[5];
+  assign tl_s1n_19_ds_d2h[5] = tl_sm1_23_us_d2h[0];
 
-  assign tl_sm1_22_us_h2d[0] = tl_s1n_19_ds_h2d[6];
-  assign tl_s1n_19_ds_d2h[6] = tl_sm1_22_us_d2h[0];
+  assign tl_sm1_25_us_h2d[0] = tl_s1n_19_ds_h2d[6];
+  assign tl_s1n_19_ds_d2h[6] = tl_sm1_25_us_d2h[0];
 
-  assign tl_sm1_23_us_h2d[0] = tl_s1n_19_ds_h2d[7];
-  assign tl_s1n_19_ds_d2h[7] = tl_sm1_23_us_d2h[0];
+  assign tl_sm1_26_us_h2d[0] = tl_s1n_19_ds_h2d[7];
+  assign tl_s1n_19_ds_d2h[7] = tl_sm1_26_us_d2h[0];
 
-  assign tl_sm1_24_us_h2d[0] = tl_s1n_19_ds_h2d[8];
-  assign tl_s1n_19_ds_d2h[8] = tl_sm1_24_us_d2h[0];
+  assign tl_sm1_28_us_h2d[0] = tl_s1n_19_ds_h2d[8];
+  assign tl_s1n_19_ds_d2h[8] = tl_sm1_28_us_d2h[0];
 
-  assign tl_sm1_25_us_h2d[0] = tl_s1n_19_ds_h2d[9];
-  assign tl_s1n_19_ds_d2h[9] = tl_sm1_25_us_d2h[0];
+  assign tl_sm1_29_us_h2d[0] = tl_s1n_19_ds_h2d[9];
+  assign tl_s1n_19_ds_d2h[9] = tl_sm1_29_us_d2h[0];
 
-  assign tl_sm1_26_us_h2d[0] = tl_s1n_19_ds_h2d[10];
-  assign tl_s1n_19_ds_d2h[10] = tl_sm1_26_us_d2h[0];
+  assign tl_sm1_30_us_h2d[0] = tl_s1n_19_ds_h2d[10];
+  assign tl_s1n_19_ds_d2h[10] = tl_sm1_30_us_d2h[0];
 
-  assign tl_sm1_15_us_h2d[2] = tl_s1n_27_ds_h2d[0];
-  assign tl_s1n_27_ds_d2h[0] = tl_sm1_15_us_d2h[2];
+  assign tl_sm1_15_us_h2d[2] = tl_s1n_31_ds_h2d[0];
+  assign tl_s1n_31_ds_d2h[0] = tl_sm1_15_us_d2h[2];
 
-  assign tl_sm1_17_us_h2d[2] = tl_s1n_27_ds_h2d[1];
-  assign tl_s1n_27_ds_d2h[1] = tl_sm1_17_us_d2h[2];
+  assign tl_sm1_17_us_h2d[2] = tl_s1n_31_ds_h2d[1];
+  assign tl_s1n_31_ds_d2h[1] = tl_sm1_17_us_d2h[2];
 
-  assign tl_sm1_18_us_h2d[2] = tl_s1n_27_ds_h2d[2];
-  assign tl_s1n_27_ds_d2h[2] = tl_sm1_18_us_d2h[2];
+  assign tl_sm1_18_us_h2d[2] = tl_s1n_31_ds_h2d[2];
+  assign tl_s1n_31_ds_d2h[2] = tl_sm1_18_us_d2h[2];
 
-  assign tl_sm1_20_us_h2d[1] = tl_s1n_27_ds_h2d[3];
-  assign tl_s1n_27_ds_d2h[3] = tl_sm1_20_us_d2h[1];
+  assign tl_sm1_21_us_h2d[1] = tl_s1n_31_ds_h2d[3];
+  assign tl_s1n_31_ds_d2h[3] = tl_sm1_21_us_d2h[1];
 
-  assign tl_sm1_21_us_h2d[1] = tl_s1n_27_ds_h2d[4];
-  assign tl_s1n_27_ds_d2h[4] = tl_sm1_21_us_d2h[1];
+  assign tl_sm1_23_us_h2d[1] = tl_s1n_31_ds_h2d[4];
+  assign tl_s1n_31_ds_d2h[4] = tl_sm1_23_us_d2h[1];
 
-  assign tl_sm1_22_us_h2d[1] = tl_s1n_27_ds_h2d[5];
-  assign tl_s1n_27_ds_d2h[5] = tl_sm1_22_us_d2h[1];
+  assign tl_sm1_25_us_h2d[1] = tl_s1n_31_ds_h2d[5];
+  assign tl_s1n_31_ds_d2h[5] = tl_sm1_25_us_d2h[1];
 
-  assign tl_sm1_23_us_h2d[1] = tl_s1n_27_ds_h2d[6];
-  assign tl_s1n_27_ds_d2h[6] = tl_sm1_23_us_d2h[1];
+  assign tl_sm1_26_us_h2d[1] = tl_s1n_31_ds_h2d[6];
+  assign tl_s1n_31_ds_d2h[6] = tl_sm1_26_us_d2h[1];
 
-  assign tl_sm1_24_us_h2d[1] = tl_s1n_27_ds_h2d[7];
-  assign tl_s1n_27_ds_d2h[7] = tl_sm1_24_us_d2h[1];
+  assign tl_sm1_28_us_h2d[1] = tl_s1n_31_ds_h2d[7];
+  assign tl_s1n_31_ds_d2h[7] = tl_sm1_28_us_d2h[1];
 
-  assign tl_sm1_25_us_h2d[1] = tl_s1n_27_ds_h2d[8];
-  assign tl_s1n_27_ds_d2h[8] = tl_sm1_25_us_d2h[1];
+  assign tl_sm1_29_us_h2d[1] = tl_s1n_31_ds_h2d[8];
+  assign tl_s1n_31_ds_d2h[8] = tl_sm1_29_us_d2h[1];
 
-  assign tl_sm1_26_us_h2d[1] = tl_s1n_27_ds_h2d[9];
-  assign tl_s1n_27_ds_d2h[9] = tl_sm1_26_us_d2h[1];
+  assign tl_sm1_30_us_h2d[1] = tl_s1n_31_ds_h2d[9];
+  assign tl_s1n_31_ds_d2h[9] = tl_sm1_30_us_d2h[1];
 
   assign tl_s1n_14_us_h2d = tl_corei_i;
   assign tl_corei_o = tl_s1n_14_us_d2h;
@@ -307,29 +337,41 @@ module xbar_main (
   assign tl_s1n_19_us_h2d = tl_cored_i;
   assign tl_cored_o = tl_s1n_19_us_d2h;
 
-  assign tl_uart_o = tl_sm1_20_ds_h2d;
-  assign tl_sm1_20_ds_d2h = tl_uart_i;
+  assign tl_uart_o = tl_asf_20_ds_h2d;
+  assign tl_asf_20_ds_d2h = tl_uart_i;
 
-  assign tl_gpio_o = tl_sm1_21_ds_h2d;
-  assign tl_sm1_21_ds_d2h = tl_gpio_i;
+  assign tl_asf_20_us_h2d = tl_sm1_21_ds_h2d;
+  assign tl_sm1_21_ds_d2h = tl_asf_20_us_d2h;
 
-  assign tl_spi_device_o = tl_sm1_22_ds_h2d;
-  assign tl_sm1_22_ds_d2h = tl_spi_device_i;
+  assign tl_gpio_o = tl_asf_22_ds_h2d;
+  assign tl_asf_22_ds_d2h = tl_gpio_i;
 
-  assign tl_flash_ctrl_o = tl_sm1_23_ds_h2d;
-  assign tl_sm1_23_ds_d2h = tl_flash_ctrl_i;
+  assign tl_asf_22_us_h2d = tl_sm1_23_ds_h2d;
+  assign tl_sm1_23_ds_d2h = tl_asf_22_us_d2h;
 
-  assign tl_rv_timer_o = tl_sm1_24_ds_h2d;
-  assign tl_sm1_24_ds_d2h = tl_rv_timer_i;
+  assign tl_spi_device_o = tl_asf_24_ds_h2d;
+  assign tl_asf_24_ds_d2h = tl_spi_device_i;
 
-  assign tl_hmac_o = tl_sm1_25_ds_h2d;
-  assign tl_sm1_25_ds_d2h = tl_hmac_i;
+  assign tl_asf_24_us_h2d = tl_sm1_25_ds_h2d;
+  assign tl_sm1_25_ds_d2h = tl_asf_24_us_d2h;
 
-  assign tl_rv_plic_o = tl_sm1_26_ds_h2d;
-  assign tl_sm1_26_ds_d2h = tl_rv_plic_i;
+  assign tl_flash_ctrl_o = tl_sm1_26_ds_h2d;
+  assign tl_sm1_26_ds_d2h = tl_flash_ctrl_i;
 
-  assign tl_s1n_27_us_h2d = tl_dm_sba_i;
-  assign tl_dm_sba_o = tl_s1n_27_us_d2h;
+  assign tl_rv_timer_o = tl_asf_27_ds_h2d;
+  assign tl_asf_27_ds_d2h = tl_rv_timer_i;
+
+  assign tl_asf_27_us_h2d = tl_sm1_28_ds_h2d;
+  assign tl_sm1_28_ds_d2h = tl_asf_27_us_d2h;
+
+  assign tl_hmac_o = tl_sm1_29_ds_h2d;
+  assign tl_sm1_29_ds_d2h = tl_hmac_i;
+
+  assign tl_rv_plic_o = tl_sm1_30_ds_h2d;
+  assign tl_sm1_30_ds_d2h = tl_rv_plic_i;
+
+  assign tl_s1n_31_us_h2d = tl_dm_sba_i;
+  assign tl_dm_sba_o = tl_s1n_31_us_d2h;
 
   always_comb begin
     // default steering to generate error response if address is not within the range
@@ -375,27 +417,27 @@ module xbar_main (
 
   always_comb begin
     // default steering to generate error response if address is not within the range
-    dev_sel_s1n_27 = 4'd10;
-    if ((tl_s1n_27_us_h2d.a_address & ~(ADDR_MASK_ROM)) == ADDR_SPACE_ROM) begin
-      dev_sel_s1n_27 = 4'd0;
-    end else if ((tl_s1n_27_us_h2d.a_address & ~(ADDR_MASK_RAM_MAIN)) == ADDR_SPACE_RAM_MAIN) begin
-      dev_sel_s1n_27 = 4'd1;
-    end else if ((tl_s1n_27_us_h2d.a_address & ~(ADDR_MASK_EFLASH)) == ADDR_SPACE_EFLASH) begin
-      dev_sel_s1n_27 = 4'd2;
-    end else if ((tl_s1n_27_us_h2d.a_address & ~(ADDR_MASK_UART)) == ADDR_SPACE_UART) begin
-      dev_sel_s1n_27 = 4'd3;
-    end else if ((tl_s1n_27_us_h2d.a_address & ~(ADDR_MASK_GPIO)) == ADDR_SPACE_GPIO) begin
-      dev_sel_s1n_27 = 4'd4;
-    end else if ((tl_s1n_27_us_h2d.a_address & ~(ADDR_MASK_SPI_DEVICE)) == ADDR_SPACE_SPI_DEVICE) begin
-      dev_sel_s1n_27 = 4'd5;
-    end else if ((tl_s1n_27_us_h2d.a_address & ~(ADDR_MASK_FLASH_CTRL)) == ADDR_SPACE_FLASH_CTRL) begin
-      dev_sel_s1n_27 = 4'd6;
-    end else if ((tl_s1n_27_us_h2d.a_address & ~(ADDR_MASK_RV_TIMER)) == ADDR_SPACE_RV_TIMER) begin
-      dev_sel_s1n_27 = 4'd7;
-    end else if ((tl_s1n_27_us_h2d.a_address & ~(ADDR_MASK_HMAC)) == ADDR_SPACE_HMAC) begin
-      dev_sel_s1n_27 = 4'd8;
-    end else if ((tl_s1n_27_us_h2d.a_address & ~(ADDR_MASK_RV_PLIC)) == ADDR_SPACE_RV_PLIC) begin
-      dev_sel_s1n_27 = 4'd9;
+    dev_sel_s1n_31 = 4'd10;
+    if ((tl_s1n_31_us_h2d.a_address & ~(ADDR_MASK_ROM)) == ADDR_SPACE_ROM) begin
+      dev_sel_s1n_31 = 4'd0;
+    end else if ((tl_s1n_31_us_h2d.a_address & ~(ADDR_MASK_RAM_MAIN)) == ADDR_SPACE_RAM_MAIN) begin
+      dev_sel_s1n_31 = 4'd1;
+    end else if ((tl_s1n_31_us_h2d.a_address & ~(ADDR_MASK_EFLASH)) == ADDR_SPACE_EFLASH) begin
+      dev_sel_s1n_31 = 4'd2;
+    end else if ((tl_s1n_31_us_h2d.a_address & ~(ADDR_MASK_UART)) == ADDR_SPACE_UART) begin
+      dev_sel_s1n_31 = 4'd3;
+    end else if ((tl_s1n_31_us_h2d.a_address & ~(ADDR_MASK_GPIO)) == ADDR_SPACE_GPIO) begin
+      dev_sel_s1n_31 = 4'd4;
+    end else if ((tl_s1n_31_us_h2d.a_address & ~(ADDR_MASK_SPI_DEVICE)) == ADDR_SPACE_SPI_DEVICE) begin
+      dev_sel_s1n_31 = 4'd5;
+    end else if ((tl_s1n_31_us_h2d.a_address & ~(ADDR_MASK_FLASH_CTRL)) == ADDR_SPACE_FLASH_CTRL) begin
+      dev_sel_s1n_31 = 4'd6;
+    end else if ((tl_s1n_31_us_h2d.a_address & ~(ADDR_MASK_RV_TIMER)) == ADDR_SPACE_RV_TIMER) begin
+      dev_sel_s1n_31 = 4'd7;
+    end else if ((tl_s1n_31_us_h2d.a_address & ~(ADDR_MASK_HMAC)) == ADDR_SPACE_HMAC) begin
+      dev_sel_s1n_31 = 4'd8;
+    end else if ((tl_s1n_31_us_h2d.a_address & ~(ADDR_MASK_RV_PLIC)) == ADDR_SPACE_RV_PLIC) begin
+      dev_sel_s1n_31 = 4'd9;
     end
   end
 
@@ -487,25 +529,20 @@ module xbar_main (
     .tl_d_i       (tl_s1n_19_ds_d2h),
     .dev_select   (dev_sel_s1n_19)
   );
-  tlul_socket_m1 #(
-    .HReqPass  (2'h0),
-    .HRspPass  (2'h0),
-    .DReqPass  (1'b0),
-    .DRspPass  (1'b0),
-    .M         (2)
-  ) u_sm1_20 (
-    .clk_i        (clk_main_i),
-    .rst_ni       (rst_main_ni),
-    .tl_h_i       (tl_sm1_20_us_h2d),
-    .tl_h_o       (tl_sm1_20_us_d2h),
-    .tl_d_o       (tl_sm1_20_ds_h2d),
-    .tl_d_i       (tl_sm1_20_ds_d2h)
+  tlul_fifo_async #(
+    .ReqDepth        (3),// At least 3 to make async work
+    .RspDepth        (3) // At least 3 to make async work
+  ) u_asf_20 (
+    .clk_h_i      (clk_main_i),
+    .rst_h_ni     (rst_main_ni),
+    .clk_d_i      (clk_fixed_i),
+    .rst_d_ni     (rst_fixed_ni),
+    .tl_h_i       (tl_asf_20_us_h2d),
+    .tl_h_o       (tl_asf_20_us_d2h),
+    .tl_d_o       (tl_asf_20_ds_h2d),
+    .tl_d_i       (tl_asf_20_ds_d2h)
   );
   tlul_socket_m1 #(
-    .HReqPass  (2'h0),
-    .HRspPass  (2'h0),
-    .DReqPass  (1'b0),
-    .DRspPass  (1'b0),
     .M         (2)
   ) u_sm1_21 (
     .clk_i        (clk_main_i),
@@ -515,25 +552,20 @@ module xbar_main (
     .tl_d_o       (tl_sm1_21_ds_h2d),
     .tl_d_i       (tl_sm1_21_ds_d2h)
   );
-  tlul_socket_m1 #(
-    .HReqPass  (2'h0),
-    .HRspPass  (2'h0),
-    .DReqPass  (1'b0),
-    .DRspPass  (1'b0),
-    .M         (2)
-  ) u_sm1_22 (
-    .clk_i        (clk_main_i),
-    .rst_ni       (rst_main_ni),
-    .tl_h_i       (tl_sm1_22_us_h2d),
-    .tl_h_o       (tl_sm1_22_us_d2h),
-    .tl_d_o       (tl_sm1_22_ds_h2d),
-    .tl_d_i       (tl_sm1_22_ds_d2h)
+  tlul_fifo_async #(
+    .ReqDepth        (3),// At least 3 to make async work
+    .RspDepth        (3) // At least 3 to make async work
+  ) u_asf_22 (
+    .clk_h_i      (clk_main_i),
+    .rst_h_ni     (rst_main_ni),
+    .clk_d_i      (clk_fixed_i),
+    .rst_d_ni     (rst_fixed_ni),
+    .tl_h_i       (tl_asf_22_us_h2d),
+    .tl_h_o       (tl_asf_22_us_d2h),
+    .tl_d_o       (tl_asf_22_ds_h2d),
+    .tl_d_i       (tl_asf_22_ds_d2h)
   );
   tlul_socket_m1 #(
-    .HReqPass  (2'h0),
-    .HRspPass  (2'h0),
-    .DReqPass  (1'b0),
-    .DRspPass  (1'b0),
     .M         (2)
   ) u_sm1_23 (
     .clk_i        (clk_main_i),
@@ -543,25 +575,20 @@ module xbar_main (
     .tl_d_o       (tl_sm1_23_ds_h2d),
     .tl_d_i       (tl_sm1_23_ds_d2h)
   );
-  tlul_socket_m1 #(
-    .HReqPass  (2'h0),
-    .HRspPass  (2'h0),
-    .DReqPass  (1'b0),
-    .DRspPass  (1'b0),
-    .M         (2)
-  ) u_sm1_24 (
-    .clk_i        (clk_main_i),
-    .rst_ni       (rst_main_ni),
-    .tl_h_i       (tl_sm1_24_us_h2d),
-    .tl_h_o       (tl_sm1_24_us_d2h),
-    .tl_d_o       (tl_sm1_24_ds_h2d),
-    .tl_d_i       (tl_sm1_24_ds_d2h)
+  tlul_fifo_async #(
+    .ReqDepth        (3),// At least 3 to make async work
+    .RspDepth        (3) // At least 3 to make async work
+  ) u_asf_24 (
+    .clk_h_i      (clk_main_i),
+    .rst_h_ni     (rst_main_ni),
+    .clk_d_i      (clk_fixed_i),
+    .rst_d_ni     (rst_fixed_ni),
+    .tl_h_i       (tl_asf_24_us_h2d),
+    .tl_h_o       (tl_asf_24_us_d2h),
+    .tl_d_o       (tl_asf_24_ds_h2d),
+    .tl_d_i       (tl_asf_24_ds_d2h)
   );
   tlul_socket_m1 #(
-    .HReqPass  (2'h0),
-    .HRspPass  (2'h0),
-    .DReqPass  (1'b0),
-    .DRspPass  (1'b0),
     .M         (2)
   ) u_sm1_25 (
     .clk_i        (clk_main_i),
@@ -585,20 +612,71 @@ module xbar_main (
     .tl_d_o       (tl_sm1_26_ds_h2d),
     .tl_d_i       (tl_sm1_26_ds_d2h)
   );
+  tlul_fifo_async #(
+    .ReqDepth        (3),// At least 3 to make async work
+    .RspDepth        (3) // At least 3 to make async work
+  ) u_asf_27 (
+    .clk_h_i      (clk_main_i),
+    .rst_h_ni     (rst_main_ni),
+    .clk_d_i      (clk_fixed_i),
+    .rst_d_ni     (rst_fixed_ni),
+    .tl_h_i       (tl_asf_27_us_h2d),
+    .tl_h_o       (tl_asf_27_us_d2h),
+    .tl_d_o       (tl_asf_27_ds_h2d),
+    .tl_d_i       (tl_asf_27_ds_d2h)
+  );
+  tlul_socket_m1 #(
+    .M         (2)
+  ) u_sm1_28 (
+    .clk_i        (clk_main_i),
+    .rst_ni       (rst_main_ni),
+    .tl_h_i       (tl_sm1_28_us_h2d),
+    .tl_h_o       (tl_sm1_28_us_d2h),
+    .tl_d_o       (tl_sm1_28_ds_h2d),
+    .tl_d_i       (tl_sm1_28_ds_d2h)
+  );
+  tlul_socket_m1 #(
+    .HReqPass  (2'h0),
+    .HRspPass  (2'h0),
+    .DReqPass  (1'b0),
+    .DRspPass  (1'b0),
+    .M         (2)
+  ) u_sm1_29 (
+    .clk_i        (clk_main_i),
+    .rst_ni       (rst_main_ni),
+    .tl_h_i       (tl_sm1_29_us_h2d),
+    .tl_h_o       (tl_sm1_29_us_d2h),
+    .tl_d_o       (tl_sm1_29_ds_h2d),
+    .tl_d_i       (tl_sm1_29_ds_d2h)
+  );
+  tlul_socket_m1 #(
+    .HReqPass  (2'h0),
+    .HRspPass  (2'h0),
+    .DReqPass  (1'b0),
+    .DRspPass  (1'b0),
+    .M         (2)
+  ) u_sm1_30 (
+    .clk_i        (clk_main_i),
+    .rst_ni       (rst_main_ni),
+    .tl_h_i       (tl_sm1_30_us_h2d),
+    .tl_h_o       (tl_sm1_30_us_d2h),
+    .tl_d_o       (tl_sm1_30_ds_h2d),
+    .tl_d_i       (tl_sm1_30_ds_d2h)
+  );
   tlul_socket_1n #(
     .HReqPass  (1'b0),
     .HRspPass  (1'b0),
     .DReqPass  (10'h0),
     .DRspPass  (10'h0),
     .N         (10)
-  ) u_s1n_27 (
+  ) u_s1n_31 (
     .clk_i        (clk_main_i),
     .rst_ni       (rst_main_ni),
-    .tl_h_i       (tl_s1n_27_us_h2d),
-    .tl_h_o       (tl_s1n_27_us_d2h),
-    .tl_d_o       (tl_s1n_27_ds_h2d),
-    .tl_d_i       (tl_s1n_27_ds_d2h),
-    .dev_select   (dev_sel_s1n_27)
+    .tl_h_i       (tl_s1n_31_us_h2d),
+    .tl_h_o       (tl_s1n_31_us_d2h),
+    .tl_d_o       (tl_s1n_31_ds_h2d),
+    .tl_d_i       (tl_s1n_31_ds_d2h),
+    .dev_select   (dev_sel_s1n_31)
   );
 
 endmodule

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -80,10 +80,12 @@ module top_earlgrey #(
   //reset wires declaration
   logic lc_rst_n;
   logic sys_rst_n;
+  logic sys_fixed_rst_n;
   logic spi_device_rst_n;
 
   //clock wires declaration
   logic main_clk;
+  logic fixed_clk;
 
   logic [53:0]  intr_vector;
   // Interrupt source list
@@ -120,6 +122,7 @@ module top_earlgrey #(
 
   // clock assignments
   assign main_clk = clk_i;
+  assign fixed_clk = clk_i;
 
   // Non-debug module reset == reset for everything except for the debug module
   logic ndmreset_req;
@@ -131,6 +134,7 @@ module top_earlgrey #(
   assign sys_rst_n = (scanmode_i) ? lc_rst_n : ~ndmreset_req & lc_rst_n;
 
   //non-root reset assignments
+  assign sys_fixed_rst_n = sys_rst_n;
   assign spi_device_rst_n = sys_rst_n;
 
   // debug request from rv_dm to core
@@ -366,8 +370,8 @@ module top_earlgrey #(
       .intr_rx_timeout_o (intr_uart_rx_timeout),
       .intr_rx_parity_err_o (intr_uart_rx_parity_err),
 
-      .clk_i (main_clk),
-      .rst_ni (sys_rst_n)
+      .clk_i (fixed_clk),
+      .rst_ni (sys_fixed_rst_n)
   );
 
   gpio gpio (
@@ -378,8 +382,8 @@ module top_earlgrey #(
       .cio_gpio_en_o (cio_gpio_gpio_en_d2p_o),
       .intr_gpio_o (intr_gpio_gpio),
 
-      .clk_i (main_clk),
-      .rst_ni (sys_rst_n)
+      .clk_i (fixed_clk),
+      .rst_ni (sys_fixed_rst_n)
   );
 
   spi_device spi_device (
@@ -398,7 +402,7 @@ module top_earlgrey #(
       .intr_txunderflow_o (intr_spi_device_txunderflow),
 
       .scanmode_i   (scanmode_i),
-      .clk_i (main_clk),
+      .clk_i (fixed_clk),
       .rst_ni (spi_device_rst_n)
   );
 
@@ -423,8 +427,8 @@ module top_earlgrey #(
       .tl_o (tl_rv_timer_d_d2h),
       .intr_timer_expired_0_0_o (intr_rv_timer_timer_expired_0_0),
 
-      .clk_i (main_clk),
-      .rst_ni (sys_rst_n)
+      .clk_i (fixed_clk),
+      .rst_ni (sys_fixed_rst_n)
   );
 
   hmac hmac (
@@ -481,7 +485,9 @@ module top_earlgrey #(
   // TL-UL Crossbar
   xbar_main u_xbar_main (
     .clk_main_i (main_clk),
+    .clk_fixed_i (fixed_clk),
     .rst_main_ni (sys_rst_n),
+    .rst_fixed_ni (sys_fixed_rst_n),
     .tl_corei_i      (tl_corei_h_h2d),
     .tl_corei_o      (tl_corei_h_d2h),
     .tl_cored_i      (tl_cored_h_h2d),

--- a/util/tlgen/elaborate.py
+++ b/util/tlgen/elaborate.py
@@ -29,10 +29,12 @@ def elaborate(xbar):  # xbar: Xbar -> bool
     ## Build address map
     ## Each socket_1n should have address map
 
-    ## Gather clocks and resets
-    xbar.clocks = {xbar.clock
-                   } | {clk
-                        for node in xbar.nodes for clk in node.clocks}
+   ## Gather clocks and resets
+   ##xbar.clocks = {xbar.clock
+   ##               } | {clk
+   ##                    for node in xbar.nodes for clk in node.clocks}
+
+
 
     return True
 
@@ -66,12 +68,16 @@ def process_node(node, xbar):  # node: Node -> xbar: Xbar -> Xbar
         # (New Node) Create ASYNC_FIFO node
         new_node = Node(name="asf_" + str(len(xbar.nodes)),
                         node_type=NodeType.ASYNC_FIFO,
-                        clock=xbar.clock)
+                        clock=xbar.clock,reset=xbar.reset)
 
+        # if node is HOST, host clock synchronizes into xbar domain
+        # if node is DEVICE, xbar synchronizes into device clock domain
         if node.node_type == NodeType.HOST:
             new_node.clocks.insert(0, node.clocks[0])
+            new_node.resets.insert(0, node.resets[0])
         else:
             new_node.clocks.append(node.clocks[0])
+            new_node.resets.append(node.resets[0])
 
         xbar.insert_node(new_node, node)
 
@@ -82,7 +88,7 @@ def process_node(node, xbar):  # node: Node -> xbar: Xbar -> Xbar
         # (New node) Create SOCKET_M1 node
         new_node = Node(name="sm1_" + str(len(xbar.nodes)),
                         node_type=NodeType.SOCKET_M1,
-                        clock=xbar.clock)
+                        clock=xbar.clock,reset=xbar.reset)
         new_node.hdepth = 2
         new_node.hpass = 2**len(node.us) - 1
         new_node.ddepth = 2
@@ -95,7 +101,7 @@ def process_node(node, xbar):  # node: Node -> xbar: Xbar -> Xbar
         # (New node) Create SOCKET_1N node
         new_node = Node(name="s1n_" + str(len(xbar.nodes)),
                         node_type=NodeType.SOCKET_1N,
-                        clock=xbar.clock)
+                        clock=xbar.clock,reset=xbar.reset)
         new_node.hdepth = 2
         new_node.hpass = 1
         new_node.ddepth = 2

--- a/util/tlgen/generate.py
+++ b/util/tlgen/generate.py
@@ -2,12 +2,14 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+import logging as log
 from mako import exceptions
 from mako.template import Template
 from pkg_resources import resource_filename
 
 from .item import NodeType
 from .xbar import Xbar
+
 
 
 def generate(xbar):  #xbar: Xbar -> str

--- a/util/tlgen/item.py
+++ b/util/tlgen/item.py
@@ -41,7 +41,8 @@ class Node:
 
     name = ""  # name: str
     # node_type: NodeType
-    clocks = []  # Clocks  # Clock domain of the node
+    clocks = []  # Clocks  # clock domains of the node
+    resets = []  # Resets  # resets of the node
     # e.g. async_fifo in : clk_core , out : clk_main
 
 
@@ -64,9 +65,10 @@ class Node:
     # FIFO passtru option. default True
     pipeline_byp = True
 
-    def __init__(self, name, node_type, clock):
+    def __init__(self, name, node_type, clock, reset):
         self.name = name
         self.node_type = node_type
         self.clocks = [clock]
+        self.resets = [reset]
         self.us = []
         self.ds = []

--- a/util/tlgen/validate.py
+++ b/util/tlgen/validate.py
@@ -41,13 +41,20 @@ def validate(obj):  # OrderedDict -> Xbar
     xbar = Xbar()
     xbar.name = obj["name"].lower()
     xbar.clock = obj["clock"].lower()
-
+    xbar.reset = obj["reset"].lower()
     addr_ranges = []
+
+    # collection of all clocks and resets of this xbar
+    xbar.clocks = [clock for clock in obj["clock_connections"].keys()]
+    xbar.resets = [reset for reset in obj["reset_connections"].keys()]
 
     # Nodes
     for nodeobj in obj["nodes"]:
         clock = nodeobj["clock"].lower() if "clock" in nodeobj.keys(
         ) else xbar.clock
+
+        reset = nodeobj["reset"].lower() if "reset" in nodeobj.keys(
+        ) else xbar.reset
 
         if checkNameExist(nodeobj["name"], xbar):
             log.error("Duplicated name: %s" % (nodeobj["name"]))
@@ -55,7 +62,7 @@ def validate(obj):  # OrderedDict -> Xbar
 
         node = Node(name=nodeobj["name"].lower(),
                     node_type=get_nodetype(nodeobj["type"].lower()),
-                    clock=clock)
+                    clock=clock,reset=reset)
 
         if node.node_type == NodeType.DEVICE:
             # Add address obj["base_addr"], obj["size"])

--- a/util/tlgen/xbar.py
+++ b/util/tlgen/xbar.py
@@ -17,9 +17,11 @@ class Xbar:
     """
     nodes = []  # Nodes
     edges = []  # Edges
-    clock = ""  # str  # Main clock remove 'clk_' prefix
+    clock = ""  # str  # primary clock of xbar
+    reset = ""  # str  # primary reset of xbar
     name = ""  # str  # e.g. "main" --> main_xbar
-    clocks = []  # Clocks
+    clocks = []  # All clocks of xbar
+    resets = []  # All resets of xbar
 
     # prefix is useful if SoC has more than one Xbar
 
@@ -31,6 +33,7 @@ class Xbar:
         self.nodes = []
         self.edges = []
         self.clocks = []
+        self.resets = []
 
     def __repr__(self):
         out = "<Xbar(%s) #nodes:%d clock:%s" % (self.name, len(self.nodes),

--- a/util/tlgen/xbar.rtl.tpl.sv
+++ b/util/tlgen/xbar.rtl.tpl.sv
@@ -11,9 +11,11 @@ ${xbar.repr_tree(host, 0)}
 % endfor
 
 module xbar_${xbar.name} (
-% for clock in xbar.clocks:
-  input clk_${clock}_i,
-  input rst_${clock}_ni,
+% for c in xbar.clocks:
+  input ${c},
+% endfor
+% for r in xbar.resets:
+  input ${r},
 % endfor
 
   // Host interfaces
@@ -172,10 +174,10 @@ module xbar_${xbar.name} (
     .ReqDepth        (3),// At least 3 to make async work
     .RspDepth        (3) // At least 3 to make async work
   ) u_${block.name} (
-    .clk_h_i      (clk_${block.clocks[0]}_i),
-    .rst_h_ni     (rst_${block.clocks[0]}_ni),
-    .clk_d_i      (clk_${block.clocks[1]}_i),
-    .rst_d_ni     (rst_${block.clocks[1]}_ni),
+    .clk_h_i      (${block.clocks[0]}),
+    .rst_h_ni     (${block.resets[0]}),
+    .clk_d_i      (${block.clocks[1]}),
+    .rst_d_ni     (${block.resets[1]}),
     .tl_h_i       (tl_${block.name}_us_h2d),
     .tl_h_o       (tl_${block.name}_us_d2h),
     .tl_d_o       (tl_${block.name}_ds_h2d),
@@ -201,8 +203,8 @@ module xbar_${xbar.name} (
     % endif
     .N         (${len(block.ds)})
   ) u_${block.name} (
-    .clk_i        (clk_${xbar.clock}_i),
-    .rst_ni       (rst_${xbar.clock}_ni),
+    .clk_i        (${block.clocks[0]}),
+    .rst_ni       (${block.resets[0]}),
     .tl_h_i       (tl_${block.name}_us_h2d),
     .tl_h_o       (tl_${block.name}_us_d2h),
     .tl_d_o       (tl_${block.name}_ds_h2d),
@@ -229,8 +231,8 @@ module xbar_${xbar.name} (
     % endif
     .M         (${len(block.us)})
   ) u_${block.name} (
-    .clk_i        (clk_${xbar.clock}_i),
-    .rst_ni       (rst_${xbar.clock}_ni),
+    .clk_i        (${block.clocks[0]}),
+    .rst_ni       (${block.resets[0]}),
     .tl_h_i       (tl_${block.name}_us_h2d),
     .tl_h_o       (tl_${block.name}_us_d2h),
     .tl_d_o       (tl_${block.name}_ds_h2d),

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -58,8 +58,6 @@ def generate_xbars(top, out_path):
         if not tlgen.elaborate(xbar):
             log.error("Elaboration failed." + repr(xbar))
 
-        # Add clocks/resets to the top configuration
-        obj["clocks"] = xbar.clocks
         try:
             out_rtl, out_pkg, out_bind = tlgen.generate(xbar)
         except:

--- a/util/topgen/merge.py
+++ b/util/topgen/merge.py
@@ -119,6 +119,7 @@ def xbar_addhost(xbar, host):
         obj = {
             "name": host,
             "clock": xbar['clock'],
+            "reset": xbar['reset'],
             "type": "host",
             "inst_type": "",
             # The default matches RTL default
@@ -128,7 +129,12 @@ def xbar_addhost(xbar, host):
         }
         topxbar["nodes"].append(obj)
     else:
-        obj[0]["clock"] = xbar['clock']
+        if 'clock' not in obj[0]:
+            obj[0]["clock"] = xbar['clock']
+
+        if 'reset' not in obj[0]:
+            obj[0]["reset"] = xbar["reset"]
+
         obj[0]["inst_type"] = predefined_modules[
             host] if host in predefined_modules else ""
         obj[0]["pipeline"] = obj[0]["pipeline"] if "pipeline" in obj[
@@ -150,7 +156,8 @@ def process_pipeline_var(node):
 def xbar_adddevice(top, xbar, device):
     """Add device nodes information
 
-    - clock: comes from module if exist. use main top clock for memory as of now
+    - clock: comes from module if exist, use xbar default otherwise
+    - reset: comes from module if exist, use xbar default otherwise
     - inst_type: comes from module or memory if exist.
     - base_addr: comes from module or memory, or assume rv_plic?
     - size_byte: comes from module or memory
@@ -181,6 +188,7 @@ def xbar_adddevice(top, xbar, device):
                         "name": "debug_mem",
                         "type": "device",
                         "clock": xbar['clock'],
+                        "reset": xbar['reset'],
                         "inst_type": predefined_modules["debug_mem"],
                         "base_addr": top["debug_mem_base_addr"],
                         "size_byte": "0x1000",
@@ -211,6 +219,7 @@ def xbar_adddevice(top, xbar, device):
             "name" : device,
             "type" : "device",
             "clock" : deviceobj[0]["clock"],
+            "reset" : deviceobj[0]["reset"],
             "inst_type" : deviceobj[0]["type"],
             "base_addr" : deviceobj[0]["base_addr"],
             "size_byte": deviceobj[0]["size"],
@@ -253,8 +262,9 @@ def amend_xbar(top, xbar):
     else:
         topxbar["nodes"] = []
 
-
-    topxbar["clock"] = xbar["clock"]
+    # xbar primary clock and reset
+    topxbar["clock"] = xbar["clock_primary"]
+    topxbar["reset"] = xbar["reset_primary"]
 
     # Build nodes from 'connections'
     device_nodes = set()


### PR DESCRIPTION
Add the ability for fabric to support multiple clocks / resets
Also separate clock / reset connectivity at top.

This is a draft, and will probably need to be broken into two
commits / PRs later

At the moment, there is no check that the fabric node assignment
is consistent with the device clock / reset assignment. Does that
need to be added?

Also, the 'fixed' naming is terrible, we really need something better.