### PR TITLE
[test] Set up CI for the Verilator-based pytest.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -131,6 +131,17 @@ jobs:
       ninja -C build-verilator all
       ninja -C build-fpga all
     displayName: 'Build embedded targets'
+  # XXX: We do not package build-fpga, only build-verilator, since the results of this
+  # job are only used for testing, not distribution. Eventually, only this job will be
+  # used for distribution.
+  - bash: |
+      dist_tar="$(Build.ArtifactStagingDirectory)/dist-partial-verilator-sw_build.tar"
+      mkdir -p "$(Build.ArtifactStagingDirectory)"
+      tar -cf "$dist_tar" build-verilator
+    displayName: 'Prepare embedded Verilator distribution artifacts'
+  - publish: $(Build.ArtifactStagingDirectory)/dist-partial-verilator-sw_build.tar
+    artifact: dist-partial-verilator-sw_build
+    displayName: "Upload embedded Verilator distribution artifacts"
 
 - job: "deprecated_make_build"
   displayName: "Build Software with Make (deprecated)"
@@ -258,6 +269,35 @@ jobs:
   - publish: $(Build.ArtifactStagingDirectory)/dist-partial-top_earlgrey_nexysvideo.tar
     artifact: dist-partial-top_earlgrey_nexysvideo
     displayName: 'Upload partial distribution artifacts'
+
+- job: "execute_verilated_tests"
+  displayName: "Execute tests on the Verilated system"
+  pool: "Default"
+  dependsOn:
+    - lint
+    - top_earlgrey_verilator
+    - sw_build
+  condition: eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0')
+  steps:
+  - bash: |
+      sudo apt-get install -y python3 python3-pip build-essential python3-setuptools
+      sudo pip3 install -r python-requirements.txt
+    displayName: 'Install dependencies'
+  - download: current
+    artifact: 'dist-partial-top_earlgrey_verilator'
+    displayName: 'Download verilated simulator'
+  - download: current
+    artifact: 'dist-partial-verilator-sw_build'
+    displayName: 'Download embedded artifacts'
+  - bash: |
+      tar -xvf "$(Pipeline.Workspace)/dist-partial-top_earlgrey_verilator/dist-partial-top_earlgrey_verilator.tar"
+      tar -xvf "$(Pipeline.Workspace)/dist-partial-verilator-sw_build/dist-partial-verilator-sw_build.tar"
+    displayName: 'Unpack pipeline artifacts'
+  - bash: |
+      export VERILATED_SYSTEM_PATH="dist/hw/top_earlgrey/Vtop_earlgrey_verilator"
+      export SW_BUILD_PATH="build-verilator"
+      ci/run_verilator_pytest.sh
+    displayName: 'Execute tests'
 
 - job: "deploy_releaseartifacts"
   displayName: "Package and deploy release distribution"

--- a/ci/run_verilator_pytest.sh
+++ b/ci/run_verilator_pytest.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+set -e
+
+readonly VERILATED_SYSTEM_DEFAULT="build/lowrisc_systems_top_earlgrey_verilator_0.1/sim-verilator/Vtop_earlgrey_verilator"
+readonly SW_BUILD_DEFAULT="build-verilator"
+
+VERILATED_SYSTEM_PATH="${VERILATED_SYSTEM_PATH:-$VERILATED_SYSTEM_DEFAULT}"
+SW_BUILD_PATH="${SW_BUILD_PATH:-$SW_BUILD_DEFAULT}"
+
+readonly TEST_TARGETS=("tests/flash_ctrl/flash_test.vmem"
+  "tests/hmac/sha256_test.vmem"
+  "tests/rv_timer/rv_timer_test.vmem"
+)
+
+FAIL_TARGETS=()
+PASS_TARGETS=()
+for target in "${TEST_TARGETS[@]}"; do
+  echo "Executing target ${target}"
+  set +e
+  set -x
+  pytest -s test/systemtest/functional_verilator_test.py \
+    --test_bin "$SW_BUILD_PATH/sw/device/${target}" \
+    --rom_bin  "$SW_BUILD_PATH/sw/device/boot_rom/boot_rom.vmem" \
+    --verilator_model "$VERILATED_SYSTEM_PATH"
+  if [[ $? == 0 ]]; then
+    PASS_TARGETS=("${PASS_TARGETS[@]}" "${target}")
+  else
+    FAIL_TARGETS=("${FAIL_TARGETS[@]}" "${target}")
+  fi
+  set +x
+  set -e
+done
+
+echo "Passing targets:"
+for target in "${PASS_TARGETS[@]}"; do
+  echo "* ${target}"
+done
+
+if [ ${#FAIL_TARGETS[@]} -eq 0 ]; then
+  echo "TESTS PASS!"
+else
+  echo
+  echo "Failing targets:"
+  for target in "${FAIL_TARGETS[@]}"; do
+    echo "* ${target}"
+  done
+  echo
+  echo "TESTS FAILED!"
+  exit 1
+fi


### PR DESCRIPTION
This is a followup of https://github.com/lowRISC/opentitan/pull/459, which sets up an Azure Pipeline job to execute the tests in `sw/tests` using the pytest I wrote.

Unfortunately, this has revealed that two of these tests fail under Verilator, so we won't be able to merge this change until that gets resolved.