### PR TITLE
[sw] Update all C files in SW to use designated initializers.

### DIFF
--- a/sw/lib/hw_sha256.c
+++ b/sw/lib/hw_sha256.c
@@ -6,9 +6,11 @@
 
 #include "hmac.h"
 
-static const HASH_VTAB HW_SHA256_VTAB = {hw_SHA256_init, hw_SHA256_update,
-                                         hw_SHA256_final, hw_SHA256_hash,
-                                         SHA256_DIGEST_SIZE};
+static const HASH_VTAB HW_SHA256_VTAB = {.init = &hw_SHA256_init,
+                                         .update = &hw_SHA256_update,
+                                         .final = &hw_SHA256_final,
+                                         .hash = &hw_SHA256_hash,
+                                         .size = SHA256_DIGEST_SIZE};
 
 static void sha256_init() {
   hmac_cfg_t config = {.mode = HMAC_OP_SHA256,

--- a/sw/tests/flash_ctrl/flash_test.c
+++ b/sw/tests/flash_ctrl/flash_test.c
@@ -106,14 +106,12 @@ int main(int argc, char **argv) {
   uint32_t bad_words = 3;
   uint32_t chk_addr = bad_addr_start - (FLASH_WORD_SZ * good_words);
 
-  mp_region_t region0 = {
-      0,                 // region 0
-      region_base_page,  // page 1 of bank1
-      region_size,       // size of 1 page
-      1,                 // allow read
-      1,                 // allow program
-      1                  // allow erase
-  };
+  mp_region_t region0 = {.num = 0,
+                         .base = region_base_page,
+                         .size = region_size,
+                         .rd_en = 1,
+                         .prog_en = 1,
+                         .erase_en = 1};
 
   // initialize good and bad regions.
   break_on_error(flash_page_erase(good_addr_start));

--- a/sw/tests/hmac/sha256_test.c
+++ b/sw/tests/hmac/sha256_test.c
@@ -15,11 +15,13 @@ typedef struct test_data {
   char data[512];
 } test_data_t;
 
-test_data_t test = {
-    {0xdc96c23d, 0xaf36e268, 0xcb68ff71, 0xe92f76e2, 0xb8a8379d, 0x426dc745,
-     0x19f5cff7, 0x4ec9c6d6},
-    "Every one suspects himself of at least one of the cardinal virtues, and "
-    "this is mine: I am one of the few honest people that I have ever known"};
+test_data_t test = {.digest = {0xdc96c23d, 0xaf36e268, 0xcb68ff71, 0xe92f76e2,
+                               0xb8a8379d, 0x426dc745, 0x19f5cff7, 0x4ec9c6d6},
+                    .data =
+                        "Every one suspects himself of at least one of "
+                        "the cardinal virtues, and this is mine: I am "
+                        "one of the few honest people that I have ever "
+                        "known"};
 
 int main(int argc, char **argv) {
   uint32_t error = 0;


### PR DESCRIPTION
This is the followup to https://github.com/lowRISC/opentitan/pull/507, which brings the tree into compliance; I believe the only violations left are all vendored-in dependencies.