### PR TITLE
[pinmux] Simplify bitwidth calculation in tpl file

### DIFF
--- a/hw/ip/pinmux/doc/pinmux.hjson
+++ b/hw/ip/pinmux/doc/pinmux.hjson
@@ -54,7 +54,7 @@
 # inputs
     { multireg: { name:     "PERIPH_INSEL",
                   desc:     "Mux select for peripheral inputs.",
-                  count:    "NPeriphOut",
+                  count:    "NPeriphIn",
                   swaccess: "rw",
                   hwaccess: "hro",
                   regwen:   "REGEN",
@@ -93,6 +93,4 @@
     },
   ],
 }
-
-
 

--- a/hw/ip/pinmux/doc/pinmux.tpl.hjson
+++ b/hw/ip/pinmux/doc/pinmux.tpl.hjson
@@ -60,7 +60,7 @@
                   regwen:   "REGEN",
                   cname:    "IN",
                   fields: [
-                    { bits: "${int(math.ceil(math.log2(n_mio_pads+2))-1)}:0",
+                    { bits: "${(n_mio_pads+1).bit_length()-1}:0",
                       name: "IN",
                       desc: '''
                       0: tie constantly to zero, 1: tie constantly to 1.
@@ -80,7 +80,7 @@
                   regwen:   "REGEN",
                   cname:    "OUT",
                   fields: [
-                    { bits: "${int(math.ceil(math.log2(n_periph_out+3))-1)}:0",
+                    { bits: "${(n_periph_out+2).bit_length()-1}:0",
                       name: "OUT",
                       desc: '''
                       0: tie constantly to zero, 1: tie constantly to 1. 2: high-Z
@@ -93,5 +93,3 @@
     },
   ],
 }
-
-


### PR DESCRIPTION
This is a small patch which simplifies the bitwidth calculation. The change in `pinmux.hjson` is due to an earlier bugfix in `pinmux.tpl.hjson`.