### PR TITLE
[reggen] Correct calculation of interrupt width

### DIFF
--- a/util/reggen/validate.py
+++ b/util/reggen/validate.py
@@ -1094,7 +1094,8 @@ def make_intr_reg(regs, name, offset, swaccess, hwaccess, desc):
 def make_intr_regs(regs, offset, addrsep, fullwidth):
     iregs = []
     intrs = regs['interrupt_list']
-    if len(intrs) > fullwidth:
+    if sum([int(x['width'], 0) if 'width' in x else 1
+            for x in intrs]) > fullwidth:
         log.error('More than ' + str(fullwidth) + ' interrupts in list')
         return iregs, 1
 
@@ -1214,7 +1215,8 @@ def check_wen_regs(regs):
     tuple_swaccess = 2
 
     reg_list = [(reg['name'].lower(), reg['genresval'], reg['swaccess'])
-                for reg in regs['registers'] if 'name' in reg and 'genresval' in reg]
+                for reg in regs['registers']
+                if 'name' in reg and 'genresval' in reg]
     mreg_list = [
         reg['multireg'] for reg in regs['registers'] if 'multireg' in reg
     ]


### PR DESCRIPTION
Issue was found during the code review #516.

Error Symptom:

    If a IP has interrupts having more than one bit width, the validate
    has a chance to not raises ERROR for the interrupt exceeding full
    register width (currently 32).

auto interrupt register generation was added to create INTERRUPT
enable/status/test registers by the tool. It does have a limitation that
only supports up to 32bit interrupts in a IP. For instance, if IP has 33
interrupts, it raises an ERROR and stop generating.

However, GPIO has only one interrupt signal but the width of the
interrupt is 32bit width. If it is set to 33 bit width, tool doesn't
create an error. as the checker only checks:

```python
if len(m['interrupt_list']) > fullwidth:
```

It should check the `width` field and account it to compare with
`fullwidth`.

Results:

    Changed to sum the width of the interrupt_list

```python
sum([int(x['width']) if 'width' in x else 1 for x in
m['interrupt_list']])
```