### PR TITLE
[prim_ram_2p] Avoid wildcard port list

### DIFF
--- a/hw/ip/prim/abstract/prim_ram_2p.sv
+++ b/hw/ip/prim/abstract/prim_ram_2p.sv
@@ -55,8 +55,19 @@ module prim_ram_2p #(
     prim_xilinx_ram_2p #(
       .Width(Width),
       .Depth(Depth)
-    ) u_mem (
-      .*
+    ) u_impl_xilinx (
+      .clk_a_i,
+      .clk_b_i,
+      .a_req_i,
+      .a_write_i,
+      .a_addr_i,
+      .a_wdata_i,
+      .a_rdata_o,
+      .b_req_i,
+      .b_write_i,
+      .b_addr_i,
+      .b_wdata_i,
+      .b_rdata_o
     );
   end else begin : gen_failure
     // TODO: Find code that works across tools and causes a compile failure


### PR DESCRIPTION
Wildcard ports lists are discouraged in our style guide, explicitly name
all ports instead.