### PR TITLE
[dv] Fix for dv plan template doc

### DIFF
--- a/hw/dv/doc/dv_plan_template.md
+++ b/hw/dv/doc/dv_plan_template.md
@@ -8,7 +8,8 @@ diagram section below. Please update / modify / remove sections below as
 applicable. Once done, remove this comment before making a PR. -->
 
 {{% lowrisc-doc-hdr FOO DV Plan }}
-{{% import_testplan foo_testplan.hjson }}
+<!-- TODO: uncomment the line below after adding the testplan -->
+<!-- {{% import_testplan foo_testplan.hjson }} -->
 
 {{% toc 4 }}
 
@@ -116,4 +117,5 @@ $ make TEST_NAME=foo_sanity
 ```
 
 ## Testplan
-{{% insert_testplan x }}
+<!-- TODO: uncomment the line below after adding the testplan -->
+<!-- {{% insert_testplan x }} -->

--- a/util/uvmdvgen/dv_plan.md.tpl
+++ b/util/uvmdvgen/dv_plan.md.tpl
@@ -8,7 +8,8 @@ diagram section below. Please update / modify / remove sections below as
 applicable. Once done, remove this comment before making a PR. -->
 
 {{% lowrisc-doc-hdr ${name.upper()} DV Plan }}
-{{% import_testplan ${name}_testplan.hjson }}
+<!-- TODO: uncomment the line below after adding the testplan -->
+<!-- {{% import_testplan ${name}_testplan.hjson }} -->
 
 {{% toc 4 }}
 
@@ -124,4 +125,5 @@ $ make TEST_NAME=${name}_sanity
 ```
 
 ${'##'} Testplan
-{{% insert_testplan x }}
+<!-- TODO: uncomment the line below after adding the testplan -->
+<!-- {{% insert_testplan x }} -->


### PR DESCRIPTION
- Commented out the `import_testplan` and `insert_testplan` tokens in DV plan templates so that build_docs does not error out