### PR TITLE
[rv_timer] Make sure the output of rv_timer known

### DIFF
--- a/hw/ip/rv_timer/rtl/rv_timer.sv
+++ b/hw/ip/rv_timer/rtl/rv_timer.sv
@@ -117,4 +117,9 @@ module rv_timer (
     .devmode_i  (1'b1)
   );
 
+  // Assertions ===============================================================
+  `ASSERT_KNOWN(TlODValidKnown, tl_o.d_valid, clk_i, !rst_ni)
+  `ASSERT_KNOWN(TlOAReadyKnown, tl_o.a_ready, clk_i, !rst_ni)
+  `ASSERT_KNOWN(IntrTimerExpired00Known, intr_timer_expired_0_0_o, clk_i, !rst_ni)
+
 endmodule


### PR DESCRIPTION
This is related to #405. All outputs of the IP should be known state
after reset is released. There's exception such as TL-UL response data
other than `d_valid` and `a_ready`.

rv_timer now has three assert_known assertions.