### PR TITLE
Upgrade FuseSoC command

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -140,7 +140,7 @@ stages:
       displayName: 'Display environment'
     - bash: |
         export PATH=$VERILATOR_PATH/bin:$PATH
-        fusesoc --cores-root=. sim --build-only lowrisc:systems:top_earlgrey_verilator
+        fusesoc --cores-root=. run --target=sim --setup --build lowrisc:systems:top_earlgrey_verilator
       displayName: 'Build simulation with Verilator'
 
   - job: "top_earlgrey_nexysvideo"
@@ -155,5 +155,5 @@ stages:
     - bash: |
         set -e
         source /opt/xilinx/Vivado/2018.3/settings64.sh
-        fusesoc --cores-root . build lowrisc:systems:top_earlgrey_nexysvideo
+        fusesoc --cores-root . run --target=synth --setup --build lowrisc:systems:top_earlgrey_nexysvideo
       displayName: 'Build bitstream with Vivado'

--- a/doc/ug/getting_started_verilator.md
+++ b/doc/ug/getting_started_verilator.md
@@ -15,7 +15,7 @@ First the simulation needs to built itself.
 
 ```console
 $ cd $REPO_TOP
-$ fusesoc --cores-root . sim --build-only lowrisc:systems:top_earlgrey_verilator
+$ fusesoc --cores-root . run --target=sim --setup --build lowrisc:systems:top_earlgrey_verilator
 ```
 
 Then we need to build software to run on the simulated system.

--- a/doc/ug/quickstart.md
+++ b/doc/ug/quickstart.md
@@ -10,7 +10,7 @@ Build the simulator and the software and then run the simulation
 
 ```console
 $ cd $REPO_TOP
-$ fusesoc --cores-root . sim --build-only lowrisc:systems:top_earlgrey_verilator
+$ fusesoc --cores-root . run --target=sim --setup --build lowrisc:systems:top_earlgrey_verilator
 $ make SIM=1 -C sw/boot_rom clean all
 $ make SIM=1 -C sw/examples/hello_world clean all
 $ build/lowrisc_systems_top_earlgrey_verilator_0.1/sim-verilator/Vtop_earlgrey_verilator --rominit=sw/boot_rom/boot_rom.vmem \
@@ -32,8 +32,8 @@ $ cd $REPO_TOP
 $ make -C sw/boot_rom clean all
 $ make -C sw/examples/hello_world clean all
 $ . /tools/xilinx/Vivado/2018.3/settings64.sh
-$ fusesoc --cores-root . build lowrisc:systems:top_earlgrey_nexysvideo
-$ fusesoc --cores-root . pgm lowrisc:systems:top_earlgrey_nexysvideo:0.1
+$ fusesoc --cores-root . run --target=synth --setup --build lowrisc:systems:top_earlgrey_nexysvideo
+$ fusesoc --cores-root . pgm lowrisc:systems:top_earlgrey_nexysvideo
 ```
 
 See the [getting started](getting_started_fpga.md) for a complete guide.

--- a/hw/dv/tools/fusesoc.mk
+++ b/hw/dv/tools/fusesoc.mk
@@ -11,7 +11,7 @@
 ####################################################################################################
 # fusesoc tool and options
 SV_FLIST_GEN_TOOL  ?= fusesoc
-SV_FLIST_GEN_OPTS  += --cores-root ${PROJ_ROOT} sim --setup --no-export ${FUSESOC_CORE}
+SV_FLIST_GEN_OPTS  += --cores-root ${PROJ_ROOT} run --target=sim --setup --no-export ${FUSESOC_CORE}
 FUSESOC_CORE_       = $(shell echo "${FUSESOC_CORE}" | tr ':' '_')
 SV_FLIST_GEN_DIR    = ${BUILD_DIR}/build/${FUSESOC_CORE_}/sim-vcs
 SV_FLIST           := ${SV_FLIST_GEN_DIR}/${FUSESOC_CORE_}.scr

--- a/hw/formal/fpv
+++ b/hw/formal/fpv
@@ -23,7 +23,7 @@ export FPV_TOP=$1
 # use fusesoc to generate file list
 #-------------------------------------------------------------------------
 \rm -Rf build jgproject
-fusesoc --cores-root .. sim --build-only formal > /dev/null 2>&1
+fusesoc --cores-root .. run --target=sim --setup --build formal > /dev/null 2>&1
 
 #-------------------------------------------------------------------------
 # run Jasper Gold

--- a/hw/formal/rtl_diff
+++ b/hw/formal/rtl_diff
@@ -19,7 +19,7 @@ export LEC_REVISED=../../../${2}
 # use fusesoc to generate file list
 #-------------------------------------------------------------------------
 \rm -Rf build rtl_diff.log
-fusesoc --cores-root .. sim --build-only formal > /dev/null 2>&1
+fusesoc --cores-root .. run --target=sim --setup --build formal > /dev/null 2>&1
 
 #-------------------------------------------------------------------------
 # run Conformal LEC

--- a/hw/lint/cdc_lint
+++ b/hw/lint/cdc_lint
@@ -20,7 +20,7 @@
 export LINT_TOP=$1
 
 # use fusesoc to generate file list
-fusesoc --cores-root .. sim --build-only formal > /dev/null 2>&1
+fusesoc --cores-root .. run --target=sim --setup --build formal > /dev/null 2>&1
 
 # run meridian CDC lint
 mcdc -i cdc_lint.tcl -wait -log cdc.log

--- a/hw/lint/lint
+++ b/hw/lint/lint
@@ -19,7 +19,7 @@
 export LINT_TOP=$1
 
 # use fusesoc to generate file list
-fusesoc --cores-root .. sim --build-only formal > /dev/null 2>&1
+fusesoc --cores-root .. run --target=sim --setup --build formal > /dev/null 2>&1
 
 # run ascent-lint tool
 ascentlint -i lint.tcl -wait -log lint.log

--- a/hw/lint/rdc_lint
+++ b/hw/lint/rdc_lint
@@ -20,7 +20,7 @@
 export LINT_TOP=$1
 
 # use fusesoc to generate file list
-fusesoc --cores-root .. sim --build-only formal > /dev/null 2>&1
+fusesoc --cores-root .. run --target=sim --setup --build formal > /dev/null 2>&1
 
 # run meridian RDC lint
 mrdc -i rdc_lint.tcl -wait -log rdc.log

--- a/util/syn_yosys.sh
+++ b/util/syn_yosys.sh
@@ -18,7 +18,7 @@
 # use fusesoc to generate files and file list
 #-------------------------------------------------------------------------
 \rm -Rf build
-fusesoc --cores-root .. sim --build-only formal > /dev/null 2>&1
+fusesoc --cores-root .. run --target=sim --setup --build formal > /dev/null 2>&1
 
 # copy all files into directory "syn_out"
 \rm -Rf syn_out


### PR DESCRIPTION
FuseSoC commands `sim` and `build` are deprecated, use `run` instead.
https://github.com/olofk/fusesoc/commit/b838e89e5093aa0c87620314e95d319a87b64b24

The formal/lint should also work, but for me only the setup was possible, would be nice if someone could test this.