### PR TITLE
[hmac] Add Error Reponse for Read of MSG

### DIFF
--- a/hw/ip/hmac/rtl/hmac.sv
+++ b/hw/ip/hmac/rtl/hmac.sv
@@ -189,7 +189,8 @@ module hmac (
     .SramAw (9),
     .SramDw (32),
     .Outstanding (1),
-    .ByteAccess  (1)
+    .ByteAccess  (1),
+    .ErrOnRead   (1)
   ) u_tlul_adapter (
     .clk_i,
     .rst_ni,


### PR DESCRIPTION
HMAC MSG FIFO is not a generic memory. It has a range of address space
(from offset 0x800 to 0xFFF in a HMAC IP) but all writes to the region
fall into a entry in the Message FIFO.

The characteristic of the MSG FIFO in the HMAC results in a test failure
of DV R/W to the MSG FIFO. Why it tries R/W to the MSG FIFO? well, as it
is defined as window in `ip.hjson`, it creates UVM memory model by the
tool. So, it needs explict waiver to work around.

Now the MSG FIFO has `swaccess` type as `wo`. It shouldn't create the
R/W test by default. But it is still useful to notify the software
whether it tries to read from the MSG FIFO or not.

@tjaychen added a Paramter to `tlul_adapter_sram`. It is `ErrOnRead` to
report error on any read request. This paramter value is set to 1 for
MSG FIFO now.

This is related to #236