### PR TITLE
[docgen] Fix two testplans that broke docgen

### DIFF
--- a/hw/dv/tools/testplans/intr_test_testplan.hjson
+++ b/hw/dv/tools/testplans/intr_test_testplan.hjson
@@ -3,7 +3,7 @@
     {
       name: intr_test
       desc: "Verify common intr_test CSRs to force interrupts via SW."
-      milestone: v2
+      milestone: V2
       tests: ["{name}{intf}_intr_test"]
     }
   ]

--- a/hw/dv/tools/testplans/tl_device_access_types_testplan.hjson
+++ b/hw/dv/tools/testplans/tl_device_access_types_testplan.hjson
@@ -3,14 +3,14 @@
     {
       name: oob_addr_access
       desc: "Access out of bounds address and verify correctness of response / behavior"
-      milestone: v2
+      milestone: V2
       tests: ["{name}_tl_errors"]
     }
     {
       name: illegal_access
       desc: '''Drive unsupported requests via TL interface and verify correctness of response
             / behavior '''
-      milestone: v2
+      milestone: V2
       tests: ["{name}_tl_errors"]
     }
     {
@@ -18,7 +18,7 @@
       desc: '''Drive back-to-back requests without waiting for response to ensure there is one
             transaction outstanding within the TL device. Also, verify one outstanding when back-
             to-back accesses are made to the same address.'''
-      milestone: v2
+      milestone: V2
       tests: ["{name}{intf}_csr_hw_reset",
               "{name}{intf}_csr_rw",
               "{name}{intf}_csr_aliasing",
@@ -27,7 +27,7 @@
     {
       name: partial_access
       desc: '''Do partial accesses.'''
-      milestone: v2
+      milestone: V2
       tests: ["{name}{intf}_csr_hw_reset",
               "{name}{intf}_csr_rw",
               "{name}{intf}_csr_aliasing"]


### PR DESCRIPTION
The testplanner expects the V* stages to be uppercase. Otherwise the documentation does not build.