### PR TITLE
[aes/rtl] Fix lint errors

### DIFF
--- a/hw/ip/aes/rtl/aes_control.sv
+++ b/hw/ip/aes/rtl/aes_control.sv
@@ -85,6 +85,7 @@ module aes_control #(
 
   logic [3:0] round_d, round_q;
   logic [3:0] num_rounds_d, num_rounds_q;
+  logic [3:0] num_rounds_regular;
   logic       dec_key_gen_d, dec_key_gen_q;
 
   logic       start, finish;
@@ -165,9 +166,9 @@ module aes_control #(
 
           // Load num_rounds, round
           round_d      = '0;
-          num_rounds_d = (key_len_i == AES_128) ? 10 :
-                         (key_len_i == AES_192) ? 12 :
-                                                  14;
+          num_rounds_d = (key_len_i == AES_128) ? 4'd10 :
+                         (key_len_i == AES_192) ? 4'd12 :
+                                                  4'd14;
 
           idle_o      = 1'b0;
           idle_we_o   = 1'b1;
@@ -229,7 +230,7 @@ module aes_control #(
         end
 
         // Make key expand advance - AES-256 has two round keys available right from beginning
-        if (key_len_i != AES_256 ) begin
+        if (key_len_i != AES_256) begin
           key_expand_step_o = 1'b1;
           key_full_we_o     = 1'b1;
         end
@@ -287,7 +288,7 @@ module aes_control #(
         round_d = round_q+1;
 
         // Are we doing the last regular round?
-        if (round_q == num_rounds_q-2) begin
+        if (round_q == num_rounds_regular) begin
           if (dec_key_gen_q) begin
             // Write decryption key and finish
             key_dec_we_o  = 1'b1;
@@ -367,6 +368,9 @@ module aes_control #(
       dec_key_gen_q <= dec_key_gen_d;
     end
   end
+
+  // Use separate signal for number of regular rounds
+  assign num_rounds_regular = num_rounds_q - 4'd2;
 
   // Detect new key, new input, output read
   // Edge detectors are cleared by the FSM

--- a/hw/ip/aes/rtl/aes_core.sv
+++ b/hw/ip/aes/rtl/aes_core.sv
@@ -25,7 +25,7 @@ module aes_core #(
   logic     [7:0] key_init_qe;
 
   mode_e          mode, key_expand_mode;
-  key_len_e       key_len;
+  key_len_e       key_len_q, key_len;
 
   logic     [7:0] state_init[16];
   logic     [7:0] state_d[16];
@@ -66,6 +66,9 @@ module aes_core #(
 
   // Unused signals
   logic    [31:0] unused_data_out_q[4];
+  logic           unused_mode_qe;
+  logic           unused_manual_start_trigger_qe;
+  logic           unused_force_data_overwrite_qe;
 
   // Inputs
   assign key_init[0] = reg2hw.key[0].q;
@@ -99,8 +102,9 @@ module aes_core #(
 
   assign mode = mode_e'(reg2hw.ctrl.mode.q);
 
+  assign key_len_q = key_len_e'(reg2hw.ctrl.key_len.q);
   always_comb begin : get_key_len
-    unique case (key_len_e'(reg2hw.ctrl.key_len.q))
+    unique case (key_len_q)
       AES_128: key_len = AES_128;
       AES_256: key_len = AES_256;
       AES_192: begin
@@ -119,6 +123,11 @@ module aes_core #(
   assign unused_data_out_q[1] = reg2hw.data_out[1].q;
   assign unused_data_out_q[2] = reg2hw.data_out[2].q;
   assign unused_data_out_q[3] = reg2hw.data_out[3].q;
+
+  // key_len is hrw and hwqe, other fields of ctrl reg are hro and don't need hwqe
+  assign unused_mode_qe                 = reg2hw.ctrl.mode.qe;
+  assign unused_manual_start_trigger_qe = reg2hw.ctrl.manual_start_trigger.qe;
+  assign unused_force_data_overwrite_qe = reg2hw.ctrl.force_data_overwrite.qe;
 
   // State registers
   always_comb begin : state_mux


### PR DESCRIPTION
This PR fixes those lint errors in the AES module we do not waive.

There are a couple of lint errors due to driving 'X (don't care) in default statements. These are currently waived but will be fixed once the course of action for those is clear. 