### PR TITLE
[reggen] Wrap output to meet code standards

### DIFF
--- a/hw/ip/alert_handler/sw/alert_handler_regs.h
+++ b/hw/ip/alert_handler/sw/alert_handler_regs.h
@@ -36,7 +36,8 @@
 #define ALERT_HANDLER_REGEN 0
 
 // Ping timeout cycle count.
-#define ALERT_HANDLER_PING_TIMEOUT_CYC(id) (ALERT_HANDLER##id##_BASE_ADDR + 0x10)
+#define ALERT_HANDLER_PING_TIMEOUT_CYC(id) \
+  (ALERT_HANDLER##id##_BASE_ADDR + 0x10)
 #define ALERT_HANDLER_PING_TIMEOUT_CYC_MASK 0xffffff
 #define ALERT_HANDLER_PING_TIMEOUT_CYC_OFFSET 0
 
@@ -98,7 +99,8 @@
 #define ALERT_HANDLER_LOC_ALERT_CAUSE_LA2 2
 #define ALERT_HANDLER_LOC_ALERT_CAUSE_LA3 3
 
-// Escalation control register for alert Class A. Can not be modified if !!REGEN is false.
+// Escalation control register for alert Class A. Can not be modified if
+// !!REGEN is false.
 #define ALERT_HANDLER_CLASSA_CTRL(id) (ALERT_HANDLER##id##_BASE_ADDR + 0x2c)
 #define ALERT_HANDLER_CLASSA_CTRL_EN 0
 #define ALERT_HANDLER_CLASSA_CTRL_LOCK 1
@@ -123,30 +125,38 @@
 #define ALERT_HANDLER_CLASSA_CLR(id) (ALERT_HANDLER##id##_BASE_ADDR + 0x34)
 #define ALERT_HANDLER_CLASSA_CLR 0
 
-// Current accumulation value for alert Class A. Software can clear this register
-#define ALERT_HANDLER_CLASSA_ACCUM_CNT(id) (ALERT_HANDLER##id##_BASE_ADDR + 0x38)
+// Current accumulation value for alert Class A. Software can clear this
+// register
+#define ALERT_HANDLER_CLASSA_ACCUM_CNT(id) \
+  (ALERT_HANDLER##id##_BASE_ADDR + 0x38)
 #define ALERT_HANDLER_CLASSA_ACCUM_CNT_MASK 0xffff
 #define ALERT_HANDLER_CLASSA_ACCUM_CNT_OFFSET 0
 
 // Accumulation threshold value for alert Class A.
-#define ALERT_HANDLER_CLASSA_ACCUM_THRESH(id) (ALERT_HANDLER##id##_BASE_ADDR + 0x3c)
+#define ALERT_HANDLER_CLASSA_ACCUM_THRESH(id) \
+  (ALERT_HANDLER##id##_BASE_ADDR + 0x3c)
 #define ALERT_HANDLER_CLASSA_ACCUM_THRESH_MASK 0xffff
 #define ALERT_HANDLER_CLASSA_ACCUM_THRESH_OFFSET 0
 
 // Interrupt timeout in cycles.
-#define ALERT_HANDLER_CLASSA_TIMEOUT_CYC(id) (ALERT_HANDLER##id##_BASE_ADDR + 0x40)
+#define ALERT_HANDLER_CLASSA_TIMEOUT_CYC(id) \
+  (ALERT_HANDLER##id##_BASE_ADDR + 0x40)
 
 // Duration of escalation phase 0 for Class A.
-#define ALERT_HANDLER_CLASSA_PHASE0_CYC(id) (ALERT_HANDLER##id##_BASE_ADDR + 0x44)
+#define ALERT_HANDLER_CLASSA_PHASE0_CYC(id) \
+  (ALERT_HANDLER##id##_BASE_ADDR + 0x44)
 
 // Duration of escalation phase 1 for Class A.
-#define ALERT_HANDLER_CLASSA_PHASE1_CYC(id) (ALERT_HANDLER##id##_BASE_ADDR + 0x48)
+#define ALERT_HANDLER_CLASSA_PHASE1_CYC(id) \
+  (ALERT_HANDLER##id##_BASE_ADDR + 0x48)
 
 // Duration of escalation phase 2 for Class A.
-#define ALERT_HANDLER_CLASSA_PHASE2_CYC(id) (ALERT_HANDLER##id##_BASE_ADDR + 0x4c)
+#define ALERT_HANDLER_CLASSA_PHASE2_CYC(id) \
+  (ALERT_HANDLER##id##_BASE_ADDR + 0x4c)
 
 // Duration of escalation phase 3 for Class A.
-#define ALERT_HANDLER_CLASSA_PHASE3_CYC(id) (ALERT_HANDLER##id##_BASE_ADDR + 0x50)
+#define ALERT_HANDLER_CLASSA_PHASE3_CYC(id) \
+  (ALERT_HANDLER##id##_BASE_ADDR + 0x50)
 
 // Escalation counter in cycles for Class A.
 #define ALERT_HANDLER_CLASSA_ESC_CNT(id) (ALERT_HANDLER##id##_BASE_ADDR + 0x54)
@@ -163,7 +173,8 @@
 #define ALERT_HANDLER_CLASSA_STATE_CLASSA_STATE_PHASE2 0b110
 #define ALERT_HANDLER_CLASSA_STATE_CLASSA_STATE_PHASE3 0b111
 
-// Escalation control register for alert Class B. Can not be modified if !!REGEN is false.
+// Escalation control register for alert Class B. Can not be modified if
+// !!REGEN is false.
 #define ALERT_HANDLER_CLASSB_CTRL(id) (ALERT_HANDLER##id##_BASE_ADDR + 0x5c)
 #define ALERT_HANDLER_CLASSB_CTRL_EN 0
 #define ALERT_HANDLER_CLASSB_CTRL_LOCK 1
@@ -188,30 +199,38 @@
 #define ALERT_HANDLER_CLASSB_CLR(id) (ALERT_HANDLER##id##_BASE_ADDR + 0x64)
 #define ALERT_HANDLER_CLASSB_CLR 0
 
-// Current accumulation value for alert Class B. Software can clear this register
-#define ALERT_HANDLER_CLASSB_ACCUM_CNT(id) (ALERT_HANDLER##id##_BASE_ADDR + 0x68)
+// Current accumulation value for alert Class B. Software can clear this
+// register
+#define ALERT_HANDLER_CLASSB_ACCUM_CNT(id) \
+  (ALERT_HANDLER##id##_BASE_ADDR + 0x68)
 #define ALERT_HANDLER_CLASSB_ACCUM_CNT_MASK 0xffff
 #define ALERT_HANDLER_CLASSB_ACCUM_CNT_OFFSET 0
 
 // Accumulation threshold value for alert Class B.
-#define ALERT_HANDLER_CLASSB_ACCUM_THRESH(id) (ALERT_HANDLER##id##_BASE_ADDR + 0x6c)
+#define ALERT_HANDLER_CLASSB_ACCUM_THRESH(id) \
+  (ALERT_HANDLER##id##_BASE_ADDR + 0x6c)
 #define ALERT_HANDLER_CLASSB_ACCUM_THRESH_MASK 0xffff
 #define ALERT_HANDLER_CLASSB_ACCUM_THRESH_OFFSET 0
 
 // Interrupt timeout in cycles.
-#define ALERT_HANDLER_CLASSB_TIMEOUT_CYC(id) (ALERT_HANDLER##id##_BASE_ADDR + 0x70)
+#define ALERT_HANDLER_CLASSB_TIMEOUT_CYC(id) \
+  (ALERT_HANDLER##id##_BASE_ADDR + 0x70)
 
 // Duration of escalation phase 0 for Class B.
-#define ALERT_HANDLER_CLASSB_PHASE0_CYC(id) (ALERT_HANDLER##id##_BASE_ADDR + 0x74)
+#define ALERT_HANDLER_CLASSB_PHASE0_CYC(id) \
+  (ALERT_HANDLER##id##_BASE_ADDR + 0x74)
 
 // Duration of escalation phase 1 for Class B.
-#define ALERT_HANDLER_CLASSB_PHASE1_CYC(id) (ALERT_HANDLER##id##_BASE_ADDR + 0x78)
+#define ALERT_HANDLER_CLASSB_PHASE1_CYC(id) \
+  (ALERT_HANDLER##id##_BASE_ADDR + 0x78)
 
 // Duration of escalation phase 2 for Class B.
-#define ALERT_HANDLER_CLASSB_PHASE2_CYC(id) (ALERT_HANDLER##id##_BASE_ADDR + 0x7c)
+#define ALERT_HANDLER_CLASSB_PHASE2_CYC(id) \
+  (ALERT_HANDLER##id##_BASE_ADDR + 0x7c)
 
 // Duration of escalation phase 3 for Class B.
-#define ALERT_HANDLER_CLASSB_PHASE3_CYC(id) (ALERT_HANDLER##id##_BASE_ADDR + 0x80)
+#define ALERT_HANDLER_CLASSB_PHASE3_CYC(id) \
+  (ALERT_HANDLER##id##_BASE_ADDR + 0x80)
 
 // Escalation counter in cycles for Class B.
 #define ALERT_HANDLER_CLASSB_ESC_CNT(id) (ALERT_HANDLER##id##_BASE_ADDR + 0x84)
@@ -228,7 +247,8 @@
 #define ALERT_HANDLER_CLASSB_STATE_CLASSB_STATE_PHASE2 0b110
 #define ALERT_HANDLER_CLASSB_STATE_CLASSB_STATE_PHASE3 0b111
 
-// Escalation control register for alert Class C. Can not be modified if !!REGEN is false.
+// Escalation control register for alert Class C. Can not be modified if
+// !!REGEN is false.
 #define ALERT_HANDLER_CLASSC_CTRL(id) (ALERT_HANDLER##id##_BASE_ADDR + 0x8c)
 #define ALERT_HANDLER_CLASSC_CTRL_EN 0
 #define ALERT_HANDLER_CLASSC_CTRL_LOCK 1
@@ -253,30 +273,38 @@
 #define ALERT_HANDLER_CLASSC_CLR(id) (ALERT_HANDLER##id##_BASE_ADDR + 0x94)
 #define ALERT_HANDLER_CLASSC_CLR 0
 
-// Current accumulation value for alert Class C. Software can clear this register
-#define ALERT_HANDLER_CLASSC_ACCUM_CNT(id) (ALERT_HANDLER##id##_BASE_ADDR + 0x98)
+// Current accumulation value for alert Class C. Software can clear this
+// register
+#define ALERT_HANDLER_CLASSC_ACCUM_CNT(id) \
+  (ALERT_HANDLER##id##_BASE_ADDR + 0x98)
 #define ALERT_HANDLER_CLASSC_ACCUM_CNT_MASK 0xffff
 #define ALERT_HANDLER_CLASSC_ACCUM_CNT_OFFSET 0
 
 // Accumulation threshold value for alert Class C.
-#define ALERT_HANDLER_CLASSC_ACCUM_THRESH(id) (ALERT_HANDLER##id##_BASE_ADDR + 0x9c)
+#define ALERT_HANDLER_CLASSC_ACCUM_THRESH(id) \
+  (ALERT_HANDLER##id##_BASE_ADDR + 0x9c)
 #define ALERT_HANDLER_CLASSC_ACCUM_THRESH_MASK 0xffff
 #define ALERT_HANDLER_CLASSC_ACCUM_THRESH_OFFSET 0
 
 // Interrupt timeout in cycles.
-#define ALERT_HANDLER_CLASSC_TIMEOUT_CYC(id) (ALERT_HANDLER##id##_BASE_ADDR + 0xa0)
+#define ALERT_HANDLER_CLASSC_TIMEOUT_CYC(id) \
+  (ALERT_HANDLER##id##_BASE_ADDR + 0xa0)
 
 // Duration of escalation phase 0 for Class C.
-#define ALERT_HANDLER_CLASSC_PHASE0_CYC(id) (ALERT_HANDLER##id##_BASE_ADDR + 0xa4)
+#define ALERT_HANDLER_CLASSC_PHASE0_CYC(id) \
+  (ALERT_HANDLER##id##_BASE_ADDR + 0xa4)
 
 // Duration of escalation phase 1 for Class C.
-#define ALERT_HANDLER_CLASSC_PHASE1_CYC(id) (ALERT_HANDLER##id##_BASE_ADDR + 0xa8)
+#define ALERT_HANDLER_CLASSC_PHASE1_CYC(id) \
+  (ALERT_HANDLER##id##_BASE_ADDR + 0xa8)
 
 // Duration of escalation phase 2 for Class C.
-#define ALERT_HANDLER_CLASSC_PHASE2_CYC(id) (ALERT_HANDLER##id##_BASE_ADDR + 0xac)
+#define ALERT_HANDLER_CLASSC_PHASE2_CYC(id) \
+  (ALERT_HANDLER##id##_BASE_ADDR + 0xac)
 
 // Duration of escalation phase 3 for Class C.
-#define ALERT_HANDLER_CLASSC_PHASE3_CYC(id) (ALERT_HANDLER##id##_BASE_ADDR + 0xb0)
+#define ALERT_HANDLER_CLASSC_PHASE3_CYC(id) \
+  (ALERT_HANDLER##id##_BASE_ADDR + 0xb0)
 
 // Escalation counter in cycles for Class C.
 #define ALERT_HANDLER_CLASSC_ESC_CNT(id) (ALERT_HANDLER##id##_BASE_ADDR + 0xb4)
@@ -293,7 +321,8 @@
 #define ALERT_HANDLER_CLASSC_STATE_CLASSC_STATE_PHASE2 0b110
 #define ALERT_HANDLER_CLASSC_STATE_CLASSC_STATE_PHASE3 0b111
 
-// Escalation control register for alert Class D. Can not be modified if !!REGEN is false.
+// Escalation control register for alert Class D. Can not be modified if
+// !!REGEN is false.
 #define ALERT_HANDLER_CLASSD_CTRL(id) (ALERT_HANDLER##id##_BASE_ADDR + 0xbc)
 #define ALERT_HANDLER_CLASSD_CTRL_EN 0
 #define ALERT_HANDLER_CLASSD_CTRL_LOCK 1
@@ -318,30 +347,38 @@
 #define ALERT_HANDLER_CLASSD_CLR(id) (ALERT_HANDLER##id##_BASE_ADDR + 0xc4)
 #define ALERT_HANDLER_CLASSD_CLR 0
 
-// Current accumulation value for alert Class D. Software can clear this register
-#define ALERT_HANDLER_CLASSD_ACCUM_CNT(id) (ALERT_HANDLER##id##_BASE_ADDR + 0xc8)
+// Current accumulation value for alert Class D. Software can clear this
+// register
+#define ALERT_HANDLER_CLASSD_ACCUM_CNT(id) \
+  (ALERT_HANDLER##id##_BASE_ADDR + 0xc8)
 #define ALERT_HANDLER_CLASSD_ACCUM_CNT_MASK 0xffff
 #define ALERT_HANDLER_CLASSD_ACCUM_CNT_OFFSET 0
 
 // Accumulation threshold value for alert Class D.
-#define ALERT_HANDLER_CLASSD_ACCUM_THRESH(id) (ALERT_HANDLER##id##_BASE_ADDR + 0xcc)
+#define ALERT_HANDLER_CLASSD_ACCUM_THRESH(id) \
+  (ALERT_HANDLER##id##_BASE_ADDR + 0xcc)
 #define ALERT_HANDLER_CLASSD_ACCUM_THRESH_MASK 0xffff
 #define ALERT_HANDLER_CLASSD_ACCUM_THRESH_OFFSET 0
 
 // Interrupt timeout in cycles.
-#define ALERT_HANDLER_CLASSD_TIMEOUT_CYC(id) (ALERT_HANDLER##id##_BASE_ADDR + 0xd0)
+#define ALERT_HANDLER_CLASSD_TIMEOUT_CYC(id) \
+  (ALERT_HANDLER##id##_BASE_ADDR + 0xd0)
 
 // Duration of escalation phase 0 for Class D.
-#define ALERT_HANDLER_CLASSD_PHASE0_CYC(id) (ALERT_HANDLER##id##_BASE_ADDR + 0xd4)
+#define ALERT_HANDLER_CLASSD_PHASE0_CYC(id) \
+  (ALERT_HANDLER##id##_BASE_ADDR + 0xd4)
 
 // Duration of escalation phase 1 for Class D.
-#define ALERT_HANDLER_CLASSD_PHASE1_CYC(id) (ALERT_HANDLER##id##_BASE_ADDR + 0xd8)
+#define ALERT_HANDLER_CLASSD_PHASE1_CYC(id) \
+  (ALERT_HANDLER##id##_BASE_ADDR + 0xd8)
 
 // Duration of escalation phase 2 for Class D.
-#define ALERT_HANDLER_CLASSD_PHASE2_CYC(id) (ALERT_HANDLER##id##_BASE_ADDR + 0xdc)
+#define ALERT_HANDLER_CLASSD_PHASE2_CYC(id) \
+  (ALERT_HANDLER##id##_BASE_ADDR + 0xdc)
 
 // Duration of escalation phase 3 for Class D.
-#define ALERT_HANDLER_CLASSD_PHASE3_CYC(id) (ALERT_HANDLER##id##_BASE_ADDR + 0xe0)
+#define ALERT_HANDLER_CLASSD_PHASE3_CYC(id) \
+  (ALERT_HANDLER##id##_BASE_ADDR + 0xe0)
 
 // Escalation counter in cycles for Class D.
 #define ALERT_HANDLER_CLASSD_ESC_CNT(id) (ALERT_HANDLER##id##_BASE_ADDR + 0xe4)

--- a/util/reggen/gen_cheader.py
+++ b/util/reggen/gen_cheader.py
@@ -9,6 +9,7 @@ import io
 import logging as log
 import re
 import sys
+import textwrap
 
 
 def genout(outfile, msg):
@@ -23,19 +24,71 @@ def as_define(s):
     return r
 
 
-def clean_desc(s):
+def first_line(s):
+    """Returns the first line of a multi-line string"""
     return s.splitlines()[0]
+
+
+def format_comment(s):
+    """Formats a string to comment wrapped to an 80 character line width
+
+    Returns wrapped string including newline and // comment characters.
+    """
+    return '\n'.join(
+        textwrap.wrap(
+            s, width=77, initial_indent='// ', subsequent_indent='// ')) + '\n'
+
+
+def gen_define(name, args, body, indent='  '):
+    r"""Produces a #define string, will split into two lines if a single line
+    has a width greater than 80 characters. Result includes newline.
+
+    Arguments:
+    name - Name of the #define
+    args - List of arguments for the define, provide an empty list if there are
+    none
+    body - Body of the #define
+    indent - Gives string to prepend on any new lines produced by
+    wrapping (default '  ')
+
+    Example result:
+    name = 'A_MACRO'
+    args = ['arg1', 'arg2'],
+    body = 'arg1 + arg2 + 10'
+
+    #define A_MACRO(arg1, arg2) arg1 + arg2 + 10
+
+    When the macro is wrapped the break happens after the argument list (or
+    macro name if there is no argument list
+
+    #define A_MACRO(arg1, arg2) \
+      arg1 + arg2 + 10
+
+    """
+    if len(args) != 0:
+        define_declare = '#define ' + name + '(' + ', '.join(args) + ')'
+    else:
+        define_declare = '#define ' + name
+
+    oneline_define = define_declare + ' ' + body
+
+    if len(oneline_define) <= 80:
+        return oneline_define + '\n'
+
+    return define_declare + ' \\\n' + indent + body + '\n'
 
 
 def gen_cdefine_register(outstr, reg, comp, width, rnames):
     rname = reg['name']
     offset = reg['genoffset']
 
-    genout(outstr, '// ' + clean_desc(reg['desc']) + '\n')
+    genout(outstr, format_comment(first_line(reg['desc'])))
     defname = as_define(comp + '_' + rname)
     genout(
-        outstr, '#define ' + defname + '(id) (' + as_define(comp) +
-        '##id##_BASE_ADDR + ' + hex(offset) + ')\n')
+        outstr,
+        gen_define(
+            defname, ['id'],
+            '(' + as_define(comp) + '##id##_BASE_ADDR + ' + hex(offset) + ')'))
 
     for field in reg['fields']:
         fieldlsb = field['bitinfo'][2]
@@ -47,22 +100,22 @@ def gen_cdefine_register(outstr, reg, comp, width, rnames):
 
         if field['bitinfo'][1] == 1:
             # single bit
-            genout(outstr, '#define ' + dname + ' ' + str(fieldlsb) + '\n')
+            genout(outstr, gen_define(dname, [], str(fieldlsb)))
         else:
             # multiple bits (unless it is the whole register)
             if field['bitinfo'][1] != width:
                 mask = field['bitinfo'][0] >> fieldlsb
-                genout(outstr,
-                       '#define ' + dname + '_MASK ' + hex(mask) + '\n')
-                genout(outstr,
-                       '#define ' + dname + '_OFFSET ' + str(fieldlsb) + '\n')
+                genout(outstr, gen_define(dname + '_MASK', [], hex(mask)))
+                genout(outstr, gen_define(dname + '_OFFSET', [],
+                                          str(fieldlsb)))
             if 'enum' in field:
                 for enum in field['enum']:
                     ename = as_define(enum['name'])
                     genout(
                         outstr,
-                        '#define ' + defname + '_' + as_define(field['name']) +
-                        '_' + ename + ' ' + enum['value'] + '\n')
+                        gen_define(
+                            defname + '_' + as_define(field['name']) + '_' +
+                            ename, [], enum['value']))
     genout(outstr, '\n')
     return
 
@@ -71,20 +124,22 @@ def gen_cdefine_window(outstr, win, comp, regwidth, rnames):
     wname = win['name']
     offset = win['genoffset']
 
-    genout(outstr, '// Memory area: ' + clean_desc(win['desc']) + '\n')
+    genout(outstr, format_comment('Memory area: ' + first_line(win['desc'])))
     defname = as_define(comp + '_' + wname)
     genout(
-        outstr, '#define ' + defname + '(id) (' + as_define(comp) +
-        '##id##_BASE_ADDR + ' + hex(offset) + ')\n')
+        outstr,
+        gen_define(
+            defname, ['id'],
+            '(' + as_define(comp) + '##id##_BASE_ADDR + ' + hex(offset) + ')'))
     items = int(win['items'])
-    genout(outstr, '#define ' + defname + '_SIZE_WORDS ' + str(items) + '\n')
+    genout(outstr, gen_define(defname + '_SIZE_WORDS', [], str(items)))
     items = items * (regwidth // 8)
-    genout(outstr, '#define ' + defname + '_SIZE_BYTES ' + str(items) + '\n')
+    genout(outstr, gen_define(defname + '_SIZE_BYTES', [], str(items)))
 
     wid = win['genvalidbits']
     if (wid != regwidth):
         mask = (1 << wid) - 1
-        genout(outstr, '#define ' + defname + '_MASK ' + hex(mask) + '\n')
+        genout(outstr, gen_define(defname + '_MASK ', [], hex(mask)))
 
 
 # Must have called validate, so should have no errors
@@ -145,3 +200,37 @@ def gen_cdefines(regs, outfile, src_lic, src_copy):
     genout(outfile, '// End generated register defines for ' + component)
 
     return
+
+
+def test_gen_define():
+    basic_oneline = '#define MACRO_NAME body\n'
+    assert gen_define('MACRO_NAME', [], 'body') == basic_oneline
+
+    basic_oneline_with_args = '#define MACRO_NAME(arg1, arg2) arg1 + arg2\n'
+    assert (gen_define('MACRO_NAME', ['arg1', 'arg2'],
+                       'arg1 + arg2') == basic_oneline_with_args)
+
+    long_macro_name = 'A_VERY_VERY_VERY_VERY_VERY_VERY_VERY_VERY_VERY_VERY_VERY_LONG_MACRO_NAME'
+
+    multiline = ('#define ' + long_macro_name + ' \\\n' +
+                 '  a_fairly_long_body + something_else + 10\n')
+
+    assert (gen_define(
+        long_macro_name, [],
+        'a_fairly_long_body + something_else + 10') == multiline)
+
+    multiline_with_args = ('#define ' + long_macro_name +
+                           '(arg1, arg2, arg3) \\\n' +
+                           '  a_fairly_long_body + arg1 + arg2 + arg3\n')
+
+    assert (gen_define(
+        long_macro_name, ['arg1', 'arg2', 'arg3'],
+        'a_fairly_long_body + arg1 + arg2 + arg3') == multiline_with_args)
+
+    multiline_with_args_big_indent = (
+        '#define ' + long_macro_name + '(arg1, arg2, arg3) \\\n' +
+        '    a_fairly_long_body + arg1 + arg2 + arg3\n')
+
+    assert (gen_define(long_macro_name, ['arg1', 'arg2', 'arg3'],
+                       'a_fairly_long_body + arg1 + arg2 + arg3',
+                       indent='    ') == multiline_with_args_big_indent)


### PR DESCRIPTION
Fixes #578

regtool could output comments and #defines that went over the 80
character line limit leading to a failure of C/C++ lint checking. This
fixes all instances of that currently seen but doesn't entirely prevent
it.

Included with the commit are the new results of running regtool which
pass the C/C++ lint checks.

Thanks to @imphil for the comment wrapping fix

This doesn't totally fix the problem, long register names would still cause issues as I don't attempt to wrap defines of the form:

#define NAME val

What I've done targets the specific issues I was seeing, attempting to solve them relatively simply rather than do something more complex that will deal with a greater variety of cases.