### PR TITLE
[test] Fix OpenOCD test breakage introduce by refactoring.

### DIFF
--- a/test/systemtest/conftest.py
+++ b/test/systemtest/conftest.py
@@ -101,8 +101,10 @@ def sim_top_build(pytestconfig):
 @pytest.fixture(scope="session")
 def openocd(pytestconfig):
     """Return path to OpenOCD executable."""
-    path = Path(pytestconfig.getoption('openocd')).resolve()
-    assert path.is_file()
+    path = Path(pytestconfig.getoption('openocd'))
+    # TODO: Require that the OpenOCD executable be passed as a command-line
+    # argument in the future, rather than relying on $PATH lookup.
+    # assert path.is_file()
     return path
 
 @pytest.fixture(scope="session")

--- a/test/systemtest/openocd_verilator_test.py
+++ b/test/systemtest/openocd_verilator_test.py
@@ -37,8 +37,8 @@ class TestCoreVerilator:
     def sim_top_earlgrey(self, tmp_path, sim_top_build, sw_test_bin, rom_bin):
         cmd_sim = [
             str(sim_top_build),
-            '--meminit', str(sw_test_bin)),
-            '--rominit', str(rom_bin))
+            '--meminit', str(sw_test_bin),
+            '--rominit', str(rom_bin)
         ]
         p_sim = test_utils.Process(
             cmd_sim,
@@ -55,9 +55,9 @@ class TestCoreVerilator:
     def test_openocd_riscv_compliancetest(self, tmp_path, sim_top_earlgrey,
                                           topsrcdir, openocd):
         """Run RISC-V Debug compliance test built into OpenOCD."""
-        assert subprocess.call([openocd, '--version']) == 0
+        assert subprocess.call([str(openocd), '--version']) == 0
         cmd_openocd = [
-            openocd,
+            str(openocd),
             '-s', str(topsrcdir / 'util' / 'openocd'),
             '-f', 'board/lowrisc-earlgrey-verilator.cfg',
             '-c', 'init; riscv test_compliance; shutdown'


### PR DESCRIPTION
This change fixes the breakage introduced in #547, due to the OpenOCD command being resolved against $PATH by default. In the future, we should consider removing this dependency on $PATH once testing is fully automated.

