### PR TITLE
[top_earlgrey] Check timing before bitstream generation

### DIFF
--- a/hw/top_earlgrey/top_earlgrey_nexysvideo.core
+++ b/hw/top_earlgrey/top_earlgrey_nexysvideo.core
@@ -19,6 +19,13 @@ filesets:
       - data/placement.xdc
     file_type: xdc
 
+  files_tcl:
+    files:
+      - util/vivado_setup_hooks.tcl: { file_type: tclSource }
+      # File copied by fusesoc into the workroot (the file containing the
+      # .eda.yml file), and referenced from vivado_setup_hooks.tcl
+      - util/vivado_hook_write_bitstream_pre.tcl: { file_type: data, copyto: vivado_hook_write_bitstream_pre.tcl }
+
 parameters:
   # XXX: This parameter needs to be absolute, or relative to the *.runs/synth_1
   # directory. It's best to pass it as absolute path when invoking fusesoc, e.g.
@@ -42,6 +49,7 @@ targets:
     filesets:
       - files_rtl_nexysvideo
       - files_constraints
+      - files_tcl
     toplevel: top_earlgrey_nexysvideo
     parameters:
       - ROM_INIT_FILE

--- a/hw/top_earlgrey/util/vivado_hook_write_bitstream_pre.tcl
+++ b/hw/top_earlgrey/util/vivado_hook_write_bitstream_pre.tcl
@@ -1,0 +1,15 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+set workroot [file dirname [info script]]
+
+send_msg "Designcheck 1-1" INFO "Checking design"
+
+# Ensure the design meets timing
+set slack_ns [get_property SLACK [get_timing_paths -delay_type min_max]]
+send_msg "Designcheck 1-2" INFO "Slack is ${slack_ns} ns."
+
+if [expr {$slack_ns < 0}] {
+  send_msg "Designcheck 1-3" ERROR "Timing failed. Slack is ${slack_ns} ns."
+}

--- a/hw/top_earlgrey/util/vivado_setup_hooks.tcl
+++ b/hw/top_earlgrey/util/vivado_setup_hooks.tcl
@@ -1,0 +1,17 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Setup hook scripts, to be called at various stages during the build process
+# See Xilinx UG 894 ("Using Tcl Scripting") for documentation.
+
+# fusesoc-generated workroot containing the Vivado project file
+set workroot [pwd]
+
+# TODO: This hook is not getting called by Vivado when running through our
+# fusesoc flow (it gets called when writing a bitstream through the GUI).
+# Requires an update to edalize, see https://github.com/olofk/edalize/pull/60.
+#set_property STEPS.WRITE_BITSTREAM.TCL.PRE "${workroot}/vivado_hook_write_bitstream_pre.tcl" [get_runs impl_1]
+
+# As workaround, we use the post route design hook, which gets called.
+set_property STEPS.ROUTE_DESIGN.TCL.POST "${workroot}/vivado_hook_write_bitstream_pre.tcl" [get_runs impl_1]


### PR DESCRIPTION
This commit adds a TCL script to ensure that there are no timing 
violations. This script is run by Vivado before it writes a bitstream.

To get this script run by Vivado, we need to do two things:

- Execute the "set_property STEPS.WRITE_BITSTREAM.TCL.PRE" command
  during project creation to register our hook script. This is done in
  vivado_setup_hooks.tcl. Adding this script to the fusesoc core file
  as tclSource ensures that it gets sourced during project creation.
- Write a hook script to do the checking.
  This script does not need to be sourced by Vivado, we only need to
  copy it to the workroot (the Vivado directory containing the project
  file).
  We instruct fusesoc doing this copying by declaring it as "data"
  file type (which fusesoc doesn't touch), and explicitly copy it to the
  desired location.

As result, "fusesoc run" now fails with an error if the design doesn't meet
timing. Since this script is also run in CI, we get CI failures if timing
isn't met.

The following error is now part of the Vivado log, and Vivado and 
ultimately fusesoc return with an 1 error code:

``` 
INFO: [Designcheck 1-1] Checking design
INFO: [Designcheck 1-2] Slack is -8.076 ns.
ERROR: [Designcheck 1-3] Timing failed. Slack is -8.076 ns.
ERROR: [runtcl-1] ERROR: [Common 17-39] 'send_msg_id' failed due to earlier errors.
```

In case of a good run, the designcheck looks like this, and no error is
reported.

```
INFO: [Designcheck 1-1] Checking design
INFO: [Designcheck 1-2] Slack is 0.040 ns.
```