### PR TITLE
[gpio/dv] Remove TODOs with following justifications:

### DIFF
--- a/hw/ip/gpio/dv/env/gpio_scoreboard.sv
+++ b/hw/ip/gpio/dv/env/gpio_scoreboard.sv
@@ -476,8 +476,6 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
       `uvm_info(msg_id, $sformatf("gpio_i_driven = 0x%0h [%0b]", gpio_i_driven, gpio_i_driven),
                 UVM_HIGH)
 
-      // TODO-Should we have a logic for 'x' and 'z' values of data_oe[pin_num]?
-
       // Predict effective value of common wire that-
       // (i) drives gpio_i, and
       // (ii) gets driven by gpio_o based on gpiooe value

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_base_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_base_vseq.sv
@@ -55,10 +55,6 @@ class gpio_base_vseq extends cip_base_vseq #(
     super.pre_start();
   endtask
 
-  virtual task dut_shutdown();
-    // TODO(sriyerg): nothing to do yet
-  endtask
-
   // Task: drive_gpio_in
   // task to drive dut gpio inputs (gpio_en_o from dut must be configured to 0)
   virtual task drive_gpio_in(bit [NUM_GPIOS-1:0] val);

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_dout_din_regs_random_rw_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_dout_din_regs_random_rw_vseq.sv
@@ -43,8 +43,6 @@ class gpio_dout_din_regs_random_rw_vseq extends gpio_base_vseq;
         1: begin
           `uvm_info(`gfn, $sformatf("Transaction-%0d: program a random gpio register", tr_num),
                     UVM_HIGH)
-          // TODO-Rather than not driving all gpio inputs, drive them such that
-          // there is no "multiple drivers" case on any of the pins
           // First, stop driving gpio_i
           undrive_gpio_in();
           // Randomize csr value

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_random_dout_din_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_random_dout_din_vseq.sv
@@ -50,8 +50,6 @@ class gpio_random_dout_din_vseq extends gpio_base_vseq;
         1: begin
           `uvm_info(`gfn, $sformatf("Transaction-%0d: program register(s) to random value(s)",
                                     tr_num), UVM_HIGH)
-          // TODO-Rather than not driving all gpio inputs, drive them such that
-          // there is no "multiple drivers" case on any of the pins
           // First, stop driving gpio_i
           undrive_gpio_in();
 


### PR DESCRIPTION
- gpio_scoreboard.sv: Values x and z for pins_oe do not constitute
  very useful stimulus, so we need not have logic for it in scoreboard
  Hence, we can remove TODO related to this
- gpio_base_vseq.sv: Removing empty method dut_shutdown() is reasonable
  as there is still nothing to do here
  Related TODO is taken care of with removal of method
- gpio_dout_din_regs_random_rw_vseq.sv, gpio_random_dout_din_vseq.sv:
  Stimulus profile described in TODO already exists in
  gpio_full_random_vseq