### PR TITLE
Require minimum version of mistletoe package

### DIFF
--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -1,5 +1,5 @@
 livereload
-mistletoe
+mistletoe>=0.7.2
 hjson
 pygments
 mako


### PR DESCRIPTION
Previous versions of this package can cause the documentation build to abort when parsing, e.g., vendored-in docs such as the one of the debug module.

The root cause lies in tables with empty cells in the right-most column which cause `tokenize` in mistletoe<=0.7.1 to fail. Tested on Ubuntu 18.04 using Python3.6.