### PR TITLE
[uart/doc] UART doc updates

### DIFF
--- a/hw/ip/uart/data/uart.hjson
+++ b/hw/ip/uart/data/uart.hjson
@@ -13,9 +13,9 @@
   ],
   interrupt_list: [
     { name: "tx_watermark"
-      desc: "raised if the transmit FIFO is past the highwater mark."}
+      desc: "raised if the transmit FIFO is past the high-water mark."}
     { name: "rx_watermark"
-      desc: "raised if the receive FIFO is past the highwater mark."}
+      desc: "raised if the receive FIFO is past the high-water mark."}
     { name: "tx_overflow"
       desc: "raised if the transmit FIFO has overflowed."}
     { name: "rx_overflow"
@@ -256,17 +256,17 @@
       ]
     }
     { name: "OVRD",
-      desc: "UART override control register",
+      desc: "TX pin override control. Gives direct SW control over TX pin state",
       swaccess: "rw",
       hwaccess: "hro",
       fields: [
         { bits: "0",
           name: "TXEN",
-          desc: "Override the TX signal"
+          desc: "Enable TX pin override control"
         }
         { bits: "1",
           name: "TXVAL",
-          desc: "Value for TX Override"
+          desc: "Write to set the value of the TX pin"
         }
       ]
     }


### PR DESCRIPTION
A few further comments/questions:

1. What happens if the SW disables RX without emptying the RX FIFO? The sentence: 'It is expected that the software reads all the pending data from RX FIFO if RX needs to be disabled.' in the 'Reception' signal says you shouldn't do this but doesn't make clear the reasons why.

2. What happens to frame errors after a break error? The document specifies that frame errors will occur ever char-time if the line stays zero. Will these continue after a break error or stop?

3. What is the purpose of the UART override control register?

4. Some further description of the RX noise filter that's in the diagram and documented in the CTRL.NF register bit would be useful.

