### PR TITLE
[sw] Fix a few places where execution could "fall off".

### DIFF
--- a/sw/boot_rom/crt0.S
+++ b/sw/boot_rom/crt0.S
@@ -64,10 +64,10 @@ zero_loop_end:
 
 
 main_entry:
-  /* jump to main program entry point (argc = argv = 0) */
-  addi x10, x0, 0
-  addi x11, x0, 0
-  jal x1, main
+  call _boot_main
+loop_forever:
+  wfi
+  j loop_forever
 
 /* ====================== [ exceptions & interrupts ] =================== */
 /* This section has to be down here, since we have to disable rvc for it  */

--- a/sw/exts/common/_crt.c
+++ b/sw/exts/common/_crt.c
@@ -2,14 +2,16 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include <stdbool.h>
+#include <stddef.h>
 #include <string.h>
 
 #include "common.h"
 #include "irq.h"
 
-extern int main(void);
+extern int main(int, char **);
 
-void _crt(void) __attribute__((section(".crt")));
+void _crt(void) NO_RETURN __attribute__((section(".crt")));
 void _crt(void) {
   extern char _sdata[];
   extern char _idata[];
@@ -21,5 +23,8 @@ void _crt(void) {
   memcpy(_sdata, _idata, _edata - _sdata);
   memset(_bss_start, 0, _bss_end - _bss_start);
 
-  main();
+  main(0, NULL);
+  while (true) {
+    __asm__ volatile("wfi");
+  }
 }

--- a/sw/lib/common.h
+++ b/sw/lib/common.h
@@ -31,6 +31,7 @@ static const unsigned long UART_BAUD_RATE = 230400;
 #define CLRBIT(val, bit) (val & ~(1 << bit))
 
 #define ARRAYSIZE(x) (sizeof(x) / sizeof(x[0]))
+#define NO_RETURN __attribute__((noreturn))
 
 /* Hamming weight */
 #define BITLENGTH_1(X) ((X) - (((X) >> 1) & 0x55555555))

--- a/sw/tests/flash_ctrl/flash_test.c
+++ b/sw/tests/flash_ctrl/flash_test.c
@@ -162,5 +162,4 @@ int main(int argc, char **argv) {
 
   // cleanly terminate execution
   uart_send_str("PASS!\r\n");
-  __asm__ volatile("wfi;");
 }

--- a/sw/tests/hmac/sha256_test.c
+++ b/sw/tests/hmac/sha256_test.c
@@ -42,10 +42,7 @@ int main(int argc, char **argv) {
 
   if (error) {
     uart_send_str("FAIL!\r\n");
-    while (1) {
-    }
   } else {
     uart_send_str("PASS!\r\n");
-    __asm__ volatile("wfi;");
   }
 }

--- a/sw/tests/rv_timer/rv_timer_test.c
+++ b/sw/tests/rv_timer/rv_timer_test.c
@@ -32,7 +32,6 @@ int main(int argc, char **argv) {
   }
 
   uart_send_str("PASS!\r\n");
-  __asm__ volatile("wfi;");
 }
 
 // Override weak default function


### PR DESCRIPTION
A few functions have been marked as noreturn, namely the boot ROM's try_launch and _crt.c's _crt. These functions, as well as the entry point from crt0.S into boot_rom.c, are now guarded by infinite-wait-for-interrupt loops. Since it is now safe to return form main() in flash binaries, I've removed superfluous inline assembly to call wfi at the end of main().

In addition, this fixes some undefined behavior where the main() function of flash binaries was being called with the wrong calling convetion (i.e., as a function takiung void, rather than a function taking int, char **).