### PR TITLE
[rv_timer/dv] Fix regression failure

### DIFF
--- a/hw/dv/sv/dv_lib/dv_base_vseq.sv
+++ b/hw/dv/sv/dv_lib/dv_base_vseq.sv
@@ -55,6 +55,8 @@ class dv_base_vseq #(type RAL_T               = dv_base_reg_block,
   virtual task dut_init(string reset_kind = "HARD");
     if (do_apply_reset)         apply_reset(reset_kind);
     else if (do_wait_for_reset) wait_for_reset(reset_kind);
+    // delay after reset for tl agent check seq_item_port empty
+    #1ps;
   endtask
 
   virtual task apply_reset(string kind = "HARD");

--- a/hw/ip/rv_timer/dv/env/rv_timer_env_cov.sv
+++ b/hw/ip/rv_timer/dv/env/rv_timer_env_cov.sv
@@ -9,9 +9,9 @@
 class rv_timer_cfg_cov_obj extends uvm_object;
   `uvm_object_utils(rv_timer_cfg_cov_obj)
 
-  // Covergroup: cfg_cg
+  // Covergroup: timer_cfg_cg
   // timer config covergroup definition
-  covergroup cfg_cg(string name) with function sample(bit [7:0]  step,
+  covergroup timer_cfg_cg(string name) with function sample(bit [7:0]  step,
                                                       bit [11:0] prescale,
                                                       uint64 mtime,
                                                       uint64 mtime_cmp);
@@ -27,11 +27,11 @@ class rv_timer_cfg_cov_obj extends uvm_object;
     cp_mtime_cmp: coverpoint mtime_cmp {
       option.auto_bin_max = 50;
     }
-  endgroup : cfg_cg
+  endgroup : timer_cfg_cg
 
   function new(string name="rv_timer_cfg_cov");
     super.new(name);
-    cfg_cg = new(name);
+    timer_cfg_cg = new(name);
   endfunction : new
 endclass : rv_timer_cfg_cov_obj
 

--- a/hw/ip/rv_timer/dv/env/rv_timer_scoreboard.sv
+++ b/hw/ip/rv_timer/dv/env/rv_timer_scoreboard.sv
@@ -257,7 +257,7 @@ class rv_timer_scoreboard extends cip_base_scoreboard #(.CFG_T (rv_timer_env_cfg
                 if (cfg.en_cov) begin
                   int timer_idx = a_i * NUM_TIMERS + a_j;
                   //Sample cfg coverage for each timer
-                  cov.cfg_values_cov_obj[timer_idx].cfg_cg.sample(step[a_i],
+                  cov.cfg_values_cov_obj[timer_idx].timer_cfg_cg.sample(step[a_i],
                       prescale[a_i], timer_val[a_i], compare_val[a_i][a_j]);
                   //Sample toggle coverage for each prescale bit
                   for (int i = 0; i < 12; i++) begin

--- a/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_cfg_update_on_fly_vseq.sv
+++ b/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_cfg_update_on_fly_vseq.sv
@@ -56,7 +56,9 @@ class rv_timer_cfg_update_on_fly_vseq extends rv_timer_sanity_vseq;
             // Wait and read intr status for clks before updating timer cfg
             num_clks = calculate_num_clks(hart, timer);
             if (upd_cfg_in_end) begin
-              num_clks -= prescale[hart] + 4;
+              // subtract one prescale value i.e.(prescale+1) +
+              // 8 (clks to update timer and compare val) + 2 (read timer val)
+              num_clks -= (prescale[hart] + 1) + 8 + 2;
             end
             else begin
               num_clks = $urandom_range((num_clks / 10), (num_clks / 2));


### PR DESCRIPTION
1. dv_base_vseq: Added 1ps delay after reset
2. rv_timer_cfg_update_on_fly_vseq: Increased minimum period before
updating timer config
3. rv_timer_scoreboard,rv_timer_env_cov: Changed covergroup name