### PR TITLE
WIP [sw] Add AES sanity check

### DIFF
--- a/sw/lib/aes.c
+++ b/sw/lib/aes.c
@@ -1,0 +1,125 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "aes.h"
+
+#include "aes_regs.h"
+#include "common.h"
+
+#define AES0_BASE_ADDR 0x40110000
+
+void aes_init(const aes_cfg_t aes_cfg) {
+  // convert key_len from bytes to onehot
+  size_t key_len_onehot = 0b001;
+  if (aes_cfg.key_len_in_bytes == 24) {
+    key_len_onehot = 0b010;
+  } else if (aes_cfg.key_len_in_bytes == 32) {
+    key_len_onehot = 0b100;
+  }
+
+  REG32(AES_CTRL(0)) =
+      aes_cfg.mode << AES_CTRL_MODE |
+      (key_len_onehot & AES_CTRL_KEY_LEN_MASK) << AES_CTRL_KEY_LEN_OFFSET |
+      aes_cfg.manual_start_trigger << AES_CTRL_MANUAL_START_TRIGGER |
+      aes_cfg.force_data_overwrite << AES_CTRL_FORCE_DATA_OVERWRITE;
+  return;
+};
+
+void aes_key_put(const void *key, const size_t key_len_in_bytes) {
+  const size_t key_len_in_words = key_len_in_bytes >> 2;
+
+  for (int i = 0; i < key_len_in_words; i++) {
+    REG32(AES_KEY0(0) + i * sizeof(uint32_t)) = ((uint32_t *)key)[i];
+  }
+  for (int i = key_len_in_words; i < 8; i++) {
+    REG32(AES_KEY0(0) + i * sizeof(uint32_t)) = 0x0;
+  }
+
+  return;
+}
+
+void aes_data_put_wait(const void *data) {
+  // wait for input being ready
+  aes_data_ready();
+
+  // put the data
+  aes_data_put(data);
+
+  return;
+}
+
+void aes_data_put(const void *data) {
+  for (int i = 0; i < 4; i++) {
+    REG32(AES_DATA_IN0(0) + i * sizeof(uint32_t)) = ((uint32_t *)data)[i];
+  }
+
+  return;
+}
+
+void aes_data_get_wait(void *data) {
+  // wait for data to be valid
+  aes_data_valid();
+
+  // get the data
+  aes_data_get(data);
+
+  return;
+}
+
+void aes_data_get(void *data) {
+  for (int i = 0; i < 4; i++) {
+    ((uint32_t *)data)[i] = REG32(AES_DATA_OUT0(0) + i * sizeof(uint32_t));
+  }
+
+  return;
+}
+
+void aes_data_ready(void) {
+  while (!((REG32(AES_STATUS(0)) >> AES_STATUS_INPUT_READY) & 0x1)) {
+  }
+  return;
+}
+
+void aes_data_valid(void) {
+  while (!((REG32(AES_STATUS(0)) >> AES_STATUS_OUTPUT_VALID) & 0x1)) {
+  }
+  return;
+}
+
+void aes_idle(void) {
+  while (!((REG32(AES_STATUS(0)) >> AES_STATUS_IDLE) & 0x1)) {
+  }
+  return;
+}
+
+void aes_clear(void) {
+  // Wait for idle
+  aes_idle();
+
+  // Disable autostart
+  REG32(AES_CTRL(0)) = 0x1 << AES_CTRL_MANUAL_START_TRIGGER;
+
+  // Clear input data registers
+  for (int i = 0; i < 4; i++) {
+    REG32(AES_DATA_IN0(0) + i * sizeof(uint32_t)) = 0x0;
+  }
+
+  // Clear initial key registers
+  for (int i = 0; i < 4; i++) {
+    REG32(AES_KEY0(0) + i * sizeof(uint32_t)) = 0x0;
+  }
+
+  // Clear internal key and output registers
+  REG32(AES_TRIGGER(0)) =
+      (0x1 << AES_TRIGGER_KEY_CLEAR) | (0x1 << AES_TRIGGER_DATA_OUT_CLEAR);
+
+  // Wait for output not valid, and input ready
+  uint32_t status = (0x1 << AES_STATUS_OUTPUT_VALID);
+  while (((status >> AES_STATUS_OUTPUT_VALID) & 0x1) ||
+         !((status >> AES_STATUS_INPUT_READY) & 0x1)) {
+    status = REG32(AES_STATUS(0));
+  }
+
+  return;
+}

--- a/sw/lib/aes.h
+++ b/sw/lib/aes.h
@@ -1,0 +1,95 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef _F_LIB_AES_H__
+#define _F_LIB_AES_H__
+
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * Supported AES modes
+ */
+typedef enum aes_modes { AES_ENC = 0, AES_DEC = 1 } aes_modes_t;
+
+/**
+ * AES unit configuration options.
+ */
+typedef struct hmac_cfg {
+  /** Operational mode @see aes_modes. */
+  aes_modes_t mode;
+  /** Can be 16, 24 or 32. */
+  size_t key_len_in_bytes;
+  /** Set to 1 to only start upon getting a trigger signal. */
+  unsigned char manual_start_trigger;
+  /** Set to 1 to not stall when previous output data has not been read. */
+  unsigned char force_data_overwrite;
+} aes_cfg_t;
+
+/**
+ * Intialize AES unit to desired mode.
+ *
+ * @param aes_cfg AES configuration settings.
+ */
+void aes_init(const aes_cfg_t aes_cfg);
+
+/**
+ * Pass initial encryption key to AES unit.
+ *
+ * @param key              pointer to key.
+ * @param key_len_in_bytes key length in bytes (16, 24, 32)
+ */
+void aes_key_put(const void *key, const size_t key_len_in_bytes);
+
+/**
+ * Wait for AES unit to be ready for new input data and then
+ * pass one 16B block of input data to AES unit.
+ *
+ * @param data pointer to input buffer.
+ */
+void aes_data_put_wait(const void *data);
+
+/**
+ * Pass one 16B block of input data to AES unit.
+ *
+ * @param data pointer to input buffer.
+ */
+void aes_data_put(const void *data);
+
+/**
+ * Wait for AES unit to have valid output data and then
+ * get one 16B block of output data from AES unit.
+ *
+ * @param data pointer to output buffer.
+ */
+void aes_data_get_wait(void *data);
+
+/**
+ * Get one 16B block of output data from AES unit.
+ *
+ * @param data pointer to output buffer.
+ */
+void aes_data_get(void *data);
+
+/**
+ * Poll for AES unit being ready to accept new input data.
+ */
+void aes_data_ready(void);
+
+/**
+ * Poll for AES unit having valid output data.
+ */
+void aes_data_valid(void);
+
+/**
+ * Poll for AES unit being idle.
+ */
+void aes_idle(void);
+
+/**
+ * Clear key, input and ouput registers of AES unit.
+ */
+void aes_clear(void);
+
+#endif  // _F_LIB_AES_H__

--- a/sw/tests/aes/aes_test.c
+++ b/sw/tests/aes/aes_test.c
@@ -1,0 +1,84 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "aes.h"
+#include "common.h"
+#include "uart.h"
+
+// The example below is extracted from
+// the Advanced Encryption Standard (AES) FIPS Publication 197 available at
+// https://www.nist.gov/publications/advanced-encryption-standard-aes.
+
+static const unsigned char plain_text_1[16] = {
+    0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+    0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff};
+
+static const unsigned char key_32_1[32] = {
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
+    0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
+    0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f};
+
+static const unsigned char cipher_text_gold_32_1[16] = {
+    0x8e, 0xa2, 0xb7, 0xca, 0x51, 0x67, 0x45, 0xbf,
+    0xea, 0xfc, 0x49, 0x90, 0x4b, 0x49, 0x60, 0x89};
+
+int main(int argc, char **argv) {
+  uint32_t error = 0;
+
+  aes_idle();
+
+  unsigned char buffer[16];
+
+  uart_init(UART_BAUD_RATE);
+  uart_send_str("Running AES test\r\n");
+
+  // Setup AES config
+  aes_cfg_t aes_cfg;
+  aes_cfg.mode = AES_ENC;
+  aes_cfg.key_len_in_bytes = 32;
+  aes_cfg.manual_start_trigger = 0x0;
+  aes_cfg.force_data_overwrite = 0x0;
+
+  aes_key_put((const void *)key_32_1, aes_cfg.key_len_in_bytes);
+
+  // Encode
+  aes_cfg.mode = AES_ENC;
+  aes_init(aes_cfg);
+  aes_data_put_wait((const void *)plain_text_1);
+  aes_data_get_wait((void *)buffer);
+
+  // Check against golden cipher text
+  for (int i = 0; i < 16; i++) {
+    if (cipher_text_gold_32_1[i] != buffer[i]) {
+      error++;
+    }
+  }
+
+  // Decode
+  aes_cfg.mode = AES_DEC;
+  aes_init(aes_cfg);
+  aes_data_put_wait((const void *)buffer);
+  aes_data_get_wait((void *)buffer);
+
+  // Check against input plain text
+  for (int i = 0; i < 16; i++) {
+    if (plain_text_1[i] != buffer[i]) {
+      error++;
+    }
+  }
+
+  if (error) {
+    uart_send_str("FAIL!\r\n");
+    while (1) {
+    }
+  } else {
+    uart_send_str("PASS!\r\n");
+    __asm__ volatile("wfi;");
+  }
+
+  return 0;
+}

--- a/sw/tests/aes/meson.build
+++ b/sw/tests/aes/meson.build
@@ -1,0 +1,21 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+custom_target(
+  'aes_test',
+  output: embedded_target_output,
+  input: executable(
+    'aes_test',
+    ['aes_test.c', startup_files],
+    name_suffix: 'elf',
+    link_args: riscv_link_args,
+    link_depends: riscv_link_deps,
+    dependencies: [
+      sw_lib_aes,
+      sw_lib_uart,
+    ],
+  ),
+  command: embedded_target_args,
+  build_by_default: true,
+)

--- a/sw/tests/aes/srcs.mk
+++ b/sw/tests/aes/srcs.mk
@@ -1,0 +1,12 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+SW_NAME       ?= aes_test
+INCS          += -I$(SW_ROOT_DIR)/vendor
+
+# list srcs for each test
+ifeq ($(SW_NAME), aes_test)
+  SW_SRCS     += $(SW_DIR)/aes_test.c
+  SW_SRCS     += $(LIB_DIR)/aes.c
+endif


### PR DESCRIPTION
This is a draft PR not yet ready for review. It adds a new application under `sw/tests/aes` serving as a sanity check for the AES module.

To interface the AES module, this PR also adds a library containing the DIFs under `sw/lib`. Currently, the sanity check application directly uses these DIFs. What is missing is an other abstraction layer, i.e., a hardware crypto library for AES using the DIFs underneath.