### PR TITLE
[top_earlgrey] Set JTAG IDCODE

### DIFF
--- a/hw/top_earlgrey/doc/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/doc/top_earlgrey.sv.tpl
@@ -43,6 +43,18 @@ module top_${top["name"]} #(
   input               scanmode_i  // 1 for Scan
 );
 
+  // JTAG IDCODE for development versions of this code.
+  // Manufacturers of OpenTitan chips must replace this code with one of their
+  // own IDs.
+  // Field structure as defined in the IEEE 1149.1 (JTAG) specification,
+  // section 12.1.1.
+  localparam JTAG_IDCODE = {
+    4'h0,     // Version
+    16'h4F54, // Part Number: "OT"
+    11'h4A6,  // Manufacturer Identity: Google
+    1'b1      // (fixed)
+  };
+
   import tlul_pkg::*;
   import top_pkg::*;
   import tl_main_pkg::*;
@@ -174,12 +186,8 @@ module top_${top["name"]} #(
   //
 
   rv_dm #(
-    .NrHarts     (  1),
-    .IdcodeValue (32'h00000001) // Temporary value
-                                // xxxx             version
-                                // xxxxxxxxxxxxxxxx part number
-                                // xxxxxxxxxxx      manufacturer id
-                                // 1                required by standard
+    .NrHarts     (1),
+    .IdcodeValue (JTAG_IDCODE)
   ) u_dm_top (
     .clk_i         (main_clk),
     .rst_ni        (lc_rst_n),

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -38,6 +38,18 @@ module top_earlgrey #(
   input               scanmode_i  // 1 for Scan
 );
 
+  // JTAG IDCODE for development versions of this code.
+  // Manufacturers of OpenTitan chips must replace this code with one of their
+  // own IDs.
+  // Field structure as defined in the IEEE 1149.1 (JTAG) specification,
+  // section 12.1.1.
+  localparam JTAG_IDCODE = {
+    4'h0,     // Version
+    16'h4F54, // Part Number: "OT"
+    11'h4A6,  // Manufacturer Identity: Google
+    1'b1      // (fixed)
+  };
+
   import tlul_pkg::*;
   import top_pkg::*;
   import tl_main_pkg::*;
@@ -179,12 +191,8 @@ module top_earlgrey #(
   //
 
   rv_dm #(
-    .NrHarts     (  1),
-    .IdcodeValue (32'h00000001) // Temporary value
-                                // xxxx             version
-                                // xxxxxxxxxxxxxxxx part number
-                                // xxxxxxxxxxx      manufacturer id
-                                // 1                required by standard
+    .NrHarts     (1),
+    .IdcodeValue (JTAG_IDCODE)
   ) u_dm_top (
     .clk_i         (main_clk),
     .rst_ni        (lc_rst_n),

--- a/util/openocd/target/lowrisc-earlgrey.cfg
+++ b/util/openocd/target/lowrisc-earlgrey.cfg
@@ -13,9 +13,7 @@ if { [info exists CHIPNAME] } {
 if { [info exists CPUTAPID ] } {
    set _CPUTAPID $CPUTAPID
 } else {
-   # TODO: This is a dummy JTAG IDCODE value currently used in the HW design.
-   # This needs to be replaced with an assigned JTAG IDCODE value as we get it.
-   set _CPUTAPID 0x00000001
+   set _CPUTAPID 0x04F5494D
 }
 
 jtag newtap $_CHIPNAME tap -irlen 5 -expected-id $_CPUTAPID


### PR DESCRIPTION
Use a Google-provided JTAG IDCODE value for the development version of
OpenTitan. Manufacturers of chips are expected to replace this IDCODE
with their own one.

Fixes #490