### PR TITLE
[dv, tool] Update xcelium.mk and rules.mk to support lsf

### DIFF
--- a/hw/dv/tools/rules.mk
+++ b/hw/dv/tools/rules.mk
@@ -29,7 +29,7 @@ gen_sv_flist: pre_compile
 	cd ${BUILD_DIR} && ${SV_FLIST_GEN_TOOL} ${SV_FLIST_GEN_OPTS}
 
 compile: gen_sv_flist
-	$(BUILD_JOB_OPTS) cd ${SV_FLIST_GEN_DIR} && ${SIMCC} ${BUILD_OPTS} ${CL_BUILD_OPTS}
+	cd ${SV_FLIST_GEN_DIR} && $(BUILD_JOB_OPTS) ${SIMCC} ${BUILD_OPTS} ${CL_BUILD_OPTS}
 
 post_compile: compile
 
@@ -63,7 +63,7 @@ ifneq (${SW_NAME},)
 endif
 
 simulate: sw_build
-	$(RUN_JOB_OPTS) cd ${RUN_DIR} && ${SIMX} ${RUN_OPTS} ${CL_RUN_OPTS}
+	cd ${RUN_DIR} && $(RUN_JOB_OPTS) ${SIMX} ${RUN_OPTS} ${CL_RUN_OPTS}
 
 post_run: simulate
 

--- a/hw/dv/tools/xcelium/xcelium.mk
+++ b/hw/dv/tools/xcelium/xcelium.mk
@@ -24,8 +24,9 @@ BUILD_OPTS  += -messages
 BUILD_OPTS  += -errormax ${ERROR_MAX}
 BUILD_OPTS  += -sv
 BUILD_OPTS  += -timescale 1ns/1ps
-BUILD_OPTS  += +incdir+${UVM_HOME}/src
-BUILD_OPTS  += ${UVM_HOME}/src/uvm.sv
+BUILD_OPTS  += +incdir+${UVM_HOME}/sv/src
+BUILD_OPTS  += -uvmhome ${UVM_HOME}
+BUILD_OPTS  += -xmlibdirname ${SV_FLIST_GEN_DIR}/xcelium.d
 BUILD_OPTS  += -f ${SV_FLIST}
 
 # set standard run options


### PR DESCRIPTION
Update xcelium/vcs.mk to support LSF
  - Define JOB_OPTS var which is used as the prefix of SIMC and SIMXX.
    The JOB_OPTS var will be locally set by WDC team to reflect
    WDC LSF system (by default, JOB_OPTS is unset)
  - Update BUILD_OPTS in xcelium.mk

Refer: #622 

I need @sriyerg and @weicaiyang to verify this PR on your side. 