### PR TITLE
[doc] Document C++14 requirement and precise minimum Python version

### DIFF
--- a/doc/ug/install_instructions/index.md
+++ b/doc/ug/install_instructions/index.md
@@ -13,7 +13,7 @@ This guide makes assumes the following system setup.
   Using a virtual machine can work, but will slow down builds considerably.
   8 GB of RAM or more are highly recommended.
 * Physical access to that machine, root permissions and a graphical environment.
-* Python 3.5 or newer. Python 3.6+ is recommended.
+* Python 3.5.2 or newer. Python 3.6+ is recommended.
 * A C++14 capable compiler. GCC 5 or Clang 3.5 should meet this requirement.
 * 60 GB or more of disk space.
   EDA tools like Xilinx Vivado can easily take up 40 GB each.


### PR DESCRIPTION
Closes #4. The consensus was that there's no real motivation for
requiring a C++17 toolchain. Document the fact that a C++14 capable
toolchain is the minimum requirement.