### PR TITLE
[rv_plic] Add skipto handling for large interrupts

### DIFF
--- a/hw/ip/rv_plic/data/rv_plic.hjson.tpl
+++ b/hw/ip/rv_plic/data/rv_plic.hjson.tpl
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
+<% import math %>\
 # RV_PLIC register template
 #
 # Parameter (given by python tool)
@@ -64,7 +65,7 @@
     }
 % endfor
 % for i in range(target):
-    { skipto: ${0x100 + i*0x100 | x} }
+    { skipto: ${0x100*(math.ceil((src*4+8*math.ceil(src/32))/0x100)) + i*0x100 | x} }
     { multireg: {
         name: "IE${i}",
         desc: "Interrupt Enable for Target ${i}",

--- a/util/reggen/validate.py
+++ b/util/reggen/validate.py
@@ -1352,14 +1352,14 @@ def validate(regs, **kwargs):
             skipto, ierr = check_int(x['skipto'], "skipto at " + hex(offset))
             if ierr:
                 error += 1
-            elif (skipto <= offset):
-                log.error("{skipto " + x['skipto'] + "} at " + hex(offset) +
-                          " evaluates as " + hex(skipto) +
+            elif (skipto < offset):
+                log.error("{skipto " + hex(x['skipto']) + "} at " +
+                          hex(offset) + " evaluates as " + hex(skipto) +
                           " which would move backwards")
                 error += 1
             elif (skipto % addrsep) != 0:
-                log.error("{skipto " + x['skipto'] + "} at " + hex(offset) +
-                          " evaluates as " + hex(skipto) +
+                log.error("{skipto " + hex(x['skipto']) + "} at " +
+                          hex(offset) + " evaluates as " + hex(skipto) +
                           " which is not a multiple of the register size " +
                           str(addrsep))
                 error += 1


### PR DESCRIPTION
Problem:

    Current `reggen` raises an error if `skipto` field is less than
    calculated `offset` field. RV_PLIC sets first target offset to
    `0x100` and if # of interrupt sources is greater than or equal to
    60, it exceeds 0x100 offset for the first target. For 60 interrupts
    , it needs 60 PRIORITY registers (240 addr offset) and two Interrupt
    Pending registers and two Level-Edge registers. So it hits the
    `skipto <= offset` condition in `reggen/validate.py#L1357`.

Error Msg:

    Traceback (most recent call last):
      File "../../../util/regtool.py", line 213, in <module>
        main()
      File "../../../util/regtool.py", line 165, in main
        elif (validate.validate(obj, params=params) == 0):
      File "/util/reggen/validate.py", line 1357, in validate
        " evaluates as " + hex(skipto) +
    TypeError: can only concatenate str (not "int") to str

Resolution:

    Changed `hw/ip/rv_plic/data/rv_plic.hjson.tpl` to consider a large
    number of interrupts case. It calculates the target offset and
    increases skip to value at 0x100 granularity. So if #Src is greater
    than 60, it changes the `skipto` value to 0x200.

    Also, validate.py now converts `['skipto']` to string so that rather
    than above Exception error, it correctly creates error on the log
    file (our stdout).

this is related to #653