### PR TITLE
[host/spiflash] Fix linking

### DIFF
--- a/sw/host/spiflash/Makefile
+++ b/sw/host/spiflash/Makefile
@@ -24,7 +24,7 @@ all: $(PROGRAM)
 	$(CXX) $(CXXFLAGS) -c -o $@ $<
 
 $(PROGRAM): $(PROGRAM).cc $(OBJS) $(MPSSE_OBJS)
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) spiflash.cc -o spiflash $(DEPS) $(OBJS) $(MPSSE_OBJS)
+	$(CXX) $(CXXFLAGS) spiflash.cc -o spiflash $(DEPS) $(OBJS) $(MPSSE_OBJS) $(LDFLAGS)
 
 clean:
 	rm -f $(PROGRAM) *.o ${MPSSE_OBJS}


### PR DESCRIPTION
The Makefile applies the linker arguments before the object files,
causing the linker on some systems to not find the FTDI and OpenSSL
symbols.

Fixes #655