### PR TITLE
[uart] d/q naming cleanup

### DIFF
--- a/hw/ip/uart/rtl/uart_rx.sv
+++ b/hw/ip/uart/rtl/uart_rx.sv
@@ -24,76 +24,82 @@ module uart_rx (
   input           rx
 );
 
+  logic            rx_valid_q;
+  logic   [10:0]   sreg_q, sreg_d;
+  logic    [3:0]   bit_cnt_q, bit_cnt_d;
+  logic    [3:0]   baud_div_q, baud_div_d;
+  logic            tick_baud_d, tick_baud_q;
+  logic            idle_d, idle_q;
 
-  logic   [10:0]   sreg, sreg_next;
-  logic    [3:0]   bit_cnt, bit_cnt_next;
-  logic    [3:0]   baud_div, baud_div_next;
-  logic            tick_baud_next, idle_next;
+  assign tick_baud = tick_baud_q;
+  assign idle      = idle_q;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      sreg      <= 11'h0;
-      bit_cnt   <= 4'h0;
-      baud_div  <= 4'h0;
-      tick_baud <= 1'b0;
-      idle      <= 1'b1;
+      sreg_q      <= 11'h0;
+      bit_cnt_q   <= 4'h0;
+      baud_div_q  <= 4'h0;
+      tick_baud_q <= 1'b0;
+      idle_q      <= 1'b1;
     end else begin
-      sreg      <= sreg_next;
-      bit_cnt   <= bit_cnt_next;
-      baud_div  <= baud_div_next;
-      tick_baud <= tick_baud_next;
-      idle      <= idle_next;
+      sreg_q      <= sreg_d;
+      bit_cnt_q   <= bit_cnt_d;
+      baud_div_q  <= baud_div_d;
+      tick_baud_q <= tick_baud_d;
+      idle_q      <= idle_d;
     end
   end
 
   always_comb begin
     if (!rx_enable) begin
-      sreg_next      = 11'h0;
-      bit_cnt_next   = 4'h0;
-      baud_div_next  = 4'h0;
-      tick_baud_next = 1'b0;
-      idle_next      = 1'b1;
+      sreg_d      = 11'h0;
+      bit_cnt_d   = 4'h0;
+      baud_div_d  = 4'h0;
+      tick_baud_d = 1'b0;
+      idle_d      = 1'b1;
     end else begin
-      tick_baud_next = 1'b0;
-      sreg_next      = sreg;
-      bit_cnt_next   = bit_cnt;
-      baud_div_next  = baud_div;
-      idle_next      = idle;
+      tick_baud_d = 1'b0;
+      sreg_d      = sreg_q;
+      bit_cnt_d   = bit_cnt_q;
+      baud_div_d  = baud_div_q;
+      idle_d      = idle_q;
       if (tick_baud_x16) begin
-        {tick_baud_next, baud_div_next} = {1'b0,baud_div} + 5'h1;
+        {tick_baud_d, baud_div_d} = {1'b0,baud_div_q} + 5'h1;
       end
 
-      if (idle && !rx) begin
+      if (idle_q && !rx) begin
         // start of char, sample in the middle of the bit time
-        baud_div_next  = 4'd8;
-        tick_baud_next = 1'b0;
-        bit_cnt_next   = (parity_enable ? 4'd11 : 4'd10);
-        sreg_next      = 11'h0;
-        idle_next      = 1'b0;
-      end else if (!idle && tick_baud) begin
-        if ((bit_cnt == (parity_enable ? 4'd11 : 4'd10)) && rx) begin
+        baud_div_d  = 4'd8;
+        tick_baud_d = 1'b0;
+        bit_cnt_d   = (parity_enable ? 4'd11 : 4'd10);
+        sreg_d      = 11'h0;
+        idle_d      = 1'b0;
+      end else if (!idle_q && tick_baud_q) begin
+        if ((bit_cnt_q == (parity_enable ? 4'd11 : 4'd10)) && rx) begin
           // must have been a glitch on the input, start bit is not set
           // in the middle of the bit time, abort
-          idle_next    = 1'b1;
-          bit_cnt_next = 4'h0;
+          idle_d    = 1'b1;
+          bit_cnt_d = 4'h0;
         end else begin
-          sreg_next    = {rx, sreg[10:1]};
-          bit_cnt_next = bit_cnt - 4'h1;
-          idle_next    = (bit_cnt == 4'h1);
+          sreg_d    = {rx, sreg_q[10:1]};
+          bit_cnt_d = bit_cnt_q - 4'h1;
+          idle_d    = (bit_cnt_q == 4'h1);
         end
       end
     end
   end
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) rx_valid <= 1'b0;
-    else         rx_valid <= tick_baud & (bit_cnt == 4'h1);
+    if (!rst_ni) rx_valid_q <= 1'b0;
+    else         rx_valid_q <= tick_baud_q & (bit_cnt_q == 4'h1);
+
   end
 
-  assign rx_data       = parity_enable ? sreg[8:1] : sreg[9:2];
-  //    (rx_parity     = sreg[9])
-  assign frame_err     = rx_valid & ~sreg[10];
-  assign rx_parity_err = parity_enable & rx_valid &
-                         (^{sreg[9:1],parity_odd});
+  assign rx_valid      = rx_valid_q;
+  assign rx_data       = parity_enable ? sreg_q[8:1] : sreg_q[9:2];
+  //    (rx_parity     = sreg_q[9])
+  assign frame_err     = rx_valid_q & ~sreg_q[10];
+  assign rx_parity_err = parity_enable & rx_valid_q &
+                         (^{sreg_q[9:1],parity_odd});
 
 endmodule


### PR DESCRIPTION
I gave the UART RTL a pass and modified a couple of style related things (added labels to all processes and updated the register naming scheme to follow the `_d/_q` convention). Otherwise LGTM.

Lint runs and the sanity check runs as well. We might want to run the full DV suite again after this change.