### PR TITLE
[doc] manually create links to top_earlgrey and Ibex specs

### DIFF
--- a/hw/index.md
+++ b/hw/index.md
@@ -1,13 +1,16 @@
 # Hardware Specifications
 
-## Available Top Earlgrey Specifications
+This is the landing spot for all hardware specifications within the OpenTitan project.
+This includes: top level specification(s); processor core(s) specifications; and [Comportable IP](../doc/rm/comportability_specification.md) specifications.
 
-{{% doctree top_earlgrey }}
+## Available Top Level Specifications
 
-## Available Ibex Core Specifications
+* [`top_earlgrey` design specification](top_earlgrey/doc/top_earlgrey.md)
 
-{{% doctree vendor/lowrisc_ibex }}
+## Available Processor Core Specifications
 
-## Available Comportable IP Block Specifications
+* [`core_ibex` user manual](https://ibex-core.readthedocs.io/en/latest)
+
+## Available Comportable IP Block Design Specifications and Verification Plans
 
 {{% specboard ip }}


### PR DESCRIPTION
One more clean-up pass here: remove the autogen for Top and Ibex specs
(was creating pointers to random READMEs) and manually put pointers to
blessed tops and cores (obviously just top_earlgrey and Ibex for now). Should
look a bit cleaner as an all-things-hardware-spec landing spot.