### PR TITLE
[dv/hmac] Fix warning and scb timing

### DIFF
--- a/hw/dv/sv/tl_agent/tl_device_driver.sv
+++ b/hw/dv/sv/tl_agent/tl_device_driver.sv
@@ -79,7 +79,7 @@ class tl_device_driver extends uvm_driver#(tl_seq_item);
         else @(vif.device_cb);
       end
       vif.device_cb.d2h.d_valid  <= 1'b1;
-      vif.device_cb.d2h.d_opcode <= rsp.d_opcode;
+      vif.device_cb.d2h.d_opcode <= tl_d_op_e'(rsp.d_opcode);
       vif.device_cb.d2h.d_data   <= rsp.d_data;
       vif.device_cb.d2h.d_source <= rsp.d_source;
       vif.device_cb.d2h.d_param  <= rsp.d_param;

--- a/hw/dv/sv/tl_agent/tl_host_driver.sv
+++ b/hw/dv/sv/tl_agent/tl_host_driver.sv
@@ -84,7 +84,7 @@ class tl_host_driver extends uvm_driver#(tl_seq_item);
     // wait until no outstanding transaction with same source id
     while (is_source_in_pending_req(req.a_source) & !reset_asserted) @(vif.host_cb);
     vif.host_cb.h2d.a_address <= req.a_addr;
-    vif.host_cb.h2d.a_opcode  <= req.a_opcode;
+    vif.host_cb.h2d.a_opcode  <= tl_a_op_e'(req.a_opcode);
     vif.host_cb.h2d.a_size    <= req.a_size;
     vif.host_cb.h2d.a_param   <= req.a_param;
     vif.host_cb.h2d.a_data    <= req.a_data;

--- a/hw/dv/sv/tl_agent/tl_reg_adapter.sv
+++ b/hw/dv/sv/tl_agent/tl_reg_adapter.sv
@@ -30,8 +30,8 @@ class tl_reg_adapter #(type ITEM_T = tl_seq_item) extends uvm_reg_adapter;
         `DV_CHECK_RANDOMIZE_WITH_FATAL(reg_item,
             a_opcode          == tlul_pkg::Get;
             a_addr[TL_AW-1:2] == rw.addr[TL_AW-1:2];
-            a_mask dist {'1         :/ 1,
-                         [1:('1-1)] :/ 1};)
+            $countones(a_mask) dist { TL_DBW       :/ 1,
+                                      [0:TL_DBW-1] :/ 1};)
       end else begin // csr field read
         `DV_CHECK_RANDOMIZE_WITH_FATAL(reg_item,
             a_opcode          == tlul_pkg::Get;


### PR DESCRIPTION
Add void to a function declaration
Add 1ns delay when updating fifo_full to avoid corner case when rd/wr
pointers are updated at the same time