### PR TITLE
[top_earlgrey] Check BRAM implementation for ROM memory 

### DIFF
--- a/hw/top_earlgrey/data/placement.xdc
+++ b/hw/top_earlgrey/data/placement.xdc
@@ -1,2 +1,5 @@
+# Any change in ROM instances path should be updated in following two files
+# 1. hw/top_earlgrey/data/placement.xdc and
+# 2. hw/top_earlgrey/util/vivado_hook_opt_design_post.tcl
 set_property LOC RAMB36_X4Y18 [get_cells -hierarchical -filter { NAME =~  "*rom_rom*dout_o_reg_0" && PRIMITIVE_TYPE =~ BMEM.*.* }]
 set_property LOC RAMB36_X4Y19 [get_cells -hierarchical -filter { NAME =~  "*rom_rom*dout_o_reg_1" && PRIMITIVE_TYPE =~ BMEM.*.* }]

--- a/hw/top_earlgrey/top_earlgrey_nexysvideo.core
+++ b/hw/top_earlgrey/top_earlgrey_nexysvideo.core
@@ -25,6 +25,7 @@ filesets:
       # File copied by fusesoc into the workroot (the file containing the
       # .eda.yml file), and referenced from vivado_setup_hooks.tcl
       - util/vivado_hook_write_bitstream_pre.tcl: { file_type: data, copyto: vivado_hook_write_bitstream_pre.tcl }
+      - util/vivado_hook_opt_design_post.tcl: { file_type: data, copyto: vivado_hook_opt_design_post.tcl }
 
 parameters:
   # XXX: This parameter needs to be absolute, or relative to the *.runs/synth_1

--- a/hw/top_earlgrey/util/vivado_hook_opt_design_post.tcl
+++ b/hw/top_earlgrey/util/vivado_hook_opt_design_post.tcl
@@ -1,0 +1,16 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Any change in ROM instances path should be updated in following two files
+# 1. hw/top_earlgrey/data/placement.xdc and
+# 2. hw/top_earlgrey/util/vivado_hook_opt_design_post.tcl
+
+send_msg "Designcheck 1-1" INFO "Checking if ROM memory is mapped to BRAM memory."
+
+if {[catch [get_cells -hierarchical -filter { NAME =~  "*rom_rom*dout_o_reg_0" && PRIMITIVE_TYPE =~ BMEM.*.* }]]\
+ && [catch [get_cells -hierarchical -filter { NAME =~  "*rom_rom*dout_o_reg_1" && PRIMITIVE_TYPE =~ BMEM.*.* }]] } {
+  send_msg "Designcheck 1-3" INFO "BRAM implementation found for ROM memory."
+} else {
+  send_msg "Designcheck 1-2" ERROR "BRAM implementation not found for ROM memory."
+}

--- a/hw/top_earlgrey/util/vivado_setup_hooks.tcl
+++ b/hw/top_earlgrey/util/vivado_setup_hooks.tcl
@@ -8,6 +8,9 @@
 # fusesoc-generated workroot containing the Vivado project file
 set workroot [pwd]
 
+# Hook to check BRAM implementation for ROM memory
+set_property STEPS.OPT_DESIGN.TCL.POST "${workroot}/vivado_hook_opt_design_post.tcl" [get_runs impl_1]
+
 # TODO: This hook is not getting called by Vivado when running through our
 # fusesoc flow (it gets called when writing a bitstream through the GUI).
 # Requires an update to edalize, see https://github.com/olofk/edalize/pull/60.


### PR DESCRIPTION
This commit adds a TCL script to ensure that there is a check 
if BRAM is inferred for ROM memory inside the design. 
This is a critical check to ensure splice flow works on inferred BRAM's 
for ROM memories in the design.

Uses the framework developed in #595 

This script is run by Vivado after opt_design.

To get this script run by Vivado, we need to do two things:

- Execute the "set_property STEPS.OPT_DESIGN.TCL.POST" command
  during project creation to register our hook script. This is done in
  vivado_setup_hooks.tcl. Adding this script to the fusesoc core file
  as tclSource ensures that it gets sourced during project creation.
- Write a hook script to do the checking.
  This script does not need to be sourced by Vivado, we only need to
  copy it to the workroot (the Vivado directory containing the project
  file).
  We instruct fusesoc doing this copying by declaring it as "data"
  file type (which fusesoc doesn't touch), and explicitly copy it to the
  desired location.

As result, "fusesoc run" now fails with an error if BRAM is not inferred 
for ROM memory. The ERROR is as well seen in CI.

The following error is now part of the Vivado log, and Vivado and
ultimately fusesoc return with an 1 error code:

```
INFO: [Designcheck 1-1] Checking if ROM memory is mapped to BRAM memory.
ERROR: [Designcheck 1-2] BRAM implementation not found for ROM memory.
ERROR: [runtcl-1] ERROR: [Common 17-39] 'send_msg_id' failed due to earlier errors.
ERROR: [Common 17-39] 'send_msg_id' failed due to earlier errors.
```

In case of a good run, the Designcheck looks like this, and no error is
reported.

```
INFO: [Designcheck 1-1] Checking if ROM memory is mapped to BRAM memory.
INFO: [Designcheck 1-3] BRAM implementation found for ROM memory.
```