### PR TITLE
[uart/rtl] Add scanmode_i to the port

### DIFF
--- a/hw/ip/uart/data/uart.hjson
+++ b/hw/ip/uart/data/uart.hjson
@@ -33,6 +33,7 @@
     { name: "rx_parity_err"
       desc: "raised if the receiver has detected a parity error."}
   ]
+  scan: "true", // Enable `scanmode_i` port
   regwidth: "32",
   registers: [
     { name: "CTRL",

--- a/hw/ip/uart/dv/tb/tb.sv
+++ b/hw/ip/uart/dv/tb/tb.sv
@@ -54,7 +54,9 @@ module tb;
     .intr_rx_frame_err_o  (intr_rx_frame_err ),
     .intr_rx_break_err_o  (intr_rx_break_err ),
     .intr_rx_timeout_o    (intr_rx_timeout   ),
-    .intr_rx_parity_err_o (intr_rx_parity_err)
+    .intr_rx_parity_err_o (intr_rx_parity_err),
+
+    .scanmode_i           (1'b0              )
   );
 
   assign interrupts[TxWatermark] = intr_tx_watermark;

--- a/hw/ip/uart/rtl/uart.sv
+++ b/hw/ip/uart/rtl/uart.sv
@@ -25,12 +25,10 @@ module uart (
   output logic    intr_rx_frame_err_o ,
   output logic    intr_rx_break_err_o ,
   output logic    intr_rx_timeout_o   ,
-  output logic    intr_rx_parity_err_o
-);
+  output logic    intr_rx_parity_err_o,
 
-  // TODO: same as in spi_device.sv, add input scanmode_i to module
-  logic scanmode_i;
-  assign scanmode_i = 1'b0;
+  input           scanmode_i
+);
 
   import uart_reg_pkg::*;
 

--- a/hw/top_earlgrey/doc/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/doc/autogen/top_earlgrey.gen.hjson
@@ -113,7 +113,7 @@
           type: interrupt
         }
       ]
-      scan: "false"
+      scan: "true"
     }
     {
       name: gpio

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -370,6 +370,7 @@ module top_earlgrey #(
       .intr_rx_timeout_o (intr_uart_rx_timeout),
       .intr_rx_parity_err_o (intr_uart_rx_parity_err),
 
+      .scanmode_i   (scanmode_i),
       .clk_i (main_clk),
       .rst_ni (sys_rst_n)
   );


### PR DESCRIPTION
Addressed remaind TODO in UART design. UART IP needs `scanmode` signal.
It is used to connect system reset to internal FIFOs' reset signals when
`scanmode` is enabled (increasing DFT coverage).