### PR TITLE
[reggen] skipto error fix

### DIFF
--- a/hw/ip/rv_plic/data/rv_plic.hjson
+++ b/hw/ip/rv_plic/data/rv_plic.hjson
@@ -309,7 +309,7 @@
         { bits: "2:0" }
       ],
     }
-    { skipto: 256 }
+    { skipto: "256" }
     { multireg: {
         name: "IE0",
         desc: "Interrupt Enable for Target 0",

--- a/hw/ip/rv_plic/data/rv_plic.hjson.tpl
+++ b/hw/ip/rv_plic/data/rv_plic.hjson.tpl
@@ -65,7 +65,7 @@
     }
 % endfor
 % for i in range(target):
-    { skipto: ${0x100*(math.ceil((src*4+8*math.ceil(src/32))/0x100)) + i*0x100 | x} }
+    { skipto: "${0x100*(math.ceil((src*4+8*math.ceil(src/32))/0x100)) + i*0x100 | x}" }
     { multireg: {
         name: "IE${i}",
         desc: "Interrupt Enable for Target ${i}",

--- a/hw/top_earlgrey/ip/rv_plic/doc/autogen/rv_plic.hjson
+++ b/hw/top_earlgrey/ip/rv_plic/doc/autogen/rv_plic.hjson
@@ -501,7 +501,7 @@
         { bits: "1:0" }
       ],
     }
-    { skipto: 256 }
+    { skipto: "256" }
     { multireg: {
         name: "IE0",
         desc: "Interrupt Enable for Target 0",

--- a/util/reggen/validate.py
+++ b/util/reggen/validate.py
@@ -1353,13 +1353,13 @@ def validate(regs, **kwargs):
             if ierr:
                 error += 1
             elif (skipto < offset):
-                log.error("{skipto " + hex(x['skipto']) + "} at " +
-                          hex(offset) + " evaluates as " + hex(skipto) +
+                log.error("{skipto " + x['skipto'] + "} at " + hex(offset) +
+                          " evaluates as " + hex(skipto) +
                           " which would move backwards")
                 error += 1
             elif (skipto % addrsep) != 0:
-                log.error("{skipto " + hex(x['skipto']) + "} at " +
-                          hex(offset) + " evaluates as " + hex(skipto) +
+                log.error("{skipto " + x['skipto'] + "} at " + hex(offset) +
+                          " evaluates as " + hex(skipto) +
                           " which is not a multiple of the register size " +
                           str(addrsep))
                 error += 1


### PR DESCRIPTION
Previous fix #654 wasn't correct.

Problem:

    `skipto` field value should be string as shown in example, not
    integer. But `rv_plic.hjson.tpl` set it to integer type. It results
    in to wrap the value with `hex()` to make it string type.

    This make the rv_plic reports correct error but it let build_docs.py
    failed.

```
Traceback (most recent call last):
  File "./util/build_docs.py", line 165, in <module>
    main()
  File "./util/build_docs.py", line 151, in main
    process_all_files()
  File "./util/build_docs.py", line 127, in process_all_files
...
  File "/mistletoe/base_renderer.py", line 95, in render
    return self.render_map[token.__class__.__name__](token)
  File "util/docgen/lowrisc_renderer.py", line 301, in render_lowrisc_escape
    if validate.validate(obj) == 0:
  File "util/reggen/validate.py", line 1363, in validate
    " which is not a multiple of the register size " +
TypeError: 'str' object cannot be interpreted as an integer
```

Resolution:

    Rolled-back the `validate.py` error report code. And changed
    `rv_plic.hjson.tpl` to make `skipto` to string type.

Issue reported by @asb