### PR TITLE
[common/dv] Fix env cfg compile warning seen for all IPs

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
@@ -26,9 +26,8 @@ class cip_base_env_cfg #(type RAL_T = dv_base_reg_block) extends dv_base_env_cfg
 
   `uvm_object_new
 
-  virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1,
-                                   bit [TL_AW-1:0] csr_addr_map_size);
-    super.initialize(csr_base_addr, csr_addr_map_size);
+  virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);
+    super.initialize(csr_base_addr);
     // create tl agent config obj
     m_tl_agent_cfg = tl_agent_cfg::type_id::create("m_tl_agent_cfg");
     m_tl_agent_cfg.is_host = 1'b1;

--- a/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
+++ b/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
@@ -45,10 +45,9 @@ class dv_base_env_cfg #(type RAL_T = dv_base_reg_block) extends uvm_object;
 
   `uvm_object_new
 
-  virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1,
-                                   bit [TL_AW-1:0] csr_addr_map_size);
+  virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);
+    initialize_csr_addr_map_size();
     `DV_CHECK_NE_FATAL(csr_addr_map_size, 0, "csr_addr_map_size can't be 0")
-    this.csr_addr_map_size = csr_addr_map_size;
     // use locally randomized csr base address, unless provided as arg to this function
     if (csr_base_addr != '1) begin
       bit is_aligned;
@@ -69,6 +68,12 @@ class dv_base_env_cfg #(type RAL_T = dv_base_reg_block) extends uvm_object;
       apply_ral_fixes();
     end
   endfunction
+
+  // This function must be implemented in extended class to
+  // initialize value of csr_addr_map_size member
+  virtual function void initialize_csr_addr_map_size();
+    `uvm_fatal(`gfn, "This task must be implemented in the extended class!")
+  endfunction : initialize_csr_addr_map_size
 
   // ral flow is limited in terms of setting correct field access policies and reset values
   // We apply those fixes here - please note these fixes need to be reflected in the scoreboard

--- a/hw/ip/alert_handler/dv/env/alert_handler_env_cfg.sv
+++ b/hw/ip/alert_handler/dv/env/alert_handler_env_cfg.sv
@@ -13,9 +13,12 @@ class alert_handler_env_cfg extends cip_base_env_cfg #(.RAL_T(alert_handler_reg_
 
   `uvm_object_new
 
-  virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1,
-                                   bit [TL_AW-1:0] csr_addr_map_size = 2048);
-    super.initialize(csr_base_addr, csr_addr_map_size);
+  virtual function void initialize_csr_addr_map_size();
+    this.csr_addr_map_size = ALERT_HANDLER_ADDR_MAP_SIZE;
+  endfunction : initialize_csr_addr_map_size
+
+  virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);
+    super.initialize(csr_base_addr);
 
     // set num_interrupts & num_alerts
     begin

--- a/hw/ip/alert_handler/dv/env/alert_handler_env_pkg.sv
+++ b/hw/ip/alert_handler/dv/env/alert_handler_env_pkg.sv
@@ -17,7 +17,8 @@ package alert_handler_env_pkg;
   `include "dv_macros.svh"
 
   // parameters
-  parameter int NUM_MAX_ESC_SEV = 8;
+  parameter uint ALERT_HANDLER_ADDR_MAP_SIZE = 2048;
+  parameter uint NUM_MAX_ESC_SEV             = 8;
 
   // types
   // forward declare classes to allow typedefs below

--- a/hw/ip/gpio/dv/env/gpio_env_cfg.sv
+++ b/hw/ip/gpio/dv/env/gpio_env_cfg.sv
@@ -19,9 +19,12 @@ class gpio_env_cfg extends cip_base_env_cfg #(.RAL_T(gpio_reg_block));
   `uvm_object_utils(gpio_env_cfg)
   `uvm_object_new
 
-  virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1,
-                                   bit [TL_AW-1:0] csr_addr_map_size = ADDR_MAP_SIZE);
-    super.initialize(csr_base_addr, csr_addr_map_size);
+  virtual function void initialize_csr_addr_map_size();
+    this.csr_addr_map_size = GPIO_ADDR_MAP_SIZE;
+  endfunction : initialize_csr_addr_map_size
+
+  virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);
+    super.initialize(csr_base_addr);
     // set num_interrupts & num_alerts which will be used to create coverage and more
     num_interrupts = ral.intr_state.get_n_used_bits();
   endfunction : initialize

--- a/hw/ip/gpio/dv/env/gpio_env_pkg.sv
+++ b/hw/ip/gpio/dv/env/gpio_env_pkg.sv
@@ -17,7 +17,7 @@ package gpio_env_pkg;
   `include "dv_macros.svh"
 
   // csr and mem total size for IP
-  parameter uint ADDR_MAP_SIZE = 64;
+  parameter uint GPIO_ADDR_MAP_SIZE = 64;
   // no. of gpio pins
   parameter uint NUM_GPIOS     = 32;
   // no. of cycles for noise filter

--- a/hw/ip/hmac/dv/env/hmac_env_cfg.sv
+++ b/hw/ip/hmac/dv/env/hmac_env_cfg.sv
@@ -6,10 +6,13 @@ class hmac_env_cfg extends cip_base_env_cfg #(.RAL_T(hmac_reg_block));
   `uvm_object_utils(hmac_env_cfg)
   `uvm_object_new
 
-  virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1,
-                                   bit [TL_AW-1:0] csr_addr_map_size = ADDR_MAP_SIZE);
+  virtual function void initialize_csr_addr_map_size();
+    this.csr_addr_map_size = HMAC_ADDR_MAP_SIZE;
+  endfunction : initialize_csr_addr_map_size
+
+  virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);
     mem_addr_s mem_addr;
-    super.initialize(csr_base_addr, csr_addr_map_size);
+    super.initialize(csr_base_addr);
     en_mem_byte_write   = 1;
     en_mem_read         = 0;
     mem_addr.start_addr = HMAC_MSG_FIFO_BASE;

--- a/hw/ip/hmac/dv/env/hmac_env_pkg.sv
+++ b/hw/ip/hmac/dv/env/hmac_env_pkg.sv
@@ -20,7 +20,7 @@ package hmac_env_pkg;
 
   // local parameters and types
   // csr and mem total size for IP
-  parameter uint   ADDR_MAP_SIZE             = 4096;
+  parameter uint   HMAC_ADDR_MAP_SIZE        = 4096;
   parameter uint32 HMAC_MSG_FIFO_DEPTH       = 16;
   parameter uint32 HMAC_MSG_FIFO_DEPTH_BYTES = HMAC_MSG_FIFO_DEPTH * 4;
   parameter uint32 HMAC_MSG_FIFO_SIZE        = 2048;

--- a/hw/ip/i2c/doc/i2c_dv_plan.md
+++ b/hw/ip/i2c/doc/i2c_dv_plan.md
@@ -45,8 +45,8 @@ All common types and methods defined at the package level can be found in
 `i2c_env_pkg`. Some of them in use are:
 ```systemverilog
 parameter uint I2C_FMT_FIFO_DEPTH = 32;
-parameter uint I2C_RX_FIFO_DEPTH = 32;
-parameter uint ADDR_MAP_SIZE = 128;
+parameter uint I2C_RX_FIFO_DEPTH  = 32;
+parameter uint I2C_ADDR_MAP_SIZE  = 128;
 ```
 
 ### TL_agent

--- a/hw/ip/i2c/dv/env/i2c_env_cfg.sv
+++ b/hw/ip/i2c/dv/env/i2c_env_cfg.sv
@@ -13,9 +13,12 @@ class i2c_env_cfg extends cip_base_env_cfg #(.RAL_T(i2c_reg_block));
 
   `uvm_object_new
 
-  virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1,
-                                   bit [TL_AW-1:0] csr_addr_map_size = ADDR_MAP_SIZE);
-    super.initialize(csr_base_addr, csr_addr_map_size);
+  virtual function void initialize_csr_addr_map_size();
+    this.csr_addr_map_size = I2C_ADDR_MAP_SIZE;
+  endfunction : initialize_csr_addr_map_size
+
+  virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);
+    super.initialize(csr_base_addr);
     // create i2c agent config obj
     m_i2c_agent_cfg = i2c_agent_cfg::type_id::create("m_i2c_agent_cfg");
 

--- a/hw/ip/i2c/dv/env/i2c_env_pkg.sv
+++ b/hw/ip/i2c/dv/env/i2c_env_pkg.sv
@@ -32,7 +32,7 @@ package i2c_env_pkg;
   } i2c_intr_e;
 
   // csr and mem total size for IP, TODO confirm below value with spec
-  parameter uint ADDR_MAP_SIZE      = 128;
+  parameter uint I2C_ADDR_MAP_SIZE  = 128;
   // local types
   parameter uint I2C_FMT_FIFO_DEPTH = 32;
   parameter uint I2C_RX_FIFO_DEPTH  = 32;

--- a/hw/ip/rv_dm/dv/env/rv_dm_env_cfg.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env_cfg.sv
@@ -19,9 +19,12 @@ class rv_dm_env_cfg extends dv_base_env_cfg #(.RAL_T(rv_dm_reg_block));
 
   `uvm_object_new
 
-  virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1,
-                                   bit [TL_AW-1:0] csr_addr_map_size = ADDR_MAP_SIZE);
-    super.initialize(csr_base_addr, csr_addr_map_size);
+  virtual function void initialize_csr_addr_map_size();
+    this.csr_addr_map_size = RV_DM_ADDR_MAP_SIZE;
+  endfunction : initialize_csr_addr_map_size
+
+  virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);
+    super.initialize(csr_base_addr);
     // create jtag agent config obj
     m_jtag_agent_cfg = jtag_agent_cfg::type_id::create("m_jtag_agent_cfg");
     // create tl_host agent config obj

--- a/hw/ip/rv_dm/dv/env/rv_dm_env_pkg.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env_pkg.sv
@@ -19,7 +19,7 @@ package rv_dm_env_pkg;
 
   // parameters
   // csr and mem total size for IP, TODO update below value
-  parameter uint ADDR_MAP_SIZE = 4096;
+  parameter uint RV_DM_ADDR_MAP_SIZE = 4096;
 
   // types
 

--- a/hw/ip/rv_timer/dv/env/rv_timer_env_cfg.sv
+++ b/hw/ip/rv_timer/dv/env/rv_timer_env_cfg.sv
@@ -6,9 +6,12 @@ class rv_timer_env_cfg extends cip_base_env_cfg #(.RAL_T(rv_timer_reg_block));
   `uvm_object_utils(rv_timer_env_cfg)
   `uvm_object_new
 
-  virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1,
-                                   bit [TL_AW-1:0] csr_addr_map_size = ADDR_MAP_SIZE);
-    super.initialize(csr_base_addr, csr_addr_map_size);
+  virtual function void initialize_csr_addr_map_size();
+    this.csr_addr_map_size = RV_TIMER_ADDR_MAP_SIZE;
+  endfunction : initialize_csr_addr_map_size
+
+  virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);
+    super.initialize(csr_base_addr);
     // set num_interrupts
     num_interrupts = NUM_HARTS * NUM_TIMERS;
   endfunction

--- a/hw/ip/rv_timer/dv/env/rv_timer_env_pkg.sv
+++ b/hw/ip/rv_timer/dv/env/rv_timer_env_pkg.sv
@@ -18,7 +18,7 @@ package rv_timer_env_pkg;
 
   // local parameters and types
   // csr and mem total size for IP
-  parameter uint ADDR_MAP_SIZE = 512;
+  parameter uint RV_TIMER_ADDR_MAP_SIZE = 512;
   // TODO: these are currently hardcoded to 1 - this will need to change if design is modified
   parameter uint NUM_HARTS = 1;
   parameter uint NUM_TIMERS = 1;

--- a/hw/ip/spi_device/dv/env/spi_device_env_cfg.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env_cfg.sv
@@ -13,10 +13,13 @@ class spi_device_env_cfg extends cip_base_env_cfg #(.RAL_T(spi_device_reg_block)
 
   `uvm_object_new
 
-  virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = 0,
-                                   bit [TL_AW-1:0] csr_addr_map_size = ADDR_MAP_SIZE);
+  virtual function void initialize_csr_addr_map_size();
+    this.csr_addr_map_size = SPI_DEVICE_ADDR_MAP_SIZE;
+  endfunction : initialize_csr_addr_map_size
+
+  virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = 0);
     mem_addr_s mem_addr;
-    super.initialize(csr_base_addr, csr_addr_map_size);
+    super.initialize(csr_base_addr);
     // create spi agent config obj
     m_spi_agent_cfg = spi_agent_cfg::type_id::create("m_spi_agent_cfg");
     // set num_interrupts & num_alerts which will be used to create coverage and more

--- a/hw/ip/spi_device/dv/env/spi_device_env_pkg.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env_pkg.sv
@@ -32,13 +32,13 @@ package spi_device_env_pkg;
   } sram_avail_type_e;
 
   // csr and mem total size for IP
-  parameter uint ADDR_MAP_SIZE      = 4096;
+  parameter uint SPI_DEVICE_ADDR_MAP_SIZE = 4096;
   // SPI SRAM is 2kB
-  parameter uint SRAM_OFFSET        = 'h800;
-  parameter uint SRAM_SIZE          = 2048;
-  parameter uint SRAM_MSB           = $clog2(SRAM_SIZE) - 1;
-  parameter uint SRAM_PTR_PHASE_BIT = SRAM_MSB + 1;
-  parameter uint SRAM_WORD_SIZE     = 4;
+  parameter uint SRAM_OFFSET              = 'h800;
+  parameter uint SRAM_SIZE                = 2048;
+  parameter uint SRAM_MSB                 = $clog2(SRAM_SIZE) - 1;
+  parameter uint SRAM_PTR_PHASE_BIT       = SRAM_MSB + 1;
+  parameter uint SRAM_WORD_SIZE           = 4;
 
   string msg_id = "spi_device_env_pkg";
 

--- a/hw/ip/tlul/dv/env/xbar_env_cfg.sv
+++ b/hw/ip/tlul/dv/env/xbar_env_cfg.sv
@@ -30,8 +30,7 @@ class xbar_env_cfg extends dv_base_env_cfg;
 
   `uvm_object_new
 
-  virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1,
-                                   bit [TL_AW-1:0] csr_addr_map_size = 2048);
+  virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);
     has_ral = 0; // no csr in xbar
     // Host TL agent cfg
     num_hosts         = xbar_hosts.size();

--- a/hw/ip/uart/doc/uart_dv_plan.md
+++ b/hw/ip/uart/doc/uart_dv_plan.md
@@ -42,8 +42,8 @@ The following utilities provide generic helper tasks and functions to perform ac
 All common types and methods defined at the package level can be found in
 `uart_env_pkg`. Some of them in use are:
 ```systemverilog
-parameter uint ADDR_MAP_SIZE   = 64;
-parameter uint UART_FIFO_DEPTH = 32;
+parameter uint UART_ADDR_MAP_SIZE = 64;
+parameter uint UART_FIFO_DEPTH    = 32;
 ```
 
 ### TL_agent

--- a/hw/ip/uart/dv/env/uart_env_cfg.sv
+++ b/hw/ip/uart/dv/env/uart_env_cfg.sv
@@ -17,9 +17,12 @@ class uart_env_cfg extends cip_base_env_cfg #(.RAL_T(uart_reg_block));
 
   `uvm_object_new
 
-  virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1,
-                                   bit [TL_AW-1:0] csr_addr_map_size = ADDR_MAP_SIZE);
-    super.initialize(csr_base_addr, csr_addr_map_size);
+  virtual function void initialize_csr_addr_map_size();
+    this.csr_addr_map_size = UART_ADDR_MAP_SIZE;
+  endfunction : initialize_csr_addr_map_size
+
+  virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);
+    super.initialize(csr_base_addr);
     // create uart agent config obj
     m_uart_agent_cfg = uart_agent_cfg::type_id::create("m_uart_agent_cfg");
     // set num_interrupts & num_alerts which will be used to create coverage and more

--- a/hw/ip/uart/dv/env/uart_env_pkg.sv
+++ b/hw/ip/uart/dv/env/uart_env_pkg.sv
@@ -19,7 +19,7 @@ package uart_env_pkg;
 
   // local types
   // csr and mem total size for IP
-  parameter uint ADDR_MAP_SIZE   = 64;
+  parameter uint UART_ADDR_MAP_SIZE   = 64;
   parameter uint UART_FIFO_DEPTH = 32;
 
   typedef enum int {

--- a/util/uvmdvgen/env_cfg.sv.tpl
+++ b/util/uvmdvgen/env_cfg.sv.tpl
@@ -21,9 +21,12 @@ class ${name}_env_cfg extends dv_base_env_cfg #(.RAL_T(${name}_reg_block));
 
   `uvm_object_new
 
-  virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1,
-                                   bit [TL_AW-1:0] csr_addr_map_size = ADDR_MAP_SIZE);
-    super.initialize(csr_base_addr, csr_addr_map_size);
+  virtual function void initialize_csr_addr_map_size();
+    this.csr_addr_map_size = ${name.upper()}_ADDR_MAP_SIZE;
+  endfunction : initialize_csr_addr_map_size
+
+  virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);
+    super.initialize(csr_base_addr);
 % for agent in env_agents:
     // create ${agent} agent config obj
     m_${agent}_agent_cfg = ${agent}_agent_cfg::type_id::create("m_${agent}_agent_cfg");

--- a/util/uvmdvgen/env_pkg.sv.tpl
+++ b/util/uvmdvgen/env_pkg.sv.tpl
@@ -23,7 +23,7 @@ package ${name}_env_pkg;
 
   // parameters
   // TODO update below, or compile error occurs
-  parameter uint ADDR_MAP_SIZE   = ;
+  parameter uint ${name.upper()}_ADDR_MAP_SIZE = ;
 
   // types
 


### PR DESCRIPTION
Instead of specifying default value of argument csr_addr_map_size
in initialize method, set csr_addr_map_size using a new method
initialize_csr_addr_map_size.
This method initialize_csr_addr_map_size is empty by default in
dv_base_env_cfg, and must be overridden with csr_addr_map_size
assignment specific to IP under verification.