### PR TITLE
[rv_timer/dv] Clean up TODO and warning

### DIFF
--- a/hw/ip/rv_timer/dv/env/rv_timer_env_cov.sv
+++ b/hw/ip/rv_timer/dv/env/rv_timer_env_cov.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// TODO - We are enclosing covergroups inside class so that we can
+// We are enclosing covergroups inside class so that we can
 // take avoid tool limitation of not allowing arrays of covergroup
 // Refer to Issue#375 for more details
 // class for wrapping timer config covergroup

--- a/hw/ip/rv_timer/dv/env/rv_timer_env_pkg.sv
+++ b/hw/ip/rv_timer/dv/env/rv_timer_env_pkg.sv
@@ -19,7 +19,7 @@ package rv_timer_env_pkg;
   // local parameters and types
   // csr and mem total size for IP
   parameter uint RV_TIMER_ADDR_MAP_SIZE = 512;
-  // TODO: these are currently hardcoded to 1 - this will need to change if design is modified
+  // These are currently hardcoded to 1 - this will need to change if design is modified
   parameter uint NUM_HARTS = 1;
   parameter uint NUM_TIMERS = 1;
 

--- a/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_base_vseq.sv
+++ b/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_base_vseq.sv
@@ -38,16 +38,6 @@ class rv_timer_base_vseq extends cip_base_vseq #(
     super.pre_start();
   endtask
 
-  virtual task dut_init(string reset_kind = "HARD");
-    super.dut_init(reset_kind);
-    // TODO: nothing extra to do yet
-  endtask
-
-  virtual task dut_shutdown();
-    super.dut_shutdown();
-    // TODO: nothing extra to do yet
-  endtask
-
   // cfg rv_timer - set a particular timer active or inactive
   virtual task cfg_timer(int hart = 0, int timer = 0, bit enable = 1'b1);
     uvm_reg       ctrl_rg;

--- a/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_cfg_update_on_fly_vseq.sv
+++ b/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_cfg_update_on_fly_vseq.sv
@@ -90,8 +90,8 @@ class rv_timer_cfg_update_on_fly_vseq extends rv_timer_sanity_vseq;
             // ((1 << 64)-1) - (max_step_value*300) = 'hFFFFFFFFFFFED52B
             // min_timer_val is calculated using max random value subtracted from
             // timer_val with below randomiztion which is (max_step_value*300) = 'h12AD4
-            if ((compare_val[hart][timer] >= 'hFFFFFFFFFFFED52B) |
-                (timer_val[hart] <= 'h12AD4)) begin
+            if ((compare_val[hart][timer] >= 64'hFFFFFFFFFFFED52B) |
+                (timer_val[hart] <= 64'h12AD4)) begin
               timer_at_min_max_val = 1'b1;
               break;
             end
@@ -103,13 +103,13 @@ class rv_timer_cfg_update_on_fly_vseq extends rv_timer_sanity_vseq;
                 compare_val[hart][timer] += step[hart] * $urandom_range(30, 300);
               end
               else begin
-                compare_val[hart][timer] -= $urandom_range((mtime_diff / 20), (mtime_diff / 4));
+                compare_val[hart][timer] -= mtime_diff / ($urandom_range(4, 20));
               end
               set_compare_val(.hart(hart), .timer(timer), .val(compare_val[hart][timer]));
 
               mtime_diff = compare_val[hart][timer] - timer_val[hart];
               if (!upd_cfg_in_end | $urandom_range(0, 1)) begin
-                timer_val[hart] += $urandom_range((mtime_diff / 20), (mtime_diff / 4));
+                timer_val[hart] += mtime_diff / ($urandom_range(4, 20));
               end
               else begin
                 timer_val[hart] -= step[hart] * $urandom_range(30, 300);


### PR DESCRIPTION
1. Makefile: turned off warnings for decimal constant too large
2. rv_timer_* : Removed TODO