### PR TITLE
[dv] reggen fixes for dv 

### DIFF
--- a/hw/ip/alert_handler/dv/env/alert_handler_reg_block.sv
+++ b/hw/ip/alert_handler/dv/env/alert_handler_reg_block.sv
@@ -93,7 +93,7 @@ class alert_handler_reg_intr_state extends dv_base_reg;
       .lsb_pos(0),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -104,7 +104,7 @@ class alert_handler_reg_intr_state extends dv_base_reg;
       .lsb_pos(1),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -115,7 +115,7 @@ class alert_handler_reg_intr_state extends dv_base_reg;
       .lsb_pos(2),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -126,7 +126,7 @@ class alert_handler_reg_intr_state extends dv_base_reg;
       .lsb_pos(3),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -159,7 +159,7 @@ class alert_handler_reg_intr_enable extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -170,7 +170,7 @@ class alert_handler_reg_intr_enable extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -181,7 +181,7 @@ class alert_handler_reg_intr_enable extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -192,7 +192,7 @@ class alert_handler_reg_intr_enable extends dv_base_reg;
       .lsb_pos(3),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -225,7 +225,7 @@ class alert_handler_reg_intr_test extends dv_base_reg;
       .lsb_pos(0),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -236,7 +236,7 @@ class alert_handler_reg_intr_test extends dv_base_reg;
       .lsb_pos(1),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -247,7 +247,7 @@ class alert_handler_reg_intr_test extends dv_base_reg;
       .lsb_pos(2),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -258,7 +258,7 @@ class alert_handler_reg_intr_test extends dv_base_reg;
       .lsb_pos(3),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -288,7 +288,7 @@ class alert_handler_reg_regen extends dv_base_reg;
       .lsb_pos(0),
       .access("W1C"),
       .volatile(0),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -318,7 +318,7 @@ class alert_handler_reg_ping_timeout_cyc extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(32),
+      .reset(32'h20),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -351,7 +351,7 @@ class alert_handler_reg_alert_en extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -362,7 +362,7 @@ class alert_handler_reg_alert_en extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -373,7 +373,7 @@ class alert_handler_reg_alert_en extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -384,7 +384,7 @@ class alert_handler_reg_alert_en extends dv_base_reg;
       .lsb_pos(3),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -417,7 +417,7 @@ class alert_handler_reg_alert_class extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -428,7 +428,7 @@ class alert_handler_reg_alert_class extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -439,7 +439,7 @@ class alert_handler_reg_alert_class extends dv_base_reg;
       .lsb_pos(4),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -450,7 +450,7 @@ class alert_handler_reg_alert_class extends dv_base_reg;
       .lsb_pos(6),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -483,7 +483,7 @@ class alert_handler_reg_alert_cause extends dv_base_reg;
       .lsb_pos(0),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -494,7 +494,7 @@ class alert_handler_reg_alert_cause extends dv_base_reg;
       .lsb_pos(1),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -505,7 +505,7 @@ class alert_handler_reg_alert_cause extends dv_base_reg;
       .lsb_pos(2),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -516,7 +516,7 @@ class alert_handler_reg_alert_cause extends dv_base_reg;
       .lsb_pos(3),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -549,7 +549,7 @@ class alert_handler_reg_loc_alert_en extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -560,7 +560,7 @@ class alert_handler_reg_loc_alert_en extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -571,7 +571,7 @@ class alert_handler_reg_loc_alert_en extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -582,7 +582,7 @@ class alert_handler_reg_loc_alert_en extends dv_base_reg;
       .lsb_pos(3),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -615,7 +615,7 @@ class alert_handler_reg_loc_alert_class extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -626,7 +626,7 @@ class alert_handler_reg_loc_alert_class extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -637,7 +637,7 @@ class alert_handler_reg_loc_alert_class extends dv_base_reg;
       .lsb_pos(4),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -648,7 +648,7 @@ class alert_handler_reg_loc_alert_class extends dv_base_reg;
       .lsb_pos(6),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -681,7 +681,7 @@ class alert_handler_reg_loc_alert_cause extends dv_base_reg;
       .lsb_pos(0),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -692,7 +692,7 @@ class alert_handler_reg_loc_alert_cause extends dv_base_reg;
       .lsb_pos(1),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -703,7 +703,7 @@ class alert_handler_reg_loc_alert_cause extends dv_base_reg;
       .lsb_pos(2),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -714,7 +714,7 @@ class alert_handler_reg_loc_alert_cause extends dv_base_reg;
       .lsb_pos(3),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -753,7 +753,7 @@ class alert_handler_reg_classa_ctrl extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -764,7 +764,7 @@ class alert_handler_reg_classa_ctrl extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -775,7 +775,7 @@ class alert_handler_reg_classa_ctrl extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -786,7 +786,7 @@ class alert_handler_reg_classa_ctrl extends dv_base_reg;
       .lsb_pos(3),
       .access("RW"),
       .volatile(0),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -797,7 +797,7 @@ class alert_handler_reg_classa_ctrl extends dv_base_reg;
       .lsb_pos(4),
       .access("RW"),
       .volatile(0),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -808,7 +808,7 @@ class alert_handler_reg_classa_ctrl extends dv_base_reg;
       .lsb_pos(5),
       .access("RW"),
       .volatile(0),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -819,7 +819,7 @@ class alert_handler_reg_classa_ctrl extends dv_base_reg;
       .lsb_pos(6),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -830,7 +830,7 @@ class alert_handler_reg_classa_ctrl extends dv_base_reg;
       .lsb_pos(8),
       .access("RW"),
       .volatile(0),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -841,7 +841,7 @@ class alert_handler_reg_classa_ctrl extends dv_base_reg;
       .lsb_pos(10),
       .access("RW"),
       .volatile(0),
-      .reset(2),
+      .reset(32'h2),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -852,7 +852,7 @@ class alert_handler_reg_classa_ctrl extends dv_base_reg;
       .lsb_pos(12),
       .access("RW"),
       .volatile(0),
-      .reset(3),
+      .reset(32'h3),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -882,7 +882,7 @@ class alert_handler_reg_classa_clren extends dv_base_reg;
       .lsb_pos(0),
       .access("W1C"),
       .volatile(1),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -912,7 +912,7 @@ class alert_handler_reg_classa_clr extends dv_base_reg;
       .lsb_pos(0),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -942,7 +942,7 @@ class alert_handler_reg_classa_accum_cnt extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -972,7 +972,7 @@ class alert_handler_reg_classa_accum_thresh extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1002,7 +1002,7 @@ class alert_handler_reg_classa_timeout_cyc extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1032,7 +1032,7 @@ class alert_handler_reg_classa_phase0_cyc extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1062,7 +1062,7 @@ class alert_handler_reg_classa_phase1_cyc extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1092,7 +1092,7 @@ class alert_handler_reg_classa_phase2_cyc extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1122,7 +1122,7 @@ class alert_handler_reg_classa_phase3_cyc extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1152,7 +1152,7 @@ class alert_handler_reg_classa_esc_cnt extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1182,7 +1182,7 @@ class alert_handler_reg_classa_state extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1221,7 +1221,7 @@ class alert_handler_reg_classb_ctrl extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1232,7 +1232,7 @@ class alert_handler_reg_classb_ctrl extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1243,7 +1243,7 @@ class alert_handler_reg_classb_ctrl extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1254,7 +1254,7 @@ class alert_handler_reg_classb_ctrl extends dv_base_reg;
       .lsb_pos(3),
       .access("RW"),
       .volatile(0),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1265,7 +1265,7 @@ class alert_handler_reg_classb_ctrl extends dv_base_reg;
       .lsb_pos(4),
       .access("RW"),
       .volatile(0),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1276,7 +1276,7 @@ class alert_handler_reg_classb_ctrl extends dv_base_reg;
       .lsb_pos(5),
       .access("RW"),
       .volatile(0),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1287,7 +1287,7 @@ class alert_handler_reg_classb_ctrl extends dv_base_reg;
       .lsb_pos(6),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1298,7 +1298,7 @@ class alert_handler_reg_classb_ctrl extends dv_base_reg;
       .lsb_pos(8),
       .access("RW"),
       .volatile(0),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1309,7 +1309,7 @@ class alert_handler_reg_classb_ctrl extends dv_base_reg;
       .lsb_pos(10),
       .access("RW"),
       .volatile(0),
-      .reset(2),
+      .reset(32'h2),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1320,7 +1320,7 @@ class alert_handler_reg_classb_ctrl extends dv_base_reg;
       .lsb_pos(12),
       .access("RW"),
       .volatile(0),
-      .reset(3),
+      .reset(32'h3),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1350,7 +1350,7 @@ class alert_handler_reg_classb_clren extends dv_base_reg;
       .lsb_pos(0),
       .access("W1C"),
       .volatile(1),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1380,7 +1380,7 @@ class alert_handler_reg_classb_clr extends dv_base_reg;
       .lsb_pos(0),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1410,7 +1410,7 @@ class alert_handler_reg_classb_accum_cnt extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1440,7 +1440,7 @@ class alert_handler_reg_classb_accum_thresh extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1470,7 +1470,7 @@ class alert_handler_reg_classb_timeout_cyc extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1500,7 +1500,7 @@ class alert_handler_reg_classb_phase0_cyc extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1530,7 +1530,7 @@ class alert_handler_reg_classb_phase1_cyc extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1560,7 +1560,7 @@ class alert_handler_reg_classb_phase2_cyc extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1590,7 +1590,7 @@ class alert_handler_reg_classb_phase3_cyc extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1620,7 +1620,7 @@ class alert_handler_reg_classb_esc_cnt extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1650,7 +1650,7 @@ class alert_handler_reg_classb_state extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1689,7 +1689,7 @@ class alert_handler_reg_classc_ctrl extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1700,7 +1700,7 @@ class alert_handler_reg_classc_ctrl extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1711,7 +1711,7 @@ class alert_handler_reg_classc_ctrl extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1722,7 +1722,7 @@ class alert_handler_reg_classc_ctrl extends dv_base_reg;
       .lsb_pos(3),
       .access("RW"),
       .volatile(0),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1733,7 +1733,7 @@ class alert_handler_reg_classc_ctrl extends dv_base_reg;
       .lsb_pos(4),
       .access("RW"),
       .volatile(0),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1744,7 +1744,7 @@ class alert_handler_reg_classc_ctrl extends dv_base_reg;
       .lsb_pos(5),
       .access("RW"),
       .volatile(0),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1755,7 +1755,7 @@ class alert_handler_reg_classc_ctrl extends dv_base_reg;
       .lsb_pos(6),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1766,7 +1766,7 @@ class alert_handler_reg_classc_ctrl extends dv_base_reg;
       .lsb_pos(8),
       .access("RW"),
       .volatile(0),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1777,7 +1777,7 @@ class alert_handler_reg_classc_ctrl extends dv_base_reg;
       .lsb_pos(10),
       .access("RW"),
       .volatile(0),
-      .reset(2),
+      .reset(32'h2),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1788,7 +1788,7 @@ class alert_handler_reg_classc_ctrl extends dv_base_reg;
       .lsb_pos(12),
       .access("RW"),
       .volatile(0),
-      .reset(3),
+      .reset(32'h3),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1818,7 +1818,7 @@ class alert_handler_reg_classc_clren extends dv_base_reg;
       .lsb_pos(0),
       .access("W1C"),
       .volatile(1),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1848,7 +1848,7 @@ class alert_handler_reg_classc_clr extends dv_base_reg;
       .lsb_pos(0),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1878,7 +1878,7 @@ class alert_handler_reg_classc_accum_cnt extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1908,7 +1908,7 @@ class alert_handler_reg_classc_accum_thresh extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1938,7 +1938,7 @@ class alert_handler_reg_classc_timeout_cyc extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1968,7 +1968,7 @@ class alert_handler_reg_classc_phase0_cyc extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1998,7 +1998,7 @@ class alert_handler_reg_classc_phase1_cyc extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2028,7 +2028,7 @@ class alert_handler_reg_classc_phase2_cyc extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2058,7 +2058,7 @@ class alert_handler_reg_classc_phase3_cyc extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2088,7 +2088,7 @@ class alert_handler_reg_classc_esc_cnt extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2118,7 +2118,7 @@ class alert_handler_reg_classc_state extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2157,7 +2157,7 @@ class alert_handler_reg_classd_ctrl extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2168,7 +2168,7 @@ class alert_handler_reg_classd_ctrl extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2179,7 +2179,7 @@ class alert_handler_reg_classd_ctrl extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2190,7 +2190,7 @@ class alert_handler_reg_classd_ctrl extends dv_base_reg;
       .lsb_pos(3),
       .access("RW"),
       .volatile(0),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2201,7 +2201,7 @@ class alert_handler_reg_classd_ctrl extends dv_base_reg;
       .lsb_pos(4),
       .access("RW"),
       .volatile(0),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2212,7 +2212,7 @@ class alert_handler_reg_classd_ctrl extends dv_base_reg;
       .lsb_pos(5),
       .access("RW"),
       .volatile(0),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2223,7 +2223,7 @@ class alert_handler_reg_classd_ctrl extends dv_base_reg;
       .lsb_pos(6),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2234,7 +2234,7 @@ class alert_handler_reg_classd_ctrl extends dv_base_reg;
       .lsb_pos(8),
       .access("RW"),
       .volatile(0),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2245,7 +2245,7 @@ class alert_handler_reg_classd_ctrl extends dv_base_reg;
       .lsb_pos(10),
       .access("RW"),
       .volatile(0),
-      .reset(2),
+      .reset(32'h2),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2256,7 +2256,7 @@ class alert_handler_reg_classd_ctrl extends dv_base_reg;
       .lsb_pos(12),
       .access("RW"),
       .volatile(0),
-      .reset(3),
+      .reset(32'h3),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2286,7 +2286,7 @@ class alert_handler_reg_classd_clren extends dv_base_reg;
       .lsb_pos(0),
       .access("W1C"),
       .volatile(1),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2316,7 +2316,7 @@ class alert_handler_reg_classd_clr extends dv_base_reg;
       .lsb_pos(0),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2346,7 +2346,7 @@ class alert_handler_reg_classd_accum_cnt extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2376,7 +2376,7 @@ class alert_handler_reg_classd_accum_thresh extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2406,7 +2406,7 @@ class alert_handler_reg_classd_timeout_cyc extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2436,7 +2436,7 @@ class alert_handler_reg_classd_phase0_cyc extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2466,7 +2466,7 @@ class alert_handler_reg_classd_phase1_cyc extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2496,7 +2496,7 @@ class alert_handler_reg_classd_phase2_cyc extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2526,7 +2526,7 @@ class alert_handler_reg_classd_phase3_cyc extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2556,7 +2556,7 @@ class alert_handler_reg_classd_esc_cnt extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2586,7 +2586,7 @@ class alert_handler_reg_classd_state extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_reg_block.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_reg_block.sv
@@ -59,7 +59,7 @@ class flash_ctrl_reg_intr_state extends dv_base_reg;
       .lsb_pos(0),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -70,7 +70,7 @@ class flash_ctrl_reg_intr_state extends dv_base_reg;
       .lsb_pos(1),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -81,7 +81,7 @@ class flash_ctrl_reg_intr_state extends dv_base_reg;
       .lsb_pos(2),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -92,7 +92,7 @@ class flash_ctrl_reg_intr_state extends dv_base_reg;
       .lsb_pos(3),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -103,7 +103,7 @@ class flash_ctrl_reg_intr_state extends dv_base_reg;
       .lsb_pos(4),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -114,7 +114,7 @@ class flash_ctrl_reg_intr_state extends dv_base_reg;
       .lsb_pos(5),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -149,7 +149,7 @@ class flash_ctrl_reg_intr_enable extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -160,7 +160,7 @@ class flash_ctrl_reg_intr_enable extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -171,7 +171,7 @@ class flash_ctrl_reg_intr_enable extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -182,7 +182,7 @@ class flash_ctrl_reg_intr_enable extends dv_base_reg;
       .lsb_pos(3),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -193,7 +193,7 @@ class flash_ctrl_reg_intr_enable extends dv_base_reg;
       .lsb_pos(4),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -204,7 +204,7 @@ class flash_ctrl_reg_intr_enable extends dv_base_reg;
       .lsb_pos(5),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -239,7 +239,7 @@ class flash_ctrl_reg_intr_test extends dv_base_reg;
       .lsb_pos(0),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -250,7 +250,7 @@ class flash_ctrl_reg_intr_test extends dv_base_reg;
       .lsb_pos(1),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -261,7 +261,7 @@ class flash_ctrl_reg_intr_test extends dv_base_reg;
       .lsb_pos(2),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -272,7 +272,7 @@ class flash_ctrl_reg_intr_test extends dv_base_reg;
       .lsb_pos(3),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -283,7 +283,7 @@ class flash_ctrl_reg_intr_test extends dv_base_reg;
       .lsb_pos(4),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -294,7 +294,7 @@ class flash_ctrl_reg_intr_test extends dv_base_reg;
       .lsb_pos(5),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -328,7 +328,7 @@ class flash_ctrl_reg_control extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -339,7 +339,7 @@ class flash_ctrl_reg_control extends dv_base_reg;
       .lsb_pos(4),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -350,7 +350,7 @@ class flash_ctrl_reg_control extends dv_base_reg;
       .lsb_pos(6),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -361,7 +361,7 @@ class flash_ctrl_reg_control extends dv_base_reg;
       .lsb_pos(7),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -372,7 +372,7 @@ class flash_ctrl_reg_control extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -402,7 +402,7 @@ class flash_ctrl_reg_addr extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -439,7 +439,7 @@ class flash_ctrl_reg_region_cfg_regwen extends dv_base_reg;
       .lsb_pos(0),
       .access("W0C"),
       .volatile(1),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -450,7 +450,7 @@ class flash_ctrl_reg_region_cfg_regwen extends dv_base_reg;
       .lsb_pos(1),
       .access("W0C"),
       .volatile(1),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -461,7 +461,7 @@ class flash_ctrl_reg_region_cfg_regwen extends dv_base_reg;
       .lsb_pos(2),
       .access("W0C"),
       .volatile(1),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -472,7 +472,7 @@ class flash_ctrl_reg_region_cfg_regwen extends dv_base_reg;
       .lsb_pos(3),
       .access("W0C"),
       .volatile(1),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -483,7 +483,7 @@ class flash_ctrl_reg_region_cfg_regwen extends dv_base_reg;
       .lsb_pos(4),
       .access("W0C"),
       .volatile(1),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -494,7 +494,7 @@ class flash_ctrl_reg_region_cfg_regwen extends dv_base_reg;
       .lsb_pos(5),
       .access("W0C"),
       .volatile(1),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -505,7 +505,7 @@ class flash_ctrl_reg_region_cfg_regwen extends dv_base_reg;
       .lsb_pos(6),
       .access("W0C"),
       .volatile(1),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -516,7 +516,7 @@ class flash_ctrl_reg_region_cfg_regwen extends dv_base_reg;
       .lsb_pos(7),
       .access("W0C"),
       .volatile(1),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -551,7 +551,7 @@ class flash_ctrl_reg_mp_region_cfg0 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -562,7 +562,7 @@ class flash_ctrl_reg_mp_region_cfg0 extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -573,7 +573,7 @@ class flash_ctrl_reg_mp_region_cfg0 extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -584,7 +584,7 @@ class flash_ctrl_reg_mp_region_cfg0 extends dv_base_reg;
       .lsb_pos(3),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -595,7 +595,7 @@ class flash_ctrl_reg_mp_region_cfg0 extends dv_base_reg;
       .lsb_pos(4),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -606,7 +606,7 @@ class flash_ctrl_reg_mp_region_cfg0 extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -641,7 +641,7 @@ class flash_ctrl_reg_mp_region_cfg1 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -652,7 +652,7 @@ class flash_ctrl_reg_mp_region_cfg1 extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -663,7 +663,7 @@ class flash_ctrl_reg_mp_region_cfg1 extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -674,7 +674,7 @@ class flash_ctrl_reg_mp_region_cfg1 extends dv_base_reg;
       .lsb_pos(3),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -685,7 +685,7 @@ class flash_ctrl_reg_mp_region_cfg1 extends dv_base_reg;
       .lsb_pos(4),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -696,7 +696,7 @@ class flash_ctrl_reg_mp_region_cfg1 extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -731,7 +731,7 @@ class flash_ctrl_reg_mp_region_cfg2 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -742,7 +742,7 @@ class flash_ctrl_reg_mp_region_cfg2 extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -753,7 +753,7 @@ class flash_ctrl_reg_mp_region_cfg2 extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -764,7 +764,7 @@ class flash_ctrl_reg_mp_region_cfg2 extends dv_base_reg;
       .lsb_pos(3),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -775,7 +775,7 @@ class flash_ctrl_reg_mp_region_cfg2 extends dv_base_reg;
       .lsb_pos(4),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -786,7 +786,7 @@ class flash_ctrl_reg_mp_region_cfg2 extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -821,7 +821,7 @@ class flash_ctrl_reg_mp_region_cfg3 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -832,7 +832,7 @@ class flash_ctrl_reg_mp_region_cfg3 extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -843,7 +843,7 @@ class flash_ctrl_reg_mp_region_cfg3 extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -854,7 +854,7 @@ class flash_ctrl_reg_mp_region_cfg3 extends dv_base_reg;
       .lsb_pos(3),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -865,7 +865,7 @@ class flash_ctrl_reg_mp_region_cfg3 extends dv_base_reg;
       .lsb_pos(4),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -876,7 +876,7 @@ class flash_ctrl_reg_mp_region_cfg3 extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -911,7 +911,7 @@ class flash_ctrl_reg_mp_region_cfg4 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -922,7 +922,7 @@ class flash_ctrl_reg_mp_region_cfg4 extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -933,7 +933,7 @@ class flash_ctrl_reg_mp_region_cfg4 extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -944,7 +944,7 @@ class flash_ctrl_reg_mp_region_cfg4 extends dv_base_reg;
       .lsb_pos(3),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -955,7 +955,7 @@ class flash_ctrl_reg_mp_region_cfg4 extends dv_base_reg;
       .lsb_pos(4),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -966,7 +966,7 @@ class flash_ctrl_reg_mp_region_cfg4 extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1001,7 +1001,7 @@ class flash_ctrl_reg_mp_region_cfg5 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1012,7 +1012,7 @@ class flash_ctrl_reg_mp_region_cfg5 extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1023,7 +1023,7 @@ class flash_ctrl_reg_mp_region_cfg5 extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1034,7 +1034,7 @@ class flash_ctrl_reg_mp_region_cfg5 extends dv_base_reg;
       .lsb_pos(3),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1045,7 +1045,7 @@ class flash_ctrl_reg_mp_region_cfg5 extends dv_base_reg;
       .lsb_pos(4),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1056,7 +1056,7 @@ class flash_ctrl_reg_mp_region_cfg5 extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1091,7 +1091,7 @@ class flash_ctrl_reg_mp_region_cfg6 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1102,7 +1102,7 @@ class flash_ctrl_reg_mp_region_cfg6 extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1113,7 +1113,7 @@ class flash_ctrl_reg_mp_region_cfg6 extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1124,7 +1124,7 @@ class flash_ctrl_reg_mp_region_cfg6 extends dv_base_reg;
       .lsb_pos(3),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1135,7 +1135,7 @@ class flash_ctrl_reg_mp_region_cfg6 extends dv_base_reg;
       .lsb_pos(4),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1146,7 +1146,7 @@ class flash_ctrl_reg_mp_region_cfg6 extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1181,7 +1181,7 @@ class flash_ctrl_reg_mp_region_cfg7 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1192,7 +1192,7 @@ class flash_ctrl_reg_mp_region_cfg7 extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1203,7 +1203,7 @@ class flash_ctrl_reg_mp_region_cfg7 extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1214,7 +1214,7 @@ class flash_ctrl_reg_mp_region_cfg7 extends dv_base_reg;
       .lsb_pos(3),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1225,7 +1225,7 @@ class flash_ctrl_reg_mp_region_cfg7 extends dv_base_reg;
       .lsb_pos(4),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1236,7 +1236,7 @@ class flash_ctrl_reg_mp_region_cfg7 extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1268,7 +1268,7 @@ class flash_ctrl_reg_default_region extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1279,7 +1279,7 @@ class flash_ctrl_reg_default_region extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1290,7 +1290,7 @@ class flash_ctrl_reg_default_region extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1320,7 +1320,7 @@ class flash_ctrl_reg_bank_cfg_regwen extends dv_base_reg;
       .lsb_pos(0),
       .access("W0C"),
       .volatile(1),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1351,7 +1351,7 @@ class flash_ctrl_reg_mp_bank_cfg extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1362,7 +1362,7 @@ class flash_ctrl_reg_mp_bank_cfg extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1393,7 +1393,7 @@ class flash_ctrl_reg_op_status extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1404,7 +1404,7 @@ class flash_ctrl_reg_op_status extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1440,7 +1440,7 @@ class flash_ctrl_reg_status extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1451,7 +1451,7 @@ class flash_ctrl_reg_status extends dv_base_reg;
       .lsb_pos(1),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1462,7 +1462,7 @@ class flash_ctrl_reg_status extends dv_base_reg;
       .lsb_pos(2),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1473,7 +1473,7 @@ class flash_ctrl_reg_status extends dv_base_reg;
       .lsb_pos(3),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1484,7 +1484,7 @@ class flash_ctrl_reg_status extends dv_base_reg;
       .lsb_pos(4),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1495,7 +1495,7 @@ class flash_ctrl_reg_status extends dv_base_reg;
       .lsb_pos(8),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1506,7 +1506,7 @@ class flash_ctrl_reg_status extends dv_base_reg;
       .lsb_pos(17),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1536,7 +1536,7 @@ class flash_ctrl_reg_scratch extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1567,7 +1567,7 @@ class flash_ctrl_reg_fifo_lvl extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(15),
+      .reset(32'hf),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1578,7 +1578,7 @@ class flash_ctrl_reg_fifo_lvl extends dv_base_reg;
       .lsb_pos(8),
       .access("RW"),
       .volatile(0),
-      .reset(15),
+      .reset(32'hf),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));

--- a/hw/ip/gpio/dv/env/gpio_reg_block.sv
+++ b/hw/ip/gpio/dv/env/gpio_reg_block.sv
@@ -46,7 +46,7 @@ class gpio_reg_intr_state extends dv_base_reg;
       .lsb_pos(0),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -76,7 +76,7 @@ class gpio_reg_intr_enable extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -106,7 +106,7 @@ class gpio_reg_intr_test extends dv_base_reg;
       .lsb_pos(0),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -136,7 +136,7 @@ class gpio_reg_data_in extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -166,7 +166,7 @@ class gpio_reg_direct_out extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -197,7 +197,7 @@ class gpio_reg_masked_out_lower extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -208,7 +208,7 @@ class gpio_reg_masked_out_lower extends dv_base_reg;
       .lsb_pos(16),
       .access("WO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -239,7 +239,7 @@ class gpio_reg_masked_out_upper extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -250,7 +250,7 @@ class gpio_reg_masked_out_upper extends dv_base_reg;
       .lsb_pos(16),
       .access("WO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -280,7 +280,7 @@ class gpio_reg_direct_oe extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -311,7 +311,7 @@ class gpio_reg_masked_oe_lower extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -322,7 +322,7 @@ class gpio_reg_masked_oe_lower extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -353,7 +353,7 @@ class gpio_reg_masked_oe_upper extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -364,7 +364,7 @@ class gpio_reg_masked_oe_upper extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -394,7 +394,7 @@ class gpio_reg_intr_ctrl_en_rising extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -424,7 +424,7 @@ class gpio_reg_intr_ctrl_en_falling extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -454,7 +454,7 @@ class gpio_reg_intr_ctrl_en_lvlhigh extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -484,7 +484,7 @@ class gpio_reg_intr_ctrl_en_lvllow extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -514,7 +514,7 @@ class gpio_reg_ctrl_en_input_filter extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));

--- a/hw/ip/hmac/dv/env/hmac_reg_block.sv
+++ b/hw/ip/hmac/dv/env/hmac_reg_block.sv
@@ -60,7 +60,7 @@ class hmac_reg_intr_state extends dv_base_reg;
       .lsb_pos(0),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -71,7 +71,7 @@ class hmac_reg_intr_state extends dv_base_reg;
       .lsb_pos(1),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -82,7 +82,7 @@ class hmac_reg_intr_state extends dv_base_reg;
       .lsb_pos(2),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -114,7 +114,7 @@ class hmac_reg_intr_enable extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -125,7 +125,7 @@ class hmac_reg_intr_enable extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -136,7 +136,7 @@ class hmac_reg_intr_enable extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -168,7 +168,7 @@ class hmac_reg_intr_test extends dv_base_reg;
       .lsb_pos(0),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -179,7 +179,7 @@ class hmac_reg_intr_test extends dv_base_reg;
       .lsb_pos(1),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -190,7 +190,7 @@ class hmac_reg_intr_test extends dv_base_reg;
       .lsb_pos(2),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -223,7 +223,7 @@ class hmac_reg_cfg extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -234,7 +234,7 @@ class hmac_reg_cfg extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -245,7 +245,7 @@ class hmac_reg_cfg extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -256,7 +256,7 @@ class hmac_reg_cfg extends dv_base_reg;
       .lsb_pos(3),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -287,7 +287,7 @@ class hmac_reg_cmd extends dv_base_reg;
       .lsb_pos(0),
       .access("W1C"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -298,7 +298,7 @@ class hmac_reg_cmd extends dv_base_reg;
       .lsb_pos(1),
       .access("W1C"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -330,7 +330,7 @@ class hmac_reg_status extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -341,7 +341,7 @@ class hmac_reg_status extends dv_base_reg;
       .lsb_pos(1),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -352,7 +352,7 @@ class hmac_reg_status extends dv_base_reg;
       .lsb_pos(4),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -382,7 +382,7 @@ class hmac_reg_err_code extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -412,7 +412,7 @@ class hmac_reg_wipe_secret extends dv_base_reg;
       .lsb_pos(0),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -442,7 +442,7 @@ class hmac_reg_key0 extends dv_base_reg;
       .lsb_pos(0),
       .access("WO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -472,7 +472,7 @@ class hmac_reg_key1 extends dv_base_reg;
       .lsb_pos(0),
       .access("WO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -502,7 +502,7 @@ class hmac_reg_key2 extends dv_base_reg;
       .lsb_pos(0),
       .access("WO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -532,7 +532,7 @@ class hmac_reg_key3 extends dv_base_reg;
       .lsb_pos(0),
       .access("WO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -562,7 +562,7 @@ class hmac_reg_key4 extends dv_base_reg;
       .lsb_pos(0),
       .access("WO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -592,7 +592,7 @@ class hmac_reg_key5 extends dv_base_reg;
       .lsb_pos(0),
       .access("WO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -622,7 +622,7 @@ class hmac_reg_key6 extends dv_base_reg;
       .lsb_pos(0),
       .access("WO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -652,7 +652,7 @@ class hmac_reg_key7 extends dv_base_reg;
       .lsb_pos(0),
       .access("WO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -682,7 +682,7 @@ class hmac_reg_digest0 extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -712,7 +712,7 @@ class hmac_reg_digest1 extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -742,7 +742,7 @@ class hmac_reg_digest2 extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -772,7 +772,7 @@ class hmac_reg_digest3 extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -802,7 +802,7 @@ class hmac_reg_digest4 extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -832,7 +832,7 @@ class hmac_reg_digest5 extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -862,7 +862,7 @@ class hmac_reg_digest6 extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -892,7 +892,7 @@ class hmac_reg_digest7 extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -922,7 +922,7 @@ class hmac_reg_msg_length_lower extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -952,7 +952,7 @@ class hmac_reg_msg_length_upper extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));

--- a/hw/ip/padctrl/dv/env/padctrl_reg_block.sv
+++ b/hw/ip/padctrl/dv/env/padctrl_reg_block.sv
@@ -37,7 +37,7 @@ class padctrl_reg_regen extends dv_base_reg;
       .lsb_pos(0),
       .access("W0C"),
       .volatile(1),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -70,7 +70,7 @@ class padctrl_reg_dio_pads extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -81,7 +81,7 @@ class padctrl_reg_dio_pads extends dv_base_reg;
       .lsb_pos(8),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -92,7 +92,7 @@ class padctrl_reg_dio_pads extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -103,7 +103,7 @@ class padctrl_reg_dio_pads extends dv_base_reg;
       .lsb_pos(24),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -136,7 +136,7 @@ class padctrl_reg_mio_pads0 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -147,7 +147,7 @@ class padctrl_reg_mio_pads0 extends dv_base_reg;
       .lsb_pos(8),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -158,7 +158,7 @@ class padctrl_reg_mio_pads0 extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -169,7 +169,7 @@ class padctrl_reg_mio_pads0 extends dv_base_reg;
       .lsb_pos(24),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -202,7 +202,7 @@ class padctrl_reg_mio_pads1 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -213,7 +213,7 @@ class padctrl_reg_mio_pads1 extends dv_base_reg;
       .lsb_pos(8),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -224,7 +224,7 @@ class padctrl_reg_mio_pads1 extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -235,7 +235,7 @@ class padctrl_reg_mio_pads1 extends dv_base_reg;
       .lsb_pos(24),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -268,7 +268,7 @@ class padctrl_reg_mio_pads2 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -279,7 +279,7 @@ class padctrl_reg_mio_pads2 extends dv_base_reg;
       .lsb_pos(8),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -290,7 +290,7 @@ class padctrl_reg_mio_pads2 extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -301,7 +301,7 @@ class padctrl_reg_mio_pads2 extends dv_base_reg;
       .lsb_pos(24),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -334,7 +334,7 @@ class padctrl_reg_mio_pads3 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -345,7 +345,7 @@ class padctrl_reg_mio_pads3 extends dv_base_reg;
       .lsb_pos(8),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -356,7 +356,7 @@ class padctrl_reg_mio_pads3 extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -367,7 +367,7 @@ class padctrl_reg_mio_pads3 extends dv_base_reg;
       .lsb_pos(24),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));

--- a/hw/ip/pinmux/dv/env/pinmux_reg_block.sv
+++ b/hw/ip/pinmux/dv/env/pinmux_reg_block.sv
@@ -36,7 +36,7 @@ class pinmux_reg_regen extends dv_base_reg;
       .lsb_pos(0),
       .access("W0C"),
       .volatile(1),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -73,7 +73,7 @@ class pinmux_reg_periph_insel0 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -84,7 +84,7 @@ class pinmux_reg_periph_insel0 extends dv_base_reg;
       .lsb_pos(4),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -95,7 +95,7 @@ class pinmux_reg_periph_insel0 extends dv_base_reg;
       .lsb_pos(8),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -106,7 +106,7 @@ class pinmux_reg_periph_insel0 extends dv_base_reg;
       .lsb_pos(12),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -117,7 +117,7 @@ class pinmux_reg_periph_insel0 extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -128,7 +128,7 @@ class pinmux_reg_periph_insel0 extends dv_base_reg;
       .lsb_pos(20),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -139,7 +139,7 @@ class pinmux_reg_periph_insel0 extends dv_base_reg;
       .lsb_pos(24),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -150,7 +150,7 @@ class pinmux_reg_periph_insel0 extends dv_base_reg;
       .lsb_pos(28),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -187,7 +187,7 @@ class pinmux_reg_periph_insel1 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -198,7 +198,7 @@ class pinmux_reg_periph_insel1 extends dv_base_reg;
       .lsb_pos(4),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -209,7 +209,7 @@ class pinmux_reg_periph_insel1 extends dv_base_reg;
       .lsb_pos(8),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -220,7 +220,7 @@ class pinmux_reg_periph_insel1 extends dv_base_reg;
       .lsb_pos(12),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -231,7 +231,7 @@ class pinmux_reg_periph_insel1 extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -242,7 +242,7 @@ class pinmux_reg_periph_insel1 extends dv_base_reg;
       .lsb_pos(20),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -253,7 +253,7 @@ class pinmux_reg_periph_insel1 extends dv_base_reg;
       .lsb_pos(24),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -264,7 +264,7 @@ class pinmux_reg_periph_insel1 extends dv_base_reg;
       .lsb_pos(28),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -299,7 +299,7 @@ class pinmux_reg_mio_outsel0 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(2),
+      .reset(32'h2),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -310,7 +310,7 @@ class pinmux_reg_mio_outsel0 extends dv_base_reg;
       .lsb_pos(5),
       .access("RW"),
       .volatile(0),
-      .reset(2),
+      .reset(32'h2),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -321,7 +321,7 @@ class pinmux_reg_mio_outsel0 extends dv_base_reg;
       .lsb_pos(10),
       .access("RW"),
       .volatile(0),
-      .reset(2),
+      .reset(32'h2),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -332,7 +332,7 @@ class pinmux_reg_mio_outsel0 extends dv_base_reg;
       .lsb_pos(15),
       .access("RW"),
       .volatile(0),
-      .reset(2),
+      .reset(32'h2),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -343,7 +343,7 @@ class pinmux_reg_mio_outsel0 extends dv_base_reg;
       .lsb_pos(20),
       .access("RW"),
       .volatile(0),
-      .reset(2),
+      .reset(32'h2),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -354,7 +354,7 @@ class pinmux_reg_mio_outsel0 extends dv_base_reg;
       .lsb_pos(25),
       .access("RW"),
       .volatile(0),
-      .reset(2),
+      .reset(32'h2),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -385,7 +385,7 @@ class pinmux_reg_mio_outsel1 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(2),
+      .reset(32'h2),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -396,7 +396,7 @@ class pinmux_reg_mio_outsel1 extends dv_base_reg;
       .lsb_pos(5),
       .access("RW"),
       .volatile(0),
-      .reset(2),
+      .reset(32'h2),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));

--- a/hw/ip/rv_plic/dv/env/rv_plic_reg_block.sv
+++ b/hw/ip/rv_plic/dv/env/rv_plic_reg_block.sv
@@ -100,7 +100,7 @@ class rv_plic_reg_ip extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -111,7 +111,7 @@ class rv_plic_reg_ip extends dv_base_reg;
       .lsb_pos(1),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -122,7 +122,7 @@ class rv_plic_reg_ip extends dv_base_reg;
       .lsb_pos(2),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -133,7 +133,7 @@ class rv_plic_reg_ip extends dv_base_reg;
       .lsb_pos(3),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -144,7 +144,7 @@ class rv_plic_reg_ip extends dv_base_reg;
       .lsb_pos(4),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -155,7 +155,7 @@ class rv_plic_reg_ip extends dv_base_reg;
       .lsb_pos(5),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -166,7 +166,7 @@ class rv_plic_reg_ip extends dv_base_reg;
       .lsb_pos(6),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -177,7 +177,7 @@ class rv_plic_reg_ip extends dv_base_reg;
       .lsb_pos(7),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -188,7 +188,7 @@ class rv_plic_reg_ip extends dv_base_reg;
       .lsb_pos(8),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -199,7 +199,7 @@ class rv_plic_reg_ip extends dv_base_reg;
       .lsb_pos(9),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -210,7 +210,7 @@ class rv_plic_reg_ip extends dv_base_reg;
       .lsb_pos(10),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -221,7 +221,7 @@ class rv_plic_reg_ip extends dv_base_reg;
       .lsb_pos(11),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -232,7 +232,7 @@ class rv_plic_reg_ip extends dv_base_reg;
       .lsb_pos(12),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -243,7 +243,7 @@ class rv_plic_reg_ip extends dv_base_reg;
       .lsb_pos(13),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -254,7 +254,7 @@ class rv_plic_reg_ip extends dv_base_reg;
       .lsb_pos(14),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -265,7 +265,7 @@ class rv_plic_reg_ip extends dv_base_reg;
       .lsb_pos(15),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -276,7 +276,7 @@ class rv_plic_reg_ip extends dv_base_reg;
       .lsb_pos(16),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -287,7 +287,7 @@ class rv_plic_reg_ip extends dv_base_reg;
       .lsb_pos(17),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -298,7 +298,7 @@ class rv_plic_reg_ip extends dv_base_reg;
       .lsb_pos(18),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -309,7 +309,7 @@ class rv_plic_reg_ip extends dv_base_reg;
       .lsb_pos(19),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -320,7 +320,7 @@ class rv_plic_reg_ip extends dv_base_reg;
       .lsb_pos(20),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -331,7 +331,7 @@ class rv_plic_reg_ip extends dv_base_reg;
       .lsb_pos(21),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -342,7 +342,7 @@ class rv_plic_reg_ip extends dv_base_reg;
       .lsb_pos(22),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -353,7 +353,7 @@ class rv_plic_reg_ip extends dv_base_reg;
       .lsb_pos(23),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -364,7 +364,7 @@ class rv_plic_reg_ip extends dv_base_reg;
       .lsb_pos(24),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -375,7 +375,7 @@ class rv_plic_reg_ip extends dv_base_reg;
       .lsb_pos(25),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -386,7 +386,7 @@ class rv_plic_reg_ip extends dv_base_reg;
       .lsb_pos(26),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -397,7 +397,7 @@ class rv_plic_reg_ip extends dv_base_reg;
       .lsb_pos(27),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -408,7 +408,7 @@ class rv_plic_reg_ip extends dv_base_reg;
       .lsb_pos(28),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -419,7 +419,7 @@ class rv_plic_reg_ip extends dv_base_reg;
       .lsb_pos(29),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -430,7 +430,7 @@ class rv_plic_reg_ip extends dv_base_reg;
       .lsb_pos(30),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -441,7 +441,7 @@ class rv_plic_reg_ip extends dv_base_reg;
       .lsb_pos(31),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -502,7 +502,7 @@ class rv_plic_reg_le extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -513,7 +513,7 @@ class rv_plic_reg_le extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -524,7 +524,7 @@ class rv_plic_reg_le extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -535,7 +535,7 @@ class rv_plic_reg_le extends dv_base_reg;
       .lsb_pos(3),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -546,7 +546,7 @@ class rv_plic_reg_le extends dv_base_reg;
       .lsb_pos(4),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -557,7 +557,7 @@ class rv_plic_reg_le extends dv_base_reg;
       .lsb_pos(5),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -568,7 +568,7 @@ class rv_plic_reg_le extends dv_base_reg;
       .lsb_pos(6),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -579,7 +579,7 @@ class rv_plic_reg_le extends dv_base_reg;
       .lsb_pos(7),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -590,7 +590,7 @@ class rv_plic_reg_le extends dv_base_reg;
       .lsb_pos(8),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -601,7 +601,7 @@ class rv_plic_reg_le extends dv_base_reg;
       .lsb_pos(9),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -612,7 +612,7 @@ class rv_plic_reg_le extends dv_base_reg;
       .lsb_pos(10),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -623,7 +623,7 @@ class rv_plic_reg_le extends dv_base_reg;
       .lsb_pos(11),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -634,7 +634,7 @@ class rv_plic_reg_le extends dv_base_reg;
       .lsb_pos(12),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -645,7 +645,7 @@ class rv_plic_reg_le extends dv_base_reg;
       .lsb_pos(13),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -656,7 +656,7 @@ class rv_plic_reg_le extends dv_base_reg;
       .lsb_pos(14),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -667,7 +667,7 @@ class rv_plic_reg_le extends dv_base_reg;
       .lsb_pos(15),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -678,7 +678,7 @@ class rv_plic_reg_le extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -689,7 +689,7 @@ class rv_plic_reg_le extends dv_base_reg;
       .lsb_pos(17),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -700,7 +700,7 @@ class rv_plic_reg_le extends dv_base_reg;
       .lsb_pos(18),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -711,7 +711,7 @@ class rv_plic_reg_le extends dv_base_reg;
       .lsb_pos(19),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -722,7 +722,7 @@ class rv_plic_reg_le extends dv_base_reg;
       .lsb_pos(20),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -733,7 +733,7 @@ class rv_plic_reg_le extends dv_base_reg;
       .lsb_pos(21),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -744,7 +744,7 @@ class rv_plic_reg_le extends dv_base_reg;
       .lsb_pos(22),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -755,7 +755,7 @@ class rv_plic_reg_le extends dv_base_reg;
       .lsb_pos(23),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -766,7 +766,7 @@ class rv_plic_reg_le extends dv_base_reg;
       .lsb_pos(24),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -777,7 +777,7 @@ class rv_plic_reg_le extends dv_base_reg;
       .lsb_pos(25),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -788,7 +788,7 @@ class rv_plic_reg_le extends dv_base_reg;
       .lsb_pos(26),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -799,7 +799,7 @@ class rv_plic_reg_le extends dv_base_reg;
       .lsb_pos(27),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -810,7 +810,7 @@ class rv_plic_reg_le extends dv_base_reg;
       .lsb_pos(28),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -821,7 +821,7 @@ class rv_plic_reg_le extends dv_base_reg;
       .lsb_pos(29),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -832,7 +832,7 @@ class rv_plic_reg_le extends dv_base_reg;
       .lsb_pos(30),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -843,7 +843,7 @@ class rv_plic_reg_le extends dv_base_reg;
       .lsb_pos(31),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -873,7 +873,7 @@ class rv_plic_reg_prio0 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -903,7 +903,7 @@ class rv_plic_reg_prio1 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -933,7 +933,7 @@ class rv_plic_reg_prio2 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -963,7 +963,7 @@ class rv_plic_reg_prio3 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -993,7 +993,7 @@ class rv_plic_reg_prio4 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1023,7 +1023,7 @@ class rv_plic_reg_prio5 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1053,7 +1053,7 @@ class rv_plic_reg_prio6 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1083,7 +1083,7 @@ class rv_plic_reg_prio7 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1113,7 +1113,7 @@ class rv_plic_reg_prio8 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1143,7 +1143,7 @@ class rv_plic_reg_prio9 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1173,7 +1173,7 @@ class rv_plic_reg_prio10 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1203,7 +1203,7 @@ class rv_plic_reg_prio11 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1233,7 +1233,7 @@ class rv_plic_reg_prio12 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1263,7 +1263,7 @@ class rv_plic_reg_prio13 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1293,7 +1293,7 @@ class rv_plic_reg_prio14 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1323,7 +1323,7 @@ class rv_plic_reg_prio15 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1353,7 +1353,7 @@ class rv_plic_reg_prio16 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1383,7 +1383,7 @@ class rv_plic_reg_prio17 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1413,7 +1413,7 @@ class rv_plic_reg_prio18 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1443,7 +1443,7 @@ class rv_plic_reg_prio19 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1473,7 +1473,7 @@ class rv_plic_reg_prio20 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1503,7 +1503,7 @@ class rv_plic_reg_prio21 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1533,7 +1533,7 @@ class rv_plic_reg_prio22 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1563,7 +1563,7 @@ class rv_plic_reg_prio23 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1593,7 +1593,7 @@ class rv_plic_reg_prio24 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1623,7 +1623,7 @@ class rv_plic_reg_prio25 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1653,7 +1653,7 @@ class rv_plic_reg_prio26 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1683,7 +1683,7 @@ class rv_plic_reg_prio27 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1713,7 +1713,7 @@ class rv_plic_reg_prio28 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1743,7 +1743,7 @@ class rv_plic_reg_prio29 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1773,7 +1773,7 @@ class rv_plic_reg_prio30 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1803,7 +1803,7 @@ class rv_plic_reg_prio31 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1864,7 +1864,7 @@ class rv_plic_reg_ie0 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1875,7 +1875,7 @@ class rv_plic_reg_ie0 extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1886,7 +1886,7 @@ class rv_plic_reg_ie0 extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1897,7 +1897,7 @@ class rv_plic_reg_ie0 extends dv_base_reg;
       .lsb_pos(3),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1908,7 +1908,7 @@ class rv_plic_reg_ie0 extends dv_base_reg;
       .lsb_pos(4),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1919,7 +1919,7 @@ class rv_plic_reg_ie0 extends dv_base_reg;
       .lsb_pos(5),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1930,7 +1930,7 @@ class rv_plic_reg_ie0 extends dv_base_reg;
       .lsb_pos(6),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1941,7 +1941,7 @@ class rv_plic_reg_ie0 extends dv_base_reg;
       .lsb_pos(7),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1952,7 +1952,7 @@ class rv_plic_reg_ie0 extends dv_base_reg;
       .lsb_pos(8),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1963,7 +1963,7 @@ class rv_plic_reg_ie0 extends dv_base_reg;
       .lsb_pos(9),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1974,7 +1974,7 @@ class rv_plic_reg_ie0 extends dv_base_reg;
       .lsb_pos(10),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1985,7 +1985,7 @@ class rv_plic_reg_ie0 extends dv_base_reg;
       .lsb_pos(11),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1996,7 +1996,7 @@ class rv_plic_reg_ie0 extends dv_base_reg;
       .lsb_pos(12),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2007,7 +2007,7 @@ class rv_plic_reg_ie0 extends dv_base_reg;
       .lsb_pos(13),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2018,7 +2018,7 @@ class rv_plic_reg_ie0 extends dv_base_reg;
       .lsb_pos(14),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2029,7 +2029,7 @@ class rv_plic_reg_ie0 extends dv_base_reg;
       .lsb_pos(15),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2040,7 +2040,7 @@ class rv_plic_reg_ie0 extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2051,7 +2051,7 @@ class rv_plic_reg_ie0 extends dv_base_reg;
       .lsb_pos(17),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2062,7 +2062,7 @@ class rv_plic_reg_ie0 extends dv_base_reg;
       .lsb_pos(18),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2073,7 +2073,7 @@ class rv_plic_reg_ie0 extends dv_base_reg;
       .lsb_pos(19),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2084,7 +2084,7 @@ class rv_plic_reg_ie0 extends dv_base_reg;
       .lsb_pos(20),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2095,7 +2095,7 @@ class rv_plic_reg_ie0 extends dv_base_reg;
       .lsb_pos(21),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2106,7 +2106,7 @@ class rv_plic_reg_ie0 extends dv_base_reg;
       .lsb_pos(22),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2117,7 +2117,7 @@ class rv_plic_reg_ie0 extends dv_base_reg;
       .lsb_pos(23),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2128,7 +2128,7 @@ class rv_plic_reg_ie0 extends dv_base_reg;
       .lsb_pos(24),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2139,7 +2139,7 @@ class rv_plic_reg_ie0 extends dv_base_reg;
       .lsb_pos(25),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2150,7 +2150,7 @@ class rv_plic_reg_ie0 extends dv_base_reg;
       .lsb_pos(26),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2161,7 +2161,7 @@ class rv_plic_reg_ie0 extends dv_base_reg;
       .lsb_pos(27),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2172,7 +2172,7 @@ class rv_plic_reg_ie0 extends dv_base_reg;
       .lsb_pos(28),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2183,7 +2183,7 @@ class rv_plic_reg_ie0 extends dv_base_reg;
       .lsb_pos(29),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2194,7 +2194,7 @@ class rv_plic_reg_ie0 extends dv_base_reg;
       .lsb_pos(30),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2205,7 +2205,7 @@ class rv_plic_reg_ie0 extends dv_base_reg;
       .lsb_pos(31),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2235,7 +2235,7 @@ class rv_plic_reg_threshold0 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2265,7 +2265,7 @@ class rv_plic_reg_cc0 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2295,7 +2295,7 @@ class rv_plic_reg_msip0 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));

--- a/hw/ip/rv_timer/dv/env/rv_timer_reg_block.sv
+++ b/hw/ip/rv_timer/dv/env/rv_timer_reg_block.sv
@@ -40,7 +40,7 @@ class rv_timer_reg_ctrl extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -71,7 +71,7 @@ class rv_timer_reg_cfg0 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -82,7 +82,7 @@ class rv_timer_reg_cfg0 extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(0),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -112,7 +112,7 @@ class rv_timer_reg_timer_v_lower0 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -142,7 +142,7 @@ class rv_timer_reg_timer_v_upper0 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -172,7 +172,7 @@ class rv_timer_reg_compare_lower0_0 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(4294967295),
+      .reset(32'hffffffff),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -202,7 +202,7 @@ class rv_timer_reg_compare_upper0_0 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(4294967295),
+      .reset(32'hffffffff),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -232,7 +232,7 @@ class rv_timer_reg_intr_enable0 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -262,7 +262,7 @@ class rv_timer_reg_intr_state0 extends dv_base_reg;
       .lsb_pos(0),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -292,7 +292,7 @@ class rv_timer_reg_intr_test0 extends dv_base_reg;
       .lsb_pos(0),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));

--- a/hw/ip/spi_device/dv/env/spi_device_reg_block.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_reg_block.sv
@@ -49,7 +49,7 @@ class spi_device_reg_intr_state extends dv_base_reg;
       .lsb_pos(0),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -60,7 +60,7 @@ class spi_device_reg_intr_state extends dv_base_reg;
       .lsb_pos(1),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -71,7 +71,7 @@ class spi_device_reg_intr_state extends dv_base_reg;
       .lsb_pos(2),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -82,7 +82,7 @@ class spi_device_reg_intr_state extends dv_base_reg;
       .lsb_pos(3),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -93,7 +93,7 @@ class spi_device_reg_intr_state extends dv_base_reg;
       .lsb_pos(4),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -104,7 +104,7 @@ class spi_device_reg_intr_state extends dv_base_reg;
       .lsb_pos(5),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -139,7 +139,7 @@ class spi_device_reg_intr_enable extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -150,7 +150,7 @@ class spi_device_reg_intr_enable extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -161,7 +161,7 @@ class spi_device_reg_intr_enable extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -172,7 +172,7 @@ class spi_device_reg_intr_enable extends dv_base_reg;
       .lsb_pos(3),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -183,7 +183,7 @@ class spi_device_reg_intr_enable extends dv_base_reg;
       .lsb_pos(4),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -194,7 +194,7 @@ class spi_device_reg_intr_enable extends dv_base_reg;
       .lsb_pos(5),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -229,7 +229,7 @@ class spi_device_reg_intr_test extends dv_base_reg;
       .lsb_pos(0),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -240,7 +240,7 @@ class spi_device_reg_intr_test extends dv_base_reg;
       .lsb_pos(1),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -251,7 +251,7 @@ class spi_device_reg_intr_test extends dv_base_reg;
       .lsb_pos(2),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -262,7 +262,7 @@ class spi_device_reg_intr_test extends dv_base_reg;
       .lsb_pos(3),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -273,7 +273,7 @@ class spi_device_reg_intr_test extends dv_base_reg;
       .lsb_pos(4),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -284,7 +284,7 @@ class spi_device_reg_intr_test extends dv_base_reg;
       .lsb_pos(5),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -317,7 +317,7 @@ class spi_device_reg_control extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -328,7 +328,7 @@ class spi_device_reg_control extends dv_base_reg;
       .lsb_pos(4),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -339,7 +339,7 @@ class spi_device_reg_control extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -350,7 +350,7 @@ class spi_device_reg_control extends dv_base_reg;
       .lsb_pos(17),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -384,7 +384,7 @@ class spi_device_reg_cfg extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -395,7 +395,7 @@ class spi_device_reg_cfg extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -406,7 +406,7 @@ class spi_device_reg_cfg extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -417,7 +417,7 @@ class spi_device_reg_cfg extends dv_base_reg;
       .lsb_pos(3),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -428,7 +428,7 @@ class spi_device_reg_cfg extends dv_base_reg;
       .lsb_pos(8),
       .access("RW"),
       .volatile(0),
-      .reset(127),
+      .reset(32'h7f),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -459,7 +459,7 @@ class spi_device_reg_fifo_level extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(128),
+      .reset(32'h80),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -470,7 +470,7 @@ class spi_device_reg_fifo_level extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -501,7 +501,7 @@ class spi_device_reg_async_fifo_level extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -512,7 +512,7 @@ class spi_device_reg_async_fifo_level extends dv_base_reg;
       .lsb_pos(16),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -547,7 +547,7 @@ class spi_device_reg_status extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -558,7 +558,7 @@ class spi_device_reg_status extends dv_base_reg;
       .lsb_pos(1),
       .access("RO"),
       .volatile(1),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -569,7 +569,7 @@ class spi_device_reg_status extends dv_base_reg;
       .lsb_pos(2),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -580,7 +580,7 @@ class spi_device_reg_status extends dv_base_reg;
       .lsb_pos(3),
       .access("RO"),
       .volatile(1),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -591,7 +591,7 @@ class spi_device_reg_status extends dv_base_reg;
       .lsb_pos(4),
       .access("RO"),
       .volatile(1),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -602,7 +602,7 @@ class spi_device_reg_status extends dv_base_reg;
       .lsb_pos(5),
       .access("RO"),
       .volatile(1),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -633,7 +633,7 @@ class spi_device_reg_rxf_ptr extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -644,7 +644,7 @@ class spi_device_reg_rxf_ptr extends dv_base_reg;
       .lsb_pos(16),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -675,7 +675,7 @@ class spi_device_reg_txf_ptr extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -686,7 +686,7 @@ class spi_device_reg_txf_ptr extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -717,7 +717,7 @@ class spi_device_reg_rxf_addr extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -728,7 +728,7 @@ class spi_device_reg_rxf_addr extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(0),
-      .reset(508),
+      .reset(32'h1fc),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -759,7 +759,7 @@ class spi_device_reg_txf_addr extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(512),
+      .reset(32'h200),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -770,7 +770,7 @@ class spi_device_reg_txf_addr extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(0),
-      .reset(1020),
+      .reset(32'h3fc),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));

--- a/hw/ip/uart/dv/env/uart_reg_block.sv
+++ b/hw/ip/uart/dv/env/uart_reg_block.sv
@@ -50,7 +50,7 @@ class uart_reg_intr_state extends dv_base_reg;
       .lsb_pos(0),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -61,7 +61,7 @@ class uart_reg_intr_state extends dv_base_reg;
       .lsb_pos(1),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -72,7 +72,7 @@ class uart_reg_intr_state extends dv_base_reg;
       .lsb_pos(2),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -83,7 +83,7 @@ class uart_reg_intr_state extends dv_base_reg;
       .lsb_pos(3),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -94,7 +94,7 @@ class uart_reg_intr_state extends dv_base_reg;
       .lsb_pos(4),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -105,7 +105,7 @@ class uart_reg_intr_state extends dv_base_reg;
       .lsb_pos(5),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -116,7 +116,7 @@ class uart_reg_intr_state extends dv_base_reg;
       .lsb_pos(6),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -127,7 +127,7 @@ class uart_reg_intr_state extends dv_base_reg;
       .lsb_pos(7),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -164,7 +164,7 @@ class uart_reg_intr_enable extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -175,7 +175,7 @@ class uart_reg_intr_enable extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -186,7 +186,7 @@ class uart_reg_intr_enable extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -197,7 +197,7 @@ class uart_reg_intr_enable extends dv_base_reg;
       .lsb_pos(3),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -208,7 +208,7 @@ class uart_reg_intr_enable extends dv_base_reg;
       .lsb_pos(4),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -219,7 +219,7 @@ class uart_reg_intr_enable extends dv_base_reg;
       .lsb_pos(5),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -230,7 +230,7 @@ class uart_reg_intr_enable extends dv_base_reg;
       .lsb_pos(6),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -241,7 +241,7 @@ class uart_reg_intr_enable extends dv_base_reg;
       .lsb_pos(7),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -278,7 +278,7 @@ class uart_reg_intr_test extends dv_base_reg;
       .lsb_pos(0),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -289,7 +289,7 @@ class uart_reg_intr_test extends dv_base_reg;
       .lsb_pos(1),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -300,7 +300,7 @@ class uart_reg_intr_test extends dv_base_reg;
       .lsb_pos(2),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -311,7 +311,7 @@ class uart_reg_intr_test extends dv_base_reg;
       .lsb_pos(3),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -322,7 +322,7 @@ class uart_reg_intr_test extends dv_base_reg;
       .lsb_pos(4),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -333,7 +333,7 @@ class uart_reg_intr_test extends dv_base_reg;
       .lsb_pos(5),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -344,7 +344,7 @@ class uart_reg_intr_test extends dv_base_reg;
       .lsb_pos(6),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -355,7 +355,7 @@ class uart_reg_intr_test extends dv_base_reg;
       .lsb_pos(7),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -393,7 +393,7 @@ class uart_reg_ctrl extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -404,7 +404,7 @@ class uart_reg_ctrl extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -415,7 +415,7 @@ class uart_reg_ctrl extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -426,7 +426,7 @@ class uart_reg_ctrl extends dv_base_reg;
       .lsb_pos(4),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -437,7 +437,7 @@ class uart_reg_ctrl extends dv_base_reg;
       .lsb_pos(5),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -448,7 +448,7 @@ class uart_reg_ctrl extends dv_base_reg;
       .lsb_pos(6),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -459,7 +459,7 @@ class uart_reg_ctrl extends dv_base_reg;
       .lsb_pos(7),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -470,7 +470,7 @@ class uart_reg_ctrl extends dv_base_reg;
       .lsb_pos(8),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -481,7 +481,7 @@ class uart_reg_ctrl extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -516,7 +516,7 @@ class uart_reg_status extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -527,7 +527,7 @@ class uart_reg_status extends dv_base_reg;
       .lsb_pos(1),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -538,7 +538,7 @@ class uart_reg_status extends dv_base_reg;
       .lsb_pos(2),
       .access("RO"),
       .volatile(1),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -549,7 +549,7 @@ class uart_reg_status extends dv_base_reg;
       .lsb_pos(3),
       .access("RO"),
       .volatile(1),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -560,7 +560,7 @@ class uart_reg_status extends dv_base_reg;
       .lsb_pos(4),
       .access("RO"),
       .volatile(1),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -571,7 +571,7 @@ class uart_reg_status extends dv_base_reg;
       .lsb_pos(5),
       .access("RO"),
       .volatile(1),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -601,7 +601,7 @@ class uart_reg_rdata extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -631,7 +631,7 @@ class uart_reg_wdata extends dv_base_reg;
       .lsb_pos(0),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -664,7 +664,7 @@ class uart_reg_fifo_ctrl extends dv_base_reg;
       .lsb_pos(0),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -675,7 +675,7 @@ class uart_reg_fifo_ctrl extends dv_base_reg;
       .lsb_pos(1),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -686,7 +686,7 @@ class uart_reg_fifo_ctrl extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -697,7 +697,7 @@ class uart_reg_fifo_ctrl extends dv_base_reg;
       .lsb_pos(5),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -728,7 +728,7 @@ class uart_reg_fifo_status extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -739,7 +739,7 @@ class uart_reg_fifo_status extends dv_base_reg;
       .lsb_pos(16),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -770,7 +770,7 @@ class uart_reg_ovrd extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -781,7 +781,7 @@ class uart_reg_ovrd extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -811,7 +811,7 @@ class uart_reg_val extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -842,7 +842,7 @@ class uart_reg_timeout_ctrl extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -853,7 +853,7 @@ class uart_reg_timeout_ctrl extends dv_base_reg;
       .lsb_pos(31),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));

--- a/hw/ip/usbuart/dv/env/usbuart_reg_block.sv
+++ b/hw/ip/usbuart/dv/env/usbuart_reg_block.sv
@@ -52,7 +52,7 @@ class usbuart_reg_intr_state extends dv_base_reg;
       .lsb_pos(0),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -63,7 +63,7 @@ class usbuart_reg_intr_state extends dv_base_reg;
       .lsb_pos(1),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -74,7 +74,7 @@ class usbuart_reg_intr_state extends dv_base_reg;
       .lsb_pos(2),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -85,7 +85,7 @@ class usbuart_reg_intr_state extends dv_base_reg;
       .lsb_pos(3),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -96,7 +96,7 @@ class usbuart_reg_intr_state extends dv_base_reg;
       .lsb_pos(4),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -107,7 +107,7 @@ class usbuart_reg_intr_state extends dv_base_reg;
       .lsb_pos(5),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -118,7 +118,7 @@ class usbuart_reg_intr_state extends dv_base_reg;
       .lsb_pos(6),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -129,7 +129,7 @@ class usbuart_reg_intr_state extends dv_base_reg;
       .lsb_pos(7),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -166,7 +166,7 @@ class usbuart_reg_intr_enable extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -177,7 +177,7 @@ class usbuart_reg_intr_enable extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -188,7 +188,7 @@ class usbuart_reg_intr_enable extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -199,7 +199,7 @@ class usbuart_reg_intr_enable extends dv_base_reg;
       .lsb_pos(3),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -210,7 +210,7 @@ class usbuart_reg_intr_enable extends dv_base_reg;
       .lsb_pos(4),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -221,7 +221,7 @@ class usbuart_reg_intr_enable extends dv_base_reg;
       .lsb_pos(5),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -232,7 +232,7 @@ class usbuart_reg_intr_enable extends dv_base_reg;
       .lsb_pos(6),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -243,7 +243,7 @@ class usbuart_reg_intr_enable extends dv_base_reg;
       .lsb_pos(7),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -280,7 +280,7 @@ class usbuart_reg_intr_test extends dv_base_reg;
       .lsb_pos(0),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -291,7 +291,7 @@ class usbuart_reg_intr_test extends dv_base_reg;
       .lsb_pos(1),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -302,7 +302,7 @@ class usbuart_reg_intr_test extends dv_base_reg;
       .lsb_pos(2),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -313,7 +313,7 @@ class usbuart_reg_intr_test extends dv_base_reg;
       .lsb_pos(3),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -324,7 +324,7 @@ class usbuart_reg_intr_test extends dv_base_reg;
       .lsb_pos(4),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -335,7 +335,7 @@ class usbuart_reg_intr_test extends dv_base_reg;
       .lsb_pos(5),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -346,7 +346,7 @@ class usbuart_reg_intr_test extends dv_base_reg;
       .lsb_pos(6),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -357,7 +357,7 @@ class usbuart_reg_intr_test extends dv_base_reg;
       .lsb_pos(7),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -395,7 +395,7 @@ class usbuart_reg_ctrl extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -406,7 +406,7 @@ class usbuart_reg_ctrl extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -417,7 +417,7 @@ class usbuart_reg_ctrl extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -428,7 +428,7 @@ class usbuart_reg_ctrl extends dv_base_reg;
       .lsb_pos(4),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -439,7 +439,7 @@ class usbuart_reg_ctrl extends dv_base_reg;
       .lsb_pos(5),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -450,7 +450,7 @@ class usbuart_reg_ctrl extends dv_base_reg;
       .lsb_pos(6),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -461,7 +461,7 @@ class usbuart_reg_ctrl extends dv_base_reg;
       .lsb_pos(7),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -472,7 +472,7 @@ class usbuart_reg_ctrl extends dv_base_reg;
       .lsb_pos(8),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -483,7 +483,7 @@ class usbuart_reg_ctrl extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -518,7 +518,7 @@ class usbuart_reg_status extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -529,7 +529,7 @@ class usbuart_reg_status extends dv_base_reg;
       .lsb_pos(1),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -540,7 +540,7 @@ class usbuart_reg_status extends dv_base_reg;
       .lsb_pos(2),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -551,7 +551,7 @@ class usbuart_reg_status extends dv_base_reg;
       .lsb_pos(3),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -562,7 +562,7 @@ class usbuart_reg_status extends dv_base_reg;
       .lsb_pos(4),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -573,7 +573,7 @@ class usbuart_reg_status extends dv_base_reg;
       .lsb_pos(5),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -603,7 +603,7 @@ class usbuart_reg_rdata extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -633,7 +633,7 @@ class usbuart_reg_wdata extends dv_base_reg;
       .lsb_pos(0),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -666,7 +666,7 @@ class usbuart_reg_fifo_ctrl extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -677,7 +677,7 @@ class usbuart_reg_fifo_ctrl extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -688,7 +688,7 @@ class usbuart_reg_fifo_ctrl extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -699,7 +699,7 @@ class usbuart_reg_fifo_ctrl extends dv_base_reg;
       .lsb_pos(5),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -730,7 +730,7 @@ class usbuart_reg_fifo_status extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -741,7 +741,7 @@ class usbuart_reg_fifo_status extends dv_base_reg;
       .lsb_pos(16),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -772,7 +772,7 @@ class usbuart_reg_ovrd extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -783,7 +783,7 @@ class usbuart_reg_ovrd extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -813,7 +813,7 @@ class usbuart_reg_val extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -844,7 +844,7 @@ class usbuart_reg_timeout_ctrl extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -855,7 +855,7 @@ class usbuart_reg_timeout_ctrl extends dv_base_reg;
       .lsb_pos(31),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -888,7 +888,7 @@ class usbuart_reg_usbstat extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -899,7 +899,7 @@ class usbuart_reg_usbstat extends dv_base_reg;
       .lsb_pos(14),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -910,7 +910,7 @@ class usbuart_reg_usbstat extends dv_base_reg;
       .lsb_pos(15),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -921,7 +921,7 @@ class usbuart_reg_usbstat extends dv_base_reg;
       .lsb_pos(16),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -952,7 +952,7 @@ class usbuart_reg_usbparam extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -963,7 +963,7 @@ class usbuart_reg_usbparam extends dv_base_reg;
       .lsb_pos(16),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));

--- a/hw/top_earlgrey/dv/env/chip_reg_block.sv
+++ b/hw/top_earlgrey/dv/env/chip_reg_block.sv
@@ -6,34 +6,19 @@
 // Do Not Edit directly
 
 // Forward declare all register/memory/block classes
-typedef class hmac_reg_intr_state;
-typedef class hmac_reg_intr_enable;
-typedef class hmac_reg_intr_test;
-typedef class hmac_reg_cfg;
-typedef class hmac_reg_cmd;
-typedef class hmac_reg_status;
-typedef class hmac_reg_err_code;
-typedef class hmac_reg_wipe_secret;
-typedef class hmac_reg_key0;
-typedef class hmac_reg_key1;
-typedef class hmac_reg_key2;
-typedef class hmac_reg_key3;
-typedef class hmac_reg_key4;
-typedef class hmac_reg_key5;
-typedef class hmac_reg_key6;
-typedef class hmac_reg_key7;
-typedef class hmac_reg_digest0;
-typedef class hmac_reg_digest1;
-typedef class hmac_reg_digest2;
-typedef class hmac_reg_digest3;
-typedef class hmac_reg_digest4;
-typedef class hmac_reg_digest5;
-typedef class hmac_reg_digest6;
-typedef class hmac_reg_digest7;
-typedef class hmac_reg_msg_length_lower;
-typedef class hmac_reg_msg_length_upper;
-typedef class hmac_mem_msg_fifo;
-typedef class hmac_reg_block;
+typedef class uart_reg_intr_state;
+typedef class uart_reg_intr_enable;
+typedef class uart_reg_intr_test;
+typedef class uart_reg_ctrl;
+typedef class uart_reg_status;
+typedef class uart_reg_rdata;
+typedef class uart_reg_wdata;
+typedef class uart_reg_fifo_ctrl;
+typedef class uart_reg_fifo_status;
+typedef class uart_reg_ovrd;
+typedef class uart_reg_val;
+typedef class uart_reg_timeout_ctrl;
+typedef class uart_reg_block;
 
 typedef class gpio_reg_intr_state;
 typedef class gpio_reg_intr_enable;
@@ -51,6 +36,21 @@ typedef class gpio_reg_intr_ctrl_en_lvlhigh;
 typedef class gpio_reg_intr_ctrl_en_lvllow;
 typedef class gpio_reg_ctrl_en_input_filter;
 typedef class gpio_reg_block;
+
+typedef class spi_device_reg_intr_state;
+typedef class spi_device_reg_intr_enable;
+typedef class spi_device_reg_intr_test;
+typedef class spi_device_reg_control;
+typedef class spi_device_reg_cfg;
+typedef class spi_device_reg_fifo_level;
+typedef class spi_device_reg_async_fifo_level;
+typedef class spi_device_reg_status;
+typedef class spi_device_reg_rxf_ptr;
+typedef class spi_device_reg_txf_ptr;
+typedef class spi_device_reg_rxf_addr;
+typedef class spi_device_reg_txf_addr;
+typedef class spi_device_mem_buffer;
+typedef class spi_device_reg_block;
 
 typedef class flash_ctrl_reg_intr_state;
 typedef class flash_ctrl_reg_intr_enable;
@@ -76,35 +76,6 @@ typedef class flash_ctrl_reg_fifo_lvl;
 typedef class flash_ctrl_mem_prog_fifo;
 typedef class flash_ctrl_mem_rd_fifo;
 typedef class flash_ctrl_reg_block;
-
-typedef class uart_reg_intr_state;
-typedef class uart_reg_intr_enable;
-typedef class uart_reg_intr_test;
-typedef class uart_reg_ctrl;
-typedef class uart_reg_status;
-typedef class uart_reg_rdata;
-typedef class uart_reg_wdata;
-typedef class uart_reg_fifo_ctrl;
-typedef class uart_reg_fifo_status;
-typedef class uart_reg_ovrd;
-typedef class uart_reg_val;
-typedef class uart_reg_timeout_ctrl;
-typedef class uart_reg_block;
-
-typedef class spi_device_reg_intr_state;
-typedef class spi_device_reg_intr_enable;
-typedef class spi_device_reg_intr_test;
-typedef class spi_device_reg_control;
-typedef class spi_device_reg_cfg;
-typedef class spi_device_reg_fifo_level;
-typedef class spi_device_reg_async_fifo_level;
-typedef class spi_device_reg_status;
-typedef class spi_device_reg_rxf_ptr;
-typedef class spi_device_reg_txf_ptr;
-typedef class spi_device_reg_rxf_addr;
-typedef class spi_device_reg_txf_addr;
-typedef class spi_device_mem_buffer;
-typedef class spi_device_reg_block;
 
 typedef class rv_timer_reg_ctrl;
 typedef class rv_timer_reg_cfg0;
@@ -183,22 +154,77 @@ typedef class rv_plic_reg_cc0;
 typedef class rv_plic_reg_msip0;
 typedef class rv_plic_reg_block;
 
+typedef class aes_reg_key0;
+typedef class aes_reg_key1;
+typedef class aes_reg_key2;
+typedef class aes_reg_key3;
+typedef class aes_reg_key4;
+typedef class aes_reg_key5;
+typedef class aes_reg_key6;
+typedef class aes_reg_key7;
+typedef class aes_reg_data_in0;
+typedef class aes_reg_data_in1;
+typedef class aes_reg_data_in2;
+typedef class aes_reg_data_in3;
+typedef class aes_reg_data_out0;
+typedef class aes_reg_data_out1;
+typedef class aes_reg_data_out2;
+typedef class aes_reg_data_out3;
+typedef class aes_reg_ctrl;
+typedef class aes_reg_trigger;
+typedef class aes_reg_status;
+typedef class aes_reg_block;
+
+typedef class hmac_reg_intr_state;
+typedef class hmac_reg_intr_enable;
+typedef class hmac_reg_intr_test;
+typedef class hmac_reg_cfg;
+typedef class hmac_reg_cmd;
+typedef class hmac_reg_status;
+typedef class hmac_reg_err_code;
+typedef class hmac_reg_wipe_secret;
+typedef class hmac_reg_key0;
+typedef class hmac_reg_key1;
+typedef class hmac_reg_key2;
+typedef class hmac_reg_key3;
+typedef class hmac_reg_key4;
+typedef class hmac_reg_key5;
+typedef class hmac_reg_key6;
+typedef class hmac_reg_key7;
+typedef class hmac_reg_digest0;
+typedef class hmac_reg_digest1;
+typedef class hmac_reg_digest2;
+typedef class hmac_reg_digest3;
+typedef class hmac_reg_digest4;
+typedef class hmac_reg_digest5;
+typedef class hmac_reg_digest6;
+typedef class hmac_reg_digest7;
+typedef class hmac_reg_msg_length_lower;
+typedef class hmac_reg_msg_length_upper;
+typedef class hmac_mem_msg_fifo;
+typedef class hmac_reg_block;
+
 typedef class chip_mem_rom;
 typedef class chip_mem_ram_main;
 typedef class chip_mem_eflash;
 typedef class chip_reg_block;
 
-// Block: hmac
-// Class: hmac_reg_intr_state
-class hmac_reg_intr_state extends dv_base_reg;
+// Block: uart
+// Class: uart_reg_intr_state
+class uart_reg_intr_state extends dv_base_reg;
   // fields
-  rand dv_base_reg_field hmac_done;
-  rand dv_base_reg_field fifo_full;
-  rand dv_base_reg_field hmac_err;
+  rand dv_base_reg_field tx_watermark;
+  rand dv_base_reg_field rx_watermark;
+  rand dv_base_reg_field tx_overflow;
+  rand dv_base_reg_field rx_overflow;
+  rand dv_base_reg_field rx_frame_err;
+  rand dv_base_reg_field rx_break_err;
+  rand dv_base_reg_field rx_timeout;
+  rand dv_base_reg_field rx_parity_err;
 
-  `uvm_object_utils(hmac_reg_intr_state)
+  `uvm_object_utils(uart_reg_intr_state)
 
-  function new(string       name = "hmac_reg_intr_state",
+  function new(string       name = "uart_reg_intr_state",
                int unsigned n_bits = 32,
                int          has_coverage = UVM_NO_COVERAGE);
     super.new(name, n_bits, has_coverage);
@@ -206,53 +232,113 @@ class hmac_reg_intr_state extends dv_base_reg;
 
   virtual function void build();
     // create fields
-    hmac_done = dv_base_reg_field::type_id::create("hmac_done");
-    hmac_done.configure(
+    tx_watermark = dv_base_reg_field::type_id::create("tx_watermark");
+    tx_watermark.configure(
       .parent(this),
       .size(1),
       .lsb_pos(0),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
-    fifo_full = dv_base_reg_field::type_id::create("fifo_full");
-    fifo_full.configure(
+    rx_watermark = dv_base_reg_field::type_id::create("rx_watermark");
+    rx_watermark.configure(
       .parent(this),
       .size(1),
       .lsb_pos(1),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
-    hmac_err = dv_base_reg_field::type_id::create("hmac_err");
-    hmac_err.configure(
+    tx_overflow = dv_base_reg_field::type_id::create("tx_overflow");
+    tx_overflow.configure(
       .parent(this),
       .size(1),
       .lsb_pos(2),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    rx_overflow = dv_base_reg_field::type_id::create("rx_overflow");
+    rx_overflow.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(3),
+      .access("W1C"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    rx_frame_err = dv_base_reg_field::type_id::create("rx_frame_err");
+    rx_frame_err.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(4),
+      .access("W1C"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    rx_break_err = dv_base_reg_field::type_id::create("rx_break_err");
+    rx_break_err.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(5),
+      .access("W1C"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    rx_timeout = dv_base_reg_field::type_id::create("rx_timeout");
+    rx_timeout.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(6),
+      .access("W1C"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    rx_parity_err = dv_base_reg_field::type_id::create("rx_parity_err");
+    rx_parity_err.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(7),
+      .access("W1C"),
+      .volatile(1),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
   endfunction : build
 
-endclass : hmac_reg_intr_state
+endclass : uart_reg_intr_state
 
-// Class: hmac_reg_intr_enable
-class hmac_reg_intr_enable extends dv_base_reg;
+// Class: uart_reg_intr_enable
+class uart_reg_intr_enable extends dv_base_reg;
   // fields
-  rand dv_base_reg_field hmac_done;
-  rand dv_base_reg_field fifo_full;
-  rand dv_base_reg_field hmac_err;
+  rand dv_base_reg_field tx_watermark;
+  rand dv_base_reg_field rx_watermark;
+  rand dv_base_reg_field tx_overflow;
+  rand dv_base_reg_field rx_overflow;
+  rand dv_base_reg_field rx_frame_err;
+  rand dv_base_reg_field rx_break_err;
+  rand dv_base_reg_field rx_timeout;
+  rand dv_base_reg_field rx_parity_err;
 
-  `uvm_object_utils(hmac_reg_intr_enable)
+  `uvm_object_utils(uart_reg_intr_enable)
 
-  function new(string       name = "hmac_reg_intr_enable",
+  function new(string       name = "uart_reg_intr_enable",
                int unsigned n_bits = 32,
                int          has_coverage = UVM_NO_COVERAGE);
     super.new(name, n_bits, has_coverage);
@@ -260,172 +346,113 @@ class hmac_reg_intr_enable extends dv_base_reg;
 
   virtual function void build();
     // create fields
-    hmac_done = dv_base_reg_field::type_id::create("hmac_done");
-    hmac_done.configure(
+    tx_watermark = dv_base_reg_field::type_id::create("tx_watermark");
+    tx_watermark.configure(
       .parent(this),
       .size(1),
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
-    fifo_full = dv_base_reg_field::type_id::create("fifo_full");
-    fifo_full.configure(
+    rx_watermark = dv_base_reg_field::type_id::create("rx_watermark");
+    rx_watermark.configure(
       .parent(this),
       .size(1),
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
-    hmac_err = dv_base_reg_field::type_id::create("hmac_err");
-    hmac_err.configure(
+    tx_overflow = dv_base_reg_field::type_id::create("tx_overflow");
+    tx_overflow.configure(
       .parent(this),
       .size(1),
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
-  endfunction : build
-
-endclass : hmac_reg_intr_enable
-
-// Class: hmac_reg_intr_test
-class hmac_reg_intr_test extends dv_base_reg;
-  // fields
-  rand dv_base_reg_field hmac_done;
-  rand dv_base_reg_field fifo_full;
-  rand dv_base_reg_field hmac_err;
-
-  `uvm_object_utils(hmac_reg_intr_test)
-
-  function new(string       name = "hmac_reg_intr_test",
-               int unsigned n_bits = 32,
-               int          has_coverage = UVM_NO_COVERAGE);
-    super.new(name, n_bits, has_coverage);
-  endfunction : new
-
-  virtual function void build();
-    // create fields
-    hmac_done = dv_base_reg_field::type_id::create("hmac_done");
-    hmac_done.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(0),
-      .access("WO"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    fifo_full = dv_base_reg_field::type_id::create("fifo_full");
-    fifo_full.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(1),
-      .access("WO"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    hmac_err = dv_base_reg_field::type_id::create("hmac_err");
-    hmac_err.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(2),
-      .access("WO"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-  endfunction : build
-
-endclass : hmac_reg_intr_test
-
-// Class: hmac_reg_cfg
-class hmac_reg_cfg extends dv_base_reg;
-  // fields
-  rand dv_base_reg_field hmac_en;
-  rand dv_base_reg_field sha_en;
-  rand dv_base_reg_field endian_swap;
-  rand dv_base_reg_field digest_swap;
-
-  `uvm_object_utils(hmac_reg_cfg)
-
-  function new(string       name = "hmac_reg_cfg",
-               int unsigned n_bits = 32,
-               int          has_coverage = UVM_NO_COVERAGE);
-    super.new(name, n_bits, has_coverage);
-  endfunction : new
-
-  virtual function void build();
-    // create fields
-    hmac_en = dv_base_reg_field::type_id::create("hmac_en");
-    hmac_en.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(0),
-      .access("RW"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    sha_en = dv_base_reg_field::type_id::create("sha_en");
-    sha_en.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(1),
-      .access("RW"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    endian_swap = dv_base_reg_field::type_id::create("endian_swap");
-    endian_swap.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(2),
-      .access("RW"),
-      .volatile(0),
-      .reset(1),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    digest_swap = dv_base_reg_field::type_id::create("digest_swap");
-    digest_swap.configure(
+    rx_overflow = dv_base_reg_field::type_id::create("rx_overflow");
+    rx_overflow.configure(
       .parent(this),
       .size(1),
       .lsb_pos(3),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    rx_frame_err = dv_base_reg_field::type_id::create("rx_frame_err");
+    rx_frame_err.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(4),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    rx_break_err = dv_base_reg_field::type_id::create("rx_break_err");
+    rx_break_err.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(5),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    rx_timeout = dv_base_reg_field::type_id::create("rx_timeout");
+    rx_timeout.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(6),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    rx_parity_err = dv_base_reg_field::type_id::create("rx_parity_err");
+    rx_parity_err.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(7),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
   endfunction : build
 
-endclass : hmac_reg_cfg
+endclass : uart_reg_intr_enable
 
-// Class: hmac_reg_cmd
-class hmac_reg_cmd extends dv_base_reg;
+// Class: uart_reg_intr_test
+class uart_reg_intr_test extends dv_base_reg;
   // fields
-  rand dv_base_reg_field hash_start;
-  rand dv_base_reg_field hash_process;
+  rand dv_base_reg_field tx_watermark;
+  rand dv_base_reg_field rx_watermark;
+  rand dv_base_reg_field tx_overflow;
+  rand dv_base_reg_field rx_overflow;
+  rand dv_base_reg_field rx_frame_err;
+  rand dv_base_reg_field rx_break_err;
+  rand dv_base_reg_field rx_timeout;
+  rand dv_base_reg_field rx_parity_err;
 
-  `uvm_object_utils(hmac_reg_cmd)
+  `uvm_object_utils(uart_reg_intr_test)
 
-  function new(string       name = "hmac_reg_cmd",
+  function new(string       name = "uart_reg_intr_test",
                int unsigned n_bits = 32,
                int          has_coverage = UVM_NO_COVERAGE);
     super.new(name, n_bits, has_coverage);
@@ -433,42 +460,114 @@ class hmac_reg_cmd extends dv_base_reg;
 
   virtual function void build();
     // create fields
-    hash_start = dv_base_reg_field::type_id::create("hash_start");
-    hash_start.configure(
+    tx_watermark = dv_base_reg_field::type_id::create("tx_watermark");
+    tx_watermark.configure(
       .parent(this),
       .size(1),
       .lsb_pos(0),
-      .access("W1C"),
+      .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
-    hash_process = dv_base_reg_field::type_id::create("hash_process");
-    hash_process.configure(
+    rx_watermark = dv_base_reg_field::type_id::create("rx_watermark");
+    rx_watermark.configure(
       .parent(this),
       .size(1),
       .lsb_pos(1),
-      .access("W1C"),
+      .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    tx_overflow = dv_base_reg_field::type_id::create("tx_overflow");
+    tx_overflow.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(2),
+      .access("WO"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    rx_overflow = dv_base_reg_field::type_id::create("rx_overflow");
+    rx_overflow.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(3),
+      .access("WO"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    rx_frame_err = dv_base_reg_field::type_id::create("rx_frame_err");
+    rx_frame_err.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(4),
+      .access("WO"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    rx_break_err = dv_base_reg_field::type_id::create("rx_break_err");
+    rx_break_err.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(5),
+      .access("WO"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    rx_timeout = dv_base_reg_field::type_id::create("rx_timeout");
+    rx_timeout.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(6),
+      .access("WO"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    rx_parity_err = dv_base_reg_field::type_id::create("rx_parity_err");
+    rx_parity_err.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(7),
+      .access("WO"),
+      .volatile(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
   endfunction : build
 
-endclass : hmac_reg_cmd
+endclass : uart_reg_intr_test
 
-// Class: hmac_reg_status
-class hmac_reg_status extends dv_base_reg;
+// Class: uart_reg_ctrl
+class uart_reg_ctrl extends dv_base_reg;
   // fields
-  rand dv_base_reg_field fifo_empty;
-  rand dv_base_reg_field fifo_full;
-  rand dv_base_reg_field fifo_depth;
+  rand dv_base_reg_field tx;
+  rand dv_base_reg_field rx;
+  rand dv_base_reg_field nf;
+  rand dv_base_reg_field slpbk;
+  rand dv_base_reg_field llpbk;
+  rand dv_base_reg_field parity_en;
+  rand dv_base_reg_field parity_odd;
+  rand dv_base_reg_field rxblvl;
+  rand dv_base_reg_field nco;
 
-  `uvm_object_utils(hmac_reg_status)
+  `uvm_object_utils(uart_reg_ctrl)
 
-  function new(string       name = "hmac_reg_status",
+  function new(string       name = "uart_reg_ctrl",
                int unsigned n_bits = 32,
                int          has_coverage = UVM_NO_COVERAGE);
     super.new(name, n_bits, has_coverage);
@@ -476,51 +575,207 @@ class hmac_reg_status extends dv_base_reg;
 
   virtual function void build();
     // create fields
-    fifo_empty = dv_base_reg_field::type_id::create("fifo_empty");
-    fifo_empty.configure(
+    tx = dv_base_reg_field::type_id::create("tx");
+    tx.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(0),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    rx = dv_base_reg_field::type_id::create("rx");
+    rx.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(1),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    nf = dv_base_reg_field::type_id::create("nf");
+    nf.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(2),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    slpbk = dv_base_reg_field::type_id::create("slpbk");
+    slpbk.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(4),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    llpbk = dv_base_reg_field::type_id::create("llpbk");
+    llpbk.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(5),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    parity_en = dv_base_reg_field::type_id::create("parity_en");
+    parity_en.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(6),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    parity_odd = dv_base_reg_field::type_id::create("parity_odd");
+    parity_odd.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(7),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    rxblvl = dv_base_reg_field::type_id::create("rxblvl");
+    rxblvl.configure(
+      .parent(this),
+      .size(2),
+      .lsb_pos(8),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    nco = dv_base_reg_field::type_id::create("nco");
+    nco.configure(
+      .parent(this),
+      .size(16),
+      .lsb_pos(16),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : uart_reg_ctrl
+
+// Class: uart_reg_status
+class uart_reg_status extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field txfull;
+  rand dv_base_reg_field rxfull;
+  rand dv_base_reg_field txempty;
+  rand dv_base_reg_field txidle;
+  rand dv_base_reg_field rxidle;
+  rand dv_base_reg_field rxempty;
+
+  `uvm_object_utils(uart_reg_status)
+
+  function new(string       name = "uart_reg_status",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    txfull = dv_base_reg_field::type_id::create("txfull");
+    txfull.configure(
       .parent(this),
       .size(1),
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
-    fifo_full = dv_base_reg_field::type_id::create("fifo_full");
-    fifo_full.configure(
+    rxfull = dv_base_reg_field::type_id::create("rxfull");
+    rxfull.configure(
       .parent(this),
       .size(1),
       .lsb_pos(1),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
-    fifo_depth = dv_base_reg_field::type_id::create("fifo_depth");
-    fifo_depth.configure(
+    txempty = dv_base_reg_field::type_id::create("txempty");
+    txempty.configure(
       .parent(this),
-      .size(5),
+      .size(1),
+      .lsb_pos(2),
+      .access("RO"),
+      .volatile(1),
+      .reset(32'h1),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    txidle = dv_base_reg_field::type_id::create("txidle");
+    txidle.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(3),
+      .access("RO"),
+      .volatile(1),
+      .reset(32'h1),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    rxidle = dv_base_reg_field::type_id::create("rxidle");
+    rxidle.configure(
+      .parent(this),
+      .size(1),
       .lsb_pos(4),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h1),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    rxempty = dv_base_reg_field::type_id::create("rxempty");
+    rxempty.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(5),
+      .access("RO"),
+      .volatile(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
   endfunction : build
 
-endclass : hmac_reg_status
+endclass : uart_reg_status
 
-// Class: hmac_reg_err_code
-class hmac_reg_err_code extends dv_base_reg;
+// Class: uart_reg_rdata
+class uart_reg_rdata extends dv_base_reg;
   // fields
-  rand dv_base_reg_field err_code;
+  rand dv_base_reg_field rdata;
 
-  `uvm_object_utils(hmac_reg_err_code)
+  `uvm_object_utils(uart_reg_rdata)
 
-  function new(string       name = "hmac_reg_err_code",
+  function new(string       name = "uart_reg_rdata",
                int unsigned n_bits = 32,
                int          has_coverage = UVM_NO_COVERAGE);
     super.new(name, n_bits, has_coverage);
@@ -528,29 +783,29 @@ class hmac_reg_err_code extends dv_base_reg;
 
   virtual function void build();
     // create fields
-    err_code = dv_base_reg_field::type_id::create("err_code");
-    err_code.configure(
+    rdata = dv_base_reg_field::type_id::create("rdata");
+    rdata.configure(
       .parent(this),
-      .size(32),
+      .size(8),
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
   endfunction : build
 
-endclass : hmac_reg_err_code
+endclass : uart_reg_rdata
 
-// Class: hmac_reg_wipe_secret
-class hmac_reg_wipe_secret extends dv_base_reg;
+// Class: uart_reg_wdata
+class uart_reg_wdata extends dv_base_reg;
   // fields
-  rand dv_base_reg_field secret;
+  rand dv_base_reg_field wdata;
 
-  `uvm_object_utils(hmac_reg_wipe_secret)
+  `uvm_object_utils(uart_reg_wdata)
 
-  function new(string       name = "hmac_reg_wipe_secret",
+  function new(string       name = "uart_reg_wdata",
                int unsigned n_bits = 32,
                int          has_coverage = UVM_NO_COVERAGE);
     super.new(name, n_bits, has_coverage);
@@ -558,29 +813,32 @@ class hmac_reg_wipe_secret extends dv_base_reg;
 
   virtual function void build();
     // create fields
-    secret = dv_base_reg_field::type_id::create("secret");
-    secret.configure(
+    wdata = dv_base_reg_field::type_id::create("wdata");
+    wdata.configure(
       .parent(this),
-      .size(32),
+      .size(8),
       .lsb_pos(0),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
   endfunction : build
 
-endclass : hmac_reg_wipe_secret
+endclass : uart_reg_wdata
 
-// Class: hmac_reg_key0
-class hmac_reg_key0 extends dv_base_reg;
+// Class: uart_reg_fifo_ctrl
+class uart_reg_fifo_ctrl extends dv_base_reg;
   // fields
-  rand dv_base_reg_field key0;
+  rand dv_base_reg_field rxrst;
+  rand dv_base_reg_field txrst;
+  rand dv_base_reg_field rxilvl;
+  rand dv_base_reg_field txilvl;
 
-  `uvm_object_utils(hmac_reg_key0)
+  `uvm_object_utils(uart_reg_fifo_ctrl)
 
-  function new(string       name = "hmac_reg_key0",
+  function new(string       name = "uart_reg_fifo_ctrl",
                int unsigned n_bits = 32,
                int          has_coverage = UVM_NO_COVERAGE);
     super.new(name, n_bits, has_coverage);
@@ -588,59 +846,63 @@ class hmac_reg_key0 extends dv_base_reg;
 
   virtual function void build();
     // create fields
-    key0 = dv_base_reg_field::type_id::create("key0");
-    key0.configure(
+    rxrst = dv_base_reg_field::type_id::create("rxrst");
+    rxrst.configure(
       .parent(this),
-      .size(32),
+      .size(1),
       .lsb_pos(0),
       .access("WO"),
-      .volatile(1),
-      .reset(0),
+      .volatile(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
-  endfunction : build
-
-endclass : hmac_reg_key0
-
-// Class: hmac_reg_key1
-class hmac_reg_key1 extends dv_base_reg;
-  // fields
-  rand dv_base_reg_field key1;
-
-  `uvm_object_utils(hmac_reg_key1)
-
-  function new(string       name = "hmac_reg_key1",
-               int unsigned n_bits = 32,
-               int          has_coverage = UVM_NO_COVERAGE);
-    super.new(name, n_bits, has_coverage);
-  endfunction : new
-
-  virtual function void build();
-    // create fields
-    key1 = dv_base_reg_field::type_id::create("key1");
-    key1.configure(
+    txrst = dv_base_reg_field::type_id::create("txrst");
+    txrst.configure(
       .parent(this),
-      .size(32),
-      .lsb_pos(0),
+      .size(1),
+      .lsb_pos(1),
       .access("WO"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    rxilvl = dv_base_reg_field::type_id::create("rxilvl");
+    rxilvl.configure(
+      .parent(this),
+      .size(3),
+      .lsb_pos(2),
+      .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    txilvl = dv_base_reg_field::type_id::create("txilvl");
+    txilvl.configure(
+      .parent(this),
+      .size(2),
+      .lsb_pos(5),
+      .access("RW"),
+      .volatile(1),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
   endfunction : build
 
-endclass : hmac_reg_key1
+endclass : uart_reg_fifo_ctrl
 
-// Class: hmac_reg_key2
-class hmac_reg_key2 extends dv_base_reg;
+// Class: uart_reg_fifo_status
+class uart_reg_fifo_status extends dv_base_reg;
   // fields
-  rand dv_base_reg_field key2;
+  rand dv_base_reg_field txlvl;
+  rand dv_base_reg_field rxlvl;
 
-  `uvm_object_utils(hmac_reg_key2)
+  `uvm_object_utils(uart_reg_fifo_status)
 
-  function new(string       name = "hmac_reg_key2",
+  function new(string       name = "uart_reg_fifo_status",
                int unsigned n_bits = 32,
                int          has_coverage = UVM_NO_COVERAGE);
     super.new(name, n_bits, has_coverage);
@@ -648,209 +910,41 @@ class hmac_reg_key2 extends dv_base_reg;
 
   virtual function void build();
     // create fields
-    key2 = dv_base_reg_field::type_id::create("key2");
-    key2.configure(
+    txlvl = dv_base_reg_field::type_id::create("txlvl");
+    txlvl.configure(
       .parent(this),
-      .size(32),
-      .lsb_pos(0),
-      .access("WO"),
-      .volatile(1),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-  endfunction : build
-
-endclass : hmac_reg_key2
-
-// Class: hmac_reg_key3
-class hmac_reg_key3 extends dv_base_reg;
-  // fields
-  rand dv_base_reg_field key3;
-
-  `uvm_object_utils(hmac_reg_key3)
-
-  function new(string       name = "hmac_reg_key3",
-               int unsigned n_bits = 32,
-               int          has_coverage = UVM_NO_COVERAGE);
-    super.new(name, n_bits, has_coverage);
-  endfunction : new
-
-  virtual function void build();
-    // create fields
-    key3 = dv_base_reg_field::type_id::create("key3");
-    key3.configure(
-      .parent(this),
-      .size(32),
-      .lsb_pos(0),
-      .access("WO"),
-      .volatile(1),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-  endfunction : build
-
-endclass : hmac_reg_key3
-
-// Class: hmac_reg_key4
-class hmac_reg_key4 extends dv_base_reg;
-  // fields
-  rand dv_base_reg_field key4;
-
-  `uvm_object_utils(hmac_reg_key4)
-
-  function new(string       name = "hmac_reg_key4",
-               int unsigned n_bits = 32,
-               int          has_coverage = UVM_NO_COVERAGE);
-    super.new(name, n_bits, has_coverage);
-  endfunction : new
-
-  virtual function void build();
-    // create fields
-    key4 = dv_base_reg_field::type_id::create("key4");
-    key4.configure(
-      .parent(this),
-      .size(32),
-      .lsb_pos(0),
-      .access("WO"),
-      .volatile(1),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-  endfunction : build
-
-endclass : hmac_reg_key4
-
-// Class: hmac_reg_key5
-class hmac_reg_key5 extends dv_base_reg;
-  // fields
-  rand dv_base_reg_field key5;
-
-  `uvm_object_utils(hmac_reg_key5)
-
-  function new(string       name = "hmac_reg_key5",
-               int unsigned n_bits = 32,
-               int          has_coverage = UVM_NO_COVERAGE);
-    super.new(name, n_bits, has_coverage);
-  endfunction : new
-
-  virtual function void build();
-    // create fields
-    key5 = dv_base_reg_field::type_id::create("key5");
-    key5.configure(
-      .parent(this),
-      .size(32),
-      .lsb_pos(0),
-      .access("WO"),
-      .volatile(1),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-  endfunction : build
-
-endclass : hmac_reg_key5
-
-// Class: hmac_reg_key6
-class hmac_reg_key6 extends dv_base_reg;
-  // fields
-  rand dv_base_reg_field key6;
-
-  `uvm_object_utils(hmac_reg_key6)
-
-  function new(string       name = "hmac_reg_key6",
-               int unsigned n_bits = 32,
-               int          has_coverage = UVM_NO_COVERAGE);
-    super.new(name, n_bits, has_coverage);
-  endfunction : new
-
-  virtual function void build();
-    // create fields
-    key6 = dv_base_reg_field::type_id::create("key6");
-    key6.configure(
-      .parent(this),
-      .size(32),
-      .lsb_pos(0),
-      .access("WO"),
-      .volatile(1),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-  endfunction : build
-
-endclass : hmac_reg_key6
-
-// Class: hmac_reg_key7
-class hmac_reg_key7 extends dv_base_reg;
-  // fields
-  rand dv_base_reg_field key7;
-
-  `uvm_object_utils(hmac_reg_key7)
-
-  function new(string       name = "hmac_reg_key7",
-               int unsigned n_bits = 32,
-               int          has_coverage = UVM_NO_COVERAGE);
-    super.new(name, n_bits, has_coverage);
-  endfunction : new
-
-  virtual function void build();
-    // create fields
-    key7 = dv_base_reg_field::type_id::create("key7");
-    key7.configure(
-      .parent(this),
-      .size(32),
-      .lsb_pos(0),
-      .access("WO"),
-      .volatile(1),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-  endfunction : build
-
-endclass : hmac_reg_key7
-
-// Class: hmac_reg_digest0
-class hmac_reg_digest0 extends dv_base_reg;
-  // fields
-  rand dv_base_reg_field digest0;
-
-  `uvm_object_utils(hmac_reg_digest0)
-
-  function new(string       name = "hmac_reg_digest0",
-               int unsigned n_bits = 32,
-               int          has_coverage = UVM_NO_COVERAGE);
-    super.new(name, n_bits, has_coverage);
-  endfunction : new
-
-  virtual function void build();
-    // create fields
-    digest0 = dv_base_reg_field::type_id::create("digest0");
-    digest0.configure(
-      .parent(this),
-      .size(32),
+      .size(6),
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    rxlvl = dv_base_reg_field::type_id::create("rxlvl");
+    rxlvl.configure(
+      .parent(this),
+      .size(6),
+      .lsb_pos(16),
+      .access("RO"),
+      .volatile(1),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
   endfunction : build
 
-endclass : hmac_reg_digest0
+endclass : uart_reg_fifo_status
 
-// Class: hmac_reg_digest1
-class hmac_reg_digest1 extends dv_base_reg;
+// Class: uart_reg_ovrd
+class uart_reg_ovrd extends dv_base_reg;
   // fields
-  rand dv_base_reg_field digest1;
+  rand dv_base_reg_field txen;
+  rand dv_base_reg_field txval;
 
-  `uvm_object_utils(hmac_reg_digest1)
+  `uvm_object_utils(uart_reg_ovrd)
 
-  function new(string       name = "hmac_reg_digest1",
+  function new(string       name = "uart_reg_ovrd",
                int unsigned n_bits = 32,
                int          has_coverage = UVM_NO_COVERAGE);
     super.new(name, n_bits, has_coverage);
@@ -858,29 +952,40 @@ class hmac_reg_digest1 extends dv_base_reg;
 
   virtual function void build();
     // create fields
-    digest1 = dv_base_reg_field::type_id::create("digest1");
-    digest1.configure(
+    txen = dv_base_reg_field::type_id::create("txen");
+    txen.configure(
       .parent(this),
-      .size(32),
+      .size(1),
       .lsb_pos(0),
-      .access("RO"),
-      .volatile(1),
-      .reset(0),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    txval = dv_base_reg_field::type_id::create("txval");
+    txval.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(1),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
   endfunction : build
 
-endclass : hmac_reg_digest1
+endclass : uart_reg_ovrd
 
-// Class: hmac_reg_digest2
-class hmac_reg_digest2 extends dv_base_reg;
+// Class: uart_reg_val
+class uart_reg_val extends dv_base_reg;
   // fields
-  rand dv_base_reg_field digest2;
+  rand dv_base_reg_field rx;
 
-  `uvm_object_utils(hmac_reg_digest2)
+  `uvm_object_utils(uart_reg_val)
 
-  function new(string       name = "hmac_reg_digest2",
+  function new(string       name = "uart_reg_val",
                int unsigned n_bits = 32,
                int          has_coverage = UVM_NO_COVERAGE);
     super.new(name, n_bits, has_coverage);
@@ -888,29 +993,30 @@ class hmac_reg_digest2 extends dv_base_reg;
 
   virtual function void build();
     // create fields
-    digest2 = dv_base_reg_field::type_id::create("digest2");
-    digest2.configure(
+    rx = dv_base_reg_field::type_id::create("rx");
+    rx.configure(
       .parent(this),
-      .size(32),
+      .size(16),
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
   endfunction : build
 
-endclass : hmac_reg_digest2
+endclass : uart_reg_val
 
-// Class: hmac_reg_digest3
-class hmac_reg_digest3 extends dv_base_reg;
+// Class: uart_reg_timeout_ctrl
+class uart_reg_timeout_ctrl extends dv_base_reg;
   // fields
-  rand dv_base_reg_field digest3;
+  rand dv_base_reg_field val;
+  rand dv_base_reg_field en;
 
-  `uvm_object_utils(hmac_reg_digest3)
+  `uvm_object_utils(uart_reg_timeout_ctrl)
 
-  function new(string       name = "hmac_reg_digest3",
+  function new(string       name = "uart_reg_timeout_ctrl",
                int unsigned n_bits = 32,
                int          has_coverage = UVM_NO_COVERAGE);
     super.new(name, n_bits, has_coverage);
@@ -918,251 +1024,51 @@ class hmac_reg_digest3 extends dv_base_reg;
 
   virtual function void build();
     // create fields
-    digest3 = dv_base_reg_field::type_id::create("digest3");
-    digest3.configure(
+    val = dv_base_reg_field::type_id::create("val");
+    val.configure(
       .parent(this),
-      .size(32),
+      .size(24),
       .lsb_pos(0),
-      .access("RO"),
-      .volatile(1),
-      .reset(0),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    en = dv_base_reg_field::type_id::create("en");
+    en.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(31),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
   endfunction : build
 
-endclass : hmac_reg_digest3
+endclass : uart_reg_timeout_ctrl
 
-// Class: hmac_reg_digest4
-class hmac_reg_digest4 extends dv_base_reg;
-  // fields
-  rand dv_base_reg_field digest4;
-
-  `uvm_object_utils(hmac_reg_digest4)
-
-  function new(string       name = "hmac_reg_digest4",
-               int unsigned n_bits = 32,
-               int          has_coverage = UVM_NO_COVERAGE);
-    super.new(name, n_bits, has_coverage);
-  endfunction : new
-
-  virtual function void build();
-    // create fields
-    digest4 = dv_base_reg_field::type_id::create("digest4");
-    digest4.configure(
-      .parent(this),
-      .size(32),
-      .lsb_pos(0),
-      .access("RO"),
-      .volatile(1),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-  endfunction : build
-
-endclass : hmac_reg_digest4
-
-// Class: hmac_reg_digest5
-class hmac_reg_digest5 extends dv_base_reg;
-  // fields
-  rand dv_base_reg_field digest5;
-
-  `uvm_object_utils(hmac_reg_digest5)
-
-  function new(string       name = "hmac_reg_digest5",
-               int unsigned n_bits = 32,
-               int          has_coverage = UVM_NO_COVERAGE);
-    super.new(name, n_bits, has_coverage);
-  endfunction : new
-
-  virtual function void build();
-    // create fields
-    digest5 = dv_base_reg_field::type_id::create("digest5");
-    digest5.configure(
-      .parent(this),
-      .size(32),
-      .lsb_pos(0),
-      .access("RO"),
-      .volatile(1),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-  endfunction : build
-
-endclass : hmac_reg_digest5
-
-// Class: hmac_reg_digest6
-class hmac_reg_digest6 extends dv_base_reg;
-  // fields
-  rand dv_base_reg_field digest6;
-
-  `uvm_object_utils(hmac_reg_digest6)
-
-  function new(string       name = "hmac_reg_digest6",
-               int unsigned n_bits = 32,
-               int          has_coverage = UVM_NO_COVERAGE);
-    super.new(name, n_bits, has_coverage);
-  endfunction : new
-
-  virtual function void build();
-    // create fields
-    digest6 = dv_base_reg_field::type_id::create("digest6");
-    digest6.configure(
-      .parent(this),
-      .size(32),
-      .lsb_pos(0),
-      .access("RO"),
-      .volatile(1),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-  endfunction : build
-
-endclass : hmac_reg_digest6
-
-// Class: hmac_reg_digest7
-class hmac_reg_digest7 extends dv_base_reg;
-  // fields
-  rand dv_base_reg_field digest7;
-
-  `uvm_object_utils(hmac_reg_digest7)
-
-  function new(string       name = "hmac_reg_digest7",
-               int unsigned n_bits = 32,
-               int          has_coverage = UVM_NO_COVERAGE);
-    super.new(name, n_bits, has_coverage);
-  endfunction : new
-
-  virtual function void build();
-    // create fields
-    digest7 = dv_base_reg_field::type_id::create("digest7");
-    digest7.configure(
-      .parent(this),
-      .size(32),
-      .lsb_pos(0),
-      .access("RO"),
-      .volatile(1),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-  endfunction : build
-
-endclass : hmac_reg_digest7
-
-// Class: hmac_reg_msg_length_lower
-class hmac_reg_msg_length_lower extends dv_base_reg;
-  // fields
-  rand dv_base_reg_field v;
-
-  `uvm_object_utils(hmac_reg_msg_length_lower)
-
-  function new(string       name = "hmac_reg_msg_length_lower",
-               int unsigned n_bits = 32,
-               int          has_coverage = UVM_NO_COVERAGE);
-    super.new(name, n_bits, has_coverage);
-  endfunction : new
-
-  virtual function void build();
-    // create fields
-    v = dv_base_reg_field::type_id::create("v");
-    v.configure(
-      .parent(this),
-      .size(32),
-      .lsb_pos(0),
-      .access("RO"),
-      .volatile(1),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-  endfunction : build
-
-endclass : hmac_reg_msg_length_lower
-
-// Class: hmac_reg_msg_length_upper
-class hmac_reg_msg_length_upper extends dv_base_reg;
-  // fields
-  rand dv_base_reg_field v;
-
-  `uvm_object_utils(hmac_reg_msg_length_upper)
-
-  function new(string       name = "hmac_reg_msg_length_upper",
-               int unsigned n_bits = 32,
-               int          has_coverage = UVM_NO_COVERAGE);
-    super.new(name, n_bits, has_coverage);
-  endfunction : new
-
-  virtual function void build();
-    // create fields
-    v = dv_base_reg_field::type_id::create("v");
-    v.configure(
-      .parent(this),
-      .size(32),
-      .lsb_pos(0),
-      .access("RO"),
-      .volatile(1),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-  endfunction : build
-
-endclass : hmac_reg_msg_length_upper
-
-// Class: hmac_mem_msg_fifo
-class hmac_mem_msg_fifo extends dv_base_mem;
-
-  `uvm_object_utils(hmac_mem_msg_fifo)
-
-  function new(string           name = "hmac_mem_msg_fifo",
-               longint unsigned size = 512,
-               int unsigned     n_bits = 32,
-               string           access = "RW"/* TODO:"WO"*/,
-               int              has_coverage = UVM_NO_COVERAGE);
-    super.new(name, size, n_bits, access, has_coverage);
-  endfunction : new
-
-endclass : hmac_mem_msg_fifo
-
-// Class: hmac_reg_block
-class hmac_reg_block extends dv_base_reg_block;
+// Class: uart_reg_block
+class uart_reg_block extends dv_base_reg_block;
   // registers
-  rand hmac_reg_intr_state intr_state;
-  rand hmac_reg_intr_enable intr_enable;
-  rand hmac_reg_intr_test intr_test;
-  rand hmac_reg_cfg cfg;
-  rand hmac_reg_cmd cmd;
-  rand hmac_reg_status status;
-  rand hmac_reg_err_code err_code;
-  rand hmac_reg_wipe_secret wipe_secret;
-  rand hmac_reg_key0 key0;
-  rand hmac_reg_key1 key1;
-  rand hmac_reg_key2 key2;
-  rand hmac_reg_key3 key3;
-  rand hmac_reg_key4 key4;
-  rand hmac_reg_key5 key5;
-  rand hmac_reg_key6 key6;
-  rand hmac_reg_key7 key7;
-  rand hmac_reg_digest0 digest0;
-  rand hmac_reg_digest1 digest1;
-  rand hmac_reg_digest2 digest2;
-  rand hmac_reg_digest3 digest3;
-  rand hmac_reg_digest4 digest4;
-  rand hmac_reg_digest5 digest5;
-  rand hmac_reg_digest6 digest6;
-  rand hmac_reg_digest7 digest7;
-  rand hmac_reg_msg_length_lower msg_length_lower;
-  rand hmac_reg_msg_length_upper msg_length_upper;
-  // memories
-  rand hmac_mem_msg_fifo msg_fifo;
+  rand uart_reg_intr_state intr_state;
+  rand uart_reg_intr_enable intr_enable;
+  rand uart_reg_intr_test intr_test;
+  rand uart_reg_ctrl ctrl;
+  rand uart_reg_status status;
+  rand uart_reg_rdata rdata;
+  rand uart_reg_wdata wdata;
+  rand uart_reg_fifo_ctrl fifo_ctrl;
+  rand uart_reg_fifo_status fifo_status;
+  rand uart_reg_ovrd ovrd;
+  rand uart_reg_val val;
+  rand uart_reg_timeout_ctrl timeout_ctrl;
 
-  `uvm_object_utils(hmac_reg_block)
+  `uvm_object_utils(uart_reg_block)
 
-  function new(string name = "hmac_reg_block",
+  function new(string name = "uart_reg_block",
                int    has_coverage = UVM_NO_COVERAGE);
     super.new(name, has_coverage);
   endfunction : new
@@ -1175,172 +1081,81 @@ class hmac_reg_block extends dv_base_reg_block;
                                   .endian(UVM_LITTLE_ENDIAN));
 
     // create registers
-    intr_state = hmac_reg_intr_state::type_id::create("intr_state");
+    intr_state = uart_reg_intr_state::type_id::create("intr_state");
     intr_state.configure(.blk_parent(this));
     intr_state.build();
     default_map.add_reg(.rg(intr_state),
                         .offset(32'h0),
                         .rights("RW"));
-    intr_enable = hmac_reg_intr_enable::type_id::create("intr_enable");
+    intr_enable = uart_reg_intr_enable::type_id::create("intr_enable");
     intr_enable.configure(.blk_parent(this));
     intr_enable.build();
     default_map.add_reg(.rg(intr_enable),
                         .offset(32'h4),
                         .rights("RW"));
-    intr_test = hmac_reg_intr_test::type_id::create("intr_test");
+    intr_test = uart_reg_intr_test::type_id::create("intr_test");
     intr_test.configure(.blk_parent(this));
     intr_test.build();
     default_map.add_reg(.rg(intr_test),
                         .offset(32'h8),
                         .rights("WO"));
-    cfg = hmac_reg_cfg::type_id::create("cfg");
-    cfg.configure(.blk_parent(this));
-    cfg.build();
-    default_map.add_reg(.rg(cfg),
+    ctrl = uart_reg_ctrl::type_id::create("ctrl");
+    ctrl.configure(.blk_parent(this));
+    ctrl.build();
+    default_map.add_reg(.rg(ctrl),
                         .offset(32'hc),
                         .rights("RW"));
-    cmd = hmac_reg_cmd::type_id::create("cmd");
-    cmd.configure(.blk_parent(this));
-    cmd.build();
-    default_map.add_reg(.rg(cmd),
-                        .offset(32'h10),
-                        .rights("RW"));
-    status = hmac_reg_status::type_id::create("status");
+    status = uart_reg_status::type_id::create("status");
     status.configure(.blk_parent(this));
     status.build();
     default_map.add_reg(.rg(status),
+                        .offset(32'h10),
+                        .rights("RO"));
+    rdata = uart_reg_rdata::type_id::create("rdata");
+    rdata.configure(.blk_parent(this));
+    rdata.build();
+    default_map.add_reg(.rg(rdata),
                         .offset(32'h14),
                         .rights("RO"));
-    err_code = hmac_reg_err_code::type_id::create("err_code");
-    err_code.configure(.blk_parent(this));
-    err_code.build();
-    default_map.add_reg(.rg(err_code),
+    wdata = uart_reg_wdata::type_id::create("wdata");
+    wdata.configure(.blk_parent(this));
+    wdata.build();
+    default_map.add_reg(.rg(wdata),
                         .offset(32'h18),
-                        .rights("RO"));
-    wipe_secret = hmac_reg_wipe_secret::type_id::create("wipe_secret");
-    wipe_secret.configure(.blk_parent(this));
-    wipe_secret.build();
-    default_map.add_reg(.rg(wipe_secret),
+                        .rights("WO"));
+    fifo_ctrl = uart_reg_fifo_ctrl::type_id::create("fifo_ctrl");
+    fifo_ctrl.configure(.blk_parent(this));
+    fifo_ctrl.build();
+    default_map.add_reg(.rg(fifo_ctrl),
                         .offset(32'h1c),
-                        .rights("WO"));
-    key0 = hmac_reg_key0::type_id::create("key0");
-    key0.configure(.blk_parent(this));
-    key0.build();
-    default_map.add_reg(.rg(key0),
+                        .rights("RW"));
+    fifo_status = uart_reg_fifo_status::type_id::create("fifo_status");
+    fifo_status.configure(.blk_parent(this));
+    fifo_status.build();
+    default_map.add_reg(.rg(fifo_status),
                         .offset(32'h20),
-                        .rights("WO"));
-    key1 = hmac_reg_key1::type_id::create("key1");
-    key1.configure(.blk_parent(this));
-    key1.build();
-    default_map.add_reg(.rg(key1),
+                        .rights("RO"));
+    ovrd = uart_reg_ovrd::type_id::create("ovrd");
+    ovrd.configure(.blk_parent(this));
+    ovrd.build();
+    default_map.add_reg(.rg(ovrd),
                         .offset(32'h24),
-                        .rights("WO"));
-    key2 = hmac_reg_key2::type_id::create("key2");
-    key2.configure(.blk_parent(this));
-    key2.build();
-    default_map.add_reg(.rg(key2),
+                        .rights("RW"));
+    val = uart_reg_val::type_id::create("val");
+    val.configure(.blk_parent(this));
+    val.build();
+    default_map.add_reg(.rg(val),
                         .offset(32'h28),
-                        .rights("WO"));
-    key3 = hmac_reg_key3::type_id::create("key3");
-    key3.configure(.blk_parent(this));
-    key3.build();
-    default_map.add_reg(.rg(key3),
+                        .rights("RO"));
+    timeout_ctrl = uart_reg_timeout_ctrl::type_id::create("timeout_ctrl");
+    timeout_ctrl.configure(.blk_parent(this));
+    timeout_ctrl.build();
+    default_map.add_reg(.rg(timeout_ctrl),
                         .offset(32'h2c),
-                        .rights("WO"));
-    key4 = hmac_reg_key4::type_id::create("key4");
-    key4.configure(.blk_parent(this));
-    key4.build();
-    default_map.add_reg(.rg(key4),
-                        .offset(32'h30),
-                        .rights("WO"));
-    key5 = hmac_reg_key5::type_id::create("key5");
-    key5.configure(.blk_parent(this));
-    key5.build();
-    default_map.add_reg(.rg(key5),
-                        .offset(32'h34),
-                        .rights("WO"));
-    key6 = hmac_reg_key6::type_id::create("key6");
-    key6.configure(.blk_parent(this));
-    key6.build();
-    default_map.add_reg(.rg(key6),
-                        .offset(32'h38),
-                        .rights("WO"));
-    key7 = hmac_reg_key7::type_id::create("key7");
-    key7.configure(.blk_parent(this));
-    key7.build();
-    default_map.add_reg(.rg(key7),
-                        .offset(32'h3c),
-                        .rights("WO"));
-    digest0 = hmac_reg_digest0::type_id::create("digest0");
-    digest0.configure(.blk_parent(this));
-    digest0.build();
-    default_map.add_reg(.rg(digest0),
-                        .offset(32'h40),
-                        .rights("RO"));
-    digest1 = hmac_reg_digest1::type_id::create("digest1");
-    digest1.configure(.blk_parent(this));
-    digest1.build();
-    default_map.add_reg(.rg(digest1),
-                        .offset(32'h44),
-                        .rights("RO"));
-    digest2 = hmac_reg_digest2::type_id::create("digest2");
-    digest2.configure(.blk_parent(this));
-    digest2.build();
-    default_map.add_reg(.rg(digest2),
-                        .offset(32'h48),
-                        .rights("RO"));
-    digest3 = hmac_reg_digest3::type_id::create("digest3");
-    digest3.configure(.blk_parent(this));
-    digest3.build();
-    default_map.add_reg(.rg(digest3),
-                        .offset(32'h4c),
-                        .rights("RO"));
-    digest4 = hmac_reg_digest4::type_id::create("digest4");
-    digest4.configure(.blk_parent(this));
-    digest4.build();
-    default_map.add_reg(.rg(digest4),
-                        .offset(32'h50),
-                        .rights("RO"));
-    digest5 = hmac_reg_digest5::type_id::create("digest5");
-    digest5.configure(.blk_parent(this));
-    digest5.build();
-    default_map.add_reg(.rg(digest5),
-                        .offset(32'h54),
-                        .rights("RO"));
-    digest6 = hmac_reg_digest6::type_id::create("digest6");
-    digest6.configure(.blk_parent(this));
-    digest6.build();
-    default_map.add_reg(.rg(digest6),
-                        .offset(32'h58),
-                        .rights("RO"));
-    digest7 = hmac_reg_digest7::type_id::create("digest7");
-    digest7.configure(.blk_parent(this));
-    digest7.build();
-    default_map.add_reg(.rg(digest7),
-                        .offset(32'h5c),
-                        .rights("RO"));
-    msg_length_lower = hmac_reg_msg_length_lower::type_id::create("msg_length_lower");
-    msg_length_lower.configure(.blk_parent(this));
-    msg_length_lower.build();
-    default_map.add_reg(.rg(msg_length_lower),
-                        .offset(32'h60),
-                        .rights("RO"));
-    msg_length_upper = hmac_reg_msg_length_upper::type_id::create("msg_length_upper");
-    msg_length_upper.configure(.blk_parent(this));
-    msg_length_upper.build();
-    default_map.add_reg(.rg(msg_length_upper),
-                        .offset(32'h64),
-                        .rights("RO"));
-
-    // create memories
-    msg_fifo = hmac_mem_msg_fifo::type_id::create("msg_fifo");
-    msg_fifo.configure(.parent(this));
-    default_map.add_mem(.mem(msg_fifo),
-                        .offset(32'h800),
-                        .rights("WO"));
+                        .rights("RW"));
   endfunction : build
 
-endclass : hmac_reg_block
+endclass : uart_reg_block
 // Block: gpio
 // Class: gpio_reg_intr_state
 class gpio_reg_intr_state extends dv_base_reg;
@@ -1364,7 +1179,7 @@ class gpio_reg_intr_state extends dv_base_reg;
       .lsb_pos(0),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1394,7 +1209,7 @@ class gpio_reg_intr_enable extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1424,7 +1239,7 @@ class gpio_reg_intr_test extends dv_base_reg;
       .lsb_pos(0),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1454,7 +1269,7 @@ class gpio_reg_data_in extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1484,7 +1299,7 @@ class gpio_reg_direct_out extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1515,7 +1330,7 @@ class gpio_reg_masked_out_lower extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1526,7 +1341,7 @@ class gpio_reg_masked_out_lower extends dv_base_reg;
       .lsb_pos(16),
       .access("WO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1557,7 +1372,7 @@ class gpio_reg_masked_out_upper extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1568,7 +1383,7 @@ class gpio_reg_masked_out_upper extends dv_base_reg;
       .lsb_pos(16),
       .access("WO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1598,7 +1413,7 @@ class gpio_reg_direct_oe extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1629,7 +1444,7 @@ class gpio_reg_masked_oe_lower extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1640,7 +1455,7 @@ class gpio_reg_masked_oe_lower extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1671,7 +1486,7 @@ class gpio_reg_masked_oe_upper extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1682,7 +1497,7 @@ class gpio_reg_masked_oe_upper extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1712,7 +1527,7 @@ class gpio_reg_intr_ctrl_en_rising extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1742,7 +1557,7 @@ class gpio_reg_intr_ctrl_en_falling extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1772,7 +1587,7 @@ class gpio_reg_intr_ctrl_en_lvlhigh extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1802,7 +1617,7 @@ class gpio_reg_intr_ctrl_en_lvllow extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1832,7 +1647,7 @@ class gpio_reg_ctrl_en_input_filter extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -1967,6 +1782,893 @@ class gpio_reg_block extends dv_base_reg_block;
   endfunction : build
 
 endclass : gpio_reg_block
+// Block: spi_device
+// Class: spi_device_reg_intr_state
+class spi_device_reg_intr_state extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field rxf;
+  rand dv_base_reg_field rxlvl;
+  rand dv_base_reg_field txlvl;
+  rand dv_base_reg_field rxerr;
+  rand dv_base_reg_field rxoverflow;
+  rand dv_base_reg_field txunderflow;
+
+  `uvm_object_utils(spi_device_reg_intr_state)
+
+  function new(string       name = "spi_device_reg_intr_state",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    rxf = dv_base_reg_field::type_id::create("rxf");
+    rxf.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(0),
+      .access("W1C"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    rxlvl = dv_base_reg_field::type_id::create("rxlvl");
+    rxlvl.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(1),
+      .access("W1C"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    txlvl = dv_base_reg_field::type_id::create("txlvl");
+    txlvl.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(2),
+      .access("W1C"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    rxerr = dv_base_reg_field::type_id::create("rxerr");
+    rxerr.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(3),
+      .access("W1C"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    rxoverflow = dv_base_reg_field::type_id::create("rxoverflow");
+    rxoverflow.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(4),
+      .access("W1C"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    txunderflow = dv_base_reg_field::type_id::create("txunderflow");
+    txunderflow.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(5),
+      .access("W1C"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : spi_device_reg_intr_state
+
+// Class: spi_device_reg_intr_enable
+class spi_device_reg_intr_enable extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field rxf;
+  rand dv_base_reg_field rxlvl;
+  rand dv_base_reg_field txlvl;
+  rand dv_base_reg_field rxerr;
+  rand dv_base_reg_field rxoverflow;
+  rand dv_base_reg_field txunderflow;
+
+  `uvm_object_utils(spi_device_reg_intr_enable)
+
+  function new(string       name = "spi_device_reg_intr_enable",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    rxf = dv_base_reg_field::type_id::create("rxf");
+    rxf.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(0),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    rxlvl = dv_base_reg_field::type_id::create("rxlvl");
+    rxlvl.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(1),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    txlvl = dv_base_reg_field::type_id::create("txlvl");
+    txlvl.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(2),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    rxerr = dv_base_reg_field::type_id::create("rxerr");
+    rxerr.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(3),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    rxoverflow = dv_base_reg_field::type_id::create("rxoverflow");
+    rxoverflow.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(4),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    txunderflow = dv_base_reg_field::type_id::create("txunderflow");
+    txunderflow.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(5),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : spi_device_reg_intr_enable
+
+// Class: spi_device_reg_intr_test
+class spi_device_reg_intr_test extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field rxf;
+  rand dv_base_reg_field rxlvl;
+  rand dv_base_reg_field txlvl;
+  rand dv_base_reg_field rxerr;
+  rand dv_base_reg_field rxoverflow;
+  rand dv_base_reg_field txunderflow;
+
+  `uvm_object_utils(spi_device_reg_intr_test)
+
+  function new(string       name = "spi_device_reg_intr_test",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    rxf = dv_base_reg_field::type_id::create("rxf");
+    rxf.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(0),
+      .access("WO"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    rxlvl = dv_base_reg_field::type_id::create("rxlvl");
+    rxlvl.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(1),
+      .access("WO"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    txlvl = dv_base_reg_field::type_id::create("txlvl");
+    txlvl.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(2),
+      .access("WO"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    rxerr = dv_base_reg_field::type_id::create("rxerr");
+    rxerr.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(3),
+      .access("WO"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    rxoverflow = dv_base_reg_field::type_id::create("rxoverflow");
+    rxoverflow.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(4),
+      .access("WO"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    txunderflow = dv_base_reg_field::type_id::create("txunderflow");
+    txunderflow.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(5),
+      .access("WO"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : spi_device_reg_intr_test
+
+// Class: spi_device_reg_control
+class spi_device_reg_control extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field abort;
+  rand dv_base_reg_field mode;
+  rand dv_base_reg_field rst_txfifo;
+  rand dv_base_reg_field rst_rxfifo;
+
+  `uvm_object_utils(spi_device_reg_control)
+
+  function new(string       name = "spi_device_reg_control",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    abort = dv_base_reg_field::type_id::create("abort");
+    abort.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(0),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    mode = dv_base_reg_field::type_id::create("mode");
+    mode.configure(
+      .parent(this),
+      .size(2),
+      .lsb_pos(4),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    rst_txfifo = dv_base_reg_field::type_id::create("rst_txfifo");
+    rst_txfifo.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(16),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    rst_rxfifo = dv_base_reg_field::type_id::create("rst_rxfifo");
+    rst_rxfifo.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(17),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : spi_device_reg_control
+
+// Class: spi_device_reg_cfg
+class spi_device_reg_cfg extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field cpol;
+  rand dv_base_reg_field cpha;
+  rand dv_base_reg_field tx_order;
+  rand dv_base_reg_field rx_order;
+  rand dv_base_reg_field timer_v;
+
+  `uvm_object_utils(spi_device_reg_cfg)
+
+  function new(string       name = "spi_device_reg_cfg",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    cpol = dv_base_reg_field::type_id::create("cpol");
+    cpol.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(0),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    cpha = dv_base_reg_field::type_id::create("cpha");
+    cpha.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(1),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    tx_order = dv_base_reg_field::type_id::create("tx_order");
+    tx_order.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(2),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    rx_order = dv_base_reg_field::type_id::create("rx_order");
+    rx_order.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(3),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    timer_v = dv_base_reg_field::type_id::create("timer_v");
+    timer_v.configure(
+      .parent(this),
+      .size(8),
+      .lsb_pos(8),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h7f),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : spi_device_reg_cfg
+
+// Class: spi_device_reg_fifo_level
+class spi_device_reg_fifo_level extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field rxlvl;
+  rand dv_base_reg_field txlvl;
+
+  `uvm_object_utils(spi_device_reg_fifo_level)
+
+  function new(string       name = "spi_device_reg_fifo_level",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    rxlvl = dv_base_reg_field::type_id::create("rxlvl");
+    rxlvl.configure(
+      .parent(this),
+      .size(16),
+      .lsb_pos(0),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h80),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    txlvl = dv_base_reg_field::type_id::create("txlvl");
+    txlvl.configure(
+      .parent(this),
+      .size(16),
+      .lsb_pos(16),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : spi_device_reg_fifo_level
+
+// Class: spi_device_reg_async_fifo_level
+class spi_device_reg_async_fifo_level extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field rxlvl;
+  rand dv_base_reg_field txlvl;
+
+  `uvm_object_utils(spi_device_reg_async_fifo_level)
+
+  function new(string       name = "spi_device_reg_async_fifo_level",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    rxlvl = dv_base_reg_field::type_id::create("rxlvl");
+    rxlvl.configure(
+      .parent(this),
+      .size(8),
+      .lsb_pos(0),
+      .access("RO"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    txlvl = dv_base_reg_field::type_id::create("txlvl");
+    txlvl.configure(
+      .parent(this),
+      .size(8),
+      .lsb_pos(16),
+      .access("RO"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : spi_device_reg_async_fifo_level
+
+// Class: spi_device_reg_status
+class spi_device_reg_status extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field rxf_full;
+  rand dv_base_reg_field rxf_empty;
+  rand dv_base_reg_field txf_full;
+  rand dv_base_reg_field txf_empty;
+  rand dv_base_reg_field abort_done;
+  rand dv_base_reg_field csb;
+
+  `uvm_object_utils(spi_device_reg_status)
+
+  function new(string       name = "spi_device_reg_status",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    rxf_full = dv_base_reg_field::type_id::create("rxf_full");
+    rxf_full.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(0),
+      .access("RO"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    rxf_empty = dv_base_reg_field::type_id::create("rxf_empty");
+    rxf_empty.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(1),
+      .access("RO"),
+      .volatile(1),
+      .reset(32'h1),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    txf_full = dv_base_reg_field::type_id::create("txf_full");
+    txf_full.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(2),
+      .access("RO"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    txf_empty = dv_base_reg_field::type_id::create("txf_empty");
+    txf_empty.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(3),
+      .access("RO"),
+      .volatile(1),
+      .reset(32'h1),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    abort_done = dv_base_reg_field::type_id::create("abort_done");
+    abort_done.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(4),
+      .access("RO"),
+      .volatile(1),
+      .reset(32'h1),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    csb = dv_base_reg_field::type_id::create("csb");
+    csb.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(5),
+      .access("RO"),
+      .volatile(1),
+      .reset(32'h1),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : spi_device_reg_status
+
+// Class: spi_device_reg_rxf_ptr
+class spi_device_reg_rxf_ptr extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field rptr;
+  rand dv_base_reg_field wptr;
+
+  `uvm_object_utils(spi_device_reg_rxf_ptr)
+
+  function new(string       name = "spi_device_reg_rxf_ptr",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    rptr = dv_base_reg_field::type_id::create("rptr");
+    rptr.configure(
+      .parent(this),
+      .size(16),
+      .lsb_pos(0),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    wptr = dv_base_reg_field::type_id::create("wptr");
+    wptr.configure(
+      .parent(this),
+      .size(16),
+      .lsb_pos(16),
+      .access("RO"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : spi_device_reg_rxf_ptr
+
+// Class: spi_device_reg_txf_ptr
+class spi_device_reg_txf_ptr extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field rptr;
+  rand dv_base_reg_field wptr;
+
+  `uvm_object_utils(spi_device_reg_txf_ptr)
+
+  function new(string       name = "spi_device_reg_txf_ptr",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    rptr = dv_base_reg_field::type_id::create("rptr");
+    rptr.configure(
+      .parent(this),
+      .size(16),
+      .lsb_pos(0),
+      .access("RO"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    wptr = dv_base_reg_field::type_id::create("wptr");
+    wptr.configure(
+      .parent(this),
+      .size(16),
+      .lsb_pos(16),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : spi_device_reg_txf_ptr
+
+// Class: spi_device_reg_rxf_addr
+class spi_device_reg_rxf_addr extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field base;
+  rand dv_base_reg_field limit;
+
+  `uvm_object_utils(spi_device_reg_rxf_addr)
+
+  function new(string       name = "spi_device_reg_rxf_addr",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    base = dv_base_reg_field::type_id::create("base");
+    base.configure(
+      .parent(this),
+      .size(16),
+      .lsb_pos(0),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    limit = dv_base_reg_field::type_id::create("limit");
+    limit.configure(
+      .parent(this),
+      .size(16),
+      .lsb_pos(16),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h1fc),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : spi_device_reg_rxf_addr
+
+// Class: spi_device_reg_txf_addr
+class spi_device_reg_txf_addr extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field base;
+  rand dv_base_reg_field limit;
+
+  `uvm_object_utils(spi_device_reg_txf_addr)
+
+  function new(string       name = "spi_device_reg_txf_addr",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    base = dv_base_reg_field::type_id::create("base");
+    base.configure(
+      .parent(this),
+      .size(16),
+      .lsb_pos(0),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h200),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    limit = dv_base_reg_field::type_id::create("limit");
+    limit.configure(
+      .parent(this),
+      .size(16),
+      .lsb_pos(16),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h3fc),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : spi_device_reg_txf_addr
+
+// Class: spi_device_mem_buffer
+class spi_device_mem_buffer extends dv_base_mem;
+
+  `uvm_object_utils(spi_device_mem_buffer)
+
+  function new(string           name = "spi_device_mem_buffer",
+               longint unsigned size = 512,
+               int unsigned     n_bits = 32,
+               string           access = "RW"/* TODO:"RW"*/,
+               int              has_coverage = UVM_NO_COVERAGE);
+    super.new(name, size, n_bits, access, has_coverage);
+  endfunction : new
+
+endclass : spi_device_mem_buffer
+
+// Class: spi_device_reg_block
+class spi_device_reg_block extends dv_base_reg_block;
+  // registers
+  rand spi_device_reg_intr_state intr_state;
+  rand spi_device_reg_intr_enable intr_enable;
+  rand spi_device_reg_intr_test intr_test;
+  rand spi_device_reg_control control;
+  rand spi_device_reg_cfg cfg;
+  rand spi_device_reg_fifo_level fifo_level;
+  rand spi_device_reg_async_fifo_level async_fifo_level;
+  rand spi_device_reg_status status;
+  rand spi_device_reg_rxf_ptr rxf_ptr;
+  rand spi_device_reg_txf_ptr txf_ptr;
+  rand spi_device_reg_rxf_addr rxf_addr;
+  rand spi_device_reg_txf_addr txf_addr;
+  // memories
+  rand spi_device_mem_buffer buffer;
+
+  `uvm_object_utils(spi_device_reg_block)
+
+  function new(string name = "spi_device_reg_block",
+               int    has_coverage = UVM_NO_COVERAGE);
+    super.new(name, has_coverage);
+  endfunction : new
+
+  virtual function void build(uvm_reg_addr_t base_addr);
+    // create default map
+    this.default_map = create_map(.name("default_map"),
+                                  .base_addr(base_addr),
+                                  .n_bytes(4),
+                                  .endian(UVM_LITTLE_ENDIAN));
+
+    // create registers
+    intr_state = spi_device_reg_intr_state::type_id::create("intr_state");
+    intr_state.configure(.blk_parent(this));
+    intr_state.build();
+    default_map.add_reg(.rg(intr_state),
+                        .offset(32'h0),
+                        .rights("RW"));
+    intr_enable = spi_device_reg_intr_enable::type_id::create("intr_enable");
+    intr_enable.configure(.blk_parent(this));
+    intr_enable.build();
+    default_map.add_reg(.rg(intr_enable),
+                        .offset(32'h4),
+                        .rights("RW"));
+    intr_test = spi_device_reg_intr_test::type_id::create("intr_test");
+    intr_test.configure(.blk_parent(this));
+    intr_test.build();
+    default_map.add_reg(.rg(intr_test),
+                        .offset(32'h8),
+                        .rights("WO"));
+    control = spi_device_reg_control::type_id::create("control");
+    control.configure(.blk_parent(this));
+    control.build();
+    default_map.add_reg(.rg(control),
+                        .offset(32'hc),
+                        .rights("RW"));
+    cfg = spi_device_reg_cfg::type_id::create("cfg");
+    cfg.configure(.blk_parent(this));
+    cfg.build();
+    default_map.add_reg(.rg(cfg),
+                        .offset(32'h10),
+                        .rights("RW"));
+    fifo_level = spi_device_reg_fifo_level::type_id::create("fifo_level");
+    fifo_level.configure(.blk_parent(this));
+    fifo_level.build();
+    default_map.add_reg(.rg(fifo_level),
+                        .offset(32'h14),
+                        .rights("RW"));
+    async_fifo_level = spi_device_reg_async_fifo_level::type_id::create("async_fifo_level");
+    async_fifo_level.configure(.blk_parent(this));
+    async_fifo_level.build();
+    default_map.add_reg(.rg(async_fifo_level),
+                        .offset(32'h18),
+                        .rights("RO"));
+    status = spi_device_reg_status::type_id::create("status");
+    status.configure(.blk_parent(this));
+    status.build();
+    default_map.add_reg(.rg(status),
+                        .offset(32'h1c),
+                        .rights("RO"));
+    rxf_ptr = spi_device_reg_rxf_ptr::type_id::create("rxf_ptr");
+    rxf_ptr.configure(.blk_parent(this));
+    rxf_ptr.build();
+    default_map.add_reg(.rg(rxf_ptr),
+                        .offset(32'h20),
+                        .rights("RW"));
+    txf_ptr = spi_device_reg_txf_ptr::type_id::create("txf_ptr");
+    txf_ptr.configure(.blk_parent(this));
+    txf_ptr.build();
+    default_map.add_reg(.rg(txf_ptr),
+                        .offset(32'h24),
+                        .rights("RW"));
+    rxf_addr = spi_device_reg_rxf_addr::type_id::create("rxf_addr");
+    rxf_addr.configure(.blk_parent(this));
+    rxf_addr.build();
+    default_map.add_reg(.rg(rxf_addr),
+                        .offset(32'h28),
+                        .rights("RW"));
+    txf_addr = spi_device_reg_txf_addr::type_id::create("txf_addr");
+    txf_addr.configure(.blk_parent(this));
+    txf_addr.build();
+    default_map.add_reg(.rg(txf_addr),
+                        .offset(32'h2c),
+                        .rights("RW"));
+
+    // create memories
+    buffer = spi_device_mem_buffer::type_id::create("buffer");
+    buffer.configure(.parent(this));
+    default_map.add_mem(.mem(buffer),
+                        .offset(32'h800),
+                        .rights("RW"));
+  endfunction : build
+
+endclass : spi_device_reg_block
 // Block: flash_ctrl
 // Class: flash_ctrl_reg_intr_state
 class flash_ctrl_reg_intr_state extends dv_base_reg;
@@ -1995,7 +2697,7 @@ class flash_ctrl_reg_intr_state extends dv_base_reg;
       .lsb_pos(0),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2006,7 +2708,7 @@ class flash_ctrl_reg_intr_state extends dv_base_reg;
       .lsb_pos(1),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2017,7 +2719,7 @@ class flash_ctrl_reg_intr_state extends dv_base_reg;
       .lsb_pos(2),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2028,7 +2730,7 @@ class flash_ctrl_reg_intr_state extends dv_base_reg;
       .lsb_pos(3),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2039,7 +2741,7 @@ class flash_ctrl_reg_intr_state extends dv_base_reg;
       .lsb_pos(4),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2050,7 +2752,7 @@ class flash_ctrl_reg_intr_state extends dv_base_reg;
       .lsb_pos(5),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2085,7 +2787,7 @@ class flash_ctrl_reg_intr_enable extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2096,7 +2798,7 @@ class flash_ctrl_reg_intr_enable extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2107,7 +2809,7 @@ class flash_ctrl_reg_intr_enable extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2118,7 +2820,7 @@ class flash_ctrl_reg_intr_enable extends dv_base_reg;
       .lsb_pos(3),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2129,7 +2831,7 @@ class flash_ctrl_reg_intr_enable extends dv_base_reg;
       .lsb_pos(4),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2140,7 +2842,7 @@ class flash_ctrl_reg_intr_enable extends dv_base_reg;
       .lsb_pos(5),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2175,7 +2877,7 @@ class flash_ctrl_reg_intr_test extends dv_base_reg;
       .lsb_pos(0),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2186,7 +2888,7 @@ class flash_ctrl_reg_intr_test extends dv_base_reg;
       .lsb_pos(1),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2197,7 +2899,7 @@ class flash_ctrl_reg_intr_test extends dv_base_reg;
       .lsb_pos(2),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2208,7 +2910,7 @@ class flash_ctrl_reg_intr_test extends dv_base_reg;
       .lsb_pos(3),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2219,7 +2921,7 @@ class flash_ctrl_reg_intr_test extends dv_base_reg;
       .lsb_pos(4),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2230,7 +2932,7 @@ class flash_ctrl_reg_intr_test extends dv_base_reg;
       .lsb_pos(5),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2264,7 +2966,7 @@ class flash_ctrl_reg_control extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2275,7 +2977,7 @@ class flash_ctrl_reg_control extends dv_base_reg;
       .lsb_pos(4),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2286,7 +2988,7 @@ class flash_ctrl_reg_control extends dv_base_reg;
       .lsb_pos(6),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2297,7 +2999,7 @@ class flash_ctrl_reg_control extends dv_base_reg;
       .lsb_pos(7),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2308,7 +3010,7 @@ class flash_ctrl_reg_control extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2338,7 +3040,7 @@ class flash_ctrl_reg_addr extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2375,7 +3077,7 @@ class flash_ctrl_reg_region_cfg_regwen extends dv_base_reg;
       .lsb_pos(0),
       .access("W0C"),
       .volatile(1),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2386,7 +3088,7 @@ class flash_ctrl_reg_region_cfg_regwen extends dv_base_reg;
       .lsb_pos(1),
       .access("W0C"),
       .volatile(1),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2397,7 +3099,7 @@ class flash_ctrl_reg_region_cfg_regwen extends dv_base_reg;
       .lsb_pos(2),
       .access("W0C"),
       .volatile(1),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2408,7 +3110,7 @@ class flash_ctrl_reg_region_cfg_regwen extends dv_base_reg;
       .lsb_pos(3),
       .access("W0C"),
       .volatile(1),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2419,7 +3121,7 @@ class flash_ctrl_reg_region_cfg_regwen extends dv_base_reg;
       .lsb_pos(4),
       .access("W0C"),
       .volatile(1),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2430,7 +3132,7 @@ class flash_ctrl_reg_region_cfg_regwen extends dv_base_reg;
       .lsb_pos(5),
       .access("W0C"),
       .volatile(1),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2441,7 +3143,7 @@ class flash_ctrl_reg_region_cfg_regwen extends dv_base_reg;
       .lsb_pos(6),
       .access("W0C"),
       .volatile(1),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2452,7 +3154,7 @@ class flash_ctrl_reg_region_cfg_regwen extends dv_base_reg;
       .lsb_pos(7),
       .access("W0C"),
       .volatile(1),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2487,7 +3189,7 @@ class flash_ctrl_reg_mp_region_cfg0 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2498,7 +3200,7 @@ class flash_ctrl_reg_mp_region_cfg0 extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2509,7 +3211,7 @@ class flash_ctrl_reg_mp_region_cfg0 extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2520,7 +3222,7 @@ class flash_ctrl_reg_mp_region_cfg0 extends dv_base_reg;
       .lsb_pos(3),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2531,7 +3233,7 @@ class flash_ctrl_reg_mp_region_cfg0 extends dv_base_reg;
       .lsb_pos(4),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2542,7 +3244,7 @@ class flash_ctrl_reg_mp_region_cfg0 extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2577,7 +3279,7 @@ class flash_ctrl_reg_mp_region_cfg1 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2588,7 +3290,7 @@ class flash_ctrl_reg_mp_region_cfg1 extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2599,7 +3301,7 @@ class flash_ctrl_reg_mp_region_cfg1 extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2610,7 +3312,7 @@ class flash_ctrl_reg_mp_region_cfg1 extends dv_base_reg;
       .lsb_pos(3),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2621,7 +3323,7 @@ class flash_ctrl_reg_mp_region_cfg1 extends dv_base_reg;
       .lsb_pos(4),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2632,7 +3334,7 @@ class flash_ctrl_reg_mp_region_cfg1 extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2667,7 +3369,7 @@ class flash_ctrl_reg_mp_region_cfg2 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2678,7 +3380,7 @@ class flash_ctrl_reg_mp_region_cfg2 extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2689,7 +3391,7 @@ class flash_ctrl_reg_mp_region_cfg2 extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2700,7 +3402,7 @@ class flash_ctrl_reg_mp_region_cfg2 extends dv_base_reg;
       .lsb_pos(3),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2711,7 +3413,7 @@ class flash_ctrl_reg_mp_region_cfg2 extends dv_base_reg;
       .lsb_pos(4),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2722,7 +3424,7 @@ class flash_ctrl_reg_mp_region_cfg2 extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2757,7 +3459,7 @@ class flash_ctrl_reg_mp_region_cfg3 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2768,7 +3470,7 @@ class flash_ctrl_reg_mp_region_cfg3 extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2779,7 +3481,7 @@ class flash_ctrl_reg_mp_region_cfg3 extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2790,7 +3492,7 @@ class flash_ctrl_reg_mp_region_cfg3 extends dv_base_reg;
       .lsb_pos(3),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2801,7 +3503,7 @@ class flash_ctrl_reg_mp_region_cfg3 extends dv_base_reg;
       .lsb_pos(4),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2812,7 +3514,7 @@ class flash_ctrl_reg_mp_region_cfg3 extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2847,7 +3549,7 @@ class flash_ctrl_reg_mp_region_cfg4 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2858,7 +3560,7 @@ class flash_ctrl_reg_mp_region_cfg4 extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2869,7 +3571,7 @@ class flash_ctrl_reg_mp_region_cfg4 extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2880,7 +3582,7 @@ class flash_ctrl_reg_mp_region_cfg4 extends dv_base_reg;
       .lsb_pos(3),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2891,7 +3593,7 @@ class flash_ctrl_reg_mp_region_cfg4 extends dv_base_reg;
       .lsb_pos(4),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2902,7 +3604,7 @@ class flash_ctrl_reg_mp_region_cfg4 extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2937,7 +3639,7 @@ class flash_ctrl_reg_mp_region_cfg5 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2948,7 +3650,7 @@ class flash_ctrl_reg_mp_region_cfg5 extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2959,7 +3661,7 @@ class flash_ctrl_reg_mp_region_cfg5 extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2970,7 +3672,7 @@ class flash_ctrl_reg_mp_region_cfg5 extends dv_base_reg;
       .lsb_pos(3),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2981,7 +3683,7 @@ class flash_ctrl_reg_mp_region_cfg5 extends dv_base_reg;
       .lsb_pos(4),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -2992,7 +3694,7 @@ class flash_ctrl_reg_mp_region_cfg5 extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -3027,7 +3729,7 @@ class flash_ctrl_reg_mp_region_cfg6 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -3038,7 +3740,7 @@ class flash_ctrl_reg_mp_region_cfg6 extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -3049,7 +3751,7 @@ class flash_ctrl_reg_mp_region_cfg6 extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -3060,7 +3762,7 @@ class flash_ctrl_reg_mp_region_cfg6 extends dv_base_reg;
       .lsb_pos(3),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -3071,7 +3773,7 @@ class flash_ctrl_reg_mp_region_cfg6 extends dv_base_reg;
       .lsb_pos(4),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -3082,7 +3784,7 @@ class flash_ctrl_reg_mp_region_cfg6 extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -3117,7 +3819,7 @@ class flash_ctrl_reg_mp_region_cfg7 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -3128,7 +3830,7 @@ class flash_ctrl_reg_mp_region_cfg7 extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -3139,7 +3841,7 @@ class flash_ctrl_reg_mp_region_cfg7 extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -3150,7 +3852,7 @@ class flash_ctrl_reg_mp_region_cfg7 extends dv_base_reg;
       .lsb_pos(3),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -3161,7 +3863,7 @@ class flash_ctrl_reg_mp_region_cfg7 extends dv_base_reg;
       .lsb_pos(4),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -3172,7 +3874,7 @@ class flash_ctrl_reg_mp_region_cfg7 extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -3204,7 +3906,7 @@ class flash_ctrl_reg_default_region extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -3215,7 +3917,7 @@ class flash_ctrl_reg_default_region extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -3226,7 +3928,7 @@ class flash_ctrl_reg_default_region extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -3256,7 +3958,7 @@ class flash_ctrl_reg_bank_cfg_regwen extends dv_base_reg;
       .lsb_pos(0),
       .access("W0C"),
       .volatile(1),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -3287,7 +3989,7 @@ class flash_ctrl_reg_mp_bank_cfg extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -3298,7 +4000,7 @@ class flash_ctrl_reg_mp_bank_cfg extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -3329,7 +4031,7 @@ class flash_ctrl_reg_op_status extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -3340,7 +4042,7 @@ class flash_ctrl_reg_op_status extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -3376,7 +4078,7 @@ class flash_ctrl_reg_status extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -3387,7 +4089,7 @@ class flash_ctrl_reg_status extends dv_base_reg;
       .lsb_pos(1),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -3398,7 +4100,7 @@ class flash_ctrl_reg_status extends dv_base_reg;
       .lsb_pos(2),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -3409,7 +4111,7 @@ class flash_ctrl_reg_status extends dv_base_reg;
       .lsb_pos(3),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -3420,7 +4122,7 @@ class flash_ctrl_reg_status extends dv_base_reg;
       .lsb_pos(4),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -3431,7 +4133,7 @@ class flash_ctrl_reg_status extends dv_base_reg;
       .lsb_pos(8),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -3442,7 +4144,7 @@ class flash_ctrl_reg_status extends dv_base_reg;
       .lsb_pos(17),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -3472,7 +4174,7 @@ class flash_ctrl_reg_scratch extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -3503,7 +4205,7 @@ class flash_ctrl_reg_fifo_lvl extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(15),
+      .reset(32'hf),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -3514,7 +4216,7 @@ class flash_ctrl_reg_fifo_lvl extends dv_base_reg;
       .lsb_pos(8),
       .access("RW"),
       .volatile(0),
-      .reset(15),
+      .reset(32'hf),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -3736,1840 +4438,6 @@ class flash_ctrl_reg_block extends dv_base_reg_block;
   endfunction : build
 
 endclass : flash_ctrl_reg_block
-// Block: uart
-// Class: uart_reg_intr_state
-class uart_reg_intr_state extends dv_base_reg;
-  // fields
-  rand dv_base_reg_field tx_watermark;
-  rand dv_base_reg_field rx_watermark;
-  rand dv_base_reg_field tx_overflow;
-  rand dv_base_reg_field rx_overflow;
-  rand dv_base_reg_field rx_frame_err;
-  rand dv_base_reg_field rx_break_err;
-  rand dv_base_reg_field rx_timeout;
-  rand dv_base_reg_field rx_parity_err;
-
-  `uvm_object_utils(uart_reg_intr_state)
-
-  function new(string       name = "uart_reg_intr_state",
-               int unsigned n_bits = 32,
-               int          has_coverage = UVM_NO_COVERAGE);
-    super.new(name, n_bits, has_coverage);
-  endfunction : new
-
-  virtual function void build();
-    // create fields
-    tx_watermark = dv_base_reg_field::type_id::create("tx_watermark");
-    tx_watermark.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(0),
-      .access("W1C"),
-      .volatile(1),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    rx_watermark = dv_base_reg_field::type_id::create("rx_watermark");
-    rx_watermark.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(1),
-      .access("W1C"),
-      .volatile(1),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    tx_overflow = dv_base_reg_field::type_id::create("tx_overflow");
-    tx_overflow.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(2),
-      .access("W1C"),
-      .volatile(1),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    rx_overflow = dv_base_reg_field::type_id::create("rx_overflow");
-    rx_overflow.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(3),
-      .access("W1C"),
-      .volatile(1),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    rx_frame_err = dv_base_reg_field::type_id::create("rx_frame_err");
-    rx_frame_err.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(4),
-      .access("W1C"),
-      .volatile(1),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    rx_break_err = dv_base_reg_field::type_id::create("rx_break_err");
-    rx_break_err.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(5),
-      .access("W1C"),
-      .volatile(1),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    rx_timeout = dv_base_reg_field::type_id::create("rx_timeout");
-    rx_timeout.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(6),
-      .access("W1C"),
-      .volatile(1),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    rx_parity_err = dv_base_reg_field::type_id::create("rx_parity_err");
-    rx_parity_err.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(7),
-      .access("W1C"),
-      .volatile(1),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-  endfunction : build
-
-endclass : uart_reg_intr_state
-
-// Class: uart_reg_intr_enable
-class uart_reg_intr_enable extends dv_base_reg;
-  // fields
-  rand dv_base_reg_field tx_watermark;
-  rand dv_base_reg_field rx_watermark;
-  rand dv_base_reg_field tx_overflow;
-  rand dv_base_reg_field rx_overflow;
-  rand dv_base_reg_field rx_frame_err;
-  rand dv_base_reg_field rx_break_err;
-  rand dv_base_reg_field rx_timeout;
-  rand dv_base_reg_field rx_parity_err;
-
-  `uvm_object_utils(uart_reg_intr_enable)
-
-  function new(string       name = "uart_reg_intr_enable",
-               int unsigned n_bits = 32,
-               int          has_coverage = UVM_NO_COVERAGE);
-    super.new(name, n_bits, has_coverage);
-  endfunction : new
-
-  virtual function void build();
-    // create fields
-    tx_watermark = dv_base_reg_field::type_id::create("tx_watermark");
-    tx_watermark.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(0),
-      .access("RW"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    rx_watermark = dv_base_reg_field::type_id::create("rx_watermark");
-    rx_watermark.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(1),
-      .access("RW"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    tx_overflow = dv_base_reg_field::type_id::create("tx_overflow");
-    tx_overflow.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(2),
-      .access("RW"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    rx_overflow = dv_base_reg_field::type_id::create("rx_overflow");
-    rx_overflow.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(3),
-      .access("RW"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    rx_frame_err = dv_base_reg_field::type_id::create("rx_frame_err");
-    rx_frame_err.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(4),
-      .access("RW"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    rx_break_err = dv_base_reg_field::type_id::create("rx_break_err");
-    rx_break_err.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(5),
-      .access("RW"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    rx_timeout = dv_base_reg_field::type_id::create("rx_timeout");
-    rx_timeout.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(6),
-      .access("RW"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    rx_parity_err = dv_base_reg_field::type_id::create("rx_parity_err");
-    rx_parity_err.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(7),
-      .access("RW"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-  endfunction : build
-
-endclass : uart_reg_intr_enable
-
-// Class: uart_reg_intr_test
-class uart_reg_intr_test extends dv_base_reg;
-  // fields
-  rand dv_base_reg_field tx_watermark;
-  rand dv_base_reg_field rx_watermark;
-  rand dv_base_reg_field tx_overflow;
-  rand dv_base_reg_field rx_overflow;
-  rand dv_base_reg_field rx_frame_err;
-  rand dv_base_reg_field rx_break_err;
-  rand dv_base_reg_field rx_timeout;
-  rand dv_base_reg_field rx_parity_err;
-
-  `uvm_object_utils(uart_reg_intr_test)
-
-  function new(string       name = "uart_reg_intr_test",
-               int unsigned n_bits = 32,
-               int          has_coverage = UVM_NO_COVERAGE);
-    super.new(name, n_bits, has_coverage);
-  endfunction : new
-
-  virtual function void build();
-    // create fields
-    tx_watermark = dv_base_reg_field::type_id::create("tx_watermark");
-    tx_watermark.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(0),
-      .access("WO"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    rx_watermark = dv_base_reg_field::type_id::create("rx_watermark");
-    rx_watermark.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(1),
-      .access("WO"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    tx_overflow = dv_base_reg_field::type_id::create("tx_overflow");
-    tx_overflow.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(2),
-      .access("WO"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    rx_overflow = dv_base_reg_field::type_id::create("rx_overflow");
-    rx_overflow.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(3),
-      .access("WO"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    rx_frame_err = dv_base_reg_field::type_id::create("rx_frame_err");
-    rx_frame_err.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(4),
-      .access("WO"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    rx_break_err = dv_base_reg_field::type_id::create("rx_break_err");
-    rx_break_err.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(5),
-      .access("WO"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    rx_timeout = dv_base_reg_field::type_id::create("rx_timeout");
-    rx_timeout.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(6),
-      .access("WO"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    rx_parity_err = dv_base_reg_field::type_id::create("rx_parity_err");
-    rx_parity_err.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(7),
-      .access("WO"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-  endfunction : build
-
-endclass : uart_reg_intr_test
-
-// Class: uart_reg_ctrl
-class uart_reg_ctrl extends dv_base_reg;
-  // fields
-  rand dv_base_reg_field tx;
-  rand dv_base_reg_field rx;
-  rand dv_base_reg_field nf;
-  rand dv_base_reg_field slpbk;
-  rand dv_base_reg_field llpbk;
-  rand dv_base_reg_field parity_en;
-  rand dv_base_reg_field parity_odd;
-  rand dv_base_reg_field rxblvl;
-  rand dv_base_reg_field nco;
-
-  `uvm_object_utils(uart_reg_ctrl)
-
-  function new(string       name = "uart_reg_ctrl",
-               int unsigned n_bits = 32,
-               int          has_coverage = UVM_NO_COVERAGE);
-    super.new(name, n_bits, has_coverage);
-  endfunction : new
-
-  virtual function void build();
-    // create fields
-    tx = dv_base_reg_field::type_id::create("tx");
-    tx.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(0),
-      .access("RW"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    rx = dv_base_reg_field::type_id::create("rx");
-    rx.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(1),
-      .access("RW"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    nf = dv_base_reg_field::type_id::create("nf");
-    nf.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(2),
-      .access("RW"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    slpbk = dv_base_reg_field::type_id::create("slpbk");
-    slpbk.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(4),
-      .access("RW"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    llpbk = dv_base_reg_field::type_id::create("llpbk");
-    llpbk.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(5),
-      .access("RW"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    parity_en = dv_base_reg_field::type_id::create("parity_en");
-    parity_en.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(6),
-      .access("RW"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    parity_odd = dv_base_reg_field::type_id::create("parity_odd");
-    parity_odd.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(7),
-      .access("RW"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    rxblvl = dv_base_reg_field::type_id::create("rxblvl");
-    rxblvl.configure(
-      .parent(this),
-      .size(2),
-      .lsb_pos(8),
-      .access("RW"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    nco = dv_base_reg_field::type_id::create("nco");
-    nco.configure(
-      .parent(this),
-      .size(16),
-      .lsb_pos(16),
-      .access("RW"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-  endfunction : build
-
-endclass : uart_reg_ctrl
-
-// Class: uart_reg_status
-class uart_reg_status extends dv_base_reg;
-  // fields
-  rand dv_base_reg_field txfull;
-  rand dv_base_reg_field rxfull;
-  rand dv_base_reg_field txempty;
-  rand dv_base_reg_field txidle;
-  rand dv_base_reg_field rxidle;
-  rand dv_base_reg_field rxempty;
-
-  `uvm_object_utils(uart_reg_status)
-
-  function new(string       name = "uart_reg_status",
-               int unsigned n_bits = 32,
-               int          has_coverage = UVM_NO_COVERAGE);
-    super.new(name, n_bits, has_coverage);
-  endfunction : new
-
-  virtual function void build();
-    // create fields
-    txfull = dv_base_reg_field::type_id::create("txfull");
-    txfull.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(0),
-      .access("RO"),
-      .volatile(1),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    rxfull = dv_base_reg_field::type_id::create("rxfull");
-    rxfull.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(1),
-      .access("RO"),
-      .volatile(1),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    txempty = dv_base_reg_field::type_id::create("txempty");
-    txempty.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(2),
-      .access("RO"),
-      .volatile(1),
-      .reset(1),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    txidle = dv_base_reg_field::type_id::create("txidle");
-    txidle.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(3),
-      .access("RO"),
-      .volatile(1),
-      .reset(1),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    rxidle = dv_base_reg_field::type_id::create("rxidle");
-    rxidle.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(4),
-      .access("RO"),
-      .volatile(1),
-      .reset(1),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    rxempty = dv_base_reg_field::type_id::create("rxempty");
-    rxempty.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(5),
-      .access("RO"),
-      .volatile(1),
-      .reset(1),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-  endfunction : build
-
-endclass : uart_reg_status
-
-// Class: uart_reg_rdata
-class uart_reg_rdata extends dv_base_reg;
-  // fields
-  rand dv_base_reg_field rdata;
-
-  `uvm_object_utils(uart_reg_rdata)
-
-  function new(string       name = "uart_reg_rdata",
-               int unsigned n_bits = 32,
-               int          has_coverage = UVM_NO_COVERAGE);
-    super.new(name, n_bits, has_coverage);
-  endfunction : new
-
-  virtual function void build();
-    // create fields
-    rdata = dv_base_reg_field::type_id::create("rdata");
-    rdata.configure(
-      .parent(this),
-      .size(8),
-      .lsb_pos(0),
-      .access("RO"),
-      .volatile(1),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-  endfunction : build
-
-endclass : uart_reg_rdata
-
-// Class: uart_reg_wdata
-class uart_reg_wdata extends dv_base_reg;
-  // fields
-  rand dv_base_reg_field wdata;
-
-  `uvm_object_utils(uart_reg_wdata)
-
-  function new(string       name = "uart_reg_wdata",
-               int unsigned n_bits = 32,
-               int          has_coverage = UVM_NO_COVERAGE);
-    super.new(name, n_bits, has_coverage);
-  endfunction : new
-
-  virtual function void build();
-    // create fields
-    wdata = dv_base_reg_field::type_id::create("wdata");
-    wdata.configure(
-      .parent(this),
-      .size(8),
-      .lsb_pos(0),
-      .access("WO"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-  endfunction : build
-
-endclass : uart_reg_wdata
-
-// Class: uart_reg_fifo_ctrl
-class uart_reg_fifo_ctrl extends dv_base_reg;
-  // fields
-  rand dv_base_reg_field rxrst;
-  rand dv_base_reg_field txrst;
-  rand dv_base_reg_field rxilvl;
-  rand dv_base_reg_field txilvl;
-
-  `uvm_object_utils(uart_reg_fifo_ctrl)
-
-  function new(string       name = "uart_reg_fifo_ctrl",
-               int unsigned n_bits = 32,
-               int          has_coverage = UVM_NO_COVERAGE);
-    super.new(name, n_bits, has_coverage);
-  endfunction : new
-
-  virtual function void build();
-    // create fields
-    rxrst = dv_base_reg_field::type_id::create("rxrst");
-    rxrst.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(0),
-      .access("WO"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    txrst = dv_base_reg_field::type_id::create("txrst");
-    txrst.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(1),
-      .access("WO"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    rxilvl = dv_base_reg_field::type_id::create("rxilvl");
-    rxilvl.configure(
-      .parent(this),
-      .size(3),
-      .lsb_pos(2),
-      .access("RW"),
-      .volatile(1),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    txilvl = dv_base_reg_field::type_id::create("txilvl");
-    txilvl.configure(
-      .parent(this),
-      .size(2),
-      .lsb_pos(5),
-      .access("RW"),
-      .volatile(1),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-  endfunction : build
-
-endclass : uart_reg_fifo_ctrl
-
-// Class: uart_reg_fifo_status
-class uart_reg_fifo_status extends dv_base_reg;
-  // fields
-  rand dv_base_reg_field txlvl;
-  rand dv_base_reg_field rxlvl;
-
-  `uvm_object_utils(uart_reg_fifo_status)
-
-  function new(string       name = "uart_reg_fifo_status",
-               int unsigned n_bits = 32,
-               int          has_coverage = UVM_NO_COVERAGE);
-    super.new(name, n_bits, has_coverage);
-  endfunction : new
-
-  virtual function void build();
-    // create fields
-    txlvl = dv_base_reg_field::type_id::create("txlvl");
-    txlvl.configure(
-      .parent(this),
-      .size(6),
-      .lsb_pos(0),
-      .access("RO"),
-      .volatile(1),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    rxlvl = dv_base_reg_field::type_id::create("rxlvl");
-    rxlvl.configure(
-      .parent(this),
-      .size(6),
-      .lsb_pos(16),
-      .access("RO"),
-      .volatile(1),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-  endfunction : build
-
-endclass : uart_reg_fifo_status
-
-// Class: uart_reg_ovrd
-class uart_reg_ovrd extends dv_base_reg;
-  // fields
-  rand dv_base_reg_field txen;
-  rand dv_base_reg_field txval;
-
-  `uvm_object_utils(uart_reg_ovrd)
-
-  function new(string       name = "uart_reg_ovrd",
-               int unsigned n_bits = 32,
-               int          has_coverage = UVM_NO_COVERAGE);
-    super.new(name, n_bits, has_coverage);
-  endfunction : new
-
-  virtual function void build();
-    // create fields
-    txen = dv_base_reg_field::type_id::create("txen");
-    txen.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(0),
-      .access("RW"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    txval = dv_base_reg_field::type_id::create("txval");
-    txval.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(1),
-      .access("RW"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-  endfunction : build
-
-endclass : uart_reg_ovrd
-
-// Class: uart_reg_val
-class uart_reg_val extends dv_base_reg;
-  // fields
-  rand dv_base_reg_field rx;
-
-  `uvm_object_utils(uart_reg_val)
-
-  function new(string       name = "uart_reg_val",
-               int unsigned n_bits = 32,
-               int          has_coverage = UVM_NO_COVERAGE);
-    super.new(name, n_bits, has_coverage);
-  endfunction : new
-
-  virtual function void build();
-    // create fields
-    rx = dv_base_reg_field::type_id::create("rx");
-    rx.configure(
-      .parent(this),
-      .size(16),
-      .lsb_pos(0),
-      .access("RO"),
-      .volatile(1),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-  endfunction : build
-
-endclass : uart_reg_val
-
-// Class: uart_reg_timeout_ctrl
-class uart_reg_timeout_ctrl extends dv_base_reg;
-  // fields
-  rand dv_base_reg_field val;
-  rand dv_base_reg_field en;
-
-  `uvm_object_utils(uart_reg_timeout_ctrl)
-
-  function new(string       name = "uart_reg_timeout_ctrl",
-               int unsigned n_bits = 32,
-               int          has_coverage = UVM_NO_COVERAGE);
-    super.new(name, n_bits, has_coverage);
-  endfunction : new
-
-  virtual function void build();
-    // create fields
-    val = dv_base_reg_field::type_id::create("val");
-    val.configure(
-      .parent(this),
-      .size(24),
-      .lsb_pos(0),
-      .access("RW"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    en = dv_base_reg_field::type_id::create("en");
-    en.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(31),
-      .access("RW"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-  endfunction : build
-
-endclass : uart_reg_timeout_ctrl
-
-// Class: uart_reg_block
-class uart_reg_block extends dv_base_reg_block;
-  // registers
-  rand uart_reg_intr_state intr_state;
-  rand uart_reg_intr_enable intr_enable;
-  rand uart_reg_intr_test intr_test;
-  rand uart_reg_ctrl ctrl;
-  rand uart_reg_status status;
-  rand uart_reg_rdata rdata;
-  rand uart_reg_wdata wdata;
-  rand uart_reg_fifo_ctrl fifo_ctrl;
-  rand uart_reg_fifo_status fifo_status;
-  rand uart_reg_ovrd ovrd;
-  rand uart_reg_val val;
-  rand uart_reg_timeout_ctrl timeout_ctrl;
-
-  `uvm_object_utils(uart_reg_block)
-
-  function new(string name = "uart_reg_block",
-               int    has_coverage = UVM_NO_COVERAGE);
-    super.new(name, has_coverage);
-  endfunction : new
-
-  virtual function void build(uvm_reg_addr_t base_addr);
-    // create default map
-    this.default_map = create_map(.name("default_map"),
-                                  .base_addr(base_addr),
-                                  .n_bytes(4),
-                                  .endian(UVM_LITTLE_ENDIAN));
-
-    // create registers
-    intr_state = uart_reg_intr_state::type_id::create("intr_state");
-    intr_state.configure(.blk_parent(this));
-    intr_state.build();
-    default_map.add_reg(.rg(intr_state),
-                        .offset(32'h0),
-                        .rights("RW"));
-    intr_enable = uart_reg_intr_enable::type_id::create("intr_enable");
-    intr_enable.configure(.blk_parent(this));
-    intr_enable.build();
-    default_map.add_reg(.rg(intr_enable),
-                        .offset(32'h4),
-                        .rights("RW"));
-    intr_test = uart_reg_intr_test::type_id::create("intr_test");
-    intr_test.configure(.blk_parent(this));
-    intr_test.build();
-    default_map.add_reg(.rg(intr_test),
-                        .offset(32'h8),
-                        .rights("WO"));
-    ctrl = uart_reg_ctrl::type_id::create("ctrl");
-    ctrl.configure(.blk_parent(this));
-    ctrl.build();
-    default_map.add_reg(.rg(ctrl),
-                        .offset(32'hc),
-                        .rights("RW"));
-    status = uart_reg_status::type_id::create("status");
-    status.configure(.blk_parent(this));
-    status.build();
-    default_map.add_reg(.rg(status),
-                        .offset(32'h10),
-                        .rights("RO"));
-    rdata = uart_reg_rdata::type_id::create("rdata");
-    rdata.configure(.blk_parent(this));
-    rdata.build();
-    default_map.add_reg(.rg(rdata),
-                        .offset(32'h14),
-                        .rights("RO"));
-    wdata = uart_reg_wdata::type_id::create("wdata");
-    wdata.configure(.blk_parent(this));
-    wdata.build();
-    default_map.add_reg(.rg(wdata),
-                        .offset(32'h18),
-                        .rights("WO"));
-    fifo_ctrl = uart_reg_fifo_ctrl::type_id::create("fifo_ctrl");
-    fifo_ctrl.configure(.blk_parent(this));
-    fifo_ctrl.build();
-    default_map.add_reg(.rg(fifo_ctrl),
-                        .offset(32'h1c),
-                        .rights("RW"));
-    fifo_status = uart_reg_fifo_status::type_id::create("fifo_status");
-    fifo_status.configure(.blk_parent(this));
-    fifo_status.build();
-    default_map.add_reg(.rg(fifo_status),
-                        .offset(32'h20),
-                        .rights("RO"));
-    ovrd = uart_reg_ovrd::type_id::create("ovrd");
-    ovrd.configure(.blk_parent(this));
-    ovrd.build();
-    default_map.add_reg(.rg(ovrd),
-                        .offset(32'h24),
-                        .rights("RW"));
-    val = uart_reg_val::type_id::create("val");
-    val.configure(.blk_parent(this));
-    val.build();
-    default_map.add_reg(.rg(val),
-                        .offset(32'h28),
-                        .rights("RO"));
-    timeout_ctrl = uart_reg_timeout_ctrl::type_id::create("timeout_ctrl");
-    timeout_ctrl.configure(.blk_parent(this));
-    timeout_ctrl.build();
-    default_map.add_reg(.rg(timeout_ctrl),
-                        .offset(32'h2c),
-                        .rights("RW"));
-  endfunction : build
-
-endclass : uart_reg_block
-// Block: spi_device
-// Class: spi_device_reg_intr_state
-class spi_device_reg_intr_state extends dv_base_reg;
-  // fields
-  rand dv_base_reg_field rxf;
-  rand dv_base_reg_field rxlvl;
-  rand dv_base_reg_field txlvl;
-  rand dv_base_reg_field rxerr;
-  rand dv_base_reg_field rxoverflow;
-  rand dv_base_reg_field txunderflow;
-
-  `uvm_object_utils(spi_device_reg_intr_state)
-
-  function new(string       name = "spi_device_reg_intr_state",
-               int unsigned n_bits = 32,
-               int          has_coverage = UVM_NO_COVERAGE);
-    super.new(name, n_bits, has_coverage);
-  endfunction : new
-
-  virtual function void build();
-    // create fields
-    rxf = dv_base_reg_field::type_id::create("rxf");
-    rxf.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(0),
-      .access("W1C"),
-      .volatile(1),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    rxlvl = dv_base_reg_field::type_id::create("rxlvl");
-    rxlvl.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(1),
-      .access("W1C"),
-      .volatile(1),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    txlvl = dv_base_reg_field::type_id::create("txlvl");
-    txlvl.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(2),
-      .access("W1C"),
-      .volatile(1),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    rxerr = dv_base_reg_field::type_id::create("rxerr");
-    rxerr.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(3),
-      .access("W1C"),
-      .volatile(1),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    rxoverflow = dv_base_reg_field::type_id::create("rxoverflow");
-    rxoverflow.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(4),
-      .access("W1C"),
-      .volatile(1),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    txunderflow = dv_base_reg_field::type_id::create("txunderflow");
-    txunderflow.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(5),
-      .access("W1C"),
-      .volatile(1),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-  endfunction : build
-
-endclass : spi_device_reg_intr_state
-
-// Class: spi_device_reg_intr_enable
-class spi_device_reg_intr_enable extends dv_base_reg;
-  // fields
-  rand dv_base_reg_field rxf;
-  rand dv_base_reg_field rxlvl;
-  rand dv_base_reg_field txlvl;
-  rand dv_base_reg_field rxerr;
-  rand dv_base_reg_field rxoverflow;
-  rand dv_base_reg_field txunderflow;
-
-  `uvm_object_utils(spi_device_reg_intr_enable)
-
-  function new(string       name = "spi_device_reg_intr_enable",
-               int unsigned n_bits = 32,
-               int          has_coverage = UVM_NO_COVERAGE);
-    super.new(name, n_bits, has_coverage);
-  endfunction : new
-
-  virtual function void build();
-    // create fields
-    rxf = dv_base_reg_field::type_id::create("rxf");
-    rxf.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(0),
-      .access("RW"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    rxlvl = dv_base_reg_field::type_id::create("rxlvl");
-    rxlvl.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(1),
-      .access("RW"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    txlvl = dv_base_reg_field::type_id::create("txlvl");
-    txlvl.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(2),
-      .access("RW"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    rxerr = dv_base_reg_field::type_id::create("rxerr");
-    rxerr.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(3),
-      .access("RW"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    rxoverflow = dv_base_reg_field::type_id::create("rxoverflow");
-    rxoverflow.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(4),
-      .access("RW"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    txunderflow = dv_base_reg_field::type_id::create("txunderflow");
-    txunderflow.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(5),
-      .access("RW"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-  endfunction : build
-
-endclass : spi_device_reg_intr_enable
-
-// Class: spi_device_reg_intr_test
-class spi_device_reg_intr_test extends dv_base_reg;
-  // fields
-  rand dv_base_reg_field rxf;
-  rand dv_base_reg_field rxlvl;
-  rand dv_base_reg_field txlvl;
-  rand dv_base_reg_field rxerr;
-  rand dv_base_reg_field rxoverflow;
-  rand dv_base_reg_field txunderflow;
-
-  `uvm_object_utils(spi_device_reg_intr_test)
-
-  function new(string       name = "spi_device_reg_intr_test",
-               int unsigned n_bits = 32,
-               int          has_coverage = UVM_NO_COVERAGE);
-    super.new(name, n_bits, has_coverage);
-  endfunction : new
-
-  virtual function void build();
-    // create fields
-    rxf = dv_base_reg_field::type_id::create("rxf");
-    rxf.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(0),
-      .access("WO"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    rxlvl = dv_base_reg_field::type_id::create("rxlvl");
-    rxlvl.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(1),
-      .access("WO"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    txlvl = dv_base_reg_field::type_id::create("txlvl");
-    txlvl.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(2),
-      .access("WO"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    rxerr = dv_base_reg_field::type_id::create("rxerr");
-    rxerr.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(3),
-      .access("WO"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    rxoverflow = dv_base_reg_field::type_id::create("rxoverflow");
-    rxoverflow.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(4),
-      .access("WO"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    txunderflow = dv_base_reg_field::type_id::create("txunderflow");
-    txunderflow.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(5),
-      .access("WO"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-  endfunction : build
-
-endclass : spi_device_reg_intr_test
-
-// Class: spi_device_reg_control
-class spi_device_reg_control extends dv_base_reg;
-  // fields
-  rand dv_base_reg_field abort;
-  rand dv_base_reg_field mode;
-  rand dv_base_reg_field rst_txfifo;
-  rand dv_base_reg_field rst_rxfifo;
-
-  `uvm_object_utils(spi_device_reg_control)
-
-  function new(string       name = "spi_device_reg_control",
-               int unsigned n_bits = 32,
-               int          has_coverage = UVM_NO_COVERAGE);
-    super.new(name, n_bits, has_coverage);
-  endfunction : new
-
-  virtual function void build();
-    // create fields
-    abort = dv_base_reg_field::type_id::create("abort");
-    abort.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(0),
-      .access("RW"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    mode = dv_base_reg_field::type_id::create("mode");
-    mode.configure(
-      .parent(this),
-      .size(2),
-      .lsb_pos(4),
-      .access("RW"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    rst_txfifo = dv_base_reg_field::type_id::create("rst_txfifo");
-    rst_txfifo.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(16),
-      .access("RW"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    rst_rxfifo = dv_base_reg_field::type_id::create("rst_rxfifo");
-    rst_rxfifo.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(17),
-      .access("RW"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-  endfunction : build
-
-endclass : spi_device_reg_control
-
-// Class: spi_device_reg_cfg
-class spi_device_reg_cfg extends dv_base_reg;
-  // fields
-  rand dv_base_reg_field cpol;
-  rand dv_base_reg_field cpha;
-  rand dv_base_reg_field tx_order;
-  rand dv_base_reg_field rx_order;
-  rand dv_base_reg_field timer_v;
-
-  `uvm_object_utils(spi_device_reg_cfg)
-
-  function new(string       name = "spi_device_reg_cfg",
-               int unsigned n_bits = 32,
-               int          has_coverage = UVM_NO_COVERAGE);
-    super.new(name, n_bits, has_coverage);
-  endfunction : new
-
-  virtual function void build();
-    // create fields
-    cpol = dv_base_reg_field::type_id::create("cpol");
-    cpol.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(0),
-      .access("RW"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    cpha = dv_base_reg_field::type_id::create("cpha");
-    cpha.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(1),
-      .access("RW"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    tx_order = dv_base_reg_field::type_id::create("tx_order");
-    tx_order.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(2),
-      .access("RW"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    rx_order = dv_base_reg_field::type_id::create("rx_order");
-    rx_order.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(3),
-      .access("RW"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    timer_v = dv_base_reg_field::type_id::create("timer_v");
-    timer_v.configure(
-      .parent(this),
-      .size(8),
-      .lsb_pos(8),
-      .access("RW"),
-      .volatile(0),
-      .reset(127),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-  endfunction : build
-
-endclass : spi_device_reg_cfg
-
-// Class: spi_device_reg_fifo_level
-class spi_device_reg_fifo_level extends dv_base_reg;
-  // fields
-  rand dv_base_reg_field rxlvl;
-  rand dv_base_reg_field txlvl;
-
-  `uvm_object_utils(spi_device_reg_fifo_level)
-
-  function new(string       name = "spi_device_reg_fifo_level",
-               int unsigned n_bits = 32,
-               int          has_coverage = UVM_NO_COVERAGE);
-    super.new(name, n_bits, has_coverage);
-  endfunction : new
-
-  virtual function void build();
-    // create fields
-    rxlvl = dv_base_reg_field::type_id::create("rxlvl");
-    rxlvl.configure(
-      .parent(this),
-      .size(16),
-      .lsb_pos(0),
-      .access("RW"),
-      .volatile(0),
-      .reset(128),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    txlvl = dv_base_reg_field::type_id::create("txlvl");
-    txlvl.configure(
-      .parent(this),
-      .size(16),
-      .lsb_pos(16),
-      .access("RW"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-  endfunction : build
-
-endclass : spi_device_reg_fifo_level
-
-// Class: spi_device_reg_async_fifo_level
-class spi_device_reg_async_fifo_level extends dv_base_reg;
-  // fields
-  rand dv_base_reg_field rxlvl;
-  rand dv_base_reg_field txlvl;
-
-  `uvm_object_utils(spi_device_reg_async_fifo_level)
-
-  function new(string       name = "spi_device_reg_async_fifo_level",
-               int unsigned n_bits = 32,
-               int          has_coverage = UVM_NO_COVERAGE);
-    super.new(name, n_bits, has_coverage);
-  endfunction : new
-
-  virtual function void build();
-    // create fields
-    rxlvl = dv_base_reg_field::type_id::create("rxlvl");
-    rxlvl.configure(
-      .parent(this),
-      .size(8),
-      .lsb_pos(0),
-      .access("RO"),
-      .volatile(1),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    txlvl = dv_base_reg_field::type_id::create("txlvl");
-    txlvl.configure(
-      .parent(this),
-      .size(8),
-      .lsb_pos(16),
-      .access("RO"),
-      .volatile(1),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-  endfunction : build
-
-endclass : spi_device_reg_async_fifo_level
-
-// Class: spi_device_reg_status
-class spi_device_reg_status extends dv_base_reg;
-  // fields
-  rand dv_base_reg_field rxf_full;
-  rand dv_base_reg_field rxf_empty;
-  rand dv_base_reg_field txf_full;
-  rand dv_base_reg_field txf_empty;
-  rand dv_base_reg_field abort_done;
-  rand dv_base_reg_field csb;
-
-  `uvm_object_utils(spi_device_reg_status)
-
-  function new(string       name = "spi_device_reg_status",
-               int unsigned n_bits = 32,
-               int          has_coverage = UVM_NO_COVERAGE);
-    super.new(name, n_bits, has_coverage);
-  endfunction : new
-
-  virtual function void build();
-    // create fields
-    rxf_full = dv_base_reg_field::type_id::create("rxf_full");
-    rxf_full.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(0),
-      .access("RO"),
-      .volatile(1),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    rxf_empty = dv_base_reg_field::type_id::create("rxf_empty");
-    rxf_empty.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(1),
-      .access("RO"),
-      .volatile(1),
-      .reset(1),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    txf_full = dv_base_reg_field::type_id::create("txf_full");
-    txf_full.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(2),
-      .access("RO"),
-      .volatile(1),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    txf_empty = dv_base_reg_field::type_id::create("txf_empty");
-    txf_empty.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(3),
-      .access("RO"),
-      .volatile(1),
-      .reset(1),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    abort_done = dv_base_reg_field::type_id::create("abort_done");
-    abort_done.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(4),
-      .access("RO"),
-      .volatile(1),
-      .reset(1),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    csb = dv_base_reg_field::type_id::create("csb");
-    csb.configure(
-      .parent(this),
-      .size(1),
-      .lsb_pos(5),
-      .access("RO"),
-      .volatile(1),
-      .reset(1),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-  endfunction : build
-
-endclass : spi_device_reg_status
-
-// Class: spi_device_reg_rxf_ptr
-class spi_device_reg_rxf_ptr extends dv_base_reg;
-  // fields
-  rand dv_base_reg_field rptr;
-  rand dv_base_reg_field wptr;
-
-  `uvm_object_utils(spi_device_reg_rxf_ptr)
-
-  function new(string       name = "spi_device_reg_rxf_ptr",
-               int unsigned n_bits = 32,
-               int          has_coverage = UVM_NO_COVERAGE);
-    super.new(name, n_bits, has_coverage);
-  endfunction : new
-
-  virtual function void build();
-    // create fields
-    rptr = dv_base_reg_field::type_id::create("rptr");
-    rptr.configure(
-      .parent(this),
-      .size(16),
-      .lsb_pos(0),
-      .access("RW"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    wptr = dv_base_reg_field::type_id::create("wptr");
-    wptr.configure(
-      .parent(this),
-      .size(16),
-      .lsb_pos(16),
-      .access("RO"),
-      .volatile(1),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-  endfunction : build
-
-endclass : spi_device_reg_rxf_ptr
-
-// Class: spi_device_reg_txf_ptr
-class spi_device_reg_txf_ptr extends dv_base_reg;
-  // fields
-  rand dv_base_reg_field rptr;
-  rand dv_base_reg_field wptr;
-
-  `uvm_object_utils(spi_device_reg_txf_ptr)
-
-  function new(string       name = "spi_device_reg_txf_ptr",
-               int unsigned n_bits = 32,
-               int          has_coverage = UVM_NO_COVERAGE);
-    super.new(name, n_bits, has_coverage);
-  endfunction : new
-
-  virtual function void build();
-    // create fields
-    rptr = dv_base_reg_field::type_id::create("rptr");
-    rptr.configure(
-      .parent(this),
-      .size(16),
-      .lsb_pos(0),
-      .access("RO"),
-      .volatile(1),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    wptr = dv_base_reg_field::type_id::create("wptr");
-    wptr.configure(
-      .parent(this),
-      .size(16),
-      .lsb_pos(16),
-      .access("RW"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-  endfunction : build
-
-endclass : spi_device_reg_txf_ptr
-
-// Class: spi_device_reg_rxf_addr
-class spi_device_reg_rxf_addr extends dv_base_reg;
-  // fields
-  rand dv_base_reg_field base;
-  rand dv_base_reg_field limit;
-
-  `uvm_object_utils(spi_device_reg_rxf_addr)
-
-  function new(string       name = "spi_device_reg_rxf_addr",
-               int unsigned n_bits = 32,
-               int          has_coverage = UVM_NO_COVERAGE);
-    super.new(name, n_bits, has_coverage);
-  endfunction : new
-
-  virtual function void build();
-    // create fields
-    base = dv_base_reg_field::type_id::create("base");
-    base.configure(
-      .parent(this),
-      .size(16),
-      .lsb_pos(0),
-      .access("RW"),
-      .volatile(0),
-      .reset(0),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    limit = dv_base_reg_field::type_id::create("limit");
-    limit.configure(
-      .parent(this),
-      .size(16),
-      .lsb_pos(16),
-      .access("RW"),
-      .volatile(0),
-      .reset(508),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-  endfunction : build
-
-endclass : spi_device_reg_rxf_addr
-
-// Class: spi_device_reg_txf_addr
-class spi_device_reg_txf_addr extends dv_base_reg;
-  // fields
-  rand dv_base_reg_field base;
-  rand dv_base_reg_field limit;
-
-  `uvm_object_utils(spi_device_reg_txf_addr)
-
-  function new(string       name = "spi_device_reg_txf_addr",
-               int unsigned n_bits = 32,
-               int          has_coverage = UVM_NO_COVERAGE);
-    super.new(name, n_bits, has_coverage);
-  endfunction : new
-
-  virtual function void build();
-    // create fields
-    base = dv_base_reg_field::type_id::create("base");
-    base.configure(
-      .parent(this),
-      .size(16),
-      .lsb_pos(0),
-      .access("RW"),
-      .volatile(0),
-      .reset(512),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-    limit = dv_base_reg_field::type_id::create("limit");
-    limit.configure(
-      .parent(this),
-      .size(16),
-      .lsb_pos(16),
-      .access("RW"),
-      .volatile(0),
-      .reset(1020),
-      .has_reset(1),
-      .is_rand(1),
-      .individually_accessible(1));
-  endfunction : build
-
-endclass : spi_device_reg_txf_addr
-
-// Class: spi_device_mem_buffer
-class spi_device_mem_buffer extends dv_base_mem;
-
-  `uvm_object_utils(spi_device_mem_buffer)
-
-  function new(string           name = "spi_device_mem_buffer",
-               longint unsigned size = 512,
-               int unsigned     n_bits = 32,
-               string           access = "RW"/* TODO:"RW"*/,
-               int              has_coverage = UVM_NO_COVERAGE);
-    super.new(name, size, n_bits, access, has_coverage);
-  endfunction : new
-
-endclass : spi_device_mem_buffer
-
-// Class: spi_device_reg_block
-class spi_device_reg_block extends dv_base_reg_block;
-  // registers
-  rand spi_device_reg_intr_state intr_state;
-  rand spi_device_reg_intr_enable intr_enable;
-  rand spi_device_reg_intr_test intr_test;
-  rand spi_device_reg_control control;
-  rand spi_device_reg_cfg cfg;
-  rand spi_device_reg_fifo_level fifo_level;
-  rand spi_device_reg_async_fifo_level async_fifo_level;
-  rand spi_device_reg_status status;
-  rand spi_device_reg_rxf_ptr rxf_ptr;
-  rand spi_device_reg_txf_ptr txf_ptr;
-  rand spi_device_reg_rxf_addr rxf_addr;
-  rand spi_device_reg_txf_addr txf_addr;
-  // memories
-  rand spi_device_mem_buffer buffer;
-
-  `uvm_object_utils(spi_device_reg_block)
-
-  function new(string name = "spi_device_reg_block",
-               int    has_coverage = UVM_NO_COVERAGE);
-    super.new(name, has_coverage);
-  endfunction : new
-
-  virtual function void build(uvm_reg_addr_t base_addr);
-    // create default map
-    this.default_map = create_map(.name("default_map"),
-                                  .base_addr(base_addr),
-                                  .n_bytes(4),
-                                  .endian(UVM_LITTLE_ENDIAN));
-
-    // create registers
-    intr_state = spi_device_reg_intr_state::type_id::create("intr_state");
-    intr_state.configure(.blk_parent(this));
-    intr_state.build();
-    default_map.add_reg(.rg(intr_state),
-                        .offset(32'h0),
-                        .rights("RW"));
-    intr_enable = spi_device_reg_intr_enable::type_id::create("intr_enable");
-    intr_enable.configure(.blk_parent(this));
-    intr_enable.build();
-    default_map.add_reg(.rg(intr_enable),
-                        .offset(32'h4),
-                        .rights("RW"));
-    intr_test = spi_device_reg_intr_test::type_id::create("intr_test");
-    intr_test.configure(.blk_parent(this));
-    intr_test.build();
-    default_map.add_reg(.rg(intr_test),
-                        .offset(32'h8),
-                        .rights("WO"));
-    control = spi_device_reg_control::type_id::create("control");
-    control.configure(.blk_parent(this));
-    control.build();
-    default_map.add_reg(.rg(control),
-                        .offset(32'hc),
-                        .rights("RW"));
-    cfg = spi_device_reg_cfg::type_id::create("cfg");
-    cfg.configure(.blk_parent(this));
-    cfg.build();
-    default_map.add_reg(.rg(cfg),
-                        .offset(32'h10),
-                        .rights("RW"));
-    fifo_level = spi_device_reg_fifo_level::type_id::create("fifo_level");
-    fifo_level.configure(.blk_parent(this));
-    fifo_level.build();
-    default_map.add_reg(.rg(fifo_level),
-                        .offset(32'h14),
-                        .rights("RW"));
-    async_fifo_level = spi_device_reg_async_fifo_level::type_id::create("async_fifo_level");
-    async_fifo_level.configure(.blk_parent(this));
-    async_fifo_level.build();
-    default_map.add_reg(.rg(async_fifo_level),
-                        .offset(32'h18),
-                        .rights("RO"));
-    status = spi_device_reg_status::type_id::create("status");
-    status.configure(.blk_parent(this));
-    status.build();
-    default_map.add_reg(.rg(status),
-                        .offset(32'h1c),
-                        .rights("RO"));
-    rxf_ptr = spi_device_reg_rxf_ptr::type_id::create("rxf_ptr");
-    rxf_ptr.configure(.blk_parent(this));
-    rxf_ptr.build();
-    default_map.add_reg(.rg(rxf_ptr),
-                        .offset(32'h20),
-                        .rights("RW"));
-    txf_ptr = spi_device_reg_txf_ptr::type_id::create("txf_ptr");
-    txf_ptr.configure(.blk_parent(this));
-    txf_ptr.build();
-    default_map.add_reg(.rg(txf_ptr),
-                        .offset(32'h24),
-                        .rights("RW"));
-    rxf_addr = spi_device_reg_rxf_addr::type_id::create("rxf_addr");
-    rxf_addr.configure(.blk_parent(this));
-    rxf_addr.build();
-    default_map.add_reg(.rg(rxf_addr),
-                        .offset(32'h28),
-                        .rights("RW"));
-    txf_addr = spi_device_reg_txf_addr::type_id::create("txf_addr");
-    txf_addr.configure(.blk_parent(this));
-    txf_addr.build();
-    default_map.add_reg(.rg(txf_addr),
-                        .offset(32'h2c),
-                        .rights("RW"));
-
-    // create memories
-    buffer = spi_device_mem_buffer::type_id::create("buffer");
-    buffer.configure(.parent(this));
-    default_map.add_mem(.mem(buffer),
-                        .offset(32'h800),
-                        .rights("RW"));
-  endfunction : build
-
-endclass : spi_device_reg_block
 // Block: rv_timer
 // Class: rv_timer_reg_ctrl
 class rv_timer_reg_ctrl extends dv_base_reg;
@@ -5593,7 +4461,7 @@ class rv_timer_reg_ctrl extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -5624,7 +4492,7 @@ class rv_timer_reg_cfg0 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -5635,7 +4503,7 @@ class rv_timer_reg_cfg0 extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(0),
-      .reset(1),
+      .reset(32'h1),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -5665,7 +4533,7 @@ class rv_timer_reg_timer_v_lower0 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -5695,7 +4563,7 @@ class rv_timer_reg_timer_v_upper0 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -5725,7 +4593,7 @@ class rv_timer_reg_compare_lower0_0 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(4294967295),
+      .reset(32'hffffffff),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -5755,7 +4623,7 @@ class rv_timer_reg_compare_upper0_0 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(4294967295),
+      .reset(32'hffffffff),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -5785,7 +4653,7 @@ class rv_timer_reg_intr_enable0 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -5815,7 +4683,7 @@ class rv_timer_reg_intr_state0 extends dv_base_reg;
       .lsb_pos(0),
       .access("W1C"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -5845,7 +4713,7 @@ class rv_timer_reg_intr_test0 extends dv_base_reg;
       .lsb_pos(0),
       .access("WO"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -5992,7 +4860,7 @@ class rv_plic_reg_ip0 extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6003,7 +4871,7 @@ class rv_plic_reg_ip0 extends dv_base_reg;
       .lsb_pos(1),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6014,7 +4882,7 @@ class rv_plic_reg_ip0 extends dv_base_reg;
       .lsb_pos(2),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6025,7 +4893,7 @@ class rv_plic_reg_ip0 extends dv_base_reg;
       .lsb_pos(3),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6036,7 +4904,7 @@ class rv_plic_reg_ip0 extends dv_base_reg;
       .lsb_pos(4),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6047,7 +4915,7 @@ class rv_plic_reg_ip0 extends dv_base_reg;
       .lsb_pos(5),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6058,7 +4926,7 @@ class rv_plic_reg_ip0 extends dv_base_reg;
       .lsb_pos(6),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6069,7 +4937,7 @@ class rv_plic_reg_ip0 extends dv_base_reg;
       .lsb_pos(7),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6080,7 +4948,7 @@ class rv_plic_reg_ip0 extends dv_base_reg;
       .lsb_pos(8),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6091,7 +4959,7 @@ class rv_plic_reg_ip0 extends dv_base_reg;
       .lsb_pos(9),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6102,7 +4970,7 @@ class rv_plic_reg_ip0 extends dv_base_reg;
       .lsb_pos(10),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6113,7 +4981,7 @@ class rv_plic_reg_ip0 extends dv_base_reg;
       .lsb_pos(11),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6124,7 +4992,7 @@ class rv_plic_reg_ip0 extends dv_base_reg;
       .lsb_pos(12),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6135,7 +5003,7 @@ class rv_plic_reg_ip0 extends dv_base_reg;
       .lsb_pos(13),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6146,7 +5014,7 @@ class rv_plic_reg_ip0 extends dv_base_reg;
       .lsb_pos(14),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6157,7 +5025,7 @@ class rv_plic_reg_ip0 extends dv_base_reg;
       .lsb_pos(15),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6168,7 +5036,7 @@ class rv_plic_reg_ip0 extends dv_base_reg;
       .lsb_pos(16),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6179,7 +5047,7 @@ class rv_plic_reg_ip0 extends dv_base_reg;
       .lsb_pos(17),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6190,7 +5058,7 @@ class rv_plic_reg_ip0 extends dv_base_reg;
       .lsb_pos(18),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6201,7 +5069,7 @@ class rv_plic_reg_ip0 extends dv_base_reg;
       .lsb_pos(19),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6212,7 +5080,7 @@ class rv_plic_reg_ip0 extends dv_base_reg;
       .lsb_pos(20),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6223,7 +5091,7 @@ class rv_plic_reg_ip0 extends dv_base_reg;
       .lsb_pos(21),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6234,7 +5102,7 @@ class rv_plic_reg_ip0 extends dv_base_reg;
       .lsb_pos(22),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6245,7 +5113,7 @@ class rv_plic_reg_ip0 extends dv_base_reg;
       .lsb_pos(23),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6256,7 +5124,7 @@ class rv_plic_reg_ip0 extends dv_base_reg;
       .lsb_pos(24),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6267,7 +5135,7 @@ class rv_plic_reg_ip0 extends dv_base_reg;
       .lsb_pos(25),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6278,7 +5146,7 @@ class rv_plic_reg_ip0 extends dv_base_reg;
       .lsb_pos(26),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6289,7 +5157,7 @@ class rv_plic_reg_ip0 extends dv_base_reg;
       .lsb_pos(27),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6300,7 +5168,7 @@ class rv_plic_reg_ip0 extends dv_base_reg;
       .lsb_pos(28),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6311,7 +5179,7 @@ class rv_plic_reg_ip0 extends dv_base_reg;
       .lsb_pos(29),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6322,7 +5190,7 @@ class rv_plic_reg_ip0 extends dv_base_reg;
       .lsb_pos(30),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6333,7 +5201,7 @@ class rv_plic_reg_ip0 extends dv_base_reg;
       .lsb_pos(31),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6385,7 +5253,7 @@ class rv_plic_reg_ip1 extends dv_base_reg;
       .lsb_pos(0),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6396,7 +5264,7 @@ class rv_plic_reg_ip1 extends dv_base_reg;
       .lsb_pos(1),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6407,7 +5275,7 @@ class rv_plic_reg_ip1 extends dv_base_reg;
       .lsb_pos(2),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6418,7 +5286,7 @@ class rv_plic_reg_ip1 extends dv_base_reg;
       .lsb_pos(3),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6429,7 +5297,7 @@ class rv_plic_reg_ip1 extends dv_base_reg;
       .lsb_pos(4),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6440,7 +5308,7 @@ class rv_plic_reg_ip1 extends dv_base_reg;
       .lsb_pos(5),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6451,7 +5319,7 @@ class rv_plic_reg_ip1 extends dv_base_reg;
       .lsb_pos(6),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6462,7 +5330,7 @@ class rv_plic_reg_ip1 extends dv_base_reg;
       .lsb_pos(7),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6473,7 +5341,7 @@ class rv_plic_reg_ip1 extends dv_base_reg;
       .lsb_pos(8),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6484,7 +5352,7 @@ class rv_plic_reg_ip1 extends dv_base_reg;
       .lsb_pos(9),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6495,7 +5363,7 @@ class rv_plic_reg_ip1 extends dv_base_reg;
       .lsb_pos(10),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6506,7 +5374,7 @@ class rv_plic_reg_ip1 extends dv_base_reg;
       .lsb_pos(11),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6517,7 +5385,7 @@ class rv_plic_reg_ip1 extends dv_base_reg;
       .lsb_pos(12),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6528,7 +5396,7 @@ class rv_plic_reg_ip1 extends dv_base_reg;
       .lsb_pos(13),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6539,7 +5407,7 @@ class rv_plic_reg_ip1 extends dv_base_reg;
       .lsb_pos(14),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6550,7 +5418,7 @@ class rv_plic_reg_ip1 extends dv_base_reg;
       .lsb_pos(15),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6561,7 +5429,7 @@ class rv_plic_reg_ip1 extends dv_base_reg;
       .lsb_pos(16),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6572,7 +5440,7 @@ class rv_plic_reg_ip1 extends dv_base_reg;
       .lsb_pos(17),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6583,7 +5451,7 @@ class rv_plic_reg_ip1 extends dv_base_reg;
       .lsb_pos(18),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6594,7 +5462,7 @@ class rv_plic_reg_ip1 extends dv_base_reg;
       .lsb_pos(19),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6605,7 +5473,7 @@ class rv_plic_reg_ip1 extends dv_base_reg;
       .lsb_pos(20),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6616,7 +5484,7 @@ class rv_plic_reg_ip1 extends dv_base_reg;
       .lsb_pos(21),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6627,7 +5495,7 @@ class rv_plic_reg_ip1 extends dv_base_reg;
       .lsb_pos(22),
       .access("RO"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6688,7 +5556,7 @@ class rv_plic_reg_le0 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6699,7 +5567,7 @@ class rv_plic_reg_le0 extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6710,7 +5578,7 @@ class rv_plic_reg_le0 extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6721,7 +5589,7 @@ class rv_plic_reg_le0 extends dv_base_reg;
       .lsb_pos(3),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6732,7 +5600,7 @@ class rv_plic_reg_le0 extends dv_base_reg;
       .lsb_pos(4),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6743,7 +5611,7 @@ class rv_plic_reg_le0 extends dv_base_reg;
       .lsb_pos(5),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6754,7 +5622,7 @@ class rv_plic_reg_le0 extends dv_base_reg;
       .lsb_pos(6),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6765,7 +5633,7 @@ class rv_plic_reg_le0 extends dv_base_reg;
       .lsb_pos(7),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6776,7 +5644,7 @@ class rv_plic_reg_le0 extends dv_base_reg;
       .lsb_pos(8),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6787,7 +5655,7 @@ class rv_plic_reg_le0 extends dv_base_reg;
       .lsb_pos(9),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6798,7 +5666,7 @@ class rv_plic_reg_le0 extends dv_base_reg;
       .lsb_pos(10),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6809,7 +5677,7 @@ class rv_plic_reg_le0 extends dv_base_reg;
       .lsb_pos(11),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6820,7 +5688,7 @@ class rv_plic_reg_le0 extends dv_base_reg;
       .lsb_pos(12),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6831,7 +5699,7 @@ class rv_plic_reg_le0 extends dv_base_reg;
       .lsb_pos(13),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6842,7 +5710,7 @@ class rv_plic_reg_le0 extends dv_base_reg;
       .lsb_pos(14),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6853,7 +5721,7 @@ class rv_plic_reg_le0 extends dv_base_reg;
       .lsb_pos(15),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6864,7 +5732,7 @@ class rv_plic_reg_le0 extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6875,7 +5743,7 @@ class rv_plic_reg_le0 extends dv_base_reg;
       .lsb_pos(17),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6886,7 +5754,7 @@ class rv_plic_reg_le0 extends dv_base_reg;
       .lsb_pos(18),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6897,7 +5765,7 @@ class rv_plic_reg_le0 extends dv_base_reg;
       .lsb_pos(19),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6908,7 +5776,7 @@ class rv_plic_reg_le0 extends dv_base_reg;
       .lsb_pos(20),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6919,7 +5787,7 @@ class rv_plic_reg_le0 extends dv_base_reg;
       .lsb_pos(21),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6930,7 +5798,7 @@ class rv_plic_reg_le0 extends dv_base_reg;
       .lsb_pos(22),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6941,7 +5809,7 @@ class rv_plic_reg_le0 extends dv_base_reg;
       .lsb_pos(23),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6952,7 +5820,7 @@ class rv_plic_reg_le0 extends dv_base_reg;
       .lsb_pos(24),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6963,7 +5831,7 @@ class rv_plic_reg_le0 extends dv_base_reg;
       .lsb_pos(25),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6974,7 +5842,7 @@ class rv_plic_reg_le0 extends dv_base_reg;
       .lsb_pos(26),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6985,7 +5853,7 @@ class rv_plic_reg_le0 extends dv_base_reg;
       .lsb_pos(27),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -6996,7 +5864,7 @@ class rv_plic_reg_le0 extends dv_base_reg;
       .lsb_pos(28),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7007,7 +5875,7 @@ class rv_plic_reg_le0 extends dv_base_reg;
       .lsb_pos(29),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7018,7 +5886,7 @@ class rv_plic_reg_le0 extends dv_base_reg;
       .lsb_pos(30),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7029,7 +5897,7 @@ class rv_plic_reg_le0 extends dv_base_reg;
       .lsb_pos(31),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7081,7 +5949,7 @@ class rv_plic_reg_le1 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7092,7 +5960,7 @@ class rv_plic_reg_le1 extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7103,7 +5971,7 @@ class rv_plic_reg_le1 extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7114,7 +5982,7 @@ class rv_plic_reg_le1 extends dv_base_reg;
       .lsb_pos(3),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7125,7 +5993,7 @@ class rv_plic_reg_le1 extends dv_base_reg;
       .lsb_pos(4),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7136,7 +6004,7 @@ class rv_plic_reg_le1 extends dv_base_reg;
       .lsb_pos(5),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7147,7 +6015,7 @@ class rv_plic_reg_le1 extends dv_base_reg;
       .lsb_pos(6),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7158,7 +6026,7 @@ class rv_plic_reg_le1 extends dv_base_reg;
       .lsb_pos(7),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7169,7 +6037,7 @@ class rv_plic_reg_le1 extends dv_base_reg;
       .lsb_pos(8),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7180,7 +6048,7 @@ class rv_plic_reg_le1 extends dv_base_reg;
       .lsb_pos(9),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7191,7 +6059,7 @@ class rv_plic_reg_le1 extends dv_base_reg;
       .lsb_pos(10),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7202,7 +6070,7 @@ class rv_plic_reg_le1 extends dv_base_reg;
       .lsb_pos(11),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7213,7 +6081,7 @@ class rv_plic_reg_le1 extends dv_base_reg;
       .lsb_pos(12),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7224,7 +6092,7 @@ class rv_plic_reg_le1 extends dv_base_reg;
       .lsb_pos(13),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7235,7 +6103,7 @@ class rv_plic_reg_le1 extends dv_base_reg;
       .lsb_pos(14),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7246,7 +6114,7 @@ class rv_plic_reg_le1 extends dv_base_reg;
       .lsb_pos(15),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7257,7 +6125,7 @@ class rv_plic_reg_le1 extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7268,7 +6136,7 @@ class rv_plic_reg_le1 extends dv_base_reg;
       .lsb_pos(17),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7279,7 +6147,7 @@ class rv_plic_reg_le1 extends dv_base_reg;
       .lsb_pos(18),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7290,7 +6158,7 @@ class rv_plic_reg_le1 extends dv_base_reg;
       .lsb_pos(19),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7301,7 +6169,7 @@ class rv_plic_reg_le1 extends dv_base_reg;
       .lsb_pos(20),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7312,7 +6180,7 @@ class rv_plic_reg_le1 extends dv_base_reg;
       .lsb_pos(21),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7323,7 +6191,7 @@ class rv_plic_reg_le1 extends dv_base_reg;
       .lsb_pos(22),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7353,7 +6221,7 @@ class rv_plic_reg_prio0 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7383,7 +6251,7 @@ class rv_plic_reg_prio1 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7413,7 +6281,7 @@ class rv_plic_reg_prio2 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7443,7 +6311,7 @@ class rv_plic_reg_prio3 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7473,7 +6341,7 @@ class rv_plic_reg_prio4 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7503,7 +6371,7 @@ class rv_plic_reg_prio5 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7533,7 +6401,7 @@ class rv_plic_reg_prio6 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7563,7 +6431,7 @@ class rv_plic_reg_prio7 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7593,7 +6461,7 @@ class rv_plic_reg_prio8 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7623,7 +6491,7 @@ class rv_plic_reg_prio9 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7653,7 +6521,7 @@ class rv_plic_reg_prio10 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7683,7 +6551,7 @@ class rv_plic_reg_prio11 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7713,7 +6581,7 @@ class rv_plic_reg_prio12 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7743,7 +6611,7 @@ class rv_plic_reg_prio13 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7773,7 +6641,7 @@ class rv_plic_reg_prio14 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7803,7 +6671,7 @@ class rv_plic_reg_prio15 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7833,7 +6701,7 @@ class rv_plic_reg_prio16 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7863,7 +6731,7 @@ class rv_plic_reg_prio17 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7893,7 +6761,7 @@ class rv_plic_reg_prio18 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7923,7 +6791,7 @@ class rv_plic_reg_prio19 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7953,7 +6821,7 @@ class rv_plic_reg_prio20 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -7983,7 +6851,7 @@ class rv_plic_reg_prio21 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -8013,7 +6881,7 @@ class rv_plic_reg_prio22 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -8043,7 +6911,7 @@ class rv_plic_reg_prio23 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -8073,7 +6941,7 @@ class rv_plic_reg_prio24 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -8103,7 +6971,7 @@ class rv_plic_reg_prio25 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -8133,7 +7001,7 @@ class rv_plic_reg_prio26 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -8163,7 +7031,7 @@ class rv_plic_reg_prio27 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -8193,7 +7061,7 @@ class rv_plic_reg_prio28 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -8223,7 +7091,7 @@ class rv_plic_reg_prio29 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -8253,7 +7121,7 @@ class rv_plic_reg_prio30 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -8283,7 +7151,7 @@ class rv_plic_reg_prio31 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -8313,7 +7181,7 @@ class rv_plic_reg_prio32 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -8343,7 +7211,7 @@ class rv_plic_reg_prio33 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -8373,7 +7241,7 @@ class rv_plic_reg_prio34 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -8403,7 +7271,7 @@ class rv_plic_reg_prio35 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -8433,7 +7301,7 @@ class rv_plic_reg_prio36 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -8463,7 +7331,7 @@ class rv_plic_reg_prio37 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -8493,7 +7361,7 @@ class rv_plic_reg_prio38 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -8523,7 +7391,7 @@ class rv_plic_reg_prio39 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -8553,7 +7421,7 @@ class rv_plic_reg_prio40 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -8583,7 +7451,7 @@ class rv_plic_reg_prio41 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -8613,7 +7481,7 @@ class rv_plic_reg_prio42 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -8643,7 +7511,7 @@ class rv_plic_reg_prio43 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -8673,7 +7541,7 @@ class rv_plic_reg_prio44 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -8703,7 +7571,7 @@ class rv_plic_reg_prio45 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -8733,7 +7601,7 @@ class rv_plic_reg_prio46 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -8763,7 +7631,7 @@ class rv_plic_reg_prio47 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -8793,7 +7661,7 @@ class rv_plic_reg_prio48 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -8823,7 +7691,7 @@ class rv_plic_reg_prio49 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -8853,7 +7721,7 @@ class rv_plic_reg_prio50 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -8883,7 +7751,7 @@ class rv_plic_reg_prio51 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -8913,7 +7781,7 @@ class rv_plic_reg_prio52 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -8943,7 +7811,7 @@ class rv_plic_reg_prio53 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -8973,7 +7841,7 @@ class rv_plic_reg_prio54 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9034,7 +7902,7 @@ class rv_plic_reg_ie00 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9045,7 +7913,7 @@ class rv_plic_reg_ie00 extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9056,7 +7924,7 @@ class rv_plic_reg_ie00 extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9067,7 +7935,7 @@ class rv_plic_reg_ie00 extends dv_base_reg;
       .lsb_pos(3),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9078,7 +7946,7 @@ class rv_plic_reg_ie00 extends dv_base_reg;
       .lsb_pos(4),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9089,7 +7957,7 @@ class rv_plic_reg_ie00 extends dv_base_reg;
       .lsb_pos(5),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9100,7 +7968,7 @@ class rv_plic_reg_ie00 extends dv_base_reg;
       .lsb_pos(6),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9111,7 +7979,7 @@ class rv_plic_reg_ie00 extends dv_base_reg;
       .lsb_pos(7),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9122,7 +7990,7 @@ class rv_plic_reg_ie00 extends dv_base_reg;
       .lsb_pos(8),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9133,7 +8001,7 @@ class rv_plic_reg_ie00 extends dv_base_reg;
       .lsb_pos(9),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9144,7 +8012,7 @@ class rv_plic_reg_ie00 extends dv_base_reg;
       .lsb_pos(10),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9155,7 +8023,7 @@ class rv_plic_reg_ie00 extends dv_base_reg;
       .lsb_pos(11),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9166,7 +8034,7 @@ class rv_plic_reg_ie00 extends dv_base_reg;
       .lsb_pos(12),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9177,7 +8045,7 @@ class rv_plic_reg_ie00 extends dv_base_reg;
       .lsb_pos(13),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9188,7 +8056,7 @@ class rv_plic_reg_ie00 extends dv_base_reg;
       .lsb_pos(14),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9199,7 +8067,7 @@ class rv_plic_reg_ie00 extends dv_base_reg;
       .lsb_pos(15),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9210,7 +8078,7 @@ class rv_plic_reg_ie00 extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9221,7 +8089,7 @@ class rv_plic_reg_ie00 extends dv_base_reg;
       .lsb_pos(17),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9232,7 +8100,7 @@ class rv_plic_reg_ie00 extends dv_base_reg;
       .lsb_pos(18),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9243,7 +8111,7 @@ class rv_plic_reg_ie00 extends dv_base_reg;
       .lsb_pos(19),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9254,7 +8122,7 @@ class rv_plic_reg_ie00 extends dv_base_reg;
       .lsb_pos(20),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9265,7 +8133,7 @@ class rv_plic_reg_ie00 extends dv_base_reg;
       .lsb_pos(21),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9276,7 +8144,7 @@ class rv_plic_reg_ie00 extends dv_base_reg;
       .lsb_pos(22),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9287,7 +8155,7 @@ class rv_plic_reg_ie00 extends dv_base_reg;
       .lsb_pos(23),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9298,7 +8166,7 @@ class rv_plic_reg_ie00 extends dv_base_reg;
       .lsb_pos(24),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9309,7 +8177,7 @@ class rv_plic_reg_ie00 extends dv_base_reg;
       .lsb_pos(25),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9320,7 +8188,7 @@ class rv_plic_reg_ie00 extends dv_base_reg;
       .lsb_pos(26),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9331,7 +8199,7 @@ class rv_plic_reg_ie00 extends dv_base_reg;
       .lsb_pos(27),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9342,7 +8210,7 @@ class rv_plic_reg_ie00 extends dv_base_reg;
       .lsb_pos(28),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9353,7 +8221,7 @@ class rv_plic_reg_ie00 extends dv_base_reg;
       .lsb_pos(29),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9364,7 +8232,7 @@ class rv_plic_reg_ie00 extends dv_base_reg;
       .lsb_pos(30),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9375,7 +8243,7 @@ class rv_plic_reg_ie00 extends dv_base_reg;
       .lsb_pos(31),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9427,7 +8295,7 @@ class rv_plic_reg_ie01 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9438,7 +8306,7 @@ class rv_plic_reg_ie01 extends dv_base_reg;
       .lsb_pos(1),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9449,7 +8317,7 @@ class rv_plic_reg_ie01 extends dv_base_reg;
       .lsb_pos(2),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9460,7 +8328,7 @@ class rv_plic_reg_ie01 extends dv_base_reg;
       .lsb_pos(3),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9471,7 +8339,7 @@ class rv_plic_reg_ie01 extends dv_base_reg;
       .lsb_pos(4),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9482,7 +8350,7 @@ class rv_plic_reg_ie01 extends dv_base_reg;
       .lsb_pos(5),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9493,7 +8361,7 @@ class rv_plic_reg_ie01 extends dv_base_reg;
       .lsb_pos(6),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9504,7 +8372,7 @@ class rv_plic_reg_ie01 extends dv_base_reg;
       .lsb_pos(7),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9515,7 +8383,7 @@ class rv_plic_reg_ie01 extends dv_base_reg;
       .lsb_pos(8),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9526,7 +8394,7 @@ class rv_plic_reg_ie01 extends dv_base_reg;
       .lsb_pos(9),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9537,7 +8405,7 @@ class rv_plic_reg_ie01 extends dv_base_reg;
       .lsb_pos(10),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9548,7 +8416,7 @@ class rv_plic_reg_ie01 extends dv_base_reg;
       .lsb_pos(11),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9559,7 +8427,7 @@ class rv_plic_reg_ie01 extends dv_base_reg;
       .lsb_pos(12),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9570,7 +8438,7 @@ class rv_plic_reg_ie01 extends dv_base_reg;
       .lsb_pos(13),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9581,7 +8449,7 @@ class rv_plic_reg_ie01 extends dv_base_reg;
       .lsb_pos(14),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9592,7 +8460,7 @@ class rv_plic_reg_ie01 extends dv_base_reg;
       .lsb_pos(15),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9603,7 +8471,7 @@ class rv_plic_reg_ie01 extends dv_base_reg;
       .lsb_pos(16),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9614,7 +8482,7 @@ class rv_plic_reg_ie01 extends dv_base_reg;
       .lsb_pos(17),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9625,7 +8493,7 @@ class rv_plic_reg_ie01 extends dv_base_reg;
       .lsb_pos(18),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9636,7 +8504,7 @@ class rv_plic_reg_ie01 extends dv_base_reg;
       .lsb_pos(19),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9647,7 +8515,7 @@ class rv_plic_reg_ie01 extends dv_base_reg;
       .lsb_pos(20),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9658,7 +8526,7 @@ class rv_plic_reg_ie01 extends dv_base_reg;
       .lsb_pos(21),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9669,7 +8537,7 @@ class rv_plic_reg_ie01 extends dv_base_reg;
       .lsb_pos(22),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9699,7 +8567,7 @@ class rv_plic_reg_threshold0 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9729,7 +8597,7 @@ class rv_plic_reg_cc0 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(1),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -9759,7 +8627,7 @@ class rv_plic_reg_msip0 extends dv_base_reg;
       .lsb_pos(0),
       .access("RW"),
       .volatile(0),
-      .reset(0),
+      .reset(32'h0),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));
@@ -10237,6 +9105,1981 @@ class rv_plic_reg_block extends dv_base_reg_block;
   endfunction : build
 
 endclass : rv_plic_reg_block
+// Block: aes
+// Class: aes_reg_key0
+class aes_reg_key0 extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field key0;
+
+  `uvm_object_utils(aes_reg_key0)
+
+  function new(string       name = "aes_reg_key0",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    key0 = dv_base_reg_field::type_id::create("key0");
+    key0.configure(
+      .parent(this),
+      .size(32),
+      .lsb_pos(0),
+      .access("WO"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : aes_reg_key0
+
+// Class: aes_reg_key1
+class aes_reg_key1 extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field key1;
+
+  `uvm_object_utils(aes_reg_key1)
+
+  function new(string       name = "aes_reg_key1",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    key1 = dv_base_reg_field::type_id::create("key1");
+    key1.configure(
+      .parent(this),
+      .size(32),
+      .lsb_pos(0),
+      .access("WO"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : aes_reg_key1
+
+// Class: aes_reg_key2
+class aes_reg_key2 extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field key2;
+
+  `uvm_object_utils(aes_reg_key2)
+
+  function new(string       name = "aes_reg_key2",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    key2 = dv_base_reg_field::type_id::create("key2");
+    key2.configure(
+      .parent(this),
+      .size(32),
+      .lsb_pos(0),
+      .access("WO"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : aes_reg_key2
+
+// Class: aes_reg_key3
+class aes_reg_key3 extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field key3;
+
+  `uvm_object_utils(aes_reg_key3)
+
+  function new(string       name = "aes_reg_key3",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    key3 = dv_base_reg_field::type_id::create("key3");
+    key3.configure(
+      .parent(this),
+      .size(32),
+      .lsb_pos(0),
+      .access("WO"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : aes_reg_key3
+
+// Class: aes_reg_key4
+class aes_reg_key4 extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field key4;
+
+  `uvm_object_utils(aes_reg_key4)
+
+  function new(string       name = "aes_reg_key4",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    key4 = dv_base_reg_field::type_id::create("key4");
+    key4.configure(
+      .parent(this),
+      .size(32),
+      .lsb_pos(0),
+      .access("WO"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : aes_reg_key4
+
+// Class: aes_reg_key5
+class aes_reg_key5 extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field key5;
+
+  `uvm_object_utils(aes_reg_key5)
+
+  function new(string       name = "aes_reg_key5",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    key5 = dv_base_reg_field::type_id::create("key5");
+    key5.configure(
+      .parent(this),
+      .size(32),
+      .lsb_pos(0),
+      .access("WO"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : aes_reg_key5
+
+// Class: aes_reg_key6
+class aes_reg_key6 extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field key6;
+
+  `uvm_object_utils(aes_reg_key6)
+
+  function new(string       name = "aes_reg_key6",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    key6 = dv_base_reg_field::type_id::create("key6");
+    key6.configure(
+      .parent(this),
+      .size(32),
+      .lsb_pos(0),
+      .access("WO"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : aes_reg_key6
+
+// Class: aes_reg_key7
+class aes_reg_key7 extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field key7;
+
+  `uvm_object_utils(aes_reg_key7)
+
+  function new(string       name = "aes_reg_key7",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    key7 = dv_base_reg_field::type_id::create("key7");
+    key7.configure(
+      .parent(this),
+      .size(32),
+      .lsb_pos(0),
+      .access("WO"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : aes_reg_key7
+
+// Class: aes_reg_data_in0
+class aes_reg_data_in0 extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field data_in0;
+
+  `uvm_object_utils(aes_reg_data_in0)
+
+  function new(string       name = "aes_reg_data_in0",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    data_in0 = dv_base_reg_field::type_id::create("data_in0");
+    data_in0.configure(
+      .parent(this),
+      .size(32),
+      .lsb_pos(0),
+      .access("WO"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : aes_reg_data_in0
+
+// Class: aes_reg_data_in1
+class aes_reg_data_in1 extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field data_in1;
+
+  `uvm_object_utils(aes_reg_data_in1)
+
+  function new(string       name = "aes_reg_data_in1",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    data_in1 = dv_base_reg_field::type_id::create("data_in1");
+    data_in1.configure(
+      .parent(this),
+      .size(32),
+      .lsb_pos(0),
+      .access("WO"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : aes_reg_data_in1
+
+// Class: aes_reg_data_in2
+class aes_reg_data_in2 extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field data_in2;
+
+  `uvm_object_utils(aes_reg_data_in2)
+
+  function new(string       name = "aes_reg_data_in2",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    data_in2 = dv_base_reg_field::type_id::create("data_in2");
+    data_in2.configure(
+      .parent(this),
+      .size(32),
+      .lsb_pos(0),
+      .access("WO"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : aes_reg_data_in2
+
+// Class: aes_reg_data_in3
+class aes_reg_data_in3 extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field data_in3;
+
+  `uvm_object_utils(aes_reg_data_in3)
+
+  function new(string       name = "aes_reg_data_in3",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    data_in3 = dv_base_reg_field::type_id::create("data_in3");
+    data_in3.configure(
+      .parent(this),
+      .size(32),
+      .lsb_pos(0),
+      .access("WO"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : aes_reg_data_in3
+
+// Class: aes_reg_data_out0
+class aes_reg_data_out0 extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field data_out0;
+
+  `uvm_object_utils(aes_reg_data_out0)
+
+  function new(string       name = "aes_reg_data_out0",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    data_out0 = dv_base_reg_field::type_id::create("data_out0");
+    data_out0.configure(
+      .parent(this),
+      .size(32),
+      .lsb_pos(0),
+      .access("RO"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : aes_reg_data_out0
+
+// Class: aes_reg_data_out1
+class aes_reg_data_out1 extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field data_out1;
+
+  `uvm_object_utils(aes_reg_data_out1)
+
+  function new(string       name = "aes_reg_data_out1",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    data_out1 = dv_base_reg_field::type_id::create("data_out1");
+    data_out1.configure(
+      .parent(this),
+      .size(32),
+      .lsb_pos(0),
+      .access("RO"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : aes_reg_data_out1
+
+// Class: aes_reg_data_out2
+class aes_reg_data_out2 extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field data_out2;
+
+  `uvm_object_utils(aes_reg_data_out2)
+
+  function new(string       name = "aes_reg_data_out2",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    data_out2 = dv_base_reg_field::type_id::create("data_out2");
+    data_out2.configure(
+      .parent(this),
+      .size(32),
+      .lsb_pos(0),
+      .access("RO"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : aes_reg_data_out2
+
+// Class: aes_reg_data_out3
+class aes_reg_data_out3 extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field data_out3;
+
+  `uvm_object_utils(aes_reg_data_out3)
+
+  function new(string       name = "aes_reg_data_out3",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    data_out3 = dv_base_reg_field::type_id::create("data_out3");
+    data_out3.configure(
+      .parent(this),
+      .size(32),
+      .lsb_pos(0),
+      .access("RO"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : aes_reg_data_out3
+
+// Class: aes_reg_ctrl
+class aes_reg_ctrl extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field mode;
+  rand dv_base_reg_field key_len;
+  rand dv_base_reg_field manual_start_trigger;
+  rand dv_base_reg_field force_data_overwrite;
+
+  `uvm_object_utils(aes_reg_ctrl)
+
+  function new(string       name = "aes_reg_ctrl",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    mode = dv_base_reg_field::type_id::create("mode");
+    mode.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(0),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    key_len = dv_base_reg_field::type_id::create("key_len");
+    key_len.configure(
+      .parent(this),
+      .size(3),
+      .lsb_pos(1),
+      .access("RW"),
+      .volatile(1),
+      .reset(32'h1),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    manual_start_trigger = dv_base_reg_field::type_id::create("manual_start_trigger");
+    manual_start_trigger.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(4),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    force_data_overwrite = dv_base_reg_field::type_id::create("force_data_overwrite");
+    force_data_overwrite.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(5),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : aes_reg_ctrl
+
+// Class: aes_reg_trigger
+class aes_reg_trigger extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field start;
+  rand dv_base_reg_field key_clear;
+  rand dv_base_reg_field data_out_clear;
+
+  `uvm_object_utils(aes_reg_trigger)
+
+  function new(string       name = "aes_reg_trigger",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    start = dv_base_reg_field::type_id::create("start");
+    start.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(0),
+      .access("RW"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    key_clear = dv_base_reg_field::type_id::create("key_clear");
+    key_clear.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(1),
+      .access("RW"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    data_out_clear = dv_base_reg_field::type_id::create("data_out_clear");
+    data_out_clear.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(2),
+      .access("RW"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : aes_reg_trigger
+
+// Class: aes_reg_status
+class aes_reg_status extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field idle;
+  rand dv_base_reg_field stall;
+  rand dv_base_reg_field output_valid;
+  rand dv_base_reg_field input_ready;
+
+  `uvm_object_utils(aes_reg_status)
+
+  function new(string       name = "aes_reg_status",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    idle = dv_base_reg_field::type_id::create("idle");
+    idle.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(0),
+      .access("RO"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    stall = dv_base_reg_field::type_id::create("stall");
+    stall.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(1),
+      .access("RO"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    output_valid = dv_base_reg_field::type_id::create("output_valid");
+    output_valid.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(2),
+      .access("RO"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    input_ready = dv_base_reg_field::type_id::create("input_ready");
+    input_ready.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(3),
+      .access("RO"),
+      .volatile(1),
+      .reset(32'h1),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : aes_reg_status
+
+// Class: aes_reg_block
+class aes_reg_block extends dv_base_reg_block;
+  // registers
+  rand aes_reg_key0 key0;
+  rand aes_reg_key1 key1;
+  rand aes_reg_key2 key2;
+  rand aes_reg_key3 key3;
+  rand aes_reg_key4 key4;
+  rand aes_reg_key5 key5;
+  rand aes_reg_key6 key6;
+  rand aes_reg_key7 key7;
+  rand aes_reg_data_in0 data_in0;
+  rand aes_reg_data_in1 data_in1;
+  rand aes_reg_data_in2 data_in2;
+  rand aes_reg_data_in3 data_in3;
+  rand aes_reg_data_out0 data_out0;
+  rand aes_reg_data_out1 data_out1;
+  rand aes_reg_data_out2 data_out2;
+  rand aes_reg_data_out3 data_out3;
+  rand aes_reg_ctrl ctrl;
+  rand aes_reg_trigger trigger;
+  rand aes_reg_status status;
+
+  `uvm_object_utils(aes_reg_block)
+
+  function new(string name = "aes_reg_block",
+               int    has_coverage = UVM_NO_COVERAGE);
+    super.new(name, has_coverage);
+  endfunction : new
+
+  virtual function void build(uvm_reg_addr_t base_addr);
+    // create default map
+    this.default_map = create_map(.name("default_map"),
+                                  .base_addr(base_addr),
+                                  .n_bytes(4),
+                                  .endian(UVM_LITTLE_ENDIAN));
+
+    // create registers
+    key0 = aes_reg_key0::type_id::create("key0");
+    key0.configure(.blk_parent(this));
+    key0.build();
+    default_map.add_reg(.rg(key0),
+                        .offset(32'h0),
+                        .rights("WO"));
+    key1 = aes_reg_key1::type_id::create("key1");
+    key1.configure(.blk_parent(this));
+    key1.build();
+    default_map.add_reg(.rg(key1),
+                        .offset(32'h4),
+                        .rights("WO"));
+    key2 = aes_reg_key2::type_id::create("key2");
+    key2.configure(.blk_parent(this));
+    key2.build();
+    default_map.add_reg(.rg(key2),
+                        .offset(32'h8),
+                        .rights("WO"));
+    key3 = aes_reg_key3::type_id::create("key3");
+    key3.configure(.blk_parent(this));
+    key3.build();
+    default_map.add_reg(.rg(key3),
+                        .offset(32'hc),
+                        .rights("WO"));
+    key4 = aes_reg_key4::type_id::create("key4");
+    key4.configure(.blk_parent(this));
+    key4.build();
+    default_map.add_reg(.rg(key4),
+                        .offset(32'h10),
+                        .rights("WO"));
+    key5 = aes_reg_key5::type_id::create("key5");
+    key5.configure(.blk_parent(this));
+    key5.build();
+    default_map.add_reg(.rg(key5),
+                        .offset(32'h14),
+                        .rights("WO"));
+    key6 = aes_reg_key6::type_id::create("key6");
+    key6.configure(.blk_parent(this));
+    key6.build();
+    default_map.add_reg(.rg(key6),
+                        .offset(32'h18),
+                        .rights("WO"));
+    key7 = aes_reg_key7::type_id::create("key7");
+    key7.configure(.blk_parent(this));
+    key7.build();
+    default_map.add_reg(.rg(key7),
+                        .offset(32'h1c),
+                        .rights("WO"));
+    data_in0 = aes_reg_data_in0::type_id::create("data_in0");
+    data_in0.configure(.blk_parent(this));
+    data_in0.build();
+    default_map.add_reg(.rg(data_in0),
+                        .offset(32'h20),
+                        .rights("WO"));
+    data_in1 = aes_reg_data_in1::type_id::create("data_in1");
+    data_in1.configure(.blk_parent(this));
+    data_in1.build();
+    default_map.add_reg(.rg(data_in1),
+                        .offset(32'h24),
+                        .rights("WO"));
+    data_in2 = aes_reg_data_in2::type_id::create("data_in2");
+    data_in2.configure(.blk_parent(this));
+    data_in2.build();
+    default_map.add_reg(.rg(data_in2),
+                        .offset(32'h28),
+                        .rights("WO"));
+    data_in3 = aes_reg_data_in3::type_id::create("data_in3");
+    data_in3.configure(.blk_parent(this));
+    data_in3.build();
+    default_map.add_reg(.rg(data_in3),
+                        .offset(32'h2c),
+                        .rights("WO"));
+    data_out0 = aes_reg_data_out0::type_id::create("data_out0");
+    data_out0.configure(.blk_parent(this));
+    data_out0.build();
+    default_map.add_reg(.rg(data_out0),
+                        .offset(32'h30),
+                        .rights("RO"));
+    data_out1 = aes_reg_data_out1::type_id::create("data_out1");
+    data_out1.configure(.blk_parent(this));
+    data_out1.build();
+    default_map.add_reg(.rg(data_out1),
+                        .offset(32'h34),
+                        .rights("RO"));
+    data_out2 = aes_reg_data_out2::type_id::create("data_out2");
+    data_out2.configure(.blk_parent(this));
+    data_out2.build();
+    default_map.add_reg(.rg(data_out2),
+                        .offset(32'h38),
+                        .rights("RO"));
+    data_out3 = aes_reg_data_out3::type_id::create("data_out3");
+    data_out3.configure(.blk_parent(this));
+    data_out3.build();
+    default_map.add_reg(.rg(data_out3),
+                        .offset(32'h3c),
+                        .rights("RO"));
+    ctrl = aes_reg_ctrl::type_id::create("ctrl");
+    ctrl.configure(.blk_parent(this));
+    ctrl.build();
+    default_map.add_reg(.rg(ctrl),
+                        .offset(32'h40),
+                        .rights("RW"));
+    trigger = aes_reg_trigger::type_id::create("trigger");
+    trigger.configure(.blk_parent(this));
+    trigger.build();
+    default_map.add_reg(.rg(trigger),
+                        .offset(32'h44),
+                        .rights("RW"));
+    status = aes_reg_status::type_id::create("status");
+    status.configure(.blk_parent(this));
+    status.build();
+    default_map.add_reg(.rg(status),
+                        .offset(32'h48),
+                        .rights("RO"));
+  endfunction : build
+
+endclass : aes_reg_block
+// Block: hmac
+// Class: hmac_reg_intr_state
+class hmac_reg_intr_state extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field hmac_done;
+  rand dv_base_reg_field fifo_full;
+  rand dv_base_reg_field hmac_err;
+
+  `uvm_object_utils(hmac_reg_intr_state)
+
+  function new(string       name = "hmac_reg_intr_state",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    hmac_done = dv_base_reg_field::type_id::create("hmac_done");
+    hmac_done.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(0),
+      .access("W1C"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    fifo_full = dv_base_reg_field::type_id::create("fifo_full");
+    fifo_full.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(1),
+      .access("W1C"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    hmac_err = dv_base_reg_field::type_id::create("hmac_err");
+    hmac_err.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(2),
+      .access("W1C"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : hmac_reg_intr_state
+
+// Class: hmac_reg_intr_enable
+class hmac_reg_intr_enable extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field hmac_done;
+  rand dv_base_reg_field fifo_full;
+  rand dv_base_reg_field hmac_err;
+
+  `uvm_object_utils(hmac_reg_intr_enable)
+
+  function new(string       name = "hmac_reg_intr_enable",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    hmac_done = dv_base_reg_field::type_id::create("hmac_done");
+    hmac_done.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(0),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    fifo_full = dv_base_reg_field::type_id::create("fifo_full");
+    fifo_full.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(1),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    hmac_err = dv_base_reg_field::type_id::create("hmac_err");
+    hmac_err.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(2),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : hmac_reg_intr_enable
+
+// Class: hmac_reg_intr_test
+class hmac_reg_intr_test extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field hmac_done;
+  rand dv_base_reg_field fifo_full;
+  rand dv_base_reg_field hmac_err;
+
+  `uvm_object_utils(hmac_reg_intr_test)
+
+  function new(string       name = "hmac_reg_intr_test",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    hmac_done = dv_base_reg_field::type_id::create("hmac_done");
+    hmac_done.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(0),
+      .access("WO"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    fifo_full = dv_base_reg_field::type_id::create("fifo_full");
+    fifo_full.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(1),
+      .access("WO"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    hmac_err = dv_base_reg_field::type_id::create("hmac_err");
+    hmac_err.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(2),
+      .access("WO"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : hmac_reg_intr_test
+
+// Class: hmac_reg_cfg
+class hmac_reg_cfg extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field hmac_en;
+  rand dv_base_reg_field sha_en;
+  rand dv_base_reg_field endian_swap;
+  rand dv_base_reg_field digest_swap;
+
+  `uvm_object_utils(hmac_reg_cfg)
+
+  function new(string       name = "hmac_reg_cfg",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    hmac_en = dv_base_reg_field::type_id::create("hmac_en");
+    hmac_en.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(0),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    sha_en = dv_base_reg_field::type_id::create("sha_en");
+    sha_en.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(1),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    endian_swap = dv_base_reg_field::type_id::create("endian_swap");
+    endian_swap.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(2),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h1),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    digest_swap = dv_base_reg_field::type_id::create("digest_swap");
+    digest_swap.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(3),
+      .access("RW"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : hmac_reg_cfg
+
+// Class: hmac_reg_cmd
+class hmac_reg_cmd extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field hash_start;
+  rand dv_base_reg_field hash_process;
+
+  `uvm_object_utils(hmac_reg_cmd)
+
+  function new(string       name = "hmac_reg_cmd",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    hash_start = dv_base_reg_field::type_id::create("hash_start");
+    hash_start.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(0),
+      .access("W1C"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    hash_process = dv_base_reg_field::type_id::create("hash_process");
+    hash_process.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(1),
+      .access("W1C"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : hmac_reg_cmd
+
+// Class: hmac_reg_status
+class hmac_reg_status extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field fifo_empty;
+  rand dv_base_reg_field fifo_full;
+  rand dv_base_reg_field fifo_depth;
+
+  `uvm_object_utils(hmac_reg_status)
+
+  function new(string       name = "hmac_reg_status",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    fifo_empty = dv_base_reg_field::type_id::create("fifo_empty");
+    fifo_empty.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(0),
+      .access("RO"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    fifo_full = dv_base_reg_field::type_id::create("fifo_full");
+    fifo_full.configure(
+      .parent(this),
+      .size(1),
+      .lsb_pos(1),
+      .access("RO"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+    fifo_depth = dv_base_reg_field::type_id::create("fifo_depth");
+    fifo_depth.configure(
+      .parent(this),
+      .size(5),
+      .lsb_pos(4),
+      .access("RO"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : hmac_reg_status
+
+// Class: hmac_reg_err_code
+class hmac_reg_err_code extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field err_code;
+
+  `uvm_object_utils(hmac_reg_err_code)
+
+  function new(string       name = "hmac_reg_err_code",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    err_code = dv_base_reg_field::type_id::create("err_code");
+    err_code.configure(
+      .parent(this),
+      .size(32),
+      .lsb_pos(0),
+      .access("RO"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : hmac_reg_err_code
+
+// Class: hmac_reg_wipe_secret
+class hmac_reg_wipe_secret extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field secret;
+
+  `uvm_object_utils(hmac_reg_wipe_secret)
+
+  function new(string       name = "hmac_reg_wipe_secret",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    secret = dv_base_reg_field::type_id::create("secret");
+    secret.configure(
+      .parent(this),
+      .size(32),
+      .lsb_pos(0),
+      .access("WO"),
+      .volatile(0),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : hmac_reg_wipe_secret
+
+// Class: hmac_reg_key0
+class hmac_reg_key0 extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field key0;
+
+  `uvm_object_utils(hmac_reg_key0)
+
+  function new(string       name = "hmac_reg_key0",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    key0 = dv_base_reg_field::type_id::create("key0");
+    key0.configure(
+      .parent(this),
+      .size(32),
+      .lsb_pos(0),
+      .access("WO"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : hmac_reg_key0
+
+// Class: hmac_reg_key1
+class hmac_reg_key1 extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field key1;
+
+  `uvm_object_utils(hmac_reg_key1)
+
+  function new(string       name = "hmac_reg_key1",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    key1 = dv_base_reg_field::type_id::create("key1");
+    key1.configure(
+      .parent(this),
+      .size(32),
+      .lsb_pos(0),
+      .access("WO"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : hmac_reg_key1
+
+// Class: hmac_reg_key2
+class hmac_reg_key2 extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field key2;
+
+  `uvm_object_utils(hmac_reg_key2)
+
+  function new(string       name = "hmac_reg_key2",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    key2 = dv_base_reg_field::type_id::create("key2");
+    key2.configure(
+      .parent(this),
+      .size(32),
+      .lsb_pos(0),
+      .access("WO"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : hmac_reg_key2
+
+// Class: hmac_reg_key3
+class hmac_reg_key3 extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field key3;
+
+  `uvm_object_utils(hmac_reg_key3)
+
+  function new(string       name = "hmac_reg_key3",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    key3 = dv_base_reg_field::type_id::create("key3");
+    key3.configure(
+      .parent(this),
+      .size(32),
+      .lsb_pos(0),
+      .access("WO"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : hmac_reg_key3
+
+// Class: hmac_reg_key4
+class hmac_reg_key4 extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field key4;
+
+  `uvm_object_utils(hmac_reg_key4)
+
+  function new(string       name = "hmac_reg_key4",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    key4 = dv_base_reg_field::type_id::create("key4");
+    key4.configure(
+      .parent(this),
+      .size(32),
+      .lsb_pos(0),
+      .access("WO"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : hmac_reg_key4
+
+// Class: hmac_reg_key5
+class hmac_reg_key5 extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field key5;
+
+  `uvm_object_utils(hmac_reg_key5)
+
+  function new(string       name = "hmac_reg_key5",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    key5 = dv_base_reg_field::type_id::create("key5");
+    key5.configure(
+      .parent(this),
+      .size(32),
+      .lsb_pos(0),
+      .access("WO"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : hmac_reg_key5
+
+// Class: hmac_reg_key6
+class hmac_reg_key6 extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field key6;
+
+  `uvm_object_utils(hmac_reg_key6)
+
+  function new(string       name = "hmac_reg_key6",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    key6 = dv_base_reg_field::type_id::create("key6");
+    key6.configure(
+      .parent(this),
+      .size(32),
+      .lsb_pos(0),
+      .access("WO"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : hmac_reg_key6
+
+// Class: hmac_reg_key7
+class hmac_reg_key7 extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field key7;
+
+  `uvm_object_utils(hmac_reg_key7)
+
+  function new(string       name = "hmac_reg_key7",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    key7 = dv_base_reg_field::type_id::create("key7");
+    key7.configure(
+      .parent(this),
+      .size(32),
+      .lsb_pos(0),
+      .access("WO"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : hmac_reg_key7
+
+// Class: hmac_reg_digest0
+class hmac_reg_digest0 extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field digest0;
+
+  `uvm_object_utils(hmac_reg_digest0)
+
+  function new(string       name = "hmac_reg_digest0",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    digest0 = dv_base_reg_field::type_id::create("digest0");
+    digest0.configure(
+      .parent(this),
+      .size(32),
+      .lsb_pos(0),
+      .access("RO"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : hmac_reg_digest0
+
+// Class: hmac_reg_digest1
+class hmac_reg_digest1 extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field digest1;
+
+  `uvm_object_utils(hmac_reg_digest1)
+
+  function new(string       name = "hmac_reg_digest1",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    digest1 = dv_base_reg_field::type_id::create("digest1");
+    digest1.configure(
+      .parent(this),
+      .size(32),
+      .lsb_pos(0),
+      .access("RO"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : hmac_reg_digest1
+
+// Class: hmac_reg_digest2
+class hmac_reg_digest2 extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field digest2;
+
+  `uvm_object_utils(hmac_reg_digest2)
+
+  function new(string       name = "hmac_reg_digest2",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    digest2 = dv_base_reg_field::type_id::create("digest2");
+    digest2.configure(
+      .parent(this),
+      .size(32),
+      .lsb_pos(0),
+      .access("RO"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : hmac_reg_digest2
+
+// Class: hmac_reg_digest3
+class hmac_reg_digest3 extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field digest3;
+
+  `uvm_object_utils(hmac_reg_digest3)
+
+  function new(string       name = "hmac_reg_digest3",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    digest3 = dv_base_reg_field::type_id::create("digest3");
+    digest3.configure(
+      .parent(this),
+      .size(32),
+      .lsb_pos(0),
+      .access("RO"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : hmac_reg_digest3
+
+// Class: hmac_reg_digest4
+class hmac_reg_digest4 extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field digest4;
+
+  `uvm_object_utils(hmac_reg_digest4)
+
+  function new(string       name = "hmac_reg_digest4",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    digest4 = dv_base_reg_field::type_id::create("digest4");
+    digest4.configure(
+      .parent(this),
+      .size(32),
+      .lsb_pos(0),
+      .access("RO"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : hmac_reg_digest4
+
+// Class: hmac_reg_digest5
+class hmac_reg_digest5 extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field digest5;
+
+  `uvm_object_utils(hmac_reg_digest5)
+
+  function new(string       name = "hmac_reg_digest5",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    digest5 = dv_base_reg_field::type_id::create("digest5");
+    digest5.configure(
+      .parent(this),
+      .size(32),
+      .lsb_pos(0),
+      .access("RO"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : hmac_reg_digest5
+
+// Class: hmac_reg_digest6
+class hmac_reg_digest6 extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field digest6;
+
+  `uvm_object_utils(hmac_reg_digest6)
+
+  function new(string       name = "hmac_reg_digest6",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    digest6 = dv_base_reg_field::type_id::create("digest6");
+    digest6.configure(
+      .parent(this),
+      .size(32),
+      .lsb_pos(0),
+      .access("RO"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : hmac_reg_digest6
+
+// Class: hmac_reg_digest7
+class hmac_reg_digest7 extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field digest7;
+
+  `uvm_object_utils(hmac_reg_digest7)
+
+  function new(string       name = "hmac_reg_digest7",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    digest7 = dv_base_reg_field::type_id::create("digest7");
+    digest7.configure(
+      .parent(this),
+      .size(32),
+      .lsb_pos(0),
+      .access("RO"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : hmac_reg_digest7
+
+// Class: hmac_reg_msg_length_lower
+class hmac_reg_msg_length_lower extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field v;
+
+  `uvm_object_utils(hmac_reg_msg_length_lower)
+
+  function new(string       name = "hmac_reg_msg_length_lower",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    v = dv_base_reg_field::type_id::create("v");
+    v.configure(
+      .parent(this),
+      .size(32),
+      .lsb_pos(0),
+      .access("RO"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : hmac_reg_msg_length_lower
+
+// Class: hmac_reg_msg_length_upper
+class hmac_reg_msg_length_upper extends dv_base_reg;
+  // fields
+  rand dv_base_reg_field v;
+
+  `uvm_object_utils(hmac_reg_msg_length_upper)
+
+  function new(string       name = "hmac_reg_msg_length_upper",
+               int unsigned n_bits = 32,
+               int          has_coverage = UVM_NO_COVERAGE);
+    super.new(name, n_bits, has_coverage);
+  endfunction : new
+
+  virtual function void build();
+    // create fields
+    v = dv_base_reg_field::type_id::create("v");
+    v.configure(
+      .parent(this),
+      .size(32),
+      .lsb_pos(0),
+      .access("RO"),
+      .volatile(1),
+      .reset(32'h0),
+      .has_reset(1),
+      .is_rand(1),
+      .individually_accessible(1));
+  endfunction : build
+
+endclass : hmac_reg_msg_length_upper
+
+// Class: hmac_mem_msg_fifo
+class hmac_mem_msg_fifo extends dv_base_mem;
+
+  `uvm_object_utils(hmac_mem_msg_fifo)
+
+  function new(string           name = "hmac_mem_msg_fifo",
+               longint unsigned size = 512,
+               int unsigned     n_bits = 32,
+               string           access = "RW"/* TODO:"WO"*/,
+               int              has_coverage = UVM_NO_COVERAGE);
+    super.new(name, size, n_bits, access, has_coverage);
+  endfunction : new
+
+endclass : hmac_mem_msg_fifo
+
+// Class: hmac_reg_block
+class hmac_reg_block extends dv_base_reg_block;
+  // registers
+  rand hmac_reg_intr_state intr_state;
+  rand hmac_reg_intr_enable intr_enable;
+  rand hmac_reg_intr_test intr_test;
+  rand hmac_reg_cfg cfg;
+  rand hmac_reg_cmd cmd;
+  rand hmac_reg_status status;
+  rand hmac_reg_err_code err_code;
+  rand hmac_reg_wipe_secret wipe_secret;
+  rand hmac_reg_key0 key0;
+  rand hmac_reg_key1 key1;
+  rand hmac_reg_key2 key2;
+  rand hmac_reg_key3 key3;
+  rand hmac_reg_key4 key4;
+  rand hmac_reg_key5 key5;
+  rand hmac_reg_key6 key6;
+  rand hmac_reg_key7 key7;
+  rand hmac_reg_digest0 digest0;
+  rand hmac_reg_digest1 digest1;
+  rand hmac_reg_digest2 digest2;
+  rand hmac_reg_digest3 digest3;
+  rand hmac_reg_digest4 digest4;
+  rand hmac_reg_digest5 digest5;
+  rand hmac_reg_digest6 digest6;
+  rand hmac_reg_digest7 digest7;
+  rand hmac_reg_msg_length_lower msg_length_lower;
+  rand hmac_reg_msg_length_upper msg_length_upper;
+  // memories
+  rand hmac_mem_msg_fifo msg_fifo;
+
+  `uvm_object_utils(hmac_reg_block)
+
+  function new(string name = "hmac_reg_block",
+               int    has_coverage = UVM_NO_COVERAGE);
+    super.new(name, has_coverage);
+  endfunction : new
+
+  virtual function void build(uvm_reg_addr_t base_addr);
+    // create default map
+    this.default_map = create_map(.name("default_map"),
+                                  .base_addr(base_addr),
+                                  .n_bytes(4),
+                                  .endian(UVM_LITTLE_ENDIAN));
+
+    // create registers
+    intr_state = hmac_reg_intr_state::type_id::create("intr_state");
+    intr_state.configure(.blk_parent(this));
+    intr_state.build();
+    default_map.add_reg(.rg(intr_state),
+                        .offset(32'h0),
+                        .rights("RW"));
+    intr_enable = hmac_reg_intr_enable::type_id::create("intr_enable");
+    intr_enable.configure(.blk_parent(this));
+    intr_enable.build();
+    default_map.add_reg(.rg(intr_enable),
+                        .offset(32'h4),
+                        .rights("RW"));
+    intr_test = hmac_reg_intr_test::type_id::create("intr_test");
+    intr_test.configure(.blk_parent(this));
+    intr_test.build();
+    default_map.add_reg(.rg(intr_test),
+                        .offset(32'h8),
+                        .rights("WO"));
+    cfg = hmac_reg_cfg::type_id::create("cfg");
+    cfg.configure(.blk_parent(this));
+    cfg.build();
+    default_map.add_reg(.rg(cfg),
+                        .offset(32'hc),
+                        .rights("RW"));
+    cmd = hmac_reg_cmd::type_id::create("cmd");
+    cmd.configure(.blk_parent(this));
+    cmd.build();
+    default_map.add_reg(.rg(cmd),
+                        .offset(32'h10),
+                        .rights("RW"));
+    status = hmac_reg_status::type_id::create("status");
+    status.configure(.blk_parent(this));
+    status.build();
+    default_map.add_reg(.rg(status),
+                        .offset(32'h14),
+                        .rights("RO"));
+    err_code = hmac_reg_err_code::type_id::create("err_code");
+    err_code.configure(.blk_parent(this));
+    err_code.build();
+    default_map.add_reg(.rg(err_code),
+                        .offset(32'h18),
+                        .rights("RO"));
+    wipe_secret = hmac_reg_wipe_secret::type_id::create("wipe_secret");
+    wipe_secret.configure(.blk_parent(this));
+    wipe_secret.build();
+    default_map.add_reg(.rg(wipe_secret),
+                        .offset(32'h1c),
+                        .rights("WO"));
+    key0 = hmac_reg_key0::type_id::create("key0");
+    key0.configure(.blk_parent(this));
+    key0.build();
+    default_map.add_reg(.rg(key0),
+                        .offset(32'h20),
+                        .rights("WO"));
+    key1 = hmac_reg_key1::type_id::create("key1");
+    key1.configure(.blk_parent(this));
+    key1.build();
+    default_map.add_reg(.rg(key1),
+                        .offset(32'h24),
+                        .rights("WO"));
+    key2 = hmac_reg_key2::type_id::create("key2");
+    key2.configure(.blk_parent(this));
+    key2.build();
+    default_map.add_reg(.rg(key2),
+                        .offset(32'h28),
+                        .rights("WO"));
+    key3 = hmac_reg_key3::type_id::create("key3");
+    key3.configure(.blk_parent(this));
+    key3.build();
+    default_map.add_reg(.rg(key3),
+                        .offset(32'h2c),
+                        .rights("WO"));
+    key4 = hmac_reg_key4::type_id::create("key4");
+    key4.configure(.blk_parent(this));
+    key4.build();
+    default_map.add_reg(.rg(key4),
+                        .offset(32'h30),
+                        .rights("WO"));
+    key5 = hmac_reg_key5::type_id::create("key5");
+    key5.configure(.blk_parent(this));
+    key5.build();
+    default_map.add_reg(.rg(key5),
+                        .offset(32'h34),
+                        .rights("WO"));
+    key6 = hmac_reg_key6::type_id::create("key6");
+    key6.configure(.blk_parent(this));
+    key6.build();
+    default_map.add_reg(.rg(key6),
+                        .offset(32'h38),
+                        .rights("WO"));
+    key7 = hmac_reg_key7::type_id::create("key7");
+    key7.configure(.blk_parent(this));
+    key7.build();
+    default_map.add_reg(.rg(key7),
+                        .offset(32'h3c),
+                        .rights("WO"));
+    digest0 = hmac_reg_digest0::type_id::create("digest0");
+    digest0.configure(.blk_parent(this));
+    digest0.build();
+    default_map.add_reg(.rg(digest0),
+                        .offset(32'h40),
+                        .rights("RO"));
+    digest1 = hmac_reg_digest1::type_id::create("digest1");
+    digest1.configure(.blk_parent(this));
+    digest1.build();
+    default_map.add_reg(.rg(digest1),
+                        .offset(32'h44),
+                        .rights("RO"));
+    digest2 = hmac_reg_digest2::type_id::create("digest2");
+    digest2.configure(.blk_parent(this));
+    digest2.build();
+    default_map.add_reg(.rg(digest2),
+                        .offset(32'h48),
+                        .rights("RO"));
+    digest3 = hmac_reg_digest3::type_id::create("digest3");
+    digest3.configure(.blk_parent(this));
+    digest3.build();
+    default_map.add_reg(.rg(digest3),
+                        .offset(32'h4c),
+                        .rights("RO"));
+    digest4 = hmac_reg_digest4::type_id::create("digest4");
+    digest4.configure(.blk_parent(this));
+    digest4.build();
+    default_map.add_reg(.rg(digest4),
+                        .offset(32'h50),
+                        .rights("RO"));
+    digest5 = hmac_reg_digest5::type_id::create("digest5");
+    digest5.configure(.blk_parent(this));
+    digest5.build();
+    default_map.add_reg(.rg(digest5),
+                        .offset(32'h54),
+                        .rights("RO"));
+    digest6 = hmac_reg_digest6::type_id::create("digest6");
+    digest6.configure(.blk_parent(this));
+    digest6.build();
+    default_map.add_reg(.rg(digest6),
+                        .offset(32'h58),
+                        .rights("RO"));
+    digest7 = hmac_reg_digest7::type_id::create("digest7");
+    digest7.configure(.blk_parent(this));
+    digest7.build();
+    default_map.add_reg(.rg(digest7),
+                        .offset(32'h5c),
+                        .rights("RO"));
+    msg_length_lower = hmac_reg_msg_length_lower::type_id::create("msg_length_lower");
+    msg_length_lower.configure(.blk_parent(this));
+    msg_length_lower.build();
+    default_map.add_reg(.rg(msg_length_lower),
+                        .offset(32'h60),
+                        .rights("RO"));
+    msg_length_upper = hmac_reg_msg_length_upper::type_id::create("msg_length_upper");
+    msg_length_upper.configure(.blk_parent(this));
+    msg_length_upper.build();
+    default_map.add_reg(.rg(msg_length_upper),
+                        .offset(32'h64),
+                        .rights("RO"));
+
+    // create memories
+    msg_fifo = hmac_mem_msg_fifo::type_id::create("msg_fifo");
+    msg_fifo.configure(.parent(this));
+    default_map.add_mem(.mem(msg_fifo),
+                        .offset(32'h800),
+                        .rights("WO"));
+  endfunction : build
+
+endclass : hmac_reg_block
 // Block: chip
 // Class: chip_mem_rom
 class chip_mem_rom extends dv_base_mem;
@@ -10286,13 +11129,14 @@ endclass : chip_mem_eflash
 // Class: chip_reg_block
 class chip_reg_block extends dv_base_reg_block;
   // sub blocks
-  rand hmac_reg_block hmac;
-  rand gpio_reg_block gpio;
-  rand flash_ctrl_reg_block flash_ctrl;
   rand uart_reg_block uart;
+  rand gpio_reg_block gpio;
   rand spi_device_reg_block spi_device;
+  rand flash_ctrl_reg_block flash_ctrl;
   rand rv_timer_reg_block rv_timer;
   rand rv_plic_reg_block rv_plic;
+  rand aes_reg_block aes;
+  rand hmac_reg_block hmac;
   // memories
   rand chip_mem_rom rom;
   rand chip_mem_ram_main ram_main;
@@ -10313,31 +11157,26 @@ class chip_reg_block extends dv_base_reg_block;
                                   .endian(UVM_LITTLE_ENDIAN));
 
     // create sub blocks and add their maps
-    hmac = hmac_reg_block::type_id::create("hmac");
-    hmac.configure(.parent(this));
-    hmac.build(.base_addr(base_addr + 32'h40120000));
-    default_map.add_submap(.child_map(hmac.default_map),
-                           .offset(base_addr + 32'h40120000));
-    gpio = gpio_reg_block::type_id::create("gpio");
-    gpio.configure(.parent(this));
-    gpio.build(.base_addr(base_addr + 32'h40010000));
-    default_map.add_submap(.child_map(gpio.default_map),
-                           .offset(base_addr + 32'h40010000));
-    flash_ctrl = flash_ctrl_reg_block::type_id::create("flash_ctrl");
-    flash_ctrl.configure(.parent(this));
-    flash_ctrl.build(.base_addr(base_addr + 32'h40030000));
-    default_map.add_submap(.child_map(flash_ctrl.default_map),
-                           .offset(base_addr + 32'h40030000));
     uart = uart_reg_block::type_id::create("uart");
     uart.configure(.parent(this));
     uart.build(.base_addr(base_addr + 32'h40000000));
     default_map.add_submap(.child_map(uart.default_map),
                            .offset(base_addr + 32'h40000000));
+    gpio = gpio_reg_block::type_id::create("gpio");
+    gpio.configure(.parent(this));
+    gpio.build(.base_addr(base_addr + 32'h40010000));
+    default_map.add_submap(.child_map(gpio.default_map),
+                           .offset(base_addr + 32'h40010000));
     spi_device = spi_device_reg_block::type_id::create("spi_device");
     spi_device.configure(.parent(this));
     spi_device.build(.base_addr(base_addr + 32'h40020000));
     default_map.add_submap(.child_map(spi_device.default_map),
                            .offset(base_addr + 32'h40020000));
+    flash_ctrl = flash_ctrl_reg_block::type_id::create("flash_ctrl");
+    flash_ctrl.configure(.parent(this));
+    flash_ctrl.build(.base_addr(base_addr + 32'h40030000));
+    default_map.add_submap(.child_map(flash_ctrl.default_map),
+                           .offset(base_addr + 32'h40030000));
     rv_timer = rv_timer_reg_block::type_id::create("rv_timer");
     rv_timer.configure(.parent(this));
     rv_timer.build(.base_addr(base_addr + 32'h40080000));
@@ -10348,6 +11187,16 @@ class chip_reg_block extends dv_base_reg_block;
     rv_plic.build(.base_addr(base_addr + 32'h40090000));
     default_map.add_submap(.child_map(rv_plic.default_map),
                            .offset(base_addr + 32'h40090000));
+    aes = aes_reg_block::type_id::create("aes");
+    aes.configure(.parent(this));
+    aes.build(.base_addr(base_addr + 32'h40110000));
+    default_map.add_submap(.child_map(aes.default_map),
+                           .offset(base_addr + 32'h40110000));
+    hmac = hmac_reg_block::type_id::create("hmac");
+    hmac.configure(.parent(this));
+    hmac.build(.base_addr(base_addr + 32'h40120000));
+    default_map.add_submap(.child_map(hmac.default_map),
+                           .offset(base_addr + 32'h40120000));
 
     // create memories
     rom = chip_mem_rom::type_id::create("rom");

--- a/util/reggen/uvm_reg.sv.tpl
+++ b/util/reggen/uvm_reg.sv.tpl
@@ -72,7 +72,7 @@ class ${gen_dv.rcname(block, r)} extends dv_base_reg;
       .lsb_pos(${f.lsb}),
       .access("${field_access}"),
       .volatile(${field_volatile}),
-      .reset(${f.resval}),
+      .reset(${reg_width}'h${format(f.resval, 'x')}),
       .has_reset(1),
       .is_rand(1),
       .individually_accessible(1));

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -185,6 +185,10 @@ def generate_top_ral(top, ip_objs, out_path):
             if block.name == module["name"]:
                 block.base_addr = module["base_addr"]
                 break
+
+    top_block.blocks.sort(key=lambda block: block.base_addr)
+    top_block.wins.sort(key=lambda win: win.base_addr)
+
     # generate the top ral model with template
     gen_dv.gen_ral(top_block, str(out_path))
 


### PR DESCRIPTION
- fixed field reset value to be set in hex instead of decimal in uvm_reg.sv.tpl
- fixed chip reg block to sort blocks and windows by base addr so that new updates
show up as incremental change (fix for #153)