### PR TITLE
[dv] Remove UVM_HOME path in xcelium.mk

### DIFF
--- a/hw/dv/tools/xcelium/xcelium.mk
+++ b/hw/dv/tools/xcelium/xcelium.mk
@@ -24,7 +24,6 @@ BUILD_OPTS  += -messages
 BUILD_OPTS  += -errormax ${ERROR_MAX}
 BUILD_OPTS  += -sv
 BUILD_OPTS  += -timescale 1ns/1ps
-BUILD_OPTS  += +incdir+${UVM_HOME}/sv/src
 BUILD_OPTS  += -uvmhome ${UVM_HOME}
 BUILD_OPTS  += -xmlibdirname ${SV_FLIST_GEN_DIR}/xcelium.d
 BUILD_OPTS  += -f ${SV_FLIST}


### PR DESCRIPTION
The path isn't right which will trigger warning and it's not needed as
we have -uvmhome ${UVM_HOME}