### PR TITLE
[hmac] Revise localparams to have unique and meaningful names

### DIFF
--- a/hw/ip/hmac/rtl/hmac_pkg.sv
+++ b/hw/ip/hmac/rtl/hmac_pkg.sv
@@ -18,12 +18,12 @@ package hmac_pkg;
   } sha_fifo_t;
 
 
-  localparam sha_word_t init_h [8]= '{
+  localparam sha_word_t InitHash [8]= '{
     32'h 6a09_e667, 32'h bb67_ae85, 32'h 3c6e_f372, 32'h a54f_f53a,
     32'h 510e_527f, 32'h 9b05_688c, 32'h 1f83_d9ab, 32'h 5be0_cd19
   };
 
-  localparam sha_word_t k [64] = '{
+  localparam sha_word_t CubicRootPrime [64] = '{
     32'h 428a_2f98, 32'h 7137_4491, 32'h b5c0_fbcf, 32'h e9b5_dba5,
     32'h 3956_c25b, 32'h 59f1_11f1, 32'h 923f_82a4, 32'h ab1c_5ed5,
     32'h d807_aa98, 32'h 1283_5b01, 32'h 2431_85be, 32'h 550c_7dc3,

--- a/hw/ip/hmac/rtl/sha2.sv
+++ b/hw/ip/hmac/rtl/sha2.sv
@@ -99,7 +99,7 @@ module sha2 import hmac_pkg::*; (
     end else if (init_hash) begin
       hash <= digest;
     end else if (run_hash) begin
-      hash <= compress( w[0], k[round], hash);
+      hash <= compress( w[0], CubicRootPrime[round], hash);
     end
   end : compress_round
 
@@ -113,7 +113,7 @@ module sha2 import hmac_pkg::*; (
       end
     end else if (hash_start) begin
       for (int i = 0 ; i < 8 ; i++) begin
-        digest[i] <= init_h[i];
+        digest[i] <= InitHash[i];
       end
     end else if (!sha_en || clear_digest) begin
       digest <= '0;


### PR DESCRIPTION
The issue #701 is reported by @imphil

Problem:

    Previous version of `hmac_pkg.sv` has duplicated names `k`. `k` is
    used as localparam and also used as an argument in `compress()`
    function.

The `k` in localparam is the first 32bit of fractional part for the
cubic root of the first 64 primes. So the name is changed to have the
meaning.