### PR TITLE
[hmac] Block the msg fifo request with packer ready

### DIFF
--- a/hw/ip/hmac/rtl/hmac.sv
+++ b/hw/ip/hmac/rtl/hmac.sv
@@ -181,7 +181,7 @@ module hmac (
   assign reg_fifo_wentry.data = conv_endian(reg_fifo_wdata, 1'b1); // always convert
   assign reg_fifo_wentry.mask = {reg_fifo_wmask[0],  reg_fifo_wmask[8],
                                  reg_fifo_wmask[16], reg_fifo_wmask[24]};
-  assign fifo_full   = ~fifo_wready & ~packer_ready;
+  assign fifo_full   = ~fifo_wready;
   assign fifo_empty  = ~fifo_rvalid;
   assign fifo_wvalid = (hmac_fifo_wsel && fifo_wready) ? hmac_fifo_wvalid : reg_fifo_wvalid;
   assign fifo_wdata  = (hmac_fifo_wsel) ? '{data: digest[hmac_fifo_wdata_sel], mask: '1}


### PR DESCRIPTION
This is follow-up PR for #683

Problem:

    In #683, the design unguarded msg_fifo_gnt signal from
    `fifo_wready`. It only needs to see `packer_ready`. This results
    unintended request acceptance as `msg_write` is also gated by
    `fifo_wready`.

What happend with the problem is, when the MSG_FIFO is full, it
de-asserts `fifo_wready`. At this time, `prim_packer` has still enough
room to accept one more request. It doesn't drop `packer_ready`
(`prim_packer.ready_o`) yet. So `msg_fifo_gnt` can be high whenever the
request comes. That request should've come to `prim_packer`, which
didn't happen due to the `msg_write` is gated by `fifo_wready`.

Resolution:

    `msg_write` is now gated by `packer_ready` not `fifo_wready`.

I've tested hmac_back_pressure test with modified design. It still
fails. But the failure isn't due to the modified design but the
scoreboard assumes getting the fifo_full status which cannot be happen
as the request was back-pressured and accepted after fifo_full condition
is resolved.

Cindy has a fix PR for this issue.