### PR TITLE
[gpio/dv] Functional coverage updates

### DIFF
--- a/hw/ip/gpio/dv/env/gpio_env_cov.sv
+++ b/hw/ip/gpio/dv/env/gpio_env_cov.sv
@@ -79,7 +79,15 @@ class gpio_env_cov extends cip_base_env_cov #(.CFG_T(gpio_env_cfg));
     cp_pin: coverpoint pin {
       bins bins_for_gpio_bits[] = {[0:NUM_GPIOS-1]};
     }
-    cp_cross_all: cross cp_pin, data_out, data_oe, data_in;
+    cp_cross_all: cross cp_pin, data_out, data_oe, data_in {
+      // If data_oe is true, data_in cannot be different from data_out value
+      illegal_bins data_oe_1_data_out_0_data_in_1 = binsof(data_out) intersect {0} &&
+                                                    binsof(data_oe)  intersect {1} &&
+                                                    binsof(data_in)  intersect {1};
+      illegal_bins data_oe_1_data_out_1_data_in_0 = binsof(data_out) intersect {1} &&
+                                                    binsof(data_oe)  intersect {1} &&
+                                                    binsof(data_in)  intersect {0};
+    }
   endgroup : data_out_data_oe_data_in_cross_cg
   // Cross coverage between gpio pin value and effective data_in value
   covergroup gpio_pins_data_in_cross_cg(string name) with function sample(uint pin,

--- a/hw/ip/gpio/dv/env/gpio_scoreboard.sv
+++ b/hw/ip/gpio/dv/env/gpio_scoreboard.sv
@@ -114,7 +114,8 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
           `uvm_info(`gfn, $sformatf("Write on intr_state: write data = %0h", item.a_data), UVM_HIGH)
           if (intr_state_update_queue.size() > 0) begin
             gpio_reg_update_due_t intr_state_write_to_clear_update = intr_state_update_queue[$];
-            `uvm_info(`gfn, $sformatf("Entry taken out for clearing is %0p", intr_state_write_to_clear_update), UVM_HIGH)
+            `uvm_info(`gfn, $sformatf("Entry taken out for clearing is %0p",
+                                      intr_state_write_to_clear_update), UVM_HIGH)
             // Update time
             intr_state_write_to_clear_update.eval_time = $time;
             for (uint each_bit = 0; each_bit < TL_DW; each_bit++) begin
@@ -576,11 +577,6 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
             intr_ctrl_en_lvlhigh[each_bit]);
         cov.intr_ctrl_en_cov_objs[each_bit]["intr_ctrl_en_lvllow"].sample(
             intr_ctrl_en_lvllow[each_bit]);
-        // Interrupt Test coverage
-        cov.intr_test_cg.sample(each_bit,
-                                last_intr_test_event[each_bit],
-                                intr_enable[each_bit],
-                                last_intr_test_event[each_bit]);
       end
     end
     // 1. Look for edge triggerred interrupts
@@ -675,6 +671,11 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
           // Clear the flag
           cleared_intr_bits[each_bit] = 1'b0;
         end
+        // Interrupt Test coverage
+        cov.intr_test_cg.sample(each_bit,
+                                last_intr_test_event[each_bit],
+                                intr_enable[each_bit],
+                                exp_intr_status[each_bit]);
       end
     end
     // Clear last_intr_test_event


### PR DESCRIPTION
- Identified uncovered bins for cross of data_out, data_oe and data_in
  as illegal bins
- Modified the way intr_test related coverage was being sampled