### PR TITLE
[dv/hmac] hmac wr_ptr needs to wait when fifo full

### DIFF
--- a/hw/ip/hmac/dv/env/hmac_env_pkg.sv
+++ b/hw/ip/hmac/dv/env/hmac_env_pkg.sv
@@ -21,7 +21,7 @@ package hmac_env_pkg;
   // local parameters and types
   // csr and mem total size for IP
   parameter uint   HMAC_ADDR_MAP_SIZE        = 4096;
-  parameter uint32 HMAC_MSG_FIFO_DEPTH       = 16;
+  parameter uint32 HMAC_MSG_FIFO_DEPTH       = 17;
   parameter uint32 HMAC_MSG_FIFO_DEPTH_BYTES = HMAC_MSG_FIFO_DEPTH * 4;
   parameter uint32 HMAC_MSG_FIFO_SIZE        = 2048;
   parameter uint32 HMAC_MSG_FIFO_BASE        = 32'h800;


### PR DESCRIPTION
When fifo is full, hmac needs to wait until d_valid is asserted.