### PR TITLE
[sw] Change update_mtvec handling

### DIFF
--- a/sw/device/exts/common/_crt.c
+++ b/sw/device/exts/common/_crt.c
@@ -11,13 +11,14 @@ extern int main(void);
 
 void _crt(void) __attribute__((section(".crt")));
 void _crt(void) {
+  extern char _svectors[];
   extern char _sdata[];
   extern char _idata[];
   extern char _edata[];
   extern char _bss_start[];
   extern char _bss_end[];
 
-  update_mtvec();
+  update_mtvec(_svectors);
   memcpy(_sdata, _idata, _edata - _sdata);
   memset(_bss_start, 0, _bss_end - _bss_start);
 

--- a/sw/device/lib/irq.h
+++ b/sw/device/lib/irq.h
@@ -11,7 +11,7 @@
 /**
  * Update to the location of vectors as specificed in the linker file
  */
-extern void update_mtvec(void);
+extern void update_mtvec(char *ptr);
 
 /**
  * Enable / disable ibex globlal interrupts

--- a/sw/device/lib/irq_vectors.S
+++ b/sw/device/lib/irq_vectors.S
@@ -6,12 +6,10 @@
 .extern handler_irq_software
 .extern handler_irq_timer
 .extern handler_irq_external
-.extern _svectors
 
 update_mtvec:
   .section .text
   .global update_mtvec
-  la a0, _svectors
   csrw mtvec, a0
   ret
 


### PR DESCRIPTION
update_mtvec used to look for an external definition of the
_svectors varibale, now it simply receives it as an argument.