### PR TITLE
[doc] Fix make commands in {fpga,sw} user guides

### DIFF
--- a/doc/ug/getting_started_fpga.md
+++ b/doc/ug/getting_started_fpga.md
@@ -34,6 +34,7 @@ In the following example we synthesize the Earl Grey design for the Nexys Video 
 ```console
 $ . /tools/xilinx/Vivado/2018.3/settings64.sh
 $ cd $REPO_TOP
+$ make -C sw/device SW_DIR=boot_rom clean all
 $ fusesoc --cores-root . build lowrisc:systems:top_earlgrey_nexysvideo
 ```
 

--- a/doc/ug/getting_started_sw.md
+++ b/doc/ug/getting_started_sw.md
@@ -6,9 +6,12 @@ _Make sure you followed the install instructions to [prepare the system]({{< rel
 
 ## Building software
 
+The following commands build the `boot_rom` and `hello_world` binaries:
+
 ```console
-$ cd $REPO_TOP/sw
-$ make SW_DIR=examples/hello_world CC=/tools/riscv/bin/riscv32-unknown-elf-gcc
+$ cd $REPO_TOP
+$ make -C sw/device SW_DIR=boot_rom clean all
+$ make -C sw/device SW_DIR=examples/hello_world clean all
 ```
 
 The build process produces a variety of output files.
@@ -18,4 +21,4 @@ The build process produces a variety of output files.
 * `.dis`: the disassembled program
 * `.vmem`: a Verilog memory file which can be read by `$readmemh()` in Verilog code
 
-Please see [SW build flow]("/sw/doc/sw_build_flow.md") for more details.
+Please see [SW build flow]("/sw/device/doc/sw_build_flow.md") for more details.


### PR DESCRIPTION
* Point to make -C sw/device, since this is where the device Make
  scaffolding lives.
* Add explicit make boot_rom command in fpga getting started
  instructions.  Some users are running into problems due to the fact
  that the boot_rom file dependency is not checked at FPGA bitstream
  build time and the instructions don't explicitly call out the make
  command for boot_rom.

Keeping instructions in Make format as requested by
lowrisc/opentitan#733.