### PR TITLE
[i2c/flash_ctrl/rv_plic] Add KNOWN assertions to all outputs

### DIFF
--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -477,5 +477,14 @@ module flash_ctrl (
   assign unused_scratch = reg2hw.scratch;
 
 
+  // Assertions
+  `ASSERT_KNOWN(TlKnownO_A,             tl_o,              clk_i, !rst_ni)
+  `ASSERT_KNOWN(FlashKnownO_A,          flash_o,           clk_i, !rst_ni)
+  `ASSERT_KNOWN(IntrProgEmptyKnownO_A,  intr_prog_empty_o, clk_i, !rst_ni)
+  `ASSERT_KNOWN(IntrProgLvlKnownO_A,    intr_prog_lvl_o,   clk_i, !rst_ni)
+  `ASSERT_KNOWN(IntrProgRdFullKnownO_A, intr_rd_full_o,    clk_i, !rst_ni)
+  `ASSERT_KNOWN(IntrRdLvlKnownO_A,      intr_rd_lvl_o,     clk_i, !rst_ni)
+  `ASSERT_KNOWN(IntrOpDoneKnownO_A,     intr_op_done_o,    clk_i, !rst_ni)
+  `ASSERT_KNOWN(IntrOpErrorKnownO_A,    intr_op_error_o,   clk_i, !rst_ni)
 
 endmodule

--- a/hw/ip/i2c/rtl/i2c.sv
+++ b/hw/ip/i2c/rtl/i2c.sv
@@ -88,6 +88,20 @@ module i2c (
   assign cio_scl_en_o = ~scl_int;
   assign cio_sda_en_o = ~sda_int;
 
-  `ASSERT_KNOWN(scanmodeKnown, scanmode_i, clk_i, 0)
+  `ASSERT_KNOWN(scanmodeKnown_A, scanmode_i, clk_i, 0)
+  `ASSERT_KNOWN(TlKnownO_A, tl_o, clk_i, !rst_ni)
+  `ASSERT_KNOWN(CioSclKnownO_A, cio_scl_o, clk_i, !rst_ni)
+  `ASSERT_KNOWN(CioSclEnKnownO_A, cio_scl_en_o, clk_i, !rst_ni)
+  `ASSERT_KNOWN(CioSdaKnownO_A, cio_sda_o, clk_i, !rst_ni)
+  `ASSERT_KNOWN(CioSdaEnKnownO_A, cio_sda_en_o, clk_i, !rst_ni)
+  `ASSERT_KNOWN(IntrFmtWtmkKnownO_A, intr_fmt_watermark_o, clk_i, !rst_ni)
+  `ASSERT_KNOWN(IntrRxWtmkKnownO_A, intr_rx_watermark_o, clk_i, !rst_ni)
+  `ASSERT_KNOWN(IntrFmtOflwKnownO_A, intr_fmt_overflow_o, clk_i, !rst_ni)
+  `ASSERT_KNOWN(IntrRxOflwKnownO_A, intr_rx_overflow_o, clk_i, !rst_ni)
+  `ASSERT_KNOWN(IntrNakKnownO_A, intr_nak_o, clk_i, !rst_ni)
+  `ASSERT_KNOWN(IntrSclInterfKnownO_A, intr_scl_interference_o, clk_i, !rst_ni)
+  `ASSERT_KNOWN(IntrSdaInterfKnownO_A, intr_sda_interference_o, clk_i, !rst_ni)
+  `ASSERT_KNOWN(IntrStretchTimeoutKnownO_A, intr_stretch_timeout_o, clk_i, !rst_ni)
+  `ASSERT_KNOWN(IntrSdaUnstableKnownO_A, intr_sda_unstable_o, clk_i, !rst_ni)
 
 endmodule

--- a/hw/ip/rv_plic/data/rv_plic.sv.tpl
+++ b/hw/ip/rv_plic/data/rv_plic.sv.tpl
@@ -201,4 +201,10 @@ module rv_plic #(
     .devmode_i  (1'b1)
   );
 
+    // Assertions
+  `ASSERT_KNOWN(TlKnownO_A, tl_o, clk_i, !rst_ni)
+  `ASSERT_KNOWN(IrqKnownO_A, irq_o, clk_i, !rst_ni)
+  `ASSERT_KNOWN(IrqIdKnownO_A, irq_id_o, clk_i, !rst_ni)
+  `ASSERT_KNOWN(MsipKnownO_A, msip_o, clk_i, !rst_ni)
+
 endmodule

--- a/hw/ip/rv_plic/rtl/rv_plic.sv
+++ b/hw/ip/rv_plic/rtl/rv_plic.sv
@@ -222,5 +222,11 @@ module rv_plic #(
     .devmode_i  (1'b1)
   );
 
+    // Assertions
+  `ASSERT_KNOWN(TlKnownO_A, tl_o, clk_i, !rst_ni)
+  `ASSERT_KNOWN(IrqKnownO_A, irq_o, clk_i, !rst_ni)
+  `ASSERT_KNOWN(IrqIdKnownO_A, irq_id_o, clk_i, !rst_ni)
+  `ASSERT_KNOWN(MsipKnownO_A, msip_o, clk_i, !rst_ni)
+
 endmodule
 

--- a/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic.sv
+++ b/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic.sv
@@ -253,4 +253,10 @@ module rv_plic #(
     .devmode_i  (1'b1)
   );
 
+    // Assertions
+  `ASSERT_KNOWN(TlKnownO_A, tl_o, clk_i, !rst_ni)
+  `ASSERT_KNOWN(IrqKnownO_A, irq_o, clk_i, !rst_ni)
+  `ASSERT_KNOWN(IrqIdKnownO_A, irq_id_o, clk_i, !rst_ni)
+  `ASSERT_KNOWN(MsipKnownO_A, msip_o, clk_i, !rst_ni)
+
 endmodule


### PR DESCRIPTION
I added `ASSERT_KNOWN` assertions for all outputs to the rv_plic, flash_ctrl and i2c modules in order to close this issue #405. PTAL, and let me know if I should amend something...