### PR TITLE
[testplanner] Restore the `foo_dv_plan.md` example

### DIFF
--- a/util/testplanner/examples/foo_dv_plan.md
+++ b/util/testplanner/examples/foo_dv_plan.md
@@ -1,0 +1,7 @@
+---
+title: "FOO DV plan"
+---
+
+# Testplan
+
+{{< testplan "util/testplanner/examples/foo_testplan.hjson" >}}


### PR DESCRIPTION
This file was removed unnecessarily during the hugo switch. Restore it
and update it to the new hugo style.