### PR TITLE
HOTFIX [ci] Move software build tasks back to self-hosted runners

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -120,8 +120,7 @@ stages:
 
   - job: "deprecated_make_build"
     displayName: "Build Software with Make (deprecated)"
-    pool:
-      vmImage: "ubuntu-latest"
+    pool: Default
     steps:
     - bash: |
         sudo apt-get install -y python3 python3-pip build-essential srecord python3-setuptools zlib1g-dev libusb-1.0 libftdi1-dev libftdi1-2 libssl-dev \
@@ -150,8 +149,7 @@ stages:
 
   - job: "top_earlgrey_verilator"
     displayName: "Build Verilator simulation of the Earl Grey toplevel design"
-    pool:
-      vmImage: "ubuntu-latest"
+    pool: Default
     steps:
     - bash: |
         sudo apt-get install -y python3 python3-pip build-essential srecord python3-setuptools zlib1g-dev libusb-1.0 \


### PR DESCRIPTION
PR #631 erroneously moved over software and verilator build tasks to the
Azure-hosted pool. It's faster to run these on the self-hosted runners
in our "Default" pool.

Quick review appreciated, as this change should help unblock the current backlog. Unfortunately, it won't do so instantly as all queued up PRs will build using the unfixed version of azure-pipelines.yml until they rebase.

Related to #739, but doing this change separately so we can land it quickly.