### PR TITLE
[hugo] Enable noEmptyLineBeforeBlock blackfriday extension

### DIFF
--- a/site/docs/config.toml
+++ b/site/docs/config.toml
@@ -47,3 +47,6 @@ disableKinds = ["taxonomy", "taxonomyTerm", "RSS", "sitemap"]
 
 [params]
 generatedRoot = "build/docs-generated"
+
+[blackfriday]
+  extensions = ["noEmptyLineBeforeBlock"]


### PR DESCRIPTION
This matches GitHub's markdown rendering behaviour and the behaviour of
mistletoe. It fixes rendering of multiple in-tree docs, where there
isn't an additional newline between a paragraph of text and a list.