### PR TITLE
[ci] Perform Meson-driven software build on Ubuntu 16.04

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,7 +97,7 @@ stages:
   - job: "sw_build"
     displayName: "Build Software"
     pool:
-      vmImage: "ubuntu-latest"
+      vmImage: "ubuntu-16.04"
     steps:
     - bash: |
         sudo apt-get install -y python3 python3-pip build-essential pkgconf srecord python3-setuptools zlib1g-dev libusb-1.0 libftdi1-dev libftdi1-2 libssl-dev ninja-build \


### PR DESCRIPTION
We want to support 16.04 as a baseline requirement, so we should run our CI on this.

Future improvements to CI might check the build on a larger matrix of systems, but in the absence of that building on the oldest system we hope to support seems the approach most likely to help in identifying problems.

This PR also includes a thematically related patch to document the pkg-config dependency and explicitly list it in the CI apt-get install command. I discovered this when looking at moving the software build to use our self hosted runners.

[Sidenote: we probably will want to sort out what gets run on self-hosted vs Azure-hosted runners after current CI issues are resolved, but I figure we're best waiting until launch to rebalance, when we'll have much more parallelism for Azure-hosted runners.].