### PR TITLE
[top_earlgrey] Only optimize hot code in verilator

### DIFF
--- a/hw/top_earlgrey/top_earlgrey_usb_verilator.core
+++ b/hw/top_earlgrey/top_earlgrey_usb_verilator.core
@@ -37,22 +37,23 @@ targets:
       verilator:
         mode: cc
         verilator_options:
-# Disabling tracing reduces compile times by multiple times, but doesn't have a
-# huge influence on runtime performance. (Based on early observations.)
+          # Disabling tracing reduces compile times but doesn't have a
+          # huge influence on runtime performance.
           - '--trace'
           - '--trace-fst' # this requires -DVM_TRACE_FMT_FST in CFLAGS below!
+          # Remove FST options for VCD trace (~100 x faster but larger files)
           - '--trace-structs'
           - '--trace-params'
           - '--trace-max-array 1024'
-# compiler flags
-#
-# -O
-#   Optimization levels have a large impact on the runtime performance of the
-#   simulation model. -O2 and -O3 are pretty similar, -Os is slower than -O2/-O3
-          - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=top_earlgrey_usb_verilator -g -O2"'
+          - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=top_earlgrey_usb_verilator -g"'
           - '-LDFLAGS "-pthread -lutil"'
           - "-Wall"
           - "-Wno-PINCONNECTEMPTY"
           # XXX: Cleanup all warnings and remove this option
           # (or make it more fine-grained at least)
           - "-Wno-fatal"
+        make_options:
+          # Optimization levels have a large impact on the runtime performance
+          # of the simulation model. -O2 and -O3 are pretty similar, -Os is
+          # slower than -O2/-O3
+          - OPT_FAST="-O2"

--- a/hw/top_earlgrey/top_earlgrey_verilator.core
+++ b/hw/top_earlgrey/top_earlgrey_verilator.core
@@ -43,22 +43,23 @@ targets:
       verilator:
         mode: cc
         verilator_options:
-# Disabling tracing reduces compile times by multiple times, but doesn't have a
-# huge influence on runtime performance. (Based on early observations.)
+          # Disabling tracing reduces compile times but doesn't have a
+          # huge influence on runtime performance.
           - '--trace'
           - '--trace-fst' # this requires -DVM_TRACE_FMT_FST in CFLAGS below!
+          # Remove FST options for VCD trace (~100 x faster but larger files)
           - '--trace-structs'
           - '--trace-params'
           - '--trace-max-array 1024'
-# compiler flags
-#
-# -O
-#   Optimization levels have a large impact on the runtime performance of the
-#   simulation model. -O2 and -O3 are pretty similar, -Os is slower than -O2/-O3
-          - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=top_earlgrey_verilator -g -O2"'
+          - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=top_earlgrey_verilator -g"'
           - '-LDFLAGS "-pthread -lutil"'
           - "-Wall"
           - "-Wno-PINCONNECTEMPTY"
           # XXX: Cleanup all warnings and remove this option
           # (or make it more fine-grained at least)
           - "-Wno-fatal"
+        make_options:
+          # Optimization levels have a large impact on the runtime performance
+          # of the simulation model. -O2 and -O3 are pretty similar, -Os is
+          # slower than -O2/-O3
+          - OPT_FAST="-O2"


### PR DESCRIPTION
- Reduces verilator compile time by ~20x
- This requires an up to date version of edalize
- Add a comment about FST vs VCD tracing