### PR TITLE
[ci] Move spiflash binary in release artifacts

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -146,8 +146,8 @@ jobs:
       make -C sw/host/spiflash clean all
       # TODO: build system updates needed to copy build output to a dist
       # staging directory.
-      mkdir -p $(Build.ArtifactStagingDirectory)/dist/sw/host/bin
-      cp sw/host/spiflash/spiflash $(Build.ArtifactStagingDirectory)/dist/sw/host/bin
+      mkdir -p $(Build.ArtifactStagingDirectory)/dist/sw/host/spiflash
+      cp sw/host/spiflash/spiflash $(Build.ArtifactStagingDirectory)/dist/sw/host/spiflash
     displayName: 'Build host targets'
   - bash: |
       cd $(Build.ArtifactStagingDirectory)


### PR DESCRIPTION
To make the quickstart guide more consistent with the self-built option
we want to have the spiflash binary in a sw/host/spiflash/spiflash, and
not in sw/host/bin/spiflash.