### PR TITLE
[ci] Avoid failing GitHub release upload

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -286,6 +286,7 @@ jobs:
     displayName: "Upload release artifacts as Azure artifact"
   - task: GithubRelease@0
     displayName: 'Upload to GitHub releases (only tags)'
+    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/'))
     inputs:
       gitHubConnection: opentitan-release-upload
       repositoryName: lowrisc/opentitan


### PR DESCRIPTION
We only upload release artifacts to GitHub for tags. However, the
'GithubRelease@0' job always ran, and issued a warning if the build
didn't happen for a tag. So all good.

But now *if* we build for a tagged release, we get two triggers: one for
the build on master, and one for the tag. Slightly surprisingly, the
GitHub artifact upload already succeeds for the master build (based on
the commit hash matching the tag), and then the build triggered for the
tag fails to upload the release artifacts.

That's not a problem as the artifacts will be the same, but having a
failing job isn't nice either. So add a condition to prevent the job
from running in the first place.

(Note: we need the tag trigger and cannot simply rely on the master
build, as we might not have a master build for all changesets if builds
are batched.)