### PR TITLE
[DV/FPV] Update KNOWN SVAs on TLUL outputs to be less restrictive

### DIFF
--- a/hw/ip/alert_handler/rtl/alert_handler.sv
+++ b/hw/ip/alert_handler/rtl/alert_handler.sv
@@ -200,7 +200,8 @@ module alert_handler (
   ////////////////
 
   // check whether all outputs have a good known state after reset
-  `ASSERT_KNOWN(TlKnownO_A, tl_o, clk_i, !rst_ni)
+  `ASSERT_KNOWN(TlDValidKnownO_A, tl_o.d_valid, clk_i, !rst_ni)
+  `ASSERT_KNOWN(TlAReadyKnownO_A, tl_o.a_ready, clk_i, !rst_ni)
   `ASSERT_KNOWN(IrqKnownO_A, irq_o, clk_i, !rst_ni)
   `ASSERT_KNOWN(CrashdumpKnownO_A, crashdump_o, clk_i, !rst_ni)
   `ASSERT_KNOWN(PingPKnownO_A, ping_po, clk_i, !rst_ni)

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -476,7 +476,8 @@ module flash_ctrl (
 
 
   // Assertions
-  `ASSERT_KNOWN(TlKnownO_A,             tl_o,              clk_i, !rst_ni)
+  `ASSERT_KNOWN(TlDValidKnownO_A,       tl_o.d_valid,      clk_i, !rst_ni)
+  `ASSERT_KNOWN(TlAReadyKnownO_A,       tl_o.a_ready,      clk_i, !rst_ni)
   `ASSERT_KNOWN(FlashKnownO_A,          flash_o,           clk_i, !rst_ni)
   `ASSERT_KNOWN(IntrProgEmptyKnownO_A,  intr_prog_empty_o, clk_i, !rst_ni)
   `ASSERT_KNOWN(IntrProgLvlKnownO_A,    intr_prog_lvl_o,   clk_i, !rst_ni)

--- a/hw/ip/i2c/rtl/i2c.sv
+++ b/hw/ip/i2c/rtl/i2c.sv
@@ -89,7 +89,8 @@ module i2c (
   assign cio_sda_en_o = ~sda_int;
 
   `ASSERT_KNOWN(scanmodeKnown_A, scanmode_i, clk_i, 0)
-  `ASSERT_KNOWN(TlKnownO_A, tl_o, clk_i, !rst_ni)
+  `ASSERT_KNOWN(TlDValidKnownO_A, tl_o.d_valid, clk_i, !rst_ni)
+  `ASSERT_KNOWN(TlAReadyKnownO_A, tl_o.a_ready, clk_i, !rst_ni)
   `ASSERT_KNOWN(CioSclKnownO_A, cio_scl_o, clk_i, !rst_ni)
   `ASSERT_KNOWN(CioSclEnKnownO_A, cio_scl_en_o, clk_i, !rst_ni)
   `ASSERT_KNOWN(CioSdaKnownO_A, cio_sda_o, clk_i, !rst_ni)

--- a/hw/ip/padctrl/rtl/padctrl.sv
+++ b/hw/ip/padctrl/rtl/padctrl.sv
@@ -111,7 +111,8 @@ module padctrl #(
   // Assertions //
   ////////////////
 
-  `ASSERT_KNOWN(TlKnownO_A, tl_o, clk_i, !rst_ni)
+  `ASSERT_KNOWN(TlDValidKnownO_A, tl_o.d_valid, clk_i, !rst_ni)
+  `ASSERT_KNOWN(TlAReadyKnownO_A, tl_o.a_ready, clk_i, !rst_ni)
   `ASSERT_KNOWN(MioKnownO_A, mio_attr_o, clk_i, !rst_ni)
   `ASSERT_KNOWN(DioKnownO_A, dio_attr_o, clk_i, !rst_ni)
 

--- a/hw/ip/pinmux/rtl/pinmux.sv
+++ b/hw/ip/pinmux/rtl/pinmux.sv
@@ -72,7 +72,8 @@ module pinmux (
   // Assertions //
   ////////////////
 
-  `ASSERT_KNOWN(TlKnownO_A, tl_o, clk_i, !rst_ni)
+  `ASSERT_KNOWN(TlDValidKnownO_A, tl_o.d_valid, clk_i, !rst_ni)
+  `ASSERT_KNOWN(TlAReadyKnownO_A, tl_o.a_ready, clk_i, !rst_ni)
   `ASSERT_KNOWN(MioToPeriphKnownO_A, mio_to_periph_o, clk_i, !rst_ni)
   `ASSERT_KNOWN(MioOutKnownO_A, mio_out_o, clk_i, !rst_ni)
   `ASSERT_KNOWN(MioOeKnownO_A, mio_oe_o, clk_i, !rst_ni)

--- a/hw/ip/rv_plic/data/rv_plic.sv.tpl
+++ b/hw/ip/rv_plic/data/rv_plic.sv.tpl
@@ -206,8 +206,9 @@ module rv_plic #(
     .devmode_i  (1'b1)
   );
 
-    // Assertions
-  `ASSERT_KNOWN(TlKnownO_A, tl_o, clk_i, !rst_ni)
+  // Assertions
+  `ASSERT_KNOWN(TlDValidKnownO_A, tl_o.d_valid, clk_i, !rst_ni)
+  `ASSERT_KNOWN(TlAReadyKnownO_A, tl_o.a_ready, clk_i, !rst_ni)
   `ASSERT_KNOWN(IrqKnownO_A, irq_o, clk_i, !rst_ni)
   `ASSERT_KNOWN(IrqIdKnownO_A, irq_id_o, clk_i, !rst_ni)
   `ASSERT_KNOWN(MsipKnownO_A, msip_o, clk_i, !rst_ni)

--- a/hw/ip/rv_plic/rtl/rv_plic.sv
+++ b/hw/ip/rv_plic/rtl/rv_plic.sv
@@ -227,8 +227,9 @@ module rv_plic #(
     .devmode_i  (1'b1)
   );
 
-    // Assertions
-  `ASSERT_KNOWN(TlKnownO_A, tl_o, clk_i, !rst_ni)
+  // Assertions
+  `ASSERT_KNOWN(TlDValidKnownO_A, tl_o.d_valid, clk_i, !rst_ni)
+  `ASSERT_KNOWN(TlAReadyKnownO_A, tl_o.a_ready, clk_i, !rst_ni)
   `ASSERT_KNOWN(IrqKnownO_A, irq_o, clk_i, !rst_ni)
   `ASSERT_KNOWN(IrqIdKnownO_A, irq_id_o, clk_i, !rst_ni)
   `ASSERT_KNOWN(MsipKnownO_A, msip_o, clk_i, !rst_ni)

--- a/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic.sv
+++ b/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic.sv
@@ -258,8 +258,9 @@ module rv_plic #(
     .devmode_i  (1'b1)
   );
 
-    // Assertions
-  `ASSERT_KNOWN(TlKnownO_A, tl_o, clk_i, !rst_ni)
+  // Assertions
+  `ASSERT_KNOWN(TlDValidKnownO_A, tl_o.d_valid, clk_i, !rst_ni)
+  `ASSERT_KNOWN(TlAReadyKnownO_A, tl_o.a_ready, clk_i, !rst_ni)
   `ASSERT_KNOWN(IrqKnownO_A, irq_o, clk_i, !rst_ni)
   `ASSERT_KNOWN(IrqIdKnownO_A, irq_id_o, clk_i, !rst_ni)
   `ASSERT_KNOWN(MsipKnownO_A, msip_o, clk_i, !rst_ni)


### PR DESCRIPTION
The previous KNOWN assertions where to restrictive. Only the `d_ready` and `a_valid` outputs need to be known when coming out of reset.