### PR TITLE
[build_docs] Add tools' selfdoc function

### DIFF
--- a/doc/rm/crossbar_tool/index.md
+++ b/doc/rm/crossbar_tool/index.md
@@ -41,16 +41,7 @@ The tool raises an error if *Required* keys are missing.
 *Optional* keys may be provided in the input files.
 The tool also may insert the optional keys with default value.
 
-The script-generated tool documentation is shown here for completeness.
-This can be given by executing the following.
-
-```console
-    $ util/tlgen.py --doc
-```
-
-```
-include !../../util/tlgen.py --doc
-```
+{{% selfdoc "tlgen" %}}
 
 ## Fabrication process
 

--- a/doc/rm/register_tool/index.md
+++ b/doc/rm/register_tool/index.md
@@ -29,6 +29,8 @@ It is an error if *required* keys are missing from the input json.
 *Optional* keys may be provided in the input file as needed, as noted in the tables the tool may insert them (with default or computed values) during validation so the output generators do not have to special case them.
 Keys marked as "inserted by tool" should not be in the input json (they will be silently overwritten if they are there), they are derived by the tool during validation of the input and available to the output generators.
 
+{{% selfdoc "reggen" %}}
+
 The tool will normally generate the register address offset by starting from 0 and allocating the registers in the order they are in the input file.
 Between each register the offset is incremented by the number of bytes in the `regwidth` (4 bytes for the default 32-bit `regwidth`), so the registers end up packed into the smallest space.
 

--- a/site/docs/layouts/shortcodes/selfdoc.html
+++ b/site/docs/layouts/shortcodes/selfdoc.html
@@ -1,0 +1,6 @@
+{{ $baseName := .Get 0 }}
+{{ $path := path.Join .Site.Params.generatedRoot (printf "%s.selfdoc" $baseName) }}
+{{ if not (fileExists $path) }}
+  {{ errorf "Tool selfdoc has not been generated for %s" $baseName }}
+{{ end }}
+{{ readFile $path | safeHTML }}


### PR DESCRIPTION
This brought back the functionality of `selfdoc` feature existed prior
to #638.

As each tool (`regtool`, `tlgen`) generates the selfdoc slightly
differently, current code manually generates case-by-case. It would be
beneficial if tool has common way to create selfdoc and gives the script
to detect whether it supports selfdoc feature or not.

Item 25 in #723 can be completed.