### PR TITLE
[reg] remove reference to Titan-style headers

### DIFF
--- a/doc/rm/register_tool/index.md
+++ b/doc/rm/register_tool/index.md
@@ -29,6 +29,8 @@ It is an error if *required* keys are missing from the input json.
 *Optional* keys may be provided in the input file as needed, as noted in the tables the tool may insert them (with default or computed values) during validation so the output generators do not have to special case them.
 Keys marked as "inserted by tool" should not be in the input json (they will be silently overwritten if they are there), they are derived by the tool during validation of the input and available to the output generators.
 
+{{% selfdoc "reggen" %}}
+
 The tool will normally generate the register address offset by starting from 0 and allocating the registers in the order they are in the input file.
 Between each register the offset is incremented by the number of bytes in the `regwidth` (4 bytes for the default 32-bit `regwidth`), so the registers end up packed into the smallest space.
 
@@ -563,15 +565,15 @@ For example:
 # define UART_CTRL_RXBLVL_BREAK16        3
 ```
 
-### Titan style headers
+### Alternate style headers
 
-The register generation tool will generate Titan project style headers if it is invoked with the `-T` flag.
+The register generation tool will generate alternate style headers if it is invoked with the `-T` flag.
 The `-o <file.h>` flag may be used to specify the output file.
 As an example the tool can be invoked to generate the uart headers with:
 
 ```console
 $ cd hw/ip/uart/doc
-$ ../../../../util/regtool.py -T -o ~/src/titan/uart.h uart.hjson
+$ ../../../../util/regtool.py -T -o ~/src/alt/uart.h uart.hjson
 ```
 
 This format assumes that there is a base address `NAME`n`_BASE_ADDR` defined where n is an identifying number to allow for multiple instantiations of peripherals.


### PR DESCRIPTION
I think it is best to remove reference to these style headers. We'll still
have the option in the tool, just don't need to advertise it at this time.

This addresses (17) of #723 