### PR TITLE
[DV/HMAC] add missing intr_test sample

### DIFF
--- a/hw/ip/hmac/dv/env/hmac_env_cov.sv
+++ b/hw/ip/hmac/dv/env/hmac_env_cov.sv
@@ -28,7 +28,7 @@ class hmac_env_cov extends cip_base_env_cov #(.CFG_T(hmac_env_cfg));
 
   covergroup msg_len_cg with function sample (bit [TL_DW-1:0] msg_len_lower, bit [TL_DW-1:0] cfg);
     hmac_en: coverpoint cfg[HmacEn];
-    msg_len: coverpoint msg_len_lower {
+    msg_len: coverpoint (msg_len_lower / 8) {
       bins len_0         = {0};
       bins len_1         = {1};
       bins len_256       = {256};
@@ -42,7 +42,7 @@ class hmac_env_cov extends cip_base_env_cov #(.CFG_T(hmac_env_cfg));
       bins len_1280      = {1280};
       bins len_1281      = {1281};
       bins len_1536      = {1536};
-      bins len_1537      = {1357};
+      bins len_1537      = {1537};
       bins len_1792      = {1792};
       bins len_1793      = {1793};
       bins len_2048      = {2048};

--- a/hw/ip/hmac/dv/env/hmac_scoreboard.sv
+++ b/hw/ip/hmac/dv/env/hmac_scoreboard.sv
@@ -139,12 +139,17 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
             hmac_intr_e intr;
             intr = intr.first;
             do begin
-              bit [TL_DW-1:0] intr_en = ral.intr_enable.get_mirrored_value();
+              bit [TL_DW-1:0] intr_en   = ral.intr_enable.get_mirrored_value();
+              bit [TL_DW-1:0] intr_test = ral.intr_test.get_mirrored_value();
               cov.intr_cg.sample(intr, intr_en[intr], item.d_data[intr]);
               cov.intr_pins_cg.sample(intr, cfg.intr_vif.pins[intr]);
+              cov.intr_test_cg.sample(intr, intr_test[intr], intr_en[intr], item.d_data[intr]);
               intr = intr.next;
             end while (intr != intr.first);
           end
+          // intr_test is WO, every time after write for a clk cycle, RTL will reset it, but for
+          // coverage purpose, we will reset intr_test after collected the coverage
+          void'(ral.intr_test.predict(.value(0), .kind(UVM_PREDICT_DIRECT)));
           if (item.d_data[HmacDone] == 1) begin
             hmac_wr_cnt = 0;
             hmac_rd_cnt = 0;


### PR DESCRIPTION
Since cip_base_vseq implemented the intr_test, during merging, missed
this sample point.