### PR TITLE
[flash_ctrl] Minor fix to known outputs

### DIFF
--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -476,14 +476,15 @@ module flash_ctrl (
 
 
   // Assertions
-  `ASSERT_KNOWN(TlDValidKnownO_A,       tl_o.d_valid,      clk_i, !rst_ni)
-  `ASSERT_KNOWN(TlAReadyKnownO_A,       tl_o.a_ready,      clk_i, !rst_ni)
-  `ASSERT_KNOWN(FlashKnownO_A,          flash_o,           clk_i, !rst_ni)
-  `ASSERT_KNOWN(IntrProgEmptyKnownO_A,  intr_prog_empty_o, clk_i, !rst_ni)
-  `ASSERT_KNOWN(IntrProgLvlKnownO_A,    intr_prog_lvl_o,   clk_i, !rst_ni)
-  `ASSERT_KNOWN(IntrProgRdFullKnownO_A, intr_rd_full_o,    clk_i, !rst_ni)
-  `ASSERT_KNOWN(IntrRdLvlKnownO_A,      intr_rd_lvl_o,     clk_i, !rst_ni)
-  `ASSERT_KNOWN(IntrOpDoneKnownO_A,     intr_op_done_o,    clk_i, !rst_ni)
-  `ASSERT_KNOWN(IntrOpErrorKnownO_A,    intr_op_error_o,   clk_i, !rst_ni)
+  `ASSERT_KNOWN(TlDValidKnownO_A,       tl_o.d_valid,       clk_i, !rst_ni)
+  `ASSERT_KNOWN(TlAReadyKnownO_A,       tl_o.a_ready,       clk_i, !rst_ni)
+  `ASSERT_KNOWN(FlashKnownO_A,          {flash_o.req, flash_o.rd, flash_o.prog, flash_o.pg_erase,
+                                         flash_o.bk_erase}, clk_i, !rst_ni)
+  `ASSERT_KNOWN(IntrProgEmptyKnownO_A,  intr_prog_empty_o,  clk_i, !rst_ni)
+  `ASSERT_KNOWN(IntrProgLvlKnownO_A,    intr_prog_lvl_o,    clk_i, !rst_ni)
+  `ASSERT_KNOWN(IntrProgRdFullKnownO_A, intr_rd_full_o,     clk_i, !rst_ni)
+  `ASSERT_KNOWN(IntrRdLvlKnownO_A,      intr_rd_lvl_o,      clk_i, !rst_ni)
+  `ASSERT_KNOWN(IntrOpDoneKnownO_A,     intr_op_done_o,     clk_i, !rst_ni)
+  `ASSERT_KNOWN(IntrOpErrorKnownO_A,    intr_op_error_o,    clk_i, !rst_ni)
 
 endmodule


### PR DESCRIPTION
Ignore outputs that are derived from FIFOs, since the contents are unknown
at reset time.