### PR TITLE
[rv_plic] Correct packed/unpacked indexing in assertion

### DIFF
--- a/hw/ip/rv_plic/data/rv_plic.sv.tpl
+++ b/hw/ip/rv_plic/data/rv_plic.sv.tpl
@@ -163,7 +163,7 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   ///////////////////////////////////
   // Target interrupt notification //
   ///////////////////////////////////
-  for (genvar i = 0 ; i < NumTarget ; i++) begin : geNumTarget
+  for (genvar i = 0 ; i < NumTarget ; i++) begin : gen_target
     rv_plic_target #(
       .N_SOURCE (NumSrc),
       .MAX_PRIO (MAX_PRIO),
@@ -206,7 +206,9 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   `ASSERT_KNOWN(TlDValidKnownO_A, tl_o.d_valid, clk_i, !rst_ni)
   `ASSERT_KNOWN(TlAReadyKnownO_A, tl_o.a_ready, clk_i, !rst_ni)
   `ASSERT_KNOWN(IrqKnownO_A, irq_o, clk_i, !rst_ni)
-  `ASSERT_KNOWN(IrqIdKnownO_A, irq_id_o, clk_i, !rst_ni)
   `ASSERT_KNOWN(MsipKnownO_A, msip_o, clk_i, !rst_ni)
+  for (genvar k = 0; k < NumTarget; k++) begin : gen_irq_id_known
+    `ASSERT_KNOWN(IrqIdKnownO_A, irq_id_o[k], clk_i, !rst_ni)
+  end
 
 endmodule

--- a/hw/ip/rv_plic/rtl/rv_plic.sv
+++ b/hw/ip/rv_plic/rtl/rv_plic.sv
@@ -207,7 +207,7 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   ///////////////////////////////////
   // Target interrupt notification //
   ///////////////////////////////////
-  for (genvar i = 0 ; i < NumTarget ; i++) begin : geNumTarget
+  for (genvar i = 0 ; i < NumTarget ; i++) begin : gen_target
     rv_plic_target #(
       .N_SOURCE (NumSrc),
       .MAX_PRIO (MAX_PRIO),
@@ -250,8 +250,10 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   `ASSERT_KNOWN(TlDValidKnownO_A, tl_o.d_valid, clk_i, !rst_ni)
   `ASSERT_KNOWN(TlAReadyKnownO_A, tl_o.a_ready, clk_i, !rst_ni)
   `ASSERT_KNOWN(IrqKnownO_A, irq_o, clk_i, !rst_ni)
-  `ASSERT_KNOWN(IrqIdKnownO_A, irq_id_o, clk_i, !rst_ni)
   `ASSERT_KNOWN(MsipKnownO_A, msip_o, clk_i, !rst_ni)
+  for (genvar k = 0; k < NumTarget; k++) begin : gen_irq_id_known
+    `ASSERT_KNOWN(IrqIdKnownO_A, irq_id_o[k], clk_i, !rst_ni)
+  end
 
 endmodule
 

--- a/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic.sv
+++ b/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic.sv
@@ -215,7 +215,7 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   ///////////////////////////////////
   // Target interrupt notification //
   ///////////////////////////////////
-  for (genvar i = 0 ; i < NumTarget ; i++) begin : geNumTarget
+  for (genvar i = 0 ; i < NumTarget ; i++) begin : gen_target
     rv_plic_target #(
       .N_SOURCE (NumSrc),
       .MAX_PRIO (MAX_PRIO),
@@ -258,7 +258,9 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   `ASSERT_KNOWN(TlDValidKnownO_A, tl_o.d_valid, clk_i, !rst_ni)
   `ASSERT_KNOWN(TlAReadyKnownO_A, tl_o.a_ready, clk_i, !rst_ni)
   `ASSERT_KNOWN(IrqKnownO_A, irq_o, clk_i, !rst_ni)
-  `ASSERT_KNOWN(IrqIdKnownO_A, irq_id_o, clk_i, !rst_ni)
   `ASSERT_KNOWN(MsipKnownO_A, msip_o, clk_i, !rst_ni)
+  for (genvar k = 0; k < NumTarget; k++) begin : gen_irq_id_known
+    `ASSERT_KNOWN(IrqIdKnownO_A, irq_id_o[k], clk_i, !rst_ni)
+  end
 
 endmodule


### PR DESCRIPTION
This corrects a KNOWN assertion in rv_plic which checks elements of an unpacked array. In particular, VCS requires the unpacked array to be indexed explicitly, which led to a syntax error with the previous implementation. 

Apart from this correction, the patch also fixes a lint warning due to a misspelled generate block label.

This patch was previously part of #798, but I have split this out since it is more critical than the rest of the lint fixes in #798.