### PR TITLE
[top_earlgrey] Fix vendor in JTAG IDCODE

### DIFF
--- a/hw/top_earlgrey/doc/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/doc/top_earlgrey.sv.tpl
@@ -64,7 +64,7 @@ module top_${top["name"]} #(
   localparam JTAG_IDCODE = {
     4'h0,     // Version
     16'h4F54, // Part Number: "OT"
-    11'h4A6,  // Manufacturer Identity: Google
+    11'h426,  // Manufacturer Identity: Google
     1'b1      // (fixed)
   };
 

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -42,7 +42,7 @@ module top_earlgrey #(
   localparam JTAG_IDCODE = {
     4'h0,     // Version
     16'h4F54, // Part Number: "OT"
-    11'h4A6,  // Manufacturer Identity: Google
+    11'h426,  // Manufacturer Identity: Google
     1'b1      // (fixed)
   };
 

--- a/util/openocd/target/lowrisc-earlgrey.cfg
+++ b/util/openocd/target/lowrisc-earlgrey.cfg
@@ -13,7 +13,7 @@ if { [info exists CHIPNAME] } {
 if { [info exists CPUTAPID ] } {
    set _CPUTAPID $CPUTAPID
 } else {
-   set _CPUTAPID 0x04F5494D
+   set _CPUTAPID 0x04f5484d
 }
 
 jtag newtap $_CHIPNAME tap -irlen 5 -expected-id $_CPUTAPID


### PR DESCRIPTION
The JTAG IDCODE field uses a manufacturer ID from the JEDEC list of
manufacturers. This list organizes its entries in banks. Google is in
bank 9. The previously used number was from bank 10.

With this change, OpenOCD reports the right vendor:

```
$ /tools/openocd/bin/openocd -s util/openocd -f board/lowrisc-earlgrey-nexysvideo.cfg
Open On-Chip Debugger 0.10.0+dev-00823-g20804cb4d (2019-10-30-22:27)
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
none separate

Info : Listening on port 6666 for tcl connections
Info : Listening on port 4444 for telnet connections
Info : clock speed 30000 kHz
Info : JTAG tap: riscv.tap tap/device found: 0x04f5484d (mfg: 0x426 (Google Inc), part: 0x4f54, ver: 0x0)
Info : datacount=2 progbufsize=8
Info : Examined RISC-V core; found 1 harts
Info :  hart 0: XLEN=32, misa=0x40001104
Info : Listening on port 3333 for gdb connections
```

Fixes #490