### PR TITLE
[tlul] Fixed TL-UL error response of d_size

### DIFF
--- a/hw/ip/tlul/rtl/tlul_err_resp.sv
+++ b/hw/ip/tlul/rtl/tlul_err_resp.sv
@@ -14,19 +14,22 @@ module tlul_err_resp (
 );
   import tlul_pkg::*;
 
-  logic [top_pkg::TL_AIW-1:0] err_source;
-  tl_a_op_e                   err_opcode;
-  logic                       err_req_pending, err_rsp_pending;
+  tl_a_op_e                          err_opcode;
+  logic [$bits(tl_h_i.a_source)-1:0] err_source;
+  logic [$bits(tl_h_i.a_size)-1:0]   err_size;
+  logic                              err_req_pending, err_rsp_pending;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       err_req_pending <= 1'b0;
       err_source      <= {top_pkg::TL_AIW{1'b0}};
       err_opcode      <= Get;
+      err_size        <= '0;
     end else if (tl_h_i.a_valid && tl_h_o.a_ready) begin
       err_req_pending <= 1'b1;
       err_source      <= tl_h_i.a_source;
       err_opcode      <= tl_h_i.a_opcode;
+      err_size        <= tl_h_i.a_size;
     end else if (!err_rsp_pending) begin
       err_req_pending <= 1'b0;
     end
@@ -38,7 +41,7 @@ module tlul_err_resp (
   assign tl_h_o.d_source = err_source;
   assign tl_h_o.d_sink   = '0;
   assign tl_h_o.d_param  = '0;
-  assign tl_h_o.d_size   = '0;
+  assign tl_h_o.d_size   = err_size;
   assign tl_h_o.d_opcode = (err_opcode == Get) ? AccessAckData : AccessAck;
   assign tl_h_o.d_user   = '0;
   assign tl_h_o.d_error  = 1'b1;


### PR DESCRIPTION
Problem:

    d_size of unmapped address was tied to 0

`tlul_err_resp` module is used to return the error response inside TL-UL
crossbar when a host tries to access unmapped address space. It tied the
`d_size` to 0 regardless of the request size. But TL specification
requires the device to return the `d_size` same as `a_size`.

Resolution:

    Latch `a_size` and return the value to `d_size`.

The issue is reported by @weicaiyang and issue #822 was created.