### PR TITLE
[doc] Minor update for markdown consistency

### DIFF
--- a/hw/ip/rv_timer/doc/_index.md
+++ b/hw/ip/rv_timer/doc/_index.md
@@ -161,7 +161,7 @@ registers per Hart.
 ```
 
 
-# Programmer's Guide
+# Programmers Guide
 
 ## Initialization
 


### PR DESCRIPTION
- only changed a single character from Programmer's to Programmers