### PR TITLE
[dv] Update cove.cfg to remove pins_if coverage

### DIFF
--- a/hw/dv/tools/vcs/cover.cfg
+++ b/hw/dv/tools/vcs/cover.cfg
@@ -3,3 +3,7 @@ begin tgl(portsonly)
   -tree tb
   +tree tb.dut 1
 end
+// pins_if#(1) is used in tlul_assert which is binded to dut, should remove it in coverage
+begin
+  line+cond+branch -module pins_if#(1)
+end


### PR DESCRIPTION
pins_if is used in tlul_assert which is binded to dut, should remove
pins_if in coverage