### PR TITLE
Add COMMITTERS and document their role

### DIFF
--- a/COMMITTERS
+++ b/COMMITTERS
@@ -1,0 +1,21 @@
+This file contains the list of individuals with write access to the OpenTitan
+repository, who are responsible for the final approval and merge of
+contributions. See doc/project/committers.md for more information.
+
+Committers are listed alphabetically by surname in the format:
+* Full Name (GitHubID)
+
+Committer list:
+* Alex Bradbury (asb)
+* Cindy Chen (cindychip)
+* Timothy Chen (tjaychen)
+* Srikrishna Iyer (sriyerg)
+* Scott Johnson (sjgtty)
+* Garret Kelly (gkelly)
+* Eunchan Kim (eunchan)
+* Miguel Osorio (moidx)
+* Dominic Rizzo (domrizz0)
+* Michael Schaffner (msfschaffner)
+* Pirmin Vogel (vogelpi)
+* Philipp Wagner (imphil)
+* Weicai Yang (weicaiyang)

--- a/doc/project/_index.md
+++ b/doc/project/_index.md
@@ -16,3 +16,9 @@ To make it to that stage, a [Hardware Signoff Checklist]({{< relref "checklist.m
 ## Initiating new development
 
 The [OpenTitan RFC process]({{< relref "rfc_process" >}}) guides developers on how to initiate new development within the program.
+
+## Committers
+
+Committers are individuals with repository write access.
+Everyone is able and encouraged to contribute and to help with code review, but committers are responsible for the final approval and merge of contributions.
+See the [Committers]({{< relref "committers.md" >}}) definition and role description for more information.

--- a/doc/project/committers.md
+++ b/doc/project/committers.md
@@ -1,0 +1,37 @@
+---
+title: "Committers"
+---
+
+Committers are individuals with repository write access.
+While everyone can and is encouraged to contribute by reviewing code, committers are responsible for final approval and merge.
+Committers must ensure that any code merged meets a high quality bar, has been properly discussed, and the design rationale adequately explained and documented.
+Making a judgement on when these requirements have been met is fundamental to the role.
+
+When reviewing a pull request, committers have a range of options.
+They are entrusted to use their judgement along with any guidelines or recommendations set by the Technical Committee (TC).
+Options include:
+* Straight-forward approval.
+  The contribution doesn't require an [RFC]({{< relref "rfc_process" >}}) or further review by others.
+  Committers should only use this for cases where they have sufficient expertise and are confident no additional review is needed.
+* Approval, but please get an additional LGTM from other named reviewers.
+* Request for changes.
+* Request for further design rationale be written up and shared (but a full RFC isn't necessary).
+* Request that an RFC be written up and submitted.
+
+Where Committers disagree on the path forwards for a given PR and are unable to reach an agreement, the review moves to the TC.
+
+Committers are proposed by and voted on by the TC.
+Committers should:
+* Be active contributors to the project, with a history of high quality contributions, including code reviews.
+* Be familiar with the project processes and rules, and be able to apply them fairly.
+* Be responsive to feedback from TC members on their review approach and interpretation of project policy.
+* Work to ensure that stakeholders are properly consulted on any code or design changes.
+
+If you meet the above criteria and are interested in becoming a committer, then approach a TC member to see if they would be willing to propose you.
+TC members may also reach out to you to ask if you would be interested in becoming a committer.
+
+Under certain exceptional circumstances, the Steering Committee may vote to revoke a committer's status.
+This may happen in cases such as a committer failing to act as a good citizen within the project and the issue cannot be resolved through discussion.
+It may also be a natural function of "pruning the tree" as an individual's involvement in the project changes over time.
+
+The list of committers is maintained within the project's Git repository and is available in the [COMMITTERS file](https://github.com/lowRISC/opentitan/blob/master/COMMITTERS) in the repository root.


### PR DESCRIPTION
This PR introduces the role of the committer, creating a COMMITTERS file in the repo root and adds documentation describing this role.

Write access won't be changed immediately after this PR is merged, but will be changed prior to launch. See the recently sent email for more information about this change.