### PR TITLE
[doc] Use dollar sign prompt indicator

### DIFF
--- a/doc/ug/install_instructions/index.md
+++ b/doc/ug/install_instructions/index.md
@@ -267,5 +267,5 @@ ACTION=="add|change", SUBSYSTEM=="usb|tty", ATTRS{idVendor}=="0403", ATTRS{idPro
 You then need to reload the udev rules:
 
 ```console
-# sudo udevadm control --reload
+$ sudo udevadm control --reload
 ```


### PR DESCRIPTION
The hash mark typically represents commands executed in a privileged
environment. Use the dollar sign for normal users, which elevate
privileges with `sudo`.