### PR TITLE
[COMMITTERS] Fix Scott's GitHub username

### DIFF
--- a/COMMITTERS
+++ b/COMMITTERS
@@ -10,7 +10,7 @@ Committer list:
 * Cindy Chen (cindychip)
 * Timothy Chen (tjaychen)
 * Srikrishna Iyer (sriyerg)
-* Scott Johnson (sjgtty)
+* Scott Johnson (sjgitty)
 * Garret Kelly (gkelly)
 * Eunchan Kim (eunchan)
 * Miguel Osorio (moidx)


### PR DESCRIPTION
Thanks to @imphil to pointing out Scott's GitHub username in #852 had a typo.