### PR TITLE
[dv/hmac] TL outstanding request max value

### DIFF
--- a/hw/dv/sv/tl_agent/tl_agent_cfg.sv
+++ b/hw/dv/sv/tl_agent/tl_agent_cfg.sv
@@ -16,7 +16,10 @@ class tl_agent_cfg extends uvm_object;
   // 0: Unlimited from the master perspective, might be back-pressured by the slave
   // 1: Only single transaction at a time
   // n: Number of maximum oustanding requests
-  int unsigned max_outstanding_req = 1; // most of IPs only support 1 outstanding req
+
+  // Set for this large value to find max outstanding req DV can hit
+  // Then compare this value with designers to check if it meets their expectation
+  int unsigned max_outstanding_req = 16;
 
   // TileLink channel valid delay (host mode)
   bit use_seq_item_a_valid_delay;


### PR DESCRIPTION
This is a temp fix for issue #860, when HMAC and SPI device has an extra
storage for outstanding access.