### PR TITLE
[tlul/doc] Minor update to `tl_h2d_t` struct

### DIFF
--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -205,7 +205,7 @@ module rv_core_ibex #(
     a_source:  TL_AIW'(tl_i_source),
     a_address: {instr_addr_o[31:WordSize], {WordSize{1'b0}}},
     a_data:    {TL_DW{1'b0}},
-    a_user:    {TL_AUW{1'b0}},
+    a_user:    '{default:'0},
 
     d_ready:   1'b1
   };
@@ -248,7 +248,7 @@ module rv_core_ibex #(
     a_source:  TL_AIW'(tl_d_source),
     a_address: {data_addr_o[31:WordSize], {WordSize{1'b0}}},
     a_data:    data_wdata_o,
-    a_user:    {TL_AUW{1'b0}},
+    a_user:    '{default:'0},
 
     d_ready:   1'b1
   };

--- a/hw/ip/tlul/doc/_index.md
+++ b/hw/ip/tlul/doc/_index.md
@@ -87,7 +87,7 @@ signals per direction to carry chip specific user bits.
 | `a_source[AIW-1:0]` | output | Request identifier of configurable width |
 | `a_size[SZW-1:0]`   | output | Request size (requested size is 2^`a_size`, thus 0 = byte, 1 = 16b, 2 = 32b, 3 = 64b, etc) |
 | `a_mask[DBW-1:0]`   | output | Write strobe, one bit per byte indicating which lanes of data are valid for this write request |
-| `a_user[AUW-1:0]`   | output | Request attributes of configurable width, use TBD. **This is an augmentation to the TL-UL specification.** |
+| `a_user`            | output | Request attributes of configurable width, use TBD. **This is an augmentation to the TL-UL specification.** |
 | `d_valid`           | input  | Response from device is valid |
 | `d_ready`           | output | Response from device is accepted by host |
 | `d_opcode[2:0]`     | input  | Response opcode (Ack or Data) |
@@ -107,7 +107,6 @@ widths based upon the other parameter sizes.
 - `DBW`: number of data bytes, generated == `DW/8`
 - `SZW`: size width, covers 2^(x) <= `DBW`; (2 bit for 4B)
 - `AIW`: width of address source (ID) bus, default 8
-- `AUW`: width of access user bits, default 4
 - `DUW`: width of device user bits, default 4
 - `DIW`: width of sink bits, default 1
 
@@ -136,7 +135,6 @@ package top_pkg;
   localparam TL_AW=32;
   localparam TL_DW=32;
   localparam TL_AIW=8;
-  localparam TL_AUW=4;
   localparam TL_DIW=1;
   localparam TL_DUW=4;
   localparam TL_DBW=(TL_DW>>3);
@@ -157,6 +155,12 @@ package tlul_pkg;
   } tl_d_op_e;
 
   typedef struct packed {
+    logic [6:0] rsvd1; // Reserved for future use
+    logic       parity_en;
+    logic [7:0] parity; // Use only lower TL_DBW bit
+  } tl_a_user_t;
+
+  typedef struct packed {
     logic                         a_valid;
     tl_a_op_e                     a_opcode;
     logic                  [2:0]  a_param;
@@ -165,7 +169,7 @@ package tlul_pkg;
     logic   [top_pkg::TL_AW-1:0]  a_address;
     logic  [top_pkg::TL_DBW-1:0]  a_mask;
     logic   [top_pkg::TL_DW-1:0]  a_data;
-    logic  [top_pkg::TL_AUW-1:0]  a_user;
+    tl_a_user_t                   a_user;
 
     logic                         d_ready;
   } tl_h2d_t;

--- a/hw/ip/tlul/rtl/tlul_pkg.sv
+++ b/hw/ip/tlul/rtl/tlul_pkg.sv
@@ -16,7 +16,7 @@ package tlul_pkg;
   } tl_d_op_e;
 
   typedef struct packed {
-    logic [6:0] rsvd1;
+    logic [6:0] rsvd1; // Reserved for future use
     logic       parity_en;
     logic [7:0] parity; // Use only lower TL_DBW bit
   } tl_a_user_t;

--- a/hw/top_earlgrey/rtl/top_pkg.sv
+++ b/hw/top_earlgrey/rtl/top_pkg.sv
@@ -9,7 +9,6 @@ localparam TL_AW=32;
 localparam TL_DW=32;    // = TL_DBW * 8; TL_DBW must be a power-of-two
 localparam TL_AIW=8;    // a_source, d_source
 localparam TL_DIW=1;    // d_sink
-localparam TL_AUW=16;   // a_user
 localparam TL_DUW=16;   // d_user
 localparam TL_DBW=(TL_DW>>3);
 localparam TL_SZW=$clog2($clog2(TL_DBW)+1);


### PR DESCRIPTION
The TL-UL doc explains `a_user` as logic [AUW-1:0] signal. It is now
defined as a `tl_a_user_t` packed struct. The doc is revised
accordingly.

Also, related codes (core_ibex wrapper and top_pkg) are revised.

This is the following PR of #792 