### PR TITLE
[reggen] Remove FIFO depth when window is used

### DIFF
--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_top.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_top.sv
@@ -67,10 +67,10 @@ module flash_ctrl_reg_top (
     .HRspPass   (1'b1),
     .DReqPass   ({3{1'b1}}),
     .DRspPass   ({3{1'b1}}),
-    .HReqDepth  (4'h1),
-    .HRspDepth  (4'h1),
-    .DReqDepth  ({3{4'h1}}),
-    .DRspDepth  ({3{4'h1}})
+    .HReqDepth  (4'h0),
+    .HRspDepth  (4'h0),
+    .DReqDepth  ({3{4'h0}}),
+    .DRspDepth  ({3{4'h0}})
   ) u_socket (
     .clk_i,
     .rst_ni,

--- a/hw/ip/hmac/rtl/hmac_reg_top.sv
+++ b/hw/ip/hmac/rtl/hmac_reg_top.sv
@@ -65,10 +65,10 @@ module hmac_reg_top (
     .HRspPass   (1'b1),
     .DReqPass   ({2{1'b1}}),
     .DRspPass   ({2{1'b1}}),
-    .HReqDepth  (4'h1),
-    .HRspDepth  (4'h1),
-    .DReqDepth  ({2{4'h1}}),
-    .DRspDepth  ({2{4'h1}})
+    .HReqDepth  (4'h0),
+    .HRspDepth  (4'h0),
+    .DReqDepth  ({2{4'h0}}),
+    .DRspDepth  ({2{4'h0}})
   ) u_socket (
     .clk_i,
     .rst_ni,

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -65,10 +65,10 @@ module spi_device_reg_top (
     .HRspPass   (1'b1),
     .DReqPass   ({2{1'b1}}),
     .DRspPass   ({2{1'b1}}),
-    .HReqDepth  (4'h1),
-    .HRspDepth  (4'h1),
-    .DReqDepth  ({2{4'h1}}),
-    .DRspDepth  ({2{4'h1}})
+    .HReqDepth  (4'h0),
+    .HRspDepth  (4'h0),
+    .DReqDepth  ({2{4'h0}}),
+    .DRspDepth  ({2{4'h0}})
   ) u_socket (
     .clk_i,
     .rst_ni,

--- a/util/reggen/reg_top.sv.tpl
+++ b/util/reggen/reg_top.sv.tpl
@@ -84,10 +84,10 @@ module ${block.name}_reg_top ${print_param(params)}(
     .HRspPass   (1'b1),
     .DReqPass   ({${num_dsp}{1'b1}}),
     .DRspPass   ({${num_dsp}{1'b1}}),
-    .HReqDepth  (4'h1),
-    .HRspDepth  (4'h1),
-    .DReqDepth  ({${num_dsp}{4'h1}}),
-    .DRspDepth  ({${num_dsp}{4'h1}})
+    .HReqDepth  (4'h0),
+    .HRspDepth  (4'h0),
+    .DReqDepth  ({${num_dsp}{4'h0}}),
+    .DRspDepth  ({${num_dsp}{4'h0}})
   ) u_socket (
     .clk_i,
     .rst_ni,


### PR DESCRIPTION
Problem:

    reggen creates unintentional TL-UL buffers inside `tl_socket_1n` for
    window feature, which creates higher number of outstanding
    acceptances in the device port.

When `window` feature was implemented, `tlul_fifo_sync` doesn't have a
way to remove internal FIFO. So, when instantiating `tl_socket_1n` for
`window` requests, `ReqDepth` and `RspDepth` are set to 1h. It results
in the number of outstanding acceptances in a IP that having a window
port, to be more than or equal to 4 at least. One buffer in HReq,
another in DReq, 1 in DRsp, and 1 in DReq.

This PR is to remove the FIFO inside tlul_socket_1n, thanks to @tjaychen
added the condition of Depth == 0 and Pass == 1 case.

The IPs, for instance HMAC, still have a buffer internally. If
`tlul_adpater_sram` is used to convert TL-UL interface to the SRAM
interface, that module still has buffers internally.

The issue is discussed in #860

Signed-off-by: Eunchan Kim <eunchan@google.com>