### PR TITLE
[Makefile] Don't override the users compiler

### DIFF
--- a/hw/vendor/lowrisc_ibex/examples/sw/led/Makefile
+++ b/hw/vendor/lowrisc_ibex/examples/sw/led/Makefile
@@ -10,7 +10,7 @@ ARCH = rv32imc
 # ARCH = rv32im # to disable compressed instructions
 SRCS = $(PROGRAM).c
 
-CC = /tools/riscv/bin/riscv32-unknown-elf-gcc
+CC ?= /tools/riscv/bin/riscv32-unknown-elf-gcc
 
 OBJCOPY ?= $(subst gcc,objcopy,$(wordlist 1,1,$(CC)))
 OBJDUMP ?= $(subst gcc,objdump,$(wordlist 1,1,$(CC)))

--- a/sw/device/opts.mk
+++ b/sw/device/opts.mk
@@ -65,12 +65,12 @@ INFOTOOL      ?= $(SW_ROOT_DIR)/../util/rom_chip_info.py
 RV_TOOLS      ?= /tools/riscv/bin
 # ARCH = rv32im # to disable compressed instructions
 ARCH           = rv32imc
-CC             = ${RV_TOOLS}/riscv32-unknown-elf-gcc
-AR             = $(subst gcc,ar,$(wordlist 1,1,$(CC)))
-AS             = $(subst gcc,as,$(wordlist 1,1,$(CC)))
-LD             = $(subst gcc,ld,$(wordlist 1,1,$(CC)))
-OBJCOPY        = $(subst gcc,objcopy,$(wordlist 1,1,$(CC)))
-OBJDUMP        = $(subst gcc,objdump,$(wordlist 1,1,$(CC)))
+CC             ?= ${RV_TOOLS}/riscv32-unknown-elf-gcc
+AR             ?= $(subst gcc,ar,$(wordlist 1,1,$(CC)))
+AS             ?= $(subst gcc,as,$(wordlist 1,1,$(CC)))
+LD             ?= $(subst gcc,ld,$(wordlist 1,1,$(CC)))
+OBJCOPY        ?= $(subst gcc,objcopy,$(wordlist 1,1,$(CC)))
+OBJDUMP        ?= $(subst gcc,objdump,$(wordlist 1,1,$(CC)))
 
 CFLAGS        += -march=$(ARCH) -mabi=ilp32 -static -mcmodel=medany -Wall -g -Os \
                  -fvisibility=hidden -nostdlib -nostartfiles $(SW_FLAGS)

--- a/sw/vendor/cryptoc/Makefile
+++ b/sw/vendor/cryptoc/Makefile
@@ -11,7 +11,7 @@ ARCH         = rv32imc
 
 RV_TOOLS    ?= /tools/riscv/bin/
 
-CC          := ${RV_TOOLS}/riscv32-unknown-elf-gcc
+CC          ?= ${RV_TOOLS}/riscv32-unknown-elf-gcc
 CFLAGS      ?= -Wall -g -Os -march=$(ARCH) -mabi=ilp32 -static -mcmodel=medany \
 	       -fvisibility=hidden -nostdlib -nostartfiles
 


### PR DESCRIPTION
If a user has specified their own cross compiler (by setting the CC and
friends variables) respect their choice and don't forcefully override
it. This removes the requirement on everyone following the exact same
paths and will help distros.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>