### PR TITLE
[rv_plic] Implement a binary tree variant of the rv_plic_target module

### DIFF
--- a/hw/formal/fpv.tcl
+++ b/hw/formal/fpv.tcl
@@ -16,8 +16,6 @@ set_message -disable VERI-2418
 #-------------------------------------------------------------------------
 analyze -sv09 \
   -f formal_0.scr \
-  [glob ../../../../ip/*/dv/*_bind.sv] \
-  [glob ../../../../ip/*/dv/tb/*_bind.sv] \
   +define+ASIC_SYNTHESIS \
   +define+SYNTHESIS      \
   +define+FPV_ON

--- a/hw/ip/rv_plic/data/rv_plic.sv.tpl
+++ b/hw/ip/rv_plic/data/rv_plic.sv.tpl
@@ -15,7 +15,6 @@
 //   MAX_PRIO: Maximum value of interrupt priority
 
 module rv_plic import rv_plic_reg_pkg::*; #(
-  parameter      FIND_MAX = "SEQUENTIAL", // SEQUENTIAL | MATRIX
   // derived parameter
   localparam int SRCW    = $clog2(NumSrc+1)
 ) (
@@ -166,8 +165,7 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   for (genvar i = 0 ; i < NumTarget ; i++) begin : gen_target
     rv_plic_target #(
       .N_SOURCE (NumSrc),
-      .MAX_PRIO (MAX_PRIO),
-      .ALGORITHM(FIND_MAX)
+      .MAX_PRIO (MAX_PRIO)
     ) u_target (
       .clk_i,
       .rst_ni,

--- a/hw/ip/rv_plic/fpv/rv_plic_fpv.core
+++ b/hw/ip/rv_plic/fpv/rv_plic_fpv.core
@@ -11,10 +11,12 @@ filesets:
       - lowrisc:ip:tlul
       - lowrisc:prim:all
       - lowrisc:ip:rv_plic_component
+      - lowrisc:ip:xbar_dv
       # include top-earlgrey in order to test
       # with the top-level configuration
       - lowrisc:systems:top_earlgrey
     files:
+      - ../dv/rv_plic_bind.sv
       - vip/rv_plic_assert_fpv.sv
       - tb/rv_plic_bind_fpv.sv
       - tb/rv_plic_fpv.sv

--- a/hw/ip/rv_plic/fpv/tb/rv_plic_fpv.sv
+++ b/hw/ip/rv_plic/fpv/tb/rv_plic_fpv.sv
@@ -6,7 +6,7 @@
 
 module rv_plic_fpv import rv_plic_reg_pkg::*; #(
   // test all implementations
-  localparam int unsigned NumInstances = 2
+  localparam int unsigned NumInstances = 1
 ) (
   input                                          clk_i,
   input                                          rst_ni,
@@ -22,9 +22,7 @@ module rv_plic_fpv import rv_plic_reg_pkg::*; #(
   // several instances with different NumSrc and NumTarget configs here
   // (in a similar way as this has been done in prim_lfsr_fpv)
   // for (genvar k = 0; k < NumInstances; k++) begin : geNumInstances
-  rv_plic #(
-    .FIND_MAX("SEQUENTIAL")
-  ) i_rv_plic_sequential (
+  rv_plic i_rv_plic (
     .clk_i      ,
     .rst_ni     ,
     .tl_i       (tl_i[0]),
@@ -33,19 +31,6 @@ module rv_plic_fpv import rv_plic_reg_pkg::*; #(
     .irq_o      (irq_o[0]),
     .irq_id_o   (irq_id_o[0]),
     .msip_o     (msip_o[0])
-  );
-
-  rv_plic #(
-    .FIND_MAX("MATRIX")
-  ) i_rv_plic_matrix (
-    .clk_i      ,
-    .rst_ni     ,
-    .tl_i       (tl_i[1]),
-    .tl_o       (tl_o[1]),
-    .intr_src_i (intr_src_i[1]),
-    .irq_o      (irq_o[1]),
-    .irq_id_o   (irq_id_o[1]),
-    .msip_o     (msip_o[1])
   );
 
 endmodule : rv_plic_fpv

--- a/hw/ip/rv_plic/rtl/rv_plic.sv
+++ b/hw/ip/rv_plic/rtl/rv_plic.sv
@@ -15,7 +15,6 @@
 //   MAX_PRIO: Maximum value of interrupt priority
 
 module rv_plic import rv_plic_reg_pkg::*; #(
-  parameter      FIND_MAX = "SEQUENTIAL", // SEQUENTIAL | MATRIX
   // derived parameter
   localparam int SRCW    = $clog2(NumSrc+1)
 ) (
@@ -121,34 +120,11 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   assign prio[29] = reg2hw.prio29.q;
   assign prio[30] = reg2hw.prio30.q;
   assign prio[31] = reg2hw.prio31.q;
-  assign prio[32] = reg2hw.prio32.q;
-  assign prio[33] = reg2hw.prio33.q;
-  assign prio[34] = reg2hw.prio34.q;
-  assign prio[35] = reg2hw.prio35.q;
-  assign prio[36] = reg2hw.prio36.q;
-  assign prio[37] = reg2hw.prio37.q;
-  assign prio[38] = reg2hw.prio38.q;
-  assign prio[39] = reg2hw.prio39.q;
-  assign prio[40] = reg2hw.prio40.q;
-  assign prio[41] = reg2hw.prio41.q;
-  assign prio[42] = reg2hw.prio42.q;
-  assign prio[43] = reg2hw.prio43.q;
-  assign prio[44] = reg2hw.prio44.q;
-  assign prio[45] = reg2hw.prio45.q;
-  assign prio[46] = reg2hw.prio46.q;
-  assign prio[47] = reg2hw.prio47.q;
-  assign prio[48] = reg2hw.prio48.q;
-  assign prio[49] = reg2hw.prio49.q;
-  assign prio[50] = reg2hw.prio50.q;
-  assign prio[51] = reg2hw.prio51.q;
-  assign prio[52] = reg2hw.prio52.q;
-  assign prio[53] = reg2hw.prio53.q;
-  assign prio[54] = reg2hw.prio54.q;
 
   //////////////////////
   // Interrupt Enable //
   //////////////////////
-  for (genvar s = 0; s < 55; s++) begin : gen_ie0
+  for (genvar s = 0; s < 32; s++) begin : gen_ie0
     assign ie[0][s] = reg2hw.ie0[s].q;
   end
 
@@ -174,7 +150,7 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   ////////
   // IP //
   ////////
-  for (genvar s = 0; s < 55; s++) begin : gen_ip
+  for (genvar s = 0; s < 32; s++) begin : gen_ip
     assign hw2reg.ip[s].de = 1'b1; // Always write
     assign hw2reg.ip[s].d  = ip[s];
   end
@@ -182,7 +158,7 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   ///////////////////////////////////
   // Detection:: 0: Level, 1: Edge //
   ///////////////////////////////////
-  for (genvar s = 0; s < 55; s++) begin : gen_le
+  for (genvar s = 0; s < 32; s++) begin : gen_le
     assign le[s] = reg2hw.le[s].q;
   end
 
@@ -210,8 +186,7 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   for (genvar i = 0 ; i < NumTarget ; i++) begin : gen_target
     rv_plic_target #(
       .N_SOURCE (NumSrc),
-      .MAX_PRIO (MAX_PRIO),
-      .ALGORITHM(FIND_MAX)
+      .MAX_PRIO (MAX_PRIO)
     ) u_target (
       .clk_i,
       .rst_ni,

--- a/hw/ip/tlul/dv/xbar_sim.core
+++ b/hw/ip/tlul/dv/xbar_sim.core
@@ -15,7 +15,7 @@ filesets:
       - lowrisc:dv:mem_model
       - lowrisc:dv:xbar_test:0.1
     files:
-      - tb/xbar_macros.svh
+      - tb/xbar_macros.svh: {is_include_file: true}
       - tb/tb.sv
       - tb/xbar_main_bind.sv
       - tb/xbar_tl_if_connection.sv: {is_include_file: true}

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -380,10 +380,6 @@
       }
       base_addr: 0x40090000
       generated: "true"
-      parameter:
-      {
-        FIND_MAX: MATRIX
-      }
       size: 0x1000
       bus_device: tlul
       bus_host: none

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -89,11 +89,6 @@
       reset_connections: {rst_ni: "sys"},
       base_addr: "0x40090000",
       generated: "true"         // Indicate this module is generated in the topgen
-      parameter: {
-        // FIND_MAX determines the algorithm for searching highest priority interrupt.
-        // Available: { SEQUENTIAL, MATRIX }
-        FIND_MAX: "MATRIX",     // Parameter as key
-      }
     }
     { name: "pinmux",
       type: "pinmux",

--- a/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic.sv
+++ b/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic.sv
@@ -23,7 +23,6 @@
 //   MAX_PRIO: Maximum value of interrupt priority
 
 module rv_plic import rv_plic_reg_pkg::*; #(
-  parameter      FIND_MAX = "SEQUENTIAL", // SEQUENTIAL | MATRIX
   // derived parameter
   localparam int SRCW    = $clog2(NumSrc+1)
 ) (
@@ -218,8 +217,7 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   for (genvar i = 0 ; i < NumTarget ; i++) begin : gen_target
     rv_plic_target #(
       .N_SOURCE (NumSrc),
-      .MAX_PRIO (MAX_PRIO),
-      .ALGORITHM(FIND_MAX)
+      .MAX_PRIO (MAX_PRIO)
     ) u_target (
       .clk_i,
       .rst_ni,

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -510,9 +510,7 @@ module top_earlgrey #(
       .rst_ni (sys_rst_n)
   );
 
-  rv_plic #(
-    .FIND_MAX("MATRIX")
-  ) rv_plic (
+  rv_plic rv_plic (
       .tl_i (tl_rv_plic_d_h2d),
       .tl_o (tl_rv_plic_d_d2h),
 


### PR DESCRIPTION
Carried over from #624.

This implements a solution that uses a binary tree to gather the interrupts and forward the highest priority request. As such, it offers `O(N)` area and `O(log(N))` delay complexity. This solution is similar in area complexity as the SEQUENTIAL implementation, and it offers similar delay as the MATRIX implementation, but without the `O(N^2)` area cost.

Below are a couple of synthesis results of the `rv_plic_target.sv` module

- 64 sources
- 1ns timing constraint (overconstrained)
- 0ns input/output delay
- device: xc7a200tffv1156-1
- Vivado 2018.3.

```
+----------------+-------+-----------+----------+
| Implementation | LUTs  | WNS (ns)  | TNS (ns) |
+----------------+-------+-----------+----------+
| SEQUENTIAL     |   469 |  -69.895  | -641.94  |
| MATRIX         |  4834 |  -18.697  | -239.480 |
| BINTREE        |   491 |  -11.724  | -168.504 |
+----------------+-------+-----------+----------+
```
It should be noted that all IOs pass through FPGA pads in this case, and hence the delay figures above are higher than the usual reg2reg timing achievable on this FPGA series.

And below are normalized synthesis results from Synopsys DC with 64 and 128 interrupt sources.
64 sources:

```
+----------------+------+-------+------+
| Implementation | Area | Delay | TNS  |
+----------------+------+-------+------+
| SEQUENTIAL     | 1.0  | 1.0   | 1.0  |
| MATRIX         | 4.7  | 0.28  | 0.21 |
| BINTREE        | 0.83 | 0.22  | 0.11 |
+----------------+------+-------+------+

128 sources:
+----------------+------+-------+------+
| Implementation | Area | Delay | TNS  |
+----------------+------+-------+------+
| SEQUENTIAL     | 1.0  | 1.0   | 1.0  |
| MATRIX         | 6.2  | 0.137 | 0.76 |
| BINTREE        | 0.69 | 0.079 | 0.09 |
+----------------+------+-------+------+
```

Based on these experiments, we have decided to remove the SEQUENTIAL and MATRIX implementations, and just use the BINTREE instead.

Signed-off-by: Michael Schaffner <msf@google.com>