### PR TITLE
[fpv] Fix tcl file for xbar bind file

### DIFF
--- a/hw/formal/fpv.tcl
+++ b/hw/formal/fpv.tcl
@@ -14,10 +14,10 @@ set_message -disable VERI-2418
 #-------------------------------------------------------------------------
 # read design
 #-------------------------------------------------------------------------
+
 analyze -sv09 \
   -f formal_0.scr \
-  [glob ../../../../ip/*/dv/*_bind.sv] \
-  [glob ../../../../ip/*/dv/tb/*_bind.sv] \
+  [glob ../../../../ip/$env(FPV_TOP)/dv/*_bind.sv ../../../../ip/$env(FPV_TOP)/dv/tb/*_bind.sv] \
   +define+ASIC_SYNTHESIS \
   +define+SYNTHESIS      \
   +define+FPV_ON


### PR DESCRIPTION
In current xbar bind file, we should not include in the FPV env, but the
glob command in tcl file will find all bind files, which result in some
compile error. Now fpv tcl file will only glob the input IPs.
Signed-off-by: Cindy Chen <chencindy@google.com>