### PR TITLE
[doc] Github Note formatting

### DIFF
--- a/doc/ug/github_notes.md
+++ b/doc/ug/github_notes.md
@@ -106,7 +106,7 @@ short summary of the change. It should be prefixed with a word in
 square brackets indicating the area being changed, typically the IP or
 Tool name. For example:
 
-```
+```console
 [doc/um] Add notes on using GitHub and the repo
 ```
 
@@ -247,7 +247,7 @@ your local git tree as usual.
 The git output actually describes what to do (once you are used to how
 to read it). For example:
 
-```
+```console
 $ git rebase master
 First, rewinding head to replay your work on top of it...
 Applying: [util][pystyle] Clean python style in single file tools
@@ -289,7 +289,7 @@ is mentioned in the middle of what looks like error output.)
 If the file is opened with an editor the points at which there are
 conflicts will have diff-style change information embedded in to them. For example:
 
-```
+```console
 <<<<<<< HEAD
 import livereload
 
@@ -312,6 +312,7 @@ addressed the file can be `git add`ed and once all files addressed the
 rebase continued.
 
 After the fix a status report will remind you where you are.
+
 ```console
 $ git status
 rebase in progress; onto cb85dc4
@@ -382,6 +383,7 @@ You may find it useful to change the default for the way git reports conflicts i
 
 With the commands below, you can checkout a pull request from the upstream repo to
 your local repo.
+
 ```console
 $ git fetch upstream pull/{ID}/head:{BRANCH_NAME}
 $ # e.g. git fetch upstream pull/5/head:docgen_review
@@ -401,25 +403,31 @@ name 'br_localfix' which has an update for the verification environment. If the
 other user created a pull request with ID #345, which has a fix for the
 design bug, then you can apply the pull request into new branch
 'br_localandremote' with the following three methods:
+
 * The `rebase` method:
-  ```console
-  $ git checkout -b br_localandremote br_localfix
-  $ git fetch upstream pull/345/head:pr_345
-  $ git rebase pr_345
-  ```
+
+    ```console
+    $ git checkout -b br_localandremote br_localfix
+    $ git fetch upstream pull/345/head:pr_345
+    $ git rebase pr_345
+    ```
+
 * The `cherry-pick` method:
-  ```console
-  $ git checkout -b br_localandremote br_localfix
-  $ git fetch upstream pull/345/head:pr_345
-  $ # find the commit ID from pr_345 that you want to merge: b345232342ff
-  $ git cherry-pick b345232342ff
-  ```
+
+    ```console
+    $ git checkout -b br_localandremote br_localfix
+    $ git fetch upstream pull/345/head:pr_345
+    $ # find the commit ID from pr_345 that you want to merge: b345232342ff
+    $ git cherry-pick b345232342ff
+    ```
 * The `merge` method:
-  ```console
-  $ git fetch upstream pull/345/head:pr_345
-  $ git checkout -b br_localandremote br_localfix
-  $ git merge pr_345
-  ```
+
+    ```console
+    $ git fetch upstream pull/345/head:pr_345
+    $ git checkout -b br_localandremote br_localfix
+    $ git merge pr_345
+    ```
+
 The `rebase` method is more convenient than `cherry-pick` if you have more
 than one commit ID to merge. The `merge` method can only be used for local
 testing as the upstream lowRISC repository does not allow merge commits.
@@ -435,33 +443,41 @@ request. The process is quite complicated so please follow the instruction below
 step-by-step with caution:
 
 * Step 1: Checkout the other pull request branch
-  ```console
-  $ git fetch upstream pull/{ID}/head:{BRANCH_NAME}
-  $ git checkout {BRANCH_NAME}
-  ```
+
+    ```console
+    $ git fetch upstream pull/{ID}/head:{BRANCH_NAME}
+    $ git checkout {BRANCH_NAME}
+    ```
+
 * Step 2: Make necessary changes
-  ```console
-  $ git add...
-  $ git commit -m “Add CFG examples to UART specification”
-  ```
+
+    ```console
+    $ git add...
+    $ git commit -m “Add CFG examples to UART specification”
+    ```
+
 * Step 3: Create your github branch for the pull request
-  ```console
-  $ git push -u origin {BRANCH_NAME}:<remote_branch_name>
-  ```
-  You can use any branch name for the pull request.
-  If you want to the created branch name same as local branch name, this can
-  simply be:
-  ```console
-  $ git push -u origin HEAD
-  ```
+
+    ```console
+    $ git push -u origin {BRANCH_NAME}:<remote_branch_name>
+    ```
+
+    You can use any branch name for the pull request.
+    If you want to the created branch name same as local branch name, this can
+    simply be:
+
+    ```console
+    $ git push -u origin HEAD
+    ```
+
 * Step 4: Create a pull request into the other contributor's forked repository
 
-  To create a pull request in other's forked repository, you can follow the same method
-  as creating a pull request as section [Working in your local repo](#working-in-your-local-repo)
-  explained in details.
-  Once the other contributor's pull request is merged into the upstream
-  repository, you will need to create a pull request in that upstream repository
-  instead.
+    To create a pull request in other's forked repository, you can follow the same method
+    as creating a pull request as section [Working in your local
+    repo](#working-in-your-local-repo) explained in details.
+    Once the other contributor's pull request is merged into the upstream
+    repository, you will need to create a pull request in that upstream repository
+    instead.
 
 These are all the steps needed. Once your pull request is reviewed and merged, you will
 be able to see that the commit is also visible in the original pull request.


### PR DESCRIPTION
Make all the pre,code to be consistent. Previously some preformatted
codes used `console` some others didn't. Unified to use `console`
always.

Signed-off-by: Eunchan Kim <eunchan@google.com>