### PR TITLE
[sw/device] Remove newlib

### DIFF
--- a/sw/device/boot_rom/rom_link.ld
+++ b/sw/device/boot_rom/rom_link.ld
@@ -4,8 +4,7 @@
 
 OUTPUT_ARCH(riscv)
 
-/* required to correctly link newlib */
-GROUP( -lc -lgloss -lgcc -lsupc++ )
+GROUP( -lgcc )
 
 SEARCH_DIR(.)
 __DYNAMIC  =  0;

--- a/sw/device/boot_rom/rom_link.ld
+++ b/sw/device/boot_rom/rom_link.ld
@@ -40,6 +40,7 @@ SECTIONS
         _stext = .;
         *(.text.startup)
         *(.text)
+        *(.text.unlikely)
         _etext  =  .;
         __CTOR_LIST__ = .;
         LONG((__CTOR_END__ - __CTOR_LIST__) / 4 - 2)

--- a/sw/device/exts/common/_crt.c
+++ b/sw/device/exts/common/_crt.c
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#include <string.h>
-
 #include "sw/device/lib/common.h"
 #include "sw/device/lib/irq.h"
 

--- a/sw/device/exts/common/link.ld
+++ b/sw/device/exts/common/link.ld
@@ -4,8 +4,7 @@
 
 OUTPUT_ARCH(riscv)
 
-/* required to correctly link newlib */
-GROUP( -lc -lgloss -lgcc -lsupc++ )
+GROUP( -lgcc )
 
 SEARCH_DIR(.)
 __DYNAMIC  =  0;

--- a/sw/device/exts/common/link.ld
+++ b/sw/device/exts/common/link.ld
@@ -38,6 +38,7 @@ SECTIONS
         _stext = .;
         *(.text.startup)
         *(.text)
+        *(.text.unlikely)
         _etext  =  .;
         __CTOR_LIST__ = .;
         LONG((__CTOR_END__ - __CTOR_LIST__) / 4 - 2)

--- a/sw/device/lib/abort.c
+++ b/sw/device/lib/abort.c
@@ -1,0 +1,7 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/common.h"
+
+_Noreturn void abort(void) { __builtin_abort(); }

--- a/sw/device/lib/common.h
+++ b/sw/device/lib/common.h
@@ -6,6 +6,7 @@
 #define _COMMON_H_
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef SIMULATION
@@ -40,5 +41,7 @@ static const unsigned long UART_BAUD_RATE = 230400;
 #define BITLENGTH_5(X) ((X) + ((X) >> 16))
 #define BITLENGTH(X) \
   ((BITLENGTH_5(BITLENGTH_4(BITLENGTH_3(BITLENGTH_2(BITLENGTH_1(X)))))) & 0x7f)
+
+void *memcpy(void *restrict dest, const void *restrict src, size_t n);
 
 #endif

--- a/sw/device/lib/common.h
+++ b/sw/device/lib/common.h
@@ -47,4 +47,6 @@ void *memset(void *dest, int val, size_t n);
 
 size_t strlen(const char *s);
 
+void abort(void);
+
 #endif

--- a/sw/device/lib/common.h
+++ b/sw/device/lib/common.h
@@ -43,5 +43,6 @@ static const unsigned long UART_BAUD_RATE = 230400;
   ((BITLENGTH_5(BITLENGTH_4(BITLENGTH_3(BITLENGTH_2(BITLENGTH_1(X)))))) & 0x7f)
 
 void *memcpy(void *restrict dest, const void *restrict src, size_t n);
+void *memset(void *dest, int val, size_t n);
 
 #endif

--- a/sw/device/lib/common.h
+++ b/sw/device/lib/common.h
@@ -45,4 +45,6 @@ static const unsigned long UART_BAUD_RATE = 230400;
 void *memcpy(void *restrict dest, const void *restrict src, size_t n);
 void *memset(void *dest, int val, size_t n);
 
+size_t strlen(const char *s);
+
 #endif

--- a/sw/device/lib/gpio.c
+++ b/sw/device/lib/gpio.c
@@ -4,8 +4,6 @@
 
 #include "sw/device/lib/gpio.h"
 
-#include <assert.h>
-
 #include "sw/device/lib/common.h"
 
 void gpio_init(uint32_t oe) { REG32(GPIO_DIRECT_OE(0)) = oe; }
@@ -20,7 +18,8 @@ void gpio_write_bit(unsigned int bit, unsigned int val) {
   } else if (bit < 32) {
     gpio_masked_out_reg = (uint32_t *)GPIO_MASKED_OUT_UPPER(0);
   } else {
-    assert(1 && "bit must be < 32");
+    /* bit must be less then 32 */
+    abort();
   }
   bit %= 16;
 

--- a/sw/device/lib/hw_sha256.h
+++ b/sw/device/lib/hw_sha256.h
@@ -6,7 +6,6 @@
 #define _F_LIB_SHA256_H__
 
 #include <stddef.h>
-#include <stdint.h>
 
 #include "sw/vendor/cryptoc/include/cryptoc/hash-internal.h"
 

--- a/sw/device/lib/memcpy.c
+++ b/sw/device/lib/memcpy.c
@@ -1,0 +1,16 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/common.h"
+
+void *memcpy(void *dest, const void *src, size_t n) {
+  char *dest_c = (char *)dest;
+  char *src_c = (char *)src;
+
+  for (; n > 0; n--) {
+    *dest_c++ = *src_c++;
+  }
+
+  return dest;
+}

--- a/sw/device/lib/memset.c
+++ b/sw/device/lib/memset.c
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/common.h"
+
+void *memset(void *dest, int val, size_t n) {
+  char *dest_c = (char *)dest;
+
+  for (; n > 0; n--) {
+    *dest_c++ = (char)val;
+  }
+
+  return dest;
+}

--- a/sw/device/lib/meson.build
+++ b/sw/device/lib/meson.build
@@ -9,6 +9,7 @@ sw_lib_mem = declare_dependency(
     sources: [
       'memcpy.c',
       'memset.c',
+      'strlen.c',
     ],
   )
 )

--- a/sw/device/lib/meson.build
+++ b/sw/device/lib/meson.build
@@ -10,6 +10,7 @@ sw_lib_mem = declare_dependency(
       'memcpy.c',
       'memset.c',
       'strlen.c',
+      'abort.c',
     ],
   )
 )

--- a/sw/device/lib/meson.build
+++ b/sw/device/lib/meson.build
@@ -2,6 +2,16 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+# Memory Operations library (sw_lib_mem)
+sw_lib_mem = declare_dependency(
+  link_with: static_library(
+    'mem_ot',
+    sources: [
+      'memcpy.c',
+    ],
+  )
+)
+
 # UART library (sw_lib_uart)
 sw_lib_uart = declare_dependency(
   sources: [hw_ip_uart_reg_h],
@@ -60,6 +70,9 @@ sw_lib_hmac = declare_dependency(
       hw_ip_hmac_reg_h,
       'hw_sha256.c',
       'hmac.c',
+    ],
+    dependencies: [
+      sw_lib_mem,
     ]
   )
 )
@@ -75,6 +88,7 @@ sw_lib_irq = declare_dependency(
     ],
     dependencies: [
       sw_lib_uart,
+      sw_lib_mem,
     ]
   )
 )

--- a/sw/device/lib/meson.build
+++ b/sw/device/lib/meson.build
@@ -8,6 +8,7 @@ sw_lib_mem = declare_dependency(
     'mem_ot',
     sources: [
       'memcpy.c',
+      'memset.c',
     ],
   )
 )

--- a/sw/device/lib/rv_timer.h
+++ b/sw/device/lib/rv_timer.h
@@ -6,7 +6,6 @@
 #define _F_LIB_RV_TIMER_H__
 
 #include <stdbool.h>
-#include <stddef.h>
 #include <stdint.h>
 
 /**

--- a/sw/device/lib/srcs.mk
+++ b/sw/device/lib/srcs.mk
@@ -7,6 +7,6 @@ INCS              += -I$(LIB_DIR)
 
 GEN_HEADERS       += $(LIB_LOC_DIF_SRCS:.c=_regs.h)
 LIB_LOC_DIF_SRCS  += uart.c gpio.c spi_device.c flash_ctrl.c hmac.c usbdev.c rv_timer.c pinmux.c
-LIB_LOC_EXT_SRCS  += usb_controlep.c usb_simpleserial.c irq.c handler.c print_log.c irq_vectors.S memcpy.c memset.c strlen.c
+LIB_LOC_EXT_SRCS  += usb_controlep.c usb_simpleserial.c irq.c handler.c print_log.c irq_vectors.S memcpy.c memset.c strlen.c abort.c
 
 LIB_SRCS          += $(addprefix $(LIB_DIR)/, $(LIB_LOC_DIF_SRCS) $(LIB_LOC_EXT_SRCS))

--- a/sw/device/lib/srcs.mk
+++ b/sw/device/lib/srcs.mk
@@ -7,6 +7,6 @@ INCS              += -I$(LIB_DIR)
 
 GEN_HEADERS       += $(LIB_LOC_DIF_SRCS:.c=_regs.h)
 LIB_LOC_DIF_SRCS  += uart.c gpio.c spi_device.c flash_ctrl.c hmac.c usbdev.c rv_timer.c pinmux.c
-LIB_LOC_EXT_SRCS  += usb_controlep.c usb_simpleserial.c irq.c handler.c print_log.c irq_vectors.S memcpy.c
+LIB_LOC_EXT_SRCS  += usb_controlep.c usb_simpleserial.c irq.c handler.c print_log.c irq_vectors.S memcpy.c memset.c
 
 LIB_SRCS          += $(addprefix $(LIB_DIR)/, $(LIB_LOC_DIF_SRCS) $(LIB_LOC_EXT_SRCS))

--- a/sw/device/lib/srcs.mk
+++ b/sw/device/lib/srcs.mk
@@ -7,6 +7,6 @@ INCS              += -I$(LIB_DIR)
 
 GEN_HEADERS       += $(LIB_LOC_DIF_SRCS:.c=_regs.h)
 LIB_LOC_DIF_SRCS  += uart.c gpio.c spi_device.c flash_ctrl.c hmac.c usbdev.c rv_timer.c pinmux.c
-LIB_LOC_EXT_SRCS  += usb_controlep.c usb_simpleserial.c irq.c handler.c print_log.c irq_vectors.S memcpy.c memset.c
+LIB_LOC_EXT_SRCS  += usb_controlep.c usb_simpleserial.c irq.c handler.c print_log.c irq_vectors.S memcpy.c memset.c strlen.c
 
 LIB_SRCS          += $(addprefix $(LIB_DIR)/, $(LIB_LOC_DIF_SRCS) $(LIB_LOC_EXT_SRCS))

--- a/sw/device/lib/srcs.mk
+++ b/sw/device/lib/srcs.mk
@@ -7,6 +7,6 @@ INCS              += -I$(LIB_DIR)
 
 GEN_HEADERS       += $(LIB_LOC_DIF_SRCS:.c=_regs.h)
 LIB_LOC_DIF_SRCS  += uart.c gpio.c spi_device.c flash_ctrl.c hmac.c usbdev.c rv_timer.c pinmux.c
-LIB_LOC_EXT_SRCS  += usb_controlep.c usb_simpleserial.c irq.c handler.c print_log.c irq_vectors.S
+LIB_LOC_EXT_SRCS  += usb_controlep.c usb_simpleserial.c irq.c handler.c print_log.c irq_vectors.S memcpy.c
 
 LIB_SRCS          += $(addprefix $(LIB_DIR)/, $(LIB_LOC_DIF_SRCS) $(LIB_LOC_EXT_SRCS))

--- a/sw/device/lib/strlen.c
+++ b/sw/device/lib/strlen.c
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/common.h"
+
+size_t strlen(const char *s) {
+  const char *start = s;
+
+  while (*s) {
+    s++;
+  }
+
+  return s - start;
+}

--- a/sw/device/lib/usb_controlep.c
+++ b/sw/device/lib/usb_controlep.c
@@ -5,8 +5,6 @@
 // Get NULL from here
 #include "usb_controlep.h"
 
-#include <stddef.h>
-
 #include "sw/device/lib/common.h"
 #include "usb_consts.h"
 #include "usbdev.h"

--- a/sw/device/lib/usb_controlep.h
+++ b/sw/device/lib/usb_controlep.h
@@ -4,7 +4,6 @@
 
 #ifndef __USB_CONTROLEP_H__
 #define __USB_CONTROLEP_H__
-#include <stddef.h>
 
 #include "sw/device/lib/common.h"
 #include "usbdev.h"

--- a/sw/device/lib/usb_simpleserial.c
+++ b/sw/device/lib/usb_simpleserial.c
@@ -5,8 +5,6 @@
 // Get NULL from here
 #include "usb_simpleserial.h"
 
-#include <stddef.h>
-
 #include "sw/device/lib/common.h"
 #include "usbdev.h"
 

--- a/sw/device/lib/usbdev.c
+++ b/sw/device/lib/usbdev.c
@@ -5,8 +5,6 @@
 // Get NULL from here
 #include "usbdev.h"
 
-#include <stddef.h>
-
 #include "sw/device/lib/common.h"
 
 #define USBDEV_BASE_ADDR 0x40020000

--- a/sw/device/tests/hmac/sha256_test.c
+++ b/sw/device/tests/hmac/sha256_test.c
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdlib.h>
-#include <string.h>
 
 #include "sw/device/lib/common.h"
 #include "sw/device/lib/flash_ctrl.h"

--- a/sw/device/tests/hmac/sha256_test.c
+++ b/sw/device/tests/hmac/sha256_test.c
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stdlib.h>
-
 #include "sw/device/lib/common.h"
 #include "sw/device/lib/flash_ctrl.h"
 #include "sw/device/lib/hw_sha256.h"

--- a/sw/device/tests/rv_timer/rv_timer_test.c
+++ b/sw/device/tests/rv_timer/rv_timer_test.c
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stdlib.h>
-
 #include "sw/device/lib/common.h"
 #include "sw/device/lib/irq.h"
 #include "sw/device/lib/rv_timer.h"

--- a/sw/device/tests/rv_timer/rv_timer_test.c
+++ b/sw/device/tests/rv_timer/rv_timer_test.c
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdlib.h>
-#include <string.h>
 
 #include "sw/device/lib/common.h"
 #include "sw/device/lib/irq.h"


### PR DESCRIPTION
We currently include newlib in OT for the `assert()`, `memcpy()`, `memset()` and `strlen()` functions. This has the following disadvantages.

1. License issues. newlib is a confusing mixture of licenses including GPL (which is not compatible with Apache 2.0). This adds a burden to developers having to understand licensing issues when using newlib. Due to the complex newlib license I suspect this results with lawyers being required to decide if and when we can statically link with it.
2. Code size. With newlib my `build-fpga/sw/device/examples/hello_world/hello_world.bin` binary is 6040 bytes. After this series it drops to 5688. That's about a 6% size reduction.
3. Build issues. Requiring users to have newlib cross compiled for RISC-V ilp32 is just another burden in the cross compile process.
4. Security, including newlib in boot ROM increases the effort required to audit the entire code base.

This series removes the requirement of newlib for sw/device binaries.

It does this by re-implemened `abort()`, `memcpy()`, `memset()` and `strlen()`. There are basic implementations, if desired they can be optimised in the future (for ROM it doesn't seem too important and simplicity seems more important).

The current only assert() is assert(1), so replacing it with abort() doesn't make any real changes.

I have removed a large number of current #includes to simplify our dependencies. I haven't removed all of them, that can be left for another day.