### PR TITLE
[dv/hmac] Remove design depended signal probing

### DIFF
--- a/hw/ip/hmac/dv/env/hmac_env.sv
+++ b/hw/ip/hmac/dv/env/hmac_env.sv
@@ -11,11 +11,6 @@ class hmac_env extends cip_base_env #(.CFG_T               (hmac_env_cfg),
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
-    // get vifs
-    if (!uvm_config_db#(d2h_a_ready_vif)::get(this, "", "d2h_a_ready_vif",
-        cfg.d2h_a_ready_vif)) begin
-      `uvm_fatal(get_full_name(), "failed to get d2h_a_ready_vif from uvm_config_db")
-    end
   endfunction
 
 endclass

--- a/hw/ip/hmac/dv/env/hmac_env_cfg.sv
+++ b/hw/ip/hmac/dv/env/hmac_env_cfg.sv
@@ -6,8 +6,6 @@ class hmac_env_cfg extends cip_base_env_cfg #(.RAL_T(hmac_reg_block));
   `uvm_object_utils(hmac_env_cfg)
   `uvm_object_new
 
-  d2h_a_ready_vif d2h_a_ready_vif;
-
   virtual function void initialize_csr_addr_map_size();
     this.csr_addr_map_size = HMAC_ADDR_MAP_SIZE;
   endfunction : initialize_csr_addr_map_size

--- a/hw/ip/hmac/dv/env/hmac_env_pkg.sv
+++ b/hw/ip/hmac/dv/env/hmac_env_pkg.sv
@@ -31,6 +31,8 @@ package hmac_env_pkg;
   parameter uint32 HMAC_MSG_PROCESS_CYCLES   = 65;
   // 80 cycles for hmac key padding
   parameter uint32 HMAC_KEY_PROCESS_CYCLES   = 80;
+  // 1 cycles to write a msg word to hmac_msg_fifo
+  parameter uint32 HMAC_WR_WORD_CYCLE        = 1;
 
   typedef enum {
     HmacDone,

--- a/hw/ip/hmac/dv/tb/tb.sv
+++ b/hw/ip/hmac/dv/tb/tb.sv
@@ -29,7 +29,6 @@ module tb;
   pins_if #(NUM_MAX_ALERTS) alerts_if(.pins(alerts));
   pins_if #(1) devmode_if(devmode);
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
-  pins_if #(1) d2h_a_ready_if(tl_if.d2h.a_ready);
 
   // dut
   hmac dut (
@@ -57,7 +56,6 @@ module tb;
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
     uvm_config_db#(tlul_assert_ctrl_vif)::set(null, "*.env", "tlul_assert_ctrl_vif",
         dut.tlul_assert_device.tlul_assert_ctrl_if);
-    uvm_config_db#(d2h_a_ready_vif)::set(null, "*.env", "d2h_a_ready_vif", d2h_a_ready_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
     $timeformat(-12, 0, " ps", 12);
     run_test();


### PR DESCRIPTION
For Hmac scb, we have cycle accurate checking, but used to depend on
tlul interface signal, now changed to a switch, and will depend on
internal cycle counting.
Signed-off-by: Cindy Chen <chencindy@google.com>