### PR TITLE
[test] Set up CI for the Verilator-based pytest.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -259,6 +259,37 @@ jobs:
     artifact: dist-partial-top_earlgrey_nexysvideo
     displayName: 'Upload partial distribution artifacts'
 
+- job: "execute_verilated_tests"
+  displayName: "Execute tests on the Verilated system"
+  pool: "Default"
+  dependsOn:
+    - top_earlgrey_verilator
+    - deprecated_make_build
+  steps:
+  - bash: |
+      sudo apt-get install -y python3 python3-pip build-essential python3-setuptools
+      sudo pip3 install -r python-requirements.txt
+    displayName: 'Install dependencies'
+  - download: current
+    artifact: 'dist-partial-top_earlgrey_verilator'
+    displayName: 'Download verilated simulator'
+  - download: current
+    artifact: 'dist-partial-sw_build'
+    displayName: 'Download embedded artifacts'
+  - bash: |
+      cd "$(Build.ArtifactStagingDirectory)"
+      tar --overwrite -xvf \
+        "$(Pipeline.Workspace)/dist-partial-top_earlgrey_verilator/dist-partial-top_earlgrey_verilator.tar"
+      tar --overwrite -xvf \
+        "$(Pipeline.Workspace)/dist-partial-sw_build/dist-partial-sw_build.tar"
+    displayName: 'Unpack pipeline artifacts'
+  - bash: |
+      export VERILATED_SYSTEM_PATH="$(Build.ArtifactStagingDirectory)/dist/hw/top_earlgrey/Vtop_earlgrey_verilator"
+      export SW_BUILD_PATH="$(Build.ArtifactStagingDirectory)/dist"
+      export MAKE_BUILD=1
+      ci/run_verilator_pytest.sh
+    displayName: 'Execute tests'
+
 - job: "deploy_releaseartifacts"
   displayName: "Package and deploy release distribution"
   pool:

--- a/ci/run_verilator_pytest.sh
+++ b/ci/run_verilator_pytest.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+set -e
+
+readonly VERILATED_SYSTEM_DEFAULT="build/lowrisc_systems_top_earlgrey_verilator_0.1/sim-verilator/Vtop_earlgrey_verilator"
+readonly SW_BUILD_DEFAULT="build-verilator"
+
+VERILATED_SYSTEM_PATH="${VERILATED_SYSTEM_PATH:-$VERILATED_SYSTEM_DEFAULT}"
+SW_BUILD_PATH="${SW_BUILD_PATH:-$SW_BUILD_DEFAULT}"
+
+BOOT_ROM_TARGET="boot_rom/boot_rom.vmem"
+
+TEST_TARGETS=("tests/flash_ctrl/flash_test.vmem"
+  "tests/hmac/sha256_test.vmem"
+  "tests/rv_timer/rv_timer_test.vmem"
+)
+
+if [[ ! -z ${MAKE_BUILD+x} ]]; then
+  BOOT_ROM_TARGET="sim/boot_rom/rom.vmem"
+  TEST_TARGETS=("sim/tests/flash_ctrl/sw.vmem"
+    "sim/tests/hmac/sw.vmem"
+    "sim/tests/rv_timer/sw.vmem"
+  )
+fi
+
+FAIL_TARGETS=()
+PASS_TARGETS=()
+for target in "${TEST_TARGETS[@]}"; do
+  echo "Executing target ${target}"
+  set +e
+  set -x
+  pytest -s test/systemtest/functional_verilator_test.py \
+    --test_bin "$SW_BUILD_PATH/sw/device/${target}" \
+    --rom_bin  "$SW_BUILD_PATH/sw/device/${BOOT_ROM_TARGET}" \
+    --verilator_model "$VERILATED_SYSTEM_PATH"
+  if [[ $? == 0 ]]; then
+    PASS_TARGETS=("${PASS_TARGETS[@]}" "${target}")
+  else
+    FAIL_TARGETS=("${FAIL_TARGETS[@]}" "${target}")
+  fi
+  set +x
+  set -e
+done
+
+echo "Passing targets:"
+for target in "${PASS_TARGETS[@]}"; do
+  echo "* ${target}"
+done
+
+if [ ${#FAIL_TARGETS[@]} -eq 0 ]; then
+  echo "TESTS PASS!"
+else
+  echo
+  echo "Failing targets:"
+  for target in "${FAIL_TARGETS[@]}"; do
+    echo "* ${target}"
+  done
+  echo
+  echo "TESTS FAILED!"
+  exit 1
+fi


### PR DESCRIPTION
Replaces https://github.com/lowRISC/opentitan/pull/524, which I can no longer push to.

This change will be followed up with another change that switches all artifacts to use Meson's artifacts.