### PR TITLE
[sw] C logging APIs

### DIFF
--- a/hw/dv/tools/rules.mk
+++ b/hw/dv/tools/rules.mk
@@ -52,10 +52,12 @@ ifneq (${SW_NAME},)
 	rm -rf ${SW_BUILD_DIR}
 	mkdir -p ${SW_BUILD_DIR}
 	$(MAKE) -C $(SW_ROOT_DIR)/device \
+	  TARGET=dv \
 	  SW_DIR=boot_rom \
 	  SW_BUILD_DIR=$(SW_BUILD_DIR)/rom \
 	  MAKEFLAGS="$(SW_OPTS)"
 	$(MAKE) -C $(SW_ROOT_DIR)/device \
+	  TARGET=dv \
 	  SW_DIR=$(SW_DIR) \
 	  SW_NAME=$(SW_NAME) \
 	  SW_BUILD_DIR=$(SW_BUILD_DIR)/sw \

--- a/sw/device/Makefile
+++ b/sw/device/Makefile
@@ -16,6 +16,8 @@
 ##               SW_SRCS to be built for that SW test.                                            ##
 ## SW_NAME:      This is the name of the SW test begin run. Optional if SW_DIR name (last dir) is ##
 ##               the same as the SW test name.                                                    ##
+## TARGET:       Target for which the sw is cross-compiled - dv|fpga|verilator|silicon, etc       ##
+##               By default, no TARGET is selected.
 ##                                                                                                ##
 ## Optional variables:                                                                            ##
 ## SW_BUILD_DIR: This is the output location for generating all sources                           ##
@@ -26,7 +28,11 @@
 
 # Generate a baremetal application for the microcontroller
 SW_ROOT_DIR   := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))/..
+REPO_TOP      ?= $(realpath $(SW_ROOT_DIR)/..)
 SW_DIR        ?= examples/hello_world
+
+# SW build targets
+TARGET        ?=
 
 # sources
 STANDALONE_SW ?= 0

--- a/sw/device/boot_rom/boot_rom.c
+++ b/sw/device/boot_rom/boot_rom.c
@@ -2,12 +2,12 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "sw/device/boot_rom/chip_info.h"  // Generated.
-
 #include "sw/device/boot_rom/bootstrap.h"
+#include "sw/device/boot_rom/chip_info.h"  // Generated.
 #include "sw/device/lib/common.h"
 #include "sw/device/lib/flash_ctrl.h"
 #include "sw/device/lib/gpio.h"
+#include "sw/device/lib/log.h"
 #include "sw/device/lib/pinmux.h"
 #include "sw/device/lib/spi_device.h"
 #include "sw/device/lib/uart.h"
@@ -29,14 +29,12 @@ int main(int argc, char **argv) {
 
   int rv = bootstrap();
   if (rv) {
-    uart_send_str("Bootstrap failed with status code: ");
-    uart_send_uint(rv, 32);
-    uart_send_str("\r\n");
+    LOG_ERROR("Bootstrap failed with status code: %d\n", rv);
     // Currently the only way to recover is by a hard reset.
     return rv;
   }
 
-  uart_send_str("Jump!\r\n");
+  LOG_INFO("Jump!\n");
   while (!uart_tx_empty()) {
   }
   try_launch();

--- a/sw/device/boot_rom/meson.build
+++ b/sw/device/boot_rom/meson.build
@@ -36,6 +36,7 @@ custom_target(
       sw_lib_hmac,
       sw_lib_spi_device,
       sw_lib_uart,
+      sw_lib_log,
     ],
   ),
   command: embedded_target_args,

--- a/sw/device/boot_rom/srcs.mk
+++ b/sw/device/boot_rom/srcs.mk
@@ -2,9 +2,11 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-SW_NAME       ?= boot_rom
-SW_SRCS       += $(SW_DIR)/bootstrap.c $(SW_DIR)/boot_rom.c $(LIB_DIR)/hw_sha256.c
-INCS          += -I$(SW_ROOT_DIR)/vendor
+SW_NAME             ?= boot_rom
+SW_SRCS             += $(SW_DIR)/bootstrap.c $(SW_DIR)/boot_rom.c $(LIB_DIR)/hw_sha256.c
+INCS                += -I$(SW_ROOT_DIR)/vendor
+
+GEN_HEADER_OUTPUTS  += ${SW_BUILD_DIR}/sw/device/boot_rom/chip_info.h
 
 # overrides
 CRT_SRCS      := $(SW_DIR)/crt0.S

--- a/sw/device/lib/log.h
+++ b/sw/device/lib/log.h
@@ -1,0 +1,219 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef _LOG_H_
+#define _LOG_H_
+
+#ifdef DV_SIM
+#include "sw/device/lib/log_uart/log_impl.h"
+#else
+#include "sw/device/lib/log_uart/log_impl.h"
+#endif
+
+/**
+ * Generic logging APIs
+ *
+ * The logging APIs below take a format string with a variable number of
+ * arguments for the type specifiers. The APIs are designed to provide a way
+ * for attaching the message type, verbosity, file name and the line number
+ * information along with the message to provide an easier path to debug.
+ * These parameters form the message header which is prepended to the actual
+ * message being printed. The following is a brief description of these:
+ *
+ *  log_type:     Severity of the message:
+ *                info, warning, error or fatal
+ *                This is indicated using LOG_TYPE_* set of macros which are
+ *                set to empty strings by default.
+ *
+ *  verbosity:    Verbosity of the message (applicable only to info messages):
+ *                none, low, medium, high, full and debug.
+ *                Based on the desired verbosity, the visibility of certain
+ *                messages can be turned off. This is expected to be done
+ *                externally (for example, if the messages go to a log,
+ *                the desired verbosity messages can be searched and filtered
+ *                out). This is indicated using the LOG_VERB_* set of macros
+ *                which are set to empty strings by default.
+ *
+ *  file name:    Name of the file using __FILE__
+ *
+ *  line number:  Line where the print originated using __LINE__
+ *
+ * The construction of the log header using the above parameters is provided
+ * by the LOG_HEADER() helper macro.
+ *
+ * Once the header is constructed, another API is invoked that takes the header
+ * and the original message as arguments and prints the whole message using the
+ * desired implementation. This is provided by the PRINT_LOG() helper macro.
+ *
+ * All of these macros defined in this file can be overridden to customize the
+ * flow based on the desired outcome. This is done in the log_impl.h header
+ * file, placed in the sw/util/log_<impl> directory. The correct log_impl.h is
+ * selected by the build system which resolves the dependency based on the
+ * desired implementation.
+ *
+ * Supported format type specifiers
+ * The list of supported format specifiers is limited to integer / numerical
+ * types to maintain compatibility of the source code across different targets
+ * such as DV, Verilator and FPGA based simulations. These are as follows:
+ * %b:  Print binary [SystemVerilog style].
+ * %i:  Signed decimal.
+ * %d:  Signed decimal.
+ * %u:  Unsigned decimal.
+ * %o:  Octal.
+ * %c:  Single character byte.
+ * %X:  Upper case hex.
+ * %H:  Upper case hex [SystemVerilog style].
+ * %x:  Lower case hex.
+ * %h:  Lower case hex [SystemVerilog style].
+ * %%:  Escape '%'.
+ *
+ * In addition, there is an elementary support for specifing the width (as a
+ * positive number) to set the minimun number of digits to be print:
+ * %3d: Print minimum 3 digits, if fewer than 3 is available, then pad with 0s.
+ */
+
+/**
+ * Log type and verbosity string constants
+ *
+ * These are strings used by the LOG_HEADER helper macro to construct the
+ * header. These are set to empty strings - override these with the desired
+ * strings in the implementation-specific log_impl.h header.
+ */
+#ifndef LOG_TYPE_INFO
+#define LOG_TYPE_INFO ""
+#endif
+
+#ifndef LOG_TYPE_WARNING
+#define LOG_TYPE_WARNING ""
+#endif
+
+#ifndef LOG_TYPE_ERROR
+#define LOG_TYPE_ERROR ""
+#endif
+
+#ifndef LOG_TYPE_FATAL
+#define LOG_TYPE_FATAL ""
+#endif
+
+#ifndef LOG_VERB_NONE
+#define LOG_VERB_NONE ""
+#endif
+
+#ifndef LOG_VERB_LOW
+#define LOG_VERB_LOW ""
+#endif
+
+#ifndef LOG_VERB_MEDIUM
+#define LOG_VERB_MEDIUM ""
+#endif
+
+#ifndef LOG_VERB_HIGH
+#define LOG_VERB_HIGH ""
+#endif
+
+#ifndef LOG_VERB_FULL
+#define LOG_VERB_FULL ""
+#endif
+
+#ifndef LOG_VERB_DEBUG
+#define LOG_VERB_DEBUG ""
+#endif
+
+/**
+ * Log header helper macro
+ *
+ * This macro provides a way to construct the log header string using the above
+ * string constants.  This is set to an empty string - override this with the
+ * desired header construction in the implementation-specific log_impl.h
+ * header.
+ */
+#ifndef LOG_HEADER
+#define LOG_HEADER(log_type, verbosity) ""
+#endif
+
+/**
+ * Print log helper macro
+ *
+ * The generic logging APIs below are expected to invoke this underneath
+ * and provide a way to suppliment the message being printed with a header.
+ * Override this in the implementation-specific log_impl.h header.
+ */
+#ifndef PRINT_LOG
+#warning PRINT_LOG undefined: it will result in vacuous invocation
+#define PRINT_LOG(log_header, fmt, ...)
+#endif
+
+/**
+ * Logging APIs
+ *
+ * The following are a set of generic message APIs available for use in
+ * OpenTitan SW. These invoke the PRINT_LOG() helper macro which is vacuously
+ * defined above. The LOG_HEADER() helper macro is invoked in place of the
+ * "log_header' argument to PRINT_LOG(). LOG_HEADER() is also vacuously defined
+ * above. These helper macros can be overridden in the implementation-specific
+ * log_impl.h macro to achieve the desired outcome.
+ * The generic message APIs themselves can also be overridden if there is a
+ * desire to do so.
+ *
+ * @param fmt:    Format string message with type specifiers. To maintain
+ *                compatibility with the message API implementation for DV, the
+ *                type specifiers are limited to integer types.
+ * @param ...:    Arguments passed to the format string based on the type
+ *                specifiers in fmt.
+ */
+// Print an info message with no verbosity.
+#ifndef LOG_INFO
+#define LOG_INFO(fmt, ...) \
+  PRINT_LOG(LOG_HEADER(LOG_TYPE_INFO, LOG_VERB_NONE), fmt, __VA_ARGS__)
+#endif
+
+// Print an info message with low verbosity.
+#ifndef LOG_INFO_LOW
+#define LOG_INFO_LOW(fmt, ...) \
+  PRINT_LOG(LOG_HEADER(LOG_TYPE_INFO, LOG_VERB_LOW), fmt, __VA_ARGS__)
+#endif
+
+// Print an info message with medium verbosity.
+#ifndef LOG_INFO_MEDIUM
+#define LOG_INFO_MEDIUM(fmt, ...) \
+  PRINT_LOG(LOG_HEADER(LOG_TYPE_INFO, LOG_VERB_MEDIUM), fmt, __VA_ARGS__)
+#endif
+
+// Print an info message with high verbosity.
+#ifndef LOG_INFO_HIGH
+#define LOG_INFO_HIGH(fmt, ...) \
+  PRINT_LOG(LOG_HEADER(LOG_TYPE_INFO, LOG_VERB_HIGH), fmt, __VA_ARGS__)
+#endif
+
+// Print an info message with full verbosity.
+#ifndef LOG_INFO_FULL
+#define LOG_INFO_FULL(fmt, ...) \
+  PRINT_LOG(LOG_HEADER(LOG_TYPE_INFO, LOG_VERB_FULL), fmt, __VA_ARGS__)
+#endif
+
+// Print an info message with debug verbosity.
+#ifndef LOG_INFO_DEBUG
+#define LOG_INFO_DEBUG(fmt, ...) \
+  PRINT_LOG(LOG_HEADER(LOG_TYPE_INFO, LOG_VERB_DEBUG), fmt, __VA_ARGS__)
+#endif
+
+// Print a warning message.
+#ifndef LOG_WARNING
+#define LOG_WARNING(fmt, ...) \
+  PRINT_LOG(LOG_HEADER(LOG_TYPE_WARNING, ""), fmt, __VA_ARGS__)
+#endif
+
+// Print an error message.
+#ifndef LOG_ERROR
+#define LOG_ERROR(fmt, ...) \
+  PRINT_LOG(LOG_HEADER(LOG_TYPE_ERROR, ""), fmt, __VA_ARGS__)
+#endif
+
+// Print a fatal error message.
+#ifndef LOG_FATAL
+#define LOG_FATAL(fmt, ...) \
+  PRINT_LOG(LOG_HEADER(LOG_TYPE_FATAL, ""), fmt, __VA_ARGS__)
+#endif
+
+#endif  // _LOG_H_

--- a/sw/device/lib/log_uart/log_impl.h
+++ b/sw/device/lib/log_uart/log_impl.h
@@ -1,0 +1,61 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef _LOG_IMPL_H
+#define _LOG_IMPL_H
+
+#include "sw/device/lib/print_log.h"
+#include "sw/device/lib/uart.h"
+
+// Stringify stuff.
+#define _LOG_IMPL_STRINGIFY(a) _LOG_IMPL_STRINGIFY_INNER(a)
+#define _LOG_IMPL_STRINGIFY_INNER(a) #a
+
+// The macro below allows forwarding arguments from a variadic macro to a
+// variadic function and support the case where number of arguments is 0.
+#define LOG_IMPL_VA_ARGS(...) , ##__VA_ARGS__
+
+/**
+ * Log type and verbosity string constants
+ */
+#define LOG_TYPE_INFO "INFO"
+#define LOG_TYPE_WARNING "WARNING"
+#define LOG_TYPE_ERROR "ERROR"
+#define LOG_TYPE_FATAL "FATAL"
+
+/**
+ * Log header helper macro
+ *
+ * This macro constructs the log header in the following way:
+ * If LOG_HEADER_INCL_FILE_LINE flag is set:      TYPE (file:line):
+ * If LOG_HEADER_INCL_FILE_LINE flag is not set:  TYPE:
+ *
+ * Log verbosity is currently unused, since the volume of messages
+ * is not expected to be very high.
+ */
+#ifdef LOG_HEADER_INCL_FILE_LINE
+#define LOG_HEADER(log_type, verbosity) \
+  "" log_type "" verbosity              \
+  ""                                    \
+  " (" __FILE__ ":" _LOG_IMPL_STRINGIFY(__LINE__) "): "
+#else
+#define LOG_HEADER(log_type, verbosity) \
+  "" log_type "" verbosity              \
+  ""                                    \
+  ": "
+#endif
+
+/**
+ * Print log helper macro
+ *
+ * This macro calls the log_print() function to process format string and its
+ * type specifier arguments. It passes uart_send_char to print the message
+ * string character by character via UART. Do not invoke this macro directly;
+ * use the logging APIs in log.h (which serve as the generic APIs and invoke
+ * this macro underneath) instead.
+ */
+#define PRINT_LOG(log_header, fmt, ...) \
+  print_log(&uart_send_char, log_header fmt LOG_IMPL_VA_ARGS(__VA_ARGS__));
+
+#endif  // _LOG_IMPL_H

--- a/sw/device/lib/meson.build
+++ b/sw/device/lib/meson.build
@@ -118,3 +118,16 @@ sw_lib_usb = declare_dependency(
     ]
   )
 )
+
+# Logging library that prints to UART directly (sw_lib_log)
+sw_lib_log = declare_dependency(
+  link_with: static_library(
+    'log_ot',
+    sources: [
+      'print_log.c',
+    ],
+    dependencies: [
+      sw_lib_uart,
+    ]
+  )
+)

--- a/sw/device/lib/print_log.c
+++ b/sw/device/lib/print_log.c
@@ -1,0 +1,118 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/print_log.h"
+
+#include <stdarg.h>
+
+// Identifiers for string format type specifiers.
+static const char kFormatSpecifier = '%';
+static const char kBinary = 'b';       // Print binary [SystemVerilog style].
+static const char kDecimalI = 'i';     // Signed decimal.
+static const char kDecimal = 'd';      // Signed decimal.
+static const char kUnsigned = 'u';     // Unsigned decimal.
+static const char kOctal = 'o';        // Octal.
+static const char kAsciiChar = 'c';    // Single character byte.
+static const char kHexUpper = 'X';     // Upper case hex.
+static const char kHexAltUpper = 'H';  // Upper case hex [SystemVerilog style].
+static const char kHexLower = 'x';     // Lower case hex.
+static const char kHexAltLower = 'h';  // Lower case hex [SystemVerilog style].
+static const char kPercent = '%';      // Escape '%'.
+
+static inline void print_digit(print_char_func print_char, unsigned int digit) {
+  print_char("0123456789ABCDEF"[digit]);
+}
+
+static inline void print_num(print_char_func print_char, int width,
+                             unsigned int n, unsigned int base) {
+  // TODO: Consider changing this to for loop.
+  if (--width > 0 || n >= base) {
+    print_num(print_char, width, n / base, base);
+  }
+  print_digit(print_char, n % base);
+}
+
+void print_log(print_char_func print_char, const char *fmt, ...) {
+  va_list va;
+  va_start(va, fmt);
+
+  while (*fmt != '\0') {
+    char ch = *fmt++;
+    if (ch != kFormatSpecifier) {
+      // Add CR to new line automatically (if not added already).
+      if (ch == '\n' && !(*(fmt - 1) == '\r' || *(fmt + 1) == '\r')) {
+        print_char('\r');
+      }
+      print_char(ch);
+    } else {
+      int w = 0;
+      // TODO: Refactor this into a separate function.
+      while (*fmt != '\0') {
+        ch = *fmt++;
+        // Parse width field.
+        if (ch >= '0' && ch <= '9') {
+          w = w * 10 + (ch - '0');
+          continue;
+        } else {
+          switch (ch) {
+            case '\0': {
+              return;
+            }
+            case kBinary: {
+              unsigned int n = va_arg(va, unsigned int);
+              print_num(print_char, w, n, 2);
+              break;
+            }
+            case kDecimalI:
+            case kDecimal: {
+              unsigned int n = va_arg(va, unsigned int);
+              if (((int)n) < 0) {
+                print_char('-');
+                n = -n;
+              }
+              print_num(print_char, w, n, 10);
+              break;
+            }
+            case kUnsigned: {
+              unsigned int n = va_arg(va, unsigned int);
+              print_num(print_char, w, n, 10);
+              break;
+            }
+            case kOctal: {
+              unsigned int n = va_arg(va, unsigned int);
+              print_num(print_char, w, n, 8);
+              break;
+            }
+            case kHexLower:
+            case kHexAltLower:
+            case kHexUpper:
+            case kHexAltUpper: {
+              // TODO: This will still print in upper case.
+              unsigned int n = va_arg(va, unsigned int);
+              print_num(print_char, w, n, 16);
+              break;
+            }
+            case kAsciiChar: {
+              char c = va_arg(va, int);
+              print_char(c);
+              break;
+            }
+            case kPercent: {
+              print_char('%');
+              break;
+            }
+            default: {
+              // Unknown format - this error message is printed inline within
+              // the message.
+              print_log(print_char, "[INVALID SPECIFIER: %%%c]", ch);
+              break;
+            }
+          }
+          break;
+        }
+      }
+    }
+  }
+  va_end(va);
+}

--- a/sw/device/lib/print_log.h
+++ b/sw/device/lib/print_log.h
@@ -1,0 +1,38 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef _MSG_PRINT_H_
+#define _MSG_PRINT_H_
+
+// Pointer to a function that prints a character.
+typedef void (*print_char_func)(char);
+
+/**
+ * Generic print log function that prints a format string with variable
+ * number of type specifiers and arguments through a real hardware in the chip
+ *
+ * Function uses a format string as input which can contain a variable number
+ * of type specifiers. These are fulfilled with with variable number of
+ * corresponding arguments. It also takes a function pointer (which itself
+ * takes a single char argument as input) as an argument to print (write) the
+ * whole message string char by char through the HW IOs.
+ *
+ * To ensure portability of code across different platforms (DV simulations,
+ * FPGA based emulations with  production SW, simulations using Verilator,
+ * etc.), DO NOT CALL THIS FUNCTION DIRECTLY! Instead please use the generic
+ * logging APIs defined in msg.h.
+ * Also, the list of supported format specifiers is limited to integer types
+ * (%c, %d, %x, %X).
+ *
+ * @param print_char: Function pointer that takes single character as input and
+ *                    writes it to a HW in the chip such as UART for printing.
+ * @param fmt:    Format string message with type specifiers. To maintain
+ *                compatibility with the logging API implementation for DV, the
+ *                type specifiers are limited to integer types.
+ * @param ...:    Arguments passed to the format string based on the type
+ *                specifiers in fmt.
+ */
+void print_log(print_char_func print_char, const char *fmt, ...);
+
+#endif  // _MSG_PRINT_H_

--- a/sw/device/lib/srcs.mk
+++ b/sw/device/lib/srcs.mk
@@ -2,8 +2,11 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-GEN_HEADERS       += $(LIB_LOC_DIF_SRCS:.c=_regs.h) sw/device/boot_rom/chip_info.h
+LIB_DIR           ?= $(SW_ROOT_DIR)/device/lib
+INCS              += -I$(LIB_DIR)
+
+GEN_HEADERS       += $(LIB_LOC_DIF_SRCS:.c=_regs.h)
 LIB_LOC_DIF_SRCS  += uart.c gpio.c spi_device.c flash_ctrl.c hmac.c usbdev.c rv_timer.c pinmux.c
-LIB_LOC_EXT_SRCS  += usb_controlep.c usb_simpleserial.c irq.c handler.c irq_vectors.S
+LIB_LOC_EXT_SRCS  += usb_controlep.c usb_simpleserial.c irq.c handler.c print_log.c irq_vectors.S
 
 LIB_SRCS          += $(addprefix $(LIB_DIR)/, $(LIB_LOC_DIF_SRCS) $(LIB_LOC_EXT_SRCS))


### PR DESCRIPTION
- provide a generic set of APIs to print logs
- provide ability to attach severity (log type) and verbosity to msgs
- provide ability to attach a header to the msg underneath
  - provide ability to construct the header based on severity, verbosity
    file and line number for ease of debug

- provide a generic print_log() function that can parse a formatted string and
take variable number of args

- provide implementation specific APIs in
sw/device/lib/log_uart/log_impl.h to do the prints via UART

- PR #259 is being split to make the review easier
- this PR focuses on providing a high level API and 'typical' SW
implementation of it using UART,
- Subsequent PR will focus on DV specific implementation

This is same as PR #357 with amends. 

Tested the following prints:
```c
  LOG_INFO("info message\n");
  LOG_INFO_LOW("info low\n");
  LOG_INFO_MEDIUM("info med\n");
  LOG_INFO_HIGH("info hi\n");
  LOG_INFO_DEBUG("info debug\n");
  LOG_INFO_FULL("info full\n");
  LOG_WARNING("warn\n");
  LOG_ERROR("err\n");
  LOG_FATAL("fatal\n");

  LOG_INFO("1 in char: %c\n", '1');
  LOG_INFO("1234 in bin: %b\n", 1234);
  LOG_INFO("1234 in dec: %d\n", 1234);
  LOG_INFO("1234 in oct: %o\n", 1234);
  LOG_INFO("1234 in hex: %x\n", 1234);
  LOG_INFO("1234 in negative: %d\n", -1234);
  LOG_INFO("1234 in unsigned: %u\n", -1234);
  LOG_INFO("invalid: %k\n", -1234);
```

Output:
```
Commit ID:  4caa9b7d58e59884414f86f8db6bb863d1104e90
Build Date: 2019-11-07, 18:52:23
INFO: info message
INFO: info low
INFO: info med
INFO: info hi
INFO: info debug
INFO: info full
WARNING: warn
ERROR: err
FATAL: fatal
INFO: 1 in char: 1
INFO: 1234 in bin: 10011010010
INFO: 1234 in dec: 1234
INFO: 1234 in oct: 2322
INFO: 1234 in hex: 4D2
INFO: 1234 in negative: -1234
INFO: 1234 in unsigned: 4294966062
INFO: invalid: [INVALID SPECIFIER: %k]
INFO: Jump!
Hello World! Nov  7 2019 18:43:04
Watch the LEDs!
Try out the switches on the board
or type anything into the console window.
The LEDs show the ASCII code of the last character.
```
Signed-off-by: Srikrishna Iyer <sriyer@google.com>