### PR TITLE
[checklist] Change D1 checklist to instantiable

### DIFF
--- a/doc/project/checklist.md
+++ b/doc/project/checklist.md
@@ -25,10 +25,10 @@ Clock(s)/Reset(s) connected to all sub-modules.
 
 Unit `.sv` exists, meet comportability requirements.
 
-### IP_INSTANCED
+### IP_INSTANTIABLE
 
-Unit is instanced and binding in top level RTL. The unit must not break top
-level functionality such as propagating X through TL-UL interface.
+Unit is able to be instantiated and bound in top level RTL.
+The unit must not break top level functionality such as propagating X through TL-UL interface, continuously asserting the interrupts, or creating undesired TL-UL transactions.
 
 ### MEM_INSTANCED_80
 

--- a/doc/project/ip_checklist.md.tpl
+++ b/doc/project/ip_checklist.md.tpl
@@ -15,7 +15,7 @@ Documentation | [SPEC_COMPLETE][]     | Not Started |
 Documentation | [CSR_DEFINED][]       | Not Started |
 RTL           | [CLKRST_CONNECTED][]  | Not Started |
 RTL           | [IP_TOP][]            | Not Started |
-RTL           | [IP_INSTANCED][]      | Not Started |
+RTL           | [IP_INSTANTIABLE][]   | Not Started |
 RTL           | [MEM_INSTANCED_80][]  | Not Started |
 RTL           | [FUNC_IMPLEMENTED][]  | Not Started |
 RTL           | [ASSERT_KNOWN_ADDED][]| Not Started |
@@ -28,7 +28,7 @@ Review        | Signoff date          | Not Started |
 [CSR_DEFINED]:        {{<relref "/doc/project/checklist.md#csr-defined" >}}
 [CLKRST_CONNECTED]:   {{<relref "/doc/project/checklist.md#clkrst-connected" >}}
 [IP_TOP]:             {{<relref "/doc/project/checklist.md#ip-top" >}}
-[IP_INSTANCED]:       {{<relref "/doc/project/checklist.md#ip-instanced" >}}
+[IP_INSTANTIABLE]:    {{<relref "/doc/project/checklist.md#ip-instantiable" >}}
 [MEM_INSTANCED_80]:   {{<relref "/doc/project/checklist.md#mem-instanced-80" >}}
 [FUNC_IMPLEMENTED]:   {{<relref "/doc/project/checklist.md#func-implemented" >}}
 [ASSERT_KNOWN_ADDED]: {{<relref "/doc/project/checklist.md#assert-known-added" >}}

--- a/hw/ip/gpio/doc/checklist.md
+++ b/hw/ip/gpio/doc/checklist.md
@@ -15,7 +15,7 @@ Documentation | [SPEC_COMPLETE][]     | Done        | [GPIO Spec][]
 Documentation | [CSR_DEFINED][]       | Done        | [GPIO CSR][]
 RTL           | [CLKRST_CONNECTED][]  | Done        |
 RTL           | [IP_TOP][]            | Done        |
-RTL           | [IP_INSTANCED][]      | Done        |
+RTL           | [IP_INSTANTIABLE][]      | Done        |
 RTL           | [MEM_INSTANCED_80][]  | N/A         |
 RTL           | [FUNC_IMPLEMENTED][]  | Done        |
 RTL           | [ASSERT_KNOWN_ADDED][]| Done        |
@@ -31,7 +31,7 @@ Review        | Signoff date          | Done        | 2019-10-30
 [CSR_DEFINED]:        {{<relref "/doc/project/checklist.md#csr-defined" >}}
 [CLKRST_CONNECTED]:   {{<relref "/doc/project/checklist.md#clkrst-connected" >}}
 [IP_TOP]:             {{<relref "/doc/project/checklist.md#ip-top" >}}
-[IP_INSTANCED]:       {{<relref "/doc/project/checklist.md#ip-instanced" >}}
+[IP_INSTANTIABLE]:    {{<relref "/doc/project/checklist.md#ip-instantiable" >}}
 [MEM_INSTANCED_80]:   {{<relref "/doc/project/checklist.md#mem-instanced-80" >}}
 [FUNC_IMPLEMENTED]:   {{<relref "/doc/project/checklist.md#func-implemented" >}}
 [ASSERT_KNOWN_ADDED]: {{<relref "/doc/project/checklist.md#assert-known-added" >}}

--- a/hw/ip/hmac/doc/checklist.md
+++ b/hw/ip/hmac/doc/checklist.md
@@ -15,7 +15,7 @@ Documentation | [SPEC_COMPLETE][]     | Done        | [HMAC Spec][]
 Documentation | [CSR_DEFINED][]       | Done        |
 RTL           | [CLKRST_CONNECTED][]  | Done        |
 RTL           | [IP_TOP][]            | Done        |
-RTL           | [IP_INSTANCED][]      | Done        |
+RTL           | [IP_INSTANTIABLE][]      | Done        |
 RTL           | [MEM_INSTANCED_80][]  | Done        |
 RTL           | [FUNC_IMPLEMENTED][]  | Done        |
 RTL           | [ASSERT_KNOWN_ADDED][]| Done        |
@@ -29,7 +29,7 @@ Review        | Signoff date          | Done        | 2019-11-01
 [CSR_DEFINED]:        {{<relref "/doc/project/checklist.md#csr-defined" >}}
 [CLKRST_CONNECTED]:   {{<relref "/doc/project/checklist.md#clkrst-connected" >}}
 [IP_TOP]:             {{<relref "/doc/project/checklist.md#ip-top" >}}
-[IP_INSTANCED]:       {{<relref "/doc/project/checklist.md#ip-instanced" >}}
+[IP_INSTANTIABLE]:    {{<relref "/doc/project/checklist.md#ip-instantiable" >}}
 [MEM_INSTANCED_80]:   {{<relref "/doc/project/checklist.md#mem-instanced-80" >}}
 [FUNC_IMPLEMENTED]:   {{<relref "/doc/project/checklist.md#func-implemented" >}}
 [ASSERT_KNOWN_ADDED]: {{<relref "/doc/project/checklist.md#assert-known-added" >}}

--- a/hw/ip/rv_core_ibex/doc/checklist.md
+++ b/hw/ip/rv_core_ibex/doc/checklist.md
@@ -18,7 +18,7 @@ Documentation | [SPEC_COMPLETE][]     | Done        |
 Documentation | [CSR_DEFINED][]       | Done        | lowRISC/ibex#307
 RTL           | [CLKRST_CONNECTED][]  | Done        |
 RTL           | [IP_TOP][]            | Done        |
-RTL           | [IP_INSTANCED][]      | Done        |
+RTL           | [IP_INSTANTIABLE][]      | Done        |
 RTL           | [MEM_INSTANCED_80][]  | N/A         |
 RTL           | [FUNC_IMPLEMENTED][]  | Done        |
 RTL           | [ASSERT_KNOWN_ADDED][]| Done        |
@@ -29,7 +29,7 @@ Code Quality  | [LINT_SETUP][]        | Done        |
 [CSR_DEFINED]:        {{<relref "/doc/project/checklist.md#csr-defined" >}}
 [CLKRST_CONNECTED]:   {{<relref "/doc/project/checklist.md#clkrst-connected" >}}
 [IP_TOP]:             {{<relref "/doc/project/checklist.md#ip-top" >}}
-[IP_INSTANCED]:       {{<relref "/doc/project/checklist.md#ip-instanced" >}}
+[IP_INSTANTIABLE]:    {{<relref "/doc/project/checklist.md#ip-instantiable" >}}
 [MEM_INSTANCED_80]:   {{<relref "/doc/project/checklist.md#mem-instanced-80" >}}
 [FUNC_IMPLEMENTED]:   {{<relref "/doc/project/checklist.md#func-implemented" >}}
 [ASSERT_KNOWN_ADDED]: {{<relref "/doc/project/checklist.md#assert-known-added" >}}

--- a/hw/ip/rv_timer/doc/checklist.md
+++ b/hw/ip/rv_timer/doc/checklist.md
@@ -16,7 +16,7 @@ Documentation | [SPEC_COMPLETE][]     | Done        | [RV_TIMER Spec][]
 Documentation | [CSR_DEFINED][]       | Done        |
 RTL           | [CLKRST_CONNECTED][]  | Done        |
 RTL           | [IP_TOP][]            | Done        |
-RTL           | [IP_INSTANCED][]      | Done        |
+RTL           | [IP_INSTANTIABLE][]      | Done        |
 RTL           | [MEM_INSTANCED_80][]  | N/A         |
 RTL           | [FUNC_IMPLEMENTED][]  | Done        |
 RTL           | [ASSERT_KNOWN_ADDED][]| Done        |
@@ -30,7 +30,7 @@ Review        | Signoff date          | Done        | 2019-10-29
 [CSR_DEFINED]:        {{<relref "/doc/project/checklist.md#csr-defined" >}}
 [CLKRST_CONNECTED]:   {{<relref "/doc/project/checklist.md#clkrst-connected" >}}
 [IP_TOP]:             {{<relref "/doc/project/checklist.md#ip-top" >}}
-[IP_INSTANCED]:       {{<relref "/doc/project/checklist.md#ip-instanced" >}}
+[IP_INSTANTIABLE]:    {{<relref "/doc/project/checklist.md#ip-instantiable" >}}
 [MEM_INSTANCED_80]:   {{<relref "/doc/project/checklist.md#mem-instanced-80" >}}
 [FUNC_IMPLEMENTED]:   {{<relref "/doc/project/checklist.md#func-implemented" >}}
 [ASSERT_KNOWN_ADDED]: {{<relref "/doc/project/checklist.md#assert-known-added" >}}

--- a/hw/ip/spi_device/doc/checklist.md
+++ b/hw/ip/spi_device/doc/checklist.md
@@ -15,7 +15,7 @@ Documentation | [SPEC_COMPLETE][]     | Done        | [SPI_DEVICE Spec][]
 Documentation | [CSR_DEFINED][]       | Done        |
 RTL           | [CLKRST_CONNECTED][]  | Done        |
 RTL           | [IP_TOP][]            | Done        |
-RTL           | [IP_INSTANCED][]      | Done        |
+RTL           | [IP_INSTANTIABLE][]      | Done        |
 RTL           | [MEM_INSTANCED_80][]  | Done        | `prim_ram_2p` is instantiated
 RTL           | [FUNC_IMPLEMENTED][]  | Done        | Firmware Operation Mode only
 RTL           | [ASSERT_KNOWN_ADDED][]| Done        |
@@ -29,7 +29,7 @@ Review        | Signoff date          | Not Started | 2019-11-07
 [CSR_DEFINED]:        {{<relref "/doc/project/checklist.md#csr-defined" >}}
 [CLKRST_CONNECTED]:   {{<relref "/doc/project/checklist.md#clkrst-connected" >}}
 [IP_TOP]:             {{<relref "/doc/project/checklist.md#ip-top" >}}
-[IP_INSTANCED]:       {{<relref "/doc/project/checklist.md#ip-instanced" >}}
+[IP_INSTANTIABLE]:    {{<relref "/doc/project/checklist.md#ip-instantiable" >}}
 [MEM_INSTANCED_80]:   {{<relref "/doc/project/checklist.md#mem-instanced-80" >}}
 [FUNC_IMPLEMENTED]:   {{<relref "/doc/project/checklist.md#func-implemented" >}}
 [ASSERT_KNOWN_ADDED]: {{<relref "/doc/project/checklist.md#assert-known-added" >}}

--- a/hw/ip/uart/doc/checklist.md
+++ b/hw/ip/uart/doc/checklist.md
@@ -18,7 +18,7 @@ Documentation | [SPEC_COMPLETE][]     | Done        | [UART Spec](../)
 Documentation | [CSR_DEFINED][]       | Done        |
 RTL           | [CLKRST_CONNECTED][]  | Done        |
 RTL           | [IP_TOP][]            | Done        |
-RTL           | [IP_INSTANCED][]      | Done        |
+RTL           | [IP_INSTANTIABLE][]      | Done        |
 RTL           | [MEM_INSTANCED_80][]  | N/A         |
 RTL           | [FUNC_IMPLEMENTED][]  | Done        |
 RTL           | [ASSERT_KNOWN_ADDED][]| Done        |
@@ -31,7 +31,7 @@ Review        | Signoff date          | Done        | 2019-10-28
 [CSR_DEFINED]:        {{<relref "/doc/project/checklist.md#csr-defined" >}}
 [CLKRST_CONNECTED]:   {{<relref "/doc/project/checklist.md#clkrst-connected" >}}
 [IP_TOP]:             {{<relref "/doc/project/checklist.md#ip-top" >}}
-[IP_INSTANCED]:       {{<relref "/doc/project/checklist.md#ip-instanced" >}}
+[IP_INSTANTIABLE]:    {{<relref "/doc/project/checklist.md#ip-instantiable" >}}
 [MEM_INSTANCED_80]:   {{<relref "/doc/project/checklist.md#mem-instanced-80" >}}
 [FUNC_IMPLEMENTED]:   {{<relref "/doc/project/checklist.md#func-implemented" >}}
 [ASSERT_KNOWN_ADDED]: {{<relref "/doc/project/checklist.md#assert-known-added" >}}

--- a/hw/top_earlgrey/ip/xbar/doc/checklist.md
+++ b/hw/top_earlgrey/ip/xbar/doc/checklist.md
@@ -15,7 +15,7 @@ Documentation | [SPEC_COMPLETE][]     | Done        | [TL-UL Spec][] [crossbar_t
 Documentation | [CSR_DEFINED][]       | N/A         |
 RTL           | [CLKRST_CONNECTED][]  | Done        |
 RTL           | [IP_TOP][]            | Done        |
-RTL           | [IP_INSTANCED][]      | Done        |
+RTL           | [IP_INSTANTIABLE][]      | Done        |
 RTL           | [MEM_INSTANCED_80][]  | N/A         |
 RTL           | [FUNC_IMPLEMENTED][]  | Done        |
 RTL           | [ASSERT_KNOWN_ADDED][]| Done        |
@@ -30,7 +30,7 @@ Review        | Signoff date          | Done        | 2019-11-04
 [CSR_DEFINED]:        {{<relref "/doc/project/checklist.md#csr-defined" >}}
 [CLKRST_CONNECTED]:   {{<relref "/doc/project/checklist.md#clkrst-connected" >}}
 [IP_TOP]:             {{<relref "/doc/project/checklist.md#ip-top" >}}
-[IP_INSTANCED]:       {{<relref "/doc/project/checklist.md#ip-instanced" >}}
+[IP_INSTANTIABLE]:    {{<relref "/doc/project/checklist.md#ip-instantiable" >}}
 [MEM_INSTANCED_80]:   {{<relref "/doc/project/checklist.md#mem-instanced-80" >}}
 [FUNC_IMPLEMENTED]:   {{<relref "/doc/project/checklist.md#func-implemented" >}}
 [ASSERT_KNOWN_ADDED]: {{<relref "/doc/project/checklist.md#assert-known-added" >}}


### PR DESCRIPTION
Changed the IP_INSTANTIATED to IP_INSTANTIABLE.

Previous term isn't appropriate. IP in D1 stage doesn't have to be
included in the top level. The intention of the checklist item is to
check whether it breaks the existing test items in the top.

Conforming to the [comportability spec][] doesn't mean that the IP
itself doesn't affect outside of the IP. For instance, some interrupt
keeps bugging the interrupt controller. This checklist item is to make
sure it is ready to test the main datapath in the top level simulation
or on the FPGA.

```console
$ git ls-files | xargs sed -i 's/IP_INSTANTIATED\]:   /IP_INSTANTIABLE\]:/'
#... similar for ip-instantiated
```