### PR TITLE
[top/earlgrey] Tying SPI interface

### DIFF
--- a/hw/top_earlgrey/rtl/top_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_asic.sv
@@ -48,6 +48,11 @@ module top_earlgrey_asic (
     .jtag_td_i        (IO_JTDI),
     .jtag_td_o        (IO_JTDO),
 
+    .dio_spi_device_sck_i     (1'b1),
+    .dio_spi_device_csb_i     (1'b1),
+    .dio_spi_device_mosi_i    (1'b1),
+    .dio_spi_device_miso_o    (),
+    .dio_spi_device_miso_en_o (),
     .dio_uart_rx_i    (cio_uart_rx_p2d),
     .dio_uart_tx_o    (cio_uart_tx_d2p),
     .dio_uart_tx_en_o (cio_uart_tx_en_d2p),


### PR DESCRIPTION
After adding ASSERT_KNOWN, top sim is failed at the SPI_DEVICE
assertion,

    UVM_ERROR @    135732 ps: (prim_assert.sv:21) [ASSERT FAILED]
    [tb.dut.top_earlgrey.spi_device.CioMisoEnOKnown] CioMisoEnOKnown:
    !$isunknown(cio_miso_en_o)
    (hw/ip/spi_device/rtl/spi_device.sv:565)

`cio_miso_en_o` is connected to csb_i, which signal is floating at the
top. So, all the inputs of SPI interface are tied to 1 for now.

Signed-off-by: Eunchan Kim <eunchan@google.com>