### PR TITLE
[ci] Only run clang-format on C/C++ diffs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,7 +63,7 @@ jobs:
       #echo "##vso[task.issue type=error;sourcepath=/azure-pipelines.yml;linenumber=45;columnnumber=1;code=100;]Found something that could be a problem."
       fork_origin=$(git merge-base --fork-point origin/master)
       changed_files=$(git diff --name-only $fork_origin | grep -v /vendor/ | grep -E '\.(cpp|cc|c|h)$')
-      test -z $changed_files || git diff -U0 $fork_origin $changed_files | clang-format-diff -p1 | tee clang-format-output
+      test -z "$changed_files" || git diff -U0 $fork_origin $changed_files | clang-format-diff -p1 | tee clang-format-output
       if [ -s clang-format-output ]; then
         echo -n "##vso[task.logissue type=error]"
         echo "C/C++ lint failed. Use 'git clang-format' with appropriate options to reformat the changed code."

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,7 +66,7 @@ jobs:
       test -z $changed_files || git diff -U0 $fork_origin $changed_files | clang-format-diff -p1 | tee clang-format-output
       if [ -s clang-format-output ]; then
         echo -n "##vso[task.logissue type=error]"
-        echo "C/C++ lint failed. Use 'util/run-clang-format.sh' or 'git clang-format' to format the code."
+        echo "C/C++ lint failed. Use 'git clang-format' with appropriate options to reformat the changed code."
         exit 1
       fi
     # This check is not idempotent, but checks changes to a base branch.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,7 @@ jobs:
       # https://developercommunity.visualstudio.com/content/problem/689794/pipelines-logging-command-logissue-does-not-report.html
       #echo "##vso[task.issue type=error;sourcepath=/azure-pipelines.yml;linenumber=45;columnnumber=1;code=100;]Found something that could be a problem."
       fork_origin=$(git merge-base --fork-point origin/master)
-      changed_files=$(git diff --name-only $fork_origin | grep -v /vendor/)
+      changed_files=$(git diff --name-only $fork_origin | grep -v /vendor/ | grep -E '\.(cpp|cc|c|h)$')
       test -z $changed_files || git diff -U0 $fork_origin $changed_files | clang-format-diff -p1 | tee clang-format-output
       if [ -s clang-format-output ]; then
         echo -n "##vso[task.logissue type=error]"


### PR DESCRIPTION
As noted in #920, the clang-format check in CI will attempt to reformat
.js files if present in the diff. This commit adds a whitelist, so only
diffs for filenames ending in .cpp, .cc, .c, or .h are passed to
clang-format-diff.

clang-format-diff (the current version on my machine at least) does have
options to filter paths on the input itself, but given we're already
filtering paths using grep it seemed better to consistently do filtering
in one place.