### PR TITLE
[aes] Fix AES DPI model

### DIFF
--- a/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi.core
+++ b/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi.core
@@ -6,6 +6,9 @@ name: "lowrisc:dv:aes_model_dpi:0.5"
 description: "AES model DPI"
 filesets:
   files_dv:
+    depend:
+      - lowrisc:model:aes:0.5
+
     files:
       # Note: VCS needs the c/h-files to be treated as systemVerilogSource
       - aes_model_dpi.c: { file_type: systemVerilogSource}

--- a/hw/ip/aes/model/aes_model.core
+++ b/hw/ip/aes/model/aes_model.core
@@ -1,0 +1,27 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:model:aes:0.5"
+description: "AES Model"
+filesets:
+  files_dv:
+    files:
+      - crypto.c
+      - crypto.h: { is_include_file: true }
+      - aes.c
+      - aes.h: { is_include_file: true }
+    # Note: VCS needs the c/h-files to be treated as systemVerilogSource
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_dv
+
+    tools:
+      verilator:
+        mode: cc
+        verilator_options:
+# linker flags
+          - '-LDFLAGS "-pthread -lcrypto"'


### PR DESCRIPTION
This PR enables fixes the compilation of the AES DPI model by adding a .core file for the C model and by adding the dependency in the DPI model.

This resolves #941.