### PR TITLE
[dv/common] Move read_and_check_all_csrs from cip_lib to csr_utils

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/cip_base_vseq.sv
@@ -351,21 +351,9 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
           // delay to avoid race condition when sending item and checking no item after reset occur at
           // the same time
           #1ps;
-          if (do_read_and_check_all_csrs) read_and_check_all_csrs();
+          if (do_read_and_check_all_csrs) read_and_check_all_csrs(ral);
         end : isolation_fork
       join
-    end
-  endtask
-
-  // task to read all csrs and check against ral expected value
-  // used after reset
-  virtual task read_and_check_all_csrs();
-    uvm_reg       csrs[$];
-    ral.get_registers(csrs);
-    csrs.shuffle();
-
-    foreach (csrs[i]) begin
-      csr_rd_check(.ptr(csrs[i]), .compare_vs_ral(1));
     end
   endtask
 

--- a/hw/dv/sv/csr_utils/README.md
+++ b/hw/dv/sv/csr_utils/README.md
@@ -50,6 +50,12 @@ Example below uses the `csr_spinwait` to wait until the CSR `fifo_status` field
 csr_spinwait(.ptr(ral.status.fifo_full), .exp_data(1'b0));
 ```
 
+##### Read and check all CSRs
+The purpose of the `read_and_check_all_csrs` task is to read all valid CSRs from
+the given `uvm_reg_block` and check against their expected values from RAL. This
+task is primarily implemented to use after reset, to make sure all the CSRs are
+being reset to the default value.
+
 ##### Under_reset
 Due to `csr_utils_pkg` is not connected to any interface, methods inside
 this package are not able to get reset information. Current the `under_reset`

--- a/hw/dv/sv/csr_utils/csr_utils_pkg.sv
+++ b/hw/dv/sv/csr_utils/csr_utils_pkg.sv
@@ -363,7 +363,14 @@ package csr_utils_pkg;
     join
   endtask
 
+  // task to read all csrs and check against ral expected value. Mainly used after reset
+  task automatic read_and_check_all_csrs(input uvm_reg_block ral);
+    uvm_reg ral_csrs[$];
+    ral.get_registers(ral_csrs);
+    ral_csrs.shuffle();
 
+    foreach (ral_csrs[i]) csr_rd_check(.ptr(ral_csrs[i]), .compare_vs_ral(1));
+  endtask
 
   // poll a csr or csr field continuously until it reads the expected value.
   task automatic csr_spinwait(input uvm_object      ptr,


### PR DESCRIPTION
Move read_and_check_all_csrs from cip_lib to csr_utils. Because its
funcationality should belong to the csr_utils
This PR solve issue : https://github.com/lowRISC/opentitan/issues/831 

Signed-off-by: Cindy Chen <chencindy@google.com>