### PR TITLE
Ensure we don't include a build-id in the elf

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -48,7 +48,8 @@ prog_git = find_program('git')
 
 # RISCV linker parameters.
 riscv_linkfile = files(['sw/device/exts/common/link.ld'])
-riscv_link_args = ['-Wl,-T,@0@/@1@'.format(meson.source_root(), riscv_linkfile[0])]
+# Ensure we don't include a build-id in the elf
+riscv_link_args = ['-Wl,-T,@0@/@1@'.format(meson.source_root(), riscv_linkfile[0]), '-Wl,--build-id=none']
 riscv_link_deps = [riscv_linkfile]
 
 # RISCV CRT parameters

--- a/sw/device/opts.mk
+++ b/sw/device/opts.mk
@@ -34,6 +34,7 @@ INCS          += -I$(REPO_TOP) -I$(SW_BUILD_DIR) -I$(LIB_BUILD_DIR)
 LINK_OPTS     += -T $(LINKER_SCRIPT)
 LINK_OPTS     += $(SW_OBJS) -L$(LIB_BUILD_DIR) -l$(LIB_NAME)
 LINK_OPTS     += -Xlinker -Map=${SW_BUILD_DIR}/${IMG_NAME}.map
+LINK_OPTS     += -Wl,--build-id=none
 
 # target (either 'boot_rom' or 'sw')
 ifeq ($(SW_NAME),boot_rom)

--- a/sw/device/opts.mk
+++ b/sw/device/opts.mk
@@ -34,6 +34,7 @@ INCS          += -I$(REPO_TOP) -I$(SW_BUILD_DIR) -I$(LIB_BUILD_DIR)
 LINK_OPTS     += -T $(LINKER_SCRIPT)
 LINK_OPTS     += $(SW_OBJS) -L$(LIB_BUILD_DIR) -l$(LIB_NAME)
 LINK_OPTS     += -Xlinker -Map=${SW_BUILD_DIR}/${IMG_NAME}.map
+# Ensure we don't include a build-id in the elf
 LINK_OPTS     += -Wl,--build-id=none
 
 # target (either 'boot_rom' or 'sw')


### PR DESCRIPTION
ld will sometimes (I guess it depends on how it's built) insert a
.note.gnu.build-id symbol into the ELF. This defaults to being at the
start of the ELF. If this happens we get non-code at the start of the
ELF which causes an illigal instruction to be executed when jumping from
ROM to a sw binary loaded into flash.

We could specify a location for the build-id (in the linker script) but
as it seems unessecay to include (it increases the size by 24 bytes) and
it isn't in the current generated release binaries it makes more sense
to just explicity disable it for all builds.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>