### PR TITLE
[util] build_docs.py add missing space

### DIFF
--- a/util/build_docs.py
+++ b/util/build_docs.py
@@ -256,7 +256,7 @@ def main():
     try:
         if not is_hugo_extended():
             logging.info(
-                "Hugo extended (with SASS support) is required, but only non-extended version found."
+                "Hugo extended (with SASS support) is required, but only non-extended version found. "
                 "Installing local copy and re-trying.")
             install_hugo(hugo_localinstall_dir)
 


### PR DESCRIPTION
This is a follow-up to ecaf87c change to make the debug output more
readable.

Signed-off-by: Silvestrs Timofejevs <silvestrst@lowrisc.org>