### PR TITLE
[docs] Add infrastructure for continuous deployment

### DIFF
--- a/site/docs/README.md
+++ b/site/docs/README.md
@@ -1,0 +1,12 @@
+# Documentation Site
+This directory contains the configuration required to build and deploy the
+[documentation site](https://docs.opentitan.org) as well as the continuous
+deployment configuration that pushes a rebuilt copy of the documentation after
+every commit.
+
+# Documentation Builder
+In order to speed up the deployment there is a GCR image
+(`gcr.io/active-premise-257318/builder`) that contains all of the project's
+python requirements pre-installed.  This cuts the deployment from several
+minutes to around twenty seconds.  To rebuild and deploy the image use the
+`deploy-builder.sh` script.

--- a/site/docs/builder.Dockerfile
+++ b/site/docs/builder.Dockerfile
@@ -1,0 +1,10 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+FROM ubuntu:18.04
+
+RUN apt-get update && apt-get install -y git curl python3 python3-pip && \
+  apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
+COPY python-requirements.txt ./
+RUN pip3 install -r python-requirements.txt

--- a/site/docs/cloudbuild-deploy-docs.yaml
+++ b/site/docs/cloudbuild-deploy-docs.yaml
@@ -1,0 +1,9 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+steps:
+- name: 'gcr.io/active-premise-257318/builder'
+  args: ['./util/build_docs.py']
+- name: 'gcr.io/cloud-builders/gsutil'
+  args: ['-m', 'rsync', '-r', 'build/docs/', 'gs://active-premise-257318']

--- a/site/docs/deploy-builder.sh
+++ b/site/docs/deploy-builder.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd $DIR
+
+docker build -t gcr.io/active-premise-257318/builder -f builder.Dockerfile \
+  ../..
+docker push gcr.io/active-premise-257318/builder


### PR DESCRIPTION
Add a Cloud Build configuration that builds and deploys the
documentation site, as well as a Dockerfile for creating a
pre-configured builder that can build the docs from scratch very
quickly.

Signed-off-by: Garret Kelly <gdk@google.com>