### PR TITLE
[docs] Add curl to installed packages in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ locally by following the steps below.
 in the repository root):
 
 ```command
-$ sudo apt install python3 python3-pip
+$ sudo apt install curl python3 python3-pip
 $ pip3 install --user -r python-requirements.txt
 ```
 


### PR DESCRIPTION
The build_docs.py script will invoke curl to fetch a suitable hugo
binary, ensure that the docs mention it as required.

Signed-off-by: Garret Kelly <gdk@google.com>