### PR TITLE
[CI] Remove signed off IPs from the register module checker

### DIFF
--- a/hw/Makefile
+++ b/hw/Makefile
@@ -19,6 +19,12 @@ IPS ?= uart          \
        padctrl       \
        nmi_gen
 
+# SIGNOFF IP to be removed from auto-reggen
+# These IPs will be skipped in `regs` and `all` targets.
+# But it can be generated explictly, e.g. make uart_regs
+# This is temporary fix before IP versioning strategy is established.
+SIGNOFF = uart gpio rv_timer
+
 TOPS ?= top_earlgrey
 
 # conditional flags
@@ -30,6 +36,8 @@ endif
 
 dir_hjson = data
 
+dynips_reg = $(addsuffix _reg, $(filter-out $(SIGNOFF),$(IPS)))
+
 ips_reg = $(addsuffix _reg, $(IPS))
 
 ips_reg_header = $(addsuffix _reg_header, $(IPS))
@@ -38,7 +46,7 @@ tops_gen = $(addsuffix _gen,$(TOPS))
 
 tops_reg = $(addsuffix _reg,$(TOPS))
 
-all: $(ips_reg) $(tops_gen) $(tops_reg) banner
+all: $(dynips_reg) $(tops_gen) $(tops_reg) banner
 
 banner:
 	@echo "############################################"
@@ -46,7 +54,7 @@ banner:
 	@echo "${REG_OUTPUT_DIR}"
 	@echo "############################################"
 
-regs: $(ips_reg) $(tops_reg) banner
+regs: $(dynips_reg) $(tops_reg) banner
 
 pre_reg:
 	mkdir -p ${REG_OUTPUT_DIR}


### PR DESCRIPTION
This is temporary fix until the IP versioning discussion is completed.
As PR #965 merged, the Azure Pipeline failed on newer PRs.

```log
Build log #L1010
Register headers not up-to-date. Regenerate them with 'make -C hw regs'.
```

PR #965 didn't include `gpio`, `uart`, `rv_timer` from the collaterals
as those IPs were signed off ( #676 #615 #652 ). The azure pipeline
checks every IPs' generated register modules.

It is good as it can catch this case, which prevents silent upgrade of
internal modules in the signed-off IPs. But it is also annoying every
PRs from now failed.

So, temporary the checker ignores signed-off IPs until better IP
versioning rule is suggested.

This is related to #975