### PR TITLE
[util] Better error message for invalid HJSON

### DIFF
--- a/util/testplanner/testplan_utils.py
+++ b/util/testplanner/testplan_utils.py
@@ -198,6 +198,9 @@ def parse_hjson(filename):
     except IOError:
         print('IO Error:', filename)
         raise SystemExit(sys.exc_info()[1])
+    except hjson.scanner.HjsonDecodeError as e:
+        print("Error: Unable to decode HJSON file %s: %s" % (str(filename), str(e)))
+        sys.exit(1)
 
 
 def merge_dicts(list1, list2):


### PR DESCRIPTION
If the testplanner comes across invalid HJSON, it only outputs a
stacktrace without the affected file. Change that to make the error
message more human-friendly.

Discovered as part of #955