### PR TITLE
[GPIO DPI] Reuse FIFO if necessary

### DIFF
--- a/hw/dv/dpi/gpiodpi/gpiodpi.c
+++ b/hw/dv/dpi/gpiodpi/gpiodpi.c
@@ -45,7 +45,7 @@ struct gpiodpi_ctx {
 /**
  * Creates a new UNIX FIFO file at |path_buf|, and opens it with |flags|.
  *
- * @return a file descriptor for the fifo, or -1 if any syscall failed.
+ * @return a file descriptor for the FIFO, or -1 if any syscall failed.
  */
 static int open_fifo(char *path_buf, int flags) {
   int fifo_status = mkfifo(path_buf, 0644);
@@ -72,7 +72,7 @@ static int open_fifo(char *path_buf, int flags) {
 }
 
 /**
- * Print out a useage message for the GPIO interface.
+ * Print out a usage message for the GPIO interface.
  *
  * @arg rfifo the path to the "read" side (w.r.t the host).
  * @arg wfifo the path to the "write" side (w.r.t the host).

--- a/hw/dv/dpi/gpiodpi/gpiodpi.c
+++ b/hw/dv/dpi/gpiodpi/gpiodpi.c
@@ -50,9 +50,13 @@ struct gpiodpi_ctx {
 static int open_fifo(char *path_buf, int flags) {
   int fifo_status = mkfifo(path_buf, 0644);
   if (fifo_status != 0) {
-    fprintf(stderr, "GPIO: Unable to create FIFO at %s: %s\n", path_buf,
-            strerror(errno));
-    return -1;
+    if (errno == EEXIST) {
+      fprintf(stderr, "GPIO: Reusing existing FIFO at %s\n", path_buf);
+    } else {
+      fprintf(stderr, "GPIO: Unable to create FIFO at %s: %s\n", path_buf,
+              strerror(errno));
+      return -1;
+    }
   }
 
   int fd = open(path_buf, flags);


### PR DESCRIPTION
If the simulation aborts in an unclean way it may leave a FIFO file behind. We can actually reuse that FIFO.

This carries forwared the work done by Tobias in #252.