### PR TITLE
[sw] Fix a few places where execution could "fall off"

### DIFF
--- a/sw/device/boot_rom/crt0.S
+++ b/sw/device/boot_rom/crt0.S
@@ -79,10 +79,11 @@ zero_loop:
   ble   t0, t1, zero_loop
 zero_loop_end:
 
-  // Jump into the main program entry point.
-  li    a0, 0x0  // argc = 0
-  li    a1, 0x0  // argv = 0
-  call  main
+  // Jump into the C program entry point.
+  call  _boot_start
+1:
+  wfi
+  j 1b
 
 /**
  * Exception and interrupt handlers.

--- a/sw/device/exts/common/_crt.c
+++ b/sw/device/exts/common/_crt.c
@@ -5,10 +5,10 @@
 #include "sw/device/lib/common.h"
 #include "sw/device/lib/irq.h"
 
-extern int main(void);
+extern int main(int, char **);
 
 void _crt(void) __attribute__((section(".crt")));
-void _crt(void) {
+noreturn void _crt(void) {
   extern char _svectors[];
   extern char _sdata[];
   extern char _idata[];
@@ -20,5 +20,8 @@ void _crt(void) {
   memcpy(_sdata, _idata, _edata - _sdata);
   memset(_bss_start, 0, _bss_end - _bss_start);
 
-  main();
+  main(0, NULL);
+  while (true) {
+    asm volatile("wfi");
+  }
 }

--- a/sw/device/lib/common.h
+++ b/sw/device/lib/common.h
@@ -8,6 +8,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <stdnoreturn.h>
 
 #ifdef SIMULATION
 #define CLK_FIXED_FREQ_HZ (500 * 1000)

--- a/sw/device/tests/flash_ctrl/flash_test.c
+++ b/sw/device/tests/flash_ctrl/flash_test.c
@@ -162,5 +162,4 @@ int main(int argc, char **argv) {
 
   // cleanly terminate execution
   uart_send_str("PASS!\r\n");
-  asm volatile("wfi;");
 }

--- a/sw/device/tests/hmac/sha256_test.c
+++ b/sw/device/tests/hmac/sha256_test.c
@@ -39,10 +39,7 @@ int main(int argc, char **argv) {
 
   if (error) {
     uart_send_str("FAIL!\r\n");
-    while (1) {
-    }
   } else {
     uart_send_str("PASS!\r\n");
-    asm volatile("wfi;");
   }
 }

--- a/sw/device/tests/rv_timer/rv_timer_test.c
+++ b/sw/device/tests/rv_timer/rv_timer_test.c
@@ -29,7 +29,6 @@ int main(int argc, char **argv) {
   }
 
   uart_send_str("PASS!\r\n");
-  asm volatile("wfi;");
 }
 
 // Override weak default function


### PR DESCRIPTION
This is a redo of #613.

>A few functions have been marked as noreturn, namely the boot ROM's try_launch and _crt.c's _crt. These functions, as well as the entry point from crt0.S into boot_rom.c, are now guarded by infinite-wait-for-interrupt loops. Since it is now safe to return form main() in flash binaries, I've removed superfluous inline assembly to call wfi at the end of main().

>In addition, this fixes some undefined behavior where the main() function of flash binaries was being called with the wrong calling convetion (i.e., as a function takiung void, rather than a function taking int, char **).