### PR TITLE
[sw/device] Drop all linker sections not specified

### DIFF
--- a/sw/device/boot_rom/rom_link.ld
+++ b/sw/device/boot_rom/rom_link.ld
@@ -39,6 +39,7 @@ SECTIONS
     .text : {
         . = ALIGN(4);
         _stext = .;
+        *(.text.startup)
         *(.text)
         _etext  =  .;
         __CTOR_LIST__ = .;
@@ -104,4 +105,7 @@ SECTIONS
     {
         [ .stabstr ]
     }
+
+    /* Discard the remaining sections */
+    /DISCARD/ : { *(*) }
 }

--- a/sw/device/exts/common/link.ld
+++ b/sw/device/exts/common/link.ld
@@ -37,6 +37,7 @@ SECTIONS
     .text : {
         . = ALIGN(0x100);
         _stext = .;
+        *(.text.startup)
         *(.text)
         _etext  =  .;
         __CTOR_LIST__ = .;
@@ -105,6 +106,9 @@ SECTIONS
     {
         [ .stabstr ]
     }
+
+    /* Discard the remaining sections */
+    /DISCARD/ : { *(*) }
 }
 
 ENTRY(main)


### PR DESCRIPTION
ld will sometimes (I guess it depends on how it's built) insert a
.note.gnu.build-id symbol into the ELF. This defaults to being at the
start of the ELF. If this happens we get non-code at the start of the
ELF which causes an illigal instruction to be executed when jumping from
ROM to a sw binary loaded into flash.

The PR https://github.com/lowRISC/opentitan/pull/966 attempted to fix
the issue using the build-id command line. This PR instead disacrds all
non specified linker sections. We have to add .text.startup to ensure
the build does not fail.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>