### PR TITLE
[doc] some documentation cleanup

### DIFF
--- a/doc/project/_index.md
+++ b/doc/project/_index.md
@@ -12,6 +12,7 @@ In order to gauge the quality of the different IP that is in our repository, we 
 The current status of different IP is reflected in the [HW Development Stages Dashboard]({{< relref "hw_dashboard" >}}).
 The final state for developed IP is *Signed Off*, indicating that design and verification is complete, and the IP should be bug free.
 To make it to that stage, a [Hardware Signoff Checklist]({{< relref "checklist.md" >}}) is used to confirm completion.
+[Here](https://github.com/lowRISC/opentitan/blob/master/doc/project/ip_checklist.md.tpl) is a template that can be used as a checklist item.
 
 ## Governance
 

--- a/doc/project/hw_stages.md
+++ b/doc/project/hw_stages.md
@@ -43,6 +43,7 @@ Feature requests towards a signed-off design requires review and approval by the
 Once accepted, it results in creating a new version and return a design to the appropriate life stage, based upon the size of the change.
 See the _Versioning_ section of the document for more discussion.
 Signed off fully-functioning (read: not buggy) designs stay in the Signoff stage as an available complete IP, with an associated revision ID.
+[Here](https://github.com/lowRISC/opentitan/blob/master/doc/project/ip_checklist.md.tpl) is a template that can be used as a checklist item.
 
 
 | **Stage** | **Name** | **Definition** |

--- a/doc/ug/_index.md
+++ b/doc/ug/_index.md
@@ -42,9 +42,3 @@ title: "User Guides"
   * Reviews
   * Filing Issues
   * Pending Work Items
-* *Validation Methodology* (TODO)
-  * How to download bit stream
-  * What tests exist today
-  * How to run tests
-  * How does this differ from verification
-  * How to add tests

--- a/doc/ug/design.md
+++ b/doc/ug/design.md
@@ -166,3 +166,25 @@ The process for getting started with a design involves many steps, including get
 These are discussed in the [Getting Started with a Design]({{< relref "getting_started_design.md" >}}) document.
 
 ## FPGA vs Silicon
+
+The OpenTitan product will be (among other things) a final silicon incarnation of the hardware functionality set out in this open source repository.
+This repository only intends to define the details to a level satisfactory to prove the hardware and software functionality in an FPGA (see [user guides]({{< relref "doc/ug" >}}) for details on how to emulate on FPGA).
+After completion of that milestone, the team will work with a vendor or vendors to ensure that a trustworthy fully functional silicon version is manufactured suitable for industry use.
+
+Functionally, the FPGA version and the silicon version will be as identical as possible.
+To that end, the project will be defining compliance collateral that ensures correctness - working the same for FPGA as for silicon.
+There may and will be differences between these two incarnations, such as described below.
+
+* Silicon versions by definition use different technologies for fundamental vendor collateral, including memories, analog designs, pads, and standard cells.
+* Some of the silicon collateral is heavily protected by foundry providers, and not available for open sourcing.
+* For security reasons, some IP designs will undergo hardening of designs to protect them against physical attack.
+  These changes will not change the functionality of the design, but are described in processes unique to an ASIC flow (as opposed to the emulated flow of an FPGA).
+
+Even given these differences, the aim is still to ensure compliance equivalence between the FPGA and silicon versions.
+This might require particular differences in the software implementation of the compliance suite.
+Taking one example: the embedded flash macro.
+This design is highly dependent upon the technology node that implements the silicon version.
+In the FPGA (open source repo), the embedded flash macro is emulated, creating a model that approximates the timing one would find in a typical silicon design.
+It however will not have all the myriad timing knobs and configuration points required to control the final flash block.
+Thus the compliance suite will have initialization sections for flash - for instance - that differ between FPGA and silicon.
+These will be clearly delimited in the compliance protocol, but are not detailed at this time.


### PR DESCRIPTION
This fixes items 15 and 16 of issue #723 

I think with this and the other issues that I've spawned, all of the items of #723 are either fixed
or recreated in standalone issues.

Adds verbiage on FPGA vs silicon in the design area, removes the expectation of
"validation methodology" user guides (since that is already pretty well covered in
all of the FPGA user guides), and links to the IP checklist.