### PR TITLE
Set output directory for FuseSoC to build/hw

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -208,7 +208,7 @@ jobs:
     displayName: 'Display environment'
   - bash: |
       export PATH=$VERILATOR_PATH/bin:$PATH
-      fusesoc --cores-root=. run --target=sim --setup --build lowrisc:systems:top_earlgrey_verilator
+      fusesoc --cores-root=. run --build-root=build/hw --target=sim --setup --build lowrisc:systems:top_earlgrey_verilator
     displayName: 'Build simulation with Verilator'
   - bash: |
       DIST_DIR="$(Build.ArtifactStagingDirectory)/dist/hw/top_earlgrey"
@@ -252,7 +252,7 @@ jobs:
       BOOTROM_VMEM=$(Build.ArtifactStagingDirectory)/dist-other/sw/device/fpga/boot_rom/rom.vmem
       test -f ${BOOTROM_VMEM}
       source /opt/xilinx/Vivado/2018.3/settings64.sh
-      fusesoc --cores-root . run --target=synth --setup --build \
+      fusesoc --cores-root . run --build-root=build/hw --target=synth --setup --build \
         lowrisc:systems:top_earlgrey_nexysvideo \
         --ROM_INIT_FILE=${BOOTROM_VMEM}
     displayName: 'Build bitstream with Vivado'

--- a/doc/rm/ref_manual_fpga.md
+++ b/doc/rm/ref_manual_fpga.md
@@ -39,7 +39,7 @@ See example below:
 ```console
 $ cd $REPO_TOP
 $ ./util/fpga/splice_nexysvideo.sh
-$ fusesoc --cores-root . pgm lowrisc:systems:top_earlgrey_nexysvideo
+$ fusesoc --cores-root . run --run --build-root=build/hw lowrisc:systems:top_earlgrey_nexysvideo
 ```
 
 The script assumes that there is an existing bitfile `build/lowrisc_systems_top_earlgrey_nexysvideo_0.1/synth-vivado/lowrisc_systems_top_earlgrey_nexysvideo_0.1.bit` (this is created after following the steps in [getting_started_fpga]({{< relref "doc/ug/getting_started_fpga" >}})).

--- a/doc/ug/getting_started_fpga.md
+++ b/doc/ug/getting_started_fpga.md
@@ -41,7 +41,7 @@ In the following example we synthesize the Earl Grey design for the Nexys Video 
 $ . /tools/xilinx/Vivado/2018.3/settings64.sh
 $ cd $REPO_TOP
 $ make -C sw/device SW_DIR=boot_rom clean all
-$ fusesoc --cores-root . run --target=synth lowrisc:systems:top_earlgrey_nexysvideo
+$ fusesoc --cores-root . run --build-root=build/hw --target=synth lowrisc:systems:top_earlgrey_nexysvideo
 ```
 
 The resulting bitstream is located at `build/lowrisc_systems_top_earlgrey_nexysvideo_0.1/synth-vivado/lowrisc_systems_top_earlgrey_nexysvideo_0.1.bit`.
@@ -65,10 +65,11 @@ Use the following command to program the FPGA with fusesoc.
 ```console
 $ . /tools/xilinx/Vivado/2018.3/settings64.sh
 $ cd $REPO_TOP
-$ fusesoc --cores-root . pgm lowrisc:systems:top_earlgrey_nexysvideo:0.1
+$ fusesoc --cores-root . run --run --build-root=build/hw lowrisc:systems:top_earlgrey_nexysvideo:0.1
 ```
 
-Note: `fusesoc pgm` is broken for edalize versions up to (and including) v0.1.3.
+Note: Device programming with `fusesoc run --run` is broken for edalize
+versions up to (and including) v0.1.3.
 You can check the version you're using with `pip3 show edalize`.
 If you have having trouble with programming using the command line, try the GUI.
 
@@ -137,7 +138,7 @@ The `--no-export` option of fusesoc disables copying the source files into the s
 
 ```console
 $ # only create Vivado project file
-$ fusesoc --cores-root . build --no-export --setup lowrisc:systems:top_earlgrey_nexysvideo
+$ fusesoc --cores-root . run --build-root=build/hw --target=synth --no-export --setup lowrisc:systems:top_earlgrey_nexysvideo
 ```
 
 ## Connect with OpenOCD and debug

--- a/doc/ug/getting_started_verilator.md
+++ b/doc/ug/getting_started_verilator.md
@@ -15,7 +15,7 @@ First the simulation needs to built itself.
 
 ```console
 $ cd $REPO_TOP
-$ fusesoc --cores-root . run --target=sim --setup --build lowrisc:systems:top_earlgrey_verilator
+$ fusesoc --cores-root . run --build-root=build/hw --target=sim --setup --build lowrisc:systems:top_earlgrey_verilator
 ```
 
 Then we need to build software to run on the simulated system.

--- a/hw/dv/tools/fusesoc.mk
+++ b/hw/dv/tools/fusesoc.mk
@@ -12,7 +12,7 @@
 # fusesoc tool and options
 SV_FLIST_GEN_TOOL  ?= fusesoc
 SV_FLIST_GEN_OPTS  += --cores-root ${PROJ_ROOT} --cores-root ${RAL_MODEL_DIR} \
-                      run --target=sim --setup --no-export ${FUSESOC_CORE}
+                      run --build-root=build/hw --target=sim --setup --no-export ${FUSESOC_CORE}
 FUSESOC_CORE_       = $(shell echo "${FUSESOC_CORE}" | tr ':' '_')
-SV_FLIST_GEN_DIR    = ${BUILD_DIR}/build/${FUSESOC_CORE_}/sim-vcs
-SV_FLIST           := ${SV_FLIST_GEN_DIR}/${FUSESOC_CORE_}.scr
+SV_FLIST_GEN_DIR    = ${BUILD_DIR}/build/hw/sim-vcs
+SV_FLIST           := ${SV_FLIST_GEN_DIR}/{FUSESOC_CORE_}.scr

--- a/hw/vendor/lowrisc_ibex/azure-pipelines.yml
+++ b/hw/vendor/lowrisc_ibex/azure-pipelines.yml
@@ -86,7 +86,7 @@ jobs:
     displayName: Display environment
 
   - bash: |
-      fusesoc --cores-root . run --target=lint lowrisc:ibex:ibex_core_tracing
+      fusesoc --cores-root . run --build-root=build/hw --target=lint lowrisc:ibex:ibex_core_tracing
       if [ $? != 0 ]; then
         echo -n "##vso[task.logissue type=error]"
         echo "Verilog lint failed. Run 'fusesoc --cores-root . run --target=lint lowrisc:ibex:ibex_core_tracing' to check and fix all errors."
@@ -101,7 +101,7 @@ jobs:
 
   - bash: |
       # Build simulation model of Ibex
-      fusesoc --cores-root=. run --target=sim --setup --build lowrisc:ibex:ibex_riscv_compliance --RV32M=1 --RV32E=0
+      fusesoc --cores-root=. run --build-root=build/hw --target=sim --setup --build lowrisc:ibex:ibex_riscv_compliance --RV32M=1 --RV32E=0
       if [ $? != 0 ]; then
         echo -n "##vso[task.logissue type=error]"
         echo "Unable to build Verilator model of Ibex for compliance testing."

--- a/hw/vendor/lowrisc_ibex/dv/riscv_compliance/README.md
+++ b/hw/vendor/lowrisc_ibex/dv/riscv_compliance/README.md
@@ -37,7 +37,7 @@ How to run RISC-V Compliance on Ibex
 
    ```sh
    cd $IBEX_REPO_BASE
-   fusesoc --cores-root=. run --target=sim --setup --build lowrisc:ibex:ibex_riscv_compliance --RV32M=1 --RV32E=0
+   fusesoc --cores-root=. run --build-root=build/hw --target=sim --setup --build lowrisc:ibex:ibex_riscv_compliance --RV32M=1 --RV32E=0
    ```
 
    You can use the two compile-time options `--RV32M` and `--RV32E` to

--- a/hw/vendor/lowrisc_ibex/examples/fpga/artya7-100/README.md
+++ b/hw/vendor/lowrisc_ibex/examples/fpga/artya7-100/README.md
@@ -31,7 +31,7 @@ This should produce a `led.vmem` file which is used in the synthesises to update
 Run the following command at the top level to build the hardware.
 
 ```
-fusesoc --cores-root=. build lowrisc:ibex:top_artya7_100
+fusesoc --cores-root=. run --setup --build --build-root=build/hw --target=synth lowrisc:ibex:top_artya7_100
 ```
 
 This will create a directory `build` which contains the output files, including
@@ -42,7 +42,7 @@ the bitstream.
 After the board is connected to the computer it can be programmed with:
 
 ```
-fusesoc --cores-root=. pgm lowrisc:ibex:top_artya7_100
+fusesoc --cores-root=. run --run --target=synth lowrisc:ibex:top_artya7_100
 ```
 
 LED1/LED3 and LED0/LED2 should alternately be on after the FPGA programming is finished.

--- a/test/fpga_manual_test.sh
+++ b/test/fpga_manual_test.sh
@@ -60,14 +60,14 @@ if [ ${BUILD_FPGA} -eq 1 ] ; then
   ninja -C ${BUILD_TARGET} sw/device/boot_rom/boot_rom.vmem
 
   echo "Building FPGA."
-  fusesoc --cores-root . build lowrisc:systems:top_earlgrey_nexysvideo \
+  fusesoc --cores-root . run --target=synth --build-root=build/hw lowrisc:systems:top_earlgrey_nexysvideo \
   --ROM_INIT_FILE=${BUILD_TARGET}/sw/device/boot_rom/boot_rom.vmem
 fi
 
 if [ ${PROGRAM_FPGA} -eq 1 ] ; then
   echo "Splice latest boot ROM and program FPGA."
   util/fpga/splice_nexysvideo.sh
-  fusesoc --cores-root . pgm lowrisc:systems:top_earlgrey_nexysvideo
+  fusesoc --cores-root . run --run --target=synth --build-root=hw lowrisc:systems:top_earlgrey_nexysvideo
 fi
 
 echo "Build spiflash tool."


### PR DESCRIPTION
This adds the --build-root argument to all the FuseSoC invocations
to allow for the structure described in
https://github.com/lowRISC/opentitan/issues/995

Signed-off-by: Olof Kindgren <olof.kindgren@gmail.com>

Note: This has not been tested as I wasn't sure which steps to run. It also doesn't touch the formal builds