### PR TITLE
[dashboard] Add multiple revisions

### DIFF
--- a/hw/ip/uart/data/uart.prj.hjson
+++ b/hw/ip/uart/data/uart.prj.hjson
@@ -4,9 +4,14 @@
 
 {
     name:               "uart",
-    version:            "1.0",
-    life_stage:         "L2",
-    design_stage:       "D3",
-    verification_stage: "V3",
-    notes:              "signoff commit id: 92e4298f8c2de268b2420a2c16939cd0784f1bf8"
+    revisions: [
+      {
+        version:            "1.0",
+        life_stage:         "L2",
+        design_stage:       "D3",
+        verification_stage: "V3",
+        commit_id:          "92e4298f8c2de268b2420a2c16939cd0784f1bf8",
+        notes:              ""
+      }
+    ]
 }

--- a/site/docs/assets/scss/_markdown.scss
+++ b/site/docs/assets/scss/_markdown.scss
@@ -136,7 +136,10 @@ table.regdef {
 
 // Dashboard design
 table.hw-project-dashboard {
-    td.hw-stage {
-        text-align: center;
+    td {
+        vertical-align: middle;
+        &.hw-stage {
+            text-align: center;
+        }
     }
 }

--- a/site/docs/layouts/shortcodes/dashboard.html
+++ b/site/docs/layouts/shortcodes/dashboard.html
@@ -6,6 +6,7 @@
 			<th>Life Stage</th>
 			<th>Design Stage</th>
 			<th>Verification Stage</th>
+			<th>Commit ID</th>
 			<th>Notes</th>
 		</tr>
 	</thead>


### PR DESCRIPTION
As IP grows and updated, it is needed to have multiple versions of IPs
to be managed in the dashboard. For instance, as UART, GPIO, RV_TIMER
were signed off, their versions shall be increased when the logic design
is changed.

This change introduces `revisions` field in the project Hjson file. If
this field is defined, the dashboard prints out new format.

![image](https://user-images.githubusercontent.com/1192814/69073259-ea373680-09e1-11ea-8f70-821ac8c43ff0.png)
