### PR TITLE
[reggen] Update register modules of the signed off IPs

### DIFF
--- a/hw/Makefile
+++ b/hw/Makefile
@@ -19,12 +19,6 @@ IPS ?= uart          \
        padctrl       \
        nmi_gen
 
-# SIGNOFF IP to be removed from auto-reggen
-# These IPs will be skipped in `regs` and `all` targets.
-# But it can be generated explictly, e.g. make uart_regs
-# This is temporary fix before IP versioning strategy is established.
-SIGNOFF = uart gpio rv_timer
-
 TOPS ?= top_earlgrey
 
 # conditional flags
@@ -36,7 +30,7 @@ endif
 
 dir_hjson = data
 
-dynips_reg = $(addsuffix _reg, $(filter-out $(SIGNOFF),$(IPS)))
+dynips_reg = $(addsuffix _reg, $(IPS))
 
 ips_reg = $(addsuffix _reg, $(IPS))
 

--- a/hw/ip/gpio/data/gpio.prj.hjson
+++ b/hw/ip/gpio/data/gpio.prj.hjson
@@ -4,9 +4,22 @@
 
 {
     name:               "gpio",
-    version:            "1.0",
-    life_stage:         "L2",
-    design_stage:       "D3",
-    verification_stage: "V3",
-    notes:              "Signoff commit id: a4638684103da48c793301243759e9d1eb2cb9dc",
+    revisions: [
+      {
+        version:            "1.0",
+        life_stage:         "L2",
+        design_stage:       "D3",
+        verification_stage: "V3",
+        commit_id:          "a4638684103da48c793301243759e9d1eb2cb9dc",
+        notes:              "",
+      }
+      {
+        version:            "1.1",
+        life_stage:         "L1",
+        design_stage:       "D2",
+        verification_stage: "V2",
+        commit_id:          "f3039d7006ca8ebd45ae0b52b22864983876175d",
+        notes:              "Rolled back to D2 as the register module is updated",
+      }
+    ]
 }

--- a/hw/ip/gpio/rtl/gpio_reg_pkg.sv
+++ b/hw/ip/gpio/rtl/gpio_reg_pkg.sv
@@ -6,138 +6,185 @@
 
 package gpio_reg_pkg;
 
-///////////////////////////////////////
-// Register to internal design logic //
-///////////////////////////////////////
+  ////////////////////////////
+  // Typedefs for registers //
+  ////////////////////////////
+  typedef struct packed {
+    logic [31:0] q;
+  } gpio_reg2hw_intr_state_reg_t;
 
-typedef struct packed {
-  struct packed {
-    logic [31:0] q; // [458:427]
-  } intr_state;
-  struct packed {
-    logic [31:0] q; // [426:395]
-  } intr_enable;
-  struct packed {
-    logic [31:0] q; // [394:363]
-    logic qe; // [362]
-  } intr_test;
-  struct packed {
-    logic [31:0] q; // [361:330]
-    logic qe; // [329]
-  } direct_out;
-  struct packed {
-    struct packed {
-      logic [15:0] q; // [328:313]
-      logic qe; // [312]
-    } data;
-    struct packed {
-      logic [15:0] q; // [311:296]
-      logic qe; // [295]
-    } mask;
-  } masked_out_lower;
-  struct packed {
-    struct packed {
-      logic [15:0] q; // [294:279]
-      logic qe; // [278]
-    } data;
-    struct packed {
-      logic [15:0] q; // [277:262]
-      logic qe; // [261]
-    } mask;
-  } masked_out_upper;
-  struct packed {
-    logic [31:0] q; // [260:229]
-    logic qe; // [228]
-  } direct_oe;
-  struct packed {
-    struct packed {
-      logic [15:0] q; // [227:212]
-      logic qe; // [211]
-    } data;
-    struct packed {
-      logic [15:0] q; // [210:195]
-      logic qe; // [194]
-    } mask;
-  } masked_oe_lower;
-  struct packed {
-    struct packed {
-      logic [15:0] q; // [193:178]
-      logic qe; // [177]
-    } data;
-    struct packed {
-      logic [15:0] q; // [176:161]
-      logic qe; // [160]
-    } mask;
-  } masked_oe_upper;
-  struct packed {
-    logic [31:0] q; // [159:128]
-  } intr_ctrl_en_rising;
-  struct packed {
-    logic [31:0] q; // [127:96]
-  } intr_ctrl_en_falling;
-  struct packed {
-    logic [31:0] q; // [95:64]
-  } intr_ctrl_en_lvlhigh;
-  struct packed {
-    logic [31:0] q; // [63:32]
-  } intr_ctrl_en_lvllow;
-  struct packed {
-    logic [31:0] q; // [31:0]
-  } ctrl_en_input_filter;
-} gpio_reg2hw_t;
+  typedef struct packed {
+    logic [31:0] q;
+  } gpio_reg2hw_intr_enable_reg_t;
 
-///////////////////////////////////////
-// Internal design logic to register //
-///////////////////////////////////////
+  typedef struct packed {
+    logic [31:0] q;
+    logic        qe;
+  } gpio_reg2hw_intr_test_reg_t;
 
-typedef struct packed {
-  struct packed {
-    logic [31:0] d; // [257:226]
-    logic de; // [225]
-  } intr_state;
-  struct packed {
-    logic [31:0] d; // [224:193]
-    logic de; // [192]
-  } data_in;
-  struct packed {
-    logic [31:0] d; // [191:160]
-  } direct_out;
-  struct packed {
+  typedef struct packed {
+    logic [31:0] q;
+    logic        qe;
+  } gpio_reg2hw_direct_out_reg_t;
+
+  typedef struct packed {
     struct packed {
-      logic [15:0] d; // [159:144]
+      logic [15:0] q;
+      logic        qe;
     } data;
     struct packed {
-      logic [15:0] d; // [143:128]
+      logic [15:0] q;
+      logic        qe;
     } mask;
-  } masked_out_lower;
-  struct packed {
+  } gpio_reg2hw_masked_out_lower_reg_t;
+
+  typedef struct packed {
     struct packed {
-      logic [15:0] d; // [127:112]
+      logic [15:0] q;
+      logic        qe;
     } data;
     struct packed {
-      logic [15:0] d; // [111:96]
+      logic [15:0] q;
+      logic        qe;
     } mask;
-  } masked_out_upper;
-  struct packed {
-    logic [31:0] d; // [95:64]
-  } direct_oe;
-  struct packed {
+  } gpio_reg2hw_masked_out_upper_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+    logic        qe;
+  } gpio_reg2hw_direct_oe_reg_t;
+
+  typedef struct packed {
     struct packed {
-      logic [15:0] d; // [63:48]
+      logic [15:0] q;
+      logic        qe;
     } data;
     struct packed {
-      logic [15:0] d; // [47:32]
+      logic [15:0] q;
+      logic        qe;
     } mask;
-  } masked_oe_lower;
-  struct packed {
+  } gpio_reg2hw_masked_oe_lower_reg_t;
+
+  typedef struct packed {
     struct packed {
-      logic [15:0] d; // [31:16]
+      logic [15:0] q;
+      logic        qe;
     } data;
     struct packed {
-      logic [15:0] d; // [15:0]
+      logic [15:0] q;
+      logic        qe;
     } mask;
-  } masked_oe_upper;
-} gpio_hw2reg_t;
+  } gpio_reg2hw_masked_oe_upper_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } gpio_reg2hw_intr_ctrl_en_rising_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } gpio_reg2hw_intr_ctrl_en_falling_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } gpio_reg2hw_intr_ctrl_en_lvlhigh_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } gpio_reg2hw_intr_ctrl_en_lvllow_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } gpio_reg2hw_ctrl_en_input_filter_reg_t;
+
+
+  typedef struct packed {
+    logic [31:0] d;
+    logic        de;
+  } gpio_hw2reg_intr_state_reg_t;
+
+  typedef struct packed {
+    logic [31:0] d;
+    logic        de;
+  } gpio_hw2reg_data_in_reg_t;
+
+  typedef struct packed {
+    logic [31:0] d;
+  } gpio_hw2reg_direct_out_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [15:0] d;
+    } data;
+    struct packed {
+      logic [15:0] d;
+    } mask;
+  } gpio_hw2reg_masked_out_lower_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [15:0] d;
+    } data;
+    struct packed {
+      logic [15:0] d;
+    } mask;
+  } gpio_hw2reg_masked_out_upper_reg_t;
+
+  typedef struct packed {
+    logic [31:0] d;
+  } gpio_hw2reg_direct_oe_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [15:0] d;
+    } data;
+    struct packed {
+      logic [15:0] d;
+    } mask;
+  } gpio_hw2reg_masked_oe_lower_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [15:0] d;
+    } data;
+    struct packed {
+      logic [15:0] d;
+    } mask;
+  } gpio_hw2reg_masked_oe_upper_reg_t;
+
+
+  ///////////////////////////////////////
+  // Register to internal design logic //
+  ///////////////////////////////////////
+  typedef struct packed {
+    gpio_reg2hw_intr_state_reg_t intr_state; // [458:427]
+    gpio_reg2hw_intr_enable_reg_t intr_enable; // [426:395]
+    gpio_reg2hw_intr_test_reg_t intr_test; // [394:362]
+    gpio_reg2hw_direct_out_reg_t direct_out; // [361:329]
+    gpio_reg2hw_masked_out_lower_reg_t masked_out_lower; // [328:295]
+    gpio_reg2hw_masked_out_upper_reg_t masked_out_upper; // [294:261]
+    gpio_reg2hw_direct_oe_reg_t direct_oe; // [260:228]
+    gpio_reg2hw_masked_oe_lower_reg_t masked_oe_lower; // [227:194]
+    gpio_reg2hw_masked_oe_upper_reg_t masked_oe_upper; // [193:160]
+    gpio_reg2hw_intr_ctrl_en_rising_reg_t intr_ctrl_en_rising; // [159:128]
+    gpio_reg2hw_intr_ctrl_en_falling_reg_t intr_ctrl_en_falling; // [127:96]
+    gpio_reg2hw_intr_ctrl_en_lvlhigh_reg_t intr_ctrl_en_lvlhigh; // [95:64]
+    gpio_reg2hw_intr_ctrl_en_lvllow_reg_t intr_ctrl_en_lvllow; // [63:32]
+    gpio_reg2hw_ctrl_en_input_filter_reg_t ctrl_en_input_filter; // [31:0]
+  } gpio_reg2hw_t;
+
+  ///////////////////////////////////////
+  // Internal design logic to register //
+  ///////////////////////////////////////
+  typedef struct packed {
+    gpio_hw2reg_intr_state_reg_t intr_state; // [257:226]
+    gpio_hw2reg_data_in_reg_t data_in; // [225:226]
+    gpio_hw2reg_direct_out_reg_t direct_out; // [225:193]
+    gpio_hw2reg_masked_out_lower_reg_t masked_out_lower; // [192:159]
+    gpio_hw2reg_masked_out_upper_reg_t masked_out_upper; // [158:125]
+    gpio_hw2reg_direct_oe_reg_t direct_oe; // [124:92]
+    gpio_hw2reg_masked_oe_lower_reg_t masked_oe_lower; // [91:58]
+    gpio_hw2reg_masked_oe_upper_reg_t masked_oe_upper; // [57:24]
+  } gpio_hw2reg_t;
 
   // Register Address
   parameter GPIO_INTR_STATE_OFFSET = 6'h 0;

--- a/hw/ip/rv_timer/data/rv_timer.prj.hjson
+++ b/hw/ip/rv_timer/data/rv_timer.prj.hjson
@@ -4,9 +4,22 @@
 
 {
     name:               "rv_timer",
-    version:            "0.5",
-    life_stage:         "L2",
-    design_stage:       "D3",
-    verification_stage: "V3",
-    notes:              "Signoff commit id: a4638684103da48c793301243759e9d1eb2cb9dc"
+    revisions: [
+      {
+        version:            "0.5",
+        life_stage:         "L2",
+        design_stage:       "D3",
+        verification_stage: "V3",
+        commit_id:          "a4638684103da48c793301243759e9d1eb2cb9dc",
+        notes:              ""
+      }
+      {
+        version:            "0.6",
+        life_stage:         "L1",
+        design_stage:       "D2",
+        verification_stage: "V2",
+        commit_id:          "f3039d7006ca8ebd45ae0b52b22864983876175d",
+        notes:              "Rolled back to D2 as the register module is updated",
+      }
+    ]
 }

--- a/hw/ip/rv_timer/rtl/rv_timer_reg_pkg.sv
+++ b/hw/ip/rv_timer/rtl/rv_timer_reg_pkg.sv
@@ -10,75 +10,91 @@ package rv_timer_reg_pkg;
   localparam int N_HARTS = 1;
   localparam int N_TIMERS = 1;
 
-////////////////////////////
-// Typedefs for multiregs //
-////////////////////////////
+  ////////////////////////////
+  // Typedefs for registers //
+  ////////////////////////////
+  typedef struct packed {
+    logic        q;
+  } rv_timer_reg2hw_ctrl_mreg_t;
 
-typedef struct packed {
-  logic [0:0] q;
-} rv_timer_reg2hw_ctrl_mreg_t;
-typedef struct packed {
-  logic [0:0] q;
-} rv_timer_reg2hw_intr_enable0_mreg_t;
-typedef struct packed {
-  logic [0:0] q;
-} rv_timer_reg2hw_intr_state0_mreg_t;
-typedef struct packed {
-  logic [0:0] q;
-  logic qe;
-} rv_timer_reg2hw_intr_test0_mreg_t;
-
-typedef struct packed {
-  logic [0:0] d;
-  logic de;
-} rv_timer_hw2reg_intr_state0_mreg_t;
-
-///////////////////////////////////////
-// Register to internal design logic //
-///////////////////////////////////////
-
-typedef struct packed {
-  rv_timer_reg2hw_ctrl_mreg_t [0:0] ctrl; // [152:152]
-  struct packed {
+  typedef struct packed {
     struct packed {
-      logic [11:0] q; // [151:140]
+      logic [11:0] q;
     } prescale;
     struct packed {
-      logic [7:0] q; // [139:132]
+      logic [7:0]  q;
     } step;
-  } cfg0;
-  struct packed {
-    logic [31:0] q; // [131:100]
-  } timer_v_lower0;
-  struct packed {
-    logic [31:0] q; // [99:68]
-  } timer_v_upper0;
-  struct packed {
-    logic [31:0] q; // [67:36]
-  } compare_lower0_0;
-  struct packed {
-    logic [31:0] q; // [35:4]
-  } compare_upper0_0;
-  rv_timer_reg2hw_intr_enable0_mreg_t [0:0] intr_enable0; // [3:3]
-  rv_timer_reg2hw_intr_state0_mreg_t [0:0] intr_state0; // [2:2]
-  rv_timer_reg2hw_intr_test0_mreg_t [0:0] intr_test0; // [1:0]
-} rv_timer_reg2hw_t;
+  } rv_timer_reg2hw_cfg0_reg_t;
 
-///////////////////////////////////////
-// Internal design logic to register //
-///////////////////////////////////////
+  typedef struct packed {
+    logic [31:0] q;
+  } rv_timer_reg2hw_timer_v_lower0_reg_t;
 
-typedef struct packed {
-  struct packed {
-    logic [31:0] d; // [67:36]
-    logic de; // [35]
-  } timer_v_lower0;
-  struct packed {
-    logic [31:0] d; // [34:3]
-    logic de; // [2]
-  } timer_v_upper0;
-  rv_timer_hw2reg_intr_state0_mreg_t [0:0] intr_state0; // [1:0]
-} rv_timer_hw2reg_t;
+  typedef struct packed {
+    logic [31:0] q;
+  } rv_timer_reg2hw_timer_v_upper0_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } rv_timer_reg2hw_compare_lower0_0_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } rv_timer_reg2hw_compare_upper0_0_reg_t;
+
+  typedef struct packed {
+    logic        q;
+  } rv_timer_reg2hw_intr_enable0_mreg_t;
+
+  typedef struct packed {
+    logic        q;
+  } rv_timer_reg2hw_intr_state0_mreg_t;
+
+  typedef struct packed {
+    logic        q;
+    logic        qe;
+  } rv_timer_reg2hw_intr_test0_mreg_t;
+
+
+  typedef struct packed {
+    logic [31:0] d;
+    logic        de;
+  } rv_timer_hw2reg_timer_v_lower0_reg_t;
+
+  typedef struct packed {
+    logic [31:0] d;
+    logic        de;
+  } rv_timer_hw2reg_timer_v_upper0_reg_t;
+
+  typedef struct packed {
+    logic        d;
+    logic        de;
+  } rv_timer_hw2reg_intr_state0_mreg_t;
+
+
+  ///////////////////////////////////////
+  // Register to internal design logic //
+  ///////////////////////////////////////
+  typedef struct packed {
+    rv_timer_reg2hw_ctrl_mreg_t [0:0] ctrl; // [152:152]
+    rv_timer_reg2hw_cfg0_reg_t cfg0; // [151:132]
+    rv_timer_reg2hw_timer_v_lower0_reg_t timer_v_lower0; // [131:100]
+    rv_timer_reg2hw_timer_v_upper0_reg_t timer_v_upper0; // [99:68]
+    rv_timer_reg2hw_compare_lower0_0_reg_t compare_lower0_0; // [67:36]
+    rv_timer_reg2hw_compare_upper0_0_reg_t compare_upper0_0; // [35:4]
+    rv_timer_reg2hw_intr_enable0_mreg_t [0:0] intr_enable0; // [3:3]
+    rv_timer_reg2hw_intr_state0_mreg_t [0:0] intr_state0; // [2:2]
+    rv_timer_reg2hw_intr_test0_mreg_t [0:0] intr_test0; // [1:0]
+  } rv_timer_reg2hw_t;
+
+  ///////////////////////////////////////
+  // Internal design logic to register //
+  ///////////////////////////////////////
+  typedef struct packed {
+    rv_timer_hw2reg_timer_v_lower0_reg_t timer_v_lower0; // [67:36]
+    rv_timer_hw2reg_timer_v_upper0_reg_t timer_v_upper0; // [35:4]
+    rv_timer_hw2reg_intr_state0_mreg_t [0:0] intr_state0; // [3:2]
+  } rv_timer_hw2reg_t;
 
   // Register Address
   parameter RV_TIMER_CTRL_OFFSET = 9'h 0;

--- a/hw/ip/uart/data/uart.prj.hjson
+++ b/hw/ip/uart/data/uart.prj.hjson
@@ -13,5 +13,13 @@
         commit_id:          "92e4298f8c2de268b2420a2c16939cd0784f1bf8",
         notes:              ""
       }
+      {
+        version:            "1.1",
+        life_stage:         "L1",
+        design_stage:       "D2",
+        verification_stage: "V2",
+        commit_id:          "f3039d7006ca8ebd45ae0b52b22864983876175d",
+        notes:              "Rolled back to D2 as the register module is updated",
+      }
     ]
 }

--- a/hw/ip/uart/rtl/uart_reg_pkg.sv
+++ b/hw/ip/uart/rtl/uart_reg_pkg.sv
@@ -6,280 +6,315 @@
 
 package uart_reg_pkg;
 
-///////////////////////////////////////
-// Register to internal design logic //
-///////////////////////////////////////
+  ////////////////////////////
+  // Typedefs for registers //
+  ////////////////////////////
+  typedef struct packed {
+    struct packed {
+      logic        q;
+    } tx_watermark;
+    struct packed {
+      logic        q;
+    } rx_watermark;
+    struct packed {
+      logic        q;
+    } tx_overflow;
+    struct packed {
+      logic        q;
+    } rx_overflow;
+    struct packed {
+      logic        q;
+    } rx_frame_err;
+    struct packed {
+      logic        q;
+    } rx_break_err;
+    struct packed {
+      logic        q;
+    } rx_timeout;
+    struct packed {
+      logic        q;
+    } rx_parity_err;
+  } uart_reg2hw_intr_state_reg_t;
 
-typedef struct packed {
-  struct packed {
+  typedef struct packed {
     struct packed {
-      logic q; // [124]
+      logic        q;
     } tx_watermark;
     struct packed {
-      logic q; // [123]
+      logic        q;
     } rx_watermark;
     struct packed {
-      logic q; // [122]
+      logic        q;
     } tx_overflow;
     struct packed {
-      logic q; // [121]
+      logic        q;
     } rx_overflow;
     struct packed {
-      logic q; // [120]
+      logic        q;
     } rx_frame_err;
     struct packed {
-      logic q; // [119]
+      logic        q;
     } rx_break_err;
     struct packed {
-      logic q; // [118]
+      logic        q;
     } rx_timeout;
     struct packed {
-      logic q; // [117]
+      logic        q;
     } rx_parity_err;
-  } intr_state;
-  struct packed {
+  } uart_reg2hw_intr_enable_reg_t;
+
+  typedef struct packed {
     struct packed {
-      logic q; // [116]
+      logic        q;
+      logic        qe;
     } tx_watermark;
     struct packed {
-      logic q; // [115]
+      logic        q;
+      logic        qe;
     } rx_watermark;
     struct packed {
-      logic q; // [114]
+      logic        q;
+      logic        qe;
     } tx_overflow;
     struct packed {
-      logic q; // [113]
+      logic        q;
+      logic        qe;
     } rx_overflow;
     struct packed {
-      logic q; // [112]
+      logic        q;
+      logic        qe;
     } rx_frame_err;
     struct packed {
-      logic q; // [111]
+      logic        q;
+      logic        qe;
     } rx_break_err;
     struct packed {
-      logic q; // [110]
+      logic        q;
+      logic        qe;
     } rx_timeout;
     struct packed {
-      logic q; // [109]
+      logic        q;
+      logic        qe;
     } rx_parity_err;
-  } intr_enable;
-  struct packed {
+  } uart_reg2hw_intr_test_reg_t;
+
+  typedef struct packed {
     struct packed {
-      logic q; // [108]
-      logic qe; // [107]
-    } tx_watermark;
-    struct packed {
-      logic q; // [106]
-      logic qe; // [105]
-    } rx_watermark;
-    struct packed {
-      logic q; // [104]
-      logic qe; // [103]
-    } tx_overflow;
-    struct packed {
-      logic q; // [102]
-      logic qe; // [101]
-    } rx_overflow;
-    struct packed {
-      logic q; // [100]
-      logic qe; // [99]
-    } rx_frame_err;
-    struct packed {
-      logic q; // [98]
-      logic qe; // [97]
-    } rx_break_err;
-    struct packed {
-      logic q; // [96]
-      logic qe; // [95]
-    } rx_timeout;
-    struct packed {
-      logic q; // [94]
-      logic qe; // [93]
-    } rx_parity_err;
-  } intr_test;
-  struct packed {
-    struct packed {
-      logic q; // [92]
+      logic        q;
     } tx;
     struct packed {
-      logic q; // [91]
+      logic        q;
     } rx;
     struct packed {
-      logic q; // [90]
+      logic        q;
     } nf;
     struct packed {
-      logic q; // [89]
+      logic        q;
     } slpbk;
     struct packed {
-      logic q; // [88]
+      logic        q;
     } llpbk;
     struct packed {
-      logic q; // [87]
+      logic        q;
     } parity_en;
     struct packed {
-      logic q; // [86]
+      logic        q;
     } parity_odd;
     struct packed {
-      logic [1:0] q; // [85:84]
+      logic [1:0]  q;
     } rxblvl;
     struct packed {
-      logic [15:0] q; // [83:68]
+      logic [15:0] q;
     } nco;
-  } ctrl;
-  struct packed {
+  } uart_reg2hw_ctrl_reg_t;
+
+  typedef struct packed {
     struct packed {
-      logic q; // [67]
-      logic re; // [66]
+      logic        q;
+      logic        re;
     } txfull;
     struct packed {
-      logic q; // [65]
-      logic re; // [64]
+      logic        q;
+      logic        re;
     } rxfull;
     struct packed {
-      logic q; // [63]
-      logic re; // [62]
+      logic        q;
+      logic        re;
     } txempty;
     struct packed {
-      logic q; // [61]
-      logic re; // [60]
+      logic        q;
+      logic        re;
     } txidle;
     struct packed {
-      logic q; // [59]
-      logic re; // [58]
+      logic        q;
+      logic        re;
     } rxidle;
     struct packed {
-      logic q; // [57]
-      logic re; // [56]
+      logic        q;
+      logic        re;
     } rxempty;
-  } status;
-  struct packed {
-    logic [7:0] q; // [55:48]
-    logic re; // [47]
-  } rdata;
-  struct packed {
-    logic [7:0] q; // [46:39]
-    logic qe; // [38]
-  } wdata;
-  struct packed {
+  } uart_reg2hw_status_reg_t;
+
+  typedef struct packed {
+    logic [7:0]  q;
+    logic        re;
+  } uart_reg2hw_rdata_reg_t;
+
+  typedef struct packed {
+    logic [7:0]  q;
+    logic        qe;
+  } uart_reg2hw_wdata_reg_t;
+
+  typedef struct packed {
     struct packed {
-      logic q; // [37]
-      logic qe; // [36]
+      logic        q;
+      logic        qe;
     } rxrst;
     struct packed {
-      logic q; // [35]
-      logic qe; // [34]
+      logic        q;
+      logic        qe;
     } txrst;
     struct packed {
-      logic [2:0] q; // [33:31]
-      logic qe; // [30]
+      logic [2:0]  q;
+      logic        qe;
     } rxilvl;
     struct packed {
-      logic [1:0] q; // [29:28]
-      logic qe; // [27]
+      logic [1:0]  q;
+      logic        qe;
     } txilvl;
-  } fifo_ctrl;
-  struct packed {
+  } uart_reg2hw_fifo_ctrl_reg_t;
+
+  typedef struct packed {
     struct packed {
-      logic q; // [26]
+      logic        q;
     } txen;
     struct packed {
-      logic q; // [25]
+      logic        q;
     } txval;
-  } ovrd;
-  struct packed {
+  } uart_reg2hw_ovrd_reg_t;
+
+  typedef struct packed {
     struct packed {
-      logic [23:0] q; // [24:1]
+      logic [23:0] q;
     } val;
     struct packed {
-      logic q; // [0]
+      logic        q;
     } en;
-  } timeout_ctrl;
-} uart_reg2hw_t;
+  } uart_reg2hw_timeout_ctrl_reg_t;
 
-///////////////////////////////////////
-// Internal design logic to register //
-///////////////////////////////////////
 
-typedef struct packed {
-  struct packed {
+  typedef struct packed {
     struct packed {
-      logic d; // [64]
-      logic de; // [63]
+      logic        d;
+      logic        de;
     } tx_watermark;
     struct packed {
-      logic d; // [62]
-      logic de; // [61]
+      logic        d;
+      logic        de;
     } rx_watermark;
     struct packed {
-      logic d; // [60]
-      logic de; // [59]
+      logic        d;
+      logic        de;
     } tx_overflow;
     struct packed {
-      logic d; // [58]
-      logic de; // [57]
+      logic        d;
+      logic        de;
     } rx_overflow;
     struct packed {
-      logic d; // [56]
-      logic de; // [55]
+      logic        d;
+      logic        de;
     } rx_frame_err;
     struct packed {
-      logic d; // [54]
-      logic de; // [53]
+      logic        d;
+      logic        de;
     } rx_break_err;
     struct packed {
-      logic d; // [52]
-      logic de; // [51]
+      logic        d;
+      logic        de;
     } rx_timeout;
     struct packed {
-      logic d; // [50]
-      logic de; // [49]
+      logic        d;
+      logic        de;
     } rx_parity_err;
-  } intr_state;
-  struct packed {
+  } uart_hw2reg_intr_state_reg_t;
+
+  typedef struct packed {
     struct packed {
-      logic d; // [48]
+      logic        d;
     } txfull;
     struct packed {
-      logic d; // [47]
+      logic        d;
     } rxfull;
     struct packed {
-      logic d; // [46]
+      logic        d;
     } txempty;
     struct packed {
-      logic d; // [45]
+      logic        d;
     } txidle;
     struct packed {
-      logic d; // [44]
+      logic        d;
     } rxidle;
     struct packed {
-      logic d; // [43]
+      logic        d;
     } rxempty;
-  } status;
-  struct packed {
-    logic [7:0] d; // [42:35]
-  } rdata;
-  struct packed {
+  } uart_hw2reg_status_reg_t;
+
+  typedef struct packed {
+    logic [7:0]  d;
+  } uart_hw2reg_rdata_reg_t;
+
+  typedef struct packed {
     struct packed {
-      logic [2:0] d; // [34:32]
-      logic de; // [31]
+      logic [2:0]  d;
+      logic        de;
     } rxilvl;
     struct packed {
-      logic [1:0] d; // [30:29]
-      logic de; // [28]
+      logic [1:0]  d;
+      logic        de;
     } txilvl;
-  } fifo_ctrl;
-  struct packed {
+  } uart_hw2reg_fifo_ctrl_reg_t;
+
+  typedef struct packed {
     struct packed {
-      logic [5:0] d; // [27:22]
+      logic [5:0]  d;
     } txlvl;
     struct packed {
-      logic [5:0] d; // [21:16]
+      logic [5:0]  d;
     } rxlvl;
-  } fifo_status;
-  struct packed {
-    logic [15:0] d; // [15:0]
-  } val;
-} uart_hw2reg_t;
+  } uart_hw2reg_fifo_status_reg_t;
+
+  typedef struct packed {
+    logic [15:0] d;
+  } uart_hw2reg_val_reg_t;
+
+
+  ///////////////////////////////////////
+  // Register to internal design logic //
+  ///////////////////////////////////////
+  typedef struct packed {
+    uart_reg2hw_intr_state_reg_t intr_state; // [124:117]
+    uart_reg2hw_intr_enable_reg_t intr_enable; // [116:109]
+    uart_reg2hw_intr_test_reg_t intr_test; // [108:93]
+    uart_reg2hw_ctrl_reg_t ctrl; // [92:68]
+    uart_reg2hw_status_reg_t status; // [67:56]
+    uart_reg2hw_rdata_reg_t rdata; // [55:47]
+    uart_reg2hw_wdata_reg_t wdata; // [46:38]
+    uart_reg2hw_fifo_ctrl_reg_t fifo_ctrl; // [37:27]
+    uart_reg2hw_ovrd_reg_t ovrd; // [26:25]
+    uart_reg2hw_timeout_ctrl_reg_t timeout_ctrl; // [24:0]
+  } uart_reg2hw_t;
+
+  ///////////////////////////////////////
+  // Internal design logic to register //
+  ///////////////////////////////////////
+  typedef struct packed {
+    uart_hw2reg_intr_state_reg_t intr_state; // [64:57]
+    uart_hw2reg_status_reg_t status; // [56:45]
+    uart_hw2reg_rdata_reg_t rdata; // [44:36]
+    uart_hw2reg_fifo_ctrl_reg_t fifo_ctrl; // [35:25]
+    uart_hw2reg_fifo_status_reg_t fifo_status; // [24:25]
+    uart_hw2reg_val_reg_t val; // [24:25]
+  } uart_hw2reg_t;
 
   // Register Address
   parameter UART_INTR_STATE_OFFSET = 6'h 0;

--- a/util/dashboard/gen_dashboard_entry.py
+++ b/util/dashboard/gen_dashboard_entry.py
@@ -5,6 +5,7 @@
 Generate html documentation from validated dashboard json tree
 """
 
+import sys
 import hjson
 import html
 import re
@@ -97,10 +98,10 @@ def print_version1_format(obj, outfile):
 
     if 'notes' in obj:
         genout(outfile,
-                    "        <td>" + mk.markdown(obj['notes']) + "</td>\n")
+                    "        <td>" + mk.markdown(obj['notes']).rstrip() + "</td>\n")
     else:
         genout(outfile,
-                    "        <td>&nbsp;</td>\n")
+                    "        <td><p>&nbsp;</p></td>\n")
     genout(outfile, "      </tr>\n")
     # yapf: enable
 
@@ -160,10 +161,11 @@ def print_multiversion_format(obj, outfile):
         else:
             outstr += "        <td>&nbsp;</td>\n"
 
-        if 'notes' in rev:
-            outstr += "        <td>" + mk.markdown(rev['notes']) + "</td>\n"
+        if 'notes' in rev and rev['notes'] != '':
+            outstr += "        <td>" + mk.markdown(
+                rev['notes']).rstrip() + "</td>\n"
         else:
-            outstr += "        <td>&nbsp;</td>\n"
+            outstr += "        <td><p>&nbsp;</p></td>\n"
         outstr += "      </tr>\n"
 
     genout(outfile, outstr)


### PR DESCRIPTION
As IP versioning scheme is finalized, now the signed off IPs have newly
generated register modules. Also, its project Hjson files are updated to
the new form ( PR #1009 ).

![image](https://user-images.githubusercontent.com/1192814/69085088-54f46c00-09fa-11ea-8fca-a8ce44693234.png)
![image](https://user-images.githubusercontent.com/1192814/69085102-5aea4d00-09fa-11ea-9e8e-0c657132b009.png)
