### PR TITLE
[ci] Add a script for generating the release.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -315,17 +315,24 @@ jobs:
       buildType: current
       targetPath: '$(Build.ArtifactStagingDirectory)/dist-partial-download'
   - bash: |
-      OT_VERSION=$(git describe --always)
-      cd "$(Build.ArtifactStagingDirectory)"
-      find "$(Build.ArtifactStagingDirectory)/dist-partial-download" -iname '*.tar' -exec tar --overwrite -xf {} \;
+      export BUILD_ROOT="$(Build.ArtifactStagingDirectory)"
+      . util/build_consts.sh
+      cd "$BUILD_ROOT"
+      find "dist-partial-download" \
+        -iname '*.tar' \
+        -exec tar --overwrite -xvf {} \;
+      # TODO: Remove this one upstream targets are outputing stuff into $BIN_DIR.
+      mv dist "$BIN_DIR"
+    displayName: "Unpack pipeline artifacts"
+  - bash: |
+      export BUILD_ROOT="$(Build.ArtifactStagingDirectory)"
+      . util/build_consts.sh
+      util/make_distribution.sh
 
-      cp $(Build.SourcesDirectory)/ci/README.snapshot dist/README
-      echo -e "\nVersion $OT_VERSION, built at $(date -u)" >> dist/README
-      cp $(Build.SourcesDirectory)/LICENSE dist/LICENSE
-
-      mv dist opentitan-$OT_VERSION
-      mkdir -p dist-final
-      tar -cJf dist-final/opentitan-$OT_VERSION.tar.xz opentitan-$OT_VERSION
+      tar --list -f $BIN_DIR/opentitan-*.tar.xz
+      # Put the resulting tar file into a directory the |publish| step below can reference.
+      mkdir "$BUILD_ROOT/dist-final"
+      mv $BIN_DIR/opentitan-*.tar.xz "$BUILD_ROOT/dist-final"
     displayName: 'Create final dist directory out of partial ones'
   - publish: $(Build.ArtifactStagingDirectory)/dist-final
     artifact: opentitan-dist

--- a/util/make_distribution.sh
+++ b/util/make_distribution.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+# make_distribution.sh takes distribution artifacts in $BIN_DIR and packs them
+# into a compressed TAR archive, which is deposited into $BIN_DIR. In
+# particular, this script should be run after make_build_bin.sh.
+#
+# The actual artifacts exported are described by the $DIST_ARTIFACTS variable
+# below.
+
+. util/build_consts.sh
+
+readonly OT_VERSION="$(git describe --always)"
+echo "\$OT_VERSION = $OT_VERSION" >&2
+
+# $DIST_ARTIFACTS is a list of |find| globs to be copied out of
+# $BIN_DIR and into the OpenTitan distribution archive.
+#
+# These globs are relative to $BIN_DIR.
+readonly DIST_ARTIFACTS=(
+  'sw/device/*.elf'
+  'sw/device/*.bin'
+  'sw/device/*.vmem'
+  'sw/host/spiflash/spiflash'
+  'hw/top_earlgrey/Vtop_earlgrey_verilator'
+  'hw/top_earlgrey/lowrisc_systems_top_earlgrey_nexysvideo_0.1.bit'
+)
+
+DIST_DIR="$OBJ_DIR/opentitan-$OT_VERSION"
+mkdir -p "$DIST_DIR"
+
+cp ci/README.snapshot "$DIST_DIR"
+cp LICENSE "$DIST_DIR"
+
+for pat in "${DIST_ARTIFACTS[@]}"; do
+  echo "Searching for $pat." >&2
+  for file in $(find "$BIN_DIR" -type f -path "$BIN_DIR/$pat"); do
+    relative_file="${file#"$BIN_DIR/"}"
+    echo "Copying \$BIN_DIR/$relative_file." >&2
+
+    destination="$DIST_DIR/$(dirname "$relative_file")"
+    mkdir -p "$destination"
+    mv "$file" "$destination"
+  done
+done
+
+cd "$OBJ_DIR"
+tar -cJf "$BIN_DIR/opentitan-$OT_VERSION.tar.xz" "opentitan-$OT_VERSION"


### PR DESCRIPTION
This script factors out logic currently locked up in azure-pipelines, cleans it up, and makes it somewhat more robust, so that local users can prepare a release themsleves.

This script should work find with either Make or Meson, but in CI it's hooked up to make right now. Hopefully the next followup will finally be the cut-over!