### PR TITLE
Register rominit and flashinit as CLI parameters in core file

### DIFF
--- a/hw/top_earlgrey/top_earlgrey_verilator.core
+++ b/hw/top_earlgrey/top_earlgrey_verilator.core
@@ -37,6 +37,15 @@ parameters:
     datatype: int
     paramtype: vlogdefine
     description: Verilator specific address to write to terminate the sim.  This value should be word offset from mem base.
+  flashinit:
+    datatype : file
+    description : Application to load into Flash (in Verilog hex format)
+    paramtype : cmdlinearg
+
+  rominit:
+    datatype : file
+    description : Application to load into Boot ROM (in Verilog hex format)
+    paramtype : cmdlinearg
 
 targets:
   sim:
@@ -45,6 +54,8 @@ targets:
       - RVFI=true
       - VERILATOR_MEM_BASE=0x10000000
       - VERILATOR_END_SIM_ADDR=0x10008000
+      - flashinit
+      - rominit
     default_tool: verilator
     filesets:
       - files_sim_verilator


### PR DESCRIPTION
Verilator uses the --rominit and --flashinit parameters but they
are not registered in the core file and therefore don't show up
when running
fusesoc run --target=sim lowrisc:systems:top_earlgrey_verilator --help

This patch registers the arguments in the core file which also helps
if there is a need to set a default value for them later on.

Signed-off-by: Olof Kindgren <olof.kindgren@gmail.com>