### PR TITLE
[site/docs] Add missing meta headers

### DIFF
--- a/site/docs/layouts/partials/head.html
+++ b/site/docs/layouts/partials/head.html
@@ -1,5 +1,18 @@
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+
+  <meta name="Description" content="{{ .Title }}">
+  <meta property="og:title" content="{{ with .Title }}{{ . }} | {{ end }}OpenTitan Documentation">
+  <meta property="twitter:title" content="{{ with .Title }}{{ . }} | {{ end }}OpenTitan Documentation">
+  <meta property="og:image" content="https://opentitan.org/opentitan.png">
+  <meta property="twitter:image:src" content="https://opentitan.org/opentitan.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:description" content="OpenTitan Documentation">
+  <meta property="twitter:description" content="OpenTitan Documentation">
+  <meta name="twitter:card" content="summary_large_image">
 
 	<link rel="apple-touch-icon" sizes="180x180" href="https://opentitan.org/apple-touch-icon.png">
 	<link rel="icon" type="image/png" sizes="32x32" href="https://opentitan.org/favicon-32x32.png">


### PR DESCRIPTION
Adding the missing viewport header that will make the page layout nicely
on mobile, as well as the social metadata used when sharing the pages.

Signed-off-by: Garret Kelly <gdk@google.com>