### PR TITLE
Add ROM FuseSoC generator

### DIFF
--- a/hw/top_earlgrey/top_earlgrey_verilator.core
+++ b/hw/top_earlgrey/top_earlgrey_verilator.core
@@ -14,6 +14,7 @@ filesets:
       - lowrisc:dv_dpi:spidpi
       - lowrisc:dv_verilator:simutil_verilator
       - lowrisc:ibex:ibex_tracer
+      - lowrisc:utils:generators
 
     files:
       - rtl/top_earlgrey_verilator.sv: { file_type: systemVerilogSource }
@@ -47,8 +48,17 @@ parameters:
     description : Application to load into Boot ROM (in Verilog hex format)
     paramtype : cmdlinearg
 
+generate:
+  default_sw:
+    generator: lowrisc_rom
+    parameters:
+      rominit   : boot_rom
+      flashinit : examples/hello_world
+      sim       : true
+
 targets:
   sim:
+    generate: [default_sw]
     parameters:
       - PRIM_DEFAULT_IMPL=prim_pkg::ImplGeneric
       - RVFI=true

--- a/sw/device/lowrisc_generators.core
+++ b/sw/device/lowrisc_generators.core
@@ -1,0 +1,26 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name : lowrisc:utils:generators:0
+
+generators:
+  lowrisc_rom:
+    command: lowrisc_rom_gen.py
+    interpreter: python
+    description : LowRISC ROM generator
+    usage: |
+      The LowRISC ROM generator can compile the included boot ROM and example
+      applications into vmem files used for simulated Flash contents
+
+      The selected applications are set as default values to the --rominit and
+      --flashinit parameters. If the --rominit or --flashinit parameters are
+      specified on the command line, these will override the default values
+
+      Parameters:
+        rominit (str): Subdirectory of sw/device where the boot ROM sources are
+                       found (e.g. boot_rom)
+        flashinit (str): Subdirectory of sw/device where the application to be
+                         loaded into Flash during simulation is found
+                         (e.g. examples/hello_world)
+        sim (bool): Compile programs with SIM=1 defined

--- a/sw/device/lowrisc_rom_gen.py
+++ b/sw/device/lowrisc_rom_gen.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+from fusesoc.capi2.generator import Generator
+import os
+import subprocess
+
+class LowriscRomGenerator(Generator):
+    def run(self):
+        rominit = self.config.get('rominit')
+        flashinit = self.config.get('flashinit')
+        files = []
+        cmd = ['make']
+        if self.config.get('sim'):
+            cmd.append('SIM=1')
+
+        if rominit:
+            outfile = os.path.join(rominit, 'rom.vmem')
+            cwd = os.path.dirname(__file__)
+            build_dir = os.path.abspath(rominit)
+            rc = subprocess.call(cmd + ['SW_DIR='+rominit, 'SW_BUILD_DIR='+build_dir, 'clean', 'all'], cwd=cwd)
+            if rc:
+                exit(1)
+            files.append({outfile : {'file_type' : 'user'}})
+            self.add_parameter('rominit',
+                               {'datatype' : 'file',
+                                'default' : os.path.join(build_dir, 'rom.vmem'),
+                                'paramtype' : 'cmdlinearg'})
+        if flashinit:
+            outfile = os.path.join(flashinit, 'sw.vmem')
+            cwd = os.path.dirname(__file__)
+            build_dir = os.path.abspath(flashinit)
+            rc = subprocess.call(cmd + ['SW_DIR='+flashinit, 'SW_BUILD_DIR='+build_dir, 'clean', 'all'], cwd=cwd)
+            if rc:
+                exit(1)
+            files.append({outfile : {'file_type' : 'user'}})
+            self.add_parameter('flashinit',
+                               {'datatype' : 'file',
+                                'default' : os.path.join(build_dir, 'sw.vmem'),
+                                'paramtype' : 'cmdlinearg'})
+
+        if not 'default' in self.targets:
+            self.targets['default'] = {}
+        if not 'filesets' in self.targets['default']:
+            self.targets['default']['filesets'] = []
+        self.add_files(files)
+
+g = LowriscRomGenerator()
+g.run()
+g.write()


### PR DESCRIPTION
Add a FuseSoC generator that compiles the source for boot ROM
and user application into vmem files as part of the build flow
and uses the built files as default values for --rominit and
--flashinit

More info about the generator can be acquired by running

fusesoc --cores-root=. gen show lowrisc_rom

A parameterized instance of the generator that loads the hello_world
app is hooked up to the sim target of top_earlgrey_verilator core

Signed-off-by: Olof Kindgren <olof.kindgren@gmail.com>

The main advantage of this generator is to be able to run `fusesoc --cores-root . run --target=sim lowrisc:systems:top_earlgrey_verilator` to build both RTL and firmware and run a simulation using one command

Some notes:
1. I settled for `utils` as the Library part of the VLNV identifier
2. I used the sim target for this, which changes the default behaviour by building the software during the setup stage. If this is unwanted we could a) hide the generation behind a use flag or b) create a new target that just inherits the sim target and adds the `generate` key