### PR TITLE
[uart/dv] Add reset with stress

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -25,6 +25,9 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
 
   virtual task run_phase(uvm_phase phase);
     super.run_phase(phase);
+    // if en_scb is off at the beginning, below processes aren't enabled
+    // but monitor_reset in super.run_phase is always running
+    wait(cfg.en_scb);
     fork
       process_tl_a_chan_fifo();
       process_tl_d_chan_fifo();
@@ -35,6 +38,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
     tl_seq_item item;
     forever begin
       tl_a_chan_fifo.get(item);
+      if (!cfg.en_scb) continue;
       // do nothing; we are using d_chan_fifo items for completed transactions
       process_tl_access(item, AddrChannel);
     end
@@ -44,6 +48,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
     tl_seq_item item;
     forever begin
       tl_d_chan_fifo.get(item);
+      if (!cfg.en_scb) continue;
       `uvm_info(`gfn, $sformatf("received tl d_chan item:\n%0s", item.sprint()), UVM_HIGH)
       // check tl packet integrity
       void'(item.is_ok());

--- a/hw/dv/sv/common_ifs/clk_rst_if.sv
+++ b/hw/dv/sv/common_ifs/clk_rst_if.sv
@@ -172,11 +172,10 @@ interface clk_rst_if #(
                              int post_reset_dly_clks = 0,
                              int rst_n_scheme        = 1);
     int dly_ps;
-    dly_ps = $urandom_range(0, clk_period_ps / 2);
+    dly_ps = $urandom_range(0, clk_period_ps);
     wait_clks(pre_reset_dly_clks);
     case (rst_n_scheme)
       0: begin : sync_assert_deassert
-        if (pre_reset_dly_clks == 0) wait_clks(1);
         o_rst_n <= 1'b0;
         wait_clks(reset_width_clks);
         o_rst_n <= 1'b1;

--- a/hw/dv/sv/csr_utils/README.md
+++ b/hw/dv/sv/csr_utils/README.md
@@ -61,11 +61,11 @@ Due to `csr_utils_pkg` is not connected to any interface, methods inside
 this package are not able to get reset information. Current the `under_reset`
 bit is declared with two functions:
 ```systemverilog
-function automatic void reset_occurred();
+function automatic void reset_asserted();
   under_reset = 1;
 endfunction
 
-function automatic void reset_cleared();
+function automatic void reset_deasserted();
   under_reset = 0;
 endfunction
 ```

--- a/hw/dv/sv/csr_utils/csr_utils_pkg.sv
+++ b/hw/dv/sv/csr_utils/csr_utils_pkg.sv
@@ -53,11 +53,11 @@ package csr_utils_pkg;
     outstanding_accesses = 0;
   endfunction
 
-  function automatic void reset_occurred();
+  function automatic void reset_asserted();
     under_reset = 1;
   endfunction
 
-  function automatic void reset_cleared();
+  function automatic void reset_deasserted();
     under_reset = 0;
   endfunction
 
@@ -390,7 +390,7 @@ package csr_utils_pkg;
 
         csr_or_fld = decode_csr_or_field(ptr);
         fork
-          while (1) begin
+          while (!under_reset) begin
             if (spinwait_delay_ns) #(spinwait_delay_ns * 1ns);
             csr_rd(.ptr(ptr), .value(read_data), .check(check), .path(path),
                    .blocking(1), .map(map));

--- a/hw/dv/sv/dv_lib/dv_base_env.sv
+++ b/hw/dv/sv/dv_lib/dv_base_env.sv
@@ -40,11 +40,10 @@ class dv_base_env #(type CFG_T               = dv_base_env_cfg,
       virtual_sequencer.cov = cov;
     end
 
-    if (cfg.en_scb) begin
-      scoreboard = SCOREBOARD_T::type_id::create("scoreboard", this);
-      scoreboard.cfg = cfg;
-      scoreboard.cov = cov;
-    end
+    // scb also monitors the reset and call cfg.reset_asserted/reset_deasserted for reset
+    scoreboard = SCOREBOARD_T::type_id::create("scoreboard", this);
+    scoreboard.cfg = cfg;
+    scoreboard.cov = cov;
   endfunction
 
   virtual function void end_of_elaboration_phase(uvm_phase phase);

--- a/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
+++ b/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
@@ -4,10 +4,11 @@
 
 class dv_base_env_cfg #(type RAL_T = dv_base_reg_block) extends uvm_object;
 
-  bit                   is_active = 1'b1;
-  bit                   en_scb = 1'b1;
-  bit                   en_cov = 1'b1;
-  bit                   has_ral = 1'b1;
+  bit                   is_active    = 1;
+  bit                   en_scb       = 1; // can be changed at run-time
+  bit                   en_cov       = 1;
+  bit                   has_ral      = 1;
+  bit                   under_reset  = 0;
 
   // bit to configure all uvcs with zero delays to create high bw test
   rand bit              zero_delays;
@@ -81,4 +82,13 @@ class dv_base_env_cfg #(type RAL_T = dv_base_reg_block) extends uvm_object;
     // fix access policies & reset values
   endfunction
 
+  virtual function void reset_asserted();
+    this.under_reset = 1;
+    csr_utils_pkg::reset_asserted();
+  endfunction
+
+  virtual function void reset_deasserted();
+    this.under_reset = 0;
+    csr_utils_pkg::reset_deasserted();
+  endfunction
 endclass

--- a/hw/dv/sv/dv_lib/dv_base_scoreboard.sv
+++ b/hw/dv/sv/dv_lib/dv_base_scoreboard.sv
@@ -12,7 +12,6 @@ class dv_base_scoreboard #(type RAL_T = dv_base_reg_block,
   COV_T    cov;
 
   bit obj_raised = 1'b0;
-  bit under_reset;
 
   `uvm_component_new
 
@@ -32,10 +31,10 @@ class dv_base_scoreboard #(type RAL_T = dv_base_reg_block,
     forever begin
       if (!cfg.clk_rst_vif.rst_n) begin
         `uvm_info(`gfn, "reset occurred", UVM_HIGH)
-        under_reset = 1'b1;
+        cfg.reset_asserted();
         @(posedge cfg.clk_rst_vif.rst_n);
+        cfg.reset_deasserted();
         reset();
-        under_reset = 1'b0;
         `uvm_info(`gfn, "out of reset", UVM_HIGH)
       end
       else begin

--- a/hw/dv/sv/tl_agent/tl_host_driver.sv
+++ b/hw/dv/sv/tl_agent/tl_host_driver.sv
@@ -97,7 +97,8 @@ class tl_host_driver extends uvm_driver#(tl_seq_item);
     while(!vif.host_cb.d2h.a_ready && !reset_asserted) @(vif.host_cb);
     invalidate_a_channel();
     seq_item_port.item_done();
-    pending_a_req.push_back(req);
+    if (reset_asserted) seq_item_port.put_response(req); // if reset, skip data phase
+    else                pending_a_req.push_back(req);
     `uvm_info(get_full_name(), $sformatf("Req sent: %0s", req.convert2string()), UVM_HIGH)
   endtask : send_a_channel_request
 

--- a/hw/dv/sv/uart_agent/uart_agent_cfg.sv
+++ b/hw/dv/sv/uart_agent/uart_agent_cfg.sv
@@ -16,6 +16,9 @@ class uart_agent_cfg extends dv_base_agent_cfg;
   bit en_parity;
   bit odd_parity;
 
+  // reset is controlled at upper seq-level as no reset pin on uart interface
+  bit under_reset;
+
   // interface handle used by driver, monitor & the sequencer
   virtual uart_if vif;
 
@@ -38,4 +41,18 @@ class uart_agent_cfg extends dv_base_agent_cfg;
     this.odd_parity = odd_parity;
   endfunction
 
+  virtual function void reset_asserted();
+    under_reset = 1;
+  endfunction
+
+  virtual function void reset_deasserted(bit re_enable_chk_mon = 1);
+    under_reset = 0;
+    vif.reset_uart_rx();
+    if (re_enable_chk_mon) begin
+      en_rx_checks  = 1;
+      en_tx_checks  = 1;
+      en_rx_monitor = 1;
+      en_tx_monitor = 1;
+    end
+  endfunction
 endclass

--- a/hw/dv/sv/uart_agent/uart_agent_cov.sv
+++ b/hw/dv/sv/uart_agent/uart_agent_cov.sv
@@ -14,9 +14,20 @@ class uart_agent_cov extends dv_base_agent_cov #(uart_agent_cfg);
     cross cp_dir, cp_data, cp_en_parity, cp_odd_parity, cp_baud_rate;
   endgroup
 
+  // sample reset at every bit location in both direction
+  covergroup uart_reset_cg with function sample(uart_dir_e dir, int bit_position);
+    cp_dir:        coverpoint dir;
+    cp_rst_pos:    coverpoint bit_position {
+      // including parity, totally NUM_BIT_START_DATA_STOP+1 bits
+      bins values[]  = {[0:NUM_UART_XFER_BITS_WO_PARITY]};
+    }
+    cross cp_dir, cp_rst_pos;
+  endgroup
+
   function new(string name, uvm_component parent);
     super.new(name, parent);
-    uart_cg = new();
+    uart_cg       = new();
+    uart_reset_cg = new();
   endfunction : new
 
 endclass

--- a/hw/dv/sv/uart_agent/uart_agent_pkg.sv
+++ b/hw/dv/sv/uart_agent/uart_agent_pkg.sv
@@ -12,6 +12,9 @@ package uart_agent_pkg;
   `include "uvm_macros.svh"
   `include "dv_macros.svh"
 
+  // 1 start + 8 data + 1 stop
+  parameter uint NUM_UART_XFER_BITS_WO_PARITY = 10;
+
   // local types
   typedef enum bit {
     UartTx,

--- a/hw/dv/sv/uart_agent/uart_if.sv
+++ b/hw/dv/sv/uart_agent/uart_if.sv
@@ -29,37 +29,9 @@ interface uart_if #(time UartDefaultClkPeriodNs = 104166.667ns) ();
   endclocking
   modport mon_rx_mp(clocking mon_rx_cb);
 
-  // Generate the uart_*x_clk, with UartDefaultClkPeriodNs period as default
-  // Clock pulses are generated when is greater than zero, so for the driver or the monitor
-  // to generate their trigger events, they set i to generate the number of pulses they need.
-  initial begin
-    uart_tx_clk = 1'b1;
-    uart_rx_clk = 1'b1;
-    fork
-      forever begin
-        if (uart_tx_clk_pulses > 0) begin
-          #(uart_clk_period_ns/2);
-          uart_tx_clk = ~uart_tx_clk;
-          #(uart_clk_period_ns/2);
-          uart_tx_clk = ~uart_tx_clk;
-          uart_tx_clk_pulses--;
-        end else begin
-          @(uart_tx, uart_tx_clk_pulses);
-        end
-      end
-      forever begin
-        if (uart_rx_clk_pulses > 0) begin
-          #(uart_clk_period_ns/2);
-          uart_rx_clk = ~uart_rx_clk;
-          #(uart_clk_period_ns/2);
-          uart_rx_clk = ~uart_rx_clk;
-          uart_rx_clk_pulses--;
-        end else begin
-          @(uart_rx, uart_rx_clk_pulses);
-        end
-      end
-    join
-  end
+  task automatic reset_uart_rx();
+    uart_rx = 1;
+  endtask
 
   task automatic wait_for_tx_idle();
     wait(uart_tx_clk_pulses == 0);

--- a/hw/ip/uart/dv/env/seq_lib/uart_base_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_base_vseq.sv
@@ -153,7 +153,7 @@ class uart_base_vseq extends cip_base_vseq #(.CFG_T               (uart_env_cfg)
     csr_rd(.ptr(ral.rdata), .value(rdata));
     // do check but only if rx is enabled
     if (ral.ctrl.rx.get_mirrored_value()) begin
-      `DV_CHECK_EQ(rdata, exp_data)
+      if (!cfg.under_reset) `DV_CHECK_EQ(rdata, exp_data)
     end
   endtask
 

--- a/hw/ip/uart/dv/env/seq_lib/uart_intr_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_intr_vseq.sv
@@ -234,9 +234,9 @@ class uart_intr_vseq extends uart_base_vseq;
     bit exp_pin;
 
     csr_rd(.ptr(ral.intr_state), .value(act_intr_state));
-    `DV_CHECK_EQ(act_intr_state[uart_intr], exp)
+    if (!cfg.under_reset) `DV_CHECK_EQ(act_intr_state[uart_intr], exp)
     exp_pin = exp & en_intr[uart_intr];
-    `DV_CHECK_EQ(cfg.intr_vif.pins[uart_intr], exp_pin, $sformatf(
+    if (!cfg.under_reset) `DV_CHECK_EQ(cfg.intr_vif.pins[uart_intr], exp_pin, $sformatf(
         "uart_intr name/val: %0s/%0d, en_intr: %0h", uart_intr.name, uart_intr, en_intr))
   endtask : check_one_intr
 
@@ -246,9 +246,9 @@ class uart_intr_vseq extends uart_base_vseq;
     bit [NumUartIntr-1:0] exp_pin;
 
     csr_rd(.ptr(ral.intr_state), .value(act_intr_state));
-    `DV_CHECK_EQ(act_intr_state, exp)
+    if (!cfg.under_reset) `DV_CHECK_EQ(act_intr_state, exp)
     exp_pin = exp & en_intr;
-    `DV_CHECK_EQ(cfg.intr_vif.pins[NumUartIntr-1:0], exp_pin, $sformatf(
+    if (!cfg.under_reset) `DV_CHECK_EQ(cfg.intr_vif.pins[NumUartIntr-1:0], exp_pin, $sformatf(
         "uart_intr val: %0h, en_intr: %0h", exp, en_intr))
 
     if (do_clear) begin

--- a/hw/ip/uart/dv/env/seq_lib/uart_loopback_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_loopback_vseq.sv
@@ -79,8 +79,10 @@ class uart_loopback_vseq extends uart_tx_rx_vseq;
           // RX has same value as TX without any synchronizer in the data path
           forever begin
             @(cfg.m_uart_agent_cfg.vif.uart_tx || cfg.m_uart_agent_cfg.vif.uart_rx);
-            #0; // avoid race condition
-            `DV_CHECK_EQ(cfg.m_uart_agent_cfg.vif.uart_tx, cfg.m_uart_agent_cfg.vif.uart_rx)
+            #1ps; // avoid race condition
+            if (!cfg.under_reset) begin
+              `DV_CHECK_EQ(cfg.m_uart_agent_cfg.vif.uart_tx, cfg.m_uart_agent_cfg.vif.uart_rx)
+            end
           end
         join_any
         disable fork;

--- a/hw/ip/uart/dv/env/seq_lib/uart_sanity_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_sanity_vseq.sv
@@ -57,7 +57,7 @@ class uart_sanity_vseq extends uart_tx_rx_vseq;
       send_rx_byte(rx_byte);
       spinwait_rxidle();
       csr_rd(.ptr(ral.rdata), .value(dut_rdata));
-      `DV_CHECK_EQ(rx_byte, dut_rdata)
+      if (!cfg.under_reset) `DV_CHECK_EQ(rx_byte, dut_rdata)
     end
   endtask : process_rx
 

--- a/hw/ip/uart/dv/env/seq_lib/uart_stress_all_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_stress_all_vseq.sv
@@ -32,8 +32,10 @@ class uart_stress_all_vseq extends uart_base_vseq;
       seq = create_seq_by_name(seq_names[seq_idx]);
       `downcast(uart_vseq, seq)
 
-      // dut_init (reset) can be skipped as reset is done in this seq
-      uart_vseq.do_dut_init = $urandom_range(0, 1);
+      // if upper seq disables do_dut_init for this seq, then can't issue reset
+      // as upper seq may drive reset
+      if (do_dut_init) uart_vseq.do_dut_init = $urandom_range(0, 1);
+      else             uart_vseq.do_dut_init = 0;
 
       uart_vseq.set_sequencer(p_sequencer);
       `DV_CHECK_RANDOMIZE_FATAL(uart_vseq)

--- a/hw/ip/uart/dv/env/seq_lib/uart_tx_ovrd_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_tx_ovrd_vseq.sv
@@ -28,7 +28,7 @@ class uart_tx_ovrd_vseq extends uart_sanity_vseq;
       else         exp = 1;
       csr_wr(.csr(ral.ovrd), .value({txval, en_ovrd}));
       cfg.clk_rst_vif.wait_clks(1);
-      `DV_CHECK_EQ(cfg.m_uart_agent_cfg.vif.uart_tx, exp)
+      if (!cfg.under_reset) `DV_CHECK_EQ(cfg.m_uart_agent_cfg.vif.uart_tx, exp)
       cfg.clk_rst_vif.wait_clks(dly_to_next_trans);
     end
     // disable ovrd

--- a/hw/ip/uart/dv/env/uart_env_cfg.sv
+++ b/hw/ip/uart/dv/env/uart_env_cfg.sv
@@ -29,4 +29,15 @@ class uart_env_cfg extends cip_base_env_cfg #(.RAL_T(uart_reg_block));
     num_interrupts = ral.intr_state.get_n_used_bits();
   endfunction
 
+  // uart doesn't have reset pin. When reset occurs/clears,
+  // need to call reset function in uart_agent_cfg
+  virtual function void reset_asserted();
+    super.reset_asserted();
+    m_uart_agent_cfg.reset_asserted();
+  endfunction
+
+  virtual function void reset_deasserted();
+    super.reset_deasserted();
+    m_uart_agent_cfg.reset_deasserted();
+  endfunction
 endclass

--- a/hw/ip/uart/dv/env/uart_scoreboard.sv
+++ b/hw/ip/uart/dv/env/uart_scoreboard.sv
@@ -30,6 +30,7 @@ class uart_scoreboard extends cip_base_scoreboard #(.CFG_T(uart_env_cfg),
 
   // local queues to hold incoming packets pending comparison
   uart_item tx_q[$];
+  // when item is removed from fifo and being sent on UART tx interface, store it in this queue
   uart_item tx_processing_item_q[$];
   uart_item rx_q[$];
 
@@ -492,6 +493,7 @@ class uart_scoreboard extends cip_base_scoreboard #(.CFG_T(uart_env_cfg),
     rxlvl_exp            = ral.fifo_status.rxlvl.get_reset();
     intr_exp             = ral.intr_state.get_reset();
     rdata_exp            = ral.rdata.get_reset();
+    process_objections(1'b0);
   endfunction
 
   function void check_phase(uvm_phase phase);


### PR DESCRIPTION
1. make uart agent support reset and add covergroup
2. update csr read & check by calling csr_hw_reset_seq
3. check if it's reset before calling DV_CHECK_EQ in seq

Signed-off-by: Weicai Yang <weicai@google.com>