### PR TITLE
[DV/HMAC] hmac support config blocking and wr key

### DIFF
--- a/hw/ip/hmac/dv/env/hmac_env_pkg.sv
+++ b/hw/ip/hmac/dv/env/hmac_env_pkg.sv
@@ -62,7 +62,8 @@ package hmac_env_pkg;
   typedef enum {
     NoError,
     SwPushMsgWhenShaDisabled,
-    SwHashStartWhenShaDisabled
+    SwHashStartWhenShaDisabled,
+    SwUpdateSecretKeyInProcess
   } err_code_e;
 
   typedef class hmac_env_cfg;


### PR DESCRIPTION
This PR supports the changes in https://github.com/lowRISC/opentitan/pull/1014
Support config blocking during msg_wr: during valid msg_wr, if trying to
update the config register, it will be discarded
Support err code when wr_key during msg_wr

Signed-off-by: Cindy Chen <chencindy@google.com>