### PR TITLE
[aes] Switch to packed array types

### DIFF
--- a/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi.h
+++ b/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi.h
@@ -18,13 +18,12 @@ extern "C" {
  * @param  mode_i    Operation mode: 0 = encryption, 1 = decryption
  * @param  key_len_i Key length: 3'b001 = 128b, 3'b010 = 192b, 3'b100 = 256b
  * @param  key_i     Full input key
- * @param  data_i    Input data
- * @param  data_o    Output data
+ * @param  data_i    Input data, 2D state matrix (3D packed array in SV)
+ * @param  data_o    Output data, 2D state matrix (3D packed array in SV)
  */
 void aes_crypt_dpi(const unsigned char impl_i, const unsigned char mode_i,
-                   const svBitVecVal *key_len_i, const svOpenArrayHandle key_i,
-                   const svOpenArrayHandle data_i,
-                   const svOpenArrayHandle data_o);
+                   const svBitVecVal *key_len_i, const svBitVecVal *key_i,
+                   const svBitVecVal *data_i, svBitVecVal *data_o);
 
 /**
  * Perform sub bytes operation during encryption/decryption.
@@ -33,9 +32,8 @@ void aes_crypt_dpi(const unsigned char impl_i, const unsigned char mode_i,
  * @param  data_i Input data
  * @param  data_o Output data
  */
-void aes_sub_bytes_dpi(const unsigned char mode_i,
-                       const svOpenArrayHandle data_i,
-                       const svOpenArrayHandle data_o);
+void aes_sub_bytes_dpi(const unsigned char mode_i, const svBitVecVal *data_i,
+                       svBitVecVal *data_o);
 
 /**
  * Perform shift rows operation during encryption/decryption.
@@ -44,9 +42,8 @@ void aes_sub_bytes_dpi(const unsigned char mode_i,
  * @param  data_i Input data
  * @param  data_o Output data
  */
-void aes_shift_rows_dpi(const unsigned char mode_i,
-                        const svOpenArrayHandle data_i,
-                        const svOpenArrayHandle data_o);
+void aes_shift_rows_dpi(const unsigned char mode_i, const svBitVecVal *data_i,
+                        svBitVecVal *data_o);
 
 /**
  * Perform mix columns operation during encryption/decryption.
@@ -55,9 +52,8 @@ void aes_shift_rows_dpi(const unsigned char mode_i,
  * @param  data_i Input data
  * @param  data_o Output data
  */
-void aes_mix_columns_dpi(const unsigned char mode_i,
-                         const svOpenArrayHandle data_i,
-                         const svOpenArrayHandle data_o);
+void aes_mix_columns_dpi(const unsigned char mode_i, const svBitVecVal *data_i,
+                         svBitVecVal *data_o);
 
 /**
  * Generate full key for next round during encryption/decryption.
@@ -69,43 +65,59 @@ void aes_mix_columns_dpi(const unsigned char mode_i,
  * @param  key_i     Full input key
  * @param  key_o     Full output key
  */
-void aes_key_expand_dpi(const unsigned char mode_i, const svBitVecVal *rcon_old,
+void aes_key_expand_dpi(const unsigned char mode_i, const svBitVecVal *rcon_i,
                         const svBitVecVal *round_i,
-                        const svBitVecVal *key_len_i,
-                        const svOpenArrayHandle key_i,
-                        const svOpenArrayHandle key_o);
+                        const svBitVecVal *key_len_i, const svBitVecVal *key_i,
+                        svBitVecVal *key_o);
 
 /**
- * Get data block from simulation.
+ * Get packed data block from simulation.
  *
  * @param  data_i Input data from simulation
  * @return Pointer to data copied to memory, 0 in case of an error
  */
-unsigned char *aes_data_get(const svOpenArrayHandle data_i);
+unsigned char *aes_data_get(const svBitVecVal *data_i);
 
 /**
- * Write data block to simulation and free the source buffer afterwards.
+ * Write packed data block to simulation and free the source buffer afterwards.
  *
  * @param  data_o Output data for simulation
  * @param  data   Data to be copied to simulation, freed after the operation
  */
-void aes_data_put(const svOpenArrayHandle data_o, unsigned char *data);
+void aes_data_put(svBitVecVal *data_o, unsigned char *data);
 
 /**
- * Get key block from simulation.
+ * Get unpacked data block from simulation.
+ *
+ * @param  data_i Input data from simulation
+ * @return Pointer to data copied to memory, 0 in case of an error
+ */
+unsigned char *aes_data_unpacked_get(const svOpenArrayHandle data_i);
+
+/**
+ * Write unpacked data block to simulation and free the source buffer
+ * afterwards.
+ *
+ * @param  data_o Output data for simulation
+ * @param  data   Data to be copied to simulation, freed after the operation
+ */
+void aes_data_unpacked_put(const svOpenArrayHandle data_o, unsigned char *data);
+
+/**
+ * Get packed key block from simulation.
  *
  * @param  key_i Input key from simulation
  * @return Pointer to key copied to memory, 0 in case of an error
  */
-unsigned char *aes_key_get(const svOpenArrayHandle key_i);
+unsigned char *aes_key_get(const svBitVecVal *key_i);
 
 /**
- * Write key block to simulation and free the source buffer afterwards.
+ * Write packed key block to simulation and free the source buffer afterwards.
  *
  * @param  key_o Output key for simulation
  * @param  key   Key to be copied to simulation, freed after the operation
  */
-void aes_key_put(const svOpenArrayHandle key_o, unsigned char *key);
+void aes_key_put(svBitVecVal *key_o, unsigned char *key);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi_pkg.sv
+++ b/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi_pkg.sv
@@ -6,39 +6,39 @@ package aes_model_dpi_pkg;
 
   // DPI-C imports
   import "DPI-C" context function void aes_crypt_dpi(
-    input  bit       impl_i,
-    input  bit       mode_i,
-    input  bit[2:0]  key_len_i,
-    input  bit[31:0] key_i[],
-    input  bit[7:0]  data_i[],
-    output bit[7:0]  data_o[]
+    input  bit                impl_i,
+    input  bit                mode_i,
+    input  bit          [2:0] key_len_i,
+    input  bit    [7:0][31:0] key_i,
+    input  bit[3:0][3:0][7:0] data_i,
+    output bit[3:0][3:0][7:0] data_o
   );
 
   import "DPI-C" context function void aes_sub_bytes_dpi(
-    input  bit      mode_i,
-    input  bit[7:0] data_i[],
-    output bit[7:0] data_o[]
+    input  bit                mode_i,
+    input  bit[3:0][3:0][7:0] data_i,
+    output bit[3:0][3:0][7:0] data_o
   );
 
   import "DPI-C" context function void aes_shift_rows_dpi(
-    input  bit      mode_i,
-    input  bit[7:0] data_i[],
-    output bit[7:0] data_o[]
+    input  bit                mode_i,
+    input  bit[3:0][3:0][7:0] data_i,
+    output bit[3:0][3:0][7:0] data_o
   );
 
   import "DPI-C" context function void aes_mix_columns_dpi(
-    input  bit      mode_i,
-    input  bit[7:0] data_i[],
-    output bit[7:0] data_o[]
+    input  bit                mode_i,
+    input  bit[3:0][3:0][7:0] data_i,
+    output bit[3:0][3:0][7:0] data_o
   );
 
   import "DPI-C" context function void aes_key_expand_dpi(
-    input  bit       mode_i,
-    input  bit[7:0]  rcon_q,
-    input  bit[3:0]  round_i,
-    input  bit[2:0]  key_len_i,
-    input  bit[31:0] key_i[],
-    output bit[31:0] key_o[]
+    input  bit            mode_i,
+    input  bit      [7:0] rcon_i,
+    input  bit      [3:0] round_i,
+    input  bit      [2:0] key_len_i,
+    input  bit[7:0][31:0] key_i,
+    output bit[7:0][31:0] key_o
   );
 
 endpackage

--- a/hw/ip/aes/model/aes.c
+++ b/hw/ip/aes/model/aes.c
@@ -151,68 +151,6 @@ int aes_get_num_rounds(int key_len) {
   return num_rounds;
 }
 
-static void aes_rcon_next(unsigned char *rcon) {
-  unsigned char rcon_tmp;
-
-  // rcon cannot be 0
-  if (*rcon) {
-    // update rcon - actually this is aes_mul2
-    rcon_tmp = *rcon;
-
-    // set individual bits of rcon
-    *rcon = 0x0;
-    //            extract bits             possible xor      shift to right
-    //            position
-    *rcon |= (((rcon_tmp >> 7) & 0x1)) << 0;
-    *rcon |= (((rcon_tmp >> 0) & 0x1) ^ ((rcon_tmp >> 7) & 0x1)) << 1;
-    *rcon |= (((rcon_tmp >> 1) & 0x1)) << 2;
-    *rcon |= (((rcon_tmp >> 2) & 0x1) ^ ((rcon_tmp >> 7) & 0x1)) << 3;
-    *rcon |= (((rcon_tmp >> 3) & 0x1) ^ ((rcon_tmp >> 7) & 0x1)) << 4;
-    *rcon |= (((rcon_tmp >> 4) & 0x1)) << 5;
-    *rcon |= (((rcon_tmp >> 5) & 0x1)) << 6;
-    *rcon |= (((rcon_tmp >> 6) & 0x1)) << 7;
-  } else {
-    // init rcon to first round value
-    *rcon = 0x1;
-  }
-
-  return;
-}
-
-static void aes_rcon_prev(unsigned char *rcon, int key_len) {
-  unsigned char rcon_tmp;
-
-  // rcon cannot be 0
-  if (*rcon) {
-    // update rcon - actually this is aes_mul2
-    rcon_tmp = *rcon;
-
-    // set individual bits of rcon
-    *rcon = 0x0;
-    //            extract bits             possible xor      shift to right
-    //            position
-    *rcon |= (((rcon_tmp >> 1) & 0x1) ^ ((rcon_tmp >> 0) & 0x1)) << 0;
-    *rcon |= (((rcon_tmp >> 2) & 0x1)) << 1;
-    *rcon |= (((rcon_tmp >> 3) & 0x1) ^ ((rcon_tmp >> 0) & 0x1)) << 2;
-    *rcon |= (((rcon_tmp >> 4) & 0x1) ^ ((rcon_tmp >> 0) & 0x1)) << 3;
-    *rcon |= (((rcon_tmp >> 5) & 0x1)) << 4;
-    *rcon |= (((rcon_tmp >> 6) & 0x1)) << 5;
-    *rcon |= (((rcon_tmp >> 7) & 0x1)) << 6;
-    *rcon |= (((rcon_tmp >> 0) & 0x1)) << 7;
-  } else {
-    // init rcon to first round value
-    if (key_len == 16) {
-      *rcon = 0x36;
-    } else if (key_len == 24) {
-      *rcon = 0x80;
-    } else {  // key_len == 32
-      *rcon = 0x40;
-    }
-  }
-
-  return;
-}
-
 static unsigned char aes_mul2(unsigned char in) {
   // set individual bits of out
   unsigned char out = 0x0;
@@ -1014,6 +952,53 @@ void aes_inv_key_expand(unsigned char *round_key, unsigned char *key,
   }
 
   free(old_key);
+
+  return;
+}
+
+void aes_rcon_next(unsigned char *rcon) {
+  // rcon cannot be 0
+  if (*rcon) {
+    // update rcon
+    *rcon = aes_mul2(*rcon);
+  } else {
+    // init rcon to first round value
+    *rcon = 0x1;
+  }
+
+  return;
+}
+
+void aes_rcon_prev(unsigned char *rcon, int key_len) {
+  unsigned char rcon_tmp;
+
+  // rcon cannot be 0
+  if (*rcon) {
+    // update rcon - actually this is the inverse of aes_mul2
+    rcon_tmp = *rcon;
+
+    // set individual bits of rcon
+    *rcon = 0x0;
+    //            extract bits             possible xor      shift to right
+    //            position
+    *rcon |= (((rcon_tmp >> 1) & 0x1) ^ ((rcon_tmp >> 0) & 0x1)) << 0;
+    *rcon |= (((rcon_tmp >> 2) & 0x1)) << 1;
+    *rcon |= (((rcon_tmp >> 3) & 0x1) ^ ((rcon_tmp >> 0) & 0x1)) << 2;
+    *rcon |= (((rcon_tmp >> 4) & 0x1) ^ ((rcon_tmp >> 0) & 0x1)) << 3;
+    *rcon |= (((rcon_tmp >> 5) & 0x1)) << 4;
+    *rcon |= (((rcon_tmp >> 6) & 0x1)) << 5;
+    *rcon |= (((rcon_tmp >> 7) & 0x1)) << 6;
+    *rcon |= (((rcon_tmp >> 0) & 0x1)) << 7;
+  } else {
+    // init rcon to first round value
+    if (key_len == 16) {
+      *rcon = 0x36;
+    } else if (key_len == 24) {
+      *rcon = 0x80;
+    } else {  // key_len == 32
+      *rcon = 0x40;
+    }
+  }
 
   return;
 }

--- a/hw/ip/aes/model/aes.h
+++ b/hw/ip/aes/model/aes.h
@@ -119,6 +119,24 @@ void aes_key_expand(unsigned char *round_key, unsigned char *key,
 void aes_inv_key_expand(unsigned char *round_key, unsigned char *key,
                         const int key_len, unsigned char *rcon, const int rnd);
 
+/**
+ * Update Rcon value for next round during encryption.
+ * If the input value is 0, rcon is initialized to the start value.
+ *
+ * @param  rcon Rcon value
+ */
+void aes_rcon_next(unsigned char *rcon);
+
+/**
+ * Update Rcon value for next round during decryption.
+ * If the input value is 0, rcon is initialized to the start value
+ * depening on key length.
+ *
+ * @param  rcon    Rcon value
+ * @param  key_len Key length in bytes (16, 24, 32)
+ */
+void aes_rcon_prev(unsigned char *rcon, int key_len);
+
 static const unsigned char sbox[256] = {
     0x63, 0x7C, 0x77, 0x7B, 0xF2, 0x6B, 0x6F, 0xC5,
     0x30, 0x01, 0x67, 0x2B, 0xFE, 0xD7, 0xAB, 0x76,

--- a/hw/ip/aes/rtl/aes_core.sv
+++ b/hw/ip/aes/rtl/aes_core.sv
@@ -19,56 +19,56 @@ module aes_core #(
   import aes_pkg::*;
 
   // Signals
-  logic    [31:0] data_in[4];
-  logic     [3:0] data_in_qe;
-  logic    [31:0] key_init[8];
-  logic     [7:0] key_init_qe;
+  logic     [3:0][31:0] data_in;
+  logic     [3:0]       data_in_qe;
+  logic     [7:0][31:0] key_init;
+  logic     [7:0]       key_init_qe;
 
-  mode_e          mode, key_expand_mode;
-  key_len_e       key_len_q, key_len;
+  mode_e                mode, key_expand_mode;
+  key_len_e             key_len_q, key_len;
 
-  logic     [7:0] state_init[16];
-  logic     [7:0] state_d[16];
-  logic     [7:0] state_q[16];
-  logic           state_we;
-  state_sel_e     state_sel;
+  logic [3:0][3:0][7:0] state_init;
+  logic [3:0][3:0][7:0] state_d;
+  logic [3:0][3:0][7:0] state_q;
+  logic                 state_we;
+  state_sel_e           state_sel;
 
-  logic     [7:0] sub_bytes_out[16];
-  logic     [7:0] shift_rows_out[16];
-  logic     [7:0] mix_columns_out[16];
-  logic     [7:0] add_round_key_in[16];
-  logic     [7:0] add_round_key_out[16];
-  add_rk_sel_e    add_round_key_in_sel;
+  logic [3:0][3:0][7:0] sub_bytes_out;
+  logic [3:0][3:0][7:0] shift_rows_out;
+  logic [3:0][3:0][7:0] mix_columns_out;
+  logic [3:0][3:0][7:0] add_round_key_in;
+  logic [3:0][3:0][7:0] add_round_key_out;
+  add_rk_sel_e          add_round_key_in_sel;
 
-  logic    [31:0] key_full_d[8];
-  logic    [31:0] key_full_q[8];
-  logic           key_full_we;
-  key_full_sel_e  key_full_sel;
-  logic    [31:0] key_dec_d[8];
-  logic    [31:0] key_dec_q[8];
-  logic           key_dec_we;
-  key_dec_sel_e   key_dec_sel;
-  logic    [31:0] key_expand_out[8];
-  logic           key_expand_step;
-  logic           key_expand_clear;
-  logic     [3:0] key_expand_round;
-  key_words_sel_e key_words_sel;
-  logic    [31:0] key_words[4];
-  logic     [7:0] key_bytes[16];
-  logic     [7:0] key_mix_columns_out[16];
-  logic     [7:0] round_key[16];
-  round_key_sel_e round_key_sel;
+  logic     [7:0][31:0] key_full_d;
+  logic     [7:0][31:0] key_full_q;
+  logic                 key_full_we;
+  key_full_sel_e        key_full_sel;
+  logic     [7:0][31:0] key_dec_d;
+  logic     [7:0][31:0] key_dec_q;
+  logic                 key_dec_we;
+  key_dec_sel_e         key_dec_sel;
+  logic     [7:0][31:0] key_expand_out;
+  logic                 key_expand_step;
+  logic                 key_expand_clear;
+  logic           [3:0] key_expand_round;
+  key_words_sel_e       key_words_sel;
+  logic     [3:0][31:0] key_words;
+  logic [3:0][3:0][7:0] key_bytes;
+  logic [3:0][3:0][7:0] key_mix_columns_out;
+  logic [3:0][3:0][7:0] round_key;
+  round_key_sel_e       round_key_sel;
 
-  logic    [31:0] data_out_d[4];
-  logic    [31:0] data_out_q[4];
-  logic           data_out_we;
-  logic     [3:0] data_out_re;
+  logic     [3:0][31:0] data_out_d;
+  logic     [3:0][31:0] data_out_q;
+  logic                 data_out_we;
+  logic           [3:0] data_out_re;
 
   // Unused signals
-  logic    [31:0] unused_data_out_q[4];
-  logic           unused_mode_qe;
-  logic           unused_manual_start_trigger_qe;
-  logic           unused_force_data_overwrite_qe;
+  logic     [3:0][31:0] unused_data_out_q;
+  logic                 unused_mode_qe;
+  logic                 unused_manual_start_trigger_qe;
+  logic                 unused_force_data_overwrite_qe;
 
   // Inputs
   assign key_init[0] = reg2hw.key[0].q;
@@ -93,10 +93,7 @@ module aes_core #(
 
   always_comb begin : conv_data_in_to_state
     for (int i=0; i<4; i++) begin
-      state_init[4*i+0] = data_in[i][ 7: 0];
-      state_init[4*i+1] = data_in[i][15: 8];
-      state_init[4*i+2] = data_in[i][23:16];
-      state_init[4*i+3] = data_in[i][31:24];
+      state_init = aes_col_set(data_in[i], i);
     end
   end
 
@@ -134,14 +131,14 @@ module aes_core #(
     unique case (state_sel)
       STATE_INIT:  state_d = state_init;
       STATE_ROUND: state_d = add_round_key_out;
-      STATE_CLEAR: state_d = '{default: '0};
-      default      state_d = '{default: 'X};
+      STATE_CLEAR: state_d = '0;
+      default:     state_d = 'X;
     endcase
   end
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : state_reg
     if (!rst_ni) begin
-      state_q <= '{default: '0};
+      state_q <= '0;
     end else if (state_we) begin
       state_q <= state_d;
     end
@@ -171,15 +168,11 @@ module aes_core #(
       ADD_RK_INIT:  add_round_key_in = state_q;
       ADD_RK_ROUND: add_round_key_in = mix_columns_out;
       ADD_RK_FINAL: add_round_key_in = shift_rows_out;
-      default:      add_round_key_in = '{default: 'X};
+      default:      add_round_key_in = 'X;
     endcase
   end
 
-  always_comb begin : add_round_key
-    for (int i=0; i<16; i++) begin
-      add_round_key_out[i] = add_round_key_in[i] ^ round_key[i];
-    end
-  end
+  assign add_round_key_out = add_round_key_in ^ round_key;
 
   // Full Key registers
   always_comb begin : key_full_mux
@@ -187,14 +180,14 @@ module aes_core #(
       KEY_FULL_ENC_INIT: key_full_d = key_init;
       KEY_FULL_DEC_INIT: key_full_d = key_dec_q;
       KEY_FULL_ROUND:    key_full_d = key_expand_out;
-      KEY_FULL_CLEAR:    key_full_d = '{default: '0};
-      default:           key_full_d = '{default: 'X};
+      KEY_FULL_CLEAR:    key_full_d = '0;
+      default:           key_full_d = 'X;
     endcase
   end
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : key_full_reg
     if (!rst_ni) begin
-      key_full_q <= '{default: '0};
+      key_full_q <= '0;
     end else if (key_full_we) begin
       key_full_q <= key_full_d;
     end
@@ -204,14 +197,14 @@ module aes_core #(
   always_comb begin : key_dec_mux
     unique case (key_dec_sel)
       KEY_DEC_EXPAND: key_dec_d = key_expand_out;
-      KEY_DEC_CLEAR:  key_dec_d = '{default: '0};
-      default:        key_dec_d = '{default: 'X};
+      KEY_DEC_CLEAR:  key_dec_d = '0;
+      default:        key_dec_d = 'X;
     endcase
   end
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : key_dec_reg
     if (!rst_ni) begin
-      key_dec_q <= '{default: '0};
+      key_dec_q <= '0;
     end else if (key_dec_we) begin
       key_dec_q <= key_dec_d;
     end
@@ -234,43 +227,17 @@ module aes_core #(
 
   always_comb begin : key_words_mux
     unique case (key_words_sel)
-      KEY_WORDS_0123: begin
-        key_words[0] = key_full_q[0];
-        key_words[1] = key_full_q[1];
-        key_words[2] = key_full_q[2];
-        key_words[3] = key_full_q[3];
-      end
-      KEY_WORDS_2345: begin
-        if (AES192Enable) begin
-          key_words[0] = key_full_q[2];
-          key_words[1] = key_full_q[3];
-          key_words[2] = key_full_q[4];
-          key_words[3] = key_full_q[5];
-        end else begin
-          key_words    = '{default: 'X};
-        end
-      end
-      KEY_WORDS_4567: begin
-        key_words[0] = key_full_q[4];
-        key_words[1] = key_full_q[5];
-        key_words[2] = key_full_q[6];
-        key_words[3] = key_full_q[7];
-      end
-      KEY_WORDS_ZERO: begin
-        key_words    = '{default: '0};
-      end
-      default: begin
-        key_words    = '{default: 'X};
-      end
+      KEY_WORDS_0123: key_words = key_full_q[3:0];
+      KEY_WORDS_2345: key_words = AES192Enable ? key_full_q[5:2] : 'X;
+      KEY_WORDS_4567: key_words = key_full_q[7:4];
+      KEY_WORDS_ZERO: key_words = '0;
+      default:        key_words = 'X;
     endcase
   end
 
   always_comb begin : conv_key_words_to_bytes
     for (int i=0; i<4; i++) begin
-      key_bytes[4*i+0] = key_words[i][ 7: 0];
-      key_bytes[4*i+1] = key_words[i][15: 8];
-      key_bytes[4*i+2] = key_words[i][23:16];
-      key_bytes[4*i+3] = key_words[i][31:24];
+      key_bytes = aes_col_set(key_words[i], i);
     end
   end
 
@@ -284,21 +251,20 @@ module aes_core #(
     unique case (round_key_sel)
       ROUND_KEY_DIRECT: round_key = key_bytes;
       ROUND_KEY_MIXED:  round_key = key_mix_columns_out;
-      default:          round_key = '{default: 'X};
+      default:          round_key = 'X;
     endcase
   end
 
   // Output registers
   always_comb begin : conv_add_rk_out_to_data_out
     for (int i=0; i<4; i++) begin
-      data_out_d[i] = {add_round_key_out[4*i+3], add_round_key_out[4*i+2],
-                       add_round_key_out[4*i+1], add_round_key_out[4*i+0]};
+      data_out_d[i] = aes_col_get(add_round_key_out, i);
     end
   end
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : data_out_reg
     if (!rst_ni) begin
-      data_out_q <= '{default: '0};
+      data_out_q <= '0;
     end else if (data_out_we) begin
       data_out_q <= data_out_d;
     end

--- a/hw/ip/aes/rtl/aes_mix_columns.sv
+++ b/hw/ip/aes/rtl/aes_mix_columns.sv
@@ -5,18 +5,28 @@
 // AES MixColumns
 
 module aes_mix_columns (
-  input  aes_pkg::mode_e mode_i,
-  input  logic [7:0]     data_i [16],
-  output logic [7:0]     data_o [16]
+  input  aes_pkg::mode_e       mode_i,
+  input  logic [3:0][3:0][7:0] data_i,
+  output logic [3:0][3:0][7:0] data_o
 );
+
+  import aes_pkg::*;
+
+  // Transpose to operate on columns
+  logic [3:0][3:0][7:0] data_i_transposed;
+  logic [3:0][3:0][7:0] data_o_transposed;
+
+  assign data_i_transposed = aes_transpose(data_i);
 
   // Individually mix columns
   for (genvar i = 0; i < 4; i++) begin : gen_mix_column
     aes_mix_single_column aes_mix_column_i (
-      .mode_i ( mode_i            ),
-      .data_i ( data_i[4*i:4*i+3] ),
-      .data_o ( data_o[4*i:4*i+3] )
+      .mode_i ( mode_i               ),
+      .data_i ( data_i_transposed[i] ),
+      .data_o ( data_o_transposed[i] )
     );
   end
+
+  assign data_o = aes_transpose(data_o_transposed);
 
 endmodule

--- a/hw/ip/aes/rtl/aes_mix_single_column.sv
+++ b/hw/ip/aes/rtl/aes_mix_single_column.sv
@@ -8,22 +8,22 @@
 // Satoh et al., "A Compact Rijndael Hardware Architecture with S-Box Optimization"
 
 module aes_mix_single_column (
-  input  aes_pkg::mode_e mode_i,
-  input  logic [7:0]     data_i [4],
-  output logic [7:0]     data_o [4]
+  input  aes_pkg::mode_e  mode_i,
+  input  logic [3:0][7:0] data_i,
+  output logic [3:0][7:0] data_o
 );
 
   import aes_pkg::*;
 
-  logic [7:0] x[4];
-  logic [7:0] y[2];
-  logic [7:0] z[2];
+  logic [3:0][7:0] x;
+  logic [1:0][7:0] y;
+  logic [1:0][7:0] z;
 
-  logic [7:0] x_mul2[4];
-  logic [7:0] y_pre_mul4[2];
-  logic [7:0] y2, y2_pre_mul2;
+  logic [3:0][7:0] x_mul2;
+  logic [1:0][7:0] y_pre_mul4;
+  logic      [7:0] y2, y2_pre_mul2;
 
-  logic [7:0] z_muxed[2];
+  logic [1:0][7:0] z_muxed;
 
   // Drive x
   assign x[0] = data_i[0] ^ data_i[3];

--- a/hw/ip/aes/rtl/aes_pkg.sv
+++ b/hw/ip/aes/rtl/aes_pkg.sv
@@ -87,4 +87,34 @@ function automatic logic [7:0] aes_div2(input logic [7:0] in);
   aes_div2[0] = in[1] ^ in[0];
 endfunction
 
+// Circular byte shift to the left
+function automatic logic [31:0] aes_circ_byte_shift(input logic [31:0] in, int shift);
+  int s = shift % 4;
+  aes_circ_byte_shift = {in[8*((7-s)%4) +: 8], in[8*((6-s)%4) +: 8],
+                         in[8*((5-s)%4) +: 8], in[8*((4-s)%4) +: 8]};
+endfunction
+
+// Transpose state matrix
+function automatic logic [3:0][3:0][7:0] aes_transpose(input logic [3:0][3:0][7:0] in);
+  for (int j=0; j<4; j++) begin
+    for (int i=0; i<4; i++) begin
+      aes_transpose[i][j] = in[j][i];
+    end
+  end
+endfunction
+
+// Extract single column from state matrix
+function automatic logic [3:0][7:0] aes_col_get(input logic [3:0][3:0][7:0] in, int idx);
+  for (int i=0; i<4; i++) begin
+    aes_col_get[i] = in[i][idx];
+  end
+endfunction
+
+// Set single column in state matrix
+function automatic logic [3:0][3:0][7:0] aes_col_set(input logic [3:0][7:0] in, int idx);
+  for (int i=0; i<4; i++) begin
+    aes_col_set[i][idx] = in[i];
+  end
+endfunction
+
 endpackage

--- a/hw/ip/aes/rtl/aes_shift_rows.sv
+++ b/hw/ip/aes/rtl/aes_shift_rows.sv
@@ -5,50 +5,25 @@
 // AES ShiftRows
 
 module aes_shift_rows (
-  input  aes_pkg::mode_e mode_i,
-  input  logic [7:0]     data_i [16],
-  output logic [7:0]     data_o [16]
+  input  aes_pkg::mode_e       mode_i,
+  input  logic [3:0][3:0][7:0] data_i,
+  output logic [3:0][3:0][7:0] data_o
 );
 
   import aes_pkg::*;
 
   // Row 0 is left untouched
-  assign data_o[0]  = data_i[0];
-  assign data_o[4]  = data_i[4];
-  assign data_o[8]  = data_i[8];
-  assign data_o[12] = data_i[12];
+  assign data_o[0] = data_i[0];
 
   // Row 2 does not depend on mode_i
-  assign data_o[2]  = data_i[10];
-  assign data_o[6]  = data_i[14];
-  assign data_o[10] = data_i[2];
-  assign data_o[14] = data_i[6];
+  assign data_o[2] = aes_circ_byte_shift(data_i[2], 2);
 
-  // Rows 1 and 3
-  always_comb begin : shift_row_1_3
-    if (mode_i == AES_ENC) begin
-      // Row 1
-      data_o[1]  = data_i[5];
-      data_o[5]  = data_i[9];
-      data_o[9]  = data_i[13];
-      data_o[13] = data_i[1];
-      // Row 3
-      data_o[3]  = data_i[15];
-      data_o[7]  = data_i[3];
-      data_o[11] = data_i[7];
-      data_o[15] = data_i[11];
-    end else begin
-      // Row 1
-      data_o[1]  = data_i[13];
-      data_o[5]  = data_i[1];
-      data_o[9]  = data_i[5];
-      data_o[13] = data_i[9];
-      // Row 3
-      data_o[3]  = data_i[7];
-      data_o[7]  = data_i[11];
-      data_o[11] = data_i[15];
-      data_o[15] = data_i[3];
-    end
-  end
+  // Row 1
+  assign data_o[1] = (mode_i == AES_ENC) ? aes_circ_byte_shift(data_i[1], -1)
+                                         : aes_circ_byte_shift(data_i[1],  1);
+
+  // Row 3
+  assign data_o[3] = (mode_i == AES_ENC) ? aes_circ_byte_shift(data_i[3],  1)
+                                         : aes_circ_byte_shift(data_i[3], -1);
 
 endmodule

--- a/hw/ip/aes/rtl/aes_sub_bytes.sv
+++ b/hw/ip/aes/rtl/aes_sub_bytes.sv
@@ -5,18 +5,20 @@
 // AES SubBytes
 
 module aes_sub_bytes (
-  input  aes_pkg::mode_e mode_i,
-  input  logic [7:0]     data_i [16],
-  output logic [7:0]     data_o [16]
+  input  aes_pkg::mode_e       mode_i,
+  input  logic [3:0][3:0][7:0] data_i,
+  output logic [3:0][3:0][7:0] data_o
 );
 
   // Individually substitute bytes
-  for (genvar i = 0; i < 16; i++) begin : gen_sbox
-    aes_sbox_lut aes_sbox_i (
-      .mode_i ( mode_i    ),
-      .data_i ( data_i[i] ),
-      .data_o ( data_o[i] )
-    );
+  for (genvar j = 0; j < 4; j++) begin : gen_sbox_j
+    for (genvar i = 0; i < 4; i++) begin : gen_sbox_i
+      aes_sbox_lut aes_sbox_ij (
+        .mode_i ( mode_i       ),
+        .data_i ( data_i[i][j] ),
+        .data_o ( data_o[i][j] )
+      );
+    end
   end
 
 endmodule


### PR DESCRIPTION
This PR switches the types of both data and key signals from unpacked to packed array types, and replaces some rather trivial wiring logic by function calls.

I successfully tested the RTL as well as the DPI calls using my Verilator test framwork.

This PR replaces the old WIP PR #471 (I cannot update the old one as it is from before opening the repo).

