### PR TITLE
[build] Move sw/device-specific definitions to sw/device/meson.build.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -46,22 +46,6 @@ prog_objcopy = find_program('objcopy')
 prog_srec_cat = find_program('srec_cat')
 prog_git = find_program('git')
 
-# RISCV linker parameters.
-riscv_linkfile = files(['sw/device/exts/common/link.ld'])
-# Ensure we don't include a build-id in the elf
-riscv_link_args = ['-Wl,-T,@0@/@1@'.format(meson.source_root(), riscv_linkfile[0]), '-Wl,--build-id=none']
-riscv_link_deps = [riscv_linkfile]
-
-# RISCV CRT parameters
-startup_files = files(['sw/device/exts/common/_crt.c'])
-
-# Additional arguments for utility in charge of generating bin and vmem outputs
-# These variables are expected to be used in custom_target rules.
-embedded_target_output = ['@BASENAME@.bin', '@BASENAME@.dis', '@BASENAME@.vmem']
-embedded_target_args = [prog_python, meson.source_root() + '/util/embedded_target.py',
-  '--objcopy', prog_objcopy, '--srec_cat', prog_srec_cat, '--objdump', prog_objdump,
-  '--input', '@INPUT@', '--basename', '@BASENAME@', '--outdir', '@OUTDIR@']
-
 # Hardware register headers. These are generated from HJSON files, and accesible
 # in C via |#include "{IP_NAME}_regs.h"|.
 gen_hw_hdr = generator(

--- a/sw/device/boot_rom/meson.build
+++ b/sw/device/boot_rom/meson.build
@@ -17,10 +17,11 @@ rom_link_deps = [rom_linkfile]
 
 custom_target(
   'boot_rom',
-  output: embedded_target_output,
+  command: make_embedded_target,
+  output: make_embedded_target_outputs,
   input: executable(
     'boot_rom',
-    [
+    sources: [
       chip_info_h,
       'boot_rom.c',
       'bootstrap.c',
@@ -39,6 +40,4 @@ custom_target(
       sw_lib_log,
     ],
   ),
-  command: embedded_target_args,
-  build_by_default: true,
 )

--- a/sw/device/examples/hello_usbdev/meson.build
+++ b/sw/device/examples/hello_usbdev/meson.build
@@ -4,20 +4,18 @@
 
 custom_target(
   'hello_usbdev',
-  output: embedded_target_output,
+  command: make_embedded_target,
+  output: make_embedded_target_outputs,
   input: executable(
     'hello_usbdev',
-    ['hello_usbdev.c', startup_files],
+    sources: ['hello_usbdev.c'],
     name_suffix: 'elf',
-    link_args: riscv_link_args,
-    link_depends: riscv_link_deps,
     dependencies: [
       sw_lib_gpio,
       sw_lib_irq,
       sw_lib_uart,
       sw_lib_usb,
+      riscv_crt,
     ],
   ),
-  command: embedded_target_args,
-  build_by_default: true,
 )

--- a/sw/device/examples/hello_world/meson.build
+++ b/sw/device/examples/hello_world/meson.build
@@ -3,22 +3,20 @@
 # SPDX-License-Identifier: Apache-2.0
 
 custom_target(
-  'hello_world',
-  output: embedded_target_output,
+  'hello_world',  
+  command: make_embedded_target,
+  output: make_embedded_target_outputs,
   input: executable(
     'hello_world',
-    ['hello_world.c', startup_files],
+    sources: ['hello_world.c',],
     name_suffix: 'elf',
-    link_args: riscv_link_args,
-    link_depends: riscv_link_deps,
     dependencies: [
       sw_lib_pinmux,
       sw_lib_gpio,
       sw_lib_irq,
       sw_lib_spi_device,
       sw_lib_uart,
+      riscv_crt,
     ],
   ),
-  command: embedded_target_args,
-  build_by_default: true,
 )

--- a/sw/device/exts/common/meson.build
+++ b/sw/device/exts/common/meson.build
@@ -1,0 +1,23 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# RISC-V linker parameters.
+riscv_linker_script = '@0@/@1@'.format(meson.source_root(), files(['link.ld'])[0])
+riscv_linker_args = [
+  '-Wl,-T,@0@'.format(riscv_linker_script),
+  # Ensure we don't include a build-id attribute in the ELF.
+  '-Wl,--build-id=none',
+]
+
+# RISC-V startup library. Every RISC-V executable should depend on this target.
+riscv_crt = declare_dependency(
+  link_args: riscv_linker_args,
+  link_with: static_library(
+    'riscv_crt',
+    sources: ['_crt.c'],
+    # NOTE: This line is mostly to make sure that a change in link.ld causes a
+    # recompilation.
+    link_depends: [riscv_linker_script],
+  ),
+)

--- a/sw/device/exts/meson.build
+++ b/sw/device/exts/meson.build
@@ -1,0 +1,5 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+subdir('common')

--- a/sw/device/meson.build
+++ b/sw/device/meson.build
@@ -3,6 +3,22 @@
 # SPDX-License-Identifier: Apache-2.0
 
 subdir('lib')
+subdir('exts')
+
+# Arguments for custom_target, for converting a linked .elf file into .bin and .vmem
+# files (plus a disassembled .dis file).
+#
+# These definitions should only be available to directories which define executables.
+make_embedded_target_outputs = ['@BASENAME@.bin', '@BASENAME@.dis', '@BASENAME@.vmem']
+make_embedded_target = [
+  prog_python, meson.source_root() + '/util/embedded_target.py',
+  '--objcopy', prog_objcopy,
+  '--srec_cat', prog_srec_cat,
+  '--objdump', prog_objdump,
+  '--input', '@INPUT@',
+  '--basename', '@BASENAME@',
+  '--outdir', '@OUTDIR@',
+]
 
 subdir('boot_rom')
 subdir('examples')

--- a/sw/device/tests/flash_ctrl/meson.build
+++ b/sw/device/tests/flash_ctrl/meson.build
@@ -4,20 +4,18 @@
 
 custom_target(
   'flash_test',
-  output: embedded_target_output,
+  command: make_embedded_target,
+  output: make_embedded_target_outputs,
   input: executable(
     'flash_test',
-    ['flash_test.c', startup_files],
+    sources: ['flash_test.c'],
     name_suffix: 'elf',
-    link_args: riscv_link_args,
-    link_depends: riscv_link_deps,
     dependencies: [
       sw_lib_flash_ctrl,
       sw_lib_gpio,
       sw_lib_irq,
       sw_lib_uart,
+      riscv_crt,
     ],
   ),
-  command: embedded_target_args,
-  build_by_default: true,
 )

--- a/sw/device/tests/hmac/meson.build
+++ b/sw/device/tests/hmac/meson.build
@@ -4,20 +4,18 @@
 
 custom_target(
   'sha256_test',
-  output: embedded_target_output,
+  command: make_embedded_target,
+  output: make_embedded_target_outputs,
   input: executable(
     'sha256_test',
-    ['sha256_test.c', startup_files],
+    sources: ['sha256_test.c'],
     name_suffix: 'elf',
-    link_args: riscv_link_args,
-    link_depends: riscv_link_deps,
     dependencies: [
       sw_lib_flash_ctrl,
       sw_lib_hmac,
       sw_lib_irq,
       sw_lib_uart,
+      riscv_crt,
     ],
   ),
-  command: embedded_target_args,
-  build_by_default: true,
 )

--- a/sw/device/tests/rv_timer/meson.build
+++ b/sw/device/tests/rv_timer/meson.build
@@ -4,19 +4,17 @@
 
 custom_target(
   'rv_timer_test',
-  output: embedded_target_output,
+  command: make_embedded_target,
+  output: make_embedded_target_outputs,
   input: executable(
     'rv_timer_test',
-    ['rv_timer_test.c', startup_files],
+    sources: ['rv_timer_test.c'],
     name_suffix: 'elf',
-    link_args: riscv_link_args,
-    link_depends: riscv_link_deps,
     dependencies: [
       sw_lib_irq,
       sw_lib_rv_timer,
       sw_lib_uart,
+      riscv_crt,
     ],
   ),
-  command: embedded_target_args,
-  build_by_default: true,
 )

--- a/sw/host/spiflash/meson.build
+++ b/sw/host/spiflash/meson.build
@@ -4,7 +4,7 @@
 
 executable(
   'spiflash',
-  [
+  sources: [
     'ftdi_spi_interface.cc',
     'spiflash.cc',
     'updater.cc',

--- a/sw/host/vendor/meson.build
+++ b/sw/host/vendor/meson.build
@@ -6,9 +6,12 @@ libmpsse = declare_dependency(
   link_with: static_library(
     'mpsse',
     sources: [
-      '../vendor/mpsse/mpsse.c',
-      '../vendor/mpsse/support.c'
+      'mpsse/mpsse.c',
+      'mpsse/support.c'
     ],
+    # libmpsse is vendored in, and as such does not conform to our include
+    # requirements. This -I argument allows libmpsse to use its existing
+    # includes.
     c_args: [
       '-I' + meson.source_root() + '/sw/host/vendor/mpsse'
     ],


### PR DESCRIPTION
Right now there's a pile of device-executable-linking stuff in the root build file. I've moved the linking and startup definitions into sw/device/ext/common, and made crt a real library that automatically causes everything to link correctly.

The arguments for embedded_target.py have been moved into sw/device.

This refactor should be completely transparent to users. Since only Meson files were affected, Make does not need any updating.