### PR TITLE
[util] splice_nexysvideo.sh fix the target directory

### DIFF
--- a/util/fpga/splice_nexysvideo.sh
+++ b/util/fpga/splice_nexysvideo.sh
@@ -17,20 +17,21 @@ set -e
 . util/build_consts.sh
 
 BUILD_DIR="$(sw_obj_dir fpga)"
-TARGET_PREFIX="/sw/device/boot_rom/boot_rom"
+TARGET_PREFIX="sw/device/boot_rom/boot_rom"
+TARGET="${BUILD_DIR}/${TARGET_PREFIX}"
 FPGA_BUILD_DIR=build/lowrisc_systems_top_earlgrey_nexysvideo_0.1/synth-vivado/
 FPGA_BIT_NAME=lowrisc_systems_top_earlgrey_nexysvideo_0.1
 
 ./meson_init.sh -f
-ninja -C "$BUILD_DIR" sw/device/boot_rom/boot_rom.bin
+ninja -C "$BUILD_DIR" "${TARGET_PREFIX}.bin"
 
-srec_cat ${TARGET_PREFIX}.bin -binary -offset 0x0 -o ${TARGET_PREFIX}.brammem \
+srec_cat "${TARGET}.bin" -binary -offset 0x0 -o "${TARGET}.brammem" \
   -vmem -Output_Block_Size 4;
 
-util/fpga/addr4x.py -i ${TARGET_PREFIX}.brammem -o ${TARGET_PREFIX}.mem
+util/fpga/addr4x.py -i "${TARGET}.brammem" -o "${TARGET}.mem"
 
 updatemem -force --meminfo util/fpga/bram_load.mmi \
-  --data ${TARGET_PREFIX}.mem \
+  --data "${TARGET}.mem" \
   --bit "${FPGA_BUILD_DIR}/${FPGA_BIT_NAME}.bit"  --proc dummy \
   --out "${FPGA_BUILD_DIR}/${FPGA_BIT_NAME}.splice.bit"
 


### PR DESCRIPTION
This change fixes an issue introduced in 6379357. When running, script
cannot find required target files due to not specifying the full path
to these files.

Signed-off-by: Silvestrs Timofejevs <silvestrst@lowrisc.org>