### PR TITLE
[prim_lfsr] Add external seed input

### DIFF
--- a/hw/ip/alert_handler/rtl/alert_handler_ping_timer.sv
+++ b/hw/ip/alert_handler/rtl/alert_handler_ping_timer.sv
@@ -55,16 +55,18 @@ module alert_handler_ping_timer (
   logic [31:0] lfsr_state, perm_state;
 
   prim_lfsr #(
-    .LfsrDw ( 32                  ),
-    .InDw   ( 1                   ),
-    .OutDw  ( 32                  ),
-    .Seed   ( alert_pkg::LfsrSeed )
+    .LfsrDw      ( 32                  ),
+    .EntropyDw   ( 1                   ),
+    .StateOutDw  ( 32                  ),
+    .DefaultSeed ( alert_pkg::LfsrSeed )
   ) i_prim_lfsr (
     .clk_i,
     .rst_ni,
-    .en_i   ( lfsr_en    ),
-    .data_i ( entropy_i  ),
-    .data_o ( lfsr_state )
+    .seed_en_i  ( 1'b0       ),
+    .seed_i     ( '0         ),
+    .lfsr_en_i  ( lfsr_en    ),
+    .entropy_i,
+    .state_o    ( lfsr_state )
   );
 
   for (genvar k = 0; k < 32; k++) begin : gen_perm

--- a/hw/ip/prim/dv/prim_lfsr_sim.core
+++ b/hw/ip/prim/dv/prim_lfsr_sim.core
@@ -16,6 +16,7 @@ filesets:
       - lowrisc:dv:common_ifs
     files:
       - tb/prim_lfsr_tb.sv
+      - tb/prim_lfsr_bind.sv
     file_type: systemVerilogSource
 
 targets:

--- a/hw/ip/prim/dv/tb/prim_lfsr_bind.sv
+++ b/hw/ip/prim/dv/tb/prim_lfsr_bind.sv
@@ -1,0 +1,9 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+module prim_lfsr_bind;
+
+  // nothing to bind here yet
+
+endmodule : prim_lfsr_bind

--- a/hw/ip/prim/fpv/tb/prim_lfsr_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_lfsr_fpv.sv
@@ -5,59 +5,70 @@
 // Testbench module for prim_lfsr. Intended to be used with a formal tool.
 
 module prim_lfsr_fpv #(
-  parameter int unsigned   InDw     = 1,
-  parameter int unsigned   OutDw    = 1,
-  parameter int unsigned   GalXorMinLfsrDw  = 4,
-  parameter int unsigned   GalXorMaxLfsrDw  = 64,
-  parameter int unsigned   FibXnorMinLfsrDw = 3,
-  parameter int unsigned   FibXnorMaxLfsrDw = 168,
-  parameter int unsigned   NumDuts  = FibXnorMaxLfsrDw - FibXnorMinLfsrDw + 1 +
-                                      GalXorMaxLfsrDw  - GalXorMinLfsrDw  + 1,
+  // LFSR entropy and output bitwidths (set to 1 here as they are unused)
+  parameter int unsigned EntropyDw        = 1,
+  parameter int unsigned StateOutDw       = 1,
+  // this specifies the range of differently
+  // parameterized LFSRs to instantiate and check
+  parameter int unsigned GalXorMinLfsrDw  = 4,
+  parameter int unsigned GalXorMaxLfsrDw  = 64,
+  parameter int unsigned FibXnorMinLfsrDw = 3,
+  parameter int unsigned FibXnorMaxLfsrDw = 168,
   // LFSRs up to this bitwidth are checked for maximum length
-  parameter int unsigned   MaxLenSVAThresh = 10
+  parameter int unsigned MaxLenSVAThresh  = 10,
+  // derived params
+  localparam int unsigned GalMaxGtFibMax  = GalXorMaxLfsrDw > FibXnorMaxLfsrDw,
+  localparam int unsigned MaxLfsrDw       = GalXorMaxLfsrDw * GalMaxGtFibMax +
+                                            FibXnorMaxLfsrDw * (1 - GalMaxGtFibMax),
+  localparam int unsigned NumDuts         = FibXnorMaxLfsrDw - FibXnorMinLfsrDw + 1 +
+                                            GalXorMaxLfsrDw - GalXorMinLfsrDw + 1
 ) (
-  input                                 clk_i,
-  input                                 rst_ni,
-  input        [NumDuts-1:0]            en_i,
-  input        [NumDuts-1:0][InDw-1:0]  data_i,
-  output logic [NumDuts-1:0][OutDw-1:0] data_o
+  input                                      clk_i,
+  input                                      rst_ni,
+  input [NumDuts-1:0]                        load_ext_en_i,
+  input [NumDuts-1:0][MaxLfsrDw-1:0]         seed_ext_i,
+  input [NumDuts-1:0]                        lfsr_en_i,
+  input [NumDuts-1:0][EntropyDw-1:0]         entropy_i,
+  output logic [NumDuts-1:0][StateOutDw-1:0] state_o
 );
 
   for (genvar k = GalXorMinLfsrDw; k <= GalXorMaxLfsrDw; k++) begin : gen_gal_xor_duts
-    prim_lfsr #(
-      .LfsrType("GAL_XOR"),
-      .LfsrDw(k),
-      .InDw(InDw),
-      .OutDw(OutDw),
-      .Seed(1),
-      .Custom('0),
+    localparam int unsigned idx = k - GalXorMinLfsrDw;
+    prim_lfsr #(.LfsrType("GAL_XOR"),
+      .LfsrDw      ( k          ),
+      .EntropyDw   ( EntropyDw  ),
+      .StateOutDw  ( StateOutDw ),
+      .DefaultSeed ( 1          ),
       // disabled for large LFSRs since this becomes prohibitive in runtime
-      .MaxLenSVA(k <= MaxLenSVAThresh)
+      .MaxLenSVA   ( k <= MaxLenSVAThresh )
     ) i_prim_lfsr (
       .clk_i,
       .rst_ni,
-      .en_i(en_i[k-GalXorMinLfsrDw]),
-      .data_i(data_i[k-GalXorMinLfsrDw]),
-      .data_o(data_o[k-GalXorMinLfsrDw])
+      .seed_en_i ( load_ext_en_i[idx]  ),
+      .seed_i    ( k'(seed_ext_i[idx]) ),
+      .lfsr_en_i ( lfsr_en_i[idx]      ),
+      .entropy_i ( entropy_i[idx]      ),
+      .state_o   ( state_o[idx]        )
     );
   end
 
   for (genvar k = FibXnorMinLfsrDw; k <= FibXnorMaxLfsrDw; k++) begin : gen_fib_xnor_duts
-    prim_lfsr #(
-      .LfsrType("FIB_XNOR"),
-      .LfsrDw(k),
-      .InDw(InDw),
-      .OutDw(OutDw),
-      .Seed(1),
-      .Custom('0),
+    localparam int unsigned idx = k - FibXnorMinLfsrDw + GalXorMaxLfsrDw - GalXorMinLfsrDw + 1;
+    prim_lfsr #(.LfsrType("FIB_XNOR"),
+      .LfsrDw      ( k          ),
+      .EntropyDw   ( EntropyDw  ),
+      .StateOutDw  ( StateOutDw ),
+      .DefaultSeed ( 1          ),
       // disabled for large LFSRs since this becomes prohibitive in runtime
-      .MaxLenSVA(k <= MaxLenSVAThresh)
+      .MaxLenSVA   ( k <= MaxLenSVAThresh )
     ) i_prim_lfsr (
       .clk_i,
       .rst_ni,
-      .en_i(en_i[k - FibXnorMinLfsrDw + GalXorMaxLfsrDw - GalXorMinLfsrDw + 1]),
-      .data_i(data_i[k - FibXnorMinLfsrDw + GalXorMaxLfsrDw - GalXorMinLfsrDw + 1]),
-      .data_o(data_o[k - FibXnorMinLfsrDw + GalXorMaxLfsrDw - GalXorMinLfsrDw + 1])
+      .seed_en_i ( load_ext_en_i[idx]  ),
+      .seed_i    ( k'(seed_ext_i[idx]) ),
+      .lfsr_en_i ( lfsr_en_i[idx]      ),
+      .entropy_i ( entropy_i[idx]      ),
+      .state_o   ( state_o[idx]        )
     );
   end
 


### PR DESCRIPTION
This adds an external seed input that allows to load a new LFSR seed at runtime, as requested in https://github.com/lowRISC/opentitan/issues/913. If the seed input value leads to a lockup condition, the LFSR will be reseeded to the default seed (provided as a design time parameter) in the subsequent cycle. Note that loading an external seed value takes precedence over internal state updates.

I adapted the FPV and DV testbenches, and both pass.

