### PR TITLE
[dv/common] Add descrption for reset seq

### DIFF
--- a/hw/dv/sv/cip_lib/doc/index.md
+++ b/hw/dv/sv/cip_lib/doc/index.md
@@ -189,6 +189,19 @@ Some examples:
 * **task cfg_interrupts, check_interrupts**: All interrupt CSRs are standardized
   according to the comportability spec, which allows us to create common tasks
   to turn on / off interrupts as well as check them.
+* **task run_stress_all_with_rand_reset_vseq**: This is a common virtual
+  sequence based on the stress_all virtual sequence. This virtual sequence
+  will randomly reset the stress_all sequence, then it will check if all
+  the readable registers are reset to the correct value.
+  To ensure the reset functionality works correctly, user will have to disable
+  any internal reset from the stress_all sequence. Below is an example of
+  disabling internal reset in `hmac_stress_all_vseq.sv`:
+  ```
+  // randomly trigger internal dut_init reset sequence
+  // disable any internal reset if used in stress_all_with_rand_reset vseq
+  if (do_dut_init) hmac_vseq.do_dut_init = $urandom_range(0, 1);
+  else hmac_vseq.do_dut_init = 0;
+  ```
 
 This class is type parameterized with the env cfg class type `CFG_T`, ral class type
 `RAL_T` and the virtual sequencer class type `VIRTUAL_SEQUENCER_T` so that the

--- a/hw/dv/tools/testplans/stress_all_with_reset_testplan.hjson
+++ b/hw/dv/tools/testplans/stress_all_with_reset_testplan.hjson
@@ -1,0 +1,14 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  entries: [
+    {
+      name: stress_all_with_rand_reset
+      desc: '''This test insert random reset during the stress_all test. After reset is asserted,
+            the test will read and check all valid CSR registers.'''
+      milestone: V2
+      tests: ["{name}_stress_all_with_rand_reset"]
+    }
+  ]
+}

--- a/hw/ip/hmac/data/hmac_testplan.hjson
+++ b/hw/ip/hmac/data/hmac_testplan.hjson
@@ -2,6 +2,7 @@
   name: "hmac"
   import_testplans: ["hw/dv/tools/testplans/csr_testplan.hjson",
                      "hw/dv/tools/testplans/intr_test_testplan.hjson",
+                     "hw/dv/tools/testplans/stress_all_with_reset_testplan.hjson",
                      "hw/dv/tools/testplans/tl_device_access_types_testplan.hjson"]
   entries: [
     {
@@ -63,13 +64,6 @@
       desc: "Stress_all test is a random mix of all the test above except csr tests."
       milestone: V2
       tests: ["hmac_stress_all"]
-    }
-    {
-      name: stress_all_with_rand_reset
-      desc: '''Reset test insert random reset during the stress_all test. After reset is asserted,
-            the test will read and check all valid CSR registers.'''
-      milestone: V2
-      tests: ["hmac_stress_all_with_rand_reset"]
     }
     {
       name: write_config_and_secret_key_during_msg_wr


### PR DESCRIPTION
Add brief description for stress_all_with_rand_reset vseq in
cip_base_vseq
Add stress_all_with_rand_reset to common testplan

Signed-off-by: Cindy Chen <chencindy@google.com>