### PR TITLE
[aes] Rework register interface

### DIFF
--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -88,10 +88,14 @@
 ##############################################################################
 # control and status registers
   { name: "CTRL",
-    desc: "Control Register",
+    desc: '''
+      Control Register. Can only be updated when the AES unit is idle. If the
+      AES unit is non-idle, writes to this register are ignored.
+    '''
     swaccess: "rw",
     hwaccess: "hro",
-    hwqe: "true",
+    hwext:    "true",
+    hwqe:     "true",
     fields: [
       { bits: "0",
         name: "MODE",

--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -36,7 +36,7 @@
       count: "NumRegsKey",
       cname: "KEY",
       swaccess: "wo",
-      hwaccess: "hro",
+      hwaccess: "hrw",
       hwqe:     "true",
       fields: [
         { bits: "31:0", name: "key", desc: "Initial Key" }
@@ -55,7 +55,7 @@
       count: "NumRegsData",
       cname: "DATA_IN",
       swaccess: "wo",
-      hwaccess: "hro",
+      hwaccess: "hrw",
       hwqe:     "true",
       fields: [
         { bits: "31:0", name: "data_in", desc: "Input Data" }
@@ -140,11 +140,17 @@
       { bits: "1",
         name: "KEY_CLEAR",
         desc:  '''
-          Keep current values in internal Full Key and Decryption Key registers (0) or clear
-          those registers (1).
+          Keep current values in Initial Key, internal Full Key and Decryption Key registers (0)
+          or clear those registers (1).
         '''
       }
       { bits: "2",
+        name: "DATA_IN_CLEAR",
+        desc:  '''
+          Keep current values in input registers (0) or clear those registers (1).
+        '''
+      }
+      { bits: "3",
         name: "DATA_OUT_CLEAR",
         desc:  '''
           Keep current values in output registers (0) or clear those registers (1).

--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -30,13 +30,15 @@
       desc: '''
         Initial Key Registers. Loaded into the internal Full Key register upon
         starting encryption/decryption of the next block. Can only be updated
-        when the AES unit is idle. All keys registers must be updated when the
+        when the AES unit is idle. If the AES unit is non-idle, writes to these
+        registers are ignored. All key registers must be updated when the
         key is changed, regardless of key length (write 0 for unusued bits).
       '''
       count: "NumRegsKey",
       cname: "KEY",
       swaccess: "wo",
       hwaccess: "hrw",
+      hwext:    "true",
       hwqe:     "true",
       fields: [
         { bits: "31:0", name: "key", desc: "Initial Key" }

--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -134,7 +134,7 @@
   },
   { name: "TRIGGER",
     desc: "Trigger Register",
-    swaccess: "rw",
+    swaccess: "wo",
     hwaccess: "hrw",
     fields: [
       { bits: "0",

--- a/hw/ip/aes/doc/_index.md
+++ b/hw/ip/aes/doc/_index.md
@@ -336,9 +336,7 @@ The code snippet below shows how to perform block operation.
 
 After finishing operation, software must:
 1. Disable the AES unit to no longer automatically start encryption/decryption by setting the MANUAL_START_TRIGGER bit in {{< regref "CTRL" >}} to `1`.
-2. Clear the configured initial key by overwriting the Initial Key registers {{< regref "KEY0" >}} - {{< regref "KEY7" >}}.
-3. Clear the previous input data by overwriting the Input Data registers {{< regref "DATA_IN0" >}} - {{< regref "DATA_IN3" >}}.
-4. Clear the internal key registers and the Output Data register by setting the KEY_CLEAR and DATA_OUT_CLEAR bits in {{< regref "TRIGGER" >}} to `1`.
+1. Clear all key registers as well as the Input Data and the Output Data registers by setting the KEY_CLEAR, DATA_IN_CLEAR and DATA_OUT_CLEAR bits in {{< regref "TRIGGER" >}} to `1`.
 
 The code snippet below shows how to perform this task.
 
@@ -346,22 +344,12 @@ The code snippet below shows how to perform this task.
   // Disable autostart
   REG32(AES_CTRL(0)) = 0x1 << AES_CTRL_MANUAL_START_TRIGGER;
 
-  // Clear Initial Key registers
-  for (int i = 0; i < 8; i++) {
-    REG32(AES_KEY0(0) + i * 4) = 0x0;
-  }
-
-  // Clear Input Data registers
-  for (int i = 0; i < 4; i++) {
-    REG32(AES_DATA_IN0(0) + i * 4) = 0x0;
-  }
-
-  // Clear internal key and Output Data registers
+  // Clear all key register, Input Data and Output Data registers
   REG32(AES_TRIGGER(0)) =
-      (0x1 << AES_TRIGGER_KEY_CLEAR) | (0x1 << AES_TRIGGER_DATA_OUT_CLEAR);
+      (0x1 << AES_TRIGGER_KEY_CLEAR) |
+      (0x1 << AES_TRIGGER_DATA_IN_CLEAR) |
+      (0x1 << AES_TRIGGER_DATA_OUT_CLEAR);
 ```
-
-Note that in future versions of the AES unit, also the Initial Key registers {{< regref "KEY0" >}} - {{< regref "KEY7" >}} and the Input Data registers {{< regref "DATA_IN0" >}} - {{< regref "DATA_IN3" >}} can be cleared using {{< regref "TRIGGER" >}}.
 
 
 ## Register Table

--- a/hw/ip/aes/rtl/aes_control.sv
+++ b/hw/ip/aes/rtl/aes_control.sv
@@ -13,8 +13,8 @@ module aes_control #(
   // Main control inputs
   input  aes_pkg::mode_e          mode_i,
   input  aes_pkg::key_len_e       key_len_i,
-  input  logic                    force_data_overwrite_i,
   input  logic                    manual_start_trigger_i,
+  input  logic                    force_data_overwrite_i,
   input  logic                    start_i,
   input  logic                    key_clear_i,
   input  logic                    data_in_clear_i,

--- a/hw/ip/aes/rtl/aes_core.sv
+++ b/hw/ip/aes/rtl/aes_core.sv
@@ -21,6 +21,8 @@ module aes_core #(
   // Signals
   logic     [3:0][31:0] data_in;
   logic     [3:0]       data_in_qe;
+  logic                 data_in_we;
+  logic                 key_we;
   logic     [7:0][31:0] key_init;
   logic     [7:0]       key_init_qe;
 
@@ -278,6 +280,7 @@ module aes_core #(
     .manual_start_trigger_i ( reg2hw.ctrl.manual_start_trigger.q ),
     .start_i                ( reg2hw.trigger.start.q             ),
     .key_clear_i            ( reg2hw.trigger.key_clear.q         ),
+    .data_in_clear_i        ( reg2hw.trigger.data_in_clear.q     ),
     .data_out_clear_i       ( reg2hw.trigger.data_out_clear.q    ),
 
     .data_in_qe_i           ( data_in_qe                         ),
@@ -298,14 +301,19 @@ module aes_core #(
     .key_words_sel_o        ( key_words_sel                      ),
     .round_key_sel_o        ( round_key_sel                      ),
 
+    .key_we_o               ( key_we                             ),
+    .data_in_we_o           ( data_in_we                         ),
     .data_out_we_o          ( data_out_we                        ),
 
     .start_o                ( hw2reg.trigger.start.d             ),
     .start_we_o             ( hw2reg.trigger.start.de            ),
     .key_clear_o            ( hw2reg.trigger.key_clear.d         ),
     .key_clear_we_o         ( hw2reg.trigger.key_clear.de        ),
+    .data_in_clear_o        ( hw2reg.trigger.data_in_clear.d     ),
+    .data_in_clear_we_o     ( hw2reg.trigger.data_in_clear.de    ),
     .data_out_clear_o       ( hw2reg.trigger.data_out_clear.d    ),
     .data_out_clear_we_o    ( hw2reg.trigger.data_out_clear.de   ),
+
     .output_valid_o         ( hw2reg.status.output_valid.d       ),
     .output_valid_we_o      ( hw2reg.status.output_valid.de      ),
     .input_ready_o          ( hw2reg.status.input_ready.d        ),
@@ -315,6 +323,21 @@ module aes_core #(
     .stall_o                ( hw2reg.status.stall.d              ),
     .stall_we_o             ( hw2reg.status.stall.de             )
   );
+
+  // Key and input data register clear
+  always_comb begin : key_reg_clear
+    for (int i=0; i<8; i++) begin
+      hw2reg.key[i].d  = '0;
+      hw2reg.key[i].de = key_we;
+    end
+  end
+
+  always_comb begin : data_in_reg_clear
+    for (int i=0; i<4; i++) begin
+      hw2reg.data_in[i].d  = '0;
+      hw2reg.data_in[i].de = data_in_we;
+    end
+  end
 
   /////////////
   // Outputs //

--- a/hw/ip/aes/rtl/aes_pkg.sv
+++ b/hw/ip/aes/rtl/aes_pkg.sv
@@ -29,6 +29,11 @@ typedef enum logic [1:0] {
   ADD_RK_FINAL
 } add_rk_sel_e;
 
+typedef enum logic {
+  KEY_INIT_INPUT,
+  KEY_INIT_CLEAR
+} key_init_sel_e;
+
 typedef enum logic [1:0] {
   KEY_FULL_ENC_INIT,
   KEY_FULL_DEC_INIT,

--- a/hw/ip/aes/rtl/aes_reg_pkg.sv
+++ b/hw/ip/aes/rtl/aes_reg_pkg.sv
@@ -79,7 +79,6 @@ package aes_reg_pkg;
   typedef struct packed {
     struct packed {
       logic [2:0]  d;
-      logic        de;
     } key_len;
   } aes_hw2reg_ctrl_reg_t;
 
@@ -137,12 +136,12 @@ package aes_reg_pkg;
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    aes_hw2reg_key_mreg_t [7:0] key; // [535:280]
-    aes_hw2reg_data_in_mreg_t [3:0] data_in; // [279:148]
-    aes_hw2reg_data_out_mreg_t [3:0] data_out; // [147:20]
-    aes_hw2reg_ctrl_reg_t ctrl; // [19:10]
-    aes_hw2reg_trigger_reg_t trigger; // [9:6]
-    aes_hw2reg_status_reg_t status; // [5:6]
+    aes_hw2reg_key_mreg_t [7:0] key; // [534:279]
+    aes_hw2reg_data_in_mreg_t [3:0] data_in; // [278:147]
+    aes_hw2reg_data_out_mreg_t [3:0] data_out; // [146:19]
+    aes_hw2reg_ctrl_reg_t ctrl; // [18:9]
+    aes_hw2reg_trigger_reg_t trigger; // [8:5]
+    aes_hw2reg_status_reg_t status; // [4:5]
   } aes_hw2reg_t;
 
   // Register Address

--- a/hw/ip/aes/rtl/aes_reg_pkg.sv
+++ b/hw/ip/aes/rtl/aes_reg_pkg.sv
@@ -10,111 +10,122 @@ package aes_reg_pkg;
   localparam int NumRegsKey = 8;
   localparam int NumRegsData = 4;
 
-/////////////////////////////////////////////////////////////////////
-// Typedefs for multiregs
-/////////////////////////////////////////////////////////////////////
+  ////////////////////////////
+  // Typedefs for registers //
+  ////////////////////////////
+  typedef struct packed {
+    logic [31:0] q;
+    logic        qe;
+  } aes_reg2hw_key_mreg_t;
 
-typedef struct packed {
-  logic [31:0] q;
-  logic qe;
-} aes_reg2hw_key_mreg_t;
-typedef struct packed {
-  logic [31:0] q;
-  logic qe;
-} aes_reg2hw_data_in_mreg_t;
-typedef struct packed {
-  logic [31:0] q;
-  logic re;
-} aes_reg2hw_data_out_mreg_t;
+  typedef struct packed {
+    logic [31:0] q;
+    logic        qe;
+  } aes_reg2hw_data_in_mreg_t;
 
-typedef struct packed {
-  logic [31:0] d;
-} aes_hw2reg_data_out_mreg_t;
+  typedef struct packed {
+    logic [31:0] q;
+    logic        re;
+  } aes_reg2hw_data_out_mreg_t;
 
-/////////////////////////////////////////////////////////////////////
-// Register to internal design logic
-/////////////////////////////////////////////////////////////////////
-
-typedef struct packed {
-  aes_reg2hw_key_mreg_t [7:0] key; // [540:277]
-  aes_reg2hw_data_in_mreg_t [3:0] data_in; // [276:145]
-  aes_reg2hw_data_out_mreg_t [3:0] data_out; // [144:13]
-  struct packed {
+  typedef struct packed {
     struct packed {
-      logic q; // [12]
-      logic qe; // [11]
+      logic        q;
+      logic        qe;
     } mode;
     struct packed {
-      logic [2:0] q; // [10:8]
-      logic qe; // [7]
+      logic [2:0]  q;
+      logic        qe;
     } key_len;
     struct packed {
-      logic q; // [6]
-      logic qe; // [5]
+      logic        q;
+      logic        qe;
     } manual_start_trigger;
     struct packed {
-      logic q; // [4]
-      logic qe; // [3]
+      logic        q;
+      logic        qe;
     } force_data_overwrite;
-  } ctrl;
-  struct packed {
+  } aes_reg2hw_ctrl_reg_t;
+
+  typedef struct packed {
     struct packed {
-      logic q; // [2]
+      logic        q;
     } start;
     struct packed {
-      logic q; // [1]
+      logic        q;
     } key_clear;
     struct packed {
-      logic q; // [0]
+      logic        q;
     } data_out_clear;
-  } trigger;
-} aes_reg2hw_t;
+  } aes_reg2hw_trigger_reg_t;
 
-/////////////////////////////////////////////////////////////////////
-// Internal design logic to register
-/////////////////////////////////////////////////////////////////////
 
-typedef struct packed {
-  aes_hw2reg_data_out_mreg_t [3:0] data_out; // [145:18]
-  struct packed {
+  typedef struct packed {
+    logic [31:0] d;
+  } aes_hw2reg_data_out_mreg_t;
+
+  typedef struct packed {
     struct packed {
-      logic [2:0] d; // [17:15]
-      logic de; // [14]
+      logic [2:0]  d;
+      logic        de;
     } key_len;
-  } ctrl;
-  struct packed {
+  } aes_hw2reg_ctrl_reg_t;
+
+  typedef struct packed {
     struct packed {
-      logic d; // [13]
-      logic de; // [12]
+      logic        d;
+      logic        de;
     } start;
     struct packed {
-      logic d; // [11]
-      logic de; // [10]
+      logic        d;
+      logic        de;
     } key_clear;
     struct packed {
-      logic d; // [9]
-      logic de; // [8]
+      logic        d;
+      logic        de;
     } data_out_clear;
-  } trigger;
-  struct packed {
+  } aes_hw2reg_trigger_reg_t;
+
+  typedef struct packed {
     struct packed {
-      logic d; // [7]
-      logic de; // [6]
+      logic        d;
+      logic        de;
     } idle;
     struct packed {
-      logic d; // [5]
-      logic de; // [4]
+      logic        d;
+      logic        de;
     } stall;
     struct packed {
-      logic d; // [3]
-      logic de; // [2]
+      logic        d;
+      logic        de;
     } output_valid;
     struct packed {
-      logic d; // [1]
-      logic de; // [0]
+      logic        d;
+      logic        de;
     } input_ready;
-  } status;
-} aes_hw2reg_t;
+  } aes_hw2reg_status_reg_t;
+
+
+  ///////////////////////////////////////
+  // Register to internal design logic //
+  ///////////////////////////////////////
+  typedef struct packed {
+    aes_reg2hw_key_mreg_t [7:0] key; // [540:277]
+    aes_reg2hw_data_in_mreg_t [3:0] data_in; // [276:145]
+    aes_reg2hw_data_out_mreg_t [3:0] data_out; // [144:13]
+    aes_reg2hw_ctrl_reg_t ctrl; // [12:3]
+    aes_reg2hw_trigger_reg_t trigger; // [2:0]
+  } aes_reg2hw_t;
+
+  ///////////////////////////////////////
+  // Internal design logic to register //
+  ///////////////////////////////////////
+  typedef struct packed {
+    aes_hw2reg_data_out_mreg_t [3:0] data_out; // [145:18]
+    aes_hw2reg_ctrl_reg_t ctrl; // [17:8]
+    aes_hw2reg_trigger_reg_t trigger; // [7:5]
+    aes_hw2reg_status_reg_t status; // [4:5]
+  } aes_hw2reg_t;
 
   // Register Address
   parameter AES_KEY0_OFFSET = 7'h 0;

--- a/hw/ip/aes/rtl/aes_reg_pkg.sv
+++ b/hw/ip/aes/rtl/aes_reg_pkg.sv
@@ -65,7 +65,6 @@ package aes_reg_pkg;
 
   typedef struct packed {
     logic [31:0] d;
-    logic        de;
   } aes_hw2reg_key_mreg_t;
 
   typedef struct packed {
@@ -138,7 +137,7 @@ package aes_reg_pkg;
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    aes_hw2reg_key_mreg_t [7:0] key; // [543:280]
+    aes_hw2reg_key_mreg_t [7:0] key; // [535:280]
     aes_hw2reg_data_in_mreg_t [3:0] data_in; // [279:148]
     aes_hw2reg_data_out_mreg_t [3:0] data_out; // [147:20]
     aes_hw2reg_ctrl_reg_t ctrl; // [19:10]

--- a/hw/ip/aes/rtl/aes_reg_pkg.sv
+++ b/hw/ip/aes/rtl/aes_reg_pkg.sv
@@ -56,9 +56,22 @@ package aes_reg_pkg;
     } key_clear;
     struct packed {
       logic        q;
+    } data_in_clear;
+    struct packed {
+      logic        q;
     } data_out_clear;
   } aes_reg2hw_trigger_reg_t;
 
+
+  typedef struct packed {
+    logic [31:0] d;
+    logic        de;
+  } aes_hw2reg_key_mreg_t;
+
+  typedef struct packed {
+    logic [31:0] d;
+    logic        de;
+  } aes_hw2reg_data_in_mreg_t;
 
   typedef struct packed {
     logic [31:0] d;
@@ -80,6 +93,10 @@ package aes_reg_pkg;
       logic        d;
       logic        de;
     } key_clear;
+    struct packed {
+      logic        d;
+      logic        de;
+    } data_in_clear;
     struct packed {
       logic        d;
       logic        de;
@@ -110,21 +127,23 @@ package aes_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    aes_reg2hw_key_mreg_t [7:0] key; // [540:277]
-    aes_reg2hw_data_in_mreg_t [3:0] data_in; // [276:145]
-    aes_reg2hw_data_out_mreg_t [3:0] data_out; // [144:13]
-    aes_reg2hw_ctrl_reg_t ctrl; // [12:3]
-    aes_reg2hw_trigger_reg_t trigger; // [2:0]
+    aes_reg2hw_key_mreg_t [7:0] key; // [541:278]
+    aes_reg2hw_data_in_mreg_t [3:0] data_in; // [277:146]
+    aes_reg2hw_data_out_mreg_t [3:0] data_out; // [145:14]
+    aes_reg2hw_ctrl_reg_t ctrl; // [13:4]
+    aes_reg2hw_trigger_reg_t trigger; // [3:0]
   } aes_reg2hw_t;
 
   ///////////////////////////////////////
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    aes_hw2reg_data_out_mreg_t [3:0] data_out; // [145:18]
-    aes_hw2reg_ctrl_reg_t ctrl; // [17:8]
-    aes_hw2reg_trigger_reg_t trigger; // [7:5]
-    aes_hw2reg_status_reg_t status; // [4:5]
+    aes_hw2reg_key_mreg_t [7:0] key; // [543:280]
+    aes_hw2reg_data_in_mreg_t [3:0] data_in; // [279:148]
+    aes_hw2reg_data_out_mreg_t [3:0] data_out; // [147:20]
+    aes_hw2reg_ctrl_reg_t ctrl; // [19:10]
+    aes_hw2reg_trigger_reg_t trigger; // [9:6]
+    aes_hw2reg_status_reg_t status; // [5:6]
   } aes_hw2reg_t;
 
   // Register Address

--- a/hw/ip/aes/rtl/aes_reg_top.sv
+++ b/hw/ip/aes/rtl/aes_reg_top.sv
@@ -119,6 +119,9 @@ module aes_reg_top (
   logic trigger_key_clear_qs;
   logic trigger_key_clear_wd;
   logic trigger_key_clear_we;
+  logic trigger_data_in_clear_qs;
+  logic trigger_data_in_clear_wd;
+  logic trigger_data_in_clear_we;
   logic trigger_data_out_clear_qs;
   logic trigger_data_out_clear_wd;
   logic trigger_data_out_clear_we;
@@ -145,8 +148,8 @@ module aes_reg_top (
     .wd     (key0_wd),
 
     // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
+    .de     (hw2reg.key[0].de),
+    .d      (hw2reg.key[0].d ),
 
     // to internal hardware
     .qe     (reg2hw.key[0].qe),
@@ -171,8 +174,8 @@ module aes_reg_top (
     .wd     (key1_wd),
 
     // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
+    .de     (hw2reg.key[1].de),
+    .d      (hw2reg.key[1].d ),
 
     // to internal hardware
     .qe     (reg2hw.key[1].qe),
@@ -197,8 +200,8 @@ module aes_reg_top (
     .wd     (key2_wd),
 
     // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
+    .de     (hw2reg.key[2].de),
+    .d      (hw2reg.key[2].d ),
 
     // to internal hardware
     .qe     (reg2hw.key[2].qe),
@@ -223,8 +226,8 @@ module aes_reg_top (
     .wd     (key3_wd),
 
     // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
+    .de     (hw2reg.key[3].de),
+    .d      (hw2reg.key[3].d ),
 
     // to internal hardware
     .qe     (reg2hw.key[3].qe),
@@ -249,8 +252,8 @@ module aes_reg_top (
     .wd     (key4_wd),
 
     // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
+    .de     (hw2reg.key[4].de),
+    .d      (hw2reg.key[4].d ),
 
     // to internal hardware
     .qe     (reg2hw.key[4].qe),
@@ -275,8 +278,8 @@ module aes_reg_top (
     .wd     (key5_wd),
 
     // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
+    .de     (hw2reg.key[5].de),
+    .d      (hw2reg.key[5].d ),
 
     // to internal hardware
     .qe     (reg2hw.key[5].qe),
@@ -301,8 +304,8 @@ module aes_reg_top (
     .wd     (key6_wd),
 
     // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
+    .de     (hw2reg.key[6].de),
+    .d      (hw2reg.key[6].d ),
 
     // to internal hardware
     .qe     (reg2hw.key[6].qe),
@@ -327,8 +330,8 @@ module aes_reg_top (
     .wd     (key7_wd),
 
     // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
+    .de     (hw2reg.key[7].de),
+    .d      (hw2reg.key[7].d ),
 
     // to internal hardware
     .qe     (reg2hw.key[7].qe),
@@ -355,8 +358,8 @@ module aes_reg_top (
     .wd     (data_in0_wd),
 
     // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
+    .de     (hw2reg.data_in[0].de),
+    .d      (hw2reg.data_in[0].d ),
 
     // to internal hardware
     .qe     (reg2hw.data_in[0].qe),
@@ -381,8 +384,8 @@ module aes_reg_top (
     .wd     (data_in1_wd),
 
     // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
+    .de     (hw2reg.data_in[1].de),
+    .d      (hw2reg.data_in[1].d ),
 
     // to internal hardware
     .qe     (reg2hw.data_in[1].qe),
@@ -407,8 +410,8 @@ module aes_reg_top (
     .wd     (data_in2_wd),
 
     // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
+    .de     (hw2reg.data_in[2].de),
+    .d      (hw2reg.data_in[2].d ),
 
     // to internal hardware
     .qe     (reg2hw.data_in[2].qe),
@@ -433,8 +436,8 @@ module aes_reg_top (
     .wd     (data_in3_wd),
 
     // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
+    .de     (hw2reg.data_in[3].de),
+    .d      (hw2reg.data_in[3].d ),
 
     // to internal hardware
     .qe     (reg2hw.data_in[3].qe),
@@ -670,7 +673,33 @@ module aes_reg_top (
   );
 
 
-  //   F[data_out_clear]: 2:2
+  //   F[data_in_clear]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_trigger_data_in_clear (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (trigger_data_in_clear_we),
+    .wd     (trigger_data_in_clear_wd),
+
+    // from internal hardware
+    .de     (hw2reg.trigger.data_in_clear.de),
+    .d      (hw2reg.trigger.data_in_clear.d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.trigger.data_in_clear.q ),
+
+    // to register interface (read)
+    .qs     (trigger_data_in_clear_qs)
+  );
+
+
+  //   F[data_out_clear]: 3:3
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
@@ -912,8 +941,11 @@ module aes_reg_top (
   assign trigger_key_clear_we = addr_hit[17] & reg_we & ~wr_err;
   assign trigger_key_clear_wd = reg_wdata[1];
 
+  assign trigger_data_in_clear_we = addr_hit[17] & reg_we & ~wr_err;
+  assign trigger_data_in_clear_wd = reg_wdata[2];
+
   assign trigger_data_out_clear_we = addr_hit[17] & reg_we & ~wr_err;
-  assign trigger_data_out_clear_wd = reg_wdata[2];
+  assign trigger_data_out_clear_wd = reg_wdata[3];
 
 
 
@@ -997,7 +1029,8 @@ module aes_reg_top (
       addr_hit[17]: begin
         reg_rdata_next[0] = trigger_start_qs;
         reg_rdata_next[1] = trigger_key_clear_qs;
-        reg_rdata_next[2] = trigger_data_out_clear_qs;
+        reg_rdata_next[2] = trigger_data_in_clear_qs;
+        reg_rdata_next[3] = trigger_data_out_clear_qs;
       end
 
       addr_hit[18]: begin

--- a/hw/ip/aes/rtl/aes_reg_top.sv
+++ b/hw/ip/aes/rtl/aes_reg_top.sv
@@ -117,16 +117,12 @@ module aes_reg_top (
   logic ctrl_force_data_overwrite_wd;
   logic ctrl_force_data_overwrite_we;
   logic ctrl_force_data_overwrite_re;
-  logic trigger_start_qs;
   logic trigger_start_wd;
   logic trigger_start_we;
-  logic trigger_key_clear_qs;
   logic trigger_key_clear_wd;
   logic trigger_key_clear_we;
-  logic trigger_data_in_clear_qs;
   logic trigger_data_in_clear_wd;
   logic trigger_data_in_clear_we;
-  logic trigger_data_out_clear_qs;
   logic trigger_data_out_clear_wd;
   logic trigger_data_out_clear_we;
   logic status_idle_qs;
@@ -504,7 +500,7 @@ module aes_reg_top (
   //   F[start]: 0:0
   prim_subreg #(
     .DW      (1),
-    .SWACCESS("RW"),
+    .SWACCESS("WO"),
     .RESVAL  (1'h0)
   ) u_trigger_start (
     .clk_i   (clk_i    ),
@@ -522,15 +518,14 @@ module aes_reg_top (
     .qe     (),
     .q      (reg2hw.trigger.start.q ),
 
-    // to register interface (read)
-    .qs     (trigger_start_qs)
+    .qs     ()
   );
 
 
   //   F[key_clear]: 1:1
   prim_subreg #(
     .DW      (1),
-    .SWACCESS("RW"),
+    .SWACCESS("WO"),
     .RESVAL  (1'h0)
   ) u_trigger_key_clear (
     .clk_i   (clk_i    ),
@@ -548,15 +543,14 @@ module aes_reg_top (
     .qe     (),
     .q      (reg2hw.trigger.key_clear.q ),
 
-    // to register interface (read)
-    .qs     (trigger_key_clear_qs)
+    .qs     ()
   );
 
 
   //   F[data_in_clear]: 2:2
   prim_subreg #(
     .DW      (1),
-    .SWACCESS("RW"),
+    .SWACCESS("WO"),
     .RESVAL  (1'h0)
   ) u_trigger_data_in_clear (
     .clk_i   (clk_i    ),
@@ -574,15 +568,14 @@ module aes_reg_top (
     .qe     (),
     .q      (reg2hw.trigger.data_in_clear.q ),
 
-    // to register interface (read)
-    .qs     (trigger_data_in_clear_qs)
+    .qs     ()
   );
 
 
   //   F[data_out_clear]: 3:3
   prim_subreg #(
     .DW      (1),
-    .SWACCESS("RW"),
+    .SWACCESS("WO"),
     .RESVAL  (1'h0)
   ) u_trigger_data_out_clear (
     .clk_i   (clk_i    ),
@@ -600,8 +593,7 @@ module aes_reg_top (
     .qe     (),
     .q      (reg2hw.trigger.data_out_clear.q ),
 
-    // to register interface (read)
-    .qs     (trigger_data_out_clear_qs)
+    .qs     ()
   );
 
 
@@ -911,10 +903,10 @@ module aes_reg_top (
       end
 
       addr_hit[17]: begin
-        reg_rdata_next[0] = trigger_start_qs;
-        reg_rdata_next[1] = trigger_key_clear_qs;
-        reg_rdata_next[2] = trigger_data_in_clear_qs;
-        reg_rdata_next[3] = trigger_data_out_clear_qs;
+        reg_rdata_next[0] = '0;
+        reg_rdata_next[1] = '0;
+        reg_rdata_next[2] = '0;
+        reg_rdata_next[3] = '0;
       end
 
       addr_hit[18]: begin

--- a/hw/ip/aes/rtl/aes_reg_top.sv
+++ b/hw/ip/aes/rtl/aes_reg_top.sv
@@ -1021,6 +1021,8 @@ module aes_reg_top (
 
   `ASSERT(en2addrHit, (reg_we || reg_re) |-> $onehot0(addr_hit), clk_i, !rst_ni)
 
+  // this is formulated as an assumption such that the FPV testbenches do disprove this
+  // property by mistake
   `ASSUME(reqParity, tl_reg_h2d.a_valid |-> tl_reg_h2d.a_user.parity_en == 1'b0, clk_i, !rst_ni)
 
 endmodule

--- a/hw/ip/aes/rtl/aes_reg_top.sv
+++ b/hw/ip/aes/rtl/aes_reg_top.sv
@@ -133,210 +133,130 @@ module aes_reg_top (
   // Register instances
 
   // Subregister 0 of Multireg key
-  // R[key0]: V(False)
+  // R[key0]: V(True)
 
-  prim_subreg #(
-    .DW      (32),
-    .SWACCESS("WO"),
-    .RESVAL  (32'h0)
+  prim_subreg_ext #(
+    .DW    (32)
   ) u_key0 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
+    .re     (1'b0),
     .we     (key0_we),
     .wd     (key0_wd),
-
-    // from internal hardware
-    .de     (hw2reg.key[0].de),
-    .d      (hw2reg.key[0].d ),
-
-    // to internal hardware
+    .d      (hw2reg.key[0].d),
+    .qre    (),
     .qe     (reg2hw.key[0].qe),
     .q      (reg2hw.key[0].q ),
-
     .qs     ()
   );
 
   // Subregister 1 of Multireg key
-  // R[key1]: V(False)
+  // R[key1]: V(True)
 
-  prim_subreg #(
-    .DW      (32),
-    .SWACCESS("WO"),
-    .RESVAL  (32'h0)
+  prim_subreg_ext #(
+    .DW    (32)
   ) u_key1 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
+    .re     (1'b0),
     .we     (key1_we),
     .wd     (key1_wd),
-
-    // from internal hardware
-    .de     (hw2reg.key[1].de),
-    .d      (hw2reg.key[1].d ),
-
-    // to internal hardware
+    .d      (hw2reg.key[1].d),
+    .qre    (),
     .qe     (reg2hw.key[1].qe),
     .q      (reg2hw.key[1].q ),
-
     .qs     ()
   );
 
   // Subregister 2 of Multireg key
-  // R[key2]: V(False)
+  // R[key2]: V(True)
 
-  prim_subreg #(
-    .DW      (32),
-    .SWACCESS("WO"),
-    .RESVAL  (32'h0)
+  prim_subreg_ext #(
+    .DW    (32)
   ) u_key2 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
+    .re     (1'b0),
     .we     (key2_we),
     .wd     (key2_wd),
-
-    // from internal hardware
-    .de     (hw2reg.key[2].de),
-    .d      (hw2reg.key[2].d ),
-
-    // to internal hardware
+    .d      (hw2reg.key[2].d),
+    .qre    (),
     .qe     (reg2hw.key[2].qe),
     .q      (reg2hw.key[2].q ),
-
     .qs     ()
   );
 
   // Subregister 3 of Multireg key
-  // R[key3]: V(False)
+  // R[key3]: V(True)
 
-  prim_subreg #(
-    .DW      (32),
-    .SWACCESS("WO"),
-    .RESVAL  (32'h0)
+  prim_subreg_ext #(
+    .DW    (32)
   ) u_key3 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
+    .re     (1'b0),
     .we     (key3_we),
     .wd     (key3_wd),
-
-    // from internal hardware
-    .de     (hw2reg.key[3].de),
-    .d      (hw2reg.key[3].d ),
-
-    // to internal hardware
+    .d      (hw2reg.key[3].d),
+    .qre    (),
     .qe     (reg2hw.key[3].qe),
     .q      (reg2hw.key[3].q ),
-
     .qs     ()
   );
 
   // Subregister 4 of Multireg key
-  // R[key4]: V(False)
+  // R[key4]: V(True)
 
-  prim_subreg #(
-    .DW      (32),
-    .SWACCESS("WO"),
-    .RESVAL  (32'h0)
+  prim_subreg_ext #(
+    .DW    (32)
   ) u_key4 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
+    .re     (1'b0),
     .we     (key4_we),
     .wd     (key4_wd),
-
-    // from internal hardware
-    .de     (hw2reg.key[4].de),
-    .d      (hw2reg.key[4].d ),
-
-    // to internal hardware
+    .d      (hw2reg.key[4].d),
+    .qre    (),
     .qe     (reg2hw.key[4].qe),
     .q      (reg2hw.key[4].q ),
-
     .qs     ()
   );
 
   // Subregister 5 of Multireg key
-  // R[key5]: V(False)
+  // R[key5]: V(True)
 
-  prim_subreg #(
-    .DW      (32),
-    .SWACCESS("WO"),
-    .RESVAL  (32'h0)
+  prim_subreg_ext #(
+    .DW    (32)
   ) u_key5 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
+    .re     (1'b0),
     .we     (key5_we),
     .wd     (key5_wd),
-
-    // from internal hardware
-    .de     (hw2reg.key[5].de),
-    .d      (hw2reg.key[5].d ),
-
-    // to internal hardware
+    .d      (hw2reg.key[5].d),
+    .qre    (),
     .qe     (reg2hw.key[5].qe),
     .q      (reg2hw.key[5].q ),
-
     .qs     ()
   );
 
   // Subregister 6 of Multireg key
-  // R[key6]: V(False)
+  // R[key6]: V(True)
 
-  prim_subreg #(
-    .DW      (32),
-    .SWACCESS("WO"),
-    .RESVAL  (32'h0)
+  prim_subreg_ext #(
+    .DW    (32)
   ) u_key6 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
+    .re     (1'b0),
     .we     (key6_we),
     .wd     (key6_wd),
-
-    // from internal hardware
-    .de     (hw2reg.key[6].de),
-    .d      (hw2reg.key[6].d ),
-
-    // to internal hardware
+    .d      (hw2reg.key[6].d),
+    .qre    (),
     .qe     (reg2hw.key[6].qe),
     .q      (reg2hw.key[6].q ),
-
     .qs     ()
   );
 
   // Subregister 7 of Multireg key
-  // R[key7]: V(False)
+  // R[key7]: V(True)
 
-  prim_subreg #(
-    .DW      (32),
-    .SWACCESS("WO"),
-    .RESVAL  (32'h0)
+  prim_subreg_ext #(
+    .DW    (32)
   ) u_key7 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
+    .re     (1'b0),
     .we     (key7_we),
     .wd     (key7_wd),
-
-    // from internal hardware
-    .de     (hw2reg.key[7].de),
-    .d      (hw2reg.key[7].d ),
-
-    // to internal hardware
+    .d      (hw2reg.key[7].d),
+    .qre    (),
     .qe     (reg2hw.key[7].qe),
     .q      (reg2hw.key[7].q ),
-
     .qs     ()
   );
 

--- a/hw/ip/aes/rtl/aes_reg_top.sv
+++ b/hw/ip/aes/rtl/aes_reg_top.sv
@@ -104,15 +104,19 @@ module aes_reg_top (
   logic ctrl_mode_qs;
   logic ctrl_mode_wd;
   logic ctrl_mode_we;
+  logic ctrl_mode_re;
   logic [2:0] ctrl_key_len_qs;
   logic [2:0] ctrl_key_len_wd;
   logic ctrl_key_len_we;
+  logic ctrl_key_len_re;
   logic ctrl_manual_start_trigger_qs;
   logic ctrl_manual_start_trigger_wd;
   logic ctrl_manual_start_trigger_we;
+  logic ctrl_manual_start_trigger_re;
   logic ctrl_force_data_overwrite_qs;
   logic ctrl_force_data_overwrite_wd;
   logic ctrl_force_data_overwrite_we;
+  logic ctrl_force_data_overwrite_re;
   logic trigger_start_qs;
   logic trigger_start_wd;
   logic trigger_start_we;
@@ -433,108 +437,64 @@ module aes_reg_top (
   );
 
 
-  // R[ctrl]: V(False)
+  // R[ctrl]: V(True)
 
   //   F[mode]: 0:0
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
+  prim_subreg_ext #(
+    .DW    (1)
   ) u_ctrl_mode (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
+    .re     (ctrl_mode_re),
     .we     (ctrl_mode_we),
     .wd     (ctrl_mode_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
+    .d      ('0),
+    .qre    (),
     .qe     (reg2hw.ctrl.mode.qe),
     .q      (reg2hw.ctrl.mode.q ),
-
-    // to register interface (read)
     .qs     (ctrl_mode_qs)
   );
 
 
   //   F[key_len]: 3:1
-  prim_subreg #(
-    .DW      (3),
-    .SWACCESS("RW"),
-    .RESVAL  (3'h1)
+  prim_subreg_ext #(
+    .DW    (3)
   ) u_ctrl_key_len (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
+    .re     (ctrl_key_len_re),
     .we     (ctrl_key_len_we),
     .wd     (ctrl_key_len_wd),
-
-    // from internal hardware
-    .de     (hw2reg.ctrl.key_len.de),
-    .d      (hw2reg.ctrl.key_len.d ),
-
-    // to internal hardware
+    .d      (hw2reg.ctrl.key_len.d),
+    .qre    (),
     .qe     (reg2hw.ctrl.key_len.qe),
     .q      (reg2hw.ctrl.key_len.q ),
-
-    // to register interface (read)
     .qs     (ctrl_key_len_qs)
   );
 
 
   //   F[manual_start_trigger]: 4:4
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
+  prim_subreg_ext #(
+    .DW    (1)
   ) u_ctrl_manual_start_trigger (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
+    .re     (ctrl_manual_start_trigger_re),
     .we     (ctrl_manual_start_trigger_we),
     .wd     (ctrl_manual_start_trigger_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
+    .d      ('0),
+    .qre    (),
     .qe     (reg2hw.ctrl.manual_start_trigger.qe),
     .q      (reg2hw.ctrl.manual_start_trigger.q ),
-
-    // to register interface (read)
     .qs     (ctrl_manual_start_trigger_qs)
   );
 
 
   //   F[force_data_overwrite]: 5:5
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
+  prim_subreg_ext #(
+    .DW    (1)
   ) u_ctrl_force_data_overwrite (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
+    .re     (ctrl_force_data_overwrite_re),
     .we     (ctrl_force_data_overwrite_we),
     .wd     (ctrl_force_data_overwrite_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
+    .d      ('0),
+    .qre    (),
     .qe     (reg2hw.ctrl.force_data_overwrite.qe),
     .q      (reg2hw.ctrl.force_data_overwrite.q ),
-
-    // to register interface (read)
     .qs     (ctrl_force_data_overwrite_qs)
   );
 
@@ -845,15 +805,19 @@ module aes_reg_top (
 
   assign ctrl_mode_we = addr_hit[16] & reg_we & ~wr_err;
   assign ctrl_mode_wd = reg_wdata[0];
+  assign ctrl_mode_re = addr_hit[16] && reg_re;
 
   assign ctrl_key_len_we = addr_hit[16] & reg_we & ~wr_err;
   assign ctrl_key_len_wd = reg_wdata[3:1];
+  assign ctrl_key_len_re = addr_hit[16] && reg_re;
 
   assign ctrl_manual_start_trigger_we = addr_hit[16] & reg_we & ~wr_err;
   assign ctrl_manual_start_trigger_wd = reg_wdata[4];
+  assign ctrl_manual_start_trigger_re = addr_hit[16] && reg_re;
 
   assign ctrl_force_data_overwrite_we = addr_hit[16] & reg_we & ~wr_err;
   assign ctrl_force_data_overwrite_wd = reg_wdata[5];
+  assign ctrl_force_data_overwrite_re = addr_hit[16] && reg_re;
 
   assign trigger_start_we = addr_hit[17] & reg_we & ~wr_err;
   assign trigger_start_wd = reg_wdata[0];


### PR DESCRIPTION
This PR contains a series of commits to implement the following two main changes:
- Input data and initial key registers can now be cleared using a bit in the trigger register (like the output data register). At the moment, these registers are cleared to 0. At a later point, an LFSR will be inserted to clear those registers with pseudo-random data. Previously those registers had to be cleared by software.
- Writes to the key and control registers are ignored if the AES unit is not idle. This similar to the behavior of the HMAC module changed in PR #1014 .

Hand in hand with these changes goes a restructuring/cleanup of the AES core (not the cipher, but the `aes_core.sv` file connecting the data paths with the registers).

The changes have been successfully tested using my Verilator test framework.