### PR TITLE
[boot_rom] Add bootstrap pre flash programming debug messages

### DIFF
--- a/sw/device/boot_rom/bootstrap.c
+++ b/sw/device/boot_rom/bootstrap.c
@@ -108,9 +108,11 @@ int bootstrap(void) {
     return 0;
   }
   // SPI device is only initialized in bootstrap mode.
+  uart_send_str("Bootstrap requested, initialising HW...\n");
   spid_init();
   flash_init_block();
 
+  uart_send_str("HW initialisation completed, waiting for SPI input...\n");
   int rv = bootstrap_flash();
   if (rv) {
     rv |= erase_flash();


### PR DESCRIPTION
When bootstrap pin is asserted - required peripherals (SPI and Flash)
are initialised, and execution enters a busy loop waiting for SPI data
to program flash.

It is useful to have a debug message describing what is happening to
prevent the system looking unresponsive.

For example:
When I had both prog and uart cables connected to my laptop and FPGA running. After running fusesoc when it flashed Boot ROM, it asserts the bootstrap pin and awaits the SPI input. The bootstrap pin is only deasserted when you power off and back on the board. It just makes it the system look hang up.