### PR TITLE
[sw] Centralize the definition of $OT_VERSION

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -9,6 +9,11 @@ if target == 'undef'
   error('target option not set. Please run meson with a valid build target option.')
 endif
 
+ot_version = get_option('ot_version')
+if ot_version == 'undef'
+  error('ot_version option not set. Please run meson with a valid OpenTitan version option.')
+endif
+
 if target == 'sim-verilator'
   # TODO: Consider using extra args array if using this flag globally is no
   # longer OK.

--- a/meson_init.sh
+++ b/meson_init.sh
@@ -12,6 +12,7 @@ set -o nounset
 echo "Detected \$REPO_TOP at $REPO_TOP."
 echo "Object directory set at $OBJ_DIR."
 echo "Binary directory set at $BIN_DIR."
+echo "OpenTitan version: $OT_VERSION"
 echo
 
 function usage() {
@@ -105,6 +106,7 @@ for platform in ${PLATFORMS[@]}; do
   mkdir -p "$obj_dir"
   meson ${FLAGS_reconfigure} \
     -Dtarget="$platform" \
+    -Dot_version="$OT_VERSION" \
     --cross-file="$CROSS_FILE" \
     --buildtype=plain \
     "$obj_dir"

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,7 @@
 option('target', type : 'combo', choices: ['sim-verilator', 'fpga', 'undef'], value : 'undef')
+
+option(
+  'ot_version',
+  type: 'string',
+  value: 'undef',
+)

--- a/sw/device/boot_rom/meson.build
+++ b/sw/device/boot_rom/meson.build
@@ -3,11 +3,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Generate header file with chip_info information.
-chip_info_h = custom_target(
-  'chip_info_h',
-  output: 'chip_info.h',
-  command: [
-    prog_python, '@SOURCE_DIR@/util/rom_chip_info.py', '--outdir', '@OUTDIR@']
+chip_info_h = declare_dependency(
+  sources: [custom_target(
+    'chip_info_h',
+    output: 'chip_info.h',
+    command: [
+      prog_python,
+      '@SOURCE_DIR@/util/rom_chip_info.py',
+      '--outdir', '@OUTDIR@',
+      '--ot_version', ot_version,
+    ]
+  )],
 )
 
 # ROM linker parameters.
@@ -23,7 +29,6 @@ custom_target(
   input: executable(
     'boot_rom',
     sources: [
-      chip_info_h,
       'boot_rom.c',
       'bootstrap.c',
       'crt0.S'
@@ -32,6 +37,7 @@ custom_target(
     link_args: rom_link_args,
     link_depends: rom_link_deps,
     dependencies: [
+      chip_info_h,
       sw_lib_flash_ctrl,
       sw_lib_pinmux,
       sw_lib_gpio,

--- a/sw/device/rules.mk
+++ b/sw/device/rules.mk
@@ -101,7 +101,7 @@ $(LIB_BUILD_DIR)/pinmux_regs.h: $(REPO_TOP)/hw/top_earlgrey/ip/pinmux/data/autog
 
 # chip_info
 $(SW_BUILD_DIR)/sw/device/boot_rom/chip_info.h: $(INFOTOOL)
-	$(INFOTOOL) -o $(dir $@)
+	$(INFOTOOL) -o $(dir $@) --ot_version "opentitan-<deprecated/make>"
 
 -include $(DEPS)
 

--- a/util/build_consts.sh
+++ b/util/build_consts.sh
@@ -16,6 +16,10 @@
 # $OBJ_DIR and $BIN_DIR are the subdirectories build-out and build-bin of
 # $BUILD_ROOT, which can be configured to any desired directory. Build artifacts
 # can be cleaned out by running |rm -rf $BUILD_ROOT/build-*|.
+#
+# This file also provides $OT_VERSION, which can be embedded in artifacts as a
+# timestamp. If a git repo is present, it will be computed from that, or else
+# will be an arbitrary string.
 
 # Since this file is intended to be sourced, we can't use |$0| to get our
 # bearings. However, the bash-specific $BASH_SOURCE works perfectly fine.
@@ -25,8 +29,15 @@ else
   echo "Non-bash shells are currently not supported." >&2
   exit 1
 fi
-BUILD_ROOT="${BUILD_ROOT:-"$REPO_TOP"}"
 
+OT_GIT_VERSION="$(git describe --always 2>/dev/null)"
+if [[ -n "$OT_GIT_VERSION" ]]; then
+  readonly OT_VERSION="opentitan-$OT_GIT_VERSION"
+else
+  readonly OT_VERSION="opentitan-<unknown>"
+fi
+
+BUILD_ROOT="${BUILD_ROOT:-"$REPO_TOP"}"
 readonly OBJ_DIR="$BUILD_ROOT/build-out"
 readonly BIN_DIR="$BUILD_ROOT/build-bin"
 

--- a/util/make_distribution.sh
+++ b/util/make_distribution.sh
@@ -14,7 +14,6 @@ set -e
 
 . util/build_consts.sh
 
-readonly OT_VERSION="$(git describe --always)"
 echo "\$OT_VERSION = $OT_VERSION" >&2
 
 # $DIST_ARTIFACTS is a list of |find| globs to be copied out of
@@ -30,7 +29,7 @@ readonly DIST_ARTIFACTS=(
   'hw/top_earlgrey/lowrisc_systems_top_earlgrey_nexysvideo_0.1.bit'
 )
 
-DIST_DIR="$OBJ_DIR/opentitan-$OT_VERSION"
+DIST_DIR="$OBJ_DIR/$OT_VERSION"
 mkdir -p "$DIST_DIR"
 
 cp ci/README.snapshot "$DIST_DIR"
@@ -55,5 +54,6 @@ for pat in "${DIST_ARTIFACTS[@]}"; do
   fi
 done
 
-cd "$OBJ_DIR"
-tar -cJf "$BIN_DIR/opentitan-$OT_VERSION.tar.xz" "opentitan-$OT_VERSION"
+cd "$(dirname "$DIST_DIR")"
+tar -cJf "$BIN_DIR/$(basename "$DIST_DIR").tar.xz" \
+  "$(basename "$DIST_DIR")"


### PR DESCRIPTION
$OT_VERSION is now defined in util/build_consts.sh. Meson, chip_info.h, and make_distribution.sh all use this definition now.

This definition is also not dependent on git: if run outside of the git repository, it will simply be "opentitan-<unknown>".

Fixes #1057.