### PR TITLE
[prim] Select proper generic implementation in prim_ram_2p_async_adv

### DIFF
--- a/hw/ip/prim/rtl/prim_ram_2p_async_adv.sv
+++ b/hw/ip/prim/rtl/prim_ram_2p_async_adv.sv
@@ -86,7 +86,7 @@ module prim_ram_2p_async_adv #(
     prim_ram_2p #(
       .Width (TotalWidth),
       .Depth (Depth),
-      .Impl  ("generic")
+      .Impl  (prim_pkg::ImplGeneric)
     ) u_mem (
       .clk_a_i    (clk_a_i),
       .clk_b_i    (clk_b_i),


### PR DESCRIPTION
Split off from #1066 

This fixes a bug in prim_ram_2p_async_adv by selecting a valid generic configiguration. Without this change the memory only ever outputs 0. The unit only seems to be used in the USB device.