### PR TITLE
Document the installation of Meson

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -123,8 +123,7 @@ jobs:
   steps:
   - bash: |
       sudo apt-get install -y python3 python3-pip build-essential pkgconf srecord python3-setuptools zlib1g-dev libusb-1.0 libftdi1-dev libftdi1-2 libssl-dev ninja-build \
-        && sudo pip3 install -U -r python-requirements.txt \
-        && sudo pip3 install -U meson
+        && sudo pip3 install -U -r python-requirements.txt
     displayName: 'Install dependencies'
   - bash: |
       set -x

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -10,6 +10,7 @@ pyyaml
 pytest
 fusesoc
 gitpython
+meson
 
 # Develpment version to get around YAML parser warning triggered by fusesoc
 # Upstream tracking: https://github.com/olofk/ipyxact/issues/19


### PR DESCRIPTION
Meson is a normal Python package, and we already require people to
install python-requirements.txt. Adding Meson there makes sure that
people get Meson when following our user guide.