### PR TITLE
[verilator] Add direct DMI to OpenOCD interface

### DIFF
--- a/hw/dv/dpi/common/tcp_server/tcp_server.c
+++ b/hw/dv/dpi/common/tcp_server/tcp_server.c
@@ -1,0 +1,439 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tcp_server.h"
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+/**
+ * Simple buffer for passing data between TCP sockets and DPI modules
+ */
+const int BUFSIZE_BYTE = 256;
+
+struct tcp_buf {
+  unsigned int rptr;
+  unsigned int wptr;
+  char buf[BUFSIZE_BYTE];
+};
+
+/**
+ * TCP Server thread context structure
+ */
+struct tcp_server_ctx {
+  // Writeable by the host thread
+  char *display_name;
+  uint16_t listen_port;
+  volatile bool socket_run;
+  // Writeable by the server thread
+  tcp_buf *buf_in;
+  tcp_buf *buf_out;
+  int sfd;  // socket fd
+  int cfd;  // client fd
+  pthread_t sock_thread;
+};
+
+static bool tcp_buffer_is_full(struct tcp_buf *buf) {
+  if (buf->wptr >= buf->rptr) {
+    return (buf->wptr - buf->rptr) == (BUFSIZE_BYTE - 1);
+  } else {
+    return (buf->rptr - buf->wptr) == 1;
+  }
+}
+
+static bool tcp_buffer_is_empty(struct tcp_buf *buf) {
+  return (buf->wptr == buf->rptr);
+}
+
+static void tcp_buffer_put_byte(struct tcp_buf *buf, char dat) {
+  bool done = false;
+  while (!done) {
+    if (!tcp_buffer_is_full(buf)) {
+      buf->buf[buf->wptr++] = dat;
+      buf->wptr %= BUFSIZE_BYTE;
+      done = true;
+    }
+  }
+}
+
+static bool tcp_buffer_get_byte(struct tcp_buf *buf, char *dat) {
+  if (tcp_buffer_is_empty(buf)) {
+    return false;
+  }
+  *dat = buf->buf[buf->rptr++];
+  buf->rptr %= BUFSIZE_BYTE;
+  return true;
+}
+
+static struct tcp_buf *tcp_buffer_new(void) {
+  struct tcp_buf *buf_new;
+  buf_new = (struct tcp_buf *)malloc(sizeof(struct tcp_buf));
+  buf_new->rptr = 0;
+  buf_new->wptr = 0;
+  return buf_new;
+}
+
+static void tcp_buffer_free(struct tcp_buf **buf) {
+  free(*buf);
+  *buf = NULL;
+}
+
+/**
+ * Start a TCP server
+ *
+ * This function creates attempts to create a new TCP socket instance. The
+ * socket is a non-blocking stream socket, with buffering disabled.
+ *
+ * @param ctx context object
+ * @return 0 on success, -1 in case of an error
+ */
+static int start(struct tcp_server_ctx *ctx) {
+  int rv;
+
+  assert(ctx->sfd == 0 && "Server already started.");
+
+  // create socket
+  int sfd = socket(AF_INET, SOCK_STREAM, 0);
+  if (sfd == -1) {
+    fprintf(stderr, "%s: Unable to create socket: %s (%d)\n", ctx->display_name,
+            strerror(errno), errno);
+    return -1;
+  }
+
+  rv = fcntl(sfd, F_SETFL, O_NONBLOCK);
+  if (rv != 0) {
+    fprintf(stderr, "%s: Unable to make socket non-blocking: %s (%d)\n",
+            ctx->display_name, strerror(errno), errno);
+    return -1;
+  }
+
+  // reuse existing socket (if existing)
+  int reuse_socket = 1;
+  rv = setsockopt(sfd, SOL_SOCKET, SO_REUSEADDR, &reuse_socket, sizeof(int));
+  if (rv != 0) {
+    fprintf(stderr, "%s: Unable to set socket options: %s (%d)\n",
+            ctx->display_name, strerror(errno), errno);
+    return -1;
+  }
+
+  // stop tcp socket from buffering (buffering prevents timely responses to
+  // OpenOCD which severly limits debugging performance)
+  int tcp_nodelay = 1;
+  rv = setsockopt(sfd, IPPROTO_TCP, TCP_NODELAY, &tcp_nodelay, sizeof(int));
+  if (rv != 0) {
+    fprintf(stderr, "%s: Unable to set socket nodelay: %s (%d)\n",
+            ctx->display_name, strerror(errno), errno);
+    return -1;
+  }
+
+  // bind server
+  struct sockaddr_in addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl(INADDR_ANY);
+  addr.sin_port = htons(ctx->listen_port);
+
+  rv = bind(sfd, (struct sockaddr *)&addr, sizeof(addr));
+  if (rv != 0) {
+    fprintf(stderr, "%s: Failed to bind socket: %s (%d)\n", ctx->display_name,
+            strerror(errno), errno);
+    return -1;
+  }
+
+  // listen for incoming connections
+  rv = listen(sfd, 1);
+  if (rv != 0) {
+    fprintf(stderr, "%s: Failed to listen on socket: %s (%d)\n",
+            ctx->display_name, strerror(errno), errno);
+    return -1;
+  }
+
+  ctx->sfd = sfd;
+  assert(ctx->sfd > 0);
+
+  return 0;
+}
+
+/**
+ * Accept an incoming connection from a client (nonblocking)
+ *
+ * The resulting client fd is made non-blocking.
+ *
+ * @param ctx context object
+ * @return 0 on success, any other value indicates an error
+ */
+static int client_tryaccept(struct tcp_server_ctx *ctx) {
+  int rv;
+
+  assert(ctx->sfd > 0);
+  assert(ctx->cfd == 0);
+
+  int cfd = accept(ctx->sfd, NULL, NULL);
+
+  if (cfd == -1 && errno == EAGAIN) {
+    return -EAGAIN;
+  }
+
+  if (cfd == -1) {
+    fprintf(stderr, "%s: Unable to accept incoming connection: %s (%d)\n",
+            ctx->display_name, strerror(errno), errno);
+    return -1;
+  }
+
+  rv = fcntl(cfd, F_SETFL, O_NONBLOCK);
+  if (rv != 0) {
+    fprintf(stderr, "%s: Unable to make client socket non-blocking: %s (%d)\n",
+            ctx->display_name, strerror(errno), errno);
+    return -1;
+  }
+
+  ctx->cfd = cfd;
+  assert(ctx->cfd > 0);
+
+  printf("%s: Accepted client connection\n", ctx->display_name);
+
+  return 0;
+}
+
+/**
+ * Stop the TCP server
+ *
+ * @param ctx context object
+ */
+void stop(struct tcp_server_ctx *ctx) {
+  assert(ctx);
+  if (!ctx->sfd) {
+    return;
+  }
+  close(ctx->sfd);
+  ctx->sfd = 0;
+}
+
+/**
+ * Receive a byte from a connected client
+ *
+ * @param ctx context object
+ * @param cmd byte received
+ * @return true if a byte was read
+ */
+static bool get_byte(struct tcp_server_ctx *ctx, char *cmd) {
+  assert(ctx);
+
+  ssize_t num_read = read(ctx->cfd, cmd, 1);
+
+  if (num_read == 0) {
+    return false;
+  }
+  if (num_read == -1) {
+    if (errno == EAGAIN || errno == EWOULDBLOCK) {
+      return false;
+    } else if (errno == EBADF) {
+      // Possibly client went away? Accept a new connection.
+      fprintf(stderr, "%s: Client disappeared.\n", ctx->display_name);
+      tcp_server_client_close(ctx);
+      return false;
+    } else {
+      fprintf(stderr, "%s: Error while reading from client: %s (%d)\n",
+              ctx->display_name, strerror(errno), errno);
+      assert(0 && "Error reading from client");
+    }
+  }
+  assert(num_read == 1);
+  return true;
+}
+
+/**
+ * Send a byte to a connected client
+ *
+ * @param ctx context object
+ * @param cmd byte to send
+ */
+void put_byte(struct tcp_server_ctx *ctx, char cmd) {
+  while (1) {
+    ssize_t num_written = send(ctx->cfd, &cmd, sizeof(cmd), MSG_NOSIGNAL);
+    if (num_written == -1) {
+      if (errno == EAGAIN || errno == EWOULDBLOCK) {
+        continue;
+      } else if (errno == EPIPE) {
+        printf("%s: Remote disconnected.\n", ctx->display_name);
+        tcp_server_client_close(ctx);
+        break;
+      } else {
+        fprintf(stderr, "%s: Error while writing to client: %s (%d)\n",
+                ctx->display_name, strerror(errno), errno);
+        assert(0 && "Error writing to client.");
+      }
+    }
+    if (num_written >= 1) {
+      break;
+    }
+  }
+}
+
+/**
+ * Cleanup server context
+ *
+ * @param ctx context object
+ */
+static void ctx_free(struct tcp_server_ctx *ctx) {
+  // Free the buffers
+  tcp_buffer_free(&ctx->buf_in);
+  tcp_buffer_free(&ctx->buf_out);
+  // Free the display name
+  free(ctx->display_name);
+  // Free the ctx
+  free(ctx);
+  ctx = NULL;
+}
+
+/**
+ * Thread function to create a new server instance
+ *
+ * @param ctx_void context object
+ * @return Always returns NULL
+ */
+void *server_create(void *ctx_void) {
+  // Cast to a server struct
+  struct tcp_server_ctx *ctx = (struct tcp_server_ctx *)ctx_void;
+  struct timeval timeout;
+
+  // Start the server
+  int rv = start(ctx);
+  if (rv != 0) {
+    fprintf(stderr, "%s: Unable to create TCP server on port %d\n",
+            ctx->display_name, ctx->listen_port);
+    goto err_cleanup_return;
+  }
+
+  // Initialise timeout
+  timeout.tv_sec = 0;
+
+  // Initialise fd_set
+
+  // Start waiting for connection / data
+  char xfer_data;
+  while (ctx->socket_run) {
+    // Initialise structure of fds
+    fd_set read_fds;
+    FD_ZERO(&read_fds);
+    if (ctx->sfd) {
+      FD_SET(ctx->sfd, &read_fds);
+    }
+    if (ctx->cfd) {
+      FD_SET(ctx->cfd, &read_fds);
+    }
+    // max fd num
+    int mfd = (ctx->cfd > ctx->sfd) ? ctx->cfd : ctx->sfd;
+
+    // Set timeout - 50us gives good performance
+    timeout.tv_usec = 50;
+
+    // Wait for socket activity or timeout
+    rv = select(mfd + 1, &read_fds, NULL, NULL, &timeout);
+
+    if (rv < 0) {
+      printf("%s: Socket read failed, port: %d\n", ctx->display_name,
+             ctx->listen_port);
+      tcp_server_client_close(ctx);
+    }
+
+    // New connection
+    if (FD_ISSET(ctx->sfd, &read_fds)) {
+      client_tryaccept(ctx);
+    }
+
+    // New client data
+    if (FD_ISSET(ctx->cfd, &read_fds)) {
+      while (get_byte(ctx, &xfer_data)) {
+        tcp_buffer_put_byte(ctx->buf_in, xfer_data);
+      }
+    }
+
+    if (ctx->cfd != 0) {
+      while (tcp_buffer_get_byte(ctx->buf_out, &xfer_data)) {
+        put_byte(ctx, xfer_data);
+      }
+    }
+  }
+
+err_cleanup_return:
+
+  // Simulation done - clean up
+  tcp_server_client_close(ctx);
+  stop(ctx);
+  // free all context
+  ctx_free(ctx);
+
+  return NULL;
+}
+
+// Abstract interface functions
+tcp_server_ctx *tcp_server_create(const char *display_name, int listen_port) {
+  struct tcp_server_ctx *ctx =
+      (struct tcp_server_ctx *)calloc(1, sizeof(struct tcp_server_ctx));
+  assert(ctx);
+
+  // Create the buffers
+  struct tcp_buf *buf_in = tcp_buffer_new();
+  struct tcp_buf *buf_out = tcp_buffer_new();
+  assert(buf_in);
+  assert(buf_out);
+
+  // Populate the struct with buffer pointers
+  ctx->buf_in = buf_in;
+  ctx->buf_out = buf_out;
+
+  // Set up socket details
+  ctx->socket_run = true;
+  ctx->listen_port = listen_port;
+  ctx->display_name = strdup(display_name);
+  assert(ctx->display_name);
+
+  if (pthread_create(&ctx->sock_thread, NULL, server_create, (void *)ctx) !=
+      0) {
+    fprintf(stderr, "%s: Unable to create TCP socket thread\n",
+            ctx->display_name);
+    ctx_free(ctx);
+    free(ctx);
+    return NULL;
+  }
+  return ctx;
+}
+
+bool tcp_server_read(struct tcp_server_ctx *ctx, char *dat) {
+  return tcp_buffer_get_byte(ctx->buf_in, dat);
+}
+
+void tcp_server_write(struct tcp_server_ctx *ctx, char dat) {
+  tcp_buffer_put_byte(ctx->buf_out, dat);
+}
+
+void tcp_server_close(struct tcp_server_ctx *ctx) {
+  // Shut down the socket thread
+  ctx->socket_run = false;
+  pthread_join(ctx->sock_thread, NULL);
+  ctx_free(ctx);
+}
+
+void tcp_server_client_close(struct tcp_server_ctx *ctx) {
+  assert(ctx);
+
+  if (!ctx->cfd) {
+    return;
+  }
+
+  close(ctx->cfd);
+  ctx->cfd = 0;
+}

--- a/hw/dv/dpi/common/tcp_server/tcp_server.core
+++ b/hw/dv/dpi/common/tcp_server/tcp_server.core
@@ -1,0 +1,17 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv_dpi:tcp_server:0.1"
+description: "TCP Server for DPI modules"
+
+filesets:
+  files_c:
+    files:
+      - tcp_server.c: { file_type: cSource }
+      - tcp_server.h: { file_type: cSource, is_include_file: true }
+
+targets:
+  default:
+    filesets:
+      - files_c

--- a/hw/dv/dpi/common/tcp_server/tcp_server.h
+++ b/hw/dv/dpi/common/tcp_server/tcp_server.h
@@ -1,0 +1,69 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Functions to create and interact with a threaded TCP server
+ *
+ * This is intended to be used by simulation add-on DPI modules to provide
+ * basic TCP socket communication between a host and simulated peripherals.
+ */
+
+#ifndef TCP_SERVER_H_
+#define TCP_SERVER_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+struct tcp_server_ctx;
+
+/**
+ * Non-blocking read of a byte from a connected client
+ *
+ * @param ctx tcp server context object
+ * @param dat byte received
+ * @return true if a byte was read
+ */
+bool tcp_server_read(struct tcp_server_ctx *ctx, char *dat);
+
+/**
+ * Write a byte to a connected client
+ *
+ * The write is internally buffered and so does not block if the client is not
+ * ready to accept data, but does block if the buffer is full.
+ *
+ * @param ctx tcp server context object
+ * @param dat byte to send
+ */
+void tcp_server_write(struct tcp_server_ctx *ctx, char dat);
+
+/**
+ * Create a new TCP server instance
+ *
+ * @param display_name C string description of server
+ * @param listen_port On which port the server should listen
+ * @return A pointer to the created context struct
+ */
+tcp_server_ctx *tcp_server_create(const char *display_name, int listen_port);
+
+/**
+ * Shut down the server and free all reserved memory
+ *
+ * @param ctx tcp server context object
+ */
+void tcp_server_close(struct tcp_server_ctx *ctx);
+
+/**
+ * Instruct the server to disconnect a client
+ *
+ * @param ctx tcp server context object
+ */
+void tcp_server_client_close(struct tcp_server_ctx *ctx);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+#endif  // TCP_SERVER_H_

--- a/hw/dv/dpi/dmidpi/README.md
+++ b/hw/dv/dpi/dmidpi/README.md
@@ -1,0 +1,22 @@
+DMI DPI module for OpenOCD remote_bitbang driver
+================================================
+
+This DPI module provides a "virtual" JTAG connection between a simulated chip and [OpenOCD](http://openocd.org/).
+It makes use of the `remote_bitbang` JTAG driver shipped with OpenOCD, which forwards JTAG requests over TCP to a remote server.
+The `dmidpi` module is instantiated in the hardware simulation to receive the JTAG requests from OpenOCD and drive DMI pins directly.
+
+Note that this module replaces the JTAG Debug Transport Module ("DTM") inside the debug system.
+
+```code
+  |------------|          |------------|          |--------------|
+  |            |          |            |          |              |
+  |            | TCP intf |            | DMI intf |              |
+  |  OpenOCD   |<========>|   dmidpi   |<========>| Debug Module |
+  |  (remote   |          |   (DTM)    |          |              |
+  |   bitbang) |          |            |          |              |
+  |------------|          |------------|          |--------------|
+```
+
+The `remote_bitbang` protocol is documented in the OpenOCD source tree at
+`doc/manual/jtag/drivers/remote_bitbang.txt`, or online at
+https://repo.or.cz/openocd.git/blob/HEAD:/doc/manual/jtag/drivers/remote_bitbang.txt

--- a/hw/dv/dpi/dmidpi/dmidpi.c
+++ b/hw/dv/dpi/dmidpi/dmidpi.c
@@ -1,0 +1,434 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dmidpi.h"
+#include "tcp_server.h"
+
+#include <assert.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// IDCODE register
+// [31:28] 0x0,    - Version
+// [27:12] 0x4F54, - Part Number: "OT"
+// [11:1]  0x426,  - Manufacturer Identity: Google
+// [0]     0x1     - fixed
+const int IDCODEVAL = 0x04F5484D;
+
+// DTMCS register
+// [31:18]  0x0  - fixed
+// [17]     0x0  - dmihardreset (unused)
+// [16]     0x0  - dmireset (unused)
+// [15]     0x0  - fixed
+// [14:12]  0x0  - RunTestIdle cycles required (0)
+// [11:10]  0x0  - DMI status (unused)
+// [9:4]    0x7  - Number of address bits
+// [3:0]    0x1  - Protocol version (0.13)
+const int DTMCSRVAL = 0x00000071;
+
+enum jtag_state_t : uint8_t {
+  TestLogicReset,
+  RunTestIdle,
+  SelectDrScan,
+  CaptureDr,
+  ShiftDr,
+  Exit1Dr,
+  PauseDr,
+  Exit2Dr,
+  UpdateDr,
+  SelectIrScan,
+  CaptureIr,
+  ShiftIr,
+  Exit1Ir,
+  PauseIr,
+  Exit2Ir,
+  UpdateIr
+};
+
+enum jtag_reg_t : uint8_t {
+  Bypass0 = 0x0,
+  IdCode = 0x1,
+  DTMCSR = 0x10,
+  DMIAccess = 0x11,
+  Bypass1 = 0x1f
+};
+
+struct jtag_ctx {
+  uint32_t ir_shift_reg;
+  uint64_t dr_shift_reg;
+  uint32_t ir_captured;
+  uint64_t dr_captured;
+  uint8_t dr_length;
+  uint8_t jtag_tdo;
+  jtag_state_t jtag_state;
+  uint8_t dmi_outstanding;
+};
+
+struct dmi_sig_values {
+  uint8_t dmi_req_valid;
+  uint8_t dmi_req_ready;
+  uint32_t dmi_req_addr;
+  uint32_t dmi_req_op;
+  uint32_t dmi_req_data;
+  uint8_t dmi_rsp_valid;
+  uint8_t dmi_rsp_ready;
+  uint32_t dmi_rsp_data;
+  uint32_t dmi_rsp_resp;
+  uint8_t dmi_rst_n;
+};
+
+struct dmidpi_ctx {
+  struct tcp_server_ctx *sock;
+  struct jtag_ctx jtag;
+  struct dmi_sig_values sig;
+};
+
+/**
+ * Setup the correct shift register data
+ *
+ * @param ctx dmidpi context object
+ */
+static void set_dr_data(struct dmidpi_ctx *ctx) {
+  switch (ctx->jtag.ir_captured) {
+    case Bypass0:
+    case Bypass1:
+      ctx->jtag.dr_shift_reg = 0;
+      ctx->jtag.dr_length = 1;
+      break;
+    case IdCode:
+      ctx->jtag.dr_shift_reg = IDCODEVAL;
+      ctx->jtag.dr_length = 32;
+      break;
+    case DTMCSR:
+      ctx->jtag.dr_shift_reg = DTMCSRVAL;
+      ctx->jtag.dr_length = 32;
+      break;
+    case DMIAccess:
+      ctx->jtag.dr_shift_reg = ctx->jtag.dr_captured;
+      ctx->jtag.dr_length = 32 + 7 + 2;
+  }
+}
+
+/**
+ * Drive a new DMI transaction to the DPI interface
+ *
+ * @param ctx dmidpi context object
+ */
+static void issue_dmi_req(struct dmidpi_ctx *ctx) {
+  ctx->jtag.dmi_outstanding = 1;
+  ctx->sig.dmi_req_valid = 1;
+  ctx->sig.dmi_req_addr = (ctx->jtag.dr_captured >> 34) & 0x7F;
+  ctx->sig.dmi_req_op = ctx->jtag.dr_captured & 0x3;
+  ctx->sig.dmi_req_data = (ctx->jtag.dr_captured >> 2) & 0xFFFFFFFF;
+}
+
+/**
+ * Advance internal JTAG state
+ *
+ * @param ctx dmidpi context object
+ * @param tdi tms tck JTAG signal values
+ * @return true when a command completes, false otherwise
+ */
+static bool process_jtag_cmd(struct dmidpi_ctx *ctx, bool tdi, bool tms,
+                             bool tck) {
+  // Return tdo values during tck low phase
+  if (!tck) {
+    if (ctx->jtag.jtag_state == ShiftDr) {
+      ctx->jtag.jtag_tdo = ctx->jtag.dr_shift_reg & 0x1;
+    } else {
+      ctx->jtag.jtag_tdo = ctx->jtag.ir_shift_reg & 0x1;
+    }
+    return false;
+  }
+
+  // standard JTAG state machine
+  switch (ctx->jtag.jtag_state) {
+    case TestLogicReset:
+      // reset design
+      ctx->sig.dmi_rst_n = 0;
+      ctx->jtag.ir_captured = 1;
+      if (!tms) {
+        ctx->jtag.jtag_state = RunTestIdle;
+      }
+      return true;
+    case RunTestIdle:
+      // release reset
+      ctx->sig.dmi_rst_n = 1;
+      if (tms) {
+        ctx->jtag.jtag_state = SelectDrScan;
+      }
+      return false;
+    case SelectDrScan:
+      if (tms) {
+        ctx->jtag.jtag_state = SelectIrScan;
+      } else {
+        ctx->jtag.jtag_state = CaptureDr;
+      }
+      return false;
+    case CaptureDr:
+      set_dr_data(ctx);
+      if (tms) {
+        ctx->jtag.jtag_state = Exit1Dr;
+      } else {
+        ctx->jtag.jtag_state = ShiftDr;
+      }
+      return false;
+    case ShiftDr:
+      ctx->jtag.dr_shift_reg |= ((uint64_t)tdi << ctx->jtag.dr_length);
+      ctx->jtag.dr_shift_reg >>= 1;
+      if (tms) {
+        ctx->jtag.jtag_state = Exit1Dr;
+      }
+      return false;
+    case Exit1Dr:
+      if (tms) {
+        ctx->jtag.jtag_state = UpdateDr;
+      } else {
+        ctx->jtag.jtag_state = PauseDr;
+      }
+      return false;
+    case PauseDr:
+      if (tms) {
+        ctx->jtag.jtag_state = Exit2Dr;
+      }
+      return false;
+    case Exit2Dr:
+      if (tms) {
+        ctx->jtag.jtag_state = UpdateDr;
+      } else {
+        ctx->jtag.jtag_state = ShiftDr;
+      }
+      return false;
+    case UpdateDr:
+      ctx->jtag.dr_captured = ctx->jtag.dr_shift_reg;
+      if (tms) {
+        ctx->jtag.jtag_state = SelectDrScan;
+      } else {
+        ctx->jtag.jtag_state = RunTestIdle;
+      }
+      // If a DMI read or write completes, write it out
+      if ((ctx->jtag.ir_captured == DMIAccess) &&
+          ((ctx->jtag.dr_captured & 0x3) != 0)) {
+        issue_dmi_req(ctx);
+        return true;
+      }
+      return false;
+    case SelectIrScan:
+      if (tms) {
+        ctx->jtag.jtag_state = TestLogicReset;
+      } else {
+        ctx->jtag.jtag_state = CaptureIr;
+      }
+      return false;
+    case CaptureIr:
+      ctx->jtag.ir_shift_reg = 0x5;
+      if (tms) {
+        ctx->jtag.jtag_state = Exit1Ir;
+      } else {
+        ctx->jtag.jtag_state = ShiftIr;
+      }
+      return false;
+    case ShiftIr:
+      ctx->jtag.ir_shift_reg |= ((uint32_t)tdi << 5);
+      ctx->jtag.ir_shift_reg >>= 1;
+      if (tms) {
+        ctx->jtag.jtag_state = Exit1Ir;
+      }
+      return false;
+    case Exit1Ir:
+      if (tms) {
+        ctx->jtag.jtag_state = UpdateIr;
+      } else {
+        ctx->jtag.jtag_state = PauseIr;
+      }
+      return false;
+    case PauseIr:
+      if (tms) {
+        ctx->jtag.jtag_state = Exit2Ir;
+      }
+      return false;
+    case Exit2Ir:
+      if (tms) {
+        ctx->jtag.jtag_state = UpdateIr;
+      } else {
+        ctx->jtag.jtag_state = ShiftIr;
+      }
+      return false;
+    case UpdateIr:
+      ctx->jtag.ir_captured = ctx->jtag.ir_shift_reg;
+      if (tms) {
+        ctx->jtag.jtag_state = SelectDrScan;
+      } else {
+        ctx->jtag.jtag_state = RunTestIdle;
+      }
+      return false;
+  }
+  return false;
+}
+
+/**
+ * Process a new command byte
+ *
+ * @param ctx a dmi context object
+ * @param cmd a packaged OpenOCD cmd
+ * @return true when a command completes, false otherwise
+ */
+static bool process_cmd_byte(struct dmidpi_ctx *ctx, char cmd) {
+  /*
+   * Documentation pointer:
+   * The remote_bitbang protocol implemented below is documented in the OpenOCD
+   * source tree at doc/manual/jtag/drivers/remote_bitbang.txt, or online at
+   * https://repo.or.cz/openocd.git/blob/HEAD:/doc/manual/jtag/drivers/remote_bitbang.txt
+   */
+
+  // parse received command byte
+  if (cmd >= '0' && cmd <= '7') {
+    // JTAG write
+    char cmd_bit = cmd - '0';
+    char tdi = (cmd_bit >> 0) & 0x1;
+    char tms = (cmd_bit >> 1) & 0x1;
+    char tck = (cmd_bit >> 2) & 0x1;
+    return (process_jtag_cmd(ctx, tdi, tms, tck));
+  } else if (cmd >= 'r' && cmd <= 'u') {
+    // JTAG reset (active high from OpenOCD)
+    char cmd_bit = cmd - 'r';
+    char trst = ((cmd_bit >> 1) & 0x1);
+    if (trst) {
+      ctx->sig.dmi_rst_n = 0;
+      ctx->jtag.jtag_state = RunTestIdle;
+    }
+    return true;
+  } else if (cmd == 'R') {
+    // JTAG read, send tdo as response
+    char tdo_ascii = ctx->jtag.jtag_tdo + '0';
+    tcp_server_write(ctx->sock, tdo_ascii);
+  } else if (cmd == 'B') {
+    // printf("DMI DPI: BLINK ON!\n");
+  } else if (cmd == 'b') {
+    // printf("DMI DPI: BLINK OFF!\n");
+  } else if (cmd == 'Q') {
+    // quit (client disconnect)
+    printf("DMI DPI: Remote disconnected.\n");
+    tcp_server_client_close(ctx->sock);
+  } else {
+    fprintf(stderr,
+            "DMI DPI: Protocol violation detected: unsupported command %c\n",
+            cmd);
+    exit(1);
+  }
+
+  return false;
+}
+
+/**
+ * Process DPI inputs from the design
+ *
+ * @param ctx dmidpi context object
+ */
+static void process_dmi_inputs(struct dmidpi_ctx *ctx) {
+  // Deassert dmi_req_valid when acked
+  if (ctx->sig.dmi_req_ready) {
+    ctx->sig.dmi_req_valid = 0;
+  }
+  // Always ready for a resp
+  ctx->sig.dmi_rsp_ready = 1;
+  if (ctx->sig.dmi_rsp_valid) {
+    ctx->jtag.dr_captured = (uint64_t)ctx->sig.dmi_rsp_data << 2;
+    ctx->jtag.dr_captured |= (uint64_t)ctx->sig.dmi_rsp_resp & 0x3;
+    // Clear req outstanding flag
+    ctx->jtag.dmi_outstanding = 0;
+  }
+}
+
+/**
+ * Advance DMI internal state
+ *
+ * @param ctx dmidpi context object
+ */
+static void update_dmi_state(struct dmidpi_ctx *ctx) {
+  assert(ctx);
+
+  // read input from design
+  process_dmi_inputs(ctx);
+
+  // If we are waiting for a previous transaction to complete, do not attempt
+  // a new one
+  if (ctx->jtag.dmi_outstanding) {
+    return;
+  }
+
+  char done = 0;
+  while (!done) {
+    // read a command byte
+    char cmd;
+    if (!tcp_server_read(ctx->sock, &cmd)) {
+      return;
+    }
+    // Process command bytes until a command completes
+    done = process_cmd_byte(ctx, cmd);
+  }
+}
+
+void *dmidpi_create(const char *display_name, int listen_port) {
+  // Create context
+  struct dmidpi_ctx *ctx =
+      (struct dmidpi_ctx *)calloc(1, sizeof(struct dmidpi_ctx));
+  assert(ctx);
+
+  // Set up socket details
+  ctx->sock = tcp_server_create(display_name, listen_port);
+
+  printf(
+      "\n"
+      "JTAG: Virtual JTAG interface %s is listening on port %d. Use\n"
+      "OpenOCD and the following configuration to connect:\n"
+      "  interface remote_bitbang\n"
+      "  remote_bitbang_host localhost\n"
+      "  remote_bitbang_port %d\n",
+      display_name, listen_port, listen_port);
+
+  return (void *)ctx;
+}
+
+void dmidpi_close(void *ctx_void) {
+  struct dmidpi_ctx *ctx = (struct dmidpi_ctx *)ctx_void;
+  if (!ctx) {
+    return;
+  }
+
+  // Shut down the server
+  tcp_server_close(ctx->sock);
+
+  free(ctx);
+}
+
+void dmidpi_tick(void *ctx_void, svBit *dmi_req_valid,
+                 const svBit dmi_req_ready, svBitVecVal *dmi_req_addr,
+                 svBitVecVal *dmi_req_op, svBitVecVal *dmi_req_data,
+                 const svBit dmi_rsp_valid, svBit *dmi_rsp_ready,
+                 const svBitVecVal *dmi_rsp_data,
+                 const svBitVecVal *dmi_rsp_resp, svBit *dmi_rst_n) {
+  struct dmidpi_ctx *ctx = (struct dmidpi_ctx *)ctx_void;
+
+  if (!ctx) {
+    return;
+  }
+
+  ctx->sig.dmi_req_ready = dmi_req_ready;
+  ctx->sig.dmi_rsp_valid = dmi_rsp_valid;
+  ctx->sig.dmi_rsp_data = *dmi_rsp_data;
+  ctx->sig.dmi_rsp_resp = *dmi_rsp_resp;
+
+  update_dmi_state(ctx);
+
+  *dmi_req_valid = ctx->sig.dmi_req_valid;
+  *dmi_req_addr = ctx->sig.dmi_req_addr;
+  *dmi_req_op = ctx->sig.dmi_req_op;
+  *dmi_req_data = ctx->sig.dmi_req_data;
+  *dmi_rsp_ready = ctx->sig.dmi_rsp_ready;
+  *dmi_rst_n = ctx->sig.dmi_rst_n;
+}

--- a/hw/dv/dpi/dmidpi/dmidpi.core
+++ b/hw/dv/dpi/dmidpi/dmidpi.core
@@ -1,0 +1,20 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv_dpi:dmidpi:0.1"
+description: "DMI DPI for OpenOCD remote_bitbang driver"
+
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:dv_dpi:tcp_server
+    files:
+      - dmidpi.sv: { file_type: systemVerilogSource }
+      - dmidpi.c: { file_type: cSource }
+      - dmidpi.h: { file_type: cSource, is_include_file: true }
+
+targets:
+  default:
+    filesets:
+      - files_rtl

--- a/hw/dv/dpi/dmidpi/dmidpi.h
+++ b/hw/dv/dpi/dmidpi/dmidpi.h
@@ -1,0 +1,52 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef DMIDPI_H_
+#define DMIDPI_H_
+
+#include <svdpi.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Constructor: Create and initialize dmidpi context object
+ *
+ * Call from a initial block.
+ *
+ * @param display_name Name of the interface (for display purposes only)
+ * @param listen_port Port to listen on
+ * @return an initialized struct dmidpi_ctx context object
+ */
+void *dmidpi_create(const char *display_name, int listen_port);
+
+/**
+ * Destructor: Close all connections and free all resources
+ *
+ * Call from a finish block.
+ *
+ * @param ctx_void  a struct dmidpi_ctx context object
+ */
+void dmidpi_close(void *ctx_void);
+
+/**
+ * Drive DMI signals
+ *
+ * Call this function from the simulation at every clock tick to read/write
+ * from/to the DMI signals.
+ *
+ * @param ctx_void  a struct dmidpi_ctx context object
+ */
+void dmidpi_tick(void *ctx_void, svBit *dmi_req_valid,
+                 const svBit dmi_req_ready, svBitVecVal *dmi_req_addr,
+                 svBitVecVal *dmi_req_op, svBitVecVal *dmi_req_data,
+                 const svBit dmi_resp_valid, svBit *dmi_resp_ready,
+                 const svBitVecVal *dmi_resp_data,
+                 const svBitVecVal *dmi_resp_resp, svBit *dmi_reset_n);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+#endif  // DMIDPI_H_

--- a/hw/dv/dpi/dmidpi/dmidpi.sv
+++ b/hw/dv/dpi/dmidpi/dmidpi.sv
@@ -1,0 +1,55 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+module dmidpi #(
+  parameter string Name = "dmi0", // name of the interface (display only)
+  parameter int ListenPort = 44853 // TCP port to listen on
+)(
+  input  bit        clk_i,
+  input  bit        rst_ni,
+
+  output bit        dmi_req_valid,
+  input  bit        dmi_req_ready,
+  output bit [6:0]  dmi_req_addr,
+  output bit [1:0]  dmi_req_op,
+  output bit [31:0] dmi_req_data,
+  input  bit        dmi_rsp_valid,
+  output bit        dmi_rsp_ready,
+  input  bit [31:0] dmi_rsp_data,
+  input  bit [1:0]  dmi_rsp_resp,
+  output bit        dmi_rst_n
+);
+
+  import "DPI-C"
+  function chandle dmidpi_create(input string name, input int listen_port);
+
+  import "DPI-C"
+  function void dmidpi_tick(input chandle ctx, output bit dmi_req_valid,
+                            input bit dmi_req_ready, output bit [6:0] dmi_req_addr,
+                            output bit [1:0] dmi_req_op, output bit [31:0] dmi_req_data,
+                            input bit dmi_rsp_valid, output bit dmi_rsp_ready,
+                            input bit [31:0] dmi_rsp_data, input bit [1:0] dmi_rsp_resp,
+                            output bit dmi_rst_n);
+
+  import "DPI-C"
+  function void dmidpi_close(input chandle ctx);
+
+  chandle ctx;
+
+  initial begin
+    ctx = dmidpi_create(Name, ListenPort);
+  end
+
+  final begin
+    dmidpi_close(ctx);
+    ctx = 0;
+  end
+
+  always_ff @(posedge clk_i, negedge rst_ni) begin
+    dmidpi_tick(ctx, dmi_req_valid, dmi_req_ready, dmi_req_addr, dmi_req_op,
+                dmi_req_data, dmi_rsp_valid, dmi_rsp_ready, dmi_rsp_data,
+                dmi_rsp_resp, dmi_rst_n);
+  end
+
+endmodule

--- a/hw/dv/dpi/jtagdpi/jtagdpi.c
+++ b/hw/dv/dpi/jtagdpi/jtagdpi.c
@@ -3,20 +3,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "jtagdpi.h"
+#include "tcp_server.h"
 
 #include <assert.h>
-#include <errno.h>
-#include <fcntl.h>
-#include <netinet/in.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/socket.h>
-#include <sys/types.h>
-#include <unistd.h>
 
-struct jtag_sig_values {
+struct jtagdpi_ctx {
+  // Server context
+  struct tcp_server_ctx *sock;
+  // Signals
   uint8_t tck;
   uint8_t tms;
   uint8_t tdi;
@@ -25,155 +23,21 @@ struct jtag_sig_values {
   uint8_t srst_n;
 };
 
-struct jtagdpi_ctx {
-  char *display_name;
-  uint16_t listen_port;
-  int sfd;  // socket fd
-  int cfd;  // client fd
-  struct jtag_sig_values sig;
-};
-
 /**
  * Reset the JTAG signals to a "dongle unplugged" state
  */
 static void reset_jtag_signals(struct jtagdpi_ctx *ctx) {
   assert(ctx);
 
-  ctx->sig.tck = 0;
-  ctx->sig.tms = 0;
-  ctx->sig.tdi = 0;
+  ctx->tck = 0;
+  ctx->tms = 0;
+  ctx->tdi = 0;
 
   // trst_n is pulled down (reset active) by default
-  ctx->sig.trst_n = 0;
+  ctx->trst_n = 0;
 
   // srst_n is pulled up (reset not active) by default
-  ctx->sig.srst_n = 1;
-}
-
-/**
- * Start a TCP server
- *
- * @param ctx jtagdpi context object
- * @return 0 on success, -1 in case of an error
- */
-static int tcp_server_start(struct jtagdpi_ctx *ctx) {
-  int rv;
-
-  assert(ctx->sfd == 0 && "Server already started.");
-
-  // create socket
-  int sfd = socket(AF_INET, SOCK_STREAM, 0);
-  if (sfd == -1) {
-    fprintf(stderr, "%s: Unable to create socket: %s (%d)\n", ctx->display_name,
-            strerror(errno), errno);
-    return -1;
-  }
-
-  rv = fcntl(sfd, F_SETFL, O_NONBLOCK);
-  if (rv != 0) {
-    fprintf(stderr, "%s: Unable to make socket non-blocking: %s (%d)\n",
-            ctx->display_name, strerror(errno), errno);
-    return -1;
-  }
-
-  // reuse existing socket (if existing)
-  int reuse_socket = 1;
-  rv = setsockopt(sfd, SOL_SOCKET, SO_REUSEADDR, &reuse_socket, sizeof(int));
-  if (rv != 0) {
-    fprintf(stderr, "%s: Unable to set socket options: %s (%d)\n",
-            ctx->display_name, strerror(errno), errno);
-    return -1;
-  }
-
-  // bind server
-  struct sockaddr_in addr;
-  memset(&addr, 0, sizeof(addr));
-  addr.sin_family = AF_INET;
-  addr.sin_addr.s_addr = htonl(INADDR_ANY);
-  addr.sin_port = htons(ctx->listen_port);
-
-  rv = bind(sfd, (struct sockaddr *)&addr, sizeof(addr));
-  if (rv != 0) {
-    fprintf(stderr, "%s: Failed to bind socket: %s (%d)\n", ctx->display_name,
-            strerror(errno), errno);
-    return -1;
-  }
-
-  // listen for incoming connections
-  rv = listen(sfd, 1);
-  if (rv != 0) {
-    fprintf(stderr, "%s: Failed to listen on socket: %s (%d)\n",
-            ctx->display_name, strerror(errno), errno);
-    return -1;
-  }
-
-  ctx->sfd = sfd;
-  assert(ctx->sfd > 0);
-
-  return 0;
-}
-
-/**
- * Accept an incoming connection from a client (nonblocking)
- *
- * The resulting client fd is made non-blocking.
- *
- * @param ctx jtagdpi context object
- * @return 0 on success, any other value indicates an error
- */
-static int tcp_server_client_tryaccept(struct jtagdpi_ctx *ctx) {
-  int rv;
-
-  assert(ctx->sfd > 0);
-  assert(ctx->cfd == 0);
-
-  int cfd = accept(ctx->sfd, NULL, NULL);
-
-  if (cfd == -1 && errno == EAGAIN) {
-    return -EAGAIN;
-  }
-
-  if (cfd == -1) {
-    fprintf(stderr, "%s: Unable to accept incoming connection: %s (%d)\n",
-            ctx->display_name, strerror(errno), errno);
-    return -1;
-  }
-
-  rv = fcntl(cfd, F_SETFL, O_NONBLOCK);
-  if (rv != 0) {
-    fprintf(stderr, "%s: Unable to make client socket non-blocking: %s (%d)\n",
-            ctx->display_name, strerror(errno), errno);
-    return -1;
-  }
-
-  ctx->cfd = cfd;
-  assert(ctx->cfd > 0);
-
-  printf("%s: Accepted client connection\n", ctx->display_name);
-
-  return 0;
-}
-
-static void tcp_server_client_close(struct jtagdpi_ctx *ctx) {
-  assert(ctx);
-
-  reset_jtag_signals(ctx);
-
-  if (!ctx->cfd) {
-    return;
-  }
-
-  close(ctx->cfd);
-  ctx->cfd = 0;
-}
-
-static void tcp_server_stop(struct jtagdpi_ctx *ctx) {
-  assert(ctx);
-  if (ctx->sfd) {
-    return;
-  }
-  close(ctx->sfd);
-  ctx->sfd = 0;
+  ctx->srst_n = 1;
 }
 
 /**
@@ -181,26 +45,6 @@ static void tcp_server_stop(struct jtagdpi_ctx *ctx) {
  */
 static void update_jtag_signals(struct jtagdpi_ctx *ctx) {
   assert(ctx);
-
-  ssize_t num_read;
-  bool act_send_resp = false;
-  bool act_quit = false;
-
-  if (ctx->sfd == 0) {
-    // Not connected yet
-    return;
-  }
-
-  // accept (possibly) incoming connection
-  if (ctx->cfd == 0) {
-    int rv = tcp_server_client_tryaccept(ctx);
-    if (rv != 0) {
-      // Unable to accept incoming connection (not necessarily an error).
-      // Try again in the next cycle.
-      return;
-    }
-  }
-  assert(ctx->cfd > 0);
 
   /*
    * Documentation pointer:
@@ -211,38 +55,25 @@ static void update_jtag_signals(struct jtagdpi_ctx *ctx) {
 
   // read a command byte
   char cmd;
-  num_read = read(ctx->cfd, &cmd, sizeof(cmd));
-  if (num_read == 0) {
+  if (!tcp_server_read(ctx->sock, &cmd)) {
     return;
   }
-  if (num_read == -1) {
-    if (errno == EAGAIN || errno == EWOULDBLOCK) {
-      return;
-    } else if (errno == EBADF) {
-      // Possibly client went away? Accept a new connection.
-      fprintf(stderr, "%s: Client disappeared.\n", ctx->display_name);
-      tcp_server_client_close(ctx);
-      return;
-    } else {
-      fprintf(stderr, "%s: Error while reading from client: %s (%d)\n",
-              ctx->display_name, strerror(errno), errno);
-      assert(0 && "Error reading from client");
-    }
-  }
-  assert(num_read == 1);
+
+  bool act_send_resp = false;
+  bool act_quit = false;
 
   // parse received command byte
   if (cmd >= '0' && cmd <= '7') {
     // JTAG write
     char cmd_bit = cmd - '0';
-    ctx->sig.tdi = (cmd_bit >> 0) & 0x1;
-    ctx->sig.tms = (cmd_bit >> 1) & 0x1;
-    ctx->sig.tck = (cmd_bit >> 2) & 0x1;
+    ctx->tdi = (cmd_bit >> 0) & 0x1;
+    ctx->tms = (cmd_bit >> 1) & 0x1;
+    ctx->tck = (cmd_bit >> 2) & 0x1;
   } else if (cmd >= 'r' && cmd <= 'u') {
     // JTAG reset (active high from OpenOCD)
     char cmd_bit = cmd - 'r';
-    ctx->sig.srst_n = !((cmd_bit >> 0) & 0x1);
-    ctx->sig.trst_n = !((cmd_bit >> 1) & 0x1);
+    ctx->srst_n = !((cmd_bit >> 0) & 0x1);
+    ctx->trst_n = !((cmd_bit >> 1) & 0x1);
   } else if (cmd == 'R') {
     // JTAG read
     act_send_resp = true;
@@ -254,38 +85,21 @@ static void update_jtag_signals(struct jtagdpi_ctx *ctx) {
     // quit (client disconnect)
     act_quit = true;
   } else {
-    fprintf(stderr, "%s: Protocol violation detected: unsupported command %c\n",
-            ctx->display_name, cmd);
+    fprintf(stderr,
+            "JTAG DPI Protocol violation detected: unsupported command %c\n",
+            cmd);
     exit(1);
   }
 
   // send tdo as response
   if (act_send_resp) {
-    char tdo_ascii = ctx->sig.tdo + '0';
-    while (1) {
-      ssize_t num_written =
-          send(ctx->cfd, &tdo_ascii, sizeof(tdo_ascii), MSG_NOSIGNAL);
-      if (num_written == -1) {
-        if (errno == EAGAIN || errno == EWOULDBLOCK) {
-          continue;
-        } else if (errno == EPIPE) {
-          act_quit = true;
-          break;
-        } else {
-          fprintf(stderr, "%s: Error while writing to client: %s (%d)\n",
-                  ctx->display_name, strerror(errno), errno);
-          assert(0 && "Error writing to client.");
-        }
-      }
-      if (num_written >= 1) {
-        break;
-      }
-    }
+    char tdo_ascii = ctx->tdo + '0';
+    tcp_server_write(ctx->sock, tdo_ascii);
   }
 
   if (act_quit) {
-    printf("%s: Remote disconnected.\n", ctx->display_name);
-    tcp_server_client_close(ctx);
+    printf("JTAG DPI: Remote disconnected.\n");
+    tcp_server_client_close(ctx->sock);
   }
 }
 
@@ -294,18 +108,10 @@ void *jtagdpi_create(const char *display_name, int listen_port) {
       (struct jtagdpi_ctx *)calloc(1, sizeof(struct jtagdpi_ctx));
   assert(ctx);
 
-  ctx->listen_port = listen_port;
-  ctx->display_name = strdup(display_name);
-  assert(ctx->display_name);
+  // Create socket
+  ctx->sock = tcp_server_create(display_name, listen_port);
 
   reset_jtag_signals(ctx);
-
-  int rv = tcp_server_start(ctx);
-  if (rv != 0) {
-    fprintf(stderr, "%s: Unable to create TCP server on port %d\n",
-            ctx->display_name, ctx->listen_port);
-    goto err_cleanup_return;
-  }
 
   printf(
       "\n"
@@ -314,14 +120,9 @@ void *jtagdpi_create(const char *display_name, int listen_port) {
       "  interface remote_bitbang\n"
       "  remote_bitbang_host localhost\n"
       "  remote_bitbang_port %d\n",
-      ctx->display_name, ctx->listen_port, ctx->listen_port);
+      display_name, listen_port, listen_port);
 
   return (void *)ctx;
-
-err_cleanup_return:
-  free(ctx->display_name);
-  free(ctx);
-  return NULL;
 }
 
 void jtagdpi_close(void *ctx_void) {
@@ -329,10 +130,7 @@ void jtagdpi_close(void *ctx_void) {
   if (!ctx) {
     return;
   }
-  tcp_server_client_close(ctx);
-  tcp_server_stop(ctx);
-
-  free(ctx->display_name);
+  tcp_server_close(ctx->sock);
   free(ctx);
 }
 
@@ -340,16 +138,16 @@ void jtagdpi_tick(void *ctx_void, svBit *tck, svBit *tms, svBit *tdi,
                   svBit *trst_n, svBit *srst_n, const svBit tdo) {
   struct jtagdpi_ctx *ctx = (struct jtagdpi_ctx *)ctx_void;
 
-  ctx->sig.tdo = tdo;
+  ctx->tdo = tdo;
 
   // TODO: Evaluate moving this functionality into a separate thread
   if (ctx) {
     update_jtag_signals(ctx);
   }
 
-  *tdi = ctx->sig.tdi;
-  *tms = ctx->sig.tms;
-  *tck = ctx->sig.tck;
-  *srst_n = ctx->sig.srst_n;
-  *trst_n = ctx->sig.trst_n;
+  *tdi = ctx->tdi;
+  *tms = ctx->tms;
+  *tck = ctx->tck;
+  *srst_n = ctx->srst_n;
+  *trst_n = ctx->trst_n;
 }

--- a/hw/dv/dpi/jtagdpi/jtagdpi.core
+++ b/hw/dv/dpi/jtagdpi/jtagdpi.core
@@ -7,11 +7,12 @@ description: "JTAG DPI for OpenOCD remote_bitbang driver (JTAG over TCP)"
 
 filesets:
   files_rtl:
+    depend:
+      - lowrisc:dv_dpi:tcp_server
     files:
       - jtagdpi.sv: { file_type: systemVerilogSource }
       - jtagdpi.c: { file_type: cSource }
       - jtagdpi.h: { file_type: cSource, is_include_file: true }
-
 
 targets:
   default:

--- a/hw/ip/rv_dm/rtl/rv_dm.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm.sv
@@ -262,6 +262,8 @@ module rv_dm #(
     .rdata_o                 ( rdata                 )
   );
 
+  // Bound-in DPI module replaces the TAP
+`ifndef DMIDirectTAP
   // JTAG TAP
   dmi_jtag #(
     .IdcodeValue    (IdcodeValue)
@@ -287,6 +289,7 @@ module rv_dm #(
     .td_o,
     .tdo_oe_o
   );
+`endif
 
   tlul_adapter_sram #(
     .SramAw(AddressWidthWords),

--- a/hw/top_earlgrey/rtl/top_earlgrey_verilator.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_verilator.sv
@@ -74,6 +74,23 @@ module top_earlgrey_verilator (
     .rx_i   (cio_uart_tx_d2p)
   );
 
+`ifdef DMIDirectTAP
+  // OpenOCD direct DMI TAP
+  bind rv_dm dmidpi u_dmidpi (
+    .clk_i,
+    .rst_ni,
+    .dmi_req_valid,
+    .dmi_req_ready,
+    .dmi_req_addr   (dmi_req.addr),
+    .dmi_req_op     (dmi_req.op),
+    .dmi_req_data   (dmi_req.data),
+    .dmi_rsp_valid,
+    .dmi_rsp_ready,
+    .dmi_rsp_data   (dmi_rsp.data),
+    .dmi_rsp_resp   (dmi_rsp.resp),
+    .dmi_rst_n      (dmi_rst_n)
+  );
+`else
   // JTAG DPI for OpenOCD
   jtagdpi u_jtagdpi (
     .clk_i,
@@ -86,6 +103,7 @@ module top_earlgrey_verilator (
     .jtag_trst_n (cio_jtag_trst_n),
     .jtag_srst_n (cio_jtag_srst_n)
   );
+`endif
 
   // SPI DPI
   spidpi u_spi (

--- a/hw/top_earlgrey/top_earlgrey_verilator.core
+++ b/hw/top_earlgrey/top_earlgrey_verilator.core
@@ -11,6 +11,7 @@ filesets:
       - lowrisc:dv_dpi:uartdpi
       - lowrisc:dv_dpi:gpiodpi
       - lowrisc:dv_dpi:jtagdpi
+      - lowrisc:dv_dpi:dmidpi
       - lowrisc:dv_dpi:spidpi
       - lowrisc:dv_verilator:memutil_verilator
       - lowrisc:dv_verilator:simutil_verilator
@@ -42,11 +43,15 @@ parameters:
     datatype : file
     description : Application to load into Flash (in Verilog hex format)
     paramtype : cmdlinearg
-
   rominit:
     datatype : file
     description : Application to load into Boot ROM (in Verilog hex format)
     paramtype : cmdlinearg
+  DMIDirectTAP:
+    datatype: bool
+    paramtype: vlogdefine
+    default: true
+    description: Replace JTAG TAP with an OpenOCD direct connection
 
 targets:
   sim:
@@ -57,6 +62,7 @@ targets:
       - VERILATOR_END_SIM_ADDR=0x10008000
       - flashinit
       - rominit
+      - DMIDirectTAP
     default_tool: verilator
     filesets:
       - files_sim_verilator


### PR DESCRIPTION
Add a direct interface from OpenOCD to DMI transactions. This bypasses all
JTAG shifting and allows a new debug command to be processed every couple of
cycles rather than every ~100 cycles.

This makes debugging performance in simulation ~10 times faster, and enables
debugging while simulation trace is active.

TCP socket functions pulled into a separate library to allow the code to be
reused by both DMI and JTAG interfaces.

Signed-off-by: Tom Roberts <tomroberts@lowrisc.org>