### PR TITLE
[sw] Fix -O3 Infinite Loop in libc functions

### DIFF
--- a/sw/device/lib/abort.c
+++ b/sw/device/lib/abort.c
@@ -4,4 +4,8 @@
 
 #include "sw/device/lib/common.h"
 
-_Noreturn void abort(void) { __builtin_abort(); }
+_Noreturn void abort(void) {
+  while (true) {
+    asm volatile("wfi;");
+  }
+}

--- a/sw/device/lib/meson.build
+++ b/sw/device/lib/meson.build
@@ -12,6 +12,9 @@ sw_lib_mem = declare_dependency(
       'strlen.c',
       'abort.c',
     ],
+    c_args: [
+      '-fno-builtin',
+    ],
   )
 )
 


### PR DESCRIPTION
A classic problem with trying to implement libc is that, at higher
optimisation levels, compilers will recognise the body of your C library
function implementation as a function it knows about, and replace the
body of that function with a call to the same function. This results in
a recursive function, which does absolutely nothing until it causes a
stack overflow.

Thankfully, GCC and clang provide options so you can disable this
recognition and replacement for individual libc functions. In
OpenTitan's case, we only need to do this for the `mem_ot` library,
as we don't mind if other libraries have calls to these libc functions
inserted into them.

We had a similar issue with `abort`, where the call to `__builtin_abort`
was being replaced with a call to `abort`, thus also causing an infinite
loop. This has now been replaced by an infinite loop containing `wfi`,
which should let the core power down.

This was first reported by @GregAC, where he was compiling CoreMark with `-O3`, but I had a hunch this week that it might be happening without us having noticed yet.