### PR TITLE
[sw] Move C Args out of toolchain.txt

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -11,6 +11,10 @@ project(
     'build.c_std=c99',
     'cpp_std=c++14',
     'build.cpp_std=c++14',
+    'warning_level=1',
+    'build.warning_level=1',
+    'werror=true',
+    'build.werror=true',
   ],
 )
 
@@ -39,23 +43,19 @@ endif
 # The following flags are applied to *all* builds, both cross builds
 # and native builds.
 add_project_arguments(
-  '-Wall', '-Werror',
   '-I' + meson.source_root(),
   '-I' + meson.build_root(),
   language: 'cpp', native: false)
 add_project_arguments(
-  '-Wall', '-Werror',
   '-I' + meson.source_root(),
   '-I' + meson.build_root(),
   language: 'cpp', native: true)
 
 add_project_arguments(
-  '-Wall', '-Werror',
   '-I' + meson.source_root(),
   '-I' + meson.build_root(),
   language: 'c', native: false)
 add_project_arguments(
-  '-Wall', '-Werror',
   '-I' + meson.source_root(),
   '-I' + meson.build_root(),
   language: 'c', native: true)

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,10 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-project('opentitan', 'c', 'cpp', version: '0.1',)
+project(
+  'opentitan', 'c', 'cpp',
+  version: '0.1',
+)
 
 target = get_option('target')
 if target == 'undef'

--- a/meson.build
+++ b/meson.build
@@ -15,6 +15,8 @@ project(
     'build.warning_level=1',
     'werror=true',
     'build.werror=true',
+    'debug=true',
+    'build.debug=true',
   ],
 )
 
@@ -63,13 +65,13 @@ add_project_arguments(
 # The following flags are applied only to cross builds
 add_project_arguments(
   '-nostartfiles', '-nostdlib',
-  '-Os', '-g',
+  '-Os',
   '-static',
   '-fvisibility=hidden',
   language: 'cpp', native: false)
 add_project_arguments(
   '-nostartfiles', '-nostdlib',
-  '-Os', '-g',
+  '-Os',
   '-static',
   '-fvisibility=hidden',
   language: 'c', native: false)

--- a/meson.build
+++ b/meson.build
@@ -53,6 +53,26 @@ add_project_arguments(
   '-I' + meson.build_root(),
   language: 'c', native: true)
 
+# The following flags are applied only to cross builds
+add_project_arguments(
+  '-nostartfiles', '-nostdlib',
+  '-Os', '-g',
+  '-static',
+  '-fvisibility=hidden',
+  language: 'cpp', native: false)
+add_project_arguments(
+  '-nostartfiles', '-nostdlib',
+  '-Os', '-g',
+  '-static',
+  '-fvisibility=hidden',
+  language: 'c', native: false)
+add_project_link_arguments(
+  '-nostdlib',
+  language: 'cpp', native: false)
+add_project_link_arguments(
+  '-nostdlib',
+  language: 'c', native: false)
+
 # Common program references.
 prog_python = import('python').find_installation('python3')
 prog_objdump = find_program('objdump')

--- a/meson.build
+++ b/meson.build
@@ -42,6 +42,12 @@ if dev_bin_dir == 'undef' or host_bin_dir == 'undef'
   error('dev_bin_dir option not set. Please run meson with a valid binary directory option.')
 endif
 
+# C Arguments to optimize for size
+optimize_size_args = [
+  '-Os', # General "Optimize for Size" Option
+  '-fvisibility=hidden', # Hide symbols by default
+]
+
 # The following flags are applied to *all* builds, both cross builds
 # and native builds.
 add_project_arguments(
@@ -64,22 +70,22 @@ add_project_arguments(
 
 # The following flags are applied only to cross builds
 add_project_arguments(
+  # Do not use standard system startup files or libraries
   '-nostartfiles', '-nostdlib',
-  '-Os',
-  '-static',
-  '-fvisibility=hidden',
+  '-static', # Only link static files
+  optimize_size_args,
   language: 'cpp', native: false)
 add_project_arguments(
+  # Do not use standard system startup files or libraries
   '-nostartfiles', '-nostdlib',
-  '-Os',
-  '-static',
-  '-fvisibility=hidden',
+  '-static', # Only link static files
+  optimize_size_args,
   language: 'c', native: false)
 add_project_link_arguments(
-  '-nostdlib',
+  '-nostdlib', # Do not use standard system startup files or libraries
   language: 'cpp', native: false)
 add_project_link_arguments(
-  '-nostdlib',
+  '-nostdlib', # Do not use standard system startup files or libraries
   language: 'c', native: false)
 
 # Common program references.

--- a/meson.build
+++ b/meson.build
@@ -5,6 +5,13 @@
 project(
   'opentitan', 'c', 'cpp',
   version: '0.1',
+  meson_version: '>=0.51.0', # Matches version in python-requirements.txt
+  default_options : [
+    'c_std=c99',
+    'build.c_std=c99',
+    'cpp_std=c++14',
+    'build.cpp_std=c++14',
+  ],
 )
 
 target = get_option('target')
@@ -32,23 +39,23 @@ endif
 # The following flags are applied to *all* builds, both cross builds
 # and native builds.
 add_project_arguments(
-  '-std=c++14', '-Wall', '-Werror',
+  '-Wall', '-Werror',
   '-I' + meson.source_root(),
   '-I' + meson.build_root(),
   language: 'cpp', native: false)
 add_project_arguments(
-  '-std=c++14', '-Wall', '-Werror',
+  '-Wall', '-Werror',
   '-I' + meson.source_root(),
   '-I' + meson.build_root(),
   language: 'cpp', native: true)
 
 add_project_arguments(
-  '-std=c99', '-Wall', '-Werror',
+  '-Wall', '-Werror',
   '-I' + meson.source_root(),
   '-I' + meson.build_root(),
   language: 'c', native: false)
 add_project_arguments(
-  '-std=c99', '-Wall', '-Werror',
+  '-Wall', '-Werror',
   '-I' + meson.source_root(),
   '-I' + meson.build_root(),
   language: 'c', native: true)

--- a/meson_init.sh
+++ b/meson_init.sh
@@ -143,7 +143,6 @@ for platform in ${PLATFORMS[@]}; do
     -Ddev_bin_dir="$bin_dir" \
     -Dhost_bin_dir="$HOST_BIN_DIR" \
     --cross-file="$CROSS_FILE" \
-    --buildtype=plain \
     "$obj_dir"
   { set +x; } 2>/dev/null
   purge_includes "$obj_dir"

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -9,13 +9,15 @@ hjson
 isort
 livereload
 mako
-meson
+meson >= 0.51.0 # Matches version in meson.build
 mistletoe>=0.7.2
 pyftdi
 pygments
 pytest
 pyyaml
 yapf
+fusesoc
+gitpython
 
 # Develpment version to get around YAML parser warning triggered by fusesoc
 # Upstream tracking: https://github.com/olofk/ipyxact/issues/19

--- a/toolchain.txt
+++ b/toolchain.txt
@@ -16,18 +16,9 @@ strip = '/tools/riscv/bin/riscv32-unknown-elf-strip'
 [properties]
 has_function_printf = false
 c_args = [
-  '-fvisibility=hidden',
-  '-g',
   '-mabi=ilp32',
   '-march=rv32imc',
-  '-mcmodel=medany',
-  '-nostartfiles',
-  '-nostdlib',
-  '-Os',
-  '-static',
-  '-Wall',
-  '-Werror']
-c_link_args = ['-nostdlib']
+  '-mcmodel=medany']
 
 [build_machine]
 system = 'linux'


### PR DESCRIPTION
Eventually the lowrisc-provided toolchain will be providing its own
toolchain.txt file, which will contain only toolchain-specific
arguments, such as `-march`, `-mabi` and `-mcmodel`.

In advance of this change, this commit moves all of the other C options
out of toolchain.txt and into meson.build.