### PR TITLE
[sw] Avoid GNU Extensions for C

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -40,12 +40,12 @@ add_project_arguments(
   language: 'cpp', native: true)
 
 add_project_arguments(
-  '-std=gnu99', '-Wall', '-Werror',
+  '-std=c99', '-Wall', '-Werror',
   '-I' + meson.source_root(),
   '-I' + meson.build_root(),
   language: 'c', native: false)
 add_project_arguments(
-  '-std=gnu99', '-Wall', '-Werror',
+  '-std=c99', '-Wall', '-Werror',
   '-I' + meson.source_root(),
   '-I' + meson.build_root(),
   language: 'c', native: true)

--- a/sw/device/benchmarks/coremark/top_earlgrey/core_portme.c
+++ b/sw/device/benchmarks/coremark/top_earlgrey/core_portme.c
@@ -33,7 +33,7 @@ volatile ee_s32 seed5_volatile = 0;
 */
 CORETIMETYPE barebones_clock() {
   ee_u32 result;
-  __asm__ volatile("csrr %0, mcycle;" : "=r"(result));
+  asm volatile("csrr %0, mcycle;" : "=r"(result));
   return result;
 }
 /* Define : TIMER_RES_DIVIDER

--- a/sw/device/boot_rom/boot_rom.c
+++ b/sw/device/boot_rom/boot_rom.c
@@ -13,7 +13,7 @@
 #include "sw/device/lib/uart.h"
 
 static inline void try_launch(void) {
-  __asm__ volatile(
+  asm volatile(
       "la a0, _flash_start;"
       "la sp, _stack_start;"
       "jr a0;"

--- a/sw/device/lib/common.h
+++ b/sw/device/lib/common.h
@@ -42,6 +42,8 @@ static const unsigned long UART_BAUD_RATE = 230400;
 #define BITLENGTH(X) \
   ((BITLENGTH_5(BITLENGTH_4(BITLENGTH_3(BITLENGTH_2(BITLENGTH_1(X)))))) & 0x7f)
 
+#define asm __asm__
+
 void *memcpy(void *restrict dest, const void *restrict src, size_t n);
 void *memset(void *dest, int val, size_t n);
 

--- a/sw/device/lib/log.h
+++ b/sw/device/lib/log.h
@@ -141,7 +141,7 @@
  */
 #ifndef PRINT_LOG
 #warning PRINT_LOG undefined: it will result in vacuous invocation
-#define PRINT_LOG(log_header, fmt, ...)
+#define PRINT_LOG(log_header, ...)
 #endif
 
 /**
@@ -164,56 +164,54 @@
  */
 // Print an info message with no verbosity.
 #ifndef LOG_INFO
-#define LOG_INFO(fmt, ...) \
-  PRINT_LOG(LOG_HEADER(LOG_TYPE_INFO, LOG_VERB_NONE), fmt, __VA_ARGS__)
+#define LOG_INFO(...) \
+  PRINT_LOG(LOG_HEADER(LOG_TYPE_INFO, LOG_VERB_NONE), __VA_ARGS__)
 #endif
 
 // Print an info message with low verbosity.
 #ifndef LOG_INFO_LOW
-#define LOG_INFO_LOW(fmt, ...) \
-  PRINT_LOG(LOG_HEADER(LOG_TYPE_INFO, LOG_VERB_LOW), fmt, __VA_ARGS__)
+#define LOG_INFO_LOW(...) \
+  PRINT_LOG(LOG_HEADER(LOG_TYPE_INFO, LOG_VERB_LOW), __VA_ARGS__)
 #endif
 
 // Print an info message with medium verbosity.
 #ifndef LOG_INFO_MEDIUM
-#define LOG_INFO_MEDIUM(fmt, ...) \
-  PRINT_LOG(LOG_HEADER(LOG_TYPE_INFO, LOG_VERB_MEDIUM), fmt, __VA_ARGS__)
+#define LOG_INFO_MEDIUM(...) \
+  PRINT_LOG(LOG_HEADER(LOG_TYPE_INFO, LOG_VERB_MEDIUM), __VA_ARGS__)
 #endif
 
 // Print an info message with high verbosity.
 #ifndef LOG_INFO_HIGH
-#define LOG_INFO_HIGH(fmt, ...) \
-  PRINT_LOG(LOG_HEADER(LOG_TYPE_INFO, LOG_VERB_HIGH), fmt, __VA_ARGS__)
+#define LOG_INFO_HIGH(...) \
+  PRINT_LOG(LOG_HEADER(LOG_TYPE_INFO, LOG_VERB_HIGH), __VA_ARGS__)
 #endif
 
 // Print an info message with full verbosity.
 #ifndef LOG_INFO_FULL
-#define LOG_INFO_FULL(fmt, ...) \
-  PRINT_LOG(LOG_HEADER(LOG_TYPE_INFO, LOG_VERB_FULL), fmt, __VA_ARGS__)
+#define LOG_INFO_FULL(...) \
+  PRINT_LOG(LOG_HEADER(LOG_TYPE_INFO, LOG_VERB_FULL), __VA_ARGS__)
 #endif
 
 // Print an info message with debug verbosity.
 #ifndef LOG_INFO_DEBUG
-#define LOG_INFO_DEBUG(fmt, ...) \
-  PRINT_LOG(LOG_HEADER(LOG_TYPE_INFO, LOG_VERB_DEBUG), fmt, __VA_ARGS__)
+#define LOG_INFO_DEBUG(...) \
+  PRINT_LOG(LOG_HEADER(LOG_TYPE_INFO, LOG_VERB_DEBUG), __VA_ARGS__)
 #endif
 
 // Print a warning message.
 #ifndef LOG_WARNING
-#define LOG_WARNING(fmt, ...) \
-  PRINT_LOG(LOG_HEADER(LOG_TYPE_WARNING, ""), fmt, __VA_ARGS__)
+#define LOG_WARNING(...) \
+  PRINT_LOG(LOG_HEADER(LOG_TYPE_WARNING, ""), __VA_ARGS__)
 #endif
 
 // Print an error message.
 #ifndef LOG_ERROR
-#define LOG_ERROR(fmt, ...) \
-  PRINT_LOG(LOG_HEADER(LOG_TYPE_ERROR, ""), fmt, __VA_ARGS__)
+#define LOG_ERROR(...) PRINT_LOG(LOG_HEADER(LOG_TYPE_ERROR, ""), __VA_ARGS__)
 #endif
 
 // Print a fatal error message.
 #ifndef LOG_FATAL
-#define LOG_FATAL(fmt, ...) \
-  PRINT_LOG(LOG_HEADER(LOG_TYPE_FATAL, ""), fmt, __VA_ARGS__)
+#define LOG_FATAL(...) PRINT_LOG(LOG_HEADER(LOG_TYPE_FATAL, ""), __VA_ARGS__)
 #endif
 
 #endif  // _LOG_H_

--- a/sw/device/lib/log_uart/log_impl.h
+++ b/sw/device/lib/log_uart/log_impl.h
@@ -12,10 +12,6 @@
 #define _LOG_IMPL_STRINGIFY(a) _LOG_IMPL_STRINGIFY_INNER(a)
 #define _LOG_IMPL_STRINGIFY_INNER(a) #a
 
-// The macro below allows forwarding arguments from a variadic macro to a
-// variadic function and support the case where number of arguments is 0.
-#define LOG_IMPL_VA_ARGS(...) , ##__VA_ARGS__
-
 /**
  * Log type and verbosity string constants
  */
@@ -55,7 +51,7 @@
  * use the logging APIs in log.h (which serve as the generic APIs and invoke
  * this macro underneath) instead.
  */
-#define PRINT_LOG(log_header, fmt, ...) \
-  print_log(&uart_send_char, log_header fmt LOG_IMPL_VA_ARGS(__VA_ARGS__));
+#define PRINT_LOG(log_header, ...) \
+  print_log(&uart_send_char, log_header __VA_ARGS__);
 
 #endif  // _LOG_IMPL_H

--- a/sw/device/tests/flash_ctrl/flash_test.c
+++ b/sw/device/tests/flash_ctrl/flash_test.c
@@ -162,5 +162,5 @@ int main(int argc, char **argv) {
 
   // cleanly terminate execution
   uart_send_str("PASS!\r\n");
-  __asm__ volatile("wfi;");
+  asm volatile("wfi;");
 }

--- a/sw/device/tests/hmac/sha256_test.c
+++ b/sw/device/tests/hmac/sha256_test.c
@@ -43,6 +43,6 @@ int main(int argc, char **argv) {
     }
   } else {
     uart_send_str("PASS!\r\n");
-    __asm__ volatile("wfi;");
+    asm volatile("wfi;");
   }
 }

--- a/sw/device/tests/rv_timer/rv_timer_test.c
+++ b/sw/device/tests/rv_timer/rv_timer_test.c
@@ -29,7 +29,7 @@ int main(int argc, char **argv) {
   }
 
   uart_send_str("PASS!\r\n");
-  __asm__ volatile("wfi;");
+  asm volatile("wfi;");
 }
 
 // Override weak default function

--- a/sw/host/spiflash/Makefile
+++ b/sw/host/spiflash/Makefile
@@ -9,7 +9,7 @@ MPSSE_DIR = ../vendor/mpsse
 MPSSE_OBJS = $(MPSSE_DIR)/mpsse.o $(MPSSE_DIR)/support.o
 
 INC += -I../../.. # i.e., $REPO_TOP.
-CFLAGS += $(INC) -std=gnu99
+CFLAGS += $(INC) -std=c99
 CXXFLAGS += $(INC) -Wall -std=c++14
 LDFLAGS += -lcrypto -lftdi1 -lusb-1.0 -L/usr/lib/x86_64-linux-gnu
 DEPS  = spi_interface.h updater.h verilator_spi_interface.h ftdi_spi_interface.h

--- a/sw/host/vendor/mpsse.lock.hjson
+++ b/sw/host/vendor/mpsse.lock.hjson
@@ -9,7 +9,7 @@
   upstream:
   {
     url: https://chromium.googlesource.com/chromiumos/platform2/
-    rev: e729a61489259d1bf34e6df7f8e284febf02da2e
+    rev: 8ff08453c2223c1269b2d6127bfdfd32e3038ada
     only_subdir: trunks/ftdi
   }
 }

--- a/sw/host/vendor/mpsse/mpsse.c
+++ b/sw/host/vendor/mpsse/mpsse.c
@@ -22,6 +22,7 @@
  * 27 December 2011
  */
 
+#define _XOPEN_SOURCE 500
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>

--- a/sw/host/vendor/patches/mpsse/0004-mpsse-ensure-usleep-available.patch
+++ b/sw/host/vendor/patches/mpsse/0004-mpsse-ensure-usleep-available.patch
@@ -1,0 +1,11 @@
+diff -u a/mpsse.c b/mpsse.c
+--- a/mpsse.c	2019-11-29 16:38:40.000000000 +0000
++++ b/mpsse.c	2019-11-29 16:38:31.000000000 +0000
+@@ -22,6 +22,7 @@
+  * 27 December 2011
+  */
+ 
++#define _XOPEN_SOURCE 500
+ #include <stdlib.h>
+ #include <string.h>
+ #include <stdint.h>


### PR DESCRIPTION
We want to keep the C that we are writing as close to standard C as
possible. This means switching off `-std=gnu99` in favour of `-std=c99`,
which should lead to better compiler warnings and errors.

Things needed to make this work:
- the variadic logging functions needed to be updated, as there's an issue in the C standard with `__VA_ARGS__` expanding to no arguments.
- a define is needed for mpsse to ensure `usleep` is available. This is added as a patch and a re-vendoring.
- an `asm` macro (expands to `__asm__`), as noted in the Assembly Style Guide

This commit does not update opentitan from C99 to C11, as that change has not yet been agreed.