### PR TITLE
[sw] Bring back debug symbols in ELF files

### DIFF
--- a/sw/device/boot_rom/rom_link.ld
+++ b/sw/device/boot_rom/rom_link.ld
@@ -38,7 +38,6 @@ SECTIONS
     .text : {
         . = ALIGN(4);
         _stext = .;
-        *(.text.startup)
         *(.text)
         *(.text.unlikely)
         _etext  =  .;
@@ -105,7 +104,4 @@ SECTIONS
     {
         [ .stabstr ]
     }
-
-    /* Discard the remaining sections */
-    /DISCARD/ : { *(*) }
 }

--- a/sw/device/exts/common/link.ld
+++ b/sw/device/exts/common/link.ld
@@ -36,7 +36,6 @@ SECTIONS
     .text : {
         . = ALIGN(0x100);
         _stext = .;
-        *(.text.startup)
         *(.text)
         *(.text.unlikely)
         _etext  =  .;
@@ -106,9 +105,6 @@ SECTIONS
     {
         [ .stabstr ]
     }
-
-    /* Discard the remaining sections */
-    /DISCARD/ : { *(*) }
 }
 
 ENTRY(main)

--- a/sw/device/exts/common/meson.build
+++ b/sw/device/exts/common/meson.build
@@ -6,7 +6,14 @@
 riscv_linker_script = '@0@/@1@'.format(meson.source_root(), files(['link.ld'])[0])
 riscv_linker_args = [
   '-Wl,-T,@0@'.format(riscv_linker_script),
-  # Ensure we don't include a build-id attribute in the ELF.
+  # Depending on the compiler and its configuration (*), |--build-id| is passed
+  # to the linker, causing the insertion of a ".note.gnu.build-id" section into
+  # the ELF file. We do not use the build ID. Achieve consistent behavior and
+  # potentially a small improvement in linking time by not computing the build
+  # ID in the first place.
+  #
+  # * GCC built with |--enable-linker-build-id|, clang before 3.9 or built with
+  #   |-DENABLE_LINKER_BUILD_ID|.
   '-Wl,--build-id=none',
 ]
 

--- a/util/embedded_target.py
+++ b/util/embedded_target.py
@@ -32,7 +32,7 @@ def run_objcopy(objcopy, input, basename, outdir):
 
 def run_srec_cat(srec_cat, input, basename, outdir):
     # TODO: Replace command for objcopy once this bug is fixed and released.
-    # https://sourceware.org/bugzilla/show_bug.cgi?id=19921
+    # https://github.com/lowRISC/opentitan/issues/1107
     filename = basename + '.vmem'
     output = os.path.join(outdir, filename)
     cmd = [


### PR DESCRIPTION
ELF files did get their debug symbols stripped by our linker script. That's not really intended; we want to use the ELF files for debugging, and the ELF loader should take care that only required sections will end up being loaded. Thankfully the build id section was already removed with a linker flag, so the linker script part was unnecessary. Revert that commit and add a couple more cleanups along the way.