### PR TITLE
[ci] Only perform step if dependencies succeeded

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -117,7 +117,7 @@ jobs:
 - job: "sw_build"
   displayName: "Build Software"
   dependsOn: lint
-  condition: eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0')
+  condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'))
   pool:
     vmImage: "ubuntu-16.04"
   steps:
@@ -147,7 +147,7 @@ jobs:
 - job: "deprecated_make_build"
   displayName: "Build Software with Make (deprecated)"
   dependsOn: lint
-  condition: eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0')
+  condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'))
   pool: Default
   steps:
   - bash: |
@@ -171,7 +171,7 @@ jobs:
 - job: "top_earlgrey_verilator"
   displayName: "Build Verilator simulation of the Earl Grey toplevel design"
   dependsOn: lint
-  condition: eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0')
+  condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'))
   pool: Default
   steps:
   - bash: |
@@ -226,7 +226,7 @@ jobs:
     - lint
     # The bootrom is built into the FPGA image at synthesis time.
     - sw_build
-  condition: eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0')
+  condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'))
   pool: Default
   timeoutInMinutes: 120 # 2 hours
   steps:


### PR DESCRIPTION
Our use of `condition:` overwrote the default behavior, in which a job
is only performed if all dependencies succeeded. Add back that behavior
by explicitly checking for `succeeded()`. This prevents for example the
FPGA synthesis job to start if the software build failed (and hence
cannot provide the FPGA build with the requried bootrom file).

Documentation:
- https://docs.microsoft.com/en-us/azure/devops/pipelines/process/conditions?view=azure-devops&tabs=yaml
- https://docs.microsoft.com/en-us/azure/devops/pipelines/process/expressions?view=azure-devops#succeeded

Example pipeline with this problem: https://dev.azure.com/lowrisc/opentitan/_build/results?buildId=6152&view=results