### PR TITLE
[DV/DPI] Add logic type to IO declaration

### DIFF
--- a/hw/dv/dpi/gpiodpi/gpiodpi.sv
+++ b/hw/dv/dpi/gpiodpi/gpiodpi.sv
@@ -7,12 +7,12 @@ module gpiodpi
   parameter string NAME = "gpio0",
   parameter        N_GPIO = 32
 )(
-  input               clk_i,
-  input               rst_ni,
+  input  logic              clk_i,
+  input  logic              rst_ni,
 
-  output [N_GPIO-1:0] gpio_p2d,
-  input [N_GPIO-1:0]  gpio_d2p,
-  input [N_GPIO-1:0]  gpio_en_d2p
+  output logic [N_GPIO-1:0] gpio_p2d,
+  input  logic [N_GPIO-1:0] gpio_d2p,
+  input  logic [N_GPIO-1:0] gpio_en_d2p
 );
    import "DPI-C" function
      chandle gpiodpi_create(input string name, input int n_bits);

--- a/hw/dv/dpi/spidpi/spidpi.sv
+++ b/hw/dv/dpi/spidpi/spidpi.sv
@@ -14,13 +14,13 @@ module spidpi
   parameter MODE = 0,
   parameter LOG_LEVEL = 9
   )(
-  input  clk_i,
-  input  rst_ni,
-  output spi_device_sck_o,
-  output spi_device_csb_o,
-  output spi_device_mosi_o,
-  input  spi_device_miso_i,
-  input  spi_device_miso_en_i
+  input  logic clk_i,
+  input  logic rst_ni,
+  output logic spi_device_sck_o,
+  output logic spi_device_csb_o,
+  output logic spi_device_mosi_o,
+  input  logic spi_device_miso_i,
+  input  logic spi_device_miso_en_i
 
 );
   import "DPI-C" function


### PR DESCRIPTION
- Fixes #1092 (compilation failures in newer Verilator versions)

Signed-off-by: Tom Roberts <tomroberts@lowrisc.org>