### PR TITLE
[coremark] Fix some issues with Meson coremark.

### DIFF
--- a/sw/device/benchmarks/coremark/meson.build
+++ b/sw/device/benchmarks/coremark/meson.build
@@ -3,38 +3,49 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if target == 'sim-verilator'
-  iterations = '-DITERATIONS=1'
+  coremark_iterations = 1
 else
-  iterations = '-DITERATIONS=100'
+  coremark_iterations = 100
 endif
 
-coremark_elf = executable(
-  'coremark',
-  sources: ['./top_earlgrey/core_portme.c',
-            './top_earlgrey/ee_printf.c',
-            coremark_base_files],
+coremark_top_earlgrey_elf = executable(
+  'coremark_top_earlgrey',
+  sources: [
+    'top_earlgrey/core_portme.c',
+    'top_earlgrey/ee_printf.c',
+    vendor_coremark_base_files,
+  ],
   name_suffix: 'elf',
   dependencies: [
     sw_lib_uart,
     sw_lib_mem,
     riscv_crt,
   ],
-  c_args : ['-DPERFORMANCE_RUN=1', iterations, '-DTOTAL_DATA_SIZE=2000', '-DMAIN_HAS_NOARGC=1']
+  # Set up coremark-specific defines.
+  c_args: [
+    '-DITERATIONS=@0@'.format(coremark_iterations),
+    '-DPERFORMANCE_RUN=1',
+    '-DTOTAL_DATA_SIZE=2000',
+    '-DMAIN_HAS_NOARGC=1',
+  ],
 )
 
-coremark_embedded = custom_target(
-  'coremark',
+coremark_top_earlgrey_embedded = custom_target(
+  'coremark_top_earlgrey',
   command: make_embedded_target,
-  input: coremark_elf,
+  input: coremark_top_earlgrey_elf,
   output: make_embedded_target_outputs,
   build_by_default: true,
 )
 
 custom_target(
-  'coremark_export',
+  'coremark_top_earlgrey_export',
   command: export_embedded_target,
-  input: [coremark_elf, coremark_embedded],
-  output: 'coremark_export',
+  input: [
+    coremark_top_earlgrey_elf,
+    coremark_top_earlgrey_embedded,
+  ],
+  output: 'coremark_top_earlgrey_export',
   build_always_stale: true,
   build_by_default: true,
 )

--- a/sw/device/benchmarks/coremark/top_earlgrey/core_portme.h
+++ b/sw/device/benchmarks/coremark/top_earlgrey/core_portme.h
@@ -12,8 +12,6 @@
 #ifndef CORE_PORTME_H
 #define CORE_PORTME_H
 
-#include <sys/types.h>
-
 #include "sw/device/lib/common.h"
 #include "sw/device/lib/uart.h"
 

--- a/sw/vendor/meson.build
+++ b/sw/vendor/meson.build
@@ -2,9 +2,10 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-coremark_base_files = files([
-  './eembc_coremark/core_list_join.c',
-  './eembc_coremark/core_main.c',
-  './eembc_coremark/core_matrix.c',
-  './eembc_coremark/core_state.c',
-  './eembc_coremark/core_util.c'])
+vendor_coremark_base_files = files([
+  'eembc_coremark/core_list_join.c',
+  'eembc_coremark/core_main.c',
+  'eembc_coremark/core_matrix.c',
+  'eembc_coremark/core_state.c',
+  'eembc_coremark/core_util.c',
+])


### PR DESCRIPTION
Fix up coremark's Meson files, so they match the style of the rest of the project; I've also renamed some variables to be a bit more unique, since all variables in Meson are in a global namespace.

Also, building embedded targets with Meson cannot included UNIX <sys/...> headers, so I've gotten rid of the one instance of that, too.