### PR TITLE
[hw] Make reggen generate a *_REG_OFFSET macro.

### DIFF
--- a/util/reggen/gen_cheader.py
+++ b/util/reggen/gen_cheader.py
@@ -89,6 +89,7 @@ def gen_cdefine_register(outstr, reg, comp, width, rnames):
         gen_define(
             defname, ['id'],
             '(' + as_define(comp) + '##id##_BASE_ADDR + ' + hex(offset) + ')'))
+    genout(outstr, gen_define(defname + '_REG_OFFSET', [], hex(offset)))
 
     for field in reg['fields']:
         fieldlsb = field['bitinfo'][2]
@@ -131,6 +132,7 @@ def gen_cdefine_window(outstr, win, comp, regwidth, rnames):
         gen_define(
             defname, ['id'],
             '(' + as_define(comp) + '##id##_BASE_ADDR + ' + hex(offset) + ')'))
+    genout(outstr, gen_define(defname + '_REG_OFFSET', [], hex(offset)))
     items = int(win['items'])
     genout(outstr, gen_define(defname + '_SIZE_WORDS', [], str(items)))
     items = items * (regwidth // 8)


### PR DESCRIPTION
This change makes it possible for DIFs to access the register offset directly, rather than having to do tricky things with macros (example at #1111). This will make writing DIFs a little bit easier.

The `*_REG_OFFSET` name was chosen since both `_OFFSET` and `_BASE_OFFSET` are in use; I can change it to something else if desired.