### PR TITLE
[dv/hmac] Fix Xcelium compile error

### DIFF
--- a/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
@@ -60,7 +60,7 @@ class hmac_base_vseq extends cip_base_vseq #(.CFG_T               (hmac_env_cfg)
   virtual task dut_init(string reset_kind = "HARD");
     super.dut_init(reset_kind);
     // TODO: need agent for full alert protocol
-    cfg.msg_push_sha_disabled_alert_vif.pins[PingEn] = 0;
+    cfg.msg_push_sha_disabled_alert_vif.drive_pin(.idx(PingEn), .val(0));
     if (do_hmac_init) hmac_init();
   endtask
 


### PR DESCRIPTION
Shouldn't drive wire (pins_if.pins) in task, use pins_if.drive_pin
instead

Signed-off-by: Weicai Yang <weicai@google.com>