### PR TITLE
[site] Suppress non-printworthy styling in print

### DIFF
--- a/site/docs/assets/scss/_main-header.scss
+++ b/site/docs/assets/scss/_main-header.scss
@@ -39,6 +39,12 @@
   }
 }
 
+@media print {
+  .skip-link, .main-header {
+    display: none;
+  }
+}
+
 .logo {
   font-size: 1em;
   width: 12.5em;

--- a/site/docs/assets/scss/_toc.scss
+++ b/site/docs/assets/scss/_toc.scss
@@ -68,3 +68,9 @@
     }
   }
 }
+
+@media print {
+  .toc {
+    display: none;
+  }
+}


### PR DESCRIPTION
Suppress the rendering of several elements during printing: the table of
contents, the header, and skip-to-content links.

Fixes #1123

Signed-off-by: Garret Kelly <gdk@google.com>