### PR TITLE
[xbar/dv] Fix compile warning at xbar bind file

### DIFF
--- a/hw/top_earlgrey/dv/Makefile
+++ b/hw/top_earlgrey/dv/Makefile
@@ -18,7 +18,7 @@ export DUT_TOP  := top_earlgrey
 export TB_TOP   := tb
 FUSESOC_CORE    := lowrisc:dv:chip_sim:0.1
 COMPILE_KEY     ?= default
-TOPS            := ${TB_TOP}
+TOPS            := ${TB_TOP} xbar_main_bind
 
 # Override RAL generation here
 RAL_PKG_NAME    ?= chip
@@ -30,6 +30,10 @@ RAL_TOOL_OPTS   += --top
 TEST_NAME       ?= chip_sanity
 UVM_TEST        ?= chip_base_test
 UVM_TEST_SEQ    ?= chip_base_vseq
+
+# TODO don't check TLUL completion at the end of sim, current sim may complete before TL
+# transaction is completed
+RUN_OPTS        += +disable_assert_final_checks
 
 ifeq (${TEST_NAME},chip_sanity)
   SW_DIR         = examples/hello_world

--- a/hw/top_earlgrey/ip/xbar/dv/autogen/xbar_main_bind.sv
+++ b/hw/top_earlgrey/ip/xbar/dv/autogen/xbar_main_bind.sv
@@ -6,19 +6,19 @@
 module xbar_main_bind;
 
   // Host interfaces
-  bind xbar_main tlul_assert tlul_assert_host_corei (
+  bind xbar_main tlul_assert #(.EndpointType("Device")) tlul_assert_host_corei (
     .clk_i  (clk_main_i),
     .rst_ni (rst_main_ni),
     .h2d    (tl_corei_i),
     .d2h    (tl_corei_o)
   );
-  bind xbar_main tlul_assert tlul_assert_host_cored (
+  bind xbar_main tlul_assert #(.EndpointType("Device")) tlul_assert_host_cored (
     .clk_i  (clk_main_i),
     .rst_ni (rst_main_ni),
     .h2d    (tl_cored_i),
     .d2h    (tl_cored_o)
   );
-  bind xbar_main tlul_assert tlul_assert_host_dm_sba (
+  bind xbar_main tlul_assert #(.EndpointType("Device")) tlul_assert_host_dm_sba (
     .clk_i  (clk_main_i),
     .rst_ni (rst_main_ni),
     .h2d    (tl_dm_sba_i),
@@ -26,91 +26,91 @@ module xbar_main_bind;
   );
 
   // Device interfaces
-  bind xbar_main tlul_assert tlul_assert_device_rom (
+  bind xbar_main tlul_assert #(.EndpointType("Host")) tlul_assert_device_rom (
     .clk_i  (clk_main_i),
     .rst_ni (rst_main_ni),
     .h2d    (tl_rom_o),
     .d2h    (tl_rom_i)
   );
-  bind xbar_main tlul_assert tlul_assert_device_debug_mem (
+  bind xbar_main tlul_assert #(.EndpointType("Host")) tlul_assert_device_debug_mem (
     .clk_i  (clk_main_i),
     .rst_ni (rst_main_ni),
     .h2d    (tl_debug_mem_o),
     .d2h    (tl_debug_mem_i)
   );
-  bind xbar_main tlul_assert tlul_assert_device_ram_main (
+  bind xbar_main tlul_assert #(.EndpointType("Host")) tlul_assert_device_ram_main (
     .clk_i  (clk_main_i),
     .rst_ni (rst_main_ni),
     .h2d    (tl_ram_main_o),
     .d2h    (tl_ram_main_i)
   );
-  bind xbar_main tlul_assert tlul_assert_device_eflash (
+  bind xbar_main tlul_assert #(.EndpointType("Host")) tlul_assert_device_eflash (
     .clk_i  (clk_main_i),
     .rst_ni (rst_main_ni),
     .h2d    (tl_eflash_o),
     .d2h    (tl_eflash_i)
   );
-  bind xbar_main tlul_assert tlul_assert_device_uart (
+  bind xbar_main tlul_assert #(.EndpointType("Host")) tlul_assert_device_uart (
     .clk_i  (clk_fixed_i),
     .rst_ni (rst_fixed_ni),
     .h2d    (tl_uart_o),
     .d2h    (tl_uart_i)
   );
-  bind xbar_main tlul_assert tlul_assert_device_gpio (
+  bind xbar_main tlul_assert #(.EndpointType("Host")) tlul_assert_device_gpio (
     .clk_i  (clk_fixed_i),
     .rst_ni (rst_fixed_ni),
     .h2d    (tl_gpio_o),
     .d2h    (tl_gpio_i)
   );
-  bind xbar_main tlul_assert tlul_assert_device_spi_device (
+  bind xbar_main tlul_assert #(.EndpointType("Host")) tlul_assert_device_spi_device (
     .clk_i  (clk_fixed_i),
     .rst_ni (rst_fixed_ni),
     .h2d    (tl_spi_device_o),
     .d2h    (tl_spi_device_i)
   );
-  bind xbar_main tlul_assert tlul_assert_device_flash_ctrl (
+  bind xbar_main tlul_assert #(.EndpointType("Host")) tlul_assert_device_flash_ctrl (
     .clk_i  (clk_main_i),
     .rst_ni (rst_main_ni),
     .h2d    (tl_flash_ctrl_o),
     .d2h    (tl_flash_ctrl_i)
   );
-  bind xbar_main tlul_assert tlul_assert_device_rv_timer (
+  bind xbar_main tlul_assert #(.EndpointType("Host")) tlul_assert_device_rv_timer (
     .clk_i  (clk_fixed_i),
     .rst_ni (rst_fixed_ni),
     .h2d    (tl_rv_timer_o),
     .d2h    (tl_rv_timer_i)
   );
-  bind xbar_main tlul_assert tlul_assert_device_hmac (
+  bind xbar_main tlul_assert #(.EndpointType("Host")) tlul_assert_device_hmac (
     .clk_i  (clk_main_i),
     .rst_ni (rst_main_ni),
     .h2d    (tl_hmac_o),
     .d2h    (tl_hmac_i)
   );
-  bind xbar_main tlul_assert tlul_assert_device_aes (
+  bind xbar_main tlul_assert #(.EndpointType("Host")) tlul_assert_device_aes (
     .clk_i  (clk_main_i),
     .rst_ni (rst_main_ni),
     .h2d    (tl_aes_o),
     .d2h    (tl_aes_i)
   );
-  bind xbar_main tlul_assert tlul_assert_device_rv_plic (
+  bind xbar_main tlul_assert #(.EndpointType("Host")) tlul_assert_device_rv_plic (
     .clk_i  (clk_main_i),
     .rst_ni (rst_main_ni),
     .h2d    (tl_rv_plic_o),
     .d2h    (tl_rv_plic_i)
   );
-  bind xbar_main tlul_assert tlul_assert_device_pinmux (
+  bind xbar_main tlul_assert #(.EndpointType("Host")) tlul_assert_device_pinmux (
     .clk_i  (clk_main_i),
     .rst_ni (rst_fixed_ni),
     .h2d    (tl_pinmux_o),
     .d2h    (tl_pinmux_i)
   );
-  bind xbar_main tlul_assert tlul_assert_device_alert_handler (
+  bind xbar_main tlul_assert #(.EndpointType("Host")) tlul_assert_device_alert_handler (
     .clk_i  (clk_main_i),
     .rst_ni (rst_main_ni),
     .h2d    (tl_alert_handler_o),
     .d2h    (tl_alert_handler_i)
   );
-  bind xbar_main tlul_assert tlul_assert_device_nmi_gen (
+  bind xbar_main tlul_assert #(.EndpointType("Host")) tlul_assert_device_nmi_gen (
     .clk_i  (clk_main_i),
     .rst_ni (rst_main_ni),
     .h2d    (tl_nmi_gen_o),

--- a/util/tlgen.py
+++ b/util/tlgen.py
@@ -88,7 +88,7 @@ def main():
     with pkg_filepath.open(mode='w', encoding='UTF-8') as fout:
         fout.write(out_pkg)
 
-    dv_filename = "xbar_%s_tb.sv" % (xbar.name)
+    dv_filename = "xbar_%s_bind.sv" % (xbar.name)
     dv_filepath = dv_path / dv_filename
     with dv_filepath.open(mode='w', encoding='UTF-8') as fout:
         fout.write(out_dv)

--- a/util/tlgen/xbar.bind.sv.tpl
+++ b/util/tlgen/xbar.bind.sv.tpl
@@ -7,7 +7,7 @@ module xbar_${xbar.name}_bind;
 
   // Host interfaces
 % for node in xbar.hosts:
-  bind xbar_${xbar.name} tlul_assert tlul_assert_host_${node.name} (
+  bind xbar_${xbar.name} tlul_assert #(.EndpointType("Device")) tlul_assert_host_${node.name} (
     .clk_i  (${node.clocks[0]}),
     .rst_ni (${node.resets[0]}),
     .h2d    (tl_${node.name}_i),
@@ -17,7 +17,7 @@ module xbar_${xbar.name}_bind;
 
   // Device interfaces
 % for node in xbar.devices:
-  bind xbar_${xbar.name} tlul_assert tlul_assert_device_${node.name} (
+  bind xbar_${xbar.name} tlul_assert #(.EndpointType("Host")) tlul_assert_device_${node.name} (
     .clk_i  (${node.clocks[0]}),
     .rst_ni (${node.resets[0]}),
     .h2d    (tl_${node.name}_o),


### PR DESCRIPTION
1. Update tlgen.py to generate bind file with corrent endpoint
2. Add xbar_main_bind as a top
Signed-off-by: Weicai Yang <weicai@google.com>