### PR TITLE
[verilator] Load ELF files

### DIFF
--- a/ci/run_verilator_pytest.sh
+++ b/ci/run_verilator_pytest.sh
@@ -12,20 +12,20 @@ readonly SW_BUILD_DEFAULT="$(sw_bin_dir sim-verilator)"
 VERILATED_SYSTEM_PATH="${VERILATED_SYSTEM_PATH:-$VERILATED_SYSTEM_DEFAULT}"
 SW_BUILD_PATH="${SW_BUILD_PATH:-$SW_BUILD_DEFAULT}"
 
-BOOT_ROM_TARGET="boot_rom/boot_rom.vmem"
+BOOT_ROM_TARGET="boot_rom/boot_rom.elf"
 
 TEST_TARGETS=(
-  "tests/flash_ctrl/flash_test.vmem"
-  "tests/hmac/sha256_test.vmem"
-  "tests/rv_timer/rv_timer_test.vmem"
+  "tests/flash_ctrl/flash_test.elf"
+  "tests/hmac/sha256_test.elf"
+  "tests/rv_timer/rv_timer_test.elf"
 )
 
 if [[ ! -z ${MAKE_BUILD+x} ]]; then
-  BOOT_ROM_TARGET="sw/device/sim/boot_rom/rom.vmem"
+  BOOT_ROM_TARGET="sw/device/sim/boot_rom/rom.elf"
   TEST_TARGETS=(
-    "sw/device/sim/tests/flash_ctrl/sw.vmem"
-    "sw/device/sim/tests/hmac/sw.vmem"
-    "sw/device/sim/tests/rv_timer/sw.vmem"
+    "sw/device/sim/tests/flash_ctrl/sw.elf"
+    "sw/device/sim/tests/hmac/sw.elf"
+    "sw/device/sim/tests/rv_timer/sw.elf"
   )
 fi
 

--- a/doc/ug/getting_started_verilator.md
+++ b/doc/ug/getting_started_verilator.md
@@ -36,13 +36,13 @@ $ make -C sw/device SIM=1 SW_DIR=examples/hello_world \
 ```
 
 Now the simulation can be run.
-The program listed after `--rominit` and `--flashinit` are loaded into the system's respective memories and start executing immediately.
+The programs listed after `--meminit` are loaded into the system's specified memory and execution is started immediately.
 
 ```console
 $ cd $REPO_TOP
 $ build/lowrisc_systems_top_earlgrey_verilator_0.1/sim-verilator/Vtop_earlgrey_verilator \
-  --rominit=sw/device/sim_boot_rom/rom.vmem \
-  --flashinit=sw/device/sim_hello_world/sw.vmem
+  --meminit=rom,sw/device/sim_boot_rom/rom.elf \
+  --meminit=flash,sw/device/sim_hello_world/sw.elf
 ```
 
 To stop the simulation press CTRL-c.
@@ -166,8 +166,8 @@ Tracing slows down the simulation by roughly factor of 1000.
 ```console
 $ cd $REPO_TOP
 $ build/lowrisc_systems_top_earlgrey_verilator_0.1/sim-verilator/Vtop_earlgrey_verilator \
-  --rominit=sw/device/sim_boot_rom/rom.vmem \
-  --flashinit=sw/device/sim_hello_world/sw.vmem \
+  --meminit=rom,sw/device/sim_boot_rom/rom.elf \
+  --meminit=flash,sw/device/sim_hello_world/sw.elf \
   --trace
 $ gtkwave sim.fst
 ```

--- a/sw/device/benchmarks/coremark/README.md
+++ b/sw/device/benchmarks/coremark/README.md
@@ -10,8 +10,8 @@ ninja -C build-out/sw/${TARGET} sw/device/benchmarks/coremark/coremark_export
 
 Where ${TARGET} is one of 'sim-verilator' or 'fpga'
 
-This will give you a .bin and .vmem file (suitable for either spiflash or
-giving directly to --flashinit for verilator) which can be found in
+This will give you a .bin and .elf file (suitable for either spiflash or
+giving directly to `--meminit` for Verilator) which can be found in
 `build-bin/sw/device/fpga/benchmarks/coremark`
 
 # CoreMark Options

--- a/sw/device/examples/hello_world/README.md
+++ b/sw/device/examples/hello_world/README.md
@@ -10,18 +10,3 @@ The test monitors changing values on the GPIO line and reports them over UART.
 
 ## SPI Echo Over UART
 All data input over SPI is echo'd on UART in a word aligned fashion.
-The sample output below is hello_world run on a verilator model.
-```shell
-$ ./Vtop_earlgrey_verilator --rominit=sw/device/boot_rom/rom.vmem --flashinit=sw/device/examples/hello_world/sw.vmem
-```
-
-Output:
-```
-dddd 1234 tgbf
-```
-
-```
-SPI: dddd
-SPI: 1234
-SPI: tgbf
-```

--- a/test/systemtest/functional_verilator_test.py
+++ b/test/systemtest/functional_verilator_test.py
@@ -6,14 +6,14 @@ r"""Runs a binary on the verilated system, which is expected to write
 one of "PASS!\r\n" or "FAIL!\r\n" to UART to determine success or failure.
 Failing to write either will result in a timeout.
 
-This test requires some configuration options. Use the following steps to
-run the test manually after building Verilator and the sw/device/boot_rom and
-sw/device/examples/hello_world targets.
+This test requires some configuration options. Use the following steps to run
+the test manually after building a Verilator simulation and the device boot ROM
+and a device software target.
 
 $ cd ${REPO_TOP}
 $ pytest -s -v test/systemtest/functional_verilator_test.py \
-  --test_bin sw/device/tests/hmac/sw.vmem \
-  --rom_bin sw/device/boot_rom/rom.vmem \
+  --test_bin sw.elf \
+  --rom_bin boot_rom.elf \
   --verilator_model build/lowrisc_systems_top_earlgrey_verilator_0.1/sim-verilator/Vtop_earlgrey_verilator
 """
 
@@ -34,8 +34,8 @@ class TestFunctionalVerilator:
     def sim_top_earlgrey(self, tmp_path, sim_top_build, sw_test_bin, rom_bin):
         cmd_sim = [
             str(sim_top_build),
-            '--flashinit', str(sw_test_bin),
-            '--rominit', str(rom_bin)
+            '--meminit', 'flash,' + str(sw_test_bin),
+            '--meminit', 'rom,' + str(rom_bin)
         ]
         p_sim = test_utils.Process(cmd_sim,
                                    logdir=str(tmp_path),

--- a/test/systemtest/openocd_verilator_test.py
+++ b/test/systemtest/openocd_verilator_test.py
@@ -4,14 +4,14 @@
 # SPDX-License-Identifier: Apache-2.0
 r"""Runs OpenOCD compliance test against Verilator target.
 
-This test requires some configuration options. Use the following steps to
-run the test manually after building Verilator and the sw/device/boot_rom and
-sw/device/examples/hello_world targets.
+This test requires some configuration options. Use the following steps to run
+the test manually after building Verilator and the boot_rom and hello_world
+targets.
 
 $ cd ${REPO_TOP}
 $ pytest -s -v test/systemtest/openocd_verilator_test.py \
-  --test_bin sw/device/examples/hello_world/sw.vmem \
-  --rom_bin sw/device/boot_rom/rom.vmem \
+  --test_bin hello_world.elf \
+  --rom_bin boot_rom.elf \
   --verilator_model build/lowrisc_systems_top_earlgrey_verilator_0.1/sim-verilator/Vtop_earlgrey_verilator
 
 In some cases the pytest environment may not be able to find the openocd binary.
@@ -37,8 +37,8 @@ class TestCoreVerilator:
     def sim_top_earlgrey(self, tmp_path, sim_top_build, sw_test_bin, rom_bin):
         cmd_sim = [
             str(sim_top_build),
-            '--meminit', str(sw_test_bin),
-            '--rominit', str(rom_bin)
+            '--meminit', 'flash,' + str(sw_test_bin),
+            '--meminit', 'rom,' + str(rom_bin)
         ]
         p_sim = test_utils.Process(
             cmd_sim,


### PR DESCRIPTION
Loading ELF files is supported with #1091.
Update the usage from VMEM files to ELF files for Verilator based
simulation.
Reformulate descriptions pointing to software locations to make it
independent of future changes.

Quickstart is not updated, see #1130 
DV needs vmem files for memory loading with `load_mem_from_file()` and `$readmemh()` so I did not change the generation of vmem files.
@imphil do you know any other place where changes would be necessary?