### PR TITLE
Change version text to git hash

### DIFF
--- a/util/build_consts.sh
+++ b/util/build_consts.sh
@@ -20,6 +20,7 @@
 # This file also provides $OT_VERSION, which can be embedded in artifacts as a
 # timestamp. If a git repo is present, it will be computed from that, or else
 # will be an arbitrary string.
+# $OT_TAG is used to get the snapshot name for a release.
 
 # Since this file is intended to be sourced, we can't use |$0| to get our
 # bearings. However, the bash-specific $BASH_SOURCE works perfectly fine.
@@ -30,11 +31,17 @@ else
   exit 1
 fi
 
-OT_GIT_VERSION="$(git describe --always 2>/dev/null)"
+OT_GIT_VERSION="$(git rev-parse --short HEAD 2>/dev/null)"
 if [[ -n "$OT_GIT_VERSION" ]]; then
   readonly OT_VERSION="opentitan-$OT_GIT_VERSION"
 else
   readonly OT_VERSION="opentitan-<unknown>"
+fi
+
+# Creation of a snapshot release is only possible from a git based environment.
+OT_GIT_TAG="$(git describe --always 2>/dev/null)"
+if [[ -n "$OT_GIT_TAG" ]]; then
+  readonly OT_TAG="opentitan-$OT_GIT_TAG"
 fi
 
 BUILD_ROOT="${BUILD_ROOT:-"$REPO_TOP"}"

--- a/util/make_distribution.sh
+++ b/util/make_distribution.sh
@@ -55,5 +55,5 @@ for pat in "${DIST_ARTIFACTS[@]}"; do
 done
 
 cd "$(dirname "$DIST_DIR")"
-tar -cJf "$BIN_DIR/$(basename "$DIST_DIR").tar.xz" \
+tar -cJf "$BIN_DIR/$OT_TAG.tar.xz" \
   "$(basename "$DIST_DIR")"


### PR DESCRIPTION
`OT_VERSION` will now contain something like "opentitan-43c98be" instead
of "snapshot-20191101-1-307-g43c98be".
The tag based name is now used only for the name of the archive for a
release.
Removing the tag reference from the version reduces the likelihood of
confusion that a version is actually a snapshot.

I think previous to #1061 the hash was used in `chip_info.h`, with this PR the chip info version is also "opentitan-43c98be".
Edit: The full hash was used and named "Commit ID" in `chip_info.h`.

Please comment if this change is in the right direction or if it should be kept the way it is.