### PR TITLE
[sw] Delete the wacky macro impl of popcnt in common.h

### DIFF
--- a/sw/device/lib/common.h
+++ b/sw/device/lib/common.h
@@ -29,13 +29,4 @@ static const unsigned long UART_BAUD_RATE = 230400;
 
 #define ARRAYSIZE(x) (sizeof(x) / sizeof(x[0]))
 
-/* Hamming weight */
-#define BITLENGTH_1(X) ((X) - (((X) >> 1) & 0x55555555))
-#define BITLENGTH_2(X) (((X)&0x33333333) + (((X) >> 2) & 0x33333333))
-#define BITLENGTH_3(X) (((X) + ((X) >> 4)) & 0x0f0f0f0f)
-#define BITLENGTH_4(X) ((X) + ((X) >> 8))
-#define BITLENGTH_5(X) ((X) + ((X) >> 16))
-#define BITLENGTH(X) \
-  ((BITLENGTH_5(BITLENGTH_4(BITLENGTH_3(BITLENGTH_2(BITLENGTH_1(X)))))) & 0x7f)
-
 #endif

--- a/sw/device/lib/spi_device.c
+++ b/sw/device/lib/spi_device.c
@@ -59,11 +59,10 @@ void spid_init(void) {
  * Fifo pointers are in bytes
  */
 inline uint32_t calc_depth(uint32_t wptr, uint32_t rptr, uint32_t size) {
-  const uint32_t sram_szw = BITLENGTH(SPI_DEVICE_BUFFER_SIZE_BYTES - 1);
   uint32_t depth;
   uint32_t wptr_phase, rptr_phase, wptr_v, rptr_v;
-  wptr_phase = wptr >> sram_szw;
-  rptr_phase = rptr >> sram_szw;
+  wptr_phase = wptr & SPI_DEVICE_BUFFER_SIZE_BYTES;
+  rptr_phase = rptr & SPI_DEVICE_BUFFER_SIZE_BYTES;
   wptr_v = wptr & (SPI_DEVICE_BUFFER_SIZE_BYTES - 1);
   rptr_v = rptr & (SPI_DEVICE_BUFFER_SIZE_BYTES - 1);
 


### PR DESCRIPTION
The one use of it wasn't necessary, and, in the future, __builtin_popcnt() should be used, instead.