### PR TITLE
[alert_handler/fpv] This adds an FPV testbench for the esc timer

### DIFF
--- a/hw/ip/alert_handler/fpv/alert_handler_esc_timer_fpv.core
+++ b/hw/ip/alert_handler/fpv/alert_handler_esc_timer_fpv.core
@@ -1,0 +1,27 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:fpv:alert_handler_esc_timer_fpv:0.1"
+description: "alert_handler_esc_timer FPV target"
+filesets:
+  files_fpv:
+    depend:
+      - lowrisc:prim:all
+      # note: this is an example config which may differ
+      # from a particular top-level config
+      - lowrisc:ip:alert_handler
+    files:
+      - vip/alert_handler_esc_timer_assert_fpv.sv
+      - tb/alert_handler_esc_timer_bind_fpv.sv
+      - tb/alert_handler_esc_timer_fpv.sv
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    # note, this setting is just used
+    # to generate a file list for jg
+    default_tool: icarus
+    filesets:
+      - files_fpv
+    toplevel: alert_handler_esc_timer_fpv

--- a/hw/ip/alert_handler/fpv/tb/alert_handler_esc_timer_bind_fpv.sv
+++ b/hw/ip/alert_handler/fpv/tb/alert_handler_esc_timer_bind_fpv.sv
@@ -1,0 +1,28 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+module alert_handler_esc_timer_bind_fpv;
+
+
+  bind alert_handler_esc_timer
+      alert_handler_esc_timer_assert_fpv i_alert_handler_esc_timer_assert_fpv (
+    .clk_i,
+    .rst_ni,
+    .en_i,
+    .clr_i,
+    .accum_trig_i,
+    .timeout_en_i,
+    .timeout_cyc_i,
+    .esc_en_i,
+    .esc_map_i,
+    .phase_cyc_i,
+    .esc_trig_o,
+    .esc_cnt_o,
+    .esc_sig_en_o,
+    .esc_state_o
+  );
+
+
+endmodule : alert_handler_esc_timer_bind_fpv

--- a/hw/ip/alert_handler/fpv/tb/alert_handler_esc_timer_fpv.sv
+++ b/hw/ip/alert_handler/fpv/tb/alert_handler_esc_timer_fpv.sv
@@ -1,0 +1,43 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Testbench module for alert_handler_esc_timer.
+// Intended to be used with a formal tool.
+
+module alert_handler_esc_timer_fpv import alert_pkg::*; (
+  input  clk_i,
+  input  rst_ni,
+  input  en_i,
+  input  clr_i,
+  input  accum_trig_i,
+  input  timeout_en_i,
+  input [EscCntDw-1:0] timeout_cyc_i,
+  input [N_ESC_SEV-1:0] esc_en_i,
+  input [N_ESC_SEV-1:0][PHASE_DW-1:0] esc_map_i,
+  input [N_PHASES-1:0][EscCntDw-1:0] phase_cyc_i,
+  output logic esc_trig_o,
+  output logic[EscCntDw-1:0] esc_cnt_o,
+  output logic[N_ESC_SEV-1:0] esc_sig_en_o,
+  output cstate_e esc_state_o
+);
+
+  alert_handler_esc_timer i_alert_handler_esc_timer (
+    .clk_i,
+    .rst_ni,
+    .en_i,
+    .clr_i,
+    .accum_trig_i,
+    .timeout_en_i,
+    .timeout_cyc_i,
+    .esc_en_i,
+    .esc_map_i,
+    .phase_cyc_i,
+    .esc_trig_o,
+    .esc_cnt_o,
+    .esc_sig_en_o,
+    .esc_state_o
+  );
+
+
+endmodule : alert_handler_esc_timer_fpv

--- a/hw/ip/alert_handler/fpv/tb/alert_handler_ping_timer_bind_fpv.sv
+++ b/hw/ip/alert_handler/fpv/tb/alert_handler_ping_timer_bind_fpv.sv
@@ -5,9 +5,23 @@
 
 module alert_handler_ping_timer_bind_fpv;
 
+
   bind alert_handler_ping_timer
-        alert_handler_ping_timer_assert_fpv alert_handler_ping_timer_assert_fpv (
-    .*
+      alert_handler_ping_timer_assert_fpv i_alert_handler_ping_timer_assert_fpv (
+    .clk_i,
+    .rst_ni,
+    .entropy_i,
+    .en_i,
+    .alert_en_i,
+    .ping_timeout_cyc_i,
+    .wait_cyc_mask_i,
+    .alert_ping_en_o,
+    .esc_ping_en_o,
+    .alert_ping_ok_i,
+    .esc_ping_ok_i,
+    .alert_ping_fail_o,
+    .esc_ping_fail_o
   );
+
 
 endmodule : alert_handler_ping_timer_bind_fpv

--- a/hw/ip/alert_handler/fpv/vip/alert_handler_esc_timer_assert_fpv.sv
+++ b/hw/ip/alert_handler/fpv/vip/alert_handler_esc_timer_assert_fpv.sv
@@ -1,0 +1,122 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Assertions for alert_handler_esc_timer.
+// Intended to be used with a formal tool.
+
+module alert_handler_esc_timer_assert_fpv import alert_pkg::*; (
+  input  clk_i,
+  input  rst_ni,
+  input  en_i,
+  input  clr_i,
+  input  accum_trig_i,
+  input  timeout_en_i,
+  input [EscCntDw-1:0] timeout_cyc_i,
+  input [N_ESC_SEV-1:0] esc_en_i,
+  input [N_ESC_SEV-1:0][PHASE_DW-1:0] esc_map_i,
+  input [N_PHASES-1:0][EscCntDw-1:0] phase_cyc_i,
+  input logic esc_trig_o,
+  input logic[EscCntDw-1:0] esc_cnt_o,
+  input logic[N_ESC_SEV-1:0] esc_sig_en_o,
+  input cstate_e esc_state_o
+);
+
+  ///////////////////////////////
+  // Declarations & Parameters //
+  ///////////////////////////////
+
+  // constrain the state-spaces
+  localparam int unsigned MAX_TIMEOUT_CYCLES = 10;
+  localparam int unsigned MAX_PHASE_CYCLES = 10;
+
+  // symbolic vars for phase map check
+  logic [1:0] esc_sel;
+  logic [1:0] phase_sel;
+  localparam cstate_e phases [4] = {Phase0, Phase1, Phase2, Phase3};
+
+  // set regs
+  logic esc_has_triggered_q;
+
+
+  /////////////////
+  // Assumptions //
+  /////////////////
+
+  `ASSUME(TimeoutCycles_M, timeout_cyc_i < MAX_TIMEOUT_CYCLES, clk_i, !rst_ni)
+  `ASSUME(TimeoutCyclesConst_M, ##1 $stable(timeout_cyc_i), clk_i, !rst_ni)
+
+  `ASSUME(PhaseCycles_M, phase_cyc_i < MAX_PHASE_CYCLES, clk_i, !rst_ni)
+  `ASSUME(PhaseCyclesConst_M, ##1 $stable(phase_cyc_i), clk_i, !rst_ni)
+
+  `ASSUME(EscSelConst_M, ##1 $stable(esc_sel), clk_i, !rst_ni)
+  `ASSUME(PhaseSelConst_M, ##1 $stable(phase_sel), clk_i, !rst_ni)
+
+  ////////////////////////
+  // Forward Assertions //
+  ////////////////////////
+
+  // if the class is not enabled and we are in IDLE state,
+  // neither of the two escalation mechanisms shall fire
+  `ASSERT(ClassDisabledNoEscTrig_A, esc_state_o == Idle && !en_i |-> !esc_trig_o, clk_i, !rst_ni)
+  `ASSERT(ClassDisabledNoEsc_A, esc_state_o == Idle && !en_i |-> !esc_sig_en_o, clk_i, !rst_ni)
+  `ASSERT(EscDisabledNoEsc_A, !esc_en_i[esc_sel] |-> !esc_sig_en_o[esc_sel], clk_i, !rst_ni)
+
+  // if timeout counter is enabled due to a pending interrupt, check escalation
+  // assume accumulation trigger is not asserted during this sequence
+  `ASSERT(TimeoutEscTrig_A, ##1 en_i && $rose(timeout_en_i) && (timeout_cyc_i > 0) ##1
+      timeout_en_i [*MAX_TIMEOUT_CYCLES] |=> esc_has_triggered_q,
+      clk_i, !rst_ni || accum_trig_i || clr_i)
+
+  // check whether an accum trig leads to escalation if enabled
+  `ASSERT(AccumEscTrig_A, ##1 en_i && accum_trig_i && esc_state_o inside {Idle, Timeout} |=>
+      esc_has_triggered_q, clk_i, !rst_ni)
+
+  // check escalation cnt and state out
+  `ASSERT(EscStateOut_A, alert_handler_esc_timer.state_q == esc_state_o, clk_i, !rst_ni)
+  `ASSERT(EscCntOut_A, alert_handler_esc_timer.cnt_q == esc_cnt_o, clk_i, !rst_ni)
+
+  // check clr input
+  // we cannot use clr to exit from the timeout state
+  `ASSERT(ClrCheck_A, clr_i && !(esc_state_o inside {Idle, Timeout}) |=>
+      esc_state_o == Idle, clk_i, !rst_ni)
+
+  // check escalation map
+  `ASSERT(PhaseEscMap_A, esc_state_o == phases[phase_sel] && esc_map_i[esc_sel] == phase_sel &&
+      esc_en_i[esc_sel] |-> esc_sig_en_o[esc_sel], clk_i, !rst_ni)
+
+  // check terminal state is reached eventually if triggered and not cleared
+  `ASSERT(TerminalState_A, esc_trig_o |-> strong(##[1:$] esc_state_o == Terminal),
+      clk_i, !rst_ni || clr_i)
+
+  /////////////////////////
+  // Backward Assertions //
+  /////////////////////////
+
+  // escalation can only be triggered when in Idle or Timeout state. Trigger mechanisms are either
+  // the accumulation trigger or a timeout trigger
+  `ASSERT(EscTrigBkwd_A, esc_trig_o |-> esc_state_o inside {Idle, Timeout} && accum_trig_i ||
+      esc_state_o  == Timeout && esc_cnt_o >= timeout_cyc_i, clk_i, !rst_ni)
+  `ASSERT(NoEscTrigBkwd_A, !esc_trig_o |-> !(esc_state_o inside {Idle, Timeout}) ||
+      (!en_i || !accum_trig_i || !timeout_en_i), clk_i, !rst_ni)
+
+  // escalation signals can only be asserted in the escalation phase states
+  `ASSERT(EscBkwd_A, esc_sig_en_o[esc_sel] |-> esc_en_i[esc_sel] &&
+      esc_has_triggered_q, clk_i, !rst_ni)
+  `ASSERT(NoEscBkwd_A, !esc_sig_en_o[esc_sel] |-> !esc_en_i[esc_sel] ||
+      esc_state_o != phases[esc_map_i[esc_sel]], clk_i, !rst_ni || clr_i)
+
+  //////////////////////
+  // Helper Processes //
+  //////////////////////
+
+  // set registers
+  always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs
+    if (!rst_ni) begin
+      esc_has_triggered_q <= 1'b0;
+    end else begin
+      esc_has_triggered_q <= esc_has_triggered_q & ~clr_i | esc_trig_o;
+    end
+  end
+
+endmodule : alert_handler_esc_timer_assert_fpv


### PR DESCRIPTION
This adds an FPV testbench for the esc timer checking all basic properties of the design. The maximum cycle counts of the timer have been restricted in order to reduce the state space.

FPV code coverage is close to 100%, there are a few corner cases that need to be looked at, though.