### PR TITLE
[github] Add owner for util

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,6 +19,7 @@
 *.h                 @moidx
 
 # Utils: reggen, topgen, tlgen
+/util/              @sjgitty
 util/*.py           @imphil @asb
 util/*gen/          @eunchan @msfschaffner @tjaychen
 util/uvmdvgen*      @sriyerg


### PR DESCRIPTION
Set default owner for root util directory.

Fixes #1140

Signed-off-by: Tobias Wölfel <tobias.woelfel@mailbox.org>