### PR TITLE
[dv/alert-handler] Add agent to drive and receive alert

### DIFF
--- a/hw/dv/sv/alert_agent/README.md
+++ b/hw/dv/sv/alert_agent/README.md
@@ -1,0 +1,1 @@
+# ALERT Agent

--- a/hw/dv/sv/alert_agent/alert_agent.core
+++ b/hw/dv/sv/alert_agent/alert_agent.core
@@ -1,0 +1,33 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:alert_agent"
+description: "Alert handler sender receiver pair DV UVM agent"
+
+filesets:
+  files_dv:
+    depend:
+      - lowrisc:prim:all:0.1
+      - lowrisc:dv:dv_lib
+    files:
+      - alert_if.sv
+      - alert_agent_pkg.sv
+      - alert_agent_cfg.sv: {is_include_file: true}
+      - alert_agent.sv: {is_include_file: true}
+      - alert_agent_cov.sv: {is_include_file: true}
+      - alert_sender_driver.sv: {is_include_file: true}
+      - alert_receiver_driver.sv: {is_include_file: true}
+      - alert_monitor.sv: {is_include_file: true}
+      - alert_seq_item.sv: {is_include_file: true}
+      - alert_sequencer.sv: {is_include_file: true}
+      - seq_lib/alert_receiver_alert_rsp_seq.sv: {is_include_file: true}
+      - seq_lib/alert_receiver_seq.sv: {is_include_file: true}
+      - seq_lib/alert_sender_ping_rsp_seq.sv: {is_include_file: true}
+      - seq_lib/alert_sender_seq.sv: {is_include_file: true}
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_dv

--- a/hw/dv/sv/alert_agent/alert_agent.sv
+++ b/hw/dv/sv/alert_agent/alert_agent.sv
@@ -1,0 +1,30 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// ---------------------------------------------
+// Alert agent
+// ---------------------------------------------
+class alert_agent extends dv_base_agent#(
+    .CFG_T           (alert_agent_cfg),
+    .DRIVER_T        (alert_base_driver),
+    .HOST_DRIVER_T   (alert_sender_driver),
+    .DEVICE_DRIVER_T (alert_receiver_driver),
+    .SEQUENCER_T     (alert_sequencer),
+    .MONITOR_T       (alert_monitor),
+    .COV_T           (alert_agent_cov)
+  );
+
+  `uvm_component_utils(alert_agent)
+
+  `uvm_component_new
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    // get alert_if handle
+    if (!uvm_config_db#(virtual alert_if)::get(this, "", "vif", cfg.vif)) begin
+      `uvm_fatal(`gfn, "failed to get alert_if handle from uvm_config_db")
+    end
+  endfunction
+
+endclass : alert_agent

--- a/hw/dv/sv/alert_agent/alert_agent_cfg.sv
+++ b/hw/dv/sv/alert_agent/alert_agent_cfg.sv
@@ -1,0 +1,43 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// ---------------------------------------------
+// Configuration class for Alert agent
+// ---------------------------------------------
+class alert_agent_cfg extends dv_base_agent_cfg;
+  virtual alert_if vif;
+  // sender mode
+  bit use_seq_item_alert_delay;
+  int unsigned alert_delay_min = 0;
+  int unsigned alert_delay_max = 10;
+
+  // receiver mode
+  bit use_seq_item_ack_delay;
+  int unsigned ack_delay_min = 0;
+  int unsigned ack_delay_max = 10;
+
+  bit use_seq_item_ack_stable;
+  int unsigned ack_stable_min = 0;
+  int unsigned ack_stable_max = 10;
+
+  bit use_seq_item_ping_delay;
+  int unsigned ping_delay_min = 0;
+  int unsigned ping_delay_max = 10;
+
+  int unsigned ping_timeout_cycle = 200;
+
+  `uvm_object_utils_begin(alert_agent_cfg)
+    `uvm_field_int(alert_delay_min, UVM_DEFAULT)
+    `uvm_field_int(alert_delay_min, UVM_DEFAULT)
+    `uvm_field_int(ack_delay_min,   UVM_DEFAULT)
+    `uvm_field_int(ack_delay_min,   UVM_DEFAULT)
+    `uvm_field_int(ack_stable_min,  UVM_DEFAULT)
+    `uvm_field_int(ack_stable_min,  UVM_DEFAULT)
+    `uvm_field_int(ping_delay_min,  UVM_DEFAULT)
+    `uvm_field_int(ping_delay_min,  UVM_DEFAULT)
+  `uvm_object_utils_end
+  `uvm_object_new
+
+endclass : alert_agent_cfg

--- a/hw/dv/sv/alert_agent/alert_agent_cov.sv
+++ b/hw/dv/sv/alert_agent/alert_agent_cov.sv
@@ -1,0 +1,13 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class alert_agent_cov extends dv_base_agent_cov #(alert_agent_cfg);
+
+  `uvm_component_utils(alert_agent_cov)
+
+  function new(string name, uvm_component parent);
+    super.new(name, parent);
+  endfunction : new
+
+endclass

--- a/hw/dv/sv/alert_agent/alert_agent_pkg.sv
+++ b/hw/dv/sv/alert_agent/alert_agent_pkg.sv
@@ -1,0 +1,47 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package alert_agent_pkg;
+  // dep packages
+  import uvm_pkg::*;
+  import dv_lib_pkg::*;
+  import dv_utils_pkg::*;
+  import prim_pkg::*;
+
+  typedef class alert_seq_item;
+  typedef class alert_agent_cfg;
+  // reuse dv_base_driver as is with the right parameter set
+  typedef dv_base_driver #(alert_seq_item, alert_agent_cfg) alert_base_driver;
+
+  typedef enum {
+    ping_trans,
+    alert_trans,
+    int_fail
+  } alert_type_e;
+
+  typedef enum {
+    alert_received,
+    ack_received,
+    alert_complete,
+    ack_complete
+  } alert_handshake_e;
+
+  // macro includes
+  `include "uvm_macros.svh"
+  `include "dv_macros.svh"
+
+  // include local files
+  `include "alert_seq_item.sv"
+  `include "alert_agent_cfg.sv"
+  `include "alert_agent_cov.sv"
+  `include "alert_sender_driver.sv"
+  `include "alert_receiver_driver.sv"
+  `include "alert_sequencer.sv"
+  `include "alert_monitor.sv"
+  `include "alert_agent.sv"
+  `include "seq_lib/alert_receiver_alert_rsp_seq.sv"
+  `include "seq_lib/alert_receiver_seq.sv"
+  `include "seq_lib/alert_sender_ping_rsp_seq.sv"
+  `include "seq_lib/alert_sender_seq.sv"
+endpackage

--- a/hw/dv/sv/alert_agent/alert_if.sv
+++ b/hw/dv/sv/alert_agent/alert_if.sv
@@ -1,0 +1,84 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// ---------------------------------------------
+// Alert interface
+// ---------------------------------------------
+interface alert_if(input clk, input rst_n);
+  wire prim_pkg::alert_tx_t alert_tx;
+  wire prim_pkg::alert_rx_t alert_rx;
+
+  clocking sender_cb @(posedge clk);
+    input  rst_n;
+    output alert_tx;
+    input  alert_rx;
+  endclocking
+
+  clocking receiver_cb @(posedge clk);
+    input  rst_n;
+    input  alert_tx;
+    output alert_rx;
+  endclocking
+
+  clocking monitor_cb @(posedge clk);
+    input  rst_n;
+    input  alert_tx;
+    input  alert_rx;
+  endclocking
+
+  task automatic wait_alert();
+    while (alert_tx.alert_p !== 1'b1) @(monitor_cb);
+  endtask : wait_alert
+
+  task automatic wait_alert_complete();
+    while (alert_tx.alert_p !== 1'b0) @(monitor_cb);
+  endtask : wait_alert_complete
+
+  task automatic wait_ping();
+    logic ping_p_value = 0;
+    while (alert_rx.ping_p === ping_p_value) begin
+      @(monitor_cb);
+      ping_p_value = alert_rx.ping_p;
+    end
+  endtask : wait_ping
+
+  task automatic wait_ack();
+    while (alert_rx.ack_p !== 1'b1) @(monitor_cb);
+  endtask : wait_ack
+
+  task automatic wait_ack_complete();
+    while (alert_rx.ack_p !== 1'b0) @(monitor_cb);
+  endtask : wait_ack_complete
+
+  task automatic set_alert();
+    sender_cb.alert_tx.alert_p <= 1'b1;
+    sender_cb.alert_tx.alert_n <= 1'b0;
+  endtask
+
+  task automatic reset_alert();
+    sender_cb.alert_tx.alert_p <= 1'b0;
+    sender_cb.alert_tx.alert_n <= 1'b1;
+  endtask
+
+  task automatic set_ack();
+    receiver_cb.alert_rx.ack_p <= 1'b1;
+    receiver_cb.alert_rx.ack_n <= 1'b0;
+  endtask
+
+  task automatic reset_ack();
+    receiver_cb.alert_rx.ack_p <= 1'b0;
+    receiver_cb.alert_rx.ack_n <= 1'b1;
+  endtask
+
+  task automatic set_ping();
+    receiver_cb.alert_rx.ping_p <= !alert_rx.ping_p;
+    receiver_cb.alert_rx.ping_n <= !alert_rx.ping_n;
+  endtask
+
+  task automatic reset_ping();
+    receiver_cb.alert_rx.ping_p <= 1'b0;
+    receiver_cb.alert_rx.ping_n <= 1'b1;
+  endtask
+
+endinterface: alert_if

--- a/hw/dv/sv/alert_agent/alert_monitor.sv
+++ b/hw/dv/sv/alert_agent/alert_monitor.sv
@@ -1,0 +1,124 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// ---------------------------------------------
+// Alert sender receiver interface monitor
+// ---------------------------------------------
+
+class alert_monitor extends dv_base_monitor#(
+    .ITEM_T (alert_seq_item),
+    .CFG_T  (alert_agent_cfg),
+    .COV_T  (alert_agent_cov)
+  );
+
+  `uvm_component_utils(alert_monitor)
+
+  bit under_ping_rsp;
+
+  uvm_analysis_port #(alert_seq_item) sender_port;
+  uvm_analysis_port #(alert_seq_item) receiver_port;
+
+  `uvm_component_new
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    sender_port = new("sender_port", this);
+    receiver_port = new("receiver_port", this);
+  endfunction : build_phase
+
+  //TODO: currently only support sync mode
+  //TODO: add support for signal int err and reset
+  virtual task run_phase(uvm_phase phase);
+    fork
+      alert_thread(phase);
+      ping_thread(phase);
+      reset_thread(phase);
+    join_none
+  endtask : run_phase
+
+  // TODO: placeholder to support reset
+  virtual task reset_thread(uvm_phase phase);
+    forever begin
+      @(negedge cfg.vif.rst_n);
+      @(posedge cfg.vif.rst_n);
+    end
+  endtask : reset_thread
+
+  virtual task ping_thread(uvm_phase phase);
+    alert_seq_item req;
+    bit            ping_p;
+    forever @(cfg.vif.monitor_cb) begin
+      if (ping_p != cfg.vif.monitor_cb.alert_rx.ping_p) begin
+        phase.raise_objection(this);
+        under_ping_rsp = 1;
+        req = alert_seq_item::type_id::create("req");
+        req.alert_type = ping_trans;
+        fork
+          begin : isolation_fork
+            fork
+              begin : wait_ping_timeout
+                repeat (cfg.ping_timeout_cycle) @(cfg.vif.monitor_cb);
+              end
+              begin : wait_ping_handshake
+                cfg.vif.wait_alert();
+                req.alert_handshake_sta = alert_received;
+                cfg.vif.wait_ack();
+                req.alert_handshake_sta = ack_received;
+                cfg.vif.wait_alert_complete();
+                req.alert_handshake_sta = alert_complete;
+                under_ping_rsp = 0;
+                cfg.vif.wait_ack_complete();
+                req.alert_handshake_sta = ack_complete;
+              end
+            join_any
+            disable fork;
+          end : isolation_fork
+        join
+        `uvm_info("alert_monitor", $sformatf("[%s]: handshake status is %s",
+            req.alert_type.name(), req.alert_handshake_sta.name()), UVM_LOW)
+        sender_port.write(req);
+        phase.drop_objection(this);
+        under_ping_rsp = 0;
+      end
+      ping_p = cfg.vif.monitor_cb.alert_rx.ping_p;
+    end
+  endtask : ping_thread
+
+  virtual task alert_thread(uvm_phase phase);
+    alert_seq_item req;
+    bit            alert_p;
+    forever @(cfg.vif.monitor_cb) begin
+      if (!alert_p && cfg.vif.monitor_cb.alert_tx.alert_p === 1'b1 && !under_ping_rsp) begin
+        phase.raise_objection(this);
+        req = alert_seq_item::type_id::create("req");
+        req.alert_type = alert_trans;
+        fork
+          begin : isolation_fork
+            fork
+              begin : alert_timeout
+                repeat (cfg.ping_timeout_cycle) @(cfg.vif.monitor_cb);
+              end
+              begin : wait_alert_handshake
+                cfg.vif.wait_ack();
+                req.alert_handshake_sta = ack_received;
+                cfg.vif.wait_alert_complete();
+                req.alert_handshake_sta = alert_complete;
+                cfg.vif.wait_ack_complete();
+                req.alert_handshake_sta = ack_complete;
+              end
+            join_any
+            disable fork;
+          end : isolation_fork
+        join
+        `uvm_info("alert_monitor", $sformatf("[%s]: handshake status is %s",
+            req.alert_type.name(), req.alert_handshake_sta.name()), UVM_LOW)
+        receiver_port.write(req);
+        phase.drop_objection(this);
+      end
+      alert_p = cfg.vif.monitor_cb.alert_tx.alert_p;
+    end
+  endtask : alert_thread
+
+endclass : alert_monitor

--- a/hw/dv/sv/alert_agent/alert_receiver_driver.sv
+++ b/hw/dv/sv/alert_agent/alert_receiver_driver.sv
@@ -1,0 +1,135 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// ---------------------------------------------
+// Alert_handler receiver driver
+// ---------------------------------------------
+class alert_receiver_driver extends alert_base_driver;
+
+  alert_seq_item ping_q[$];
+  alert_seq_item alert_q[$];
+
+  `uvm_component_utils(alert_receiver_driver)
+
+  `uvm_component_new
+
+  virtual task reset_signals();
+    cfg.vif.reset_ping();
+    cfg.vif.reset_ack();
+  endtask
+
+  virtual task get_and_drive();
+    fork
+      get_req();
+      send_ping();
+      rsp_alert();
+    join_none
+  endtask : get_and_drive
+
+  virtual task get_req();
+    forever begin
+      alert_seq_item req_clone;
+      seq_item_port.get(req);
+      $cast(req_clone, req.clone());
+      req_clone.set_id_info(req);
+      // TODO: if ping or alert queue size is larger than 2, need additional support
+      if (req.ping_send) ping_q.push_back(req_clone);
+      if (req.alert_rsp) alert_q.push_back(req_clone);
+    end
+  endtask : get_req
+
+  virtual task send_ping();
+    forever begin
+      int unsigned ping_delay;
+      alert_seq_item req, rsp;
+      ping_delay = (cfg.use_seq_item_ping_delay) ? req.ping_delay :
+          $urandom_range(cfg.ping_delay_max, cfg.ping_delay_min);
+      wait(ping_q.size() > 0);
+      req = ping_q.pop_front();
+      $cast(rsp, req.clone());
+      rsp.set_id_info(req);
+      `uvm_info(`gfn,
+          $sformatf("starting to send receiver item, ping_send=%0b, alert_rsp=%0b, int_fail=%0b",
+          req.ping_send, req.alert_rsp, req.ping_int_err), UVM_HIGH)
+
+      if (!req.ping_int_err) begin
+        @(cfg.vif.receiver_cb);
+        repeat (ping_delay) @(cfg.vif.receiver_cb);
+        cfg.vif.set_ping();
+        // TODO: add ping fail and differential signal fail scenarios
+        fork
+          begin : ping_timeout
+            repeat (cfg.ping_timeout_cycle) @(cfg.vif.receiver_cb);
+          end
+          begin : wait_ping_handshake
+            cfg.vif.wait_alert();
+            set_ack_pins(req);
+          end
+        join_any
+        disable fork;
+      end else begin
+        // TODO: differential signal fail
+      end
+
+      `uvm_info(`gfn,
+          $sformatf("finished sending receiver item, ping_send=%0b, alert_rsp=%0b, int_fail=%0b",
+          req.ping_send, req.alert_rsp, req.ping_int_err), UVM_HIGH)
+      seq_item_port.put_response(rsp);
+    end // end forever
+  endtask : send_ping
+
+  virtual task rsp_alert();
+    forever begin
+      alert_seq_item req, rsp;
+      wait(alert_q.size() > 0);
+      req = alert_q.pop_front();
+      $cast(rsp, req.clone());
+      rsp.set_id_info(req);
+      `uvm_info(`gfn,
+          $sformatf("starting to send receiver item, ping_send=%0b, alert_rsp=%0b, int_fail=%0b",
+          req.ping_send, req.alert_rsp, req.ping_int_err), UVM_HIGH)
+
+      cfg.vif.wait_alert();
+      set_ack_pins(req);
+
+      `uvm_info(`gfn,
+          $sformatf("finished sending receiver item, ping_send=%0b, alert_rsp=%0b, int_fail=%0b",
+          req.ping_send, req.alert_rsp, req.ping_int_err), UVM_HIGH)
+      seq_item_port.put_response(rsp);
+    end // end forever
+  endtask : rsp_alert
+
+  virtual task set_ack_pins(alert_seq_item req);
+    int unsigned ack_delay, ack_stable;
+    ack_delay = (cfg.use_seq_item_ack_delay) ? req.ack_delay :
+        $urandom_range(cfg.ack_delay_max, cfg.ack_delay_min);
+    ack_stable = (cfg.use_seq_item_ack_stable) ? req.ack_stable :
+        $urandom_range(cfg.ack_stable_max, cfg.ack_stable_min);
+    if (!req.ack_int_err) begin
+      @(cfg.vif.receiver_cb);
+      repeat (ack_delay) @(cfg.vif.receiver_cb);
+      cfg.vif.set_ack();
+      fork
+        begin : isolation_fork
+          fork
+            begin : ack_timeout
+              repeat (cfg.ping_timeout_cycle) @(cfg.vif.sender_cb);
+            end
+            begin : wait_ack_handshake
+              cfg.vif.wait_alert_complete();
+              @(cfg.vif.receiver_cb);
+              repeat (ack_stable) @(cfg.vif.receiver_cb);
+              cfg.vif.reset_ack();
+            end
+          join_any
+          disable fork;
+        end : isolation_fork
+      join
+    end else begin
+    // TODO: differential signal fail
+    end
+  endtask : set_ack_pins
+
+endclass : alert_receiver_driver

--- a/hw/dv/sv/alert_agent/alert_sender_driver.sv
+++ b/hw/dv/sv/alert_agent/alert_sender_driver.sv
@@ -1,0 +1,113 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// ---------------------------------------------
+// Alert_handler sender driver
+// ---------------------------------------------
+class alert_sender_driver extends alert_base_driver;
+  alert_seq_item alert_q[$];
+  alert_seq_item ping_q[$];
+
+  `uvm_component_utils(alert_sender_driver)
+
+  `uvm_component_new
+
+  virtual task reset_signals();
+    cfg.vif.reset_alert();
+  endtask
+
+  // alert_sender drive responses by sending the alert_p and alert_n
+  // one alert sent by sequence driving the alert_send signal
+  // another alert sent by responding to the ping signal
+  virtual task get_and_drive();
+    fork
+      get_req();
+      send_alert();
+      rsp_ping();
+    join_none
+  endtask : get_and_drive
+
+  virtual task get_req();
+    forever begin
+      alert_seq_item req_clone;
+      seq_item_port.get(req);
+      $cast(req_clone, req.clone());
+      req_clone.set_id_info(req);
+      if (req.alert_send) alert_q.push_back(req_clone);
+      if (req.ping_rsp)   ping_q.push_back(req_clone);
+    end
+  endtask : get_req
+
+  virtual task send_alert();
+    forever begin
+      alert_seq_item req, rsp;
+      wait(alert_q.size() > 0);
+      req = alert_q.pop_front();
+      $cast(rsp, req.clone());
+      rsp.set_id_info(req);
+      `uvm_info(`gfn,
+          $sformatf("starting to send sender item, alert_send=%0b, ping_rsp=%0b, int_err=%0b",
+          req.alert_send, req.ping_rsp, req.alert_int_err), UVM_HIGH)
+
+      set_alert_pins(req);
+
+      `uvm_info(`gfn,
+          $sformatf("finished sending sender item, alert_send=%0b, ping_rsp=%0b, int_err=%0b",
+          req.alert_send, req.ping_rsp, req.alert_int_err), UVM_HIGH)
+      seq_item_port.put_response(rsp);
+    end // end forever
+  endtask : send_alert
+
+  virtual task rsp_ping();
+    forever begin
+      alert_seq_item req, rsp;
+      wait(ping_q.size() > 0);
+      req = ping_q.pop_front();
+      $cast(rsp, req.clone());
+      rsp.set_id_info(req);
+      `uvm_info(`gfn,
+          $sformatf("starting to send sender item, alert_send=%0b, ping_rsp=%0b, int_err=%0b",
+          req.alert_send, req.ping_rsp, req.alert_int_err), UVM_HIGH)
+
+      cfg.vif.wait_ping();
+      set_alert_pins(req);
+
+      `uvm_info(`gfn,
+          $sformatf("finished sending sender item, alert_send=%0b, ping_rsp=%0b, int_err=%0b",
+          req.alert_send, req.ping_rsp, req.alert_int_err), UVM_HIGH)
+      seq_item_port.put_response(rsp);
+    end
+  endtask : rsp_ping
+
+  virtual task set_alert_pins(alert_seq_item req);
+    int unsigned alert_delay, ack_delay;
+    alert_delay = (cfg.use_seq_item_alert_delay) ? req.alert_delay :
+        $urandom_range(cfg.alert_delay_max, cfg.alert_delay_min);
+    ack_delay = (cfg.use_seq_item_ack_delay) ? req.ack_delay :
+        $urandom_range(cfg.ack_delay_max, cfg.ack_delay_min);
+    repeat (alert_delay) @(cfg.vif.sender_cb);
+    if (!req.alert_int_err) begin
+      @(cfg.vif.sender_cb);
+      repeat (alert_delay) @(cfg.vif.sender_cb);
+      cfg.vif.set_alert();
+      // TODO: add alert fail and differential signal fail scenarios
+      fork
+        begin : alert_timeout
+          repeat (cfg.ping_timeout_cycle) @(cfg.vif.sender_cb);
+        end
+        begin : wait_alert_handshake
+          cfg.vif.wait_ack();
+          @(cfg.vif.sender_cb);
+          repeat (ack_delay) @(cfg.vif.sender_cb);
+          cfg.vif.reset_alert();
+        end
+      join_any
+      disable fork;
+    end else begin
+    // TODO: differential signal fail
+    end
+  endtask : set_alert_pins
+
+endclass : alert_sender_driver

--- a/hw/dv/sv/alert_agent/alert_seq_item.sv
+++ b/hw/dv/sv/alert_agent/alert_seq_item.sv
@@ -1,0 +1,52 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// ---------------------------------------------
+// Alert sender receiver sequence item
+// ---------------------------------------------
+
+class alert_seq_item extends uvm_sequence_item;
+
+  rand bit alert_send;
+  rand bit alert_rsp; // receiver response to alert using ack
+  rand bit alert_int_err;
+  rand bit ping_rsp; // sender response to ping using alert
+  rand bit ack_int_err;
+  rand bit ping_send;
+  rand bit ping_int_err;
+
+  // for alert_monitor
+  rand alert_type_e      alert_type;
+  rand alert_handshake_e alert_handshake_sta;
+
+  // delays
+  rand int unsigned ping_delay;
+  rand int unsigned ack_delay;
+  rand int unsigned ack_stable;
+  rand int unsigned alert_delay;
+
+  constraint delay_c {
+    soft ping_delay  dist {0 :/ 5, [1:10] :/ 5};
+    soft ack_delay   dist {0 :/ 5, [1:10] :/ 5};
+    soft alert_delay dist {0 :/ 5, [1:10] :/ 5};
+    soft ack_stable  dist {1 :/ 5, [2:10] :/ 5};
+  }
+
+  `uvm_object_utils_begin(alert_seq_item)
+    `uvm_field_int (alert_send,    UVM_DEFAULT)
+    `uvm_field_int (alert_int_err, UVM_DEFAULT)
+    `uvm_field_int (alert_rsp,     UVM_DEFAULT)
+    `uvm_field_int (ping_rsp,      UVM_DEFAULT)
+    `uvm_field_int (ack_int_err,   UVM_DEFAULT)
+    `uvm_field_int (ping_send,     UVM_DEFAULT)
+    `uvm_field_int (ping_int_err,  UVM_DEFAULT)
+    `uvm_field_enum(alert_type_e, alert_type, UVM_DEFAULT)
+    `uvm_field_enum(alert_handshake_e, alert_handshake_sta, UVM_DEFAULT)
+  `uvm_object_utils_end
+
+  function new (string name = "");
+    super.new(name);
+  endfunction : new
+
+endclass : alert_seq_item

--- a/hw/dv/sv/alert_agent/alert_sequencer.sv
+++ b/hw/dv/sv/alert_agent/alert_sequencer.sv
@@ -1,0 +1,10 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class alert_sequencer extends dv_base_sequencer#(alert_seq_item, alert_agent_cfg);
+  `uvm_component_utils(alert_sequencer)
+
+  `uvm_component_new
+
+endclass

--- a/hw/dv/sv/alert_agent/seq_lib/alert_receiver_alert_rsp_seq.sv
+++ b/hw/dv/sv/alert_agent/seq_lib/alert_receiver_alert_rsp_seq.sv
@@ -1,0 +1,36 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// this sequence responses to alert pins by sending the ack pins
+class alert_receiver_alert_rsp_seq extends dv_base_seq #(
+    .REQ         (alert_seq_item),
+    .CFG_T       (alert_agent_cfg),
+    .SEQUENCER_T (alert_sequencer)
+  );
+
+  `uvm_object_utils(alert_receiver_alert_rsp_seq)
+  `uvm_object_new
+
+  rand bit  ack_int_err;
+
+  constraint no_int_err_c {
+    ack_int_err == 0;
+  }
+
+  virtual task body();
+    `uvm_info(`gfn, $sformatf("starting alert receiver transfer"), UVM_HIGH)
+    req = REQ::type_id::create("req");
+    start_item(req);
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(req,
+        ping_send    == 0;
+        ping_int_err == 0;
+        alert_rsp    == 1;
+        ack_int_err  == local::ack_int_err;
+    )
+    finish_item(req);
+    get_response(rsp);
+    `uvm_info(`gfn, "alert receiver transfer done", UVM_HIGH)
+  endtask : body
+
+endclass : alert_receiver_alert_rsp_seq

--- a/hw/dv/sv/alert_agent/seq_lib/alert_receiver_seq.sv
+++ b/hw/dv/sv/alert_agent/seq_lib/alert_receiver_seq.sv
@@ -1,0 +1,37 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// this sequence send ping_p and ping_n to trigger ping signals
+class alert_receiver_seq extends dv_base_seq #(
+    .REQ         (alert_seq_item),
+    .CFG_T       (alert_agent_cfg),
+    .SEQUENCER_T (alert_sequencer)
+  );
+
+  `uvm_object_utils(alert_receiver_seq)
+
+  rand bit  ping_int_err;
+
+  constraint no_int_err_c {
+    ping_int_err == 0;
+  }
+  `uvm_object_new
+
+  task body();
+    `uvm_info(`gfn, $sformatf("starting alert receiver transfer"), UVM_HIGH)
+    req = REQ::type_id::create("req");
+    start_item(req);
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(req,
+        ping_send    == 1;
+        ping_int_err == local::ping_int_err;
+        alert_rsp    == 0;
+        ack_int_err  == 0;
+    )
+    `uvm_info(`gfn, $sformatf("seq_item: ping_send, ping_int_err=%0b", ping_int_err), UVM_LOW)
+    finish_item(req);
+    get_response(rsp);
+    `uvm_info(`gfn, "alert receiver transfer done", UVM_HIGH)
+  endtask : body
+
+endclass : alert_receiver_seq

--- a/hw/dv/sv/alert_agent/seq_lib/alert_sender_ping_rsp_seq.sv
+++ b/hw/dv/sv/alert_agent/seq_lib/alert_sender_ping_rsp_seq.sv
@@ -1,0 +1,35 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// this sequence responses to ping pins by sending the alert pins
+class alert_sender_ping_rsp_seq extends dv_base_seq #(
+    .REQ         (alert_seq_item),
+    .CFG_T       (alert_agent_cfg),
+    .SEQUENCER_T (alert_sequencer)
+  );
+
+  `uvm_object_utils(alert_sender_ping_rsp_seq)
+  `uvm_object_new
+
+  rand bit  alert_int_err;
+
+  constraint no_int_err_c {
+    alert_int_err == 0;
+  }
+
+  virtual task body();
+    `uvm_info(`gfn, $sformatf("starting alert receiver transfer"), UVM_HIGH)
+    req = REQ::type_id::create("req");
+    start_item(req);
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(req,
+        alert_send    == 0;
+        ping_rsp      == 1;
+        alert_int_err == local::alert_int_err;
+    )
+    finish_item(req);
+    get_response(rsp);
+    `uvm_info(`gfn, "alert receiver transfer done", UVM_HIGH)
+  endtask : body
+
+endclass : alert_sender_ping_rsp_seq

--- a/hw/dv/sv/alert_agent/seq_lib/alert_sender_seq.sv
+++ b/hw/dv/sv/alert_agent/seq_lib/alert_sender_seq.sv
@@ -1,0 +1,36 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// this sequence send the alert pins to the receiver
+class alert_sender_seq extends dv_base_seq #(
+    .REQ         (alert_seq_item),
+    .CFG_T       (alert_agent_cfg),
+    .SEQUENCER_T (alert_sequencer)
+  );
+
+  `uvm_object_utils(alert_sender_seq)
+
+  rand bit  alert_int_err;
+
+  constraint no_int_err_c {
+    alert_int_err == 0;
+  }
+  `uvm_object_new
+
+  task body();
+    `uvm_info(`gfn, $sformatf("starting alert sender transfer"), UVM_HIGH)
+    req = REQ::type_id::create("req");
+    start_item(req);
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(req,
+        alert_send    == 1;
+        alert_int_err == local::alert_int_err;
+        ping_rsp      == 0;
+    )
+    `uvm_info(`gfn, $sformatf("seq_item, alert_send=%0b", req.alert_send), UVM_LOW)
+    finish_item(req);
+    get_response(rsp);
+    `uvm_info(`gfn, "alert sender transfer done", UVM_HIGH)
+  endtask : body
+
+endclass : alert_sender_seq

--- a/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
@@ -5,10 +5,10 @@
 class cip_base_env_cfg #(type RAL_T = dv_base_reg_block) extends dv_base_env_cfg #(RAL_T);
   // ext component cfgs
   rand tl_agent_cfg     m_tl_agent_cfg;
+  rand alert_agent_cfg  m_alert_agent_cfg[string];
 
   // common interfaces - intrrupts and alerts
   intr_vif              intr_vif;
-  alerts_vif            alerts_vif;
   devmode_vif           devmode_vif;
   tlul_assert_ctrl_vif  tlul_assert_ctrl_vif;
 
@@ -16,12 +16,12 @@ class cip_base_env_cfg #(type RAL_T = dv_base_reg_block) extends dv_base_env_cfg
   bit                   en_devmode = 0;
 
   uint                  num_interrupts;
-  uint                  num_alerts;
+  string                list_of_alerts[] = {};
 
   `uvm_object_param_utils_begin(cip_base_env_cfg #(RAL_T))
-    `uvm_field_object(m_tl_agent_cfg, UVM_DEFAULT)
-    `uvm_field_int   (num_interrupts, UVM_DEFAULT)
-    `uvm_field_int   (num_alerts,     UVM_DEFAULT)
+    `uvm_field_object          (m_tl_agent_cfg,    UVM_DEFAULT)
+    `uvm_field_aa_object_string(m_alert_agent_cfg, UVM_DEFAULT)
+    `uvm_field_int             (num_interrupts,    UVM_DEFAULT)
  `uvm_object_utils_end
 
   `uvm_object_new

--- a/hw/dv/sv/cip_lib/cip_base_env_cov.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env_cov.sv
@@ -72,7 +72,7 @@ class cip_base_env_cov #(type CFG_T = cip_base_env_cfg) extends dv_base_env_cov 
       intr_test_cg = new(cfg.num_interrupts);
       intr_pins_cg = new(cfg.num_interrupts);
     end
-    if (cfg.num_alerts != 0) alert_cg = new(cfg.num_alerts);
+    if (cfg.list_of_alerts.size() != 0) alert_cg = new(cfg.list_of_alerts.size());
   endfunction
 
 endclass

--- a/hw/dv/sv/cip_lib/cip_base_pkg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_pkg.sv
@@ -10,6 +10,7 @@ package cip_base_pkg;
   import csr_utils_pkg::*;
   import dv_lib_pkg::*;
   import tl_agent_pkg::*;
+  import alert_agent_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"

--- a/hw/dv/sv/cip_lib/cip_base_virtual_sequencer.sv
+++ b/hw/dv/sv/cip_lib/cip_base_virtual_sequencer.sv
@@ -7,7 +7,8 @@ class cip_base_virtual_sequencer #(type CFG_T = cip_base_env_cfg,
                                    extends dv_base_virtual_sequencer #(CFG_T, COV_T);
   `uvm_component_param_utils(cip_base_virtual_sequencer #(CFG_T, COV_T))
 
-  tl_sequencer  tl_sequencer_h;
+  tl_sequencer    tl_sequencer_h;
+  alert_sequencer alert_sequencer_h[string];
 
   `uvm_component_new
 

--- a/hw/dv/sv/cip_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/cip_base_vseq.sv
@@ -387,4 +387,31 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
     run_csr_vseq(.csr_test_type("hw_reset"), .csr_excl(csr_excl), .do_rand_wr_and_reset(0));
   endtask
 
+  virtual task run_alert_rsp_seq_nonblocking();
+    foreach(cfg.list_of_alerts[i]) begin
+      automatic string seqr_name = cfg.list_of_alerts[i];
+      fork
+        forever begin
+          alert_receiver_alert_rsp_seq ack_seq =
+              alert_receiver_alert_rsp_seq::type_id::create("ack_seq");
+          `DV_CHECK_RANDOMIZE_FATAL(ack_seq);
+          ack_seq.start(p_sequencer.alert_sequencer_h[seqr_name]);
+        end
+      join_none
+    end
+  endtask
+
+  virtual task run_ping_rsp_seq_nonblocking();
+    foreach(cfg.list_of_alerts[i]) begin
+      automatic string seqr_name = cfg.list_of_alerts[i];
+      fork
+        forever begin
+          alert_sender_ping_rsp_seq ping_seq =
+              alert_sender_ping_rsp_seq::type_id::create("ping_seq");
+          `DV_CHECK_RANDOMIZE_FATAL(ping_seq);
+          ping_seq.start(p_sequencer.alert_sequencer_h[seqr_name]);
+        end
+      join_none
+    end
+  endtask
 endclass

--- a/hw/dv/sv/cip_lib/cip_lib.core
+++ b/hw/dv/sv/cip_lib/cip_lib.core
@@ -10,6 +10,7 @@ filesets:
     depend:
       - lowrisc:dv:dv_lib
       - lowrisc:dv:tl_agent
+      - lowrisc:dv:alert_agent
     files:
       - cip_base_pkg.sv
       - cip_base_env_cfg.sv: {is_include_file: true}

--- a/hw/dv/sv/dv_utils/dv_utils_pkg.sv
+++ b/hw/dv/sv/dv_utils/dv_utils_pkg.sv
@@ -14,7 +14,6 @@ package dv_utils_pkg;
   // common parameters used across all benches
   parameter int NUM_MAX_INTERRUPTS  = 32;
   parameter int NUM_MAX_ALERTS      = 32;
-  parameter int NUM_ALERT_PINS      = 10;
 
   // types & variables
   typedef bit [31:0] uint;
@@ -25,19 +24,8 @@ package dv_utils_pkg;
 
   // typedef parameterized pins_if for ease of implementation for interrupts and alerts
   typedef virtual pins_if #(NUM_MAX_INTERRUPTS) intr_vif;
-  typedef virtual pins_if #(NUM_MAX_ALERTS)     alerts_vif;
   typedef virtual pins_if #(1)                  devmode_vif;
   typedef virtual pins_if #(1)                  tlul_assert_ctrl_vif;
-
-  // alert io signals
-  typedef enum {
-    PingEn    = 0,
-    PingOk    = 1,
-    IntegFail = 2,
-    Alert     = 3,
-    AlertRx   = 4, // rx has 4 bits
-    AlertTx   = 8  // tx has 2 bits
-  } alert_pin_e;
 
   // interface direction / mode - Host or Device
   typedef enum bit {

--- a/hw/ip/aes/dv/tb/tb.sv
+++ b/hw/ip/aes/dv/tb/tb.sv
@@ -15,12 +15,10 @@ module tb;
 
   wire clk, rst_n;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
-  wire [NUM_MAX_ALERTS-1:0] alerts;
 
   // interfaces
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
   pins_if #(NUM_MAX_INTERRUPTS) intr_if(interrupts);
-  pins_if #(NUM_MAX_ALERTS) alerts_if(alerts);
   pins_if #(1) devmode_if();
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
 
@@ -40,7 +38,6 @@ module tb;
     clk_rst_if.set_active();
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
-    uvm_config_db#(alerts_vif)::set(null, "*.env", "alerts_vif", alerts_if);
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
 //    uvm_config_db#(tlul_assert_vif)::set(null, "*.env", "tlul_assert_vif", tb.dut.tlul_assert);
     uvm_config_db#(tlul_assert_ctrl_vif)::set(null, "*.env", "tlul_assert_ctrl_vif",

--- a/hw/ip/alert_handler/dv/env/alert_handler_env_cfg.sv
+++ b/hw/ip/alert_handler/dv/env/alert_handler_env_cfg.sv
@@ -26,7 +26,6 @@ class alert_handler_env_cfg extends cip_base_env_cfg #(.RAL_T(alert_handler_reg_
       if (rg != null) begin
         num_interrupts = ral.intr_state.get_n_used_bits();
       end
-      num_alerts = 0;
     end
   endfunction
 

--- a/hw/ip/gpio/dv/tb/tb.sv
+++ b/hw/ip/gpio/dv/tb/tb.sv
@@ -23,12 +23,10 @@ module tb;
   wire [NUM_GPIOS-1:0] gpio_oe;
   wire [NUM_GPIOS-1:0] gpio_intr;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
-  wire [NUM_MAX_ALERTS-1:0] alerts;
 
   // interfaces
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
   pins_if #(NUM_MAX_INTERRUPTS) intr_if(.pins(interrupts));
-  pins_if #(NUM_MAX_ALERTS) alerts_if(.pins(alerts));
   pins_if #(1) devmode_if(.pins(devmode));
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
   pins_if #(NUM_GPIOS) gpio_if(.pins(gpio_pins));
@@ -64,7 +62,6 @@ module tb;
     clk_rst_if.set_active();
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
-    uvm_config_db#(alerts_vif)::set(null, "*.env", "alerts_vif", alerts_if);
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
     uvm_config_db#(tlul_assert_ctrl_vif)::set(null, "*.env", "tlul_assert_ctrl_vif",
         dut.tlul_assert_device.tlul_assert_ctrl_if);

--- a/hw/ip/hmac/dv/env/hmac_env.sv
+++ b/hw/ip/hmac/dv/env/hmac_env.sv
@@ -11,11 +11,6 @@ class hmac_env extends cip_base_env #(.CFG_T               (hmac_env_cfg),
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
-    // get vifs
-    if (!uvm_config_db#(msg_push_sha_disabled_alert_vif)::get(this, "",
-        "msg_push_sha_disabled_alert_vif", cfg.msg_push_sha_disabled_alert_vif)) begin
-      `uvm_fatal(get_full_name(), "failed to get msg_push_sha_disabled_alert from uvm_config_db")
-    end
   endfunction
 
 endclass

--- a/hw/ip/hmac/dv/env/hmac_env_cfg.sv
+++ b/hw/ip/hmac/dv/env/hmac_env_cfg.sv
@@ -4,8 +4,6 @@
 
 class hmac_env_cfg extends cip_base_env_cfg #(.RAL_T(hmac_reg_block));
 
-  msg_push_sha_disabled_alert_vif msg_push_sha_disabled_alert_vif;
-
   `uvm_object_utils(hmac_env_cfg)
   `uvm_object_new
 
@@ -21,6 +19,7 @@ class hmac_env_cfg extends cip_base_env_cfg #(.RAL_T(hmac_reg_block));
     mem_addr.start_addr = HMAC_MSG_FIFO_BASE;
     mem_addr.end_addr   = HMAC_MSG_FIFO_LAST_ADDR;
     mem_addrs.push_back(mem_addr);
+    list_of_alerts      = {"msg_push_sha_disabled"};
   endfunction
 
   // ral flow is limited in terms of setting correct field access policies and reset values

--- a/hw/ip/hmac/dv/env/hmac_env_pkg.sv
+++ b/hw/ip/hmac/dv/env/hmac_env_pkg.sv
@@ -9,6 +9,7 @@ package hmac_env_pkg;
   import dv_utils_pkg::*;
   import csr_utils_pkg::*;
   import tl_agent_pkg::*;
+  import alert_agent_pkg::*;
   import cryptoc_dpi_pkg::*;
   import dv_lib_pkg::*;
   import cip_base_pkg::*;
@@ -70,9 +71,6 @@ package hmac_env_pkg;
   typedef class hmac_env_cov;
   typedef cip_base_virtual_sequencer #(hmac_env_cfg, hmac_env_cov) hmac_virtual_sequencer;
   typedef virtual pins_if #(1) d2h_a_ready_vif;
-
-  // TODO: need to standardize this and move into uvm generator
-  typedef virtual pins_if #(NUM_ALERT_PINS) msg_push_sha_disabled_alert_vif;
 
   // functions
 

--- a/hw/ip/hmac/dv/env/hmac_scoreboard.sv
+++ b/hw/ip/hmac/dv/env/hmac_scoreboard.sv
@@ -233,7 +233,8 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
           wait(!under_reset);
           fork
             begin : increase_wr_cnt
-              wait(msg_q.size() >= (hmac_wr_cnt + 1) * 4 || (hmac_process && msg_q.size() % 4 != 0));
+              wait(msg_q.size() >= (hmac_wr_cnt + 1) * 4 ||
+                  (hmac_process && msg_q.size() % 4 != 0));
               if (sha_en) begin
                 // if fifo full, tlul will not write next data until fifo has space again
                 if (fifo_full) begin

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
@@ -59,9 +59,15 @@ class hmac_base_vseq extends cip_base_vseq #(.CFG_T               (hmac_env_cfg)
 
   virtual task dut_init(string reset_kind = "HARD");
     super.dut_init(reset_kind);
-    // TODO: need agent for full alert protocol
-    cfg.msg_push_sha_disabled_alert_vif.drive_pin(.idx(PingEn), .val(0));
+    alert_send_ping();
     if (do_hmac_init) hmac_init();
+  endtask
+
+  virtual task alert_send_ping();
+    alert_receiver_seq ping_seq;
+    `uvm_create_on(ping_seq, p_sequencer.alert_sequencer_h[cfg.list_of_alerts[0]]);
+    `DV_CHECK_RANDOMIZE_FATAL(ping_seq)
+    `uvm_send(ping_seq)
   endtask
 
   virtual task dut_shutdown();

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_sanity_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_sanity_vseq.sv
@@ -49,6 +49,7 @@ class hmac_sanity_vseq extends hmac_base_vseq;
   endtask
 
   task body();
+    run_alert_rsp_seq_nonblocking();
     for (int i = 1; i <= num_trans; i++) begin
       bit [7:0] msg_q[$];
       `DV_CHECK_RANDOMIZE_FATAL(this)

--- a/hw/ip/hmac/dv/tb/tb.sv
+++ b/hw/ip/hmac/dv/tb/tb.sv
@@ -7,6 +7,7 @@ module tb;
   import uvm_pkg::*;
   import dv_utils_pkg::*;
   import tl_agent_pkg::*;
+  import alert_agent_pkg::*;
   import hmac_env_pkg::*;
   import hmac_test_pkg::*;
 
@@ -17,42 +18,20 @@ module tb;
   wire clk, rst_n;
   wire devmode;
   wire [NUM_MAX_INTERRUPTS-1:0]  interrupts;
-  wire [NUM_ALERT_PINS-1:0]      msg_push_sha_disabled_alert;
-  wire [hmac_pkg::NumAlerts-1:0] alerts;
-  wire [hmac_pkg::NumAlerts-1:0] ping_ok;
-  wire [hmac_pkg::NumAlerts-1:0] ping_en;
-  wire [hmac_pkg::NumAlerts-1:0] integ_fail;
-  wire prim_pkg::alert_rx_t [hmac_pkg::NumAlerts-1:0] alert_rx;
-  wire prim_pkg::alert_tx_t [hmac_pkg::NumAlerts-1:0] alert_tx;
 
   wire intr_hmac_done;
   wire intr_fifo_full;
   wire intr_hmac_err;
 
+  // parameters
+  string list_of_alerts[] = {"msg_push_sha_disabled"};
+
   // interfaces
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
   pins_if #(NUM_MAX_INTERRUPTS) intr_if(.pins(interrupts));
-  pins_if #(NUM_ALERT_PINS) msg_push_sha_disabled_alert_if(.pins(msg_push_sha_disabled_alert));
   pins_if #(1) devmode_if(devmode);
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
-
-
-  // alert receivers
-  for (genvar j = 0; j < hmac_pkg::NumAlerts; j++) begin : gen_alert_rx
-    prim_alert_receiver #(
-      .AsyncOn(hmac_pkg::AlertAsyncOn[j])
-    ) i_prim_alert_receiver (
-      .clk_i        ( clk           ),
-      .rst_ni       ( rst_n         ),
-      .ping_en_i    ( ping_en[j]    ),
-      .ping_ok_o    ( ping_ok[j]    ),
-      .integ_fail_o ( integ_fail[j] ),
-      .alert_o      ( alerts[j]     ),
-      .alert_rx_o   ( alert_rx[j]   ),
-      .alert_tx_i   ( alert_tx[j]   )
-    );
-  end : gen_alert_rx
-
+  alert_if alert_if_msg_push_sha_disabled(.clk(clk), .rst_n(rst_n));
 
   // dut
   hmac dut (
@@ -66,33 +45,25 @@ module tb;
     .intr_fifo_full_o   ( intr_fifo_full ),
     .intr_hmac_err_o    ( intr_hmac_err  ),
 
-    .alert_rx_i         ( alert_rx       ),
-    .alert_tx_o         ( alert_tx       )
+    .alert_rx_i         ( alert_if_msg_push_sha_disabled.alert_rx ),
+    .alert_tx_o         ( alert_if_msg_push_sha_disabled.alert_tx )
   );
 
   assign interrupts[HmacDone]        = intr_hmac_done;
   assign interrupts[HmacMsgFifoFull] = intr_fifo_full;
   assign interrupts[HmacErr]         = intr_hmac_err;
 
-  assign ping_en[0]  = msg_push_sha_disabled_alert[PingEn];
-  assign msg_push_sha_disabled_alert[PingOk]            = ping_ok[0];
-  assign msg_push_sha_disabled_alert[IntegFail]         = integ_fail[0];
-  assign msg_push_sha_disabled_alert[Alert]             = alerts[0];
-  assign msg_push_sha_disabled_alert[AlertRx+3:AlertRx] = alert_rx[0];
-  assign msg_push_sha_disabled_alert[AlertTx+1:AlertTx] = alert_tx[0];
-
-
   initial begin
     // drive clk and rst_n from clk_if
     clk_rst_if.set_active();
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
-    uvm_config_db#(msg_push_sha_disabled_alert_vif)::set(null, "*.env",
-                   "msg_push_sha_disabled_alert_vif", msg_push_sha_disabled_alert_if);
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
     uvm_config_db#(tlul_assert_ctrl_vif)::set(null, "*.env", "tlul_assert_ctrl_vif",
         dut.tlul_assert_device.tlul_assert_ctrl_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
+    uvm_config_db#(virtual alert_if)::set(null, "*.env.m_alert_agent_msg_push_sha_disabled",
+        "vif", alert_if_msg_push_sha_disabled);
     $timeformat(-12, 0, " ps", 12);
     run_test();
   end

--- a/hw/ip/i2c/dv/env/i2c_env_cfg.sv
+++ b/hw/ip/i2c/dv/env/i2c_env_cfg.sv
@@ -24,7 +24,6 @@ class i2c_env_cfg extends cip_base_env_cfg #(.RAL_T(i2c_reg_block));
 
     // set num_interrupts & num_alerts which will be used to create coverage and more
     num_interrupts = ral.intr_state.get_n_used_bits();
-    num_alerts = 0;
   endfunction
 
 endclass

--- a/hw/ip/i2c/dv/tb/tb.sv
+++ b/hw/ip/i2c/dv/tb/tb.sv
@@ -25,12 +25,10 @@ module tb;
   wire intr_stretch_timeout;
   wire intr_sda_unstable;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
-  wire [NUM_MAX_ALERTS-1:0] alerts;
 
   // interfaces
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
   pins_if #(NUM_MAX_INTERRUPTS) intr_if(interrupts);
-  pins_if #(NUM_MAX_ALERTS) alerts_if(alerts);
   pins_if #(1) devmode_if(devmode);
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
   i2c_if i2c_if();
@@ -77,7 +75,6 @@ module tb;
     clk_rst_if.set_active();
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
-    uvm_config_db#(alerts_vif)::set(null, "*.env", "alerts_vif", alerts_if);
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
     uvm_config_db#(tlul_assert_ctrl_vif)::set(null, "*.env", "tlul_assert_ctrl_vif",
         dut.tlul_assert_device.tlul_assert_ctrl_if);

--- a/hw/ip/rv_timer/dv/tb/tb.sv
+++ b/hw/ip/rv_timer/dv/tb/tb.sv
@@ -18,12 +18,10 @@ module tb;
   wire devmode;
   wire [NUM_HARTS-1:0][NUM_TIMERS-1:0] intr_timer_expired;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
-  wire [NUM_MAX_ALERTS-1:0] alerts;
 
   // interfaces
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
   pins_if #(NUM_MAX_INTERRUPTS) intr_if(.pins(interrupts));
-  pins_if #(NUM_MAX_ALERTS) alerts_if(.pins(alerts));
   pins_if #(1) devmode_if(devmode);
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
 
@@ -45,7 +43,6 @@ module tb;
     clk_rst_if.set_active();
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
-    uvm_config_db#(alerts_vif)::set(null, "*.env", "alerts_vif", alerts_if);
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
     uvm_config_db#(tlul_assert_ctrl_vif)::set(null, "*.env", "tlul_assert_ctrl_vif",
         dut.tlul_assert_device.tlul_assert_ctrl_if);

--- a/hw/ip/spi_device/dv/tb/tb.sv
+++ b/hw/ip/spi_device/dv/tb/tb.sv
@@ -17,7 +17,6 @@ module tb;
   wire clk, rst_n;
   wire devmode;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
-  wire [NUM_MAX_ALERTS-1:0] alerts;
 
   wire sck;
   wire csb;
@@ -35,7 +34,6 @@ module tb;
   // interfaces
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
   pins_if #(NUM_MAX_INTERRUPTS) intr_if(.pins(interrupts));
-  pins_if #(NUM_MAX_ALERTS) alerts_if(.pins(alerts));
   pins_if #(1) devmode_if(devmode);
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
   spi_if spi_if(.rst_n(rst_n));
@@ -80,7 +78,6 @@ module tb;
     clk_rst_if.set_active();
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
-    uvm_config_db#(alerts_vif)::set(null, "*.env", "alerts_vif", alerts_if);
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
     uvm_config_db#(tlul_assert_ctrl_vif)::set(null, "*.env", "tlul_assert_ctrl_vif",
         dut.tlul_assert_device.tlul_assert_ctrl_if);

--- a/hw/ip/uart/dv/tb/tb.sv
+++ b/hw/ip/uart/dv/tb/tb.sv
@@ -25,12 +25,10 @@ module tb;
   wire intr_rx_timeout;
   wire intr_rx_parity_err;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
-  wire [NUM_MAX_INTERRUPTS-1:0] alerts;
 
   // interfaces
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
   pins_if #(NUM_MAX_INTERRUPTS) intr_if(interrupts);
-  pins_if #(NUM_MAX_ALERTS) alerts_if(alerts);
   pins_if #(1) devmode_if(devmode);
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
   uart_if uart_if();
@@ -71,7 +69,6 @@ module tb;
     clk_rst_if.set_active();
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
-    uvm_config_db#(alerts_vif)::set(null, "*.env", "alerts_vif", alerts_if);
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
     uvm_config_db#(tlul_assert_ctrl_vif)::set(null, "*.env", "tlul_assert_ctrl_vif",
         dut.tlul_assert_device.tlul_assert_ctrl_if);

--- a/util/uvmdvgen/env_cfg.sv.tpl
+++ b/util/uvmdvgen/env_cfg.sv.tpl
@@ -39,7 +39,6 @@ class ${name}_env_cfg extends dv_base_env_cfg #(.RAL_T(${name}_reg_block));
       if (rg != null) begin
         num_interrupts = ral.intr_state.get_n_used_bits();
       end
-      num_alerts = 0;
     end
 % endif
   endfunction

--- a/util/uvmdvgen/tb.sv.tpl
+++ b/util/uvmdvgen/tb.sv.tpl
@@ -19,7 +19,8 @@ module tb;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
 % endif
 % if has_alerts:
-  wire [NUM_MAX_ALERTS-1:0] alerts;
+  // TODO: change alert_names
+  list_of_alerts = {"alert_names"};
 % endif
 % endif
 
@@ -30,7 +31,8 @@ module tb;
   pins_if #(NUM_MAX_INTERRUPTS) intr_if(interrupts);
 % endif
 % if has_alerts:
-  pins_if #(NUM_MAX_ALERTS) alerts_if(alerts);
+  // TODO: declare alert interfaces according to the list_of_alerts
+  alert_if alert_names(.clk(clk), .rst_n(rst_n))
 % endif
   pins_if #(1) devmode_if();
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
@@ -46,8 +48,13 @@ module tb;
     .rst_ni               (rst_n      ),
 
     .tl_i                 (tl_if.h2d  ),
+% if has_alerts:
+    .tl_o                 (tl_if.d2h  ),
+    .alert_rx_i           (alert_names.alert_rx ),
+    .alert_tx_o           (alert_names.alert_tx )
+% else:
     .tl_o                 (tl_if.d2h  )
-
+% endif
 % else:
     .rst_ni               (rst_n      )
 
@@ -64,7 +71,9 @@ module tb;
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
 % endif
 % if has_alerts:
-    uvm_config_db#(alerts_vif)::set(null, "*.env", "alerts_vif", alerts_if);
+  // TODO: set alert interfaces with the correct names
+  uvm_config_db#(virtual alert_if)::set(null, "*.env.m_alert_agent_alert_names",
+        "vif", alert_names);
 % endif
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
     uvm_config_db#(tlul_assert_ctrl_vif)::set(null, "*.env", "tlul_assert_ctrl_vif",


### PR DESCRIPTION
Add alert_agent under dv/sv to support receiver and sender pairs
Delete original temp support for alert handler in HMAC

Signed-off-by: Cindy Chen <chencindy@google.com>