### PR TITLE
[prim_fifo/fpv] This adds an FPV testbench for sync FIFO primitives

### DIFF
--- a/hw/ip/prim/fpv/prim_fifo_sync_fpv.core
+++ b/hw/ip/prim/fpv/prim_fifo_sync_fpv.core
@@ -1,0 +1,24 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:fpv:prim_fifo_sync_fpv:0.1"
+description: "prim_fifo_sync FPV target"
+filesets:
+  files_fpv:
+    depend:
+      - lowrisc:prim:all
+    files:
+      - vip/prim_fifo_sync_assert_fpv.sv
+      - tb/prim_fifo_sync_bind_fpv.sv
+      - tb/prim_fifo_sync_fpv.sv
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    # note, this setting is just used
+    # to generate a file list for jg
+    default_tool: icarus
+    filesets:
+      - files_fpv
+    toplevel: prim_fifo_sync_fpv

--- a/hw/ip/prim/fpv/tb/prim_fifo_sync_bind_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_fifo_sync_bind_fpv.sv
@@ -1,0 +1,193 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+module prim_fifo_sync_bind_fpv;
+
+  // need to instantiate by hand since bind statements inside
+  // generate blocks are currently not supported
+
+  ////////////////////
+  // non-pass FIFOs //
+  ////////////////////
+
+  bind i_nopass1 prim_fifo_sync_assert_fpv #(
+    .Pass(1'b0),
+    .Depth(1)
+  ) i_prim_fifo_sync_assert_fpv (
+    .clk_i,
+    .rst_ni,
+    .clr_i,
+    .wvalid,
+    .wready,
+    .wdata,
+    .rvalid,
+    .rready,
+    .rdata,
+    .depth
+  );
+
+  bind i_nopass7 prim_fifo_sync_assert_fpv #(
+    .Pass(1'b0),
+    .Depth(7)
+  ) i_prim_fifo_sync_assert_fpv (
+    .clk_i,
+    .rst_ni,
+    .clr_i,
+    .wvalid,
+    .wready,
+    .wdata,
+    .rvalid,
+    .rready,
+    .rdata,
+    .depth
+  );
+
+  bind i_nopass8 prim_fifo_sync_assert_fpv #(
+    .Pass(1'b0),
+    .Depth(8)
+  ) i_prim_fifo_sync_assert_fpv (
+    .clk_i,
+    .rst_ni,
+    .clr_i,
+    .wvalid,
+    .wready,
+    .wdata,
+    .rvalid,
+    .rready,
+    .rdata,
+    .depth
+  );
+
+  bind i_nopass15 prim_fifo_sync_assert_fpv #(
+    .EnableDataCheck(1'b0),
+    .Pass(1'b0),
+    .Depth(15)
+  ) i_prim_fifo_sync_assert_fpv (
+    .clk_i,
+    .rst_ni,
+    .clr_i,
+    .wvalid,
+    .wready,
+    .wdata,
+    .rvalid,
+    .rready,
+    .rdata,
+    .depth
+  );
+
+  bind i_nopass16 prim_fifo_sync_assert_fpv #(
+    .EnableDataCheck(1'b0),
+    .Pass(1'b0),
+    .Depth(16)
+  ) i_prim_fifo_sync_assert_fpv (
+    .clk_i,
+    .rst_ni,
+    .clr_i,
+    .wvalid,
+    .wready,
+    .wdata,
+    .rvalid,
+    .rready,
+    .rdata,
+    .depth
+  );
+
+  ////////////////
+  // pass FIFOs //
+  ////////////////
+
+  bind i_pass0 prim_fifo_sync_assert_fpv #(
+    .Depth(0)
+  ) i_prim_fifo_sync_assert_fpv (
+    .clk_i,
+    .rst_ni,
+    .clr_i,
+    .wvalid,
+    .wready,
+    .wdata,
+    .rvalid,
+    .rready,
+    .rdata,
+    .depth
+  );
+
+  bind i_pass1 prim_fifo_sync_assert_fpv #(
+    .Depth(1)
+  ) i_prim_fifo_sync_assert_fpv (
+    .clk_i,
+    .rst_ni,
+    .clr_i,
+    .wvalid,
+    .wready,
+    .wdata,
+    .rvalid,
+    .rready,
+    .rdata,
+    .depth
+  );
+
+  bind i_pass7 prim_fifo_sync_assert_fpv #(
+    .Depth(7)
+  ) i_prim_fifo_sync_assert_fpv (
+    .clk_i,
+    .rst_ni,
+    .clr_i,
+    .wvalid,
+    .wready,
+    .wdata,
+    .rvalid,
+    .rready,
+    .rdata,
+    .depth
+  );
+
+  bind i_pass8 prim_fifo_sync_assert_fpv #(
+    .Depth(8)
+  ) i_prim_fifo_sync_assert_fpv (
+    .clk_i,
+    .rst_ni,
+    .clr_i,
+    .wvalid,
+    .wready,
+    .wdata,
+    .rvalid,
+    .rready,
+    .rdata,
+    .depth
+  );
+
+  bind i_pass15 prim_fifo_sync_assert_fpv #(
+    .EnableDataCheck(1'b0),
+    .Depth(15)
+  ) i_prim_fifo_sync_assert_fpv (
+    .clk_i,
+    .rst_ni,
+    .clr_i,
+    .wvalid,
+    .wready,
+    .wdata,
+    .rvalid,
+    .rready,
+    .rdata,
+    .depth
+  );
+
+  bind i_pass16 prim_fifo_sync_assert_fpv #(
+    .EnableDataCheck(1'b0),
+    .Depth(16)
+  ) i_prim_fifo_sync_assert_fpv (
+    .clk_i,
+    .rst_ni,
+    .clr_i,
+    .wvalid,
+    .wready,
+    .wdata,
+    .rvalid,
+    .rready,
+    .rdata,
+    .depth
+  );
+
+endmodule : prim_fifo_sync_bind_fpv

--- a/hw/ip/prim/fpv/tb/prim_fifo_sync_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_fifo_sync_fpv.sv
@@ -1,0 +1,230 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Testbench module for prim_fifo_sync.
+// Intended to be used with a formal tool.
+//
+// This formal testbench instantiates a set of differently parameterized FIFOs:
+//
+//  - a depth 0 pass through FIFO
+//  - depth 1, 7, 8, 15, 16 pass through FIFOs
+//  - depth 1, 7, 8, 15, 16 non-pass through FIFOs
+//
+// Data/depth value checks are enabled up to depth 8 in order to constrain the
+// runtime.
+
+module prim_fifo_sync_fpv #(
+  // number of DUTs instantiated in this FPV testbench
+  parameter int unsigned NumDuts = 11,
+  // fifo params
+  parameter int unsigned Width = 16,
+  parameter int unsigned MaxDepth = 16, // max depth used in this destbench
+  localparam int unsigned DepthW = ($clog2(MaxDepth+1) == 0) ? 1 : $clog2(MaxDepth+1)
+) (
+  input               clk_i,
+  input               rst_ni,
+  input               clr_i,
+  input               wvalid [NumDuts],
+  output              wready [NumDuts],
+  input  [Width-1:0]  wdata  [NumDuts],
+  output              rvalid [NumDuts],
+  input               rready [NumDuts],
+  output [Width-1:0]  rdata  [NumDuts],
+  output [DepthW-1:0] depth  [NumDuts]
+);
+
+  // need to instantiate by hand since bind statements inside
+  // generate blocks are currently not supported
+
+  ////////////////////
+  // non-pass FIFOs //
+  ////////////////////
+
+  prim_fifo_sync #(
+    .Width(Width),
+    .Pass(1'b0),
+    .Depth(1)
+  ) i_nopass1 (
+    .clk_i,
+    .rst_ni,
+    .clr_i,
+    .wvalid(wvalid[0]),
+    .wready(wready[0]),
+    .wdata(wdata[0]),
+    .rvalid(rvalid[0]),
+    .rready(rready[0]),
+    .rdata(rdata[0]),
+    .depth(depth[0][0])
+  );
+
+  prim_fifo_sync #(
+    .Width(Width),
+    .Pass(1'b0),
+    .Depth(7)
+  ) i_nopass7 (
+    .clk_i,
+    .rst_ni,
+    .clr_i,
+    .wvalid(wvalid[1]),
+    .wready(wready[1]),
+    .wdata(wdata[1]),
+    .rvalid(rvalid[1]),
+    .rready(rready[1]),
+    .rdata(rdata[1]),
+    .depth(depth[1][2:0])
+  );
+
+  prim_fifo_sync #(
+    .Width(Width),
+    .Pass(1'b0),
+    .Depth(8)
+  ) i_nopass8 (
+    .clk_i,
+    .rst_ni,
+    .clr_i,
+    .wvalid(wvalid[2]),
+    .wready(wready[2]),
+    .wdata(wdata[2]),
+    .rvalid(rvalid[2]),
+    .rready(rready[2]),
+    .rdata(rdata[2]),
+    .depth(depth[2][3:0])
+  );
+
+  prim_fifo_sync #(
+    .Width(Width),
+    .Pass(1'b0),
+    .Depth(15)
+  ) i_nopass15 (
+    .clk_i,
+    .rst_ni,
+    .clr_i,
+    .wvalid(wvalid[3]),
+    .wready(wready[3]),
+    .wdata(wdata[3]),
+    .rvalid(rvalid[3]),
+    .rready(rready[3]),
+    .rdata(rdata[3]),
+    .depth(depth[3][3:0])
+  );
+
+  prim_fifo_sync #(
+    .Width(Width),
+    .Pass(1'b0),
+    .Depth(16)
+  ) i_nopass16 (
+    .clk_i,
+    .rst_ni,
+    .clr_i,
+    .wvalid(wvalid[4]),
+    .wready(wready[4]),
+    .wdata(wdata[4]),
+    .rvalid(rvalid[4]),
+    .rready(rready[4]),
+    .rdata(rdata[4]),
+    .depth(depth[4][4:0])
+  );
+
+  ////////////////
+  // pass FIFOs //
+  ////////////////
+
+  // depth-zero is per definition a pass-through FIFO
+  prim_fifo_sync #(
+    .Width(Width),
+    .Depth(0)
+  ) i_pass0 (
+    .clk_i,
+    .rst_ni,
+    .clr_i,
+    .wvalid(wvalid[5]),
+    .wready(wready[5]),
+    .wdata(wdata[5]),
+    .rvalid(rvalid[5]),
+    .rready(rready[5]),
+    .rdata(rdata[5]),
+    .depth(depth[5][0])
+  );
+
+  prim_fifo_sync #(
+    .Width(Width),
+    .Depth(1)
+  ) i_pass1 (
+    .clk_i,
+    .rst_ni,
+    .clr_i,
+    .wvalid(wvalid[6]),
+    .wready(wready[6]),
+    .wdata(wdata[6]),
+    .rvalid(rvalid[6]),
+    .rready(rready[6]),
+    .rdata(rdata[6]),
+    .depth(depth[6][0])
+  );
+
+  prim_fifo_sync #(
+    .Width(Width),
+    .Depth(7)
+  ) i_pass7 (
+    .clk_i,
+    .rst_ni,
+    .clr_i,
+    .wvalid(wvalid[7]),
+    .wready(wready[7]),
+    .wdata(wdata[7]),
+    .rvalid(rvalid[7]),
+    .rready(rready[7]),
+    .rdata(rdata[7]),
+    .depth(depth[7][2:0])
+  );
+
+  prim_fifo_sync #(
+    .Width(Width),
+    .Depth(8)
+  ) i_pass8 (
+    .clk_i,
+    .rst_ni,
+    .clr_i,
+    .wvalid(wvalid[8]),
+    .wready(wready[8]),
+    .wdata(wdata[8]),
+    .rvalid(rvalid[8]),
+    .rready(rready[8]),
+    .rdata(rdata[8]),
+    .depth(depth[8][3:0])
+  );
+
+  prim_fifo_sync #(
+    .Width(Width),
+    .Depth(15)
+  ) i_pass15 (
+    .clk_i,
+    .rst_ni,
+    .clr_i,
+    .wvalid(wvalid[9]),
+    .wready(wready[9]),
+    .wdata(wdata[9]),
+    .rvalid(rvalid[9]),
+    .rready(rready[9]),
+    .rdata(rdata[9]),
+    .depth(depth[9][3:0])
+  );
+
+  prim_fifo_sync #(
+    .Width(Width),
+    .Depth(16)
+  ) i_pass16 (
+    .clk_i,
+    .rst_ni,
+    .clr_i,
+    .wvalid(wvalid[10]),
+    .wready(wready[10]),
+    .wdata(wdata[10]),
+    .rvalid(rvalid[10]),
+    .rready(rready[10]),
+    .rdata(rdata[10]),
+    .depth(depth[10][4:0])
+  );
+
+endmodule : prim_fifo_sync_fpv

--- a/hw/ip/prim/fpv/vip/prim_fifo_sync_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_fifo_sync_assert_fpv.sv
@@ -1,0 +1,212 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Assertions for prim_fifo_sync.
+// Intended to be used with a formal tool.
+
+module prim_fifo_sync_assert_fpv #(
+  // can be desabled for deeper FIFOs
+  parameter bit EnableDataCheck = 1'b1,
+  parameter int unsigned Width = 16,
+  parameter bit Pass = 1'b1,
+  parameter int unsigned Depth = 4,
+  localparam int unsigned DepthWNorm = $clog2(Depth+1),
+  localparam int unsigned DepthW = (DepthWNorm == 0) ? 1 : DepthWNorm
+) (
+  input  clk_i,
+  input  rst_ni,
+  input  clr_i,
+  input  wvalid,
+  input  wready,
+  input [Width-1:0] wdata,
+  input  rvalid,
+  input  rready,
+  input [Width-1:0] rdata,
+  input [DepthW-1:0] depth
+);
+
+  /////////////////
+  // Assumptions //
+  /////////////////
+
+  // no need to consider all possible input words
+  // 2-3 different values suffice
+  `ASSUME(WdataValues_M, wdata inside {Width'(1'b0), Width'(1'b1), {Width{1'b1}}}, clk_i, !rst_ni)
+
+  ////////////////////////////////
+  // Data and Depth Value Check //
+  ////////////////////////////////
+
+   if (EnableDataCheck && Depth > 0) begin : gen_data_check
+
+    logic [DepthW+2:0] ref_depth;
+    logic [Width-1:0]  ref_rdata;
+
+    // no pointers needed in this case
+    if (Depth == 1) begin : gen_no_ptrs
+
+      logic [Width-1:0]  fifo;
+      logic [DepthW+2:0] wptr, rptr;
+
+      // this only models the data flow, since the control logic is tested below
+      always_ff @(posedge clk_i or negedge rst_ni) begin : p_fifo_model
+        if (!rst_ni) begin
+          ref_depth <= 0;
+        end else begin
+          if (clr_i) begin
+            ref_depth <= 0;
+          end else begin
+            if (wvalid && wready && rvalid && rready) begin
+              fifo <= wdata;
+            end else if (wvalid && wready) begin
+              fifo <= wdata;
+              ref_depth <= ref_depth + 1;
+            end else if (rvalid && rready) begin
+              ref_depth <= ref_depth - 1;
+            end
+          end
+        end
+      end
+
+      if (Pass) begin : gen_pass
+        assign ref_rdata = (ref_depth == 0) ? wdata : fifo;
+      end else begin : no_pass
+        assign ref_rdata = fifo;
+      end
+
+    // general case
+    end else begin : gen_ptrs
+
+      logic [Width-1:0]  fifo [0:Depth-1];
+      logic [DepthW+2:0] wptr, rptr;
+
+      // implements (++val) mod Depth
+      function automatic logic [DepthW+2:0] modinc(logic [DepthW+2:0] val, int modval);
+        if (val == Depth-1) return 0;
+        else                return val + 1;
+      endfunction
+
+      // this only models the data flow, since the control logic is tested below
+      always_ff @(posedge clk_i or negedge rst_ni) begin : p_fifo_model
+        if (!rst_ni) begin
+          wptr      <= 0;
+          rptr      <= 0;
+          ref_depth <= 0;
+        end else begin
+          if (clr_i) begin
+            wptr      <= 0;
+            rptr      <= 0;
+            ref_depth <= 0;
+          end else begin
+            if (wvalid && wready && rvalid && rready) begin
+              fifo[wptr] <= wdata;
+              wptr <= modinc(wptr, Depth);
+              rptr <= modinc(rptr, Depth);
+            end else if (wvalid && wready) begin
+              fifo[wptr] <= wdata;
+              wptr <= modinc(wptr, Depth);
+              ref_depth <= ref_depth + 1;
+            end else if (rvalid && rready) begin
+              rptr <= modinc(rptr, Depth);
+              ref_depth <= ref_depth - 1;
+            end
+          end
+        end
+      end
+
+      if (Pass) begin : gen_pass
+        assign ref_rdata = (ref_depth == 0) ? wdata : fifo[rptr];
+      end else begin : no_pass
+        assign ref_rdata = fifo[rptr];
+      end
+
+    end
+
+    // check the data
+    `ASSERT(DataCheck_A, rvalid |-> rdata == ref_rdata, clk_i, !rst_ni)
+    // check the depth
+    `ASSERT(DepthCheck_A, ref_depth == depth, clk_i, !rst_ni)
+
+  end
+
+  ////////////////////////
+  // Forward Assertions //
+  ////////////////////////
+
+  // assert depth of FIFO
+  `ASSERT(Depth_A, depth <= Depth, clk_i, !rst_ni)
+  // if we clear the FIFO, it must be empty in the next cycle
+  `ASSERT(CheckClrDepth_A, clr_i |=> depth == 0, clk_i, !rst_ni)
+  // check write on full
+  `ASSERT(WriteFull_A, depth == Depth && wvalid && !rready |=> depth == $past(depth),
+      clk_i, !rst_ni || clr_i)
+  // read empty
+  `ASSERT(ReadEmpty_A, depth == 0 && rready && !wvalid |=> depth == 0,
+      clk_i, !rst_ni || clr_i)
+
+  // this is unreachable in depth 1 no-pass through mode
+  if (Depth == 1 && Pass) begin
+    // check simultaneous write and read
+    `ASSERT(WriteAndRead_A, wready && wvalid && rvalid && rready |=> depth == $past(depth),
+        clk_i, !rst_ni || clr_i)
+  end
+
+  if (Depth == 0) begin : gen_depth0
+    // if there is no register, the FIFO is per definition pass-through
+    `ASSERT_INIT(ZeroDepthNeedsPass_A, Pass == 1)
+    // depth must remain zero
+    `ASSERT(DepthAlwaysZero_A, depth == 0, clk_i, !rst_ni)
+    // data is just passed through
+    `ASSERT(DataPassThru_A, wdata == rdata, clk_i, !rst_ni)
+    // FIFO is ready if downstream logic is ready
+    `ASSERT(Wready_A, rready == wready, clk_i, !rst_ni)
+    // valid input is valid output
+    `ASSERT(Rvalid_A, rvalid == wvalid, clk_i, !rst_ni)
+    // ensure full coverage
+    `ASSERT(UnusedClr_A, prim_fifo_sync.gen_passthru_fifo.unused_clr == clr_i,
+        clk_i, !rst_ni)
+  end else begin : gen_depth_gt0
+    // check wready
+    `ASSERT(Wready_A, depth < Depth |-> wready, clk_i, !rst_ni)
+    // check rvalid
+    `ASSERT(Rvalid_A, depth > 0 |-> rvalid, clk_i, !rst_ni)
+    // check write only
+    `ASSERT(WriteOnly_A, wvalid && wready && !rready && depth < Depth |=>
+        depth == $past(depth) + 1, clk_i, !rst_ni || clr_i)
+    // check read only
+    `ASSERT(ReadOnly_A, !wvalid && rready && rvalid && depth > 0 |=>
+      depth == $past(depth) - 1, clk_i, !rst_ni || clr_i)
+  end
+
+  if (Pass) begin : gen_pass_fwd
+    // if we clear the FIFO, it must be empty in the next cycle
+    // but we may also get a pass through
+    `ASSERT(CheckClrValid_A, clr_i |=> wvalid == rvalid, clk_i, !rst_ni)
+  end else begin : gen_nopass_fwd
+    // if we clear the FIFO, it must be empty in the next cycle
+    `ASSERT(CheckClrValid_A, clr_i |=> !rvalid, clk_i, !rst_ni)
+  end
+
+  /////////////////////////
+  // Backward Assertions //
+  /////////////////////////
+
+  if (Pass) begin : gen_pass_bkwd
+    // there is still space in the FIFO or downstream logic is ready
+    `ASSERT(WreadySpacekBkwd_A, wready |-> depth < Depth || rready, clk_i, !rst_ni)
+    // elements ready to be read or upstream data is valid
+    `ASSERT(RvalidElemskBkwd_A, rvalid |-> depth > 0 || wvalid, clk_i, !rst_ni)
+  end else begin : gen_nopass_bkwd
+    // there is still space in the FIFO
+    `ASSERT(WreadySpacekBkwd_A, wready |-> depth < Depth, clk_i, !rst_ni)
+    // elements ready to be read
+    `ASSERT(RvalidElemskBkwd_A, rvalid |-> depth > 0, clk_i, !rst_ni)
+  end
+
+  // no more space in the FIFO
+  `ASSERT(WreadyNoSpaceBkwd_A, !wready |-> depth == Depth, clk_i, !rst_ni)
+  // elements ready to be read
+  `ASSERT(RvalidNoElemskBkwd_A, !rvalid |-> depth == 0, clk_i, !rst_ni)
+
+endmodule : prim_fifo_sync_assert_fpv

--- a/hw/ip/prim/rtl/prim_fifo_sync.sv
+++ b/hw/ip/prim/rtl/prim_fifo_sync.sv
@@ -141,4 +141,13 @@ module prim_fifo_sync #(
   end // block: gen_normal_fifo
 
 
+  //////////////////////
+  // Known Assertions //
+  //////////////////////
+
+  `ASSERT(DataKnown_A, rvalid |-> !$isunknown(rdata), clk_i, !rst_ni)
+  `ASSERT_KNOWN(DepthKnown_A, depth, clk_i, !rst_ni)
+  `ASSERT_KNOWN(RvalidKnown_A, rvalid, clk_i, !rst_ni)
+  `ASSERT_KNOWN(WreadyKnown_A, wready, clk_i, !rst_ni)
+
 endmodule

--- a/util/fpvgen/bind_fpv.sv.tpl
+++ b/util/fpvgen/bind_fpv.sv.tpl
@@ -5,22 +5,37 @@
 
 module ${dut.name}_bind_fpv;
 
-  bind ${dut.name} ${dut.name}_assert_fpv ${dut.name}_assert_fpv (
-    .*
+<% params = dut.get_param_style("parameter") %>
+% if params:
+  bind ${dut.name} ${dut.name}_assert_fpv #(
+% for k, param in enumerate(params):
+  <% comma = "" if (k == len(params)-1) else "," %>  .${param.name}(${param.name})${comma}
+% endfor
+  ) i_${dut.name}_assert_fpv (
+% else:
+  bind ${dut.name} ${dut.name}_assert_fpv i_${dut.name}_assert_fpv (
+%endif
+  % for k, port in enumerate(dut.ports):
+<% comma = "" if (k == len(dut.ports)-1) else "," %>    .${port.name}${comma}
+  % endfor
   );
+
 % if dut.is_cip:
 
   bind ${dut.name} tlul_assert #(
     .EndpointType("Device")
-  ) tlul_assert_device (
+  ) i_tlul_assert_device (
     .clk_i,
     .rst_ni,
     .h2d  (tl_i),
     .d2h  (tl_o)
   );
 
-  bind ${dut.name} ${dut.name}_csr_assert_fpv (
-  	.*
+  bind ${dut.name} ${dut.name}_csr_assert_fpv i_${dut.name}_csr_assert_fpv (
+    .clk_i,
+    .rst_ni,
+    .h2d  (tl_i),
+    .d2h  (tl_o)
   );
 % endif
 


### PR DESCRIPTION
This adds an FPV testbench that tests differently parameterized FIFOs:

 - a depth 0 pass through FIFO
 - depth 1,7,8,15,16 pass through FIFOs
 - depth 1,7,8,15,16 non-pass through FIFOs

Data/depth value checks are enabled up to depth 8 in order to constrain the runtime.

All manually written SVAs have been covered and proven. No design bugs have been found so far.

Automatic FPV code coverage averaged over all instances is as follows and requires some further tuning to reach 100%:

- Stimuli Coverage: 98.07% (609/621) 
- COI Coverage:      94.84%   (441/465)
- Proof Coverage:    92.26%   (429/465)

Note: this is an example of how an FPV TB testbench can be quickly generated using: 
```
util/fpvgen.py hw/ip/prim/rtl/prim_fifo_sync.sv
```

Signed-off-by: Michael Schaffner <msf@opentitan.org>