### PR TITLE
[dv] Add TL error seq to run in parallel with stress & reset

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_vseq__tl_errors.svh
+++ b/hw/dv/sv/cip_lib/cip_base_vseq__tl_errors.svh
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Shorthand to create and send a TL error seq
-// TODO use low priority to send error item to TL agent, so when crossing error item with normal
-// seq, normal seq has the priority to access TL driver
+// Set low priority (1) to send error item to TL agent, so when crossing error item with normal
+// seq, normal seq with default priority (100) has the priority to access TL driver
 `define create_tl_access_error_case(task_name_, with_c_, seq_t_ = tl_host_custom_seq) \
   begin \
     seq_t_ tl_seq; \
@@ -16,7 +16,7 @@
     end \
     `DV_CHECK_RANDOMIZE_WITH_FATAL(tl_seq, with_c_) \
     csr_utils_pkg::increment_outstanding_access(); \
-    `uvm_send(tl_seq) \
+    `uvm_send_pri(tl_seq, 1) \
     csr_utils_pkg::decrement_outstanding_access(); \
   end
 

--- a/hw/dv/sv/cip_lib/doc/index.md
+++ b/hw/dv/sv/cip_lib/doc/index.md
@@ -189,10 +189,15 @@ Some examples:
 * **task cfg_interrupts, check_interrupts**: All interrupt CSRs are standardized
   according to the comportability spec, which allows us to create common tasks
   to turn on / off interrupts as well as check them.
-* **task run_stress_all_with_rand_reset_vseq**: This is a common virtual
-  sequence based on the stress_all virtual sequence. This virtual sequence
-  will randomly reset the stress_all sequence, then it will check if all
-  the readable registers are reset to the correct value.
+* **task run_tl_errors_vseq**: This task will test all kinds of TileLink error
+  cases, including unmapped address error, protocol error, memory access error
+  etc. All the items sent in this task will trigger d_error and won't change the
+  CSR/memory value.
+* **task run_stress_all_with_rand_reset_vseq**: This task runs 3 parallel threads,
+  which are ip_stress_all_vseq, run_tl_errors_vseq and reset sequence. After
+  reset occurs, the other threads will be killed and then all the CSRs will be read
+  for check. This task runs multiple iterations to ensure DUT won't be broken after
+  reset and TL errors.
   To ensure the reset functionality works correctly, user will have to disable
   any internal reset from the stress_all sequence. Below is an example of
   disabling internal reset in `hmac_stress_all_vseq.sv`:

--- a/hw/dv/sv/csr_utils/csr_utils_pkg.sv
+++ b/hw/dv/sv/csr_utils/csr_utils_pkg.sv
@@ -193,7 +193,7 @@ package csr_utils_pkg;
         fork
           begin
             increment_outstanding_access();
-            csr.update(.status(status), .path(path), .map(map));
+            csr.update(.status(status), .path(path), .map(map), .prior(100));
             if (check == UVM_CHECK) begin
               `DV_CHECK_EQ(status, UVM_IS_OK, "", error, msg_id)
             end
@@ -243,7 +243,7 @@ package csr_utils_pkg;
         fork
           begin
             increment_outstanding_access();
-            csr.write(.status(status), .value(value), .path(path), .map(map));
+            csr.write(.status(status), .value(value), .path(path), .map(map), .prior(100));
             if (check == UVM_CHECK) begin
               `DV_CHECK_EQ(status, UVM_IS_OK, "", error, msg_id)
             end
@@ -296,9 +296,11 @@ package csr_utils_pkg;
             increment_outstanding_access();
             csr_or_fld = decode_csr_or_field(ptr);
             if (csr_or_fld.field != null) begin
-              csr_or_fld.field.read(.status(status), .value(value), .path(path), .map(map));
+              csr_or_fld.field.read(.status(status), .value(value), .path(path), .map(map),
+                                    .prior(100));
             end else begin
-              csr_or_fld.csr.read(.status(status), .value(value), .path(path), .map(map));
+              csr_or_fld.csr.read(.status(status), .value(value), .path(path), .map(map),
+                                  .prior(100));
             end
             if (check == UVM_CHECK) begin
               `DV_CHECK_EQ(status, UVM_IS_OK, "", error, msg_id)
@@ -452,7 +454,7 @@ package csr_utils_pkg;
         fork
           begin
             increment_outstanding_access();
-            ptr.read(.status(status), .offset(offset), .value(data), .map(map));
+            ptr.read(.status(status), .offset(offset), .value(data), .map(map), .prior(100));
             if (check == UVM_CHECK) begin
               `DV_CHECK_EQ(status, UVM_IS_OK, "", error, msg_id)
             end
@@ -501,7 +503,7 @@ package csr_utils_pkg;
         fork
           begin
             increment_outstanding_access();
-            ptr.write(.status(status), .offset(offset), .value(data), .map(map));
+            ptr.write(.status(status), .offset(offset), .value(data), .map(map), .prior(100));
             if (check == UVM_CHECK) begin
               `DV_CHECK_EQ(status, UVM_IS_OK, "", error, msg_id)
             end

--- a/hw/dv/sv/tl_agent/tl_seq_lib.sv
+++ b/hw/dv/sv/tl_agent/tl_seq_lib.sv
@@ -39,7 +39,7 @@ class tl_host_seq extends uvm_sequence#(.REQ(tl_seq_item), .RSP(tl_seq_item));
               break;
             end
           end // foreach
-          if (!found_req) begin
+          if (!found_req && !csr_utils_pkg::under_reset) begin
             `uvm_error(`gfn, $sformatf("fail to find matching req for rsp[%0d]: %0s",
                                        i, rsp.convert2string()))
           end

--- a/hw/dv/tools/testplans/stress_all_with_reset_testplan.hjson
+++ b/hw/dv/tools/testplans/stress_all_with_reset_testplan.hjson
@@ -5,8 +5,9 @@
   entries: [
     {
       name: stress_all_with_rand_reset
-      desc: '''This test insert random reset during the stress_all test. After reset is asserted,
-            the test will read and check all valid CSR registers.'''
+      desc: '''This test runs 3 parallel threads - stress_all, tl_errors and random reset.
+            After reset is asserted, the test will read and check all valid CSR registers.
+            '''
       milestone: V2
       tests: ["{name}_stress_all_with_rand_reset"]
     }


### PR DESCRIPTION
1. Add tl_err seq with stress & reset
2. use low priority for tl_err and set the other tl item priority to be
100 at tl_access and csr_utils_pkg
Signed-off-by: Weicai Yang <weicai@google.com>