### PR TITLE
[aes/rtl] Remove X-assignments, add SVAs for undefined values

### DIFF
--- a/hw/ip/aes/rtl/aes_control.sv
+++ b/hw/ip/aes/rtl/aes_control.sv
@@ -215,10 +215,10 @@ module aes_control #(
                 unique case (mode_i)
                   AES_ENC: key_words_sel_o = KEY_WORDS_0123;
                   AES_DEC: key_words_sel_o = KEY_WORDS_2345;
-                  default: key_words_sel_o = key_words_sel_e'(1'bX);
+                  default: key_words_sel_o = KEY_WORDS_ZERO;
                 endcase
               end else begin
-                key_words_sel_o = key_words_sel_e'(1'bX);
+                key_words_sel_o = KEY_WORDS_ZERO;
               end
             end
 
@@ -226,11 +226,11 @@ module aes_control #(
               unique case (mode_i)
                 AES_ENC:   key_words_sel_o = KEY_WORDS_0123;
                 AES_DEC:   key_words_sel_o = KEY_WORDS_4567;
-                default:   key_words_sel_o = key_words_sel_e'(1'bX);
+                default:   key_words_sel_o = KEY_WORDS_ZERO;
               endcase
             end
 
-            default: key_words_sel_o = key_words_sel_e'(1'bX);
+            default: key_words_sel_o = KEY_WORDS_ZERO;
           endcase
         end
 
@@ -263,10 +263,10 @@ module aes_control #(
                 unique case (mode_i)
                   AES_ENC: key_words_sel_o = KEY_WORDS_2345;
                   AES_DEC: key_words_sel_o = KEY_WORDS_0123;
-                  default: key_words_sel_o = key_words_sel_e'(1'bX);
+                  default: key_words_sel_o = KEY_WORDS_ZERO;
                 endcase
               end else begin
-                key_words_sel_o = key_words_sel_e'(1'bX);
+                key_words_sel_o = KEY_WORDS_ZERO;
               end
             end
 
@@ -274,11 +274,11 @@ module aes_control #(
               unique case (mode_i)
                 AES_ENC:   key_words_sel_o = KEY_WORDS_4567;
                 AES_DEC:   key_words_sel_o = KEY_WORDS_0123;
-                default:   key_words_sel_o = key_words_sel_e'(1'bX);
+                default:   key_words_sel_o = KEY_WORDS_ZERO;
               endcase
             end
 
-            default: key_words_sel_o = key_words_sel_e'(1'bX);
+            default: key_words_sel_o = KEY_WORDS_ZERO;
           endcase
         end
 
@@ -320,10 +320,10 @@ module aes_control #(
                 unique case (mode_i)
                   AES_ENC: key_words_sel_o = KEY_WORDS_2345;
                   AES_DEC: key_words_sel_o = KEY_WORDS_0123;
-                  default: key_words_sel_o = key_words_sel_e'(1'bX);
+                  default: key_words_sel_o = KEY_WORDS_ZERO;
                 endcase
               end else begin
-                key_words_sel_o = key_words_sel_e'(1'bX);
+                key_words_sel_o = KEY_WORDS_ZERO;
               end
             end
 
@@ -331,11 +331,11 @@ module aes_control #(
               unique case (mode_i)
                 AES_ENC:   key_words_sel_o = KEY_WORDS_4567;
                 AES_DEC:   key_words_sel_o = KEY_WORDS_0123;
-                default:   key_words_sel_o = key_words_sel_e'(1'bX);
+                default:   key_words_sel_o = KEY_WORDS_ZERO;
               endcase
             end
 
-            default: key_words_sel_o = key_words_sel_e'(1'bX);
+            default: key_words_sel_o = KEY_WORDS_ZERO;
           endcase
         end
 
@@ -381,7 +381,7 @@ module aes_control #(
         aes_ctrl_ns = IDLE;
       end
 
-      default: aes_ctrl_ns = aes_ctrl_e'(1'bX);
+      default: aes_ctrl_ns = IDLE;
     endcase
   end
 
@@ -450,5 +450,20 @@ module aes_control #(
   assign key_clear_o         = 1'b0;
   assign data_in_clear_o     = 1'b0;
   assign data_out_clear_o    = 1'b0;
+
+  // Selectors must be known/valid
+  `ASSERT_KNOWN(AesModeKnown, mode_i, clk_i, !rst_ni)
+  `ASSERT(AesKeyLenValid, key_len_i inside {
+      AES_128,
+      AES_192,
+      AES_256
+      }, clk_i, !rst_ni)
+  `ASSERT(AesControlStateValid, aes_ctrl_cs inside {
+      IDLE,
+      INIT,
+      ROUND,
+      FINISH,
+      CLEAR
+      }, clk_i, !rst_ni)
 
 endmodule


### PR DESCRIPTION
This PR replaces the X assignments in the AES RTL by assignments of defined values, and adds SVAs to detect undefined values as discussed in the last silicon meeting.

About the SVAs I am not sure, ideally we would not need to list again all enum values (avoid code duplication) and instead just provide the enum type, but as far as I understand the `inside` constraint does not support this. Maybe you guys have a better idea.

Now that we know how to handle these cases, I also reworked some large combinations of `if/else` and `unique case` statements and replaced them with ternary expressions that are easier to understand. I could factor this change out into a separate PR but as we said to clean this up once we know how to deal with X assignments, I put it into this one.


