### PR TITLE
[aes/rtl] Use ternaries instead of combinations of `if/else` and `unique case`

### DIFF
--- a/hw/ip/aes/rtl/aes_control.sv
+++ b/hw/ip/aes/rtl/aes_control.sv
@@ -4,9 +4,7 @@
 //
 // AES control
 
-module aes_control #(
-  parameter bit AES192Enable = 1
-) (
+module aes_control (
   input  logic                    clk_i,
   input  logic                    rst_ni,
 
@@ -204,35 +202,12 @@ module aes_control #(
         add_rk_sel_o = ADD_RK_INIT;
 
         // Select key words for initial add_round_key
-        if (dec_key_gen_q) begin
-          key_words_sel_o = KEY_WORDS_ZERO;
-        end else begin
-          unique case (key_len_i)
-            AES_128:       key_words_sel_o = KEY_WORDS_0123;
-
-            AES_192: begin
-              if (AES192Enable) begin
-                unique case (mode_i)
-                  AES_ENC: key_words_sel_o = KEY_WORDS_0123;
-                  AES_DEC: key_words_sel_o = KEY_WORDS_2345;
-                  default: key_words_sel_o = KEY_WORDS_ZERO;
-                endcase
-              end else begin
-                key_words_sel_o = KEY_WORDS_ZERO;
-              end
-            end
-
-            AES_256: begin
-              unique case (mode_i)
-                AES_ENC:   key_words_sel_o = KEY_WORDS_0123;
-                AES_DEC:   key_words_sel_o = KEY_WORDS_4567;
-                default:   key_words_sel_o = KEY_WORDS_ZERO;
-              endcase
-            end
-
-            default: key_words_sel_o = KEY_WORDS_ZERO;
-          endcase
-        end
+        key_words_sel_o = dec_key_gen_q                 ? KEY_WORDS_ZERO :
+            (key_len_i == AES_128)                      ? KEY_WORDS_0123 :
+            (key_len_i == AES_192 && mode_i == AES_ENC) ? KEY_WORDS_0123 :
+            (key_len_i == AES_192 && mode_i == AES_DEC) ? KEY_WORDS_2345 :
+            (key_len_i == AES_256 && mode_i == AES_ENC) ? KEY_WORDS_0123 :
+            (key_len_i == AES_256 && mode_i == AES_DEC) ? KEY_WORDS_4567 : KEY_WORDS_ZERO;
 
         // Make key expand advance - AES-256 has two round keys available right from beginning
         if (key_len_i != AES_256) begin
@@ -252,35 +227,12 @@ module aes_control #(
         state_we_o = ~dec_key_gen_q;
 
         // Select key words for add_round_key
-        if (dec_key_gen_q) begin
-          key_words_sel_o = KEY_WORDS_ZERO;
-        end else begin
-          unique case (key_len_i)
-            AES_128:       key_words_sel_o = KEY_WORDS_0123;
-
-            AES_192: begin
-              if (AES192Enable) begin
-                unique case (mode_i)
-                  AES_ENC: key_words_sel_o = KEY_WORDS_2345;
-                  AES_DEC: key_words_sel_o = KEY_WORDS_0123;
-                  default: key_words_sel_o = KEY_WORDS_ZERO;
-                endcase
-              end else begin
-                key_words_sel_o = KEY_WORDS_ZERO;
-              end
-            end
-
-            AES_256: begin
-              unique case (mode_i)
-                AES_ENC:   key_words_sel_o = KEY_WORDS_4567;
-                AES_DEC:   key_words_sel_o = KEY_WORDS_0123;
-                default:   key_words_sel_o = KEY_WORDS_ZERO;
-              endcase
-            end
-
-            default: key_words_sel_o = KEY_WORDS_ZERO;
-          endcase
-        end
+        key_words_sel_o = dec_key_gen_q                 ? KEY_WORDS_ZERO :
+            (key_len_i == AES_128)                      ? KEY_WORDS_0123 :
+            (key_len_i == AES_192 && mode_i == AES_ENC) ? KEY_WORDS_2345 :
+            (key_len_i == AES_192 && mode_i == AES_DEC) ? KEY_WORDS_0123 :
+            (key_len_i == AES_256 && mode_i == AES_ENC) ? KEY_WORDS_4567 :
+            (key_len_i == AES_256 && mode_i == AES_DEC) ? KEY_WORDS_0123 : KEY_WORDS_ZERO;
 
         // Make key expand advance
         key_expand_step_o = 1'b1;
@@ -309,35 +261,12 @@ module aes_control #(
         // Final round
 
         // Select key words for add_round_key
-        if (dec_key_gen_q) begin
-          key_words_sel_o = KEY_WORDS_ZERO;
-        end else begin
-          unique case (key_len_i)
-            AES_128:       key_words_sel_o = KEY_WORDS_0123;
-
-            AES_192: begin
-              if (AES192Enable) begin
-                unique case (mode_i)
-                  AES_ENC: key_words_sel_o = KEY_WORDS_2345;
-                  AES_DEC: key_words_sel_o = KEY_WORDS_0123;
-                  default: key_words_sel_o = KEY_WORDS_ZERO;
-                endcase
-              end else begin
-                key_words_sel_o = KEY_WORDS_ZERO;
-              end
-            end
-
-            AES_256: begin
-              unique case (mode_i)
-                AES_ENC:   key_words_sel_o = KEY_WORDS_4567;
-                AES_DEC:   key_words_sel_o = KEY_WORDS_0123;
-                default:   key_words_sel_o = KEY_WORDS_ZERO;
-              endcase
-            end
-
-            default: key_words_sel_o = KEY_WORDS_ZERO;
-          endcase
-        end
+        key_words_sel_o = dec_key_gen_q                 ? KEY_WORDS_ZERO :
+            (key_len_i == AES_128)                      ? KEY_WORDS_0123 :
+            (key_len_i == AES_192 && mode_i == AES_ENC) ? KEY_WORDS_2345 :
+            (key_len_i == AES_192 && mode_i == AES_DEC) ? KEY_WORDS_0123 :
+            (key_len_i == AES_256 && mode_i == AES_ENC) ? KEY_WORDS_4567 :
+            (key_len_i == AES_256 && mode_i == AES_DEC) ? KEY_WORDS_0123 : KEY_WORDS_ZERO;
 
         // Skip mix_columns
         add_rk_sel_o = ADD_RK_FINAL;

--- a/hw/ip/aes/rtl/aes_core.sv
+++ b/hw/ip/aes/rtl/aes_core.sv
@@ -283,9 +283,7 @@ module aes_core #(
   /////////////
 
   // Control
-  aes_control #(
-  .AES192Enable (AES192Enable)
-  ) aes_control (
+  aes_control aes_control (
     .clk_i                  ( clk_i                              ),
     .rst_ni                 ( rst_ni                             ),
 


### PR DESCRIPTION
This PR is based on top of #1182 .

Now that we know how to handle X assignments, I have reworked some large combinations of `if/else` and `unique case` statements and replaced them with ternary expressions that are easier to understand.