### PR TITLE
[sw] Create libbase with a README.md

### DIFF
--- a/sw/device/lib/base/README.md
+++ b/sw/device/lib/base/README.md
@@ -1,0 +1,11 @@
+# `libbase`, the OpenTitan Standard Library
+
+This subtree provides headers and libraries known collectively as `libbase`, which serve as OpenTitan's ersatz `libc`.
+
+## Differences from a `libc`
+
+`libbase` is not a `libc`, even though it implements a number of `libc` symbols, and should not be used as such.
+`libbase` is, rather, a place for base libraries which may need to make use of more compiler/platform intrinsics than average, in order to present a safe, stable, and uesful interface that other parts of OpenTitan can rely on.
+
+In general, a library exposing general utilities for working close to the hardware should live in this subtree: for example, a library providing `memcpy` and related symbols.
+A library for talking to a particular peripheral, like a UART port, is a non-example.


### PR DESCRIPTION
A number of other commits add files to sw/device/lib/base, and discussion around them indicates to a consensus that this directory should house all of our "libc-like" stuff. This commit "officially" creates the directory and gives it a README to codify this consensus.