### PR TITLE
[sw] Move the definition of |asm| into its own header.

### DIFF
--- a/sw/device/lib/base/stdasm.h
+++ b/sw/device/lib/base/stdasm.h
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef SW_DEVICE_LIB_BASE_STDASM_H_
+#define SW_DEVICE_LIB_BASE_STDASM_H_
+
+/**
+ * This header simply provides the |asm| keyword, in analogy with the ISO C
+ * headers |stdbool.h|, |stdnoreturn.h|, and so on.
+ */
+
+#define asm __asm__
+
+#endif  // SW_DEVICE_LIB_BASE_STDASM_H_

--- a/sw/device/lib/common.h
+++ b/sw/device/lib/common.h
@@ -9,6 +9,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "sw/device/lib/base/stdasm.h"
+
 #ifdef SIMULATION
 #define CLK_FIXED_FREQ_HZ (500 * 1000)
 static const unsigned long UART_BAUD_RATE = 9600;
@@ -41,8 +43,6 @@ static const unsigned long UART_BAUD_RATE = 230400;
 #define BITLENGTH_5(X) ((X) + ((X) >> 16))
 #define BITLENGTH(X) \
   ((BITLENGTH_5(BITLENGTH_4(BITLENGTH_3(BITLENGTH_2(BITLENGTH_1(X)))))) & 0x7f)
-
-#define asm __asm__
 
 void *memcpy(void *restrict dest, const void *restrict src, size_t n);
 void *memset(void *dest, int val, size_t n);


### PR DESCRIPTION
As part of the contiuing battle to clean up `common.h`, this commit gives the `asm` keyword a libc-like "keyword header", like `stdbool.h`.

I also have the following, more radical idea. Since we control the definition of `asm`, it may be worthwile to instead provide the following definitions:
```c
#define asm __asm__ volatile
#define asm_pure __asm__
```

This is the model that Rust seems to be moving towards in its inline assembly syntax: side-effecting assembly (which includes anything that touches anything that isn't a RISC-V register) represents 99% of use-cases, while pure assembly (which, for most purposes, means "can be hoisted out of a loop") is extremely rare.

I think that volatile is the sane default, and, unless it's an onerous change for existing C programmers, should probably be our sane default. I'd especially like @asb and @lenary to comment on this idea.