### PR TITLE
Fix markdown syntax for heading

### DIFF
--- a/doc/rm/c_cpp_coding_style.md
+++ b/doc/rm/c_cpp_coding_style.md
@@ -143,7 +143,7 @@ The [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) 
 Consequently, C++-specific rules don't apply.
 In addition to the shared C and C++ style guide rules outlined before, the following C-specific rules apply.
 
-### C Version
+### C Version
 
 ***C code should target C11.***
 


### PR DESCRIPTION
The heading "C Version" renders incorrectly because the character after last # is not space. This change fixes that.


Signed-off-by: Alphan Ulusoy <alphan@google.com>