### PR TITLE
[hmac] Case to Unique and default

### DIFF
--- a/hw/ip/hmac/rtl/hmac.sv
+++ b/hw/ip/hmac/rtl/hmac.sv
@@ -449,7 +449,7 @@ module hmac
 
   always_comb begin
     err_code = NoError;
-    case (1'b1)
+    unique case (1'b1)
       msg_push_sha_disabled: begin
         err_code = SwPushMsgWhenShaDisabled;
       end

--- a/hw/ip/prim/rtl/prim_packer.sv
+++ b/hw/ip/prim/rtl/prim_packer.sv
@@ -133,9 +133,9 @@ module prim_packer #(
   always_comb begin
     flush_st_next = FlushIdle;
 
-    flush_ready = 0;
+    flush_ready = 1'b0;
 
-    case (flush_st)
+    unique case (flush_st)
       FlushIdle: begin
         if (flush_i && !ready_i) begin
           // Wait until hold released
@@ -165,6 +165,12 @@ module prim_packer #(
 
           flush_ready = 1'b0;
         end
+      end
+
+      default: begin
+        flush_st_next = FlushIdle;
+
+        flush_ready = 1'b0;
       end
     endcase
   end


### PR DESCRIPTION
The style guide is updated to mandate `unique case` with exceptions.
Also, the case is recommended to have `default` statement regardless of
whether the condition inside the case statement is full or not.

HMAC/ PrimPacker modules are updated to have them in place.