### PR TITLE
Update the hello_world FPGA compile and download instructions

### DIFF
--- a/doc/ug/getting_started_fpga.md
+++ b/doc/ug/getting_started_fpga.md
@@ -70,6 +70,15 @@ $ cd $REPO_TOP
 $ fusesoc --cores-root . pgm lowrisc:systems:top_earlgrey_nexysvideo:0.1
 ```
 
+This should produce a message like this from the UART:
+
+```
+Version:    opentitan-snapshot-20191101-1-366-gca61d28
+Build Date: 2019-12-13, 13:15:48
+Bootstrap requested, initialising HW...
+HW initialisation completed, waiting for SPI input...
+```
+
 Note: `fusesoc pgm` is broken for edalize versions up to (and including) v0.1.3.
 You can check the version you're using with `pip3 show edalize`.
 If you have having trouble with programming using the command line, try the GUI.
@@ -97,7 +106,7 @@ Now the Vivado GUI opens and loads the project.
 
 The `hello_world` demo software shows off some capabilities of the design.
 In order to load `hello_world` into the FPGA, both the binary and the [loading tool]({{< relref "/sw/host/spiflash/README.md" >}}) must be compiled.
-Please follow the steps below.
+Please follow the steps shown below.
 
 * Generate the bitstream and flash it to the FPGA as described above.
 * Open a serial console (use the device file determined before) and connect.
@@ -114,20 +123,44 @@ Please follow the steps below.
   ```console
   $ cd ${REPO_TOP}
   $ ./meson_init.sh
-  $ ninja -C build-out/sw/fpga sw/device/examples/hello_world_export
+  $ ninja -C build-out/sw/fpga sw/device/examples/hello_world/hello_world_export
   $ ninja -C build-out/sw/fpga sw/host/spiflash/spiflash_export
   $ build-bin/sw/host/spiflash/spiflash \
       --input build-bin/sw/device/fpga/examples/hello_world/hello_world.bin
-
-  Running SPI flash update.
-  Image divided into 6 frames.
-  frame: 0x00000000 to offset: 0x00000000
-  frame: 0x00000001 to offset: 0x000003d8
-  frame: 0x00000002 to offset: 0x000007b0
-  frame: 0x00000003 to offset: 0x00000b88
-  frame: 0x00000004 to offset: 0x00000f60
-  frame: 0x80000005 to offset: 0x00001338
   ```
+
+  which should report how the binary is split into frames:
+
+  ```
+   Running SPI flash update.
+   Image divided into 6 frames.
+   frame: 0x00000000 to offset: 0x00000000
+   frame: 0x00000001 to offset: 0x000003d8
+   frame: 0x00000002 to offset: 0x000007b0
+   frame: 0x00000003 to offset: 0x00000b88
+   frame: 0x00000004 to offset: 0x00000f60
+   frame: 0x80000005 to offset: 0x00001338
+   ```
+
+  and then output like this should appear from the UART:
+  ```
+  Processing frame no: 00000000 exp no: 00000000
+  Processing frame no: 00000001 exp no: 00000001
+  Processing frame no: 00000002 exp no: 00000002
+  Processing frame no: 00000003 exp no: 00000003
+  Processing frame no: 00000004 exp no: 00000004
+  Processing frame no: 80000005 exp no: 00000005
+  bootstrap: DONE!
+  INFO: Boot ROM initialisation has completed, jump into flash!
+  Hello World! Dec 13 2019 15:06:29
+  Watch the LEDs!
+  Try out the switches on the board
+  or type anything into the console window.
+  The LEDs show the ASCII code of the last character.
+  GPIO: Switch 7 changed to 1
+  FTDI control changed. Enable JTAG
+  ```
+
 * Observe the output both on the board and the serial console. Type any text into the console window.
 * Exit `screen` by pressing CTRL-a k, and confirm with y.
 


### PR DESCRIPTION
I think the compile and download instructions for the `hello_world` FPGA example are still lagging behind some of the other changes from recent commits. I think these steps should work.