### PR TITLE
[dv] Fix csr seq and adaptor

### DIFF
--- a/hw/dv/sv/csr_utils/csr_seq_lib.sv
+++ b/hw/dv/sv/csr_utils/csr_seq_lib.sv
@@ -260,11 +260,11 @@ class csr_rw_seq extends csr_base_seq;
         test_csrs[i].get_fields(test_fields);
         test_fields.shuffle();
         foreach (test_fields[j]) begin
+          bit compare = !m_csr_excl_item.is_excl(test_fields[j], CsrExclWriteCheck);
           csr_rd_check(.ptr           (test_fields[j]),
                        .blocking      (0),
-                       .compare       (!external_checker),
-                       .compare_vs_ral(1'b1),
-                       .compare_mask  (compare_mask));
+                       .compare       (!external_checker && compare),
+                       .compare_vs_ral(1'b1));
         end
       end
     end

--- a/hw/dv/sv/tl_agent/tl_reg_adapter.sv
+++ b/hw/dv/sv/tl_agent/tl_reg_adapter.sv
@@ -47,8 +47,14 @@ class tl_reg_adapter #(type ITEM_T = tl_seq_item) extends uvm_reg_adapter;
       uvm_reg_item item    = get_item();
       uvm_reg_map  loc_map = item.local_map;
       uvm_reg      rg      = loc_map.get_reg_by_offset(rw.addr);
-      `DV_CHECK_FATAL($cast(csr, rg))
-      msb = csr.get_msb_pos();
+      if (rg != null) begin // csr address
+        `DV_CHECK_FATAL($cast(csr, rg))
+        msb = csr.get_msb_pos();
+      end else if (loc_map.get_mem_by_offset(rw.addr) != null) begin // memory address
+        msb = TL_DW - 1;
+      end else begin
+        `uvm_fatal(`gfn, $sformatf("unexpected address 0x%0h", rw.addr))
+      end
       `DV_CHECK_RANDOMIZE_WITH_FATAL(reg_item,
           a_opcode inside {PutFullData, PutPartialData};
           a_addr    == rw.addr;


### PR DESCRIPTION
1. Fix null object error at mem address in reg_adaptor
2. Fix csr exclusion issue in csr_rw_seq

Signed-off-by: Weicai Yang <weicai@google.com>