### PR TITLE
[fifo_sync/fpv] Make bind files unique and explicitly override params

### DIFF
--- a/hw/ip/prim/fpv/tb/prim_fifo_sync_bind_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_fifo_sync_bind_fpv.sv
@@ -5,6 +5,8 @@
 
 module prim_fifo_sync_bind_fpv;
 
+  localparam int unsigned Width = 4;
+
   // need to instantiate by hand since bind statements inside
   // generate blocks are currently not supported
 
@@ -13,9 +15,11 @@ module prim_fifo_sync_bind_fpv;
   ////////////////////
 
   bind i_nopass1 prim_fifo_sync_assert_fpv #(
+    .Width(Width),
     .Pass(1'b0),
-    .Depth(1)
-  ) i_prim_fifo_sync_assert_fpv (
+    .Depth(1),
+    .EnableDataCheck(1'b1)
+  ) i_nopass1_assert_fpv (
     .clk_i,
     .rst_ni,
     .clr_i,
@@ -29,9 +33,11 @@ module prim_fifo_sync_bind_fpv;
   );
 
   bind i_nopass7 prim_fifo_sync_assert_fpv #(
+    .Width(Width),
     .Pass(1'b0),
-    .Depth(7)
-  ) i_prim_fifo_sync_assert_fpv (
+    .Depth(7),
+    .EnableDataCheck(1'b1)
+  ) i_nopass7_assert_fpv (
     .clk_i,
     .rst_ni,
     .clr_i,
@@ -45,9 +51,11 @@ module prim_fifo_sync_bind_fpv;
   );
 
   bind i_nopass8 prim_fifo_sync_assert_fpv #(
+    .Width(Width),
     .Pass(1'b0),
-    .Depth(8)
-  ) i_prim_fifo_sync_assert_fpv (
+    .Depth(8),
+    .EnableDataCheck(1'b1)
+  ) i_nopass8_assert_fpv (
     .clk_i,
     .rst_ni,
     .clr_i,
@@ -61,10 +69,11 @@ module prim_fifo_sync_bind_fpv;
   );
 
   bind i_nopass15 prim_fifo_sync_assert_fpv #(
-    .EnableDataCheck(1'b0),
+    .Width(Width),
     .Pass(1'b0),
-    .Depth(15)
-  ) i_prim_fifo_sync_assert_fpv (
+    .Depth(15),
+    .EnableDataCheck(1'b0)
+  ) i_nopass15_assert_fpv (
     .clk_i,
     .rst_ni,
     .clr_i,
@@ -78,10 +87,11 @@ module prim_fifo_sync_bind_fpv;
   );
 
   bind i_nopass16 prim_fifo_sync_assert_fpv #(
-    .EnableDataCheck(1'b0),
+    .Width(Width),
     .Pass(1'b0),
-    .Depth(16)
-  ) i_prim_fifo_sync_assert_fpv (
+    .Depth(16),
+    .EnableDataCheck(1'b0)
+  ) i_nopass16_assert_fpv (
     .clk_i,
     .rst_ni,
     .clr_i,
@@ -99,8 +109,11 @@ module prim_fifo_sync_bind_fpv;
   ////////////////
 
   bind i_pass0 prim_fifo_sync_assert_fpv #(
-    .Depth(0)
-  ) i_prim_fifo_sync_assert_fpv (
+    .Width(Width),
+    .Pass(1'b1),
+    .Depth(0),
+    .EnableDataCheck(1'b1)
+  ) i_pass0_assert_fpv (
     .clk_i,
     .rst_ni,
     .clr_i,
@@ -114,8 +127,11 @@ module prim_fifo_sync_bind_fpv;
   );
 
   bind i_pass1 prim_fifo_sync_assert_fpv #(
-    .Depth(1)
-  ) i_prim_fifo_sync_assert_fpv (
+    .Width(Width),
+    .Pass(1'b1),
+    .Depth(1),
+    .EnableDataCheck(1'b1)
+  ) i_pass1_assert_fpv (
     .clk_i,
     .rst_ni,
     .clr_i,
@@ -129,8 +145,11 @@ module prim_fifo_sync_bind_fpv;
   );
 
   bind i_pass7 prim_fifo_sync_assert_fpv #(
-    .Depth(7)
-  ) i_prim_fifo_sync_assert_fpv (
+    .Width(Width),
+    .Pass(1'b1),
+    .Depth(7),
+    .EnableDataCheck(1'b1)
+  ) i_pass7_assert_fpv (
     .clk_i,
     .rst_ni,
     .clr_i,
@@ -144,8 +163,11 @@ module prim_fifo_sync_bind_fpv;
   );
 
   bind i_pass8 prim_fifo_sync_assert_fpv #(
-    .Depth(8)
-  ) i_prim_fifo_sync_assert_fpv (
+    .Width(Width),
+    .Pass(1'b1),
+    .Depth(8),
+    .EnableDataCheck(1'b1)
+  ) i_pass8_assert_fpv (
     .clk_i,
     .rst_ni,
     .clr_i,
@@ -159,9 +181,11 @@ module prim_fifo_sync_bind_fpv;
   );
 
   bind i_pass15 prim_fifo_sync_assert_fpv #(
-    .EnableDataCheck(1'b0),
-    .Depth(15)
-  ) i_prim_fifo_sync_assert_fpv (
+    .Width(Width),
+    .Pass(1'b1),
+    .Depth(15),
+    .EnableDataCheck(1'b0)
+  ) i_pass15_assert_fpv (
     .clk_i,
     .rst_ni,
     .clr_i,
@@ -175,9 +199,11 @@ module prim_fifo_sync_bind_fpv;
   );
 
   bind i_pass16 prim_fifo_sync_assert_fpv #(
-    .EnableDataCheck(1'b0),
-    .Depth(16)
-  ) i_prim_fifo_sync_assert_fpv (
+    .Width(Width),
+    .Pass(1'b1),
+    .Depth(16),
+    .EnableDataCheck(1'b0)
+  ) i_pass16_assert_fpv (
     .clk_i,
     .rst_ni,
     .clr_i,

--- a/hw/ip/prim/fpv/tb/prim_fifo_sync_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_fifo_sync_fpv.sv
@@ -18,7 +18,7 @@ module prim_fifo_sync_fpv #(
   // number of DUTs instantiated in this FPV testbench
   parameter int unsigned NumDuts = 11,
   // fifo params
-  parameter int unsigned Width = 16,
+  parameter int unsigned Width = 4,
   parameter int unsigned MaxDepth = 16, // max depth used in this destbench
   localparam int unsigned DepthW = ($clog2(MaxDepth+1) == 0) ? 1 : $clog2(MaxDepth+1)
 ) (
@@ -133,6 +133,7 @@ module prim_fifo_sync_fpv #(
   // depth-zero is per definition a pass-through FIFO
   prim_fifo_sync #(
     .Width(Width),
+    .Pass(1'b1),
     .Depth(0)
   ) i_pass0 (
     .clk_i,
@@ -149,6 +150,7 @@ module prim_fifo_sync_fpv #(
 
   prim_fifo_sync #(
     .Width(Width),
+    .Pass(1'b1),
     .Depth(1)
   ) i_pass1 (
     .clk_i,
@@ -165,6 +167,7 @@ module prim_fifo_sync_fpv #(
 
   prim_fifo_sync #(
     .Width(Width),
+    .Pass(1'b1),
     .Depth(7)
   ) i_pass7 (
     .clk_i,
@@ -181,6 +184,7 @@ module prim_fifo_sync_fpv #(
 
   prim_fifo_sync #(
     .Width(Width),
+    .Pass(1'b1),
     .Depth(8)
   ) i_pass8 (
     .clk_i,
@@ -197,6 +201,7 @@ module prim_fifo_sync_fpv #(
 
   prim_fifo_sync #(
     .Width(Width),
+    .Pass(1'b1),
     .Depth(15)
   ) i_pass15 (
     .clk_i,
@@ -213,6 +218,7 @@ module prim_fifo_sync_fpv #(
 
   prim_fifo_sync #(
     .Width(Width),
+    .Pass(1'b1),
     .Depth(16)
   ) i_pass16 (
     .clk_i,


### PR DESCRIPTION
This amends #1165. I also reduced the FIFO width to 4 bits in order to speed up the proofs.

Signed-off-by: Michael Schaffner <msf@opentitan.org>