### PR TITLE
[meson] Ensure we don't include a build-id in the ROM

### DIFF
--- a/sw/device/boot_rom/meson.build
+++ b/sw/device/boot_rom/meson.build
@@ -18,7 +18,7 @@ chip_info_h = declare_dependency(
 
 # ROM linker parameters.
 rom_linkfile = files(['rom_link.ld'])
-rom_link_args = ['-Wl,-T,@0@/@1@'.format(meson.source_root(), rom_linkfile[0])]
+rom_link_args = ['-Wl,-T,@0@/@1@'.format(meson.source_root(), rom_linkfile[0]), '-Wl,--build-id=none']
 rom_link_deps = [rom_linkfile]
 
 boot_rom_elf = executable(


### PR DESCRIPTION
This is a followup patch from 5e2c8db45819acaa4f1c3b01cd958abd7e13b26a
which ensured we don't see a build-id in the SW binaries. This patche
ensures it doesn't make it into the ROM binary.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>