### PR TITLE
[synthesis] Preparations for ASIC synthesis flow using DC

### DIFF
--- a/hw/ip/prim/abstract/prim_clock_gating.sv
+++ b/hw/ip/prim/abstract/prim_clock_gating.sv
@@ -34,6 +34,13 @@ module prim_clock_gating #(
       .test_en_i,
       .clk_o
     );
+  end else if (Impl == ImplAsic) begin : gen_asic
+    prim_asic_clock_gating u_impl_asic (
+      .clk_i,
+      .en_i,
+      .test_en_i,
+      .clk_o
+    );
   end else begin : gen_failure
     // TODO: Find code that works across tools and causes a compile failure
   end

--- a/hw/ip/prim/abstract/prim_clock_mux2.sv
+++ b/hw/ip/prim/abstract/prim_clock_mux2.sv
@@ -34,6 +34,13 @@ module prim_clock_mux2 #(
       .sel_i,
       .clk_o
     );
+  end else if (Impl == ImplAsic) begin : gen_asic
+    prim_asic_clock_mux2 u_impl_asic (
+      .clk0_i,
+      .clk1_i,
+      .sel_i,
+      .clk_o
+    );
   end else begin : gen_failure
     // TODO: Find code that works across tools and causes a compile failure
   end

--- a/hw/ip/prim/abstract/prim_flash.sv
+++ b/hw/ip/prim/abstract/prim_flash.sv
@@ -68,6 +68,31 @@ module prim_flash #(
       .rd_data_o,
       .init_busy_o
     );
+  end else if (Impl == ImplAsic) begin : gen_asic
+    prim_asic_flash #(
+      .PagesPerBank(PagesPerBank),
+      .WordsPerPage(WordsPerPage),
+      .DataWidth(DataWidth)
+    ) u_impl_asic (
+      .clk_i,
+      .rst_ni,
+      .req_i,
+      .host_req_i,
+      .host_addr_i,
+      .rd_i,
+      .prog_i,
+      .pg_erase_i,
+      .bk_erase_i,
+      .addr_i,
+      .prog_data_i,
+      .host_req_rdy_o,
+      .host_req_done_o,
+      .rd_done_o,
+      .prog_done_o,
+      .erase_done_o,
+      .rd_data_o,
+      .init_busy_o
+    );
   end else begin : gen_failure
     // TODO: Find code that works across tools and causes a compile failure
   end

--- a/hw/ip/prim/abstract/prim_pad_wrapper.sv
+++ b/hw/ip/prim/abstract/prim_pad_wrapper.sv
@@ -45,6 +45,16 @@ module prim_pad_wrapper #(
       .oe_i,
       .attr_i
     );
+  end else if (Impl == ImplAsic) begin : gen_pad_asic
+    prim_asic_pad_wrapper #(
+      .AttrDw(AttrDw)
+    ) i_pad_wrapper (
+      .inout_io,
+      .in_o,
+      .out_i,
+      .oe_i,
+      .attr_i
+    );
   end else begin : gen_failure
     // TODO: Find code that works across tools and causes a compile failure
   end

--- a/hw/ip/prim/abstract/prim_ram_1p.sv
+++ b/hw/ip/prim/abstract/prim_ram_1p.sv
@@ -47,6 +47,21 @@ module prim_ram_1p #(
       .rvalid_o,
       .rdata_o
     );
+   end else if (Impl == ImplAsic) begin : gen_mem_asic
+    prim_asic_ram_1p #(
+      .Width(Width),
+      .Depth(Depth)
+    ) u_impl_asic (
+      .clk_i,
+      .rst_ni,
+      .req_i,
+      .write_i,
+      .addr_i,
+      .wdata_i,
+      .wmask_i,
+      .rvalid_o,
+      .rdata_o
+    );
   end else begin : gen_failure
     // TODO: Find code that works across tools and causes a compile failure
   end

--- a/hw/ip/prim/abstract/prim_ram_2p.sv
+++ b/hw/ip/prim/abstract/prim_ram_2p.sv
@@ -72,6 +72,26 @@ module prim_ram_2p #(
       .b_wdata_i,
       .b_rdata_o
     );
+  end else if (Impl == ImplAsic) begin : gen_mem_asic
+    prim_asic_ram_2p #(
+      .Width(Width),
+      .Depth(Depth)
+    ) u_impl_asic (
+      .clk_a_i,
+      .clk_b_i,
+      .a_req_i,
+      .a_write_i,
+      .a_addr_i,
+      .a_wdata_i,
+      .a_wmask_i({Width{1'b1}}),
+      .a_rdata_o,
+      .b_req_i,
+      .b_write_i,
+      .b_addr_i,
+      .b_wdata_i,
+      .b_wmask_i({Width{1'b1}}),
+      .b_rdata_o
+    );
   end else begin : gen_failure
     // TODO: Find code that works across tools and causes a compile failure
   end

--- a/hw/ip/prim/abstract/prim_rom.sv
+++ b/hw/ip/prim/abstract/prim_rom.sv
@@ -47,6 +47,17 @@ module prim_rom #(
       .dout_o,
       .dvalid_o
     );
+  end else if (Impl == ImplAsic) begin: gen_rom_asic
+    prim_asic_rom #(
+      .Width(Width),
+      .Depth(Depth)
+    ) u_impl_asic (
+      .clk_i,
+      .addr_i,
+      .cs_i,
+      .dout_o,
+      .dvalid_o
+    );
   end else begin : gen_rom_unsupported_impl
     // TODO: Find code that works across tools and causes a compile failure
   end

--- a/hw/ip/prim/rtl/prim_pkg.sv
+++ b/hw/ip/prim/rtl/prim_pkg.sv
@@ -9,7 +9,8 @@ package prim_pkg;
   // Implementation target specialization
   typedef enum integer {
     ImplGeneric = 0,
-    ImplXilinx  = 1
+    ImplXilinx  = 1,
+    ImplAsic    = 2
   } impl_e;
 
   // interface structs for prim_alert_* and prim_esc_*

--- a/hw/top_earlgrey/top_earlgrey.core
+++ b/hw/top_earlgrey/top_earlgrey.core
@@ -46,6 +46,12 @@ filesets:
       - rtl/padctl.sv
       - rtl/autogen/top_earlgrey.sv
     file_type: systemVerilogSource
+  files_rtl_asic:
+    depend:
+      # need to include technology-specific prim wrappers
+      - lowrisc:prim_asic:all
+    files:
+    file_type: systemVerilogSource
 
   files_verilator_waiver:
     depend:
@@ -95,7 +101,6 @@ targets:
     parameters:
       - PRIM_DEFAULT_IMPL=prim_pkg::ImplGeneric
     toplevel: top_earlgrey
-
   lint:
     <<: *default_target
     default_tool: verilator
@@ -106,3 +111,14 @@ targets:
         mode: lint-only
         verilator_options:
           - "-Wall"
+  asic-synth:
+    # TODO switch to DC once supported by Edalize
+    # olofk/edalize#89
+    default_tool: icarus
+    filesets:
+      - files_rtl_generic
+      - files_rtl_asic
+    parameters:
+      - SYNTHESIS=True
+      - PRIM_DEFAULT_IMPL=prim_pkg::ImplAsic
+    toplevel: top_earlgrey


### PR DESCRIPTION
This PR introduces a couple of preparatory changes to introduce a Synopsys DC based synthesis flow in an upcoming PR. In particular:
- The `common.core` imported an interface to be used in DV only, and DC doesn't like it. Hence this has been moved to the corresponding DV core where it is actually needed.
- Add the `ImplAsic` option to all tech-dependent macro wrappers.
- Add the `ASIC_SYNTHESIS` ifdef around some of the assertions to make this pass in DC. This requires a slight change in the FPV flow (basically not defining the `SYNTHESIS` related macros).
- Replace some invocations of `$fatal` with assertions.
- Add the ASIC synthesis target to `top_earlgrey.core`
