### PR TITLE
[dv] Use macro UVM to distinguash UVM TB and the other environments

### DIFF
--- a/hw/dv/sv/sw_msg_monitor_if/sw_msg_monitor_if.sv
+++ b/hw/dv/sv/sw_msg_monitor_if/sw_msg_monitor_if.sv
@@ -410,7 +410,7 @@ interface sw_msg_monitor_if #(
                                     string verbosity = "n",
                                     string msg_header = "",
                                     string msg);
-`ifdef UVM_PKG_SV
+`ifdef UVM
     import uvm_pkg::*;
     `include "uvm_macros.svh"
 

--- a/hw/dv/tools/modes.mk
+++ b/hw/dv/tools/modes.mk
@@ -9,6 +9,8 @@
 ## Please add tool specific options with appropriate ifeq's                                       ##
 ####################################################################################################
 
+# Distinguish UVM TB and the other environments for Verilator, FPGA etc
+BUILD_OPTS  += +define+UVM
 # uvm specific - set default widths
 BUILD_OPTS  += +define+UVM_NO_DEPRECATED
 BUILD_OPTS  += +define+UVM_REGEX_NO_DPI

--- a/hw/ip/prim/rtl/prim_assert.sv
+++ b/hw/ip/prim/rtl/prim_assert.sv
@@ -12,7 +12,7 @@
 //  - can we remove pragma translate_off and ifndef VERILATOR?
 //  - should we add "pragma coverage off" and "VCS coverage off"?
 
-`ifdef UVM_PKG_SV
+`ifdef UVM
   // report assertion error with UVM if compiled
   package assert_rpt_pkg;
     import uvm_pkg::*;
@@ -34,7 +34,7 @@
 
   // ASSERT_RPT is available to change the reporting mechanism when an assert fails
 `define ASSERT_RPT(__name, __msg)                                         \
-`ifdef UVM_PKG_SV                                                         \
+`ifdef UVM                                                                \
   assert_rpt_pkg::assert_rpt($sformatf("[%m] %s: %s (%s:%0d)",            \
                              __name, __msg, `__FILE__, `__LINE__));       \
 `else                                                                     \


### PR DESCRIPTION
Xcelium doesn't compile UVM at the beginning. UVM_PKG_SV macro isn't set
before compile prim_assert. Hence, assert error isn't reported as
uvm_error. Use +define+UVM to solve this issue

Signed-off-by: Weicai Yang <weicai@google.com>