### PR TITLE
[dv:xcelium] Added xprop for xcelium

### DIFF
--- a/hw/dv/tools/xcelium/xcelium.mk
+++ b/hw/dv/tools/xcelium/xcelium.mk
@@ -27,6 +27,9 @@ BUILD_OPTS  += -timescale 1ns/1ps
 BUILD_OPTS  += -uvmhome ${UVM_HOME}
 BUILD_OPTS  += -xmlibdirname ${SV_FLIST_GEN_DIR}/xcelium.d
 BUILD_OPTS  += -f ${SV_FLIST}
+BUILD_OPTS  += -64bit
+BUILD_OPTS  += -xprop F # -xverbose  << add to see which modules does not have xprop enabled
+
 
 # set standard run options
 RUN_OPTS    += -input ${SIM_SETUP}
@@ -36,6 +39,8 @@ RUN_OPTS    += +UVM_TESTNAME=${UVM_TEST}
 RUN_OPTS    += +UVM_TEST_SEQ=${UVM_TEST_SEQ}
 RUN_OPTS    += -l ${RUN_LOG}
 RUN_OPTS    += -xmlibdirname ${SV_FLIST_GEN_DIR}/xcelium.d -R
+RUN_OPTS    += -64bit
+
 
 #########################
 ## Tool Specific Modes ##


### PR DESCRIPTION
I have added to new options to xcelium make file
the main -xprop F
enables x-progation as per https://github.com/lowRISC/opentitan/issues/1234

I have tested with the following code based on example in cadence xprop manual
`  // test code for xprop //
  logic a, b,c, q;
  
  initial begin
    a= 0;
    b= 1;
  end
  

  always@(posedge clk_i) begin
    if(c) begin
      q <= a;
    end else begin
      q <= b;
    end
  end`

it Works
I went with forward propagate x (FOX) mode

the difference between that and CAT mode can be seen here.
![image](https://user-images.githubusercontent.com/53917183/71259449-c21c5980-2338-11ea-80ee-a75e167e1578.png)

in xcelium.mk I also left the option -xverbosity commented out for future debugging use.
by commenting that in xcelium generates an xprop log. in

> /scratch/<ip>/default/build/lowrisc_dv_<ip>_sim_0.1/sim-vcs/

this can be used to see which modules does not have xpropagation enabled - there are  a bunch but they are all DV.
for future work we could switch to -xfile instead of xprop
that takes a configuration file. this will enable us to add RTL only Xprop.

the second parameter added is 64bit option for xcelium
I need that to get the correct SSL libraries. and I just think it is better to run in 64bit mode also.



