### PR TITLE
[tlgen] Unify Address Range for Device ports

### DIFF
--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -673,8 +673,13 @@
           reset: rst_main_ni
           pipeline: "false"
           inst_type: rom
-          base_addr: 0x00008000
-          size_byte: 0x2000
+          addr_range:
+          [
+            {
+              base_addr: 0x00008000
+              size_byte: 0x2000
+            }
+          ]
           xbar: false
           pipeline_byp: "true"
         }
@@ -685,8 +690,13 @@
           reset: rst_main_ni
           pipeline_byp: "false"
           inst_type: rv_dm
-          base_addr: 0x1A110000
-          size_byte: 0x1000
+          addr_range:
+          [
+            {
+              base_addr: 0x1A110000
+              size_byte: 0x1000
+            }
+          ]
           xbar: false
           pipeline: "true"
         }
@@ -697,8 +707,13 @@
           reset: rst_main_ni
           pipeline: "false"
           inst_type: ram_1p
-          base_addr: 0x10000000
-          size_byte: 0x10000
+          addr_range:
+          [
+            {
+              base_addr: 0x10000000
+              size_byte: 0x10000
+            }
+          ]
           xbar: false
           pipeline_byp: "true"
         }
@@ -709,8 +724,13 @@
           reset: rst_main_ni
           pipeline: "false"
           inst_type: eflash
-          base_addr: 0x20000000
-          size_byte: 0x80000
+          addr_range:
+          [
+            {
+              base_addr: 0x20000000
+              size_byte: 0x80000
+            }
+          ]
           xbar: false
           pipeline_byp: "true"
         }
@@ -722,7 +742,7 @@
           pipeline_byp: "false"
           xbar: true
           pipeline: "true"
-          xbar_addr:
+          addr_range:
           [
             {
               base_addr: 0x40000000
@@ -741,8 +761,13 @@
           reset: rst_main_ni
           pipeline_byp: "false"
           inst_type: flash_ctrl
-          base_addr: 0x40030000
-          size_byte: 0x1000
+          addr_range:
+          [
+            {
+              base_addr: 0x40030000
+              size_byte: 0x1000
+            }
+          ]
           xbar: false
           pipeline: "true"
         }
@@ -753,8 +778,13 @@
           reset: rst_main_ni
           pipeline_byp: "false"
           inst_type: hmac
-          base_addr: 0x40120000
-          size_byte: 0x1000
+          addr_range:
+          [
+            {
+              base_addr: 0x40120000
+              size_byte: 0x1000
+            }
+          ]
           xbar: false
           pipeline: "true"
         }
@@ -765,8 +795,13 @@
           reset: rst_main_ni
           pipeline_byp: "false"
           inst_type: aes
-          base_addr: 0x40110000
-          size_byte: 0x1000
+          addr_range:
+          [
+            {
+              base_addr: 0x40110000
+              size_byte: 0x1000
+            }
+          ]
           xbar: false
           pipeline: "true"
         }
@@ -776,8 +811,13 @@
           clock: clk_main_i
           reset: rst_main_ni
           inst_type: rv_plic
-          base_addr: 0x40090000
-          size_byte: 0x1000
+          addr_range:
+          [
+            {
+              base_addr: 0x40090000
+              size_byte: 0x1000
+            }
+          ]
           pipeline_byp: "false"
           xbar: false
           pipeline: "true"
@@ -788,8 +828,13 @@
           clock: clk_main_i
           reset: rst_fixed_ni
           inst_type: pinmux
-          base_addr: 0x40070000
-          size_byte: 0x1000
+          addr_range:
+          [
+            {
+              base_addr: 0x40070000
+              size_byte: 0x1000
+            }
+          ]
           pipeline_byp: "false"
           xbar: false
           pipeline: "true"
@@ -800,8 +845,13 @@
           clock: clk_main_i
           inst_type: alert_handler
           pipeline_byp: "false"
-          base_addr: 0x40130000
-          size_byte: 0x1000
+          addr_range:
+          [
+            {
+              base_addr: 0x40130000
+              size_byte: 0x1000
+            }
+          ]
           xbar: false
           pipeline: "true"
         }
@@ -811,8 +861,13 @@
           clock: clk_main_i
           inst_type: nmi_gen
           pipeline_byp: "false"
-          base_addr: 0x40140000
-          size_byte: 0x1000
+          addr_range:
+          [
+            {
+              base_addr: 0x40140000
+              size_byte: 0x1000
+            }
+          ]
           xbar: false
           pipeline: "true"
         }
@@ -859,8 +914,13 @@
           reset: rst_peri_ni
           pipeline: "false"
           inst_type: uart
-          base_addr: 0x40000000
-          size_byte: 0x1000
+          addr_range:
+          [
+            {
+              base_addr: 0x40000000
+              size_byte: 0x1000
+            }
+          ]
           xbar: false
           pipeline_byp: "true"
         }
@@ -871,8 +931,13 @@
           reset: rst_peri_ni
           pipeline: "false"
           inst_type: gpio
-          base_addr: 0x40010000
-          size_byte: 0x1000
+          addr_range:
+          [
+            {
+              base_addr: 0x40010000
+              size_byte: 0x1000
+            }
+          ]
           xbar: false
           pipeline_byp: "true"
         }
@@ -883,8 +948,13 @@
           reset: rst_peri_ni
           pipeline: "false"
           inst_type: spi_device
-          base_addr: 0x40020000
-          size_byte: 0x1000
+          addr_range:
+          [
+            {
+              base_addr: 0x40020000
+              size_byte: 0x1000
+            }
+          ]
           xbar: false
           pipeline_byp: "true"
         }
@@ -895,8 +965,13 @@
           reset: rst_peri_ni
           pipeline: "false"
           inst_type: rv_timer
-          base_addr: 0x40080000
-          size_byte: 0x1000
+          addr_range:
+          [
+            {
+              base_addr: 0x40080000
+              size_byte: 0x1000
+            }
+          ]
           xbar: false
           pipeline_byp: "true"
         }

--- a/hw/top_earlgrey/data/xbar_main.hjson
+++ b/hw/top_earlgrey/data/xbar_main.hjson
@@ -80,8 +80,10 @@
       clock:     "clk_main_i",
       reset:     "rst_main_ni",
       inst_type: "rv_plic",
-      base_addr: "0x40090000",
-      size_byte: "0x1000",
+      addr_range: [{
+        base_addr: "0x40090000",
+        size_byte: "0x1000",
+        }],
       pipeline_byp: "false"
     },
     { name:      "pinmux",
@@ -89,8 +91,10 @@
       clock:     "clk_main_i",
       reset:     "rst_fixed_ni",
       inst_type: "pinmux",
-      base_addr: "0x40070000",
-      size_byte: "0x1000",
+      addr_range: [{
+        base_addr: "0x40070000",
+        size_byte: "0x1000",
+        }],
       pipeline_byp: "false"
     },
     { name:      "alert_handler",

--- a/hw/top_earlgrey/ip/xbar_main/data/autogen/xbar_main.gen.hjson
+++ b/hw/top_earlgrey/ip/xbar_main/data/autogen/xbar_main.gen.hjson
@@ -97,8 +97,13 @@
       reset: rst_main_ni
       pipeline: "false"
       inst_type: rom
-      base_addr: 0x00008000
-      size_byte: 0x2000
+      addr_range:
+      [
+        {
+          base_addr: 0x00008000
+          size_byte: 0x2000
+        }
+      ]
       xbar: false
       pipeline_byp: "true"
     }
@@ -109,8 +114,13 @@
       reset: rst_main_ni
       pipeline_byp: "false"
       inst_type: rv_dm
-      base_addr: 0x1A110000
-      size_byte: 0x1000
+      addr_range:
+      [
+        {
+          base_addr: 0x1A110000
+          size_byte: 0x1000
+        }
+      ]
       xbar: false
       pipeline: "true"
     }
@@ -121,8 +131,13 @@
       reset: rst_main_ni
       pipeline: "false"
       inst_type: ram_1p
-      base_addr: 0x10000000
-      size_byte: 0x10000
+      addr_range:
+      [
+        {
+          base_addr: 0x10000000
+          size_byte: 0x10000
+        }
+      ]
       xbar: false
       pipeline_byp: "true"
     }
@@ -133,8 +148,13 @@
       reset: rst_main_ni
       pipeline: "false"
       inst_type: eflash
-      base_addr: 0x20000000
-      size_byte: 0x80000
+      addr_range:
+      [
+        {
+          base_addr: 0x20000000
+          size_byte: 0x80000
+        }
+      ]
       xbar: false
       pipeline_byp: "true"
     }
@@ -146,7 +166,7 @@
       pipeline_byp: "false"
       xbar: true
       pipeline: "true"
-      xbar_addr:
+      addr_range:
       [
         {
           base_addr: 0x40000000
@@ -165,8 +185,13 @@
       reset: rst_main_ni
       pipeline_byp: "false"
       inst_type: flash_ctrl
-      base_addr: 0x40030000
-      size_byte: 0x1000
+      addr_range:
+      [
+        {
+          base_addr: 0x40030000
+          size_byte: 0x1000
+        }
+      ]
       xbar: false
       pipeline: "true"
     }
@@ -177,8 +202,13 @@
       reset: rst_main_ni
       pipeline_byp: "false"
       inst_type: hmac
-      base_addr: 0x40120000
-      size_byte: 0x1000
+      addr_range:
+      [
+        {
+          base_addr: 0x40120000
+          size_byte: 0x1000
+        }
+      ]
       xbar: false
       pipeline: "true"
     }
@@ -189,8 +219,13 @@
       reset: rst_main_ni
       pipeline_byp: "false"
       inst_type: aes
-      base_addr: 0x40110000
-      size_byte: 0x1000
+      addr_range:
+      [
+        {
+          base_addr: 0x40110000
+          size_byte: 0x1000
+        }
+      ]
       xbar: false
       pipeline: "true"
     }
@@ -200,8 +235,13 @@
       clock: clk_main_i
       reset: rst_main_ni
       inst_type: rv_plic
-      base_addr: 0x40090000
-      size_byte: 0x1000
+      addr_range:
+      [
+        {
+          base_addr: 0x40090000
+          size_byte: 0x1000
+        }
+      ]
       pipeline_byp: "false"
       xbar: false
       pipeline: "true"
@@ -212,8 +252,13 @@
       clock: clk_main_i
       reset: rst_fixed_ni
       inst_type: pinmux
-      base_addr: 0x40070000
-      size_byte: 0x1000
+      addr_range:
+      [
+        {
+          base_addr: 0x40070000
+          size_byte: 0x1000
+        }
+      ]
       pipeline_byp: "false"
       xbar: false
       pipeline: "true"
@@ -224,8 +269,13 @@
       clock: clk_main_i
       inst_type: alert_handler
       pipeline_byp: "false"
-      base_addr: 0x40130000
-      size_byte: 0x1000
+      addr_range:
+      [
+        {
+          base_addr: 0x40130000
+          size_byte: 0x1000
+        }
+      ]
       xbar: false
       pipeline: "true"
     }
@@ -235,8 +285,13 @@
       clock: clk_main_i
       inst_type: nmi_gen
       pipeline_byp: "false"
-      base_addr: 0x40140000
-      size_byte: 0x1000
+      addr_range:
+      [
+        {
+          base_addr: 0x40140000
+          size_byte: 0x1000
+        }
+      ]
       xbar: false
       pipeline: "true"
     }

--- a/hw/top_earlgrey/ip/xbar_peri/data/autogen/xbar_peri.gen.hjson
+++ b/hw/top_earlgrey/ip/xbar_peri/data/autogen/xbar_peri.gen.hjson
@@ -46,8 +46,13 @@
       reset: rst_peri_ni
       pipeline: "false"
       inst_type: uart
-      base_addr: 0x40000000
-      size_byte: 0x1000
+      addr_range:
+      [
+        {
+          base_addr: 0x40000000
+          size_byte: 0x1000
+        }
+      ]
       xbar: false
       pipeline_byp: "true"
     }
@@ -58,8 +63,13 @@
       reset: rst_peri_ni
       pipeline: "false"
       inst_type: gpio
-      base_addr: 0x40010000
-      size_byte: 0x1000
+      addr_range:
+      [
+        {
+          base_addr: 0x40010000
+          size_byte: 0x1000
+        }
+      ]
       xbar: false
       pipeline_byp: "true"
     }
@@ -70,8 +80,13 @@
       reset: rst_peri_ni
       pipeline: "false"
       inst_type: spi_device
-      base_addr: 0x40020000
-      size_byte: 0x1000
+      addr_range:
+      [
+        {
+          base_addr: 0x40020000
+          size_byte: 0x1000
+        }
+      ]
       xbar: false
       pipeline_byp: "true"
     }
@@ -82,8 +97,13 @@
       reset: rst_peri_ni
       pipeline: "false"
       inst_type: rv_timer
-      base_addr: 0x40080000
-      size_byte: 0x1000
+      addr_range:
+      [
+        {
+          base_addr: 0x40080000
+          size_byte: 0x1000
+        }
+      ]
       xbar: false
       pipeline_byp: "true"
     }


### PR DESCRIPTION
With #1236 , Xbars now have `xbar_addr` field to indicate multiple addresses in a device port if the port is connected to another Xbar. `xbar_addr`, however, functions same as the `base_addr` and `size_byte` at the normal device port but having many of them.

It is logical to have unified data structure regardless of the device port's type (xbar vs non-xbar). This PR addresses the issue above. Now every device port has `addr_range` field, which type is a list of address group. The address group has `base_addr` and `size_byte` field in it.