### PR TITLE
[sw] Apply util/fix_include_guard.py to the sw tree

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -81,6 +81,20 @@ jobs:
     displayName: 'Use clang-format to check C/C++ coding style'
 
   - bash: |
+      fork_origin="$(git merge-base --fork-point origin/master)"
+      changed_files="$(git diff --name-only "$fork_origin")"
+      if [[ -z "$changed_files" ]]; then
+        xargs util/fix_include_guard.py --dry-run <<< "$changed_files" | tee fix-include-guard-output
+        if [[ -s fix-include-guard-output ]]; then
+          echo -n "##vso[task.logissue type=error]"
+          echo "Include guard check failed. Please run util/fix_include_guard.py on the above files."
+          exit 1
+        fi
+      fi
+    condition: eq(variables['Build.Reason'], 'PullRequest')
+    displayName: 'Check formatting on header guards'
+
+  - bash: |
       commit_range=$(git merge-base --fork-point origin/master)..HEAD
       # Notes:
       # * Merge commits are not checked. We always use rebases instead of

--- a/sw/device/benchmarks/coremark/top_earlgrey/core_portme.h
+++ b/sw/device/benchmarks/coremark/top_earlgrey/core_portme.h
@@ -9,8 +9,8 @@
    different platforms
 */
 
-#ifndef CORE_PORTME_H
-#define CORE_PORTME_H
+#ifndef OPENTITAN_SW_DEVICE_BENCHMARKS_COREMARK_TOP_EARLGREY_CORE_PORTME_H_
+#define OPENTITAN_SW_DEVICE_BENCHMARKS_COREMARK_TOP_EARLGREY_CORE_PORTME_H_
 
 #include <stddef.h>
 
@@ -203,4 +203,4 @@ void portable_fini(core_portable *p);
 
 int ee_printf(const char *fmt, ...);
 
-#endif /* CORE_PORTME_H */
+#endif  // OPENTITAN_SW_DEVICE_BENCHMARKS_COREMARK_TOP_EARLGREY_CORE_PORTME_H_

--- a/sw/device/boot_rom/bootstrap.h
+++ b/sw/device/boot_rom/bootstrap.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef _F_BOOTSTRAP_H__
-#define _F_BOOTSTRAP_H__
+#ifndef OPENTITAN_SW_DEVICE_BOOT_ROM_BOOTSTRAP_H_
+#define OPENTITAN_SW_DEVICE_BOOT_ROM_BOOTSTRAP_H_
 
 #include "sw/device/boot_rom/bootstrap_msgs.h"
 
@@ -21,4 +21,4 @@
  */
 int bootstrap(void);
 
-#endif  // _F_BOOTSTRAP_H__
+#endif  // OPENTITAN_SW_DEVICE_BOOT_ROM_BOOTSTRAP_H_

--- a/sw/device/boot_rom/bootstrap_msgs.h
+++ b/sw/device/boot_rom/bootstrap_msgs.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef _F_BOOTSTRAP_MSGS_H__
-#define _F_BOOTSTRAP_MSGS_H__
+#ifndef OPENTITAN_SW_DEVICE_BOOT_ROM_BOOTSTRAP_MSGS_H_
+#define OPENTITAN_SW_DEVICE_BOOT_ROM_BOOTSTRAP_MSGS_H_
 #include <stdint.h>
 
 #define RAW_BUFFER_SIZE 1024
@@ -35,4 +35,4 @@ typedef struct {
 #define E_BS_NOTEMPTY 11
 #define E_BS_WRITE 12
 
-#endif  // _F_BOOTSTRAP_MSGS_H__
+#endif  // OPENTITAN_SW_DEVICE_BOOT_ROM_BOOTSTRAP_MSGS_H_

--- a/sw/device/lib/aes.h
+++ b/sw/device/lib/aes.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef _F_LIB_AES_H__
-#define _F_LIB_AES_H__
+#ifndef OPENTITAN_SW_DEVICE_LIB_AES_H_
+#define OPENTITAN_SW_DEVICE_LIB_AES_H_
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -109,4 +109,4 @@ bool aes_idle(void);
  */
 void aes_clear(void);
 
-#endif  // _F_LIB_AES_H__
+#endif  // OPENTITAN_SW_DEVICE_LIB_AES_H_

--- a/sw/device/lib/base/memory.h
+++ b/sw/device/lib/base/memory.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef SW_DEVICE_LIB_BASE_MEMORY_H_
-#define SW_DEVICE_LIB_BASE_MEMORY_H_
+#ifndef OPENTITAN_SW_DEVICE_LIB_BASE_MEMORY_H_
+#define OPENTITAN_SW_DEVICE_LIB_BASE_MEMORY_H_
 
 #include <stdalign.h>
 #include <stdbool.h>
@@ -94,4 +94,4 @@ void *memcpy(void *restrict dest, const void *restrict src, size_t len);
  */
 void *memset(void *dest, int value, size_t len);
 
-#endif  // SW_DEVICE_LIB_BASE_MEMORY_H_
+#endif  // OPENTITAN_SW_DEVICE_LIB_BASE_MEMORY_H_

--- a/sw/device/lib/base/mmio.h
+++ b/sw/device/lib/base/mmio.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef SW_DEVICE_LIB_BASE_MMIO_H_
-#define SW_DEVICE_LIB_BASE_MMIO_H_
+#ifndef OPENTITAN_SW_DEVICE_LIB_BASE_MMIO_H_
+#define OPENTITAN_SW_DEVICE_LIB_BASE_MMIO_H_
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -153,4 +153,4 @@ inline void reg32_nonatomic_set_bit(reg32_t base, ptrdiff_t offset,
   reg32_nonatomic_set_mask(base, offset, 0x1, bit_index);
 }
 
-#endif  // SW_DEVICE_LIB_BASE_MMIO_H_
+#endif  // OPENTITAN_SW_DEVICE_LIB_BASE_MMIO_H_

--- a/sw/device/lib/base/stdasm.h
+++ b/sw/device/lib/base/stdasm.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef SW_DEVICE_LIB_BASE_STDASM_H_
-#define SW_DEVICE_LIB_BASE_STDASM_H_
+#ifndef OPENTITAN_SW_DEVICE_LIB_BASE_STDASM_H_
+#define OPENTITAN_SW_DEVICE_LIB_BASE_STDASM_H_
 
 /**
  * This header simply provides the |asm| keyword, in analogy with the ISO C
@@ -12,4 +12,4 @@
 
 #define asm __asm__
 
-#endif  // SW_DEVICE_LIB_BASE_STDASM_H_
+#endif  // OPENTITAN_SW_DEVICE_LIB_BASE_STDASM_H_

--- a/sw/device/lib/common.h
+++ b/sw/device/lib/common.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef _COMMON_H_
-#define _COMMON_H_
+#ifndef OPENTITAN_SW_DEVICE_LIB_COMMON_H_
+#define OPENTITAN_SW_DEVICE_LIB_COMMON_H_
 
 #ifdef SIMULATION
 static const unsigned long UART_BAUD_RATE = 9600;
@@ -27,4 +27,4 @@ static const unsigned long UART_BAUD_RATE = 230400;
 
 #define ARRAYSIZE(x) (sizeof(x) / sizeof(x[0]))
 
-#endif
+#endif  // OPENTITAN_SW_DEVICE_LIB_COMMON_H_

--- a/sw/device/lib/flash_ctrl.h
+++ b/sw/device/lib/flash_ctrl.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef _F_FLASH_CTRL_H__
-#define _F_FLASH_CTRL_H__
+#ifndef OPENTITAN_SW_DEVICE_LIB_FLASH_CTRL_H_
+#define OPENTITAN_SW_DEVICE_LIB_FLASH_CTRL_H_
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -97,4 +97,4 @@ void flash_write_scratch_reg(uint32_t value);
 /** Read scratch register */
 uint32_t flash_read_scratch_reg(void);
 
-#endif  // _F_FLASH_CTRL_H__
+#endif  // OPENTITAN_SW_DEVICE_LIB_FLASH_CTRL_H_

--- a/sw/device/lib/gpio.h
+++ b/sw/device/lib/gpio.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef _GPIO_H_
-#define _GPIO_H_
+#ifndef OPENTITAN_SW_DEVICE_LIB_GPIO_H_
+#define OPENTITAN_SW_DEVICE_LIB_GPIO_H_
 
 #include <stdint.h>
 
@@ -22,4 +22,4 @@ void gpio_write_bit(unsigned int bit, unsigned int val);
 void gpio_write_all(uint32_t val);
 uint32_t gpio_read(void);
 
-#endif
+#endif  // OPENTITAN_SW_DEVICE_LIB_GPIO_H_

--- a/sw/device/lib/handler.h
+++ b/sw/device/lib/handler.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef _HANDLER_H_
-#define _HANDLER_H_
+#ifndef OPENTITAN_SW_DEVICE_LIB_HANDLER_H_
+#define OPENTITAN_SW_DEVICE_LIB_HANDLER_H_
 
 typedef enum exc_id {
   kInstMisa = 0,
@@ -126,4 +126,4 @@ void handler_lsu_fault(void);
  */
 void handler_ecall(void);
 
-#endif
+#endif  // OPENTITAN_SW_DEVICE_LIB_HANDLER_H_

--- a/sw/device/lib/hmac.h
+++ b/sw/device/lib/hmac.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef _F_LIB_HMAC_H__
-#define _F_LIB_HMAC_H__
+#ifndef OPENTITAN_SW_DEVICE_LIB_HMAC_H_
+#define OPENTITAN_SW_DEVICE_LIB_HMAC_H_
 
 #include <stddef.h>
 #include <stdint.h>
@@ -49,4 +49,4 @@ void hmac_update(const void *data, size_t size_in_bytes);
  */
 void hmac_done(uint32_t *digest);
 
-#endif  // _F_LIB_HMAC_H__
+#endif  // OPENTITAN_SW_DEVICE_LIB_HMAC_H_

--- a/sw/device/lib/hw_sha256.h
+++ b/sw/device/lib/hw_sha256.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef _F_LIB_SHA256_H__
-#define _F_LIB_SHA256_H__
+#ifndef OPENTITAN_SW_DEVICE_LIB_HW_SHA256_H_
+#define OPENTITAN_SW_DEVICE_LIB_HW_SHA256_H_
 
 #include <stddef.h>
 
@@ -47,4 +47,4 @@ const uint8_t *hw_SHA256_final(HW_SHA256_CTX *ctx);
  */
 const uint8_t *hw_SHA256_hash(const void *data, size_t len, uint8_t *digest);
 
-#endif  // _F_LIB_SHA256_H__
+#endif  // OPENTITAN_SW_DEVICE_LIB_HW_SHA256_H_

--- a/sw/device/lib/irq.h
+++ b/sw/device/lib/irq.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef _IRQ_H_
-#define _IRQ_H_
+#ifndef OPENTITAN_SW_DEVICE_LIB_IRQ_H_
+#define OPENTITAN_SW_DEVICE_LIB_IRQ_H_
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -35,4 +35,4 @@ void irq_timer_ctrl(bool en);
  */
 void irq_software_ctrl(bool en);
 
-#endif
+#endif  // OPENTITAN_SW_DEVICE_LIB_IRQ_H_

--- a/sw/device/lib/log.h
+++ b/sw/device/lib/log.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef _LOG_H_
-#define _LOG_H_
+#ifndef OPENTITAN_SW_DEVICE_LIB_LOG_H_
+#define OPENTITAN_SW_DEVICE_LIB_LOG_H_
 
 #ifdef DV_SIM
 #include "sw/device/lib/log_uart/log_impl.h"
@@ -214,4 +214,4 @@
 #define LOG_FATAL(...) PRINT_LOG(LOG_HEADER(LOG_TYPE_FATAL, ""), __VA_ARGS__)
 #endif
 
-#endif  // _LOG_H_
+#endif  // OPENTITAN_SW_DEVICE_LIB_LOG_H_

--- a/sw/device/lib/log_uart/log_impl.h
+++ b/sw/device/lib/log_uart/log_impl.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef _LOG_IMPL_H
-#define _LOG_IMPL_H
+#ifndef OPENTITAN_SW_DEVICE_LIB_LOG_UART_LOG_IMPL_H_
+#define OPENTITAN_SW_DEVICE_LIB_LOG_UART_LOG_IMPL_H_
 
 #include "sw/device/lib/print_log.h"
 #include "sw/device/lib/uart.h"
@@ -54,4 +54,4 @@
 #define PRINT_LOG(log_header, ...) \
   print_log(&uart_send_char, log_header __VA_ARGS__);
 
-#endif  // _LOG_IMPL_H
+#endif  // OPENTITAN_SW_DEVICE_LIB_LOG_UART_LOG_IMPL_H_

--- a/sw/device/lib/pinmux.h
+++ b/sw/device/lib/pinmux.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef _PINMUX_H_
-#define _PINMUX_H_
+#ifndef OPENTITAN_SW_DEVICE_LIB_PINMUX_H_
+#define OPENTITAN_SW_DEVICE_LIB_PINMUX_H_
 
 #include <stdint.h>
 
@@ -14,4 +14,4 @@
  */
 void pinmux_init(void);
 
-#endif  // _PINMUX_H_
+#endif  // OPENTITAN_SW_DEVICE_LIB_PINMUX_H_

--- a/sw/device/lib/print_log.h
+++ b/sw/device/lib/print_log.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef _MSG_PRINT_H_
-#define _MSG_PRINT_H_
+#ifndef OPENTITAN_SW_DEVICE_LIB_PRINT_LOG_H_
+#define OPENTITAN_SW_DEVICE_LIB_PRINT_LOG_H_
 
 // Pointer to a function that prints a character.
 typedef void (*print_char_func)(char);
@@ -35,4 +35,4 @@ typedef void (*print_char_func)(char);
  */
 void print_log(print_char_func print_char, const char *fmt, ...);
 
-#endif  // _MSG_PRINT_H_
+#endif  // OPENTITAN_SW_DEVICE_LIB_PRINT_LOG_H_

--- a/sw/device/lib/runtime/hart.h
+++ b/sw/device/lib/runtime/hart.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef SW_DEVICE_LIB_RUNTIME_HART_H_
-#define SW_DEVICE_LIB_RUNTIME_HART_H_
+#ifndef OPENTITAN_SW_DEVICE_LIB_RUNTIME_HART_H_
+#define OPENTITAN_SW_DEVICE_LIB_RUNTIME_HART_H_
 
 #include <stddef.h>
 #include <stdnoreturn.h>
@@ -37,4 +37,4 @@ void busy_sleep_micros(size_t microseconds);
  */
 noreturn void abort(void);
 
-#endif  // SW_DEVICE_LIB_RUNTIME_HART_H_
+#endif  // OPENTITAN_SW_DEVICE_LIB_RUNTIME_HART_H_

--- a/sw/device/lib/runtime/ibex.h
+++ b/sw/device/lib/runtime/ibex.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef SW_DEVICE_LIB_RUNTIME_IBEX_H_
-#define SW_DEVICE_LIB_RUNTIME_IBEX_H_
+#ifndef OPENTITAN_SW_DEVICE_LIB_RUNTIME_IBEX_H_
+#define OPENTITAN_SW_DEVICE_LIB_RUNTIME_IBEX_H_
 
 #include <stddef.h>
 
@@ -38,4 +38,4 @@ inline void ibex_busy_loop(size_t cycles) {
       : "0"(cycles));
 }
 
-#endif  // SW_DEVICE_LIB_RUNTIME_IBEX_H_
+#endif  // OPENTITAN_SW_DEVICE_LIB_RUNTIME_IBEX_H_

--- a/sw/device/lib/rv_timer.h
+++ b/sw/device/lib/rv_timer.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef _F_LIB_RV_TIMER_H__
-#define _F_LIB_RV_TIMER_H__
+#ifndef OPENTITAN_SW_DEVICE_LIB_RV_TIMER_H_
+#define OPENTITAN_SW_DEVICE_LIB_RV_TIMER_H_
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -49,4 +49,4 @@ void rv_timer_intr_enable(uint32_t hart, bool en);
  */
 void rv_timer_clr_all_intrs(void);
 
-#endif  // _F_LIB_RV_TIMER_H__
+#endif  // OPENTITAN_SW_DEVICE_LIB_RV_TIMER_H_

--- a/sw/device/lib/spi_device.h
+++ b/sw/device/lib/spi_device.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef _SPI_DEVICE_H_
-#define _SPI_DEVICE_H_
+#ifndef OPENTITAN_SW_DEVICE_LIB_SPI_DEVICE_H_
+#define OPENTITAN_SW_DEVICE_LIB_SPI_DEVICE_H_
 
 #include <stdint.h>
 
@@ -35,4 +35,4 @@ uint32_t spid_read_nb(void *data, uint32_t len);
  */
 uint32_t spid_bytes_available(void);
 
-#endif /* _SPI_DEVICE_H_ */
+#endif  // OPENTITAN_SW_DEVICE_LIB_SPI_DEVICE_H_

--- a/sw/device/lib/uart.h
+++ b/sw/device/lib/uart.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef _UART_H_
-#define _UART_H_
+#ifndef OPENTITAN_SW_DEVICE_LIB_UART_H_
+#define OPENTITAN_SW_DEVICE_LIB_UART_H_
 
 #include <stdint.h>
 
@@ -35,4 +35,4 @@ int uart_tx_idle(void);
  */
 int uart_rcv_char(char *c);
 
-#endif
+#endif  // OPENTITAN_SW_DEVICE_LIB_UART_H_

--- a/sw/device/lib/usb_consts.h
+++ b/sw/device/lib/usb_consts.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef _USB_CONSTS_H_
-#define _USB_CONSTS_H_
+#ifndef OPENTITAN_SW_DEVICE_LIB_USB_CONSTS_H_
+#define OPENTITAN_SW_DEVICE_LIB_USB_CONSTS_H_
 
 // SETUP requests
 typedef enum usb_setup_req {
@@ -51,4 +51,4 @@ typedef enum usb_status {
   kUsbStatusHalted = 1        // Endpoint status request
 } usb_status_t;
 
-#endif  // _USB_CONSTS_H_
+#endif  // OPENTITAN_SW_DEVICE_LIB_USB_CONSTS_H_

--- a/sw/device/lib/usb_controlep.h
+++ b/sw/device/lib/usb_controlep.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef __USB_CONTROLEP_H__
-#define __USB_CONTROLEP_H__
+#ifndef OPENTITAN_SW_DEVICE_LIB_USB_CONTROLEP_H_
+#define OPENTITAN_SW_DEVICE_LIB_USB_CONTROLEP_H_
 
 #include <stddef.h>
 #include <stdint.h>
@@ -94,4 +94,4 @@ void usb_controlep_init(usb_controlep_ctx_t *ctctx, usbdev_ctx_t *ctx, int ep,
 
 // KEEP BLANK LINE ABOVE, it is in the macro!
 
-#endif
+#endif  // OPENTITAN_SW_DEVICE_LIB_USB_CONTROLEP_H_

--- a/sw/device/lib/usb_simpleserial.h
+++ b/sw/device/lib/usb_simpleserial.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef __USB_SIMPLESERIAL_H__
-#define __USB_SIMPLESERIAL_H__
+#ifndef OPENTITAN_SW_DEVICE_LIB_USB_SIMPLESERIAL_H_
+#define OPENTITAN_SW_DEVICE_LIB_USB_SIMPLESERIAL_H_
 
 #include <stddef.h>
 #include <stdint.h>
@@ -43,4 +43,4 @@ void usb_simpleserial_send_byte(usb_ss_ctx_t *ssctx, uint8_t c);
 void usb_simpleserial_init(usb_ss_ctx_t *ssctx, usbdev_ctx_t *ctx, int ep,
                            void (*got_byte)(uint8_t));
 
-#endif
+#endif  // OPENTITAN_SW_DEVICE_LIB_USB_SIMPLESERIAL_H_

--- a/sw/device/lib/usbdev.h
+++ b/sw/device/lib/usbdev.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef _USBDEV_H_
-#define _USBDEV_H_
+#ifndef OPENTITAN_SW_DEVICE_LIB_USBDEV_H_
+#define OPENTITAN_SW_DEVICE_LIB_USBDEV_H_
 
 #include <stddef.h>
 #include <stdint.h>
@@ -230,4 +230,4 @@ void usbdev_init(usbdev_ctx_t *ctx);
 #define TRC_I(i, b) uart_send_uint(i, b)
 #define TRC_C(c) uart_send_char(c)
 
-#endif
+#endif  // OPENTITAN_SW_DEVICE_LIB_USBDEV_H_

--- a/sw/host/spiflash/ftdi_spi_interface.h
+++ b/sw/host/spiflash/ftdi_spi_interface.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef _F_SPIFLASH_FTDI_SPI_INTERFACE_H__
-#define _F_SPIFLASH_FTDI_SPI_INTERFACE_H__
+#ifndef OPENTITAN_SW_HOST_SPIFLASH_FTDI_SPI_INTERFACE_H_
+#define OPENTITAN_SW_HOST_SPIFLASH_FTDI_SPI_INTERFACE_H_
 
 #include <memory>
 #include <string>
@@ -40,4 +40,4 @@ class FtdiSpiInterface : public SpiInterface {
 }  // namespace spiflash
 }  // namespace opentitan
 
-#endif  // _F_SPIFLASH_FTDI_SPI_INTERFACE_H__
+#endif  // OPENTITAN_SW_HOST_SPIFLASH_FTDI_SPI_INTERFACE_H_

--- a/sw/host/spiflash/spi_interface.h
+++ b/sw/host/spiflash/spi_interface.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef _F_SPIFLASH_SPI_INTERFACE_H__
-#define _F_SPIFLASH_SPI_INTERFACE_H__
+#ifndef OPENTITAN_SW_HOST_SPIFLASH_SPI_INTERFACE_H_
+#define OPENTITAN_SW_HOST_SPIFLASH_SPI_INTERFACE_H_
 
 #include <cstdint>
 #include <cstring>
@@ -33,4 +33,4 @@ class SpiInterface {
 }  // namespace spiflash
 }  // namespace opentitan
 
-#endif  // _F_SPIFLASH_SPI_INTERFACE_H__
+#endif  // OPENTITAN_SW_HOST_SPIFLASH_SPI_INTERFACE_H_

--- a/sw/host/spiflash/updater.h
+++ b/sw/host/spiflash/updater.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef _F_SPIFLASH_UPDATER_H__
-#define _F_SPIFLASH_UPDATER_H__
+#ifndef OPENTITAN_SW_HOST_SPIFLASH_UPDATER_H_
+#define OPENTITAN_SW_HOST_SPIFLASH_UPDATER_H_
 
 #include <openssl/sha.h>
 
@@ -78,4 +78,4 @@ class Updater {
 }  // namespace spiflash
 }  // namespace opentitan
 
-#endif
+#endif  // OPENTITAN_SW_HOST_SPIFLASH_UPDATER_H_

--- a/sw/host/spiflash/verilator_spi_interface.h
+++ b/sw/host/spiflash/verilator_spi_interface.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef _F_SPIFLASH_VERILATOR_SPI_INTERFACE_H__
-#define _F_SPIFLASH_VERILATOR_SPI_INTERFACE_H__
+#ifndef OPENTITAN_SW_HOST_SPIFLASH_VERILATOR_SPI_INTERFACE_H_
+#define OPENTITAN_SW_HOST_SPIFLASH_VERILATOR_SPI_INTERFACE_H_
 
 #include <string>
 
@@ -41,4 +41,4 @@ class VerilatorSpiInterface : public SpiInterface {
 }  // namespace spiflash
 }  // namespace opentitan
 
-#endif  // _F_SPIFLASH_VERILATOR_SPI_INTERFACE_H__
+#endif  // OPENTITAN_SW_HOST_SPIFLASH_VERILATOR_SPI_INTERFACE_H_


### PR DESCRIPTION
Also, add a step to the lint CI stage to check that files remain formatted.

This only applies to the SW, mostly because I don't want to go ahead and touch headers under hw quite yet.