### PR TITLE
[top] Re-align USB top

### DIFF
--- a/hw/dv/dpi/jtagdpi/jtagdpi.sv
+++ b/hw/dv/dpi/jtagdpi/jtagdpi.sv
@@ -6,15 +6,15 @@ module jtagdpi #(
   parameter string Name = "jtag0", // name of the JTAG interface (display only)
   parameter int ListenPort = 44853 // TCP port to listen on
 )(
-  input  clk_i,
-  input  rst_ni,
+  input  logic clk_i,
+  input  logic rst_ni,
 
-  output jtag_tck,
-  output jtag_tms,
-  output jtag_tdi,
-  input  jtag_tdo,
-  output jtag_trst_n,
-  output jtag_srst_n
+  output logic jtag_tck,
+  output logic jtag_tms,
+  output logic jtag_tdi,
+  input  logic jtag_tdo,
+  output logic jtag_trst_n,
+  output logic jtag_srst_n
 );
 
   import "DPI-C"

--- a/hw/dv/dpi/uartdpi/uartdpi.sv
+++ b/hw/dv/dpi/uartdpi/uartdpi.sv
@@ -7,11 +7,11 @@ module uartdpi #(
   parameter FREQ = 'x,
   parameter string NAME = "uart0"
 )(
-  input      clk_i,
-  input      rst_ni,
+  input  logic clk_i,
+  input  logic rst_ni,
 
-  output reg tx_o,
-  input      rx_i
+  output logic tx_o,
+  input  logic rx_i
 );
 
   localparam CYCLES_PER_SYMBOL = FREQ/BAUD;

--- a/hw/dv/dpi/usbdpi/usbdpi.sv
+++ b/hw/dv/dpi/usbdpi/usbdpi.sv
@@ -8,23 +8,22 @@
 // 0x01 -- monitor_usb (packet level)
 // 0x08 -- bit level
 
-module usbdpi
-  #(
+module usbdpi #(
   parameter string NAME = "usb0",
   parameter LOG_LEVEL = 1
-  )(
-  input  clk_i,
-  input  rst_ni,
-  input  clk_48MHz_i,
-  output dp_p2d,
-  input  dp_d2p,
-  input  dp_en_d2p,
-  output dn_p2d,
-  input  dn_d2p,
-  input  dn_en_d2p,
-  output sense_p2d,
-  input  pullup_d2p,
-  input  pullup_en_d2p
+)(
+  input  logic clk_i,
+  input  logic rst_ni,
+  input  logic clk_48MHz_i,
+  output logic dp_p2d,
+  input  logic dp_d2p,
+  input  logic dp_en_d2p,
+  output logic dn_p2d,
+  input  logic dn_d2p,
+  input  logic dn_en_d2p,
+  output logic sense_p2d,
+  input  logic pullup_d2p,
+  input  logic pullup_en_d2p
 );
   import "DPI-C" function
     chandle usbdpi_create(input string name, input int loglevel);

--- a/hw/top_earlgrey/rtl/top_earlgrey_usb.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_usb.sv
@@ -100,6 +100,10 @@ module top_earlgrey_usb #(
   tl_d2h_t  tl_rv_plic_d_d2h;
   tl_h2d_t  tl_pinmux_d_h2d;
   tl_d2h_t  tl_pinmux_d_d2h;
+  tl_h2d_t  tl_alert_handler_d_h2d;
+  tl_d2h_t  tl_alert_handler_d_d2h;
+  tl_h2d_t  tl_nmi_gen_d_h2d;
+  tl_d2h_t  tl_nmi_gen_d_d2h;
 
   tl_h2d_t tl_rom_d_h2d;
   tl_d2h_t tl_rom_d_d2h;
@@ -108,13 +112,23 @@ module top_earlgrey_usb #(
   tl_h2d_t tl_eflash_d_h2d;
   tl_d2h_t tl_eflash_d_d2h;
 
+  tl_h2d_t tl_main_h_h2d;
+  tl_d2h_t tl_main_h_d2h;
+  tl_h2d_t tl_peri_d_h2d;
+  tl_d2h_t tl_peri_d_d2h;
+
+  assign tl_main_h_h2d = tl_peri_d_h2d;
+  assign tl_peri_d_d2h = tl_main_h_d2h;
+
   //reset wires declaration
   logic lc_rst_n;
   logic sys_rst_n;
+  logic sys_fixed_rst_n;
   logic spi_device_rst_n;
 
   //clock wires declaration
   logic main_clk;
+  logic fixed_clk;
 
   // Signals
   logic [31:0] m2p;
@@ -140,9 +154,11 @@ module top_earlgrey_usb #(
   // hmac
   // rv_plic
   // pinmux
+  // alert_handler
+  // nmi_gen
 
 
-  logic [54:0]  intr_vector;
+  logic [62:0]  intr_vector;
   // Interrupt source list
   logic intr_uart_tx_watermark;
   logic intr_uart_rx_watermark;
@@ -169,6 +185,14 @@ module top_earlgrey_usb #(
   logic intr_hmac_hmac_done;
   logic intr_hmac_fifo_full;
   logic intr_hmac_hmac_err;
+  logic intr_alert_handler_classa;
+  logic intr_alert_handler_classb;
+  logic intr_alert_handler_classc;
+  logic intr_alert_handler_classd;
+  logic intr_nmi_gen_esc0;
+  logic intr_nmi_gen_esc1;
+  logic intr_nmi_gen_esc2;
+  logic intr_nmi_gen_esc3;
 
   
   logic [0:0] irq_plic;
@@ -179,8 +203,16 @@ module top_earlgrey_usb #(
   // this avoids lint errors
   assign unused_irq_id = irq_id;
 
+  // Alert list
+  prim_pkg::alert_tx_t [alert_pkg::NAlerts-1:0]  alert_tx;
+  prim_pkg::alert_rx_t [alert_pkg::NAlerts-1:0]  alert_rx;
+  // Escalation outputs
+  prim_pkg::esc_tx_t [alert_pkg::N_ESC_SEV-1:0]  esc_tx;
+  prim_pkg::esc_rx_t [alert_pkg::N_ESC_SEV-1:0]  esc_rx;
+
   // clock assignments
   assign main_clk = clk_i;
+  assign fixed_clk = clk_i;
 
   // Non-debug module reset == reset for everything except for the debug module
   logic ndmreset_req;
@@ -192,6 +224,7 @@ module top_earlgrey_usb #(
   assign sys_rst_n = (scanmode_i) ? lc_rst_n : ~ndmreset_req & lc_rst_n;
 
   //non-root reset assignments
+  assign sys_fixed_rst_n = sys_rst_n;
   assign spi_device_rst_n = sys_rst_n;
 
   // debug request from rv_dm to core
@@ -430,8 +463,8 @@ module top_earlgrey_usb #(
         .intr_rx_timeout_o    (intr_uart_rx_timeout),
         .intr_rx_parity_err_o (intr_uart_rx_parity_err),
 
-        .clk_i (main_clk),
-        .rst_ni (sys_rst_n)
+        .clk_i (fixed_clk),
+        .rst_ni (sys_fixed_rst_n)
     );
   end else begin : gen_uuart
     logic unused_rx = cio_uart_rx_p2d;
@@ -479,8 +512,8 @@ module top_earlgrey_usb #(
       // Interrupt
       .intr_gpio_o (intr_gpio_gpio),
 
-      .clk_i (main_clk),
-      .rst_ni (sys_rst_n)
+      .clk_i (fixed_clk),
+      .rst_ni (sys_fixed_rst_n)
   );
 
   if (USB_DEVICE == 0) begin : gen_spi
@@ -507,7 +540,7 @@ module top_earlgrey_usb #(
 
         .scanmode_i   (scanmode_i),
 
-        .clk_i (main_clk),
+        .clk_i (fixed_clk),
         .rst_ni (spi_device_rst_n)
     );
   end else begin : gen_usbdev // block: gen_spi
@@ -547,7 +580,7 @@ module top_earlgrey_usb #(
       .intr_rx_full_o       (intr_spi_device_rxerr),
       .intr_av_overflow_o   (intr_spi_device_txunderflow)
     );
-  end // block: gen_usbdev  
+  end // block: gen_usbdev
 
   // Tie off unused USB
   if (N_USB < MAX_USB) begin: gen_utie
@@ -589,8 +622,8 @@ module top_earlgrey_usb #(
       // Interrupt
       .intr_timer_expired_0_0_o (intr_rv_timer_timer_expired_0_0),
 
-      .clk_i (main_clk),
-      .rst_ni (sys_rst_n)
+      .clk_i (fixed_clk),
+      .rst_ni (sys_fixed_rst_n)
   );
 
   aes aes (
@@ -609,6 +642,10 @@ module top_earlgrey_usb #(
       .intr_hmac_done_o (intr_hmac_hmac_done),
       .intr_fifo_full_o (intr_hmac_fifo_full),
       .intr_hmac_err_o  (intr_hmac_hmac_err),
+
+      // [0]: msg_push_sha_disabled
+      .alert_tx_o  ( alert_tx[0:0] ),
+      .alert_rx_i  ( alert_rx[0:0] ),
 
       .clk_i (main_clk),
       .rst_ni (sys_rst_n)
@@ -643,8 +680,57 @@ module top_earlgrey_usb #(
       .rst_ni (sys_rst_n)
   );
 
+  alert_handler alert_handler (
+      .tl_i (tl_alert_handler_d_h2d),
+      .tl_o (tl_alert_handler_d_d2h),
+
+      // Interrupt
+      .intr_classa_o (intr_alert_handler_classa),
+      .intr_classb_o (intr_alert_handler_classb),
+      .intr_classc_o (intr_alert_handler_classc),
+      .intr_classd_o (intr_alert_handler_classd),
+      // TODO: wire this to hardware debug circuit
+      .crashdump_o (          ),
+      // TODO: wire this to TRNG
+      .entropy_i   ( 1'b0     ),
+      // alert signals
+      .alert_rx_o  ( alert_rx ),
+      .alert_tx_i  ( alert_tx ),
+      // escalation outputs
+      .esc_rx_i    ( esc_rx   ),
+      .esc_tx_o    ( esc_tx   ),
+
+      .clk_i (main_clk),
+      .rst_ni (sys_rst_n)
+  );
+
+  nmi_gen nmi_gen (
+      .tl_i (tl_nmi_gen_d_h2d),
+      .tl_o (tl_nmi_gen_d_d2h),
+
+      // Interrupt
+      .intr_esc0_o (intr_nmi_gen_esc0),
+      .intr_esc1_o (intr_nmi_gen_esc1),
+      .intr_esc2_o (intr_nmi_gen_esc2),
+      .intr_esc3_o (intr_nmi_gen_esc3),
+      // escalation signal inputs
+      .esc_rx_o    ( esc_rx   ),
+      .esc_tx_i    ( esc_tx   ),
+
+      .clk_i (main_clk),
+      .rst_ni (sys_rst_n)
+  );
+
   // interrupt assignments
   assign intr_vector = {
+      intr_nmi_gen_esc3,
+      intr_nmi_gen_esc2,
+      intr_nmi_gen_esc1,
+      intr_nmi_gen_esc0,
+      intr_alert_handler_classd,
+      intr_alert_handler_classc,
+      intr_alert_handler_classb,
+      intr_alert_handler_classa,
       intr_hmac_hmac_err,
       intr_hmac_fifo_full,
       intr_hmac_hmac_done,
@@ -674,39 +760,55 @@ module top_earlgrey_usb #(
   // TL-UL Crossbar
   xbar_main u_xbar_main (
     .clk_main_i (main_clk),
+    .clk_fixed_i (fixed_clk),
     .rst_main_ni (sys_rst_n),
-    .tl_corei_i      (tl_corei_h_h2d),
-    .tl_corei_o      (tl_corei_h_d2h),
-    .tl_cored_i      (tl_cored_h_h2d),
-    .tl_cored_o      (tl_cored_h_d2h),
-    .tl_dm_sba_i     (tl_dm_sba_h_h2d),
-    .tl_dm_sba_o     (tl_dm_sba_h_d2h),
-    .tl_rom_o        (tl_rom_d_h2d),
-    .tl_rom_i        (tl_rom_d_d2h),
-    .tl_debug_mem_o  (tl_debug_mem_d_h2d),
-    .tl_debug_mem_i  (tl_debug_mem_d_d2h),
-    .tl_ram_main_o   (tl_ram_main_d_h2d),
-    .tl_ram_main_i   (tl_ram_main_d_d2h),
-    .tl_eflash_o     (tl_eflash_d_h2d),
-    .tl_eflash_i     (tl_eflash_d_d2h),
+    .rst_fixed_ni (sys_fixed_rst_n),
+    .tl_corei_i         (tl_corei_h_h2d),
+    .tl_corei_o         (tl_corei_h_d2h),
+    .tl_cored_i         (tl_cored_h_h2d),
+    .tl_cored_o         (tl_cored_h_d2h),
+    .tl_dm_sba_i        (tl_dm_sba_h_h2d),
+    .tl_dm_sba_o        (tl_dm_sba_h_d2h),
+    .tl_rom_o           (tl_rom_d_h2d),
+    .tl_rom_i           (tl_rom_d_d2h),
+    .tl_debug_mem_o     (tl_debug_mem_d_h2d),
+    .tl_debug_mem_i     (tl_debug_mem_d_d2h),
+    .tl_ram_main_o      (tl_ram_main_d_h2d),
+    .tl_ram_main_i      (tl_ram_main_d_d2h),
+    .tl_eflash_o        (tl_eflash_d_h2d),
+    .tl_eflash_i        (tl_eflash_d_d2h),
+    .tl_peri_o          (tl_peri_d_h2d),
+    .tl_peri_i          (tl_peri_d_d2h),
+    .tl_flash_ctrl_o    (tl_flash_ctrl_d_h2d),
+    .tl_flash_ctrl_i    (tl_flash_ctrl_d_d2h),
+    .tl_hmac_o          (tl_hmac_d_h2d),
+    .tl_hmac_i          (tl_hmac_d_d2h),
+    .tl_aes_o           (tl_aes_d_h2d),
+    .tl_aes_i           (tl_aes_d_d2h),
+    .tl_rv_plic_o       (tl_rv_plic_d_h2d),
+    .tl_rv_plic_i       (tl_rv_plic_d_d2h),
+    .tl_pinmux_o        (tl_pinmux_d_h2d),
+    .tl_pinmux_i        (tl_pinmux_d_d2h),
+    .tl_alert_handler_o (tl_alert_handler_d_h2d),
+    .tl_alert_handler_i (tl_alert_handler_d_d2h),
+    .tl_nmi_gen_o       (tl_nmi_gen_d_h2d),
+    .tl_nmi_gen_i       (tl_nmi_gen_d_d2h),
+
+    .scanmode_i
+  );
+  xbar_peri u_xbar_peri (
+    .clk_peri_i (fixed_clk),
+    .rst_peri_ni (sys_fixed_rst_n),
+    .tl_main_i       (tl_main_h_h2d),
+    .tl_main_o       (tl_main_h_d2h),
     .tl_uart_o       (tl_uart_d_h2d),
     .tl_uart_i       (tl_uart_d_d2h),
     .tl_gpio_o       (tl_gpio_d_h2d),
     .tl_gpio_i       (tl_gpio_d_d2h),
     .tl_spi_device_o (tl_spi_device_d_h2d),
     .tl_spi_device_i (tl_spi_device_d_d2h),
-    .tl_flash_ctrl_o (tl_flash_ctrl_d_h2d),
-    .tl_flash_ctrl_i (tl_flash_ctrl_d_d2h),
     .tl_rv_timer_o   (tl_rv_timer_d_h2d),
     .tl_rv_timer_i   (tl_rv_timer_d_d2h),
-    .tl_hmac_o       (tl_hmac_d_h2d),
-    .tl_hmac_i       (tl_hmac_d_d2h),
-    .tl_aes_o        (tl_aes_d_h2d),
-    .tl_aes_i        (tl_aes_d_d2h),
-    .tl_rv_plic_o    (tl_rv_plic_d_h2d),
-    .tl_rv_plic_i    (tl_rv_plic_d_d2h),
-    .tl_pinmux_o     (tl_pinmux_d_h2d),
-    .tl_pinmux_i     (tl_pinmux_d_d2h),
 
     .scanmode_i
   );

--- a/hw/top_earlgrey/top_earlgrey_usb.core
+++ b/hw/top_earlgrey/top_earlgrey_usb.core
@@ -22,27 +22,58 @@ filesets:
       - lowrisc:prim:flash
       - lowrisc:ip:flash_ctrl:0.1
       - lowrisc:constants:top_pkg
+      - lowrisc:ip:nmi_gen
       - lowrisc:ip:usbuart
       - lowrisc:ip:usbdev
     files:
-      - ip/xbar/rtl/autogen/tl_main_pkg.sv
-      - ip/xbar/rtl/autogen/xbar_main.sv
+      - ip/xbar_main/rtl/autogen/tl_main_pkg.sv
+      - ip/xbar_main/rtl/autogen/xbar_main.sv
+      - ip/xbar_peri/rtl/autogen/tl_peri_pkg.sv
+      - ip/xbar_peri/rtl/autogen/xbar_peri.sv
       - ip/rv_plic/rtl/autogen/rv_plic_reg_pkg.sv
       - ip/rv_plic/rtl/autogen/rv_plic_reg_top.sv
       - ip/rv_plic/rtl/autogen/rv_plic.sv
       - ip/pinmux/rtl/autogen/pinmux_reg_pkg.sv
       - ip/pinmux/rtl/autogen/pinmux_reg_top.sv
       - ../ip/pinmux/rtl/pinmux.sv
+      - ip/alert_handler/rtl/autogen/alert_handler_reg_pkg.sv
+      - ip/alert_handler/rtl/autogen/alert_handler_reg_top.sv
+      - ../ip/alert_handler/rtl/alert_pkg.sv
+      - ../ip/alert_handler/rtl/alert_handler_reg_wrap.sv
+      - ../ip/alert_handler/rtl/alert_handler_class.sv
+      - ../ip/alert_handler/rtl/alert_handler_ping_timer.sv
+      - ../ip/alert_handler/rtl/alert_handler_esc_timer.sv
+      - ../ip/alert_handler/rtl/alert_handler_accu.sv
+      - ../ip/alert_handler/rtl/alert_handler.sv
       - rtl/padctl_usb.sv
       - rtl/top_earlgrey_usb.sv
     file_type: systemVerilogSource
 
+parameters:
+  SYNTHESIS:
+    datatype: bool
+    paramtype: vlogdefine
+  ASIC_SYNTHESIS:
+    datatype: bool
+    paramtype: vlogdefine
+  # For value definition, please see ip/prim/rtl/prim_pkg.sv
+  PRIM_DEFAULT_IMPL:
+    datatype: str
+    paramtype: vlogdefine
+    description: Primitives implementation to use, e.g. "prim_pkg::ImplGeneric".
+    default: prim_pkg::ImplGeneric
+
 targets:
-  default:
+  default: &default_target
     filesets:
       - files_rtl_generic
+    parameters:
+      - PRIM_DEFAULT_IMPL=prim_pkg::ImplGeneric
+    toplevel: top_earlgrey
   sim:
     default_tool: icarus
     filesets:
       - files_rtl_generic
+    parameters:
+      - PRIM_DEFAULT_IMPL=prim_pkg::ImplGeneric
     toplevel: top_earlgrey_usb


### PR DESCRIPTION
The USB top got once more out of sync with the normal, non-USB top. This PR re-aligns the USB top to the normal top.

I tested the changes using Veriilator and the `hello_usbdev` example and it runs through successfully.