### PR TITLE
[doc] Change back to int for loop counters in example code

### DIFF
--- a/hw/ip/rv_plic/doc/_index.md
+++ b/hw/ip/rv_plic/doc/_index.md
@@ -161,12 +161,12 @@ shall configure them.
 // Pseudo-code below
 void plic_init() {
   // Set to level-triggered for interrupt sources
-  for (size_t i = 0; i < ceil(N_SOURCE / 32); ++i) {
+  for (int i = 0; i < ceil(N_SOURCE / 32); ++i) {
     *(LE + i) = 0;
   }
 
   // Configure priority
-  for (size_t i = 0; i < N_SOURCE; ++i) {
+  for (int i = 0; i < N_SOURCE; ++i) {
     *(PRIO + i) = value(i);
   }
 }


### PR DESCRIPTION
Our C and C++ style guide builds on top of Google's, which [prefers int
for simple loop counters](https://google.github.io/styleguide/cppguide.html#Integer_Types). There's relevant discussion on the advantages
of this approach on this llvm-dev thread, which also cites a range of
other sources:
* http://lists.llvm.org/pipermail/llvm-dev/2019-June/132890.html
* http://lists.llvm.org/pipermail/llvm-dev/2019-June/133023.html

PR #1240 changed two loops in example code from using int to using
size_t as a loop counter, and this commit reverts that change.

I'm posting this as a PR to test the waters to see if we're happy
sticking with our current approach or if someobody wants to champion a
proposed change to recommend `size_t` for loop counters.

CC @imphil