### PR TITLE
[sw/dif] DRAFT: SPI DIF unit-testing

### DIFF
--- a/sw/device/lib/base/meson.build
+++ b/sw/device/lib/base/meson.build
@@ -12,3 +12,11 @@ sw_lib_mem = declare_dependency(
     c_args: ['-fno-builtin'],
   )
 )
+
+# MMIO register manipulation library
+sw_lib_mmio = declare_dependency(
+  link_with: static_library(
+    'mmio_ot',
+    sources: ['mmio.c'],
+  )
+)

--- a/sw/device/lib/base/mmio.c
+++ b/sw/device/lib/base/mmio.c
@@ -1,0 +1,16 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/mmio.h"
+
+// |extern| declarations to give the inline functions in the
+// corresponding header a link location.
+extern reg32_t reg32_from_addr(uintptr_t);
+extern uint32_t reg32_read(reg32_t, ptrdiff_t);
+extern void reg32_write(reg32_t, ptrdiff_t, uint32_t);
+extern void reg32_clear_mask(reg32_t, ptrdiff_t, uint32_t);
+extern void reg32_set_mask(reg32_t, ptrdiff_t, uint32_t);
+extern bool reg32_get_bit(reg32_t, ptrdiff_t, uint32_t);
+extern void reg32_clear_bit(reg32_t, ptrdiff_t, uint32_t);
+extern void reg32_set_bit(reg32_t, ptrdiff_t, uint32_t);

--- a/sw/device/lib/base/mmio.h
+++ b/sw/device/lib/base/mmio.h
@@ -9,6 +9,11 @@
 #include <stddef.h>
 #include <stdint.h>
 
+// This disables the definitions for reg32_t, reg32_read, and reg32_write for
+// testing purposes, but does not disable functions that are implemented in
+// terms of them. This is useful for mocking out read and write in tests,
+// without having to replicate all the other functions.
+#ifndef MOCK_MMIO
 /**
  * A reg32_t is an opaque handle to an MMIO register; it should only be modified
  * using the functions provided in this header.
@@ -54,6 +59,7 @@ inline uint32_t reg32_read(reg32_t base, ptrdiff_t offset) {
 inline void reg32_write(reg32_t base, ptrdiff_t offset, uint32_t value) {
   base.inner_ptr[offset / sizeof(uint32_t)] = value;
 }
+#endif  // MOCK_MMIO
 
 /**
  * Clears the bits in |mask| from the MMIO register |base| at the given offset.

--- a/sw/device/lib/base/mmio.h
+++ b/sw/device/lib/base/mmio.h
@@ -1,0 +1,129 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_BASE_MMIO_H_
+#define OPENTITAN_SW_DEVICE_LIB_BASE_MMIO_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * A reg32_t is an opaque handle to an MMIO register; it should only be modified
+ * using the functions provided in this header.
+ */
+typedef struct reg32 { volatile uint32_t *inner_ptr; } reg32_t;
+
+/**
+ * Create a new |reg32_t| from the given address.
+ *
+ * @param address an address to an MMIO register.
+ * @return a |reg32_t| value representing that register.
+ */
+inline reg32_t reg32_from_addr(uintptr_t address) {
+  return (reg32_t){
+      .inner_ptr = (volatile uint32_t *)address,
+  };
+}
+
+/**
+ * Reads an aligned word from the MMIO register |base| at the given byte offset.
+ *
+ * This function is guaranteed to commit a read to memory, and will not be
+ * reordered with respect to other register manipulations.
+ *
+ * @param base the register to read from.
+ * @param offset the offset to read at, in bytes.
+ * @return the read word.
+ */
+inline uint32_t reg32_read(reg32_t base, ptrdiff_t offset) {
+  return base.inner_ptr[offset / sizeof(uint32_t)];
+}
+
+/**
+ * Writes an aligned word to the MMIO register |base| at the given byte offset.
+ *
+ * This function is guaranteed to commit a write to memory, and will not be
+ * reordered with respect to other register manipulations.
+ *
+ * @param base the register to write to.
+ * @param offset the offset to write at, in bytes.
+ * @param value the word to write.
+ */
+inline void reg32_write(reg32_t base, ptrdiff_t offset, uint32_t value) {
+  base.inner_ptr[offset / sizeof(uint32_t)] = value;
+}
+
+/**
+ * Clears the bits in |mask| from the MMIO register |base| at the given offset.
+ *
+ * This function has the same guarantees as |reg32_read()| and |reg32_write()|.
+ *
+ * @param base the register to mask.
+ * @param offset the offset to apply the mask at, in bytes.
+ * @param mask the mask to clear from the selected register.
+ */
+inline void reg32_clear_mask(reg32_t base, ptrdiff_t offset, uint32_t mask) {
+  uint32_t value = reg32_read(base, offset);
+  value &= ~mask;
+  reg32_write(base, offset, value);
+}
+
+/**
+ * Sets the bits in |mask| from the MMIO register |base| at the given offset.
+ *
+ * This function has the same guarantees as |reg32_read()| and |reg32_write()|.
+ *
+ * @param base the register to mask.
+ * @param offset the offset to apply the mask at, in bytes.
+ * @param mask the mask to set on the selected register.
+ */
+inline void reg32_set_mask(reg32_t base, ptrdiff_t offset, uint32_t mask) {
+  uint32_t value = reg32_read(base, offset);
+  value |= mask;
+  reg32_write(base, offset, value);
+}
+
+/**
+ * Checks whether the |bit_index|th bit is set in the MMIO register |base| at
+ * the given offset.
+ *
+ * This function has the same guarantees as |reg32_read()| and |reg32_write()|.
+ *
+ * @param base the register to mask.
+ * @param offset the offset to apply the mask at.
+ * @param bit_index the bit to check.
+ */
+inline bool reg32_get_bit(reg32_t base, ptrdiff_t offset, uint32_t bit_index) {
+  return (reg32_read(base, offset) >> bit_index) & 0x1;
+}
+
+/**
+ * Clears the |bit_index|th bit in the MMIO register |base| at the given offset.
+ *
+ * This function has the same guarantees as |reg32_read()| and |reg32_write()|.
+ *
+ * @param base the register to mask.
+ * @param offset the offset to apply the mask at.
+ * @param bit_index the bit to clear.
+ */
+inline void reg32_clear_bit(reg32_t base, ptrdiff_t offset,
+                            uint32_t bit_index) {
+  reg32_clear_mask(base, offset, 0x1 << bit_index);
+}
+
+/**
+ * Sets the |bit_index|th bit in the MMIO register |base| at the given offset.
+ *
+ * This function has the same guarantees as |reg32_read()| and |reg32_write()|.
+ *
+ * @param base the register to mask.
+ * @param offset the offset to apply the mask at.
+ * @param bit_index the bit to set.
+ */
+inline void reg32_set_bit(reg32_t base, ptrdiff_t offset, uint32_t bit_index) {
+  reg32_set_mask(base, offset, 0x1 << bit_index);
+}
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_BASE_MMIO_H_

--- a/sw/device/lib/dif/dif_spi_device.c
+++ b/sw/device/lib/dif/dif_spi_device.c
@@ -1,0 +1,290 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/dif/dif_spi_device.h"
+
+#include "spi_device_regs.h"  // Generated.
+
+// This is a hack to get the SPI offsets out of regs.h.
+// DO NOT MERGE.
+#define SPI_DEVICE0_BASE_ADDR 0x0
+#define SPI_DEVICE_CONTROL_REG SPI_DEVICE_CONTROL(0)
+#define SPI_DEVICE_CFG_REG SPI_DEVICE_CFG(0)
+#define SPI_DEVICE_RXF_ADDR_REG SPI_DEVICE_RXF_ADDR(0)
+#define SPI_DEVICE_TXF_ADDR_REG SPI_DEVICE_TXF_ADDR(0)
+
+#define SPI_DEVICE_RXF_PTR_REG SPI_DEVICE_RXF_PTR(0)
+#define SPI_DEVICE_TXF_PTR_REG SPI_DEVICE_TXF_PTR(0)
+
+#define SPI_DEVICE_BUFFER_REG SPI_DEVICE_BUFFER(0)
+
+// Converts a FIFO pointer into an offset from a base register address.
+// To convert a FIFO pointer, one must:
+// - Remove the phase bit, and the least significant two bits (so that it is
+//   word-aligned).
+// - Use that as an offset from the respective RXF/TXF buffer, with itself is
+//   offset from the SPI device's shared buffer.
+//
+// The resulting formula, when used as an offset in |reg32_read()| or
+// |reg32_write()|, is
+//   base_addr + spi_buffer_offset +
+//   (rx/tx)_buffer_offset + align(ptr_value, 4).
+#define SPI_DEVICE_RXF_OFFSET(ptr) \
+  (SPI_DEVICE_BUFFER_REG + SPI_DEVICE_RXF_BASE + ((ptr)&VALUE_MASK & ~0b11))
+#define SPI_DEVICE_TXF_OFFSET(ptr) \
+  (SPI_DEVICE_BUFFER_REG + SPI_DEVICE_TXF_BASE + ((ptr)&VALUE_MASK & ~0b11))
+
+// RX FIFO SRAM range, given as an inclusive, word-aligned byte range.
+// |SPI_DEVICE_RXF_SIZE| is the number of bytes in this range.
+#define SPI_DEVICE_RXF_BASE 0x000
+#define SPI_DEVICE_RXF_END 0x3ff
+#define SPI_DEVICE_RXF_SIZE (SPI_DEVICE_RXF_END - SPI_DEVICE_RXF_BASE + 1)
+
+// TX FIFO SRAM range, given as an inclusive, word-aligned byte range.
+// |SPI_DEVICE_TXF_SIZE| is the number of bytes in this range.
+#define SPI_DEVICE_TXF_BASE 0x600
+#define SPI_DEVICE_TXF_END 0x7ff
+#define SPI_DEVICE_TXF_SIZE (SPI_DEVICE_TXF_END - SPI_DEVICE_TXF_BASE + 1)
+
+// Masks off the "phase" bit from a FIFO pointer. The phase bit is used to track
+// whether a pair of pointers in a ring buffer are leading or trailing each
+// other; when the phase is different, the valid area wraps around past the end
+// of the buffer.
+//
+// See |fifo_depth()| for more information.
+#define PHASE_MASK (SPI_DEVICE_BUFFER_SIZE_BYTES)
+
+// Masks off the "value" bits from a FIFO. The value bits are actual offsets
+// within the FIFO buffer.
+#define VALUE_MASK (SPI_DEVICE_BUFFER_SIZE_BYTES - 1)
+
+void dif_spi_device_init(dif_spi_device_config_t config,
+                         dif_spi_device_t *spi_out) {
+  // Reset the abort bit, to cause the SPI device to trash all pending
+  // sends/recvs.
+  reg32_clear_bit(config.base_addr, SPI_DEVICE_CONTROL_REG,
+                  SPI_DEVICE_CONTROL_ABORT);
+
+  uint32_t device_config = 0;
+  // Set clock polarity to positive-edge latch.
+  device_config |= 0x0 << SPI_DEVICE_CFG_CPOL;
+  // Set data phase to negative-edge change.
+  device_config |= 0x0 << SPI_DEVICE_CFG_CPHA;
+  // Set TX order to MSB-to-LSB.
+  device_config |= 0x0 << SPI_DEVICE_CFG_TX_ORDER;
+  // Set RX order to MSB-to-LSB.
+  device_config |= 0x0 << SPI_DEVICE_CFG_RX_ORDER;
+  // Set the RXF to tick every 63 clock edges.
+  device_config |=
+      0x7f & SPI_DEVICE_CFG_TIMER_V_MASK << SPI_DEVICE_CFG_TIMER_V_OFFSET;
+  reg32_write(config.base_addr, SPI_DEVICE_CFG_REG, device_config);
+
+  // Set up the range of the RXF region, inclusive.
+  uint32_t rxf_addr = 0;
+  rxf_addr |= (SPI_DEVICE_RXF_BASE & SPI_DEVICE_RXF_ADDR_BASE_MASK)
+              << SPI_DEVICE_RXF_ADDR_BASE_OFFSET;
+  rxf_addr |= (SPI_DEVICE_RXF_END & SPI_DEVICE_RXF_ADDR_LIMIT_MASK)
+              << SPI_DEVICE_RXF_ADDR_LIMIT_OFFSET;
+  reg32_write(config.base_addr, SPI_DEVICE_RXF_ADDR_REG, rxf_addr);
+
+  // Set up the range of the TXF region, inclusive.
+  uint32_t txf_addr = 0;
+  txf_addr |= (SPI_DEVICE_TXF_BASE & SPI_DEVICE_TXF_ADDR_BASE_MASK)
+              << SPI_DEVICE_TXF_ADDR_BASE_OFFSET;
+  txf_addr |= (SPI_DEVICE_TXF_END & SPI_DEVICE_TXF_ADDR_LIMIT_MASK)
+              << SPI_DEVICE_TXF_ADDR_LIMIT_OFFSET;
+  reg32_write(config.base_addr, SPI_DEVICE_TXF_ADDR_REG, txf_addr);
+
+  spi_out->base_addr = config.base_addr;
+}
+
+/**
+ * Calculates the *depth*, or bytes-in-use of a SPI FIFO (which is implemented
+ * as a ring buffer).
+ *
+ * If the read/write pointers are in-phase, this is just their difference; if
+ * they're out-of-phase, one of the pointers has "wrapped around", so there is
+ * an additional FIFO's worth of data pending.
+ */
+static size_t fifo_depth(uint32_t write_addr, uint32_t read_addr,
+                                size_t fifo_len) {
+  uint32_t write_phase = write_addr & PHASE_MASK;
+  uint32_t read_phase = read_addr & PHASE_MASK;
+  uint32_t write_ptr_val = write_addr & VALUE_MASK;
+  uint32_t read_ptr_val = read_addr & VALUE_MASK;
+
+  // This represents the case where the valid data of the fifo is "inclusive",
+  // i.e., the buffer looks like (where a / represents valid data):
+  // [ /////       ]
+  //   ^    ^
+  //   read write
+  if (write_phase == read_phase) {
+    return write_ptr_val - read_ptr_val;
+  }
+
+  // This represents the case where the valid data of the fifo is "exclusive",
+  // i.e., the buffer looks like (where a / represents valid data):
+  // [/      //////]
+  //   ^     ^
+  //   write read
+  return fifo_len - (read_ptr_val - write_ptr_val);
+}
+
+/**
+ * Increments the FIFO address pointed to by |addr| by |increment|.
+ *
+ * If the pointer would wrap around the FIFO buffer, it gets wrapped and the
+ * phase bit is flipped, since this causes the FIFO to switch between
+ * "inclusive" and "exclusive" modes (see |fifo_depth()| above).
+ *
+ * A fifo pointer can be approximated by a 12-bit sign-and-magnitude integer.
+ */
+static void fifo_increment(uint32_t *addr, uint32_t increment,
+                                  size_t fifo_len) {
+  uint32_t phase_bit = *addr & PHASE_MASK;
+  uint32_t inc_ptr = (*addr & VALUE_MASK) + increment;
+
+  // If we would overflow, wrap and flip the sign bit.
+  if (inc_ptr >= fifo_len) {
+    inc_ptr = (inc_ptr - fifo_len) & VALUE_MASK;
+    phase_bit = ~phase_bit & PHASE_MASK;
+  }
+
+  *addr = inc_ptr | phase_bit;
+}
+
+#define IS_WORD_ALIGNED(addr) (((uintptr_t)(addr)&0b11) == 0)
+
+size_t dif_spi_device_send(const dif_spi_device_t *spi, const void *data,
+                           size_t len) {
+  uint32_t txf_ptr = reg32_read(spi->base_addr, SPI_DEVICE_TXF_PTR_REG);
+  uint32_t txf_write_addr = (txf_ptr >> SPI_DEVICE_TXF_PTR_WPTR_OFFSET) &
+                            SPI_DEVICE_TXF_PTR_WPTR_MASK;
+  uint32_t txf_read_addr = (txf_ptr >> SPI_DEVICE_TXF_PTR_RPTR_OFFSET) &
+                           SPI_DEVICE_TXF_PTR_RPTR_MASK;
+
+  size_t fifo_in_use_len =
+      fifo_depth(txf_write_addr, txf_read_addr, SPI_DEVICE_TXF_SIZE);
+  size_t space_left = SPI_DEVICE_TXF_SIZE - fifo_in_use_len - sizeof(uint32_t);
+
+  size_t message_len;
+  if (len < space_left) {
+    message_len = len;
+  } else {
+    message_len = space_left;
+  }
+
+  size_t bytes_left = message_len;
+
+  // First, bring txf_write into word-alignment, so we can do full-word writes.
+  if (!IS_WORD_ALIGNED(txf_write_addr)) {
+    // Pull off the sub-word indexing in txf_write_addr.
+    size_t misalignment = txf_write_addr & (sizeof(uint32_t) - 1);
+    size_t needed_bytes = sizeof(uint32_t) - misalignment;
+    if (needed_bytes > bytes_left) {
+      needed_bytes = bytes_left;
+    }
+
+    uint32_t value =
+        reg32_read(spi->base_addr, SPI_DEVICE_TXF_OFFSET(txf_write_addr));
+    __builtin_memcpy(((uint8_t *)&value) + misalignment, data, needed_bytes);
+    reg32_write(spi->base_addr, SPI_DEVICE_TXF_OFFSET(txf_write_addr), value);
+
+    fifo_increment(&txf_write_addr, needed_bytes, SPI_DEVICE_TXF_SIZE);
+    data += needed_bytes;
+    bytes_left -= needed_bytes;
+  }
+
+  // Now we can treat txf_write_addr as being word-aligned, assuming we have
+  // data left to write.
+  while (bytes_left != 0) {
+    size_t bytes_to_copy =
+        bytes_left < sizeof(uint32_t) ? bytes_left : sizeof(uint32_t);
+
+    uint32_t value = 0;
+    __builtin_memcpy(&value, data, bytes_to_copy);
+    reg32_write(spi->base_addr, SPI_DEVICE_TXF_OFFSET(txf_write_addr), value);
+
+    fifo_increment(&txf_write_addr, bytes_to_copy, SPI_DEVICE_TXF_SIZE);
+    data += bytes_to_copy;
+    bytes_left -= bytes_to_copy;
+  }
+
+  // Write the new positions of the FIFO pointers to the pointer register.
+  uint32_t new_txf_ptr = 0;
+  new_txf_ptr |= txf_write_addr << SPI_DEVICE_TXF_PTR_WPTR_OFFSET;
+  new_txf_ptr |= txf_read_addr << SPI_DEVICE_TXF_PTR_RPTR_OFFSET;
+  reg32_write(spi->base_addr, SPI_DEVICE_TXF_PTR_REG, new_txf_ptr);
+
+  return message_len;
+}
+
+size_t dif_spi_device_recv(const dif_spi_device_t *spi, void *buf, size_t len) {
+  uint32_t rxf_ptr = reg32_read(spi->base_addr, SPI_DEVICE_RXF_PTR_REG);
+  uint32_t rxf_write_addr = (rxf_ptr >> SPI_DEVICE_RXF_PTR_WPTR_OFFSET) &
+                            SPI_DEVICE_RXF_PTR_WPTR_MASK;
+  uint32_t rxf_read_addr = (rxf_ptr >> SPI_DEVICE_RXF_PTR_RPTR_OFFSET) &
+                           SPI_DEVICE_RXF_PTR_RPTR_MASK;
+
+  size_t fifo_in_use_len =
+      fifo_depth(rxf_write_addr, rxf_read_addr, SPI_DEVICE_RXF_SIZE);
+
+  if (fifo_in_use_len == 0) {
+    return 0;
+  }
+
+  size_t message_len = fifo_in_use_len > len ? len : fifo_in_use_len;
+  size_t bytes_left = message_len;
+
+  // First, bring rxf_read into word alignment, so that we can do full-word
+  // reads later.
+  if (!IS_WORD_ALIGNED(rxf_read_addr)) {
+    size_t misalignment = rxf_read_addr & 0b11;
+    size_t needed_bytes = sizeof(uint32_t) - misalignment;
+    if (needed_bytes > bytes_left) {
+      needed_bytes = bytes_left;
+    }
+
+    uint32_t value =
+        reg32_read(spi->base_addr, SPI_DEVICE_RXF_OFFSET(rxf_read_addr));
+    __builtin_memcpy(buf, ((char *)&value) + misalignment, needed_bytes);
+
+    fifo_increment(&rxf_write_addr, needed_bytes, SPI_DEVICE_RXF_SIZE);
+    buf += needed_bytes;
+    bytes_left -= needed_bytes;
+  }
+
+  // Now we can just treat rxf_read as being word-aligned, if we still have data
+  // left.
+  while (bytes_left != 0) {
+    size_t bytes_to_copy =
+        bytes_left < sizeof(uint32_t) ? bytes_left : sizeof(uint32_t);
+
+    uint32_t value =
+        reg32_read(spi->base_addr, SPI_DEVICE_RXF_OFFSET(rxf_read_addr));
+    __builtin_memcpy(buf, &value, bytes_to_copy);
+
+    fifo_increment(&rxf_write_addr, bytes_to_copy, SPI_DEVICE_TXF_SIZE);
+    buf += bytes_to_copy;
+    bytes_left -= bytes_to_copy;
+  }
+
+  // Set the new positions of the FIFO pointers.
+  uint32_t new_rxf_ptr = 0;
+  new_rxf_ptr |= rxf_write_addr << SPI_DEVICE_RXF_PTR_WPTR_OFFSET;
+  new_rxf_ptr |= rxf_read_addr << SPI_DEVICE_RXF_PTR_RPTR_OFFSET;
+  reg32_write(spi->base_addr, SPI_DEVICE_RXF_PTR_REG, new_rxf_ptr);
+
+  return message_len;
+}
+
+size_t dif_spi_device_bytes_pending(const dif_spi_device_t *spi) {
+  uint32_t rxf_ptr = reg32_read(spi->base_addr, SPI_DEVICE_RXF_PTR_REG);
+  uint32_t rxf_write_addr = (rxf_ptr >> SPI_DEVICE_RXF_PTR_WPTR_OFFSET) &
+                            SPI_DEVICE_RXF_PTR_WPTR_MASK;
+  uint32_t rxf_read_addr = (rxf_ptr >> SPI_DEVICE_RXF_PTR_RPTR_OFFSET) &
+                           SPI_DEVICE_RXF_PTR_RPTR_MASK;
+
+  return fifo_depth(rxf_write_addr, rxf_read_addr, SPI_DEVICE_RXF_SIZE);
+}

--- a/sw/device/lib/dif/dif_spi_device.h
+++ b/sw/device/lib/dif/dif_spi_device.h
@@ -1,0 +1,85 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_DIF_SPI_DEVICE_H_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_DIF_SPI_DEVICE_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/mmio.h"
+
+/**
+ * Configuration for initializing a SPI device.
+ */
+typedef struct dif_spi_device_config {
+  reg32_t base_addr;
+} dif_spi_device_config_t;
+
+/**
+ * State for a particular SPI device.
+ *
+ * Its member variables should be considered private, and are only provided so
+ * that callers can allocate it.
+ */
+typedef struct dif_spi_device { reg32_t base_addr; } dif_spi_device_t;
+
+/**
+ * Initializes the SPI device described by |config|, writing internal state to
+ * |spi_out|.
+ *
+ * This function *must* be called on a particular |reg32_t| before calling any
+ * other functions in this header with that |reg32_t|; moreover, it *may not*
+ * be called more than once with any |reg32_t|. All deviations are Undefined
+ * Behavior.
+ *
+ * @param config configuration supplied for initializing a particular device.
+ * @param spi_out the location at which to write SPI state; this location must
+ *                be valid to write to.
+ */
+void dif_spi_device_init(dif_spi_device_config_t config,
+                         dif_spi_device_t *spi_out);
+
+/**
+ * Attempts to send |len| bytes from the buffer pointed to by |data| over the
+ * initialized SPI device at |spi|.
+ *
+ * |data| *must* point to a buffer of at least |len| bytes of initialized data;
+ * not doing so is Undefined Behavior.
+ *
+ * @param spi the SPI device to send to.
+ * @param data a contiguous buffer to copy from.
+ * @param len the length of the buffer |data| points to.
+ * @return the number of bytes actually sent.
+ */
+size_t dif_spi_device_send(const dif_spi_device_t *spi, const void *data,
+                           size_t len);
+
+/**
+ * Attempts to recieve |len| bytes over the SPI device at |spi|, which
+ * will be written to the buffer pointed to by |data|.
+ *
+ * |data| *must* point to a buffer of at least |len| bytes of allocated data,
+ * which may be uninitialized; not doing so is Undefined Behavior.
+ *
+ * After this function returns, the first |len| bytes pointed to by |buf| will
+ * be in an initialized state. This function will never read from |buf|.
+ *
+ * @param spi the SPI device to send to.
+ * @param buf a contiguous, possibly uninitialized buffer to write to.
+ * @param len the length of the buffer |data| points to.
+ * @return the number of bytes actually recieved.
+ */
+size_t dif_spi_device_recv(const dif_spi_device_t *spi, void *buf, size_t len);
+
+/**
+ * Retrieves the number of bytes that would be returned if |spi_device_recv| was
+ * called with a buffer of infinite length on the SPI device at |spi|.
+ *
+ * @param spi the SPI device to send to.
+ * @return the number of bytes that could potentially be read.
+ */
+size_t dif_spi_device_bytes_pending(const dif_spi_device_t *spi);
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_DIF_SPI_DEVICE_H_

--- a/sw/device/lib/dif/dif_spi_device.h
+++ b/sw/device/lib/dif/dif_spi_device.h
@@ -8,6 +8,10 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef MOCK_MMIO
+#include "sw/device/lib/dif/testing/mock_mmio.h"
+#endif  // MOCK_MMIO
+
 #include "sw/device/lib/base/mmio.h"
 
 /**

--- a/sw/device/lib/dif/dif_spi_device_test.cc
+++ b/sw/device/lib/dif/dif_spi_device_test.cc
@@ -1,0 +1,39 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+extern "C" {
+#include "sw/device/lib/dif/dif_spi_device.h"
+}
+
+#include "sw/device/lib/dif/testing/fixture.h"
+#include "sw/device/lib/dif/testing/mock_mmio.h"
+
+using dif_test::AccessType;
+using dif_test::DifTest;
+using dif_test::MockDevice;
+
+bool _ = DifTest::NewTest("SmokeCheck", [] {
+  MockDevice device{{
+      {AccessType::kRead, 0x0000000c, 0xffffffff},
+      {AccessType::kWrite, 0x0000000c, 0xfffffffe},
+      {AccessType::kWrite, 0x00000010, 0x00000000},
+      {AccessType::kWrite, 0x00000028, 0x03ff0000},
+      {AccessType::kWrite, 0x0000002c, 0x07ff0600},
+
+      {AccessType::kRead, 0x00000000, 0x00000000},
+      {AccessType::kRead, 0x00000000, 0x00000000},
+      {AccessType::kWrite, 0x00000000, 0x00000000},
+      {AccessType::kWrite, 0x00000000, 0x00000000},
+      {AccessType::kWrite, 0x00000000, 0x00000000},
+  }};
+  dif_spi_device_config_t conf{&device};
+  dif_spi_device_t spi;
+
+  dif_spi_device_init(conf, &spi);
+  dif_spi_device_send(&spi, "xyz", 3);
+
+  return device;
+});
+
+int main() { return DifTest::RunAll(); }

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -2,6 +2,8 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+subdir('testing')
+
 # SPI device DIF library
 sw_dif_spi_device = declare_dependency(
   link_with: static_library(
@@ -11,5 +13,24 @@ sw_dif_spi_device = declare_dependency(
       'dif_spi_device.c',
     ],
     dependencies: [sw_lib_mmio],
+  )
+)
+
+test(
+  'sw_dif_spi_device_test_test',
+  executable(
+    'sw_dif_spi_device_test',
+    sources: [
+      hw_ip_spi_device_reg_h,
+      'dif_spi_device.c',
+      'dif_spi_device_test.cc',
+    ],
+    dependencies: [
+      sw_dif_testing_fixture,
+      sw_dif_testing_mock_mmio,
+    ],
+    native: true,
+    c_args: ['-DMOCK_MMIO=1'],
+    cpp_args: ['-DMOCK_MMIO=1'],
   )
 )

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -1,0 +1,15 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# SPI device DIF library
+sw_dif_spi_device = declare_dependency(
+  link_with: static_library(
+    'sw_dif_spi_device',
+    sources: [
+      hw_ip_spi_device_reg_h,
+      'dif_spi_device.c',
+    ],
+    dependencies: [sw_lib_mmio],
+  )
+)

--- a/sw/device/lib/dif/testing/fixture.cc
+++ b/sw/device/lib/dif/testing/fixture.cc
@@ -1,0 +1,31 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/dif/testing/fixture.h"
+
+#include <cstdio>
+#include <vector>
+
+namespace dif_test {
+int DifTest::RunAll() {
+  int exit_val = 0;
+  for (auto &test : *AllTests()) {
+    std::printf("Running %s...\n", test.name_.c_str());
+    auto result = test.test_();
+    if (result.failed_expectations == 0) {
+      std::printf("Passed!\n");
+      continue;
+    }
+    exit_val = 1;
+    std::printf("Failed with %zu assertion failures\n",
+                result.failed_expectations);
+  }
+  return exit_val;
+}
+
+std::vector<DifTest> *DifTest::AllTests() {
+  static std::vector<DifTest> tests;
+  return &tests;
+}
+}  // namespace dif_test

--- a/sw/device/lib/dif/testing/fixture.h
+++ b/sw/device/lib/dif/testing/fixture.h
@@ -1,0 +1,35 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_TESTING_FIXTURE_H_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_TESTING_FIXTURE_H_
+
+#include <string>
+#include <vector>
+
+#include "sw/device/lib/dif/testing/mock_mmio.h"
+
+namespace dif_test {
+class DifTest {
+ public:
+  template <typename F>
+  static bool NewTest(std::string name, F test) {
+    DifTest new_test(name, test);
+    AllTests()->push_back(new_test);
+    return true;
+  }
+
+  static int RunAll();
+
+ private:
+  template <typename F>
+  DifTest(std::string name, F test) : name_(name), test_(test) {}
+  static std::vector<DifTest> *AllTests();
+
+  std::string name_;
+  MockDevice (*test_)();
+};
+}  // namespace dif_test
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_TESTING_FIXTURE_H_

--- a/sw/device/lib/dif/testing/meson.build
+++ b/sw/device/lib/dif/testing/meson.build
@@ -1,0 +1,23 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+sw_dif_testing_mock_mmio = declare_dependency(
+  link_with: static_library(
+    'sw_dif_testing_mock_mmio',
+    sources: [
+      'mock_mmio.cc',
+      'mmio_externs.c',
+    ],
+    native: true,
+  ),
+)
+
+sw_dif_testing_fixture = declare_dependency(
+  link_with: static_library(
+    'sw_dif_testing_fixture',
+    sources: ['fixture.cc'],
+    c_args: ['-DMOCK_MMIO'],
+    native: true,
+  ),
+)

--- a/sw/device/lib/dif/testing/mmio_externs.c
+++ b/sw/device/lib/dif/testing/mmio_externs.c
@@ -1,0 +1,16 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/dif/testing/mock_mmio.h"
+
+#define MOCK_MMIO
+#include "sw/device/lib/base/mmio.h"
+
+// |extern| declarations to give the inline functions in the
+// corresponding header a link location.
+extern void reg32_clear_mask(reg32_t, ptrdiff_t, uint32_t);
+extern void reg32_set_mask(reg32_t, ptrdiff_t, uint32_t);
+extern bool reg32_get_bit(reg32_t, ptrdiff_t, uint32_t);
+extern void reg32_clear_bit(reg32_t, ptrdiff_t, uint32_t);
+extern void reg32_set_bit(reg32_t, ptrdiff_t, uint32_t);

--- a/sw/device/lib/dif/testing/mock_mmio.cc
+++ b/sw/device/lib/dif/testing/mock_mmio.cc
@@ -1,0 +1,62 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/dif/testing/mock_mmio.h"
+
+#include <cstdio>
+
+using dif_test::AccessType;
+
+extern "C" uint32_t reg32_read(reg32_t base, ptrdiff_t offset) {
+  auto index = base->current_action_index;
+  if (index >= base->expected_actions.size()) {
+    std::printf("Attempted to execute superfluous read.\n");
+    ++base->failed_expectations;
+    ++base->current_action_index;
+    return 0xffffffff;
+  }
+
+  auto expected = base->expected_actions[index];
+  ++base->current_action_index;
+
+  if (expected.kind == AccessType::kRead && expected.offset == offset) {
+    return expected.value;
+  }
+
+  const char *type_name = expected.kind == AccessType::kRead ? "read" : "write";
+  std::printf("Mismatch at action #%zu:\n", index);
+  std::printf("* Expected: %s at 0x%.8tx, with value 0x%.8x.\n", type_name,
+              expected.offset, expected.value);
+  std::printf("* Got: read at 0x%.8tx.\n", offset);
+  ++base->failed_expectations;
+
+  return 0xffffffff;
+}
+
+extern "C" void reg32_write(reg32_t base, ptrdiff_t offset, uint32_t value) {
+  auto index = base->current_action_index;
+  if (index >= base->expected_actions.size()) {
+    std::printf("Attempted to execute superfluous write.\n");
+    ++base->failed_expectations;
+    ++base->current_action_index;
+    return;
+  }
+
+  auto expected = base->expected_actions[index];
+  ++base->current_action_index;
+
+  if (expected.kind == AccessType::kWrite && expected.offset == offset &&
+      expected.value == value) {
+    return;
+  }
+
+  const char *type_name = expected.kind == AccessType::kRead ? "read" : "write";
+  std::printf("Mismatch at action #%zu:\n", index);
+  std::printf("* Expected: %s at 0x%.8tx, with value 0x%.8x.\n", type_name,
+              expected.offset, expected.value);
+  std::printf("* Got: write at 0x%.8tx, with value 0x%.8x\n.", offset, value);
+  ++base->failed_expectations;
+
+  return;
+}

--- a/sw/device/lib/dif/testing/mock_mmio.h
+++ b/sw/device/lib/dif/testing/mock_mmio.h
@@ -1,0 +1,51 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_TESTING_MOCK_MMIO_H_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_TESTING_MOCK_MMIO_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C++" {
+#include <vector>
+namespace dif_test {
+
+enum class AccessType { kRead, kWrite };
+
+struct VolatileAction {
+  AccessType kind;
+  ptrdiff_t offset;
+  uint32_t value;
+};
+
+struct MockDevice {
+  std::vector<VolatileAction> expected_actions;
+
+  size_t current_action_index;
+  size_t failed_expectations;
+};
+
+}  // namespace dif_test
+
+typedef dif_test::MockDevice *reg32_t;
+
+}  // extern "C++"
+extern "C" {
+#endif  // __cplusplus
+
+#ifndef __cplusplus
+typedef void *reg32_t;
+#endif  // __cplusplus
+
+uint32_t reg32_read(reg32_t base, ptrdiff_t offset);
+
+void reg32_write(reg32_t base, ptrdiff_t offset, uint32_t value);
+
+#ifdef __cplusplus
+}  // extern C
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_TESTING_MOCK_MMIO_H_

--- a/sw/device/lib/meson.build
+++ b/sw/device/lib/meson.build
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 subdir('base')
+subdir('dif')
 
 # UART library (sw_lib_uart)
 sw_lib_uart = declare_dependency(
@@ -134,7 +135,10 @@ sw_lib_spi_device = declare_dependency(
     sources: [
       hw_ip_spi_device_reg_h,
       'spi_device.c',
-    ]
+    ],
+    dependencies: [
+      sw_dif_spi_device,
+    ],
   )
 )
 

--- a/sw/device/lib/spi_device.c
+++ b/sw/device/lib/spi_device.c
@@ -4,213 +4,27 @@
 
 #include "sw/device/lib/spi_device.h"
 
-#include "spi_device_regs.h"  // Generated.
-
-#include "sw/device/lib/common.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_spi_device.h"
 
 #define SPI_DEVICE0_BASE_ADDR 0x40020000
-#define SPID_SRAM_ADDR SPI_DEVICE_BUFFER(0)
-#define SPID_RXF_BASE 0x000
-#define SPID_RXF_SIZE 0x400
-#define SPID_TXF_BASE 0x600
-#define SPID_TXF_SIZE 0x200
 
-#define SPID_SRAM_SIZE (0x800)
-
-/* Note: these will correctly remove the phase bit */
-#define READ32_RXFPTR(P) \
-  REG32(SPID_SRAM_ADDR + SPID_RXF_BASE + ((P) & (SPID_RXF_SIZE - 1)))
-
-#define ACCESS32_TXFPTR(P) \
-  REG32(SPID_SRAM_ADDR + SPID_TXF_BASE + ((P) & ((SPID_TXF_SIZE - 1) & ~0x3)))
-
-uint32_t calc_depth(uint32_t wptr, uint32_t rptr, uint32_t size);
+dif_spi_device_t spi;
 
 void spid_init(void) {
-  /* Abort 0 */
-  REG32(SPI_DEVICE_CONTROL(0)) =
-      REG32(SPI_DEVICE_CONTROL(0)) & ~(1 << SPI_DEVICE_CONTROL_ABORT);
-
-  /* CPOL(0), CPHA(0), ORDERs(00), TIMER(63) */
-  REG32(SPI_DEVICE_CFG(0)) =
-      ((0 << SPI_DEVICE_CFG_CPOL) | (0 << SPI_DEVICE_CFG_CPHA) |
-       (0 << SPI_DEVICE_CFG_RX_ORDER) | (0 << SPI_DEVICE_CFG_TX_ORDER) |
-       ((63 & SPI_DEVICE_CFG_TIMER_V_MASK) << SPI_DEVICE_CFG_TIMER_V_OFFSET));
-
-  /* SRAM RXF/TXF ADDR. */
-  REG32(SPI_DEVICE_RXF_ADDR(0)) =
-      ((SPID_RXF_BASE & SPI_DEVICE_RXF_ADDR_BASE_MASK)
-       << SPI_DEVICE_RXF_ADDR_BASE_OFFSET) |
-      (((SPID_RXF_SIZE - 1) & SPI_DEVICE_RXF_ADDR_LIMIT_MASK)
-       << SPI_DEVICE_RXF_ADDR_LIMIT_OFFSET);
-
-  REG32(SPI_DEVICE_TXF_ADDR(0)) =
-      ((SPID_TXF_BASE & SPI_DEVICE_TXF_ADDR_BASE_MASK)
-       << SPI_DEVICE_TXF_ADDR_BASE_OFFSET) |
-      (((SPID_TXF_SIZE - 1) & SPI_DEVICE_TXF_ADDR_LIMIT_MASK)
-       << SPI_DEVICE_TXF_ADDR_LIMIT_OFFSET);
+  dif_spi_device_init((dif_spi_device_config_t) {
+    .base_addr = reg32_from_addr(SPI_DEVICE0_BASE_ADDR),
+  }, &spi);
 }
-
-/**
- * Calculation FIFO depth in bytes
- *
- *  Assume SRAM size is fixed (constant) given by SPI_DEVICE_BUFFER_SIZE
- *
- * Fifo pointers are in bytes
- */
-inline uint32_t calc_depth(uint32_t wptr, uint32_t rptr, uint32_t size) {
-  uint32_t depth;
-  uint32_t wptr_phase, rptr_phase, wptr_v, rptr_v;
-  wptr_phase = wptr & SPI_DEVICE_BUFFER_SIZE_BYTES;
-  rptr_phase = rptr & SPI_DEVICE_BUFFER_SIZE_BYTES;
-  wptr_v = wptr & (SPI_DEVICE_BUFFER_SIZE_BYTES - 1);
-  rptr_v = rptr & (SPI_DEVICE_BUFFER_SIZE_BYTES - 1);
-
-  if (wptr_phase == rptr_phase) {
-    depth = (wptr_v - rptr_v);
-  } else {
-    depth = size - rptr_v + wptr_v;
-  }
-
-  return depth;
-}
-
-/*
- * Increment pointer, zero and flip phase if it gets to size
- */
-uint32_t ptr_inc(uint32_t ptr, uint32_t inc, uint32_t size) {
-  uint32_t phase = ptr & SPI_DEVICE_BUFFER_SIZE_BYTES;
-  ptr = (ptr & (SPI_DEVICE_BUFFER_SIZE_BYTES - 1)) + inc;
-  if (ptr >= size) {
-    ptr -= size;
-    phase ^= SPI_DEVICE_BUFFER_SIZE_BYTES;
-  }
-  return ptr | phase;
-}
-
-static int word_aligned(void *p) { return (((int)p & 0x3) == 0); }
 
 uint32_t spid_send(void *data, uint32_t len_bytes) {
-  uint32_t txf_ptr, txf_wptr, txf_rptr;
-  uint32_t fifo_inuse_bytes;
-  uint32_t msg_length_bytes;
-
-  /* Check if TXF has enough space */
-  txf_ptr = REG32(SPI_DEVICE_TXF_PTR(0));
-  txf_wptr = (txf_ptr >> SPI_DEVICE_TXF_PTR_WPTR_OFFSET) &
-             SPI_DEVICE_TXF_PTR_WPTR_MASK;
-  txf_rptr = (txf_ptr >> SPI_DEVICE_TXF_PTR_RPTR_OFFSET) &
-             SPI_DEVICE_TXF_PTR_RPTR_MASK;
-
-  fifo_inuse_bytes = calc_depth(txf_wptr, txf_rptr, SPID_TXF_SIZE);
-
-  // Reserve the last 4 bytes in the fifo so it is always safe
-  // to write 32-bit words
-  if (len_bytes < SPID_TXF_SIZE - fifo_inuse_bytes - 4) {
-    // Safe to send all data
-    msg_length_bytes = len_bytes;
-  } else {
-    msg_length_bytes = SPID_TXF_SIZE - fifo_inuse_bytes - 4;
-  }
-  int tocopy = msg_length_bytes;
-
-  // Aligned case can just copy words
-  if (word_aligned(data) && word_aligned((void *)txf_wptr)) {
-    uint32_t *data_w = (uint32_t *)data;
-    while (tocopy > 0) {
-      ACCESS32_TXFPTR(txf_wptr) = *data_w++;
-      if (tocopy >= 4) {
-        txf_wptr = ptr_inc(txf_wptr, 4, SPID_TXF_SIZE);
-        tocopy -= 4;
-      } else {
-        txf_wptr = ptr_inc(txf_wptr, tocopy, SPID_TXF_SIZE);
-        tocopy = 0;  // tocopy -= tocopy always gives zero
-      }
-    }
-  } else {
-    // preserve data if unaligned start
-    uint8_t *data_b = (uint8_t *)data;
-    uint32_t d = ACCESS32_TXFPTR(txf_wptr);
-    while (tocopy > 0) {
-      int shift = (txf_wptr & 0x3) * 8;
-      uint32_t mask = 0xff << shift;
-      d = (d & ~mask) | (*data_b++ << shift);
-      if ((txf_wptr & 0x3) == 0x3) {
-        ACCESS32_TXFPTR(txf_wptr) = d;
-      }
-      txf_wptr = ptr_inc(txf_wptr, 1, SPID_TXF_SIZE);
-      tocopy--;
-    }
-  }
-
-  // Write pointer, requires read pointer to be RO
-  REG32(SPI_DEVICE_TXF_PTR(0)) = txf_wptr << SPI_DEVICE_TXF_PTR_WPTR_OFFSET;
-
-  return msg_length_bytes;
+  return dif_spi_device_send(&spi, data, len_bytes);
 }
 
 uint32_t spid_read_nb(void *data, uint32_t len_bytes) {
-  uint32_t rxf_ptr, rxf_wptr, rxf_rptr;
-  uint32_t msg_len_bytes;
-
-  rxf_ptr = REG32(SPI_DEVICE_RXF_PTR(0));
-  rxf_wptr = (rxf_ptr >> SPI_DEVICE_RXF_PTR_WPTR_OFFSET) &
-             SPI_DEVICE_RXF_PTR_WPTR_MASK;
-  rxf_rptr = (rxf_ptr >> SPI_DEVICE_RXF_PTR_RPTR_OFFSET) &
-             SPI_DEVICE_RXF_PTR_RPTR_MASK;
-
-  msg_len_bytes = calc_depth(rxf_wptr, rxf_rptr, SPID_RXF_SIZE);
-  if (msg_len_bytes == 0) {
-    return 0;
-  }
-  /* Check there is room for the whole buffer */
-  if (msg_len_bytes > len_bytes) {
-    msg_len_bytes = len_bytes;
-  }
-
-  int tocopy = msg_len_bytes;
-  // Aligned case  -- which for now it always will be
-  // if tocopy is not multiple of 4 then will read / write extra bytes
-  // so check buffer length
-  if (word_aligned(data) && ((len_bytes & 0x3) == 0) &&
-      word_aligned((void *)rxf_ptr)) {
-    uint32_t *data_w = (uint32_t *)data;
-    while (tocopy > 0) {
-      *data_w++ = READ32_RXFPTR(rxf_rptr);
-      if (tocopy >= 4) {
-        rxf_rptr = ptr_inc(rxf_rptr, 4, SPID_RXF_SIZE);
-        tocopy -= 4;
-      } else {
-        rxf_rptr = ptr_inc(rxf_rptr, tocopy, SPID_RXF_SIZE);
-        tocopy = 0;  // tocopy -= tocopy always gives zero
-      }
-    }
-  } else {
-    uint8_t *data_b = (uint8_t *)data;
-    // Have to deal with only being able to do 32-bit accesses
-    int dst = 0;
-    uint32_t d = READ32_RXFPTR(rxf_rptr & ~0x3);
-    while (tocopy--) {
-      int boff = rxf_rptr & 0x3;
-      data_b[dst++] = (d >> (boff * 8)) & 0xff;
-      rxf_rptr = ptr_inc(rxf_rptr, 1, SPID_RXF_SIZE);
-      if (((rxf_rptr & 0x3) == 0) && tocopy) {
-        d = READ32_RXFPTR(rxf_rptr);
-      }
-    }
-  }
-  /* Update read pointer -- NB relies on write pointer being RO */
-  REG32(SPI_DEVICE_RXF_PTR(0)) = rxf_rptr << SPI_DEVICE_RXF_PTR_RPTR_OFFSET;
-
-  return msg_len_bytes;
+  return dif_spi_device_recv(&spi, data, len_bytes);
 }
 
 uint32_t spid_bytes_available(void) {
-  uint32_t rxf_ptr = REG32(SPI_DEVICE_RXF_PTR(0));
-  uint32_t rxf_wptr = (rxf_ptr >> SPI_DEVICE_RXF_PTR_WPTR_OFFSET) &
-                      SPI_DEVICE_RXF_PTR_WPTR_MASK;
-  uint32_t rxf_rptr = (rxf_ptr >> SPI_DEVICE_RXF_PTR_RPTR_OFFSET) &
-                      SPI_DEVICE_RXF_PTR_RPTR_MASK;
-
-  return calc_depth(rxf_wptr, rxf_rptr, SPID_RXF_SIZE);
+  return dif_spi_device_bytes_pending(&spi);
 }


### PR DESCRIPTION
This PR is more-or-less a response to https://github.com/lowRISC/opentitan/pull/1254. I discussed some options with @alphan offline and decided to write a POC for discussion purposes. This PR is essentially a patch on top of https://github.com/lowRISC/opentitan/pull/1135

I've sketched out what unit tests for DIF libraries could look like, by mocking out a physical IP block with a sequence of expected reads and writes to a device register. The DIF is handed the mock device, and read() and write() calls are transparently instrumented, so that reads and writes are checked to match the expectations set out by the test. Tests like this one do not test the silicon design; they assume that they silicon design is correct, and check that the DIF is twiddling the device registers in the expected manner.

The test in this PR produces a failure that looks roughly like this (mostly because I haven't made the effort to work out what the correct reads and writes for the SPI block should be in this case...)
```
--- command ---
/<snip>/build-out/sw/sim-verilator/sw/device/lib/dif/sw_dif_spi_device_test
--- stdout ---
Running SmokeCheck...
Mismatch at action #5:
* Expected: read at 0x00000000, with value 0x00000000.
* Got: read at 0x00000024.
Mismatch at action #6:
* Expected: read at 0x00000000, with value 0x00000000.
* Got: read at 0x000015fc.
Mismatch at action #7:
* Expected: write at 0x00000000, with value 0x00000000.
* Got: write at 0x000015fc, with value 0x78ffffff
.Mismatch at action #8:
* Expected: write at 0x00000000, with value 0x00000000.
* Got: write at 0x00001400, with value 0x00007a79
.Mismatch at action #9:
* Expected: write at 0x00000000, with value 0x00000000.
* Got: write at 0x00000024, with value 0x0c02ffff
.Failed with 5 assertion failures
-------
```

This code is intended mostly for exposition of the idea and how the alternate implementation of mmio.h could be injected; the bits that create test fixtures (like fixture.h) are not particularly relevant to the design, and is a stand-in for whatever unit testing framework we decide we'd like to use.