### PR TITLE
[dv] Fix top_earlgrey failure

### DIFF
--- a/hw/dv/sv/jtag_agent/jtag_driver.sv
+++ b/hw/dv/sv/jtag_agent/jtag_driver.sv
@@ -22,7 +22,6 @@ class jtag_driver extends dv_base_driver #(jtag_item, jtag_agent_cfg);
   virtual task reset_signals();
     if (cfg.if_mode == Host) begin
       cfg.vif.tck_en <= 1'b0;
-      cfg.vif.trst_n <= 1'b1;
       `HOST_CB.tms <= 1'b0;
       `HOST_CB.tdi <= 1'b0;
     end

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -36,8 +36,19 @@ class chip_base_vseq extends dv_base_vseq #(
     if (do_cpu_init) cpu_init();
   endtask
 
+  virtual task apply_reset(string kind = "HARD");
+    fork
+      begin
+        super.apply_reset(kind);
+      end
+      begin
+        cfg.m_jtag_agent_cfg.do_trst_n();
+      end
+    join
+  endtask
+
   virtual task dut_init(string reset_kind = "HARD");
-    super.dut_init();
+    super.dut_init(reset_kind);
     cfg.m_uart_agent_cfg.set_baud_rate(BaudRate1Mbps);
     // Initialize gpio pin default states
     cfg.gpio_vif.set_pulldown_en({chip_env_pkg::NUM_GPIOS{1'b1}});


### PR DESCRIPTION
X is propagated from dm_top due to lack of reset on jtag reset pin
Add reset at the beginning of run phase in jtag driver

Signed-off-by: Weicai Yang <weicai@google.com>