### PR TITLE
[topgen] optimize xbar size_byte to pow2

### DIFF
--- a/util/topgen/merge.py
+++ b/util/topgen/merge.py
@@ -408,18 +408,42 @@ def xbar_cross_node(node_name, device_xbar, xbars, visited=[]):
 
     visited.pop()
 
-    # TODO: simplify the result? if contiguous, combine into one?
-    return simplify_addr(result, device_xbar)
+    return result
 
 
-def simplify_addr(addrs, xbar):
-    """If any contiguous regions exist, concatenate them
+def simplify_xbar(xbars):
+    """ Simplify the address of xbar device port.
 
+    It cannot be done without fully expanded addresses.
+    So, this should be done after adding all xbar addresses.
+    """
+
+    for xbar in xbars:
+        xdev_list = [
+            x for x in xbar["nodes"] if x["type"] == "device" and x["xbar"]
+        ]
+
+        for e in xdev_list:
+            e["addr_range"] = simplify_addr(e, xbar)
+
+
+# TODO: Move to tlgen
+def simplify_addr(dev, xbar):
+    """Reduce the number of entries smaller by combining them
+
+    If any contiguous regions exist, concatenate them.
     For instance, 0x1000 ~ 0x1FFF , 0x2000~ 0x2FFF ==> 0x1000 ~ 0x2FFF
+
+    It also checks if there's no device between the gap, then merge
+    the ranges. For instance:
+
+    {0x4000_0000, 0x1_0000}, {0x4008_0000, 0x1_0000} then it combines two
+    entries into {0x4000_0000, 0x9_0000}
 
     @param addrs List of Dict[Addr] : {'base_addr':,'size_byte':}
     """
 
+    addrs = dev["addr_range"]
     # Sort based on the base addr
     newlist = sorted(addrs, key=lambda k: int(k['base_addr'], 0))
     # check if overlap or contiguous
@@ -436,11 +460,24 @@ def simplify_addr(addrs, xbar):
                 int(result[-1]["size_byte"], 0) + int(e["size_byte"], 0))
             continue
 
-        # TODO: If no other device in current xbar between the gap?
-        if no_device_in_range(xbar, result[-1], e):
-            result[-1]["size_byte"] = "0x{:x}".format(
-                int(e["base_addr"], 0) + int(e["size_byte"], 0) -
-                int(result[-1]["base_addr"], 0))
+        if no_device_in_range(xbar, dev["name"], result[-1], e):
+            # Determine if size can be power of 2 value
+            smallest_addr_gte = get_next_base_addr(e["base_addr"], xbar,
+                                                   dev["name"])
+
+            # Choose next value
+            if smallest_addr_gte == -1:
+                next_value = 0x100000000
+            else:
+                next_value = int(smallest_addr_gte["base_addr"], 0)
+
+            calc_size = int(e["base_addr"], 0) + int(e["size_byte"], 0) - int(
+                result[-1]["base_addr"], 0)
+
+            # find power of 2 if possible
+            size_byte = find_pow2_size(result[-1], calc_size, next_value)
+
+            result[-1]["size_byte"] = "0x{:x}".format(size_byte)
             continue
 
         # If overlapping (Should it be consider? TlGen will catch it)
@@ -452,13 +489,16 @@ def simplify_addr(addrs, xbar):
     return result
 
 
-def no_device_in_range(xbar, f, t):
+def no_device_in_range(xbar, name, f, t):
     """Check if other devices doesn't overlap with the from <= x < to
     """
     from_addr = int(f["base_addr"], 0) + int(f["size_byte"], 0)
     to_addr = int(t["base_addr"], 0)
 
-    for node in [x for x in xbar["nodes"] if x["type"] == "device"]:
+    for node in [
+            x for x in xbar["nodes"]
+            if x["type"] == "device" and not x["name"] == name
+    ]:
         if not "addr_range" in node:
             # Xbar?
             log.info("Xbar type node cannot be compared in this version.",
@@ -475,6 +515,81 @@ def no_device_in_range(xbar, f, t):
                 continue
             return False
     return True
+
+
+def get_next_base_addr(addr, xbar, name):
+    """Return the least value of base_addr of the IP greater than addr
+
+    """
+    if isinstance(addr, str):
+        value = int(addr, 0)
+    else:
+        assert isinstance(addr, int)
+        value = addr
+
+    device_list = [
+        x for x in xbar["nodes"]
+        if x["type"] == "device" and not x["name"] == name
+    ]
+
+    try:
+        addrs = [a for r in device_list for a in r["addr_range"]]
+    except KeyError:
+        log.error("Address range is wrong.\n {}".format(
+            [x for x in device_list if not "addr_range" in x]))
+        raise SystemExit()
+
+    sorted_list = sorted(addrs, key=lambda k: int(k["base_addr"], 0))
+
+    gte_list = [x for x in sorted_list if int(x["base_addr"], 0) > value]
+
+    if len(gte_list) == 0:
+        return -1
+
+    return gte_list[0]
+
+
+def find_pow2_size(addr, min_size, next_value):
+    """Find smallest power of 2 value greater than min_size by given addr.
+
+    For instance, (0x4000_0000, 0x21000) and `next_value` as 0x40080000,
+    the result will be 0x4_0000
+
+    But it should return result not exceeding the base_addr's leading one bit
+    position. For instance, if the base_addr is 0x4003_0000, the return value
+    should be less than or equal to 0x1_0000. Cannot be 0x4_0000.
+    """
+    base_addr = int(addr["base_addr"], 0)
+
+    diff = next_value - base_addr
+
+    # Find the least one bit position.
+    # If base_addr is 0, then any value can be used
+    if not base_addr == 0:
+        leading_one = 1
+        while True:
+            if base_addr & leading_one != 0:
+                break
+            leading_one = leading_one << 1
+
+        if leading_one <= diff:
+            diff = leading_one
+
+    i = 1
+    while True:
+        i = i << 1
+        if i >= min_size:
+            break
+
+    # If found pow2 value is greater tha diff, it cannot be used. Just use
+    # min_size then the tool will use comparators (>=, <=)
+    if i > diff:
+        i = min_size
+
+    # Shall be greater than 4kB
+    assert i >= 0x1000
+
+    return i
 
 
 def amend_interrupt(top):
@@ -664,6 +779,8 @@ def merge_top(topcfg, ipobjs, xbarobjs):
     # 2nd phase of xbar (gathering the devices address range)
     for xbar in gencfg["xbar"]:
         xbar_cross(xbar, gencfg["xbar"])
+
+    simplify_xbar(gencfg["xbar"])
 
     # remove unwanted fields 'debug_mem_base_addr'
     gencfg.pop('debug_mem_base_addr', None)


### PR DESCRIPTION

Top Gen has optimization code to find max power of 2 value of the device
size, which can create simple mask comparison in RTL. Current
top_earlgrey cannot achieve this though.
    
The topgen now does below for multiple address ranges in a device:
    
1.  It combines two contiguous address ranges.
    
    For instance, 0x0000 ~ 0x1FFF and 0x2000 ~ 0x2FFF become 0x0000 ~
    0x2FFF.
    
2.  It combines two separate ranges in a device if there's no other
    device in a gap.
    
    e.g) 0x0000 ~ 0x1FFF and 0x3000 ~ 0x3FFF are given addresses. and no
    device having 0x2000 ~ 0x2FFF in the crossbar, topgen merges the
    address range into 0x0000 ~ 0x3FFF.
    
3.  It tries to find the size which can be a power of 2. If size is a
    power of 2 value and smaller than the base address leading one
    position, the address comparison can be converted into simple
    bit-wise operation such as `addr & (~MASK) == OFFSET`.
    
    e.g) the device: 0x4000_0000 ~ 0x4002_0FFFF
         next device: 0x4008_0000 ~
   
    Then the address can be 0x4000_0000 ~ 0x4007_FFFF. the address range
    above only can be represented in RTL as below:
    
    ```systemverilog
    (addr >= 0x4000_0000) && (addr <= 0x4002_0FFFF)
    ```
    
    but with the modification:
    
    ```systemverilog
    addr & (~0x7_FFFF) == 0x4000_0000
    ```
    
    It is also important that the calculated size shouldn't exceed the
    leading one position of the base address. For instance, if the base
    address is 0x4003_0000, the maximum size that can be represented as
    a power of 2 is 0x1_0000.
