### PR TITLE
[synthesis] Several small fixes to make DC synthesis run cleanly

### DIFF
--- a/hw/formal/fpv.tcl
+++ b/hw/formal/fpv.tcl
@@ -19,8 +19,6 @@ check_cov -init -model {branch statement functional} \
 
 # only one scr file exists in this folder
 analyze -sv09                 \
-  +define+ASIC_SYNTHESIS      \
-  +define+SYNTHESIS           \
   +define+FPV_ON              \
   -f [glob *.scr]
 

--- a/hw/ip/prim/rtl/prim_filter_ctr.sv
+++ b/hw/ip/prim/rtl/prim_filter_ctr.sv
@@ -21,7 +21,7 @@ module prim_filter_ctr #(parameter Cycles = 4) (
 );
 
   localparam CTR_WIDTH = $clog2(Cycles);
-  localparam [CTR_WIDTH-1:0] CYCLESM1 = Cycles-1;
+  localparam [CTR_WIDTH-1:0] CYCLESM1 = (CTR_WIDTH)'(Cycles-1);
 
   logic [CTR_WIDTH-1:0] diff_ctr_q, diff_ctr_d;
   logic filter_q, stored_value_q, update_stored_value;

--- a/hw/ip/prim/rtl/prim_ram_2p_async_adv.sv
+++ b/hw/ip/prim/rtl/prim_ram_2p_async_adv.sv
@@ -6,7 +6,7 @@
 //   This module to connect SRAM interface to actual SRAM interface
 //   At this time, it doesn't utilize ECC or any pipeline.
 //   This module stays to include any additional calculation logic later on.
-//   Instantiating SRAM is up to the top design to remove process dependancy.
+//   Instantiating SRAM is up to the top design to remove process dependency.
 
 // Parameter
 //   EnableECC:
@@ -25,7 +25,7 @@ module prim_ram_2p_async_adv #(
   parameter bit EnableInputPipeline  = 0,
   parameter bit EnableOutputPipeline = 0,
 
-  parameter MemT = "REGISTER",
+  parameter MemT = "REGISTER", // can be "REGISTER" or "SRAM"
 
   // Do not touch
   parameter int SramAw = $clog2(Depth)
@@ -86,7 +86,8 @@ module prim_ram_2p_async_adv #(
     prim_ram_2p #(
       .Width (TotalWidth),
       .Depth (Depth),
-      .Impl  (prim_pkg::ImplGeneric)
+      // force register implementation for all targets
+      .Impl(prim_pkg::ImplGeneric)
     ) u_mem (
       .clk_a_i    (clk_a_i),
       .clk_b_i    (clk_b_i),
@@ -103,13 +104,34 @@ module prim_ram_2p_async_adv #(
       .b_wdata_i  (b_wdata_q),
       .b_rdata_o  (b_rdata_sram)
     );
-    always_ff @(posedge clk_a_i) begin
-      a_rvalid_sram <= a_req_q & ~a_write_q;
-    end
-    always_ff @(posedge clk_b_i) begin
-      b_rvalid_sram <= b_req_q & ~b_write_q;
-    end
   // end else if (TotalWidth == aa && Depth == yy) begin
+  end else if (MemT == "SRAM") begin : gen_srammem
+    prim_ram_2p #(
+      .Width (TotalWidth),
+      .Depth (Depth)
+    ) u_mem (
+      .clk_a_i    (clk_a_i),
+      .clk_b_i    (clk_b_i),
+
+      .a_req_i    (a_req_q),
+      .a_write_i  (a_write_q),
+      .a_addr_i   (a_addr_q),
+      .a_wdata_i  (a_wdata_q),
+      .a_rdata_o  (a_rdata_sram),
+
+      .b_req_i    (b_req_q),
+      .b_write_i  (b_write_q),
+      .b_addr_i   (b_addr_q),
+      .b_wdata_i  (b_wdata_q),
+      .b_rdata_o  (b_rdata_sram)
+    );
+  end
+
+  always_ff @(posedge clk_a_i) begin
+    a_rvalid_sram <= a_req_q & ~a_write_q;
+  end
+  always_ff @(posedge clk_b_i) begin
+    b_rvalid_sram <= b_req_q & ~b_write_q;
   end
 
   assign a_req_d              = a_req_i;
@@ -127,13 +149,13 @@ module prim_ram_2p_async_adv #(
   assign b_rerror_o           = b_rerror_q;
 
   // TODO: Parity Logic
-  if (EnableParity == 1) begin : gen_parity
-    initial begin
-      $fatal("Current wrapper doesn't support PARITY");
-    end
-  end
+  `ASSERT_INIT(ParityNotYetSupported_A, EnableParity == 0)
 
   if (EnableParity == 0 && EnableECC) begin : gen_secded
+
+    // check supported widths
+    `ASSERT_INIT(SecDecWidth_A, Width inside {32})
+
     if (Width == 32) begin : gen_secded_39_32
       prim_secded_39_32_enc u_enc_a (.in(a_wdata_i), .out(a_wdata_d));
       prim_secded_39_32_dec u_dec_a (
@@ -151,12 +173,6 @@ module prim_ram_2p_async_adv #(
       );
       assign a_rvalid_d = a_rvalid_sram;
       assign b_rvalid_d = b_rvalid_sram;
-    end else begin : gen_error
-    `ifndef VERILATOR
-      initial begin
-        $fatal("Current wrapper doesn't support SECDED with Width %d", Width);
-      end
-    `endif
     end
   end else begin : gen_nosecded
     assign a_wdata_d[0+:Width] = a_wdata_i;

--- a/hw/ip/prim_xilinx/rtl/prim_xilinx_rom.sv
+++ b/hw/ip/prim_xilinx/rtl/prim_xilinx_rom.sv
@@ -48,9 +48,9 @@ module prim_xilinx_rom #(
     end
   end
   `else
-    // If the ROM is not initialized it reads X for all addresses
+    // ROM is not initialized
     always_ff @(posedge clk_i) begin
-      dout_o <= 'x;
+      dout_o <= '0;
     end
   `endif
 

--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -519,8 +519,8 @@ module spi_device #(
     .EnableParity        (0),
     .EnableInputPipeline (0),
     .EnableOutputPipeline(0),
-
-    .MemT ("REGISTER")
+    // this is a large memory, implement with SRAM
+    .MemT ("SRAM")
   ) u_memory_2p (
     .clk_i,
     .rst_ni,

--- a/hw/ip/tlul/common.core
+++ b/hw/ip/tlul/common.core
@@ -8,7 +8,6 @@ description: "TL-UL common building blocks"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:dv:pins_if
       - lowrisc:prim:all
       - lowrisc:tlul:headers
     files:

--- a/hw/ip/tlul/rtl/tlul_assert.sv
+++ b/hw/ip/tlul/rtl/tlul_assert.sv
@@ -17,6 +17,7 @@ module tlul_assert #(
 );
 
 `ifndef VERILATOR
+`ifndef SYNTHESIS
 
   import tlul_pkg::*;
   import top_pkg::*;
@@ -280,5 +281,6 @@ module tlul_assert #(
   //  make sure ready is not X after reset
   `ASSERT_KNOWN(aReadyKnown_A, d2h.a_ready, clk_i, !rst_ni)
   `ASSERT_KNOWN(dReadyKnown_A, h2d.d_ready, clk_i, !rst_ni)
+`endif
 `endif
 endmodule : tlul_assert

--- a/hw/ip/usbdev/rtl/usbdev.sv
+++ b/hw/ip/usbdev/rtl/usbdev.sv
@@ -428,7 +428,8 @@ module usbdev (
     .EnableInputPipeline (0),
     .EnableOutputPipeline(0),
 
-    .MemT ("REGISTER")
+    // large memory, implement with SRAMs
+    .MemT ("SRAM")
   ) u_memory_2p (
     .clk_a_i    (clk_i),
     .clk_b_i    (clk_usb_48mhz_i),

--- a/hw/vendor/lowrisc_ibex/shared/rtl/prim_assert.sv
+++ b/hw/vendor/lowrisc_ibex/shared/rtl/prim_assert.sv
@@ -7,12 +7,11 @@
 //  - Provides boiler plate template for common assertions
 
 // TODO:
-//  - check if ASSERT_FINAL needs an `ifndef SYNTHESIS
+//  - double check whether VERILATOR and SYNTHESIS checks are really needed
 //  - should we add ASSERT_INIT_DISABLE?
-//  - can we remove pragma translate_off and ifndef VERILATOR?
 //  - should we add "pragma coverage off" and "VCS coverage off"?
 
-`ifdef UVM_PKG_SV
+`ifdef UVM
   // report assertion error with UVM if compiled
   package assert_rpt_pkg;
     import uvm_pkg::*;
@@ -28,13 +27,19 @@
 // Helper macros //
 ///////////////////
 
+// local helper macro to reduce code clutter. undefined at the end of this file
+`ifndef VERILATOR
+`ifndef SYNTHESIS
+`define INC_ASSERT
+`endif
+`endif
 
 // Converts an arbitrary block of code into a Verilog string
 `define PRIM_STRINGIFY(__x) `"__x`"
 
   // ASSERT_RPT is available to change the reporting mechanism when an assert fails
 `define ASSERT_RPT(__name, __msg)                                         \
-`ifdef UVM_PKG_SV                                                         \
+`ifdef UVM                                                                \
   assert_rpt_pkg::assert_rpt($sformatf("[%m] %s: %s (%s:%0d)",            \
                              __name, __msg, `__FILE__, `__LINE__));       \
 `else                                                                     \
@@ -48,43 +53,35 @@
 // Immediate assertion
 // Note that immediate assertions are sensitive to simulation glitches.
 `define ASSERT_I(__name, __prop)                                       \
-`ifndef VERILATOR                                                      \
-  //pragma translate_off                                               \
+`ifdef INC_ASSERT                                                      \
   __name: assert (__prop)                                              \
     else `ASSERT_RPT(`PRIM_STRINGIFY(__name), `PRIM_STRINGIFY(__prop)) \
-  //pragma translate_on                                                \
 `endif
 
 // Assertion in initial block. Can be used for things like parameter checking.
 `define ASSERT_INIT(__name, __prop)                                      \
-`ifndef VERILATOR                                                        \
-  //pragma translate_off                                                 \
+`ifdef INC_ASSERT                                                        \
   initial                                                                \
     __name: assert (__prop)                                              \
       else `ASSERT_RPT(`PRIM_STRINGIFY(__name), `PRIM_STRINGIFY(__prop)) \
-  //pragma translate_on                                                  \
 `endif
 
 // Assertion in final block. Can be used for things like queues being empty
 // at end of sim, all credits returned at end of sim, state machines in idle
 // at end of sim.
 `define ASSERT_FINAL(__name, __prop)                                         \
-`ifndef VERILATOR                                                            \
-  //pragma translate_off                                                     \
+`ifdef INC_ASSERT                                                            \
   final                                                                      \
     __name: assert (__prop || $test$plusargs("disable_assert_final_checks")) \
       else `ASSERT_RPT(`PRIM_STRINGIFY(__name), `PRIM_STRINGIFY(__prop))     \
-  //pragma translate_on                                                      \
 `endif
 
 // Assert a concurrent property directly.
 // It can be called as a module (or interface) body item.
 `define ASSERT(__name, __prop, __clk, __rst)                                     \
-`ifndef VERILATOR                                                                \
-  //pragma translate_off                                                         \
+`ifdef INC_ASSERT                                                                \
   __name: assert property (@(posedge __clk) disable iff (__rst !== '0) (__prop)) \
     else `ASSERT_RPT(`PRIM_STRINGIFY(__name), `PRIM_STRINGIFY(__prop))           \
-  //pragma translate_on                                                          \
 `endif
 // Note: Above we use (__rst !== '0) in the disable iff statements instead of
 // (__rst == '1).  This properly disables the assertion in cases when reset is X at
@@ -93,28 +90,22 @@
 
 // Assert a concurrent property NEVER happens
 `define ASSERT_NEVER(__name, __prop, __clk, __rst)                                   \
-`ifndef VERILATOR                                                                    \
-  //pragma translate_off                                                             \
+`ifdef INC_ASSERT                                                                    \
   __name: assert property (@(posedge __clk) disable iff (__rst !== '0) not (__prop)) \
     else `ASSERT_RPT(`PRIM_STRINGIFY(__name), `PRIM_STRINGIFY(__prop))               \
-  //pragma translate_on                                                              \
 `endif
 
 // Assert that signal has a known value (each bit is either '0' or '1') after reset.
 // It can be called as a module (or interface) body item.
 `define ASSERT_KNOWN(__name, __sig, __clk, __rst)   \
-`ifndef VERILATOR                                   \
-  //pragma translate_off                            \
+`ifdef INC_ASSERT                                   \
   `ASSERT(__name, !$isunknown(__sig), __clk, __rst) \
-  //pragma translate_on                             \
 `endif
 
 //  Cover a concurrent property
 `define COVER(__name, __prop, __clk, __rst)                                      \
-`ifndef VERILATOR                                                                \
-  //pragma translate_off                                                         \
+`ifdef INC_ASSERT                                                                \
   __name: cover property (@(posedge __clk) disable iff (__rst !== '0) (__prop)); \
-  //pragma translate_on                                                          \
 `endif
 
 //////////////////////////////
@@ -123,29 +114,23 @@
 
 // Assert that signal is an active-high pulse with pulse length of 1 clock cycle
 `define ASSERT_PULSE(__name, __sig, __clk, __rst)          \
-`ifndef VERILATOR                                          \
-  //pragma translate_off                                   \
+`ifdef INC_ASSERT                                          \
   `ASSERT(__name, $rose(__sig) |=> !(__sig), __clk, __rst) \
-  //pragma translate_on                                    \
 `endif
 
 // Assert that valid is known after reset and data is known when valid == 1
 `define ASSERT_VALID_DATA(__name, __valid, __dat, __clk, __rst)                  \
-`ifndef VERILATOR                                                                \
-  //pragma translate_off                                                         \
+`ifdef INC_ASSERT                                                                \
   `ASSERT_KNOWN(__name``KnownValid, __valid, __clk, __rst)                       \
   `ASSERT_NEVER(__name``KnownData, (__valid) && $isunknown(__dat), __clk, __rst) \
-  //pragma translate_on                                                          \
 `endif
 
 // Same as ASSERT_VALID_DATA, but also assert that ready is known after reset
 `define ASSERT_VALID_READY_DATA(__name, __valid, __ready, __dat, __clk, __rst)   \
-`ifndef VERILATOR                                                                \
-  //pragma translate_off                                                         \
+`ifdef INC_ASSERT                                                                \
   `ASSERT_KNOWN(__name``KnownValid, __valid, __clk, __rst)                       \
   `ASSERT_KNOWN(__name``KnownReady, __ready, __clk, __rst)                       \
   `ASSERT_NEVER(__name``KnownData, (__valid) && $isunknown(__dat), __clk, __rst) \
-  //pragma translate_on                                                          \
 `endif
 
 ///////////////////////
@@ -154,18 +139,16 @@
 
 // Assume a concurrent property
 `define ASSUME(__name, __prop, __clk, __rst)                                      \
-`ifndef VERILATOR                                                                 \
+`ifdef INC_ASSERT                                                                 \
   __name: assume property (@(posedge __clk) disable iff (__rst !== '0) (__prop))  \
      else begin `ASSERT_RPT(`PRIM_STRINGIFY(__name), `PRIM_STRINGIFY(__prop)) end \
 `endif
 
 // Assume an immediate property
 `define ASSUME_I(__name, __prop)                                       \
-`ifndef VERILATOR                                                      \
-  //pragma translate_off                                               \
+`ifdef INC_ASSERT                                                      \
   __name: assume (__prop)                                              \
     else `ASSERT_RPT(`PRIM_STRINGIFY(__name), `PRIM_STRINGIFY(__prop)) \
-  //pragma translate_on                                                \
 `endif
 
 //////////////////////////////////
@@ -195,3 +178,6 @@
 `ifdef FPV_ON                                    \
    `COVER(__name, __prop, __clk, __rst)          \
 `endif
+
+// undefine local helper macro
+`undef INC_ASSERT


### PR DESCRIPTION
This is a cleanup PR in preparation for a synopsys DC flow. In particular, this reworks the assertion macros, and adds the `SRAM` memory type to `prim_ram_2p_adv.sv` in order to avoid overly large register files.

These changes have been split out from #1235, as discussed in that PR.

Signed-off-by: Michael Schaffner <msf@opentitan.org>