### PR TITLE
Avoid broken meson version 0.53.0

### DIFF
--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -9,7 +9,9 @@ hjson
 isort
 livereload
 mako
-meson >= 0.51.0 # Matches version in meson.build
+# Meson 0.53.0 broke compatibility with Python 3.5.2, see
+# https://github.com/lowRISC/opentitan/issues/1288 for details.
+meson >= 0.51.0, < 0.53.0 # minimum matches version in meson.build
 mistletoe>=0.7.2
 pyftdi
 pygments


### PR DESCRIPTION
Error message with meson 0.53.0 in our Ubuntu 16.04/Python 3.5.1 CI
environment:

```
meson -Dtarget=sim-verilator -Dot_version=opentitan-snapshot-20191101-1-434-gb99db7f -Ddev_bin_dir=/home/vsts/work/1/a/build-bin/sw/device/sim-verilator -Dhost_bin_dir=/home/vsts/work/1/a/build-bin/sw/host --cross-file=/tmp/toolchain.dhA3HP.txt /home/vsts/work/1/a/build-out/sw/sim-verilator
Traceback (most recent call last):
  File "/usr/local/bin/meson", line 11, in <module>
    load_entry_point('meson==0.53.0', 'console_scripts', 'meson')()
  File "/usr/local/lib/python3.5/dist-packages/pkg_resources/__init__.py", line 489, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/local/lib/python3.5/dist-packages/pkg_resources/__init__.py", line 2852, in load_entry_point
    return ep.load()
  File "/usr/local/lib/python3.5/dist-packages/pkg_resources/__init__.py", line 2443, in load
    return self.resolve()
  File "/usr/local/lib/python3.5/dist-packages/pkg_resources/__init__.py", line 2449, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/usr/local/lib/python3.5/dist-packages/mesonbuild/mesonmain.py", line 25, in <module>
    from . import mconf, mdist, minit, minstall, mintro, msetup, mtest, rewriter, msubprojects, munstable_coredata
  File "/usr/local/lib/python3.5/dist-packages/mesonbuild/mconf.py", line 16, in <module>
    from . import coredata, environment, mesonlib, build, mintro, mlog
  File "/usr/local/lib/python3.5/dist-packages/mesonbuild/environment.py", line 32, in <module>
    from . import compilers
  File "/usr/local/lib/python3.5/dist-packages/mesonbuild/compilers/__init__.py", line 102, in <module>
    from .compilers import (
  File "/usr/local/lib/python3.5/dist-packages/mesonbuild/compilers/compilers.py", line 389, in <module>
    class CompilerArgs(typing.MutableSequence[str]):
  File "/usr/local/lib/python3.5/dist-packages/mesonbuild/compilers/compilers.py", line 658, in CompilerArgs
    def __eq__(self, other: typing.Any) -> typing.Union[bool, 'NotImplemented']:
    "Forward references must evaluate to types.")
  File "/usr/lib/python3.5/typing.py", line 312, in _type_check
    raise TypeError(msg + " Got %.100r." % (arg,))
TypeError: Forward references must evaluate to types. Got NotImplemented.
```

Works around #1288 for now. No upstream bug filed yet.