### PR TITLE
Change tx_empty_prev_d default to 1

### DIFF
--- a/hw/dv/sv/uart_agent/uart_agent_pkg.sv
+++ b/hw/dv/sv/uart_agent/uart_agent_pkg.sv
@@ -17,8 +17,8 @@ package uart_agent_pkg;
 
   // local types
   typedef enum bit {
-    UartTx,
-    UartRx
+    UartRx,
+    UartTx
   } uart_dir_e;
 
   typedef enum int {

--- a/hw/ip/uart/data/uart.hjson
+++ b/hw/ip/uart/data/uart.hjson
@@ -215,13 +215,14 @@
         }
         { bits: "6:5",
           name: "TXILVL",
-          desc: '''Trigger level for TX interrupts. If the FIFO depth is greater than or equal to
+          desc: '''Trigger level for TX interrupts. If the FIFO depth is less than
                 the setting, it raises tx_watermark interrupt.
                 ''',
           enum: [
             { value: "0",
               name: "txlvl1",
-              desc: "1 character"
+              desc: '''2 characters.  This is different from RXLVL because 1 character is the same
+                     as empty and there is already an existing interrupt for that purpose'''
             },
             { value: "1",
               name: "txlvl4",

--- a/hw/ip/uart/dv/env/seq_lib/uart_intr_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_intr_vseq.sv
@@ -53,7 +53,7 @@ class uart_intr_vseq extends uart_base_vseq;
     case (uart_intr)
       TxWatermark: begin
         int level = ral.fifo_ctrl.txilvl.get_mirrored_value();
-        int watermark_bytes = get_watermark_bytes_by_level(level);
+        int watermark_bytes = get_watermark_bytes_by_level(level, UartTx);
         //  when tx is enabled, one extra item is in the data path
         //  when watermark_bytes==1, watermark interrupt is triggered before item is processed
         if (en_tx && watermark_bytes > 1) watermark_bytes += 1;

--- a/hw/ip/uart/dv/env/uart_env_pkg.sv
+++ b/hw/ip/uart/dv/env/uart_env_pkg.sv
@@ -35,10 +35,11 @@ package uart_env_pkg;
     NumUartIntr = 8
   } uart_intr_e;
 
+
   // get the number of bytes that triggers watermark interrupt
-  function automatic int get_watermark_bytes_by_level(int lvl);
+  function automatic int get_watermark_bytes_by_level(int lvl, uart_dir_e dir=UartRx);
     case(lvl)
-      0: return 1;
+      0: return 1 + dir;
       1: return 4;
       2: return 8;
       3: return 16;

--- a/hw/ip/uart/dv/env/uart_scoreboard.sv
+++ b/hw/ip/uart/dv/env/uart_scoreboard.sv
@@ -115,7 +115,8 @@ class uart_scoreboard extends cip_base_scoreboard #(.CFG_T(uart_env_cfg),
   endtask
 
   virtual function void predict_tx_watermark_intr(uint tx_q_size = tx_q.size, bit just_cleared = 0);
-    uint watermark = get_watermark_bytes_by_level(ral.fifo_ctrl.txilvl.get_mirrored_value());
+    uint watermark = get_watermark_bytes_by_level(ral.fifo_ctrl.txilvl.get_mirrored_value(), UartTx);
+    `uvm_info(`gfn, $sformatf("tx watermark level is %d", watermark), UVM_LOW)
     intr_exp[TxWatermark] |= (tx_q_size < watermark);
   endfunction
 

--- a/hw/ip/uart/rtl/uart_core.sv
+++ b/hw/ip/uart/rtl/uart_core.sv
@@ -295,7 +295,7 @@ module uart_core (
 
   always_comb begin
     unique case(uart_fifo_txilvl)
-      2'h0:    tx_watermark_d = (tx_fifo_depth < 6'd1);
+      2'h0:    tx_watermark_d = (tx_fifo_depth < 6'd2);
       2'h1:    tx_watermark_d = (tx_fifo_depth < 6'd4);
       2'h2:    tx_watermark_d = (tx_fifo_depth < 6'd8);
       default: tx_watermark_d = (tx_fifo_depth < 6'd16);
@@ -349,12 +349,12 @@ module uart_core (
 
   assign event_rx_timeout = (rx_timeout_count_q == uart_rxto_val) & uart_rxto_en;
 
-  assign tx_empty_d = tx_fifo_depth == 6'h0;
+  assign tx_empty_d = hw2reg.status.txidle.d;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       rx_timeout_count_q   <= 24'd0;
       rx_fifo_depth_prev_q <= 6'd0;
-      tx_empty_prev_q      <= 1'd0;
+      tx_empty_prev_q      <= 1'd1;
     end else begin
       rx_timeout_count_q    <= rx_timeout_count_d;
       rx_fifo_depth_prev_q  <= rx_fifo_depth;


### PR DESCRIPTION
This way tx_empty will not immediately trigger after reset until something
has been written into the FIFO.

Signed-off-by: Timothy Chen <timothytim@google.com>