### PR TITLE
[sw/device] Disable PIC and PIE for device code

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -17,6 +17,8 @@ project(
     'build.werror=true',
     'debug=true',
     'build.debug=true',
+    'b_staticpic=false', # Disable PIC for device static libraries
+    'b_pie=false',       # Disable PIE for device executables
   ],
 )
 


### PR DESCRIPTION
Meson by default enables position-indepdendent code (PIC) in static
libraries. This is so that static libraries can be linked into shared
libraries, without the static library needing to be rebuilt.

Unfortunately, this causes some symbol lookups in the final executables
to use the GOT. Our device linker scripts do not support using a GOT, so
we must disable PIC everywhere. This can be done with `pic: false` in
the `static_library` call, but we wish to disable it globally for device
code.

I have taken this opportunity to disable position-independent
executables (PIE) explicitly as well. PIE is not enabled by default, but
explicitly disabling it should mean that future meson updates will not
break our device code.