### PR TITLE
[dv regr tool] Generate testplan annotated results

### DIFF
--- a/hw/dv/data/common_sim_cfg.hjson
+++ b/hw/dv/data/common_sim_cfg.hjson
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   project:          opentitan
+  flow:             sim
   flow_makefile:    "{proj_root}/hw/dv/data/sim.mk"
 
   import_cfgs:      ["{proj_root}/hw/dv/data/common_modes.hjson",

--- a/hw/ip/uart/data/uart_testplan.hjson
+++ b/hw/ip/uart/data/uart_testplan.hjson
@@ -189,7 +189,7 @@
       name: stress_all_with_reset
       desc: '''Have random reset in parallel with stress_all and tl_errors sequences'''
       milestone: V2
-      tests: ["uart_stress_all_with_reset"]
+      tests: ["uart_stress_all_with_rand_reset"]
     }
   ]
 }

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -21,6 +21,7 @@ pyyaml
 yapf
 fusesoc
 gitpython
+tabulate
 
 # Develpment version to get around YAML parser warning triggered by fusesoc
 # Upstream tracking: https://github.com/olofk/ipyxact/issues/19

--- a/util/testplanner/testplan_utils.py
+++ b/util/testplanner/testplan_utils.py
@@ -129,8 +129,8 @@ def gen_html_regr_results_table(testplan, regr_results, outbuf):
         else:
             tests_str = tests
             results_str = results
-        if ms == "na": ms = ""
-        if name == "<ignore>":
+        if ms == "N.A.": ms = ""
+        if name == "N.A.":
             name = ""
             tests_str = "<strong>" + tests_str + "</strong>"
             results_str = "<strong>" + results_str + "</strong>"


### PR DESCRIPTION
- Updated script to generate a testplan annotated results table
- Additional minor fixes to support the above change

Note the table is generated using a thirld party python library called
'tabulate'. This needs to be installed separately by running
```
pip3 install --user tabulate
```

It has been added to the `python-requirements.txt` file.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>