### PR TITLE
DRAFT: Add mock_mmio.c/h for DIF unit-tests (alternative)

### DIFF
--- a/sw/device/lib/base/mmio.h
+++ b/sw/device/lib/base/mmio.h
@@ -27,6 +27,9 @@ inline reg32_t reg32_from_addr(uintptr_t address) {
   };
 }
 
+// Declare but not define reg32_read and reg32_write if compiling for tests
+// since these functions will be mocked in tests.
+#ifndef MOCK_MMIO
 /**
  * Reads an aligned word from the MMIO register |base| at the given byte offset.
  *
@@ -54,6 +57,10 @@ inline uint32_t reg32_read(reg32_t base, ptrdiff_t offset) {
 inline void reg32_write(reg32_t base, ptrdiff_t offset, uint32_t value) {
   base.inner_ptr[offset / sizeof(uint32_t)] = value;
 }
+#else
+uint32_t reg32_read(reg32_t base, ptrdiff_t offset);
+void reg32_write(reg32_t base, ptrdiff_t offset, uint32_t value);
+#endif  // MOCK_MMIO
 
 /**
  * Reads the bits in |mask| from the MMIO register |base| at the given offset.

--- a/sw/device/lib/meson.build
+++ b/sw/device/lib/meson.build
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 subdir('base')
+subdir('testing')
 
 # UART library (sw_lib_uart)
 sw_lib_uart = declare_dependency(

--- a/sw/device/lib/testing/dif_gpio_test.cc
+++ b/sw/device/lib/testing/dif_gpio_test.cc
@@ -1,0 +1,36 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "mock_mmio.h"
+
+#include "gpio_regs.h"
+extern "C" {
+#include "sw/device/lib/dif/dif_gpio.h"
+}  // extern "C"
+
+// Test fixture that provides a |dif_gpio_t| instance.
+class DifGpioTest : public MmioMockTest {
+ protected:
+  DifGpioTest() : gpio_{reg32_from_addr(0xAABBCCDDU)} {}
+
+  dif_gpio_t gpio_;
+};
+
+// Helper macros for passing |DifGpioTest::gpio_| to |EXPECT_MMIO_READ/WRITE()|.
+// Defined as macros so that error messages show the actual points of usage.
+#define EXPECT_READ(offset, val) EXPECT_MMIO_READ(gpio_.base_addr, offset, val)
+#define EXPECT_WRITE(offset, val) \
+  EXPECT_MMIO_WRITE(gpio_.base_addr, offset, val)
+
+// Tests
+
+TEST_F(DifGpioTest, ReadPin) {
+  EXPECT_READ(GPIO_DATA_IN_REG_OFFSET, 0xFFFF7FFFU);
+  EXPECT_WRITE(GPIO_DIRECT_OUT_REG_OFFSET, 0xAA55AA55U);
+  EXPECT_READ(GPIO_DATA_IN_REG_OFFSET, 0x00000080U);
+
+  EXPECT_EQ(false, dif_gpio_read_pin(&gpio_, 15));
+  dif_gpio_write_all_pins(&gpio_, 0xAA55AA55U);
+  EXPECT_EQ(true, dif_gpio_read_pin(&gpio_, 7));
+}

--- a/sw/device/lib/testing/meson.build
+++ b/sw/device/lib/testing/meson.build
@@ -1,0 +1,46 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+sw_lib_testing_gtest = declare_dependency(
+  include_directories: include_directories(
+    '/tools/googletest/gtest',
+    '/tools/googletest/gmock',
+  ),
+  link_args: [
+    '-L/tools/googletest/lib',
+    '-lgtest',
+    '-lgtest_main',
+    '-lgmock',
+    '-lpthread',
+  ],
+)
+
+sw_lib_testing_mock_mmio = declare_dependency(
+  link_with: static_library(
+    'mock_mmio',
+    sources: ['mock_mmio.cc'],
+    dependencies: [sw_lib_testing_gtest],
+    native: true,
+    cpp_args: ['-DMOCK_MMIO'],
+  )
+)
+
+dif_gpio_test = executable(
+  'dif_gpio_test',
+  sources: [
+    hw_ip_gpio_reg_h,
+    'dif_gpio_test.cc',
+    meson.source_root() / 'sw/device/lib/dif/dif_gpio.c',
+    meson.source_root() / 'sw/device/lib/base/mmio.c',
+  ],
+  dependencies: [
+    sw_lib_testing_gtest,
+    sw_lib_testing_mock_mmio,
+  ],
+  native: true,
+  cpp_args: ['-DMOCK_MMIO'],
+  c_args: ['-DMOCK_MMIO']
+)
+
+test('dif_gpio_test', dif_gpio_test)

--- a/sw/device/lib/testing/mock_mmio.cc
+++ b/sw/device/lib/testing/mock_mmio.cc
@@ -1,0 +1,34 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "mock_mmio.h"
+
+void MmioMockTest::SetUp() {
+  if (mock_ == nullptr) {
+    // Using new because constructor is private
+    mock_.reset(new MmioMock());
+  }
+}
+
+void MmioMockTest::TearDown() {
+  if (mock_ != nullptr) {
+    // Destroy the mock object here to verify its expectations. Otherwise,
+    // it is destroyed at program exit, i.e. we end up leaking it, and its
+    // expectations are not verified.
+    mock_.reset();
+  }
+}
+
+thread_local std::unique_ptr<MmioMock> MmioMockTest::mock_;
+
+extern "C" {
+// Mock |reg32_read()| and |reg32_write()|
+uint32_t reg32_read(reg32_t base, ptrdiff_t offset) {
+  return MmioMockTest::mock_->MmioRead(base, offset);
+}
+
+void reg32_write(reg32_t base, ptrdiff_t offset, uint32_t value) {
+  MmioMockTest::mock_->MmioWrite(base, offset, value);
+}
+}  // extern "C"

--- a/sw/device/lib/testing/mock_mmio.h
+++ b/sw/device/lib/testing/mock_mmio.h
@@ -1,0 +1,56 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+extern "C" {
+#include "sw/device/lib/base/mmio.h"
+}  // extern "C"
+
+// Class for mocking |reg32_read()| and |reg32_write()|.
+// This class should only be used by MmioMockTest and
+// the private constructor expresses this expectation.
+class MmioMock {
+ public:
+  MOCK_METHOD(uint32_t, MmioRead, (reg32_t, ptrdiff_t));
+  MOCK_METHOD(void, MmioWrite, (reg32_t, ptrdiff_t, uint32_t));
+
+ private:
+  MmioMock() = default;
+
+  friend class MmioMockTest;
+};
+
+// Fixture for constructing and destroying a static MmioMock instance
+// that can be used from |reg32_read()| and |reg32_write()| mocks.
+class MmioMockTest : public testing::Test {
+ protected:
+  void SetUp() override;
+  void TearDown() override;
+
+  // Static mock instance
+  thread_local static std::unique_ptr<MmioMock> mock_;
+
+  // Friends to be able to redispatch calls to MmioMock
+  friend uint32_t reg32_read(reg32_t, ptrdiff_t);
+  friend void reg32_write(reg32_t, ptrdiff_t, uint32_t);
+
+ private:
+  testing::InSequence expectationSequence_;
+};
+
+// Equal to operator to able to use reg32_t in expectations
+inline bool operator==(const reg32_t &lhs, const reg32_t &rhs) {
+  return lhs.inner_ptr == rhs.inner_ptr;
+}
+
+// Helper macros for passing |*mock_| to |EXPECT_CALL|. Tests must use the
+// |MmioMockTest| fixture defined above. These are not defined as member
+// functions because error messages would end up pointing to this file,
+// which is not very helpful.
+#define EXPECT_MMIO_WRITE(addr, offset, val) \
+  EXPECT_CALL(*mock_, MmioWrite(addr, offset, val))
+#define EXPECT_MMIO_READ(addr, offset, val) \
+  EXPECT_CALL(*mock_, MmioRead(addr, offset)).WillOnce(::testing::Return(val))


### PR DESCRIPTION
I had the chance to take a look at @mcy's #1298 before creating this PR
and it seems like both approaches are starting to look similar. I'm
creating this PR so that we can take a look at both and come up with a
solution that combines the best parts.

This PR is a patch on top of #1254 and uses GoogleTest and GoogleMock
to provide a test fixture with `EXPECT_REG32_READ()` and
`EXPECT_REG32_WRITE()` similar to my previous PR. The test fixture in
`dif_gpio_test.cc` further encapsulates the `gpio` instance to simplify
tests. We can move this to `mock_mmio.h` in the form of a class template
if all device instances has the `base_addr` field.

Signed-off-by: Alphan Ulusoy <alphan@google.com>