### PR TITLE
[fpv/prim_assert] resolve TODOs

### DIFF
--- a/hw/dv/sv/common_ifs/pins_if.sv
+++ b/hw/dv/sv/common_ifs/pins_if.sv
@@ -5,6 +5,8 @@
 // Interface: pins_if
 // Description: Pin interface for driving and sampling individual pins such as interrupts, alerts
 // and gpios.
+`ifndef SYNTHESIS
+
 interface pins_if #(
   parameter int Width = 1
 ) (
@@ -91,3 +93,4 @@ interface pins_if #(
   endgenerate
 
 endinterface
+`endif

--- a/hw/ip/prim/rtl/prim_assert.sv
+++ b/hw/ip/prim/rtl/prim_assert.sv
@@ -6,11 +6,6 @@
 //  - Provides default clk and rst options to simplify code
 //  - Provides boiler plate template for common assertions
 
-// TODO:
-//  - double check whether VERILATOR and SYNTHESIS checks are really needed
-//  - should we add ASSERT_INIT_DISABLE?
-//  - should we add "pragma coverage off" and "VCS coverage off"?
-
 `ifdef UVM
   // report assertion error with UVM if compiled
   package assert_rpt_pkg;
@@ -21,7 +16,6 @@
     endfunction
   endpackage
 `endif
-
 
 ///////////////////
 // Helper macros //
@@ -178,6 +172,3 @@
 `ifdef FPV_ON                                    \
    `COVER(__name, __prop, __clk, __rst)          \
 `endif
-
-// undefine local helper macro
-`undef INC_ASSERT

--- a/hw/ip/tlul/common.core
+++ b/hw/ip/tlul/common.core
@@ -8,6 +8,7 @@ description: "TL-UL common building blocks"
 filesets:
   files_rtl:
     depend:
+      - lowrisc:dv:pins_if
       - lowrisc:prim:all
       - lowrisc:tlul:headers
     files:

--- a/hw/vendor/lowrisc_ibex/shared/rtl/prim_assert.sv
+++ b/hw/vendor/lowrisc_ibex/shared/rtl/prim_assert.sv
@@ -6,11 +6,6 @@
 //  - Provides default clk and rst options to simplify code
 //  - Provides boiler plate template for common assertions
 
-// TODO:
-//  - double check whether VERILATOR and SYNTHESIS checks are really needed
-//  - should we add ASSERT_INIT_DISABLE?
-//  - should we add "pragma coverage off" and "VCS coverage off"?
-
 `ifdef UVM
   // report assertion error with UVM if compiled
   package assert_rpt_pkg;
@@ -21,7 +16,6 @@
     endfunction
   endpackage
 `endif
-
 
 ///////////////////
 // Helper macros //
@@ -178,6 +172,3 @@
 `ifdef FPV_ON                                    \
    `COVER(__name, __prop, __clk, __rst)          \
 `endif
-
-// undefine local helper macro
-`undef INC_ASSERT


### PR DESCRIPTION
1. Checked with DV team, plan to collect assertion coverages in DV cov
db
2. Script still need ifndef VERILATOR, because verilator does not
support ## sv syntax
3. Remove the pragma translate_off as it duplicates the purpose of
SYNTHESIS

Signed-off-by: Cindy Chen <chencindy@google.com>