### PR TITLE
[lint] Add lint targets and waiver files for remaining IPs

### DIFF
--- a/hw/ip/alert_handler/alert_handler.core
+++ b/hw/ip/alert_handler/alert_handler.core
@@ -22,11 +22,46 @@ filesets:
       - rtl/alert_handler.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/alert_handler.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/alert_handler.waiver
+    file_type: waiver
+
+
+parameters:
+  SYNTHESIS:
+    datatype: bool
+    paramtype: vlogdefine
+
 
 targets:
   default: &default_target
     filesets:
+      - tool_verilator  ? (files_verilator_waiver)
+      - tool_ascentlint ? (files_ascentlint_waiver)
       - files_rtl
     toplevel: alert_handler
 
-
+  lint:
+    <<: *default_target
+    default_tool: verilator
+    parameters:
+      - SYNTHESIS=true
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"

--- a/hw/ip/alert_handler/lint/alert_handler.vlt
+++ b/hw/ip/alert_handler/lint/alert_handler.vlt
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// waiver file for alert_handler
+

--- a/hw/ip/alert_handler/lint/alert_handler.waiver
+++ b/hw/ip/alert_handler/lint/alert_handler.waiver
@@ -1,0 +1,39 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for alert handler
+
+waive -rules ENUM_RANGE -location {alert_handler_esc_timer.sv} -regexp {state_q} \
+      -comment "State is used to index timeout cycle counts"
+
+waive -rules NOT_READ -location {alert_handler_ping_timer.sv} -regexp {perm_state} \
+      -comment "Upper bits of permuted array are not read"
+
+waive -rules HIER_NET_NOT_READ -location {alert_handler_ping_timer.sv} -regexp {perm_state} \
+      -comment "Upper bits of permuted array are not read"
+
+waive -rules HIER_NET_NOT_READ -location {alert_handler.sv} -regexp {[Nn]et 'tl_[io]\.[ad]_(address|param|user)} \
+      -comment "Register interface doesn't use upper address and param, user filed"
+
+waive -rules INSIDE_OP_CONTEXT -location {prim_esc_sender.sv} -regexp {inside} \
+      -comment "Inside operator is used within SVA"
+
+waive -rules CASE_INC -location {alert_handler_esc_timer.sv} -regexp {'b010} \
+      -comment "Not all case tags are required."
+
+waive -rules CASE_INC -location {alert_handler_ping_timer.sv} -regexp {'b11} \
+      -comment "Not all case tags are required."
+
+waive -rules CASE_INC -location {prim_esc_sender.sv} -regexp {'b111} \
+      -comment "Not all case tags are required."
+
+waive -rules ONE_BIT_VEC -location {prim_lfsr.sv} -regexp {InDw - 1:0} \
+      -comment "Data input may be one bit wide."
+
+waive -rules VAR_INDEX -location {alert_handler_esc_timer.sv} -regexp {phase_cyc_i\[phase_idx\]} \
+      -comment "This indexing expression is correct."
+
+waive -rules VAR_INDEX -location {alert_handler_ping_timer.sv} -regexp {enable_mask\[id_to_ping\]} \
+      -comment "This indexing expression is correct."
+

--- a/hw/ip/flash_ctrl/flash_ctrl.core
+++ b/hw/ip/flash_ctrl/flash_ctrl.core
@@ -22,8 +22,47 @@ filesets:
       - rtl/flash_phy.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/flash_ctrl.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/flash_ctrl.waiver
+    file_type: waiver
+
+
+parameters:
+  SYNTHESIS:
+    datatype: bool
+    paramtype: vlogdefine
+
+
 targets:
   default: &default_target
     filesets:
+      - tool_verilator  ? (files_verilator_waiver)
+      - tool_ascentlint ? (files_ascentlint_waiver)
       - files_rtl
     toplevel: flash_ctrl
+
+  lint:
+    <<: *default_target
+    default_tool: verilator
+    parameters:
+      - SYNTHESIS=true
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"
+

--- a/hw/ip/flash_ctrl/lint/flash_ctrl.vlt
+++ b/hw/ip/flash_ctrl/lint/flash_ctrl.vlt
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// waiver file for flash_ctrl
+

--- a/hw/ip/flash_ctrl/lint/flash_ctrl.waiver
+++ b/hw/ip/flash_ctrl/lint/flash_ctrl.waiver
@@ -1,0 +1,5 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for Flash Controller

--- a/hw/ip/gpio/gpio.core
+++ b/hw/ip/gpio/gpio.core
@@ -15,8 +15,48 @@ filesets:
       - rtl/gpio_reg_top.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/gpio.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/gpio.waiver
+    file_type: waiver
+
+
+parameters:
+  SYNTHESIS:
+    datatype: bool
+    paramtype: vlogdefine
+
+
 targets:
   default: &default_target
     filesets:
+      - tool_verilator  ? (files_verilator_waiver)
+      - tool_ascentlint ? (files_ascentlint_waiver)
       - files_rtl
     toplevel: gpio
+
+  lint:
+    <<: *default_target
+    default_tool: verilator
+    parameters:
+      - SYNTHESIS=true
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"
+
+

--- a/hw/ip/gpio/lint/gpio.vlt
+++ b/hw/ip/gpio/lint/gpio.vlt
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// waiver file for gpio
+

--- a/hw/ip/gpio/lint/gpio.waiver
+++ b/hw/ip/gpio/lint/gpio.waiver
@@ -1,0 +1,12 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for GPIO lint
+
+waive -rules HIER_NET_NOT_READ -location {gpio.sv} -regexp {[nN]et.*a_(address|param|user).*not read from} \
+      -comment "several TLUL signals are not used by register file"
+waive -rules HIER_NET_NOT_READ -location {gpio.sv} -regexp {Net .reg2hw.*.qe. is not read from} \
+      -comment "registers with multiple fields often have unused qe's since they are duplicative"
+waive -rules NOT_READ -location {gpio.sv} -regexp {Signal 'reg2hw.*.qe' is not read from} \
+      -comment "registers with multiple fields often have unused qe's since they are duplicative"

--- a/hw/ip/hmac/hmac.core
+++ b/hw/ip/hmac/hmac.core
@@ -19,8 +19,48 @@ filesets:
       - rtl/hmac.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/hmac.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/hmac.waiver
+    file_type: waiver
+
+
+parameters:
+  SYNTHESIS:
+    datatype: bool
+    paramtype: vlogdefine
+
+
 targets:
   default: &default_target
     filesets:
+      - tool_verilator  ? (files_verilator_waiver)
+      - tool_ascentlint ? (files_ascentlint_waiver)
       - files_rtl
     toplevel: hmac
+
+  lint:
+    <<: *default_target
+    default_tool: verilator
+    parameters:
+      - SYNTHESIS=true
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"
+
+

--- a/hw/ip/hmac/lint/hmac.vlt
+++ b/hw/ip/hmac/lint/hmac.vlt
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// waiver file for hmac
+

--- a/hw/ip/hmac/lint/hmac.waiver
+++ b/hw/ip/hmac/lint/hmac.waiver
@@ -1,0 +1,49 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for Platform-Level Interrupt Controller
+
+waive -rules {CONST_FF RESET_ONLY PARTIAL_CONST_ASSIGN} -location {hmac_core.sv} -regexp {txcount\[4:0\]} \
+      -comment "lower 32bits of message are aligned. So ignoring txcount for lower 5 bits"
+waive -rules {CONST_FF RESET_ONLY PARTIAL_CONST_ASSIGN} -location {sha2.sv} -regexp {processed_length\[8:0\]} \
+      -comment "lower 512bits of message are aligned. So ignoring txcount for lower 9 bits"
+waive -rules {CONST_FF RESET_ONLY PARTIAL_CONST_ASSIGN} -location {sha2_pad.sv} -regexp {tx_count\[4:0\]} \
+      -comment "lower 32bits of message are aligned. So ignoring txcount for lower 5 bits"
+waive -rules {NOT_READ HIER_NET_NOT_READ CONST_OUTPUT} -location {sha2_pad.sv sha2.sv} \
+      -regexp {padded_length\[8:0\]} \
+      -comment "lower 512bits of padded message are 0 (always aligned message)"
+
+waive -rules {EXPLICIT_BITLEN} -location {hmac_*.sv} \
+      -comment "Bit length is guarded by the assigned wire (64bit)"
+
+waive -rules {EXPLICIT_BITLEN} -location {sha2.sv} -regexp {.*(0|1)} \
+      -comment "Added or subtracted by 1"
+
+waive -rules {HIER_BRANCH_NOT_READ INPUT_NOT_READ} -location {hmac_core.sv sha2_pad.sv} -regexp {wipe_(secret|v)} \
+      -comment "Not used but remained for future use"
+
+waive -rules {NOT_READ} -location {*_reg_top.sv} -regexp {(address|param|user)} \
+      -comment "Register module waiver"
+
+# ARITH_CONTEXT
+waive -rules {ARITH_CONTEXT} -location {sha2.sv}     -regexp {Bitlength of arithmetic operation '.processed_length.63:9. \+ 1'b1.'} \
+      -comment "Bitwidth overflow is intended"
+waive -rules {ARITH_CONTEXT} -location {sha2_pad.sv} -regexp {Bitlength of arithmetic operation 'tx_count.63:5. \+ 2'd1'} \
+      -comment "Bitwidth overflow is intended"
+waive -rules {ARITH_CONTEXT} -location {sha2_pad.sv} -regexp {Bitlength of arithmetic operation 'message_length.63:9. \+ (1'b1|2'b10)'} \
+      -comment "Bitwidth overflow is intended"
+
+waive -rules {NOT_READ HIER_NET_NOT_READ} -location {hmac.sv} -regexp {msg_fifo_addr.* is not read} \
+      -comment "Ignore Address intentionally"
+
+waive -rules {INTEGER}        -location {hmac_pkg.sv} -regexp {'amt' of type int used as a}
+waive -rules {TWO_STATE_TYPE} -location {hmac_pkg.sv} -regexp {'amt' is of two state type 'int'} \
+      -comment "shift function behaves as static, it is called with constant in the design"
+
+waive -rules {INTEGER}        -location {tlul_socket_1n.sv} -regexp {'idx' of type int used} \
+      -comment "It compares with the signal and used as constant"
+
+waive -rules {NOT_READ HIER_NET_NOT_READ} -location {hmac.sv} -regexp {'msg_fifo_wmask.* is not read} \
+      -comment "Only first bit in a byte is used"
+

--- a/hw/ip/i2c/i2c.core
+++ b/hw/ip/i2c/i2c.core
@@ -18,8 +18,48 @@ filesets:
       - rtl/i2c.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/i2c.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/i2c.waiver
+    file_type: waiver
+
+
+parameters:
+  SYNTHESIS:
+    datatype: bool
+    paramtype: vlogdefine
+
+
 targets:
   default: &default_target
     filesets:
+      - tool_verilator  ? (files_verilator_waiver)
+      - tool_ascentlint ? (files_ascentlint_waiver)
       - files_rtl
     toplevel: i2c
+
+  lint:
+    <<: *default_target
+    default_tool: verilator
+    parameters:
+      - SYNTHESIS=true
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"
+
+

--- a/hw/ip/i2c/lint/i2c.vlt
+++ b/hw/ip/i2c/lint/i2c.vlt
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// waiver file for i2c
+

--- a/hw/ip/i2c/lint/i2c.waiver
+++ b/hw/ip/i2c/lint/i2c.waiver
@@ -1,0 +1,6 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for i2c
+

--- a/hw/ip/nmi_gen/lint/nmi_gen.vlt
+++ b/hw/ip/nmi_gen/lint/nmi_gen.vlt
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// waiver file for nmi_gen
+

--- a/hw/ip/nmi_gen/lint/nmi_gen.waiver
+++ b/hw/ip/nmi_gen/lint/nmi_gen.waiver
@@ -1,0 +1,12 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for nmi_gen
+
+waive -rules HIER_NET_NOT_READ -location {nmi_gen_reg_top.sv} -regexp {Net 'reg_wdata.*' is not read from.*} \
+      -comment "Not all wdata bits are used in this module due to its configuration"
+waive -rules HIER_NET_NOT_READ -location {nmi_gen_reg_top.sv} -regexp {Net 'reg_be.*' is not read from.*} \
+      -comment "Not all wdata bits are used in this module due to its configuration"
+waive -rules NOT_READ -location {nmi_gen_reg_top.sv} -regexp {Signal 'reg_wdata.*' is not read from.*} \
+      -comment "Not all wdata bits are used in this module due to its configuration"

--- a/hw/ip/nmi_gen/nmi_gen.core
+++ b/hw/ip/nmi_gen/nmi_gen.core
@@ -16,10 +16,48 @@ filesets:
       - rtl/nmi_gen.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/nmi_gen.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/nmi_gen.waiver
+    file_type: waiver
+
+
+parameters:
+  SYNTHESIS:
+    datatype: bool
+    paramtype: vlogdefine
+
+
 targets:
   default: &default_target
     filesets:
+      - tool_verilator  ? (files_verilator_waiver)
+      - tool_ascentlint ? (files_ascentlint_waiver)
       - files_rtl
     toplevel: nmi_gen
+
+  lint:
+    <<: *default_target
+    default_tool: verilator
+    parameters:
+      - SYNTHESIS=true
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"
 
 

--- a/hw/ip/padctrl/lint/padctrl.vlt
+++ b/hw/ip/padctrl/lint/padctrl.vlt
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// waiver file for padctrl
+

--- a/hw/ip/padctrl/lint/padctrl.waiver
+++ b/hw/ip/padctrl/lint/padctrl.waiver
@@ -1,0 +1,20 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for padctrl
+
+waive -rules HIER_NET_NOT_READ -regexp {Connected net 'attr\_i\[.*\]' at prim\_.*\_pad\_wrapper\.sv:.* is not read from in module.*}
+      -location {padring.sv}
+      -comment "Some IO attributes may not be implemented."
+
+waive -rules NOT_READ -regexp {Signal 'reg_wdata.* is not read from}
+      -location {padctrl_reg_top.sv}
+      -comment "Some wdata bits may be unconnected."
+
+waive -rules HIER_NET_NOT_READ -regexp {Net 'reg_wdata.* is not read from}
+      -location {padctrl_reg_top.sv}
+      -comment "Some wdata bits may be unconnected."
+
+waive -rules MULTI_DRIVEN -location {padring.sv} -regexp {('clk'|'rst_n') has 2 drivers, also driven at padring.sv.*}
+      -comment "This error is a false positive in this case, since OE is set to 0."

--- a/hw/ip/padctrl/padctrl.core
+++ b/hw/ip/padctrl/padctrl.core
@@ -18,11 +18,48 @@ filesets:
       - rtl/padctrl.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/padctrl.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/padctrl.waiver
+    file_type: waiver
+
+
+parameters:
+  SYNTHESIS:
+    datatype: bool
+    paramtype: vlogdefine
+
 
 targets:
   default: &default_target
     filesets:
+      - tool_verilator  ? (files_verilator_waiver)
+      - tool_ascentlint ? (files_ascentlint_waiver)
       - files_rtl
-    toplevel: padctrl padring
+    toplevel: padctrl
+
+  lint:
+    <<: *default_target
+    default_tool: verilator
+    parameters:
+      - SYNTHESIS=true
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"
 
 

--- a/hw/ip/pinmux/lint/pinmux.vlt
+++ b/hw/ip/pinmux/lint/pinmux.vlt
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// waiver file for pinmux
+

--- a/hw/ip/pinmux/lint/pinmux.waiver
+++ b/hw/ip/pinmux/lint/pinmux.waiver
@@ -1,0 +1,15 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for pinmux
+
+waive -rules NOT_READ -location {pinmux_reg_top.sv} -regexp {.*reg_wdata.*} \
+      -comment "Upper bits of reg_wdata are not read"
+
+waive -rules HIER_NET_NOT_READ -location {pinmux_reg_top.sv} -regexp {.*reg_wdata.*} \
+      -comment "Upper bits of reg_wdata are not read"
+
+waive -rules VAR_INDEX_RANGE -location {pinmux.sv} -regexp {.*maximum value.*} \
+      -comment "Indexed arrays may not be fully populated."
+

--- a/hw/ip/pinmux/pinmux.core
+++ b/hw/ip/pinmux/pinmux.core
@@ -16,11 +16,48 @@ filesets:
       - rtl/pinmux.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/pinmux.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/pinmux.waiver
+    file_type: waiver
+
+
+parameters:
+  SYNTHESIS:
+    datatype: bool
+    paramtype: vlogdefine
+
 
 targets:
   default: &default_target
     filesets:
+      - tool_verilator  ? (files_verilator_waiver)
+      - tool_ascentlint ? (files_ascentlint_waiver)
       - files_rtl
     toplevel: pinmux
+
+  lint:
+    <<: *default_target
+    default_tool: verilator
+    parameters:
+      - SYNTHESIS=true
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"
 
 

--- a/hw/ip/prim/lint/prim.vlt
+++ b/hw/ip/prim/lint/prim.vlt
@@ -1,0 +1,4 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//

--- a/hw/ip/prim/lint/prim.waiver
+++ b/hw/ip/prim/lint/prim.waiver
@@ -1,0 +1,65 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim
+
+# prim_fifo_sync
+waive -rules {ONE_BIT_MEM_WIDTH} -location {prim_fifo_sync.sv} -msg {Memory 'gen_normal_fifo.storage' has word width which is single bit wide} \
+      -comment "It is permissible that a FIFO has a wordwidth of 1bit"
+
+# prim_fifo_async
+waive -rules {ASSIGN_SIGN} -location {prim_fifo_async.sv} -msg {Signed target 'i' assigned unsigned value 'PTR_WIDTH - 3'} \
+      -comment "Parameter PTR_WIDTH is unsigned, but integer i is signed. This is fine. Changing the integer to unsigned might \
+                cause issues with the for loop never exiting, because an unsigned integer can never become < 0."
+
+# prim_ram_2p_adv
+waive -rules {INPUT_NOT_READ} -location {prim_ram_2p_adv.sv} -msg {Input port 'cfg_i' is not read from in module} \
+      -comment "We will eventually use this input for RTC/WTC or other memory parameters."
+
+# prim_assert
+waive -rules {UNDEF_MACRO_REF} -location {prim_assert.sv} -regexp {Macro definition for 'ASSERT_RPT' includes expansion of undefined macro '__(FILE|LINE)__'} \
+      -comment "This is an UVM specific macro inside our assertion shortcuts"
+
+# prim_packer
+waive -rules INTEGER           -location {prim_packer.sv} -msg {'i' of type int used as a non-constant value} \
+      -comment "This assigns int i (signed) to a multibit logic variable (unsigned), which is fine"
+
+# primitives: prim_subreg
+
+waive -rules INPUT_NOT_READ       -location {prim_subreg.sv} -regexp {Input port 'wd' is not read from} \
+      -comment "for RO wd is not used"
+
+# primitives: prim_arbiter
+
+waive -rules PARTIAL_CONST_ASSIGN -location {prim_arbiter.sv} -regexp {'mask.0.' is conditionally assigned a constant} \
+      -comment "makes the code more readable"
+waive -rules CONST_FF -location {prim_arbiter.sv} -regexp {Flip-flop 'mask.0.' is driven by constant} \
+      -comment "makes the code more readable"
+
+# primitives: prim_sram_arbiter
+waive -rules CONST_OUTPUT -location {prim_sram_arbiter.sv} -regexp {rsp_error.* is driven by constant} \
+      -comment "SRAM protection is not yet implemented"
+
+# primitives: prim_fifos
+
+waive -rules VAR_INDEX_RANGE      -location {prim_fifo_*sync.sv} -regexp {maximum value .* may be too large for 'storage'} \
+      -comment "index is protected by control logic"
+waive -rules EXPLICIT_BITLEN      -location {prim_fifo_*sync.sv} -regexp {Bit length not specified for constant '1'} \
+      -comment "index is protected by control logic"
+waive -rules NOT_READ             -location {prim_fifo_async.sv} -regexp {Signal 'nc_decval_msb' is not read} \
+      -comment "Store temporary values. Not used intentionally"
+
+waive -rules {INPUT_NOT_READ} -location {prim_fifo_sync.sv} -regexp {Input port '(clk_i|rst_ni)' is not read from, instance.*Depth=0\)} \
+      -comment "In passthrough mode, clk and reset are not read form within this module"
+
+# TL-UL fifo
+waive -rules {HIER_BRANCH_NOT_READ} -location {tlul_fifo_sync.sv} -regexp {Connected net '(clk_i|rst_ni)' at prim_fifo_sync.sv:.* is not read from in module 'prim_fifo_sync'} \
+      -comment "In passthrough mode, clk and reset are not read form within this module"
+
+# primitivies: prim_ram_2p_wrapper
+#
+#waive -rules INPUT_NOT_READ -location {prim_ram_*_wrapper*} -regexp {cfg_i} \
+#      -comment "Register model doesn't need config port"
+#waive -rules NOT_READ -location {prim_ram_*_wrapper*} -regexp {(a|b)_rdata_(q|d)\[38} \
+#      -comment "Syndrome is not going out to the interface"

--- a/hw/ip/prim/prim.core
+++ b/hw/ip/prim/prim.core
@@ -40,7 +40,26 @@ filesets:
       - rtl/prim_ram_2p_async_adv.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim.waiver
+    file_type: waiver
+
+
 targets:
-  default: &default_target
+  default:
     filesets:
+      - tool_verilator  ? (files_verilator_waiver)
+      - tool_ascentlint ? (files_ascentlint_waiver)
       - files_rtl

--- a/hw/ip/prim_generic/lint/prim_generic_clock_gating.vlt
+++ b/hw/ip/prim_generic/lint/prim_generic_clock_gating.vlt
@@ -1,0 +1,4 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//

--- a/hw/ip/prim_generic/lint/prim_generic_clock_gating.waiver
+++ b/hw/ip/prim_generic/lint/prim_generic_clock_gating.waiver
@@ -1,0 +1,9 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# primitives: prim_clock_gating
+waive -rules LATCH                -location {prim_generic_clock_gating.sv} -regexp {'en_latch' is a latch} \
+      -comment "clock gating cell creates a latch"
+waive -rules COMBO_NBA            -location {prim_generic_clock_gating.sv} -regexp {Non-blocking assignment to 'en_latch'} \
+      -comment "clock gating cell creates a latch"

--- a/hw/ip/prim_generic/lint/prim_generic_clock_mux2.vlt
+++ b/hw/ip/prim_generic/lint/prim_generic_clock_mux2.vlt
@@ -1,0 +1,4 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//

--- a/hw/ip/prim_generic/lint/prim_generic_clock_mux2.waiver
+++ b/hw/ip/prim_generic/lint/prim_generic_clock_mux2.waiver
@@ -1,0 +1,5 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_clock_mux2

--- a/hw/ip/prim_generic/lint/prim_generic_flash.vlt
+++ b/hw/ip/prim_generic/lint/prim_generic_flash.vlt
@@ -1,0 +1,4 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//

--- a/hw/ip/prim_generic/lint/prim_generic_flash.waiver
+++ b/hw/ip/prim_generic/lint/prim_generic_flash.waiver
@@ -1,0 +1,5 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_generic_flash

--- a/hw/ip/prim_generic/lint/prim_generic_pad_wrapper.vlt
+++ b/hw/ip/prim_generic/lint/prim_generic_pad_wrapper.vlt
@@ -1,0 +1,4 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//

--- a/hw/ip/prim_generic/lint/prim_generic_pad_wrapper.waiver
+++ b/hw/ip/prim_generic/lint/prim_generic_pad_wrapper.waiver
@@ -1,0 +1,17 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_generic_pad_wrapper
+# note that this code is NOT synthesizable and meant for sim only
+
+waive -rules TRI_DRIVER -regexp {'inout_io' is driven by a tristate driver} -location {prim_generic_pad_wrapper.sv} \
+      -comment "This is a bidirectional pad inout."
+waive -rules MULTI_DRIVEN -regexp {.* drivers on 'inout_io' here} -location {prim_generic_pad_wrapper.sv} \
+      -comment "The pad simulation model has multiple drivers to emulate different IO terminations."
+waive -rules SELF_ASSIGN -regexp {LHS signal 'inout_io' encountered on the RHS of a continuous assignment statement} -location {prim_generic_pad_wrapper.sv} \
+      -comment "This implements a keeper termination (it's basically an explicit TRIREG)"
+waive -rules DRIVE_STRENGTH -regexp {Drive strength .* encountered on assignment to 'inout_io'} -location {prim_generic_pad_wrapper.sv} \
+      -comment "The pad simulation model uses driving strength attributes to emulate different IO terminations."
+waive -rules INPUT_NOT_READ -regexp {Input port 'attr\_i\[.:6\]' is not read from} -location {prim_generic_pad_wrapper.sv}\
+      -comment "Some IO attributes may not be implemented."

--- a/hw/ip/prim_generic/lint/prim_generic_ram_1p.vlt
+++ b/hw/ip/prim_generic/lint/prim_generic_ram_1p.vlt
@@ -1,0 +1,4 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//

--- a/hw/ip/prim_generic/lint/prim_generic_ram_1p.waiver
+++ b/hw/ip/prim_generic/lint/prim_generic_ram_1p.waiver
@@ -1,0 +1,12 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_generic_ram_[1,2]p
+
+waive -rules MULTI_PROC_ASSIGN -location {prim_generic_ram_2p.sv} -regexp {Assignment to 'storage' from more than one block} \
+      -comment "That is the nature of a dual-port memory: both write ports can access the same storage simultaneously"
+waive -rules ALWAYS_SPEC       -location {prim_generic_ram_*p.sv} -regexp {Edge triggered block may be more accurately modeled as always_ff} \
+      -comment "Vivado requires here an always instead of always_ff"
+waive -rules HIER_NET_NOT_READ -regexp {Connected net '(addr|wdata)_i' at prim_generic_ram_1p.sv.* is not read from in module 'prim_generic_ram_1p'} \
+      -comment "Ascentlint blackboxes very deep RAMs to speed up runtime. This blacboxing causes above lint errors."

--- a/hw/ip/prim_generic/lint/prim_generic_ram_2p.vlt
+++ b/hw/ip/prim_generic/lint/prim_generic_ram_2p.vlt
@@ -1,0 +1,4 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//

--- a/hw/ip/prim_generic/lint/prim_generic_ram_2p.waiver
+++ b/hw/ip/prim_generic/lint/prim_generic_ram_2p.waiver
@@ -1,0 +1,12 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_generic_ram_[1,2]p
+
+waive -rules MULTI_PROC_ASSIGN -location {prim_generic_ram_2p.sv} -regexp {Assignment to 'storage' from more than one block} \
+      -comment "That is the nature of a dual-port memory: both write ports can access the same storage simultaneously"
+waive -rules ALWAYS_SPEC       -location {prim_generic_ram_*p.sv} -regexp {Edge triggered block may be more accurately modeled as always_ff} \
+      -comment "Vivado requires here an always instead of always_ff"
+waive -rules HIER_NET_NOT_READ -regexp {Connected net '(addr|wdata)_i' at prim_generic_ram_1p.sv.* is not read from in module 'prim_generic_ram_1p'} \
+      -comment "Ascentlint blackboxes very deep RAMs to speed up runtime. This blacboxing causes above lint errors."

--- a/hw/ip/prim_generic/lint/prim_generic_rom.vlt
+++ b/hw/ip/prim_generic/lint/prim_generic_rom.vlt
@@ -1,0 +1,4 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//

--- a/hw/ip/prim_generic/lint/prim_generic_rom.waiver
+++ b/hw/ip/prim_generic/lint/prim_generic_rom.waiver
@@ -1,0 +1,9 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_generic_rom
+
+waive -rules NOT_DRIVEN  -location {prim_generic_rom.sv} -regexp {Signal 'mem' has no driver in module 'prim_generic_rom'} \
+      -comment "since this is a ROM, the signal mem has no driver, but it is populated using an initialization file"
+

--- a/hw/ip/prim_generic/prim_generic_clock_gating.core
+++ b/hw/ip/prim_generic/prim_generic_clock_gating.core
@@ -11,7 +11,26 @@ filesets:
       - rtl/prim_generic_clock_gating.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_generic_clock_gating.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_generic_clock_gating.waiver
+    file_type: waiver
+
+
 targets:
   default:
     filesets:
+      - tool_verilator  ? (files_verilator_waiver)
+      - tool_ascentlint ? (files_ascentlint_waiver)
       - files_rtl

--- a/hw/ip/prim_generic/prim_generic_clock_mux2.core
+++ b/hw/ip/prim_generic/prim_generic_clock_mux2.core
@@ -11,7 +11,26 @@ filesets:
       - rtl/prim_generic_clock_mux2.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_generic_clock_mux2.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_generic_clock_mux2.waiver
+    file_type: waiver
+
+
 targets:
   default:
     filesets:
+      - tool_verilator  ? (files_verilator_waiver)
+      - tool_ascentlint ? (files_ascentlint_waiver)
       - files_rtl

--- a/hw/ip/prim_generic/prim_generic_flash.core
+++ b/hw/ip/prim_generic/prim_generic_flash.core
@@ -11,8 +11,26 @@ filesets:
       - rtl/prim_generic_flash.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_generic_flash.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_generic_flash.waiver
+    file_type: waiver
+
+
 targets:
-  default: &default_target
+  default:
     filesets:
+      - tool_verilator  ? (files_verilator_waiver)
+      - tool_ascentlint ? (files_ascentlint_waiver)
       - files_rtl
-    toplevel: prim_generic_flash

--- a/hw/ip/prim_generic/prim_generic_pad_wrapper.core
+++ b/hw/ip/prim_generic/prim_generic_pad_wrapper.core
@@ -11,7 +11,26 @@ filesets:
       - rtl/prim_generic_pad_wrapper.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_generic_pad_wrapper.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_generic_pad_wrapper.waiver
+    file_type: waiver
+
+
 targets:
   default:
     filesets:
+      - tool_verilator  ? (files_verilator_waiver)
+      - tool_ascentlint ? (files_ascentlint_waiver)
       - files_rtl

--- a/hw/ip/prim_generic/prim_generic_ram_1p.core
+++ b/hw/ip/prim_generic/prim_generic_ram_1p.core
@@ -11,8 +11,26 @@ filesets:
       - rtl/prim_generic_ram_1p.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_generic_ram_1p.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_generic_ram_1p.waiver
+    file_type: waiver
+
+
 targets:
-  default: &default_target
+  default:
     filesets:
+      - tool_verilator  ? (files_verilator_waiver)
+      - tool_ascentlint ? (files_ascentlint_waiver)
       - files_rtl
-    toplevel: prim_generic_ram_1p

--- a/hw/ip/prim_generic/prim_generic_ram_2p.core
+++ b/hw/ip/prim_generic/prim_generic_ram_2p.core
@@ -11,8 +11,26 @@ filesets:
       - rtl/prim_generic_ram_2p.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_generic_ram_2p.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_generic_ram_2p.waiver
+    file_type: waiver
+
+
 targets:
-  default: &default_target
+  default:
     filesets:
+      - tool_verilator  ? (files_verilator_waiver)
+      - tool_ascentlint ? (files_ascentlint_waiver)
       - files_rtl
-    toplevel: prim_generic_ram_2p

--- a/hw/ip/prim_generic/prim_generic_rom.core
+++ b/hw/ip/prim_generic/prim_generic_rom.core
@@ -13,7 +13,26 @@ filesets:
       - rtl/prim_generic_rom.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_generic_rom.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_generic_rom.waiver
+    file_type: waiver
+
+
 targets:
   default:
     filesets:
+      - tool_verilator  ? (files_verilator_waiver)
+      - tool_ascentlint ? (files_ascentlint_waiver)
       - files_rtl

--- a/hw/ip/prim_xilinx/lint/prim_xilinx_clock_gating.vlt
+++ b/hw/ip/prim_xilinx/lint/prim_xilinx_clock_gating.vlt
@@ -1,0 +1,4 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//

--- a/hw/ip/prim_xilinx/lint/prim_xilinx_clock_gating.waiver
+++ b/hw/ip/prim_xilinx/lint/prim_xilinx_clock_gating.waiver
@@ -1,0 +1,4 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#

--- a/hw/ip/prim_xilinx/lint/prim_xilinx_clock_mux2.vlt
+++ b/hw/ip/prim_xilinx/lint/prim_xilinx_clock_mux2.vlt
@@ -1,0 +1,4 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//

--- a/hw/ip/prim_xilinx/lint/prim_xilinx_clock_mux2.waiver
+++ b/hw/ip/prim_xilinx/lint/prim_xilinx_clock_mux2.waiver
@@ -1,0 +1,4 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#

--- a/hw/ip/prim_xilinx/lint/prim_xilinx_pad_wrapper.vlt
+++ b/hw/ip/prim_xilinx/lint/prim_xilinx_pad_wrapper.vlt
@@ -1,0 +1,4 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//

--- a/hw/ip/prim_xilinx/lint/prim_xilinx_pad_wrapper.waiver
+++ b/hw/ip/prim_xilinx/lint/prim_xilinx_pad_wrapper.waiver
@@ -1,0 +1,12 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_xilinx_pad_wrapper
+# note that this code is NOT synthesizable and meant for sim only
+waive -rules TRI_DRIVER -regexp {'inout_io' is driven by a tristate driver}
+      -location {prim_xilinx_pad_wrapper.sv}
+      -comment "This is a bidirectional pad inout."
+waive -rules INPUT_NOT_READ -regexp {Input port 'attr\_i\[.:2\]' is not read from}
+      -location {prim_xilinx_pad_wrapper.sv}
+      -comment "Some IO attributes may not be implemented."

--- a/hw/ip/prim_xilinx/lint/prim_xilinx_ram_2p.vlt
+++ b/hw/ip/prim_xilinx/lint/prim_xilinx_ram_2p.vlt
@@ -1,0 +1,4 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//

--- a/hw/ip/prim_xilinx/lint/prim_xilinx_ram_2p.waiver
+++ b/hw/ip/prim_xilinx/lint/prim_xilinx_ram_2p.waiver
@@ -1,0 +1,4 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#

--- a/hw/ip/prim_xilinx/lint/prim_xilinx_rom.vlt
+++ b/hw/ip/prim_xilinx/lint/prim_xilinx_rom.vlt
@@ -1,0 +1,4 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//

--- a/hw/ip/prim_xilinx/lint/prim_xilinx_rom.waiver
+++ b/hw/ip/prim_xilinx/lint/prim_xilinx_rom.waiver
@@ -1,0 +1,4 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#

--- a/hw/ip/prim_xilinx/prim_xilinx_clock_gating.core
+++ b/hw/ip/prim_xilinx/prim_xilinx_clock_gating.core
@@ -11,7 +11,26 @@ filesets:
       - rtl/prim_xilinx_clock_gating.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_xilinx_clock_gating.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_xilinx_clock_gating.waiver
+    file_type: waiver
+
+
 targets:
   default:
     filesets:
+      - tool_verilator  ? (files_verilator_waiver)
+      - tool_ascentlint ? (files_ascentlint_waiver)
       - files_rtl

--- a/hw/ip/prim_xilinx/prim_xilinx_clock_mux2.core
+++ b/hw/ip/prim_xilinx/prim_xilinx_clock_mux2.core
@@ -11,7 +11,26 @@ filesets:
       - rtl/prim_xilinx_clock_mux2.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_xilinx_clock_mux2.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_xilinx_clock_mux2.waiver
+    file_type: waiver
+
+
 targets:
   default:
     filesets:
+      - tool_verilator  ? (files_verilator_waiver)
+      - tool_ascentlint ? (files_ascentlint_waiver)
       - files_rtl

--- a/hw/ip/prim_xilinx/prim_xilinx_pad_wrapper.core
+++ b/hw/ip/prim_xilinx/prim_xilinx_pad_wrapper.core
@@ -11,7 +11,26 @@ filesets:
       - rtl/prim_xilinx_pad_wrapper.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_xilinx_pad_wrapper.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_xilinx_pad_wrapper.waiver
+    file_type: waiver
+
+
 targets:
   default:
     filesets:
+      - tool_verilator  ? (files_verilator_waiver)
+      - tool_ascentlint ? (files_ascentlint_waiver)
       - files_rtl

--- a/hw/ip/prim_xilinx/prim_xilinx_ram_2p.core
+++ b/hw/ip/prim_xilinx/prim_xilinx_ram_2p.core
@@ -11,7 +11,26 @@ filesets:
       - rtl/prim_xilinx_ram_2p.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_xilinx_ram_2p.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_xilinx_ram_2p.waiver
+    file_type: waiver
+
+
 targets:
   default:
     filesets:
+      - tool_verilator  ? (files_verilator_waiver)
+      - tool_ascentlint ? (files_ascentlint_waiver)
       - files_rtl

--- a/hw/ip/prim_xilinx/prim_xilinx_rom.core
+++ b/hw/ip/prim_xilinx/prim_xilinx_rom.core
@@ -13,7 +13,26 @@ filesets:
       - rtl/prim_xilinx_rom.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_xilinx_rom.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_xilinx_rom.waiver
+    file_type: waiver
+
+
 targets:
   default:
     filesets:
+      - tool_verilator  ? (files_verilator_waiver)
+      - tool_ascentlint ? (files_ascentlint_waiver)
       - files_rtl

--- a/hw/ip/rv_core_ibex/lint/rv_core_ibex.vlt
+++ b/hw/ip/rv_core_ibex/lint/rv_core_ibex.vlt
@@ -1,0 +1,1 @@
+../../../vendor/lowrisc_ibex/lint/verilator_waiver.vlt

--- a/hw/ip/rv_core_ibex/lint/rv_core_ibex.waiver
+++ b/hw/ip/rv_core_ibex/lint/rv_core_ibex.waiver
@@ -1,0 +1,101 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for Ibex core
+
+waive -rules ONE_BRANCH           -location {ibex_alu.sv} -regexp {unique case statement has only one branch} \
+      -comment "acceptable coding style, more readable than if-string"
+waive -rules EXPLICIT_BITLEN      -location {ibex_core.sv} -regexp {Bit length not specified for constant .*h2} \
+      -comment "better way to write it?"
+waive -rules HIER_BRANCH_NOT_READ -location {ibex_decoder.sv} -regexp {Net 'instr_rdata_i.*is not read from in module} \
+      -comment "not all bits are used"
+waive -rules INPUT_NOT_READ       -location {ibex_decoder.sv} -regexp {Input port 'instr_rdata_i.*is not read from in module} \
+      -comment "not all bits are used"
+waive -rules HIER_BRANCH_NOT_READ -location {ibex_id_stage.sv} -regexp {[nN]et 'test_en_i' .* is not read from} \
+      -comment "testability signal used in some versions of register file"
+waive -rules INPUT_NOT_READ       -location {ibex_register_file_ff.sv} -regexp {Input port 'test_en_i' is not read from} \
+      -comment "testability signal used in some versions of register file"
+waive -rules INPUT_NOT_READ       -location {ibex_core.sv} -regexp {Input port 'clock_en_i' is not read from} \
+      -comment "clock enable signal used in behavioral code"
+waive -rules HIER_NET_NOT_READ    -location {rv_core_ibex.sv} -regexp {Net 'instr_addr_o.1.0.' is not read from} \
+      -comment "Bottom bits not needed, cleaner to keep them as inputs"
+waive -rules NOT_READ             -location {rv_core_ibex.sv} -regexp {Signal 'instr_addr_o.1.0.' is not read from} \
+      -comment "Bottom bits not needed, cleaner to keep them as inputs"
+waive -rules HIER_NET_NOT_READ    -location {rv_core_ibex.sv} -regexp {Net 'data_addr_o.1.0.' is not read from} \
+      -comment "Bottom bits not needed, cleaner to keep them as inputs"
+waive -rules NOT_READ             -location {rv_core_ibex.sv} -regexp {Signal 'data_addr_o.1.0.' is not read from} \
+      -comment "Bottom bits not needed, cleaner to keep them as inputs"
+waive -rules HIER_NET_NOT_READ    -location {ibex_ex_block.sv} -regexp {Net 'alu_adder_result_ext.0.' .* is not read from} \
+      -comment "Bottom bit is round, not needed"
+waive -rules HIER_NET_NOT_READ    -location {ibex_ex_block.sv} -regexp {Connected net 'alu_adder_ext_i.0.' .* is not read from} \
+      -comment "Bottom bit is round, not needed"
+waive -rules HIER_NET_NOT_READ    -location {ibex_core.sv} -regexp {[nN]et 'boot_addr_i.7:0.' .* is not read from} \
+      -comment "Boot address is 256B aligned, cleaner to pass all bits in"
+waive -rules {INPUT_NOT_READ HIER_BRANCH_NOT_READ} -location {ibex_if_stage.sv} -regexp {'boot_addr_i.7:0.' is not read from} \
+      -comment "Boot address is 256B aligned, cleaner to pass all bits in"
+waive -rules HIER_NET_NOT_READ    -location {ibex_ex_block.sv} -regexp {[nN]et 'alu_adder.*0' is not read from} \
+      -comment "LSB is not needed here, shifting off before using"
+waive -rules INPUT_NOT_READ       -location {ibex_multdiv_fast.sv} -regexp {Input port 'alu_adder_ext_i.0.' is not read from} \
+      -comment "LSB is not needed here, shifting off before using"
+waive -rules HIER_NET_NOT_READ    -location {rv_core_ibex.sv} -regexp {Net 'tl_._fifo2ibex.d_(error|opcode|param|sink|size|source|user).*' is not read} \
+      -comment "Not all bits of instruction response needed"
+waive -rules NOT_READ             -location {rv_core_ibex.sv} -regexp {Signal 'tl_._fifo2ibex.d_(error|opcode|param|sink|size|source|user).*' is not read} \
+      -comment "Not all bits of instruction response needed"
+waive -rules NOT_READ             -location {ibex_cs_registers.sv} -regexp {Signal 'mstatus_n.mpp' is not read from} \
+      -comment "Cleaner to write this way even if currently fixed at M mode"
+waive -rules CONST_FF             -location {ibex_cs_registers.sv} -regexp {Flip.flop 'mstatus_q.mpp' is driven by constant ones} \
+      -comment "Cleaner to write this way even if currently fixed at M mode"
+waive -rules NOT_READ             -location {ibex_if_stage.sv} -regexp {Signal 'fetch_addr_n.0.' is not read from} \
+      -comment "cleaner to write all bits even if not all are used"
+waive -rules NOT_READ             -location {ibex_multdiv_fast.sv} -regexp {Signal 'mac_res_ext.34.' is not read from} \
+      -comment "cleaner to write all bits even if not all are used"
+waive -rules NOT_READ             -location {ibex_multdiv_fast.sv} -regexp {Signal 'res_adder_h.32.' is not read from} \
+      -comment "cleaner to write all bits even if not all are used"
+waive -rules MULTIPLY             -location {ibex_multdiv_fast.sv} -regexp {Multiply operation.*encountered} \
+      -comment "got to pay the price for the multiplier"
+waive -rules CONST_OUTPUT         -location {rv_core_ibex.sv} -regexp {Output 'tl_(i|d)_o..*' is driven by constant} \
+      -comment "not all bus constructs are used"
+waive -rules CONST_OUTPUT         -location {ibex_controller.sv} -regexp {Output 'exc_cause_o.5.' is driven by constant} \
+      -comment "easier to write with enum, not all causes used yet"
+waive -rules CONST_OUTPUT         -location {ibex_decoder.sv} -regexp {Output 'data_reg_offset_o' is driven by constant} \
+      -comment "fixed register offset"
+waive -rules CONST_OUTPUT         -location {ibex_decoder.sv} -regexp {Output 'alu_op_._mux_sel_o.*' is driven by constant} \
+      -comment "not all possible mux select values are used in enum"
+waive -rules CONST_OUTPUT         -location {ibex_multdiv_fast.sv} -regexp {Output 'alu_operand_._o.0.' is driven by constant} \
+      -comment "bottom bit set to 1 for rounding"
+waive -rules VAR_INDEX            -location {ibex_multdiv_fast.sv} -regexp {Variable index expression 'op_numerator_q.div_counter_n.' encountered} \
+      -comment "TODO: discuss: I don't think this is a problem"
+waive -rules VAR_INDEX            -location {ibex_register_file_ff.sv} -regexp {Variable index expression 'rf_reg.raddr_._i.' encountered} \
+      -comment "TODO: discuss: I don't think this is a problem"
+waive -rules NOT_READ             -location {ibex_cs_registers.sv} -regexp {Signal 'pccr_index' is not read from} \
+      -comment "Used in non synthesis scenario"
+waive -rules NOT_READ             -location {ibex_cs_registers.sv} -regexp {Signal 'pccr_all_sel' is not read from} \
+      -comment "Used in non synthesis scenario"
+waive -rules NOT_USED             -location {ibex_cs_registers.sv} -regexp {Signal 'PCCR_inc.*11.1.' is not used} \
+      -comment "Used in non synthesis scenario"
+waive -rules NOT_READ             -location {ibex_alu.sv} -regexp {Signal 'shift_right_result_ext.32.' is not read from} \
+      -comment "As mentioned in the RTL, MSB of shift_right_result_ext can be safely ignored"
+waive -rules NOT_READ             -location {ibex_id_stage.sv} -regexp {Signal 'operand_b_fw_id' is not read from in module 'ibex_id_stage'} \
+      -comment "This signal is actually used (not via a port but through hierarchical path) in ibex_core.sv"
+waive -rules INTEGER              -location {ibex_register_file_ff.sv rv_core_ibex.sv} -msg {'i' of type int used as a non-constant value} \
+      -comment "This assigns int i (signed) to a multibit logic variable (unsigned), which is fine"
+waive -rules ONE_BIT_MEM_WIDTH             -location {ibex_core.sv} -regexp {Memory 'pmp_req_err' has word width which is single bit wide} \
+      -comment "For consistency with related signals, we use an unpacked array for this signal."
+waive -rules HIER_BRANCH_NOT_READ -location {ibex_decoder.sv ibex_compressed_decoder.sv} -regexp {Net '(clk_i|rst_ni)' is not read from in module '(ibex_decoder|ibex_compressed_decoder)'.*} \
+      -comment "These signals are only used for assertions inside these two modules"
+waive -rules INPUT_NOT_READ -location {ibex_decoder.sv ibex_compressed_decoder.sv} -regexp {Input port '(clk_i|rst_ni)' is not read from in module '(ibex_decoder|ibex_compressed_decoder)'.*} \
+      -comment "These signals are only used for assertions inside these two modules"
+
+# Highlighting my main concerns here, documenting areas to review in next dive
+#
+# data_err_i is not used in load/store unit beyond assertions; this signal is
+# true when bus requests return in error. What is the right way to handle?
+#
+# lsu_load_err/lsu_store_err: similar above, except that the condition is
+# tied to false in ibex_load_store_unit and is unused in ID stage. Dead
+# code that should be removed? Or is this an indication of missing error
+# handling logic?
+#
+# output signal out_valid_stored_o from ibex_fetch_fifo is not used. Dead
+# code or indicating a bigger problem?

--- a/hw/ip/rv_core_ibex/rv_core_ibex.core
+++ b/hw/ip/rv_core_ibex/rv_core_ibex.core
@@ -15,16 +15,48 @@ filesets:
       - rtl/rv_core_ibex.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/rv_core_ibex.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/rv_core_ibex.waiver
+    file_type: waiver
+
+
 parameters:
   SYNTHESIS:
     datatype: bool
     paramtype: vlogdefine
-  ASIC_SYNTHESIS:
-    datatype: bool
-    paramtype: vlogdefine
+
 
 targets:
   default: &default_target
     filesets:
+      - tool_verilator  ? (files_verilator_waiver)
+      - tool_ascentlint ? (files_ascentlint_waiver)
       - files_rtl
     toplevel: rv_core_ibex
+
+  lint:
+    <<: *default_target
+    default_tool: verilator
+    parameters:
+      - SYNTHESIS=true
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"
+
+

--- a/hw/ip/rv_dm/lint/rv_dm.vlt
+++ b/hw/ip/rv_dm/lint/rv_dm.vlt
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// waiver file for rv_dm
+

--- a/hw/ip/rv_dm/lint/rv_dm.waiver
+++ b/hw/ip/rv_dm/lint/rv_dm.waiver
@@ -1,0 +1,77 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for rv_dm lint
+
+# dmi_jtag_tap
+waive -rules CLOCK_MUX -location {dmi_jtag_tap.sv} -regexp {Clock 'tck_n' is driven by a multiplexer here, used as a clock at dmi_jtag_tap.sv} \
+      -comment "This is permissible for now, but should be revised as soon as ASIC targets come into play."
+waive -rules INV_CLOCK -location {dmi_jtag_tap.sv} -regexp {'tck_i' is inverted, used as clock at dmi_jtag_tap.sv} \
+      -comment "This is permissible for now, but should be revised as soon as ASIC targets come into play."
+
+# dm_csrs
+waive -rules CONST_FF -location {dm_csrs.sv} -regexp {Flip-flop 'dmcontrol_q.*' is driven by constant zero} \
+      -comment "Parts of this struct are constantly set to zero."
+waive -rules CONST_FF -location {dm_csrs.sv} -regexp {Flip-flop 'abstractauto_q.*' is driven by constant zero.} \
+      -comment "Parts of this struct are constantly set to zero."
+waive -rules CONST_FF -location {dm_csrs.sv} -regexp {Flip-flop 'sbcs_q.sbaccess(8|16|64|128|\[17\]|\[19\])' is driven by constant zero} \
+      -comment "Parts of this struct are constantly set to zero."
+      waive -rules CONST_FF -location {dm_csrs.sv} -regexp {Flip-flop 'sbcs_q.sbasize\[(9:5|11)\]' is driven by constant zero} \
+      -comment "Parts of this struct are constantly set to zero."
+      waive -rules CONST_FF -location {dm_csrs.sv} -regexp {Flip-flop 'sbcs_q.sbversion\[31:30\]' is driven by constant zero.} \
+      -comment "Parts of this struct are constantly set to zero."
+waive -rules CASE_SEL_EXPR -location {dm_csrs.sv} -regexp {Expression 'dm::dm_csr_e.*as case selector} \
+      -comment "acceptable use"
+waive -rules NOT_READ -location {dm_csrs.sv} -regexp {Signal 'dmcontrol.(clrresethaltreq|dmactive|haltreq|hartreset|hartselhi|hartsello|hasel|ndmreset|resumereq|setresethaltreq|zero[0-1])' is not read from} \
+      -comment "These signals are not needed by dm_csrs module"
+waive -rules NOT_READ -location {dm_csrs.sv} -regexp {Signal 'a_abstractcs.(busy|datacount|progbufsize|zero[0-3])' is not read from} \
+      -comment "These signals are not needed by dm_csrs module"
+
+# dm_mem
+waive -rules INPUT_NOT_READ -location {dm_mem.sv} -regexp {Input port 'hartsel_i\[19:1\]' is not read from.*} \
+      -comment "These bits are not used since the system has only one hart."
+waive -rules ARITH_CONTEXT -location {dm_mem.sv} -regexp {Bitlength.*DbgAddressBits.*self-determined} \
+      -comment "should be no concern about loss of bit accuracy"
+waive -rules ONE_BRANCH    -location {dm_mem.sv} -regexp {unique case statement has only one branch} \
+      -comment "easier to write this way for extendability"
+waive -rules NOT_READ -location {dm_mem.sv} -regexp {Signal 'ac_ar.(regno.13.|zero1)' is not read from in module 'dm_mem'} \
+      -comment "These bits and fields are not used, but all other bits and fields are used"
+
+# tlul_adapter_host
+waive -rules HIER_BRANCH_NOT_READ -location {tlul_adapter_host.sv} -regexp {Net '(clk_i|rst_ni)' is not read from in module 'tlul_adapter_host'} \
+      -comment "These 2 signals are only used by assertions"
+waive -rules INPUT_NOT_READ       -location {tlul_adapter_host.sv} -regexp {Input port 'tl_i.d_(error|opcode|param|sink|size|source|user)' is not read from} \
+      -comment "Not all fields of response needed"
+waive -rules HIER_NET_NOT_READ -location {rv_dm.sv} -regexp {Connected net 'tl_i.d_(error|opcode|param|sink|size|source|user).*' at tlul_adapter_host.* is not read from} \
+      -comment "Not all fields of response needed"
+
+# dm_sba
+waive -rules HIER_BRANCH_NOT_READ  -location {dm_sba.sv}            -regexp {Net 'dmactive_i' is not read from in module 'dm_sba'} \
+      -comment "This signal is only used in an assertion"
+waive -rules INPUT_NOT_READ        -location {dm_sba.sv}            -regexp {Input port 'dmactive_i' is not read from in module 'dm_sba'} \
+      -comment "This input is only used by an assertion"
+
+# dm_pkg
+waive -rules INPUT_NOT_READ -location {dm_pkg.sv} -regexp {Input port 'imm.0.' is not read from in function '(jal|auipc)'} \
+      -comment "These functions use all bits of input imm, except for bit 0"
+
+# debug_rom and dm_mem
+waive -rules INPUT_NOT_READ -location {debug_rom.sv} -regexp {Input port 'addr_i.(2:0|63:8).' is not read from in module 'debug_rom'} \
+      -comment "These bits are not used, but the remaining address bits are used"
+waive -rules HIER_NET_NOT_READ -location {dm_mem.sv} -regexp {Connected net 'addr_i.(2:0|31:8).' at debug_rom.sv} \
+      -comment "These bits are not used, but the remaining address bits are used"
+
+# rv_dm
+waive -rules HIER_NET_NOT_READ -location {rv_dm.sv} -regexp {Net 'hartsel\[19:1\]' in module 'rv_dm'} \
+      -comment "These bits are not used since the system has only one hart."
+# dmi_jtag
+waive -rules HIER_NET_NOT_READ -location {dmi_jtag.sv} -regexp {Net 'dmi_resp.resp' is not read from in module 'dmi_jtag'} \
+      -comment "This part of the struct is not read from within this module."
+# dmi_jtag
+waive -rules NOT_READ -location {dmi_jtag.sv} -regexp {Signal 'dmi_resp.resp' is not read from in module 'dmi_jtag'} \
+      -comment "This part of the struct is not read from within this module."
+
+# tlul_adapter_host
+waive -rules INPUT_NOT_READ -location {tlul_adapter_host.sv} -regexp {Input port '(clk_i|rst_ni)' is not read from in module 'tlul_adapter_host'} \
+      -comment "The clock and reset signals are only used inside an assertion in this module"

--- a/hw/ip/rv_dm/rv_dm.core
+++ b/hw/ip/rv_dm/rv_dm.core
@@ -16,14 +16,53 @@ filesets:
       - rtl/tlul_adapter_host.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      #- lowrisc:lint:comportable
+    files:
+      - lint/rv_dm.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      #- lowrisc:lint:comportable
+    files:
+      - lint/rv_dm.waiver
+    file_type: waiver
+
+
 parameters:
   NrHarts:
     datatype: int
     paramtype: vlogparam
     description: Number of harts
 
+  SYNTHESIS:
+    datatype: bool
+    paramtype: vlogdefine
+
+
 targets:
   default: &default_target
     filesets:
+      - tool_verilator  ? (files_verilator_waiver)
+      - tool_ascentlint ? (files_ascentlint_waiver)
       - files_rtl
     toplevel: rv_dm
+
+  lint:
+    <<: *default_target
+    default_tool: verilator
+    parameters:
+      - SYNTHESIS=true
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"
+
+

--- a/hw/ip/rv_plic/lint/rv_plic.vlt
+++ b/hw/ip/rv_plic/lint/rv_plic.vlt
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// waiver file for rv_plic
+

--- a/hw/ip/rv_plic/lint/rv_plic.waiver
+++ b/hw/ip/rv_plic/lint/rv_plic.waiver
@@ -1,0 +1,23 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for Platform-Level Interrupt Controller
+
+waive -rules ONE_BIT_MEM_WIDTH -location {rv_plic.sv} -regexp {Memory '(claim_re|complete_we)' has} \
+      -comment "N_TARGET can be 1."
+
+waive -rules VAR_INDEX_RANGE -location {rv_plic.sv} -regexp {(claim_id|complete_id).* (maximum|minimum) value} \
+      -comment "Claim ID is guarded inside target module, complete ID has undeterministic behavior if FW writes OOR value"
+
+waive -rules HIER_NET_NOT_READ -location {rv_plic.sv} -regexp {[Nn]et 'tl_[io]\.[ad]_(address|param|user)} \
+      -comment "Register interface doesn't use upper address and param, user filed"
+
+waive -rules EXPLICIT_BITLEN -location {rv_plic_target.sv} -regexp {Bit length .* '1'} \
+      -comment "i + 1 is assumed as constant and guarded by SRCW"
+waive -rules INTEGER -location {rv_plic_target.sv} -regexp {'i' of type int used as} \
+      -comment "int i is static and only assigned to irq_id_next when it hits condition"
+
+waive -rules TWOS_COMP -location {rv_plic_target.sv} -regexp {Explicit two's complement with terms} \
+      -comment "This is permissible in this context"
+

--- a/hw/ip/rv_plic/rv_plic.core
+++ b/hw/ip/rv_plic/rv_plic.core
@@ -17,8 +17,47 @@ filesets:
       - rtl/rv_plic.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      #- lowrisc:lint:comportable
+    files:
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      #- lowrisc:lint:comportable
+    files:
+    file_type: waiver
+
+
+parameters:
+  SYNTHESIS:
+    datatype: bool
+    paramtype: vlogdefine
+
+
 targets:
   default: &default_target
     filesets:
+      - tool_verilator  ? (files_verilator_waiver)
+      - tool_ascentlint ? (files_ascentlint_waiver)
       - files_rtl
     toplevel: rv_plic
+
+  lint:
+    <<: *default_target
+    default_tool: verilator
+    parameters:
+      - SYNTHESIS=true
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"
+
+
+

--- a/hw/ip/rv_plic/rv_plic_component.core
+++ b/hw/ip/rv_plic/rv_plic_component.core
@@ -15,8 +15,29 @@ filesets:
       - rtl/rv_plic_target.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/rv_plic.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/rv_plic.waiver
+    file_type: waiver
+
+
 targets:
-  default: &default_target
+  default:
     filesets:
+      - tool_verilator  ? (files_verilator_waiver)
+      - tool_ascentlint ? (files_ascentlint_waiver)
       - files_rtl
-    toplevel: rv_plic
+

--- a/hw/ip/rv_timer/lint/rv_timer.vlt
+++ b/hw/ip/rv_timer/lint/rv_timer.vlt
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// waiver file for rv_timer
+

--- a/hw/ip/rv_timer/lint/rv_timer.waiver
+++ b/hw/ip/rv_timer/lint/rv_timer.waiver
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for timer
+
+waive -rules ARITH_BITLEN -location {timer_core.sv} -msg {Bitlength mismatch between 'mtime' length 64 and 'step' length 8} \
+      -comment "Bitwidths are fine here, it's a wrap-around counter"

--- a/hw/ip/rv_timer/rv_timer.core
+++ b/hw/ip/rv_timer/rv_timer.core
@@ -16,8 +16,48 @@ filesets:
       - rtl/rv_timer.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/rv_timer.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/rv_timer.waiver
+    file_type: waiver
+
+
+parameters:
+  SYNTHESIS:
+    datatype: bool
+    paramtype: vlogdefine
+
+
 targets:
   default: &default_target
     filesets:
+      - tool_verilator  ? (files_verilator_waiver)
+      - tool_ascentlint ? (files_ascentlint_waiver)
       - files_rtl
     toplevel: rv_timer
+
+  lint:
+    <<: *default_target
+    default_tool: verilator
+    parameters:
+      - SYNTHESIS=true
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"
+
+

--- a/hw/ip/spi_device/lint/spi_device.vlt
+++ b/hw/ip/spi_device/lint/spi_device.vlt
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// waiver file for spi_device
+

--- a/hw/ip/spi_device/lint/spi_device.waiver
+++ b/hw/ip/spi_device/lint/spi_device.waiver
@@ -1,0 +1,91 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for SPI Device
+
+waive -rules HIER_NET_NOT_READ -location {spi_device.sv} -regexp {[nN]et.*a_(address|param|user).*not read from} \
+      -comment "several TLUL signals are not used by register file"
+waive -rules HIER_NET_NOT_READ -location {spi_device.sv} -regexp {Net .reg2hw.*.qe. is not read from} \
+      -comment "registers with multiple fields often have unused qe's since they are duplicative"
+waive -rules NOT_READ -location {spi_device.sv} -regexp {Signal 'reg2hw.*.qe' is not read from} \
+      -comment "registers with multiple fields often have unused qe's since they are duplicative"
+
+waive -rules HIER_NET_NOT_READ -location {spi_device.sv} -regexp {[nN]et.*tl_h_i.[ad]_(ready|param|sink|size|source|user)} \
+      -comment "TL-UL converter doesn't use the signals"
+waive -rules HIER_NET_NOT_READ -location {spi_device.sv} -regexp {[nN]et.*[tr]xf_addr\.(base|limit)\.q.*' is not read} \
+      -comment "Only lower 9bits are used for sram_addr but leaving the register fields flexible"
+waive -rules HIER_NET_NOT_READ -location {spi_device.sv} -regexp {[nN]et.*sram_base_addr.*' is not read} \
+      -comment "Sram base address is given by parameter. Didn't decided if this field is used."
+waive -rules HIER_NET_NOT_READ -location {spi_device.sv} -regexp {[nN]et.*[rt]xf_ptr.*' is not read} \
+      -comment "Only lower bits are used for sram_addr but leaving the register fields flexible"
+waive -rules NOT_READ -location {spi_device.sv} -regexp {Signal.*[tr]xf_addr\.(base|limit)\.q.*' is not read} \
+      -comment "Only lower 9bits are used for sram_addr but leaving the register fields flexible"
+waive -rules NOT_READ -location {spi_device.sv} -regexp {Signal.*sram_base_addr.*' is not read} \
+      -comment "Sram base address is given by parameter. Didn't decided if this field is used."
+waive -rules NOT_READ -location {spi_device.sv} -regexp {Signal.*[rt]xf_ptr.*' is not read} \
+      -comment "Only lower bits are used for sram_addr but leaving the register fields flexible"
+waive -rules HIER_NET_NOT_READ -location {spi_device.sv} -regexp {[nN]et.*spi_mode.* is not read} \
+      -comment "FwMode is used. This field is used when EEPROM is implemented"
+waive -rules HIER_NET_NOT_READ -location {spi_device.sv} -regexp {[nN]et.*fwm_sram_error.* is not read} \
+      -comment "SRAM error correction code is not implemented"
+waive -rules HIER_NET_NOT_READ NOT_READ -location {spi_device.sv} -regexp {.*fifo_level\..xlvl\.q} \
+      -comment "RXLevel and TXLevel is used only for pointer width."
+waive -rules HIER_NET_NOT_READ -location {spi_device.sv} -regexp {(tl_sram_h2d|tl_i).*a_mask} \
+      -comment "TL SRAM adapter does not use mask"
+waive -rules HIER_NET_NOT_READ NOT_READ -location {spi_device.sv} -regexp {mem_(a|b)_(rerror|addr)} \
+      -comment "Only portion of Memory address is used depending on SramAw parameter"
+
+waive -rules NOT_READ -location {spi_fwm_rxf_ctrl.sv} -regexp {Signal 'ptr_cmp\[1:0\]' is not read} \
+      -comment "Only upper bits are used to compare FIFO full condition to avoid partial write"
+
+waive -rules CONST_OUTPUT -location {spi_fwm_txf_ctrl.sv} -regexp {Output 'sram_w.*' is driven} \
+      -comment "always read operation from TX FIFO CTRL"
+waive -rules CONST_OUTPUT -location {spi_fwm_*xf_ctrl.sv} -regexp {Output 'depth.*} \
+      -comment "Based on the SRAM size 2kB, it cannot hit the case"
+
+waive -rules CONST_FF -location {spi_fwmode.sv} -regexp {Flip-flop 'miso_shift\[0\]' is driven} \
+      -comment "Intended behavior"
+waive -rules CONST_FF -location {spi_device.sv} -regexp {fwm_rerr_q} \
+      -comment "Will implement the interrupt later. Waive for now"
+waive -rules CONST_FF -location {spi_fwmode.sv} -regexp {'tx_state' is driven by constant one} \
+      -comment "Intentionally reset to TxIdle and assign TxActive else. For CPHA=1 mode"
+
+waive -rules TWO_STATE_TYPE -location {spi_device.sv} -regexp {'fwm_fifo_e' is of} \
+      -comment "Intended declaration"
+
+waive -rules ONE_BIT_MEM_WIDTH -location {spi_device.sv} -regexp {Memory 'fwm_sram_.*' has word} \
+      -comment "Intended implementation to make it consistent with other signals"
+
+waive -rules EXPLICIT_BITLEN -location {spi_*} -regexp {for constant '1'} \
+      -comment "Parameter subtract is fine"
+
+waive -rules INPUT_NOT_READ -location {spi_fwm_*xf_ctrl.sv} -regexp {Input port 'sram_error' is not read} \
+      -comment "Sram error protection is not yet implemented"
+waive -rules INPUT_NOT_READ -location {spi_fwmode.sv} -regexp {Input port 'mode_i' is not read} \
+      -comment "Only FwMode is used at this moment"
+
+waive -rules CONST_FF -location {spi_device.sv} -msg {Flip-flop 'fwm_rxerr_q' is driven by constant zero} \
+      -comment "This is an unimplemented error signal which is currently tied to 0."
+
+# async resets
+waive -rules RESET_DRIVER -location {spi_device.sv} -regexp {'rst_(spi|txfifo|rxfifo)_n' is driven here, and used as an asynchronous reset} \
+      -comment "Async reset generation is required here"
+waive -rules RESET_MUX    -location {spi_device.sv} -regexp {Asynchronous reset 'rst_(spi|txfifo|rxfifo)_n' is driven by a multiplexer} \
+      -comment "The MUX is needed to control the reset during scanmode (scanmode_i == 1)"
+
+# clock inverter and muxes
+waive -rules CLOCK_MUX -location {spi_device.sv} -regexp {Clock 'sck_n' is driven by a multiplexer here, used as a clock 'clk_(out|src)_i'} \
+      -comment "The multiplexer is needed to bypass the clock inverter during testing"
+waive -rules CLOCK_MUX -location {spi_device.sv} -regexp {Clock 'clk_spi_(in|out)' is driven by a multiplexer here, used as a clock 'clk_(in|out|src)_i'} \
+      -comment "Thes multiplexers are needed to select between inverted and non-inverted clock based on configuration"
+
+#### INFO
+waive -rules VAR_INDEX -location {spi_fwm_rxf_ctrl.sv} -regexp {'byte_enable\[pos\]'} \
+      -comment "Flip-flop implemented"
+waive -rules VAR_INDEX -location {spi_fwm_rxf_ctrl.sv} -regexp {'sram_[wr]data.*'} \
+      -comment "Flip-flop implemented"
+waive -rules VAR_INDEX -location {spi_fwm_txf_ctrl.sv} -regexp {'fifo_wdata_d.*'} \
+      -comment "fifo_data_d is latched to fifo_data[7:0]"
+waive -rules CASE_INC -location {spi_fwm_*xf_ctrl.sv} -regexp {Case statement tag not} \
+      -comment "Enum type is used for state machine"

--- a/hw/ip/spi_device/spi_device.core
+++ b/hw/ip/spi_device/spi_device.core
@@ -21,8 +21,48 @@ filesets:
       - rtl/spi_device.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/spi_device.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/spi_device.waiver
+    file_type: waiver
+
+
+parameters:
+  SYNTHESIS:
+    datatype: bool
+    paramtype: vlogdefine
+
+
 targets:
   default: &default_target
     filesets:
+      - tool_verilator  ? (files_verilator_waiver)
+      - tool_ascentlint ? (files_ascentlint_waiver)
       - files_rtl
     toplevel: spi_device
+
+  lint:
+    <<: *default_target
+    default_tool: verilator
+    parameters:
+      - SYNTHESIS=true
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"
+
+

--- a/hw/ip/tlul/adapter_reg.core
+++ b/hw/ip/tlul/adapter_reg.core
@@ -14,8 +14,44 @@ filesets:
       - rtl/tlul_adapter_reg.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/tlul_adapter_reg.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/tlul_adapter_reg.waiver
+    file_type: waiver
+
+
+parameters:
+  SYNTHESIS:
+    datatype: bool
+    paramtype: vlogdefine
+
+
 targets:
   default: &default_target
     filesets:
+      - tool_verilator  ? (files_verilator_waiver)
+      - tool_ascentlint ? (files_ascentlint_waiver)
       - files_rtl
     toplevel: tlul_adapter_reg
+
+  lint:
+    <<: *default_target
+    default_tool: verilator
+    parameters:
+      - SYNTHESIS=true
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"

--- a/hw/ip/tlul/adapter_sram.core
+++ b/hw/ip/tlul/adapter_sram.core
@@ -14,8 +14,44 @@ filesets:
       - rtl/tlul_adapter_sram.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/tlul_adapter_sram.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/tlul_adapter_sram.waiver
+    file_type: waiver
+
+
+parameters:
+  SYNTHESIS:
+    datatype: bool
+    paramtype: vlogdefine
+
+
 targets:
   default: &default_target
     filesets:
+      - tool_verilator  ? (files_verilator_waiver)
+      - tool_ascentlint ? (files_ascentlint_waiver)
       - files_rtl
     toplevel: tlul_adapter_sram
+
+  lint:
+    <<: *default_target
+    default_tool: verilator
+    parameters:
+      - SYNTHESIS=true
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"

--- a/hw/ip/tlul/common.core
+++ b/hw/ip/tlul/common.core
@@ -18,7 +18,27 @@ filesets:
       - rtl/tlul_assert_multiple.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/tlul_common.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/tlul_common.waiver
+    file_type: waiver
+
+
 targets:
   default:
     filesets:
+      - tool_verilator  ? (files_verilator_waiver)
+      - tool_ascentlint ? (files_ascentlint_waiver)
       - files_rtl
+

--- a/hw/ip/tlul/lint/tlul_adapter_reg.vlt
+++ b/hw/ip/tlul/lint/tlul_adapter_reg.vlt
@@ -1,0 +1,4 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//

--- a/hw/ip/tlul/lint/tlul_adapter_reg.waiver
+++ b/hw/ip/tlul/lint/tlul_adapter_reg.waiver
@@ -1,0 +1,13 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for TLUL elements lint
+
+# Adapter (RegIF)
+waive -rules PARTIAL_CONST_ASSIGN -location {tlul_adapter_reg.sv} -regexp {rspop.*conditionally assigned a constant} \
+      -comment "makes the code more readable"
+waive -rules CONST_FF             -location {tlul_adapter_reg.sv} -regexp {rspop.*is driven by constant zeros} \
+      -comment "makes the code more readable"
+waive -rules INPUT_NOT_READ       -location {tlul_adapter_reg.sv} -regexp {Input port.*a_(address|param|user).*not read from} \
+      -comment "several TLUL signals are not used by register file"

--- a/hw/ip/tlul/lint/tlul_adapter_sram.vlt
+++ b/hw/ip/tlul/lint/tlul_adapter_sram.vlt
@@ -1,0 +1,4 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//

--- a/hw/ip/tlul/lint/tlul_adapter_sram.waiver
+++ b/hw/ip/tlul/lint/tlul_adapter_sram.waiver
@@ -1,0 +1,27 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for TLUL elements lint
+
+# Adapter (SRAM)
+# INPUT_NOT_READ
+waive -rules INPUT_NOT_READ -location {tlul_adapter_sram.sv} -regexp {Input port 'tl_i.a_(mask|param|user)} \
+      -comment "Not necessary for SRAM access"
+waive -rules HIER_NET_NOT_READ -regexp {Connected net 'tl_i.a_(mask|param|user).* is not read from in module 'tlul_adapter_sram'} \
+      -comment "Not necessary for SRAM access"
+waive -rules HIER_NET_NOT_READ -regexp {'rspfifo_full' is not read from in module 'tlul_adapter_sram'} \
+      -comment "This signal is only used by assertions"
+waive -rules CONST_OUTPUT -location {tlul_adapter_sram.sv} -regexp {tl_o\.d_(param|sink|user)} \
+      -comment "Tied to 0"
+waive -rules INPUT_NOT_READ -regexp {Input port 'rerror_i.0.' is not read from in module 'tlul_adapter_sram'} \
+      -comment "This module only cares about bit [1] of error (i.e. uncorrectable errors), it doesn't care about correctable errors (bit [0])"
+waive -rules INPUT_NOT_READ -regexp {Input port 'tl_i.a_address.*' is not read from} \
+      -comment "Not all bits of a_address are used (depending on the address parameters)"
+waive -rules HIER_NET_NOT_READ -regexp {Connected net 'tl_i.a_address.*' at tlul_adapter_sram.sv.* is not read from in module 'tlul_adapter_sram'} \
+      -comment "Not all bits of a_address are used (depending on the address parameters)"
+waive -rules HIER_NET_NOT_READ -msg {Net 'rspfifo_wready' is not read from in module 'tlul_adapter_sram'} \
+      -comment "This signal is only used by an assertion"
+waive -rules NOT_READ -msg {Signal 'rspfifo_wready' is not read from in module 'tlul_adapter_sram'} \
+      -comment "This signal is only used by an assertion"
+

--- a/hw/ip/tlul/lint/tlul_common.vlt
+++ b/hw/ip/tlul/lint/tlul_common.vlt
@@ -1,0 +1,4 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//

--- a/hw/ip/tlul/lint/tlul_common.waiver
+++ b/hw/ip/tlul/lint/tlul_common.waiver
@@ -1,0 +1,21 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for common TLUL elements
+
+# TLUL Error
+waive -rules {HIER_NET_NOT_READ HIER_BRANCH_NOT_READ INPUT_NOT_READ NOT_READ PARAM_NOT_USED} -location {tlul_err.sv} \
+      -comment "All error checkings are comb logic and only portion of signals are used"
+waive -rules {ASSIGN_SIGN} -location {tlul_err.sv} -regexp {Unsigned target 'mask'} \
+      -comment "Waive for readability"
+waive -rules {HIER_NET_NOT_READ} -regexp {Connected net 'tl_i.a_(address|param|user).*in module 'tlul_err'} \
+      -comment "unused signal is back-propagated to the instance"
+
+# TODO: move this into the top-level waiver file
+## xbar
+#waive -rules HIER_NET_NOT_READ -location {tlul_xbar.sv} -regexp {a_source.* is not read from} \
+#      -comment "upper bits of a_source are shifted off when going through M:1 sockets"
+#
+#waive -rules LINE_LENGTH -location {xbar_main.sv} -regexp {Line length of .* exceeds 100 character limit} \
+#      -comment "This is a generated file and it is hence permissible to have line lengths that exceed this limit"

--- a/hw/ip/tlul/lint/tlul_socket_1n.vlt
+++ b/hw/ip/tlul/lint/tlul_socket_1n.vlt
@@ -1,0 +1,4 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//

--- a/hw/ip/tlul/lint/tlul_socket_1n.waiver
+++ b/hw/ip/tlul/lint/tlul_socket_1n.waiver
@@ -1,0 +1,24 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for TLUL elements lint
+
+# socket 1:N
+waive -rules INVALID_COMPARE   -location {tlul_socket_1n.sv} -regexp {Comparison '.dev_select_t == NWD'.*can never be true} \
+      -comment "lint appears to be confused about the width expansion of NWD'(2)'"
+waive -rules MIXED_SIGN        -location {tlul_socket_1n.sv} -regexp {Unsigned operand .* and signed .NWD} \
+      -comment "is there a way to make NWD'(idx)' an unsigned operand?"
+waive -rules HIER_NET_NOT_READ -location {tlul_socket_1n.sv} -regexp {a_(address|data|mask|param|size|user.*)' in module 'tlul_socket_1n'} \
+      -comment "request collateral is not used in \[N\] case, just for error response"
+waive -rules NOT_READ          -location {tlul_socket_1n.sv} -regexp {'tl_t_p.a_ready' is not read from in module 'tlul_socket_1n'} \
+      -comment "a_ready not needed, goes into FIFO"
+waive -rules INTEGER           -location {tlul_socket_1n.sv} -msg {'idx' of type int used as a non-constant value} \
+      -comment "This compares int idx (signed) with a multibit logic variable (unsigned), which is fine"
+
+# err_rsp
+waive -rules INPUT_NOT_READ    -location {tlul_err_resp.sv} -regexp {Input port 'tl_h_i.a_.*' is not read from in module 'tlul_err_resp'} \
+      -comment "error response does not require command/address information"
+waive -rules CONST_OUTPUT      -location {tlul_err_resp.sv} -regexp {Output 'tl_h_o.d_.*' is driven by constant} \
+      -comment "error response hard codes reponse data collateral"
+

--- a/hw/ip/tlul/lint/tlul_socket_m1.vlt
+++ b/hw/ip/tlul/lint/tlul_socket_m1.vlt
@@ -1,0 +1,4 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//

--- a/hw/ip/tlul/lint/tlul_socket_m1.waiver
+++ b/hw/ip/tlul/lint/tlul_socket_m1.waiver
@@ -1,0 +1,18 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for TLUL elements lint
+
+# socket M:1
+waive -rules HIER_NET_NOT_READ -location {tlul_socket_m1.sv} -regexp {a_.* in module 'tlul_socket_1n'} \
+      -comment "request collateral is not used in \[N\] case, just for error response"
+waive -rules HIER_NET_NOT_READ -location {tlul_socket_m1.sv} -regexp {Net 'arb_data.a_valid' is not read from in module 'tlul_socket_m1'} \
+      -comment "valid is not used, it is assumed valid if it got into the arbiter"
+waive -rules HIER_NET_NOT_READ -location {tlul_socket_m1.sv} -regexp {Net 'arb_data.d_ready' is not read from in module 'tlul_socket_m1'} \
+      -comment "ready is not used, it is assumed valid if it got into the arbiter"
+waive -rules NOT_READ          -location {tlul_socket_m1.sv} -regexp {Signal 'arb_data.a_valid' is not read from in module 'tlul_socket_m1'} \
+      -comment "valid is not used, it is assumed valid if it got into the arbiter"
+waive -rules NOT_READ          -location {tlul_socket_m1.sv} -regexp {Signal 'arb_data.d_ready' is not read from in module 'tlul_socket_m1'} \
+      -comment "ready is not used, it is assumed valid if it got into the arbiter"
+

--- a/hw/ip/tlul/lint/tlul_sram2tlul.vlt
+++ b/hw/ip/tlul/lint/tlul_sram2tlul.vlt
@@ -1,0 +1,4 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//

--- a/hw/ip/tlul/lint/tlul_sram2tlul.waiver
+++ b/hw/ip/tlul/lint/tlul_sram2tlul.waiver
@@ -1,0 +1,16 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for TLUL elements lint
+
+# sram2tlul
+waive -rules CONST_OUTPUT -location {sram2tlul.sv} -regexp {Output 'tl_o\.[ad]_.*' is driven by constant} \
+      -comment "Outputs are fixed value for TL-UL converter"
+waive -rules HIER_BRANCH_NOT_READ -location {sram2tlul.sv} -regexp {Net '(clk_i|rst_ni)' is not read from} \
+      -comment "Leaving clock and reset port for next update, looking at TL-UL ready signal"
+waive -rules INPUT_NOT_READ -location {sram2tlul.sv} -regexp {Input.*'(clk_i|rst_ni)' is not read} \
+      -comment "leaving clock and reset in converter for future use, handling a_ready"
+waive -rules INPUT_NOT_READ -location {sram2tlul.sv} -regexp {Input.*'tl_i\.[ad]_(ready|param|sink|size|source|user.*)' is not read} \
+      -comment "Those values are not checked by SRAM TL-UL adapter"
+

--- a/hw/ip/tlul/socket_1n.core
+++ b/hw/ip/tlul/socket_1n.core
@@ -16,8 +16,44 @@ filesets:
       - rtl/tlul_socket_1n.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/tlul_socket_1n.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/tlul_socket_1n.waiver
+    file_type: waiver
+
+
+parameters:
+  SYNTHESIS:
+    datatype: bool
+    paramtype: vlogdefine
+
+
 targets:
   default: &default_target
     filesets:
+      - tool_verilator  ? (files_verilator_waiver)
+      - tool_ascentlint ? (files_ascentlint_waiver)
       - files_rtl
     toplevel: tlul_socket_1n
+
+  lint:
+    <<: *default_target
+    default_tool: verilator
+    parameters:
+      - SYNTHESIS=true
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"

--- a/hw/ip/tlul/socket_m1.core
+++ b/hw/ip/tlul/socket_m1.core
@@ -15,8 +15,44 @@ filesets:
       - rtl/tlul_socket_m1.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/tlul_socket_m1.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/tlul_socket_m1.waiver
+    file_type: waiver
+
+
+parameters:
+  SYNTHESIS:
+    datatype: bool
+    paramtype: vlogdefine
+
+
 targets:
   default: &default_target
     filesets:
+      - tool_verilator  ? (files_verilator_waiver)
+      - tool_ascentlint ? (files_ascentlint_waiver)
       - files_rtl
     toplevel: tlul_socket_m1
+
+  lint:
+    <<: *default_target
+    default_tool: verilator
+    parameters:
+      - SYNTHESIS=true
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"

--- a/hw/ip/tlul/sram2tlul.core
+++ b/hw/ip/tlul/sram2tlul.core
@@ -14,8 +14,44 @@ filesets:
       - rtl/sram2tlul.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/tlul_sram2tlul.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/tlul_sram2tlul.waiver
+    file_type: waiver
+
+
+parameters:
+  SYNTHESIS:
+    datatype: bool
+    paramtype: vlogdefine
+
+
 targets:
   default: &default_target
     filesets:
+      - tool_verilator  ? (files_verilator_waiver)
+      - tool_ascentlint ? (files_ascentlint_waiver)
       - files_rtl
     toplevel: sram2tlul
+
+  lint:
+    <<: *default_target
+    default_tool: verilator
+    parameters:
+      - SYNTHESIS=true
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"

--- a/hw/ip/uart/lint/uart.waiver
+++ b/hw/ip/uart/lint/uart.waiver
@@ -1,0 +1,37 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for UART lint
+
+waive -rules HIER_NET_NOT_READ -location {uart.sv} -regexp {[nN]et.*a_(address|param|user).*not read from} \
+      -comment "several TLUL signals are not used by register file"
+waive -rules HIER_NET_NOT_READ -location {uart.sv} -regexp {[nN]et 'reg2hw.rdata.q' .* is not read from} \
+      -comment "don't need this data, only marking hwaccess as 'hrw' in order to get the .re signal"
+waive -rules INPUT_NOT_READ    -location {uart_core.sv} -regexp {Input port 'reg2hw.rdata.q' is not read from} \
+      -comment "don't need this data, only marking hwaccess as 'hrw' in order to get the .re signal"
+waive -rules HIER_NET_NOT_READ -location {uart.sv} -regexp {[nN]et 'reg2hw.status.*q' .* is not read from} \
+      -comment "don't need this data, only marking hwaccess as 'hrw' in order to get the .re signal"
+waive -rules INPUT_NOT_READ    -location {uart_core.sv} -regexp {Input port 'reg2hw.status.*' is not read from} \
+      -comment "don't need this data, only marking hwaccess as 'hrw' in order to get the .re signal"
+waive -rules HIER_NET_NOT_READ -location {uart.sv} -regexp {[nN]et 'reg2hw.status.*re' .* is not read from} \
+      -comment "registers with multiple fields often have unused re's since they are duplicative"
+waive -rules HIER_NET_NOT_READ -location {uart.sv} -regexp {Net 'reg2hw.*.qe.* is not read from} \
+      -comment "registers with multiple fields often have unused qe's since they are duplicative"
+waive -rules NOT_READ          -location {uart.sv} -regexp {Signal 'reg2hw.*.qe' is not read from} \
+      -comment "registers with multiple fields often have unused qe's since they are duplicative"
+waive -rules INPUT_NOT_READ    -location {uart_core.sv} -regexp {Input port 'reg2hw.*.qe' is not read from} \
+      -comment "registers with multiple fields often have unused qe's since they are duplicative"
+waive -rules CONST_OUTPUT      -location {uart.sv} -regexp {Output 'cio_tx_en_o' is driven by constant one} \
+      -comment "required output, always true"
+waive -rules CONST_OUTPUT      -location {uart_core.sv} -regexp {Output 'hw2reg.fifo_ctrl.*.(d|de)' is driven by constant} \
+      -comment "need .d/.de for some fields, not for others"
+
+# async resets
+waive -rules RESET_DRIVER -location {uart_core.sv} -regexp {'(tx|rx)_fifo_rst_n' is driven here, and used as an asynchronous reset} \
+      -comment "Async reset generation is required here"
+waive -rules RESET_MUX    -location {uart_core.sv} -regexp {Asynchronous reset '(tx|rx)_fifo_rst_n' is driven by a multiplexer} \
+      -comment "The MUX is needed to control the reset during scanmode (scanmode_i == 1)"
+
+waive -rules UNREACHABLE -location {uart_core.sv} -msg {'break_st_q' is assigned to a non-x value within the default branch of a fully specified case statement} \
+      -comment "This is fine, lint tool doesn't seem to recognize the if-statements in the case-items."

--- a/hw/ip/uart/uart.core
+++ b/hw/ip/uart/uart.core
@@ -19,8 +19,48 @@ filesets:
       - rtl/uart.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/uart.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/uart.waiver
+    file_type: waiver
+
+
+parameters:
+  SYNTHESIS:
+    datatype: bool
+    paramtype: vlogdefine
+
+
 targets:
   default: &default_target
     filesets:
+      - tool_verilator  ? (files_verilator_waiver)
+      - tool_ascentlint ? (files_ascentlint_waiver)
       - files_rtl
     toplevel: uart
+
+  lint:
+    <<: *default_target
+    default_tool: verilator
+    parameters:
+      - SYNTHESIS=true
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"
+
+

--- a/hw/ip/usb_fs_nb_pe/lint/usb_fs_nb_pe.vlt
+++ b/hw/ip/usb_fs_nb_pe/lint/usb_fs_nb_pe.vlt
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// waiver file for usb_fs_nb_pe
+

--- a/hw/ip/usb_fs_nb_pe/lint/usb_fs_nb_pe.waiver
+++ b/hw/ip/usb_fs_nb_pe/lint/usb_fs_nb_pe.waiver
@@ -1,0 +1,5 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for usb_fs_nb_pe

--- a/hw/ip/usb_fs_nb_pe/usbfs_nb_pe.core
+++ b/hw/ip/usb_fs_nb_pe/usbfs_nb_pe.core
@@ -17,8 +17,48 @@ filesets:
       - rtl/usb_fs_nb_pe.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/usb_fs_nb_pe.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/usb_fs_nb_pe.waiver
+    file_type: waiver
+
+
+parameters:
+  SYNTHESIS:
+    datatype: bool
+    paramtype: vlogdefine
+
+
 targets:
   default: &default_target
     filesets:
+      - tool_verilator  ? (files_verilator_waiver)
+      - tool_ascentlint ? (files_ascentlint_waiver)
       - files_rtl
     toplevel: usb_fs_nb_pe
+
+  lint:
+    <<: *default_target
+    default_tool: verilator
+    parameters:
+      - SYNTHESIS=true
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"
+
+

--- a/hw/ip/usbdev/lint/usbdev.vlt
+++ b/hw/ip/usbdev/lint/usbdev.vlt
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// waiver file for usbdev
+

--- a/hw/ip/usbdev/lint/usbdev.waiver
+++ b/hw/ip/usbdev/lint/usbdev.waiver
@@ -1,0 +1,5 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for usbdev

--- a/hw/ip/usbdev/usbdev.core
+++ b/hw/ip/usbdev/usbdev.core
@@ -19,8 +19,48 @@ filesets:
       - rtl/usbdev.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/usbdev.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/usbdev.waiver
+    file_type: waiver
+
+
+parameters:
+  SYNTHESIS:
+    datatype: bool
+    paramtype: vlogdefine
+
+
 targets:
   default: &default_target
     filesets:
+      - tool_verilator  ? (files_verilator_waiver)
+      - tool_ascentlint ? (files_ascentlint_waiver)
       - files_rtl
     toplevel: usbdev
+
+  lint:
+    <<: *default_target
+    default_tool: verilator
+    parameters:
+      - SYNTHESIS=true
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"
+
+

--- a/hw/ip/usbuart/lint/usbuart.vlt
+++ b/hw/ip/usbuart/lint/usbuart.vlt
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// waiver file for usbuart
+

--- a/hw/ip/usbuart/lint/usbuart.waiver
+++ b/hw/ip/usbuart/lint/usbuart.waiver
@@ -1,0 +1,6 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for usbuart
+

--- a/hw/ip/usbuart/usbuart.core
+++ b/hw/ip/usbuart/usbuart.core
@@ -20,8 +20,48 @@ filesets:
       - rtl/usbuart.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/usbuart.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/usbuart.waiver
+    file_type: waiver
+
+
+parameters:
+  SYNTHESIS:
+    datatype: bool
+    paramtype: vlogdefine
+
+
 targets:
   default: &default_target
     filesets:
+      - tool_verilator  ? (files_verilator_waiver)
+      - tool_ascentlint ? (files_ascentlint_waiver)
       - files_rtl
     toplevel: usbuart
+
+  lint:
+    <<: *default_target
+    default_tool: verilator
+    parameters:
+      - SYNTHESIS=true
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"
+
+

--- a/hw/top_earlgrey/lint/top_earlgrey.vlt
+++ b/hw/top_earlgrey/lint/top_earlgrey.vlt
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// waiver file for top_earlgrey
+

--- a/hw/top_earlgrey/lint/top_earlgrey.waiver
+++ b/hw/top_earlgrey/lint/top_earlgrey.waiver
@@ -1,0 +1,23 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for top_earlgrey
+
+# dedicated reset drivers / muxes
+waive -rules RESET_DRIVER -location {top_earlgrey.sv} -msg {sys_rst_n' is driven here, and used as an asynchronous reset 'rst_ni'} \
+      -comment "This is dedicated reset infrastructure, and hence permissible"
+waive -rules RESET_DRIVER -location {top_earlgrey.sv} -msg {'spi_device_rst_n' is driven here, and used as an asynchronous reset 'rst_ni' at spi_device} \
+      -comment "This is dedicated reset infrastructure, and hence permissible"
+waive -rules RESET_DRIVER -location {top_earlgrey.sv} -msg {'spi_device_rst_n' driven in module 'top_earlgrey' by 'sys_rst_n' at top_earlgrey} \
+      -comment "This is dedicated reset infrastructure, and hence permissible"
+waive -rules RESET_DRIVER -location {top_earlgrey.sv} -msg {'sys_rst_n' driven in module 'top_earlgrey' at top_earlgrey} \
+      -comment "This is dedicated reset infrastructure, and hence permissible"
+waive -rules RESET_MUX -location {top_earlgrey.sv} -msg {Asynchronous reset 'sys_rst_n' is driven by a multiplexer here, used as a reset 'rst_ni' at rv_core_ibex} \
+      -comment "This is dedicated reset infrastructure, and hence permissible"
+
+## xbar
+#waive -rules HIER_NET_NOT_READ -location {tlul_xbar.sv} -regexp {a_source.* is not read from} \
+#      -comment "upper bits of a_source are shifted off when going through M:1 sockets"
+#waive -rules LINE_LENGTH -location {xbar_main.sv} -regexp {Line length of .* exceeds 100 character limit} \
+#      -comment "This is a generated file and it is hence permissible to have line lengths that exceed this limit"

--- a/hw/top_earlgrey/top_earlgrey.core
+++ b/hw/top_earlgrey/top_earlgrey.core
@@ -47,11 +47,27 @@ filesets:
       - rtl/autogen/top_earlgrey.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/top_earlgrey.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/top_earlgrey.waiver
+    file_type: waiver
+
+
 parameters:
   SYNTHESIS:
-    datatype: bool
-    paramtype: vlogdefine
-  ASIC_SYNTHESIS:
     datatype: bool
     paramtype: vlogdefine
   # For value definition, please see ip/prim/rtl/prim_pkg.sv
@@ -61,13 +77,17 @@ parameters:
     description: Primitives implementation to use, e.g. "prim_pkg::ImplGeneric".
     default: prim_pkg::ImplGeneric
 
+
 targets:
   default: &default_target
     filesets:
+      - tool_verilator  ? (files_verilator_waiver)
+      - tool_ascentlint ? (files_ascentlint_waiver)
       - files_rtl_generic
     parameters:
       - PRIM_DEFAULT_IMPL=prim_pkg::ImplGeneric
     toplevel: top_earlgrey
+
   sim:
     default_tool: icarus
     filesets:
@@ -75,3 +95,14 @@ targets:
     parameters:
       - PRIM_DEFAULT_IMPL=prim_pkg::ImplGeneric
     toplevel: top_earlgrey
+
+  lint:
+    <<: *default_target
+    default_tool: verilator
+    parameters:
+      - SYNTHESIS=true
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"


### PR DESCRIPTION
This is a follow-up PR of #1304 and basically replicates what has been done in that PR for all other IPs. Further, this PR adds all the ascentlint and verilator waiver files.

Do not merge this before the precursor PR has been merged.