### PR TITLE
[dv/hmac] Add non-blocking support to stress_all with rst and tl_error sequence

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/cip_base_vseq.sv
@@ -341,7 +341,9 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
             begin : seq_wo_reset
               fork
                 begin : tl_err_seq
-                  if (do_tl_err) run_tl_errors_vseq(.num_times($urandom_range(10, 1000)));
+                  if (do_tl_err) begin
+                    run_tl_errors_vseq(.num_times($urandom_range(10, 1000)), .do_wait_clk(1'b1));
+                  end
                 end
                 begin : stress_seq
                   uvm_sequence seq;

--- a/hw/dv/sv/cip_lib/cip_base_vseq__tl_errors.svh
+++ b/hw/dv/sv/cip_lib/cip_base_vseq__tl_errors.svh
@@ -114,13 +114,13 @@ virtual task tl_read_mem_err();
 endtask
 
 // generic task to check interrupt test reg functionality
-virtual task run_tl_errors_vseq(int num_times = 1);
+virtual task run_tl_errors_vseq(int num_times = 1, bit do_wait_clk = 0);
   bit test_mem_err_byte_write = (cfg.mem_ranges.size > 0) && !cfg.en_mem_byte_write;
   bit test_mem_err_read       = (cfg.mem_ranges.size > 0) && !cfg.en_mem_read;
-  `uvm_info(`gfn, "Running run_tl_errors_vseq", UVM_LOW)
   cfg.tlul_assert_ctrl_vif.drive(1'b0);
 
   for (int trans = 1; trans <= num_times; trans++) begin
+    `uvm_info(`gfn, $sformatf("Running run_tl_errors_vseq %0d/%0d", trans, num_times), UVM_LOW)
     if (cfg.en_devmode == 1) begin
       cfg.devmode_vif.drive($urandom_range(0, 1));
     end
@@ -139,6 +139,7 @@ virtual task run_tl_errors_vseq(int num_times = 1);
       end
     join_none
     wait fork;
+    if (do_wait_clk) cfg.clk_rst_vif.wait_clks($urandom_range(500, 10_000));
   end // for
   cfg.tlul_assert_ctrl_vif.drive(1'b1);
 endtask : run_tl_errors_vseq

--- a/hw/dv/sv/test_vectors/test_vectors_pkg.sv
+++ b/hw/dv/sv/test_vectors/test_vectors_pkg.sv
@@ -42,7 +42,7 @@ package test_vectors_pkg;
         `uvm_fatal(header, "Cannot find $plusarg for the test_vectors_dir.")
       end
     end
-    path = {test_vectors_dir, file_name};
+    path = {test_vectors_dir, "/", file_name};
   endfunction : get_test_vectors_path
 
   function automatic void open_file(input string path, output int fd);

--- a/hw/ip/aes/dv/env/aes_scoreboard.sv
+++ b/hw/ip/aes/dv/env/aes_scoreboard.sv
@@ -37,9 +37,6 @@ class aes_scoreboard extends cip_base_scoreboard #(
     bit write = item.is_write();
     uvm_reg_addr_t csr_addr = get_normalized_addr(item.a_addr);
 
-    super.process_tl_access(item, channel);
-    if (is_tl_err_exp || is_tl_unmapped_addr) return;
-
     // if access was to a valid csr, get the csr handle
      if (csr_addr inside {cfg.csr_addrs}) begin
 

--- a/hw/ip/gpio/dv/env/gpio_scoreboard.sv
+++ b/hw/ip/gpio/dv/env/gpio_scoreboard.sv
@@ -58,9 +58,6 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
     bit write               = item.is_write();
     uvm_reg_addr_t csr_addr = get_normalized_addr(item.a_addr);
 
-    super.process_tl_access(item, channel);
-    if (is_tl_err_exp || is_tl_unmapped_addr) return;
-
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.csr_addrs}) begin
       csr = ral.default_map.get_reg_by_offset(csr_addr);

--- a/hw/ip/hmac/dv/Makefile
+++ b/hw/ip/hmac/dv/Makefile
@@ -54,22 +54,22 @@ endif
 
 ifeq (${TEST_NAME},hmac_test_sha_vectors)
   UVM_TEST_SEQ   = hmac_test_vectors_sha_vseq
-  RUN_OPTS      += +test_vectors_dir=${DV_DIR}/../../../dv/sv/test_vectors/
+  RUN_OPTS      += +test_vectors_dir=${DV_DIR}/../../../dv/sv/test_vectors
 endif
 
 ifeq (${TEST_NAME},hmac_test_hmac_vectors)
   UVM_TEST_SEQ   = hmac_test_vectors_hmac_vseq
-  RUN_OPTS      += +test_vectors_dir=${DV_DIR}/../../../dv/sv/test_vectors/
+  RUN_OPTS      += +test_vectors_dir=${DV_DIR}/../../../dv/sv/test_vectors
 endif
 
 ifeq (${TEST_NAME},hmac_stress_all)
   UVM_TEST_SEQ   = hmac_stress_all_vseq
-  RUN_OPTS      += +test_vectors_dir=${DV_DIR}/../../../dv/sv/test_vectors/
+  RUN_OPTS      += +test_vectors_dir=${DV_DIR}/../../../dv/sv/test_vectors
   RUN_OPTS      += +test_timeout_ns=10_000_000_000
 endif
 
 ifeq (${TEST_NAME},hmac_stress_all_with_rand_reset)
-  RUN_OPTS      += +test_vectors_dir=${DV_DIR}/../../../dv/sv/test_vectors/
+  RUN_OPTS      += +test_vectors_dir=${DV_DIR}/../../../dv/sv/test_vectors
 endif
 ####################################################################################################
 ## Include the tool Makefile below                                                                ##

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_stress_all_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_stress_all_vseq.sv
@@ -36,8 +36,7 @@ class hmac_stress_all_vseq extends hmac_base_vseq;
       if (seq_names[seq_idx] == "hmac_common_vseq") begin
         hmac_common_vseq common_vseq;
         `downcast(common_vseq, hmac_vseq)
-        if ($urandom_range(0, 1)) common_vseq.common_seq_type = "intr_test";
-        else common_vseq.common_seq_type = "tl_errors";
+        common_vseq.common_seq_type = "intr_test";
       end
       hmac_vseq.start(p_sequencer);
     end

--- a/hw/ip/i2c/dv/env/i2c_scoreboard.sv
+++ b/hw/ip/i2c/dv/env/i2c_scoreboard.sv
@@ -49,9 +49,6 @@ class i2c_scoreboard extends cip_base_scoreboard #(
     bit write = item.is_write();
     uvm_reg_addr_t csr_addr = get_normalized_addr(item.a_addr);
 
-    super.process_tl_access(item, channel);
-    if (is_tl_err_exp || is_tl_unmapped_addr) return;
-
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.csr_addrs}) begin
       csr = ral.default_map.get_reg_by_offset(item.a_addr);

--- a/hw/ip/rv_timer/dv/env/rv_timer_scoreboard.sv
+++ b/hw/ip/rv_timer/dv/env/rv_timer_scoreboard.sv
@@ -40,9 +40,6 @@ class rv_timer_scoreboard extends cip_base_scoreboard #(.CFG_T (rv_timer_env_cfg
     bit     write           = item.is_write();
     uvm_reg_addr_t csr_addr = get_normalized_addr(item.a_addr);
 
-    super.process_tl_access(item, channel);
-    if (is_tl_err_exp || is_tl_unmapped_addr) return;
-
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.csr_addrs}) begin
       csr = ral.default_map.get_reg_by_offset(csr_addr);

--- a/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
@@ -71,8 +71,6 @@ class spi_device_scoreboard extends cip_base_scoreboard #(.CFG_T (spi_device_env
     bit     write           = item.is_write();
     uvm_reg_addr_t csr_addr = get_normalized_addr(item.a_addr);
 
-    super.process_tl_access(item, channel);
-    if (is_tl_err_exp || is_tl_unmapped_addr) return;
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.csr_addrs}) begin
       csr = ral.default_map.get_reg_by_offset(csr_addr);

--- a/hw/ip/uart/dv/env/uart_scoreboard.sv
+++ b/hw/ip/uart/dv/env/uart_scoreboard.sv
@@ -140,8 +140,6 @@ class uart_scoreboard extends cip_base_scoreboard #(.CFG_T(uart_env_cfg),
     bit     write           = item.is_write();
     uvm_reg_addr_t csr_addr = get_normalized_addr(item.a_addr);
 
-    super.process_tl_access(item, channel);
-    if (is_tl_err_exp || is_tl_unmapped_addr) return;
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.csr_addrs}) begin
       csr = ral.default_map.get_reg_by_offset(csr_addr);

--- a/util/uvmdvgen/scoreboard.sv.tpl
+++ b/util/uvmdvgen/scoreboard.sv.tpl
@@ -64,9 +64,6 @@ class ${name}_scoreboard extends dv_base_scoreboard #(
     bit     write           = item.is_write();
     uvm_reg_addr_t csr_addr = get_normalized_addr(item.a_addr);
 
-    super.process_tl_access(item, channel);
-    if (is_tl_err_exp || is_tl_unmapped_addr) return;
-
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.csr_addrs}) begin
       csr = ral.default_map.get_reg_by_offset(csr_addr);


### PR DESCRIPTION
Fix tl_err with rst in scb could not handle non-blocking read/write.
Fix hmac stress all test adding tl_error when the new
tl_err_with_rand_reset already included this test

Signed-off-by: Cindy Chen <chencindy@google.com>