### PR TITLE
[Aes /dv] added sanity test and a complete environment

### DIFF
--- a/hw/ip/aes/dv/Makefile
+++ b/hw/ip/aes/dv/Makefile
@@ -22,6 +22,16 @@ COMPILE_KEY     ?= default
 UVM_TEST        ?= aes_base_test
 UVM_TEST_SEQ    ?= aes_base_vseq
 
+# Make GCC find aes.h
+ifeq (${SIMULATOR},vcs)
+  BUILD_OPTS += -CFLAGS "-I${DV_DIR}/../model"
+else ifeq (${SIMULATOR},xcelium)
+  BUILD_OPTS += -I${DV_DIR}/../model
+endif
+
+# Make GCC link OpenSSL/BoringSSL
+BUILD_OPTS += -lcrypto
+
 ####################################################################################################
 ##                     A D D    I N D I V I D U A L    T E S T S    B E L O W                     ##
 ####################################################################################################
@@ -36,7 +46,7 @@ ifeq (${TEST_NAME},aes_wakeup_test)
   UVM_TEST_SEQ   = aes_wake_up_vseq
 endif
 
-ifeq (${TEST_NAME},aes_sanity)
+ifeq (${TEST_NAME},aes_sanity_test)
   UVM_TEST_SEQ   = aes_sanity_vseq
 endif
 

--- a/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi.c
+++ b/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi.c
@@ -4,7 +4,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <cstring>
+#include <string.h>
 
 #include "aes.h"
 #include "crypto.h"

--- a/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi.core
+++ b/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi.core
@@ -10,9 +10,8 @@ filesets:
       - lowrisc:model:aes:0.5
 
     files:
-      # Note: VCS needs the c/h-files to be treated as systemVerilogSource
-      - aes_model_dpi.c: { file_type: systemVerilogSource}
-      - aes_model_dpi.h: { file_type: systemVerilogSource, is_include_file: true}
+      - aes_model_dpi.c: { file_type: cSource }
+      - aes_model_dpi.h: { file_type: cSource, is_include_file: true }
       - aes_model_dpi_pkg.sv: { file_type: systemVerilogSource }
 
 targets:

--- a/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi.core
+++ b/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi.core
@@ -7,6 +7,7 @@ description: "AES model DPI"
 filesets:
   files_dv:
     depend:
+      - lowrisc:ip:aes:0.5
       - lowrisc:model:aes:0.5
 
     files:

--- a/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi_pkg.sv
+++ b/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi_pkg.sv
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 package aes_model_dpi_pkg;
+  import aes_pkg::*;
 
   // DPI-C imports
   import "DPI-C" context function void aes_crypt_dpi(
@@ -40,5 +41,23 @@ package aes_model_dpi_pkg;
     input  bit[7:0][31:0] key_i,
     output bit[7:0][31:0] key_o
   );
+
+  // wrapper function that converts from register format (4x32bit)
+  // to the 4x4x8 format of the c functions and back
+  // this ensures that RTL and refence models have same input and output format.
+  function automatic void aes_crypt(
+    input  bit             impl_i,
+    input  bit             mode_i,
+    input  bit       [2:0] key_len_i,
+    input  bit [7:0][31:0] key_i,
+    input  bit [3:0][31:0] data_i,
+    output bit [3:0][31:0] data_o);
+
+    bit [3:0][3:0][7:0] data_in, data_out;
+    data_in = aes_transpose(data_i);
+    aes_crypt_dpi(impl_i, mode_i, key_len_i, key_i, data_in, data_out);
+    data_o  = aes_transpose(data_out);
+    return;
+  endfunction
 
 endpackage

--- a/hw/ip/aes/dv/env/aes_env.core
+++ b/hw/ip/aes/dv/env/aes_env.core
@@ -13,9 +13,11 @@ filesets:
       - lowrisc:dv:cip_lib
       - lowrisc:dv:csr_utils
       - lowrisc:dv:gen_ral_pkg
+      - lowrisc:dv:aes_model_dpi
     files:
+      - aes_seq_item.sv: {is_include_file: true}
       - aes_env_pkg.sv
-      - aes_virtual_sequencer.sv: {is_include_file: true}      
+      - aes_virtual_sequencer.sv: {is_include_file: true}
       - aes_env_cfg.sv: {is_include_file: true}
       - aes_env_cov.sv: {is_include_file: true}
       - aes_env.sv: {is_include_file: true}

--- a/hw/ip/aes/dv/env/aes_env_cfg.sv
+++ b/hw/ip/aes/dv/env/aes_env_cfg.sv
@@ -9,6 +9,40 @@ class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block));
 
   `uvm_object_new
 
+  // Knobs //
+  int          data_len_min    = 128;
+  int          data_len_max    = 128;
+  bit          use_key_mask    = 0;
+  bit          use_c_model_pct = 0;
+
+
+  // rand variables
+  rand bit     ref_model;                        // 0: C model 1: OPEN_SSL/BORING_SSL
+  rand bit     key_mask;                         // randomly select if we force unused key bits to 0
+
+  // constraints
+  constraint c_ref_model { ref_model dist { 0 :/ use_c_model_pct,
+                                            1 :/ (100-use_c_model_pct) }; }
+
+
+  function void post_randomize();
+    if(use_key_mask) key_mask = 1;
+  endfunction
+
+
+  virtual function string convert2string();
+    string str = "";
+    str = super.convert2string();
+    str = {str,  $psprintf("\n\t ----| AES ENVIRONMENT CONFIG \t ") };
+    str = {str,  $psprintf("\n\t ----| Max data len %d bits \t ", data_len_max) };
+    str = {str,  $psprintf("\n\t ----| Min data len %d bits \t ", data_len_min) };
+    str = {str,  $psprintf("\n\t ----| Reference model:\t    %s              \t ",
+          (ref_model==0) ? "C-MODEL" : "OPEN_SSL" ) };
+    str = {str, "\n"};
+    return str;
+  endfunction
+
+
   virtual function void initialize_csr_addr_map_size();
     this.csr_addr_map_size = AES_ADDR_MAP_SIZE;
   endfunction : initialize_csr_addr_map_size

--- a/hw/ip/aes/dv/env/aes_env_pkg.sv
+++ b/hw/ip/aes/dv/env/aes_env_pkg.sv
@@ -29,8 +29,8 @@ package aes_env_pkg;
   // functions
 
   // package sources
-// `include "aes_reg_block.sv"
  `include "aes_env_cfg.sv"
+ `include "aes_seq_item.sv"
  `include "aes_env_cov.sv"
  `include "aes_virtual_sequencer.sv"
  `include "aes_scoreboard.sv"

--- a/hw/ip/aes/dv/env/aes_scoreboard.sv
+++ b/hw/ip/aes/dv/env/aes_scoreboard.sv
@@ -1,6 +1,8 @@
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
+import aes_model_dpi_pkg::*;
+import aes_pkg::*;
 
 class aes_scoreboard extends cip_base_scoreboard #(
     .CFG_T(aes_env_cfg),
@@ -9,39 +11,49 @@ class aes_scoreboard extends cip_base_scoreboard #(
   );
   `uvm_component_utils(aes_scoreboard)
 
-  // local variables
+  `uvm_component_new
 
+  // local variables
+  aes_seq_item dut_item;
   // TLM agent fifos
 
   // local queues to hold incoming packets pending comparison
+  mailbox #(aes_seq_item) dut_fifo;                                   // all incoming TL transactions will be written to this one
+  mailbox #(aes_seq_item) ref_fifo;                                   // this will be a clone of the above before the result has been calculated by the dut!
 
-  `uvm_component_new
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
+
+    dut_fifo = new();
+    ref_fifo = new();
+    dut_item = new("dut_item");
   endfunction
+
 
   function void connect_phase(uvm_phase phase);
     super.connect_phase(phase);
   endfunction
 
+
   task run_phase(uvm_phase phase);
     super.run_phase(phase);
     fork
+      compare();
     join_none
   endtask
 
+
   virtual task process_tl_access(tl_seq_item item, tl_channels_e channel = DataChannel);
-    uvm_reg csr;
-    bit do_read_check = 1'b0;
-    bit write = item.is_write();
-    uvm_reg_addr_t csr_addr = get_normalized_addr(item.a_addr);
+    uvm_reg        csr;
+    aes_seq_item   ref_item;
+    bit            do_read_check = 1'b0;
+    bit            write         = item.is_write();
+    uvm_reg_addr_t csr_addr      = get_normalized_addr(item.a_addr);
 
     // if access was to a valid csr, get the csr handle
-     if (csr_addr inside {cfg.csr_addrs}) begin
-
-       csr = ral.default_map.get_reg_by_offset(csr_addr);
-
+    if (csr_addr inside {cfg.csr_addrs}) begin
+      csr = ral.default_map.get_reg_by_offset(csr_addr);
       `DV_CHECK_NE_FATAL(csr, null)
     end else begin
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
@@ -52,26 +64,171 @@ class aes_scoreboard extends cip_base_scoreboard #(
       if (write) begin
         void'(csr.predict(.value(item.a_data), .kind(UVM_PREDICT_WRITE), .be(item.a_mask)));
       end
+      case (csr.get_name())
+        // add individual case item for each csr
+        "ctrl": begin
+          {dut_item.allow_data_ovrwrt, dut_item.man_trigger,dut_item.key_size,dut_item.mode}
+          = item.a_data[5:0];
+        end
+        "key0": begin
+          dut_item.key[0] = item.a_data;
+        end
+        "key1": begin
+          dut_item.key[1] = item.a_data;
+        end
+        "key2": begin
+          dut_item.key[2] = item.a_data;
+        end
+        "key3": begin
+          dut_item.key[3] = item.a_data;
+        end
+        "key4": begin
+          dut_item.key[4] = item.a_data;
+        end
+        "key5": begin
+          dut_item.key[5] = item.a_data;
+        end
+        "key6": begin
+          dut_item.key[6] = item.a_data;
+        end
+        "key7": begin
+          dut_item.key[7] = item.a_data;
+        end
+
+        "data_in0" :begin
+          dut_item.data_in[0]     = item.a_data;
+          dut_item.data_in_vld[0] = 1;
+        end
+
+        "data_in1" :begin
+          dut_item.data_in[1]     = item.a_data;
+          dut_item.data_in_vld[1] = 1;
+        end
+
+        "data_in2" :begin
+          dut_item.data_in[2]     = item.a_data;
+          dut_item.data_in_vld[2] = 1;
+        end
+
+        "data_in3": begin
+          dut_item.data_in[3]     = item.a_data;
+          dut_item.data_in_vld[3] = 1;
+        end
+
+        "trigger": begin
+          if (item.a_data[0]) begin
+            `downcast(ref_item, dut_item.clone());
+            ref_fifo.put(ref_item);
+          end
+        end
+
+        "status": begin
+            //TBD
+        end
+
+        default: begin
+         // DO nothing- trying to write to a read only register
+        end
+      endcase
+
+      // forward Item and clear valid bits
+        if (!dut_item.man_trigger && (& dut_item.data_in_vld)) begin
+        `downcast(ref_item, dut_item.clone());
+        ref_fifo.put(ref_item);
+        ref_item = new();
+        dut_item.data_in_vld = '0;
+      end
     end
+
 
     // process the csr req
     // for write, update local variable and fifo at address phase
     // for read, update predication at address phase and compare at data phase
-    case (csr.get_name())
-      // add individual case item for each csr
-      default: begin
-        //`uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
-      end
-    endcase
-
     // On reads, if do_read_check, is set, then check mirrored_value against item.d_data
+    `uvm_info(`gfn, $sformatf("\n\t ---| channel  %h", channel), UVM_HIGH)
     if (!write && channel == DataChannel) begin
       if (do_read_check) begin
         `DV_CHECK_EQ(csr.get_mirrored_value(), item.d_data,
                      $sformatf("reg name: %0s", csr.get_full_name()))
       end
       void'(csr.predict(.value(item.d_data), .kind(UVM_PREDICT_READ)));
+        `uvm_info(`gfn, $sformatf("\n\t ----| SAW READ - %s data %02h",csr.get_name(),  item.d_data)
+                  , UVM_HIGH)
+
+      case (csr.get_name())
+        "data_out0": begin
+          dut_item.data_out[0]     = item.d_data;
+          dut_item.data_out_vld[0] = 1;
+        end
+        "data_out1": begin
+          dut_item.data_out[1]     = item.d_data;
+          dut_item.data_out_vld[1] = 1;
+        end
+        "data_out2": begin
+          dut_item.data_out[2]     = item.d_data;
+          dut_item.data_out_vld[2] = 1;
+        end
+        "data_out3": begin
+          dut_item.data_out[3]     = item.d_data;
+          dut_item.data_out_vld[3] = 1;
+        end
+      endcase
+        if (&dut_item.data_out_vld) begin
+        dut_fifo.put(dut_item);
+        dut_item = new();
+      end
     end
+  endtask
+
+
+  virtual task compare();
+    string txt="";
+    forever begin
+      aes_seq_item rtl_item;
+      aes_seq_item c_item;
+      bit [127:0] calc_data;
+
+      `uvm_info(`gfn, $sformatf("\n\t ----| TRYING to get item "), UVM_HIGH)
+      dut_fifo.get(rtl_item);
+      ref_fifo.get(c_item );
+      `uvm_info(`gfn, $sformatf("\n\t ----| GOT item "), UVM_HIGH)
+
+      aes_crypt(1'b0, c_item.mode, c_item.key_size, c_item.key, c_item.data_in, c_item.data_out);
+         `uvm_info(`gfn, $sformatf("\n\t ----| printing C MODEL %s", c_item.convert2string() )
+                   , UVM_HIGH)
+
+      if (!rtl_item.compare(c_item)) begin
+        txt = {txt,  $sformatf("\n\t ----| RTL_ITEM %s \n\t ", rtl_item.convert2string())};
+        txt = {txt, $sformatf("\n\t ----| printing C MODEL %s", c_item.convert2string() )};
+        txt = {txt,  $sformatf("\n\t ----| \t\t\t  DATA OUTPUT \t\t  |---- ")};
+        txt = {txt, $sformatf("\n\t ----| \t\t\t  RTL \t\t REF \t  |---- ")};
+        foreach (rtl_item.data_out[i]) begin
+          txt = {txt, $sformatf("\n\t ----| [%d] \t %02h \t %02h |----", i, rtl_item.data_out[i],
+                                c_item.data_out[i])};
+        end
+        `uvm_fatal(`gfn, $sformatf("\t TEST FAILED ITEMS DOES NOT MATCH \n\t %s \n",txt))
+      end else begin
+        `uvm_info(`gfn, $sformatf("\n\t ----|    ITEMS MATCHED    |-----"), UVM_LOW)
+      end
+    end
+  endtask
+
+
+  virtual function void phase_ready_to_end(uvm_phase phase);
+    if (phase.get_name() != "run") return;
+    if ( (dut_fifo.num() != 0 ) || (ref_fifo.num() != 0) ) begin
+      phase.raise_objection(this, "fifos still has data");
+      fork begin
+        wait_fifo_empty();
+        phase.drop_objection(this);
+      end
+      join_none
+    end
+  endfunction
+
+
+  virtual task wait_fifo_empty();
+    wait ((dut_fifo.num() == 0 ) && (ref_fifo.num() == 0));
   endtask
 
 
@@ -80,9 +237,19 @@ class aes_scoreboard extends cip_base_scoreboard #(
     // reset local fifos queues and variables
   endfunction
 
+
   function void check_phase(uvm_phase phase);
     super.check_phase(phase);
-    // post test checks - ensure that all local fifos and queues are empty
+    if ((dut_fifo.num() !=0 ) || (ref_fifo.num() != 0)) begin
+      `uvm_error(`gfn, $sformatf("\n\t ----| NO NO NO there are still items in the fifos dut: %d, ref %d"
+                                 , dut_fifo.num(), ref_fifo.num()))
+    end
+  endfunction
+
+
+  function void report_phase(uvm_phase phase);
+    super.report_phase(phase);
+    `uvm_info(`gfn, $sformatf("%s", cfg.convert2string()), UVM_LOW)
   endfunction
 
 endclass

--- a/hw/ip/aes/dv/env/aes_seq_item.sv
+++ b/hw/ip/aes/dv/env/aes_seq_item.sv
@@ -1,0 +1,168 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class aes_seq_item extends uvm_sequence_item;
+
+  // Knobs //
+  // min number of data bytes
+  int    data_len_max;
+  // Max number of data bytes
+  int    data_len_min;
+
+
+  // randomized values //
+  rand bit                                 mode; // TODO implement this as enum
+  // 0: auto start, 1: wait for start
+  rand bit                                 man_trigger;
+  // 0: output data cannot be overwritten
+  // 1: new output will overwrite old output even if not read.
+  rand bit                                 allow_data_ovrwrt;
+  // lenth of plaintext / cypher
+  rand bit                   [31:0]        data_len;
+  // key len 0: 128, 1: 192, 2: 256 3: NOT VALID
+  rand bit                   [2:0]         key_size;
+  // 256 bit key (8x32 bit)
+  rand bit              [7:0][31:0]        key;
+  // data queue to hold the randomized data
+  rand bit                   [31:0]        data_in_queue[$];
+  // randomized data to add to queue
+
+
+
+
+  // fixed variables //
+  // indicated which words has data
+  bit [3:0] data_in_vld  = 4'b0;
+  // indicated which words has data
+  bit                         [3:0]       data_out_vld = 4'b0;
+  // used by the checker
+  bit                   [3:0][31:0]       data_in;
+  // used by the checker
+  bit                   [3:0][31:0]       data_out;
+  // used to store output data
+  bit                        [31:0]       data_out_queue[$];
+  // set if data should be fixed and not randomized
+  bit                                     fixed_data = 0;
+  // if set unused key bytes will be forced to 0 - controlled from test
+  bit                                     key_mask=0;
+
+
+
+  function new( string name="aes_sequence_item");
+    super.new(name);
+  endfunction
+
+
+  // contraints //
+  constraint c_data {
+    solve data_len before data_in_queue;
+    data_len inside { [data_len_min: data_len_max] };
+
+    if(data_len[1:0] == 2'b00) {
+      data_in_queue.size() == data_len >> 2;
+    } else {
+      data_in_queue.size() ==  data_len >> 2 + 1;
+    }
+    if(data_len[1:0] == 2'b01) {
+      data_in_queue[$][31:8]   == 0;
+    } else if (data_len[1:0] == 2'b10) {
+      data_in_queue[$][31:16]  == 0;
+    } else {
+      data_in_queue[$][31:24]  == 0;
+    }
+  }
+
+  constraint c_key_size {key_size inside {3'b001, 3'b010, 3'b100 };
+             // key len 0: 128, 1: 192, 2: 256 3: NOT VALID
+  }
+
+  constraint c_mode_reg {mode == 0; man_trigger == 0; allow_data_ovrwrt == 0; }
+
+  function void post_randomize();
+    if(key_mask) begin
+      case (key_size)
+        3'b001: begin
+          key[7:4] = 32'h00000000;
+        end
+        3'b010: begin
+          key[7:6] = 32'h00000000;
+        end
+        default: begin
+        end
+      endcase
+    end
+  endfunction
+
+
+  function bit add2output( logic [31:0] data );
+    data_out_queue.push_back(data);
+    return 1;
+  endfunction
+
+
+  virtual function void do_copy(uvm_object rhs);
+    aes_seq_item rhs_;
+
+    if(!$cast(rhs_,rhs) ) begin
+      uvm_report_error("do_copy:", "acst failed");
+      return;
+    end
+    super.do_copy(rhs);
+    mode     = rhs_.mode;
+    data_in  = rhs_.data_in;
+    key      = rhs_.key;
+    key_size = rhs_.key_size;
+    data_out = rhs_.data_out;
+  endfunction // copy
+
+
+// do compare //
+virtual function bit do_compare(uvm_object rhs, uvm_comparer comparer);
+
+  aes_seq_item rhs_;
+
+  if(!$cast(rhs_,rhs))begin
+    return 0; // compare failed because object is not of sequence item type
+  end
+
+return(super.do_compare(rhs,comparer) &&
+  (mode     == rhs_.mode) &&
+  (data_in  == rhs_.data_in) &&
+  (key      == rhs_.key) &&
+  (data_out == rhs_.data_out) );
+endfunction // compare
+
+
+// convert to string //
+virtual function string convert2string();
+ string str;
+  str = super.convert2string();
+  str = {str,  $psprintf("\n\t ----| AES SEQUENCE ITEM                                  |----\t ")
+        };
+  str = {str,  $psprintf("\n\t ----| Mode:    \t %s                          |----\t ",
+        (mode==1'b0) ? "ENCRYPT" : "DECRYPT" ) };
+  str = {str,  $psprintf("\n\t ----| Key size:    \t %s                             |----\t ",
+         (key_size==3'b001) ? "128b" : (key_size == 3'b010) ? "192b" : "256b") };
+  str = {str,  $psprintf("\n\t ----| Key:         \t ") };
+  for(int i=0; i <8; i++) begin
+    str = {str, $psprintf("%h ",key[i])};
+  end
+  str = {str,  $psprintf("\n\t ----| Input data:  \t %h |----\t ", data_in) };
+  str = {str,  $psprintf("\n\t ----| Output data: \t %h |----\t ", data_out) };
+  str = {str,  $psprintf("\n\t") };
+
+  return str;
+  endfunction // conver2string
+
+  virtual function string bytes2string();
+    string str="\n\t ----| data_out: ";
+    for(int i=0; i<4; i++) begin
+        str = {str, $psprintf("%h", data_out[i][31:0])};
+    end
+    return str;
+  endfunction
+
+`uvm_object_utils(aes_seq_item)
+
+endclass

--- a/hw/ip/aes/dv/env/seq_lib/aes_sanity_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_sanity_vseq.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // basic sanity test vseq
-class aes_sanity_vseq extends aes_base_vseq;
+  class aes_sanity_vseq extends aes_base_vseq;
   `uvm_object_utils(aes_sanity_vseq)
 
   `uvm_object_new
@@ -11,11 +11,19 @@ class aes_sanity_vseq extends aes_base_vseq;
   task body();
 
     `uvm_info(`gfn, $sformatf("STARTING AES SEQUENCE"), UVM_LOW);
-    `DV_CHECK_RANDOMIZE_FATAL(this)
-    `uvm_info(`gfn, $sformatf("running aes sanity sequence"), UVM_LOW);
+
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(aes_item, key_size == 3'b001;)
+    set_mode(aes_item.mode);
+    set_key_len(aes_item.key_size);
+    // add key
+    write_key(aes_item.key);
+
+    // add data
+    add_data(aes_item.data_in_queue);
+
+    // get cypher
+    read_data(aes_item.data_out_queue);
 
   endtask : body
 
 endclass : aes_sanity_vseq
-
-

--- a/hw/ip/aes/dv/env/seq_lib/aes_wake_up_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_wake_up_vseq.sv
@@ -9,34 +9,45 @@ class aes_wake_up_vseq extends aes_base_vseq;
 
   `uvm_object_new
 
-  logic [127:0] plain_text = 128'hDEADBEEFEEDDBBAABAADBEEFDEAFBEAD;
-  logic [255:0] init_key   = 256'h0000111122223333444455556666777788889999AAAABBBBCCCCDDDDEEEEFFFF;
-  logic [127:0] cypher_text, decrypted_text;
+  bit [31:0]  plain_text[$]   = {32'hDEADBEEF, 32'hEEDDBBAA, 32'hBAADBEEF, 32'hDEAFBEAD};
+  logic [255:0] init_key      = 256'h0000111122223333444455556666777788889999AAAABBBBCCCCDDDDEEEEFFFF;
+  bit [31:0]    cypher_text[$];
+  bit [31:0]    decrypted_text[$];
+  logic [31:0]  read_text[$];
+
+  string  str="";
+
+
+
+
 
   task body();
 
-    `uvm_info(`gfn, $sformatf("STARTING AES SEQUENCE"), UVM_DEBUG)
+    `uvm_info(`gfn, $sformatf("STARTING AES SEQUENCE"), UVM_LOW)
     `DV_CHECK_RANDOMIZE_FATAL(this)
-    `uvm_info(`gfn, $sformatf("running aes sanity sequence"), UVM_DEBUG)
+    `uvm_info(`gfn, $sformatf("running aes sanity sequence"), UVM_LOW)
 
-    `uvm_info(`gfn, $sformatf(" \n\t ---|setting mode to encrypt"), UVM_DEBUG)
+    `uvm_info(`gfn, $sformatf(" \n\t ---|setting mode to encrypt"), UVM_LOW)
     // set mode to encrypt
     set_mode(ENCRYPT);
 
-    `uvm_info(`gfn, $sformatf(" \n\t ---| WRITING INIT KEY"), UVM_DEBUG)
-    // add init key
+
+    `uvm_info(`gfn, $sformatf(" \n\t ---| WRITING INIT KEY  %02h", init_key), UVM_LOW)
+
     write_key(init_key);
     cfg.clk_rst_vif.wait_clks(20);
 
-    `uvm_info(`gfn, $sformatf(" \n\t ---| ADDING PLAIN TEXT"), UVM_DEBUG)
+    `uvm_info(`gfn, $sformatf(" \n\t ---| ADDING PLAIN TEXT"), UVM_LOW)
+
     add_data(plain_text);
 
     cfg.clk_rst_vif.wait_clks(20);
     // poll status register
+
     `uvm_info(`gfn, $sformatf("\n\t ---| Polling for data register %s",
-        ral.status.convert2string()), UVM_DEBUG)
+                              ral.status.convert2string()), UVM_DEBUG)
+
     read_data(cypher_text);
-    `uvm_info(`gfn, $sformatf("\n\t ---|cypher text : %02h", cypher_text), UVM_DEBUG)
 
     // read output
     `uvm_info(`gfn, $sformatf("\n\t ------|WAIT 0 |-------"), UVM_LOW)
@@ -44,28 +55,32 @@ class aes_wake_up_vseq extends aes_base_vseq;
 
     // set aes to decrypt
     set_mode(DECRYPT);
-
-    `uvm_info(`gfn, $sformatf("\n\t ---|WRITING INIT KEY FOR DECRYPT: %02h", init_key), UVM_DEBUG)
+    cfg.clk_rst_vif.wait_clks(20);
+    `uvm_info(`gfn, $sformatf("\n\t ---|WRITING INIT KEY FOR DECRYPT: %02h", init_key), UVM_LOW)
     write_key(init_key);
-
-    `uvm_info(`gfn, $sformatf("\n\t ---| WRITING CYPHER TEXT %02h", cypher_text), UVM_DEBUG)
+    cfg.clk_rst_vif.wait_clks(20);
+    `uvm_info(`gfn, $sformatf("\n\t ---| WRITING CYPHER TEXT"), UVM_LOW)
     add_data(cypher_text);
-    `uvm_info(`gfn, $sformatf("\n\t ---| Polling for data %s", ral.status.convert2string()),
-        UVM_DEBUG)
-    read_data(decrypted_text);
 
-    if(decrypted_text == plain_text) begin
-      `uvm_info(`gfn, $sformatf(
-          " \n\t ---| YAY TEST PASSED |--- \n \t DECRYPTED: \t %02h \n\t Plaintext: \t %02h ",
-          decrypted_text, plain_text), UVM_NONE)
-    end else begin
-      `uvm_fatal(`gfn, $sformatf(
-          " \n\t ---| NOO TEST FAILED |--- \n \t DECRYPTED: \t %02h \n\t Plaintext: \t %02h ",
-          decrypted_text, plain_text))
+    `uvm_info(`gfn, $sformatf("\n\t ---| Polling for data %s", ral.status.convert2string()),
+              UVM_DEBUG)
+
+    cfg.clk_rst_vif.wait_clks(20);
+
+    read_data(decrypted_text);
+    foreach(decrypted_text[i]) begin
+      `uvm_info(`gfn, $sformatf("\n\t ----| decrypted text elememt [%d] : %02h", i, decrypted_text[i]), UVM_LOW)
     end
 
-    `uvm_info(`gfn, $sformatf("DATA ADDED "), UVM_DEBUG)
+    foreach(plain_text[i]) begin
+      if(plain_text[i] != decrypted_text[i]) begin
+        str = $sformatf(" \n\t ---| OH NOO TEST FAILED AT POS %d|--- \n \t DECRYPTED: \t %02h \n\t Plaintext: \t %02h ",
+                        i, decrypted_text[i], plain_text[i]);
+        `uvm_fatal(`gfn, $sformatf("%s",str));
+      end
+
+    end
+
+    `uvm_info(`gfn, $sformatf(" \n\t ---| YAY TEST PASSED |--- \n \t "), UVM_NONE)
   endtask : body
 endclass : aes_wake_up_vseq
-
-

--- a/hw/ip/aes/dv/tb/tb.sv
+++ b/hw/ip/aes/dv/tb/tb.sv
@@ -19,6 +19,7 @@ module tb;
   // interfaces
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
   pins_if #(NUM_MAX_INTERRUPTS) intr_if(interrupts);
+
   pins_if #(1) devmode_if();
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
 
@@ -29,8 +30,6 @@ module tb;
 
     .tl_i                 (tl_if.h2d  ),
     .tl_o                 (tl_if.d2h  )
-
-    // TODO: add remaining IOs and hook them
   );
 
   initial begin
@@ -39,7 +38,6 @@ module tb;
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
-//    uvm_config_db#(tlul_assert_vif)::set(null, "*.env", "tlul_assert_vif", tb.dut.tlul_assert);
     uvm_config_db#(tlul_assert_ctrl_vif)::set(null, "*.env", "tlul_assert_ctrl_vif",
         dut.tlul_assert_device.tlul_assert_ctrl_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);

--- a/hw/ip/aes/dv/tests/aes_base_test.sv
+++ b/hw/ip/aes/dv/tests/aes_base_test.sv
@@ -19,6 +19,4 @@ class aes_base_test extends cip_base_test #(
 //    function configure_knobs()
 //      endfunction // configure_knobs
 
-
 endclass : aes_base_test
-

--- a/hw/ip/aes/model/aes_model.core
+++ b/hw/ip/aes/model/aes_model.core
@@ -11,8 +11,7 @@ filesets:
       - crypto.h: { is_include_file: true }
       - aes.c
       - aes.h: { is_include_file: true }
-    # Note: VCS needs the c/h-files to be treated as systemVerilogSource
-    file_type: systemVerilogSource
+    file_type: cSource
 
 targets:
   default:


### PR DESCRIPTION
this PR has multiple updates.

- it enables support for DPI in AES in both VCS and Xcelium
  the current solution uses some added build options in the aes/dv/Makefile
  this is not optimal, and should go into fusesoc eventually.
  I currently track this here https://github.com/lowRISC/opentitan/issues/1315

- full environment with randomized reference model Currently openSSL is used 80% of the time and the model made by @vogelpi 20% but this is costumizable.

- also implemented a sequence item for aes (aes_seq_item_pkg) this is the part of the uvm DV proposal that I am working on. 




