### PR TITLE
[sw/dif] Implement a DIF library for HMAC

### DIFF
--- a/sw/device/lib/dif/dif_hmac.c
+++ b/sw/device/lib/dif/dif_hmac.c
@@ -1,0 +1,394 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/dif/dif_hmac.h"
+
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/mmio.h"
+
+#include "hmac_regs.h"  // Generated.
+
+/**
+ * Read the status register from `hmac`.
+ *
+ * @param hmac The HMAC device to read the status register from.
+ * @return The contents of hmac.STATUS.
+ */
+static uint32_t get_status(const dif_hmac_t *hmac) {
+  return mmio_region_read32(hmac->base_addr, HMAC_STATUS_REG_OFFSET);
+}
+
+/**
+ * Returns the number of entries in the FIFO of `hmac`. If the FIFO is empty,
+ * this function will return 0, and if the FIFO is full, this funciton will
+ * return `HMAC_FIFO_MAX`.
+ *
+ * @param hmac The HMAC device to check the FIFO size of.
+ * @return The number of entries in the HMAC FIFO.
+ */
+static uint32_t get_fifo_entry_count(const dif_hmac_t *hmac) {
+  return bitfield_field32_read(get_status(hmac),
+                               (bitfield_field32_t){
+                                   .mask = HMAC_STATUS_FIFO_DEPTH_MASK,
+                                   .index = HMAC_STATUS_FIFO_DEPTH_OFFSET,
+                               });
+}
+
+/**
+ * A helper function for calculating `HMAC_FIFO_MAX` - `get_fifo_entry_count()`.
+ */
+static uint32_t get_fifo_available_space(const dif_hmac_t *hmac) {
+  return HMAC_MSG_FIFO_SIZE_WORDS - get_fifo_entry_count(hmac);
+}
+
+/**
+ * Convert from a `dif_hmac_interrupt_t` to the appropriate bit index.
+ * INTR_STATE, INTR_ENABLE, and INTR_TEST registers have the same bit offset.
+ */
+static bool irq_bit_offset_get(dif_hmac_interrupt_t irq_type,
+                               uint8_t *offset_out) {
+  ptrdiff_t offset;
+  switch (irq_type) {
+    case kDifHmacInterruptHmacDone:
+      offset = HMAC_INTR_COMMON_HMAC_DONE;
+      break;
+    case kDifHmacInterruptFifoEmpty:
+      offset = HMAC_INTR_COMMON_FIFO_EMPTY;
+      break;
+    case kDifHmacInterruptHmacErr:
+      offset = HMAC_INTR_COMMON_HMAC_ERR;
+      break;
+    default:
+      return false;
+  }
+
+  *offset_out = offset;
+
+  return true;
+}
+
+dif_hmac_result_t dif_hmac_init(const dif_hmac_config_t *config,
+                                dif_hmac_t *hmac) {
+  // Basic sanity checks on parameters. In `kDifHmacModeHmac` mode a key is
+  // required.
+  if (config == NULL || hmac == NULL) {
+    return kDifHmacBadArg;
+  }
+
+  hmac->base_addr = config->base_addr;
+
+  // Clear the config, stopping the SHA engine.
+  mmio_region_write32(config->base_addr, HMAC_CFG_REG_OFFSET, 0);
+
+  // Clear INTER.
+  mmio_region_write32(config->base_addr, HMAC_INTR_STATE_REG_OFFSET,
+                      (1 << HMAC_INTR_STATE_HMAC_DONE) |
+                          (1 << HMAC_INTR_STATE_FIFO_EMPTY) |
+                          (1 << HMAC_INTR_STATE_HMAC_ERR));
+
+  uint32_t device_config = 0;
+
+  // Set the byte-order of the input message.
+  switch (config->message_endianness) {
+    case kDifHmacEndiannessBig:
+      device_config |= (1 << HMAC_CFG_ENDIAN_SWAP);
+      break;
+    case kDifHmacEndiannessLittle:
+      break;
+    default:
+      return kDifHmacError;
+  }
+
+  // Set the byte-order of the digest.
+  switch (config->digest_endianness) {
+    case kDifHmacEndiannessBig:
+      device_config |= (1 << HMAC_CFG_DIGEST_SWAP);
+      break;
+    case kDifHmacEndiannessLittle:
+      break;
+    default:
+      return kDifHmacError;
+  }
+
+  // Write the configuration.
+  mmio_region_write32(config->base_addr, HMAC_CFG_REG_OFFSET, device_config);
+
+  return kDifHmacOk;
+}
+
+dif_hmac_result_t dif_hmac_irq_state_get(const dif_hmac_t *hmac,
+                                         dif_hmac_interrupt_t irq_type,
+                                         dif_hmac_enable_t *state) {
+  if (hmac == NULL || state == NULL) {
+    return kDifHmacBadArg;
+  }
+
+  uint8_t offset;
+  if (!irq_bit_offset_get(irq_type, &offset)) {
+    return kDifHmacError;
+  }
+
+  // Get the interrupt state.
+  bool enabled = mmio_region_get_bit32(hmac->base_addr,
+                                       HMAC_INTR_STATE_REG_OFFSET, offset);
+  *state = (enabled ? kDifHmacEnable : kDifHmacDisable);
+
+  return kDifHmacOk;
+}
+
+dif_hmac_result_t dif_hmac_irq_state_clear(const dif_hmac_t *hmac,
+                                           dif_hmac_interrupt_t irq_type) {
+  if (hmac == NULL) {
+    return kDifHmacBadArg;
+  }
+
+  uint8_t offset;
+  if (!irq_bit_offset_get(irq_type, &offset)) {
+    return kDifHmacError;
+  }
+
+  // Clear the interrupt state.
+  mmio_region_write_only_set_bit32(hmac->base_addr, HMAC_INTR_STATE_REG_OFFSET,
+                                   offset);
+
+  return kDifHmacOk;
+}
+
+dif_hmac_result_t dif_hmac_irqs_disable(const dif_hmac_t *hmac,
+                                        uint32_t *state) {
+  if (hmac == NULL) {
+    return kDifHmacBadArg;
+  }
+
+  // Pass the interrupt state back to the caller.
+  if (state != NULL) {
+    *state = mmio_region_read32(hmac->base_addr, HMAC_INTR_ENABLE_REG_OFFSET);
+  }
+
+  // Disable all interrupts.
+  mmio_region_write32(hmac->base_addr, HMAC_INTR_ENABLE_REG_OFFSET, 0u);
+
+  return kDifHmacOk;
+}
+
+dif_hmac_result_t dif_hmac_irqs_restore(const dif_hmac_t *hmac,
+                                        uint32_t state) {
+  if (hmac == NULL) {
+    return kDifHmacBadArg;
+  }
+
+  // Restore interrupt state.
+  mmio_region_write32(hmac->base_addr, HMAC_INTR_ENABLE_REG_OFFSET, state);
+
+  return kDifHmacOk;
+}
+
+dif_hmac_result_t dif_hmac_irq_control(const dif_hmac_t *hmac,
+                                       dif_hmac_interrupt_t irq_type,
+                                       dif_hmac_enable_t enable) {
+  if (hmac == NULL) {
+    return kDifHmacBadArg;
+  }
+
+  uint8_t offset;
+  if (!irq_bit_offset_get(irq_type, &offset)) {
+    return kDifHmacError;
+  }
+
+  // Enable/Disable interrupt.
+  if (enable == kDifHmacEnable) {
+    mmio_region_nonatomic_set_bit32(hmac->base_addr,
+                                    HMAC_INTR_ENABLE_REG_OFFSET, offset);
+  } else {
+    mmio_region_nonatomic_clear_bit32(hmac->base_addr,
+                                      HMAC_INTR_ENABLE_REG_OFFSET, offset);
+  }
+
+  return kDifHmacOk;
+}
+
+dif_hmac_result_t dif_hmac_irq_force(const dif_hmac_t *hmac,
+                                     dif_hmac_interrupt_t irq_type) {
+  if (hmac == NULL) {
+    return kDifHmacBadArg;
+  }
+
+  uint8_t offset;
+  if (!irq_bit_offset_get(irq_type, &offset)) {
+    return kDifHmacError;
+  }
+
+  // Force the requested interrupt.
+  mmio_region_nonatomic_set_bit32(hmac->base_addr, HMAC_INTR_TEST_REG_OFFSET,
+                                  offset);
+
+  return kDifHmacOk;
+}
+
+dif_hmac_result_t dif_hmac_mode_hmac_start(const dif_hmac_t *hmac,
+                                           const uint8_t *key) {
+  if (hmac == NULL || key == NULL) {
+    return kDifHmacBadArg;
+  }
+
+  // Disable SHA256 while configuring and to clear the digest.
+  mmio_region_nonatomic_clear_bit32(hmac->base_addr, HMAC_CFG_REG_OFFSET,
+                                    HMAC_CFG_SHA_EN);
+
+  // Set the HMAC key.
+  // TODO Static assert register layout.
+  mmio_region_memcpy_to_mmio32(hmac->base_addr, HMAC_KEY0_REG_OFFSET, key,
+                               HMAC_PARAM_NUMWORDS * sizeof(uint32_t));
+
+  // Set HMAC to process in HMAC mode (not SHA256-only mode).
+  mmio_region_nonatomic_set_mask32(
+      hmac->base_addr, HMAC_CFG_REG_OFFSET,
+      (1 << HMAC_CFG_SHA_EN) | (1 << HMAC_CFG_HMAC_EN), 0);
+
+  // Begin HMAC operation.
+  mmio_region_nonatomic_set_bit32(hmac->base_addr, HMAC_CMD_REG_OFFSET,
+                                  HMAC_CMD_HASH_START);
+  return kDifHmacOk;
+}
+
+dif_hmac_result_t dif_hmac_mode_sha256_start(const dif_hmac_t *hmac) {
+  if (hmac == NULL) {
+    return kDifHmacBadArg;
+  }
+
+  // Disable SHA256 while configuring and to clear the digest.
+  mmio_region_nonatomic_clear_bit32(hmac->base_addr, HMAC_CFG_REG_OFFSET,
+                                    HMAC_CFG_SHA_EN);
+
+  // Disable HMAC mode.
+  mmio_region_nonatomic_clear_bit32(hmac->base_addr, HMAC_CFG_REG_OFFSET,
+                                    HMAC_CFG_HMAC_EN);
+
+  // Set HMAC to process in SHA256-only mode.
+  mmio_region_nonatomic_set_bit32(hmac->base_addr, HMAC_CFG_REG_OFFSET,
+                                  HMAC_CFG_SHA_EN);
+
+  // Begin SHA256-only operation.
+  mmio_region_nonatomic_set_bit32(hmac->base_addr, HMAC_CMD_REG_OFFSET,
+                                  HMAC_CMD_HASH_START);
+
+  return kDifHmacOk;
+}
+
+dif_hmac_fifo_result_t dif_hmac_fifo_push(const dif_hmac_t *hmac,
+                                          const void *data, size_t len,
+                                          size_t *bytes_sent) {
+  if (hmac == NULL || data == NULL) {
+    return kDifHmacFifoBadArg;
+  }
+
+  const uint8_t *data_sent = (const uint8_t *)data;
+  size_t bytes_remaining = len;
+
+  while (bytes_remaining > 0 && get_fifo_available_space(hmac) > 0) {
+    bool word_aligned = (uintptr_t)data_sent % sizeof(uint32_t) == 0;
+    size_t bytes_written = 0;
+
+    if (bytes_remaining < sizeof(uint32_t) || !word_aligned) {
+      // Individual byte writes are needed if the buffer isn't aligned or there
+      // are no more full words to write.
+      mmio_region_write8(hmac->base_addr, HMAC_MSG_FIFO_REG_OFFSET, *data_sent);
+      bytes_written = 1;
+    } else {
+      // `data_sent` is word-aligned and there are still words to write.
+      uint32_t word = read_32(data_sent);
+      mmio_region_write32(hmac->base_addr, HMAC_MSG_FIFO_REG_OFFSET, word);
+      bytes_written = sizeof(uint32_t);
+    }
+
+    bytes_remaining -= bytes_written;
+    data_sent += bytes_written;
+  }
+
+  if (bytes_sent != NULL) {
+    *bytes_sent = len - bytes_remaining;
+  }
+
+  if (bytes_remaining > 0) {
+    return kDifHmacFifoFull;
+  }
+
+  return kDifHmacFifoOk;
+}
+
+dif_hmac_result_t dif_hmac_fifo_count_entries(const dif_hmac_t *hmac,
+                                              uint32_t *num_entries) {
+  if (hmac == NULL || num_entries == NULL) {
+    return kDifHmacBadArg;
+  }
+
+  *num_entries = get_fifo_entry_count(hmac);
+
+  return kDifHmacOk;
+}
+
+dif_hmac_result_t dif_hmac_get_message_length(const dif_hmac_t *hmac,
+                                              uint64_t *msg_len) {
+  if (hmac == NULL || msg_len == NULL) {
+    return kDifHmacBadArg;
+  }
+
+  uint64_t msg_lower =
+      mmio_region_read32(hmac->base_addr, HMAC_MSG_LENGTH_LOWER_REG_OFFSET);
+  uint64_t msg_upper =
+      mmio_region_read32(hmac->base_addr, HMAC_MSG_LENGTH_UPPER_REG_OFFSET);
+
+  *msg_len = (msg_upper << 32) | msg_lower;
+
+  return kDifHmacOk;
+}
+
+dif_hmac_result_t dif_hmac_process(const dif_hmac_t *hmac) {
+  if (hmac == NULL) {
+    return kDifHmacBadArg;
+  }
+
+  mmio_region_nonatomic_set_bit32(hmac->base_addr, HMAC_CMD_REG_OFFSET,
+                                  HMAC_CMD_HASH_PROCESS);
+  return kDifHmacOk;
+}
+
+dif_hmac_digest_result_t dif_hmac_digest_read(const dif_hmac_t *hmac,
+                                              dif_hmac_digest_t *digest) {
+  if (hmac == NULL || digest == NULL) {
+    return kDifHmacDigestBadArg;
+  }
+
+  // Check if hmac_done is asserted.
+  bool done = mmio_region_get_bit32(hmac->base_addr, HMAC_INTR_STATE_REG_OFFSET,
+                                    HMAC_INTR_STATE_HMAC_DONE);
+
+  if (done) {
+    // Clear hmac_done.
+    mmio_region_nonatomic_set_bit32(hmac->base_addr, HMAC_INTR_STATE_REG_OFFSET,
+                                    HMAC_INTR_STATE_HMAC_DONE);
+  } else {
+    return kDifHmacDigestProcessing;
+  }
+
+  // Read the digest.
+  // TODO Static assert register layout.
+  mmio_region_memcpy_from_mmio32(hmac->base_addr, HMAC_DIGEST0_REG_OFFSET,
+                                 digest->digest,
+                                 HMAC_PARAM_NUMWORDS * sizeof(uint32_t));
+
+  return kDifHmacDigestOk;
+}
+
+dif_hmac_result_t dif_hmac_wipe_secret(const dif_hmac_t *hmac,
+                                       uint32_t entropy) {
+  if (hmac == NULL) {
+    return kDifHmacBadArg;
+  }
+
+  mmio_region_write32(hmac->base_addr, HMAC_WIPE_SECRET_REG_OFFSET, entropy);
+
+  return kDifHmacOk;
+}

--- a/sw/device/lib/dif/dif_hmac.h
+++ b/sw/device/lib/dif/dif_hmac.h
@@ -1,0 +1,364 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_DIF_HMAC_H_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_DIF_HMAC_H_
+
+#include "sw/device/lib/base/mmio.h"
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * HMAC interrupt configuration.
+ *
+ * Enumeration used to enable, disable, test and query the UART interrupts.
+ * Please see the comportability specification for more information:
+ * https://docs.opentitan.org/doc/rm/comportability_specification/
+ */
+typedef enum dif_hmac_interrupt {
+  //! HMAC is done.
+  /*! Associated with the `hmac.INTR_STATE.hmac_done` hardware interrupt. */
+  kDifHmacInterruptHmacDone = 0,
+  //! FIFO empty.
+  /*! Associated with the `hmac.INTR_STATE.fifo_empty` hardware interrupt. */
+  kDifHmacInterruptFifoEmpty,
+  //! HMAC error occurred.
+  /*! Associated with the `hmac.INTR_STATE.hmac_err` hardware interrupt. */
+  kDifHmacInterruptHmacErr,
+} dif_hmac_interrupt_t;
+
+/**
+ * Generic enable/disable enumeration.
+ *
+ * Enumeration used to enable/disable bits, flags, ...
+ */
+typedef enum dif_hmac_enable {
+  //! Enable interrupt.
+  kDifHmacEnable = 0,
+  //! Disable interrupt.
+  kDifHmacDisable,
+} dif_hmac_enable_t;
+
+/**
+ * Supported HMAC modes of operation.
+ */
+typedef enum dif_hmac_mode {
+  //! The HMAC mode.
+  kDifHmacModeHmac = 0,
+  //! The SHA256-only mode.
+  kDifHmacModeSha256,
+} dif_hmac_mode_t;
+
+/**
+ * Supported byte endienness options.
+ */
+typedef enum dif_hmac_endianness {
+  //! Big endian byte ordering.
+  kDifHmacEndiannessBig = 0,
+  //! Little endian byte ordering.
+  kDifHmacEndiannessLittle,
+} dif_hmac_endianness_t;
+
+/**
+ * Error codes for HMAC functions that may exhibit generic failures.
+ */
+typedef enum dif_hmac_result {
+  //! No error occurred.
+  kDifHmacOk = 0,
+  //! An unknown error occurred.
+  kDifHmacError,
+  //! An invalid argument was provided.
+  kDifHmacBadArg,
+} dif_hmac_result_t;
+
+/**
+ * Error codes for HMAC FIFO operations that may fail.
+ */
+typedef enum dif_hmac_fifo_result {
+  //! No error occurred.
+  kDifHmacFifoOk = 0,
+  //! An unknown error occurred.
+  kDifHmacFifoError,
+  //! An invalid argument was provided.
+  kDifHmacFifoBadArg,
+  //! The FIFO filled up before the buffer was fully consumed.
+  /*!
+    Retryable. This error indicates that FIFO has filled up and will empty over
+    time. A function that returns this error may be retried at any time, or the
+    caller may choose to do so when the `kDifHmacInterruptFifoEmpty` interrupt
+    is raised, provided this interrupt has been enabled via the interrupt API.
+  */
+  kDifHmacFifoFull,
+} dif_hmac_fifo_result_t;
+
+/**
+ * Error codes for reading the HMAC digest.
+ */
+typedef enum dif_hmac_digest_result {
+  //! No error occurred.
+  kDifHmacDigestOk = 0,
+  //! An unknown error occurred.
+  kDifHmacDigestError,
+  //! An invalid argument was provided.
+  kDifHmacDigestBadArg,
+  //! The HMAC operation is still in progress.
+  /*!
+    Retryable. This error indicates HMAC is still processing and will finish in
+    time. A function that returns this error may be retried at any time, or the
+    caller may choose to do so when the `kDifHmacInterruptHmacDone` interrupt
+    is raised, provided this interrupt has been enabled via the interrupt API.
+
+    Any function that returns this error is guaranteed to have not produced any
+    side effects.
+  */
+  kDifHmacDigestProcessing,
+} dif_hmac_digest_result_t;
+
+/**
+ * Configuration for initializing the HMAC device.
+ */
+typedef struct dif_hmac_config {
+  //! The base address for registers in the HMAC IP
+  mmio_region_t base_addr;
+  //! Byte endianness for writes to the FIFO
+  dif_hmac_endianness_t message_endianness;
+  //! Byte endianness for reads from the digest.
+  dif_hmac_endianness_t digest_endianness;
+} dif_hmac_config_t;
+
+/**
+ * A typed representation of the HMAC digest.
+ */
+typedef struct dif_hmac_digest { uint32_t digest[8]; } dif_hmac_digest_t;
+
+/**
+ * State for a particular HMAC device.
+ *
+ * Its member variables should be considered private, and are only provided so
+ * that callers can allocate it.
+ */
+typedef struct dif_hmac { mmio_region_t base_addr; } dif_hmac_t;
+
+/**
+ * Initializes the HMAC device described by `config`, writing internal state to
+ * `hmac_out`.
+ *
+ * This function *must* be called on a particular `mmio_region_t` before calling
+ * any other functions in this header with that `mmio_region_t`.
+ *
+ * @param config Configuration supplied for initializing a particular device.
+ * @param hmac_out The location at which to write HMAC state. This location
+ *                 must be valid to write to.
+ * @return `kDifHmacBadArg` if `config` is null or contains illegal
+ *          arguments or `hmac_out` is null, `kDifHmacOk` otherwise.
+ */
+dif_hmac_result_t dif_hmac_init(const dif_hmac_config_t *config,
+                                dif_hmac_t *hmac_out);
+
+/**
+ * HMAC get requested IRQ state.
+ *
+ * Get the state of the requested IRQ in `irq_type`.
+ *
+ * @param hmac HMAC state data.
+ * @param irq_type IRQ to get the state of.
+ * @param state IRQ state passed back to the caller.
+ * @return `dif_hmac_result_t`.
+ */
+dif_hmac_result_t dif_hmac_irq_state_get(const dif_hmac_t *hmac,
+                                         dif_hmac_interrupt_t irq_type,
+                                         dif_hmac_enable_t *state);
+/**
+ * HMAC clear requested IRQ state.
+ *
+ * Clear the state of the requested IRQ in `irq_type`. Primary use of this
+ * function is to de-assert the interrupt after it has been serviced.
+ *
+ * @param hmac HMAC state data.
+ * @param irq_type IRQ to be de-asserted.
+ * @return `dif_hmac_result_t`.
+ */
+dif_hmac_result_t dif_hmac_irq_state_clear(const dif_hmac_t *hmac,
+                                           dif_hmac_interrupt_t irq_type);
+
+/**
+ * HMAC disable interrupts.
+ *
+ * Disable generation of all HMAC interrupts, and pass previous interrupt state
+ * in `state` back to the caller. Parameter `state` is ignored if NULL.
+ *
+ * @param hmac HMAC state data.
+ * @param state IRQ state passed back to the caller.
+ * @return 'dif_hmac_result_t'.
+ */
+dif_hmac_result_t dif_hmac_irqs_disable(const dif_hmac_t *hmac,
+                                        uint32_t *state);
+
+/**
+ * HMAC restore IRQ state.
+ *
+ * Restore previous HMAC IRQ state. This function is used to restore the
+ * HMAC interrupt state prior to `dif_hmac_irqs_disable` function call.
+ *
+ * @param hmac HMAC state data.
+ * @param state IRQ state to restore.
+ * @return 'dif_hmac_result_t'.
+ */
+dif_hmac_result_t dif_hmac_irqs_restore(const dif_hmac_t *hmac, uint32_t state);
+
+/**
+ * HMAC interrupt control.
+ *
+ * Enable/disable an HMAC interrupt specified in `irq_type`.
+ *
+ * @param hmac HMAC state data.
+ * @param irq_type HMAC interrupt type.
+ * @param enable enable or disable the interrupt.
+ * @return `dif_hmac_result_t`.
+ */
+dif_hmac_result_t dif_hmac_irq_control(const dif_hmac_t *hmac,
+                                       dif_hmac_interrupt_t irq_type,
+                                       dif_hmac_enable_t enable);
+
+/**
+ * HMAC interrupt force.
+ *
+ * Force interrupt specified in `irq_type`.
+ *
+ * @param hmac HMAC state data.
+ * @param irq_type HMAC interrupt type to be forced.
+ * @return `dif_hmac_result_t`.
+ */
+dif_hmac_result_t dif_hmac_irq_force(const dif_hmac_t *hmac,
+                                     dif_hmac_interrupt_t irq_type);
+
+/**
+ * Resets the HMAC engine and readies it to receive a new message to process an
+ * HMAC digest.
+ *
+ * This function causes the HMAC engine to start its operation. After a
+ * successful call to this function, |dif_hmac_fifo_push()| can be called to
+ * write the message for HMAC processing.
+ *
+ * This function must be called with a valid `key` that references a 32-byte,
+ * contiguous, readable region where the key may be copied from.
+ *
+ * @param hmac The HMAC device to start HMAC operation for.
+ * @param key The 256-bit HMAC key.
+ * @return `kDifHmacBadArg` if `hmac` or `key` is null, `kDifHmacOk` otherwise.
+ */
+dif_hmac_result_t dif_hmac_mode_hmac_start(const dif_hmac_t *hmac,
+                                           const uint8_t *key);
+
+/**
+ * Resets the HMAC engine and readies it to receive a new message to process a
+ * SHA256 digest.
+ *
+ * This function causes the HMAC engine to start its operation. After a
+ * successful call to this function, |dif_hmac_fifo_push()| can be called to
+ * write the message for SHA256 processing.
+ *
+ * @param hmac The HMAC device to start SHA256 operation for.
+ * @return `kDifHmacBadArg` if `hmac` null, `kDifHmacOk` otherwise.
+ */
+dif_hmac_result_t dif_hmac_mode_sha256_start(const dif_hmac_t *hmac);
+
+/**
+ * Attempts to send `len` bytes from the buffer pointed to by `data` to the
+ * device described by `hmac`. This function will send to the message FIFO until
+ * the FIFO fills up or `len` bytes have been sent.
+ *
+ * In the event that the FIFO fills up before `len` bytes have been sent this
+ * function will return a `kDifHmacFifoFull` error. In this case it is valid
+ * to call this function again by advancing `data` by `len` - |*bytes_sent|
+ * bytes. It may be desirable to wait for space to free up on the FIFO before
+ * issuing subsequent calls to this function, but it is not strictly
+ * necessary. The number of entries in the FIFO can be queried with
+ * `dif_hmac_fifo_count_entries()`.
+ *
+ * `data` *must* point to an allocated buffer of at least length `len`.
+ *
+ * @param hmac The HMAC device to send to.
+ * @param data A contiguous buffer to copy from.
+ * @param len The length of the buffer to copy from.
+ * @param bytes_sent The number of bytes sent to the FIFO (optional).
+ * @return `kDifHmacFifoFull` if the FIFO fills up, `kDifHmacFifoBadArg` if
+ *         `hmac` or `data` is null, and `kDifHmacFifoOk` otherwise.
+ */
+dif_hmac_fifo_result_t dif_hmac_fifo_push(const dif_hmac_t *hmac,
+                                          const void *data, size_t len,
+                                          size_t *bytes_sent);
+
+/**
+ * Retrieves the number of entries in the HMAC FIFO. These entries may be
+ * semi-arbitrary in length; this function should not be used to calculate
+ * message length.
+ *
+ * @param hmac The HMAC device to get the FIFO depth for.
+ * @param num_entries The number of entries in the FIFO.
+ * @return `kDifHmacBadArg` if `hmac` or `num_entries` is null, `kDifHmacOk`
+ *         otherwise.
+ */
+dif_hmac_result_t dif_hmac_fifo_count_entries(const dif_hmac_t *hmac,
+                                              uint32_t *num_entries);
+
+/**
+ * Retrieves the number of bits in the loaded HMAC device.
+ * `dif_hmac_fifo_count_entries()` should be called before this function to
+ * ensure the FIFO is empty, as any bits in the FIFO are not counted in
+ * `msg_len`.
+ *
+ * @param hmac The HMAC device to get the message length for.
+ * @param msg_len The number of bits in the HMAC message.
+ * @return `kDifHmacBadArg` if `hmac` or `msg_len` is null, `kDifHmacOk`
+ *         otherwise.
+ */
+dif_hmac_result_t dif_hmac_get_message_length(const dif_hmac_t *hmac,
+                                              uint64_t *msg_len);
+
+/**
+ * Attempts to run HMAC or SHA256 depending on the mode `hmac` was initialized
+ * in. Calls to this function always succeed and return without blocking. The
+ * caller can use `dif_hmac_check_state()` to check for errors and for the
+ * `DIF_HMAC_DONE` status before reading the digest with
+ * `dif_hmac_digest_read()`.
+ *
+ * @param hmac The HMAC device to initiate the run on.
+ * @return `kDifHmacBadArg` if `hmac` is null `kDifHmacOk` otherwise.
+ */
+dif_hmac_result_t dif_hmac_process(const dif_hmac_t *hmac);
+
+/**
+ * Attempts to read the HMAC digest and store store the result in the buffer
+ * referenced by `digest`.
+ *
+ * If HMAC is still processing this will return `kDifHmacErrorDigestProcessing`
+ *
+ * `digest` must reference an allocated, contiguous, 32-byte buffer. This buffer
+ * shall also be 4-byte aligned. This is all consistent with the platform
+ * requirements for size and alignment requirements of `dif_hmac_digest_t`.
+ *
+ * @param hmac The HMAC device to read the digest from.
+ * @param digest A contiguous 32-byte, 4-byte aligned buffer for the digest.
+ * @return `kDifHmacBadArg` if `hmac` or `digest` is null,
+ *         `kDifHmacDigestProcessing` if HMAC is still processing, and
+ *         `kDifHmacOk` otherwise.
+ */
+dif_hmac_digest_result_t dif_hmac_digest_read(const dif_hmac_t *hmac,
+                                              dif_hmac_digest_t *digest);
+
+/**
+ * Randomizes internal secret registers on the HMAC device. This includes the
+ * key, hash value, and internal state machine. The value of `entropy` will be
+ * used to "randomize" the internal state of the HMAC device. See the HMAC IP
+ * documentation for more information: hw/ip/hmac/doc.
+ *
+ * @param hmac The HMAC device to clobber state on.
+ * @param entropy A source of randomness to write to the HMAC internal state.
+ * @return `kDifHmacBadArg` if `hmac` is null `kDifHmacOk` otherwise.
+ */
+dif_hmac_result_t dif_hmac_wipe_secret(const dif_hmac_t *hmac,
+                                       uint32_t entropy);
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_DIF_HMAC_H_

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -98,3 +98,19 @@ sw_lib_dif_usbdev = declare_dependency(
     ],
   )
 )
+
+# HMAC device DIF library
+sw_dif_hmac = declare_dependency(
+  link_with: static_library(
+    'sw_dif_hmac',
+    sources: [
+      hw_ip_hmac_reg_h,
+      'dif_hmac.c'
+    ],
+    dependencies: [
+      sw_lib_bitfield,
+      sw_lib_mmio,
+    ],
+  )
+)
+

--- a/sw/device/tests/dif/dif_hmac_sanitytest.c
+++ b/sw/device/tests/dif/dif_hmac_sanitytest.c
@@ -1,0 +1,207 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/dif/dif_hmac.h"
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/log.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/common.h"
+#include "sw/device/lib/flash_ctrl.h"
+#include "sw/device/lib/runtime/check.h"
+#include "sw/device/lib/testing/test_main.h"
+#include "sw/device/lib/uart.h"
+
+#define HMAC0_BASE_ADDR 0x40120000
+#define MAX_FIFO_FILL 10
+
+const test_config_t kTestConfig = {
+    .can_clobber_uart = false,
+};
+
+static const char kData[142] =
+    "Every one suspects himself of at least one of "
+    "the cardinal virtues, and this is mine: I am "
+    "one of the few honest people that I have ever "
+    "known";
+
+static uint32_t kHmacKey[8] = {0x243f6a88, 0x85a308d3, 0x13198a2e, 0x03707344,
+                               0xa4093822, 0x299f31d0, 0x082efa98, 0xec4e6c89};
+
+static const uint32_t kExpectedShaDigest[8] = {
+    0xdc96c23d, 0xaf36e268, 0xcb68ff71, 0xe92f76e2,
+    0xb8a8379d, 0x426dc745, 0x19f5cff7, 0x4ec9c6d6};
+
+static const uint32_t kExpectedHmacDigest[8] = {
+    0xe4987b39, 0x3f83d390, 0xc2f3bbaf, 0x3195dbfa,
+    0x23fb480c, 0xb012ae5e, 0xf1394d28, 0x1940ceeb};
+
+/**
+ * Initialize the HMAC engine. Return `true` if the configuration is valid.
+ */
+static void test_setup(const dif_hmac_config_t *config, dif_hmac_t *hmac) {
+  dif_hmac_result_t res = dif_hmac_init(config, hmac);
+
+  CHECK(res != kDifHmacBadArg, "Invalid arguments encountered in HMAC init.");
+  CHECK(res == kDifHmacOk, "Unknown error encountered in HMAC init.");
+}
+
+/**
+ * Start HMAC in the correct mode. If `key` == NULL use SHA256 mode, otherwise
+ * use the provided key in HMAC mode.
+ */
+static void test_start(const dif_hmac_t *hmac, const uint8_t *key) {
+  dif_hmac_result_t res;
+  // Let a null key indicate we are operating in SHA256-only mode.
+  if (key == NULL) {
+    res = dif_hmac_mode_sha256_start(hmac);
+  } else {
+    res = dif_hmac_mode_hmac_start(hmac, key);
+  }
+
+  CHECK(res != kDifHmacBadArg, "Invalid arguments encountered in HMAC start.");
+  CHECK(res == kDifHmacOk, "Unknown error encountered in HMAC start.");
+}
+
+/**
+ * Load a message into the HMAC engine. This function may block if the FIFO
+ * fills up.
+ */
+static void push_message(const dif_hmac_t *hmac, const char *data, size_t len) {
+  int fifo_fill_count = 0;
+  const char *dp = data;
+  size_t sent_bytes;
+
+  while (dp - data < len) {
+    dif_hmac_fifo_result_t res =
+        dif_hmac_fifo_push(hmac, dp, len - (dp - data), &sent_bytes);
+
+    CHECK(res != kDifHmacFifoBadArg,
+          "Invalid arguments encountered while pushing to FIFO.");
+
+    if (res == kDifHmacFifoFull) {
+      ++fifo_fill_count;
+    } else {
+      CHECK(res != kDifHmacFifoBadArg,
+            "Invalid arguments encountered while pushing to FIFO.");
+      CHECK(res == kDifHmacFifoOk,
+            "Unknown error encountered while pushing to FIFO.");
+    }
+
+    CHECK(fifo_fill_count <= MAX_FIFO_FILL,
+          "FIFO filled up too may times, giving up.");
+
+    dp += sent_bytes;
+  }
+}
+
+/** Spin while the HMAC FIFO still has entries in it. Once the FIFO is empty we
+ * can check the message length. Return `true` if there are no errors.
+ */
+static void wait_for_fifo_empty(const dif_hmac_t *hmac) {
+  uint32_t fifo_depth;
+  do {
+    dif_hmac_result_t res = dif_hmac_fifo_count_entries(hmac, &fifo_depth);
+
+    CHECK(res != kDifHmacBadArg,
+          "Invalid arguments encountered checking FIFO depth.");
+    CHECK(res == kDifHmacOk, "Unknown error encountered checking FIFO depth.");
+  } while (fifo_depth > 0);
+}
+
+/**
+ * Read and compare the length of the message in the HMAC engine to the length
+ * of the message sent in bits.
+ */
+static void check_message_length(const dif_hmac_t *hmac,
+                                 uint64_t expected_sent_bits) {
+  uint64_t sent_bits;
+  dif_hmac_result_t res = dif_hmac_get_message_length(hmac, &sent_bits);
+
+  CHECK(res != kDifHmacBadArg,
+        "Invalid arguments encountered checking message length.");
+  CHECK(res == kDifHmacOk,
+        "Unknown error encountered checking message length.");
+
+  // TODO: Support 64-bit integers in logging.
+  CHECK(expected_sent_bits == sent_bits,
+        "Message length mismatch. Expected %u bits but got %u bits.",
+        (uint32_t)expected_sent_bits, (uint32_t)sent_bits);
+}
+
+/**
+ * Kick off the HMAC (or SHA256) run.
+ */
+static void run_hmac(const dif_hmac_t *hmac) {
+  dif_hmac_result_t res = dif_hmac_process(hmac);
+
+  CHECK(res != kDifHmacBadArg, "Invalid arguments encountered running HMAC.");
+  CHECK(res == kDifHmacOk, "Unknown error encountered running HMAC.");
+}
+
+/**
+ * Read the HMAC digest and compare it to the expected result.
+ */
+static void check_digest(const dif_hmac_t *hmac,
+                         const uint32_t *expected_digest) {
+  dif_hmac_digest_t digest_result;
+  bool hmac_done = false;
+  do {
+    dif_hmac_digest_result_t res = dif_hmac_digest_read(hmac, &digest_result);
+
+    CHECK(res != kDifHmacDigestBadArg,
+          "Invalid arguments encountered reading HMAC digest.");
+
+    hmac_done = (res != kDifHmacDigestProcessing);
+
+    if (hmac_done) {
+      CHECK(res == kDifHmacDigestOk,
+            "Unknown error encountered reading HMAC digest.");
+    }
+  } while (!hmac_done);
+
+  for (int i = 0; i < 8; ++i) {
+    CHECK(expected_digest[i] == digest_result.digest[i],
+          "Digest mismatch, expected: 0x%X at index [%i] but got: 0x%X.",
+          expected_digest[i], i, digest_result.digest[i]);
+  }
+}
+
+static void run_test(const dif_hmac_t *hmac, const char *data, size_t len,
+                     const uint8_t *key, const uint32_t *expected_digest) {
+  test_start(hmac, key);
+  push_message(hmac, data, len);
+  wait_for_fifo_empty(hmac);
+  check_message_length(hmac, len * 8);
+  run_hmac(hmac);
+  check_digest(hmac, expected_digest);
+}
+
+bool test_main() {
+  LOG_INFO("Running HMAC DIF test...");
+
+  dif_hmac_config_t hmac_config = {
+      .base_addr = mmio_region_from_addr(HMAC0_BASE_ADDR),
+      .digest_endianness = kDifHmacEndiannessBig,
+      .message_endianness = kDifHmacEndiannessBig,
+  };
+
+  dif_hmac_t hmac;
+  test_setup(&hmac_config, &hmac);
+
+  LOG_INFO("Running test SHA256 pass 1...");
+  run_test(&hmac, kData, sizeof(kData), NULL, kExpectedShaDigest);
+
+  LOG_INFO("Running test SHA256 pass 2...");
+  run_test(&hmac, kData, sizeof(kData), NULL, kExpectedShaDigest);
+
+  LOG_INFO("Running test HMAC pass 1...");
+  run_test(&hmac, kData, sizeof(kData), (uint8_t *)(&kHmacKey[0]),
+           kExpectedHmacDigest);
+
+  LOG_INFO("Running test HMAC pass 2...");
+  run_test(&hmac, kData, sizeof(kData), (uint8_t *)(&kHmacKey[0]),
+           kExpectedHmacDigest);
+
+  return true;
+}

--- a/sw/device/tests/dif/meson.build
+++ b/sw/device/tests/dif/meson.build
@@ -143,3 +143,17 @@ dif_rv_timer_sanitytest_lib = declare_dependency(
 )
 sw_tests += { 'dif_rv_timer_sanitytest': dif_rv_timer_sanitytest_lib }
 
+dif_hmac_sanitytest_lib = declare_dependency(
+  link_with: static_library(
+    'dif_hmac_sanitytest_lib',
+    sources: ['dif_hmac_sanitytest.c'],
+    dependencies: [
+      sw_dif_hmac,
+      sw_lib_base_log,
+      sw_lib_mmio,
+      sw_lib_runtime_hart,
+    ],
+  ),
+)
+
+sw_tests += { 'dif_hmac_sanitytest': dif_hmac_sanitytest_lib }


### PR DESCRIPTION
This is my first attempt to write a DIF (or anything for that matter)  for the opentitan project. This PR has @mcy's SPI DIF #1135 as a dependency since it adds some volatile register access abstractions that I wanted to use. 

There are a few bits that I'm unhappy with, like how groups of registers at adjacent addresses are handled, but I was trying to stay in the spirit of @gkelly's DIF document and not make any assumptions about register addresses. I'm more than happy to change these things if anyone has better ideas to offer.

I also included some ragtag smoke test cases that I used to convince myself that this DIF actually does useful things. This will probably get replaced with some more useful testing once we have a DIF testing process worked out.