### PR TITLE
[dv regr tool] Enabled 2 command line switches

### DIFF
--- a/util/dvsim.py
+++ b/util/dvsim.py
@@ -329,6 +329,13 @@ def main():
         "Print dvsim tool messages only, without actually running any command")
 
     parser.add_argument(
+        "--map-full-testplan",
+        default=False,
+        action='store_true',
+        help="Force complete testplan annotated results to be shown at the end."
+    )
+
+    parser.add_argument(
         "-pi",
         "--print-interval",
         type=int,
@@ -371,14 +378,21 @@ def main():
     # be deployed.
     cfg = SimCfg.SimCfg(proj_root=get_proj_root(), args=args)
 
+    # Purge the scratch path if --purge option is set.
+    if args.purge:
+        cfg.do_purge()
+        sys.exit(0)
+
+    # List items available for run if --list switch is passed, and exit.
+    if args.list != []:
+        cfg.print_list()
+        sys.exit(0)
+
     # Deploy the builds and runs
     Deploy.Deploy.deploy(cfg.deploy)
 
     # Generate results.
-    cfg.gen_results()
-
-    # sim_cfg_list = dvsim_parser.run(args)
-    # dvsim_scheduler.dispatch(sim_cfg_list)
+    print(cfg.gen_results())
 
 
 if __name__ == '__main__':

--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -200,7 +200,7 @@ class Deploy():
         try:
             # If output directory exists, back it up.
             if os.path.exists(self.odir):
-                ts = run_cmd("date '" + self.sim_cfg.ts_format + "' -d \"" +
+                ts = run_cmd("date '+" + self.sim_cfg.ts_format + "' -d \"" +
                              "$(stat -c '%y' " + self.odir + ")\"")
                 os.system('mv ' + self.odir + " " + self.odir + "_" + ts)
         except IOError:


### PR DESCRIPTION
- Enabled the following command line switches:
  - --purge: Clean the scratch area
  This is a standalone switch meant to be run by itself. If items are
  specified to be run, they are ignored.

  - --map-full-testplan: This forces the result to be mapped to the
  complete testplan. By default the full mapping is disabled; only the
  tests that are run in that regression are mapped instead for a smaller
  and more concise table.

- Fixes:
  - Fixed results table column alignment

Signed-off-by: Srikrishna Iyer <sriyer@google.com>