### PR TITLE
[dv/alert_handler] fix Xcelium error

### DIFF
--- a/hw/dv/sv/alert_agent/alert_monitor.sv
+++ b/hw/dv/sv/alert_agent/alert_monitor.sv
@@ -95,7 +95,10 @@ class alert_monitor extends dv_base_monitor#(
         req = alert_seq_item::type_id::create("req");
         req.alert_type = AlertTrans;
         req.alert_handshake_sta = AlertReceived;
+        // Write alert packet to scb when receiving alert signal
         alert_port.write(req);
+        // Duplicate req for writing alert packet at the end of alert handshake
+        `downcast(req, req.clone())
         fork
           begin : isolation_fork
             fork


### PR DESCRIPTION
Xcelium run time error due to using the same object to send seq_item twice

Signed-off-by: Cindy Chen <chencindy@google.com>