### PR TITLE
[fpv/adapter_sram] Fix assertion X check

### DIFF
--- a/hw/ip/tlul/rtl/tlul_adapter_sram.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_sram.sv
@@ -126,7 +126,8 @@ module tlul_adapter_sram #(
       d_size   : (d_valid) ? reqfifo_rdata.size : '0,
       d_source : (d_valid) ? reqfifo_rdata.source : '0,
       d_sink   : 1'b0,
-      d_data   : (d_valid && reqfifo_rdata.op == OpRead) ? rspfifo_rdata.data : '0,
+      d_data   : (d_valid && rspfifo_rvalid && reqfifo_rdata.op == OpRead)
+                 ? rspfifo_rdata.data : '0,
       d_user   : '0,
       d_error  : d_error,
 


### PR DESCRIPTION
Current assertion checks if read out value is X,
but when no data is written, FIFO read out is X, so we decide to relax
the assertion.

Signed-off-by: Cindy Chen <chencindy@google.com>