### PR TITLE
[dv/common] same csr outstanding access

### DIFF
--- a/hw/dv/data/tests/csr_tests.hjson
+++ b/hw/dv/data/tests/csr_tests.hjson
@@ -32,6 +32,12 @@
       run_opts: ["+csr_aliasing"]
       en_run_modes: ["csr_tests_mode"]
     }
+
+    {
+      name: "{name}_same_csr_outstanding"
+      run_opts: ["+run_same_csr_outstanding"]
+      en_run_modes: ["csr_tests_mode"]
+    }
   ]
 
   regressions: [
@@ -45,7 +51,8 @@
       tests: ["{name}_csr_hw_reset",
               "{name}_csr_rw",
               "{name}_csr_bit_bash",
-              "{name}_csr_aliasing"]
+              "{name}_csr_aliasing",
+              "{name}_same_csr_outstanding"]
     }
   ]
 }

--- a/hw/dv/sv/csr_utils/csr_utils_pkg.sv
+++ b/hw/dv/sv/csr_utils/csr_utils_pkg.sv
@@ -520,8 +520,26 @@ package csr_utils_pkg;
     join
   endtask : mem_wr_sub
 
-  // sources
   `include "csr_excl_item.sv"
+
+  // Fields could be excluded from writes & reads - This function zeros out the excluded fields
+  function automatic uvm_reg_data_t get_mask_excl_fields(uvm_reg csr,
+                                                         csr_excl_type_e csr_excl_type,
+                                                         csr_excl_item m_csr_excl_item);
+    uvm_reg_field flds[$];
+    csr.get_fields(flds);
+    get_mask_excl_fields = '1;
+    foreach (flds[i]) begin
+      if (m_csr_excl_item.is_excl(flds[i], csr_excl_type)) begin
+        csr_field_s fld_params = decode_csr_or_field(flds[i]);
+        `uvm_info(msg_id, $sformatf("Skipping field %0s due to %0s exclusion",
+                                  flds[i].get_full_name(), csr_excl_type.name()), UVM_MEDIUM)
+        get_mask_excl_fields &= ~(fld_params.mask << fld_params.shift);
+      end
+    end
+  endfunction
+
+  // sources
   `include "csr_seq_lib.sv"
 
 endpackage

--- a/hw/dv/sv/dv_lib/dv_base_reg_field.sv
+++ b/hw/dv/sv/dv_lib/dv_base_reg_field.sv
@@ -6,4 +6,12 @@
 class dv_base_reg_field extends uvm_reg_field;
   `uvm_object_utils(dv_base_reg_field)
   `uvm_object_new
+
+  // when use UVM_PREDICT_WRITE and the CSR access is WO, this function will return the default
+  // val of the register, rather than the written value
+  virtual function uvm_reg_data_t XpredictX(uvm_reg_data_t cur_val, uvm_reg_data_t wr_val, uvm_reg_map map);
+    if (get_access(map) == "WO") return cur_val;
+    else return super.XpredictX(cur_val, wr_val, map);
+  endfunction
+
 endclass

--- a/hw/dv/tools/common_tests.mk
+++ b/hw/dv/tools/common_tests.mk
@@ -35,6 +35,12 @@ ifeq (${TEST_NAME},${TEST_PREFIX}_csr_aliasing)
   RUN_OPTS      += +en_scb=0
 endif
 
+ifeq (${TEST_NAME},${TEST_PREFIX}_same_csr_outstanding)
+  UVM_TEST_SEQ   = ${TEST_PREFIX}_common_vseq
+  RUN_OPTS      += +run_same_csr_outstanding
+  RUN_OPTS      += +en_scb=0
+endif
+
 # make sure DUT has memory and support this seq before run the test
 ifeq (${TEST_NAME},${TEST_PREFIX}_csr_mem_walk)
   UVM_TEST_SEQ   = ${TEST_PREFIX}_common_vseq

--- a/hw/ip/gpio/dv/Makefile
+++ b/hw/ip/gpio/dv/Makefile
@@ -99,6 +99,9 @@ ifeq (${TEST_NAME},gpio_csr_aliasing)
   RUN_OPTS      += +do_clear_all_interrupts=0
 endif
 
+ifeq (${TEST_NAME},gpio_same_csr_outstanding)
+  RUN_OPTS      += +do_clear_all_interrupts=0
+endif
 ####################################################################################################
 ## Include the tool Makefile below                                                                ##
 ## Dont add anything else below it!                                                               ##

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_common_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_common_vseq.sv
@@ -25,12 +25,8 @@ class hmac_common_vseq extends hmac_base_vseq;
                                            string           scope = "ral");
     // write exclusions - these should not apply to hw_reset test
     if (csr_test_type != "hw_reset") begin
-      // the following csrs is WO - uvm_reg_field assumes reading WO will result in bus error; in
-      // reality it does not - dut reads back 0s, but uvm_reg_field expects original written value
+      // intr_test csr will result in intr_state change
       csr_excl.add_excl({scope, ".", "intr_test"}, CsrExclWrite);
-      csr_excl.add_excl({scope, ".", "wipe_secret"}, CsrExclWrite);
-      csr_excl.add_excl({scope, ".", "key?"}, CsrExclWrite);
-      csr_excl.add_excl({scope, ".", "msg_fifo"}, CsrExclWrite);
 
       // don't enable hmac and sha data paths - we will do that in functional tests
       csr_excl.add_excl({scope, ".", "cfg.hmac_en"}, CsrExclWrite);
@@ -38,9 +34,8 @@ class hmac_common_vseq extends hmac_base_vseq;
     end
 
     // design assertion : after hash_start sets, can only wr msg or set hash_process
-    csr_excl.add_excl({scope, ".", "cmd.hash_start"}, CsrExclWrite);
     // design assertion : hash_process can be set only after hash_start is set
-    csr_excl.add_excl({scope, ".", "cmd.hash_process"}, CsrExclWrite);
+    csr_excl.add_excl({scope, ".", "cmd"}, CsrExclWrite);
   endfunction
 
 endclass

--- a/hw/ip/uart/dv/env/seq_lib/uart_common_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_common_vseq.sv
@@ -35,9 +35,6 @@ class uart_common_vseq extends uart_base_vseq;
     // writes to ovrd.txen causes tx output to be forced to ovrd.txval causing protocol violation
     csr_excl.add_excl({scope, ".", "ovrd.txen"}, CsrExclWrite);
 
-    // exclude txrst and rxrst fields in fifo_ctrl - these pulse for 1 clock and read back 0
-    csr_excl.add_excl({scope, ".", "fifo_ctrl.*rst"}, CsrExclWriteCheck);
-
     // writing 0 to timeout csr can cause rx_timeout to assert - exclude this in bit_bash seq
     if (csr_test_type == "bit_bash")
       csr_excl.add_excl({scope, ".", "intr_state.rx_timeout"}, CsrExclWriteCheck);


### PR DESCRIPTION
In DV common seq, add an outstanding access for the same CSR. cannot use
ral build in read/write, so uses tl_access

Signed-off-by: Cindy Chen <chencindy@google.com>