### PR TITLE
[util/uvmdvgen tool] Updated tool for dvsim regr

### DIFF
--- a/hw/ip/hmac/dv/hmac_sim_cfg.hjson
+++ b/hw/ip/hmac/dv/hmac_sim_cfg.hjson
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  // Name of the sim cfg - typically same as the IP under test.
+  // Name of the sim cfg - typically same as the DUT under test.
   name: hmac
 
   // Top level dut name (sv module).

--- a/hw/ip/uart/dv/sim_cfg.hjson
+++ b/hw/ip/uart/dv/sim_cfg.hjson
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  // Name of the sim cfg - typically same as the IP under test.
+  // Name of the sim cfg - typically same as the DUT under test.
   name: uart
 
   // Top level dut name (sv module).

--- a/util/uvmdvgen.py
+++ b/util/uvmdvgen.py
@@ -96,6 +96,16 @@ def main():
                 tb and tests to place all of the testbench sources. (default set to './<name>')"""
     )
 
+    parser.add_argument(
+        "-m",
+        "--add-makefile",
+        default=False,
+        action='store_true',
+        help=
+        """Tests are now run with dvsim.py tool that requires a hjson based sim cfg.
+             Setting this option will also result in the Makefile to be auto-generated (which is
+             the older way of building and running sims going through deprecation).""")
+
     args = parser.parse_args()
     if args.agent_outdir == "name": args.agent_outdir = args.name
     if args.env_outdir == "name": args.env_outdir = args.name
@@ -112,7 +122,8 @@ def main():
                         args.has_interrupts, \
                         args.has_alerts, \
                         args.env_agents, \
-                        args.env_outdir)
+                        args.env_outdir, \
+                        args.add_makefile)
 
 
 if __name__ == '__main__':

--- a/util/uvmdvgen/gen_env.py
+++ b/util/uvmdvgen/gen_env.py
@@ -10,7 +10,8 @@ from mako.template import Template
 from pkg_resources import resource_filename
 
 
-def gen_env(name, is_cip, has_interrupts, has_alerts, env_agents, root_dir):
+def gen_env(name, is_cip, has_interrupts, has_alerts, env_agents, root_dir,
+            add_makefile):
     # yapf: disable
     # 4-tuple - sub-path, ip name, class name, file ext
     env_srcs = [('dv/env',          name + '_', 'env_cfg',            '.sv'),
@@ -31,6 +32,7 @@ def gen_env(name, is_cip, has_interrupts, has_alerts, env_agents, root_dir):
                 ('dv/tests',        name + '_', 'test',               '.core'),
                 ('dv/cov',          '',         '',                   ''),
                 ('dv',              '',         'Makefile',           ''),
+                ('dv',              name + '_', 'sim_cfg',            '.hjson'),
                 ('doc',             name + '_', 'dv_plan',            '.md'),
                 ('data',            name + '_', 'testplan',           '.hjson'),
                 ('dv',              name + '_', 'sim',                '.core')]
@@ -41,6 +43,9 @@ def gen_env(name, is_cip, has_interrupts, has_alerts, env_agents, root_dir):
         src_prefix = tup[1]
         src = tup[2]
         src_suffix = tup[3]
+
+        # Skip Makefile
+        if src == 'Makefile' and not add_makefile: continue
 
         ftpl = src + src_suffix + '.tpl'
         fname = src_prefix + src + src_suffix

--- a/util/uvmdvgen/sim_cfg.hjson.tpl
+++ b/util/uvmdvgen/sim_cfg.hjson.tpl
@@ -1,0 +1,60 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  // Name of the sim cfg - typically same as the DUT under test.
+  name: ${name}
+
+  // Top level dut name (sv module).
+  dut: ${name}
+
+  // Top level testbench name (sv module).
+  tb: tb
+
+  // Fusesoc core file used for building the file list.
+  fusesoc_core: lowrisc:dv:${name}_sim:0.1
+
+  // Testplan hjson file.
+  testplan: "{proj_root}/hw/ip/${name}/data/${name}_testplan.hjson"
+
+  // RAL spec - used to generate the RAL model.
+  ral_spec: "{proj_root}/hw/ip/${name}/data/${name}.hjson"
+
+  // Import additional common sim cfg files.
+  // TODO: remove imported cfgs that do not apply.
+% if is_cip:
+  import_cfgs: [// Project wide common sim cfg file
+                "{proj_root}/hw/dv/data/common_sim_cfg.hjson",
+                // Common CIP test lists
+                "{proj_root}/hw/dv/data/tests/csr_tests.hjson",
+                "{proj_root}/hw/dv/data/tests/mem_tests.hjson",
+% if has_interrupts:
+                "{proj_root}/hw/dv/data/tests/intr_test.hjson",
+% endif
+                "{proj_root}/hw/dv/data/tests/tl_access_tests.hjson",
+                "{proj_root}/hw/dv/data/tests/stress_tests.hjson"]
+% else:
+  import_cfgs: [// Project wide common sim cfg file
+                "{proj_root}/hw/dv/data/common_sim_cfg.hjson",
+                "{proj_root}/hw/dv/data/tests/csr_tests.hjson",
+                "{proj_root}/hw/dv/data/tests/mem_tests.hjson"]
+% endif
+
+  // Default iterations for all tests - each test entry can override this.
+  reseed: 50
+
+  // Default UVM test and seq class name.
+  uvm_test: ${name}_base_test
+  uvm_test_seq: ${name}_base_vseq
+
+  // List of test specifications.
+  tests: [
+    {
+      name: ${name}_sanity
+      uvm_test_seq: ${name}_sanity_vseq
+    }
+
+    // TODO: add more tests here
+  ]
+}
+


### PR DESCRIPTION
This PR updates the `uvmdvgen` script to generate the hjson for dvsim.py regression tool for building and running tests. The generation of the Makefile is relegated to a tool switch `--add-makefile` which is set to False by default. 

Signed-off-by: Srikrishna Iyer <sriyer@google.com>