### PR TITLE
[sw] Add README to DIF directory

### DIFF
--- a/sw/device/lib/dif/README.md
+++ b/sw/device/lib/dif/README.md
@@ -1,0 +1,14 @@
+# The OpenTitan DIF Library
+
+A DIF is a "Device Interface Function". DIFs are low-level routines for
+accessing the hardware functionality directly, and are agnostic to the
+particular environment or context they are called from. The intention is that
+DIFs can be used during design verification, and during early silicon
+verification, and by the high-level driver software in production firmware.
+
+This subtree provides headers and libraries known collectively as the DIF
+libraries.
+
+There is one DIF library per hardware IP, and each one contains the DIFs
+required to actuate all of the specification-required functionality of the
+hardware they are written for.


### PR DESCRIPTION
This explains what is in the directory, and what a DIF is.

---
This is not yet the canonical specification for how a DIF should
be written and tested, it is a only a short introduction that can potentially
be added to when the official DIF specification is complete.

I have added this file because I think this might be where we write extra
coding guidelines for the DIFs themselves, even if it ends up never containing
the official DIF specification.