### PR TITLE
[verible] Add build and run scripts for Verible format/lint

### DIFF
--- a/util/build-verible.sh
+++ b/util/build-verible.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# This script installs Verible, an open-source style lint and code
+# formatting tool: https://github.com/google/verible
+# Note that this tool is still experimental. Especially the formatting
+# part is still under active development, and hence not production ready.
+#
+
+VERIBLE_VERSION=e654c18e4e712285757f9667f737a73f88f71c01
+INSTALL_DIR=/tools/verible
+
+# this requires the bazel build system and GCC7
+# see https://docs.bazel.build/versions/master/install-ubuntu.html
+
+echo "checking whether bazel is installed..."
+if which bazel; then
+	echo "OK"
+else
+	echo "bazel is not installed. installing bazel..."
+	sudo apt install curl -y
+	curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
+	echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" \
+		| sudo tee /etc/apt/sources.list.d/bazel.list
+	sudo apt update && sudo apt install bazel -y
+fi
+
+# upgrade to GCC7
+# TODO: check whether we need to maintain the default symlinks here
+# for gcc -> GCC-5* such that other tools still work.
+echo "checking whether GCC7 is installed..."
+if which gcc-7; then
+	echo "OK"
+else
+	echo "GCC7 is not installed. installing GCC7..."
+	sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+	sudo apt update
+	sudo apt install g++-7 -y
+fi
+
+# get verible and install under /tools/verible
+# note: you may add $INSTALL_DIR to the PATH, but it is not
+# required for the run scripts to work.
+echo "Installing Verible ($VERIBLE_VERSION)..."
+
+mkdir -p build && cd build
+git clone https://github.com/google/verible.git
+cd verible
+git checkout $VERIBLE_VERSION
+
+bazel build --cxxopt='-std=c++17' //...
+bazel test --cxxopt='-std=c++17' //...
+
+sudo mkdir -p $INSTALL_DIR
+
+sudo install bazel-bin/verilog/tools/syntax/verilog_syntax $INSTALL_DIR
+sudo install bazel-bin/verilog/tools/formatter/verilog_format $INSTALL_DIR
+sudo install bazel-bin/verilog/tools/lint/verilog_lint $INSTALL_DIR
+
+echo "done"
+
+

--- a/util/verible-format.sh
+++ b/util/verible-format.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# this script runs the verible formatter on all system verilog
+# files under hw/{ip,vendor,top_earlgrey}
+#
+# make sure to invoke this tool from the project root.
+#
+# NOTE: this operates in-place - so make sure to make a backup or
+# run this on an experimental branch
+#
+# TODO: integrate this with Fusesoc and the other linting flows.
+
+NUM_PROCS=8
+REPORT_FILE="verible-style-format.rpt"
+
+# this is a precaution in order to prevent accidental
+# overwriting of uncomitted changes
+git add -u
+
+# get all system verilog files and pipe through style formatter
+find hw/{ip,vendor,top_earlgrey} -type f -name "*.sv" -o -name "*.svh" | \
+    xargs -n 1 -P $NUM_PROCS /tools/verible/verilog_format               \
+    --inplace
+
+# report changed files
+git status                  | \
+    grep modified           | \
+    grep dv                 | \
+    awk -F ' ' '{print $2}' | \
+    tee $REPORT_FILE

--- a/util/verible-style-lint.sh
+++ b/util/verible-style-lint.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# this script runs the verible style linte on all system verilog
+# files under hw/{ip,vendor,top_earlgrey}
+#
+# TODO: integrate this with Fusesoc and the other linting flows.
+
+NUM_PROCS=8
+REPORT_FILE="verible-style-lint.rpt"
+EXCLUDED_RULES="-macro-name-style"
+
+# get all system verilog files and pipe through style linter
+find hw/{ip,vendor,top_earlgrey} -type f -name "*.sv" -o -name "*.svh" |  \
+    xargs -n 1 -P $NUM_PROCS /tools/verible/verilog_lint                  \
+    --rules=$EXCLUDED_RULES                                               \
+    | tee $REPORT_FILE


### PR DESCRIPTION
This commit adds a build script and two run scripts to enable Verible style linting and formatting. Verible is opensource and still under active development, so this is currently only for experimental purposes.

Note that the run scripts are very simplistic at the moment, but it is planned to integrate this with the Fusesoc linting flow that is already in place.

Tracking issue: https://github.com/lowRISC/opentitan/issues/1342
Related Edalize issue: https://github.com/olofk/edalize/issues/95

Signed-off-by: Michael Schaffner <msf@opentitan.org>