### PR TITLE
missing newline escape prevents docker build from working

### DIFF
--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -16,7 +16,7 @@ ARG RISCV_TOOLCHAIN_TAR_VERSION=20190807-1
 # transports.
 FROM ubuntu:16.04 AS openocd
 RUN apt-get update && apt-get install -y \
-    autoconf
+    autoconf \
     git \
     libftdi1-dev \
     libtool \


### PR DESCRIPTION
Currently
```
$ docker build -t opentitan -f util/container/Dockerfile .
Sending build context to Docker daemon  372.9MB
Error response from daemon: Dockerfile parse error line 20: unknown instruction: GIT
```

The fix was simple:
```
 RUN apt-get update && apt-get install -y \
-    autoconf
+    autoconf \
     git \
     libftdi1-dev \
     libtool \
```