### PR TITLE
[usbdev dv] Initial dv bench

### DIFF
--- a/hw/_index.md
+++ b/hw/_index.md
@@ -32,3 +32,4 @@ This includes: top level specification(s); processor core(s) specifications; and
 | `spi_device`    | [design spec]({{< relref "hw/ip/spi_device/doc" >}})    | [DV plan]({{< relref "hw/ip/spi_device/doc/dv_plan" >}}) |
 | `tlul`          | [design spec]({{< relref "hw/ip/tlul/doc" >}})          | [DV plan]({{< relref "hw/ip/tlul/doc/dv_plan" >}})
 | `uart`          | [design spec]({{< relref "hw/ip/uart/doc" >}})          | [DV plan]({{< relref "hw/ip/uart/doc/dv_plan" >}}) |
+| `usbdev`        | [design spec]({{< relref "hw/ip/usbdev/doc" >}})        | [DV plan]({{< relref "hw/ip/usbdev/doc/dv_plan" >}}) |

--- a/hw/dv/sv/dv_lib/dv_base_reg_field.sv
+++ b/hw/dv/sv/dv_lib/dv_base_reg_field.sv
@@ -9,7 +9,10 @@ class dv_base_reg_field extends uvm_reg_field;
 
   // when use UVM_PREDICT_WRITE and the CSR access is WO, this function will return the default
   // val of the register, rather than the written value
-  virtual function uvm_reg_data_t XpredictX(uvm_reg_data_t cur_val, uvm_reg_data_t wr_val, uvm_reg_map map);
+  virtual function uvm_reg_data_t XpredictX(uvm_reg_data_t cur_val,
+                                            uvm_reg_data_t wr_val,
+                                            uvm_reg_map map);
+
     if (get_access(map) == "WO") return cur_val;
     else return super.XpredictX(cur_val, wr_val, map);
   endfunction

--- a/hw/dv/sv/usb20_agent/README.md
+++ b/hw/dv/sv/usb20_agent/README.md
@@ -1,0 +1,4 @@
+# USB20 UVM Agent
+
+USB20 UVM Agent is extended from DV library agent classes. This is just a
+skeleton implementation for now. There is no functionality available yet.

--- a/hw/dv/sv/usb20_agent/seq_lib/usb20_base_seq.sv
+++ b/hw/dv/sv/usb20_agent/seq_lib/usb20_base_seq.sv
@@ -1,0 +1,17 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class usb20_base_seq extends dv_base_seq #(
+  .CFG_T       (usb20_agent_cfg),
+  .SEQUENCER_T (usb20_sequencer)
+);
+  `uvm_object_utils(usb20_base_seq)
+
+  `uvm_object_new
+
+  virtual task body();
+    `uvm_fatal(`gtn, "Need to override this when you extend from this class!")
+  endtask
+
+endclass

--- a/hw/dv/sv/usb20_agent/seq_lib/usb20_seq_list.sv
+++ b/hw/dv/sv/usb20_agent/seq_lib/usb20_seq_list.sv
@@ -1,0 +1,5 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`include "usb20_base_seq.sv"

--- a/hw/dv/sv/usb20_agent/usb20_agent.core
+++ b/hw/dv/sv/usb20_agent/usb20_agent.core
@@ -1,0 +1,29 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:usb20_agent:0.1"
+description: "USB20 DV UVM agent"
+filesets:
+  files_dv:
+    depend:
+      - lowrisc:dv:dv_utils
+      - lowrisc:dv:dv_lib
+    files:
+      - usb20_if.sv
+      - usb20_agent_pkg.sv
+      - usb20_agent_cfg.sv: {is_include_file: true}
+      - usb20_agent_cov.sv: {is_include_file: true}
+      - usb20_item.sv: {is_include_file: true}
+      - usb20_host_driver.sv: {is_include_file: true}
+      - usb20_device_driver.sv: {is_include_file: true}
+      - usb20_monitor.sv: {is_include_file: true}
+      - usb20_agent.sv: {is_include_file: true}
+      - seq_lib/usb20_base_seq.sv: {is_include_file: true}
+      - seq_lib/usb20_seq_list.sv: {is_include_file: true}
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_dv

--- a/hw/dv/sv/usb20_agent/usb20_agent.sv
+++ b/hw/dv/sv/usb20_agent/usb20_agent.sv
@@ -1,0 +1,26 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class usb20_agent extends dv_base_agent #(
+  .CFG_T          (usb20_agent_cfg),
+  .DRIVER_T       (usb20_driver),
+  .HOST_DRIVER_T  (usb20_host_driver),
+  .DEVICE_DRIVER_T(usb20_device_driver),
+  .SEQUENCER_T    (usb20_sequencer),
+  .MONITOR_T      (usb20_monitor),
+  .COV_T          (usb20_agent_cov)
+);
+  `uvm_component_utils(usb20_agent)
+
+  `uvm_component_new
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    // get usb20_if handle
+    if (!uvm_config_db#(virtual usb20_if)::get(this, "", "vif", cfg.vif)) begin
+      `uvm_fatal(`gfn, "failed to get usb20_if handle from uvm_config_db")
+    end
+  endfunction
+
+endclass

--- a/hw/dv/sv/usb20_agent/usb20_agent_cfg.sv
+++ b/hw/dv/sv/usb20_agent/usb20_agent_cfg.sv
@@ -2,12 +2,12 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class ${name}_agent_cfg extends dv_base_agent_cfg;
+class usb20_agent_cfg extends dv_base_agent_cfg;
 
   // interface handle used by driver, monitor & the sequencer, via cfg handle
-  virtual ${name}_if vif;
+  virtual usb20_if vif;
 
-  `uvm_object_utils_begin(${name}_agent_cfg)
+  `uvm_object_utils_begin(usb20_agent_cfg)
   `uvm_object_utils_end
 
   `uvm_object_new

--- a/hw/dv/sv/usb20_agent/usb20_agent_cov.sv
+++ b/hw/dv/sv/usb20_agent/usb20_agent_cov.sv
@@ -1,0 +1,18 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class usb20_agent_cov extends dv_base_agent_cov #(usb20_agent_cfg);
+  `uvm_component_utils(usb20_agent_cov)
+
+  // the base class provides the following handles for use:
+  // usb20_agent_cfg: cfg
+
+  // covergroups
+
+  function new(string name, uvm_component parent);
+    super.new(name, parent);
+    // instantiate all covergroups here
+  endfunction : new
+
+endclass

--- a/hw/dv/sv/usb20_agent/usb20_agent_pkg.sv
+++ b/hw/dv/sv/usb20_agent/usb20_agent_pkg.sv
@@ -1,0 +1,43 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package usb20_agent_pkg;
+  // dep packages
+  import uvm_pkg::*;
+  import dv_utils_pkg::*;
+  import dv_lib_pkg::*;
+
+  // macro includes
+  `include "uvm_macros.svh"
+  `include "dv_macros.svh"
+
+  // parameters
+
+  // local types
+  // forward declare classes to allow typedefs below
+  typedef class usb20_item;
+  typedef class usb20_agent_cfg;
+
+  // add typedef for usb20_driver which is dv_base_driver with the right parameter set
+  // usb20_host_driver and usb20_device_driver will extend from this
+  typedef dv_base_driver #(.ITEM_T        (usb20_item),
+                           .CFG_T         (usb20_agent_cfg)) usb20_driver;
+
+  // reuse dv_base_seqeuencer as is with the right parameter set
+  typedef dv_base_sequencer #(.ITEM_T     (usb20_item),
+                              .CFG_T      (usb20_agent_cfg)) usb20_sequencer;
+
+  // functions
+
+  // package sources
+  `include "usb20_item.sv"
+  `include "usb20_agent_cfg.sv"
+  `include "usb20_agent_cov.sv"
+  `include "usb20_host_driver.sv"
+  `include "usb20_device_driver.sv"
+  `include "usb20_monitor.sv"
+  `include "usb20_agent.sv"
+  `include "usb20_seq_list.sv"
+
+endpackage: usb20_agent_pkg

--- a/hw/dv/sv/usb20_agent/usb20_device_driver.sv
+++ b/hw/dv/sv/usb20_agent/usb20_device_driver.sv
@@ -1,0 +1,26 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class usb20_device_driver extends usb20_driver;
+  `uvm_component_utils(usb20_device_driver)
+
+  // the base class provides the following handles for use:
+  // usb20_agent_cfg: cfg
+
+  `uvm_component_new
+
+  virtual task run_phase(uvm_phase phase);
+    // base class forks off reset_signals() and get_and_drive() tasks
+    super.run_phase(phase);
+  endtask
+
+  // reset signals
+  virtual task reset_signals();
+  endtask
+
+  // drive trans received from sequencer
+  virtual task get_and_drive();
+  endtask
+
+endclass

--- a/hw/dv/sv/usb20_agent/usb20_host_driver.sv
+++ b/hw/dv/sv/usb20_agent/usb20_host_driver.sv
@@ -1,0 +1,37 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class usb20_host_driver extends usb20_driver;
+  `uvm_component_utils(usb20_host_driver)
+
+  // the base class provides the following handles for use:
+  // usb20_agent_cfg: cfg
+
+  `uvm_component_new
+
+  virtual task run_phase(uvm_phase phase);
+    // base class forks off reset_signals() and get_and_drive() tasks
+    super.run_phase(phase);
+  endtask
+
+  // reset signals
+  virtual task reset_signals();
+  endtask
+
+  // drive trans received from sequencer
+  virtual task get_and_drive();
+    forever begin
+      seq_item_port.get_next_item(req);
+      $cast(rsp, req.clone());
+      rsp.set_id_info(req);
+      `uvm_info(`gfn, $sformatf("rcvd item:\n%0s", req.sprint()), UVM_HIGH)
+      // TODO: do the driving part
+      //
+      // send rsp back to seq
+      `uvm_info(`gfn, "item sent", UVM_HIGH)
+      seq_item_port.item_done(rsp);
+    end
+  endtask
+
+endclass

--- a/hw/dv/sv/usb20_agent/usb20_if.sv
+++ b/hw/dv/sv/usb20_agent/usb20_if.sv
@@ -1,0 +1,11 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+interface usb20_if ();
+
+  // interface pins
+
+  // debug signals
+
+endinterface

--- a/hw/dv/sv/usb20_agent/usb20_item.sv
+++ b/hw/dv/sv/usb20_agent/usb20_item.sv
@@ -2,12 +2,11 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class ${name}_agent_cfg extends dv_base_agent_cfg;
+class usb20_item extends uvm_sequence_item;
 
-  // interface handle used by driver, monitor & the sequencer, via cfg handle
-  virtual ${name}_if vif;
+  // random variables
 
-  `uvm_object_utils_begin(${name}_agent_cfg)
+  `uvm_object_utils_begin(usb20_item)
   `uvm_object_utils_end
 
   `uvm_object_new

--- a/hw/dv/sv/usb20_agent/usb20_monitor.sv
+++ b/hw/dv/sv/usb20_agent/usb20_monitor.sv
@@ -1,0 +1,43 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class usb20_monitor extends dv_base_monitor #(
+  .ITEM_T (usb20_item),
+  .CFG_T  (usb20_agent_cfg),
+  .COV_T  (usb20_agent_cov)
+);
+  `uvm_component_utils(usb20_monitor)
+
+  // the base class provides the following handles for use:
+  // usb20_agent_cfg: cfg
+  // usb20_agent_cov: cov
+  // uvm_analysis_port #(usb20_item): analysis_port
+
+  `uvm_component_new
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+  endfunction
+
+  task run_phase(uvm_phase phase);
+    super.run_phase(phase);
+  endtask
+
+  // collect transactions forever - already forked in dv_base_moditor::run_phase
+  virtual protected task collect_trans(uvm_phase phase);
+    forever begin
+      // TODO: detect event
+
+      // TODO: sample the interface
+
+      // TODO: sample the covergroups
+
+      // TODO: write trans to analysis_port
+
+      // TODO: remove the line below: it is added to prevent zero delay loop in template code
+      #1us;
+    end
+  endtask
+
+endclass

--- a/hw/ip/usbdev/data/usbdev.hjson
+++ b/hw/ip/usbdev/data/usbdev.hjson
@@ -219,6 +219,7 @@
         {
           bits: "31",
           name: "rx_empty",
+          resval: "1",
           desc: "Receive FIFO is empty"
         }
       ]
@@ -359,9 +360,9 @@
                       transaction to this endpoint will be responded to
                       with a STALL return. This is used when the endpoint
                       is disabled (functional stall) or when a control transfer
-                      is not supported (protocol stall). SETUP transactions 
+                      is not supported (protocol stall). SETUP transactions
                       are always accepted and a SETUP will clear the stall
-                      flag (this is necessary for protocol stalls, to avoid 
+                      flag (this is necessary for protocol stalls, to avoid
                       sending stalls on subsequent IN/OUT transfers).
                       '''
           }
@@ -500,7 +501,7 @@
           name: "eop_single_bit",
           resval: "1",
           desc: '''
-               Recognize a single SE0 bit as an end of packet, otherwise two 
+               Recognize a single SE0 bit as an end of packet, otherwise two
                successive bits are required.
           '''
         }

--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -1,0 +1,28 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  name: "usbdev"
+  // TODO: remove the common testplans if not applicable
+  import_testplans: ["hw/dv/tools/testplans/csr_testplan.hjson",
+                     "hw/dv/tools/testplans/mem_testplan.hjson",
+                     "hw/dv/tools/testplans/intr_test_testplan.hjson",
+                     "hw/dv/tools/testplans/tl_device_access_types_testplan.hjson"]
+  entries: [
+    {
+      name: sanity
+      desc: '''**Goal**: Basic sanity test acessing a major datapath in USBDEV.
+
+            **Stimulus**: Describe the stimulus procedure.
+
+            **Checks**": Describe the self-check procedure.
+            - add bullets as needed
+            - second bullet<br>
+              describe second bullet
+
+            Start a new paragraph.'''
+      milestone: V1
+      tests: ["usbdev_sanity"]
+    }
+  ]
+}

--- a/hw/ip/usbdev/doc/dv_plan/index.md
+++ b/hw/ip/usbdev/doc/dv_plan/index.md
@@ -1,0 +1,101 @@
+---
+title: "USBDEV DV Plan"
+---
+
+## Goals
+* **DV**
+  * Verify all USBDEV IP features by running dynamic simulations with a SV/UVM based testbench.
+  * Develop and run all tests based on the [testplan](#testplan) below towards closing code and functional coverage on the IP and all of its sub-modules.
+    * Note that code and functional coverage goals are TBD due to pending evaluation of where / how to source a USB20 UVM VIP.
+    * The decision is trending towards hooking up a cocotb (Python) based open source USB20 compliance test suite with this UVM environment.
+* **FPV**
+  * Verify TileLink device protocol compliance with an SVA based testbench.
+
+## Current status
+* [Design & verification stage]({{< relref "doc/project/hw_dashboard" >}})
+  * [HW development stages]({{< relref "doc/project/hw_stages" >}})
+* DV regression results dashboard (link TBD)
+
+## Design features
+For detailed information on USBDEV design features, please see the [USBDEV HWIP technical specification]({{< relref "hw/ip/usbdev/doc" >}}).
+
+## Testbench architecture
+USBDEV testbench has been constructed based on the [CIP testbench architecture]({{< relref "hw/dv/sv/cip_lib/doc" >}}).
+
+### Block diagram
+![Block diagram](tb.svg)
+
+### Top level testbench
+Top level testbench is located at `hw/ip/usbdev/dv/tb/tb.sv`.
+It instantiates the USBDEV DUT module `hw/ip/usbdev/rtl/usbdev.sv`.
+In addition, it instantiates the following interfaces, connects them to the DUT and sets their handle into `uvm_config_db`:
+* [Clock and reset interface for the TL and USB domains]({{< relref "hw/dv/sv/common_ifs" >}})
+* [TileLink host interface]({{< relref "hw/dv/sv/tl_agent/README.md" >}})
+* USBDEV IOs
+* Interrupts ([`pins_if`]({{< relref "hw/dv/sv/common_ifs" >}})
+
+### Common DV utility components
+The following utilities provide generic helper tasks and functions to perform activities that are common across the project:
+* [dv_utils_pkg]({{< relref "hw/dv/sv/dv_utils/README.md" >}})
+* [csr_utils_pkg]({{< relref "hw/dv/sv/csr_utils/README.md" >}})
+
+### Compile-time configurations
+None for now.
+
+### Global types & methods
+All common types and methods defined at the package level can be found in `usbdev_env_pkg`.
+Some of them in use are:
+```systemverilog
+[list a few parameters, types & methods; no need to mention all]
+```
+
+### TL_agent
+USBDEV testbench instantiates (already handled in CIP base env) [tl_agent]({{< relref "hw/dv/sv/tl_agent/README.md" >}}) which provides the ability to drive and independently monitor random traffic via TL host interface into USBDEV device.
+
+###  USB20 Agent
+The [usb20_agent]({{< relref "hw/dv/sv/usb20_agent/README.md" >}}) is currently a skeleton implementation.
+It does not offer any functionality yet.
+
+### UVM RAL Model
+The USBDEV RAL model is created with the `hw/dv/tools/gen_ral_pkg.py` wrapper script at the start of the simulation automatically and is placed in the build area, along with a corresponding `fusesoc` core file.
+The wrapper script invokes the [regtool.py]({{< relref "util/reggen/README.md" >}}) script from within to generate the RAL model.
+
+### Reference models
+There are no reference models in use currently.
+
+### Stimulus strategy
+#### Test sequences
+All test sequences reside in `hw/ip/usbdev/dv/env/seq_lib`.
+The `usbdev_base_vseq` virtual sequence is extended from `cip_base_vseq` and serves as a starting point.
+All test sequences are extended from `usbdev_base_vseq`.
+It provides commonly used handles, variables, functions and tasks that the test sequences can simple use / call.
+Some of the most commonly used tasks / functions are as follows:
+* `usbdev_init()`: Do basic USB device initialization.
+
+#### Functional coverage
+To ensure high quality constrained random stimulus, it is necessary to develop a functional coverage model.
+The following covergroups have been developed to prove that the test intent has been adequately met:
+* TBD
+
+### Self-checking strategy
+#### Scoreboard
+The `usbdev_scoreboard` is primarily used for end to end checking.
+It creates the following analysis ports to retrieve the data monitored by corresponding interface agents:
+* TBD
+
+#### Assertions
+* TLUL assertions: The `tb/usbdev_bind.sv` binds the `tlul_assert` [assertions]({{< relref "hw/ip/tlul/doc/TlulProtocolChecker.md" >}}) to the IP to ensure TileLink interface protocol compliance.
+* Unknown checks on DUT outputs: The RTL has assertions to ensure all outputs are initialized to known values after coming out of reset.
+* TBD
+
+## Building and running tests
+We are using our in-house developed [regression tool]({{< relref "hw/dv/tools/README.md" >}}) for building and running our tests and regressions.
+Please take a look at the link for detailed information on the usage, capabilities, features and known issues.
+Here's how to run a basic sanity test:
+```console
+$ cd hw/ip/usbdev/dv
+$ make TEST_NAME=usbdev_sanity
+```
+
+## Testplan
+{{< testplan "hw/ip/usbdev/data/usbdev_testplan.hjson" >}}

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
@@ -1,0 +1,90 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class usbdev_base_vseq extends cip_base_vseq #(
+  .CFG_T               (usbdev_env_cfg),
+  .RAL_T               (usbdev_reg_block),
+  .COV_T               (usbdev_env_cov),
+  .VIRTUAL_SEQUENCER_T (usbdev_virtual_sequencer)
+);
+  `uvm_object_utils(usbdev_base_vseq)
+
+  // various knobs to enable certain routines
+  bit do_usbdev_init = 1'b1;
+
+  // add post_reset_delays for sync between bus clk and usb clk in the apply_reset task
+  bit apply_post_reset_delays_for_sync = 1'b1;
+
+  `uvm_object_new
+
+  // Override apply_reset to cater to usb domain as well.
+  virtual task apply_reset(string kind = "HARD");
+    fork
+      if (kind == "HARD" || kind == "BUS_IF") begin
+        super.apply_reset("HARD");
+      end
+      if (kind == "HARD" || kind == "USB_IF") begin
+        cfg.usb_clk_rst_vif.apply_reset();
+      end
+    join
+    do_apply_post_reset_delays_for_sync();
+  endtask
+
+  // Apply additional delays at the dut_init stage when either apply_reset or
+  // wait_for_reset is called. The additional delays allow the logic to sync
+  // across clock domains so that the Dut behaves deterministically. To disable
+  // this, set apply_post_reset_delays_for_sync in the extended class' pre_start.
+  virtual task do_apply_post_reset_delays_for_sync();
+    if (apply_post_reset_delays_for_sync) begin
+      fork
+        cfg.clk_rst_vif.wait_clks($urandom_range(5, 10));
+        cfg.usb_clk_rst_vif.wait_clks($urandom_range(5, 10));
+      join
+    end
+  endtask
+
+  // Override wait_for_reset to cater to usb domain as well.
+  virtual task wait_for_reset(string reset_kind     = "HARD",
+                              bit wait_for_assert   = 1,
+                              bit wait_for_deassert = 1);
+
+    fork
+      if (reset_kind == "HARD" || reset_kind == "BUS_IF") begin
+        super.wait_for_reset(reset_kind, wait_for_assert, wait_for_deassert);
+      end
+      if (reset_kind == "HARD" || reset_kind == "USB_IF") begin
+        if (wait_for_assert) begin
+          `uvm_info(`gfn, "waiting for usb rst_n assertion...", UVM_MEDIUM)
+          @(negedge cfg.usb_clk_rst_vif.rst_n);
+        end
+        if (wait_for_deassert) begin
+          `uvm_info(`gfn, "waiting for usb rst_n de-assertion...", UVM_MEDIUM)
+          @(posedge cfg.usb_clk_rst_vif.rst_n);
+        end
+        `uvm_info(`gfn, "usb wait_for_reset done", UVM_HIGH)
+      end
+    join
+    do_apply_post_reset_delays_for_sync();
+  endtask
+
+  // Override dut_init to do some basic usbdev initializations (if enabled).
+  virtual task dut_init(string reset_kind = "HARD");
+    super.dut_init();
+    if (do_usbdev_init) usbdev_init();
+  endtask
+
+  virtual task dut_shutdown();
+    // check for pending usbdev operations and wait for them to complete
+    // TODO
+  endtask
+
+  // setup basic usbdev features
+  virtual task usbdev_init(bit [TL_DW-1:0] device_address = 0);
+    // Enable USBDEV
+    ral.usbctrl.enable.set(1'b1);
+    ral.usbctrl.device_address.set(device_address);
+    csr_update(ral.usbctrl);
+  endtask
+
+endclass : usbdev_base_vseq

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_common_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_common_vseq.sv
@@ -1,0 +1,51 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class usbdev_common_vseq extends usbdev_base_vseq;
+  `uvm_object_utils(usbdev_common_vseq)
+
+  constraint num_trans_c {
+    num_trans inside {[1:2]};
+  }
+  `uvm_object_new
+
+  task pre_start();
+    // Common test sequences do not need device init.
+    do_usbdev_init = 1'b0;
+    super.pre_start();
+  endtask
+
+  virtual task body();
+    run_common_vseq_wrapper(num_trans);
+  endtask : body
+
+  // function to add csr exclusions of the given type using the csr_excl_item item
+  virtual function void add_csr_exclusions(string           csr_test_type,
+                                           csr_excl_item    csr_excl,
+                                           string           scope = "ral");
+
+    // Link reset occurs every 3 us. There doesn't seem to be a way to turn that off.
+    // It results in the modification of some CSRS which makes the prediction hard.
+    // Those are being excluded from checks below.
+
+    // write exclusions - these should not apply to hw_reset test
+    if (csr_test_type != "hw_reset") begin
+      // intr_test CSR affects the intr_state csr. It is already tested in intr_test.
+      csr_excl.add_excl({scope, ".", "intr_test"}, CsrExclWrite);
+
+      // Writing ral.avbuffer affects the ral.usbstat.av_depth field.
+      csr_excl.add_excl({scope, ".", "avbuffer"}, CsrExclWrite);
+
+      // ral.usbctrl.device_address is reset to 0 if usb is not enabled.
+      csr_excl.add_excl({scope, ".", "usbctrl.device_address"}, CsrExclWriteCheck);
+
+      // Prevent usb from being enabled to avoid other unforeseen side effects.
+      csr_excl.add_excl({scope, ".", "usbctrl.enable"}, CsrExclWrite);
+
+      // Overriding pwr sense will cause the usbdev to think the link is powered up
+      csr_excl.add_excl({scope, ".", "phy_config.override_pwr_sense_en"}, CsrExclWrite);
+    end
+  endfunction
+
+endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_sanity_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_sanity_vseq.sv
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// basic sanity test vseq
+class usbdev_sanity_vseq extends usbdev_base_vseq;
+  `uvm_object_utils(usbdev_sanity_vseq)
+
+  `uvm_object_new
+
+  task body();
+    `uvm_error(`gfn, "FIXME")
+  endtask : body
+
+endclass : usbdev_sanity_vseq

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
@@ -1,0 +1,7 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`include "usbdev_base_vseq.sv"
+`include "usbdev_sanity_vseq.sv"
+`include "usbdev_common_vseq.sv"

--- a/hw/ip/usbdev/dv/env/usbdev_env.core
+++ b/hw/ip/usbdev/dv/env/usbdev_env.core
@@ -1,0 +1,26 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:usbdev_env:0.1"
+description: "USBDEV DV UVM environment"
+filesets:
+  files_dv:
+    depend:
+      - lowrisc:dv:cip_lib
+      - lowrisc:dv:usb20_agent
+      - lowrisc:dv:gen_ral_pkg
+    files:
+      - usbdev_env_pkg.sv
+      - usbdev_env_cfg.sv: {is_include_file: true}
+      - usbdev_env_cov.sv: {is_include_file: true}
+      - usbdev_env.sv: {is_include_file: true}
+      - usbdev_virtual_sequencer.sv: {is_include_file: true}
+      - usbdev_scoreboard.sv: {is_include_file: true}
+      - seq_lib/usbdev_vseq_list.sv: {is_include_file: true}
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_dv

--- a/hw/ip/usbdev/dv/env/usbdev_env.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_env.sv
@@ -1,0 +1,41 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class usbdev_env extends cip_base_env #(
+  .CFG_T              (usbdev_env_cfg),
+  .COV_T              (usbdev_env_cov),
+  .VIRTUAL_SEQUENCER_T(usbdev_virtual_sequencer),
+  .SCOREBOARD_T       (usbdev_scoreboard)
+);
+  `uvm_component_utils(usbdev_env)
+
+  usb20_agent m_usb20_agent;
+
+  `uvm_component_new
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    // get vifs
+    if (!uvm_config_db#(virtual clk_rst_if)::get(this, "", "usb_clk_rst_vif",
+        cfg.usb_clk_rst_vif)) begin
+      `uvm_fatal(get_full_name(), "failed to get usb_clk_rst_if from uvm_config_db")
+    end
+    cfg.usb_clk_rst_vif.set_freq_mhz(cfg.usb_clk_freq_mhz);
+
+    // create components
+    m_usb20_agent = usb20_agent::type_id::create("m_usb20_agent", this);
+    uvm_config_db#(usb20_agent_cfg)::set(this, "m_usb20_agent*", "cfg", cfg.m_usb20_agent_cfg);
+  endfunction
+
+  function void connect_phase(uvm_phase phase);
+    super.connect_phase(phase);
+    if (cfg.en_scb) begin
+      m_usb20_agent.monitor.analysis_port.connect(scoreboard.usb20_fifo.analysis_export);
+    end
+    if (cfg.is_active && cfg.m_usb20_agent_cfg.is_active) begin
+      virtual_sequencer.usb20_sequencer_h = m_usb20_agent.sequencer;
+    end
+  endfunction
+
+endclass

--- a/hw/ip/usbdev/dv/env/usbdev_env_cfg.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_env_cfg.sv
@@ -1,0 +1,54 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class usbdev_env_cfg extends cip_base_env_cfg #(.RAL_T(usbdev_reg_block));
+
+  virtual clk_rst_if  usb_clk_rst_vif;
+  rand clk_freq_mhz_e usb_clk_freq_mhz;
+
+  // Reset kinds for USB
+  string reset_kinds[] = {"HARD", "TL_IF", "USB_IF"};
+
+  // Constrain USB to be at 48MHz based on spec
+  constraint usb_clk_freq_mhz_c {
+    usb_clk_freq_mhz == dv_utils_pkg::ClkFreq48Mhz;
+  }
+
+  // ext component cfgs
+  rand usb20_agent_cfg m_usb20_agent_cfg;
+
+  `uvm_object_utils_begin(usbdev_env_cfg)
+    `uvm_field_object(m_usb20_agent_cfg,                UVM_DEFAULT)
+    `uvm_field_enum  (clk_freq_mhz_e, usb_clk_freq_mhz, UVM_DEFAULT)
+  `uvm_object_utils_end
+
+  `uvm_object_new
+
+  virtual function void initialize_csr_addr_map_size();
+    this.csr_addr_map_size = USBDEV_ADDR_MAP_SIZE;
+  endfunction : initialize_csr_addr_map_size
+
+  virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);
+    super.initialize(csr_base_addr);
+    // create usb20 agent config obj
+    m_usb20_agent_cfg = usb20_agent_cfg::type_id::create("m_usb20_agent_cfg");
+
+    // set num_interrupts & num_alerts
+    begin
+      uvm_reg rg = ral.get_reg_by_name("intr_state");
+      if (rg != null) begin
+        num_interrupts = ral.intr_state.get_n_used_bits();
+      end
+    end
+  endfunction
+
+  // ral flow is limited in terms of setting correct field access policies and reset values
+  // We apply those fixes here - please note these fixes need to be reflected in the scoreboard
+  protected virtual function void apply_ral_fixes();
+    // fix access policies
+    // Out of reset, the link is in disconnected state.
+    ral.intr_state.disconnected.set_reset(1'b1);
+  endfunction
+
+endclass

--- a/hw/ip/usbdev/dv/env/usbdev_env_cov.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_env_cov.sv
@@ -1,0 +1,32 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Covergoups that are dependent on run-time parameters that may be available
+ * only in build_phase can be defined here
+ * Covergroups may also be wrapped inside helper classes if needed.
+ */
+
+class usbdev_env_cov extends cip_base_env_cov #(.CFG_T(usbdev_env_cfg));
+  `uvm_component_utils(usbdev_env_cov)
+
+  // the base class provides the following handles for use:
+  // usbdev_env_cfg: cfg
+
+  // covergroups
+  // [add covergroups here]
+
+  function new(string name, uvm_component parent);
+    super.new(name, parent);
+    // [instantiate covergroups here]
+  endfunction : new
+
+  virtual function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    // [or instantiate covergroups here]
+    // Please instantiate sticky_intr_cov array of objects for all interrupts that are sticky
+    // See cip_base_env_cov for details
+  endfunction
+
+endclass

--- a/hw/ip/usbdev/dv/env/usbdev_env_pkg.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_env_pkg.sv
@@ -1,0 +1,55 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package usbdev_env_pkg;
+  // dep packages
+  import uvm_pkg::*;
+  import top_pkg::*;
+  import dv_utils_pkg::*;
+  import csr_utils_pkg::*;
+  import tl_agent_pkg::*;
+  import usb20_agent_pkg::*;
+  import dv_lib_pkg::*;
+  import cip_base_pkg::*;
+  import usbdev_ral_pkg::*;
+
+  // macro includes
+  `include "uvm_macros.svh"
+  `include "dv_macros.svh"
+
+  // parameters
+  parameter uint USBDEV_ADDR_MAP_SIZE = 4096;
+
+  // types
+  typedef enum {
+    IntrPktReceived = 0,
+    IntrPktSent = 1,
+    IntrDisconnected = 2,
+    IntrHostLost = 3,
+    IntrLinkReset = 4,
+    IntrLinkSuspend = 5,
+    IntrLinkResume = 6,
+    IntrAvEmpty = 7,
+    IntrRxFull = 8,
+    IntrAvOverflow = 9,
+    IntrLinkInErr = 10,
+    IntrRxCrcErr = 11,
+    IntrRxPidErr = 12,
+    IntrRxBitstuffErr = 13,
+    IntrFrame = 14,
+    IntrConnected = 15,
+    NumUsbdevInterrupts
+  } usbdev_intr_e;
+
+  // functions
+
+  // package sources
+  `include "usbdev_env_cfg.sv"
+  `include "usbdev_env_cov.sv"
+  `include "usbdev_virtual_sequencer.sv"
+  `include "usbdev_scoreboard.sv"
+  `include "usbdev_env.sv"
+  `include "usbdev_vseq_list.sv"
+
+endpackage

--- a/hw/ip/usbdev/dv/env/usbdev_virtual_sequencer.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_virtual_sequencer.sv
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class usbdev_virtual_sequencer extends cip_base_virtual_sequencer #(
+  .CFG_T(usbdev_env_cfg),
+  .COV_T(usbdev_env_cov)
+);
+  `uvm_component_utils(usbdev_virtual_sequencer)
+
+  usb20_sequencer usb20_sequencer_h;
+
+  `uvm_component_new
+
+endclass

--- a/hw/ip/usbdev/dv/tb/tb.sv
+++ b/hw/ip/usbdev/dv/tb/tb.sv
@@ -1,0 +1,128 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+module tb;
+  // dep packages
+  import uvm_pkg::*;
+  import dv_utils_pkg::*;
+  import usbdev_env_pkg::*;
+  import usbdev_test_pkg::*;
+
+  // macro includes
+  `include "uvm_macros.svh"
+  `include "dv_macros.svh"
+
+  wire clk, rst_n;
+  wire usb_clk, usb_rst_n;
+  wire devmode;
+  wire intr_pkt_received;
+  wire intr_pkt_sent;
+  wire intr_connected;
+  wire intr_disconnected;
+  wire intr_host_lost;
+  wire intr_link_reset;
+  wire intr_link_suspend;
+  wire intr_link_resume;
+  wire intr_av_empty;
+  wire intr_rx_full;
+  wire intr_av_overflow;
+  wire intr_link_in_err;
+  wire intr_rx_crc_err;
+  wire intr_rx_pid_err;
+  wire intr_rx_bitstuff_err;
+  wire intr_frame;
+
+  wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
+
+  // interfaces
+  clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
+  clk_rst_if usb_clk_rst_if(.clk(usb_clk), .rst_n(usb_rst_n));
+  pins_if #(NUM_MAX_INTERRUPTS) intr_if(interrupts);
+  pins_if #(1) devmode_if(devmode);
+  tl_if tl_if(.clk(clk), .rst_n(rst_n));
+  usb20_if usb20_if();
+
+  // dut
+  usbdev dut (
+    .clk_i                (clk        ),
+    .rst_ni               (rst_n      ),
+
+    .clk_usb_48mhz_i      (usb_clk    ),
+    .rst_usb_ni           (usb_rst_n  ),
+
+    .tl_i                 (tl_if.h2d  ),
+    .tl_o                 (tl_if.d2h  ),
+
+
+    // USB Interface
+    // TOOD: need to hook up an interface
+    .cio_usb_d_i          (1'b0),
+    .cio_usb_dp_i         (1'b1),
+    .cio_usb_dn_i         (1'b0),
+
+    .cio_usb_d_o          (),
+    .cio_usb_se0_o        (),
+    .cio_usb_dp_o         (),
+    .cio_usb_dn_o         (),
+    .cio_usb_oe_o         (),
+
+    .cio_usb_tx_mode_se_o (),
+    .cio_usb_sense_i      (1'b0),
+    .cio_usb_pullup_en_o  (),
+    .cio_usb_suspend_o    (),
+
+    // Interrupts
+    .intr_pkt_received_o    (intr_pkt_received    ),
+    .intr_pkt_sent_o        (intr_pkt_sent        ),
+    .intr_connected_o       (intr_connected       ),
+    .intr_disconnected_o    (intr_disconnected    ),
+    .intr_host_lost_o       (intr_host_lost       ),
+    .intr_link_reset_o      (intr_link_reset      ),
+    .intr_link_suspend_o    (intr_link_suspend    ),
+    .intr_link_resume_o     (intr_link_resume     ),
+    .intr_av_empty_o        (intr_av_empty        ),
+    .intr_rx_full_o         (intr_rx_full         ),
+    .intr_av_overflow_o     (intr_av_overflow     ),
+    .intr_link_in_err_o     (intr_link_in_err     ),
+    .intr_rx_crc_err_o      (intr_rx_crc_err      ),
+    .intr_rx_pid_err_o      (intr_rx_pid_err      ),
+    .intr_rx_bitstuff_err_o (intr_rx_bitstuff_err ),
+    .intr_frame_o           (intr_frame           )
+  );
+
+  // Hook up the interrupt pins to the intr_if
+  assign interrupts[IntrPktReceived]    = intr_pkt_received;
+  assign interrupts[IntrPktSent]        = intr_pkt_sent;
+  assign interrupts[IntrConnected]      = intr_connected;
+  assign interrupts[IntrDisconnected]   = intr_disconnected;
+  assign interrupts[IntrHostLost]       = intr_host_lost;
+  assign interrupts[IntrLinkReset]      = intr_link_reset;
+  assign interrupts[IntrLinkSuspend]    = intr_link_suspend;
+  assign interrupts[IntrLinkResume]     = intr_link_resume;
+  assign interrupts[IntrAvEmpty]        = intr_av_empty;
+  assign interrupts[IntrRxFull]         = intr_rx_full;
+  assign interrupts[IntrAvOverflow]     = intr_av_overflow;
+  assign interrupts[IntrLinkInErr]      = intr_link_in_err;
+  assign interrupts[IntrRxCrcErr]       = intr_rx_crc_err;
+  assign interrupts[IntrRxPidErr]       = intr_rx_pid_err;
+  assign interrupts[IntrRxBitstuffErr]  = intr_rx_bitstuff_err;
+  assign interrupts[IntrFrame]          = intr_frame;
+
+  initial begin
+    // drive clk and rst_n from clk_if
+    clk_rst_if.set_active();
+    usb_clk_rst_if.set_active();
+    uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
+    uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "usb_clk_rst_vif", usb_clk_rst_if);
+    uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
+    uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
+    uvm_config_db#(tlul_assert_ctrl_vif)::set(null, "*.env", "tlul_assert_ctrl_vif",
+        dut.tlul_assert_device.tlul_assert_ctrl_if);
+    uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
+    uvm_config_db#(virtual usb20_if)::set(null, "*.env.m_usb20_agent*", "vif", usb20_if);
+    $timeformat(-12, 0, " ps", 12);
+    run_test();
+  end
+
+endmodule

--- a/hw/ip/usbdev/dv/tb/usbdev_bind.sv
+++ b/hw/ip/usbdev/dv/tb/usbdev_bind.sv
@@ -9,8 +9,8 @@ module usbdev_bind;
   ) tlul_assert_device (
     .clk_i,
     .rst_ni,
-    .h2d  (tl_d_i),
-    .d2h  (tl_d_o)
+    .h2d  (tl_i),
+    .d2h  (tl_o)
   );
 
 endmodule

--- a/hw/ip/usbdev/dv/tests/usbdev_base_test.sv
+++ b/hw/ip/usbdev/dv/tests/usbdev_base_test.sv
@@ -1,0 +1,21 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class usbdev_base_test extends cip_base_test #(
+  .ENV_T(usbdev_env),
+  .CFG_T(usbdev_env_cfg)
+);
+
+  `uvm_component_utils(usbdev_base_test)
+  `uvm_component_new
+
+  // the base class dv_base_test creates the following instances:
+  // usbdev_env_cfg: cfg
+  // usbdev_env:     env
+
+  // the base class also looks up UVM_TEST_SEQ plusarg to create and run that seq in
+  // the run_phase; as such, nothing more needs to be done
+
+endclass : usbdev_base_test
+

--- a/hw/ip/usbdev/dv/tests/usbdev_test.core
+++ b/hw/ip/usbdev/dv/tests/usbdev_test.core
@@ -1,0 +1,19 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:usbdev_test:0.1"
+description: "USBDEV DV UVM test"
+filesets:
+  files_dv:
+    depend:
+      - lowrisc:dv:usbdev_env
+    files:
+      - usbdev_test_pkg.sv
+      - usbdev_base_test.sv: {is_include_file: true}
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_dv

--- a/hw/ip/usbdev/dv/tests/usbdev_test_pkg.sv
+++ b/hw/ip/usbdev/dv/tests/usbdev_test_pkg.sv
@@ -1,0 +1,22 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package usbdev_test_pkg;
+  // dep packages
+  import uvm_pkg::*;
+  import cip_base_pkg::*;
+  import usbdev_env_pkg::*;
+
+  // macro includes
+  `include "uvm_macros.svh"
+  `include "dv_macros.svh"
+
+  // local types
+
+  // functions
+
+  // package sources
+  `include "usbdev_base_test.sv"
+
+endpackage

--- a/hw/ip/usbdev/dv/usbdev_sim.core
+++ b/hw/ip/usbdev/dv/usbdev_sim.core
@@ -1,0 +1,28 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:usbdev_sim:0.1"
+description: "USBDEV DV sim target"
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:ip:usbdev:0.1
+    files:
+      - tb/usbdev_bind.sv
+    file_type: systemVerilogSource
+
+  files_dv:
+    depend:
+      - lowrisc:dv:usbdev_test
+    files:
+      - tb/tb.sv
+    file_type: systemVerilogSource
+
+targets:
+  sim:
+    toplevel: tb
+    filesets:
+      - files_rtl
+      - files_dv
+    default_tool: vcs

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -1,0 +1,58 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  // Name of the sim cfg - typically same as the name of the DUT.
+  name: usbdev
+
+  // Top level dut name (sv module).
+  dut: usbdev
+
+  // Top level testbench name (sv module).
+  tb: tb
+
+  // Fusesoc core file used for building the file list.
+  fusesoc_core: lowrisc:dv:usbdev_sim:0.1
+
+  // Testplan hjson file.
+  testplan: "{proj_root}/hw/ip/usbdev/data/usbdev_testplan.hjson"
+
+  // RAL spec - used to generate the RAL model.
+  ral_spec: "{proj_root}/hw/ip/usbdev/data/usbdev.hjson"
+
+  // Import additional common sim cfg files.
+  import_cfgs: [// Project wide common sim cfg file
+                "{proj_root}/hw/dv/data/common_sim_cfg.hjson",
+                // Common CIP test lists
+                "{proj_root}/hw/dv/data/tests/csr_tests.hjson",
+                "{proj_root}/hw/dv/data/tests/mem_tests.hjson",
+                "{proj_root}/hw/dv/data/tests/intr_test.hjson",
+                "{proj_root}/hw/dv/data/tests/tl_access_tests.hjson",
+                "{proj_root}/hw/dv/data/tests/stress_tests.hjson"]
+
+  // Default iterations for all tests - each test entry can override this.
+  reseed: 50
+
+  // Default UVM test and seq class name.
+  uvm_test: usbdev_base_test
+  uvm_test_seq: usbdev_base_vseq
+
+  // TODO: temporary fix for CSR tests - USB link reset interrupt is sticky - clearing it
+  // has no effect. Update "csr_test_mode" to add +do_clear_all_interrupts=0 switch to
+  // prevent the intr checks from being run.
+  run_modes: [
+    {
+      name: csr_tests_mode
+      run_opts: ["+do_clear_all_interrupts=0"]
+    }
+  ]
+
+  // List of test specifications.
+  tests: [
+    {
+      name: usbdev_sanity
+      uvm_test_seq: usbdev_sanity_vseq
+    }
+  ]
+}
+

--- a/hw/ip/usbdev/rtl/usbdev.sv
+++ b/hw/ip/usbdev/rtl/usbdev.sv
@@ -14,8 +14,8 @@ module usbdev (
   input  logic       rst_usb_ni, // async reset, with relase sync to clk_usb_48_mhz_i
 
   // Register interface
-  input  tlul_pkg::tl_h2d_t tl_d_i,
-  output tlul_pkg::tl_d2h_t tl_d_o,
+  input  tlul_pkg::tl_h2d_t tl_i,
+  output tlul_pkg::tl_d2h_t tl_o,
 
   // USB Interface
   input  logic       cio_usb_d_i,
@@ -239,7 +239,7 @@ module usbdev (
     .rst_ni (rst_usb_ni),
     .d      ({enable_setup, enable_out, ep_stall}),
     .q      ({usb_enable_setup, usb_enable_out, usb_ep_stall})
-  );  
+  );
 
   // CDC: ok, quasi-static
   always_comb begin : proc_map_iso
@@ -272,7 +272,7 @@ module usbdev (
   );
 
   // CDC: We synchronize the qe (write pulse) and assume that the
-  // rest of the register remains stable 
+  // rest of the register remains stable
   prim_pulse_sync usbdev_data_toggle_clear (
     .clk_src_i   (clk_i),
     .clk_dst_i   (clk_usb_48mhz_i),
@@ -286,9 +286,9 @@ module usbdev (
     usb_data_toggle_clear = '0;
     for (int i = 0; i < NEndpoints; i++) begin
       if (usb_data_toggle_clear_en) begin
-        usb_data_toggle_clear[i] = reg2hw.data_toggle_clear[i].q; 
-      end      
-    end  
+        usb_data_toggle_clear[i] = reg2hw.data_toggle_clear[i].q;
+      end
+    end
   end
 
   // Clear of ready and set of sent is a pulse in USB clock domain
@@ -392,7 +392,7 @@ module usbdev (
     end else begin
       // Clear pending when a SETUP is received
       // CDC: usb_out_endpoint is synchronized implicitly by
-      // setup_received, as it is stable 
+      // setup_received, as it is stable
       clear_rdybit[usb_out_endpoint] = setup_received;
       update_pend[usb_out_endpoint]  = setup_received;
 
@@ -520,7 +520,7 @@ module usbdev (
     .rst_ni (rst_usb_ni),
     .d      ({reg2hw.usbctrl.enable.q, reg2hw.usbctrl.device_address.q}),
     .q      ({usb_enable,              usb_device_addr})
-  );  
+  );
 
   // CDC for event signals (arguably they are there for a long time so would be ok)
   // Just want a pulse to ensure only one interrupt for an event
@@ -529,7 +529,7 @@ module usbdev (
     .rst_ni (rst_ni),
     .d      ({usb_event_disconnect, usb_event_link_reset, usb_event_link_suspend,
               usb_event_host_lost, usb_event_connect}),
-    .q      ({event_disconnect, event_link_reset, event_link_suspend, 
+    .q      ({event_disconnect, event_link_reset, event_link_suspend,
               event_host_lost, event_connect})
   );
 
@@ -579,17 +579,17 @@ module usbdev (
   // Clear the stall flag when a SETUP is received
 
   // CDC: usb_out_endpoint is synchronized implicitly by
-  // setup_received, as it is stable 
+  // setup_received, as it is stable
   always_comb begin : proc_stall_tieoff
     for (int i = 0; i < NEndpoints; i++) begin
-      hw2reg.stall[i].d  = 1'b0;              
+      hw2reg.stall[i].d  = 1'b0;
       if (setup_received && usb_out_endpoint == 4'(i)) begin
         hw2reg.stall[i].de = 1'b1;
       end else begin
         hw2reg.stall[i].de = 1'b0;
-      end        
-    end  
-  end  
+      end
+    end
+  end
 
   logic        unused_mem_a_rerror_d;
 
@@ -659,8 +659,8 @@ module usbdev (
     .clk_i,
     .rst_ni,
 
-    .tl_i (tl_d_i),
-    .tl_o (tl_d_o),
+    .tl_i (tl_i),
+    .tl_o (tl_o),
 
     .tl_win_o (tl_sram_h2d),
     .tl_win_i (tl_sram_d2h),

--- a/hw/top_earlgrey/rtl/top_earlgrey_usb.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_usb.sv
@@ -194,7 +194,7 @@ module top_earlgrey_usb #(
   logic intr_nmi_gen_esc2;
   logic intr_nmi_gen_esc3;
 
-  
+
   logic [0:0] irq_plic;
   logic [0:0] msip;
   logic [5:0] irq_id[1];
@@ -561,8 +561,8 @@ module top_earlgrey_usb #(
       .clk_usb_48mhz_i         (clk_48mhz_i),
       .rst_ni                  (spi_device_rst_n),
       .rst_usb_ni              (spi_device_rst_n), // TODO: Need a real USB reset here
-      .tl_d_i                  (tl_spi_device_d_h2d),
-      .tl_d_o                  (tl_spi_device_d_d2h),
+      .tl_i                    (tl_spi_device_d_h2d),
+      .tl_o                    (tl_spi_device_d_d2h),
 
       .cio_usb_d_i             (1'b0),
       .cio_usb_dp_i            (dio_usb_dp_i[USB_DEVICE - 1]),
@@ -573,7 +573,7 @@ module top_earlgrey_usb #(
       .cio_usb_dp_o            (dio_usb_dp_o[USB_DEVICE - 1]),
       .cio_usb_dn_o            (dio_usb_dn_o[USB_DEVICE - 1]),
       .cio_usb_oe_o            (usbdev_usb_oe),
-      
+
       .cio_usb_tx_mode_se_o    (),
       .cio_usb_sense_i         (dio_usb_sense_i[USB_DEVICE - 1]),
       .cio_usb_pullup_en_o     (usbdev_usb_pullup_en),

--- a/util/build_docs.py
+++ b/util/build_docs.py
@@ -81,6 +81,7 @@ config = {
         "hw/ip/rv_timer/data/rv_timer_testplan.hjson",
         "hw/ip/spi_device/data/spi_device_testplan.hjson",
         "hw/ip/uart/data/uart_testplan.hjson",
+        "hw/ip/usbdev/data/usbdev_testplan.hjson",
         "hw/ip/tlul/data/tlul_testplan.hjson",
         "hw/top_earlgrey/data/standalone_sw_testplan.hjson",
         "util/testplanner/examples/foo_testplan.hjson",

--- a/util/uvmdvgen/README.md.tpl
+++ b/util/uvmdvgen/README.md.tpl
@@ -1,5 +1,3 @@
 # ${name.upper()} UVM Agent
 
-{{% toc 4 }}
-
 ${name.upper()} UVM Agent is extended from DV library agent classes.

--- a/util/uvmdvgen/agent.sv.tpl
+++ b/util/uvmdvgen/agent.sv.tpl
@@ -3,16 +3,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 class ${name}_agent extends dv_base_agent #(
-      .CFG_T          (${name}_agent_cfg),
-      .DRIVER_T       (${name}_driver),
+  .CFG_T          (${name}_agent_cfg),
+  .DRIVER_T       (${name}_driver),
 % if has_separate_host_device_driver:
-      .HOST_DRIVER_T  (${name}_host_driver),
-      .DEVICE_DRIVER_T(${name}_device_driver),
+  .HOST_DRIVER_T  (${name}_host_driver),
+  .DEVICE_DRIVER_T(${name}_device_driver),
 % endif
-      .SEQUENCER_T    (${name}_sequencer),
-      .MONITOR_T      (${name}_monitor),
-      .COV_T          (${name}_agent_cov)
-  );
+  .SEQUENCER_T    (${name}_sequencer),
+  .MONITOR_T      (${name}_monitor),
+  .COV_T          (${name}_agent_cov)
+);
 
   `uvm_component_utils(${name}_agent)
 
@@ -21,8 +21,9 @@ class ${name}_agent extends dv_base_agent #(
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
     // get ${name}_if handle
-    if (!uvm_config_db#(virtual ${name}_if)::get(this, "", "vif", cfg.vif))
+    if (!uvm_config_db#(virtual ${name}_if)::get(this, "", "vif", cfg.vif)) begin
       `uvm_fatal(`gfn, "failed to get ${name}_if handle from uvm_config_db")
+    end
   endfunction
 
 endclass

--- a/util/uvmdvgen/agent_pkg.sv.tpl
+++ b/util/uvmdvgen/agent_pkg.sv.tpl
@@ -22,13 +22,13 @@ package ${name}_agent_pkg;
 % if has_separate_host_device_driver:
   // add typedef for ${name}_driver which is dv_base_driver with the right parameter set
   // ${name}_host_driver and ${name}_device_driver will extend from this
-  typedef dv_base_driver #(.ITEM_T        (${name}_item),
-                           .CFG_T         (${name}_agent_cfg)) ${name}_driver;
+  typedef dv_base_driver #(.ITEM_T(${name}_item),
+                           .CFG_T (${name}_agent_cfg)) ${name}_driver;
 
 % endif
   // reuse dv_base_seqeuencer as is with the right parameter set
-  typedef dv_base_sequencer #(.ITEM_T     (${name}_item),
-                              .CFG_T      (${name}_agent_cfg)) ${name}_sequencer;
+  typedef dv_base_sequencer #(.ITEM_T(${name}_item),
+                              .CFG_T (${name}_agent_cfg)) ${name}_sequencer;
 
   // functions
 
@@ -46,4 +46,4 @@ package ${name}_agent_pkg;
   `include "${name}_agent.sv"
   `include "${name}_seq_list.sv"
 
-  endpackage: ${name}_agent_pkg
+endpackage: ${name}_agent_pkg

--- a/util/uvmdvgen/bind.sv.tpl
+++ b/util/uvmdvgen/bind.sv.tpl
@@ -5,7 +5,9 @@
 module ${name}_bind;
 % if is_cip:
 
-  bind ${name} tlul_assert tlul_assert_host (
+  bind ${name} tlul_assert #(
+    .EndpointType("Device")
+  ) tlul_assert_device (
     .clk_i,
     .rst_ni,
     .h2d  (tl_i),

--- a/util/uvmdvgen/env.sv.tpl
+++ b/util/uvmdvgen/env.sv.tpl
@@ -25,6 +25,7 @@ class ${name}_env extends dv_base_env #(
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
 % for agent in env_agents:
+    // create components
     m_${agent}_agent = ${agent}_agent::type_id::create("m_${agent}_agent", this);
     uvm_config_db#(${agent}_agent_cfg)::set(this, "m_${agent}_agent*", "cfg", cfg.m_${agent}_agent_cfg);
 % endfor


### PR DESCRIPTION
- Full UVM DV bench for usbdev
- Added a skeleton usb20 UVM agent just in case someone has BW to
develop it
- RTL and testbench compiles cleanly
- Basic CSR power on reset test passing with 100 seeds

- Added usbdev links to hw/_index.md to get it to show the USBDEV spec
and DV plan docs
- Renamed usbdev.sv tl ports from tl_d_i to tl_i and tl_d_o to tl_o
  - Reason for this is to support automation (conformity across all IPs
  helps)
- Minor fixes to uvmdvgen templates

Signed-off-by: Srikrishna Iyer <sriyer@google.com>