### PR TITLE
[lint] Add waiver rule for AES Verilator lint

### DIFF
--- a/hw/ip/aes/lint/aes.vlt
+++ b/hw/ip/aes/lint/aes.vlt
@@ -4,3 +4,8 @@
 //
 // waiver file for aes
 
+`verilator_config
+
+// Always_comb variable driven after use: 'regular'
+// regular is assigned in a for loop, regular[1] depends on regular[0]
+lint_off -msg ALWCOMBORDER -file "*/rtl/aes_key_expand.sv" -lines 206


### PR DESCRIPTION
This PR adds a first waiver rule for AES Verilator lint.