### PR TITLE
[dv regr tool] Added 'overrides' directive

### DIFF
--- a/hw/dv/data/common_sim_cfg.hjson
+++ b/hw/dv/data/common_sim_cfg.hjson
@@ -118,4 +118,5 @@
 
   // Project defaults for VCS
   vcs_cov_hier: "-cm_hier {proj_root}/hw/dv/tools/vcs/cover.cfg"
+  vcs_cov_excl_files: ["{proj_root}/hw/dv/tools/vcs/common_cov_excl.el"]
 }

--- a/hw/dv/data/vcs/vcs.hjson
+++ b/hw/dv/data/vcs/vcs.hjson
@@ -34,8 +34,9 @@
 
   // Defaults for VCS
   cov_metrics:          "line+cond+fsm+tgl+branch+assert"
-  vcs_cov_hier:         "-cm_hier {proj_root}/hw/dv/tools/vcs/cover.cfg"
+  vcs_cov_hier:         ""
   vcs_cov_assert_hier:  ""
+  vcs_cov_excl_files:   []
 
   build_modes: [
     {

--- a/hw/ip/uart/dv/uart_sim_cfg.hjson
+++ b/hw/ip/uart/dv/uart_sim_cfg.hjson
@@ -36,6 +36,9 @@
   uvm_test: uart_base_test
   uvm_test_seq: uart_base_vseq
 
+  // Add UART specific exclusion files.
+  vcs_cov_excl_files: ["{proj_root}/hw/ip/uart/dv/cov/uart_cov_excl.el"]
+
   // List of test specifications.
   tests: [
     {

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -94,7 +94,6 @@ class SimCfg(FlowCfg):
         self.flist_file = ""
         self.run_cmd = ""
         self.dump_file = ""
-        self.exports = []
 
         # Generated data structures
         self.links = {}
@@ -111,6 +110,9 @@ class SimCfg(FlowCfg):
         # If build_unique is set, then add current timestamp to uniquify it
         if self.build_unique:
             self.build_dir += "_" + self.timestamp
+
+        # Process overrides before substituting the wildcards.
+        self._process_overrides()
 
         # Make substitutions, while ignoring the following wildcards
         # TODO: Find a way to set these in sim cfg instead


### PR DESCRIPTION
- You can now specify overrides for default sim key values using the
overrides keyword.
- Example:
```hjson

  // In 'common' cfg, specify a default attribute
  foo: bar

  // In DUT specific cfg, provide an override for it
  overrides: [
    {
      name: foo
      value: baz
    }
  ]
```

- This us useful to set a project-default attribute and use overrides if
an IP needs a custom version of it.
- This is needed to setup the hjson cfg for the chip level where the
coverage collection model is different.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>