### PR TITLE
Fix busy_sleep_micros and ibex_busy_loop

### DIFF
--- a/sw/device/examples/hello_usbdev/hello_usbdev.c
+++ b/sw/device/examples/hello_usbdev/hello_usbdev.c
@@ -36,9 +36,9 @@ static usb_ss_ctx_t ss_ctx[2];
 static void test_error(void) {
   while (1) {
     gpio_write_all(0xAA00);  // pattern
-    busy_sleep_micros(200 * 1000);
+    usleep(200 * 1000);
     gpio_write_all(0x5500);  // pattern
-    busy_sleep_micros(100 * 1000);
+    usleep(100 * 1000);
   }
 }
 
@@ -79,7 +79,7 @@ int main(int argc, char **argv) {
 
   // Give a LED pattern as startup indicator for 5 seconds
   gpio_write_all(0xAA00);  // pattern
-  busy_sleep_micros(1000);
+  usleep(1000);
   gpio_write_all(0x5500);  // pattern
   // usbdev_init here so dpi code will not start until simulation
   // got through all the printing (which takes a while if --trace)

--- a/sw/device/examples/hello_world/hello_world.c
+++ b/sw/device/examples/hello_world/hello_world.c
@@ -19,9 +19,9 @@ void trap_handler(uint32_t mepc, char c) {
   uart_send_uint(mepc, 32);
   while (1) {
     gpio_write_all(0xAA00);  // pattern
-    busy_sleep_micros(200 * 1000);
+    usleep(200 * 1000);
     gpio_write_all(0x5500);  // pattern
-    busy_sleep_micros(100 * 1000);
+    usleep(100 * 1000);
   }
 }
 
@@ -45,7 +45,7 @@ int main(int argc, char **argv) {
   // Give a LED pattern as startup indicator for 5 seconds
   gpio_write_all(0xFF00);  // all LEDs on
   for (int i = 0; i < 32; i++) {
-    busy_sleep_micros(100 * 1000);  // 100 ms
+    usleep(100 * 1000);  // 100 ms
 
     gpio_write_bit(8 + (i % 8), (i / 8));
   }
@@ -66,7 +66,7 @@ int main(int argc, char **argv) {
   spid_send("SPI!", 4);
 
   while (1) {
-    busy_sleep_micros(10 * 1000);  // 10 ms
+    usleep(10 * 1000);  // 10 ms
 
     // report changed switches over UART
     gpio_in = gpio_read() & 0x100FF;  // 0-7 is switch input, 16 is FTDI

--- a/sw/device/lib/runtime/hart.c
+++ b/sw/device/lib/runtime/hart.c
@@ -10,9 +10,11 @@
 
 extern void wait_for_interrupt(void);
 
-void busy_sleep_micros(size_t microseconds) {
-  size_t cycles = kIbexClockFreqHz * microseconds / 10000000;
-  ibex_busy_loop(cycles);
+void usleep(uint32_t usec) {
+  uint64_t cycles = (uint64_t)kIbexClockFreqHz * usec / 1000000;
+  uint64_t start = ibex_mcycle_read();
+  while ((ibex_mcycle_read() - start) < cycles) {
+  }
 }
 
 noreturn void abort(void) {

--- a/sw/device/lib/runtime/hart.h
+++ b/sw/device/lib/runtime/hart.h
@@ -24,11 +24,11 @@
 inline void wait_for_interrupt(void) { asm volatile("wfi"); }
 
 /**
- * Spin for roughly the given number of microseconds.
+ * Spin for at least the given number of microseconds.
  *
- * @param microseconds the duration for which to spin.
+ * @param usec Duration in microseconds.
  */
-void busy_sleep_micros(size_t microseconds);
+void usleep(uint32_t usec);
 
 /**
  * Immediately halt program execution.

--- a/sw/device/lib/runtime/ibex.c
+++ b/sw/device/lib/runtime/ibex.c
@@ -10,4 +10,4 @@ const size_t kIbexClockFreqHz = 500 * 1000;  // 500 kHz
 const size_t kIbexClockFreqHz = 50 * 1000 * 1000;  // 50 MHz
 #endif
 
-extern void ibex_busy_loop(size_t);
+extern uint64_t ibex_mcycle_read();

--- a/sw/device/tests/flash_ctrl/flash_test.c
+++ b/sw/device/tests/flash_ctrl/flash_test.c
@@ -14,7 +14,7 @@ static void break_on_error(uint32_t error) {
     // inifinitely fetch instructions, will flag an assertion error
     uart_send_str("FAIL!\r\n");
     while (1) {
-      busy_sleep_micros(100);
+      usleep(100);
     }
   }
 }


### PR DESCRIPTION
While I was rebasing my changes for the GPIO DIF, I noticed that
bouncing LEDs part of `hello_world.c` did not work correctly. This
change fixes the following:

- `busy_sleep_micros(size_t)`:
  - Modified to use a `uint64_t` to store the number of cycles instead
of `uint32_t`.
  - Renamed to `usleep(uint32_t)`.
- `ibex_busy_loop(size_t)`
  - Added code to make sure that `cycles` is a multiple of 8.
  - Modified to expect a `uint64_t` instead of a `uint32_t`.
  - Modified inline assembly to work with a `uint64_t` (split into two
`uint32_t`s). Since this is my first time writing inline asm in this
project, I would appreciate if you could review this part more closely.

See also: #1227, #1207.

Note: I reverted my earlier change that moves division before
multiplication in `udelay(uint32_t)` because `kIbexClockFreqHz` is
defined as 50 kHZ for simulations in `ibex.c`.

Signed-off-by: Alphan Ulusoy <alphan@google.com>