### PR TITLE
[dv regr tool] Added V milestones as regr targets

### DIFF
--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -203,6 +203,13 @@ class SimCfg(FlowCfg):
         tests = Tests.create_tests(getattr(self, "tests"), self)
         setattr(self, "tests", tests)
 
+        # Regressions
+        # Parse testplan if provided.
+        if self.testplan != "":
+            self.testplan = testplan_utils.parse_testplan(self.testplan)
+            # Extract tests in each milestone and add them as regression target.
+            self.regressions.extend(self.testplan.get_milestone_regressions())
+
         # Create regressions
         regressions = Regressions.create_regressions(
             getattr(self, "regressions"), self, tests)
@@ -390,8 +397,8 @@ class SimCfg(FlowCfg):
         results_str = "# " + self.name.upper() + " Regression Results\n"
         results_str += "  Run on " + self.timestamp_long + "\n"
         results_str += "\n## Test Results\n"
-        testplan = testplan_utils.parse_testplan(self.testplan)
-        results_str += testplan.results_table(
+        # TODO: check if testplan is not null?
+        results_str += self.testplan.results_table(
             regr_results=gen_results_sub(self.deploy, []),
             map_full_testplan=self.map_full_testplan)
 

--- a/util/testplanner/class_defs.py
+++ b/util/testplanner/class_defs.py
@@ -257,6 +257,28 @@ class Testplan():
         for entry in self.entries:
             entry.display()
 
+    def get_milestone_regressions(self):
+        regressions = {}
+        for entry in self.entries:
+            # Skip if milestone is "n.a."
+            if entry.milestone not in entry.milestones[1:]: continue
+            # if ms key doesnt exist, create one
+            if entry.milestone not in regressions.keys():
+                regressions[entry.milestone] = []
+            # Append new tests to the list
+            for test in entry.tests:
+                if test not in regressions[entry.milestone]:
+                    regressions[entry.milestone].append(test)
+
+        # Build regressions dict into a hjson like data structure
+        output = []
+        for ms in regressions.keys():
+            ms_dict = {}
+            ms_dict["name"] = ms
+            ms_dict["tests"] = regressions[ms]
+            output.append(ms_dict)
+        return output
+
     def results_table(self,
                       regr_results,
                       map_full_testplan=True,


### PR DESCRIPTION
- This update enables specifying V1, V2 or V3 as a regression target
(run tests tagged for a particular V ms in one shot)

Signed-off-by: Srikrishna Iyer <sriyer@google.com>