### PR TITLE
[aes dv] Enabled AES DV with dvsim regr tool

### DIFF
--- a/hw/dv/data/vcs/vcs.hjson
+++ b/hw/dv/data/vcs/vcs.hjson
@@ -3,15 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   build_cmd:  "{job_prefix} vcs"
-  build_ex:   "simv"
-  run_cmd:    "{job_prefix} {build_dir}/{build_ex}"
+  build_ex:   "{build_dir}/simv"
+  run_cmd:    "{job_prefix} {build_ex}"
 
   tcl:        "{proj_root}/hw/dv/tools/vcs/vcs_fsdb.tcl"
 
   build_opts: ["-sverilog -full64 -licqueue -kdb -ntb_opts uvm-1.2",
                "-timescale=1ns/1ps",
-               "-Mdir={build_dir}/simv.csrc",
-               "-o {run_cmd}",
+               "-Mdir={build_ex}.csrc",
+               "-o {build_ex}",
                "-f {sv_flist}",
                "+incdir+{build_dir}",
                // Turn on warnings for non-void functions called with return values ignored

--- a/hw/dv/data/xcelium/xcelium.hjson
+++ b/hw/dv/data/xcelium/xcelium.hjson
@@ -2,13 +2,12 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  build_cmd:  "{job_prefix} xrun -elaborate"
-  build_ex:   "xrun"
-  run_cmd:    "{job_prefix} {build_ex}"
+  build_cmd:  "{job_prefix} xrun"
+  run_cmd:    "{job_prefix} xrun"
 
   tcl:        "{proj_root}/hw/dv/tools/xcelium/xcelium_{dump}.tcl"
 
-  build_opts: ["-64bit -access +r -sv",
+  build_opts: [" -elaborate -64bit -access +r -sv",
                "-messages -errormax 50",
                "-timescale 1ns/1ps",
                "-f {sv_flist}",

--- a/hw/ip/aes/dv/Makefile
+++ b/hw/ip/aes/dv/Makefile
@@ -38,15 +38,15 @@ BUILD_OPTS += -lcrypto
 # common tests/seqs
 include ${DV_DIR}/../../../dv/tools/common_tests.mk
 
-TEST_NAME       ?= aes_wakeup_test
+TEST_NAME       ?= aes_wakeup
 UVM_TEST        ?= aes_base_test
 UVM_TEST_SEQ    ?= aes_wake_up_vseq
 
-ifeq (${TEST_NAME},aes_wakeup_test)
+ifeq (${TEST_NAME},aes_wakeup)
   UVM_TEST_SEQ   = aes_wake_up_vseq
 endif
 
-ifeq (${TEST_NAME},aes_sanity_test)
+ifeq (${TEST_NAME},aes_sanity)
   UVM_TEST_SEQ   = aes_sanity_vseq
 endif
 

--- a/hw/ip/aes/dv/aes_sim_cfg.hjson
+++ b/hw/ip/aes/dv/aes_sim_cfg.hjson
@@ -23,11 +23,14 @@
   // Import additional common sim cfg files.
   import_cfgs: [// Project wide common sim cfg file
                 "{proj_root}/hw/dv/data/common_sim_cfg.hjson",
+                // Enable C compilation of AES model for DPI-C
+                "{proj_root}/hw/ip/aes/model/aes_model_sim_opts.hjson",
                 // Common CIP test lists
                 "{proj_root}/hw/dv/data/tests/csr_tests.hjson",
                 "{proj_root}/hw/dv/data/tests/intr_test.hjson",
-                "{proj_root}/hw/dv/data/tests/tl_access_tests.hjson",
-                "{proj_root}/hw/dv/data/tests/stress_tests.hjson"]
+                "{proj_root}/hw/dv/data/tests/tl_access_tests.hjson"]
+                // TODO: enable stress tests later.
+                // "{proj_root}/hw/dv/data/tests/stress_tests.hjson"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50
@@ -36,16 +39,29 @@
   uvm_test: aes_base_test
   uvm_test_seq: aes_wake_up_vseq
 
+  // Update the default build mode to add options specific to AES C model compilation.
+  build_modes: [
+    {
+      name: default
+      en_build_modes: ["{simulator}_aes_model_build_opts"]
+    }
+  ]
+
   // List of test specifications.
   tests: [
     {
-      name: aes_wakeup_test
+      name: aes_wakeup
       uvm_test_seq: aes_wake_up_vseq
     }
 
     {
       name: aes_sanity
       uvm_test_seq: aes_sanity_vseq
+    }
+
+    {
+      // TODO: Need to add test below to get it to map to the testplan entry.
+      name: aes_stress
     }
   ]
 }

--- a/hw/ip/aes/model/aes_model_sim_opts.hjson
+++ b/hw/ip/aes/model/aes_model_sim_opts.hjson
@@ -1,0 +1,18 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  // Additional build-time options for enabling the compilation of the C sources
+  // with DV simulators such as VCS and Xcelium.
+  build_modes: [
+    {
+      name: vcs_aes_model_build_opts
+      build_opts: ["-CFLAGS -I{proj_root}/hw/ip/aes/model", "-lcrypto"]
+    }
+
+    {
+      name: xcelium_aes_model_build_opts
+      build_opts: ["-I{proj_root}/hw/ip/aes/model", "-lcrypto"]
+    }
+  ]
+}

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -88,7 +88,6 @@ class SimCfg(FlowCfg):
 
         # Options from simulators - for building and running tests
         self.build_cmd = ""
-        self.build_ex = ""
         self.flist_gen_cmd = ""
         self.flist_gen_opts = []
         self.flist_file = ""


### PR DESCRIPTION
This PR enables AES model C compilation with VCS and Xcelium for DPI-C                            
- Fixed some key value pairs in hw/dv/data/vcs|xcelium/*.hjson 
- Fixed test names to match the testplan entries in the Makefile as well as sim_cfg hjson file
- Added hw/ip/aes/model/aes_model_sim_opts.hjson to capture DPI-C compilation specific build options that are required to be passed (this is independent hjson cfg file other other DV environments can simple include)


- aes_wakeup test results:

```console
---- With Xcelium:

$ ../../../../util/dvsim.py aes_sim_cfg.hjson  -i aes_wakeup --reseed 1 -s xcelium --purge
INFO: [SimCfg] Scratch path for aes: /edascratch/sriyer-opentitan/scratch/aes_fix.aes.sim.xcelium
INFO: [SimCfg] Purging scratch path /edascratch/sriyer-opentitan/scratch/aes_fix.aes.sim.xcelium
INFO: [Deploy] [dvsim]: build:
 [default]
INFO: [Deploy] [dvsim]: [000010s] [build]: [.]
INFO: [Deploy] [dvsim]: run:
 [0.aes_wakeup]
INFO: [Deploy] [dvsim]: [000018s] [build]: [P]
INFO: [Deploy] [dvsim]: [000020s] [run]: [.]
INFO: [Deploy] [dvsim]: [000022s] [run]: [P]
# AES Regression Results
  Run on Tuesday January 21 2020 04:37:38PM 

## Test Results
|  Milestone  |  Name   |      Tests |  Results  |
|:-----------:|:-------:|-----------:|:---------:|
|     V1      | wake_up | aes_wakeup |    2/2    |
|     V1      |         |      TOTAL |    2/2    |
|             |         |      TOTAL |    2/2    |


---- With VCS:

$ ../../../../util/dvsim.py aes_sim_cfg.hjson  -i aes_wakeup --reseed 1 --purge
INFO: [SimCfg] Scratch path for aes: /edascratch/sriyer-opentitan/scratch/aes_fix.aes.sim.vcs
INFO: [SimCfg] Purging scratch path /edascratch/sriyer-opentitan/scratch/aes_fix.aes.sim.vcs
INFO: [Deploy] [dvsim]: build:
 [default]
INFO: [Deploy] [dvsim]: [000010s] [build]: [.]
INFO: [Deploy] [dvsim]: [000020s] [build]: [.]
INFO: [Deploy] [dvsim]: [000030s] [build]: [.]
INFO: [Deploy] [dvsim]: run:
 [0.aes_wakeup]
INFO: [Deploy] [dvsim]: [000031s] [build]: [P]
INFO: [Deploy] [dvsim]: [000036s] [run]: [P]
# AES Regression Results
  Run on Tuesday January 21 2020 04:38:08PM 

## Test Results
|  Milestone  |  Name   |      Tests |  Results  |
|:-----------:|:-------:|-----------:|:---------:|
|     V1      | wake_up | aes_wakeup |    2/2    |
|     V1      |         |      TOTAL |    2/2    |
|             |         |      TOTAL |    2/2    |
```