### PR TITLE
[dv regr tool] Some fixes

### DIFF
--- a/hw/dv/data/vcs/vcs.hjson
+++ b/hw/dv/data/vcs/vcs.hjson
@@ -14,7 +14,6 @@
                "-o {run_cmd}",
                "-f {sv_flist}",
                "+incdir+{build_dir}",
-               "-debug_access+pp",
                // Turn on warnings for non-void functions called with return values ignored
                "+warn=SV-NFIVC",
                "+warn=noUII-L",

--- a/util/dvsim.py
+++ b/util/dvsim.py
@@ -352,7 +352,7 @@ def main():
         "-mp",
         "--max-parallel",
         type=int,
-        default=32,
+        default=16,
         metavar="N",
         help="""Run only upto a fixed number of builds/tests at a time.""")
 

--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -236,9 +236,14 @@ class Deploy():
         if self.status == '.':
             log.error("Method unexpectedly called!")
         else:
-            cmd = "mv " + self.sim_cfg.links['D'] + "/" + self.odir_ln + " " + \
-                  self.sim_cfg.links[self.status] + "/."
-            os.system(cmd)
+            old_link = self.sim_cfg.links['D'] + "/" + self.odir_ln
+            new_link = self.sim_cfg.links[self.status] + "/" + self.odir_ln
+            cmd = "ln -s " + self.odir + " " + new_link + "; "
+            cmd += "rm " + old_link
+            try:
+                os.system(cmd)
+            except Exception as e:
+                log.error("Cmd \"%s\" could not be run", cmd)
 
     def get_status(self):
         if self.status != ".": return

--- a/util/dvsim/Modes.py
+++ b/util/dvsim/Modes.py
@@ -532,7 +532,6 @@ class Regressions(Modes):
                         log.error(
                             "Test \"%s\" added to regression \"%s\" not found!",
                             test, regression_obj.name)
-                        sys.exit(1)
                     tests_objs.append(test_obj)
                 regression_obj.tests = tests_objs
 

--- a/util/testplanner/class_defs.py
+++ b/util/testplanner/class_defs.py
@@ -267,7 +267,7 @@ class Testplan():
                 regressions[entry.milestone] = []
             # Append new tests to the list
             for test in entry.tests:
-                if test not in regressions[entry.milestone]:
+                if test not in regressions[entry.milestone] and test != "":
                     regressions[entry.milestone].append(test)
 
         # Build regressions dict into a hjson like data structure


### PR DESCRIPTION
- Reduced max parallel from 32 to 16
- Changed the command to move the test result links from mv to ln (more
stable)
- Test not found in regressions does not cause script to exit (just
throws an error and runs whatever it could find)

Signed-off-by: Srikrishna Iyer <sriyer@google.com>