### PR TITLE
[dv_util/macro] added check for non empty mailbox macro in dv util

### DIFF
--- a/hw/dv/sv/dv_utils/dv_macros.svh
+++ b/hw/dv/sv/dv_utils/dv_macros.svh
@@ -250,6 +250,16 @@
   end
 `endif
 
+// check for non-empty mailbox and print items that were uncompared at end of test
+`ifndef DV_EOT_PRINT_MAILBOX_CONTENTS
+`define DV_EOT_PRINT_MAILBOX_CONTENTS(TYP_, MAILBOX_, SEV_=error, ID_=`gfn) \
+  while (MAILBOX_.num() != 0) begin \
+    TYP_ item; \
+    void'(MAILBOX_.try_get(item)); \
+    `uvm_``SEV_(ID_, $sformatf("%s item uncompared:\n%s", `"MAILBOX_`", item.sprint())) \
+  end
+`endif
+
 // get parity - implemented as a macro so that it can be invoked in constraints as well
 `ifndef GET_PARITY
   `define GET_PARITY(val, odd=0) (^val ^ odd)
@@ -276,4 +286,3 @@
     disable fork; \
   end join
 `endif
-

--- a/hw/ip/aes/dv/env/aes_scoreboard.sv
+++ b/hw/ip/aes/dv/env/aes_scoreboard.sv
@@ -24,7 +24,6 @@ class aes_scoreboard extends cip_base_scoreboard #(
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
-
     dut_fifo = new();
     ref_fifo = new();
     dut_item = new("dut_item");
@@ -240,10 +239,8 @@ class aes_scoreboard extends cip_base_scoreboard #(
 
   function void check_phase(uvm_phase phase);
     super.check_phase(phase);
-    if ((dut_fifo.num() !=0 ) || (ref_fifo.num() != 0)) begin
-      `uvm_error(`gfn, $sformatf("\n\t ----| NO NO NO there are still items in the fifos dut: %d, ref %d"
-                                 , dut_fifo.num(), ref_fifo.num()))
-    end
+    `DV_EOT_PRINT_MAILBOX_CONTENTS(aes_seq_item, dut_fifo)
+    `DV_EOT_PRINT_MAILBOX_CONTENTS(aes_seq_item, ref_fifo)
   endfunction
 
 


### PR DESCRIPTION
Hi all 
as per request from @sriyerg 
I have created a macro that checks if a mailbox is empty similar to the other TLM_fifo/queue checks.

I verified the functionality by inserting a temporary fifo in the aes scoreboard that and only adding items to it never taking them off again.
it works fine.

I removed my tmp fifo again and updated the aes_scoreboard to use this new macro.

