### PR TITLE
[prim_fifo_sync] Fix DC synth issue related to unpacked array

### DIFF
--- a/hw/ip/prim/rtl/prim_fifo_sync.sv
+++ b/hw/ip/prim/rtl/prim_fifo_sync.sv
@@ -110,7 +110,7 @@ module prim_fifo_sync #(
 
     // the generate blocks below are needed to avoid lint errors due to array indexing
     // in the where the fifo only has one storage element
-    logic [Width-1:0] storage [Depth];
+    logic [Depth-1:0][Width-1:0] storage;
     logic [Width-1:0] storage_rdata;
     if (Depth == 1) begin : gen_depth_eq1
       assign storage_rdata = storage[0];


### PR DESCRIPTION
The unpacked array causes problems if `Depth` is set to zero in DC. I.e., DC throws a warning about reversed ranges even if this statement is in the inactive generate block region. This change fixes this behavior.

Signed-off-by: Michael Schaffner <msf@opentitan.org>