### PR TITLE
[aes/dv/makefile] I have updated the aes/dv/Makefile

### DIFF
--- a/hw/ip/aes/dv/Makefile
+++ b/hw/ip/aes/dv/Makefile
@@ -23,10 +23,10 @@ UVM_TEST        ?= aes_base_test
 UVM_TEST_SEQ    ?= aes_base_vseq
 
 # Make GCC find aes.h
-ifeq (${SIMULATOR},vcs)
-  BUILD_OPTS += -CFLAGS "-I${DV_DIR}/../model"
-else ifeq (${SIMULATOR},xcelium)
+ifeq (${SIMULATOR},xcelium)
   BUILD_OPTS += -I${DV_DIR}/../model
+else
+  BUILD_OPTS += -CFLAGS "-I${DV_DIR}/../model"
 endif
 
 # Make GCC link OpenSSL/BoringSSL


### PR DESCRIPTION
I have changed the Makefile for aes/dv so VCS is selected as default simulator.
the previous code required you to either specify simulator as environment variable or on commands line.
this should go away with the new build system. but for now this is the cleanest implementation

Signed-off-by: Rasmus Madsen <rasmus.madsen@wdc.com>