### PR TITLE
[dv regr tool] Publish results to OT web server

### DIFF
--- a/hw/dv/data/common_sim_cfg.hjson
+++ b/hw/dv/data/common_sim_cfg.hjson
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   project:          opentitan
+  results_server:   "gs://reports.opentitan.org"
+
   flow:             sim
   flow_makefile:    "{proj_root}/hw/dv/data/sim.mk"
 
@@ -20,10 +22,10 @@
 
   // pass and fail patterns
   pass_patterns:    ["^TEST PASSED (UVM_)?CHECKS$"]
-  fail_patterns:    ["^TEST FAILED (UVM_)?CHECKS$",
-                     "^UVM_ERROR\\s[^:].*$",
+  fail_patterns:    ["^UVM_ERROR\\s[^:].*$",
                      "^Assert failed: ",
-                     "^\\s*Offending '.*'"]
+                     "^\\s*Offending '.*'",
+                     "^TEST FAILED (UVM_)?CHECKS$"]
 
   // Default TileLink widths
   tl_aw: 32

--- a/hw/ip/aes/data/aes_testplan.hjson
+++ b/hw/ip/aes/data/aes_testplan.hjson
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   name: "aes"
-  import_testplans: ["hw/dv/tools/testplans/csr_testplan.hjson",                         
+  import_testplans: ["hw/dv/tools/testplans/csr_testplan.hjson",
                      "hw/dv/tools/testplans/tl_device_access_types_testplan.hjson"]
   entries: [
    // {
@@ -47,8 +47,8 @@
       desc: '''
             - Tests what happens if a register is written a the wrong time?,
               if a key does not match the key setting etc. will module ignore or fail gracefully
-            - enter a 256bit key but set AES to use 128 for encryption. 
-              then enter the 128bit of the key and use for decryption. 
+            - enter a 256bit key but set AES to use 128 for encryption.
+              then enter the 128bit of the key and use for decryption.
               will result match plain text and vice verca'''
       milestone: V2
       tests: ["aes_stress"]
@@ -66,6 +66,6 @@
             Make sure that there is no residual data from latest operation '''
       milestone: V2
       tests: ["aes_stress"]
-    }    
+    }
   ]
 }

--- a/util/dvsim.py
+++ b/util/dvsim.py
@@ -341,6 +341,12 @@ def main():
     )
 
     parser.add_argument(
+        "--publish",
+        default=False,
+        action='store_true',
+        help="Publish results to the reports.opentitan.org web server.")
+
+    parser.add_argument(
         "-pi",
         "--print-interval",
         type=int,
@@ -374,6 +380,9 @@ def main():
     if not os.path.exists(args.cfg):
         log.fatal("Simulation config file %s appears to be invalid.", args.cfg)
         sys.exit(1)
+
+    # If publishing results, then force full testplan mapping of results.
+    if args.publish: args.map_full_testplan = True
 
     args.scratch_root = resolve_scratch_root(args.scratch_root)
     args.branch = resolve_branch(args.branch)
@@ -422,6 +431,9 @@ def main():
 
     # Generate results.
     results = cfg.gen_results()
+
+    # Publish results
+    if args.publish: cfg.publish_results()
 
 
 if __name__ == '__main__':

--- a/util/dvsim/FlowCfg.py
+++ b/util/dvsim/FlowCfg.py
@@ -6,8 +6,10 @@ r"""
 Class describing a flow configuration object
 """
 
+import datetime
 import logging as log
 import pprint
+from shutil import which
 
 from .utils import *
 
@@ -22,10 +24,16 @@ class FlowCfg():
 
     def __init__(self, flow_cfg_file, proj_root, args):
         # Options set from command line
+        self.items = []
+        self.items.extend(args.items)
+        self.list_items = []
+        self.list_items.extend(args.list)
         self.flow_cfg_file = flow_cfg_file
         self.proj_root = proj_root
         self.args = args
         self.scratch_root = args.scratch_root
+        self.branch = args.branch
+        self.job_prefix = args.job_prefix
 
         # Imported cfg files using 'import_cfgs' keyword
         self.imported_cfg_files = []
@@ -45,6 +53,10 @@ class FlowCfg():
         # Add a notion of "master" cfg - this is indicated using
         # a special key 'use_cfgs' within the hjson cfg.
         self.is_master_cfg = False
+
+        # Set the partial path to the IP's DV area.
+        self.rel_path = os.path.dirname(flow_cfg_file).replace(
+            self.proj_root + '/', '')
 
         # Timestamp
         self.ts_format_long = args.ts_format_long
@@ -289,10 +301,13 @@ class FlowCfg():
     def create_deploy_objects(self):
         '''Public facing API for _create_deploy_objects().
         '''
-        self.deploy = []
-        for item in self.cfgs:
-            item._create_deploy_objects()
-            self.deploy.extend(item.deploy)
+        if self.is_master_cfg:
+            self.deploy = []
+            for item in self.cfgs:
+                item._create_deploy_objects()
+                self.deploy.extend(item.deploy)
+        else:
+            self._create_deploy_objects()
 
     def _gen_results(self, fmt="md"):
         '''
@@ -303,12 +318,145 @@ class FlowCfg():
         '''
         return
 
-    def gen_results(self, fmt="md"):
+    def gen_results(self):
         '''Public facing API for _gen_results().
         '''
         results = []
         for item in self.cfgs:
-            result = item._gen_results(fmt)
+            result = item._gen_results()
             print(result)
             results.append(result)
         return results
+
+    def _publish_results(self):
+        '''Publish results to the opentitan web server.
+        Results are uploaded to {results_server}/{rel_path}/latest/results.
+        If the 'latest' directory exists, then it is renamed to its 'timestamp' directory.
+        If the list of directories in this area is > 7, then the oldest entry is removed.
+        {results_server}/{rel_path}/history.md contains links to the last 7 results.
+        '''
+        if which('gsutil') is None or which('gcloud') is None:
+            log.error(
+                "Google cloud SDK not installed! Cannot access the results server"
+            )
+            return
+
+        # Construct the paths
+        results_root_dir = self.results_server + '/' + self.rel_path
+        results_dir = results_root_dir + '/latest'
+        results_page = results_dir + '/results.md'
+
+        # Timeformat for moving the dir
+        tf = "%Y.%m.%d_%H.%M.%S"
+
+        # Extract the timestamp of the existing results_page
+        cmd = "gsutil ls -L " + results_page + " | " + "grep \'Creation time:\'"
+        cmd_output = subprocess.run(cmd,
+                                    shell=True,
+                                    stdout=subprocess.PIPE,
+                                    stderr=subprocess.DEVNULL)
+        old_results_ts = cmd_output.stdout.decode("utf-8")
+        old_results_ts = old_results_ts.replace("Creation time:", "")
+        old_results_ts = old_results_ts.strip()
+
+        # Move the 'latest' to its timestamp directory if lookup succeeded
+        if cmd_output.returncode == 0:
+            try:
+                if old_results_ts != "":
+                    ts = datetime.datetime.strptime(
+                        old_results_ts, "%a, %d %b %Y %H:%M:%S %Z")
+                    old_results_ts = ts.strftime(tf)
+            except ValueError as e:
+                log.error(
+                    "%s: \'%s\' Timestamp conversion value error raised!", e)
+                old_results_ts = ""
+
+            # If the timestamp conversion failed - then create a dummy one with
+            # yesterday's date.
+            if old_results_ts == "":
+                log.log(VERBOSE,
+                        "Creating dummy timestamp with yesterday's date")
+                ts = datetime.datetime.now(
+                    datetime.timezone.utc) - datetime.timedelta(days=1)
+                old_results_ts = ts.strftime(tf)
+
+            old_results_dir = results_root_dir + "/" + old_results_ts
+            cmd = ["gsutil", "mv", results_dir, old_results_dir]
+            cmd_output = subprocess.run(cmd,
+                                        stdout=subprocess.PIPE,
+                                        stderr=subprocess.DEVNULL)
+            if cmd_output.returncode != 0:
+                log.error("Failed to mv old results page \"%s\" to \"%s\"!",
+                          results_dir, old_results_dir)
+
+        # Do an ls in the results root dir to check what directories exist.
+        results_dirs = []
+        cmd = ["gsutil", "ls", results_root_dir]
+        cmd_output = subprocess.run(args=cmd,
+                                    stdout=subprocess.PIPE,
+                                    stderr=subprocess.DEVNULL)
+        if cmd_output.returncode == 0:
+            # Some directories exist. Check if 'latest' is one of them
+            results_dirs = cmd_output.stdout.decode("utf-8").strip()
+            results_dirs = results_dirs.split("\n")
+        else:
+            log.log(VERBOSE, "Failed to run \"%s\"!", cmd)
+
+        # Start pruning
+        log.log(VERBOSE, "Pruning %s area to limit last 7 results",
+                results_root_dir)
+
+        rdirs = []
+        for rdir in results_dirs:
+            dirname = rdir.replace(results_root_dir, '')
+            dirname = dirname.replace('/', '')
+            if dirname in ['latest', 'history.md']: continue
+            rdirs.append(dirname)
+        rdirs.sort(reverse=True)
+
+        rm_cmd = ""
+        history_txt = " History\n\n"
+        history_txt += "- [Latest](" + results_page + ")\n"
+        if len(rdirs) > 0:
+            for i in range(len(rdirs)):
+                if i < 6:
+                    rdir_url = results_root_dir + '/' + rdirs[i] + "/results.md"
+                    history_txt += "- [{}]({})\n".format(rdirs[i], rdir_url)
+                else:
+                    rm_cmd += results_root_dir + '/' + rdirs[i] + " "
+
+        if rm_cmd != "":
+            rm_cmd = "gsutil rm -r " + rm_cmd + "; "
+
+        # Publish the updated history page.
+        history_txt = history_txt.replace("gs://", "http://")
+        history_file = self.scratch_path + "/history_" + self.timestamp + ".md"
+        history_page = results_root_dir + "/history.md"
+
+        f = open(history_file, 'w')
+        f.write(history_txt)
+        f.close()
+
+        # Construct history cp cmd
+        history_cp_cmd = "gsutil cp " + history_file + " " + history_page + \
+                          "; rm -rf " + history_file + "; "
+
+        # Copy over the latest regression result.
+        log.info("Publishing results to %s",
+                 results_page.replace("gs://", "http://"))
+        cmd = history_cp_cmd + rm_cmd + \
+              "gsutil cp "  + self.results_file + " " + results_page
+
+        try:
+            cmd_output = subprocess.run(args=cmd,
+                                        shell=True,
+                                        stdout=subprocess.PIPE,
+                                        stderr=subprocess.DEVNULL)
+        except Exception as e:
+            log.error("%s: Failed to publish results:\n\"%s\"", e, str(cmd))
+
+    def publish_results(self):
+        '''Public facing API for publishing results to the opentitan web server.
+        '''
+        for item in self.cfgs:
+            item._publish_results()

--- a/util/testplanner/class_defs.py
+++ b/util/testplanner/class_defs.py
@@ -279,10 +279,7 @@ class Testplan():
             output.append(ms_dict)
         return output
 
-    def results_table(self,
-                      regr_results,
-                      map_full_testplan=True,
-                      tablefmt="pipe"):
+    def results_table(self, regr_results, map_full_testplan=True):
         '''Print the mapped regression results into a table.
         '''
         self.map_regr_results(regr_results, map_full_testplan)
@@ -301,5 +298,5 @@ class Testplan():
                 entry_name = ""
         return tabulate(table,
                         headers="firstrow",
-                        tablefmt=tablefmt,
+                        tablefmt="pipe",
                         colalign=align)


### PR DESCRIPTION
- Added `--publish` switch to upload regression results to
  `reports.opentitan.org`
- Src tree hierarchy is replicated in the reports server
  - Latest results always gets uploaded to reports.opentitan.org/hw/ip/<ip>/dv/latest/results.md
- A history of 7 previous results are maintained
  - History can be looked up at reports.opentitan.org/hw/ip/<ip>/dv/history.md
  - report directories older than 7 most recent are deleted
  - if 'latest' directory exists, then it is renamed to its timestamp
- All results are in MD format - #1411 tracks their inline conversion to
html

Remaining work items:
- Enabling end to end coverage collection (run final URG html based reports generation after regression is over)
- Upload coverage reports to the web server as well

Signed-off-by: Srikrishna Iyer <sriyer@google.com>