### PR TITLE
[aes] Correct reset value and meaning of IDLE bit in status register

### DIFF
--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -174,8 +174,9 @@
     fields: [
       { bits: "0",
         name: "IDLE",
+        resval: "1",
         desc:  '''
-          The AES unit is idle (0) or busy (1).
+          The AES unit is idle (1) or busy (0).
         '''
       }
       { bits: "1",

--- a/hw/ip/aes/rtl/aes_reg_top.sv
+++ b/hw/ip/aes/rtl/aes_reg_top.sv
@@ -603,7 +603,7 @@ module aes_reg_top (
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RO"),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h1)
   ) u_status_idle (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),


### PR DESCRIPTION
This PR ensures the IDLE bit is set to 1 if the unit is idle (reset value), or 0 if the unit is busy.

This resolves lowRISC/OpenTitan#1407.