### PR TITLE
[dif, uart] Add IRQ state clear routine

### DIFF
--- a/sw/device/lib/dif/dif_uart.c
+++ b/sw/device/lib/dif/dif_uart.c
@@ -319,6 +319,20 @@ bool dif_uart_irq_state_get(const dif_uart_t *uart,
   return true;
 }
 
+bool dif_uart_irq_state_clear(const dif_uart_t *uart,
+                              dif_uart_interrupt_t irq_type) {
+  if (uart == NULL) {
+    return false;
+  }
+
+  // Writing to the register clears the corresponding bits
+  ptrdiff_t offset = uart_irq_offset_get(irq_type);
+  mmio_region_nonatomic_set_bit32(uart->base_addr, UART_INTR_STATE_REG_OFFSET,
+                                  offset);
+
+  return true;
+}
+
 bool dif_uart_irqs_disable(const dif_uart_t *uart, uint32_t *state) {
   if (uart == NULL) {
     return false;

--- a/sw/device/lib/dif/dif_uart.h
+++ b/sw/device/lib/dif/dif_uart.h
@@ -207,6 +207,18 @@ bool dif_uart_byte_receive_polled(const dif_uart_t *uart, uint8_t *byte);
 bool dif_uart_irq_state_get(const dif_uart_t *uart,
                             dif_uart_interrupt_t irq_type,
                             dif_uart_enable_t *state);
+/**
+ * UART clear requested IRQ state
+ *
+ * Clear the state of the requested IRQ in @p arg2. Primary use of this
+ * function is to de-assert the interrupt after it has been serviced.
+ *
+ * @param uart UART state data
+ * @param irq_type IRQ to be de-asserted
+ * @return true if the function was successful, false otherwise
+ */
+bool dif_uart_irq_state_clear(const dif_uart_t *uart,
+                              dif_uart_interrupt_t irq_type);
 
 /**
  * UART disable interrupts


### PR DESCRIPTION
When an interrupt has occured, the ISR must clear the Interrupt State
bit for the corresponding interrupt. Othwerwise when the ISR returns,
the interrupt will be re-asserted.

This routine allows to clear the Interrupt State.

Signed-off-by: Silvestrs Timofejevs <silvestrst@lowrisc.org>