### PR TITLE
[dv] fusesoc with export + Chip sims with dvsim

### DIFF
--- a/hw/dv/data/common_sim_cfg.hjson
+++ b/hw/dv/data/common_sim_cfg.hjson
@@ -42,10 +42,12 @@
   // Default waves dump settings
   dump_file:  waves.{dump}
 
+  // Top level simulation entities.
+  sim_tops: ["-top {tb}"]
+
   // Default build and run opts
   build_opts: [// List multiple tops for the simulation
-               "-top {tb}",
-               "-top {dut}_bind",
+               "{sim_tops}",
                // Standard UVM defines
                "+define+UVM_NO_DEPRECATED",
                "+define+UVM_REGEX_NO_DPI",

--- a/hw/dv/data/fusesoc.hjson
+++ b/hw/dv/data/fusesoc.hjson
@@ -6,7 +6,7 @@
   fusesoc_core_:      "{eval_cmd} echo \"{fusesoc_core}\" | tr ':' '_'"
   sv_flist_gen_opts:  ["--cores-root {proj_root} --cores-root {gen_ral_pkg_dir}",
                        "run --target=sim --build-root={build_dir}",
-                       "--setup --no-export {fusesoc_core}"]
+                       "--setup {fusesoc_core}"]
   sv_flist_gen_dir:   "{build_dir}/sim-vcs"
   sv_flist:           "{sv_flist_gen_dir}/{fusesoc_core_}.scr"
 }

--- a/hw/dv/data/gen_ral_pkg.hjson
+++ b/hw/dv/data/gen_ral_pkg.hjson
@@ -5,5 +5,5 @@
   gen_ral_pkg:      "{name}"
   gen_ral_pkg_dir:  "{build_dir}/gen_ral_pkg"
   gen_ral_pkg_cmd:  "{proj_root}/hw/dv/tools/gen_ral_pkg.py"
-  gen_ral_pkg_opts: "{gen_ral_pkg} {ral_spec} -o {gen_ral_pkg_dir}"
+  gen_ral_pkg_opts: ["{gen_ral_pkg} {ral_spec} -o {gen_ral_pkg_dir}"]
 }

--- a/hw/dv/data/tests/csr_tests.hjson
+++ b/hw/dv/data/tests/csr_tests.hjson
@@ -4,7 +4,6 @@
       name: csr_tests_mode
       uvm_test_seq: "{name}_common_vseq"
       run_opts: ["+en_scb=0"]
-      reseed: 20
     }
   ]
 

--- a/hw/dv/data/tests/mem_tests.hjson
+++ b/hw/dv/data/tests/mem_tests.hjson
@@ -1,10 +1,16 @@
 {
+  run_modes: [
+    {
+      name: mem_tests_mode
+      uvm_test_seq: "{name}_common_vseq"
+      run_opts: ["+csr_mem_walk", "+en_scb=0"]
+    }
+  ]
+
   tests: [
     {
       name: "{name}_mem_walk"
-      uvm_test_seq: "{name}_common_vseq"
-      run_opts: ["+csr_mem_walk", "+en_scb=0"]
-      reseed: 20
+      en_run_modes: ["mem_tests_mode"]
     }
   ]
 

--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent.core
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent.core
@@ -21,6 +21,7 @@ filesets:
       - alert_receiver_driver.sv: {is_include_file: true}
       - alert_sender_driver.sv: {is_include_file: true}
       - esc_receiver_driver.sv: {is_include_file: true}
+      - esc_sender_driver.sv: {is_include_file: true}
       - alert_esc_base_monitor.sv: {is_include_file: true}
       - alert_monitor.sv: {is_include_file: true}
       - esc_monitor.sv: {is_include_file: true}

--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent_pkg.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent_pkg.sv
@@ -52,9 +52,12 @@ package alert_esc_agent_pkg;
   `include "alert_monitor.sv"
   `include "esc_monitor.sv"
   `include "alert_esc_agent.sv"
+
+  // Sequences
   `include "seq_lib/alert_receiver_alert_rsp_seq.sv"
   `include "seq_lib/alert_receiver_seq.sv"
   `include "seq_lib/alert_sender_ping_rsp_seq.sv"
   `include "seq_lib/alert_sender_seq.sv"
   `include "seq_lib/esc_receiver_esc_rsp_seq.sv"
+
 endpackage

--- a/hw/dv/sv/cip_lib/cip_lib.core
+++ b/hw/dv/sv/cip_lib/cip_lib.core
@@ -14,13 +14,13 @@ filesets:
     files:
       - cip_base_pkg.sv
       - cip_base_env_cfg.sv: {is_include_file: true}
-      - cip_base_env.sv: {is_include_file: true}
-      - cip_base_scoreboard.sv: {is_include_file: true}
-      - cip_base_test.sv: {is_include_file: true}
-      - cip_base_virtual_sequencer.sv: {is_include_file: true}
       - cip_base_env_cov.sv: {is_include_file: true}
+      - cip_base_virtual_sequencer.sv: {is_include_file: true}
+      - cip_base_scoreboard.sv: {is_include_file: true}
+      - cip_base_env.sv: {is_include_file: true}
       - cip_base_vseq.sv: {is_include_file: true}
       - cip_base_vseq__tl_errors.svh: {is_include_file: true}
+      - cip_base_test.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:

--- a/hw/dv/sv/dv_lib/dv_lib.core
+++ b/hw/dv/sv/dv_lib/dv_lib.core
@@ -13,9 +13,9 @@ filesets:
     files:
       - dv_lib_pkg.sv
 
-      - dv_base_reg.sv: {is_include_file: true}
       - dv_base_reg_field.sv: {is_include_file: true}
-      - dv_base_reg_mem.sv: {is_include_file: true}
+      - dv_base_reg.sv: {is_include_file: true}
+      - dv_base_mem.sv: {is_include_file: true}
       - dv_base_reg_block.sv: {is_include_file: true}
       - dv_base_reg_map.sv: {is_include_file: true}
 
@@ -25,6 +25,7 @@ filesets:
       - dv_base_sequencer.sv: {is_include_file: true}
       - dv_base_driver.sv: {is_include_file: true}
       - dv_base_agent.sv: {is_include_file: true}
+      - dv_base_seq.sv: {is_include_file: true}
 
       - dv_base_env_cfg.sv: {is_include_file: true}
       - dv_base_env_cov.sv: {is_include_file: true}

--- a/hw/dv/sv/script/vcs.compile.option.f
+++ b/hw/dv/sv/script/vcs.compile.option.f
@@ -1,6 +1,0 @@
--sverilog
--ntb_opts uvm-1.2
--lca
-+define+UVM_REGEX_NO_DPI
--timescale=1ns/10ps
--licqueue

--- a/hw/dv/sv/spi_agent/spi_agent.core
+++ b/hw/dv/sv/spi_agent/spi_agent.core
@@ -12,14 +12,18 @@ filesets:
     files:
       - spi_if.sv
       - spi_agent_pkg.sv
+      - spi_item.sv: {is_include_file: true}
       - spi_agent_cfg.sv: {is_include_file: true}
       - spi_agent_cov.sv: {is_include_file: true}
-      - spi_item.sv: {is_include_file: true}
       - spi_driver.sv: {is_include_file: true}
+      - spi_host_driver.sv: {is_include_file: true}
+      - spi_device_driver.sv: {is_include_file: true}
       - spi_monitor.sv: {is_include_file: true}
       - spi_sequencer.sv: {is_include_file: true}
       - spi_agent.sv: {is_include_file: true}
       - seq_lib/spi_seq_list.sv: {is_include_file: true}
+      - seq_lib/spi_base_seq.sv: {is_include_file: true}
+      - seq_lib/spi_host_seq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:

--- a/hw/dv/sv/test_vectors/test_vectors.core
+++ b/hw/dv/sv/test_vectors/test_vectors.core
@@ -8,6 +8,9 @@ filesets:
   files_dv:
     files:
       - test_vectors_pkg.sv
+      - HMAC_RFC4868.rsp: {is_include_file: true}
+      - SHA256ShortMsg.rsp: {is_include_file: true}
+      - SHA256LongMsg.rsp: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:

--- a/hw/dv/sv/tl_agent/tl_agent.core
+++ b/hw/dv/sv/tl_agent/tl_agent.core
@@ -14,16 +14,16 @@ filesets:
     files:
       - tl_if.sv
       - tl_agent_pkg.sv
+      - tl_seq_item.sv: {is_include_file: true}
       - tl_agent_cfg.sv: {is_include_file: true}
-      - tl_agent.sv: {is_include_file: true}
       - tl_agent_cov.sv: {is_include_file: true}
       - tl_device_driver.sv: {is_include_file: true}
       - tl_host_driver.sv: {is_include_file: true}
-      - tl_monitor.sv: {is_include_file: true}
-      - tl_reg_adapter.sv: {is_include_file: true}
-      - tl_seq_item.sv: {is_include_file: true}
-      - tl_seq_lib.sv: {is_include_file: true}
       - tl_sequencer.sv: {is_include_file: true}
+      - tl_monitor.sv: {is_include_file: true}
+      - tl_agent.sv: {is_include_file: true}
+      - tl_reg_adapter.sv: {is_include_file: true}
+      - tl_seq_lib.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:

--- a/hw/dv/sv/uart_agent/uart_agent.core
+++ b/hw/dv/sv/uart_agent/uart_agent.core
@@ -12,15 +12,16 @@ filesets:
     files:
       - uart_if.sv
       - uart_agent_pkg.sv
-      - uart_agent_cfg.sv: {is_include_file: true}
       - uart_item.sv: {is_include_file: true}
+      - uart_agent_cfg.sv: {is_include_file: true}
+      - uart_agent_cov.sv: {is_include_file: true}
       - uart_driver.sv: {is_include_file: true}
       - uart_monitor.sv: {is_include_file: true}
       - uart_sequencer.sv: {is_include_file: true}
       - uart_agent.sv: {is_include_file: true}
-      - uart_agent_cov.sv: {is_include_file: true}
-      - seq_lib/uart_base_seq.sv: {is_include_file: true}
       - seq_lib/uart_seq_list.sv: {is_include_file: true}
+      - seq_lib/uart_base_seq.sv: {is_include_file: true}
+      - seq_lib/uart_default_seq.sv: {is_include_file: true}
       - seq_lib/uart_seq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 

--- a/hw/dv/sv/usb20_agent/usb20_agent.core
+++ b/hw/dv/sv/usb20_agent/usb20_agent.core
@@ -19,8 +19,8 @@ filesets:
       - usb20_device_driver.sv: {is_include_file: true}
       - usb20_monitor.sv: {is_include_file: true}
       - usb20_agent.sv: {is_include_file: true}
-      - seq_lib/usb20_base_seq.sv: {is_include_file: true}
       - seq_lib/usb20_seq_list.sv: {is_include_file: true}
+      - seq_lib/usb20_base_seq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:

--- a/hw/dv/tools/fusesoc.mk
+++ b/hw/dv/tools/fusesoc.mk
@@ -12,7 +12,7 @@
 # fusesoc tool and options
 SV_FLIST_GEN_TOOL  ?= fusesoc
 SV_FLIST_GEN_OPTS  += --cores-root ${PROJ_ROOT} --cores-root ${RAL_MODEL_DIR} \
-                      run --target=sim --setup --no-export ${FUSESOC_CORE}
+                      run --target=sim --setup ${FUSESOC_CORE}
 FUSESOC_CORE_       = $(shell echo "${FUSESOC_CORE}" | tr ':' '_')
 SV_FLIST_GEN_DIR    = ${BUILD_DIR}/build/${FUSESOC_CORE_}/sim-vcs
 SV_FLIST           := ${SV_FLIST_GEN_DIR}/${FUSESOC_CORE_}.scr

--- a/hw/ip/aes/data/aes_testplan.hjson
+++ b/hw/ip/aes/data/aes_testplan.hjson
@@ -18,7 +18,7 @@
       desc: '''
             Basic hello world,  encrypt a plain text read it back - decrypt and compare to input'''
       milestone: V1
-      tests: ["aes_wakeup"]
+      tests: ["aes_wake_up"]
     }
     {
       name: sanity

--- a/hw/ip/aes/dv/aes_sim_cfg.hjson
+++ b/hw/ip/aes/dv/aes_sim_cfg.hjson
@@ -32,6 +32,9 @@
                 // TODO: enable stress tests later.
                 // "{proj_root}/hw/dv/data/tests/stress_tests.hjson"]
 
+  // Add additional tops for simulation.
+  sim_tops: ["-top aes_bind"]
+
   // Default iterations for all tests - each test entry can override this.
   reseed: 50
 
@@ -50,8 +53,9 @@
   // List of test specifications.
   tests: [
     {
-      name: aes_wakeup
+      name: aes_wake_up
       uvm_test_seq: aes_wake_up_vseq
+      reseed: 1
     }
 
     {

--- a/hw/ip/aes/dv/env/aes_env.core
+++ b/hw/ip/aes/dv/env/aes_env.core
@@ -15,15 +15,18 @@ filesets:
       - lowrisc:dv:gen_ral_pkg
       - lowrisc:dv:aes_model_dpi
     files:
-      - aes_seq_item.sv: {is_include_file: true}
       - aes_env_pkg.sv
-      - aes_virtual_sequencer.sv: {is_include_file: true}
+      - aes_seq_item.sv: {is_include_file: true}
       - aes_env_cfg.sv: {is_include_file: true}
       - aes_env_cov.sv: {is_include_file: true}
-      - aes_env.sv: {is_include_file: true}
-      - aes_reg_block.sv: {is_include_file: true}
+      - aes_virtual_sequencer.sv: {is_include_file: true}
       - aes_scoreboard.sv: {is_include_file: true}
+      - aes_env.sv: {is_include_file: true}
       - seq_lib/aes_vseq_list.sv: {is_include_file: true}
+      - seq_lib/aes_base_vseq.sv: {is_include_file: true}
+      - seq_lib/aes_common_vseq.sv: {is_include_file: true}
+      - seq_lib/aes_wake_up_vseq.sv: {is_include_file: true}
+      - seq_lib/aes_sanity_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:

--- a/hw/ip/alert_handler/dv/alert_handler_sim_cfg.hjson
+++ b/hw/ip/alert_handler/dv/alert_handler_sim_cfg.hjson
@@ -29,6 +29,9 @@
                 "{proj_root}/hw/dv/data/tests/tl_access_tests.hjson",
                 "{proj_root}/hw/dv/data/tests/stress_tests.hjson"]
 
+  // Add additional tops for simulation.
+  sim_tops: ["-top alert_handler_bind"]
+
   // Default iterations for all tests - each test entry can override this.
   reseed: 50
 

--- a/hw/ip/alert_handler/dv/env/alert_handler_env.core
+++ b/hw/ip/alert_handler/dv/env/alert_handler_env.core
@@ -13,9 +13,13 @@ filesets:
       - alert_handler_env_pkg.sv
       - alert_handler_env_cfg.sv: {is_include_file: true}
       - alert_handler_env_cov.sv: {is_include_file: true}
-      - alert_handler_env.sv: {is_include_file: true}
+      - alert_handler_virtual_sequencer.sv: {is_include_file: true}
       - alert_handler_scoreboard.sv: {is_include_file: true}
+      - alert_handler_env.sv: {is_include_file: true}
       - seq_lib/alert_handler_vseq_list.sv: {is_include_file: true}
+      - seq_lib/alert_handler_base_vseq.sv: {is_include_file: true}
+      - seq_lib/alert_handler_common_vseq.sv: {is_include_file: true}
+      - seq_lib/alert_handler_sanity_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:

--- a/hw/ip/gpio/dv/env/gpio_env.core
+++ b/hw/ip/gpio/dv/env/gpio_env.core
@@ -13,12 +13,21 @@ filesets:
       - gpio_env_pkg.sv
       - gpio_env_cfg.sv: {is_include_file: true}
       - gpio_env_cov.sv: {is_include_file: true}
-      - gpio_env.sv: {is_include_file: true}
       - gpio_scoreboard.sv: {is_include_file: true}
+      - gpio_env.sv: {is_include_file: true}
       - seq_lib/gpio_vseq_list.sv: {is_include_file: true}
       - seq_lib/gpio_base_vseq.sv: {is_include_file: true}
+      - seq_lib/gpio_common_vseq.sv: {is_include_file: true}
       - seq_lib/gpio_sanity_vseq.sv: {is_include_file: true}
-      - seq_lib/gpio_csr_vseq.sv: {is_include_file: true}
+      - seq_lib/gpio_rand_intr_trigger_vseq.sv: {is_include_file: true}
+      - seq_lib/gpio_random_dout_din_vseq.sv: {is_include_file: true}
+      - seq_lib/gpio_dout_din_regs_random_rw_vseq.sv: {is_include_file: true}
+      - seq_lib/gpio_random_long_reg_writes_reg_reads_vseq.sv: {is_include_file: true}
+      - seq_lib/gpio_filter_stress_vseq.sv: {is_include_file: true}
+      - seq_lib/gpio_full_random_vseq.sv: {is_include_file: true}
+      - seq_lib/gpio_stress_all_vseq.sv: {is_include_file: true}
+      - seq_lib/gpio_intr_rand_pgm_vseq.sv: {is_include_file: true}
+      - seq_lib/gpio_intr_with_filter_rand_intr_event_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:

--- a/hw/ip/gpio/dv/gpio_sim_cfg.hjson
+++ b/hw/ip/gpio/dv/gpio_sim_cfg.hjson
@@ -29,6 +29,9 @@
                 "{proj_root}/hw/dv/data/tests/tl_access_tests.hjson",
                 "{proj_root}/hw/dv/data/tests/stress_tests.hjson"]
 
+  // Add additional tops for simulation.
+  sim_tops: ["-top gpio_bind"]
+
   // Default iterations for all tests - each test entry can override this.
   reseed: 50
 

--- a/hw/ip/hmac/dv/cryptoc_dpi/cryptoc_dpi.core
+++ b/hw/ip/hmac/dv/cryptoc_dpi/cryptoc_dpi.core
@@ -7,21 +7,20 @@ description: "SHA / HASH Crypto implementations in C from Chromium open source r
 filesets:
   files_dv:
     files:
-      - hash-internal.h: { file_type: systemVerilogSource, is_include_file: true }
-      - hash-internal.h: { file_type: systemVerilogSource, is_include_file: true }
-      - md5.h: { file_type: systemVerilogSource, is_include_file: true }
-      - sha.h: { file_type: systemVerilogSource, is_include_file: true }
-      - sha256.h: { file_type: systemVerilogSource, is_include_file: true }
-      - util.h: { file_type: systemVerilogSource, is_include_file: true }
-      - hmac.h: { file_type: systemVerilogSource, is_include_file: true }
-      - hmac_wrap.h: { file_type: systemVerilogSource, is_include_file: true }
-      - util.c: { file_type: systemVerilogSource }
-      - sha.c: { file_type: systemVerilogSource }
-      - sha256.c: { file_type: systemVerilogSource }
-      - hmac.c: { file_type: systemVerilogSource }
-      - hmac_wrap.c: { file_type: systemVerilogSource }
-      - cryptoc_dpi.c: { file_type: systemVerilogSource }
-      - cryptoc_dpi_pkg.sv: { file_type: systemVerilogSource }
+      - hash-internal.h: {file_type: cSource, is_include_file: true}
+      - sha.h: {file_type: cSource, is_include_file: true}
+      - sha256.h: {file_type: cSource, is_include_file: true}
+      - util.h: {file_type: cSource, is_include_file: true}
+      - hmac.h: {file_type: cSource, is_include_file: true}
+      - hmac_wrap.h: {file_type: cSource, is_include_file: true}
+      - util.c: {file_type: cSource}
+      - sha.c: {file_type: cSource}
+      - sha256.c: {file_type: cSource}
+      - hmac.c: {file_type: cSource}
+      - hmac_wrap.c: {file_type: cSource}
+      - cryptoc_dpi.c: {file_type: cSource}
+      - cryptoc_dpi_pkg.sv: {file_type: systemVerilogSource}
+    file_type: cSource
 
 targets:
   default:

--- a/hw/ip/hmac/dv/env/hmac_env.core
+++ b/hw/ip/hmac/dv/env/hmac_env.core
@@ -15,12 +15,19 @@ filesets:
       - hmac_env_pkg.sv
       - hmac_env_cfg.sv: {is_include_file: true}
       - hmac_env_cov.sv: {is_include_file: true}
-      - hmac_env.sv: {is_include_file: true}
       - hmac_scoreboard.sv: {is_include_file: true}
+      - hmac_env.sv: {is_include_file: true}
       - seq_lib/hmac_vseq_list.sv: {is_include_file: true}
       - seq_lib/hmac_base_vseq.sv: {is_include_file: true}
+      - seq_lib/hmac_common_vseq.sv: {is_include_file: true}
       - seq_lib/hmac_sanity_vseq.sv: {is_include_file: true}
-      - seq_lib/hmac_csr_vseq.sv: {is_include_file: true}
+      - seq_lib/hmac_back_pressure_vseq.sv: {is_include_file: true}
+      - seq_lib/hmac_datapath_stress_vseq.sv: {is_include_file: true}
+      - seq_lib/hmac_test_vectors_hmac_vseq.sv: {is_include_file: true}
+      - seq_lib/hmac_long_msg_vseq.sv: {is_include_file: true}
+      - seq_lib/hmac_test_vectors_sha_vseq.sv: {is_include_file: true}
+      - seq_lib/hmac_burst_wr_vseq.sv: {is_include_file: true}
+      - seq_lib/hmac_stress_all_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:

--- a/hw/ip/hmac/dv/hmac_sim_cfg.hjson
+++ b/hw/ip/hmac/dv/hmac_sim_cfg.hjson
@@ -29,6 +29,9 @@
                 "{proj_root}/hw/dv/data/tests/tl_access_tests.hjson",
                 "{proj_root}/hw/dv/data/tests/stress_tests.hjson"]
 
+  // Add additional tops for simulation.
+  sim_tops: ["-top hmac_bind"]
+
   // Default iterations for all tests - each test entry can override this.
   reseed: 50
 
@@ -68,25 +71,25 @@
     {
       name: hmac_test_sha_vectors
       uvm_test_seq: hmac_test_vectors_sha_vseq
-      run_opts: ["+test_vectors_dir={proj_root}/hw/dv/sv/test_vectors"]
+      run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0"]
     }
 
     {
       name: hmac_test_hmac_vectors
       uvm_test_seq: hmac_test_vectors_hmac_vseq
-      run_opts: ["+test_vectors_dir={proj_root}/hw/dv/sv/test_vectors"]
+      run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0"]
     }
 
     {
       // Append the common stress_tests.hjson entry for more run_opts.
       name: hmac_stress_all
-      run_opts: ["+test_vectors_dir={proj_root}/hw/dv/sv/test_vectors"]
+      run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0"]
     }
 
     {
       // Append the common stress_tests.hjson entry for more run_opts.
       name: hmac_stress_all_with_rand_reset
-      run_opts: ["+test_vectors_dir={proj_root}/hw/dv/sv/test_vectors"]
+      run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0"]
     }
   ]
 }

--- a/hw/ip/i2c/dv/env/i2c_env.core
+++ b/hw/ip/i2c/dv/env/i2c_env.core
@@ -14,10 +14,13 @@ filesets:
       - i2c_env_pkg.sv
       - i2c_env_cfg.sv: {is_include_file: true}
       - i2c_env_cov.sv: {is_include_file: true}
-      - i2c_env.sv: {is_include_file: true}
       - i2c_virtual_sequencer.sv: {is_include_file: true}
       - i2c_scoreboard.sv: {is_include_file: true}
+      - i2c_env.sv: {is_include_file: true}
       - seq_lib/i2c_vseq_list.sv: {is_include_file: true}
+      - seq_lib/i2c_base_vseq.sv: {is_include_file: true}
+      - seq_lib/i2c_common_vseq.sv: {is_include_file: true}
+      - seq_lib/i2c_sanity_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -29,6 +29,9 @@
                 "{proj_root}/hw/dv/data/tests/tl_access_tests.hjson",
                 "{proj_root}/hw/dv/data/tests/stress_tests.hjson"]
 
+  // Add additional tops for simulation.
+  sim_tops: ["-top i2c_bind"]
+
   // Default iterations for all tests - each test entry can override this.
   reseed: 50
 

--- a/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
+++ b/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
@@ -31,6 +31,9 @@
                 "{proj_root}/hw/dv/data/tests/mem_tests.hjson",
                 "{proj_root}/hw/dv/data/tests/stress_tests.hjson"]
 
+  // Add additional tops for simulation.
+  sim_tops: ["-top rv_dm_bind"]
+
   // Default iterations for all tests - each test entry can override this.
   reseed: 50
 

--- a/hw/ip/rv_timer/dv/env/rv_timer_env.core
+++ b/hw/ip/rv_timer/dv/env/rv_timer_env.core
@@ -13,12 +13,16 @@ filesets:
       - rv_timer_env_pkg.sv
       - rv_timer_env_cfg.sv: {is_include_file: true}
       - rv_timer_env_cov.sv: {is_include_file: true}
-      - rv_timer_env.sv: {is_include_file: true}
       - rv_timer_scoreboard.sv: {is_include_file: true}
+      - rv_timer_env.sv: {is_include_file: true}
       - seq_lib/rv_timer_vseq_list.sv: {is_include_file: true}
       - seq_lib/rv_timer_base_vseq.sv: {is_include_file: true}
+      - seq_lib/rv_timer_common_vseq.sv: {is_include_file: true}
       - seq_lib/rv_timer_sanity_vseq.sv: {is_include_file: true}
-      - seq_lib/rv_timer_csr_vseq.sv: {is_include_file: true}
+      - seq_lib/rv_timer_disabled_vseq.sv: {is_include_file: true}
+      - seq_lib/rv_timer_cfg_update_on_fly_vseq.sv: {is_include_file: true}
+      - seq_lib/rv_timer_random_reset_vseq.sv: {is_include_file: true}
+      - seq_lib/rv_timer_stress_all_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:

--- a/hw/ip/rv_timer/dv/rv_timer_sim_cfg.hjson
+++ b/hw/ip/rv_timer/dv/rv_timer_sim_cfg.hjson
@@ -29,6 +29,9 @@
                 "{proj_root}/hw/dv/data/tests/tl_access_tests.hjson",
                 "{proj_root}/hw/dv/data/tests/stress_tests.hjson"]
 
+  // Add additional tops for simulation.
+  sim_tops: ["-top rv_timer_bind"]
+
   // Default iterations for all tests - each test entry can override this.
   reseed: 50
 

--- a/hw/ip/spi_device/dv/env/spi_device_env.core
+++ b/hw/ip/spi_device/dv/env/spi_device_env.core
@@ -14,12 +14,17 @@ filesets:
       - spi_device_env_pkg.sv
       - spi_device_env_cfg.sv: {is_include_file: true}
       - spi_device_env_cov.sv: {is_include_file: true}
-      - spi_device_env.sv: {is_include_file: true}
+      - spi_device_virtual_sequencer.sv: {is_include_file: true}
       - spi_device_scoreboard.sv: {is_include_file: true}
+      - spi_device_env.sv: {is_include_file: true}
       - seq_lib/spi_device_vseq_list.sv: {is_include_file: true}
       - seq_lib/spi_device_base_vseq.sv: {is_include_file: true}
+      - seq_lib/spi_device_common_vseq.sv: {is_include_file: true}
       - seq_lib/spi_device_sanity_vseq.sv: {is_include_file: true}
-      - seq_lib/spi_device_csr_vseq.sv: {is_include_file: true}
+      - seq_lib/spi_device_fifo_underflow_overflow_vseq.sv: {is_include_file: true}
+      - seq_lib/spi_device_extreme_fifo_size_vseq.sv: {is_include_file: true}
+      - seq_lib/spi_device_txrx_vseq.sv: {is_include_file: true}
+      - seq_lib/spi_device_fifo_full_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:

--- a/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson
+++ b/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson
@@ -29,6 +29,9 @@
                 "{proj_root}/hw/dv/data/tests/tl_access_tests.hjson",
                 "{proj_root}/hw/dv/data/tests/stress_tests.hjson"]
 
+  // Add additional tops for simulation.
+  sim_tops: ["-top spi_device_bind"]
+
   // Default iterations for all tests - each test entry can override this.
   reseed: 50
 

--- a/hw/ip/uart/dv/env/uart_env.core
+++ b/hw/ip/uart/dv/env/uart_env.core
@@ -14,15 +14,26 @@ filesets:
       - uart_env_pkg.sv
       - uart_env_cfg.sv: {is_include_file: true}
       - uart_env_cov.sv: {is_include_file: true}
-      - uart_env.sv: {is_include_file: true}
       - uart_virtual_sequencer.sv: {is_include_file: true}
       - uart_scoreboard.sv: {is_include_file: true}
+      - uart_env.sv: {is_include_file: true}
       - seq_lib/uart_vseq_list.sv: {is_include_file: true}
-      - seq_lib/uart_tx_rx_vseq.sv: {is_include_file: true}
       - seq_lib/uart_base_vseq.sv: {is_include_file: true}
-      - seq_lib/uart_csr_vseq.sv: {is_include_file: true}
+      - seq_lib/uart_sanity_vseq.sv: {is_include_file: true}
+      - seq_lib/uart_common_vseq.sv: {is_include_file: true}
+      - seq_lib/uart_tx_rx_vseq.sv: {is_include_file: true}
       - seq_lib/uart_fifo_full_vseq.sv: {is_include_file: true}
       - seq_lib/uart_fifo_overflow_vseq.sv: {is_include_file: true}
+      - seq_lib/uart_fifo_reset_vseq.sv: {is_include_file: true}
+      - seq_lib/uart_intr_vseq.sv: {is_include_file: true}
+      - seq_lib/uart_loopback_vseq.sv: {is_include_file: true}
+      - seq_lib/uart_noise_filter_vseq.sv: {is_include_file: true}
+      - seq_lib/uart_perf_vseq.sv: {is_include_file: true}
+      - seq_lib/uart_rx_oversample_vseq.sv: {is_include_file: true}
+      - seq_lib/uart_rx_parity_err_vseq.sv: {is_include_file: true}
+      - seq_lib/uart_rx_start_bit_filter_vseq.sv: {is_include_file: true}
+      - seq_lib/uart_stress_all_vseq.sv: {is_include_file: true}
+      - seq_lib/uart_tx_ovrd_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:

--- a/hw/ip/uart/dv/uart_sim_cfg.hjson
+++ b/hw/ip/uart/dv/uart_sim_cfg.hjson
@@ -29,6 +29,9 @@
                 "{proj_root}/hw/dv/data/tests/tl_access_tests.hjson",
                 "{proj_root}/hw/dv/data/tests/stress_tests.hjson"]
 
+  // Add additional tops for simulation.
+  sim_tops: ["-top uart_bind"]
+
   // Default iterations for all tests - each test entry can override this.
   reseed: 50
 

--- a/hw/ip/usbdev/dv/env/usbdev_env.core
+++ b/hw/ip/usbdev/dv/env/usbdev_env.core
@@ -14,10 +14,13 @@ filesets:
       - usbdev_env_pkg.sv
       - usbdev_env_cfg.sv: {is_include_file: true}
       - usbdev_env_cov.sv: {is_include_file: true}
-      - usbdev_env.sv: {is_include_file: true}
       - usbdev_virtual_sequencer.sv: {is_include_file: true}
       - usbdev_scoreboard.sv: {is_include_file: true}
+      - usbdev_env.sv: {is_include_file: true}
       - seq_lib/usbdev_vseq_list.sv: {is_include_file: true}
+      - seq_lib/usbdev_base_vseq.sv: {is_include_file: true}
+      - seq_lib/usbdev_common_vseq.sv: {is_include_file: true}
+      - seq_lib/usbdev_sanity_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -1,0 +1,18 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  name: "chip"
+  import_testplans: ["hw/dv/tools/testplans/csr_testplan.hjson",
+                     "hw/dv/tools/testplans/mem_testplan.hjson",
+                     "hw/dv/tools/testplans/tl_device_access_types_testplan.hjson"]
+  entries: [
+    {
+      name: sanity
+      desc: ''' Basic hello world type test.
+            '''
+      milestone: V1
+      tests: ["chip_sanity"]
+    }
+  ]
+}

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -3,22 +3,26 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   // Name of the sim cfg - typically same as the name of the DUT.
-  name: usbdev
+  name: chip
 
   // Top level dut name (sv module).
-  dut: usbdev
+  dut: top_earlgrey
 
   // Top level testbench name (sv module).
   tb: tb
 
   // Fusesoc core file used for building the file list.
-  fusesoc_core: lowrisc:dv:usbdev_sim:0.1
+  fusesoc_core: lowrisc:dv:chip_sim:0.1
 
   // Testplan hjson file.
-  testplan: "{proj_root}/hw/ip/usbdev/data/usbdev_testplan.hjson"
+  testplan: "{proj_root}/hw/top_earlgrey/data/chip_testplan.hjson"
 
   // RAL spec - used to generate the RAL model.
-  ral_spec: "{proj_root}/hw/ip/usbdev/data/usbdev.hjson"
+  ral_spec: "{proj_root}/hw/top_earlgrey/data/top_earlgrey.hjson"
+
+  // Add additional tops for simulation.
+  sim_tops: ["-top xbar_main_bind",
+             "-top xbar_peri_bind"]
 
   // Import additional common sim cfg files.
   import_cfgs: [// Project wide common sim cfg file
@@ -26,35 +30,43 @@
                 // Common CIP test lists
                 "{proj_root}/hw/dv/data/tests/csr_tests.hjson",
                 "{proj_root}/hw/dv/data/tests/mem_tests.hjson",
-                "{proj_root}/hw/dv/data/tests/intr_test.hjson",
-                "{proj_root}/hw/dv/data/tests/tl_access_tests.hjson",
-                "{proj_root}/hw/dv/data/tests/stress_tests.hjson"]
-
-  // Add additional tops for simulation.
-  sim_tops: ["-top usbdev_bind"]
+                "{proj_root}/hw/dv/data/tests/tl_access_tests.hjson"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 50
+  reseed: 1
 
   // Default UVM test and seq class name.
-  uvm_test: usbdev_base_test
-  uvm_test_seq: usbdev_base_vseq
+  uvm_test: chip_base_test
+  uvm_test_seq: chip_base_vseq
 
-  // TODO: temporary fix for CSR tests - USB link reset interrupt is sticky - clearing it
-  // has no effect. Update "csr_test_mode" to add +do_clear_all_interrupts=0 switch to
-  // prevent the intr checks from being run.
+  // Additional option to RAL generation for top level.
+  gen_ral_pkg_opts: ["--top"]
+
+  // Add run modes.
   run_modes: [
     {
+      name: stub_cpu
+      run_opts: ["+stub_cpu=1"]
+    }
+
+    {
+      // Append stub cpu mode to csr_tests_mode
       name: csr_tests_mode
-      run_opts: ["+do_clear_all_interrupts=0"]
+      en_run_modes: ["stub_cpu"]
+    }
+
+    {
+      // Append stub cpu mode to mem_tests_mode
+      name: mem_tests_mode
+      en_run_modes: ["stub_cpu"]
     }
   ]
 
   // List of test specifications.
   tests: [
     {
-      name: usbdev_sanity
-      uvm_test_seq: usbdev_sanity_vseq
+      name: chip_sanity
+      uvm_test_seq: chip_sanity_vseq
     }
   ]
 }

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -20,12 +20,16 @@ filesets:
       - lowrisc:dv:gen_ral_pkg
     files:
       - chip_env_pkg.sv
+      - chip_tl_seq_item.sv: {is_include_file: true}
       - chip_env_cfg.sv: {is_include_file: true}
       - chip_env_cov.sv: {is_include_file: true}
       - chip_env.sv: {is_include_file: true}
       - chip_virtual_sequencer.sv: {is_include_file: true}
       - chip_scoreboard.sv: {is_include_file: true}
+      - chip_env.sv: {is_include_file: true}
       - seq_lib/chip_vseq_list.sv: {is_include_file: true}
+      - seq_lib/chip_base_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_common_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
@@ -9,8 +9,8 @@
     m_``ip``_common_vseq.add_csr_exclusions(csr_test_type, csr_excl, {scope, ".", `"ip`"}); \
   end
 
-class chip_csr_vseq extends chip_base_vseq;
-  `uvm_object_utils(chip_csr_vseq)
+class chip_common_vseq extends chip_base_vseq;
+  `uvm_object_utils(chip_common_vseq)
 
   constraint num_trans_c {
     num_trans inside {[1:2]};

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -3,4 +3,4 @@
 // SPDX-License-Identifier: Apache-2.0
 
 `include "chip_base_vseq.sv"
-`include "chip_csr_vseq.sv"
+`include "chip_common_vseq.sv"

--- a/util/dvsim/utils.py
+++ b/util/dvsim/utils.py
@@ -105,10 +105,21 @@ def subst_wildcards(var, mdict, ignored_wildcards=[]):
                     log.debug("Found wildcard in \"%s\": \"%s\"", var, item)
                     found = subst(item, mdict)
                     if found is not None:
-                        if type(found) is str:
+                        if type(found) is list:
+                            subst_found = []
+                            for element in found:
+                                element = subst_wildcards(element, mdict,
+                                                          ignored_wildcards)
+                                subst_found.append(element)
+                            # Expand list into a str since list within list is
+                            # not supported.
+                            found = " ".join(subst_found)
+
+                        elif type(found) is str:
                             found = subst_wildcards(found, mdict,
                                                     ignored_wildcards)
-                        if type(found) is bool:
+
+                        elif type(found) is bool:
                             found = int(found)
                         subst_list[item] = found
                     else:
@@ -157,5 +168,4 @@ def find_and_substitute_wildcards(sub_dict, full_dict, ignored_wildcards=[]):
         elif type(sub_dict[key]) is str:
             sub_dict[key] = subst_wildcards(sub_dict[key], full_dict,
                                             ignored_wildcards)
-
     return sub_dict

--- a/util/uvmdvgen/agent.core.tpl
+++ b/util/uvmdvgen/agent.core.tpl
@@ -12,9 +12,9 @@ filesets:
     files:
       - ${name}_if.sv
       - ${name}_agent_pkg.sv
+      - ${name}_item.sv: {is_include_file: true}
       - ${name}_agent_cfg.sv: {is_include_file: true}
       - ${name}_agent_cov.sv: {is_include_file: true}
-      - ${name}_item.sv: {is_include_file: true}
 % if has_separate_host_device_driver:
       - ${name}_host_driver.sv: {is_include_file: true}
       - ${name}_device_driver.sv: {is_include_file: true}

--- a/util/uvmdvgen/env.core.tpl
+++ b/util/uvmdvgen/env.core.tpl
@@ -20,12 +20,15 @@ filesets:
       - ${name}_env_pkg.sv
       - ${name}_env_cfg.sv: {is_include_file: true}
       - ${name}_env_cov.sv: {is_include_file: true}
-      - ${name}_env.sv: {is_include_file: true}
 % if env_agents != []:
       - ${name}_virtual_sequencer.sv: {is_include_file: true}
 % endif
       - ${name}_scoreboard.sv: {is_include_file: true}
+      - ${name}_env.sv: {is_include_file: true}
       - seq_lib/${name}_vseq_list.sv: {is_include_file: true}
+      - seq_lib/${name}_base_vseq.sv: {is_include_file: true}
+      - seq_lib/${name}_common_vseq.sv: {is_include_file: true}
+      - seq_lib/${name}_sanity_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:

--- a/util/uvmdvgen/sim_cfg.hjson.tpl
+++ b/util/uvmdvgen/sim_cfg.hjson.tpl
@@ -40,6 +40,9 @@
                 "{proj_root}/hw/dv/data/tests/mem_tests.hjson"]
 % endif
 
+  // Add additional tops for simulation.
+  sim_tops: ["-top {name}_bind"]
+
   // Default iterations for all tests - each test entry can override this.
   reseed: 50
 


### PR DESCRIPTION
Fusesoc updates:
- This PR updates the fusesoc invoked within DV to export the sources to
the build area.
- Several fusesoc core files are updated to reflect the full list of sources
  - This is mandatory going forward! 
- This is done to enable the tool to use GCP resources for sim build / run deployment (or LSF)

Chip top sim updates:
- This PR also updates the chip level to use the DVSIM regression flow.
It adds a chip testplan and the sim cfg hjson file to enable it. These are only basic at the moment; More content will be added in sbsequent PRs. 

DVSIM Script updates:
- This regression script has a minor update to enable top_earlgrey sims
using the dvsim flow.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>