### PR TITLE
[sw] Document CMake Requirement

### DIFF
--- a/apt-requirements.txt
+++ b/apt-requirements.txt
@@ -7,6 +7,7 @@ autoconf
 bison
 build-essential
 clang-format
+cmake
 curl
 flex
 g++

--- a/doc/ug/install_instructions/index.md
+++ b/doc/ug/install_instructions/index.md
@@ -15,6 +15,7 @@ This guide makes assumes the following system setup.
 * Physical access to that machine, root permissions and a graphical environment.
 * Python 3.5.2 or newer. Python 3.6+ is recommended.
 * A C++14 capable compiler. GCC 5 or Clang 3.5 should meet this requirement.
+* CMake 2.8.8 or newer.
 * 60 GB or more of disk space.
   EDA tools like Xilinx Vivado can easily take up 40 GB each.
 * We develop and test on the following Linux distributions:


### PR DESCRIPTION
Pull request #1345 vendored googletest and googlemock, which are
built using CMake. While we intend to move googletest to meson,
in the short term we should document the CMake requirement.
