### PR TITLE
[dv regr tool] Publish results in html + fixes

### DIFF
--- a/hw/dv/data/common_sim_cfg.hjson
+++ b/hw/dv/data/common_sim_cfg.hjson
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   project:          opentitan
-  results_server:   "gs://reports.opentitan.org"
+  doc_server:       "docs.opentitan.org"
+  results_server:   "reports.opentitan.org"
 
   flow:             sim
   flow_makefile:    "{proj_root}/hw/dv/data/sim.mk"

--- a/hw/dv/data/master_sim_cfgs_list.hjson
+++ b/hw/dv/data/master_sim_cfgs_list.hjson
@@ -5,12 +5,13 @@
   // This is the master cfg hjson for DV simulations. It imports ALL individual DV sim
   // cfgs in OpenTitan so that regressions in all available DUTs can be invoked together in
   // one shot.
-  use_cfgs: ["{proj_root}/hw/ip/uart/dv/uart_sim_cfg.hjson",
-             "{proj_root}/hw/ip/hmac/dv/hmac_sim_cfg.hjson",
-             "{proj_root}/hw/ip/aes/dv/aes_sim_cfg.hjson",
+  use_cfgs: ["{proj_root}/hw/ip/aes/dv/aes_sim_cfg.hjson",
              "{proj_root}/hw/ip/alert_handler/dv/alert_handler_sim_cfg.hjson",
              "{proj_root}/hw/ip/gpio/dv/gpio_sim_cfg.hjson",
+             "{proj_root}/hw/ip/hmac/dv/hmac_sim_cfg.hjson",
              "{proj_root}/hw/ip/i2c/dv/i2c_sim_cfg.hjson",
              "{proj_root}/hw/ip/rv_timer/dv/rv_timer_sim_cfg.hjson",
-             "{proj_root}/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson"]
+             "{proj_root}/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson",
+             "{proj_root}/hw/ip/uart/dv/uart_sim_cfg.hjson",
+             "{proj_root}/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson"]
 }

--- a/hw/ip/aes/doc/dv_plan/index.md
+++ b/hw/ip/aes/doc/dv_plan/index.md
@@ -12,7 +12,7 @@ title: "AES DV Plan"
 ## Current status
 * [Design & verification stage]({{< relref "doc/project/hw_dashboard" >}})
   * [HW development stages]({{< relref "doc/project/hw_stages.md" >}})
-* DV regression results dashboard (link TBD)
+* [Simulation results](https://reports.opentitan.org/hw/ip/aes/dv/latest/results.html)
 
 ## Design features
 For detailed information on AES design features, please see the [AES HWIP Technical Specification]({{< relref "hw/ip/aes/doc" >}}).

--- a/hw/ip/alert_handler/doc/dv_plan/index.md
+++ b/hw/ip/alert_handler/doc/dv_plan/index.md
@@ -14,7 +14,7 @@ title: "ALERT_HANDLER DV Plan"
 ## Current status
 * [Design & verification stage]({{< relref "doc/project/hw_dashboard" >}})
   * [HW development stages]({{< relref "doc/project/hw_stages" >}})
-* DV regression results dashboard (link TBD)
+* [Simulation results](https://reports.opentitan.org/hw/ip/alert_handler/dv/latest/results.html)
 
 ## Design features
 For detailed information on ALERT_HANDLER design features, please see the [ALERT_HANDLER HWIP technical specification]({{< relref "hw/ip/alert_handler/doc" >}}).

--- a/hw/ip/gpio/doc/dv_plan/index.md
+++ b/hw/ip/gpio/doc/dv_plan/index.md
@@ -12,7 +12,7 @@ title: "GPIO DV Plan"
 ## Current status
 * [Design & verification stage]({{< relref "doc/project/hw_dashboard" >}})
   * [HW development stages]({{< relref "doc/project/hw_stages.md" >}})
-* DV regression results dashboard (link TBD)
+* [Simulation results](https://reports.opentitan.org/hw/ip/gpio/dv/latest/results.html)
 
 ## Design features
 For detailed information on GPIO design features, please see the [GPIO design specification]({{< relref "hw/ip/gpio/doc" >}}).

--- a/hw/ip/hmac/doc/dv_plan/index.md
+++ b/hw/ip/hmac/doc/dv_plan/index.md
@@ -12,7 +12,7 @@ title: "HMAC DV Plan"
 ## Current status
 * [Design & verification stage]({{< relref "doc/project/hw_dashboard" >}})
   * [HW development stages]({{< relref "doc/project/hw_stages.md" >}})
-* DV regression results dashboard (link TBD)
+* [Simulation results](https://reports.opentitan.org/hw/ip/hmac/dv/latest/results.html)
 
 ## Design features
 For detailed information on HMAC design features, please see the

--- a/hw/ip/i2c/doc/dv_plan/index.md
+++ b/hw/ip/i2c/doc/dv_plan/index.md
@@ -12,7 +12,7 @@ title: "I2C DV Plan"
 ## Current status
 * [Design & verification stage]({{< relref "doc/project/hw_dashboard" >}})
   * [HW development stages]({{< relref "doc/project/hw_stages.md" >}})
-* DV regression results dashboard (link TBD)
+* [Simulation results](https://reports.opentitan.org/hw/ip/i2c/dv/latest/results.html)
 
 ## Design features
 For detailed information on I2C design features, please see the

--- a/hw/ip/rv_timer/doc/dv_plan/index.md
+++ b/hw/ip/rv_timer/doc/dv_plan/index.md
@@ -12,7 +12,7 @@ title: "RV_TIMER DV Plan"
 ## Current status
 * [Design & verification stage]({{< relref "doc/project/hw_dashboard" >}})
   * [HW development stages]({{< relref "doc/project/hw_stages.md" >}})
-* DV regression results dashboard (link TBD)
+* [Simulation results](https://reports.opentitan.org/hw/ip/rv_timer/dv/latest/results.html)
 
 ## Design features
 For detailed information on RV_TIMER design features, please see the [RV_TIMER design specification]({{< relref "hw/ip/rv_timer/doc" >}}).

--- a/hw/ip/spi_device/doc/dv_plan/index.md
+++ b/hw/ip/spi_device/doc/dv_plan/index.md
@@ -13,7 +13,7 @@ title: "SPI Device DV Plan"
 ## Current status
 * [Design & verification stage]({{< relref "doc/project/hw_dashboard" >}})
   * [HW development stages]({{< relref "doc/project/hw_stages.md" >}})
-* DV regression results dashboard (link TBD)
+* [Simulation results](https://reports.opentitan.org/hw/ip/spi_device/dv/latest/results.html)
 
 ## Design features
 For detailed information on SPI Device design features, please see the [SPI_device design specification]({{< relref "hw/ip/spi_device/doc" >}}).

--- a/hw/ip/uart/doc/dv_plan/index.md
+++ b/hw/ip/uart/doc/dv_plan/index.md
@@ -13,7 +13,7 @@ title: "UART DV Plan"
 ## Current status
 * [Design & verification stage]({{< relref "doc/project/hw_dashboard" >}})
   * [HW development stages]({{< relref "doc/project/hw_stages.md" >}})
-* DV regression results dashboard (link TBD)
+* [Simulation results](https://reports.opentitan.org/hw/ip/uart/dv/latest/results.html)
 
 ## Design features
 For detailed information on UART design features, please see the [UART design specification]({{< relref "hw/ip/uart/doc" >}}).

--- a/hw/ip/usbdev/doc/dv_plan/index.md
+++ b/hw/ip/usbdev/doc/dv_plan/index.md
@@ -14,7 +14,7 @@ title: "USBDEV DV Plan"
 ## Current status
 * [Design & verification stage]({{< relref "doc/project/hw_dashboard" >}})
   * [HW development stages]({{< relref "doc/project/hw_stages" >}})
-* DV regression results dashboard (link TBD)
+* [Simulation results](https://reports.opentitan.org/hw/ip/usbdev/dv/latest/results.html)
 
 ## Design features
 For detailed information on USBDEV design features, please see the [USBDEV HWIP technical specification]({{< relref "hw/ip/usbdev/doc" >}}).

--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -262,10 +262,10 @@ class Deploy():
         if self.process.poll() is not None:
             self.log_fd.close()
             if self.process.returncode != 0:
-                msg = "Last 2 lines of the log:<br>\n"
+                msg = "Last 5 lines of the log:<br>\n"
                 self.fail_msg += msg
                 log.log(VERBOSE, msg)
-                get_fail_msg_cmd = "tail -n 2 " + self.log
+                get_fail_msg_cmd = "tail -n 5 " + self.log
                 msg = run_cmd(get_fail_msg_cmd)
                 msg = "```\n{}\n```\n".format(msg)
                 self.fail_msg += msg
@@ -417,8 +417,8 @@ class CompileSim(Deploy):
 
         # Start fail message construction
         self.fail_msg = "\n**BUILD:** {}<br>\n".format(self.name)
-        log_sub_path = self.log.replace(self.sim_cfg.scratch_root + '/', '')
-        self.fail_msg += "**LOG: {}<br>\n".format(log_sub_path)
+        log_sub_path = self.log.replace(self.sim_cfg.scratch_path + '/', '')
+        self.fail_msg += "**LOG:** $scratch_path/{}<br>\n".format(log_sub_path)
 
         CompileSim.items.append(self)
 

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -143,6 +143,7 @@ class SimCfg(FlowCfg):
     def __post_init__(self):
         # Run some post init checks
         super().__post_init__()
+        self.results_title = self.name.upper() + " Simulation Results"
 
     @staticmethod
     def create_instance(flow_cfg_file, proj_root, args):
@@ -400,9 +401,14 @@ class SimCfg(FlowCfg):
             fail_msgs = "\n## List of Failures\n" + fail_msgs
 
         # Generate results table for runs.
-        results_str = "# " + self.name.upper() + " Regression Results\n"
-        results_str += "  Run on " + self.timestamp_long + "\n"
-        results_str += "\n## Test Results\n"
+        results_str = "## " + self.results_title + "\n"
+        results_str += "### " + self.timestamp_long + "\n"
+
+        # Add path to testplan.
+        testplan = "https://" + self.doc_server + '/' + self.rel_path
+        testplan = testplan.replace("/dv", "/doc/dv_plan/#testplan")
+        results_str += "### [Testplan](" + testplan + ")\n\n"
+
         # TODO: check if testplan is not null?
         results_str += self.testplan.results_table(
             regr_results=regr_results,
@@ -413,7 +419,7 @@ class SimCfg(FlowCfg):
         self.results_md = results_str + fail_msgs
 
         # Write results to the scratch area
-        self.results_file = self.scratch_path + "/regr_results_" + self.timestamp + ".md"
+        self.results_file = self.scratch_path + "/results_" + self.timestamp + ".md"
         log.info("Detailed results are available at %s", self.results_file)
         f = open(self.results_file, 'w')
         f.write(self.results_md)

--- a/util/dvsim/style.css
+++ b/util/dvsim/style.css
@@ -1,0 +1,74 @@
+/* Copyright lowRISC contributors.
+ * Licensed under the Apache License, Version 2.0, see LICENSE for details.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* CSS for reports.opentitan.org.
+ * This is currently uploaded to reports.opentitan.org/css/style,css. It is
+ * referenced by all results published to the reports server for some basic
+ * styling. After making any change to this file, it needs to be manually
+ * copied over so that the new changes are reflected in the results pages.
+ * gsutil cp <this-file> gs://reports.opentitan.org/css/style.css
+ */
+
+.results {
+  width: 80%;
+  max-width: 960px;
+  padding-left: 40px;
+  padding-right: 40px;
+  margin: 0 auto;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-height: 100vh;
+  font-family: "Trebuchet MS", Arial, Helvetica, sans-serif;
+}
+
+.results p {
+  text-align: justify;
+}
+
+.results pre {
+   overflow-x: auto;
+   white-space: pre-wrap;
+   white-space: -moz-pre-wrap;
+   white-space: -pre-wrap;
+   white-space: -o-pre-wrap;
+}
+
+.results h1, .results h2, .results h3 {
+  text-align: center;
+}
+
+.results table {
+  width: 90%;
+  margin: 2% auto;
+  border: 1px solid #f2f2f2;
+  border-collapse: collapse;
+  text-align: center;
+  vertical-align: middle;
+  display: table;
+  table-layout: auto
+}
+
+.results th {
+  padding-top: 12px;
+  padding-bottom: 12px;
+  background-color: #3D1067;
+  text-transform: uppercase;
+  color: white;
+}
+
+.results th, .results td {
+  border: 1px solid #f2f2f2;
+  padding: 8px;
+}
+
+.results tr:hover {
+  background-color: #f2f2f2;
+}
+
+.results tbody tr:nth-child(even) {
+  background: #f2f2f2;
+}

--- a/util/dvsim/utils.py
+++ b/util/dvsim/utils.py
@@ -17,6 +17,7 @@ import time
 from collections import OrderedDict
 
 import hjson
+import mistletoe
 
 # For verbose logging
 VERBOSE = 15
@@ -77,9 +78,9 @@ def parse_hjson(hjson_file):
         text = f.read()
         hjson_cfg_dict = hjson.loads(text, use_decimal=True)
         f.close()
-    except:
-        log.fatal("Failed to parse \"%s\" possibly due to bad path",
-                  hjson_file)
+    except Exception as e:
+        log.fatal("Failed to parse \"%s\" possibly due to bad path or syntax error.\n%s",
+                  hjson_file, e)
         sys.exit(1)
     return hjson_cfg_dict
 
@@ -108,8 +109,8 @@ def subst_wildcards(var, mdict, ignored_wildcards=[]):
                         if type(found) is list:
                             subst_found = []
                             for element in found:
-                                element = subst_wildcards(element, mdict,
-                                                          ignored_wildcards)
+                                element = subst_wildcards(
+                                    element, mdict, ignored_wildcards)
                                 subst_found.append(element)
                             # Expand list into a str since list within list is
                             # not supported.
@@ -169,3 +170,24 @@ def find_and_substitute_wildcards(sub_dict, full_dict, ignored_wildcards=[]):
             sub_dict[key] = subst_wildcards(sub_dict[key], full_dict,
                                             ignored_wildcards)
     return sub_dict
+
+
+def md_results_to_html(title, css_path, md_text):
+    '''Convert results in md format to html. Add a little bit of styling.
+    '''
+    html_text = "<!DOCTYPE html>\n"
+    html_text += "<html lang=\"en\">\n"
+    html_text += "<head>\n"
+    if title != "":
+        html_text += "  <title>{}</title>\n".format(title)
+    if css_path != "":
+        html_text += "  <link rel=\"stylesheet\" type=\"text/css\""
+        html_text += " href=\"{}\"/>\n".format(css_path)
+    html_text += "</head>\n"
+    html_text += "<body>\n"
+    html_text += "<div class=\"results\">\n"
+    html_text += mistletoe.markdown(md_text)
+    html_text += "</div>\n"
+    html_text += "</body>\n"
+    html_text += "</html>\n"
+    return html_text

--- a/util/testplanner/class_defs.py
+++ b/util/testplanner/class_defs.py
@@ -198,7 +198,7 @@ class Testplan():
                 # Create dummy tests entry for milestone total
                 if totals[ms].tests == []:
                     totals[ms].tests = [{
-                        "name": "TOTAL",
+                        "name": "**TOTAL**",
                         "passing": 0,
                         "total": 0
                     }]
@@ -218,7 +218,7 @@ class Testplan():
                                        desc="Total tests",
                                        milestone=ms,
                                        tests=[{
-                                           "name": "TOTAL",
+                                           "name": "**TOTAL**",
                                            "passing": 0,
                                            "total": 0
                                        }])
@@ -283,20 +283,21 @@ class Testplan():
         '''Print the mapped regression results into a table.
         '''
         self.map_regr_results(regr_results, map_full_testplan)
-        table = [["Milestone", "Name", "Tests", "Results"]]
-        align = ["center", "center", "right", "center"]
+        table = [[
+            "Milestone", "Name", "Tests", "Passing", "Iterations", "Pass Rate"
+        ]]
         for entry in self.entries:
             milestone = entry.milestone
             entry_name = entry.name
             if milestone == "N.A.": milestone = ""
             if entry_name == "N.A.": entry_name = ""
             for test in entry.tests:
-                results_str = str(test["passing"]) + "/" + str(test["total"])
-                table.append(
-                    [milestone, entry_name, test["name"], results_str])
+                pass_rate = test["passing"] / test["total"] * 100
+                pass_rate = "{0:.2f}".format(round(pass_rate, 2))
+                table.append([
+                    milestone, entry_name, test["name"], test["passing"],
+                    test["total"], pass_rate
+                ])
                 milestone = ""
                 entry_name = ""
-        return tabulate(table,
-                        headers="firstrow",
-                        tablefmt="pipe",
-                        colalign=align)
+        return tabulate(table, headers="firstrow", tablefmt="pipe")

--- a/util/uvmdvgen/dv_plan.md.tpl
+++ b/util/uvmdvgen/dv_plan.md.tpl
@@ -21,7 +21,7 @@ ${'##'} Goals
 ${'##'} Current status
 * [Design & verification stage]({{< relref "doc/project/hw_dashboard" >}})
   * [HW development stages]({{< relref "doc/project/hw_stages" >}})
-* DV regression results dashboard (link TBD)
+* [Simulation results](https://reports.opentitan.org/hw/ip/${name}/dv/latest/results.html)
 
 ${'##'} Design features
 For detailed information on ${name.upper()} design features, please see the [${name.upper()} HWIP technical specification]({{< relref "hw/ip/${name}/doc" >}}).


### PR DESCRIPTION
 - In this PR, the results published to the results server is switched
 over from markdown to html directly.
 - css style sheet for some basic decoration is checked in.
 - Uploaded results reuse the same css style that is already uploaded to
 `reports.opentitan.org/css/style.css`
 - This is just an elementary styling - enough to get the results look
 presentable.

In addition, there are few more updates:
- The regression results table is expanded to include # passing, # total 
and the pass rate separately. 
- The history of past regressions are embedded as a section in the
latest results as opposed to being copied over to a separate
history.html
- All DV plan documents are updated to reflect the latest regression
results page correctly
- The results page now also provides a link back to the testplan for
ease of cross referencing the test points in the table.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>