### PR TITLE
[aes/rtl] Refactor RTL, split cipher core from I/O handling

### DIFF
--- a/hw/ip/aes/aes.core
+++ b/hw/ip/aes/aes.core
@@ -14,6 +14,9 @@ filesets:
       - rtl/aes_reg_pkg.sv
       - rtl/aes_reg_top.sv
       - rtl/aes_core.sv
+      - rtl/aes_control.sv
+      - rtl/aes_cipher_core.sv
+      - rtl/aes_cipher_control.sv
       - rtl/aes_sub_bytes.sv
       - rtl/aes_sbox.sv
       - rtl/aes_sbox_lut.sv
@@ -22,7 +25,6 @@ filesets:
       - rtl/aes_mix_columns.sv
       - rtl/aes_mix_single_column.sv
       - rtl/aes_key_expand.sv
-      - rtl/aes_control.sv
       - rtl/aes.sv
     file_type: systemVerilogSource
 

--- a/hw/ip/aes/rtl/aes_cipher_control.sv
+++ b/hw/ip/aes/rtl/aes_cipher_control.sv
@@ -1,0 +1,305 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// AES cipher core control
+//
+// This module controls the AES cipher core including the key expand module.
+
+`include "prim_assert.sv"
+
+module aes_cipher_control (
+  input  logic                    clk_i,
+  input  logic                    rst_ni,
+
+  // Input handshake signals
+  input  logic                    in_valid_i,
+  output logic                    in_ready_o,
+
+  // Output handshake signals
+  output logic                    out_valid_o,
+  input  logic                    out_ready_i,
+
+  // Control and sync signals
+  input  aes_pkg::mode_e          mode_i,
+  input  aes_pkg::key_len_e       key_len_i,
+  input  logic                    start_i,
+  input  logic                    dec_key_gen_i,
+  output logic                    dec_key_gen_o,
+  input  logic                    key_clear_i,
+  output logic                    key_clear_o,
+  input  logic                    data_out_clear_i,
+  output logic                    data_out_clear_o,
+
+  // Control outputs cipher data path
+  output aes_pkg::state_sel_e     state_sel_o,
+  output logic                    state_we_o,
+  output aes_pkg::add_rk_sel_e    add_rk_sel_o,
+
+  // Control outputs key expand data path
+  output aes_pkg::mode_e          key_expand_mode_o,
+  output aes_pkg::key_full_sel_e  key_full_sel_o,
+  output logic                    key_full_we_o,
+  output aes_pkg::key_dec_sel_e   key_dec_sel_o,
+  output logic                    key_dec_we_o,
+  output logic                    key_expand_step_o,
+  output logic                    key_expand_clear_o,
+  output logic [3:0]              key_expand_round_o,
+  output aes_pkg::key_words_sel_e key_words_sel_o,
+  output aes_pkg::round_key_sel_e round_key_sel_o
+);
+
+  import aes_pkg::*;
+
+  // Types
+  typedef enum logic [2:0] {
+    IDLE, INIT, ROUND, FINISH, CLEAR
+  } aes_cipher_ctrl_e;
+
+  aes_cipher_ctrl_e aes_cipher_ctrl_ns, aes_cipher_ctrl_cs;
+
+  // Signals
+  logic [3:0] round_d, round_q;
+  logic [3:0] num_rounds_d, num_rounds_q;
+  logic [3:0] num_rounds_regular;
+  logic       dec_key_gen_d, dec_key_gen_q;
+  logic       key_clear_d, key_clear_q;
+  logic       data_out_clear_d, data_out_clear_q;
+
+  // FSM
+  always_comb begin : aes_cipher_ctrl_fsm
+
+    // Handshake signals
+    in_ready_o         = 1'b0;
+    out_valid_o        = 1'b0;
+
+    // Cipher data path
+    state_sel_o        = STATE_ROUND;
+    state_we_o         = 1'b0;
+    add_rk_sel_o       = ADD_RK_ROUND;
+
+    // Key expand data path
+    key_full_sel_o     = KEY_FULL_ROUND;
+    key_full_we_o      = 1'b0;
+    key_dec_sel_o      = KEY_DEC_EXPAND;
+    key_dec_we_o       = 1'b0;
+    key_expand_step_o  = 1'b0;
+    key_expand_clear_o = 1'b0;
+    key_words_sel_o    = KEY_WORDS_ZERO;
+    round_key_sel_o    = ROUND_KEY_DIRECT;
+
+    // FSM
+    aes_cipher_ctrl_ns = aes_cipher_ctrl_cs;
+    round_d            = round_q;
+    num_rounds_d       = num_rounds_q;
+    dec_key_gen_d      = dec_key_gen_q;
+    key_clear_d        = key_clear_q;
+    data_out_clear_d   = data_out_clear_q;
+
+    unique case (aes_cipher_ctrl_cs)
+
+      IDLE: begin
+        dec_key_gen_d = 1'b0;
+
+        // Signal that we are ready, wait for handshake.
+        in_ready_o = 1'b1;
+        if (in_valid_i) begin
+          if (start_i) begin
+            // Start generation of start key for decryption.
+            dec_key_gen_d = dec_key_gen_i;
+
+            // Load input data to state
+            state_sel_o = dec_key_gen_d ? STATE_CLEAR : STATE_INIT;
+            state_we_o  = 1'b1;
+
+            // Init key expand
+            key_expand_clear_o = 1'b1;
+
+            // Load full key
+            key_full_sel_o = dec_key_gen_d ? KEY_FULL_ENC_INIT :
+                       (mode_i == AES_ENC) ? KEY_FULL_ENC_INIT :
+                                             KEY_FULL_DEC_INIT;
+            key_full_we_o  = 1'b1;
+
+            // Load num_rounds, clear round
+            round_d      = '0;
+            num_rounds_d = (key_len_i == AES_128) ? 4'd10 :
+                           (key_len_i == AES_192) ? 4'd12 :
+                                                    4'd14;
+            aes_cipher_ctrl_ns = INIT;
+          end else if (key_clear_i || data_out_clear_i) begin
+            key_clear_d      = key_clear_i;
+            data_out_clear_d = data_out_clear_i;
+
+            aes_cipher_ctrl_ns = CLEAR;
+          end
+        end
+      end
+
+      INIT: begin
+        // Initial round: just add key to state
+        state_we_o   = ~dec_key_gen_q;
+        add_rk_sel_o = ADD_RK_INIT;
+
+        // Select key words for initial add_round_key
+        key_words_sel_o = dec_key_gen_q                 ? KEY_WORDS_ZERO :
+            (key_len_i == AES_128)                      ? KEY_WORDS_0123 :
+            (key_len_i == AES_192 && mode_i == AES_ENC) ? KEY_WORDS_0123 :
+            (key_len_i == AES_192 && mode_i == AES_DEC) ? KEY_WORDS_2345 :
+            (key_len_i == AES_256 && mode_i == AES_ENC) ? KEY_WORDS_0123 :
+            (key_len_i == AES_256 && mode_i == AES_DEC) ? KEY_WORDS_4567 : KEY_WORDS_ZERO;
+
+        // Make key expand advance - AES-256 has two round keys available right from beginning.
+        if (key_len_i != AES_256) begin
+          key_expand_step_o = 1'b1;
+          key_full_we_o     = 1'b1;
+        end
+
+        aes_cipher_ctrl_ns = ROUND;
+      end
+
+      ROUND: begin
+        // Normal rounds
+        state_we_o = ~dec_key_gen_q;
+
+        // Select key words for add_round_key
+        key_words_sel_o = dec_key_gen_q                 ? KEY_WORDS_ZERO :
+            (key_len_i == AES_128)                      ? KEY_WORDS_0123 :
+            (key_len_i == AES_192 && mode_i == AES_ENC) ? KEY_WORDS_2345 :
+            (key_len_i == AES_192 && mode_i == AES_DEC) ? KEY_WORDS_0123 :
+            (key_len_i == AES_256 && mode_i == AES_ENC) ? KEY_WORDS_4567 :
+            (key_len_i == AES_256 && mode_i == AES_DEC) ? KEY_WORDS_0123 : KEY_WORDS_ZERO;
+
+        // Make key expand advance
+        key_expand_step_o = 1'b1;
+        key_full_we_o     = 1'b1;
+
+        // Select round key: direct or mixed (equivalent inverse cipher)
+        round_key_sel_o = (mode_i == AES_ENC) ? ROUND_KEY_DIRECT : ROUND_KEY_MIXED;
+
+        // Update round
+        round_d = round_q + 4'b1;
+
+        // Are we doing the last regular round?
+        if (round_q == num_rounds_regular) begin
+          aes_cipher_ctrl_ns = FINISH;
+
+          if (dec_key_gen_q) begin
+            // Write decryption key.
+            key_dec_we_o = 1'b1;
+
+            // Indicate that we are done, try to perform the handshake. But we don't wait here
+            // as the decryption key is valid only during one cycle. If we don't get the
+            // handshake now, we will wait in the finish state.
+            out_valid_o = 1'b1;
+            if (out_ready_i) begin
+              // Go to idle state directly.
+              dec_key_gen_d      = 1'b0;
+              aes_cipher_ctrl_ns = IDLE;
+            end
+          end
+        end
+      end
+
+      FINISH: begin
+        // Final round
+
+        // Select key words for add_round_key
+        key_words_sel_o = dec_key_gen_q                 ? KEY_WORDS_ZERO :
+            (key_len_i == AES_128)                      ? KEY_WORDS_0123 :
+            (key_len_i == AES_192 && mode_i == AES_ENC) ? KEY_WORDS_2345 :
+            (key_len_i == AES_192 && mode_i == AES_DEC) ? KEY_WORDS_0123 :
+            (key_len_i == AES_256 && mode_i == AES_ENC) ? KEY_WORDS_4567 :
+            (key_len_i == AES_256 && mode_i == AES_DEC) ? KEY_WORDS_0123 : KEY_WORDS_ZERO;
+
+        // Skip mix_columns
+        add_rk_sel_o = ADD_RK_FINAL;
+
+        // Indicate that we are done, wait for handshake.
+        out_valid_o = 1'b1;
+        if (out_ready_i) begin
+          // We don't need the state anymore, clear it.
+          state_we_o         = 1'b1;
+          state_sel_o        = STATE_CLEAR;
+          // If we were generating the decryption key and didn't get the handshake in the last
+          // regular round, we should clear dec_key_gen now.
+          dec_key_gen_d      = 1'b0;
+          aes_cipher_ctrl_ns = IDLE;
+        end
+      end
+
+      CLEAR: begin
+        if (key_clear_q) begin
+          key_full_sel_o = KEY_FULL_CLEAR;
+          key_full_we_o  = 1'b1;
+          key_dec_sel_o  = KEY_DEC_CLEAR;
+          key_dec_we_o   = 1'b1;
+        end
+        if (data_out_clear_q) begin
+          add_rk_sel_o    = ADD_RK_INIT;
+          key_words_sel_o = KEY_WORDS_ZERO;
+          round_key_sel_o = ROUND_KEY_DIRECT;
+        end
+        // Indicate that we are done, wait for handshake.
+        out_valid_o = 1'b1;
+        if (out_ready_i) begin
+          key_clear_d        = 1'b0;
+          data_out_clear_d   = 1'b0;
+          aes_cipher_ctrl_ns = IDLE;
+        end
+      end
+
+      default: aes_cipher_ctrl_ns = IDLE;
+    endcase
+  end
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : reg_fsm
+    if (!rst_ni) begin
+      aes_cipher_ctrl_cs <= IDLE;
+      round_q            <= '0;
+      num_rounds_q       <= '0;
+      dec_key_gen_q      <= 1'b0;
+      key_clear_q        <= 1'b0;
+      data_out_clear_q   <= 1'b0;
+    end else begin
+      aes_cipher_ctrl_cs <= aes_cipher_ctrl_ns;
+      round_q            <= round_d;
+      num_rounds_q       <= num_rounds_d;
+      dec_key_gen_q      <= dec_key_gen_d;
+      key_clear_q        <= key_clear_d;
+      data_out_clear_q   <= data_out_clear_d;
+    end
+  end
+
+  // Use separate signal for number of regular rounds.
+  assign num_rounds_regular = num_rounds_q - 4'd2;
+
+  // Use separate signals for key expand mode and round.
+  assign key_expand_mode_o  = (dec_key_gen_d || dec_key_gen_q) ? AES_ENC : mode_i;
+  assign key_expand_round_o = round_d;
+
+  // Let the main controller know whate we are doing.
+  assign dec_key_gen_o    = dec_key_gen_q;
+  assign key_clear_o      = key_clear_q;
+  assign data_out_clear_o = data_out_clear_q;
+
+  ////////////////
+  // Assertions //
+  ////////////////
+
+  // Selectors must be known/valid
+  `ASSERT_KNOWN(AesModeKnown, mode_i)
+  `ASSERT(AesKeyLenValid, key_len_i inside {
+      AES_128,
+      AES_192,
+      AES_256
+      })
+  `ASSERT(AesControlStateValid, aes_cipher_ctrl_cs inside {
+      IDLE,
+      INIT,
+      ROUND,
+      FINISH,
+      CLEAR
+      })
+
+endmodule

--- a/hw/ip/aes/rtl/aes_cipher_core.sv
+++ b/hw/ip/aes/rtl/aes_cipher_core.sv
@@ -1,0 +1,281 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// AES cipher core implementation
+//
+// This module contains the AES cipher core including, state register, full key and decryption key
+// registers as well as key expand module and control unit.
+
+`include "prim_assert.sv"
+
+module aes_cipher_core #(
+  parameter bit AES192Enable = 1,
+  parameter     SBoxImpl     = "lut"
+) (
+  input  logic                 clk_i,
+  input  logic                 rst_ni,
+
+  // Input handshake signals
+  input  logic                 in_valid_i,
+  output logic                 in_ready_o,
+
+  // Output handshake signals
+  output logic                 out_valid_o,
+  input  logic                 out_ready_i,
+
+  // Control and sync signals
+  input  aes_pkg::mode_e       mode_i,
+  input  aes_pkg::key_len_e    key_len_i,
+  input  logic                 start_i,
+  input  logic                 dec_key_gen_i,
+  output logic                 dec_key_gen_o,
+  input  logic                 key_clear_i,
+  output logic                 key_clear_o,
+  input  logic                 data_out_clear_i, // Re-use the cipher core muxes.
+  output logic                 data_out_clear_o,
+
+  // I/O data & initial key
+  input  logic [3:0][3:0][7:0] state_init_i,
+  input  logic     [7:0][31:0] key_init_i,
+  output logic [3:0][3:0][7:0] state_o
+);
+
+  import aes_pkg::*;
+
+  // Signals
+  logic [3:0][3:0][7:0] state_d;
+  logic [3:0][3:0][7:0] state_q;
+  logic                 state_we;
+  state_sel_e           state_sel;
+
+  logic [3:0][3:0][7:0] sub_bytes_out;
+  logic [3:0][3:0][7:0] shift_rows_out;
+  logic [3:0][3:0][7:0] mix_columns_out;
+  logic [3:0][3:0][7:0] add_round_key_in;
+  logic [3:0][3:0][7:0] add_round_key_out;
+  add_rk_sel_e          add_round_key_in_sel;
+
+  logic     [7:0][31:0] key_full_d;
+  logic     [7:0][31:0] key_full_q;
+  logic                 key_full_we;
+  key_full_sel_e        key_full_sel;
+  logic     [7:0][31:0] key_dec_d;
+  logic     [7:0][31:0] key_dec_q;
+  logic                 key_dec_we;
+  key_dec_sel_e         key_dec_sel;
+  logic     [7:0][31:0] key_expand_out;
+  mode_e                key_expand_mode;
+  logic                 key_expand_step;
+  logic                 key_expand_clear;
+  logic           [3:0] key_expand_round;
+  key_words_sel_e       key_words_sel;
+  logic     [3:0][31:0] key_words;
+  logic [3:0][3:0][7:0] key_bytes;
+  logic [3:0][3:0][7:0] key_mix_columns_out;
+  logic [3:0][3:0][7:0] round_key;
+  round_key_sel_e       round_key_sel;
+
+  //////////
+  // Data //
+  //////////
+
+  // State registers
+  always_comb begin : state_mux
+    unique case (state_sel)
+      STATE_INIT:  state_d = state_init_i;
+      STATE_ROUND: state_d = add_round_key_out;
+      STATE_CLEAR: state_d = '0;
+      default:     state_d = '0;
+    endcase
+  end
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : state_reg
+    if (!rst_ni) begin
+      state_q <= '0;
+    end else if (state_we) begin
+      state_q <= state_d;
+    end
+  end
+
+  // Cipher data path
+  aes_sub_bytes #(
+    .SBoxImpl ( SBoxImpl )
+  ) aes_sub_bytes (
+    .mode_i ( mode_i        ),
+    .data_i ( state_q       ),
+    .data_o ( sub_bytes_out )
+  );
+
+  aes_shift_rows aes_shift_rows (
+    .mode_i ( mode_i         ),
+    .data_i ( sub_bytes_out  ),
+    .data_o ( shift_rows_out )
+  );
+
+  aes_mix_columns aes_mix_columns (
+    .mode_i ( mode_i          ),
+    .data_i ( shift_rows_out  ),
+    .data_o ( mix_columns_out )
+  );
+
+  always_comb begin : add_round_key_in_mux
+    unique case (add_round_key_in_sel)
+      ADD_RK_INIT:  add_round_key_in = state_q;
+      ADD_RK_ROUND: add_round_key_in = mix_columns_out;
+      ADD_RK_FINAL: add_round_key_in = shift_rows_out;
+      default:      add_round_key_in = state_q;
+    endcase
+  end
+
+  assign add_round_key_out = add_round_key_in ^ round_key;
+
+  /////////
+  // Key //
+  /////////
+
+  // Full Key registers
+  always_comb begin : key_full_mux
+    unique case (key_full_sel)
+      KEY_FULL_ENC_INIT: key_full_d = key_init_i;
+      KEY_FULL_DEC_INIT: key_full_d = key_dec_q;
+      KEY_FULL_ROUND:    key_full_d = key_expand_out;
+      KEY_FULL_CLEAR:    key_full_d = '0;
+      default:           key_full_d = '0;
+    endcase
+  end
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : key_full_reg
+    if (!rst_ni) begin
+      key_full_q <= '0;
+    end else if (key_full_we) begin
+      key_full_q <= key_full_d;
+    end
+  end
+
+  // Decryption Key registers
+  always_comb begin : key_dec_mux
+    unique case (key_dec_sel)
+      KEY_DEC_EXPAND: key_dec_d = key_expand_out;
+      KEY_DEC_CLEAR:  key_dec_d = '0;
+      default:        key_dec_d = '0;
+    endcase
+  end
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : key_dec_reg
+    if (!rst_ni) begin
+      key_dec_q <= '0;
+    end else if (key_dec_we) begin
+      key_dec_q <= key_dec_d;
+    end
+  end
+
+  // Key expand data path
+  aes_key_expand #(
+    .AES192Enable ( AES192Enable ),
+    .SBoxImpl     ( SBoxImpl     )
+  ) aes_key_expand (
+    .clk_i     ( clk_i            ),
+    .rst_ni    ( rst_ni           ),
+    .mode_i    ( key_expand_mode  ),
+    .step_i    ( key_expand_step  ),
+    .clear_i   ( key_expand_clear ),
+    .round_i   ( key_expand_round ),
+    .key_len_i ( key_len_i        ),
+    .key_i     ( key_full_q       ),
+    .key_o     ( key_expand_out   )
+  );
+
+  always_comb begin : key_words_mux
+    unique case (key_words_sel)
+      KEY_WORDS_0123: key_words = key_full_q[3:0];
+      KEY_WORDS_2345: key_words = AES192Enable ? key_full_q[5:2] : '0;
+      KEY_WORDS_4567: key_words = key_full_q[7:4];
+      KEY_WORDS_ZERO: key_words = '0;
+      default:        key_words = '0;
+    endcase
+  end
+
+  // Convert words to bytes (every key word contains one column)
+  assign key_bytes = aes_transpose(key_words);
+
+  aes_mix_columns aes_key_mix_columns (
+    .mode_i ( AES_DEC             ),
+    .data_i ( key_bytes           ),
+    .data_o ( key_mix_columns_out )
+  );
+
+  always_comb begin : round_key_mux
+    unique case (round_key_sel)
+      ROUND_KEY_DIRECT: round_key = key_bytes;
+      ROUND_KEY_MIXED:  round_key = key_mix_columns_out;
+      default:          round_key = key_bytes;
+    endcase
+  end
+
+  /////////////
+  // Control //
+  /////////////
+
+  // Control
+  aes_cipher_control aes_cipher_control (
+    .clk_i                  ( clk_i                ),
+    .rst_ni                 ( rst_ni               ),
+
+    .in_valid_i             ( in_valid_i           ),
+    .in_ready_o             ( in_ready_o           ),
+    .out_valid_o            ( out_valid_o          ),
+    .out_ready_i            ( out_ready_i          ),
+    .mode_i                 ( mode_i               ),
+    .key_len_i              ( key_len_i            ),
+    .start_i                ( start_i              ),
+    .dec_key_gen_i          ( dec_key_gen_i        ),
+    .dec_key_gen_o          ( dec_key_gen_o        ),
+    .key_clear_i            ( key_clear_i          ),
+    .key_clear_o            ( key_clear_o          ),
+    .data_out_clear_i       ( data_out_clear_i     ),
+    .data_out_clear_o       ( data_out_clear_o     ),
+
+    .state_sel_o            ( state_sel            ),
+    .state_we_o             ( state_we             ),
+    .add_rk_sel_o           ( add_round_key_in_sel ),
+    .key_expand_mode_o      ( key_expand_mode      ),
+    .key_full_sel_o         ( key_full_sel         ),
+    .key_full_we_o          ( key_full_we          ),
+    .key_dec_sel_o          ( key_dec_sel          ),
+    .key_dec_we_o           ( key_dec_we           ),
+    .key_expand_step_o      ( key_expand_step      ),
+    .key_expand_clear_o     ( key_expand_clear     ),
+    .key_expand_round_o     ( key_expand_round     ),
+    .key_words_sel_o        ( key_words_sel        ),
+    .round_key_sel_o        ( round_key_sel        )
+  );
+
+  /////////////
+  // Outputs //
+  /////////////
+
+  // The output of the last round is not stored into the state register but forwarded directly.
+  assign state_o = add_round_key_out;
+
+  ////////////////
+  // Assertions //
+  ////////////////
+
+  // Selectors must be known/valid
+  `ASSERT(AesStateSelValid, state_sel inside {
+      STATE_INIT,
+      STATE_ROUND,
+      STATE_CLEAR
+      })
+  `ASSERT(AesAddRKSelValid, add_round_key_in_sel inside {
+      ADD_RK_INIT,
+      ADD_RK_ROUND,
+      ADD_RK_FINAL
+      })
+  `ASSERT_KNOWN(AesKeyFullSelKnown, key_full_sel)
+  `ASSERT_KNOWN(AesKeyDecSelKnown, key_dec_sel)
+  `ASSERT_KNOWN(AesKeyWordsSelKnown, key_words_sel)
+  `ASSERT_KNOWN(AesRoundKeySelKnown, round_key_sel)
+
+endmodule

--- a/hw/ip/aes/rtl/aes_control.sv
+++ b/hw/ip/aes/rtl/aes_control.sv
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// AES control
+// AES main control
+//
+// This module controls the interplay of input/output registers and the AES cipher core.
 
 `include "prim_assert.sv"
 
@@ -12,7 +14,6 @@ module aes_control (
 
   // Main control inputs
   input  aes_pkg::mode_e          mode_i,
-  input  aes_pkg::key_len_e       key_len_i,
   input  logic                    manual_start_trigger_i,
   input  logic                    force_data_overwrite_i,
   input  logic                    start_i,
@@ -24,29 +25,25 @@ module aes_control (
   input  logic [3:0]              data_in_qe_i,
   input  logic [7:0]              key_init_qe_i,
   input  logic [3:0]              data_out_re_i,
-
-  // Control outputs cipher data path
-  output aes_pkg::state_sel_e     state_sel_o,
-  output logic                    state_we_o,
-  output aes_pkg::add_rk_sel_e    add_rk_sel_o,
-
-  // Control outputs key expand data path
-  output aes_pkg::mode_e          key_expand_mode_o,
-  output aes_pkg::key_init_sel_e  key_init_sel_o,
-  output logic [7:0]              key_init_we_o,
-  output aes_pkg::key_full_sel_e  key_full_sel_o,
-  output logic                    key_full_we_o,
-  output aes_pkg::key_dec_sel_e   key_dec_sel_o,
-  output logic                    key_dec_we_o,
-  output logic                    key_expand_step_o,
-  output logic                    key_expand_clear_o,
-  output logic [3:0]              key_expand_round_o,
-  output aes_pkg::key_words_sel_e key_words_sel_o,
-  output aes_pkg::round_key_sel_e round_key_sel_o,
-
-  // Key/data registers
   output logic                    data_in_we_o,
   output logic                    data_out_we_o,
+
+  // Cipher core control and sync
+  output logic                    cipher_in_valid_o,
+  input  logic                    cipher_in_ready_i,
+  input  logic                    cipher_out_valid_i,
+  output logic                    cipher_out_ready_o,
+  output logic                    cipher_start_o,
+  output logic                    cipher_dec_key_gen_o,
+  input  logic                    cipher_dec_key_gen_i,
+  output logic                    cipher_key_clear_o,
+  input  logic                    cipher_key_clear_i,
+  output logic                    cipher_data_out_clear_o,
+  input  logic                    cipher_data_out_clear_i,
+
+  // Initial key registers
+  output aes_pkg::key_init_sel_e  key_init_sel_o,
+  output logic [7:0]              key_init_we_o,
 
   // Trigger register
   output logic                    start_o,
@@ -72,8 +69,8 @@ module aes_control (
   import aes_pkg::*;
 
   // Types
-  typedef enum logic [2:0] {
-    IDLE, INIT, ROUND, FINISH, CLEAR
+  typedef enum logic [1:0] {
+    IDLE, LOAD, WAIT, CLEAR
   } aes_ctrl_e;
 
   aes_ctrl_e aes_ctrl_ns, aes_ctrl_cs;
@@ -92,11 +89,6 @@ module aes_control (
   logic       data_out_read;
   logic       output_valid_q;
 
-  logic [3:0] round_d, round_q;
-  logic [3:0] num_rounds_d, num_rounds_q;
-  logic [3:0] num_rounds_regular;
-  logic       dec_key_gen_d, dec_key_gen_q;
-
   logic       start, finish;
 
   // If not set to manually start, we start once we have valid data available.
@@ -108,22 +100,17 @@ module aes_control (
   // FSM
   always_comb begin : aes_ctrl_fsm
 
-    // Cipher data path
-    state_sel_o  = STATE_ROUND;
-    state_we_o   = 1'b0;
-    add_rk_sel_o = ADD_RK_ROUND;
+    // Cipher core control
+    cipher_in_valid_o       = 1'b0;
+    cipher_out_ready_o      = 1'b0;
+    cipher_start_o          = 1'b0;
+    cipher_dec_key_gen_o    = 1'b0;
+    cipher_key_clear_o      = 1'b0;
+    cipher_data_out_clear_o = 1'b0;
 
-    // Key expand data path
-    key_init_sel_o     = KEY_INIT_INPUT;
-    key_init_we_o      = 8'h00;
-    key_full_sel_o     = KEY_FULL_ROUND;
-    key_full_we_o      = 1'b0;
-    key_dec_sel_o      = KEY_DEC_EXPAND;
-    key_dec_we_o       = 1'b0;
-    key_expand_step_o  = 1'b0;
-    key_expand_clear_o = 1'b0;
-    key_words_sel_o    = KEY_WORDS_ZERO;
-    round_key_sel_o    = ROUND_KEY_DIRECT;
+    // Initial key registers
+    key_init_sel_o = KEY_INIT_INPUT;
+    key_init_we_o  = 8'h00;
 
     // Trigger register control
     start_we_o          = 1'b0;
@@ -145,9 +132,6 @@ module aes_control (
 
     // FSM
     aes_ctrl_ns   = aes_ctrl_cs;
-    round_d       = round_q;
-    num_rounds_d  = num_rounds_q;
-    dec_key_gen_d = dec_key_gen_q;
 
     unique case (aes_ctrl_cs)
 
@@ -157,38 +141,38 @@ module aes_control (
         stall_o       = 1'b0;
         stall_we_o    = 1'b1;
 
-        dec_key_gen_d = 1'b0;
-
         if (start) begin
-          // We got a new initial key, but want to do decryption.
-          // We first must get the start key for decryption.
-          dec_key_gen_d = key_init_new & (mode_i == AES_DEC);
+          cipher_start_o = 1'b1;
+          // We got a new initial key, but want to do decryption. The cipher core must first
+          // generate the start key for decryption.
+          cipher_dec_key_gen_o = key_init_new & (mode_i == AES_DEC);
 
-          // Load input data to state
-          state_sel_o = dec_key_gen_d ? STATE_CLEAR : STATE_INIT;
-          state_we_o  = 1'b1;
+          // We have work for the cipher core, perform handshake.
+          cipher_in_valid_o = 1'b1;
+          if (cipher_in_ready_i) begin
+            idle_o      = 1'b0;
+            idle_we_o   = 1'b1;
+            start_we_o  = ~cipher_dec_key_gen_o;
 
-          // Init key expand
-          key_expand_clear_o = 1'b1;
+            aes_ctrl_ns = LOAD;
+          end
+         end else if (key_clear_i || data_out_clear_i) begin
+          // To clear the output data registers, we re-use the muxing resources of the cipher core.
+          // To clear all key material, some key registers inside the cipher core need to be
+          // cleared.
+          cipher_key_clear_o      = key_clear_i;
+          cipher_data_out_clear_o = data_out_clear_i;
 
-          // Load full key
-          key_full_sel_o = dec_key_gen_d ? KEY_FULL_ENC_INIT :
-                     (mode_i == AES_ENC) ? KEY_FULL_ENC_INIT :
-                                           KEY_FULL_DEC_INIT;
-          key_full_we_o  = 1'b1;
+          // We have work for the cipher core, perform handshake.
+          cipher_in_valid_o = 1'b1;
+          if (cipher_in_ready_i) begin
+            idle_o      = 1'b0;
+            idle_we_o   = 1'b1;
 
-          // Load num_rounds, round
-          round_d      = '0;
-          num_rounds_d = (key_len_i == AES_128) ? 4'd10 :
-                         (key_len_i == AES_192) ? 4'd12 :
-                                                  4'd14;
-
-          idle_o      = 1'b0;
-          idle_we_o   = 1'b1;
-          start_we_o  = 1'b1;
-
-          aes_ctrl_ns = INIT;
-        end else if (key_clear_i || data_in_clear_i || data_out_clear_i) begin
+            aes_ctrl_ns = CLEAR;
+          end
+        end else if (data_in_clear_i) begin
+          // To clear the input data registers, no handshake with the cipher core is needed.
           idle_o      = 1'b0;
           idle_we_o   = 1'b1;
 
@@ -198,118 +182,66 @@ module aes_control (
         key_init_we_o = idle_o ? key_init_qe_i : 8'h00;
       end
 
-      INIT: begin
-        // Initial round: just add key to state
-        state_we_o   = ~dec_key_gen_q;
-        add_rk_sel_o = ADD_RK_INIT;
-
-        // Select key words for initial add_round_key
-        key_words_sel_o = dec_key_gen_q                 ? KEY_WORDS_ZERO :
-            (key_len_i == AES_128)                      ? KEY_WORDS_0123 :
-            (key_len_i == AES_192 && mode_i == AES_ENC) ? KEY_WORDS_0123 :
-            (key_len_i == AES_192 && mode_i == AES_DEC) ? KEY_WORDS_2345 :
-            (key_len_i == AES_256 && mode_i == AES_ENC) ? KEY_WORDS_0123 :
-            (key_len_i == AES_256 && mode_i == AES_DEC) ? KEY_WORDS_4567 : KEY_WORDS_ZERO;
-
-        // Make key expand advance - AES-256 has two round keys available right from beginning
-        if (key_len_i != AES_256) begin
-          key_expand_step_o = 1'b1;
-          key_full_we_o     = 1'b1;
-        end
-
+      LOAD: begin
         // Clear data_in_new, key_init_new
-        data_in_load = ~dec_key_gen_q;
-        dec_key_gen  =  dec_key_gen_q;
+        data_in_load = ~cipher_dec_key_gen_i;
+        dec_key_gen  =  cipher_dec_key_gen_i;
 
-        aes_ctrl_ns = ROUND;
+        aes_ctrl_ns = WAIT;
       end
 
-      ROUND: begin
-        // Normal rounds
-        state_we_o = ~dec_key_gen_q;
+      WAIT: begin
+        // Wait for cipher core to finish.
 
-        // Select key words for add_round_key
-        key_words_sel_o = dec_key_gen_q                 ? KEY_WORDS_ZERO :
-            (key_len_i == AES_128)                      ? KEY_WORDS_0123 :
-            (key_len_i == AES_192 && mode_i == AES_ENC) ? KEY_WORDS_2345 :
-            (key_len_i == AES_192 && mode_i == AES_DEC) ? KEY_WORDS_0123 :
-            (key_len_i == AES_256 && mode_i == AES_ENC) ? KEY_WORDS_4567 :
-            (key_len_i == AES_256 && mode_i == AES_DEC) ? KEY_WORDS_0123 : KEY_WORDS_ZERO;
-
-        // Make key expand advance
-        key_expand_step_o = 1'b1;
-        key_full_we_o     = 1'b1;
-
-        // Select round key: direct or mixed (equivalent inverse cipher)
-        round_key_sel_o = (mode_i == AES_ENC) ? ROUND_KEY_DIRECT : ROUND_KEY_MIXED;
-
-        // Update round
-        round_d = round_q+1;
-
-        // Are we doing the last regular round?
-        if (round_q == num_rounds_regular) begin
-          if (dec_key_gen_q) begin
-            // Write decryption key and finish
-            key_dec_we_o  = 1'b1;
-            dec_key_gen_d = 1'b0;
-            aes_ctrl_ns   = IDLE;
-          end else begin
-            aes_ctrl_ns   = FINISH;
+        if (cipher_dec_key_gen_i) begin
+          // We are ready.
+          cipher_out_ready_o = 1'b1;
+          if (cipher_out_valid_i) begin
+            aes_ctrl_ns      = IDLE;
+          end
+        end else begin
+          // We are ready once the output data registers can be written.
+          stall_o            = !finish;
+          stall_we_o         = 1'b1;
+          cipher_out_ready_o = finish;
+          if (cipher_out_valid_i) begin
+            data_out_we_o    = 1'b1;
+            aes_ctrl_ns      = IDLE;
           end
         end
       end
 
-      FINISH: begin
-        // Final round
-
-        // Select key words for add_round_key
-        key_words_sel_o = dec_key_gen_q                 ? KEY_WORDS_ZERO :
-            (key_len_i == AES_128)                      ? KEY_WORDS_0123 :
-            (key_len_i == AES_192 && mode_i == AES_ENC) ? KEY_WORDS_2345 :
-            (key_len_i == AES_192 && mode_i == AES_DEC) ? KEY_WORDS_0123 :
-            (key_len_i == AES_256 && mode_i == AES_ENC) ? KEY_WORDS_4567 :
-            (key_len_i == AES_256 && mode_i == AES_DEC) ? KEY_WORDS_0123 : KEY_WORDS_ZERO;
-
-        // Skip mix_columns
-        add_rk_sel_o = ADD_RK_FINAL;
-
-        // Write ouput register and clear internal state
-        if (!finish) begin
-          stall_o       = 1'b1;
-          stall_we_o    = 1'b1;
-        end else begin
-          stall_o       = 1'b0;
-          stall_we_o    = 1'b1;
-          data_out_we_o = 1'b1;
-          aes_ctrl_ns   = IDLE;
-          state_we_o    = 1'b1;
-          state_sel_o   = STATE_CLEAR;
-        end
-      end
-
       CLEAR: begin
-        if (key_clear_i) begin
-          key_init_sel_o = KEY_INIT_CLEAR;
-          key_init_we_o  = 8'hFF;
-          key_full_sel_o = KEY_FULL_CLEAR;
-          key_full_we_o  = 1'b1;
-          key_dec_sel_o  = KEY_DEC_CLEAR;
-          key_dec_we_o   = 1'b1;
-          key_clear_we_o = 1'b1;
-        end
+        // The input data registers can be cleared independently of the cipher core.
         if (data_in_clear_i) begin
           data_in_we_o       = 1'b1;
           data_in_clear_we_o = 1'b1;
         end
-        if (data_out_clear_i) begin
-          add_rk_sel_o        = ADD_RK_INIT;
-          key_words_sel_o     = KEY_WORDS_ZERO;
-          round_key_sel_o     = ROUND_KEY_DIRECT;
-          data_out_we_o       = 1'b1;
-          data_out_clear_we_o = 1'b1;
-        end
 
-        aes_ctrl_ns = IDLE;
+        // To clear the output data registers, we re-use the muxing resources of the cipher core.
+        // To clear all key material, some key registers inside the cipher core need to be cleared.
+        if (cipher_key_clear_i || cipher_data_out_clear_i) begin
+
+          // Perform handshake.
+          cipher_out_ready_o = 1'b1;
+          if (cipher_out_valid_i) begin
+
+            if (cipher_key_clear_i) begin
+              key_init_sel_o      = KEY_INIT_CLEAR;
+              key_init_we_o       = 8'hFF;
+              key_clear_we_o      = 1'b1;
+            end
+
+            if (cipher_data_out_clear_i) begin
+              data_out_we_o       = 1'b1;
+              data_out_clear_we_o = 1'b1;
+            end
+            aes_ctrl_ns = IDLE;
+          end
+
+        end else begin
+          aes_ctrl_ns = IDLE;
+        end
       end
 
       default: aes_ctrl_ns = IDLE;
@@ -318,20 +250,11 @@ module aes_control (
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : reg_fsm
     if (!rst_ni) begin
-      aes_ctrl_cs   <= IDLE;
-      round_q       <= '0;
-      num_rounds_q  <= '0;
-      dec_key_gen_q <= 1'b0;
+      aes_ctrl_cs <= IDLE;
     end else begin
-      aes_ctrl_cs   <= aes_ctrl_ns;
-      round_q       <= round_d;
-      num_rounds_q  <= num_rounds_d;
-      dec_key_gen_q <= dec_key_gen_d;
+      aes_ctrl_cs <= aes_ctrl_ns;
     end
   end
-
-  // Use separate signal for number of regular rounds
-  assign num_rounds_regular = num_rounds_q - 4'd2;
 
   // Detect new key, new input, output read
   // Edge detectors are cleared by the FSM
@@ -373,9 +296,6 @@ module aes_control (
   assign input_ready_o     = ~data_in_new;
   assign input_ready_we_o  =  data_in_new | data_in_load | data_in_we_o;
 
-  assign key_expand_mode_o  = (dec_key_gen_d || dec_key_gen_q) ? AES_ENC : mode_i;
-  assign key_expand_round_o = round_d;
-
   // Trigger register, the control only ever clears these
   assign start_o             = 1'b0;
   assign key_clear_o         = 1'b0;
@@ -384,17 +304,6 @@ module aes_control (
 
   // Selectors must be known/valid
   `ASSERT_KNOWN(AesModeKnown, mode_i)
-  `ASSERT(AesKeyLenValid, key_len_i inside {
-      AES_128,
-      AES_192,
-      AES_256
-      })
-  `ASSERT(AesControlStateValid, aes_ctrl_cs inside {
-      IDLE,
-      INIT,
-      ROUND,
-      FINISH,
-      CLEAR
-      })
+  `ASSERT_KNOWN(AesControlStateValid, aes_ctrl_cs)
 
 endmodule

--- a/hw/ip/aes/rtl/aes_core.sv
+++ b/hw/ip/aes/rtl/aes_core.sv
@@ -10,8 +10,8 @@ module aes_core #(
   parameter bit AES192Enable = 1,
   parameter     SBoxImpl     = "lut"
 ) (
-  input                            clk_i,
-  input                            rst_ni,
+  input logic                      clk_i,
+  input logic                      rst_ni,
 
   // Bus Interface
   input  aes_reg_pkg::aes_reg2hw_t reg2hw,
@@ -37,46 +37,29 @@ module aes_core #(
   logic                 force_data_overwrite_q;
 
   logic [3:0][3:0][7:0] state_init;
-  logic [3:0][3:0][7:0] state_d;
-  logic [3:0][3:0][7:0] state_q;
-  logic                 state_we;
-  state_sel_e           state_sel;
-
-  logic [3:0][3:0][7:0] sub_bytes_out;
-  logic [3:0][3:0][7:0] shift_rows_out;
-  logic [3:0][3:0][7:0] mix_columns_out;
-  logic [3:0][3:0][7:0] add_round_key_in;
-  logic [3:0][3:0][7:0] add_round_key_out;
-  add_rk_sel_e          add_round_key_in_sel;
+  logic [3:0][3:0][7:0] state_done;
 
   logic     [7:0][31:0] key_init_d;
   logic     [7:0][31:0] key_init_q;
   logic     [7:0]       key_init_we;
   key_init_sel_e        key_init_sel;
-  logic     [7:0][31:0] key_full_d;
-  logic     [7:0][31:0] key_full_q;
-  logic                 key_full_we;
-  key_full_sel_e        key_full_sel;
-  logic     [7:0][31:0] key_dec_d;
-  logic     [7:0][31:0] key_dec_q;
-  logic                 key_dec_we;
-  key_dec_sel_e         key_dec_sel;
-  logic     [7:0][31:0] key_expand_out;
-  mode_e                key_expand_mode;
-  logic                 key_expand_step;
-  logic                 key_expand_clear;
-  logic           [3:0] key_expand_round;
-  key_words_sel_e       key_words_sel;
-  logic     [3:0][31:0] key_words;
-  logic [3:0][3:0][7:0] key_bytes;
-  logic [3:0][3:0][7:0] key_mix_columns_out;
-  logic [3:0][3:0][7:0] round_key;
-  round_key_sel_e       round_key_sel;
 
   logic     [3:0][31:0] data_out_d;
   logic     [3:0][31:0] data_out_q;
   logic                 data_out_we;
   logic           [3:0] data_out_re;
+
+  logic                 cipher_in_valid;
+  logic                 cipher_in_ready;
+  logic                 cipher_out_valid;
+  logic                 cipher_out_ready;
+  logic                 cipher_start;
+  logic                 cipher_dec_key_gen;
+  logic                 cipher_dec_key_gen_busy;
+  logic                 cipher_key_clear;
+  logic                 cipher_key_clear_busy;
+  logic                 cipher_data_out_clear;
+  logic                 cipher_data_out_clear_busy;
 
   // Unused signals
   logic     [3:0][31:0] unused_data_out_q;
@@ -123,66 +106,12 @@ module aes_core #(
   assign ctrl_qe = reg2hw.ctrl.mode.qe & reg2hw.ctrl.key_len.qe &
       reg2hw.ctrl.manual_start_trigger.qe & reg2hw.ctrl.force_data_overwrite.qe;
 
-  //////////
-  // Data //
-  //////////
+  //////////////////
+  // Data and Key //
+  //////////////////
 
   // Convert input data to state (every input data word contains one state column)
   assign state_init = aes_transpose(data_in);
-
-  // State registers
-  always_comb begin : state_mux
-    unique case (state_sel)
-      STATE_INIT:  state_d = state_init;
-      STATE_ROUND: state_d = add_round_key_out;
-      STATE_CLEAR: state_d = '0;
-      default:     state_d = '0;
-    endcase
-  end
-
-  always_ff @(posedge clk_i or negedge rst_ni) begin : state_reg
-    if (!rst_ni) begin
-      state_q <= '0;
-    end else if (state_we) begin
-      state_q <= state_d;
-    end
-  end
-
-  // Cipher data path
-  aes_sub_bytes #(
-  .SBoxImpl     ( SBoxImpl )
-  ) aes_sub_bytes (
-    .mode_i ( mode_q        ),
-    .data_i ( state_q       ),
-    .data_o ( sub_bytes_out )
-  );
-
-  aes_shift_rows aes_shift_rows (
-    .mode_i ( mode_q         ),
-    .data_i ( sub_bytes_out  ),
-    .data_o ( shift_rows_out )
-  );
-
-  aes_mix_columns aes_mix_columns (
-    .mode_i ( mode_q          ),
-    .data_i ( shift_rows_out  ),
-    .data_o ( mix_columns_out )
-  );
-
-  always_comb begin : add_round_key_in_mux
-    unique case (add_round_key_in_sel)
-      ADD_RK_INIT:  add_round_key_in = state_q;
-      ADD_RK_ROUND: add_round_key_in = mix_columns_out;
-      ADD_RK_FINAL: add_round_key_in = shift_rows_out;
-      default:      add_round_key_in = state_q;
-    endcase
-  end
-
-  assign add_round_key_out = add_round_key_in ^ round_key;
-
-  /////////
-  // Key //
-  /////////
 
   // Initial Key registers
   always_comb begin : key_init_mux
@@ -205,84 +134,36 @@ module aes_core #(
     end
   end
 
-  // Full Key registers
-  always_comb begin : key_full_mux
-    unique case (key_full_sel)
-      KEY_FULL_ENC_INIT: key_full_d = key_init_q;
-      KEY_FULL_DEC_INIT: key_full_d = key_dec_q;
-      KEY_FULL_ROUND:    key_full_d = key_expand_out;
-      KEY_FULL_CLEAR:    key_full_d = '0;
-      default:           key_full_d = '0;
-    endcase
-  end
+  /////////////////
+  // Cipher Core //
+  /////////////////
 
-  always_ff @(posedge clk_i or negedge rst_ni) begin : key_full_reg
-    if (!rst_ni) begin
-      key_full_q <= '0;
-    end else if (key_full_we) begin
-      key_full_q <= key_full_d;
-    end
-  end
+  // Cipher core
+  aes_cipher_core #(
+    .AES192Enable ( AES192Enable ),
+    .SBoxImpl     ( SBoxImpl     )
+  ) aes_cipher_core (
+    .clk_i            ( clk_i                      ),
+    .rst_ni           ( rst_ni                     ),
 
-  // Decryption Key registers
-  always_comb begin : key_dec_mux
-    unique case (key_dec_sel)
-      KEY_DEC_EXPAND: key_dec_d = key_expand_out;
-      KEY_DEC_CLEAR:  key_dec_d = '0;
-      default:        key_dec_d = '0;
-    endcase
-  end
+    .in_valid_i       ( cipher_in_valid            ),
+    .in_ready_o       ( cipher_in_ready            ),
+    .out_valid_o      ( cipher_out_valid           ),
+    .out_ready_i      ( cipher_out_ready           ),
+    .mode_i           ( mode_q                     ),
+    .key_len_i        ( key_len_q                  ),
+    .start_i          ( cipher_start               ),
+    .dec_key_gen_i    ( cipher_dec_key_gen         ),
+    .dec_key_gen_o    ( cipher_dec_key_gen_busy    ),
+    .key_clear_i      ( cipher_key_clear           ),
+    .key_clear_o      ( cipher_key_clear_busy      ),
+    .data_out_clear_i ( cipher_data_out_clear      ),
+    .data_out_clear_o ( cipher_data_out_clear_busy ),
 
-  always_ff @(posedge clk_i or negedge rst_ni) begin : key_dec_reg
-    if (!rst_ni) begin
-      key_dec_q <= '0;
-    end else if (key_dec_we) begin
-      key_dec_q <= key_dec_d;
-    end
-  end
-
-  // Key expand data path
-  aes_key_expand #(
-  .AES192Enable ( AES192Enable ),
-  .SBoxImpl     ( SBoxImpl     )
-  ) aes_key_expand (
-    .clk_i     ( clk_i            ),
-    .rst_ni    ( rst_ni           ),
-    .mode_i    ( key_expand_mode  ),
-    .step_i    ( key_expand_step  ),
-    .clear_i   ( key_expand_clear ),
-    .round_i   ( key_expand_round ),
-    .key_len_i ( key_len_q        ),
-    .key_i     ( key_full_q       ),
-    .key_o     ( key_expand_out   )
+    .state_init_i     ( state_init                 ),
+    .key_init_i       ( key_init_q                 ),
+    .state_o          ( state_done                 )
   );
-
-  always_comb begin : key_words_mux
-    unique case (key_words_sel)
-      KEY_WORDS_0123: key_words = key_full_q[3:0];
-      KEY_WORDS_2345: key_words = AES192Enable ? key_full_q[5:2] : '0;
-      KEY_WORDS_4567: key_words = key_full_q[7:4];
-      KEY_WORDS_ZERO: key_words = '0;
-      default:        key_words = '0;
-    endcase
-  end
-
-  // Convert words to bytes (every key word contains one column)
-  assign key_bytes = aes_transpose(key_words);
-
-  aes_mix_columns aes_key_mix_columns (
-    .mode_i ( AES_DEC             ),
-    .data_i ( key_bytes           ),
-    .data_o ( key_mix_columns_out )
-  );
-
-  always_comb begin : round_key_mux
-    unique case (round_key_sel)
-      ROUND_KEY_DIRECT: round_key = key_bytes;
-      ROUND_KEY_MIXED:  round_key = key_mix_columns_out;
-      default:          round_key = key_bytes;
-    endcase
-  end
 
   /////////////
   // Control //
@@ -290,59 +171,55 @@ module aes_core #(
 
   // Control
   aes_control aes_control (
-    .clk_i                  ( clk_i                              ),
-    .rst_ni                 ( rst_ni                             ),
+    .clk_i                   ( clk_i                            ),
+    .rst_ni                  ( rst_ni                           ),
 
-    .mode_i                 ( mode_q                             ),
-    .key_len_i              ( key_len_q                          ),
-    .manual_start_trigger_i ( manual_start_trigger_q             ),
-    .force_data_overwrite_i ( force_data_overwrite_q             ),
-    .start_i                ( reg2hw.trigger.start.q             ),
-    .key_clear_i            ( reg2hw.trigger.key_clear.q         ),
-    .data_in_clear_i        ( reg2hw.trigger.data_in_clear.q     ),
-    .data_out_clear_i       ( reg2hw.trigger.data_out_clear.q    ),
+    .mode_i                  ( mode_q                           ),
+    .manual_start_trigger_i  ( manual_start_trigger_q           ),
+    .force_data_overwrite_i  ( force_data_overwrite_q           ),
+    .start_i                 ( reg2hw.trigger.start.q           ),
+    .key_clear_i             ( reg2hw.trigger.key_clear.q       ),
+    .data_in_clear_i         ( reg2hw.trigger.data_in_clear.q   ),
+    .data_out_clear_i        ( reg2hw.trigger.data_out_clear.q  ),
 
-    .data_in_qe_i           ( data_in_qe                         ),
-    .key_init_qe_i          ( key_init_qe                        ),
-    .data_out_re_i          ( data_out_re                        ),
+    .data_in_qe_i            ( data_in_qe                       ),
+    .key_init_qe_i           ( key_init_qe                      ),
+    .data_out_re_i           ( data_out_re                      ),
+    .data_in_we_o            ( data_in_we                       ),
+    .data_out_we_o           ( data_out_we                      ),
 
-    .state_sel_o            ( state_sel                          ),
-    .state_we_o             ( state_we                           ),
-    .add_rk_sel_o           ( add_round_key_in_sel               ),
+    .cipher_in_valid_o       ( cipher_in_valid                  ),
+    .cipher_in_ready_i       ( cipher_in_ready                  ),
+    .cipher_out_valid_i      ( cipher_out_valid                 ),
+    .cipher_out_ready_o      ( cipher_out_ready                 ),
+    .cipher_start_o          ( cipher_start                     ),
+    .cipher_dec_key_gen_o    ( cipher_dec_key_gen               ),
+    .cipher_dec_key_gen_i    ( cipher_dec_key_gen_busy          ),
+    .cipher_key_clear_o      ( cipher_key_clear                 ),
+    .cipher_key_clear_i      ( cipher_key_clear_busy            ),
+    .cipher_data_out_clear_o ( cipher_data_out_clear            ),
+    .cipher_data_out_clear_i ( cipher_data_out_clear_busy       ),
 
-    .key_expand_mode_o      ( key_expand_mode                    ),
-    .key_init_sel_o         ( key_init_sel                       ),
-    .key_init_we_o          ( key_init_we                        ),
-    .key_full_sel_o         ( key_full_sel                       ),
-    .key_full_we_o          ( key_full_we                        ),
-    .key_dec_sel_o          ( key_dec_sel                        ),
-    .key_dec_we_o           ( key_dec_we                         ),
-    .key_expand_step_o      ( key_expand_step                    ),
-    .key_expand_clear_o     ( key_expand_clear                   ),
-    .key_expand_round_o     ( key_expand_round                   ),
-    .key_words_sel_o        ( key_words_sel                      ),
-    .round_key_sel_o        ( round_key_sel                      ),
+    .key_init_sel_o          ( key_init_sel                     ),
+    .key_init_we_o           ( key_init_we                      ),
 
-    .data_in_we_o           ( data_in_we                         ),
-    .data_out_we_o          ( data_out_we                        ),
+    .start_o                 ( hw2reg.trigger.start.d           ),
+    .start_we_o              ( hw2reg.trigger.start.de          ),
+    .key_clear_o             ( hw2reg.trigger.key_clear.d       ),
+    .key_clear_we_o          ( hw2reg.trigger.key_clear.de      ),
+    .data_in_clear_o         ( hw2reg.trigger.data_in_clear.d   ),
+    .data_in_clear_we_o      ( hw2reg.trigger.data_in_clear.de  ),
+    .data_out_clear_o        ( hw2reg.trigger.data_out_clear.d  ),
+    .data_out_clear_we_o     ( hw2reg.trigger.data_out_clear.de ),
 
-    .start_o                ( hw2reg.trigger.start.d             ),
-    .start_we_o             ( hw2reg.trigger.start.de            ),
-    .key_clear_o            ( hw2reg.trigger.key_clear.d         ),
-    .key_clear_we_o         ( hw2reg.trigger.key_clear.de        ),
-    .data_in_clear_o        ( hw2reg.trigger.data_in_clear.d     ),
-    .data_in_clear_we_o     ( hw2reg.trigger.data_in_clear.de    ),
-    .data_out_clear_o       ( hw2reg.trigger.data_out_clear.d    ),
-    .data_out_clear_we_o    ( hw2reg.trigger.data_out_clear.de   ),
-
-    .output_valid_o         ( hw2reg.status.output_valid.d       ),
-    .output_valid_we_o      ( hw2reg.status.output_valid.de      ),
-    .input_ready_o          ( hw2reg.status.input_ready.d        ),
-    .input_ready_we_o       ( hw2reg.status.input_ready.de       ),
-    .idle_o                 ( hw2reg.status.idle.d               ),
-    .idle_we_o              ( hw2reg.status.idle.de              ),
-    .stall_o                ( hw2reg.status.stall.d              ),
-    .stall_we_o             ( hw2reg.status.stall.de             )
+    .output_valid_o          ( hw2reg.status.output_valid.d     ),
+    .output_valid_we_o       ( hw2reg.status.output_valid.de    ),
+    .input_ready_o           ( hw2reg.status.input_ready.d      ),
+    .input_ready_we_o        ( hw2reg.status.input_ready.de     ),
+    .idle_o                  ( hw2reg.status.idle.d             ),
+    .idle_we_o               ( hw2reg.status.idle.de            ),
+    .stall_o                 ( hw2reg.status.stall.d            ),
+    .stall_we_o              ( hw2reg.status.stall.de           )
   );
 
   // Input data register clear
@@ -375,7 +252,7 @@ module aes_core #(
   /////////////
 
   // Convert output state to output data (every state column corresponds to one output word)
-  assign data_out_d = aes_transpose(add_round_key_out);
+  assign data_out_d = aes_transpose(state_done);
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : data_out_reg
     if (!rst_ni) begin
@@ -410,26 +287,6 @@ module aes_core #(
   ////////////////
 
   // Selectors must be known/valid
-  `ASSERT_KNOWN(AesModeKnown, mode_q)
-  `ASSERT(AesKeyLenValid, key_len_q inside {
-      AES_128,
-      AES_192,
-      AES_256
-      })
-  `ASSERT(AesStateSelValid, state_sel inside {
-      STATE_INIT,
-      STATE_ROUND,
-      STATE_CLEAR
-      })
-  `ASSERT(AesAddRKSelValid, add_round_key_in_sel inside {
-      ADD_RK_INIT,
-      ADD_RK_ROUND,
-      ADD_RK_FINAL
-      })
   `ASSERT_KNOWN(AesKeyInitSelKnown, key_init_sel)
-  `ASSERT_KNOWN(AesKeyFullSelKnown, key_full_sel)
-  `ASSERT_KNOWN(AesKeyDecSelKnown, key_dec_sel)
-  `ASSERT_KNOWN(AesKeyWordsSelKnown, key_words_sel)
-  `ASSERT_KNOWN(AesRoundKeySelKnown, round_key_sel)
 
 endmodule


### PR DESCRIPTION
This is the first PR in a series of commits refactoring the RTL of the AES unit in preparation for adding other block cipher modes. It contains a single commit which splits out the AES cipher core into a separate module to separate it from the I/O handling and control.

The main changes are:
- Factor out AES cipher core and associated control into a separate module/file `aes_cipher_core.sv`. The previous top-level control in `aes_control.sv` now only deals with the input/output CSRs and with feeding the cipher core.
- Use a valid/ready handshake protocol between the top-level control unit and the cipher core for both inputs and outputs of the cipher core. This makes the top-level control independent from the internal implementation of the cipher core and eases future adaptions on both sides.

The changes are successfully tested using both my scratch Verilator TB and the UVM-based TB in the tree.

What this PR does not contain, but will follow in future PRs:
- Reworking the "mode" signals and enums. These are currently used to control whether the unit does encryption or decryption which might be confusing. The signal controlling encryption/decryption should be called "operation" . "mode" us usually indicating the block cipher mode (ECB, CBC, CFB,...).
- Unifying the FORCE_DATA_OVERWRITE and MANUAL_START_TRIGGER bits of the CONTROL register into a single bit called MANUAL_OPERATION or similar.
- Support for other block cipher modes beyond ECB.

These changes will impact the documentation, the register interface, software and DV. They will thus go into separate PRs.
