### PR TITLE
[CI] Use named Ubuntu image for package/deploy step

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -279,7 +279,7 @@ jobs:
 - job: "deploy_releaseartifacts"
   displayName: "Package and deploy release distribution"
   pool:
-    vmImage: "ubuntu-latest"
+    vmImage: "ubuntu-16.04"
   dependsOn:
     - lint
     - sw_build


### PR DESCRIPTION
The package/deploy step used "ubuntu-latest" as CI image, which doesn't
give reproducible results. Use Ubuntu 16.04 instead, which is our
default image.