### PR TITLE
[aes] Refactor RTL, change programming interface

### DIFF
--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -52,7 +52,7 @@
       name: "DATA_IN",
       desc: '''
         Input Data Registers.
-        If MANUAL_START_TRIGGER=0 (see Control Register), the AES unit automatically starts encryption/decryption after these register have been written.
+        If MANUAL_OPERATION=0 (see Control Register), the AES unit automatically starts encryption/decryption after these register have been written.
         Each register has to be written at least once.
         The order in which the registers are written does not matter.
         Loaded into the internal State register upon starting encryption/decryption of the next block.
@@ -75,7 +75,7 @@
       desc: '''
         Output Data Register.
         Holds the output data produced by the AES unit during the last encryption/decryption operation.
-        If FORCE_DATA_OVERWRITE=0 (see Control Register), the AES unit is stalled when the previous output data has not yet been read and is about to be overwritten.
+        If MANUAL_OPERATION=0 (see Control Register), the AES unit is stalled when the previous output data has not yet been read and is about to be overwritten.
         Each register has to be read at least once.
         The order in which the registers are read does not matter.
       '''
@@ -120,19 +120,13 @@
         '''
       }
       { bits: "4",
-        name: "MANUAL_START_TRIGGER",
+        name: "MANUAL_OPERATION",
         desc:  '''
-          Controls whether the AES unit should automatically start to encrypt/decrypt
-          when it receives new input data (0) or wait for separate trigger signal
-          before starting (1) (see Trigger Register).
-        '''
-      }
-      { bits: "5",
-        name: "FORCE_DATA_OVERWRITE",
-        desc:  '''
-          Control whether the AES unit is stalled during the last
-          encryption/decryption cycle if the previous output data has not yet been
-          read (0) or finishes the operation and overwrites the previous output data (1).
+          Controls whether the AES unit is operated in normal/automatic mode (0) or fully manual mode (1).
+          In automatic mode (0), the AES unit automatically i) starts to encrypt/decrypt when it receives new input data, and ii) stalls during the last encryption/decryption cycle if the previous output data has not yet been read.
+          This is the most efficient mode to operate in.
+          In manual mode (1), the AES unit i) only starts to encrypt/decrypt after receiving a start trigger (see Trigger Register), and ii) overwrites previous output data irrespective of whether it has been read out or not.
+          This mode is useful if software needs full control over the AES unit.
         '''
       }
     ]
@@ -149,7 +143,7 @@
         name: "START",
         desc:  '''
           Keep AES unit paused (0) or trigger the encryption/decryption of one data block (1).
-          This trigger is ignored if MANUAL_START_TRIGGER=0 (see Control Register).
+          This trigger is ignored if MANUAL_OPERATION=0 (see Control Register).
         '''
       }
       { bits: "1",

--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -103,9 +103,9 @@
     hwqe:     "true",
     fields: [
       { bits: "0",
-        name: "MODE",
+        name: "OPERATION",
         desc:  '''
-          Select encryption(0) or decryption(1) operating mode of AES unit.
+          Select encryption(0) or decryption(1) operation of AES unit.
         '''
       }
       { bits: "3:1",

--- a/hw/ip/aes/doc/dv_plan/index.md
+++ b/hw/ip/aes/doc/dv_plan/index.md
@@ -60,7 +60,7 @@ All test sequences are extended from `aes_base_vseq`.
 It provides commonly used handles, variables, functions and tasks that the test sequences can simple use / call.
 Some of the most commonly used tasks / functions are as follows:
 * aes_init:    Configure aes control and can via a knob be set to randomize register content before starting a test.
-* set_mode:    Set AES to encrypt or decrypt.
+* set_op:      Set AES operation to encrypt or decrypt.
 * write_key:   Write initial key to aes init key registers.
 * add_data:    Add the next 128 block to the input registers.
 * read_output:  Poll the status reg for dataready bit and read the result from aes output regs

--- a/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi.c
+++ b/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi.c
@@ -12,7 +12,7 @@
 
 #include "aes_model_dpi.h"
 
-void c_dpi_aes_crypt(const unsigned char impl_i, const unsigned char mode_i,
+void c_dpi_aes_crypt(const unsigned char impl_i, const unsigned char op_i,
                      const svBitVecVal *key_len_i, const svBitVecVal *key_i,
                      const svBitVecVal *data_i, svBitVecVal *data_o) {
   // get input data from simulator
@@ -45,7 +45,7 @@ void c_dpi_aes_crypt(const unsigned char impl_i, const unsigned char mode_i,
   }
 
   if (impl_i == 0) {
-    if (!mode_i) {
+    if (!op_i) {
       aes_encrypt_block(ref_in, key, key_len, ref_out);
     } else {
       aes_decrypt_block(ref_in, key, key_len, ref_out);
@@ -58,7 +58,7 @@ void c_dpi_aes_crypt(const unsigned char impl_i, const unsigned char mode_i,
     // the final spare block produced by crypto_encrypt()
     int len = crypto_encrypt(ref_out, iv, ref_in, 16, key, key_len);
 
-    if (mode_i) {
+    if (op_i) {
       // prepare
       unsigned char *ref_in_crypto =
           (unsigned char *)malloc(num_elem_ref_out * sizeof(unsigned char));
@@ -89,13 +89,13 @@ void c_dpi_aes_crypt(const unsigned char impl_i, const unsigned char mode_i,
   return;
 }
 
-void c_dpi_aes_sub_bytes(const unsigned char mode_i, const svBitVecVal *data_i,
+void c_dpi_aes_sub_bytes(const unsigned char op_i, const svBitVecVal *data_i,
                          svBitVecVal *data_o) {
   // get input data from simulator
   unsigned char *data = aes_data_get(data_i);
 
   // perform sub bytes
-  if (!mode_i) {
+  if (!op_i) {
     aes_sub_bytes(data);
   } else {
     aes_inv_sub_bytes(data);
@@ -107,13 +107,13 @@ void c_dpi_aes_sub_bytes(const unsigned char mode_i, const svBitVecVal *data_i,
   return;
 }
 
-void c_dpi_aes_shift_rows(const unsigned char mode_i, const svBitVecVal *data_i,
+void c_dpi_aes_shift_rows(const unsigned char op_i, const svBitVecVal *data_i,
                           svBitVecVal *data_o) {
   // get input data from simulator
   unsigned char *data = aes_data_get(data_i);
 
   // perform shift rows
-  if (!mode_i) {
+  if (!op_i) {
     aes_shift_rows(data);
   } else {
     aes_inv_shift_rows(data);
@@ -125,13 +125,13 @@ void c_dpi_aes_shift_rows(const unsigned char mode_i, const svBitVecVal *data_i,
   return;
 }
 
-void c_dpi_aes_mix_columns(const unsigned char mode_i,
-                           const svBitVecVal *data_i, svBitVecVal *data_o) {
+void c_dpi_aes_mix_columns(const unsigned char op_i, const svBitVecVal *data_i,
+                           svBitVecVal *data_o) {
   // get input data from simulator
   unsigned char *data = aes_data_get(data_i);
 
   // perform mix columns
-  if (!mode_i) {
+  if (!op_i) {
     aes_mix_columns(data);
   } else {
     aes_inv_mix_columns(data);
@@ -143,7 +143,7 @@ void c_dpi_aes_mix_columns(const unsigned char mode_i,
   return;
 }
 
-void c_dpi_aes_key_expand(const unsigned char mode_i, const svBitVecVal *rcon_i,
+void c_dpi_aes_key_expand(const unsigned char op_i, const svBitVecVal *rcon_i,
                           const svBitVecVal *round_i,
                           const svBitVecVal *key_len_i,
                           const svBitVecVal *key_i, svBitVecVal *key_o) {
@@ -165,7 +165,7 @@ void c_dpi_aes_key_expand(const unsigned char mode_i, const svBitVecVal *rcon_i,
   }
 
   // perform key expand
-  if (!mode_i) {
+  if (!op_i) {
     aes_rcon_prev(&rcon, key_len);
     aes_key_expand(round_key, key, key_len, &rcon, rnd);
   } else {

--- a/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi.h
+++ b/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi.h
@@ -15,57 +15,57 @@ extern "C" {
  * Perform encryption/decryption of one block.
  *
  * @param  impl_i    Select reference impl.: 0 = C model, 1 = OpenSSL/BoringSSL
- * @param  mode_i    Operation mode: 0 = encryption, 1 = decryption
+ * @param  op_i      Operation: 0 = encrypt, 1 = decrypt
  * @param  key_len_i Key length: 3'b001 = 128b, 3'b010 = 192b, 3'b100 = 256b
  * @param  key_i     Full input key
  * @param  data_i    Input data, 2D state matrix (3D packed array in SV)
  * @param  data_o    Output data, 2D state matrix (3D packed array in SV)
  */
-void c_dpi_aes_crypt(const unsigned char impl_i, const unsigned char mode_i,
+void c_dpi_aes_crypt(const unsigned char impl_i, const unsigned char op_i,
                      const svBitVecVal *key_len_i, const svBitVecVal *key_i,
                      const svBitVecVal *data_i, svBitVecVal *data_o);
 
 /**
  * Perform sub bytes operation during encryption/decryption.
  *
- * @param  mode_i Operation mode: 0 = encryption, 1 = decryption
+ * @param  op_i   Operation: 0 = encrypt, 1 = decrypt
  * @param  data_i Input data
  * @param  data_o Output data
  */
-void c_dpi_aes_sub_bytes(const unsigned char mode_i, const svBitVecVal *data_i,
+void c_dpi_aes_sub_bytes(const unsigned char op_i, const svBitVecVal *data_i,
                          svBitVecVal *data_o);
 
 /**
  * Perform shift rows operation during encryption/decryption.
  *
- * @param  mode_i Operation mode: 0 = encryption, 1 = decryption
+ * @param  op_i   Operation: 0 = encrypt, 1 = decrypt
  * @param  data_i Input data
  * @param  data_o Output data
  */
-void c_dpi_aes_shift_rows(const unsigned char mode_i, const svBitVecVal *data_i,
+void c_dpi_aes_shift_rows(const unsigned char op_i, const svBitVecVal *data_i,
                           svBitVecVal *data_o);
 
 /**
  * Perform mix columns operation during encryption/decryption.
  *
- * @param  mode_i Operation mode: 0 = encryption, 1 = decryption
+ * @param  op_i   Operation: 0 = encrypt, 1 = decrypt
  * @param  data_i Input data
  * @param  data_o Output data
  */
-void c_dpi_aes_mix_columns(const unsigned char mode_i,
-                           const svBitVecVal *data_i, svBitVecVal *data_o);
+void c_dpi_aes_mix_columns(const unsigned char op_i, const svBitVecVal *data_i,
+                           svBitVecVal *data_o);
 
 /**
  * Generate full key for next round during encryption/decryption.
  *
- * @param  mode_i    Operation mode: 0 = encryption, 1 = decryption
+ * @param  op_i      Operation: 0 = encrypt, 1 = decrypt
  * @param  rcon_old  Previous rcon (updates intenally before being used)
  * @param  round_i   Round index
  * @param  key_len_i Key length: 3'b001 = 128b, 3'b010 = 192b, 3'b100 = 256b
  * @param  key_i     Full input key
  * @param  key_o     Full output key
  */
-void c_dpi_aes_key_expand(const unsigned char mode_i, const svBitVecVal *rcon_i,
+void c_dpi_aes_key_expand(const unsigned char op_i, const svBitVecVal *rcon_i,
                           const svBitVecVal *round_i,
                           const svBitVecVal *key_len_i,
                           const svBitVecVal *key_i, svBitVecVal *key_o);

--- a/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi_pkg.sv
+++ b/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi_pkg.sv
@@ -8,7 +8,7 @@ package aes_model_dpi_pkg;
   // DPI-C imports
   import "DPI-C" context function void c_dpi_aes_crypt(
     input  bit                impl_i,
-    input  bit                mode_i,
+    input  bit                op_i,
     input  bit          [2:0] key_len_i,
     input  bit    [7:0][31:0] key_i,
     input  bit[3:0][3:0][7:0] data_i,
@@ -16,25 +16,25 @@ package aes_model_dpi_pkg;
   );
 
   import "DPI-C" context function void c_dpi_aes_sub_bytes(
-    input  bit                mode_i,
+    input  bit                op_i,
     input  bit[3:0][3:0][7:0] data_i,
     output bit[3:0][3:0][7:0] data_o
   );
 
   import "DPI-C" context function void c_dpi_aes_shift_rows(
-    input  bit                mode_i,
+    input  bit                op_i,
     input  bit[3:0][3:0][7:0] data_i,
     output bit[3:0][3:0][7:0] data_o
   );
 
   import "DPI-C" context function void c_dpi_aes_mix_columns(
-    input  bit                mode_i,
+    input  bit                op_i,
     input  bit[3:0][3:0][7:0] data_i,
     output bit[3:0][3:0][7:0] data_o
   );
 
   import "DPI-C" context function void c_dpi_aes_key_expand(
-    input  bit            mode_i,
+    input  bit            op_i,
     input  bit      [7:0] rcon_i,
     input  bit      [3:0] round_i,
     input  bit      [2:0] key_len_i,
@@ -47,7 +47,7 @@ package aes_model_dpi_pkg;
   // this ensures that RTL and refence models have same input and output format.
   function automatic void sv_dpi_aes_crypt(
     input  bit             impl_i,
-    input  bit             mode_i,
+    input  bit             op_i,
     input  bit       [2:0] key_len_i,
     input  bit [7:0][31:0] key_i,
     input  bit [3:0][31:0] data_i,
@@ -55,7 +55,7 @@ package aes_model_dpi_pkg;
 
     bit [3:0][3:0][7:0] data_in, data_out;
     data_in = aes_transpose(data_i);
-    c_dpi_aes_crypt(impl_i, mode_i, key_len_i, key_i, data_in, data_out);
+    c_dpi_aes_crypt(impl_i, op_i, key_len_i, key_i, data_in, data_out);
     data_o  = aes_transpose(data_out);
     return;
   endfunction

--- a/hw/ip/aes/dv/env/aes_scoreboard.sv
+++ b/hw/ip/aes/dv/env/aes_scoreboard.sv
@@ -66,7 +66,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
       case (csr.get_name())
         // add individual case item for each csr
         "ctrl": begin
-          {dut_item.allow_data_ovrwrt, dut_item.man_trigger,dut_item.key_size,dut_item.mode}
+          {dut_item.allow_data_ovrwrt, dut_item.man_trigger,dut_item.key_size,dut_item.operation}
           = item.a_data[5:0];
         end
         "key0": begin
@@ -192,7 +192,8 @@ class aes_scoreboard extends cip_base_scoreboard #(
       ref_fifo.get(c_item );
       `uvm_info(`gfn, $sformatf("\n\t ----| GOT item "), UVM_HIGH)
 
-      sv_dpi_aes_crypt(1'b0, c_item.mode, c_item.key_size, c_item.key, c_item.data_in, c_item.data_out);
+      sv_dpi_aes_crypt(1'b0, c_item.operation, c_item.key_size, c_item.key, c_item.data_in,
+          c_item.data_out);
          `uvm_info(`gfn, $sformatf("\n\t ----| printing C MODEL %s", c_item.convert2string() )
                    , UVM_HIGH)
 

--- a/hw/ip/aes/dv/env/aes_seq_item.sv
+++ b/hw/ip/aes/dv/env/aes_seq_item.sv
@@ -12,7 +12,7 @@ class aes_seq_item extends uvm_sequence_item;
 
 
   // randomized values //
-  rand bit                                 mode; // TODO implement this as enum
+  rand bit                                 operation; // TODO implement this as enum
   // 0: auto start, 1: wait for start
   rand bit                                 man_trigger;
   // 0: output data cannot be overwritten
@@ -77,7 +77,7 @@ class aes_seq_item extends uvm_sequence_item;
              // key len 0: 128, 1: 192, 2: 256 3: NOT VALID
   }
 
-  constraint c_mode_reg {mode == 0; man_trigger == 0; allow_data_ovrwrt == 0; }
+  constraint c_operation_reg {operation == 0; man_trigger == 0; allow_data_ovrwrt == 0; }
 
   function void post_randomize();
     if(key_mask) begin
@@ -109,11 +109,11 @@ class aes_seq_item extends uvm_sequence_item;
       return;
     end
     super.do_copy(rhs);
-    mode     = rhs_.mode;
-    data_in  = rhs_.data_in;
-    key      = rhs_.key;
-    key_size = rhs_.key_size;
-    data_out = rhs_.data_out;
+    operation = rhs_.operation;
+    data_in   = rhs_.data_in;
+    key       = rhs_.key;
+    key_size  = rhs_.key_size;
+    data_out  = rhs_.data_out;
   endfunction // copy
 
 
@@ -127,10 +127,10 @@ virtual function bit do_compare(uvm_object rhs, uvm_comparer comparer);
   end
 
 return(super.do_compare(rhs,comparer) &&
-  (mode     == rhs_.mode) &&
-  (data_in  == rhs_.data_in) &&
-  (key      == rhs_.key) &&
-  (data_out == rhs_.data_out) );
+  (operation == rhs_.operation) &&
+  (data_in   == rhs_.data_in) &&
+  (key       == rhs_.key) &&
+  (data_out  == rhs_.data_out) );
 endfunction // compare
 
 
@@ -141,7 +141,7 @@ virtual function string convert2string();
   str = {str,  $psprintf("\n\t ----| AES SEQUENCE ITEM                                  |----\t ")
         };
   str = {str,  $psprintf("\n\t ----| Mode:    \t %s                          |----\t ",
-        (mode==1'b0) ? "ENCRYPT" : "DECRYPT" ) };
+        (operation==1'b0) ? "ENCRYPT" : "DECRYPT" ) };
   str = {str,  $psprintf("\n\t ----| Key size:    \t %s                             |----\t ",
          (key_size==3'b001) ? "128b" : (key_size == 3'b010) ? "192b" : "256b") };
   str = {str,  $psprintf("\n\t ----| Key:         \t ") };

--- a/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
@@ -43,8 +43,7 @@ class aes_base_vseq extends cip_base_vseq #(
     // initialize control register
     aes_ctrl[0]   = 0;        // set to encryption
     aes_ctrl[3:1] = 3'b001;   // set to 128b key
-    aes_ctrl[4]   = 0;        // start encryption automaticaly
-    aes_ctrl[5]   = 0;        // don't overwrite output reg.
+    aes_ctrl[4]   = 0;        // start encryption automatically, don't overwrite output reg
     csr_wr(.csr(ral.ctrl), .value(aes_ctrl));
     csr_wr(.csr(ral.trigger), .value(aes_trigger));
   endtask
@@ -62,14 +61,8 @@ class aes_base_vseq extends cip_base_vseq #(
   endtask
 
 
-  virtual task set_trigger(bit trigger);
-    ral.ctrl.manual_start_trigger.set(trigger);
-    csr_update(.csr(ral.ctrl));
-  endtask
-
-
-  virtual task set_force_overwrite(bit f_ovrwrt);
-    ral.ctrl.force_data_overwrite.set(f_ovrwrt);
+  virtual task set_manual_operation(bit manual_operation);
+    ral.ctrl.manual_operation.set(manual_operation);
     csr_update(.csr(ral.ctrl));
   endtask
 

--- a/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
@@ -50,8 +50,8 @@ class aes_base_vseq extends cip_base_vseq #(
   endtask
 
 
-  virtual task set_mode(bit mode);
-    ral.ctrl.mode.set(mode);
+  virtual task set_operation(bit operation);
+    ral.ctrl.operation.set(operation);
     csr_update(.csr(ral.ctrl));
   endtask
 

--- a/hw/ip/aes/dv/env/seq_lib/aes_sanity_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_sanity_vseq.sv
@@ -13,7 +13,7 @@
     `uvm_info(`gfn, $sformatf("STARTING AES SEQUENCE"), UVM_LOW);
 
     `DV_CHECK_RANDOMIZE_WITH_FATAL(aes_item, key_size == 3'b001;)
-    set_mode(aes_item.mode);
+    set_operation(aes_item.operation);
     set_key_len(aes_item.key_size);
     // add key
     write_key(aes_item.key);

--- a/hw/ip/aes/dv/env/seq_lib/aes_wake_up_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_wake_up_vseq.sv
@@ -27,9 +27,9 @@ class aes_wake_up_vseq extends aes_base_vseq;
     `DV_CHECK_RANDOMIZE_FATAL(this)
     `uvm_info(`gfn, $sformatf("running aes sanity sequence"), UVM_LOW)
 
-    `uvm_info(`gfn, $sformatf(" \n\t ---|setting mode to encrypt"), UVM_LOW)
-    // set mode to encrypt
-    set_mode(ENCRYPT);
+    `uvm_info(`gfn, $sformatf(" \n\t ---|setting operation to encrypt"), UVM_LOW)
+    // set operation to encrypt
+    set_operation(ENCRYPT);
 
 
     `uvm_info(`gfn, $sformatf(" \n\t ---| WRITING INIT KEY  %02h", init_key), UVM_LOW)
@@ -54,7 +54,7 @@ class aes_wake_up_vseq extends aes_base_vseq;
     cfg.clk_rst_vif.wait_clks(20);
 
     // set aes to decrypt
-    set_mode(DECRYPT);
+    set_operation(DECRYPT);
     cfg.clk_rst_vif.wait_clks(20);
     `uvm_info(`gfn, $sformatf("\n\t ---|WRITING INIT KEY FOR DECRYPT: %02h", init_key), UVM_LOW)
     write_key(init_key);

--- a/hw/ip/aes/rtl/aes_cipher_core.sv
+++ b/hw/ip/aes/rtl/aes_cipher_core.sv
@@ -25,7 +25,7 @@ module aes_cipher_core #(
   input  logic                 out_ready_i,
 
   // Control and sync signals
-  input  aes_pkg::mode_e       mode_i,
+  input  aes_pkg::ciph_op_e    op_i,
   input  aes_pkg::key_len_e    key_len_i,
   input  logic                 start_i,
   input  logic                 dec_key_gen_i,
@@ -65,7 +65,7 @@ module aes_cipher_core #(
   logic                 key_dec_we;
   key_dec_sel_e         key_dec_sel;
   logic     [7:0][31:0] key_expand_out;
-  mode_e                key_expand_mode;
+  ciph_op_e             key_expand_op;
   logic                 key_expand_step;
   logic                 key_expand_clear;
   logic           [3:0] key_expand_round;
@@ -102,19 +102,19 @@ module aes_cipher_core #(
   aes_sub_bytes #(
     .SBoxImpl ( SBoxImpl )
   ) aes_sub_bytes (
-    .mode_i ( mode_i        ),
+    .op_i   ( op_i          ),
     .data_i ( state_q       ),
     .data_o ( sub_bytes_out )
   );
 
   aes_shift_rows aes_shift_rows (
-    .mode_i ( mode_i         ),
+    .op_i   ( op_i           ),
     .data_i ( sub_bytes_out  ),
     .data_o ( shift_rows_out )
   );
 
   aes_mix_columns aes_mix_columns (
-    .mode_i ( mode_i          ),
+    .op_i   ( op_i            ),
     .data_i ( shift_rows_out  ),
     .data_o ( mix_columns_out )
   );
@@ -177,7 +177,7 @@ module aes_cipher_core #(
   ) aes_key_expand (
     .clk_i     ( clk_i            ),
     .rst_ni    ( rst_ni           ),
-    .mode_i    ( key_expand_mode  ),
+    .op_i      ( key_expand_op    ),
     .step_i    ( key_expand_step  ),
     .clear_i   ( key_expand_clear ),
     .round_i   ( key_expand_round ),
@@ -200,7 +200,7 @@ module aes_cipher_core #(
   assign key_bytes = aes_transpose(key_words);
 
   aes_mix_columns aes_key_mix_columns (
-    .mode_i ( AES_DEC             ),
+    .op_i   ( CIPH_INV            ),
     .data_i ( key_bytes           ),
     .data_o ( key_mix_columns_out )
   );
@@ -226,7 +226,7 @@ module aes_cipher_core #(
     .in_ready_o             ( in_ready_o           ),
     .out_valid_o            ( out_valid_o          ),
     .out_ready_i            ( out_ready_i          ),
-    .mode_i                 ( mode_i               ),
+    .op_i                   ( op_i                 ),
     .key_len_i              ( key_len_i            ),
     .start_i                ( start_i              ),
     .dec_key_gen_i          ( dec_key_gen_i        ),
@@ -239,7 +239,7 @@ module aes_cipher_core #(
     .state_sel_o            ( state_sel            ),
     .state_we_o             ( state_we             ),
     .add_rk_sel_o           ( add_round_key_in_sel ),
-    .key_expand_mode_o      ( key_expand_mode      ),
+    .key_expand_op_o        ( key_expand_op        ),
     .key_full_sel_o         ( key_full_sel         ),
     .key_full_we_o          ( key_full_we          ),
     .key_dec_sel_o          ( key_dec_sel          ),

--- a/hw/ip/aes/rtl/aes_control.sv
+++ b/hw/ip/aes/rtl/aes_control.sv
@@ -14,8 +14,7 @@ module aes_control (
 
   // Main control inputs
   input  aes_pkg::ciph_op_e       cipher_op_i,
-  input  logic                    manual_start_trigger_i,
-  input  logic                    force_data_overwrite_i,
+  input  logic                    manual_operation_i,
   input  logic                    start_i,
   input  logic                    key_clear_i,
   input  logic                    data_in_clear_i,
@@ -92,10 +91,10 @@ module aes_control (
   logic       start, finish;
 
   // If not set to manually start, we start once we have valid data available.
-  assign start = manual_start_trigger_i ? start_i : data_in_new;
+  assign start = manual_operation_i ? start_i : data_in_new;
 
   // If not set to overwrite data, we wait for previous output data to be read.
-  assign finish = force_data_overwrite_i ? 1'b1 : ~output_valid_q;
+  assign finish = manual_operation_i ? 1'b1 : ~output_valid_q;
 
   // FSM
   always_comb begin : aes_ctrl_fsm

--- a/hw/ip/aes/rtl/aes_control.sv
+++ b/hw/ip/aes/rtl/aes_control.sv
@@ -13,7 +13,7 @@ module aes_control (
   input  logic                    rst_ni,
 
   // Main control inputs
-  input  aes_pkg::mode_e          mode_i,
+  input  aes_pkg::ciph_op_e       cipher_op_i,
   input  logic                    manual_start_trigger_i,
   input  logic                    force_data_overwrite_i,
   input  logic                    start_i,
@@ -145,7 +145,7 @@ module aes_control (
           cipher_start_o = 1'b1;
           // We got a new initial key, but want to do decryption. The cipher core must first
           // generate the start key for decryption.
-          cipher_dec_key_gen_o = key_init_new & (mode_i == AES_DEC);
+          cipher_dec_key_gen_o = key_init_new & (cipher_op_i == CIPH_INV);
 
           // We have work for the cipher core, perform handshake.
           cipher_in_valid_o = 1'b1;
@@ -303,7 +303,7 @@ module aes_control (
   assign data_out_clear_o    = 1'b0;
 
   // Selectors must be known/valid
-  `ASSERT_KNOWN(AesModeKnown, mode_i)
+  `ASSERT_KNOWN(AesCiphOpKnown, cipher_op_i)
   `ASSERT_KNOWN(AesControlStateValid, aes_ctrl_cs)
 
 endmodule

--- a/hw/ip/aes/rtl/aes_mix_columns.sv
+++ b/hw/ip/aes/rtl/aes_mix_columns.sv
@@ -5,7 +5,7 @@
 // AES MixColumns
 
 module aes_mix_columns (
-  input  aes_pkg::mode_e       mode_i,
+  input  aes_pkg::ciph_op_e    op_i,
   input  logic [3:0][3:0][7:0] data_i,
   output logic [3:0][3:0][7:0] data_o
 );
@@ -21,7 +21,7 @@ module aes_mix_columns (
   // Individually mix columns
   for (genvar i = 0; i < 4; i++) begin : gen_mix_column
     aes_mix_single_column aes_mix_column_i (
-      .mode_i ( mode_i               ),
+      .op_i   ( op_i                 ),
       .data_i ( data_i_transposed[i] ),
       .data_o ( data_o_transposed[i] )
     );

--- a/hw/ip/aes/rtl/aes_mix_single_column.sv
+++ b/hw/ip/aes/rtl/aes_mix_single_column.sv
@@ -8,9 +8,9 @@
 // Satoh et al., "A Compact Rijndael Hardware Architecture with S-Box Optimization"
 
 module aes_mix_single_column (
-  input  aes_pkg::mode_e  mode_i,
-  input  logic [3:0][7:0] data_i,
-  output logic [3:0][7:0] data_o
+  input  aes_pkg::ciph_op_e op_i,
+  input  logic [3:0][7:0]   data_i,
+  output logic [3:0][7:0]   data_o
 );
 
   import aes_pkg::*;
@@ -56,8 +56,8 @@ module aes_mix_single_column (
   assign z[1] = y2 ^ y[1];
 
   // Mux z
-  assign z_muxed[0] = (mode_i == AES_ENC) ? 8'b0 : z[0];
-  assign z_muxed[1] = (mode_i == AES_ENC) ? 8'b0 : z[1];
+  assign z_muxed[0] = (op_i == CIPH_FWD) ? 8'b0 : z[0];
+  assign z_muxed[1] = (op_i == CIPH_FWD) ? 8'b0 : z[1];
 
   // Drive outputs
   assign data_o[0] = data_i[1] ^ x_mul2[3] ^ x[1] ^ z_muxed[1];

--- a/hw/ip/aes/rtl/aes_pkg.sv
+++ b/hw/ip/aes/rtl/aes_pkg.sv
@@ -9,7 +9,12 @@ package aes_pkg;
 typedef enum logic {
   AES_ENC = 1'b0,
   AES_DEC = 1'b1
-} mode_e;
+} aes_op_e;
+
+typedef enum logic {
+  CIPH_FWD = 1'b0,
+  CIPH_INV = 1'b1
+} ciph_op_e;
 
 typedef enum logic [2:0] {
   AES_128 = 3'b001,

--- a/hw/ip/aes/rtl/aes_reg_pkg.sv
+++ b/hw/ip/aes/rtl/aes_reg_pkg.sv
@@ -32,7 +32,7 @@ package aes_reg_pkg;
     struct packed {
       logic        q;
       logic        qe;
-    } mode;
+    } operation;
     struct packed {
       logic [2:0]  q;
       logic        qe;
@@ -79,7 +79,7 @@ package aes_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        d;
-    } mode;
+    } operation;
     struct packed {
       logic [2:0]  d;
     } key_len;

--- a/hw/ip/aes/rtl/aes_reg_pkg.sv
+++ b/hw/ip/aes/rtl/aes_reg_pkg.sv
@@ -40,11 +40,7 @@ package aes_reg_pkg;
     struct packed {
       logic        q;
       logic        qe;
-    } manual_start_trigger;
-    struct packed {
-      logic        q;
-      logic        qe;
-    } force_data_overwrite;
+    } manual_operation;
   } aes_reg2hw_ctrl_reg_t;
 
   typedef struct packed {
@@ -85,10 +81,7 @@ package aes_reg_pkg;
     } key_len;
     struct packed {
       logic        d;
-    } manual_start_trigger;
-    struct packed {
-      logic        d;
-    } force_data_overwrite;
+    } manual_operation;
   } aes_hw2reg_ctrl_reg_t;
 
   typedef struct packed {
@@ -134,10 +127,10 @@ package aes_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    aes_reg2hw_key_mreg_t [7:0] key; // [541:278]
-    aes_reg2hw_data_in_mreg_t [3:0] data_in; // [277:146]
-    aes_reg2hw_data_out_mreg_t [3:0] data_out; // [145:14]
-    aes_reg2hw_ctrl_reg_t ctrl; // [13:4]
+    aes_reg2hw_key_mreg_t [7:0] key; // [539:276]
+    aes_reg2hw_data_in_mreg_t [3:0] data_in; // [275:144]
+    aes_reg2hw_data_out_mreg_t [3:0] data_out; // [143:12]
+    aes_reg2hw_ctrl_reg_t ctrl; // [11:4]
     aes_reg2hw_trigger_reg_t trigger; // [3:0]
   } aes_reg2hw_t;
 
@@ -145,12 +138,12 @@ package aes_reg_pkg;
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    aes_hw2reg_key_mreg_t [7:0] key; // [537:282]
-    aes_hw2reg_data_in_mreg_t [3:0] data_in; // [281:150]
-    aes_hw2reg_data_out_mreg_t [3:0] data_out; // [149:22]
-    aes_hw2reg_ctrl_reg_t ctrl; // [21:12]
-    aes_hw2reg_trigger_reg_t trigger; // [11:8]
-    aes_hw2reg_status_reg_t status; // [7:8]
+    aes_hw2reg_key_mreg_t [7:0] key; // [536:281]
+    aes_hw2reg_data_in_mreg_t [3:0] data_in; // [280:149]
+    aes_hw2reg_data_out_mreg_t [3:0] data_out; // [148:21]
+    aes_hw2reg_ctrl_reg_t ctrl; // [20:13]
+    aes_hw2reg_trigger_reg_t trigger; // [12:9]
+    aes_hw2reg_status_reg_t status; // [8:9]
   } aes_hw2reg_t;
 
   // Register Address

--- a/hw/ip/aes/rtl/aes_reg_top.sv
+++ b/hw/ip/aes/rtl/aes_reg_top.sv
@@ -103,10 +103,10 @@ module aes_reg_top (
   logic data_out2_re;
   logic [31:0] data_out3_qs;
   logic data_out3_re;
-  logic ctrl_mode_qs;
-  logic ctrl_mode_wd;
-  logic ctrl_mode_we;
-  logic ctrl_mode_re;
+  logic ctrl_operation_qs;
+  logic ctrl_operation_wd;
+  logic ctrl_operation_we;
+  logic ctrl_operation_re;
   logic [2:0] ctrl_key_len_qs;
   logic [2:0] ctrl_key_len_wd;
   logic ctrl_key_len_we;
@@ -437,18 +437,18 @@ module aes_reg_top (
 
   // R[ctrl]: V(True)
 
-  //   F[mode]: 0:0
+  //   F[operation]: 0:0
   prim_subreg_ext #(
     .DW    (1)
-  ) u_ctrl_mode (
-    .re     (ctrl_mode_re),
-    .we     (ctrl_mode_we),
-    .wd     (ctrl_mode_wd),
-    .d      (hw2reg.ctrl.mode.d),
+  ) u_ctrl_operation (
+    .re     (ctrl_operation_re),
+    .we     (ctrl_operation_we),
+    .wd     (ctrl_operation_wd),
+    .d      (hw2reg.ctrl.operation.d),
     .qre    (),
-    .qe     (reg2hw.ctrl.mode.qe),
-    .q      (reg2hw.ctrl.mode.q ),
-    .qs     (ctrl_mode_qs)
+    .qe     (reg2hw.ctrl.operation.qe),
+    .q      (reg2hw.ctrl.operation.q ),
+    .qs     (ctrl_operation_qs)
   );
 
 
@@ -797,9 +797,9 @@ module aes_reg_top (
 
   assign data_out3_re = addr_hit[15] && reg_re;
 
-  assign ctrl_mode_we = addr_hit[16] & reg_we & ~wr_err;
-  assign ctrl_mode_wd = reg_wdata[0];
-  assign ctrl_mode_re = addr_hit[16] && reg_re;
+  assign ctrl_operation_we = addr_hit[16] & reg_we & ~wr_err;
+  assign ctrl_operation_wd = reg_wdata[0];
+  assign ctrl_operation_re = addr_hit[16] && reg_re;
 
   assign ctrl_key_len_we = addr_hit[16] & reg_we & ~wr_err;
   assign ctrl_key_len_wd = reg_wdata[3:1];
@@ -898,7 +898,7 @@ module aes_reg_top (
       end
 
       addr_hit[16]: begin
-        reg_rdata_next[0] = ctrl_mode_qs;
+        reg_rdata_next[0] = ctrl_operation_qs;
         reg_rdata_next[3:1] = ctrl_key_len_qs;
         reg_rdata_next[4] = ctrl_manual_start_trigger_qs;
         reg_rdata_next[5] = ctrl_force_data_overwrite_qs;

--- a/hw/ip/aes/rtl/aes_reg_top.sv
+++ b/hw/ip/aes/rtl/aes_reg_top.sv
@@ -111,14 +111,10 @@ module aes_reg_top (
   logic [2:0] ctrl_key_len_wd;
   logic ctrl_key_len_we;
   logic ctrl_key_len_re;
-  logic ctrl_manual_start_trigger_qs;
-  logic ctrl_manual_start_trigger_wd;
-  logic ctrl_manual_start_trigger_we;
-  logic ctrl_manual_start_trigger_re;
-  logic ctrl_force_data_overwrite_qs;
-  logic ctrl_force_data_overwrite_wd;
-  logic ctrl_force_data_overwrite_we;
-  logic ctrl_force_data_overwrite_re;
+  logic ctrl_manual_operation_qs;
+  logic ctrl_manual_operation_wd;
+  logic ctrl_manual_operation_we;
+  logic ctrl_manual_operation_re;
   logic trigger_start_wd;
   logic trigger_start_we;
   logic trigger_key_clear_wd;
@@ -467,33 +463,18 @@ module aes_reg_top (
   );
 
 
-  //   F[manual_start_trigger]: 4:4
+  //   F[manual_operation]: 4:4
   prim_subreg_ext #(
     .DW    (1)
-  ) u_ctrl_manual_start_trigger (
-    .re     (ctrl_manual_start_trigger_re),
-    .we     (ctrl_manual_start_trigger_we),
-    .wd     (ctrl_manual_start_trigger_wd),
-    .d      (hw2reg.ctrl.manual_start_trigger.d),
+  ) u_ctrl_manual_operation (
+    .re     (ctrl_manual_operation_re),
+    .we     (ctrl_manual_operation_we),
+    .wd     (ctrl_manual_operation_wd),
+    .d      (hw2reg.ctrl.manual_operation.d),
     .qre    (),
-    .qe     (reg2hw.ctrl.manual_start_trigger.qe),
-    .q      (reg2hw.ctrl.manual_start_trigger.q ),
-    .qs     (ctrl_manual_start_trigger_qs)
-  );
-
-
-  //   F[force_data_overwrite]: 5:5
-  prim_subreg_ext #(
-    .DW    (1)
-  ) u_ctrl_force_data_overwrite (
-    .re     (ctrl_force_data_overwrite_re),
-    .we     (ctrl_force_data_overwrite_we),
-    .wd     (ctrl_force_data_overwrite_wd),
-    .d      (hw2reg.ctrl.force_data_overwrite.d),
-    .qre    (),
-    .qe     (reg2hw.ctrl.force_data_overwrite.qe),
-    .q      (reg2hw.ctrl.force_data_overwrite.q ),
-    .qs     (ctrl_force_data_overwrite_qs)
+    .qe     (reg2hw.ctrl.manual_operation.qe),
+    .q      (reg2hw.ctrl.manual_operation.q ),
+    .qs     (ctrl_manual_operation_qs)
   );
 
 
@@ -805,13 +786,9 @@ module aes_reg_top (
   assign ctrl_key_len_wd = reg_wdata[3:1];
   assign ctrl_key_len_re = addr_hit[16] && reg_re;
 
-  assign ctrl_manual_start_trigger_we = addr_hit[16] & reg_we & ~wr_err;
-  assign ctrl_manual_start_trigger_wd = reg_wdata[4];
-  assign ctrl_manual_start_trigger_re = addr_hit[16] && reg_re;
-
-  assign ctrl_force_data_overwrite_we = addr_hit[16] & reg_we & ~wr_err;
-  assign ctrl_force_data_overwrite_wd = reg_wdata[5];
-  assign ctrl_force_data_overwrite_re = addr_hit[16] && reg_re;
+  assign ctrl_manual_operation_we = addr_hit[16] & reg_we & ~wr_err;
+  assign ctrl_manual_operation_wd = reg_wdata[4];
+  assign ctrl_manual_operation_re = addr_hit[16] && reg_re;
 
   assign trigger_start_we = addr_hit[17] & reg_we & ~wr_err;
   assign trigger_start_wd = reg_wdata[0];
@@ -900,8 +877,7 @@ module aes_reg_top (
       addr_hit[16]: begin
         reg_rdata_next[0] = ctrl_operation_qs;
         reg_rdata_next[3:1] = ctrl_key_len_qs;
-        reg_rdata_next[4] = ctrl_manual_start_trigger_qs;
-        reg_rdata_next[5] = ctrl_force_data_overwrite_qs;
+        reg_rdata_next[4] = ctrl_manual_operation_qs;
       end
 
       addr_hit[17]: begin

--- a/hw/ip/aes/rtl/aes_sbox.sv
+++ b/hw/ip/aes/rtl/aes_sbox.sv
@@ -7,20 +7,20 @@
 module aes_sbox #(
   parameter SBoxImpl = "lut"
 ) (
-  input  aes_pkg::mode_e mode_i,
-  input  logic [7:0]     data_i,
-  output logic [7:0]     data_o
+  input  aes_pkg::ciph_op_e op_i,
+  input  logic [7:0]        data_i,
+  output logic [7:0]        data_o
 );
 
   if (SBoxImpl == "lut") begin : gen_sbox_lut
     aes_sbox_lut aes_sbox (
-      .mode_i,
+      .op_i,
       .data_i,
       .data_o
     );
   end else if (SBoxImpl == "canright") begin : gen_sbox_canright
     aes_sbox_canright aes_sbox (
-      .mode_i,
+      .op_i,
       .data_i,
       .data_o
     );

--- a/hw/ip/aes/rtl/aes_sbox_canright.sv
+++ b/hw/ip/aes/rtl/aes_sbox_canright.sv
@@ -8,9 +8,9 @@
 // available at https://hdl.handle.net/10945/25608
 
 module aes_sbox_canright (
-  input  aes_pkg::mode_e mode_i,
-  input  logic [7:0]     data_i,
-  output logic [7:0]     data_o
+  input  aes_pkg::ciph_op_e op_i,
+  input  logic [7:0]        data_i,
+  output logic [7:0]        data_o
 );
 
   import aes_pkg::*;
@@ -131,14 +131,14 @@ module aes_sbox_canright (
   logic [7:0] data_basis_x, data_inverse;
 
   // Convert to normal basis X.
-  assign data_basis_x = (mode_i == AES_ENC) ? aes_mvm(data_i, a2x) :
-                                              aes_mvm(data_i ^ 8'h63, s2x);
+  assign data_basis_x = (op_i == CIPH_FWD) ? aes_mvm(data_i, a2x) :
+                                             aes_mvm(data_i ^ 8'h63, s2x);
 
   // Do the inversion in normal basis X.
   assign data_inverse = aes_inverse_gf2p8(data_basis_x);
 
   // Convert to basis S or A.
-  assign data_o       = (mode_i == AES_ENC) ? aes_mvm(data_inverse, x2s) ^ 8'h63 :
-                                              aes_mvm(data_inverse, x2a);
+  assign data_o       = (op_i == CIPH_FWD) ? aes_mvm(data_inverse, x2s) ^ 8'h63 :
+                                             aes_mvm(data_inverse, x2a);
 
 endmodule

--- a/hw/ip/aes/rtl/aes_sbox_lut.sv
+++ b/hw/ip/aes/rtl/aes_sbox_lut.sv
@@ -5,15 +5,15 @@
 // AES LUT-based SBox
 
 module aes_sbox_lut (
-  input  aes_pkg::mode_e mode_i,
-  input  logic [7:0]     data_i,
-  output logic [7:0]     data_o
+  input  aes_pkg::ciph_op_e op_i,
+  input  logic [7:0]        data_i,
+  output logic [7:0]        data_o
 );
 
   import aes_pkg::*;
 
   // Define the LUTs
-  const logic [7:0] sbox_enc [256] = '{
+  const logic [7:0] sbox_fwd [256] = '{
     8'h63, 8'h7C, 8'h77, 8'h7B, 8'hF2, 8'h6B, 8'h6F, 8'hC5,
     8'h30, 8'h01, 8'h67, 8'h2B, 8'hFE, 8'hD7, 8'hAB, 8'h76,
 
@@ -63,7 +63,7 @@ module aes_sbox_lut (
     8'h41, 8'h99, 8'h2D, 8'h0F, 8'hB0, 8'h54, 8'hBB, 8'h16
   };
 
-  const logic [7:0] sbox_dec [256] = '{
+  const logic [7:0] sbox_inv [256] = '{
     8'h52, 8'h09, 8'h6a, 8'hd5, 8'h30, 8'h36, 8'ha5, 8'h38,
     8'hbf, 8'h40, 8'ha3, 8'h9e, 8'h81, 8'hf3, 8'hd7, 8'hfb,
 
@@ -114,6 +114,6 @@ module aes_sbox_lut (
   };
 
   // Drive output
-  assign data_o = (mode_i == AES_ENC) ? sbox_enc[data_i] : sbox_dec[data_i];
+  assign data_o = (op_i == CIPH_FWD) ? sbox_fwd[data_i] : sbox_inv[data_i];
 
 endmodule

--- a/hw/ip/aes/rtl/aes_shift_rows.sv
+++ b/hw/ip/aes/rtl/aes_shift_rows.sv
@@ -5,7 +5,7 @@
 // AES ShiftRows
 
 module aes_shift_rows (
-  input  aes_pkg::mode_e       mode_i,
+  input  aes_pkg::ciph_op_e    op_i,
   input  logic [3:0][3:0][7:0] data_i,
   output logic [3:0][3:0][7:0] data_o
 );
@@ -15,15 +15,15 @@ module aes_shift_rows (
   // Row 0 is left untouched
   assign data_o[0] = data_i[0];
 
-  // Row 2 does not depend on mode_i
+  // Row 2 does not depend on op_i
   assign data_o[2] = aes_circ_byte_shift(data_i[2], 2);
 
   // Row 1
-  assign data_o[1] = (mode_i == AES_ENC) ? aes_circ_byte_shift(data_i[1], -1)
-                                         : aes_circ_byte_shift(data_i[1],  1);
+  assign data_o[1] = (op_i == CIPH_FWD) ? aes_circ_byte_shift(data_i[1], -1)
+                                        : aes_circ_byte_shift(data_i[1],  1);
 
   // Row 3
-  assign data_o[3] = (mode_i == AES_ENC) ? aes_circ_byte_shift(data_i[3],  1)
-                                         : aes_circ_byte_shift(data_i[3], -1);
+  assign data_o[3] = (op_i == CIPH_FWD) ? aes_circ_byte_shift(data_i[3],  1)
+                                        : aes_circ_byte_shift(data_i[3], -1);
 
 endmodule

--- a/hw/ip/aes/rtl/aes_sub_bytes.sv
+++ b/hw/ip/aes/rtl/aes_sub_bytes.sv
@@ -7,7 +7,7 @@
 module aes_sub_bytes #(
   parameter SBoxImpl = "lut"
 ) (
-  input  aes_pkg::mode_e       mode_i,
+  input  aes_pkg::ciph_op_e    op_i,
   input  logic [3:0][3:0][7:0] data_i,
   output logic [3:0][3:0][7:0] data_o
 );
@@ -18,7 +18,7 @@ module aes_sub_bytes #(
       aes_sbox #(
         .SBoxImpl ( SBoxImpl )
       ) aes_sbox_ij (
-        .mode_i ( mode_i       ),
+        .op_i   ( op_i         ),
         .data_i ( data_i[i][j] ),
         .data_o ( data_o[i][j] )
       );

--- a/sw/device/lib/aes.c
+++ b/sw/device/lib/aes.c
@@ -15,8 +15,7 @@ void aes_init(aes_cfg_t aes_cfg) {
   REG32(AES_CTRL(0)) =
       (aes_cfg.operation << AES_CTRL_OPERATION) |
       ((aes_cfg.key_len & AES_CTRL_KEY_LEN_MASK) << AES_CTRL_KEY_LEN_OFFSET) |
-      (aes_cfg.manual_start_trigger << AES_CTRL_MANUAL_START_TRIGGER) |
-      (aes_cfg.force_data_overwrite << AES_CTRL_FORCE_DATA_OVERWRITE);
+      (aes_cfg.manual_operation << AES_CTRL_MANUAL_OPERATION);
 };
 
 void aes_key_put(const void *key, aes_key_len_t key_len) {
@@ -91,7 +90,7 @@ void aes_clear(void) {
   }
 
   // Disable autostart
-  REG32(AES_CTRL(0)) = 0x1u << AES_CTRL_MANUAL_START_TRIGGER;
+  REG32(AES_CTRL(0)) = 0x1u << AES_CTRL_MANUAL_OPERATION;
 
   // Clear internal key and output registers
   REG32(AES_TRIGGER(0)) = (0x1u << AES_TRIGGER_KEY_CLEAR) |

--- a/sw/device/lib/aes.c
+++ b/sw/device/lib/aes.c
@@ -13,7 +13,7 @@
 
 void aes_init(aes_cfg_t aes_cfg) {
   REG32(AES_CTRL(0)) =
-      (aes_cfg.mode << AES_CTRL_MODE) |
+      (aes_cfg.operation << AES_CTRL_OPERATION) |
       ((aes_cfg.key_len & AES_CTRL_KEY_LEN_MASK) << AES_CTRL_KEY_LEN_OFFSET) |
       (aes_cfg.manual_start_trigger << AES_CTRL_MANUAL_START_TRIGGER) |
       (aes_cfg.force_data_overwrite << AES_CTRL_FORCE_DATA_OVERWRITE);

--- a/sw/device/lib/aes.h
+++ b/sw/device/lib/aes.h
@@ -32,10 +32,9 @@ typedef struct aes_cfg {
   aes_op_t operation;
   /** Key length @see aes_key_len. */
   aes_key_len_t key_len;
-  /** Set to 1 to only start upon getting a trigger signal. */
-  bool manual_start_trigger;
-  /** Set to 1 to not stall when previous output data has not been read. */
-  bool force_data_overwrite;
+  /** Set to 1 to i) only start upon getting a trigger signal, and ii) not stall
+   * when previous output data has not been read. */
+  bool manual_operation;
 } aes_cfg_t;
 
 /**

--- a/sw/device/lib/aes.h
+++ b/sw/device/lib/aes.h
@@ -10,9 +10,9 @@
 #include <stdint.h>
 
 /**
- * Supported AES modes: encode or decode.
+ * Supported AES operation modes: encode or decode.
  */
-typedef enum aes_mode { kAesEnc = 0, kAesDec = 1 } aes_mode_t;
+typedef enum aes_op { kAesEnc = 0, kAesDec = 1 } aes_op_t;
 
 /**
  * Supported AES key lengths: 128 bit, 192 bit or 256 bit. The hardware uses a
@@ -28,8 +28,8 @@ typedef enum aes_key_len {
  * AES unit configuration options.
  */
 typedef struct aes_cfg {
-  /** Operational mode @see aes_mode. */
-  aes_mode_t mode;
+  /** Operational mode @see aes_op. */
+  aes_op_t operation;
   /** Key length @see aes_key_len. */
   aes_key_len_t key_len;
   /** Set to 1 to only start upon getting a trigger signal. */

--- a/sw/device/tests/aes/aes_test.c
+++ b/sw/device/tests/aes/aes_test.c
@@ -45,7 +45,7 @@ int main(int argc, char **argv) {
   aes_key_put(key_32_1, aes_cfg.key_len);
 
   // Encode
-  aes_cfg.mode = kAesEnc;
+  aes_cfg.operation = kAesEnc;
   aes_init(aes_cfg);
   aes_data_put_wait(plain_text_1);
   aes_data_get_wait(buffer);
@@ -58,7 +58,7 @@ int main(int argc, char **argv) {
   }
 
   // Decode
-  aes_cfg.mode = kAesDec;
+  aes_cfg.operation = kAesDec;
   aes_init(aes_cfg);
   aes_data_put_wait(buffer);
   aes_data_get_wait(buffer);

--- a/sw/device/tests/aes/aes_test.c
+++ b/sw/device/tests/aes/aes_test.c
@@ -37,9 +37,7 @@ int main(int argc, char **argv) {
 
   // Setup AES config
   aes_cfg_t aes_cfg = {
-      .key_len = kAes256,
-      .manual_start_trigger = false,
-      .force_data_overwrite = false,
+      .key_len = kAes256, .manual_operation = false,
   };
 
   aes_key_put(key_32_1, aes_cfg.key_len);


### PR DESCRIPTION
This PR is based on #1452

This is the second PR refactoring the RTL of the AES unit in preparation for adding other block cipher modes. It contains a two commits to implement the following main changes:
* Reworking the "mode" signals and enums. These were previously used to control whether the unit does encryption or decryption which might be confusing. The signal controlling encryption/decryption should be called "operation" . "mode" us usually indicating the block cipher mode (ECB, CBC, CFB,...) in AES terms.
* Unifying the FORCE_DATA_OVERWRITE and MANUAL_START_TRIGGER bits of the CONTROL register into a single bit called MANUAL_OPERATION. This simplifies the programming interface as well as verification, and it prevents having odd configurations where, e.g., FORCE_DATA_OVERWITE is set while MANUAL_START_TRIGGER isn't (previously possible).

Both these commits are successfully tested using my scratch Verilator testbench and the UVM-based DV in the tree. 