### PR TITLE
[hmac] Message Length calculated at prim_packer

### DIFF
--- a/hw/ip/hmac/rtl/hmac.sv
+++ b/hw/ip/hmac/rtl/hmac.sv
@@ -296,7 +296,7 @@ module hmac
   always_comb begin
     wmask_ones = '0;
     for (int i = 0 ; i < 32 ; i++) begin
-      wmask_ones = wmask_ones + reg_fifo_wmask[i];
+      wmask_ones = wmask_ones + msg_fifo_wmask[i];
     end
   end
 
@@ -306,7 +306,7 @@ module hmac
       message_length <= '0;
     end else if (hash_start) begin
       message_length <= '0;
-    end else if (reg_fifo_wvalid && fifo_wready && !hmac_fifo_wsel) begin
+    end else if (msg_write && sha_en && packer_ready) begin
       message_length <= message_length + 64'(wmask_ones);
     end
   end


### PR DESCRIPTION
Problem:

    Received Message Length doesn't account the partial write to the
    MSG_FIFO until `hash_process` is triggered.

As Jon addressed in the issue #1449, HMAC calculates the received
message length in front of the MSG_FIFO. Between the TL-UL port and the
MSG_FIFO, `prim_packer` module exists to support partial write without
alignment. While changing, the message length calculation logic didn't
move. So, it only updates when any writes happen to MSG_FIFO not to
`prim_packer`.

If partial write happens, `prim_packer` stores it until it becomes full
4 byte write or `hash_process` is triggered. So, this is not visible to
the recevied message length until above conditions happen.

Resolution:

    Moved the message length calculation logic in front of the
    `prim_packer`.
