### PR TITLE
[dv/hmac] support new msg_len

### DIFF
--- a/hw/ip/hmac/dv/env/hmac_scoreboard.sv
+++ b/hw/ip/hmac/dv/env/hmac_scoreboard.sv
@@ -65,6 +65,7 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
             end
           end
           foreach (msg[i]) msg_q.push_back(msg[i]);
+          update_wr_msg_length(msg_q.size());
         end
       end else begin
         case (csr_name)
@@ -74,10 +75,10 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
               if (hmac_process) begin
                 // check if msg all streamed in, could happen during wr msg or trigger process
                 predict_digest(msg_q);
-                update_wr_msg_length(msg_q.size());
                 msg_q.delete();
               end else if (hmac_start) begin
                 msg_q.delete(); // make sure did not include previous msg
+                update_wr_msg_length(msg_q.size());
               end
             end else if (item.a_data[HashStart] == 1) begin
               void'(ral.intr_state.hmac_err.predict(.value(1), .kind(UVM_PREDICT_DIRECT)));

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
@@ -228,6 +228,7 @@ class hmac_base_vseq extends cip_base_vseq #(.CFG_T               (hmac_env_cfg)
     end
     // ensure all msg fifo are written before trigger hmac_process
     csr_utils_pkg::wait_no_outstanding_access();
+    if ($urandom_range(0, 1)) rd_msg_length();
   endtask
 
   // read fifo_depth reg and burst write a chunk of words
@@ -260,6 +261,7 @@ class hmac_base_vseq extends cip_base_vseq #(.CFG_T               (hmac_env_cfg)
         break;
       end
     csr_utils_pkg::wait_no_outstanding_access();
+    if ($urandom_range(0, 1)) rd_msg_length();
     end
   endtask
 

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_sanity_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_sanity_vseq.sv
@@ -106,9 +106,10 @@ class hmac_sanity_vseq extends hmac_base_vseq;
         end
       end
 
+
       // if disable sha, digest should be cleared
       // read msg fifo length
-      rd_msg_length();
+      if ($urandom_range(0, 1)) rd_msg_length();
 
       // read digest from DUT
       rd_digest();


### PR DESCRIPTION
Add check msg length before hash_trigger
Reported by issue: https://github.com/lowRISC/opentitan/issues/1449
RTL fix: https://github.com/lowRISC/opentitan/pull/1455

Signed-off-by: Cindy Chen <chencindy@google.com>