### PR TITLE
[uvmdvgen] Base seq template fix

### DIFF
--- a/hw/dv/sv/alert_esc_agent/seq_lib/alert_receiver_alert_rsp_seq.sv
+++ b/hw/dv/sv/alert_esc_agent/seq_lib/alert_receiver_alert_rsp_seq.sv
@@ -14,7 +14,7 @@ class alert_receiver_alert_rsp_seq extends dv_base_seq #(
 
   virtual task body();
     `uvm_info(`gfn, $sformatf("starting alert receiver transfer"), UVM_HIGH)
-    req = REQ::type_id::create("req");
+    req = alert_esc_seq_item::type_id::create("req");
     start_item(req);
     `DV_CHECK_RANDOMIZE_WITH_FATAL(req,
         r_alert_ping_send == 0;

--- a/hw/dv/sv/alert_esc_agent/seq_lib/alert_receiver_seq.sv
+++ b/hw/dv/sv/alert_esc_agent/seq_lib/alert_receiver_seq.sv
@@ -15,7 +15,7 @@ class alert_receiver_seq extends dv_base_seq #(
 
   task body();
     `uvm_info(`gfn, $sformatf("starting alert receiver transfer"), UVM_HIGH)
-    req = REQ::type_id::create("req");
+    req = alert_esc_seq_item::type_id::create("req");
     start_item(req);
     `DV_CHECK_RANDOMIZE_WITH_FATAL(req,
         r_alert_ping_send == 1;

--- a/hw/dv/sv/alert_esc_agent/seq_lib/alert_sender_ping_rsp_seq.sv
+++ b/hw/dv/sv/alert_esc_agent/seq_lib/alert_sender_ping_rsp_seq.sv
@@ -14,7 +14,7 @@ class alert_sender_ping_rsp_seq extends dv_base_seq #(
 
   virtual task body();
     `uvm_info(`gfn, $sformatf("starting alert receiver transfer"), UVM_HIGH)
-    req = REQ::type_id::create("req");
+    req = alert_esc_seq_item::type_id::create("req");
     start_item(req);
     `DV_CHECK_RANDOMIZE_WITH_FATAL(req,
         s_alert_send     == 0;

--- a/hw/dv/sv/alert_esc_agent/seq_lib/alert_sender_seq.sv
+++ b/hw/dv/sv/alert_esc_agent/seq_lib/alert_sender_seq.sv
@@ -14,7 +14,7 @@ class alert_sender_seq extends dv_base_seq #(
 
   task body();
     `uvm_info(`gfn, $sformatf("starting alert sender transfer"), UVM_HIGH)
-    req = REQ::type_id::create("req");
+    req = alert_esc_seq_item::type_id::create("req");
     start_item(req);
     `DV_CHECK_RANDOMIZE_WITH_FATAL(req,
         s_alert_send     == 1;

--- a/hw/dv/sv/alert_esc_agent/seq_lib/esc_receiver_esc_rsp_seq.sv
+++ b/hw/dv/sv/alert_esc_agent/seq_lib/esc_receiver_esc_rsp_seq.sv
@@ -14,7 +14,7 @@ class esc_receiver_esc_rsp_seq extends dv_base_seq #(
 
   virtual task body();
     `uvm_info(`gfn, $sformatf("starting escalator receiver transfer"), UVM_HIGH)
-    req = REQ::type_id::create("req");
+    req = alert_esc_seq_item::type_id::create("req");
     start_item(req);
     `DV_CHECK_RANDOMIZE_WITH_FATAL(req,
         r_esc_rsp == 1;

--- a/hw/dv/sv/uart_agent/seq_lib/uart_seq.sv
+++ b/hw/dv/sv/uart_agent/seq_lib/uart_seq.sv
@@ -21,7 +21,7 @@ class uart_seq extends uart_base_seq;
 
   task body();
     `uvm_info(`gfn, $sformatf("starting uart rx byte xfer seq: 0x%0h", data), UVM_HIGH)
-    req = REQ::type_id::create("req");
+    req = uart_item::type_id::create("req");
     start_item(req);
     req.stop_bit_c.constraint_mode(0);
     `DV_CHECK_RANDOMIZE_WITH_FATAL(req,

--- a/util/uvmdvgen/base_seq.sv.tpl
+++ b/util/uvmdvgen/base_seq.sv.tpl
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 class ${name}_base_seq extends dv_base_seq #(
+    .REQ         (${name}_item),
     .CFG_T       (${name}_agent_cfg),
     .SEQUENCER_T (${name}_sequencer)
   );

--- a/util/uvmdvgen/base_test.sv.tpl
+++ b/util/uvmdvgen/base_test.sv.tpl
@@ -7,8 +7,8 @@ class ${name}_base_test extends cip_base_test #(
 % else:
 class ${name}_base_test extends dv_base_test #(
 % endif
-    .ENV_T(${name}_env),
-    .CFG_T(${name}_env_cfg)
+    .CFG_T(${name}_env_cfg),
+    .ENV_T(${name}_env)
   );
 
   `uvm_component_utils(${name}_base_test)

--- a/util/uvmdvgen/base_vseq.sv.tpl
+++ b/util/uvmdvgen/base_vseq.sv.tpl
@@ -7,8 +7,8 @@ class ${name}_base_vseq extends cip_base_vseq #(
 % else:
 class ${name}_base_vseq extends dv_base_vseq #(
 % endif
-    .CFG_T               (${name}_env_cfg),
     .RAL_T               (${name}_reg_block),
+    .CFG_T               (${name}_env_cfg),
     .COV_T               (${name}_env_cov),
     .VIRTUAL_SEQUENCER_T (${name}_virtual_sequencer)
   );


### PR DESCRIPTION
- Fixed the base_seq template to override the REQ type to the correct
type
- This came from a discussion in PR #1441 

This PR also replaces references to the base class's override type parameter with the actual parameter type value (which is better since it makes it clear what type of item we are creating). 

Signed-off-by: Srikrishna Iyer <sriyer@google.com>