### PR TITLE
[dv] Added some documentation

### DIFF
--- a/hw/dv/sv/csr_utils/csr_seq_lib.sv
+++ b/hw/dv/sv/csr_utils/csr_seq_lib.sv
@@ -115,9 +115,12 @@ class csr_base_seq extends uvm_reg_sequence #(uvm_sequence #(uvm_reg_item));
 endclass
 
 //--------------------------------------------------------------------------------------------------
-// Brief Description: generic CSR seq lib - HW reset seq
+// Class: csr_hw_reset_seq
+// Brief Description: This sequence reads all CSRs and checks it against the reset value provided
+// in the RAL specification. Note that this does not sufficiently qualify as the CSR HW reset test.
+// The 'full' CSR HW reset test is constructed externally by running the csr_write_seq below first,
+// issuing reset and only then running this sequence.
 //--------------------------------------------------------------------------------------------------
-
 class csr_hw_reset_seq extends csr_base_seq;
   `uvm_object_utils(csr_hw_reset_seq)
 
@@ -149,9 +152,10 @@ class csr_hw_reset_seq extends csr_base_seq;
 endclass
 
 //--------------------------------------------------------------------------------------------------
-// Brief Description: generic CSR seq lib - write all registers with random values
+// Class: csr_write_seq
+// Brief Description: This sequence writes a random value to all CSRs. It does not perform any
+// checks. It is run as the first step of the CSR HW reset test.
 //--------------------------------------------------------------------------------------------------
-
 class csr_write_seq extends csr_base_seq;
   `uvm_object_utils(csr_write_seq)
 
@@ -181,9 +185,12 @@ endclass
 
 
 //--------------------------------------------------------------------------------------------------
-// Brief Description: generic CSR seq lib - reg access seq
+// Class: csr_rw_seq
+// Brief Description: This seq writes a random value to a CSR and reads it back. The read value
+// is checked for correctness while adhering to its access policies. A random choice is made between
+// reading back the CSR as a whole or reading fields individually, so that partial accesses are made
+// into the DUT as well.
 //--------------------------------------------------------------------------------------------------
-
 class csr_rw_seq extends csr_base_seq;
   `uvm_object_utils(csr_rw_seq)
 
@@ -257,10 +264,11 @@ class csr_rw_seq extends csr_base_seq;
 endclass
 
 //--------------------------------------------------------------------------------------------------
-// Brief Description: generic CSR seq lib - bit bash seq
-// reusing pieces of code from uvm_reg_bit_bash_seq
+// Class: csr_bit_bash_seq
+// Brief Description: This sequence walks a 1 through each CSR by writing one bit at a time and
+// reading the CSR back. The read value is checked for correctness while adhering to its access
+// policies. This verifies that there is no aliasing within the fields / bits of a CSR.
 //--------------------------------------------------------------------------------------------------
-
 class csr_bit_bash_seq extends csr_base_seq;
   `uvm_object_utils(csr_bit_bash_seq)
 
@@ -383,9 +391,12 @@ class csr_bit_bash_seq extends csr_base_seq;
 endclass
 
 //--------------------------------------------------------------------------------------------------
-// Brief Description: generic CSR seq lib - aliasing seq
+// Class: csr_aliasing_seq
+// Brief Description: For each CSR, this sequence writes a random value to it and reads ALL CSRs
+// back. The read value of the CSR that was written is checked for correctness while adhering to its
+// access policies. The read value of all other CSRs are compared against their previous values.
+// This verifies that there is no aliasing across the address bits within the valid CSR space.
 //--------------------------------------------------------------------------------------------------
-
 class csr_aliasing_seq extends csr_base_seq;
   `uvm_object_utils(csr_aliasing_seq)
 
@@ -442,9 +453,10 @@ class csr_aliasing_seq extends csr_base_seq;
 endclass
 
 //--------------------------------------------------------------------------------------------------
-// Brief Description: generic CSR seq lib - mem walk
+// Class: csr_mem_walk_seq
+// Brief Description: This seq walks through each address of the memory by running the default
+// UVM mem walk sequence.
 //--------------------------------------------------------------------------------------------------
-
 class csr_mem_walk_seq extends csr_base_seq;
   uvm_mem_walk_seq mem_walk_seq;
 

--- a/hw/dv/tools/testplans/csr_testplan.hjson
+++ b/hw/dv/tools/testplans/csr_testplan.hjson
@@ -4,16 +4,68 @@
 {
   entries: [
     {
-      name: csr
-      desc: '''Standard CSR suite of tests run from all valid interfaces to prove SW
-            accessibility.'''
+      name: csr_hw_reset
+      desc: '''
+            Verify the reset values as indicated in the RAL specification.
+            - Write all CSRs with a random value.
+            - Apply reset to the DUT as well as the RAL model.
+            - Read each CSR and compare it against the reset value.
+              it is mandatory to replicate this test for each reset that affects
+              all or a subset of the CSRs.
+            - It is mandatory to run this test for all available interfaces the
+              CSRs are accessible from.
+            - Shuffle the list of CSRs first to remove the effect of ordering.
+            '''
       milestone: V1
-      tests: ["{name}{intf}_csr_hw_reset",
-              "{name}{intf}_csr_rw",
-              "{name}{intf}_csr_bit_bash",
-              "{name}{intf}_csr_aliasing",]
+      tests: ["{name}{intf}_csr_hw_reset"]
     }
-    // TODO: add CSR accesses with reset
+    {
+      name: csr_rw
+      desc: '''
+            Verify accessibility of CSRs as indicated in the RAL specification.
+            - Loop through each CSR to write it with a random value.
+            - Read the CSR back and check for correctness while adhering to its
+              access policies.
+            - It is mandatory to run this test for all available interfaces the
+              CSRs are accessible from.
+            - Shuffle the list of CSRs first to remove the effect of ordering.
+            '''
+      milestone: V1
+      tests: ["{name}{intf}_csr_rw"]
+    }
+    {
+      name: csr_bit_bash
+      desc: '''
+            Verify no aliasing within individual bits of a CSR.
+            - Walk a 1 through each CSR by flipping 1 bit at a time.
+            - Read the CSR back and check for correctness while adhering to its
+              access policies.
+            - This verify that writing a specific bit within the CSR did not affect
+              any of the other bits.
+            - It is mandatory to run this test for all available interfaces the
+              CSRs are accessible from.
+            - Shuffle the list of CSRs first to remove the effect of ordering.
+            '''
+      milestone: V1
+      tests: ["{name}{intf}_csr_bit_bash"]
+    }
+    {
+      name: csr_aliasing
+      desc: '''
+            Verify no aliasing within the CSR address space.
+            - Loop through each CSR to write it with a random value
+            - Shuffle and read ALL CSRs back.
+            - All CSRs except for the one that was written in this iteration should
+              read back the previous value.
+            - The CSR that was written in this iteration is checked for correctness
+              while adhering to its access policies.
+            - It is mandatory to run this test for all available interfaces the
+              CSRs are accessible from.
+            - Shuffle the list of CSRs first to remove the effect of ordering.
+            '''
+      milestone: V1
+      tests: ["{name}{intf}_csr_aliasing",]
+    }
   ]
 }
 

--- a/hw/dv/tools/testplans/intr_test_testplan.hjson
+++ b/hw/dv/tools/testplans/intr_test_testplan.hjson
@@ -5,7 +5,20 @@
   entries: [
     {
       name: intr_test
-      desc: "Verify common intr_test CSRs to force interrupts via SW."
+      desc: '''
+            Verify common intr_test CSRs that allows SW to mock-inject interrupts.
+            - Enable a random set of interrupts by writing random value(s) to
+              intr_enable CSR(s).
+            - Randomly "turn on" interrupts by writing random value(s) to intr_test
+              CSR(s).
+            - Read all intr_state CSR(s) back to verify that it reflects the same value
+              as what was written to the corresponding intr_test CSR.
+            - Check the cfg.intr_vif pins to verify that only the interrupts that were
+              enabled and turned on are set.
+            - Clear a random set of interrupts by writing a randomly value to intr_state
+              CSR(s).
+            - Repeat the above steps a bunch of times.
+            '''
       milestone: V2
       tests: ["{name}{intf}_intr_test"]
     }

--- a/hw/dv/tools/testplans/mem_testplan.hjson
+++ b/hw/dv/tools/testplans/mem_testplan.hjson
@@ -5,13 +5,22 @@
   entries: [
     {
       name: mem_walk
-      desc: "Walk 1 through memory addresses from all interfaces"
+      desc: '''
+            Verify accessibility of all memories in the design.
+            - Run the standard UVM mem walk sequence on all memories in the RAL model.
+            - It is mandatory to run this test from all available interfaces the
+              memories are accessible from.
+            '''
       milestone: V1
       tests: ["{name}{intf}_mem_walk"]
     }
     {
       name: mem_partial_access
-      desc: "Do partial accesses to memories."
+      desc: '''
+            Verify partial-accessibility of all memories in the design.
+            - Do partial reads and writes into the memories and verify the outcome for
+              correctness.
+            '''
       milestone: V1
       // mem_walk does partial writes, so we can reuse that test here
       tests: ["{name}{intf}_mem_walk"]


### PR DESCRIPTION
- Updated descriptions of CSR test sequences as requested by
@rasmus-madsen in #1432.
- Split the "csr" test point in the CSR testplan into individual tests
since each serves a unique purpose.
- Updated some descriptions of tests in other testplan entries as well.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>