### PR TITLE
[dv regr tool] Use builtin for generating seeds

### DIFF
--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -10,6 +10,7 @@ import logging as log
 import pprint
 import random
 import re
+import secrets
 import shlex
 import sys
 import time
@@ -483,13 +484,9 @@ class RunTest(Deploy):
     @staticmethod
     def get_seed():
         if RunTest.seeds == []:
-            try:
-                # Pre-populate 1000 seeds at a time
-                RunTest.seeds = run_cmd(
-                    "od -vAn -N4000 -tu < /dev/random | xargs").split()
-                random.shuffle(RunTest.seeds)
-            except Exception as e:
-                log.error("%s. Failed to generate a list of 1000 random seeds",
-                          e)
-                sys.exit(1)
+            # Py lib 'secrets' provides crypto quality strong random numbers.
+            for i in range(1000):
+                seed = secrets.token_bytes(4)
+                seed = int.from_bytes(seed, byteorder='little')
+                RunTest.seeds.append(seed)
         return RunTest.seeds.pop(0)


### PR DESCRIPTION
- The tool used octal dump [`od`] to pre-populate a list of 1000 random
numbers to be supplied as seeds to the tests
- Due to an unknown issue this ended up hanging on WDC machines
- This PR changes it to use python3 in-built library called 'secrets'
instead, which supposedly produces strong random numbers suitable for
crypto applications.
- Performance wise, the secrets lib takes 0.005s to generate 1000 random
numbers which is an order of magniture better than `od` which is a
system call that takes 0.097s. So this is an added plus.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>