### PR TITLE
[reggen] Correct hro to hwo for hwext registers readable by software

### DIFF
--- a/util/reggen/validate.py
+++ b/util/reggen/validate.py
@@ -797,6 +797,13 @@ def validate_reg_defaults(reg, rname):
         if ierr:
             error += 1
             reg['hwext'] = "false"
+        elif hwext == True and default_hw == "hro" and (default_sw != "wo" and
+                                                        default_sw != "r0w1c"):
+            log.warning(
+                rname +
+                ": hwext register readable by software cannot be hro. " +
+                "Changing it to hrw.")
+            default_hw = "hrw"
     else:
         reg['hwext'] = "false"
 


### PR DESCRIPTION
This PR changes reggen to 1) output a warning for hwext registers that are readable for software but ready-only for hardware (hro) and to 2) change those registers to read/write for hardware (hrw). Otherwise, software only ever reads back 0 and is not able to read the actual register content.

This resolves lowRISC/OpenTitan#1428.