### PR TITLE
[rv_timer] Int clr by mtimecmp update

### DIFF
--- a/hw/ip/rv_timer/data/rv_timer.hjson
+++ b/hw/ip/rv_timer/data/rv_timer.hjson
@@ -72,6 +72,7 @@
       desc: "Timer value Lower",
       swaccess: "rw",
       hwaccess: "hro",
+      hwqe: "true",
       fields: [
         { bits: "31:0", name: "v", resval: "0xffffffff", desc: "Timer compare value [31:0]" },
       ],
@@ -80,6 +81,7 @@
       desc: "Timer value Upper",
       swaccess: "rw",
       hwaccess: "hro",
+      hwqe: "true",
       fields: [
         { bits: "31:0", name: "v", resval: "0xffffffff", desc: "Timer compare value [63:32]" },
       ],
@@ -124,3 +126,4 @@
     },
   ],
 }
+

--- a/hw/ip/rv_timer/data/rv_timer.hjson.tpl
+++ b/hw/ip/rv_timer/data/rv_timer.hjson.tpl
@@ -6,7 +6,7 @@
 ##  - harts:  number of HART in timer module
 ##  - timers: number of timers in each hart
 { name: "rv_timer",
-  clock_primary: "clk_fixed",
+  clock_primary: "clk_i",
   bus_device: "tlul",
   bus_host: "none",
   available_input_list: [
@@ -81,6 +81,7 @@
       desc: "Timer value Lower",
       swaccess: "rw",
       hwaccess: "hro",
+      hwqe: "true",
       fields: [
         { bits: "31:0", name: "v", resval: "0xffffffff", desc: "Timer compare value [31:0]" },
       ],
@@ -89,6 +90,7 @@
       desc: "Timer value Upper",
       swaccess: "rw",
       hwaccess: "hro",
+      hwqe: "true",
       fields: [
         { bits: "31:0", name: "v", resval: "0xffffffff", desc: "Timer compare value [63:32]" },
       ],

--- a/hw/ip/rv_timer/doc/_index.md
+++ b/hw/ip/rv_timer/doc/_index.md
@@ -234,7 +234,11 @@ between `mtime` and `mtimecmp` care is needed. A couple of cases are:
 
 ## Interrupt Handling
 
-TBD
+If `mtime` is greater than or equal to the value of `mtimecmp`, the interrupt is generated from the RV_TIMER module.
+If the core enables the timer interrupt in `MIE` CSR, it jumps into the timer interupt service routine.
+Clearing the interrupt can be done by writing 1 into the Interrupt Status register {{<regref "INTR_STATE0">}}.
+The RV_TIMER module also follows RISC-V Previliged spec that requires the interrupt to be cleared by updating `mtimecmp` memory-mapped CSRs.
+In this case both {{<regref "COMPARE_LOWER0_0">}} and {{<regref "COMPARE_UPPER0_0">}} can clear the interrupt source.
 
 ## Register Table
 

--- a/hw/ip/rv_timer/dv/env/rv_timer_scoreboard.sv
+++ b/hw/ip/rv_timer/dv/env/rv_timer_scoreboard.sv
@@ -103,16 +103,30 @@ class rv_timer_scoreboard extends cip_base_scoreboard #(.CFG_T (rv_timer_env_cfg
         (!uvm_re_match("compare_lower*", csr_name)): begin
           for (int i = 0; i < NUM_HARTS; i++) begin
             for (int j = 0; j < NUM_TIMERS; j++) begin
+              int timer_idx = i * NUM_TIMERS + j;
               compare_val[i][j][31:0] = get_reg_fld_mirror_value(
                                             ral, $sformatf("compare_lower%0d_%0d", i, j), "v");
+              // Reset the interrupt when mtimecmp is updated
+              intr_status_exp[i][j] = 0;
+              if (cfg.en_cov) begin
+                cov.sticky_intr_cov[{"rv_timer_sticky_intr_pin",
+                                    $sformatf("%0d", timer_idx)}].sample(1'b0);
+              end
             end
           end
         end
         (!uvm_re_match("compare_upper*", csr_name)): begin
           for (int i = 0; i < NUM_HARTS; i++) begin
             for (int j = 0; j < NUM_TIMERS; j++) begin
+              int timer_idx = i * NUM_TIMERS + j;
               compare_val[i][j][63:32] = get_reg_fld_mirror_value(
                                              ral, $sformatf("compare_upper%0d_%0d", i, j), "v");
+              // Reset the interrupt when mtimecmp is updated
+              intr_status_exp[i][j] = 0;
+              if (cfg.en_cov) begin
+                cov.sticky_intr_cov[{"rv_timer_sticky_intr_pin",
+                                    $sformatf("%0d", timer_idx)}].sample(1'b0);
+              end
             end
           end
         end

--- a/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_base_vseq.sv
+++ b/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_base_vseq.sv
@@ -143,8 +143,9 @@ class rv_timer_base_vseq extends cip_base_vseq #(
     `DV_CHECK_NE_FATAL(intr_state_rg, null)
     is_fld = intr_state_rg.get_field_by_name($sformatf("is%0d", timer));
     `DV_CHECK_NE_FATAL(is_fld, null)
-    is_fld.set(1);
-    csr_update(.csr(intr_state_rg));
+    //is_fld.set(1);
+    //csr_update(.csr(intr_state_rg));
+    set_compare_val(hart, timer, 1);
     csr_rd(.ptr(intr_state_rg), .value(status));
   endtask
 

--- a/hw/ip/rv_timer/rtl/rv_timer_reg_pkg.sv
+++ b/hw/ip/rv_timer/rtl/rv_timer_reg_pkg.sv
@@ -36,10 +36,12 @@ package rv_timer_reg_pkg;
 
   typedef struct packed {
     logic [31:0] q;
+    logic        qe;
   } rv_timer_reg2hw_compare_lower0_0_reg_t;
 
   typedef struct packed {
     logic [31:0] q;
+    logic        qe;
   } rv_timer_reg2hw_compare_upper0_0_reg_t;
 
   typedef struct packed {
@@ -76,12 +78,12 @@ package rv_timer_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    rv_timer_reg2hw_ctrl_mreg_t [0:0] ctrl; // [152:152]
-    rv_timer_reg2hw_cfg0_reg_t cfg0; // [151:132]
-    rv_timer_reg2hw_timer_v_lower0_reg_t timer_v_lower0; // [131:100]
-    rv_timer_reg2hw_timer_v_upper0_reg_t timer_v_upper0; // [99:68]
-    rv_timer_reg2hw_compare_lower0_0_reg_t compare_lower0_0; // [67:36]
-    rv_timer_reg2hw_compare_upper0_0_reg_t compare_upper0_0; // [35:4]
+    rv_timer_reg2hw_ctrl_mreg_t [0:0] ctrl; // [154:154]
+    rv_timer_reg2hw_cfg0_reg_t cfg0; // [153:134]
+    rv_timer_reg2hw_timer_v_lower0_reg_t timer_v_lower0; // [133:102]
+    rv_timer_reg2hw_timer_v_upper0_reg_t timer_v_upper0; // [101:70]
+    rv_timer_reg2hw_compare_lower0_0_reg_t compare_lower0_0; // [69:37]
+    rv_timer_reg2hw_compare_upper0_0_reg_t compare_upper0_0; // [36:4]
     rv_timer_reg2hw_intr_enable0_mreg_t [0:0] intr_enable0; // [3:3]
     rv_timer_reg2hw_intr_state0_mreg_t [0:0] intr_state0; // [2:2]
     rv_timer_reg2hw_intr_test0_mreg_t [0:0] intr_test0; // [1:0]

--- a/hw/ip/rv_timer/rtl/rv_timer_reg_top.sv
+++ b/hw/ip/rv_timer/rtl/rv_timer_reg_top.sv
@@ -258,7 +258,7 @@ module rv_timer_reg_top (
     .d      ('0  ),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.compare_lower0_0.qe),
     .q      (reg2hw.compare_lower0_0.q ),
 
     // to register interface (read)
@@ -285,7 +285,7 @@ module rv_timer_reg_top (
     .d      ('0  ),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.compare_upper0_0.qe),
     .q      (reg2hw.compare_upper0_0.q ),
 
     // to register interface (read)

--- a/sw/device/tests/rv_timer/meson.build
+++ b/sw/device/tests/rv_timer/meson.build
@@ -10,6 +10,8 @@ rv_timer_test_elf = executable(
     sw_lib_irq,
     sw_lib_rv_timer,
     sw_lib_uart,
+    sw_lib_gpio,
+    sw_lib_pinmux,
     riscv_crt,
     sw_lib_irq_handlers,
   ],

--- a/sw/device/tests/rv_timer/rv_timer_test.c
+++ b/sw/device/tests/rv_timer/rv_timer_test.c
@@ -2,10 +2,11 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "sw/device/lib/common.h"
-#include "sw/device/lib/irq.h"
 #include "sw/device/lib/rv_timer.h"
+
+#include "sw/device/lib/common.h"
 #include "sw/device/lib/gpio.h"
+#include "sw/device/lib/irq.h"
 #include "sw/device/lib/pinmux.h"
 #include "sw/device/lib/uart.h"
 

--- a/sw/device/tests/rv_timer/rv_timer_test.c
+++ b/sw/device/tests/rv_timer/rv_timer_test.c
@@ -5,6 +5,8 @@
 #include "sw/device/lib/common.h"
 #include "sw/device/lib/irq.h"
 #include "sw/device/lib/rv_timer.h"
+#include "sw/device/lib/gpio.h"
+#include "sw/device/lib/pinmux.h"
 #include "sw/device/lib/uart.h"
 
 static uint32_t intr_handling_success = 0;
@@ -15,6 +17,10 @@ int main(int argc, char **argv) {
 
   uart_init(UART_BAUD_RATE);
 
+  pinmux_init();
+  // Enable GPIO: 0-7 and 16 is input, 8-15 is output
+  gpio_init(0xFF00);
+
   irq_global_ctrl(true);
   irq_timer_ctrl(true);
   rv_timer_set_us_tick(hart);
@@ -22,11 +28,15 @@ int main(int argc, char **argv) {
   rv_timer_ctrl(hart, true);
   rv_timer_intr_enable(hart, true);
 
+  gpio_write_all(0xFF00);  // all LEDs on
+
   while (1) {
     if (intr_handling_success) {
       break;
     }
   }
+
+  gpio_write_all(0xAA00);  // Test Completed
 
   uart_send_str("PASS!\r\n");
 }


### PR DESCRIPTION
RISC-V Previliged Spec mentioned that the interrupt line is dropped by
writing values to `mtimecmp`. @pfmooney raised the issue that the
RV_TIMER in OpenTitan doesn't follow this (see issue #1404 )

This commit is to change the rv_timer behavior to support clearing the
interrupt by updating `mtimecmp` CSRs.

Please note that the writing 1 to the interrupt status register also
clears it to support current VIP and the firmware.