### PR TITLE
[dv] Updates to enable CI setup

### DIFF
--- a/hw/dv/data/common_sim_cfg.hjson
+++ b/hw/dv/data/common_sim_cfg.hjson
@@ -100,7 +100,7 @@
   regressions: [
     {
       name: sanity
-      tests: ["{name}_sanity"]
+      reseed: 1
     }
 
     {

--- a/hw/ip/aes/dv/aes_sim_cfg.hjson
+++ b/hw/ip/aes/dv/aes_sim_cfg.hjson
@@ -68,4 +68,12 @@
       name: aes_stress
     }
   ]
+
+  // List of regressions.
+  regressions: [
+    {
+      name: sanity
+      tests: ["aes_sanity"]
+    }
+  ]
 }

--- a/hw/ip/alert_handler/dv/alert_handler_sim_cfg.hjson
+++ b/hw/ip/alert_handler/dv/alert_handler_sim_cfg.hjson
@@ -46,4 +46,12 @@
       uvm_test_seq: alert_handler_sanity_vseq
     }
   ]
+
+  // List of regressions.
+  regressions: [
+    {
+      name: sanity
+      tests: ["alert_handler_sanity"]
+    }
+  ]
 }

--- a/hw/ip/gpio/dv/gpio_sim_cfg.hjson
+++ b/hw/ip/gpio/dv/gpio_sim_cfg.hjson
@@ -120,4 +120,12 @@
       run_opts: ["+do_clear_all_interrupts=0"]
     }
   ]
+
+  // List of regressions.
+  regressions: [
+    {
+      name: sanity
+      tests: ["gpio_sanity"]
+    }
+  ]
 }

--- a/hw/ip/hmac/dv/hmac_sim_cfg.hjson
+++ b/hw/ip/hmac/dv/hmac_sim_cfg.hjson
@@ -92,5 +92,13 @@
       run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0"]
     }
   ]
+
+  // List of regressions.
+  regressions: [
+    {
+      name: sanity
+      tests: ["hmac_sanity", "hmac_test_sha_vectors"]
+    }
+  ]
 }
 

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -46,4 +46,12 @@
       uvm_test_seq: i2c_sanity_vseq
     }
   ]
+
+  // List of regressions.
+  regressions: [
+    // {
+    //   name: sanity
+    //   tests: ["i2c_sanity"]
+    // }
+  ]
 }

--- a/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
+++ b/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
@@ -48,4 +48,12 @@
       uvm_test_seq: rv_dm_sanity_vseq
     }
   ]
+
+  // List of regressions.
+  regressions: [
+    {
+      name: sanity
+      tests: ["rv_dm_sanity"]
+    }
+  ]
 }

--- a/hw/ip/rv_timer/dv/rv_timer_sim_cfg.hjson
+++ b/hw/ip/rv_timer/dv/rv_timer_sim_cfg.hjson
@@ -62,4 +62,12 @@
       uvm_test_seq: rv_timer_random_reset_vseq
     }
   ]
+
+  // List of regressions.
+  regressions: [
+    {
+      name: sanity
+      tests: ["rv_timer_sanity"]
+    }
+  ]
 }

--- a/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson
+++ b/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson
@@ -73,4 +73,12 @@
       uvm_test_seq: spi_device_dummy_item_extra_dly_vseq
     }
   ]
+
+  // List of regressions.
+  regressions: [
+    {
+      name: sanity
+      tests: ["spi_device_sanity"]
+    }
+  ]
 }

--- a/hw/ip/uart/dv/uart_sim_cfg.hjson
+++ b/hw/ip/uart/dv/uart_sim_cfg.hjson
@@ -111,4 +111,12 @@
       run_opts: ["+zero_delays=1"]
     }
   ]
+
+  // List of regressions.
+  regressions: [
+    {
+      name: sanity
+      tests: ["uart_sanity"]
+    }
+  ]
 }

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -57,5 +57,13 @@
       uvm_test_seq: usbdev_sanity_vseq
     }
   ]
+
+  // List of regressions.
+  regressions: [
+    // {
+    //   name: sanity
+    //   tests: ["usbdev_sanity"]
+    // }
+  ]
 }
 

--- a/hw/top_earlgrey/data/top_earlgrey_sim_cfgs_list.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey_sim_cfgs_list.hjson
@@ -1,0 +1,21 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  // This is the master cfg hjson for DV simulations. It imports ALL individual DV sim
+  // cfgs of the IPs and the full chip used in top_earlgrey. This enables the common
+  // regression sets to be run in one shot.
+  use_cfgs: [// TODO: #1467 AES DV is WIP - uncomment when sims are passing.
+             // "{proj_root}/hw/ip/aes/dv/aes_sim_cfg.hjson",
+             "{proj_root}/hw/ip/alert_handler/dv/alert_handler_sim_cfg.hjson",
+             "{proj_root}/hw/ip/gpio/dv/gpio_sim_cfg.hjson",
+             "{proj_root}/hw/ip/hmac/dv/hmac_sim_cfg.hjson",
+             // TODO: #1467 I2C DV is WIP - uncomment when sims are passing.
+             // "{proj_root}/hw/ip/i2c/dv/i2c_sim_cfg.hjson",
+             "{proj_root}/hw/ip/rv_timer/dv/rv_timer_sim_cfg.hjson",
+             "{proj_root}/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson",
+             "{proj_root}/hw/ip/uart/dv/uart_sim_cfg.hjson",
+             "{proj_root}/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson"]
+             // TODO: #1467 chip DV is WIP - uncomment when sims are passing.
+             // "{proj_root}/hw/top_earlgrey/dv/chip_sim_cfg.hjson"]
+}

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -69,5 +69,12 @@
       uvm_test_seq: chip_sanity_vseq
     }
   ]
-}
 
+  // List of regressions.
+  regressions: [
+    {
+      name: sanity
+      tests: ["chip_sanity"]
+    }
+  ]
+}

--- a/util/uvmdvgen/sim_cfg.hjson.tpl
+++ b/util/uvmdvgen/sim_cfg.hjson.tpl
@@ -59,5 +59,13 @@
 
     // TODO: add more tests here
   ]
+
+  // List of regressions.
+  regressions: [
+    {
+      name: sanity
+      tests: ["${name}_sanity"]
+    }
+  ]
 }
 


### PR DESCRIPTION
- Added 'sanity' regression bucket that each IP can set the list of
tests for
- Updated 'sanity' regression to have only 1 reseed
- Added top_earlgrey_sim_cfgs_list.hjson as a 'master' cfg list to run
sanity for all IPs it comprises of and the full chip

Signed-off-by: Srikrishna Iyer <sriyer@google.com>