### PR TITLE
[dv/hmac,ase] DPI_naming_convention

### DIFF
--- a/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi.c
+++ b/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi.c
@@ -12,9 +12,9 @@
 
 #include "aes_model_dpi.h"
 
-void aes_crypt_dpi(const unsigned char impl_i, const unsigned char mode_i,
-                   const svBitVecVal *key_len_i, const svBitVecVal *key_i,
-                   const svBitVecVal *data_i, svBitVecVal *data_o) {
+void c_dpi_aes_crypt(const unsigned char impl_i, const unsigned char mode_i,
+                     const svBitVecVal *key_len_i, const svBitVecVal *key_i,
+                     const svBitVecVal *data_i, svBitVecVal *data_o) {
   // get input data from simulator
   unsigned char *key = aes_key_get(key_i);
   unsigned char *ref_in = aes_data_get(data_i);
@@ -89,8 +89,8 @@ void aes_crypt_dpi(const unsigned char impl_i, const unsigned char mode_i,
   return;
 }
 
-void aes_sub_bytes_dpi(const unsigned char mode_i, const svBitVecVal *data_i,
-                       svBitVecVal *data_o) {
+void c_dpi_aes_sub_bytes(const unsigned char mode_i, const svBitVecVal *data_i,
+                         svBitVecVal *data_o) {
   // get input data from simulator
   unsigned char *data = aes_data_get(data_i);
 
@@ -107,8 +107,8 @@ void aes_sub_bytes_dpi(const unsigned char mode_i, const svBitVecVal *data_i,
   return;
 }
 
-void aes_shift_rows_dpi(const unsigned char mode_i, const svBitVecVal *data_i,
-                        svBitVecVal *data_o) {
+void c_dpi_aes_shift_rows(const unsigned char mode_i, const svBitVecVal *data_i,
+                          svBitVecVal *data_o) {
   // get input data from simulator
   unsigned char *data = aes_data_get(data_i);
 
@@ -125,8 +125,8 @@ void aes_shift_rows_dpi(const unsigned char mode_i, const svBitVecVal *data_i,
   return;
 }
 
-void aes_mix_columns_dpi(const unsigned char mode_i, const svBitVecVal *data_i,
-                         svBitVecVal *data_o) {
+void c_dpi_aes_mix_columns(const unsigned char mode_i,
+                           const svBitVecVal *data_i, svBitVecVal *data_o) {
   // get input data from simulator
   unsigned char *data = aes_data_get(data_i);
 
@@ -143,10 +143,10 @@ void aes_mix_columns_dpi(const unsigned char mode_i, const svBitVecVal *data_i,
   return;
 }
 
-void aes_key_expand_dpi(const unsigned char mode_i, const svBitVecVal *rcon_i,
-                        const svBitVecVal *round_i,
-                        const svBitVecVal *key_len_i, const svBitVecVal *key_i,
-                        svBitVecVal *key_o) {
+void c_dpi_aes_key_expand(const unsigned char mode_i, const svBitVecVal *rcon_i,
+                          const svBitVecVal *round_i,
+                          const svBitVecVal *key_len_i,
+                          const svBitVecVal *key_i, svBitVecVal *key_o) {
   unsigned char round_key[16];  // just used by model
 
   // get input data

--- a/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi.h
+++ b/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi.h
@@ -21,9 +21,9 @@ extern "C" {
  * @param  data_i    Input data, 2D state matrix (3D packed array in SV)
  * @param  data_o    Output data, 2D state matrix (3D packed array in SV)
  */
-void aes_crypt_dpi(const unsigned char impl_i, const unsigned char mode_i,
-                   const svBitVecVal *key_len_i, const svBitVecVal *key_i,
-                   const svBitVecVal *data_i, svBitVecVal *data_o);
+void c_dpi_aes_crypt(const unsigned char impl_i, const unsigned char mode_i,
+                     const svBitVecVal *key_len_i, const svBitVecVal *key_i,
+                     const svBitVecVal *data_i, svBitVecVal *data_o);
 
 /**
  * Perform sub bytes operation during encryption/decryption.
@@ -32,8 +32,8 @@ void aes_crypt_dpi(const unsigned char impl_i, const unsigned char mode_i,
  * @param  data_i Input data
  * @param  data_o Output data
  */
-void aes_sub_bytes_dpi(const unsigned char mode_i, const svBitVecVal *data_i,
-                       svBitVecVal *data_o);
+void c_dpi_aes_sub_bytes(const unsigned char mode_i, const svBitVecVal *data_i,
+                         svBitVecVal *data_o);
 
 /**
  * Perform shift rows operation during encryption/decryption.
@@ -42,8 +42,8 @@ void aes_sub_bytes_dpi(const unsigned char mode_i, const svBitVecVal *data_i,
  * @param  data_i Input data
  * @param  data_o Output data
  */
-void aes_shift_rows_dpi(const unsigned char mode_i, const svBitVecVal *data_i,
-                        svBitVecVal *data_o);
+void c_dpi_aes_shift_rows(const unsigned char mode_i, const svBitVecVal *data_i,
+                          svBitVecVal *data_o);
 
 /**
  * Perform mix columns operation during encryption/decryption.
@@ -52,8 +52,8 @@ void aes_shift_rows_dpi(const unsigned char mode_i, const svBitVecVal *data_i,
  * @param  data_i Input data
  * @param  data_o Output data
  */
-void aes_mix_columns_dpi(const unsigned char mode_i, const svBitVecVal *data_i,
-                         svBitVecVal *data_o);
+void c_dpi_aes_mix_columns(const unsigned char mode_i,
+                           const svBitVecVal *data_i, svBitVecVal *data_o);
 
 /**
  * Generate full key for next round during encryption/decryption.
@@ -65,10 +65,10 @@ void aes_mix_columns_dpi(const unsigned char mode_i, const svBitVecVal *data_i,
  * @param  key_i     Full input key
  * @param  key_o     Full output key
  */
-void aes_key_expand_dpi(const unsigned char mode_i, const svBitVecVal *rcon_i,
-                        const svBitVecVal *round_i,
-                        const svBitVecVal *key_len_i, const svBitVecVal *key_i,
-                        svBitVecVal *key_o);
+void c_dpi_aes_key_expand(const unsigned char mode_i, const svBitVecVal *rcon_i,
+                          const svBitVecVal *round_i,
+                          const svBitVecVal *key_len_i,
+                          const svBitVecVal *key_i, svBitVecVal *key_o);
 
 /**
  * Get packed data block from simulation.

--- a/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi_pkg.sv
+++ b/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi_pkg.sv
@@ -6,7 +6,7 @@ package aes_model_dpi_pkg;
   import aes_pkg::*;
 
   // DPI-C imports
-  import "DPI-C" context function void aes_crypt_dpi(
+  import "DPI-C" context function void c_dpi_aes_crypt(
     input  bit                impl_i,
     input  bit                mode_i,
     input  bit          [2:0] key_len_i,
@@ -15,25 +15,25 @@ package aes_model_dpi_pkg;
     output bit[3:0][3:0][7:0] data_o
   );
 
-  import "DPI-C" context function void aes_sub_bytes_dpi(
+  import "DPI-C" context function void c_dpi_aes_sub_bytes(
     input  bit                mode_i,
     input  bit[3:0][3:0][7:0] data_i,
     output bit[3:0][3:0][7:0] data_o
   );
 
-  import "DPI-C" context function void aes_shift_rows_dpi(
+  import "DPI-C" context function void c_dpi_aes_shift_rows(
     input  bit                mode_i,
     input  bit[3:0][3:0][7:0] data_i,
     output bit[3:0][3:0][7:0] data_o
   );
 
-  import "DPI-C" context function void aes_mix_columns_dpi(
+  import "DPI-C" context function void c_dpi_aes_mix_columns(
     input  bit                mode_i,
     input  bit[3:0][3:0][7:0] data_i,
     output bit[3:0][3:0][7:0] data_o
   );
 
-  import "DPI-C" context function void aes_key_expand_dpi(
+  import "DPI-C" context function void c_dpi_aes_key_expand(
     input  bit            mode_i,
     input  bit      [7:0] rcon_i,
     input  bit      [3:0] round_i,
@@ -45,7 +45,7 @@ package aes_model_dpi_pkg;
   // wrapper function that converts from register format (4x32bit)
   // to the 4x4x8 format of the c functions and back
   // this ensures that RTL and refence models have same input and output format.
-  function automatic void aes_crypt(
+  function automatic void sv_dpi_aes_crypt(
     input  bit             impl_i,
     input  bit             mode_i,
     input  bit       [2:0] key_len_i,
@@ -55,7 +55,7 @@ package aes_model_dpi_pkg;
 
     bit [3:0][3:0][7:0] data_in, data_out;
     data_in = aes_transpose(data_i);
-    aes_crypt_dpi(impl_i, mode_i, key_len_i, key_i, data_in, data_out);
+    c_dpi_aes_crypt(impl_i, mode_i, key_len_i, key_i, data_in, data_out);
     data_o  = aes_transpose(data_out);
     return;
   endfunction

--- a/hw/ip/aes/dv/env/aes_scoreboard.sv
+++ b/hw/ip/aes/dv/env/aes_scoreboard.sv
@@ -192,7 +192,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
       ref_fifo.get(c_item );
       `uvm_info(`gfn, $sformatf("\n\t ----| GOT item "), UVM_HIGH)
 
-      aes_crypt(1'b0, c_item.mode, c_item.key_size, c_item.key, c_item.data_in, c_item.data_out);
+      sv_dpi_aes_crypt(1'b0, c_item.mode, c_item.key_size, c_item.key, c_item.data_in, c_item.data_out);
          `uvm_info(`gfn, $sformatf("\n\t ----| printing C MODEL %s", c_item.convert2string() )
                    , UVM_HIGH)
 

--- a/hw/ip/hmac/dv/cryptoc_dpi/cryptoc_dpi.c
+++ b/hw/ip/hmac/dv/cryptoc_dpi/cryptoc_dpi.c
@@ -13,8 +13,8 @@
 
 typedef unsigned long long ull_t;
 
-extern void SHA_hash_dpi(const svOpenArrayHandle msg, ull_t len,
-                         uint8_t hash[8]) {
+extern void c_dpi_SHA_hash(const svOpenArrayHandle msg, ull_t len,
+                           uint8_t hash[8]) {
   unsigned char *arr;
   unsigned int *arr_ptr;
   ull_t i;
@@ -32,8 +32,8 @@ extern void SHA_hash_dpi(const svOpenArrayHandle msg, ull_t len,
   free(arr);
 }
 
-extern void SHA256_hash_dpi(const svOpenArrayHandle msg, ull_t len,
-                            uint8_t hash[8]) {
+extern void c_dpi_SHA256_hash(const svOpenArrayHandle msg, ull_t len,
+                              uint8_t hash[8]) {
   unsigned char *arr;
   unsigned int *arr_ptr;
   ull_t i;
@@ -56,9 +56,9 @@ extern void SHA256_hash_dpi(const svOpenArrayHandle msg, ull_t len,
   }
 }
 
-extern void HMAC_SHA_dpi(const svOpenArrayHandle key, ull_t key_len,
-                         const svOpenArrayHandle msg, ull_t msg_len,
-                         uint8_t hmac[8]) {
+extern void c_dpi_HMAC_SHA(const svOpenArrayHandle key, ull_t key_len,
+                           const svOpenArrayHandle msg, ull_t msg_len,
+                           uint8_t hmac[8]) {
   unsigned char *msg_arr;
   unsigned int *msg_arr_ptr;
   unsigned char *key_arr;
@@ -86,9 +86,9 @@ extern void HMAC_SHA_dpi(const svOpenArrayHandle key, ull_t key_len,
   free(key_arr);
 }
 
-extern void HMAC_SHA256_dpi(const svOpenArrayHandle key, ull_t key_len,
-                            const svOpenArrayHandle msg, ull_t msg_len,
-                            uint8_t hmac[8]) {
+extern void c_dpi_HMAC_SHA256(const svOpenArrayHandle key, ull_t key_len,
+                              const svOpenArrayHandle msg, ull_t msg_len,
+                              uint8_t hmac[8]) {
   unsigned char *msg_arr;
   unsigned int *msg_arr_ptr;
   unsigned char *key_arr;

--- a/hw/ip/hmac/dv/cryptoc_dpi/cryptoc_dpi_pkg.sv
+++ b/hw/ip/hmac/dv/cryptoc_dpi/cryptoc_dpi_pkg.sv
@@ -10,55 +10,55 @@ package cryptoc_dpi_pkg;
   `include "uvm_macros.svh"
 
   // DPI-C imports
-  import "DPI-C" context function void SHA_hash_dpi(input bit[7:0] msg[],
-                                                    input longint unsigned len,
-                                                    output int unsigned hash[8]);
+  import "DPI-C" context function void c_dpi_SHA_hash(input bit[7:0] msg[],
+                                                      input longint unsigned len,
+                                                      output int unsigned hash[8]);
 
-  import "DPI-C" context function void SHA256_hash_dpi(input bit[7:0] msg[],
-                                                       input longint unsigned len,
-                                                       output int unsigned hash[8]);
+  import "DPI-C" context function void c_dpi_SHA256_hash(input bit[7:0] msg[],
+                                                         input longint unsigned len,
+                                                         output int unsigned hash[8]);
 
-  import "DPI-C" context function void HMAC_SHA_dpi(input bit[7:0] key[],
-                                                    input longint unsigned key_len,
-                                                    input bit[7:0] msg[],
-                                                    input longint unsigned msg_len,
-                                                    output int unsigned hmac[8]);
+  import "DPI-C" context function void c_dpi_HMAC_SHA(input bit[7:0] key[],
+                                                      input longint unsigned key_len,
+                                                      input bit[7:0] msg[],
+                                                      input longint unsigned msg_len,
+                                                      output int unsigned hmac[8]);
 
-  import "DPI-C" context function void HMAC_SHA256_dpi(input bit[7:0] key[],
-                                                       input longint unsigned key_len,
-                                                       input bit[7:0] msg[],
-                                                       input longint unsigned msg_len,
-                                                       output int unsigned hmac[8]);
+  import "DPI-C" context function void c_dpi_HMAC_SHA256(input bit[7:0] key[],
+                                                         input longint unsigned key_len,
+                                                         input bit[7:0] msg[],
+                                                         input longint unsigned msg_len,
+                                                         output int unsigned hmac[8]);
 
   // sv wrapper functions
-  function automatic void get_sha_digest(input bit[7:0] msg[],
-                                         output int unsigned hash[8]);
-    SHA_hash_dpi(msg, msg.size(), hash);
+  function automatic void sv_dpi_get_sha_digest(input bit[7:0] msg[],
+                                                output int unsigned hash[8]);
+    c_dpi_SHA_hash(msg, msg.size(), hash);
   endfunction
 
-  function automatic void get_sha256_digest(input bit[7:0] msg[],
-                                            output int unsigned hash[8]);
-    SHA256_hash_dpi(msg, msg.size(), hash);
+  function automatic void sv_dpi_get_sha256_digest(input bit[7:0] msg[],
+                                                   output int unsigned hash[8]);
+    c_dpi_SHA256_hash(msg, msg.size(), hash);
   endfunction
 
-  function automatic void get_hmac_sha(input bit[31:0] key[],
-                                       input bit[7:0] msg[],
-                                       output int unsigned hmac[8]);
+  function automatic void sv_dpi_get_hmac_sha(input bit[31:0] key[],
+                                              input bit[7:0] msg[],
+                                              output int unsigned hmac[8]);
     bit [7:0] ckey[];
     int ckey_size_bytes = $bits(key) / 8;
     ckey = new[ckey_size_bytes];
     {>>{ckey}} = key;
-    HMAC_SHA_dpi(ckey, ckey.size(), msg, msg.size(), hmac);
+    c_dpi_HMAC_SHA(ckey, ckey.size(), msg, msg.size(), hmac);
   endfunction
 
-  function automatic void get_hmac_sha256(input bit[31:0] key[],
-                                          input bit[7:0]  msg[],
-                                          output int unsigned hmac[8]);
+  function automatic void sv_dpi_get_hmac_sha256(input bit[31:0] key[],
+                                                 input bit[7:0]  msg[],
+                                                 output int unsigned hmac[8]);
     bit [7:0] ckey[];
     int ckey_size_bytes = $bits(key) / 8;
     ckey = new[ckey_size_bytes];
     {>>{ckey}} = key;
-    HMAC_SHA256_dpi(ckey, ckey.size(), msg, msg.size(), hmac);
+    c_dpi_HMAC_SHA256(ckey, ckey.size(), msg, msg.size(), hmac);
   endfunction
 
 endpackage

--- a/hw/ip/hmac/dv/env/hmac_scoreboard.sv
+++ b/hw/ip/hmac/dv/env/hmac_scoreboard.sv
@@ -358,10 +358,10 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
     bit          sha_en  = ral.cfg.sha_en.get_mirrored_value();
     case ({hmac_en, sha_en})
       2'b11: begin
-        cryptoc_dpi_pkg::get_hmac_sha256(key, msg_q, exp_digest);
+        cryptoc_dpi_pkg::sv_dpi_get_hmac_sha256(key, msg_q, exp_digest);
       end
       2'b01: begin
-        cryptoc_dpi_pkg::get_sha256_digest(msg_q, exp_digest);
+        cryptoc_dpi_pkg::sv_dpi_get_sha256_digest(msg_q, exp_digest);
       end
       default: begin
         // disgest is cleared if sha_en = 0


### PR DESCRIPTION
Follow the verilog style guide DPI naming convention

Signed-off-by: Cindy Chen <chencindy@google.com>