### PR TITLE
[sw] Fix a few non-absolute includes

### DIFF
--- a/sw/device/lib/handler.c
+++ b/sw/device/lib/handler.c
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "handler.h"
+#include "sw/device/lib/handler.h"
 
 #include "sw/device/lib/base/stdasm.h"
 #include "sw/device/lib/common.h"

--- a/sw/device/lib/hmac.c
+++ b/sw/device/lib/hmac.c
@@ -2,10 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "hmac.h"
+#include "sw/device/lib/hmac.h"
 
 #include "hmac_regs.h"  // Generated.
-
 #include "sw/device/lib/common.h"
 
 #define HMAC0_BASE_ADDR 0x40120000

--- a/sw/device/lib/hw_sha256.c
+++ b/sw/device/lib/hw_sha256.c
@@ -4,7 +4,7 @@
 
 #include "sw/device/lib/hw_sha256.h"
 
-#include "hmac.h"
+#include "sw/device/lib/hmac.h"
 
 static const HASH_VTAB HW_SHA256_VTAB = {.init = &hw_SHA256_init,
                                          .update = &hw_SHA256_update,

--- a/sw/device/lib/usb_simpleserial.h
+++ b/sw/device/lib/usb_simpleserial.h
@@ -9,7 +9,7 @@
 #include <stdint.h>
 
 #include "sw/device/lib/common.h"
-#include "usbdev.h"
+#include "sw/device/lib/usbdev.h"
 
 // This is only here because caller of _init needs it
 typedef struct usb_ss_ctx {


### PR DESCRIPTION
Unfortunately I don't know of a way to force GCC and Clang to not include these in their include searches, so they've been slipping by quietly.