### PR TITLE
[mock_testing, dif_uart] Introduce UART mock tests

### DIFF
--- a/sw/device/lib/dif/dif_uart.c
+++ b/sw/device/lib/dif/dif_uart.c
@@ -9,10 +9,9 @@
 #include "sw/device/lib/base/mmio.h"
 #include "uart_regs.h"  // Generated.
 
-#define UART_RX_FIFO_SIZE_BYTES 32u
-#define UART_TX_FIFO_SIZE_BYTES 32u
-
 #define UART_INTR_STATE_MASK 0xffffffffu
+
+const uint32_t kDifUartFifoSizeBytes = 32u;
 
 static bool uart_tx_full(const dif_uart_t *uart) {
   return mmio_region_get_bit32(uart->base_addr, UART_STATUS_REG_OFFSET,
@@ -456,7 +455,7 @@ bool dif_uart_tx_bytes_available(const dif_uart_t *uart, size_t *num_bytes) {
       uart->base_addr, UART_FIFO_STATUS_REG_OFFSET, UART_FIFO_STATUS_TXLVL_MASK,
       UART_FIFO_STATUS_TXLVL_OFFSET);
 
-  *num_bytes = UART_TX_FIFO_SIZE_BYTES - fill_bytes;
+  *num_bytes = kDifUartFifoSizeBytes - fill_bytes;
 
   return true;
 }

--- a/sw/device/lib/dif/dif_uart.c
+++ b/sw/device/lib/dif/dif_uart.c
@@ -169,7 +169,7 @@ static size_t uart_bytes_receive(const dif_uart_t *uart, size_t bytes_requested,
 
 bool dif_uart_init(mmio_region_t base_addr, const dif_uart_config_t *config,
                    dif_uart_t *uart) {
-  if (uart == NULL || config == NULL || base_addr.base == NULL) {
+  if (uart == NULL || config == NULL) {
     return false;
   }
 

--- a/sw/device/lib/dif/dif_uart.h
+++ b/sw/device/lib/dif/dif_uart.h
@@ -10,6 +10,9 @@
 
 #include "sw/device/lib/base/mmio.h"
 
+// The size of UART TX and RX FIFOs in bytes.
+extern const uint32_t kDifUartFifoSizeBytes;
+
 /**
  * UART interrupt configuration.
  *

--- a/sw/device/tests/dif/dif_uart_test.cc
+++ b/sw/device/tests/dif/dif_uart_test.cc
@@ -1,0 +1,650 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/testing/mock_mmio.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/mmio.h"
+
+extern "C" {
+#include "sw/device/lib/dif/dif_uart.h"
+#include "uart_regs.h"  // Generated.
+}  // extern "C"
+
+namespace dif_uart_test {
+namespace {
+using mock_mmio::MmioTest;
+using mock_mmio::MockDevice;
+using testing::Each;
+using testing::Eq;
+using testing::Test;
+
+const std::vector<uint8_t> kBytesArray = {
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a',
+    'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l',
+    'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
+};
+
+class UartTest : public Test, public MmioTest {
+ protected:
+  void ExpectDeviceReset() {
+    EXPECT_WRITE32(UART_CTRL_REG_OFFSET, 0);
+    EXPECT_WRITE32(UART_FIFO_CTRL_REG_OFFSET, {
+                                                  {UART_FIFO_CTRL_RXRST, true},
+                                                  {UART_FIFO_CTRL_TXRST, true},
+                                              });
+    EXPECT_WRITE32(UART_OVRD_REG_OFFSET, 0);
+    EXPECT_WRITE32(UART_TIMEOUT_CTRL_REG_OFFSET, 0);
+    EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET, 0);
+    EXPECT_WRITE32(UART_INTR_STATE_REG_OFFSET,
+                   std::numeric_limits<uint32_t>::max());
+  }
+
+  mmio_region_t base_addr_ = dev().region();
+  dif_uart_t dif_uart_ = {
+      /* base_addr = */ base_addr_,
+  };
+
+  // NCO is calculated as NCO = 2^20 * fbaud / fpclk, so the following values
+  // should result in NCO of 1. This is the default configuration, which will
+  // be used unless the values are overriden.
+  dif_uart_config_t dif_uart_config_ = {
+      /* baudrate = */ 1,
+      /* clk_freq_hz = */ 1048576,
+      /* parity_enable = */ kDifUartDisable,
+      /* parity = */ kDifUartParityEven,
+  };
+};
+
+class InitTest : public UartTest {};
+
+TEST_F(InitTest, NullArgs) {
+  EXPECT_FALSE(dif_uart_init(base_addr_, &dif_uart_config_, nullptr));
+  EXPECT_FALSE(dif_uart_init(base_addr_, nullptr, &dif_uart_));
+  EXPECT_FALSE(dif_uart_init(base_addr_, nullptr, nullptr));
+}
+
+TEST_F(InitTest, Default) {
+  ExpectDeviceReset();
+
+  EXPECT_WRITE32(
+      UART_CTRL_REG_OFFSET,
+      {
+          {UART_CTRL_TX, true}, {UART_CTRL_RX, true}, {UART_CTRL_NCO_OFFSET, 1},
+      });
+
+  EXPECT_WRITE32(UART_FIFO_CTRL_REG_OFFSET,
+                 {
+                     {UART_FIFO_CTRL_RXRST, true}, {UART_FIFO_CTRL_TXRST, true},
+                 });
+
+  EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET, 0);
+
+  EXPECT_TRUE(dif_uart_init(base_addr_, &dif_uart_config_, &dif_uart_));
+}
+
+TEST_F(InitTest, ParityEven) {
+  dif_uart_config_.parity_enable = kDifUartEnable;
+  dif_uart_config_.parity = kDifUartParityEven;
+
+  ExpectDeviceReset();
+
+  EXPECT_WRITE32(UART_CTRL_REG_OFFSET, {
+                                           {UART_CTRL_TX, true},
+                                           {UART_CTRL_RX, true},
+                                           {UART_CTRL_PARITY_EN, true},
+                                           {UART_CTRL_NCO_OFFSET, 1},
+                                       });
+
+  EXPECT_WRITE32(UART_FIFO_CTRL_REG_OFFSET,
+                 {
+                     {UART_FIFO_CTRL_RXRST, true}, {UART_FIFO_CTRL_TXRST, true},
+                 });
+
+  EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET, 0);
+
+  EXPECT_TRUE(dif_uart_init(base_addr_, &dif_uart_config_, &dif_uart_));
+}
+
+TEST_F(InitTest, ParityOdd) {
+  dif_uart_config_.parity_enable = kDifUartEnable;
+  dif_uart_config_.parity = kDifUartParityOdd;
+
+  ExpectDeviceReset();
+
+  EXPECT_WRITE32(UART_CTRL_REG_OFFSET, {
+                                           {UART_CTRL_TX, true},
+                                           {UART_CTRL_RX, true},
+                                           {UART_CTRL_PARITY_EN, true},
+                                           {UART_CTRL_PARITY_ODD, true},
+                                           {UART_CTRL_NCO_OFFSET, 1},
+                                       });
+
+  EXPECT_WRITE32(UART_FIFO_CTRL_REG_OFFSET,
+                 {
+                     {UART_FIFO_CTRL_RXRST, true}, {UART_FIFO_CTRL_TXRST, true},
+                 });
+
+  EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET, 0);
+
+  EXPECT_TRUE(dif_uart_init(base_addr_, &dif_uart_config_, &dif_uart_));
+}
+
+class ConfigTest : public UartTest {};
+
+TEST_F(ConfigTest, NullArgs) {
+  EXPECT_FALSE(dif_uart_init(base_addr_, &dif_uart_config_, nullptr));
+  EXPECT_FALSE(dif_uart_init(base_addr_, nullptr, &dif_uart_));
+  EXPECT_FALSE(dif_uart_init(base_addr_, nullptr, nullptr));
+}
+
+TEST_F(ConfigTest, Default) {
+  ExpectDeviceReset();
+
+  EXPECT_WRITE32(
+      UART_CTRL_REG_OFFSET,
+      {
+          {UART_CTRL_TX, true}, {UART_CTRL_RX, true}, {UART_CTRL_NCO_OFFSET, 1},
+      });
+
+  EXPECT_WRITE32(UART_FIFO_CTRL_REG_OFFSET,
+                 {
+                     {UART_FIFO_CTRL_RXRST, true}, {UART_FIFO_CTRL_TXRST, true},
+                 });
+
+  EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET, 0);
+
+  EXPECT_TRUE(dif_uart_configure(&dif_uart_, &dif_uart_config_));
+}
+
+TEST_F(ConfigTest, ParityEven) {
+  ExpectDeviceReset();
+
+  dif_uart_config_.parity_enable = kDifUartEnable;
+  dif_uart_config_.parity = kDifUartParityEven;
+
+  EXPECT_WRITE32(UART_CTRL_REG_OFFSET, {
+                                           {UART_CTRL_TX, true},
+                                           {UART_CTRL_RX, true},
+                                           {UART_CTRL_PARITY_EN, true},
+                                           {UART_CTRL_NCO_OFFSET, 1},
+                                       });
+
+  EXPECT_WRITE32(UART_FIFO_CTRL_REG_OFFSET,
+                 {
+                     {UART_FIFO_CTRL_RXRST, true}, {UART_FIFO_CTRL_TXRST, true},
+                 });
+
+  EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET, 0);
+
+  EXPECT_TRUE(dif_uart_configure(&dif_uart_, &dif_uart_config_));
+}
+
+TEST_F(ConfigTest, ParityOdd) {
+  ExpectDeviceReset();
+
+  dif_uart_config_.parity_enable = kDifUartEnable;
+  dif_uart_config_.parity = kDifUartParityOdd;
+
+  EXPECT_WRITE32(UART_CTRL_REG_OFFSET, {
+                                           {UART_CTRL_TX, true},
+                                           {UART_CTRL_RX, true},
+                                           {UART_CTRL_PARITY_EN, true},
+                                           {UART_CTRL_PARITY_ODD, true},
+                                           {UART_CTRL_NCO_OFFSET, 1},
+                                       });
+
+  EXPECT_WRITE32(UART_FIFO_CTRL_REG_OFFSET,
+                 {
+                     {UART_FIFO_CTRL_RXRST, true}, {UART_FIFO_CTRL_TXRST, true},
+                 });
+
+  EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET, 0);
+
+  EXPECT_TRUE(dif_uart_configure(&dif_uart_, &dif_uart_config_));
+}
+
+class WatermarkRxSetTest : public UartTest {};
+
+TEST_F(WatermarkRxSetTest, UartNull) {
+  EXPECT_FALSE(dif_uart_watermark_rx_set(nullptr, kDifUartWatermarkByte1));
+}
+
+/**
+ * Tests the first and the last RX watermark variants.
+ */
+TEST_F(WatermarkRxSetTest, Success) {
+  EXPECT_MASK32(UART_FIFO_CTRL_REG_OFFSET,
+                {
+                    {UART_FIFO_CTRL_RXILVL_OFFSET, UART_FIFO_CTRL_RXILVL_MASK,
+                     UART_FIFO_CTRL_RXILVL_RXLVL1},
+                });
+
+  EXPECT_TRUE(dif_uart_watermark_rx_set(&dif_uart_, kDifUartWatermarkByte1));
+
+  EXPECT_MASK32(UART_FIFO_CTRL_REG_OFFSET,
+                {
+                    {UART_FIFO_CTRL_RXILVL_OFFSET, UART_FIFO_CTRL_RXILVL_MASK,
+                     UART_FIFO_CTRL_RXILVL_RXLVL30},
+                });
+
+  EXPECT_TRUE(dif_uart_watermark_rx_set(&dif_uart_, kDifUartWatermarkByte30));
+}
+
+class WatermarkTxSetTest : public UartTest {};
+
+TEST_F(WatermarkTxSetTest, NullArgs) {
+  EXPECT_FALSE(dif_uart_watermark_tx_set(nullptr, kDifUartWatermarkByte1));
+}
+
+TEST_F(WatermarkTxSetTest, InvalidWatermark) {
+  EXPECT_FALSE(dif_uart_watermark_tx_set(&dif_uart_, kDifUartWatermarkByte30));
+}
+
+/**
+ * Tests the first and the last TX watermark variants.
+ */
+TEST_F(WatermarkTxSetTest, Success) {
+  EXPECT_MASK32(UART_FIFO_CTRL_REG_OFFSET,
+                {
+                    {UART_FIFO_CTRL_TXILVL_OFFSET, UART_FIFO_CTRL_TXILVL_MASK,
+                     UART_FIFO_CTRL_TXILVL_TXLVL1},
+                });
+
+  EXPECT_TRUE(dif_uart_watermark_tx_set(&dif_uart_, kDifUartWatermarkByte1));
+
+  EXPECT_MASK32(UART_FIFO_CTRL_REG_OFFSET,
+                {
+                    {UART_FIFO_CTRL_TXILVL_OFFSET, UART_FIFO_CTRL_TXILVL_MASK,
+                     UART_FIFO_CTRL_TXILVL_TXLVL16},
+                });
+
+  EXPECT_TRUE(dif_uart_watermark_tx_set(&dif_uart_, kDifUartWatermarkByte16));
+}
+
+class BytesSendTest : public UartTest {
+ protected:
+  /**
+   * Sets TX bytes expectations.
+   *
+   * Every sent byte by the "send bytes" routine is expected to result in the
+   * STATUS read of 0 (FIFO not full), and write to WDATA.
+   */
+  void ExpectSendBytes(int num_elements) {
+    ASSERT_LE(num_elements, kBytesArray.size());
+    for (int i = 0; i < num_elements; ++i) {
+      uint32_t value = static_cast<uint32_t>(kBytesArray[i]);
+      EXPECT_READ32(UART_STATUS_REG_OFFSET, 0);
+      EXPECT_WRITE32(UART_WDATA_REG_OFFSET, value);
+    }
+  }
+};
+
+TEST_F(BytesSendTest, NullArgs) {
+  EXPECT_FALSE(dif_uart_bytes_send(nullptr, kBytesArray.data(), 1, nullptr));
+  EXPECT_FALSE(dif_uart_bytes_send(&dif_uart_, nullptr, 1, nullptr));
+  EXPECT_FALSE(dif_uart_bytes_send(nullptr, nullptr, 1, nullptr));
+}
+
+TEST_F(BytesSendTest, TxFifoEmptyBytesWrittenNull) {
+  uint8_t num_bytes = kBytesArray.size();
+  ExpectSendBytes(num_bytes);
+
+  EXPECT_TRUE(
+      dif_uart_bytes_send(&dif_uart_, kBytesArray.data(), num_bytes, nullptr));
+}
+
+TEST_F(BytesSendTest, TxFifoEmpty) {
+  uint8_t num_bytes = kBytesArray.size();
+  ExpectSendBytes(num_bytes);
+
+  size_t bytes_written = 0;
+  EXPECT_TRUE(dif_uart_bytes_send(&dif_uart_, kBytesArray.data(), num_bytes,
+                                  &bytes_written));
+
+  EXPECT_EQ(bytes_written, num_bytes);
+}
+
+TEST_F(BytesSendTest, TxFifoFull) {
+  EXPECT_READ32(UART_STATUS_REG_OFFSET, {{UART_STATUS_TXFULL, true}});
+
+  uint8_t num_bytes = kBytesArray.size();
+  size_t bytes_written = std::numeric_limits<size_t>::max();
+  EXPECT_TRUE(dif_uart_bytes_send(&dif_uart_, kBytesArray.data(), num_bytes,
+                                  &bytes_written));
+
+  EXPECT_EQ(bytes_written, 0);
+}
+
+class BytesReceiveTest : public UartTest {
+ protected:
+  /**
+   * Sets RX bytes expectations.
+   *
+   * Every read byte by the "receive bytes" routine is expected to result in the
+   * STATUS read of 0 (FIFO not empty), and read of RDATA.
+   */
+  void ExpectReceiveBytes(int num_elements) {
+    for (int i = 0; i < num_elements; ++i) {
+      uint32_t value = static_cast<uint32_t>(kBytesArray[i]);
+      EXPECT_READ32(UART_STATUS_REG_OFFSET, 0);
+      EXPECT_READ32(UART_RDATA_REG_OFFSET, value);
+    }
+  }
+};
+
+TEST_F(BytesReceiveTest, UartNull) {
+  std::vector<uint8_t> receive_bytes(1);
+  EXPECT_FALSE(
+      dif_uart_bytes_receive(nullptr, 1, receive_bytes.data(), nullptr));
+  EXPECT_THAT(receive_bytes, Each(Eq(0)));
+
+  EXPECT_FALSE(dif_uart_bytes_receive(&dif_uart_, 1, nullptr, nullptr));
+  EXPECT_FALSE(dif_uart_bytes_receive(nullptr, 1, nullptr, nullptr));
+}
+
+TEST_F(BytesReceiveTest, RxFifoFullBytesWrittenNull) {
+  uint8_t num_bytes = kBytesArray.size();
+  ExpectReceiveBytes(num_bytes);
+
+  std::vector<uint8_t> receive_bytes(num_bytes);
+  EXPECT_TRUE(dif_uart_bytes_receive(&dif_uart_, num_bytes,
+                                     receive_bytes.data(), nullptr));
+
+  EXPECT_EQ(kBytesArray, receive_bytes);
+}
+
+TEST_F(BytesReceiveTest, RxFifoFull) {
+  uint8_t num_bytes = kBytesArray.size();
+  ExpectReceiveBytes(num_bytes);
+
+  size_t bytes_read = 0;
+  std::vector<uint8_t> receive_bytes(num_bytes);
+  EXPECT_TRUE(dif_uart_bytes_receive(&dif_uart_, num_bytes,
+                                     receive_bytes.data(), &bytes_read));
+
+  EXPECT_EQ(bytes_read, num_bytes);
+  EXPECT_EQ(kBytesArray, receive_bytes);
+}
+
+TEST_F(BytesReceiveTest, RxFifoEmpty) {
+  EXPECT_READ32(UART_STATUS_REG_OFFSET, {{UART_STATUS_RXEMPTY, true}});
+
+  uint8_t num_bytes = kBytesArray.size();
+  size_t bytes_read = std::numeric_limits<size_t>::max();
+  std::vector<uint8_t> receive_bytes(num_bytes);
+  EXPECT_TRUE(dif_uart_bytes_receive(&dif_uart_, num_bytes,
+                                     receive_bytes.data(), &bytes_read));
+
+  EXPECT_EQ(bytes_read, 0);
+  EXPECT_THAT(receive_bytes, Each(Eq(0)));
+}
+
+class BytesSendPolledTest : public UartTest {};
+
+TEST_F(BytesSendPolledTest, NullArgs) {
+  EXPECT_FALSE(dif_uart_byte_send_polled(nullptr, 'X'));
+}
+
+TEST_F(BytesSendPolledTest, Success) {
+  // Busy loop 1 iteration (waiting for TX FIFO to free up)
+  EXPECT_READ32(UART_STATUS_REG_OFFSET, {{UART_STATUS_TXFULL, true}});
+  EXPECT_READ32(UART_STATUS_REG_OFFSET, {{UART_STATUS_TXFULL, false}});
+
+  // Set expectations for the byte to be set
+  EXPECT_READ32(UART_STATUS_REG_OFFSET, {{UART_STATUS_TXFULL, false}});
+  EXPECT_WRITE32(UART_WDATA_REG_OFFSET, 'X');
+
+  // Busy loop 1 iteration (waiting for the byte to be sent out by the HW)
+  EXPECT_READ32(UART_STATUS_REG_OFFSET, {{UART_STATUS_TXIDLE, false}});
+  EXPECT_READ32(UART_STATUS_REG_OFFSET, {{UART_STATUS_TXIDLE, true}});
+
+  EXPECT_TRUE(dif_uart_byte_send_polled(&dif_uart_, 'X'));
+}
+
+class BytesReceivePolledTest : public UartTest {};
+
+TEST_F(BytesReceivePolledTest, NullArgs) {
+  uint8_t byte;
+  EXPECT_FALSE(dif_uart_byte_receive_polled(nullptr, &byte));
+  EXPECT_FALSE(dif_uart_byte_receive_polled(&dif_uart_, nullptr));
+  EXPECT_FALSE(dif_uart_byte_receive_polled(nullptr, nullptr));
+}
+
+TEST_F(BytesReceivePolledTest, Success) {
+  // Busy loop 1 iteration (waiting for RX FIFO to fill up)
+  EXPECT_READ32(UART_STATUS_REG_OFFSET, {{UART_STATUS_RXEMPTY, true}});
+  EXPECT_READ32(UART_STATUS_REG_OFFSET, {{UART_STATUS_RXEMPTY, false}});
+
+  // Set expectations for the byte to be read
+  EXPECT_READ32(UART_STATUS_REG_OFFSET, {{UART_STATUS_RXEMPTY, false}});
+  EXPECT_READ32(UART_RDATA_REG_OFFSET, 'X');
+
+  uint8_t byte = 'Y';
+  EXPECT_TRUE(dif_uart_byte_receive_polled(&dif_uart_, &byte));
+
+  EXPECT_EQ('X', byte);
+}
+
+class IrqStateGetTest : public UartTest {};
+
+TEST_F(IrqStateGetTest, NullArgs) {
+  dif_uart_enable_t state;
+  EXPECT_FALSE(
+      dif_uart_irq_state_get(nullptr, kDifUartInterruptTxWatermark, &state));
+  EXPECT_FALSE(dif_uart_irq_state_get(&dif_uart_, kDifUartInterruptTxWatermark,
+                                      nullptr));
+  EXPECT_FALSE(
+      dif_uart_irq_state_get(nullptr, kDifUartInterruptTxWatermark, nullptr));
+}
+
+TEST_F(IrqStateGetTest, Success) {
+  // Get the first IRQ state.
+  EXPECT_READ32(UART_INTR_STATE_REG_OFFSET,
+                {{UART_INTR_STATE_TX_WATERMARK, true}});
+
+  dif_uart_enable_t tx_watermark_state = kDifUartDisable;
+  EXPECT_TRUE(dif_uart_irq_state_get(&dif_uart_, kDifUartInterruptTxWatermark,
+                                     &tx_watermark_state));
+
+  EXPECT_EQ(tx_watermark_state, kDifUartEnable);
+
+  // Get the last IRQ state.
+  EXPECT_READ32(UART_INTR_STATE_REG_OFFSET,
+                {{UART_INTR_STATE_RX_PARITY_ERR, false}});
+
+  dif_uart_enable_t rx_parity_error_state = kDifUartEnable;
+  EXPECT_TRUE(dif_uart_irq_state_get(&dif_uart_, kDifUartInterruptRxParityErr,
+                                     &rx_parity_error_state));
+
+  EXPECT_EQ(rx_parity_error_state, kDifUartDisable);
+}
+
+class IrqStateClearTest : public UartTest {};
+
+TEST_F(IrqStateClearTest, NullArgs) {
+  EXPECT_FALSE(dif_uart_irq_state_clear(nullptr, kDifUartInterruptTxWatermark));
+}
+
+TEST_F(IrqStateClearTest, Success) {
+  // Clear the first IRQ state.
+  EXPECT_MASK32(UART_INTR_STATE_REG_OFFSET,
+                {{UART_INTR_STATE_TX_WATERMARK, 0x1, true}});
+
+  EXPECT_TRUE(
+      dif_uart_irq_state_clear(&dif_uart_, kDifUartInterruptTxWatermark));
+
+  // Clear the last IRQ state.
+  EXPECT_MASK32(UART_INTR_STATE_REG_OFFSET,
+                {{UART_INTR_STATE_RX_PARITY_ERR, 0x1, true}});
+
+  EXPECT_TRUE(
+      dif_uart_irq_state_clear(&dif_uart_, kDifUartInterruptRxParityErr));
+}
+
+class IrqsDisableTest : public UartTest {};
+
+TEST_F(IrqsDisableTest, NullArgs) {
+  uint32_t state;
+  EXPECT_FALSE(dif_uart_irqs_disable(nullptr, &state));
+  EXPECT_FALSE(dif_uart_irqs_disable(nullptr, nullptr));
+}
+
+TEST_F(IrqsDisableTest, Success) {
+  EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET, 0);
+
+  EXPECT_TRUE(dif_uart_irqs_disable(&dif_uart_, nullptr));
+}
+
+TEST_F(IrqsDisableTest, AllDisabled) {
+  // IRQs disabled
+  EXPECT_READ32(UART_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET, 0);
+
+  uint32_t state = std::numeric_limits<uint32_t>::max();
+  EXPECT_TRUE(dif_uart_irqs_disable(&dif_uart_, &state));
+
+  EXPECT_EQ(state, 0);
+}
+
+TEST_F(IrqsDisableTest, AllEnabled) {
+  // IRQs enabled
+  EXPECT_READ32(UART_INTR_ENABLE_REG_OFFSET,
+                std::numeric_limits<uint32_t>::max());
+  EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET, 0);
+
+  uint32_t state = 0;
+  EXPECT_TRUE(dif_uart_irqs_disable(&dif_uart_, &state));
+
+  EXPECT_EQ(state, std::numeric_limits<uint32_t>::max());
+}
+
+class IrqsRestoreTest : public UartTest {};
+
+TEST_F(IrqsRestoreTest, NullArgs) {
+  EXPECT_FALSE(
+      dif_uart_irqs_restore(nullptr, std::numeric_limits<uint32_t>::max()));
+}
+
+TEST_F(IrqsRestoreTest, AllEnabled) {
+  uint32_t state = std::numeric_limits<uint32_t>::max();
+  EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET, state);
+
+  EXPECT_TRUE(dif_uart_irqs_restore(&dif_uart_, state));
+}
+
+TEST_F(IrqsRestoreTest, NoneEnabled) {
+  uint32_t state = 0;
+  EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET, state);
+
+  EXPECT_TRUE(dif_uart_irqs_restore(&dif_uart_, state));
+}
+
+class IrqEnableTest : public UartTest {};
+
+TEST_F(IrqEnableTest, NullArgs) {
+  EXPECT_FALSE(dif_uart_irq_enable(nullptr, kDifUartInterruptTxWatermark,
+                                   kDifUartEnable));
+}
+
+TEST_F(IrqEnableTest, Success) {
+  // Enable first IRQ.
+  EXPECT_MASK32(UART_INTR_ENABLE_REG_OFFSET,
+                {{UART_INTR_ENABLE_TX_WATERMARK, 0x1, true}});
+
+  EXPECT_TRUE(dif_uart_irq_enable(&dif_uart_, kDifUartInterruptTxWatermark,
+                                  kDifUartEnable));
+
+  // Disable last IRQ.
+  EXPECT_MASK32(UART_INTR_ENABLE_REG_OFFSET,
+                {{UART_INTR_STATE_RX_PARITY_ERR, 0x1, false}});
+
+  EXPECT_TRUE(dif_uart_irq_enable(&dif_uart_, kDifUartInterruptRxParityErr,
+                                  kDifUartDisable));
+}
+
+class IrqForceTest : public UartTest {};
+
+TEST_F(IrqForceTest, NullArgs) {
+  EXPECT_FALSE(dif_uart_irq_force(nullptr, kDifUartInterruptTxWatermark));
+}
+
+TEST_F(IrqForceTest, Success) {
+  // Force first IRQ.
+  EXPECT_MASK32(UART_INTR_TEST_REG_OFFSET,
+                {{UART_INTR_TEST_TX_WATERMARK, 0x1, true}});
+
+  EXPECT_TRUE(dif_uart_irq_force(&dif_uart_, kDifUartInterruptTxWatermark));
+
+  // Force last IRQ.
+  EXPECT_MASK32(UART_INTR_TEST_REG_OFFSET,
+                {{UART_INTR_ENABLE_RX_PARITY_ERR, 0x1, true}});
+
+  EXPECT_TRUE(dif_uart_irq_force(&dif_uart_, kDifUartInterruptRxParityErr));
+}
+
+class RxBytesAvailableTest : public UartTest {};
+
+TEST_F(RxBytesAvailableTest, NullArgs) {
+  size_t num_bytes;
+  EXPECT_FALSE(dif_uart_rx_bytes_available(nullptr, &num_bytes));
+  EXPECT_FALSE(dif_uart_rx_bytes_available(&dif_uart_, nullptr));
+  EXPECT_FALSE(dif_uart_rx_bytes_available(nullptr, nullptr));
+}
+
+TEST_F(RxBytesAvailableTest, FifoFull) {
+  // kDifUartFifoSizeBytes bytes available to read.
+  EXPECT_READ32(UART_FIFO_STATUS_REG_OFFSET,
+                {{UART_FIFO_STATUS_RXLVL_OFFSET, kDifUartFifoSizeBytes}});
+
+  size_t num_bytes = 0;
+  EXPECT_TRUE(dif_uart_rx_bytes_available(&dif_uart_, &num_bytes));
+
+  EXPECT_EQ(num_bytes, kDifUartFifoSizeBytes);
+}
+
+TEST_F(RxBytesAvailableTest, FifoEmpty) {
+  // 0 bytes available to read.
+  EXPECT_READ32(UART_FIFO_STATUS_REG_OFFSET,
+                {{UART_FIFO_STATUS_RXLVL_OFFSET, 0}});
+
+  size_t num_bytes = kDifUartFifoSizeBytes;
+  EXPECT_TRUE(dif_uart_rx_bytes_available(&dif_uart_, &num_bytes));
+
+  EXPECT_EQ(num_bytes, 0);
+}
+
+class TxBytesAvailableTest : public UartTest {};
+
+TEST_F(TxBytesAvailableTest, NullArgs) {
+  size_t num_bytes;
+  EXPECT_FALSE(dif_uart_tx_bytes_available(nullptr, &num_bytes));
+  EXPECT_FALSE(dif_uart_tx_bytes_available(&dif_uart_, nullptr));
+  EXPECT_FALSE(dif_uart_tx_bytes_available(nullptr, nullptr));
+}
+
+TEST_F(TxBytesAvailableTest, FifoFull) {
+  // 0 bytes available to write.
+  EXPECT_READ32(UART_FIFO_STATUS_REG_OFFSET,
+                {{UART_FIFO_STATUS_TXLVL_OFFSET, kDifUartFifoSizeBytes}});
+
+  size_t num_bytes = kDifUartFifoSizeBytes;
+  EXPECT_TRUE(dif_uart_tx_bytes_available(&dif_uart_, &num_bytes));
+
+  EXPECT_EQ(num_bytes, 0);
+}
+
+TEST_F(TxBytesAvailableTest, FifoEmpty) {
+  // kDifUartFifoSizeBytes available to write.
+  EXPECT_READ32(UART_FIFO_STATUS_REG_OFFSET,
+                {{UART_FIFO_STATUS_TXLVL_OFFSET, 0}});
+
+  size_t num_bytes = 0;
+  EXPECT_TRUE(dif_uart_tx_bytes_available(&dif_uart_, &num_bytes));
+
+  EXPECT_EQ(num_bytes, kDifUartFifoSizeBytes);
+}
+
+}  // namespace
+}  // namespace dif_uart_test

--- a/sw/device/tests/dif/meson.build
+++ b/sw/device/tests/dif/meson.build
@@ -17,3 +17,19 @@ test('dif_spi_device_test', executable(
   c_args: ['-DMOCK_MMIO'],
   cpp_args: ['-DMOCK_MMIO'],
 ))
+
+test('dif_uart_test', executable(
+  'dif_uart_test',
+  sources: [
+    'dif_uart_test.cc',
+    meson.source_root() / 'sw/device/lib/dif/dif_uart.c',
+    hw_ip_uart_reg_h,
+  ],
+  dependencies: [
+    sw_vendor_gtest,
+    sw_lib_testing_mock_mmio,
+  ],
+  native: true,
+  c_args: ['-DMOCK_MMIO'], 
+  cpp_args: ['-DMOCK_MMIO'],
+))


### PR DESCRIPTION
This change introduces a set of UART mock tests to test the public API. The aim is to validate the API implementation in terms of different use-cases.

This PR is related to #1076 and #1224 