### PR TITLE
[dv regr tool] Updates to support LSF

### DIFF
--- a/hw/dv/data/common_sim_cfg.hjson
+++ b/hw/dv/data/common_sim_cfg.hjson
@@ -16,6 +16,7 @@
 
   // Default directory structure for the output
   scratch_path:     "{scratch_root}/{branch}.{dut}.{flow}.{simulator}"
+  tool_dir:         "{scratch_path}/{simulator}"
   build_dir:        "{scratch_path}/{build_mode}"
   run_dir_name:     "{index}.{test}"
   run_dir:          "{scratch_path}/{run_dir_name}/out"

--- a/hw/dv/data/sim.mk
+++ b/hw/dv/data/sim.mk
@@ -24,7 +24,9 @@ build: compile_result
 
 pre_compile:
 	@echo "[make]: pre_compile"
-	mkdir -p ${build_dir} && env > ${build_dir}/env_vars
+	mkdir -p ${build_dir} && env | sort > ${build_dir}/env_vars
+	mkdir -p ${tool_dir}
+	cp -Ru ${tool_srcs} ${tool_dir}/.
 
 gen_sv_flist: pre_compile ral
 	@echo "[make]: gen_sv_flist"
@@ -44,7 +46,7 @@ run: run_result
 
 pre_run:
 	@echo "[make]: pre_run"
-	mkdir -p ${run_dir} && env > ${run_dir}/env_vars
+	mkdir -p ${run_dir} && env | sort > ${run_dir}/env_vars
 
 sw_build: pre_run
 	@echo "[make]: sw_build"

--- a/hw/dv/data/vcs/vcs.hjson
+++ b/hw/dv/data/vcs/vcs.hjson
@@ -5,8 +5,7 @@
   build_cmd:  "{job_prefix} vcs"
   build_ex:   "{build_dir}/simv"
   run_cmd:    "{job_prefix} {build_ex}"
-
-  tcl:        "{proj_root}/hw/dv/tools/vcs/vcs_fsdb.tcl"
+  tool_srcs:  ["{proj_root}/hw/dv/tools/vcs/*"]
 
   build_opts: ["-sverilog -full64 -licqueue -kdb -ntb_opts uvm-1.2",
                "-timescale=1ns/1ps",
@@ -18,10 +17,18 @@
                "+warn=SV-NFIVC",
                "+warn=noUII-L",
                // Below option required for $error/$fatal system calls
-               "-assert svaext"]
+               "-assert svaext",
+               // Force DPI-C compilation in C99 mode
+               "-CFLAGS \"--std=c99\"",
+               // Without this magic LDFLAGS argument below, we get compile time errors with
+               // VCS on Google Linux machines that look like this:
+               // .../libvcsnew.so: undefined reference to `snpsReallocFunc'
+               // .../libvcsnew.so: undefined reference to `snpsCheckStrdupFunc'
+               // .../libvcsnew.so: undefined reference to `snpsGetMemBytes'
+               "-LDFLAGS \"-Wl,--no-as-needed\""]
 
   run_opts:   ["-licqueue",
-               "-ucli -do {tcl}",
+               "-ucli -do {tool_dir}/vcs_fsdb.tcl",
                "+ntb_random_seed={seed}",
                "+UVM_TESTNAME={uvm_test}",
                "+UVM_TEST_SEQ={uvm_test_seq}"]
@@ -79,7 +86,7 @@
     {
       name: vcs_xprop
       is_sim_mode: 1
-      build_opts: ["-xprop={proj_root}/hw/dv/tools/vcs/xprop.cfg"]
+      build_opts: ["-xprop={tool_dir}/xprop.cfg"]
     }
     {
       name: vcs_profile

--- a/hw/dv/data/xcelium/xcelium.hjson
+++ b/hw/dv/data/xcelium/xcelium.hjson
@@ -4,8 +4,7 @@
 {
   build_cmd:  "{job_prefix} xrun"
   run_cmd:    "{job_prefix} xrun"
-
-  tcl:        "{proj_root}/hw/dv/tools/xcelium/xcelium_{dump}.tcl"
+  tool_srcs:  ["{proj_root}/hw/dv/tools/xcelium/*"]
 
   build_opts: [" -elaborate -64bit -access +r -sv",
                "-messages -errormax 50",
@@ -14,7 +13,7 @@
                "-uvmhome {UVM_HOME}",
                "-xmlibdirname {build_dir}/xcelium.d"]
 
-  run_opts:   ["-input {tcl}",
+  run_opts:   ["-input {tool_dir}/xcelium_{dump}.tcl",
                "-64bit -xmlibdirname {build_dir}/xcelium.d -R",
                "+SVSEED={seed}",
                "+UVM_TESTNAME={uvm_test}",

--- a/hw/dv/tools/vcs/vcs.mk
+++ b/hw/dv/tools/vcs/vcs.mk
@@ -29,6 +29,14 @@ BUILD_OPTS  += +warn=noUII-L
 BUILD_OPTS  += +warn=SV-NFIVC
 # option below is required for $error / $fatal system calls
 BUILD_OPTS  += -assert svaext
+# Force DPI-C compilation in C99 mode
+BUILD_OPTS  += -CFLAGS "--std=c99"
+# Without this magic LDFLAGS argument below, we get compile time errors with
+# VCS on Google Linux machines that look like this:
+# .../libvcsnew.so: undefined reference to `snpsReallocFunc'
+# .../libvcsnew.so: undefined reference to `snpsCheckStrdupFunc'
+# .../libvcsnew.so: undefined reference to `snpsGetMemBytes'
+BUILD_OPTS  += -LDFLAGS "-Wl,--no-as-needed"
 
 # set standard run options
 RUN_OPTS    += -licqueue

--- a/hw/ip/aes/model/aes_model_sim_opts.hjson
+++ b/hw/ip/aes/model/aes_model_sim_opts.hjson
@@ -4,15 +4,18 @@
 {
   // Additional build-time options for enabling the compilation of the C sources
   // with DV simulators such as VCS and Xcelium.
+  aes_mode_core: "lowrisc:model:aes:0.5"
+  aes_mode_src_dir: "{eval_cmd} echo \"{aes_mode_core}\" | tr ':' '_'"
+
   build_modes: [
     {
       name: vcs_aes_model_build_opts
-      build_opts: ["-CFLAGS -I{proj_root}/hw/ip/aes/model", "-lcrypto"]
+      build_opts: ["-CFLAGS -I{build_dir}/src/{aes_mode_src_dir}", "-lcrypto"]
     }
 
     {
       name: xcelium_aes_model_build_opts
-      build_opts: ["-I{proj_root}/hw/ip/aes/model", "-lcrypto"]
+      build_opts: ["-I{build_dir}/src/{aes_mode_src_dir}", "-lcrypto"]
     }
   ]
 }

--- a/util/dvsim.py
+++ b/util/dvsim.py
@@ -362,6 +362,14 @@ def main():
         metavar="N",
         help="""Run only upto a fixed number of builds/tests at a time.""")
 
+    parser.add_argument(
+        "--local",
+        default=False,
+        action='store_true',
+        help=
+        """Deploy builds and runs on the local workstation instead of the compute farm.
+        Support for this has not been added yet.""")
+
     args = parser.parse_args()
 
     if args.version:

--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -388,7 +388,12 @@ class CompileSim(Deploy):
         self.pass_patterns = []
         self.fail_patterns = []
 
-        self.mandatory_cmd_attrs = {  # RAL gen
+        self.mandatory_cmd_attrs = {
+            # tool srcs
+            "tool_srcs": False,
+            "tool_dir": False,
+
+            # RAL gen
             "skip_ral": False,
             "gen_ral_pkg_cmd": False,
             "gen_ral_pkg_dir": False,

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -409,11 +409,16 @@ class SimCfg(FlowCfg):
         testplan = testplan.replace("/dv", "/doc/dv_plan/#testplan")
         results_str += "### [Testplan](" + testplan + ")\n\n"
 
-        # TODO: check if testplan is not null?
-        results_str += self.testplan.results_table(
-            regr_results=regr_results,
-            map_full_testplan=self.map_full_testplan)
-        results_str += "\n"
+        if regr_results == []:
+            results_str += "No results to display.\n"
+
+        else:
+            # TODO: check if testplan is not null?
+            # Map regr results to the testplan entries.
+            results_str += self.testplan.results_table(
+                regr_results=regr_results,
+                map_full_testplan=self.map_full_testplan)
+            results_str += "\n"
 
         # Append failures for triage
         self.results_md = results_str + fail_msgs


### PR DESCRIPTION
- Update to move all tool sources to scratch area before build/run
- Added necessary build opts that are required for running VCS on Google
machines
- Fixed tool error thrown during the reporting stage when the when build itself fails 

VCS no longer works locally on Google machines. With these fixes, VCS can either be deployed on docker or on the LSF. 

To run with docker, additional installation steps are required. The legacy make flow for DV only works with docker, it does not work with LSF. 

```
GOOGLE ONLY

# With dvsim script
# using LSF
util/dvsim.py <path-to-sim-cfg-hjson> -i [stuff-to-run] --job-prefix "bsub -P opentitan -I" 
# using docker
util/dvsim.py <path-to-sim-cfg-hjson> -i [stuff-to-run] --job-prefix "runlocaldocker stty -nl &&" 
$ cd hw/ip/<ip>/dv

# With make flow
# using docker 
$ make [options] JOB_OPTS="runlocaldocker"
```

Signed-off-by: Srikrishna Iyer <sriyer@google.com>