### PR TITLE
[flash_ctrl] Revise the connection structure name

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson
@@ -13,6 +13,16 @@
     { name: "op_error",   desc: "Operation failed with error" },
   ],
 
+  // Define flash_ctrl <-> flash_phy struct package
+  inter_signal_list: [
+    { struct:  "flash",          // flash_req_t, flash_rsp_t
+      type:    "req_rsp",
+      name:    "flash",          // flash_o (req), flash_i (rsp)
+      act:     "requester",
+      package: "flash_ctrl_pkg", // Origin package (only needs for the requester)
+    }
+  ],
+
   param_list: [
     { name: "NumBanks",
       desc: "Number of flash banks",

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -17,8 +17,8 @@ module flash_ctrl (
   output       tlul_pkg::tl_d2h_t tl_o,
 
   // Flash Interface
-  input        flash_ctrl_pkg::flash_m2c_t flash_i,
-  output       flash_ctrl_pkg::flash_c2m_t flash_o,
+  input        flash_ctrl_pkg::flash_rsp_t flash_i,
+  output       flash_ctrl_pkg::flash_req_t flash_o,
 
   // Interrupts
   output logic intr_prog_empty_o, // Program fifo is empty

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
@@ -38,7 +38,18 @@ package flash_ctrl_pkg;
     logic                         bk_erase;
     logic [top_pkg::FLASH_AW-1:0] addr;
     logic [top_pkg::FLASH_DW-1:0] prog_data;
-  } flash_c2m_t;
+  } flash_req_t;
+
+  // default value of flash_req_t (for dangling ports)
+  parameter flash_req_t FLASH_REQ_DEFAULT = '{
+    req:       1'b0,
+    rd:        1'b0,
+    prog:      1'b0,
+    pg_erase:  1'b0,
+    bk_erase:  1'b0,
+    addr:      '0,
+    prog_data: '0
+  };
 
   // memory to flash controller
   typedef struct packed {
@@ -47,6 +58,15 @@ package flash_ctrl_pkg;
     logic                         erase_done;
     logic [top_pkg::FLASH_DW-1:0] rd_data;
     logic                         init_busy;
-  } flash_m2c_t;
+  } flash_rsp_t;
+
+  // default value of flash_rsp_t (for dangling ports)
+  parameter flash_rsp_t FLASH_RSP_DEFAULT = '{
+    rd_done:    1'b0,
+    prog_done:  1'b0,
+    erase_done: 1'b0,
+    rd_data:    '0,
+    init_busy:  1'b0
+  };
 
 endpackage : flash_ctrl_pkg

--- a/hw/ip/flash_ctrl/rtl/flash_phy.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy.sv
@@ -29,8 +29,8 @@ module flash_phy #(
   output logic host_req_rdy_o,
   output logic host_req_done_o,
   output logic [DataWidth-1:0] host_rdata_o,
-  input flash_ctrl_pkg::flash_c2m_t flash_ctrl_i,
-  output flash_ctrl_pkg::flash_m2c_t flash_ctrl_o
+  input flash_ctrl_pkg::flash_req_t flash_ctrl_i,
+  output flash_ctrl_pkg::flash_rsp_t flash_ctrl_o
 );
 
   // Flash macro outstanding refers to how many reads we allow a macro to move ahead of an

--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -434,8 +434,8 @@ module top_${top["name"]} #(
   % elif m["type"] == "eflash":
 
   // flash controller to eflash communication
-  flash_c2m_t flash_c2m;
-  flash_m2c_t flash_m2c;
+  flash_req_t flash_req;
+  flash_rsp_t flash_rsp;
 
   // host to flash communication
   logic flash_host_req;
@@ -489,8 +489,8 @@ module top_${top["name"]} #(
     .host_req_rdy_o  (flash_host_req_rdy),
     .host_req_done_o (flash_host_req_done),
     .host_rdata_o    (flash_host_rdata),
-    .flash_ctrl_i    (flash_c2m),
-    .flash_ctrl_o    (flash_m2c)
+    .flash_ctrl_i    (flash_req),
+    .flash_ctrl_o    (flash_rsp)
   );
 
   % else:
@@ -594,8 +594,8 @@ else:
     ## TODO: Inter-module Connection
     % if m["type"] == "flash_ctrl":
 
-      .flash_o(flash_c2m),
-      .flash_i(flash_m2c),
+      .flash_o(flash_req),
+      .flash_i(flash_rsp),
     % endif
     % if m["type"] == "rv_plic":
 

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -426,8 +426,8 @@ module top_earlgrey #(
   );
 
   // flash controller to eflash communication
-  flash_c2m_t flash_c2m;
-  flash_m2c_t flash_m2c;
+  flash_req_t flash_req;
+  flash_rsp_t flash_rsp;
 
   // host to flash communication
   logic flash_host_req;
@@ -473,8 +473,8 @@ module top_earlgrey #(
     .host_req_rdy_o  (flash_host_req_rdy),
     .host_req_done_o (flash_host_req_done),
     .host_rdata_o    (flash_host_rdata),
-    .flash_ctrl_i    (flash_c2m),
-    .flash_ctrl_o    (flash_m2c)
+    .flash_ctrl_i    (flash_req),
+    .flash_ctrl_o    (flash_rsp)
   );
 
 
@@ -560,8 +560,8 @@ module top_earlgrey #(
       .intr_op_done_o    (intr_flash_ctrl_op_done),
       .intr_op_error_o   (intr_flash_ctrl_op_error),
 
-      .flash_o(flash_c2m),
-      .flash_i(flash_m2c),
+      .flash_o(flash_req),
+      .flash_i(flash_rsp),
 
       .clk_i (main_clk),
       .rst_ni (lc_rst_n)


### PR DESCRIPTION
Revised the connection between `flash_ctrl` and `flash_phy` to be
consistent with inter-module connectio definition.

Also, `inter_module_signals` field is added into `flash_ctrl`.

This is related to #42
