### PR TITLE
[topgen] Inter-module connection

### DIFF
--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -76,61 +76,61 @@
       available_input_list:
       [
         {
-          name: rx
           width: 1
           type: input
+          name: rx
         }
       ]
       available_output_list:
       [
         {
-          name: tx
           width: 1
           type: output
+          name: tx
         }
       ]
       available_inout_list: []
       interrupt_list:
       [
         {
+          width: 1
+          type: interrupt
           name: tx_watermark
-          width: 1
-          type: interrupt
         }
         {
+          width: 1
+          type: interrupt
           name: rx_watermark
-          width: 1
-          type: interrupt
         }
         {
+          width: 1
+          type: interrupt
           name: tx_empty
-          width: 1
-          type: interrupt
         }
         {
+          width: 1
+          type: interrupt
           name: rx_overflow
-          width: 1
-          type: interrupt
         }
         {
+          width: 1
+          type: interrupt
           name: rx_frame_err
-          width: 1
-          type: interrupt
         }
         {
+          width: 1
+          type: interrupt
           name: rx_break_err
-          width: 1
-          type: interrupt
         }
         {
+          width: 1
+          type: interrupt
           name: rx_timeout
-          width: 1
-          type: interrupt
         }
         {
-          name: rx_parity_err
           width: 1
           type: interrupt
+          name: rx_parity_err
         }
       ]
       alert_list: []
@@ -156,17 +156,17 @@
       available_inout_list:
       [
         {
-          name: gpio
           width: 32
           type: inout
+          name: gpio
         }
       ]
       interrupt_list:
       [
         {
-          name: gpio
           width: 32
           type: interrupt
+          name: gpio
         }
       ]
       alert_list: []
@@ -190,61 +190,61 @@
       available_input_list:
       [
         {
+          width: 1
+          type: input
           name: sck
-          width: 1
-          type: input
         }
         {
+          width: 1
+          type: input
           name: csb
-          width: 1
-          type: input
         }
         {
-          name: mosi
           width: 1
           type: input
+          name: mosi
         }
       ]
       available_output_list:
       [
         {
-          name: miso
           width: 1
           type: output
+          name: miso
         }
       ]
       available_inout_list: []
       interrupt_list:
       [
         {
+          width: 1
+          type: interrupt
           name: rxf
-          width: 1
-          type: interrupt
         }
         {
+          width: 1
+          type: interrupt
           name: rxlvl
-          width: 1
-          type: interrupt
         }
         {
+          width: 1
+          type: interrupt
           name: txlvl
-          width: 1
-          type: interrupt
         }
         {
+          width: 1
+          type: interrupt
           name: rxerr
-          width: 1
-          type: interrupt
         }
         {
+          width: 1
+          type: interrupt
           name: rxoverflow
-          width: 1
-          type: interrupt
         }
         {
-          name: txunderflow
           width: 1
           type: interrupt
+          name: txunderflow
         }
       ]
       alert_list: []
@@ -271,38 +271,50 @@
       interrupt_list:
       [
         {
+          width: 1
+          type: interrupt
           name: prog_empty
-          width: 1
-          type: interrupt
         }
         {
+          width: 1
+          type: interrupt
           name: prog_lvl
-          width: 1
-          type: interrupt
         }
         {
+          width: 1
+          type: interrupt
           name: rd_full
-          width: 1
-          type: interrupt
         }
         {
+          width: 1
+          type: interrupt
           name: rd_lvl
-          width: 1
-          type: interrupt
         }
         {
+          width: 1
+          type: interrupt
           name: op_done
-          width: 1
-          type: interrupt
         }
         {
-          name: op_error
           width: 1
           type: interrupt
+          name: op_error
         }
       ]
       alert_list: []
       scan: "false"
+      inter_signal_list:
+      [
+        {
+          inst_name: flash_ctrl
+          top_signame: im0_flash
+          act: requester
+          struct: flash
+          type: req_rsp
+          name: flash
+          package: flash_ctrl_pkg
+        }
+      ]
     }
     {
       name: rv_timer
@@ -325,9 +337,9 @@
       interrupt_list:
       [
         {
-          name: timer_expired_0_0
           width: 1
           type: interrupt
+          name: timer_expired_0_0
         }
       ]
       alert_list: []
@@ -376,27 +388,27 @@
       interrupt_list:
       [
         {
+          width: 1
+          type: interrupt
           name: hmac_done
-          width: 1
-          type: interrupt
         }
         {
+          width: 1
+          type: interrupt
           name: fifo_full
-          width: 1
-          type: interrupt
         }
         {
-          name: hmac_err
           width: 1
           type: interrupt
+          name: hmac_err
         }
       ]
       alert_list:
       [
         {
-          name: msg_push_sha_disabled
           width: 1
           type: alert
+          name: msg_push_sha_disabled
           async: 0
         }
       ]
@@ -477,24 +489,24 @@
       interrupt_list:
       [
         {
+          width: 1
+          type: interrupt
           name: classa
-          width: 1
-          type: interrupt
         }
         {
+          width: 1
+          type: interrupt
           name: classb
-          width: 1
-          type: interrupt
         }
         {
+          width: 1
+          type: interrupt
           name: classc
-          width: 1
-          type: interrupt
         }
         {
-          name: classd
           width: 1
           type: interrupt
+          name: classd
         }
       ]
       alert_list: []
@@ -521,24 +533,24 @@
       interrupt_list:
       [
         {
+          width: 1
+          type: interrupt
           name: esc0
-          width: 1
-          type: interrupt
         }
         {
+          width: 1
+          type: interrupt
           name: esc1
-          width: 1
-          type: interrupt
         }
         {
+          width: 1
+          type: interrupt
           name: esc2
-          width: 1
-          type: interrupt
         }
         {
-          name: esc3
           width: 1
           type: interrupt
+          name: esc3
         }
       ]
       alert_list: []
@@ -564,113 +576,113 @@
       available_input_list:
       [
         {
-          name: sense
           width: 1
           type: input
+          name: sense
         }
       ]
       available_output_list:
       [
         {
-          name: pullup
           width: 1
           type: output
+          name: pullup
         }
       ]
       available_inout_list:
       [
         {
-          name: dp
           width: 1
           type: inout
+          name: dp
         }
         {
-          name: dn
           width: 1
           type: inout
+          name: dn
         }
       ]
       interrupt_list:
       [
         {
+          width: 1
+          type: interrupt
           name: pkt_received
-          width: 1
-          type: interrupt
         }
         {
+          width: 1
+          type: interrupt
           name: pkt_sent
-          width: 1
-          type: interrupt
         }
         {
+          width: 1
+          type: interrupt
           name: disconnected
-          width: 1
-          type: interrupt
         }
         {
+          width: 1
+          type: interrupt
           name: host_lost
-          width: 1
-          type: interrupt
         }
         {
+          width: 1
+          type: interrupt
           name: link_reset
-          width: 1
-          type: interrupt
         }
         {
+          width: 1
+          type: interrupt
           name: link_suspend
-          width: 1
-          type: interrupt
         }
         {
+          width: 1
+          type: interrupt
           name: link_resume
-          width: 1
-          type: interrupt
         }
         {
+          width: 1
+          type: interrupt
           name: av_empty
-          width: 1
-          type: interrupt
         }
         {
+          width: 1
+          type: interrupt
           name: rx_full
-          width: 1
-          type: interrupt
         }
         {
+          width: 1
+          type: interrupt
           name: av_overflow
-          width: 1
-          type: interrupt
         }
         {
+          width: 1
+          type: interrupt
           name: link_in_err
-          width: 1
-          type: interrupt
         }
         {
+          width: 1
+          type: interrupt
           name: rx_crc_err
-          width: 1
-          type: interrupt
         }
         {
+          width: 1
+          type: interrupt
           name: rx_pid_err
-          width: 1
-          type: interrupt
         }
         {
+          width: 1
+          type: interrupt
           name: rx_bitstuff_err
-          width: 1
-          type: interrupt
         }
         {
+          width: 1
+          type: interrupt
           name: frame
-          width: 1
-          type: interrupt
         }
         {
-          name: connected
           width: 1
           type: interrupt
+          name: connected
         }
       ]
       alert_list: []
@@ -720,8 +732,26 @@
       type: eflash
       base_addr: 0x20000000
       size: 0x80000
+      inter_signal_list:
+      [
+        {
+          struct: flash
+          type: req_rsp
+          name: flash_ctrl
+          act: responder
+          inst_name: eflash
+          top_signame: im0_flash
+        }
+      ]
     }
   ]
+  inter_module:
+  {
+    flash_ctrl.flash:
+    [
+      eflash.flash_ctrl
+    ]
+  }
   xbar:
   [
     {
@@ -818,8 +848,8 @@
           addr_range:
           [
             {
-              base_addr: 0x00008000
               size_byte: 0x2000
+              base_addr: 0x00008000
             }
           ]
           xbar: false
@@ -835,8 +865,8 @@
           addr_range:
           [
             {
-              base_addr: 0x1A110000
               size_byte: 0x1000
+              base_addr: 0x1A110000
             }
           ]
           xbar: false
@@ -852,8 +882,8 @@
           addr_range:
           [
             {
-              base_addr: 0x10000000
               size_byte: 0x10000
+              base_addr: 0x10000000
             }
           ]
           xbar: false
@@ -869,8 +899,8 @@
           addr_range:
           [
             {
-              base_addr: 0x20000000
               size_byte: 0x80000
+              base_addr: 0x20000000
             }
           ]
           xbar: false
@@ -887,24 +917,24 @@
           addr_range:
           [
             {
+              size_byte: 0x1000
               base_addr: 0x40000000
-              size_byte: 0x1000
             }
             {
+              size_byte: 0x1000
               base_addr: 0x40010000
-              size_byte: 0x1000
             }
             {
+              size_byte: 0x1000
               base_addr: 0x40020000
-              size_byte: 0x1000
             }
             {
+              size_byte: 0x1000
               base_addr: 0x40080000
-              size_byte: 0x1000
             }
             {
-              base_addr: 0x40150000
               size_byte: 0x1000
+              base_addr: 0x40150000
             }
           ]
         }
@@ -918,8 +948,8 @@
           addr_range:
           [
             {
-              base_addr: 0x40030000
               size_byte: 0x1000
+              base_addr: 0x40030000
             }
           ]
           xbar: false
@@ -935,8 +965,8 @@
           addr_range:
           [
             {
-              base_addr: 0x40120000
               size_byte: 0x1000
+              base_addr: 0x40120000
             }
           ]
           xbar: false
@@ -952,8 +982,8 @@
           addr_range:
           [
             {
-              base_addr: 0x40110000
               size_byte: 0x1000
+              base_addr: 0x40110000
             }
           ]
           xbar: false
@@ -968,8 +998,8 @@
           addr_range:
           [
             {
-              base_addr: 0x40090000
               size_byte: 0x1000
+              base_addr: 0x40090000
             }
           ]
           pipeline_byp: "false"
@@ -985,8 +1015,8 @@
           addr_range:
           [
             {
-              base_addr: 0x40070000
               size_byte: 0x1000
+              base_addr: 0x40070000
             }
           ]
           pipeline_byp: "false"
@@ -1002,8 +1032,8 @@
           addr_range:
           [
             {
-              base_addr: 0x40130000
               size_byte: 0x1000
+              base_addr: 0x40130000
             }
           ]
           xbar: false
@@ -1018,8 +1048,8 @@
           addr_range:
           [
             {
-              base_addr: 0x40140000
               size_byte: 0x1000
+              base_addr: 0x40140000
             }
           ]
           xbar: false
@@ -1072,8 +1102,8 @@
           addr_range:
           [
             {
-              base_addr: 0x40000000
               size_byte: 0x1000
+              base_addr: 0x40000000
             }
           ]
           xbar: false
@@ -1089,8 +1119,8 @@
           addr_range:
           [
             {
-              base_addr: 0x40010000
               size_byte: 0x1000
+              base_addr: 0x40010000
             }
           ]
           xbar: false
@@ -1106,8 +1136,8 @@
           addr_range:
           [
             {
-              base_addr: 0x40020000
               size_byte: 0x1000
+              base_addr: 0x40020000
             }
           ]
           xbar: false
@@ -1123,8 +1153,8 @@
           addr_range:
           [
             {
-              base_addr: 0x40080000
               size_byte: 0x1000
+              base_addr: 0x40080000
             }
           ]
           xbar: false
@@ -1140,8 +1170,8 @@
           addr_range:
           [
             {
-              base_addr: 0x40150000
               size_byte: 0x1000
+              base_addr: 0x40150000
             }
           ]
           xbar: false
@@ -1165,244 +1195,244 @@
   interrupt:
   [
     {
-      name: gpio_gpio
       width: 32
       type: interrupt
+      name: gpio_gpio
     }
     {
+      width: 1
+      type: interrupt
       name: uart_tx_watermark
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: uart_rx_watermark
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: uart_tx_empty
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: uart_rx_overflow
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: uart_rx_frame_err
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: uart_rx_break_err
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: uart_rx_timeout
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: uart_rx_parity_err
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: spi_device_rxf
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: spi_device_rxlvl
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: spi_device_txlvl
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: spi_device_rxerr
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: spi_device_rxoverflow
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: spi_device_txunderflow
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: flash_ctrl_prog_empty
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: flash_ctrl_prog_lvl
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: flash_ctrl_rd_full
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: flash_ctrl_rd_lvl
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: flash_ctrl_op_done
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: flash_ctrl_op_error
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: hmac_hmac_done
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: hmac_fifo_full
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: hmac_hmac_err
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: alert_handler_classa
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: alert_handler_classb
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: alert_handler_classc
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: alert_handler_classd
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: nmi_gen_esc0
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: nmi_gen_esc1
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: nmi_gen_esc2
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: nmi_gen_esc3
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: usbdev_pkt_received
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: usbdev_pkt_sent
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: usbdev_disconnected
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: usbdev_host_lost
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: usbdev_link_reset
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: usbdev_link_suspend
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: usbdev_link_resume
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: usbdev_av_empty
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: usbdev_rx_full
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: usbdev_av_overflow
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: usbdev_link_in_err
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: usbdev_rx_crc_err
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: usbdev_rx_pid_err
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: usbdev_rx_bitstuff_err
-      width: 1
-      type: interrupt
     }
     {
+      width: 1
+      type: interrupt
       name: usbdev_frame
-      width: 1
-      type: interrupt
     }
     {
-      name: usbdev_connected
       width: 1
       type: interrupt
+      name: usbdev_connected
     }
   ]
   alert_module:
@@ -1412,9 +1442,9 @@
   alert:
   [
     {
-      name: hmac_msg_push_sha_disabled
       width: 1
       type: alert
+      name: hmac_msg_push_sha_disabled
       async: 0
     }
   ]
@@ -1458,79 +1488,78 @@
     dio:
     [
       {
+        width: 1
+        type: input
+        pad:
+        [
+          {
+            name: ChB
+            index: 0
+          }
+        ]
         name: spi_device_sck
+      }
+      {
         width: 1
         type: input
         pad:
         [
           {
             name: ChB
-            index: 0
+            index: 1
           }
         ]
-      }
-      {
         name: spi_device_csb
+      }
+      {
         width: 1
         type: input
         pad:
         [
           {
             name: ChB
-            index: 1
+            index: 2
           }
         ]
-      }
-      {
         name: spi_device_mosi
+      }
+      {
         width: 1
-        type: input
+        type: output
         pad:
         [
           {
             name: ChB
-            index: 2
+            index: 3
           }
         ]
-      }
-      {
         name: spi_device_miso
+      }
+      {
         width: 1
-        type: output
+        type: input
         pad:
         [
           {
-            name: ChB
-            index: 3
+            name: ChA
+            index: 0
           }
         ]
-      }
-      {
         name: uart_rx
+      }
+      {
         width: 1
-        type: input
+        type: output
         pad:
         [
           {
             name: ChA
-            index: 0
+            index: 1
           }
         ]
-      }
-      {
         name: uart_tx
-        width: 1
-        type: output
-        pad:
-        [
-          {
-            name: ChA
-            index: 1
-          }
-        ]
       }
       {
-        name: usbdev_sense
         width: 1
         type: input
         pad:
@@ -1540,9 +1569,9 @@
             index: 0
           }
         ]
+        name: usbdev_sense
       }
       {
-        name: usbdev_pullup
         width: 1
         type: output
         pad:
@@ -1552,9 +1581,9 @@
             index: 1
           }
         ]
+        name: usbdev_pullup
       }
       {
-        name: usbdev_dp
         width: 1
         type: inout
         pad:
@@ -1564,9 +1593,9 @@
             index: 2
           }
         ]
+        name: usbdev_dp
       }
       {
-        name: usbdev_dn
         width: 1
         type: inout
         pad:
@@ -1576,6 +1605,7 @@
             index: 3
           }
         ]
+        name: usbdev_dn
       }
     ]
     inputs: []
@@ -1583,9 +1613,9 @@
     inouts:
     [
       {
-        name: gpio_gpio
         width: 32
         type: inout
+        name: gpio_gpio
       }
     ]
   }
@@ -1621,6 +1651,38 @@
           KEEP
           STRONG
         ]
+      }
+    ]
+  }
+  inter_signal:
+  {
+    signals:
+    [
+      {
+        inst_name: flash_ctrl
+        top_signame: im0_flash
+        act: requester
+        struct: flash
+        type: req_rsp
+        name: flash
+        package: flash_ctrl_pkg
+      }
+      {
+        struct: flash
+        type: req_rsp
+        name: flash_ctrl
+        act: responder
+        inst_name: eflash
+        top_signame: im0_flash
+      }
+    ]
+    definitions:
+    [
+      {
+        struct: flash
+        type: req_rsp
+        signame: im0_flash
+        package: flash_ctrl_pkg
       }
     ]
   }

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -151,8 +151,26 @@
       reset_connections: {rst_ni: "lc"},
       type: "eflash",
       base_addr: "0x20000000",
-      size: "0x80000" },
+      size: "0x80000",
+      inter_signal_list: [
+        { struct: "flash",    // flash_req_t, flash_rsp_t
+          type: "req_rsp",
+          name: "flash_ctrl", // flash_ctrl_i (req), flash_ctrl_o (rsp)
+          act:  "responder",
+        }
+      ],
+    },
   ],
+
+  // Inter-module Connection.
+  // format:
+  //    requester: [ resp1, resp2, ... ],
+  //
+  //  the field and value should be module_inst.signal_name
+  //  e.g flash_ctrl0.flash: [flash_phy0.flash_ctrl]
+  inter_module: {
+    'flash_ctrl.flash': ['eflash.flash_ctrl']
+  },
 
   debug_mem_base_addr: "0x1A110000",
 

--- a/hw/top_earlgrey/ip/xbar_main/data/autogen/xbar_main.gen.hjson
+++ b/hw/top_earlgrey/ip/xbar_main/data/autogen/xbar_main.gen.hjson
@@ -100,8 +100,8 @@
       addr_range:
       [
         {
-          base_addr: 0x00008000
           size_byte: 0x2000
+          base_addr: 0x00008000
         }
       ]
       xbar: false
@@ -117,8 +117,8 @@
       addr_range:
       [
         {
-          base_addr: 0x1A110000
           size_byte: 0x1000
+          base_addr: 0x1A110000
         }
       ]
       xbar: false
@@ -134,8 +134,8 @@
       addr_range:
       [
         {
-          base_addr: 0x10000000
           size_byte: 0x10000
+          base_addr: 0x10000000
         }
       ]
       xbar: false
@@ -151,8 +151,8 @@
       addr_range:
       [
         {
-          base_addr: 0x20000000
           size_byte: 0x80000
+          base_addr: 0x20000000
         }
       ]
       xbar: false
@@ -169,16 +169,16 @@
       addr_range:
       [
         {
-          base_addr: 0x40000000
           size_byte: 0x21000
+          base_addr: 0x40000000
         }
         {
+          size_byte: 0x1000
           base_addr: 0x40080000
-          size_byte: 0x1000
         }
         {
-          base_addr: 0x40150000
           size_byte: 0x1000
+          base_addr: 0x40150000
         }
       ]
     }
@@ -192,8 +192,8 @@
       addr_range:
       [
         {
-          base_addr: 0x40030000
           size_byte: 0x1000
+          base_addr: 0x40030000
         }
       ]
       xbar: false
@@ -209,8 +209,8 @@
       addr_range:
       [
         {
-          base_addr: 0x40120000
           size_byte: 0x1000
+          base_addr: 0x40120000
         }
       ]
       xbar: false
@@ -226,8 +226,8 @@
       addr_range:
       [
         {
-          base_addr: 0x40110000
           size_byte: 0x1000
+          base_addr: 0x40110000
         }
       ]
       xbar: false
@@ -242,8 +242,8 @@
       addr_range:
       [
         {
-          base_addr: 0x40090000
           size_byte: 0x1000
+          base_addr: 0x40090000
         }
       ]
       pipeline_byp: "false"
@@ -259,8 +259,8 @@
       addr_range:
       [
         {
-          base_addr: 0x40070000
           size_byte: 0x1000
+          base_addr: 0x40070000
         }
       ]
       pipeline_byp: "false"
@@ -276,8 +276,8 @@
       addr_range:
       [
         {
-          base_addr: 0x40130000
           size_byte: 0x1000
+          base_addr: 0x40130000
         }
       ]
       xbar: false
@@ -292,8 +292,8 @@
       addr_range:
       [
         {
-          base_addr: 0x40140000
           size_byte: 0x1000
+          base_addr: 0x40140000
         }
       ]
       xbar: false

--- a/hw/top_earlgrey/ip/xbar_peri/data/autogen/xbar_peri.gen.hjson
+++ b/hw/top_earlgrey/ip/xbar_peri/data/autogen/xbar_peri.gen.hjson
@@ -50,8 +50,8 @@
       addr_range:
       [
         {
-          base_addr: 0x40000000
           size_byte: 0x1000
+          base_addr: 0x40000000
         }
       ]
       xbar: false
@@ -67,8 +67,8 @@
       addr_range:
       [
         {
-          base_addr: 0x40010000
           size_byte: 0x1000
+          base_addr: 0x40010000
         }
       ]
       xbar: false
@@ -84,8 +84,8 @@
       addr_range:
       [
         {
-          base_addr: 0x40020000
           size_byte: 0x1000
+          base_addr: 0x40020000
         }
       ]
       xbar: false
@@ -101,8 +101,8 @@
       addr_range:
       [
         {
-          base_addr: 0x40080000
           size_byte: 0x1000
+          base_addr: 0x40080000
         }
       ]
       xbar: false
@@ -118,8 +118,8 @@
       addr_range:
       [
         {
-          base_addr: 0x40150000
           size_byte: 0x1000
+          base_addr: 0x40150000
         }
       ]
       xbar: false

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -61,7 +61,6 @@ module top_earlgrey #(
   import tlul_pkg::*;
   import top_pkg::*;
   import tl_main_pkg::*;
-  import flash_ctrl_pkg::*;
 
   tl_h2d_t  tl_corei_h_h2d;
   tl_d2h_t  tl_corei_h_d2h;
@@ -423,9 +422,9 @@ module top_earlgrey #(
     .rdata_o  (ram_main_rdata)
   );
 
-  // flash controller to eflash communication
-  flash_req_t flash_req;
-  flash_rsp_t flash_rsp;
+  // define inter-module signals
+  flash_ctrl_pkg::flash_req_t im0_flash_req;
+  flash_ctrl_pkg::flash_rsp_t im0_flash_rsp;
 
   // host to flash communication
   logic flash_host_req;
@@ -471,8 +470,8 @@ module top_earlgrey #(
     .host_req_rdy_o  (flash_host_req_rdy),
     .host_req_done_o (flash_host_req_done),
     .host_rdata_o    (flash_host_rdata),
-    .flash_ctrl_i    (flash_req),
-    .flash_ctrl_o    (flash_rsp)
+    .flash_ctrl_i    (im0_flash_req),
+    .flash_ctrl_o    (im0_flash_rsp)
   );
 
 
@@ -558,8 +557,9 @@ module top_earlgrey #(
       .intr_op_done_o    (intr_flash_ctrl_op_done),
       .intr_op_error_o   (intr_flash_ctrl_op_error),
 
-      .flash_o(flash_req),
-      .flash_i(flash_rsp),
+      // Inter-module signals
+      .flash_o(im0_flash_req),
+      .flash_i(im0_flash_rsp),
 
       .clk_i (main_clk),
       .rst_ni (lc_rst_n)

--- a/util/topgen/intermodule.py
+++ b/util/topgen/intermodule.py
@@ -1,0 +1,111 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import logging as log
+from typing import Dict
+
+from .lib import *
+
+
+def elab_intermodule(topcfg):
+    """Check the connection of inter-module and categorize them
+
+    In the top template, it uses updated inter_module fields to create
+    connections between the modules (incl. memories). This function is to
+    create and check the validity of the connections `inter_module` using IPs'
+    `inter_signal_list`.
+    """
+
+    list_of_intersignals = []
+
+    if "inter_signal" not in topcfg:
+        topcfg["inter_signal"] = {}
+
+    # Gather the inter_signal_list
+    instances = topcfg["module"] + topcfg["memory"]
+
+    intermodule_instances = [x for x in instances if "inter_signal_list" in x]
+
+    for x in intermodule_instances:
+        for sig in x["inter_signal_list"]:
+            # Add instance name to the entry and add to list_of_intersignals
+            sig["inst_name"] = x["name"]
+            list_of_intersignals.append(sig)
+
+    # TODO: Cross check
+
+    # Add field to the topcfg
+    topcfg["inter_signal"]["signals"] = list_of_intersignals
+
+    # intermodule
+    definitions = []
+
+    uid = 0  # Unique connection ID across the top
+
+    for req, rsps in topcfg["inter_module"].items():
+        log.info("{req} --> {rsps}".format(req=req, rsps=rsps))
+        req_module, req_signal = req.split('.')
+
+        # get the module signal
+        req_struct = find_intermodule_signal(list_of_intersignals, req_module,
+                                             req_signal)
+
+        rsp_len = len(rsps)
+        for i, rsp in enumerate(rsps):
+            assert i == 0, "Handling multiple connections (array) isn't yet supported"
+            rsp_module, rsp_signal = rsp.split('.')
+
+            rsp_struct = find_intermodule_signal(list_of_intersignals,
+                                                 rsp_module, rsp_signal)
+
+            # determine the signal name
+            sig_name = "im{uid}_{req_s}".format(uid=uid,
+                                                req_s=req_struct['struct'])
+
+            req_struct["top_signame"] = sig_name
+            rsp_struct["top_signame"] = sig_name
+
+            # Add to definitions
+            if "package" in req_struct:
+                package = req_struct["package"]
+            else:
+                assert "package" in rsp_struct, "Either req/rsp shall have 'package' field"
+                package = rsp_struct["package"]
+
+            definitions.append({
+                'package': package,
+                'struct': req_struct["struct"],
+                'signame': sig_name,
+                'type': req_struct["type"]
+            })
+
+            if rsp_len != 1:
+                log.warning("{req}[{i}] -> {rsp}".format(req=req, i=i,
+                                                         rsp=rsp))
+            else:
+                log.warning("{req} -> {rsp}".format(req=req, rsp=rsp))
+
+            # increase Unique ID
+            uid += 1
+
+    # TODO: Check unconnected port
+
+    if "definitions" not in topcfg["inter_signal"]:
+        topcfg["inter_signal"]["definitions"] = definitions
+
+
+def find_intermodule_signal(sig_list, m_name, s_name) -> Dict:
+    """Return the intermodule signal structure
+    """
+
+    filtered = [
+        x for x in sig_list if x["name"] == s_name and x["inst_name"] == m_name
+    ]
+
+    assert len(
+        filtered
+    ) == 1, "Error on finding the inter module signal {m_name}.{s_name}".format(
+        m_name=m_name, s_name=s_name)
+
+    return filtered[0]

--- a/util/topgen/lib.py
+++ b/util/topgen/lib.py
@@ -70,6 +70,32 @@ def get_module_by_name(top, name):
     return module
 
 
+def intersignal_to_signalname(top, m_name, s_name) -> str:
+
+    # TODO: Find the signal in the `inter_module_list` and get the correct signal name
+
+    return "{m_name}_{s_name}".format(m_name=m_name, s_name=s_name)
+
+
+def get_package_name_by_intermodule_signal(top, struct) -> str:
+    """Search inter-module signal package with the struct name
+
+    For instance, if `flash_ctrl` has inter-module signal package,
+    this function returns the package name
+    """
+    instances = top["module"] + top["memory"]
+
+    intermodule_instances = [
+        x["inter_signal_list"] for x in top["module"] + top["memory"]
+        if "inter_signal_list" in x
+    ]
+
+    for m in intermodule_instances:
+        if m["name"] == struct and "package" in m:
+            return m["package"]
+    return ""
+
+
 def get_signal_by_name(module, name):
     """Return the signal struct with the type input/output/inout
     """

--- a/util/topgen/merge.py
+++ b/util/topgen/merge.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 from functools import partial
 
 from .lib import *
-import hjson
+from .intermodule import elab_intermodule
 
 
 def amend_ip(top, ip):
@@ -111,6 +111,12 @@ def amend_ip(top, ip):
         ip_module["scan"] = ip["scan"]
     else:
         ip_module["scan"] = "false"
+
+    # inter-module
+    if "inter_signal_list" in ip:
+        ip_module["inter_signal_list"] = ip["inter_signal_list"]
+
+        # TODO: validate
 
 
 # TODO: Replace this part to be configurable from Hjson or template
@@ -580,6 +586,9 @@ def merge_top(topcfg, ipobjs, xbarobjs):
     # Combine ip cfg into topcfg
     for ip in ipobjs:
         amend_ip(gencfg, ip)
+
+    # Inter-module signals
+    elab_intermodule(gencfg)
 
     # Combine the interrupt (should be processed prior to xbar)
     amend_interrupt(gencfg)


### PR DESCRIPTION
[topgen] Primitive Inter-module connection
    
Adding simple inter-module connection feature to the top template.
    
A.I:
    
1. Define unique inter-module signal (naming rule) when it has multiple
       connections of the same struct
2. Reduce the fields of `inter_signal_list` in the ip.hjson
3. Add `broadcast` type and handling
4. Add validation check
5. Add dangling port handling code using default parameters
    
This is related to #42
