### PR TITLE
[sw] Build googletest using meson

### DIFF
--- a/apt-requirements.txt
+++ b/apt-requirements.txt
@@ -7,7 +7,6 @@ autoconf
 bison
 build-essential
 clang-format
-cmake
 curl
 flex
 g++

--- a/doc/ug/install_instructions/index.md
+++ b/doc/ug/install_instructions/index.md
@@ -15,7 +15,6 @@ This guide makes assumes the following system setup.
 * Physical access to that machine, root permissions and a graphical environment.
 * Python 3.5.2 or newer. Python 3.6+ is recommended.
 * A C++14 capable compiler. GCC 5 or Clang 3.5 should meet this requirement.
-* CMake 2.8.8 or newer.
 * 60 GB or more of disk space.
   EDA tools like Xilinx Vivado can easily take up 40 GB each.
 * We develop and test on the following Linux distributions:

--- a/sw/device/lib/testing/meson.build
+++ b/sw/device/lib/testing/meson.build
@@ -2,54 +2,6 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-sw_lib_testing_gtest_src_dir = meson.source_root() / 'sw/vendor/google_googletest'
-sw_lib_testing_gtest_lock_file = meson.source_root() / 'sw/vendor/google_googletest.lock.hjson'
-# Build dir below is $REPO_TOP/build-out/sw/${DEVICE}/sw/device/lib/testing/google_googletest
-sw_lib_testing_gtest_build_dir = meson.current_build_dir() / 'google_googletest'
-sw_lib_testing_empty_file_for_dep = 'empty_file_for_googletest_dependency.cc'
-
-# Bash script used for building googletest. Also creates an empty file
-# which is used to establish the dependency between gtest and mock_mmio.
-build_gtest_cmd = '''
-echo "Building googletest..."
-GTEST_BUILD_DIR="@0@"
-GTEST_SRC_DIR="@1@"
-EMPTY_FILE_FOR_DEP="@2@"
-# Create a directory for building gtest
-mkdir -p $GTEST_BUILD_DIR
-# Build googletest
-cmake -B $GTEST_BUILD_DIR -S $GTEST_SRC_DIR > /dev/null
-make -C $GTEST_BUILD_DIR > /dev/null
-# Create an empty file for dependencies
-touch "@OUTDIR@/$EMPTY_FILE_FOR_DEP"
-echo "Done!"
-'''.format(sw_lib_testing_gtest_build_dir, sw_lib_testing_gtest_src_dir, sw_lib_testing_empty_file_for_dep)
-
-sw_lib_testing_build_gtest = custom_target(
-  'googletest',
-  output: sw_lib_testing_empty_file_for_dep,
-  depend_files: sw_lib_testing_gtest_lock_file,
-  command: ['bash', '-e', '-c', build_gtest_cmd],
-  console: true,
-)
-
-sw_lib_testing_gtest = declare_dependency(
-  sources: [sw_lib_testing_build_gtest],
-  link_args: [
-    '-L' + sw_lib_testing_gtest_build_dir / 'lib',
-    '-lgmock',
-    '-lgmock_main',
-    '-lgtest',
-  ],
-  dependencies: dependency('threads'),
-  compile_args: [
-    # These are necessary in order to make gtest headers correctly find other
-    # gtest headers.
-    '-I' + meson.source_root() / 'sw/vendor/google_googletest/googletest/include',
-    '-I' + meson.source_root() / 'sw/vendor/google_googletest/googlemock/include',
-  ],
-)
-
 sw_lib_testing_mock_mmio = declare_dependency(
   link_with: static_library(
     'mock_mmio',
@@ -57,7 +9,7 @@ sw_lib_testing_mock_mmio = declare_dependency(
       meson.source_root() / 'sw/device/lib/base/mmio.c',
       'mock_mmio.cc',
     ],
-    dependencies: [sw_lib_testing_gtest],
+    dependencies: [sw_vendor_gtest],
     native: true,
     c_args: ['-DMOCK_MMIO'],
     cpp_args: ['-DMOCK_MMIO'],
@@ -70,7 +22,7 @@ test('mock_mmio_test', executable(
   'mock_mmio_test',
   sources: ['mock_mmio_test.cc'],
   dependencies: [
-    sw_lib_testing_gtest,
+    sw_vendor_gtest,
     sw_lib_testing_mock_mmio,
   ],
   native: true,

--- a/sw/vendor/meson.build
+++ b/sw/vendor/meson.build
@@ -9,3 +9,42 @@ vendor_coremark_base_files = files([
   'eembc_coremark/core_state.c',
   'eembc_coremark/core_util.c',
 ])
+
+# googletest and googlemock build definitions
+#
+# The following is inspired by the meson configuration available in
+# https://github.com/mesonbuild/gtest/tree/1.10.0 (which is MIT
+# licensed).
+thread_dep = dependency('threads')
+sw_vendor_gtest_dir = 'google_googletest'
+
+sw_vendor_gtest_googletest_dir = sw_vendor_gtest_dir / 'googletest'
+sw_vendor_gtest_googletest_inc_dir = include_directories(
+  sw_vendor_gtest_googletest_dir / 'include',
+  sw_vendor_gtest_googletest_dir,
+  is_system: true,
+)
+sw_vendor_gtest_googletest_libsources = files(sw_vendor_gtest_googletest_dir / 'src/gtest-all.cc')
+
+sw_vendor_gtest_googlemock_dir = sw_vendor_gtest_dir / 'googlemock'
+sw_vendor_gtest_googlemock_inc_dir = include_directories(
+  sw_vendor_gtest_googlemock_dir / 'include',
+  sw_vendor_gtest_googlemock_dir,
+  is_system: true,
+)
+sw_vendor_gtest_googlemock_libsources = files(sw_vendor_gtest_googlemock_dir / 'src/gmock-all.cc')
+sw_vendor_gtest_googlemock_mainsources = files(sw_vendor_gtest_googlemock_dir / 'src/gmock_main.cc')
+
+sw_vendor_gtest = declare_dependency(
+  include_directories: [
+    sw_vendor_gtest_googletest_inc_dir,
+    sw_vendor_gtest_googlemock_inc_dir,
+  ],
+  sources: [
+    sw_vendor_gtest_googletest_libsources,
+    sw_vendor_gtest_googlemock_libsources,
+    sw_vendor_gtest_googlemock_mainsources,
+  ],
+  dependencies: thread_dep,
+)
+# End googletest and googlemock build definitions


### PR DESCRIPTION
Vendoring googletest introduced a dependency on CMake, which has caused
issues, including #1484.

This commit removes the dependency on CMake by adding build rules for
googletest directly in meson.

This commit also reverts b94e3f8964ccea0a73811537a4c783fedec5270c, as
CMake should no longer be needed.

---

Closes #1484.

The Meson rules used are inspired by https://github.com/mesonbuild/gtest/blob/1.10.0/googletest/meson.build and https://github.com/mesonbuild/gtest/blob/1.10.0/googlemock/meson.build which are MIT licensed.