### PR TITLE
[lint] Add AscentLint 2019.A.p3 configuration

### DIFF
--- a/hw/lint/ascentlint-config.tcl
+++ b/hw/lint/ascentlint-config.tcl
@@ -1,0 +1,9 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# get installation path of ascentlint
+set RI_INSTALL [file dirname [exec which ascentlint]]
+
+# source the policy file containing the lowrisc lint rules
+source "$RI_INSTALL/../Ascent/Lint/lib/policies/lowRISC/LRLR-v1.0.policy"

--- a/hw/lint/common.core
+++ b/hw/lint/common.core
@@ -13,7 +13,7 @@ filesets:
   files_ascentlint:
     files:
       - common.waiver: {file_type: waiver}
-      - ascentlint.policy: {file_type: tclSource}
+      - ascentlint-config.tcl: {file_type: tclSource}
 
 targets:
   default: &default_target


### PR DESCRIPTION
AscentLint 2019.A.p3 has been released, and starting from this version the lowRISC lint policy conforming to our style guide is part of the default policies available in that tool!

This patch adds a configuration script that enables that lint policy - so everybody who has a license for AscentLint 2019.A.p3 (or newer) will be able to run AscentLint on OT with the lowRISC lint rules.

Note that I will update the corresponding lint documentation soon.