### PR TITLE
[doc] Ensure install instructions match apt requirements

### DIFF
--- a/doc/ug/install_instructions/index.md
+++ b/doc/ug/install_instructions/index.md
@@ -55,12 +55,7 @@ A number of software packages from the distribution's package manager is require
 All installation instructions below are for Ubuntu 16.04.
 Adjust as necessary for other Linux distributions.
 
-```console
-$ sudo apt-get install git python3 python3-pip python3-setuptools \
-    build-essential autoconf flex bison ninja-build pkgconf \
-    srecord zlib1g-dev libftdi1-dev libftdi1-2 libssl-dev \
-    libusb-1.0-0-dev libtool libelf-dev
-```
+{{< apt_cmd >}}
 
 Some tools in this repository are written in Python 3 and require Python dependencies to be installed through `pip`.
 (Note that the `diff_generated_util_output.py` tool works better with Python 3.6 or later where the order is preserved in `dict` types, earlier versions of Python will show spurious differences caused by things being reordered.)

--- a/site/docs/layouts/shortcodes/apt_cmd.html
+++ b/site/docs/layouts/shortcodes/apt_cmd.html
@@ -1,0 +1,6 @@
+{{ $path := path.Join .Site.Params.generatedRoot "apt_cmd.txt" }}
+{{ if not (fileExists $path) }}
+  {{ errorf "apt_cmd.txt has not been generated" }}
+{{ end }}
+
+<pre><code class="language-console" data-lang="console">{{ readFile $path | safeHTML }}</code></pre>


### PR DESCRIPTION
The `apt-get install` command has, at some points, not been updated with
changes to "apt-requirements.txt" (as happened when CMake was
accidentally added to the dependencies then hastily documented).

This commit allows us to generate the `apt-get install` command based on
the contents of apt-requirements.txt, and include that directly. This
has changed the listed order of packages, but ensures the documentation
stays up to date when apt-requirements.txt changes.

---

This problem was noticed by @gregac, who gave me the idea to generate the line directly from the requirements. 