### PR TITLE
[sw] Remove redundant dependency from sw_lib_uart build

### DIFF
--- a/sw/device/lib/meson.build
+++ b/sw/device/lib/meson.build
@@ -9,7 +9,6 @@ subdir('dif')
 
 # UART library (sw_lib_uart)
 sw_lib_uart = declare_dependency(
-  sources: [hw_ip_uart_reg_h],
   link_with: static_library(
     'uart_ot',
     sources: ['uart.c'],


### PR DESCRIPTION
UART driver should not be able to directly access any of the UART peripheral defines.