### PR TITLE
[dv regr tool] Coverage collection and reporting

### DIFF
--- a/hw/dv/data/common_sim_cfg.hjson
+++ b/hw/dv/data/common_sim_cfg.hjson
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   project:          opentitan
-  doc_server:       "docs.opentitan.org"
-  results_server:   "reports.opentitan.org"
+  doc_server:       docs.opentitan.org
+  results_server:   reports.opentitan.org
 
   flow:             sim
   flow_makefile:    "{proj_root}/hw/dv/data/sim.mk"
@@ -123,6 +123,14 @@
   ]
 
   // Project defaults for VCS
-  vcs_cov_hier: "-cm_hier {proj_root}/hw/dv/tools/vcs/cover.cfg"
-  vcs_cov_excl_files: ["{proj_root}/hw/dv/tools/vcs/common_cov_excl.el"]
+  vcs_cov_hier: "-cm_hier {tool_dir}/cover.cfg"
+  vcs_cov_excl_files: ["{tool_dir}/common_cov_excl.el"]
+
+  // Results server stuff - indicate what command to use to copy over the results.
+  // Workaround for gsutil to fall back to using python2.7.
+  results_server_prefix:      "gs://"
+  results_server_url_prefix:  "https://"
+  results_server_cmd:     "CLOUDSDK_PYTHON=/usr/bin/python2.7 /usr/bin/gsutil"
+  results_server_path:    "{results_server_prefix}{results_server}/{rel_path}"
+  results_server_dir:     "{results_server_path}/latest"
 }

--- a/hw/dv/data/sim.mk
+++ b/hw/dv/data/sim.mk
@@ -73,16 +73,17 @@ debug_waves:
 ############################
 ## coverage rated targets ##
 ############################
+# Merge coverage if there are multiple builds.
 cov_merge:
-	# TODO: add script to merge coverage in scratch scope
+	${cov_merge_cmd} ${cov_merge_opts}
 
-# open coverage tool to review and create report or exclusion file
+# Open coverage tool to review and create report or exclusion file.
 cov_analyze:
-	cd ${scratch_path} && ${cov_analyze_cmd} ${cov_analyze_opts}
+	${cov_analyze_cmd} ${cov_analyze_opts}
 
-# generate coverage report directly
+# Generate coverage reports.
 cov_report:
-	cd ${scratch_path} && ${cov_report} ${cov_report_opts}
+	${cov_report_cmd} ${cov_report_opts}
 
 clean:
 	echo "[make]: clean"

--- a/hw/dv/data/vcs/vcs.hjson
+++ b/hw/dv/data/vcs/vcs.hjson
@@ -33,6 +33,58 @@
                "+UVM_TESTNAME={uvm_test}",
                "+UVM_TEST_SEQ={uvm_test_seq}"]
 
+  // Coverage related.
+  cov_db_dir: "{build_dir}/cov.vdb"
+
+  // Individual test specific coverage data - this will be deleted if the test fails
+  // so that coverage from failiing tests is not included in the final report.
+  cov_db_test_dir_name: "{run_dir_name}.{seed}"
+  cov_db_test_dir: "{cov_db_dir}/snps/coverage/db/testdata/{cov_db_test_dir_name}"
+
+  // Merging coverage.
+  // "cov_db_dirs" is a special variable that appends all build directories in use.
+  // It is constructed by the tool itself.
+  cov_merge_dir:    "{scratch_path}/cov_merge"
+  cov_merge_db_dir: "{cov_merge_dir}/merged.vdb"
+  cov_merge_cmd:    "{job_prefix} urg"
+  cov_merge_opts:   ["-full64",
+                     "+urg+lic+wait",
+                     "-nocheck",
+                     "-noreport",
+                     "-flex_merge drop",
+                     "-group merge_across_scopes",
+                     "-parallel",
+                     "-parallel_split 20",
+                     // Use cov_db_dirs var for dir args; append -dir in front of each
+                     '''{eval_cmd} dirs=`echo {cov_db_dirs}`; dir_args=; \
+                     for d in $dirs; do dir_args="$dir_args -dir $d"; done; \
+                     echo $dir_args
+                     ''',
+                     "-dbname {cov_merge_db_dir}"]
+
+  // Generate coverage reports in text as well as html.
+  cov_report_dir:       "{scratch_path}/cov_report"
+  cov_report_cmd:       "{job_prefix} urg"
+  cov_report_opts:      ["-full64",
+                        "+urg+lic+wait",
+                        "-dir {cov_merge_db_dir}",
+                        "-group instcov_for_score",
+                        "-line nocasedef",
+                        "-format both",
+                        "-elfile {vcs_cov_excl_files}",
+                        "-report {cov_report_dir}"]
+  cov_report_dashboard: "{cov_report_dir}/dashboard.txt"
+
+  // Analyzing coverage - this is done by invoking --cov-analyze switch. It opens up the
+  // GUI for visual analysis.
+  cov_analyze_dir:  "{scratch_path}/cov_analyze"
+  cov_analyze_cmd:  "{job_prefix} verdi"
+  cov_analyze_opts: ["-cov",
+                     "-covdir {cov_merge_db_dir}",
+                     "-line nocasedef"
+                     "-elfile {vcs_cov_excl_files}"]
+
+  // Vars that need to exported to the env.
   exports: [
     VCS_ARCH_OVERRIDE: linux
     VCS_LIC_EXPIRE_WARNING: 1
@@ -70,7 +122,7 @@
                    // Ignore warnings about not applying cm_glitch to path and FSM
                    "+warn=noVCM-OPTIGN",
                    // Coverage database output location
-                   "-cm_dir {build_dir}/cov.vdb"]
+                   "-cm_dir {cov_db_dir}"]
 
       run_opts:   [// Enable the required cov metrics
                    "-cm {cov_metrics}",
@@ -79,7 +131,7 @@
                    // Don't output cm.log which can be quite large
                    "-cm_log /dev/null",
                    // Provide a name to the coverage collected for this test
-                   "-cm_name {index}.{test}",
+                   "-cm_name {cov_db_test_dir_name}",
                    // Don't dump all the coverage assertion attempts at the end of simulation
                    "-assert nopostproc"]
     }

--- a/hw/dv/data/xcelium/xcelium.hjson
+++ b/hw/dv/data/xcelium/xcelium.hjson
@@ -19,6 +19,35 @@
                "+UVM_TESTNAME={uvm_test}",
                "+UVM_TEST_SEQ={uvm_test_seq}"]
 
+  // Coverage related.
+  // TODO: These options have to be filled in.
+  cov_db_dir: ""
+
+  // Individual test specific coverage data - this will be deleted if the test fails
+  // so that coverage from failiing tests is not included in the final report.
+  cov_db_test_dir_name: "{run_dir_name}.{seed}"
+  cov_db_test_dir: ""
+
+  // Merging coverage.
+  // "cov_db_dirs" is a special variable that appends all build directories in use.
+  // It is constructed by the tool itself.
+  cov_merge_dir:    "{scratch_path}/cov_merge"
+  cov_merge_db_dir: ""
+  cov_merge_cmd:    ""
+  cov_merge_opts:   []
+
+  // Generate covreage reports in text as well as html.
+  cov_report_dir:       "{scratch_path}/cov_report"
+  cov_report_cmd:       ""
+  cov_report_opts:      []
+  cov_report_dashboard: ""
+
+  // Analyzing coverage - this is done by invoking --cov-analyze switch. It opens up the
+  // GUI for visual analysis.
+  cov_analyze_dir:  "{scratch_path}/cov_analyze"
+  cov_analyze_cmd:  ""
+  cov_analyze_opts: []
+
   build_modes: [
     {
       name: xcelium_waves

--- a/hw/ip/aes/data/aes_testplan.hjson
+++ b/hw/ip/aes/data/aes_testplan.hjson
@@ -33,14 +33,14 @@
       desc: '''
             Compare cypher text from AWS module with the output of a C model using same key and data'''
       milestone: V2
-      tests: ["aes_sanity", "aes_stress"]
+      tests: ["aes_sanity"]
     }
     {
       name: key_size
       desc: '''
            Randomly select keysize to verify all supported keysizes are working'''
       milestone: V2
-      tests: ["aes_stress"]
+      tests: []
     }
     {
       name: failure_test
@@ -51,21 +51,21 @@
               then enter the 128bit of the key and use for decryption.
               will result match plain text and vice verca'''
       milestone: V2
-      tests: ["aes_stress"]
+      tests: []
     }
     {
       name: reset_recovery
       desc: '''
             Pull reset at random times make sure AES recover/resets correctly'''
       milestone: V2
-      tests: ["aes_stress"]
+      tests: []
     }
     {
       name: deinitialization
       desc: '''
             Make sure that there is no residual data from latest operation '''
       milestone: V2
-      tests: ["aes_stress"]
+      tests: []
     }
   ]
 }

--- a/hw/ip/aes/dv/aes_sim_cfg.hjson
+++ b/hw/ip/aes/dv/aes_sim_cfg.hjson
@@ -62,11 +62,6 @@
       name: aes_sanity
       uvm_test_seq: aes_sanity_vseq
     }
-
-    {
-      // TODO: Need to add test below to get it to map to the testplan entry.
-      name: aes_stress
-    }
   ]
 
   // List of regressions.

--- a/hw/ip/uart/dv/uart_sim_cfg.hjson
+++ b/hw/ip/uart/dv/uart_sim_cfg.hjson
@@ -40,7 +40,12 @@
   uvm_test_seq: uart_base_vseq
 
   // Add UART specific exclusion files.
-  vcs_cov_excl_files: ["{proj_root}/hw/ip/uart/dv/cov/uart_cov_excl.el"]
+
+  // Add excl files to tool_srcs so that it gets copied over to the scratch area.
+  tool_srcs: ["{proj_root}/hw/ip/uart/dv/cov/uart_cov_excl.el"]
+  // Refer to the excl file with vcs_cov_excl_files var with the rel path from tool_dir
+  // so the VCS can find it.
+  vcs_cov_excl_files: ["{tool_dir}/uart_cov_excl.el"]
 
   // List of test specifications.
   tests: [

--- a/util/dvsim/style.css
+++ b/util/dvsim/style.css
@@ -72,3 +72,64 @@
 .results tbody tr:nth-child(even) {
   background: #f2f2f2;
 }
+
+/* Color encoding for percentages. */
+.cna  {
+  color: 000000;
+  background-color: #f8f8f8;
+}
+
+.c0  {
+  color: #ffffff;
+  background-color: #EF6F6F;
+}
+
+.c1  {
+  color: #ffffff;
+  background-color: #EF886F;
+}
+
+.c2  {
+  color: #000000;
+  background-color: #EFA26F;
+}
+
+.c3  {
+  color: #000000;
+  background-color: #EFBB6F;
+}
+
+.c4  {
+  color: #000000;
+  background-color: #EFD56F;
+}
+
+.c5  {
+  color: #000000;
+  background-color: #EEEF6F;
+}
+
+.c6  {
+  color: #000000;
+  background-color: #D5EF6F;
+}
+
+.c7  {
+  color: #000000;
+  background-color: #BBEF6F;
+}
+
+.c8  {
+  color: #000000;
+  background-color: #A2EF6F;
+}
+
+.c9  {
+  color: #000000;
+  background-color: #88EF6F;
+}
+
+.c10  {
+  color: #000000;
+  background-color: #6FEF6F;
+}

--- a/util/testplanner/class_defs.py
+++ b/util/testplanner/class_defs.py
@@ -132,12 +132,12 @@ class TestplanEntry():
 
             # if a test was not found in regr results, indicate 0/1 passing
             if map_full_testplan and not found:
-                test_results.append({"name": test, "passing": 0, "total": 1})
+                test_results.append({"name": test, "passing": 0, "total": 0})
 
         # if no written tests were indicated in the testplan, reuse planned
         # test name and indicate 0/1 passing
         if map_full_testplan and self.tests == []:
-            test_results.append({"name": self.name, "passing": 0, "total": 1})
+            test_results.append({"name": self.name, "passing": 0, "total": 0})
 
         # replace tests with test results
         self.tests = test_results
@@ -305,7 +305,7 @@ class Testplan():
         '''
         self.map_regr_results(regr_results, map_full_testplan)
         table = [[
-            "Milestone", "Name", "Tests", "Passing", "Iterations", "Pass Rate"
+            "Milestone", "Name", "Tests", "Passing", "Total", "Pass Rate"
         ]]
         colalign = ("center", "center", "left", "center", "center", "center")
         for entry in self.entries:
@@ -314,8 +314,10 @@ class Testplan():
             if milestone == "N.A.": milestone = ""
             if entry_name == "N.A.": entry_name = ""
             for test in entry.tests:
-                pass_rate = test["passing"] / test["total"] * 100
-                pass_rate = "{0:.2f}".format(round(pass_rate, 2))
+                if test["total"] == 0: pass_rate = "-- %"
+                else:
+                    pass_rate = test["passing"] / test["total"] * 100
+                    pass_rate = "{0:.2f} %".format(round(pass_rate, 2))
                 table.append([
                     milestone, entry_name, test["name"], test["passing"],
                     test["total"], pass_rate


### PR DESCRIPTION
- This PR enables coverage collection as a part of the regression run
when --cov switch is passed
- If there are multiple builds as a part of the same DUT, it merges the
coverage across them
- It also merges coverage from previous regressions if the
--cov-merge-previous switch is passed
- Finally, it extracts the high level summary coverage from the VCS
coverage dashboard and prints it as a part of the regression report

Another major update in this PR is - all percentages indicated in a
report table indicated with a '%' sign is automatically colored in the
html report as a heat map, from red for low percentages to green
approaching 100%. This is enabled for regression results as well as
coverage results.

https://reports.opentitan.org/hw/ip/hmac/dv/latest/results.html

Signed-off-by: Srikrishna Iyer <sriyer@google.com>