### PR TITLE
[dv/gpio] Fix failure tests

### DIFF
--- a/hw/ip/gpio/dv/env/gpio_scoreboard.sv
+++ b/hw/ip/gpio/dv/env/gpio_scoreboard.sv
@@ -784,6 +784,8 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
     last_intr_update_except_clearing = '0;
     last_intr_test_event = '0;
     cleared_intr_bits = '0;
+    // call again to predict 'data_in_update_queue' to ensure data_in ral is updated
+    gpio_predict_and_compare();
   endfunction
 
   // Function: check_phase


### PR DESCRIPTION
Fix failure tests due to after reset, simulator might run the deleting
queue thread first, then add items to the queue.

Signed-off-by: Cindy Chen <chencindy@google.com>