### PR TITLE
[sw, dif_plic] Use generated register definitions

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -108,5 +108,6 @@ hw_ip_rv_timer_reg_h = gen_hw_hdr.process('hw/ip/rv_timer/data/rv_timer.hjson')
 hw_ip_uart_reg_h = gen_hw_hdr.process('hw/ip/uart/data/uart.hjson')
 hw_ip_usbdev_reg_h = gen_hw_hdr.process('hw/ip/usbdev/data/usbdev.hjson')
 hw_top_earlgrey_pinmux_h = gen_hw_hdr.process('hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson')
+hw_top_earlgrey_rv_plic_h = gen_hw_hdr.process('hw/top_earlgrey/ip/rv_plic/data/autogen/rv_plic.hjson')
 
 subdir('sw')

--- a/sw/device/lib/dif/dif_plic.c
+++ b/sw/device/lib/dif/dif_plic.c
@@ -8,28 +8,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "rv_plic_regs.h"  // Generated.
 #include "sw/device/lib/base/mmio.h"
-
-// Interrupt Pending register offsets from the PLIC base.
-#define RV_PLIC_IP0 0x0u
-#define RV_PLIC_IP1 0x4u
-
-// Level/Edge register offsets from the PLIC base.
-#define RV_PLIC_LE0 0x8u
-#define RV_PLIC_LE1 0xCu
-
-// Priority register offsets from the PLIC base.
-#define RV_PLIC_PRIO0 0x10u
-
-// Interrupt Enable register offsets from the PLIC base.
-#define RV_PLIC_IE00 0x200u
-#define RV_PLIC_IE01 0x204u
-
-// Threshold register offsets from the PLIC base.
-#define RV_PLIC_THRESHOLD0 0x208u
-
-// Interrupt Claim register offsets from the PLIC base.
-#define RV_PLIC_CC0 0x20cu
 
 // The highest interrupt priority.
 #define RV_PLIC_MAX_PRIORITY 0x3u
@@ -82,9 +62,9 @@ typedef struct plic_peripheral_range {
 static const plic_target_reg_offset_t plic_target_reg_offsets[] = {
         [kDifPlicTargetIbex0] =
             {
-                .ie = RV_PLIC_IE00,
-                .cc = RV_PLIC_CC0,
-                .threshold = RV_PLIC_THRESHOLD0,
+                .ie = RV_PLIC_IE00_REG_OFFSET,
+                .cc = RV_PLIC_CC0_REG_OFFSET,
+                .threshold = RV_PLIC_THRESHOLD0_REG_OFFSET,
             },
 };
 
@@ -169,7 +149,7 @@ static void plic_irq_enable_reg_info(dif_plic_irq_id_t irq,
 static void plic_irq_trigger_type_reg_info(dif_plic_irq_id_t irq,
                                            plic_reg_info_t *reg_info) {
   ptrdiff_t offset = plic_offset_from_reg0(irq);
-  reg_info->offset = RV_PLIC_LE0 + offset;
+  reg_info->offset = RV_PLIC_LE0_REG_OFFSET + offset;
   reg_info->bit_index = plic_reg_bit_index_from_irq_id(irq);
 }
 
@@ -179,7 +159,7 @@ static void plic_irq_trigger_type_reg_info(dif_plic_irq_id_t irq,
 static void plic_irq_pending_reg_info(dif_plic_irq_id_t irq,
                                       plic_reg_info_t *reg_info) {
   ptrdiff_t offset = plic_offset_from_reg0(irq);
-  reg_info->offset = RV_PLIC_IP0 + offset;
+  reg_info->offset = RV_PLIC_IP0_REG_OFFSET + offset;
   reg_info->bit_index = plic_reg_bit_index_from_irq_id(irq);
 }
 
@@ -191,7 +171,7 @@ static void plic_irq_pending_reg_info(dif_plic_irq_id_t irq,
  */
 static ptrdiff_t plic_priority_reg_offset(dif_plic_irq_id_t irq) {
   ptrdiff_t offset = PLIC_ID_TO_INDEX(irq) * sizeof(uint32_t);
-  return RV_PLIC_PRIO0 + offset;
+  return RV_PLIC_PRIO0_REG_OFFSET + offset;
 }
 
 bool dif_plic_init(mmio_region_t base_addr, dif_plic_t *plic) {

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -19,9 +19,13 @@ dif_uart = declare_dependency(
 
 # PLIC DIF library (dif_plic)
 dif_plic = declare_dependency(
+  sources: [hw_top_earlgrey_rv_plic_h],
   link_with: static_library(
     'dif_plic_ot',
-    sources: ['dif_plic.c'],
+    sources: [
+      hw_top_earlgrey_rv_plic_h,
+      'dif_plic.c',
+    ],
     dependencies: [sw_lib_mmio]
   )
 )


### PR DESCRIPTION
This PR fixes #1508, and consists from two changes:
1) Generate register PLIC register definitions.
2) Change DIF PLIC to use the generated register definitions instead of the hardcoded.

The change 2) requires further tweak that I hope @eunchan can help me with. The issue is that the generated register definitions in some cases define the same definition twice. Example:
```
// Interrupt Source mode. 0: Level, 1: Edge-triggered                                                                                                                                               
#define RV_PLIC_LE0(id) (RV_PLIC##id##_BASE_ADDR + 0xc)
#define RV_PLIC_LE0_REG_OFFSET 0xc
#define RV_PLIC_LE0 0
...
// msip for Hart 0.                                                                                                                                                                                 
#define RV_PLIC_MSIP0(id) (RV_PLIC##id##_BASE_ADDR + 0x214)
#define RV_PLIC_MSIP0_REG_OFFSET 0x214
#define RV_PLIC_MSIP0 0
```
Looking at the `hw/top_earlgrey/ip/rv_plic/data/autogen/rv_plic.hjson`, if you take register IE, the `name` in `fields` has value of `E`. It seems that other registers apart from `MSIP0` and `LE` follow this convention.

It seems that when `name` in `multireg` and `name` in `fields` matches:
```
{ multireg: {
        name: "LE",
        desc: "Interrupt Source mode. 0: Level, 1: Edge-triggered",
        count: "NumSrc",
        cname: "RV_PLIC",
        swaccess: "rw",
        hwaccess: "hro",
        fields: [
          { bits: "0", name: "LE", desc: "L0E1" }
        ],
      }
    },
```
regtool produces `#define RV_PLIC_LE0` and not `#define RV_PLIC_LE0_LE0`, whether that is by design or a bug I am not sure.