### PR TITLE
Python requirements: Allow newer meson versions

### DIFF
--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -11,7 +11,8 @@ livereload
 mako
 # Meson 0.53.0 broke compatibility with Python 3.5.2, see
 # https://github.com/lowRISC/opentitan/issues/1288 for details.
-meson >= 0.51.0, < 0.53.0 # minimum matches version in meson.build
+# Newer versions are fine.
+meson >= 0.51.0, != 0.53.0 # minimum matches version in meson.build
 mistletoe>=0.7.2
 pyftdi
 pygments


### PR DESCRIPTION
Meson fixed the incompatibility with Python 3.5.2 introduced in meson
0.53.0, and we can use newer versions again.

Upstream fix: https://github.com/mesonbuild/meson/pull/6498

Fixes #1288