### PR TITLE
Revert "[prim_assert] Fix lint error due to long lines"

### DIFF
--- a/hw/ip/prim/rtl/prim_assert.sv
+++ b/hw/ip/prim/rtl/prim_assert.sv
@@ -120,20 +120,18 @@
 `endif
 
 // Assert that valid is known after reset and data is known when valid == 1
-`define ASSERT_VALID_DATA                                                              \
-    (__name, __valid, __dat, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST) \
-`ifdef INC_ASSERT                                                                      \
-  `ASSERT_KNOWN(__name``KnownValid, __valid, __clk, __rst)                             \
-  `ASSERT_NEVER(__name``KnownData, (__valid) && $isunknown(__dat), __clk, __rst)       \
+`define ASSERT_VALID_DATA(__name, __valid, __dat, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST) \
+`ifdef INC_ASSERT                                                                                           \
+  `ASSERT_KNOWN(__name``KnownValid, __valid, __clk, __rst)                                                  \
+  `ASSERT_NEVER(__name``KnownData, (__valid) && $isunknown(__dat), __clk, __rst)                            \
 `endif
 
 // Same as ASSERT_VALID_DATA, but also assert that ready is known after reset
-`define ASSERT_VALID_READY_DATA                                                                 \
-    (__name, __valid, __ready, __dat, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST) \
-`ifdef INC_ASSERT                                                                               \
-  `ASSERT_KNOWN(__name``KnownValid, __valid, __clk, __rst)                                      \
-  `ASSERT_KNOWN(__name``KnownReady, __ready, __clk, __rst)                                      \
-  `ASSERT_NEVER(__name``KnownData, (__valid) && $isunknown(__dat), __clk, __rst)                \
+`define ASSERT_VALID_READY_DATA(__name, __valid, __ready, __dat, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST) \
+`ifdef INC_ASSERT                                                                                                          \
+  `ASSERT_KNOWN(__name``KnownValid, __valid, __clk, __rst)                                                                 \
+  `ASSERT_KNOWN(__name``KnownReady, __ready, __clk, __rst)                                                                 \
+  `ASSERT_NEVER(__name``KnownData, (__valid) && $isunknown(__dat), __clk, __rst)                                           \
 `endif
 
 ///////////////////////


### PR DESCRIPTION
This reverts commit 17f60494bd4c515b650d82711ee1ff9a9a979fdd.

Backed out for CI failure:

Verilator reports (Vivado also fails):
```
%Error: ../src/lowrisc_ip_flash_ctrl_0.1/rtl/flash_ctrl.sv:474: syntax error, unexpected '('
```