### PR TITLE
[doc] Add C Style Guide Rules for Symbol Naming

### DIFF
--- a/doc/rm/c_cpp_coding_style.md
+++ b/doc/rm/c_cpp_coding_style.md
@@ -162,6 +162,34 @@ Any nonstandard features that are used must be compatible with both GCC and Clan
 
 This rule deviates from the Google C++ style guide to align closer with a typical way of writing C code.
 
+***All symbols in a particular header must share the same unique prefix.***
+
+"Prefix" in this case refers to the identifying string of words, and not the specific type/struct/enum/constant/macro-based capitalisation.
+This rule also deviates from the Google C++ style guide, because C does not have namespaces, so we have to use long names to avoid name clashes.
+Symbols that have specific, global meaning imparted by an external script or specification may break this rule.
+For example:
+```c
+// in my_unit.h
+extern const int kMyUnitMaskValue = 0xFF;
+
+typedef enum { kMyUnitReturnOk } my_unit_return_t;
+
+my_unit_return_t my_unit_init(void);
+```
+
+***The names of enumeration constants must be prefixed with the name of their respective enumeration type.***
+
+Again, this is because C does not have namespaces.
+The exact capitalisation does not need to match, as enumeration type names have a different capitalisation rule to enumeration constants.
+For example:
+```c
+typedef enum my_wonderful_option {
+  kMyWonderfulOptionEnabled,
+  kMyWonderfulOptionDisabled,
+  kMyWonderfulOptionOnlySometimes
+} my_wonderful_option_t;
+```
+
 ### Preprocessor Macros
 
 Macros are often necessary and reasonable coding practice C (as opposed to C++) projects.


### PR DESCRIPTION
Unlike C++, C does not have user-defined namespaces. This means
programmers need to be a lot more careful when naming types, functions,
and symbols.

The following two rules have come up in the software team when
discussing the DIFs, and I feel they are important enough to go into the
OpenTitan-wide C style guide.

1. All symbols in a particular header must share the same unique prefix.
2. The names of enumeration constants must be prefixed with the name of
   their respective enumeration type.

This commit adds both rules with some explanation as to why they are
needed, and some illustrative examples.

---

This PR started with only the enum naming rule, but now has both rules. I've expanded the examples and the commit message due to the addition of the first rule.
