### PR TITLE
[uvmdvgen] add a has_ral flag to uvmdvgen flow

### DIFF
--- a/util/uvmdvgen.py
+++ b/util/uvmdvgen.py
@@ -51,6 +51,15 @@ def main():
     )
 
     parser.add_argument(
+        "-hr",
+        "--has_ral",
+        default=False,
+        action='store_true',
+        help="""Specify whether the DUT has CSRs and thus needs a UVM RAL model.
+                This option is required if either --is_cip or --has_interrupts are
+                enabled.""")
+
+    parser.add_argument(
         "-hi",
         "--has_interrupts",
         default=False,
@@ -104,11 +113,18 @@ def main():
         help=
         """Tests are now run with dvsim.py tool that requires a hjson based sim cfg.
              Setting this option will also result in the Makefile to be auto-generated (which is
-             the older way of building and running sims going through deprecation).""")
+             the older way of building and running sims going through deprecation)."""
+    )
 
     args = parser.parse_args()
     if args.agent_outdir == "name": args.agent_outdir = args.name
     if args.env_outdir == "name": args.env_outdir = args.name
+
+    """ The has_ral option must be set if either is_cip or has_interrupts is set,
+        as both require use of a RAL model. As such, it is disallowed to not have
+        has_ral set if one of these options is set."""
+    if not args.has_ral:
+        args.has_ral = args.is_cip or args.has_interrupts
 
     if args.gen_agent:
         gen_agent.gen_agent(args.name, \
@@ -119,6 +135,7 @@ def main():
         if not args.env_agents: args.env_agents = []
         gen_env.gen_env(args.name, \
                         args.is_cip, \
+                        args.has_ral, \
                         args.has_interrupts, \
                         args.has_alerts, \
                         args.env_agents, \

--- a/util/uvmdvgen/README.md
+++ b/util/uvmdvgen/README.md
@@ -44,6 +44,8 @@ optional arguments:
                         extended from CIP library. If switch is not passed,
                         then the code will be extended from DV library
                         instead. (ignored if -e switch is not passed)
+  -hr, --has_ral        Specify whether the DUT has CSRs and thus needs a UVM
+                        RAL model
   -hi, --has_interrupts
                         CIP has interrupts. Create interrupts interface in tb
   -ha, --has_alerts     CIP has alerts. Create alerts interface in tb
@@ -305,21 +307,28 @@ $ util/uvmdvgen.py i2c -a -s -ao hw/dv/sv
 This will create the I2C agent with separate 'host' mode and 'device' mode drivers.
 
 ```console
-$ util/uvmdvgen.py i2c_host -e -c -hi -ea i2c -eo hw/ip/i2c_host/dv
+$ util/uvmdvgen.py i2c -e -c -hi -eo hw/ip/i2c/dv
+```
+This is an illegal command, it is not allowed to specify that an IP testbench
+extends from CIP lib or has interrupts without specifying that it should support
+a RAL model using the `-hr` flag.
+
+```console
+$ util/uvmdvgen.py i2c_host -e -c -hi -hr -ea i2c -eo hw/ip/i2c_host/dv
 ```
 This will create the complete `i2c_host` DV testbench extended from CIP lib and will
 instantiate `i2c_agent`. It will also create and hook up the interrupt interface
 in the testbench.
 
 ```console
-$ util/uvmdvgen.py foo -e -c -hi -ha -ea foo -eo hw/ip/i2c_host/dv
+$ util/uvmdvgen.py foo -e -c -hi -ha -hr -ea foo -eo hw/ip/i2c_host/dv
 ```
 This will create the complete foo DV testbench extended from CIP lib and
 will instantiate `foo_agent`. It will also create and hook up the interrupt interface
 as well as alerts interface in the testbench.
 
 ```console
-$ util/uvmdvgen.py aes -e -c -ea i2c -eo hw/ip/i2c_host/dv
+$ util/uvmdvgen.py aes -e -c -hr -ea i2c -eo hw/ip/i2c_host/dv
 ```
 This will create the complete `i2c_host` DV testbench extended from CIP lib and will
 instantiate `i2c_agent`.

--- a/util/uvmdvgen/base_test.sv.tpl
+++ b/util/uvmdvgen/base_test.sv.tpl
@@ -18,6 +18,13 @@ class ${name}_base_test extends dv_base_test #(
   // ${name}_env_cfg: cfg
   // ${name}_env:     env
 
+% if not has_ral:
+  virtual function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    cfg.has_ral = 1'b0;
+  endfunction
+% endif
+
   // the base class also looks up UVM_TEST_SEQ plusarg to create and run that seq in
   // the run_phase; as such, nothing more needs to be done
 

--- a/util/uvmdvgen/common_vseq.sv.tpl
+++ b/util/uvmdvgen/common_vseq.sv.tpl
@@ -14,6 +14,7 @@ class ${name}_common_vseq extends ${name}_base_vseq;
     run_common_vseq_wrapper(num_trans);
   endtask : body
 
+% if has_ral:
   // function to add csr exclusions of the given type using the csr_excl_item item
   virtual function void add_csr_exclusions(string           csr_test_type,
                                            csr_excl_item    csr_excl,
@@ -26,5 +27,6 @@ class ${name}_common_vseq extends ${name}_base_vseq;
       // csr_excl.add_excl({scope, ".", "status"}, CsrExclWriteCheck);
     end
   endfunction
+% endif
 
 endclass

--- a/util/uvmdvgen/dv_plan.md.tpl
+++ b/util/uvmdvgen/dv_plan.md.tpl
@@ -75,11 +75,13 @@ ${'###'} UVC/agent 1
 ${'###'} UVC/agent 2
 [Describe here or add link to its README]
 
+% if has_ral:
 ${'###'} UVM RAL Model
 The ${name.upper()} RAL model is created with the `hw/dv/tools/gen_ral_pkg.py` wrapper script at the start of the simulation automatically and is placed in the build area, along with a corresponding `fusesoc` core file.
 The wrapper script invokes the [regtool.py]({{< relref "util/reggen/README.md" >}}) script from within to generate the RAL model.
 
 It can be created manually by running `make ral` command from the `dv` area.
+% endif
 
 ${'###'} Reference models
 [Describe reference models in use if applicable, example: SHA256/HMAC]

--- a/util/uvmdvgen/env.core.tpl
+++ b/util/uvmdvgen/env.core.tpl
@@ -15,7 +15,9 @@ filesets:
 % for agent in env_agents:
       - lowrisc:dv:${agent}_agent
 % endfor
+% if has_ral:
       - lowrisc:dv:gen_ral_pkg
+% endif
     files:
       - ${name}_env_pkg.sv
       - ${name}_env_cfg.sv: {is_include_file: true}

--- a/util/uvmdvgen/env_cfg.sv.tpl
+++ b/util/uvmdvgen/env_cfg.sv.tpl
@@ -21,12 +21,16 @@ class ${name}_env_cfg extends dv_base_env_cfg #(.RAL_T(${name}_reg_block));
 
   `uvm_object_new
 
+% if has_ral:
   virtual function void initialize_csr_addr_map_size();
     this.csr_addr_map_size = ${name.upper()}_ADDR_MAP_SIZE;
   endfunction : initialize_csr_addr_map_size
+% endif
 
   virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);
+% if has_ral:
     super.initialize(csr_base_addr);
+% endif
 % for agent in env_agents:
     // create ${agent} agent config obj
     m_${agent}_agent_cfg = ${agent}_agent_cfg::type_id::create("m_${agent}_agent_cfg");

--- a/util/uvmdvgen/env_pkg.sv.tpl
+++ b/util/uvmdvgen/env_pkg.sv.tpl
@@ -7,24 +7,28 @@ package ${name}_env_pkg;
   import uvm_pkg::*;
   import top_pkg::*;
   import dv_utils_pkg::*;
-  import csr_utils_pkg::*;
-  import tl_agent_pkg::*;
 % for agent in env_agents:
   import ${agent}_agent_pkg::*;
 % endfor
   import dv_lib_pkg::*;
 % if is_cip:
+  import tl_agent_pkg::*;
   import cip_base_pkg::*;
 % endif
+% if has_ral:
+  import csr_utils_pkg::*;
   import ${name}_ral_pkg::*;
+% endif
 
   // macro includes
   `include "uvm_macros.svh"
   `include "dv_macros.svh"
 
   // parameters
+% if has_ral:
   // TODO update below, or compile error occurs
   parameter uint ${name.upper()}_ADDR_MAP_SIZE = ;
+% endif
 
   // types
 

--- a/util/uvmdvgen/gen_env.py
+++ b/util/uvmdvgen/gen_env.py
@@ -10,8 +10,8 @@ from mako.template import Template
 from pkg_resources import resource_filename
 
 
-def gen_env(name, is_cip, has_interrupts, has_alerts, env_agents, root_dir,
-            add_makefile):
+def gen_env(name, is_cip, has_ral, has_interrupts, has_alerts, env_agents,
+            root_dir, add_makefile):
     # yapf: disable
     # 4-tuple - sub-path, ip name, class name, file ext
     env_srcs = [('dv/env',          name + '_', 'env_cfg',            '.sv'),
@@ -62,6 +62,7 @@ def gen_env(name, is_cip, has_interrupts, has_alerts, env_agents, root_dir,
                 fout.write(
                     tpl.render(name=name,
                                is_cip=is_cip,
+                               has_ral=has_ral,
                                has_interrupts=has_interrupts,
                                has_alerts=has_alerts,
                                env_agents=env_agents))

--- a/util/uvmdvgen/sim_cfg.hjson.tpl
+++ b/util/uvmdvgen/sim_cfg.hjson.tpl
@@ -17,8 +17,10 @@
   // Testplan hjson file.
   testplan: "{proj_root}/hw/ip/${name}/data/${name}_testplan.hjson"
 
+% if has_ral:
   // RAL spec - used to generate the RAL model.
   ral_spec: "{proj_root}/hw/ip/${name}/data/${name}.hjson"
+% endif
 
   // Import additional common sim cfg files.
   // TODO: remove imported cfgs that do not apply.
@@ -26,7 +28,9 @@
   import_cfgs: [// Project wide common sim cfg file
                 "{proj_root}/hw/dv/data/common_sim_cfg.hjson",
                 // Common CIP test lists
+% if has_ral:
                 "{proj_root}/hw/dv/data/tests/csr_tests.hjson",
+% endif
                 "{proj_root}/hw/dv/data/tests/mem_tests.hjson",
 % if has_interrupts:
                 "{proj_root}/hw/dv/data/tests/intr_test.hjson",
@@ -36,8 +40,10 @@
 % else:
   import_cfgs: [// Project wide common sim cfg file
                 "{proj_root}/hw/dv/data/common_sim_cfg.hjson",
+% if has_ral:
                 "{proj_root}/hw/dv/data/tests/csr_tests.hjson",
                 "{proj_root}/hw/dv/data/tests/mem_tests.hjson"]
+% endif
 % endif
 
   // Add additional tops for simulation.

--- a/util/uvmdvgen/test_pkg.sv.tpl
+++ b/util/uvmdvgen/test_pkg.sv.tpl
@@ -17,6 +17,9 @@ package ${name}_test_pkg;
   `include "dv_macros.svh"
 
   // local types
+% if not has_ral:
+  typedef uvm_object ${name}_reg_block;
+% endif
 
   // functions
 


### PR DESCRIPTION
Adds a 'has_ral' flag to the uvmdvgen testbench generation flow to easily allow testbenches for DUTs that do not have a RAL model or CSRs.

Signed-off-by: Udi Jonnalagadda <udij@google.com>