### PR TITLE
[dv regr tool] Coverage collection across branches

### DIFF
--- a/hw/dv/data/common_sim_cfg.hjson
+++ b/hw/dv/data/common_sim_cfg.hjson
@@ -15,12 +15,13 @@
                      "{proj_root}/hw/dv/data/{simulator}/{simulator}.hjson"]
 
   // Default directory structure for the output
-  scratch_path:     "{scratch_root}/{branch}.{dut}.{flow}.{simulator}"
-  tool_dir:         "{scratch_path}/{simulator}"
-  build_dir:        "{scratch_path}/{build_mode}"
-  run_dir_name:     "{index}.{test}"
-  run_dir:          "{scratch_path}/{run_dir_name}/out"
-  sw_build_dir:     "{run_dir}/sw_build"
+  scratch_base_path:  "{scratch_root}/{dut}.{flow}.{simulator}"
+  scratch_path:       "{scratch_base_path}/{branch}"
+  simulator_srcs_dir: "{scratch_path}/{simulator}"
+  build_dir:          "{scratch_path}/{build_mode}"
+  run_dir_name:       "{index}.{test}"
+  run_dir:            "{scratch_path}/{run_dir_name}/out"
+  sw_build_dir:       "{run_dir}/sw_build"
 
   // pass and fail patterns
   pass_patterns:    ["^TEST PASSED (UVM_)?CHECKS$"]
@@ -123,8 +124,8 @@
   ]
 
   // Project defaults for VCS
-  vcs_cov_hier: "-cm_hier {tool_dir}/cover.cfg"
-  vcs_cov_excl_files: ["{tool_dir}/common_cov_excl.el"]
+  vcs_cov_hier: "-cm_hier {simulator_srcs_dir}/cover.cfg"
+  vcs_cov_excl_files: ["{simulator_srcs_dir}/common_cov_excl.el"]
 
   // Results server stuff - indicate what command to use to copy over the results.
   // Workaround for gsutil to fall back to using python2.7.

--- a/hw/dv/data/sim.mk
+++ b/hw/dv/data/sim.mk
@@ -25,8 +25,8 @@ build: compile_result
 pre_compile:
 	@echo "[make]: pre_compile"
 	mkdir -p ${build_dir} && env | sort > ${build_dir}/env_vars
-	mkdir -p ${tool_dir}
-	cp -Ru ${tool_srcs} ${tool_dir}/.
+	mkdir -p ${simulator_srcs_dir}
+	cp -Ru ${simulator_srcs} ${simulator_srcs_dir}/.
 
 gen_sv_flist: pre_compile ral
 	@echo "[make]: gen_sv_flist"

--- a/hw/dv/data/vcs/vcs.hjson
+++ b/hw/dv/data/vcs/vcs.hjson
@@ -5,7 +5,10 @@
   build_cmd:  "{job_prefix} vcs"
   build_ex:   "{build_dir}/simv"
   run_cmd:    "{job_prefix} {build_ex}"
-  tool_srcs:  ["{proj_root}/hw/dv/tools/vcs/*"]
+
+  // Indicate the simulator specific helper sources - these are copied over to the
+  // {simulator_srcs_dir} before running the simulation.
+  simulator_srcs:  ["{proj_root}/hw/dv/tools/vcs/*"]
 
   build_opts: ["-sverilog -full64 -licqueue -kdb -ntb_opts uvm-1.2",
                "-timescale=1ns/1ps",
@@ -28,7 +31,7 @@
                "-LDFLAGS \"-Wl,--no-as-needed\""]
 
   run_opts:   ["-licqueue",
-               "-ucli -do {tool_dir}/vcs_fsdb.tcl",
+               "-ucli -do {simulator_srcs_dir}/vcs_fsdb.tcl",
                "+ntb_random_seed={seed}",
                "+UVM_TESTNAME={uvm_test}",
                "+UVM_TEST_SEQ={uvm_test_seq}"]
@@ -44,7 +47,7 @@
   // Merging coverage.
   // "cov_db_dirs" is a special variable that appends all build directories in use.
   // It is constructed by the tool itself.
-  cov_merge_dir:    "{scratch_path}/cov_merge"
+  cov_merge_dir:    "{scratch_base_path}/cov_merge"
   cov_merge_db_dir: "{cov_merge_dir}/merged.vdb"
   cov_merge_cmd:    "{job_prefix} urg"
   cov_merge_opts:   ["-full64",
@@ -63,7 +66,7 @@
                      "-dbname {cov_merge_db_dir}"]
 
   // Generate coverage reports in text as well as html.
-  cov_report_dir:       "{scratch_path}/cov_report"
+  cov_report_dir:       "{scratch_base_path}/cov_report"
   cov_report_cmd:       "{job_prefix} urg"
   cov_report_opts:      ["-full64",
                         "+urg+lic+wait",
@@ -77,7 +80,7 @@
 
   // Analyzing coverage - this is done by invoking --cov-analyze switch. It opens up the
   // GUI for visual analysis.
-  cov_analyze_dir:  "{scratch_path}/cov_analyze"
+  cov_analyze_dir:  "{scratch_base_path}/cov_analyze"
   cov_analyze_cmd:  "{job_prefix} verdi"
   cov_analyze_opts: ["-cov",
                      "-covdir {cov_merge_db_dir}",
@@ -138,7 +141,7 @@
     {
       name: vcs_xprop
       is_sim_mode: 1
-      build_opts: ["-xprop={tool_dir}/xprop.cfg"]
+      build_opts: ["-xprop={simulator_srcs_dir}/xprop.cfg"]
     }
     {
       name: vcs_profile

--- a/hw/dv/data/xcelium/xcelium.hjson
+++ b/hw/dv/data/xcelium/xcelium.hjson
@@ -4,7 +4,10 @@
 {
   build_cmd:  "{job_prefix} xrun"
   run_cmd:    "{job_prefix} xrun"
-  tool_srcs:  ["{proj_root}/hw/dv/tools/xcelium/*"]
+
+  // Indicate the simulator specific helper sources - these are copied over to the
+  // {simulator_srcs_dir} before running the simulation.
+  simulator_srcs:  ["{proj_root}/hw/dv/tools/xcelium/*"]
 
   build_opts: [" -elaborate -64bit -access +r -sv",
                "-messages -errormax 50",
@@ -13,7 +16,7 @@
                "-uvmhome {UVM_HOME}",
                "-xmlibdirname {build_dir}/xcelium.d"]
 
-  run_opts:   ["-input {tool_dir}/xcelium_{dump}.tcl",
+  run_opts:   ["-input {simulator_srcs_dir}/xcelium_{dump}.tcl",
                "-64bit -xmlibdirname {build_dir}/xcelium.d -R",
                "+SVSEED={seed}",
                "+UVM_TESTNAME={uvm_test}",
@@ -31,20 +34,20 @@
   // Merging coverage.
   // "cov_db_dirs" is a special variable that appends all build directories in use.
   // It is constructed by the tool itself.
-  cov_merge_dir:    "{scratch_path}/cov_merge"
+  cov_merge_dir:    "{scratch_base_path}/cov_merge"
   cov_merge_db_dir: ""
   cov_merge_cmd:    ""
   cov_merge_opts:   []
 
   // Generate covreage reports in text as well as html.
-  cov_report_dir:       "{scratch_path}/cov_report"
+  cov_report_dir:       "{scratch_base_path}/cov_report"
   cov_report_cmd:       ""
   cov_report_opts:      []
   cov_report_dashboard: ""
 
   // Analyzing coverage - this is done by invoking --cov-analyze switch. It opens up the
   // GUI for visual analysis.
-  cov_analyze_dir:  "{scratch_path}/cov_analyze"
+  cov_analyze_dir:  "{scratch_base_path}/cov_analyze"
   cov_analyze_cmd:  ""
   cov_analyze_opts: []
 
@@ -70,7 +73,8 @@
     {
       name: xcelium_xprop
       is_sim_mode: 1
-      build_opts: ["-xprop F"] # -xverbose  << add to see which modules does not have xprop enabled
+      # -xverbose  << add to see which modules does not have xprop enabled
+      build_opts: ["-xprop F"]
     }
   ]
 }

--- a/hw/ip/uart/dv/uart_sim_cfg.hjson
+++ b/hw/ip/uart/dv/uart_sim_cfg.hjson
@@ -41,11 +41,12 @@
 
   // Add UART specific exclusion files.
 
-  // Add excl files to tool_srcs so that it gets copied over to the scratch area.
-  tool_srcs: ["{proj_root}/hw/ip/uart/dv/cov/uart_cov_excl.el"]
-  // Refer to the excl file with vcs_cov_excl_files var with the rel path from tool_dir
+  // Add excl files to simulator_srcs so that it gets copied over to the scratch area.
+  simulator_srcs: ["{proj_root}/hw/ip/uart/dv/cov/uart_cov_excl.el"]
+
+  // Refer to the excl file with vcs_cov_excl_files var with the rel path from simulator_srcs_dir
   // so the VCS can find it.
-  vcs_cov_excl_files: ["{tool_dir}/uart_cov_excl.el"]
+  vcs_cov_excl_files: ["{simulator_srcs_dir}/uart_cov_excl.el"]
 
   // List of test specifications.
   tests: [

--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -411,8 +411,8 @@ class CompileSim(Deploy):
 
         self.mandatory_cmd_attrs = {
             # tool srcs
-            "tool_srcs": False,
-            "tool_dir": False,
+            "simulator_srcs": False,
+            "simulator_srcs_dir": False,
 
             # RAL gen
             "skip_ral": False,


### PR DESCRIPTION
The existing approach created {branch}.{dut}.sim.{simulator} as the
directory in the scratch area where the entire regression was run,
including coverage. The {branch} indicates the github branch so that the
simulations across branches were isolated. A side effect of this was it
prevented coverage from being merged from sim runs across two different
github branches when the `--cov-merge-previous` switch is passed. This
PR removes that limitation by reorging the directory structure as
follows: simulation results go to {dut}.sim.{simulator}/{branch}.
Coverage db is merged at {dut}.sim.{simulator}/cov_merge. This effect of
this is past coverge databases in the cov_merge directory could be from
sims run in other branches so we get the benefit of being able to merge
them all together.

Another minor change is {tool_dir, tool_srcs} in the hjson files renamed
to {simulator_srcs, simulator_srcs_dir}. The later is clearer, whereas
tool can mean anything.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>