### PR TITLE
[doc, style] Make C coding style public API example more clear

### DIFF
--- a/doc/rm/c_cpp_coding_style.md
+++ b/doc/rm/c_cpp_coding_style.md
@@ -120,8 +120,8 @@ Example:
 /**
  * Do something amazing
  *
- * Create a rainbow and place a unicorn at the bottom of it. @p arg1 pots of
- * gold will be positioned on the east end of the rainbow.
+ * Create a rainbow and place a unicorn at the bottom of it. @p pots_of_gold
+ * pots of gold will be positioned on the east end of the rainbow.
  *
  * @param pots_of_gold Number of gold pots to place next to the rainbow
  * @param unicorns Number of unicorns to position on the rainbow


### PR DESCRIPTION
The example should be sufficient to be able to adapt without the need of visiting doxygen documentation.

"@p arg1" is misleading, whilst "@p pots_of_gold" matches the doxygen style exactly.

Current example is misleading for people that haven't used doxygen style function descriptions, or at least haven't done for a while.