### PR TITLE
[sw, dif_uart] Change argument referencing in function descriptions

### DIFF
--- a/sw/device/lib/dif/dif_uart.h
+++ b/sw/device/lib/dif/dif_uart.h
@@ -86,9 +86,9 @@ typedef struct dif_uart {
 /**
  * Initialise an instance of UART
  *
- * Initialise UART instance using the configuration data in @p arg2.
+ * Initialise UART instance using the configuration data in @p config.
  * Information that must be retained, and is required to program UART must be
- * stored in @p arg3.
+ * stored in @p uart.
  * @param base_addr Base address of an instance of UART IP block
  * @param config UART configuration data
  * @param uart UART state data
@@ -100,7 +100,7 @@ bool dif_uart_init(mmio_region_t base_addr, const dif_uart_config_t *config,
 /**
  * Configure an instance of UART
  *
- * Configure UART using the configuration data in @p arg2. This operation
+ * Configure UART using the configuration data in @p config. This operation
  * performs fundamental configuration.
  *
  * @param uart UART state data
@@ -141,9 +141,10 @@ bool dif_uart_watermark_tx_set(const dif_uart_t *uart,
  * UART send bytes
  *
  * Non-blocking UART send bytes routine. Can be used from inside an UART ISR.
- * This function attempts to write @p arg3 number of bytes to the UART TX FIFO
- * from @p arg3, and passes @p arg4 back to the caller. @p arg4 is optional,
- * NULL should be passed in if the value is not needed.
+ * This function attempts to write @p bytes_requested number of bytes to the
+ * UART TX FIFO from @p bytes_requested, and passes @p bytes_written back to
+ * the caller. @p bytes_written is optional, NULL should be passed in if the
+ * value is not needed.
  *
  * @param uart UART state data
  * @param data Data to be written
@@ -158,9 +159,10 @@ bool dif_uart_bytes_send(const dif_uart_t *uart, const uint8_t *data,
  * UART receive bytes
  *
  * Non-blocking UART receive bytes routine. Can be used from inside an UART ISR.
- * This function attempts to read @p arg2 number of bytes from the UART RX FIFO
- * into @p arg3, and passes @p arg4 back to the caller. @p arg4 is optional,
- * NULL should be passed in if the value is not needed.
+ * This function attempts to read @p bytes_requested number of bytes from the
+ * UART RX FIFO into @p data, and passes @p bytes_read back to the caller.
+ * @p bytes_read is optional, NULL should be passed in if the value is not
+ * needed.
  *
  * @param uart UART state data
  * @param bytes_requested Number of bytes requested to be read by the caller
@@ -174,7 +176,7 @@ bool dif_uart_bytes_receive(const dif_uart_t *uart, size_t bytes_requested,
 /**
  * Transmit a single UART byte (polled)
  *
- * Transmit a single UART byte @p arg2. This operation is polled, and will busy
+ * Transmit a single UART byte @p byte. This operation is polled, and will busy
  * wait until a byte has been sent. Must not be used inside an ISR.
  *
  * @param uart UART state data
@@ -186,7 +188,7 @@ bool dif_uart_byte_send_polled(const dif_uart_t *uart, uint8_t byte);
 /**
  * Receive a single UART byte (polled)
  *
- * Receive a single UART byte and store it in @p arg2. This operation is polled,
+ * Receive a single UART byte and store it in @p byte. This operation is polled,
  * and will busy wait until a byte has been read. Must not be used inside an
  * ISR.
  *
@@ -199,9 +201,9 @@ bool dif_uart_byte_receive_polled(const dif_uart_t *uart, uint8_t *byte);
 /**
  * UART get requested IRQ state
  *
- * Get the state of the requested IRQ in @p arg2.
+ * Get the state of the requested IRQ in @p irq_type.
  *
- * @para uart UART state data
+ * @param uart UART state data
  * @param irq_type IRQ to get the state of
  * @param state IRQ state passed back to the caller
  * @return true if the function was successful, false otherwise
@@ -212,7 +214,7 @@ bool dif_uart_irq_state_get(const dif_uart_t *uart,
 /**
  * UART clear requested IRQ state
  *
- * Clear the state of the requested IRQ in @p arg2. Primary use of this
+ * Clear the state of the requested IRQ in @p irq_type. Primary use of this
  * function is to de-assert the interrupt after it has been serviced.
  *
  * @param uart UART state data
@@ -226,7 +228,7 @@ bool dif_uart_irq_state_clear(const dif_uart_t *uart,
  * UART disable interrupts
  *
  * Disable generation of all UART interrupts, and pass previous interrupt state
- * in @p arg3 back to the caller. Parameter @p arg2 is ignored if NULL.
+ * in @p state back to the caller. Parameter @p state is ignored if NULL.
  *
  * @param uart UART state data
  * @param state IRQ state passed back to the caller
@@ -249,7 +251,7 @@ bool dif_uart_irqs_restore(const dif_uart_t *uart, uint32_t state);
 /**
  * UART interrupt control
  *
- * Enable/disable an UART interrupt specified in @p arg3.
+ * Enable/disable an UART interrupt specified in @p enable.
  *
  * @param uart UART state data
  * @param irq_type UART interrupt type
@@ -262,7 +264,7 @@ bool dif_uart_irq_enable(const dif_uart_t *uart, dif_uart_interrupt_t irq_type,
 /**
  * UART interrupt force
  *
- * Force interrupt specified in @p arg2.
+ * Force interrupt specified in @p irq_type.
  *
  * @param uart UART state data
  * @param irq_type UART interrupt type to be forced


### PR DESCRIPTION
This change is a follow-up on #1535