### PR TITLE
[prim_generic, prim_xilinx] Use STRINGIFY macro

### DIFF
--- a/hw/ip/prim_generic/rtl/prim_generic_ram_1p.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_ram_1p.sv
@@ -4,6 +4,8 @@
 //
 // Synchronous single-port SRAM model
 
+`include "prim_assert.sv"
+
 module prim_generic_ram_1p #(
   parameter  int Width           = 32, // bit
   parameter  int Depth           = 128,
@@ -85,7 +87,7 @@ module prim_generic_ram_1p #(
   `endif
 
   `ifdef SRAM_INIT_FILE
-    localparam MEM_FILE = `"`SRAM_INIT_FILE`";
+    localparam MEM_FILE = `PRIM_STRINGIFY(`SRAM_INIT_FILE);
     initial begin
       $display("Initializing SRAM from %s", MEM_FILE);
       $readmemh(MEM_FILE, mem);

--- a/hw/ip/prim_generic/rtl/prim_generic_rom.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_rom.sv
@@ -65,7 +65,7 @@ module prim_generic_rom #(
   `endif
 
   `ifdef ROM_INIT_FILE
-    localparam MEM_FILE = `"`ROM_INIT_FILE`";
+    localparam MEM_FILE = `PRIM_STRINGIFY(`ROM_INIT_FILE);
     initial begin
       $display("Initializing ROM from %s", MEM_FILE);
       $readmemh(MEM_FILE, mem);

--- a/hw/ip/prim_xilinx/rtl/prim_xilinx_rom.sv
+++ b/hw/ip/prim_xilinx/rtl/prim_xilinx_rom.sv
@@ -38,7 +38,7 @@ module prim_xilinx_rom #(
    // instead. This severely degrades the synthesis quality for no good reason.
    logic [Width-1:0] mem [Depth];
 
-   localparam MEM_FILE = `"`ROM_INIT_FILE`";
+   localparam MEM_FILE = `PRIM_STRINGIFY(`ROM_INIT_FILE);
    initial
    begin
       $display("Initializing ROM from %s", MEM_FILE);


### PR DESCRIPTION
In my understanding, ``` `" ``` can be used in macro_text only according to IEEE Std 1800-2017.
So I think the usage of `STRINGIFY` macro is better.

Signed-off-by: Naoya Hatta <dalance@gmail.com>