### PR TITLE
[tlul] Fix $fatal call with invalid syntax

### DIFF
--- a/hw/ip/tlul/rtl/sram2tlul.sv
+++ b/hw/ip/tlul/rtl/sram2tlul.sv
@@ -32,9 +32,7 @@ module sram2tlul #(
 
   import tlul_pkg::*;
 
-  `ifndef SYNTHESIS
-  if (SramDw != top_pkg::TL_DW) $fatal("SRAM_DW should be same as TL-UL DW");
-  `endif
+  `ASSERT_INIT(wrongSramDw, SramDw == top_pkg::TL_DW)
 
   localparam int unsigned SRAM_DWB = $clog2(SramDw/8);
 


### PR DESCRIPTION
I think `$fatal` call without any block is invalid syntax.

Signed-off-by: Naoya Hatta <dalance@gmail.com>