### PR TITLE
Fix for incompatible array types on function call

### DIFF
--- a/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
@@ -148,7 +148,7 @@ class hmac_base_vseq extends cip_base_vseq #(.CFG_T               (hmac_env_cfg)
   endtask
 
     // read digest value and output read value
-  virtual task csr_rd_digest(output bit [TL_DW-1:0] digest[8]);
+  virtual task csr_rd_digest(output logic [TL_DW-1:0] digest[8]);
     csr_rd(.ptr(ral.digest0), .value(digest[0]));
     csr_rd(.ptr(ral.digest1), .value(digest[1]));
     csr_rd(.ptr(ral.digest2), .value(digest[2]));

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
@@ -143,12 +143,12 @@ class hmac_base_vseq extends cip_base_vseq #(.CFG_T               (hmac_env_cfg)
 
   // read digest value
   virtual task rd_digest();
-    logic [TL_DW-1:0] digest[8];
+    bit [TL_DW-1:0] digest[8];
     csr_rd_digest(digest);
   endtask
 
     // read digest value and output read value
-  virtual task csr_rd_digest(output logic [TL_DW-1:0] digest[8]);
+  virtual task csr_rd_digest(output bit [TL_DW-1:0] digest[8]);
     csr_rd(.ptr(ral.digest0), .value(digest[0]));
     csr_rd(.ptr(ral.digest1), .value(digest[1]));
     csr_rd(.ptr(ral.digest2), .value(digest[2]));
@@ -317,7 +317,7 @@ class hmac_base_vseq extends cip_base_vseq #(.CFG_T               (hmac_env_cfg)
   endtask
 
   virtual task compare_digest(bit [TL_DW-1:0] exp_digest[8]);
-    logic [TL_DW-1:0] act_digest[8];
+    bit [TL_DW-1:0] act_digest[8];
     csr_rd_digest(act_digest);
     if (cfg.clk_rst_vif.rst_n) begin
       foreach (act_digest[i]) begin

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_txrx_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_txrx_vseq.sv
@@ -149,7 +149,7 @@ class spi_device_txrx_vseq extends spi_device_base_vseq;
     uint sram_avail_bytes;
     uint tx_write_bytes;
     while (remaining_bytes > 0) begin
-      bit [31:0] device_words_q[$];
+      logic [31:0] device_words_q[$];
       `DV_CHECK_MEMBER_RANDOMIZE_FATAL(tx_delay)
       cfg.clk_rst_vif.wait_clks(tx_delay);
 


### PR DESCRIPTION
It is illegal to pass array of bit vector to function with formal argument array of logic vector (and vice versa).
Such array types are incompatible.

This pull request fixes such issue in 2 places.