### PR TITLE
[sw, dif_uart] Add null checks to send and receive routines

### DIFF
--- a/sw/device/lib/dif/dif_uart.c
+++ b/sw/device/lib/dif/dif_uart.c
@@ -238,7 +238,7 @@ bool dif_uart_watermark_tx_set(const dif_uart_t *uart,
 
 bool dif_uart_bytes_send(const dif_uart_t *uart, const uint8_t *data,
                          size_t bytes_requested, size_t *bytes_written) {
-  if (uart == NULL) {
+  if (uart == NULL || data == NULL) {
     return false;
   }
 
@@ -253,7 +253,7 @@ bool dif_uart_bytes_send(const dif_uart_t *uart, const uint8_t *data,
 
 bool dif_uart_bytes_receive(const dif_uart_t *uart, size_t bytes_requested,
                             uint8_t *data, size_t *bytes_read) {
-  if (uart == NULL) {
+  if (uart == NULL || data == NULL) {
     return false;
   }
 


### PR DESCRIPTION
These parameters must be valid, and hence must be checked.