### PR TITLE
[sw, dif_uart] Fix dif_uart_byte_send_polled() routine

### DIFF
--- a/sw/device/lib/dif/dif_uart.c
+++ b/sw/device/lib/dif/dif_uart.c
@@ -17,9 +17,9 @@ static bool uart_tx_full(const dif_uart_t *uart) {
                                UART_STATUS_TXFULL);
 }
 
-static bool uart_tx_empty(const dif_uart_t *uart) {
+static bool uart_tx_idle(const dif_uart_t *uart) {
   return mmio_region_get_bit32(uart->base_addr, UART_STATUS_REG_OFFSET,
-                               UART_STATUS_TXEMPTY);
+                               UART_STATUS_TXIDLE);
 }
 
 static bool uart_rx_empty(const dif_uart_t *uart) {
@@ -280,9 +280,9 @@ bool dif_uart_byte_send_polled(const dif_uart_t *uart, uint8_t byte) {
 
   (void)uart_bytes_send(uart, &byte, 1);
 
-  // Busy wait for the TX FIFO to be drained (the byte has been processed by
-  // the UART hardware).
-  while (!uart_tx_empty(uart)) {
+  // Busy wait for the TX FIFO to be drained and for HW to finish processing
+  // the last byte.
+  while (!uart_tx_idle(uart)) {
   }
 
   return true;


### PR DESCRIPTION
UART_STATUS_TXEMPTY means that the HW took the last data element of
the FIFO for processing. UART_STATUS_TXIDLE is set when there is no
activity on the UART lines. Combination of these two flags can be used
to determine whether the HW has completely processed the last element.

NOTE: polling operation guarantees that the requested byte is
      processed completely on return from the function. This means
      that we must check whether the FIFO is drained to insure that
      this is the case.

Fixes issue in PR #1510