### PR TITLE
[aes/rtl] Fix controller behavior when stalling the cipher core

### DIFF
--- a/hw/ip/aes/rtl/aes_control.sv
+++ b/hw/ip/aes/rtl/aes_control.sv
@@ -200,10 +200,10 @@ module aes_control (
           end
         end else begin
           // We are ready once the output data registers can be written.
-          stall_o            = !finish;
+          stall_o            = !finish & cipher_out_valid_i;
           stall_we_o         = 1'b1;
           cipher_out_ready_o = finish;
-          if (cipher_out_valid_i) begin
+          if (finish & cipher_out_valid_i) begin
             data_out_we_o    = 1'b1;
             aes_ctrl_ns      = IDLE;
           end


### PR DESCRIPTION
This PR corrects two issues in the behavior of the main controller when the stalling the cipher core (because the DATA_OUT registers cannot yet be overwritten).

1) The controller must not overwrite the DATA_OUT registers and not proceed to the next state until the DATA_OUT registers have been read by software. Without this commit, the controller keeps the cipher core stalled (and waiting forever) but still proceeds.

2) The stall bit in the STATUS register must only be asserted if the cipher core has valid output and is indeed being stalled. Without this commit, the stall bit is asserted also when the cipher core is still busy and does not yet have valid output.

This resolves lowRISC/OpenTitan#1560 reported by @labbott.