### PR TITLE
[sw,dif_plic] Rename k*Count Enum Variants

### DIFF
--- a/sw/device/lib/dif/dif_plic.c
+++ b/sw/device/lib/dif/dif_plic.c
@@ -79,55 +79,53 @@ typedef struct plic_peripheral_range {
 
 // An array of target specific set of register offsets. Every supported PLIC
 // target must have an entry in this array.
-static const plic_target_reg_offset_t
-    plic_target_reg_offsets[kDifPlicTargetCount] = {
-            [kDifPlicTargetIbex0] =
-                {
-                    .ie = RV_PLIC_IE00,
-                    .cc = RV_PLIC_CC0,
-                    .threshold = RV_PLIC_THRESHOLD0,
-                },
+static const plic_target_reg_offset_t plic_target_reg_offsets[] = {
+        [kDifPlicTargetIbex0] =
+            {
+                .ie = RV_PLIC_IE00,
+                .cc = RV_PLIC_CC0,
+                .threshold = RV_PLIC_THRESHOLD0,
+            },
 };
 
 // An array of IRQ source ID ranges per peripheral. Every peripheral supported
 // by the PLIC, must have an entry in this array.
-static const plic_peripheral_range_t
-    plic_peripheral_ranges[kDifPlicPeripheralCount] = {
-            [kDifPlicPeripheralGpio] =
-                {
-                    .first_irq_id = kDifPlicIrqIdGpio0,
-                    .last_irq_id = kDifPlicIrqIdGpio31,
-                },
-            [kDifPlicPeripheralUart] =
-                {
-                    .first_irq_id = kDifPlicIrqIdUartTxWatermark,
-                    .last_irq_id = kDifPlicIrqIdUartRxParityErr,
-                },
-            [kDifPlicPeripheralSpiDevice] =
-                {
-                    .first_irq_id = kDifPlicIrqIdSpiDeviceRxF,
-                    .last_irq_id = kDifPlicIrqIdSpiDeviceTxUnderflow,
-                },
-            [kDifPlicPeripheralFlashCtrl] =
-                {
-                    .first_irq_id = kDifPlicIrqIdFlashCtrlProgEmpty,
-                    .last_irq_id = kDifPlicIrqIdFlashCtrlOpError,
-                },
-            [kDifPlicPeripheralHmac] =
-                {
-                    .first_irq_id = kDifPlicIrqIdHmacDone,
-                    .last_irq_id = kDifPlicIrqIdHmacErr,
-                },
-            [kDifPlicPeripheralAlertHandler] =
-                {
-                    .first_irq_id = kDifPlicIrqIdAlertHandlerClassA,
-                    .last_irq_id = kDifPlicIrqIdAlertHandlerClassD,
-                },
-            [kDifPlicPeripheralNmiGen] =
-                {
-                    .first_irq_id = kDifPlicIrqIdNmiGenEsc0,
-                    .last_irq_id = kDifPlicIrqIdNmiGenEsc3,
-                },
+static const plic_peripheral_range_t plic_peripheral_ranges[] = {
+        [kDifPlicPeripheralGpio] =
+            {
+                .first_irq_id = kDifPlicIrqIdGpio0,
+                .last_irq_id = kDifPlicIrqIdGpio31,
+            },
+        [kDifPlicPeripheralUart] =
+            {
+                .first_irq_id = kDifPlicIrqIdUartTxWatermark,
+                .last_irq_id = kDifPlicIrqIdUartRxParityErr,
+            },
+        [kDifPlicPeripheralSpiDevice] =
+            {
+                .first_irq_id = kDifPlicIrqIdSpiDeviceRxF,
+                .last_irq_id = kDifPlicIrqIdSpiDeviceTxUnderflow,
+            },
+        [kDifPlicPeripheralFlashCtrl] =
+            {
+                .first_irq_id = kDifPlicIrqIdFlashCtrlProgEmpty,
+                .last_irq_id = kDifPlicIrqIdFlashCtrlOpError,
+            },
+        [kDifPlicPeripheralHmac] =
+            {
+                .first_irq_id = kDifPlicIrqIdHmacDone,
+                .last_irq_id = kDifPlicIrqIdHmacErr,
+            },
+        [kDifPlicPeripheralAlertHandler] =
+            {
+                .first_irq_id = kDifPlicIrqIdAlertHandlerClassA,
+                .last_irq_id = kDifPlicIrqIdAlertHandlerClassD,
+            },
+        [kDifPlicPeripheralNmiGen] =
+            {
+                .first_irq_id = kDifPlicIrqIdNmiGenEsc0,
+                .last_irq_id = kDifPlicIrqIdNmiGenEsc3,
+            },
 };
 
 /**
@@ -308,7 +306,7 @@ bool dif_plic_irq_claim(const dif_plic_t *plic, dif_plic_target_t target,
   // Validate an IRQ source, and determine which peripheral it belongs to.
   dif_plic_irq_id_t irq_src = (dif_plic_irq_id_t)irq_id;
   for (dif_plic_peripheral_t peripheral = kDifPlicPeripheralGpio;
-       peripheral < kDifPlicPeripheralCount; ++peripheral) {
+       peripheral <= kDifPlicPeripheralLast; ++peripheral) {
     if (irq_src < plic_peripheral_ranges[peripheral].first_irq_id ||
         irq_src > plic_peripheral_ranges[peripheral].last_irq_id) {
       continue;

--- a/sw/device/lib/dif/dif_plic.h
+++ b/sw/device/lib/dif/dif_plic.h
@@ -98,7 +98,8 @@ typedef enum dif_plic_peripheral {
   kDifPlicPeripheralHmac,         /**< HMAC */
   kDifPlicPeripheralAlertHandler, /**< Alert handler */
   kDifPlicPeripheralNmiGen,       /**< NMI generator */
-  kDifPlicPeripheralCount,        /**< Number of PLIC peripherals */
+  kDifPlicPeripheralLast =
+      kDifPlicPeripheralNmiGen, /**< \internal Final PLIC peripheral */
 } dif_plic_peripheral_t;
 
 /**
@@ -108,8 +109,8 @@ typedef enum dif_plic_peripheral {
  * access dependent on the target.
  */
 typedef enum dif_plic_target {
-  kDifPlicTargetIbex0 = 0, /* Ibex CPU */
-  kDifPlicTargetCount,
+  kDifPlicTargetIbex0 = 0,                  /**< Ibex CPU */
+  kDifPlicTargetLast = kDifPlicTargetIbex0, /**< \internal Final PLIC target */
 } dif_plic_target_t;
 
 /**


### PR DESCRIPTION
kFooCount enum variants (which come last) are useful for being able to
iterate over the domain of an enum type. However, they add an additional
variant which needs to be checked against during DIF preconditions (as
usually this `Count` does not mean anything semantically).

This replaces kFooCount enum variants with kFooLast enum variants.
kFooLast should have the same value as the last valid variant, so do
not need to be checked against in preconditions, and they can still be
used for iteration (but are off-by-one when counting).

---

This is an alternate approach to #1558, which ends up keeping the
preconditions cleaner.