### PR TITLE
[util, reggen] gen_cheader do not omit register field name

### DIFF
--- a/sw/device/lib/dif/dif_uart.c
+++ b/sw/device/lib/dif/dif_uart.c
@@ -30,11 +30,11 @@ static bool uart_rx_empty(const dif_uart_t *uart) {
 static uint8_t uart_rx_fifo_read(const dif_uart_t *uart) {
   uint32_t reg = mmio_region_read32(uart->base_addr, UART_RDATA_REG_OFFSET);
 
-  return reg & UART_RDATA_MASK;
+  return reg & UART_RDATA_RDATA_MASK;
 }
 
 static void uart_tx_fifo_write(const dif_uart_t *uart, uint8_t byte) {
-  uint32_t reg = (byte & UART_WDATA_MASK) << UART_WDATA_OFFSET;
+  uint32_t reg = (byte & UART_WDATA_WDATA_MASK) << UART_WDATA_WDATA_OFFSET;
   mmio_region_write32(uart->base_addr, UART_WDATA_REG_OFFSET, reg);
 }
 

--- a/util/reggen/gen_cheader.py
+++ b/util/reggen/gen_cheader.py
@@ -102,10 +102,7 @@ def gen_cdefine_register(outstr, reg, comp, width, rnames, existing_defines):
     for field in reg['fields']:
         fieldlsb = field['bitinfo'][2]
         fname = field['name']
-        if fname == rname:
-            dname = defname
-        else:
-            dname = defname + '_' + as_define(fname)
+        dname = defname + '_' + as_define(fname)
 
         if field['bitinfo'][1] == 1:
             # single bit


### PR DESCRIPTION
Currently, when the register name matches the register field, the produced define does not add the field name. This is more readable, however in some cases like for RV_PLIC can result in duplicated values, and build failure.

This change removes this feature, and makes the register definitions always follow <REG_NAME>_<REG_FIELD_NAME>_<...>.

Example:
OLD:
rv_plic_regs.h
define RV_PLIC_LE0 0

uart_regs.h
define UART_WDATA_MASK 0xff

NEW:
rv_plic_regs.h
define RV_PLIC_LE0_LE0 0

uart_regs.h
define UART_WDATA_WDATA_MASK 0xff

ALTERNATIVES:
1) As the clash only occurs between legacy (compatibility) defines and register fields:
`define RV_PLIC_LE0(id) (RV_PLIC##id##_BASE_ADDR + 0xc)` compatibility define
`#define RV_PLIC_LE0 0` clashing register field define
@lenary proposed to conditionally generate and use register definitions for DIFs and pre-DIF code. This however is more work, and affects build.meson of every consumer.

2) Remove the compatibility feature entirely, something like in #1090 . This then will result in fixing up all non-DIF consumers of the `_regs.h`.