### PR TITLE
[aes] Disable padding in crypto (OpenSSL/BoringSSL) interface

### DIFF
--- a/hw/ip/aes/model/aes_example.c
+++ b/hw/ip/aes/model/aes_example.c
@@ -97,8 +97,8 @@ int main(int argc, char *argv[]) {
   // libcrypto-related variables and buffers
   unsigned char *iv = (unsigned char *)"0000000000000000";
   int cipher_text_len;
-  unsigned char cipher_text[32];  // libcrypto expects at least 32B buffers
-  unsigned char decrypted_text[32];
+  unsigned char cipher_text[16];
+  unsigned char decrypted_text[16];
 
   printf("Encryption key:\t\t");
   aes_print_block((const unsigned char *)key, 16);

--- a/hw/ip/aes/model/crypto.c
+++ b/hw/ip/aes/model/crypto.c
@@ -32,6 +32,10 @@ int crypto_encrypt(unsigned char *output, const unsigned char *iv,
     return -1;
   }
 
+  // Disable padding - It is safe to do so here because we only ever encrypt
+  // multiples of 16 bytes (the block size).
+  EVP_CIPHER_CTX_set_padding(ctx, 0);
+
   // Provide encryption input, get first output bytes
   ret = EVP_EncryptUpdate(ctx, output, &output_len, input, input_len);
   if (ret != 1) {
@@ -79,6 +83,10 @@ int crypto_decrypt(unsigned char *output, const unsigned char *iv,
     printf("ERROR: Initialization of decryption context failed\n");
     return -1;
   }
+
+  // Disable padding - It is safe to do so here because we only ever decrypt
+  // multiples of 16 bytes (the block size).
+  EVP_CIPHER_CTX_set_padding(ctx, 0);
 
   // Provide decryption input, get first output bytes
   ret = EVP_DecryptUpdate(ctx, output, &output_len, input, input_len);

--- a/hw/ip/aes/model/crypto.h
+++ b/hw/ip/aes/model/crypto.h
@@ -8,10 +8,11 @@
 /**
  * Encrypt using BoringSSL/OpenSSL
  *
- * @param  output    Output cipher text, buffer must be at least 32 bytes
+ * @param  output    Output cipher text, must be a multiple of 16 bytes
  * @param  iv        16-byte initialization vector
- * @param  input     Input plain text to encode
- * @param  input_len Length of the input plain text in bytes
+ * @param  input     Input plain text to encode, must be a multiple of 16 bytes
+ * @param  input_len Length of the input plain text in bytes, must be a multiple
+ *                   of 16
  * @param  key       Encryption key
  * @param  key_len   Encryption key length in bytes (16, 24, 32)
  * @return Length of the output cipher text in bytes, -1 in case of error
@@ -23,10 +24,11 @@ int crypto_encrypt(unsigned char *output, const unsigned char *iv,
 /**
  * Decrypt using BoringSSL/OpenSSL
  *
- * @param  output    Output plain text, buffer must be at least 32 bytes
+ * @param  output    Output plain text, must be a multiple of 16 bytes
  * @param  iv        16-byte initialization vector
- * @param  input     Input cipher text to decode
- * @param  input_len Length of the input cipher text in bytes
+ * @param  input     Input cipher text to decode, must be a multiple of 16 bytes
+ * @param  input_len Length of the input cipher text in bytes, must be a
+ *                   multiple of 16
  * @param  key       Encryption key, decryption key is derived internally
  * @param  key_len   Encryption key length in bytes (16, 24, 32)
  * @return Length of the output plain text in bytes, -1 in case of error


### PR DESCRIPTION
By default, padding is enabled in the used EVP functions of OpenSSL/BoringSSL. Both the sizes of the NIST test data sets we are using so far and the sizes of our tests are multiples of the block size. No padding is actually required. However, to make the paddings checks in the EVP decryption functions succeed, workarounds are required.

This PR disables the padding and padding checks in the EVP functions and removes the corresponding workarounds for the padding checks.

I tested the changes, AES DV is still passing.