### PR TITLE
[doc] Track DIF Development on HW Dashboard

### DIFF
--- a/site/docs/layouts/shortcodes/dashboard.html
+++ b/site/docs/layouts/shortcodes/dashboard.html
@@ -6,6 +6,7 @@
 			<th>Life Stage</th>
 			<th>Design Stage</th>
 			<th>Verification Stage</th>
+			<th>DIF Stage</th>
 			<th>Commit ID</th>
 			<th>Notes</th>
 		</tr>

--- a/util/dashboard/dashboard_validate.py
+++ b/util/dashboard/dashboard_validate.py
@@ -35,6 +35,7 @@ field_required = {
 field_optional = {
     'design_stage': ['s', "design stage of module"],
     'verification_stage': ['s', "verification stage of module"],
+    'dif_stage': ['s', "DIF stage of module"],
     'notes': ['s', "random notes"],
 }
 
@@ -45,6 +46,7 @@ entry_required = {
 entry_optional = {
     'design_stage': ['s', "design stage of module"],
     'verification_stage': ['s', "verification stage of module"],
+    'dif_stage': ['s', "DIF stage of module"],
     'commit_id': ['s', "Staged commit ID"],
     'notes': ['s', "notes"],
 }

--- a/util/dashboard/gen_dashboard_entry.py
+++ b/util/dashboard/gen_dashboard_entry.py
@@ -20,17 +20,25 @@ def genout(outfile, msg):
 
 
 STAGE_STRINGS = {
+    # Life Stage
     'L0': 'Specification',
     'L1': 'Development',
     'L2': 'Signed Off',
+    # Design Stage
     'D0': 'Initial Work',
     'D1': 'Functional',
     'D2': 'Feature Complete',
     'D3': 'Design Complete',
+    # Verification Stage
     'V0': 'Initial Work',
     'V1': 'Under Test',
     'V2': 'Testing Complete',
-    'V3': 'Verification Complete'
+    'V3': 'Verification Complete',
+    # DIF stage (S for Software)
+    'S0': 'Initial Work',
+    'S1': 'Functional',
+    'S2': 'Complete',
+    'S3': 'Frozen'
 }
 
 
@@ -83,12 +91,23 @@ def print_version1_format(obj, outfile):
     else:
         genout(outfile,
                     "        <td>&nbsp;</td>\n")
+
     if life_stage != 'L0' and 'verification_stage' in obj:
         verification_stage_mapping = convert_stage(obj['verification_stage'])
         genout(outfile,
                     "        <td class=\"hw-stage\"><span class='hw-stage' title='" +
                     html.escape(verification_stage_mapping) + "'>" +
                     html.escape(obj['verification_stage']) + "</span></td>\n")
+    else:
+        genout(outfile,
+                    "        <td>&nbsp;</td>\n")
+
+    if life_stage != 'L0' and 'dif_stage' in obj:
+        dif_stage_mapping = convert_stage(obj['dif_stage'])
+        genout(outfile,
+                    "        <td class=\"hw-stage\"><span class='hw-stage' title='" +
+                    html.escape(dif_stage_mapping) + "'>" +
+                    html.escape(obj['dif_stage']) + "</span></td>\n")
     else:
         genout(outfile,
                     "        <td>&nbsp;</td>\n")
@@ -150,6 +169,14 @@ def print_multiversion_format(obj, outfile):
             outstr += "        <td class=\"hw-stage\"><span class='hw-stage' title='"
             outstr += html.escape(verification_stage_mapping) + "'>"
             outstr += html.escape(rev['verification_stage']) + "</span></td>\n"
+        else:
+            outstr += "        <td>&nbsp;</td>\n"
+
+        if life_stage != 'L0' and 'dif_stage' in rev:
+            dif_stage_mapping = convert_stage(rev['dif_stage'])
+            outstr += "        <td class=\"hw-stage\"><span class='hw-stage' title='"
+            outstr += html.escape(dif_stage_mapping) + "'>"
+            outstr += html.escape(rev['dif_stage']) + "</span></td>\n"
         else:
             outstr += "        <td>&nbsp;</td>\n"
 


### PR DESCRIPTION
As we get closer to standardising DIFs, it will be good to track their
implementation progress. Given DIFs are so closely linked to the
hardware they target, it seems prudent to track DIF status with the
Hardware status, on the same dashboard.

---

This is FAO @gkelly, it is the initial additions to the HW dashboard for DIF lifecycle.