### PR TITLE
[hmac] Block `hash_start` when HMAC active

### DIFF
--- a/hw/ip/hmac/rtl/hmac_pkg.sv
+++ b/hw/ip/hmac/rtl/hmac_pkg.sv
@@ -95,7 +95,8 @@ package hmac_pkg;
     NoError                    = 32'h 0000_0000,
     SwPushMsgWhenShaDisabled   = 32'h 0000_0001,
     SwHashStartWhenShaDisabled = 32'h 0000_0002,
-    SwUpdateSecretKeyInProcess = 32'h 0000_0003
+    SwUpdateSecretKeyInProcess = 32'h 0000_0003,
+    SwHashStartWhenActive      = 32'h 0000_0004
   } err_code_e;
 
 endpackage : hmac_pkg


### PR DESCRIPTION
Problem:

    HMAC can be stuck if `hash_start` is asserted while HMAC is in
    active state and received message chunks already.

If `hash_start` is asserted in the middle of the data operation, the
`message_length` is not matched with the actual data feed. So, SHA
compute engine has more data than the given message length. It affects
to the padding logic, which cannot complete with correct sequence then
SHA engine waits indefinitely. Only option to recover from this hang
state is the IP reset.

This scenario was already added to the assertions in HMAC design. So, if
this case happens in simulation, it fails immediately. However,
triggering the hang condition is not wise, as `hash_start` is the
software-controlled signal and the scenario can happen in production.

Resolution:

    Block the `hash_start` when HMAC is in active.

This commit is to block the second `hash_start` when configuration is
blocked. So, only option for the software is to complete the current
hash process with `hash_process` and initiates another round of the
hash.

Also, if the scenario happens, the HMAC IP now reports an error with
error code 0x4 (SwHashStartWhenActive).

Thanks to @cindychip