### PR TITLE
[rtl, dv] Fix top_earlgrey_asic, dv updates

### DIFF
--- a/hw/dv/data/common_sim_cfg.hjson
+++ b/hw/dv/data/common_sim_cfg.hjson
@@ -52,6 +52,7 @@
   build_opts: [// List multiple tops for the simulation
                "{sim_tops}",
                // Standard UVM defines
+               "+define+UVM",
                "+define+UVM_NO_DEPRECATED",
                "+define+UVM_REGEX_NO_DPI",
                "+define+UVM_REG_ADDR_WIDTH={tl_aw}",

--- a/hw/dv/sv/tl_agent/tl_reg_adapter.sv
+++ b/hw/dv/sv/tl_agent/tl_reg_adapter.sv
@@ -16,8 +16,8 @@ class tl_reg_adapter #(type ITEM_T = tl_seq_item) extends uvm_reg_adapter;
   endfunction : new
 
   function uvm_sequence_item reg2bus(const ref uvm_reg_bus_op rw);
-    ITEM_T reg_item;
-    reg_item = ITEM_T::type_id::create("reg_item");
+    ITEM_T bus_item_loc;
+    bus_item_loc = ITEM_T::type_id::create("bus_item_loc");
 
     // TODO: add a knob to contrl the randomization in case TLUL implementation changes and does
     // not support partial read/write
@@ -27,35 +27,36 @@ class tl_reg_adapter #(type ITEM_T = tl_seq_item) extends uvm_reg_adapter;
     // if CSR field read, will do a partial read if protocal allows by setting a_mask to byte_en
     if (rw.kind == UVM_READ) begin
       if (rw.byte_en == '1) begin // csr full read
-        `DV_CHECK_RANDOMIZE_WITH_FATAL(reg_item,
-            a_opcode          == tlul_pkg::Get;
-            a_addr[TL_AW-1:2] == rw.addr[TL_AW-1:2];
-            $countones(a_mask) dist { TL_DBW       :/ 1,
+        `DV_CHECK_RANDOMIZE_WITH_FATAL(bus_item_loc,
+            a_opcode            == tlul_pkg::Get;
+            a_addr[TL_AW-1:2]   == rw.addr[TL_AW-1:2];
+            $countones(a_mask)  dist {TL_DBW       :/ 1,
                                       [0:TL_DBW-1] :/ 1};)
       end else begin // csr field read
-        `DV_CHECK_RANDOMIZE_WITH_FATAL(reg_item,
-            a_opcode          == tlul_pkg::Get;
-            a_addr[TL_AW-1:2] == rw.addr[TL_AW-1:2];
-            a_mask            == rw.byte_en;)
+        `DV_CHECK_RANDOMIZE_WITH_FATAL(bus_item_loc,
+            a_opcode            == tlul_pkg::Get;
+            a_addr[TL_AW-1:2]   == rw.addr[TL_AW-1:2];
+            a_mask              == rw.byte_en;)
       end
     end else begin // randomize CSR partial or full write
       // Actual width of the CSR may be < TL_DW bits depending on fields and their widths
       // In that case, the transaction size in bytes and partial write mask need to be at least as
       // wide as the CSR to be a valid transaction. Otherwise, the DUT can return an error response
-      int          msb;
-      dv_base_reg  csr;
-      uvm_reg_item item    = get_item();
-      uvm_reg_map  loc_map = item.local_map;
-      uvm_reg      rg      = loc_map.get_reg_by_offset(rw.addr);
-      if (rg != null) begin // csr address
+      int msb;
+      uvm_reg_item item = get_item();
+
+      // Check if csr addr or mem addr; accordingly, get the msb bit.
+      if (item.element_kind == UVM_REG) begin
+        dv_base_reg csr;
+        uvm_object rg = item.element;
         `DV_CHECK_FATAL($cast(csr, rg))
         msb = csr.get_msb_pos();
-      end else if (loc_map.get_mem_by_offset(rw.addr) != null) begin // memory address
+      end else if (item.element_kind == UVM_MEM) begin
         msb = TL_DW - 1;
       end else begin
-        `uvm_fatal(`gfn, $sformatf("unexpected address 0x%0h", rw.addr))
+        `uvm_fatal(`gfn, $sformatf("Unexpected address 0x%0h", rw.addr))
       end
-      `DV_CHECK_RANDOMIZE_WITH_FATAL(reg_item,
+      `DV_CHECK_RANDOMIZE_WITH_FATAL(bus_item_loc,
           a_opcode inside {PutFullData, PutPartialData};
           a_addr    == rw.addr;
           a_data    == rw.data;
@@ -63,21 +64,21 @@ class tl_reg_adapter #(type ITEM_T = tl_seq_item) extends uvm_reg_adapter;
           $countones(a_mask) > (msb / 8);)
     end
     `uvm_info(`gtn, $sformatf("tl reg req item: addr=0x%0h, op=%0s data=0x%0h, mask = %0h",
-                              reg_item.a_addr, rw.kind.name, reg_item.a_data,
-                              reg_item.a_mask), UVM_HIGH)
-    return reg_item;
+                              bus_item_loc.a_addr, rw.kind.name, bus_item_loc.a_data,
+                              bus_item_loc.a_mask), UVM_HIGH)
+    return bus_item_loc;
   endfunction : reg2bus
 
   function void bus2reg(uvm_sequence_item bus_item, ref uvm_reg_bus_op rw);
-    tl_seq_item reg_item;
-    if (!$cast(reg_item, bus_item)) begin
-      `uvm_fatal(`gtn, "Incorrect bus item type, expecting tl_seq_item");
+    ITEM_T bus_item_loc;
+    if (!$cast(bus_item_loc, bus_item)) begin
+      `uvm_fatal(`gtn, "Incorrect bus item type, expecting tl_seq_item (or it's derivative)");
     end
-    rw.kind    = reg_item.a_opcode == tlul_pkg::PutFullData ? UVM_WRITE : UVM_READ;
-    rw.addr    = reg_item.a_addr;
-    rw.data    = (rw.kind == UVM_WRITE) ? reg_item.a_data : reg_item.d_data;
-    rw.byte_en = reg_item.a_mask;
-    rw.status  = reg_item.d_error? UVM_NOT_OK : UVM_IS_OK;
+    rw.kind    = bus_item_loc.a_opcode == tlul_pkg::PutFullData ? UVM_WRITE : UVM_READ;
+    rw.addr    = bus_item_loc.a_addr;
+    rw.data    = (rw.kind == UVM_WRITE) ? bus_item_loc.a_data : bus_item_loc.d_data;
+    rw.byte_en = bus_item_loc.a_mask;
+    rw.status  = bus_item_loc.d_error ? UVM_NOT_OK : UVM_IS_OK;
     `uvm_info(`gtn, $sformatf("tl reg rsp item: addr=0x%0h, op=%0s data=0x%0h",
                               rw.addr, rw.kind.name, rw.data), UVM_HIGH)
   endfunction: bus2reg

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -10,12 +10,14 @@ filesets:
       - lowrisc:dv:cip_lib
       - lowrisc:dv:uart_agent
       - lowrisc:dv:jtag_agent
+      - lowrisc:dv:spi_agent
       - lowrisc:dv:mem_bkdr_if
       - lowrisc:dv:uart_env
       - lowrisc:dv:gpio_env
       - lowrisc:dv:hmac_env
       - lowrisc:dv:rv_timer_env
       - lowrisc:dv:spi_device_env
+      - lowrisc:dv:usbdev_env
       - lowrisc:dv:sw_msg_monitor_if
       - lowrisc:dv:gen_ral_pkg
     files:

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -11,6 +11,7 @@ package chip_env_pkg;
   import tl_agent_pkg::*;
   import uart_agent_pkg::*;
   import jtag_agent_pkg::*;
+  import spi_agent_pkg::*;
   import dv_lib_pkg::*;
   import cip_base_pkg::*;
   import chip_ral_pkg::*;
@@ -21,6 +22,7 @@ package chip_env_pkg;
   import hmac_env_pkg::*;
   import rv_timer_env_pkg::*;
   import spi_device_env_pkg::*;
+  import usbdev_env_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"

--- a/hw/top_earlgrey/dv/env/chip_virtual_sequencer.sv
+++ b/hw/top_earlgrey/dv/env/chip_virtual_sequencer.sv
@@ -10,6 +10,7 @@ class chip_virtual_sequencer extends dv_base_virtual_sequencer #(
 
   uart_sequencer  uart_sequencer_h;
   jtag_sequencer  jtag_sequencer_h;
+  spi_sequencer   spi_sequencer_h;
   tl_sequencer    cpu_d_tl_sequencer_h;
 
   `uvm_component_new

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -44,6 +44,10 @@ class chip_base_vseq extends dv_base_vseq #(
 
   virtual task dut_init(string reset_kind = "HARD");
     super.dut_init(reset_kind);
+    cfg.srst_n_vif.drive(1'b1);
+    cfg.jtag_spi_n_vif.drive(1'b0); // Select SPI.
+    cfg.bootstrap_vif.drive(1'b1);
+    cfg.usb_clk_rst_vif.set_freq_mhz(dv_utils_pkg::ClkFreq48Mhz);
     cfg.m_uart_agent_cfg.set_baud_rate(BaudRate1Mbps);
     // Initialize gpio pin default states
     cfg.gpio_vif.set_pulldown_en({chip_env_pkg::NUM_GPIOS{1'b1}});

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
@@ -17,8 +17,13 @@ class chip_common_vseq extends chip_base_vseq;
   }
   `uvm_object_new
 
+  virtual task pre_start();
+    super.pre_start();
+    // keep sck on - needed for csr tests since some csrs are flopped on sck
+    cfg.m_spi_agent_cfg.sck_on = 1'b1;;
+  endtask
+
   virtual task body();
-    `uvm_info(`gfn, $sformatf("%0s", cfg.ral.sprint()), UVM_LOW)
     run_csr_vseq_wrapper(num_trans);
   endtask : body
 
@@ -29,11 +34,12 @@ class chip_common_vseq extends chip_base_vseq;
                                            string           scope = "ral");
 
     // reuse exclusions from IP benches
-    `add_ip_csr_exclusions(uart)
     `add_ip_csr_exclusions(gpio)
     `add_ip_csr_exclusions(hmac)
     `add_ip_csr_exclusions(rv_timer)
     `add_ip_csr_exclusions(spi_device)
+    `add_ip_csr_exclusions(uart)
+    `add_ip_csr_exclusions(usbdev)
 
   endfunction
 

--- a/hw/top_earlgrey/dv/tb/chip_hier_macros.svh
+++ b/hw/top_earlgrey/dv/tb/chip_hier_macros.svh
@@ -11,5 +11,6 @@
 `define RAM_MAIN_HIER   `CHIP_HIER.u_ram1p_ram_main
 `define ROM_HIER        `CHIP_HIER.u_rom_rom
 `define FLASH_HIER      `CHIP_HIER.u_flash_eflash
+`define USBDEV_HIER     `CHIP_HIER.usbdev
 `define FLASH0_MEM_HIER `FLASH_HIER.gen_flash_banks[0].u_flash.gen_flash.u_impl_generic.u_mem
 `define FLASH1_MEM_HIER `FLASH_HIER.gen_flash_banks[1].u_flash.gen_flash.u_impl_generic.u_mem

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -16,30 +16,42 @@ module tb;
   `include "dv_macros.svh"
   `include "chip_hier_macros.svh"
 
-  wire clk, clk_usb_48mhz, rst_n;
+  wire clk, rst_n;
+  wire usb_clk, usb_rst_n;
+
   wire [NUM_GPIOS-1:0] gpio_pins;
+
   wire jtag_tck;
   wire jtag_tms;
   wire jtag_trst_n;
   wire jtag_tdi;
   wire jtag_tdo;
+
+  wire spi_device_sck;
+  wire spi_device_csb;
+  wire spi_device_miso_o;
+  wire spi_device_mosi_i;
+
+  wire srst_n;
+  wire jtag_spi_n;
+  wire bootstrap;
+  wire [7:0] io_dps;
+
   wire usb_dp0, usb_dn0, usb_sense0, usb_pullup0;
 
   bit stub_cpu;
 
   // interfaces
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
+  clk_rst_if usb_clk_rst_if(.clk(usb_clk), .rst_n(usb_rst_n));
   pins_if #(NUM_GPIOS) gpio_if(.pins(gpio_pins));
+  pins_if #(1) srst_n_if(.pins(srst_n));
+  pins_if #(1) jtag_spi_n_if(.pins(jtag_spi_n));
+  pins_if #(1) bootstrap_if(.pins(bootstrap));
+  spi_if spi_if(.rst_n(rst_n));
   tl_if   cpu_d_tl_if(.clk(clk), .rst_n(rst_n));
   uart_if uart_if();
   jtag_if jtag_if();
-
-  // USB-related signals
-  assign clk_usb_48mhz = clk; // TODO: Generate the 48MHz clock
-  assign usb_dp0 = 1'bz; // TODO: Do something more reasonable, is I/O
-  assign usb_dn0 = 1'bz; // TODO: Do something more reasonable, is I/O
-  assign usb_sense0 = 1'bz; // TODO: Do something more reasonable, is I/O
-  // TODO: Do something reasonable with usb_pullup0
 
   // backdoors
   bind `ROM_HIER mem_bkdr_if rom_mem_bkdr_if();
@@ -50,21 +62,28 @@ module tb;
     // Clock and Reset
     .IO_CLK           (clk),
     .IO_RST_N         (rst_n),
-    .IO_CLK_USB_48MHZ (clk_usb_48mhz),
-    // JTAG interface
-    .IO_JTCK          (jtag_tck),
-    .IO_JTMS          (jtag_tms),
-    .IO_JTRST_N       (jtag_trst_n),
-    .IO_JTDI          (jtag_tdi),
-    .IO_JTDO          (jtag_tdo),
+    .IO_CLK_USB_48MHZ (usb_clk),
+
+    // JTAG / SPI interface
+    .IO_DPS0          (io_dps[0]),
+    .IO_DPS1          (io_dps[1]),
+    .IO_DPS2          (io_dps[2]),
+    .IO_DPS3          (io_dps[3]),
+    .IO_DPS4          (io_dps[4]),
+    .IO_DPS5          (io_dps[5]),
+    .IO_DPS6          (io_dps[6]),
+    .IO_DPS7          (io_dps[7]),
+
     // UART interface
     .IO_URX           (uart_if.uart_rx),
     .IO_UTX           (uart_if.uart_tx),
+
     // USB interface
     .IO_USB_DP0       (usb_dp0),
     .IO_USB_DN0       (usb_dn0),
     .IO_USB_SENSE0    (usb_sense0),
     .IO_USB_PULLUP0   (usb_pullup0),
+
     // GPIO x 16 interface
     .IO_GP0           (gpio_pins[0 ]),
     .IO_GP1           (gpio_pins[1 ]),
@@ -99,6 +118,16 @@ module tb;
                                 (`RAM_MAIN_HIER.addr_i == sw_msg_monitor_sw_msg_addr);
 
   // connect signals
+  assign io_dps[0]  = jtag_spi_n ? jtag_tck : spi_device_sck;
+  assign io_dps[1]  = jtag_spi_n ? jtag_tdi : spi_device_mosi_i;
+  assign io_dps[3]  = jtag_spi_n ? jtag_tms : spi_device_csb;
+  assign io_dps[4]  = jtag_trst_n;
+  assign io_dps[5]  = srst_n;
+  assign io_dps[6]  = jtag_spi_n;
+  assign io_dps[7]  = bootstrap;
+  assign spi_device_miso_o  = jtag_spi_n ? 1'b0 : io_dps[2];
+  assign jtag_tdo           = jtag_spi_n ? io_dps[2] : 1'b0;
+
   assign jtag_tck         = jtag_if.tck;
   assign jtag_tms         = jtag_if.tms;
   assign jtag_trst_n      = jtag_if.trst_n;
@@ -106,22 +135,50 @@ module tb;
   assign jtag_if.tdo      = jtag_tdo;
   assign cpu_d_tl_if.d2h  = `CPU_HIER.tl_d_i;
 
+  assign spi_device_sck     = spi_if.sck;
+  assign spi_device_csb     = spi_if.csb;
+  assign spi_device_mosi_i  = spi_if.mosi;
+  assign spi_if.miso        = spi_device_miso_o;
+
+  // TODO: USB-related signals, hookup an interface.
+  assign usb_rst_n  = `USBDEV_HIER.rst_usb_48mhz_ni;
+  assign usb_dp0    = 1'b1;
+  assign usb_dn0    = 1'b0;
+  assign usb_sense0 = 1'b0;
+
   initial begin
+    // Set clk_rst_vifs
     // drive clk and rst_n from clk_if
     clk_rst_if.set_active();
+    usb_clk_rst_if.set_active(.drive_clk_val(1'b1), .drive_rst_n_val(1'b0));
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
-    uvm_config_db#(virtual tl_if)::set(null, "*.env.m_cpu_d_tl_agent*", "vif", cpu_d_tl_if);
+    uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "usb_clk_rst_vif", usb_clk_rst_if);
+
+    // IO Interfaces
     uvm_config_db#(virtual pins_if #(NUM_GPIOS))::set(null, "*.env", "gpio_vif", gpio_if);
     uvm_config_db#(virtual uart_if)::set(null, "*.env.m_uart_agent*", "vif", uart_if);
     uvm_config_db#(virtual jtag_if)::set(null, "*.env.m_jtag_agent*", "vif", jtag_if);
-    uvm_config_db#(virtual mem_bkdr_if)::set(null, "*.env", "mem_bkdr_vifs[Rom]",
-        `ROM_HIER.rom_mem_bkdr_if);
-    uvm_config_db#(virtual mem_bkdr_if)::set(null, "*.env", "mem_bkdr_vifs[FlashBank0]",
-        `FLASH0_MEM_HIER.flash0_mem_bkdr_if);
-    uvm_config_db#(virtual mem_bkdr_if)::set(null, "*.env", "mem_bkdr_vifs[FlashBank1]",
-        `FLASH1_MEM_HIER.flash1_mem_bkdr_if);
-    uvm_config_db#(virtual sw_msg_monitor_if)::set(null, "*.env", "sw_msg_monitor_vif",
-        sw_msg_monitor_if);
+    uvm_config_db#(virtual spi_if)::set(null, "*.env.m_spi_agent*", "vif", spi_if);
+    uvm_config_db#(virtual tl_if)::set(null, "*.env.m_cpu_d_tl_agent*", "vif", cpu_d_tl_if);
+
+    // Strap pins
+    uvm_config_db#(virtual pins_if #(1))::set(
+        null, "*.env", "srst_n_vif", srst_n_if);
+    uvm_config_db#(virtual pins_if #(1))::set(
+        null, "*.env", "jtag_spi_n_vif", jtag_spi_n_if);
+    uvm_config_db#(virtual pins_if #(1))::set(
+        null, "*.env", "bootstrap_vif", bootstrap_if);
+
+    // Backdoors
+    uvm_config_db#(virtual mem_bkdr_if)::set(
+        null, "*.env", "mem_bkdr_vifs[Rom]", `ROM_HIER.rom_mem_bkdr_if);
+    uvm_config_db#(virtual mem_bkdr_if)::set(
+        null, "*.env", "mem_bkdr_vifs[FlashBank0]", `FLASH0_MEM_HIER.flash0_mem_bkdr_if);
+    uvm_config_db#(virtual mem_bkdr_if)::set(
+        null, "*.env", "mem_bkdr_vifs[FlashBank1]", `FLASH1_MEM_HIER.flash1_mem_bkdr_if);
+    uvm_config_db#(virtual sw_msg_monitor_if)::set(
+        null, "*.env", "sw_msg_monitor_vif", sw_msg_monitor_if);
+
     $timeformat(-12, 0, " ps", 12);
     run_test();
   end

--- a/hw/top_earlgrey/dv/tests/chip_base_test.sv
+++ b/hw/top_earlgrey/dv/tests/chip_base_test.sv
@@ -20,6 +20,8 @@ class chip_base_test extends dv_base_test #(
     super.build_phase(phase);
     // knob to en/dis stubbing cpu (disabled by default)
     void'($value$plusargs("stub_cpu=%0b", cfg.stub_cpu));
+    // Set tl_agent's is_active bit based on the retrieved stub_cpu value.
+    cfg.m_cpu_d_tl_agent_cfg.is_active = cfg.stub_cpu;
   endfunction : build_phase
 
 

--- a/hw/top_earlgrey/rtl/top_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_asic.sv
@@ -8,11 +8,14 @@ module top_earlgrey_asic (
   input               IO_RST_N,
   input               IO_CLK_USB_48MHZ,
   // JTAG interface
-  input               IO_JTCK,
-  input               IO_JTMS,
-  input               IO_JTDI,
-  input               IO_JTRST_N,
-  output              IO_JTDO,
+  input               IO_DPS0, // IO_JTCK,    IO_SDCK
+  input               IO_DPS3, // IO_JTMS,    IO_SDCSB
+  input               IO_DPS1, // IO_JTDI,    IO_SDMOSI
+  input               IO_DPS4, // IO_JTRST_N,
+  input               IO_DPS5, // IO_JSRST_N,
+  output              IO_DPS2, // IO_JTDO,    IO_MISO
+  input               IO_DPS6, // JTAG=0,     SPI=1
+  input               IO_DPS7, // BOOTSTRAP=1
   // UART interface
   input               IO_URX,
   output              IO_UTX,
@@ -42,31 +45,37 @@ module top_earlgrey_asic (
 
   logic [31:0] cio_gpio_p2d, cio_gpio_d2p, cio_gpio_en_d2p;
   logic cio_uart_rx_p2d, cio_uart_tx_d2p, cio_uart_tx_en_d2p;
+  logic cio_spi_device_sck_p2d, cio_spi_device_csb_p2d, cio_spi_device_mosi_p2d,
+        cio_spi_device_miso_d2p, cio_spi_device_miso_en_d2p;
+  logic cio_jtag_tck_p2d, cio_jtag_tms_p2d, cio_jtag_tdi_p2d, cio_jtag_tdo_d2p;
+  logic cio_jtag_trst_n_p2d, cio_jtag_srst_n_p2d;
   logic cio_usbdev_sense_p2d, cio_usbdev_pullup_d2p, cio_usbdev_pullup_en_d2p;
   logic cio_usbdev_dp_p2d, cio_usbdev_dp_d2p, cio_usbdev_dp_en_d2p;
   logic cio_usbdev_dn_p2d, cio_usbdev_dn_d2p, cio_usbdev_dn_en_d2p;
 
   // Top-level design
   top_earlgrey top_earlgrey (
-    .clk_i            (IO_CLK),
-    .rst_ni           (IO_RST_N),
+    .clk_i                    (IO_CLK),
+    .rst_ni                   (IO_RST_N),
 
-    .clk_usb_48mhz_i  (IO_CLK_USB_48MHZ),
+    .clk_usb_48mhz_i          (IO_CLK_USB_48MHZ),
 
-    .jtag_tck_i       (IO_JTCK),
-    .jtag_tms_i       (IO_JTMS),
-    .jtag_trst_ni     (IO_JTRST_N),
-    .jtag_td_i        (IO_JTDI),
-    .jtag_td_o        (IO_JTDO),
+    .jtag_tck_i               (cio_jtag_tck_p2d),
+    .jtag_tms_i               (cio_jtag_tms_p2d),
+    .jtag_trst_ni             (cio_jtag_trst_n_p2d),
+    .jtag_td_i                (cio_jtag_tdi_p2d),
+    .jtag_td_o                (cio_jtag_tdo_d2p),
 
-    .dio_spi_device_sck_i     (1'b1),
-    .dio_spi_device_csb_i     (1'b1),
-    .dio_spi_device_mosi_i    (1'b1),
-    .dio_spi_device_miso_o    (),
-    .dio_spi_device_miso_en_o (),
-    .dio_uart_rx_i    (cio_uart_rx_p2d),
-    .dio_uart_tx_o    (cio_uart_tx_d2p),
-    .dio_uart_tx_en_o (cio_uart_tx_en_d2p),
+    .dio_spi_device_sck_i     (cio_spi_device_sck_p2d),
+    .dio_spi_device_csb_i     (cio_spi_device_csb_p2d),
+    .dio_spi_device_mosi_i    (cio_spi_device_mosi_p2d),
+    .dio_spi_device_miso_o    (cio_spi_device_miso_d2p),
+    .dio_spi_device_miso_en_o (cio_spi_device_miso_en_d2p),
+
+    .dio_uart_rx_i            (cio_uart_rx_p2d),
+    .dio_uart_tx_o            (cio_uart_tx_d2p),
+    .dio_uart_tx_en_o         (cio_uart_tx_en_d2p),
+
     .dio_usbdev_sense_i       (cio_usbdev_sense_p2d),
     .dio_usbdev_pullup_o      (cio_usbdev_pullup_d2p),
     .dio_usbdev_pullup_en_o   (cio_usbdev_pullup_en_d2p),
@@ -77,11 +86,11 @@ module top_earlgrey_asic (
     .dio_usbdev_dn_o          (cio_usbdev_dn_d2p),
     .dio_usbdev_dn_en_o       (cio_usbdev_dn_en_d2p),
 
-    .mio_in_i         (cio_gpio_p2d),
-    .mio_out_o        (cio_gpio_d2p),
-    .mio_oe_o         (cio_gpio_en_d2p),
+    .mio_in_i                 (cio_gpio_p2d),
+    .mio_out_o                (cio_gpio_d2p),
+    .mio_oe_o                 (cio_gpio_en_d2p),
 
-    .scanmode_i       (1'b0)
+    .scanmode_i               (1'b0)
   );
 
   // pad control
@@ -104,6 +113,19 @@ module top_earlgrey_asic (
     .cio_gpio_p2d,
     .cio_gpio_d2p,
     .cio_gpio_en_d2p,
+    // SPI device
+    .cio_spi_device_sck_p2d,
+    .cio_spi_device_csb_p2d,
+    .cio_spi_device_mosi_p2d,
+    .cio_spi_device_miso_d2p,
+    .cio_spi_device_miso_en_d2p,
+    // JTAG
+    .cio_jtag_tck_p2d,
+    .cio_jtag_tms_p2d,
+    .cio_jtag_trst_n_p2d,
+    .cio_jtag_srst_n_p2d,
+    .cio_jtag_tdi_p2d,
+    .cio_jtag_tdo_d2p,
     // pads
     .IO_URX,
     .IO_UTX,
@@ -127,15 +149,14 @@ module top_earlgrey_asic (
     .IO_GP13,
     .IO_GP14,
     .IO_GP15,
-    // SPI related pins
-    .IO_DPS0(1'b1),
-    .IO_DPS1(1'b1),
-    .IO_DPS2(),
-    .IO_DPS3(1'b0),
-    .IO_DPS4(1'b0),
-    .IO_DPS5(1'b0),
-    .IO_DPS6(1'b0),
-    .IO_DPS7(1'b0)
+    .IO_DPS0,
+    .IO_DPS1,
+    .IO_DPS2,
+    .IO_DPS3,
+    .IO_DPS4,
+    .IO_DPS5,
+    .IO_DPS6,
+    .IO_DPS7
   );
 
 endmodule


### PR DESCRIPTION
- Updated top_earlgrey to hookup the SPI interface (make it look more
like nexysvideo)
  - SPI is muxed with JTAG due to 'nexysvideo' version of padctl - once
  the 'asic' version of padctl lands, we can fix the tb as needed later

- Updates to get CSR HW reset test passing at the chip level
  - There are several assertion errors that are currently under debug

Signed-off-by: Srikrishna Iyer <sriyer@google.com>