### PR TITLE
[hw, rv_core_ibex] Enable hardware breakpoints

### DIFF
--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -16,6 +16,7 @@ module rv_core_ibex #(
   parameter int unsigned MHPMCounterWidth = 40,
   parameter bit          RV32E            = 0,
   parameter bit          RV32M            = 1,
+  parameter bit          DbgTriggerEn     = 1'b1,
   parameter int unsigned DmHaltAddr       = 32'h1A110800,
   parameter int unsigned DmExceptionAddr  = 32'h1A110808,
   parameter bit          PipeLine         = 0
@@ -116,6 +117,7 @@ module rv_core_ibex #(
      .MHPMCounterWidth ( MHPMCounterWidth  ),
      .RV32E            ( RV32E             ),
      .RV32M            ( RV32M             ),
+     .DbgTriggerEn     ( DbgTriggerEn      ),
      .DmHaltAddr       ( DmHaltAddr        ),
      .DmExceptionAddr  ( DmExceptionAddr   )
   ) u_core (

--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -242,6 +242,7 @@ module top_${top["name"]} #(
     .MHPMCounterWidth    (40),
     .RV32E               (0),
     .RV32M               (1),
+    .DbgTriggerEn        (1),
     .DmHaltAddr          (ADDR_SPACE_DEBUG_MEM + dm::HaltAddress),
     .DmExceptionAddr     (ADDR_SPACE_DEBUG_MEM + dm::ExceptionAddress),
     .PipeLine            (IbexPipeLine)

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -273,6 +273,7 @@ module top_earlgrey #(
     .MHPMCounterWidth    (40),
     .RV32E               (0),
     .RV32M               (1),
+    .DbgTriggerEn        (1),
     .DmHaltAddr          (ADDR_SPACE_DEBUG_MEM + dm::HaltAddress),
     .DmExceptionAddr     (ADDR_SPACE_DEBUG_MEM + dm::ExceptionAddress),
     .PipeLine            (IbexPipeLine)


### PR DESCRIPTION
This change enables hardware breakpoints, which allows the usage of hbreak in GDB.

Without it there is currently no easy way to debug OpenTitan using GDB.