### PR TITLE
[util/vendor.py] Enable patching in combination with `only_subdir`

### DIFF
--- a/util/vendor.py
+++ b/util/vendor.py
@@ -379,7 +379,7 @@ def main(argv):
                                    vendor_file_base_dir).glob('*.patch')
             for patch in sorted(patches):
                 log.info("Applying patch %s" % str(patch))
-                apply_patch(clone_subdir, str(patch))
+                apply_patch(clone_dir, str(patch))
 
         # import selected (patched) files from upstream repo
         exclude_files = []


### PR DESCRIPTION
Git can only apply patches in the root directory of a repository. This PR makes sure patches can also be applied when only a sub directory of the upstream repo is actually being used.