### PR TITLE
[dv tool] css fix for reports page

### DIFF
--- a/util/dvsim/style.css
+++ b/util/dvsim/style.css
@@ -20,7 +20,6 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  justify-content: center;
   min-height: 100vh;
   font-family: "Trebuchet MS", Arial, Helvetica, sans-serif;
 }


### PR DESCRIPTION
- Removed CSS style that causes report content to be centered in the
page rather than start from the top.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>