### PR TITLE
[ci, verilator_pytest] Remove make related dead code

### DIFF
--- a/ci/run_verilator_pytest.sh
+++ b/ci/run_verilator_pytest.sh
@@ -22,17 +22,6 @@ TEST_TARGETS=(
   "tests/rv_timer/rv_timer_test_sim_verilator.elf"
 )
 
-if [[ ! -z ${MAKE_BUILD+x} ]]; then
-  BOOT_ROM_TARGET="sw/device/sim/boot_rom/rom.elf"
-  TEST_TARGETS=(
-    "sw/device/sim/examples/hello_usbdev.elf"
-    "sw/device/sim/tests/aes/sw.elf"
-    "sw/device/sim/tests/flash_ctrl/sw.elf"
-    "sw/device/sim/tests/hmac/sw.elf"
-    "sw/device/sim/tests/rv_timer/sw.elf"
-  )
-fi
-
 FAIL_TARGETS=()
 PASS_TARGETS=()
 for target in "${TEST_TARGETS[@]}"; do


### PR DESCRIPTION
Make has been removed from the OT SW build flow, which makes this block of code redundant.