### PR TITLE
[sw, dif_plic] Sync DIF_PLIC with RTL

### DIFF
--- a/sw/device/lib/dif/dif_plic.c
+++ b/sw/device/lib/dif/dif_plic.c
@@ -106,6 +106,11 @@ static const plic_peripheral_range_t plic_peripheral_ranges[] = {
                 .first_irq_id = kDifPlicIrqIdNmiGenEsc0,
                 .last_irq_id = kDifPlicIrqIdNmiGenEsc3,
             },
+        [kDifPlicPeripheralUsbDev] =
+            {
+                .first_irq_id = kDifPlicIrqIdUsbDevPktReceived,
+                .last_irq_id = kDifPlicIrqIdUsbDevConnected,
+            },
 };
 
 /**

--- a/sw/device/lib/dif/dif_plic.h
+++ b/sw/device/lib/dif/dif_plic.h
@@ -52,7 +52,7 @@ typedef enum dif_plic_irq_id {
   kDifPlicIrqIdGpio31 = 32,          /**< GPIO pin 31. */
   kDifPlicIrqIdUartTxWatermark = 33, /**< UART TX FIFO watermark. */
   kDifPlicIrqIdUartRxWatermark = 34, /**< UART RX FIFO watermark. */
-  kDifPlicIrqIdUartTxOverflow = 35,  /**< UART TX FIFO overflow. */
+  kDifPlicIrqIdUartTxEmpty = 35,     /**< UART TX FIFO empty. */
   kDifPlicIrqIdUartRxOverflow = 36,  /**< UART RX FIFO overflow. */
   kDifPlicIrqIdUartRxFrameErr = 37,  /**< UART RX frame error. */
   kDifPlicIrqIdUartRxBreakErr = 38,  /**< UART RX break error. */

--- a/sw/device/lib/dif/dif_plic.h
+++ b/sw/device/lib/dif/dif_plic.h
@@ -81,7 +81,24 @@ typedef enum dif_plic_irq_id {
   kDifPlicIrqIdNmiGenEsc1 = 61,         /**< NMI Gen escalation interrupt 1. */
   kDifPlicIrqIdNmiGenEsc2 = 62,         /**< NMI Gen escalation interrupt 2. */
   kDifPlicIrqIdNmiGenEsc3 = 63,         /**< NMI Gen escalation interrupt 3. */
-  kDifPlicIrqIdLast = kDifPlicIrqIdNmiGenEsc3, /**< The last valid IRQ ID. */
+  kDifPlicIrqIdUsbDevPktReceived = 64,  /**< USB packet received (OUT/SETUP). */
+  kDifPlicIrqIdUsbDevPktSent = 65,      /**< USB packet sent (IN). */
+  kDifPlicIrqIdUsbDevDisconnected = 66, /**< USB link disconn (VBUS lost). */
+  kDifPlicIrqIdUsbDevHostLost = 67,     /*<< USB frame not received in time. */
+  kDifPlicIrqIdUsbDevLinkReset = 68,    /*<< USB link reset. */
+  kDifPlicIrqIdUsbDevLinkSuspend = 69,  /*<< USB link suspend. */
+  kDifPlicIrqIdUsbDevLinkResume = 70,   /*<< USB link resume. */
+  kDifPlicIrqIdUsbDevAvEmpty = 71, /*<< USB AvBuffer FIFO empty (OUT/SETUP). */
+  kDifPlicIrqIdUsbDevRxFull = 72,  /*<< USB Receive FIFO full (OUT/SETUP). */
+  kDifPlicIrqIdUsbDevAvOverflow = 73,    /*<< USB AvBuffer FIFO overflow. */
+  kDifPlicIrqIdUsbDevLinkInErr = 74,     /*<< USB IN error. */
+  kDifPlicIrqIdUsbDevRxCrcErr = 75,      /*<< USB CRC error. */
+  kDifPlicIrqIdUsbDevRxPidErr = 76,      /*<< USB PID invalid error. */
+  kDifPlicIrqIdUsbDevRxBitstuffErr = 77, /*<< USB bitstuffing invalid error. */
+  kDifPlicIrqIdUsbDevFrame = 78, /*<< USB frame number updated, SOF valid. */
+  kDifPlicIrqIdUsbDevConnected = 79, /*<< USB connected (VBUS applied). */
+  kDifPlicIrqIdLast =
+      kDifPlicIrqIdUsbDevConnected, /**< The last valid IRQ ID. */
 } dif_plic_irq_id_t;
 
 /**
@@ -98,8 +115,9 @@ typedef enum dif_plic_peripheral {
   kDifPlicPeripheralHmac,         /**< HMAC */
   kDifPlicPeripheralAlertHandler, /**< Alert handler */
   kDifPlicPeripheralNmiGen,       /**< NMI generator */
+  kDifPlicPeripheralUsbDev,       /**< USB device */
   kDifPlicPeripheralLast =
-      kDifPlicPeripheralNmiGen, /**< \internal Final PLIC peripheral */
+      kDifPlicPeripheralUsbDev, /**< \internal Final PLIC peripheral */
 } dif_plic_peripheral_t;
 
 /**

--- a/sw/device/tests/consecutive_irqs/consecutive_irqs_test.c
+++ b/sw/device/tests/consecutive_irqs/consecutive_irqs_test.c
@@ -64,7 +64,7 @@ static void handler_uart_isr(const dif_irq_claim_data_t *data) {
         uart_rx_overflow_handled = true;
       }
       break;
-    case kDifPlicIrqIdUartTxOverflow:
+    case kDifPlicIrqIdUartTxEmpty:
       uart_irq = kDifUartInterruptTxEmpty;
 
       // It is an error if this IRQ is asserted more than once.
@@ -162,7 +162,7 @@ static bool plic_configure_irqs(dif_plic_t *plic) {
               "PLIC: RX overflow trigger type set failed!\n");
     return false;
   }
-  if (!dif_plic_irq_trigger_type_set(plic, kDifPlicIrqIdUartTxOverflow,
+  if (!dif_plic_irq_trigger_type_set(plic, kDifPlicIrqIdUartTxEmpty,
                                      kDifPlicDisable)) {
     print_log(uart_print_char_p, "PLIC: TX empty trigger type set failed!\n");
     return false;
@@ -175,7 +175,7 @@ static bool plic_configure_irqs(dif_plic_t *plic) {
               "PLIC: priority set for RX overflow failed!\n");
     return false;
   }
-  if (!dif_plic_irq_priority_set(plic, kDifPlicIrqIdUartTxOverflow,
+  if (!dif_plic_irq_priority_set(plic, kDifPlicIrqIdUartTxEmpty,
                                  PLIC_PRIORITY_MAX)) {
     print_log(uart_print_char_p, "PLIC: priority set for TX empty failed!\n");
     return false;
@@ -194,7 +194,7 @@ static bool plic_configure_irqs(dif_plic_t *plic) {
               "PLIC: interrupt Enable for RX overflow failed!\n");
     return false;
   }
-  if (!dif_plic_irq_enable_set(plic, kDifPlicIrqIdUartTxOverflow, PLIC_TARGET,
+  if (!dif_plic_irq_enable_set(plic, kDifPlicIrqIdUartTxEmpty, PLIC_TARGET,
                                kDifPlicEnable)) {
     print_log(uart_print_char_p,
               "PLIC: interrupt Enable for TX empty failed!\n");


### PR DESCRIPTION
This PR contains two changes:
* Renamed tx_overflow to tx_empty to match UART RTL.
* Added USB Device interrupts and peripheral enumerations to match top_earlgrey and PLIC RTL.