### PR TITLE
[flash] Fix default interrupt state

### DIFF
--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -404,7 +404,7 @@ module flash_ctrl (
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      intr_src_q <= 'h0;
+      intr_src_q <= 4'h8; //prog_fifo is empty by default
     end else begin
       intr_src_q <= intr_src;
     end


### PR DESCRIPTION
Make sure interrups do not assert by default

Signed-off-by: Timothy Chen <timothytim@google.com>