### PR TITLE
[dv/alert_handler] Use a base sequence for alert_handler_seq

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent.core
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent.core
@@ -27,8 +27,10 @@ filesets:
       - esc_monitor.sv: {is_include_file: true}
       - alert_esc_seq_item.sv: {is_include_file: true}
       - alert_esc_sequencer.sv: {is_include_file: true}
+      - seq_lib/alert_receiver_base_seq.sv: {is_include_file: true}
       - seq_lib/alert_receiver_alert_rsp_seq.sv: {is_include_file: true}
       - seq_lib/alert_receiver_seq.sv: {is_include_file: true}
+      - seq_lib/alert_sender_base_seq.sv: {is_include_file: true}
       - seq_lib/alert_sender_ping_rsp_seq.sv: {is_include_file: true}
       - seq_lib/alert_sender_seq.sv: {is_include_file: true}
       - seq_lib/esc_receiver_esc_rsp_seq.sv: {is_include_file: true}

--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent_pkg.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent_pkg.sv
@@ -54,8 +54,10 @@ package alert_esc_agent_pkg;
   `include "alert_esc_agent.sv"
 
   // Sequences
+  `include "seq_lib/alert_receiver_base_seq.sv"
   `include "seq_lib/alert_receiver_alert_rsp_seq.sv"
   `include "seq_lib/alert_receiver_seq.sv"
+  `include "seq_lib/alert_sender_base_seq.sv"
   `include "seq_lib/alert_sender_ping_rsp_seq.sv"
   `include "seq_lib/alert_sender_seq.sv"
   `include "seq_lib/esc_receiver_esc_rsp_seq.sv"

--- a/hw/dv/sv/alert_esc_agent/seq_lib/alert_receiver_alert_rsp_seq.sv
+++ b/hw/dv/sv/alert_esc_agent/seq_lib/alert_receiver_alert_rsp_seq.sv
@@ -3,27 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // this sequence responses to alert pins by sending the ack pins
-class alert_receiver_alert_rsp_seq extends dv_base_seq #(
-    .REQ         (alert_esc_seq_item),
-    .CFG_T       (alert_esc_agent_cfg),
-    .SEQUENCER_T (alert_esc_sequencer)
-  );
+class alert_receiver_alert_rsp_seq extends alert_receiver_base_seq;
 
   `uvm_object_utils(alert_receiver_alert_rsp_seq)
   `uvm_object_new
 
-  virtual task body();
-    `uvm_info(`gfn, $sformatf("starting alert receiver transfer"), UVM_HIGH)
-    req = alert_esc_seq_item::type_id::create("req");
-    start_item(req);
-    `DV_CHECK_RANDOMIZE_WITH_FATAL(req,
-        r_alert_ping_send == 0;
-        r_alert_rsp       == 1;
-    )
-    `uvm_info(`gfn, $sformatf("seq_item: alert_rsp, int_err=%0b", req.int_err), UVM_LOW)
-    finish_item(req);
-    get_response(rsp);
-    `uvm_info(`gfn, "alert receiver transfer done", UVM_HIGH)
-  endtask : body
+  constraint alert_receiver_alert_rsp_seq_c {
+    r_alert_ping_send == 0;
+    r_alert_rsp       == 1;
+  }
 
 endclass : alert_receiver_alert_rsp_seq

--- a/hw/dv/sv/alert_esc_agent/seq_lib/alert_receiver_base_seq.sv
+++ b/hw/dv/sv/alert_esc_agent/seq_lib/alert_receiver_base_seq.sv
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// this is a base sequence for alert_receiver side
+class alert_receiver_base_seq extends dv_base_seq #(
+    .REQ         (alert_esc_seq_item),
+    .CFG_T       (alert_esc_agent_cfg),
+    .SEQUENCER_T (alert_esc_sequencer)
+  );
+
+  `uvm_object_utils(alert_receiver_base_seq)
+
+  `uvm_object_new
+
+  rand bit r_alert_ping_send;
+  rand bit r_alert_rsp;
+
+  task body();
+    `uvm_info(`gfn, $sformatf("starting alert receiver transfer"), UVM_HIGH)
+    req = alert_esc_seq_item::type_id::create("req");
+    start_item(req);
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(req,
+        r_alert_ping_send == local::r_alert_ping_send;
+        r_alert_rsp       == local::r_alert_rsp;
+    )
+    `uvm_info(`gfn, $sformatf("seq_item: ping_send, int_err=%0b", req.int_err), UVM_LOW)
+    finish_item(req);
+    get_response(rsp);
+    `uvm_info(`gfn, "alert receiver transfer done", UVM_HIGH)
+  endtask : body
+
+endclass : alert_receiver_base_seq

--- a/hw/dv/sv/alert_esc_agent/seq_lib/alert_receiver_seq.sv
+++ b/hw/dv/sv/alert_esc_agent/seq_lib/alert_receiver_seq.sv
@@ -3,28 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // this sequence send ping_p and ping_n to trigger ping signals
-class alert_receiver_seq extends dv_base_seq #(
-    .REQ         (alert_esc_seq_item),
-    .CFG_T       (alert_esc_agent_cfg),
-    .SEQUENCER_T (alert_esc_sequencer)
-  );
+class alert_receiver_seq extends alert_receiver_base_seq;
 
   `uvm_object_utils(alert_receiver_seq)
 
   `uvm_object_new
 
-  task body();
-    `uvm_info(`gfn, $sformatf("starting alert receiver transfer"), UVM_HIGH)
-    req = alert_esc_seq_item::type_id::create("req");
-    start_item(req);
-    `DV_CHECK_RANDOMIZE_WITH_FATAL(req,
-        r_alert_ping_send == 1;
-        r_alert_rsp       == 0;
-    )
-    `uvm_info(`gfn, $sformatf("seq_item: ping_send, int_err=%0b", req.int_err), UVM_LOW)
-    finish_item(req);
-    get_response(rsp);
-    `uvm_info(`gfn, "alert receiver transfer done", UVM_HIGH)
-  endtask : body
+  constraint alert_receiver_seq_c {
+    r_alert_ping_send == 1;
+    r_alert_rsp       == 0;
+  }
 
 endclass : alert_receiver_seq

--- a/hw/dv/sv/alert_esc_agent/seq_lib/alert_sender_base_seq.sv
+++ b/hw/dv/sv/alert_esc_agent/seq_lib/alert_sender_base_seq.sv
@@ -1,0 +1,32 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// this is a base sequence for alert sender side
+class alert_sender_base_seq extends dv_base_seq #(
+    .REQ         (alert_esc_seq_item),
+    .CFG_T       (alert_esc_agent_cfg),
+    .SEQUENCER_T (alert_esc_sequencer)
+  );
+
+  `uvm_object_utils(alert_sender_base_seq)
+  `uvm_object_new
+
+  rand bit s_alert_send;
+  rand bit s_alert_ping_rsp;
+
+  virtual task body();
+    `uvm_info(`gfn, $sformatf("starting alert sender transfer"), UVM_HIGH)
+    req = alert_esc_seq_item::type_id::create("req");
+    start_item(req);
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(req,
+        s_alert_send     == local::s_alert_send;
+        s_alert_ping_rsp == local::s_alert_ping_rsp;
+    )
+    `uvm_info(`gfn, $sformatf("seq_item: ping_rsp, int_err=%0b", req.int_err), UVM_LOW)
+    finish_item(req);
+    get_response(rsp);
+    `uvm_info(`gfn, "alert sendver transfer done", UVM_HIGH)
+  endtask : body
+
+endclass : alert_sender_base_seq

--- a/hw/dv/sv/alert_esc_agent/seq_lib/alert_sender_ping_rsp_seq.sv
+++ b/hw/dv/sv/alert_esc_agent/seq_lib/alert_sender_ping_rsp_seq.sv
@@ -3,27 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // this sequence responses to ping pins by sending the alert pins
-class alert_sender_ping_rsp_seq extends dv_base_seq #(
-    .REQ         (alert_esc_seq_item),
-    .CFG_T       (alert_esc_agent_cfg),
-    .SEQUENCER_T (alert_esc_sequencer)
-  );
+class alert_sender_ping_rsp_seq extends alert_sender_base_seq;
 
   `uvm_object_utils(alert_sender_ping_rsp_seq)
   `uvm_object_new
 
-  virtual task body();
-    `uvm_info(`gfn, $sformatf("starting alert receiver transfer"), UVM_HIGH)
-    req = alert_esc_seq_item::type_id::create("req");
-    start_item(req);
-    `DV_CHECK_RANDOMIZE_WITH_FATAL(req,
-        s_alert_send     == 0;
-        s_alert_ping_rsp == 1;
-    )
-    `uvm_info(`gfn, $sformatf("seq_item: ping_rsp, int_err=%0b", req.int_err), UVM_LOW)
-    finish_item(req);
-    get_response(rsp);
-    `uvm_info(`gfn, "alert receiver transfer done", UVM_HIGH)
-  endtask : body
+  constraint alert_sender_ping_rsp_seq_c {
+    s_alert_send     == 0;
+    s_alert_ping_rsp == 1;
+  }
 
 endclass : alert_sender_ping_rsp_seq

--- a/hw/dv/sv/alert_esc_agent/seq_lib/alert_sender_seq.sv
+++ b/hw/dv/sv/alert_esc_agent/seq_lib/alert_sender_seq.sv
@@ -3,27 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // this sequence send the alert pins to the receiver
-class alert_sender_seq extends dv_base_seq #(
-    .REQ         (alert_esc_seq_item),
-    .CFG_T       (alert_esc_agent_cfg),
-    .SEQUENCER_T (alert_esc_sequencer)
-  );
+class alert_sender_seq extends alert_sender_base_seq;
 
   `uvm_object_utils(alert_sender_seq)
   `uvm_object_new
 
-  task body();
-    `uvm_info(`gfn, $sformatf("starting alert sender transfer"), UVM_HIGH)
-    req = alert_esc_seq_item::type_id::create("req");
-    start_item(req);
-    `DV_CHECK_RANDOMIZE_WITH_FATAL(req,
-        s_alert_send     == 1;
-        s_alert_ping_rsp == 0;
-    )
-    `uvm_info(`gfn, $sformatf("seq_item: alert_send, int_err=%0b", req.int_err), UVM_HIGH)
-    finish_item(req);
-    get_response(rsp);
-    `uvm_info(`gfn, "alert sender transfer done", UVM_HIGH)
-  endtask : body
+  constraint alert_sender_seq_c {
+    s_alert_send     == 1;
+    s_alert_ping_rsp == 0;
+  }
 
 endclass : alert_sender_seq


### PR DESCRIPTION
As Sri recommanded, use a base sequence to reduce code for alert seq

Signed-off-by: Cindy Chen <chencindy@google.com>