### PR TITLE
Fix ROM_INIT_FILE after build output changes

### DIFF
--- a/hw/top_earlgrey/top_earlgrey_nexysvideo.core
+++ b/hw/top_earlgrey/top_earlgrey_nexysvideo.core
@@ -30,14 +30,14 @@ filesets:
 parameters:
   # XXX: This parameter needs to be absolute, or relative to the *.runs/synth_1
   # directory. It's best to pass it as absolute path when invoking fusesoc, e.g.
-  # --ROM_INIT_FILE=$PWD/build-bin/sw/device/fpga/boot_rom/boot_rom.vmem
+  # --ROM_INIT_FILE=$PWD/build-bin/sw/device/boot_rom/boot_rom_fpga_nexysvideo.vmem
   # XXX: The VMEM file should be added to the sources of the Vivado project to
   # make the Vivado dependency tracking work. However this requires changes to
   # fusesoc first.
   ROM_INIT_FILE:
     datatype: str
     description: ROM initialization file in vmem hex format
-    default: "../../../../../build-bin/sw/device/fpga/boot_rom/boot_rom.vmem"
+    default: "../../../../../build-bin/sw/device/boot_rom/boot_rom_fpga_nexysvideo.vmem"
     paramtype: vlogdefine
   # For value definition, please see ip/prim/rtl/prim_pkg.sv
   PRIM_DEFAULT_IMPL:


### PR DESCRIPTION
Recent work changed the directory structure in the build output
directory. Adjust references to ROM_INIT_FILE which were forgotten.

Fixes #1586