### PR TITLE
[cleanup] This cleans up header comments in makefiles 

### DIFF
--- a/hw/dv/data/sim.mk
+++ b/hw/dv/data/sim.mk
@@ -1,8 +1,7 @@
-####################################################################################################
-## Copyright lowRISC contributors.                                                                ##
-## Licensed under the Apache License, Version 2.0, see LICENSE for details.                       ##
-## SPDX-License-Identifier: Apache-2.0                                                            ##
-####################################################################################################
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
 .DEFAULT_GOAL := all
 
 all: build run

--- a/hw/dv/tools/Makefile
+++ b/hw/dv/tools/Makefile
@@ -1,9 +1,6 @@
-####################################################################################################
-## Copyright lowRISC contributors.                                                                ##
-## Licensed under the Apache License, Version 2.0, see LICENSE for details.                       ##
-## SPDX-License-Identifier: Apache-2.0                                                            ##
-####################################################################################################
-
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
 # directory paths
 # _ROOT are paths indicating a 'starting point'
 # _PATH paths are intermediate paths leading to a _DIR
@@ -48,11 +45,11 @@ RUN_LOG           ?= ${RUN_DIR}/run.log
 UVM_VERBOSITY     ?= UVM_LOW
 
 TOPS              ?= ${TB_TOP} ${DUT_TOP}_bind
-####################################################################################################
-## Options for SV build / C build / simulation run                                                ##
-## CL_ prefix represents command line versions of these options - they should be empty and only   ##
-## be set on the command line                                                                     ##
-####################################################################################################
+
+# Options for SV build / C build / simulation run
+# CL_ prefix represents command line versions of these options - they should be empty and only
+# be set on the command line
+
 # BUILD_OPTS are passed to the simulator during the SV testbench compile step
 CL_BUILD_OPTS     +=
 BUILD_OPTS        += $(addprefix -top , $(TOPS))

--- a/hw/dv/tools/common_tests.mk
+++ b/hw/dv/tools/common_tests.mk
@@ -1,13 +1,10 @@
-####################################################################################################
-## Copyright lowRISC contributors.                                                                ##
-## Licensed under the Apache License, Version 2.0, see LICENSE for details.                       ##
-## SPDX-License-Identifier: Apache-2.0                                                            ##
-####################################################################################################
-## Makefile option groups that can be enabled by test Makefile / command line.                    ##
-## These are generic set of option groups that apply to all testbenches.                          ##
-## These are meant to be simulator agnostic                                                       ##
-## Please add tool specific options with appropriate ifeq's                                       ##
-####################################################################################################
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+# Makefile option groups that can be enabled by test Makefile / command line.
+# These are generic set of option groups that apply to all testbenches.
+# These are meant to be simulator agnostic
+# Please add tool specific options with appropriate ifeq's
 
 TEST_PREFIX     ?= ${DUT_TOP}
 

--- a/hw/dv/tools/fusesoc.mk
+++ b/hw/dv/tools/fusesoc.mk
@@ -1,14 +1,12 @@
-####################################################################################################
-## Copyright lowRISC contributors.                                                                ##
-## Licensed under the Apache License, Version 2.0, see LICENSE for details.                       ##
-## SPDX-License-Identifier: Apache-2.0                                                            ##
-####################################################################################################
-## Make variables specific to FUSESOC tool used for generating the filelist                       ##
-## The following Make variables are to be set in the Test Makefile                                ##
-## FUSESOC_CORE: the top level fusesoc core file developed for the ip/top level testbench         ##
-##               see hw/ip/uart/dv/uart_sim.core as an example                                    ##
-## Rest of the Make variables added here are intermeditiate ones used in the flow                 ##
-####################################################################################################
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+# Make variables specific to FUSESOC tool used for generating the filelist
+# The following Make variables are to be set in the Test Makefile
+# FUSESOC_CORE: the top level fusesoc core file developed for the ip/top level testbench
+#               see hw/ip/uart/dv/uart_sim.core as an example
+# Rest of the Make variables added here are intermeditiate ones used in the flow
+
 # fusesoc tool and options
 SV_FLIST_GEN_TOOL  ?= fusesoc
 SV_FLIST_GEN_OPTS  += --cores-root ${PROJ_ROOT} --cores-root ${RAL_MODEL_DIR} \

--- a/hw/dv/tools/modes.mk
+++ b/hw/dv/tools/modes.mk
@@ -1,13 +1,10 @@
-####################################################################################################
-## Copyright lowRISC contributors.                                                                ##
-## Licensed under the Apache License, Version 2.0, see LICENSE for details.                       ##
-## SPDX-License-Identifier: Apache-2.0                                                            ##
-####################################################################################################
-## Makefile option groups that can be enabled by test Makefile / command line.                    ##
-## These are generic set of option groups that apply to all testbenches.                          ##
-## These are meant to be simulator agnostic                                                       ##
-## Please add tool specific options with appropriate ifeq's                                       ##
-####################################################################################################
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+# Makefile option groups that can be enabled by test Makefile / command line.
+# These are generic set of option groups that apply to all testbenches.
+# These are meant to be simulator agnostic
+# Please add tool specific options with appropriate ifeq's
 
 # Distinguish UVM TB and the other environments for Verilator, FPGA etc
 BUILD_OPTS  += +define+UVM

--- a/hw/dv/tools/ral_gen.mk
+++ b/hw/dv/tools/ral_gen.mk
@@ -1,8 +1,7 @@
-####################################################################################################
-## Copyright lowRISC contributors.                                                                ##
-## Licensed under the Apache License, Version 2.0, see LICENSE for details.                       ##
-## SPDX-License-Identifier: Apache-2.0                                                            ##
-####################################################################################################
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
 # tool and options for generating the UVM RAL model
 RAL_SPEC      ?= ${DV_DIR}/../data/${DUT_TOP}.hjson
 RAL_MODEL_DIR ?= ${BUILD_DIR}/gen_ral_pkg

--- a/hw/dv/tools/rules.mk
+++ b/hw/dv/tools/rules.mk
@@ -1,8 +1,7 @@
-####################################################################################################
-## Copyright lowRISC contributors.                                                                ##
-## Licensed under the Apache License, Version 2.0, see LICENSE for details.                       ##
-## SPDX-License-Identifier: Apache-2.0                                                            ##
-####################################################################################################
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
 .DEFAULT_GOAL := all
 
 all: build run

--- a/hw/dv/tools/vcs/vcs.mk
+++ b/hw/dv/tools/vcs/vcs.mk
@@ -1,11 +1,8 @@
-####################################################################################################
-## Copyright lowRISC contributors.                                                                ##
-## Licensed under the Apache License, Version 2.0, see LICENSE for details.                       ##
-## SPDX-License-Identifier: Apache-2.0                                                            ##
-####################################################################################################
-## Makefile option groups that can be enabled by test Makefile / command line.                    ##
-## These are generic set of option groups that apply to all testbenches.                          ##
-####################################################################################################
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+# Makefile option groups that can be enabled by test Makefile / command line.
+# These are generic set of option groups that apply to all testbenches.
 # Simulator too specific options
 # Mandatory items to set (these are used by rules.mk):
 # SIMCC       - Simulator compiler used to build / elaborate the bench

--- a/hw/dv/tools/xcelium/xcelium.mk
+++ b/hw/dv/tools/xcelium/xcelium.mk
@@ -1,11 +1,8 @@
-####################################################################################################
-## Copyright lowRISC contributors.                                                                ##
-## Licensed under the Apache License, Version 2.0, see LICENSE for details.                       ##
-## SPDX-License-Identifier: Apache-2.0                                                            ##
-####################################################################################################
-## Makefile option groups that can be enabled by test Makefile / command line.                    ##
-## These are generic set of option groups that apply to all testbenches.                          ##
-####################################################################################################
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+# Makefile option groups that can be enabled by test Makefile / command line.
+# These are generic set of option groups that apply to all testbenches.
 # Simulator too specific options
 # Mandatory items to set (these are used by rules.mk):
 # SIMCC       - Simulator compiler used to build / elaborate the bench

--- a/hw/ip/aes/dv/Makefile
+++ b/hw/ip/aes/dv/Makefile
@@ -1,18 +1,16 @@
-####################################################################################################
-## Copyright lowRISC contributors.                                                                ##
-## Licensed under the Apache License, Version 2.0, see LICENSE for details.                       ##
-## SPDX-License-Identifier: Apache-2.0                                                            ##
-####################################################################################################
-## Entry point test Makefile forr building and running tests.                                     ##
-## These are generic set of option groups that apply to all testbenches.                          ##
-## This flow requires the following options to be set:                                            ##
-## DV_DIR       - current dv directory that contains the test Makefile                            ##
-## DUT_TOP      - top level dut module name                                                       ##
-## TB_TOP       - top level tb module name                                                        ##
-## DOTF         - .f file used for compilation                                                    ##
-## COMPILE_KEY  - compile option set                                                              ##
-## TEST_NAME    - name of the test to run - this is supplied on the command line                  ##
-####################################################################################################
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+# Entry point test Makefile for building and running tests.
+# These are generic set of option groups that apply to all testbenches.
+# This flow requires the following options to be set:
+# DV_DIR       - current dv directory that contains the test Makefile
+# DUT_TOP      - top level dut module name
+# TB_TOP       - top level tb module name
+# DOTF         - .f file used for compilation
+# COMPILE_KEY  - compile option set
+# TEST_NAME    - name of the test to run - this is supplied on the command line
+
 DV_DIR          := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 export DUT_TOP  := aes
 export TB_TOP   := tb
@@ -32,9 +30,9 @@ endif
 # Make GCC link OpenSSL/BoringSSL
 BUILD_OPTS += -lcrypto
 
-####################################################################################################
-##                     A D D    I N D I V I D U A L    T E S T S    B E L O W                     ##
-####################################################################################################
+##########################################################
+# A D D    I N D I V I D U A L    T E S T S    B E L O W #
+##########################################################
 # common tests/seqs
 include ${DV_DIR}/../../../dv/tools/common_tests.mk
 
@@ -50,10 +48,8 @@ ifeq (${TEST_NAME},aes_sanity)
   UVM_TEST_SEQ   = aes_sanity_vseq
 endif
 
-
-
-####################################################################################################
-## Include the tool Makefile below                                                                ##
-## Dont add anything else below it!                                                               ##
-####################################################################################################
+####################################
+# Include the tool Makefile below  #
+# Dont add anything else below it! #
+####################################
 include ${DV_DIR}/../../../dv/tools/Makefile

--- a/hw/ip/alert_handler/dv/Makefile
+++ b/hw/ip/alert_handler/dv/Makefile
@@ -1,18 +1,16 @@
-####################################################################################################
-## Copyright lowRISC contributors.                                                                ##
-## Licensed under the Apache License, Version 2.0, see LICENSE for details.                       ##
-## SPDX-License-Identifier: Apache-2.0                                                            ##
-####################################################################################################
-## Entry point test Makefile for building and running tests.                                      ##
-## These are generic set of option groups that apply to all testbenches.                          ##
-## This flow requires the following options to be set:                                            ##
-## DV_DIR       - current dv directory that contains the test Makefile                            ##
-## DUT_TOP      - top level dut module name                                                       ##
-## TB_TOP       - top level tb module name                                                        ##
-## DOTF         - .f file used for compilation                                                    ##
-## COMPILE_KEY  - compile option set                                                              ##
-## TEST_NAME    - name of the test to run - this is supplied on the command line                  ##
-####################################################################################################
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+# Entry point test Makefile for building and running tests.
+# These are generic set of option groups that apply to all testbenches.
+# This flow requires the following options to be set:
+# DV_DIR       - current dv directory that contains the test Makefile
+# DUT_TOP      - top level dut module name
+# TB_TOP       - top level tb module name
+# DOTF         - .f file used for compilation
+# COMPILE_KEY  - compile option set
+# TEST_NAME    - name of the test to run - this is supplied on the command line
+
 DV_DIR          := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 export DUT_TOP  := alert_handler
 export TB_TOP   := tb
@@ -22,9 +20,9 @@ COMPILE_KEY     ?= default
 UVM_TEST        ?= alert_handler_base_test
 UVM_TEST_SEQ    ?= alert_handler_base_vseq
 
-####################################################################################################
-##                     A D D    I N D I V I D U A L    T E S T S    B E L O W                     ##
-####################################################################################################
+##########################################################
+# A D D    I N D I V I D U A L    T E S T S    B E L O W #
+##########################################################
 TEST_NAME       ?= alert_handler_sanity
 UVM_TEST        ?= alert_handler_base_test
 UVM_TEST_SEQ    ?= alert_handler_base_vseq
@@ -36,8 +34,9 @@ UVM_TEST_SEQ    ?= alert_handler_base_vseq
  ifeq (${TEST_NAME},alert_handler_random_alerts)
    UVM_TEST_SEQ   = alert_handler_random_alerts_vseq
  endif
-####################################################################################################
-## Include the tool Makefile below                                                                ##
-## Dont add anything else below it!                                                               ##
-####################################################################################################
+
+####################################
+# Include the tool Makefile below  #
+# Dont add anything else below it! #
+####################################
 include ${DV_DIR}/../../../dv/tools/Makefile

--- a/hw/ip/gpio/dv/Makefile
+++ b/hw/ip/gpio/dv/Makefile
@@ -1,18 +1,15 @@
-####################################################################################################
-## Copyright lowRISC contributors.                                                                ##
-## Licensed under the Apache License, Version 2.0, see LICENSE for details.                       ##
-## SPDX-License-Identifier: Apache-2.0                                                            ##
-####################################################################################################
-## Entry point test Makefile forr building and running tests.                                     ##
-## These are generic set of option groups that apply to all testbenches.                          ##
-## This flow requires the following options to be set:                                            ##
-## DV_DIR       - current dv directory that contains the test Makefile                            ##
-## DUT_TOP      - top level dut module name                                                       ##
-## TB_TOP       - top level tb module name                                                        ##
-## DOTF         - .f file used for compilation                                                    ##
-## COMPILE_KEY  - compile option set                                                              ##
-## TEST_NAME    - name of the test to run - this is supplied on the command line                  ##
-####################################################################################################
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+# Entry point test Makefile for building and running tests.
+# These are generic set of option groups that apply to all testbenches.
+# This flow requires the following options to be set:
+# DV_DIR       - current dv directory that contains the test Makefile
+# DUT_TOP      - top level dut module name
+# TB_TOP       - top level tb module name
+# DOTF         - .f file used for compilation
+# COMPILE_KEY  - compile option set
+# TEST_NAME    - name of the test to run - this is supplied on the command line
 DV_DIR          := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 export DUT_TOP  := gpio
 export TB_TOP   := tb
@@ -20,9 +17,9 @@ FUSESOC_CORE    := lowrisc:dv:gpio_sim:0.1
 COMPILE_KEY     ?= default
 COV_DUT_EXCL    ?= ${DV_DIR}/cov/gpio_cov_excl.el
 
-####################################################################################################
-##                     A D D    I N D I V I D U A L    T E S T S    B E L O W                     ##
-####################################################################################################
+##########################################################
+# A D D    I N D I V I D U A L    T E S T S    B E L O W #
+##########################################################
 TEST_NAME       ?= gpio_sanity
 UVM_TEST        ?= gpio_base_test
 UVM_TEST_SEQ    ?= gpio_base_vseq
@@ -102,9 +99,10 @@ endif
 ifeq (${TEST_NAME},gpio_same_csr_outstanding)
   RUN_OPTS      += +do_clear_all_interrupts=0
 endif
-####################################################################################################
-## Include the tool Makefile below                                                                ##
-## Dont add anything else below it!                                                               ##
-####################################################################################################
+
+####################################
+# Include the tool Makefile below  #
+# Dont add anything else below it! #
+####################################
 include ${DV_DIR}/../../../dv/tools/Makefile
 

--- a/hw/ip/hmac/dv/Makefile
+++ b/hw/ip/hmac/dv/Makefile
@@ -1,18 +1,16 @@
-####################################################################################################
-## Copyright lowRISC contributors.                                                                ##
-## Licensed under the Apache License, Version 2.0, see LICENSE for details.                       ##
-## SPDX-License-Identifier: Apache-2.0                                                            ##
-####################################################################################################
-## Entry point test Makefile forr building and running tests.                                     ##
-## These are generic set of option groups that apply to all testbenches.                          ##
-## This flow requires the following options to be set:                                            ##
-## DV_DIR       - current dv directory that contains the test Makefile                            ##
-## DUT_TOP      - top level dut module name                                                       ##
-## TB_TOP       - top level tb module name                                                        ##
-## DOTF         - .f file used for compilation                                                    ##
-## COMPILE_KEY  - compile option set                                                              ##
-## TEST_NAME    - name of the test to run - this is supplied on the command line                  ##
-####################################################################################################
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+# Entry point test Makefile for building and running tests.
+# These are generic set of option groups that apply to all testbenches.
+# This flow requires the following options to be set:
+# DV_DIR       - current dv directory that contains the test Makefile
+# DUT_TOP      - top level dut module name
+# TB_TOP       - top level tb module name
+# DOTF         - .f file used for compilation
+# COMPILE_KEY  - compile option set
+# TEST_NAME    - name of the test to run - this is supplied on the command line
+
 DV_DIR          := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 export DUT_TOP  := hmac
 export TB_TOP   := tb
@@ -20,9 +18,9 @@ FUSESOC_CORE    := lowrisc:dv:hmac_sim:0.1
 COMPILE_KEY     ?= default
 COV_DUT_EXCL    ?= {DV_DIR}/cov/hmac_cov_excl.el
 
-####################################################################################################
-##                     A D D    I N D I V I D U A L    T E S T S    B E L O W                     ##
-####################################################################################################
+##########################################################
+# A D D    I N D I V I D U A L    T E S T S    B E L O W #
+##########################################################
 TEST_NAME       ?= hmac_sanity
 UVM_TEST        ?= hmac_base_test
 UVM_TEST_SEQ    ?= hmac_base_vseq
@@ -71,8 +69,8 @@ endif
 ifeq (${TEST_NAME},hmac_stress_all_with_rand_reset)
   RUN_OPTS      += +test_vectors_dir=${DV_DIR}/../../../dv/sv/test_vectors
 endif
-####################################################################################################
-## Include the tool Makefile below                                                                ##
-## Dont add anything else below it!                                                               ##
-####################################################################################################
+####################################
+# Include the tool Makefile below  #
+# Dont add anything else below it! #
+####################################
 include ${DV_DIR}/../../../dv/tools/Makefile

--- a/hw/ip/i2c/dv/Makefile
+++ b/hw/ip/i2c/dv/Makefile
@@ -1,27 +1,24 @@
-####################################################################################################
-## Copyright lowRISC contributors.                                                                ##
-## Licensed under the Apache License, Version 2.0, see LICENSE for details.                       ##
-## SPDX-License-Identifier: Apache-2.0                                                            ##
-####################################################################################################
-## Entry point test Makefile forr building and running tests.                                     ##
-## These are generic set of option groups that apply to all testbenches.                          ##
-## This flow requires the following options to be set:                                            ##
-## DV_DIR       - current dv directory that contains the test Makefile                            ##
-## DUT_TOP      - top level dut module name                                                       ##
-## TB_TOP       - top level tb module name                                                        ##
-## DOTF         - .f file used for compilation                                                    ##
-## COMPILE_KEY  - compile option set                                                              ##
-## TEST_NAME    - name of the test to run - this is supplied on the command line                  ##
-####################################################################################################
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+# Entry point test Makefile for building and running tests.
+# These are generic set of option groups that apply to all testbenches.
+# This flow requires the following options to be set:
+# DV_DIR       - current dv directory that contains the test Makefile
+# DUT_TOP      - top level dut module name
+# TB_TOP       - top level tb module name
+# DOTF         - .f file used for compilation
+# COMPILE_KEY  - compile option set
+# TEST_NAME    - name of the test to run - this is supplied on the command line
 DV_DIR          := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 export DUT_TOP  := i2c
 export TB_TOP   := tb
 FUSESOC_CORE    := lowrisc:dv:i2c_sim:0.1
 COMPILE_KEY     ?= default
 
-####################################################################################################
-##                     A D D    I N D I V I D U A L    T E S T S    B E L O W                     ##
-####################################################################################################
+##########################################################
+# A D D    I N D I V I D U A L    T E S T S    B E L O W #
+##########################################################
 # common tests/seqs
 include ${DV_DIR}/../../../dv/tools/common_tests.mk
 
@@ -34,8 +31,8 @@ ifeq (${TEST_NAME},i2c_sanity)
   RUN_OPTS      += +en_scb=0
 endif
 
-####################################################################################################
-## Include the tool Makefile below                                                                ##
-## Dont add anything else below it!                                                               ##
-####################################################################################################
+####################################
+# Include the tool Makefile below  #
+# Dont add anything else below it! #
+####################################
 include ${DV_DIR}/../../../dv/tools/Makefile

--- a/hw/ip/prim/dv/Makefile
+++ b/hw/ip/prim/dv/Makefile
@@ -1,24 +1,21 @@
-####################################################################################################
-## Copyright lowRISC contributors.                                                                ##
-## Licensed under the Apache License, Version 2.0, see LICENSE for details.                       ##
-## SPDX-License-Identifier: Apache-2.0                                                            ##
-####################################################################################################
-## Entry point test Makefile forr building and running tests.                                     ##
-## These are generic set of option groups that apply to all testbenches.                          ##
-## This flow requires the following options to be set:                                            ##
-## DV_DIR       - current dv directory that contains the test Makefile                            ##
-## DUT_TOP      - top level dut module name                                                       ##
-## TB_TOP       - top level tb module name                                                        ##
-## DOTF         - .f file used for compilation                                                    ##
-## COMPILE_KEY  - compile option set                                                              ##
-## TEST_NAME    - name of the test to run - this is supplied on the command line                  ##
-####################################################################################################
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+# Entry point test Makefile for building and running tests.
+# These are generic set of option groups that apply to all testbenches.
+# This flow requires the following options to be set:
+# DV_DIR       - current dv directory that contains the test Makefile
+# DUT_TOP      - top level dut module name
+# TB_TOP       - top level tb module name
+# DOTF         - .f file used for compilation
+# COMPILE_KEY  - compile option set
+# TEST_NAME    - name of the test to run - this is supplied on the command line
 DV_DIR          := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 COMPILE_KEY     ?= default
 
-####################################################################################################
-##                     A D D    I N D I V I D U A L    T E S T S    B E L O W                     ##
-####################################################################################################
+##########################################################
+# A D D    I N D I V I D U A L    T E S T S    B E L O W #
+##########################################################
 
 ifeq (${TEST_NAME},prim_lfsr_gal_xor)
   export DUT_TOP := prim_lfsr
@@ -42,8 +39,8 @@ ifeq (${COMPILE_KEY},fib_xnor)
   BUILD_OPTS  := +define+LFSR_TYPE="\"FIB_XNOR\""+MAX_LFSR_DW=28+MIN_LFSR_DW=3
 endif
 
-####################################################################################################
-## Include the tool Makefile below                                                                ##
-## Dont add anything else below it!                                                               ##
-####################################################################################################
+####################################
+# Include the tool Makefile below  #
+# Dont add anything else below it! #
+####################################
 include ${DV_DIR}/../../../dv/tools/Makefile

--- a/hw/ip/rv_dm/dv/Makefile
+++ b/hw/ip/rv_dm/dv/Makefile
@@ -1,18 +1,15 @@
-####################################################################################################
-## Copyright lowRISC contributors.                                                                ##
-## Licensed under the Apache License, Version 2.0, see LICENSE for details.                       ##
-## SPDX-License-Identifier: Apache-2.0                                                            ##
-####################################################################################################
-## Entry point test Makefile forr building and running tests.                                     ##
-## These are generic set of option groups that apply to all testbenches.                          ##
-## This flow requires the following options to be set:                                            ##
-## DV_DIR       - current dv directory that contains the test Makefile                            ##
-## DUT_TOP      - top level dut module name                                                       ##
-## TB_TOP       - top level tb module name                                                        ##
-## DOTF         - .f file used for compilation                                                    ##
-## COMPILE_KEY  - compile option set                                                              ##
-## TEST_NAME    - name of the test to run - this is supplied on the command line                  ##
-####################################################################################################
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+# Entry point test Makefile for building and running tests.
+# These are generic set of option groups that apply to all testbenches.
+# This flow requires the following options to be set:
+# DV_DIR       - current dv directory that contains the test Makefile
+# DUT_TOP      - top level dut module name
+# TB_TOP       - top level tb module name
+# DOTF         - .f file used for compilation
+# COMPILE_KEY  - compile option set
+# TEST_NAME    - name of the test to run - this is supplied on the command line
 DV_DIR          := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 export DUT_TOP  := rv_dm
 export TB_TOP   := tb
@@ -22,9 +19,9 @@ COMPILE_KEY     ?= default
 UVM_TEST        ?= rv_dm_base_test
 UVM_TEST_SEQ    ?= rv_dm_base_vseq
 
-####################################################################################################
-##                     A D D    I N D I V I D U A L    T E S T S    B E L O W                     ##
-####################################################################################################
+##########################################################
+# A D D    I N D I V I D U A L    T E S T S    B E L O W #
+##########################################################
 TEST_NAME       ?= rv_dm_sanity
 UVM_TEST        ?= rv_dm_base_test
 UVM_TEST_SEQ    ?= rv_dm_base_vseq
@@ -64,8 +61,8 @@ endif
   RUN_OPTS      += +en_scb=0
 endif
 
-####################################################################################################
-## Include the tool Makefile below                                                                ##
-## Dont add anything else below it!                                                               ##
-####################################################################################################
+####################################
+# Include the tool Makefile below  #
+# Dont add anything else below it! #
+####################################
 include ${DV_DIR}/../../../dv/tools/Makefile

--- a/hw/ip/rv_timer/dv/Makefile
+++ b/hw/ip/rv_timer/dv/Makefile
@@ -1,27 +1,24 @@
-####################################################################################################
-## Copyright lowRISC contributors.                                                                ##
-## Licensed under the Apache License, Version 2.0, see LICENSE for details.                       ##
-## SPDX-License-Identifier: Apache-2.0                                                            ##
-####################################################################################################
-## Entry point test Makefile forr building and running tests.                                     ##
-## These are generic set of option groups that apply to all testbenches.                          ##
-## This flow requires the following options to be set:                                            ##
-## DV_DIR       - current dv directory that contains the test Makefile                            ##
-## DUT_TOP      - top level dut module name                                                       ##
-## TB_TOP       - top level tb module name                                                        ##
-## DOTF         - .f file used for compilation                                                    ##
-## COMPILE_KEY  - compile option set                                                              ##
-## TEST_NAME    - name of the test to run - this is supplied on the command line                  ##
-####################################################################################################
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+# Entry point test Makefile for building and running tests.
+# These are generic set of option groups that apply to all testbenches.
+# This flow requires the following options to be set:
+# DV_DIR       - current dv directory that contains the test Makefile
+# DUT_TOP      - top level dut module name
+# TB_TOP       - top level tb module name
+# DOTF         - .f file used for compilation
+# COMPILE_KEY  - compile option set
+# TEST_NAME    - name of the test to run - this is supplied on the command line
 DV_DIR          := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 export DUT_TOP  := rv_timer
 export TB_TOP   := tb
 FUSESOC_CORE    := lowrisc:dv:rv_timer_sim:0.1
 COMPILE_KEY     ?= default
 
-####################################################################################################
-##                     A D D    I N D I V I D U A L    T E S T S    B E L O W                     ##
-####################################################################################################
+##########################################################
+# A D D    I N D I V I D U A L    T E S T S    B E L O W #
+##########################################################
 TEST_NAME       ?= rv_timer_sanity
 UVM_TEST        ?= rv_timer_base_test
 UVM_TEST_SEQ    ?= rv_timer_base_vseq
@@ -52,9 +49,9 @@ ifeq (${TEST_NAME},rv_timer_stress_all)
   RUN_OPTS      += +test_timeout_ns=10_000_000_000
 endif
 
-####################################################################################################
-## Include the tool Makefile below                                                                ##
-## Dont add anything else below it!                                                               ##
-####################################################################################################
+####################################
+# Include the tool Makefile below  #
+# Dont add anything else below it! #
+####################################
 include ${DV_DIR}/../../../dv/tools/Makefile
 

--- a/hw/ip/spi_device/dv/Makefile
+++ b/hw/ip/spi_device/dv/Makefile
@@ -1,27 +1,24 @@
-####################################################################################################
-## Copyright lowRISC contributors.                                                                ##
-## Licensed under the Apache License, Version 2.0, see LICENSE for details.                       ##
-## SPDX-License-Identifier: Apache-2.0                                                            ##
-####################################################################################################
-## Entry point test Makefile forr building and running tests.                                     ##
-## These are generic set of option groups that apply to all testbenches.                          ##
-## This flow requires the following options to be set:                                            ##
-## DV_DIR       - current dv directory that contains the test Makefile                            ##
-## DUT_TOP      - top level dut module name                                                       ##
-## TB_TOP       - top level tb module name                                                        ##
-## DOTF         - .f file used for compilation                                                    ##
-## COMPILE_KEY  - compile option set                                                              ##
-## TEST_NAME    - name of the test to run - this is supplied on the command line                  ##
-####################################################################################################
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+# Entry point test Makefile for building and running tests.
+# These are generic set of option groups that apply to all testbenches.
+# This flow requires the following options to be set:
+# DV_DIR       - current dv directory that contains the test Makefile
+# DUT_TOP      - top level dut module name
+# TB_TOP       - top level tb module name
+# DOTF         - .f file used for compilation
+# COMPILE_KEY  - compile option set
+# TEST_NAME    - name of the test to run - this is supplied on the command line
 DV_DIR          := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 export DUT_TOP  := spi_device
 export TB_TOP   := tb
 FUSESOC_CORE    := lowrisc:dv:spi_device_sim:0.1
 COMPILE_KEY     ?= default
 
-####################################################################################################
-##                     A D D    I N D I V I D U A L    T E S T S    B E L O W                     ##
-####################################################################################################
+##########################################################
+# A D D    I N D I V I D U A L    T E S T S    B E L O W #
+##########################################################
 TEST_NAME       ?= spi_device_sanity
 UVM_TEST        ?= spi_device_base_test
 UVM_TEST_SEQ    ?= spi_device_base_vseq
@@ -53,8 +50,8 @@ ifeq (${TEST_NAME},spi_device_dummy_item_extra_dly)
   UVM_TEST_SEQ   = spi_device_dummy_item_extra_dly_vseq
 endif
 
-####################################################################################################
-## Include the tool Makefile below                                                                ##
-## Dont add anything else below it!                                                               ##
-####################################################################################################
+####################################
+# Include the tool Makefile below  #
+# Dont add anything else below it! #
+####################################
 include ${DV_DIR}/../../../dv/tools/Makefile

--- a/hw/ip/tlul/generic_dv/xbar.mk
+++ b/hw/ip/tlul/generic_dv/xbar.mk
@@ -1,24 +1,21 @@
-####################################################################################################
-## Copyright lowRISC contributors.                                                                ##
-## Licensed under the Apache License, Version 2.0, see LICENSE for details.                       ##
-## SPDX-License-Identifier: Apache-2.0                                                            ##
-####################################################################################################
-## Entry point test Makefile forr building and running tests.                                     ##
-## These are generic set of option groups that apply to all testbenches.                          ##
-## This flow requires the following options to be set:                                            ##
-## DV_DIR       - current dv directory that contains the test Makefile                            ##
-## DUT_TOP      - top level dut module name                                                       ##
-## TB_TOP       - top level tb module name                                                        ##
-## DOTF         - .f file used for compilation                                                    ##
-## COMPILE_KEY  - compile option set                                                              ##
-## TEST_NAME    - name of the test to run - this is supplied on the command line                  ##
-####################################################################################################
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+# Entry point test Makefile for building and running tests.
+# These are generic set of option groups that apply to all testbenches.
+# This flow requires the following options to be set:
+# DV_DIR       - current dv directory that contains the test Makefile
+# DUT_TOP      - top level dut module name
+# TB_TOP       - top level tb module name
+# DOTF         - .f file used for compilation
+# COMPILE_KEY  - compile option set
+# TEST_NAME    - name of the test to run - this is supplied on the command line
 export TB_TOP   := tb
 COMPILE_KEY     ?= default
 
-####################################################################################################
-##                     A D D    I N D I V I D U A L    T E S T S    B E L O W                     ##
-####################################################################################################
+##########################################################
+# A D D    I N D I V I D U A L    T E S T S    B E L O W #
+##########################################################
 TEST_NAME       ?= xbar_sanity
 UVM_TEST        ?= xbar_base_test
 UVM_TEST_SEQ    ?= xbar_base_vseq
@@ -122,8 +119,8 @@ ifeq (${TEST_NAME},xbar_stress_all_with_reset_error)
   UVM_TEST_SEQ   = xbar_stress_all_with_rand_reset_vseq
 endif
 
-####################################################################################################
-## Include the tool Makefile below                                                                ##
-## Dont add anything else below it!                                                               ##
-####################################################################################################
+####################################
+# Include the tool Makefile below  #
+# Dont add anything else below it! #
+####################################
 include ${DV_DIR}/../../../dv/tools/Makefile

--- a/hw/ip/trial1/dv/Makefile
+++ b/hw/ip/trial1/dv/Makefile
@@ -1,18 +1,15 @@
-####################################################################################################
-## Copyright lowRISC contributors.                                                                ##
-## Licensed under the Apache License, Version 2.0, see LICENSE for details.                       ##
-## SPDX-License-Identifier: Apache-2.0                                                            ##
-####################################################################################################
-## Entry point test Makefile forr building and running tests.                                     ##
-## These are generic set of option groups that apply to all testbenches.                          ##
-## This flow requires the following options to be set:                                            ##
-## DV_DIR       - current dv directory that contains the test Makefile                            ##
-## DUT_TOP      - top level dut module name                                                       ##
-## TB_TOP       - top level tb module name                                                        ##
-## DOTF         - .f file used for compilation                                                    ##
-## COMPILE_KEY  - compile option set                                                              ##
-## TEST_NAME    - name of the test to run - this is supplied on the command line                  ##
-####################################################################################################
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+# Entry point test Makefile for building and running tests.
+# These are generic set of option groups that apply to all testbenches.
+# This flow requires the following options to be set:
+# DV_DIR       - current dv directory that contains the test Makefile
+# DUT_TOP      - top level dut module name
+# TB_TOP       - top level tb module name
+# DOTF         - .f file used for compilation
+# COMPILE_KEY  - compile option set
+# TEST_NAME    - name of the test to run - this is supplied on the command line
 DV_DIR          := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 export DUT_TOP  := trial1_reg_top
 export TB_TOP   := tb
@@ -22,8 +19,8 @@ TOPS            ?= ${TB_TOP}
 TEST_NAME       ?= trial1_sanity
 UVM_TEST        ?= ${TEST_NAME}
 
-####################################################################################################
-## Include the tool Makefile below                                                                ##
-## Dont add anything else below it!                                                               ##
-####################################################################################################
+####################################
+# Include the tool Makefile below  #
+# Dont add anything else below it! #
+####################################
 include ${DV_DIR}/../../../dv/tools/Makefile

--- a/hw/ip/uart/dv/Makefile
+++ b/hw/ip/uart/dv/Makefile
@@ -1,18 +1,15 @@
-####################################################################################################
-## Copyright lowRISC contributors.                                                                ##
-## Licensed under the Apache License, Version 2.0, see LICENSE for details.                       ##
-## SPDX-License-Identifier: Apache-2.0                                                            ##
-####################################################################################################
-## Entry point test Makefile forr building and running tests.                                     ##
-## These are generic set of option groups that apply to all testbenches.                          ##
-## This flow requires the following options to be set:                                            ##
-## DV_DIR       - current dv directory that contains the test Makefile                            ##
-## DUT_TOP      - top level dut module name                                                       ##
-## TB_TOP       - top level tb module name                                                        ##
-## DOTF         - .f file used for compilation                                                    ##
-## COMPILE_KEY  - compile option set                                                              ##
-## TEST_NAME    - name of the test to run - this is supplied on the command line                  ##
-####################################################################################################
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+# Entry point test Makefile for building and running tests.
+# These are generic set of option groups that apply to all testbenches.
+# This flow requires the following options to be set:
+# DV_DIR       - current dv directory that contains the test Makefile
+# DUT_TOP      - top level dut module name
+# TB_TOP       - top level tb module name
+# DOTF         - .f file used for compilation
+# COMPILE_KEY  - compile option set
+# TEST_NAME    - name of the test to run - this is supplied on the command line
 DV_DIR          := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 export DUT_TOP  := uart
 export TB_TOP   := tb
@@ -20,9 +17,9 @@ FUSESOC_CORE    := lowrisc:dv:uart_sim:0.1
 COMPILE_KEY     ?= default
 
 COV_DUT_EXCL    ?= ${DV_DIR}/cov/uart_cov_excl.el
-####################################################################################################
-##                     A D D    I N D I V I D U A L    T E S T S    B E L O W                     ##
-####################################################################################################
+##########################################################
+# A D D    I N D I V I D U A L    T E S T S    B E L O W #
+##########################################################
 TEST_NAME       ?= uart_sanity
 UVM_TEST        ?= uart_base_test
 UVM_TEST_SEQ    ?= uart_base_vseq
@@ -90,8 +87,8 @@ ifeq (${TEST_NAME},uart_stress_all)
   UVM_TEST_SEQ   = uart_stress_all_vseq
 endif
 
-####################################################################################################
-## Include the tool Makefile below                                                                ##
-## Dont add anything else below it!                                                               ##
-####################################################################################################
+####################################
+# Include the tool Makefile below  #
+# Dont add anything else below it! #
+####################################
 include ${DV_DIR}/../../../dv/tools/Makefile

--- a/hw/lint/data/lint.mk
+++ b/hw/lint/data/lint.mk
@@ -1,8 +1,6 @@
-####################################################################################################
-## Copyright lowRISC contributors.                                                                ##
-## Licensed under the Apache License, Version 2.0, see LICENSE for details.                       ##
-## SPDX-License-Identifier: Apache-2.0                                                            ##
-####################################################################################################
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
 .DEFAULT_GOAL := all
 
 all: build

--- a/hw/top_earlgrey/dv/Makefile
+++ b/hw/top_earlgrey/dv/Makefile
@@ -1,18 +1,15 @@
-####################################################################################################
-## Copyright lowRISC contributors.                                                                ##
-## Licensed under the Apache License, Version 2.0, see LICENSE for details.                       ##
-## SPDX-License-Identifier: Apache-2.0                                                            ##
-####################################################################################################
-## Entry point test Makefile forr building and running tests.                                     ##
-## These are generic set of option groups that apply to all testbenches.                          ##
-## This flow requires the following options to be set:                                            ##
-## DV_DIR       - current dv directory that contains the test Makefile                            ##
-## DUT_TOP      - top level dut module name                                                       ##
-## TB_TOP       - top level tb module name                                                        ##
-## DOTF         - .f file used for compilation                                                    ##
-## COMPILE_KEY  - compile option set                                                              ##
-## TEST_NAME    - name of the test to run - this is supplied on the command line                  ##
-####################################################################################################
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+# Entry point test Makefile for building and running tests.
+# These are generic set of option groups that apply to all testbenches.
+# This flow requires the following options to be set:
+# DV_DIR       - current dv directory that contains the test Makefile
+# DUT_TOP      - top level dut module name
+# TB_TOP       - top level tb module name
+# DOTF         - .f file used for compilation
+# COMPILE_KEY  - compile option set
+# TEST_NAME    - name of the test to run - this is supplied on the command line
 DV_DIR          := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 export DUT_TOP  := top_earlgrey
 export TB_TOP   := tb
@@ -32,9 +29,9 @@ endif
 # Use generic implementations of prim modules.
 BUILD_OPTS      += +define+PRIM_DEFAULT_IMPL=prim_pkg::ImplGeneric
 
-####################################################################################################
-##                     A D D    I N D I V I D U A L    T E S T S    B E L O W                     ##
-####################################################################################################
+##########################################################
+# A D D    I N D I V I D U A L    T E S T S    B E L O W #
+##########################################################
 TEST_NAME       ?= chip_sanity
 UVM_TEST        ?= chip_base_test
 UVM_TEST_SEQ    ?= chip_base_vseq
@@ -102,8 +99,8 @@ ifeq (${TEST_NAME},chip_csr_aliasing)
 endif
 
 
-####################################################################################################
-## Include the tool Makefile below                                                                ##
-## Dont add anything else below it!                                                               ##
-####################################################################################################
+####################################
+# Include the tool Makefile below  #
+# Dont add anything else below it! #
+####################################
 include ${DV_DIR}/../../dv/tools/Makefile


### PR DESCRIPTION
This cleans up the header comments with the lowRISC license in makefiles and aligns them with the style we use project wide.

Note that it is dependent on #1596, so do not merge before that went in.