### PR TITLE
 [cleanup] Remove shebang from non-standalone files

### DIFF
--- a/test/systemtest/conftest.py
+++ b/test/systemtest/conftest.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0

--- a/test/systemtest/functional_fpga_test.py
+++ b/test/systemtest/functional_fpga_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0

--- a/test/systemtest/functional_verilator_test.py
+++ b/test/systemtest/functional_verilator_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0

--- a/test/systemtest/openocd_verilator_test.py
+++ b/test/systemtest/openocd_verilator_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0

--- a/test/systemtest/test_utils.py
+++ b/test/systemtest/test_utils.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0

--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0

--- a/util/dvsim/FlowCfg.py
+++ b/util/dvsim/FlowCfg.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0

--- a/util/dvsim/LintCfg.py
+++ b/util/dvsim/LintCfg.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0

--- a/util/dvsim/Modes.py
+++ b/util/dvsim/Modes.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0

--- a/util/dvsim/OneShotCfg.py
+++ b/util/dvsim/OneShotCfg.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0

--- a/util/dvsim/utils.py
+++ b/util/dvsim/utils.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0

--- a/util/fpvgen/sv_parse.py
+++ b/util/fpvgen/sv_parse.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0

--- a/util/reggen/gen_json.py
+++ b/util/reggen/gen_json.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0

--- a/util/testplanner/class_defs.py
+++ b/util/testplanner/class_defs.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0

--- a/util/testplanner/testplan_utils.py
+++ b/util/testplanner/testplan_utils.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
This removes the shebang line in python files that are not directly run as scripts. This is a follow up for this https://github.com/lowRISC/opentitan/pull/1596#discussion_r383358518 . Let me know if you think this should not be removed in certain files.

Note that it is dependent on #1596, so do not merge before that went in.