### PR TITLE
[sw/dif] Introduce a DIF for spi_device

### DIFF
--- a/sw/device/lib/dif/dif_spi_device.c
+++ b/sw/device/lib/dif/dif_spi_device.c
@@ -1,0 +1,696 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/dif/dif_spi_device.h"
+
+#include "spi_device_regs.h"  // Generated.
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/memory.h"
+
+const uint16_t kDifSpiDeviceBufferLen = SPI_DEVICE_BUFFER_SIZE_BYTES;
+
+/**
+ * Computes the required value of the control register from a given
+ * configuration.
+ */
+static dif_spi_device_result_t build_control_word(
+    const dif_spi_device_config_t *config, uint32_t *control_word) {
+  *control_word = 0;
+
+  // Default polarity is positive.
+  if (config->clock_polarity == kDifSpiDeviceEdgeNegative) {
+    *control_word |= 0x1 << SPI_DEVICE_CFG_CPOL;
+  }
+
+  // Default phase is negative.
+  if (config->data_phase == kDifSpiDeviceEdgePositive) {
+    *control_word |= 0x1 << SPI_DEVICE_CFG_CPHA;
+  }
+
+  // Default order is msb to lsb.
+  if (config->tx_order == kDifSpiDeviceBitOrderLsbToMsb) {
+    *control_word |= 0x1 << SPI_DEVICE_CFG_TX_ORDER;
+  }
+
+  // Default order is msb to lsb.
+  if (config->rx_order == kDifSpiDeviceBitOrderLsbToMsb) {
+    *control_word |= 0x1 << SPI_DEVICE_CFG_RX_ORDER;
+  }
+
+  *control_word = bitfield_set_field32(
+      *control_word, (bitfield_field32_t){
+                         .mask = SPI_DEVICE_CFG_TIMER_V_MASK,
+                         .index = SPI_DEVICE_CFG_TIMER_V_OFFSET,
+                         .value = config->rx_fifo_timeout,
+                     });
+
+  return kDifSpiDeviceResultOk;
+}
+
+dif_spi_device_result_t dif_spi_device_init(
+    mmio_region_t base_addr, const dif_spi_device_config_t *config,
+    dif_spi_device_t *spi) {
+  if (config == NULL || spi == NULL) {
+    return kDifSpiDeviceResultBadArg;
+  }
+  spi->base_addr = base_addr;
+
+  // NOTE: we do not write to any registers until performing all
+  // function argument checks, to avoid a halfway-configured SPI.
+
+  uint32_t device_config;
+  dif_spi_device_result_t control_error =
+      build_control_word(config, &device_config);
+  if (control_error != kDifSpiDeviceResultOk) {
+    return control_error;
+  }
+
+  uint16_t rx_fifo_start = 0x0;
+  uint16_t rx_fifo_end = config->rx_fifo_len - 1;
+  uint16_t tx_fifo_start = rx_fifo_end + 1;
+  uint16_t tx_fifo_end = tx_fifo_start + config->tx_fifo_len - 1;
+  if (tx_fifo_end >= kDifSpiDeviceBufferLen) {
+    // We've overflown the SRAM region...
+    return kDifSpiDeviceResultBadArg;
+  }
+
+  uint32_t rx_fifo_bounds = 0;
+  rx_fifo_bounds = bitfield_set_field32(
+      rx_fifo_bounds, (bitfield_field32_t){
+                          .mask = SPI_DEVICE_RXF_ADDR_BASE_MASK,
+                          .index = SPI_DEVICE_RXF_ADDR_BASE_OFFSET,
+                          .value = rx_fifo_start,
+                      });
+  rx_fifo_bounds = bitfield_set_field32(
+      rx_fifo_bounds, (bitfield_field32_t){
+                          .mask = SPI_DEVICE_RXF_ADDR_LIMIT_MASK,
+                          .index = SPI_DEVICE_RXF_ADDR_LIMIT_OFFSET,
+                          .value = rx_fifo_end,
+                      });
+
+  uint32_t tx_fifo_bounds = 0;
+  tx_fifo_bounds = bitfield_set_field32(
+      tx_fifo_bounds, (bitfield_field32_t){
+                          .mask = SPI_DEVICE_TXF_ADDR_BASE_MASK,
+                          .index = SPI_DEVICE_TXF_ADDR_BASE_OFFSET,
+                          .value = tx_fifo_start,
+                      });
+  tx_fifo_bounds = bitfield_set_field32(
+      tx_fifo_bounds, (bitfield_field32_t){
+                          .mask = SPI_DEVICE_TXF_ADDR_LIMIT_MASK,
+                          .index = SPI_DEVICE_TXF_ADDR_LIMIT_OFFSET,
+                          .value = tx_fifo_end,
+                      });
+
+  spi->rx_fifo_base = rx_fifo_start;
+  spi->rx_fifo_len = config->rx_fifo_len;
+  spi->tx_fifo_base = tx_fifo_start;
+  spi->tx_fifo_len = config->tx_fifo_len;
+
+  // Now that we know that all function arguments are valid, we can abort
+  // all current transactions and begin reconfiguring the device.
+  dif_spi_device_result_t err;
+  err = dif_spi_device_abort(spi);
+  if (err != kDifSpiDeviceResultOk) {
+    return err;
+  }
+  err = dif_spi_device_irq_reset(spi);
+  if (err != kDifSpiDeviceResultOk) {
+    return err;
+  }
+
+  mmio_region_write32(spi->base_addr, SPI_DEVICE_CFG_REG_OFFSET, device_config);
+  mmio_region_write32(spi->base_addr, SPI_DEVICE_RXF_ADDR_REG_OFFSET,
+                      rx_fifo_bounds);
+  mmio_region_write32(spi->base_addr, SPI_DEVICE_TXF_ADDR_REG_OFFSET,
+                      tx_fifo_bounds);
+
+  return kDifSpiDeviceResultOk;
+}
+
+dif_spi_device_result_t dif_spi_device_abort(const dif_spi_device_t *spi) {
+  if (spi == NULL) {
+    return kDifSpiDeviceResultBadArg;
+  }
+
+  // Set the `abort` bit, and then spin until `abort_done` is asserted.
+  mmio_region_nonatomic_set_bit32(spi->base_addr, SPI_DEVICE_CONTROL_REG_OFFSET,
+                                  SPI_DEVICE_CONTROL_ABORT);
+  while (!mmio_region_get_bit32(spi->base_addr, SPI_DEVICE_STATUS_REG_OFFSET,
+                                SPI_DEVICE_STATUS_ABORT_DONE)) {
+  }
+
+  return kDifSpiDeviceResultOk;
+}
+
+dif_spi_device_result_t dif_spi_device_irq_reset(const dif_spi_device_t *spi) {
+  if (spi == NULL) {
+    return kDifSpiDeviceResultBadArg;
+  }
+
+  dif_spi_device_result_t err;
+
+  err = dif_spi_device_irq_clear_all(spi);
+  if (err != kDifSpiDeviceResultOk) {
+    return err;
+  }
+  err = dif_spi_device_set_irq_levels(spi, 0x80, 0x00);
+  if (err != kDifSpiDeviceResultOk) {
+    return err;
+  }
+
+  // Disable interrupts manually, since the relevant DIF only allows for single
+  // bit flips.
+  mmio_region_write32(spi->base_addr, SPI_DEVICE_INTR_ENABLE_REG_OFFSET, 0);
+
+  return kDifSpiDeviceResultOk;
+}
+
+dif_spi_device_result_t dif_spi_device_irq_get(const dif_spi_device_t *spi,
+                                               dif_spi_device_irq_type_t type,
+                                               bool *flag_out) {
+  if (spi == NULL || flag_out == NULL) {
+    return kDifSpiDeviceResultBadArg;
+  }
+
+  uint32_t bit_index = 0;
+  switch (type) {
+    case kDifSpiDeviceIrqTypeRxFull:
+      bit_index = SPI_DEVICE_INTR_STATE_RXF;
+      break;
+    case kDifSpiDeviceIrqTypeRxAboveLevel:
+      bit_index = SPI_DEVICE_INTR_STATE_RXLVL;
+      break;
+    case kDifSpiDeviceIrqTypeTxBelowLevel:
+      bit_index = SPI_DEVICE_INTR_STATE_TXLVL;
+      break;
+    case kDifSpiDeviceIrqTypeRxError:
+      bit_index = SPI_DEVICE_INTR_STATE_RXERR;
+      break;
+    case kDifSpiDeviceIrqTypeRxOverflow:
+      bit_index = SPI_DEVICE_INTR_STATE_RXOVERFLOW;
+      break;
+    case kDifSpiDeviceIrqTypeTxUnderflow:
+      bit_index = SPI_DEVICE_INTR_STATE_TXUNDERFLOW;
+      break;
+  }
+
+  *flag_out = mmio_region_get_bit32(
+      spi->base_addr, SPI_DEVICE_INTR_STATE_REG_OFFSET, bit_index);
+  return kDifSpiDeviceResultOk;
+}
+
+dif_spi_device_result_t dif_spi_device_irq_clear_all(
+    const dif_spi_device_t *spi) {
+  if (spi == NULL) {
+    return kDifSpiDeviceResultBadArg;
+  }
+
+  // The state register is a write-one-clear register.
+  mmio_region_write32(spi->base_addr, SPI_DEVICE_INTR_STATE_REG_OFFSET,
+                      UINT32_MAX);
+
+  return kDifSpiDeviceResultOk;
+}
+
+dif_spi_device_result_t dif_spi_device_irq_enable(
+    const dif_spi_device_t *spi, dif_spi_device_irq_type_t type,
+    dif_spi_device_irq_state_t state) {
+  if (spi == NULL) {
+    return kDifSpiDeviceResultBadArg;
+  }
+
+  uint32_t bit_index = 0;
+  switch (type) {
+    case kDifSpiDeviceIrqTypeRxFull:
+      bit_index = SPI_DEVICE_INTR_ENABLE_RXF;
+      break;
+    case kDifSpiDeviceIrqTypeRxAboveLevel:
+      bit_index = SPI_DEVICE_INTR_ENABLE_RXLVL;
+      break;
+    case kDifSpiDeviceIrqTypeTxBelowLevel:
+      bit_index = SPI_DEVICE_INTR_ENABLE_TXLVL;
+      break;
+    case kDifSpiDeviceIrqTypeRxError:
+      bit_index = SPI_DEVICE_INTR_ENABLE_RXERR;
+      break;
+    case kDifSpiDeviceIrqTypeRxOverflow:
+      bit_index = SPI_DEVICE_INTR_ENABLE_RXOVERFLOW;
+      break;
+    case kDifSpiDeviceIrqTypeTxUnderflow:
+      bit_index = SPI_DEVICE_INTR_ENABLE_TXUNDERFLOW;
+      break;
+  }
+
+  switch (state) {
+    case kDifSpiDeviceIrqStateEnabled:
+      mmio_region_nonatomic_set_bit32(
+          spi->base_addr, SPI_DEVICE_INTR_ENABLE_REG_OFFSET, bit_index);
+      break;
+    case kDifSpiDeviceIrqStateDisabled:
+      mmio_region_nonatomic_clear_bit32(
+          spi->base_addr, SPI_DEVICE_INTR_ENABLE_REG_OFFSET, bit_index);
+      break;
+  }
+
+  return kDifSpiDeviceResultOk;
+}
+
+dif_spi_device_result_t dif_spi_device_irq_force(
+    const dif_spi_device_t *spi, dif_spi_device_irq_type_t type) {
+  if (spi == NULL) {
+    return kDifSpiDeviceResultBadArg;
+  }
+
+  uint32_t bit_index = 0;
+  switch (type) {
+    case kDifSpiDeviceIrqTypeRxFull:
+      bit_index = SPI_DEVICE_INTR_TEST_RXF;
+      break;
+    case kDifSpiDeviceIrqTypeRxAboveLevel:
+      bit_index = SPI_DEVICE_INTR_TEST_RXLVL;
+      break;
+    case kDifSpiDeviceIrqTypeTxBelowLevel:
+      bit_index = SPI_DEVICE_INTR_TEST_TXLVL;
+      break;
+    case kDifSpiDeviceIrqTypeRxError:
+      bit_index = SPI_DEVICE_INTR_TEST_RXERR;
+      break;
+    case kDifSpiDeviceIrqTypeRxOverflow:
+      bit_index = SPI_DEVICE_INTR_TEST_RXOVERFLOW;
+      break;
+    case kDifSpiDeviceIrqTypeTxUnderflow:
+      bit_index = SPI_DEVICE_INTR_TEST_TXUNDERFLOW;
+      break;
+  }
+
+  uint32_t mask = 1 << bit_index;
+  mmio_region_write32(spi->base_addr, SPI_DEVICE_INTR_TEST_REG_OFFSET, mask);
+
+  return kDifSpiDeviceResultOk;
+}
+
+dif_spi_device_result_t dif_spi_device_set_irq_levels(
+    const dif_spi_device_t *spi, uint16_t rx_level, uint16_t tx_level) {
+  if (spi == NULL) {
+    return kDifSpiDeviceResultBadArg;
+  }
+
+  uint32_t compressed_limit = 0;
+  compressed_limit = bitfield_set_field32(
+      compressed_limit, (bitfield_field32_t){
+                            .mask = SPI_DEVICE_FIFO_LEVEL_RXLVL_MASK,
+                            .index = SPI_DEVICE_FIFO_LEVEL_RXLVL_OFFSET,
+                            .value = rx_level,
+                        });
+  compressed_limit = bitfield_set_field32(
+      compressed_limit, (bitfield_field32_t){
+                            .mask = SPI_DEVICE_FIFO_LEVEL_TXLVL_MASK,
+                            .index = SPI_DEVICE_FIFO_LEVEL_TXLVL_OFFSET,
+                            .value = tx_level,
+                        });
+  mmio_region_write32(spi->base_addr, SPI_DEVICE_FIFO_LEVEL_REG_OFFSET,
+                      compressed_limit);
+
+  return kDifSpiDeviceResultOk;
+}
+
+/**
+ * Parameters for compressing and decompressing a FIFO pointer register.
+ */
+typedef struct fifo_ptr_params {
+  ptrdiff_t reg_offset;
+  ptrdiff_t write_offset;
+  ptrdiff_t read_offset;
+  uint32_t write_mask;
+  uint32_t read_mask;
+} fifo_ptr_params_t;
+
+/**
+ * Parameters for the transmission FIFO.
+ */
+static const fifo_ptr_params_t kTxFifoParams = {
+    .reg_offset = SPI_DEVICE_TXF_PTR_REG_OFFSET,
+    .write_offset = SPI_DEVICE_TXF_PTR_WPTR_OFFSET,
+    .write_mask = SPI_DEVICE_TXF_PTR_WPTR_MASK,
+    .read_offset = SPI_DEVICE_TXF_PTR_RPTR_OFFSET,
+    .read_mask = SPI_DEVICE_TXF_PTR_RPTR_MASK,
+};
+
+/**
+ * Parameters for the receipt FIFO.
+ */
+static const fifo_ptr_params_t kRxFifoParams = {
+    .reg_offset = SPI_DEVICE_RXF_PTR_REG_OFFSET,
+    .write_offset = SPI_DEVICE_RXF_PTR_WPTR_OFFSET,
+    .write_mask = SPI_DEVICE_RXF_PTR_WPTR_MASK,
+    .read_offset = SPI_DEVICE_RXF_PTR_RPTR_OFFSET,
+    .read_mask = SPI_DEVICE_RXF_PTR_RPTR_MASK,
+};
+
+/**
+ * An exploded FIFO pointer value, consisting of a `uint11_t`
+ * offset part (an offset into a FIFO), and a `uint1_t` phase
+ * (which indicates whether this pointer has wrapped around or not).
+ *
+ * See also `fifo_ptrs_t`.
+ */
+typedef struct fifo_ptr {
+  uint16_t offset;
+  bool phase;
+} fifo_ptr_t;
+
+// Masks for extracting the phase and offset parts from a
+// compressed FIFO pointer.
+static const uint16_t kFifoPhaseMask = (1 << 11);
+static const uint16_t kFifoOffsetMask = (1 << 11) - 1;
+
+/**
+ * Modifies a `fifo_ptr_t` into a FIFO of length `fifo_len` by
+ * incrementing it by `increment`, making sure to correctly flip the
+ * phase bit on overflow.
+ *
+ * @param ptr the poitner to increment.
+ * @param increment the amount to increment by.
+ * @param fifo_len the length of the FIFO the pointer points into.
+ */
+static void fifo_ptr_increment(fifo_ptr_t *ptr, uint16_t increment,
+                               uint16_t fifo_len) {
+  uint32_t inc_with_overflow = ptr->offset + increment;
+  // If we would overflow, wrap and flip the overflow bit.
+  if (inc_with_overflow >= fifo_len) {
+    inc_with_overflow -= fifo_len;
+    ptr->phase = !ptr->phase;
+  }
+
+  ptr->offset = inc_with_overflow & kFifoOffsetMask;
+}
+
+/**
+ * A decompressed FIFO pointer register, consisting of a read offset
+ * and a write offset within the FIFO region.
+ *
+ * The offsets themselves are only `uint11_t`, with an additional
+ * 12th "phase" bit used for detecting the wrap around behavior of
+ * the ring buffer FIFOs.
+ */
+typedef struct fifo_ptrs {
+  fifo_ptr_t write_ptr;
+  fifo_ptr_t read_ptr;
+} fifo_ptrs_t;
+
+/**
+ * Expands read and write FIFO pointers out of `spi`, using the given FIFO
+ * parameters.
+ *
+ * @param spi the SPI device.
+ * @param params bitfield parameters for the FIFO.
+ * @return expanded pointers read out of `spi`.
+ */
+static fifo_ptrs_t decompress_ptrs(const dif_spi_device_t *spi,
+                                   fifo_ptr_params_t params) {
+  uint32_t ptr = mmio_region_read32(spi->base_addr, params.reg_offset);
+  uint16_t write_val =
+      (uint16_t)((ptr >> params.write_offset) & params.write_mask);
+  uint16_t read_val =
+      (uint16_t)((ptr >> params.read_offset) & params.read_mask);
+  return (fifo_ptrs_t){
+      .write_ptr =
+          {
+              .offset = write_val & kFifoOffsetMask,
+              .phase = (write_val & kFifoPhaseMask) != 0,
+          },
+      .read_ptr =
+          {
+              .offset = read_val & kFifoOffsetMask,
+              .phase = (read_val & kFifoPhaseMask) != 0,
+          },
+  };
+}
+
+/**
+ * Writes back read and write FIFO pointers into `spi`, using the given FIFO
+ * parameters.
+ *
+ * @param spi the SPI device.
+ * @param params bitfield parameters for the FIFO.
+ * @param ptrs the new pointer values.
+ */
+static void compress_ptrs(const dif_spi_device_t *spi, fifo_ptr_params_t params,
+                          fifo_ptrs_t ptrs) {
+  uint16_t write_val = ptrs.write_ptr.offset;
+  if (ptrs.write_ptr.phase) {
+    write_val |= kFifoPhaseMask;
+  }
+  uint16_t read_val = ptrs.read_ptr.offset;
+  if (ptrs.read_ptr.phase) {
+    read_val |= kFifoPhaseMask;
+  }
+
+  uint32_t ptr = 0;
+  ptr = bitfield_set_field32(ptr, (bitfield_field32_t){
+                                      .mask = params.write_mask,
+                                      .index = params.write_offset,
+                                      .value = write_val,
+                                  });
+  ptr = bitfield_set_field32(ptr, (bitfield_field32_t){
+                                      .mask = params.read_mask,
+                                      .index = params.read_offset,
+                                      .value = read_val,
+                                  });
+  mmio_region_write32(spi->base_addr, params.reg_offset, ptr);
+}
+
+/**
+ * Counts the number of bytes from the read pointer to the write pointer in
+ * `ptrs`, in a FIFO of length `fifo_len`.
+ *
+ * @param ptrs a set of FIFO pointers.
+ * @param fifo_len the length of the fifo, in bytes.
+ * @return the number of bytes "in use".
+ */
+static uint16_t fifo_bytes_in_use(fifo_ptrs_t ptrs, uint16_t fifo_len) {
+  // This represents the case where the valid data of the fifo is "inclusive",
+  // i.e., the buffer looks like (where a / represents valid data):
+  // [ /////       ]
+  //   ^    ^
+  //   r    w
+  //
+  // In particular, when r == w, the fifo is empty.
+  if (ptrs.write_ptr.phase == ptrs.read_ptr.phase) {
+    return ptrs.write_ptr.offset - ptrs.read_ptr.offset;
+  }
+
+  // This represents the case where the valid data of the fifo is "exclusive",
+  // i.e., the buffer looks like (where a / represents valid data):
+  // [/      //////]
+  //   ^     ^
+  //   w     r
+  //
+  // In particular, when r == w, the fifo is full.
+  return fifo_len - (ptrs.read_ptr.offset - ptrs.write_ptr.offset);
+}
+
+dif_spi_device_result_t dif_spi_device_rx_pending(const dif_spi_device_t *spi,
+                                                  size_t *bytes_pending) {
+  if (spi == NULL || bytes_pending == NULL) {
+    return kDifSpiDeviceResultBadArg;
+  }
+
+  fifo_ptrs_t ptrs = decompress_ptrs(spi, kRxFifoParams);
+  *bytes_pending = fifo_bytes_in_use(ptrs, spi->rx_fifo_len);
+
+  return kDifSpiDeviceResultOk;
+}
+
+dif_spi_device_result_t dif_spi_device_tx_pending(const dif_spi_device_t *spi,
+                                                  size_t *bytes_pending) {
+  if (spi == NULL || bytes_pending == NULL) {
+    return kDifSpiDeviceResultBadArg;
+  }
+
+  fifo_ptrs_t ptrs = decompress_ptrs(spi, kTxFifoParams);
+  *bytes_pending = fifo_bytes_in_use(ptrs, spi->tx_fifo_len);
+
+  return kDifSpiDeviceResultOk;
+}
+
+/**
+ * Computes how many bytes `addr` is ahead of the previous 32-bit word alignment
+ * boundary.
+ */
+static ptrdiff_t misalignment32_of(uintptr_t addr) {
+  return (addr & (alignof(uint32_t) - 1));
+}
+
+/**
+ * Performs a "memcpy" of sorts between a main memory buffer and SPI SRAM,
+ * which does not support non-word I/O.
+ *
+ * If `is_recv` is set, then the copy direction is `spi -> buf`. If it is
+ * unset, the copy direction is `buf -> spi`.
+ *
+ * @param spi a SPI device.
+ * @param fifo a decompressed FIFO pointer pair.
+ * @param fifo_base the offset from start of SRAM for the FIFO to copy to/from.
+ * @param fifo_len the length of the FIFO, in bytes.
+ * @param byte_buf a main memory buffer for copying from/to.
+ * @param buf_len the length of the main memory buffer.
+ * @param is_recv whether this is a SPI reciept or SPI transmit transaction.
+ * @return the number of bytes copied.
+ */
+static size_t spi_memcpy(const dif_spi_device_t *spi, fifo_ptrs_t *fifo,
+                         uint16_t fifo_base, uint16_t fifo_len,
+                         uint8_t *byte_buf, size_t buf_len, bool is_recv) {
+  uint16_t bytes_left = fifo_bytes_in_use(*fifo, fifo_len);
+  // When sending, the bytes left are the empty space still available.
+  if (!is_recv) {
+    bytes_left = fifo_len - bytes_left;
+  }
+
+  if (bytes_left > buf_len) {
+    bytes_left = buf_len;
+  }
+  if (bytes_left == 0) {
+    return 0;
+  }
+
+  // For receipt, we advance the read pointer, which indicates how far ahead
+  // we've read so far. For sending, we advance the write pointer, which
+  // indicates how far ahead we've written.
+  fifo_ptr_t *ptr;
+  if (is_recv) {
+    ptr = &fifo->read_ptr;
+  } else {
+    ptr = &fifo->write_ptr;
+  }
+
+  uint16_t total_bytes_available = bytes_left;
+
+  // First, bring the fifo write pointer into word alignment, so we can do
+  // simple full-word I/O rather than partial word I/O; note that the FIFO
+  // SRAM is not guaranteed to support subword writes.
+  ptrdiff_t misalignment = misalignment32_of(ptr->offset);
+  if (misalignment != 0) {
+    // The number of bytes missing to bring `ptr->offset` back into alignment.
+    // For exmaple, 0x3 has misalignment of 3 and realignment of 1.
+    ptrdiff_t realignment = sizeof(uint32_t) - misalignment;
+    // Note that we might be doing less I/O than the misalignment requires; we
+    // might be off by a single byte, but not have the full three bytes for full
+    // realignment.
+    if (realignment > bytes_left) {
+      realignment = bytes_left;
+    }
+
+    // Converts `offset`, which points to a subword boundary, to point to the
+    // start of the current word it points into.
+    ptrdiff_t current_word_offset = ptr->offset - misalignment;
+    uint32_t current_word =
+        mmio_region_read32(spi->base_addr, SPI_DEVICE_BUFFER_REG_OFFSET +
+                                               fifo_base + current_word_offset);
+
+    // Act on only to a suffix of `current_word`, corresponding to the necessary
+    // realignment.
+    uint8_t *current_byte = ((uint8_t *)&current_word) + misalignment;
+    if (is_recv) {
+      memcpy(byte_buf, current_byte, realignment);
+    } else {
+      // When sending, we need to commit the staged write.
+      memcpy(current_byte, byte_buf, realignment);
+      mmio_region_write32(spi->base_addr, SPI_DEVICE_BUFFER_REG_OFFSET +
+                                              fifo_base + current_word_offset,
+                          current_word);
+    }
+
+    fifo_ptr_increment(ptr, realignment, fifo_len);
+    byte_buf += realignment;
+    bytes_left -= realignment;
+  }
+
+  // Now, we just do full word I/O until we run out of stuff to act on.
+  while (bytes_left > 0) {
+    // At the end, we may not have a full word to copy, but it's otherwise
+    // the same case as a full word, since we're already word aligned (if
+    // this would be a subword read, it would end the loop anyway).
+    uint16_t bytes_to_copy = bytes_left;
+    if (bytes_to_copy > sizeof(uint32_t)) {
+      bytes_to_copy = sizeof(uint32_t);
+    }
+
+    uint32_t current_word = 0;
+    if (is_recv || bytes_to_copy != sizeof(uint32_t)) {
+      // If recieving, we need to read this word always.
+      //
+      // If sending, we only need to write a prefix when writing a subword.
+      // In that case, we need to avoid clobbering the current contents of the
+      // FIFO.
+      current_word =
+          mmio_region_read32(spi->base_addr, SPI_DEVICE_BUFFER_REG_OFFSET +
+                                                 fifo_base + ptr->offset);
+    }
+
+    // Copy a prefix; most of the time, this will be the whole word.
+    if (is_recv) {
+      memcpy(byte_buf, &current_word, bytes_to_copy);
+    } else {
+      // When sending, we need to commit the staged write.
+      memcpy(&current_word, byte_buf, bytes_to_copy);
+      mmio_region_write32(
+          spi->base_addr,
+          SPI_DEVICE_BUFFER_REG_OFFSET + fifo_base + ptr->offset, current_word);
+    }
+
+    fifo_ptr_increment(ptr, bytes_to_copy, fifo_len);
+    byte_buf += bytes_to_copy;
+    bytes_left -= bytes_to_copy;
+  }
+
+  return total_bytes_available - bytes_left;
+}
+
+dif_spi_device_result_t dif_spi_device_recv(const dif_spi_device_t *spi,
+                                            void *buf, size_t buf_len,
+                                            size_t *bytes_received) {
+  if (spi == NULL || buf == NULL) {
+    return kDifSpiDeviceResultBadArg;
+  }
+
+  uint16_t fifo_base = spi->rx_fifo_base;
+  uint16_t fifo_len = spi->rx_fifo_len;
+  fifo_ptrs_t fifo = decompress_ptrs(spi, kRxFifoParams);
+
+  size_t bytes = spi_memcpy(spi, &fifo, fifo_base, fifo_len, (uint8_t *)buf,
+                            buf_len, /*is_recv=*/true);
+  if (bytes_received != NULL) {
+    *bytes_received = bytes;
+  }
+  if (bytes > 0) {
+    // Commit the new RX FIFO pointers.
+    compress_ptrs(spi, kRxFifoParams, fifo);
+  }
+  return kDifSpiDeviceResultOk;
+}
+
+dif_spi_device_result_t dif_spi_device_send(const dif_spi_device_t *spi,
+                                            const void *buf, size_t buf_len,
+                                            size_t *bytes_sent) {
+  if (spi == NULL || buf == NULL) {
+    return kDifSpiDeviceResultBadArg;
+  }
+
+  uint16_t fifo_base = spi->tx_fifo_base;
+  uint16_t fifo_len = spi->tx_fifo_len;
+  fifo_ptrs_t fifo = decompress_ptrs(spi, kTxFifoParams);
+
+  size_t bytes = spi_memcpy(spi, &fifo, fifo_base, fifo_len, (uint8_t *)buf,
+                            buf_len, /*is_recv=*/false);
+  if (bytes_sent != NULL) {
+    *bytes_sent = bytes;
+  }
+  if (bytes > 0) {
+    // Commit the new TX FIFO pointers.
+    compress_ptrs(spi, kTxFifoParams, fifo);
+  }
+  return kDifSpiDeviceResultOk;
+}

--- a/sw/device/lib/dif/dif_spi_device.h
+++ b/sw/device/lib/dif/dif_spi_device.h
@@ -1,0 +1,245 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_DIF_SPI_DEVICE_H_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_DIF_SPI_DEVICE_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/mmio.h"
+
+/**
+ * Represents a signal edge type.
+ */
+typedef enum dif_spi_device_edge {
+  kDifSpiDeviceEdgePositive,
+  kDifSpiDeviceEdgeNegative,
+} dif_spi_device_edge_t;
+
+/**
+ * Represents a bit ordering.
+ */
+typedef enum dif_spi_device_bit_order {
+  kDifSpiDeviceBitOrderMsbToLsb,
+  kDifSpiDeviceBitOrderLsbToMsb,
+} dif_spi_device_bit_order_t;
+
+/**
+ * Represents the enablement state of a particular SPI IRQ.
+ */
+typedef enum dif_spi_device_irq_state {
+  kDifSpiDeviceIrqStateEnabled = true,
+  kDifSpiDeviceIrqStateDisabled = false,
+} dif_spi_device_irq_state_t;
+
+/**
+ * Represents the types of interrupts that the SPI device will
+ * fire to signal state.
+ */
+typedef enum dif_spi_device_irq_type {
+  kDifSpiDeviceIrqTypeRxFull,
+  kDifSpiDeviceIrqTypeRxAboveLevel,
+  kDifSpiDeviceIrqTypeTxBelowLevel,
+  kDifSpiDeviceIrqTypeRxError,
+  kDifSpiDeviceIrqTypeRxOverflow,
+  kDifSpiDeviceIrqTypeTxUnderflow,
+} dif_spi_device_irq_type_t;
+
+/**
+ * Errors returned by SPI DIF functions.
+ */
+typedef enum dif_spi_device_result {
+  /**
+   * Indicates a successful operation.
+   */
+  kDifSpiDeviceResultOk = 0,
+  /**
+   * Indicates a failed precondition on the function arguments.
+   */
+  kDifSpiDeviceResultBadArg,
+} dif_spi_device_result_t;
+
+/**
+ * The length of the SPI device FIFO buffer, in bytes.
+ *
+ * Useful for initializing FIFO lengths: for example, for equally-sized FIFOs,
+ * `rx_fifo_len` and `tx_fifo_len` would be set to `kDifSpiDeviceBufferLen / 2`.
+ */
+extern const uint16_t kDifSpiDeviceBufferLen;
+
+/**
+ * Configuration for initializing a SPI device.
+ */
+typedef struct dif_spi_device_config {
+  dif_spi_device_edge_t clock_polarity;
+  dif_spi_device_edge_t data_phase;
+  dif_spi_device_bit_order_t tx_order;
+  dif_spi_device_bit_order_t rx_order;
+  uint8_t rx_fifo_timeout;
+  uint16_t rx_fifo_len;
+  uint16_t tx_fifo_len;
+} dif_spi_device_config_t;
+
+/**
+ * State for a particular SPI device.
+ *
+ * Its member variables should be considered private, and are only provided so
+ * that callers can allocate it.
+ */
+typedef struct dif_spi_device {
+  mmio_region_t base_addr;
+  uint16_t rx_fifo_base;
+  uint16_t rx_fifo_len;
+  uint16_t tx_fifo_base;
+  uint16_t tx_fifo_len;
+} dif_spi_device_t;
+
+/**
+ * Initializes a SPI device with the given configuration.
+ *
+ * @param base_addr The start of the SPI device register.
+ * @param config The configuration to initialize with.
+ * @param spi Out param for the initialized device.
+ * @return The result of the operation.
+ */
+dif_spi_device_result_t dif_spi_device_init(
+    mmio_region_t base_addr, const dif_spi_device_config_t *config,
+    dif_spi_device_t *spi);
+
+/**
+ * Issues an "abort" to the given SPI device, causing all in-progress IO to
+ * halt.
+ *
+ * @param spi A SPI device.
+ * @return The result of the operation.
+ */
+dif_spi_device_result_t dif_spi_device_abort(const dif_spi_device_t *spi);
+
+/**
+ * Resets all interrupt-related state on the given SPI device, such as enabled
+ * interrupts and set RX/TX levels.
+ *
+ * @param spi A SPI device.
+ * @return The result of the operation.
+ */
+dif_spi_device_result_t dif_spi_device_irq_reset(const dif_spi_device_t *spi);
+
+/**
+ * Returns whether the given IRQ is currently being serviced.
+ *
+ * @param spi A SPI device.
+ * @param type Which IRQ type to check.
+ * @param flag Out param for whether the IRQ is active..
+ * @return The result of the operation.
+ */
+dif_spi_device_result_t dif_spi_device_irq_get(const dif_spi_device_t *spi,
+                                               dif_spi_device_irq_type_t type,
+                                               bool *flag_out);
+
+/**
+ * Clears all active interrupt bits.
+ *
+ * @param spi A SPI device.
+ * @return The result of the operation.
+ */
+dif_spi_device_result_t dif_spi_device_irq_clear_all(
+    const dif_spi_device_t *spi);
+
+/**
+ * Enable or disable a particular interrupt.
+ *
+ * @param spi A SPI device.
+ * @param type Which IRQ type to toggle.
+ * @param state The state to update the bit to.
+ * @return The result of the operation.
+ */
+dif_spi_device_result_t dif_spi_device_irq_enable(
+    const dif_spi_device_t *spi, dif_spi_device_irq_type_t type,
+    dif_spi_device_irq_state_t state);
+
+/**
+ * Forces a particular IRQ type to fire.
+ *
+ * @param spi A SPI device.
+ * @param type Which IRQ type to fire.
+ * @return The result of the operation.
+ */
+dif_spi_device_result_t dif_spi_device_irq_force(
+    const dif_spi_device_t *spi, dif_spi_device_irq_type_t type);
+
+/**
+ * Sets up the "FIFO level" (that is, number of bytes present in a particular
+ * FIFO) at which the TxLevel and RxLevel IRQs will fire.
+ *
+ * For the reciept side, when the FIFO overflows `rx_level` (i.e., goes over
+ * the set level), an interrupt is fired. This can be used to detect that more
+ * data should be read from the RX FIFO. This is the
+ * `Spi Buffer -> Main Memory` case.
+ *
+ * Conversely, for the transmission side, when the FIFO underflows `tx_level`
+ * (i.e., goes below the set level), an interrupt is fired. This can be used
+ * to detect that there is free space to write more data to the TX FIFO.
+ * This is the `Main Memory -> Spi Buffer` case.
+ *
+ * @param spi A SPI device.
+ * @param rx_level The new RX level, as described above.
+ * @param tx_level The new TX level, as described above.
+ * @return The result of the operation.
+ */
+dif_spi_device_result_t dif_spi_device_set_irq_levels(
+    const dif_spi_device_t *spi, uint16_t rx_level, uint16_t tx_level);
+
+/**
+ * Returns the number of bytes still pending receipt by software in the RX FIFO.
+ *
+ * @param spi A SPI device.
+ * @param bytes_pending Out param for the number of bytes pending
+ * @return The result of the operation.
+ */
+dif_spi_device_result_t dif_spi_device_rx_pending(const dif_spi_device_t *spi,
+                                                  size_t *bytes_pending);
+
+/**
+ * Returns the number of bytes still pending transmission by hardware in the TX
+ * FIFO.
+ *
+ * @param spi A SPI device.
+ * @param bytes_pending Out param for the number of bytes pending
+ * @return The result of the operation.
+ */
+dif_spi_device_result_t dif_spi_device_tx_pending(const dif_spi_device_t *spi,
+                                                  size_t *bytes_pending);
+
+/**
+ * Reads at most `buf_len` bytes from the RX FIFO; the number of bytes read
+ * will be written to `bytes_received`.
+ *
+ * @param spi A SPI device.
+ * @param buf A pointer to valid memory.
+ * @param buf_len The length of the buffer `buf` points to.
+ * @param bytes_received Out param for the number of bytes successfully read;
+ * may be null.
+ * @return The result of the operation.
+ */
+dif_spi_device_result_t dif_spi_device_recv(const dif_spi_device_t *spi,
+                                            void *buf, size_t buf_len,
+                                            size_t *bytes_received);
+
+/**
+ * Writes at most `buf_len` bytes to the TX FIFO; the number of bytes actually
+ * written will be written to `bytes_sent`.
+ *
+ * @param spi A SPI device.
+ * @param buf A pointer to bytes to be written.
+ * @param buf_len The length of the buffer `buf` points to.
+ * @param bytes_recved Out param for the number of bytes successfully written;
+ * may be null.
+ * @return The result of the operation.
+ */
+dif_spi_device_result_t dif_spi_device_send(const dif_spi_device_t *spi,
+                                            const void *buf, size_t buf_len,
+                                            size_t *bytes_sent);
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_DIF_SPI_DEVICE_H_

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -43,3 +43,15 @@ sw_lib_dif_gpio = declare_dependency(
     ],
   )
 )
+
+# SPI DIF library
+sw_lib_dif_spi_device = declare_dependency(
+  link_with: static_library(
+    'sw_lib_dif_spi_device',
+    sources: [
+      hw_ip_spi_device_reg_h,
+      'dif_spi_device.c',
+    ],
+    dependencies: [sw_lib_mmio],
+  )
+)

--- a/sw/device/tests/dif/dif_spi_device_test.cc
+++ b/sw/device/tests/dif/dif_spi_device_test.cc
@@ -1,0 +1,835 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <limits>
+
+extern "C" {
+#include "spi_device_regs.h"  // Generated.
+#include "sw/device/lib/dif/dif_spi_device.h"
+}  // extern "C"
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/testing/mock_mmio.h"
+
+namespace dif_spi_device_test {
+namespace {
+using ::mock_mmio::LeInt;
+using ::mock_mmio::MmioTest;
+using ::mock_mmio::MockDevice;
+
+// Convenience function for assembling a phased FIFO pointer.
+uintptr_t FifoPtr(uintptr_t offset, bool phase) {
+  return offset | (static_cast<uintptr_t>(phase) << 11);
+}
+
+// Convenience function for generating a vector full of noisy data.
+std::vector<char> MakeBlob(size_t len) {
+  std::vector<char> buf;
+  buf.resize(len);
+  uint8_t val = 1;
+  for (auto &c : buf) {
+    c = val;
+    val *= 31;
+  }
+  return buf;
+}
+
+class SpiTest : public testing::Test, public MmioTest {
+ protected:
+  static const uint16_t kFifoLen = 0x400;
+
+  dif_spi_device_t spi_ = {
+      /*base_addr=*/dev().region(),
+      /*rx_fifo_base=*/0x0000,
+      /*rx_fifo_len=*/kFifoLen,
+      /*tx_fifo_base=*/kFifoLen,
+      /*tx_fifo_len=*/kFifoLen,
+  };
+
+  dif_spi_device_config_t config_ = {
+      /*clock_polarity=*/kDifSpiDeviceEdgePositive,
+      /*data_phase=*/kDifSpiDeviceEdgeNegative,
+      /*tx_order=*/kDifSpiDeviceBitOrderMsbToLsb,
+      /*rx_order=*/kDifSpiDeviceBitOrderMsbToLsb,
+      /*rx_fifo_timeout=*/63,
+      /*rx_fifo_len=*/kFifoLen,
+      /*tx_fifo_len=*/kFifoLen,
+  };
+};
+
+class AbortTest : public SpiTest {};
+
+TEST_F(AbortTest, Immediate) {
+  EXPECT_MASK32(SPI_DEVICE_CONTROL_REG_OFFSET,
+                {{SPI_DEVICE_CONTROL_ABORT, 0x1, 0x1}});
+  EXPECT_READ32(SPI_DEVICE_STATUS_REG_OFFSET,
+                {{SPI_DEVICE_STATUS_ABORT_DONE, 0x1}});
+
+  EXPECT_EQ(dif_spi_device_abort(&spi_), kDifSpiDeviceResultOk);
+}
+
+TEST_F(AbortTest, Delayed) {
+  EXPECT_MASK32(SPI_DEVICE_CONTROL_REG_OFFSET,
+                {{SPI_DEVICE_CONTROL_ABORT, 0x1, 0x1}});
+  EXPECT_READ32(SPI_DEVICE_STATUS_REG_OFFSET, 0);
+  EXPECT_READ32(SPI_DEVICE_STATUS_REG_OFFSET, 0);
+  EXPECT_READ32(SPI_DEVICE_STATUS_REG_OFFSET, 0);
+  EXPECT_READ32(SPI_DEVICE_STATUS_REG_OFFSET, 0);
+  EXPECT_READ32(SPI_DEVICE_STATUS_REG_OFFSET, 0);
+  EXPECT_READ32(SPI_DEVICE_STATUS_REG_OFFSET, 0);
+  EXPECT_READ32(SPI_DEVICE_STATUS_REG_OFFSET,
+                {{SPI_DEVICE_STATUS_ABORT_DONE, 0x1}});
+
+  EXPECT_EQ(dif_spi_device_abort(&spi_), kDifSpiDeviceResultOk);
+}
+
+TEST_F(AbortTest, NullArgs) {
+  EXPECT_EQ(dif_spi_device_abort(nullptr), kDifSpiDeviceResultBadArg);
+}
+
+class InitTest : public SpiTest {};
+
+TEST_F(InitTest, BasicInit) {
+  EXPECT_MASK32(SPI_DEVICE_CONTROL_REG_OFFSET,
+                {{SPI_DEVICE_CONTROL_ABORT, 0x1, 0x1}});
+  EXPECT_READ32(SPI_DEVICE_STATUS_REG_OFFSET,
+                {{SPI_DEVICE_STATUS_ABORT_DONE, 0x1}});
+
+  EXPECT_WRITE32(SPI_DEVICE_INTR_STATE_REG_OFFSET,
+                 std::numeric_limits<uint32_t>::max());
+
+  EXPECT_WRITE32(SPI_DEVICE_FIFO_LEVEL_REG_OFFSET,
+                 {{SPI_DEVICE_FIFO_LEVEL_RXLVL_OFFSET, 0x80},
+                  {SPI_DEVICE_FIFO_LEVEL_TXLVL_OFFSET, 0x00}});
+
+  EXPECT_WRITE32(SPI_DEVICE_INTR_ENABLE_REG_OFFSET, 0x0);
+
+  EXPECT_WRITE32(SPI_DEVICE_CFG_REG_OFFSET,
+                 {
+                     {SPI_DEVICE_CFG_CPOL, 0},
+                     {SPI_DEVICE_CFG_CPHA, 0},
+                     {SPI_DEVICE_CFG_TX_ORDER, 0},
+                     {SPI_DEVICE_CFG_RX_ORDER, 0},
+                     {SPI_DEVICE_CFG_TIMER_V_OFFSET, config_.rx_fifo_timeout},
+                 });
+  EXPECT_WRITE32(SPI_DEVICE_RXF_ADDR_REG_OFFSET,
+                 {
+                     {SPI_DEVICE_RXF_ADDR_BASE_OFFSET, 0x000},
+                     {SPI_DEVICE_RXF_ADDR_LIMIT_OFFSET, 0x400 - 1},
+                 });
+  EXPECT_WRITE32(SPI_DEVICE_TXF_ADDR_REG_OFFSET,
+                 {
+                     {SPI_DEVICE_TXF_ADDR_BASE_OFFSET, 0x400},
+                     {SPI_DEVICE_TXF_ADDR_LIMIT_OFFSET, 0x800 - 1},
+                 });
+
+  EXPECT_EQ(dif_spi_device_init(dev().region(), &config_, &spi_),
+            kDifSpiDeviceResultOk);
+}
+
+TEST_F(InitTest, ComplexInit) {
+  config_.clock_polarity = kDifSpiDeviceEdgeNegative;
+  config_.data_phase = kDifSpiDeviceEdgePositive;
+  config_.tx_order = kDifSpiDeviceBitOrderLsbToMsb;
+  config_.rx_fifo_timeout = 42;
+  config_.rx_fifo_len = 0x24;
+
+  EXPECT_MASK32(SPI_DEVICE_CONTROL_REG_OFFSET,
+                {{SPI_DEVICE_CONTROL_ABORT, 0x1, 0x1}});
+  EXPECT_READ32(SPI_DEVICE_STATUS_REG_OFFSET,
+                {{SPI_DEVICE_STATUS_ABORT_DONE, 0x1}});
+
+  EXPECT_WRITE32(SPI_DEVICE_INTR_STATE_REG_OFFSET,
+                 std::numeric_limits<uint32_t>::max());
+
+  EXPECT_WRITE32(SPI_DEVICE_FIFO_LEVEL_REG_OFFSET,
+                 {{SPI_DEVICE_FIFO_LEVEL_RXLVL_OFFSET, 0x80},
+                  {SPI_DEVICE_FIFO_LEVEL_TXLVL_OFFSET, 0x00}});
+
+  EXPECT_WRITE32(SPI_DEVICE_INTR_ENABLE_REG_OFFSET, 0x0);
+
+  EXPECT_WRITE32(SPI_DEVICE_CFG_REG_OFFSET,
+                 {
+                     {SPI_DEVICE_CFG_CPOL, 1},
+                     {SPI_DEVICE_CFG_CPHA, 1},
+                     {SPI_DEVICE_CFG_TX_ORDER, 1},
+                     {SPI_DEVICE_CFG_RX_ORDER, 0},
+                     {SPI_DEVICE_CFG_TIMER_V_OFFSET, config_.rx_fifo_timeout},
+                 });
+  EXPECT_WRITE32(SPI_DEVICE_RXF_ADDR_REG_OFFSET,
+                 {
+                     {SPI_DEVICE_RXF_ADDR_BASE_OFFSET, 0x000},
+                     {SPI_DEVICE_RXF_ADDR_LIMIT_OFFSET, 0x023},
+                 });
+  EXPECT_WRITE32(SPI_DEVICE_TXF_ADDR_REG_OFFSET,
+                 {
+                     {SPI_DEVICE_TXF_ADDR_BASE_OFFSET, 0x024},
+                     {SPI_DEVICE_TXF_ADDR_LIMIT_OFFSET, 0x423},
+                 });
+
+  EXPECT_EQ(dif_spi_device_init(dev().region(), &config_, &spi_),
+            kDifSpiDeviceResultOk);
+}
+
+TEST_F(InitTest, NullArgs) {
+  EXPECT_EQ(dif_spi_device_init(dev().region(), &config_, nullptr),
+            kDifSpiDeviceResultBadArg);
+  EXPECT_EQ(dif_spi_device_init(dev().region(), nullptr, &spi_),
+            kDifSpiDeviceResultBadArg);
+}
+
+TEST_F(InitTest, InitSramOverflow) {
+  config_.rx_fifo_len = 0x1000;
+  EXPECT_EQ(dif_spi_device_init(dev().region(), &config_, &spi_),
+            kDifSpiDeviceResultBadArg);
+}
+
+class IrqTest : public SpiTest {};
+
+TEST_F(IrqTest, Get) {
+  bool out;
+
+  EXPECT_READ32(SPI_DEVICE_INTR_STATE_REG_OFFSET,
+                {{SPI_DEVICE_INTR_STATE_RXF, 1}});
+  EXPECT_EQ(dif_spi_device_irq_get(&spi_, kDifSpiDeviceIrqTypeRxFull, &out),
+            kDifSpiDeviceResultOk);
+  EXPECT_TRUE(out);
+
+  EXPECT_READ32(
+      SPI_DEVICE_INTR_STATE_REG_OFFSET,
+      {{SPI_DEVICE_INTR_STATE_RXERR, 0}, {SPI_DEVICE_INTR_STATE_RXF, 1}});
+  EXPECT_EQ(dif_spi_device_irq_get(&spi_, kDifSpiDeviceIrqTypeRxError, &out),
+            kDifSpiDeviceResultOk);
+  EXPECT_FALSE(out);
+
+  EXPECT_READ32(SPI_DEVICE_INTR_STATE_REG_OFFSET,
+                {{SPI_DEVICE_INTR_STATE_TXUNDERFLOW, 1}});
+  EXPECT_EQ(
+      dif_spi_device_irq_get(&spi_, kDifSpiDeviceIrqTypeTxUnderflow, &out),
+      kDifSpiDeviceResultOk);
+  EXPECT_TRUE(out);
+
+  EXPECT_READ32(SPI_DEVICE_INTR_STATE_REG_OFFSET,
+                {{SPI_DEVICE_INTR_STATE_TXLVL, 0}});
+  EXPECT_EQ(
+      dif_spi_device_irq_get(&spi_, kDifSpiDeviceIrqTypeTxBelowLevel, &out),
+      kDifSpiDeviceResultOk);
+  EXPECT_FALSE(out);
+}
+
+TEST_F(IrqTest, GetNull) {
+  bool out;
+  EXPECT_EQ(dif_spi_device_irq_get(nullptr, kDifSpiDeviceIrqTypeRxFull, &out),
+            kDifSpiDeviceResultBadArg);
+  EXPECT_EQ(dif_spi_device_irq_get(&spi_, kDifSpiDeviceIrqTypeRxFull, nullptr),
+            kDifSpiDeviceResultBadArg);
+}
+
+TEST_F(IrqTest, Enable) {
+  EXPECT_MASK32(SPI_DEVICE_INTR_ENABLE_REG_OFFSET,
+                {{SPI_DEVICE_INTR_ENABLE_RXF, 0x1, 1}});
+  EXPECT_EQ(dif_spi_device_irq_enable(&spi_, kDifSpiDeviceIrqTypeRxFull,
+                                      kDifSpiDeviceIrqStateEnabled),
+            kDifSpiDeviceResultOk);
+
+  EXPECT_MASK32(SPI_DEVICE_INTR_ENABLE_REG_OFFSET,
+                {{SPI_DEVICE_INTR_ENABLE_RXERR, 0x1, 0}});
+  EXPECT_EQ(dif_spi_device_irq_enable(&spi_, kDifSpiDeviceIrqTypeRxError,
+                                      kDifSpiDeviceIrqStateDisabled),
+            kDifSpiDeviceResultOk);
+
+  EXPECT_MASK32(SPI_DEVICE_INTR_ENABLE_REG_OFFSET,
+                {{SPI_DEVICE_INTR_ENABLE_TXUNDERFLOW, 0x1, 1}});
+  EXPECT_EQ(dif_spi_device_irq_enable(&spi_, kDifSpiDeviceIrqTypeTxUnderflow,
+                                      kDifSpiDeviceIrqStateEnabled),
+            kDifSpiDeviceResultOk);
+
+  EXPECT_MASK32(SPI_DEVICE_INTR_ENABLE_REG_OFFSET,
+                {{SPI_DEVICE_INTR_ENABLE_TXLVL, 0x1, 0}});
+  EXPECT_EQ(dif_spi_device_irq_enable(&spi_, kDifSpiDeviceIrqTypeTxBelowLevel,
+                                      kDifSpiDeviceIrqStateDisabled),
+            kDifSpiDeviceResultOk);
+}
+
+TEST_F(IrqTest, EnableNull) {
+  EXPECT_EQ(dif_spi_device_irq_enable(nullptr, kDifSpiDeviceIrqTypeRxFull,
+                                      kDifSpiDeviceIrqStateEnabled),
+            kDifSpiDeviceResultBadArg);
+}
+
+TEST_F(IrqTest, Force) {
+  EXPECT_WRITE32(SPI_DEVICE_INTR_TEST_REG_OFFSET,
+                 {{SPI_DEVICE_INTR_TEST_RXF, 1}});
+  EXPECT_EQ(dif_spi_device_irq_force(&spi_, kDifSpiDeviceIrqTypeRxFull),
+            kDifSpiDeviceResultOk);
+
+  EXPECT_WRITE32(SPI_DEVICE_INTR_TEST_REG_OFFSET,
+                 {{SPI_DEVICE_INTR_TEST_RXERR, 1}});
+  EXPECT_EQ(dif_spi_device_irq_force(&spi_, kDifSpiDeviceIrqTypeRxError),
+            kDifSpiDeviceResultOk);
+
+  EXPECT_WRITE32(SPI_DEVICE_INTR_TEST_REG_OFFSET,
+                 {{SPI_DEVICE_INTR_TEST_TXUNDERFLOW, 1}});
+  EXPECT_EQ(dif_spi_device_irq_force(&spi_, kDifSpiDeviceIrqTypeTxUnderflow),
+            kDifSpiDeviceResultOk);
+
+  EXPECT_WRITE32(SPI_DEVICE_INTR_TEST_REG_OFFSET,
+                 {{SPI_DEVICE_INTR_TEST_TXLVL, 1}});
+  EXPECT_EQ(dif_spi_device_irq_force(&spi_, kDifSpiDeviceIrqTypeTxBelowLevel),
+            kDifSpiDeviceResultOk);
+}
+
+TEST_F(IrqTest, ForceNull) {
+  EXPECT_EQ(dif_spi_device_irq_force(nullptr, kDifSpiDeviceIrqTypeRxFull),
+            kDifSpiDeviceResultBadArg);
+}
+
+TEST_F(IrqTest, Levels) {
+  EXPECT_WRITE32(SPI_DEVICE_FIFO_LEVEL_REG_OFFSET,
+                 {{SPI_DEVICE_FIFO_LEVEL_RXLVL_OFFSET, 42},
+                  {SPI_DEVICE_FIFO_LEVEL_TXLVL_OFFSET, 123}});
+  EXPECT_EQ(dif_spi_device_set_irq_levels(&spi_, 42, 123),
+            kDifSpiDeviceResultOk);
+}
+
+TEST_F(IrqTest, LevelsNull) {
+  EXPECT_EQ(dif_spi_device_set_irq_levels(nullptr, 123, 456),
+            kDifSpiDeviceResultBadArg);
+}
+
+class RxPendingTest : public SpiTest {};
+
+TEST_F(RxPendingTest, BothZero) {
+  EXPECT_READ32(SPI_DEVICE_RXF_PTR_REG_OFFSET,
+                {{SPI_DEVICE_RXF_PTR_WPTR_OFFSET, 0x0},
+                 {SPI_DEVICE_RXF_PTR_RPTR_OFFSET, 0x0}});
+  size_t bytes_remaining;
+  EXPECT_EQ(dif_spi_device_rx_pending(&spi_, &bytes_remaining),
+            kDifSpiDeviceResultOk);
+  EXPECT_EQ(bytes_remaining, 0);
+}
+
+TEST_F(RxPendingTest, InPhaseEmpty) {
+  EXPECT_READ32(SPI_DEVICE_RXF_PTR_REG_OFFSET,
+                {{SPI_DEVICE_RXF_PTR_WPTR_OFFSET, FifoPtr(0x42, true)},
+                 {SPI_DEVICE_RXF_PTR_RPTR_OFFSET, FifoPtr(0x42, true)}});
+  size_t bytes_remaining;
+  EXPECT_EQ(dif_spi_device_rx_pending(&spi_, &bytes_remaining),
+            kDifSpiDeviceResultOk);
+  EXPECT_EQ(bytes_remaining, 0);
+}
+
+TEST_F(RxPendingTest, InPhase) {
+  EXPECT_READ32(SPI_DEVICE_RXF_PTR_REG_OFFSET,
+                {{SPI_DEVICE_RXF_PTR_WPTR_OFFSET, FifoPtr(0x57, true)},
+                 {SPI_DEVICE_RXF_PTR_RPTR_OFFSET, FifoPtr(0x42, true)}});
+  size_t bytes_remaining;
+  EXPECT_EQ(dif_spi_device_rx_pending(&spi_, &bytes_remaining),
+            kDifSpiDeviceResultOk);
+  EXPECT_EQ(bytes_remaining, 0x15);
+}
+
+TEST_F(RxPendingTest, OutOfPhaseFull) {
+  EXPECT_READ32(SPI_DEVICE_RXF_PTR_REG_OFFSET,
+                {{SPI_DEVICE_RXF_PTR_WPTR_OFFSET, FifoPtr(0x42, false)},
+                 {SPI_DEVICE_RXF_PTR_RPTR_OFFSET, FifoPtr(0x42, true)}});
+  size_t bytes_remaining;
+  EXPECT_EQ(dif_spi_device_rx_pending(&spi_, &bytes_remaining),
+            kDifSpiDeviceResultOk);
+  EXPECT_EQ(bytes_remaining, 0x400);
+}
+
+TEST_F(RxPendingTest, OutOfPhase) {
+  EXPECT_READ32(SPI_DEVICE_RXF_PTR_REG_OFFSET,
+                {{SPI_DEVICE_RXF_PTR_WPTR_OFFSET, FifoPtr(0x42, false)},
+                 {SPI_DEVICE_RXF_PTR_RPTR_OFFSET, FifoPtr(0x57, true)}});
+  size_t bytes_remaining;
+  EXPECT_EQ(dif_spi_device_rx_pending(&spi_, &bytes_remaining),
+            kDifSpiDeviceResultOk);
+  EXPECT_EQ(bytes_remaining, 0x3eb);
+}
+
+TEST_F(RxPendingTest, NullArgs) {
+  size_t bytes_remaining;
+  EXPECT_EQ(dif_spi_device_rx_pending(nullptr, &bytes_remaining),
+            kDifSpiDeviceResultBadArg);
+  EXPECT_EQ(dif_spi_device_rx_pending(&spi_, nullptr),
+            kDifSpiDeviceResultBadArg);
+}
+
+class TxPendingTest : public SpiTest {};
+
+TEST_F(TxPendingTest, BothZero) {
+  EXPECT_READ32(SPI_DEVICE_TXF_PTR_REG_OFFSET,
+                {{SPI_DEVICE_TXF_PTR_WPTR_OFFSET, 0x0},
+                 {SPI_DEVICE_TXF_PTR_RPTR_OFFSET, 0x0}});
+  size_t bytes_remaining;
+  EXPECT_EQ(dif_spi_device_tx_pending(&spi_, &bytes_remaining),
+            kDifSpiDeviceResultOk);
+  EXPECT_EQ(bytes_remaining, 0);
+}
+
+TEST_F(TxPendingTest, InPhaseEmpty) {
+  EXPECT_READ32(SPI_DEVICE_TXF_PTR_REG_OFFSET,
+                {{SPI_DEVICE_TXF_PTR_WPTR_OFFSET, FifoPtr(0x42, true)},
+                 {SPI_DEVICE_TXF_PTR_RPTR_OFFSET, FifoPtr(0x42, true)}});
+  size_t bytes_remaining;
+  EXPECT_EQ(dif_spi_device_tx_pending(&spi_, &bytes_remaining),
+            kDifSpiDeviceResultOk);
+  EXPECT_EQ(bytes_remaining, 0);
+}
+
+TEST_F(TxPendingTest, InPhase) {
+  EXPECT_READ32(SPI_DEVICE_TXF_PTR_REG_OFFSET,
+                {{SPI_DEVICE_TXF_PTR_WPTR_OFFSET, FifoPtr(0x57, true)},
+                 {SPI_DEVICE_TXF_PTR_RPTR_OFFSET, FifoPtr(0x42, true)}});
+  size_t bytes_remaining;
+  EXPECT_EQ(dif_spi_device_tx_pending(&spi_, &bytes_remaining),
+            kDifSpiDeviceResultOk);
+  EXPECT_EQ(bytes_remaining, 0x15);
+}
+
+TEST_F(TxPendingTest, OutOfPhaseFull) {
+  EXPECT_READ32(SPI_DEVICE_TXF_PTR_REG_OFFSET,
+                {{SPI_DEVICE_TXF_PTR_WPTR_OFFSET, FifoPtr(0x42, false)},
+                 {SPI_DEVICE_TXF_PTR_RPTR_OFFSET, FifoPtr(0x42, true)}});
+  size_t bytes_remaining;
+  EXPECT_EQ(dif_spi_device_tx_pending(&spi_, &bytes_remaining),
+            kDifSpiDeviceResultOk);
+  EXPECT_EQ(bytes_remaining, 0x400);
+}
+
+TEST_F(TxPendingTest, OutOfPhase) {
+  EXPECT_READ32(SPI_DEVICE_TXF_PTR_REG_OFFSET,
+                {{SPI_DEVICE_TXF_PTR_WPTR_OFFSET, FifoPtr(0x42, false)},
+                 {SPI_DEVICE_TXF_PTR_RPTR_OFFSET, FifoPtr(0x57, true)}});
+  size_t bytes_remaining;
+  EXPECT_EQ(dif_spi_device_tx_pending(&spi_, &bytes_remaining),
+            kDifSpiDeviceResultOk);
+  EXPECT_EQ(bytes_remaining, 0x3eb);
+}
+
+TEST_F(TxPendingTest, NullArgs) {
+  size_t bytes_remaining;
+  EXPECT_EQ(dif_spi_device_tx_pending(nullptr, &bytes_remaining),
+            kDifSpiDeviceResultBadArg);
+  EXPECT_EQ(dif_spi_device_tx_pending(&spi_, nullptr),
+            kDifSpiDeviceResultBadArg);
+}
+
+class RecvTest : public SpiTest {};
+
+TEST_F(RecvTest, EmptyFifo) {
+  EXPECT_READ32(SPI_DEVICE_RXF_PTR_REG_OFFSET,
+                {{SPI_DEVICE_RXF_PTR_WPTR_OFFSET, FifoPtr(0x5a, false)},
+                 {SPI_DEVICE_RXF_PTR_RPTR_OFFSET, FifoPtr(0x5a, false)}});
+
+  std::string buf(16, '\0');
+  size_t recv_len = 0;
+  EXPECT_EQ(dif_spi_device_recv(&spi_, const_cast<char *>(buf.data()),
+                                buf.size(), &recv_len),
+            kDifSpiDeviceResultOk);
+  EXPECT_EQ(recv_len, 0);
+  buf.resize(recv_len);
+  EXPECT_EQ(buf, "");
+}
+
+TEST_F(RecvTest, FullFifoAligned) {
+  EXPECT_READ32(SPI_DEVICE_RXF_PTR_REG_OFFSET,
+                {{SPI_DEVICE_RXF_PTR_WPTR_OFFSET, FifoPtr(0x50, true)},
+                 {SPI_DEVICE_RXF_PTR_RPTR_OFFSET, FifoPtr(0x50, false)}});
+
+  auto message = MakeBlob(kFifoLen);
+  auto fifo_base = SPI_DEVICE_BUFFER_REG_OFFSET + spi_.rx_fifo_base;
+  for (int i = 0; i < kFifoLen; i += 4) {
+    auto idx = fifo_base + (i + 0x50) % kFifoLen;
+    EXPECT_READ32(idx, LeInt(&message[i]));
+  }
+
+  EXPECT_WRITE32(SPI_DEVICE_RXF_PTR_REG_OFFSET,
+                 {{SPI_DEVICE_RXF_PTR_WPTR_OFFSET, FifoPtr(0x50, true)},
+                  {SPI_DEVICE_RXF_PTR_RPTR_OFFSET, FifoPtr(0x50, true)}});
+
+  std::vector<char> buf;
+  buf.resize(message.size() * 2);
+  size_t recv_len = 0;
+  EXPECT_EQ(dif_spi_device_recv(&spi_, buf.data(), buf.size(), &recv_len),
+            kDifSpiDeviceResultOk);
+  EXPECT_EQ(recv_len, message.size());
+  buf.resize(recv_len);
+  EXPECT_EQ(buf, message);
+}
+
+TEST_F(RecvTest, FullFifoSmallBuf) {
+  size_t buf_len = 0x22;
+
+  EXPECT_READ32(SPI_DEVICE_RXF_PTR_REG_OFFSET,
+                {{SPI_DEVICE_RXF_PTR_WPTR_OFFSET, FifoPtr(0x50, true)},
+                 {SPI_DEVICE_RXF_PTR_RPTR_OFFSET, FifoPtr(0x50, false)}});
+
+  auto message = MakeBlob(kFifoLen);
+  auto fifo_base = SPI_DEVICE_BUFFER_REG_OFFSET + spi_.rx_fifo_base;
+  for (size_t i = 0; i < buf_len; i += 4) {
+    auto idx = fifo_base + (i + 0x50) % kFifoLen;
+    EXPECT_READ32(idx, LeInt(&message[i]));
+  }
+
+  EXPECT_WRITE32(
+      SPI_DEVICE_RXF_PTR_REG_OFFSET,
+      {{SPI_DEVICE_RXF_PTR_WPTR_OFFSET, FifoPtr(0x50, true)},
+       {SPI_DEVICE_RXF_PTR_RPTR_OFFSET, FifoPtr(0x50 + buf_len, false)}});
+
+  std::vector<char> buf;
+  buf.resize(buf_len);
+  size_t recv_len = 0;
+  EXPECT_EQ(dif_spi_device_recv(&spi_, buf.data(), buf.size(), &recv_len),
+            kDifSpiDeviceResultOk);
+  EXPECT_EQ(recv_len, buf_len);
+  buf.resize(recv_len);
+  message.resize(recv_len);
+  EXPECT_EQ(buf, message);
+}
+
+TEST_F(RecvTest, FullyAligned) {
+  std::string message = "Hello, SPI!!";
+  ASSERT_EQ(message.size() % 4, 0);
+
+  EXPECT_READ32(
+      SPI_DEVICE_RXF_PTR_REG_OFFSET,
+      {{SPI_DEVICE_RXF_PTR_WPTR_OFFSET, FifoPtr(message.size(), false)},
+       {SPI_DEVICE_RXF_PTR_RPTR_OFFSET, FifoPtr(0x00, false)}});
+
+  auto fifo_base = SPI_DEVICE_BUFFER_REG_OFFSET + spi_.rx_fifo_base;
+  EXPECT_READ32(fifo_base + 0x0, LeInt(&message[0x0]));
+  EXPECT_READ32(fifo_base + 0x4, LeInt(&message[0x4]));
+  EXPECT_READ32(fifo_base + 0x8, LeInt(&message[0x8]));
+
+  EXPECT_WRITE32(
+      SPI_DEVICE_RXF_PTR_REG_OFFSET,
+      {{SPI_DEVICE_RXF_PTR_WPTR_OFFSET, FifoPtr(message.size(), false)},
+       {SPI_DEVICE_RXF_PTR_RPTR_OFFSET, FifoPtr(message.size(), false)}});
+
+  std::string buf(message.size() * 2, '\0');
+  size_t recv_len = 0;
+  EXPECT_EQ(dif_spi_device_recv(&spi_, const_cast<char *>(buf.data()),
+                                buf.size(), &recv_len),
+            kDifSpiDeviceResultOk);
+  EXPECT_EQ(recv_len, message.size());
+  buf.resize(recv_len);
+  EXPECT_EQ(buf, message);
+}
+
+TEST_F(RecvTest, UnalignedMessage) {
+  std::string message = "Hello, SPI!!";
+  ASSERT_EQ(message.size() % 4, 0);
+
+  uintptr_t cropped_len = 9;
+  EXPECT_READ32(SPI_DEVICE_RXF_PTR_REG_OFFSET,
+                {{SPI_DEVICE_RXF_PTR_WPTR_OFFSET, FifoPtr(cropped_len, false)},
+                 {SPI_DEVICE_RXF_PTR_RPTR_OFFSET, FifoPtr(0x00, false)}});
+
+  auto fifo_base = SPI_DEVICE_BUFFER_REG_OFFSET + spi_.rx_fifo_base;
+  EXPECT_READ32(fifo_base + 0x0, LeInt(&message[0x0]));
+  EXPECT_READ32(fifo_base + 0x4, LeInt(&message[0x4]));
+  EXPECT_READ32(fifo_base + 0x8, LeInt(&message[0x8]));
+
+  EXPECT_WRITE32(
+      SPI_DEVICE_RXF_PTR_REG_OFFSET,
+      {{SPI_DEVICE_RXF_PTR_WPTR_OFFSET, FifoPtr(cropped_len, false)},
+       {SPI_DEVICE_RXF_PTR_RPTR_OFFSET, FifoPtr(cropped_len, false)}});
+
+  std::string buf(message.size() * 2, '\0');
+  size_t recv_len = 0;
+  EXPECT_EQ(dif_spi_device_recv(&spi_, const_cast<char *>(buf.data()),
+                                buf.size(), &recv_len),
+            kDifSpiDeviceResultOk);
+  EXPECT_EQ(recv_len, cropped_len);
+
+  buf.resize(message.size());
+  EXPECT_NE(buf, message);
+
+  buf.resize(recv_len);
+  EXPECT_EQ(buf, message.substr(0, cropped_len));
+}
+
+TEST_F(RecvTest, UnalignedStart) {
+  std::string message = "Hello, SPI!!";
+  ASSERT_EQ(message.size() % 4, 0);
+
+  uintptr_t cropped_start = 1;
+  uintptr_t cropped_len = 9;
+  EXPECT_READ32(
+      SPI_DEVICE_RXF_PTR_REG_OFFSET,
+      {{SPI_DEVICE_RXF_PTR_WPTR_OFFSET, FifoPtr(cropped_len, false)},
+       {SPI_DEVICE_RXF_PTR_RPTR_OFFSET, FifoPtr(cropped_start, false)}});
+
+  auto fifo_base = SPI_DEVICE_BUFFER_REG_OFFSET + spi_.rx_fifo_base;
+  EXPECT_READ32(fifo_base + 0x0, LeInt(&message[0x0]));
+  EXPECT_READ32(fifo_base + 0x4, LeInt(&message[0x4]));
+  EXPECT_READ32(fifo_base + 0x8, LeInt(&message[0x8]));
+
+  EXPECT_WRITE32(
+      SPI_DEVICE_RXF_PTR_REG_OFFSET,
+      {{SPI_DEVICE_RXF_PTR_WPTR_OFFSET, FifoPtr(cropped_len, false)},
+       {SPI_DEVICE_RXF_PTR_RPTR_OFFSET, FifoPtr(cropped_len, false)}});
+
+  std::string buf(message.size() * 2, '\0');
+  size_t recv_len = 0;
+  EXPECT_EQ(dif_spi_device_recv(&spi_, const_cast<char *>(buf.data()),
+                                buf.size(), &recv_len),
+            kDifSpiDeviceResultOk);
+  EXPECT_EQ(recv_len, cropped_len - cropped_start);
+
+  buf.resize(message.size());
+  EXPECT_NE(buf, message);
+
+  buf.resize(recv_len);
+  EXPECT_EQ(buf, message.substr(cropped_start, cropped_len - cropped_start));
+}
+
+TEST_F(RecvTest, UnalignedSmall) {
+  std::string message = "Hello, SPI!!";
+  ASSERT_EQ(message.size() % 4, 0);
+
+  uintptr_t cropped_start = 1;
+  uintptr_t cropped_len = 3;
+  EXPECT_READ32(
+      SPI_DEVICE_RXF_PTR_REG_OFFSET,
+      {{SPI_DEVICE_RXF_PTR_WPTR_OFFSET, FifoPtr(cropped_len, false)},
+       {SPI_DEVICE_RXF_PTR_RPTR_OFFSET, FifoPtr(cropped_start, false)}});
+
+  auto fifo_base = SPI_DEVICE_BUFFER_REG_OFFSET + spi_.rx_fifo_base;
+  EXPECT_READ32(fifo_base + 0x0, LeInt(&message[0x0]));
+
+  EXPECT_WRITE32(
+      SPI_DEVICE_RXF_PTR_REG_OFFSET,
+      {{SPI_DEVICE_RXF_PTR_WPTR_OFFSET, FifoPtr(cropped_len, false)},
+       {SPI_DEVICE_RXF_PTR_RPTR_OFFSET, FifoPtr(cropped_len, false)}});
+
+  std::string buf(message.size() * 2, '\0');
+  size_t recv_len = 0;
+  EXPECT_EQ(dif_spi_device_recv(&spi_, const_cast<char *>(buf.data()),
+                                buf.size(), &recv_len),
+            kDifSpiDeviceResultOk);
+  EXPECT_EQ(recv_len, cropped_len - cropped_start);
+
+  buf.resize(message.size());
+  EXPECT_NE(buf, message);
+
+  buf.resize(recv_len);
+  EXPECT_EQ(buf, message.substr(cropped_start, cropped_len - cropped_start));
+}
+
+TEST_F(RecvTest, NullArgs) {
+  std::string buf(16, '\0');
+  size_t recv_len;
+
+  EXPECT_EQ(dif_spi_device_recv(nullptr, const_cast<char *>(buf.data()),
+                                buf.size(), &recv_len),
+            kDifSpiDeviceResultBadArg);
+  EXPECT_EQ(dif_spi_device_recv(&spi_, nullptr, buf.size(), &recv_len),
+            kDifSpiDeviceResultBadArg);
+
+  EXPECT_READ32(SPI_DEVICE_RXF_PTR_REG_OFFSET,
+                {{SPI_DEVICE_RXF_PTR_WPTR_OFFSET, FifoPtr(0x5a, false)},
+                 {SPI_DEVICE_RXF_PTR_RPTR_OFFSET, FifoPtr(0x5a, false)}});
+  EXPECT_EQ(dif_spi_device_recv(&spi_, const_cast<char *>(buf.data()),
+                                buf.size(), nullptr),
+            kDifSpiDeviceResultOk);
+}
+
+class SendTest : public SpiTest {};
+
+TEST_F(SendTest, FullFifo) {
+  EXPECT_READ32(SPI_DEVICE_TXF_PTR_REG_OFFSET,
+                {{SPI_DEVICE_TXF_PTR_WPTR_OFFSET, FifoPtr(0x5a, true)},
+                 {SPI_DEVICE_TXF_PTR_RPTR_OFFSET, FifoPtr(0x5a, false)}});
+
+  std::string message = "Hello, SPI!!";
+  size_t send_len = 0;
+  EXPECT_EQ(
+      dif_spi_device_send(&spi_, message.data(), message.size(), &send_len),
+      kDifSpiDeviceResultOk);
+  EXPECT_EQ(send_len, 0);
+}
+
+TEST_F(SendTest, EmptyToFull) {
+  EXPECT_READ32(SPI_DEVICE_TXF_PTR_REG_OFFSET,
+                {{SPI_DEVICE_TXF_PTR_WPTR_OFFSET, FifoPtr(0x50, true)},
+                 {SPI_DEVICE_TXF_PTR_RPTR_OFFSET, FifoPtr(0x50, true)}});
+
+  auto message = MakeBlob(kFifoLen);
+  auto fifo_base = SPI_DEVICE_BUFFER_REG_OFFSET + spi_.tx_fifo_base;
+  for (int i = 0; i < kFifoLen; i += 4) {
+    auto idx = fifo_base + (i + 0x50) % kFifoLen;
+    EXPECT_WRITE32(idx, LeInt(&message[i]));
+  }
+
+  EXPECT_WRITE32(SPI_DEVICE_TXF_PTR_REG_OFFSET,
+                 {{SPI_DEVICE_TXF_PTR_WPTR_OFFSET, FifoPtr(0x50, false)},
+                  {SPI_DEVICE_TXF_PTR_RPTR_OFFSET, FifoPtr(0x50, true)}});
+
+  size_t sent_len = 0;
+  EXPECT_EQ(
+      dif_spi_device_send(&spi_, message.data(), message.size(), &sent_len),
+      kDifSpiDeviceResultOk);
+  EXPECT_EQ(sent_len, message.size());
+}
+
+TEST_F(SendTest, AlmostFull) {
+  EXPECT_READ32(SPI_DEVICE_TXF_PTR_REG_OFFSET,
+                {{SPI_DEVICE_TXF_PTR_WPTR_OFFSET, FifoPtr(0x4e, true)},
+                 {SPI_DEVICE_TXF_PTR_RPTR_OFFSET, FifoPtr(0x50, false)}});
+
+  std::string message = "Hello, world!";
+  uintptr_t value = 0;
+  memcpy(&value, message.data(), 2);
+
+  auto fifo_base = SPI_DEVICE_BUFFER_REG_OFFSET + spi_.tx_fifo_base;
+  EXPECT_MASK32(fifo_base + 0x4c, {{0x10, 0xffff, value}});
+
+  EXPECT_WRITE32(SPI_DEVICE_TXF_PTR_REG_OFFSET,
+                 {{SPI_DEVICE_TXF_PTR_WPTR_OFFSET, FifoPtr(0x50, true)},
+                  {SPI_DEVICE_TXF_PTR_RPTR_OFFSET, FifoPtr(0x50, false)}});
+
+  size_t sent_len = 0;
+  EXPECT_EQ(
+      dif_spi_device_send(&spi_, message.data(), message.size(), &sent_len),
+      kDifSpiDeviceResultOk);
+  EXPECT_EQ(sent_len, 2);
+}
+
+TEST_F(SendTest, FullyAligned) {
+  std::string message = "Hello, SPI!!";
+  ASSERT_EQ(message.size() % 4, 0);
+
+  EXPECT_READ32(SPI_DEVICE_TXF_PTR_REG_OFFSET,
+                {{SPI_DEVICE_TXF_PTR_WPTR_OFFSET, FifoPtr(0x00, false)},
+                 {SPI_DEVICE_TXF_PTR_RPTR_OFFSET, FifoPtr(0x00, false)}});
+
+  auto fifo_base = SPI_DEVICE_BUFFER_REG_OFFSET + spi_.tx_fifo_base;
+  EXPECT_WRITE32(fifo_base + 0x0, LeInt(&message[0x0]));
+  EXPECT_WRITE32(fifo_base + 0x4, LeInt(&message[0x4]));
+  EXPECT_WRITE32(fifo_base + 0x8, LeInt(&message[0x8]));
+
+  EXPECT_WRITE32(
+      SPI_DEVICE_TXF_PTR_REG_OFFSET,
+      {{SPI_DEVICE_TXF_PTR_WPTR_OFFSET, FifoPtr(message.size(), false)},
+       {SPI_DEVICE_TXF_PTR_RPTR_OFFSET, FifoPtr(0x0, false)}});
+
+  size_t send_len = 0;
+  EXPECT_EQ(
+      dif_spi_device_send(&spi_, message.data(), message.size(), &send_len),
+      kDifSpiDeviceResultOk);
+  EXPECT_EQ(send_len, message.size());
+}
+
+TEST_F(SendTest, UnalignedMessage) {
+  std::string message = "Hello, SPI!!";
+  ASSERT_EQ(message.size() % 4, 0);
+
+  uintptr_t cropped_len = 9;
+  EXPECT_READ32(SPI_DEVICE_TXF_PTR_REG_OFFSET,
+                {{SPI_DEVICE_TXF_PTR_WPTR_OFFSET, FifoPtr(0x00, false)},
+                 {SPI_DEVICE_TXF_PTR_RPTR_OFFSET, FifoPtr(0x00, false)}});
+
+  auto fifo_base = SPI_DEVICE_BUFFER_REG_OFFSET + spi_.tx_fifo_base;
+  EXPECT_WRITE32(fifo_base + 0x0, LeInt(&message[0x0]));
+  EXPECT_WRITE32(fifo_base + 0x4, LeInt(&message[0x4]));
+
+  uintptr_t value = 0;
+  memcpy(&value, &message[0x8], 1);
+  EXPECT_MASK32(fifo_base + 0x8, {{0x0, 0xff, value}});
+
+  EXPECT_WRITE32(SPI_DEVICE_TXF_PTR_REG_OFFSET,
+                 {{SPI_DEVICE_TXF_PTR_WPTR_OFFSET, FifoPtr(cropped_len, false)},
+                  {SPI_DEVICE_TXF_PTR_RPTR_OFFSET, FifoPtr(0x0, false)}});
+
+  size_t send_len = 0;
+  EXPECT_EQ(dif_spi_device_send(&spi_, message.data(), cropped_len, &send_len),
+            kDifSpiDeviceResultOk);
+  EXPECT_EQ(send_len, cropped_len);
+}
+
+TEST_F(SendTest, UnalignedStart) {
+  std::string message = "Hello, SPI!!";
+  ASSERT_EQ(message.size() % 4, 0);
+
+  uintptr_t cropped_start = 1;
+  uintptr_t cropped_len = 9;
+  EXPECT_READ32(
+      SPI_DEVICE_TXF_PTR_REG_OFFSET,
+      {{SPI_DEVICE_TXF_PTR_WPTR_OFFSET, FifoPtr(cropped_start, false)},
+       {SPI_DEVICE_TXF_PTR_RPTR_OFFSET, FifoPtr(cropped_start, false)}});
+
+  auto fifo_base = SPI_DEVICE_BUFFER_REG_OFFSET + spi_.tx_fifo_base;
+
+  uintptr_t start_value = 0;
+  memcpy(&start_value, &message[0x0], 3);
+  EXPECT_MASK32(fifo_base + 0x0, {{0x8, 0xffffff, start_value}});
+  EXPECT_WRITE32(fifo_base + 0x4, LeInt(&message[0x3]));
+
+  uintptr_t end_value = 0;
+  memcpy(&end_value, &message[0x7], 2);
+  EXPECT_MASK32(fifo_base + 0x8, {{0x0, 0xffff, end_value}});
+
+  EXPECT_WRITE32(
+      SPI_DEVICE_TXF_PTR_REG_OFFSET,
+      {{SPI_DEVICE_TXF_PTR_WPTR_OFFSET,
+        FifoPtr(cropped_len + cropped_start, false)},
+       {SPI_DEVICE_TXF_PTR_RPTR_OFFSET, FifoPtr(cropped_start, false)}});
+
+  size_t send_len = 0;
+  EXPECT_EQ(dif_spi_device_send(&spi_, message.data(), cropped_len, &send_len),
+            kDifSpiDeviceResultOk);
+  EXPECT_EQ(send_len, cropped_len);
+}
+
+TEST_F(SendTest, UnalignedSmall) {
+  std::string message = "Hello, SPI!!";
+  ASSERT_EQ(message.size() % 4, 0);
+
+  uintptr_t cropped_start = 1;
+  uintptr_t cropped_len = 2;
+  EXPECT_READ32(
+      SPI_DEVICE_TXF_PTR_REG_OFFSET,
+      {{SPI_DEVICE_TXF_PTR_WPTR_OFFSET, FifoPtr(cropped_start, false)},
+       {SPI_DEVICE_TXF_PTR_RPTR_OFFSET, FifoPtr(cropped_start, false)}});
+
+  auto fifo_base = SPI_DEVICE_BUFFER_REG_OFFSET + spi_.tx_fifo_base;
+
+  uintptr_t start_value = 0;
+  memcpy(&start_value, &message[0x0], 2);
+  EXPECT_MASK32(fifo_base + 0x0, {{0x8, 0xffff, start_value}});
+
+  EXPECT_WRITE32(
+      SPI_DEVICE_TXF_PTR_REG_OFFSET,
+      {{SPI_DEVICE_TXF_PTR_WPTR_OFFSET,
+        FifoPtr(cropped_len + cropped_start, false)},
+       {SPI_DEVICE_TXF_PTR_RPTR_OFFSET, FifoPtr(cropped_start, false)}});
+
+  size_t send_len = 0;
+  EXPECT_EQ(dif_spi_device_send(&spi_, message.data(), cropped_len, &send_len),
+            kDifSpiDeviceResultOk);
+  EXPECT_EQ(send_len, cropped_len);
+}
+
+TEST_F(SendTest, NullArgs) {
+  std::string buf(16, '\0');
+  size_t recv_len;
+
+  EXPECT_EQ(dif_spi_device_send(nullptr, buf.data(), buf.size(), &recv_len),
+            kDifSpiDeviceResultBadArg);
+  EXPECT_EQ(dif_spi_device_send(&spi_, nullptr, buf.size(), &recv_len),
+            kDifSpiDeviceResultBadArg);
+
+  EXPECT_READ32(SPI_DEVICE_TXF_PTR_REG_OFFSET,
+                {{SPI_DEVICE_TXF_PTR_WPTR_OFFSET, FifoPtr(0x5a, true)},
+                 {SPI_DEVICE_TXF_PTR_RPTR_OFFSET, FifoPtr(0x5a, false)}});
+  EXPECT_EQ(dif_spi_device_send(&spi_, buf.data(), buf.size(), nullptr),
+            kDifSpiDeviceResultOk);
+}
+}  // namespace
+}  // namespace dif_spi_device_test

--- a/sw/device/tests/dif/meson.build
+++ b/sw/device/tests/dif/meson.build
@@ -1,0 +1,19 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+test('dif_spi_device_test', executable(
+  'dif_spi_device_test',
+  sources: [
+    hw_ip_spi_device_reg_h,
+    meson.source_root() / 'sw/device/lib/dif/dif_spi_device.c',
+    'dif_spi_device_test.cc',
+  ],
+  dependencies: [
+    sw_vendor_gtest,
+    sw_lib_testing_mock_mmio,
+  ],
+  native: true,
+  c_args: ['-DMOCK_MMIO'],
+  cpp_args: ['-DMOCK_MMIO'],
+))

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -2,6 +2,8 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+subdir('dif')
+
 subdir('aes')
 subdir('flash_ctrl')
 subdir('hmac')


### PR DESCRIPTION
This change also removes the old SPI library and replaces all of its callsites.

This change replaces https://github.com/lowRISC/opentitan/pull/1135, and is such a significant rework that I would like it to be reviewed from scratch, too.