### PR TITLE
[ROM] Double ROM size to 16KB

### DIFF
--- a/doc/ug/getting_started_verilator.md
+++ b/doc/ug/getting_started_verilator.md
@@ -25,7 +25,7 @@ There are 3 memory types: ROM, RAM and Flash.
 By default, the system will first execute out of ROM and then jump to flash.
 A program needs to be built for each until ROM functionality for code download is ready.
 
-For that purpose compile the demo program with "simulation" settings, which adjusts the frequencies to better match the simulation speed. 
+For that purpose compile the demo program with "simulation" settings, which adjusts the frequencies to better match the simulation speed.
 For more information on building software targets refer to the [Software Getting Started Guide]({{< relref "getting_started_sw.md" >}}).
 
 ```console

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -703,7 +703,7 @@
       }
       type: rom
       base_addr: 0x00008000
-      size: 0x2000
+      size: 0x4000
     }
     {
       name: ram_main
@@ -849,7 +849,7 @@
           [
             {
               base_addr: 0x00008000
-              size_byte: 0x2000
+              size_byte: 0x4000
             }
           ]
           xbar: false

--- a/hw/top_earlgrey/data/placement.xdc
+++ b/hw/top_earlgrey/data/placement.xdc
@@ -3,3 +3,5 @@
 # 2. hw/top_earlgrey/util/vivado_hook_opt_design_post.tcl
 set_property LOC RAMB36_X4Y18 [get_cells -hierarchical -filter { NAME =~  "*rom_rom*dout_o_reg_0" && PRIMITIVE_TYPE =~ BMEM.*.* }]
 set_property LOC RAMB36_X4Y19 [get_cells -hierarchical -filter { NAME =~  "*rom_rom*dout_o_reg_1" && PRIMITIVE_TYPE =~ BMEM.*.* }]
+set_property LOC RAMB36_X3Y14 [get_cells -hierarchical -filter { NAME =~  "*rom_rom*dout_o_reg_2" && PRIMITIVE_TYPE =~ BMEM.*.* }]
+set_property LOC RAMB36_X3Y15 [get_cells -hierarchical -filter { NAME =~  "*rom_rom*dout_o_reg_3" && PRIMITIVE_TYPE =~ BMEM.*.* }]

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -138,7 +138,7 @@
       reset_connections: {rst_ni: "sys"},
       type: "rom",
       base_addr: "0x00008000",
-      size: "0x2000"
+      size: "0x4000"
     },
     { name: "ram_main",
       clock_connections: {clk_i: "main"},

--- a/hw/top_earlgrey/doc/_index.md
+++ b/hw/top_earlgrey/doc/_index.md
@@ -19,7 +19,7 @@ This is not a specification of the final implementation.
 - Memory contents
   - 512kB emulated eFlash for code and data storage
   - 64kB SRAM for data storage
-  - 8kB ROM for secure boot code storage
+  - 16kB ROM for secure boot code storage
 - Security peripherals
   - Flash controller
   - AES-ECB module
@@ -196,7 +196,7 @@ CoreMark was compiled with GCC 9.2.0 with flags: `-march=rv32imc -mabi=ilp32 -mc
 
 The device contains three memory address spaces for instruction and data.
 
-Instruction ROM (8kB) is the target for the Ibex processor after release of external reset.
+Instruction ROM (16kB) is the target for the Ibex processor after release of external reset.
 The ROM contains hard-coded instructions whose purpose is to do a minimal subset of platform checking before checking the next stage of code.
 The next stage - a boot loader stored in embedded flash memory - is the first piece of code that is not hard-coded into the silicon of the device, and thus must be signature checked.
 The ROM executes this signature check by implementing a RSA-check algorithm on the full contents of the boot loader.
@@ -437,7 +437,7 @@ For the purpose of `top_earlgrey`, the first option has been chosen to benefit s
 
 | Item | base address | bound address |
 | --- | --- | --- |
-| `ROM`        | `0x00008000` | `0x00009fff` |
+| `ROM`        | `0x00008000` | `0x0000bfff` |
 | `SRAM`       | `0x10000000` | `0x1000ffff` |
 | `Flash`      | `0x20000000` | `0x2007ffff` |
 | `uart`       | `0x40000000` | `0x4000ffff` |

--- a/hw/top_earlgrey/ip/xbar_main/data/autogen/xbar_main.gen.hjson
+++ b/hw/top_earlgrey/ip/xbar_main/data/autogen/xbar_main.gen.hjson
@@ -101,7 +101,7 @@
       [
         {
           base_addr: 0x00008000
-          size_byte: 0x2000
+          size_byte: 0x4000
         }
       ]
       xbar: false

--- a/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_env_pkg__params.sv
+++ b/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_env_pkg__params.sv
@@ -8,7 +8,7 @@
 // List of Xbar device memory map
 tl_device_t xbar_devices[$] = '{
     '{"rom", '{
-        '{32'h00008000, 32'h00009fff}
+        '{32'h00008000, 32'h0000bfff}
     }},
     '{"debug_mem", '{
         '{32'h1a110000, 32'h1a110fff}

--- a/hw/top_earlgrey/ip/xbar_main/rtl/autogen/tl_main_pkg.sv
+++ b/hw/top_earlgrey/ip/xbar_main/rtl/autogen/tl_main_pkg.sv
@@ -23,7 +23,7 @@ package tl_main_pkg;
   localparam logic [31:0] ADDR_SPACE_ALERT_HANDLER = 32'h 40130000;
   localparam logic [31:0] ADDR_SPACE_NMI_GEN       = 32'h 40140000;
 
-  localparam logic [31:0] ADDR_MASK_ROM           = 32'h 00001fff;
+  localparam logic [31:0] ADDR_MASK_ROM           = 32'h 00003fff;
   localparam logic [31:0] ADDR_MASK_DEBUG_MEM     = 32'h 00000fff;
   localparam logic [31:0] ADDR_MASK_RAM_MAIN      = 32'h 0000ffff;
   localparam logic [31:0] ADDR_MASK_EFLASH        = 32'h 0007ffff;

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -337,12 +337,12 @@ module top_earlgrey #(
 
   // ROM device
   logic        rom_req;
-  logic [10:0] rom_addr;
+  logic [11:0] rom_addr;
   logic [31:0] rom_rdata;
   logic        rom_rvalid;
 
   tlul_adapter_sram #(
-    .SramAw(11),
+    .SramAw(12),
     .SramDw(32),
     .Outstanding(1),
     .ErrOnWrite(1)
@@ -366,7 +366,7 @@ module top_earlgrey #(
 
   prim_rom #(
     .Width(32),
-    .Depth(2048)
+    .Depth(4096)
   ) u_rom_rom (
     .clk_i   (main_clk),
     .rst_ni   (sys_rst_n),

--- a/sw/device/boot_rom/rom_link.ld
+++ b/sw/device/boot_rom/rom_link.ld
@@ -17,7 +17,7 @@ GROUP(-lgcc)
 __DYNAMIC = 0;
 
 MEMORY {
-  rom(rx)   : ORIGIN = 0x00008000, LENGTH = 0x2000
+  rom(rx)   : ORIGIN = 0x00008000, LENGTH = 0x4000
   ram(w)    : ORIGIN = 0x10000000, LENGTH = 0x10000
   flash(rx) : ORIGIN = 0x20000000, LENGTH = 0x100000
 }
@@ -51,7 +51,7 @@ _chip_info_start = ORIGIN(rom) + LENGTH(rom) - _chip_info_size;
  */
 SECTIONS {
   /**
-   * Ibex interrupt vector. See irq_vector.S for more information. 
+   * Ibex interrupt vector. See irq_vector.S for more information.
    *
    * This has to be set up at the boot address, so that execution jumps to the
    * reset handler correctly.
@@ -87,17 +87,17 @@ SECTIONS {
   } > rom
 
   /**
-   * "Intitial data" section, the initial values of the mutable data section 
+   * "Intitial data" section, the initial values of the mutable data section
    * initialized at runtime.
-   */ 
+   */
   .idata : ALIGN(4) {
     _data_init_start = .;
   } > rom
 
-  /** 
+  /**
    * Standard mutable data section, at the bottom of RAM. This will be
    * initialized from the .idata section at runtime by the CRT.
-   */ 
+   */
   .data ORIGIN(ram): AT(_data_init_start) ALIGN(4) {
     _data_start = .;
     *(.data)

--- a/util/fpga/bram_load.mmi
+++ b/util/fpga/bram_load.mmi
@@ -1,16 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <MemInfo Version="1" Minor="0">
   <Processor Endianness="Little" InstPath="dummy">
-  <AddressSpace Name="axi_bram_ctrl_0_bram" Begin="0" End="8191">
+  <AddressSpace Name="brom" Begin="0" End="4095">
       <BusBlock>
         <BitLane MemType="RAMB32" Placement="X4Y18">
-          <DataWidth MSB="15" LSB="0"/>
-          <AddressRange Begin="0" End="2047"/>
+          <DataWidth MSB="7" LSB="0"/>
+          <AddressRange Begin="0" End="4095"/>
           <Parity ON="false" NumBits="0"/>
         </BitLane>
         <BitLane MemType="RAMB32" Placement="X4Y19">
-          <DataWidth MSB="31" LSB="16"/>
-          <AddressRange Begin="0" End="2047"/>
+          <DataWidth MSB="15" LSB="8"/>
+          <AddressRange Begin="0" End="4095"/>
+          <Parity ON="false" NumBits="0"/>
+        </BitLane>
+        <BitLane MemType="RAMB32" Placement="X3Y14">
+          <DataWidth MSB="23" LSB="16"/>
+          <AddressRange Begin="0" End="4095"/>
+          <Parity ON="false" NumBits="0"/>
+        </BitLane>
+        <BitLane MemType="RAMB32" Placement="X3Y15">
+          <DataWidth MSB="31" LSB="24"/>
+          <AddressRange Begin="0" End="4095"/>
           <Parity ON="false" NumBits="0"/>
         </BitLane>
       </BusBlock>


### PR DESCRIPTION
- Current software development is running out of space, so the ROM is doubled
  to accommodate the increase

- Note, at the moment bram_load.mmi and placement.xdc need to be manually updated.  It seems simple enough to re-create this file as long as a tcl hook can be provided as part of the build flow.  Need to check to see if this is possible.

Signed-off-by: Timothy Chen <timothytim@google.com>