### PR TITLE
[dvsim] Avoid using the secrets module

### DIFF
--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -10,7 +10,6 @@ import logging as log
 import pprint
 import random
 import re
-import secrets
 import shlex
 import sys
 import time
@@ -528,10 +527,8 @@ class RunTest(Deploy):
     @staticmethod
     def get_seed():
         if RunTest.seeds == []:
-            # Py lib 'secrets' provides crypto quality strong random numbers.
             for i in range(1000):
-                seed = secrets.token_bytes(4)
-                seed = int.from_bytes(seed, byteorder='little')
+                seed = random.getrandbits(32)
                 RunTest.seeds.append(seed)
         return RunTest.seeds.pop(0)
 

--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -526,7 +526,7 @@ class RunTest(Deploy):
 
     @staticmethod
     def get_seed():
-        if RunTest.seeds == []:
+        if not RunTest.seeds:
             for i in range(1000):
                 seed = random.getrandbits(32)
                 RunTest.seeds.append(seed)


### PR DESCRIPTION
The `secrets` Python module is currently not listed as dependency in the
`python_requirements.txt` file. It is also tricky to install with `pip` as
it contains binary components that depend on OpenSSL being present on the
system.

To simplify things, this commit switches to using the `random` core Python
module to generate random seeds. There is no requirements for simulation
seeds to be cryptographically secure, so this change shouldn't affect the
quality of our simulations.