### PR TITLE
[sw] Clean up example device programs

### DIFF
--- a/sw/device/examples/demos.c
+++ b/sw/device/examples/demos.c
@@ -1,0 +1,80 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/examples/demos.h"
+
+#include <stdbool.h>
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/dif/dif_gpio.h"
+#include "sw/device/lib/log.h"
+#include "sw/device/lib/runtime/hart.h"
+#include "sw/device/lib/spi_device.h"
+#include "sw/device/lib/uart.h"
+
+void demo_gpio_startup(dif_gpio_t *gpio) {
+  LOG_INFO("Watch the LEDs!\n");
+
+  // Give a LED pattern as startup indicator for 5 seconds.
+  dif_gpio_all_write(gpio, 0xff00);
+  for (int i = 0; i < 32; ++i) {
+    usleep(5 * 1000);  // 5 ms
+    dif_gpio_pin_write(gpio, 8 + (i % 8), (i / 8) % 2);
+  }
+  dif_gpio_all_write(gpio, 0x0000);  // All LEDs off.
+}
+
+/**
+ * Mask for "valid" GPIO bits. The first byte represents switch inputs,
+ * while byte 16 represents the FTDI bit.
+ */
+static const uint32_t kGpioMask = 0x100ff;
+
+/**
+ * Mask for the FTDI bit among the GPIO bits.
+ */
+static const uint32_t kFtdiMask = 0x10000;
+
+uint32_t demo_gpio_to_log_echo(dif_gpio_t *gpio, uint32_t prev_gpio_state) {
+  uint32_t gpio_state;
+  dif_gpio_all_read(gpio, &gpio_state);
+  gpio_state &= kGpioMask;
+
+  uint32_t state_delta = prev_gpio_state ^ gpio_state;
+  for (int bit_idx = 0; bit_idx < 8; ++bit_idx) {
+    bool changed = ((state_delta >> bit_idx) & 0x1) != 0;
+    bool is_currently_set = ((gpio_state >> bit_idx) & 0x1) != 0;
+    if (changed) {
+      LOG_INFO("GPIO switch #%d changed to %d\n", bit_idx, is_currently_set);
+    }
+  }
+
+  if ((state_delta & kFtdiMask) != 0) {
+    if ((gpio_state & kFtdiMask) != 0) {
+      LOG_INFO("FTDI control changed. Enable JTAG.\r\n");
+    } else {
+      LOG_INFO("FTDI control changed. Enable JTAG.\r\n");
+    }
+  }
+
+  return gpio_state;
+}
+
+void demo_spi_to_log_echo(void) {
+  uint32_t spi_buf[8];
+  size_t spi_len = spid_read_nb(spi_buf, sizeof(spi_buf));
+  if (spi_len > 0) {
+    uint32_t echo_word = spi_buf[0] ^ 0x01010101;
+    spid_send(&echo_word, sizeof(echo_word));
+    LOG_INFO("SPI: %z\r\n", spi_len, spi_buf);
+  }
+}
+
+void demo_uart_to_uart_and_gpio_echo(dif_gpio_t *gpio) {
+  char rcv_char;
+  while (uart_rcv_char(&rcv_char) != -1) {
+    uart_send_char(rcv_char);
+    dif_gpio_all_write(gpio, rcv_char << 8);
+  }
+}

--- a/sw/device/examples/demos.h
+++ b/sw/device/examples/demos.h
@@ -1,0 +1,52 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_EXAMPLES_DEMOS_H_
+#define OPENTITAN_SW_DEVICE_EXAMPLES_DEMOS_H_
+
+#include <stdint.h>
+
+#include "sw/device/lib/dif/dif_gpio.h"
+
+/**
+ * This header provides a small library of reuseable demos for use with
+ * OpenTitan example code.
+ */
+
+/**
+ * Runs a small demo on the GPIO pins to show that things are working.
+ *
+ * @param gpio the GPIO device to actuate.
+ */
+void demo_gpio_startup(dif_gpio_t *gpio);
+
+/**
+ * Executes a step of a GPIO -> LOG echo demo, by diffing
+ * the previous GPIO state with the current state, and reporting
+ * the difference.
+ *
+ * The new state is returned, so it can be passed in on the next
+ * iteration.
+ *
+ * @param gpio the GPIO device to pull bits from.
+ * @param prev_gpio_state the previous GPIO state to diff against.
+ * @return the new GPIO state.
+ */
+uint32_t demo_gpio_to_log_echo(dif_gpio_t *gpio, uint32_t prev_gpio_state);
+
+/**
+ * Attempts to read at most 32 bytes from SPI, and echo them as printable
+ * characters to LOG.
+ */
+void demo_spi_to_log_echo(void);
+
+/**
+ * Attempts to read characters from UART and immediately echo them back,
+ * as well as to write its bits to GPIO pins 8-15.
+ *
+ * @param gpio the GPIO device to actuate.
+ */
+void demo_uart_to_uart_and_gpio_echo(dif_gpio_t *gpio);
+
+#endif  // OPENTITAN_SW_DEVICE_EXAMPLES_DEMOS_H_

--- a/sw/device/examples/hello_usbdev/hello_usbdev.c
+++ b/sw/device/examples/hello_usbdev/hello_usbdev.c
@@ -2,12 +2,14 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include <stdalign.h>
 #include <stdbool.h>
 
+#include "sw/device/examples/demos.h"
 #include "sw/device/lib/arch/device.h"
-#include "sw/device/lib/base/stdasm.h"
 #include "sw/device/lib/common.h"
 #include "sw/device/lib/dif/dif_gpio.h"
+#include "sw/device/lib/log.h"
 #include "sw/device/lib/pinmux.h"
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/spi_device.h"
@@ -20,154 +22,122 @@
 #define USBDEV_BASE_ADDR 0x40150000
 #include "usbdev_regs.h"  // Generated.
 
-#define SPI_MAX 32
-#define GPIO0_BASE_ADDR 0x40010000u
+/**
+ * Configuration values for USB.
+ */
+static uint8_t config_descriptors[] = {
+    USB_CFG_DSCR_HEAD(USB_CFG_DSCR_LEN +
+                          2 * (USB_INTERFACE_DSCR_LEN + 2 * USB_EP_DSCR_LEN),
+                      2),
+    VEND_INTERFACE_DSCR(0, 2, 0x50, 1),
+    USB_BULK_EP_DSCR(0, 1, 32, 0),
+    USB_BULK_EP_DSCR(1, 1, 32, 4),
+    VEND_INTERFACE_DSCR(1, 2, 0x50, 1),
+    USB_BULK_EP_DSCR(0, 2, 32, 0),
+    USB_BULK_EP_DSCR(1, 2, 32, 4),
+};
+
+/**
+ * USB device context types.
+ */
+static usbdev_ctx_t usbdev;
+static usb_controlep_ctx_t usbdev_control;
+static usb_ss_ctx_t simple_serial0;
+static usb_ss_ctx_t simple_serial1;
+
+/**
+ * Makes |c| into a printable character, replacing it with |replacement|
+ * as necessary.
+ */
+static char make_printable(char c, char replacement) {
+  if (c == 0xa || c == 0xd) {
+    return c;
+  }
+
+  if (c < ' ' || c > '~') {
+    c = replacement;
+  }
+  return c;
+}
+
+static const size_t kExpectedUsbCharsRecved = 6;
+static size_t usb_chars_recved_total;
+
+/**
+ * Callbacks for processing USB reciept. The latter increments the
+ * recieved character by one, to make them distinct.
+ */
+static void usb_receipt_callback_0(uint8_t c) {
+  c = make_printable(c, '?');
+  uart_send_char(c);
+  ++usb_chars_recved_total;
+}
+static void usb_receipt_callback_1(uint8_t c) {
+  c = make_printable(c + 1, '?');
+  uart_send_char(c);
+  ++usb_chars_recved_total;
+}
 
 static dif_gpio_t gpio;
-
-// called from ctr0 when something bad happens
-// char I=illegal instruction, A=lsu error (address), E=ecall
-void trap_handler(uint32_t mepc, char c) {
-  uart_send_char(c);
-  uart_send_uint(mepc, 32);
-  while (1) {
-    dif_gpio_all_write(&gpio, 0xAA00);  // pattern
-    usleep(200 * 1000);
-    dif_gpio_all_write(&gpio, 0x5500);  // pattern
-    usleep(100 * 1000);
-  }
-}
-
-#define MK_PRINT(c) \
-  (((c != 0xa) && (c != 0xd) && ((c < 32) || (c > 126))) ? '_' : c)
-
-// Build Configuration descriptor array
-static uint8_t cfg_dscr[] = {
-    USB_CFG_DSCR_HEAD(
-        USB_CFG_DSCR_LEN + 2 * (USB_INTERFACE_DSCR_LEN + 2 * USB_EP_DSCR_LEN),
-        2) VEND_INTERFACE_DSCR(0, 2, 0x50, 1) USB_BULK_EP_DSCR(0, 1, 32, 0)
-        USB_BULK_EP_DSCR(1, 1, 32, 4) VEND_INTERFACE_DSCR(1, 2, 0x50, 1)
-            USB_BULK_EP_DSCR(0, 2, 32, 0) USB_BULK_EP_DSCR(1, 2, 32, 4)};
-
-/* context areas */
-static usbdev_ctx_t usbdev_ctx;
-static usb_controlep_ctx_t control_ctx;
-static usb_ss_ctx_t ss_ctx[2];
-
-// We signal PASS! after receiving USB_MAX.
-static volatile unsigned int num_chars_rx = 0;
-#ifndef USB_MAX
-#define USB_MAX 6
-#endif
-
-/* Inbound USB characters get printed to the UART via these callbacks */
-/* Not ideal because the UART is slower */
-static void serial_rx0(uint8_t c) {
-  uart_send_char(MK_PRINT(c));
-  num_chars_rx++;
-}
-/* Add one to rx character so you can tell it is the second instance */
-static void serial_rx1(uint8_t c) {
-  uart_send_char(MK_PRINT(c + 1));
-  num_chars_rx++;
-}
 
 int main(int argc, char **argv) {
   uart_init(kUartBaudrate);
   pinmux_init();
   spid_init();
-  // Enable GPIO: 0-7 and 16 is input, 8-15 is output
+
   dif_gpio_config_t gpio_config = {.base_addr =
-                                       mmio_region_from_addr(GPIO0_BASE_ADDR)};
+                                       mmio_region_from_addr(0x40010000)};
   dif_gpio_init(&gpio_config, &gpio);
-  dif_gpio_output_mode_all_set(&gpio, 0xFF00);
+  // Enable GPIO: 0-7 and 16 is input; 8-15 is output.
+  dif_gpio_output_mode_all_set(&gpio, 0x0ff00);
 
-  // Add DATE and TIME because I keep fooling myself with old versions
-  uart_send_str(
-      "Hello USB! "__DATE__
-      " "__TIME__
-      "\r\n");
-  uart_send_str("Characters from UART go to USB and GPIO\r\n");
-  uart_send_str("Characters from USB go to UART\r\n");
+  LOG_INFO("Hello, USB!\n");
+  LOG_INFO("Built at " __DATE__ " " __TIME__ "\n");
 
-  // Give a LED pattern as startup indicator for 5 seconds
-  dif_gpio_all_write(&gpio, 0xAA00);  // pattern
-  usleep(1000);
-  dif_gpio_all_write(&gpio, 0x5500);  // pattern
-  // usbdev_init here so dpi code will not start until simulation
-  // got through all the printing (which takes a while if --trace)
-  usbdev_init(&usbdev_ctx);
-  usb_controlep_init(&control_ctx, &usbdev_ctx, 0, cfg_dscr, sizeof(cfg_dscr));
-  usb_simpleserial_init(&ss_ctx[0], &usbdev_ctx, 1, serial_rx0);
-  usb_simpleserial_init(&ss_ctx[1], &usbdev_ctx, 2, serial_rx1);
-  bool pass_signaled = false;
+  demo_gpio_startup(&gpio);
 
-  uint32_t gpio_in;
-  uint32_t gpio_in_prev = 0;
-  uint32_t gpio_in_changes;
-  uint8_t spi_buf[SPI_MAX];
-  uint32_t spi_in;
+  // Call |usbdev_init| here so that DPI will not start until the
+  // simulation has finished all of the printing, which takes a while
+  // if |--trace| was passed in.
+  usbdev_init(&usbdev);
+  usb_controlep_init(&usbdev_control, &usbdev, 0, config_descriptors,
+                     sizeof(config_descriptors));
+  usb_simpleserial_init(&simple_serial0, &usbdev, 1, usb_receipt_callback_0);
+  usb_simpleserial_init(&simple_serial1, &usbdev, 2, usb_receipt_callback_1);
 
   spid_send("SPI!", 4);
 
-  while (1) {
-    usbdev_poll(&usbdev_ctx);
+  uint32_t gpio_state = 0;
+  bool pass_signaled = false;
+  while (true) {
+    usbdev_poll(&usbdev);
 
-    // report changed switches over UART
-    dif_gpio_all_read(&gpio, &gpio_in);
-    gpio_in &= 0x100FF;  // 0-7 is switch input, 16 is FTDI
-    gpio_in_changes = (gpio_in & ~gpio_in_prev) | (~gpio_in & gpio_in_prev);
-    for (int b = 0; b < 8; b++) {
-      if (gpio_in_changes & (1 << b)) {
-        int val_now = (gpio_in >> b) & 0x01;
-        uart_send_str("GPIO: Switch ");
-        uart_send_char(b + 48);
-        uart_send_str(" changed to ");
-        uart_send_char(val_now + 48);
-        uart_send_str("\r\n");
-      }
-    }
-    if (gpio_in_changes & 0x10000) {
-      uart_send_str("FTDI control changed. Enable ");
-      uart_send_str((gpio_in & 0x10000) ? "JTAG\r\n" : "SPI\r\n");
-    }
-    gpio_in_prev = gpio_in;
+    gpio_state = demo_gpio_to_log_echo(&gpio, gpio_state);
+    demo_spi_to_log_echo();
 
-    // SPI character echo
-    spi_in = spid_read_nb(spi_buf, SPI_MAX);
-    if (spi_in) {
-      uint32_t d = (*(uint32_t *)spi_buf) ^ 0x01010101;
-      spid_send(&d, 4);
-      uart_send_str("SPI: ");
-      for (int i = 0; i < spi_in; i++) {
-        uart_send_char(MK_PRINT(spi_buf[i]));
-      }
-      uart_send_str("\r\n");
-    }
-    // UART echo
     char rcv_char;
     while (uart_rcv_char(&rcv_char) != -1) {
       uart_send_char(rcv_char);
       dif_gpio_all_write(&gpio, rcv_char << 8);
+
       if (rcv_char == '/') {
-        uart_send_char('I');
-        uart_send_uint(REG32(USBDEV_INTR_STATE()), 16);
-        uart_send_char('-');
-        uart_send_uint(REG32(USBDEV_USBSTAT()), 32);
-        uart_send_char(' ');
+        uint32_t usb_irq_state = REG32(USBDEV_INTR_STATE());
+        uint32_t usb_stat = REG32(USBDEV_USBSTAT());
+        LOG_INFO("I%4x-%8x\r\n", usb_irq_state, usb_stat);
       } else {
-        usb_simpleserial_send_byte(&ss_ctx[0], rcv_char);
-        usb_simpleserial_send_byte(&ss_ctx[1], rcv_char + 1);
+        usb_simpleserial_send_byte(&simple_serial0, rcv_char);
+        usb_simpleserial_send_byte(&simple_serial1, rcv_char + 1);
       }
     }
 
-    // Signal that the simulation passed
-    if ((num_chars_rx >= USB_MAX) && (pass_signaled == false)) {
-      uart_send_str("\r\nPASS!\r\n");
+    // Signal that the simulation succeeded.
+    if (usb_chars_recved_total >= kExpectedUsbCharsRecved && !pass_signaled) {
+      uart_send_str("\r\n");
+      uart_send_str("PASS!\r\n");
       pass_signaled = true;
     }
   }
-  uart_send_str("\r\nUSB received 0x");
-  uart_send_uint(num_chars_rx, 32);
-  uart_send_str(" characters.\r\n");
+
+  uart_send_str("\r\n");
+  LOG_INFO("USB recieved %d characters.\r\n", usb_chars_recved_total);
 }

--- a/sw/device/examples/hello_usbdev/meson.build
+++ b/sw/device/examples/hello_usbdev/meson.build
@@ -8,6 +8,7 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
     sources: ['hello_usbdev.c'],
     name_suffix: 'elf',
     dependencies: [
+    sw_examples_demos,
     sw_lib_runtime_hart,
     sw_lib_pinmux,
     sw_lib_dif_gpio,

--- a/sw/device/examples/hello_world/hello_world.c
+++ b/sw/device/examples/hello_world/hello_world.c
@@ -2,35 +2,17 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/examples/demos.h"
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/print.h"
-#include "sw/device/lib/base/stdasm.h"
-#include "sw/device/lib/common.h"
 #include "sw/device/lib/dif/dif_gpio.h"
+#include "sw/device/lib/log.h"
 #include "sw/device/lib/pinmux.h"
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/spi_device.h"
 #include "sw/device/lib/uart.h"
 
-#define SPI_MAX 32
-#define GPIO0_BASE_ADDR 0x40010000u
-
 static dif_gpio_t gpio;
-
-// called from ctr0 when something bad happens
-// char I=illegal instruction, A=lsu error (address), E=ecall
-void trap_handler(uint32_t mepc, char c) {
-  uart_send_char(c);
-  uart_send_uint(mepc, 32);
-  while (1) {
-    dif_gpio_all_write(&gpio, 0xAA00);  // pattern
-    usleep(200 * 1000);
-    dif_gpio_all_write(&gpio, 0x5500);  // pattern
-    usleep(100 * 1000);
-  }
-}
-
-#define MK_PRINT(c) (((c < 32) || (c > 126)) ? '_' : c)
 
 int main(int argc, char **argv) {
   uart_init(kUartBaudrate);
@@ -38,74 +20,29 @@ int main(int argc, char **argv) {
   
   pinmux_init();
   spid_init();
-  // Enable GPIO: 0-7 and 16 is input, 8-15 is output
+
   dif_gpio_config_t gpio_config = {.base_addr =
-                                       mmio_region_from_addr(GPIO0_BASE_ADDR)};
+                                       mmio_region_from_addr(0x40010000)};
   dif_gpio_init(&gpio_config, &gpio);
-  dif_gpio_output_mode_all_set(&gpio, 0xFF00);
-  // Add DATE and TIME because I keep fooling myself with old versions
-  base_printf("Hello World!\r\n");
-  base_printf("Built at: " __DATE__ ", " __TIME__ "\r\n");
-  base_printf("Watch the LEDs!\r\n");
+  // Enable GPIO: 0-7 and 16 is input; 8-15 is output.
+  dif_gpio_output_mode_all_set(&gpio, 0x0ff00);
 
-  // Give a LED pattern as startup indicator for 5 seconds
-  dif_gpio_all_write(&gpio, 0xFF00);  // all LEDs on
-  for (int i = 0; i < 32; i++) {
-    usleep(100 * 1000);  // 100 ms
+  LOG_INFO("Hello, World!\n");
+  LOG_INFO("Built at " __DATE__ " " __TIME__ "\n");
 
-    dif_gpio_pin_write(&gpio, 8 + (i % 8), (i / 8) % 2);
-  }
+  demo_gpio_startup(&gpio);
 
-  // Now have UART <-> Buttons/LEDs demo
-  // all LEDs off
-  dif_gpio_all_write(&gpio, 0x0000);
-  base_printf("Try out the switches on the board\r\n");
-  base_printf("or type anything into the console window.\r\n");
-  base_printf("The LEDs show the ASCII code of the last character.\r\n");
-
-  uint32_t gpio_in;
-  uint32_t gpio_in_prev = 0;
-  uint32_t gpio_in_changes;
-  uint8_t spi_buf[SPI_MAX];
-  uint32_t spi_in;
+  LOG_INFO("Try out the switches on the board,\n");
+  LOG_INFO("or type anything into the UART console window.\n");
+  LOG_INFO("The LEDs show the ASCII code of the last character.\n");
 
   spid_send("SPI!", 4);
 
-  while (1) {
+  uint32_t gpio_state = 0;
+  while (true) {
     usleep(10 * 1000);  // 10 ms
-
-    // report changed switches over UART
-    dif_gpio_all_read(&gpio, &gpio_in);
-    gpio_in &= 0x100FF;  // 0-7 is switch input, 16 is FTDI
-    gpio_in_changes = (gpio_in & ~gpio_in_prev) | (~gpio_in & gpio_in_prev);
-    for (int b = 0; b < 8; b++) {
-      if (gpio_in_changes & (1 << b)) {
-        int val_now = (gpio_in >> b) & 0x01;
-        base_printf("GPIO: Switch %d changed to %d\r\n", b, val_now);
-      }
-    }
-    if (gpio_in_changes & 0x10000) {
-      const char *port_type = (gpio_in & 0x10000) ? "JTAG" : "SPI";
-      base_printf("FTDI control changed. Enable %s.\r\n", port_type);
-    }
-    gpio_in_prev = gpio_in;
-
-    // SPI character echo
-    spi_in = spid_read_nb(spi_buf, SPI_MAX);
-    if (spi_in) {
-      uint32_t d = (*(uint32_t *)spi_buf) ^ 0x01010101;
-      spid_send(&d, 4);
-      base_printf("SPI: ");
-      for (int i = 0; i < spi_in; i++) {
-        base_printf("%c", MK_PRINT(spi_buf[i]));
-      }
-      base_printf("\r\n");
-    }
-    // UART echo
-    char rcv_char;
-    while (uart_rcv_char(&rcv_char) != -1) {
-      uart_send_char(rcv_char);
-      dif_gpio_all_write(&gpio, rcv_char << 8);
-    }
+    gpio_state = demo_gpio_to_log_echo(&gpio, gpio_state);
+    demo_spi_to_log_echo();
+    demo_uart_to_uart_and_gpio_echo(&gpio);
   }
 }

--- a/sw/device/examples/hello_world/meson.build
+++ b/sw/device/examples/hello_world/meson.build
@@ -8,6 +8,7 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
     sources: ['hello_world.c'],
     name_suffix: 'elf',
     dependencies: [
+      sw_examples_demos, 
       sw_lib_runtime_hart,
       sw_lib_base_print,
       sw_lib_pinmux,

--- a/sw/device/examples/meson.build
+++ b/sw/device/examples/meson.build
@@ -2,5 +2,18 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+sw_examples_demos = declare_dependency(
+  link_with: static_library(
+    'sw_examples_demos',
+    sources: ['demos.c'],
+    dependencies: [
+      sw_lib_runtime_hart,
+      sw_lib_dif_gpio,
+      sw_lib_spi_device,
+      sw_lib_uart,
+    ],
+  )
+)
+
 subdir('hello_usbdev')
 subdir('hello_world')

--- a/sw/device/lib/usb_controlep.h
+++ b/sw/device/lib/usb_controlep.h
@@ -46,38 +46,38 @@ void usb_controlep_init(usb_controlep_ctx_t *ctctx, usbdev_ctx_t *ctx, int ep,
 /* Use them to initialize a uint8_t array for cfg_dscr              */
 
 #define USB_CFG_DSCR_LEN 9
-#define USB_CFG_DSCR_HEAD(total_len, nint)                                    \
-  /* This is the actual configuration descriptor                 */           \
-  USB_CFG_DSCR_LEN,     /* bLength                                   */       \
-      2,                /* bDescriptorType                           */       \
-      (total_len)&0xff, /* wTotalLength[0]                           */       \
-      (total_len) >> 8, /* wTotalLength[1]                           */       \
-      (nint),           /* bNumInterfaces                            */       \
-      1,                /* bConfigurationValu                        */       \
-      0,                /* iConfiguration                            */       \
-      0xC0,             /* bmAttributes: must-be-one, self-powered   */       \
-      50, /* bMaxPower                                 */ /* MUST be followed \
-                                                             by (nint)        \
-                                                             Interface +      \
-                                                             Endpoint         \
-                                                             Descriptors */
+#define USB_CFG_DSCR_HEAD(total_len, nint)                                   \
+  /* This is the actual configuration descriptor                 */          \
+  USB_CFG_DSCR_LEN,     /* bLength                                   */      \
+      2,                /* bDescriptorType                           */      \
+      (total_len)&0xff, /* wTotalLength[0]                           */      \
+      (total_len) >> 8, /* wTotalLength[1]                           */      \
+      (nint),           /* bNumInterfaces                            */      \
+      1,                /* bConfigurationValu                        */      \
+      0,                /* iConfiguration                            */      \
+      0xC0,             /* bmAttributes: must-be-one, self-powered   */      \
+      50 /* bMaxPower                                 */ /* MUST be followed \
+                                                            by (nint)        \
+                                                            Interface +      \
+                                                            Endpoint         \
+                                                            Descriptors */
 
 // KEEP BLANK LINE ABOVE, it is in the macro!
 
 #define USB_INTERFACE_DSCR_LEN 9
-#define VEND_INTERFACE_DSCR(inum, nep, subclass, protocol)                \
-  /* interface descriptor, USB spec 9.6.5, page 267-269, Table 9-12 */    \
-  USB_INTERFACE_DSCR_LEN, /* bLength                             */       \
-      4,                  /* bDescriptorType                     */       \
-      (inum),             /* bInterfaceNumber                    */       \
-      0,                  /* bAlternateSetting                   */       \
-      (nep),              /* bNumEndpoints                       */       \
-      0xff,               /* bInterfaceClass (Vendor Specific)   */       \
-      (subclass),         /* bInterfaceSubClass                  */       \
-      (protocol),         /* bInterfaceProtocol                  */       \
-      0, /* iInterface                          */ /* MUST be followed by \
-                                                      (nep) Endpoint      \
-                                                      Descriptors */
+#define VEND_INTERFACE_DSCR(inum, nep, subclass, protocol)               \
+  /* interface descriptor, USB spec 9.6.5, page 267-269, Table 9-12 */   \
+  USB_INTERFACE_DSCR_LEN, /* bLength                             */      \
+      4,                  /* bDescriptorType                     */      \
+      (inum),             /* bInterfaceNumber                    */      \
+      0,                  /* bAlternateSetting                   */      \
+      (nep),              /* bNumEndpoints                       */      \
+      0xff,               /* bInterfaceClass (Vendor Specific)   */      \
+      (subclass),         /* bInterfaceSubClass                  */      \
+      (protocol),         /* bInterfaceProtocol                  */      \
+      0 /* iInterface                          */ /* MUST be followed by \
+                                                     (nep) Endpoint      \
+                                                     Descriptors */
 
 // KEEP BLANK LINE ABOVE, it is in the macro!
 
@@ -90,7 +90,7 @@ void usb_controlep_init(usb_controlep_ctx_t *ctctx, usbdev_ctx_t *ctx, int ep,
       0x02,                        /* bmAttributes (0x02=bulk, data)       */ \
       (maxsize)&0xff,              /* wMaxPacketSize[0]                    */ \
       (maxsize) >> 8,              /* wMaxPacketSize[1]                    */ \
-      (interval),                  /* bInterval                            */
+      (interval)                   /* bInterval                            */
 
 // KEEP BLANK LINE ABOVE, it is in the macro!
 


### PR DESCRIPTION
This makes the two "hello" examples a little more readable, and factors out some common demos in them, as well.

It also removes a couple of nasty warts in hello_usbdev, including a very very UB alignment hack (which is now handled, as it should be, by the linker).