### PR TITLE
[assertion/alert_handler] Move reset condition to pre_condition

### DIFF
--- a/hw/ip/alert_handler/rtl/alert_handler_esc_timer.sv
+++ b/hw/ip/alert_handler/rtl/alert_handler_esc_timer.sv
@@ -234,12 +234,12 @@ module alert_handler_esc_timer import alert_pkg::*; (
   `ASSERT(CheckAccumTrig1,  accum_trig_i && state_q == Timeout && en_i |=>
       state_q == Phase0)
   // Check if timeout correctly captured
-  `ASSERT(CheckTimeout0, state_q == Idle && timeout_en_i && en_i && timeout_cyc_i != 0 |=>
-      state_q == Timeout, clk_i, !rst_ni || accum_trig_i)
-  `ASSERT(CheckTimeout1, state_q == Timeout && timeout_en_i && cnt_q < timeout_cyc_i |=>
-      state_q == Timeout, clk_i, !rst_ni || accum_trig_i)
-  `ASSERT(CheckTimeout2, state_q == Timeout && !timeout_en_i |=>
-      state_q == Idle, clk_i, !rst_ni || accum_trig_i)
+  `ASSERT(CheckTimeout0, state_q == Idle && timeout_en_i && en_i && timeout_cyc_i != 0 &&
+      !accum_trig_i |=> state_q == Timeout)
+  `ASSERT(CheckTimeout1, state_q == Timeout && timeout_en_i && cnt_q < timeout_cyc_i &&
+      !accum_trig_i |=> state_q == Timeout)
+  `ASSERT(CheckTimeout2, state_q == Timeout && !timeout_en_i && !accum_trig_i |=>
+      state_q == Idle)
   // Check if timeout correctly triggers escalation
   `ASSERT(CheckTimeoutTrig, state_q == Timeout && timeout_en_i &&
       cnt_q == timeout_cyc_i |=> state_q == Phase0)

--- a/hw/ip/prim/rtl/prim_assert.sv
+++ b/hw/ip/prim/rtl/prim_assert.sv
@@ -81,7 +81,7 @@
 // It can be called as a module (or interface) body item.
 `define ASSERT(__name, __prop, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST) \
 `ifdef INC_ASSERT                                                                        \
-  __name: assert property (@(posedge __clk) disable iff (__rst !== '0) (__prop))         \
+  __name: assert property (@(posedge __clk) disable iff ((__rst) !== '0) (__prop))       \
     else `ASSERT_RPT(`PRIM_STRINGIFY(__name), `PRIM_STRINGIFY(__prop))                   \
 `endif
 // Note: Above we use (__rst !== '0) in the disable iff statements instead of
@@ -92,7 +92,7 @@
 // Assert a concurrent property NEVER happens
 `define ASSERT_NEVER(__name, __prop, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST) \
 `ifdef INC_ASSERT                                                                              \
-  __name: assert property (@(posedge __clk) disable iff (__rst !== '0) not (__prop))           \
+  __name: assert property (@(posedge __clk) disable iff ((__rst) !== '0) not (__prop))         \
     else `ASSERT_RPT(`PRIM_STRINGIFY(__name), `PRIM_STRINGIFY(__prop))                         \
 `endif
 
@@ -106,7 +106,7 @@
 //  Cover a concurrent property
 `define COVER(__name, __prop, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST) \
 `ifdef INC_ASSERT                                                                       \
-  __name: cover property (@(posedge __clk) disable iff (__rst !== '0) (__prop));        \
+  __name: cover property (@(posedge __clk) disable iff ((__rst) !== '0) (__prop));      \
 `endif
 
 //////////////////////////////
@@ -141,7 +141,7 @@
 // Assume a concurrent property
 `define ASSUME(__name, __prop, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST) \
 `ifdef INC_ASSERT                                                                        \
-  __name: assume property (@(posedge __clk) disable iff (__rst !== '0) (__prop))         \
+  __name: assume property (@(posedge __clk) disable iff ((__rst) !== '0) (__prop))       \
      else begin `ASSERT_RPT(`PRIM_STRINGIFY(__name), `PRIM_STRINGIFY(__prop)) end        \
 `endif
 


### PR DESCRIPTION
Some assertions gated under reset condition, as reset is asyn, causes
some issue in simulation. We decided to move them to the
pre-condition instead.
This fix issue: https://github.com/lowRISC/opentitan/issues/1589

Signed-off-by: Cindy Chen <chencindy@google.com>