### PR TITLE
[sw/spiflash] Update spiflash to resend prev.frame

### DIFF
--- a/sw/host/spiflash/updater.cc
+++ b/sw/host/spiflash/updater.cc
@@ -95,7 +95,7 @@ bool Updater::Run() {
       // ack marker and CRC.
       // The current implementation will send the previous frame if the current
       // ack doesn't match the expected response.
-      if (current_frame > 1) {
+      if (current_frame >= 1) {
         current_frame--;
       }
       ack_expected_index = (current_frame == 0) ? 0 : current_frame - 1;


### PR DESCRIPTION
Problem:

    If spiflash hash doesn't match, it sends current frame again.

When spiflash sends firmware image, it splits the data into smaller
chunk (frame). Every frame is verified by checking the calculated hash
in the device side and the expected hash in the host side.

The calculated hash is sent by the device bootrom firmware at the next
frame. If the hash failed, the spiflash tries to re-send the frame
again.

But, current code doesn't handle it correctly. If the very first hash is
failed, it doesn't go back to frame 0, but re-sending frame 1. So the
device always returns error as the first frame isn't yet arrived.

This is a simple fix to resolve. spiflash now sends the frame 0 again.

This is related to #1606 but doesn't solve the root cause.
