### PR TITLE
[chip dv] Fixes to get CSR HW reset test passing

### DIFF
--- a/hw/dv/sv/dv_lib/dv_base_agent.sv
+++ b/hw/dv/sv/dv_lib/dv_base_agent.sv
@@ -27,6 +27,7 @@ class dv_base_agent #(type CFG_T            = dv_base_agent_cfg,
     if (!uvm_config_db#(CFG_T)::get(this, "", "cfg", cfg)) begin
       `uvm_fatal(`gfn, $sformatf("failed to get %s from uvm_config_db", cfg.get_type_name()))
     end
+    `uvm_info(`gfn, $sformatf("\n%0s", cfg.sprint()), UVM_HIGH)
 
     // create components
     if (cfg.en_cov) begin

--- a/hw/dv/sv/tl_agent/tl_agent.sv
+++ b/hw/dv/sv/tl_agent/tl_agent.sv
@@ -25,6 +25,7 @@ class tl_agent extends dv_base_agent#(
     if (!uvm_config_db#(virtual tl_if)::get(this, "", "vif", cfg.vif)) begin
       `uvm_fatal(`gfn, "failed to get tl_if handle from uvm_config_db")
     end
+    cfg.vif.if_mode = cfg.if_mode;
   endfunction
 
   function void connect_phase(uvm_phase phase);

--- a/hw/dv/sv/tl_agent/tl_device_driver.sv
+++ b/hw/dv/sv/tl_agent/tl_device_driver.sv
@@ -12,41 +12,43 @@ class tl_device_driver extends tl_base_driver;
   `uvm_component_new
 
   virtual task get_and_drive();
+    // Wait for initial reset to pass.
+    wait(cfg.vif.rst_n === 1'b0);
+    wait(cfg.vif.rst_n === 1'b1);
     fork
       a_channel_thread();
       d_channel_thread();
-      reset_thread();
     join_none
  endtask
 
-  virtual task reset_thread();
+  // reset signals every time reset occurs.
+  virtual task reset_signals();
     forever begin
-      @(posedge cfg.vif.rst_n);
+      @(negedge cfg.vif.rst_n);
+      invalidate_d_channel();
+      cfg.vif.d2h_int.a_ready <= 1'b0;
       // Check for seq_item_port FIFO is empty when coming out of reset
       `DV_CHECK_EQ(seq_item_port.has_do_available(), 0);
+      @(posedge cfg.vif.rst_n);
     end
-  endtask : reset_thread
-
-  virtual task reset_signals();
-    invalidate_d_channel();
-    cfg.vif.device_cb.d2h.a_ready <= 1'b0;
-    @(posedge cfg.vif.device_cb.rst_n);
   endtask
 
   virtual task a_channel_thread();
     int unsigned ready_delay;
+
     forever begin
       ready_delay = $urandom_range(cfg.a_ready_delay_min, cfg.a_ready_delay_max);
       repeat(ready_delay) @(cfg.vif.device_cb);
-      cfg.vif.device_cb.d2h.a_ready <= 1'b1;
+      cfg.vif.device_cb.d2h_int.a_ready <= 1'b1;
       @(cfg.vif.device_cb);
-      cfg.vif.device_cb.d2h.a_ready <= 1'b0;
+      cfg.vif.device_cb.d2h_int.a_ready <= 1'b0;
     end
   endtask
 
   virtual task d_channel_thread();
     bit req_found;
     tl_seq_item rsp;
+
     forever begin
       int unsigned d_valid_delay;
       seq_item_port.get_next_item(rsp);
@@ -60,15 +62,15 @@ class tl_device_driver extends tl_base_driver;
         if (!cfg.vif.rst_n) break;
         else @(cfg.vif.device_cb);
       end
-      cfg.vif.device_cb.d2h.d_valid  <= 1'b1;
-      cfg.vif.device_cb.d2h.d_opcode <= tl_d_op_e'(rsp.d_opcode);
-      cfg.vif.device_cb.d2h.d_data   <= rsp.d_data;
-      cfg.vif.device_cb.d2h.d_source <= rsp.d_source;
-      cfg.vif.device_cb.d2h.d_param  <= rsp.d_param;
-      cfg.vif.device_cb.d2h.d_error  <= rsp.d_error;
-      cfg.vif.device_cb.d2h.d_sink   <= rsp.d_sink;
-      cfg.vif.device_cb.d2h.d_user   <= rsp.d_user;
-      cfg.vif.device_cb.d2h.d_size   <= rsp.d_size;
+      cfg.vif.device_cb.d2h_int.d_valid  <= 1'b1;
+      cfg.vif.device_cb.d2h_int.d_opcode <= tl_d_op_e'(rsp.d_opcode);
+      cfg.vif.device_cb.d2h_int.d_data   <= rsp.d_data;
+      cfg.vif.device_cb.d2h_int.d_source <= rsp.d_source;
+      cfg.vif.device_cb.d2h_int.d_param  <= rsp.d_param;
+      cfg.vif.device_cb.d2h_int.d_error  <= rsp.d_error;
+      cfg.vif.device_cb.d2h_int.d_sink   <= rsp.d_sink;
+      cfg.vif.device_cb.d2h_int.d_user   <= rsp.d_user;
+      cfg.vif.device_cb.d2h_int.d_size   <= rsp.d_size;
       // bypass delay in case of reset
       if (cfg.vif.rst_n) @(cfg.vif.device_cb);
       while (!cfg.vif.device_cb.h2d.d_ready && cfg.vif.rst_n) @(cfg.vif.device_cb);
@@ -78,15 +80,15 @@ class tl_device_driver extends tl_base_driver;
   endtask : d_channel_thread
 
   function void invalidate_d_channel();
-    cfg.vif.device_cb.d2h.d_opcode <= tlul_pkg::tl_d_op_e'('x);
-    cfg.vif.device_cb.d2h.d_param <= '{default:'x};
-    cfg.vif.device_cb.d2h.d_size <= '{default:'x};
-    cfg.vif.device_cb.d2h.d_source <= '{default:'x};
-    cfg.vif.device_cb.d2h.d_sink <= '{default:'x};
-    cfg.vif.device_cb.d2h.d_data <= '{default:'x};
-    cfg.vif.device_cb.d2h.d_user <= '{default:'x};
-    cfg.vif.device_cb.d2h.d_error <= 1'bx;
-    cfg.vif.device_cb.d2h.d_valid <= 1'b0;
+    cfg.vif.d2h_int.d_opcode <= tlul_pkg::tl_d_op_e'('x);
+    cfg.vif.d2h_int.d_param <= '{default:'x};
+    cfg.vif.d2h_int.d_size <= '{default:'x};
+    cfg.vif.d2h_int.d_source <= '{default:'x};
+    cfg.vif.d2h_int.d_sink <= '{default:'x};
+    cfg.vif.d2h_int.d_data <= '{default:'x};
+    cfg.vif.d2h_int.d_user <= '{default:'x};
+    cfg.vif.d2h_int.d_error <= 1'bx;
+    cfg.vif.d2h_int.d_valid <= 1'b0;
   endfunction : invalidate_d_channel
 
 endclass

--- a/hw/dv/sv/tl_agent/tl_if.sv
+++ b/hw/dv/sv/tl_agent/tl_if.sv
@@ -9,12 +9,18 @@ interface tl_if(input clk, input rst_n);
 
   wire tlul_pkg::tl_h2d_t h2d; // req
   wire tlul_pkg::tl_d2h_t d2h; // rsp
-  modport dut_host_mp(output h2d, input d2h);
-  modport dut_device_mp(input h2d, output d2h);
+
+  tlul_pkg::tl_h2d_t h2d_int; // req (internal)
+  tlul_pkg::tl_d2h_t d2h_int; // rsp (internal)
+
+  dv_utils_pkg::if_mode_e if_mode; // interface mode - Host or Device
+
+  modport dut_host_mp(output h2d_int, input d2h_int);
+  modport dut_device_mp(input h2d_int, output d2h_int);
 
   clocking host_cb @(posedge clk);
     input  rst_n;
-    output h2d;
+    output h2d_int;
     input  d2h;
   endclocking
   modport host_mp(clocking host_cb);
@@ -22,7 +28,7 @@ interface tl_if(input clk, input rst_n);
   clocking device_cb @(posedge clk);
     input  rst_n;
     input  h2d;
-    output d2h;
+    output d2h_int;
   endclocking
   modport device_mp(clocking device_cb);
 
@@ -32,5 +38,8 @@ interface tl_if(input clk, input rst_n);
     input  d2h;
   endclocking
   modport mon_mp(clocking mon_cb);
+
+  assign h2d = (if_mode == dv_utils_pkg::Host) ? h2d_int : 'z;
+  assign d2h = (if_mode == dv_utils_pkg::Device) ? d2h_int : 'z;
 
 endinterface : tl_if

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -69,8 +69,6 @@ class chip_env_cfg extends dv_base_env_cfg #(.RAL_T(chip_reg_block));
   // ral flow is limited in terms of setting correct field access policies and reset values
   // We apply those fixes here - please note these fixes need to be reflected in the scoreboard
   protected virtual function void apply_ral_fixes();
-    // Flash ctrl prog_empty interrupt is set to 1 out of reset since it really is empty.
-    ral.flash_ctrl.intr_state.prog_empty.set_reset(1'b1);
     // Out of reset, the link is in disconnected state.
     ral.usbdev.intr_state.disconnected.set_reset(1'b1);
   endfunction

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
@@ -20,6 +20,8 @@ class chip_common_vseq extends chip_base_vseq;
   virtual task pre_start();
     super.pre_start();
     // keep sck on - needed for csr tests since some csrs are flopped on sck
+    // Select SPI interface.
+    cfg.jtag_spi_n_vif.drive(1'b0);
     cfg.m_spi_agent_cfg.sck_on = 1'b1;;
   endtask
 
@@ -40,6 +42,15 @@ class chip_common_vseq extends chip_base_vseq;
     `add_ip_csr_exclusions(spi_device)
     `add_ip_csr_exclusions(uart)
     `add_ip_csr_exclusions(usbdev)
+
+    // The following exclusions are added at the chip level since no IP level bench
+    // exist for these.
+
+    // Random writes to these pinmux CSRs may result in array index going OOB and
+    // assertion errors thrown.
+    csr_excl.add_excl({scope, ".", "pinmux.periph_insel*"}, CsrExclWrite);
+    csr_excl.add_excl({scope, ".", "pinmux.mio_outsel*"}, CsrExclWrite);
+    csr_excl.add_excl({scope, ".", "flash_ctrl.control.start"}, CsrExclWrite);
 
   endfunction
 

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -133,7 +133,6 @@ module tb;
   assign jtag_trst_n      = jtag_if.trst_n;
   assign jtag_tdi         = jtag_if.tdi;
   assign jtag_if.tdo      = jtag_tdo;
-  assign cpu_d_tl_if.d2h  = `CPU_HIER.tl_d_i;
 
   assign spi_device_sck     = spi_if.sck;
   assign spi_device_csb     = spi_if.csb;
@@ -191,10 +190,10 @@ module tb;
     if (stub_cpu) begin
       force `CPU_HIER.clk_i = 1'b0;
       force `CPU_HIER.tl_d_o = cpu_d_tl_if.h2d;
-    end
-    else begin
+    end else begin
       force cpu_d_tl_if.h2d = `CPU_HIER.tl_d_o;
     end
   end
+  assign cpu_d_tl_if.d2h = `CPU_HIER.tl_d_i;
 
 endmodule


### PR DESCRIPTION
TL agent: 
- Removed `wire` keyword from `h2d` and `d2h` signals in `tl_if`
- Replaced `reset_thread()` with existing `reset_signals()` method (merged them) in `tl_*_driver`
- added pinmux CSR exclusions

Chip env:
- Added strap interfaces to drive srst, bootstrap and jtag_spi_n signals
- Added SPI agent and hooked them to the chip IOs
- Updated DUT reset routine to assert rst_n as well as jtag trst_n (to properly reset the DM)

Padctl
- Removed mux on IO_DPS4 and IO_DPS5 - they seem to not be needed  

I am running the full nightly now to ensure I did not break anything else. 

Signed-off-by: Srikrishna Iyer <sriyer@google.com>