### PR TITLE
[aes] Fix lint warnings and errors

### DIFF
--- a/hw/ip/aes/lint/aes.vlt
+++ b/hw/ip/aes/lint/aes.vlt
@@ -8,4 +8,4 @@
 
 // Always_comb variable driven after use: 'regular'
 // regular is assigned in a for loop, regular[1] depends on regular[0]
-lint_off -msg ALWCOMBORDER -file "*/rtl/aes_key_expand.sv" -lines 206
+lint_off -msg ALWCOMBORDER -file "*/rtl/aes_key_expand.sv" -lines 208

--- a/hw/ip/aes/rtl/aes_control.sv
+++ b/hw/ip/aes/rtl/aes_control.sv
@@ -69,7 +69,7 @@ module aes_control (
 
   // Types
   typedef enum logic [1:0] {
-    IDLE, LOAD, WAIT, CLEAR
+    IDLE, LOAD, FINISH, CLEAR
   } aes_ctrl_e;
 
   aes_ctrl_e aes_ctrl_ns, aes_ctrl_cs;
@@ -157,7 +157,7 @@ module aes_control (
 
             aes_ctrl_ns = LOAD;
           end
-         end else if (key_clear_i || data_out_clear_i) begin
+        end else if (key_clear_i || data_out_clear_i) begin
           // To clear the output data registers, we re-use the muxing resources of the cipher core.
           // To clear all key material, some key registers inside the cipher core need to be
           // cleared.
@@ -188,10 +188,10 @@ module aes_control (
         data_in_load = ~cipher_dec_key_gen_i;
         dec_key_gen  =  cipher_dec_key_gen_i;
 
-        aes_ctrl_ns = WAIT;
+        aes_ctrl_ns = FINISH;
       end
 
-      WAIT: begin
+      FINISH: begin
         // Wait for cipher core to finish.
 
         if (cipher_dec_key_gen_i) begin

--- a/hw/ip/aes/rtl/aes_sbox_lut.sv
+++ b/hw/ip/aes/rtl/aes_sbox_lut.sv
@@ -13,7 +13,7 @@ module aes_sbox_lut (
   import aes_pkg::*;
 
   // Define the LUTs
-  const logic [7:0] sbox_fwd [256] = '{
+  localparam logic [7:0] SBOX_FWD [256] = '{
     8'h63, 8'h7C, 8'h77, 8'h7B, 8'hF2, 8'h6B, 8'h6F, 8'hC5,
     8'h30, 8'h01, 8'h67, 8'h2B, 8'hFE, 8'hD7, 8'hAB, 8'h76,
 
@@ -63,7 +63,7 @@ module aes_sbox_lut (
     8'h41, 8'h99, 8'h2D, 8'h0F, 8'hB0, 8'h54, 8'hBB, 8'h16
   };
 
-  const logic [7:0] sbox_inv [256] = '{
+  localparam logic [7:0] SBOX_INV [256] = '{
     8'h52, 8'h09, 8'h6a, 8'hd5, 8'h30, 8'h36, 8'ha5, 8'h38,
     8'hbf, 8'h40, 8'ha3, 8'h9e, 8'h81, 8'hf3, 8'hd7, 8'hfb,
 
@@ -114,6 +114,6 @@ module aes_sbox_lut (
   };
 
   // Drive output
-  assign data_o = (op_i == CIPH_FWD) ? sbox_fwd[data_i] : sbox_inv[data_i];
+  assign data_o = (op_i == CIPH_FWD) ? SBOX_FWD[data_i] : SBOX_INV[data_i];
 
 endmodule


### PR DESCRIPTION
This PR adjusts the Verilator lint waiver + fixes lint warnings and errors in AscentLint. The test suite is passing with these changes.