### PR TITLE
Docs toc

### DIFF
--- a/doc/rm/register_tool/index.md
+++ b/doc/rm/register_tool/index.md
@@ -22,7 +22,7 @@ Setup and examples of the tool are given in the README.md file in the `util/regg
 
 The tool input is an Hjson file containing the Comportable description of the IP block and its registers.
 
-A description of Hjson (a variant of JSON) and the recommended style is in the [Hjson Usage and Style Guide]({{< relref "hjson_usage_style.md" >}}).
+A description of Hjson (a variant of JSON) and the recommended style is in the [Hjson Usage and Style Guide]({{< relref "doc/rm/hjson_usage_style.md" >}}).
 
 The tables below describe valid keys for each context.
 It is an error if *required* keys are missing from the input JSON.
@@ -222,7 +222,7 @@ Instance 16 does not fit, so will start a new register.
 
 This section details the register generation for hardware instantiation.
 The input to the tool for this generation is the same `.hjson` file described above.
-The output is two Verilog files that can be instantiated by a peripheral that follows the [Comportability Guidelines]({{< relref "comportability_specification" >}}).
+The output is two Verilog files that can be instantiated by a peripheral that follows the [Comportability Guidelines]({{< relref "doc/rm/comportability_specification" >}}).
 
 The register generation tool will generate the RTL if it is invoked with the `-r` flag.
 The `-t <directory>` flag is used to specify the output directory where the two files will be written.

--- a/doc/ug/install_instructions/index.md
+++ b/doc/ug/install_instructions/index.md
@@ -38,7 +38,7 @@ $ sudo chown $(id -un) /tools
 
 ### Clone repository
 
-If you intend to contribute back to OpenTitan you will want your own fork of the repository on GitHub and to work using that, see the [notes for using GitHub]({{< relref "github_notes.md" >}}).
+If you intend to contribute back to OpenTitan you will want your own fork of the repository on GitHub and to work using that, see the [notes for using GitHub]({{< relref "doc/ug/github_notes.md" >}}).
 Otherwise make a simple clone of the main OpenTitan repository.
 
 ```console

--- a/site/docs/assets/scss/_toc.scss
+++ b/site/docs/assets/scss/_toc.scss
@@ -1,9 +1,13 @@
 .toc {
   width: 20em;
+  height: 100%;
   flex-grow: 1;
   flex-shrink: 0;
   padding: $m-s;
   font-size: 1em;
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0;
   border-left: 1px solid $medium-purple;
   border-left: 1px solid var(--text-second);
 

--- a/site/docs/assets/scss/_toc.scss
+++ b/site/docs/assets/scss/_toc.scss
@@ -3,16 +3,31 @@
   flex-grow: 1;
   flex-shrink: 0;
   padding: $m-s;
-  font-size: 1.125em;
-  border-right: 1px solid $medium-purple;
-  border-right: 1px solid var(--text-second);
+  font-size: 1em;
+  border-left: 1px solid $medium-purple;
+  border-left: 1px solid var(--text-second);
+
+  > nav > ul {
+    font-size: 1em;
+    font-weight: normal;
+  }
+
+  > nav > ul ul {
+    font-weight: bold;
+    font-size: 0.875em;
+    margin-top: 0.75em;
+
+    a {
+      text-transform: none;
+    }
+  }
 
   > nav > ul > li > a {
     text-transform: uppercase;
-    font-size: 1.25em;
-    font-weight: 300;
-    font-family: 'Livvic', sans-serif;
-    margin-top: 1.5em;
+    font-size: 0.875em;
+    font-weight: bold;
+    font-family: 'Ubuntu', sans-serif;
+    margin-top: 1em;
     display: block;
   }
 
@@ -24,10 +39,6 @@
 
   li {
     margin-bottom: 0.75em;
-  }
-
-  > nav > ul {
-    font-weight: bold;
   }
 
   a {
@@ -49,24 +60,6 @@
     }
   }
 
-  > nav > ul ul {
-    //font-weight: normal;
-    margin-top: 0.75em;
-
-    a {
-      text-transform: none;
-    }
-  }
-
-  > nav > ul ul ul {
-    font-weight: normal;
-    font-size: 0.875em;
-
-    a {
-      color: $medium-purple;
-      color: var(--text-second);
-    }
-  }
 }
 
 @media print {

--- a/site/docs/config.toml
+++ b/site/docs/config.toml
@@ -60,5 +60,10 @@ googleAnalytics = "UA-151030466-2"
 [params]
 generatedRoot = "build/docs-generated"
 
-[blackfriday]
-  extensions = ["noEmptyLineBeforeBlock"]
+[markup]
+  [markup.goldmark.renderer]
+    unsafe = true
+  [markup.tableOfContents]
+    startLevel = 1
+    endLevel = 2
+    ordered = false

--- a/site/docs/layouts/_default/single.html
+++ b/site/docs/layouts/_default/single.html
@@ -4,13 +4,11 @@
     {{ partial "header.html" . }}
     <section class="light-bg">
       <div class="layout">
-        <aside class="toc">
-          {{ .TableOfContents }}
-        </aside>
         <main id="main" role="main" class="markdown">
           {{ if .Title }}<h1 class="title">{{ .Title }}</h1>{{ end }}
           {{ .Content }}
         </main>
+        {{ partial "toc.html" . }}
       </div>
     </section>
     {{ partial "footer.html" . }}

--- a/site/docs/layouts/partials/toc.html
+++ b/site/docs/layouts/partials/toc.html
@@ -1,6 +1,6 @@
 <aside class="toc">
   <header>
-    On this Page
+    <p>On this Page</p>
   </header>
   {{ .TableOfContents }}
 </aside>

--- a/site/docs/layouts/partials/toc.html
+++ b/site/docs/layouts/partials/toc.html
@@ -1,0 +1,6 @@
+<aside class="toc">
+  <header>
+    On this Page
+  </header>
+  {{ .TableOfContents }}
+</aside>

--- a/util/build_docs.py
+++ b/util/build_docs.py
@@ -36,7 +36,7 @@ USAGE = """
 """
 
 # Version of hugo extended to be used to build the docs
-HUGO_EXTENDED_VERSION = "0.59.0"
+HUGO_EXTENDED_VERSION = "0.60.0"
 
 # Configurations
 # TODO: Move to config.yaml


### PR DESCRIPTION
"Depends" on #1624, will drop the commit "[doc] Make links.." here. Should have thought about this first...

WIP as I just wanted to get some feedback for the design changes.
My plan was to add some orientation the left side, like a global table of content, but then I liked the local ToC on the right side on its own already.

I like the more concise overview of the current page, I think this make it actually more useful as the original could be at some point quite overwhelming.

WDYT?
![toc-orig](https://user-images.githubusercontent.com/8666134/75356459-48609900-58b0-11ea-8f05-bba51cf365f8.png)

![toc-right](https://user-images.githubusercontent.com/8666134/75356481-4d254d00-58b0-11ea-9978-7627ffdcebaa.png)
