### PR TITLE
[dv/common] add docs for enable register testplan

### DIFF
--- a/hw/dv/tools/testplans/enable_reg_testplan.hjson
+++ b/hw/dv/tools/testplans/enable_reg_testplan.hjson
@@ -1,0 +1,19 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  entries: [
+    {
+      name: enable_reg
+      desc: '''
+            The CSR test sequences will read and write accessible CSRs including the enable
+            registers and their locked registers. The RAL model supports predicting the correct
+            value of the locked registers based on their enable registers.
+            '''
+      milestone: V2
+      tests: ["{name}{intf}_csr_rw",
+              "{name}{intf}_csr_bit_bash",
+              "{name}{intf}_csr_aliasing"]
+    }
+  ]
+}

--- a/hw/ip/alert_handler/data/alert_handler_testplan.hjson
+++ b/hw/ip/alert_handler/data/alert_handler_testplan.hjson
@@ -5,6 +5,7 @@
   name: "alert_handler"
   import_testplans: ["hw/dv/tools/testplans/csr_testplan.hjson",
                      "hw/dv/tools/testplans/intr_test_testplan.hjson",
+                     "hw/dv/tools/testplans/enable_reg_testplan.hjson",
                      "hw/dv/tools/testplans/tl_device_access_types_testplan.hjson"]
   entries: [
     {


### PR DESCRIPTION
Add a separate common testplan for the enable registers.
Add the testplan for applicable IP module: alert_handler

Signed-off-by: Cindy Chen <chencindy@google.com>