### PR TITLE
[sw, spiflash] Dramatically increase transfer rate

### DIFF
--- a/sw/host/spiflash/ftdi_spi_interface.h
+++ b/sw/host/spiflash/ftdi_spi_interface.h
@@ -29,9 +29,10 @@ class FtdiSpiInterface : public SpiInterface {
   // Initialize interface.
   bool Init() final;
 
-  // Transmit bytes from |tx| buffer and read data back onto |rx| buffer. The
-  // number of bytes are defined by |size|.
-  bool TransmitFrame(const uint8_t *tx, uint8_t *rx, size_t size) final;
+  // Transmit bytes from |tx| buffer. The number of bytes are defined by |size|.
+  bool TransmitFrame(const uint8_t *tx, size_t size) final;
+
+  bool CheckHash(const uint8_t *tx, size_t size) final;
 
  private:
   std::unique_ptr<MpsseHandle> spi_;

--- a/sw/host/spiflash/spi_interface.h
+++ b/sw/host/spiflash/spi_interface.h
@@ -25,9 +25,14 @@ class SpiInterface {
   // Initialize SPI interface. Returns true on success.
   virtual bool Init() = 0;
 
-  // Transmit bytes from |tx| buffer and read data back onto |rx| buffer. The
-  // number of bytes transferred is defined by |size|.
-  virtual bool TransmitFrame(const uint8_t *tx, uint8_t *rx, size_t size) = 0;
+  // Transmit bytes from |tx| buffer. The number of bytes transferred is defined
+  // by |size|.
+  virtual bool TransmitFrame(const uint8_t *tx, size_t size) = 0;
+
+  // Wait until the hash from the previously sent is able to be read. The
+  // previous frame to check the hash for should be provided in |tx| and the
+  // frame's length as |size|.
+  virtual bool CheckHash(const uint8_t *tx, size_t size) = 0;
 };
 
 }  // namespace spiflash

--- a/sw/host/spiflash/updater.cc
+++ b/sw/host/spiflash/updater.cc
@@ -44,15 +44,6 @@ void HashFrame(Frame *f) {
   SHA256_Final(f->hdr.hash, &sha256);
 }
 
-// Check hash portion of |ack| against |ack_expected|.
-bool CheckAckHash(const std::string &ack, const std::string &ack_expected) {
-  uint8_t result = 0;
-  for (int i = 0; i < 32; ++i) {
-    result |= ack[i] ^ ack_expected[i];
-  }
-  return (result == 0);
-}
-
 }  // namespace
 
 bool Updater::Run() {
@@ -77,31 +68,16 @@ bool Updater::Run() {
               << std::setw(8) << std::hex << f.hdr.offset << std::endl;
 
     if (!spi_->TransmitFrame(reinterpret_cast<const uint8_t *>(&f),
-                             reinterpret_cast<uint8_t *>(&ack[0]),
                              sizeof(Frame))) {
       std::cerr << "Failed to transmit frame no: 0x" << std::setfill('0')
                 << std::setw(8) << std::hex << f.hdr.frame_num << std::endl;
     }
 
-    // When we send the next frame, we'll get the previous frame's hash as
-    // the ack, so with each increment of |current_frame| we also need to
-    // update the |ack_expected| value.
-    uint32_t ack_expected_index = 0;
-    if (current_frame == 0 || CheckAckHash(ack, ack_expected)) {
-      ack_expected_index = current_frame;
+    // When we send each frame we wait for the correct hash before continuing.
+    if (current_frame == frames.size() - 1 ||
+        spi_->CheckHash(reinterpret_cast<const uint8_t *>(&f), sizeof(Frame))) {
       current_frame++;
-    } else {
-      // TODO: Improve protocol by encoding NEXT frame number, current error,
-      // ack marker and CRC.
-      // The current implementation will send the previous frame if the current
-      // ack doesn't match the expected response.
-      if (current_frame >= 1) {
-        current_frame--;
-      }
-      ack_expected_index = (current_frame == 0) ? 0 : current_frame - 1;
     }
-    SHA256(reinterpret_cast<const uint8_t *>(&frames[ack_expected_index]),
-           sizeof(f), reinterpret_cast<uint8_t *>(&ack_expected[0]));
   }
   return true;
 }

--- a/sw/host/spiflash/verilator_spi_interface.h
+++ b/sw/host/spiflash/verilator_spi_interface.h
@@ -29,9 +29,10 @@ class VerilatorSpiInterface : public SpiInterface {
   // Initialize interface.
   bool Init() final;
 
-  // Transmit bytes from |tx| buffer and read data back onto |rx| buffer. The
-  // number of bytes are defined by |size|.
-  bool TransmitFrame(const uint8_t *tx, uint8_t *rx, size_t size) final;
+  // Transmit bytes from |tx| buffer. The number of bytes are defined by |size|.
+  bool TransmitFrame(const uint8_t *tx, size_t size) final;
+
+  bool CheckHash(const uint8_t *tx, size_t size) final;
 
  private:
   std::string spi_filename_;


### PR DESCRIPTION
The `spiflash` utility hasn't been using any kind of flow control up until now. This PR adjusts the implementation to read the hash of each frame before writing the next frame rather than checking the hash after writing the next frame.

By my measurements this decreases the transfer time of large binaries, like Tock, by ~95%.

The new implementation will timeout after the same period of time the old implementation used to wait before reading the hash, 1 second. A short delay is inserted between reads since the FPGA seems to trip over itself if reads occur too quickly in succession.

### Issues:

- Doesn't work with Verilator, though `spiflash` doesn't work with Verilator at tip of master right now either. I wasn't able to figure out what's going on here; the hashes read back seem nonsensical. I'll file a second issue for this. I'm not sure how often `spiflash` is used on Verilator in reality or if most people just `meminit` the flash.
- It's too fast. Now I don't have time to go grab a coffee between builds :(