### PR TITLE
[i2c, dv] Update i2c_csr_* tests

### DIFF
--- a/hw/ip/i2c/dv/env/i2c_env.sv
+++ b/hw/ip/i2c/dv/env/i2c_env.sv
@@ -23,8 +23,7 @@ class i2c_env extends cip_base_env #(
   function void connect_phase(uvm_phase phase);
     super.connect_phase(phase);
     if (cfg.en_scb) begin
-      m_i2c_agent.monitor.analysis_port.connect(scoreboard.i2c_tx_fifo.analysis_export);
-      m_i2c_agent.monitor.analysis_port.connect(scoreboard.i2c_rx_fifo.analysis_export);
+      m_i2c_agent.monitor.analysis_port.connect(scoreboard.i2c_fifo.analysis_export);
     end
     if (cfg.m_i2c_agent_cfg.is_active) begin
       virtual_sequencer.i2c_sequencer_h = m_i2c_agent.sequencer;

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
@@ -48,14 +48,14 @@ class i2c_base_vseq extends cip_base_vseq #(
     cfg.m_i2c_agent_cfg.max_delay_stop = 5;
     cfg.m_i2c_agent_cfg.max_delay_data = 5;
     // program ctrl reg
-    ral.ctrl.enablehost.set(ON);
+    ral.ctrl.enablehost.set(I2C_FLAG_ON);
     csr_update(ral.ctrl);
     // disable override the logic level of output pins
-    ral.ovrd.txovrden.set(OFF);
+    ral.ovrd.txovrden.set(I2C_FLAG_OFF);
     csr_update(ral.ovrd);
     // reset fmt_fifo and rx_fifo
-    ral.fifo_ctrl.rxrst.set(ON);
-    ral.fifo_ctrl.fmtrst.set(ON);
+    ral.fifo_ctrl.rxrst.set(I2C_FLAG_ON);
+    ral.fifo_ctrl.fmtrst.set(I2C_FLAG_ON);
     csr_update(ral.fifo_ctrl);
 
     if (do_interrupt) begin
@@ -107,7 +107,7 @@ class i2c_base_vseq extends cip_base_vseq #(
 
     if (ral.ctrl.enablehost.get_mirrored_value()) begin
       `DV_CHECK_MEMBER_RANDOMIZE_FATAL(dly_to_access_fifo)
-      csr_spinwait(.ptr(ral.status.fmtfull), .exp_data(1'b0),
+      csr_spinwait(.ptr(ral.status.fmtfull), .exp_data(I2C_FLAG_OFF),
                    .spinwait_delay_ns(dly_to_access_fifo));
     end
     `uvm_info(`gfn, "wait_for_tx_fifo_not_full is done", UVM_HIGH)
@@ -117,7 +117,7 @@ class i2c_base_vseq extends cip_base_vseq #(
   virtual task wait_for_rx_fifo_not_full();
     if (ral.ctrl.enablehost.get_mirrored_value()) begin
       `DV_CHECK_MEMBER_RANDOMIZE_FATAL(dly_to_access_fifo)
-      csr_spinwait(.ptr(ral.status.rxfull), .exp_data(1'b0),
+      csr_spinwait(.ptr(ral.status.rxfull), .exp_data(I2C_FLAG_OFF),
                    .spinwait_delay_ns(dly_to_access_fifo),
                    .timeout_ns(50_000_000)); // use longer timeout as i2c freq is low
     end

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_common_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_common_vseq.sv
@@ -27,37 +27,14 @@ class i2c_common_vseq extends i2c_base_vseq;
                                            csr_excl_item    csr_excl,
                                            string           scope = "ral");
 
-    // by default, apply all init, write, and write-read check (CsrNoExcl) for all registers
-    if (csr_test_type != "hw_reset") begin   // csr_rw, csr_bit_bash, or csr_aliasing
-      // RO registers - not able to write
-      csr_excl.add_excl({scope, ".", "val"}, CsrExclWriteCheck);
-      // intr_test csr is WO which - it reads back 0s, plus it affects the i2c_state csr
-      csr_excl.add_excl({scope, ".", "intr_test"}, CsrExclWriteCheck);
-      // fdata csr is WO which - it reads back 0s
-      csr_excl.add_excl({scope, ".", "fdata"}, CsrExclWriteCheck);
-      // intr_state csr is affected by writes to other csrs
-      csr_excl.add_excl({scope, ".", "intr_state"}, CsrExclWriteCheck);
-    end
-
-    // aliasing: write to specifc non-RO/non-INIT register (CsrExclWrite) and
-    // read all registers (CsrExclInit/WriteCheck) then check the specifc register
-    // content is updated (matching the mirrored value)
-    if (csr_test_type == "aliasing") begin
-      // RO registers - not able to write
-      csr_excl.add_excl({scope, ".", "status"}, CsrExclWrite);
-      csr_excl.add_excl({scope, ".", "rdata"}, CsrExclWrite);
-      csr_excl.add_excl({scope, ".", "fifo_status"}, CsrExclWrite);
-      csr_excl.add_excl({scope, ".", "val"}, CsrExclWrite);
-    end
-
-    // for csr_rw test
-    // fmtrst and rxrst fields in fifo_ctrl are WO - it read back 0s
-    csr_excl.add_excl({scope, ".", "fifo_ctrl.*rst"}, CsrExclWriteCheck);
-    // read rdata when fifo is empty, dut may return unknown data
-    csr_excl.add_excl({scope, ".", "rdata"}, CsrExclWriteCheck);
-    // status csr is RO - writing is not permitted
-    csr_excl.add_excl({scope, ".", "status"}, CsrExclWrite);
-
+    // intr_state is affected by writes to other csrs
+    csr_excl.add_excl({scope, ".", "intr_state"}, CsrExclCheck);
+    // RO registers - exclude init and write-read check
+    csr_excl.add_excl({scope, ".", "status"}, CsrExclWriteCheck);
+    csr_excl.add_excl({scope, ".", "fifo_status"}, CsrExclWriteCheck);
+    // RO registers - exclude init and write-read check
+    csr_excl.add_excl({scope, ".", "val"}, CsrExclCheck);
+    csr_excl.add_excl({scope, ".", "rdata"}, CsrExclCheck);
   endfunction : add_csr_exclusions
 
   task post_start();


### PR DESCRIPTION
[i2c, dv] Update i2c_csr_* tests

- Fixed incorrect parameter name used in bave_vseq. 
- Fixed syntax in scoreboard (TODO, no need review)
- Correct CsrExcl* property for common_vseq (test passed)

Signed-off-by: Tung Hoang <tung.hoang.290780@gmail.com>