### PR TITLE
[i2c, rtl] Format flag assignments 

### DIFF
--- a/hw/ip/i2c/rtl/i2c_core.sv
+++ b/hw/ip/i2c/rtl/i2c_core.sv
@@ -188,8 +188,8 @@ module  i2c_core (
   assign fmt_byte               = fmt_fifo_rdata[7:0];
   assign fmt_flag_start_before  = fmt_fifo_rdata[8];
   assign fmt_flag_stop_after    = fmt_fifo_rdata[9];
-  assign fmt_flag_read_continue = fmt_fifo_rdata[10];
-  assign fmt_flag_read_bytes    = fmt_fifo_rdata[11];
+  assign fmt_flag_read_bytes    = fmt_fifo_rdata[10];
+  assign fmt_flag_read_continue = fmt_fifo_rdata[11];
   assign fmt_flag_nak_ok        = fmt_fifo_rdata[12];
 
   // Unused parts of exposed bits

--- a/hw/ip/i2c/rtl/i2c_fsm.sv
+++ b/hw/ip/i2c/rtl/i2c_fsm.sv
@@ -92,7 +92,7 @@ module i2c_fsm (
         tClockPulse : tcount_d = t_r_i + thigh_i;
         tHoldBit    : tcount_d = t_f_i + thd_dat_i;
         tSetupStop  : tcount_d = t_r_i + tsu_sto_i;
-        tHoldStop   : tcount_d = t_r_i + t_buf_i;
+        tHoldStop   : tcount_d = t_r_i + t_buf_i - tsu_sta_i;
         tNoDelay    : tcount_d = '0;
         default     : tcount_d = '0;
       endcase


### PR DESCRIPTION
1. Swapped bits for fmt_flag_read_bytes and fmt_flag_read_continue (bug fix in i2c_core.sv).
2. Reduced hold time in Stop condition to a minimum.