### PR TITLE
[sw] Remove all unwinding from device binaries

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -66,12 +66,16 @@ add_project_arguments(
   '-nostartfiles', '-nostdlib', '-nostdinc',
   '-static', # Only link static files
   optimize_size_args,
+  # Don't emit eh_frame, which we straight up do not use.
+  '-fno-asynchronous-unwind-tables',
   language: 'cpp', native: false)
 add_project_arguments(
   # Do not use standard system startup files or libraries
   '-nostartfiles', '-nostdlib', '-nostdinc',
   '-static', # Only link static files
   optimize_size_args,
+  # Don't emit eh_frame, which we straight up do not use.
+  '-fno-asynchronous-unwind-tables',
   language: 'c', native: false)
 add_project_link_arguments(
   '-nostdlib', # Do not use standard system startup files or libraries

--- a/sw/device/boot_rom/rom_link.ld
+++ b/sw/device/boot_rom/rom_link.ld
@@ -139,4 +139,14 @@ SECTIONS {
   .stabstr 0x0 (NOLOAD): {
     [.stabstr]
   }
+
+  /**
+   * Explicitly discarded sections.
+   */
+  /DISCARD/ : {
+    /**
+     * OpenTitan does not support unwinding.
+     */
+    *(.eh_frame)
+  }
 }

--- a/sw/device/exts/common/flash_link.ld
+++ b/sw/device/exts/common/flash_link.ld
@@ -124,4 +124,11 @@ SECTIONS {
   .stabstr 0x0 (NOLOAD): {
     *(.stabstr)
   }
+
+  /**
+   * Explicitly discarded sections.
+   */
+  /DISCARD/ : {
+    *(.eh_frame)
+  }
 }


### PR DESCRIPTION
For whatever reason, gcc insists on emitting .eh_frame information,
which we do not use anywhere. This change adds compiler flags and linker
script stanzas to completely eliminate it, since it wastes precious
binary space.