### PR TITLE
[sw] Add more string.h functions to memory.h.

### DIFF
--- a/sw/device/lib/base/memory.c
+++ b/sw/device/lib/base/memory.c
@@ -25,3 +25,44 @@ void *memset(void *dest, int value, size_t len) {
   return dest;
 }
 
+enum {
+  kMemCmpEq = 0,
+  kMemCmpLt = -42,
+  kMemCmpGt = 42,
+};
+
+int memcmp(const void *lhs, const void *rhs, size_t len) {
+  const uint8_t *lhs8 = (uint8_t *)lhs;
+  const uint8_t *rhs8 = (uint8_t *)rhs;
+  for (size_t i = 0; i < len; ++i) {
+    if (lhs8[i] < rhs8[i]) {
+      return kMemCmpLt;
+    } else if (lhs8[i] > rhs8[i]) {
+      return kMemCmpGt;
+    }
+  }
+  return kMemCmpEq;
+}
+
+void *memchr(const void *ptr, int value, size_t len) {
+  uint8_t *ptr8 = (uint8_t *)ptr;
+  uint8_t value8 = (uint8_t)value;
+  for (size_t i = 0; i < len; ++i) {
+    if (ptr8[i] == value8) {
+      return ptr8 + i;
+    }
+  }
+  return NULL;
+}
+
+void *memrchr(const void *ptr, int value, size_t len) {
+  uint8_t *ptr8 = (uint8_t *)ptr;
+  uint8_t value8 = (uint8_t)value;
+  for (size_t i = 0; i < len; ++i) {
+    size_t idx = len - i - 1;
+    if (ptr8[idx] == value8) {
+      return ptr8 + idx;
+    }
+  }
+  return NULL;
+}

--- a/sw/device/lib/base/memory.h
+++ b/sw/device/lib/base/memory.h
@@ -6,12 +6,8 @@
 #define OPENTITAN_SW_DEVICE_LIB_BASE_MEMORY_H_
 
 #include <stdalign.h>
-#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <stdnoreturn.h>
-
-#include "sw/device/lib/base/stdasm.h"
 
 /**
  * Load a word from memory directly, bypassing aliasing rules.
@@ -90,8 +86,51 @@ void *memcpy(void *restrict dest, const void *restrict src, size_t len);
  * @param dest the region to write to.
  * @param value the value, converted to a byte, to write to each byte cell.
  * @param len the number of bytes to write.
- * #return the value of |dest|.
+ * @return the value of |dest|.
  */
 void *memset(void *dest, int value, size_t len);
+
+/**
+ * Compare two (potentially overlapping) regions of memory for byte-wise
+ * lexicographic order.
+ *
+ * This function conforms to the semantics defined in ISO C11 S7.24.4.1.
+ *
+ * @param lhs the left-hand-side of the comparison.
+ * @param rhs the right-hand-side of the comparison.
+ * @param len the length of both regions, in bytes.
+ * @return a zero, positive, or negative integer, corresponding to the
+ * contingencies of |lhs == rhs|, |lhs > rhs|, and |lhs < rhs| (as buffers, not
+ * pointers), respectively.
+ */
+int memcmp(const void *lhs, const void *rhs, size_t len);
+
+/**
+ * Search a region of memory for the first occurence of a particular byte value.
+ *
+ * This function conforms to the semantics defined in ISO C11 S7.24.5.1.
+ *
+ * Since libbase does not provide a |strlen()| function, this function can be
+ * used as an approximation: |memchr(my_str, 0, SIZE_MAX) - my_str|.
+ *
+ * @param ptr the region to search.
+ * @param value the value, converted to a byte, to search for.
+ * @param len the length of the region, in bytes.
+ * @return a pointer to the found value, or NULL.
+ */
+void *memchr(const void *ptr, int value, size_t len);
+
+/**
+ * Search a region of memory for the last occurence of a particular byte value.
+ *
+ * This function is not specified by C11, but is named for a well-known glibc
+ * extension.
+ *
+ * @param ptr the region to search.
+ * @param value the value, converted to a byte, to search for.
+ * @param len the length of the region, in bytes.
+ * @return a pointer to the found value, or NULL.
+ */
+void *memrchr(const void *ptr, int value, size_t len);
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_BASE_MEMORY_H_


### PR DESCRIPTION
This change adds memcmp, memchr, and the glibc extension memrchr to the memory.h header.

I'm mostly tired of half-ass implementing these as static functions in TUs, and all of them seem useful. I considered re-adding strlen, but:
- I don't want to encourage C strings outside of libbase.
- memchr is basically a better strlen.