### PR TITLE
[sw] Fix build breaks due to misaligned binaries

### DIFF
--- a/sw/device/examples/hello_usbdev/hello_usbdev.c
+++ b/sw/device/examples/hello_usbdev/hello_usbdev.c
@@ -48,11 +48,6 @@ static uint8_t cfg_dscr[] = {
         2) VEND_INTERFACE_DSCR(0, 2, 0x50, 1) USB_BULK_EP_DSCR(0, 1, 32, 0)
         USB_BULK_EP_DSCR(1, 1, 32, 4) VEND_INTERFACE_DSCR(1, 2, 0x50, 1)
             USB_BULK_EP_DSCR(0, 2, 32, 0) USB_BULK_EP_DSCR(1, 2, 32, 4)};
-// The array above may not end aligned on a 4-byte boundary
-// and is probably at the end of the initialized data section
-// Conversion to srec needs this to be aligned so force it by
-// initializing an int32 (volatile else it is not used and can go away)
-static volatile int32_t sdata_align = 42;
 
 /* context areas */
 static usbdev_ctx_t usbdev_ctx;

--- a/util/embedded_target.py
+++ b/util/embedded_target.py
@@ -18,14 +18,25 @@ def run_objdump(objdump, input, basename, outdir):
     filename = basename + '.dis'
     output = os.path.join(outdir, filename)
     f = open(output, "w")
-    cmd = [objdump, '-SDhl', input, ]
+    cmd = [
+        objdump,
+        '--disassemble-all',
+        '--headers',
+        '--line-numbers',
+        '--source',
+        input,
+    ]
     subprocess.run(cmd, stdout=f, check=True)
     return output
 
 def run_objcopy(objcopy, input, basename, outdir):
     filename = basename + '.bin'
     output = os.path.join(outdir, filename)
-    cmd = [objcopy, '-O', 'binary', input, output]
+    cmd = [
+        objcopy, 
+        '--output-target', 'binary',
+        input, output,
+    ]
     subprocess.run(cmd, check=True)
     return output
 
@@ -36,8 +47,16 @@ def run_srec_cat(srec_cat, input, basename, outdir):
     filename = basename + '.vmem'
     output = os.path.join(outdir, filename)
     cmd = [
-        srec_cat, input, '-binary', '-offset', '0x0', '-byte-swap', '4', '-o',
-        output, '-vmem'
+        srec_cat, 
+        # Input is to be interpreted as a pure binary
+        input, '--binary',
+        # Reverse the endianness of every 32-bit word.
+        '--offset', '0x0', '--byte-swap', '4',
+        # Fill the entire range with garbage, to pad it up to a
+        # four-byte alignment.
+        '--fill', '0xff', '-within', input, '-binary', '-range-pad', '4',
+        # Output as a 32-bit VMem file.
+        '--output', output, '--vmem', '32',
     ]
     subprocess.run(cmd, check=True)
 


### PR DESCRIPTION
The VMem format variant we use requires binaries to be a whole number of
32-bit words long. This change ensures this at the build level, allowing
us to remove a hack in hello_usbdev.c.

Signed-off-by: Miguel Young de la Sota <mcyoung@google.com>