### PR TITLE
[CI] Trigger private CI runs 

### DIFF
--- a/ci/azp-private.yml
+++ b/ci/azp-private.yml
@@ -1,0 +1,15 @@
+# Private CI trigger.  Used to run tooling that can't currently be shared
+# publicly.
+
+# The runner used for private CI enforces the use of the template below. All
+# build steps need to be placed into the template.
+resources:
+  repositories:
+  - repository: opentitan-private-ci
+    type: github
+    endpoint: lowRISC
+    name: lowrisc/opentitan-private-ci
+
+extends:
+  template: jobs.yml@opentitan-private-ci
+


### PR DESCRIPTION
Add the necessary infrastructure to trigger CI runs which are specified
in another (private) repository, and which do not have public facing
build results. This is to satisfy legal requirements on some tools we're
using.