### PR TITLE
[dv] add coverage exclusion for hmac and gpio

### DIFF
--- a/hw/ip/gpio/dv/env/gpio_env_cfg.sv
+++ b/hw/ip/gpio/dv/env/gpio_env_cfg.sv
@@ -27,6 +27,9 @@ class gpio_env_cfg extends cip_base_env_cfg #(.RAL_T(gpio_reg_block));
     super.initialize(csr_base_addr);
     // set num_interrupts & num_alerts which will be used to create coverage and more
     num_interrupts = ral.intr_state.get_n_used_bits();
+
+    // only support 1 outstanding TL item
+    m_tl_agent_cfg.max_outstanding_req = 1;
   endfunction : initialize
 
 endclass

--- a/hw/ip/gpio/dv/gpio_sim_cfg.hjson
+++ b/hw/ip/gpio/dv/gpio_sim_cfg.hjson
@@ -42,6 +42,15 @@
   uvm_test: gpio_base_test
   uvm_test_seq: gpio_base_vseq
 
+  // Add GPIO specific exclusion files.
+
+  // Add excl files to tool_srcs so that it gets copied over to the scratch area.
+  tool_srcs: ["{proj_root}/hw/ip/gpio/dv/cov/gpio_cov_excl.el"]
+
+  // Refer to the excl file with vcs_cov_excl_files var with the rel path from tool_srcs_dir
+  // so the VCS can find it.
+  vcs_cov_excl_files: ["{tool_srcs_dir}/gpio_cov_excl.el"]
+
   // List of test specifications.
   tests: [
     {

--- a/hw/ip/hmac/dv/env/hmac_env_cfg.sv
+++ b/hw/ip/hmac/dv/env/hmac_env_cfg.sv
@@ -19,6 +19,9 @@ class hmac_env_cfg extends cip_base_env_cfg #(.RAL_T(hmac_reg_block));
     list_of_alerts      = {"msg_push_sha_disabled"};
     // set num_interrupts & num_alerts which will be used to create coverage and more
     num_interrupts = ral.intr_state.get_n_used_bits();
+
+    // only support 2 outstanding TL items in tlul_adapter
+    m_tl_agent_cfg.max_outstanding_req = 2;
   endfunction
 
 endclass

--- a/hw/ip/hmac/dv/hmac_sim_cfg.hjson
+++ b/hw/ip/hmac/dv/hmac_sim_cfg.hjson
@@ -38,6 +38,15 @@
   // Default iterations for all tests - each test entry can override this.
   reseed: 50
 
+  // Add HMAC specific exclusion files.
+
+  // Add excl files to tool_srcs so that it gets copied over to the scratch area.
+  tool_srcs: ["{proj_root}/hw/ip/hmac/dv/cov/hmac_cov_excl.el"]
+
+  // Refer to the excl file with vcs_cov_excl_files var with the rel path from tool_srcs_dir
+  // so the VCS can find it.
+  vcs_cov_excl_files: ["{tool_srcs_dir}/hmac_cov_excl.el"]
+
   // Default UVM test and seq class name.
   uvm_test: hmac_base_test
   uvm_test_seq: hmac_base_vseq

--- a/hw/ip/rv_timer/dv/env/rv_timer_env_cfg.sv
+++ b/hw/ip/rv_timer/dv/env/rv_timer_env_cfg.sv
@@ -14,6 +14,9 @@ class rv_timer_env_cfg extends cip_base_env_cfg #(.RAL_T(rv_timer_reg_block));
     super.initialize(csr_base_addr);
     // set num_interrupts
     num_interrupts = NUM_HARTS * NUM_TIMERS;
+
+    // only support 1 outstanding TL item
+    m_tl_agent_cfg.max_outstanding_req = 1;
   endfunction
 
 endclass


### PR DESCRIPTION
Add coverage exclusion into the hjson file for hmac and gpio.
Add max_outstanding_req for hmac, gpio, and rv_timer.

Signed-off-by: Cindy Chen <chencindy@google.com>