### PR TITLE
Update Verilator version

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,7 @@
 # Documentation at https://aka.ms/yaml
 
 variables:
-  VERILATOR_VERSION: 4.010
+  VERILATOR_VERSION: 4.028
   VERILATOR_PATH: /opt/buildcache/verilator/$(VERILATOR_VERSION)
   TOOLCHAIN_PATH: /opt/buildcache/riscv
   # Release tag from https://github.com/lowRISC/lowrisc-toolchains/releases

--- a/check_tool_requirements.core
+++ b/check_tool_requirements.core
@@ -1,0 +1,31 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:tool:check_tool_requirements:0.1"
+description: "Check tool requirements"
+
+filesets:
+  files_check_tool_requirements:
+    files:
+      - ./util/check_tool_requirements.py : { copyto: util/check_tool_requirements.py }
+      - ./tool_requirements.py : { copyto: tool_requirements.py }
+
+scripts:
+  check_tool_requirements:
+    cmd:
+      - python3
+      - util/check_tool_requirements.py
+    # TODO: Use this syntax once https://github.com/olofk/fusesoc/issues/353 is
+    # fixed. Remove the filesets from the default target, and also remove the
+    # copyto.
+    #filesets:
+    #  - files_check_tool_requirements
+
+targets:
+  default:
+    filesets:
+      - files_check_tool_requirements
+    hooks:
+      pre_build:
+        - tool_verilator ? (check_tool_requirements)

--- a/doc/ug/install_instructions/index.md
+++ b/doc/ug/install_instructions/index.md
@@ -134,7 +134,7 @@ We recommend compiling Verilator from source, as outlined here.
 Then you can fetch, build and install Verilator itself (this should be done outside the `$REPO_TOP` directory).
 
 ```console
-$ export VERILATOR_VERSION=4.010
+$ export VERILATOR_VERSION=4.028
 
 $ git clone http://git.veripool.org/git/verilator
 $ cd verilator

--- a/doc/ug/install_instructions/index.md
+++ b/doc/ug/install_instructions/index.md
@@ -134,7 +134,7 @@ We recommend compiling Verilator from source, as outlined here.
 Then you can fetch, build and install Verilator itself (this should be done outside the `$REPO_TOP` directory).
 
 ```console
-$ export VERILATOR_VERSION=4.028
+$ export VERILATOR_VERSION={{< tool_version "verilator" >}}
 
 $ git clone http://git.veripool.org/git/verilator
 $ cd verilator

--- a/hw/lint/common.core
+++ b/hw/lint/common.core
@@ -15,10 +15,13 @@ filesets:
       - common.waiver: {file_type: waiver}
       - ascentlint-config.tcl: {file_type: tclSource}
 
+  files_check_tool_requirements:
+    depend:
+     - lowrisc:tool:check_tool_requirements
+
 targets:
   default: &default_target
     filesets:
       - tool_verilator  ? (files_verilator)
       - tool_ascentlint ? (files_ascentlint)
-
-
+      - files_check_tool_requirements

--- a/site/docs/layouts/shortcodes/tool_version.html
+++ b/site/docs/layouts/shortcodes/tool_version.html
@@ -1,0 +1,7 @@
+{{- $tool := .Get 0 -}}
+{{- $file := (print "version_" $tool ".txt") -}}
+{{- $path := path.Join .Site.Params.generatedRoot $file -}}
+{{- if not (fileExists $path) -}}
+  {{- errorf (print $file " has not been generated") -}}
+{{- end -}}
+{{- readFile $path | plainify -}}

--- a/tool_requirements.py
+++ b/tool_requirements.py
@@ -1,0 +1,9 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Version requirements for various tools. Checked by tooling (e.g. fusesoc),
+# and inserted into the documentation.
+__TOOL_REQUIREMENTS__ = {
+    'verilator': '4.028',
+}

--- a/util/build_docs.py
+++ b/util/build_docs.py
@@ -196,6 +196,23 @@ def generate_apt_reqs():
     with open(str(apt_cmd_path), mode='w') as fout:
         fout.write(apt_cmd)
 
+def generate_tool_versions():
+    """Generate an tool version number requirement from tool_requirements.py
+
+    The version number per tool will be saved in outdir-generated/version_$TOOL_NAME.txt
+    """
+
+    # Populate __TOOL_REQUIREMENTS__
+    requirements_file = str(SRCTREE_TOP.joinpath("tool_requirements.py"))
+    exec(open(requirements_file).read(), globals())
+
+    # And then write a version file for every tool.
+    for tool in __TOOL_REQUIREMENTS__:
+        version_path = config["outdir-generated"].joinpath('version_' + tool + '.txt')
+        version_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(str(version_path), mode='w') as fout:
+            fout.write(__TOOL_REQUIREMENTS__[tool])
+
 
 def is_hugo_extended():
     args = ["hugo", "version"]
@@ -285,6 +302,7 @@ def main():
     generate_testplans()
     generate_selfdocs()
     generate_apt_reqs()
+    generate_tool_versions()
 
     hugo_localinstall_dir = SRCTREE_TOP / 'build' / 'docs-hugo'
     os.environ["PATH"] += os.pathsep + str(hugo_localinstall_dir)

--- a/util/check_tool_requirements.py
+++ b/util/check_tool_requirements.py
@@ -1,0 +1,63 @@
+#!/usr/bin/python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+from distutils.version import StrictVersion
+import logging as log
+import os
+import subprocess
+import sys
+
+# Display INFO log messages and up.
+log.basicConfig(level=log.INFO, format="%(levelname)s: %(message)s")
+
+# Populate __TOOL_REQUIREMENTS__
+topsrcdir = os.path.join(os.path.dirname(__file__), '..')
+exec(open(os.path.join(topsrcdir, 'tool_requirements.py')).read())
+
+def get_verilator_version():
+    try:
+        # Note: "verilator" needs to be called through a shell and with all
+        # arguments in a string, as it doesn't have a shebang, but instead
+        # relies on perl magic to parse command line arguments.
+        version_str = subprocess.run('verilator --version', shell=True,
+                                     check=True, stdout=subprocess.PIPE,
+                                     stderr=subprocess.STDOUT,
+                                     universal_newlines=True)
+        return version_str.stdout.split(' ')[1].strip()
+
+    except subprocess.CalledProcessError as e:
+        log.error("Unable to call Verilator to check version: " + str(e))
+        log.error(e.stdout)
+        return None
+
+def check_version(tool_name, required_version, actual_version):
+    if required_version is None or actual_version is None:
+        return False
+
+    if StrictVersion(actual_version) < StrictVersion(required_version):
+        log.error("%s is too old: found version %s, need at least %s",
+                  tool_name, actual_version, required_version)
+        return False
+    else:
+        log.info("Found sufficiently recent version of %s (found %s, need %s)",
+                 tool_name, actual_version, required_version)
+        return True
+
+
+def main():
+    any_failed = False
+
+    if not check_version('verilator', __TOOL_REQUIREMENTS__['verilator'],
+                         get_verilator_version()):
+        any_failed = True
+
+    if any_failed:
+        log.error("Tool requirements not fulfilled. "
+                  "Please update the tools and retry.")
+        return 1
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -6,7 +6,7 @@
 # for OpenTitan.
 
 # Global configuration options.
-ARG VERILATOR_VERSION=4.010
+ARG VERILATOR_VERSION=4.028
 
 # The RISCV toolchain version should match the release tag used in GitHub.
 ARG RISCV_TOOLCHAIN_TAR_VERSION=20190807-1


### PR DESCRIPTION
As of version 4.028, Verilator supports wildcard matching for `lint_off` rules. This reduces the effort required to keep lint waiver files aligned with the actual source code.