### PR TITLE
Add qualifier to `instr_error_i`

### DIFF
--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -215,7 +215,7 @@ module rv_core_ibex #(
   assign instr_gnt_i    = tl_i_fifo2ibex.a_ready & tl_i_ibex2fifo.a_valid;
   assign instr_rvalid_i = tl_i_fifo2ibex.d_valid;
   assign instr_rdata_i  = tl_i_fifo2ibex.d_data;
-  assign instr_err_i    = tl_i_fifo2ibex.d_error;
+  assign instr_err_i    = tl_i_fifo2ibex.d_valid & tl_i_fifo2ibex.d_error;
 
   tlul_fifo_sync #(
     .ReqPass(FifoPass),
@@ -257,7 +257,7 @@ module rv_core_ibex #(
   assign data_gnt_i    = tl_d_fifo2ibex.a_ready & tl_d_ibex2fifo.a_valid;
   assign data_rvalid_i = tl_d_fifo2ibex.d_valid;
   assign data_rdata_i  = tl_d_fifo2ibex.d_data;
-  assign data_err_i    = tl_d_fifo2ibex.d_error;
+  assign data_err_i    = tl_d_fifo2ibex.d_valid & tl_d_fifo2ibex.d_error;
 
   tlul_fifo_sync #(
     .ReqPass(FifoPass),


### PR DESCRIPTION
Problem:

    `d_error` signal in rv_core_ibex directly affects the Ibex IF stage.
    And it affects prefetch, then it creates the loop.

Resolution:

    Add `d_valid` qualifier at the `instr_error_i` and `data_error_i`.

If the request from the TL-UL hosts are not valid, the TL-UL creates
error responses and returns to the requesters with `d_error` as 1. The
error signal in TL-UL D channel is valid only when the `d_valid` is
asserted.

Ibex, however, sees the error signal always and it triggers the branch
if the error signal is asserted. And the prefetch sends a new request to
the crossbar. It creates a logical loop.

This fix is to add `d_valid` qualifier to the `*_error_i` in
`rv_core_ibex`. It may not be a perfect solution but would break the
loop.

This closes issue #1657