### PR TITLE
[reggen] Fix Interrupt `genresmask`

### DIFF
--- a/util/reggen/validate.py
+++ b/util/reggen/validate.py
@@ -1015,6 +1015,8 @@ def validate_multi(mreg, offset, addrsep, width, top):
         if closereg:
             genreg['fields'] = genfields
             genreg['genbasebits'] = bused
+            genreg['genresval'] = resval
+            genreg['genresmask'] = resmask
             error += validate_register(genreg, offset + (rnum * addrsep),
                                        width, top)
             if error:
@@ -1085,7 +1087,7 @@ def make_intr_reg(regs, name, offset, swaccess, hwaccess, desc):
         newf['genresval'] = 0
         newf['genresvalx'] = False
 
-        bits_used = bits_used | (1 << cur_bit)
+        bits_used = bits_used | ((2**w - 1) << cur_bit)
         cur_bit += 1
         genfields.append(newf)
 


### PR DESCRIPTION
Problem:

    Multireg doesn't show correct mask value

The auto generated multi registers doesn't consider the multi-width
field in the interrupt related registers. Now the code is changed to
consider the `width` field to correctly calculate the `genresmask`.

Also in multireg validation code, when it creates a `genreg`, it didn't
store the `genresval` and `genresmask`. So the register table in the
specification only showed 0 reset value and 1 mask value.

This fixes #41
