### PR TITLE
[prim] Move unrelated constants out of prim_pkg.sv

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent_pkg.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent_pkg.sv
@@ -7,7 +7,8 @@ package alert_esc_agent_pkg;
   import uvm_pkg::*;
   import dv_lib_pkg::*;
   import dv_utils_pkg::*;
-  import prim_pkg::*;
+  import prim_alert_pkg::*;
+  import prim_esc_pkg::*;
 
   typedef class alert_esc_seq_item;
   typedef class alert_esc_agent_cfg;

--- a/hw/dv/sv/alert_esc_agent/alert_esc_if.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_if.sv
@@ -6,10 +6,10 @@
 // Alert interface
 // ---------------------------------------------
 interface alert_esc_if(input clk, input rst_n);
-  wire prim_pkg::alert_tx_t alert_tx;
-  wire prim_pkg::alert_rx_t alert_rx;
-  wire prim_pkg::esc_tx_t esc_tx;
-  wire prim_pkg::esc_rx_t esc_rx;
+  wire prim_alert_pkg::alert_tx_t alert_tx;
+  wire prim_alert_pkg::alert_rx_t alert_rx;
+  wire prim_esc_pkg::esc_tx_t esc_tx;
+  wire prim_esc_pkg::esc_rx_t esc_rx;
 
   clocking sender_cb @(posedge clk);
     input  rst_n;

--- a/hw/ip/alert_handler/dv/tb/tb.sv
+++ b/hw/ip/alert_handler/dv/tb/tb.sv
@@ -27,11 +27,11 @@ module tb;
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
 
   // dut signals
-  prim_pkg::alert_rx_t [alert_pkg::NAlerts-1:0] alert_rx;
-  prim_pkg::alert_tx_t [alert_pkg::NAlerts-1:0] alert_tx;
+  prim_alert_pkg::alert_rx_t [alert_pkg::NAlerts-1:0] alert_rx;
+  prim_alert_pkg::alert_tx_t [alert_pkg::NAlerts-1:0] alert_tx;
 
-  prim_pkg::esc_rx_t [alert_pkg::N_ESC_SEV-1:0] esc_rx;
-  prim_pkg::esc_tx_t [alert_pkg::N_ESC_SEV-1:0] esc_tx;
+  prim_esc_pkg::esc_rx_t [alert_pkg::N_ESC_SEV-1:0] esc_rx;
+  prim_esc_pkg::esc_tx_t [alert_pkg::N_ESC_SEV-1:0] esc_tx;
 
   alert_esc_if alert_host_if[alert_pkg::NAlerts](.clk(clk), .rst_n(rst_n));
   for (genvar k = 0; k < alert_pkg::NAlerts; k++) begin : gen_alert_if

--- a/hw/ip/alert_handler/rtl/alert_handler.sv
+++ b/hw/ip/alert_handler/rtl/alert_handler.sv
@@ -10,7 +10,11 @@
 
 `include "prim_assert.sv"
 
-module alert_handler import alert_pkg::*; import prim_pkg::*; (
+module alert_handler
+  import alert_pkg::*;
+  import prim_alert_pkg::*;
+  import prim_esc_pkg::*;
+(
   input                           clk_i,
   input                           rst_ni,
   // Bus Interface (device)

--- a/hw/ip/hmac/rtl/hmac.sv
+++ b/hw/ip/hmac/rtl/hmac.sv
@@ -7,7 +7,7 @@
 `include "prim_assert.sv"
 
 module hmac
-  import prim_pkg::*;
+  import prim_alert_pkg::*;
   import hmac_pkg::*;
   import hmac_reg_pkg::*;
 (

--- a/hw/ip/nmi_gen/rtl/nmi_gen.sv
+++ b/hw/ip/nmi_gen/rtl/nmi_gen.sv
@@ -6,7 +6,9 @@
 // receivers and converts them into interrupts such that they can be tested in system.
 // See also alert handler documentation for more context.
 
-module nmi_gen import prim_pkg::*; #(
+module nmi_gen
+  import prim_esc_pkg::*;
+#(
   // leave constant
   localparam int unsigned N_ESC_SEV = 4
 ) (

--- a/hw/ip/prim/fpv/tb/prim_alert_rxtx_async_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_alert_rxtx_async_fpv.sv
@@ -5,7 +5,10 @@
 // Testbench module for alert sender/receiver pair. Intended to use with
 // a formal tool.
 
-module prim_alert_rxtx_async_fpv import prim_pkg::*; (
+module prim_alert_rxtx_async_fpv
+  import prim_alert_pkg::*;
+  import prim_esc_pkg::*;
+(
   input        clk_i,
   input        rst_ni,
   // for sigint error and skew injection only

--- a/hw/ip/prim/fpv/tb/prim_alert_rxtx_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_alert_rxtx_fpv.sv
@@ -5,7 +5,10 @@
 // Testbench module for alert sender/receiver pair. Intended to use with
 // a formal tool.
 
-module prim_alert_rxtx_fpv import prim_pkg::*; (
+module prim_alert_rxtx_fpv
+  import prim_alert_pkg::*;
+  import prim_esc_pkg::*;
+(
   input        clk_i,
   input        rst_ni,
   // for sigint error injection only

--- a/hw/ip/prim/fpv/tb/prim_esc_rxtx_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_esc_rxtx_fpv.sv
@@ -5,7 +5,10 @@
 // Testbench module for escalation sender/receiver pair. Intended to use with
 // a formal tool.
 
-module prim_esc_rxtx_fpv import prim_pkg::*; (
+module prim_esc_rxtx_fpv
+  import prim_alert_pkg::*;
+  import prim_esc_pkg::*;
+(
   input        clk_i,
   input        rst_ni,
   // for sigint error injection only

--- a/hw/ip/prim/prim.core
+++ b/hw/ip/prim/prim.core
@@ -17,10 +17,12 @@ filesets:
       - lowrisc:prim:clock_mux2
     files:
       - rtl/prim_clock_inverter.sv
+      - rtl/prim_alert_pkg.sv
       - rtl/prim_alert_receiver.sv
       - rtl/prim_alert_sender.sv
       - rtl/prim_arbiter_ppc.sv
       - rtl/prim_arbiter_tree.sv
+      - rtl/prim_esc_pkg.sv
       - rtl/prim_esc_receiver.sv
       - rtl/prim_esc_sender.sv
       - rtl/prim_sram_arbiter.sv

--- a/hw/ip/prim/rtl/prim_alert_pkg.sv
+++ b/hw/ip/prim/rtl/prim_alert_pkg.sv
@@ -1,0 +1,17 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package prim_alert_pkg;
+  typedef struct packed {
+    logic alert_p;
+    logic alert_n;
+  } alert_tx_t;
+
+  typedef struct packed {
+    logic ping_p;
+    logic ping_n;
+    logic ack_p;
+    logic ack_n;
+  } alert_rx_t;
+endpackage

--- a/hw/ip/prim/rtl/prim_alert_receiver.sv
+++ b/hw/ip/prim/rtl/prim_alert_receiver.sv
@@ -29,7 +29,9 @@
 
 `include "prim_assert.sv"
 
-module prim_alert_receiver import prim_pkg::*; #(
+module prim_alert_receiver
+  import prim_alert_pkg::*;
+#(
   // enables additional synchronization logic
   parameter bit AsyncOn = 1'b0
 ) (

--- a/hw/ip/prim/rtl/prim_alert_sender.sv
+++ b/hw/ip/prim/rtl/prim_alert_sender.sv
@@ -26,7 +26,9 @@
 
 `include "prim_assert.sv"
 
-module prim_alert_sender import prim_pkg::*; #(
+module prim_alert_sender
+  import prim_alert_pkg::*;
+#(
   // enables additional synchronization logic
   parameter bit AsyncOn = 1'b1
 ) (

--- a/hw/ip/prim/rtl/prim_esc_pkg.sv
+++ b/hw/ip/prim/rtl/prim_esc_pkg.sv
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package prim_esc_pkg;
+  typedef struct packed {
+    logic esc_p;
+    logic esc_n;
+  } esc_tx_t;
+
+  typedef struct packed {
+    logic resp_p;
+    logic resp_n;
+  } esc_rx_t;
+endpackage

--- a/hw/ip/prim/rtl/prim_esc_receiver.sv
+++ b/hw/ip/prim/rtl/prim_esc_receiver.sv
@@ -18,7 +18,9 @@
 
 `include "prim_assert.sv"
 
-module prim_esc_receiver import prim_pkg::*; (
+module prim_esc_receiver
+  import prim_esc_pkg::*;
+(
   input           clk_i,
   input           rst_ni,
   // escalation enable

--- a/hw/ip/prim/rtl/prim_esc_sender.sv
+++ b/hw/ip/prim/rtl/prim_esc_sender.sv
@@ -21,7 +21,9 @@
 
 `include "prim_assert.sv"
 
-module prim_esc_sender import prim_pkg::*; (
+module prim_esc_sender
+  import prim_esc_pkg::*;
+(
   input           clk_i,
   input           rst_ni,
   // this triggers a ping test. keep asserted

--- a/hw/ip/prim/rtl/prim_pkg.sv
+++ b/hw/ip/prim/rtl/prim_pkg.sv
@@ -11,28 +11,4 @@ package prim_pkg;
     ImplGeneric = 0,
     ImplXilinx  = 1
   } impl_e;
-
-  // interface structs for prim_alert_* and prim_esc_*
-  typedef struct packed {
-    logic alert_p;
-    logic alert_n;
-  } alert_tx_t;
-
-  typedef struct packed {
-    logic ping_p;
-    logic ping_n;
-    logic ack_p;
-    logic ack_n;
-  } alert_rx_t;
-
-  typedef struct packed {
-    logic esc_p;
-    logic esc_n;
-  } esc_tx_t;
-
-  typedef struct packed {
-    logic resp_p;
-    logic resp_n;
-  } esc_rx_t;
-
 endpackage : prim_pkg

--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -183,11 +183,11 @@ module top_${top["name"]} #(
   assign unused_irq_id = irq_id;
 
   // Alert list
-  prim_pkg::alert_tx_t [alert_pkg::NAlerts-1:0]  alert_tx;
-  prim_pkg::alert_rx_t [alert_pkg::NAlerts-1:0]  alert_rx;
+  prim_alert_pkg::alert_tx_t [alert_pkg::NAlerts-1:0]  alert_tx;
+  prim_alert_pkg::alert_rx_t [alert_pkg::NAlerts-1:0]  alert_rx;
   // Escalation outputs
-  prim_pkg::esc_tx_t [alert_pkg::N_ESC_SEV-1:0]  esc_tx;
-  prim_pkg::esc_rx_t [alert_pkg::N_ESC_SEV-1:0]  esc_rx;
+  prim_esc_pkg::esc_tx_t [alert_pkg::N_ESC_SEV-1:0]  esc_tx;
+  prim_esc_pkg::esc_rx_t [alert_pkg::N_ESC_SEV-1:0]  esc_rx;
 
 % if not top["alert"]:
   for (genvar k = 0; k < alert_pkg::NAlerts; k++) begin : gen_alert_tie_off

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -227,11 +227,11 @@ module top_earlgrey #(
   assign unused_irq_id = irq_id;
 
   // Alert list
-  prim_pkg::alert_tx_t [alert_pkg::NAlerts-1:0]  alert_tx;
-  prim_pkg::alert_rx_t [alert_pkg::NAlerts-1:0]  alert_rx;
+  prim_alert_pkg::alert_tx_t [alert_pkg::NAlerts-1:0]  alert_tx;
+  prim_alert_pkg::alert_rx_t [alert_pkg::NAlerts-1:0]  alert_rx;
   // Escalation outputs
-  prim_pkg::esc_tx_t [alert_pkg::N_ESC_SEV-1:0]  esc_tx;
-  prim_pkg::esc_rx_t [alert_pkg::N_ESC_SEV-1:0]  esc_rx;
+  prim_esc_pkg::esc_tx_t [alert_pkg::N_ESC_SEV-1:0]  esc_tx;
+  prim_esc_pkg::esc_rx_t [alert_pkg::N_ESC_SEV-1:0]  esc_rx;
 
 
   // Clock assignments

--- a/hw/top_earlgrey/top_earlgrey.core
+++ b/hw/top_earlgrey/top_earlgrey.core
@@ -31,6 +31,7 @@ filesets:
       - lowrisc:ip:xbar_main
       - lowrisc:ip:xbar_peri
       - lowrisc:tlul:headers
+      - lowrisc:prim:all
     files:
       - rtl/padctl.sv
       - rtl/autogen/top_earlgrey.sv


### PR DESCRIPTION
`prim_pkg.sv` will be auto-generated and cannot be used as common file
for constants. Put these constants into a primitives-specific package.

The toplevel uses these constants, therefore we need to include the
relevant core there.

This is in preparation for the dynamic generation of primitives from technology libraries.