### PR TITLE
[top_earlgrey] Depend on core providing tlul_pkg.sv

### DIFF
--- a/hw/top_earlgrey/top_earlgrey.core
+++ b/hw/top_earlgrey/top_earlgrey.core
@@ -30,6 +30,7 @@ filesets:
       - lowrisc:ip:usbdev
       - lowrisc:ip:xbar_main
       - lowrisc:ip:xbar_peri
+      - lowrisc:tlul:headers
     files:
       - rtl/padctl.sv
       - rtl/autogen/top_earlgrey.sv


### PR DESCRIPTION
`top_earlgrey.sv` uses the `tlul_pkg`, it therefore needs to be a
dependency.