### PR TITLE
[usbdev] Don't import package into global scope

### DIFF
--- a/hw/ip/usbdev/rtl/usbdev_iomux.sv
+++ b/hw/ip/usbdev/rtl/usbdev_iomux.sv
@@ -9,9 +9,9 @@
 //  single-ended signaling. The incomming signals are also muxed and synchronized
 //  to the corresponding clock domain.
 
-import usbdev_reg_pkg::*;
-
-module usbdev_iomux (
+module usbdev_iomux
+  import usbdev_reg_pkg::*;
+(
   input  logic                          clk_i,
   input  logic                          rst_ni,
   input  logic                          clk_usb_48mhz_i, // use usb_ prefix for signals in this clk


### PR DESCRIPTION
This style of import isn't allowed in our style guide because it
pollutes the global scope. Verilator warns about it, as do typically our
linting tools.