### PR TITLE
[sw, tock] Install missing rustup components

### DIFF
--- a/sw/device/tock/meson.build
+++ b/sw/device/tock/meson.build
@@ -3,12 +3,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cargo = find_program('cargo')
+rustup = find_program('rustup')
 
 target = 'riscv32imc-unknown-none-elf'
 build_type = 'release'
 
 manifest_path = meson.source_root() / 'sw/device/tock/boards/opentitan/Cargo.toml'
 toolchain_file = meson.source_root() / 'sw/device/tock/boards/opentitan/rust-toolchain'
+toolchain = run_command('cat', toolchain_file).stdout().strip()
 
 rust_flags = '-C link-arg=-Tlayout.ld ' + \
 '-C linker=rust-lld ' + \
@@ -17,6 +19,37 @@ rust_flags = '-C link-arg=-Tlayout.ld ' + \
 '-C link-arg=-zmax-page-size=512'
 
 build_tock_cmd = meson.source_root() / 'util/build_tock.sh'
+
+llvm_tools_installed = false
+rust_src_installed = false
+target_tools_installed = false
+
+# Query rustup and search for required components
+rustup_components = run_command(rustup, 'component', 'list', '--toolchain', toolchain).stdout()
+foreach c : rustup_components.split('\n')
+  if not c.endswith('(installed)')
+    continue
+  endif
+
+  if c.contains('llvm-tools-preview')
+    llvm_tools_installed = true
+  elif c.contains('rust-src')
+    rust_src_installed = true
+  elif c.contains(target)
+    target_tools_installed = true
+  endif
+endforeach
+
+# Install missing components
+if not llvm_tools_installed
+  run_command(rustup, 'component', 'add', '--toolchain', toolchain, 'llvm-tools-preview')
+endif
+if not rust_src_installed
+  run_command(rustup, 'component', 'add', '--toolchain', toolchain, 'rust-src')
+endif
+if not target_tools_installed
+  run_command(rustup, 'target', 'add', '--toolchain', toolchain, target)
+endif
 
 tock_raw = custom_target(
   'tock_raw',


### PR DESCRIPTION
As @mcy pointed out in #1678, we are not installing the required Rust components before trying to build tock. We should do this, and this PR makes the build check if any of the required components are missing and installs them.

This is analogous to what is done in Tock's [`Makefile.common`].(https://github.com/tock/tock/blob/d68ec06d4b01aeb8e3cfb91c02e5215525a9d567/boards/Makefile.common#L62-L74)