### PR TITLE
[dv/uart] make UART nightly coverage 100%

### DIFF
--- a/hw/dv/data/tests/intr_test.hjson
+++ b/hw/dv/data/tests/intr_test.hjson
@@ -4,7 +4,7 @@
       name: "{name}_intr_test"
       uvm_test_seq: "{name}_common_vseq"
       run_opts: ["+run_intr_test"]
-      reseed: 20
+      reseed: 50
     }
   ]
 }

--- a/hw/dv/sv/cip_lib/cip_base_env_cov.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env_cov.sv
@@ -23,9 +23,7 @@ covergroup intr_test_cg (uint num_interrupts) with function sample(uint intr,
   cp_intr: coverpoint intr {
     bins all_values[] = {[0:num_interrupts-1]};
   }
-  cp_intr_test: coverpoint intr_test {
-    bins intr_test_1 = {1};
-  }
+  cp_intr_test: coverpoint intr_test;
   cp_intr_en: coverpoint intr_en;
   cp_intr_state: coverpoint intr_state;
   cross cp_intr, cp_intr_test, cp_intr_en, cp_intr_state {

--- a/hw/dv/sv/tl_agent/tl_monitor.sv
+++ b/hw/dv/sv/tl_agent/tl_monitor.sv
@@ -77,7 +77,7 @@ class tl_monitor extends dv_base_monitor#(
                    agent_name, req.convert2string()), UVM_HIGH)
         a_chan_port.write(req);
         pending_a_req.push_back(req);
-        if (cfg.max_outstanding_req > 0) begin
+        if (cfg.max_outstanding_req > 0 && cfg.vif.rst_n === 1) begin
           if (pending_a_req.size() > cfg.max_outstanding_req) begin
             `uvm_error(get_full_name(), $sformatf("Number of pending a_req exceeds limit %0d",
                                         pending_a_req.size()))

--- a/hw/ip/uart/dv/env/uart_scoreboard.sv
+++ b/hw/ip/uart/dv/env/uart_scoreboard.sv
@@ -270,7 +270,7 @@ class uart_scoreboard extends cip_base_scoreboard #(.CFG_T(uart_env_cfg),
       end
       "intr_test": begin
         if (write && channel == AddrChannel) begin
-          bit [TL_DW-1:0] intr_en = item.a_data;
+          bit [TL_DW-1:0] intr_en = ral.intr_enable.get_mirrored_value();
           intr_exp |= item.a_data;
           if (cfg.en_cov) begin
             foreach (intr_exp[i]) begin

--- a/hw/ip/uart/dv/uart_sim_cfg.hjson
+++ b/hw/ip/uart/dv/uart_sim_cfg.hjson
@@ -75,8 +75,8 @@
 
     {
       name: uart_fifo_reset
-      // need more seeds to cover uart_agent_cov::uart_reset_cg and uart_env_cov::fifo_level_cg
-      reseed: 200
+      // need more seeds to cover uart_env_cov::fifo_level_cg
+      reseed: 300
       uvm_test_seq: uart_fifo_reset_vseq
     }
 
@@ -122,6 +122,12 @@
       name: uart_perf
       uvm_test_seq: uart_perf_vseq
       run_opts: ["+zero_delays=1"]
+    }
+
+    {
+      name: uart_stress_all_with_rand_reset
+      // need more seeds to cover uart_agent_cov::uart_reset_cg
+      reseed: 100
     }
   ]
 


### PR DESCRIPTION
1. fix TL outstanding excess limit issue during reset
2. fix intr_test cov in uart
3. increase reseed for reset_fifo and stress_reset

Ran uart nightly regression twice, both reached 100% coverage

Signed-off-by: Weicai Yang <weicai@google.com>