### PR TITLE
[tlul] Match tlul_adapter_sram Outstanding to value

### DIFF
--- a/hw/ip/tlul/rtl/tlul_adapter_sram.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_sram.sv
@@ -218,15 +218,17 @@ module tlul_adapter_sram #(
   //    responses), storing the request is necessary. And if the read entry
   //    is write op, it is safe to return the response right away. If it is
   //    read reqeust, then D response is waiting until read data arrives.
-  prim_fifo_sync #(
-    .Width  (ReqFifoWidth),
-    .Pass   (1'b0),
+
+  // Notes:
   // The oustanding+1 allows the reqfifo to absorb back to back transactions
   // without any wait states.  Alternatively, the depth can be kept as
   // oustanding as long as the outgoing ready is qualified with the acceptance
   // of the response in the same cycle.  Doing so however creates a path from
   // ready_i to ready_o, which may not be desireable.
-    .Depth  (Outstanding+1'b1)
+  prim_fifo_sync #(
+    .Width  (ReqFifoWidth),
+    .Pass   (1'b0),
+    .Depth  (Outstanding)
   ) u_reqfifo (
     .clk_i,
     .rst_ni,

--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -330,7 +330,7 @@ module top_${top["name"]} #(
   tlul_adapter_sram #(
     .SramAw(${addr_width}),
     .SramDw(${data_width}),
-    .Outstanding(1)
+    .Outstanding(2)
   ) tl_adapter_${m["name"]} (
     % for key in clocks:
     .${key}   (${clocks[key]}_clk),
@@ -390,7 +390,7 @@ module top_${top["name"]} #(
   tlul_adapter_sram #(
     .SramAw(${addr_width}),
     .SramDw(${data_width}),
-    .Outstanding(1),
+    .Outstanding(2),
     .ErrOnWrite(1)
   ) tl_adapter_${m["name"]} (
     % for key in clocks:
@@ -453,7 +453,7 @@ module top_${top["name"]} #(
   tlul_adapter_sram #(
     .SramAw(FLASH_AW),
     .SramDw(FLASH_DW),
-    .Outstanding(1),
+    .Outstanding(2),
     .ByteAccess(0),
     .ErrOnWrite(1)
   ) tl_adapter_${m["name"]} (

--- a/hw/top_earlgrey/dv/Makefile
+++ b/hw/top_earlgrey/dv/Makefile
@@ -26,7 +26,9 @@ RAL_TOOL_OPTS   += --top
 
 # Common build options.
 # Enable the RISC-V Formal Interface (RVFI) for the ibex tracer.
-BUILD_OPTS      += +define+RVFI=1
+ifeq (${TRACE},1)
+  BUILD_OPTS      += +define+RVFI=1
+endif
 # Use generic implementations of prim modules.
 BUILD_OPTS      += +define+PRIM_DEFAULT_IMPL=prim_pkg::ImplGeneric
 

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -344,7 +344,7 @@ module top_earlgrey #(
   tlul_adapter_sram #(
     .SramAw(12),
     .SramDw(32),
-    .Outstanding(1),
+    .Outstanding(2),
     .ErrOnWrite(1)
   ) tl_adapter_rom (
     .clk_i   (main_clk),
@@ -388,7 +388,7 @@ module top_earlgrey #(
   tlul_adapter_sram #(
     .SramAw(14),
     .SramDw(32),
-    .Outstanding(1)
+    .Outstanding(2)
   ) tl_adapter_ram_main (
     .clk_i   (main_clk),
     .rst_ni   (sys_rst_n),
@@ -437,7 +437,7 @@ module top_earlgrey #(
   tlul_adapter_sram #(
     .SramAw(FLASH_AW),
     .SramDw(FLASH_DW),
-    .Outstanding(1),
+    .Outstanding(2),
     .ByteAccess(0),
     .ErrOnWrite(1)
   ) tl_adapter_eflash (


### PR DESCRIPTION
Reduce the number of Oustanding to its parameter value. Previous design
increased the request outstanding capability by one to accept next
request when it processes current request. It creates assertion error
below:

    `ASSERT(rvalidHighWhenRspFifoFull, rvalid_i |-> rspfifo_wready)

It is debatable whether the second request should be allowed or not.
This commit is to limit the request when the number of outstanding
requests reaches to its max value. Or we could revise the assertion to
consider the case.

This is related to #1489