### PR TITLE
[hw/top_earlgrey/data] PERIPH_OUTSEL index starts from 3 instead of 2.

### DIFF
--- a/hw/top_earlgrey/data/top_earlgrey.h.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.h.tpl
@@ -6,7 +6,6 @@
 #define _TOP_EARLGREY_H_
 
 #define PINMUX_PERIPH_INSEL_IDX_OFFSET 2
-#define PINMUX_PERIPH_OUTSEL_IDX_OFFSET 2
 
 // PERIPH_INSEL ranges from 0 to NUM_MIO + 2 -1}
 //  0 and 1 are tied to value 0 and 1
@@ -24,6 +23,11 @@
 <% offset += sig["width"] %>\
   % endif
 % endfor
+
+#define PINMUX_PERIPH_OUTSEL_IDX_OFFSET 3
+
+// PERIPH_OUTSEL ranges from 0 to NUM_MIO + 3 -1}
+// 0, 1 and 2 are tied to value 0, 1 and high-impedance
 
 ## offset starts from 3 as 0, 1, 2 are prefixed value
 <% offset = 3 %>\

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -6,7 +6,6 @@
 #define _TOP_EARLGREY_H_
 
 #define PINMUX_PERIPH_INSEL_IDX_OFFSET 2
-#define PINMUX_PERIPH_OUTSEL_IDX_OFFSET 2
 
 // PERIPH_INSEL ranges from 0 to NUM_MIO + 2 -1}
 //  0 and 1 are tied to value 0 and 1
@@ -45,6 +44,11 @@
 #define PINMUX_GPIO_GPIO_29_IN 29
 #define PINMUX_GPIO_GPIO_30_IN 30
 #define PINMUX_GPIO_GPIO_31_IN 31
+
+#define PINMUX_PERIPH_OUTSEL_IDX_OFFSET 3
+
+// PERIPH_OUTSEL ranges from 0 to NUM_MIO + 3 -1}
+// 0, 1 and 2 are tied to value 0, 1 and high-impedance
 
 #define PINMUX_VALUE_0_OUT 0
 #define PINMUX_VALUE_1_OUT 1


### PR DESCRIPTION
Fixes #1546

Signed-off-by: Zhongyi Chen <zhongyi.chen@gmail.com>