### PR TITLE
[top_earlgrey dv] Enabled DV with dvsim

### DIFF
--- a/hw/dv/data/common_sim_cfg.hjson
+++ b/hw/dv/data/common_sim_cfg.hjson
@@ -19,7 +19,8 @@
   build_dir:          "{scratch_path}/{build_mode}"
   run_dir_name:       "{index}.{test}"
   run_dir:            "{scratch_path}/{run_dir_name}/out"
-  sw_build_dir:       "{run_dir}/sw_build"
+  sw_build_dir:       "{scratch_path}/sw"
+  sw_root_dir:        "{proj_root}/sw"
 
   // pass and fail patterns
   pass_patterns:    ["^TEST PASSED (UVM_)?CHECKS$"]

--- a/hw/dv/data/sim.mk
+++ b/hw/dv/data/sim.mk
@@ -51,7 +51,20 @@ pre_run:
 sw_build: pre_run
 	@echo "[make]: sw_build"
 ifneq (${sw_name},)
-	$(error "sw_build target is not supported yet")
+	# Initialize meson build system.
+	cd ${proj_root} && \
+		BUILD_ROOT=${sw_build_dir} ${proj_root}/meson_init.sh
+	# Compile boot rom code and generate the image.
+	ninja -C ${sw_build_dir}/build-out \
+		sw/device/boot_rom/boot_rom_export_${sw_build_device}
+	# Compile the test sw code and generate the image.
+	ninja -C ${sw_build_dir}/build-out \
+		sw/device/${sw_dir}/${sw_name}_export_${sw_build_device}
+	# Copy over the images to the run_dir.
+	cp ${sw_build_dir}/build-out/sw/device/boot_rom/boot_rom_${sw_build_device}.vmem \
+		${run_dir}/rom.vmem
+	cp ${sw_build_dir}/build-out/sw/device/${sw_dir}/${sw_name}_${sw_build_device}.vmem \
+		${run_dir}/sw.vmem
 endif
 
 simulate: sw_build

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -11,6 +11,9 @@
   // Top level testbench name (sv module).
   tb: tb
 
+  // Default simulator used to sign off.
+  tool: vcs
+
   // Fusesoc core file used for building the file list.
   fusesoc_core: lowrisc:dv:chip_sim:0.1
 
@@ -28,7 +31,6 @@
   import_cfgs: [// Project wide common sim cfg file
                 "{proj_root}/hw/dv/data/common_sim_cfg.hjson",
                 // Common CIP test lists
-                "{proj_root}/hw/dv/data/tests/csr_tests.hjson",
                 "{proj_root}/hw/dv/data/tests/mem_tests.hjson",
                 "{proj_root}/hw/dv/data/tests/tl_access_tests.hjson"]
 
@@ -38,27 +40,32 @@
   // Default UVM test and seq class name.
   uvm_test: chip_base_test
   uvm_test_seq: chip_base_vseq
+  sw_build_device: fpga_nexysvideo
 
   // Additional option to RAL generation for top level.
   gen_ral_pkg_opts: ["--top"]
 
   // Add default build_opts.
-  build_opts: [// Enable the RISC-V Formal Interface (RVFI) for the ibex tracer.
-               "+define+RVFI=1",
-               // Use generic implementations of prim modules.
+  build_opts: [// Use generic implementations of prim modules.
                "+define+PRIM_DEFAULT_IMPL=prim_pkg::ImplGeneric"]
+
+  // Add default run opts.
+  run_opts: [// TODO: temp fix for C based tests.
+             "+disable_assert_final_checks"]
+
+  // Add build modes.
+  build_modes: [
+    {
+      name: en_ibex_tracer
+      build_opts: ["+define+RVFI=1"]
+    }
+  ]
 
   // Add run modes.
   run_modes: [
     {
       name: stub_cpu
       run_opts: ["+stub_cpu=1"]
-    }
-
-    {
-      // Append stub cpu mode to csr_tests_mode
-      name: csr_tests_mode
-      en_run_modes: ["stub_cpu"]
     }
 
     {
@@ -72,7 +79,62 @@
   tests: [
     {
       name: chip_sanity
-      uvm_test_seq: chip_sanity_vseq
+      sw_name: hello_world
+      sw_dir: examples/hello_world
+    }
+    {
+      name: chip_flash_test
+      sw_name: flash_test
+      sw_dir: tests/flash_ctrl
+      run_opts: ["+cpu_test_timeout_ns=15000000"]
+    }
+    {
+      name: chip_sha256_test
+      sw_name: sha256_test
+      sw_dir: tests/hmac
+      run_opts: ["+cpu_test_timeout_ns=4000000"]
+    }
+    {
+      name: chip_rv_timer_test
+      sw_name: rv_timer_test
+      sw_dir: tests/rv_timer
+      run_opts: ["+cpu_test_timeout_ns=40000000"]
+    }
+    {
+      name: coremark
+      sw_name: coremark
+      sw_dir: benchmarks/coremark
+      run_opts: ["+cpu_test_timeout_ns=20000000"]
+    }
+
+    // TODO: CSR suite of tests. Rather than reuse the common one, we are
+    // replicating here since we dont want CSR tests added to the sanity just yet.
+    {
+      name: chip_csr_hw_reset
+      uvm_test_seq: chip_common_vseq
+      run_opts: ["+en_scb=0", "+csr_hw_reset"]
+      en_run_modes: ["stub_cpu"]
+    }
+
+    {
+      name: chip_csr_rw
+      uvm_test_seq: chip_common_vseq
+      run_opts: ["+en_scb=0", "+csr_rw"]
+      en_run_modes: ["stub_cpu"]
+    }
+
+    {
+      name: chip_csr_bit_bash
+      uvm_test_seq: chip_common_vseq
+      run_opts: ["+en_scb=0", "+csr_bit_bash"]
+      en_run_modes: ["stub_cpu"]
+    }
+
+    {
+      name: chip_csr_aliasing
+      uvm_test_seq: chip_common_vseq
+      run_opts: ["+en_scb=0", "+csr_aliasing"]
+      en_run_modes: ["stub_cpu"]
     }
   ]
 

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -17,10 +17,10 @@ class chip_env_cfg extends dv_base_env_cfg #(.RAL_T(chip_reg_block));
   // sw msg monitor related
   sw_msg_monitor_vif  sw_msg_monitor_vif;
   // below values are constants, but made variables in case some test has different requirements
-  string              rom_image         = "sw_build/rom/rom.vmem";
-  string              rom_msg_data_file = "sw_build/rom/msg_data.txt";
-  string              sw_image          = "sw_build/sw/sw.vmem";
-  string              sw_msg_data_file  = "sw_build/sw/msg_data.txt";
+  string              rom_image         = "rom.vmem";
+  string              rom_msg_data_file = "msg_data.txt";
+  string              sw_image          = "sw.vmem";
+  string              sw_msg_data_file  = "msg_data.txt";
   bit [TL_AW-1:0]     sw_msg_addr       = 32'h1000fff4;
 
   // ext component cfgs

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -31,7 +31,7 @@ class chip_base_vseq extends dv_base_vseq #(
     // Drive strap signals at the start.
     cfg.srst_n_vif.drive(1'b1);
     cfg.jtag_spi_n_vif.drive(1'b1); // Select JTAG.
-    cfg.bootstrap_vif.drive(1'b1);
+    cfg.bootstrap_vif.drive(1'b0);
 
     // Now safe to do DUT init.
     dut_init();

--- a/hw/top_earlgrey/dv/top_earlgrey_sim_cfgs.hjson
+++ b/hw/top_earlgrey/dv/top_earlgrey_sim_cfgs.hjson
@@ -21,7 +21,6 @@
              "{proj_root}/hw/ip/uart/dv/uart_sim_cfg.hjson",
              "{proj_root}/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson",
              "{proj_root}/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_main_sim_cfg.hjson",
-             "{proj_root}/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_peri_sim_cfg.hjson"]
-             // TODO: #1467 chip DV is WIP - uncomment when sims are passing.
-             // "{proj_root}/hw/top_earlgrey/dv/chip_sim_cfg.hjson"]
+             "{proj_root}/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_peri_sim_cfg.hjson",
+             "{proj_root}/hw/top_earlgrey/dv/chip_sim_cfg.hjson"]
 }

--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -472,11 +472,14 @@ class RunTest(Deploy):
         self.fail_patterns = []
 
         self.mandatory_cmd_attrs = {
+            "proj_root": False,
             "uvm_test": False,
             "uvm_test_seq": False,
             "run_opts": False,
             "sw_dir": False,
             "sw_name": False,
+            "sw_build_device":False,
+            "sw_build_dir":False,
             "run_dir": False,
             "run_cmd": False,
             "run_opts": False

--- a/util/dvsim/Modes.py
+++ b/util/dvsim/Modes.py
@@ -272,6 +272,7 @@ class RunModes(Modes):
         self.en_run_modes = []
         self.sw_dir = ""
         self.sw_name = ""
+        self.sw_build_device = ""
 
         super().__init__(rdict)
         self.en_run_modes = list(set(self.en_run_modes))
@@ -295,7 +296,10 @@ class Tests(RunModes):
         "reseed": -1,
         "uvm_test": "",
         "uvm_test_seq": "",
-        "build_mode": ""
+        "build_mode": "",
+        "sw_dir": "",
+        "sw_name": "",
+        "sw_build_device": "",
     }
 
     def __init__(self, tdict):
@@ -366,13 +370,6 @@ class Tests(RunModes):
 
                     if global_val is not None and global_val != default_val:
                         setattr(test_obj, attr, global_val)
-
-                    else:
-                        # TODO: should we even enforce this?
-                        log.error(
-                            "Required value \"%s\" for the test \"%s\" is missing",
-                            attr, test_obj.name)
-                        sys, exit(1)
 
             # Unpack the build mode for this test
             build_mode_objs = Modes.find_and_merge_modes(test_obj,

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -116,7 +116,7 @@ class SimCfg(FlowCfg):
         # TODO: Find a way to set these in sim cfg instead
         ignored_wildcards = [
             "build_mode", "index", "test", "seed", "uvm_test", "uvm_test_seq",
-            "cov_db_dirs"
+            "cov_db_dirs", "sw_dir", "sw_name", "sw_build_device"
         ]
         self.__dict__ = find_and_substitute_wildcards(self.__dict__,
                                                       self.__dict__,


### PR DESCRIPTION
- Tool updates to enable sw build using meson wihin dvsim
- SW based tests now passing at chip level
- Added chip_sim_cfg.hjson to the top_earlgrey sim cfgs set so that chip
level DV tests get run as a part of nightly and CI

Signed-off-by: Srikrishna Iyer <sriyer@google.com>