### PR TITLE
[dvsim] Add i2c to the regressions

### DIFF
--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -53,6 +53,7 @@
 
   // List of regressions.
   regressions: [
+    // TODO: Add i2c_sanity test to the sanity suite once it is passing.
     // {
     //   name: sanity
     //   tests: ["i2c_sanity"]

--- a/hw/top_earlgrey/dv/top_earlgrey_sim_cfgs.hjson
+++ b/hw/top_earlgrey/dv/top_earlgrey_sim_cfgs.hjson
@@ -14,8 +14,7 @@
              "{proj_root}/hw/ip/alert_handler/dv/alert_handler_sim_cfg.hjson",
              "{proj_root}/hw/ip/gpio/dv/gpio_sim_cfg.hjson",
              "{proj_root}/hw/ip/hmac/dv/hmac_sim_cfg.hjson",
-             // TODO: #1467 I2C DV is WIP - uncomment when sims are passing.
-             // "{proj_root}/hw/ip/i2c/dv/i2c_sim_cfg.hjson",
+             "{proj_root}/hw/ip/i2c/dv/i2c_sim_cfg.hjson",
              "{proj_root}/hw/ip/rv_timer/dv/rv_timer_sim_cfg.hjson",
              "{proj_root}/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson",
              "{proj_root}/hw/ip/uart/dv/uart_sim_cfg.hjson",


### PR DESCRIPTION
- Added i2c to top_earlgrey sim cfgs list so that it gets run as a part
of sanity and nightly
- i2c will use Xcelium as the default simulator 

Signed-off-by: Srikrishna Iyer <sriyer@google.com>