### PR TITLE
[spi_device/dv] Remove setting spi clk on in csr test

### DIFF
--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_common_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_common_vseq.sv
@@ -10,12 +10,6 @@ class spi_device_common_vseq extends spi_device_base_vseq;
     num_trans inside {[1:3]};
   }
 
-  virtual task pre_start();
-    super.pre_start();
-    // keep sck on - needed for csr tests since some csrs are flopped on sck
-    cfg.m_spi_agent_cfg.sck_on = 1'b1;;
-  endtask
-
   virtual task body();
     run_common_vseq_wrapper(num_trans);
   endtask : body

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
@@ -19,10 +19,8 @@ class chip_common_vseq extends chip_base_vseq;
 
   virtual task pre_start();
     super.pre_start();
-    // keep sck on - needed for csr tests since some csrs are flopped on sck
     // Select SPI interface.
     cfg.jtag_spi_n_vif.drive(1'b0);
-    cfg.m_spi_agent_cfg.sck_on = 1'b1;;
   endtask
 
   virtual task body();


### PR DESCRIPTION
reset value is added in design reg #1669, no need to set spi clock always
on to avoid reading unknown reg value
Signed-off-by: Weicai Yang <weicai@google.com>