### PR TITLE
[i2c, rtl] Issue lowRISC#1662 fix and FIFO watermarks cleared after reset

### DIFF
--- a/hw/ip/i2c/rtl/i2c_core.sv
+++ b/hw/ip/i2c/rtl/i2c_core.sv
@@ -85,6 +85,11 @@ module  i2c_core (
   logic        rx_fifo_rready;
   logic [7:0]  rx_fifo_rdata;
 
+  logic        fmt_watermark_d;
+  logic        fmt_watermark_q;
+  logic        rx_watermark_d;
+  logic        rx_watermark_q;
+
   logic        host_idle;
   logic        target_idle;
 
@@ -146,25 +151,39 @@ module  i2c_core (
   assign i2c_fifo_rxilvl  = reg2hw.fifo_ctrl.rxilvl.q;
   assign i2c_fifo_fmtilvl = reg2hw.fifo_ctrl.fmtilvl.q;
 
+  always_ff @ (posedge clk_i or negedge rst_ni) begin : watermark_transition
+    if (!rst_ni) begin
+      fmt_watermark_q <= 1'b1; // true by default
+      rx_watermark_q  <= 1'b0; // false by default
+    end else begin
+      fmt_watermark_q <= fmt_watermark_d;
+      rx_watermark_q  <= rx_watermark_d;
+    end
+  end
+ 
   always_comb begin
     unique case(i2c_fifo_fmtilvl)
-      2'h0:    event_fmt_watermark = (fmt_fifo_depth <= 6'd1);
-      2'h1:    event_fmt_watermark = (fmt_fifo_depth <= 6'd4);
-      2'h2:    event_fmt_watermark = (fmt_fifo_depth <= 6'd8);
-      default: event_fmt_watermark = (fmt_fifo_depth <= 6'd16);
+      2'h0:    fmt_watermark_d = (fmt_fifo_depth <= 6'd1);
+      2'h1:    fmt_watermark_d = (fmt_fifo_depth <= 6'd4);
+      2'h2:    fmt_watermark_d = (fmt_fifo_depth <= 6'd8);
+      default: fmt_watermark_d = (fmt_fifo_depth <= 6'd16);
     endcase
   end
 
+  assign event_fmt_watermark = fmt_watermark_d & ~fmt_watermark_q;
+
   always_comb begin
     unique case(i2c_fifo_rxilvl)
-      3'h0:    event_rx_watermark = (rx_fifo_depth >= 6'd1);
-      3'h1:    event_rx_watermark = (rx_fifo_depth >= 6'd4);
-      3'h2:    event_rx_watermark = (rx_fifo_depth >= 6'd8);
-      3'h3:    event_rx_watermark = (rx_fifo_depth >= 6'd16);
-      3'h4:    event_rx_watermark = (rx_fifo_depth >= 6'd30);
-      default: event_rx_watermark = 1'b0;
+      3'h0:    rx_watermark_d = (rx_fifo_depth >= 6'd1);
+      3'h1:    rx_watermark_d = (rx_fifo_depth >= 6'd4);
+      3'h2:    rx_watermark_d = (rx_fifo_depth >= 6'd8);
+      3'h3:    rx_watermark_d = (rx_fifo_depth >= 6'd16);
+      3'h4:    rx_watermark_d = (rx_fifo_depth >= 6'd30);
+      default: rx_watermark_d = 1'b0;
     endcase
   end
+
+  assign event_rx_watermark = rx_watermark_d & ~rx_watermark_q;
 
   assign event_fmt_overflow = fmt_fifo_wvalid & ~fmt_fifo_wready;
   assign event_rx_overflow = rx_fifo_wvalid & ~rx_fifo_wready;

--- a/hw/ip/i2c/rtl/i2c_fsm.sv
+++ b/hw/ip/i2c/rtl/i2c_fsm.sv
@@ -183,7 +183,8 @@ module i2c_fsm (
         ClockLow, SetupBit, ClockPulse, HoldBit,
         ClockLowAck, SetupDevAck, ClockPulseAck, HoldDevAck,
         ReadClockLow, ReadSetupBit, ReadClockPulse, ReadHoldBit,
-        HostClockLowAck, HostSetupBitAck, HostClockPulseAck, HostHoldBitAck
+        HostClockLowAck, HostSetupBitAck, HostClockPulseAck, HostHoldBitAck,
+        PopFmtFifoCont
   } state_e;
 
   state_e state_q, state_d;
@@ -365,7 +366,13 @@ module i2c_fsm (
         scl_temp = 1'b1;
         if (sda_i == 0) event_sda_interference_o = 1'b1;
       end
-      // PopFmtFifo: populates fmt_fifo
+      // PopFmtFifoCont: populates fmt_fifo and continues
+      PopFmtFifoCont : begin
+        host_idle_o = 1'b0;
+        scl_temp = 1'b0;
+        fmt_fifo_rready_o = 1'b1;
+      end
+      // PopFmtFifo: populates fmt_fifo and goes to idle
       PopFmtFifo : begin
         host_idle_o = 1'b0;
         fmt_fifo_rready_o = 1'b1;
@@ -508,7 +515,7 @@ module i2c_fsm (
             load_tcount = 1'b1;
             tcount_sel = tSetupStop;
           end else begin
-            state_d = PopFmtFifo;
+            state_d = PopFmtFifoCont;
             load_tcount = 1'b1;
             tcount_sel = tNoDelay;
           end
@@ -589,7 +596,7 @@ module i2c_fsm (
               load_tcount = 1'b1;
               tcount_sel = tSetupStop;
             end else begin
-              state_d = PopFmtFifo;
+              state_d = PopFmtFifoCont;
               load_tcount = 1'b1;
               tcount_sel = tNoDelay;
             end
@@ -619,7 +626,33 @@ module i2c_fsm (
         end
       end
 
-      // PopFmtFifo: populates fmt_fifo
+      // PopFmtFifoCont: populates fmt_fifo and continues
+      PopFmtFifoCont : begin
+        if (!host_enable_i) begin
+          state_d = Idle;
+          load_tcount = 1'b1;
+          tcount_sel = tNoDelay;
+        end else if (!fmt_fifo_rvalid_i) begin
+          state_d = Idle;
+          load_tcount = 1'b1;
+          tcount_sel = tNoDelay;
+        end else if (fmt_flag_read_bytes_i) begin
+          byte_clr = 1'b1;
+          state_d = ReadClockLow;
+          load_tcount = 1'b1;
+          tcount_sel = tClockLow;
+        end else if (fmt_flag_start_before_i) begin
+          state_d = SetupStart;
+          load_tcount = 1'b1;
+          tcount_sel = tSetupStart;
+        end else begin
+          state_d = ClockLow;
+          load_tcount = 1'b1;
+          tcount_sel = tClockLow;
+        end
+      end
+
+      // PopFmtFifo: populates fmt_fifo and goes to idle
       PopFmtFifo : begin
         state_d = Idle;
         load_tcount = 1'b1;


### PR DESCRIPTION
Added PopFmtFifoCont state which goes to the next fmt_byte and flags while bypassing Idle.

Signed-off-by: Igor Kouznetsov <igor.kouznetsov@wdc.com>