### PR TITLE
Use a ot-specific patched version of fusesoc

### DIFF
--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Keep sorted.
-fusesoc
 gitpython
 hjson
 isort
@@ -28,3 +27,6 @@ git+https://github.com/olofk/ipyxact.git@master
 
 # Development version of edalize until all our changes are upstream
 git+https://github.com/lowRISC/edalize.git@ot
+
+# Development version with OT-specific changes
+git+https://github.com/lowRISC/fusesoc.git@ot


### PR DESCRIPTION
For recent work on OpenTitan we need modifications in fusesoc, which are
not yet merged upstream. Until that happens, switch to a OT-specific
branch of fuseosoc, as we did for edalize.