### PR TITLE
Correct a documentation error for the uart.

### DIFF
--- a/hw/ip/uart/doc/_index.md
+++ b/hw/ip/uart/doc/_index.md
@@ -398,9 +398,9 @@ int uart_rx_empty() {
           (0 << UART_FIFO_STATUS_RXLVL_LSB)) ? 1 : 0;
 }
 
-char uart_rcv_char() {
+int uart_rcv_char() {
   if(uart_rx_empty())
-    return 0xff;
+    return -1;
   return *UART_RDATA_REG;
 }
 ```


### PR DESCRIPTION
The documentation has an example function which should either
receive a character or return -1 if the receive fifo is empty.
The documentation uses the type 'char' and the value '0xff' to
represent -1, however the C standard does not define the
signedness of char.  Change to 'int', similar to the C standard
library's 'getc' and friends, to conform the documented
return value.

It is also unclear what the C definition of 'UART_RDATA_REG' is,
apart that it is a pointer itno the register space.  The sample
code in sw/device/lib/dif/dif_uart.c treats this register as a
32-bit register, so one assumes the sample code is meant to read
this as a uint32 (however if it were declared as pointer-to-char,
then a similar issue would exist with sign extension to the
return type of int).