### PR TITLE
Be more specific about the libusb dependency

### DIFF
--- a/apt-requirements.txt
+++ b/apt-requirements.txt
@@ -16,7 +16,7 @@ libelf-dev
 libftdi1-2
 libftdi1-dev
 libssl-dev
-libusb-1.0
+libusb-1.0-0
 make
 ninja-build
 pkgconf


### PR DESCRIPTION
The libusb package on Ubuntu/Debian is actually called libusb-1.0-0. The
currently used version `libusb-1.0` works as well when installing
through apt, but not when installed through other means which are more
strict.