### PR TITLE
[rv_plic] Import package only once

### DIFF
--- a/hw/ip/rv_plic/data/rv_plic.sv.tpl
+++ b/hw/ip/rv_plic/data/rv_plic.sv.tpl
@@ -35,8 +35,6 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   output logic [NumTarget-1:0] msip_o
 );
 
-  import rv_plic_reg_pkg::*;
-
   rv_plic_reg2hw_t reg2hw;
   rv_plic_hw2reg_t hw2reg;
 

--- a/hw/ip/rv_plic/rtl/rv_plic.sv
+++ b/hw/ip/rv_plic/rtl/rv_plic.sv
@@ -14,8 +14,6 @@
 // Verilog parameter
 //   MAX_PRIO: Maximum value of interrupt priority
 
-`include "prim_assert.sv"
-
 module rv_plic import rv_plic_reg_pkg::*; #(
   // derived parameter
   localparam int SRCW    = $clog2(NumSrc+1)
@@ -36,8 +34,6 @@ module rv_plic import rv_plic_reg_pkg::*; #(
 
   output logic [NumTarget-1:0] msip_o
 );
-
-  import rv_plic_reg_pkg::*;
 
   rv_plic_reg2hw_t reg2hw;
   rv_plic_hw2reg_t hw2reg;

--- a/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic.sv
+++ b/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic.sv
@@ -43,8 +43,6 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   output logic [NumTarget-1:0] msip_o
 );
 
-  import rv_plic_reg_pkg::*;
-
   rv_plic_reg2hw_t reg2hw;
   rv_plic_hw2reg_t hw2reg;
 


### PR DESCRIPTION
The rv_plic template imported the rv_plic_reg_pkg once in the header and
once in the body; remove the import in the body to avoid a NOTE from
VCS during regression runs.

Regenerated SystemVerilog files after changes to the template.

```
Parsing design file '../src/lowrisc_top_earlgrey_rv_plic_0.1/rtl/autogen/rv_plic.sv'

Note-[SV-LCM-PPWI] Package previously wildcard imported
../src/lowrisc_top_earlgrey_rv_plic_0.1/rtl/autogen/rv_plic.sv, 46
rv_plic
  Package 'rv_plic_reg_pkg' already wildcard imported.
  Ignoring rv_plic_reg_pkg::*
  See the SystemVerilog LRM(1800-2005), section 19.2.1.
```