### PR TITLE
[sw] Clean up most uses of uart_send_* into LOG_*

### DIFF
--- a/sw/device/boot_rom/bootstrap.c
+++ b/sw/device/boot_rom/bootstrap.c
@@ -5,12 +5,13 @@
 #include "sw/device/boot_rom/bootstrap.h"
 
 #include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/log.h"
 #include "sw/device/lib/common.h"
 #include "sw/device/lib/dif/dif_gpio.h"
 #include "sw/device/lib/flash_ctrl.h"
 #include "sw/device/lib/hw_sha256.h"
 #include "sw/device/lib/spi_device.h"
-#include "sw/device/lib/uart.h"  // TODO: Wrap uart in DEBUG macros.
+#include "sw/device/lib/uart.h"
 
 #define GPIO0_BASE_ADDR 0x40010000u
 #define GPIO_BOOTSTRAP_BIT_MASK 0x00020000u
@@ -70,17 +71,12 @@ static int bootstrap_flash(void) {
   for (;;) {
     if (spid_bytes_available() >= sizeof(f)) {
       spid_read_nb(&f, sizeof(f));
-      uart_send_str("Processing frame no: ");
-      uart_send_uint(f.hdr.frame_num, 32);
-      uart_send_str(" exp no: ");
-      uart_send_uint(expected_frame_no, 32);
-      uart_send_str("\r\n");
+      LOG_INFO("Processing frame #%d, expecting #%d", f.hdr.frame_num,
+               expected_frame_no);
 
       if (FRAME_NO(f.hdr.frame_num) == expected_frame_no) {
         if (check_frame_hash(&f)) {
-          uart_send_str("Error: detected hash mismatch on frame: ");
-          uart_send_uint(f.hdr.frame_num, 32);
-          uart_send_str("\r\n");
+          LOG_ERROR("Detected hash mismatch on frame #%d", f.hdr.frame_num);
           spid_send(ack, sizeof(ack));
           continue;
         }
@@ -110,7 +106,7 @@ static int bootstrap_flash(void) {
       }
     }
   }
-  uart_send_str("bootstrap: DONE!\r\n");
+  LOG_INFO("Bootstrap: DONE!");
   return 0;
 }
 
@@ -119,11 +115,11 @@ int bootstrap(void) {
     return 0;
   }
   // SPI device is only initialized in bootstrap mode.
-  uart_send_str("Bootstrap requested, initialising HW...\n");
+  LOG_INFO("Bootstrap requested, initialising HW...");
   spid_init();
   flash_init_block();
 
-  uart_send_str("HW initialisation completed, waiting for SPI input...\n");
+  LOG_INFO("HW initialisation completed, waiting for SPI input...");
   int rv = bootstrap_flash();
   if (rv) {
     rv |= erase_flash();

--- a/sw/device/examples/hello_usbdev/hello_usbdev.c
+++ b/sw/device/examples/hello_usbdev/hello_usbdev.c
@@ -7,9 +7,10 @@
 
 #include "sw/device/examples/demos.h"
 #include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/log.h"
+#include "sw/device/lib/base/print.h"
 #include "sw/device/lib/common.h"
 #include "sw/device/lib/dif/dif_gpio.h"
-#include "sw/device/lib/base/log.h"
 #include "sw/device/lib/pinmux.h"
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/spi_device.h"
@@ -82,6 +83,8 @@ static dif_gpio_t gpio;
 
 int main(int argc, char **argv) {
   uart_init(kUartBaudrate);
+  base_set_stdout(uart_stdout);
+
   pinmux_init();
   spid_init();
 

--- a/sw/device/lib/handler.c
+++ b/sw/device/lib/handler.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/handler.h"
 
+#include "sw/device/lib/base/log.h"
 #include "sw/device/lib/base/stdasm.h"
 #include "sw/device/lib/common.h"
 #include "sw/device/lib/uart.h"
@@ -15,21 +16,6 @@ static uint32_t get_mtval(void) {
   uint32_t mtval;
   asm volatile("csrr %0, mtval" : "=r"(mtval) : :);
   return mtval;
-}
-
-/**
- * Default Error Handling
- * @param error message supplied by caller
- * TODO - this will be soon by a real print formatting
- */
-static void print_exc_msg(const char *msg) {
-  const uint32_t mtval = get_mtval();
-  uart_send_str((char *)msg);
-  uart_send_str("MTVAL value is ");
-  uart_send_uint(mtval, 32);
-  uart_send_str("\n");
-  while (1) {
-  };
 }
 
 // Below functions are default weak exception handlers meant to be overriden
@@ -69,48 +55,41 @@ __attribute__((weak)) void handler_exception(void) {
 }
 
 __attribute__((weak)) void handler_irq_software(void) {
-  uart_send_str("Software IRQ triggered!\n");
+  LOG_INFO("Software IRQ triggered!");
   while (1) {
   }
 }
 
 __attribute__((weak)) void handler_irq_timer(void) {
-  uart_send_str("Timer IRQ triggered!\n");
+  LOG_INFO("Timer IRQ triggered!");
   while (1) {
   }
 }
 
 __attribute__((weak)) void handler_irq_external(void) {
-  uart_send_str("External IRQ triggered!\n");
+  LOG_INFO("External IRQ triggered!");
   while (1) {
   }
 }
 
 __attribute__((weak)) void handler_instr_acc_fault(void) {
-  const char fault_msg[] =
-      "Instruction access fault, mtval shows fault address\n";
-  print_exc_msg(fault_msg);
+  LOG_ERROR("Instruction access fault at address %p", get_mtval());
 }
 
 __attribute__((weak)) void handler_instr_ill_fault(void) {
-  const char fault_msg[] =
-      "Illegal Instruction fault, mtval shows instruction content\n";
-  print_exc_msg(fault_msg);
+  LOG_ERROR("Illegal instruction fault at address %p", get_mtval());
 }
 
 __attribute__((weak)) void handler_bkpt(void) {
-  const char exc_msg[] =
-      "Breakpoint triggerd, mtval shows the breakpoint address\n";
-  print_exc_msg(exc_msg);
+  LOG_INFO("Breakpoint triggered at address %p", get_mtval());
 }
 
 __attribute__((weak)) void handler_lsu_fault(void) {
-  const char exc_msg[] = "Load/Store fault, mtval shows the fault address\n";
-  print_exc_msg(exc_msg);
+  LOG_ERROR("Load/store unit fault at address %p", get_mtval());
 }
 
 __attribute__((weak)) void handler_ecall(void) {
-  uart_send_str("Environment call encountered\n");
+  LOG_INFO("Environment call encountered");
   while (1) {
   }
 }

--- a/sw/device/lib/meson.build
+++ b/sw/device/lib/meson.build
@@ -104,7 +104,7 @@ sw_lib_irq_handlers = declare_dependency(
     dependencies: [
       sw_lib_irq,
       sw_lib_runtime_ibex,
-      sw_lib_uart,
+      sw_lib_base_log,
     ],
   )
 )

--- a/sw/device/tests/aes/aes_test.c
+++ b/sw/device/tests/aes/aes_test.c
@@ -5,6 +5,8 @@
 #include "sw/device/lib/aes.h"
 
 #include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/log.h"
+#include "sw/device/lib/base/print.h"
 #include "sw/device/lib/common.h"
 #include "sw/device/lib/uart.h"
 
@@ -35,7 +37,8 @@ int main(int argc, char **argv) {
   uint8_t buffer[16];
 
   uart_init(kUartBaudrate);
-  uart_send_str("Running AES test\r\n");
+  base_set_stdout(uart_stdout);
+  LOG_INFO("Running AES test");
 
   // Setup AES config
   aes_cfg_t aes_cfg = {

--- a/sw/device/tests/aes/meson.build
+++ b/sw/device/tests/aes/meson.build
@@ -11,6 +11,8 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
       sw_lib_aes,
       sw_lib_uart,
       sw_lib_mem,
+      sw_lib_base_print,
+      sw_lib_base_log,
       riscv_crt,
       device_lib,
     ],

--- a/sw/device/tests/flash_ctrl/flash_test.c
+++ b/sw/device/tests/flash_ctrl/flash_test.c
@@ -3,8 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/log.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/base/print.h"
 #include "sw/device/lib/base/stdasm.h"
 #include "sw/device/lib/common.h"
 #include "sw/device/lib/dif/dif_gpio.h"
@@ -12,14 +14,13 @@
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/uart.h"
 
-#define CHECK(cond)                                 \
-  do {                                              \
-    if (!(cond)) {                                  \
-      uart_send_str("Assertion failed at line 0x"); \
-      uart_send_uint(__LINE__, 32);                 \
-      uart_send_str("\r\nFAIL!\r\n");               \
-      abort();                                      \
-    }                                               \
+#define CHECK(cond)                   \
+  do {                                \
+    if (!(cond)) {                    \
+      LOG_ERROR("Assertion failed!"); \
+      uart_send_str("FAIL!\r\n");     \
+      abort();                        \
+    }                                 \
   } while (false)
 
 #define CHECK_ARRAYS_EQ(xs, ys, len) \
@@ -143,6 +144,8 @@ static void test_memory_protection(void) {
 
 int main(int argc, char **argv) {
   uart_init(kUartBaudrate);
+  base_set_stdout(uart_stdout);
+
   flash_init_block();
 
   flash_cfg_bank_erase(FLASH_BANK_0, /*erase_en=*/true);

--- a/sw/device/tests/flash_ctrl/meson.build
+++ b/sw/device/tests/flash_ctrl/meson.build
@@ -13,6 +13,8 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
       sw_lib_dif_gpio,
       sw_lib_irq,
       sw_lib_uart,
+      sw_lib_base_print,
+      sw_lib_base_log,
       riscv_crt,
       sw_lib_irq_handlers,
       device_lib,

--- a/sw/device/tests/hmac/meson.build
+++ b/sw/device/tests/hmac/meson.build
@@ -12,6 +12,8 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
       sw_lib_hmac,
       sw_lib_irq,
       sw_lib_uart,
+      sw_lib_base_print,
+      sw_lib_base_log,
       riscv_crt,
       sw_lib_irq_handlers,
       device_lib,

--- a/sw/device/tests/hmac/sha256_test.c
+++ b/sw/device/tests/hmac/sha256_test.c
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/log.h"
+#include "sw/device/lib/base/print.h"
 #include "sw/device/lib/common.h"
 #include "sw/device/lib/flash_ctrl.h"
 #include "sw/device/lib/hw_sha256.h"
@@ -21,7 +23,8 @@ static const uint32_t kExpectedDigest[8] = {0xdc96c23d, 0xaf36e268, 0xcb68ff71,
 
 int main(int argc, char **argv) {
   uart_init(kUartBaudrate);
-  uart_send_str("Running SHA256 test\r\n");
+  base_set_stdout(uart_stdout);
+  LOG_INFO("Running SHA256 test");
 
   uint32_t digest[8];
   hw_SHA256_hash(kData, kDataLen, (uint8_t *)digest);

--- a/sw/device/tests/rv_timer/meson.build
+++ b/sw/device/tests/rv_timer/meson.build
@@ -13,6 +13,8 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
       sw_lib_uart,
       sw_lib_dif_gpio,
       sw_lib_pinmux,
+      sw_lib_base_print,
+      sw_lib_base_log,
       riscv_crt,
       sw_lib_irq_handlers,
       device_lib,

--- a/sw/device/tests/rv_timer/rv_timer_test.c
+++ b/sw/device/tests/rv_timer/rv_timer_test.c
@@ -5,6 +5,8 @@
 #include "sw/device/lib/rv_timer.h"
 
 #include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/log.h"
+#include "sw/device/lib/base/print.h"
 #include "sw/device/lib/common.h"
 #include "sw/device/lib/dif/dif_gpio.h"
 #include "sw/device/lib/irq.h"
@@ -21,6 +23,7 @@ int main(int argc, char **argv) {
   const uint64_t cmp = 0x000000000000000F;
 
   uart_init(kUartBaudrate);
+  base_set_stdout(uart_stdout);
 
   pinmux_init();
   // Enable GPIO: 0-7 and 16 is input, 8-15 is output
@@ -51,7 +54,7 @@ int main(int argc, char **argv) {
 
 // Override weak default function
 void handler_irq_timer(void) {
-  uart_send_str("In Interrupt handler!\r\n");
+  LOG_INFO("In Interrupt handler!");
   rv_timer_ctrl(hart, false);
   rv_timer_clr_all_intrs();
   intr_handling_success = 1;


### PR DESCRIPTION
Some uses remain which don't quite cleanly fit into the purpose that the LOG macros serve, mostly in the PASS/FAIL domain.