### PR TITLE
[prim_present/prince] Update PRINCE keyschedule and update docs

### DIFF
--- a/hw/ip/prim/doc/prim_present.md
+++ b/hw/ip/prim/doc/prim_present.md
@@ -66,5 +66,5 @@ for (int i=1; i < 32; i++) {
 data_o = state ^ round_keys[32];
 ```
 
-The reduced 32bit block-size variant implemented is non-standard and should only be used for scrambling purposes, since it is not secure.
+The reduced 32bit block-size variant implemented is non-standard and should only be used for scrambling purposes, since it **is not secure**.
 It leverages the same crypto primitives and key derivation functions as the 64bit variant, with the difference that the permutation layer is formulated for 32 instead of 64 elements.

--- a/hw/ip/prim/doc/prim_prince.md
+++ b/hw/ip/prim/doc/prim_prince.md
@@ -16,11 +16,12 @@ This [paper](https://csrc.nist.gov/csrc/media/events/lightweight-cryptography-wo
 
 ## Parameters
 
-Name         | type   | Description
--------------|--------|----------------------------------------------------------
-DataWidth    | int    | Block size, can be 32 or 64.
-KeyWidth     | int    | Key size, can be 64 for block size 32, or 128 for block size 64
-NumRounds    | int    | Half the number of the reflected PRINCE rounds. Can range from 1 to 5. The effective number of non-linear layers is 2 + 2 * NumRounds.
+Name           | type   | Description
+---------------|--------|----------------------------------------------------------
+DataWidth      | int    | Block size, can be 32 or 64.
+KeyWidth       | int    | Key size, can be 64 for block size 32, or 128 for block size 64
+NumRounds      | int    | Half the number of the reflected PRINCE rounds. Can range from 1 to 5. The effective number of non-linear layers is 2 + 2 * NumRounds.
+UseOldKeySched | bit    | If set to 1, fall back to the original keyschedule (not recommended). Defaults to 0.
 
 ## Signal Interfaces
 
@@ -34,18 +35,18 @@ data_o       | output | Output of the ciphertext
 # Theory of Operations
 
 ```
-             /---------------\
-dec_i        |               |
------------->|    PRINCE     |
-key_i        |               |
-=====/======>|   DataWidth   |
- [KeyWidth]  |   KeyWidth    |
-             |   NumRounds   |
-data_i       |               |  data_o
-=====/======>|               |=====/=======>
- [DataWidth] |               |  [DataWidth]
-             |               |
-             \---------------/
+             /----------------\
+dec_i        |                |
+------------>|     PRINCE     |
+key_i        |                |
+=====/======>|    DataWidth   |
+ [KeyWidth]  |    KeyWidth    |
+             |    NumRounds   |
+data_i       | UseOldKeySched |  data_o
+=====/======>|                |=====/=======>
+ [DataWidth] |                |  [DataWidth]
+             |                |
+             \----------------/
 ```
 
 The PRINCE module is fully unrolled and combinational, meaning that it does not have any clock, reset or handshaking inputs.
@@ -75,7 +76,7 @@ for (int i=1; i < 6; i++) {
       state = mult_layer(state);
       state = shiftrows_layer(state);
       state ^= ROUND_CONSTANT[i]
-      state ^= k1;
+      data_state ^= (k & 0x1) ? k0 : k1;
 }
 
 // middle part
@@ -85,7 +86,7 @@ state = sbox4_inverse_layer(state);
 
 // reverse pass
 for (int i=6; i < 11; i++) {
-      state ^= k1;
+      data_state ^= (k & 0x1) ? k1 : k0;
       state ^= ROUND_CONSTANT[i]
       state = shiftrows_inverse_layer(state);
       state = mult_layer(state);
@@ -97,10 +98,15 @@ state ^= k1;
 
 data_o = state ^ k0_prime;
 ```
+The multiplicative layer is an involution, meaning that it is its own inverse and it can hence be used in the reverse pass without inversion.
 
-Note that the multiplicative layer is an involution, meaning that it is its own inverse and it can hence be used in the reverse pass without inversion.
+It should be noted that the actual choice of the `ALPHA_CONSTANT` used in the key tweak can have security impacts as detailed in [this paper](https://eprint.iacr.org/2015/372.pdf).
+The constant chosen by the designers of PRINCE does not have these issues - but proper care should be taken if it is decided to modify this constant.
+Also, [this paper](https://eprint.iacr.org/2014/656.pdf) proposes an improved key schedule to fend against attacks on the FX structure of PRINCE (see Appendix C), and this improvement has been incorporated in this design.
+The improvement involves alternating the keys `k0` and `k1` between rounds, as opposed to always using the same key `k1`.
 
-The reduced 32bit variant mentioned above and all reduced round variants are non-standard and must only be used for scrambling purposes, since they are not secure.
+
+The reduced 32bit variant mentioned above and all reduced round variants are non-standard and must only be used for scrambling purposes, since they **are not secure**.
 The 32bit variant leverages the same crypto primitives and key derivation functions as the 64bit variant, with the difference that the multiplication matrix is only comprised of the first two block diagonal submatrices (^M0 and ^M1 in the paper), and the shiftrows operation does not operate on nibbles but pairs of 2 bits instead.
 
 


### PR DESCRIPTION
This incorporates documentation updates suggested by @cdgori in #1651, and reworks the keyschedule of PRINCE according to Appendix C in https://eprint.iacr.org/2014/656.pdf in order to fend against a specific type of attacks on the FX construction of this primitive.

Signed-off-by: Michael Schaffner <msf@opentitan.org>