### PR TITLE
[dv] Chip CSR tests with automated exclusions

### DIFF
--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -87,7 +87,9 @@
       hwre:     "true",
       fields: [
         { bits: "31:0", name: "data_out", desc: "Output Data" }
-      ],
+      ]
+      tags: [// Updated by the hw. Exclude from write-checks.
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
       }
     },
 ##############################################################################
@@ -130,6 +132,8 @@
         '''
       }
     ]
+    tags: [// Updated by hw. Exclude from write-checks.
+           "excl:CsrNonInitTests:CsrExclWriteCheck"]
   },
   { name: "TRIGGER",
     desc: '''
@@ -166,6 +170,8 @@
         '''
       }
     ]
+    tags: [// Updated by hw. Exclude from write-checks.
+           "excl:CsrNonInitTests:CsrExclWriteCheck"]
   },
   { name: "STATUS",
     desc: "Status Register",
@@ -203,6 +209,8 @@
         '''
       }
     ]
+    tags: [// Updated by hw. Exclude from write-checks.
+           "excl:CsrNonInitTests:CsrExclWriteCheck"]
   },
   ],
 }

--- a/hw/ip/aes/dv/env/seq_lib/aes_common_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_common_vseq.sv
@@ -14,20 +14,4 @@ class aes_common_vseq extends aes_base_vseq;
     run_common_vseq_wrapper(num_trans);
   endtask : body
 
-  // function to add csr exclusions of the given type using the csr_excl_item item
-  virtual function void add_csr_exclusions(string           csr_test_type,
-                                           csr_excl_item    csr_excl,
-                                           string           scope = "ral");
-
-    // write exclusions - these should not apply to hw_reset test
-    if (csr_test_type != "hw_reset") begin
-      csr_excl.add_excl({scope, ".", "trigger"      }, CsrExclWriteCheck);
-      csr_excl.add_excl({scope, ".", "ctrl"         }, CsrExclWriteCheck);
-
-      // exclude dataout/status because they change once data in has been written
-      csr_excl.add_excl({scope, ".", "status"       }, CsrExclWriteCheck);
-      csr_excl.add_excl({scope, ".", "data_out*"    }, CsrExclWriteCheck);
-    end
-
-  endfunction
 endclass

--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson
@@ -53,6 +53,8 @@
             CONTROL register and ADDR have been programmed
             '''
           resval: "0"
+          tags: [// Dont enable flash - it causes several side-effects.
+                 "excl:CsrAllTests:CsrExclWrite"],
         },
         { bits: "5:4",
           name: "OP",

--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -100,6 +100,8 @@
           resval: "1"
         }
       ]
+      tags: [// Updated by the hw. Exclude from write-checks.
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
     }
     { name: "RDATA"
       desc: "I2C read data"
@@ -110,6 +112,8 @@
       fields: [
         {bits: "7:0"}
       ]
+      tags: [// Updated by the hw. Exclude from init and write-checks.
+             "excl:CsrAllTests:CsrExclCheck"]
     }
     { name: "FDATA"
       desc: "I2C Format Data"
@@ -228,6 +232,8 @@
           desc: "Current fill level of RX fifo"
         }
       ]
+      tags: [// Updated by the hw. Exclude from write-checks.
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
     }
     { name: "OVRD"
       desc: "I2C override control register"
@@ -267,6 +273,8 @@
                 '''
         }
       ]
+      tags: [// Affected by IO pins - exclude from init and write checks.
+             "excl:CsrAllTests:CsrExclCheck"]
     }
 
     { name: "TIMING0"

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_common_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_common_vseq.sv
@@ -22,21 +22,6 @@ class i2c_common_vseq extends i2c_base_vseq;
     run_common_vseq_wrapper(num_trans); // inherit from cip_base_vseq.sv
   endtask : body
 
-  // function to add csr exclusions of the given type using the csr_excl_item item
-  virtual function void add_csr_exclusions(string           csr_test_type,
-                                           csr_excl_item    csr_excl,
-                                           string           scope = "ral");
-
-    // intr_state is affected by writes to other csrs
-    csr_excl.add_excl({scope, ".", "intr_state"}, CsrExclCheck);
-    // RO registers - exclude init and write-read check
-    csr_excl.add_excl({scope, ".", "status"}, CsrExclWriteCheck);
-    csr_excl.add_excl({scope, ".", "fifo_status"}, CsrExclWriteCheck);
-    // RO registers - exclude init and write-read check
-    csr_excl.add_excl({scope, ".", "val"}, CsrExclCheck);
-    csr_excl.add_excl({scope, ".", "rdata"}, CsrExclCheck);
-  endfunction : add_csr_exclusions
-
   task post_start();
     `uvm_info(`gfn, "stop simulation", UVM_DEBUG)
   endtask : post_start

--- a/hw/ip/pinmux/data/pinmux.hjson
+++ b/hw/ip/pinmux/data/pinmux.hjson
@@ -66,7 +66,9 @@
                       0: tie constantly to zero, 1: tie constantly to 1.
                       >=2: MIO pads (i.e., add 2 to the native MIO pad index).
                       '''
-                      resval: 0
+                      resval: 0,
+                      tags: [// Random writes to this field may result in array index going OOB.
+                             "excl:CsrNonInitTests:CsrExclWriteCheck"]
                     }
                   ]
                 }
@@ -86,7 +88,9 @@
                       0: tie constantly to zero, 1: tie constantly to 1. 2: high-Z
                       >=3: peripheral outputs (i.e., add 3 to the native peripheral pad index).
                       '''
-                      resval: 2
+                      resval: 2,
+                      tags: [// Random writes to this field may result in array index going OOB.
+                             "excl:CsrNonInitTests:CsrExclWriteCheck"]
                     }
                   ]
                 }

--- a/hw/ip/pinmux/data/pinmux.hjson.tpl
+++ b/hw/ip/pinmux/data/pinmux.hjson.tpl
@@ -67,7 +67,9 @@
                       0: tie constantly to zero, 1: tie constantly to 1.
                       >=2: MIO pads (i.e., add 2 to the native MIO pad index).
                       '''
-                      resval: 0
+                      resval: 0,
+                      tags: [// Random writes to this field may result in array index going OOB.
+                             "excl:CsrNonInitTests:CsrExclWriteCheck"]
                     }
                   ]
                 }
@@ -87,7 +89,9 @@
                       0: tie constantly to zero, 1: tie constantly to 1. 2: high-Z
                       >=3: peripheral outputs (i.e., add 3 to the native peripheral pad index).
                       '''
-                      resval: 2
+                      resval: 2,
+                      tags: [// Random writes to this field may result in array index going OOB.
+                             "excl:CsrNonInitTests:CsrExclWriteCheck"]
                     }
                   ]
                 }

--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -157,6 +157,8 @@
             but no clock from the host is given, the data stuck at this async fifo waiting
             host toggles SCK. This value represents the number of bytes.
             '''
+          tags: [// HW modifies async_fifo_level.txlvl when txf_ptr.wptr is updated.
+                 "excl:CsrNonInitTests:CsrExclWriteCheck"]
         },
         { bits: "7:0",
           name: "rxlvl",
@@ -181,6 +183,8 @@
         { bits: "4", name: "abort_done", desc: "Abort process is completed", resval: "1" },
         { bits: "5", name: "csb",        desc: "Direct input of CSb signal", resval: "1" },
       ]
+      tags: [// Status reads back unexpected values due to writes to other CSRs.
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
     { name: "RXF_PTR",
       desc: "Receiver FIFO (SRAM) pointers",
@@ -214,6 +218,8 @@
           swaccess: "ro",
           hwaccess: "hwo",
           resval: "0",
+          tags: [// HW modifies rptr for the txfifo in unexpected way.
+                 "excl:CsrNonInitTests:CsrExclWriteCheck"]
         },
         { bits: "31:16",
           name: "WPTR",

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_common_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_common_vseq.sv
@@ -14,27 +14,4 @@ class spi_device_common_vseq extends spi_device_base_vseq;
     run_common_vseq_wrapper(num_trans);
   endtask : body
 
-  // function to add csr exclusions of the given type using the csr_excl_item item
-  virtual function void add_csr_exclusions(string           csr_test_type,
-                                           csr_excl_item    csr_excl,
-                                           string           scope = "ral");
-    // write exclusions - these should not apply to hw_reset test
-    if (csr_test_type != "hw_reset") begin
-      // status reads back unexpected values due to writes to other csrs
-      csr_excl.add_excl({scope, ".", "status"}, CsrExclWriteCheck);
-
-      // intr_test csr is WO - read behavior undefined and mismatches with uvm_reg_field
-      csr_excl.add_excl({scope, ".", "intr_test"}, CsrExclWriteCheck);
-
-      // intr_state reads back unexpected values due to writes to other csrs
-      csr_excl.add_excl({scope, ".", "intr_state"}, CsrExclWriteCheck);
-
-      // hw modifies rptr for the txfifo in unexpected way
-      csr_excl.add_excl({scope, ".", "txf_ptr.rptr"}, CsrExclWriteCheck);
-
-      // hw modifies async_fifo_level.txlvl when txf_ptr.wptr is updated
-      csr_excl.add_excl({scope, ".", "async_fifo_level.txlvl"}, CsrExclWriteCheck);
-    end
-  endfunction
-
 endclass

--- a/hw/ip/uart/data/uart.hjson
+++ b/hw/ip/uart/data/uart.hjson
@@ -154,22 +154,22 @@
       hwaccess: "hrw",
       hwext: "true",
       hwre: "true",
-      tags: [// read wdata when fifo is empty, dut may return unknown data
-             "excl:CsrAllTests:CsrExclCheck"],
       fields: [
         { bits: "7:0" }
       ]
+      tags: [// read wdata when fifo is empty, dut may return unknown data
+             "excl:CsrAllTests:CsrExclCheck"]
     }
     { name: "WDATA",
       desc: "UART write data",
       swaccess: "wo",
       hwaccess: "hro",
       hwqe: "true",
-      tags: [// don't write to wdata - it affects several other csrs
-             "excl:CsrNonInitTests:CsrExclWrite"],
       fields: [
         { bits: "7:0" }
       ]
+      tags: [// don't write to wdata - it affects several other csrs
+             "excl:CsrNonInitTests:CsrExclWrite"]
     }
     { name: "FIFO_CTRL",
       desc: "UART FIFO control register",
@@ -267,7 +267,8 @@
         { bits: "0",
           name: "TXEN",
           desc: "Enable TX pin override control",
-          tags: [// writes to ovrd.txen causes tx output to be forced to ovrd.txval causing protocol violation
+          tags: [// writes to ovrd.txen causes tx output to be forced to ovrd.txval
+                 // causing protocol violation
                  "excl:CsrAllTests:CsrExclWrite"]
         }
         { bits: "1",

--- a/hw/ip/usbdev/data/usbdev.hjson
+++ b/hw/ip/usbdev/data/usbdev.hjson
@@ -124,6 +124,8 @@
           desc: '''
                Set to enable the USB interface and assert the FS pullup.
           '''
+          tags: [// Prevent usb from being enabled to avoid other unforeseen side effects.
+                 "excl:CsrNonInitTests:CsrExclWrite"]
         }
         {
           bits: "22:16",
@@ -135,6 +137,8 @@
 
                 This will be zeroed by the hardware when the link resets.
           '''
+          tags: [// This field is reset to 0 if usb is not enabled.
+                 "excl:CsrNonInitTests:CsrExclWriteCheck"]
         }
       ]
     }
@@ -247,6 +251,8 @@
                 '''
         }
       ]
+      tags: [// Writing this CSR affects the ral.usbstat.av_depth field.
+             "excl:CsrNonInitTests:CsrExclWrite"]
     }
     { name: "rxfifo",
       desc: "Received packet FIFO",
@@ -515,6 +521,8 @@
           bits: "3",
           name: "override_pwr_sense_en",
           desc: "Override the USB Power sense value with override_pwr_sense_val."
+          tags: [// Overriding pwr sense will cause the usbdev to think the link is powered up.
+                 "excl:CsrNonInitTests:CsrExclWrite"]
         }
         {
           bits: "4",

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_common_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_common_vseq.sv
@@ -20,32 +20,4 @@ class usbdev_common_vseq extends usbdev_base_vseq;
     run_common_vseq_wrapper(num_trans);
   endtask : body
 
-  // function to add csr exclusions of the given type using the csr_excl_item item
-  virtual function void add_csr_exclusions(string           csr_test_type,
-                                           csr_excl_item    csr_excl,
-                                           string           scope = "ral");
-
-    // Link reset occurs every 3 us. There doesn't seem to be a way to turn that off.
-    // It results in the modification of some CSRS which makes the prediction hard.
-    // Those are being excluded from checks below.
-
-    // write exclusions - these should not apply to hw_reset test
-    if (csr_test_type != "hw_reset") begin
-      // intr_test CSR affects the intr_state csr. It is already tested in intr_test.
-      csr_excl.add_excl({scope, ".", "intr_test"}, CsrExclWrite);
-
-      // Writing ral.avbuffer affects the ral.usbstat.av_depth field.
-      csr_excl.add_excl({scope, ".", "avbuffer"}, CsrExclWrite);
-
-      // ral.usbctrl.device_address is reset to 0 if usb is not enabled.
-      csr_excl.add_excl({scope, ".", "usbctrl.device_address"}, CsrExclWriteCheck);
-
-      // Prevent usb from being enabled to avoid other unforeseen side effects.
-      csr_excl.add_excl({scope, ".", "usbctrl.enable"}, CsrExclWrite);
-
-      // Overriding pwr sense will cause the usbdev to think the link is powered up
-      csr_excl.add_excl({scope, ".", "phy_config.override_pwr_sense_en"}, CsrExclWrite);
-    end
-  endfunction
-
 endclass

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -144,5 +144,12 @@
       name: sanity
       tests: ["chip_sanity"]
     }
+    {
+      name: sw_access
+      tests: ["chip_csr_hw_reset",
+              "chip_csr_rw",
+              "chip_csr_bit_bash",
+              "chip_csr_aliasing"]
+    }
   ]
 }

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -58,10 +58,6 @@ class chip_base_vseq extends dv_base_vseq #(
   virtual task dut_init(string reset_kind = "HARD");
     // Set default frequencies.
     cfg.usb_clk_rst_vif.set_freq_mhz(dv_utils_pkg::ClkFreq48Mhz);
-    // Set 'default' UART baud rate of 2Mbps - this is also programmed by the C test.
-    // TODO: Fixing this for now - need to find a way to pass this on to the SW test.
-    cfg.m_uart_agent_cfg.set_parity(1'b0, 1'b0);
-    cfg.m_uart_agent_cfg.set_baud_rate(BaudRate2Mbps);
     // Initialize gpio pin default states
     cfg.gpio_vif.set_pulldown_en({chip_env_pkg::NUM_GPIOS{1'b1}});
     // Bring the chip out of reset.
@@ -71,6 +67,12 @@ class chip_base_vseq extends dv_base_vseq #(
   // routine to backdoor load cpu test hex image and bring the cpu out of reset (if required)
   // TODO: for future implementation
   virtual task cpu_init();
+    // Set 'default' UART baud rate of 2Mbps - this is also programmed by the C test.
+    // TODO: Fixing this for now - need to find a way to pass this on to the SW test.
+    cfg.m_uart_agent_cfg.set_parity(1'b0, 1'b0);
+    cfg.m_uart_agent_cfg.set_baud_rate(BaudRate2Mbps);
+
+    // Backdoor load memories.
     cfg.mem_bkdr_vifs[Rom].load_mem_from_file(cfg.rom_image);
     cfg.mem_bkdr_vifs[FlashBank0].set_mem();
     cfg.mem_bkdr_vifs[FlashBank1].set_mem();

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
@@ -27,31 +27,6 @@ class chip_common_vseq extends chip_base_vseq;
     run_csr_vseq_wrapper(num_trans);
   endtask : body
 
-
-  // function to add csr exclusions of the given type using the csr_excl_item item
-  virtual function void add_csr_exclusions(string           csr_test_type,
-                                           csr_excl_item    csr_excl,
-                                           string           scope = "ral");
-
-    // reuse exclusions from IP benches
-    `add_ip_csr_exclusions(gpio)
-    `add_ip_csr_exclusions(hmac)
-    `add_ip_csr_exclusions(rv_timer)
-    `add_ip_csr_exclusions(spi_device)
-    `add_ip_csr_exclusions(uart)
-    `add_ip_csr_exclusions(usbdev)
-
-    // The following exclusions are added at the chip level since no IP level bench
-    // exist for these.
-
-    // Random writes to these pinmux CSRs may result in array index going OOB and
-    // assertion errors thrown.
-    csr_excl.add_excl({scope, ".", "pinmux.periph_insel*"}, CsrExclWrite);
-    csr_excl.add_excl({scope, ".", "pinmux.mio_outsel*"}, CsrExclWrite);
-    csr_excl.add_excl({scope, ".", "flash_ctrl.control.start"}, CsrExclWrite);
-
-  endfunction
-
 endclass
 
 `undef add_ip_csr_exclusions

--- a/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
+++ b/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
@@ -75,7 +75,9 @@
                       0: tie constantly to zero, 1: tie constantly to 1.
                       >=2: MIO pads (i.e., add 2 to the native MIO pad index).
                       '''
-                      resval: 0
+                      resval: 0,
+                      tags: [// Random writes to this field may result in array index going OOB.
+                             "excl:CsrNonInitTests:CsrExclWriteCheck"]
                     }
                   ]
                 }
@@ -95,7 +97,9 @@
                       0: tie constantly to zero, 1: tie constantly to 1. 2: high-Z
                       >=3: peripheral outputs (i.e., add 3 to the native peripheral pad index).
                       '''
-                      resval: 2
+                      resval: 2,
+                      tags: [// Random writes to this field may result in array index going OOB.
+                             "excl:CsrNonInitTests:CsrExclWriteCheck"]
                     }
                   ]
                 }

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -267,10 +267,11 @@ class SimCfg(FlowCfg):
                 overlapping_tests = get_overlapping_tests(
                     regression.tests, run_list_names)
                 if overlapping_tests != []:
-                    log.error("Regression \"%s\" added for run contains tests that overlap with " + \
-                              "other regressions added. This can result in conflicting " + \
-                              "build / run_opts to be set causing unexpected results.",
-                              regression.name)
+                    log.error(
+                        "Regression \"%s\" added for run contains tests that overlap with "
+                        "other regressions added. This can result in conflicting "
+                        "build / run_opts to be set causing unexpected results.",
+                        regression.name)
                     sys.exit(1)
 
                 self.run_list.extend(regression.tests)
@@ -295,13 +296,12 @@ class SimCfg(FlowCfg):
         # Merge the global build and run opts
         Tests.merge_global_opts(self.run_list, self.build_opts, self.run_opts)
 
-        # Check if all items has been processed
+        # Check if all items have been processed
         if items_list != []:
             log.error(
-                "The items %s added for run were not found in \n%s!\n \
-                Use the --list switch to see a list of available \
-                tests / regressions.", items_list, self.flow_cfg_file)
-            sys.exit(1)
+                "The items %s added for run were not found in \n%s!\n "
+                "Use the --list switch to see a list of available "
+                "tests / regressions.", items_list, self.flow_cfg_file)
 
         # Process reseed override and create the build_list
         build_list_names = []
@@ -496,16 +496,17 @@ class SimCfg(FlowCfg):
             results_str += "\n"
             self.results_summary = self.testplan.results_summary
 
-        # Append coverage results of coverage was enabled.
-        if self.cov and self.cov_report_deploy.status == "P":
-            results_str += "\n## Coverage Results\n"
-            results_str += "\n### [Coverage Dashboard](cov_report/dashboard.html)\n\n"
-            results_str += self.cov_report_deploy.cov_results
-            self.results_summary["Coverage"] = self.cov_report_deploy.cov_total
+            # Append coverage results of coverage was enabled.
+            if self.cov and self.cov_report_deploy.status == "P":
+                results_str += "\n## Coverage Results\n"
+                results_str += "\n### [Coverage Dashboard](cov_report/dashboard.html)\n\n"
+                results_str += self.cov_report_deploy.cov_results
+                self.results_summary[
+                    "Coverage"] = self.cov_report_deploy.cov_total
 
-        # append link of detail result to block name
-        self.results_summary["Name"] = self._get_results_page_link(
-            self.results_summary["Name"])
+            # append link of detail result to block name
+            self.results_summary["Name"] = self._get_results_page_link(
+                self.results_summary["Name"])
 
         # Append failures for triage
         self.results_md = results_str + fail_msgs
@@ -532,7 +533,7 @@ class SimCfg(FlowCfg):
             row = []
             for title in item.results_summary:
                 row.append(item.results_summary[title])
-            table.append(row)
+            if len(row) == len(header): table.append(row)
         self.results_summary_md = "## " + self.results_title + " (Summary)\n"
         self.results_summary_md += "### " + self.timestamp_long + "\n"
         self.results_summary_md += tabulate(table,


### PR DESCRIPTION
- Updated hjson files to add exclusion tags for I2C and AES IP blocks.
- Added exclusions for flash ctrl, pinmux and alert handler.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>