### PR TITLE
Revert "[i2c, dv] Update i2c.hjson to support automation for csr excl"

### DIFF
--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -70,8 +70,6 @@
       swaccess: "ro"
       hwaccess: "hwo"
       hwext:    "true"
-      tags: [// ro registers - exclude init and write-read check
-             "excl:CsrAllTests:CsrExclWriteCheck"]
       fields: [
         { bits: "0"
           name: "FMTFULL"
@@ -109,8 +107,6 @@
       hwaccess: "hrw"
       hwext: "true"
       hwre: "true"
-      tags: [// ro registers - exclude init and write-read check
-             "excl:CsrAllTests:CsrExclCheck"]
       fields: [
         {bits: "7:0"}
       ]
@@ -222,8 +218,6 @@
       swaccess: "ro"
       hwaccess: "hwo"
       hwext: "true"
-      tags: [// ro registers - exclude init and write-read check
-             "excl:CsrAllTests:CsrExclWriteCheck"]
       fields: [
         { bits: "5:0"
           name: "FMTLVL"
@@ -259,8 +253,6 @@
       swaccess: "ro"
       hwaccess: "hwo"
       hwext:    "true"
-      tags: [// ro registers - exclude init and write-read check
-             "excl:CsrAllTests:CsrExclCheck"]
       fields: [
         { bits: "15:0"
           name: "SCL_RX"

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_common_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_common_vseq.sv
@@ -22,6 +22,21 @@ class i2c_common_vseq extends i2c_base_vseq;
     run_common_vseq_wrapper(num_trans); // inherit from cip_base_vseq.sv
   endtask : body
 
+  // function to add csr exclusions of the given type using the csr_excl_item item
+  virtual function void add_csr_exclusions(string           csr_test_type,
+                                           csr_excl_item    csr_excl,
+                                           string           scope = "ral");
+
+    // intr_state is affected by writes to other csrs
+    csr_excl.add_excl({scope, ".", "intr_state"}, CsrExclCheck);
+    // RO registers - exclude init and write-read check
+    csr_excl.add_excl({scope, ".", "status"}, CsrExclWriteCheck);
+    csr_excl.add_excl({scope, ".", "fifo_status"}, CsrExclWriteCheck);
+    // RO registers - exclude init and write-read check
+    csr_excl.add_excl({scope, ".", "val"}, CsrExclCheck);
+    csr_excl.add_excl({scope, ".", "rdata"}, CsrExclCheck);
+  endfunction : add_csr_exclusions
+
   task post_start();
     `uvm_info(`gfn, "stop simulation", UVM_DEBUG)
   endtask : post_start


### PR DESCRIPTION
Reverts lowRISC/opentitan#1738

I made the mistake of assuming the design fix in #1703 that this PR depends on has been merged. Reverting this PR since it will again break the CI. 

@tunghoang290780 
I have already factored in your changes in #1740, so you don't have to worry about this reversion. 

