### PR TITLE
[dvsim] Added --fixed-seed switch

### DIFF
--- a/util/dvsim.py
+++ b/util/dvsim.py
@@ -212,6 +212,13 @@ def main():
            items being run in the order they are passed.""")
 
     parser.add_argument(
+        "--fixed-seed",
+        type=int,
+        default=None,
+        help="""Run all items with a fixed seed value. This option enforces
+           --reseed 1.""")
+
+    parser.add_argument(
         "-r",
         "--reseed",
         type=int,
@@ -425,6 +432,9 @@ def main():
 
     # Register the seeds from command line with RunTest class.
     Deploy.RunTest.seeds = args.seeds
+    # If we are fixing a seed value, no point in tests having multiple reseeds.
+    if args.fixed_seed: args.reseed = 1
+    Deploy.RunTest.fixed_seed = args.fixed_seed
 
     # Register the common deploy settings.
     Deploy.Deploy.print_interval = args.print_interval

--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -537,6 +537,7 @@ class RunTest(Deploy):
 
     # Initial seed values when running tests (if available).
     seeds = []
+    fixed_seed = None
 
     # Register all runs with the class
     items = []
@@ -609,7 +610,11 @@ class RunTest(Deploy):
 
     @staticmethod
     def get_seed():
+        # If --seeds option is passed, then those custom seeds are consumed
+        # first. If --fixed-seed <val> is also passed, the subsequent tests
+        # (once the custom seeds are consumed) will be run with the fixed seed.
         if not RunTest.seeds:
+            if RunTest.fixed_seed: return RunTest.fixed_seed
             for i in range(1000):
                 seed = random.getrandbits(32)
                 RunTest.seeds.append(seed)


### PR DESCRIPTION
- Added a --fixed-seed <integer> switch that will fix the seed value to
be used for running ALL tests.
- Setting this option on the command line will enforce --reseed 1, since
there is no point in running multiple seeds.

This addresses #1735 (partially). 

Signed-off-by: Srikrishna Iyer <sriyer@google.com>