### PR TITLE
[usb] Rework I/O

### DIFF
--- a/hw/ip/usbdev/data/usbdev.hjson
+++ b/hw/ip/usbdev/data/usbdev.hjson
@@ -9,7 +9,7 @@
   bus_device: "tlul",
   bus_host: "none",
   available_inout_list: [
-    #{ name: "d", desc: "USB data differential" }
+    { name: "d", desc: "USB data differential" }
     { name: "dp", desc: "USB data D+" }
     { name: "dn", desc: "USB data D-" }
   ],
@@ -17,7 +17,10 @@
     {  name: "sense", desc: "USB host VBUS sense" }
   ],
   available_output_list: [
-    { name: "pullup", desc: "USB Full Speed pullup control" }
+    { name: "se0", desc: "USB single-ended zero link state" }
+    { name: "pullup", desc: "USB pullup control" }
+    { name: "tx_mode_se", desc: "USB single-ended transmit mode control" }
+    { name: "suspend", desc: "USB link suspend state" }
   ],
   param_list: [
     { name:    "NEndpoints",
@@ -189,9 +192,9 @@
         }
         {
           bits: "15",
-          name: "usb_sense",
+          name: "sense",
           desc: '''
-                Refelects the state of the usb_sense pin. 1 indicates that
+                Refelects the state of the sense pin. 1 indicates that
                 the host is providing VBUS.
                 '''
         }

--- a/hw/ip/usbdev/dv/tb/tb.sv
+++ b/hw/ip/usbdev/dv/tb/tb.sv
@@ -54,23 +54,27 @@ module tb;
     .tl_i                 (tl_if.h2d  ),
     .tl_o                 (tl_if.d2h  ),
 
-
     // USB Interface
     // TOOD: need to hook up an interface
+    .cio_sense_i          (1'b0),
     .cio_d_i              (1'b0),
     .cio_dp_i             (1'b1),
     .cio_dn_i             (1'b0),
 
-    .cio_d_o              (),
     .cio_se0_o            (),
-    .cio_dp_o             (),
-    .cio_dn_o             (),
-    .cio_oe_o             (),
-
-    .cio_tx_mode_se_o     (),
-    .cio_sense_i          (1'b0),
+    .cio_se0_en_o         (),
+    .cio_pullup_o         (),
     .cio_pullup_en_o      (),
+    .cio_tx_mode_se_o     (),
+    .cio_tx_mode_se_en_o  (),
     .cio_suspend_o        (),
+    .cio_suspend_en_o     (),
+    .cio_d_o              (),
+    .cio_d_en_o           (),
+    .cio_dp_o             (),
+    .cio_dp_en_o          (),
+    .cio_dn_o             (),
+    .cio_dn_en_o          (),
 
     // Interrupts
     .intr_pkt_received_o    (intr_pkt_received    ),

--- a/hw/ip/usbdev/rtl/usbdev.sv
+++ b/hw/ip/usbdev/rtl/usbdev.sv
@@ -17,21 +17,29 @@ module usbdev (
   input  tlul_pkg::tl_h2d_t tl_i,
   output tlul_pkg::tl_d2h_t tl_o,
 
-  // USB Interface
-  input  logic       cio_d_i,
-  input  logic       cio_dp_i,
-  input  logic       cio_dn_i,
+  // Data inputs
+  input  logic       cio_d_i, // differential
+  input  logic       cio_dp_i, // single-ended, can be used in differential mode to detect SE0
+  input  logic       cio_dn_i, // single-ended, can be used in differential mode to detect SE0
 
+  // Data outputs
   output logic       cio_d_o,
-  output logic       cio_se0_o,
+  output logic       cio_d_en_o,
   output logic       cio_dp_o,
+  output logic       cio_dp_en_o,
   output logic       cio_dn_o,
-  output logic       cio_oe_o,
+  output logic       cio_dn_en_o,
 
-  output logic       cio_tx_mode_se_o,
+  // Non-data I/O
   input  logic       cio_sense_i,
+  output logic       cio_se0_o,
+  output logic       cio_se0_en_o,
+  output logic       cio_pullup_o,
   output logic       cio_pullup_en_o,
   output logic       cio_suspend_o,
+  output logic       cio_suspend_en_o,
+  output logic       cio_tx_mode_se_o,
+  output logic       cio_tx_mode_se_en_o,
 
   // Interrupts
   output logic       intr_pkt_received_o, // Packet received
@@ -858,7 +866,7 @@ module usbdev (
     .rx_differential_mode_i (reg2hw.phy_config.rx_differential_mode),
     .tx_differential_mode_i (reg2hw.phy_config.tx_differential_mode),
     .sys_reg2hw_config_i    (reg2hw.phy_config),
-    .sys_usb_sense_o        (hw2reg.usbstat.usb_sense.d),
+    .sys_usb_sense_o        (hw2reg.usbstat.sense.d),
 
     // Chip IO
     .cio_usb_d_i            (cio_d_i),
@@ -868,7 +876,7 @@ module usbdev (
     .cio_usb_se0_o          (cio_se0_o),
     .cio_usb_dp_o           (cio_dp_o),
     .cio_usb_dn_o           (cio_dn_o),
-    .cio_usb_oe_o           (cio_oe_o),
+    .cio_usb_oe_o           (cio_oe),
     .cio_usb_tx_mode_se_o   (cio_tx_mode_se_o),
     .cio_usb_sense_i        (cio_sense_i),
     .cio_usb_pullup_en_o    (cio_pullup_en_o),
@@ -884,5 +892,23 @@ module usbdev (
     .usb_pullup_en_i        (usb_pullup_en),
     .usb_suspend_i          (usb_event_link_suspend)
   );
+
+  ////////////////////////
+  // USB Output Enables //
+  ////////////////////////
+  logic cio_oe;
+
+  // Data outputs
+  assign cio_d_en_o  = cio_oe;
+  assign cio_dp_en_o = cio_oe;
+  assign cio_dn_en_o = cio_oe;
+
+  // Non-data outputs - always enabled.
+  assign cio_se0_en_o        = 1'b1;
+  assign cio_suspend_en_o    = 1'b1;
+  assign cio_tx_mode_se_en_o = 1'b1;
+
+  // Pullup
+  assign cio_pullup_o        = 1'b1;
 
 endmodule

--- a/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
@@ -355,7 +355,7 @@ package usbdev_reg_pkg;
     } link_state;
     struct packed {
       logic        d;
-    } usb_sense;
+    } sense;
     struct packed {
       logic [2:0]  d;
     } av_depth;

--- a/hw/ip/usbdev/rtl/usbdev_reg_top.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_top.sv
@@ -257,8 +257,8 @@ module usbdev_reg_top (
   logic usbstat_host_lost_re;
   logic [2:0] usbstat_link_state_qs;
   logic usbstat_link_state_re;
-  logic usbstat_usb_sense_qs;
-  logic usbstat_usb_sense_re;
+  logic usbstat_sense_qs;
+  logic usbstat_sense_re;
   logic [2:0] usbstat_av_depth_qs;
   logic usbstat_av_depth_re;
   logic usbstat_av_full_qs;
@@ -1821,18 +1821,18 @@ module usbdev_reg_top (
   );
 
 
-  //   F[usb_sense]: 15:15
+  //   F[sense]: 15:15
   prim_subreg_ext #(
     .DW    (1)
-  ) u_usbstat_usb_sense (
-    .re     (usbstat_usb_sense_re),
+  ) u_usbstat_sense (
+    .re     (usbstat_sense_re),
     .we     (1'b0),
     .wd     ('0),
-    .d      (hw2reg.usbstat.usb_sense.d),
+    .d      (hw2reg.usbstat.sense.d),
     .qre    (),
     .qe     (),
     .q      (),
-    .qs     (usbstat_usb_sense_qs)
+    .qs     (usbstat_sense_qs)
   );
 
 
@@ -5514,7 +5514,7 @@ module usbdev_reg_top (
 
   assign usbstat_link_state_re = addr_hit[4] && reg_re;
 
-  assign usbstat_usb_sense_re = addr_hit[4] && reg_re;
+  assign usbstat_sense_re = addr_hit[4] && reg_re;
 
   assign usbstat_av_depth_re = addr_hit[4] && reg_re;
 
@@ -5980,7 +5980,7 @@ module usbdev_reg_top (
         reg_rdata_next[10:0] = usbstat_frame_qs;
         reg_rdata_next[11] = usbstat_host_lost_qs;
         reg_rdata_next[14:12] = usbstat_link_state_qs;
-        reg_rdata_next[15] = usbstat_usb_sense_qs;
+        reg_rdata_next[15] = usbstat_sense_qs;
         reg_rdata_next[18:16] = usbstat_av_depth_qs;
         reg_rdata_next[23] = usbstat_av_full_qs;
         reg_rdata_next[26:24] = usbstat_rx_depth_qs;

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -584,13 +584,33 @@
       available_output_list:
       [
         {
+          name: se0
+          width: 1
+          type: output
+        }
+        {
           name: pullup
+          width: 1
+          type: output
+        }
+        {
+          name: tx_mode_se
+          width: 1
+          type: output
+        }
+        {
+          name: suspend
           width: 1
           type: output
         }
       ]
       available_inout_list:
       [
+        {
+          name: d
+          width: 1
+          type: inout
+        }
         {
           name: dp
           width: 1
@@ -1471,7 +1491,7 @@
         name: usbdev
         pad:
         [
-          ChC[0..3]
+          ChC[0..7]
         ]
       }
     ]
@@ -1572,7 +1592,7 @@
         ]
       }
       {
-        name: usbdev_pullup
+        name: usbdev_se0
         width: 1
         type: output
         pad:
@@ -1584,6 +1604,54 @@
         ]
       }
       {
+        name: usbdev_pullup
+        width: 1
+        type: output
+        pad:
+        [
+          {
+            name: ChC
+            index: 2
+          }
+        ]
+      }
+      {
+        name: usbdev_tx_mode_se
+        width: 1
+        type: output
+        pad:
+        [
+          {
+            name: ChC
+            index: 3
+          }
+        ]
+      }
+      {
+        name: usbdev_suspend
+        width: 1
+        type: output
+        pad:
+        [
+          {
+            name: ChC
+            index: 4
+          }
+        ]
+      }
+      {
+        name: usbdev_d
+        width: 1
+        type: inout
+        pad:
+        [
+          {
+            name: ChC
+            index: 5
+          }
+        ]
+      }
+      {
         name: usbdev_dp
         width: 1
         type: inout
@@ -1591,7 +1659,7 @@
         [
           {
             name: ChC
-            index: 2
+            index: 6
           }
         ]
       }
@@ -1603,7 +1671,7 @@
         [
           {
             name: ChC
-            index: 3
+            index: 7
           }
         ]
       }

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -231,7 +231,7 @@
       //{ name: "uart.tx", pad: ["ChA[0]"]},
       { name: "uart", pad: ["ChA[0..1]"]},
       // { name: "dio_module.signal_input", pad: ["ChA[31]"] }
-      { name: "usbdev", pad: ["ChC[0..3]"]},
+      { name: "usbdev", pad: ["ChC[0..7]"]},
     ],
 
     // Multiplexing IO modules. The in/out ports of the modules below are

--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -543,42 +543,21 @@ else:
       .tl_h_o (tl_${m["name"]}_h_h2d),
       .tl_h_i (tl_${m["name"]}_h_d2h),
     % endif
-    % if m["type"] == "usbdev":
-
-      // Differential data - Currently not used.
-      .cio_d_i          (1'b0),
-      .cio_d_o          (),
-      .cio_se0_o        (),
-
-      // Single-ended data
-      .cio_dp_i         (cio_usbdev_dp_p2d),
-      .cio_dn_i         (cio_usbdev_dn_p2d),
-      .cio_dp_o         (cio_usbdev_dp_d2p),
-      .cio_dn_o         (cio_usbdev_dn_d2p),
-
-      // Non-data I/O
-      .cio_sense_i      (cio_usbdev_sense_p2d),
-      .cio_oe_o         (cio_usbdev_dp_en_d2p),
-      .cio_tx_mode_se_o (),
-      .cio_pullup_en_o  (cio_usbdev_pullup_en_d2p),
-      .cio_suspend_o    (),
-    % else:
-      % for p_in in m["available_input_list"] + m["available_inout_list"]:
-        % if loop.first:
+    % for p_in in m["available_input_list"] + m["available_inout_list"]:
+      % if loop.first:
 
       // Input
-        % endif
+      % endif
       .${lib.ljust("cio_"+p_in["name"]+"_i",max_sigwidth+9)} (cio_${m["name"]}_${p_in["name"]}_p2d),
-      % endfor
-      % for p_out in m["available_output_list"] + m["available_inout_list"]:
-        % if loop.first:
+    % endfor
+    % for p_out in m["available_output_list"] + m["available_inout_list"]:
+      % if loop.first:
 
       // Output
-        % endif
+      % endif
       .${lib.ljust("cio_"+p_out["name"]+"_o",   max_sigwidth+9)} (cio_${m["name"]}_${p_out["name"]}_d2p),
       .${lib.ljust("cio_"+p_out["name"]+"_en_o",max_sigwidth+9)} (cio_${m["name"]}_${p_out["name"]}_en_d2p),
-      % endfor
-    % endif
+    % endfor
     % for intr in m["interrupt_list"] if "interrupt_list" in m else []:
       % if loop.first:
 
@@ -662,10 +641,6 @@ else:
   );
 
 % endfor
-  // USB assignments
-  assign cio_usbdev_dn_en_d2p = cio_usbdev_dp_en_d2p; // have a single output enable only
-  assign cio_usbdev_pullup_d2p = 1'b1;
-
   // interrupt assignments
   assign intr_vector = {
   % for intr in top["interrupt"][::-1]:

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -34,8 +34,17 @@ module top_earlgrey #(
   output logic        dio_uart_tx_o,
   output logic        dio_uart_tx_en_o,
   input               dio_usbdev_sense_i,
+  output logic        dio_usbdev_se0_o,
+  output logic        dio_usbdev_se0_en_o,
   output logic        dio_usbdev_pullup_o,
   output logic        dio_usbdev_pullup_en_o,
+  output logic        dio_usbdev_tx_mode_se_o,
+  output logic        dio_usbdev_tx_mode_se_en_o,
+  output logic        dio_usbdev_suspend_o,
+  output logic        dio_usbdev_suspend_en_o,
+  input               dio_usbdev_d_i,
+  output logic        dio_usbdev_d_o,
+  output logic        dio_usbdev_d_en_o,
   input               dio_usbdev_dp_i,
   output logic        dio_usbdev_dp_o,
   output logic        dio_usbdev_dp_en_o,
@@ -154,10 +163,19 @@ module top_earlgrey #(
   // nmi_gen
   // usbdev
   logic        cio_usbdev_sense_p2d;
+  logic        cio_usbdev_d_p2d;
   logic        cio_usbdev_dp_p2d;
   logic        cio_usbdev_dn_p2d;
+  logic        cio_usbdev_se0_d2p;
+  logic        cio_usbdev_se0_en_d2p;
   logic        cio_usbdev_pullup_d2p;
   logic        cio_usbdev_pullup_en_d2p;
+  logic        cio_usbdev_tx_mode_se_d2p;
+  logic        cio_usbdev_tx_mode_se_en_d2p;
+  logic        cio_usbdev_suspend_d2p;
+  logic        cio_usbdev_suspend_en_d2p;
+  logic        cio_usbdev_d_d2p;
+  logic        cio_usbdev_d_en_d2p;
   logic        cio_usbdev_dp_d2p;
   logic        cio_usbdev_dp_en_d2p;
   logic        cio_usbdev_dn_d2p;
@@ -676,23 +694,27 @@ module top_earlgrey #(
       .tl_i (tl_usbdev_d_h2d),
       .tl_o (tl_usbdev_d_d2h),
 
-      // Differential data - Currently not used.
-      .cio_d_i          (1'b0),
-      .cio_d_o          (),
-      .cio_se0_o        (),
+      // Input
+      .cio_sense_i         (cio_usbdev_sense_p2d),
+      .cio_d_i             (cio_usbdev_d_p2d),
+      .cio_dp_i            (cio_usbdev_dp_p2d),
+      .cio_dn_i            (cio_usbdev_dn_p2d),
 
-      // Single-ended data
-      .cio_dp_i         (cio_usbdev_dp_p2d),
-      .cio_dn_i         (cio_usbdev_dn_p2d),
-      .cio_dp_o         (cio_usbdev_dp_d2p),
-      .cio_dn_o         (cio_usbdev_dn_d2p),
-
-      // Non-data I/O
-      .cio_sense_i      (cio_usbdev_sense_p2d),
-      .cio_oe_o         (cio_usbdev_dp_en_d2p),
-      .cio_tx_mode_se_o (),
-      .cio_pullup_en_o  (cio_usbdev_pullup_en_d2p),
-      .cio_suspend_o    (),
+      // Output
+      .cio_se0_o           (cio_usbdev_se0_d2p),
+      .cio_se0_en_o        (cio_usbdev_se0_en_d2p),
+      .cio_pullup_o        (cio_usbdev_pullup_d2p),
+      .cio_pullup_en_o     (cio_usbdev_pullup_en_d2p),
+      .cio_tx_mode_se_o    (cio_usbdev_tx_mode_se_d2p),
+      .cio_tx_mode_se_en_o (cio_usbdev_tx_mode_se_en_d2p),
+      .cio_suspend_o       (cio_usbdev_suspend_d2p),
+      .cio_suspend_en_o    (cio_usbdev_suspend_en_d2p),
+      .cio_d_o             (cio_usbdev_d_d2p),
+      .cio_d_en_o          (cio_usbdev_d_en_d2p),
+      .cio_dp_o            (cio_usbdev_dp_d2p),
+      .cio_dp_en_o         (cio_usbdev_dp_en_d2p),
+      .cio_dn_o            (cio_usbdev_dn_d2p),
+      .cio_dn_en_o         (cio_usbdev_dn_en_d2p),
 
       // Interrupt
       .intr_pkt_received_o    (intr_usbdev_pkt_received),
@@ -717,10 +739,6 @@ module top_earlgrey #(
       .rst_ni (sys_fixed_rst_n),
       .rst_usb_48mhz_ni (usb_rst_n)
   );
-
-  // USB assignments
-  assign cio_usbdev_dn_en_d2p = cio_usbdev_dp_en_d2p; // have a single output enable only
-  assign cio_usbdev_pullup_d2p = 1'b1;
 
   // interrupt assignments
   assign intr_vector = {
@@ -843,23 +861,32 @@ module top_earlgrey #(
     cio_gpio_gpio_p2d
   } = m2p;
 
-  assign cio_spi_device_sck_p2d   = dio_spi_device_sck_i;
-  assign cio_spi_device_csb_p2d   = dio_spi_device_csb_i;
-  assign cio_spi_device_mosi_p2d  = dio_spi_device_mosi_i;
-  assign dio_spi_device_miso_o    = cio_spi_device_miso_d2p;
-  assign dio_spi_device_miso_en_o = cio_spi_device_miso_en_d2p;
-  assign cio_uart_rx_p2d          = dio_uart_rx_i;
-  assign dio_uart_tx_o            = cio_uart_tx_d2p;
-  assign dio_uart_tx_en_o         = cio_uart_tx_en_d2p;
-  assign cio_usbdev_sense_p2d     = dio_usbdev_sense_i;
-  assign dio_usbdev_pullup_o      = cio_usbdev_pullup_d2p;
-  assign dio_usbdev_pullup_en_o   = cio_usbdev_pullup_en_d2p;
-  assign cio_usbdev_dp_p2d        = dio_usbdev_dp_i;
-  assign dio_usbdev_dp_o          = cio_usbdev_dp_d2p;
-  assign dio_usbdev_dp_en_o       = cio_usbdev_dp_en_d2p;
-  assign cio_usbdev_dn_p2d        = dio_usbdev_dn_i;
-  assign dio_usbdev_dn_o          = cio_usbdev_dn_d2p;
-  assign dio_usbdev_dn_en_o       = cio_usbdev_dn_en_d2p;
+  assign cio_spi_device_sck_p2d     = dio_spi_device_sck_i;
+  assign cio_spi_device_csb_p2d     = dio_spi_device_csb_i;
+  assign cio_spi_device_mosi_p2d    = dio_spi_device_mosi_i;
+  assign dio_spi_device_miso_o      = cio_spi_device_miso_d2p;
+  assign dio_spi_device_miso_en_o   = cio_spi_device_miso_en_d2p;
+  assign cio_uart_rx_p2d            = dio_uart_rx_i;
+  assign dio_uart_tx_o              = cio_uart_tx_d2p;
+  assign dio_uart_tx_en_o           = cio_uart_tx_en_d2p;
+  assign cio_usbdev_sense_p2d       = dio_usbdev_sense_i;
+  assign dio_usbdev_se0_o           = cio_usbdev_se0_d2p;
+  assign dio_usbdev_se0_en_o        = cio_usbdev_se0_en_d2p;
+  assign dio_usbdev_pullup_o        = cio_usbdev_pullup_d2p;
+  assign dio_usbdev_pullup_en_o     = cio_usbdev_pullup_en_d2p;
+  assign dio_usbdev_tx_mode_se_o    = cio_usbdev_tx_mode_se_d2p;
+  assign dio_usbdev_tx_mode_se_en_o = cio_usbdev_tx_mode_se_en_d2p;
+  assign dio_usbdev_suspend_o       = cio_usbdev_suspend_d2p;
+  assign dio_usbdev_suspend_en_o    = cio_usbdev_suspend_en_d2p;
+  assign cio_usbdev_d_p2d           = dio_usbdev_d_i;
+  assign dio_usbdev_d_o             = cio_usbdev_d_d2p;
+  assign dio_usbdev_d_en_o          = cio_usbdev_d_en_d2p;
+  assign cio_usbdev_dp_p2d          = dio_usbdev_dp_i;
+  assign dio_usbdev_dp_o            = cio_usbdev_dp_d2p;
+  assign dio_usbdev_dp_en_o         = cio_usbdev_dp_en_d2p;
+  assign cio_usbdev_dn_p2d          = dio_usbdev_dn_i;
+  assign dio_usbdev_dn_o            = cio_usbdev_dn_d2p;
+  assign dio_usbdev_dn_en_o         = cio_usbdev_dn_en_d2p;
 
   // make sure scanmode_i is never X (including during reset)
   `ASSERT_KNOWN(scanmodeKnown, scanmode_i, clk_i, 0)

--- a/hw/top_earlgrey/rtl/padctl.sv
+++ b/hw/top_earlgrey/rtl/padctl.sv
@@ -33,8 +33,17 @@ module padctl (
   inout   IO_GP15,
   // USB device side
   output cio_usbdev_sense_p2d,
+  input  cio_usbdev_se0_d2p,
+  input  cio_usbdev_se0_en_d2p,
   input  cio_usbdev_pullup_d2p,
   input  cio_usbdev_pullup_en_d2p,
+  input  cio_usbdev_tx_mode_se_d2p,
+  input  cio_usbdev_tx_mode_se_en_d2p,
+  input  cio_usbdev_suspend_d2p,
+  input  cio_usbdev_suspend_en_d2p,
+  output cio_usbdev_d_p2d,
+  input  cio_usbdev_d_d2p,
+  input  cio_usbdev_d_en_d2p,
   output cio_usbdev_dp_p2d,
   input  cio_usbdev_dp_d2p,
   input  cio_usbdev_dp_en_d2p,
@@ -83,6 +92,21 @@ module padctl (
   // clock you are regenerating, rather than just holding the phase.
   assign cio_usbdev_dp_p2d = cio_usbdev_dp_en_d2p ? 1'b1 : IO_USB_DP0;
   assign cio_usbdev_dn_p2d = cio_usbdev_dn_en_d2p ? 1'b0 : IO_USB_DN0;
+
+  // Tie off unused signals.
+  logic unused_cio_usbdev_se0_d2p, unused_cio_usbdev_se0_en_d2p;
+  logic unused_cio_usbdev_tx_mode_se_d2p, unused_cio_usbdev_tx_mode_se_en_d2p;
+  logic unused_cio_usbdev_supsend_d2p, unused_cio_usbdev_supsend_en_d2p;
+  logic unused_cio_usbdev_d_d2p, unused_cio_usbdev_d_en_d2p;
+  assign unused_cio_usbdev_se0_d2p = cio_usbdev_se0_d2p;
+  assign unused_cio_usbdev_se0_en_d2p = cio_usbdev_se0_en_d2p;
+  assign unused_cio_usbdev_tx_mode_se_d2p = cio_usbdev_tx_mode_se_d2p;
+  assign unused_cio_usbdev_tx_mode_se_en_d2p = cio_usbdev_tx_mode_se_en_d2p;
+  assign unused_cio_usbdev_suspend_d2p = cio_usbdev_suspend_d2p;
+  assign unused_cio_usbdev_suspend_en_d2p = cio_usbdev_suspend_en_d2p;
+  assign cio_usbdev_d_p2d = 1'b0;
+  assign unused_cio_usbdev_d_d2p = cio_usbdev_d_d2p;
+  assign unused_cio_usbdev_d_en_d2p = cio_usbdev_d_en_d2p;
 
   // JTAG or SPI mux to the FTDI MSEE pins DPS0-DPS6
   logic    jtag_spi_n, dps2, dps2_en;

--- a/hw/top_earlgrey/rtl/top_earlgrey_artys7.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_artys7.sv
@@ -42,7 +42,12 @@ module top_earlgrey_artys7 (
   logic clk_sys, clk_48mhz, rst_sys_n;
   logic [31:0] cio_gpio_p2d, cio_gpio_d2p, cio_gpio_en_d2p;
   logic cio_uart_rx_p2d, cio_uart_tx_d2p, cio_uart_tx_en_d2p;
-  logic cio_usbdev_sense_p2d, cio_usbdev_pullup_d2p, cio_usbdev_pullup_en_d2p;
+  logic cio_usbdev_sense_p2d;
+  logic cio_usbdev_se0_d2p, cio_usbdev_se0_en_d2p;
+  logic cio_usbdev_pullup_d2p, cio_usbdev_pullup_en_d2p;
+  logic cio_usbdev_tx_mode_se_d2p, cio_usbdev_tx_mode_se_en_d2p;
+  logic cio_usbdev_supsend_d2p, cio_usbdev_supsend_en_d2p;
+  logic cio_usbdev_d_p2d, cio_usbdev_d_d2p, cio_usbdev_d_en_d2p;
   logic cio_usbdev_dp_p2d, cio_usbdev_dp_d2p, cio_usbdev_dp_en_d2p;
   logic cio_usbdev_dn_p2d, cio_usbdev_dn_d2p, cio_usbdev_dn_en_d2p;
 
@@ -55,36 +60,45 @@ module top_earlgrey_artys7 (
 
   // Top-level design
   top_earlgrey top_earlgrey (
-    .clk_i                  (clk_sys),
-    .rst_ni                 (rst_sys_n),
+    .clk_i                      (clk_sys),
+    .rst_ni                     (rst_sys_n),
 
-    .clk_usb_48mhz_i        (clk_48mhz),
+    .clk_usb_48mhz_i            (clk_48mhz),
 
-    .jtag_tck_i             (IO_JTCK),
-    .jtag_tms_i             (IO_JTMS),
-    .jtag_trst_ni           (IO_JTRST_N),
-    .jtag_td_i              (IO_JTDI),
-    .jtag_td_o              (IO_JTDO),
+    .jtag_tck_i                 (IO_JTCK),
+    .jtag_tms_i                 (IO_JTMS),
+    .jtag_trst_ni               (IO_JTRST_N),
+    .jtag_td_i                  (IO_JTDI),
+    .jtag_td_o                  (IO_JTDO),
 
-    .dio_uart_rx_i          (cio_uart_rx_p2d),
-    .dio_uart_tx_o          (cio_uart_tx_d2p),
-    .dio_uart_tx_en_o       (cio_uart_tx_en_d2p),
+    .dio_uart_rx_i              (cio_uart_rx_p2d),
+    .dio_uart_tx_o              (cio_uart_tx_d2p),
+    .dio_uart_tx_en_o           (cio_uart_tx_en_d2p),
 
-    .mio_in_i               (cio_gpio_p2d),
-    .mio_out_o              (cio_gpio_d2p),
-    .mio_oe_o               (cio_gpio_en_d2p),
+    .mio_in_i                   (cio_gpio_p2d),
+    .mio_out_o                  (cio_gpio_d2p),
+    .mio_oe_o                   (cio_gpio_en_d2p),
 
-    .dio_usbdev_sense_i     (cio_usbdev_sense_p2d),
-    .dio_usbdev_pullup_o    (cio_usbdev_pullup_d2p),
-    .dio_usbdev_pullup_en_o (cio_usbdev_pullup_en_d2p),
-    .dio_usbdev_dp_i        (cio_usbdev_dp_p2d),
-    .dio_usbdev_dp_o        (cio_usbdev_dp_d2p),
-    .dio_usbdev_dp_en_o     (cio_usbdev_dp_en_d2p),
-    .dio_usbdev_dn_i        (cio_usbdev_dn_p2d),
-    .dio_usbdev_dn_o        (cio_usbdev_dn_d2p),
-    .dio_usbdev_dn_en_o     (cio_usbdev_dn_en_d2p),
+    .dio_usbdev_sense_i         (cio_usbdev_sense_p2d),
+    .dio_usbdev_se0_o           (cio_usbdev_se0_d2p),
+    .dio_usbdev_se0_en_o        (cio_usbdev_se0_en_d2p),
+    .dio_usbdev_pullup_o        (cio_usbdev_pullup_d2p),
+    .dio_usbdev_pullup_en_o     (cio_usbdev_pullup_en_d2p),
+    .dio_usbdev_tx_mode_se_o    (cio_usbdev_tx_mode_se_d2p),
+    .dio_usbdev_tx_mode_se_en_o (cio_usbdev_tx_mode_se_en_d2p),
+    .dio_usbdev_suspend_o       (cio_usbdev_suspend_d2p),
+    .dio_usbdev_suspend_en_o    (cio_usbdev_suspend_en_d2p),
+    .dio_usbdev_d_i             (cio_usbdev_d_p2d),
+    .dio_usbdev_d_o             (cio_usbdev_d_d2p),
+    .dio_usbdev_d_en_o          (cio_usbdev_d_en_d2p),
+    .dio_usbdev_dp_i            (cio_usbdev_dp_p2d),
+    .dio_usbdev_dp_o            (cio_usbdev_dp_d2p),
+    .dio_usbdev_dp_en_o         (cio_usbdev_dp_en_d2p),
+    .dio_usbdev_dn_i            (cio_usbdev_dn_p2d),
+    .dio_usbdev_dn_o            (cio_usbdev_dn_d2p),
+    .dio_usbdev_dn_en_o         (cio_usbdev_dn_en_d2p),
 
-    .scanmode_i             (1'b0) // 1 for Scan
+    .scanmode_i                 (1'b0) // 1 for Scan
   );
 
   // Clock and reset
@@ -104,8 +118,17 @@ module top_earlgrey_artys7 (
     .cio_uart_tx_en_d2p,
     // USB
     .cio_usbdev_sense_p2d(cio_usbdev_sense_p2d),
+    .cio_usbdev_se0_d2p(cio_usbdev_se0_d2p),
+    .cio_usbdev_se0_en_d2p(cio_usbdev_se0_en_d2p),
     .cio_usbdev_pullup_d2p(cio_usbdev_pullup_d2p),
     .cio_usbdev_pullup_en_d2p(cio_usbdev_pullup_en_d2p),
+    .cio_usbdev_tx_mode_se_d2p(cio_usbdev_tx_mode_se_d2p),
+    .cio_usbdev_tx_mode_se_en_d2p(cio_usbdev_tx_mode_se_en_d2p),
+    .cio_usbdev_suspend_d2p(cio_usbdev_suspend_d2p),
+    .cio_usbdev_suspend_en_d2p(cio_usbdev_suspend_en_d2p),
+    .cio_usbdev_d_p2d(cio_usbdev_d_p2d),
+    .cio_usbdev_d_d2p(cio_usbdev_d_d2p),
+    .cio_usbdev_d_en_d2p(cio_usbdev_d_en_d2p),
     .cio_usbdev_dp_p2d(cio_usbdev_dp_p2d),
     .cio_usbdev_dp_d2p(cio_usbdev_dp_d2p),
     .cio_usbdev_dp_en_d2p(cio_usbdev_dp_en_d2p),

--- a/hw/top_earlgrey/rtl/top_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_asic.sv
@@ -49,48 +49,62 @@ module top_earlgrey_asic (
         cio_spi_device_miso_d2p, cio_spi_device_miso_en_d2p;
   logic cio_jtag_tck_p2d, cio_jtag_tms_p2d, cio_jtag_tdi_p2d, cio_jtag_tdo_d2p;
   logic cio_jtag_trst_n_p2d, cio_jtag_srst_n_p2d;
-  logic cio_usbdev_sense_p2d, cio_usbdev_pullup_d2p, cio_usbdev_pullup_en_d2p;
+  logic cio_usbdev_sense_p2d;
+  logic cio_usbdev_se0_d2p, cio_usbdev_se0_en_d2p;
+  logic cio_usbdev_pullup_d2p, cio_usbdev_pullup_en_d2p;
+  logic cio_usbdev_tx_mode_se_d2p, cio_usbdev_tx_mode_se_en_d2p;
+  logic cio_usbdev_supsend_d2p, cio_usbdev_supsend_en_d2p;
+  logic cio_usbdev_d_p2d, cio_usbdev_d_d2p, cio_usbdev_d_en_d2p;
   logic cio_usbdev_dp_p2d, cio_usbdev_dp_d2p, cio_usbdev_dp_en_d2p;
   logic cio_usbdev_dn_p2d, cio_usbdev_dn_d2p, cio_usbdev_dn_en_d2p;
 
   // Top-level design
   top_earlgrey top_earlgrey (
-    .clk_i                    (IO_CLK),
-    .rst_ni                   (IO_RST_N),
+    .clk_i                      (IO_CLK),
+    .rst_ni                     (IO_RST_N),
 
-    .clk_usb_48mhz_i          (IO_CLK_USB_48MHZ),
+    .clk_usb_48mhz_i            (IO_CLK_USB_48MHZ),
 
-    .jtag_tck_i               (cio_jtag_tck_p2d),
-    .jtag_tms_i               (cio_jtag_tms_p2d),
-    .jtag_trst_ni             (cio_jtag_trst_n_p2d),
-    .jtag_td_i                (cio_jtag_tdi_p2d),
-    .jtag_td_o                (cio_jtag_tdo_d2p),
+    .jtag_tck_i                 (cio_jtag_tck_p2d),
+    .jtag_tms_i                 (cio_jtag_tms_p2d),
+    .jtag_trst_ni               (cio_jtag_trst_n_p2d),
+    .jtag_td_i                  (cio_jtag_tdi_p2d),
+    .jtag_td_o                  (cio_jtag_tdo_d2p),
 
-    .dio_spi_device_sck_i     (cio_spi_device_sck_p2d),
-    .dio_spi_device_csb_i     (cio_spi_device_csb_p2d),
-    .dio_spi_device_mosi_i    (cio_spi_device_mosi_p2d),
-    .dio_spi_device_miso_o    (cio_spi_device_miso_d2p),
-    .dio_spi_device_miso_en_o (cio_spi_device_miso_en_d2p),
+    .dio_spi_device_sck_i       (cio_spi_device_sck_p2d),
+    .dio_spi_device_csb_i       (cio_spi_device_csb_p2d),
+    .dio_spi_device_mosi_i      (cio_spi_device_mosi_p2d),
+    .dio_spi_device_miso_o      (cio_spi_device_miso_d2p),
+    .dio_spi_device_miso_en_o   (cio_spi_device_miso_en_d2p),
 
-    .dio_uart_rx_i            (cio_uart_rx_p2d),
-    .dio_uart_tx_o            (cio_uart_tx_d2p),
-    .dio_uart_tx_en_o         (cio_uart_tx_en_d2p),
+    .dio_uart_rx_i              (cio_uart_rx_p2d),
+    .dio_uart_tx_o              (cio_uart_tx_d2p),
+    .dio_uart_tx_en_o           (cio_uart_tx_en_d2p),
 
-    .dio_usbdev_sense_i       (cio_usbdev_sense_p2d),
-    .dio_usbdev_pullup_o      (cio_usbdev_pullup_d2p),
-    .dio_usbdev_pullup_en_o   (cio_usbdev_pullup_en_d2p),
-    .dio_usbdev_dp_i          (cio_usbdev_dp_p2d),
-    .dio_usbdev_dp_o          (cio_usbdev_dp_d2p),
-    .dio_usbdev_dp_en_o       (cio_usbdev_dp_en_d2p),
-    .dio_usbdev_dn_i          (cio_usbdev_dn_p2d),
-    .dio_usbdev_dn_o          (cio_usbdev_dn_d2p),
-    .dio_usbdev_dn_en_o       (cio_usbdev_dn_en_d2p),
+    .dio_usbdev_sense_i         (cio_usbdev_sense_p2d),
+    .dio_usbdev_se0_o           (cio_usbdev_se0_d2p),
+    .dio_usbdev_se0_en_o        (cio_usbdev_se0_en_d2p),
+    .dio_usbdev_pullup_o        (cio_usbdev_pullup_d2p),
+    .dio_usbdev_pullup_en_o     (cio_usbdev_pullup_en_d2p),
+    .dio_usbdev_tx_mode_se_o    (cio_usbdev_tx_mode_se_d2p),
+    .dio_usbdev_tx_mode_se_en_o (cio_usbdev_tx_mode_se_en_d2p),
+    .dio_usbdev_suspend_o       (cio_usbdev_suspend_d2p),
+    .dio_usbdev_suspend_en_o    (cio_usbdev_suspend_en_d2p),
+    .dio_usbdev_d_i             (cio_usbdev_d_p2d),
+    .dio_usbdev_d_o             (cio_usbdev_d_d2p),
+    .dio_usbdev_d_en_o          (cio_usbdev_d_en_d2p),
+    .dio_usbdev_dp_i            (cio_usbdev_dp_p2d),
+    .dio_usbdev_dp_o            (cio_usbdev_dp_d2p),
+    .dio_usbdev_dp_en_o         (cio_usbdev_dp_en_d2p),
+    .dio_usbdev_dn_i            (cio_usbdev_dn_p2d),
+    .dio_usbdev_dn_o            (cio_usbdev_dn_d2p),
+    .dio_usbdev_dn_en_o         (cio_usbdev_dn_en_d2p),
 
-    .mio_in_i                 (cio_gpio_p2d),
-    .mio_out_o                (cio_gpio_d2p),
-    .mio_oe_o                 (cio_gpio_en_d2p),
+    .mio_in_i                   (cio_gpio_p2d),
+    .mio_out_o                  (cio_gpio_d2p),
+    .mio_oe_o                   (cio_gpio_en_d2p),
 
-    .scanmode_i               (1'b0)
+    .scanmode_i                 (1'b0)
   );
 
   // pad control
@@ -101,8 +115,17 @@ module top_earlgrey_asic (
     .cio_uart_tx_en_d2p,
     // USB
     .cio_usbdev_sense_p2d(cio_usbdev_sense_p2d),
+    .cio_usbdev_se0_d2p(cio_usbdev_se0_d2p),
+    .cio_usbdev_se0_en_d2p(cio_usbdev_se0_en_d2p),
     .cio_usbdev_pullup_d2p(cio_usbdev_pullup_d2p),
     .cio_usbdev_pullup_en_d2p(cio_usbdev_pullup_en_d2p),
+    .cio_usbdev_tx_mode_se_d2p(cio_usbdev_tx_mode_se_d2p),
+    .cio_usbdev_tx_mode_se_en_d2p(cio_usbdev_tx_mode_se_en_d2p),
+    .cio_usbdev_suspend_d2p(cio_usbdev_suspend_d2p),
+    .cio_usbdev_suspend_en_d2p(cio_usbdev_suspend_en_d2p),
+    .cio_usbdev_d_p2d(cio_usbdev_d_p2d),
+    .cio_usbdev_d_d2p(cio_usbdev_d_d2p),
+    .cio_usbdev_d_en_d2p(cio_usbdev_d_en_d2p),
     .cio_usbdev_dp_p2d(cio_usbdev_dp_p2d),
     .cio_usbdev_dp_d2p(cio_usbdev_dp_d2p),
     .cio_usbdev_dp_en_d2p(cio_usbdev_dp_en_d2p),

--- a/hw/top_earlgrey/rtl/top_earlgrey_nexysvideo.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_nexysvideo.sv
@@ -49,7 +49,12 @@ module top_earlgrey_nexysvideo (
         cio_spi_device_miso_d2p, cio_spi_device_miso_en_d2p;
   logic cio_jtag_tck_p2d, cio_jtag_tms_p2d, cio_jtag_tdi_p2d, cio_jtag_tdo_d2p;
   logic cio_jtag_trst_n_p2d, cio_jtag_srst_n_p2d;
-  logic cio_usbdev_sense_p2d, cio_usbdev_pullup_d2p, cio_usbdev_pullup_en_d2p;
+  logic cio_usbdev_sense_p2d;
+  logic cio_usbdev_se0_d2p, cio_usbdev_se0_en_d2p;
+  logic cio_usbdev_pullup_d2p, cio_usbdev_pullup_en_d2p;
+  logic cio_usbdev_tx_mode_se_d2p, cio_usbdev_tx_mode_se_en_d2p;
+  logic cio_usbdev_supsend_d2p, cio_usbdev_supsend_en_d2p;
+  logic cio_usbdev_d_p2d, cio_usbdev_d_d2p, cio_usbdev_d_en_d2p;
   logic cio_usbdev_dp_p2d, cio_usbdev_dp_d2p, cio_usbdev_dp_en_d2p;
   logic cio_usbdev_dn_p2d, cio_usbdev_dn_d2p, cio_usbdev_dn_en_d2p;
 
@@ -57,42 +62,51 @@ module top_earlgrey_nexysvideo (
   top_earlgrey #(
     .IbexPipeLine(1)
   ) top_earlgrey (
-    .clk_i                    (clk_sys),
-    .rst_ni                   (rst_sys_n),
+    .clk_i                      (clk_sys),
+    .rst_ni                     (rst_sys_n),
 
-    .clk_usb_48mhz_i          (clk_48mhz),
+    .clk_usb_48mhz_i            (clk_48mhz),
 
-    .jtag_tck_i               (cio_jtag_tck_p2d),
-    .jtag_tms_i               (cio_jtag_tms_p2d),
-    .jtag_trst_ni             (cio_jtag_trst_n_p2d),
-    .jtag_td_i                (cio_jtag_tdi_p2d),
-    .jtag_td_o                (cio_jtag_tdo_d2p),
+    .jtag_tck_i                 (cio_jtag_tck_p2d),
+    .jtag_tms_i                 (cio_jtag_tms_p2d),
+    .jtag_trst_ni               (cio_jtag_trst_n_p2d),
+    .jtag_td_i                  (cio_jtag_tdi_p2d),
+    .jtag_td_o                  (cio_jtag_tdo_d2p),
 
-    .mio_in_i                 (cio_gpio_p2d),
-    .mio_out_o                (cio_gpio_d2p),
-    .mio_oe_o                 (cio_gpio_en_d2p),
+    .mio_in_i                   (cio_gpio_p2d),
+    .mio_out_o                  (cio_gpio_d2p),
+    .mio_oe_o                   (cio_gpio_en_d2p),
 
-    .dio_uart_rx_i            (cio_uart_rx_p2d),
-    .dio_uart_tx_o            (cio_uart_tx_d2p),
-    .dio_uart_tx_en_o         (cio_uart_tx_en_d2p),
+    .dio_uart_rx_i              (cio_uart_rx_p2d),
+    .dio_uart_tx_o              (cio_uart_tx_d2p),
+    .dio_uart_tx_en_o           (cio_uart_tx_en_d2p),
 
-    .dio_spi_device_sck_i     (cio_spi_device_sck_p2d),
-    .dio_spi_device_csb_i     (cio_spi_device_csb_p2d),
-    .dio_spi_device_mosi_i    (cio_spi_device_mosi_p2d),
-    .dio_spi_device_miso_o    (cio_spi_device_miso_d2p),
-    .dio_spi_device_miso_en_o (cio_spi_device_miso_en_d2p),
+    .dio_spi_device_sck_i       (cio_spi_device_sck_p2d),
+    .dio_spi_device_csb_i       (cio_spi_device_csb_p2d),
+    .dio_spi_device_mosi_i      (cio_spi_device_mosi_p2d),
+    .dio_spi_device_miso_o      (cio_spi_device_miso_d2p),
+    .dio_spi_device_miso_en_o   (cio_spi_device_miso_en_d2p),
 
-    .dio_usbdev_sense_i       (cio_usbdev_sense_p2d),
-    .dio_usbdev_pullup_o      (cio_usbdev_pullup_d2p),
-    .dio_usbdev_pullup_en_o   (cio_usbdev_pullup_en_d2p),
-    .dio_usbdev_dp_i          (cio_usbdev_dp_p2d),
-    .dio_usbdev_dp_o          (cio_usbdev_dp_d2p),
-    .dio_usbdev_dp_en_o       (cio_usbdev_dp_en_d2p),
-    .dio_usbdev_dn_i          (cio_usbdev_dn_p2d),
-    .dio_usbdev_dn_o          (cio_usbdev_dn_d2p),
-    .dio_usbdev_dn_en_o       (cio_usbdev_dn_en_d2p),
+    .dio_usbdev_sense_i         (cio_usbdev_sense_p2d),
+    .dio_usbdev_se0_o           (cio_usbdev_se0_d2p),
+    .dio_usbdev_se0_en_o        (cio_usbdev_se0_en_d2p),
+    .dio_usbdev_pullup_o        (cio_usbdev_pullup_d2p),
+    .dio_usbdev_pullup_en_o     (cio_usbdev_pullup_en_d2p),
+    .dio_usbdev_tx_mode_se_o    (cio_usbdev_tx_mode_se_d2p),
+    .dio_usbdev_tx_mode_se_en_o (cio_usbdev_tx_mode_se_en_d2p),
+    .dio_usbdev_suspend_o       (cio_usbdev_suspend_d2p),
+    .dio_usbdev_suspend_en_o    (cio_usbdev_suspend_en_d2p),
+    .dio_usbdev_d_i             (cio_usbdev_d_p2d),
+    .dio_usbdev_d_o             (cio_usbdev_d_d2p),
+    .dio_usbdev_d_en_o          (cio_usbdev_d_en_d2p),
+    .dio_usbdev_dp_i            (cio_usbdev_dp_p2d),
+    .dio_usbdev_dp_o            (cio_usbdev_dp_d2p),
+    .dio_usbdev_dp_en_o         (cio_usbdev_dp_en_d2p),
+    .dio_usbdev_dn_i            (cio_usbdev_dn_p2d),
+    .dio_usbdev_dn_o            (cio_usbdev_dn_d2p),
+    .dio_usbdev_dn_en_o         (cio_usbdev_dn_en_d2p),
 
-    .scanmode_i               (1'b0) // 1 for Scan
+    .scanmode_i                 (1'b0) // 1 for Scan
   );
 
   clkgen_xil7series clkgen (
@@ -111,8 +125,17 @@ module top_earlgrey_nexysvideo (
     .cio_uart_tx_en_d2p,
     // USB
     .cio_usbdev_sense_p2d(cio_usbdev_sense_p2d),
+    .cio_usbdev_se0_d2p(cio_usbdev_se0_d2p),
+    .cio_usbdev_se0_en_d2p(cio_usbdev_se0_en_d2p),
     .cio_usbdev_pullup_d2p(cio_usbdev_pullup_d2p),
     .cio_usbdev_pullup_en_d2p(cio_usbdev_pullup_en_d2p),
+    .cio_usbdev_tx_mode_se_d2p(cio_usbdev_tx_mode_se_d2p),
+    .cio_usbdev_tx_mode_se_en_d2p(cio_usbdev_tx_mode_se_en_d2p),
+    .cio_usbdev_suspend_d2p(cio_usbdev_suspend_d2p),
+    .cio_usbdev_suspend_en_d2p(cio_usbdev_suspend_en_d2p),
+    .cio_usbdev_d_p2d(cio_usbdev_d_p2d),
+    .cio_usbdev_d_d2p(cio_usbdev_d_d2p),
+    .cio_usbdev_d_en_d2p(cio_usbdev_d_en_d2p),
     .cio_usbdev_dp_p2d(cio_usbdev_dp_p2d),
     .cio_usbdev_dp_d2p(cio_usbdev_dp_d2p),
     .cio_usbdev_dp_en_d2p(cio_usbdev_dp_en_d2p),

--- a/hw/top_earlgrey/rtl/top_earlgrey_verilator.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_verilator.sv
@@ -18,7 +18,12 @@ module top_earlgrey_verilator (
   logic cio_spi_device_mosi_p2d;
   logic cio_spi_device_miso_d2p, cio_spi_device_miso_en_d2p;
 
-  logic cio_usbdev_sense_p2d, cio_usbdev_pullup_d2p, cio_usbdev_pullup_en_d2p;
+  logic cio_usbdev_sense_p2d;
+  logic cio_usbdev_se0_d2p, cio_usbdev_se0_en_d2p;
+  logic cio_usbdev_pullup_d2p, cio_usbdev_pullup_en_d2p;
+  logic cio_usbdev_tx_mode_se_d2p, cio_usbdev_tx_mode_se_en_d2p;
+  logic cio_usbdev_supsend_d2p, cio_usbdev_supsend_en_d2p;
+  logic cio_usbdev_d_p2d, cio_usbdev_d_d2p, cio_usbdev_d_en_d2p;
   logic cio_usbdev_dp_p2d, cio_usbdev_dp_d2p, cio_usbdev_dp_en_d2p;
   logic cio_usbdev_dn_p2d, cio_usbdev_dn_d2p, cio_usbdev_dn_en_d2p;
 
@@ -26,44 +31,53 @@ module top_earlgrey_verilator (
 
   // Top-level design
   top_earlgrey top_earlgrey (
-    .clk_i                    (clk_i),
-    .rst_ni                   (rst_ni),
+    .clk_i                      (clk_i),
+    .rst_ni                     (rst_ni),
 
-    .clk_usb_48mhz_i          (clk_i),
+    .clk_usb_48mhz_i            (clk_i),
 
-    .jtag_tck_i               (cio_jtag_tck),
-    .jtag_tms_i               (cio_jtag_tms),
-    .jtag_trst_ni             (cio_jtag_trst_n),
-    .jtag_td_i                (cio_jtag_tdi),
-    .jtag_td_o                (cio_jtag_tdo),
+    .jtag_tck_i                 (cio_jtag_tck),
+    .jtag_tms_i                 (cio_jtag_tms),
+    .jtag_trst_ni               (cio_jtag_trst_n),
+    .jtag_td_i                  (cio_jtag_tdi),
+    .jtag_td_o                  (cio_jtag_tdo),
 
     // Multiplexed I/O
-    .mio_in_i                 (cio_gpio_p2d),
-    .mio_out_o                (cio_gpio_d2p),
-    .mio_oe_o                 (cio_gpio_en_d2p),
+    .mio_in_i                   (cio_gpio_p2d),
+    .mio_out_o                  (cio_gpio_d2p),
+    .mio_oe_o                   (cio_gpio_en_d2p),
 
     // Dedicated I/O
-    .dio_uart_rx_i            (cio_uart_rx_p2d),
-    .dio_uart_tx_o            (cio_uart_tx_d2p),
-    .dio_uart_tx_en_o         (cio_uart_tx_en_d2p),
+    .dio_uart_rx_i              (cio_uart_rx_p2d),
+    .dio_uart_tx_o              (cio_uart_tx_d2p),
+    .dio_uart_tx_en_o           (cio_uart_tx_en_d2p),
 
-    .dio_spi_device_sck_i     (cio_spi_device_sck_p2d),
-    .dio_spi_device_csb_i     (cio_spi_device_csb_p2d),
-    .dio_spi_device_mosi_i    (cio_spi_device_mosi_p2d),
-    .dio_spi_device_miso_o    (cio_spi_device_miso_d2p),
-    .dio_spi_device_miso_en_o (cio_spi_device_miso_en_d2p),
+    .dio_spi_device_sck_i       (cio_spi_device_sck_p2d),
+    .dio_spi_device_csb_i       (cio_spi_device_csb_p2d),
+    .dio_spi_device_mosi_i      (cio_spi_device_mosi_p2d),
+    .dio_spi_device_miso_o      (cio_spi_device_miso_d2p),
+    .dio_spi_device_miso_en_o   (cio_spi_device_miso_en_d2p),
 
-    .dio_usbdev_sense_i       (cio_usbdev_sense_p2d),
-    .dio_usbdev_pullup_o      (cio_usbdev_pullup_d2p),
-    .dio_usbdev_pullup_en_o   (cio_usbdev_pullup_en_d2p),
-    .dio_usbdev_dp_i          (cio_usbdev_dp_p2d),
-    .dio_usbdev_dp_o          (cio_usbdev_dp_d2p),
-    .dio_usbdev_dp_en_o       (cio_usbdev_dp_en_d2p),
-    .dio_usbdev_dn_i          (cio_usbdev_dn_p2d),
-    .dio_usbdev_dn_o          (cio_usbdev_dn_d2p),
-    .dio_usbdev_dn_en_o       (cio_usbdev_dn_en_d2p),
+    .dio_usbdev_sense_i         (cio_usbdev_sense_p2d),
+    .dio_usbdev_se0_o           (cio_usbdev_se0_d2p),
+    .dio_usbdev_se0_en_o        (cio_usbdev_se0_en_d2p),
+    .dio_usbdev_pullup_o        (cio_usbdev_pullup_d2p),
+    .dio_usbdev_pullup_en_o     (cio_usbdev_pullup_en_d2p),
+    .dio_usbdev_tx_mode_se_o    (cio_usbdev_tx_mode_se_d2p),
+    .dio_usbdev_tx_mode_se_en_o (cio_usbdev_tx_mode_se_en_d2p),
+    .dio_usbdev_suspend_o       (cio_usbdev_suspend_d2p),
+    .dio_usbdev_suspend_en_o    (cio_usbdev_suspend_en_d2p),
+    .dio_usbdev_d_i             (cio_usbdev_d_p2d),
+    .dio_usbdev_d_o             (cio_usbdev_d_d2p),
+    .dio_usbdev_d_en_o          (cio_usbdev_d_en_d2p),
+    .dio_usbdev_dp_i            (cio_usbdev_dp_p2d),
+    .dio_usbdev_dp_o            (cio_usbdev_dp_d2p),
+    .dio_usbdev_dp_en_o         (cio_usbdev_dp_en_d2p),
+    .dio_usbdev_dn_i            (cio_usbdev_dn_p2d),
+    .dio_usbdev_dn_o            (cio_usbdev_dn_d2p),
+    .dio_usbdev_dn_en_o         (cio_usbdev_dn_en_d2p),
 
-    .scanmode_i               (1'b0)
+    .scanmode_i                 (1'b0)
   );
 
   // GPIO DPI
@@ -147,6 +161,21 @@ module top_earlgrey_verilator (
     .dn_d2p        (cio_usbdev_dn_d2p),
     .dn_en_d2p     (cio_usbdev_dn_en_d2p)
   );
+
+  // Tie off unused signals.
+  logic unused_cio_usbdev_se0_d2p, unused_cio_usbdev_se0_en_d2p;
+  logic unused_cio_usbdev_tx_mode_se_d2p, unused_cio_usbdev_tx_mode_se_en_d2p;
+  logic unused_cio_usbdev_supsend_d2p, unused_cio_usbdev_supsend_en_d2p;
+  logic unused_cio_usbdev_d_d2p, unused_cio_usbdev_d_en_d2p;
+  assign unused_cio_usbdev_se0_d2p = cio_usbdev_se0_d2p;
+  assign unused_cio_usbdev_se0_en_d2p = cio_usbdev_se0_en_d2p;
+  assign unused_cio_usbdev_tx_mode_se_d2p = cio_usbdev_tx_mode_se_d2p;
+  assign unused_cio_usbdev_tx_mode_se_en_d2p = cio_usbdev_tx_mode_se_en_d2p;
+  assign unused_cio_usbdev_suspend_d2p = cio_usbdev_suspend_d2p;
+  assign unused_cio_usbdev_suspend_en_d2p = cio_usbdev_suspend_en_d2p;
+  assign cio_usbdev_d_p2d = 1'b0;
+  assign unused_cio_usbdev_d_d2p = cio_usbdev_d_d2p;
+  assign unused_cio_usbdev_d_en_d2p = cio_usbdev_d_en_d2p;
 
   // monitor for termination
 `ifndef END_MON_PATH

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -10,7 +10,7 @@
 // PERIPH_INSEL ranges from 0 to NUM_MIO + 2 -1}
 //  0 and 1 are tied to value 0 and 1
 #define NUM_MIO 32
-#define NUM_DIO 10
+#define NUM_DIO 14
 
 #define PINMUX_GPIO_GPIO_0_IN 0
 #define PINMUX_GPIO_GPIO_1_IN 1


### PR DESCRIPTION
This PR reworks the I/O of the USB device such that topgen can be used for the top-level integration.

To ease review, the autogenerated files are in a separate commit. I will squash these before merging.

This PR is related to #1677.