### PR TITLE
Add missing dependencies between fusesoc cores

### DIFF
--- a/hw/ip/alert_handler/dv/env/alert_handler_env.core
+++ b/hw/ip/alert_handler/dv/env/alert_handler_env.core
@@ -9,6 +9,7 @@ filesets:
     depend:
       - lowrisc:dv:cip_lib
       - lowrisc:dv:gen_ral_pkg
+      - lowrisc:ip:alert_handler_component
     files:
       - alert_handler_env_pkg.sv
       - alert_handler_env_cfg.sv: {is_include_file: true}

--- a/hw/ip/i2c/dv/env/i2c_env.core
+++ b/hw/ip/i2c/dv/env/i2c_env.core
@@ -10,6 +10,7 @@ filesets:
       - lowrisc:dv:cip_lib
       - lowrisc:dv:i2c_agent
       - lowrisc:dv:gen_ral_pkg
+      - lowrisc:ip:i2c
     files:
       - i2c_env_pkg.sv
       - i2c_env_cfg.sv: {is_include_file: true}


### PR DESCRIPTION
The i2c and alert cores were missing dependencies on packages, which could lead to a wrong include order of these files, failing compilation. See the individual commit messages for the exact error message and steps taken to resolve that.