### PR TITLE
Install packages for a better Python experience

### DIFF
--- a/apt-requirements.txt
+++ b/apt-requirements.txt
@@ -23,6 +23,7 @@ pkgconf
 python3
 python3-pip
 python3-setuptools
+python3-wheel
 srecord
 tree
 zlib1g-dev

--- a/apt-requirements.txt
+++ b/apt-requirements.txt
@@ -24,6 +24,9 @@ python3
 python3-pip
 python3-setuptools
 python3-wheel
+# The pip-installed version does not come with LibYAML support by default,
+# which significantly speeds up the parsing/dumping of YAML files in fusesoc.
+python3-yaml
 srecord
 tree
 zlib1g-dev


### PR DESCRIPTION
Install wheel for pre-compiled binary parts in packages, and install a version of pyyaml backed by a native (C) YAML parser/dumper for more speed when using fusesoc.