### PR TITLE
[spi_device/dv] Add interrupt seq

### DIFF
--- a/hw/dv/sv/dv_utils/dv_utils_pkg.sv
+++ b/hw/dv/sv/dv_utils/dv_utils_pkg.sv
@@ -76,6 +76,16 @@ package dv_utils_pkg;
 
   string msg_id = "dv_utils_pkg";
 
+  // return the smaller value of 2 inputs
+  function automatic int min2(int a, int b);
+      return (a < b) ? a : b;
+  endfunction
+
+  // return the bigger value of 2 inputs
+  function automatic int max2(int a, int b);
+    return (a > b) ? a : b;
+  endfunction
+
   // Simple function to set max errors before quitting sim
   function automatic void set_max_quit_count(int n);
     uvm_report_server report_server = uvm_report_server::get_server();

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_extreme_fifo_size_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_extreme_fifo_size_vseq.sv
@@ -8,13 +8,13 @@ class spi_device_extreme_fifo_size_vseq extends spi_device_txrx_vseq;
   `uvm_object_new
 
   constraint sram_size_constraints_c {
-    host_sram_word_size dist {
+    num_host_sram_words dist {
       1 :/ 1,                     // 1 word
       SRAM_SIZE[31:2]/2     :/ 1, // half of the total mem
       SRAM_SIZE[31:2]-1     :/ 1, // max size
       [2:SRAM_SIZE[31:2]-2] :/ 1
     };
-    device_sram_word_size dist {
+    num_device_sram_words dist {
       1 :/ 1,                     // 1 word
       SRAM_SIZE[31:2]/2     :/ 1, // half of the total mem
       SRAM_SIZE[31:2]-1     :/ 1, // max size

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_fifo_underflow_overflow_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_fifo_underflow_overflow_vseq.sv
@@ -30,13 +30,13 @@ class spi_device_fifo_underflow_overflow_vseq extends spi_device_txrx_vseq;
     // there are some underflow data in fifo, clean them up
     // repeat twice in case some data in async_fifo when sram fifo is full
     for (uint i = 0; i < 2; i++) begin
+      cfg.clk_rst_vif.wait_clks(2); // 2 cycle for fifo ptr to be updated
       read_rx_avail_bytes(SramDataAvail, rx_avail_bytes);
       if (rx_avail_bytes == 0) break;
       read_host_words_rcvd(rx_avail_bytes / SRAM_WORD_SIZE, device_words_q);
       // in case data is transferred from async fifo, wait until transfer is done
       if (i == 0) begin
         csr_spinwait(.ptr(ral.async_fifo_level.rxlvl), .exp_data(0));
-        cfg.clk_rst_vif.wait_clks(2); // 2 cycle for fifo ptr to be updated
       end
     end
 

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_intr_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_intr_vseq.sv
@@ -1,0 +1,162 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// directly test all the interrupt one by one
+class spi_device_intr_vseq extends spi_device_txrx_vseq;
+  `uvm_object_utils(spi_device_intr_vseq)
+  `uvm_object_new
+
+  virtual task body();
+    spi_device_intr_e spi_dev_intr;
+    bit               is_tx_async_fifo_filled;
+
+    for (int i = 1; i <= num_trans; i++) begin
+      `DV_CHECK_RANDOMIZE_FATAL(this)
+      spi_device_init();
+
+      // fill tx async fifo to avoid sending out unknown data
+      if (!is_tx_async_fifo_filled) begin
+        bit [7:0] device_bytes_q[$];
+        // fill the fifo and wait until data is ready
+        process_tx_write(ASYNC_FIFO_SIZE);
+        csr_spinwait(.ptr(ral.async_fifo_level.txlvl), .exp_data(ASYNC_FIFO_SIZE));
+        // clean up tx fifo
+        spi_host_xfer_bytes(ASYNC_FIFO_SIZE, device_bytes_q);
+        // clean up rx fifo
+        process_rx_read(ASYNC_FIFO_SIZE);
+        // clean interrupts
+        csr_wr(.csr(ral.intr_state), .value('1));
+      end
+
+      repeat (NumSpiDevIntr) begin
+        `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(spi_dev_intr,
+                                           spi_dev_intr != NumSpiDevIntr;)
+        `uvm_info(`gfn, $sformatf("\nTesting %0s", spi_dev_intr.name), UVM_LOW)
+        drive_and_check_one_intr(spi_dev_intr);
+
+        csr_wr(.csr(ral.intr_state), .value('1));
+        check_for_tx_rx_idle();
+      end
+      `uvm_info(`gfn, $sformatf("finished run %0d/%0d", i, num_trans), UVM_LOW)
+    end
+
+  endtask : body
+
+  task drive_and_check_one_intr(spi_device_intr_e spi_dev_intr);
+    bit [7:0] device_bytes_q[$];
+    uint avail_bytes;
+
+    case (spi_dev_intr)
+      RxFifoFull, RxFifoOverflow: begin // test fifo full and overflow together
+        // just below fifo full
+        spi_host_xfer_bytes(sram_host_byte_size - SRAM_WORD_SIZE, device_bytes_q);
+        wait_for_rx_avail_bytes(sram_host_byte_size - SRAM_WORD_SIZE, SramDataAvail, avail_bytes);
+        check_interrupts(.interrupts(1 << RxFifoFull), .check_set(0));
+
+        // fifo should be full
+        spi_host_xfer_bytes(SRAM_WORD_SIZE, device_bytes_q);
+        wait_for_rx_avail_bytes(sram_host_byte_size, SramDataAvail, avail_bytes);
+        check_interrupts(.interrupts(1 << RxFifoFull), .check_set(1));
+
+        // fill async fifo and check fifo doesn't overflow
+        spi_host_xfer_bytes(ASYNC_FIFO_SIZE, device_bytes_q);
+        cfg.clk_rst_vif.wait_clks(2); // for interrupt to triggered
+        check_interrupts(.interrupts(1 << RxFifoOverflow), .check_set(0));
+
+        // fill 1 word and check fifo overflow
+        spi_host_xfer_bytes(SRAM_WORD_SIZE, device_bytes_q);
+        check_interrupts(.interrupts(1 << RxFifoOverflow), .check_set(1));
+        check_interrupts(.interrupts(1 << RxFifoGeLevel),
+                         .check_set(rx_watermark_lvl inside {[1:sram_host_byte_size]}));
+
+        // clean up rx fifo
+        process_rx_read(sram_host_byte_size + ASYNC_FIFO_SIZE);
+      end
+      RxFifoGeLevel: begin
+        uint aligned_watermark = (rx_watermark_lvl >> 2) << 2; // remove lsb 2bits
+        uint filled_bytes;
+
+        if (rx_watermark_lvl[1:0] > 0) aligned_watermark += SRAM_WORD_SIZE;
+
+        if (rx_watermark_lvl > 0 && aligned_watermark < sram_host_byte_size) begin
+          // just below watermark
+          if (aligned_watermark - SRAM_WORD_SIZE > 0) begin
+            spi_host_xfer_bytes(aligned_watermark - SRAM_WORD_SIZE, device_bytes_q);
+            wait_for_rx_avail_bytes(aligned_watermark - SRAM_WORD_SIZE, SramDataAvail, avail_bytes);
+            check_interrupts(.interrupts(1 << RxFifoGeLevel), .check_set(0));
+          end
+          // equal to watermark
+          spi_host_xfer_bytes(SRAM_WORD_SIZE, device_bytes_q);
+          wait_for_rx_avail_bytes(aligned_watermark, SramDataAvail, avail_bytes);
+          check_interrupts(.interrupts(1 << RxFifoGeLevel), .check_set(1));
+
+          // clean interrupts and test it's edge triggered
+          filled_bytes = aligned_watermark + SRAM_WORD_SIZE;
+          csr_wr(.csr(ral.intr_state), .value('1));
+          spi_host_xfer_bytes(SRAM_WORD_SIZE, device_bytes_q);
+          wait_for_rx_avail_bytes(filled_bytes, SramDataAvail, avail_bytes);
+          check_interrupts(.interrupts(1 << RxFifoGeLevel), .check_set(0));
+
+          // clean up rx fifo
+          process_rx_read(filled_bytes);
+        end
+      end
+      TxFifoLtLevel: begin
+        uint aligned_watermark = (tx_watermark_lvl >> 2) << 2; // remove lsb 2bits
+        uint filled_bytes;
+
+        if (tx_watermark_lvl[1:0] > 0) aligned_watermark += SRAM_WORD_SIZE;
+
+        if (tx_watermark_lvl == 0 || tx_watermark_lvl > sram_device_byte_size) begin // no intr
+          // fill the sram fifo and async fifo, als wait until data is ready
+          process_tx_write(sram_device_byte_size + SRAM_WORD_SIZE);
+          wait_for_tx_avail_bytes(sram_device_byte_size, SramDataAvail, avail_bytes);
+
+          // clean up tx fifo
+          spi_host_xfer_bytes(sram_device_byte_size + SRAM_WORD_SIZE, device_bytes_q);
+
+          // clean up rx fifo
+          process_rx_read(dv_utils_pkg::min2(sram_host_byte_size + ASYNC_FIFO_SIZE,
+                                             sram_device_byte_size + SRAM_WORD_SIZE));
+          // check no interrupt since tx_watermark_lvl is 0 or over the max size
+          check_interrupts(.interrupts(1 << TxFifoLtLevel), .check_set(0));
+        end else begin
+          // fill async fifo, design has 2 words depth, but only update ptr to 2nd word when 1st
+          // one is out
+          process_tx_write(SRAM_WORD_SIZE);
+          // just at watermark
+          if (aligned_watermark != 0) process_tx_write(aligned_watermark);
+          else csr_spinwait(.ptr(ral.async_fifo_level.txlvl), .exp_data(SRAM_WORD_SIZE));
+          if (aligned_watermark > ASYNC_FIFO_SIZE) begin
+            check_interrupts(.interrupts(1 << TxFifoLtLevel), .check_set(0));
+          end
+
+          // send one word and fifo is less than watermark
+          spi_host_xfer_bytes(SRAM_WORD_SIZE, device_bytes_q);
+          cfg.clk_rst_vif.wait_clks(2); // for interrupt to triggered
+          check_interrupts(.interrupts(1 << TxFifoLtLevel), .check_set(1));
+
+          // clean up tx fifo
+          if (aligned_watermark != 0) spi_host_xfer_bytes(aligned_watermark, device_bytes_q);
+
+          // clean up rx fifo
+          process_rx_read(dv_utils_pkg::min2(sram_host_byte_size + ASYNC_FIFO_SIZE,
+                                             aligned_watermark + SRAM_WORD_SIZE));
+        end
+      end
+      RxFwModeErr: begin
+        // TODO, do it later
+      end
+      TxFifoUnderflow: begin
+        // send one word when fifo is empty
+        spi_host_xfer_bytes(SRAM_WORD_SIZE, device_bytes_q);
+        cfg.clk_rst_vif.wait_clks(2); // for interrupt to triggered
+        check_interrupts(.interrupts(1 << TxFifoUnderflow), .check_set(1));
+
+        // clean up rx fifo
+        process_rx_read(SRAM_WORD_SIZE);
+      end
+    endcase
+  endtask : drive_and_check_one_intr
+endclass : spi_device_intr_vseq

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_vseq_list.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_vseq_list.sv
@@ -10,3 +10,4 @@
 `include "spi_device_fifo_underflow_overflow_vseq.sv"
 `include "spi_device_extreme_fifo_size_vseq.sv"
 `include "spi_device_dummy_item_extra_dly_vseq.sv"
+`include "spi_device_intr_vseq.sv"

--- a/hw/ip/spi_device/dv/env/spi_device_env.core
+++ b/hw/ip/spi_device/dv/env/spi_device_env.core
@@ -26,6 +26,7 @@ filesets:
       - seq_lib/spi_device_txrx_vseq.sv: {is_include_file: true}
       - seq_lib/spi_device_fifo_full_vseq.sv: {is_include_file: true}
       - seq_lib/spi_device_dummy_item_extra_dly_vseq.sv: {is_include_file: true}
+      - seq_lib/spi_device_intr_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:

--- a/hw/ip/spi_device/dv/env/spi_device_env_pkg.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env_pkg.sv
@@ -22,11 +22,12 @@ package spi_device_env_pkg;
   // local parameters and types
   typedef enum {
     RxFifoFull,
-    RxFifoGtLevel,
+    RxFifoGeLevel,
     TxFifoLtLevel,
     RxFwModeErr,
     RxFifoOverflow,
-    TxFifoUnderflow
+    TxFifoUnderflow,
+    NumSpiDevIntr
   } spi_device_intr_e;
 
   typedef enum bit {

--- a/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson
+++ b/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson
@@ -75,6 +75,11 @@
       name: spi_device_dummy_item_extra_dly
       uvm_test_seq: spi_device_dummy_item_extra_dly_vseq
     }
+
+    {
+      name: spi_device_intr
+      uvm_test_seq: spi_device_intr_vseq
+    }
   ]
 
   // List of regressions.

--- a/hw/ip/spi_device/dv/tb/tb.sv
+++ b/hw/ip/spi_device/dv/tb/tb.sv
@@ -67,7 +67,7 @@ module tb;
   assign spi_if.miso  = miso_en ? miso_o : 1'bz;
 
   assign interrupts[RxFifoFull]      = intr_rxf;
-  assign interrupts[RxFifoGtLevel]   = intr_rxlvl;
+  assign interrupts[RxFifoGeLevel]   = intr_rxlvl;
   assign interrupts[TxFifoLtLevel]   = intr_txlvl;
   assign interrupts[RxFwModeErr]     = intr_rxerr;
   assign interrupts[RxFifoOverflow]  = intr_rxoverflow;


### PR DESCRIPTION
spi_device:
1. Add interrupt seq to test interrupts directly and adjust some seq for
reuse
2. Add intr_test coverage sample
3. Fix underflow_overflow corner issue

common dv:
1. Add max2 min2 functions
2. update check_interrups function to use intr_enable

Signed-off-by: Weicai Yang <weicai@google.com>