### PR TITLE
[dv/gpio] fix errors from nightly regression

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/cip_base_vseq.sv
@@ -409,7 +409,6 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
     csr_test_type_e csr_test_type = CsrRwTest; // share the same exclusion as csr_rw_test
     uvm_reg     test_csrs[$];
     ral.get_registers(test_csrs);
-    do_clear_all_interrupts = 0; // skip checking interrupts at the end of seq
 
     for (int trans = 1; trans <= num_times; trans++) begin
       `uvm_info(`gfn, $sformatf("Running same CSR outstanding test iteration %0d/%0d",

--- a/hw/ip/gpio/data/gpio_testplan.hjson
+++ b/hw/ip/gpio/data/gpio_testplan.hjson
@@ -2,6 +2,7 @@
   name: "gpio"
   import_testplans: ["hw/dv/tools/testplans/csr_testplan.hjson",
                      "hw/dv/tools/testplans/intr_test_testplan.hjson",
+                     "hw/dv/tools/testplans/stress_all_with_reset_testplan.hjson",
                      "hw/dv/tools/testplans/tl_device_access_types_testplan.hjson"]
   entries: [
     {
@@ -97,7 +98,7 @@
             3. Drives each  GPIO pin with the mix of both synchronous and asynchronous driving,
                and each pin is driven independently of others'''
       milestone: V2
-      tests: ["gpio_filter_stress_test"]
+      tests: ["gpio_filter_stress"]
     }
     {
       name: regs_long_reads_and_writes
@@ -126,6 +127,13 @@
             - Apply hard reset'''
       milestone: V2
       tests: ["gpio_full_random"]
+    }
+    {
+      name: stress_all
+      desc: '''Stress_all test is a random mix of all the test above except csr tests, gpio full
+            random, intr_test and other gpio test that disabled scoreboard'''
+      milestone: V2
+      tests: ["gpio_stress_all"]
     }
   ]
 }

--- a/hw/ip/gpio/dv/env/gpio_scoreboard.sv
+++ b/hw/ip/gpio/dv/env/gpio_scoreboard.sv
@@ -229,6 +229,8 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
       `uvm_info(`gfn, $sformatf("cfg.gpio_vif.pins = %0h, under_reset = %0b",
                                 cfg.gpio_vif.pins, under_reset), UVM_HIGH)
       if (under_reset == 1'b0) begin
+        // wait 1 ps to allow reset() function reset the values first
+        #1ps;
         // Coverage Sampling: gpio pin values' coverage
         if (cfg.en_cov) begin
           foreach (cov.gpio_pin_values_cov_obj[each_pin]) begin
@@ -784,8 +786,6 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
     last_intr_update_except_clearing = '0;
     last_intr_test_event = '0;
     cleared_intr_bits = '0;
-    // call again to predict 'data_in_update_queue' to ensure data_in ral is updated
-    gpio_predict_and_compare();
   endfunction
 
   // Function: check_phase

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_stress_all_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_stress_all_vseq.sv
@@ -12,7 +12,8 @@ class gpio_stress_all_vseq extends gpio_base_vseq;
 
   task body();
     string seq_names[] = {"gpio_sanity_vseq",
-                          "gpio_common_vseq", // for intr_test
+                          // "gpio_common_vseq",
+                          // does not support intr_test as plus_arg disable do_clear_all_interrupts
                           "gpio_random_dout_din_vseq",
                           "gpio_dout_din_regs_random_rw_vseq",
                           "gpio_intr_rand_pgm_vseq",
@@ -26,17 +27,12 @@ class gpio_stress_all_vseq extends gpio_base_vseq;
       seq = create_seq_by_name(seq_names[seq_idx]);
       `downcast(gpio_vseq, seq)
 
-      // dut_init (reset) can be skipped
-      if (do_dut_init) gpio_vseq.do_dut_init = $urandom_range(0, 1);
-      else gpio_vseq.do_dut_init = 0;
+      // hard_reset in dut_init can be skipped
+      if (do_dut_init) gpio_vseq.do_init_reset = $urandom_range(0, 1);
+      else gpio_vseq.do_init_reset = 0;
 
       gpio_vseq.set_sequencer(p_sequencer);
       `DV_CHECK_RANDOMIZE_FATAL(gpio_vseq)
-      if (seq_names[seq_idx] == "gpio_common_vseq") begin
-        gpio_common_vseq common_vseq;
-        `downcast(common_vseq, gpio_vseq);
-        common_vseq.common_seq_type = "intr_test";
-      end
       `uvm_info(`gfn, $sformatf("seq_idx = %0d, sequence is %0s", seq_idx, gpio_vseq.get_name()),
                 UVM_HIGH)
 
@@ -45,5 +41,4 @@ class gpio_stress_all_vseq extends gpio_base_vseq;
           seq_idx), UVM_HIGH)
     end
   endtask : body
-
 endclass

--- a/hw/ip/gpio/dv/gpio_sim_cfg.hjson
+++ b/hw/ip/gpio/dv/gpio_sim_cfg.hjson
@@ -123,7 +123,17 @@
     }
 
     {
+      name: gpio_stress_all_with_rand_reset
+      run_opts: ["+do_clear_all_interrupts=0"]
+    }
+
+    {
       name: gpio_csr_rw
+      run_opts: ["+do_clear_all_interrupts=0"]
+    }
+
+    {
+      name: gpio_same_csr_outstanding
       run_opts: ["+do_clear_all_interrupts=0"]
     }
 


### PR DESCRIPTION
Fix unmapped gpio tests
Fix stress_all and stress_all_with_rand_reset errors (fix issue https://github.com/lowRISC/opentitan/issues/1096)
Update same_csr_outstanding to only disable clear_all_interrupts in gpio
tests

Signed-off-by: Cindy Chen <chencindy@google.com>