### PR TITLE
[dv/rv_timer] fix nightly coverage to 100%

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/cip_base_vseq.sv
@@ -281,7 +281,7 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
       test_index.shuffle();
       foreach (test_index[i]) begin
         bit [TL_DW-1:0] wr_data;
-        wr_data = $urandom_range(1, ((1 << intr_test_csrs[test_index[i]].get_n_used_bits()) - 1));
+        wr_data = $urandom_range(0, ((1 << intr_test_csrs[test_index[i]].get_n_used_bits()) - 1));
         // Add wr_data to expected state queue
         exp_intr_state[test_index[i]] |= wr_data;
         csr_wr(.csr(intr_test_csrs[test_index[i]]), .value(wr_data));

--- a/hw/ip/rv_timer/dv/env/rv_timer_scoreboard.sv
+++ b/hw/ip/rv_timer/dv/env/rv_timer_scoreboard.sv
@@ -193,7 +193,7 @@ class rv_timer_scoreboard extends cip_base_scoreboard #(.CFG_T (rv_timer_env_cfg
             string intr_test_str = $sformatf("intr_test%0d", i);
             if (csr_name == intr_test_str) begin
               uint intr_test_val = item.a_data;
-              foreach (intr_test_val[j]) begin
+              for (int j = 0 ; j < NUM_TIMERS; j++) begin
                 int intr_pin_idx = i * NUM_TIMERS + j;
                 if (intr_test_val[j]) intr_status_exp[i][j] = intr_test_val[j];
                 //Sample intr_test coverage for each bit of test reg


### PR DESCRIPTION
The reason it is not 100% is because currently rv_timer only has one
interrupt, but the random write value starts from 1, thus it will never
cover interrupt test write value is 0. Now change the random range to
start from 0.

Signed-off-by: Cindy Chen <chencindy@google.com>