### PR TITLE
[CI] Explicitly trigger builds on branches and PRs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,14 +11,17 @@ variables:
   BUILD_ROOT: $(Build.ArtifactStagingDirectory)
 
 trigger:
-  tags:
-    include:
-    - "*"
-  # Combine builds on master as long as another build is running
   batch: true
   branches:
     include:
-    - master
+    - '*'
+  tags:
+    include:
+    - "*"
+pr:
+  branches:
+    include:
+    - '*'
 
 jobs:
 - job: lint

--- a/ci/azp-private.yml
+++ b/ci/azp-private.yml
@@ -1,6 +1,19 @@
 # Private CI trigger.  Used to run tooling that can't currently be shared
 # publicly.
 
+trigger:
+  batch: true
+  branches:
+    include:
+    - '*'
+  tags:
+    include:
+    - "*"
+pr:
+  branches:
+    include:
+    - '*'
+
 # The runner used for private CI enforces the use of the template below. All
 # build steps need to be placed into the template.
 resources:
@@ -12,4 +25,3 @@ resources:
 
 extends:
   template: jobs.yml@opentitan-private-ci
-


### PR DESCRIPTION
Azure Pipelines doesn't trigger builds currently if trigger conditions
are not explicitly mentioned. This is against their documentation and
will be fixed on the Azure side later; until that's fixed, we can work
around it by explicitly specifying the triggers.

Fixes #1746