### PR TITLE
[sw, dif_pinmux] Introduce DIF Pinmux library with unit tests

### DIFF
--- a/sw/device/lib/dif/dif_pinmux.c
+++ b/sw/device/lib/dif/dif_pinmux.c
@@ -1,0 +1,168 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/dif/dif_pinmux.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/mmio.h"
+#include "pinmux_regs.h"  // Generated.
+
+// If either of these static assertions fail, then the assumptions in this DIF
+// implementation should be revisited. In particular, `plic_target_reg_offsets`
+// may need updating,
+_Static_assert(PINMUX_PERIPH_INSEL_IN_FIELD_WIDTH == 6,
+               "Pinmux instantiation parameters have changed.");
+_Static_assert(PINMUX_PERIPH_INSEL_IN_FIELDS_PER_REG == 5,
+               "Pinmux instantiation parameters have changed.");
+_Static_assert(PINMUX_PERIPH_INSEL_MULTIREG_COUNT == 7,
+               "Pinmux instantiation parameters have changed.");
+
+_Static_assert(PINMUX_MIO_OUTSEL_OUT_FIELD_WIDTH == 6,
+               "Pinmux instantiation parameters have changed.");
+_Static_assert(PINMUX_MIO_OUTSEL_OUT_FIELDS_PER_REG == 5,
+               "Pinmux instantiation parameters have changed.");
+_Static_assert(PINMUX_MIO_OUTSEL_MULTIREG_COUNT == 7,
+               "Pinmux instantiation parameters have changed.");
+
+#define PINMUX_INSEL_RESET_DEFAULT 0
+#define PINMUX_OUTSEL_RESET_DEFAULT 0x2082082
+
+const uint32_t kDifPinmuxPeripheralInLast = PINMUX_PARAM_NMIOPERIPHIN - 1;
+const uint32_t kDifPinmuxMioOutLast = PINMUX_PARAM_NMIOPADS - 1;
+
+#define PINMUX_INSEL_FIRST_IN 2
+const uint32_t kDifPinmuxInselFirstIn = PINMUX_INSEL_FIRST_IN;
+const uint32_t kDifPinmuxInselLast =
+    PINMUX_INSEL_FIRST_IN + (PINMUX_PARAM_NMIOPADS - 1);
+
+#define PINMUX_OUTSEL_FIRST_OUT 3
+const uint32_t kDifPinmuxOutselFirstOut = PINMUX_OUTSEL_FIRST_OUT;
+const uint32_t kDifPinmuxOutselLast =
+    PINMUX_OUTSEL_FIRST_OUT + (PINMUX_PARAM_NMIOPERIPHOUT - 1);
+
+/**
+ * Insel/outsel register offset based on a given Padring MIO/Peripheral ID.
+ */
+static ptrdiff_t multireg_offset(ptrdiff_t base, uint32_t id,
+                                 uint32_t fields_per_reg) {
+  size_t register_index = id / fields_per_reg;
+  ptrdiff_t register_offset = base + (register_index * sizeof(uint32_t));
+
+  return register_offset;
+}
+
+/**
+ * Field offset inside an insel/outsel register based on a given Padring
+ * MIO/Peripheral ID.
+ */
+static size_t multireg_field_offset(uint32_t id, uint32_t fields_per_reg,
+                                    uint32_t field_width) {
+  size_t field_index = id % fields_per_reg;
+  return field_index * field_width;
+}
+
+static void dif_pinmux_reset(const dif_pinmux_t *pinmux) {
+  // Reset all of the insel registers (multireg) to the reset value.
+  for (int i = 0; i < PINMUX_PERIPH_INSEL_MULTIREG_COUNT; ++i) {
+    ptrdiff_t register_offset =
+        PINMUX_PERIPH_INSEL0_REG_OFFSET + (i * sizeof(uint32_t));
+    mmio_region_write32(pinmux->base_addr, register_offset,
+                        PINMUX_INSEL_RESET_DEFAULT);
+  }
+
+  // Reset all of the outsel registers (multireg) to the reset value.
+  for (int i = 0; i < PINMUX_MIO_OUTSEL_MULTIREG_COUNT; ++i) {
+    ptrdiff_t register_offset =
+        PINMUX_MIO_OUTSEL0_REG_OFFSET + (i * sizeof(uint32_t));
+    mmio_region_write32(pinmux->base_addr, register_offset,
+                        PINMUX_OUTSEL_RESET_DEFAULT);
+  }
+}
+
+dif_pinmux_init_result_t dif_pinmux_init(mmio_region_t base_addr,
+                                         dif_pinmux_t *pinmux) {
+  if (pinmux == NULL) {
+    return kDifPinmuxInitBadArg;
+  }
+
+  // Check if pinmux registers are locked.
+  bool write_enabled = mmio_region_get_bit32(base_addr, PINMUX_REGEN_REG_OFFSET,
+                                             PINMUX_REGEN_WEN);
+  if (!write_enabled) {
+    return kDifPinmuxInitLocked;
+  }
+
+  pinmux->base_addr = base_addr;
+
+  dif_pinmux_reset(pinmux);
+
+  return kDifPinmuxInitOk;
+}
+
+dif_pinmux_result_t dif_pinmux_registers_lock(dif_pinmux_t *pinmux) {
+  if (pinmux == NULL) {
+    return kDifPinmuxBadArg;
+  }
+
+  mmio_region_write32(pinmux->base_addr, PINMUX_REGEN_REG_OFFSET, 0);
+
+  return kDifPinmuxOk;
+}
+
+dif_pinmux_result_t dif_pinmux_insel_set(
+    const dif_pinmux_t *pinmux, dif_pinmux_peripheral_in_t peripheral_in,
+    dif_pinmux_insel_t mio_in_select) {
+  if (pinmux == NULL || peripheral_in > kDifPinmuxPeripheralInLast ||
+      mio_in_select > kDifPinmuxInselLast) {
+    return kDifPinmuxBadArg;
+  }
+
+  size_t field_offset = multireg_field_offset(
+      peripheral_in, PINMUX_PERIPH_INSEL_IN_FIELDS_PER_REG,
+      PINMUX_PERIPH_INSEL_IN_FIELD_WIDTH);
+
+  bitfield_field32_t field = {
+      .mask = PINMUX_PERIPH_INSEL0_IN0_MASK,
+      .index = field_offset,
+      .value = mio_in_select,
+  };
+
+  ptrdiff_t register_offset =
+      multireg_offset(PINMUX_PERIPH_INSEL0_REG_OFFSET, peripheral_in,
+                      PINMUX_PERIPH_INSEL_IN_FIELDS_PER_REG);
+
+  mmio_region_nonatomic_set_field32(pinmux->base_addr, register_offset, field);
+
+  return kDifPinmuxOk;
+}
+
+dif_pinmux_result_t dif_pinmux_outsel_set(
+    const dif_pinmux_t *pinmux, dif_pinmux_mio_out_t mio_out,
+    dif_pinmux_outsel_t peripheral_out_select) {
+  if (pinmux == NULL || mio_out > kDifPinmuxMioOutLast ||
+      peripheral_out_select > kDifPinmuxOutselLast) {
+    return kDifPinmuxBadArg;
+  }
+
+  size_t field_offset =
+      multireg_field_offset(mio_out, PINMUX_MIO_OUTSEL_OUT_FIELDS_PER_REG,
+                            PINMUX_MIO_OUTSEL_OUT_FIELD_WIDTH);
+
+  bitfield_field32_t field = {
+      .mask = PINMUX_MIO_OUTSEL0_OUT0_MASK,
+      .index = field_offset,
+      .value = peripheral_out_select,
+  };
+
+  ptrdiff_t register_offset =
+      multireg_offset(PINMUX_MIO_OUTSEL0_REG_OFFSET, mio_out,
+                      PINMUX_MIO_OUTSEL_OUT_FIELDS_PER_REG);
+
+  mmio_region_nonatomic_set_field32(pinmux->base_addr, register_offset, field);
+
+  return kDifPinmuxOk;
+}

--- a/sw/device/lib/dif/dif_pinmux.h
+++ b/sw/device/lib/dif/dif_pinmux.h
@@ -1,0 +1,168 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_DIF_PINMUX_H_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_DIF_PINMUX_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/mmio.h"
+
+/**
+ * Pinmux connects peripheral input/output signals to the padring MIO
+ * input/output signals.
+ *
+ * Every peripheral input signal is fed into a multiplexer, where selects
+ * determine which padring MIO input or constants should be connected to it.
+ *
+ * Every padring MIO output signal is fed into a multiplexer, where selects
+ * determine which peripheral output or constants should be connected to it.
+ *
+ * Please refer to `https://docs.opentitan.org/hw/ip/pinmux/doc/index.html` for
+ * more information.
+ *
+ * It could be useful to refer to the Pad Control documentation
+ * `https://docs.opentitan.org/hw/ip/padctrl/doc/` for more complete
+ * understanding, as Pinmux HW is tightly coupled with Pad Control HW.
+ */
+
+/**
+ * Peripheral input signal last and the Padring MIO input signal selects last.
+ * `kDifPinmuxInselLast` is the last Padring MIO input signal + constants
+ * (constant zero, constant one).
+ */
+extern const uint32_t kDifPinmuxPeripheralInLast;
+extern const uint32_t kDifPinmuxInselFirstIn;
+extern const uint32_t kDifPinmuxInselLast;
+
+/**
+ * Peripheral input signal connection.
+ *
+ * This is an unsigned 32-bit value that is at least zero and is no more than
+ * the `kDifPinmuxPeripheralInLast` instantiation parameter of the `pinmux`
+ * device.
+ */
+typedef uint32_t dif_pinmux_peripheral_in_t;
+
+/**
+ * Padring MIO input signal connection select.
+ *
+ * This is an unsigned 32-bit value that is at least zero and is no more than
+ * the `kDifPinmuxInselLast` instantiation parameter of the `pinmux` device.
+ */
+typedef uint32_t dif_pinmux_insel_t;
+
+/**
+ * Padring MIO output signal last and the peripheral output signal selects
+ * last. `kDifPinmuxOutselLast` is the last peripheral output signal + constants
+ * (constant zero, constant one and High-Z).
+ */
+extern const uint32_t kDifPinmuxMioOutLast;
+extern const uint32_t kDifPinmuxOutselFirstOut;
+extern const uint32_t kDifPinmuxOutselLast;
+
+/**
+ * Padring MIO output signal connection.
+ *
+ * This is an unsigned 32-bit value that is at least zero and is no more than
+ * the `kDifPinmuxMioOutLast` instantiation parameter of the `pinmux` device.
+ */
+typedef uint32_t dif_pinmux_mio_out_t;
+
+/**
+ * Peripheral output signal connection select.
+ *
+ * This is an unsigned 32-bit value that is at least zero and is no more than
+ * the `kDifPinmuxOutselLast` instantiation parameter of the `pinmux` device.
+ */
+typedef uint32_t dif_pinmux_outsel_t;
+
+/**
+ * Pinmux instance state.
+ *
+ * Pinmux persistent data that is required by all the Pinmux API.
+ */
+typedef struct dif_pinmux {
+  mmio_region_t base_addr; /**< Pinmux instance base address. */
+} dif_pinmux_t;
+
+/**
+ * Pinmux generic status codes.
+ *
+ * These error codes can be used by any function. However if a function
+ * requires additional status codes, it must define a set of status codes to
+ * be used exclusively by such function.
+ */
+typedef enum dif_pinmux_result {
+  kDifPinmuxOk = 0, /**< Success. */
+  kDifPinmuxError,  /**< General error. */
+  kDifPinmuxBadArg, /**< Input parameter is not valid. */
+} dif_pinmux_result_t;
+
+/**
+ * Pinmux initialisation routine status codes.
+ */
+typedef enum dif_pinmux_init_result {
+  kDifPinmuxInitOk = kDifPinmuxOk,
+  kDifPinmuxInitError = kDifPinmuxError,
+  kDifPinmuxInitBadArg = kDifPinmuxBadArg,
+  kDifPinmuxInitLocked, /**< Peripheral registers are locked. */
+} dif_pinmux_init_result_t;
+
+/**
+ * Initialises an instance of Pinmux.
+ *
+ * Information that must be retained, and is required to program Pinmux, shall
+ * be stored in `pinmux`. When pinmux registers are locked, no register write
+ * will take any effect. The only way to unlock the pinmux registers is by the
+ * system reset.
+ *
+ * @param base_addr Base address of an instance of the Pinmux IP block
+ * @param pinmux Pinmux state data.
+ * @return `dif_pinmux_init_result_t`.
+ */
+dif_pinmux_init_result_t dif_pinmux_init(mmio_region_t base_addr,
+                                         dif_pinmux_t *pinmux);
+
+/**
+ * Locks the pinmux registers.
+ *
+ * After the registers have been locked, they can only be unlocked by the
+ * system reset.
+ *
+ * @param pinmux Pinmux state data.
+ * @return `dif_pinmux_result_t`.
+ */
+dif_pinmux_result_t dif_pinmux_registers_lock(dif_pinmux_t *pinmux);
+
+/**
+ * Sets the connection between a peripheral input and a Padring MIO input.
+ *
+ * `peripheral_input` can be connected to any available Padring MIO input.
+ *
+ * @param pinmux Pinmux state data.
+ * @param peripheral_in Peripheral input.
+ * @param mio_in_select Padring MIO input to be connected to `peripheral_input`.
+ * @return `dif_pinmux_result_t`.
+ */
+dif_pinmux_result_t dif_pinmux_insel_set(
+    const dif_pinmux_t *pinmux, dif_pinmux_peripheral_in_t peripheral_in,
+    dif_pinmux_insel_t mio_in_select);
+
+/**
+ * Sets the connection between a Padring MIO output and peripheral output.
+ *
+ * `mio_out` can be connected to any available `peripheral_select` output.
+ *
+ * @param pinmux Pinmux state data.
+ * @param mio_out Padring MIO output.
+ * @param peripheral_out_select Peripheral output select.
+ * @return `dif_pinmux_result_t`.
+ */
+dif_pinmux_result_t dif_pinmux_outsel_set(
+    const dif_pinmux_t *pinmux, dif_pinmux_mio_out_t mio_out,
+    dif_pinmux_outsel_t peripheral_out_select);
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_DIF_PINMUX_H_

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -30,6 +30,18 @@ dif_plic = declare_dependency(
   )
 )
 
+# Pinmux DIF library (dif_pinmux)
+dif_pinmux = declare_dependency(
+  link_with: static_library(
+    'sw_lib_dif_pinmux',
+    sources: [
+      'dif_pinmux.c',
+      hw_top_earlgrey_pinmux_reg_h,
+    ],
+    dependencies: [sw_lib_mmio]
+  )
+)
+
 # GPIO DIF library
 sw_lib_dif_gpio = declare_dependency(
   link_with: static_library(

--- a/sw/device/lib/meson.build
+++ b/sw/device/lib/meson.build
@@ -41,12 +41,13 @@ sw_lib_pinmux = declare_dependency(
   link_with: static_library(
     'pinmux_ot',
     sources: [
-      hw_top_earlgrey_pinmux_reg_h,
       'pinmux.c',
     ],
     dependencies: [
-      top_earlgrey,
-    ]
+      dif_pinmux,
+      sw_lib_base_log,
+      sw_lib_runtime_hart,
+    ],
   )
 )
 

--- a/sw/device/tests/dif/dif_pinmux_gpio_padctrl_sanitytest.c
+++ b/sw/device/tests/dif/dif_pinmux_gpio_padctrl_sanitytest.c
@@ -1,0 +1,64 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/dif/dif_gpio.h"
+#include "sw/device/lib/dif/dif_pinmux.h"
+
+
+#include "sw/device/lib/base/log.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/runtime/check.h"
+#include "sw/device/lib/testing/test_main.h"
+#include "sw/device/lib/testing/test_status.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
+
+static dif_pinmux_t pinmux;
+static dif_gpio_t gpio;
+
+static void difs_initialise(void) {
+  dif_gpio_config_t gpio_config = {
+    .base_addr = mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR),
+  };
+
+  dif_gpio_result_t gpio_result = dif_gpio_init(&gpio_config, &gpio);
+  CHECK(gpio_result != kDifGpioOk, "Failed to initialise GPIO");
+
+  mmio_region_t pinmux_base_addr =
+      mmio_region_from_addr(TOP_EARLGREY_PINMUX_BASE_ADDR);
+
+  dif_pinmux_init_result_t pinmux_result =
+    dif_pinmux_init(pinmux_base_addr, &pinmux);
+  CHECK(pinmux_result != kDifPinmuxInitOk, "Failed to initialise Pinmux");
+}
+
+// 
+/**
+ * Creates a connection between GPIO0 output and GPIO1 input.
+ *
+ * Pinmux creates a connection between GPIO0 and Pad Control MIO0 outputs,
+ * and GPIO1 and Pad Control MIO0 inputs. What it means in practice, is that
+ * driven value on GPIO0 can be read on GPIO1, or to put it simply:
+ * GPIO0 => MIO0 => GPIO1.
+ *
+ * Please see Pad Control documentation for more information:
+ * https://docs.opentitan.org/hw/ip/padctrl/doc/index.html#design-details
+ * In particular "pad wrapper", which explains the relationship between
+ * Pad Control internal input/output signals and the external INOUT pins. 
+ */
+void gpio0_output_to_gpio1_input(void) {
+  dif_pinmux_result_t result =
+    dif_pinmux_outsel_set(&pinmux, 0, kDifPinmuxOutselFirstOut);
+  CHECK(result != kDifPinmuxOk, "Failed to connect GPIO0 and MIO0 outputs");
+
+  result = dif_pinmux_insel_set(&pinmux, 1, kDifPinmuxInselFirstIn);
+  CHECK(result != kDifPinmuxOk, "Failed to connect GPIO1 and MIO0 inputs");
+}
+
+bool test_main(void) {
+  difs_initialise();
+  gpio0_output_to_gpio1_input();
+
+  return true;
+}

--- a/sw/device/tests/dif/dif_pinmux_test.cc
+++ b/sw/device/tests/dif/dif_pinmux_test.cc
@@ -1,0 +1,246 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/testing/mock_mmio.h"
+
+extern "C" {
+#include "sw/device/lib/dif/dif_pinmux.h"
+#include "pinmux_regs.h"  // Generated.
+}
+
+namespace dif_pinmux_test {
+namespace {
+using testing::Test;
+using mock_mmio::MmioTest;
+using mock_mmio::MockDevice;
+
+class PinmuxTest : public Test, public MmioTest {
+ protected:
+  mmio_region_t base_addr_ = dev().region();
+  dif_pinmux_t dif_pinmux_ = {
+      /* base_addr = */ base_addr_,
+  };
+};
+
+class InitTest : public PinmuxTest {
+ protected:
+  InitTest() {
+    EXPECT_EQ(insel_registers_.size(), PINMUX_PERIPH_INSEL_MULTIREG_COUNT);
+    EXPECT_EQ(outsel_registers_.size(), PINMUX_MIO_OUTSEL_MULTIREG_COUNT);
+  }
+
+  void ExpectInitReset() {
+    EXPECT_READ32(PINMUX_REGEN_REG_OFFSET, 1);
+
+    for (const auto &reg : insel_registers_) {
+      EXPECT_WRITE32(reg, 0);
+    }
+
+    for (const auto &reg : outsel_registers_) {
+      EXPECT_WRITE32(reg, 0x2082082);
+    }
+  }
+
+  std::vector<ptrdiff_t> insel_registers_{
+      PINMUX_PERIPH_INSEL0_REG_OFFSET, PINMUX_PERIPH_INSEL1_REG_OFFSET,
+      PINMUX_PERIPH_INSEL2_REG_OFFSET, PINMUX_PERIPH_INSEL3_REG_OFFSET,
+      PINMUX_PERIPH_INSEL4_REG_OFFSET, PINMUX_PERIPH_INSEL5_REG_OFFSET,
+      PINMUX_PERIPH_INSEL6_REG_OFFSET,
+  };
+
+  std::vector<ptrdiff_t> outsel_registers_{
+      PINMUX_MIO_OUTSEL0_REG_OFFSET, PINMUX_MIO_OUTSEL1_REG_OFFSET,
+      PINMUX_MIO_OUTSEL2_REG_OFFSET, PINMUX_MIO_OUTSEL3_REG_OFFSET,
+      PINMUX_MIO_OUTSEL4_REG_OFFSET, PINMUX_MIO_OUTSEL5_REG_OFFSET,
+      PINMUX_MIO_OUTSEL6_REG_OFFSET,
+  };
+};
+
+TEST_F(InitTest, NullArgs) {
+  EXPECT_EQ(dif_pinmux_init(base_addr_, nullptr), kDifPinmuxBadArg);
+}
+
+TEST_F(InitTest, RegistersLocked) {
+  EXPECT_READ32(PINMUX_REGEN_REG_OFFSET, 0);
+
+  EXPECT_EQ(dif_pinmux_init(base_addr_, &dif_pinmux_), kDifPinmuxInitLocked);
+}
+
+TEST_F(InitTest, Success) {
+  ExpectInitReset();
+
+  EXPECT_EQ(dif_pinmux_init(base_addr_, &dif_pinmux_), kDifPinmuxInitOk);
+}
+
+class RegistersLockTest : public PinmuxTest {};
+
+TEST_F(RegistersLockTest, NullArgs) {
+  EXPECT_EQ(dif_pinmux_registers_lock(nullptr), kDifPinmuxBadArg);
+}
+
+TEST_F(RegistersLockTest, Success) {
+  EXPECT_WRITE32(PINMUX_REGEN_REG_OFFSET, 0);
+
+  EXPECT_EQ(dif_pinmux_registers_lock(&dif_pinmux_), kDifPinmuxOk);
+}
+
+class SetTests : public PinmuxTest {
+ protected:
+  // Tests should not rely on DIF defined constants and defines for setting
+  // expectations.
+  static constexpr uint32_t kExpectConstantZero = 0;
+
+  static constexpr uint32_t kExpectInselFirstIn = 2;
+  static constexpr uint32_t kExpectInselLastIn =
+      kExpectInselFirstIn + (PINMUX_PARAM_NMIOPADS - 1);
+
+  static constexpr uint32_t kExpectOutselFirstOut = 3;
+  static constexpr uint32_t kExpectOutselLastOut =
+      kExpectOutselFirstOut + (PINMUX_PARAM_NMIOPERIPHOUT - 1);
+
+  struct Register {
+    ptrdiff_t offset;    // Register offset from the base.
+    uint8_t last_field;  // Last field offset in the register.
+  };
+
+  // Set multireg expectations, one field per call for every multireg register.
+  void ExpectSetTests(const std::vector<Register> &regs, uint32_t field_width,
+                      uint32_t field_mask, uint32_t value) {
+    for (const auto &reg : regs) {
+      for (uint32_t i = 0; i <= reg.last_field; i += field_width) {
+        EXPECT_MASK32(reg.offset, {{i, field_mask, value}});
+      }
+    }
+  }
+};
+
+class InselSet : public SetTests {
+ protected:
+  InselSet() {
+    EXPECT_EQ(registers_.size(), PINMUX_PERIPH_INSEL_MULTIREG_COUNT);
+  }
+
+  std::vector<Register> registers_ = {
+      {
+          PINMUX_PERIPH_INSEL0_REG_OFFSET, PINMUX_PERIPH_INSEL0_IN4_OFFSET,
+      },
+      {
+          PINMUX_PERIPH_INSEL1_REG_OFFSET, PINMUX_PERIPH_INSEL1_IN9_OFFSET,
+      },
+      {
+          PINMUX_PERIPH_INSEL2_REG_OFFSET, PINMUX_PERIPH_INSEL2_IN14_OFFSET,
+      },
+      {
+          PINMUX_PERIPH_INSEL3_REG_OFFSET, PINMUX_PERIPH_INSEL3_IN19_OFFSET,
+      },
+      {
+          PINMUX_PERIPH_INSEL4_REG_OFFSET, PINMUX_PERIPH_INSEL4_IN24_OFFSET,
+      },
+      {
+          PINMUX_PERIPH_INSEL5_REG_OFFSET, PINMUX_PERIPH_INSEL5_IN29_OFFSET,
+      },
+      {
+          PINMUX_PERIPH_INSEL6_REG_OFFSET, PINMUX_PERIPH_INSEL6_IN31_OFFSET,
+      },
+  };
+};
+
+TEST_F(InselSet, NullArgs) {
+  EXPECT_EQ(dif_pinmux_insel_set(nullptr, 0, 0), kDifPinmuxBadArg);
+}
+
+TEST_F(InselSet, BadArgs) {
+  EXPECT_EQ(dif_pinmux_insel_set(&dif_pinmux_, 0, kDifPinmuxInselLast + 1),
+            kDifPinmuxBadArg);
+
+  EXPECT_EQ(
+      dif_pinmux_insel_set(&dif_pinmux_, kDifPinmuxPeripheralInLast + 1, 0),
+      kDifPinmuxBadArg);
+}
+
+TEST_F(InselSet, Success) {
+  // Set first MIO select variant for every multireg register.
+  ExpectSetTests(registers_, PINMUX_PERIPH_INSEL_IN_FIELD_WIDTH,
+                 PINMUX_PERIPH_INSEL0_IN0_MASK, kExpectConstantZero);
+
+  for (dif_pinmux_peripheral_in_t i = 0; i <= kDifPinmuxPeripheralInLast; ++i) {
+    EXPECT_EQ(dif_pinmux_insel_set(&dif_pinmux_, i, 0), kDifPinmuxOk);
+  }
+
+  // Set the last MIO select variant for every multireg register.
+  ExpectSetTests(registers_, PINMUX_PERIPH_INSEL_IN_FIELD_WIDTH,
+                 PINMUX_PERIPH_INSEL0_IN0_MASK, kDifPinmuxInselLast);
+
+  for (dif_pinmux_peripheral_in_t i = 0; i <= kDifPinmuxPeripheralInLast; ++i) {
+    EXPECT_EQ(dif_pinmux_insel_set(&dif_pinmux_, i, kExpectInselLastIn),
+              kDifPinmuxOk);
+  }
+}
+
+class OutselSet : public SetTests {
+ protected:
+  OutselSet() {
+    EXPECT_EQ(registers_.size(), PINMUX_MIO_OUTSEL_MULTIREG_COUNT);
+  }
+
+  std::vector<Register> registers_ = {
+      {
+          PINMUX_MIO_OUTSEL0_REG_OFFSET, PINMUX_MIO_OUTSEL0_OUT4_OFFSET,
+      },
+      {
+          PINMUX_MIO_OUTSEL1_REG_OFFSET, PINMUX_MIO_OUTSEL1_OUT9_OFFSET,
+      },
+      {
+          PINMUX_MIO_OUTSEL2_REG_OFFSET, PINMUX_MIO_OUTSEL2_OUT14_OFFSET,
+      },
+      {
+          PINMUX_MIO_OUTSEL3_REG_OFFSET, PINMUX_MIO_OUTSEL3_OUT19_OFFSET,
+      },
+      {
+          PINMUX_MIO_OUTSEL4_REG_OFFSET, PINMUX_MIO_OUTSEL4_OUT24_OFFSET,
+      },
+      {
+          PINMUX_MIO_OUTSEL5_REG_OFFSET, PINMUX_MIO_OUTSEL5_OUT29_OFFSET,
+      },
+      {
+          PINMUX_MIO_OUTSEL6_REG_OFFSET, PINMUX_MIO_OUTSEL6_OUT31_OFFSET,
+      },
+  };
+};
+
+TEST_F(OutselSet, NullArgs) {
+  EXPECT_EQ(dif_pinmux_outsel_set(nullptr, 0, 0), kDifPinmuxBadArg);
+}
+
+TEST_F(OutselSet, BadArgs) {
+  EXPECT_EQ(dif_pinmux_outsel_set(&dif_pinmux_, kDifPinmuxMioOutLast + 1, 0),
+            kDifPinmuxBadArg);
+
+  EXPECT_EQ(dif_pinmux_outsel_set(&dif_pinmux_, 0, kDifPinmuxOutselLast + 1),
+            kDifPinmuxBadArg);
+}
+
+TEST_F(OutselSet, Success) {
+  // Set first peripheral select variant for every multireg register.
+  ExpectSetTests(registers_, PINMUX_MIO_OUTSEL_OUT_FIELD_WIDTH,
+                 PINMUX_MIO_OUTSEL0_OUT0_MASK, kExpectConstantZero);
+
+  for (dif_pinmux_mio_out_t i = 0; i <= kDifPinmuxMioOutLast; ++i) {
+    EXPECT_EQ(dif_pinmux_outsel_set(&dif_pinmux_, i, 0), kDifPinmuxOk);
+  }
+
+  // Set the last peripehral select variant for every multireg register.
+  ExpectSetTests(registers_, PINMUX_MIO_OUTSEL_OUT_FIELD_WIDTH,
+                 PINMUX_MIO_OUTSEL0_OUT0_MASK, kExpectOutselLastOut);
+
+  for (dif_pinmux_mio_out_t i = 0; i <= kDifPinmuxMioOutLast; ++i) {
+    EXPECT_EQ(dif_pinmux_outsel_set(&dif_pinmux_, i, kDifPinmuxOutselLast),
+              kDifPinmuxOk);
+  }
+}
+
+}  // namespace
+}  // namespace dif_pinmux_test

--- a/sw/device/tests/dif/meson.build
+++ b/sw/device/tests/dif/meson.build
@@ -82,6 +82,22 @@ test('dif_gpio_unittest', executable(
   cpp_args: ['-DMOCK_MMIO'],
 ))
 
+test('dif_pinmux_test', executable(
+  'dif_pinmux_test',
+  sources: [
+    'dif_pinmux_test.cc',
+    hw_top_earlgrey_pinmux_reg_h,
+    meson.source_root() / 'sw/device/lib/dif/dif_pinmux.c',
+  ],
+  dependencies: [
+    sw_vendor_gtest,
+    sw_lib_testing_mock_mmio,
+  ],
+  native: true,
+  c_args: ['-DMOCK_MMIO'], 
+  cpp_args: ['-DMOCK_MMIO'],
+))
+
 dif_plic_sanitytest_lib = declare_dependency(
   link_with: static_library(
     'dif_plic_sanitytest_lib',

--- a/sw/device/tests/dif/meson.build
+++ b/sw/device/tests/dif/meson.build
@@ -114,4 +114,22 @@ dif_plic_sanitytest_lib = declare_dependency(
   ),
 )
 
-sw_tests += { 'dif_plic_sanitytest': dif_plic_sanitytest_lib }
+dif_pinmux_gpio_padctrl_sanitytest_lib = declare_dependency(
+  link_with: static_library(
+    'dif_pinmux_gpio_padctrl_sanitytest_lib',
+    sources: ['dif_pinmux_gpio_padctrl_sanitytest.c'],
+    dependencies: [
+      dif_pinmux,
+      sw_lib_dif_gpio,
+      sw_lib_mmio,
+      sw_lib_base_log,
+      sw_lib_runtime_hart,
+      sw_lib_testing_test_status,
+    ],
+  ),
+)
+
+sw_tests += {
+  'dif_plic_sanitytest': dif_plic_sanitytest_lib,
+  'dif_pinmux_gpio_padctrl_sanitytest': dif_pinmux_gpio_padctrl_sanitytest_lib,
+}


### PR DESCRIPTION
This PR:
- Introduces DIF Pinmux library.
- Introduces DIF Pinmux library unit tests.
- Change the current Pinmux "driver" to use the DIF Pinmux.

NOTE:
This DIF is not complete - the corresponding IP is being extended to include sleep/wake-up and other functionality. However, adding new features to the Pinmux IP does not affect the existing registers and functionality (**meaning that the current functionality will not need to be changed, only extended**).