### PR TITLE
[usb/doc] Revise documenation

### DIFF
--- a/hw/ip/usbdev/data/usbdev.hjson
+++ b/hw/ip/usbdev/data/usbdev.hjson
@@ -32,27 +32,33 @@
   ],
   interrupt_list: [
     { name: "pkt_received"
-      desc: "raised if a packet was received using an OUT or SETUP transaction."}
+      desc: '''
+            Raised if a packet was received using an OUT or SETUP transaction.
+            '''
+    }
     { name: "pkt_sent"
-      desc: "raised if a packet was sent as part of an IN transaction."}
+      desc: '''
+            Raised if a packet was sent as part of an IN transaction.
+            '''
+    }
     { name: "disconnected",
-      desc: "Raised if VBUS is lost thus the link is disconnected"}
+      desc: '''
+            Raised if VBUS is lost thus the link is disconnected.
+            '''
+    }
     { name: "host_lost",
       desc: '''
-            Raised if link is active but start of frame not received from
-            host for 4.096ms. The SOF should be every 1ms.
+            Raised if link is active but SOF was not received from host for 4.096 ms. The SOF should be every 1 ms.
             '''
     }
     { name: "link_reset",
       desc: '''
-            Raised if the link is at SE0 longer than 3us indicating a link
-            reset (host asserts for min 10ms, device can react after 2.5us).
+            Raised if the link is at SE0 longer than 3 us indicating a link reset (host asserts for min 10 ms, device can react after 2.5 us).
             '''
     }
     { name: "link_suspend",
       desc: '''
-            Raised if the line has signalled J for longer than 3ms and is
-            therefore in suspend state.
+            Raised if the line has signaled J for longer than 3ms and is therefore in suspend state.
             '''
     }
     { name: "link_resume",
@@ -62,20 +68,17 @@
     }
     { name: "av_empty",
       desc: '''
-            Raised when a transaction is NACKed because the AVBuffer FIFO
-            for OUT or SETUP transactions is empty.
+            Raised when a transaction is NACKed because the Available Buffer FIFO for OUT or SETUP transactions is empty.
             '''
     }
     { name: "rx_full",
       desc: '''
-            Raised when a transaction is NACKed because the Receive FIFO
-            for OUT or SETUP transactions is full.
+            Raised when a transaction is NACKed because the Received Buffer FIFO for OUT or SETUP transactions is full.
             '''
     }
     { name: "av_overflow",
       desc: '''
-            Raised if a write was done to the AVBuffer fifo when the
-            FIFO was full.
+            Raised if a write was done to the Available Buffer FIFO when the FIFO was full.
             '''
     }
     { name: "link_in_err",
@@ -94,7 +97,7 @@
     }
     { name: "rx_pid_err",
       desc: '''
-            Raised if an invalid PID was received.
+            Raised if an invalid packed identifier (PID) was received.
             '''
     }
     { name: "rx_bitstuff_err",
@@ -104,7 +107,7 @@
     }
     { name: "frame",
       desc: '''
-            Raised when the USB frame number is updated with a valid SOF frame.
+            Raised when the USB frame number is updated with a valid SOF.
             '''
     }
     { name: "connected",
@@ -122,8 +125,8 @@
           bits: "0",
           name: "enable",
           desc: '''
-               Set to enable the USB interface and assert the FS pullup.
-          '''
+                Set to enable the USB interface and assert the pullup.
+                '''
           tags: [// Prevent usb from being enabled to avoid other unforeseen side effects.
                  "excl:CsrNonInitTests:CsrExclWrite"]
         }
@@ -136,7 +139,7 @@
                 the Set Device ID SETUP packet).
 
                 This will be zeroed by the hardware when the link resets.
-          '''
+                '''
           tags: [// This field is reset to 0 if usb is not enabled.
                  "excl:CsrNonInitTests:CsrExclWriteCheck"]
         }
@@ -152,16 +155,14 @@
           bits: "10:0",
           name: "frame",
           desc: '''
-                Frame index received from host. On an active link this
-                will increment every milisecond.
+                Frame index received from host. On an active link, this will increment every milisecond.
                 '''
         }
         {
           bits: "11",
           name: "host_lost",
           desc: '''
-                Start of frame not received from host for 4.096ms
-                and the line is active.
+                Start of frame not received from host for 4.096 ms and the line is active.
                 '''
         }
         {
@@ -181,7 +182,7 @@
             },
             { value: "2",
               name: "powered_suspend",
-              desc: "Link suspended (constant idle for > 3ms), but not reset yet"
+              desc: "Link suspended (constant idle/J for > 3 ms), but not reset yet"
             },
             { value: "3",
               name: "active",
@@ -189,7 +190,7 @@
             },
             { value: "4",
               name: "suspend",
-              desc: "Link suspended (constant idle for > 3ms)"
+              desc: "Link suspended (constant idle for > 3 ms), was active before becoming suspended"
             },
 
           ]
@@ -198,15 +199,14 @@
           bits: "15",
           name: "sense",
           desc: '''
-                Refelects the state of the sense pin. 1 indicates that
-                the host is providing VBUS.
+                Reflects the state of the sense pin. 1 indicates that the host is providing VBUS.
                 '''
         }
         {
           bits: "18:16",
           name: "av_depth",
           desc: '''
-                Number of buffers in the Available-Buffer FIFO.
+                Number of buffers in the Available Buffer FIFO.
 
                 These buffers are available for receiving packets.
                 '''
@@ -214,13 +214,15 @@
         {
           bits: "23",
           name: "av_full",
-          desc: "Available buffers FIFO is full"
+          desc: '''
+                Available Buffer FIFO is full.
+                '''
         }
         {
           bits: "26:24",
           name: "rx_depth",
           desc: '''
-                Number of buffers in the Receive FIFO.
+                Number of buffers in the Received Buffer FIFO.
 
                 These buffers have packets that have been received and
                 should be popped from the FIFO and processed.
@@ -230,7 +232,9 @@
           bits: "31",
           name: "rx_empty",
           resval: "1",
-          desc: "Receive FIFO is empty"
+          desc: '''
+                Received Buffer FIFO is empty.
+                '''
         }
       ]
     }
@@ -244,10 +248,9 @@
           bits: "4:0",
           name: "buffer",
           desc: '''
-                This field contains the buffer number being passed to the
-                USB receive engine.
+                This field contains the buffer ID being passed to the USB receive engine.
 
-                If the FIFO is full then the write is discarded.
+                If the Available Buffer FIFO is full, any write operations are discarded.
                 '''
         }
       ]
@@ -255,7 +258,7 @@
              "excl:CsrNonInitTests:CsrExclWrite"]
     }
     { name: "rxfifo",
-      desc: "Received packet FIFO",
+      desc: "Received Buffer FIFO",
       swaccess: "ro",
       hwaccess: "hrw",
       hwext: "true",
@@ -265,33 +268,29 @@
           bits: "4:0",
           name: "buffer",
           desc: '''
-                This field contains the buffer number that data was received
-                into. On read the buffer is popped from the FIFO and returned
-                to software.
+                This field contains the buffer ID that data was received into.
+                On read the buffer ID is popped from the Received Buffer FIFO and returned to software.
                 '''
         }
         {
           bits: "14:8",
           name: "size",
           desc: '''
-                This field contains the size in bytes of the packet written
-                to the buffer.
+                This field contains the data lenght in bytes of the packet written to the buffer.
                 '''
         }
         {
           bits: "19",
           name: "setup",
           desc: '''
-                This field indicates the type of transaction received. It is
-                set for a SETUP transaction and clear for an OUT transaction.
+                This bit indicates if the received transaction is of type SETUP (1) or OUT (0).
                 '''
         }
         {
           bits: "23:20",
           name: "ep",
           desc: '''
-                This field contains the Endpoint to which the packet was
-                directed.
+                This field contains the endpoint ID to which the packet was directed.
                 '''
         }
       ]
@@ -365,18 +364,13 @@
         hwaccess: "hrw",
         fields: [
           {
-                bits: "0",
-                name: "stall",
-                desc: '''
-                      If this bit is set then an IN or OUT
-                      transaction to this endpoint will be responded to
-                      with a STALL return. This is used when the endpoint
-                      is disabled (functional stall) or when a control transfer
-                      is not supported (protocol stall). SETUP transactions
-                      are always accepted and a SETUP will clear the stall
-                      flag (this is necessary for protocol stalls, to avoid
-                      sending stalls on subsequent IN/OUT transfers).
-                      '''
+            bits: "0",
+            name: "stall",
+            desc: '''
+                  If this bit is set then an IN or OUT transaction to this endpoint will be responded to with a STALL return.
+                  This is used when the endpoint is disabled (functional stall) or when a control transfer is not supported (protocol stall).
+                  SETUP transactions are always accepted and a SETUP will clear the stall flag (this is necessary for protocol stalls, to avoid sending stalls on subsequent IN/OUT transfers).
+                  '''
           }
         ]
       }
@@ -393,8 +387,7 @@
             bits: "4:0",
             name: "buffer",
             desc: '''
-                  The buffer number containing the data to send when
-                  an IN transaction is received on the Endpoint.
+                  The buffer ID containing the data to send when an IN transaction is received on the endpoint.
                   '''
           }
           {
@@ -427,17 +420,14 @@
             name: "rdy",
             hwaccess: "hrw"
             desc: '''
-                  This bit should be set to indicate the buffer is ready
-                  for sending. It will be cleared when the ACK is received
-                  indicating the host has accepted the data.
+                  This bit should be set to indicate the buffer is ready for sending.
+                  It will be cleared when the ACK is received indicating the host has accepted the data.
 
-                  This bit will also be cleared if an enabled SETUP
-                  transaction is received on the Endpoint. This allows
-                  use of the IN channel for transfer of SETUP information.
-                  The original buffer must be resubmitted after the SETUP
-                  sequence is complete. A link reset also clears the bit.
-                  In either of the cases where the hardware cancels the
-                  transaction it will also set the pend bit.
+                  This bit will also be cleared if an enabled SETUP transaction is received on the endpoint.
+                  This allows use of the IN channel for transfer of SETUP information.
+                  The original buffer must be resubmitted after the SETUP sequence is complete.
+                  A link reset also clears the bit.
+                  In either of the cases where the hardware cancels the transaction it will also set the pend bit.
                   '''
           }
         ]
@@ -452,14 +442,12 @@
         hwaccess: "hro",
         fields: [
           {
-                bits: "0",
-                name: "iso",
-                desc: '''
-                      If this bit is set then the endpoint will be treated
-                      as an ISO endpoint. No handshake packet will be sent
-                      for an OUT transaction and no handshake packet will be
-                      expected for an IN transaction.
-                      '''
+            bits: "0",
+            name: "iso",
+            desc: '''
+                  If this bit is set then the endpoint will be treated as an ISO endpoint.
+                  No handshake packet will be sent for an OUT transaction and no handshake packet will be expected for an IN transaction.
+                  '''
           }
         ]
       }
@@ -474,13 +462,12 @@
         hwqe: "true",
         fields: [
           {
-                bits: "0",
-                name: "clear",
-                desc: '''
-                      Writing 1 to this bit will clear the data toggle bit for
-                      this endpoint to Data0 in both IN and OUT directions.
-                      The register must no be written again within 200 ns.
-                      '''
+            bits: "0",
+            name: "clear",
+            desc: '''
+                  Writing 1 to this bit will clear the data toggle bit for this endpoint to Data0 in both IN and OUT directions.
+                  The register must no be written again within 200 ns.
+                  '''
           }
         ]
       }
@@ -495,39 +482,42 @@
           resval: "0",
           name: "rx_differential_mode",
           desc: '''
-               Use the differential RX signal instead of the single ended signals.
-               Currently only 0 (single-ended operation) is supported.
-          '''
+                Use the differential RX signal instead of the single-ended signals.
+                Currently only 0 (single-ended operation) is supported.
+                '''
         }
         {
           bits: "1",
           resval: "0",
           name: "tx_differential_mode",
           desc: '''
-               Use the differential TX signal instead of the single ended signals.
-               Currently only 0 (single-ended operation) is supported.
-          '''
+                Use the differential TX signal instead of the single-ended signals.
+                Currently only 0 (single-ended operation) is supported.
+                '''
         }
         {
           bits: "2",
           name: "eop_single_bit",
           resval: "1",
           desc: '''
-               Recognize a single SE0 bit as an end of packet, otherwise two
-               successive bits are required.
-          '''
+                Recognize a single SE0 bit as an end of packet, otherwise two successive bits are required.
+                '''
         }
         {
           bits: "3",
           name: "override_pwr_sense_en",
-          desc: "Override the USB Power sense value with override_pwr_sense_val."
+          desc: '''
+                Override the USB power sense value with override_pwr_sense_val.
+                '''
           tags: [// Overriding pwr sense will cause the usbdev to think the link is powered up.
                  "excl:CsrNonInitTests:CsrExclWrite"]
         }
         {
           bits: "4",
           name: "override_pwr_sense_val",
-          desc: "0: USB power not present, 1: present."
+          desc: '''
+                0: USB power not present, 1: present.
+                '''
         }
       ]
     }
@@ -540,7 +530,7 @@
         unusual: "false"
         swaccess: "rw",
         desc: '''
-              2kB packet buffer. Divided into 32 64-byte packets.
+              2 kB packet buffer. Divided into 32 64-byte buffers.
 
               The packet buffer is used for sending and receiveing packets.
               '''

--- a/hw/ip/usbdev/doc/_index.md
+++ b/hw/ip/usbdev/doc/_index.md
@@ -1,65 +1,58 @@
 ---
-title: "Simple USB Full Speed Device IP Technical Specification"
+title: "USB 2.0 Full-Speed Device HWIP Technical Specification"
 ---
 
 # Overview
 
+This document specifies the USB device hardware IP functionality.
+This IP block implements a Full-Speed device according to the [USB 2.0 specification.](https://www.usb.org/document-library/usb-20-specification)
+It is attached to the chip interconnect bus as a peripheral module and conforms to the [Comportable guideline for peripheral functionality.]({{< relref "doc/rm/comportability_specification" >}})
 
 
 ## Features
 
-- USB Full-Speed (12Mbps) Device interface
+The IP block implements the following features:
 
-- 2kbyte Interface buffer
-
-- Up to 12 Endpoints (including required Endpoint 0)
-
-- Support for USB packet size up to 64 bytes
-
+- USB 2.0 Full-Speed (12 Mbps) Device interface
+- 2 kB interface buffer
+- Up to 12 endpoints (including required Endpoint 0), configurable using a compile-time Verilog parameter
+- Support for USB packet sizes up to 64 bytes
 - Support SETUP, IN and OUT transactions
-
 - Support for Bulk, Control, Interrupt and Isochronous endpoints and transactions
-
-- Initial version does not support Isochronous transfers larger than
-  64 bytes (later extension)
-
 - Streaming possible through software
-
 - Interrupts for packet reception and transmission
+
+Isochronous transfers larger than 64 bytes are currently not supported.
+This feature might be added in a later version of this IP.
 
 
 ## Description
 
-The USB device module is a simple software-driven gneric USB device
-interface for Full-Speed USB operation. The IP includes the physical
-layer interface (switchable between regular 3.3V I/O pads, or a differential
-USB transceiver), the low level USB protocol and a packet
-buffer interface to the software.
+The USB device module is a simple software-driven generic USB device interface for Full-Speed USB 2.0 operation.
+The IP includes the physical layer interface, the low level USB protocol and a packet buffer interface to the software.
+The physical layer interface features both differential and single-ended transmit and receive paths to allow interfacing with a variety of USB PHYs or regular 3.3V IO pads for FPGA prototyping.
 
 
 ## Compatibility
 
-The USB device programming interface is not based on any existing
-interface.
+The USB device programming interface is not based on any existing interface.
 
 
 # Theory of Operations
 
-A useful quick reference for USB Full-Speed is
-[http://www.usbmadesimple.co.uk/ums_3.htm](http://www.usbmadesimple.co.uk/ums_3.htm)
+A useful quick reference for USB Full-Speed is [USB Made Simple, Part 3 - Data Flow.](http://www.usbmadesimple.co.uk/ums_3.htm)
 
-The block diagram shows a high level view of the simple USB Device
-including the main register access paths.
+The block diagram shows a high level view of the USB device including the main register access paths.
 
 ![Block Diagram](usbdev_block.svg "image_tooltip")
 
 
 ## Clocking
 
-The USB Full-Speed interface runs at a 12MHz datarate. 
-The interface runs at four times this and must be clocked from an accurate 48MHz clock source. 
-The USB specification for a Full-Speed device requires the average bit-rate is 12Mbps +/- 0.25%, so the clock needs to support maximum error of 2,500ppm.  
-The maximum allowable integrated jitter is +/- 1ns over 1 to 7 bit-periods.
+The USB Full-Speed interface runs at a data rate of 12 MHz.
+The interface runs at four times this frequency and must be clocked from an accurate 48 MHz clock source.
+The USB specification for a Full-Speed device requires the average bit rate is 12 Mbps +/- 0.25%, so the clock needs to support maximum error of 2,500 ppm.
+The maximum allowable integrated jitter is +/- 1 ns over 1 to 7 bit periods.
 
 Control transfers pass through asynchronous FIFOs or have a ready bit
 synchronized across the clock domain boundary. A dual-port
@@ -122,7 +115,7 @@ The USB device features the following non-data pins.
 |----------------|------------------|-------|
 | sense (VBUS)   | sense_i          | The sense pin indicates the presence of VBUS from the USB host. |
 | [pullup]       | pullup_o         | When the pullup_o asserts a 1.5k pullup resistor should be connected to D+. This can be done inside the chip or with an external pin. A permanently connected resistor can also be used. |
-| [suspend]      | suspend_o        | The suspend pin indicates to the USB transceiver that a constant idle has been detected on the link and the device is in the Suspended state (see Section 7.1.7.6 of the [USB 2.0 specification](https://www.usb.org/document-library/usb-20-specification)). |
+| [suspend]      | suspend_o        | The suspend pin indicates to the USB transceiver that a constant idle has been detected on the link and the device is in the Suspend state (see Section 7.1.7.6 of the [USB 2.0 specification](https://www.usb.org/document-library/usb-20-specification)). |
 
 The USB host will identify itself to the device by enabling the 5V VBUS power.
 It may do a hard reset of a port by removing and reasserting VBUS (the Linux driver will do this when it finds a port in an inconsistent state or a port that generates errors during enumeration).
@@ -144,111 +137,94 @@ Alternatively, it can be used to enable an internal 1.5k pullup on the D+ pin.
 
 ## USB Link State
 
-The USB link has a number of states. 
-These are detected and reported in {{< regref "usbstat.link_state" >}} and state changes are reported using interrupts. 
-The FSM implements a subset of the USB device state diagram shown in Figure 9-1 of the USB 2.0 specification.
+The USB link has a number of states.
+These are detected and reported in {{< regref "usbstat.link_state" >}} and state changes are reported using interrupts.
+The FSM implements a subset of the USB device state diagram shown in Figure 9-1 of the [USB 2.0 specification.](https://www.usb.org/document-library/usb-20-specification)
 
 |State| Description |
 |-----|-------------|
-|Disconnected | The link is disconnected. This is signalled when the VBUS is not driven by the host, which results in the sense input pin being low. An interrupt is raised on entering this state.|
-|Powered| The device has been powered as VBUS is being driven by the host, but has not been reset yet. The link is reset whenever the D+ and D- are both low (an SE0 condition) for an extended period. The host will assert reset for a minumum of 10ms, but the USB specification allows the device to detect and respond to a reset after 2.5us. The implementation here will report the reset state and raise an interrupt when the link is in SE0 for 3us.|
-|Powered Suspend| The link is suspended when at idle (a J condition) for more than 3ms. An interrupt is generated when the suspend is detected and a resume interrupt is generated when the link exits the suspend state. This state is entered, if the device has not been reset yet.|
-|Active| The link is active when it is running normally|
-|Suspened| Similar to 'Powered Suspend', but the device was in the active state before being suspended.|
+|Disconnect | The link is disconnected. This is signaled when the VBUS is not driven by the host, which results in the sense input pin being low. An interrupt is raised on entering this state.|
+|Powered| The device has been powered as VBUS is being driven by the host, but has not been reset yet. The link is reset whenever the D+ and D- are both low (an SE0 condition) for an extended period. The host will assert reset for a minimum of 10 ms, but the USB specification allows the device to detect and respond to a reset after 2.5 us. The implementation here will report the reset state and raise an interrupt when the link is in SE0 for 3 us.|
+|Powered Suspend| The link is suspended when at idle (a J condition) for more than 3 ms. An interrupt is generated when the suspend is detected and a resume interrupt is generated when the link exits the suspend state. This state is entered, if the device has not been reset yet.|
+|Active| The link is active when it is running normally. |
+|Suspend| Similar to 'Powered Suspend', but the device was in the active state before being suspended.|
 
 |Link Events| Description |
 |-----------|-------------|
 |Disconnect| VBUS has been lost. |
-|Link Reset| The link has been in the SE0 state for 3us.|
-|Link Suspend| The link has been in the J state for more than 3ms, upon which we have to enter the suspend state.|
-|Link Resume| The link has been driven to a non-J state after being in suspend.|
-|Host Lost| The host lost interrupt will be signalled if the link is active but a start of frame has not been received from the host in 4.096ms. The host is required to send a SOF every 1ms. This is not an expected condition.|
+|Link Reset| The link has been in the SE0 state for 3 us.|
+|Link Suspend| The link has been in the J state for more than 3 ms, upon which we have to enter the Suspend state.|
+|Link Resume| The link has been driven to a non-J state after being in Suspend.|
+|Host Lost| Signaled using an interrupt if the link is active but a start of frame (SOF) packet has not been received from the host in 4.096 ms. The host is required to send a SOF packet every 1 ms. This is not an expected condition.|
 
 
 ## USB Protocol Engine
 
-The USB 2.0 Full Speed Protocol Engine is provided by the common USB
-interface code and is not part of this module.
+The USB 2.0 Full-Speed Protocol Engine is provided by the common USB interface code and is, strictly speaking, not part of this USB device module.
 
-At the lowest level of the USB stack the transmit bitstream is serialized, converted to NRZI encoding with bit-stuffing and sent to the transmitter. 
-The received bitstream is recovered, clock aligned and decoded and has bit-stuffing removed. 
+At the lowest level of the USB stack the transmit bitstream is serialized, converted to non-return-to-zero inverted (NRZI) encoding with bit-stuffing and sent to the transmitter.
+The received bitstream is recovered, clock aligned and decoded and has bit-stuffing removed.
 The recovered clock alignment is used for transmission.
 
-The higher level protocol engine forms the bitstream into packets,
-performs CRC checking and recognizes IN, OUT and SETUP
-transactions. These are presented without buffering to this module
-which must accept or provide data when requested. The protocol engine
-may cancel a transaction because of a bad CRC or request a retry if an
-ACK was not received.
+The higher level protocol engine forms the bitstream into packets, performs CRC checking and recognizes IN, OUT and SETUP transactions.
+These are presented to this module without buffering.
+This means the USB device module must accept or provide data when requested.
+The protocol engine may cancel a transaction because of a bad cyclic redundancy check (CRC) or request a retry if an acknowledgment (ACK) was not received.
+
 
 ## Buffer Interface
 
-A 2k Byte SRAM is used to hold data between the system and the USB
-interface. This is divided up into 32 buffers each containing 64
-bytes. This is an asynchronous dual-port SRAM with the software
-accessing from the bus clock domain and the USB interface accessing
-from the USB 48MHz clock domain.
+A 2 kB SRAM is used as a packet buffer to hold data between the system and the USB interface.
+This is divided up into 32 buffers each containing 64 bytes.
+This is an asynchronous dual-port SRAM with software accessing from the bus clock domain and the USB interface accessing from the USB 48 MHz clock domain.
 
-The 64 byte size for the buffers satisfies the maximum USB packet size
-for a Full Speed interface for Control transfers (max may be 8, 16, 32
-or 64 bytes), Bulk Transfers (max is 64 bytes) and Interrupt transfers
-(max is 64 bytes). It is small for Isochronous transfers (which have a
-max of 1023 bytes) and the interface will need extending for high rate
-isochronous use (would probably allow up to 8 or 16 buffers to be
-aggregated as the isoc buffer).
 
-The software provides buffers for packet reception through a 4-entry
-available-buffer FIFO. (More study needed but 4 seems about right: one
-just returned to software, one being filled, one ready to be filled
-and one for luck.) The {{< regref "RxEnable" >}} register is used to indicate which
-endpoints will accept data from the host using SETUP or OUT
-transactions. When a packet is transferred from the host to the device
-(using an OUT or SETUP transaction) and reception of that type of
-transaction is enabled for the requested endpoint, the next receive
-buffer is pulled from the FIFO and will be filled with the data from
-the packet. If the packet is correctly received then an ACK is
-returned to the host and the buffer number, the packet size, an
-out/setup flag and the endpoint number are passed back to software
-using the receive FIFO and a pkt_received interrupt raised. The driver
-should immediately provide a free buffer for future reception by
-writing its buffer number to the available-buffer FIFO, then can
-process the packet and eventually return the received buffer to the
-free pool. This allows streaming on a single endpoint or across a
-number of endpoints. If the packets cannot be consumed at the rate
-they are received then software can implement selective flow-control
-by disabling OUT or SETUP transactions for a particular endpoint,
-which will result in a request to that endpoint being NACKed. In the
-unfortunate event that the available-buffer FIFO is empty or receive
-FIFO is full then all OUT/SETUP transactions are NACKed.
+### Reception
 
-To send data to the host in response to an IN transaction the software
-writes the data into a free buffer and writes the buffer number, data
-length and a ready flag to the {{< regref "configin" >}} register for the endpoint
-that the data is from. When the host next does an IN transaction to
-that endpoint the data will be sent from the buffer. On receipt of the
-ACK from the host the ready flag in the {{< regref "configin" >}} register will be
-cleared and the bit corresponding to the endpoint number will be set
-in the {{< regref "in_sent" >}} register which will cause a pkt_sent
-interrupt. Software can return the buffer to the free pool and write a
-1 to clear the bit in the {{< regref "in_sent" >}} register. Note that streaming can be
-achieved if the next buffer has been prepared and is written to the
-{{< regref "configin" >}} register when the interrupt is received.
+Software provides buffers for packet reception through a 4-entry Available Buffer FIFO.
+(More study needed but four seems about right: one just returned to software, one being filled, one ready to be filled, and one for luck.)
+The {{< regref "rxenable_out" >}} and {{< regref "rxenable_setup" >}} registers is used to indicate which endpoints will accept data from the host using OUT or SETUP transactions, respectively.
+When a packet is transferred from the host to the device (using an OUT or SETUP transaction) and reception of that type of transaction is enabled for the requested endpoint, the next buffer ID is pulled from the Available Buffer FIFO.
+The packet data is written to the corresponding buffer in the packet buffer (the 2 kB SRAM).
+If the packet is correctly received, an ACK is returned to the host.
+In addition, the buffer ID, the packet size, an out/setup flag and the endpoint ID are passed back to software using the Received Buffer FIFO and a pkt_received interrupt is raised.
 
-A Control transfer may need an IN data transfer. Therefore when a
-SETUP transaction is received for an endpoint the ready bit is cleared
-in {{< regref "configin" >}} to cancel any buffer that was pending being sent to the
-host from the Endpoint. When this is done the pending bit will be
-set. The transfer must be queued again after the Control transfer is
-completed.
+Software should immediately provide a free buffer for future reception by writing the corresponding buffer ID to the Available Buffer FIFO.
+It can then process the packet and eventually return the received buffer to the free pool.
+This allows streaming on a single endpoint or across a number of endpoints.
+If the packets cannot be consumed at the rate they are received, software can implement selective flow control by disabling OUT or SETUP transactions for a particular endpoint, which will result in a request to that endpoint being NACKed (negative acknowledgment).
+In the unfortunate event that the Available Buffer FIFO is empty or the Received Buffer FIFO is full, all OUT and SETUP transactions are NACKed.
 
-A link level reset will also cancel pending IN transactions by
-clearing the ready bit and setting the pending bit.
 
-In general the 32 buffers will be allocated with one being processed
-following reception, 4 in the available-buffer FIFO and 12 (worst
-case) waiting transmission in the {{< regref "configin" >}} registers. This leaves 15
-for preparation of next transmission (which would need 12 in the worst
-case of one per endpoint) and the free pool.
+### Transmission
+
+To send data to the host in response to an IN transaction, software first writes the data into a free buffer.
+Then, it writes the buffer ID, data length and rdy flag to the {{< regref "configin" >}} register of the corresponding endpoint.
+When the host next does an IN transaction to that endpoint, the data will be sent from the buffer.
+On receipt of the ACK from the host, the rdy bit in the {{< regref "configin" >}} register will be cleared, and the bit corresponding to the endpoint ID will be set in the {{< regref "in_sent" >}} register causing a pkt_sent interrupt to be raised.
+Software can return the buffer to the free pool and write a 1 to clear the endpoint bit in the {{< regref "in_sent" >}} register.
+Note that streaming can be achieved if the next buffer has been prepared and is written to the {{< regref "configin" >}} register when the interrupt is received.
+
+A Control transfer may need an IN data transfer.
+Therefore, when a SETUP transaction is received for an endpoint, any buffers that are waiting to be sent out to the host from that endpoint are canceled by clearing the rdy bit in the corresponding {{< regref "configin" >}} register.
+To keep track of such canceled buffers, the pend bit in the same register is set.
+The transfer must be queued again after the Control transfer is completed.
+
+Similarly, a Link Reset cancels any waiting IN transactions by clearing the rdy bit in the {{< regref "configin" >}} register of all endpoints.
+The pend bit in the {{< regref "configin" >}} register is set for all endpoints with a pending IN transaction.
+
+
+### Buffer Count and Size
+
+Under high load, the 32 buffers of the packet buffer (2 kB SRAM) are allocated as follows:
+- 1 is being processed following reception,
+- 4 are in the Available Buffer FIFO, and
+- 12 (worst case) waiting transmissions in the {{< regref "configin" >}} registers.
+This leaves 15 buffers for preparation of future transmissions (which would need 12 in the worst case of one per endpoint) and the free pool.
+
+The size of 64 bytes per buffer satisfies the maximum USB packet size for a Full-Speed interface for Control transfers (max may be 8, 16, 32 or 64 bytes), Bulk Transfers (max is 64 bytes) and Interrupt transfers (max is 64 bytes).
+It is small for Isochronous transfers (which have a max size of 1023 bytes).
+The interface will need extending for high rate isochronous use (a possible option would be to allow up to 8 or 16 64-byte buffers to be aggregated as the isochronous buffer).
 
 
 # Design Details
@@ -259,127 +235,79 @@ case of one per endpoint) and the free pool.
 
 ## Initialization
 
-The basic hardware initialization is to (in any order) fill the
-Available buffer FIFO, enable reception of SETUP and OUT packets on
-Endpoint 0 (this is the control endpoint that the host will use to
-configure the interface), enable reception of SETUP and OUT packets on
-any endpoints that accept them and enable any required
-interrupts. Finally the interface is enabled by setting the
-{{< regref "usbctrl.enable" >}} bit. Setting this bit will cause the USB device to
-assert the Full-Speed pullup on the D+ line, which is used by the host
-to detect the device. In most cases there is no need to configure the
-device ID ({{< regref "usbctrl.device_address" >}}) at this point -- the line will be
-in reset and the hardware will have forced the device ID to zero.
+The basic hardware initialization is to (in any order) fill the Available Buffer FIFO, enable reception of SETUP and OUT packets on Endpoint 0 (this is the control endpoint that the host will use to configure the interface), enable reception of SETUP and OUT packets on any endpoints that accept them and enable any required interrupts.
+Finally, the interface is enabled by setting the enable bit in the {{< regref "usbctrl" >}} register.
+Setting this bit causes the USB device to assert the pullup on the D+ line, which is used by the host to detect the device.
+There is no need to configure the device ID in ({{< regref "usbctrl.device_address" >}}) at this point -- the line remains in reset and the hardware forces the device ID to zero.
 
-The second stage of initialization is done under control of the host,
-which will use control transfers (always beginning with SETUP
-transactions) to Endpoint 0. Initially these will be sent to device
-ID 0. When a Set Address request is received the device ID received
-must be stored in the {{< regref "usbctrl.device_address" >}} register. Note that
-device 0 is used for the entire control transaction setting the new
-device ID, so writing the new ID to the register should not be done
-until the ACK for the Status stage (see USB specification) has been
-received.
+The second stage of initialization is done under control of the host, which will use control transfers (always beginning with SETUP transactions) to Endpoint 0.
+Initially these will be sent to device ID 0.
+When a Set Address request is received, the device ID received must be stored in the {{< regref "usbctrl.device_address" >}} register.
+Note that device 0 is used for the entire control transaction setting the new device ID, so writing the new ID to the register should not be done until the ACK for the Status stage has been received (see [USB 2.0 specification](https://www.usb.org/document-library/usb-20-specification)).
 
 
 ## Buffers
 
-The driver needs to manage the buffers in the interface SRAM. Each
-buffer can hold the maximum length packet (64 bytes). Other than for
-data movement this is most likely done based on their buffer
-identifier which is a small integer between zero and (SRAM
-size-in-bytes)/(MaxPacket-in-bytes).
+Software needs to manage the buffers in the packet buffer (2 kB SRAM).
+Each buffer can hold the maximum length packet for a Full-Speed interface (64 bytes).
+Other than for data movement, the management is most likely done based on their buffer ID which is a small integer between zero and (SRAM size in bytes)/(max packet size in bytes).
 
-In order to avoid unintentionally stalling the interface there must be
-buffers available when the host sends data to the device (an OUT or
-STATUS transaction). The driver needs to ensure (1) there are always
-buffer identifiers in the Available buffer FIFO (2) the receive FIFO
-is not full. If the AV FIFO is empty or the RX FIFO is full when data
-is received a NAK will be returned to the host, requesting the packet
-be retried later. Generating NAK with this mechanism is generally to
-be avoided (for example the host expects a device will always accept
-STATUS packets to endpoint 0).
+In order to avoid unintentional stalling the interface, there must be buffers available when the host sends data to the device (an OUT or STATUS transaction).
+Software needs to ensure (1) there are always buffer IDs in the Available Buffer FIFO, and (2) the Received Buffer FIFO is not full.
+If the Available Buffer FIFO is empty or the Received Buffer FIFO is full when data is received, a NACK will be returned to the host, requesting the packet be retried later.
+Generating NACK with this mechanism is generally to be avoided (for example the host expects a device will always accept STATUS packets to Endpoint 0).
 
-Keeping the AV FIFO full can be done with a simple loop, adding
-buffers from the software managed free-pool until the FIFO is full. A
-simpler policy of just adding a buffer to the AV FIFO everytime one is
-removed from the RX FIFO should work on average, but will be slightly
-worse when a burst of packets are received.
+Keeping the Available Buffer FIFO full can be done with a simple loop, adding buffer IDs from the software-managed free pool until the FIFO is full.
+A simpler policy of just adding a buffer ID to the Available Buffer FIFO whenever a buffer ID is removed from the Received Buffer FIFO should work on average, but performance will be slightly worse when bursts of packets are received.
 
-Flow control (using NAKs) may be done per-endpoint using the
-{{< regref "rxenable" >}} register. If this does not indicate OUT packet reception
-is enabled then any packet will receive a NAK to request a retry
-later. This should only be done for short durations or the host may
-timeout the transaction.
+Flow control (using NACKs) may be done on a per-endpoint basis using the {{< regref "rxenable_out" >}} and {{< regref "rxenable_setup" >}} registers.
+If this does not indicate OUT/SETUP packet reception is enabled, then any packet will receive a NACK to request a retry later.
+This should only be done for short durations or the host may timeout the transaction.
 
 
 ## Reception
 
-The host will send OUT or SETUP transactions when it wants to transfer
-data to the device. The data packets are directed to a particular
-endpoint, and the maximum packet size is set per-endpoint in its
-Endpoint Descriptor (this must be the same or smaller than the maximum
-packet size supported by the device). A received interrupt is raised
-whenever there is one or more packets in the RX FIFO. The driver
-should pop the information from the FIFO by reading the {{< regref "rxfifo" >}}
-register, which gives (a) the buffer ID that the data was received in
-(b) the data length, in bytes, received (c) the endpoint to which the
-packet was sent (d) an indication if the packet was sent with an OUT
-or STATUS transaction. Note that the data length could be between 0
-and the maximum packet size -- in some situations a zero length packet
-is used as an acknowledgement or end of transmission.
+The host will send OUT or SETUP transactions when it wants to transfer data to the device.
+The data packets are directed to a particular endpoint, and the maximum packet size is set per-endpoint in its Endpoint Descriptor (this must be the same or smaller than the maximum packet size supported by the device).
+A pkt_received interrupt is raised whenever there is one or more packets in the Received Buffer FIFO.
+Software should pop the information from the Received Buffer FIFO by reading the {{< regref "rxfifo" >}} register, which gives (1) the buffer ID that the data was received in, (2) the data length received in bytes, (3) the endpoint to which the packet was sent, and (4) an indication if the packet was sent with an OUT or STATUS transaction.
+Note that the data length could be between zero and the maximum packet size -- in some situations a zero length packet is used as an acknowledgment or end of transmission.
 
-The data length does not include the packet CRC. (The CRC bytes are
-written to the buffer if they fit within the maximum buffer size.)
-Packets with a bad CRC will **not** be transferred to the RX FIFO, the
-hardware will request a retry.
+The data length does not include the packet CRC.
+(The CRC bytes are written to the buffer if they fit within the maximum buffer size.)
+Packets with a bad CRC will **not** be transferred to the Received Buffer FIFO, the hardware will request a retry.
 
 
 ## Transmission
 
-Data is transferred to the host based on the host requesting a
-transfer with an IN transaction. The host will only generate IN
-requests if the endpoint is declared as an IN endpoint in its Endpoint
-Descriptor (note that two descriptors are needed if the same endpoint
-is used for both IN and OUT transfers). The Endpoint Descriptor also
-includes a description of the frequency the endpoint should be polled.
+Data is transferred to the host based on the host requesting a transfer with an IN transaction.
+The host will only generate IN requests if the endpoint is declared as an IN endpoint in its Endpoint Descriptor (note that two descriptors are needed if the same endpoint is used for both IN and OUT transfers).
+The Endpoint Descriptor also includes a description of the frequency the endpoint should be polled.
 
-Data is queued for transmission by writing the corresponding
-{{< regref "configin" >}} register with the buffer ID containing the data, the
-length in bytes of data (0 to maximum packet length) and setting the
-Rdy bit. This data (with the packet CRC) will be sent as a response to
-the next IN transaction on the endpoint. When the host ACKs the data
-the Rdy bit is cleared, the bit corresponding to the endpoint is set
-in the {{< regref "in_sent" >}} register and a transmit interrupt is raised. If the
-host does not ACK the data then the packet will be retried. When the
-packet transmission has been noted by the driver the endpoint bit
-should be cleared by writing a 1 to it in the {{< regref "in_sent" >}} register.
+Data is queued for transmission by writing the corresponding {{< regref "configin" >}} register with the buffer ID containing the data, the length in bytes of data (0 to maximum packet length) and setting the rdy bit.
+This data (with the packet CRC) will be sent as a response to the next IN transaction on the corresponding endpoint.
+When the host ACKs the data, the rdy bit is cleared, the corresponding endpoint bit is set in the {{< regref "in_sent" >}} register, and a pkt_sent interrupt is raised. If the host does not ACK the data, the packet will be retried.
+When the packet transmission has been noted by software, the corresponding endpoint bit should be cleared in the {{< regref "in_sent" >}} register (by writing a 1 to this very bit).
 
-Note that the {{< regref "configin" >}} for an endpoint is a single register, so no
-new data packet should be queued until the previous packet has been
-acknowledged. This causes a problem if a Control Transaction is
-received on an endpoint with a transmission pending because the
-Control Transaction may require an IN packet. Therefore the hardware
-will **clear the rdy bit** if an enabled SETUP transaction is received
-on any endpoint and **set the pending bit** if there was data
-pending. The driver must remember the pending transfer and, after the
-Control transaction is complete, write it back to the {{< regref "configin" >}}
-register with the rdy bit set.
+Note that the {{< regref "configin" >}} for an endpoint is a single register, so no new data packet should be queued until the previous packet has been ACKed.
+If an enabled SETUP transaction is received on an endpoint that has a transmission pending, the hardware will **clear the rdy bit** and **set the pend bit** in the {{< regref "configin" >}} register of that endpoint.
+Software must remember the pending transmission and, after the Control transaction is complete, write it back to the {{< regref "configin" >}} register with the rdy bit set.
 
 
-## Stall
+## Stalling
 
-The {{< regref "stall" >}} register is used to Stall an endpoint. 
-This is used if it is shutdown for some reason, or to signal certain error conditions (functional stall). 
-Control endpoints also use a STALL to indicate unsupported requests (protocol stall). 
-This register is used in both cases. Unused endpoints can have their {{< regref "stall" >}} register bit left clear, so in many cases there is no need to use the {{< regref "stall" >}} register. 
-If the stall bit is set for an endpoint then the STALL response will be provided to all IN or OUT requests on that endpoint.
+The {{< regref "stall" >}} registers are used for endpoint stalling.
+There is one dedicated register per endpoint.
+Stalling is used to signal that the host should not retry a particular transmission or to signal certain error conditions (functional stall).
+Control endpoints also use a STALL to indicate unsupported requests (protocol stall).
+Unused endpoints can have their {{< regref "stall" >}} register left clear, so in many cases there is no need to use the {{< regref "stall" >}} register.
+If the {{< regref "stall" >}} register is set for an endpoint then the STALL response will be provided to all IN/OUT requests on that endpoint.
 
-In the case of a protocol stall, the device must send a STALL for all IN and OUT requests until the next SETUP token is received. 
-To support this, the software sets the STALL bit for an endpoint when an unsupported transfer is requested. 
+In the case of a protocol stall, the device must send a STALL for all IN/OUT requests until the next SETUP token is received.
+To support this, software sets the {{< regref "stall" >}} register for an endpoint when the host requests an unsupported transfer.
 The hardware will then send a STALL response to all IN/OUT transactions until the next SETUP is received for this endpoint.
-Receiving the **SETUP token then clears the STALL flag** for the endpoint. 
-The hardware then sends NAKs to any IN/OUT requets until the software has decided what action to take for the new SETUP request.
+Receiving the **SETUP token clears the {{< regref "stall" >}} register** for that endpoint.
+The hardware then sends NACKs to any IN/OUT requests until the software has decided what action to take for the new SETUP request.
 
 
 ## Register Table


### PR DESCRIPTION
This PR revises the documentation of the USB device to mainly:
- Add a note that the USB device is a comportable IP (it is according to our spec).
- Add references to the USB 2.0 specification where suitable.
- Harmonize spelling.
- Harmonize usage of terms describing the same thing (e.g. Available Buffer FIFO & AV FIFO, Received Buffer FIFO & Receive FIFO, buffer ID & buffer number)
- Add missing definitions of acronyms.
- Fix broken references to register descriptions.
