### PR TITLE
[uvmdvgen] add missing conditional

### DIFF
--- a/util/uvmdvgen/common_vseq.sv.tpl
+++ b/util/uvmdvgen/common_vseq.sv.tpl
@@ -11,7 +11,11 @@ class ${name}_common_vseq extends ${name}_base_vseq;
   `uvm_object_new
 
   virtual task body();
+% if is_cip:
     run_common_vseq_wrapper(num_trans);
+% elif has_ral:
+    run_csr_vseq_wrapper(num_trans);
+% endif
   endtask : body
 
 endclass


### PR DESCRIPTION
Currently, the run_common_vseq_wrapper() method is defined regardless of whether a class extends from cip_lib or dv_base DV libraries, this needs to change to only be generated if a testbench is extending from the cip_lib library, where this function is defined.

Signed-off-by: Udi Jonnalagadda <udij@google.com>