### PR TITLE
[sw, DIF unittests] Create the directory and a readme file

### DIFF
--- a/sw/device/tests/dif/README.md
+++ b/sw/device/tests/dif/README.md
@@ -1,0 +1,28 @@
+# The OpenTitan DIFs (Device Interface Functions) Library unit tests
+
+The purpose of DIF unit tests is to verify that the operations performed by the
+API match the expectations.
+
+For a detailed information on DIFs, please refer to the "DIF Style Guide"
+`sw/device/lib/dif/README.md`.
+
+## Testing strategy
+
+Peripherals are designed to perform a set of specific operations, so it is not
+possible to define a complete list of tests that would uniformly cover all the
+different DIF libraries. However, there are many commonalities that DIF APIs
+exhibit, which in turn makes it possible to define a set of minimal required
+tests.
+
+### Function error codes
+
+* When defined, DIF API must be able to return every variant of the error code
+  associated with this API.
+
+### Common register access patterns
+
+* Enable/disable/set/unset/... API often perform a simple set of operations that
+  simply access a register bit or field at given offset. In this case an access
+  to the first and last element of the register must be tested. If the elements
+  are split across multiple same function registers (multi reg), the access to
+  the first and last element of the first and last register must be tested.


### PR DESCRIPTION
It is useful to establish at least minimum required set of tests for the DIF libraries. This will make it much easier for others to review, and also make the unit tests more uniform and easier to write.

This is a first take, and is fairly minimalistic. Please let me know what is your opinion on this, and what common things you can see that could be added. For example, I think that FIFO write/read probably can be split out in something like, try to write when:
* FIFO is empty
* FIFO is full
* Write one element
* Write n elements

The best reference implementation is probably #1763 