### PR TITLE
[dv] add send email option to dvsim.py

### DIFF
--- a/util/dvsim/FlowCfg.py
+++ b/util/dvsim/FlowCfg.py
@@ -461,6 +461,7 @@ class FlowCfg():
             self.errors_seen |= item.errors_seen
 
         if self.is_master_cfg: self.gen_results_summary()
+        self.gen_email_html_summary()
 
     def gen_results_summary(self):
         '''Public facing API to generate summary results for each IP/cfg file
@@ -472,6 +473,19 @@ class FlowCfg():
         results_page_url = self.results_server_page.replace(
             self.results_server_prefix, self.results_server_url_prefix)
         return "[%s](%s)" % (link_text, results_page_url)
+
+    def gen_email_html_summary(self):
+        if self.is_master_cfg:
+            gen_results = self.results_summary_md
+        else:
+            gen_results = self.results_md
+        results_html = md_results_to_html(self.results_title, self.results_server_css_path,
+                                          gen_results)
+        results_html_file = self.scratch_root + "/email.html"
+        f = open(results_html_file, 'w')
+        f.write(results_html)
+        f.close()
+        log.info("[results summary]: %s [%s]", "generated for email purpose", results_html_file)
 
     def _publish_results(self):
         '''Publish results to the opentitan web server.

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -48,7 +48,6 @@ class SimCfg(FlowCfg):
         self.xprop_off = args.xprop_off
         self.no_rerun = args.no_rerun
         self.verbosity = "{" + args.verbosity + "}"
-        self.email = args.email
         self.verbose = args.verbose
         self.dry_run = args.dry_run
         self.map_full_testplan = args.map_full_testplan

--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -84,7 +84,6 @@ def resolve_branch(arg_branch):
             arg_branch = "default"
     return (arg_branch)
 
-
 # Get the project root directory path - this is used to construct the full paths
 def get_proj_root():
     cmd = ["git", "rev-parse", "--show-toplevel"]
@@ -362,12 +361,6 @@ def main():
                         help="""Set verbosity to none/low/medium/high/debug;
                                 This will override any setting added to any of the hjson files
                                 used for config""")
-
-    parser.add_argument("--email",
-                        nargs="+",
-                        default=[],
-                        metavar="",
-                        help="""email the report to specified addresses""")
 
     parser.add_argument(
         "--verbose",


### PR DESCRIPTION
Add a send email options for dvsim.py. This only works when less secure
app is turned on. For google internal user, the script will use an
internal lib to route the email.

Signed-off-by: Cindy Chen <chencindy@google.com>