### PR TITLE
[top/usbdev] Compile error fix in usbdev and naming changes in toplevel

### DIFF
--- a/hw/ip/usbdev/rtl/usbdev.sv
+++ b/hw/ip/usbdev/rtl/usbdev.sv
@@ -857,12 +857,13 @@ module usbdev (
   /////////////////////////////////
   // USB IO Muxing               //
   /////////////////////////////////
+  logic cio_oe;
 
   usbdev_iomux i_usbdev_iomux (
     .clk_i                  (clk_i),
     .rst_ni                 (rst_ni),
     .clk_usb_48mhz_i        (clk_usb_48mhz_i),
-    .rst_usb_48mhz_ni             (rst_usb_48mhz_ni),
+    .rst_usb_48mhz_ni       (rst_usb_48mhz_ni),
     .rx_differential_mode_i (reg2hw.phy_config.rx_differential_mode),
     .tx_differential_mode_i (reg2hw.phy_config.tx_differential_mode),
     .sys_reg2hw_config_i    (reg2hw.phy_config),
@@ -896,7 +897,6 @@ module usbdev (
   ////////////////////////
   // USB Output Enables //
   ////////////////////////
-  logic cio_oe;
 
   // Data outputs
   assign cio_d_en_o  = cio_oe;

--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -246,7 +246,7 @@ module top_${top["name"]} #(
     .DmHaltAddr          (ADDR_SPACE_DEBUG_MEM + dm::HaltAddress),
     .DmExceptionAddr     (ADDR_SPACE_DEBUG_MEM + dm::ExceptionAddress),
     .PipeLine            (IbexPipeLine)
-  ) core (
+  ) u_rv_core_ibex (
     // clock and reset
     .clk_i                (main_clk),
     .rst_ni               (sys_rst_n),
@@ -331,7 +331,7 @@ module top_${top["name"]} #(
     .SramAw(${addr_width}),
     .SramDw(${data_width}),
     .Outstanding(2)
-  ) tl_adapter_${m["name"]} (
+  ) u_tl_adapter_${m["name"]} (
     % for key in clocks:
     .${key}   (${clocks[key]}_clk),
     % endfor
@@ -392,7 +392,7 @@ module top_${top["name"]} #(
     .SramDw(${data_width}),
     .Outstanding(2),
     .ErrOnWrite(1)
-  ) tl_adapter_${m["name"]} (
+  ) u_tl_adapter_${m["name"]} (
     % for key in clocks:
     .${key}   (${clocks[key]}_clk),
     % endfor
@@ -456,7 +456,7 @@ module top_${top["name"]} #(
     .Outstanding(2),
     .ByteAccess(0),
     .ErrOnWrite(1)
-  ) tl_adapter_${m["name"]} (
+  ) u_tl_adapter_${m["name"]} (
     % for key in clocks:
     .${key}   (${clocks[key]}_clk),
     % endfor
@@ -530,9 +530,9 @@ else:
     .${k}(${v | lib.parameterize}),
         % endif
     % endfor
-  ) ${m["name"]} (
+  ) u_${m["name"]} (
   % else:
-  ${m["type"]} ${m["name"]} (
+  ${m["type"]} u_${m["name"]} (
   % endif
     % if not "bus_host" in m or m["bus_host"] in ["none", ""]:
       .tl_i (tl_${m["name"]}_d_h2d),

--- a/hw/top_earlgrey/dv/tb/chip_hier_macros.svh
+++ b/hw/top_earlgrey/dv/tb/chip_hier_macros.svh
@@ -4,13 +4,13 @@
 
 `define DUT_HIER        dut
 `define CHIP_HIER       `DUT_HIER.top_earlgrey
-`define UART_HIER       `CHIP_HIER.uart
-`define GPIO_HIER       `CHIP_HIER.gpio
-`define SPI_DEVICE_HIER `CHIP_HIER.spi_device
-`define CPU_HIER        `CHIP_HIER.core
+`define UART_HIER       `CHIP_HIER.u_uart
+`define GPIO_HIER       `CHIP_HIER.u_gpio
+`define SPI_DEVICE_HIER `CHIP_HIER.u_spi_device
+`define CPU_HIER        `CHIP_HIER.u_rv_core_ibex
 `define RAM_MAIN_HIER   `CHIP_HIER.u_ram1p_ram_main
 `define ROM_HIER        `CHIP_HIER.u_rom_rom
 `define FLASH_HIER      `CHIP_HIER.u_flash_eflash
-`define USBDEV_HIER     `CHIP_HIER.usbdev
+`define USBDEV_HIER     `CHIP_HIER.u_usbdev
 `define FLASH0_MEM_HIER `FLASH_HIER.gen_flash_banks[0].u_flash.gen_generic.u_impl_generic.u_mem
 `define FLASH1_MEM_HIER `FLASH_HIER.gen_flash_banks[1].u_flash.gen_generic.u_impl_generic.u_mem

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -295,7 +295,7 @@ module top_earlgrey #(
     .DmHaltAddr          (ADDR_SPACE_DEBUG_MEM + dm::HaltAddress),
     .DmExceptionAddr     (ADDR_SPACE_DEBUG_MEM + dm::ExceptionAddress),
     .PipeLine            (IbexPipeLine)
-  ) core (
+  ) u_rv_core_ibex (
     // clock and reset
     .clk_i                (main_clk),
     .rst_ni               (sys_rst_n),
@@ -364,7 +364,7 @@ module top_earlgrey #(
     .SramDw(32),
     .Outstanding(2),
     .ErrOnWrite(1)
-  ) tl_adapter_rom (
+  ) u_tl_adapter_rom (
     .clk_i   (main_clk),
     .rst_ni   (sys_rst_n),
 
@@ -407,7 +407,7 @@ module top_earlgrey #(
     .SramAw(14),
     .SramDw(32),
     .Outstanding(2)
-  ) tl_adapter_ram_main (
+  ) u_tl_adapter_ram_main (
     .clk_i   (main_clk),
     .rst_ni   (sys_rst_n),
     .tl_i     (tl_ram_main_d_h2d),
@@ -458,7 +458,7 @@ module top_earlgrey #(
     .Outstanding(2),
     .ByteAccess(0),
     .ErrOnWrite(1)
-  ) tl_adapter_eflash (
+  ) u_tl_adapter_eflash (
     .clk_i   (main_clk),
     .rst_ni   (lc_rst_n),
 
@@ -495,7 +495,7 @@ module top_earlgrey #(
 
 
 
-  uart uart (
+  uart u_uart (
       .tl_i (tl_uart_d_h2d),
       .tl_o (tl_uart_d_d2h),
 
@@ -520,7 +520,7 @@ module top_earlgrey #(
       .rst_ni (sys_fixed_rst_n)
   );
 
-  gpio gpio (
+  gpio u_gpio (
       .tl_i (tl_gpio_d_h2d),
       .tl_o (tl_gpio_d_d2h),
 
@@ -538,7 +538,7 @@ module top_earlgrey #(
       .rst_ni (sys_fixed_rst_n)
   );
 
-  spi_device spi_device (
+  spi_device u_spi_device (
       .tl_i (tl_spi_device_d_h2d),
       .tl_o (tl_spi_device_d_d2h),
 
@@ -564,7 +564,7 @@ module top_earlgrey #(
       .rst_ni (spi_device_rst_n)
   );
 
-  flash_ctrl flash_ctrl (
+  flash_ctrl u_flash_ctrl (
       .tl_i (tl_flash_ctrl_d_h2d),
       .tl_o (tl_flash_ctrl_d_d2h),
 
@@ -584,7 +584,7 @@ module top_earlgrey #(
       .rst_ni (lc_rst_n)
   );
 
-  rv_timer rv_timer (
+  rv_timer u_rv_timer (
       .tl_i (tl_rv_timer_d_h2d),
       .tl_o (tl_rv_timer_d_d2h),
 
@@ -595,7 +595,7 @@ module top_earlgrey #(
       .rst_ni (sys_fixed_rst_n)
   );
 
-  aes aes (
+  aes u_aes (
       .tl_i (tl_aes_d_h2d),
       .tl_o (tl_aes_d_d2h),
 
@@ -603,7 +603,7 @@ module top_earlgrey #(
       .rst_ni (sys_rst_n)
   );
 
-  hmac hmac (
+  hmac u_hmac (
       .tl_i (tl_hmac_d_h2d),
       .tl_o (tl_hmac_d_d2h),
 
@@ -620,7 +620,7 @@ module top_earlgrey #(
       .rst_ni (sys_rst_n)
   );
 
-  rv_plic rv_plic (
+  rv_plic u_rv_plic (
       .tl_i (tl_rv_plic_d_h2d),
       .tl_o (tl_rv_plic_d_d2h),
 
@@ -633,7 +633,7 @@ module top_earlgrey #(
       .rst_ni (sys_rst_n)
   );
 
-  pinmux pinmux (
+  pinmux u_pinmux (
       .tl_i (tl_pinmux_d_h2d),
       .tl_o (tl_pinmux_d_d2h),
 
@@ -649,7 +649,7 @@ module top_earlgrey #(
       .rst_ni (sys_rst_n)
   );
 
-  alert_handler alert_handler (
+  alert_handler u_alert_handler (
       .tl_i (tl_alert_handler_d_h2d),
       .tl_o (tl_alert_handler_d_d2h),
 
@@ -673,7 +673,7 @@ module top_earlgrey #(
       .rst_ni (sys_rst_n)
   );
 
-  nmi_gen nmi_gen (
+  nmi_gen u_nmi_gen (
       .tl_i (tl_nmi_gen_d_h2d),
       .tl_o (tl_nmi_gen_d_d2h),
 
@@ -690,7 +690,7 @@ module top_earlgrey #(
       .rst_ni (sys_rst_n)
   );
 
-  usbdev usbdev (
+  usbdev u_usbdev (
       .tl_i (tl_usbdev_d_h2d),
       .tl_o (tl_usbdev_d_d2h),
 


### PR DESCRIPTION
This fixes a small syntax error in usbdev, and aligns the naming scheme of modules instantiated in the top level. These module names will be visible on the synthesis dashboard.
https://reports.opentitan.org/hw/top_earlgrey/syn/latest/results.html

Signed-off-by: Michael Schaffner <msf@opentitan.org>