### PR TITLE
[dv/common] Fix reset and under_reset order for nightly

### DIFF
--- a/hw/dv/data/common_sim_cfg.hjson
+++ b/hw/dv/data/common_sim_cfg.hjson
@@ -25,6 +25,7 @@
   // pass and fail patterns
   pass_patterns:    ["^TEST PASSED (UVM_)?CHECKS$"]
   fail_patterns:    ["^UVM_ERROR\\s[^:].*$",
+                     "^UVM_FATAL\\s[^:].*$",
                      "^Assert failed: ",
                      "^\\s*Offending '.*'",
                      "^TEST FAILED (UVM_)?CHECKS$"]

--- a/hw/dv/sv/dv_lib/dv_base_scoreboard.sv
+++ b/hw/dv/sv/dv_lib/dv_base_scoreboard.sv
@@ -34,8 +34,8 @@ class dv_base_scoreboard #(type RAL_T = dv_base_reg_block,
         `uvm_info(`gfn, "reset occurred", UVM_HIGH)
         cfg.reset_asserted();
         @(posedge cfg.clk_rst_vif.rst_n);
-        cfg.reset_deasserted();
         reset();
+        cfg.reset_deasserted();
         `uvm_info(`gfn, "out of reset", UVM_HIGH)
       end
       else begin

--- a/hw/ip/gpio/dv/env/gpio_scoreboard.sv
+++ b/hw/ip/gpio/dv/env/gpio_scoreboard.sv
@@ -225,12 +225,10 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
     logic [NUM_GPIOS-1:0] prev_gpio_i = cfg.gpio_vif.pins;
 
     forever begin : monitor_pins_if
-      @(cfg.gpio_vif.pins or under_reset);
+      @(cfg.gpio_vif.pins or cfg.under_reset);
       `uvm_info(`gfn, $sformatf("cfg.gpio_vif.pins = %0h, under_reset = %0b",
-                                cfg.gpio_vif.pins, under_reset), UVM_HIGH)
-      if (under_reset == 1'b0) begin
-        // wait 1 ps to allow reset() function reset the values first
-        #1ps;
+                                cfg.gpio_vif.pins, cfg.under_reset), UVM_HIGH)
+      if (cfg.under_reset == 1'b0) begin
         // Coverage Sampling: gpio pin values' coverage
         if (cfg.en_cov) begin
           foreach (cov.gpio_pin_values_cov_obj[each_pin]) begin
@@ -329,8 +327,8 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
   // Task: monitor_gpio_interrupt_pins
   virtual task monitor_gpio_interrupt_pins();
     forever begin : monitor_gpio_intr
-      @(cfg.intr_vif.pins or under_reset) begin
-        if (under_reset == 0) begin
+      @(cfg.intr_vif.pins or cfg.under_reset) begin
+        if (cfg.under_reset == 0) begin
           if (cfg.en_cov) begin
             // Coverage Sampling: gpio interrupt pin values and transitions
             for (uint each_pin = 0; each_pin < NUM_GPIOS; each_pin++) begin

--- a/hw/ip/hmac/dv/env/hmac_scoreboard.sv
+++ b/hw/ip/hmac/dv/env/hmac_scoreboard.sv
@@ -53,7 +53,7 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
         if (!sha_en) begin
           void'(ral.intr_state.hmac_err.predict(.value(1), .kind(UVM_PREDICT_DIRECT)));
           void'(ral.err_code.predict(.value(SwPushMsgWhenShaDisabled), .kind(UVM_PREDICT_DIRECT)));
-        end else if (hmac_start && !under_reset) begin
+        end else if (hmac_start && !cfg.under_reset) begin
           bit [7:0] bytes[4];
           bit [7:0] msg[];
           {<<byte{bytes}} = item.a_data;
@@ -241,7 +241,7 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
     fork
       begin : insolation_fork_process_fifo_wr
         forever begin
-          wait(!under_reset);
+          wait(!cfg.under_reset);
           fork
             begin : increase_wr_cnt
               wait(msg_q.size() >= (hmac_wr_cnt + 1) * 4 ||
@@ -259,7 +259,7 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
               end
             end
             begin : reset_increase_wr_cnt
-              wait(under_reset);
+              wait(cfg.under_reset);
             end
           join_any
           disable fork;
@@ -291,7 +291,7 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
     fork
       begin : process_hmac_key_pad
         forever begin
-          wait(!under_reset);
+          wait(!cfg.under_reset);
           // delay 1ps to make sure all variables are being reset, before moving to the next
           // forever loop
           #1ps;
@@ -310,7 +310,7 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
               end
             end
             begin : reset_key_padding
-              wait(under_reset);
+              wait(cfg.under_reset);
             end
           join_any
           disable fork;
@@ -320,7 +320,7 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
 
       begin : process_internal_fifo_rd
         forever begin
-          wait(!under_reset);
+          wait(!cfg.under_reset);
           // delay 1ps to make sure all variables are being reset, before moving to the next
           // forever loop
           #1ps;
@@ -339,7 +339,7 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
               end
             end
             begin : reset_hmac_fifo_rd
-              wait(under_reset);
+              wait(cfg.under_reset);
             end
           join_any
           disable fork;

--- a/hw/ip/rv_timer/data/rv_timer_testplan.hjson
+++ b/hw/ip/rv_timer/data/rv_timer_testplan.hjson
@@ -2,6 +2,7 @@
   name: "rv_timer"
   import_testplans: ["hw/dv/tools/testplans/csr_testplan.hjson",
                      "hw/dv/tools/testplans/intr_test_testplan.hjson",
+                     "hw/dv/tools/testplans/stress_all_with_reset_testplan.hjson",
                      "hw/dv/tools/testplans/tl_device_access_types_testplan.hjson"]
   entries: [
     {


### PR DESCRIPTION
Use cfg.under_reset rather than under_reset. Change the order so reset()
values first then reset cfg.under_reset.

Add rv_timer stress_all_with_rand_reset in hjson.

Signed-off-by: Cindy Chen <chencindy@google.com>