### PR TITLE
[sw, libbase] Add mmio set field/fields helper functions

### DIFF
--- a/sw/device/lib/base/meson.build
+++ b/sw/device/lib/base/meson.build
@@ -26,6 +26,7 @@ sw_lib_mmio = declare_dependency(
   link_with: static_library(
     'mmio_ot',
     sources: ['mmio.c'],
+    dependencies: [sw_lib_bitfield],
   )
 )
 

--- a/sw/device/lib/base/mmio.c
+++ b/sw/device/lib/base/mmio.c
@@ -27,7 +27,7 @@ extern void mmio_region_nonatomic_set_mask32(mmio_region_t base,
                                              uint32_t mask_index);
 extern void mmio_region_nonatomic_set_field32(mmio_region_t base,
                                               ptrdiff_t offset,
-                                              mmio_region_field32_t field);
+                                              bitfield_field32_t field);
 extern void mmio_region_nonatomic_clear_bit32(mmio_region_t base,
                                               ptrdiff_t offset,
                                               uint32_t bit_index);

--- a/sw/device/lib/base/mmio.c
+++ b/sw/device/lib/base/mmio.c
@@ -25,6 +25,9 @@ extern void mmio_region_nonatomic_clear_mask32(mmio_region_t base,
 extern void mmio_region_nonatomic_set_mask32(mmio_region_t base,
                                              ptrdiff_t offset, uint32_t mask,
                                              uint32_t mask_index);
+extern void mmio_region_nonatomic_set_field32(mmio_region_t base,
+                                              ptrdiff_t offset,
+                                              mmio_region_field32_t field);
 extern void mmio_region_nonatomic_clear_bit32(mmio_region_t base,
                                               ptrdiff_t offset,
                                               uint32_t bit_index);

--- a/sw/device/lib/testing/meson.build
+++ b/sw/device/lib/testing/meson.build
@@ -7,6 +7,7 @@ sw_lib_testing_mock_mmio = declare_dependency(
     'mock_mmio',
     sources: [
       meson.source_root() / 'sw/device/lib/base/mmio.c',
+      meson.source_root() / 'sw/device/lib/base/bitfield.c',
       'mock_mmio.cc',
     ],
     dependencies: [sw_vendor_gtest],


### PR DESCRIPTION
This allows setting fields of arbitrary width inside a register, without affecting other register bits.

For example, I have noticed that I have been misusing `mmio_region_nonatomic_set_mask32`, which internally ORs the given mask (sets multiple bits). The following code becomes buggy, as once the bits set - they won't be unset by this function. Meaning that watermark level cannot be decreased below the highest value it has been set to.

Using the `mmio_region_nonatomic_set_field32` solves this issue in #1788 .

The `mmio_region_nonatomic_set_fields32` logic has been taken from @mcy #1647 `EXPECT_MASK32`.