### PR TITLE
[chip dv] Removed unused dependent env packages

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -12,12 +12,6 @@ filesets:
       - lowrisc:dv:jtag_agent
       - lowrisc:dv:spi_agent
       - lowrisc:dv:mem_bkdr_if
-      - lowrisc:dv:uart_env
-      - lowrisc:dv:gpio_env
-      - lowrisc:dv:hmac_env
-      - lowrisc:dv:rv_timer_env
-      - lowrisc:dv:spi_device_env
-      - lowrisc:dv:usbdev_env
       - lowrisc:dv:sw_msg_monitor_if
       - lowrisc:dv:gen_ral_pkg
     files:

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -16,14 +16,6 @@ package chip_env_pkg;
   import cip_base_pkg::*;
   import chip_ral_pkg::*;
 
-  // import individual env IP env pkgs
-  import uart_env_pkg::*;
-  import gpio_env_pkg::*;
-  import hmac_env_pkg::*;
-  import rv_timer_env_pkg::*;
-  import spi_device_env_pkg::*;
-  import usbdev_env_pkg::*;
-
   // macro includes
   `include "uvm_macros.svh"
   `include "dv_macros.svh"

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
@@ -2,13 +2,6 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-`define add_ip_csr_exclusions(ip) \
-  begin \
-    ip``_common_vseq m_``ip``_common_vseq; \
-    m_``ip``_common_vseq = ip``_common_vseq::type_id::create({"m_", `"ip`", "_common_vseq"}); \
-    m_``ip``_common_vseq.add_csr_exclusions(csr_test_type, csr_excl, {scope, ".", `"ip`"}); \
-  end
-
 class chip_common_vseq extends chip_base_vseq;
   `uvm_object_utils(chip_common_vseq)
 


### PR DESCRIPTION
- Now that we have automated the CSR exclusions, the PR removes the
dependent env packages.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>