### PR TITLE
[dvsim] Add vpd wave dumping support

### DIFF
--- a/hw/dv/data/vcs/vcs.hjson
+++ b/hw/dv/data/vcs/vcs.hjson
@@ -31,7 +31,7 @@
                "-LDFLAGS \"-Wl,--no-as-needed\""]
 
   run_opts:   ["-licqueue",
-               "-ucli -do {tool_srcs_dir}/vcs_fsdb.tcl",
+               "-ucli -do {tool_srcs_dir}/vcs_{dump}.tcl",
                "+ntb_random_seed={seed}",
                "+UVM_TESTNAME={uvm_test}",
                "+UVM_TEST_SEQ={uvm_test_seq}"]

--- a/hw/dv/tools/vcs/vcs_vpd.tcl
+++ b/hw/dv/tools/vcs/vcs_vpd.tcl
@@ -1,0 +1,15 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# TCL file invoked from VCS's simv at run-time using this: -ucli -do <this file>
+
+if {[info exists ::env(WAVES)]} {
+  if {$::env(WAVES) == 1} {
+    dump -file $::env(DUMP_FILE)
+    dump -add $::env(TB_TOP) -depth 0 -aggregates -scope "."
+  }
+}
+
+run
+quit


### PR DESCRIPTION
If you don't have access to the verdi libraries the default FSDB option actually causes VCS to hang so a potential improvement here is to check if verdi exists and cause an error if it doesn't when FSDB is selected as the wave dump type.

There's also no validation on the dump types. What is valid also depends upon the simulator selected as I wasn't sure of the best way to handle that in dvsim.