### PR TITLE
[sw] Linker Script Improvements

### DIFF
--- a/sw/device/boot_rom/rom_crt.S
+++ b/sw/device/boot_rom/rom_crt.S
@@ -54,6 +54,13 @@ _reset_start:
   // Set up the stack.
   la  sp, _stack_start
 
+  // Set up the global pointer. This requires that we disable linker relaxations
+  // (or it will be relaxed to `mv gp, gp`).
+  .option push
+  .option norelax
+  la  gp, __global_pointer$
+  .option pop
+
   // Explicit fall-through to |_start|.
 
 /**

--- a/sw/device/boot_rom/rom_link.ld
+++ b/sw/device/boot_rom/rom_link.ld
@@ -100,9 +100,19 @@ SECTIONS {
    */
   .data ORIGIN(ram): AT(_data_init_start) ALIGN(4) {
     _data_start = .;
+    __global_pointer$ = . + 2048;
+
+    /* Small data should come before larger data. This helps to ensure small
+     * globals are within 2048 bytes of the value of `gp`, making their accesses
+     * hopefully only take one instruction. */
+    *(.sdata)
+    *(.sdata.*)
+
+    /* Other data will likely need multiple instructions to load, so we're less
+     * concerned about address materialisation taking more than one instruction.
+     */
     *(.data)
     *(.data.*)
-    *(.sdata)
     _data_end = .;
   } > ram
 
@@ -118,10 +128,12 @@ SECTIONS {
    */
   .bss : ALIGN(4) {
     _bss_start = .;
-    *(.bss)
-    *(.bss.*)
+    /* Small BSS comes before regular BSS for the same reasons as in the data
+     * section */
     *(.sbss)
     *(.sbss.*)
+    *(.bss)
+    *(.bss.*)
     *(COMMON)
     _bss_end = .;
   } > ram

--- a/sw/device/boot_rom/rom_link.ld
+++ b/sw/device/boot_rom/rom_link.ld
@@ -82,6 +82,10 @@ SECTIONS {
    * strings.
    */
   .rodata : ALIGN(4) {
+    /* Small read-only data comes before regular read-only data for the same
+     * reasons as in the data section */
+    *(.srodata)
+    *(.srodata.*)
     *(.rodata)
     *(.rodata.*)
   } > rom

--- a/sw/device/exts/common/flash_crt.S
+++ b/sw/device/exts/common/flash_crt.S
@@ -25,6 +25,13 @@ _start:
   // jumps here will have the correct stack start linked in.
   la sp, _stack_start
 
+  // Set up the global pointer. This requires that we disable linker relaxations
+  // (or it will be relaxed to `mv gp, gp`).
+  .option push
+  .option norelax
+  la gp, __global_pointer$
+  .option pop
+
   // Set up the new interrupt vector.
   la   t0, _vectors_start
   csrw mtvec, t0

--- a/sw/device/exts/common/flash_link.ld
+++ b/sw/device/exts/common/flash_link.ld
@@ -92,9 +92,19 @@ SECTIONS {
    */ 
   .data ORIGIN(ram): AT(_data_init_start) ALIGN(4) {
     _data_start = .;
+    __global_pointer$ = . + 2048;
+
+    /* Small data should come before larger data. This helps to ensure small
+     * globals are within 2048 bytes of the value of `gp`, making their accesses
+     * hopefully only take one instruction. */
+    *(.sdata)
+    *(.sdata.*)
+
+    /* Other data will likely need multiple instructions to load, so we're less
+     * concerned about address materialisation taking more than one instruction.
+     */
     *(.data)
     *(.data.*)
-    *(.sdata)
     _data_end = .;
   } > ram
 
@@ -103,10 +113,12 @@ SECTIONS {
    */
   .bss : ALIGN(4) {
     _bss_start = .;
-    *(.bss)
-    *(.bss.*)
+    /* Small BSS comes before regular BSS for the same reasons as in the data
+     * section */
     *(.sbss)
     *(.sbss.*)
+    *(.bss)
+    *(.bss.*)
     *(COMMON)
     _bss_end = .;
   } > ram

--- a/sw/device/exts/common/flash_link.ld
+++ b/sw/device/exts/common/flash_link.ld
@@ -74,6 +74,10 @@ SECTIONS {
    * strings.
    */
   .rodata : ALIGN(4) {
+    /* Small read-only data comes before regular read-only data for the same
+     * reasons as in the data section */
+    *(.srodata)
+    *(.srodata.*)
     *(.rodata)
     *(.rodata.*)
   } > flash


### PR DESCRIPTION
Two separate improvements:
- We now define and use `__global_pointer$` to initialise `gp` which enables some extra relaxations when doing data accesses. This has meant we have reordered the small data sections to come before their respective data sections, in the hope this allows most small accesses to use `gp` (this doesn't really apply to `.sbss`).
- We now make sure to include small read-only data sections (`.srodata`, `.srodata.*`) in the linker scripts. These go into ROM because they are read-only, which is not what GNU ld would do by default.

We have enabled linker relaxations (they are enabled by default). We have not yet enabled the small data threshold but could in future.