### PR TITLE
[dvsim] Minor fix in LintCfg class

### DIFF
--- a/util/dvsim/OneShotCfg.py
+++ b/util/dvsim/OneShotCfg.py
@@ -107,8 +107,8 @@ class OneShotCfg(FlowCfg):
             # tests and regressions, only if not a master cfg obj
             self._create_objects()
 
-            # Post init checks
-            self.__post_init__()
+        # Post init checks
+        self.__post_init__()
 
     def __post_init__(self):
         # Run some post init checks


### PR DESCRIPTION
Post init was not properly called for master lint configs.

Signed-off-by: Michael Schaffner <msf@opentitan.org>