### PR TITLE
[dvsim] Initial verible lint integration

### DIFF
--- a/hw/lint/data/ascentlint.hjson
+++ b/hw/lint/data/ascentlint.hjson
@@ -1,0 +1,9 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+    // Ascentlint-specific results parsing script that is called after running lint
+    report_cmd: "{proj_root}/hw/lint/tools/{tool}/parse-lint-report.py "
+    report_opts: ["--repdir={build_dir}/lint-{tool}",
+                  "--outdir={build_dir}"]
+}

--- a/hw/lint/data/common_lint_cfg.hjson
+++ b/hw/lint/data/common_lint_cfg.hjson
@@ -6,25 +6,28 @@
   flow_makefile:    "{proj_root}/hw/lint/data/lint.mk"
 
   import_cfgs:      [// common server configuration for results upload
-                     "{proj_root}/hw/data/common_project_cfg.hjson"]
+                     "{proj_root}/hw/data/common_project_cfg.hjson"
+                     // tool-specific configuration
+                     "{proj_root}/hw/lint/data/{tool}.hjson"]
+
+  // Name of the DUT / top-level to be run through lint
+  dut:        "{name}"
 
   // Default directory structure for the output
-  dut:              "{name}"
-  build_dir:        "{scratch_path}/{build_mode}"
-
+  build_dir:  "{scratch_path}/{build_mode}"
+  build_log:  "{build_dir}/lint.log"
   // We rely on fusesoc to run lint for us
-  build_cmd:  "fusesoc "
+  build_cmd:  "fusesoc"
   build_opts: ["--cores-root {proj_root}",
-               "run --target={flow} --tool={tool} --build-root={build_dir}",
-               " {fusesoc_core} "]
-  build_log: "{build_dir}/{dut}_flow.log"
-
-  report_cmd: "{proj_root}/hw/lint/tools/{tool}/parse-lint-report.py "
-  report_opts: ["--repdir={build_dir}/lint-{tool} --outdir={build_dir}"]
-  tool_srcs: []
+               "run",
+               "--target={flow}",
+               "--tool={tool}",
+               "--build-root={build_dir}",
+               "{fusesoc_core}"]
 
   // these are not needed currently, but have to be defined
   sv_flist_gen_cmd:   ""
   sv_flist_gen_opts:  []
   sv_flist_gen_dir:   ""
+  tool_srcs:          []
 }

--- a/hw/lint/data/veriblelint.hjson
+++ b/hw/lint/data/veriblelint.hjson
@@ -1,0 +1,13 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+    // TODO(#1342): switch over to native structured tool output, once supported by Verible
+    // Verible lint-specific results parsing script that is called after running lint
+    report_cmd: "{proj_root}/hw/lint/tools/{tool}/parse-lint-report.py "
+    report_opts: ["--repdir={build_dir}",
+                  "--outdir={build_dir}"]
+
+    // This customizes the report format for style lint
+    is_style_lint: True
+}

--- a/hw/lint/tools/veriblelint/parse-lint-report.py
+++ b/hw/lint/tools/veriblelint/parse-lint-report.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+r"""Parses lint report and dump filtered messages in hjson format.
+"""
+import argparse
+import re
+import sys
+from pathlib import Path
+
+import hjson
+
+
+def extract_messages(full_file, patterns, results):
+    """
+    This extracts messages from the sting buffer full_file.
+    The argument patterns needs to be a list of tuples with
+    (<error_severity>, <pattern_to_match_for>).
+    """
+    for severity, pattern in patterns:
+        results[severity] += re.findall(pattern, full_file, flags=re.MULTILINE)
+
+    return results
+
+
+def get_results(resdir):
+    """
+    Parse report and corresponding logfiles and extract error, warning
+    and info messages for each IP present in the result folder
+    """
+    results = {
+        "tool": "veriblelint",
+        "errors": [],
+        "warnings": [],
+        "lint_errors": [],
+        "lint_warnings": [],
+        "lint_infos": []
+    }
+    try:
+        # check the report file for lint INFO, WARNING and ERRORs
+        with Path(resdir).joinpath('lint.log').open() as f:
+            full_file = f.read()
+            err_warn_patterns = {("errors", r"^ERROR: .*"),
+                                 ("errors", r"^Error: .*"),
+                                 ("warnings", r"^WARNING: .*"),
+                                 ("warnings", r"^Warning: .* "),
+                                 ("lint_warnings", r"^.*\[Style:.*")}
+            extract_messages(full_file, err_warn_patterns, results)
+    except IOError as err:
+        results["errors"] += ["IOError: %s" % err]
+
+    return results
+
+
+def main():
+
+    parser = argparse.ArgumentParser(
+        description="""This script parses verible lint log files from
+        a lint run, filters the messages and creates an aggregated result
+        .hjson file with the following fields:
+
+           {"tool": "veriblelint",
+            "errors" : [],
+            "warnings" : [],
+            "lint_errors" : [],
+            "lint_warnings" : [],
+            "lint_infos" : []}
+
+        The fields 'errors' and 'warnings' contain file IO messages or
+        messages output by the tool itself, whereas the fields prefixed with
+        'lint_' contain lint-related messages.
+
+        The script returns nonzero status if any warnings or errors are present.
+        """)
+    parser.add_argument('--repdir',
+                        type=str,
+                        default="./",
+                        help="""The script searches the 'lint.log'
+                        files in this directory.
+                        Defaults to './'""")
+
+    parser.add_argument('--outdir',
+                        type=str,
+                        default="./",
+                        help="Output directory for the 'results.hjson' file. Defaults to '%(default)s'")
+
+    args = parser.parse_args()
+    results = get_results(args.repdir)
+
+    with Path(args.outdir).joinpath("results.hjson").open("w") as results_file:
+        hjson.dump(results,
+                   results_file,
+                   ensure_ascii=False,
+                   for_json=True,
+                   use_decimal=True)
+
+    # return nonzero status if any warnings or errors are present
+    # lint infos do not count as failures
+    nr_errors = len(results["errors"]) + len(results["lint_errors"])
+    nr_warnings = len(results["warnings"]) + len(results["lint_warnings"])
+    print("Lint not successful, got %d warnings and %d errors." %
+          (nr_warnings, nr_errors))
+    if nr_errors > 0 and nr_warnings > 0:
+        sys.exit(1)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/hw/syn/data/common_syn_cfg.hjson
+++ b/hw/syn/data/common_syn_cfg.hjson
@@ -18,13 +18,17 @@
   build_log:        "{build_dir}/synthesis.log"
 
   // We rely on Fusesoc to generate the file list for us
-  sv_flist_gen_cmd:   fusesoc
+  sv_flist_gen_cmd:   "fusesoc"
   fusesoc_core_:      "{eval_cmd} echo \"{fusesoc_core}\" | tr ':' '_'"
 
   // TODO: switch the tool to dc once the corresponding edalize backend is available
-  sv_flist_gen_opts:  ["--cores-root {proj_root} ",
-                       "run --target={flow} --tool icarus --build-root={build_dir}",
-                       "--setup {fusesoc_core}"]
+  sv_flist_gen_opts:  ["--cores-root {proj_root}",
+                       "run"
+                       "--target={flow}",
+                       "--tool icarus",
+                       "--build-root={build_dir}",
+                       "--setup",
+                       "{fusesoc_core}"]
   sv_flist_gen_dir:   "{build_dir}/syn-icarus"
   sv_flist:           "{sv_flist_gen_dir}/{fusesoc_core_}.scr"
 }

--- a/hw/top_earlgrey/lint/top_earlgrey_lint_cfgs.hjson
+++ b/hw/top_earlgrey/lint/top_earlgrey_lint_cfgs.hjson
@@ -6,135 +6,140 @@
   // This is the master cfg hjson for RTL linting. It imports ALL individual lint
   // cfgs of the IPs and the full chip used in top_earlgrey. This enables to run
   // them all as a regression in one shot.
-  name: top_earlgrey_batch_lint
+  name: top_earlgrey_batch
 
   import_cfgs:      [// common server configuration for results upload
-                     "{proj_root}/hw/data/common_project_cfg.hjson"]
+                     "{proj_root}/hw/data/common_project_cfg.hjson"
+                     // tool-specific configuration
+                     "{proj_root}/hw/lint/data/{tool}.hjson"]
+
+  // Different dashboard output path for each tool
+  rel_path: "hw/top_earlgrey/lint/{tool}"
 
   use_cfgs: [{    name: aes
                   fusesoc_core: lowrisc:ip:aes
                   import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
-                  rel_path: "hw/ip/aes/lint"
+                  rel_path: "hw/ip/aes/lint/{tool}"
              },
              {    name: alert_handler
                   fusesoc_core: lowrisc:ip:alert_handler
                   import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
-                  rel_path: "hw/ip/alert_handler/lint"
+                  rel_path: "hw/ip/alert_handler/lint/{tool}"
              },
              {    name: flash_ctrl
                   fusesoc_core: lowrisc:ip:flash_ctrl
                   import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
-                  rel_path: "hw/ip/flash_ctrl/lint"
+                  rel_path: "hw/ip/flash_ctrl/lint/{tool}"
              },
              {    name: gpio
                   fusesoc_core: lowrisc:ip:gpio
                   import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
-                  rel_path: "hw/ip/gpio/lint"
+                  rel_path: "hw/ip/gpio/lint/{tool}"
              },
              {    name: hmac
                   fusesoc_core: lowrisc:ip:hmac
                   import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
-                  rel_path: "hw/ip/hmac/lint"
+                  rel_path: "hw/ip/hmac/lint/{tool}"
              },
              {    name: i2c
                   fusesoc_core: lowrisc:ip:i2c
                   import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
-                  rel_path: "hw/ip/i2c/lint"
+                  rel_path: "hw/ip/i2c/lint/{tool}"
              },
              {    name: nmi_gen
                   fusesoc_core: lowrisc:ip:nmi_gen
                   import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
-                  rel_path: "hw/ip/nmi_gen/lint"
+                  rel_path: "hw/ip/nmi_gen/lint/{tool}"
              },
              {    name: padctrl
                   fusesoc_core: lowrisc:ip:padctrl
                   import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
-                  rel_path: "hw/ip/padctrl/lint"
+                  rel_path: "hw/ip/padctrl/lint/{tool}"
              },
              {    name: padring
                   fusesoc_core: lowrisc:ip:padring
                   import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
-                  rel_path: "hw/ip/padring/lint"
+                  rel_path: "hw/ip/padring/lint/{tool}"
              },
              {    name: pinmux
                   fusesoc_core: lowrisc:ip:pinmux
                   import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
-                  rel_path: "hw/ip/pinmux/lint"
+                  rel_path: "hw/ip/pinmux/lint/{tool}"
              },
              {    name: rv_core_ibex
                   fusesoc_core: lowrisc:ip:rv_core_ibex
                   import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
-                  rel_path: "hw/ip/rv_core_ibex/lint"
+                  rel_path: "hw/ip/rv_core_ibex/lint/{tool}"
              },
              {    name: rv_dm
                   fusesoc_core: lowrisc:ip:rv_dm
                   import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
-                  rel_path: "hw/ip/rv_dm/lint"
+                  rel_path: "hw/ip/rv_dm/lint/{tool}"
              },
              {    name: rv_plic_example
                   fusesoc_core: lowrisc:ip:rv_plic_example
                   import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
-                  rel_path: "hw/ip/rv_plic_example/lint"
+                  rel_path: "hw/ip/rv_plic_example/lint/{tool}"
              },
              {    name: rv_timer
                   fusesoc_core: lowrisc:ip:rv_timer
                   import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
-                  rel_path: "hw/ip/rv_timer/lint"
+                  rel_path: "hw/ip/rv_timer/lint/{tool}"
              },
              {    name: spi_device
                   fusesoc_core: lowrisc:ip:spi_device
                   import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
-                  rel_path: "hw/ip/spi_device/lint"
+                  rel_path: "hw/ip/spi_device/lint/{tool}"
              },
              {    name: uart
                   fusesoc_core: lowrisc:ip:uart
                   import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
-                  rel_path: "hw/ip/uart/lint"
+                  rel_path: "hw/ip/uart/lint/{tool}"
              },
              {    name: usbdev
                   fusesoc_core: lowrisc:ip:usbdev
                   import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
-                  rel_path: "hw/ip/usbdev/lint"
+                  rel_path: "hw/ip/usbdev/lint/{tool}"
              },
              {    name: usb_fs_nb_pe
                   fusesoc_core: lowrisc:ip:usb_fs_nb_pe
                   import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
-                  rel_path: "hw/ip/usb_fs_nb_pe/lint"
+                  rel_path: "hw/ip/usb_fs_nb_pe/lint/{tool}"
              },
              {    name: usbuart
                   fusesoc_core: lowrisc:ip:usbuart
                   import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
-                  rel_path: "hw/ip/usbuart/lint"
+                  rel_path: "hw/ip/usbuart/lint/{tool}"
              },
              {    name: socket_1n
                   fusesoc_core: lowrisc:tlul:socket_1n
                   import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
-                  rel_path: "hw/ip/tlul/socket_1n/lint"
+                  rel_path: "hw/ip/tlul/socket_1n/lint/{tool}"
              },
              {    name: socket_m1
                   fusesoc_core: lowrisc:tlul:socket_m1
                   import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
-                  rel_path: "hw/ip/tlul/socket_m1/lint"
+                  rel_path: "hw/ip/tlul/socket_m1/lint/{tool}"
              },
              {    name: adapter_reg
                   fusesoc_core: lowrisc:tlul:adapter_reg
                   import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
-                  rel_path: "hw/ip/tlul/adapter_reg/lint"
+                  rel_path: "hw/ip/tlul/adapter_reg/lint/{tool}"
              },
              {    name: adapter_sram
                   fusesoc_core: lowrisc:tlul:adapter_sram
                   import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
-                  rel_path: "hw/ip/tlul/adapter_sram/lint"
+                  rel_path: "hw/ip/tlul/adapter_sram/lint/{tool}"
              },
              {    name: sram2tlul
                   fusesoc_core: lowrisc:tlul:sram2tlul
                   import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
-                  rel_path: "hw/ip/tlul/sram2tlul/lint"
+                  rel_path: "hw/ip/tlul/sram2tlul/lint/{tool}"
              },
              {    name: top_earlgrey
                   fusesoc_core: lowrisc:systems:top_earlgrey
                   import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
-                  rel_path: "hw/top_earlgrey/lint"
+                  rel_path: "hw/top_earlgrey/lint/{tool}"
              },
             ]
 }

--- a/util/dvsim/LintCfg.py
+++ b/util/dvsim/LintCfg.py
@@ -34,12 +34,24 @@ class LintCfg(OneShotCfg):
     """Derivative class for linting purposes.
     """
     def __init__(self, flow_cfg_file, proj_root, args):
+        # This is a lint-specific attribute
+        self.is_style_lint = ""
         super().__init__(flow_cfg_file, proj_root, args)
 
     def __post_init__(self):
         super().__post_init__()
+
+        # Convert to boolean
+        if self.is_style_lint == "True":
+            self.is_style_lint = True
+        else:
+            self.is_style_lint = False
+
         # Set the title for lint results.
-        self.results_title = self.name.upper() + " Lint Results"
+        if self.is_style_lint:
+            self.results_title = self.name.upper() + " Style Lint Results"
+        else:
+            self.results_title = self.name.upper() + " Lint Results"
 
     @staticmethod
     def create_instance(flow_cfg_file, proj_root, args):

--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -129,7 +129,7 @@ def main():
     parser.add_argument("-t",
                         "--tool",
                         default="",
-                        metavar="vcs|xcelium|ascentlint|dc|...",
+                        metavar="vcs|xcelium|ascentlint|veriblelint|dc|...",
                         help="Override the tool that is set in hjson file")
 
     parser.add_argument("-select_cfgs",
@@ -483,7 +483,7 @@ def main():
 
     # TODO: SimCfg item below implies DV - need to solve this once we add FPV
     # and other ASIC flow targets.
-    if args.tool == 'ascentlint':
+    if args.tool in ['ascentlint', 'veriblelint']:
         cfg = LintCfg.LintCfg(args.cfg, proj_root, args)
     elif args.tool == 'dc':
         cfg = SynCfg.SynCfg(args.cfg, proj_root, args)


### PR DESCRIPTION
This allows us to call Verible through dvsim and produce a dashboard similar to the one that we produce for Ascentlint. The report parsing script has been largely reused from the Ascentlint flow.
See [here](https://reports.opentitan.org/hw/top_earlgrey/lint/veriblelint/summary.html) for a sneak preview of the dashboard. I am going to add this to my lint cronjob once this PR is merged.

Note that this flow still produces many warnings, since we do not yet make use of the new configurability features that have been added to Verible (#229). For that we have to make sure we can pass the configuration file to Verible through Fusesoc by extending the Edalize backend:
https://github.com/olofk/edalize/blob/63d9512f29dc552099492f10cc45ae0df1490a9f/edalize/veriblelint.py#L64

The "run-in-bash" wrapper is currently needed in order to write the tool output to a logfile. If there would be another way to write such an output file that would of course be great. We mainly have two options to achieve this: we could either add that functionality to Verible or the Fusesoc command wrapper (I tend to prefer the former if that is possible). 

For reference, Ascentlint generates two output files that are of interest to us: 

1) a `.log` file with general tool errors/warnings, including messages from syntax checking.
2) a `.rpt` file with lint-rule-specific messages with different severities (info, warning, error)

Example of Ascentlint invocation in the Edalize backend:
https://github.com/olofk/edalize/blob/63d9512f29dc552099492f10cc45ae0df1490a9f/edalize/templates/ascentlint/Makefile.j2#L7-L8

CC @hzeller @mithro @fangism 

Signed-off-by: Michael Schaffner <msf@opentitan.org>