### PR TITLE
[sw, libbase] Create non-volatile bit manipulation library

### DIFF
--- a/sw/device/lib/base/bitfield.c
+++ b/sw/device/lib/base/bitfield.c
@@ -1,0 +1,9 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/bitfield.h"
+
+// |extern| declarations to give the inline functions in the
+// corresponding header a link location.
+extern void bitfield_set_field32(uint32_t bitfield, bitfield_field32_t field);

--- a/sw/device/lib/base/bitfield.h
+++ b/sw/device/lib/base/bitfield.h
@@ -1,0 +1,46 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_BASE_BITFIELD_H_
+#define OPENTITAN_SW_DEVICE_LIB_BASE_BITFIELD_H_
+
+#include <stdint.h>
+
+/**
+ * Masked field for use in 32-bit bitfields.
+ *
+ * `index` represents a shift in bits starting from the 0 bit of a given 32-bit
+ * bitfield. It is used to zero the memory inside this bitfield by applying an
+ * inverted `mask` at the `index` offset. `value` is then capped by applying
+ * `mask` and is shifted to the `index` bits of the bitfield.
+ *
+ * Example:
+ * ```
+ * 32-bit bitfield = 0b11111111'11111111'11111111'11111111
+ * set_field32( mask = 0b11111111, index = 16, value = 0b01111110 (126) )
+ * result 32-bit bitfield = 0b11111111'01111110'11111111'11111111
+ * ```
+ */
+typedef struct bitfield_field32 {
+  uint32_t mask;  /**< The field mask. */
+  uint32_t index; /**< The field position within a bitfield. */
+  uint32_t value; /**< The field value to be written. */
+} bitfield_field32_t;
+
+/**
+ * Sets @p field in the @p bitfield.
+ *
+ * This function uses the bitfield_field32 type @p field to set a value
+ * at a given offset in @p bitfield. The relevant portion of @p bitfield
+ * is zeroed before the value is set.
+ *
+ * @param bitfield Bitfield to set the field in.
+ * @param field field within selected register field to be set.
+ */
+inline void bitfield_set_field32(uint32_t bitfield, bitfield_field32_t field) {
+  bitfield &= ~(field.mask << field.index);
+  bitfield |= (field.value & field.mask) << field.index;
+}
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_BASE_BITFIELD_H_

--- a/sw/device/lib/base/meson.build
+++ b/sw/device/lib/base/meson.build
@@ -4,6 +4,14 @@
 
 subdir('freestanding')
 
+# Non volatile bit manipulation helper library (sw_lib_bitfield).
+sw_lib_bitfield = declare_dependency(
+  link_with: static_library(
+    'bitfield_ot',
+    sources: ['bitfield.c'],
+  )
+)
+
 # Memory Operations library (sw_lib_mem)
 sw_lib_mem = declare_dependency(
   link_with: static_library(


### PR DESCRIPTION
This change was suggested by Miguel Young, and aims to create a set of bit manipulation routines that can be used across the project.

The functionality added in this change can be used in mmio library, which will simply wrap the non-volatile versions. This would make it easier to create a set of expectations in the mock MMIO library to mimic the mmio library exactly.

There could be other use-cases outside of DIF that could benefit from non-volatile bit manipulation API.

NOTE:

This PR has been deliberately made separate from #1787 , to prevent blocking the former on this PR. The idea is to eventually use `bitfield.h` in `mmio.h`, but this can be done as a follow-up change.

I think it might make sense to split out the rest of the `non-atomic` `mmio` functions, and create non-volatile counterparts - the same principle as with `bitfield_set_field32` and `mmio_region_non_atomic_set_field32`. It could also potentially be used with reggen for increased type safety.

