### PR TITLE
[prim/keccak] Fix the doc meta

### DIFF
--- a/hw/ip/prim/doc/prim_keccak.md
+++ b/hw/ip/prim/doc/prim_keccak.md
@@ -1,6 +1,6 @@
-----
+---
 title: "Primitive Component: Keccak permutation"
-----
+---
 
 # Overview
 


### PR DESCRIPTION
Meta YAML field should begin with `---`, three dashes.
The keccak doc has four dashes in previsou commit.

This is fixed here.

