### PR TITLE
[Toolchain] Upgrade Toolchain to 20200326-1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ variables:
   VERILATOR_PATH: /opt/buildcache/verilator/$(VERILATOR_VERSION)
   TOOLCHAIN_PATH: /opt/buildcache/riscv
   # Release tag from https://github.com/lowRISC/lowrisc-toolchains/releases
-  TOOLCHAIN_VERSION: 20191010-1
+  TOOLCHAIN_VERSION: 20200326-1-rc1
   # This controls where builds happen, and gets picked up by build_consts.sh.
   BUILD_ROOT: $(Build.ArtifactStagingDirectory)
 


### PR DESCRIPTION
The 20200326-1 toolchain includes support for the experimental B (bit
manipulation) extension, but does not enable it when compiling the
toolchain libraries.

---

This PR is currently only intended to test lowrisc/lowrisc-toolchains#13.