### PR TITLE
[dv/tool] Add support to choose sub-cfgs in dvsim.py

### DIFF
--- a/util/dvsim/FlowCfg.py
+++ b/util/dvsim/FlowCfg.py
@@ -30,6 +30,8 @@ class FlowCfg():
         self.items.extend(args.items)
         self.list_items = []
         self.list_items.extend(args.list)
+        self.select_cfgs = []
+        self.select_cfgs.extend(args.select_cfgs)
         self.flow_cfg_file = flow_cfg_file
         self.proj_root = proj_root
         self.args = args
@@ -392,6 +394,19 @@ class FlowCfg():
         for item in self.cfgs:
             item._print_list()
 
+    # function to prune only selected cfgs to build and run
+    # it will return if the object is not a master_cfg or -select_cfgs is empty
+    def prune_selected_cfgs(self):
+        if not self.is_master_cfg or not self.select_cfgs:
+            return
+        else:
+            remove_cfgs = []
+            for item in self.cfgs:
+                if item.name not in self.select_cfgs:
+                    remove_cfgs.append(item)
+            for remove_cfg in remove_cfgs:
+                self.cfgs.remove(remove_cfg)
+
     def _create_deploy_objects(self):
         '''Create deploy objects from items that were passed on for being run.
         The deploy objects for build and run are created from the objects that were
@@ -402,6 +417,7 @@ class FlowCfg():
     def create_deploy_objects(self):
         '''Public facing API for _create_deploy_objects().
         '''
+        self.prune_selected_cfgs()
         if self.is_master_cfg:
             self.deploy = []
             for item in self.cfgs:

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -124,9 +124,11 @@ class SimCfg(FlowCfg):
         # Set the title for simulation results.
         self.results_title = self.name.upper() + " Simulation Results"
 
-        # Stuff below only pertains to individual cfg (not master cfg).
-        if not self.is_master_cfg:
-            # Print info
+        # Stuff below only pertains to individual cfg (not master cfg)
+        # or individual selected cfgs (if select_cfgs is configured via command line)
+        # TODO: find a better way to support select_cfgs
+        if not self.is_master_cfg and (not self.select_cfgs or self.name in self.select_cfgs):
+            # Print info:
             log.info("[scratch_dir]: [%s]: [%s]", self.name, self.scratch_path)
 
             # Set directories with links for ease of debug / triage.

--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -132,6 +132,14 @@ def main():
                         metavar="vcs|xcelium|ascentlint|dc|...",
                         help="Override the tool that is set in hjson file")
 
+    parser.add_argument("-select_cfgs",
+                        nargs="*",
+                        default=[],
+                        metavar="cfg1, cfg2, cfg3, ...",
+                        help="""Specifies which cfg(s) of the master cfg shall be processed.
+                If this switch is not specified, dvsim will process all cfgs specified in
+                the master cfg list.""")
+
     parser.add_argument(
         "-sr",
         "--scratch-root",


### PR DESCRIPTION
Add a parse_arg for user to choose which dut to run in a master cfg that
contains more than one sub-cfgs.

Signed-off-by: Cindy Chen <chencindy@google.com>