### PR TITLE
[prim] Close GAPI file handle in primgen

### DIFF
--- a/hw/ip/prim/util/primgen.py
+++ b/hw/ip/prim/util/primgen.py
@@ -380,7 +380,8 @@ def _get_action_from_gapi(gapi, default_action):
 
 def main():
     gapi_filepath = sys.argv[1]
-    gapi = yaml.load(open(gapi_filepath), Loader=YamlLoader)
+    with open(gapi_filepath) as f:
+        gapi = yaml.load(f, Loader=YamlLoader)
 
     if not _check_gapi(gapi):
         sys.exit(1)


### PR DESCRIPTION
The file was opened, but never closed. Wrap the reading in a context
manager to ensure the file is closed promptly.