### PR TITLE
[dvsim] Fix summary table

### DIFF
--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -504,7 +504,7 @@ class SimCfg(FlowCfg):
                 results_str += self.cov_report_deploy.cov_results
                 self.results_summary[
                     "Coverage"] = self.cov_report_deploy.cov_total
-            else:
+            elif self.cov:
                 self.results_summary["Coverage"] = "--"
 
             # append link of detail result to block name


### PR DESCRIPTION
When coverage isn't enabled rows in the results summary still include a
'--' cell for the non-existent coverage. So 'coverage' must always
appear in the header otherwise the table is mis-printed.