### PR TITLE
Avoid meson 0.54.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,6 +39,8 @@ jobs:
       isort --version
       clang-format -version
       flake8 --version
+      ninja --version
+      meson --version
       echo "PATH=$PATH"
     displayName: Display tool versions
   - bash: |

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -10,8 +10,9 @@ livereload
 mako
 # Meson 0.53.0 broke compatibility with Python 3.5.2, see
 # https://github.com/lowRISC/opentitan/issues/1288 for details.
-# Newer versions are fine.
-meson >= 0.51.0, != 0.53.0 # minimum matches version in meson.build
+# Meson 0.54.0+ requires ninja 1.7+, which isn't available by default on
+# Ubuntu 16.04.
+meson >= 0.51.0, != 0.53.0, <0.54.0 # minimum matches version in meson.build
 mistletoe>=0.7.2
 pyftdi
 pygments


### PR DESCRIPTION
Meson 0.54.0 requires Ninja 1.7, as documented at 
https://mesonbuild.com/Release-notes-for-0-54-0.html. Ubuntu 16.04 only 
ships with ninja 1.5.1 by default (a backport is available). We have no 
need for newer ninja/meson versions at the moment, so let's avoid requiring
all Ubuntu 16.04 users to add/enable a separate repository and stick to
older versions of meson.