### PR TITLE
[aes] Clear internal registers with pseudo-random data

### DIFF
--- a/hw/ip/aes/aes.core
+++ b/hw/ip/aes/aes.core
@@ -14,6 +14,7 @@ filesets:
       - rtl/aes_reg_pkg.sv
       - rtl/aes_reg_top.sv
       - rtl/aes_core.sv
+      - rtl/aes_prng.sv
       - rtl/aes_ctr.sv
       - rtl/aes_control.sv
       - rtl/aes_cipher_core.sv

--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -121,8 +121,10 @@
       fields: [
         { bits: "31:0", name: "data_out", desc: "Output Data" }
       ]
-      tags: [// Updated by the hw. Exclude from write-checks.
-             "excl:CsrNonInitTests:CsrExclWriteCheck"]
+      tags: [// Updated by the HW.
+             // No reset but sync clear with random data.
+             // Exclude from init and write checks.
+             "excl:CsrAllTests:CsrExclCheck"]
       }
     },
 ##############################################################################
@@ -181,6 +183,7 @@
     desc: '''
       Trigger Register.
       Each bit is individually cleared to zero when executing the corresponding trigger.
+
     '''
     swaccess: "wo",
     hwaccess: "hrw",
@@ -194,32 +197,45 @@
       }
       { bits: "1",
         name: "KEY_CLEAR",
+        resval: "1"
         desc:  '''
           Keep current values in Initial Key, internal Full Key and Decryption Key registers (0)
-          or clear those registers to zero (1).
+          or clear those registers with pseudo-random data (1).
         '''
       }
       { bits: "2",
         name: "IV_CLEAR",
+        resval: "1"
         desc:  '''
-          Keep current values in IV registers (0) or clear those registers to zero (1).
+          Keep current values in IV registers (0) or clear those registers with pseudo-random data (1).
         '''
       }
       { bits: "3",
         name: "DATA_IN_CLEAR",
+        resval: "1"
         desc:  '''
-          Keep current values in input registers (0) or clear those registers to zero (1).
+          Keep current values in input registers (0) or clear those registers with pseudo-random data (1).
         '''
       }
       { bits: "4",
         name: "DATA_OUT_CLEAR",
+        resval: "1"
         desc:  '''
-          Keep current values in output registers (0) or clear those registers to zero (1).
+          Keep current values in output registers (0) or clear those registers with pseudo-random data (1).
+        '''
+      }
+      { bits: "5",
+        name: "PRNG_RESEED",
+        resval: "1"
+        desc:  '''
+          Keep continuing with the current internal state of the internal pseudo-random number generator (0) or perform a reseed of the internal state from the connected entropy source (1).
         '''
       }
     ]
-    tags: [// Updated by hw. Exclude from write-checks.
-           "excl:CsrNonInitTests:CsrExclWriteCheck"]
+    tags: [// Updated by the HW.
+           // Reset value cleared to zero.
+           // Exclude from init and write checks.
+           "excl:CsrAllTests:CsrExclCheck"]
   },
   { name: "STATUS",
     desc: "Status Register",

--- a/hw/ip/aes/doc/_index.md
+++ b/hw/ip/aes/doc/_index.md
@@ -183,7 +183,7 @@ The AES unit operates as follows (phrases in italics apply to peculiarities of d
     Since the counter value is used in the first round only, and since the encryption/decryption of a single block takes 12/14/16 cycles, the iterative counter implementation does not affect the throughput of the AES unit._
 1. Finally, the AES cipher core performs the final encryption/decryption round in which the MixColumns operation is skipped.
    The output is forwarded to the output register in the CSRs but not stored back into the State register.
-   The internal State register is cleared to zero.
+   The internal State register is cleared with pseudo-random data.
 
    _Depending on the cipher mode, the output of the final round is potentially XORed with either the value in the IV registers (CBC decryption) or the value stored in the previous input data register (CTR mode), before being forwarded to the output register in the CSRs.
    If running in CBC mode, the IV registers are updated with the output data (encryption) or the value stored in the previous input data register (decryption)._
@@ -411,7 +411,7 @@ It is recommended that software discards the padding bits after reading the outp
 
 After finishing operation, software must:
 1. Disable the AES unit to no longer automatically start encryption/decryption by setting the MANUAL_OPERATION bit in {{< regref "CTRL" >}} to `1`.
-1. Clear all key registers, IV registers as well as the Input Data and the Output Data registers by setting the KEY_CLEAR, IV_CLEAR, DATA_IN_CLEAR and DATA_OUT_CLEAR bits in {{< regref "TRIGGER" >}} to `1`.
+1. Clear all key registers with pseudo-random data, IV registers as well as the Input Data and the Output Data registers by setting the KEY_CLEAR, IV_CLEAR, DATA_IN_CLEAR and DATA_OUT_CLEAR bits in {{< regref "TRIGGER" >}} to `1`.
 
 The code snippet below shows how to perform this task.
 

--- a/hw/ip/aes/rtl/aes.sv
+++ b/hw/ip/aes/rtl/aes.sv
@@ -13,7 +13,14 @@ module aes #(
   input                     clk_i,
   input                     rst_ni,
 
-  // Bus Interface
+  // Entropy source interface
+  // TODO: This still needs to be connected.
+  // See https://github.com/lowRISC/opentitan/issues/1005
+  //output logic              entropy_req_o,
+  //input  logic              entropy_ack_i,
+  //input  logic [63:0]       entropy_i,
+
+  // Bus interface
   input  tlul_pkg::tl_h2d_t tl_i,
   output tlul_pkg::tl_d2h_t tl_o
 );
@@ -23,7 +30,13 @@ module aes #(
   aes_reg2hw_t reg2hw;
   aes_hw2reg_t hw2reg;
 
-  aes_reg_top u_reg (
+  logic        prng_data_req;
+  logic        prng_data_ack;
+  logic [63:0] prng_data;
+  logic        prng_reseed_req;
+  logic        prng_reseed_ack;
+
+  aes_reg_top aes_reg_top (
     .clk_i,
     .rst_ni,
     .tl_i,
@@ -39,8 +52,32 @@ module aes #(
   ) aes_core (
     .clk_i,
     .rst_ni,
+
+    .prng_data_req_o   ( prng_data_req   ),
+    .prng_data_ack_i   ( prng_data_ack   ),
+    .prng_data_i       ( prng_data       ),
+    .prng_reseed_req_o ( prng_reseed_req ),
+    .prng_reseed_ack_i ( prng_reseed_ack ),
+
     .reg2hw,
     .hw2reg
+  );
+
+  aes_prng aes_prng (
+    .clk_i,
+    .rst_ni,
+
+    .data_req_i   ( prng_data_req   ),
+    .data_ack_o   ( prng_data_ack   ),
+    .data_o       ( prng_data       ),
+    .reseed_req_i ( prng_reseed_req ),
+    .reseed_ack_o ( prng_reseed_ack ),
+
+    // TODO: This still needs to be connected to the entropy source.
+    // See https://github.com/lowRISC/opentitan/issues/1005
+    .entropy_req_o(                      ),
+    .entropy_ack_i(                 1'b1 ),
+    .entropy_i    ( 64'hFEDCBA9876543210 )
   );
 
   // All outputs should have a known value after reset

--- a/hw/ip/aes/rtl/aes_prng.sv
+++ b/hw/ip/aes/rtl/aes_prng.sv
@@ -1,0 +1,78 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// AES pseudo-random number generator
+//
+// This module uses an LFSR connected to a PRINCE S-Box to provide pseudo-random data to the AES
+// module primarily for clearing registers. The LFSR can be reseeded using an external interface.
+
+module aes_prng(
+  input  logic        clk_i,
+  input  logic        rst_ni,
+
+  // Connections to AES internals, PRNG consumers
+  input  logic        data_req_i,
+  output logic        data_ack_o,
+  output logic [63:0] data_o,
+  input  logic        reseed_req_i,
+  output logic        reseed_ack_o,
+
+  // Connections to outer world, LFSR re-seed
+  output logic        entropy_req_o,
+  input  logic        entropy_ack_i,
+  input  logic [63:0] entropy_i
+);
+
+  localparam int unsigned DATA_WIDTH = 64;
+
+  // The S-Box of the PRINCE cipher is used to "scramble" the LFSR output.
+  localparam logic[15:0][3:0] PRINCE_SBOX_FWD = {4'h4, 4'hD, 4'h5, 4'hE,
+                                                 4'h0, 4'h8, 4'h7, 4'h6,
+                                                 4'h1, 4'h9, 4'hC, 4'hA,
+                                                 4'h2, 4'h3, 4'hF, 4'hB};
+
+  // "Scramble" with PRINCE cipher S-Box.
+  function automatic logic [63:0] aes_prng_scramble(logic [63:0] in);
+    logic [63:0] out;
+    // The PRINCE cipher S-Box operates on 4-bit nibbles.
+    for (int i=0; i<16; i++) begin
+      out[i*4 +: 4] = PRINCE_SBOX_FWD[in[i*4 +: 4]];
+    end
+    return out;
+  endfunction
+
+  logic [DATA_WIDTH-1:0] lfsr_state;
+  logic                  lfsr_en;
+  logic                  seed_en;
+
+  // The data requests are fed from the LFSR, reseed requests have the highest priority.
+  assign data_ack_o    = reseed_req_i ? 1'b0 : data_req_i;
+
+  // Reseed requests are directly forwarded to the external interface.
+  assign reseed_ack_o  = entropy_ack_i;
+  assign entropy_req_o = reseed_req_i;
+
+  // LFSR control
+  assign lfsr_en = data_req_i & data_ack_o;
+  assign seed_en = entropy_req_o & entropy_ack_i;
+
+  // LFSR instance
+  prim_lfsr #(
+    .LfsrType    ( "GAL_XOR"  ),
+    .LfsrDw      ( DATA_WIDTH ),
+    .StateOutDw  ( DATA_WIDTH )
+  ) aes_prng_lfsr (
+    .clk_i     ( clk_i      ),
+    .rst_ni    ( rst_ni     ),
+    .seed_en_i ( seed_en    ),
+    .seed_i    ( entropy_i  ),
+    .lfsr_en_i ( lfsr_en    ),
+    .entropy_i (         '0 ),
+    .state_o   ( lfsr_state )
+  );
+
+  // "Scramble" the LFSR state.
+  assign data_o = aes_prng_scramble(lfsr_state);
+
+endmodule

--- a/hw/ip/aes/rtl/aes_reg_pkg.sv
+++ b/hw/ip/aes/rtl/aes_reg_pkg.sv
@@ -69,6 +69,9 @@ package aes_reg_pkg;
     struct packed {
       logic        q;
     } data_out_clear;
+    struct packed {
+      logic        q;
+    } prng_reseed;
   } aes_reg2hw_trigger_reg_t;
 
 
@@ -125,6 +128,10 @@ package aes_reg_pkg;
       logic        d;
       logic        de;
     } data_out_clear;
+    struct packed {
+      logic        d;
+      logic        de;
+    } prng_reseed;
   } aes_hw2reg_trigger_reg_t;
 
   typedef struct packed {
@@ -151,25 +158,25 @@ package aes_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    aes_reg2hw_key_mreg_t [7:0] key; // [676:413]
-    aes_reg2hw_iv_mreg_t [3:0] iv; // [412:281]
-    aes_reg2hw_data_in_mreg_t [3:0] data_in; // [280:149]
-    aes_reg2hw_data_out_mreg_t [3:0] data_out; // [148:17]
-    aes_reg2hw_ctrl_reg_t ctrl; // [16:5]
-    aes_reg2hw_trigger_reg_t trigger; // [4:0]
+    aes_reg2hw_key_mreg_t [7:0] key; // [677:414]
+    aes_reg2hw_iv_mreg_t [3:0] iv; // [413:282]
+    aes_reg2hw_data_in_mreg_t [3:0] data_in; // [281:150]
+    aes_reg2hw_data_out_mreg_t [3:0] data_out; // [149:18]
+    aes_reg2hw_ctrl_reg_t ctrl; // [17:6]
+    aes_reg2hw_trigger_reg_t trigger; // [5:0]
   } aes_reg2hw_t;
 
   ///////////////////////////////////////
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    aes_hw2reg_key_mreg_t [7:0] key; // [669:414]
-    aes_hw2reg_iv_mreg_t [3:0] iv; // [413:286]
-    aes_hw2reg_data_in_mreg_t [3:0] data_in; // [285:154]
-    aes_hw2reg_data_out_mreg_t [3:0] data_out; // [153:26]
-    aes_hw2reg_ctrl_reg_t ctrl; // [25:14]
-    aes_hw2reg_trigger_reg_t trigger; // [13:9]
-    aes_hw2reg_status_reg_t status; // [8:9]
+    aes_hw2reg_key_mreg_t [7:0] key; // [671:416]
+    aes_hw2reg_iv_mreg_t [3:0] iv; // [415:288]
+    aes_hw2reg_data_in_mreg_t [3:0] data_in; // [287:156]
+    aes_hw2reg_data_out_mreg_t [3:0] data_out; // [155:28]
+    aes_hw2reg_ctrl_reg_t ctrl; // [27:16]
+    aes_hw2reg_trigger_reg_t trigger; // [15:10]
+    aes_hw2reg_status_reg_t status; // [9:10]
   } aes_hw2reg_t;
 
   // Register Address

--- a/hw/ip/aes/rtl/aes_reg_top.sv
+++ b/hw/ip/aes/rtl/aes_reg_top.sv
@@ -137,6 +137,8 @@ module aes_reg_top (
   logic trigger_data_in_clear_we;
   logic trigger_data_out_clear_wd;
   logic trigger_data_out_clear_we;
+  logic trigger_prng_reseed_wd;
+  logic trigger_prng_reseed_we;
   logic status_idle_qs;
   logic status_stall_qs;
   logic status_output_valid_qs;
@@ -604,7 +606,7 @@ module aes_reg_top (
   prim_subreg #(
     .DW      (1),
     .SWACCESS("WO"),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h1)
   ) u_trigger_key_clear (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -629,7 +631,7 @@ module aes_reg_top (
   prim_subreg #(
     .DW      (1),
     .SWACCESS("WO"),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h1)
   ) u_trigger_iv_clear (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -654,7 +656,7 @@ module aes_reg_top (
   prim_subreg #(
     .DW      (1),
     .SWACCESS("WO"),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h1)
   ) u_trigger_data_in_clear (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -679,7 +681,7 @@ module aes_reg_top (
   prim_subreg #(
     .DW      (1),
     .SWACCESS("WO"),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h1)
   ) u_trigger_data_out_clear (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -695,6 +697,31 @@ module aes_reg_top (
     // to internal hardware
     .qe     (),
     .q      (reg2hw.trigger.data_out_clear.q ),
+
+    .qs     ()
+  );
+
+
+  //   F[prng_reseed]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("WO"),
+    .RESVAL  (1'h1)
+  ) u_trigger_prng_reseed (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (trigger_prng_reseed_we),
+    .wd     (trigger_prng_reseed_wd),
+
+    // from internal hardware
+    .de     (hw2reg.trigger.prng_reseed.de),
+    .d      (hw2reg.trigger.prng_reseed.d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.trigger.prng_reseed.q ),
 
     .qs     ()
   );
@@ -949,6 +976,9 @@ module aes_reg_top (
   assign trigger_data_out_clear_we = addr_hit[21] & reg_we & ~wr_err;
   assign trigger_data_out_clear_wd = reg_wdata[4];
 
+  assign trigger_prng_reseed_we = addr_hit[21] & reg_we & ~wr_err;
+  assign trigger_prng_reseed_wd = reg_wdata[5];
+
 
 
 
@@ -1050,6 +1080,7 @@ module aes_reg_top (
         reg_rdata_next[2] = '0;
         reg_rdata_next[3] = '0;
         reg_rdata_next[4] = '0;
+        reg_rdata_next[5] = '0;
       end
 
       addr_hit[22]: begin


### PR DESCRIPTION
This PR adds an LFSR-based pseudo-random number generator to the AES module that is used to clear various registers (input data, output data, IV, key, internal state). The LFSR can be reseeded at runtime using a bit in the TRIGGER register.

The reset for all these registers is removed. After a reset, the AES unit first reseeds the LFSR and then clears all these registers with pseudo-random data.

At the moment, this LFSR is not yet hooked up with the entropy source. Consequently it is "reseeded" to a deterministic, arbitrarily-chosen value.
