### PR TITLE
[aes/rtl] Adapt coding style of functions

### DIFF
--- a/hw/ip/aes/rtl/aes_ctr.sv
+++ b/hw/ip/aes/rtl/aes_ctr.sv
@@ -19,17 +19,21 @@ module aes_ctr(
 );
 
   // Reverse byte order
-  function automatic logic [15:0][7:0] aes_rev_order_byte(input logic [15:0][7:0] in);
+  function automatic logic [15:0][7:0] aes_rev_order_byte(logic [15:0][7:0] in);
+    logic [15:0][7:0] out;
     for (int i=0; i<16; i++) begin
-      aes_rev_order_byte[i] = in[15-i];
+      out[i] = in[15-i];
     end
+    return out;
   endfunction
 
   // Reverse bit order
-  function automatic logic [7:0] aes_rev_order_bit(input logic [7:0] in);
+  function automatic logic [7:0] aes_rev_order_bit(logic [7:0] in);
+    logic [7:0] out;
     for (int i=0; i<8; i++) begin
-      aes_rev_order_bit[i] = in[7-i];
+      out[i] = in[7-i];
     end
+    return out;
   endfunction
 
   // Types

--- a/hw/ip/aes/rtl/aes_key_expand.sv
+++ b/hw/ip/aes/rtl/aes_key_expand.sv
@@ -161,7 +161,7 @@ module aes_key_expand #(
   end
 
   // RotWord: cyclic byte shift
-  assign rot_word_out = aes_circ_byte_shift(rot_word_in, 3);
+  assign rot_word_out = aes_circ_byte_shift(rot_word_in, 2'h3);
 
   // Mux input for SubWord
   assign sub_word_in = use_rot_word ? rot_word_out : rot_word_in;

--- a/hw/ip/aes/rtl/aes_pkg.sv
+++ b/hw/ip/aes/rtl/aes_pkg.sv
@@ -101,46 +101,53 @@ typedef enum logic [2:0] {
 // Multiplication by {02} (i.e. x) on GF(2^8)
 // with field generating polynomial {01}{1b} (9'h11b)
 // Sometimes also denoted by xtime().
-function automatic logic [7:0] aes_mul2(input logic [7:0] in);
-  aes_mul2[7] = in[6];
-  aes_mul2[6] = in[5];
-  aes_mul2[5] = in[4];
-  aes_mul2[4] = in[3] ^ in[7];
-  aes_mul2[3] = in[2] ^ in[7];
-  aes_mul2[2] = in[1];
-  aes_mul2[1] = in[0] ^ in[7];
-  aes_mul2[0] = in[7];
+function automatic logic [7:0] aes_mul2(logic [7:0] in);
+  logic [7:0] out;
+  out[7] = in[6];
+  out[6] = in[5];
+  out[5] = in[4];
+  out[4] = in[3] ^ in[7];
+  out[3] = in[2] ^ in[7];
+  out[2] = in[1];
+  out[1] = in[0] ^ in[7];
+  out[0] = in[7];
+  return out;
 endfunction
 
 // Multiplication by {04} (i.e. x^2) on GF(2^8)
 // with field generating polynomial {01}{1b} (9'h11b)
-function automatic logic [7:0] aes_mul4(input logic [7:0] in);
-  aes_mul4 = aes_mul2(aes_mul2(in));
+function automatic logic [7:0] aes_mul4(logic [7:0] in);
+  return aes_mul2(aes_mul2(in));
 endfunction
 
 // Division by {02} (i.e. x) on GF(2^8)
 // with field generating polynomial {01}{1b} (9'h11b)
 // This is the inverse of aes_mul2() or xtime().
-function automatic logic [7:0] aes_div2(input logic [7:0] in);
-  aes_div2[7] = in[0];
-  aes_div2[6] = in[7];
-  aes_div2[5] = in[6];
-  aes_div2[4] = in[5];
-  aes_div2[3] = in[4] ^ in[0];
-  aes_div2[2] = in[3] ^ in[0];
-  aes_div2[1] = in[2];
-  aes_div2[0] = in[1] ^ in[0];
+function automatic logic [7:0] aes_div2(logic [7:0] in);
+  logic [7:0] out;
+  out[7] = in[0];
+  out[6] = in[7];
+  out[5] = in[6];
+  out[4] = in[5];
+  out[3] = in[4] ^ in[0];
+  out[2] = in[3] ^ in[0];
+  out[1] = in[2];
+  out[0] = in[1] ^ in[0];
+  return out;
 endfunction
 
 // Circular byte shift to the left
-function automatic logic [31:0] aes_circ_byte_shift(input logic [31:0] in, integer shift);
-  integer s = shift % 4;
-  aes_circ_byte_shift = {in[8*((7-s)%4) +: 8], in[8*((6-s)%4) +: 8],
-                         in[8*((5-s)%4) +: 8], in[8*((4-s)%4) +: 8]};
+function automatic logic [31:0] aes_circ_byte_shift(logic [31:0] in, logic [1:0] shift);
+  logic [31:0] out;
+  logic [31:0] s;
+  s = {30'b0,shift};
+  out = {in[8*((7-s)%4) +: 8], in[8*((6-s)%4) +: 8],
+         in[8*((5-s)%4) +: 8], in[8*((4-s)%4) +: 8]};
+  return out;
 endfunction
 
 // Transpose state matrix
-function automatic logic [3:0][3:0][7:0] aes_transpose(input logic [3:0][3:0][7:0] in);
+function automatic logic [3:0][3:0][7:0] aes_transpose(logic [3:0][3:0][7:0] in);
   logic [3:0][3:0][7:0] transpose;
   transpose = '0;
   for (int j=0; j<4; j++) begin
@@ -152,16 +159,18 @@ function automatic logic [3:0][3:0][7:0] aes_transpose(input logic [3:0][3:0][7:
 endfunction
 
 // Extract single column from state matrix
-function automatic logic [3:0][7:0] aes_col_get(input logic [3:0][3:0][7:0] in, int idx);
+function automatic logic [3:0][7:0] aes_col_get(logic [3:0][3:0][7:0] in, logic [1:0] idx);
+  logic [3:0][7:0] out;
   for (int i=0; i<4; i++) begin
-    aes_col_get[i] = in[i][idx];
+    out[i] = in[i][idx];
   end
+  return out;
 endfunction
 
 // Matrix-vector multiplication in GF(2^8): c = A * b
 function automatic logic [7:0] aes_mvm(
-  input logic [7:0] vec_b,
-  input logic [7:0] mat_a [8]
+  logic [7:0] vec_b,
+  logic [7:0] mat_a [8]
 );
   logic [7:0] vec_c;
   vec_c = '0;

--- a/hw/ip/aes/rtl/aes_sbox_canright.sv
+++ b/hw/ip/aes/rtl/aes_sbox_canright.sv
@@ -21,7 +21,7 @@ module aes_sbox_canright (
 
   // Multiplication in GF(2^2), using normal basis [Omega^2, Omega]
   // (see Figure 14 in the technical report)
-  function automatic logic [1:0] aes_mul_gf2p2(input logic [1:0] g, input logic [1:0] d);
+  function automatic logic [1:0] aes_mul_gf2p2(logic [1:0] g, logic [1:0] d);
     logic [1:0] f;
     logic       a, b, c;
     a    = g[1] & d[1];
@@ -34,7 +34,7 @@ module aes_sbox_canright (
 
   // Scale by Omega^2 = N in GF(2^2), using normal basis [Omega^2, Omega]
   // (see Figure 16 in the technical report)
-  function automatic logic [1:0] aes_scale_omega2_gf2p2(input logic [1:0] g);
+  function automatic logic [1:0] aes_scale_omega2_gf2p2(logic [1:0] g);
     logic [1:0] d;
     d[1] = g[0];
     d[0] = g[1] ^ g[0];
@@ -43,7 +43,7 @@ module aes_sbox_canright (
 
   // Scale by Omega = N^2 in GF(2^2), using normal basis [Omega^2, Omega]
   // (see Figure 15 in the technical report)
-  function automatic logic [1:0] aes_scale_omega_gf2p2(input logic [1:0] g);
+  function automatic logic [1:0] aes_scale_omega_gf2p2(logic [1:0] g);
     logic [1:0] d;
     d[1] = g[1] ^ g[0];
     d[0] = g[1];
@@ -52,7 +52,7 @@ module aes_sbox_canright (
 
   // Square in GF(2^2), using normal basis [Omega^2, Omega]
   // (see Figures 8 and 10 in the technical report)
-  function automatic logic [1:0] aes_square_gf2p2(input logic [1:0] g);
+  function automatic logic [1:0] aes_square_gf2p2(logic [1:0] g);
     logic [1:0] d;
     d[1] = g[0];
     d[0] = g[1];
@@ -61,7 +61,7 @@ module aes_sbox_canright (
 
   // Multiplication in GF(2^4), using normal basis [alpha^8, alpha^2]
   // (see Figure 13 in the technical report)
-  function automatic logic [3:0] aes_mul_gf2p4(input logic [3:0] gamma, input logic [3:0] delta);
+  function automatic logic [3:0] aes_mul_gf2p4(logic [3:0] gamma, logic [3:0] delta);
     logic [3:0] theta;
     logic [1:0] a, b, c;
     a          = aes_mul_gf2p2(gamma[3:2], delta[3:2]);
@@ -74,7 +74,7 @@ module aes_sbox_canright (
 
   // Square and scale by nu in GF(2^4)/GF(2^2), using normal basis [alpha^8, alpha^2]
   // (see Figure 19 as well as Appendix A of the technical report)
-  function automatic logic [3:0] aes_square_scale_gf2p4_gf2p2(input logic [3:0] gamma);
+  function automatic logic [3:0] aes_square_scale_gf2p4_gf2p2(logic [3:0] gamma);
     logic [3:0] delta;
     logic [1:0] a, b;
     a          = gamma[3:2] ^ gamma[1:0];
@@ -86,7 +86,7 @@ module aes_sbox_canright (
 
   // Inverse in GF(2^4), using normal basis [alpha^8, alpha^2]
   // (see Figure 12 in the technical report)
-  function automatic logic [3:0] aes_inverse_gf2p4(input logic [3:0] gamma);
+  function automatic logic [3:0] aes_inverse_gf2p4(logic [3:0] gamma);
     logic [3:0] delta;
     logic [1:0] a, b, c, d;
     a          = gamma[3:2] ^ gamma[1:0];
@@ -100,7 +100,7 @@ module aes_sbox_canright (
 
   // Inverse in GF(2^8), using normal basis [d^16, d]
   // (see Figure 11 in the technical report)
-  function automatic logic [7:0] aes_inverse_gf2p8(input logic [7:0] gamma);
+  function automatic logic [7:0] aes_inverse_gf2p8(logic [7:0] gamma);
     logic [7:0] delta;
     logic [3:0] a, b, c, d;
     a          = gamma[7:4] ^ gamma[3:0];

--- a/hw/ip/aes/rtl/aes_shift_rows.sv
+++ b/hw/ip/aes/rtl/aes_shift_rows.sv
@@ -16,14 +16,14 @@ module aes_shift_rows (
   assign data_o[0] = data_i[0];
 
   // Row 2 does not depend on op_i
-  assign data_o[2] = aes_circ_byte_shift(data_i[2], 2);
+  assign data_o[2] = aes_circ_byte_shift(data_i[2], 2'h2);
 
   // Row 1
-  assign data_o[1] = (op_i == CIPH_FWD) ? aes_circ_byte_shift(data_i[1], -1)
-                                        : aes_circ_byte_shift(data_i[1],  1);
+  assign data_o[1] = (op_i == CIPH_FWD) ? aes_circ_byte_shift(data_i[1], 2'h3)
+                                        : aes_circ_byte_shift(data_i[1], 2'h1);
 
   // Row 3
-  assign data_o[3] = (op_i == CIPH_FWD) ? aes_circ_byte_shift(data_i[3],  1)
-                                        : aes_circ_byte_shift(data_i[3], -1);
+  assign data_o[3] = (op_i == CIPH_FWD) ? aes_circ_byte_shift(data_i[3], 2'h1)
+                                        : aes_circ_byte_shift(data_i[3], 2'h3);
 
 endmodule


### PR DESCRIPTION
This PR changes the coding style of functions to match the updated coding style guidelines. The following is now required:
- Explicitly specify `return`.
- 4-state input/output types only (no more `int`/`integer`)