### PR TITLE
Specify minimum versions of Python dependencies

### DIFF
--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -22,8 +22,8 @@ pyyaml
 tabulate
 yapf
 
-# Development version of edalize until all our changes are upstream
-git+https://github.com/lowRISC/edalize.git@ot
+# Development version with OT-specific changes
+git+https://github.com/lowRISC/fusesoc.git@ot#egg=fusesoc >= 1.11.0
 
 # Development version with OT-specific changes
-git+https://github.com/lowRISC/fusesoc.git@ot
+git+https://github.com/lowRISC/edalize.git@ot#egg=edalize >= 0.2.0

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -5,6 +5,7 @@
 # Keep sorted.
 gitpython
 hjson
+ipyxact >= 0.2.4
 isort
 livereload
 mako
@@ -20,10 +21,6 @@ pytest-timeout
 pyyaml
 tabulate
 yapf
-
-# Develpment version to get around YAML parser warning triggered by fusesoc
-# Upstream tracking: https://github.com/olofk/ipyxact/issues/19
-git+https://github.com/olofk/ipyxact.git@master
 
 # Development version of edalize until all our changes are upstream
 git+https://github.com/lowRISC/edalize.git@ot


### PR DESCRIPTION
We install the fusesoc and edalize Python dependencies from Git
repositories which contain OT-specific modifications (potentially; 
currently, edalize is unmodified, only fusesoc is patched). The 
requirements in python-requirements.txt were written under the assumption
that a call to `pip install -r python-requirements.txt` would aways install
the latest version as specified by the branch argument. This assumption is
wrong, as documented in 
https://pip.readthedocs.io/en/latest/reference/pip_install/#git:

"For non-editable installs, the project is built locally in a temp dir and
then installed normally. Note that if a satisfactory version of the package
is already installed, the VCS source will not overwrite it without an
--upgrade flag. VCS requirements pin the package version
(specified in the setup.py file) of the target commit, not necessarily the
commit itself."

It's still hard to specify the exact version we require and users are 
encouraged to always use the `--upgrade`/`-U` flag with pip to be on the 
safe side. Nonetheless, we can be slightly more specific by adding the 
minimum version we need for fusesoc and edalize.