### PR TITLE
[dv/hmac] support hash_start not set error case

### DIFF
--- a/hw/ip/hmac/data/hmac_testplan.hjson
+++ b/hw/ip/hmac/data/hmac_testplan.hjson
@@ -60,6 +60,17 @@
       tests: ["hmac_datapath_stress"]
     }
     {
+      name: error
+      desc: '''This error case runs sequences that will cause interrupt bit hmac_err to set.
+            This sequence includes:
+            - Write msg_fifo or set hash_start when sha is disabled
+            - Update secret key when hash is in process
+            - Set hash_start when hash is active
+            - Write msg before hash_start is set'''
+      milestone: V2
+      tests: ["hmac_error"]
+    }
+    {
       name: stress_all
       desc: "Stress_all test is a random mix of all the test above except csr tests."
       milestone: V2

--- a/hw/ip/hmac/dv/env/hmac_env.core
+++ b/hw/ip/hmac/dv/env/hmac_env.core
@@ -27,6 +27,7 @@ filesets:
       - seq_lib/hmac_long_msg_vseq.sv: {is_include_file: true}
       - seq_lib/hmac_test_vectors_sha_vseq.sv: {is_include_file: true}
       - seq_lib/hmac_burst_wr_vseq.sv: {is_include_file: true}
+      - seq_lib/hmac_error_vseq.sv: {is_include_file: true}
       - seq_lib/hmac_stress_all_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 

--- a/hw/ip/hmac/dv/env/hmac_env_pkg.sv
+++ b/hw/ip/hmac/dv/env/hmac_env_pkg.sv
@@ -65,7 +65,8 @@ package hmac_env_pkg;
     SwPushMsgWhenShaDisabled   = 32'h 0000_0001,
     SwHashStartWhenShaDisabled = 32'h 0000_0002,
     SwUpdateSecretKeyInProcess = 32'h 0000_0003,
-    SwHashStartWhenActive      = 32'h 0000_0004
+    SwHashStartWhenActive      = 32'h 0000_0004,
+    SwPushMsgWhenIdle          = 32'h 0000_0005
   } err_code_e;
 
   typedef class hmac_env_cfg;

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_error_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_error_vseq.sv
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// this sequence test error cases in hmac, and making sure the core is not locked
+
+class hmac_error_vseq extends hmac_long_msg_vseq;
+  `uvm_object_utils(hmac_error_vseq)
+  `uvm_object_new
+
+  function void pre_randomize();
+    this.legal_seq_c.constraint_mode(0);
+  endfunction
+
+endclass : hmac_error_vseq

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_stress_all_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_stress_all_vseq.sv
@@ -16,6 +16,7 @@ class hmac_stress_all_vseq extends hmac_base_vseq;
                           "hmac_common_vseq", // for intr_test
                           "hmac_datapath_stress_vseq",
                           "hmac_long_msg_vseq",
+                          "hmac_error_vseq",
                           "hmac_test_vectors_sha_vseq",
                           "hmac_test_vectors_hmac_vseq"};
     for (int i = 1; i <= num_trans; i++) begin

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_vseq_list.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_vseq_list.sv
@@ -11,4 +11,5 @@
 `include "hmac_burst_wr_vseq.sv"
 `include "hmac_common_vseq.sv"
 `include "hmac_datapath_stress_vseq.sv"
+`include "hmac_error_vseq.sv"
 `include "hmac_stress_all_vseq.sv"

--- a/hw/ip/hmac/dv/hmac_sim_cfg.hjson
+++ b/hw/ip/hmac/dv/hmac_sim_cfg.hjson
@@ -81,6 +81,11 @@
     }
 
     {
+      name: hmac_error
+      uvm_test_seq: hmac_error_vseq
+    }
+
+    {
       name: hmac_test_sha_vectors
       uvm_test_seq: hmac_test_vectors_sha_vseq
       run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0"]


### PR DESCRIPTION
Add a sequence to run illegal cases for hmac

Thanks to Jon's reporting #1869, this PR adds the sequence to the testbench

Signed-off-by: Cindy Chen <chencindy@google.com>