### PR TITLE
[hmac] Drop the request prior to hash_start

### DIFF
--- a/hw/ip/hmac/rtl/hmac_pkg.sv
+++ b/hw/ip/hmac/rtl/hmac_pkg.sv
@@ -96,7 +96,8 @@ package hmac_pkg;
     SwPushMsgWhenShaDisabled   = 32'h 0000_0001,
     SwHashStartWhenShaDisabled = 32'h 0000_0002,
     SwUpdateSecretKeyInProcess = 32'h 0000_0003,
-    SwHashStartWhenActive      = 32'h 0000_0004
+    SwHashStartWhenActive      = 32'h 0000_0004,
+    SwPushMsgWhenDisallowed    = 32'h 0000_0005
   } err_code_e;
 
 endpackage : hmac_pkg


### PR DESCRIPTION
@jon-flatley  mentioned the case that MSG_FIFO can be back-pressured when the
software writes the message into MSG_FIFO when `hash_start` is not
asserted in issue #1869. It is not desirable behavior as it can lock the
core access. If that happens, core cannot set `hash_start` to flush out
the data.

This commit is to restrict the access from the software. It only allows
the MSG_FIFO (request to packer) from `hash_start` to `hash_process`. If
the software tries to write the message other than the time above, it
drops the request and raises an error with
`SwPushMsgWhenDisallowed(0x5)` error code.

This is related to #1869 #1871

