### PR TITLE
[regtool] Generate C Defines for Interrupt Fields

### DIFF
--- a/util/reggen/validate.py
+++ b/util/reggen/validate.py
@@ -1128,7 +1128,7 @@ def make_intr_reg(regs, name, offset, swaccess, hwaccess, desc):
     bits_used = 0
     genfields = []
     cur_bit = 0
-    for bit in intrs:
+    for (field_idx, bit) in enumerate(intrs):
         newf = {}
         newf['name'] = bit['name']
         w = 1
@@ -1139,6 +1139,13 @@ def make_intr_reg(regs, name, offset, swaccess, hwaccess, desc):
         else:
             newf['bits'] = str(cur_bit)
             newf['bitinfo'] = (1 << cur_bit, 1, cur_bit)
+
+        # Put the automatically generated information back into
+        # `interrupt_list`, so that it can be used to generate C preprocessor
+        # definitions if needed.
+        intrs[field_idx]['bits'] = newf['bits']
+        intrs[field_idx]['bitinfo'] = newf['bitinfo']
+
         if name == 'INTR_ENABLE':
             newf['desc'] = 'Enable interrupt when ' + \
                            ('corresponding bit in ' if w > 1 else '') + \


### PR DESCRIPTION
Each Interrupt register (INTR_ENABLE, INTR_STATE, INTR_TEST) has the
exact same field layout (if the layout is auto-generated). This change
generates an extra set of preprocessor definitions which can be used by
DIFs to access these fields regardless of the interrupt register, rather
than choosing one to use, or not using any at all.

---

Fixes #1206 (I hope)
