### PR TITLE
[dv] Fix unmapped test and add partial mem write support

### DIFF
--- a/hw/dv/data/tests/mem_tests.hjson
+++ b/hw/dv/data/tests/mem_tests.hjson
@@ -15,9 +15,9 @@
     }
 
     {
-      name: "{name}_mem_partial_read"
+      name: "{name}_mem_partial_access"
       en_run_modes: ["mem_tests_mode"]
-      run_opts: ["+run_mem_partial_read"]
+      run_opts: ["+run_mem_partial_access"]
     }
   ]
 
@@ -25,7 +25,7 @@
     {
       name: sw_access
       tests: ["{name}_mem_walk",
-              "{name}_mem_partial_read"]
+              "{name}_mem_partial_access"]
     }
   ]
 }

--- a/hw/dv/sv/cip_lib/doc/index.md
+++ b/hw/dv/sv/cip_lib/doc/index.md
@@ -204,7 +204,7 @@ Some examples:
 * **task run_same_csr_outstanding_vseq**: This task tests the same CSR with
   non-blocking accesses as the regular CSR sequences don't cover that due to
   limitation of uvm_reg.
-* **task run_mem_partial_read_vseq**: This task tests the partial read to the
+* **task run_mem_partial_access_vseq**: This task tests the partial access to the
   memories by randomizing mask, size, and the 2 LSB bits of the address. It also runs
   with non-blocking access enabled.
   ```

--- a/hw/dv/tools/testplans/mem_testplan.hjson
+++ b/hw/dv/tools/testplans/mem_testplan.hjson
@@ -20,10 +20,10 @@
             Verify partial-accessibility of all memories in the design.
             - Do partial reads and writes into the memories and verify the outcome for
               correctness.
+            - Also test outstanding access on memories
             '''
       milestone: V1
-      // mem_walk does partial writes, so we can reuse that test here
-      tests: ["{name}{intf}_mem_walk"]
+      tests: ["{name}{intf}_mem_partial_access"]
     }
     // TODO: add mem access with reset
   ]


### PR DESCRIPTION
Add partial mem write to the seq to match original plan, but no IP
supports that yet
(hmac supports mem partial write, but can't read mem for check)

Signed-off-by: Weicai Yang <weicai@google.com>