### PR TITLE
[syn] Split SDC file into per IP file and add AES example

### DIFF
--- a/hw/ip/aes/syn/aes_syn_cfg.hjson
+++ b/hw/ip/aes/syn/aes_syn_cfg.hjson
@@ -3,16 +3,16 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   // Top level dut name (sv module).
-  name: top_earlgrey
+  name: aes
 
   // Fusesoc core file used for building the file list.
-  fusesoc_core: lowrisc:systems:top_earlgrey:0.1
+  fusesoc_core: lowrisc:ip:aes:0.6
 
   import_cfgs: [// Project wide common synthesis config file
                 "{proj_root}/hw/syn/data/common_syn_cfg.hjson"]
 
   // Timing constraints for this module
-  sdc_file: "{proj_root}/hw/top_earlgrey/syn/constraints.sdc"
+  sdc_file: "{proj_root}/hw/ip/aes/syn/constraints.sdc"
 
   // TODO: add support for loading the constraints here
  }

--- a/hw/ip/aes/syn/constraints.sdc
+++ b/hw/ip/aes/syn/constraints.sdc
@@ -1,0 +1,46 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Generic constraints file for simple testsynthesis flow
+
+# note that we do not fix hold timing in this flow
+set SETUP_CLOCK_UNCERTAINTY 0.5
+
+puts "Applying constraints for AES block"
+
+#####################
+# main clock        #
+#####################
+set MAIN_CLK_PIN clk_i
+set MAIN_RST_PIN rst_ni
+# set main clock to 125 MHz
+set MAIN_TCK  8.0
+set_ideal_network ${MAIN_CLK_PIN}
+set_ideal_network ${MAIN_RST_PIN}
+set_clock_uncertainty ${SETUP_CLOCK_UNCERTAINTY} ${MAIN_CLK_PIN}
+
+# other timing constraint in ns
+set IN_DEL    1.0
+set OUT_DEL   1.0
+set DELAY     ${MAIN_TCK}
+
+create_clock ${MAIN_CLK_PIN} -period ${MAIN_TCK}
+
+# in to out
+set_max_delay ${DELAY} -from [all_inputs] -to [all_outputs]
+# in to reg / reg to out
+set_input_delay ${IN_DEL} [remove_from_collection [all_inputs] {${MAIN_CLK_PIN}}] -clock ${MAIN_CLK_PIN}
+set_output_delay ${OUT_DEL}  [all_outputs] -clock ${MAIN_CLK_PIN}
+
+#####################
+# I/O drive/load    #
+#####################
+
+# attach load and drivers to IOs to get a more realistic estimate
+set_driving_cell  -no_design_rule -lib_cell ${driving_cell} -pin X [all_inputs]
+set_load [load_of ${load_lib}/${load_cell}/A] [all_outputs]
+
+# set a nonzero critical range to be able to spot the violating paths better
+# in the report
+set_critical_range 0.5 ${DUT}

--- a/hw/syn/data/dc.hjson
+++ b/hw/syn/data/dc.hjson
@@ -6,7 +6,7 @@
   // the main synthesis run script and the constraints file
   tool_srcs: ["{proj_root}/hw/foundry/syn/{tool}/setup.tcl"
               "{proj_root}/hw/syn/tools/{tool}/run-syn.tcl"
-              "{proj_root}/hw/syn/tools/{tool}/constraints.sdc"]
+              "{sdc_file}"]
 
   // Environment variables that are needed in the synthesis script
   exports: [{"DUT"       : "{dut}"},

--- a/hw/top_earlgrey/syn/constraints.sdc
+++ b/hw/top_earlgrey/syn/constraints.sdc
@@ -3,13 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Generic constraints file for simple testsynthesis flow
-# This held very simple for now and needs to be refined
 
 # note that we do not fix hold timing in this flow
 set SETUP_CLOCK_UNCERTAINTY 0.5
-
-# TODO: consider splitting this into per-IP .sdc files
-if {$DUT == "top_earlgrey"} {
 
 puts "Applying constraints for top level"
 
@@ -120,36 +116,8 @@ set_clock_groups -name group1 -async -group ${MAIN_CLK_PIN} \
 # loopback path can be considered to be a false path
 set_false_path -from dio_uart_rx_i -to dio_uart_tx_o
 
-} else {
-
 #####################
-# main clock        #
-#####################
-set MAIN_CLK_PIN clk_i
-set MAIN_RST_PIN rst_ni
-# set main clock to 125 MHz
-set MAIN_TCK  8.0
-set_ideal_network ${MAIN_CLK_PIN}
-set_ideal_network ${MAIN_RST_PIN}
-set_clock_uncertainty ${SETUP_CLOCK_UNCERTAINTY} ${MAIN_CLK_PIN}
-
-# other timing constraint in ns
-set IN_DEL    1.0
-set OUT_DEL   1.0
-set DELAY     ${MAIN_TCK}
-
-create_clock ${MAIN_CLK_PIN} -period ${MAIN_TCK}
-
-# in to out
-set_max_delay ${DELAY} -from [all_inputs] -to [all_outputs]
-# in to reg / reg to out
-set_input_delay ${IN_DEL} [remove_from_collection [all_inputs] {${MAIN_CLK_PIN}}] -clock ${MAIN_CLK_PIN}
-set_output_delay ${OUT_DEL}  [all_outputs] -clock ${MAIN_CLK_PIN}
-
-}
-
-#####################
-# Common            #
+# I/O drive/load    #
 #####################
 
 # attach load and drivers to IOs to get a more realistic estimate


### PR DESCRIPTION
This splits the previously shared SDC file for synthesis into per-IP SDC files. I have also added a synthesis configuration for AES to illustrate how this can be used on comportable IPs.

Signed-off-by: Michael Schaffner <msf@opentitan.org>