### PR TITLE
[sw, libbase] Make bitfield lib, set_field32 return value

### DIFF
--- a/sw/device/lib/base/bitfield.c
+++ b/sw/device/lib/base/bitfield.c
@@ -6,4 +6,5 @@
 
 // `extern` declarations to give the inline functions in the
 // corresponding header a link location.
-extern void bitfield_set_field32(uint32_t bitfield, bitfield_field32_t field);
+extern uint32_t bitfield_set_field32(uint32_t bitfield,
+                                     bitfield_field32_t field);

--- a/sw/device/lib/base/bitfield.c
+++ b/sw/device/lib/base/bitfield.c
@@ -4,6 +4,6 @@
 
 #include "sw/device/lib/base/bitfield.h"
 
-// |extern| declarations to give the inline functions in the
+// `extern` declarations to give the inline functions in the
 // corresponding header a link location.
 extern void bitfield_set_field32(uint32_t bitfield, bitfield_field32_t field);

--- a/sw/device/lib/base/bitfield.h
+++ b/sw/device/lib/base/bitfield.h
@@ -29,10 +29,10 @@ typedef struct bitfield_field32 {
 } bitfield_field32_t;
 
 /**
- * Sets @p field in the @p bitfield.
+ * Sets `field` in the `bitfield`.
  *
- * This function uses the bitfield_field32 type @p field to set a value
- * at a given offset in @p bitfield. The relevant portion of @p bitfield
+ * This function uses the bitfield_field32 type `field` to set a value
+ * at a given offset in `bitfield`. The relevant portion of `bitfield`
  * is zeroed before the value is set.
  *
  * @param bitfield Bitfield to set the field in.

--- a/sw/device/lib/base/bitfield.h
+++ b/sw/device/lib/base/bitfield.h
@@ -37,10 +37,13 @@ typedef struct bitfield_field32 {
  *
  * @param bitfield Bitfield to set the field in.
  * @param field field within selected register field to be set.
+ * @return The 32-bit resulting bitfield.
  */
-inline void bitfield_set_field32(uint32_t bitfield, bitfield_field32_t field) {
+inline uint32_t bitfield_set_field32(uint32_t bitfield,
+                                     bitfield_field32_t field) {
   bitfield &= ~(field.mask << field.index);
   bitfield |= (field.value & field.mask) << field.index;
+  return bitfield;
 }
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_BASE_BITFIELD_H_


### PR DESCRIPTION
Without a return value this function is useless (was overlooked in the initial commit).