### PR TITLE
[ibex] Enable PMPs

### DIFF
--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -234,9 +234,9 @@ module top_${top["name"]} #(
 
   // processor core
   rv_core_ibex #(
-    .PMPEnable                (0),
-    .PMPGranularity           (0),
-    .PMPNumRegions            (4),
+    .PMPEnable                (1),
+    .PMPGranularity           (0), // 2^(PMPGranularity+2) == 4 byte granularity
+    .PMPNumRegions            (16),
     .MHPMCounterNum           (8),
     .MHPMCounterWidth         (40),
     .RV32E                    (0),

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -268,9 +268,9 @@ module top_earlgrey #(
 
   // processor core
   rv_core_ibex #(
-    .PMPEnable                (0),
-    .PMPGranularity           (0),
-    .PMPNumRegions            (4),
+    .PMPEnable                (1),
+    .PMPGranularity           (0), // 2^(PMPGranularity+2) == 4 byte granularity
+    .PMPNumRegions            (16),
     .MHPMCounterNum           (8),
     .MHPMCounterWidth         (40),
     .RV32E                    (0),


### PR DESCRIPTION
Enable the maximum of 16 PMPs with the most fine-grained granularity of
a word.

Note that PMP is EXPERIMENTAL at this point and not yet fully verified on the Ibex side. Still, enabling it now has two benefits:

- It gives software an early access to test this fundamental functionality
  during operating system development (with the clear expectation that
  the hardware could be buggy).
- Given the significant area increase of Ibex with PMP enabled, it gives
  us a better indication of area and timing pressure across the chip.

Fixes #1445