### PR TITLE
[sw] Cleanup how Register Headers are used

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -100,14 +100,14 @@ gen_hw_hdr = generator(
 
 # TODO: Considering moving these into hw/ip directories.
 hw_ip_aes_reg_h = gen_hw_hdr.process('hw/ip/aes/data/aes.hjson')
-hw_ip_flash_ctrl_regs_h = gen_hw_hdr.process('hw/ip/flash_ctrl/data/flash_ctrl.hjson')
+hw_ip_flash_ctrl_reg_h = gen_hw_hdr.process('hw/ip/flash_ctrl/data/flash_ctrl.hjson')
 hw_ip_gpio_reg_h = gen_hw_hdr.process('hw/ip/gpio/data/gpio.hjson')
 hw_ip_hmac_reg_h = gen_hw_hdr.process('hw/ip/hmac/data/hmac.hjson')
 hw_ip_spi_device_reg_h = gen_hw_hdr.process('hw/ip/spi_device/data/spi_device.hjson')
 hw_ip_rv_timer_reg_h = gen_hw_hdr.process('hw/ip/rv_timer/data/rv_timer.hjson')
 hw_ip_uart_reg_h = gen_hw_hdr.process('hw/ip/uart/data/uart.hjson')
 hw_ip_usbdev_reg_h = gen_hw_hdr.process('hw/ip/usbdev/data/usbdev.hjson')
-hw_top_earlgrey_pinmux_h = gen_hw_hdr.process('hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson')
-hw_top_earlgrey_rv_plic_h = gen_hw_hdr.process('hw/top_earlgrey/ip/rv_plic/data/autogen/rv_plic.hjson')
+hw_top_earlgrey_pinmux_reg_h = gen_hw_hdr.process('hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson')
+hw_top_earlgrey_rv_plic_reg_h = gen_hw_hdr.process('hw/top_earlgrey/ip/rv_plic/data/autogen/rv_plic.hjson')
 
 subdir('sw')

--- a/sw/device/examples/hello_usbdev/meson.build
+++ b/sw/device/examples/hello_usbdev/meson.build
@@ -6,6 +6,7 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
   hello_usbdev_elf = executable(
     'hello_usbdev_' + device_name,
     sources: [
+      hw_ip_usbdev_reg_h,
       'hello_usbdev.c',
     ],
     name_suffix: 'elf',

--- a/sw/device/examples/hello_usbdev/meson.build
+++ b/sw/device/examples/hello_usbdev/meson.build
@@ -5,7 +5,9 @@
 foreach device_name, device_lib : sw_lib_arch_core_devices
   hello_usbdev_elf = executable(
     'hello_usbdev_' + device_name,
-    sources: ['hello_usbdev.c'],
+    sources: [
+      'hello_usbdev.c',
+    ],
     name_suffix: 'elf',
     dependencies: [
       sw_examples_demos,

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -4,7 +4,6 @@
 
 # UART DIF library (dif_uart)
 dif_uart = declare_dependency(
-  sources: [hw_ip_uart_reg_h],
   link_with: static_library(
     'uart_ot',
     sources: [
@@ -19,7 +18,6 @@ dif_uart = declare_dependency(
 
 # PLIC DIF library (dif_plic)
 dif_plic = declare_dependency(
-  sources: [hw_top_earlgrey_rv_plic_h],
   link_with: static_library(
     'dif_plic_ot',
     sources: [

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -13,7 +13,7 @@ dif_uart = declare_dependency(
     ],
     dependencies: [
       sw_lib_mmio,
-    ]
+    ],
   )
 )
 
@@ -23,10 +23,12 @@ dif_plic = declare_dependency(
   link_with: static_library(
     'dif_plic_ot',
     sources: [
-      hw_top_earlgrey_rv_plic_h,
+      hw_top_earlgrey_rv_plic_reg_h,
       'dif_plic.c',
     ],
-    dependencies: [sw_lib_mmio]
+    dependencies: [
+      sw_lib_mmio,
+    ],
   )
 )
 

--- a/sw/device/lib/meson.build
+++ b/sw/device/lib/meson.build
@@ -27,7 +27,7 @@ sw_lib_flash_ctrl = declare_dependency(
   link_with: static_library(
     'flash_ctrl_ot',
     sources: [
-      hw_ip_flash_ctrl_regs_h,
+      hw_ip_flash_ctrl_reg_h,
       'flash_ctrl.c',
     ]
   )
@@ -39,7 +39,7 @@ sw_lib_pinmux = declare_dependency(
   link_with: static_library(
     'pinmux_ot',
     sources: [
-      hw_top_earlgrey_pinmux_h,
+      hw_top_earlgrey_pinmux_reg_h,
       'pinmux.c',
     ]
   )

--- a/sw/device/lib/meson.build
+++ b/sw/device/lib/meson.build
@@ -23,7 +23,6 @@ sw_lib_uart = declare_dependency(
 
 # Flash controller library (sw_lib_flash_ctrl)
 sw_lib_flash_ctrl = declare_dependency(
-  sources: [hw_ip_flash_ctrl_regs_h],
   link_with: static_library(
     'flash_ctrl_ot',
     sources: [
@@ -35,7 +34,6 @@ sw_lib_flash_ctrl = declare_dependency(
 
 # PINMUX library (sw_lib_pinmux)
 sw_lib_pinmux = declare_dependency(
-  sources: [hw_top_earlgrey_pinmux_h],
   link_with: static_library(
     'pinmux_ot',
     sources: [
@@ -47,7 +45,6 @@ sw_lib_pinmux = declare_dependency(
 
 # AES library (sw_lib_aes)
 sw_lib_aes = declare_dependency(
-  sources: [hw_ip_aes_reg_h],
   link_with: static_library(
     'aes_ot',
     sources: [
@@ -59,7 +56,6 @@ sw_lib_aes = declare_dependency(
 
 # HMAC library (sw_lib_hmac)
 sw_lib_hmac = declare_dependency(
-  sources: [hw_ip_hmac_reg_h],
   link_with: static_library(
     'hmac_ot',
     sources: [
@@ -111,7 +107,6 @@ sw_lib_irq_handlers = declare_dependency(
 
 # RV_TIMER library (sw_lib_rv_timer)
 sw_lib_rv_timer = declare_dependency(
-  sources: [hw_ip_rv_timer_reg_h],
   link_with: static_library(
     'rv_timer_ot',
     sources: [
@@ -135,7 +130,6 @@ sw_lib_spi_device = declare_dependency(
 
 # USB DEV library (sw_lib_usb)
 sw_lib_usb = declare_dependency(
-  sources: [hw_ip_usbdev_reg_h],
   link_with: static_library(
     'usb_ot',
     sources: [

--- a/sw/device/lib/pinmux.c
+++ b/sw/device/lib/pinmux.c
@@ -9,6 +9,8 @@
 
 #define PINMUX0_BASE_ADDR 0x40070000
 
+#include "pinmux_regs.h"  // Generated.
+
 static void init_pinmux_reg(uint32_t reg, uint32_t size, uint32_t num_fields,
                             uint32_t mask, uint32_t start_v) {
   uint32_t reg_value = 0;

--- a/sw/device/lib/pinmux.h
+++ b/sw/device/lib/pinmux.h
@@ -7,8 +7,6 @@
 
 #include <stdint.h>
 
-#include "pinmux_regs.h"  // Generated.
-
 /**
  * PINMUX default initialization.
  */


### PR DESCRIPTION
Before this change, a build directory would contain multiple copies of
each of the generated register definition headers. We now almost
exclusively use these headers from inside the DIF implementations (or
the device drivers, for those hardware ip blocks without DIFs yet), and
do not consider the definitions to be a public interface.

With this in mind, taking any `<ip>_regs.h` file out of the meson-
declared sources for a dependency means it will not be rebuilt by any
library that depends on the implementation that uses the header.

This cuts down on warnings from generating the headers, and ensures
that only one copy of each header should exist in the build directory.

The exception here is `usbdev_regs.h` which is currently used by
`hello_usbdev.c`, but this should be sorted when a USB device DIF is
completed.

---

There is also a commit that does some minimal cleanups to the meson
target definitions: ensuring that all the `*_regs.h` have the same target
suffix, and that DIF target definitions match each other.