### PR TITLE
[topgen] Inter-module validation code

### DIFF
--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -312,6 +312,7 @@
           act: requester
           package: flash_ctrl_pkg
           inst_name: flash_ctrl
+          width: 1
           top_signame: flash_ctrl_eflash_flash
         }
       ]
@@ -760,6 +761,7 @@
           name: flash_ctrl
           act: responder
           inst_name: eflash
+          width: 1
           top_signame: flash_ctrl_eflash_flash
         }
       ]
@@ -1733,6 +1735,7 @@
         act: requester
         package: flash_ctrl_pkg
         inst_name: flash_ctrl
+        width: 1
         top_signame: flash_ctrl_eflash_flash
       }
       {
@@ -1741,6 +1744,7 @@
         name: flash_ctrl
         act: responder
         inst_name: eflash
+        width: 1
         top_signame: flash_ctrl_eflash_flash
       }
     ]

--- a/util/topgen/intermodule.py
+++ b/util/topgen/intermodule.py
@@ -2,11 +2,14 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+import re
 import logging as log
-from typing import Dict
+from typing import Dict, Tuple
 from collections import OrderedDict
 
 from .lib import *
+
+from reggen.validate import check_int
 
 
 def intersignal_format(uid: int, req: Dict, rsp: Dict) -> str:
@@ -65,19 +68,30 @@ def elab_intermodule(topcfg: OrderedDict):
             sig["inst_name"] = x["name"]
             list_of_intersignals.append(sig)
 
-    # TODO: Cross check
-
     # Add field to the topcfg
     topcfg["inter_signal"]["signals"] = list_of_intersignals
+
+    # TODO: Cross check Can be done here not in validate as ipobj is not
+    # available in validate
+    error = check_intermodule(topcfg, "Inter-module Check")
+    assert error is 0, "Inter-module validation is failed cannot move forward."
 
     # intermodule
     definitions = []
 
     uid = 0  # Unique connection ID across the top
 
+    # inter_module: {
+    #   // template 1
+    #   'flash_ctrl.flash': ['eflash.flash_ctrl']
+    #   // template 2
+    #   'module_a.sig_a' : ['module_b.sig_a', 'module_c.sig_a[0]']
+    # },
     for req, rsps in topcfg["inter_module"].items():
         log.info("{req} --> {rsps}".format(req=req, rsps=rsps))
-        req_module, req_signal = req.split('.')
+
+        # Split index
+        req_module, req_signal, req_index = filter_index(req)
 
         # get the module signal
         req_struct = find_intermodule_signal(list_of_intersignals, req_module,
@@ -86,7 +100,9 @@ def elab_intermodule(topcfg: OrderedDict):
         rsp_len = len(rsps)
         for i, rsp in enumerate(rsps):
             assert i == 0, "Handling multiple connections (array) isn't yet supported"
-            rsp_module, rsp_signal = rsp.split('.')
+
+            # Split index
+            rsp_module, rsp_signal, rsp_index = filter_index(rsp)
 
             rsp_struct = find_intermodule_signal(list_of_intersignals,
                                                  rsp_module, rsp_signal)
@@ -138,6 +154,27 @@ def elab_intermodule(topcfg: OrderedDict):
         topcfg["inter_signal"]["definitions"] = definitions
 
 
+def filter_index(signame: str) -> Tuple[str, str, int]:
+    """If the signal has array indicator `[N]` then split and return name and
+    array index. If not, array index is -1.
+
+    param signame module.sig{[N]}
+
+    result (module_name, signal_name, array_index)
+    """
+    m = re.match(r'(\w+)\.(\w+)(\[(\d+)\])*', signame)
+
+    if not m:
+        # Cannot match the pattern
+        return "", "", -1
+
+    if m.groups(3):
+        # array index is not None
+        return m.group(1), m.group(2), m.group(4)
+
+    return m.group(1), m.group(2), -1
+
+
 def find_intermodule_signal(sig_list, m_name, s_name) -> Dict:
     """Return the intermodule signal structure
     """
@@ -146,9 +183,131 @@ def find_intermodule_signal(sig_list, m_name, s_name) -> Dict:
         x for x in sig_list if x["name"] == s_name and x["inst_name"] == m_name
     ]
 
-    assert len(
-        filtered
-    ) == 1, "Error on finding the inter module signal {m_name}.{s_name}".format(
-        m_name=m_name, s_name=s_name)
+    return filtered[0] if len(filtered) == 1 else None
 
-    return filtered[0]
+
+## Validation
+def check_intermodule(topcfg: Dict, prefix: str) -> int:
+    if "inter_module" not in topcfg:
+        return 0
+
+    total_error = 0
+
+    for req, rsps in topcfg["inter_module"].items():
+        error = 0
+        # checking the key, value are in correct format
+        # Allowed format
+        #   1. module.signal
+        #   2. module.signal[index] // Remember array is not yet supported
+        #                           // But allow in format checker
+        #
+        # Example:
+        #   inter_module: {
+        #     'flash_ctrl.flash': ['eflash.flash_ctrl'],
+        #     'life_cycle.provision': ['debug_tap.dbg_en', 'dft_ctrl.en'],
+        #     'otp.pwr_hold': ['pwrmgr.peri[0]'],
+        #     'flash_ctrl.pwr_hold': ['pwrmgr.peri[1]'],
+        #   }
+        #
+        # If length of value list is > 1, then key should be array (width need to match)
+        # If key is format #2, then lenght of value list shall be 1
+        # If one of the value is format #2, then the key should be 1 bit width and
+        # entries of value list should be 1
+        req_m, req_s, req_i = filter_index(req)
+
+        if req_s is "":
+            log.error(
+                "Cannot parse the inter-module signal key '{req}'".format(
+                    req=req))
+            error += 1
+
+        # Check rsps signal format is list
+        if not isinstance(rsps, list):
+            log.error("Value of key '{req}' should be a list".format(req=req))
+            error += 1
+            continue
+
+        req_struct = find_intermodule_signal(topcfg["inter_signal"]["signals"],
+                                             req_m, req_s)
+
+        # Check 'width' field
+        if "width" not in req_struct:
+            req_struct["width"] = 1
+        elif not isinstance(req_struct["width"], int):
+            width, err = check_int(req_struct["width"], req_struct["name"])
+            if err:
+                log.error(
+                    "Inter-module {inst}.{sig} 'width' should be int type.".
+                    format(inst=req_struct["inst_name"],
+                           sig=req_struct["name"]))
+                error += 1
+            else:
+                # convert to int value
+                req_struct["width"] = width
+
+        if req_i != -1 and len(rsps) != 1:
+            # Array format should have one entry
+            log.error(
+                "If key {req} has index, only one entry is allowed.".format(
+                    req=req))
+            error += 1
+
+        # Check rsp format
+        for i, rsp in enumerate(rsps):
+            rsp_m, rsp_s, rsp_i = filter_index(rsp)
+            if rsp_s is "":
+                log.error(
+                    "Cannot parse the inter-module signal key '{req}->{rsp}'".
+                    format(req=req, rsp=rsp))
+                error += 1
+
+            rsp_struct = find_intermodule_signal(
+                topcfg["inter_signal"]["signals"], rsp_m, rsp_s)
+
+            # Check 'width' field
+            width = 1
+            if "width" not in rsp_struct:
+                rsp_struct["width"] = 1
+            elif not isinstance(rsp_struct["width"], int):
+                width, err = check_int(rsp_struct["width"], rsp_struct["name"])
+                if err:
+                    log.error(
+                        "Inter-module {inst}.{sig} 'width' should be int type."
+                        .format(inst=rsp_struct["inst_name"],
+                                sig=rsp_struct["name"]))
+                    error += 1
+                else:
+                    # convert to int value
+                    rsp_struct["width"] = width
+
+            if rsp_i != -1 and req_struct["width"] != 1:
+                # If rsp has index, req should be width 1
+                log.error(
+                    "If rsp {rsp} has an array index, only one-to-one map is allowed."
+                    .format(rsp=rsp))
+                error += 1
+
+        # All rsps are checked, check the total width to req width
+        # If req is array, it is not allowed to have partial connections.
+        # Doing for loop again here: Make code separate from other checker
+        # for easier maintenance
+        total_error += error
+
+        if error != 0:
+            # Skip the check
+            continue
+        rsps_width = 0
+        for rsp in rsps:
+            rsp_m, rsp_s, rsp_i = filter_index(rsp)
+            rsp_struct = find_intermodule_signal(
+                topcfg["inter_signal"]["signals"], rsp_m, rsp_s)
+            # Update total responses width
+            rsps_width += rsp_struct["width"]
+
+        if req_struct["width"] != rsps_width:
+            log.error(
+                "Request {} width is not matched with total responses width {}"
+                .format(req_struct["width"], rsps_width))
+            error += 1
+
+    return total_error

--- a/util/topgen/validate.py
+++ b/util/topgen/validate.py
@@ -58,6 +58,7 @@ top_optional = {
     'pinmux': ['g', 'pinmux definition if doesn\'t exist, tool uses defaults'],
     'padctrl':
     ['g', 'PADS instantiation, if doesn\'t exist, tool creates direct output'],
+    'inter_module': ['g', 'define the signal connections between the modules'],
 }
 
 top_added = {}


### PR DESCRIPTION
topgen didn't have a validation code for inter-module signal.
This commit is to implement basic signal format part for inter_module.
It checks below:

1. Check if req/rsp format is `module.signal{[index]}` ({} means
   optional)
2. Check if request is array and matched the number of entries
3. Check if response has an array index, and request is not an array