### PR TITLE
[sw, dif_uart] Fix documentation

### DIFF
--- a/sw/device/lib/dif/dif_uart.c
+++ b/sw/device/lib/dif/dif_uart.c
@@ -84,7 +84,7 @@ static bool uart_irq_offset_get(dif_uart_interrupt_t irq_type,
 
 static void uart_reset(const dif_uart_t *uart) {
   mmio_region_write32(uart->base_addr, UART_CTRL_REG_OFFSET, 0u);
-  // Write to the relevant bits clears the FIFOs
+  // Write to the relevant bits clears the FIFOs.
   mmio_region_write32(
       uart->base_addr, UART_FIFO_CTRL_REG_OFFSET,
       (1u << UART_FIFO_CTRL_RXRST) | (1u << UART_FIFO_CTRL_TXRST));
@@ -104,19 +104,19 @@ static bool uart_configure(const dif_uart_t *uart,
     return false;
   }
 
-  // Calculation formula: NCO = 2^20 * baud / fclk
+  // Calculation formula: NCO = 2^20 * baud / fclk.
   uint64_t nco = ((uint64_t)config->baudrate << 20) / config->clk_freq_hz;
   uint32_t nco_masked = nco & UART_CTRL_NCO_MASK;
 
-  // Requested baudrate is too high for the given clock frequency
+  // Requested baudrate is too high for the given clock frequency.
   if (nco != nco_masked) {
     return false;
   }
 
-  // Must be called before the first write to any of the UART registers
+  // Must be called before the first write to any of the UART registers.
   uart_reset(uart);
 
-  // Set baudrate, enable RX and TX, configure parity
+  // Set baudrate, enable RX and TX, configure parity.
   uint32_t reg = (nco_masked << UART_CTRL_NCO_OFFSET);
   reg |= (1u << UART_CTRL_TX);
   reg |= (1u << UART_CTRL_RX);
@@ -128,12 +128,12 @@ static bool uart_configure(const dif_uart_t *uart,
   }
   mmio_region_write32(uart->base_addr, UART_CTRL_REG_OFFSET, reg);
 
-  // Reset RX/TX FIFOs
+  // Reset RX/TX FIFOs.
   reg = (1u << UART_FIFO_CTRL_RXRST);
   reg |= (1u << UART_FIFO_CTRL_TXRST);
   mmio_region_write32(uart->base_addr, UART_FIFO_CTRL_REG_OFFSET, reg);
 
-  // Disable interrupts
+  // Disable interrupts.
   mmio_region_write32(uart->base_addr, UART_INTR_ENABLE_REG_OFFSET, 0u);
 
   return true;
@@ -194,7 +194,7 @@ bool dif_uart_watermark_rx_set(const dif_uart_t *uart,
   }
 
   // Check if the requested watermark is valid, and get a corresponding
-  // register definition to be written
+  // register definition to be written.
   bitfield_field32_t field = {
       .mask = UART_FIFO_CTRL_RXILVL_MASK, .index = UART_FIFO_CTRL_RXILVL_OFFSET,
   };
@@ -218,7 +218,7 @@ bool dif_uart_watermark_rx_set(const dif_uart_t *uart,
       return false;
   }
 
-  // Set watermark level
+  // Set watermark level.
   mmio_region_nonatomic_set_field32(uart->base_addr, UART_FIFO_CTRL_REG_OFFSET,
                                     field);
 
@@ -250,11 +250,11 @@ bool dif_uart_watermark_tx_set(const dif_uart_t *uart,
       field.value = UART_FIFO_CTRL_TXILVL_TXLVL16;
       break;
     default:
-      // The minimal TX watermark is 1 byte, maximal 16 bytes
+      // The minimal TX watermark is 1 byte, maximal 16 bytes.
       return false;
   }
 
-  // Set watermark level
+  // Set watermark level.
   mmio_region_nonatomic_set_field32(uart->base_addr, UART_FIFO_CTRL_REG_OFFSET,
                                     field);
 
@@ -267,7 +267,7 @@ bool dif_uart_bytes_send(const dif_uart_t *uart, const uint8_t *data,
     return false;
   }
 
-  // `bytes_written` is an optional parameter
+  // `bytes_written` is an optional parameter.
   size_t res = uart_bytes_send(uart, data, bytes_requested);
   if (bytes_written != NULL) {
     *bytes_written = res;
@@ -282,7 +282,7 @@ bool dif_uart_bytes_receive(const dif_uart_t *uart, size_t bytes_requested,
     return false;
   }
 
-  // `bytes_read` is an optional parameter
+  // `bytes_read` is an optional parameter.
   size_t res = uart_bytes_receive(uart, bytes_requested, data);
   if (bytes_read != NULL) {
     *bytes_read = res;
@@ -296,7 +296,7 @@ bool dif_uart_byte_send_polled(const dif_uart_t *uart, uint8_t byte) {
     return false;
   }
 
-  // Busy wait for the TX FIFO to free up
+  // Busy wait for the TX FIFO to free up.
   while (uart_tx_full(uart)) {
   }
 
@@ -315,7 +315,7 @@ bool dif_uart_byte_receive_polled(const dif_uart_t *uart, uint8_t *byte) {
     return false;
   }
 
-  // Busy wait for the RX message in the FIFO
+  // Busy wait for the RX message in the FIFO.
   while (uart_rx_empty(uart)) {
   }
 
@@ -336,7 +336,7 @@ bool dif_uart_irq_state_get(const dif_uart_t *uart,
     return false;
   }
 
-  // Get the requested interrupt state (enabled/disabled)
+  // Get the requested interrupt state (enabled/disabled).
   bool enabled = mmio_region_get_bit32(uart->base_addr,
                                        UART_INTR_STATE_REG_OFFSET, offset);
   if (enabled) {
@@ -359,7 +359,7 @@ bool dif_uart_irq_state_clear(const dif_uart_t *uart,
     return false;
   }
 
-  // Writing to the register clears the corresponding bits
+  // Writing to the register clears the corresponding bits.
   mmio_region_nonatomic_set_bit32(uart->base_addr, UART_INTR_STATE_REG_OFFSET,
                                   offset);
 
@@ -371,12 +371,12 @@ bool dif_uart_irqs_disable(const dif_uart_t *uart, uint32_t *state) {
     return false;
   }
 
-  // Pass the current interrupt state to the caller
+  // Pass the current interrupt state to the caller.
   if (state != NULL) {
     *state = mmio_region_read32(uart->base_addr, UART_INTR_ENABLE_REG_OFFSET);
   }
 
-  // Disable all UART interrupts
+  // Disable all UART interrupts.
   mmio_region_write32(uart->base_addr, UART_INTR_ENABLE_REG_OFFSET, 0u);
 
   return true;
@@ -387,7 +387,7 @@ bool dif_uart_irqs_restore(const dif_uart_t *uart, uint32_t state) {
     return false;
   }
 
-  // Restore the interrupt state
+  // Restore the interrupt state.
   mmio_region_write32(uart->base_addr, UART_INTR_ENABLE_REG_OFFSET, state);
 
   return true;
@@ -404,7 +404,7 @@ bool dif_uart_irq_enable(const dif_uart_t *uart, dif_uart_interrupt_t irq_type,
     return false;
   }
 
-  // Enable/disable the requested interrupt
+  // Enable/disable the requested interrupt.
   if (enable == kDifUartEnable) {
     mmio_region_nonatomic_set_bit32(uart->base_addr,
                                     UART_INTR_ENABLE_REG_OFFSET, offset);
@@ -426,7 +426,7 @@ bool dif_uart_irq_force(const dif_uart_t *uart, dif_uart_interrupt_t irq_type) {
     return false;
   }
 
-  // Force the requested interrupt
+  // Force the requested interrupt.
   mmio_region_nonatomic_set_bit32(uart->base_addr, UART_INTR_TEST_REG_OFFSET,
                                   offset);
 
@@ -438,7 +438,7 @@ bool dif_uart_rx_bytes_available(const dif_uart_t *uart, size_t *num_bytes) {
     return false;
   }
 
-  // RX FIFO fill level (in bytes)
+  // RX FIFO fill level (in bytes).
   *num_bytes = (size_t)mmio_region_read_mask32(
       uart->base_addr, UART_FIFO_STATUS_REG_OFFSET, UART_FIFO_STATUS_RXLVL_MASK,
       UART_FIFO_STATUS_RXLVL_OFFSET);
@@ -451,7 +451,7 @@ bool dif_uart_tx_bytes_available(const dif_uart_t *uart, size_t *num_bytes) {
     return false;
   }
 
-  // TX FIFO fill level (in bytes)
+  // TX FIFO fill level (in bytes).
   uint32_t fill_bytes = mmio_region_read_mask32(
       uart->base_addr, UART_FIFO_STATUS_REG_OFFSET, UART_FIFO_STATUS_TXLVL_MASK,
       UART_FIFO_STATUS_TXLVL_OFFSET);

--- a/sw/device/lib/dif/dif_uart.h
+++ b/sw/device/lib/dif/dif_uart.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef _SW_DEVICE_LIB_DIF_UART_H_
-#define _SW_DEVICE_LIB_DIF_UART_H_
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_DIF_UART_H_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_DIF_UART_H_
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -11,7 +11,7 @@
 #include "sw/device/lib/base/mmio.h"
 
 /**
- * UART interrupt configuration
+ * UART interrupt configuration.
  *
  * Enumeration used to enable, disable, test and query the UART interrupts.
  * Please see the comportability specification for more information:
@@ -31,28 +31,28 @@ typedef enum dif_uart_interrupt {
 } dif_uart_interrupt_t;
 
 /**
- * TX and RX FIFO depth configuration
+ * TX and RX FIFO depth configuration.
  *
  * Enumeration used to set the upper limit of bytes to queue.
  */
 typedef enum dif_uart_watermark {
-  kDifUartWatermarkByte1 = 0, /**< 1 byte */
-  kDifUartWatermarkByte4,     /**< 4 bytes */
-  kDifUartWatermarkByte8,     /**< 8 bytes */
-  kDifUartWatermarkByte16,    /**< 16 bytes */
-  kDifUartWatermarkByte30,    /**< 30 bytes */
+  kDifUartWatermarkByte1 = 0, /**< 1 byte. */
+  kDifUartWatermarkByte4,     /**< 4 bytes. */
+  kDifUartWatermarkByte8,     /**< 8 bytes. */
+  kDifUartWatermarkByte16,    /**< 16 bytes. */
+  kDifUartWatermarkByte30,    /**< 30 bytes. */
   kDifUartWatermarkLast =
-      kDifUartWatermarkByte30, /**< \internal Final UART watermark */
+      kDifUartWatermarkByte30, /**< \internal Final UART watermark. */
 } dif_uart_watermark_t;
 
 /**
- * Generic enable/disable enumeration
+ * Generic enable/disable enumeration.
  *
  * Enumeration used to enable/disable bits, flags, ...
  */
 typedef enum dif_uart_enable {
-  kDifUartEnable = 0, /**< enable */
-  kDifUartDisable,    /**< disable */
+  kDifUartEnable = 0, /**< enable. */
+  kDifUartDisable,    /**< disable. */
 } dif_uart_enable_t;
 
 /**
@@ -61,88 +61,88 @@ typedef enum dif_uart_enable {
  * Enumeration used to convey parity information
  */
 typedef enum dif_uart_parity {
-  kDifUartParityOdd = 0, /**< odd */
-  kDifUartParityEven,    /**< even */
+  kDifUartParityOdd = 0, /**< odd. */
+  kDifUartParityEven,    /**< even. */
 } dif_uart_parity_t;
 
 /**
- * UART configuration data
+ * UART configuration data.
  *
- * The fundamental data used to configure an UART instance
+ * The fundamental data used to configure an UART instance.
  */
 typedef struct dif_uart_config {
-  uint32_t baudrate;               /**< Requested baudrate */
-  uint32_t clk_freq_hz;            /**< Input clock frequency */
-  dif_uart_enable_t parity_enable; /**< Enable parity check */
-  dif_uart_parity_t parity;        /**< Set parity (even by default) */
+  uint32_t baudrate;               /**< Requested baudrate. */
+  uint32_t clk_freq_hz;            /**< Input clock frequency. */
+  dif_uart_enable_t parity_enable; /**< Enable parity check. */
+  dif_uart_parity_t parity;        /**< Set parity (even by default). */
 } dif_uart_config_t;
 
 /**
- * UART instance state
+ * UART instance state.
  *
  * UART persistent data that is required by all UART API. `base_address` must
  * be initialised by the caller, before passing into the UART DIF init routine.
  */
 typedef struct dif_uart {
-  mmio_region_t base_addr; /**< UART base address */
+  mmio_region_t base_addr; /**< UART base address. */
 } dif_uart_t;
 
 /**
- * Initialise an instance of UART
+ * Initialise an instance of UART.
  *
  * Initialise UART instance using the configuration data in @p config.
  * Information that must be retained, and is required to program UART must be
  * stored in @p uart.
- * @param base_addr Base address of an instance of UART IP block
- * @param config UART configuration data
- * @param uart UART state data
- * @return true if the function was successful, false otherwise
+ * @param base_addr Base address of an instance of UART IP block.
+ * @param config UART configuration data.
+ * @param uart UART state data.
+ * @return true if the function was successful, false otherwise.
  */
 bool dif_uart_init(mmio_region_t base_addr, const dif_uart_config_t *config,
                    dif_uart_t *uart);
 
 /**
- * Configure an instance of UART
+ * Configure an instance of UART.
  *
  * Configure UART using the configuration data in @p config. This operation
  * performs fundamental configuration.
  *
- * @param uart UART state data
- * @param config UART configuration data
- * @return true if the function was successful, false otherwise
+ * @param uart UART state data.
+ * @param config UART configuration data.
+ * @return true if the function was successful, false otherwise.
  */
 bool dif_uart_configure(const dif_uart_t *uart,
                         const dif_uart_config_t *config);
 
 /**
- * Set the RX FIFO watermark
+ * Set the RX FIFO watermark.
  *
  * Set the RX FIFO watermark, is only useful when the corresponding interrupt
  * is enabled. When the queued RX FIFO number of bytes rises to or above this
  * level, the RX watermark interrupt is raised.
  *
- * @param uart UART state data
- * @param watermark RX FIFO watermark
- * @return true if the function was successful, false otherwise
+ * @param uart UART state data.
+ * @param watermark RX FIFO watermark.
+ * @return true if the function was successful, false otherwise.
  */
 bool dif_uart_watermark_rx_set(const dif_uart_t *uart,
                                dif_uart_watermark_t watermark);
 /**
- * Set the TX FIFO watermark
+ * Set the TX FIFO watermark.
  *
  * Set the TX FIFO watermark, is only useful when the corresponding interrupt
  * is enabled. When the queued TX FIFO number of bytes falls to or below this
  * level, the TX watermark interrupt is raised.
  *
- * @param uart UART state data
- * @param watermark TX FIFO watermark
- * @return true if the function was successful, false otherwise
+ * @param uart UART state data.
+ * @param watermark TX FIFO watermark.
+ * @return true if the function was successful, false otherwise.
  */
 bool dif_uart_watermark_tx_set(const dif_uart_t *uart,
                                dif_uart_watermark_t watermark);
 
 /**
- * UART send bytes
+ * UART send bytes.
  *
  * Non-blocking UART send bytes routine. Can be used from inside an UART ISR.
  * This function attempts to write @p bytes_requested number of bytes to the
@@ -150,17 +150,17 @@ bool dif_uart_watermark_tx_set(const dif_uart_t *uart,
  * the caller. @p bytes_written is optional, NULL should be passed in if the
  * value is not needed.
  *
- * @param uart UART state data
- * @param data Data to be written
- * @param bytes_requested Number of bytes requested to be written by the caller
- * @param bytes_written Number of bytes written (optional)
- * @return true if the function was successful, false otherwise
+ * @param uart UART state data.
+ * @param data Data to be written.
+ * @param bytes_requested Number of bytes requested to be written by the caller.
+ * @param bytes_written Number of bytes written (optional).
+ * @return true if the function was successful, false otherwise.
  */
 bool dif_uart_bytes_send(const dif_uart_t *uart, const uint8_t *data,
                          size_t bytes_requested, size_t *bytes_written);
 
 /**
- * UART receive bytes
+ * UART receive bytes.
  *
  * Non-blocking UART receive bytes routine. Can be used from inside an UART ISR.
  * This function attempts to read @p bytes_requested number of bytes from the
@@ -168,136 +168,136 @@ bool dif_uart_bytes_send(const dif_uart_t *uart, const uint8_t *data,
  * @p bytes_read is optional, NULL should be passed in if the value is not
  * needed.
  *
- * @param uart UART state data
- * @param bytes_requested Number of bytes requested to be read by the caller
- * @param data Data to be read
- * @param bytes_read Number of bytes read (optional)
- * @return true if the function was successful, false otherwise
+ * @param uart UART state data.
+ * @param bytes_requested Number of bytes requested to be read by the caller.
+ * @param data Data to be read.
+ * @param bytes_read Number of bytes read (optional).
+ * @return true if the function was successful, false otherwise.
  */
 bool dif_uart_bytes_receive(const dif_uart_t *uart, size_t bytes_requested,
                             uint8_t *data, size_t *bytes_read);
 
 /**
- * Transmit a single UART byte (polled)
+ * Transmit a single UART byte (polled).
  *
  * Transmit a single UART byte @p byte. This operation is polled, and will busy
  * wait until a byte has been sent. Must not be used inside an ISR.
  *
- * @param uart UART state data
- * @param byte Byte to be transmitted
- * @return true if the function was successful, false otherwise
+ * @param uart UART state data.
+ * @param byte Byte to be transmitted.
+ * @return true if the function was successful, false otherwise.
  */
 bool dif_uart_byte_send_polled(const dif_uart_t *uart, uint8_t byte);
 
 /**
- * Receive a single UART byte (polled)
+ * Receive a single UART byte (polled).
  *
  * Receive a single UART byte and store it in @p byte. This operation is polled,
  * and will busy wait until a byte has been read. Must not be used inside an
  * ISR.
  *
- * @param uart UART state data
- * @param byte Received byte
- * @return true if the function was successful, false otherwise
+ * @param uart UART state data.
+ * @param byte Received byte.
+ * @return true if the function was successful, false otherwise.
  */
 bool dif_uart_byte_receive_polled(const dif_uart_t *uart, uint8_t *byte);
 
 /**
- * UART get requested IRQ state
+ * UART get requested IRQ state.
  *
  * Get the state of the requested IRQ in @p irq_type.
  *
- * @param uart UART state data
- * @param irq_type IRQ to get the state of
- * @param state IRQ state passed back to the caller
- * @return true if the function was successful, false otherwise
+ * @param uart UART state data.
+ * @param irq_type IRQ to get the state of.
+ * @param state IRQ state passed back to the caller.
+ * @return true if the function was successful, false otherwise.
  */
 bool dif_uart_irq_state_get(const dif_uart_t *uart,
                             dif_uart_interrupt_t irq_type,
                             dif_uart_enable_t *state);
 /**
- * UART clear requested IRQ state
+ * UART clear requested IRQ state.
  *
  * Clear the state of the requested IRQ in @p irq_type. Primary use of this
  * function is to de-assert the interrupt after it has been serviced.
  *
- * @param uart UART state data
- * @param irq_type IRQ to be de-asserted
- * @return true if the function was successful, false otherwise
+ * @param uart UART state data.
+ * @param irq_type IRQ to be de-asserted.
+ * @return true if the function was successful, false otherwise.
  */
 bool dif_uart_irq_state_clear(const dif_uart_t *uart,
                               dif_uart_interrupt_t irq_type);
 
 /**
- * UART disable interrupts
+ * UART disable interrupts.
  *
  * Disable generation of all UART interrupts, and pass previous interrupt state
  * in @p state back to the caller. Parameter @p state is ignored if NULL.
  *
- * @param uart UART state data
- * @param state IRQ state passed back to the caller
- * @return true if the function was successful, false otherwise
+ * @param uart UART state data.
+ * @param state IRQ state passed back to the caller.
+ * @return true if the function was successful, false otherwise.
  */
 bool dif_uart_irqs_disable(const dif_uart_t *uart, uint32_t *state);
 
 /**
- * UART restore IRQ state
+ * UART restore IRQ state.
  *
  * Restore previous UART IRQ state. This function is used to restore the
  * UART interrupt state prior to dif_uart_irqs_disable function call.
  *
- * @param uart UART state data
- * @param state IRQ state to restore
- * @return true if the function was successful, false otherwise
+ * @param uart UART state data.
+ * @param state IRQ state to restore.
+ * @return true if the function was successful, false otherwise.
  */
 bool dif_uart_irqs_restore(const dif_uart_t *uart, uint32_t state);
 
 /**
- * UART interrupt control
+ * UART interrupt control.
  *
  * Enable/disable an UART interrupt specified in @p enable.
  *
- * @param uart UART state data
- * @param irq_type UART interrupt type
- * @param enable enable or disable the interrupt
- * @return true if the function was successful, false otherwise
+ * @param uart UART state data.
+ * @param irq_type UART interrupt type.
+ * @param enable enable or disable the interrupt.
+ * @return true if the function was successful, false otherwise.
  */
 bool dif_uart_irq_enable(const dif_uart_t *uart, dif_uart_interrupt_t irq_type,
                          dif_uart_enable_t enable);
 
 /**
- * UART interrupt force
+ * UART interrupt force.
  *
  * Force interrupt specified in @p irq_type.
  *
- * @param uart UART state data
- * @param irq_type UART interrupt type to be forced
- * @return true if the function was successful, false otherwise
+ * @param uart UART state data.
+ * @param irq_type UART interrupt type to be forced.
+ * @return true if the function was successful, false otherwise.
  */
 bool dif_uart_irq_force(const dif_uart_t *uart, dif_uart_interrupt_t irq_type);
 
 /**
- * UART RX bytes available
+ * UART RX bytes available.
  *
  * Get the number of bytes available to be read from the UART RX FIFO. This
  * function can be used to check FIFO full and empty conditions.
  *
- * @param uart UART state data
- * @param num_bytes Number of bytes available to be read
- * @return true if the function was successful, false otherwise
+ * @param uart UART state data.
+ * @param num_bytes Number of bytes available to be read.
+ * @return true if the function was successful, false otherwise.
  */
 bool dif_uart_rx_bytes_available(const dif_uart_t *uart, size_t *num_bytes);
 
 /**
- * UART TX bytes available
+ * UART TX bytes available.
  *
  * Get the number of bytes available to be written to the UART TX FIFO. This
  * function can be used to check FIFO full and empty conditions.
  *
- * @param uart UART state data
- * @param num_bytes Number of bytes available to be written
- * @return true if the function was successful, false otherwise
+ * @param uart UART state data.
+ * @param num_bytes Number of bytes available to be written.
+ * @return true if the function was successful, false otherwise.
  */
 bool dif_uart_tx_bytes_available(const dif_uart_t *uart, size_t *num_bytes);
 
-#endif
+#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_DIF_UART_H_

--- a/sw/device/lib/dif/dif_uart.h
+++ b/sw/device/lib/dif/dif_uart.h
@@ -90,9 +90,9 @@ typedef struct dif_uart {
 /**
  * Initialise an instance of UART.
  *
- * Initialise UART instance using the configuration data in @p config.
+ * Initialise UART instance using the configuration data in `config`.
  * Information that must be retained, and is required to program UART must be
- * stored in @p uart.
+ * stored in `uart`.
  * @param base_addr Base address of an instance of UART IP block.
  * @param config UART configuration data.
  * @param uart UART state data.
@@ -104,7 +104,7 @@ bool dif_uart_init(mmio_region_t base_addr, const dif_uart_config_t *config,
 /**
  * Configure an instance of UART.
  *
- * Configure UART using the configuration data in @p config. This operation
+ * Configure UART using the configuration data in `config`. This operation
  * performs fundamental configuration.
  *
  * @param uart UART state data.
@@ -145,9 +145,9 @@ bool dif_uart_watermark_tx_set(const dif_uart_t *uart,
  * UART send bytes.
  *
  * Non-blocking UART send bytes routine. Can be used from inside an UART ISR.
- * This function attempts to write @p bytes_requested number of bytes to the
- * UART TX FIFO from @p bytes_requested, and passes @p bytes_written back to
- * the caller. @p bytes_written is optional, NULL should be passed in if the
+ * This function attempts to write `bytes_requested` number of bytes to the
+ * UART TX FIFO from `bytes_requested`, and passes `bytes_written` back to
+ * the caller. `bytes_written` is optional, NULL should be passed in if the
  * value is not needed.
  *
  * @param uart UART state data.
@@ -163,9 +163,9 @@ bool dif_uart_bytes_send(const dif_uart_t *uart, const uint8_t *data,
  * UART receive bytes.
  *
  * Non-blocking UART receive bytes routine. Can be used from inside an UART ISR.
- * This function attempts to read @p bytes_requested number of bytes from the
- * UART RX FIFO into @p data, and passes @p bytes_read back to the caller.
- * @p bytes_read is optional, NULL should be passed in if the value is not
+ * This function attempts to read `bytes_requested` number of bytes from the
+ * UART RX FIFO into `data`, and passes `bytes_read` back to the caller.
+ * `bytes_read` is optional, NULL should be passed in if the value is not
  * needed.
  *
  * @param uart UART state data.
@@ -180,7 +180,7 @@ bool dif_uart_bytes_receive(const dif_uart_t *uart, size_t bytes_requested,
 /**
  * Transmit a single UART byte (polled).
  *
- * Transmit a single UART byte @p byte. This operation is polled, and will busy
+ * Transmit a single UART byte `byte`. This operation is polled, and will busy
  * wait until a byte has been sent. Must not be used inside an ISR.
  *
  * @param uart UART state data.
@@ -192,7 +192,7 @@ bool dif_uart_byte_send_polled(const dif_uart_t *uart, uint8_t byte);
 /**
  * Receive a single UART byte (polled).
  *
- * Receive a single UART byte and store it in @p byte. This operation is polled,
+ * Receive a single UART byte and store it in `byte`. This operation is polled,
  * and will busy wait until a byte has been read. Must not be used inside an
  * ISR.
  *
@@ -205,7 +205,7 @@ bool dif_uart_byte_receive_polled(const dif_uart_t *uart, uint8_t *byte);
 /**
  * UART get requested IRQ state.
  *
- * Get the state of the requested IRQ in @p irq_type.
+ * Get the state of the requested IRQ in `irq_type`.
  *
  * @param uart UART state data.
  * @param irq_type IRQ to get the state of.
@@ -218,7 +218,7 @@ bool dif_uart_irq_state_get(const dif_uart_t *uart,
 /**
  * UART clear requested IRQ state.
  *
- * Clear the state of the requested IRQ in @p irq_type. Primary use of this
+ * Clear the state of the requested IRQ in `irq_type`. Primary use of this
  * function is to de-assert the interrupt after it has been serviced.
  *
  * @param uart UART state data.
@@ -232,7 +232,7 @@ bool dif_uart_irq_state_clear(const dif_uart_t *uart,
  * UART disable interrupts.
  *
  * Disable generation of all UART interrupts, and pass previous interrupt state
- * in @p state back to the caller. Parameter @p state is ignored if NULL.
+ * in `state` back to the caller. Parameter `state` is ignored if NULL.
  *
  * @param uart UART state data.
  * @param state IRQ state passed back to the caller.
@@ -244,7 +244,7 @@ bool dif_uart_irqs_disable(const dif_uart_t *uart, uint32_t *state);
  * UART restore IRQ state.
  *
  * Restore previous UART IRQ state. This function is used to restore the
- * UART interrupt state prior to dif_uart_irqs_disable function call.
+ * UART interrupt state prior to `dif_uart_irqs_disable` function call.
  *
  * @param uart UART state data.
  * @param state IRQ state to restore.
@@ -255,7 +255,7 @@ bool dif_uart_irqs_restore(const dif_uart_t *uart, uint32_t state);
 /**
  * UART interrupt control.
  *
- * Enable/disable an UART interrupt specified in @p enable.
+ * Enable/disable an UART interrupt specified in `enable`.
  *
  * @param uart UART state data.
  * @param irq_type UART interrupt type.
@@ -268,7 +268,7 @@ bool dif_uart_irq_enable(const dif_uart_t *uart, dif_uart_interrupt_t irq_type,
 /**
  * UART interrupt force.
  *
- * Force interrupt specified in @p irq_type.
+ * Force interrupt specified in `irq_type`.
  *
  * @param uart UART state data.
  * @param irq_type UART interrupt type to be forced.


### PR DESCRIPTION
1) Add full stop at the end of every comment.
2) Substitute @ for backticks.