### PR TITLE
[sw] Fix Software Code Formatting

### DIFF
--- a/sw/device/benchmarks/coremark/top_earlgrey/core_portme.h
+++ b/sw/device/benchmarks/coremark/top_earlgrey/core_portme.h
@@ -182,9 +182,7 @@ typedef ee_u32 CORE_TICKS;
 */
 extern ee_u32 default_num_contexts;
 
-typedef struct CORE_PORTABLE_S {
-  ee_u8 portable_id;
-} core_portable;
+typedef struct CORE_PORTABLE_S { ee_u8 portable_id; } core_portable;
 
 /* target specific init/fini */
 void portable_init(core_portable *p, int *argc, char *argv[]);

--- a/sw/device/boot_rom/boot_rom.c
+++ b/sw/device/boot_rom/boot_rom.c
@@ -23,9 +23,7 @@
  * by the flash binary: see sw/device/exts/common/flash_link.ld
  * for that.
  */
-extern struct {
-  void (*entry)(void);
-} _flash_header;
+extern struct { void (*entry)(void); } _flash_header;
 
 void _boot_start(void) {
   pinmux_init();

--- a/sw/device/examples/demos.c
+++ b/sw/device/examples/demos.c
@@ -7,8 +7,8 @@
 #include <stdbool.h>
 
 #include "sw/device/lib/arch/device.h"
-#include "sw/device/lib/dif/dif_gpio.h"
 #include "sw/device/lib/base/log.h"
+#include "sw/device/lib/dif/dif_gpio.h"
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/spi_device.h"
 #include "sw/device/lib/uart.h"

--- a/sw/device/examples/hello_usbdev/hello_usbdev.c
+++ b/sw/device/examples/hello_usbdev/hello_usbdev.c
@@ -7,9 +7,9 @@
 
 #include "sw/device/examples/demos.h"
 #include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/log.h"
 #include "sw/device/lib/common.h"
 #include "sw/device/lib/dif/dif_gpio.h"
-#include "sw/device/lib/base/log.h"
 #include "sw/device/lib/pinmux.h"
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/spi_device.h"
@@ -26,15 +26,12 @@
  * Configuration values for USB.
  */
 static uint8_t config_descriptors[] = {
-    USB_CFG_DSCR_HEAD(USB_CFG_DSCR_LEN +
-                          2 * (USB_INTERFACE_DSCR_LEN + 2 * USB_EP_DSCR_LEN),
-                      2),
-    VEND_INTERFACE_DSCR(0, 2, 0x50, 1),
-    USB_BULK_EP_DSCR(0, 1, 32, 0),
-    USB_BULK_EP_DSCR(1, 1, 32, 4),
-    VEND_INTERFACE_DSCR(1, 2, 0x50, 1),
-    USB_BULK_EP_DSCR(0, 2, 32, 0),
-    USB_BULK_EP_DSCR(1, 2, 32, 4),
+    USB_CFG_DSCR_HEAD(
+        USB_CFG_DSCR_LEN + 2 * (USB_INTERFACE_DSCR_LEN + 2 * USB_EP_DSCR_LEN),
+        2),
+    VEND_INTERFACE_DSCR(0, 2, 0x50, 1), USB_BULK_EP_DSCR(0, 1, 32, 0),
+    USB_BULK_EP_DSCR(1, 1, 32, 4), VEND_INTERFACE_DSCR(1, 2, 0x50, 1),
+    USB_BULK_EP_DSCR(0, 2, 32, 0), USB_BULK_EP_DSCR(1, 2, 32, 4),
 };
 
 /**

--- a/sw/device/examples/hello_world/hello_world.c
+++ b/sw/device/examples/hello_world/hello_world.c
@@ -16,7 +16,7 @@ static dif_gpio_t gpio;
 int main(int argc, char **argv) {
   uart_init(kUartBaudrate);
   base_set_stdout(uart_stdout);
-  
+
   pinmux_init();
   spid_init();
 

--- a/sw/device/lib/arch/device_sim_dv.c
+++ b/sw/device/lib/arch/device_sim_dv.c
@@ -15,4 +15,4 @@ const device_type_t kDeviceType = kDeviceSimDV;
 
 const uint64_t kClockFreqHz = 50 * 1000 * 1000;  // 50MHz
 
-const uint64_t kUartBaudrate = 2 * (1 << 20); // 2Mib/s
+const uint64_t kUartBaudrate = 2 * (1 << 20);  // 2Mib/s

--- a/sw/device/lib/base/log.c
+++ b/sw/device/lib/base/log.c
@@ -36,20 +36,22 @@ static const char *stringify_severity(log_severity_t severity) {
  */
 void base_log_internal_core(log_severity_t severity, const char *file_name,
                             uint32_t line, const char *format, ...) {
-  size_t file_name_len = ((char *)memchr(file_name, '\0', PTRDIFF_MAX)) - file_name;
+  size_t file_name_len =
+      ((char *)memchr(file_name, '\0', PTRDIFF_MAX)) - file_name;
   const char *base_name = memrchr(file_name, '/', file_name_len);
   if (base_name == NULL) {
     base_name = file_name;
-  } else { 
+  } else {
     ++base_name;  // Remove the final '/'.
   }
 
-  // A small global counter that increments with each log line. This can be useful for
-  // seeing how many times this function has been called, even if nothing was printed
-  // for some time.
+  // A small global counter that increments with each log line. This can be
+  // useful for seeing how many times this function has been called, even if
+  // nothing was printed for some time.
   static uint16_t global_log_counter = 0;
 
-  base_printf("%s%5d %s:%d] ", stringify_severity(severity), global_log_counter, base_name, line);
+  base_printf("%s%5d %s:%d] ", stringify_severity(severity), global_log_counter,
+              base_name, line);
   ++global_log_counter;
 
   va_list args;

--- a/sw/device/lib/base/log.h
+++ b/sw/device/lib/base/log.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef OPENTITAN_SW_DEVICE_LIB_LOG_H_
-#define OPENTITAN_SW_DEVICE_LIB_LOG_H_
+#ifndef OPENTITAN_SW_DEVICE_LIB_BASE_LOG_H_
+#define OPENTITAN_SW_DEVICE_LIB_BASE_LOG_H_
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -130,4 +130,4 @@ void base_log_internal_dv(log_severity_t severity, const char *format, ...);
  */
 #define LOG_ERROR(...) LOG(kLogSeverityError, __VA_ARGS__)
 
-#endif  // OPENTITAN_SW_DEVICE_LIB_LOG_H_
+#endif  // OPENTITAN_SW_DEVICE_LIB_BASE_LOG_H_

--- a/sw/device/lib/base/print.c
+++ b/sw/device/lib/base/print.c
@@ -47,8 +47,7 @@ static size_t base_dev_null(void *data, const char *buf, size_t len) {
   return len;
 }
 static buffer_sink_t base_stdout = {
-    .data = NULL,
-    .sink = &base_dev_null,
+    .data = NULL, .sink = &base_dev_null,
 };
 
 void base_set_stdout(buffer_sink_t out) {
@@ -95,12 +94,10 @@ size_t base_snprintf(char *buf, size_t len, const char *format, ...) {
   va_start(args, format);
 
   snprintf_captures_t data = {
-      .buf = buf,
-      .bytes_left = len,
+      .buf = buf, .bytes_left = len,
   };
   buffer_sink_t out = {
-      .data = &data,
-      .sink = &snprintf_sink,
+      .data = &data, .sink = &snprintf_sink,
   };
   size_t bytes_left = base_vfprintf(out, format, args);
   va_end(args);
@@ -158,8 +155,8 @@ typedef struct format_specifier {
  * @return whether the parse succeeded.
  */
 static bool consume_format_specifier(buffer_sink_t out, const char **format,
-                                   size_t *bytes_written,
-                                   format_specifier_t *spec) {
+                                     size_t *bytes_written,
+                                     format_specifier_t *spec) {
   *spec = (format_specifier_t){0};
 
   // Consume the percent sign.
@@ -295,7 +292,8 @@ static void process_specifier(buffer_sink_t out, format_specifier_t spec,
       // - amd64:   0x0000000000000000 (eight bytes, sixteen nybbles).
       *bytes_written += out.sink(out.data, "0x", 2);
       uintptr_t value = va_arg(*args, uintptr_t);
-      *bytes_written += write_digits(out, value, sizeof(uintptr_t) * 2, 16, kDigitsLow);
+      *bytes_written +=
+          write_digits(out, value, sizeof(uintptr_t) * 2, 16, kDigitsLow);
       break;
     }
     case kSvHexLow:

--- a/sw/device/lib/base/print_test.cc
+++ b/sw/device/lib/base/print_test.cc
@@ -153,7 +153,7 @@ TEST_F(PrintfTest, Pointer) {
   auto *ptr = reinterpret_cast<uint32_t *>(0x1234);
   base_printf("Hello, %p!\n", ptr);
   switch (sizeof(uintptr_t)) {
-    case 4: 
+    case 4:
       EXPECT_EQ(buf_, "Hello, 0x00001234!\n");
       break;
     case 8:
@@ -165,7 +165,7 @@ TEST_F(PrintfTest, Pointer) {
 TEST_F(PrintfTest, NullPtr) {
   base_printf("Hello, %p!\n", nullptr);
   switch (sizeof(uintptr_t)) {
-    case 4: 
+    case 4:
       EXPECT_EQ(buf_, "Hello, 0x00000000!\n");
       break;
     case 8:
@@ -224,14 +224,18 @@ TEST(SnprintfTest, SimpleWrite) {
 
 TEST(SnprintfTest, ComplexFormating) {
   std::string buf(128, '\0');
-  auto len = base_snprintf(&buf[0], buf.size(), "%d + %d == %d, also spelled 0x%x", 2, 8, 2 + 8, 2 + 8);
+  auto len =
+      base_snprintf(&buf[0], buf.size(), "%d + %d == %d, also spelled 0x%x", 2,
+                    8, 2 + 8, 2 + 8);
   buf.resize(len);
   EXPECT_EQ(buf, "2 + 8 == 10, also spelled 0xa");
 }
 
 TEST(SnprintfTest, PartialWrite) {
   std::string buf(16, '\0');
-  auto len = base_snprintf(&buf[0], buf.size(), "%d + %d == %d, also spelled 0x%x", 2, 8, 2 + 8, 2 + 8);
+  auto len =
+      base_snprintf(&buf[0], buf.size(), "%d + %d == %d, also spelled 0x%x", 2,
+                    8, 2 + 8, 2 + 8);
   buf.resize(len);
   EXPECT_EQ(len, 16);
   EXPECT_EQ(buf, "2 + 8 == 10, als");

--- a/sw/device/lib/dif/dif_gpio.c
+++ b/sw/device/lib/dif/dif_gpio.c
@@ -30,10 +30,10 @@ static uint32_t index_to_mask(uint32_t index) { return 1u << index; }
  * upper half of DIRECT_OUT.
  *
  * @param gpio GPIO instance.
- * @param reg_lower_offset Offset of the masked access register that corresponds to
- * the lower half of the actual register.
- * @param reg_upper_offset Offset of the masked access register that corresponds to
- * the upper half of the actual register.
+ * @param reg_lower_offset Offset of the masked access register that corresponds
+ * to the lower half of the actual register.
+ * @param reg_upper_offset Offset of the masked access register that corresponds
+ * to the upper half of the actual register.
  * @param mask Mask that identifies the bits to write to.
  * @param val Value to write.
  */
@@ -64,14 +64,15 @@ static void gpio_masked_write(const dif_gpio_t *gpio, uint32_t reg_lower_offset,
  * See also `gpio_masked_write()`.
  *
  * @param gpio GPIO instance.
- * @param reg_lower_offset Offset of the masked access register that corresponds to
- * the lower half of the actual register.
- * @param reg_upper_offset Offset of the masked access register that corresponds to
- * the upper half of the actual register.
+ * @param reg_lower_offset Offset of the masked access register that corresponds
+ * to the lower half of the actual register.
+ * @param reg_upper_offset Offset of the masked access register that corresponds
+ * to the upper half of the actual register.
  * @param index Zero-based index of the bit to write to.
  * @param val Value to write.
  */
-static void gpio_masked_bit_write(const dif_gpio_t *gpio, uint32_t reg_lower_offset,
+static void gpio_masked_bit_write(const dif_gpio_t *gpio,
+                                  uint32_t reg_lower_offset,
                                   uint32_t reg_upper_offset, uint32_t index,
                                   bool val) {
   // Write to reg_lower_offset if the bit is in the lower half, write to
@@ -324,8 +325,9 @@ dif_gpio_result_t dif_gpio_irq_trigger_masked_disable(const dif_gpio_t *gpio,
   return kDifGpioResultOK;
 }
 
-dif_gpio_result_t dif_gpio_irq_trigger_masked_config(
-    const dif_gpio_t *gpio, uint32_t mask, dif_gpio_irq_t config) {
+dif_gpio_result_t dif_gpio_irq_trigger_masked_config(const dif_gpio_t *gpio,
+                                                     uint32_t mask,
+                                                     dif_gpio_irq_t config) {
   if (gpio == NULL) {
     return kDifGpioResultInvalidArgument;
   }

--- a/sw/device/lib/dif/dif_gpio.h
+++ b/sw/device/lib/dif/dif_gpio.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef SW_DEVICE_LIB_DIF_GPIO_H
-#define SW_DEVICE_LIB_DIF_GPIO_H
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_DIF_GPIO_H_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_DIF_GPIO_H_
 
 #include <stddef.h>
 #include <stdint.h>
@@ -330,4 +330,4 @@ dif_gpio_result_t dif_gpio_irq_trigger_masked_config(const dif_gpio_t *gpio,
                                                      uint32_t mask,
                                                      dif_gpio_irq_t config);
 
-#endif  // SW_DEVICE_LIB_DIF_GPIO_H
+#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_DIF_GPIO_H_

--- a/sw/device/lib/dif/dif_gpio.h
+++ b/sw/device/lib/dif/dif_gpio.h
@@ -326,7 +326,8 @@ dif_gpio_result_t dif_gpio_irq_trigger_masked_disable(const dif_gpio_t *gpio,
  * @return `kDifGpioResultOK` if the function is successful,
  * `kDifGpioResultInvalidArgument` otherwise.
  */
-dif_gpio_result_t dif_gpio_irq_trigger_masked_config(
-    const dif_gpio_t *gpio, uint32_t mask, dif_gpio_irq_t config);
+dif_gpio_result_t dif_gpio_irq_trigger_masked_config(const dif_gpio_t *gpio,
+                                                     uint32_t mask,
+                                                     dif_gpio_irq_t config);
 
 #endif  // SW_DEVICE_LIB_DIF_GPIO_H

--- a/sw/device/lib/dif/dif_uart.h
+++ b/sw/device/lib/dif/dif_uart.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef _SW_DEVICE_LIB_DIF_UART_H_
-#define _SW_DEVICE_LIB_DIF_UART_H_
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_DIF_UART_H_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_DIF_UART_H_
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -300,4 +300,4 @@ bool dif_uart_rx_bytes_available(const dif_uart_t *uart, size_t *num_bytes);
  */
 bool dif_uart_tx_bytes_available(const dif_uart_t *uart, size_t *num_bytes);
 
-#endif
+#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_DIF_UART_H_

--- a/sw/device/lib/testing/mock_mmio.h
+++ b/sw/device/lib/testing/mock_mmio.h
@@ -120,8 +120,10 @@ template <typename Int>
 Int ToInt(std::initializer_list<BitField> fields) {
   Int val = 0;
   for (auto field : fields) {
-    // Due to the way that gtest ASSERT_* works, and the fact that this must be a
-    // function (since we use function overloading), these cannot be ASSERTs, and
+    // Due to the way that gtest ASSERT_* works, and the fact that this must be
+    // a
+    // function (since we use function overloading), these cannot be ASSERTs,
+    // and
     // must be EXPECTs.
     EXPECT_LE(field.offset, sizeof(Int) * 8);
     val |= static_cast<Int>(field.value << field.offset);

--- a/sw/device/lib/testing/mock_mmio_test.cc
+++ b/sw/device/lib/testing/mock_mmio_test.cc
@@ -62,8 +62,7 @@ TEST_F(MockMmioTest, ExpectWithBits) {
 
 TEST_F(MockMmioTest, ExpectMask) {
   EXPECT_MASK32(0x8, {
-                         {0x0, 0xfff, 0xabc},
-                         {0x10, 0x1, 0x0},
+                         {0x0, 0xfff, 0xabc}, {0x10, 0x1, 0x0},
                      });
 
   auto value = mmio_region_read32(dev().region(), 0x8);

--- a/sw/device/lib/uart.c
+++ b/sw/device/lib/uart.c
@@ -42,8 +42,7 @@ size_t uart_send_buf(void *data, const char *buf, size_t len) {
 }
 
 const buffer_sink_t uart_stdout = {
-    .data = NULL,
-    .sink = &uart_send_buf,
+    .data = NULL, .sink = &uart_send_buf,
 };
 
 #define hexchar(i) (((i & 0xf) > 9) ? (i & 0xf) - 10 + 'A' : (i & 0xf) + '0')

--- a/sw/device/lib/usbdev.c
+++ b/sw/device/lib/usbdev.c
@@ -134,14 +134,15 @@ void usbdev_poll(usbdev_ctx_t *ctx) {
     // Clear the interupt
     REG32(USBDEV_INTR_STATE()) = (1 << USBDEV_INTR_STATE_PKT_RECEIVED);
   }
-  if (istate & ~((1 << USBDEV_INTR_STATE_PKT_RECEIVED) |
-                 (1 << USBDEV_INTR_STATE_PKT_SENT))) {
+  if (istate &
+      ~((1 << USBDEV_INTR_STATE_PKT_RECEIVED) |
+        (1 << USBDEV_INTR_STATE_PKT_SENT))) {
     TRC_C('I');
     TRC_I(istate, 12);
     TRC_C(' ');
-    REG32(USBDEV_INTR_STATE()) =
-        istate & ~((1 << USBDEV_INTR_STATE_PKT_RECEIVED) |
-                   (1 << USBDEV_INTR_STATE_PKT_SENT));
+    REG32(USBDEV_INTR_STATE()) = istate &
+                                 ~((1 << USBDEV_INTR_STATE_PKT_RECEIVED) |
+                                   (1 << USBDEV_INTR_STATE_PKT_SENT));
     if (istate & (1 << USBDEV_INTR_ENABLE_LINK_RESET)) {
       // Link reset
       for (int ep = 0; ep < NUM_ENDPOINTS; ep++) {

--- a/sw/device/tests/aes/aes_test.c
+++ b/sw/device/tests/aes/aes_test.c
@@ -39,9 +39,7 @@ int main(int argc, char **argv) {
 
   // Setup AES config
   aes_cfg_t aes_cfg = {
-      .mode = kAesEcb,
-      .key_len = kAes256,
-      .manual_operation = false,
+      .mode = kAesEcb, .key_len = kAes256, .manual_operation = false,
   };
 
   aes_key_put(key_32_1, aes_cfg.key_len);

--- a/sw/device/tests/consecutive_irqs/consecutive_irqs_test.c
+++ b/sw/device/tests/consecutive_irqs/consecutive_irqs_test.c
@@ -3,9 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/log.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/print.h"
-#include "sw/device/lib/base/log.h"
 #include "sw/device/lib/dif/dif_plic.h"
 #include "sw/device/lib/dif/dif_uart.h"
 #include "sw/device/lib/handler.h"
@@ -40,15 +40,15 @@ static size_t polled_uart_sink_func(void *data, const char *buf, size_t len) {
 }
 
 static const buffer_sink_t kPolledUartSink = {
-    .data = NULL,
-    .sink = &polled_uart_sink_func,
+    .data = NULL, .sink = &polled_uart_sink_func,
 };
 
-#define LOG_FATAL(...) do { \
-  LOG_ERROR(__VA_ARGS__); \
-  base_printf("FAIL!\r\n"); \
-  abort(); \
-} while(false)
+#define LOG_FATAL(...)        \
+  do {                        \
+    LOG_ERROR(__VA_ARGS__);   \
+    base_printf("FAIL!\r\n"); \
+    abort();                  \
+  } while (false)
 
 /**
  * UART interrupt handler


### PR DESCRIPTION
Recently a bug was found in CI where the code formatting hooks were not
firing correctly. This bug was fixed in
lowrisc/opentitan#ffa126f00f5cae43bd8ccd1e212550ab2d997491.

This change reformats the existing software tree, so that going forwards
we know the software tree is and remains correctly formatted.

