### PR TITLE
[doc] Add DIF Specification, Checklists, Progress

### DIFF
--- a/doc/project/_index.md
+++ b/doc/project/_index.md
@@ -8,7 +8,7 @@ More information will be added over time.
 
 ## Quality standards for open hardware IP
 
-In order to gauge the quality of the different IP that is in our repository, we define a series of [Hardware Development Stages]({{< relref "hw_stages" >}}) to track the designs.
+In order to gauge the quality of the different IP that is in our repository, we define a series of [Hardware Development Stages]({{< relref "development_stages" >}}) to track the designs.
 The current status of different IP is reflected in the [Hardware Dashboard]({{< relref "hw" >}}).
 The final state for developed IP is *Signed Off*, indicating that design and verification is complete, and the IP should be bug free.
 To make it to that stage, a [Hardware Signoff Checklist]({{< relref "checklist.md" >}}) is used to confirm completion.

--- a/doc/project/checklist.md
+++ b/doc/project/checklist.md
@@ -2,7 +2,7 @@
 title: "Signoff Checklist"
 ---
 
-This document explains the recommended checklist items to review when transitioning from one [Hardware Stage]({{<relref "/doc/project/hw_stages.md" >}}) to another, for both design and verification stages.
+This document explains the recommended checklist items to review when transitioning from one [Hardware Stage]({{<relref "/doc/project/development_stages.md" >}}) to another, for both design and verification stages.
 It is expected that the items in each stage (D1, V1, etc) are completed.
 
 ## D1

--- a/doc/project/checklist.md
+++ b/doc/project/checklist.md
@@ -2,8 +2,8 @@
 title: "Signoff Checklist"
 ---
 
-This document explains the recommended checklist items to review when transitioning from one [Hardware Stage]({{<relref "/doc/project/development_stages.md" >}}) to another, for both design and verification stages.
-It is expected that the items in each stage (D1, V1, etc) are completed.
+This document explains the recommended checklist items to review when transitioning from one [Development Stage]({{<relref "/doc/project/development_stages.md" >}}) to another, for design, verification, and [software device interface function (DIF)]({{< relref "doc/rm/device_interface_functions.md" >}}) stages.
+It is expected that the items in each stage (D1, V1, S1, etc) are completed.
 
 ## D1
 
@@ -395,3 +395,102 @@ Clean up all compile-time and run-time warnings thrown by the simulator.
 ### PRE_VERIFIED_SUB_MODULES_V3
 
 Sub-modules that are pre-verified with their own testbenches have already reached V3 stage.
+
+## S1
+
+For a transition from S0 to S1, the following items are expected be completed.
+
+### DIF_EXISTS
+
+`dif_<ip>.h` and, optionally, `dif_<ip>.c` exist in `sw/device/lib/dif`.
+
+### DIF_USED_IN_TREE
+
+All existing in-tree code which uses the device, uses the device via the DIF.
+There is no remaining driver code that directly uses the device outside of DIF code.
+
+### DIF_TEST_UNIT
+
+Software unit tests exist for the DIF in `sw/device/tests/dif` named `dif_<ip>_unittest.cc`.
+
+### DIF_TEST_SANITY
+
+Sanity tests exist for the DIF in `sw/device/tests/dif` named `dif_<ip>_sanitytest.c`.
+
+This should perform a basic test of the main datapath of the hardware module by the embedded core, via the DIF, and should be able to be run on all OpenTitan platforms (including FPGA, simulation, and DV).
+This test will be shared with DV.
+
+Sanity tests are for diagnosing major issues in both software and hardware, and with this in mind, they should execute quickly.
+Initially we expect this kind of test to be written by hardware designers for debugging issues during module development.
+This happens long before a DIF is implemented, so there are no requirements on how these should work, though we suggest they are placed in `sw/device/tests/<ip>/<ip>.c` as this has been the convention until now.
+Later, when a DIF is written, the DIF author is responsible for updating this test to use the DIF, and for moving this test into the aforementioned location.
+
+## S2
+
+For a transition from S1 to S2, the following items are expected be completed.
+
+### DIF_FEATURES
+
+DIF has functions to cover all specified hardware functionality.
+
+### DIF_HW_USAGE_REVIEWED
+
+The DIF's usage of its respective IP device has been reviewed by the device's hardware designer.
+
+### DIF_HW_FEATURE_COMPLETE
+
+The DIF's respective device IP is at least stage D2.
+
+### DIF_HW_PARAMS
+
+DIF uses automatically generated HW parameters and register definitions.
+
+### DIF_DOC_HW
+
+HW IP Programmer's guide references specific DIF APIs that can be used for operations.
+
+### DIF_CODE_STYLE
+
+DIF follows the DIF-specific guidelines in [`sw/device/lib/dif/README.md`]({{< relref "sw/device/lib/dif/README.md" >}}) and the OpenTitan C style guidelines.
+
+### DIF_DV_TESTS
+
+Chip-level DV testing for the IP using DIFs has been started.
+
+### DIF_USED_TOCK
+
+DIF has initial interface for use from Tock.
+
+## S3
+
+For a transition from S2 to S3, the following items are expected be completed.
+
+### DIF_HW_DESIGN_COMPLETE
+
+The DIF's respective device IP is at least stage D3.
+
+### DIF_HW_VERIFICATION_COMPLETE
+
+The DIF's respective device IP is at least stage V3.
+
+### DIF_REVIEW_C_STABLE
+
+Fully re-review C interface and implementation, with a view to the interface not changing in future.
+
+### DIF_TEST_UNIT_COMPLETE
+
+Unit tests cover (at least):
+
+- Device Initialisation
+- All Device FIFOs (including when empty, full, and adding data)
+- All Device Registers
+- All DIF Functions
+- All DIF return codes
+
+### DIF_TODO_COMPLETE
+
+Ensure all DIF TODOs are complete.
+
+### DIF_REVIEW_TOCK_STABLE
+
+Fully re-review Tock interface, with a view to the interface not changing in future.

--- a/doc/project/development_stages.md
+++ b/doc/project/development_stages.md
@@ -47,8 +47,10 @@ Feature requests towards a signed-off design requires review and approval by the
 Once accepted, it results in creating a new version and return a design to the appropriate life stage, based upon the size of the change.
 See the _Versioning_ section of the document for more discussion.
 Signed off fully-functioning (read: not buggy) designs stay in the Signoff stage as an available complete IP, with an associated revision ID.
-[Here](https://github.com/lowRISC/opentitan/blob/master/doc/project/hw_checklist.md.tpl) is a template that can be used as a checklist item.
 
+There exists a [template for IP checklists](https://github.com/lowRISC/opentitan/blob/master/util/uvmdvgen/checklist.md.tpl).
+The DIF stages use a separate, [software-specific checklist](https://github.com/lowRISC/opentitan/blob/master/doc/project/sw_checklist.md.tpl).
+All the checklist items are listed in the [Signoff Checklist]({{< relref "doc/project/checklist.md" >}}).
 
 | **Stage** | **Name** | **Definition** |
 | --- | --- | --- |
@@ -123,6 +125,35 @@ Once all coverage metrics have been met, waivers checked, the verification moves
 | V2 | Testing Complete | <ul> <li> Documentation: <ul> <li> DV plan completely written </ul> <li> Design Issues: <ul> <li> all high priority bugs addressed <li> low priority bugs root-caused </ul> <li> Testbench: <ul> <li> all interfaces have assertions checking the protocol <li> all functional assertions written and enabled <li> assumptions for FPV specified and reviewed </ul> <li> Tests (written and passing): all tests planned for in the testplan <li> Regression: 90% of properties proven in nightly regression <li> Coverage: 90% code coverage and 75% logic cone of influence (COI) coverage </ul> |
 | V3 | Verification Complete | <ul> <li> Design Issues: all bugs addressed <li> Assertions (written and proven): all assertions including newly added post-V2 assertions (if any) <li> Regression: 100% of properties proven (with reviewed assumptions) <li> Coverage: 100% code coverage and 100% COI coverage</ul> |
 
+## Device Interface Function Stages
+
+The following development stages are for [Device Interface Function (DIF)]({{< relref "doc/rm/device_interface_functions.md" >}}) work.
+These milestones have a slightly different emphasis to the hardware design and verification milestones, because software is much easier to change if bugs are found.
+The metric they are trying to capture is the stability and completeness of a low-level software interface to hardware design.
+We are aiming to keep this process fairly lightweight in the early stages, and not significantly burdeonsome to the associated HW designer through all stages.
+
+There are explicit checkpoints in these stages to ensure that DIF development does not overtake design and verification.
+
+The first DIF stage is **Initial Work**.
+This indicates the period of time between starting the software API, and it being complete enough for other software to start using it.
+The exact API is still being defined.
+Once the DIF is complete enough to cover all existing in-tree uses of the device, and has mock tests, it has completed the Initial Work stage.
+
+The second stage is **Functional**.
+In this stage, the DIF can be used for basic operations, but may not cover all the specified functionality of the device.
+Once the DIF is complete enough to cover all the functionality of the device, in the way the hardware designer envisioned; is used for both DV testing; and can be used Tock, it has completed this stage.
+
+The third stage is **Complete**.
+In this stage, no changes to the interface are expected.
+Once testing is complete, and we are satisfied that the interface will not change (except for bug fixes), the DIF moves into its final stage: **Stable**.
+
+| **Stage** | **Name** | **Definition** |
+| --- | --- | --- |
+| S0 | Initial Work | Work has started on a DIF for the given IP block. |
+| S1 | Functional | <ul> <li> DIF has been reviewed and merged <li> DIF is used by all in-tree device code <li> DIF has (mocked) unit tests </ul> |
+| S2 | Complete | <ul> <li> DIF API is now Complete <li> The respective IP block is feature complete (at least D2) <li> DIF matches HW designer's agreed IP block usage <li> DIF covers all specified functionality of the IP block <li> DIF is used for chip-level DV <li> DIF documented in IP documentation <li> DIF has initial Tock integration </ul> |
+| S3 | Stable | <ul> <li> DIF API Reviewed and Stable <li> The respective IP block is at D3/V3 <li> DIF tested fully (DV + Unit tests, full functional coverage) <li> Complete and Stable Tock interface to DIF </ul> |
+
 ## Signoff Review
 
 At the end of the final design and verification phase, the IP block should be proposed to the Technical Committee as ready for sign-off.
@@ -159,6 +190,7 @@ For example, `file: gpio.prj.hjson`:
     life_stage:         "L1"
     design_stage:       "D2"
     verification_stage: "V1"
+    dif_stage:          "S0"
     notes:              "information shown on the dashboard"
 }
 ```
@@ -176,6 +208,7 @@ The commit ID has its own entry in the project Hjson file, as shown below.
     life_stage:         "L1"
     design_stage:       "D2"
     verification_stage: "V1"
+    dif_stage:          "S0"
     commit_id:          "92e4298f8c2de268b2420a2c16939cd0784f1bf8"
     notes:              "information shown on the dashboard"
 }
@@ -192,6 +225,7 @@ They are converted to complete URLs in the generated dashboard.
     design_spec:  "hw/ip/gpio/doc"
     dv_plan:      "hw/ip/gpio/doc/dv_plan"
     hw_checklist: "hw/ip/gpio/doc/checklist"
+    sw_checklist: "sw/device/lib/dif/dif_gpio"
 }
 ```
 
@@ -233,6 +267,7 @@ This is indicated as two versions as shown in this example.
         life_stage:         "L2",
         design_stage:       "D3",
         verification_stage: "V3",
+        dif_stage:          "S0",
         commit_id:          "92e4298f8c2de268b2420a2c16939cd0784f1bf8",
         notes:              ""
       }
@@ -241,6 +276,7 @@ This is indicated as two versions as shown in this example.
         life_stage:         "L1",
         design_stage:       "D2",
         verification_stage: "V2",
+        dif_stage:          "S0",
         commit_id:          "f3039d7006ca8ebd45ae0b52b22864983876175d",
         notes:              "Rolled back to D2 as the register module is updated",
       }

--- a/doc/project/development_stages.md
+++ b/doc/project/development_stages.md
@@ -1,3 +1,7 @@
+---
+aliases: [/doc/project/hw_stages/]
+---
+
 # OpenTitan Hardware Development Stages
 
 ## Document Goals

--- a/doc/project/sw_checklist.md.tpl
+++ b/doc/project/sw_checklist.md.tpl
@@ -1,0 +1,77 @@
+---
+title: "${name.upper()} DIF Checklist"
+---
+
+<!--
+NOTE: This is a template checklist document that is required to be copied over
+to `sw/device/lib/difs/dif_${name.lower()}.md` for a new DIF that transitions
+from L0 (Specification) to L1 (Development) stage, and updated as needed.
+Once done, please remove this comment before checking it in.
+-->
+This checklist is for [Development Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [${name.upper()} DIF]({{< relref "hw/ip/${name}/doc" >}}).
+All checklist items refer to the content in the [Checklist]({{< relref "/doc/project/checklist.md" >}}).
+
+## DIF Checklist
+
+### S1
+
+Type           | Item                 | Resolution  | Note/Collaterals
+---------------|----------------------|-------------|------------------
+Implementation | [DIF_EXISTS][]       | Not Started |
+Implementation | [DIF_USED_IN_TREE][] | Not Started |
+Tests          | [DIF_TEST_UNIT][]    | Not Started |
+Tests          | [DIF_TEST_SANITY][]  | Not Started |
+Review         | Reviewer(s)          | Not Started |
+Review         | Signoff date         | Not Started |
+
+[DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif-exists" >}}
+[DIF_USED_IN_TREE]: {{< relref "/doc/project/checklist.md#dif-used-in-tree" >}}
+[DIF_TEST_UNIT]:    {{< relref "/doc/project/checklist.md#dif-test-unit" >}}
+[DIF_TEST_SANITY]:  {{< relref "/doc/project/checklist.md#dif-test-sanity" >}}
+
+### S2
+
+Type           | Item                        | Resolution  | Note/Collaterals
+---------------|-----------------------------|-------------|------------------
+Implementation | [DIF_FEATURES][]            | Not Started |
+Coordination   | [DIF_HW_USAGE_REVIEWED][]   | Not Started |
+Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Not Started | [HW Dashboard]({{<relref "hw" >}})
+Implementation | [DIF_HW_PARAMS][]           | Not Started |
+Documentation  | [DIF_DOC_HW][]              | Not Started |
+Documentation  | [DIF_DOC_API][]             | Not Started |
+Code Quality   | [DIF_CODE_STYLE][]          | Not Started |
+Coordination   | [DIF_DV_TESTS][]            | Not Started |
+Implementation | [DIF_USED_TOCK][]           | Not Started |
+Review         | HW IP Usage Reviewer(s)     | Not Started |
+Review         | Reviewer(s)                 | Not Started |
+Review         | Signoff date                | Not Started |
+
+[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif-features" >}}
+[DIF_HW_USAGE_REVIEWED]:   {{< relref "/doc/project/checklist.md#dif-hw-usage-reviewed" >}}
+[DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif-hw-feature-complete" >}}
+[DIF_HW_PARAMS]:           {{< relref "/doc/project/checklist.md#dif-hw-params" >}}
+[DIF_DOC_HW]:              {{< relref "/doc/project/checklist.md#dif-doc-hw" >}}
+[DIF_DOC_API]:             {{< relref "/doc/project/checklist.md#dif-doc-api" >}}
+[DIF_CODE_STYLE]:          {{< relref "/doc/project/checklist.md#dif-code-style" >}}
+[DIF_DV_TESTS]:            {{< relref "/doc/project/checklist.md#dif-dv-tests" >}}
+[DIF_USED_TOCK]:           {{< relref "/doc/project/checklist.md#dif-used-tock" >}}
+
+### S3
+
+Type           | Item                             | Resolution  | Note/Collaterals
+---------------|----------------------------------|-------------|------------------
+Coordination   | [DIF_HW_DESIGN_COMPLETE][]       | Not Started |
+Coordination   | [DIF_HW_VERIFICATION_COMPLETE][] | Not Started |
+Review         | [DIF_REVIEW_C_STABLE][]          | Not Started |
+Tests          | [DIF_TEST_UNIT_COMPLETE][]       | Not Started |
+Review         | [DIF_TODO_COMPLETE][]            | Not Started |
+Review         | [DIF_REVIEW_TOCK_STABLE][]       | Not Started |
+Review         | Reviewer(s)                      | Not Started |
+Review         | Signoff date                     | Not Started |
+
+[DIF_HW_DESIGN_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif-hw-design-complete" >}}
+[DIF_HW_VERIFICATION_COMPLETE]: {{< relref "/doc/project/checklist.md#dif-hw-verification-complete" >}}
+[DIF_REVIEW_C_STABLE]:          {{< relref "/doc/project/checklist.md#dif-review-c-stable" >}}
+[DIF_TEST_UNIT_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif-test-unit-complete" >}}
+[DIF_TODO_COMPLETE]:            {{< relref "/doc/project/checklist.md#dif-todo-complete" >}}
+[DIF_REVIEW_TOCK_STABLE]:       {{< relref "/doc/project/checklist.md#dif-review-tock-stable" >}}

--- a/doc/rm/_index.md
+++ b/doc/rm/_index.md
@@ -1,6 +1,7 @@
 # Reference Manuals
 
 * [Comportability Definition and Specification]({{< relref "comportability_specification" >}})
+* [Device Interface Function (DIF) Specification]({{< relref "device_interface_functions" >}})
 * Tool Guides
    * [Topgen Tool]({{< relref "topgen_tool" >}}): Describes `topgen.py` and its Hjson format source. Used to generate rtl and validation files for top specific modules such as PLIC, Pinmux and crossbar.
    * [Register Tool]({{< relref "register_tool" >}}): Describes `regtool.py` and its Hjson format source. Used to generate documentation, rtl, header files and validation files for IP Registers and toplevel.

--- a/doc/rm/c_cpp_coding_style.md
+++ b/doc/rm/c_cpp_coding_style.md
@@ -139,9 +139,9 @@ Example:
 int create_rainbow(int pots_of_gold, int unicorns);
 ```
 
-## C++ Style Guide
+## C++ Style Guide {#cxx-style-guide}
 
-### C++ Version
+### C++ Version {#cxx-version}
 
 C++ code should target C++14.
 

--- a/doc/rm/device_interface_functions.md
+++ b/doc/rm/device_interface_functions.md
@@ -1,0 +1,167 @@
+---
+title: "Device Interface Functions (DIFs)"
+---
+
+# Motivation
+
+Every hardware peripheral needs some form of higher-level software to actuate it to perform its intended function.
+Device Interface Functions (DIFs) aim to make it easy to use hardware for its intended purposes while making it difficult, or impossible, to misuse.
+DIFs can be seen as a living best-practices document for interacting with a given piece of hardware.
+
+# Objectives
+
+DIFs provide extensively reviewed APIs for actuating hardware for three separate use cases: design verification, FPGA + post-silicon validation, and reference firmware including end-consumer applications.
+
+# Requirements
+
+## Common Requirements
+
+### Language
+
+DIFs **must** be written in C, specifically [C11 (with a few allowed extensions)]({{< relref "doc/rm/c_cpp_coding_style.md#c-style-guide" >}}).
+DIFs **must** conform to the style guide in [`sw/device/lib/dif/README.md`]({{< relref "sw/device/lib/dif/README.md" >}}).
+
+DIFs **must** only depend on:
+
+*   the [freestanding C library headers]({{< relref "sw/device/lib/base/freestanding/README.md" >}}),
+*   compiler runtime libraries (e.g. libgcc and compiler-rt),
+*   the mmio library for interacting with memory-mapped registers (`sw/device/lib/base/mmio.h`),
+*   the memory library for interacting with non-volatile memory (`sw/device/lib/base/memory.h`), and
+*   any IP-specific register definition files.
+
+DIFs **must not** depend on DIFs for other IP blocks, or other external libraries.
+
+This decision is motivated by the requirement that DIFs must be extremely flexible in their possible execution environments, including being hosted in bare metal, or being called from other languages such as Rust through Foreign Function Interface.
+
+### Runtime Independence
+
+DIFs **must not** depend on runtime services provided by an operating system.
+If functions must be called in response to system stimulus such as interrupts then the DIF must make these requirements explicit in their documentation.
+This decision makes DIFs appropriate for execution environments without OS support such as DV.
+
+### Architecture Independence
+
+DIFs **should not** depend on architecture-specific constructs such as inline assembly or platform-defined registers, except where a peripheral is integrated into the core in a way making them unavoidable.
+As a concrete example: a SPI DIF must not depend on a pinmux or clock control DIF in order to be operated.
+This highlights a clear separation of concern: making a pin on the package driven from the SPI block involves multiple systems.
+By design, a DIF cannot coordinate cross-functional control.
+
+### Coverage Requirements
+
+DIFs *must* actuate all of the specification-required functionality of the hardware that they are written for, and no more.
+A DIF cannot be declared complete until it provides an API for accessing all of the functionality that is expected of the hardware.
+This is distinct from mandating that a DIF be required to cover all of the functionality of a given piece of hardware.
+
+# Details
+
+## Verification Stage Allowances
+
+DV, FPGA, and early silicon validation have unique requirements in their use of hardware.
+They might actuate hardware on vastly different timescales, use verification-specific registers, or otherwise manipulate aspects of the hardware that “production"-level code would not (or cannot) do.
+To this end, verification-only functionality may be added to a DIF **only** in modules that are included in verification.
+This functionality **must not** be made accessible outside of verification environments, and is enforced by not including DV-specific code in non-DV builds.
+
+## Separation of Concerns and Stateful Information
+
+In addition to the interface functions themselves, DIFs are expected to usually take the form of a structure that contains instance-specific information such as base register addresses and non-hardware-backed state required to actuate the hardware.
+DIFs **should not** track hardware-backed state in their own state machine.
+
+A DIF instance is expressly an instance of a hardware block, so DIFs **must not** intrinsically know the location of the hardware blocks they're associated with in memory.
+That is:
+
+```c
+dif_timer_init_result_t dif_timer_init(dif_timer_t *timer,
+                                       const timer_config_t *config,
+                                       uintptr_t base_address);
+```
+
+allows the system initialization code to instantiate timers at specific locations, whereas:
+
+```c
+// Don't do this:
+bool dif_timer_init(timer_t *timer, enum timer_num num);
+```
+
+suggests that the timer DIF knows about the number and placement of timers in the system.
+
+DIFs **must not** store or provide information in their implementation or state that is outside of their area of concern.
+The number of timers in a system is the concern of the system, not the timer DIF.
+
+## Naming
+
+All DIF functions **must** have clear direct objects and verbs, be written in the imperative mood, and follow the format of `dif_<object>_<verb_phrase>`.
+The object in the name must be common to the DIF it appears it, and unique among DIFs.
+
+Consider the following examples of good names:
+
+*   `dif_timer_init`,
+*   `dif_timer_reset`,
+*   `dif_timer_set_time_remaining`,
+*   `dif_timer_get_time_remaining`.
+
+The following are bad names:
+
+*   `dif_clear_timer` (wrong object/verb-phrase ordering),
+*   `dif_timer_gets_reset` (passive voice not imperative),
+*   `timer_init` (not correctly prefixed for C).
+
+Prefer common names: `init` is more commonly written than `initialize`, but `reset` is more commonly written than `rst`, for example.
+This is a subjective call on the DIF author and reviewers' parts, so common agreement will be more useful than strict prescription.
+
+## Documentation
+
+All DIF exported types and functions **must** have associated API documentation.
+All function parameters **must** be documented.
+All function semantics **must** be documented, no matter how obvious one suspects the function to be.
+The documentation should be exhaustive enough that the implementation can reasonably be inferred from it and the IP specification.
+
+It is important that the DIFs are documented alongside the hardware IP that they are written for.
+Each hardware IP block also contains a "programmers' guide" section, which tells programmers how to use the hardware interfaces correctly, using prose descriptions and relevant diagrams.
+The prose descriptions should include references to relevant DIF functions.
+
+Programmers' guides **should** primarily refer to the [Software API Documentation]({{< relref "/sw#opentitan-software-api-documentation" >}}).
+Programmers' guides **should not** contain standalone examples that do not match how we implement DIFs and can become out of date.
+The software API documentation includes full source code of the respective DIFs, should extra clarity be needed to explain how a hardware interface should be used.
+
+The programmers' guide must also include a list of DIF functions which relate to it, along with a brief description of each, and a link to further API documentation.
+
+## Source Layout
+
+DIFs **must** live in the `sw/device/lib/dif` folder.
+They **must** comprise at least one header unique to the hardware in question, and **may** contain more than one C file providing the implementation, if the complexity of the implementation warrants it (this is subjective).
+Any files for a given IP should have a filename starting `dif_<IP name>`.
+
+Verification-specific extensions and logic **must not** live in `sw/device/lib/dif`.
+This code must be placed in the directory belonging to the verification domain which the extension is applicable to.
+Verification-specific extensions must not be built and included in production firmware builds.
+
+## Testing
+
+Tests **must** live in the `sw/device/tests/dif` folder.
+
+DIFs **must** have unit tests, which cover all their specification-required functionality.
+These unit tests use a mocking system which allows the test to control all hardware reads and writes, without requiring complex management of the hardware.
+These unit tests are written using [googletest](https://github.com/google/googletest), and may be run on a non-RISC-V host.
+
+DIFs **should** also have other tests, including standalone C sanity tests---which can quickly diagnose major issues between the DIF and the hardware but are not required to test all device functionality.
+
+DIFs are also being used by DV for chip-level tests, which should help catch any issues with the DIFs not corresponding to the hardware implementation exactly.
+These tests may not live in `sw/device/tests/dif`.
+
+## DIF Development Stages
+
+As part of the DIF Standardisation process, we've decided to establish more concrete DIF lifecycle stages.
+These are documented with the [Development Stages]({{< relref "doc/project/development_stages.md" >}}).
+
+In the hardware world, there are checklists for establishing that each stage is complete and the next stage can be moved to.
+
+In software, we don't have to follow the same stability guarantees, because software is much more modifiable.
+It makes sense to have some kind of review process, but this should be much more lightweight in the early stages and not significantly burdensome to the associated HW designer.
+
+The current proposal only covers a DIF being written against a single version of its respective hardware IP block.
+This specifically excludes how to disambiguate DIFs in the repository that are written against different versions of the same IP block, or writing a single DIF that is compatible with multiple versions of an IP block.
+
+## Signoff Review
+
+The DIF lead author is expected to participate in the hardware IP block's L2 signoff review.
+This review can only happen once hardware design and verification are complete, and the DIF itself has reached stage S3.

--- a/doc/ug/design.md
+++ b/doc/ug/design.md
@@ -35,7 +35,7 @@ TODO: briefly discuss key architectural decisions, and how we came to the conclu
 Designs within the OpenTitan project come in a variety of completion status levels.
 Some designs are "tapeout ready" while others are still a work in progress.
 Understanding the status of a design is important to gauge the confidence in its advertised feature set.
-To that end, we've designated a spectrum of design stages in the [OpenTitan Hardware Development Stages]({{< relref "doc/project/hw_stages.md" >}}) document.
+To that end, we've designated a spectrum of design stages in the [OpenTitan Hardware Development Stages]({{< relref "doc/project/development_stages.md" >}}) document.
 This document defines the design stages and references where one can find the current status of each of the designs in the repository.
 
 ## Documentation
@@ -85,7 +85,7 @@ Once the Pull Request has been merged, these developers can then work with the m
 
 Note that all designs with enabled AscentLint targets will be run through the tool in eight-hour intervals and the results are published as part of the tool dashboards on the [hardware IP overview page](https://docs.opentitan.org/hw), enabling designers to close the lint errors and warnings even if they cannot run the sign-off tool locally.
 
-Goals for linting closure per design milestone are given in the [OpenTitan Development Stages]({{< relref "doc/project/hw_stages" >}}) document.
+Goals for linting closure per design milestone are given in the [OpenTitan Development Stages]({{< relref "doc/project/development_stages" >}}) document.
 
 ## Assertion Methodology
 

--- a/doc/ug/dv_methodology.md
+++ b/doc/ug/dv_methodology.md
@@ -33,7 +33,7 @@ The discussions on how those are used within the program are carried out in a di
 Verification within the OpenTitan project comes in a variety of completion status levels.
 Some designs are "tapeout ready" while others are still a work in progress.
 Understanding the status of verification is important to gauge the confidence in the design's advertised feature set.
-To that end, we've designated a spectrum of design and verification stages in the  [OpenTitan Hardware Development Stages]({{< relref "doc/project/hw_stages.md" >}}) document.
+To that end, we've designated a spectrum of design and verification stages in the  [OpenTitan Hardware Development Stages]({{< relref "doc/project/development_stages.md" >}}) document.
 It defines the verification stages and references where one can find the current verification status of each of the designs in the repository.
 Splitting the effort in such a way enables the team to pace the development effort and allows the progress to be in lock-step with the design stages.
 The list of tasks that are required to be completed to enable the effort to transition from one stage to the next is defined in the [checklists]({{< relref "doc/project/checklist" >}}) document.
@@ -44,7 +44,7 @@ We will explain some of the key items in those checklists in the remainder of th
 
 DV effort needs to be well documented to not only provide a detailed description of what tests are being planned, but also how the overall effort is strategized and implemented.
 The first is provided by the **testplan** document and the second, by the **DV plan** document.
-The [**project status**]({{< relref "doc/project/hw_stages.md#indicating-stages-and-making-transitions" >}}) document tracks to progression of the effort through the stages.
+The [**project status**]({{< relref "doc/project/development_stages.md#indicating-stages-and-making-transitions" >}}) document tracks to progression of the effort through the stages.
 
 In addition to these documents, a nightly **regression dashboard** tabulating the test and coverage results will provide ability to track progress towards completion of the verification stages.
 
@@ -186,7 +186,7 @@ The chip DV plan, which is currently under active development will explain these
 When progressing through the verification stages, there are key focus areas or testing activities that are perhaps common across all DUTs.
 These are as follows.
 
-### Progressing towards [V1]({{< relref "doc/project/hw_stages#hardware-verification-stages" >}})
+### Progressing towards [V1]({{< relref "doc/project/development_stages#hardware-verification-stages" >}})
 
 These set of tests (not exhaustive) provide the confidence that the design is ready for vertical integration.
 
@@ -203,7 +203,7 @@ This test (or set of tests) is also included as a part of the sanity regression 
 The very first set of real tests validate the SW interface laid out using the regtool.
 These prove that the SW interface is solid and all assumptions in CSRs in terms of field descriptions and their accessibility are correctly captured and there are no address decode bugs.
 
-### Progressing towards [V2]({{< relref "doc/project/hw_stages#hardware-verification-stages" >}})
+### Progressing towards [V2]({{< relref "doc/project/development_stages#hardware-verification-stages" >}})
 
 Bulk of testing in this stage focus on functionally testing the DUT.
 There however are certain categories of tests that may need additional attention.
@@ -250,7 +250,7 @@ To mitigate that, they are constructed with knobs to control the level of constr
 The level of constraints are then slowly eased to allow deeper state space exploration, until all areas of the DUT are satisfactorily stressed.
 Stress tests are ideal for bug hunting and closing coverage.
 
-### Progressing towards [V3]({{< relref "doc/project/hw_stages#hardware-verification-stages" >}})
+### Progressing towards [V3]({{< relref "doc/project/development_stages#hardware-verification-stages" >}})
 
 The main focus of testing at this stage is to meet our [regression](#nightly) and [coverage](#coverage-collection) goals.
 Apart from that, there are cleanup activities to resolve all pending TODO items in the DV code base and fix all compile and run time warnings (if any) thrown by the simulator tools.
@@ -492,7 +492,7 @@ The goal of this review is to achieve utmost clarity in the planning of the DV e
 The feedback in this review flows both ways - the language in the design specification could be made more precise, or missing items in both, the design specification as well as in the testplan could be identified and added.
 This enables the development stage to progress smoothly.
 
-Subsequently, the intermediate transitions within the verification stages are reviewed within the GitHub pull-request made for updating the checklist and the [project status]({{< relref "doc/project/hw_stages.md#indicating-stages-and-making-transitions" >}}).
+Subsequently, the intermediate transitions within the verification stages are reviewed within the GitHub pull-request made for updating the checklist and the [project status]({{< relref "doc/project/development_stages.md#indicating-stages-and-making-transitions" >}}).
 
 Finally, after the verification effort is complete, there is a final sign-off review to ensure all checklist items are completed satisfactorily without any major exceptions or open issues.
 

--- a/doc/ug/getting_started_design.md
+++ b/doc/ug/getting_started_design.md
@@ -13,7 +13,7 @@ Feedback and improvements are welcome.
 
 ## Stages of a Design
 
-The life stages of a design within the OpenTitan are described in the [Hardware Development Stages]({{< relref "doc/project/hw_stages.md" >}}) document.
+The life stages of a design within the OpenTitan are described in the [Hardware Development Stages]({{< relref "doc/project/development_stages.md" >}}) document.
 This separates the life of the design into three broad stages: Specification, In Development, and Signed off.
 This document attempts to give guidance on how to get going with the first stage and have a smooth transition into the Development stage.
 They are not hard and fast rules but methods we have seen work well in the project.
@@ -76,7 +76,7 @@ This applies only for those specifications that originated on the Drive.
 
 ## Full Design
 
-As the design develops within the OpenTitan repository, it transitions into "D0", "D1", etc., [design stages]({{< relref "doc/project/hw_stages.md" >}}) and will be eventually plugged into the top level.
+As the design develops within the OpenTitan repository, it transitions into "D0", "D1", etc., [design stages]({{< relref "doc/project/development_stages.md" >}}) and will be eventually plugged into the top level.
 Following the recommended best practices for digestible pull requests suggests that continuing to stage the design from the initial skeleton into the full featured design is a good way to make steady progress without over-burdening the reviewers.
 
 ## Top Level Inclusion

--- a/doc/ug/getting_started_dv.md
+++ b/doc/ug/getting_started_dv.md
@@ -8,7 +8,7 @@ Please refer to the [DV methodology]({{< relref "dv_methodology.md" >}}) documen
 
 ## Stages of DV
 
-The life stages of a design / DV effort within the OpenTitan are described in the [Hardware Development Stages]({{< relref "doc/project/hw_stages.md" >}}) document.
+The life stages of a design / DV effort within the OpenTitan are described in the [Hardware Development Stages]({{< relref "doc/project/development_stages.md" >}}) document.
 It separates the life of DV into three broad stages: Initial Work, Under Test and Testing Complete.
 This document attempts to give guidance on how to get going with the first stage and have a smooth transition into the Under Test stage.
 They are not hard and fast rules but methods we have seen work well in the project.
@@ -88,7 +88,7 @@ Please refer to [CSR utilities]({{< relref "hw/dv/sv/csr_utils/README" >}}) for 
 
 ## Full DV
 
-Running the sanity and CSR suite of tests while making progress toward reaching the [V1 stage]({{< relref "doc/project/hw_stages#hardware-verification-stages" >}}) should provide a good reference in terms of how to develop tests as outlined in the testplan and running and debugging them.
+Running the sanity and CSR suite of tests while making progress toward reaching the [V1 stage]({{< relref "doc/project/development_stages#hardware-verification-stages" >}}) should provide a good reference in terms of how to develop tests as outlined in the testplan and running and debugging them.
 Please refer to the [checklist]({{< relref "doc/project/checklist" >}}) to understand the key requirements for progressing through the subsequent verification stages and final signoff.
 
 The [UART DV](https://github.com/lowRISC/opentitan/tree/master/hw/ip/uart/dv) area can be used as a canonical example for making progress.

--- a/hw/_index.md
+++ b/hw/_index.md
@@ -8,7 +8,7 @@ We start off by providing links to the [results of various tool-flows](#results-
 This includes DV simulations, FPV and lint, all of which are run with the `dvsim` tool which serves as the common frontend.
 
 The [Comportable IPs](#comportable-ips) following it provides links to their design specifications and DV plans, and tracks their current stage of development.
-See the [Hardware Development Stages]({{< relref "/doc/project/hw_stages.md" >}}) for description of the hardware stages and how they are determined.
+See the [Hardware Development Stages]({{< relref "/doc/project/development_stages.md" >}}) for description of the hardware stages and how they are determined.
 
 Next, we focus on all available [processor cores](#processor-cores) and provide links to their design specifications, DV plans and the DV simulation results.
 

--- a/hw/dv/doc/dv_plan_template.md
+++ b/hw/dv/doc/dv_plan_template.md
@@ -20,7 +20,7 @@ applicable. Once done, remove this comment before making a PR. -->
 
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
-  * [HW development stages]({{< relref "doc/project/hw_stages.md" >}})
+  * [HW development stages]({{< relref "doc/project/development_stages.md" >}})
 * [Simulation results](https://reports.opentitan.org/hw/ip/foo/dv/latest/results.html)
 
 ## Design features

--- a/hw/ip/aes/doc/checklist.md
+++ b/hw/ip/aes/doc/checklist.md
@@ -2,7 +2,7 @@
 title: "AES Checklist"
 ---
 
-This checklist is for [Hardware Stage]({{< relref "/doc/project/hw_stages.md" >}}) transitions for the [AES peripheral.]({{<relref "hw/ip/aes/doc" >}})
+This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [AES peripheral.]({{<relref "hw/ip/aes/doc" >}})
 All checklist items refer to the content in the [Checklist.]({{< relref "/doc/project/checklist.md" >}})
 
 ## Design Checklist

--- a/hw/ip/aes/doc/dv_plan/index.md
+++ b/hw/ip/aes/doc/dv_plan/index.md
@@ -11,7 +11,7 @@ title: "AES DV Plan"
 
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
-  * [HW development stages]({{< relref "doc/project/hw_stages.md" >}})
+  * [HW development stages]({{< relref "doc/project/development_stages.md" >}})
 * [Simulation results](https://reports.opentitan.org/hw/ip/aes/dv/latest/results.html)
 
 ## Design features

--- a/hw/ip/alert_handler/doc/checklist.md
+++ b/hw/ip/alert_handler/doc/checklist.md
@@ -2,7 +2,7 @@
 title: "Alert Handler Checklist"
 ---
 
-This checklist is for [Hardware Stage]({{< relref "/doc/project/hw_stages.md" >}}) transitions for the [Alert Handler peripheral.]({{< relref "./" >}})
+This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [Alert Handler peripheral.]({{< relref "./" >}})
 All checklist items refer to the content in the [Checklist.]({{< relref "/doc/project/checklist.md" >}})
 
 ## Design Checklist

--- a/hw/ip/alert_handler/doc/dv_plan/index.md
+++ b/hw/ip/alert_handler/doc/dv_plan/index.md
@@ -13,7 +13,7 @@ title: "ALERT_HANDLER DV Plan"
 
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
-  * [HW development stages]({{< relref "doc/project/hw_stages" >}})
+  * [HW development stages]({{< relref "doc/project/development_stages" >}})
 * [Simulation results](https://reports.opentitan.org/hw/ip/alert_handler/dv/latest/results.html)
 
 ## Design features

--- a/hw/ip/entropy_src/doc/checklist.md
+++ b/hw/ip/entropy_src/doc/checklist.md
@@ -2,7 +2,7 @@
 title: "ENTROPY_SRC Checklist"
 ---
 
-This checklist is for [Hardware Stage]({{< relref "/doc/project/hw_stages.md" >}}) transitions for the [ENTROPY_SRC peripheral.]({{< relref "hw/ip/entropy_src/doc" >}})
+This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [ENTROPY_SRC peripheral.]({{< relref "hw/ip/entropy_src/doc" >}})
 All checklist items refer to the content in the [Checklist.]({{< relref "/doc/project/checklist.md" >}})
 
 ## Design Checklist

--- a/hw/ip/entropy_src/doc/dv_plan/index.md
+++ b/hw/ip/entropy_src/doc/dv_plan/index.md
@@ -11,7 +11,7 @@ title: "ENTROPY_SRC DV Plan"
 
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
-  * [HW development stages]({{< relref "doc/project/hw_stages" >}})
+  * [HW development stages]({{< relref "doc/project/development_stages" >}})
 * [Simulation results](https://reports.opentitan.org/hw/ip/entropy_src/dv/latest/results.html)
 
 ## Design features

--- a/hw/ip/flash_ctrl/doc/checklist.md
+++ b/hw/ip/flash_ctrl/doc/checklist.md
@@ -2,7 +2,7 @@
 title: "FLASH_CTRL Checklist"
 ---
 
-This checklist is for [Hardware Stage]({{< relref "/doc/project/hw_stages.md" >}}) transitions for the [FLASH_CTRL peripheral.](../)
+This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [FLASH_CTRL peripheral.](../)
 All checklist items refer to the content in the [Checklist.]({{< relref "/doc/project/checklist.md" >}})
 
 ## Design Checklist

--- a/hw/ip/gpio/data/gpio.prj.hjson
+++ b/hw/ip/gpio/data/gpio.prj.hjson
@@ -21,6 +21,7 @@
         life_stage:         "L1",
         design_stage:       "D2",
         verification_stage: "V2",
+        dif_stage:          "S0",
         notes:              "Rolled back to D2 as the register module is updated",
       }
     ]

--- a/hw/ip/gpio/doc/checklist.md
+++ b/hw/ip/gpio/doc/checklist.md
@@ -2,7 +2,7 @@
 title: "GPIO Checklist"
 ---
 
-This checklist is for [Hardware Stage]({{<relref "/doc/project/hw_stages.md">}}) transitions for the [GPIO peripheral][GPIO Spec].
+This checklist is for [Hardware Stage]({{<relref "/doc/project/development_stages.md">}}) transitions for the [GPIO peripheral][GPIO Spec].
 All checklist items refer to the content in the [Checklist.]({{<relref "/doc/project/checklist.md">}})
 
 ## Design Checklist

--- a/hw/ip/gpio/doc/dv_plan/index.md
+++ b/hw/ip/gpio/doc/dv_plan/index.md
@@ -11,7 +11,7 @@ title: "GPIO DV Plan"
 
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
-  * [HW development stages]({{< relref "doc/project/hw_stages.md" >}})
+  * [HW development stages]({{< relref "doc/project/development_stages.md" >}})
 * [Simulation results](https://reports.opentitan.org/hw/ip/gpio/dv/latest/results.html)
 
 ## Design features

--- a/hw/ip/hmac/doc/checklist.md
+++ b/hw/ip/hmac/doc/checklist.md
@@ -2,7 +2,7 @@
 title: "HMAC Checklist"
 ---
 
-This checklist is for [Hardware Stage]({{<relref "/doc/project/hw_stages.md" >}}) transitions for the [HMAC peripheral](../).
+This checklist is for [Hardware Stage]({{<relref "/doc/project/development_stages.md" >}}) transitions for the [HMAC peripheral](../).
 All checklist items refer to the content in the [Checklist.]({{<relref "/doc/project/checklist.md" >}})
 
 ## Design Checklist

--- a/hw/ip/hmac/doc/dv_plan/index.md
+++ b/hw/ip/hmac/doc/dv_plan/index.md
@@ -11,7 +11,7 @@ title: "HMAC DV Plan"
 
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
-  * [HW development stages]({{< relref "doc/project/hw_stages.md" >}})
+  * [HW development stages]({{< relref "doc/project/development_stages.md" >}})
 * [Simulation results](https://reports.opentitan.org/hw/ip/hmac/dv/latest/results.html)
 
 ## Design features

--- a/hw/ip/i2c/doc/dv_plan/index.md
+++ b/hw/ip/i2c/doc/dv_plan/index.md
@@ -11,7 +11,7 @@ title: "I2C DV Plan"
 
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
-  * [HW development stages]({{< relref "doc/project/hw_stages.md" >}})
+  * [HW development stages]({{< relref "doc/project/development_stages.md" >}})
 * [Simulation results](https://reports.opentitan.org/hw/ip/i2c/dv/latest/results.html)
 
 ## Design features

--- a/hw/ip/padctrl/doc/checklist.md
+++ b/hw/ip/padctrl/doc/checklist.md
@@ -2,7 +2,7 @@
 title: "Padctrl Checklist"
 ---
 
-This checklist is for [Hardware Stage]({{< relref "/doc/project/hw_stages.md" >}}) transitions for the [Padctrl peripheral.]({{< relref "./" >}})
+This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [Padctrl peripheral.]({{< relref "./" >}})
 All checklist items refer to the content in the [Checklist.]({{< relref "/doc/project/checklist.md" >}})
 
 ## Design Checklist

--- a/hw/ip/pinmux/doc/checklist.md
+++ b/hw/ip/pinmux/doc/checklist.md
@@ -2,7 +2,7 @@
 title: "Pinmux Checklist"
 ---
 
-This checklist is for [Hardware Stage]({{< relref "/doc/project/hw_stages.md" >}}) transitions for the [Pinmux peripheral.]({{< relref "./" >}})
+This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [Pinmux peripheral.]({{< relref "./" >}})
 All checklist items refer to the content in the [Checklist.]({{< relref "/doc/project/checklist.md" >}})
 
 ## Design Checklist

--- a/hw/ip/pinmux/doc/dv_plan/index.md
+++ b/hw/ip/pinmux/doc/dv_plan/index.md
@@ -12,7 +12,7 @@ title: "PINMUX DV Plan"
 
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
-  * [HW development stages]({{< relref "doc/project/hw_stages" >}})
+  * [HW development stages]({{< relref "doc/project/development_stages" >}})
 * FPV dashboard (link TBD)
 
 ## Design features

--- a/hw/ip/rv_core_ibex/doc/checklist.md
+++ b/hw/ip/rv_core_ibex/doc/checklist.md
@@ -5,7 +5,7 @@ title: "Ibex Processor Core Checklist"
 This checklist is for [Hardware Stage][] transitions for the [Ibex Processor Core.](../)
 All checklist items refer to the content in the [Checklist.]({{<relref "/doc/project/checklist.md">}})
 
-[Hardware Stage]: {{<relref "/doc/project/hw_stages.md" >}}
+[Hardware Stage]: {{<relref "/doc/project/development_stages.md" >}}
 
 
 ## Design Checklist

--- a/hw/ip/rv_plic/data/rv_plic.prj.hjson
+++ b/hw/ip/rv_plic/data/rv_plic.prj.hjson
@@ -13,6 +13,7 @@
         life_stage:         "L1",
         design_stage:       "D2",
         verification_stage: "V2",
+        dif_stage:          "S0",
         commit_id:          "d4d5d2f3bb87af5ca2f2787af5bc19bee04ffc6a",
         notes:              "based on FPV at block level",
       }

--- a/hw/ip/rv_plic/doc/checklist.md
+++ b/hw/ip/rv_plic/doc/checklist.md
@@ -2,7 +2,7 @@
 title: "RV_PLIC Checklist"
 ---
 
-This checklist is for [Hardware Stage]({{<relref "/doc/project/hw_stages.md" >}}) transitions for the [RV_PLIC peripheral](../).
+This checklist is for [Hardware Stage]({{<relref "/doc/project/development_stages.md" >}}) transitions for the [RV_PLIC peripheral](../).
 All checklist items refer to the content in the [Checklist.]({{<relref "/doc/project/checklist.md" >}})
 
 ## Design Checklist

--- a/hw/ip/rv_plic/doc/dv_plan/index.md
+++ b/hw/ip/rv_plic/doc/dv_plan/index.md
@@ -13,7 +13,7 @@ title: "RV_PLIC DV Plan"
 
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
-  * [HW development stages]({{< relref "doc/project/hw_stages" >}})
+  * [HW development stages]({{< relref "doc/project/development_stages" >}})
 * FPV dashboard (link TBD)
 
 ## Design features

--- a/hw/ip/rv_timer/doc/checklist.md
+++ b/hw/ip/rv_timer/doc/checklist.md
@@ -2,7 +2,7 @@
 title: "RV_TIMER Checklist"
 ---
 
-This checklist is for [Hardware Stage]({{<relref "/doc/project/hw_stages.md" >}})
+This checklist is for [Hardware Stage]({{<relref "/doc/project/development_stages.md" >}})
 transitions for the [rv_timer peripheral.](../) All checklist
 items refer to the content in the [Checklist.]({{<relref "/doc/project/checklist.md" >}})
 

--- a/hw/ip/rv_timer/doc/dv_plan/index.md
+++ b/hw/ip/rv_timer/doc/dv_plan/index.md
@@ -11,7 +11,7 @@ title: "RV_TIMER DV Plan"
 
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
-  * [HW development stages]({{< relref "doc/project/hw_stages.md" >}})
+  * [HW development stages]({{< relref "doc/project/development_stages.md" >}})
 * [Simulation results](https://reports.opentitan.org/hw/ip/rv_timer/dv/latest/results.html)
 
 ## Design features

--- a/hw/ip/spi_device/data/spi_device.prj.hjson
+++ b/hw/ip/spi_device/data/spi_device.prj.hjson
@@ -13,6 +13,7 @@
         life_stage:         "L1",
         design_stage:       "D1",
         verification_stage: "V1",
+        dif_stage:          "S0",
         commit_id:          "553ca956e0204e5b67b3bbea47f2e067f60b5510",
         notes:              ""
       }

--- a/hw/ip/spi_device/doc/checklist.md
+++ b/hw/ip/spi_device/doc/checklist.md
@@ -2,7 +2,7 @@
 title: "SPI_DEVICE Checklist"
 ---
 
-This checklist is for [Hardware Stage]({{< relref "/doc/project/hw_stages.md" >}}) transitions for the [spi_device peripheral]({{< relref "./" >}}).
+This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [spi_device peripheral]({{< relref "./" >}}).
 All checklist items refer to the content in the [Checklist]({{< relref "/doc/project/checklist.md" >}}).
 
 ## Design Checklist

--- a/hw/ip/spi_device/doc/dv_plan/index.md
+++ b/hw/ip/spi_device/doc/dv_plan/index.md
@@ -12,7 +12,7 @@ title: "SPI Device DV Plan"
 
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
-  * [HW development stages]({{< relref "doc/project/hw_stages.md" >}})
+  * [HW development stages]({{< relref "doc/project/development_stages.md" >}})
 * [Simulation results](https://reports.opentitan.org/hw/ip/spi_device/dv/latest/results.html)
 
 ## Design features

--- a/hw/ip/tlul/doc/dv_plan/index.md
+++ b/hw/ip/tlul/doc/dv_plan/index.md
@@ -12,7 +12,7 @@ title: "TLUL XBAR DV Plan"
 
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
-  * [HW development stages]({{< relref "doc/project/hw_stages" >}})
+  * [HW development stages]({{< relref "doc/project/development_stages" >}})
 * DV regression results dashboard (link TBD)
 
 ## Design features

--- a/hw/ip/uart/data/uart.prj.hjson
+++ b/hw/ip/uart/data/uart.prj.hjson
@@ -21,6 +21,7 @@
         life_stage:         "L1",
         design_stage:       "D2",
         verification_stage: "V2",
+        dif_stage:          "S0",
         notes:              "Rolled back to D2 as the register module is updated"
       }
     ]

--- a/hw/ip/uart/doc/checklist.md
+++ b/hw/ip/uart/doc/checklist.md
@@ -5,7 +5,7 @@ title: "UART Checklist"
 This checklist is for [Hardware Stage][] transitions for the [UART peripheral.](../)
 All checklist items refer to the content in the [Checklist.]({{<relref "/doc/project/checklist.md">}})
 
-[Hardware Stage]: {{<relref "/doc/project/hw_stages.md" >}}
+[Hardware Stage]: {{<relref "/doc/project/development_stages.md" >}}
 
 
 ## Design Checklist

--- a/hw/ip/uart/doc/dv_plan/index.md
+++ b/hw/ip/uart/doc/dv_plan/index.md
@@ -12,7 +12,7 @@ title: "UART DV Plan"
 
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
-  * [HW development stages]({{< relref "doc/project/hw_stages.md" >}})
+  * [HW development stages]({{< relref "doc/project/development_stages.md" >}})
 * [Simulation results](https://reports.opentitan.org/hw/ip/uart/dv/latest/results.html)
 
 ## Design features

--- a/hw/ip/usbdev/doc/dv_plan/index.md
+++ b/hw/ip/usbdev/doc/dv_plan/index.md
@@ -13,7 +13,7 @@ title: "USBDEV DV Plan"
 
 ## Current status
 * [Design & verification stage]({{< relref "hw" >}})
-  * [HW development stages]({{< relref "doc/project/hw_stages" >}})
+  * [HW development stages]({{< relref "doc/project/development_stages" >}})
 * [Simulation results](https://reports.opentitan.org/hw/ip/usbdev/dv/latest/results.html)
 
 ## Design features

--- a/hw/top_earlgrey/ip/xbar/doc/checklist.md
+++ b/hw/top_earlgrey/ip/xbar/doc/checklist.md
@@ -2,7 +2,7 @@
 title: "TL-UL Checklist"
 ---
 
-This checklist is for [Hardware Stage]({{< relref "/doc/project/hw_stages.md" >}}) transitions for the [TL-UL component.]({{<relref "/hw/ip/tlul/doc">}})
+This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [TL-UL component.]({{<relref "/hw/ip/tlul/doc">}})
 All checklist items refer to the content in the [Checklist]({{< relref "/doc/project/checklist.md" >}}).
 
 ## Design Checklist

--- a/site/docs/layouts/shortcodes/dashboard.html
+++ b/site/docs/layouts/shortcodes/dashboard.html
@@ -3,8 +3,8 @@
     <tr>
       <th>Design Spec</th>
       <th>DV Plan</th>
-      <th><a href="{{ relref . "doc/project/hw_stages#versioning" }}">Version</a></th>
-      <th><a href="{{ relref . "doc/project/hw_stages#life-stages" }}">Development Stage</a></th>
+      <th><a href="{{ relref . "doc/project/development_stages#versioning" }}">Version</a></th>
+      <th><a href="{{ relref . "doc/project/development_stages#life-stages" }}">Development Stage</a></th>
       <th>Notes</th>
     </tr>
   </thead>

--- a/util/dashboard/dashboard_validate.py
+++ b/util/dashboard/dashboard_validate.py
@@ -37,7 +37,9 @@ field_optional = {
     ['s', "path to the design specification, relative to repo root"],
     'dv_plan': ['s', "path to the DV plan, relative to repo root"],
     'hw_checklist': ['s', "path to the hw_checklist, relative to repo root"],
+    'sw_checklist': ['s', "path to the sw_checklist, relative to repo root"],
     'design_stage': ['s', "design stage of module"],
+    'dif_stage': ['s', 'DIF stage of module'],
     'verification_stage': ['s', "verification stage of module"],
     'notes': ['s', "random notes"],
 }
@@ -49,6 +51,7 @@ entry_required = {
 entry_optional = {
     'design_stage': ['s', "design stage of module"],
     'verification_stage': ['s', "verification stage of module"],
+    'dif_stage': ['s', 'DIF stage of module'],
     'commit_id': ['s', "Staged commit ID"],
     'notes': ['s', "notes"],
 }

--- a/util/dvsim/testplanner/README.md
+++ b/util/dvsim/testplanner/README.md
@@ -43,7 +43,7 @@ intent of a planned test:
 * **tests: list of actual written tests that maps to this planned test**
 
     Testplan is written in the initial work stage of the verification
-    [life-cycle]({{< relref "doc/project/hw_stages#hardware-verification-stages" >}}).
+    [life-cycle]({{< relref "doc/project/development_stages#hardware-verification-stages" >}}).
     When the DV engineer gets to actually developing the test, it may not map 1:1 to
     the planned test - it may be possible that an already written test that mapped
     to another planned test also satisfies the current one; OR it may also be

--- a/util/uvmdvgen/checklist.md.tpl
+++ b/util/uvmdvgen/checklist.md.tpl
@@ -7,7 +7,7 @@ NOTE: This is a template checklist document that is required to be copied over t
 directory for a new design that transitions from L0 (Specification) to L1 (Development)
 stage, and updated as needed. Once done, please remove this comment before checking it in.
 -->
-This checklist is for [Hardware Stage]({{< relref "/doc/project/hw_stages.md" >}}) transitions for the [${name.upper()} peripheral.]({{< relref "hw/ip/${name}/doc" >}})
+This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [${name.upper()} peripheral.]({{< relref "hw/ip/${name}/doc" >}})
 All checklist items refer to the content in the [Checklist.]({{< relref "/doc/project/checklist.md" >}})
 
 ## Design Checklist

--- a/util/uvmdvgen/index.md.tpl
+++ b/util/uvmdvgen/index.md.tpl
@@ -20,7 +20,7 @@ ${'##'} Goals
 
 ${'##'} Current status
 * [Design & verification stage]({{< relref "hw" >}})
-  * [HW development stages]({{< relref "doc/project/hw_stages" >}})
+  * [HW development stages]({{< relref "doc/project/development_stages" >}})
 * [Simulation results](https://reports.opentitan.org/hw/ip/${name}/dv/latest/results.html)
 
 ${'##'} Design features


### PR DESCRIPTION
This adds the agreed version of the "OpenTitan Device Interface
Functions" document. It is split between several different locations:

doc/rm/device_interface_functions.md - The main DIF document
doc/project/hw_stages.md - Added DIF stages and checklist reference.
doc/project/checklist.md - Added list of DIF checklist items

This change also includes a template for the DIF checklist:
doc/project/sw_checklist.md.tpl

--- 

There are also two other commits, one which adds the DIF status to the hardware
dashboard, and one which sets the three committed DIFs (uart, plic, gpio) to stage `S0`.
This allows the updated dashboard to be previewed, but not the checklist yet.

---

FAO @sjgitty and @gkelly so we can start discussions on how we want this to be structured, or whether more changes are required to integrate DIF stages into existing lifecycle documentation.