### PR TITLE
[dv/alert_handler] support multi class and alert in scb

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_seq_item.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_seq_item.sv
@@ -23,6 +23,7 @@ class alert_esc_seq_item extends uvm_sequence_item;
   rand alert_esc_trans_type_e alert_esc_type;
   rand alert_handshake_e      alert_handshake_sta;
   rand esc_handshake_e        esc_handshake_sta;
+  rand int                    sig_cycle_cnt;
 
   // delays
   rand int unsigned ping_delay;
@@ -65,6 +66,7 @@ class alert_esc_seq_item extends uvm_sequence_item;
     `uvm_field_int (ack_stable,        UVM_DEFAULT)
     `uvm_field_int (alert_delay,       UVM_DEFAULT)
     `uvm_field_int (int_err_cyc,       UVM_DEFAULT)
+    `uvm_field_int (sig_cycle_cnt,     UVM_DEFAULT)
     `uvm_field_enum(alert_sig_int_err_e,    alert_int_err_type,  UVM_DEFAULT)
     `uvm_field_enum(resp_sig_int_err_e,     resp_int_err_type,   UVM_DEFAULT)
     `uvm_field_enum(alert_esc_trans_type_e, alert_esc_type,      UVM_DEFAULT)

--- a/hw/ip/alert_handler/data/alert_handler_testplan.hjson
+++ b/hw/ip/alert_handler/data/alert_handler_testplan.hjson
@@ -6,6 +6,7 @@
   import_testplans: ["hw/dv/tools/testplans/csr_testplan.hjson",
                      "hw/dv/tools/testplans/intr_test_testplan.hjson",
                      "hw/dv/tools/testplans/enable_reg_testplan.hjson",
+                     "hw/dv/tools/testplans/stress_all_with_reset_testplan.hjson",
                      "hw/dv/tools/testplans/tl_device_access_types_testplan.hjson"]
   entries: [
     {
@@ -76,22 +77,15 @@
     }
     {
       name: random_classes
-      desc: "Randomly enable classes and randomly write phase cycles"
+      desc: "Based on random_alerts test, this test will also randomly enable interrupt classes"
       milestone: V2
       tests: ["alert_handler_random_classes"]
     }
     {
       name: stress_all
-      desc: '''
-            - Combine above sequences in one test to run sequentially, except csr sequence'''
+      desc: "Combine above sequences in one test to run sequentially, except csr sequence"
       milestone: V2
       tests: ["alert_handler_stress_all"]
-    }
-    {
-      name: stress_all_with_rand_reset
-      desc: '''Have random reset in parallel with stress_all and tl_errors sequences'''
-      milestone: V2
-      tests: ["alert_handler_stress_all_with_rand_reset"]
     }
   ]
 }

--- a/hw/ip/alert_handler/dv/env/alert_handler_env_pkg.sv
+++ b/hw/ip/alert_handler/dv/env/alert_handler_env_pkg.sv
@@ -66,11 +66,6 @@ package alert_handler_env_pkg;
     LocalEscIntFail
   } local_alert_type_e;
 
-  typedef struct {
-    realtime    start_time;
-    esc_phase_e phase;
-  } esc_phase_t;
-
   // forward declare classes to allow typedefs below
   typedef virtual pins_if #(NUM_MAX_ESC_SEV) esc_en_vif;
   typedef virtual pins_if #(1) entropy_vif;

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_entropy_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_entropy_vseq.sv
@@ -17,6 +17,12 @@ class alert_handler_entropy_vseq extends alert_handler_sanity_vseq;
     num_trans inside {[4000:8000]};
   }
 
+  function void pre_randomize();
+    this.enable_one_alert_c.constraint_mode(0);
+    this.enable_classa_only_c.constraint_mode(0);
+    this.sig_int_c.constraint_mode(0);
+  endfunction
+
   virtual task alert_handler_init(bit [NUM_ALERT_HANDLER_CLASSES-1:0] intr_en = '1,
                                   bit [alert_pkg::NAlerts-1:0]        alert_en = '1,
                                   bit [TL_DW-1:0]                     alert_class = 'h0,

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_random_classes_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_random_classes_vseq.sv
@@ -4,12 +4,13 @@
 
 // this sequence enable random classes, and rand wr phase cycles
 
-class alert_handler_random_classes_vseq extends alert_handler_sanity_vseq;
+class alert_handler_random_classes_vseq extends alert_handler_random_alerts_vseq;
   `uvm_object_utils(alert_handler_random_classes_vseq)
 
   `uvm_object_new
 
   function void pre_randomize();
+    super.pre_randomize();
     this.enable_classa_only_c.constraint_mode(0);
   endfunction
 

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_sig_int_fail_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_sig_int_fail_vseq.sv
@@ -11,16 +11,12 @@ class alert_handler_sig_int_fail_vseq extends alert_handler_sanity_vseq;
 
   constraint sig_int_c {
     alert_int_err == '1;
-  }
-
-  constraint enable_alert_int_fail_only_c {
-    local_alert_en inside {1 << LocalAlertIntFail, 1 << LocalEscIntFail};
-    // TODO: temp constraint, take off once scb support ping response fail
+    esc_int_err == '1;
   }
 
   function void pre_randomize();
     this.enable_one_alert_c.constraint_mode(0);
-    // TODO: add support this.enable_classa_only_c.constraint_mode(0);
+    this.enable_classa_only_c.constraint_mode(0);
   endfunction
 
 endclass : alert_handler_sig_int_fail_vseq


### PR DESCRIPTION
Enable multiple alert and multiple class enable at the same time
SCB supports esc signals triggered from different interrupt classes
Minor testplan fix to reflect the changes

Signed-off-by: Cindy Chen <chencindy@google.com>