### PR TITLE
[dv] Add begin...end in macro

### DIFF
--- a/hw/dv/sv/dv_utils/dv_macros.svh
+++ b/hw/dv/sv/dv_utils/dv_macros.svh
@@ -23,10 +23,12 @@
 // throw error if cast fails
 `ifndef downcast
   `define downcast(EXT_, BASE_, MSG_="", SEV_=fatal, ID_=`gfn) \
-    if (!$cast(EXT_, BASE_)) begin \
-      `uvm_``SEV_(ID_, $sformatf({"Cast failed: base class variable %0s ", \
-                                  "does not hold extended class %0s handle %s"}, \
-                                  `"BASE_`", `"EXT_`", MSG_)) \
+    begin \
+      if (!$cast(EXT_, BASE_)) begin \
+        `uvm_``SEV_(ID_, $sformatf({"Cast failed: base class variable %0s ", \
+                                    "does not hold extended class %0s handle %s"}, \
+                                    `"BASE_`", `"EXT_`", MSG_)) \
+      end \
     end
 `endif
 
@@ -59,72 +61,90 @@
 // Note: Should not be called by user code
 `ifndef DV_CHECK
   `define DV_CHECK(T_, MSG_="", SEV_=error, ID_=`gfn) \
-    if (!(T_)) begin \
-      `uvm_``SEV_(ID_, $sformatf("Check failed (%s) %s ", `"T_`", MSG_)) \
+    begin \
+      if (!(T_)) begin \
+        `uvm_``SEV_(ID_, $sformatf("Check failed (%s) %s ", `"T_`", MSG_)) \
+      end \
     end
 `endif
 
 `ifndef DV_CHECK_EQ
   `define DV_CHECK_EQ(ACT_, EXP_, MSG_="", SEV_=error, ID_=`gfn) \
-    if (!(ACT_ == EXP_)) begin \
-      `uvm_``SEV_(ID_, $sformatf("Check failed %s == %s (%0d [0x%0h] vs %0d [0x%0h]) %s", \
-                                  `"ACT_`", `"EXP_`", ACT_, ACT_, EXP_, EXP_, MSG_)) \
+    begin \
+      if (!(ACT_ == EXP_)) begin \
+        `uvm_``SEV_(ID_, $sformatf("Check failed %s == %s (%0d [0x%0h] vs %0d [0x%0h]) %s", \
+                                    `"ACT_`", `"EXP_`", ACT_, ACT_, EXP_, EXP_, MSG_)) \
+      end \
     end
 `endif
 
 `ifndef DV_CHECK_NE
   `define DV_CHECK_NE(ACT_, EXP_, MSG_="", SEV_=error, ID_=`gfn) \
-    if (!(ACT_ != EXP_)) begin \
-      `uvm_``SEV_(ID_, $sformatf("Check failed %s != %s (%0d [0x%0h] vs %0d [0x%0h]) %s", \
-                                  `"ACT_`", `"EXP_`", ACT_, ACT_, EXP_, EXP_, MSG_)) \
+    begin \
+      if (!(ACT_ != EXP_)) begin \
+        `uvm_``SEV_(ID_, $sformatf("Check failed %s != %s (%0d [0x%0h] vs %0d [0x%0h]) %s", \
+                                    `"ACT_`", `"EXP_`", ACT_, ACT_, EXP_, EXP_, MSG_)) \
+      end \
     end
 `endif
 
 `ifndef DV_CHECK_CASE_EQ
   `define DV_CHECK_CASE_EQ(ACT_, EXP_, MSG_="", SEV_=error, ID_=`gfn) \
-    if (!(ACT_ === EXP_)) begin \
-      `uvm_``SEV_(ID_, $sformatf("Check failed %s === %s (0x%0h [%0b] vs 0x%0h [%0b]) %s", \
-                                  `"ACT_`", `"EXP_`", ACT_, ACT_, EXP_, EXP_, MSG_)) \
+    begin \
+      if (!(ACT_ === EXP_)) begin \
+        `uvm_``SEV_(ID_, $sformatf("Check failed %s === %s (0x%0h [%0b] vs 0x%0h [%0b]) %s", \
+                                    `"ACT_`", `"EXP_`", ACT_, ACT_, EXP_, EXP_, MSG_)) \
+      end \
     end
 `endif
 
 `ifndef DV_CHECK_CASE_NE
   `define DV_CHECK_CASE_NE(ACT_, EXP_, MSG_="", SEV_=error, ID_=`gfn) \
-    if (!(ACT_ !== EXP_)) begin \
-      `uvm_``SEV_(ID_, $sformatf("Check failed %s !== %s (%0d [0x%0h] vs %0d [0x%0h]) %s", \
-                                  `"ACT_`", `"EXP_`", ACT_, ACT_, EXP_, EXP_, MSG_)) \
+    begin \
+      if (!(ACT_ !== EXP_)) begin \
+        `uvm_``SEV_(ID_, $sformatf("Check failed %s !== %s (%0d [0x%0h] vs %0d [0x%0h]) %s", \
+                                    `"ACT_`", `"EXP_`", ACT_, ACT_, EXP_, EXP_, MSG_)) \
+      end \
     end
 `endif
 
 `ifndef DV_CHECK_LT
   `define DV_CHECK_LT(ACT_, EXP_, MSG_="", SEV_=error, ID_=`gfn) \
-    if (!(ACT_ < EXP_)) begin \
-      `uvm_``SEV_(ID_, $sformatf("Check failed %s < %s (%0d [0x%0h] vs %0d [0x%0h]) %s", \
-                                  `"ACT_`", `"EXP_`", ACT_, ACT_, EXP_, EXP_, MSG_)) \
+    begin \
+      if (!(ACT_ < EXP_)) begin \
+        `uvm_``SEV_(ID_, $sformatf("Check failed %s < %s (%0d [0x%0h] vs %0d [0x%0h]) %s", \
+                                    `"ACT_`", `"EXP_`", ACT_, ACT_, EXP_, EXP_, MSG_)) \
+      end \
     end
 `endif
 
 `ifndef DV_CHECK_GT
   `define DV_CHECK_GT(ACT_, EXP_, MSG_="", SEV_=error, ID_=`gfn) \
-    if (!(ACT_ > EXP_)) begin \
-      `uvm_``SEV_(ID_, $sformatf("Check failed %s > %s (%0d [0x%0h] vs %0d [0x%0h]) %s", \
-                                  `"ACT_`", `"EXP_`", ACT_, ACT_, EXP_, EXP_, MSG_)) \
+    begin \
+      if (!(ACT_ > EXP_)) begin \
+        `uvm_``SEV_(ID_, $sformatf("Check failed %s > %s (%0d [0x%0h] vs %0d [0x%0h]) %s", \
+                                    `"ACT_`", `"EXP_`", ACT_, ACT_, EXP_, EXP_, MSG_)) \
+      end \
     end
 `endif
 
 `ifndef DV_CHECK_LE
   `define DV_CHECK_LE(ACT_, EXP_, MSG_="", SEV_=error, ID_=`gfn) \
-    if (!(ACT_ <= EXP_)) begin \
-      `uvm_``SEV_(ID_, $sformatf("Check failed %s <= %s (%0d [0x%0h] vs %0d [0x%0h]) %s", \
-                                  `"ACT_`", `"EXP_`", ACT_, ACT_, EXP_, EXP_, MSG_)) \
+    begin \
+      if (!(ACT_ <= EXP_)) begin \
+        `uvm_``SEV_(ID_, $sformatf("Check failed %s <= %s (%0d [0x%0h] vs %0d [0x%0h]) %s", \
+                                    `"ACT_`", `"EXP_`", ACT_, ACT_, EXP_, EXP_, MSG_)) \
+      end \
     end
 `endif
 
 `ifndef DV_CHECK_GE
   `define DV_CHECK_GE(ACT_, EXP_, MSG_="", SEV_=error, ID_=`gfn) \
-    if (!(ACT_ >= EXP_)) begin \
-      `uvm_``SEV_(ID_, $sformatf("Check failed %s >= %s (%0d [0x%0h] vs %0d [0x%0h]) %s", \
-                                  `"ACT_`", `"EXP_`", ACT_, ACT_, EXP_, EXP_, MSG_)) \
+    begin \
+      if (!(ACT_ >= EXP_)) begin \
+        `uvm_``SEV_(ID_, $sformatf("Check failed %s >= %s (%0d [0x%0h] vs %0d [0x%0h]) %s", \
+                                    `"ACT_`", `"EXP_`", ACT_, ACT_, EXP_, EXP_, MSG_)) \
+      end \
     end
 `endif
 
@@ -203,29 +223,35 @@
 // print static/dynamic 1d array or queue
 `ifndef DV_PRINT_ARR_CONTENTS
 `define DV_PRINT_ARR_CONTENTS(ARR_, V_=UVM_MEDIUM, ID_=`gfn) \
-  foreach (ARR_[i]) begin \
-    `uvm_info(ID_, $sformatf("%s[%0d] = 0x%0d[0x%0h]", `"ARR_`", i, ARR_[i], ARR_[i]), V_) \
+  begin \
+    foreach (ARR_[i]) begin \
+      `uvm_info(ID_, $sformatf("%s[%0d] = 0x%0d[0x%0h]", `"ARR_`", i, ARR_[i], ARR_[i]), V_) \
+    end \
   end
 `endif
 
 // print non-empty tlm fifos that were uncompared at end of test
 `ifndef DV_EOT_PRINT_TLM_FIFO_CONTENTS
 `define DV_EOT_PRINT_TLM_FIFO_CONTENTS(TYP_, FIFO_, SEV_=error, ID_=`gfn) \
-  while (!FIFO_.is_empty()) begin \
-    TYP_ item; \
-    void'(FIFO_.try_get(item)); \
-    `uvm_``SEV_(ID_, $sformatf("%s item uncompared:\n%s", `"FIFO_`", item.sprint())) \
+  begin \
+    while (!FIFO_.is_empty()) begin \
+      TYP_ item; \
+      void'(FIFO_.try_get(item)); \
+      `uvm_``SEV_(ID_, $sformatf("%s item uncompared:\n%s", `"FIFO_`", item.sprint())) \
+    end \
   end
 `endif
 
 // print non-empty tlm fifos that were uncompared at end of test
 `ifndef DV_EOT_PRINT_TLM_FIFO_ARR_CONTENTS
 `define DV_EOT_PRINT_TLM_FIFO_ARR_CONTENTS(TYP_, FIFO_, SEV_=error, ID_=`gfn) \
-  foreach (FIFO_[i]) begin \
-    while (!FIFO_[i].is_empty()) begin \
-      TYP_ item; \
-      void'(FIFO_[i].try_get(item)); \
-      `uvm_``SEV_(ID_, $sformatf("%s[%0d] item uncompared:\n%s", `"FIFO_`", i, item.sprint())) \
+  begin \
+    foreach (FIFO_[i]) begin \
+      while (!FIFO_[i].is_empty()) begin \
+        TYP_ item; \
+        void'(FIFO_[i].try_get(item)); \
+        `uvm_``SEV_(ID_, $sformatf("%s[%0d] item uncompared:\n%s", `"FIFO_`", i, item.sprint())) \
+      end \
     end \
   end
 `endif
@@ -233,19 +259,23 @@
 // print non-empty tlm fifos that were uncompared at end of test
 `ifndef DV_EOT_PRINT_Q_CONTENTS
 `define DV_EOT_PRINT_Q_CONTENTS(TYP_, Q_, SEV_=error, ID_=`gfn) \
-  while (Q_.size() != 0) begin \
-    TYP_ item = Q_.pop_front(); \
-    `uvm_``SEV_(ID_, $sformatf("%s item uncompared:\n%s", `"Q_`", item.sprint())) \
+  begin \
+    while (Q_.size() != 0) begin \
+      TYP_ item = Q_.pop_front(); \
+      `uvm_``SEV_(ID_, $sformatf("%s item uncompared:\n%s", `"Q_`", item.sprint())) \
+    end \
   end
 `endif
 
 // print non-empty tlm fifos that were uncompared at end of test
 `ifndef DV_EOT_PRINT_Q_ARR_CONTENTS
 `define DV_EOT_PRINT_Q_ARR_CONTENTS(TYP_, Q_, SEV_=error, ID_=`gfn) \
-  foreach (Q_[i]) begin \
-    while (Q_[i].size() != 0) begin \
-      TYP_ item = Q_[i].pop_front(); \
-      `uvm_``SEV_(ID_, $sformatf("%s[%0d] item uncompared:\n%s", `"Q_`", i, item.sprint())) \
+  begin \
+    foreach (Q_[i]) begin \
+      while (Q_[i].size() != 0) begin \
+        TYP_ item = Q_[i].pop_front(); \
+        `uvm_``SEV_(ID_, $sformatf("%s[%0d] item uncompared:\n%s", `"Q_`", i, item.sprint())) \
+      end \
     end \
   end
 `endif
@@ -253,10 +283,12 @@
 // check for non-empty mailbox and print items that were uncompared at end of test
 `ifndef DV_EOT_PRINT_MAILBOX_CONTENTS
 `define DV_EOT_PRINT_MAILBOX_CONTENTS(TYP_, MAILBOX_, SEV_=error, ID_=`gfn) \
-  while (MAILBOX_.num() != 0) begin \
-    TYP_ item; \
-    void'(MAILBOX_.try_get(item)); \
-    `uvm_``SEV_(ID_, $sformatf("%s item uncompared:\n%s", `"MAILBOX_`", item.sprint())) \
+  begin \
+    while (MAILBOX_.num() != 0) begin \
+      TYP_ item; \
+      void'(MAILBOX_.try_get(item)); \
+      `uvm_``SEV_(ID_, $sformatf("%s item uncompared:\n%s", `"MAILBOX_`", item.sprint())) \
+    end \
   end
 `endif
 
@@ -274,15 +306,17 @@
 //              end)
 `ifndef DV_SPINWAIT
 `define DV_SPINWAIT(WAIT_, MSG_ = "", TIMEOUT_NS_ = default_spinwait_timeout_ns, ID_ =`gfn) \
-  fork begin \
-    fork \
-      begin \
-        WAIT_ \
-      end \
-      begin \
-        wait_timeout(TIMEOUT_NS_, ID_, MSG_); \
-      end \
-    join_any \
-    disable fork; \
-  end join
+  begin \
+    fork begin \
+      fork \
+        begin \
+          WAIT_ \
+        end \
+        begin \
+          wait_timeout(TIMEOUT_NS_, ID_, MSG_); \
+        end \
+      join_any \
+      disable fork; \
+    end join \
+  end
 `endif


### PR DESCRIPTION
Found this didn't work as the `else` paired with the `if` in downcast
```
  if (...) `downcast(...)
  else     `downcast(...)
```
We have a similar mismatch in our code [here](https://github.com/lowRISC/opentitan/blob/master/hw/dv/sv/cip_lib/cip_base_vseq.sv#L330).

This problem isn't easy to debug and I feel it's better to avoid it by
adding `begin...end` in the macro

Signed-off-by: Weicai Yang <weicai@google.com>