### PR TITLE
[dv/top] Fix csr rw test

### DIFF
--- a/hw/ip/rv_plic/data/rv_plic.hjson.tpl
+++ b/hw/ip/rv_plic/data/rv_plic.hjson.tpl
@@ -40,6 +40,8 @@
         fields: [
           { bits: "0", name: "P", desc: "Interrupt Pending of Source" }
         ],
+        tags: [// IP is driven by intr_src, cannot auto-predict
+               "excl:CsrNonInitTests:CsrExclCheck"],
       }
     },
     { multireg: {
@@ -97,6 +99,8 @@
       fields: [
         { bits: "${(src).bit_length()-1}:0" }
       ],
+      tags: [// CC register value is related to IP
+             "excl:CsrNonInitTests:CsrExclCheck"],
     }
     { name: "MSIP${i}",
       desc: '''msip for Hart ${i}.

--- a/hw/top_earlgrey/ip/rv_plic/data/autogen/rv_plic.hjson
+++ b/hw/top_earlgrey/ip/rv_plic/data/autogen/rv_plic.hjson
@@ -47,7 +47,9 @@
         fields: [
           { bits: "0", name: "P", desc: "Interrupt Pending of Source" }
         ],
-      }
+        tags: [// IP is driven by intr_src, cannot auto-predict
+               "excl:CsrNonInitTests:CsrExclCheck"],
+     }
     },
     { multireg: {
         name: "LE",
@@ -725,6 +727,8 @@
       fields: [
         { bits: "6:0" }
       ],
+        tags: [// CC register value is related to IP
+               "excl:CsrNonInitTests:CsrExclCheck"],
     }
     { name: "MSIP0",
       desc: '''msip for Hart 0.

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -20,7 +20,7 @@ from reggen import gen_dv, gen_rtl, validate
 from topgen import get_hjsonobj_xbars, merge_top, search_ips, validate_top
 
 # Filter from IP list but adding generated hjson
-filter_list = ['rv_plic', 'pinmux']
+filter_list = ['rv_plic', 'pinmux', 'alert_handler']
 
 # Common header for generated files
 genhdr = '''// Copyright lowRISC contributors.
@@ -491,6 +491,9 @@ def main():
 
         pinmux_hjson = hjson_dir.parent / 'ip/pinmux/data/autogen/pinmux.hjson'
         ips.append(pinmux_hjson)
+
+        alert_handler_hjson = hjson_dir.parent / 'ip/alert_handler/data/autogen/alert_handler.hjson'
+        ips.append(alert_handler_hjson)
 
         # load Hjson and pass validate from reggen
         try:


### PR DESCRIPTION
Fix top_earlgrey csr rw test:
1. Exclude certain registers from rv_plic
2. Use top_level alert_handler.hjson
3. Enable register support w1c and w0c

Signed-off-by: Cindy Chen <chencindy@google.com>