### PR TITLE
[doc] Update getting started verilator guide

### DIFF
--- a/doc/ug/getting_started_verilator.md
+++ b/doc/ug/getting_started_verilator.md
@@ -105,7 +105,7 @@ To connect GDB use the following command (noting it needs to be altered to point
 
 ```console
 $ riscv32-unknown-elf-gdb -ex "target extended-remote :3333" -ex "info reg" \
-  build-bin/sw/device/sim-verilator/examples/hello_world/hello_world.elf
+  build-bin/sw/device/examples/hello_world/hello_world_sim_verilator.elf
 ```
 
 Note that debug support is not yet mature (see https://github.com/lowRISC/opentitan/issues/574).
@@ -166,8 +166,8 @@ Tracing slows down the simulation by roughly factor of 1000.
 ```console
 $ cd $REPO_TOP
 $ build/lowrisc_systems_top_earlgrey_verilator_0.1/sim-verilator/Vtop_earlgrey_verilator \
-  --meminit=rom,build-bin/sw/device/sim-verilator/boot_rom/boot_rom.elf \
-  --meminit=flash,build-bin/sw/device/sim-verilator/examples/hello_world/hello_world.elf \
+  --meminit=rom,build-bin/sw/device/boot_rom/boot_rom_sim_verilator.elf \
+  --meminit=flash,build-bin/sw/device/examples/hello_world/hello_world_sim_verilator.elf \
   --trace
 $ gtkwave sim.fst
 ```


### PR DESCRIPTION
Paths to built binaries have changed, this updates the documentation so
the correct paths are given.

Note that quickstart guide still uses the old paths but the latest release that the quickstart tells you to use is from last year and hence will still use the old paths.