### PR TITLE
[doc] Hardware breakpoints are now supported

### DIFF
--- a/doc/ug/getting_started_fpga.md
+++ b/doc/ug/getting_started_fpga.md
@@ -209,10 +209,6 @@ $ cd $REPO_TOP
 $ /tools/riscv/bin/riscv32-unknown-elf-gdb -ex "target extended-remote :3333" -ex "info reg" sw/device/boot_rom/rom.elf
 ```
 
-Note that debug support is not yet mature (see https://github.com/lowRISC/opentitan/issues/574).
-In particular GDB cannot set breakpoints as it can't write to the (emulated) flash memory.
-HW breakpoint support is planned for Ibex to allow breakpointing code in flash.
-
 #### Common operations with GDB
 
 Examine 16 memory words in the hex format starting at 0x200005c0

--- a/doc/ug/getting_started_verilator.md
+++ b/doc/ug/getting_started_verilator.md
@@ -108,10 +108,6 @@ $ riscv32-unknown-elf-gdb -ex "target extended-remote :3333" -ex "info reg" \
   build-bin/sw/device/sim-verilator/examples/hello_world/hello_world.elf
 ```
 
-Note that debug support is not yet mature (see https://github.com/lowRISC/opentitan/issues/574).
-In particular GDB cannot set breakpoints as it can't write to the (emulated) flash memory.
-HW breakpoint support is planned for Ibex to allow breakpointing code in flash.
-
 You can also run the debug compliance test suite built into OpenOCD.
 
 ```console


### PR DESCRIPTION
Remove a paragraph about hardware breakpoints not being supported, which
was fixed in #1577.