### PR TITLE
[sw] Make non-DV logging consistent with DV logging

### DIFF
--- a/hw/dv/data/sim.mk
+++ b/hw/dv/data/sim.mk
@@ -52,7 +52,7 @@ ifneq (${sw_name},)
 	# Extract the rom logs.
 	${proj_root}/util/device_sw_utils/extract_sw_logs.py \
 		-e "${sw_build_dir}/build-out/sw/device/boot_rom/boot_rom_${sw_build_device}.elf" \
-		-f .logs.fields -r .rodata .logs.strings .chip_info \
+		-f .logs.fields -r .rodata .chip_info \
 		-n "rom" -o "${run_dir}"
 	# Compile the test sw code and generate the image.
 	ninja -C ${sw_build_dir}/build-out \
@@ -60,7 +60,7 @@ ifneq (${sw_name},)
 	# Extract the sw logs.
 	${proj_root}/util/device_sw_utils/extract_sw_logs.py \
 		-e "${sw_build_dir}/build-out/sw/device/${sw_dir}/${sw_name}_${sw_build_device}.elf" \
-		-f .logs.fields -r .rodata .logs.strings \
+		-f .logs.fields -r .rodata \
 		-n "sw" -o "${run_dir}"
 	# Copy over the images to the run_dir.
 	cp ${sw_build_dir}/build-out/sw/device/boot_rom/boot_rom_${sw_build_device}.vmem \

--- a/sw/device/boot_rom/rom_link.ld
+++ b/sw/device/boot_rom/rom_link.ld
@@ -171,15 +171,6 @@ SECTIONS {
    */
 
   /**
-   * The following section contains strings. Examples include file names where
-   * the log is invoked (using the __FILE__ preprocessor macro). To prevent
-   * address collisions, this must not coincide with the rodata section.
-   */
-  .logs.strings 0x80000000 (DSECT): {
-    *(.logs.strings)
-  }
-
-  /**
    * The following section contains log fields constructed from the logs using
    * the log_fields_t struct defined in sw/device/lib/base/log.h. The size of
    * each log field is fixed - 20 bytes, which is used as the delimiter.

--- a/sw/device/exts/common/flash_link.ld
+++ b/sw/device/exts/common/flash_link.ld
@@ -159,15 +159,6 @@ SECTIONS {
    */
 
   /**
-   * The following section contains strings. Examples include file names where
-   * the log is invoked (using the __FILE__ preprocessor macro). To prevent
-   * address collisions, this must not coincide with the rodata section.
-   */
-  .logs.strings 0x80000000 (DSECT): {
-    *(.logs.strings)
-  }
-
-  /**
    * The following section contains log fields constructed from the logs using
    * the log_fields_t struct defined in sw/device/lib/base/log.h. The size of
    * each log field is fixed - 20 bytes, which is used as the delimiter.

--- a/sw/device/lib/base/macros.h
+++ b/sw/device/lib/base/macros.h
@@ -2,27 +2,33 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef OPENTITAN_SW_DEVICE_LIB_MACROS_H_
-#define OPENTITAN_SW_DEVICE_LIB_MACROS_H_
+#ifndef OPENTITAN_SW_DEVICE_LIB_BASE_MACROS_H_
+#define OPENTITAN_SW_DEVICE_LIB_BASE_MACROS_H_
 
 /**
- * Computes the number of variable args at compile-time.
- *
- * Currently, there is no way of knowing the number of var args at compile time.
- * This information is needed for the 'backdoor' logging to work in DV. The
- * following meta-programming enables us to get that information as long as the
- * number of var args passed is <=32.
+ * Generic preprocessor macros that don't really fit anywhere else.
  */
-#define GET_NTH_VARIABLE_ARG(xf, x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10,  \
-                             x11, x12, x13, x14, x15, x16, x17, x18, x19, x20, \
-                             x21, x22, x23, x24, x25, x26, x27, x28, x29, x30, \
-                             x31, n, ...)                                      \
-  n
-#define SHIFT_N_VARIABLE_ARGS(...) GET_NTH_VARIABLE_ARG(__VA_ARGS__)
-#define PASS_N_VARIABLE_ARGS(...)                                             \
-  SHIFT_N_VARIABLE_ARGS(__VA_ARGS__, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22,  \
-                        21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, \
-                        7, 6, 5, 4, 3, 2, 1, 0)
-#define GET_NUM_VARIABLE_ARGS(...) PASS_N_VARIABLE_ARGS(0, ##__VA_ARGS__)
 
-#endif  // OPENTITAN_SW_DEVICE_LIB_MACROS_H_
+/**
+ * A variable-argument macro that expands to the number of arguments passed into
+ * it, between 0 and 31 arguments.
+ *
+ * This macro is based off of a well-known preprocessor trick. This
+ * StackOverflow post expains the trick in detail:
+ * https://stackoverflow.com/questions/2308243/macro-returning-the-number-of-arguments-it-is-given-in-c
+ */
+#define GET_NUM_VARIABLE_ARGS(...) PASS_N_VARIABLE_ARGS_(0, ##__VA_ARGS__)
+
+// Implementation details for `GET_NUM_VARIABLE_ARGS()`.
+#define PASS_N_VARIABLE_ARGS_(...)                                             \
+  SHIFT_N_VARIABLE_ARGS_(__VA_ARGS__, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22,  \
+                         21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, \
+                         7, 6, 5, 4, 3, 2, 1, 0)
+#define SHIFT_N_VARIABLE_ARGS_(...) GET_NTH_VARIABLE_ARG_(__VA_ARGS__)
+#define GET_NTH_VARIABLE_ARG_(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, \
+                              x11, x12, x13, x14, x15, x16, x17, x18, x19, \
+                              x20, x21, x22, x23, x24, x25, x26, x27, x28, \
+                              x29, x30, x31, n, ...)                       \
+  n
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_BASE_MACROS_H_


### PR DESCRIPTION
Namely, this change makes both types of logging use the same structures,
for consistency.