### PR TITLE
[top_earlgrey] re-generate the autogen files

### DIFF
--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -1754,6 +1754,7 @@
         package: flash_ctrl_pkg
         struct: flash
         signame: flash_ctrl_eflash_flash
+        width: 1
         type: req_rsp
       }
     ]

--- a/hw/top_earlgrey/ip/rv_plic/data/autogen/rv_plic.hjson
+++ b/hw/top_earlgrey/ip/rv_plic/data/autogen/rv_plic.hjson
@@ -49,7 +49,7 @@
         ],
         tags: [// IP is driven by intr_src, cannot auto-predict
                "excl:CsrNonInitTests:CsrExclCheck"],
-     }
+      }
     },
     { multireg: {
         name: "LE",
@@ -727,8 +727,8 @@
       fields: [
         { bits: "6:0" }
       ],
-        tags: [// CC register value is related to IP
-               "excl:CsrNonInitTests:CsrExclCheck"],
+      tags: [// CC register value is related to IP
+             "excl:CsrNonInitTests:CsrExclCheck"],
     }
     { name: "MSIP0",
       desc: '''msip for Hart 0.


### PR DESCRIPTION
A few files were missed. RV_PLIC and top.gen.hjson are re-generated.
