### PR TITLE
[dv] improve rv_timer gpio coverage

### DIFF
--- a/hw/ip/gpio/dv/env/gpio_scoreboard.sv
+++ b/hw/ip/gpio/dv/env/gpio_scoreboard.sv
@@ -179,7 +179,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
               // Coverage Sampling: Cross coverage on mask and data within masked_* registers
               if (!uvm_re_match("masked*", csr.get_name())) begin
                 bit [(NUM_GPIOS/2) - 1:0] mask, data;
-                {mask, data} = item.d_data;
+                {mask, data} = item.a_data;
                 for (uint each_pin = 0; each_pin < NUM_GPIOS/2; each_pin++) begin
                   cov.out_oe_mask_data_cov_objs[each_pin][csr.get_name()].var1_var2_cg.sample(
                       mask[each_pin], data[each_pin]);

--- a/hw/ip/rv_timer/dv/rv_timer_sim_cfg.hjson
+++ b/hw/ip/rv_timer/dv/rv_timer_sim_cfg.hjson
@@ -59,6 +59,7 @@
       uvm_test_seq: rv_timer_cfg_update_on_fly_vseq
       // 10ms
       run_opts: ["+zero_delays=1", "+test_timeout_ns=10000000000"]
+      reseed: 200
     }
 
     {


### PR DESCRIPTION
Increase seeds for rv_timer to get 100% coverage
Fix gpio scb typo to collect a_data instead of d_data

Signed-off-by: Cindy Chen <chencindy@google.com>