### PR TITLE
[topgen] Array of inter-module signal

### DIFF
--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -313,7 +313,8 @@
           package: flash_ctrl_pkg
           inst_name: flash_ctrl
           width: 1
-          top_signame: flash_ctrl_eflash_flash
+          top_signame: flash_ctrl_flash
+          index: -1
         }
       ]
     }
@@ -762,7 +763,8 @@
           act: responder
           inst_name: eflash
           width: 1
-          top_signame: flash_ctrl_eflash_flash
+          top_signame: flash_ctrl_flash
+          index: -1
         }
       ]
     }
@@ -1736,7 +1738,8 @@
         package: flash_ctrl_pkg
         inst_name: flash_ctrl
         width: 1
-        top_signame: flash_ctrl_eflash_flash
+        top_signame: flash_ctrl_flash
+        index: -1
       }
       {
         struct: flash
@@ -1745,7 +1748,8 @@
         act: responder
         inst_name: eflash
         width: 1
-        top_signame: flash_ctrl_eflash_flash
+        top_signame: flash_ctrl_flash
+        index: -1
       }
     ]
     definitions:
@@ -1753,7 +1757,7 @@
       {
         package: flash_ctrl_pkg
         struct: flash
-        signame: flash_ctrl_eflash_flash
+        signame: flash_ctrl_flash
         width: 1
         type: req_rsp
       }

--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -443,8 +443,8 @@ module top_${top["name"]} #(
   % endif
   % for sig in top["inter_signal"]["definitions"]:
     % if sig["type"] == "req_rsp":
-  ${sig["package"]}::${sig["struct"]}_req_t ${sig["signame"]}_req;
-  ${sig["package"]}::${sig["struct"]}_rsp_t ${sig["signame"]}_rsp;
+  ${sig["package"]}::${sig["struct"]}_req_t ${lib.bitarray(sig["width"],1)} ${sig["signame"]}_req;
+  ${sig["package"]}::${sig["struct"]}_rsp_t ${lib.bitarray(sig["width"],1)} ${sig["signame"]}_rsp;
     % elif sig["type"] == "broadcast":
       % if sig["struct"] == "logic":
   logic ${lib.bitarray(sig["width"],1)} ${sig["signame"]};
@@ -596,18 +596,18 @@ else:
         % if "top_signame" in sig:
           % if sig["type"] == "req_rsp":
             % if sig["act"] == "requester":
-      .${sig["name"]}_o(${sig["top_signame"]}_req),
-      .${sig["name"]}_i(${sig["top_signame"]}_rsp),
+      .${sig["name"]}_o(${sig["top_signame"]}_req${lib.index(sig["index"])}),
+      .${sig["name"]}_i(${sig["top_signame"]}_rsp${lib.index(sig["index"])}),
           % elif sig["act"] == "responder":
-      .${sig["name"]}_i(${sig["top_signame"]}_req),
-      .${sig["name"]}_o(${sig["top_signame"]}_rsp),
+      .${sig["name"]}_i(${sig["top_signame"]}_req${lib.index(sig["index"])}),
+      .${sig["name"]}_o(${sig["top_signame"]}_rsp${lib.index(sig["index"])}),
             % endif # sig["act"] == requester
           % elif sig["type"] == "broadcast":
             ## TODO: Broadcast type
             % if sig["act"] == "requester":
-      .${sig["name"]}_o(${sig["top_signame"]}),
+      .${sig["name"]}_o(${sig["top_signame"]}${lib.index(sig["index"])}),
             % elif sig["act"] == "receiver":
-      .${sig["name"]}_i(${sig["top_signame"]}),
+      .${sig["name"]}_i(${sig["top_signame"]}${lib.index(sig["index"])}),
             % endif
           % endif
         % else: # no top_signame in sig

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -445,8 +445,8 @@ module top_earlgrey #(
   );
 
   // define inter-module signals
-  flash_ctrl_pkg::flash_req_t flash_ctrl_eflash_flash_req;
-  flash_ctrl_pkg::flash_rsp_t flash_ctrl_eflash_flash_rsp;
+  flash_ctrl_pkg::flash_req_t       flash_ctrl_flash_req;
+  flash_ctrl_pkg::flash_rsp_t       flash_ctrl_flash_rsp;
 
   // host to flash communication
   logic flash_host_req;
@@ -492,8 +492,8 @@ module top_earlgrey #(
     .host_req_rdy_o  (flash_host_req_rdy),
     .host_req_done_o (flash_host_req_done),
     .host_rdata_o    (flash_host_rdata),
-    .flash_ctrl_i    (flash_ctrl_eflash_flash_req),
-    .flash_ctrl_o    (flash_ctrl_eflash_flash_rsp)
+    .flash_ctrl_i    (flash_ctrl_flash_req),
+    .flash_ctrl_o    (flash_ctrl_flash_rsp)
   );
 
 
@@ -580,8 +580,8 @@ module top_earlgrey #(
       .intr_op_error_o   (intr_flash_ctrl_op_error),
 
       // Inter-module signals
-      .flash_o(flash_ctrl_eflash_flash_req),
-      .flash_i(flash_ctrl_eflash_flash_rsp),
+      .flash_o(flash_ctrl_flash_req),
+      .flash_i(flash_ctrl_flash_rsp),
 
       .clk_i (main_clk),
       .rst_ni (lc_rst_n)

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -37,7 +37,7 @@ def generate_top(top, tpl_filename):
 
     try:
         out_rtl = top_rtl_tpl.render(top=top)
-    except:
+    except:  # noqa: E722
         log.error(exceptions.text_error_template().render())
     return out_rtl
 
@@ -62,7 +62,7 @@ def generate_xbars(top, out_path):
 
         try:
             out_rtl, out_pkg, out_core = tlgen.generate(xbar)
-        except:
+        except:  # noqa: E722
             log.error(exceptions.text_error_template().render())
 
         rtl_path = out_path / 'ip/xbar_{}/rtl/autogen'.format(obj["name"])
@@ -160,7 +160,7 @@ def generate_alert_handler(top, out_path):
                                    lfsr_seed=lfsr_seed,
                                    async_on=async_on,
                                    n_classes=n_classes)
-        except:
+        except:  # noqa: E722
             log.error(exceptions.text_error_template().render())
         log.info("alert_handler hjson: %s" % out)
 
@@ -218,7 +218,7 @@ def generate_plic(top, out_path):
         hjson_tpl = Template(fin.read())
         try:
             out = hjson_tpl.render(src=src, target=target, prio=prio)
-        except:
+        except:  # noqa: E722
             log.error(exceptions.text_error_template().render())
         log.info("RV_PLIC hjson: %s" % out)
 
@@ -246,7 +246,7 @@ def generate_plic(top, out_path):
         rtl_tpl = Template(fin.read())
         try:
             out = rtl_tpl.render(src=src, target=target, prio=prio)
-        except:
+        except:  # noqa: E722
             log.error(exceptions.text_error_template().render())
         log.info("RV_PLIC RTL: %s" % out)
 
@@ -303,7 +303,7 @@ def generate_pinmux(top, out_path):
             out = hjson_tpl.render(n_periph_in=n_periph_in,
                                    n_periph_out=n_periph_out,
                                    n_mio_pads=num_mio)
-        except:
+        except:  # noqa: E722
             log.error(exceptions.text_error_template().render())
         log.info("PINMUX HJSON: %s" % out)
 
@@ -374,7 +374,7 @@ def main():
         '-o',
         help='''Target TOP directory.
              Module is created under rtl/. (default: dir(topcfg)/..)
-             ''') # yapf: disable
+             ''')  # yapf: disable
     parser.add_argument('--verbose', '-v', action='store_true', help="Verbose")
 
     # Generator options: 'no' series. cannot combined with 'only' series
@@ -403,7 +403,7 @@ def main():
     parser.add_argument(
         '--top-only',
         action='store_true',
-        help="If defined, the tool generates top RTL only") # yapf:disable
+        help="If defined, the tool generates top RTL only")  # yapf:disable
     parser.add_argument(
         '--xbar-only',
         action='store_true',
@@ -503,7 +503,7 @@ def main():
             ip_objs = []
             for x in ips:
                 # Skip if it is not in the module list
-                if not x.stem in [ip["type"] for ip in topcfg["module"]]:
+                if x.stem not in [ip["type"] for ip in topcfg["module"]]:
                     log.info(
                         "Skip module %s as it isn't in the top module list" %
                         x.stem)
@@ -559,7 +559,7 @@ def main():
             raise SystemExit(sys.exc_info()[1])
 
     # Generate PLIC
-    if not args.no_plic            and \
+    if not args.no_plic and \
        not args.alert_handler_only and \
        not args.xbar_only:
         generate_plic(completecfg, out_path)

--- a/util/topgen/lib.py
+++ b/util/topgen/lib.py
@@ -7,6 +7,7 @@ from copy import deepcopy
 from pathlib import Path
 from collections import OrderedDict
 import hjson
+import sys
 
 import re
 
@@ -56,7 +57,7 @@ def get_hjsonobj_xbars(xbar_path):
                        object_pairs_hook=OrderedDict) for x in p
         ]
     except ValueError:
-        raise Systemexit(sys.exc_info()[1])
+        raise SystemExit(sys.exc_info()[1])
 
     xbar_objs = [x for x in xbar_objs if is_xbarcfg(x)]
 
@@ -91,8 +92,7 @@ def get_package_name_by_intermodule_signal(top, struct) -> str:
     instances = top["module"] + top["memory"]
 
     intermodule_instances = [
-        x["inter_signal_list"] for x in top["module"] + top["memory"]
-        if "inter_signal_list" in x
+        x["inter_signal_list"] for x in instances if "inter_signal_list" in x
     ]
 
     for m in intermodule_instances:
@@ -119,7 +119,7 @@ def add_prefix_to_signal(signal, prefix):
     """
     result = deepcopy(signal)
 
-    if not "name" in signal:
+    if "name" not in signal:
         raise SystemExit("signal {} doesn't have name field".format(signal))
 
     result["name"] = prefix + "_" + signal["name"]
@@ -162,7 +162,7 @@ def get_pad_list(padstr):
         last = first
     first = int(first, 0)
     last = int(last, 0)
-    width = first - last + 1
+    # width = first - last + 1
 
     for p in range(first, last + 1):
         pads.append(OrderedDict([("name", pad), ("index", p)]))
@@ -204,7 +204,13 @@ def bitarray(d, width):
 def parameterize(text):
     """Return the value wrapping with quote if not integer nor bits
     """
-    if re.match('(\d+\'[hdb]\s*[0-9a-f_A-F]+|[0-9]+)', text) == None:
+    if re.match(r'(\d+\'[hdb]\s*[0-9a-f_A-F]+|[0-9]+)', text) is None:
         return "\"{}\"".format(text)
 
     return text
+
+
+def index(i: int) -> str:
+    """Return index if it is not -1
+    """
+    return "[{}]".format(i) if i != -1 else ""


### PR DESCRIPTION
This commit is to support an array of inter-module signals.

To achieve the array feature in inter-module, regardless of the act
(requester, responder/receiver), the key shall be an array and the
entries should be `width` as 1. So, inter-module signal only supports
1:1, 1:N, N:1.

Also, the top-level signal name follows the key instance name not
'req->rsp' as before.

```hjson
inter_module: {
  'module_a.sig_a': ['module_b.sig_a', 'module_c.sig_a']
}
```

In the above example, `sig_a` in `module_a` can be requester or
responder/receiver.  The `width` of `module_a.sig_a` shall be 2.
