### PR TITLE
[rv_plic] Change PRIO number starting from 1

### DIFF
--- a/hw/ip/rv_plic/data/rv_plic.hjson
+++ b/hw/ip/rv_plic/data/rv_plic.hjson
@@ -39,6 +39,8 @@
         fields: [
           { bits: "0", name: "P", desc: "Interrupt Pending of Source" }
         ],
+        tags: [// IP is driven by intr_src, cannot auto-predict
+               "excl:CsrNonInitTests:CsrExclCheck"],
       }
     },
     { multireg: {
@@ -341,6 +343,8 @@
       fields: [
         { bits: "5:0" }
       ],
+      tags: [// CC register value is related to IP
+             "excl:CsrNonInitTests:CsrExclCheck"],
     }
     { name: "MSIP0",
       desc: '''msip for Hart 0.

--- a/hw/ip/rv_plic/data/rv_plic.sv.tpl
+++ b/hw/ip/rv_plic/data/rv_plic.sv.tpl
@@ -16,7 +16,7 @@
 
 module rv_plic import rv_plic_reg_pkg::*; #(
   // derived parameter
-  localparam int SRCW    = $clog2(NumSrc+1)
+  localparam int SRCW    = $clog2(NumSrc)
 ) (
   input     clk_i,
   input     rst_ni,
@@ -66,13 +66,13 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   always_comb begin
     claim = '0;
     for (int i = 0 ; i < NumTarget ; i++) begin
-      if (claim_re[i]) claim[claim_id[i] -1] = 1'b1;
+      if (claim_re[i]) claim[claim_id[i]] = 1'b1;
     end
   end
   always_comb begin
     complete = '0;
     for (int i = 0 ; i < NumTarget ; i++) begin
-      if (complete_we[i]) complete[complete_id[i] -1] = 1'b1;
+      if (complete_we[i]) complete[complete_id[i]] = 1'b1;
     end
   end
 
@@ -206,5 +206,8 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   for (genvar k = 0; k < NumTarget; k++) begin : gen_irq_id_known
     `ASSERT_KNOWN(IrqIdKnownO_A, irq_id_o[k])
   end
+
+  // Assume
+  `ASSUME(Irq0Tied_A, intr_src_i[0] == 1'b0)
 
 endmodule

--- a/hw/ip/rv_plic/fpv/vip/rv_plic_assert_fpv.sv
+++ b/hw/ip/rv_plic/fpv/vip/rv_plic_assert_fpv.sv
@@ -31,7 +31,7 @@ module rv_plic_assert_fpv import rv_plic_reg_pkg::*; (
   int unsigned src_sel;
   int unsigned tgt_sel;
 
-  `ASSUME_FPV(IsrcRange_M, src_sel >= 0 && src_sel < NumSrc, clk_i, !rst_ni)
+  `ASSUME_FPV(IsrcRange_M, src_sel >  0 && src_sel < NumSrc, clk_i, !rst_ni)
   `ASSUME_FPV(ItgtRange_M, tgt_sel >= 0 && tgt_sel < NumTarget, clk_i, !rst_ni)
   `ASSUME_FPV(IsrcStable_M, ##1 $stable(src_sel), clk_i, !rst_ni)
   `ASSUME_FPV(ItgtStable_M, ##1 $stable(tgt_sel), clk_i, !rst_ni)
@@ -97,10 +97,10 @@ module rv_plic_assert_fpv import rv_plic_reg_pkg::*; (
           max_priority && ie[tgt_sel][src_sel] |=> irq_o[tgt_sel])
 
   `ASSERT(TriggerIrqBackwardCheck_A, $rose(irq_o[tgt_sel]) |->
-          $past(irq) && (irq_id_o[tgt_sel] - 1) == $past(i_high_prio))
+          $past(irq) && (irq_id_o[tgt_sel]) == $past(i_high_prio))
 
   // when irq ID changed, but not to ID=0, irq_o should be high, or irq represents the largest prio
   // but smaller than the threshold
   `ASSERT(IdChangeWithIrq_A, !$stable(irq_id_o[tgt_sel]) && irq_id_o[tgt_sel] != 0 |->
-          irq_o[tgt_sel] || ((irq_id_o[tgt_sel] - 1) == $past(i_high_prio) && !$past(irq)))
+          irq_o[tgt_sel] || ((irq_id_o[tgt_sel]) == $past(i_high_prio) && !$past(irq)))
 endmodule : rv_plic_assert_fpv

--- a/hw/ip/rv_plic/rtl/rv_plic.sv
+++ b/hw/ip/rv_plic/rtl/rv_plic.sv
@@ -16,7 +16,7 @@
 
 module rv_plic import rv_plic_reg_pkg::*; #(
   // derived parameter
-  localparam int SRCW    = $clog2(NumSrc+1)
+  localparam int SRCW    = $clog2(NumSrc)
 ) (
   input     clk_i,
   input     rst_ni,
@@ -66,13 +66,13 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   always_comb begin
     claim = '0;
     for (int i = 0 ; i < NumTarget ; i++) begin
-      if (claim_re[i]) claim[claim_id[i] -1] = 1'b1;
+      if (claim_re[i]) claim[claim_id[i]] = 1'b1;
     end
   end
   always_comb begin
     complete = '0;
     for (int i = 0 ; i < NumTarget ; i++) begin
-      if (complete_we[i]) complete[complete_id[i] -1] = 1'b1;
+      if (complete_we[i]) complete[complete_id[i]] = 1'b1;
     end
   end
 
@@ -227,6 +227,9 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   for (genvar k = 0; k < NumTarget; k++) begin : gen_irq_id_known
     `ASSERT_KNOWN(IrqIdKnownO_A, irq_id_o[k])
   end
+
+  // Assume
+  `ASSUME(Irq0Tied_A, intr_src_i[0] == 1'b0)
 
 endmodule
 

--- a/hw/ip/rv_plic/rtl/rv_plic_target.sv
+++ b/hw/ip/rv_plic/rtl/rv_plic_target.sv
@@ -70,7 +70,7 @@ module rv_plic_target #(
       if (level == N_LEVELS) begin : gen_leafs
         if (offset < N_SOURCE) begin : gen_assign
           assign is_tree[pa]  = ip[offset] & ie[offset];
-          assign id_tree[pa]  = offset+1'b1;
+          assign id_tree[pa]  = offset;
           assign max_tree[pa] = prio[offset];
         end else begin : gen_tie_off
           assign is_tree[pa]  = '0;

--- a/hw/top_earlgrey/ip/rv_plic/data/autogen/rv_plic.hjson
+++ b/hw/top_earlgrey/ip/rv_plic/data/autogen/rv_plic.hjson
@@ -25,7 +25,7 @@
     { name: "NumSrc",
       desc: "Number of interrupt sources",
       type: "int",
-      default: "79",
+      default: "80",
       local: "true"
     },
     { name: "NumTarget",
@@ -689,6 +689,14 @@
     }
     { name: "PRIO78",
       desc: "Interrupt Source 78 Priority",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "1:0" }
+      ],
+    }
+    { name: "PRIO79",
+      desc: "Interrupt Source 79 Priority",
       swaccess: "rw",
       hwaccess: "hro",
       fields: [

--- a/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic.sv
+++ b/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic.sv
@@ -24,7 +24,7 @@
 
 module rv_plic import rv_plic_reg_pkg::*; #(
   // derived parameter
-  localparam int SRCW    = $clog2(NumSrc+1)
+  localparam int SRCW    = $clog2(NumSrc)
 ) (
   input     clk_i,
   input     rst_ni,
@@ -74,13 +74,13 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   always_comb begin
     claim = '0;
     for (int i = 0 ; i < NumTarget ; i++) begin
-      if (claim_re[i]) claim[claim_id[i] -1] = 1'b1;
+      if (claim_re[i]) claim[claim_id[i]] = 1'b1;
     end
   end
   always_comb begin
     complete = '0;
     for (int i = 0 ; i < NumTarget ; i++) begin
-      if (complete_we[i]) complete[complete_id[i] -1] = 1'b1;
+      if (complete_we[i]) complete[complete_id[i]] = 1'b1;
     end
   end
 
@@ -173,11 +173,12 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   assign prio[76] = reg2hw.prio76.q;
   assign prio[77] = reg2hw.prio77.q;
   assign prio[78] = reg2hw.prio78.q;
+  assign prio[79] = reg2hw.prio79.q;
 
   //////////////////////
   // Interrupt Enable //
   //////////////////////
-  for (genvar s = 0; s < 79; s++) begin : gen_ie0
+  for (genvar s = 0; s < 80; s++) begin : gen_ie0
     assign ie[0][s] = reg2hw.ie0[s].q;
   end
 
@@ -203,7 +204,7 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   ////////
   // IP //
   ////////
-  for (genvar s = 0; s < 79; s++) begin : gen_ip
+  for (genvar s = 0; s < 80; s++) begin : gen_ip
     assign hw2reg.ip[s].de = 1'b1; // Always write
     assign hw2reg.ip[s].d  = ip[s];
   end
@@ -211,7 +212,7 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   ///////////////////////////////////
   // Detection:: 0: Level, 1: Edge //
   ///////////////////////////////////
-  for (genvar s = 0; s < 79; s++) begin : gen_le
+  for (genvar s = 0; s < 80; s++) begin : gen_le
     assign le[s] = reg2hw.le[s].q;
   end
 
@@ -282,5 +283,8 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   for (genvar k = 0; k < NumTarget; k++) begin : gen_irq_id_known
     `ASSERT_KNOWN(IrqIdKnownO_A, irq_id_o[k])
   end
+
+  // Assume
+  `ASSUME(Irq0Tied_A, intr_src_i[0] == 1'b0)
 
 endmodule

--- a/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_pkg.sv
@@ -7,7 +7,7 @@
 package rv_plic_reg_pkg;
 
   // Param list
-  parameter int NumSrc = 79;
+  parameter int NumSrc = 80;
   parameter int NumTarget = 1;
 
   ////////////////////////////
@@ -334,6 +334,10 @@ package rv_plic_reg_pkg;
   } rv_plic_reg2hw_prio78_reg_t;
 
   typedef struct packed {
+    logic [1:0]  q;
+  } rv_plic_reg2hw_prio79_reg_t;
+
+  typedef struct packed {
     logic        q;
   } rv_plic_reg2hw_ie0_mreg_t;
 
@@ -366,87 +370,88 @@ package rv_plic_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    rv_plic_reg2hw_le_mreg_t [78:0] le; // [327:249]
-    rv_plic_reg2hw_prio0_reg_t prio0; // [248:247]
-    rv_plic_reg2hw_prio1_reg_t prio1; // [246:245]
-    rv_plic_reg2hw_prio2_reg_t prio2; // [244:243]
-    rv_plic_reg2hw_prio3_reg_t prio3; // [242:241]
-    rv_plic_reg2hw_prio4_reg_t prio4; // [240:239]
-    rv_plic_reg2hw_prio5_reg_t prio5; // [238:237]
-    rv_plic_reg2hw_prio6_reg_t prio6; // [236:235]
-    rv_plic_reg2hw_prio7_reg_t prio7; // [234:233]
-    rv_plic_reg2hw_prio8_reg_t prio8; // [232:231]
-    rv_plic_reg2hw_prio9_reg_t prio9; // [230:229]
-    rv_plic_reg2hw_prio10_reg_t prio10; // [228:227]
-    rv_plic_reg2hw_prio11_reg_t prio11; // [226:225]
-    rv_plic_reg2hw_prio12_reg_t prio12; // [224:223]
-    rv_plic_reg2hw_prio13_reg_t prio13; // [222:221]
-    rv_plic_reg2hw_prio14_reg_t prio14; // [220:219]
-    rv_plic_reg2hw_prio15_reg_t prio15; // [218:217]
-    rv_plic_reg2hw_prio16_reg_t prio16; // [216:215]
-    rv_plic_reg2hw_prio17_reg_t prio17; // [214:213]
-    rv_plic_reg2hw_prio18_reg_t prio18; // [212:211]
-    rv_plic_reg2hw_prio19_reg_t prio19; // [210:209]
-    rv_plic_reg2hw_prio20_reg_t prio20; // [208:207]
-    rv_plic_reg2hw_prio21_reg_t prio21; // [206:205]
-    rv_plic_reg2hw_prio22_reg_t prio22; // [204:203]
-    rv_plic_reg2hw_prio23_reg_t prio23; // [202:201]
-    rv_plic_reg2hw_prio24_reg_t prio24; // [200:199]
-    rv_plic_reg2hw_prio25_reg_t prio25; // [198:197]
-    rv_plic_reg2hw_prio26_reg_t prio26; // [196:195]
-    rv_plic_reg2hw_prio27_reg_t prio27; // [194:193]
-    rv_plic_reg2hw_prio28_reg_t prio28; // [192:191]
-    rv_plic_reg2hw_prio29_reg_t prio29; // [190:189]
-    rv_plic_reg2hw_prio30_reg_t prio30; // [188:187]
-    rv_plic_reg2hw_prio31_reg_t prio31; // [186:185]
-    rv_plic_reg2hw_prio32_reg_t prio32; // [184:183]
-    rv_plic_reg2hw_prio33_reg_t prio33; // [182:181]
-    rv_plic_reg2hw_prio34_reg_t prio34; // [180:179]
-    rv_plic_reg2hw_prio35_reg_t prio35; // [178:177]
-    rv_plic_reg2hw_prio36_reg_t prio36; // [176:175]
-    rv_plic_reg2hw_prio37_reg_t prio37; // [174:173]
-    rv_plic_reg2hw_prio38_reg_t prio38; // [172:171]
-    rv_plic_reg2hw_prio39_reg_t prio39; // [170:169]
-    rv_plic_reg2hw_prio40_reg_t prio40; // [168:167]
-    rv_plic_reg2hw_prio41_reg_t prio41; // [166:165]
-    rv_plic_reg2hw_prio42_reg_t prio42; // [164:163]
-    rv_plic_reg2hw_prio43_reg_t prio43; // [162:161]
-    rv_plic_reg2hw_prio44_reg_t prio44; // [160:159]
-    rv_plic_reg2hw_prio45_reg_t prio45; // [158:157]
-    rv_plic_reg2hw_prio46_reg_t prio46; // [156:155]
-    rv_plic_reg2hw_prio47_reg_t prio47; // [154:153]
-    rv_plic_reg2hw_prio48_reg_t prio48; // [152:151]
-    rv_plic_reg2hw_prio49_reg_t prio49; // [150:149]
-    rv_plic_reg2hw_prio50_reg_t prio50; // [148:147]
-    rv_plic_reg2hw_prio51_reg_t prio51; // [146:145]
-    rv_plic_reg2hw_prio52_reg_t prio52; // [144:143]
-    rv_plic_reg2hw_prio53_reg_t prio53; // [142:141]
-    rv_plic_reg2hw_prio54_reg_t prio54; // [140:139]
-    rv_plic_reg2hw_prio55_reg_t prio55; // [138:137]
-    rv_plic_reg2hw_prio56_reg_t prio56; // [136:135]
-    rv_plic_reg2hw_prio57_reg_t prio57; // [134:133]
-    rv_plic_reg2hw_prio58_reg_t prio58; // [132:131]
-    rv_plic_reg2hw_prio59_reg_t prio59; // [130:129]
-    rv_plic_reg2hw_prio60_reg_t prio60; // [128:127]
-    rv_plic_reg2hw_prio61_reg_t prio61; // [126:125]
-    rv_plic_reg2hw_prio62_reg_t prio62; // [124:123]
-    rv_plic_reg2hw_prio63_reg_t prio63; // [122:121]
-    rv_plic_reg2hw_prio64_reg_t prio64; // [120:119]
-    rv_plic_reg2hw_prio65_reg_t prio65; // [118:117]
-    rv_plic_reg2hw_prio66_reg_t prio66; // [116:115]
-    rv_plic_reg2hw_prio67_reg_t prio67; // [114:113]
-    rv_plic_reg2hw_prio68_reg_t prio68; // [112:111]
-    rv_plic_reg2hw_prio69_reg_t prio69; // [110:109]
-    rv_plic_reg2hw_prio70_reg_t prio70; // [108:107]
-    rv_plic_reg2hw_prio71_reg_t prio71; // [106:105]
-    rv_plic_reg2hw_prio72_reg_t prio72; // [104:103]
-    rv_plic_reg2hw_prio73_reg_t prio73; // [102:101]
-    rv_plic_reg2hw_prio74_reg_t prio74; // [100:99]
-    rv_plic_reg2hw_prio75_reg_t prio75; // [98:97]
-    rv_plic_reg2hw_prio76_reg_t prio76; // [96:95]
-    rv_plic_reg2hw_prio77_reg_t prio77; // [94:93]
-    rv_plic_reg2hw_prio78_reg_t prio78; // [92:91]
-    rv_plic_reg2hw_ie0_mreg_t [78:0] ie0; // [90:12]
+    rv_plic_reg2hw_le_mreg_t [79:0] le; // [331:252]
+    rv_plic_reg2hw_prio0_reg_t prio0; // [251:250]
+    rv_plic_reg2hw_prio1_reg_t prio1; // [249:248]
+    rv_plic_reg2hw_prio2_reg_t prio2; // [247:246]
+    rv_plic_reg2hw_prio3_reg_t prio3; // [245:244]
+    rv_plic_reg2hw_prio4_reg_t prio4; // [243:242]
+    rv_plic_reg2hw_prio5_reg_t prio5; // [241:240]
+    rv_plic_reg2hw_prio6_reg_t prio6; // [239:238]
+    rv_plic_reg2hw_prio7_reg_t prio7; // [237:236]
+    rv_plic_reg2hw_prio8_reg_t prio8; // [235:234]
+    rv_plic_reg2hw_prio9_reg_t prio9; // [233:232]
+    rv_plic_reg2hw_prio10_reg_t prio10; // [231:230]
+    rv_plic_reg2hw_prio11_reg_t prio11; // [229:228]
+    rv_plic_reg2hw_prio12_reg_t prio12; // [227:226]
+    rv_plic_reg2hw_prio13_reg_t prio13; // [225:224]
+    rv_plic_reg2hw_prio14_reg_t prio14; // [223:222]
+    rv_plic_reg2hw_prio15_reg_t prio15; // [221:220]
+    rv_plic_reg2hw_prio16_reg_t prio16; // [219:218]
+    rv_plic_reg2hw_prio17_reg_t prio17; // [217:216]
+    rv_plic_reg2hw_prio18_reg_t prio18; // [215:214]
+    rv_plic_reg2hw_prio19_reg_t prio19; // [213:212]
+    rv_plic_reg2hw_prio20_reg_t prio20; // [211:210]
+    rv_plic_reg2hw_prio21_reg_t prio21; // [209:208]
+    rv_plic_reg2hw_prio22_reg_t prio22; // [207:206]
+    rv_plic_reg2hw_prio23_reg_t prio23; // [205:204]
+    rv_plic_reg2hw_prio24_reg_t prio24; // [203:202]
+    rv_plic_reg2hw_prio25_reg_t prio25; // [201:200]
+    rv_plic_reg2hw_prio26_reg_t prio26; // [199:198]
+    rv_plic_reg2hw_prio27_reg_t prio27; // [197:196]
+    rv_plic_reg2hw_prio28_reg_t prio28; // [195:194]
+    rv_plic_reg2hw_prio29_reg_t prio29; // [193:192]
+    rv_plic_reg2hw_prio30_reg_t prio30; // [191:190]
+    rv_plic_reg2hw_prio31_reg_t prio31; // [189:188]
+    rv_plic_reg2hw_prio32_reg_t prio32; // [187:186]
+    rv_plic_reg2hw_prio33_reg_t prio33; // [185:184]
+    rv_plic_reg2hw_prio34_reg_t prio34; // [183:182]
+    rv_plic_reg2hw_prio35_reg_t prio35; // [181:180]
+    rv_plic_reg2hw_prio36_reg_t prio36; // [179:178]
+    rv_plic_reg2hw_prio37_reg_t prio37; // [177:176]
+    rv_plic_reg2hw_prio38_reg_t prio38; // [175:174]
+    rv_plic_reg2hw_prio39_reg_t prio39; // [173:172]
+    rv_plic_reg2hw_prio40_reg_t prio40; // [171:170]
+    rv_plic_reg2hw_prio41_reg_t prio41; // [169:168]
+    rv_plic_reg2hw_prio42_reg_t prio42; // [167:166]
+    rv_plic_reg2hw_prio43_reg_t prio43; // [165:164]
+    rv_plic_reg2hw_prio44_reg_t prio44; // [163:162]
+    rv_plic_reg2hw_prio45_reg_t prio45; // [161:160]
+    rv_plic_reg2hw_prio46_reg_t prio46; // [159:158]
+    rv_plic_reg2hw_prio47_reg_t prio47; // [157:156]
+    rv_plic_reg2hw_prio48_reg_t prio48; // [155:154]
+    rv_plic_reg2hw_prio49_reg_t prio49; // [153:152]
+    rv_plic_reg2hw_prio50_reg_t prio50; // [151:150]
+    rv_plic_reg2hw_prio51_reg_t prio51; // [149:148]
+    rv_plic_reg2hw_prio52_reg_t prio52; // [147:146]
+    rv_plic_reg2hw_prio53_reg_t prio53; // [145:144]
+    rv_plic_reg2hw_prio54_reg_t prio54; // [143:142]
+    rv_plic_reg2hw_prio55_reg_t prio55; // [141:140]
+    rv_plic_reg2hw_prio56_reg_t prio56; // [139:138]
+    rv_plic_reg2hw_prio57_reg_t prio57; // [137:136]
+    rv_plic_reg2hw_prio58_reg_t prio58; // [135:134]
+    rv_plic_reg2hw_prio59_reg_t prio59; // [133:132]
+    rv_plic_reg2hw_prio60_reg_t prio60; // [131:130]
+    rv_plic_reg2hw_prio61_reg_t prio61; // [129:128]
+    rv_plic_reg2hw_prio62_reg_t prio62; // [127:126]
+    rv_plic_reg2hw_prio63_reg_t prio63; // [125:124]
+    rv_plic_reg2hw_prio64_reg_t prio64; // [123:122]
+    rv_plic_reg2hw_prio65_reg_t prio65; // [121:120]
+    rv_plic_reg2hw_prio66_reg_t prio66; // [119:118]
+    rv_plic_reg2hw_prio67_reg_t prio67; // [117:116]
+    rv_plic_reg2hw_prio68_reg_t prio68; // [115:114]
+    rv_plic_reg2hw_prio69_reg_t prio69; // [113:112]
+    rv_plic_reg2hw_prio70_reg_t prio70; // [111:110]
+    rv_plic_reg2hw_prio71_reg_t prio71; // [109:108]
+    rv_plic_reg2hw_prio72_reg_t prio72; // [107:106]
+    rv_plic_reg2hw_prio73_reg_t prio73; // [105:104]
+    rv_plic_reg2hw_prio74_reg_t prio74; // [103:102]
+    rv_plic_reg2hw_prio75_reg_t prio75; // [101:100]
+    rv_plic_reg2hw_prio76_reg_t prio76; // [99:98]
+    rv_plic_reg2hw_prio77_reg_t prio77; // [97:96]
+    rv_plic_reg2hw_prio78_reg_t prio78; // [95:94]
+    rv_plic_reg2hw_prio79_reg_t prio79; // [93:92]
+    rv_plic_reg2hw_ie0_mreg_t [79:0] ie0; // [91:12]
     rv_plic_reg2hw_threshold0_reg_t threshold0; // [11:10]
     rv_plic_reg2hw_cc0_reg_t cc0; // [9:1]
     rv_plic_reg2hw_msip0_reg_t msip0; // [0:0]
@@ -456,7 +461,7 @@ package rv_plic_reg_pkg;
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    rv_plic_hw2reg_ip_mreg_t [78:0] ip; // [164:7]
+    rv_plic_hw2reg_ip_mreg_t [79:0] ip; // [166:7]
     rv_plic_hw2reg_cc0_reg_t cc0; // [6:-2]
   } rv_plic_hw2reg_t;
 
@@ -546,6 +551,7 @@ package rv_plic_reg_pkg;
   parameter logic [9:0] RV_PLIC_PRIO76_OFFSET = 10'h 148;
   parameter logic [9:0] RV_PLIC_PRIO77_OFFSET = 10'h 14c;
   parameter logic [9:0] RV_PLIC_PRIO78_OFFSET = 10'h 150;
+  parameter logic [9:0] RV_PLIC_PRIO79_OFFSET = 10'h 154;
   parameter logic [9:0] RV_PLIC_IE00_OFFSET = 10'h 200;
   parameter logic [9:0] RV_PLIC_IE01_OFFSET = 10'h 204;
   parameter logic [9:0] RV_PLIC_IE02_OFFSET = 10'h 208;
@@ -641,6 +647,7 @@ package rv_plic_reg_pkg;
     RV_PLIC_PRIO76,
     RV_PLIC_PRIO77,
     RV_PLIC_PRIO78,
+    RV_PLIC_PRIO79,
     RV_PLIC_IE00,
     RV_PLIC_IE01,
     RV_PLIC_IE02,
@@ -650,7 +657,7 @@ package rv_plic_reg_pkg;
   } rv_plic_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] RV_PLIC_PERMIT [91] = '{
+  parameter logic [3:0] RV_PLIC_PERMIT [92] = '{
     4'b 1111, // index[ 0] RV_PLIC_IP0
     4'b 1111, // index[ 1] RV_PLIC_IP1
     4'b 0011, // index[ 2] RV_PLIC_IP2
@@ -736,12 +743,13 @@ package rv_plic_reg_pkg;
     4'b 0001, // index[82] RV_PLIC_PRIO76
     4'b 0001, // index[83] RV_PLIC_PRIO77
     4'b 0001, // index[84] RV_PLIC_PRIO78
-    4'b 1111, // index[85] RV_PLIC_IE00
-    4'b 1111, // index[86] RV_PLIC_IE01
-    4'b 0011, // index[87] RV_PLIC_IE02
-    4'b 0001, // index[88] RV_PLIC_THRESHOLD0
-    4'b 0001, // index[89] RV_PLIC_CC0
-    4'b 0001  // index[90] RV_PLIC_MSIP0
+    4'b 0001, // index[85] RV_PLIC_PRIO79
+    4'b 1111, // index[86] RV_PLIC_IE00
+    4'b 1111, // index[87] RV_PLIC_IE01
+    4'b 0011, // index[88] RV_PLIC_IE02
+    4'b 0001, // index[89] RV_PLIC_THRESHOLD0
+    4'b 0001, // index[90] RV_PLIC_CC0
+    4'b 0001  // index[91] RV_PLIC_MSIP0
   };
 endpackage
 

--- a/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_top.sv
+++ b/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_top.sv
@@ -150,6 +150,7 @@ module rv_plic_reg_top (
   logic ip2_p76_qs;
   logic ip2_p77_qs;
   logic ip2_p78_qs;
+  logic ip2_p79_qs;
   logic le0_le0_qs;
   logic le0_le0_wd;
   logic le0_le0_we;
@@ -387,6 +388,9 @@ module rv_plic_reg_top (
   logic le2_le78_qs;
   logic le2_le78_wd;
   logic le2_le78_we;
+  logic le2_le79_qs;
+  logic le2_le79_wd;
+  logic le2_le79_we;
   logic [1:0] prio0_qs;
   logic [1:0] prio0_wd;
   logic prio0_we;
@@ -624,6 +628,9 @@ module rv_plic_reg_top (
   logic [1:0] prio78_qs;
   logic [1:0] prio78_wd;
   logic prio78_we;
+  logic [1:0] prio79_qs;
+  logic [1:0] prio79_wd;
+  logic prio79_we;
   logic ie00_e0_qs;
   logic ie00_e0_wd;
   logic ie00_e0_we;
@@ -861,6 +868,9 @@ module rv_plic_reg_top (
   logic ie02_e78_qs;
   logic ie02_e78_wd;
   logic ie02_e78_we;
+  logic ie02_e79_qs;
+  logic ie02_e79_wd;
+  logic ie02_e79_we;
   logic [1:0] threshold0_qs;
   logic [1:0] threshold0_wd;
   logic threshold0_we;
@@ -2855,6 +2865,31 @@ module rv_plic_reg_top (
 
     // to register interface (read)
     .qs     (ip2_p78_qs)
+  );
+
+
+  // F[p79]: 15:15
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RO"),
+    .RESVAL  (1'h0)
+  ) u_ip2_p79 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    .we     (1'b0),
+    .wd     ('0  ),
+
+    // from internal hardware
+    .de     (hw2reg.ip[79].de),
+    .d      (hw2reg.ip[79].d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (ip2_p79_qs)
   );
 
 
@@ -4920,6 +4955,32 @@ module rv_plic_reg_top (
 
     // to register interface (read)
     .qs     (le2_le78_qs)
+  );
+
+
+  // F[le79]: 15:15
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_le2_le79 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (le2_le79_we),
+    .wd     (le2_le79_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.le[79].q ),
+
+    // to register interface (read)
+    .qs     (le2_le79_qs)
   );
 
 
@@ -7057,6 +7118,33 @@ module rv_plic_reg_top (
   );
 
 
+  // R[prio79]: V(False)
+
+  prim_subreg #(
+    .DW      (2),
+    .SWACCESS("RW"),
+    .RESVAL  (2'h0)
+  ) u_prio79 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (prio79_we),
+    .wd     (prio79_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.prio79.q ),
+
+    // to register interface (read)
+    .qs     (prio79_qs)
+  );
+
+
 
   // Subregister 0 of Multireg ie0
   // R[ie00]: V(False)
@@ -9121,6 +9209,32 @@ module rv_plic_reg_top (
   );
 
 
+  // F[e79]: 15:15
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_ie02_e79 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ie02_e79_we),
+    .wd     (ie02_e79_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ie0[79].q ),
+
+    // to register interface (read)
+    .qs     (ie02_e79_qs)
+  );
+
+
 
   // R[threshold0]: V(False)
 
@@ -9194,7 +9308,7 @@ module rv_plic_reg_top (
 
 
 
-  logic [90:0] addr_hit;
+  logic [91:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == RV_PLIC_IP0_OFFSET);
@@ -9282,12 +9396,13 @@ module rv_plic_reg_top (
     addr_hit[82] = (reg_addr == RV_PLIC_PRIO76_OFFSET);
     addr_hit[83] = (reg_addr == RV_PLIC_PRIO77_OFFSET);
     addr_hit[84] = (reg_addr == RV_PLIC_PRIO78_OFFSET);
-    addr_hit[85] = (reg_addr == RV_PLIC_IE00_OFFSET);
-    addr_hit[86] = (reg_addr == RV_PLIC_IE01_OFFSET);
-    addr_hit[87] = (reg_addr == RV_PLIC_IE02_OFFSET);
-    addr_hit[88] = (reg_addr == RV_PLIC_THRESHOLD0_OFFSET);
-    addr_hit[89] = (reg_addr == RV_PLIC_CC0_OFFSET);
-    addr_hit[90] = (reg_addr == RV_PLIC_MSIP0_OFFSET);
+    addr_hit[85] = (reg_addr == RV_PLIC_PRIO79_OFFSET);
+    addr_hit[86] = (reg_addr == RV_PLIC_IE00_OFFSET);
+    addr_hit[87] = (reg_addr == RV_PLIC_IE01_OFFSET);
+    addr_hit[88] = (reg_addr == RV_PLIC_IE02_OFFSET);
+    addr_hit[89] = (reg_addr == RV_PLIC_THRESHOLD0_OFFSET);
+    addr_hit[90] = (reg_addr == RV_PLIC_CC0_OFFSET);
+    addr_hit[91] = (reg_addr == RV_PLIC_MSIP0_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -9386,7 +9501,9 @@ module rv_plic_reg_top (
     if (addr_hit[88] && reg_we && (RV_PLIC_PERMIT[88] != (RV_PLIC_PERMIT[88] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[89] && reg_we && (RV_PLIC_PERMIT[89] != (RV_PLIC_PERMIT[89] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[90] && reg_we && (RV_PLIC_PERMIT[90] != (RV_PLIC_PERMIT[90] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[91] && reg_we && (RV_PLIC_PERMIT[91] != (RV_PLIC_PERMIT[91] & reg_be))) wr_err = 1'b1 ;
   end
+
 
 
 
@@ -9704,6 +9821,9 @@ module rv_plic_reg_top (
   assign le2_le78_we = addr_hit[5] & reg_we & ~wr_err;
   assign le2_le78_wd = reg_wdata[14];
 
+  assign le2_le79_we = addr_hit[5] & reg_we & ~wr_err;
+  assign le2_le79_wd = reg_wdata[15];
+
   assign prio0_we = addr_hit[6] & reg_we & ~wr_err;
   assign prio0_wd = reg_wdata[1:0];
 
@@ -9941,251 +10061,257 @@ module rv_plic_reg_top (
   assign prio78_we = addr_hit[84] & reg_we & ~wr_err;
   assign prio78_wd = reg_wdata[1:0];
 
-  assign ie00_e0_we = addr_hit[85] & reg_we & ~wr_err;
+  assign prio79_we = addr_hit[85] & reg_we & ~wr_err;
+  assign prio79_wd = reg_wdata[1:0];
+
+  assign ie00_e0_we = addr_hit[86] & reg_we & ~wr_err;
   assign ie00_e0_wd = reg_wdata[0];
 
-  assign ie00_e1_we = addr_hit[85] & reg_we & ~wr_err;
+  assign ie00_e1_we = addr_hit[86] & reg_we & ~wr_err;
   assign ie00_e1_wd = reg_wdata[1];
 
-  assign ie00_e2_we = addr_hit[85] & reg_we & ~wr_err;
+  assign ie00_e2_we = addr_hit[86] & reg_we & ~wr_err;
   assign ie00_e2_wd = reg_wdata[2];
 
-  assign ie00_e3_we = addr_hit[85] & reg_we & ~wr_err;
+  assign ie00_e3_we = addr_hit[86] & reg_we & ~wr_err;
   assign ie00_e3_wd = reg_wdata[3];
 
-  assign ie00_e4_we = addr_hit[85] & reg_we & ~wr_err;
+  assign ie00_e4_we = addr_hit[86] & reg_we & ~wr_err;
   assign ie00_e4_wd = reg_wdata[4];
 
-  assign ie00_e5_we = addr_hit[85] & reg_we & ~wr_err;
+  assign ie00_e5_we = addr_hit[86] & reg_we & ~wr_err;
   assign ie00_e5_wd = reg_wdata[5];
 
-  assign ie00_e6_we = addr_hit[85] & reg_we & ~wr_err;
+  assign ie00_e6_we = addr_hit[86] & reg_we & ~wr_err;
   assign ie00_e6_wd = reg_wdata[6];
 
-  assign ie00_e7_we = addr_hit[85] & reg_we & ~wr_err;
+  assign ie00_e7_we = addr_hit[86] & reg_we & ~wr_err;
   assign ie00_e7_wd = reg_wdata[7];
 
-  assign ie00_e8_we = addr_hit[85] & reg_we & ~wr_err;
+  assign ie00_e8_we = addr_hit[86] & reg_we & ~wr_err;
   assign ie00_e8_wd = reg_wdata[8];
 
-  assign ie00_e9_we = addr_hit[85] & reg_we & ~wr_err;
+  assign ie00_e9_we = addr_hit[86] & reg_we & ~wr_err;
   assign ie00_e9_wd = reg_wdata[9];
 
-  assign ie00_e10_we = addr_hit[85] & reg_we & ~wr_err;
+  assign ie00_e10_we = addr_hit[86] & reg_we & ~wr_err;
   assign ie00_e10_wd = reg_wdata[10];
 
-  assign ie00_e11_we = addr_hit[85] & reg_we & ~wr_err;
+  assign ie00_e11_we = addr_hit[86] & reg_we & ~wr_err;
   assign ie00_e11_wd = reg_wdata[11];
 
-  assign ie00_e12_we = addr_hit[85] & reg_we & ~wr_err;
+  assign ie00_e12_we = addr_hit[86] & reg_we & ~wr_err;
   assign ie00_e12_wd = reg_wdata[12];
 
-  assign ie00_e13_we = addr_hit[85] & reg_we & ~wr_err;
+  assign ie00_e13_we = addr_hit[86] & reg_we & ~wr_err;
   assign ie00_e13_wd = reg_wdata[13];
 
-  assign ie00_e14_we = addr_hit[85] & reg_we & ~wr_err;
+  assign ie00_e14_we = addr_hit[86] & reg_we & ~wr_err;
   assign ie00_e14_wd = reg_wdata[14];
 
-  assign ie00_e15_we = addr_hit[85] & reg_we & ~wr_err;
+  assign ie00_e15_we = addr_hit[86] & reg_we & ~wr_err;
   assign ie00_e15_wd = reg_wdata[15];
 
-  assign ie00_e16_we = addr_hit[85] & reg_we & ~wr_err;
+  assign ie00_e16_we = addr_hit[86] & reg_we & ~wr_err;
   assign ie00_e16_wd = reg_wdata[16];
 
-  assign ie00_e17_we = addr_hit[85] & reg_we & ~wr_err;
+  assign ie00_e17_we = addr_hit[86] & reg_we & ~wr_err;
   assign ie00_e17_wd = reg_wdata[17];
 
-  assign ie00_e18_we = addr_hit[85] & reg_we & ~wr_err;
+  assign ie00_e18_we = addr_hit[86] & reg_we & ~wr_err;
   assign ie00_e18_wd = reg_wdata[18];
 
-  assign ie00_e19_we = addr_hit[85] & reg_we & ~wr_err;
+  assign ie00_e19_we = addr_hit[86] & reg_we & ~wr_err;
   assign ie00_e19_wd = reg_wdata[19];
 
-  assign ie00_e20_we = addr_hit[85] & reg_we & ~wr_err;
+  assign ie00_e20_we = addr_hit[86] & reg_we & ~wr_err;
   assign ie00_e20_wd = reg_wdata[20];
 
-  assign ie00_e21_we = addr_hit[85] & reg_we & ~wr_err;
+  assign ie00_e21_we = addr_hit[86] & reg_we & ~wr_err;
   assign ie00_e21_wd = reg_wdata[21];
 
-  assign ie00_e22_we = addr_hit[85] & reg_we & ~wr_err;
+  assign ie00_e22_we = addr_hit[86] & reg_we & ~wr_err;
   assign ie00_e22_wd = reg_wdata[22];
 
-  assign ie00_e23_we = addr_hit[85] & reg_we & ~wr_err;
+  assign ie00_e23_we = addr_hit[86] & reg_we & ~wr_err;
   assign ie00_e23_wd = reg_wdata[23];
 
-  assign ie00_e24_we = addr_hit[85] & reg_we & ~wr_err;
+  assign ie00_e24_we = addr_hit[86] & reg_we & ~wr_err;
   assign ie00_e24_wd = reg_wdata[24];
 
-  assign ie00_e25_we = addr_hit[85] & reg_we & ~wr_err;
+  assign ie00_e25_we = addr_hit[86] & reg_we & ~wr_err;
   assign ie00_e25_wd = reg_wdata[25];
 
-  assign ie00_e26_we = addr_hit[85] & reg_we & ~wr_err;
+  assign ie00_e26_we = addr_hit[86] & reg_we & ~wr_err;
   assign ie00_e26_wd = reg_wdata[26];
 
-  assign ie00_e27_we = addr_hit[85] & reg_we & ~wr_err;
+  assign ie00_e27_we = addr_hit[86] & reg_we & ~wr_err;
   assign ie00_e27_wd = reg_wdata[27];
 
-  assign ie00_e28_we = addr_hit[85] & reg_we & ~wr_err;
+  assign ie00_e28_we = addr_hit[86] & reg_we & ~wr_err;
   assign ie00_e28_wd = reg_wdata[28];
 
-  assign ie00_e29_we = addr_hit[85] & reg_we & ~wr_err;
+  assign ie00_e29_we = addr_hit[86] & reg_we & ~wr_err;
   assign ie00_e29_wd = reg_wdata[29];
 
-  assign ie00_e30_we = addr_hit[85] & reg_we & ~wr_err;
+  assign ie00_e30_we = addr_hit[86] & reg_we & ~wr_err;
   assign ie00_e30_wd = reg_wdata[30];
 
-  assign ie00_e31_we = addr_hit[85] & reg_we & ~wr_err;
+  assign ie00_e31_we = addr_hit[86] & reg_we & ~wr_err;
   assign ie00_e31_wd = reg_wdata[31];
 
-  assign ie01_e32_we = addr_hit[86] & reg_we & ~wr_err;
+  assign ie01_e32_we = addr_hit[87] & reg_we & ~wr_err;
   assign ie01_e32_wd = reg_wdata[0];
 
-  assign ie01_e33_we = addr_hit[86] & reg_we & ~wr_err;
+  assign ie01_e33_we = addr_hit[87] & reg_we & ~wr_err;
   assign ie01_e33_wd = reg_wdata[1];
 
-  assign ie01_e34_we = addr_hit[86] & reg_we & ~wr_err;
+  assign ie01_e34_we = addr_hit[87] & reg_we & ~wr_err;
   assign ie01_e34_wd = reg_wdata[2];
 
-  assign ie01_e35_we = addr_hit[86] & reg_we & ~wr_err;
+  assign ie01_e35_we = addr_hit[87] & reg_we & ~wr_err;
   assign ie01_e35_wd = reg_wdata[3];
 
-  assign ie01_e36_we = addr_hit[86] & reg_we & ~wr_err;
+  assign ie01_e36_we = addr_hit[87] & reg_we & ~wr_err;
   assign ie01_e36_wd = reg_wdata[4];
 
-  assign ie01_e37_we = addr_hit[86] & reg_we & ~wr_err;
+  assign ie01_e37_we = addr_hit[87] & reg_we & ~wr_err;
   assign ie01_e37_wd = reg_wdata[5];
 
-  assign ie01_e38_we = addr_hit[86] & reg_we & ~wr_err;
+  assign ie01_e38_we = addr_hit[87] & reg_we & ~wr_err;
   assign ie01_e38_wd = reg_wdata[6];
 
-  assign ie01_e39_we = addr_hit[86] & reg_we & ~wr_err;
+  assign ie01_e39_we = addr_hit[87] & reg_we & ~wr_err;
   assign ie01_e39_wd = reg_wdata[7];
 
-  assign ie01_e40_we = addr_hit[86] & reg_we & ~wr_err;
+  assign ie01_e40_we = addr_hit[87] & reg_we & ~wr_err;
   assign ie01_e40_wd = reg_wdata[8];
 
-  assign ie01_e41_we = addr_hit[86] & reg_we & ~wr_err;
+  assign ie01_e41_we = addr_hit[87] & reg_we & ~wr_err;
   assign ie01_e41_wd = reg_wdata[9];
 
-  assign ie01_e42_we = addr_hit[86] & reg_we & ~wr_err;
+  assign ie01_e42_we = addr_hit[87] & reg_we & ~wr_err;
   assign ie01_e42_wd = reg_wdata[10];
 
-  assign ie01_e43_we = addr_hit[86] & reg_we & ~wr_err;
+  assign ie01_e43_we = addr_hit[87] & reg_we & ~wr_err;
   assign ie01_e43_wd = reg_wdata[11];
 
-  assign ie01_e44_we = addr_hit[86] & reg_we & ~wr_err;
+  assign ie01_e44_we = addr_hit[87] & reg_we & ~wr_err;
   assign ie01_e44_wd = reg_wdata[12];
 
-  assign ie01_e45_we = addr_hit[86] & reg_we & ~wr_err;
+  assign ie01_e45_we = addr_hit[87] & reg_we & ~wr_err;
   assign ie01_e45_wd = reg_wdata[13];
 
-  assign ie01_e46_we = addr_hit[86] & reg_we & ~wr_err;
+  assign ie01_e46_we = addr_hit[87] & reg_we & ~wr_err;
   assign ie01_e46_wd = reg_wdata[14];
 
-  assign ie01_e47_we = addr_hit[86] & reg_we & ~wr_err;
+  assign ie01_e47_we = addr_hit[87] & reg_we & ~wr_err;
   assign ie01_e47_wd = reg_wdata[15];
 
-  assign ie01_e48_we = addr_hit[86] & reg_we & ~wr_err;
+  assign ie01_e48_we = addr_hit[87] & reg_we & ~wr_err;
   assign ie01_e48_wd = reg_wdata[16];
 
-  assign ie01_e49_we = addr_hit[86] & reg_we & ~wr_err;
+  assign ie01_e49_we = addr_hit[87] & reg_we & ~wr_err;
   assign ie01_e49_wd = reg_wdata[17];
 
-  assign ie01_e50_we = addr_hit[86] & reg_we & ~wr_err;
+  assign ie01_e50_we = addr_hit[87] & reg_we & ~wr_err;
   assign ie01_e50_wd = reg_wdata[18];
 
-  assign ie01_e51_we = addr_hit[86] & reg_we & ~wr_err;
+  assign ie01_e51_we = addr_hit[87] & reg_we & ~wr_err;
   assign ie01_e51_wd = reg_wdata[19];
 
-  assign ie01_e52_we = addr_hit[86] & reg_we & ~wr_err;
+  assign ie01_e52_we = addr_hit[87] & reg_we & ~wr_err;
   assign ie01_e52_wd = reg_wdata[20];
 
-  assign ie01_e53_we = addr_hit[86] & reg_we & ~wr_err;
+  assign ie01_e53_we = addr_hit[87] & reg_we & ~wr_err;
   assign ie01_e53_wd = reg_wdata[21];
 
-  assign ie01_e54_we = addr_hit[86] & reg_we & ~wr_err;
+  assign ie01_e54_we = addr_hit[87] & reg_we & ~wr_err;
   assign ie01_e54_wd = reg_wdata[22];
 
-  assign ie01_e55_we = addr_hit[86] & reg_we & ~wr_err;
+  assign ie01_e55_we = addr_hit[87] & reg_we & ~wr_err;
   assign ie01_e55_wd = reg_wdata[23];
 
-  assign ie01_e56_we = addr_hit[86] & reg_we & ~wr_err;
+  assign ie01_e56_we = addr_hit[87] & reg_we & ~wr_err;
   assign ie01_e56_wd = reg_wdata[24];
 
-  assign ie01_e57_we = addr_hit[86] & reg_we & ~wr_err;
+  assign ie01_e57_we = addr_hit[87] & reg_we & ~wr_err;
   assign ie01_e57_wd = reg_wdata[25];
 
-  assign ie01_e58_we = addr_hit[86] & reg_we & ~wr_err;
+  assign ie01_e58_we = addr_hit[87] & reg_we & ~wr_err;
   assign ie01_e58_wd = reg_wdata[26];
 
-  assign ie01_e59_we = addr_hit[86] & reg_we & ~wr_err;
+  assign ie01_e59_we = addr_hit[87] & reg_we & ~wr_err;
   assign ie01_e59_wd = reg_wdata[27];
 
-  assign ie01_e60_we = addr_hit[86] & reg_we & ~wr_err;
+  assign ie01_e60_we = addr_hit[87] & reg_we & ~wr_err;
   assign ie01_e60_wd = reg_wdata[28];
 
-  assign ie01_e61_we = addr_hit[86] & reg_we & ~wr_err;
+  assign ie01_e61_we = addr_hit[87] & reg_we & ~wr_err;
   assign ie01_e61_wd = reg_wdata[29];
 
-  assign ie01_e62_we = addr_hit[86] & reg_we & ~wr_err;
+  assign ie01_e62_we = addr_hit[87] & reg_we & ~wr_err;
   assign ie01_e62_wd = reg_wdata[30];
 
-  assign ie01_e63_we = addr_hit[86] & reg_we & ~wr_err;
+  assign ie01_e63_we = addr_hit[87] & reg_we & ~wr_err;
   assign ie01_e63_wd = reg_wdata[31];
 
-  assign ie02_e64_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie02_e64_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie02_e64_wd = reg_wdata[0];
 
-  assign ie02_e65_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie02_e65_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie02_e65_wd = reg_wdata[1];
 
-  assign ie02_e66_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie02_e66_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie02_e66_wd = reg_wdata[2];
 
-  assign ie02_e67_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie02_e67_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie02_e67_wd = reg_wdata[3];
 
-  assign ie02_e68_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie02_e68_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie02_e68_wd = reg_wdata[4];
 
-  assign ie02_e69_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie02_e69_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie02_e69_wd = reg_wdata[5];
 
-  assign ie02_e70_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie02_e70_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie02_e70_wd = reg_wdata[6];
 
-  assign ie02_e71_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie02_e71_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie02_e71_wd = reg_wdata[7];
 
-  assign ie02_e72_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie02_e72_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie02_e72_wd = reg_wdata[8];
 
-  assign ie02_e73_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie02_e73_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie02_e73_wd = reg_wdata[9];
 
-  assign ie02_e74_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie02_e74_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie02_e74_wd = reg_wdata[10];
 
-  assign ie02_e75_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie02_e75_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie02_e75_wd = reg_wdata[11];
 
-  assign ie02_e76_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie02_e76_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie02_e76_wd = reg_wdata[12];
 
-  assign ie02_e77_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie02_e77_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie02_e77_wd = reg_wdata[13];
 
-  assign ie02_e78_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie02_e78_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie02_e78_wd = reg_wdata[14];
 
-  assign threshold0_we = addr_hit[88] & reg_we & ~wr_err;
+  assign ie02_e79_we = addr_hit[88] & reg_we & ~wr_err;
+  assign ie02_e79_wd = reg_wdata[15];
+
+  assign threshold0_we = addr_hit[89] & reg_we & ~wr_err;
   assign threshold0_wd = reg_wdata[1:0];
 
-  assign cc0_we = addr_hit[89] & reg_we & ~wr_err;
+  assign cc0_we = addr_hit[90] & reg_we & ~wr_err;
   assign cc0_wd = reg_wdata[6:0];
-  assign cc0_re = addr_hit[89] && reg_re;
+  assign cc0_re = addr_hit[90] && reg_re;
 
-  assign msip0_we = addr_hit[90] & reg_we & ~wr_err;
+  assign msip0_we = addr_hit[91] & reg_we & ~wr_err;
   assign msip0_wd = reg_wdata[0];
 
   // Read data return
@@ -10278,6 +10404,7 @@ module rv_plic_reg_top (
         reg_rdata_next[12] = ip2_p76_qs;
         reg_rdata_next[13] = ip2_p77_qs;
         reg_rdata_next[14] = ip2_p78_qs;
+        reg_rdata_next[15] = ip2_p79_qs;
       end
 
       addr_hit[3]: begin
@@ -10366,6 +10493,7 @@ module rv_plic_reg_top (
         reg_rdata_next[12] = le2_le76_qs;
         reg_rdata_next[13] = le2_le77_qs;
         reg_rdata_next[14] = le2_le78_qs;
+        reg_rdata_next[15] = le2_le79_qs;
       end
 
       addr_hit[6]: begin
@@ -10685,6 +10813,10 @@ module rv_plic_reg_top (
       end
 
       addr_hit[85]: begin
+        reg_rdata_next[1:0] = prio79_qs;
+      end
+
+      addr_hit[86]: begin
         reg_rdata_next[0] = ie00_e0_qs;
         reg_rdata_next[1] = ie00_e1_qs;
         reg_rdata_next[2] = ie00_e2_qs;
@@ -10719,7 +10851,7 @@ module rv_plic_reg_top (
         reg_rdata_next[31] = ie00_e31_qs;
       end
 
-      addr_hit[86]: begin
+      addr_hit[87]: begin
         reg_rdata_next[0] = ie01_e32_qs;
         reg_rdata_next[1] = ie01_e33_qs;
         reg_rdata_next[2] = ie01_e34_qs;
@@ -10754,7 +10886,7 @@ module rv_plic_reg_top (
         reg_rdata_next[31] = ie01_e63_qs;
       end
 
-      addr_hit[87]: begin
+      addr_hit[88]: begin
         reg_rdata_next[0] = ie02_e64_qs;
         reg_rdata_next[1] = ie02_e65_qs;
         reg_rdata_next[2] = ie02_e66_qs;
@@ -10770,17 +10902,18 @@ module rv_plic_reg_top (
         reg_rdata_next[12] = ie02_e76_qs;
         reg_rdata_next[13] = ie02_e77_qs;
         reg_rdata_next[14] = ie02_e78_qs;
-      end
-
-      addr_hit[88]: begin
-        reg_rdata_next[1:0] = threshold0_qs;
+        reg_rdata_next[15] = ie02_e79_qs;
       end
 
       addr_hit[89]: begin
-        reg_rdata_next[6:0] = cc0_qs;
+        reg_rdata_next[1:0] = threshold0_qs;
       end
 
       addr_hit[90]: begin
+        reg_rdata_next[6:0] = cc0_qs;
+      end
+
+      addr_hit[91]: begin
         reg_rdata_next[0] = msip0_qs;
       end
 

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -182,7 +182,7 @@ module top_earlgrey #(
   logic        cio_usbdev_dn_en_d2p;
 
 
-  logic [78:0]  intr_vector;
+  logic [79:0]  intr_vector;
   // Interrupt source list
   logic intr_uart_tx_watermark;
   logic intr_uart_rx_watermark;
@@ -789,7 +789,8 @@ module top_earlgrey #(
       intr_uart_tx_empty,
       intr_uart_rx_watermark,
       intr_uart_tx_watermark,
-      intr_gpio_gpio
+      intr_gpio_gpio,
+      1'b 0 // For ID 0.
   };
 
   // TL-UL Crossbar

--- a/sw/device/lib/dif/dif_plic.c
+++ b/sw/device/lib/dif/dif_plic.c
@@ -17,9 +17,8 @@
 // These defines are used to calculate the IRQ index in IP, LE, IE registers.
 // These registers are 32bit wide, and in order to accommodate all the IRQs,
 // multiple of the same type registers are defined (IE00, IE01, ...). For
-// example, IRQ ID 33 corresponds to bit 0 in registers IP1, LE1, IE01.
+// example, IRQ ID 32 corresponds to bit 0 in registers IP1, LE1, IE01.
 #define PLIC_ID_TO_INDEX_REG_SIZE 32u
-#define PLIC_ID_TO_INDEX(id) ((uint32_t)id - 1)
 
 /**
  * PLIC register info.
@@ -135,10 +134,10 @@ static size_t plic_num_irq_reg(void) {
  *
  * With more than 32 IRQ sources, there is a multiple of these registers to
  * accommodate all the bits (1 bit per IRQ source). This function calculates
- * the offset for a specific IRQ source ID (ID 33 would be IE01, ...).
+ * the offset for a specific IRQ source ID (ID 32 would be IE01, ...).
  */
 static ptrdiff_t plic_offset_from_reg0(dif_plic_irq_id_t irq) {
-  uint8_t register_index = PLIC_ID_TO_INDEX(irq) / PLIC_ID_TO_INDEX_REG_SIZE;
+  uint8_t register_index = irq / PLIC_ID_TO_INDEX_REG_SIZE;
   return register_index * sizeof(uint32_t);
 }
 
@@ -147,11 +146,11 @@ static ptrdiff_t plic_offset_from_reg0(dif_plic_irq_id_t irq) {
  *
  * With more than 32 IRQ sources, there is a multiple of these registers to
  * accommodate all the bits (1 bit per IRQ source). This function calculates
- * the bit position within a register for a specifci IRQ source ID (ID 33 would
+ * the bit position within a register for a specifci IRQ source ID (ID 32 would
  * be bit 0).
  */
 static uint8_t plic_reg_bit_index_from_irq_id(dif_plic_irq_id_t irq) {
-  return PLIC_ID_TO_INDEX(irq) % PLIC_ID_TO_INDEX_REG_SIZE;
+  return irq % PLIC_ID_TO_INDEX_REG_SIZE;
 }
 
 /**
@@ -188,10 +187,10 @@ static void plic_irq_pending_reg_info(dif_plic_irq_id_t irq,
 /**
  * Get a total number of priority registers (one for every IRQ source).
  *
- * The IRQ source IDs start from 1, so the last IRQ ID variant is also
- * the number of priority registers (one per IRQ source).
+ * As PRIO0 register is not used, last IRQ + 1 is the total number of
+ * priority register.
  */
-static size_t plic_num_priority_reg(void) { return kDifPlicIrqIdLast; }
+static size_t plic_num_priority_reg(void) { return kDifPlicIrqIdLast + 1; }
 
 /**
  * Get a PRIO register offset (PRIO0, PRIO1, ...) from an IRQ source ID.
@@ -200,7 +199,7 @@ static size_t plic_num_priority_reg(void) { return kDifPlicIrqIdLast; }
  * source specific PRIO register offset.
  */
 static ptrdiff_t plic_priority_reg_offset(dif_plic_irq_id_t irq) {
-  ptrdiff_t offset = PLIC_ID_TO_INDEX(irq) * sizeof(uint32_t);
+  ptrdiff_t offset = irq * sizeof(uint32_t);
   return RV_PLIC_PRIO0_REG_OFFSET + offset;
 }
 

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -186,7 +186,10 @@ def generate_alert_handler(top, out_path):
 
 def generate_plic(top, out_path):
     # Count number of interrupts
-    src = sum([x["width"] if "width" in x else 1 for x in top["interrupt"]])
+    # Interrupt source 0 is tied to 0 to conform RISC-V PLIC spec.
+    # So, total number of interrupts are the number of entries in the list + 1
+    src = sum([x["width"] if "width" in x else 1
+               for x in top["interrupt"]]) + 1
 
     # Target and priority: Currently fixed
     target = int(top["num_cores"], 0) if "num_cores" in top else 1


### PR DESCRIPTION
As discussed in #1823, this PR is to match the PRIO* registers name to
the ID read in CC register.

Previously, ID read from CC register is not matched with the offset of
PRIO0, IS, IE, IP. For example, if the software read 0x3 value from CC
register, its corresponding bit in IS is IS[2].

PLIC now generates ID w.r.t the interrupt source bit position. RISC-V
PLIC spec requires to return ID value 0 when no interrupt. So, topgen
ties bit0 of interrupt source signal to 0. By doing in this way, reggen
doesn't have to support arithmetic operation to the parameter.