### PR TITLE
[dv,sw] SW -> DV tb self-checking mechanism

### DIFF
--- a/hw/dv/sv/dv_lib/dv_base_test.sv
+++ b/hw/dv/sv/dv_lib/dv_base_test.sv
@@ -61,12 +61,12 @@ class dv_base_test #(type CFG_T = dv_base_env_cfg,
     test_seq.set_sequencer(env.virtual_sequencer);
     `DV_CHECK_RANDOMIZE_FATAL(test_seq)
 
-    `uvm_info(`gfn, {"starting vseq ", test_seq_s}, UVM_MEDIUM)
+    `uvm_info(`gfn, {"Starting test sequence ", test_seq_s}, UVM_MEDIUM)
     phase.raise_objection(this, $sformatf("%s objection raised", `gn));
     test_seq.start(env.virtual_sequencer);
     phase.drop_objection(this, $sformatf("%s objection dropped", `gn));
     phase.phase_done.display_objections();
-    `uvm_info(`gfn, {"finished vseq ", test_seq_s}, UVM_MEDIUM)
+    `uvm_info(`gfn, {"Finished test sequence ", test_seq_s}, UVM_MEDIUM)
   endtask
 
   // TODO: add default report_phase implementation

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -76,32 +76,37 @@
   tests: [
     {
       name: chip_sanity
+      uvm_test_seq: chip_sw_test_base_vseq
       sw_name: hello_world
       sw_dir: examples/hello_world
     }
     {
       name: chip_flash_test
+      uvm_test_seq: chip_sw_test_base_vseq
       sw_name: flash_test
       sw_dir: tests/flash_ctrl
-      run_opts: ["+cpu_test_timeout_ns=15000000"]
+      run_opts: ["+sw_test_timeout_ns=15000000"]
     }
     {
       name: chip_sha256_test
+      uvm_test_seq: chip_sw_test_base_vseq
       sw_name: sha256_test
       sw_dir: tests/hmac
-      run_opts: ["+cpu_test_timeout_ns=4000000"]
+      run_opts: ["+sw_test_timeout_ns=4000000"]
     }
     {
       name: chip_rv_timer_test
+      uvm_test_seq: chip_sw_test_base_vseq
       sw_name: rv_timer_test
       sw_dir: tests/rv_timer
-      run_opts: ["+cpu_test_timeout_ns=40000000"]
+      run_opts: ["+sw_test_timeout_ns=40000000"]
     }
     {
       name: coremark
+      uvm_test_seq: chip_sw_test_base_vseq
       sw_name: coremark
       sw_dir: benchmarks/coremark
-      run_opts: ["+cpu_test_timeout_ns=20000000"]
+      run_opts: ["+sw_test_timeout_ns=20000000"]
     }
 
     // TODO: CSR suite of tests. Rather than reuse the common one, we are

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -15,6 +15,8 @@ filesets:
       - lowrisc:dv:mem_bkdr_if
       - lowrisc:dv:sw_logger_if
     files:
+      - sw_test_status_pkg.sv
+      - sw_test_status_if.sv
       - chip_env_pkg.sv
       - chip_tl_seq_item.sv: {is_include_file: true}
       - chip_env_cfg.sv: {is_include_file: true}
@@ -26,6 +28,7 @@ filesets:
       - seq_lib/chip_vseq_list.sv: {is_include_file: true}
       - seq_lib/chip_base_vseq.sv: {is_include_file: true}
       - seq_lib/chip_common_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_test_base_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/top_earlgrey/dv/env/chip_env.sv
+++ b/hw/top_earlgrey/dv/env/chip_env.sv
@@ -73,6 +73,11 @@ class chip_env extends dv_base_env #(
       end
     end
 
+    if (!uvm_config_db#(virtual sw_test_status_if)::get(this, "", "sw_test_status_vif",
+        cfg.sw_test_status_vif)) begin
+      `uvm_fatal(`gfn, "failed to get sw_test_status_vif from uvm_config_db")
+    end
+
     // create components
     m_uart_agent = uart_agent::type_id::create("m_uart_agent", this);
     uvm_config_db#(uart_agent_cfg)::set(this, "m_uart_agent*", "cfg", cfg.m_uart_agent_cfg);

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -18,10 +18,12 @@ class chip_env_cfg extends dv_base_env_cfg #(.RAL_T(chip_reg_block));
   virtual pins_if#(1) bootstrap_vif;
 
   // sw logger related
-  string sw_types[]   = '{"rom", "sw"};
-  sw_logger_vif       sw_logger_vif[string];
-  string              sw_images[string];
-  string              sw_log_files[string];
+  string sw_types[]         = '{"rom", "sw"};
+  sw_logger_vif             sw_logger_vif[string];
+  string                    sw_images[string];
+  string                    sw_log_files[string];
+  virtual sw_test_status_if sw_test_status_vif;
+  uint                      sw_test_timeout_ns = 2_000_000; // 2ms
 
   // ext component cfgs
   rand uart_agent_cfg m_uart_agent_cfg;
@@ -45,24 +47,26 @@ class chip_env_cfg extends dv_base_env_cfg #(.RAL_T(chip_reg_block));
 
   `uvm_object_new
 
-  // TODO review value for csr_base_addr, csr_addr_map_size
   virtual function void initialize_csr_addr_map_size();
     this.csr_addr_map_size = 1 << TL_AW;
   endfunction : initialize_csr_addr_map_size
 
   virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);
-
     chip_mem_e mems[] = {Rom, FlashBank0, FlashBank1};
 
     super.initialize(csr_base_addr);
     // create uart agent config obj
     m_uart_agent_cfg = uart_agent_cfg::type_id::create("m_uart_agent_cfg");
+
     // create jtag agent config obj
     m_jtag_agent_cfg = jtag_agent_cfg::type_id::create("m_jtag_agent_cfg");
+
     // create spi agent config obj
     m_spi_agent_cfg = spi_agent_cfg::type_id::create("m_spi_agent_cfg");
+
     // create tl agent config obj
     m_cpu_d_tl_agent_cfg = tl_agent_cfg::type_id::create("m_cpu_d_tl_agent_cfg");
+
     m_cpu_d_tl_agent_cfg.if_mode = dv_utils_pkg::Host;
     // initialize the mem_bkdr_if vifs we want for this chip
     foreach (mems[mem]) begin

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -15,6 +15,7 @@ package chip_env_pkg;
   import dv_lib_pkg::*;
   import cip_base_pkg::*;
   import chip_ral_pkg::*;
+  import sw_test_status_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"
@@ -24,21 +25,14 @@ package chip_env_pkg;
   parameter NUM_GPIOS = 16;
 
   // SW constants
-  parameter bit [TL_AW-1:0] SW_LOG_DV_ADDR = 32'h1000fffc;
-  parameter bit [TL_AW-1:0] SW_TEST_STATUS_ADDR = 32'h1000fff8;
+  parameter bit [TL_AW-1:0] SW_DV_LOG_ADDR = 32'h1000fffc;
+  parameter bit [TL_AW-1:0] SW_DV_TEST_STATUS_ADDR = 32'h1000fff8;
 
   typedef virtual pins_if #(NUM_GPIOS)  gpio_vif;
   typedef virtual mem_bkdr_if           mem_bkdr_vif;
   typedef virtual sw_logger_if          sw_logger_vif;
 
-  // enum to indicate cpu test pass / fail status
-  typedef enum bit [15:0] {
-    CpuUnderReset   = 16'hffff,   // cpu is held under reset
-    CpuTestRunning  = 16'hb004,   // cpu test running
-    CpuTestPass     = 16'hff00,   // cpu test passed
-    CpuTestFail     = 16'h00ff    // cpu test failed
-  } cpu_test_state_e;
-
+  // Types of memories in the chip.
   typedef enum {
     Rom,
     Ram,

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -11,41 +11,13 @@ class chip_base_vseq extends dv_base_vseq #(
   `uvm_object_utils(chip_base_vseq)
 
   // knobs to enable pre_start routines
-  bit do_cpu_init = 1'b1; // boot cpu
+  bit do_strap_pins_init = 1'b1; // initialize the strap
 
   // knobs to enable post_start routines
 
   // various knobs to enable certain routines
 
-  // local state variables
-  cpu_test_state_e cpu_test_state;
-  uint cpu_test_timeout_ns = 500_000; // 500us
-
   `uvm_object_new
-
-  virtual task pre_start();
-    // Do DUT init after some additional settings.
-    do_dut_init = 1'b0;
-    super.pre_start();
-
-    // Drive strap signals at the start.
-    cfg.srst_n_vif.drive(1'b1);
-    cfg.jtag_spi_n_vif.drive(1'b1); // Select JTAG.
-    cfg.bootstrap_vif.drive(1'b0);
-
-    // Now safe to do DUT init.
-    dut_init();
-
-    cpu_test_state = CpuUnderReset;
-    if (cfg.stub_cpu) begin
-      do_cpu_init = 1'b0;
-    end else begin
-      // check if this knob is set via plusarg
-      void'($value$plusargs("do_cpu_init=%0b", do_cpu_init));
-    end
-    void'($value$plusargs("cpu_test_timeout_ns=%0d", cpu_test_timeout_ns));
-    if (do_cpu_init) cpu_init();
-  endtask
 
   virtual task apply_reset(string kind = "HARD");
     // TODO: Cannot assert different types of resets in parallel; due to randomization
@@ -64,95 +36,27 @@ class chip_base_vseq extends dv_base_vseq #(
     super.dut_init(reset_kind);
   endtask
 
-  // routine to backdoor load cpu test hex image and bring the cpu out of reset (if required)
-  // TODO: for future implementation
-  virtual task cpu_init();
-    // Set 'default' UART baud rate of 2Mbps - this is also programmed by the C test.
-    // TODO: Fixing this for now - need to find a way to pass this on to the SW test.
-    cfg.m_uart_agent_cfg.set_parity(1'b0, 1'b0);
-    cfg.m_uart_agent_cfg.set_baud_rate(BaudRate2Mbps);
-
-    // Backdoor load memories.
-    cfg.mem_bkdr_vifs[Rom].load_mem_from_file(cfg.sw_images["rom"]);
-    cfg.mem_bkdr_vifs[FlashBank0].set_mem();
-    cfg.mem_bkdr_vifs[FlashBank1].set_mem();
-    // TODO: the location of the main execution image should be randomized for either bank in future
-    cfg.mem_bkdr_vifs[FlashBank0].load_mem_from_file(cfg.sw_images["sw"]);
-    cpu_test_state = CpuTestRunning;
-
-    // initialize the sw msg monitor
-    foreach (cfg.sw_types[i]) begin
-      cfg.sw_logger_vif[cfg.sw_types[i]].sw_log_addr = SW_LOG_DV_ADDR;
-      cfg.sw_logger_vif[cfg.sw_types[i]].set_sw_log_file(cfg.sw_types[i],
-                                                         cfg.sw_log_files[cfg.sw_types[i]]);
-      cfg.sw_logger_vif[cfg.sw_types[i]].ready();
-    end
-  endtask
-
   virtual task dut_shutdown();
     // check for pending chip operations and wait for them to complete
     // TODO
   endtask
 
-  virtual task body();
-    if (!cfg.stub_cpu) begin
-      monitor_cpu_state();
-      wait_for_cpu_test_complete(.timeout_ns(cpu_test_timeout_ns));
+  virtual task pre_start();
+    // Do DUT init after some additional settings.
+    bit do_dut_init_save = do_dut_init;
+    do_dut_init = 1'b0;
+    super.pre_start();
+    do_dut_init = do_dut_init_save;
+
+    // Drive strap signals at the start.
+    if (do_strap_pins_init) begin
+      cfg.srst_n_vif.drive(1'b1);
+      cfg.jtag_spi_n_vif.drive(1'b1); // Select JTAG.
+      cfg.bootstrap_vif.drive(1'b0);
     end
-  endtask : body
 
-  // maintain a specific memory location for cpu test status
-  // TODO: using gpio for now - need to use mem loc instead
-  // TODO: need to more cpu monitoring logic to separate uvm component
-  virtual task monitor_cpu_state();
-    fork
-      forever begin
-        `uvm_info(`gfn, $sformatf("cpu_test_state = %0s", cpu_test_state), UVM_LOW)
-        case (cpu_test_state)
-          CpuUnderReset: begin
-            wait(cpu_test_state == CpuTestRunning);
-          end
-
-          CpuTestRunning: begin
-            // monitor gpio pins for specific value
-            @(cfg.gpio_vif.pins);
-            if (cfg.gpio_vif.pins === CpuTestPass) begin
-              cpu_test_state = CpuTestPass;
-              `uvm_info(`gfn, "cpu test passed!", UVM_LOW)
-            end
-            else if (cfg.gpio_vif.pins === CpuTestFail) begin
-              cpu_test_state = CpuTestFail;
-              `uvm_error(`gfn, "cpu test failed!")
-            end
-          end
-
-          CpuTestPass, CpuTestFail: begin
-            wait(cpu_test_state == CpuUnderReset);
-          end
-        endcase
-      end
-    join_none
+    // Now safe to do DUT init.
+    if (do_dut_init) dut_init();
   endtask
 
-  // wait for cpu test to finish
-  virtual task wait_for_cpu_test_complete(uint timeout_ns = 500_000);
-    fork
-      begin: isolation_thread
-        fork
-          begin: timeout_thread
-            #(timeout_ns * 1ns);
-            // TODO: uncomment after c framework is in place
-            // `uvm_fatal(`gfn, $sformatf("timeout occurred - in cpu test state %0s",
-            //                             cpu_test_state.name()))
-          end: timeout_thread
-
-          if (cpu_test_state == CpuTestRunning) begin: cpu_state_thread
-            wait (cpu_test_state inside {CpuTestPass, CpuTestFail});
-          end: cpu_state_thread
-        join_any
-        disable fork;
-      end: isolation_thread
-    join
-  endtask
-
- endclass : chip_base_vseq
+endclass : chip_base_vseq

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_test_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_test_base_vseq.sv
@@ -1,0 +1,90 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_test_base_vseq extends chip_base_vseq;
+  `uvm_object_utils(chip_sw_test_base_vseq)
+
+  bit sw_test_done;
+
+  `uvm_object_new
+
+  virtual task dut_init(string reset_kind = "HARD");
+    // Reset the sw_test_status.
+    cfg.sw_test_status_vif.sw_test_status = SwTestStatusUnderReset;
+    // Bring the chip out of reset.
+    super.dut_init(reset_kind);
+  endtask
+
+  // Backdoor load the sw test image, setup UART, logger and test status interfaces.
+  virtual task cpu_init();
+    // Set 'default' UART baud rate of 2Mbps - this is also programmed by the C test.
+    // TODO: Fixing this for now - need to find a way to pass this on to the SW test.
+    cfg.m_uart_agent_cfg.set_parity(1'b0, 1'b0);
+    cfg.m_uart_agent_cfg.set_baud_rate(BaudRate2Mbps);
+
+    // initialize the sw msg monitor
+    foreach (cfg.sw_types[i]) begin
+      cfg.sw_logger_vif[cfg.sw_types[i]].sw_log_addr = SW_DV_LOG_ADDR;
+      cfg.sw_logger_vif[cfg.sw_types[i]].set_sw_log_file(cfg.sw_types[i],
+                                                         cfg.sw_log_files[cfg.sw_types[i]]);
+      cfg.sw_logger_vif[cfg.sw_types[i]].ready();
+    end
+
+    // initialize the sw test status
+    cfg.sw_test_status_vif.sw_test_status_addr = SW_DV_TEST_STATUS_ADDR;
+
+    // Backdoor load memories.
+    cfg.mem_bkdr_vifs[Rom].load_mem_from_file(cfg.sw_images["rom"]);
+    cfg.mem_bkdr_vifs[FlashBank0].set_mem();
+    cfg.mem_bkdr_vifs[FlashBank1].set_mem();
+    // TODO: the location of the main execution image should be randomized for either bank in future
+    cfg.mem_bkdr_vifs[FlashBank0].load_mem_from_file(cfg.sw_images["sw"]);
+    cfg.sw_test_status_vif.sw_test_status = SwTestStatusBooted;
+  endtask
+
+  virtual task pre_start();
+    super.pre_start();
+    cpu_init();
+  endtask
+
+  virtual task body();
+    // Spawn off a thread to monitor the SW test status.
+    fork monitor_sw_test_status(); join_none
+  endtask
+
+  // Monitors the SW test status.
+  virtual task monitor_sw_test_status();
+    `uvm_info(`gfn, "Monitoring the SW test status", UVM_MEDIUM)
+    fork
+      begin: isolation_thread
+        fork
+          wait(cfg.sw_test_status_vif.sw_test_done);
+          #(cfg.sw_test_timeout_ns * 1ns);
+        join_any
+        disable fork;
+        sw_test_done = 1'b1;
+        log_sw_test_status();
+      end: isolation_thread
+    join
+  endtask
+
+  virtual task post_start();
+    // Wait for sw test to finish before exiting.
+    wait(sw_test_done);
+  endtask
+
+  // Print pass / fail message to the log.
+  virtual function void log_sw_test_status();
+    case (cfg.sw_test_status_vif.sw_test_status)
+      SwTestStatusPassed: `uvm_info(`gfn, "SW TEST PASSED!", UVM_LOW)
+      SwTestStatusFailed: `uvm_error(`gfn, "SW TEST FAILED!")
+      default: begin
+        // If the SW test has not reached the passed / failed state, then it timed out.
+        `uvm_error(`gfn, $sformatf("SW TEST TIMED OUT. STATE: %0s, TIMEOUT = %0d ns\n",
+            cfg.sw_test_status_vif.sw_test_status.name(), cfg.sw_test_timeout_ns))
+      end
+    endcase
+  endfunction
+
+endclass : chip_sw_test_base_vseq

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -4,3 +4,4 @@
 
 `include "chip_base_vseq.sv"
 `include "chip_common_vseq.sv"
+`include "chip_sw_test_base_vseq.sv"

--- a/hw/top_earlgrey/dv/env/sw_test_status_if.sv
+++ b/hw/top_earlgrey/dv/env/sw_test_status_if.sv
@@ -1,0 +1,38 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+interface sw_test_status_if ();
+  import top_pkg::*;
+  import sw_test_status_pkg::*;
+
+  // Single cycle qualifier for the sw_test_status_val.
+  logic valid;
+
+  // Address to which the test status is written to.
+  logic [TL_AW-1:0] sw_test_status_addr;
+
+  // SW test status written by the CPU.
+  logic [TL_DW-1:0] sw_test_status_val;
+
+  // SW test status indication.
+  sw_test_status_e sw_test_status;
+
+  // If the sw_test_status reaches the terminal states, assert that we are done.
+  bit sw_test_done;
+
+  // Logic that updates the sw_test_status from the val.
+  // Note that sw_test_status is set by the testbench when the CPU is under reset.
+  initial begin
+    forever begin
+      @(valid);
+      if (valid) begin
+        sw_test_status = sw_test_status_e'(sw_test_status_val[15:0]);
+        if (!sw_test_done) begin
+          sw_test_done = (sw_test_status inside {SwTestStatusPassed, SwTestStatusFailed});
+        end
+      end
+    end
+  end
+
+endinterface

--- a/hw/top_earlgrey/dv/env/sw_test_status_pkg.sv
+++ b/hw/top_earlgrey/dv/env/sw_test_status_pkg.sv
@@ -1,0 +1,18 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package sw_test_status_pkg;
+
+  // Enum to indicate the SW test status.
+  typedef enum bit [15:0] {
+    SwTestStatusUnderReset  = 16'h0000, // 'boot', CPU is under reset.
+    SwTestStatusBooted      = 16'hb004, // 'boot', CPU has booted
+    SwTestStatusBootRom     = 16'hb090, // 'bogo', BOotrom GO, SW has entered boot rom code
+    SwTestStatusUnderTest   = 16'h4354, // 'test', SW has entered test code.
+    SwTestStatusWfi         = 16'h1d1e, // 'idle', CPU has entered WFI state.
+    SwTestStatusPassed      = 16'h900d, // 'good', SW test has passed.
+    SwTestStatusFailed      = 16'hbaad  // 'baad', SW test has failed.
+  } sw_test_status_e;
+
+endpackage

--- a/hw/top_earlgrey/dv/tests/chip_base_test.sv
+++ b/hw/top_earlgrey/dv/tests/chip_base_test.sv
@@ -27,6 +27,9 @@ class chip_base_test extends dv_base_test #(
     void'($value$plusargs("en_uart_logger=%0b", cfg.en_uart_logger));
     cfg.m_uart_agent_cfg.en_logger = cfg.en_uart_logger;
     cfg.m_uart_agent_cfg.logger_msg_id  = "SW_LOGS";
+
+    // Set the sw_test_timeout_ns knob from plusarg if available.
+    void'($value$plusargs("sw_test_timeout_ns=%0d", cfg.sw_test_timeout_ns));
   endfunction : build_phase
 
 endclass : chip_base_test

--- a/sw/device/boot_rom/boot_rom.c
+++ b/sw/device/boot_rom/boot_rom.c
@@ -13,6 +13,7 @@
 #include "sw/device/lib/flash_ctrl.h"
 #include "sw/device/lib/pinmux.h"
 #include "sw/device/lib/spi_device.h"
+#include "sw/device/lib/testing/test_status.h"
 #include "sw/device/lib/uart.h"
 
 /**
@@ -26,6 +27,7 @@
 extern struct { void (*entry)(void); } _flash_header;
 
 void _boot_start(void) {
+  set_test_status(kTestStatusBootRom);
   pinmux_init();
   uart_init(kUartBaudrate);
   base_set_stdout(uart_stdout);
@@ -36,7 +38,7 @@ void _boot_start(void) {
   if (bootstrap_err != 0) {
     LOG_ERROR("Bootstrap failed with status code: %d", bootstrap_err);
     // Currently the only way to recover is by a hard reset.
-    return;
+    test_failed();
   }
 
   LOG_INFO("Boot ROM initialisation has completed, jump into flash!");

--- a/sw/device/boot_rom/meson.build
+++ b/sw/device/boot_rom/meson.build
@@ -45,6 +45,7 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
       sw_lib_uart,
       sw_lib_base_log,
       device_lib,
+      sw_lib_testing_test_status,
     ],
   )
 

--- a/sw/device/examples/hello_world/hello_world.c
+++ b/sw/device/examples/hello_world/hello_world.c
@@ -9,6 +9,7 @@
 #include "sw/device/lib/pinmux.h"
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/spi_device.h"
+#include "sw/device/lib/testing/test_status.h"
 #include "sw/device/lib/uart.h"
 
 static dif_gpio_t gpio;
@@ -28,6 +29,10 @@ int main(int argc, char **argv) {
   // Add DATE and TIME because I keep fooling myself with old versions
   LOG_INFO("Hello World!");
   LOG_INFO("Built at: " __DATE__ ", " __TIME__);
+
+  // End the test here for DV simulations.
+  if (kDeviceType == kDeviceSimDV)
+    test_passed();
 
   demo_gpio_startup(&gpio);
 

--- a/sw/device/examples/hello_world/meson.build
+++ b/sw/device/examples/hello_world/meson.build
@@ -8,7 +8,7 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
     sources: ['hello_world.c'],
     name_suffix: 'elf',
     dependencies: [
-      sw_examples_demos, 
+      sw_examples_demos,
       sw_lib_runtime_hart,
       sw_lib_base_print,
       sw_lib_base_log,
@@ -20,6 +20,7 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
       riscv_crt,
       sw_lib_irq_handlers,
       device_lib,
+      sw_lib_testing_test_status,
     ],
   )
 

--- a/sw/device/lib/base/log.c
+++ b/sw/device/lib/base/log.c
@@ -73,7 +73,7 @@ void base_log_internal_core(log_fields_t log, ...) {
  * Indicates the fixed location in RAM for SW logging for DV.
  * TODO: Figure aout a better place to put this.
  */
-static const uintptr_t kSwLogDvAddr = 0x1000fffc;
+static const uintptr_t kSwDvLogAddr = 0x1000fffc;
 
 /**
  * Logs `log and the values that follow in an efficient, DV-testbench
@@ -86,7 +86,7 @@ static const uintptr_t kSwLogDvAddr = 0x1000fffc;
  * @param ... format parameters matching the format string.
  */
 void base_log_internal_dv(const log_fields_t *log, uint32_t nargs, ...) {
-  mmio_region_t log_device = mmio_region_from_addr(kSwLogDvAddr);
+  mmio_region_t log_device = mmio_region_from_addr(kSwDvLogAddr);
   mmio_region_write32(log_device, 0x0, (uintptr_t)log);
 
   va_list args;

--- a/sw/device/lib/base/log.h
+++ b/sw/device/lib/base/log.h
@@ -114,12 +114,12 @@ void base_log_internal_dv(const log_fields_t *log, uint32_t nargs, ...);
       /* Put DV-only log constants in .logs.* sections, which
        * the linker will dutifully discard.
        * Unfortunately, clang-format really mangles these
-       * declarations, so we format them manually. */            \
-      __attribute__((section(".logs.fields")))                   \
-      static const log_fields_t kLogFields =                     \
-          LOG_MAKE_FIELDS_(severity, format, ##__VA_ARGS__);     \
-      base_log_internal_dv(&kLogFields,                          \
-                           GET_NUM_VARIABLE_ARGS(__VA_ARGS__),   \
+       * declarations, so we format them manually. */               \
+      __attribute__((section(".logs.fields")))                      \
+      static const log_fields_t kLogFields =                        \
+          LOG_MAKE_FIELDS_(severity, format, ##__VA_ARGS__);        \
+      base_log_internal_dv(&kLogFields,                             \
+                           GET_NUM_VARIABLE_ARGS(0, ##__VA_ARGS__), \
                            ##__VA_ARGS__); /* clang-format on */ \
     } else {                                                     \
       log_fields_t log_fields =                                  \
@@ -131,10 +131,10 @@ void base_log_internal_dv(const log_fields_t *log, uint32_t nargs, ...);
 /**
  * Implementation detail of `LOG`.
  */
-#define LOG_MAKE_FIELDS_(_severity, _format, ...)                         \
-  {                                                                       \
-    .severity = _severity, .file_name = "" __FILE__ "", .line = __LINE__, \
-    .nargs = GET_NUM_VARIABLE_ARGS(__VA_ARGS__), .format = "" _format "", \
+#define LOG_MAKE_FIELDS_(_severity, _format, ...)                              \
+  {                                                                            \
+    .severity = _severity, .file_name = "" __FILE__ "", .line = __LINE__,      \
+    .nargs = GET_NUM_VARIABLE_ARGS(0, ##__VA_ARGS__), .format = "" _format "", \
   }
 
 /**

--- a/sw/device/lib/base/macros.h
+++ b/sw/device/lib/base/macros.h
@@ -17,7 +17,7 @@
  * StackOverflow post expains the trick in detail:
  * https://stackoverflow.com/questions/2308243/macro-returning-the-number-of-arguments-it-is-given-in-c
  */
-#define GET_NUM_VARIABLE_ARGS(...) PASS_N_VARIABLE_ARGS_(0, ##__VA_ARGS__)
+#define GET_NUM_VARIABLE_ARGS(...) PASS_N_VARIABLE_ARGS_(__VA_ARGS__)
 
 // Implementation details for `GET_NUM_VARIABLE_ARGS()`.
 #define PASS_N_VARIABLE_ARGS_(...)                                             \

--- a/sw/device/lib/testing/check.h
+++ b/sw/device/lib/testing/check.h
@@ -2,13 +2,14 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0`
 
-#ifndef OPENTITAN_SW_DEVICE_LIB_RUNTIME_CHECK_H_
-#define OPENTITAN_SW_DEVICE_LIB_RUNTIME_CHECK_H_
+#ifndef OPENTITAN_SW_DEVICE_LIB_TESTING_CHECK_H_
+#define OPENTITAN_SW_DEVICE_LIB_TESTING_CHECK_H_
 
 #include <stdbool.h>
 
 #include "sw/device/lib/base/log.h"
 #include "sw/device/lib/runtime/hart.h"
+#include "sw/device/lib/testing/test_status.h"
 
 /**
  * Runtime assertion macros with log.h integration.
@@ -26,7 +27,7 @@
   do {                                       \
     if (!(condition)) {                      \
       LOG_ERROR("CHECK-fail: " __VA_ARGS__); \
-      abort();                               \
+      test_failed();                         \
     }                                        \
   } while (false)
 
@@ -39,4 +40,4 @@
  */
 #define CHECKZ(value, ...) CHECK((value) == 0, ##__VA_ARGS__)
 
-#endif  // OPENTITAN_SW_DEVICE_LIB_RUNTIME_CHECK_H_
+#endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_CHECK_H_

--- a/sw/device/lib/testing/meson.build
+++ b/sw/device/lib/testing/meson.build
@@ -2,6 +2,19 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+# Test status libary.
+sw_lib_testing_test_status = declare_dependency(
+  link_with: static_library(
+    'test_status_ot',
+    sources: ['test_status.c'],
+    dependencies: [
+      sw_lib_mmio,
+      sw_lib_base_log,
+      sw_lib_runtime_hart,
+    ],
+  )
+)
+
 sw_lib_testing_mock_mmio = declare_dependency(
   link_with: static_library(
     'mock_mmio',

--- a/sw/device/lib/testing/test_status.c
+++ b/sw/device/lib/testing/test_status.c
@@ -1,0 +1,35 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/testing/test_status.h"
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/log.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/runtime/hart.h"
+
+/**
+ * Address of the memory location to write the test status. For DV use only.
+ */
+static const uintptr_t kSwDvTestStatusAddr = 0x1000fff8;
+
+inline void set_test_status(const test_status_t test_status) {
+  if (kDeviceType != kDeviceSimDV)
+    return;
+  mmio_region_t sw_dv_test_status_addr =
+      mmio_region_from_addr(kSwDvTestStatusAddr);
+  mmio_region_write32(sw_dv_test_status_addr, 0x0, (uint32_t)test_status);
+}
+
+noreturn void test_passed(void) {
+  LOG_INFO("PASS");
+  set_test_status(kTestStatusPassed);
+  abort();
+}
+
+noreturn void test_failed(void) {
+  LOG_INFO("FAIL");
+  set_test_status(kTestStatusFailed);
+  abort();
+}

--- a/sw/device/lib/testing/test_status.h
+++ b/sw/device/lib/testing/test_status.h
@@ -1,0 +1,63 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_STATUS_H_
+#define OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_STATUS_H_
+
+#include <stdnoreturn.h>
+
+/**
+ * Indicates the status of the software running on the CPU, from a testing
+ * perspective.
+ *
+ * It is useful to track the current status of the test SW executing on the CPU
+ * as a signal the helps aid in debug.
+ *
+ * The values set to these literals is arbitrary and do not possess any special
+ * meaning (other than being hex 'words'). They are chosen to be 16-bit only.
+ * The upper 16-bits are reserved for future use.
+ *
+ * At minimum, it is mandatory to set the status of the software to explicitly
+ * indicate whether the software test passed or failed, with
+ * `kTestStatusPassed` and `kTestStatusFailed` values. As such these are
+ * terimnal states - SW **must not** execute any code after reaching that
+ * status.
+ */
+typedef enum test_status {
+  /* Indicates that the CPU has started executing the boot_rom code. */
+  kTestStatusBootRom = 0xb090,  // 'bogo', BOotrom GO
+
+  /* Indicates that the CPU has started executing the test code. */
+  kTestStatusUnderTest = 0x4354,  // 'test'
+
+  /* Indicates that the CPU is in the WFI state. */
+  kTestStatusWfi = 0x1d1e,  // 'idle'
+
+  /* This indicates that the test has passed. */
+  kTestStatusPassed = 0x900d,  // 'good'
+
+  /* This indicates that the test has failed. */
+  kTestStatusFailed = 0xbaad  // 'baad'
+} test_status_t;
+
+/**
+ * Sets the test status.
+ *
+ * In DV testing, this function writes the current status of the software to a
+ * specific memory location. In non-DV testing, this converts to a log.
+ */
+void set_test_status(const test_status_t test_status);
+
+/**
+ * Helper functions that assert the end-of-test.
+ *
+ * These assert that the test has passed/failed and stop execution by calling
+ * the `abort()` function. It is mandatory to use the functions below to
+ * indicate the terminal status' `kTestStatusPassed` and `kTestStatusFailed`.
+ * The `set_test_status()` must not be invoked directly for these.
+ */
+noreturn void test_passed(void);
+noreturn void test_failed(void);
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_STATUS_H_

--- a/sw/device/tests/README.md
+++ b/sw/device/tests/README.md
@@ -14,13 +14,18 @@ For FPGA / silicon this may be a host machine, while for UVM / Verilator this ma
 
 ## Self Checking Mechanism
 
-Currently, the self-checking mechanism is accomplished through a console message.
-When the tests pass, it will output `PASS!\r\n`.
+The self-checking mechanism is accomplished by invoking one of the test status indication APIs defined in `sw/device/lib/testing/test_status.h`.
+It is mandatory to invoke either `test_failed()` or `test_passed()` based on the checks performed in the test.
+These methods provide a platform-agnostic way to indicate the test status.
+Invoking these methods also causes the core to abort the execution and never return after reaching one of these terminal states.
 
+For non-UVM DV platforms (Verilator DV, FPGA or silicon), these methods write a message to the console.
+When the tests pass, it will output `PASS!\r\n`.
 The capturing and generation of this message will differ per testing target.
-On FPGA / silicon, they will feed directly to a host machine through a physical UART conection, where the host can decipher the message correctness.
+On FPGA / silicon, they will feed directly to a host machine through a physical UART connection, where the host can decipher the message correctness.
 On Verilator, they will feed to a virtual UART terminal where the host can do the same.
-On DV, they will feed to a fixed memory location where the DV backend can efficiently pick up the message without significant parsing overhead.
+
+For UVM DV, these methods write the test status signature to a known location in the memory, which is monitored by the testbench.
 
 # List of Tests
 


### PR DESCRIPTION
This commit adds SW to DV testbench self checking mechanism. It uses a
reserved location in RAM (`test_reserved_size` region) to monitor the
status of the SW test running on the Ibex core.
- Added test status lib in C for the SW to be able to write the status
(implemented as an enum). Apart from pass and fail, the enum provides
indications for these: executing boot rom, executing the test, in WFI,
etc. These are loosely defined at the moment and can change in future.

- Added sw test status interface on the DV side, hooked it up to the
testbench, connected it to the RAM (so that it can monitor the writes to
that location)

- Added `chip_sw_test_base_vseq` as an abstraction for chip level tests
run with SW running on the CPU. This enables the SW logger and the test
status monitor.

- Related fixes to supporting code, meson build files.

- Fixed incorrect calculation of number of variable args in `log.h`.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>