### PR TITLE
[flash_ctrl] Minor refactoring to get ready for upcoming changes

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson
@@ -24,7 +24,7 @@
   ],
 
   param_list: [
-    { name: "NumBanks",
+    { name: "NBanks",
       desc: "Number of flash banks",
       type: "int",
       default: "2",
@@ -320,7 +320,7 @@
         cname: "FLASH_CTRL",
         name: "MP_BANK_CFG",
         desc: "Memory protect bank configuration",
-        count: "NumBanks",
+        count: "NBanks",
         swaccess: "rw",
         hwaccess: "hro",
         regwen: "BANK_CFG_REGWEN"

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
@@ -7,8 +7,30 @@
 
 package flash_ctrl_pkg;
 
-  localparam int FlashTotalPages = top_pkg::FLASH_BANKS * top_pkg::FLASH_PAGES_PER_BANK;
-  localparam int AllPagesW = $clog2(FlashTotalPages);
+  // parameters for flash macro properties
+  localparam int NumBanks        = top_pkg::FLASH_BANKS;
+  localparam int PagesPerBank    = top_pkg::FLASH_PAGES_PER_BANK;
+  localparam int WordsPerPage    = top_pkg::FLASH_WORDS_PER_PAGE;
+  localparam int BytesPerWord    = top_pkg::FLASH_BYTES_PER_WORD;
+  localparam int BankW           = $clog2(NumBanks);
+  localparam int PageW           = $clog2(PagesPerBank);
+  localparam int WordW           = $clog2(WordsPerPage);
+  localparam int AddrW           = BankW + PageW + WordW; // all flash range
+  localparam int BankAddrW       = PageW + WordW;         // 1 bank of flash range
+  localparam int DataWidth       = BytesPerWord * 8;
+  localparam int FlashTotalPages = NumBanks * PagesPerBank;
+  localparam int AllPagesW       = BankW + PageW;
+
+  // bus interface
+  localparam int BusWidth        = top_pkg::TL_DW;
+
+  // flash controller protection regions
+  localparam int MpRegions       = 8;
+
+  // fifo parameters
+  localparam int FifoDepth       = 16;
+  localparam int FifoDepthW      = $clog2(FifoDepth+1);
+
 
   // Flash Operations Supported
   typedef enum logic [1:0] {
@@ -31,13 +53,13 @@ package flash_ctrl_pkg;
 
   // Flash controller to memory
   typedef struct packed {
-    logic                         req;
-    logic                         rd;
-    logic                         prog;
-    logic                         pg_erase;
-    logic                         bk_erase;
-    logic [top_pkg::FLASH_AW-1:0] addr;
-    logic [top_pkg::FLASH_DW-1:0] prog_data;
+    logic                req;
+    logic                rd;
+    logic                prog;
+    logic                pg_erase;
+    logic                bk_erase;
+    logic [AddrW-1:0]    addr;
+    logic [BusWidth-1:0] prog_data;
   } flash_req_t;
 
   // default value of flash_req_t (for dangling ports)
@@ -53,11 +75,11 @@ package flash_ctrl_pkg;
 
   // memory to flash controller
   typedef struct packed {
-    logic                         rd_done;
-    logic                         prog_done;
-    logic                         erase_done;
-    logic [top_pkg::FLASH_DW-1:0] rd_data;
-    logic                         init_busy;
+    logic                rd_done;
+    logic                prog_done;
+    logic                erase_done;
+    logic [BusWidth-1:0] rd_data;
+    logic                init_busy;
   } flash_rsp_t;
 
   // default value of flash_rsp_t (for dangling ports)

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
@@ -7,7 +7,7 @@
 package flash_ctrl_reg_pkg;
 
   // Param list
-  parameter int NumBanks = 2;
+  parameter int NBanks = 2;
   parameter int NumRegions = 8;
 
   ////////////////////////////

--- a/hw/ip/flash_ctrl/rtl/flash_phy_core.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_core.sv
@@ -9,34 +9,26 @@
 // scramble, ECC, security and arbitration logic.
 // Most of the items are TODO, at the moment only arbitration logic exists.
 
-module flash_phy_core #(
-  parameter int PagesPerBank = 256, // pages per bank
-  parameter int WordsPerPage = 256, // words per page
-  parameter int DataWidth   = 32,   // bits per word
-  parameter bit SkipInit = 1,       // this is an option to reset flash to all F's at reset
-
-  // Derived parameters
-  localparam int PageW = $clog2(PagesPerBank),
-  localparam int WordW = $clog2(WordsPerPage),
-  localparam int AddrW = PageW + WordW
+module flash_phy_core import flash_ctrl_pkg::*; #(
+  parameter bit SkipInit     = 1   // this is an option to reset flash to all F's at reset
 ) (
   input                        clk_i,
   input                        rst_ni,
   input                        host_req_i, // host request - read only
-  input [AddrW-1:0]            host_addr_i,
+  input [BankAddrW-1:0]        host_addr_i,
   input                        req_i,      // controller request
   input                        rd_i,
   input                        prog_i,
   input                        pg_erase_i,
   input                        bk_erase_i,
-  input [AddrW-1:0]            addr_i,
-  input [DataWidth-1:0]        prog_data_i,
+  input [BankAddrW-1:0]        addr_i,
+  input [BusWidth-1:0]         prog_data_i,
   output logic                 host_req_rdy_o,
   output logic                 host_req_done_o,
   output logic                 rd_done_o,
   output logic                 prog_done_o,
   output logic                 erase_done_o,
-  output logic [DataWidth-1:0] rd_data_o,
+  output logic [BusWidth-1:0]  rd_data_o,
   output logic                 init_busy_o
 );
 
@@ -56,7 +48,7 @@ module flash_phy_core #(
   logic ack;
 
   // interface with flash macro
-  logic [AddrW-1:0] muxed_addr;
+  logic [BankAddrW-1:0] muxed_addr;
 
   // valid request conditions
   logic op_clr_cond;

--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -453,12 +453,12 @@ module top_${top["name"]} #(
   logic flash_host_req;
   logic flash_host_req_rdy;
   logic flash_host_req_done;
-  logic [FLASH_DW-1:0] flash_host_rdata;
-  logic [FLASH_AW-1:0] flash_host_addr;
+  logic [flash_ctrl_pkg::BusWidth-1:0] flash_host_rdata;
+  logic [flash_ctrl_pkg::AddrW-1:0] flash_host_addr;
 
   tlul_adapter_sram #(
-    .SramAw(FLASH_AW),
-    .SramDw(FLASH_DW),
+    .SramAw(flash_ctrl_pkg::AddrW),
+    .SramDw(flash_ctrl_pkg::BusWidth),
     .Outstanding(2),
     .ByteAccess(0),
     .ErrOnWrite(1)
@@ -484,12 +484,7 @@ module top_${top["name"]} #(
     .rerror_i (2'b00)
   );
 
-  flash_phy #(
-    .NumBanks(FLASH_BANKS),
-    .PagesPerBank(FLASH_PAGES_PER_BANK),
-    .WordsPerPage(FLASH_WORDS_PER_PAGE),
-    .DataWidth(${data_width})
-  ) u_flash_${m["name"]} (
+  flash_phy u_flash_${m["name"]} (
     % for key in clocks:
     .${key}   (${clocks[key]}_clk),
     % endfor

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -449,12 +449,12 @@ module top_earlgrey #(
   logic flash_host_req;
   logic flash_host_req_rdy;
   logic flash_host_req_done;
-  logic [FLASH_DW-1:0] flash_host_rdata;
-  logic [FLASH_AW-1:0] flash_host_addr;
+  logic [flash_ctrl_pkg::BusWidth-1:0] flash_host_rdata;
+  logic [flash_ctrl_pkg::AddrW-1:0] flash_host_addr;
 
   tlul_adapter_sram #(
-    .SramAw(FLASH_AW),
-    .SramDw(FLASH_DW),
+    .SramAw(flash_ctrl_pkg::AddrW),
+    .SramDw(flash_ctrl_pkg::BusWidth),
     .Outstanding(2),
     .ByteAccess(0),
     .ErrOnWrite(1)
@@ -476,12 +476,7 @@ module top_earlgrey #(
     .rerror_i (2'b00)
   );
 
-  flash_phy #(
-    .NumBanks(FLASH_BANKS),
-    .PagesPerBank(FLASH_PAGES_PER_BANK),
-    .WordsPerPage(FLASH_WORDS_PER_PAGE),
-    .DataWidth(32)
-  ) u_flash_eflash (
+  flash_phy u_flash_eflash (
     .clk_i   (main_clk),
     .rst_ni   (lc_rst_n),
     .host_req_i      (flash_host_req),

--- a/hw/top_earlgrey/rtl/top_pkg.sv
+++ b/hw/top_earlgrey/rtl/top_pkg.sv
@@ -16,10 +16,5 @@ localparam FLASH_BANKS=2;
 localparam FLASH_PAGES_PER_BANK=256;
 localparam FLASH_WORDS_PER_PAGE=256;
 localparam FLASH_BYTES_PER_WORD=4;
-localparam FLASH_BKW = $clog2(FLASH_BANKS);
-localparam FLASH_PGW = $clog2(FLASH_PAGES_PER_BANK);
-localparam FLASH_WDW = $clog2(FLASH_WORDS_PER_PAGE);
-localparam FLASH_AW = FLASH_BKW + FLASH_PGW + FLASH_WDW;
-localparam FLASH_DW = FLASH_BYTES_PER_WORD * 8;
 
 endpackage


### PR DESCRIPTION
- Move most parameters out of top_pkg to get ready for flash_ctrl templating
- Separate bus width from flash data width to get ready for wider flash

Signed-off-by: Timothy Chen <timothytim@google.com>