### PR TITLE
[topgen] - Generate reset paths for top level connection

### DIFF
--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -29,30 +29,34 @@
     {
       name: lc
       type: root
-      clk: main
+      root: lc
+      clk: fixed
     }
     {
       name: sys
       type: root
+      root: sys
       clk: main
     }
     {
       name: sys_fixed
-      type: leaf
+      type: gen
       root: sys
       clk: fixed
     }
     {
       name: spi_device
-      type: leaf
+      type: gen
       root: sys
       clk: fixed
+      sw: 1
     }
     {
       name: usb
-      type: leaf
+      type: gen
       root: sys
       clk: usb
+      sw: 1
     }
   ]
   num_cores: "1"
@@ -1725,6 +1729,14 @@
         ]
       }
     ]
+  }
+  reset_paths:
+  {
+    lc: lc_rst_n
+    sys: sys_rst_n
+    sys_fixed: sys_fixed_rst_n
+    spi_device: spi_device_rst_n
+    usb: usb_rst_n
   }
   inter_signal:
   {

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -15,16 +15,27 @@
   ]
 
   // Reset attributes
-  // name: name of reset. Real name is `name`_rst_n
-  // type: reset type, either root or leaf
-  // root: if reset type not root, the root reset it is related to
+  // name: name of reset.
+  // If type is "gen", then real name is `name`_rst_n
+  // If type is "por", then real name is just `name`
+  // The root type is temporary until rstmgr integration
+  //
+  // root: The parent reset.
+  // If type is "por", there is no root, since it is the root
+  //
   // clk:  related clock domain for synchronous release
+  // If type is "por", there is not related clock, since it is
+  // likely external or generated from a voltage comparator
+  //
   resets: [
-    { name: "lc", type: "root", clk: "main"}
-    { name: "sys", type: "root", clk: "main"}
-    { name: "sys_fixed", type: "leaf", root: "sys", clk: "fixed"}
-    { name: "spi_device", type: "leaf", root: "sys", clk: "fixed"}
-    { name: "usb", type: "leaf", root: "sys", clk: "usb"}
+  // The rst_ni and por resets are relevant once rstmgr / pwrmgr are integrated
+  //  { name: "rst_ni",     type: "por" }
+  //  { name: "por",        type: "gen", root: "lc",  clk: "fixed" }
+    { name: "lc",         type: "root", root: "lc",  clk: "fixed" }
+    { name: "sys",        type: "root", root: "sys", clk: "main"  }
+    { name: "sys_fixed",  type: "gen",  root: "sys", clk: "fixed" }
+    { name: "spi_device", type: "gen",  root: "sys", clk: "fixed", sw: 1}
+    { name: "usb",        type: "gen",  root: "sys", clk: "usb",   sw: 1}
   ]
 
   // Number of cores: used in rv_plic and timer

--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -220,7 +220,7 @@ module top_${top["name"]} #(
 
   // Non-root reset assignments
 % for reset in top['resets']:
-  % if reset['type'] in ['leaf'] and reset['name'] != "usb" :
+  % if reset['type'] in ['gen'] and reset['name'] != "usb" :
   assign ${reset['name']}_rst_n = ${reset['root']}_rst_n;
   % endif
 % endfor
@@ -254,7 +254,7 @@ module top_${top["name"]} #(
   ) u_rv_core_ibex (
     // clock and reset
     .clk_i                (main_clk),
-    .rst_ni               (sys_rst_n),
+    .rst_ni               (${top["reset_paths"]["sys"]}),
     .test_en_i            (1'b0),
     // static pinning
     .hart_id_i            (32'b0),
@@ -285,7 +285,7 @@ module top_${top["name"]} #(
     .IdcodeValue (JTAG_IDCODE)
   ) u_dm_top (
     .clk_i         (main_clk),
-    .rst_ni        (lc_rst_n),
+    .rst_ni        (${top["reset_paths"]["lc"]}),
     .testmode_i    (1'b0),
     .ndmreset_o    (ndmreset_req),
     .dmactive_o    (),
@@ -341,7 +341,7 @@ module top_${top["name"]} #(
     .${key}   (${clocks[key]}_clk),
     % endfor
     % for key in resets:
-    .${key}   (${resets[key]}_rst_n),
+    .${key}   (${top["reset_paths"][resets[key]]}),
     % endfor
     .tl_i     (tl_${m["name"]}_d_h2d),
     .tl_o     (tl_${m["name"]}_d_d2h),
@@ -367,7 +367,7 @@ module top_${top["name"]} #(
     .${key}   (${clocks[key]}_clk),
     % endfor
     % for key in resets:
-    .${key}   (${resets[key]}_rst_n),
+    .${key}   (${top["reset_paths"][resets[key]]}),
     % endfor
 
     .req_i    (${m["name"]}_req),
@@ -402,7 +402,7 @@ module top_${top["name"]} #(
     .${key}   (${clocks[key]}_clk),
     % endfor
     % for key in resets:
-    .${key}   (${resets[key]}_rst_n),
+    .${key}   (${top["reset_paths"][resets[key]]}),
     % endfor
 
     .tl_i     (tl_${m["name"]}_d_h2d),
@@ -428,7 +428,7 @@ module top_${top["name"]} #(
     .${key}   (${clocks[key]}_clk),
     % endfor
     % for key in resets:
-    .${key}   (${resets[key]}_rst_n),
+    .${key}   (${top["reset_paths"][resets[key]]}),
     % endfor
     .cs_i     (${m["name"]}_req),
     .addr_i   (${m["name"]}_addr),
@@ -472,7 +472,7 @@ module top_${top["name"]} #(
     .${key}   (${clocks[key]}_clk),
     % endfor
     % for key in resets:
-    .${key}   (${resets[key]}_rst_n),
+    .${key}   (${top["reset_paths"][resets[key]]}),
     % endfor
 
     .tl_i       (tl_${m["name"]}_d_h2d),
@@ -494,7 +494,7 @@ module top_${top["name"]} #(
     .${key}   (${clocks[key]}_clk),
     % endfor
     % for key in resets:
-    .${key}   (${resets[key]}_rst_n),
+    .${key}   (${top["reset_paths"][resets[key]]}),
     % endfor
     .host_req_i      (flash_host_req),
     .host_addr_i     (flash_host_addr),
@@ -667,7 +667,7 @@ else:
       .${k} (${v}_clk),
     % endfor
     % for k, v in m["reset_connections"].items():
-      .${k} (${v}_rst_n)${"," if not loop.last else ""}
+      .${k} (${top["reset_paths"][v]})${"," if not loop.last else ""}
     % endfor
   );
 
@@ -690,7 +690,7 @@ else:
     .${k} (${v}_clk),
   % endfor
   % for k, v in xbar["reset_connections"].items():
-    .${k} (${v}_rst_n),
+    .${k} (${top["reset_paths"][v]}),
   % endfor
   % for node in xbar["nodes"]:
     % if node["type"] == "device":

--- a/util/topgen/lib.py
+++ b/util/topgen/lib.py
@@ -214,3 +214,12 @@ def index(i: int) -> str:
     """Return index if it is not -1
     """
     return "[{}]".format(i) if i != -1 else ""
+
+def get_reset_path(resets, name):
+    """Return the appropriate reset path given name
+    """
+    for reset in resets:
+        if reset['name'] == name:
+            return reset['path']
+
+    return "none"

--- a/util/topgen/merge.py
+++ b/util/topgen/merge.py
@@ -416,6 +416,30 @@ def xbar_cross_node(node_name, device_xbar, xbars, visited=[]):
     return result
 
 
+def amend_resets(top):
+    """Add a path variable to reset declaration
+    """
+    reset_paths = {}
+
+    for reset in top["resets"]:
+
+        if "type" not in reset:
+            log.error("{} missing type field".format(reset["name"]))
+            return
+
+        if reset["type"] in ["root", "gen"]:
+            # The resets structure will be used once rstmgr is integrated
+            # reset_paths[reset["name"]] = "resets.{}_rst_n".format(reset["name"])
+            reset_paths[reset["name"]] = "{}_rst_n".format(reset["name"])
+        elif reset["type"] == "por":
+            reset_paths[reset["name"]] = "rst_ni"
+        else:
+            log.error("{} type is invalid".format(reset["type"]))
+
+    top["reset_paths"] = reset_paths
+    return
+
+
 def amend_interrupt(top):
     """Check interrupt_module if exists, or just use all modules
     """
@@ -586,6 +610,9 @@ def merge_top(topcfg: OrderedDict, ipobjs: OrderedDict,
     # Combine ip cfg into topcfg
     for ip in ipobjs:
         amend_ip(gencfg, ip)
+
+    # Add path names to declared resets
+    amend_resets(gencfg)
 
     # Inter-module signals
     elab_intermodule(gencfg)


### PR DESCRIPTION
- This is in preparation for rstmgr integration where resets will
  no longer always be coming from a top level port or generated
  from rstmgr

Signed-off-by: Timothy Chen <timothytim@google.com>