### PR TITLE
[fpv] remove auto gen fpv assert from makefile

### DIFF
--- a/hw/Makefile
+++ b/hw/Makefile
@@ -5,7 +5,6 @@ export PRJ_DIR
 REG_OUTPUT_DIR    ?= ${PRJ_DIR}/build/regs-generated
 REG_OUTPUT_DV_DIR ?= ${REG_OUTPUT_DIR}/dv
 REG_OUTPUT_SW_DIR ?= ${REG_OUTPUT_DIR}/sw
-REG_OUTPUT_FPV_CSR_DIR ?= ${REG_OUTPUT_DIR}/fpv/vip
 
 IPS ?= aes           \
        alert_handler \
@@ -65,9 +64,6 @@ $(ips_reg): pre_reg
 	if [ -f ${PRJ_DIR}/hw/ip/$(subst _reg,,$@)/$(dir_hjson)/$(subst _reg,,$@).hjson ]; then \
 		${PRJ_DIR}/util/regtool.py -r ${PRJ_DIR}/hw/ip/$(subst _reg,,$@)/$(dir_hjson)/$(subst _reg,,$@).hjson; \
 		${PRJ_DIR}/util/regtool.py -s -t ${REG_OUTPUT_DV_DIR} \
-		  ${PRJ_DIR}/hw/ip/$(subst _reg,,$@)/$(dir_hjson)/$(subst _reg,,$@).hjson; \
-		mkdir -p ${PRJ_DIR}/hw/ip/$(subst _reg,,$@)/fpv/vip; \
-		${PRJ_DIR}/util/regtool.py -f -t ${PRJ_DIR}/hw/ip/$(subst _reg,,$@)/fpv/vip/ \
 		  ${PRJ_DIR}/hw/ip/$(subst _reg,,$@)/$(dir_hjson)/$(subst _reg,,$@).hjson; \
 	fi
 


### PR DESCRIPTION
Remove automatic generate FPV assertions from makefile
This FPV assertions right now should only generate with FPV testbench

Signed-off-by: Cindy Chen <chencindy@google.com>