### PR TITLE
Use StrictMock in MmioTest

### DIFF
--- a/sw/device/lib/testing/mock_mmio.h
+++ b/sw/device/lib/testing/mock_mmio.h
@@ -212,7 +212,8 @@ class MmioTest {
   MockDevice &dev() { return *dev_; }
 
  private:
-  std::unique_ptr<MockDevice> dev_ = std::make_unique<MockDevice>();
+  std::unique_ptr<MockDevice> dev_ =
+      std::make_unique<testing::StrictMock<MockDevice>>();
   testing::InSequence seq_;
 };
 }  // namespace mock_mmio


### PR DESCRIPTION
There are three types of mock objects in googlemock: nice, naggy, and strict. The difference between them is the way they handle _uninteresting_ mock method calls. Uninteresting calls are calls to mock methods that don't have any `EXPECT_CALL` specifications. `NiceMock` silently ignores such calls, `NaggyMock` prints warnings while `StrictMock` makes all uninteresting calls failures.

A mock object is currently naggy by default, which can potentially hide some issues in DIF libraries  because MMIO accesses without corresponding `EXPECT_CALL`s do not cause tests to fail. This change makes the mock object in `MmioTest` a `StrictMock` so that such accesses will cause tests to fail.

Signed-off-by: Alphan Ulusoy <alphan@google.com>
