### PR TITLE
[hw] Switch to higher performing Ibex

### DIFF
--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -9,17 +9,20 @@
  * Instruction and data bus are 32 bit wide TileLink-UL (TL-UL).
  */
 module rv_core_ibex #(
-  parameter bit          PMPEnable        = 1'b0,
-  parameter int unsigned PMPGranularity   = 0,
-  parameter int unsigned PMPNumRegions    = 4,
-  parameter int unsigned MHPMCounterNum   = 8,
-  parameter int unsigned MHPMCounterWidth = 40,
-  parameter bit          RV32E            = 0,
-  parameter bit          RV32M            = 1,
-  parameter bit          DbgTriggerEn     = 1'b1,
-  parameter int unsigned DmHaltAddr       = 32'h1A110800,
-  parameter int unsigned DmExceptionAddr  = 32'h1A110808,
-  parameter bit          PipeLine         = 0
+  parameter bit          PMPEnable                = 1'b0,
+  parameter int unsigned PMPGranularity           = 0,
+  parameter int unsigned PMPNumRegions            = 4,
+  parameter int unsigned MHPMCounterNum           = 8,
+  parameter int unsigned MHPMCounterWidth         = 40,
+  parameter bit          RV32E                    = 0,
+  parameter bit          RV32M                    = 1,
+  parameter bit          BranchTargetALU          = 1,
+  parameter bit          WritebackStage           = 1,
+  parameter              MultiplierImplementation = "single-cycle",
+  parameter bit          DbgTriggerEn             = 1'b1,
+  parameter int unsigned DmHaltAddr               = 32'h1A110800,
+  parameter int unsigned DmExceptionAddr          = 32'h1A110808,
+  parameter bit          PipeLine                 = 0
 ) (
   // Clock and Reset
   input  logic        clk_i,
@@ -110,16 +113,19 @@ module rv_core_ibex #(
 `endif
 
   ibex_core #(
-     .PMPEnable        ( PMPEnable         ),
-     .PMPGranularity   ( PMPGranularity    ),
-     .PMPNumRegions    ( PMPNumRegions     ),
-     .MHPMCounterNum   ( MHPMCounterNum    ),
-     .MHPMCounterWidth ( MHPMCounterWidth  ),
-     .RV32E            ( RV32E             ),
-     .RV32M            ( RV32M             ),
-     .DbgTriggerEn     ( DbgTriggerEn      ),
-     .DmHaltAddr       ( DmHaltAddr        ),
-     .DmExceptionAddr  ( DmExceptionAddr   )
+     .PMPEnable                ( PMPEnable                ),
+     .PMPGranularity           ( PMPGranularity           ),
+     .PMPNumRegions            ( PMPNumRegions            ),
+     .MHPMCounterNum           ( MHPMCounterNum           ),
+     .MHPMCounterWidth         ( MHPMCounterWidth         ),
+     .RV32E                    ( RV32E                    ),
+     .RV32M                    ( RV32M                    ),
+     .BranchTargetALU          ( BranchTargetALU          ),
+     .WritebackStage           ( WritebackStage           ),
+     .MultiplierImplementation ( MultiplierImplementation ),
+     .DbgTriggerEn             ( DbgTriggerEn             ),
+     .DmHaltAddr               ( DmHaltAddr               ),
+     .DmExceptionAddr          ( DmExceptionAddr          )
   ) u_core (
      .clk_i,
      .rst_ni,

--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -237,17 +237,20 @@ module top_${top["name"]} #(
 
   // processor core
   rv_core_ibex #(
-    .PMPEnable           (0),
-    .PMPGranularity      (0),
-    .PMPNumRegions       (4),
-    .MHPMCounterNum      (8),
-    .MHPMCounterWidth    (40),
-    .RV32E               (0),
-    .RV32M               (1),
-    .DbgTriggerEn        (1),
-    .DmHaltAddr          (ADDR_SPACE_DEBUG_MEM + dm::HaltAddress),
-    .DmExceptionAddr     (ADDR_SPACE_DEBUG_MEM + dm::ExceptionAddress),
-    .PipeLine            (IbexPipeLine)
+    .PMPEnable                (0),
+    .PMPGranularity           (0),
+    .PMPNumRegions            (4),
+    .MHPMCounterNum           (8),
+    .MHPMCounterWidth         (40),
+    .RV32E                    (0),
+    .RV32M                    (1),
+    .BranchTargetALU          (1),
+    .WritebackStage           (1),
+    .MultiplierImplementation ("single-cycle"),
+    .DbgTriggerEn             (1),
+    .DmHaltAddr               (ADDR_SPACE_DEBUG_MEM + dm::HaltAddress),
+    .DmExceptionAddr          (ADDR_SPACE_DEBUG_MEM + dm::ExceptionAddress),
+    .PipeLine                 (IbexPipeLine)
   ) u_rv_core_ibex (
     // clock and reset
     .clk_i                (main_clk),

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -284,17 +284,20 @@ module top_earlgrey #(
 
   // processor core
   rv_core_ibex #(
-    .PMPEnable           (0),
-    .PMPGranularity      (0),
-    .PMPNumRegions       (4),
-    .MHPMCounterNum      (8),
-    .MHPMCounterWidth    (40),
-    .RV32E               (0),
-    .RV32M               (1),
-    .DbgTriggerEn        (1),
-    .DmHaltAddr          (ADDR_SPACE_DEBUG_MEM + dm::HaltAddress),
-    .DmExceptionAddr     (ADDR_SPACE_DEBUG_MEM + dm::ExceptionAddress),
-    .PipeLine            (IbexPipeLine)
+    .PMPEnable                (0),
+    .PMPGranularity           (0),
+    .PMPNumRegions            (4),
+    .MHPMCounterNum           (8),
+    .MHPMCounterWidth         (40),
+    .RV32E                    (0),
+    .RV32M                    (1),
+    .BranchTargetALU          (1),
+    .WritebackStage           (1),
+    .MultiplierImplementation ("single-cycle"),
+    .DbgTriggerEn             (1),
+    .DmHaltAddr               (ADDR_SPACE_DEBUG_MEM + dm::HaltAddress),
+    .DmExceptionAddr          (ADDR_SPACE_DEBUG_MEM + dm::ExceptionAddress),
+    .PipeLine                 (IbexPipeLine)
   ) u_rv_core_ibex (
     // clock and reset
     .clk_i                (main_clk),


### PR DESCRIPTION
This enables the following features in Ibex:

* Seperate branch target ALU
* Third pipeline stage
* Single cycle multiply

Signed-off-by: Greg Chadwick <gac@lowrisc.org>

Note that there's some things to address in the OT memory system before we'll see the coremark numbers I can currently obtain on Ibex simple system.