### PR TITLE
[verible] Add git commit hook script from verible

### DIFF
--- a/util/verible/diff-to-changed-lines.awk
+++ b/util/verible/diff-to-changed-lines.awk
@@ -1,0 +1,129 @@
+#!/usr/bin/awk -f
+# Copyright 2020 The Verible Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Converts a unified-diff into file names and their modified line ranges.
+# This supports reading the output of 'git diff', but should handle most
+# variants of diffs.
+# Note, however, that git diffs shows files as being prefixed with "a/" and "b/",
+# so the caller of this script will need to adjust filenames accordingly.
+# The output style of line ranges is suitable for 'verilog_format --lines=...'
+#
+# usage: awk -f (this_script) < file.diff
+#
+# Changed lines are those that start with '+' in unified diffs.
+# Ranges can be compact: N,P-Q
+# Prints one file per line, e.g.:
+#   abc.sv 5,10-12,18,21-22
+#   xyz.sv 232-245
+# New files (diffed vs. /dev/null) will appear without line ranges:
+#   new_file.sv
+#
+# TODO(fangism): use or write a proper diff/patch-reader library (C++)
+
+BEGIN {
+  expect_filename = 0;
+  active_range = 0;
+  seen_file = 0;
+}
+
+# Detect whether this entry is a new file.
+/^---/ {
+  is_new_file = ($2 == "/dev/null");
+}
+
+# contains filename at $2
+/^+++/ {
+  if (expect_filename) {
+    filename = $2;
+    if (seen_file) print "";
+    printf(filename " ");
+    expect_filename = 0;
+    seen_range = 0;
+    seen_file = 1;
+  }
+}
+
+# given:
+# @@ -L,J +R,K
+# R is the next starting line number in the next chunk
+/^@@ / {
+  split($3, a, ",");
+  left_current_line = substr(a[1], 2) - 1;
+  right_current_line = left_current_line;
+  active_range = 0;
+}
+
+# seen in 'git diff'
+# diff before-file after-file
+/^diff/ {
+  auto_flush_range();
+  expect_filename = 1;
+}
+
+# seen in 'p4 diff'
+# ==== //depot/...#N - /local/path/to/file ====
+/^==== .* ====$/ {
+  auto_flush_range();
+  expect_filename = 1;
+}
+
+
+# + lines are after change only
+/^+/ {
+  if (!expect_filename) {
+    ++right_current_line;
+    if (!active_range) {
+      modified_from = right_current_line;
+    }
+    active_range = 1;
+  }
+}
+
+# print the most recent completed range
+function flush_range() {
+  if (!is_new_file) {
+    if (seen_range) printf(",");
+    modified_to = right_current_line;
+    if (modified_from == modified_to) printf(modified_from);
+    else printf(modified_from "-" modified_to);
+  }
+  seen_range = 1;
+  active_range = 0;
+}
+
+function auto_flush_range() {
+  if (active_range) {
+    flush_range();
+  }
+}
+
+# <space> lines in unified diffs are common to both before/after
+/^ / {
+  auto_flush_range();
+  ++left_current_line;
+  ++right_current_line;
+}
+
+# - lines are before change only
+/^-/ {
+  auto_flush_range();
+  ++left_current_line;
+}
+
+END {
+  # if diff ends with an active range, print it.
+  auto_flush_range();
+  print "";
+}

--- a/util/verible/git-verilog_format.sh
+++ b/util/verible/git-verilog_format.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+# git-verilog_format.sh
+#
+# Copyright 2020 The Verible Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+script_name="$(basename $0)"
+script_dir="$(realpath $(dirname $0))"
+
+formatter="$(which verilog_format)" || \
+  formatter="$script_dir"/verilog_format
+
+# Required support script.
+diff_parser="$script_dir"/diff-to-changed-lines.awk
+
+function usage() {
+  cat <<EOF
+$0:
+Performs incremental file formatting (verilog_format) based on current diffs.
+New files explicitly git-add-ed by the user are wholly formatted.
+
+Actions:
+  1) Runs 'git add -u' to stage currently modified files to the index.
+     To format new files (wholly), 'git add' those before calling this script.
+  2) Runs 'git diff -u --cached' to generate a unified diff.
+  3) Diff is scanned to determine added or modified lines in each file.
+  4) Invokes 'verilog_format --inplace' on all touched or new Verilog files,
+     but does not 'git add' so the changes may be examined and tested.
+     Formatting can be easily undone with:
+       'git diff | git apply --reverse -'.
+
+usage: $0 [script options] [-- [verilog_format options]]
+  (no positional arguments)
+  Run from anywhere inside a git project tree.
+
+script options: (options with arguments can be: --flag=VALUE or --flag VALUE)
+  --help | -h : print help and exit
+  --verbose | -v : execute verbosely
+  --dry-run : stop before running formatter, and print formatting commands
+  --formatter TOOL : path to verilog_format binary
+       [using: $formatter]
+  -- : stops option processing, and forwards remaining args as flags to the
+       underlying --formatter tool.
+EOF
+}
+
+# self-identify message coming from this script
+function msg()  {
+  echo "[$script_name] " "$@"
+}
+
+verbose=0
+dry_run=0
+# 'args' will be forwarded to the formatter as additional tool options
+args=()
+
+# option processing
+for opt
+do
+  # handle: --option arg
+  if test -n "$prev_opt"
+  then
+    eval $prev_opt=\$opt
+    prev_opt=
+    shift
+    continue
+  fi
+  case $opt in
+    *=?*) optarg=$(expr "X$opt" : '[^=]*=\(.*\)') ;;
+    *=) optarg= ;;
+  esac
+  case $opt in
+    -- ) shift ; break ;; # stop option processing
+    --help | -h ) { usage ; exit ;} ;;
+    --verbose | -v ) verbose=1 ;;
+    --formatter ) prev_opt=formatter ;;
+    --formatter=* ) formatter="$optarg" ;;
+    --dry-run ) dry_run=1 ;;
+    --* | -* ) msg "Unknown option: $opt" ; exit 1 ;;
+    *) args=("${args[@]}" "$opt") ;;
+  esac
+  shift
+done
+
+# Check some requirements.
+[[ -x "$formatter" ]] || {
+  msg "*** Unable to find executable 'verilog_format'."
+  msg "  Please specify formatter with: --formatter TOOL."
+  exit 1
+}
+[[ -r "$diff_parser" ]] || {
+  msg "*** Required helper script '$diff_parser' is missing."
+  exit 1
+}
+
+# collect remainder after stopping option processing
+args=("${args[@]}" "$@")
+
+function verbose_command() {
+  if [[ "$dry_run" = 1 ]] || [[ "$verbose" = 1 ]]
+  then
+    msg "[command]: $@"
+  fi
+
+  [[ "$dry_run" = 1 ]] || "$@" || \
+    msg "Note: '$@' failed with status: $?"
+}
+
+# Switch to git root directory, so relative paths will be correct.
+cd "$(git rev-parse --show-toplevel)"
+msg "Working from git root: $PWD"
+
+tempdir="$(mktemp -d --tmpdir "tmp.$script_name.XXXXXXX")"
+msg "Temporary files in: $tempdir"
+
+# Save current workspace in git index.
+git add -u
+# Examine current differences for changed lines.
+# Strip the 'b/' from git diffs.
+# Format only changed lines for each file, one file at a time.
+git diff -u --cached | \
+  tee "$tempdir"/git-cached.diff | \
+  awk -f "$diff_parser" | \
+  sed -e 's|^b/||' | \
+  tee "$tempdir"/file-lines.txt | \
+  while read filename lines
+  do
+    # Check file extension: skip non-Verilog files.
+    case "$filename" in
+      *.v | *.vh | *.sv | *.svh ) ;;
+      * ) continue ;;
+    esac
+
+    # If $lines is blank, that implies a new file (format entire file).
+    # Otherwise it is the argument to --lines.
+    lines_flag=()
+    [[ -z "$lines" ]] || lines_flag=("--lines=$lines")
+
+    # Format one file at a time.
+    format_command=("$formatter" --inplace "$filename" "${lines_flag[@]}" "${args[@]}")
+    verbose_command "${format_command[@]}"
+    # Ignore exit statuses and keep going.
+  done
+
+if [[ "$dry_run" = 0 ]]
+then
+  cat <<EOF
+[$script_name] Done formatting.  You could run:
+  'git status' to see what files were formatted.
+  'git diff' to see detailed formatting changes.
+  'git add -u' to accept formatting changes for commit.
+  'git diff | git apply --reverse -' to undo formatting changes.
+EOF
+else
+  msg "Stopping before formatting due to --dry-run."
+fi
+


### PR DESCRIPTION
Imported files from google/verible@598ba93

Add two script files to add into git-hook.
The script checks verilog files and re-format the code for diff portion
only.

If lintpy.py is installed to pre-commit hook, then remove the symlink
and add pre-commit script as below.

```sh
#!/bin/bash
REPO_TOP=`git rev-parse --show-toplevel`
$REPO_TOP/util/lintpy.py --commit
$REPO_TOP/util/lintpy.py --commit --tools flake8
$REPO_TOP/util/verible/git-verilog_format.sh
```

CC: @fangism