### PR TITLE
[dv/rv_timer] fix nighly regression failure

### DIFF
--- a/hw/ip/rv_timer/dv/env/rv_timer_scoreboard.sv
+++ b/hw/ip/rv_timer/dv/env/rv_timer_scoreboard.sv
@@ -93,12 +93,14 @@ class rv_timer_scoreboard extends cip_base_scoreboard #(.CFG_T (rv_timer_env_cfg
           for (int i = 0; i < NUM_HARTS; i++) begin
             timer_val[i][31:0] = get_reg_fld_mirror_value(
                                      ral, $sformatf("timer_v_lower%0d", i), "v");
+            num_clk_update_due[i] = 1'b1;
           end
         end
         (!uvm_re_match("timer_v_upper*", csr_name)): begin
           for (int i = 0; i < NUM_HARTS; i++) begin
             timer_val[i][63:32] = get_reg_fld_mirror_value(
                                       ral, $sformatf("timer_v_upper%0d", i), "v");
+            num_clk_update_due[i] = 1'b1;
           end
         end
         (!uvm_re_match("compare_lower*", csr_name)): begin

--- a/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_cfg_update_on_fly_vseq.sv
+++ b/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_cfg_update_on_fly_vseq.sv
@@ -30,6 +30,11 @@ class rv_timer_cfg_update_on_fly_vseq extends rv_timer_sanity_vseq;
     num_trans inside {[1:4]};
   }
 
+  function void pre_randomize();
+    super.pre_randomize();
+    max_clks_until_expiry = 1_000_000; // Redefining max clock to avoid timeout
+  endfunction
+
   task body();
     for (int trans = 1; trans <= num_trans; trans++) begin
       `uvm_info(`gfn, $sformatf("Running test iteration %0d/%0d", trans, num_trans), UVM_LOW)


### PR DESCRIPTION
1.Constraints the cfg settings to avoid timeout
2.Fix update timer_v on the fly, need to reset counter once the value is
updated

Signed-off-by: Cindy Chen <chencindy@google.com>