### PR TITLE
[spi_device] Remove latches

### DIFF
--- a/hw/ip/spi_device/rtl/spi_fwm_txf_ctrl.sv
+++ b/hw/ip/spi_device/rtl/spi_fwm_txf_ctrl.sv
@@ -84,6 +84,7 @@ module spi_fwm_txf_ctrl #(
   // State Machine next , output logic
   always_comb begin
     // default output value
+    st_next     = StIdle;
     sram_req_d  = 1'b0;
     update_rptr = 1'b0;
     latch_wptr  = 1'b0;
@@ -134,7 +135,7 @@ module spi_fwm_txf_ctrl #(
           fifo_valid = 1'b1;
           txf_sel = 1'b1; // select sram_rdata_q
           cnt_incr = 1'b1;
-        end else if (fifo_ready && cnt_eq_end) begin
+        end else begin //if (fifo_ready && cnt_eq_end) begin
           // current SRAM word is written to FIFO
           st_next = StUpdate;
         end


### PR DESCRIPTION
Problem:

    SPI TXF state machine has had latches inside.

The state machine is coded in a way based on the state machine table
described in the specification. The last part in `StPush` state is to
move to `StUpdate` based on the condition left over (fifo_ready &&
cnt_eq_end). Mistakenly, the condition is added as `else if`. It should
be `else` to eliminate the latches. The condition is matched to what
left over anyway.

The state machine is fixed to have `else` rather than `else if` now.

This is related to #2001
