### PR TITLE
[doc/rv_plic] add missing doc link

### DIFF
--- a/hw/ip/rv_plic/data/rv_plic.prj.hjson
+++ b/hw/ip/rv_plic/data/rv_plic.prj.hjson
@@ -4,6 +4,9 @@
 
 {
     name:               "rv_plic",
+    design_spec:        "hw/ip/rv_plic/doc",
+    dv_plan:            "hw/ip/rv_plic/doc/dv_plan",
+    hw_checklist:       "hw/ip/rv_plic/doc/checklist",
     revisions: [
       {
         version:            "0.5",


### PR DESCRIPTION
Add back rv_plic spec and DV documentation links

Signed-off-by: Cindy Chen <chencindy@google.com>