### PR TITLE
[topgen] Generate top clock groups variable

### DIFF
--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -10,20 +10,93 @@
   type: top
   datawidth: "32"
   clocks:
-  [
-    {
-      name: main
-      freq: "100000000"
-    }
-    {
-      name: fixed
-      freq: "100000000"
-    }
-    {
-      name: usb
-      freq: "48000000"
-    }
-  ]
+  {
+    srcs:
+    [
+      {
+        name: main
+        freq: "100000000"
+      }
+      {
+        name: fixed
+        freq: "100000000"
+      }
+      {
+        name: usb_48mhz
+        freq: "48000000"
+      }
+    ]
+    groups:
+    [
+      {
+        name: powerup
+        sw_cg: no
+        unique: no
+        clocks:
+        {
+          clk_fixed_powerup: fixed
+        }
+      }
+      {
+        name: trans
+        sw_cg: hint
+        unique: yes
+        clocks:
+        {
+          clk_main_aes: main
+          clk_main_hmac: main
+        }
+      }
+      {
+        name: infra
+        sw_cg: no
+        unique: no
+        clocks:
+        {
+          clk_main_infra: main
+          clk_fixed_infra: fixed
+        }
+      }
+      {
+        name: secure
+        sw_cg: no
+        unique: no
+        clocks:
+        {
+          clk_fixed_secure: fixed
+          clk_main_secure: main
+        }
+      }
+      {
+        name: peri
+        sw_cg: yes
+        unique: no
+        clocks:
+        {
+          clk_fixed_peri: fixed
+          clk_usb_48mhz_peri: usb_48mhz
+        }
+      }
+      {
+        name: timers
+        sw_cg: no
+        unique: no
+        clocks:
+        {
+          clk_fixed_timers: fixed
+        }
+      }
+      {
+        name: proc
+        sw_cg: no
+        unique: no
+        clocks:
+        {
+          clk_proc_main: main
+        }
+      }
+    ]
+  }
   resets:
   [
     {
@@ -65,7 +138,7 @@
     {
       name: uart
       type: uart
-      clock_connections:
+      clock_srcs:
       {
         clk_i: fixed
       }
@@ -195,14 +268,20 @@
       ]
       alert_list: []
       scan: "false"
+      clock_group: secure
+      clock_connections:
+      {
+        clk_i: clk_fixed_secure
+      }
     }
     {
       name: gpio
       type: gpio
-      clock_connections:
+      clock_srcs:
       {
         clk_i: fixed
       }
+      clock_group: peri
       reset_connections:
       {
         rst_ni: sys_fixed
@@ -238,14 +317,19 @@
       ]
       alert_list: []
       scan: "false"
+      clock_connections:
+      {
+        clk_i: clk_fixed_peri
+      }
     }
     {
       name: spi_device
       type: spi_device
-      clock_connections:
+      clock_srcs:
       {
         clk_i: fixed
       }
+      clock_group: peri
       reset_connections:
       {
         rst_ni: spi_device
@@ -358,14 +442,19 @@
       ]
       alert_list: []
       scan: "true"
+      clock_connections:
+      {
+        clk_i: clk_fixed_peri
+      }
     }
     {
       name: flash_ctrl
       type: flash_ctrl
-      clock_connections:
+      clock_srcs:
       {
         clk_i: main
       }
+      clock_group: infra
       reset_connections:
       {
         rst_ni: lc
@@ -468,14 +557,19 @@
           index: -1
         }
       ]
+      clock_connections:
+      {
+        clk_i: clk_main_infra
+      }
     }
     {
       name: rv_timer
       type: rv_timer
-      clock_connections:
+      clock_srcs:
       {
         clk_i: fixed
       }
+      clock_group: timers
       reset_connections:
       {
         rst_ni: sys_fixed
@@ -497,14 +591,19 @@
       ]
       alert_list: []
       scan: "false"
+      clock_connections:
+      {
+        clk_i: clk_fixed_timers
+      }
     }
     {
       name: aes
       type: aes
-      clock_connections:
+      clock_srcs:
       {
         clk_i: main
       }
+      clock_group: trans
       reset_connections:
       {
         rst_ni: sys
@@ -519,14 +618,19 @@
       interrupt_list: []
       alert_list: []
       scan: "false"
+      clock_connections:
+      {
+        clk_i: clk_main_aes
+      }
     }
     {
       name: hmac
       type: hmac
-      clock_connections:
+      clock_srcs:
       {
         clk_i: main
       }
+      clock_group: trans
       reset_connections:
       {
         rst_ni: sys
@@ -587,14 +691,19 @@
         }
       ]
       scan: "false"
+      clock_connections:
+      {
+        clk_i: clk_main_hmac
+      }
     }
     {
       name: rv_plic
       type: rv_plic
-      clock_connections:
+      clock_srcs:
       {
         clk_i: main
       }
+      clock_group: secure
       reset_connections:
       {
         rst_ni: sys
@@ -610,15 +719,20 @@
       interrupt_list: []
       alert_list: []
       scan: "false"
+      clock_connections:
+      {
+        clk_i: clk_main_secure
+      }
     }
     {
       name: pinmux
       type: pinmux
       clock: main
-      clock_connections:
+      clock_srcs:
       {
         clk_i: main
       }
+      clock_group: secure
       reset_connections:
       {
         rst_ni: sys
@@ -634,14 +748,19 @@
       interrupt_list: []
       alert_list: []
       scan: "false"
+      clock_connections:
+      {
+        clk_i: clk_main_secure
+      }
     }
     {
       name: alert_handler
       type: alert_handler
-      clock_connections:
+      clock_srcs:
       {
         clk_i: main
       }
+      clock_group: secure
       reset_connections:
       {
         rst_ni: sys
@@ -713,16 +832,21 @@
       ]
       alert_list: []
       scan: "false"
+      clock_connections:
+      {
+        clk_i: clk_main_secure
+      }
     }
     {
       name: pwrmgr
       type: pwrmgr
       clock: main
-      clock_connections:
+      clock_srcs:
       {
         clk_i: fixed
         clk_slow_i: fixed
       }
+      clock_group: powerup
       reset_connections:
       {
         rst_ni: sys_fixed
@@ -828,14 +952,20 @@
           index: -1
         }
       ]
+      clock_connections:
+      {
+        clk_i: clk_fixed_powerup
+        clk_slow_i: clk_fixed_powerup
+      }
     }
     {
       name: nmi_gen
       type: nmi_gen
-      clock_connections:
+      clock_srcs:
       {
         clk_i: main
       }
+      clock_group: secure
       reset_connections:
       {
         rst_ni: sys
@@ -900,15 +1030,20 @@
       ]
       alert_list: []
       scan: "false"
+      clock_connections:
+      {
+        clk_i: clk_main_secure
+      }
     }
     {
       name: usbdev
       type: usbdev
-      clock_connections:
+      clock_srcs:
       {
         clk_i: fixed
-        clk_usb_48mhz_i: usb
+        clk_usb_48mhz_i: usb_48mhz
       }
+      clock_group: peri
       reset_connections:
       {
         rst_ni: sys_fixed
@@ -1164,30 +1299,42 @@
       ]
       alert_list: []
       scan: "false"
+      clock_connections:
+      {
+        clk_i: clk_fixed_peri
+        clk_usb_48mhz_i: clk_usb_48mhz_peri
+      }
     }
   ]
   memory:
   [
     {
       name: rom
-      clock_connections:
+      clock_srcs:
       {
         clk_i: main
       }
+      clock_group: infra
       reset_connections:
       {
         rst_ni: sys
       }
       type: rom
       base_addr: 0x00008000
+      swaccess: ro
       size: 0x4000
+      clock_connections:
+      {
+        clk_i: clk_main_infra
+      }
     }
     {
       name: ram_main
-      clock_connections:
+      clock_srcs:
       {
         clk_i: main
       }
+      clock_group: infra
       reset_connections:
       {
         rst_ni: sys
@@ -1195,19 +1342,25 @@
       type: ram_1p
       base_addr: 0x10000000
       size: 0x10000
+      clock_connections:
+      {
+        clk_i: clk_main_infra
+      }
     }
     {
       name: eflash
-      clock_connections:
+      clock_srcs:
       {
         clk_i: main
       }
+      clock_group: infra
       reset_connections:
       {
         rst_ni: lc
       }
       type: eflash
       base_addr: 0x20000000
+      swaccess: ro
       size: 0x80000
       inter_signal_list:
       [
@@ -1223,6 +1376,10 @@
           index: -1
         }
       ]
+      clock_connections:
+      {
+        clk_i: clk_main_infra
+      }
     }
   ]
   inter_module:
@@ -1241,16 +1398,22 @@
   [
     {
       name: main
-      clock_connections:
+      clock_srcs:
       {
         clk_main_i: main
         clk_fixed_i: fixed
       }
+      clock_group: infra
       reset: rst_main_ni
       reset_connections:
       {
         rst_main_ni: sys
         rst_fixed_ni: sys_fixed
+      }
+      clock_connections:
+      {
+        clk_main_i: clk_main_infra
+        clk_fixed_i: clk_fixed_infra
       }
       connections:
       {
@@ -1549,14 +1712,19 @@
     }
     {
       name: peri
-      clock_connections:
+      clock_srcs:
       {
         clk_peri_i: fixed
       }
+      clock_group: infra
       reset: rst_peri_ni
       reset_connections:
       {
         rst_peri_ni: sys_fixed
+      }
+      clock_connections:
+      {
+        clk_peri_i: clk_fixed_infra
       }
       connections:
       {

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -8,11 +8,51 @@
 
   datawidth: "32",  # 32-bit datawidth
 
-  clocks: [
-    { name: "main", freq: "100000000" }
-    { name: "fixed", freq: "100000000" }
-    { name: "usb", freq: "48000000" }
-  ]
+  // This is the clock data strcture of the design.
+  // The src key indicates the raw clock sources in the design
+  // The groups key indicates the various clock groupings in the design
+  clocks: {
+
+    srcs: [
+      { name: "main",      freq: "100000000" }
+      { name: "fixed",     freq: "100000000" }
+      { name: "usb_48mhz", freq: "48000000" }
+    ],
+
+    // Clock Group attributes
+    // name: name of group.
+    //
+    // sw_cfg: whether software is allowed to gate the clock
+    // "no"   - software is not allowed to gate clocks
+    // "yes"  - software is allowed to gate clocks
+    // "hint" - software can provide a hint, and hw controls the rest
+    //
+    // unique: whether each module in the group can be separately gated
+    //         if sw_cfg is "no", this field has no meaning
+    // "yes"  - each clock is individually controlled
+    // "no"   - the group is controlled as one single unit
+    //
+    // The powerup and proc groups are unique.
+    // The powerup group of clocks do not need through the clock
+    // controller as they manage clock controller behavior
+    // The proc group is not peripheral, and direclty hardwired
+
+    groups: [
+      { name: "powerup", sw_cg: "no"                   }
+      { name: "trans",   sw_cg: "hint", unique: "yes", }
+      { name: "infra",   sw_cg: "no",                  }
+      { name: "secure",  sw_cg: "no"                   }
+      { name: "peri",    sw_cg: "yes",  unique: "no"   }
+      { name: "timers",  sw_cg: "no"                   }
+      { name: "proc",
+        sw_cg: "no"
+        unique: "no"
+        clocks: {
+          clk_proc_main: main
+        }
+      }
+    ],
+  }
 
   // Reset attributes
   // name: name of reset.
@@ -52,7 +92,7 @@
       // clock connections defines the port to top level clock connection
       // the ip.hjson will declare the clock port names
       // If none are defined at ip.hjson, clk_i is used by default
-      clock_connections: {clk_i: "fixed"},
+      clock_srcs: {clk_i: "fixed"},
 
       // reset connections defines the port to top level reset connection
       // the ip.hjson will declare the reset port names
@@ -63,44 +103,51 @@
     },
     { name: "gpio",
       type: "gpio",
-      clock_connections: {clk_i: "fixed"},
+      clock_srcs: {clk_i: "fixed"},
+      clock_group: "peri",
       reset_connections: {rst_ni: "sys_fixed"},
       base_addr: "0x40010000",
     }
 
     { name: "spi_device",
       type: "spi_device",
-      clock_connections: {clk_i: "fixed"},
+      clock_srcs: {clk_i: "fixed"},
+      clock_group: "peri",
       reset_connections: {rst_ni: "spi_device"},
       base_addr: "0x40020000",
     },
     { name: "flash_ctrl",
       type: "flash_ctrl",
-      clock_connections: {clk_i: "main"},
+      clock_srcs: {clk_i: "main"},
+      clock_group: "infra",
       reset_connections: {rst_ni: "lc"},
       base_addr: "0x40030000",
     },
     { name: "rv_timer",
       type: "rv_timer",
-      clock_connections: {clk_i: "fixed"},
+      clock_srcs: {clk_i: "fixed"},
+      clock_group: "timers",
       reset_connections: {rst_ni: "sys_fixed"},
       base_addr: "0x40080000",
     },
     { name: "aes",
       type: "aes",
-      clock_connections: {clk_i: "main"},
+      clock_srcs: {clk_i: "main"},
+      clock_group: "trans",
       reset_connections: {rst_ni: "sys"},
       base_addr: "0x40110000",
     },
     { name: "hmac",
       type: "hmac",
-      clock_connections: {clk_i: "main"},
+      clock_srcs: {clk_i: "main"},
+      clock_group: "trans",
       reset_connections: {rst_ni: "sys"},
       base_addr: "0x40120000",
     },
     { name: "rv_plic",
       type: "rv_plic",
-      clock_connections: {clk_i: "main"},
+      clock_srcs: {clk_i: "main"},
+      clock_group: "secure",
       reset_connections: {rst_ni: "sys"},
       base_addr: "0x40090000",
       generated: "true"         // Indicate this module is generated in the topgen
@@ -108,14 +155,16 @@
     { name: "pinmux",
       type: "pinmux",
       clock: "main",
-      clock_connections: {clk_i: "main"},
+      clock_srcs: {clk_i: "main"},
+      clock_group: "secure",
       reset_connections: {rst_ni: "sys"},
       base_addr: "0x40070000",
       generated: "true"
     },
     { name: "alert_handler",
       type: "alert_handler",
-      clock_connections: {clk_i: "main"},
+      clock_srcs: {clk_i: "main"},
+      clock_group: "secure",
       reset_connections: {rst_ni: "sys"},
       base_addr: "0x40130000",
       generated: "true"         // Indicate this module is generated in the topgen
@@ -128,7 +177,8 @@
     { name: "pwrmgr",
       type: "pwrmgr",
       clock: "main",
-      clock_connections: {clk_i: "fixed", clk_slow_i: "fixed"},
+      clock_srcs: {clk_i: "fixed", clk_slow_i: "fixed"},
+      clock_group: "powerup",
       reset_connections: {rst_ni: "sys_fixed", rst_slow_ni: "sys_fixed"},
       base_addr: "0x400A0000",
       generated: "true"
@@ -137,13 +187,15 @@
     // and test them by converting them into IRQs
     { name: "nmi_gen",
       type: "nmi_gen",
-      clock_connections: {clk_i: "main"},
+      clock_srcs: {clk_i: "main"},
+      clock_group: "secure",
       reset_connections: {rst_ni: "sys"},
       base_addr: "0x40140000",
     }
     { name: "usbdev",
       type: "usbdev",
-      clock_connections: {clk_i: "fixed", clk_usb_48mhz_i: "usb"},
+      clock_srcs: {clk_i: "fixed", clk_usb_48mhz_i: "usb_48mhz"},
+      clock_group: "peri",
       reset_connections: {rst_ni: "sys_fixed", rst_usb_48mhz_ni: "usb"},
       base_addr: "0x40150000",
     },
@@ -153,7 +205,8 @@
   // It utilizes the primitive cells but configurable
   memory: [
     { name: "rom",
-      clock_connections: {clk_i: "main"},
+      clock_srcs: {clk_i: "main"},
+      clock_group: "infra",
       reset_connections: {rst_ni: "sys"},
       type: "rom",
       base_addr: "0x00008000",
@@ -161,13 +214,15 @@
       size: "0x4000"
     },
     { name: "ram_main",
-      clock_connections: {clk_i: "main"},
+      clock_srcs: {clk_i: "main"},
+      clock_group: "infra",
       reset_connections: {rst_ni: "sys"},
       type: "ram_1p",
       base_addr: "0x10000000",
       size: "0x10000" },
     { name: "eflash",
-      clock_connections: {clk_i: "main"},
+      clock_srcs: {clk_i: "main"},
+      clock_group: "infra",
       reset_connections: {rst_ni: "lc"},
       type: "eflash",
       base_addr: "0x20000000",
@@ -210,12 +265,14 @@
   // Assume xbar.hjson is located in the same directory of top.hjson
   xbar: [
     { name: "main",
-      clock_connections: {clk_main_i: "main", clk_fixed_i: "fixed"},
+      clock_srcs: {clk_main_i: "main", clk_fixed_i: "fixed"},
+      clock_group: "infra",
       reset: "sys",
       reset_connections: {rst_main_ni: "sys", rst_fixed_ni: "sys_fixed"}
     },
     { name: "peri",
-      clock_connections: {clk_peri_i: "fixed"},
+      clock_srcs: {clk_peri_i: "fixed"},
+      clock_group: "infra",
       reset: "sys_fixed",
       reset_connections: {rst_peri_ni: "sys_fixed"},
     }

--- a/hw/top_earlgrey/ip/xbar_main/data/autogen/xbar_main.gen.hjson
+++ b/hw/top_earlgrey/ip/xbar_main/data/autogen/xbar_main.gen.hjson
@@ -8,16 +8,22 @@
 
 {
   name: main
-  clock_connections:
+  clock_srcs:
   {
     clk_main_i: main
     clk_fixed_i: fixed
   }
+  clock_group: infra
   reset: rst_main_ni
   reset_connections:
   {
     rst_main_ni: sys
     rst_fixed_ni: sys_fixed
+  }
+  clock_connections:
+  {
+    clk_main_i: clk_main_infra
+    clk_fixed_i: clk_fixed_infra
   }
   connections:
   {

--- a/hw/top_earlgrey/ip/xbar_peri/data/autogen/xbar_peri.gen.hjson
+++ b/hw/top_earlgrey/ip/xbar_peri/data/autogen/xbar_peri.gen.hjson
@@ -8,14 +8,19 @@
 
 {
   name: peri
-  clock_connections:
+  clock_srcs:
   {
     clk_peri_i: fixed
   }
+  clock_group: infra
   reset: rst_peri_ni
   reset_connections:
   {
     rst_peri_ni: sys_fixed
+  }
+  clock_connections:
+  {
+    clk_peri_i: clk_fixed_infra
   }
   connections:
   {

--- a/hw/top_earlgrey/rtl/top_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_asic.sv
@@ -62,7 +62,7 @@ module top_earlgrey_asic (
   top_earlgrey top_earlgrey (
     .clk_i                      (IO_CLK),
     .rst_ni                     (IO_RST_N),
-
+    .clk_fixed_i                (IO_CLK),
     .clk_usb_48mhz_i            (IO_CLK_USB_48MHZ),
 
     .jtag_tck_i                 (cio_jtag_tck_p2d),

--- a/hw/top_earlgrey/rtl/top_earlgrey_nexysvideo.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_nexysvideo.sv
@@ -64,7 +64,7 @@ module top_earlgrey_nexysvideo (
   ) top_earlgrey (
     .clk_i                      (clk_sys),
     .rst_ni                     (rst_sys_n),
-
+    .clk_fixed_i                (clk_sys),
     .clk_usb_48mhz_i            (clk_48mhz),
 
     .jtag_tck_i                 (cio_jtag_tck_p2d),

--- a/hw/top_earlgrey/rtl/top_earlgrey_verilator.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_verilator.sv
@@ -33,7 +33,7 @@ module top_earlgrey_verilator (
   top_earlgrey top_earlgrey (
     .clk_i                      (clk_i),
     .rst_ni                     (rst_ni),
-
+    .clk_fixed_i                (clk_i),
     .clk_usb_48mhz_i            (clk_i),
 
     .jtag_tck_i                 (cio_jtag_tck),

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.c
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.c
@@ -11,7 +11,7 @@
  * `top_earlgrey_plic_peripheral_t`.
  */
 const top_earlgrey_plic_peripheral_t
-    top_earlgrey_plic_interrupt_for_peripheral[80] = {
+    top_earlgrey_plic_interrupt_for_peripheral[81] = {
             [kTopEarlgreyPlicIrqIdNone] = kTopEarlgreyPlicPeripheralUnknown,
             [kTopEarlgreyPlicIrqIdGpioGpio0] = kTopEarlgreyPlicPeripheralGpio,
             [kTopEarlgreyPlicIrqIdGpioGpio1] = kTopEarlgreyPlicPeripheralGpio,
@@ -137,4 +137,6 @@ const top_earlgrey_plic_peripheral_t
                 kTopEarlgreyPlicPeripheralUsbdev,
             [kTopEarlgreyPlicIrqIdUsbdevConnected] =
                 kTopEarlgreyPlicPeripheralUsbdev,
+            [kTopEarlgreyPlicIrqIdPwrmgrWakeup] =
+                kTopEarlgreyPlicPeripheralPwrmgr,
 };

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -102,7 +102,8 @@ typedef enum top_earlgrey_plic_peripheral {
   kTopEarlgreyPlicPeripheralAlertHandler = 6, /**< alert_handler */
   kTopEarlgreyPlicPeripheralNmiGen = 7,       /**< nmi_gen */
   kTopEarlgreyPlicPeripheralUsbdev = 8,       /**< usbdev */
-  kTopEarlgreyPlicPeripheralLast = 8, /**< \internal Final PLIC peripheral */
+  kTopEarlgreyPlicPeripheralPwrmgr = 9,       /**< pwrmgr */
+  kTopEarlgreyPlicPeripheralLast = 9, /**< \internal Final PLIC peripheral */
 } top_earlgrey_plic_peripheral_t;
 
 /**
@@ -192,7 +193,8 @@ typedef enum top_earlgrey_plic_irq_id {
   kTopEarlgreyPlicIrqIdUsbdevRxBitstuffErr = 77,  /**< usbdev_rx_bitstuff_err */
   kTopEarlgreyPlicIrqIdUsbdevFrame = 78,          /**< usbdev_frame */
   kTopEarlgreyPlicIrqIdUsbdevConnected = 79,      /**< usbdev_connected */
-  kTopEarlgreyPlicIrqIdLast = 79, /**< \internal The Last Valid Interrupt ID. */
+  kTopEarlgreyPlicIrqIdPwrmgrWakeup = 80,         /**< pwrmgr_wakeup */
+  kTopEarlgreyPlicIrqIdLast = 80, /**< \internal The Last Valid Interrupt ID. */
 } top_earlgrey_plic_irq_id_t;
 
 /**
@@ -202,7 +204,7 @@ typedef enum top_earlgrey_plic_irq_id {
  * `top_earlgrey_plic_peripheral_t`.
  */
 extern const top_earlgrey_plic_peripheral_t
-    top_earlgrey_plic_interrupt_for_peripheral[80];
+    top_earlgrey_plic_interrupt_for_peripheral[81];
 
 /**
  * PLIC external interrupt target.

--- a/util/topgen/lib.py
+++ b/util/topgen/lib.py
@@ -220,6 +220,14 @@ def index(i: int) -> str:
     return "[{}]".format(i) if i != -1 else ""
 
 
+def get_clk_name(clk):
+    """Return the appropriate clk name
+    """
+    if clk == 'main':
+        return 'clk_i'
+    else:
+        return "clk_{}_i".format(clk)
+
 def get_reset_path(resets, name):
     """Return the appropriate reset path given name
     """


### PR DESCRIPTION
- clock_groups will eventually be fed to clock_controller for generation
- clock_groups walks through all modules, memories and xbars and associates
  the correct clock given the grouping and source attributes
- top_earlgrey.gen.hjson clock_connections looks very different from the
  original input

Signed-off-by: Timothy Chen <timothytim@google.com>