### PR TITLE
[ci] Temporarily disable risc-v compliance CI

### DIFF
--- a/ci/run-riscv-compliance.yml
+++ b/ci/run-riscv-compliance.yml
@@ -9,6 +9,9 @@ jobs:
     dependsOn:
       - top_earlgrey_verilator
       - sw_build
+    # The risc-v compliance suite is failing for a mysterious reason, disabling
+    # it for now whilst it is debugged see issue #2012
+    condition: false
     steps:
     - template: install-package-dependencies.yml
     - template: download-artifacts-template.yml


### PR DESCRIPTION
Disabling until #2012 is fixed.

It's something specific to the azure environment rather than an outright failure, may take some time to debug so best to disable it to allow other work to continue.

Signed-off-by: Greg Chadwick <gac@lowrisc.org>