### PR TITLE
[sw, dif_plic] Use enums instead of bools, and minor documentation changes

### DIFF
--- a/sw/device/lib/dif/dif_plic.c
+++ b/sw/device/lib/dif/dif_plic.c
@@ -193,24 +193,25 @@ static void plic_reset(const dif_plic_t *plic) {
   mmio_region_write32(plic->base_addr, RV_PLIC_MSIP0_REG_OFFSET, 0);
 }
 
-bool dif_plic_init(mmio_region_t base_addr, dif_plic_t *plic) {
+dif_plic_result_t dif_plic_init(mmio_region_t base_addr, dif_plic_t *plic) {
   if (plic == NULL) {
-    return false;
+    return kDifPlicBadArg;
   }
 
   plic->base_addr = base_addr;
 
   plic_reset(plic);
 
-  return true;
+  return kDifPlicOk;
 }
 
-bool dif_plic_irq_enable_set(const dif_plic_t *plic, dif_plic_irq_id_t irq,
-                             dif_plic_target_t target,
-                             dif_plic_enable_t enable) {
+dif_plic_result_t dif_plic_irq_enable_set(const dif_plic_t *plic,
+                                          dif_plic_irq_id_t irq,
+                                          dif_plic_target_t target,
+                                          dif_plic_enable_t enable) {
   if (plic == NULL || irq >= RV_PLIC_PARAM_NUMSRC ||
       target >= RV_PLIC_PARAM_NUMTARGET) {
-    return false;
+    return kDifPlicBadArg;
   }
 
   // Get a target and an IRQ source specific Interrupt Enable register info.
@@ -225,14 +226,14 @@ bool dif_plic_irq_enable_set(const dif_plic_t *plic, dif_plic_irq_id_t irq,
                                       reg_info.bit_index);
   }
 
-  return true;
+  return kDifPlicOk;
 }
 
-bool dif_plic_irq_trigger_type_set(const dif_plic_t *plic,
-                                   dif_plic_irq_id_t irq,
-                                   dif_plic_enable_t enable) {
+dif_plic_result_t dif_plic_irq_trigger_type_set(const dif_plic_t *plic,
+                                                dif_plic_irq_id_t irq,
+                                                dif_plic_enable_t enable) {
   if (plic == NULL || irq >= RV_PLIC_PARAM_NUMSRC) {
-    return false;
+    return kDifPlicBadArg;
   }
 
   // Get an IRQ source specific Level/Edge register info.
@@ -247,41 +248,42 @@ bool dif_plic_irq_trigger_type_set(const dif_plic_t *plic,
                                       reg_info.bit_index);
   }
 
-  return true;
+  return kDifPlicOk;
 }
 
-bool dif_plic_irq_priority_set(const dif_plic_t *plic, dif_plic_irq_id_t irq,
-                               uint32_t priority) {
+dif_plic_result_t dif_plic_irq_priority_set(const dif_plic_t *plic,
+                                            dif_plic_irq_id_t irq,
+                                            uint32_t priority) {
   if (plic == NULL || irq >= RV_PLIC_PARAM_NUMSRC ||
       priority > RV_PLIC_MAX_PRIORITY) {
-    return false;
+    return kDifPlicBadArg;
   }
 
   ptrdiff_t offset = plic_priority_reg_offset(irq);
   mmio_region_write32(plic->base_addr, offset, priority);
 
-  return true;
+  return kDifPlicOk;
 }
 
-bool dif_plic_target_threshold_set(const dif_plic_t *plic,
-                                   dif_plic_target_t target,
-                                   uint32_t threshold) {
+dif_plic_result_t dif_plic_target_threshold_set(const dif_plic_t *plic,
+                                                dif_plic_target_t target,
+                                                uint32_t threshold) {
   if (plic == NULL || target >= RV_PLIC_PARAM_NUMTARGET ||
       threshold > RV_PLIC_MAX_PRIORITY) {
-    return false;
+    return kDifPlicBadArg;
   }
 
   ptrdiff_t threshold_offset = plic_target_reg_offsets[target].threshold;
   mmio_region_write32(plic->base_addr, threshold_offset, threshold);
 
-  return true;
+  return kDifPlicOk;
 }
 
-bool dif_plic_irq_pending_status_get(const dif_plic_t *plic,
-                                     dif_plic_irq_id_t irq,
-                                     dif_plic_flag_t *status) {
+dif_plic_result_t dif_plic_irq_pending_status_get(const dif_plic_t *plic,
+                                                  dif_plic_irq_id_t irq,
+                                                  dif_plic_flag_t *status) {
   if (plic == NULL || irq >= RV_PLIC_PARAM_NUMSRC || status == NULL) {
-    return false;
+    return kDifPlicBadArg;
   }
 
   plic_reg_info_t reg_info;
@@ -294,13 +296,14 @@ bool dif_plic_irq_pending_status_get(const dif_plic_t *plic,
     *status = kDifPlicUnset;
   }
 
-  return true;
+  return kDifPlicOk;
 }
 
-bool dif_plic_irq_claim(const dif_plic_t *plic, dif_plic_target_t target,
-                        dif_plic_irq_id_t *claim_data) {
+dif_plic_result_t dif_plic_irq_claim(const dif_plic_t *plic,
+                                     dif_plic_target_t target,
+                                     dif_plic_irq_id_t *claim_data) {
   if (plic == NULL || target >= RV_PLIC_PARAM_NUMTARGET || claim_data == NULL) {
-    return false;
+    return kDifPlicBadArg;
   }
 
   // Get an IRQ ID from the target specific CC register.
@@ -309,14 +312,15 @@ bool dif_plic_irq_claim(const dif_plic_t *plic, dif_plic_target_t target,
 
   // Return the IRQ ID directly.
   *claim_data = irq_id;
-  return true;
+  return kDifPlicOk;
 }
 
-bool dif_plic_irq_complete(const dif_plic_t *plic, dif_plic_target_t target,
-                           const dif_plic_irq_id_t *complete_data) {
+dif_plic_result_t dif_plic_irq_complete(
+    const dif_plic_t *plic, dif_plic_target_t target,
+    const dif_plic_irq_id_t *complete_data) {
   if (plic == NULL || target >= RV_PLIC_PARAM_NUMTARGET ||
       complete_data == NULL) {
-    return false;
+    return kDifPlicBadArg;
   }
 
   // Write back the claimed IRQ ID to the target specific CC register,
@@ -324,5 +328,5 @@ bool dif_plic_irq_complete(const dif_plic_t *plic, dif_plic_target_t target,
   ptrdiff_t cc_offset = plic_target_reg_offsets[target].cc;
   mmio_region_write32(plic->base_addr, cc_offset, (uint32_t)*complete_data);
 
-  return true;
+  return kDifPlicOk;
 }

--- a/sw/device/lib/dif/dif_plic.h
+++ b/sw/device/lib/dif/dif_plic.h
@@ -61,7 +61,7 @@ typedef enum dif_plic_flag {
  * PLIC persistent data that is required by all the PLIC API.
  */
 typedef struct dif_plic {
-  mmio_region_t base_addr; /**< PLIC instance base address */
+  mmio_region_t base_addr; /**< PLIC instance base address. */
 } dif_plic_t;
 
 /**
@@ -83,8 +83,8 @@ typedef enum dif_plic_result {
  * Information that must be retained, and is required to program PLIC, shall
  * be stored in @p plic.
  *
- * @param base_addr Base address of an instance of the PLIC IP block
- * @param plic PLIC state data
+ * @param base_addr Base address of an instance of the PLIC IP block.
+ * @param plic PLIC state data.
  * @return `dif_plic_result_t`.
  */
 dif_plic_result_t dif_plic_init(mmio_region_t base_addr, dif_plic_t *plic);
@@ -94,10 +94,10 @@ dif_plic_result_t dif_plic_init(mmio_region_t base_addr, dif_plic_t *plic);
  *
  * This operation does not affect the IRQ generation in the peripherals, which
  * must be configured in a corresponding peripheral itself.
- * @param plic PLIC state data
- * @param irq Interrupt Source ID
- * @param target Target to enable the IRQ for
- * @param enable Enable/disable the IRQ handling
+ * @param plic PLIC state data.
+ * @param irq Interrupt Source ID.
+ * @param target Target to enable the IRQ for.
+ * @param enable Enable/disable the IRQ handling.
  * @return `dif_plic_result_t`.
  */
 dif_plic_result_t dif_plic_irq_enable_set(const dif_plic_t *plic,
@@ -110,10 +110,11 @@ dif_plic_result_t dif_plic_irq_enable_set(const dif_plic_t *plic,
  *
  * Sets the behaviour of the Interrupt Gateway for a particular IRQ to be edge
  * or level triggered.
- * @param plic PLIC state data
- * @param irq Interrupt source ID
- * @param enable Enable for the edge triggered, disable for level triggered IRQs
- * @return `dif_plic_result_t`
+ * @param plic PLIC state data.
+ * @param irq Interrupt source ID.
+ * @param enable Enable for the edge triggered, disable for level triggered
+ * IRQs.
+ * @return `dif_plic_result_t`.
  */
 dif_plic_result_t dif_plic_irq_trigger_type_set(const dif_plic_t *plic,
                                                 dif_plic_irq_id_t irq,
@@ -125,9 +126,9 @@ dif_plic_result_t dif_plic_irq_trigger_type_set(const dif_plic_t *plic,
  * In order for PLIC to set a CC register and assert the external interrupt line
  * to the target (Ibex, ...), the priority of an IRQ source must be higher than
  * the threshold for this source.
- * @param plic PLIC state data
- * @param irq Interrupt source ID
- * @param priority Priority to be set
+ * @param plic PLIC state data.
+ * @param irq Interrupt source ID.
+ * @param priority Priority to be set.
  * @return `dif_plic_result_t`.
  */
 dif_plic_result_t dif_plic_irq_priority_set(const dif_plic_t *plic,
@@ -140,9 +141,9 @@ dif_plic_result_t dif_plic_irq_priority_set(const dif_plic_t *plic,
  * Sets the target priority threshold. PLIC will only interrupt a target when
  * IRQ source priority is set higher than the priority threshold for the
  * corresponding target.
- * @param plic PLIC state data
- * @param target Target to set the IRQ priority threshold for
- * @param threshold IRQ priority threshold to be set
+ * @param plic PLIC state data.
+ * @param target Target to set the IRQ priority threshold for.
+ * @param threshold IRQ priority threshold to be set.
  * @return `dif_plic_result_t`.
  */
 dif_plic_result_t dif_plic_target_threshold_set(const dif_plic_t *plic,
@@ -154,9 +155,9 @@ dif_plic_result_t dif_plic_target_threshold_set(const dif_plic_t *plic,
  *
  * Gets the status of the PLIC Interrupt Pending register bit for a specific IRQ
  * source.
- * @param plic PLIC state data
- * @param irq Interrupt source ID
- * @param status Flag indicating whether the IRQ pending bit is set in PLIC
+ * @param plic PLIC state data.
+ * @param irq Interrupt source ID.
+ * @param status Flag indicating whether the IRQ pending bit is set in PLIC.
  * @return `dif_plic_result_t`.
  */
 dif_plic_result_t dif_plic_irq_pending_status_get(const dif_plic_t *plic,
@@ -170,8 +171,8 @@ dif_plic_result_t dif_plic_irq_pending_status_get(const dif_plic_t *plic,
  * reads a target specific CC register. dif_plic_irq_complete must be called
  * after the claimed IRQ has been serviced.
  *
- * @param plic PLIC state data
- * @param target Target that claimed the IRQ
+ * @param plic PLIC state data.
+ * @param target Target that claimed the IRQ.
  * @param claim_data Data that describes the origin of the IRQ.
  * @return `dif_plic_result_t`.
  */
@@ -186,8 +187,8 @@ dif_plic_result_t dif_plic_irq_claim(const dif_plic_t *plic,
  * target specific CC register. This function must be called after
  * dif_plic_claim_irq, when a caller has finished servicing the IRQ.
  *
- * @param plic PLIC state data
- * @param target Target that claimed the IRQ
+ * @param plic PLIC state data.
+ * @param target Target that claimed the IRQ.
  * @param complete_data Previously claimed IRQ data that is used to signal PLIC
  *                      of the IRQ servicing completion.
  * @return `dif_plic_result_t`.

--- a/sw/device/lib/dif/dif_plic.h
+++ b/sw/device/lib/dif/dif_plic.h
@@ -81,7 +81,7 @@ typedef enum dif_plic_result {
  * Initialises an instance of PLIC.
  *
  * Information that must be retained, and is required to program PLIC, shall
- * be stored in @p plic.
+ * be stored in `plic`.
  *
  * @param base_addr Base address of an instance of the PLIC IP block.
  * @param plic PLIC state data.

--- a/sw/device/lib/dif/dif_plic.h
+++ b/sw/device/lib/dif/dif_plic.h
@@ -65,6 +65,19 @@ typedef struct dif_plic {
 } dif_plic_t;
 
 /**
+ * PLIC generic status codes.
+ *
+ * These error codes can be used by any function. However if a function
+ * requires additional status codes, it must define a set of status codes to
+ * be used exclusicvely by such function.
+ */
+typedef enum dif_plic_result {
+  kDifPlicOk = 0, /**< Success. */
+  kDifPlicError,  /**< General error. */
+  kDifPlicBadArg, /**< Input parameter is not valid. */
+} dif_plic_result_t;
+
+/**
  * Initialises an instance of PLIC.
  *
  * Information that must be retained, and is required to program PLIC, shall
@@ -72,9 +85,9 @@ typedef struct dif_plic {
  *
  * @param base_addr Base address of an instance of the PLIC IP block
  * @param plic PLIC state data
- * @return true if the function was successful, false otherwise
+ * @return `dif_plic_result_t`.
  */
-bool dif_plic_init(mmio_region_t base_addr, dif_plic_t *plic);
+dif_plic_result_t dif_plic_init(mmio_region_t base_addr, dif_plic_t *plic);
 
 /**
  * Enables/disables handling of IRQ source in PLIC.
@@ -85,11 +98,12 @@ bool dif_plic_init(mmio_region_t base_addr, dif_plic_t *plic);
  * @param irq Interrupt Source ID
  * @param target Target to enable the IRQ for
  * @param enable Enable/disable the IRQ handling
- * @return true if the function was successful, false otherwise
+ * @return `dif_plic_result_t`.
  */
-bool dif_plic_irq_enable_set(const dif_plic_t *plic, dif_plic_irq_id_t irq,
-                             dif_plic_target_t target,
-                             dif_plic_enable_t enable);
+dif_plic_result_t dif_plic_irq_enable_set(const dif_plic_t *plic,
+                                          dif_plic_irq_id_t irq,
+                                          dif_plic_target_t target,
+                                          dif_plic_enable_t enable);
 
 /**
  * Sets the IRQ trigger type (edge/level).
@@ -99,11 +113,11 @@ bool dif_plic_irq_enable_set(const dif_plic_t *plic, dif_plic_irq_id_t irq,
  * @param plic PLIC state data
  * @param irq Interrupt source ID
  * @param enable Enable for the edge triggered, disable for level triggered IRQs
- * @return true if the function was successful, false otherwise
+ * @return `dif_plic_result_t`
  */
-bool dif_plic_irq_trigger_type_set(const dif_plic_t *plic,
-                                   dif_plic_irq_id_t irq,
-                                   dif_plic_enable_t enable);
+dif_plic_result_t dif_plic_irq_trigger_type_set(const dif_plic_t *plic,
+                                                dif_plic_irq_id_t irq,
+                                                dif_plic_enable_t enable);
 
 /**
  * Sets IRQ source priority (0-3).
@@ -114,10 +128,11 @@ bool dif_plic_irq_trigger_type_set(const dif_plic_t *plic,
  * @param plic PLIC state data
  * @param irq Interrupt source ID
  * @param priority Priority to be set
- * @return true if the function was successful, false otherwise
+ * @return `dif_plic_result_t`.
  */
-bool dif_plic_irq_priority_set(const dif_plic_t *plic, dif_plic_irq_id_t irq,
-                               uint32_t priority);
+dif_plic_result_t dif_plic_irq_priority_set(const dif_plic_t *plic,
+                                            dif_plic_irq_id_t irq,
+                                            uint32_t priority);
 
 /**
  * Sets the target priority threshold.
@@ -128,11 +143,11 @@ bool dif_plic_irq_priority_set(const dif_plic_t *plic, dif_plic_irq_id_t irq,
  * @param plic PLIC state data
  * @param target Target to set the IRQ priority threshold for
  * @param threshold IRQ priority threshold to be set
- * @return true if the function was successful, false otherwise
+ * @return `dif_plic_result_t`.
  */
-bool dif_plic_target_threshold_set(const dif_plic_t *plic,
-                                   dif_plic_target_t target,
-                                   uint32_t threshold);
+dif_plic_result_t dif_plic_target_threshold_set(const dif_plic_t *plic,
+                                                dif_plic_target_t target,
+                                                uint32_t threshold);
 
 /**
  * Checks the Interrupt Pending bit.
@@ -142,11 +157,11 @@ bool dif_plic_target_threshold_set(const dif_plic_t *plic,
  * @param plic PLIC state data
  * @param irq Interrupt source ID
  * @param status Flag indicating whether the IRQ pending bit is set in PLIC
- * @return true if the function was successful, false otherwise
+ * @return `dif_plic_result_t`.
  */
-bool dif_plic_irq_pending_status_get(const dif_plic_t *plic,
-                                     dif_plic_irq_id_t irq,
-                                     dif_plic_flag_t *status);
+dif_plic_result_t dif_plic_irq_pending_status_get(const dif_plic_t *plic,
+                                                  dif_plic_irq_id_t irq,
+                                                  dif_plic_flag_t *status);
 
 /**
  * Claims an IRQ and gets the information about the source.
@@ -158,10 +173,11 @@ bool dif_plic_irq_pending_status_get(const dif_plic_t *plic,
  * @param plic PLIC state data
  * @param target Target that claimed the IRQ
  * @param claim_data Data that describes the origin of the IRQ.
- * @return true if the function was successful, false otherwise
+ * @return `dif_plic_result_t`.
  */
-bool dif_plic_irq_claim(const dif_plic_t *plic, dif_plic_target_t target,
-                        dif_plic_irq_id_t *claim_data);
+dif_plic_result_t dif_plic_irq_claim(const dif_plic_t *plic,
+                                     dif_plic_target_t target,
+                                     dif_plic_irq_id_t *claim_data);
 
 /**
  * Completes the claimed IRQ.
@@ -174,9 +190,10 @@ bool dif_plic_irq_claim(const dif_plic_t *plic, dif_plic_target_t target,
  * @param target Target that claimed the IRQ
  * @param complete_data Previously claimed IRQ data that is used to signal PLIC
  *                      of the IRQ servicing completion.
- * @return true if the function was successful, false otherwise
+ * @return `dif_plic_result_t`.
  */
-bool dif_plic_irq_complete(const dif_plic_t *plic, dif_plic_target_t target,
-                           const dif_plic_irq_id_t *complete_data);
+dif_plic_result_t dif_plic_irq_complete(const dif_plic_t *plic,
+                                        dif_plic_target_t target,
+                                        const dif_plic_irq_id_t *complete_data);
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_DIF_DIF_PLIC_H_

--- a/sw/device/tests/consecutive_irqs_test.c
+++ b/sw/device/tests/consecutive_irqs_test.c
@@ -88,7 +88,7 @@ static void handle_uart_isr(const dif_plic_irq_id_t interrupt_id) {
 void handler_irq_external(void) {
   // Claim the IRQ by reading the Ibex specific CC register.
   dif_plic_irq_id_t interrupt_id;
-  if (!dif_plic_irq_claim(&plic0, PLIC_TARGET, &interrupt_id)) {
+  if (dif_plic_irq_claim(&plic0, PLIC_TARGET, &interrupt_id) != kDifPlicOk) {
     LOG_FATAL_AND_ABORT("ISR is not implemented!");
   }
 
@@ -102,7 +102,7 @@ void handler_irq_external(void) {
 
   // Complete the IRQ by writing the IRQ source to the Ibex specific CC
   // register.
-  if (!dif_plic_irq_complete(&plic0, PLIC_TARGET, &interrupt_id)) {
+  if (dif_plic_irq_complete(&plic0, PLIC_TARGET, &interrupt_id) != kDifPlicOk) {
     LOG_FATAL_AND_ABORT("Unable to complete the IRQ request!");
   }
 }
@@ -122,7 +122,7 @@ static void uart_initialise(mmio_region_t base_addr, dif_uart_t *uart) {
 }
 
 static void plic_initialise(mmio_region_t base_addr, dif_plic_t *plic) {
-  if (!dif_plic_init(base_addr, plic)) {
+  if (dif_plic_init(base_addr, plic) != kDifPlicOk) {
     LOG_FATAL_AND_ABORT("PLIC init failed!");
   }
 }
@@ -150,43 +150,45 @@ static bool uart_configure_irqs(dif_uart_t *uart) {
  */
 static bool plic_configure_irqs(dif_plic_t *plic) {
   // Set IRQ triggers to be level triggered
-  if (!dif_plic_irq_trigger_type_set(plic, kTopEarlgreyPlicIrqIdUartRxOverflow,
-                                     kDifPlicDisable)) {
+  if (dif_plic_irq_trigger_type_set(plic, kTopEarlgreyPlicIrqIdUartRxOverflow,
+                                    kDifPlicDisable) != kDifPlicOk) {
     LOG_ERROR("RX overflow trigger type set failed!");
     return false;
   }
-  if (!dif_plic_irq_trigger_type_set(plic, kTopEarlgreyPlicIrqIdUartTxEmpty,
-                                     kDifPlicDisable)) {
+  if (dif_plic_irq_trigger_type_set(plic, kTopEarlgreyPlicIrqIdUartTxEmpty,
+                                    kDifPlicDisable) != kDifPlicOk) {
     LOG_ERROR("TX empty trigger type set failed!");
     return false;
   }
 
   // Set IRQ priorities to MAX
-  if (!dif_plic_irq_priority_set(plic, kTopEarlgreyPlicIrqIdUartRxOverflow,
-                                 PLIC_PRIORITY_MAX)) {
+  if (dif_plic_irq_priority_set(plic, kTopEarlgreyPlicIrqIdUartRxOverflow,
+                                PLIC_PRIORITY_MAX) != kDifPlicOk) {
     LOG_ERROR("priority set for RX overflow failed!");
     return false;
   }
-  if (!dif_plic_irq_priority_set(plic, kTopEarlgreyPlicIrqIdUartTxEmpty,
-                                 PLIC_PRIORITY_MAX)) {
+
+  if (dif_plic_irq_priority_set(plic, kTopEarlgreyPlicIrqIdUartTxEmpty,
+                                PLIC_PRIORITY_MAX) != kDifPlicOk) {
     LOG_ERROR("priority set for TX empty failed!");
     return false;
   }
 
   // Set Ibex IRQ priority threshold level
-  if (!dif_plic_target_threshold_set(&plic0, PLIC_TARGET, PLIC_PRIORITY_MIN)) {
+  if (dif_plic_target_threshold_set(&plic0, PLIC_TARGET, PLIC_PRIORITY_MIN) !=
+      kDifPlicOk) {
     LOG_ERROR("threshold set failed!");
     return false;
   }
 
   // Enable IRQs in PLIC
-  if (!dif_plic_irq_enable_set(plic, kTopEarlgreyPlicIrqIdUartRxOverflow,
-                               PLIC_TARGET, kDifPlicEnable)) {
+  if (dif_plic_irq_enable_set(plic, kTopEarlgreyPlicIrqIdUartRxOverflow,
+                              PLIC_TARGET, kDifPlicEnable) != kDifPlicOk) {
     LOG_ERROR("interrupt Enable for RX overflow failed!");
     return false;
   }
-  if (!dif_plic_irq_enable_set(plic, kTopEarlgreyPlicIrqIdUartTxEmpty,
-                               PLIC_TARGET, kDifPlicEnable)) {
+  if (dif_plic_irq_enable_set(plic, kTopEarlgreyPlicIrqIdUartTxEmpty,
+                              PLIC_TARGET, kDifPlicEnable) != kDifPlicOk) {
     LOG_ERROR("interrupt Enable for TX empty failed!");
     return false;
   }


### PR DESCRIPTION
Three part PR:
* Use enum error codes instead of booleans.
* Add full stop at the end of every comment in the header file for consistency.
* Substitute '@p' for backticks '`'