### PR TITLE
[CI] Use packaged Verilator

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -164,7 +164,8 @@ jobs:
   displayName: Build Verilator simulation of the Earl Grey toplevel design
   dependsOn: lint
   condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'))
-  pool: Default
+  pool:
+    vmImage: ubuntu-16.04
   steps:
   - template: ci/install-package-dependencies.yml
   - bash: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,7 @@
 # Documentation at https://aka.ms/yaml
 
 variables:
-  VERILATOR_VERSION: 4.028
+  VERILATOR_VERSION: 4.032
   VERILATOR_PATH: /opt/buildcache/verilator/$(VERILATOR_VERSION)
   TOOLCHAIN_PATH: /opt/buildcache/riscv
   # Release tag from https://github.com/lowRISC/lowrisc-toolchains/releases

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,6 @@
 
 variables:
   VERILATOR_VERSION: 4.032
-  VERILATOR_PATH: /opt/buildcache/verilator/$(VERILATOR_VERSION)
   TOOLCHAIN_PATH: /opt/buildcache/riscv
   # Release tag from https://github.com/lowRISC/lowrisc-toolchains/releases
   TOOLCHAIN_VERSION: 20191010-1
@@ -169,27 +168,6 @@ jobs:
   steps:
   - template: ci/install-package-dependencies.yml
   - bash: |
-      set -e
-      if [[ ! -d "$(VERILATOR_PATH)" ]]; then
-        echo "Building verilator (no cached build found)"
-
-        mkdir -p build/verilator
-        cd build/verilator
-        curl -Ls -o verilator.tgz \
-          "https://www.veripool.org/ftp/verilator-$(VERILATOR_VERSION).tgz"
-        tar -xf verilator.tgz
-
-        cd "verilator-$(VERILATOR_VERSION)"
-        ./configure --prefix="$(VERILATOR_PATH)"
-        make -j$(nproc)
-        mkdir -p "$VERILATOR_PATH"
-        make install
-      else
-        echo "Re-using cached verilator build"
-      fi
-    displayName: Build and install Verilator
-  - bash: |
-      export PATH="$VERILATOR_PATH/bin:$PATH"
       python3 --version
       fusesoc --version
       verilator --version
@@ -199,7 +177,6 @@ jobs:
       mkdir -p "$OBJ_DIR/hw"
       mkdir -p "$BIN_DIR/hw/top_earlgrey"
 
-      export PATH="$VERILATOR_PATH/bin:$PATH"
       fusesoc --cores-root=. \
         run --target=sim --setup --build \
         --build-root="$OBJ_DIR/hw" \

--- a/ci/install-package-dependencies.yml
+++ b/ci/install-package-dependencies.yml
@@ -33,12 +33,24 @@ steps:
 
       cd "${{ parameters.REPO_TOP }}"
 
+      # Install verilator from experimental OBS repository
+      # apt-requirements.txt doesn't cover this dependency as we don't support
+      # using the repository below for anything but our CI (yet).
+      EDATOOLS_REPO_KEY="https://download.opensuse.org/repositories/home:phiwag:edatools/xUbuntu_16.04/Release.key"
+      EDATOOLS_REPO="deb http://download.opensuse.org/repositories/home:/phiwag:/edatools/xUbuntu_16.04/ /"
+      curl -sL "$EDATOOLS_REPO_KEY" | sudo apt-key add -
+      sudo sh -c "echo \"$EDATOOLS_REPO\" > /etc/apt/sources.list.d/edatools.list"
+
+      cp apt-requirements.txt apt-requirements-ci.txt
+      echo "verilator-$(VERILATOR_VERSION)" >> apt-requirements-ci.txt
+      cat apt-requirements-ci.txt
+
       # Ensure apt package index is up-to-date.
       sudo $APT_CMD update
 
       # NOTE: We use sed to remove all comments from apt-requirements.txt,
       # since apt-get/apt-fast doesn't actually provide such a feature.
-      sed 's/#.*//' apt-requirements.txt \
+      sed 's/#.*//' apt-requirements-ci.txt \
         | xargs sudo $APT_CMD install -y
 
       # Python requirements are installed to the local user directory so prepend


### PR DESCRIPTION
The Verilator package is provided by an experimental repository from Open
Build Service (OBS), which is maintained by me. The repository differs from
"traditional" distribution repositories, as it provides multiple versioned
packages (e.g. verilator-4.032), as opposed to only a single version. This
allows CI to choose and pin exactly one version, without having to follow
the latest releases.

All of this infrastructure is currently experimental and not supported 
anywhere except for the use in CI. If it proves to be successful, we can 
think about expanding its scope towards end-users as well.

This change allows us to move our Verilator builds to cloud infrastructure, freeing our in-house builder for Vivado tasks.