### PR TITLE
[test] Dump temp files in log for pytest runs

### DIFF
--- a/test/systemtest/conftest.py
+++ b/test/systemtest/conftest.py
@@ -35,17 +35,17 @@ def pytest_exception_interact(node, call, report):
         return
 
     tmp_path = str(node.funcargs['tmp_path'])
-    print("\n\n")
-    print("================= DUMP OF ALL TEMPORARY FILES =================")
+    logging.debug("================= DUMP OF ALL TEMPORARY FILES =================")
 
     for f in os.listdir(tmp_path):
         f_abs = os.path.join(tmp_path, f)
         if not os.path.isfile(f_abs):
             continue
-        print("vvvvvvvvvvvvvvvvvvvv {} vvvvvvvvvvvvvvvvvvvv".format(f))
+        logging.debug("vvvvvvvvvvvvvvvvvvvv {} vvvvvvvvvvvvvvvvvvvv".format(f))
         with open(f_abs, 'r') as fp:
-            print(fp.read())
-        print("^^^^^^^^^^^^^^^^^^^^ {} ^^^^^^^^^^^^^^^^^^^^\n\n".format(f))
+            for line in fp.readlines():
+                logging.debug(line.rstrip())
+        logging.debug("^^^^^^^^^^^^^^^^^^^^ {} ^^^^^^^^^^^^^^^^^^^^".format(f))
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
This is handy for when we're using parallel runs in RISC-V conformance
CI. When its output to the log its gets a testname prepended so when a
failure is seen it's easier to work out where the temp file dump is
coming from.