### PR TITLE
[sw] Adds @lenary to SW Codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -53,7 +53,7 @@ formal/             @cindychip
 # lint/             # TBD
 
 # SW related
-/sw/                @mcy @moidx @gkelly @sriyerg
+/sw/                @mcy @moidx @gkelly @sriyerg @lenary
 
 # Common docs
 /doc/               @sjgitty @asb


### PR DESCRIPTION
I have almost missed some software-related PRs recently. This ensures I will not miss any in future.