### PR TITLE
[aes/dv/aes_model_dpi] Add DPI call to encrypt/decrypt entire messages

### DIFF
--- a/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi.h
+++ b/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef _AES_MODEL_DPI_H_
-#define _AES_MODEL_DPI_H_
+#ifndef OPENTITAN_HW_IP_AES_DV_AES_MODEL_DPI_AES_MODEL_DPI_H_
+#define OPENTITAN_HW_IP_AES_DV_AES_MODEL_DPI_AES_MODEL_DPI_H_
 
 #include "svdpi.h"
 
@@ -19,14 +19,35 @@ extern "C" {
  * @param  mode_i    Cipher mode: 3'b001 = ECB, 3'b010 = CBC, 3'b100 = CTR
  * @param  iv_i      Initialization vector: 2D matrix (3D packed array in SV)
  * @param  key_len_i Key length: 3'b001 = 128b, 3'b010 = 192b, 3'b100 = 256b
- * @param  key_i     Full input key
+ * @param  key_i     Full input key, 1D array of words (2D packed array in SV)
  * @param  data_i    Input data, 2D state matrix (3D packed array in SV)
  * @param  data_o    Output data, 2D state matrix (3D packed array in SV)
  */
-void c_dpi_aes_crypt(const unsigned char impl_i, const unsigned char op_i,
-                     const svBitVecVal *mode_i, const svBitVecVal *iv_i,
-                     const svBitVecVal *key_len_i, const svBitVecVal *key_i,
-                     const svBitVecVal *data_i, svBitVecVal *data_o);
+void c_dpi_aes_crypt_block(const unsigned char impl_i, const unsigned char op_i,
+                           const svBitVecVal *mode_i, const svBitVecVal *iv_i,
+                           const svBitVecVal *key_len_i,
+                           const svBitVecVal *key_i, const svBitVecVal *data_i,
+                           svBitVecVal *data_o);
+
+/**
+ * Perform encryption/decryption of an entire message using OpenSSL/BoringSSL.
+ *
+ * @param  impl_i    Select reference impl.: 0 = C model, 1 = OpenSSL/BoringSSL
+ * @param  op_i      Operation: 0 = encrypt, 1 = decrypt
+ * @param  mode_i    Cipher mode: 3'b001 = ECB, 3'b010 = CBC, 3'b100 = CTR
+ * @param  iv_i      Initialization vector: 1D array of words (2D packed array
+ *                   in SV)
+ * @param  key_len_i Key length: 3'b001 = 128b, 3'b010 = 192b, 3'b100 = 256b
+ * @param  key_i     Full input key, 1D array of words (2D packed array in SV)
+ * @param  data_i    Input data, 1D byte array (open array in SV)
+ * @param  data_o    Output data, 1D byte array (open array in SV)
+ */
+void c_dpi_aes_crypt_message(unsigned char impl_i, unsigned char op_i,
+                             const svBitVecVal *mode_i, const svBitVecVal *iv_i,
+                             const svBitVecVal *key_len_i,
+                             const svBitVecVal *key_i,
+                             const svOpenArrayHandle data_i,
+                             svOpenArrayHandle data_o);
 
 /**
  * Perform sub bytes operation for forward/inverse cipher operation.
@@ -90,7 +111,7 @@ unsigned char *aes_data_get(const svBitVecVal *data_i);
 void aes_data_put(svBitVecVal *data_o, unsigned char *data);
 
 /**
- * Get unpacked data block from simulation.
+ * Get unpacked data from simulation.
  *
  * @param  data_i Input data from simulation
  * @return Pointer to data copied to memory, 0 in case of an error
@@ -98,7 +119,7 @@ void aes_data_put(svBitVecVal *data_o, unsigned char *data);
 unsigned char *aes_data_unpacked_get(const svOpenArrayHandle data_i);
 
 /**
- * Write unpacked data block to simulation and free the source buffer
+ * Write unpacked data to simulation and free the source buffer
  * afterwards.
  *
  * @param  data_o Output data for simulation
@@ -125,4 +146,4 @@ void aes_key_put(svBitVecVal *key_o, unsigned char *key);
 #ifdef __cplusplus
 }  // extern "C"
 #endif
-#endif  // _AES_MODEL_DPI_H_
+#endif  // OPENTITAN_HW_IP_AES_DV_AES_MODEL_DPI_AES_MODEL_DPI_H_

--- a/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi_pkg.sv
+++ b/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi_pkg.sv
@@ -6,40 +6,51 @@ package aes_model_dpi_pkg;
   import aes_pkg::*;
 
   // DPI-C imports
-  import "DPI-C" context function void c_dpi_aes_crypt(
-    input  bit                impl_i,
-    input  bit                op_i,
-    input  bit          [2:0] mode_i,
+  import "DPI-C" context function void c_dpi_aes_crypt_block(
+    input  bit                impl_i,    // 0 = C model, 1 = OpenSSL/BoringSSL
+    input  bit                op_i,      // 0 = encrypt, 1 = decrypt
+    input  bit          [2:0] mode_i,    // 3'b001 = ECB, 3'b010 = CBC, 3'b100 = CTR
     input  bit[3:0][3:0][7:0] iv_i,
-    input  bit          [2:0] key_len_i,
+    input  bit          [2:0] key_len_i, // 3'b001 = 128b, 3'b010 = 192b, 3'b100 = 256b
     input  bit    [7:0][31:0] key_i,
     input  bit[3:0][3:0][7:0] data_i,
     output bit[3:0][3:0][7:0] data_o
   );
 
+  import "DPI-C" context function void c_dpi_aes_crypt_message(
+    input  bit              impl_i,    // 0 = C model, 1 = OpenSSL/BoringSSL
+    input  bit              op_i,      // 0 = encrypt, 1 = decrypt
+    input  bit        [2:0] mode_i,    // 3'b001 = ECB, 3'b010 = CBC, 3'b100 = CTR
+    input  bit  [3:0][31:0] iv_i,
+    input  bit        [2:0] key_len_i, // 3'b001 = 128b, 3'b010 = 192b, 3'b100 = 256b
+    input  bit  [7:0][31:0] key_i,
+    input  bit        [7:0] data_i[],
+    output bit        [7:0] data_o[]
+  );
+
   import "DPI-C" context function void c_dpi_aes_sub_bytes(
-    input  bit                op_i,
+    input  bit                op_i, // 0 = encrypt, 1 = decrypt
     input  bit[3:0][3:0][7:0] data_i,
     output bit[3:0][3:0][7:0] data_o
   );
 
   import "DPI-C" context function void c_dpi_aes_shift_rows(
-    input  bit                op_i,
+    input  bit                op_i, // 0 = encrypt, 1 = decrypt
     input  bit[3:0][3:0][7:0] data_i,
     output bit[3:0][3:0][7:0] data_o
   );
 
   import "DPI-C" context function void c_dpi_aes_mix_columns(
-    input  bit                op_i,
+    input  bit                op_i, // 0 = encrypt, 1 = decrypt
     input  bit[3:0][3:0][7:0] data_i,
     output bit[3:0][3:0][7:0] data_o
   );
 
   import "DPI-C" context function void c_dpi_aes_key_expand(
-    input  bit            op_i,
+    input  bit            op_i,      // 0 = encrypt, 1 = decrypt
     input  bit      [7:0] rcon_i,
     input  bit      [3:0] round_i,
-    input  bit      [2:0] key_len_i,
+    input  bit      [2:0] key_len_i, // 3'b001 = 128b, 3'b010 = 192b, 3'b100 = 256b
     input  bit[7:0][31:0] key_i,
     output bit[7:0][31:0] key_o
   );
@@ -47,12 +58,12 @@ package aes_model_dpi_pkg;
   // wrapper function that converts from register format (4x32bit)
   // to the 4x4x8 format of the c functions and back
   // this ensures that RTL and refence models have same input and output format.
-  function automatic void sv_dpi_aes_crypt(
-    input  bit             impl_i,
-    input  bit             op_i,
-    input  bit       [2:0] mode_i,
+  function automatic void sv_dpi_aes_crypt_block(
+    input  bit             impl_i,    // 0 = C model, 1 = OpenSSL/BoringSSL
+    input  bit             op_i,      // 0 = encrypt, 1 = decrypt
+    input  bit       [2:0] mode_i,    // 3'b001 = ECB, 3'b010 = CBC, 3'b100 = CTR
     input  bit [3:0][31:0] iv_i,
-    input  bit       [2:0] key_len_i,
+    input  bit       [2:0] key_len_i, // 3'b001 = 128b, 3'b010 = 192b, 3'b100 = 256b
     input  bit [7:0][31:0] key_i,
     input  bit [3:0][31:0] data_i,
     output bit [3:0][31:0] data_o);
@@ -60,7 +71,7 @@ package aes_model_dpi_pkg;
     bit [3:0][3:0][7:0] iv_in, data_in, data_out;
     data_in = aes_transpose(data_i);
     iv_in   = aes_transpose(iv_i);
-    c_dpi_aes_crypt(impl_i, op_i, mode_i, iv_in, key_len_i, key_i, data_in, data_out);
+    c_dpi_aes_crypt_block(impl_i, op_i, mode_i, iv_in, key_len_i, key_i, data_in, data_out);
     data_o  = aes_transpose(data_out);
     return;
   endfunction

--- a/hw/ip/aes/dv/env/aes_scoreboard.sv
+++ b/hw/ip/aes/dv/env/aes_scoreboard.sv
@@ -192,7 +192,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
       ref_fifo.get(c_item );
       `uvm_info(`gfn, $sformatf("\n\t ----| GOT item "), UVM_HIGH)
 
-      sv_dpi_aes_crypt(1'b0, c_item.operation, 3'b001, 128'b0, c_item.key_size, c_item.key,
+      sv_dpi_aes_crypt_block(1'b0, c_item.operation, 3'b001, 128'b0, c_item.key_size, c_item.key,
           c_item.data_in, c_item.data_out);
       `uvm_info(`gfn, $sformatf("\n\t ----| printing C MODEL %s", c_item.convert2string() )
           , UVM_HIGH)


### PR DESCRIPTION
This PR adds a new DPI call to encrypt entire messages potentially consisting of multiple blocks.

At the moment, only OpenSSL/BoringSSL can be used. For the C model an additional wrapper will be required as it supports ECB only.