### PR TITLE
[dv] Update top-level to extend from cip_base

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env.sv
@@ -34,7 +34,8 @@ class cip_base_env #(type CFG_T               = cip_base_env_cfg,
         cfg.num_interrupts > 0) begin
       `uvm_fatal(get_full_name(), "failed to get intr_vif from uvm_config_db")
     end
-    if (!uvm_config_db#(devmode_vif)::get(this, "", "devmode_vif", cfg.devmode_vif)) begin
+    if (cfg.has_devmode && !uvm_config_db#(devmode_vif)::get(this, "", "devmode_vif",
+                                                             cfg.devmode_vif)) begin
       `uvm_fatal(get_full_name(), "failed to get devmode_vif from uvm_config_db")
     end
     if (!uvm_config_db#(tlul_assert_ctrl_vif)::get(this, "", "tlul_assert_ctrl_vif",
@@ -78,7 +79,9 @@ class cip_base_env #(type CFG_T               = cip_base_env_cfg,
   virtual function void end_of_elaboration_phase(uvm_phase phase);
     super.end_of_elaboration_phase(phase);
     // Set the TL adapter / sequencer to the default_map.
-    cfg.ral.default_map.set_sequencer(m_tl_agent.sequencer, m_tl_reg_adapter);
+    if (cfg.m_tl_agent_cfg.is_active) begin
+      cfg.ral.default_map.set_sequencer(m_tl_agent.sequencer, m_tl_reg_adapter);
+    end
   endfunction : end_of_elaboration_phase
 
 endclass

--- a/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
@@ -13,6 +13,7 @@ class cip_base_env_cfg #(type RAL_T = dv_base_reg_block) extends dv_base_env_cfg
   tlul_assert_ctrl_vif  tlul_assert_ctrl_vif;
 
   // only security IP can support devmode. If supported, override it to 1 in initialize()
+  bit                   has_devmode = 1;
   bit                   en_devmode = 0;
 
   uint                  num_interrupts;

--- a/hw/dv/sv/cip_lib/cip_base_vseq__tl_errors.svh
+++ b/hw/dv/sv/cip_lib/cip_base_vseq__tl_errors.svh
@@ -120,11 +120,16 @@ virtual task tl_read_mem_err();
   end
 endtask
 
+virtual function void disable_tl_assert(string path = "*");
+  uvm_config_db#(bit)::set(null, path, "tlul_assert_en", 0);
+endfunction
+
 // generic task to check interrupt test reg functionality
 virtual task run_tl_errors_vseq(int num_times = 1, bit do_wait_clk = 0);
   bit test_mem_err_byte_write = (cfg.mem_ranges.size > 0) && !cfg.en_mem_byte_write;
   bit test_mem_err_read       = (cfg.mem_ranges.size > 0) && !cfg.en_mem_read;
-  cfg.tlul_assert_ctrl_vif.drive(1'b0);
+  cfg.tlul_assert_ctrl_vif.drive(1'b0); // TODO to clean up
+  disable_tl_assert();
 
   for (int trans = 1; trans <= num_times; trans++) begin
     `uvm_info(`gfn, $sformatf("Running run_tl_errors_vseq %0d/%0d", trans, num_times), UVM_LOW)

--- a/hw/dv/sv/tl_agent/seq_lib/tl_host_custom_seq.sv
+++ b/hw/dv/sv/tl_agent/seq_lib/tl_host_custom_seq.sv
@@ -12,7 +12,6 @@ class tl_host_custom_seq extends tl_host_single_seq;
   virtual function void randomize_req(REQ req, int idx);
     control_addr_alignment = 1;
     control_rand_size      = 1;
-    control_rand_source    = 1;
     control_rand_opcode    = 1;
     req.disable_a_chan_protocol_constraint();
     super.randomize_req(req, idx);

--- a/hw/ip/tlul/rtl/tlul_assert.sv
+++ b/hw/ip/tlul/rtl/tlul_assert.sv
@@ -21,6 +21,7 @@ module tlul_assert #(
 `ifndef VERILATOR
 `ifndef SYNTHESIS
 
+  import uvm_pkg::*;
   import tlul_pkg::*;
   import top_pkg::*;
 
@@ -282,6 +283,13 @@ module tlul_assert #(
   //  make sure ready is not X after reset
   `ASSERT_KNOWN(aReadyKnown_A, d2h.a_ready)
   `ASSERT_KNOWN(dReadyKnown_A, h2d.d_ready)
+
+  initial forever begin
+    bit tlul_assert_en;
+    uvm_config_db#(bit)::wait_modified(null, "%m", "tlul_assert_en");
+    uvm_config_db#(bit)::get(null, "%m", "tlul_assert_en", tlul_assert_en);
+    force tlul_assert_ctrl = tlul_assert_en; // TODO to clean up
+  end
 `endif
 `endif
 endmodule : tlul_assert

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -138,6 +138,20 @@
       run_opts: ["+en_scb=0", "+csr_aliasing"]
       en_run_modes: ["stub_cpu"]
     }
+
+    {
+      name: "chip_same_csr_outstanding"
+      uvm_test_seq: chip_common_vseq
+      run_opts: ["+en_scb=0", "+run_same_csr_outstanding"]
+      en_run_modes: ["stub_cpu"]
+    }
+
+    {
+      name: chip_tl_errors
+      uvm_test_seq: chip_common_vseq
+      run_opts: ["+run_tl_errors"]
+      en_run_modes: ["stub_cpu"]
+    }
   ]
 
   // List of regressions.

--- a/hw/top_earlgrey/dv/env/chip_env.sv
+++ b/hw/top_earlgrey/dv/env/chip_env.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class chip_env extends dv_base_env #(
+class chip_env extends cip_base_env #(
     .CFG_T              (chip_env_cfg),
     .COV_T              (chip_env_cov),
     .VIRTUAL_SEQUENCER_T(chip_virtual_sequencer),
@@ -13,25 +13,12 @@ class chip_env extends dv_base_env #(
   uart_agent          m_uart_agent;
   jtag_agent          m_jtag_agent;
   spi_agent           m_spi_agent;
-  tl_agent            m_cpu_d_tl_agent;
-  chip_tl_reg_adapter m_cpu_d_tl_reg_adapter;
 
   `uvm_component_new
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
     // configure the cpu d tl agent
-    if (cfg.m_cpu_d_tl_agent_cfg.is_active && cfg.zero_delays) begin
-      cfg.m_cpu_d_tl_agent_cfg.a_valid_delay_min = 0;
-      cfg.m_cpu_d_tl_agent_cfg.a_valid_delay_max = 0;
-      cfg.m_cpu_d_tl_agent_cfg.d_valid_delay_min = 0;
-      cfg.m_cpu_d_tl_agent_cfg.d_valid_delay_max = 0;
-      cfg.m_cpu_d_tl_agent_cfg.a_ready_delay_min = 0;
-      cfg.m_cpu_d_tl_agent_cfg.a_ready_delay_max = 0;
-      cfg.m_cpu_d_tl_agent_cfg.d_ready_delay_min = 0;
-      cfg.m_cpu_d_tl_agent_cfg.d_ready_delay_max = 0;
-    end
-
     // get the vifs from config db
     if (!uvm_config_db#(virtual clk_rst_if)::get(this, "", "usb_clk_rst_vif",
         cfg.usb_clk_rst_vif)) begin
@@ -88,10 +75,6 @@ class chip_env extends dv_base_env #(
     m_spi_agent = spi_agent::type_id::create("m_spi_agent", this);
     uvm_config_db#(spi_agent_cfg)::set(this, "m_spi_agent*", "cfg", cfg.m_spi_agent_cfg);
 
-    m_cpu_d_tl_agent = tl_agent::type_id::create("m_cpu_d_tl_agent", this);
-    uvm_config_db#(tl_agent_cfg)::set(this, "m_cpu_d_tl_agent*", "cfg", cfg.m_cpu_d_tl_agent_cfg);
-
-    m_cpu_d_tl_reg_adapter = chip_tl_reg_adapter::type_id::create("m_cpu_d_tl_reg_adapter");
   endfunction
 
   function void connect_phase(uvm_phase phase);
@@ -100,9 +83,6 @@ class chip_env extends dv_base_env #(
       m_uart_agent.monitor.tx_analysis_port.connect(scoreboard.uart_tx_fifo.analysis_export);
       m_uart_agent.monitor.rx_analysis_port.connect(scoreboard.uart_rx_fifo.analysis_export);
       m_jtag_agent.monitor.analysis_port.connect(scoreboard.jtag_fifo.analysis_export);
-      // TODO: add scoreboard connections for monitoring tl accesses
-      // m_cpu_d_tl_agent.mon.a_chan_port.connect(scoreboard.tl_a_chan_fifo.analysis_export);
-      // m_cpu_d_tl_agent.mon.d_chan_port.connect(scoreboard.tl_d_chan_fifo.analysis_export);
     end
     if (cfg.is_active && cfg.m_uart_agent_cfg.is_active) begin
       virtual_sequencer.uart_sequencer_h = m_uart_agent.sequencer;
@@ -113,17 +93,10 @@ class chip_env extends dv_base_env #(
     if (cfg.is_active && cfg.m_spi_agent_cfg.is_active) begin
       virtual_sequencer.spi_sequencer_h = m_spi_agent.sequencer;
     end
-    if (cfg.is_active && cfg.m_cpu_d_tl_agent_cfg.is_active) begin
-      virtual_sequencer.cpu_d_tl_sequencer_h = m_cpu_d_tl_agent.sequencer;
-    end
   endfunction
 
   virtual function void end_of_elaboration_phase(uvm_phase phase);
     super.end_of_elaboration_phase(phase);
-    if (cfg.stub_cpu) begin
-      // Set the TL adapter / sequencer to the default_map.
-      cfg.ral.default_map.set_sequencer(m_cpu_d_tl_agent.sequencer, m_cpu_d_tl_reg_adapter);
-    end
   endfunction : end_of_elaboration_phase
 
 endclass

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class chip_env_cfg extends dv_base_env_cfg #(.RAL_T(chip_reg_block));
+class chip_env_cfg extends cip_base_env_cfg #(.RAL_T(chip_reg_block));
 
   // Testbench settings
   bit                 stub_cpu;
@@ -29,14 +29,12 @@ class chip_env_cfg extends dv_base_env_cfg #(.RAL_T(chip_reg_block));
   rand uart_agent_cfg m_uart_agent_cfg;
   rand jtag_agent_cfg m_jtag_agent_cfg;
   rand spi_agent_cfg  m_spi_agent_cfg;
-  rand tl_agent_cfg   m_cpu_d_tl_agent_cfg;
 
   `uvm_object_utils_begin(chip_env_cfg)
     `uvm_field_int   (stub_cpu,             UVM_DEFAULT)
     `uvm_field_object(m_uart_agent_cfg,     UVM_DEFAULT)
     `uvm_field_object(m_jtag_agent_cfg,     UVM_DEFAULT)
     `uvm_field_object(m_spi_agent_cfg,      UVM_DEFAULT)
-    `uvm_field_object(m_cpu_d_tl_agent_cfg, UVM_DEFAULT)
   `uvm_object_utils_end
 
   // TODO: Fixing core clk freq to 50MHz for now.
@@ -54,6 +52,10 @@ class chip_env_cfg extends dv_base_env_cfg #(.RAL_T(chip_reg_block));
   virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);
     chip_mem_e mems[] = {Rom, FlashBank0, FlashBank1};
 
+    has_devmode = 0;
+    // TODO: may need to add scb later
+    en_scb = 0;
+
     super.initialize(csr_base_addr);
     // create uart agent config obj
     m_uart_agent_cfg = uart_agent_cfg::type_id::create("m_uart_agent_cfg");
@@ -64,10 +66,6 @@ class chip_env_cfg extends dv_base_env_cfg #(.RAL_T(chip_reg_block));
     // create spi agent config obj
     m_spi_agent_cfg = spi_agent_cfg::type_id::create("m_spi_agent_cfg");
 
-    // create tl agent config obj
-    m_cpu_d_tl_agent_cfg = tl_agent_cfg::type_id::create("m_cpu_d_tl_agent_cfg");
-
-    m_cpu_d_tl_agent_cfg.if_mode = dv_utils_pkg::Host;
     // initialize the mem_bkdr_if vifs we want for this chip
     foreach (mems[mem]) begin
       mem_bkdr_vifs[mems[mem]] = null;

--- a/hw/top_earlgrey/dv/env/chip_env_cov.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cov.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class chip_env_cov extends dv_base_env_cov #(.CFG_T(chip_env_cfg));
+class chip_env_cov extends cip_base_env_cov #(.CFG_T(chip_env_cfg));
   `uvm_component_utils(chip_env_cov)
 
   // the base class provides the following handles for use:

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -41,9 +41,6 @@ package chip_env_pkg;
     SpiMem
   } chip_mem_e;
 
-  typedef class chip_tl_seq_item;
-  typedef tl_reg_adapter #(.ITEM_T(chip_tl_seq_item)) chip_tl_reg_adapter;
-
   // functions
 
   // package sources

--- a/hw/top_earlgrey/dv/env/chip_scoreboard.sv
+++ b/hw/top_earlgrey/dv/env/chip_scoreboard.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class chip_scoreboard extends dv_base_scoreboard #(
+class chip_scoreboard extends cip_base_scoreboard #(
     .CFG_T(chip_env_cfg),
     .RAL_T(chip_reg_block),
     .COV_T(chip_env_cov)

--- a/hw/top_earlgrey/dv/env/chip_tl_seq_item.sv
+++ b/hw/top_earlgrey/dv/env/chip_tl_seq_item.sv
@@ -9,7 +9,7 @@ class chip_tl_seq_item extends tl_seq_item;
 
   // TODO: need to capture this as param
   constraint a_source_c {
-    a_source inside {[0:1]};
+    a_source[TL_AIW-1:TL_AIW-2] == 0;
   }
 
   `uvm_object_utils_begin(chip_tl_seq_item)

--- a/hw/top_earlgrey/dv/env/chip_virtual_sequencer.sv
+++ b/hw/top_earlgrey/dv/env/chip_virtual_sequencer.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class chip_virtual_sequencer extends dv_base_virtual_sequencer #(
+class chip_virtual_sequencer extends cip_base_virtual_sequencer #(
     .CFG_T(chip_env_cfg),
     .COV_T(chip_env_cov)
   );
@@ -11,7 +11,6 @@ class chip_virtual_sequencer extends dv_base_virtual_sequencer #(
   uart_sequencer  uart_sequencer_h;
   jtag_sequencer  jtag_sequencer_h;
   spi_sequencer   spi_sequencer_h;
-  tl_sequencer    cpu_d_tl_sequencer_h;
 
   `uvm_component_new
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class chip_base_vseq extends dv_base_vseq #(
+class chip_base_vseq extends cip_base_vseq #(
     .CFG_T               (chip_env_cfg),
     .RAL_T               (chip_reg_block),
     .COV_T               (chip_env_cov),
@@ -18,6 +18,11 @@ class chip_base_vseq extends dv_base_vseq #(
   // various knobs to enable certain routines
 
   `uvm_object_new
+
+  task post_start();
+    do_clear_all_interrupts = 0;
+    super.post_start();
+  endtask
 
   virtual task apply_reset(string kind = "HARD");
     // TODO: Cannot assert different types of resets in parallel; due to randomization

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
@@ -17,7 +17,7 @@ class chip_common_vseq extends chip_base_vseq;
   endtask
 
   virtual task body();
-    run_csr_vseq_wrapper(num_trans);
+    run_common_vseq_wrapper(num_trans);
   endtask : body
 
 endclass

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -50,6 +50,7 @@ module tb;
   pins_if #(1) bootstrap_if(.pins(bootstrap));
   spi_if spi_if(.rst_n(rst_n));
   tl_if   cpu_d_tl_if(.clk(clk), .rst_n(rst_n));
+  pins_if #(1) tlul_assert_ctrl_if(tlul_assert_ctrl);
   uart_if uart_if();
   jtag_if jtag_if();
 
@@ -178,7 +179,9 @@ module tb;
     uvm_config_db#(virtual uart_if)::set(null, "*.env.m_uart_agent*", "vif", uart_if);
     uvm_config_db#(virtual jtag_if)::set(null, "*.env.m_jtag_agent*", "vif", jtag_if);
     uvm_config_db#(virtual spi_if)::set(null, "*.env.m_spi_agent*", "vif", spi_if);
-    uvm_config_db#(virtual tl_if)::set(null, "*.env.m_cpu_d_tl_agent*", "vif", cpu_d_tl_if);
+    uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", cpu_d_tl_if);
+    uvm_config_db#(tlul_assert_ctrl_vif)::set(null, "*.env", "tlul_assert_ctrl_vif",
+                                              tlul_assert_ctrl_if);
 
     // Strap pins
     uvm_config_db#(virtual pins_if #(1))::set(

--- a/hw/top_earlgrey/dv/tests/chip_base_test.sv
+++ b/hw/top_earlgrey/dv/tests/chip_base_test.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class chip_base_test extends dv_base_test #(
+class chip_base_test extends cip_base_test #(
     .ENV_T(chip_env),
     .CFG_T(chip_env_cfg)
   );
@@ -21,7 +21,7 @@ class chip_base_test extends dv_base_test #(
     // knob to en/dis stubbing cpu (disabled by default)
     void'($value$plusargs("stub_cpu=%0b", cfg.stub_cpu));
     // Set tl_agent's is_active bit based on the retrieved stub_cpu value.
-    cfg.m_cpu_d_tl_agent_cfg.is_active = cfg.stub_cpu;
+    cfg.m_tl_agent_cfg.is_active = cfg.stub_cpu;
 
     // knob to enable logging via uart
     void'($value$plusargs("en_uart_logger=%0b", cfg.en_uart_logger));
@@ -30,6 +30,9 @@ class chip_base_test extends dv_base_test #(
 
     // Set the sw_test_timeout_ns knob from plusarg if available.
     void'($value$plusargs("sw_test_timeout_ns=%0d", cfg.sw_test_timeout_ns));
+
+    // override tl_seq_item to apply constraint on source_id
+    tl_seq_item::type_id::set_type_override(chip_tl_seq_item::get_type());
   endfunction : build_phase
 
 endclass : chip_base_test

--- a/hw/top_earlgrey/dv/tests/chip_test_pkg.sv
+++ b/hw/top_earlgrey/dv/tests/chip_test_pkg.sv
@@ -5,8 +5,9 @@
 package chip_test_pkg;
   // dep packages
   import uvm_pkg::*;
-  import dv_lib_pkg::*;
+  import cip_base_pkg::*;
   import chip_env_pkg::*;
+  import tl_agent_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"


### PR DESCRIPTION
1. with this PR, #1925 and #1940, all csr/mem tests should pass
2. use `uvm_config_db#(bit)::wait_modified` to control assertion on/off,
which is more dynamic and flexible. After this PR merged, need to make
update for the other IPs

Signed-off-by: Weicai Yang <weicai@google.com>