### PR TITLE
[dv] Allow dv_lib-based sequences to have different RSP/REQ types

### DIFF
--- a/hw/dv/sv/dv_lib/dv_base_driver.sv
+++ b/hw/dv/sv/dv_lib/dv_base_driver.sv
@@ -2,9 +2,14 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class dv_base_driver #(type ITEM_T = uvm_sequence_item,
-                       type CFG_T  = dv_base_agent_cfg) extends uvm_driver #(ITEM_T);
-  `uvm_component_param_utils(dv_base_driver #())
+class dv_base_driver #(type ITEM_T     = uvm_sequence_item,
+                       type CFG_T      = dv_base_agent_cfg,
+                       type RSP_ITEM_T = ITEM_T)
+  extends uvm_driver #(.REQ(ITEM_T), .RSP(RSP_ITEM_T));
+
+  `uvm_component_param_utils(dv_base_driver #(.ITEM_T     (ITEM_T),
+                                              .CFG_T      (CFG_T),
+                                              .RSP_ITEM_T (RSP_ITEM_T)))
 
   bit   under_reset;
   CFG_T cfg;

--- a/hw/dv/sv/dv_lib/dv_base_sequencer.sv
+++ b/hw/dv/sv/dv_lib/dv_base_sequencer.sv
@@ -2,9 +2,14 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class dv_base_sequencer #(type ITEM_T = uvm_sequence_item,
-                          type CFG_T  = dv_base_agent_cfg) extends uvm_sequencer #(ITEM_T);
-  `uvm_component_param_utils(dv_base_sequencer #(ITEM_T, CFG_T))
+class dv_base_sequencer #(type ITEM_T     = uvm_sequence_item,
+                          type CFG_T      = dv_base_agent_cfg,
+                          type RSP_ITEM_T = ITEM_T)
+  extends uvm_sequencer #(.REQ(ITEM_T), .RSP(RSP_ITEM_T));
+
+  `uvm_component_param_utils(dv_base_sequencer #(.ITEM_T     (ITEM_T),
+                                                 .CFG_T      (CFG_T),
+                                                 .RSP_ITEM_T (RSP_ITEM_T)))
 
   CFG_T cfg;
 


### PR DESCRIPTION
Most UVM sequences just send items and don't receive any response:

    start_item(req);
    `DV_CHECK_RANDOMIZE_FATAL(req)
    finish_item(req);

However, sometimes a driver needs to report what happened. For
example, there might have been some sort of error on the bus which
will affect the next sequence item to send. In this case, the driver
calls

    seq_item_port.item_done(rsp);

and the sequencer's code looks like

    start_item(req);
    `DV_CHECK_RANDOMIZE_FATAL(req)
    finish_item(req);
    get_response(rsp);
    // Do something based on rsp...

But what type is rsp? Sometimes, it's enough to send the request item
back. This works nicely when the sequence items are actually
pipelined (so that the sequence can figure out what item finished).
Sometimes, however, you might want to use a different type from the
request type - it's a bit of a bodge just to add another field to the
request for a "back channel".

To support this, many UVM classes are parameterised by "REQ" and
"RSP": the type of request and response item, respectively. Some of
the dv_lib code supported this already (dv_base_seq), but the
sequencer and driver base classes didn't.

This patch adds that support, defaulting to RSP = REQ. The ordering of
parameters looks a little odd, but it seems that lots of OpenTitan
code sets parameters by position, rather than name, so we have to add
any new optional parameter at the end of the list.