### PR TITLE
[topgen] Generate Peripheral Base Addresses for C

### DIFF
--- a/hw/top_earlgrey/data/top_earlgrey.h.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.h.tpl
@@ -45,6 +45,17 @@
   % endif
 % endfor
 
+% for m in top["module"]:
+/**
+ * Base address for ${m["name"]} peripheral in top earlgrey.
+ *
+ * This should be used with #mmio_region_from_addr to access the memory-mapped
+ * registers associated with the peripheral (usually via a DIF).
+ */
+#define TOP_EARLGREY_${m["name"].upper()}_BASE_ADDR ${m["base_addr"]}u
+
+% endfor
+
 <%!
 
 def camelcase(str):

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -87,6 +87,102 @@
 #define PINMUX_GPIO_GPIO_31_OUT 34
 
 /**
+ * Base address for uart peripheral in top earlgrey.
+ *
+ * This should be used with #mmio_region_from_addr to access the memory-mapped
+ * registers associated with the peripheral (usually via a DIF).
+ */
+#define TOP_EARLGREY_UART_BASE_ADDR 0x40000000u
+
+/**
+ * Base address for gpio peripheral in top earlgrey.
+ *
+ * This should be used with #mmio_region_from_addr to access the memory-mapped
+ * registers associated with the peripheral (usually via a DIF).
+ */
+#define TOP_EARLGREY_GPIO_BASE_ADDR 0x40010000u
+
+/**
+ * Base address for spi_device peripheral in top earlgrey.
+ *
+ * This should be used with #mmio_region_from_addr to access the memory-mapped
+ * registers associated with the peripheral (usually via a DIF).
+ */
+#define TOP_EARLGREY_SPI_DEVICE_BASE_ADDR 0x40020000u
+
+/**
+ * Base address for flash_ctrl peripheral in top earlgrey.
+ *
+ * This should be used with #mmio_region_from_addr to access the memory-mapped
+ * registers associated with the peripheral (usually via a DIF).
+ */
+#define TOP_EARLGREY_FLASH_CTRL_BASE_ADDR 0x40030000u
+
+/**
+ * Base address for rv_timer peripheral in top earlgrey.
+ *
+ * This should be used with #mmio_region_from_addr to access the memory-mapped
+ * registers associated with the peripheral (usually via a DIF).
+ */
+#define TOP_EARLGREY_RV_TIMER_BASE_ADDR 0x40080000u
+
+/**
+ * Base address for aes peripheral in top earlgrey.
+ *
+ * This should be used with #mmio_region_from_addr to access the memory-mapped
+ * registers associated with the peripheral (usually via a DIF).
+ */
+#define TOP_EARLGREY_AES_BASE_ADDR 0x40110000u
+
+/**
+ * Base address for hmac peripheral in top earlgrey.
+ *
+ * This should be used with #mmio_region_from_addr to access the memory-mapped
+ * registers associated with the peripheral (usually via a DIF).
+ */
+#define TOP_EARLGREY_HMAC_BASE_ADDR 0x40120000u
+
+/**
+ * Base address for rv_plic peripheral in top earlgrey.
+ *
+ * This should be used with #mmio_region_from_addr to access the memory-mapped
+ * registers associated with the peripheral (usually via a DIF).
+ */
+#define TOP_EARLGREY_RV_PLIC_BASE_ADDR 0x40090000u
+
+/**
+ * Base address for pinmux peripheral in top earlgrey.
+ *
+ * This should be used with #mmio_region_from_addr to access the memory-mapped
+ * registers associated with the peripheral (usually via a DIF).
+ */
+#define TOP_EARLGREY_PINMUX_BASE_ADDR 0x40070000u
+
+/**
+ * Base address for alert_handler peripheral in top earlgrey.
+ *
+ * This should be used with #mmio_region_from_addr to access the memory-mapped
+ * registers associated with the peripheral (usually via a DIF).
+ */
+#define TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR 0x40130000u
+
+/**
+ * Base address for nmi_gen peripheral in top earlgrey.
+ *
+ * This should be used with #mmio_region_from_addr to access the memory-mapped
+ * registers associated with the peripheral (usually via a DIF).
+ */
+#define TOP_EARLGREY_NMI_GEN_BASE_ADDR 0x40140000u
+
+/**
+ * Base address for usbdev peripheral in top earlgrey.
+ *
+ * This should be used with #mmio_region_from_addr to access the memory-mapped
+ * registers associated with the peripheral (usually via a DIF).
+ */
+#define TOP_EARLGREY_USBDEV_BASE_ADDR 0x40150000u
+
+/**
  * PLIC Interrupt source peripheral enumeration.
  *
  * Enumeration used to determine which peripheral asserted the corresponding

--- a/sw/device/boot_rom/bootstrap.c
+++ b/sw/device/boot_rom/bootstrap.c
@@ -13,7 +13,8 @@
 #include "sw/device/lib/spi_device.h"
 #include "sw/device/lib/uart.h"  // TODO: Wrap uart in DEBUG macros.
 
-#define GPIO0_BASE_ADDR 0x40010000u
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
 #define GPIO_BOOTSTRAP_BIT_MASK 0x00020000u
 
 /* Checks if flash is blank to determine if bootstrap is needed. */
@@ -27,8 +28,8 @@ static int bootstrap_requested(void) {
   }
   // Initialize GPIO device
   dif_gpio_t gpio;
-  dif_gpio_config_t gpio_config = {.base_addr =
-                                       mmio_region_from_addr(GPIO0_BASE_ADDR)};
+  dif_gpio_config_t gpio_config = {
+      .base_addr = mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR)};
   dif_gpio_init(&gpio_config, &gpio);
   // Read pin
   uint32_t gpio_in;

--- a/sw/device/boot_rom/meson.build
+++ b/sw/device/boot_rom/meson.build
@@ -44,6 +44,7 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
       sw_lib_spi_device,
       sw_lib_uart,
       sw_lib_base_log,
+      top_earlgrey,
       device_lib,
     ],
   )

--- a/sw/device/lib/aes.c
+++ b/sw/device/lib/aes.c
@@ -4,10 +4,12 @@
 
 #include "sw/device/lib/aes.h"
 
-#include "aes_regs.h"  // Generated.
 #include "sw/device/lib/common.h"
 
-#define AES0_BASE_ADDR 0x40110000
+#include "aes_regs.h"  // Generated.
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+#define AES0_BASE_ADDR TOP_EARLGREY_AES_BASE_ADDR
 #define AES_NUM_REGS_KEY 8
 #define AES_NUM_REGS_IV 4
 #define AES_NUM_REGS_DATA 4

--- a/sw/device/lib/flash_ctrl.c
+++ b/sw/device/lib/flash_ctrl.c
@@ -4,10 +4,11 @@
 #include "sw/device/lib/flash_ctrl.h"
 
 #include "flash_ctrl_regs.h"  // Generated.
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 #include "sw/device/lib/common.h"
 
-#define FLASH_CTRL0_BASE_ADDR 0x40030000
+#define FLASH_CTRL0_BASE_ADDR TOP_EARLGREY_FLASH_CTRL_BASE_ADDR
 
 typedef enum flash_op {
   FLASH_READ = 0,

--- a/sw/device/lib/hmac.c
+++ b/sw/device/lib/hmac.c
@@ -4,10 +4,12 @@
 
 #include "sw/device/lib/hmac.h"
 
-#include "hmac_regs.h"  // Generated.
 #include "sw/device/lib/common.h"
 
-#define HMAC0_BASE_ADDR 0x40120000
+#include "hmac_regs.h"  // Generated.
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+#define HMAC0_BASE_ADDR TOP_EARLGREY_HMAC_BASE_ADDR
 #define HMAC_FIFO_MAX 16
 #define HMAC_FIFO_GROUP_SIZE HMAC_FIFO_MAX / 2
 

--- a/sw/device/lib/meson.build
+++ b/sw/device/lib/meson.build
@@ -17,6 +17,7 @@ sw_lib_uart = declare_dependency(
       sw_lib_base_print,
       sw_lib_runtime_ibex,
       dif_uart,
+      top_earlgrey,
     ],
   )
 )
@@ -28,6 +29,9 @@ sw_lib_flash_ctrl = declare_dependency(
     sources: [
       hw_ip_flash_ctrl_reg_h,
       'flash_ctrl.c',
+    ],
+    dependencies: [
+      top_earlgrey,
     ]
   )
 )
@@ -39,6 +43,9 @@ sw_lib_pinmux = declare_dependency(
     sources: [
       hw_top_earlgrey_pinmux_reg_h,
       'pinmux.c',
+    ],
+    dependencies: [
+      top_earlgrey,
     ]
   )
 )
@@ -50,6 +57,9 @@ sw_lib_aes = declare_dependency(
     sources: [
       hw_ip_aes_reg_h,
       'aes.c',
+    ],
+    dependencies: [
+      top_earlgrey,
     ]
   )
 )
@@ -65,6 +75,7 @@ sw_lib_hmac = declare_dependency(
     ],
     dependencies: [
       sw_lib_mem,
+      top_earlgrey,
     ]
   )
 )
@@ -113,7 +124,10 @@ sw_lib_rv_timer = declare_dependency(
       hw_ip_rv_timer_reg_h,
       'rv_timer.c',
     ],
-    dependencies: [sw_lib_runtime_ibex],
+    dependencies: [
+      sw_lib_runtime_ibex,
+      top_earlgrey,
+    ],
   )
 )
 
@@ -124,6 +138,9 @@ sw_lib_spi_device = declare_dependency(
     sources: [
       hw_ip_spi_device_reg_h,
       'spi_device.c',
+    ],
+    dependencies: [
+      top_earlgrey,
     ]
   )
 )
@@ -140,6 +157,7 @@ sw_lib_usb = declare_dependency(
     ],
     dependencies: [
       sw_lib_uart,
+      top_earlgrey,
     ]
   )
 )

--- a/sw/device/lib/pinmux.c
+++ b/sw/device/lib/pinmux.c
@@ -7,9 +7,10 @@
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "sw/device/lib/common.h"
 
-#define PINMUX0_BASE_ADDR 0x40070000
-
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "pinmux_regs.h"  // Generated.
+
+#define PINMUX0_BASE_ADDR TOP_EARLGREY_PINMUX_BASE_ADDR
 
 static void init_pinmux_reg(uint32_t reg, uint32_t size, uint32_t num_fields,
                             uint32_t mask, uint32_t start_v) {

--- a/sw/device/lib/rv_timer.c
+++ b/sw/device/lib/rv_timer.c
@@ -4,12 +4,14 @@
 
 #include "sw/device/lib/rv_timer.h"
 
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "rv_timer_regs.h"  // Generated.
+
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/common.h"
 #include "sw/device/lib/runtime/ibex.h"
 
-#define RV_TIMER0_BASE_ADDR 0x40080000
+#define RV_TIMER0_BASE_ADDR TOP_EARLGREY_RV_TIMER_BASE_ADDR
 #define HART_CFG_ADDR_GAP 0x100
 
 static const uint32_t NS_IN_S = 1000 * 1000 * 1000;

--- a/sw/device/lib/spi_device.c
+++ b/sw/device/lib/spi_device.c
@@ -4,11 +4,12 @@
 
 #include "sw/device/lib/spi_device.h"
 
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "spi_device_regs.h"  // Generated.
 
 #include "sw/device/lib/common.h"
 
-#define SPI_DEVICE0_BASE_ADDR 0x40020000
+#define SPI_DEVICE0_BASE_ADDR TOP_EARLGREY_SPI_DEVICE_BASE_ADDR
 #define SPID_SRAM_ADDR SPI_DEVICE_BUFFER(0)
 #define SPID_RXF_BASE 0x000
 #define SPID_RXF_SIZE 0x400

--- a/sw/device/lib/uart.c
+++ b/sw/device/lib/uart.c
@@ -8,7 +8,8 @@
 #include "sw/device/lib/common.h"
 #include "sw/device/lib/dif/dif_uart.h"
 #include "sw/device/lib/runtime/ibex.h"
-#define UART0_BASE_ADDR 0x40000000
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 static dif_uart_t uart0;
 
@@ -20,7 +21,7 @@ void uart_init(unsigned int baud) {
       .parity = kDifUartParityEven,
   };
 
-  mmio_region_t base_addr = mmio_region_from_addr(UART0_BASE_ADDR);
+  mmio_region_t base_addr = mmio_region_from_addr(TOP_EARLGREY_UART_BASE_ADDR);
   (void)dif_uart_init(base_addr, &config, &uart0);
 }
 

--- a/sw/device/lib/usbdev.c
+++ b/sw/device/lib/usbdev.c
@@ -6,8 +6,10 @@
 
 #include "sw/device/lib/common.h"
 
-#define USBDEV_BASE_ADDR 0x40150000
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "usbdev_regs.h"  // Generated.
+
+#define USBDEV_BASE_ADDR TOP_EARLGREY_USBDEV_BASE_ADDR
 
 #define EXTRACT(n, f) ((n >> USBDEV_##f##_OFFSET) & USBDEV_##f##_MASK)
 

--- a/sw/device/tests/consecutive_irqs/consecutive_irqs_test.c
+++ b/sw/device/tests/consecutive_irqs/consecutive_irqs_test.c
@@ -13,8 +13,7 @@
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/runtime/ibex.h"
 
-#define UART0_BASE_ADDR 0x40000000u
-#define PLIC0_BASE_ADDR 0x40090000u
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 #define PLIC_TARGET kDifPlicTargetIbex0
 
@@ -254,11 +253,13 @@ int main(int argc, char **argv) {
   irq_external_ctrl(true);
 
   // No debug output in case of UART initialisation failure.
-  mmio_region_t uart_base_addr = mmio_region_from_addr(UART0_BASE_ADDR);
+  mmio_region_t uart_base_addr =
+      mmio_region_from_addr(TOP_EARLGREY_UART_BASE_ADDR);
   uart_initialise(uart_base_addr, &uart0);
   base_set_stdout(kPolledUartSink);
 
-  mmio_region_t plic_base_addr = mmio_region_from_addr(PLIC0_BASE_ADDR);
+  mmio_region_t plic_base_addr =
+      mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR);
   if (!plic_initialise(plic_base_addr, &plic0)) {
     base_printf("FAIL!\r\n");
     return -1;

--- a/sw/device/tests/consecutive_irqs/meson.build
+++ b/sw/device/tests/consecutive_irqs/meson.build
@@ -18,6 +18,7 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
       sw_lib_mmio,
       sw_lib_runtime_hart,
       sw_lib_uart,
+      top_earlgrey,
     ],
   )
 

--- a/sw/device/tests/rv_timer/meson.build
+++ b/sw/device/tests/rv_timer/meson.build
@@ -15,6 +15,7 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
       sw_lib_pinmux,
       riscv_crt,
       sw_lib_irq_handlers,
+      top_earlgrey,
       device_lib,
     ],
   )

--- a/sw/device/tests/rv_timer/rv_timer_test.c
+++ b/sw/device/tests/rv_timer/rv_timer_test.c
@@ -11,7 +11,7 @@
 #include "sw/device/lib/pinmux.h"
 #include "sw/device/lib/uart.h"
 
-#define GPIO0_BASE_ADDR 0x40010000u
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 static dif_gpio_t gpio;
 static uint32_t intr_handling_success = 0;
@@ -24,8 +24,8 @@ int main(int argc, char **argv) {
 
   pinmux_init();
   // Enable GPIO: 0-7 and 16 is input, 8-15 is output
-  dif_gpio_config_t gpio_config = {.base_addr =
-                                       mmio_region_from_addr(GPIO0_BASE_ADDR)};
+  dif_gpio_config_t gpio_config = {
+      .base_addr = mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR)};
   dif_gpio_init(&gpio_config, &gpio);
   dif_gpio_output_mode_all_set(&gpio, 0xFF00);
 


### PR DESCRIPTION
This commit means we now auto-generate `_BASE_ADDR` macros for C based
on the definitions in `top_earlgrey.hjson`. This should mean these
definitions do not go out of date as we add more peripherals or move
them in memory space.

---

I had a discussion with @silvestrst about whether we should use `#define`s or
`const uintptr_t` globals. We felt that for the moment `#defines` were simpler,
despite the fact they are untyped. 

I hoped that using defines would not introduce as many dependencies to meson,
but `top_earlgrey.h` has definitions that require the `top_earlgrey` library, so I
felt it safest to update all the dependencies anyway.