### PR TITLE
PEP8 fixes in dvsim

### DIFF
--- a/util/dvsim/LintCfg.py
+++ b/util/dvsim/LintCfg.py
@@ -5,16 +5,14 @@ r"""
 Class describing lint configuration object
 """
 
+import hjson
 import logging as log
-import sys
 from pathlib import Path
 
 from tabulate import tabulate
 
-from Deploy import *
-from Modes import *
 from OneShotCfg import OneShotCfg
-from utils import *
+from utils import subst_wildcards
 
 
 # helper function for printing messages
@@ -24,7 +22,6 @@ def _print_msg_list(msg_list_name, msg_list):
         md_results += "### %s\n" % msg_list_name
         md_results += "```\n"
         for msg in msg_list:
-            msg_parts = msg.split()
             md_results += msg + "\n\n"
         md_results += "```\n"
     return md_results
@@ -209,7 +206,7 @@ class LintCfg(OneShotCfg):
                                              self.result["lint_errors"])
                 fail_msgs += _print_msg_list("Lint Warnings",
                                              self.result["lint_warnings"])
-                #fail_msgs += _print_msg_list("Lint Infos", results["lint_infos"])
+                # fail_msgs += _print_msg_list("Lint Infos", results["lint_infos"])
 
         if len(table) > 1:
             self.results_md = results_str + tabulate(

--- a/util/dvsim/Modes.py
+++ b/util/dvsim/Modes.py
@@ -1,18 +1,12 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-r"""
-Classes
-"""
 
 import logging as log
 import pprint
-import re
 import sys
 
-import hjson
-
-from utils import *
+from utils import VERBOSE
 
 
 class Modes():
@@ -25,8 +19,10 @@ class Modes():
         This is used to construct the string representation of the entire class object.
         '''
         tname = ""
-        if self.type != "": tname = self.type + "_"
-        if self.mname != "": tname += self.mname
+        if self.type != "":
+            tname = self.type + "_"
+        if self.mname != "":
+            tname += self.mname
         if log.getLogger().isEnabledFor(VERBOSE):
             return "\n<---" + tname + ":\n" + pprint.pformat(self.__dict__) + \
                    "\n--->\n"
@@ -43,7 +39,7 @@ class Modes():
         keys = mdict.keys()
         attrs = self.__dict__.keys()
 
-        if not 'name' in keys:
+        if 'name' not in keys:
             log.error("Key \"name\" missing in mode %s", mdict)
             sys.exit(1)
 
@@ -51,7 +47,8 @@ class Modes():
             log.fatal("Key \"type\" is missing or invalid")
             sys.exit(1)
 
-        if not hasattr(self, "mname"): self.mname = ""
+        if not hasattr(self, "mname"):
+            self.mname = ""
 
         for key in keys:
             if key not in attrs:
@@ -100,14 +97,15 @@ class Modes():
         if sub_modes != []:
             new_sub_modes = []
             for sub_mode in sub_modes:
-                if not self.name == sub_mode and not sub_mode in new_sub_modes:
+                if self.name != sub_mode and sub_mode not in new_sub_modes:
                     new_sub_modes.append(sub_mode)
             self.set_sub_modes(new_sub_modes)
         return True
 
     def check_conflict(self, name, attr, mode_attr_val):
         self_attr_val = getattr(self, attr)
-        if self_attr_val == mode_attr_val: return
+        if self_attr_val == mode_attr_val:
+            return
 
         default_val = None
         if type(self_attr_val) is int:
@@ -134,7 +132,8 @@ class Modes():
         def merge_sub_modes(mode, parent, objs):
             # Check if there are modes available to merge
             sub_modes = mode.get_sub_modes()
-            if sub_modes == []: return
+            if sub_modes == []:
+                return
 
             # Set parent if it is None. If not, check cyclic dependency
             if parent is None:
@@ -166,7 +165,8 @@ class Modes():
         modes_objs = []
         # create a default mode if available
         default_mode = ModeType.get_default_mode()
-        if default_mode is not None: modes_objs.append(default_mode)
+        if default_mode is not None:
+            modes_objs.append(default_mode)
 
         # Process list of raw dicts that represent the modes
         # Pass 1: Create unique set of modes by merging modes with the same name
@@ -203,7 +203,6 @@ class Modes():
         Given a mode_name in string, go through list of modes and return the mode with
         the string that matches. Thrown an error and return None if nothing was found.
         '''
-        found = False
         for mode in modes:
             if mode_name == mode.name:
                 return mode
@@ -218,7 +217,8 @@ class Modes():
             sub_mode = Modes.find_mode(mode_name, modes)
             if sub_mode is not None:
                 found_mode_objs.append(sub_mode)
-                if merge_modes is True: mode.merge_mode(sub_mode)
+                if merge_modes is True:
+                    mode.merge_mode(sub_mode)
             else:
                 log.error("Mode \"%s\" enabled within mode \"%s\" not found!",
                           mode_name, mode.name)
@@ -237,7 +237,8 @@ class BuildModes(Modes):
     def __init__(self, bdict):
         self.name = ""
         self.type = "build"
-        if not hasattr(self, "mname"): self.mname = "mode"
+        if not hasattr(self, "mname"):
+            self.mname = "mode"
         self.is_sim_mode = 0
         self.build_opts = []
         self.run_opts = []
@@ -262,7 +263,8 @@ class RunModes(Modes):
     def __init__(self, rdict):
         self.name = ""
         self.type = "run"
-        if not hasattr(self, "mname"): self.mname = "mode"
+        if not hasattr(self, "mname"):
+            self.mname = "mode"
         self.reseed = -1
         self.run_opts = []
         self.uvm_test = ""
@@ -302,7 +304,8 @@ class Tests(RunModes):
     }
 
     def __init__(self, tdict):
-        if not hasattr(self, "mname"): self.mname = "test"
+        if not hasattr(self, "mname"):
+            self.mname = "test"
         super().__init__(tdict)
 
     @staticmethod
@@ -413,7 +416,8 @@ class Regressions(Modes):
     def __init__(self, regdict):
         self.name = ""
         self.type = ""
-        if not hasattr(self, "mname"): self.mname = "regression"
+        if not hasattr(self, "mname"):
+            self.mname = "regression"
         self.tests = []
         self.reseed = -1
         self.test_names = []
@@ -440,7 +444,7 @@ class Regressions(Modes):
 
             # Check for name conflicts with tests before merging
             if new_regression.name in Tests.item_names:
-                log.error("Test names and regression names are required to be unique. " + \
+                log.error("Test names and regression names are required to be unique. "
                           "The regression \"%s\" bears the same name with an existing test. ",
                           new_regression.name)
                 sys.exit(1)
@@ -484,7 +488,7 @@ class Regressions(Modes):
                 # Throw an error and exit.
                 for sim_mode_obj_sub in sim_mode_obj.en_build_modes:
                     if sim_mode_obj_sub in regression_obj.en_sim_modes:
-                        log.error("Regression \"%s\" enables sim_modes \"%s\" and \"%s\". " + \
+                        log.error("Regression \"%s\" enables sim_modes \"%s\" and \"%s\". "
                                   "The former is already a sub_mode of the latter.",
                                   regression_obj.name, sim_mode_obj_sub, sim_mode_obj.name)
                         sys.exit(1)

--- a/util/dvsim/Modes.py
+++ b/util/dvsim/Modes.py
@@ -509,7 +509,7 @@ class Regressions(Modes):
                 # which case, skip
                 if run_mode_obj.name in sim_cfg.en_run_modes:
                     continue
-                self.run_opts.extend(run_mode_obj.run_opts)
+                regression_obj.run_opts.extend(run_mode_obj.run_opts)
 
             # Unpack tests
             if regression_obj.tests == []:

--- a/util/dvsim/OneShotCfg.py
+++ b/util/dvsim/OneShotCfg.py
@@ -6,13 +6,14 @@ Class describing a one-shot build configuration object
 """
 
 import logging as log
+import os
 import sys
 from collections import OrderedDict
 
-from Deploy import *
+from Deploy import CompileOneShot
 from FlowCfg import FlowCfg
-from Modes import *
-from utils import *
+from Modes import BuildModes, Modes
+from utils import find_and_substitute_wildcards
 
 
 class OneShotCfg(FlowCfg):

--- a/util/dvsim/SynCfg.py
+++ b/util/dvsim/SynCfg.py
@@ -6,15 +6,13 @@ Class describing synthesis configuration object
 """
 
 import logging as log
-import sys
 from pathlib import Path
 
+import hjson
 from tabulate import tabulate
 
-from Deploy import *
-from Modes import *
 from OneShotCfg import OneShotCfg
-from utils import *
+from utils import subst_wildcards
 
 
 class SynCfg(OneShotCfg):
@@ -243,7 +241,8 @@ class SynCfg(OneShotCfg):
 
                     # go through submodules
                     for name in self.result["area"]["instances"].keys():
-                        if name == self.result["top"]: continue
+                        if name == self.result["top"]:
+                            continue
                         row = [name]
                         for field in ["comb", "buf", "reg", "macro", "total"]:
                             row += [
@@ -329,11 +328,11 @@ class SynCfg(OneShotCfg):
 
                     total_power = sum(power)
 
-                    row = [_create_entry(power[0], 1.0E-3) + " / " + \
+                    row = [_create_entry(power[0], 1.0E-3) + " / " +
                            _create_entry(power[0], 1.0E-3, total_power),
-                           _create_entry(power[1], 1.0E-3) + " / " + \
+                           _create_entry(power[1], 1.0E-3) + " / " +
                            _create_entry(power[1], 1.0E-3, total_power),
-                           _create_entry(power[2], 1.0E-3) + " / " + \
+                           _create_entry(power[2], 1.0E-3) + " / " +
                            _create_entry(power[2], 1.0E-3, total_power),
                            _create_entry(total_power, 1.0E-3)]
 

--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -18,7 +18,6 @@ import logging as log
 import os
 import subprocess
 import sys
-from pathlib import Path
 from signal import SIGINT, signal
 
 import Deploy
@@ -83,6 +82,7 @@ def resolve_branch(arg_branch):
                 "Failed to find current git branch. Setting it to \"default\"")
             arg_branch = "default"
     return (arg_branch)
+
 
 # Get the project root directory path - this is used to construct the full paths
 def get_proj_root():

--- a/util/dvsim/sim_utils.py
+++ b/util/dvsim/sim_utils.py
@@ -66,13 +66,15 @@ def xcelium_cov_summary_table(buf):
             values = []
             cov_total = None
             for metric in items.keys():
-                if items[metric]['total'] == 0: values.append("-- %")
+                if items[metric]['total'] == 0:
+                    values.append("-- %")
                 else:
                     value = items[metric]['covered'] / items[metric][
                         'total'] * 100
                     value = "{0:.2f} %".format(round(value, 2))
                     values.append(value)
-                    if metric == 'Score': cov_total = value
+                    if metric == 'Score':
+                        cov_total = value
             return [metrics, values], cov_total, None
 
     # If we reached here, then we were unable to extract the coverage.

--- a/util/dvsim/testplanner.py
+++ b/util/dvsim/testplanner.py
@@ -6,12 +6,7 @@ r"""Command-line tool to parse and process testplan Hjson
 
 """
 import argparse
-import logging as log
-import os
 import sys
-from pathlib import PurePath
-
-import hjson
 
 from testplanner import testplan_utils
 

--- a/util/dvsim/testplanner/class_defs.py
+++ b/util/dvsim/testplanner/class_defs.py
@@ -32,7 +32,8 @@ class TestplanEntry():
         self.desc = desc
         self.milestone = milestone
         self.tests = tests
-        if not self.do_substitutions(substitutions): sys.exit(1)
+        if not self.do_substitutions(substitutions):
+            sys.exit(1)
 
     @staticmethod
     def is_valid_entry(kv_pairs):
@@ -40,7 +41,7 @@ class TestplanEntry():
         from it.
         '''
         for field in TestplanEntry.fields:
-            if not field in kv_pairs.keys():
+            if field not in kv_pairs.keys():
                 print(
                     "Error: input key-value pairs does not contain all of the ",
                     "required fields to create an entry:\n", kv_pairs,
@@ -65,7 +66,8 @@ class TestplanEntry():
         key=value pairs provided by the substitutions arg. If wildcards are present but no
         replacement is available, then the wildcards are replaced with an empty string.
         '''
-        if substitutions == []: return True
+        if substitutions == []:
+            return True
         for kv_pair in substitutions:
             resolved_tests = []
             [(k, v)] = kv_pair.items()
@@ -98,7 +100,8 @@ class TestplanEntry():
                                 return False
                 else:
                     resolved_tests.append(test)
-            if resolved_tests != []: self.tests = resolved_tests
+            if resolved_tests != []:
+                self.tests = resolved_tests
 
         # if wildcards have no available replacements in substitutions arg, then
         # replace with empty string
@@ -108,7 +111,8 @@ class TestplanEntry():
             if len(match) > 0:
                 for item in match:
                     resolved_tests.append(test.replace("{" + item + "}", ""))
-        if resolved_tests != []: self.tests = resolved_tests
+        if resolved_tests != []:
+            self.tests = resolved_tests
         return True
 
     def map_regr_results(self, regr_results, map_full_testplan=True):
@@ -183,7 +187,8 @@ class Testplan():
     def add_entry(self, entry):
         '''add a new entry into the testplan
         '''
-        if self.entry_exists(entry): sys.exit(1)
+        if self.entry_exists(entry):
+            sys.exit(1)
         self.entries.append(entry)
 
     def sort(self):
@@ -226,7 +231,8 @@ class Testplan():
                                            "passing": 0,
                                            "total": 0
                                        }])
-            if ms != "N.A.": totals[ms].tests = []
+            if ms != "N.A.":
+                totals[ms].tests = []
 
         for entry in self.entries:
             regr_results = entry.map_regr_results(regr_results,
@@ -236,7 +242,7 @@ class Testplan():
         # extract unmapped tests from regr_results and create 'unmapped' entry
         unmapped_regr_results = []
         for regr_result in regr_results:
-            if not "mapped" in regr_result.keys():
+            if "mapped" not in regr_result.keys():
                 unmapped_regr_results.append(regr_result)
 
         unmapped = TestplanEntry(
@@ -265,7 +271,8 @@ class Testplan():
         regressions = {}
         for entry in self.entries:
             # Skip if milestone is "n.a."
-            if entry.milestone not in entry.milestones[1:]: continue
+            if entry.milestone not in entry.milestones[1:]:
+                continue
             # if ms key doesnt exist, create one
             if entry.milestone not in regressions.keys():
                 regressions[entry.milestone] = []
@@ -314,10 +321,13 @@ class Testplan():
         for entry in self.entries:
             milestone = entry.milestone
             entry_name = entry.name
-            if milestone == "N.A.": milestone = ""
-            if entry_name == "N.A.": entry_name = ""
+            if milestone == "N.A.":
+                milestone = ""
+            if entry_name == "N.A.":
+                entry_name = ""
             for test in entry.tests:
-                if test["total"] == 0: pass_rate = "-- %"
+                if test["total"] == 0:
+                    pass_rate = "-- %"
                 else:
                     pass_rate = test["passing"] / test["total"] * 100
                     pass_rate = "{0:.2f} %".format(round(pass_rate, 2))

--- a/util/dvsim/testplanner/testplan_utils.py
+++ b/util/dvsim/testplanner/testplan_utils.py
@@ -5,16 +5,14 @@ r"""Command-line tool to parse and process testplan Hjson into a data structure
     The data structure is used for expansion inline within DV plan documentation
     as well as for annotating the regression results.
 """
-import logging as log
 import os
 import sys
-from pathlib import PurePath
 
 import hjson
 import mistletoe
 from tabulate import tabulate
 
-from .class_defs import *
+from .class_defs import Testplan, TestplanEntry
 
 
 def parse_testplan(filename):
@@ -30,7 +28,8 @@ def parse_testplan(filename):
         if key == "import_testplans":
             imported_testplans = obj[key]
         elif key != "entries":
-            if key == "name": name = obj[key]
+            if key == "name":
+                name = obj[key]
             substitutions.append({key: obj[key]})
     for imported_testplan in imported_testplans:
         obj = merge_dicts(
@@ -38,7 +37,8 @@ def parse_testplan(filename):
 
     testplan = Testplan(name=name)
     for entry in obj["entries"]:
-        if not TestplanEntry.is_valid_entry(entry): sys.exit(1)
+        if not TestplanEntry.is_valid_entry(entry):
+            sys.exit(1)
         testplan_entry = TestplanEntry(name=entry["name"],
                                        desc=entry["desc"],
                                        milestone=entry["milestone"],
@@ -110,7 +110,7 @@ def gen_html_regr_results_table(testplan, regr_results, outbuf):
 def parse_regr_results(filename):
     obj = parse_hjson(filename)
     # TODO need additional syntax checks
-    if not "test_results" in obj.keys():
+    if "test_results" not in obj.keys():
         print("Error: key \'test_results\' not found")
         sys, exit(1)
     return obj

--- a/util/dvsim/utils.py
+++ b/util/dvsim/utils.py
@@ -7,7 +7,6 @@ Utility functions common across dvsim.
 
 import logging as log
 import os
-import pprint
 import re
 import shlex
 import subprocess
@@ -63,7 +62,8 @@ def run_cmd_with_timeout(cmd, timeout=-1, exit_on_failure=1):
 
     if status != 0:
         log.error("cmd \"%s\" exited with status %d", cmd, status)
-        if exit_on_failure == 1: sys.exit(status)
+        if exit_on_failure == 1:
+            sys.exit(status)
 
     return (result, status)
 
@@ -90,8 +90,10 @@ def subst_wildcards(var, mdict, ignored_wildcards=[], ignore_error=False):
     If var has wildcards specified within {..}, find and substitute them.
     '''
     def subst(wildcard, mdict):
-        if wildcard in mdict.keys(): return mdict[wildcard]
-        else: return None
+        if wildcard in mdict.keys():
+            return mdict[wildcard]
+        else:
+            return None
 
     if "{eval_cmd}" in var:
         idx = var.find("{eval_cmd}") + 11
@@ -133,7 +135,8 @@ def subst_wildcards(var, mdict, ignored_wildcards=[], ignore_error=False):
                     else:
                         # Check if the wildcard exists as an environment variable
                         env_var = os.environ.get(item)
-                        if env_var is not None: subst_list[item] = env_var
+                        if env_var is not None:
+                            subst_list[item] = env_var
                         elif not ignore_error:
                             log.error(
                                 "Substitution for the wildcard \"%s\" not found",
@@ -254,7 +257,7 @@ def htmc_color_pc_cells(text):
     def color_cell(cell, cclass, indicator="%"):
         op = cell.replace("<td", "<td class=\"" + cclass + "\"")
         # Remove the indicator.
-        op = re.sub(r"\s*" + indicator + "\s*", "", op)
+        op = re.sub(r"\s*" + indicator + r"\s*", "", op)
         return op
 
     # List of 'not applicable' identifiers.
@@ -262,12 +265,11 @@ def htmc_color_pc_cells(text):
     na_list_patterns = '|'.join(na_list)
 
     # List of floating point patterns: '0', '0.0' & '.0'
-    fp_patterns = "[\+\-]?\d+\.?\d*"
+    fp_patterns = r"[\+\-]?\d+\.?\d*"
 
     patterns = fp_patterns + '|' + na_list_patterns
     indicators = "%|%u|G|B|E|W|EN|WN"
-    match = re.findall(
-        r"(<td.*>\s*(" + patterns + ")\s+(" + indicators + ")\s*</td>)", text)
+    match = re.findall(r"(<td.*>\s*(" + patterns + r")\s+(" + indicators + r")\s*</td>)", text)
     if len(match) > 0:
         subst_list = {}
         fp_nums = []
@@ -278,20 +280,23 @@ def htmc_color_pc_cells(text):
             fp_num = item[1]
             indicator = item[2]
             # Skip if fp_num is already processed.
-            if (fp_num, indicator) in fp_nums: continue
+            if (fp_num, indicator) in fp_nums:
+                continue
             fp_nums.append((fp_num, indicator))
-            if fp_num in na_list: subst = color_cell(cell, "cna", indicator)
+            if fp_num in na_list:
+                subst = color_cell(cell, "cna", indicator)
             else:
                 # Item is a fp num.
                 try:
                     fp = float(fp_num)
                 except ValueError:
-                    log.error("Percentage item \"%s\" in cell \"%s\" is not an " + \
+                    log.error("Percentage item \"%s\" in cell \"%s\" is not an "
                               "integer or a floating point number", fp_num, cell)
                     continue
                 # Percentage, colored.
                 if indicator == "%":
-                    if fp >= 0.0 and fp < 10.0: subst = color_cell(cell, "c0")
+                    if fp >= 0.0 and fp < 10.0:
+                        subst = color_cell(cell, "c0")
                     elif fp >= 10.0 and fp < 20.0:
                         subst = color_cell(cell, "c1")
                     elif fp >= 20.0 and fp < 30.0:


### PR DESCRIPTION
The first patch corrects a minor bug in Modes.py (presumably the relevant code never ran?). I've split it out because I'm not completely certain the change is correct. @sriyerg ?

The second patch corrects all the other PEP8 errors that flake8 reports in the codebase. The changes are mostly pretty mechanical; the only interesting one is probably the change to `merg_dicts`.

Here's the commit message from that patch:

> [dvsim] PEP8 fixes in dvsim
> 
> These should cause no functional change. Detailed list of code changes:
> 
>   - Get rid of 'import *': this defeats static analysis tools. Don't
>     do it.
> 
>   - Add newline after colon in "if foo: bar"
> 
>   - Use 'is' to check for equality with boolean literals
> 
>   - Don't catch exceptions when running os.system in Deploy.py: the
>     os.system function returns the program's exit code.
> 
>   - Delete some variables that are written but not read.
> 
>   - Minor whitespace changes (missing blank lines between functions;
>     weird indentation; missing space after '#')
> 
>   - Delete autogenerated module docstrings (they didn't contain any
>     information. Maybe it would be good to have a docstring, but at
>     the moment it's just noise).
> 
>   - Don't use \ as a line continuation character. Use parentheses if
>     necessary.
> 
>   - Replace code like "foo" + \ "bar" with just "foo" "bar" (Python
>     concatenates adjacent string literals just like C). (I didn't do
>     this everywhere, but it happened a lot next to the backslash
>     continuations, so I got rid of the unnecessary '+' then).
> 
>   - Replace "not foo in bar" with "foo not in bar"
> 
>   - Use raw strings for regexes with backslashes (r'a\+', not 'a\+')
> 
>   - General cleanup in utils.py's merge_dicts function. This caused
>     flake8 errors because it compared equality of types. The new code
>     avoids the errors and I think it's generally a bit easier to
>     understand.
