### PR TITLE
[util] Check Vendoring is Reproducible in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -122,6 +122,25 @@ jobs:
     condition: eq(variables['Build.Reason'], 'PullRequest')
     displayName: Check commit metadata
   - bash: |
+      # Here we look for all *.vendor.hjson files in the repo to re-vendor them.
+      # We exclude the following:
+      # - Any in 'hw/vendor/lowrisc_ibex', because that directory is vendored.
+      # - `./sw/vendor/riscv_compliance.vendor.hjson`, because it has whitespace
+      #   issues in the repository that we cannot easily solve.
+      find . \
+        -not \( -path './hw/vendor/lowrisc_ibex' -prune \) \
+        -not \( -name 'riscv_compliance.vendor.hjson' \) \
+        -name '*.vendor.hjson' \
+        | xargs -n1 util/vendor.py --verbose \
+        && git diff --exit-code
+      if [[ $? != 0 ]]; then
+        echo -n "##vso[task.logissue type=error]"
+        echo "Vendored repositories not up-to-date. Run util/vendor.py to fix."
+        exit 1
+      fi
+    condition: always()
+    displayName: Check vendored directories are up-to-date
+  - bash: |
       only_doc_changes=0
       if [[ "$(Build.Reason)" = "PullRequest" ]]; then
         # Conservative way of checking for documentation-only changes.

--- a/util/vendor.py
+++ b/util/vendor.py
@@ -580,7 +580,7 @@ def main(argv):
 
         # Try to load lock file (which might not exist)
         try:
-            with open(lock_file_path, 'r') as lock_file:
+            with open(str(lock_file_path), 'r') as lock_file:
                 lock = LockDesc(lock_file)
         except FileNotFoundError:
             lock = None
@@ -597,7 +597,7 @@ def main(argv):
 
     if lock is None and not args.update:
         log.warning("No lock file at {}, so will update upstream repo."
-                    .format(desc.lock_file_path()))
+                    .format(str(desc.lock_file_path())))
         args.update = True
 
     # If we have a lock file and we're not in update mode, override desc's


### PR DESCRIPTION
Now that vendoring no longer updates by default, we can ensure that vendoring is reproducible in CI.

This PR adds a CI task which checks the vendoring, as part of linting.

This is built upon #2039, and for the moment I'm just trying this out, because CI can be hard to enable.