### PR TITLE
[sw] Add a wfi to the bootrom irq handlers

### DIFF
--- a/sw/device/boot_rom/irq_vector.S
+++ b/sw/device/boot_rom/irq_vector.S
@@ -53,10 +53,12 @@
  * Default exception handler; loops forever.
  */
 exception_handler:
+  wfi
   j exception_handler
 
 /**
  * Default interrupt handler; loops forever.
  */
 default_irq_handler:
+  wfi
   j default_irq_handler


### PR DESCRIPTION
Rather than spin endlessly, filling the Verilog instruction trace with
garbage `c.j` instructions, an IRQ in the bootrom will now `wfi`, making it easy
to debug the cause of an unhandled interrupt by tailing the
instruction trace.