### PR TITLE
[dv] Use uvm_config_db to control tlul_assert

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env.sv
@@ -38,10 +38,6 @@ class cip_base_env #(type CFG_T               = cip_base_env_cfg,
                                                              cfg.devmode_vif)) begin
       `uvm_fatal(get_full_name(), "failed to get devmode_vif from uvm_config_db")
     end
-    if (!uvm_config_db#(tlul_assert_ctrl_vif)::get(this, "", "tlul_assert_ctrl_vif",
-          cfg.tlul_assert_ctrl_vif)) begin
-      `uvm_fatal(get_full_name(), "failed to get tlul_assert_ctrl_vif from uvm_config_db")
-    end
 
     // create components
     m_tl_agent = tl_agent::type_id::create("m_tl_agent", this);

--- a/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
@@ -10,7 +10,6 @@ class cip_base_env_cfg #(type RAL_T = dv_base_reg_block) extends dv_base_env_cfg
   // common interfaces - intrrupts and alerts
   intr_vif              intr_vif;
   devmode_vif           devmode_vif;
-  tlul_assert_ctrl_vif  tlul_assert_ctrl_vif;
 
   // only security IP can support devmode. If supported, override it to 1 in initialize()
   bit                   has_devmode = 1;

--- a/hw/dv/sv/cip_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/cip_base_vseq.sv
@@ -518,4 +518,10 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
                                        $countones(mask ^ {mask[TL_DBW-2:0], 1'b0}) <= 2;)
     return mask;
   endfunction
+
+  // enable/disable tl_assert
+  virtual function void set_tl_assert_en(bit enable, string path = "*");
+    uvm_config_db#(bit)::set(null, path, "tlul_assert_en", enable);
+  endfunction
+
 endclass

--- a/hw/dv/sv/cip_lib/cip_base_vseq__tl_errors.svh
+++ b/hw/dv/sv/cip_lib/cip_base_vseq__tl_errors.svh
@@ -120,17 +120,12 @@ virtual task tl_read_mem_err();
   end
 endtask
 
-virtual function void disable_tl_assert(string path = "*");
-  uvm_config_db#(bit)::set(null, path, "tlul_assert_en", 0);
-endfunction
-
 // generic task to check interrupt test reg functionality
 virtual task run_tl_errors_vseq(int num_times = 1, bit do_wait_clk = 0);
   bit test_mem_err_byte_write = (cfg.mem_ranges.size > 0) && !cfg.en_mem_byte_write;
   bit test_mem_err_read       = (cfg.mem_ranges.size > 0) && !cfg.en_mem_read;
-  cfg.tlul_assert_ctrl_vif.drive(1'b0); // TODO to clean up
-  disable_tl_assert();
 
+  set_tl_assert_en(.enable(0));
   for (int trans = 1; trans <= num_times; trans++) begin
     `uvm_info(`gfn, $sformatf("Running run_tl_errors_vseq %0d/%0d", trans, num_times), UVM_LOW)
     if (cfg.en_devmode == 1) begin
@@ -159,7 +154,7 @@ virtual task run_tl_errors_vseq(int num_times = 1, bit do_wait_clk = 0);
     join
     if (do_wait_clk) cfg.clk_rst_vif.wait_clks($urandom_range(500, 10_000));
   end // for
-  cfg.tlul_assert_ctrl_vif.drive(1'b1);
+  set_tl_assert_en(.enable(1));
 endtask : run_tl_errors_vseq
 
 `undef create_tl_access_error_case

--- a/hw/dv/sv/dv_utils/dv_utils_pkg.sv
+++ b/hw/dv/sv/dv_utils/dv_utils_pkg.sv
@@ -25,7 +25,6 @@ package dv_utils_pkg;
   // typedef parameterized pins_if for ease of implementation for interrupts and alerts
   typedef virtual pins_if #(NUM_MAX_INTERRUPTS) intr_vif;
   typedef virtual pins_if #(1)                  devmode_vif;
-  typedef virtual pins_if #(1)                  tlul_assert_ctrl_vif;
 
   // interface direction / mode - Host or Device
   typedef enum bit {

--- a/hw/ip/aes/dv/tb/tb.sv
+++ b/hw/ip/aes/dv/tb/tb.sv
@@ -38,8 +38,6 @@ module tb;
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
-    uvm_config_db#(tlul_assert_ctrl_vif)::set(null, "*.env", "tlul_assert_ctrl_vif",
-        dut.tlul_assert_device.tlul_assert_ctrl_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
     $timeformat(-12, 0, " ps", 12);
     run_test();

--- a/hw/ip/alert_handler/dv/tb/tb.sv
+++ b/hw/ip/alert_handler/dv/tb/tb.sv
@@ -84,8 +84,6 @@ module tb;
     uvm_config_db#(esc_en_vif)::set(null, "*.env", "esc_en_vif", esc_en_if);
     uvm_config_db#(entropy_vif)::set(null, "*.env", "entropy_vif", entropy_if);
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
-    uvm_config_db#(tlul_assert_ctrl_vif)::set(null, "*.env", "tlul_assert_ctrl_vif",
-        dut.tlul_assert_device.tlul_assert_ctrl_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
     $timeformat(-12, 0, " ps", 12);
     run_test();

--- a/hw/ip/entropy_src/dv/tb/tb.sv
+++ b/hw/ip/entropy_src/dv/tb/tb.sv
@@ -38,8 +38,6 @@ module tb;
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
-    uvm_config_db#(tlul_assert_ctrl_vif)::set(null, "*.env", "tlul_assert_ctrl_vif",
-        dut.tlul_assert_device.tlul_assert_ctrl_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
     $timeformat(-12, 0, " ps", 12);
     run_test();

--- a/hw/ip/gpio/dv/tb/tb.sv
+++ b/hw/ip/gpio/dv/tb/tb.sv
@@ -63,8 +63,6 @@ module tb;
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
-    uvm_config_db#(tlul_assert_ctrl_vif)::set(null, "*.env", "tlul_assert_ctrl_vif",
-        dut.tlul_assert_device.tlul_assert_ctrl_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
     uvm_config_db#(virtual pins_if #(NUM_GPIOS))::set(null, "*.env", "gpio_vif", gpio_if);
     $timeformat(-12, 0, " ps", 12);

--- a/hw/ip/hmac/dv/tb/tb.sv
+++ b/hw/ip/hmac/dv/tb/tb.sv
@@ -59,8 +59,6 @@ module tb;
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
-    uvm_config_db#(tlul_assert_ctrl_vif)::set(null, "*.env", "tlul_assert_ctrl_vif",
-        dut.tlul_assert_device.tlul_assert_ctrl_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
     uvm_config_db#(virtual alert_esc_if)::set(null, "*.env.m_alert_agent_msg_push_sha_disabled",
         "vif", alert_if_msg_push_sha_disabled);

--- a/hw/ip/i2c/dv/tb/tb.sv
+++ b/hw/ip/i2c/dv/tb/tb.sv
@@ -94,8 +94,6 @@ module tb;
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
-    uvm_config_db#(tlul_assert_ctrl_vif)::set(null, "*.env", "tlul_assert_ctrl_vif",
-        dut.tlul_assert_device.tlul_assert_ctrl_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
     uvm_config_db#(virtual i2c_if)::set(null, "*.env.m_i2c_agent*", "vif", i2c_if);
     $timeformat(-12, 0, " ps", 12);

--- a/hw/ip/rv_timer/dv/tb/tb.sv
+++ b/hw/ip/rv_timer/dv/tb/tb.sv
@@ -44,8 +44,6 @@ module tb;
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
-    uvm_config_db#(tlul_assert_ctrl_vif)::set(null, "*.env", "tlul_assert_ctrl_vif",
-        dut.tlul_assert_device.tlul_assert_ctrl_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
     $timeformat(-12, 0, " ps", 12);
     run_test();

--- a/hw/ip/spi_device/dv/tb/tb.sv
+++ b/hw/ip/spi_device/dv/tb/tb.sv
@@ -79,8 +79,6 @@ module tb;
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
-    uvm_config_db#(tlul_assert_ctrl_vif)::set(null, "*.env", "tlul_assert_ctrl_vif",
-        dut.tlul_assert_device.tlul_assert_ctrl_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
     uvm_config_db#(virtual spi_if)::set(null, "*.env.m_spi_agent*", "vif", spi_if);
     $timeformat(-12, 0, " ps", 12);

--- a/hw/ip/tlul/generic_dv/env/xbar_env.sv
+++ b/hw/ip/tlul/generic_dv/env/xbar_env.sv
@@ -21,10 +21,6 @@ class xbar_env extends dv_base_env#(.CFG_T              (xbar_env_cfg),
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
-    if (!uvm_config_db#(tlul_assert_ctrl_vif)::get(this, "", "tlul_assert_ctrl_vif",
-                                                   cfg.tlul_assert_ctrl_vif)) begin
-      `uvm_fatal(get_full_name(), "failed to get tlul_assert_ctrl_vif from uvm_config_db")
-    end
     // Connect TileLink host and device agents
     host_agent = new[cfg.num_hosts];
     foreach (host_agent[i]) begin

--- a/hw/ip/tlul/generic_dv/env/xbar_env_cfg.sv
+++ b/hw/ip/tlul/generic_dv/env/xbar_env_cfg.sv
@@ -23,8 +23,6 @@ class xbar_env_cfg extends dv_base_env_cfg;
   uint               max_device_req_delay = 20;
   uint               min_device_rsp_delay = 0;
   uint               max_device_rsp_delay = 20;
-  // use to disable/enable assert for TL error cases
-  tlul_assert_ctrl_vif  tlul_assert_ctrl_vif;
 
   `uvm_object_utils_begin(xbar_env_cfg)
     `uvm_field_array_object(host_agent_cfg,    UVM_DEFAULT)

--- a/hw/ip/tlul/generic_dv/tb/tb.sv
+++ b/hw/ip/tlul/generic_dv/tb/tb.sv
@@ -11,8 +11,6 @@ module tb;
 
   wire clk, rst_n;
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
-  wire tlul_assert_ctrl;
-  pins_if #(1) tlul_assert_ctrl_if(tlul_assert_ctrl);
 
   // this file is auto-generated and the path to this file should be provided in xbar_*_sim.core
   `include "tb__xbar_connect.sv"
@@ -21,8 +19,6 @@ module tb;
     // drive clk and rst_n from clk_if
     clk_rst_if.set_active();
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env*", "clk_rst_vif", clk_rst_if);
-    uvm_config_db#(tlul_assert_ctrl_vif)::set(null, "*.env", "tlul_assert_ctrl_vif",
-                                              tlul_assert_ctrl_if);
     $timeformat(-12, 0, " ps", 12);
     run_test();
   end

--- a/hw/ip/tlul/generic_dv/tb/xbar_macros.svh
+++ b/hw/ip/tlul/generic_dv/tb/xbar_macros.svh
@@ -11,7 +11,6 @@
    initial begin \
      force ``tl_name``_tl_if.h2d = ``path``.tl_``tl_name``_o; \
      force ``path``.tl_``tl_name``_i = ``tl_name``_tl_if.d2h; \
-     force ``path``.tlul_assert_device_``tl_name``.tlul_assert_ctrl = tlul_assert_ctrl; \
      uvm_config_db#(virtual tl_if)::set(null, $sformatf("*%0s*", `"tl_name`"), "vif", \
                                         ``tl_name``_tl_if); \
    end
@@ -21,7 +20,6 @@
    initial begin \
      force ``tl_name``_tl_if.d2h = ``path``.tl_``tl_name``_o; \
      force ``path``.tl_``tl_name``_i = ``tl_name``_tl_if.h2d; \
-     force ``path``.tlul_assert_host_``tl_name``.tlul_assert_ctrl = tlul_assert_ctrl; \
      uvm_config_db#(virtual tl_if)::set(null, $sformatf("*%0s*", `"tl_name`"), "vif", \
                                         ``tl_name``_tl_if); \
    end

--- a/hw/ip/tlul/generic_dv/tests/xbar_error_test.sv
+++ b/hw/ip/tlul/generic_dv/tests/xbar_error_test.sv
@@ -14,7 +14,7 @@ class xbar_error_test extends xbar_base_test;
 
   virtual task run_phase(uvm_phase phase);
     // disable assertions for TL errors
-    cfg.tlul_assert_ctrl_vif.drive(0);
+    uvm_config_db#(bit)::set(null, "*", "tlul_assert_en", 0);
     super.run_phase(phase);
   endtask : run_phase
 endclass : xbar_error_test

--- a/hw/ip/tlul/rtl/tlul_assert.sv
+++ b/hw/ip/tlul/rtl/tlul_assert.sv
@@ -44,13 +44,7 @@ module tlul_assert #(
 
   pend_req_t [2**TL_AIW-1:0] pend_req;
 
-  // this interfaces allows the testbench to disable some assertions
-  // by driving the corresponding pin to 1'b0
-  wire tlul_assert_ctrl, disable_sva;
-  pins_if #(1) tlul_assert_ctrl_if(tlul_assert_ctrl);
-  // the interface may be uninitialized, in which case the assertions
-  // shall be enabled, hence the explicit check for 1'b0
-  assign disable_sva = (tlul_assert_ctrl === 1'b0);
+  bit disable_sva;
 
   logic [7:0]  a_mask, d_mask;
   logic [63:0] a_data, d_data;
@@ -288,7 +282,7 @@ module tlul_assert #(
     bit tlul_assert_en;
     uvm_config_db#(bit)::wait_modified(null, "%m", "tlul_assert_en");
     uvm_config_db#(bit)::get(null, "%m", "tlul_assert_en", tlul_assert_en);
-    force tlul_assert_ctrl = tlul_assert_en; // TODO to clean up
+    disable_sva = !tlul_assert_en;
   end
 `endif
 `endif

--- a/hw/ip/uart/dv/tb/tb.sv
+++ b/hw/ip/uart/dv/tb/tb.sv
@@ -70,8 +70,6 @@ module tb;
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
-    uvm_config_db#(tlul_assert_ctrl_vif)::set(null, "*.env", "tlul_assert_ctrl_vif",
-        dut.tlul_assert_device.tlul_assert_ctrl_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
     uvm_config_db#(virtual uart_if)::set(null, "*.env.m_uart_agent*", "vif", uart_if);
     $timeformat(-12, 0, " ps", 12);

--- a/hw/ip/usbdev/dv/tb/tb.sv
+++ b/hw/ip/usbdev/dv/tb/tb.sv
@@ -121,8 +121,6 @@ module tb;
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "usb_clk_rst_vif", usb_clk_rst_if);
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
-    uvm_config_db#(tlul_assert_ctrl_vif)::set(null, "*.env", "tlul_assert_ctrl_vif",
-        dut.tlul_assert_device.tlul_assert_ctrl_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
     uvm_config_db#(virtual usb20_if)::set(null, "*.env.m_usb20_agent*", "vif", usb20_if);
     $timeformat(-12, 0, " ps", 12);

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -50,7 +50,6 @@ module tb;
   pins_if #(1) bootstrap_if(.pins(bootstrap));
   spi_if spi_if(.rst_n(rst_n));
   tl_if   cpu_d_tl_if(.clk(clk), .rst_n(rst_n));
-  pins_if #(1) tlul_assert_ctrl_if(tlul_assert_ctrl);
   uart_if uart_if();
   jtag_if jtag_if();
 
@@ -180,8 +179,6 @@ module tb;
     uvm_config_db#(virtual jtag_if)::set(null, "*.env.m_jtag_agent*", "vif", jtag_if);
     uvm_config_db#(virtual spi_if)::set(null, "*.env.m_spi_agent*", "vif", spi_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", cpu_d_tl_if);
-    uvm_config_db#(tlul_assert_ctrl_vif)::set(null, "*.env", "tlul_assert_ctrl_vif",
-                                              tlul_assert_ctrl_if);
 
     // Strap pins
     uvm_config_db#(virtual pins_if #(1))::set(

--- a/util/uvmdvgen/tb.sv.tpl
+++ b/util/uvmdvgen/tb.sv.tpl
@@ -76,8 +76,6 @@ module tb;
         "vif", alert_names);
 % endif
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
-    uvm_config_db#(tlul_assert_ctrl_vif)::set(null, "*.env", "tlul_assert_ctrl_vif",
-        dut.tlul_assert_device.tlul_assert_ctrl_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
 % endif
 % for agent in env_agents:


### PR DESCRIPTION
This is a cleanup for #2027 to update all TBs to enable/disable
tlul_assert by uvm_config_db

Signed-off-by: Weicai Yang <weicai@google.com>