### PR TITLE
[chip dv] UART integration test for DV, using DIFs. 

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -55,7 +55,7 @@
 
   // Default UVM test and seq class name.
   uvm_test: chip_base_test
-  uvm_test_seq: chip_base_vseq
+  uvm_test_seq: chip_sw_base_vseq
   sw_build_device: sim_dv
 
   // Add default build_opts.
@@ -93,42 +93,41 @@
   // List of test specifications.
   tests: [
     {
-      name: chip_sanity
-      uvm_test_seq: chip_sw_test_base_vseq
-      sw_test: sw/device/examples/hello_world/hello_world
+      name: chip_uart_tx_rx
+      uvm_test_seq: chip_sw_uart_tx_rx_vseq
+      sw_test: sw/device/tests/uart_tx_rx_test
     }
     {
       name: chip_aes_test
-      uvm_test_seq: chip_sw_test_base_vseq
+      uvm_test_seq: chip_sw_base_vseq
       sw_test: sw/device/tests/aes_test
     }
     {
       name: chip_consecutive_irqs_test
-      uvm_test_seq: chip_sw_test_base_vseq
+      uvm_test_seq: chip_sw_base_vseq
       sw_test: sw/device/tests/consecutive_irqs_test
     }
     {
       name: chip_flash_ctrl_test
-      uvm_test_seq: chip_sw_test_base_vseq
+      uvm_test_seq: chip_sw_base_vseq
       sw_test: sw/device/tests/flash_ctrl_test
-      run_opts: ["+sw_test_timeout_ns=3000000"]
     }
     {
       name: chip_sha256_test
-      uvm_test_seq: chip_sw_test_base_vseq
+      uvm_test_seq: chip_sw_base_vseq
       sw_test: sw/device/tests/sha256_test
     }
     {
       name: chip_rv_timer_test
-      uvm_test_seq: chip_sw_test_base_vseq
+      uvm_test_seq: chip_sw_base_vseq
       sw_test: sw/device/tests/rv_timer_test
     }
     {
       name: chip_coremark
-      uvm_test_seq: chip_sw_test_base_vseq
+      uvm_test_seq: chip_sw_base_vseq
       sw_test: sw/device/benchmarks/coremark/coremark_top_earlgrey
       run_opts: ["+en_uart_logger=1",
-                 "+sw_test_timeout_ns=22000000"] // 22ms
+                 "+sw_test_timeout_ns=22000000"]
     }
 
     // The test below is added in the included tl_access_tests.hjson.
@@ -143,7 +142,7 @@
   regressions: [
     {
       name: sanity
-      tests: ["chip_sanity"]
+      tests: ["chip_uart_tx_rx"]
     }
   ]
 }

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -28,7 +28,8 @@ filesets:
       - seq_lib/chip_vseq_list.sv: {is_include_file: true}
       - seq_lib/chip_base_vseq.sv: {is_include_file: true}
       - seq_lib/chip_common_vseq.sv: {is_include_file: true}
-      - seq_lib/chip_sw_test_base_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_base_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_uart_tx_rx_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/top_earlgrey/dv/env/chip_env.sv
+++ b/hw/top_earlgrey/dv/env/chip_env.sv
@@ -88,6 +88,9 @@ class chip_env extends cip_base_env #(
     if (cfg.is_active && cfg.m_spi_agent_cfg.is_active) begin
       virtual_sequencer.spi_sequencer_h = m_spi_agent.sequencer;
     end
+
+    // Connect the DUT's UART TX TLM port to the sequencer.
+    m_uart_agent.monitor.tx_analysis_port.connect(virtual_sequencer.uart_tx_fifo.analysis_export);
   endfunction
 
   virtual function void end_of_elaboration_phase(uvm_phase phase);

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -6,7 +6,7 @@ class chip_env_cfg extends cip_base_env_cfg #(.RAL_T(chip_reg_block));
 
   // Testbench settings
   bit                 stub_cpu;
-  bit                 en_uart_logger = 1'b1;
+  bit                 en_uart_logger;
   bit                 use_gpio_for_sw_test_status;
 
   // chip top interfaces

--- a/hw/top_earlgrey/dv/env/chip_virtual_sequencer.sv
+++ b/hw/top_earlgrey/dv/env/chip_virtual_sequencer.sv
@@ -12,6 +12,14 @@ class chip_virtual_sequencer extends cip_base_virtual_sequencer #(
   jtag_sequencer  jtag_sequencer_h;
   spi_sequencer   spi_sequencer_h;
 
+  // Grab packets from UART TX port for in-sequence checking.
+  uvm_tlm_analysis_fifo #(uart_item) uart_tx_fifo;
+
   `uvm_component_new
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    uart_tx_fifo = new("uart_tx_fifo", this);
+  endfunction
 
 endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -17,6 +17,9 @@ class chip_base_vseq extends cip_base_vseq #(
 
   // various knobs to enable certain routines
 
+  // Local queue for holding received UART TX data.
+  byte uart_tx_data_q[$];
+
   `uvm_object_new
 
   task post_start();
@@ -69,6 +72,16 @@ class chip_base_vseq extends cip_base_vseq #(
 
     // Now safe to do DUT init.
     if (do_dut_init) dut_init();
+  endtask
+
+  // Grab packets sent by the DUT over the UART TX port.
+  virtual task get_uart_tx_items();
+    uart_item item;
+    forever begin
+      p_sequencer.uart_tx_fifo.get(item);
+      `uvm_info(`gfn, $sformatf("Received UART data over TX:\n%0h", item.data), UVM_HIGH)
+      uart_tx_data_q.push_back(item.data);
+    end
   endtask
 
 endclass : chip_base_vseq

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class chip_sw_test_base_vseq extends chip_base_vseq;
-  `uvm_object_utils(chip_sw_test_base_vseq)
+class chip_sw_base_vseq extends chip_base_vseq;
+  `uvm_object_utils(chip_sw_base_vseq)
 
   bit sw_test_done;
 
@@ -88,4 +88,4 @@ class chip_sw_test_base_vseq extends chip_base_vseq;
     endcase
   endfunction
 
-endclass : chip_sw_test_base_vseq
+endclass : chip_sw_base_vseq

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_uart_tx_rx_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_uart_tx_rx_vseq.sv
@@ -1,0 +1,89 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_uart_tx_rx_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_uart_tx_rx_vseq)
+
+  `uvm_object_new
+
+  localparam UART_RX_FIFO_SIZE = 32;
+
+  // A set of bytes expected to be received on TX.
+  byte exp_uart_tx_data[] = {
+    8'he8, 8'h50, 8'hc6, 8'hb4, 8'hbe, 8'h16, 8'hed, 8'h55,
+    8'h16, 8'h1d, 8'he6, 8'h1c, 8'hde, 8'h9f, 8'hfd, 8'h24,
+    8'h89, 8'h81, 8'h4d, 8'h0d, 8'h1a, 8'h12, 8'h4f, 8'h57,
+    8'hea, 8'hd6, 8'h6f, 8'hc0, 8'h7d, 8'h46, 8'he7, 8'h37,
+    8'h81, 8'hd3, 8'h8e, 8'h16, 8'had, 8'h7b, 8'hd0, 8'he2,
+    8'h4f, 8'hff, 8'h39, 8'he6, 8'h71, 8'h3c, 8'h82, 8'h04,
+    8'hec, 8'h3a, 8'h27, 8'hcc, 8'h3d, 8'h58, 8'h0e, 8'h56,
+    8'hd2, 8'hd2, 8'hb9, 8'ha3, 8'hb5, 8'h3d, 8'hc0, 8'h40,
+    8'hba, 8'h90, 8'h16, 8'hd8, 8'he3, 8'ha4, 8'h22, 8'h74,
+    8'h80, 8'hcb, 8'h7b, 8'hde, 8'hd7, 8'h3f, 8'h4d, 8'h93,
+    8'h4d, 8'h59, 8'h79, 8'h88, 8'h24, 8'he7, 8'h68, 8'h8b,
+    8'h7a, 8'h78, 8'hb7, 8'h07, 8'h09, 8'h26, 8'hcf, 8'h6b,
+    8'h52, 8'hd9, 8'h4c, 8'hd3, 8'h33, 8'hdf, 8'h2e, 8'h0d,
+    8'h3b, 8'hab, 8'h45, 8'h85, 8'hc2, 8'hc2, 8'h19, 8'he5,
+    8'hc7, 8'h2b, 8'hb0, 8'hf6, 8'hcb, 8'h06, 8'hf6, 8'he2,
+    8'hf5, 8'hb1, 8'hab, 8'hef, 8'h6f, 8'hd8, 8'h23, 8'hfd
+  };
+
+// A set of bytes to be send back over RX.
+  byte uart_rx_data[] = {
+    8'h1b, 8'h95, 8'hc5, 8'hb5, 8'h8a, 8'ha4, 8'ha8, 8'h9f,
+    8'h6a, 8'h7d, 8'h6b, 8'h0c, 8'hcd, 8'hd5, 8'ha6, 8'h8f,
+    8'h07, 8'h3a, 8'h9e, 8'h82, 8'he6, 8'ha2, 8'h2b, 8'he0,
+    8'h0c, 8'h30, 8'he8, 8'h5a, 8'h05, 8'h14, 8'h79, 8'h8a,
+    8'hFf, 8'h88, 8'h29, 8'hda, 8'hc8, 8'hdd, 8'h82, 8'hd5,
+    8'h68, 8'ha5, 8'h9d, 8'h5a, 8'h48, 8'h02, 8'h7f, 8'h24,
+    8'h32, 8'haf, 8'h9d, 8'hca, 8'ha7, 8'h06, 8'h0c, 8'h96,
+    8'h65, 8'h18, 8'he4, 8'h7f, 8'h26, 8'h44, 8'hf3, 8'h14,
+    8'hC1, 8'he7, 8'hd9, 8'h82, 8'hf7, 8'h64, 8'he8, 8'h68,
+    8'hf9, 8'h6c, 8'ha9, 8'he7, 8'hd1, 8'h9b, 8'hac, 8'he1,
+    8'hFd, 8'hd8, 8'h59, 8'hb7, 8'h8e, 8'hdc, 8'h24, 8'hb8,
+    8'ha7, 8'haf, 8'h20, 8'hee, 8'h6c, 8'h61, 8'h48, 8'h41,
+    8'hB4, 8'h62, 8'h3c, 8'hcb, 8'h2c, 8'hbb, 8'he4, 8'h44,
+    8'h97, 8'h8a, 8'h5e, 8'h2f, 8'h7f, 8'h2b, 8'h10, 8'hcc,
+    8'h7d, 8'h89, 8'h32, 8'hfd, 8'hfd, 8'h58, 8'h7f, 8'hd8,
+    8'hc7, 8'h33, 8'hd1, 8'h6a, 8'hc7, 8'hba, 8'h78, 8'h69
+  };
+
+  virtual task body();
+    super.body();
+
+    // Spawn off a thread to retrieve UART TX items.
+    fork get_uart_tx_items(); join_none
+
+    // Wait until we receive at least 1 byte from the DUT (SW test).
+    wait(uart_tx_data_q.size() > 0);
+
+    // Start sending uart_rx_data in over RX.
+    fork send_uart_rx_data(); join_none
+
+    // Wait until we receive all bytes over TX.
+    wait(uart_tx_data_q.size() == exp_uart_tx_data.size());
+
+    // Check if we received the right data set over the TX port.
+    foreach (uart_tx_data_q[i]) begin
+      `DV_CHECK_EQ(uart_tx_data_q[i], exp_uart_tx_data[i])
+    end
+
+    // Send UART_RX_FIFO_SIZE+1 random bytes over RX to create an overflow condition.
+    send_uart_rx_data(.size(UART_RX_FIFO_SIZE + 1), .random(1'b1));
+  endtask
+
+  // Send data over RX.
+  virtual task send_uart_rx_data(int size = -1, bit random = 0);
+    uart_default_seq send_rx_seq;
+    `uvm_create_on(send_rx_seq, p_sequencer.uart_sequencer_h);
+    if (size == -1) size = uart_rx_data.size();
+    `uvm_info(`gfn, "Checking the received UART TX data for consistency.", UVM_LOW)
+    for (int i = 0; i < size; i++) begin
+      byte rx_data = random ? $urandom : uart_rx_data[i];
+      `DV_CHECK_RANDOMIZE_WITH_FATAL(send_rx_seq, data == rx_data;)
+      `uvm_send(send_rx_seq)
+    end
+  endtask
+
+endclass : chip_sw_uart_tx_rx_vseq

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -4,4 +4,5 @@
 
 `include "chip_base_vseq.sv"
 `include "chip_common_vseq.sv"
-`include "chip_sw_test_base_vseq.sv"
+`include "chip_sw_base_vseq.sv"
+`include "chip_sw_uart_tx_rx_vseq.sv"

--- a/sw/device/examples/hello_world/hello_world.c
+++ b/sw/device/examples/hello_world/hello_world.c
@@ -30,12 +30,6 @@ int main(int argc, char **argv) {
   LOG_INFO("Hello World!");
   LOG_INFO("Built at: " __DATE__ ", " __TIME__);
 
-  // End the test here for DV simulation, since the rest of the code is more
-  // appropriate for an FPGA demonstration.
-  if (kDeviceType == kDeviceSimDV) {
-    test_status_set(kTestStatusPassed);
-  }
-
   demo_gpio_startup(&gpio);
 
   // Now have UART <-> Buttons/LEDs demo

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -5,6 +5,7 @@
 sw_tests = {}
 
 subdir('dif')
+subdir('sim_dv')
 
 aes_test_lib = declare_dependency(
   link_with: static_library(

--- a/sw/device/tests/sim_dv/meson.build
+++ b/sw/device/tests/sim_dv/meson.build
@@ -1,0 +1,25 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+uart_tx_rx_test_lib = declare_dependency(
+  link_with: static_library(
+    'uart_tx_rx_test_lib',
+    sources: ['uart_tx_rx_test.c'],
+    dependencies: [
+      dif_uart,
+      dif_plic,
+      sw_lib_irq,
+      sw_lib_mmio,
+      sw_lib_uart,
+      sw_lib_base_log,
+      sw_lib_runtime_hart,
+      sw_lib_testing_test_status,
+      top_earlgrey,
+    ],
+  ),
+)
+
+sw_tests += {
+  'uart_tx_rx_test': uart_tx_rx_test_lib,
+}

--- a/sw/device/tests/sim_dv/uart_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/uart_tx_rx_test.c
@@ -1,0 +1,454 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/uart.h"
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/log.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_plic.h"
+#include "sw/device/lib/dif/dif_uart.h"
+#include "sw/device/lib/handler.h"
+#include "sw/device/lib/irq.h"
+#include "sw/device/lib/runtime/check.h"
+#include "sw/device/lib/runtime/hart.h"
+#include "sw/device/lib/testing/test_main.h"
+#include "sw/device/lib/testing/test_status.h"
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+#define UART_DATASET_SIZE 128
+
+static dif_uart_t uart;
+static dif_plic_t plic;
+
+/**
+ * UART TX RX test
+ *
+ * This test sends and receives a known dataset over UART. The size of the
+ * dataset is indicated with UART_DATASET_SIZE. The dataset is agreed upon by
+ * the device (a.k.a. the OpenTitan chip) and the host (a.k.a. the simulation
+ * device, such as DV testbench) communicating with it. Data transmitted over
+ * TX is checked for correctness at the host, and likewise, data sent by the
+ * host is checked for correctness at the device (in this SW test). The data
+ * transmitted over TX and RX ports may occur simultaneously. The test ensures
+ * that the TX watermark, RX watermark and TX empty interrupts are seen.
+ * At the end, the host transmits another set of random data (greater than the
+ * RX fifo size) which the device drops, to generate the RX overflow condition.
+ * The test passes when the datasets at both ends match the expected and all
+ * required interrupts are seen.
+ */
+
+/**
+ * UART test data transfer direction
+ *
+ * Enumeration indicating the direction of transfer of test data.
+ */
+typedef enum uart_direction {
+  kUartSend = 0,
+  kUartReceive,
+} uart_direction_t;
+
+// TODO: Make these datasets random.
+
+// A set of bytes to be send out of TX.
+static const uint8_t uart_tx_data[UART_DATASET_SIZE] = {
+    0xe8, 0x50, 0xc6, 0xb4, 0xbe, 0x16, 0xed, 0x55, 0x16, 0x1d, 0xe6, 0x1c,
+    0xde, 0x9f, 0xfd, 0x24, 0x89, 0x81, 0x4d, 0x0d, 0x1a, 0x12, 0x4f, 0x57,
+    0xea, 0xd6, 0x6f, 0xc0, 0x7d, 0x46, 0xe7, 0x37, 0x81, 0xd3, 0x8e, 0x16,
+    0xad, 0x7b, 0xd0, 0xe2, 0x4f, 0xff, 0x39, 0xe6, 0x71, 0x3c, 0x82, 0x04,
+    0xec, 0x3a, 0x27, 0xcc, 0x3d, 0x58, 0x0e, 0x56, 0xd2, 0xd2, 0xb9, 0xa3,
+    0xb5, 0x3d, 0xc0, 0x40, 0xba, 0x90, 0x16, 0xd8, 0xe3, 0xa4, 0x22, 0x74,
+    0x80, 0xcb, 0x7b, 0xde, 0xd7, 0x3f, 0x4d, 0x93, 0x4d, 0x59, 0x79, 0x88,
+    0x24, 0xe7, 0x68, 0x8b, 0x7a, 0x78, 0xb7, 0x07, 0x09, 0x26, 0xcf, 0x6b,
+    0x52, 0xd9, 0x4c, 0xd3, 0x33, 0xdf, 0x2e, 0x0d, 0x3b, 0xab, 0x45, 0x85,
+    0xc2, 0xc2, 0x19, 0xe5, 0xc7, 0x2b, 0xb0, 0xf6, 0xcb, 0x06, 0xf6, 0xe2,
+    0xf5, 0xb1, 0xab, 0xef, 0x6f, 0xd8, 0x23, 0xfd,
+};
+
+// The set of bytes expected to be received over RX.
+static const uint8_t exp_uart_rx_data[UART_DATASET_SIZE] = {
+    0x1b, 0x95, 0xc5, 0xb5, 0x8a, 0xa4, 0xa8, 0x9f, 0x6a, 0x7d, 0x6b, 0x0c,
+    0xcd, 0xd5, 0xa6, 0x8f, 0x07, 0x3a, 0x9e, 0x82, 0xe6, 0xa2, 0x2b, 0xe0,
+    0x0c, 0x30, 0xe8, 0x5a, 0x05, 0x14, 0x79, 0x8a, 0xFf, 0x88, 0x29, 0xda,
+    0xc8, 0xdd, 0x82, 0xd5, 0x68, 0xa5, 0x9d, 0x5a, 0x48, 0x02, 0x7f, 0x24,
+    0x32, 0xaf, 0x9d, 0xca, 0xa7, 0x06, 0x0c, 0x96, 0x65, 0x18, 0xe4, 0x7f,
+    0x26, 0x44, 0xf3, 0x14, 0xC1, 0xe7, 0xd9, 0x82, 0xf7, 0x64, 0xe8, 0x68,
+    0xf9, 0x6c, 0xa9, 0xe7, 0xd1, 0x9b, 0xac, 0xe1, 0xFd, 0xd8, 0x59, 0xb7,
+    0x8e, 0xdc, 0x24, 0xb8, 0xa7, 0xaf, 0x20, 0xee, 0x6c, 0x61, 0x48, 0x41,
+    0xB4, 0x62, 0x3c, 0xcb, 0x2c, 0xbb, 0xe4, 0x44, 0x97, 0x8a, 0x5e, 0x2f,
+    0x7f, 0x2b, 0x10, 0xcc, 0x7d, 0x89, 0x32, 0xfd, 0xfd, 0x58, 0x7f, 0xd8,
+    0xc7, 0x33, 0xd1, 0x6a, 0xc7, 0xba, 0x78, 0x69,
+};
+
+// Set our expectation & event indications of the interrupts we intend to
+// exercise in this test. These are declared volatile since they are used by the
+// interrupt handler.
+static volatile bool exp_uart_irq_tx_watermark;
+static volatile bool uart_irq_tx_watermark_fired;
+static volatile bool exp_uart_irq_rx_watermark;
+static volatile bool uart_irq_rx_watermark_fired;
+static volatile bool exp_uart_irq_tx_empty;
+static volatile bool uart_irq_tx_empty_fired;
+static volatile bool exp_uart_irq_rx_overflow;
+static volatile bool uart_irq_rx_overflow_fired;
+
+/**
+ * Provides external irq handling for this test.
+ *
+ * This function overrides the default external irq handler in
+ * `sw/device/lib/handler.h`.
+ */
+void handler_irq_external(void) {
+  // Find which interrupt fired at PLIC by claiming it.
+  dif_plic_irq_id_t plic_irq_id;
+  CHECK(dif_plic_irq_claim(&plic, kTopEarlgreyPlicTargetIbex0, &plic_irq_id) ==
+            kDifPlicOk,
+        "dif_plic_irq_claim failed");
+
+  // Check if it is the right peripheral.
+  top_earlgrey_plic_peripheral_t peripheral = (top_earlgrey_plic_peripheral_t)
+      top_earlgrey_plic_interrupt_for_peripheral[plic_irq_id];
+  CHECK(peripheral == kTopEarlgreyPlicPeripheralUart,
+        "Interurpt from unexpected peripheral: %d", peripheral);
+
+  // Correlate the interrupt fired at PLIC with UART.
+  dif_uart_interrupt_t uart_irq;
+  switch (plic_irq_id) {
+    case kTopEarlgreyPlicIrqIdUartTxWatermark:
+      CHECK(exp_uart_irq_tx_watermark, "Unexpected TX watermark interrupt");
+      uart_irq_tx_watermark_fired = true;
+      uart_irq = kDifUartInterruptTxWatermark;
+      break;
+    case kTopEarlgreyPlicIrqIdUartRxWatermark:
+      CHECK(exp_uart_irq_rx_watermark, "Unexpected RX watermark interrupt");
+      uart_irq_rx_watermark_fired = true;
+      uart_irq = kDifUartInterruptRxWatermark;
+      break;
+    case kTopEarlgreyPlicIrqIdUartTxEmpty:
+      CHECK(exp_uart_irq_tx_empty, "Unexpected TX empty interrupt");
+      uart_irq_tx_empty_fired = true;
+      uart_irq = kDifUartInterruptTxEmpty;
+      break;
+    case kTopEarlgreyPlicIrqIdUartRxOverflow:
+      CHECK(exp_uart_irq_rx_overflow, "Unexpected RX overflow interrupt");
+      uart_irq_rx_overflow_fired = true;
+      uart_irq = kDifUartInterruptRxOverflow;
+      break;
+    default:
+      LOG_ERROR("Unexpected interrupt (at PLIC): %d", plic_irq_id);
+      test_status_set(kTestStatusFailed);
+      // The `abort()` call below is redundant. It is added to prevent the
+      // compilation error due to not initializing the `uart_irq` enum variable
+      // above. See issue #2157 for moe details.
+      abort();
+  }
+
+  // Check if the same interrupt fired at UART as well.
+  dif_uart_enable_t irq_state;
+  CHECK(dif_uart_irq_state_get(&uart, uart_irq, &irq_state) == kDifUartOk,
+        "dif_uart_irq_state_get failed");
+  CHECK(irq_state == kDifUartEnable,
+        "UART interrupt fired at PLIC did not fire at UART");
+
+  // Clear the interrupt at UART.
+  CHECK(dif_uart_irq_state_clear(&uart, uart_irq) == kDifUartOk,
+        "dif_uart_irq_state_clear failed");
+
+  // Complete the IRQ at PLIC.
+  CHECK(dif_plic_irq_complete(&plic, kTopEarlgreyPlicTargetIbex0,
+                              &plic_irq_id) == kDifPlicOk,
+        "dif_plic_irq_complete failed");
+}
+
+/**
+ * Initializes UART and enables the relevant interrupts.
+ */
+static void uart_init_with_irqs(mmio_region_t base_addr, dif_uart_t *uart) {
+  LOG_INFO("Initializing the UART.");
+
+  dif_uart_config_t config = {
+      .baudrate = kUartBaudrate,
+      .clk_freq_hz = kClockFreqHz,
+      .parity_enable = kDifUartDisable,
+      .parity = kDifUartParityEven,
+  };
+  CHECK(dif_uart_init(base_addr, &config, uart) == kDifUartConfigOk,
+        "dif_uart_init failed");
+
+  // Set the TX and RX watermark to 16 bytes.
+  CHECK(dif_uart_watermark_tx_set(uart, kDifUartWatermarkByte16) == kDifUartOk,
+        "dif_uart_watermark_tx_set failed");
+  CHECK(dif_uart_watermark_rx_set(uart, kDifUartWatermarkByte16) == kDifUartOk,
+        "dif_uart_watermark_rx_set failed");
+
+  // Enable these UART interrupts - TX/TX watermark, TX empty and RX overflow.
+  CHECK(dif_uart_irq_enable(uart, kDifUartInterruptTxWatermark,
+                            kDifUartEnable) == kDifUartOk,
+        "dif_uart_irq_enable failed");
+  CHECK(dif_uart_irq_enable(uart, kDifUartInterruptRxWatermark,
+                            kDifUartEnable) == kDifUartOk,
+        "dif_uart_irq_enable failed");
+  CHECK(dif_uart_irq_enable(uart, kDifUartInterruptTxEmpty, kDifUartEnable) ==
+            kDifUartOk,
+        "dif_uart_irq_enable failed");
+  CHECK(dif_uart_irq_enable(uart, kDifUartInterruptRxOverflow,
+                            kDifUartEnable) == kDifUartOk,
+        "dif_uart_irq_enable failed");
+}
+
+/**
+ * Initializes PLIC and enables the relevant UART interrupts.
+ */
+static void plic_init_with_irqs(mmio_region_t base_addr, dif_plic_t *plic) {
+  LOG_INFO("Initializing the PLIC.");
+
+  CHECK(dif_plic_init(base_addr, plic) == kDifPlicOk, "dif_plic_init failed");
+
+  // Enable UART interrupts at PLIC as edge triggered.
+  CHECK(
+      dif_plic_irq_trigger_type_set(plic, kTopEarlgreyPlicIrqIdUartTxWatermark,
+                                    kDifPlicEnable) == kDifPlicOk,
+      "dif_plic_irq_trigger_type_set failed");
+  CHECK(
+      dif_plic_irq_trigger_type_set(plic, kTopEarlgreyPlicIrqIdUartRxWatermark,
+                                    kDifPlicEnable) == kDifPlicOk,
+      "dif_plic_irq_trigger_type_set failed");
+  CHECK(dif_plic_irq_trigger_type_set(plic, kTopEarlgreyPlicIrqIdUartTxEmpty,
+                                      kDifPlicEnable) == kDifPlicOk,
+        "dif_plic_irq_trigger_type_set failed");
+  CHECK(dif_plic_irq_trigger_type_set(plic, kTopEarlgreyPlicIrqIdUartRxOverflow,
+                                      kDifPlicEnable) == kDifPlicOk,
+        "dif_plic_irq_trigger_type_set failed");
+  CHECK(dif_plic_irq_trigger_type_set(plic, kTopEarlgreyPlicIrqIdUartRxFrameErr,
+                                      kDifPlicEnable) == kDifPlicOk,
+        "dif_plic_irq_trigger_type_set failed");
+  CHECK(dif_plic_irq_trigger_type_set(plic, kTopEarlgreyPlicIrqIdUartRxBreakErr,
+                                      kDifPlicEnable) == kDifPlicOk,
+        "dif_plic_irq_trigger_type_set failed");
+  CHECK(dif_plic_irq_trigger_type_set(plic, kTopEarlgreyPlicIrqIdUartRxTimeout,
+                                      kDifPlicEnable) == kDifPlicOk,
+        "dif_plic_irq_trigger_type_set failed");
+  CHECK(
+      dif_plic_irq_trigger_type_set(plic, kTopEarlgreyPlicIrqIdUartRxParityErr,
+                                    kDifPlicEnable) == kDifPlicOk,
+      "dif_plic_irq_trigger_type_set failed");
+
+  // Set the priority of UART interrupts at PLIC to be >=1 (so ensure the target
+  // does get interrupted).
+  CHECK(dif_plic_irq_priority_set(plic, kTopEarlgreyPlicIrqIdUartTxWatermark,
+                                  0x1) == kDifPlicOk,
+        "dif_plic_irq_priority_set failed");
+  CHECK(dif_plic_irq_priority_set(plic, kTopEarlgreyPlicIrqIdUartRxWatermark,
+                                  0x2) == kDifPlicOk,
+        "dif_plic_irq_priority_set failed");
+  CHECK(dif_plic_irq_priority_set(plic, kTopEarlgreyPlicIrqIdUartTxEmpty,
+                                  0x3) == kDifPlicOk,
+        , "dif_plic_irq_priority_set failed");
+  CHECK(dif_plic_irq_priority_set(plic, kTopEarlgreyPlicIrqIdUartRxOverflow,
+                                  0x1) == kDifPlicOk,
+        "dif_plic_irq_priority_set failed");
+  CHECK(dif_plic_irq_priority_set(plic, kTopEarlgreyPlicIrqIdUartRxFrameErr,
+                                  0x2) == kDifPlicOk,
+        "dif_plic_irq_priority_set failed");
+  CHECK(dif_plic_irq_priority_set(plic, kTopEarlgreyPlicIrqIdUartRxBreakErr,
+                                  0x3) == kDifPlicOk,
+        "dif_plic_irq_priority_set failed");
+  CHECK(dif_plic_irq_priority_set(plic, kTopEarlgreyPlicIrqIdUartRxTimeout,
+                                  0x1) == kDifPlicOk,
+        "dif_plic_irq_priority_set failed");
+  CHECK(dif_plic_irq_priority_set(plic, kTopEarlgreyPlicIrqIdUartRxParityErr,
+                                  0x2) == kDifPlicOk,
+        "dif_plic_irq_priority_set failed");
+
+  // Set the threshold for the Ibex to 0.
+  CHECK(dif_plic_target_threshold_set(plic, kTopEarlgreyPlicTargetIbex0, 0x0) ==
+            kDifPlicOk,
+        "dif_plic_target_threshold_set failed");
+
+  // Enable all UART interrupts at the PLIC.
+  CHECK(dif_plic_irq_enable_set(plic, kTopEarlgreyPlicIrqIdUartTxWatermark,
+                                kTopEarlgreyPlicTargetIbex0,
+                                kDifPlicEnable) == kDifPlicOk,
+        "dif_plic_irq_enable_set failed");
+
+  CHECK(dif_plic_irq_enable_set(plic, kTopEarlgreyPlicIrqIdUartRxWatermark,
+                                kTopEarlgreyPlicTargetIbex0,
+                                kDifPlicEnable) == kDifPlicOk,
+        "dif_plic_irq_enable_set failed");
+
+  CHECK(dif_plic_irq_enable_set(plic, kTopEarlgreyPlicIrqIdUartTxEmpty,
+                                kTopEarlgreyPlicTargetIbex0,
+                                kDifPlicEnable) == kDifPlicOk,
+        "dif_plic_irq_enable_set failed");
+
+  CHECK(dif_plic_irq_enable_set(plic, kTopEarlgreyPlicIrqIdUartRxOverflow,
+                                kTopEarlgreyPlicTargetIbex0,
+                                kDifPlicEnable) == kDifPlicOk,
+        "dif_plic_irq_enable_set failed");
+
+  CHECK(dif_plic_irq_enable_set(plic, kTopEarlgreyPlicIrqIdUartRxFrameErr,
+                                kTopEarlgreyPlicTargetIbex0,
+                                kDifPlicEnable) == kDifPlicOk,
+        "dif_plic_irq_enable_set failed");
+
+  CHECK(dif_plic_irq_enable_set(plic, kTopEarlgreyPlicIrqIdUartRxBreakErr,
+                                kTopEarlgreyPlicTargetIbex0,
+                                kDifPlicEnable) == kDifPlicOk,
+        "dif_plic_irq_enable_set failed");
+
+  CHECK(dif_plic_irq_enable_set(plic, kTopEarlgreyPlicIrqIdUartRxTimeout,
+                                kTopEarlgreyPlicTargetIbex0,
+                                kDifPlicEnable) == kDifPlicOk,
+        "dif_plic_irq_enable_set failed");
+
+  CHECK(dif_plic_irq_enable_set(plic, kTopEarlgreyPlicIrqIdUartRxParityErr,
+                                kTopEarlgreyPlicTargetIbex0,
+                                kDifPlicEnable) == kDifPlicOk,
+        "dif_plic_irq_enable_set failed");
+}
+
+/**
+ * Continue ongoing transmission of bytes.
+ *
+ * This is a wrapper around `dif_uart_bytes_send|receive()` functions. It picks
+ * up an ongoing transfer of data starting at `dataset_index` location until
+ * the UART can no longer accept any more data to be sent / return any more
+ * data received, depending on the direction of the data transfer indicated with
+ * the `uart_direction` argument. It uses the `bytes_written` / `bytes_read`
+ * value to advance the `dataset_index` for the next round. It updates the
+ * `transfer_done` arg to indicate if the ongoing transfer has completed.
+ */
+static bool uart_transfer_ongoing_bytes(const dif_uart_t *uart,
+                                        uart_direction_t uart_direction,
+                                        uint8_t *data, size_t dataset_size,
+                                        size_t *dataset_index,
+                                        bool *transfer_done) {
+  size_t bytes_remaining = dataset_size - *dataset_index;
+  size_t bytes_transferred = 0;
+  bool result = false;
+  switch (uart_direction) {
+    case kUartSend:
+      result = dif_uart_bytes_send(uart, &data[*dataset_index], bytes_remaining,
+                                   &bytes_transferred) == kDifUartOk;
+      break;
+    case kUartReceive:
+      result =
+          dif_uart_bytes_receive(uart, bytes_remaining, &data[*dataset_index],
+                                 &bytes_transferred) == kDifUartOk;
+      break;
+    default:
+      LOG_FATAL("Invalid UART data transfer direction!");
+  }
+  *dataset_index += bytes_transferred;
+  *transfer_done = *dataset_index == dataset_size;
+  return result;
+}
+
+static bool execute_test(const dif_uart_t *uart) {
+  bool uart_tx_done = false;
+  size_t uart_tx_bytes_written = 0;
+  exp_uart_irq_tx_watermark = true;
+  // Set the flag below to true to allow TX data to be sent the first time in
+  // the if comdition below. Subsequently, TX watermark interrupt will trigger
+  // more data to be sent.
+  uart_irq_tx_watermark_fired = true;
+  exp_uart_irq_tx_empty = false;
+  uart_irq_tx_empty_fired = false;
+
+  bool uart_rx_done = false;
+  size_t uart_rx_bytes_read = 0;
+  exp_uart_irq_rx_watermark = true;
+  // Set the flag below to true to allow RX data to be received the first time
+  // in the if comdition below. Subsequently, RX watermark interrupt will
+  // trigger more data to be received.
+  uart_irq_rx_watermark_fired = true;
+  exp_uart_irq_rx_overflow = false;
+  uart_irq_rx_overflow_fired = false;
+
+  // A set of bytes actually received over RX.
+  uint8_t uart_rx_data[UART_DATASET_SIZE];
+
+  LOG_INFO("Executing the test.");
+  while (!uart_tx_done || !uart_rx_done || !uart_irq_tx_empty_fired ||
+         !uart_irq_rx_overflow_fired) {
+    if (!uart_tx_done && uart_irq_tx_watermark_fired) {
+      uart_irq_tx_watermark_fired = false;
+
+      // Send the remaining uart_tx_data as and when the TX watermark fires.
+      CHECK(uart_transfer_ongoing_bytes(
+          uart, kUartSend, (uint8_t *)uart_tx_data, UART_DATASET_SIZE,
+          &uart_tx_bytes_written, &uart_tx_done));
+
+      if (uart_tx_done) {
+        // At this point, we have sent the required number of bytes.
+        // Expect the TX empty interrupt to fire at some point.
+        exp_uart_irq_tx_empty = true;
+      }
+    }
+
+    if (!uart_rx_done && uart_irq_rx_watermark_fired) {
+      uart_irq_rx_watermark_fired = false;
+
+      // Receive the remaining uart_rx_data as and when the RX watermark fires.
+      CHECK(uart_transfer_ongoing_bytes(uart, kUartReceive, uart_rx_data,
+                                        UART_DATASET_SIZE, &uart_rx_bytes_read,
+                                        &uart_rx_done));
+
+      if (uart_rx_done) {
+        exp_uart_irq_rx_watermark = false;
+        // At this point we have received the required number of bytes.
+        // We disable the RX watermark interrupt and let the fifo
+        // overflow by dropping all future incoming data.
+        CHECK(dif_uart_irq_enable(uart, kDifUartInterruptRxWatermark,
+                                  kDifUartDisable) == kDifUartOk,
+              "dif_uart_irq_enable failed");
+        // Expect the RX overflow interrupt to fire at some point.
+        exp_uart_irq_rx_overflow = true;
+      }
+    }
+
+    if (uart_irq_tx_empty_fired) {
+      exp_uart_irq_tx_watermark = false;
+      exp_uart_irq_tx_empty = false;
+    }
+
+    if (uart_irq_rx_overflow_fired) {
+      exp_uart_irq_rx_overflow = false;
+    }
+
+    // Wait for the next interrupt to arrive.
+    wait_for_interrupt();
+  }
+
+  // Check data consistency.
+  LOG_INFO("Checking the received UART RX data for consistency.");
+  for (int i = 0; i < UART_DATASET_SIZE; ++i) {
+    CHECK(uart_rx_data[i] == exp_uart_rx_data[i],
+          "UART RX data[%0d] mismatched: {act: %x, exp: %x}", i,
+          uart_rx_data[i], exp_uart_rx_data[i]);
+  }
+
+  // If we reached here, then the test passed.
+  return true;
+}
+
+bool test_main(void) {
+  LOG_INFO("UART TX RX test");
+
+  // Initialize the UART.
+  mmio_region_t uart_base_addr =
+      mmio_region_from_addr(TOP_EARLGREY_UART_BASE_ADDR);
+  uart_init_with_irqs(uart_base_addr, &uart);
+
+  // Initialize the PLIC.
+  mmio_region_t plic_base_addr =
+      mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR);
+  plic_init_with_irqs(plic_base_addr, &plic);
+
+  // Enable the external IRQ at Ibex.
+  irq_global_ctrl(true);
+  irq_external_ctrl(true);
+
+  // Execute the test.
+  return execute_test(&uart);
+}


### PR DESCRIPTION
The C test and the SV test work together to send a payload of 128 bytes over UART TX and RX ports respectively. Each entity checks the integrity of the received payload. 

The C test in addition checks and services 4 UART interrupts - tx/rx watermark, tx empty and rx overflow. 

The test currently fails due to a fix required in `dif_uart_irq_state_clear()` function made in #2047. 