### PR TITLE
[dv/alert_handler] entropy length adjustment

### DIFF
--- a/hw/ip/alert_handler/dv/alert_handler_sim_cfg.hjson
+++ b/hw/ip/alert_handler/dv/alert_handler_sim_cfg.hjson
@@ -77,7 +77,11 @@
     {
       name: alert_handler_entropy
       uvm_test_seq: alert_handler_entropy_vseq
-      run_opts: ["+test_timeout_ns=10000000000"]
+      run_opts: ["+test_timeout_ns=20_000_000_000"]
+    }
+    {
+      name: alert_handler_stress_all
+      run_opts: ["+test_timeout_ns=200_000_000_000"]
     }
   ]
 

--- a/hw/ip/alert_handler/dv/env/alert_handler_scoreboard.sv
+++ b/hw/ip/alert_handler/dv/env/alert_handler_scoreboard.sv
@@ -188,12 +188,12 @@ class alert_handler_scoreboard extends cip_base_scoreboard #(
 
   // check if escalation signal's duration length is correct
   virtual function void check_esc_signal(int cycle_cnt, int esc_sig_i);
-    `uvm_info(`gfn, $sformatf("esc signal_%0d triggered, cycle cnt is %0d", esc_sig_i, cycle_cnt),
-              UVM_LOW)
     if (ral.regen.get_mirrored_value()) begin
       // if ping response enabled, will not check cycle count if esc ping is enabled
       `DV_CHECK_EQ(cycle_cnt, esc_cnter_per_signal[esc_sig_i],
                    $sformatf("check signal_%0d", esc_sig_i))
+      `uvm_info(`gfn, $sformatf("esc signal_%0d triggered, cycle cnt is %0d",
+                                esc_sig_i, cycle_cnt), UVM_LOW)
     end
     esc_cnter_per_signal[esc_sig_i] = 0;
     esc_sig_class[esc_sig_i] = 0;

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_entropy_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_entropy_vseq.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// this sequence triggers escalation by the interrupt timeout
+// this sequence enable entropy by writing 1 to the lock_regen register.
 
 class alert_handler_entropy_vseq extends alert_handler_sanity_vseq;
   `uvm_object_utils(alert_handler_entropy_vseq)
@@ -12,15 +12,22 @@ class alert_handler_entropy_vseq extends alert_handler_sanity_vseq;
   rand bit drive_entropy;
   rand bit lock_regen;
 
-  // TODO: re-evaluate the constraint based on ping coverage data
+  // large number of num_trans to make sure covers all alerts and escalation pings
   constraint num_trans_c {
-    num_trans inside {[4000:8000]};
+    num_trans inside {[4000:100_000]};
+  }
+
+  // increase the possibility to enable more alerts, because alert_handler only sends ping on
+  // enabled alerts
+  constraint enable_one_alert_c {
+    alert_en dist {'b1111 := 9, [0:'b1110] := 1};
   }
 
   function void pre_randomize();
-    this.enable_one_alert_c.constraint_mode(0);
     this.enable_classa_only_c.constraint_mode(0);
     this.sig_int_c.constraint_mode(0);
+    // set verbosity high to avoid printing out too much information
+    verbosity = UVM_HIGH;
   endfunction
 
   virtual task alert_handler_init(bit [NUM_ALERT_HANDLER_CLASSES-1:0] intr_en = '1,
@@ -30,6 +37,11 @@ class alert_handler_entropy_vseq extends alert_handler_sanity_vseq;
                                   bit [TL_DW-1:0]                     loc_alert_class = 'h0);
     super.alert_handler_init(intr_en, alert_en, alert_class, loc_alert_en, loc_alert_class);
     cfg.entropy_vif.drive(drive_entropy);
+    if (ral.regen.get_mirrored_value() == 1) begin
+      `uvm_info(`gfn,
+          $sformatf("init setting: intr_en=%0b, alert_en=%0b, alert_class=%0b, regen=%0b",
+          intr_en, alert_en, alert_class, lock_regen), UVM_LOW)
+    end
     csr_wr(.csr(ral.regen), .value(lock_regen));
   endtask
 

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_sanity_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_sanity_vseq.sv
@@ -26,6 +26,8 @@ class alert_handler_sanity_vseq extends alert_handler_base_vseq;
 
   int      max_wait_phases_cyc = MIN_CYCLE_PER_PHASE * NUM_ESC_PHASES;
 
+  uvm_verbosity verbosity = UVM_LOW;
+
   constraint enable_one_alert_c {
     $onehot(alert_en);
   }
@@ -61,7 +63,7 @@ class alert_handler_sanity_vseq extends alert_handler_base_vseq;
 
       `uvm_info(`gfn,
           $sformatf("starting seq %0d/%0d: intr_en=%0b, alert=%0b, alert_en=%0b, alert_class=%0b",
-          i, num_trans, intr_en, alert_trigger, alert_en, alert_class_map), UVM_LOW)
+          i, num_trans, intr_en, alert_trigger, alert_en, alert_class_map), verbosity)
 
       // write initial settings (enable and mapping csrs)
       alert_handler_init(.intr_en(intr_en), .alert_en(alert_en), .alert_class(alert_class_map),


### PR DESCRIPTION
Based on the coverage results, to cover the ping for all alerts and
escalation devices, we need to increase the num_trans and timeout limit

Signed-off-by: Cindy Chen <chencindy@google.com>