### PR TITLE
[top_earlgrey] Change the `earlgrey` to generic

### DIFF
--- a/hw/top_earlgrey/data/top_earlgrey.c.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.c.tpl
@@ -7,11 +7,11 @@
 /**
  * PLIC Interrupt Id to Peripheral Map
  *
- * This array is a mapping from `top_earlgrey_plic_irq_id_t` to
- * `top_earlgrey_plic_peripheral_t`.
+ * This array is a mapping from `top_${top["name"]}_plic_irq_id_t` to
+ * `top_${top["name"]}_plic_peripheral_t`.
  */
-const top_earlgrey_plic_peripheral_t
-    top_earlgrey_plic_interrupt_for_peripheral[${len(c_gen_info["interrupt_id_map"])}] = {
+const top_${top["name"]}_plic_peripheral_t
+    top_${top["name"]}_plic_interrupt_for_peripheral[${len(c_gen_info["interrupt_id_map"])}] = {
 % for (irq_id_name, module_name) in c_gen_info["interrupt_id_map"].items():
   [${irq_id_name}] = ${module_name},
 %endfor

--- a/hw/top_earlgrey/data/top_earlgrey.h.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.h.tpl
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef _TOP_EARLGREY_H_
-#define _TOP_EARLGREY_H_
+#ifndef _TOP_${top["name"].upper()}_H_
+#define _TOP_${top["name"].upper()}_H_
 
 #define PINMUX_PERIPH_INSEL_IDX_OFFSET 2
 
@@ -47,12 +47,12 @@
 
 % for m in top["module"]:
 /**
- * Base address for ${m["name"]} peripheral in top earlgrey.
+ * Base address for ${m["name"]} peripheral in top ${top["name"]}.
  *
  * This should be used with #mmio_region_from_addr to access the memory-mapped
  * registers associated with the peripheral (usually via a DIF).
  */
-#define TOP_EARLGREY_${m["name"].upper()}_BASE_ADDR ${m["base_addr"]}u
+#define TOP_${top["name"].upper()}_${m["name"].upper()}_BASE_ADDR ${m["base_addr"]}u
 
 % endfor
 
@@ -78,7 +78,7 @@ def interrupt_id_enum_name(intr_name, intr_num=None):
 
 %>\
 ## This dictionary will be used in the C implementation to generate
-## `top_earlgrey_plic_interrupt_for_peripheral`.
+## `top_${top["name"]}_plic_interrupt_for_peripheral`.
 <% c_gen_info["interrupt_id_map"] = {} %>\
 /**
  * PLIC Interrupt source peripheral enumeration.
@@ -86,7 +86,7 @@ def interrupt_id_enum_name(intr_name, intr_num=None):
  * Enumeration used to determine which peripheral asserted the corresponding
  * interrupt.
  */
-typedef enum top_earlgrey_plic_peripheral {
+typedef enum top_${top["name"]}_plic_peripheral {
   ${peripheral_enum_name("unknown")} = 0, /**< Unknown Peripheral */
 <% enum_id = 1 %>\
 % for mod_name in top["interrupt_module"]:
@@ -94,7 +94,7 @@ typedef enum top_earlgrey_plic_peripheral {
 <% enum_id += 1 %>\
 % endfor
   ${peripheral_enum_name("last")} = ${enum_id - 1}, /**< \internal Final PLIC peripheral */
-} top_earlgrey_plic_peripheral_t;
+} top_${top["name"]}_plic_peripheral_t;
 
 /**
  * PLIC Interrupt Ids Enumeration
@@ -102,7 +102,7 @@ typedef enum top_earlgrey_plic_peripheral {
  * Enumeration of all PLIC interrupt source IDs. The IRQ IDs belonging to
  * the same peripheral are guaranteed to be consecutive.
  */
-typedef enum top_earlgrey_plic_irq_id {
+typedef enum top_${top["name"]}_plic_irq_id {
   ${interrupt_id_enum_name("none")} = 0, /**< No Interrupt */
 <% c_gen_info["interrupt_id_map"][interrupt_id_enum_name("none")] = peripheral_enum_name("unknown") %>\
 <% enum_id = 1 %>\
@@ -120,16 +120,16 @@ typedef enum top_earlgrey_plic_irq_id {
     % endif
 % endfor
   ${interrupt_id_enum_name("last")} = ${enum_id - 1}, /**< \internal The Last Valid Interrupt ID. */
-} top_earlgrey_plic_irq_id_t;
+} top_${top["name"]}_plic_irq_id_t;
 
 /**
  * PLIC Interrupt Id to Peripheral Map
  *
- * This array is a mapping from `top_earlgrey_plic_irq_id_t` to
- * `top_earlgrey_plic_peripheral_t`.
+ * This array is a mapping from `top_${top["name"]}_plic_irq_id_t` to
+ * `top_${top["name"]}_plic_peripheral_t`.
  */
-extern const top_earlgrey_plic_peripheral_t
-    top_earlgrey_plic_interrupt_for_peripheral[${len(c_gen_info["interrupt_id_map"])}];
+extern const top_${top["name"]}_plic_peripheral_t
+    top_${top["name"]}_plic_interrupt_for_peripheral[${len(c_gen_info["interrupt_id_map"])}];
 
 /**
  * PLIC external interrupt target.
@@ -137,13 +137,13 @@ extern const top_earlgrey_plic_peripheral_t
  * Enumeration used to determine which set of IE, CC, threshold registers to
  * access dependent on the target.
  */
-typedef enum top_earlgrey_plic_target {
+typedef enum top_${top["name"]}_plic_target {
 <% enum_id = 0 %>\
 % for core_id in range(int(top["num_cores"])):
   kTopEarlgreyPlicTargetIbex${core_id} = ${enum_id}, /**< Ibex Core ${core_id} */
 <% enum_id += 1 %>\
 % endfor
   kTopEarlgreyPlicTargetLast = ${enum_id - 1}, /**< \internal Final PLIC target */
-} top_earlgrey_plic_target_t;
+} top_${top["name"]}_plic_target_t;
 
-#endif  // _TOP_EARLGREY_H_
+#endif  // _TOP_${top["name"].upper()}_H_

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -167,6 +167,22 @@
 #define TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR 0x40130000u
 
 /**
+ * Base address for pwrmgr peripheral in top earlgrey.
+ *
+ * This should be used with #mmio_region_from_addr to access the memory-mapped
+ * registers associated with the peripheral (usually via a DIF).
+ */
+#define TOP_EARLGREY_PWRMGR_BASE_ADDR 0x400A0000u
+
+/**
+ * Base address for rstmgr peripheral in top earlgrey.
+ *
+ * This should be used with #mmio_region_from_addr to access the memory-mapped
+ * registers associated with the peripheral (usually via a DIF).
+ */
+#define TOP_EARLGREY_RSTMGR_BASE_ADDR 0x400B0000u
+
+/**
  * Base address for nmi_gen peripheral in top earlgrey.
  *
  * This should be used with #mmio_region_from_addr to access the memory-mapped
@@ -181,6 +197,7 @@
  * registers associated with the peripheral (usually via a DIF).
  */
 #define TOP_EARLGREY_USBDEV_BASE_ADDR 0x40150000u
+
 
 /**
  * PLIC Interrupt source peripheral enumeration.

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -34,6 +34,7 @@ genhdr = '''// Copyright lowRISC contributors.
 
 SRCTREE_TOP = Path(__file__).parent.parent
 
+
 def generate_top(top, tpl_filename, **kwargs):
     top_tpl = Template(filename=tpl_filename)
 
@@ -621,7 +622,8 @@ def main():
 
         def render_template(out_name_tpl, out_dir, **other_info):
             top_tplpath = tpl_path / ((out_name_tpl + '.tpl') % (top_name))
-            template_contents = generate_top(completecfg, str(top_tplpath), **other_info)
+            template_contents = generate_top(completecfg, str(top_tplpath),
+                                             **other_info)
 
             rendered_dir = out_path / out_dir
             rendered_dir.mkdir(parents=True, exist_ok=True)
@@ -649,22 +651,25 @@ def main():
         cformat_path.write_text(cformat_tplpath.read_text())
 
         # 'top_earlgrey.h.tpl' -> 'sw/autogen/top_earlgrey.h'
-        cheader_path = render_template('top_%s.h', 'sw/autogen', c_gen_info=c_gen_info)
+        cheader_path = render_template('top_%s.h',
+                                       'sw/autogen',
+                                       c_gen_info=c_gen_info)
 
         # Save the relative header path into `c_gen_info`
         rel_header_path = cheader_path.relative_to(SRCTREE_TOP)
         c_gen_info["header_path"] = str(rel_header_path)
 
         # 'top_earlgrey.c.tpl' -> 'sw/autogen/top_earlgrey.c'
-        cimpl_path = render_template('top_%s.c', 'sw/autogen', c_gen_info=c_gen_info)
+        render_template('top_%s.c', 'sw/autogen', c_gen_info=c_gen_info)
 
         # Fix the C header guard, which will have the wrong name
-        subprocess.run(["util/fix_include_guard.py", str(cheader_path)],
-                        universal_newlines=True,
-                        stdout=subprocess.DEVNULL,
-                        stderr=subprocess.DEVNULL,
-                        check=True,
-                        cwd=str(SRCTREE_TOP))
+        subprocess.run(["util/fix_include_guard.py",
+                        str(cheader_path)],
+                       universal_newlines=True,
+                       stdout=subprocess.DEVNULL,
+                       stderr=subprocess.DEVNULL,
+                       check=True,
+                       cwd=str(SRCTREE_TOP))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Revise the hard-coded top name `earlgrey` to generic.
It makes easier to port the top design over to new top.