### PR TITLE
[dv] Add excl for rstmgr, pwrmgr and fix top-level csr test

### DIFF
--- a/hw/dv/sv/dv_lib/dv_base_reg.sv
+++ b/hw/dv/sv/dv_lib/dv_base_reg.sv
@@ -74,6 +74,7 @@ class dv_base_reg extends uvm_reg;
         // rw.value is a dynamic array
         "W1C": if (rw.value[0][0] == 1'b1) set_locked_regs_access("RO");
         "W0C": if (rw.value[0][0] == 1'b0) set_locked_regs_access("RO");
+        "RO": ; // if RO, it's updated by design, need to predict in scb
         default:`uvm_fatal(`gtn, $sformatf("enable register invalid access %s", field_access))
       endcase
     end

--- a/hw/ip/pwrmgr/data/pwrmgr.hjson
+++ b/hw/ip/pwrmgr/data/pwrmgr.hjson
@@ -104,6 +104,9 @@
           resval: "1",
         },
       ]
+      tags: [// This regwen is completely under HW management and thus cannot be manipulated
+             // by software.
+             "excl:CsrNonInitTests:CsrExclCheck"]
     },
 
 
@@ -201,6 +204,8 @@
           ]
         },
       ],
+      tags: [// The regwen for this reg is RO. CSR seq can't support to check this reg
+             "excl:CsrNonInitTests:CsrExclCheck"]
     },
 
     { name: "CFG_CDC_SYNC",
@@ -228,6 +233,9 @@
           resval: "0",
         },
       ]
+      tags: [// This bit triggers a payload synchronization and self clears when complete.
+             // Do not write this bit as there will be side effects and the value will not persist
+             "excl:CsrNonInitTests:CsrExclCheck"]
     },
 
     { name: "WAKEUP_EN_REGWEN",
@@ -380,10 +388,9 @@
           ''',
         },
       ]
+      tags: [// This regwen is completely under HW management and thus cannot be manipulated
+             // by software.
+             "excl:CsrNonInitTests:CsrExclCheck"]
     },
-
-
-
-
   ]
 }

--- a/hw/ip/rstmgr/data/rstmgr.hjson
+++ b/hw/ip/rstmgr/data/rstmgr.hjson
@@ -101,6 +101,8 @@
             resval: 1,
         },
       ]
+      tags: [// Don't reset other IPs as it will affect CSR access on these IPs
+             "excl:CsrAllTests:CsrExclWrite"]
     },
 
     { name: "USB_REGEN",
@@ -117,6 +119,8 @@
             resval: 1,
         },
       ]
+      tags: [// Don't reset other IPs as it will affect CSR access on these IPs
+             "excl:CsrAllTests:CsrExclWrite"]
     },
 
     { name: "RST_SPI_DEVICE_N",
@@ -135,6 +139,8 @@
             resval: 1,
         },
       ]
+      tags: [// Don't reset other IPs as it will affect CSR access on these IPs
+             "excl:CsrAllTests:CsrExclWrite"]
     },
 
     { name: "RST_USB_N",
@@ -153,6 +159,8 @@
             resval: 1,
         },
       ]
+      tags: [// Don't reset other IPs as it will affect CSR access on these IPs
+             "excl:CsrAllTests:CsrExclWrite"]
     }
   ]
 }

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
@@ -16,6 +16,13 @@ class chip_common_vseq extends chip_base_vseq;
     cfg.jtag_spi_n_vif.drive(1'b0);
   endtask
 
+  virtual task apply_reset(string kind = "HARD");
+    super.apply_reset(kind);
+    // TODO rstmgr takes some time to release reset for IPs. Need to find a better way to know when
+    // reset is released by rstmgr
+    cfg.clk_rst_vif.wait_clks(100);
+  endtask
+
   virtual task body();
     run_common_vseq_wrapper(num_trans);
   endtask : body


### PR DESCRIPTION
1. Add excl for rstmgr, pwrmgr
2. Update dv_base_reg to allow RO type for regwen
3. Add extra delay in apply_reset to allow rstmgr release reset for
other IPs
Signed-off-by: Weicai Yang <weicai@google.com>