### PR TITLE
[sw] Change the SPI IRQ clear function to take an IRQ type

### DIFF
--- a/sw/device/lib/dif/dif_spi_device.h
+++ b/sw/device/lib/dif/dif_spi_device.h
@@ -142,10 +142,11 @@ dif_spi_device_result_t dif_spi_device_irq_get(const dif_spi_device_t *spi,
  * Clears all active interrupt bits.
  *
  * @param spi A SPI device.
+ * @type Which IRQ type to clear.
  * @return The result of the operation.
  */
-dif_spi_device_result_t dif_spi_device_irq_clear_all(
-    const dif_spi_device_t *spi);
+dif_spi_device_result_t dif_spi_device_irq_clear(
+    const dif_spi_device_t *spi, dif_spi_device_irq_type_t type);
 
 /**
  * Enable or disable a particular interrupt.


### PR DESCRIPTION
This change makes the SPI API match that of other DIFs.

That said, I sort of wonder if we should be moving these APIs towards a bitflags type deal, so that a caller could potentially do `dif_spi_device_irq_clear(spi, kIrq1 | kIrq2)`? This seems in line with @silvestrst's work with IRQ enums?