### PR TITLE
[doc] Linked DV plan & testplan in HW stages

### DIFF
--- a/doc/project/hw_stages.md
+++ b/doc/project/hw_stages.md
@@ -77,9 +77,9 @@ Once all bugs have fixed, lint and CDC violations cleaned up, the design moves i
 | **Stage** | **Name** | **Definition** |
 | --- | --- | --- |
 | D0 | Initial Work | RTL being developed, not functional |
-| D1 | Functional | <ul> <li>Feature set finalized, spec complete <li>CSRs identified; RTL/DV/SW collateral generated <li>SW interface automation completed <li>Clock(s)/reset(s) connected to all sub modules <li>Lint run setup <li>Ports Frozen </ul> |
-| D2 | Feature Complete | <ul> <li>Full Feature Complete: all features implemented.  <li>Feature frozen </ul> |
-| D3 | Design Complete | <ul> <li>Lint/CDC clean, waivers reviewed <li>Design optimization for power and/or performance complete </ul> |
+| D1 | Functional | <ul> <li> Feature set finalized, spec complete <li> CSRs identified; RTL/DV/SW collateral generated <li> SW interface automation completed <li> Clock(s)/reset(s) connected to all sub modules <li> Lint run setup <li> Ports Frozen </ul> |
+| D2 | Feature Complete | <ul> <li> Full Feature Complete: all features implemented.  <li> Feature frozen </ul> |
+| D3 | Design Complete | <ul> <li> Lint/CDC clean, waivers reviewed <li> Design optimization for power and/or performance complete </ul> |
 
 ## Hardware Verification Stages
 
@@ -90,12 +90,12 @@ The verification stages can be applied to simulation-based DV and formal propert
 
 The first verification stage is **Initial Work**.
 This indicates the period of time between the beginning of verification planning and the testbench up and running.
-The testbench is still being created, scoreboards implemented, test plan being written, nightly regressions running, etc.
-Once the verification environment is available for writing tests, with a test plan written, it has completed the Initial Work stage.
+The testbench is still being created, scoreboards implemented, testplan being written, nightly regressions running, etc.
+Once the verification environment is available for writing tests, with a testplan written, it has completed the Initial Work stage.
 
 The second verification stage is **Under Test**.
-In this stage, the verification environment is available but not tests in the test plan are completed.
-Once all of the items in the test plan are implemented, it exits this stage.
+In this stage, the verification environment is available but not tests in the testplan are completed.
+Once all of the items in the testplan are implemented, it exits this stage.
 
 The third verification stage is **Testing Complete**.
 In this phase, no changes are expected on the testplan, no changes expected on the testbench, and no new tests are expected except to complete full coverage of the design.
@@ -105,19 +105,19 @@ Once all coverage metrics have been met, waivers checked, the verification moves
 
 | **Stage** | **Name** | **Definition** |
 | --- | --- | --- |
-| V0 | Initial Work | Testbench being developed, not functional; test plan being written; decided which methodology to use (sim-based DV, FPV, or both). |
-| V1 | Under Test | <ul> <li> Documentation: DV Plan available, testplan completed and reviewed <li> Testbench: <ul><li>DUT instantiated with major interfaces hooked up <li>All available interface assertion monitors hooked up <li>X / unknown checks on DUT outputs added <li>Skeleton environment created with UVCs <li>TLM connections made from interface monitors to the scoreboard </ul> <li>Tests (written and passing): <ul> <li>Sanity test accessing basic functionality <li>CSR / mem test suite </ul> <li>Regressions: Sanity and nightly regression set up</ul> |
-| V2 | Testing Complete | <ul> <li>Documentation: DV plan completely written <li>Design Issues: <ul><li> all high priority bugs addressed <li> low priority bugs root-caused </ul> <li>Testbench: <ul><li>all interfaces hooked up and exercised <li> all assertions written and enabled </ul> <li>UVM environment: fully developed with end-to-end checks in scoreboard <li>Tests (written and passing): all tests planned for in the testplan <li>Regression: all tests passing in nightly regression with multiple seeds (> 90%)  <li>Coverage: 90% code coverage across the board, 100% functional coverpoints covered and 75% crosses covered</ul></ul> |
-| V3 | Verification Complete | <ul> <li>Design Issues: all bugs addressed <li> Tests (written and passing): all tests including newly added post-V2 tests (if any) <li>Regression: all tests with all seeds passing <li>Coverage: 100% code and 100% functional coverage with waivers </ul> </ul> |
+| V0 | Initial Work | Testbench being developed, not functional; testplan being written; decided which methodology to use (sim-based DV, FPV, or both). |
+| V1 | Under Test | <ul> <li> Documentation: <ul> <li> [DV plan]({{< relref "doc/ug/dv_methodology#documentation" >}}) available, [testplan]({{< relref "doc/ug/dv_methodology#documentation" >}}) completed and reviewed </ul> <li> Testbench: <ul> <li> DUT instantiated with major interfaces hooked up <li> All available interface assertion monitors hooked up <li> X / unknown checks on DUT outputs added <li> Skeleton environment created with UVCs <li> TLM connections made from interface monitors to the scoreboard </ul> <li> Tests (written and passing): <ul> <li> Sanity test accessing basic functionality <li> CSR / mem test suite </ul> <li> Regressions: Sanity and nightly regression set up</ul> |
+| V2 | Testing Complete | <ul> <li> Documentation: <ul> <li> DV plan completely written </ul> <li> Design Issues: <ul> <li> all high priority bugs addressed <li> low priority bugs root-caused </ul> <li> Testbench: <ul> <li> all interfaces hooked up and exercised <li> all assertions written and enabled </ul> <li> UVM environment: fully developed with end-to-end checks in scoreboard <li> Tests (written and passing): all tests planned for in the testplan <li> Regression: all tests passing in nightly regression with multiple seeds (> 90%)  <li> Coverage: 90% code coverage across the board, 100% functional coverpoints covered and 75% crosses covered</ul></ul> |
+| V3 | Verification Complete | <ul> <li> Design Issues: all bugs addressed <li> Tests (written and passing): all tests including newly added post-V2 tests (if any) <li> Regression: all tests with all seeds passing <li> Coverage: 100% code and 100% functional coverage with waivers </ul> </ul> |
 
 **Stages for FPV approaches**:
 
 | **Stage** | **Name** | **Definition** |
 | --- | --- | --- |
-| V0 | Initial Work | Testbench being developed, not functional; test plan being written; decided which methodology to use (sim-based DV, FPV, or both). |
-| V1 | Under Test | <ul> <li> Documentation: <ul> <li> DV Plan available, testplan completed and reviewed </ul> <li> Testbench: <ul><li> Formal testbench with DUT bound to assertion module(s) <li> All available interface assertion monitors hooked up <li> X / unknown assertions on DUT outputs added </ul> <li> Assertions (written and proven): <ul> <li>All functional properties identified and described in testplan <li>Assertions for main functional path implemented and passing (sanity check)<li> Each input and each output is part of at least one assertion</ul><li>Regressions: Sanity and nightly regression set up</ul> |
-| V2 | Testing Complete | <ul> <li>Documentation: DV plan completely written <li>Design Issues: <ul><li> all high priority bugs addressed <li> low priority bugs root-caused </ul> <li>Testbench: <ul><li>all interfaces have assertions checking the protocol <li> all functional assertions written and enabled <li> assumptions for FPV specified and reviewed </ul> <li>Tests (written and passing): all tests planned for in the testplan <li> Regression: 90% of properties proven in nightly regression <li> Coverage: 90% code coverage and 75% logic cone of influence (COI) coverage </ul> |
-| V3 | Verification Complete | <ul> <li>Design Issues: all bugs addressed <li> Assertions (written and proven): all assertions including newly added post-V2 assertions (if any) <li>Regression: 100% of properties proven (with reviewed assumptions) <li> Coverage: 100% code coverage and 100% COI coverage</ul> |
+| V0 | Initial Work | Testbench being developed, not functional; testplan being written; decided which methodology to use (sim-based DV, FPV, or both). |
+| V1 | Under Test | <ul> <li> Documentation: <ul> <li> [DV plan]({{< relref "doc/ug/dv_methodology#documentation" >}}) available, [testplan]({{< relref "doc/ug/dv_methodology#documentation" >}}) completed and reviewed </ul> <li> Testbench: <ul> <li> Formal testbench with DUT bound to assertion module(s) <li> All available interface assertion monitors hooked up <li> X / unknown assertions on DUT outputs added </ul> <li> Assertions (written and proven): <ul> <li> All functional properties identified and described in testplan <li> Assertions for main functional path implemented and passing (sanity check)<li> Each input and each output is part of at least one assertion</ul> <li> Regressions: Sanity and nightly regression set up</ul> |
+| V2 | Testing Complete | <ul> <li> Documentation: <ul> <li> DV plan completely written </ul> <li> Design Issues: <ul> <li> all high priority bugs addressed <li> low priority bugs root-caused </ul> <li> Testbench: <ul> <li> all interfaces have assertions checking the protocol <li> all functional assertions written and enabled <li> assumptions for FPV specified and reviewed </ul> <li> Tests (written and passing): all tests planned for in the testplan <li> Regression: 90% of properties proven in nightly regression <li> Coverage: 90% code coverage and 75% logic cone of influence (COI) coverage </ul> |
+| V3 | Verification Complete | <ul> <li> Design Issues: all bugs addressed <li> Assertions (written and proven): all assertions including newly added post-V2 assertions (if any) <li> Regression: 100% of properties proven (with reviewed assumptions) <li> Coverage: 100% code coverage and 100% COI coverage</ul> |
 
 ## Signoff Review
 


### PR DESCRIPTION
- Linked 'DV plan' and 'testplan' in HW stages doc 
- Changed all instances of 'test plan' with 'testplan' to keep it consistent
- Made spacing between `<ul>` and `<li>` in the table consistent

Signed-off-by: Srikrishna Iyer <sriyer@google.com>