### PR TITLE
[fpv] Fix compile error

### DIFF
--- a/hw/ip/tlul/rtl/tlul_assert.sv
+++ b/hw/ip/tlul/rtl/tlul_assert.sv
@@ -21,7 +21,9 @@ module tlul_assert #(
 `ifndef VERILATOR
 `ifndef SYNTHESIS
 
+`ifdef UVM
   import uvm_pkg::*;
+`endif
   import tlul_pkg::*;
   import top_pkg::*;
 
@@ -278,12 +280,14 @@ module tlul_assert #(
   `ASSERT_KNOWN(aReadyKnown_A, d2h.a_ready)
   `ASSERT_KNOWN(dReadyKnown_A, h2d.d_ready)
 
-  initial forever begin
-    bit tlul_assert_en;
-    uvm_config_db#(bit)::wait_modified(null, "%m", "tlul_assert_en");
-    uvm_config_db#(bit)::get(null, "%m", "tlul_assert_en", tlul_assert_en);
-    disable_sva = !tlul_assert_en;
-  end
+  `ifdef UVM
+    initial forever begin
+      bit tlul_assert_en;
+      uvm_config_db#(bit)::wait_modified(null, "%m", "tlul_assert_en");
+      uvm_config_db#(bit)::get(null, "%m", "tlul_assert_en", tlul_assert_en);
+      disable_sva = !tlul_assert_en;
+    end
+  `endif
 `endif
 `endif
 endmodule : tlul_assert


### PR DESCRIPTION
Add a macro to wrap around UVM only items in tlul_assert to avoid FPV
compile error

Signed-off-by: Cindy Chen <chencindy@google.com>