### PR TITLE
[topgen] Add External to the top port

### DIFF
--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -1506,7 +1506,7 @@
       rstmgr.cpu
       pwrmgr.pwr_cpu
     ]
-    ext: []
+    external: []
   }
   xbar:
   [
@@ -3091,6 +3091,7 @@
         index: -1
       }
     ]
+    external: []
     definitions:
     [
       {

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -263,7 +263,7 @@
     'top': ['rstmgr.resets', 'rstmgr.cpu', 'pwrmgr.pwr_cpu'],
 
     // ext is to create port in the top.
-    'ext': [],
+    'external': [],
   },
 
   debug_mem_base_addr: "0x1A110000",

--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -12,6 +12,8 @@ num_mio_inout = sum([x["width"] if "width" in x else 1 for x in top["pinmux"]["i
 
 num_dio = sum([x["width"] if "width" in x else 1 for x in top["pinmux"]["dio"]])
 
+num_im = sum([x["width"] if "width" in x else 1 for x in top["inter_signal"]["external"]])
+
 max_miolength = max([len(x["name"]) for x in top["pinmux"]["inputs"] + top["pinmux"]["outputs"] + top["pinmux"]["inouts"]])
 max_diolength = max([len(x["name"]) for x in top["pinmux"]["dio"]])
 
@@ -58,6 +60,13 @@ module top_${top["name"]} #(
   output logic ${lib.bitarray(sig["width"], max_sigwidth)} dio_${sig["name"]}_o,
   output logic ${lib.bitarray(sig["width"], max_sigwidth)} dio_${sig["name"]}_en_o,
     % endif
+  % endfor
+% endif
+% if num_im != 0:
+
+  // Inter-module Signal External type
+  % for sig in top["inter_signal"]["external"]:
+  ${"input " if sig["direction"] == "in" else "output"} ${lib.im_defname(sig)} ${lib.bitarray(sig["width"],1)} ${sig["signame"]},
   % endfor
 % endif
 


### PR DESCRIPTION
This commit is to support last part of inter-module signal, 'exteranl'
type. If any inter-module signal is listed in `inter_module`.`ext` hjson
field, it creates top port with the struct defined in the list.

For instance, if `mod_a` has 'uni' type `sig_a` inter_signal structure
as requester,

```hjson
  'inter_module': {
    'ext': [
        'mod_a.sig_a'
    ]}
```

above hjson configuration creates `output my_pkg::sig_struct_t sig_a_o`
port in the top.