### PR TITLE
Teach the vendor tool to support multiple source directories

### DIFF
--- a/doc/rm/vendor_in_tool.md
+++ b/doc/rm/vendor_in_tool.md
@@ -57,6 +57,13 @@ Optional parts can be removed if they are not used.
     rev: "pulpissimo_integration",
   },
 
+  // Optional: Pick specific files or subdirectories from upstream and
+  // specify where to put them.
+  mapping: [
+    {from: 'src', to: 'the-source'},
+    {from: 'doc', to: 'some/documentation', patch_dir: 'doc_patches'}
+  ]
+
   // Optional: Apply patches from the following directory to the upstream
   // sources
   patch_dir: "patches/pulp_riscv_dbg",
@@ -72,7 +79,7 @@ Optional parts can be removed if they are not used.
   },
 
   // Optional: Exclude files or directories from the upstream sources
-  // The standard glob wildcards (*, ?, etc.) are supported
+  // The standard glob wildcards (*, ?, etc.) are supported.
   exclude_from_upstream: [
     "src/dm_top.sv",
     "src_files.yml",
@@ -80,8 +87,18 @@ Optional parts can be removed if they are not used.
 }
 ```
 
-If only the contents of a single subdirectory (including its children) of an upstream repository are to be copied in, the optional `only_subdir` key of can be used in the `upstream` section to specify the subdirectory to be copied in.
+If only the contents of a single subdirectory (including its children) of an upstream repository are to be copied in, the optional `only_subdir` key of can be used in the `upstream` section to specify the subdirectory to be copied.
 The contents of that subdirectory will populate the `target_dir` directly (without any intervening directory levels).
+
+For a more complicated set of copying rules ("get directories `A/B` and `A/C` but not anything else in `A`"), use a `mapping` list.
+Each element of the list should be a dictionary with keys `from` and `to`.
+The value of `from` should be a path relative to the source directory (either the top of the cloned directory, or the `only_subdir` subdirectory, if set).
+The value of `to` should be a path relative to `target_dir`.
+
+If `patch_dir` is supplied, it names a directory containing patches to be applied to the vendored code.
+If there is no `mapping` list, this directory's patches are applied in lexicographical order relative to `target_dir`.
+If there is a mapping list, each element of the list may contain a `patch_dir` key.
+The value at that key is a directory, relative to the global `patch_dir` and patches in that directory are applied in lexicographical order relative to the target directory of the mapping, `to`.
 
 In the example vendor description file below, the mpsse directory is populated from the chromiumos platform2 repository, extracting just the few files in the trunks/ftdi subdirectory.
 

--- a/util/vendor.py
+++ b/util/vendor.py
@@ -297,17 +297,13 @@ def refresh_patches(desc):
 
 def _export_patches(patchrepo_clone_url, target_patch_dir, upstream_rev,
                     patched_rev):
-    clone_dir = Path(tempfile.mkdtemp())
-    try:
+    with tempfile.TemporaryDirectory() as clone_dir:
         clone_git_repo(patchrepo_clone_url, clone_dir, patched_rev)
         rev_range = 'origin/' + upstream_rev + '..' + 'origin/' + patched_rev
         cmd = ['git', 'format-patch', '-o', str(target_patch_dir), rev_range]
         if not verbose:
             cmd += ['-q']
         subprocess.run(cmd, cwd=str(clone_dir), check=True)
-
-    finally:
-        shutil.rmtree(str(clone_dir), ignore_errors=True)
 
 
 def import_from_upstream(upstream_path, target_path, exclude_files=[]):
@@ -482,8 +478,7 @@ def main(argv):
     if args.refresh_patches:
         refresh_patches(desc)
 
-    clone_dir = Path(tempfile.mkdtemp())
-    try:
+    with tempfile.TemporaryDirectory() as clone_dir:
         # clone upstream repository
         upstream_new_rev = clone_git_repo(desc.upstream.url, clone_dir, rev=desc.upstream.rev)
 
@@ -581,9 +576,6 @@ def main(argv):
             commit_paths.append(lock_file_path)
 
             git_add_commit(commit_paths, commit_msg)
-
-    finally:
-        shutil.rmtree(str(clone_dir), ignore_errors=True)
 
     log.info('Import finished')
 

--- a/util/vendor.py
+++ b/util/vendor.py
@@ -3,6 +3,16 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+'''A tool to copy source code from upstream into this repository.
+
+For an introduction to using this tool, see doc/ug/vendor_hw.md in this
+repository (on the internet at https://docs.opentitan.org/doc/ug/vendor_hw/).
+
+For full documentation, see doc/rm/vendor_in_tool.md (on the internet at
+https://docs.opentitan.org/doc/rm/vendor_in_tool).
+
+'''
+
 import argparse
 import fnmatch
 import logging as log
@@ -16,8 +26,6 @@ import textwrap
 from pathlib import Path
 
 import hjson
-
-DESC = """vendor, copy source code from upstream into this repository"""
 
 EXCLUDE_ALWAYS = ['.git']
 
@@ -302,7 +310,7 @@ def _cp_from_upstream(src, dest, exclude=[]):
 
 
 def main(argv):
-    parser = argparse.ArgumentParser(prog="vendor", description=DESC)
+    parser = argparse.ArgumentParser(prog="vendor", description=__doc__)
     parser.add_argument(
         '--update',
         '-U',

--- a/util/vendor.py
+++ b/util/vendor.py
@@ -173,7 +173,7 @@ def format_list_to_str(list, width=70):
 
 
 def refresh_patches(desc):
-    if not 'patch_repo' in desc:
+    if 'patch_repo' not in desc:
         log.fatal('Unable to refresh patches, patch_repo not set in config.')
         sys.exit(1)
 
@@ -273,7 +273,7 @@ def git_add_commit(repo_base, paths, commit_msg):
                        check=True,
                        universal_newlines=True,
                        input=commit_msg)
-    except subprocess.CalledProcessError as e:
+    except subprocess.CalledProcessError:
         log.warning("Unable to create commit. Are there no changes?")
 
 
@@ -351,7 +351,6 @@ def main(argv):
     except ValueError:
         raise SystemExit(sys.exc_info()[1])
     desc['_base_dir'] = vendor_file_base_dir
-
 
     desc_file_stem = desc_file_path.name.rsplit('.', 2)[0]
     lock_file_path = desc_file_path.with_name(desc_file_stem + '.lock.hjson')


### PR DESCRIPTION
The new feature is in the last patch in the series. The previous patches are code tidyups. The biggest of these is the "Parse inputs into objects" patch, which tries to properly "parse" the data we got from the JSON file, to allow all the validation code to sit in one place, and slightly clean up the business logic that happens later. Doing this made the last patch *much* easier to write.