### PR TITLE
[docker] Added clang-format-3.8 to docker

### DIFF
--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -65,6 +65,7 @@ COPY --from=verilator /tools/verilator/${VERILATOR_VERSION} verilator/${VERILATO
 RUN apt-get update && apt-get install -y \
     build-essential \
     curl \
+    clang-format-3.8 \
     git \
     gnupg2 \
     libc6-i386 \


### PR DESCRIPTION
The version of clang-format used in CI is 3.8 which is much older than
most of our machines that run newer linux distros. With this update, one
can build our docker image with clang-format-3.8 and stay consistent
with the CI. IMO this is better than installing multiple packages in our
native machines.

Docker instructions are provided [here](https://docs.opentitan.org/util/container/README/).
With this change, you can run `git clang-format` inside the docker to stay in sync with CI. 

Signed-off-by: Srikrishna Iyer <sriyer@google.com>