### PR TITLE
[dv] Fix failures in test csr_mem_rw_with_rand_reset

### DIFF
--- a/hw/dv/data/tests/csr_tests.hjson
+++ b/hw/dv/data/tests/csr_tests.hjson
@@ -41,7 +41,7 @@
     {
       name: "{name}_csr_mem_rw_with_rand_reset"
       uvm_test_seq: "{name}_common_vseq"
-      run_opts: ["+run_csr_mem_rw_with_rand_reset"]
+      run_opts: ["+run_csr_mem_rw_with_rand_reset", "+test_timeout_ns=10000000000"]
       en_run_modes: ["csr_tests_mode"]
     }
   ]

--- a/hw/dv/sv/cip_lib/cip_base_vseq__tl_errors.svh
+++ b/hw/dv/sv/cip_lib/cip_base_vseq__tl_errors.svh
@@ -22,18 +22,16 @@
 
 virtual task tl_access_unmapped_addr();
   bit [TL_AW-1:0] normalized_csr_addrs[] = new[cfg.csr_addrs.size()];
-  bit [TL_AW-1:0] addr_mask = cfg.csr_addr_map_size - 1;
-  addr_mask[1:0] = 0;
   // calculate normalized address outside the loop to improve perf
   foreach (cfg.csr_addrs[i]) normalized_csr_addrs[i] = cfg.csr_addrs[i] - cfg.csr_base_addr;
   // randomize unmapped_addr first to improve perf
   repeat ($urandom_range(10, 100)) begin
     bit [TL_AW-1:0] unmapped_addr;
     `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(unmapped_addr,
-        !((unmapped_addr & addr_mask) inside {normalized_csr_addrs});
-        foreach (cfg.mem_ranges[i]) {
-          !((unmapped_addr & addr_mask)
-              inside {[cfg.mem_ranges[i].start_addr : cfg.mem_ranges[i].end_addr]});}
+        !((unmapped_addr & csr_addr_mask) inside {normalized_csr_addrs});
+        foreach (updated_mem_ranges[i]) {
+          !((unmapped_addr & csr_addr_mask)
+              inside {[updated_mem_ranges[i].start_addr : updated_mem_ranges[i].end_addr]});}
         )
     `create_tl_access_error_case(
         tl_access_unmapped_addr,
@@ -42,14 +40,13 @@ virtual task tl_access_unmapped_addr();
 endtask
 
 virtual task tl_write_csr_word_unaligned_addr();
-  bit [TL_AW-1:0] addr_mask = cfg.csr_addr_map_size - 1;
   repeat ($urandom_range(10, 100)) begin
     `create_tl_access_error_case(
         tl_write_csr_word_unaligned_addr,
         opcode inside {tlul_pkg::PutFullData, tlul_pkg::PutPartialData};
-        foreach (local::cfg.mem_ranges[i]) {
-          !((addr & addr_mask)
-              inside {[local::cfg.mem_ranges[i].start_addr : local::cfg.mem_ranges[i].end_addr]});
+        foreach (updated_mem_ranges[i]) {
+          !((addr & csr_addr_mask)
+              inside {[updated_mem_ranges[i].start_addr : updated_mem_ranges[i].end_addr]});
         }
         addr[1:0] != 2'b00;)
   end
@@ -92,15 +89,20 @@ endtask
 
 virtual task tl_write_mem_less_than_word();
   uint mem_idx;
+  dv_base_mem mem;
   repeat ($urandom_range(10, 100)) begin
     // if more than one memories, randomly select one memory
     mem_idx = $urandom_range(0, cfg.mem_ranges.size - 1);
+    // only test when mem doesn't support partial write
+    `downcast(mem, get_mem_by_addr(ral, cfg.mem_ranges[mem_idx].start_addr))
+    if (mem.get_mem_partial_write_support()) continue;
+
     `create_tl_access_error_case(
         tl_write_mem_less_than_word,
         opcode inside {tlul_pkg::PutFullData, tlul_pkg::PutPartialData};
         addr[1:0] == 0; // word aligned
-        addr inside
-            {[local::cfg.mem_ranges[mem_idx].start_addr : local::cfg.mem_ranges[mem_idx].end_addr]};
+        (addr & csr_addr_mask) inside
+            {[updated_mem_ranges[mem_idx].start_addr : updated_mem_ranges[mem_idx].end_addr]};
         mask != '1 || size < 2;
         )
   end
@@ -111,19 +113,28 @@ virtual task tl_read_mem_err();
   repeat ($urandom_range(10, 100)) begin
     // if more than one memories, randomly select one memory
     mem_idx = $urandom_range(0, cfg.mem_ranges.size - 1);
+    if (get_mem_access_by_addr(ral, cfg.mem_ranges[mem_idx].start_addr) != "WO") continue;
     `create_tl_access_error_case(
         tl_read_mem_err,
         opcode == tlul_pkg::Get;
-        addr inside
-            {[local::cfg.mem_ranges[mem_idx].start_addr : local::cfg.mem_ranges[mem_idx].end_addr]};
+        (addr & csr_addr_mask) inside
+            {[updated_mem_ranges[mem_idx].start_addr : updated_mem_ranges[mem_idx].end_addr]};
         )
   end
 endtask
 
 // generic task to check interrupt test reg functionality
 virtual task run_tl_errors_vseq(int num_times = 1, bit do_wait_clk = 0);
-  bit test_mem_err_byte_write = (cfg.mem_ranges.size > 0) && !cfg.en_mem_byte_write;
-  bit test_mem_err_read       = (cfg.mem_ranges.size > 0) && !cfg.en_mem_read;
+  bit has_mem = (cfg.mem_ranges.size > 0);
+
+  csr_addr_mask = (cfg.csr_addr_map_size - 1);
+  csr_addr_mask[1:0] = 0;
+  if (updated_mem_ranges.size == 0) begin
+    foreach (cfg.mem_ranges[i]) begin
+      updated_mem_ranges.push_back(addr_range_t'{cfg.mem_ranges[i].start_addr - cfg.csr_base_addr,
+                                                 cfg.mem_ranges[i].end_addr - cfg.csr_base_addr});
+    end
+  end
 
   set_tl_assert_en(.enable(0));
   for (int trans = 1; trans <= num_times; trans++) begin
@@ -142,9 +153,9 @@ virtual task run_tl_errors_vseq(int num_times = 1, bit do_wait_clk = 0);
                 1: tl_write_csr_word_unaligned_addr();
                 1: tl_write_less_than_csr_width();
                 1: tl_protocol_err();
-                // only run this task when the mem supports error response
-                test_mem_err_byte_write: tl_write_mem_less_than_word();
-                test_mem_err_read:       tl_read_mem_err();
+                // only run this task when there is an mem
+                has_mem: tl_write_mem_less_than_word();
+                has_mem: tl_read_mem_err();
               endcase
             end
           join_none

--- a/hw/dv/sv/csr_utils/csr_utils_pkg.sv
+++ b/hw/dv/sv/csr_utils/csr_utils_pkg.sv
@@ -91,7 +91,6 @@ package csr_utils_pkg;
   function automatic void get_mem_addr_ranges(uvm_reg_block ral, ref addr_range_t mem_ranges[$]);
     uvm_mem mems[$];
     ral.get_memories(mems);
-    mems.delete();
     foreach (mems[i]) begin
       addr_range_t mem_range;
       mem_range.start_addr = mems[i].get_address();
@@ -99,6 +98,21 @@ package csr_utils_pkg;
                              mems[i].get_size() * mems[i].get_n_bytes() - 1;
       mem_ranges.push_back(mem_range);
     end
+  endfunction
+
+  // get mem object from address
+  function automatic uvm_mem get_mem_by_addr(uvm_reg_block ral, uvm_reg_addr_t addr);
+    uvm_mem mem;
+    addr[1:0] = 0;
+    mem = ral.default_map.get_mem_by_offset(addr);
+    `DV_CHECK_NE_FATAL(mem, null, $sformatf("Can't find any mem with addr 0x%0h", addr), msg_id)
+    return mem;
+  endfunction
+
+  // get mem access like RW, RO
+  function automatic string get_mem_access_by_addr(uvm_reg_block ral, uvm_reg_addr_t addr);
+    uvm_mem mem = get_mem_by_addr(ral, addr);
+    return mem.get_access();
   endfunction
 
   // This fucntion return mirrored value of reg/field of given RAL

--- a/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
+++ b/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
@@ -17,9 +17,6 @@ class dv_base_env_cfg #(type RAL_T = dv_base_reg_block) extends uvm_object;
   RAL_T                 ral;
   bit [TL_AW-1:0]       csr_addrs[$];
   addr_range_t          mem_ranges[$];
-  // mem access support, if not enabled, will trigger error
-  bit                   en_mem_byte_write = 0;
-  bit                   en_mem_read       = 1;
 
   // ral base address and size
   bit [TL_AW-1:0]       csr_base_addr;     // base address where csr map begins

--- a/hw/dv/sv/dv_lib/dv_base_mem.sv
+++ b/hw/dv/sv/dv_lib/dv_base_mem.sv
@@ -8,6 +8,9 @@ class dv_base_mem extends uvm_mem;
   // uvm_mem::m_access is local variable. Create it again in order to use "access" in current class
   local string m_access;
 
+  // if mem doesn't support partial write, doing that will result d_error = 1
+  local bit mem_partial_write_support;
+
   function new(string           name,
                longint unsigned size,
                int unsigned     n_bits,
@@ -16,6 +19,14 @@ class dv_base_mem extends uvm_mem;
     super.new(name, size, n_bits, access, has_coverage);
     m_access = access;
   endfunction : new
+
+  function void set_mem_partial_write_support(bit enable);
+    mem_partial_write_support = enable;
+  endfunction : set_mem_partial_write_support
+
+  function bit get_mem_partial_write_support();
+    return mem_partial_write_support;
+  endfunction : get_mem_partial_write_support
 
   // rewrite this function to support "WO" access type for mem
   function void configure(uvm_reg_block  parent,

--- a/hw/ip/gpio/dv/gpio_sim_cfg.hjson
+++ b/hw/ip/gpio/dv/gpio_sim_cfg.hjson
@@ -141,6 +141,11 @@
       name: gpio_csr_aliasing
       run_opts: ["+do_clear_all_interrupts=0"]
     }
+
+    {
+      name: gpio_csr_mem_rw_with_rand_reset
+      run_opts: ["+do_clear_all_interrupts=0"]
+    }
   ]
 
   // List of regressions.

--- a/hw/ip/hmac/data/hmac.hjson
+++ b/hw/ip/hmac/data/hmac.hjson
@@ -129,6 +129,8 @@
           desc: '''If error interrupt occurs, this register has information of error cause.
                 Please take a look at `hw/ip/hmac/rtl/hmac_pkg.sv:err_code_e enum type.
                 '''
+          tags: [// Randomly write mem will cause this reg updated by design
+                 "excl:CsrNonInitTests:CsrExclCheck"]
         }
       ]
     }

--- a/hw/ip/hmac/dv/env/hmac_env.sv
+++ b/hw/ip/hmac/dv/env/hmac_env.sv
@@ -13,4 +13,12 @@ class hmac_env extends cip_base_env #(.CFG_T               (hmac_env_cfg),
     super.build_phase(phase);
   endfunction
 
+  virtual function void end_of_elaboration_phase(uvm_phase phase);
+    dv_base_mem mem;
+    super.end_of_elaboration_phase(phase);
+    // hmac mem supports partial write, set it after ral model is locked
+    `downcast(mem, get_mem_by_addr(cfg.ral, cfg.csr_base_addr + HMAC_MSG_FIFO_BASE))
+    mem.set_mem_partial_write_support(1);
+  endfunction
+
 endclass

--- a/hw/ip/hmac/dv/env/hmac_env_cfg.sv
+++ b/hw/ip/hmac/dv/env/hmac_env_cfg.sv
@@ -13,9 +13,6 @@ class hmac_env_cfg extends cip_base_env_cfg #(.RAL_T(hmac_reg_block));
 
   virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);
     super.initialize(csr_base_addr);
-    en_mem_byte_write   = 1;
-    en_mem_read         = 0;
-    mem_ranges.push_back('{HMAC_MSG_FIFO_BASE, HMAC_MSG_FIFO_LAST_ADDR});
     list_of_alerts      = {"msg_push_sha_disabled"};
     // set num_interrupts & num_alerts which will be used to create coverage and more
     num_interrupts = ral.intr_state.get_n_used_bits();

--- a/hw/ip/hmac/dv/env/hmac_scoreboard.sv
+++ b/hw/ip/hmac/dv/env/hmac_scoreboard.sv
@@ -34,7 +34,8 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
     bit     do_cycle_accurate_check = 1'b1;
     bit     write                   = item.is_write();
     string  csr_name;
-    uvm_reg_addr_t  csr_addr         = get_normalized_addr(item.a_addr);
+    bit [TL_AW-1:0] addr_mask       = cfg.csr_addr_map_size - 1;
+    uvm_reg_addr_t  csr_addr        = get_normalized_addr(item.a_addr);
 
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.csr_addrs}) begin
@@ -42,14 +43,15 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
       `DV_CHECK_NE_FATAL(csr, null)
       csr_name = csr.get_name();
     // if addr inside msg fifo, no ral model
-    end else if (!(item.a_addr inside {[HMAC_MSG_FIFO_BASE : HMAC_MSG_FIFO_LAST_ADDR]})) begin
+    end else if (!((item.a_addr & addr_mask) inside {[HMAC_MSG_FIFO_BASE :
+                                                      HMAC_MSG_FIFO_LAST_ADDR]})) begin
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
     end
 
     // if incoming access is a write to a valid csr or mem, then update right away on addr channel
     if (write && channel == AddrChannel) begin
       // push the msg into msg_fifo
-      if (item.a_addr inside {[HMAC_MSG_FIFO_BASE : HMAC_MSG_FIFO_LAST_ADDR]}) begin
+      if ((item.a_addr & addr_mask) inside {[HMAC_MSG_FIFO_BASE : HMAC_MSG_FIFO_LAST_ADDR]}) begin
         if (!hmac_start) begin
           update_err_intr_code(SwPushMsgWhenIdle);
         end else if (!sha_en) begin

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
@@ -179,7 +179,7 @@ class hmac_base_vseq extends cip_base_vseq #(.CFG_T               (hmac_env_cfg)
       word = {>>byte{word_unpack}};
       `uvm_info(`gfn, $sformatf("wr_addr = %0h, wr_mask = %0h, words = 0x%0h",
                                 wr_addr, wr_mask, word), UVM_HIGH)
-      tl_access(.addr(wr_addr), .write(1'b1), .data(word), .mask(wr_mask),
+      tl_access(.addr(wr_addr + cfg.csr_base_addr), .write(1'b1), .data(word), .mask(wr_mask),
                 .blocking(non_blocking));
 
       if (ral.cfg.sha_en.get_mirrored_value()) begin
@@ -215,7 +215,7 @@ class hmac_base_vseq extends cip_base_vseq #(.CFG_T               (hmac_env_cfg)
           `uvm_info(`gfn, $sformatf("wr_addr = %0h, wr_mask = %0h, words = 0x%0h",
                                     wr_addr, wr_mask, word), UVM_HIGH)
           `DV_CHECK_FATAL(randomize(wr_addr, wr_mask) with {wr_mask == '1;})
-          tl_access(.addr(wr_addr), .write(1'b1), .data(word), .mask(wr_mask),
+          tl_access(.addr(wr_addr + cfg.csr_base_addr), .write(1'b1), .data(word), .mask(wr_mask),
                     .blocking($urandom_range(0, 1)));
         end
         if (ral.cfg.sha_en.get_mirrored_value()) begin

--- a/hw/ip/spi_device/dv/env/spi_device_env_cfg.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env_cfg.sv
@@ -24,9 +24,8 @@ class spi_device_env_cfg extends cip_base_env_cfg #(.RAL_T(spi_device_reg_block)
     // set num_interrupts & num_alerts which will be used to create coverage and more
     num_interrupts = ral.intr_state.get_n_used_bits();
 
-    sram_start_addr     = SRAM_OFFSET;
-    sram_end_addr       = sram_start_addr + SRAM_SIZE - 1;
-    mem_ranges.push_back('{sram_start_addr, sram_end_addr});
+    sram_start_addr = SRAM_OFFSET + this.csr_base_addr;
+    sram_end_addr   = sram_start_addr + SRAM_SIZE - 1;
   endfunction
 
 endclass

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -147,6 +147,13 @@
     }
 
     {
+      name: "chip_csr_mem_rw_with_rand_reset"
+      uvm_test_seq: chip_common_vseq
+      run_opts: ["+en_scb=0", "+run_csr_mem_rw_with_rand_reset", "+test_timeout_ns=10000000000"]
+      en_run_modes: ["stub_cpu"]
+    }
+
+    {
       name: chip_tl_errors
       uvm_test_seq: chip_common_vseq
       run_opts: ["+run_tl_errors"]


### PR DESCRIPTION
1. Disable interrupt check for gpio
2. Solve hmac mem read returning d_error=1
3. Add csr excl for hmac reg err_code as it's affected by mem write
4. Increase timeout value
5. some enhancement to use mem access and clean up mem flags

when this PR is merged, mem test will pass, except top-level due to issue #2110 
Signed-off-by: Weicai Yang <weicai@google.com>