### PR TITLE
[sw/dif_usbdev] Implement USBDEV DIF Library

### DIFF
--- a/sw/device/lib/dif/dif_usbdev.c
+++ b/sw/device/lib/dif/dif_usbdev.c
@@ -1,0 +1,1112 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/dif/dif_usbdev.h"
+
+#include "sw/device/lib/base/bitfield.h"
+
+#include "usbdev_regs.h"  // Generated.
+
+/**
+ * Definition in the header file (and probably other places) must be updated if
+ * there is a hardware change.
+ */
+_Static_assert(USBDEV_NUM_ENDPOINTS == USBDEV_PARAM_NENDPOINTS,
+               "Mismatch in number of endpoints");
+
+/**
+ * Max packet size is equal to the size of buffer entries.
+ */
+#define USBDEV_BUFFER_ENTRY_SIZE_BYTES USBDEV_MAX_PACKET_SIZE
+
+/**
+ * Bit index for the state of read buffer operation in
+ * dif_usbdev_t.active_buffer_ops`. See the definition of `buffer_op_init`.
+ */
+#define USBDEV_READ_BUFFER_OP_BIT_INDEX 15
+
+/**
+ * Constants used to indicate that a buffer pool is full or empty.
+ */
+#define BUFFER_POOL_FULL (USBDEV_NUM_BUFFERS - 1)
+#define BUFFER_POOL_EMPTY -1
+
+/**
+ * Hardware information for endpoints.
+ */
+typedef struct endpoint_hw_info {
+  uint32_t config_in_reg_offset;
+  uint8_t bit_index;
+} endpoint_hw_info_t;
+
+/**
+ * Helper macro to define an `endpoint_hw_info_t` entry for endpoint N.
+ *
+ * Note: This uses the bit indices of `USBDEV_IN_SENT` register for the sake
+ * of conciseness because other endpoint registers use the same layout.
+ */
+#define ENDPOINT_HW_INFO_ENTRY(N)                                 \
+  [N] = {.config_in_reg_offset = USBDEV_CONFIGIN##N##_REG_OFFSET, \
+         .bit_index = USBDEV_IN_SENT_SENT##N}
+
+static const endpoint_hw_info_t kEndpointHwInfos[USBDEV_NUM_ENDPOINTS] = {
+    ENDPOINT_HW_INFO_ENTRY(0),  ENDPOINT_HW_INFO_ENTRY(1),
+    ENDPOINT_HW_INFO_ENTRY(2),  ENDPOINT_HW_INFO_ENTRY(3),
+    ENDPOINT_HW_INFO_ENTRY(4),  ENDPOINT_HW_INFO_ENTRY(5),
+    ENDPOINT_HW_INFO_ENTRY(6),  ENDPOINT_HW_INFO_ENTRY(7),
+    ENDPOINT_HW_INFO_ENTRY(8),  ENDPOINT_HW_INFO_ENTRY(9),
+    ENDPOINT_HW_INFO_ENTRY(10), ENDPOINT_HW_INFO_ENTRY(11),
+};
+
+#undef ENDPOINT_HW_INFO_ENTRY
+
+/**
+ * Mapping from `dif_usbdev_irq_t` to bit indices in interrupt registers.
+ */
+static const uint8_t kIrqEnumToBitIndex[] = {
+        [kDifUsbdevIrqPktReceived] = USBDEV_INTR_COMMON_PKT_RECEIVED,
+        [kDifUsbdevIrqPktSent] = USBDEV_INTR_COMMON_PKT_SENT,
+        [kDifUsbdevIrqDisconnected] = USBDEV_INTR_COMMON_DISCONNECTED,
+        [kDifUsbdevIrqHostLost] = USBDEV_INTR_COMMON_HOST_LOST,
+        [kDifUsbdevIrqLinkReset] = USBDEV_INTR_COMMON_LINK_RESET,
+        [kDifUsbdevIrqLinkSuspend] = USBDEV_INTR_COMMON_LINK_SUSPEND,
+        [kDifUsbdevIrqLinkResume] = USBDEV_INTR_COMMON_LINK_RESUME,
+        [kDifUsbdevIrqAvEmpty] = USBDEV_INTR_COMMON_AV_EMPTY,
+        [kDifUsbdevIrqRxFull] = USBDEV_INTR_COMMON_RX_FULL,
+        [kDifUsbdevIrqAvOverflow] = USBDEV_INTR_COMMON_AV_OVERFLOW,
+        [kDifUsbdevIrqLinkInError] = USBDEV_INTR_COMMON_LINK_IN_ERR,
+        [kDifUsbdevIrqRxCrcError] = USBDEV_INTR_COMMON_RX_CRC_ERR,
+        [kDifUsbdevIrqRxPidError] = USBDEV_INTR_COMMON_RX_PID_ERR,
+        [kDifUsbdevIrqRxBitstuffError] = USBDEV_INTR_COMMON_RX_BITSTUFF_ERR,
+        [kDifUsbdevIrqFrame] = USBDEV_INTR_COMMON_FRAME,
+        [kDifUsbdevIrqConnected] = USBDEV_INTR_COMMON_CONNECTED,
+};
+
+/**
+ * Static functions for the free buffer pool.
+ */
+
+/**
+ * Checks if a buffer pool is full.
+ *
+ * A buffer pool is full if it contains `USBDEV_NUM_BUFFERS` entries.
+ *
+ * @param pool A buffer pool.
+ * @return `true` if the buffer pool if full, `false` otherwise.
+ */
+DIF_WARN_UNUSED_RESULT
+static bool buffer_pool_is_full(dif_usbdev_buffer_pool_t *pool) {
+  return pool->top == BUFFER_POOL_FULL;
+}
+
+/**
+ * Checks if a buffer pool is empty.
+ *
+ * @param pool A buffer pool.
+ * @return `true` if the buffer pool is empty, `false` otherwise.
+ */
+DIF_WARN_UNUSED_RESULT
+static bool buffer_pool_is_empty(dif_usbdev_buffer_pool_t *pool) {
+  return pool->top == BUFFER_POOL_EMPTY;
+}
+
+/**
+ * Checks if a buffer entry is valid.
+ *
+ * An entry is valid if it is less than `USBDEV_NUM_BUFFERS`.
+ *
+ * @param entry A buffer entry.
+ * @return `true` if the entry is valid, `false` otherwise.
+ */
+DIF_WARN_UNUSED_RESULT
+static bool buffer_pool_is_valid_entry(uint8_t entry) {
+  return entry < USBDEV_NUM_BUFFERS;
+}
+
+/**
+ * Adds a buffer entry to a buffer pool.
+ *
+ * @param pool A buffer pool.
+ * @param entry A buffer entry.
+ * @return `true` if the operation was successful, `false` otherwise.
+ */
+DIF_WARN_UNUSED_RESULT
+static bool buffer_pool_add(dif_usbdev_buffer_pool_t *pool, uint8_t entry) {
+  if (buffer_pool_is_full(pool) || !buffer_pool_is_valid_entry(entry)) {
+    return false;
+  }
+
+  ++pool->top;
+  pool->entries[pool->top] = entry;
+
+  return true;
+}
+
+/**
+ * Removes a buffer entry from a buffer pool.
+ *
+ * @param pool A buffer pool.
+ * @param entry A buffer entry.
+ * @return `true` if the operation was successful, `false` otherwise.
+ */
+DIF_WARN_UNUSED_RESULT
+static bool buffer_pool_remove(dif_usbdev_buffer_pool_t *pool, uint8_t *entry) {
+  if (buffer_pool_is_empty(pool) || entry == NULL) {
+    return false;
+  }
+
+  *entry = pool->entries[pool->top];
+  --pool->top;
+
+  return true;
+}
+
+/**
+ * Initializes the buffer pool.
+ *
+ * At the end of this operation, the buffer pool contains `USBDEV_NUM_BUFFERS`
+ * buffer entries.
+ *
+ * @param pool A buffer pool.
+ * @return `true` if the operation was successful, `false` otherwise.
+ */
+DIF_WARN_UNUSED_RESULT
+static bool buffer_pool_init(dif_usbdev_buffer_pool_t *pool) {
+  // Start with an empty pool
+  pool->top = -1;
+
+  // Add all entries
+  for (uint8_t i = 0; i < USBDEV_NUM_BUFFERS; ++i) {
+    if (!buffer_pool_add(pool, i)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Static functions for managing read and write buffer operations.
+ */
+
+/**
+ * Initializes the `active_buffer_ops` field of a `dif_usbdev_t`.
+ *
+ * In `dif_usbdev_t.active_buffer_ops`:
+ * - Bits 0..11: True if writing bytes of an outgoing packet for endpoint N
+ * (0..11).
+ * - Bits 12..14: Unused.
+ * - Bit 15: True if reading bytes of an incoming packet.
+ */
+static void buffer_op_init(dif_usbdev_t *usbdev) {
+  usbdev->active_buffer_ops = 0;
+}
+
+/**
+ * Mark the start of a buffer write operation for an endpoint.
+ *
+ * @param usbdev A USB device.
+ * @param endpoint An endpoint.
+ */
+static void buffer_op_start_write(dif_usbdev_t *usbdev, uint8_t endpoint) {
+  usbdev->active_buffer_ops = bitfield_field32_write(
+      usbdev->active_buffer_ops,
+      (bitfield_field32_t){
+          .mask = 1, .index = kEndpointHwInfos[endpoint].bit_index,
+      },
+      1);
+}
+
+/**
+ * Mark the end of a buffer write operation for an endpoint.
+ *
+ * @param usbdev A USB device.
+ * @param endpoint An endpoint.
+ */
+static void buffer_op_stop_write(dif_usbdev_t *usbdev, uint8_t endpoint) {
+  usbdev->active_buffer_ops = bitfield_field32_write(
+      usbdev->active_buffer_ops,
+      (bitfield_field32_t){
+          .mask = 1, .index = kEndpointHwInfos[endpoint].bit_index,
+      },
+      0);
+}
+
+/**
+ * Check if there is an active buffer write operation for an endpoint.
+ *
+ * @param usbdev A USB device.
+ * @param endpoint An endpoint.
+ * @return `true` if there is an active buffer write operation for the endpoint,
+ * `false` otherwise.
+ */
+DIF_WARN_UNUSED_RESULT
+static bool buffer_op_is_writing(dif_usbdev_t *usbdev, uint8_t endpoint) {
+  return bitfield_field32_read(
+             usbdev->active_buffer_ops,
+             (bitfield_field32_t){
+                 .mask = 1, .index = kEndpointHwInfos[endpoint].bit_index,
+             }) > 0;
+}
+
+/**
+ * Mark the start of a buffer read operation for an endpoint.
+ *
+ * @param usbdev A USB device.
+ * @param endpoint An endpoint.
+ */
+static void buffer_op_start_read(dif_usbdev_t *usbdev) {
+  usbdev->active_buffer_ops = bitfield_field32_write(
+      usbdev->active_buffer_ops,
+      (bitfield_field32_t){
+          .mask = 1, .index = USBDEV_READ_BUFFER_OP_BIT_INDEX,
+      },
+      1);
+}
+
+/**
+ * Mark the end of a buffer read operation for an endpoint.
+ *
+ * @param usbdev A USB device.
+ * @param endpoint An endpoint.
+ */
+static void buffer_op_stop_read(dif_usbdev_t *usbdev) {
+  usbdev->active_buffer_ops = bitfield_field32_write(
+      usbdev->active_buffer_ops,
+      (bitfield_field32_t){
+          .mask = 1, .index = USBDEV_READ_BUFFER_OP_BIT_INDEX,
+      },
+      0);
+}
+
+/**
+ * Check if there is an active buffer read operation for an endpoint.
+ *
+ * @param usbdev A USB device.
+ * @param endpoint An endpoint.
+ * @return `true` if there is an active buffer read operation for the endpoint,
+ * `false` otherwise.
+ */
+DIF_WARN_UNUSED_RESULT
+static bool buffer_op_is_reading(dif_usbdev_t *usbdev) {
+  return bitfield_field32_read(
+             usbdev->active_buffer_ops,
+             (bitfield_field32_t){
+                 .mask = 1, .index = USBDEV_READ_BUFFER_OP_BIT_INDEX,
+             }) > 0;
+}
+
+/**
+ * Utility functions
+ */
+
+/**
+ * Checks if the given value is a valid `dif_usbdev_toggle_t` variant.
+ */
+DIF_WARN_UNUSED_RESULT
+static bool is_valid_toggle(dif_usbdev_toggle_t val) {
+  return val == kDifUsbdevToggleEnable || val == kDifUsbdevToggleDisable;
+}
+
+/**
+ * Checks if the given value is a valid `dif_usbdev_power_sense_override_t`
+ * variant.
+ */
+DIF_WARN_UNUSED_RESULT
+static bool is_valid_power_sense_override(
+    dif_usbdev_power_sense_override_t val) {
+  return val == kDifUsbdevPowerSenseOverrideDisabled ||
+         val == kDifUsbdevPowerSenseOverridePresent ||
+         val == kDifUsbdevPowerSenseOverrideNotPresent;
+}
+
+/**
+ * Checks if the given value is a valid endpoint number.
+ */
+DIF_WARN_UNUSED_RESULT
+static bool is_valid_endpoint(uint8_t endpoint) {
+  return endpoint < USBDEV_NUM_ENDPOINTS;
+}
+
+/**
+ * Checks if the given value is a valid `dif_usbdev_irq_t` variant.
+ */
+DIF_WARN_UNUSED_RESULT
+static bool is_valid_irq(dif_usbdev_irq_t irq) {
+  return irq >= kDifUsbdevIrqFirst && irq <= kDifUsbdevIrqLast;
+}
+
+/**
+ * Enables/disables the functionality controlled by the register at `reg_offset`
+ * for an endpoint.
+ */
+DIF_WARN_UNUSED_RESULT
+static dif_usbdev_result_t endpoint_functionality_enable(
+    dif_usbdev_t *usbdev, uint32_t reg_offset, uint8_t endpoint,
+    dif_usbdev_toggle_t new_state) {
+  if (usbdev == NULL || !is_valid_endpoint(endpoint) ||
+      !is_valid_toggle(new_state)) {
+    return kDifUsbdevBadArg;
+  }
+
+  if (kDifUsbdevToggleEnable) {
+    mmio_region_nonatomic_set_bit32(usbdev->base_addr, reg_offset,
+                                    kEndpointHwInfos[endpoint].bit_index);
+  } else {
+    mmio_region_nonatomic_clear_bit32(usbdev->base_addr, reg_offset,
+                                      kEndpointHwInfos[endpoint].bit_index);
+  }
+
+  return kDifUsbdevOK;
+}
+
+/**
+ * Returns the address that corresponds to the given buffer entry and offset
+ * into that entry.
+ */
+DIF_WARN_UNUSED_RESULT
+static uint32_t get_buffer_addr(uint8_t buffer_entry, size_t offset) {
+  return USBDEV_BUFFER_REG_OFFSET +
+         (buffer_entry * USBDEV_BUFFER_ENTRY_SIZE_BYTES) + offset;
+}
+
+/**
+ * USBDEV DIF library functions.
+ */
+
+dif_usbdev_result_t dif_usbdev_init(dif_usbdev_config_t *config,
+                                    dif_usbdev_t *usbdev) {
+  if (usbdev == NULL || config == NULL) {
+    return kDifUsbdevBadArg;
+  }
+
+  // Check enum fields
+  if (!is_valid_toggle(config->differential_rx) ||
+      !is_valid_toggle(config->differential_tx) ||
+      !is_valid_toggle(config->single_bit_eop) ||
+      !is_valid_power_sense_override(config->power_sense_override)) {
+    return kDifUsbdevBadArg;
+  }
+
+  // Store base address
+  usbdev->base_addr = config->base_addr;
+
+  // Initialize the free buffer pool
+  if (!buffer_pool_init(&usbdev->buffer_pool)) {
+    return kDifUsbdevError;
+  }
+
+  // No active buffer operation
+  buffer_op_init(usbdev);
+
+  // Determine the value of the PHY_CONFIG register.
+  uint32_t phy_config_val = 0;
+
+  if (config->differential_rx == kDifUsbdevToggleEnable) {
+    phy_config_val = bitfield_field32_write(
+        phy_config_val,
+        (bitfield_field32_t){
+            .mask = 1, .index = USBDEV_PHY_CONFIG_RX_DIFFERENTIAL_MODE,
+        },
+        1);
+  }
+
+  if (config->differential_tx == kDifUsbdevToggleEnable) {
+    phy_config_val = bitfield_field32_write(
+        phy_config_val,
+        (bitfield_field32_t){
+            .mask = 1, .index = USBDEV_PHY_CONFIG_TX_DIFFERENTIAL_MODE,
+        },
+        1);
+  }
+
+  if (config->single_bit_eop == kDifUsbdevToggleEnable) {
+    phy_config_val = bitfield_field32_write(
+        phy_config_val,
+        (bitfield_field32_t){
+            .mask = 1, .index = USBDEV_PHY_CONFIG_EOP_SINGLE_BIT,
+        },
+        1);
+  }
+
+  if (config->power_sense_override == kDifUsbdevPowerSenseOverridePresent) {
+    phy_config_val = bitfield_field32_write(
+        phy_config_val,
+        (bitfield_field32_t){
+            .mask = 1, .index = USBDEV_PHY_CONFIG_OVERRIDE_PWR_SENSE_EN,
+        },
+        1);
+    phy_config_val = bitfield_field32_write(
+        phy_config_val,
+        (bitfield_field32_t){
+            .mask = 1, .index = USBDEV_PHY_CONFIG_OVERRIDE_PWR_SENSE_VAL,
+        },
+        1);
+  } else if (config->power_sense_override ==
+             kDifUsbdevPowerSenseOverrideNotPresent) {
+    phy_config_val = bitfield_field32_write(
+        phy_config_val,
+        (bitfield_field32_t){
+            .mask = 1, .index = USBDEV_PHY_CONFIG_OVERRIDE_PWR_SENSE_EN,
+        },
+        1);
+  }
+
+  // Write configuration to PHY_CONFIG register
+  mmio_region_write32(usbdev->base_addr, USBDEV_PHY_CONFIG_REG_OFFSET,
+                      phy_config_val);
+
+  return kDifUsbdevOK;
+}
+
+dif_usbdev_result_t dif_usbdev_fill_available_fifo(dif_usbdev_t *usbdev) {
+  if (usbdev == NULL) {
+    return kDifUsbdevBadArg;
+  }
+
+  // Remove entries from the pool and write them to the AV FIFO until it is full
+  while (!mmio_region_get_bit32(usbdev->base_addr, USBDEV_USBSTAT_REG_OFFSET,
+                                USBDEV_USBSTAT_AV_FULL) &&
+         !buffer_pool_is_empty(&usbdev->buffer_pool)) {
+    uint8_t buffer_entry;
+    if (!buffer_pool_remove(&usbdev->buffer_pool, &buffer_entry)) {
+      return kDifUsbdevError;
+    }
+    mmio_region_write_only_set_field32(
+        usbdev->base_addr, USBDEV_AVBUFFER_REG_OFFSET,
+        (bitfield_field32_t){
+            .mask = USBDEV_AVBUFFER_BUFFER_MASK,
+            .index = USBDEV_AVBUFFER_BUFFER_OFFSET,
+        },
+        buffer_entry);
+  }
+
+  return kDifUsbdevOK;
+}
+
+dif_usbdev_result_t dif_usbdev_endpoint_setup_enable(
+    dif_usbdev_t *usbdev, uint8_t endpoint, dif_usbdev_toggle_t new_state) {
+  return endpoint_functionality_enable(usbdev, USBDEV_RXENABLE_SETUP_REG_OFFSET,
+                                       endpoint, new_state);
+}
+
+dif_usbdev_result_t dif_usbdev_endpoint_out_enable(
+    dif_usbdev_t *usbdev, uint8_t endpoint, dif_usbdev_toggle_t new_state) {
+  return endpoint_functionality_enable(usbdev, USBDEV_RXENABLE_OUT_REG_OFFSET,
+                                       endpoint, new_state);
+}
+
+dif_usbdev_result_t dif_usbdev_endpoint_stall_enable(
+    dif_usbdev_t *usbdev, uint8_t endpoint, dif_usbdev_toggle_t new_state) {
+  return endpoint_functionality_enable(usbdev, USBDEV_STALL_REG_OFFSET,
+                                       endpoint, new_state);
+}
+
+dif_usbdev_result_t dif_usbdev_endpoint_stall_get(dif_usbdev_t *usbdev,
+                                                  uint8_t endpoint,
+                                                  bool *state) {
+  if (usbdev == NULL || state == NULL || !is_valid_endpoint(endpoint)) {
+    return kDifUsbdevBadArg;
+  }
+
+  *state = mmio_region_get_bit32(usbdev->base_addr, USBDEV_STALL_REG_OFFSET,
+                                 kEndpointHwInfos[endpoint].bit_index);
+
+  return kDifUsbdevOK;
+}
+
+dif_usbdev_result_t dif_usbdev_endpoint_iso_enable(
+    dif_usbdev_t *usbdev, uint8_t endpoint, dif_usbdev_toggle_t new_state) {
+  return endpoint_functionality_enable(usbdev, USBDEV_ISO_REG_OFFSET, endpoint,
+                                       new_state);
+}
+
+dif_usbdev_result_t dif_usbdev_interface_enable(dif_usbdev_t *usbdev,
+                                                dif_usbdev_toggle_t new_state) {
+  if (usbdev == NULL || !is_valid_toggle(new_state)) {
+    return kDifUsbdevBadArg;
+  }
+
+  if (new_state == kDifUsbdevToggleEnable) {
+    mmio_region_nonatomic_set_bit32(
+        usbdev->base_addr, USBDEV_USBCTRL_REG_OFFSET, USBDEV_USBCTRL_ENABLE);
+  } else {
+    mmio_region_nonatomic_clear_bit32(
+        usbdev->base_addr, USBDEV_USBCTRL_REG_OFFSET, USBDEV_USBCTRL_ENABLE);
+  }
+
+  return kDifUsbdevOK;
+}
+
+dif_usbdev_rx_packet_get_info_result_t dif_usbdev_rx_packet_get_info(
+    dif_usbdev_t *usbdev, dif_usbdev_rx_packet_info_t *packet) {
+  if (usbdev == NULL || packet == NULL) {
+    return kDifUsbdevRxPacketGetInfoResultBadArg;
+  }
+
+  // Check if there is already a read buffer operation in progress
+  if (buffer_op_is_reading(usbdev)) {
+    return kDifUsbdevRxPacketGetInfoResultBusy;
+  }
+
+  // Check if the RX FIFO is empty
+  if (mmio_region_get_bit32(usbdev->base_addr, USBDEV_USBSTAT_REG_OFFSET,
+                            USBDEV_USBSTAT_RX_EMPTY)) {
+    return kDifUsbdevRxPacketGetInfoResultNoPackets;
+  }
+
+  // Read fifo entry
+  const uint32_t fifo_entry =
+      mmio_region_read32(usbdev->base_addr, USBDEV_RXFIFO_REG_OFFSET);
+  // Fill packet info
+  packet->endpoint = bitfield_field32_read(
+      fifo_entry,
+      (bitfield_field32_t){
+          .mask = USBDEV_RXFIFO_EP_MASK, .index = USBDEV_RXFIFO_EP_OFFSET,
+      });
+  packet->is_setup = bitfield_field32_read(
+      fifo_entry, (bitfield_field32_t){
+                      .mask = 1, .index = USBDEV_RXFIFO_SETUP,
+                  });
+  packet->len = bitfield_field32_read(
+      fifo_entry,
+      (bitfield_field32_t){
+          .mask = USBDEV_RXFIFO_SIZE_MASK, .index = USBDEV_RXFIFO_SIZE_OFFSET,
+      });
+  // Get the buffer entry that holds the payload
+  uint8_t buffer_entry = bitfield_field32_read(
+      fifo_entry, (bitfield_field32_t){
+                      .mask = USBDEV_RXFIFO_BUFFER_MASK,
+                      .index = USBDEV_RXFIFO_BUFFER_OFFSET,
+                  });
+  // Start a read buffer operation
+  buffer_op_start_read(usbdev);
+  usbdev->read_buffer_op_state = (dif_usbdev_read_buffer_op_state_t){
+      .buffer_entry = buffer_entry, .remaining_bytes = packet->len, .offset = 0,
+  };
+
+  return kDifUsbdevRxPacketGetInfoResultOK;
+}
+
+dif_usbdev_rx_packet_read_bytes_result_t dif_usbdev_rx_packet_read_bytes(
+    dif_usbdev_t *usbdev, uint8_t *dst, size_t dst_len, size_t *bytes_written) {
+  if (usbdev == NULL || dst == NULL) {
+    return kDifUsbdevRxPacketReadBytesResultBadArg;
+  }
+
+  // Make sure that a read buffer operation is in progress
+  if (!buffer_op_is_reading(usbdev)) {
+    return kDifUsbdevRxPacketReadBytesResultNotReading;
+  }
+  // bytes_to_copy is the minimum of remaining bytes and `dst_len`
+  size_t bytes_to_copy = usbdev->read_buffer_op_state.remaining_bytes;
+  if (bytes_to_copy > dst_len) {
+    bytes_to_copy = dst_len;
+  }
+  // Copy payload to buffer
+  const uint32_t buffer_addr =
+      get_buffer_addr(usbdev->read_buffer_op_state.buffer_entry,
+                      usbdev->read_buffer_op_state.offset);
+  mmio_region_memcpy_from_mmio32(usbdev->base_addr, buffer_addr, dst,
+                                 bytes_to_copy);
+  // Update current buffer operation
+  usbdev->read_buffer_op_state.offset += bytes_to_copy;
+  usbdev->read_buffer_op_state.remaining_bytes -= bytes_to_copy;
+  // Check if the entire payload is read
+  dif_usbdev_rx_packet_read_bytes_result_t res =
+      kDifUsbdevRxPacketReadBytesResultContinue;
+  if (usbdev->read_buffer_op_state.remaining_bytes == 0) {
+    res = kDifUsbdevRxPacketReadBytesResultOK;
+    // Finish read buffer operation
+    buffer_op_stop_read(usbdev);
+    // Return the buffer to the free buffer pool
+    if (!buffer_pool_add(&usbdev->buffer_pool,
+                         usbdev->read_buffer_op_state.buffer_entry)) {
+      return kDifUsbdevRxPacketReadBytesResultError;
+    }
+  }
+
+  if (bytes_written != NULL) {
+    *bytes_written = bytes_to_copy;
+  }
+
+  return res;
+}
+
+dif_usbdev_rx_packet_discard_bytes_result_t dif_usbdev_rx_packet_discard_bytes(
+    dif_usbdev_t *usbdev) {
+  if (usbdev == NULL) {
+    return kDifUsbdevRxPacketDiscardBytesResultBadArg;
+  }
+
+  // Make sure that a read buffer operation is in progress
+  if (!buffer_op_is_reading(usbdev)) {
+    return kDifUsbdevRxPacketDiscardBytesResultNotReading;
+  }
+  // Finish read buffer operation
+  buffer_op_stop_read(usbdev);
+  // Return the buffer to the free buffer pool
+  if (!buffer_pool_add(&usbdev->buffer_pool,
+                       usbdev->read_buffer_op_state.buffer_entry)) {
+    return kDifUsbdevRxPacketDiscardBytesResultError;
+  }
+
+  return kDifUsbdevRxPacketDiscardBytesResultOK;
+}
+
+dif_usbdev_tx_packet_write_bytes_result_t dif_usbdev_tx_packet_write_bytes(
+    dif_usbdev_t *usbdev, uint8_t endpoint, uint8_t *src, size_t src_len,
+    size_t *bytes_written) {
+  if (usbdev == NULL || (src_len > 0 && src == NULL) ||
+      !is_valid_endpoint(endpoint)) {
+    return kDifUsbdevTxPacketWriteBytesResultBadArg;
+  }
+
+  // Get tx packet status for the endpoint.
+  dif_usbdev_tx_packet_status_t in_packet_status;
+  if (dif_usbdev_tx_packet_get_status(usbdev, endpoint, &in_packet_status) !=
+      kDifUsbdevOK) {
+    return kDifUsbdevTxPacketWriteBytesResultError;
+  }
+
+  // Get the configin register offset of the endpoint.
+  const uint32_t config_in_reg_offset =
+      kEndpointHwInfos[endpoint].config_in_reg_offset;
+
+  uint32_t config_in_val;
+  uint8_t buffer_entry;
+  uint8_t buffer_len;
+  switch (in_packet_status) {
+    case kDifUsbdevTxPacketStatusNoPacket: {
+      // There is no packet for the endpoint
+      // Allocate a new buffer entry
+      if (buffer_pool_is_empty(&usbdev->buffer_pool)) {
+        return kDifUsbdevTxPacketWriteBytesResultNoBuffers;
+      }
+      if (!buffer_pool_remove(&usbdev->buffer_pool, &buffer_entry)) {
+        return kDifUsbdevTxPacketWriteBytesResultError;
+      }
+      buffer_len = 0;
+      // Start buffer write operation
+      buffer_op_start_write(usbdev, endpoint);
+      // Update USBDEV_CONFIGINX register.
+      // Note: Using mask and offset values for the USBDEV_CONFIGIN0 register
+      // for all endpoints because all USBDEV_CONFIGINX registers have the same
+      // layout.
+      uint32_t config_in_val =
+          mmio_region_read32(usbdev->base_addr, config_in_reg_offset);
+      config_in_val =
+          bitfield_field32_write(config_in_val,
+                                 (bitfield_field32_t){
+                                     .mask = USBDEV_CONFIGIN0_BUFFER0_MASK,
+                                     .index = USBDEV_CONFIGIN0_BUFFER0_OFFSET,
+                                 },
+                                 buffer_entry);
+      config_in_val =
+          bitfield_field32_write(config_in_val,
+                                 (bitfield_field32_t){
+                                     .mask = USBDEV_CONFIGIN0_SIZE0_MASK,
+                                     .index = USBDEV_CONFIGIN0_SIZE0_OFFSET,
+                                 },
+                                 buffer_len);
+      mmio_region_write32(usbdev->base_addr, config_in_reg_offset,
+                          config_in_val);
+      break;
+    }
+    case kDifUsbdevTxPacketStatusStillWriting: {
+      // Use existing buffer entry
+      config_in_val =
+          mmio_region_read32(usbdev->base_addr, config_in_reg_offset);
+      buffer_entry = bitfield_field32_read(
+          config_in_val, (bitfield_field32_t){
+                             .mask = USBDEV_CONFIGIN0_BUFFER0_MASK,
+                             .index = USBDEV_CONFIGIN0_BUFFER0_OFFSET,
+                         });
+      buffer_len = bitfield_field32_read(
+          config_in_val, (bitfield_field32_t){
+                             .mask = USBDEV_CONFIGIN0_SIZE0_MASK,
+                             .index = USBDEV_CONFIGIN0_SIZE0_OFFSET,
+                         });
+      break;
+    }
+    case kDifUsbdevTxPacketStatusPending:
+    case kDifUsbdevTxPacketStatusSent:
+    case kDifUsbdevTxPacketStatusCancelled:
+      // Endpoint already has a packet pending transmission or the status of the
+      // last transmission is not read yet.
+      return kDifUsbdevTxPacketWriteBytesResultBusy;
+    default:
+      return kDifUsbdevTxPacketWriteBytesResultError;
+  }
+
+  size_t remaining_buffer_space = USBDEV_BUFFER_ENTRY_SIZE_BYTES - buffer_len;
+  // `bytes_to_copy` is the minimum of `src_len` and `remaining_buffer_space`.
+  size_t bytes_to_copy = src_len;
+  if (bytes_to_copy > remaining_buffer_space) {
+    bytes_to_copy = remaining_buffer_space;
+  }
+
+  // Write bytes to the buffer
+  const uint32_t buffer_addr = get_buffer_addr(buffer_entry, buffer_len);
+  mmio_region_memcpy_to_mmio32(usbdev->base_addr, buffer_addr, src,
+                               bytes_to_copy);
+
+  buffer_len += bytes_to_copy;
+  remaining_buffer_space -= bytes_to_copy;
+
+  // Update buffer length in the USBDEV_CONFIGINX register.
+  mmio_region_nonatomic_set_field32(usbdev->base_addr, config_in_reg_offset,
+                                    (bitfield_field32_t){
+                                        .mask = USBDEV_CONFIGIN0_SIZE0_MASK,
+                                        .index = USBDEV_CONFIGIN0_SIZE0_OFFSET,
+                                    },
+                                    buffer_len);
+
+  if (bytes_written) {
+    *bytes_written = bytes_to_copy;
+  }
+
+  if (remaining_buffer_space == 0 && bytes_to_copy < src_len) {
+    return kDifUsbdevTxPacketWriteBytesResultBufferFull;
+  }
+
+  return kDifUsbdevTxPacketWriteBytesResultOK;
+}
+
+dif_usbdev_tx_packet_send_result_t dif_usbdev_tx_packet_send(
+    dif_usbdev_t *usbdev, uint8_t endpoint) {
+  if (usbdev == NULL || !is_valid_endpoint(endpoint)) {
+    return kDifUsbdevTxPacketSendResultBadArg;
+  }
+
+  // Make sure that there is an active write operation for the endpoint
+  if (!buffer_op_is_writing(usbdev, endpoint)) {
+    return kDifUsbdevTxPacketSendResultNotWriting;
+  }
+
+  // Stop writing to buffer for this endpoint
+  buffer_op_stop_write(usbdev, endpoint);
+  // Mark the packet as ready for transmission
+  mmio_region_nonatomic_set_bit32(
+      usbdev->base_addr, kEndpointHwInfos[endpoint].config_in_reg_offset,
+      USBDEV_CONFIGIN0_RDY0);
+
+  return kDifUsbdevTxPacketSendResultOK;
+}
+
+dif_usbdev_result_t dif_usbdev_tx_packet_get_status(
+    dif_usbdev_t *usbdev, uint8_t endpoint,
+    dif_usbdev_tx_packet_status_t *status) {
+  if (usbdev == NULL || status == NULL || !is_valid_endpoint(endpoint)) {
+    return kDifUsbdevBadArg;
+  }
+
+  // Make sure that there is no active write buffer operation for the endpoint
+  if (buffer_op_is_writing(usbdev, endpoint)) {
+    *status = kDifUsbdevTxPacketStatusStillWriting;
+    return kDifUsbdevOK;
+  }
+
+  // Get the configin register offset and bit index of the endpoint
+  uint32_t config_in_reg_offset =
+      kEndpointHwInfos[endpoint].config_in_reg_offset;
+  uint8_t endpoint_bit_index = kEndpointHwInfos[endpoint].bit_index;
+
+  // Read the configin register
+  uint32_t config_in_val =
+      mmio_region_read32(usbdev->base_addr, config_in_reg_offset);
+
+  // Buffer used by this endpoint
+  uint8_t buffer = bitfield_field32_read(
+      config_in_val, (bitfield_field32_t){
+                         .mask = USBDEV_CONFIGIN0_BUFFER0_MASK,
+                         .index = USBDEV_CONFIGIN0_BUFFER0_OFFSET,
+                     });
+
+  // Check the status of the packet
+  if (bitfield_field32_read(config_in_val,
+                            (bitfield_field32_t){
+                                .mask = 1, .index = USBDEV_CONFIGIN0_RDY0,
+                            })) {
+    // Packet is marked as ready to be sent and pending transmission
+    *status = kDifUsbdevTxPacketStatusPending;
+  } else if (mmio_region_get_bit32(usbdev->base_addr, USBDEV_IN_SENT_REG_OFFSET,
+                                   endpoint_bit_index)) {
+    // Packet was sent successfully
+    // Clear IN_SENT bit (rw1c)
+    mmio_region_write_only_set_bit32(
+        usbdev->base_addr, USBDEV_IN_SENT_REG_OFFSET, endpoint_bit_index);
+    // Return the buffer back to the free buffer pool
+    if (!buffer_pool_add(&usbdev->buffer_pool, buffer)) {
+      return kDifUsbdevError;
+    }
+    *status = kDifUsbdevTxPacketStatusSent;
+  } else if (bitfield_field32_read(
+                 config_in_val, (bitfield_field32_t){
+                                    .mask = 1, .index = USBDEV_CONFIGIN0_PEND0,
+                                })) {
+    // Canceled due to an IN SETUP packet
+    // Clear pending bit (rw1c)
+    mmio_region_write_only_set_bit32(usbdev->base_addr, config_in_reg_offset,
+                                     USBDEV_CONFIGIN0_PEND0);
+    // Return the buffer back to the free buffer pool
+    if (!buffer_pool_add(&usbdev->buffer_pool, buffer)) {
+      return kDifUsbdevError;
+    }
+    *status = kDifUsbdevTxPacketStatusCancelled;
+  } else {
+    // No packet has been queued for this endpoint
+    *status = kDifUsbdevTxPacketStatusNoPacket;
+  }
+
+  return kDifUsbdevOK;
+}
+
+dif_usbdev_result_t dif_usbdev_address_set(dif_usbdev_t *usbdev, uint8_t addr) {
+  if (usbdev == NULL) {
+    return kDifUsbdevBadArg;
+  }
+
+  mmio_region_nonatomic_set_field32(
+      usbdev->base_addr, USBDEV_USBCTRL_REG_OFFSET,
+      (bitfield_field32_t){
+          .mask = USBDEV_USBCTRL_DEVICE_ADDRESS_MASK,
+          .index = USBDEV_USBCTRL_DEVICE_ADDRESS_OFFSET,
+      },
+      addr);
+
+  return kDifUsbdevOK;
+}
+
+dif_usbdev_result_t dif_usbdev_address_get(dif_usbdev_t *usbdev,
+                                           uint8_t *addr) {
+  if (usbdev == NULL || addr == NULL) {
+    return kDifUsbdevBadArg;
+  }
+
+  // Note: Size of address is 7 bits.
+  *addr = mmio_region_read_mask32(usbdev->base_addr, USBDEV_USBCTRL_REG_OFFSET,
+                                  USBDEV_USBCTRL_DEVICE_ADDRESS_MASK,
+                                  USBDEV_USBCTRL_DEVICE_ADDRESS_OFFSET);
+
+  return kDifUsbdevOK;
+}
+
+dif_usbdev_result_t dif_usbdev_status_get_frame(dif_usbdev_t *usbdev,
+                                                uint16_t *frame_index) {
+  if (usbdev == NULL || frame_index == NULL) {
+    return kDifUsbdevBadArg;
+  }
+
+  // Note: size of frame index is 11 bits.
+  *frame_index = mmio_region_read_mask32(
+      usbdev->base_addr, USBDEV_USBSTAT_REG_OFFSET, USBDEV_USBSTAT_FRAME_MASK,
+      USBDEV_USBSTAT_FRAME_OFFSET);
+
+  return kDifUsbdevOK;
+}
+
+dif_usbdev_result_t dif_usbdev_status_get_host_lost(dif_usbdev_t *usbdev,
+                                                    bool *host_lost) {
+  if (usbdev == NULL || host_lost == NULL) {
+    return kDifUsbdevBadArg;
+  }
+
+  *host_lost = mmio_region_get_bit32(
+      usbdev->base_addr, USBDEV_USBSTAT_REG_OFFSET, USBDEV_USBSTAT_HOST_LOST);
+
+  return kDifUsbdevOK;
+}
+
+dif_usbdev_result_t dif_usbdev_status_get_link_state(
+    dif_usbdev_t *usbdev, dif_usbdev_link_state_t *link_state) {
+  if (usbdev == NULL || link_state == NULL) {
+    return kDifUsbdevBadArg;
+  }
+
+  uint32_t val = mmio_region_read_mask32(
+      usbdev->base_addr, USBDEV_USBSTAT_REG_OFFSET,
+      USBDEV_USBSTAT_LINK_STATE_MASK, USBDEV_USBSTAT_LINK_STATE_OFFSET);
+
+  switch (val) {
+    case USBDEV_USBSTAT_LINK_STATE_DISCONNECT:
+      *link_state = kDifUsbdevLinkStateDisconnected;
+      break;
+    case USBDEV_USBSTAT_LINK_STATE_POWERED:
+      *link_state = kDifUsbdevLinkStatePowered;
+      break;
+    case USBDEV_USBSTAT_LINK_STATE_POWERED_SUSPEND:
+      *link_state = kDifUsbdevLinkStatePoweredSuspend;
+      break;
+    case USBDEV_USBSTAT_LINK_STATE_ACTIVE:
+      *link_state = kDifUsbdevLinkStateActive;
+      break;
+    case USBDEV_USBSTAT_LINK_STATE_SUSPEND:
+      *link_state = kDifUsbdevLinkStateSuspend;
+      break;
+    default:
+      return kDifUsbdevError;
+  }
+
+  return kDifUsbdevOK;
+}
+
+dif_usbdev_result_t dif_usbdev_status_get_sense(dif_usbdev_t *usbdev,
+                                                bool *sense) {
+  if (usbdev == NULL || sense == NULL) {
+    return kDifUsbdevBadArg;
+  }
+
+  *sense = mmio_region_get_bit32(usbdev->base_addr, USBDEV_USBSTAT_REG_OFFSET,
+                                 USBDEV_USBSTAT_SENSE);
+
+  return kDifUsbdevOK;
+}
+
+dif_usbdev_result_t dif_usbdev_status_get_available_fifo_depth(
+    dif_usbdev_t *usbdev, uint8_t *depth) {
+  if (usbdev == NULL || depth == NULL) {
+    return kDifUsbdevBadArg;
+  }
+
+  // Note: Size of available FIFO depth is 3 bits.
+  *depth = mmio_region_read_mask32(usbdev->base_addr, USBDEV_USBSTAT_REG_OFFSET,
+                                   USBDEV_USBSTAT_AV_DEPTH_MASK,
+                                   USBDEV_USBSTAT_AV_DEPTH_OFFSET);
+
+  return kDifUsbdevOK;
+}
+
+dif_usbdev_result_t dif_usbdev_status_get_available_fifo_full(
+    dif_usbdev_t *usbdev, bool *is_full) {
+  if (usbdev == NULL || is_full == NULL) {
+    return kDifUsbdevBadArg;
+  }
+
+  *is_full = mmio_region_get_bit32(usbdev->base_addr, USBDEV_USBSTAT_REG_OFFSET,
+                                   USBDEV_USBSTAT_AV_FULL);
+
+  return kDifUsbdevOK;
+}
+
+dif_usbdev_result_t dif_usbdev_status_get_rx_fifo_depth(dif_usbdev_t *usbdev,
+                                                        uint8_t *depth) {
+  if (usbdev == NULL || depth == NULL) {
+    return kDifUsbdevBadArg;
+  }
+
+  // Note: Size of RX FIFO depth is 3 bits.
+  *depth = mmio_region_read_mask32(usbdev->base_addr, USBDEV_USBSTAT_REG_OFFSET,
+                                   USBDEV_USBSTAT_RX_DEPTH_MASK,
+                                   USBDEV_USBSTAT_RX_DEPTH_OFFSET);
+
+  return kDifUsbdevOK;
+}
+
+dif_usbdev_result_t dif_usbdev_status_get_rx_fifo_empty(dif_usbdev_t *usbdev,
+                                                        bool *is_full) {
+  if (usbdev == NULL || is_full == NULL) {
+    return kDifUsbdevBadArg;
+  }
+
+  *is_full = mmio_region_get_bit32(usbdev->base_addr, USBDEV_USBSTAT_REG_OFFSET,
+                                   USBDEV_USBSTAT_RX_EMPTY);
+
+  return kDifUsbdevOK;
+}
+
+dif_usbdev_result_t dif_usbdev_irq_enable(dif_usbdev_t *usbdev,
+                                          dif_usbdev_irq_t irq,
+                                          dif_usbdev_toggle_t state) {
+  if (usbdev == NULL || !is_valid_irq(irq) || !is_valid_toggle(state)) {
+    return kDifUsbdevBadArg;
+  }
+
+  if (state == kDifUsbdevToggleEnable) {
+    mmio_region_nonatomic_set_bit32(usbdev->base_addr,
+                                    USBDEV_INTR_ENABLE_REG_OFFSET,
+                                    kIrqEnumToBitIndex[irq]);
+  } else {
+    mmio_region_nonatomic_clear_bit32(usbdev->base_addr,
+                                      USBDEV_INTR_ENABLE_REG_OFFSET,
+                                      kIrqEnumToBitIndex[irq]);
+  }
+
+  return kDifUsbdevOK;
+}
+
+dif_usbdev_result_t dif_usbdev_irq_get(dif_usbdev_t *usbdev,
+                                       dif_usbdev_irq_t irq, bool *state) {
+  if (usbdev == NULL || state == NULL || !is_valid_irq(irq)) {
+    return kDifUsbdevBadArg;
+  }
+
+  *state = mmio_region_get_bit32(
+      usbdev->base_addr, USBDEV_INTR_STATE_REG_OFFSET, kIrqEnumToBitIndex[irq]);
+
+  return kDifUsbdevOK;
+}
+
+dif_usbdev_result_t dif_usbdev_irq_clear(dif_usbdev_t *usbdev,
+                                         dif_usbdev_irq_t irq) {
+  if (usbdev == NULL || !is_valid_irq(irq)) {
+    return kDifUsbdevBadArg;
+  }
+
+  mmio_region_write_only_set_bit32(
+      usbdev->base_addr, USBDEV_INTR_STATE_REG_OFFSET, kIrqEnumToBitIndex[irq]);
+
+  return kDifUsbdevOK;
+}
+
+dif_usbdev_result_t dif_usbdev_irq_clear_all(dif_usbdev_t *usbdev) {
+  if (usbdev == NULL) {
+    return kDifUsbdevBadArg;
+  }
+
+  mmio_region_write32(usbdev->base_addr, USBDEV_INTR_STATE_REG_OFFSET,
+                      UINT32_MAX);
+
+  return kDifUsbdevOK;
+}
+
+dif_usbdev_result_t dif_usbdev_irq_disable_all(dif_usbdev_t *usbdev,
+                                               uint32_t *cur_config) {
+  if (usbdev == NULL) {
+    return kDifUsbdevBadArg;
+  }
+
+  if (cur_config != NULL) {
+    *cur_config =
+        mmio_region_read32(usbdev->base_addr, USBDEV_INTR_ENABLE_REG_OFFSET);
+  }
+
+  mmio_region_write32(usbdev->base_addr, USBDEV_INTR_ENABLE_REG_OFFSET, 0);
+
+  return kDifUsbdevOK;
+}
+
+dif_usbdev_result_t dif_usbdev_irq_restore(dif_usbdev_t *usbdev,
+                                           uint32_t new_config) {
+  if (usbdev == NULL) {
+    return kDifUsbdevBadArg;
+  }
+
+  mmio_region_write32(usbdev->base_addr, USBDEV_INTR_ENABLE_REG_OFFSET,
+                      new_config);
+
+  return kDifUsbdevOK;
+}
+
+dif_usbdev_result_t dif_usbdev_irq_test(dif_usbdev_t *usbdev,
+                                        dif_usbdev_irq_t irq) {
+  if (usbdev == NULL || !is_valid_irq(irq)) {
+    return kDifUsbdevBadArg;
+  }
+
+  mmio_region_write_only_set_bit32(
+      usbdev->base_addr, USBDEV_INTR_TEST_REG_OFFSET, kIrqEnumToBitIndex[irq]);
+
+  return kDifUsbdevOK;
+}

--- a/sw/device/lib/dif/dif_usbdev.h
+++ b/sw/device/lib/dif/dif_usbdev.h
@@ -1,0 +1,879 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_DIF_USBDEV_H_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_DIF_USBDEV_H_
+
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_warn_unused_result.h"
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * Hardware constants.
+ */
+#define USBDEV_NUM_ENDPOINTS 12
+#define USBDEV_MAX_PACKET_SIZE 64
+// Internal constant that should not be used by clients. Defined here because
+// it is used in the definition of `dif_usbdev_buffer_pool` below.
+#define USBDEV_NUM_BUFFERS 32
+
+/**
+ * Free buffer pool.
+ *
+ * A USB device has a fixed number of buffers that are used for storing incoming
+ * and outgoing packets and the software is responsible for keeping track of
+ * free buffers. The pool is implemented as a stack for constant-time add and
+ * remove. `top` points to the last free buffer added to the pool. The pool is
+ * full when `top == USBDEV_NUM_BUFFERS - 1` and empty when `top == -1`.
+ */
+typedef struct dif_usbdev_buffer_pool {
+  uint8_t entries[USBDEV_NUM_BUFFERS];
+  int8_t top;
+} dif_usbdev_buffer_pool_t;
+
+/**
+ * State of a read buffer operation.
+ *
+ * This struct is used to track the state of a read buffer operation internally.
+ * Thus, clients can freely choose their buffer sizes and easily process
+ * packets that are larger than their buffers by simply calling
+ * `dif_usbdev_rx_packet_read_bytes` repeatedly until they read the entire
+ * payload of each packet.
+ *
+ * See also: `dif_usbdev_rx_packet_get_info`, `dif_usbdev_rx_packet_read_bytes`.
+ */
+typedef struct dif_usbdev_read_buffer_op_state {
+  /**
+   * Buffer to read from.
+   */
+  uint8_t buffer_entry;
+  /**
+   * Number of remaining bytes.
+   */
+  size_t remaining_bytes;
+  /**
+   * Offset to start reading from.
+   */
+  size_t offset;
+} dif_usbdev_read_buffer_op_state_t;
+
+/**
+ * Internal state of a USB device.
+ *
+ * Instances of this struct must be initialized by `dif_usbdev_init()` before
+ * being passed to other functions in this library. Its fields should be
+ * considered private and are only provided here so that callers can allocate
+ * it.
+ */
+typedef struct dif_usbdev {
+  mmio_region_t base_addr;
+  dif_usbdev_buffer_pool_t buffer_pool;
+  dif_usbdev_read_buffer_op_state_t read_buffer_op_state;
+  uint16_t active_buffer_ops;
+} dif_usbdev_t;
+
+/**
+ * Enumeration for enabling/disabling various functionality.
+ */
+typedef enum dif_usbdev_toggle {
+  kDifUsbdevToggleDisable,
+  kDifUsbdevToggleEnable,
+} dif_usbdev_toggle_t;
+
+/**
+ * Set of allowed configurations for USB power sense override.
+ */
+typedef enum dif_usbdev_power_sense_override {
+  kDifUsbdevPowerSenseOverrideDisabled,
+  kDifUsbdevPowerSenseOverridePresent,
+  kDifUsbdevPowerSenseOverrideNotPresent
+} dif_usbdev_power_sense_override_t;
+
+/**
+ * Configuration for initializing a USB device.
+ */
+typedef struct dif_usbdev_config {
+  /**
+   * Base address of the USB device.
+   */
+  mmio_region_t base_addr;
+  /**
+   * Use the differential rx signal instead of the single-ended signals.
+   */
+  dif_usbdev_toggle_t differential_rx;
+  /**
+   * Use the differential tx signal instead of the single-ended signals.
+   */
+  dif_usbdev_toggle_t differential_tx;
+  /*
+   * Recognize a single SE0 bit as end of packet instead of requiring
+   * two bits.
+   */
+  dif_usbdev_toggle_t single_bit_eop;
+  /**
+   * Override USB power sense.
+   */
+  dif_usbdev_power_sense_override_t power_sense_override;
+} dif_usbdev_config_t;
+
+/**
+ * Common return codes for the functions in this library.
+ */
+typedef enum dif_usbdev_result {
+  /**
+   * Indicates that the call succeeded.
+   */
+  kDifUsbdevOK = 0,
+  /**
+   * Indicates that a non-specific error occurred and the hardware is in an
+   * invalid or irrecoverable state.
+   */
+  kDifUsbdevError = 1,
+  /**
+   * Indicates that the caller supplied invalid arguments but the call did not
+   * cause any side-effects and the hardware is in a valid and recoverable
+   * state.
+   */
+  kDifUsbdevBadArg = 2,
+} dif_usbdev_result_t;
+
+/**
+ * Initialize a USB device.
+ *
+ * A USB device must first be initialized by this function before calling other
+ * functions in this library.
+ *
+ * @param config Configuration for initializing a USB device.
+ * @param usbdev Internal state of the initialized USB device.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_usbdev_result_t dif_usbdev_init(dif_usbdev_config_t *config,
+                                    dif_usbdev_t *usbdev);
+
+/**
+ * Fill the available buffer FIFO of a USB device.
+ *
+ * The USB device has a small FIFO (AV FIFO) that stores free buffers for
+ * incoming packets. It is the responsibility of the software to ensure that the
+ * AV FIFO is never empty. If the host tries to send a packet when the AV FIFO
+ * is empty, the USB device will respond with a NAK. While this will typically
+ * cause the host to retry transmission for regular data packets, there are
+ * transactions in the USB protocol during which the USB device is not allowed
+ * to send a NAK. Thus, the software must make sure that the AV FIFO is never
+ * empty by calling this function periodically.
+ *
+ * @param usbdev A USB device.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_usbdev_result_t dif_usbdev_fill_available_fifo(dif_usbdev_t *usbdev);
+
+/**
+ * Enable or disable reception of SETUP packets for an endpoint.
+ *
+ * @param usbdev A USB device.
+ * @param endpoint An endpoint.
+ * @param new_state New SETUP packet reception state.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_usbdev_result_t dif_usbdev_endpoint_setup_enable(
+    dif_usbdev_t *usbdev, uint8_t endpoint, dif_usbdev_toggle_t new_state);
+
+/**
+ * Enable or disable reception of OUT packets for an endpoint.
+ *
+ * @param usbdev A USB device.
+ * @param endpoint An endpoint.
+ * @param new_state New OUT packet reception state.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_usbdev_result_t dif_usbdev_endpoint_out_enable(
+    dif_usbdev_t *usbdev, uint8_t endpoint, dif_usbdev_toggle_t new_state);
+
+/**
+ * Enable or disable STALL for an endpoint.
+ *
+ * @param usbdev A USB device.
+ * @param endpoint An endpoint.
+ * @param new_state New STALL state.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_usbdev_result_t dif_usbdev_endpoint_stall_enable(
+    dif_usbdev_t *usbdev, uint8_t endpoint, dif_usbdev_toggle_t new_state);
+
+/**
+ * Get STALL state of an endpoint.
+ *
+ * @param usbdev A USB device.
+ * @param endpoint An endpoint.
+ * @param state Current STALL state.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_usbdev_result_t dif_usbdev_endpoint_stall_get(dif_usbdev_t *usbdev,
+                                                  uint8_t endpoint,
+                                                  bool *state);
+
+/**
+ * Enable or disable isochronous mode for an endpoint.
+ *
+ * Isochronous endpoints transfer data periodically. Since isochronous transfers
+ * do not have a handshaking stage, isochronous endpoints cannot report errors
+ * or STALL conditions.
+ *
+ * @param usbdev A USB device.
+ * @param endpoint An endpoint.
+ * @param new_state New isochronous state.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_usbdev_result_t dif_usbdev_endpoint_iso_enable(
+    dif_usbdev_t *usbdev, uint8_t endpoint, dif_usbdev_toggle_t new_state);
+
+/**
+ * Enable the USB interface of a USB device.
+ *
+ * Calling this function causes the USB device to assert the full-speed pull-up
+ * signal to indicate its presence to the host.
+ *
+ * @param usbdev A USB device.
+ * @param new_state New interface state.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_usbdev_result_t dif_usbdev_interface_enable(dif_usbdev_t *usbdev,
+                                                dif_usbdev_toggle_t new_state);
+
+/**
+ * Information about a received packet.
+ */
+typedef struct dif_usbdev_rx_packet_info {
+  /**
+   * Endpoint of the packet.
+   */
+  uint8_t endpoint;
+  /**
+   * Length of the packet in bytes.
+   */
+  uint8_t len;
+  /**
+   * Indicates if the packet is a SETUP packet.
+   */
+  bool is_setup;
+} dif_usbdev_rx_packet_info_t;
+
+/**
+ * Return codes for `dif_usbdev_rx_packet_get_info`.
+ */
+typedef enum dif_usbdev_rx_packet_get_info_result {
+  /**
+   * Indicates that the call succeeded.
+   */
+  kDifUsbdevRxPacketGetInfoResultOK = kDifUsbdevOK,
+  /**
+   * Indicates that a non-specific error occurred and the hardware is in an
+   * invalid or irrecoverable state.
+   */
+  kDifUsbdevRxPacketGetInfoResultError = kDifUsbdevError,
+  /**
+   * Indicates that the caller supplied invalid arguments but the call did not
+   * cause any side-effects and the hardware is in a valid and recoverable
+   * state.
+   */
+  kDifUsbdevRxPacketGetInfoResultBadArg = kDifUsbdevBadArg,
+  /**
+   * Indicates that there is already a read buffer operation in progress.
+   */
+  kDifUsbdevRxPacketGetInfoResultBusy,
+  /**
+   * Indicates that RX FIFO is empty.
+   */
+  kDifUsbdevRxPacketGetInfoResultNoPackets,
+} dif_usbdev_rx_packet_get_info_result_t;
+
+/**
+ * Get information about the packet at the front of RX FIFO.
+ *
+ * The USB device has a small FIFO (RX FIFO) that stores received packets until
+ * the software has a chance to process them. It is the responsibility of the
+ * software to ensure that the RX FIFO is never full. If the host tries to send
+ * a packet when the RX FIFO is full, the USB device will respond with a NAK.
+ * While this will typically cause the host to retry transmission for regular
+ * data packets, there are transactions in the USB protocol during which the USB
+ * device is not allowed to send a NAK. Thus, the software must read received
+ * packets as soon as possible.
+ *
+ * Reading received packets involves two main steps:
+ * - Calling this function, i.e. `dif_usbdev_rx_packet_get_info`, and
+ * - Calling `dif_usbdev_rx_packet_read_bytes` until the entire packet payload
+ * is read or calling `dif_usbdev_rx_packet_discard_bytes`.
+ *
+ * In order to read an incoming packet, clients should first call this function
+ * to get information about the packet. In addition to populating a
+ * `dif_usbdev_rx_packet_info_t` struct, this also starts an internal read
+ * buffer operation. The state of this operation, i.e. the buffer to read from,
+ * number of bytes remaining and the offset to start reading from, is tracked by
+ * this library, therefore clients do not need to perform any additional state
+ * tracking. Then, clients should call `dif_usbdev_rx_packet_read_bytes` one or
+ * more times (depending on the sizes of their internal buffers) until the
+ * entire packet payload is read. Once the entire packet is read, the read
+ * buffer operation ends and the buffer that holds the packet payload is
+ * returned to the free buffer pool. If the clients want to ignore the payload
+ * of a packet, e.g. for an unsupported or a zero-length packet, they can call
+ * `dif_usbdev_rx_packet_discard_bytes` to immediately return the buffer that
+ * holds the packet payload to the free buffer pool and end the read buffer
+ * operation.
+ *
+ * @param usbdev A USB device.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_usbdev_rx_packet_get_info_result_t dif_usbdev_rx_packet_get_info(
+    dif_usbdev_t *usbdev, dif_usbdev_rx_packet_info_t *packet);
+
+/**
+ * Return codes for `dif_usbdev_rx_packet_read_bytes`.
+ */
+typedef enum dif_usbdev_rx_packet_read_bytes_result {
+  /**
+   * Indicates that the call succeeded and the entire packet payload is read.
+   */
+  kDifUsbdevRxPacketReadBytesResultOK = kDifUsbdevOK,
+  /**
+   * Indicates that a non-specific error occurred and the hardware is in an
+   * invalid or irrecoverable state.
+   */
+  kDifUsbdevRxPacketReadBytesResultError = kDifUsbdevError,
+  /**
+   * Indicates that the caller supplied invalid arguments but the call did not
+   * cause any side-effects and the hardware is in a valid and recoverable
+   * state.
+   */
+  kDifUsbdevRxPacketReadBytesResultBadArg = kDifUsbdevBadArg,
+  /**
+   * Indicates that the call was successful but there are remaining bytes to be
+   * read.
+   */
+  kDifUsbdevRxPacketReadBytesResultContinue,
+  /**
+   * Indicates that there is no active read buffer operation.
+   */
+  kDifUsbdevRxPacketReadBytesResultNotReading,
+} dif_usbdev_rx_packet_read_bytes_result_t;
+
+/**
+ * Read the payload of the last received packet.
+ *
+ * The clients should call this function to read the payload of the last
+ * received packet after calling `dif_usbdev_rx_packet_get_info`. This function
+ * copies the smaller of `dst_len` and remaining number of bytes to `dst`. The
+ * active read buffer operation ends and the buffer that holds the packet
+ * payload is returned to the free buffer pool when the entire packet payload is
+ * read.
+ *
+ * See also: `dif_usbdev_rx_packet_get_info`.
+ *
+ * @param usbdev A USB device.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_usbdev_rx_packet_read_bytes_result_t dif_usbdev_rx_packet_read_bytes(
+    dif_usbdev_t *usbdev, uint8_t *dst, size_t dst_len, size_t *bytes_written);
+
+/**
+ * Return codes for `dif_usbdev_rx_packet_discard_bytes`.
+ */
+typedef enum dif_usbdev_rx_packet_discard_bytes_result {
+  /**
+   * Indicates that the call succeeded.
+   */
+  kDifUsbdevRxPacketDiscardBytesResultOK = kDifUsbdevOK,
+  /**
+   * Indicates that a non-specific error occurred and the hardware is in an
+   * invalid or irrecoverable state.
+   */
+  kDifUsbdevRxPacketDiscardBytesResultError = kDifUsbdevError,
+  /**
+   * Indicates that the caller supplied invalid arguments but the call did not
+   * cause any side-effects and the hardware is in a valid and recoverable
+   * state.
+   */
+  kDifUsbdevRxPacketDiscardBytesResultBadArg = kDifUsbdevBadArg,
+  /**
+   * Indicates that there is no active read buffer operation.
+   */
+  kDifUsbdevRxPacketDiscardBytesResultNotReading,
+} dif_usbdev_rx_packet_discard_bytes_result_t;
+
+/**
+ * Discard the payload of the last received packet.
+ *
+ * The clients should call this function to discard the payload of the last
+ * received packet after calling `dif_usbdev_rx_packet_get_info`. This function
+ * immediately ends the active read buffer operation and returns the buffer
+ * that holds the packet payload to the free buffer pool.
+ *
+ * See also: `dif_usbdev_rx_packet_get_info`.
+ *
+ * @param usbdev A USB device.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_usbdev_rx_packet_discard_bytes_result_t dif_usbdev_rx_packet_discard_bytes(
+    dif_usbdev_t *usbdev);
+
+/**
+ * Return codes for `dif_usbdev_tx_packet_write_bytes`.
+ */
+typedef enum dif_usbdev_tx_packet_write_bytes_result {
+  /**
+   * Indicates that the call succeeded.
+   */
+  kDifUsbdevTxPacketWriteBytesResultOK = kDifUsbdevOK,
+  /**
+   * Indicates that a non-specific error occurred and the hardware is in an
+   * invalid or irrecoverable state.
+   */
+  kDifUsbdevTxPacketWriteBytesResultError = kDifUsbdevError,
+  /**
+   * Indicates that the caller supplied invalid arguments but the call did not
+   * cause any side-effects and the hardware is in a valid and recoverable
+   * state.
+   */
+  kDifUsbdevTxPacketWriteBytesResultBadArg = kDifUsbdevBadArg,
+  /**
+   * Indicates that there are no free buffers.
+   */
+  kDifUsbdevTxPacketWriteBytesResultNoBuffers,
+  /**
+   * Indicates that the requested write exceeds the device buffer size.
+   */
+  kDifUsbdevTxPacketWriteBytesResultBufferFull,
+  /**
+   * Indicates that the endpoint already has a packet pending transmission.
+   */
+  kDifUsbdevTxPacketWriteBytesResultBusy,
+} dif_usbdev_tx_packet_write_bytes_result_t;
+
+/**
+ * Write outgoing packet payload for an endpoint.
+ *
+ * The USB device has 12 endpoints, each of which can be used to send packets to
+ * the host. Since a packet is not actually transmitted to the host until the
+ * host sends an IN token, clients must write the packet payload to a device
+ * buffer and mark it as ready for transmission from a particular endpoint. Note
+ * that this can be done in parallel for multiple endpoints. A packet queued for
+ * transmission from a particular endpoint is transmitted once the host sends an
+ * IN token for that endpoint.
+ *
+ * After a packet is queued for transmission, clients should periodically check
+ * its status. While the USB device handles transmission errors automatically by
+ * retrying transmission, transmission of a packet may be canceled if the
+ * endpoint receives a SETUP packet or the link is reset before the queued
+ * packet is transmitted. In these cases, clients should handle the SETUP packet
+ * or the link reset first and then optionally send the same packet again.
+ *
+ * Sending a packet from a particular endpoint to the host involves three main
+ * steps:
+ * - Calling this function, i.e. `dif_usbdev_tx_packet_write_bytes`,
+ * - Calling `dif_usbdev_tx_packet_send`, and
+ * - Calling `dif_usbdev_tx_packet_get_status`.
+ *
+ * In order to send a packet, clients should first call this function (one or
+ * more times depending on the sizes of their internal buffers) to write the
+ * packet payload to a device buffer. Calling this function also starts an
+ * internal write buffer operation similar to `dif_usbdev_rx_packet_get_info`.
+ * After writing the packet payload, clients should call
+ * `dif_usbdev_tx_packet_send` to mark the packet as ready for transmission,
+ * which also ends the active write buffer operation. Then, clients should
+ * periodically call `dif_usbdev_tx_packet_get_status` to check the status of
+ * the packet. `dif_usbdev_tx_packet_get_status` returns the buffer that holds
+ * the packet payload to the free buffer pool once the packet is either
+ * successfully transmitted or canceled due to an incoming SETUP packet.
+ *
+ * @param usbdev A USB device.
+ * @param endpoint An endpoint.
+ * @param src Source buffer.
+ * @param src_len Length of the source buffer.
+ * @bytes_written Number of bytes written to the USB device buffer.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_usbdev_tx_packet_write_bytes_result_t dif_usbdev_tx_packet_write_bytes(
+    dif_usbdev_t *usbdev, uint8_t endpoint, uint8_t *src, size_t src_len,
+    size_t *bytes_written);
+
+/**
+ * Return codes for `dif_usbdev_tx_packet_send`.
+ */
+typedef enum dif_usbdev_tx_packet_send_result {
+  /**
+   * Indicates that the call succeeded.
+   */
+  kDifUsbdevTxPacketSendResultOK = kDifUsbdevOK,
+  /**
+   * Indicates that a non-specific error occurred and the hardware is in an
+   * invalid or irrecoverable state.
+   */
+  kDifUsbdevTxPacketSendResultError = kDifUsbdevError,
+  /**
+   * Indicates that the caller supplied invalid arguments but the call did not
+   * cause any side-effects and the hardware is in a valid and recoverable
+   * state.
+   */
+  kDifUsbdevTxPacketSendResultBadArg = kDifUsbdevBadArg,
+  /**
+   * Indicates that the endpoint does not have a packet to be sent.
+   */
+  kDifUsbdevTxPacketSendResultNotWriting,
+} dif_usbdev_tx_packet_send_result_t;
+
+/**
+ * Mark the packet buffered for the given endpoint as ready for transmission.
+ *
+ * See also: `dif_usbdev_tx_packet_write_bytes`.
+ *
+ * @param usbdev A USB device.
+ * @param endpoint An endpoint.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_usbdev_tx_packet_send_result_t dif_usbdev_tx_packet_send(
+    dif_usbdev_t *usbdev, uint8_t endpoint);
+
+/**
+ * Status of an outgoing packet.
+ */
+typedef enum dif_usbdev_tx_packet_status {
+  /**
+   *  There is no packet for the given endpoint.
+   */
+  kDifUsbdevTxPacketStatusNoPacket,
+  /**
+   * There is an active write buffer operation and the packet is not marked as
+   * ready for transmission yet.
+   */
+  kDifUsbdevTxPacketStatusStillWriting,
+  /**
+   * Packet is pending transmission.
+   */
+  kDifUsbdevTxPacketStatusPending,
+  /**
+   * Packet was sent successfully.
+   */
+  kDifUsbdevTxPacketStatusSent,
+  /**
+   * Transmission was canceled due to an incoming SETUP packet.
+   */
+  kDifUsbdevTxPacketStatusCancelled,
+} dif_usbdev_tx_packet_status_t;
+
+/**
+ * Get the status of a packet that has been queued to be sent from an endpoint.
+ *
+ * @param usbdev A USB device.
+ * @param endpoint An endpoint.
+ * @param status Status of the packet.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_usbdev_result_t dif_usbdev_tx_packet_get_status(
+    dif_usbdev_t *usbdev, uint8_t endpoint,
+    dif_usbdev_tx_packet_status_t *status);
+
+/**
+ * Set the address of a USB device.
+ *
+ * @param usbdev A USB device.
+ * @param addr New address. Only the last 7 bits are significant.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_usbdev_result_t dif_usbdev_address_set(dif_usbdev_t *usbdev, uint8_t addr);
+
+/**
+ * Get the address of a USB device.
+ *
+ * @param usbdev A USB device.
+ * @param addr Current address.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_usbdev_result_t dif_usbdev_address_get(dif_usbdev_t *usbdev, uint8_t *addr);
+
+/**
+ * Get USB frame index.
+ *
+ * @param usbdev A USB device.
+ * @param frame_index USB frame index.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_usbdev_result_t dif_usbdev_status_get_frame(dif_usbdev_t *usbdev,
+                                                uint16_t *frame_index);
+
+/**
+ * Check if the host is lost.
+ *
+ * The host is lost if the link is still active but a start of frame packet has
+ * not been received in the last 4.096ms.
+ *
+ * @param usbdev A USB device.
+ * @param host_lost Status of the host. `true` if the host is lost, `false`
+ * otherwise.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_usbdev_result_t dif_usbdev_status_get_host_lost(dif_usbdev_t *usbdev,
+                                                    bool *host_lost);
+
+/**
+ * USB link state.
+ */
+typedef enum dif_usbdev_link_state {
+  kDifUsbdevLinkStateDisconnected,
+  kDifUsbdevLinkStatePowered,
+  kDifUsbdevLinkStatePoweredSuspend,
+  kDifUsbdevLinkStateActive,
+  kDifUsbdevLinkStateSuspend,
+} dif_usbdev_link_state_t;
+
+/**
+ * Get USB link state.
+ *
+ * @param usbdev A USB device.
+ * @param link_state USB link state.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_usbdev_result_t dif_usbdev_status_get_link_state(
+    dif_usbdev_t *usbdev, dif_usbdev_link_state_t *link_state);
+
+/**
+ * Get the state of the sense pin.
+ *
+ * @param usbdev A USB device.
+ * @param sense State of the sense pin. `true` if the host is providing VBUS,
+ * `false` otherwise.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_usbdev_result_t dif_usbdev_status_get_sense(dif_usbdev_t *usbdev,
+                                                bool *sense);
+
+/**
+ * Get the depth of the AV FIFO.
+ *
+ * See also: `dif_usbdev_fill_available_fifo`.
+ *
+ * @param usbdev A USB device.
+ * @param depth Depth of the AV FIFO.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_usbdev_result_t dif_usbdev_status_get_available_fifo_depth(
+    dif_usbdev_t *usbdev, uint8_t *depth);
+/**
+ * Check if AV FIFO is full.
+ *
+ * See also: `dif_usbdev_fill_available_fifo`.
+ *
+ * @param usbdev A USB device.
+ * @param is_full State of the AV FIFO. `true` if full, false otherwise.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_usbdev_result_t dif_usbdev_status_get_available_fifo_full(
+    dif_usbdev_t *usbdev, bool *is_full);
+/**
+ * Get the depth of the RX FIFO.
+ *
+ * See also: `dif_usbdev_rx_packet_get_info`.
+ *
+ * @param usbdev A USB device.
+ * @param depth Depth of the RX FIFO.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_usbdev_result_t dif_usbdev_status_get_rx_fifo_depth(dif_usbdev_t *usbdev,
+                                                        uint8_t *depth);
+
+/**
+ * Check if the RX FIFO is empty.
+ *
+ * See also: `dif_usbdev_rx_packet_get_info`.
+ *
+ * @param usbdev A USB device.
+ * @param is_empty State of the RX FIFO. `true` if empty, `false` otherwise.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_usbdev_result_t dif_usbdev_status_get_rx_fifo_empty(dif_usbdev_t *usbdev,
+                                                        bool *is_empty);
+
+/**
+ * USB device interrupts.
+ */
+typedef enum dif_usbdev_irq {
+  /**
+   * \internal First USB device interrupt.
+   */
+  kDifUsbdevIrqFirst,
+  /**
+   * A packet was received as part of an OUT or SETUP transaction.
+   */
+  kDifUsbdevIrqPktReceived = kDifUsbdevIrqFirst,
+  /**
+   * A packet was sent as part of an IN transaction.
+   */
+  kDifUsbdevIrqPktSent,
+  /**
+   * VBUS was lost and the link was disconnected.
+   */
+  kDifUsbdevIrqDisconnected,
+  /**
+   * A Start-of-Frame (SOF) packet was not received on an active link
+   * for 4.096 ms. The host must send a SOF packet every 1 ms.
+   */
+  kDifUsbdevIrqHostLost,
+  /**
+   * Link was reset by the host.
+   */
+  kDifUsbdevIrqLinkReset,
+  /**
+   * Link was suspended by the host.
+   */
+  kDifUsbdevIrqLinkSuspend,
+  /**
+   * Link became active again after being suspended.
+   */
+  kDifUsbdevIrqLinkResume,
+  /**
+   * Available buffer FIFO was empty.
+   */
+  kDifUsbdevIrqAvEmpty,
+  /**
+   * Received buffer FIFO was full.
+   */
+  kDifUsbdevIrqRxFull,
+  /**
+   * A write was done to available buffer FIFO when it was full.
+   */
+  kDifUsbdevIrqAvOverflow,
+  /**
+   * The ACK packet expected in response to an IN transaction was
+   * not received.
+   */
+  kDifUsbdevIrqLinkInError,
+  /**
+   * A CRC error occurred.
+   */
+  kDifUsbdevIrqRxCrcError,
+  /**
+   * A packet with an invalid packet identifier (PID) was received.
+   */
+  kDifUsbdevIrqRxPidError,
+  /**
+   * A packet with invalid bitstuffing was received.
+   */
+  kDifUsbdevIrqRxBitstuffError,
+  /**
+   * USB frame number was updated with a valid SOF packet.
+   */
+  kDifUsbdevIrqFrame,
+  /**
+   * VBUS was detected.
+   */
+  kDifUsbdevIrqConnected,
+  /**
+   * \internal Last USB device interrupt.
+   */
+  kDifUsbdevIrqLast = kDifUsbdevIrqConnected
+} dif_usbdev_irq_t;
+
+/**
+ * Enable or disable an interrupt.
+ *
+ * @param usbdev A USB device.
+ * @param irq An interrupt.
+ * @param state New state of the interrupt.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_usbdev_result_t dif_usbdev_irq_enable(dif_usbdev_t *usbdev,
+                                          dif_usbdev_irq_t irq,
+                                          dif_usbdev_toggle_t state);
+
+/**
+ * Check if there is a pending request for an interrupt.
+ *
+ * @param usbdev A USB device.
+ * @param irq An interrupt.
+ * @param state State of the interrupt.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_usbdev_result_t dif_usbdev_irq_get(dif_usbdev_t *usbdev,
+                                       dif_usbdev_irq_t irq, bool *state);
+
+/**
+ * Clear an interrupt.
+ *
+ * @param usbdev A USB device.
+ * @param irq An interrupt.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_usbdev_result_t dif_usbdev_irq_clear(dif_usbdev_t *usbdev,
+                                         dif_usbdev_irq_t irq);
+
+/**
+ * Clear all pending interrupts.
+ *
+ * @param usbdev A USB device.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_usbdev_result_t dif_usbdev_irq_clear_all(dif_usbdev_t *usbdev);
+
+/**
+ * Disable all interrupts and optionally return the current interrupt
+ * configuration.
+ *
+ * @param usbdev A USB device.
+ * @param cur_config Current interrupt configuration.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_usbdev_result_t dif_usbdev_irq_disable_all(dif_usbdev_t *usbdev,
+                                               uint32_t *cur_config);
+
+/**
+ * Restore interrupt configuration.
+ *
+ * @param usbdev A USB device.
+ * @param new_config New interrupt configuration.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_usbdev_result_t dif_usbdev_irq_restore(dif_usbdev_t *usbdev,
+                                           uint32_t new_config);
+
+/**
+ * Test an interrupt.
+ *
+ * @param usbdev A USB device.
+ * @param irq An interrupt.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_usbdev_result_t dif_usbdev_irq_test(dif_usbdev_t *usbdev,
+                                        dif_usbdev_irq_t irq);
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_DIF_USBDEV_H_

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -83,3 +83,18 @@ sw_lib_dif_i2c = declare_dependency(
     ],
   )
 )
+
+# USBDEV DIF library (dif_usbdev)
+sw_lib_dif_usbdev = declare_dependency(
+  link_with: static_library(
+    'sw_lib_dif_usbdev',
+    sources: [
+      hw_ip_usbdev_reg_h,
+      'dif_usbdev.c',
+    ],
+    dependencies: [
+      sw_lib_mmio,
+      sw_lib_bitfield,
+    ],
+  )
+)


### PR DESCRIPTION
This change introduces a DIF library for the [USB device](https://docs.opentitan.org/hw/ip/usbdev/doc/).

See also: lowRISC/opentitan#1601 (tracking)

Signed-off-by: Alphan Ulusoy <alphan@google.com>