### PR TITLE
Dif uart *irq_state_clear fix

### DIFF
--- a/sw/device/lib/dif/dif_uart.c
+++ b/sw/device/lib/dif/dif_uart.c
@@ -359,8 +359,8 @@ bool dif_uart_irq_state_clear(const dif_uart_t *uart,
   }
 
   // Writing to the register clears the corresponding bits.
-  mmio_region_nonatomic_set_bit32(uart->base_addr, UART_INTR_STATE_REG_OFFSET,
-                                  offset);
+  mmio_region_write_only_set_bit32(uart->base_addr, UART_INTR_STATE_REG_OFFSET,
+                                   offset);
 
   return true;
 }

--- a/sw/device/tests/dif/dif_uart_test.cc
+++ b/sw/device/tests/dif/dif_uart_test.cc
@@ -469,15 +469,15 @@ TEST_F(IrqStateClearTest, NullArgs) {
 
 TEST_F(IrqStateClearTest, Success) {
   // Clear the first IRQ state.
-  EXPECT_MASK32(UART_INTR_STATE_REG_OFFSET,
-                {{UART_INTR_STATE_TX_WATERMARK, 0x1, true}});
+  EXPECT_WRITE32(UART_INTR_STATE_REG_OFFSET,
+                 {{UART_INTR_STATE_TX_WATERMARK, 1}});
 
   EXPECT_TRUE(
       dif_uart_irq_state_clear(&dif_uart_, kDifUartInterruptTxWatermark));
 
   // Clear the last IRQ state.
-  EXPECT_MASK32(UART_INTR_STATE_REG_OFFSET,
-                {{UART_INTR_STATE_RX_PARITY_ERR, 0x1, true}});
+  EXPECT_WRITE32(UART_INTR_STATE_REG_OFFSET,
+                 {{UART_INTR_STATE_RX_PARITY_ERR, 1}});
 
   EXPECT_TRUE(
       dif_uart_irq_state_clear(&dif_uart_, kDifUartInterruptRxParityErr));


### PR DESCRIPTION
- Current method does a read-modify-write to the INTR_STATE register
which ends up clearing more interrupt bit than required. This change
fixes that by writing 1 only to the given interrupt bit.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>