### PR TITLE
[doc] Document Docker clang-format version

### DIFF
--- a/util/container/README.md
+++ b/util/container/README.md
@@ -7,7 +7,10 @@ software development tools for OpenTitan. Current list of tools:
 * fusesoc
 * OpenOCD
 * RISCV toolchain
+* clang-format
 * Verilator
+
+The versions of the above should match the versions installed in CI.
 
 ## Local Build Instructions
 


### PR DESCRIPTION
#2082 recently added clang-format 3.8 (to match CI) to the Docker image.