### PR TITLE
[aes/rtl] Add masked versions of the Canright S-Box

### DIFF
--- a/hw/ip/aes/aes.core
+++ b/hw/ip/aes/aes.core
@@ -22,7 +22,10 @@ filesets:
       - rtl/aes_sub_bytes.sv
       - rtl/aes_sbox.sv
       - rtl/aes_sbox_lut.sv
+      - rtl/aes_sbox_canright_pkg.sv
       - rtl/aes_sbox_canright.sv
+      - rtl/aes_sbox_canright_masked_noreuse.sv
+      - rtl/aes_sbox_canright_masked.sv
       - rtl/aes_shift_rows.sv
       - rtl/aes_mix_columns.sv
       - rtl/aes_mix_single_column.sv

--- a/hw/ip/aes/pre_dv/aes_sbox_lec/aes_sbox_lec.ys
+++ b/hw/ip/aes/pre_dv/aes_sbox_lec/aes_sbox_lec.ys
@@ -9,6 +9,7 @@ read_verilog aes_sbox_ref.v aes_sbox_dut.v
 
 # Do some preprocessing
 proc
+flatten
 
 # Set up equivalence check
 equiv_make aes_sbox_ref aes_sbox_dut aes_sbox_equiv

--- a/hw/ip/aes/pre_dv/aes_sbox_lec/aes_sbox_masked_wrapper.sv
+++ b/hw/ip/aes/pre_dv/aes_sbox_lec/aes_sbox_masked_wrapper.sv
@@ -1,0 +1,34 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Wrapper to allow LEC of masked S-Boxes against LUT-based S-Box.
+
+module aes_sbox_masked_wrapper (
+  input  aes_pkg::ciph_op_e op_i,
+  input  logic [7:0]        data_i,
+  output logic [7:0]        data_o
+);
+
+  logic [7:0] in_data_m, out_data_m;
+  logic [7:0] in_mask, out_mask;
+
+  // The mask inputs are tied to constant values.
+  assign in_mask  = 8'hAA;
+  assign out_mask = 8'h55;
+
+  // Mask input data
+  assign in_data_m = data_i ^ in_mask;
+
+  aes_sbox_masked aes_sbox_masked (
+    .op_i       ( op_i       ),
+    .data_i     ( in_data_m  ),
+    .in_mask_i  ( in_mask    ),
+    .out_mask_i ( out_mask   ),
+    .data_o     ( out_data_m )
+  );
+
+  // Unmask output data
+  assign data_o = out_data_m ^ out_mask;
+
+endmodule

--- a/hw/ip/aes/pre_dv/aes_sbox_tb/rtl/aes_sbox_tb.sv
+++ b/hw/ip/aes/pre_dv/aes_sbox_tb/rtl/aes_sbox_tb.sv
@@ -20,7 +20,9 @@ module aes_sbox_tb #(
   ciph_op_e   op;
 
   localparam int NUM_SBOX_IMPLS = 2;
-  logic [7:0] responses[NUM_SBOX_IMPLS];
+  localparam int NUM_SBOX_IMPLS_MASKED = 2;
+  localparam int NumSBoxImplsTotal = NUM_SBOX_IMPLS + NUM_SBOX_IMPLS_MASKED;
+  logic [7:0] responses[NumSBoxImplsTotal];
 
   // Generate the stimuli
   assign count_d = count_q + 9'h1;
@@ -52,16 +54,61 @@ module aes_sbox_tb #(
     .data_o ( responses[1] )
   );
 
+  // Mask Generation
+  logic [7:0] masked_stimulus;
+  logic [7:0] in_mask;
+  logic [7:0] out_mask;
+  logic [7:0] masked_response [NUM_SBOX_IMPLS_MASKED];
+  logic [31:0] tmp;
+  logic [15:0] unused_tmp;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : reg_tmp
+    if (!rst_ni) begin
+      tmp <= 32'hAAAFF;
+    end else begin
+      tmp <= $random;
+    end
+  end
+  assign unused_tmp = tmp[31:16];
+  assign in_mask  = tmp[7:0];
+  assign out_mask = tmp[15:8];
+
+  assign masked_stimulus = stimulus ^ in_mask;
+
+  // Instantiate Masked SBox Implementations
+  aes_sbox_canright_masked_noreuse aes_sbox_canright_masked_noreuse (
+    .op_i       ( op                 ),
+    .data_i     ( masked_stimulus    ),
+    .in_mask_i  ( in_mask            ),
+    .out_mask_i ( out_mask           ),
+    .data_o     ( masked_response[0] )
+  );
+
+  aes_sbox_canright_masked aes_sbox_canright_masked (
+    .op_i       ( op                 ),
+    .data_i     ( masked_stimulus    ),
+    .in_mask_i  ( in_mask            ),
+    .out_mask_i ( out_mask           ),
+    .data_o     ( masked_response[1] )
+  );
+
+  // Unmask responses
+  always_comb begin : unmask_resp
+    for (int i=0; i<NUM_SBOX_IMPLS_MASKED; i++) begin
+      responses[NUM_SBOX_IMPLS+i] = masked_response[i] ^ out_mask;
+    end
+  end
+
   // Check responses, signal end of simulation
   always_ff @(posedge clk_i or negedge rst_ni) begin : tb_ctrl
     test_done_o   <= 1'b0;
     test_passed_o <= 1'b1;
 
-    for (int i=1; i<NUM_SBOX_IMPLS; i++) begin
+    for (int i=1; i<NumSBoxImplsTotal; i++) begin
       if (rst_ni && (responses[i] != responses[0])) begin
         $display("\nERROR: Mismatch between LUT-based S-Box and Implementation %0d found.", i);
         $display("op = %s, stimulus = 8'h%h, expected resp = 8'h%h, actual resp = 8'h%h\n",
-            (op == CIPH_FWD) ? "CIPH_FWD" : "CIPH_INV", stimulus, responses[0], responses[1]);
+            (op == CIPH_FWD) ? "CIPH_FWD" : "CIPH_INV", stimulus, responses[0], responses[i]);
         test_passed_o <= 1'b0;
         test_done_o   <= 1'b1;
       end

--- a/hw/ip/aes/rtl/aes.sv
+++ b/hw/ip/aes/rtl/aes.sv
@@ -8,7 +8,10 @@
 
 module aes #(
   parameter bit AES192Enable = 1,    // Can be 0 (disable), or 1 (enable).
-  parameter     SBoxImpl     = "lut" // Can be "lut" (LUT-based SBox), or "canright".
+  parameter     SBoxImpl     = "lut" // Can be "lut" (LUT-based SBox), "canright",
+                                     // "canright_masked_noreuse", or "canright_masked".
+                                     // Note: Currently, constant masks are used, this is
+                                     // of course not secure.
 ) (
   input                     clk_i,
   input                     rst_ni,

--- a/hw/ip/aes/rtl/aes_sbox.sv
+++ b/hw/ip/aes/rtl/aes_sbox.sv
@@ -24,6 +24,35 @@ module aes_sbox #(
       .data_i,
       .data_o
     );
+  end else begin
+    // TODO: Use non-constant masks + remove corresponding comment in aes.sv.
+    // See https://github.com/lowRISC/opentitan/issues/1005
+    logic [7:0] in_data_m, out_data_m;
+    logic [7:0] in_mask, out_mask;
+    assign in_mask  = 8'hAA;
+    assign out_mask = 8'h55;
+
+    // Mask input data
+    assign in_data_m = data_i ^ in_mask;
+    if (SBoxImpl == "canright_masked_noreuse") begin : gen_sbox_canright_masked_noreuse
+      aes_sbox_canright_masked_noreuse aes_sbox (
+        .op_i,
+        .data_i     ( in_data_m  ),
+        .in_mask_i  ( in_mask    ),
+        .out_mask_i ( out_mask   ),
+        .data_o     ( out_data_m )
+      );
+    end else if (SBoxImpl == "canright_masked") begin : gen_sbox_canright_masked
+      aes_sbox_canright_masked aes_sbox (
+        .op_i,
+        .data_i     ( in_data_m  ),
+        .in_mask_i  ( in_mask    ),
+        .out_mask_i ( out_mask   ),
+        .data_o     ( out_data_m )
+      );
+    end
+    // Unmask output data
+    assign data_o = out_data_m ^ out_mask;
   end
 
 endmodule

--- a/hw/ip/aes/rtl/aes_sbox_canright.sv
+++ b/hw/ip/aes/rtl/aes_sbox_canright.sv
@@ -14,75 +14,11 @@ module aes_sbox_canright (
 );
 
   import aes_pkg::*;
+  import aes_sbox_canright_pkg::*;
 
-  ///////////////////////////
-  // Functions & Constants //
-  ///////////////////////////
-
-  // Multiplication in GF(2^2), using normal basis [Omega^2, Omega]
-  // (see Figure 14 in the technical report)
-  function automatic logic [1:0] aes_mul_gf2p2(logic [1:0] g, logic [1:0] d);
-    logic [1:0] f;
-    logic       a, b, c;
-    a    = g[1] & d[1];
-    b    = (^g) & (^d);
-    c    = g[0] & d[0];
-    f[1] = a ^ b;
-    f[0] = c ^ b;
-    return f;
-  endfunction
-
-  // Scale by Omega^2 = N in GF(2^2), using normal basis [Omega^2, Omega]
-  // (see Figure 16 in the technical report)
-  function automatic logic [1:0] aes_scale_omega2_gf2p2(logic [1:0] g);
-    logic [1:0] d;
-    d[1] = g[0];
-    d[0] = g[1] ^ g[0];
-    return d;
-  endfunction
-
-  // Scale by Omega = N^2 in GF(2^2), using normal basis [Omega^2, Omega]
-  // (see Figure 15 in the technical report)
-  function automatic logic [1:0] aes_scale_omega_gf2p2(logic [1:0] g);
-    logic [1:0] d;
-    d[1] = g[1] ^ g[0];
-    d[0] = g[1];
-    return d;
-  endfunction
-
-  // Square in GF(2^2), using normal basis [Omega^2, Omega]
-  // (see Figures 8 and 10 in the technical report)
-  function automatic logic [1:0] aes_square_gf2p2(logic [1:0] g);
-    logic [1:0] d;
-    d[1] = g[0];
-    d[0] = g[1];
-    return d;
-  endfunction
-
-  // Multiplication in GF(2^4), using normal basis [alpha^8, alpha^2]
-  // (see Figure 13 in the technical report)
-  function automatic logic [3:0] aes_mul_gf2p4(logic [3:0] gamma, logic [3:0] delta);
-    logic [3:0] theta;
-    logic [1:0] a, b, c;
-    a          = aes_mul_gf2p2(gamma[3:2], delta[3:2]);
-    b          = aes_mul_gf2p2(gamma[3:2] ^ gamma[1:0], delta[3:2] ^ delta[1:0]);
-    c          = aes_mul_gf2p2(gamma[1:0], delta[1:0]);
-    theta[3:2] = a ^ aes_scale_omega2_gf2p2(b);
-    theta[1:0] = c ^ aes_scale_omega2_gf2p2(b);
-    return theta;
-  endfunction
-
-  // Square and scale by nu in GF(2^4)/GF(2^2), using normal basis [alpha^8, alpha^2]
-  // (see Figure 19 as well as Appendix A of the technical report)
-  function automatic logic [3:0] aes_square_scale_gf2p4_gf2p2(logic [3:0] gamma);
-    logic [3:0] delta;
-    logic [1:0] a, b;
-    a          = gamma[3:2] ^ gamma[1:0];
-    b          = aes_square_gf2p2(gamma[1:0]);
-    delta[3:2] = aes_square_gf2p2(a);
-    delta[1:0] = aes_scale_omega_gf2p2(b);
-    return delta;
-  endfunction
+  ///////////////
+  // Functions //
+  ///////////////
 
   // Inverse in GF(2^4), using normal basis [alpha^8, alpha^2]
   // (see Figure 12 in the technical report)
@@ -112,18 +48,6 @@ module aes_sbox_canright (
     return delta;
   endfunction
 
-  // Basis conversion matrices to convert between polynomial basis A, normal basis X
-  // and basis S incorporating the bit matrix of the SBox. More specifically,
-  // multiplication by x2s performs the transformation from normal basis X into
-  // polynomial basis A, followed by the affine transformation (substep 2). Likewise,
-  // multiplication by s2x performs the inverse affine transformation followed by the
-  // transformation from polynomial basis A to normal basis X.
-  // (see Appendix A of the technical report)
-  const logic [7:0] a2x [8] = '{8'h98, 8'hf3, 8'hf2, 8'h48, 8'h09, 8'h81, 8'ha9, 8'hff};
-  const logic [7:0] x2a [8] = '{8'h64, 8'h78, 8'h6e, 8'h8c, 8'h68, 8'h29, 8'hde, 8'h60};
-  const logic [7:0] x2s [8] = '{8'h58, 8'h2d, 8'h9e, 8'h0b, 8'hdc, 8'h04, 8'h03, 8'h24};
-  const logic [7:0] s2x [8] = '{8'h8c, 8'h79, 8'h05, 8'heb, 8'h12, 8'h04, 8'h51, 8'h53};
-
   ///////////////////
   // Canright SBox //
   ///////////////////
@@ -131,14 +55,14 @@ module aes_sbox_canright (
   logic [7:0] data_basis_x, data_inverse;
 
   // Convert to normal basis X.
-  assign data_basis_x = (op_i == CIPH_FWD) ? aes_mvm(data_i, a2x) :
-                                             aes_mvm(data_i ^ 8'h63, s2x);
+  assign data_basis_x = (op_i == CIPH_FWD) ? aes_mvm(data_i, A2X) :
+                                             aes_mvm(data_i ^ 8'h63, S2X);
 
   // Do the inversion in normal basis X.
   assign data_inverse = aes_inverse_gf2p8(data_basis_x);
 
   // Convert to basis S or A.
-  assign data_o       = (op_i == CIPH_FWD) ? aes_mvm(data_inverse, x2s) ^ 8'h63 :
-                                             aes_mvm(data_inverse, x2a);
+  assign data_o       = (op_i == CIPH_FWD) ? aes_mvm(data_inverse, X2S) ^ 8'h63 :
+                                             aes_mvm(data_inverse, X2A);
 
 endmodule

--- a/hw/ip/aes/rtl/aes_sbox_canright_masked.sv
+++ b/hw/ip/aes/rtl/aes_sbox_canright_masked.sv
@@ -1,0 +1,180 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// AES Masked Canright SBox with Mask Re-Use
+//
+// For details, see the following paper:
+// Canright, "A very compact 'perfectly masked' S-box for AES (corrected)"
+// available at https://eprint.iacr.org/2009/011.pdf
+//
+// Note: This module implements the masked inversion algorithm with re-using masks.
+// For details, see Section 2.3 of the paper. Re-using masks may make the implementation more
+// vulnerable to higher-order differential side-channel analysis, but it remains secure against
+// first-order attacks. This implementation is commonly referred to as THE Canright Masked SBox.
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// IMPORTANT NOTE:                                                                               //
+//                            DO NOT USE THIS FOR SYNTHESIS BLINDLY!                             //
+//                                                                                               //
+// This is a high-level implementation targeting primarily RTL simulation. Synthesis tools might //
+// heavily optimize the design. The result is likely insecure. Use with care.                    //
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+module aes_sbox_canright_masked (
+  input  aes_pkg::ciph_op_e op_i,
+  input  logic [7:0]        data_i,     // masked, the actual input data is data_i ^ in_mask_i
+  input  logic [7:0]        in_mask_i,  // input mask, independent from actual input data
+  input  logic [7:0]        out_mask_i, // output mask, independent from input mask
+  output logic [7:0]        data_o      // masked, the actual output data is data_o ^ out_mask_i
+);
+
+  import aes_pkg::*;
+  import aes_sbox_canright_pkg::*;
+
+  ///////////////
+  // Functions //
+  ///////////////
+
+  // Masked inverse in GF(2^4), using normal basis [z^4, z]
+  // (see Formulas 6, 13, 14, 15, 21, 22, 23, 24 in the paper)
+  function automatic logic [3:0] aes_masked_inverse_gf2p4(logic [3:0] b,
+                                                          logic [3:0] q,
+                                                          logic [1:0] r,
+                                                          logic [3:0] m1);
+    logic [3:0] b_inv;
+    logic [1:0] b1, b0, q1, q0, c, c_inv, c2_inv, r_sq, m11, m10, b1_inv, b0_inv;
+    logic [1:0] mul_b0_q1, mul_b1_q0, mul_q0_q1;
+    b1  = b[3:2];
+    b0  = b[1:0];
+    q1  = q[3:2];
+    q0  = q[1:0];
+    m11 = m1[3:2];
+    m10 = m1[1:0];
+
+    // Get re-usable intermediate results.
+    mul_b0_q1 = aes_mul_gf2p2(b0, q1);
+    mul_b1_q0 = aes_mul_gf2p2(b1, q0);
+    mul_q0_q1 = aes_mul_gf2p2(q0, q1);
+
+    // Formula 13
+    // IMPORTANT: The following ops must be executed in order (left to right):
+    c = r ^ aes_scale_omega2_gf2p2(aes_square_gf2p2(b1 ^ b0))
+          ^ aes_scale_omega2_gf2p2(aes_square_gf2p2(q1 ^ q0))
+          ^ aes_mul_gf2p2(b1, b0)
+          ^ aes_mul_gf2p2(b1, q0) ^ mul_b0_q1 ^ mul_q0_q1;
+    //
+
+    // Formulas 14 and 15
+    c_inv = aes_square_gf2p2(c);
+    r_sq  = aes_square_gf2p2(r);
+
+    // Re-masking c_inv
+    // Formulas 21 and 23
+    // IMPORTANT: First combine the masks (ops in parens) then apply to c_inv:
+    c_inv  = c_inv ^ (q1 ^ r_sq);
+    c2_inv = c_inv ^ (q0 ^ q1);
+    //
+
+    // Formulas 22 and 24
+    // IMPORTANT: The following ops must be executed in order (left to right):
+    b1_inv = m11 ^ aes_mul_gf2p2(b0, c_inv)
+                 ^ mul_b0_q1 ^ aes_mul_gf2p2(q0, c_inv)  ^ mul_q0_q1;
+    b0_inv = m10 ^ aes_mul_gf2p2(b1, c2_inv)
+                 ^ mul_b1_q0 ^ aes_mul_gf2p2(q1, c2_inv) ^ mul_q0_q1;
+    //
+
+    // Note: b_inv is masked by m1, b was masked by q.
+    b_inv = {b1_inv, b0_inv};
+
+    return b_inv;
+  endfunction
+
+  // Masked inverse in GF(2^8), using normal basis [y^16, y]
+  // (see Formulas 3, 12, 25, 26 and 27 in the paper)
+  function automatic logic [7:0] aes_masked_inverse_gf2p8(logic [7:0] a,
+                                                          logic [7:0] m,
+                                                          logic [7:0] n);
+    logic [7:0] a_inv;
+    logic [3:0] a1, a0, m1, m0, b, b_inv, b2_inv, q, s1, s0, a1_inv, a0_inv;
+    logic [3:0] mul_a0_m1, mul_a1_m0, mul_m0_m1;
+    logic [1:0] r;
+    a1 = a[7:4];
+    a0 = a[3:0];
+    m1 = m[7:4];
+    m0 = m[3:0];
+
+    // Get re-usable intermediate results.
+    mul_a0_m1 = aes_mul_gf2p4(a0, m1);
+    mul_a1_m0 = aes_mul_gf2p4(a1, m0);
+    mul_m0_m1 = aes_mul_gf2p4(m0, m1);
+
+    // q must be independent of m.
+    q = n[7:4];
+
+    // Formula 12
+    // IMPORTANT: The following ops must be executed in order (left to right):
+    b = q ^ aes_square_scale_gf2p4_gf2p2(a1 ^ a0)
+          ^ aes_square_scale_gf2p4_gf2p2(m1 ^ m0)
+          ^ aes_mul_gf2p4(a1, a0)
+          ^ mul_a1_m0 ^ mul_a0_m1 ^ mul_m0_m1;
+    //
+
+    // r must be independent of q.
+    r = m1[3:2];
+
+    // b is masked by q, b_inv is masked by m1.
+    b_inv = aes_masked_inverse_gf2p4(b, q, r, m1);
+
+    // Formula 26
+    // IMPORTANT: First combine the masks (ops in parens) then apply to b_inv:
+    b2_inv = b_inv ^ (m1 ^ m0);
+    //
+
+    // s is the specified output mask n.
+    s1 = n[7:4];
+    s0 = n[3:0];
+
+    // Formulas 25 and 27
+    // IMPORTANT: The following ops must be executed in order (left to right):
+    a1_inv = s1 ^ aes_mul_gf2p4(a0, b_inv)
+                ^ mul_a0_m1 ^ aes_mul_gf2p4(m0, b_inv)  ^ mul_m0_m1;
+    a0_inv = s0 ^ aes_mul_gf2p4(a1, b2_inv)
+                ^ mul_a1_m0 ^ aes_mul_gf2p4(m1, b2_inv) ^ mul_m0_m1;
+    //
+
+    // Note: a_inv is now masked by s = n, a was masked by m.
+    a_inv = {a1_inv, a0_inv};
+
+    return a_inv;
+  endfunction
+
+  //////////////////////////
+  // Masked Canright SBox //
+  //////////////////////////
+
+  logic [7:0] data_basis_x, data_inverse;
+  logic [7:0] in_mask_basis_x;
+  logic [7:0] out_mask_basis_x;
+
+  // Convert data to normal basis X.
+  assign data_basis_x = (op_i == CIPH_FWD) ? aes_mvm(data_i, A2X) :
+                                             aes_mvm(data_i ^ 8'h63, S2X);
+
+  // Convert masks to normal basis X.
+  // The addition of constant 8'h63 following the affine transformation is skipped.
+  assign in_mask_basis_x  = (op_i == CIPH_FWD) ? aes_mvm(in_mask_i, A2X) :
+                                                 aes_mvm(in_mask_i, S2X);
+
+  // The output mask is converted in the opposite direction.
+  assign out_mask_basis_x = (op_i == CIPH_INV) ? aes_mvm(out_mask_i, A2X) :
+                                                 aes_mvm(out_mask_i, S2X);
+
+  // Do the inversion in normal basis X.
+  assign data_inverse = aes_masked_inverse_gf2p8(data_basis_x, in_mask_basis_x, out_mask_basis_x);
+
+  // Convert to basis S or A.
+  assign data_o = (op_i == CIPH_FWD) ? (aes_mvm(data_inverse, X2S) ^ 8'h63) :
+                                       (aes_mvm(data_inverse, X2A));
+
+endmodule

--- a/hw/ip/aes/rtl/aes_sbox_canright_masked_noreuse.sv
+++ b/hw/ip/aes/rtl/aes_sbox_canright_masked_noreuse.sv
@@ -1,0 +1,174 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// AES Masked Canright SBox without Mask Re-Use
+//
+// For details, see the following paper:
+// Canright, "A very compact 'perfectly masked' S-box for AES (corrected)"
+// available at https://eprint.iacr.org/2009/011.pdf
+//
+// Note: This module implements the original masked inversion algorithm without re-using masks.
+// For details, see Section 2.2 of the paper.
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// IMPORTANT NOTE:                                                                               //
+//                            DO NOT USE THIS FOR SYNTHESIS BLINDLY!                             //
+//                                                                                               //
+// This is a high-level implementation targeting primarily RTL simulation. Synthesis tools might //
+// heavily optimize the design. The result is likely insecure. Use with care.                    //
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+module aes_sbox_canright_masked_noreuse (
+  input  aes_pkg::ciph_op_e op_i,
+  input  logic [7:0]        data_i,     // masked, the actual input data is data_i ^ in_mask_i
+  input  logic [7:0]        in_mask_i,  // input mask, independent from actual input data
+  input  logic [7:0]        out_mask_i, // output mask, independent from input mask
+  output logic [7:0]        data_o      // masked, the actual output data is data_o ^ out_mask_i
+);
+
+  import aes_pkg::*;
+  import aes_sbox_canright_pkg::*;
+
+  ///////////////
+  // Functions //
+  ///////////////
+
+  // Masked inverse in GF(2^4), using normal basis [z^4, z]
+  // (see Formulas 6, 13, 14, 15, 16, 17 in the paper)
+  function automatic logic [3:0] aes_masked_inverse_gf2p4(logic [3:0] b,
+                                                          logic [3:0] q,
+                                                          logic [1:0] r,
+                                                          logic [3:0] t);
+    logic [3:0] b_inv;
+    logic [1:0] b1, b0, q1, q0, c, c_inv, r_sq, t1, t0, b1_inv, b0_inv;
+    b1 = b[3:2];
+    b0 = b[1:0];
+    q1 = q[3:2];
+    q0 = q[1:0];
+    t1 = t[3:2];
+    t0 = t[1:0];
+
+    // Formula 13
+    // IMPORTANT: The following ops must be executed in order (left to right):
+    c = r ^ aes_scale_omega2_gf2p2(aes_square_gf2p2(b1 ^ b0))
+          ^ aes_scale_omega2_gf2p2(aes_square_gf2p2(q1 ^ q0))
+          ^ aes_mul_gf2p2(b1, b0)
+          ^ aes_mul_gf2p2(b1, q0) ^ aes_mul_gf2p2(b0, q1) ^ aes_mul_gf2p2(q1, q0);
+    //
+
+    // Formulas 14 and 15
+    c_inv = aes_square_gf2p2(c);
+    r_sq  = aes_square_gf2p2(r);
+
+    // Formulas 16 and 17
+    // IMPORTANT: The following ops must be executed in order (left to right):
+    b1_inv = t1 ^ aes_mul_gf2p2(b0, c_inv)
+                ^ aes_mul_gf2p2(b0, r_sq) ^ aes_mul_gf2p2(q0, c_inv) ^ aes_mul_gf2p2(q0, r_sq);
+    b0_inv = t0 ^ aes_mul_gf2p2(b1, c_inv)
+                ^ aes_mul_gf2p2(b1, r_sq) ^ aes_mul_gf2p2(q1, c_inv) ^ aes_mul_gf2p2(q1, r_sq);
+    //
+
+    // Note: b_inv is masked by t, b was masked by q.
+    b_inv = {b1_inv, b0_inv};
+
+    return b_inv;
+  endfunction
+
+  // Masked inverse in GF(2^8), using normal basis [y^16, y]
+  // (see Formulas 3, 12, 18 and 19 in the paper)
+  function automatic logic [7:0] aes_masked_inverse_gf2p8(logic [7:0] a,
+                                                          logic [7:0] m,
+                                                          logic [7:0] n);
+    logic [7:0] a_inv;
+    logic [3:0] a1, a0, m1, m0, b, b_inv, q, s1, s0, t, a1_inv, a0_inv;
+    logic [1:0] r;
+    a1 = a[7:4];
+    a0 = a[3:0];
+    m1 = m[7:4];
+    m0 = m[3:0];
+
+    // q must be independent of m.
+    q = n[7:4];
+
+    // Formula 12
+    // IMPORTANT: The following ops must be executed in order (left to right):
+    b = q ^ aes_square_scale_gf2p4_gf2p2(a1 ^ a0)
+          ^ aes_square_scale_gf2p4_gf2p2(m1 ^ m0)
+          ^ aes_mul_gf2p4(a1, a0)
+          ^ aes_mul_gf2p4(a1, m0) ^ aes_mul_gf2p4(a0, m1) ^ aes_mul_gf2p4(m1, m0);
+    //
+
+    // r must be independent of q.
+    r = m1[3:2];
+
+    // Note that the paper states the following requirements on t:
+    // - t must be independent of r.
+    // - t1 must be independent of q0, t0 must be independent of q1.
+    // - t must be independent of m (for the final steps involving s)
+    // The paper suggests to use t = q. To select s = n for the output mask (s must be independent
+    // of t = q = n[7:4]), we would need t = m0 or similar (not r, m1[3:2] though), but this would
+    // break the random product distribution of aes_mul_gf2p4(m0, t), or aes_mul_gf2p4(m1, t) below
+    // (see Lemma 2 in the paper). For this reason, we select t = q here and apply a final mask
+    // switch from s = m to n after the inversion.
+    t = q;
+
+    // b is masked by q, b_inv is masked by t.
+    b_inv = aes_masked_inverse_gf2p4(b, q, r, t);
+
+    // Note that the paper states the following requirements on s:
+    // - s must be independent of t
+    // - s1 must be independent of m0, s0 must be independent of m1.
+    // The paper suggests to use s = m (the input mask). To still end up with the specified output
+    // mask n, we will apply a final mask switch after the inversion.
+    s1 = m1;
+    s0 = m0;
+
+    // Formulas 18 and 19
+    // IMPORTANT: The following ops must be executed in order (left to right):
+    a1_inv = s1 ^ aes_mul_gf2p4(a0, b_inv)
+                ^ aes_mul_gf2p4(a0, t) ^ aes_mul_gf2p4(m0, b_inv) ^ aes_mul_gf2p4(m0, t);
+    a0_inv = s0 ^ aes_mul_gf2p4(a1, b_inv)
+                ^ aes_mul_gf2p4(a1, t) ^ aes_mul_gf2p4(m1, b_inv) ^ aes_mul_gf2p4(m1, t);
+    //
+
+    // Note: a_inv is now masked by s = m, a was masked by m.
+    a_inv = {a1_inv, a0_inv};
+
+    // To have a_inv masked by n (the specified output mask), we perform a final mask switch.
+    // IMPORTANT: The following ops must be executed in order (left to right):
+    a_inv = a_inv ^ n ^ m;
+    //
+
+    return a_inv;
+  endfunction
+
+  //////////////////////////
+  // Masked Canright SBox //
+  //////////////////////////
+
+  logic [7:0] data_basis_x, data_inverse;
+  logic [7:0] in_mask_basis_x;
+  logic [7:0] out_mask_basis_x;
+
+  // Convert data to normal basis X.
+  assign data_basis_x = (op_i == CIPH_FWD) ? aes_mvm(data_i, A2X) :
+                                             aes_mvm(data_i ^ 8'h63, S2X);
+
+  // Convert masks to normal basis X.
+  // The addition of constant 8'h63 following the affine transformation is skipped.
+  assign in_mask_basis_x  = (op_i == CIPH_FWD) ? aes_mvm(in_mask_i, A2X) :
+                                                 aes_mvm(in_mask_i, S2X);
+
+  // The output mask is converted in the opposite direction.
+  assign out_mask_basis_x = (op_i == CIPH_INV) ? aes_mvm(out_mask_i, A2X) :
+                                                 aes_mvm(out_mask_i, S2X);
+
+  // Do the inversion in normal basis X.
+  assign data_inverse = aes_masked_inverse_gf2p8(data_basis_x, in_mask_basis_x, out_mask_basis_x);
+
+  // Convert to basis S or A.
+  assign data_o = (op_i == CIPH_FWD) ? (aes_mvm(data_inverse, X2S) ^ 8'h63) :
+                                       (aes_mvm(data_inverse, X2A));
+
+endmodule

--- a/hw/ip/aes/rtl/aes_sbox_canright_pkg.sv
+++ b/hw/ip/aes/rtl/aes_sbox_canright_pkg.sv
@@ -1,0 +1,92 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// AES Canright SBox package
+//
+// For details, see the following documents:
+// - Canright, "A very compact Rijndael S-box", technical report
+//   available at https://hdl.handle.net/10945/25608
+// - Canright, "A very compact 'perfectly masked' S-box for AES (corrected)", paper
+//   available at https://eprint.iacr.org/2009/011.pdf
+
+package aes_sbox_canright_pkg;
+
+  // Multiplication in GF(2^2), using normal basis [Omega^2, Omega]
+  // (see Figure 14 in the technical report)
+  function automatic logic [1:0] aes_mul_gf2p2(logic [1:0] g, logic [1:0] d);
+    logic [1:0] f;
+    logic       a, b, c;
+    a    = g[1] & d[1];
+    b    = (^g) & (^d);
+    c    = g[0] & d[0];
+    f[1] = a ^ b;
+    f[0] = c ^ b;
+    return f;
+  endfunction
+
+  // Scale by Omega^2 = N in GF(2^2), using normal basis [Omega^2, Omega]
+  // (see Figure 16 in the technical report)
+  function automatic logic [1:0] aes_scale_omega2_gf2p2(logic [1:0] g);
+    logic [1:0] d;
+    d[1] = g[0];
+    d[0] = g[1] ^ g[0];
+    return d;
+  endfunction
+
+  // Scale by Omega = N^2 in GF(2^2), using normal basis [Omega^2, Omega]
+  // (see Figure 15 in the technical report)
+  function automatic logic [1:0] aes_scale_omega_gf2p2(logic [1:0] g);
+    logic [1:0] d;
+    d[1] = g[1] ^ g[0];
+    d[0] = g[1];
+    return d;
+  endfunction
+
+  // Square in GF(2^2), using normal basis [Omega^2, Omega]
+  // (see Figures 8 and 10 in the technical report)
+  function automatic logic [1:0] aes_square_gf2p2(logic [1:0] g);
+    logic [1:0] d;
+    d[1] = g[0];
+    d[0] = g[1];
+    return d;
+  endfunction
+
+  // Multiplication in GF(2^4), using normal basis [alpha^8, alpha^2]
+  // (see Figure 13 in the technical report)
+  function automatic logic [3:0] aes_mul_gf2p4(logic [3:0] gamma, logic [3:0] delta);
+    logic [3:0] theta;
+    logic [1:0] a, b, c;
+    a          = aes_mul_gf2p2(gamma[3:2], delta[3:2]);
+    b          = aes_mul_gf2p2(gamma[3:2] ^ gamma[1:0], delta[3:2] ^ delta[1:0]);
+    c          = aes_mul_gf2p2(gamma[1:0], delta[1:0]);
+    theta[3:2] = a ^ aes_scale_omega2_gf2p2(b);
+    theta[1:0] = c ^ aes_scale_omega2_gf2p2(b);
+    return theta;
+  endfunction
+
+  // Square and scale by nu in GF(2^4)/GF(2^2), using normal basis [alpha^8, alpha^2]
+  // (see Figure 19 as well as Appendix A of the technical report)
+  function automatic logic [3:0] aes_square_scale_gf2p4_gf2p2(logic [3:0] gamma);
+    logic [3:0] delta;
+    logic [1:0] a, b;
+    a          = gamma[3:2] ^ gamma[1:0];
+    b          = aes_square_gf2p2(gamma[1:0]);
+    delta[3:2] = aes_square_gf2p2(a);
+    delta[1:0] = aes_scale_omega_gf2p2(b);
+    return delta;
+  endfunction
+
+  // Basis conversion matrices to convert between polynomial basis A, normal basis X
+  // and basis S incorporating the bit matrix of the SBox. More specifically,
+  // multiplication by X2X performs the transformation from normal basis X into
+  // polynomial basis A, followed by the affine transformation (substep 2). Likewise,
+  // multiplication by S2X performs the inverse affine transformation followed by the
+  // transformation from polynomial basis A to normal basis X.
+  // (see Appendix A of the technical report)
+  parameter logic [7:0] A2X [8] = '{8'h98, 8'hf3, 8'hf2, 8'h48, 8'h09, 8'h81, 8'ha9, 8'hff};
+  parameter logic [7:0] X2A [8] = '{8'h64, 8'h78, 8'h6e, 8'h8c, 8'h68, 8'h29, 8'hde, 8'h60};
+  parameter logic [7:0] X2S [8] = '{8'h58, 8'h2d, 8'h9e, 8'h0b, 8'hdc, 8'h04, 8'h03, 8'h24};
+  parameter logic [7:0] S2X [8] = '{8'h8c, 8'h79, 8'h05, 8'heb, 8'h12, 8'h04, 8'h51, 8'h53};
+
+endpackage


### PR DESCRIPTION
This PR adds two versions of the masked Canright S-Box:
- A version without mask re-use.
- A version with mask re-use, i.e., THE masked Canright S-Box. This version is smaller but might be more vulnerable to higher-order differential side-channel analysis.

Unlike the [freely available reference implementation by Canright](https://faculty.nps.edu/drcanrig/pub/sboxmaskcorr.txt) these implementations here does not contain optimizations for a certain gate type/library. They are generic, higher-level, behavioural SystemVerilog implementations.

Just like for the original implementation, tools have to be carefully instructed to properly optimize the circuit and apply the masking operations in the correct order during synthesis. This is highlighted in both implementations.

Both implementations have been verified against the original implementation with random masks. This PR also adds the implementations to the scratch Verilator testbench. ~They are excluded from LEC as the mask inputs prevent a comparison against unmasked S-Boxes.~

The masked S-Boxes can be instantiated in the AES module but constant masks are currently used. This is of course not secure and will be reworked in future PRs. 