### PR TITLE
[dvsim] small fix on css style

### DIFF
--- a/util/dvsim/style.css
+++ b/util/dvsim/style.css
@@ -25,9 +25,6 @@
 .results pre {
    overflow-x: auto;
    white-space: pre-wrap;
-   white-space: -moz-pre-wrap;
-   white-space: -pre-wrap;
-   white-space: -o-pre-wrap;
 }
 
 .results h1, .results h2, .results h3 {

--- a/util/dvsim/utils.py
+++ b/util/dvsim/utils.py
@@ -204,12 +204,9 @@ def md_results_to_html(title, css_file, md_text):
     html_text += "</html>\n"
     html_text = htmc_color_pc_cells(html_text)
     # this function converts css style to inline html style
-    # set cssutils logging to critical because `style.css` is incompatible
-    # with css level 2.1 checking. But these ERRORs do not affect the inline
-    # style coversion. TODO: fix the errors from cssutils
     html_text = transform(html_text,
                           external_styles=css_file,
-                          cssutils_logging_level=log.CRITICAL)
+                          cssutils_logging_level=log.ERROR)
     return html_text
 
 


### PR DESCRIPTION
Previous style does not wrap text around

premailer picked up a wrong white-space style for chrome browser, it picked one (`-o-pre-wrap`) that could not be used.

Current version:
![image](https://user-images.githubusercontent.com/11466553/80826546-49a39000-8b97-11ea-8d05-19da2bff7f86.png)

Fixed version:
![image](https://user-images.githubusercontent.com/11466553/80826729-92f3df80-8b97-11ea-8c69-50bdf0b30d67.png)

Signed-off-by: Cindy Chen <chencindy@google.com>