### PR TITLE
[dv/alert_handler] fully support esc int fail

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent.core
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent.core
@@ -12,6 +12,7 @@ filesets:
       - lowrisc:dv:dv_lib
     files:
       - alert_esc_if.sv
+      - alert_esc_probe_if.sv
       - alert_esc_agent_pkg.sv
       - alert_esc_agent_cfg.sv: {is_include_file: true}
       - alert_esc_agent.sv: {is_include_file: true}

--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent.sv
@@ -51,6 +51,14 @@ class alert_esc_agent extends dv_base_agent#(
     if (!uvm_config_db#(virtual alert_esc_if)::get(this, "", "vif", cfg.vif)) begin
       `uvm_fatal(`gfn, "failed to get alert_esc_if handle from uvm_config_db")
     end
+    // get esc_en signal for esc_monitor
+    if (cfg.is_active && !cfg.is_alert) begin
+      if (!uvm_config_db#(virtual alert_esc_probe_if)::get(this, "", "probe_vif", cfg.probe_vif))
+          begin
+        `uvm_fatal(`gfn, "failed to get probe_vif handle from uvm_config_db")
+      end
+    end
+
   endfunction
 
 endclass : alert_esc_agent

--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent_cfg.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent_cfg.sv
@@ -8,7 +8,7 @@
 // ---------------------------------------------
 class alert_esc_agent_cfg extends dv_base_agent_cfg;
   virtual alert_esc_if vif;
-
+  virtual alert_esc_probe_if probe_vif;
   bit is_alert = 1;
 
   // sender mode

--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent_pkg.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent_pkg.sv
@@ -32,7 +32,9 @@ package alert_esc_agent_pkg;
     EscRespReceived,
     EscComplete,
     EscRespComplete,
-    EscIntFail
+    EscIntFail,
+    EscRespHi,
+    EscRespLo
   } esc_handshake_e;
 
   typedef enum bit [1:0] {
@@ -41,12 +43,6 @@ package alert_esc_agent_pkg;
     HasAlertAfterIntFailOnly   = 'b10,
     HasAlertBeforeAfterIntFail = 'b11
   } alert_sig_int_err_e;
-
-  typedef enum {
-    NoResponse,
-    RandResponse,
-    SigPNIntErr
-  } resp_sig_int_err_e;
 
   // macro includes
   `include "uvm_macros.svh"

--- a/hw/dv/sv/alert_esc_agent/alert_esc_if.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_if.sv
@@ -147,6 +147,16 @@ interface alert_esc_if(input clk, input rst_n);
     receiver_cb.esc_rx.resp_n <= 1'b1;
   endtask
 
+  task automatic set_resp_both_high();
+    receiver_cb.esc_rx.resp_p <= 1'b1;
+    receiver_cb.esc_rx.resp_n <= 1'b1;
+  endtask
+
+  task automatic set_resp_both_low();
+    receiver_cb.esc_rx.resp_p <= 1'b0;
+    receiver_cb.esc_rx.resp_n <= 1'b0;
+  endtask
+
   function automatic bit get_esc();
     return monitor_cb.esc_tx.esc_p && !monitor_cb.esc_tx.esc_n;
   endfunction

--- a/hw/dv/sv/alert_esc_agent/alert_esc_probe_if.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_probe_if.sv
@@ -1,0 +1,24 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// this is a probing interface for signal "esc_en_i":
+// "esc_en_i" is one of the input signal for "prim_esc_sender"
+// "esc_en_i" needs to be probed because: in esc_sig_integrity_fail cases, "esc_en_i" gated if next
+// state the expected resp_p should be high or not. However, from the esc_receiver interface, we
+// can only see "esc_p/n", which follows "esc_en_i" with one clock cycle delay.
+// Thus we need to probe this signal to accurately predict the signal integrity fail count.
+interface alert_esc_probe_if(input clk, input rst_n);
+
+  wire esc_en;
+
+  clocking monitor_cb @(posedge clk);
+    input rst_n;
+    input esc_en;
+  endclocking
+
+  function automatic logic get_esc_en();
+    return monitor_cb.esc_en;
+  endfunction
+
+endinterface

--- a/hw/dv/sv/alert_esc_agent/alert_esc_seq_item.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_seq_item.sv
@@ -17,7 +17,6 @@ class alert_esc_seq_item extends uvm_sequence_item;
   rand bit int_err;
   rand bit timeout;
   rand alert_sig_int_err_e alert_int_err_type;
-  rand resp_sig_int_err_e  resp_int_err_type;
 
   // for monitor only
   rand alert_esc_trans_type_e alert_esc_type;
@@ -50,7 +49,6 @@ class alert_esc_seq_item extends uvm_sequence_item;
   // TODO: temp constraint, will support soon
   constraint sig_int_err_c {
     alert_int_err_type == NoAlertBeforeAfterIntFail;
-    resp_int_err_type == RandResponse;
   }
 
   `uvm_object_utils_begin(alert_esc_seq_item)
@@ -68,7 +66,6 @@ class alert_esc_seq_item extends uvm_sequence_item;
     `uvm_field_int (int_err_cyc,       UVM_DEFAULT)
     `uvm_field_int (sig_cycle_cnt,     UVM_DEFAULT)
     `uvm_field_enum(alert_sig_int_err_e,    alert_int_err_type,  UVM_DEFAULT)
-    `uvm_field_enum(resp_sig_int_err_e,     resp_int_err_type,   UVM_DEFAULT)
     `uvm_field_enum(alert_esc_trans_type_e, alert_esc_type,      UVM_DEFAULT)
     `uvm_field_enum(alert_handshake_e,      alert_handshake_sta, UVM_DEFAULT)
     `uvm_field_enum(esc_handshake_e,        esc_handshake_sta,   UVM_DEFAULT)

--- a/hw/dv/sv/alert_esc_agent/esc_receiver_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/esc_receiver_driver.sv
@@ -55,18 +55,15 @@ class esc_receiver_driver extends alert_esc_base_driver;
               $sformatf("starting to send receiver item, esc_rsp=%0b int_fail=%0b",
               req.r_esc_rsp, req.int_err), UVM_HIGH)
 
-          // toggle resp signals only when esc signals are not set
-          if (req.int_err && req.resp_int_err_type == RandResponse) begin
-            cfg.vif.wait_esc_complete();
+          if (req.int_err) begin
+            repeat ($urandom_range(10, 1000)) @(cfg.vif.receiver_cb);
             repeat (req.int_err_cyc) begin
-              if (cfg.vif.get_esc() === 1'b0) begin
-                randcase
-                  1: cfg.vif.set_resp();
-                  1: cfg.vif.reset_resp();
-                endcase
-              end else begin
-                break;
-              end
+              randcase
+                1: cfg.vif.set_resp();
+                1: cfg.vif.reset_resp();
+                1: cfg.vif.set_resp_both_high();
+                1: cfg.vif.set_resp_both_low();
+              endcase
               @(cfg.vif.receiver_cb);
             end
             if (cfg.vif.get_esc() === 1'b0) cfg.vif.reset_resp();

--- a/hw/ip/alert_handler/dv/env/alert_handler_env.sv
+++ b/hw/ip/alert_handler/dv/env/alert_handler_env.sv
@@ -36,9 +36,6 @@ class alert_handler_env extends cip_base_env #(
           $sformatf("esc_device_agent[%0d]", i), "cfg", cfg.esc_device_cfg[i]);
     end
     // get vifs
-    if (!uvm_config_db#(esc_en_vif)::get(this, "", "esc_en_vif", cfg.esc_en_vif)) begin
-      `uvm_fatal(get_full_name(), "failed to get esc_en_vif from uvm_config_db")
-    end
     if (!uvm_config_db#(entropy_vif)::get(this, "", "entropy_vif", cfg.entropy_vif)) begin
       `uvm_fatal(get_full_name(), "failed to get entropy_vif from uvm_config_db")
     end

--- a/hw/ip/alert_handler/dv/env/alert_handler_env_pkg.sv
+++ b/hw/ip/alert_handler/dv/env/alert_handler_env_pkg.sv
@@ -27,7 +27,9 @@ package alert_handler_env_pkg;
   parameter uint NUM_ALERT_HANDLER_CLASS_MSB = $clog2(NUM_ALERT_HANDLER_CLASSES) - 1;
   parameter uint MIN_CYCLE_PER_PHASE         = 2;
   parameter uint NUM_LOCAL_ALERT             = 4;
-
+  // ignore esc signal cycle count after ping occurs - as ping response might ended up adding one
+  // extra cycle to the calculated cnt, or even combine two signals into one.
+  parameter uint IGNORE_CNT_CHECK_NS         = 100_000_000;
   // types
   typedef enum {
     EscPhase0,

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_entropy_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_entropy_vseq.sv
@@ -23,9 +23,13 @@ class alert_handler_entropy_vseq extends alert_handler_sanity_vseq;
     alert_en dist {'b1111 := 9, [0:'b1110] := 1};
   }
 
+  // temp constraint, should take off when support ping_int_err
+  constraint sig_int_c {
+    esc_int_err == 0;
+  }
+
   function void pre_randomize();
     this.enable_classa_only_c.constraint_mode(0);
-    this.sig_int_c.constraint_mode(0);
     // set verbosity high to avoid printing out too much information
     verbosity = UVM_HIGH;
   endfunction

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_sanity_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_sanity_vseq.sv
@@ -56,8 +56,10 @@ class alert_handler_sanity_vseq extends alert_handler_base_vseq;
   }
 
   task body();
-    run_esc_rsp_seq_nonblocking();
+    `DV_CHECK_RANDOMIZE_FATAL(this)
+    run_esc_rsp_seq_nonblocking(esc_int_err);
     run_alert_ping_rsp_seq_nonblocking();
+    if (verbosity != UVM_LOW) `uvm_info(`gfn, $sformatf("num_trans=%0d", num_trans), UVM_LOW)
     for (int i = 1; i <= num_trans; i++) begin
       `DV_CHECK_RANDOMIZE_FATAL(this)
 
@@ -80,7 +82,6 @@ class alert_handler_sanity_vseq extends alert_handler_base_vseq;
       if (do_esc_intr_timeout) wr_intr_timeout_cycle(intr_timeout_cyc);
       wr_class_accum_threshold(accum_thresh);
 
-      if (esc_int_err) drive_esc_resp(esc_int_err);
       // drive alert
       drive_alert(alert_trigger, alert_int_err);
 
@@ -95,7 +96,7 @@ class alert_handler_sanity_vseq extends alert_handler_base_vseq;
       end
 
       // read and check interrupt
-      clear_all_interrupts();
+      check_alert_interrupts();
 
       wait_alert_handshake_done();
       fork

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_sig_int_fail_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_sig_int_fail_vseq.sv
@@ -2,21 +2,26 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// this sequence enable signal intergrity fail. TODO: current escalation int fail
+// this sequence enable signal intergrity fail.
 
 class alert_handler_sig_int_fail_vseq extends alert_handler_sanity_vseq;
   `uvm_object_utils(alert_handler_sig_int_fail_vseq)
 
   `uvm_object_new
 
-  constraint sig_int_c {
-    alert_int_err == '1;
-    esc_int_err == '1;
-  }
-
   function void pre_randomize();
     this.enable_one_alert_c.constraint_mode(0);
     this.enable_classa_only_c.constraint_mode(0);
+    this.sig_int_c.constraint_mode(0);
   endfunction
 
+  virtual task alert_handler_init(bit [NUM_ALERT_HANDLER_CLASSES-1:0] intr_en = '1,
+                                  bit [alert_pkg::NAlerts-1:0]        alert_en = '1,
+                                  bit [TL_DW-1:0]                     alert_class = 'h0,
+                                  bit [NUM_LOCAL_ALERT-1:0]           loc_alert_en = '1,
+                                  bit [TL_DW-1:0]                     loc_alert_class = 'h0);
+    super.alert_handler_init(intr_en, alert_en, alert_class, loc_alert_en, loc_alert_class);
+   // lock regen to avoid changing real config settings during escalation
+    csr_wr(.csr(ral.regen), .value(1));
+  endtask
 endclass : alert_handler_sig_int_fail_vseq

--- a/hw/ip/alert_handler/dv/tb/tb.sv
+++ b/hw/ip/alert_handler/dv/tb/tb.sv
@@ -21,10 +21,12 @@ module tb;
   // interfaces
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
   pins_if #(NUM_MAX_INTERRUPTS) intr_if(interrupts);
-  pins_if #(NUM_MAX_ESC_SEV) esc_en_if(esc_en);
   pins_if #(1) entropy_if(entropy);
   pins_if #(1) devmode_if();
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
+  alert_esc_if esc_device_if[alert_pkg::N_ESC_SEV](.clk(clk), .rst_n(rst_n));
+  alert_esc_if alert_host_if[alert_pkg::NAlerts](.clk(clk), .rst_n(rst_n));
+  alert_esc_probe_if probe_if[alert_pkg::N_ESC_SEV](.clk(clk), .rst_n(rst_n));
 
   // dut signals
   prim_alert_pkg::alert_rx_t [alert_pkg::NAlerts-1:0] alert_rx;
@@ -33,7 +35,6 @@ module tb;
   prim_esc_pkg::esc_rx_t [alert_pkg::N_ESC_SEV-1:0] esc_rx;
   prim_esc_pkg::esc_tx_t [alert_pkg::N_ESC_SEV-1:0] esc_tx;
 
-  alert_esc_if alert_host_if[alert_pkg::NAlerts](.clk(clk), .rst_n(rst_n));
   for (genvar k = 0; k < alert_pkg::NAlerts; k++) begin : gen_alert_if
     assign alert_tx[k].alert_p = alert_host_if[k].alert_tx.alert_p;
     assign alert_tx[k].alert_n = alert_host_if[k].alert_tx.alert_n;
@@ -47,15 +48,18 @@ module tb;
     end
   end
 
-  alert_esc_if esc_device_if[alert_pkg::N_ESC_SEV](.clk(clk), .rst_n(rst_n));
   for (genvar k = 0; k < alert_pkg::N_ESC_SEV; k++) begin : gen_esc_if
     assign esc_rx[k].resp_p = esc_device_if[k].esc_rx.resp_p;
     assign esc_rx[k].resp_n = esc_device_if[k].esc_rx.resp_n;
     assign esc_device_if[k].esc_tx.esc_p = esc_tx[k].esc_p;
     assign esc_device_if[k].esc_tx.esc_n = esc_tx[k].esc_n;
+    // TODO: add assertions to check the probed signal
+    assign probe_if[k].esc_en = alert_handler.esc_sig_en[k];
     initial begin
       uvm_config_db#(virtual alert_esc_if)::set(null, $sformatf("*.env.esc_device_agent[%0d]", k),
                                                 "vif", esc_device_if[k]);
+      uvm_config_db#(virtual alert_esc_probe_if)::set(null, $sformatf("*.env.esc_device_agent[%0d]", k),
+                                                "probe_vif", probe_if[k]);
     end
   end
   // main dut
@@ -81,7 +85,6 @@ module tb;
     clk_rst_if.set_active();
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
-    uvm_config_db#(esc_en_vif)::set(null, "*.env", "esc_en_vif", esc_en_if);
     uvm_config_db#(entropy_vif)::set(null, "*.env", "entropy_vif", entropy_if);
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);


### PR DESCRIPTION
Add three conditions of signal int fail:
1. Unexpected resp without esc_p/n
2. esc_p/n not in the correct order
3. esc_p/n are not differential pair

Signed-off-by: Cindy Chen <chencindy@google.com>