### PR TITLE
[util] Update Tool Dockerfile Package Dependencies

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,6 +6,7 @@ variables:
   VERILATOR_PATH: /opt/buildcache/verilator/$(VERILATOR_VERSION)
   TOOLCHAIN_PATH: /opt/buildcache/riscv
   # Release tag from https://github.com/lowRISC/lowrisc-toolchains/releases
+  # if you update this, update the definition in util/container/Dockerfile
   TOOLCHAIN_VERSION: 20191010-1
   # This controls where builds happen, and gets picked up by build_consts.sh.
   BUILD_ROOT: $(Build.ArtifactStagingDirectory)

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -9,7 +9,7 @@
 ARG VERILATOR_VERSION=4.028
 
 # The RISCV toolchain version should match the release tag used in GitHub.
-ARG RISCV_TOOLCHAIN_TAR_VERSION=20190807-1
+ARG RISCV_TOOLCHAIN_TAR_VERSION=20191010-1
 
 # Build OpenOCD
 # OpenOCD is a tool to connect with the target chip over JTAG and similar
@@ -61,36 +61,21 @@ WORKDIR /tools
 COPY --from=openocd /tools/openocd openocd
 COPY --from=verilator /tools/verilator/${VERILATOR_VERSION} verilator/${VERILATOR_VERSION}
 
-# Required packages
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    curl \
-    clang-format-3.8 \
-    git \
-    gnupg2 \
-    libc6-i386 \
-    libelf-dev \
-    libftdi-dev \
-    libftdi1-dev \
-    libftdi1 \
-    libssl-dev \
-    libtool \
-    libusb-1.0-0-dev \
-    libxml2-dev \
-    minicom \
-    ninja-build \
-    pkgconf \
-    screen \
-    srecord \
-    zlib1g-dev
-
-# Install Python 3 and support libraries. Cleanup install in place to reduce
-# binary size.
-RUN apt-get install -y \
-    python3 \
-    python3-pip \
-    python3-setuptools && \
-    apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
+# Install (and cleanup) required packages (from apt-requirements.txt)
+# The list of extra packages is leftover from before this Dockerfile used
+# apt-requirements.txt
+COPY apt-requirements.txt /tmp/apt-requirements.txt
+RUN apt-get update && \
+    sed 's/#.*//' /tmp/apt-requirements.txt \
+        | xargs apt-get install -y && \
+    apt-get install -y \
+        gnupg2 \
+        libc6-i386 \
+        libtool \
+        minicom \
+        screen && \
+    apt-get clean ; \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
 
 # Copy repository into tmp directory to execute additional install steps.
 COPY python-requirements.txt /tmp/python-requirements.txt

--- a/util/container/README.md
+++ b/util/container/README.md
@@ -35,7 +35,7 @@ $ docker run -it -v ${REPO_TOP}:/repo -w /repo opentitan --user $(id -u):$(id -g
 There is an experimental version of the container available. To download, run:
 
 ```shell
-$ time docker pull gcr.io/opentitan/hw_dev
+$ docker pull gcr.io/opentitan/hw_dev
 ```
 
 Use `gcr.io/opentitan/hw_dev` as the container name in any Docker commands.


### PR DESCRIPTION
Commit #2082 showed that the Hardware Tool Dockerfile was out of date
against the general project apt dependencies (which are now specified in
a text file).

This commit updates the Dockerfile to use the official version of the
project dependencies. It also updates the toolchain version to match CI.
The aim here is that all the tools in this Docker image match CI, so
that it is easier to get started with the project.

I have left any package names that were not in apt-requirements.txt as
I'm not sure what these may or may not affect.