### PR TITLE
[clkmgr] Fix core name

### DIFF
--- a/hw/ip/clkmgr/clkmgr_pkg.core
+++ b/hw/ip/clkmgr/clkmgr_pkg.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: "lowrisc:ip:rstmgr_pkg:0.1"
+name: "lowrisc:ip:clkmgr_pkg:0.1"
 description: "Clock Manager Package"
 
 filesets:


### PR DESCRIPTION
The clkmgr_pkg core file could overwrite the rstmgr_pkg core file
depending on how fusesoc happens to pick up files, leading to a broken
build.