### PR TITLE
[doc] Remove doc build instructions from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,26 +23,7 @@ across partners participating in the OpenTitan project.
 ## Documentation
 
 The project contains comprehensive documentation of all IPs and tools. You can
-either access it [online](https://docs.opentitan.org/) or build it
-locally by following the steps below.
-
-1. Ensure that you have the required Python modules installed (to be executed
-in the repository root):
-
-```command
-$ sudo apt install curl python3 python3-pip
-$ pip3 install --user -r python-requirements.txt
-```
-
-2. Execute the build script:
-
-```command
-$ ./util/build_docs.py --preview
-```
-
-This compiles the documentation into `./build/docs` and starts a local
-server, which allows you to access the documentation at
-[http://127.0.0.1:1313](http://127.0.0.1:1313).
+access it [online at docs.opentitan.org](https://docs.opentitan.org/).
 
 ## How to contribute
 
@@ -52,5 +33,4 @@ contribute code to this repository.
 ## Licensing
 
 Unless otherwise noted, everything in this repository is covered by the Apache
-License, Version 2.0 (see
-[LICENSE](./LICENSE) for full text).
+License, Version 2.0 (see [LICENSE](./LICENSE) for full text).


### PR DESCRIPTION
These instructions feel a bit out of place in the README, which is the
first impression users get from the OpenTitan project if they go to
GitHub. The online documentation at docs.opentitan.org is up to date
with the master branch; self-building documentation is only necessary to
actually test documentation changes, which is rather rare.