### PR TITLE
[dvsim] Specify encoding of opened files as UTF-8

### DIFF
--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -174,13 +174,13 @@ class Deploy():
                 self.odir_limiter(odir=self.odir)
             os.system("mkdir -p " + self.odir)
             # Dump all env variables for ease of debug.
-            with open(self.odir + "/env_vars", "w") as f:
+            with open(self.odir + "/env_vars", "w", encoding="UTF-8") as f:
                 for var in sorted(self.exports.keys()):
                     f.write("{}={}\n".format(var, self.exports[var]))
                 f.close()
             os.system("ln -s " + self.odir + " " + self.sim_cfg.links['D'] +
                       '/' + self.odir_ln)
-            f = open(self.log, "w")
+            f = open(self.log, "w", encoding="UTF-8")
             self.process = subprocess.Popen(args,
                                             bufsize=4096,
                                             universal_newlines=True,


### PR DESCRIPTION
In private CI we get the following error:

```
Traceback (most recent call last):
  File "util/dvsim/dvsim.py", line 539, in <module>
    main()
  File "util/dvsim/dvsim.py", line 520, in main
    cfg.deploy_objects()
  File "/azp/agent/_work/1/s/util/dvsim/SimCfg.py", line 412, in deploy_objects
    super().deploy_objects()
  File "/azp/agent/_work/1/s/util/dvsim/FlowCfg.py", line 442, in deploy_objects
    Deploy.deploy(self.deploy)
  File "/azp/agent/_work/1/s/util/dvsim/Deploy.py", line 506, in deploy
    dispatch_items(queued_items[0:num_slots])
  File "/azp/agent/_work/1/s/util/dvsim/Deploy.py", line 399, in dispatch_items
    item.dispatch_cmd()
  File "/azp/agent/_work/1/s/util/dvsim/Deploy.py", line 582, in dispatch_cmd
    super().dispatch_cmd()
  File "/azp/agent/_work/1/s/util/dvsim/Deploy.py", line 179, in dispatch_cmd
    f.write("{}={}\n".format(var, self.exports[var]))
UnicodeEncodeError: 'ascii' codec can't encode characters in position 2194-2195: ordinal not in range(128)
```

It looks like some environment variable is having a non-ASCII character
in it. That's actually not forbidden, so let's be explicit about the
encoding when opening files, a best practice we follow in other scripts
equally.