### PR TITLE
[dv] Use phase_ready_to_end to handle end of test

### DIFF
--- a/hw/dv/sv/dv_lib/dv_base_agent_cfg.sv
+++ b/hw/dv/sv/dv_lib/dv_base_agent_cfg.sv
@@ -9,6 +9,9 @@ class dv_base_agent_cfg extends uvm_object;
   bit         en_cov    = 1'b1;   // enable coverage
   if_mode_e   if_mode;            // interface mode - Host or Device
 
+  // use for phase_ready_to_end to add additional delay after ok_to_end is set
+  int ok_to_end_delay_ns = 1000;
+
   `uvm_object_utils_begin(dv_base_agent_cfg)
     `uvm_field_int (is_active,          UVM_DEFAULT)
     `uvm_field_int (en_cov,             UVM_DEFAULT)

--- a/hw/dv/sv/dv_lib/dv_base_monitor.sv
+++ b/hw/dv/sv/dv_lib/dv_base_monitor.sv
@@ -10,6 +10,13 @@ class dv_base_monitor #(type ITEM_T = uvm_sequence_item,
   CFG_T cfg;
   COV_T cov;
 
+  // extended monitor needs to drive ok_to_end = 0 when bus is busy, set to 1 when it's not busy
+  protected bit ok_to_end = 1;
+
+  // make sure at least we add ok_to_end_delay_ns once and invoke monitor_ready_to_end once
+  // after enter phase_ready_to_end
+  protected bit watchdog_done;
+
   // Analysis port for the collected transfer.
   uvm_analysis_port #(ITEM_T) analysis_port;
 
@@ -31,5 +38,64 @@ class dv_base_monitor #(type ITEM_T = uvm_sequence_item,
     `uvm_fatal(`gfn, "this method is not supposed to be called directly!")
   endtask
 
+  virtual function void phase_ready_to_end(uvm_phase phase);
+    if (phase.is(uvm_run_phase::get())) begin
+      if (watchdog_done) fork
+          monitor_ready_to_end();
+      join_none
+      if (!ok_to_end || !watchdog_done) begin
+        phase.raise_objection(this, $sformatf("%s objection raised", `gfn));
+        `uvm_info(`gfn, $sformatf("Raised objection, because ok_to_end: %0b, watchdog_done: %0b",
+                                  ok_to_end, watchdog_done), UVM_MEDIUM)
+
+        fork
+          begin
+            // wait until ok_to_end is set plus the delay of ok_to_end_delay_ns
+            watchdog_ok_to_end();
+            phase.drop_objection(this, $sformatf("%s objection dropped", `gfn));
+            `uvm_info(`gfn, $sformatf("Dropped objection"), UVM_MEDIUM)
+          end
+        join_none;
+      end
+    end
+  endfunction
+
+  // This watchdog will wait for ok_to_end_delay_ns while checking for any
+  // traffic on the bus during this period.
+  // If traffic is seen before ok_to_end_delay_ns, the watchdog will keep
+  // repeating this process until the traffic has stopped.
+  virtual task watchdog_ok_to_end();
+    fork
+      begin : isolation_fork
+        bit watchdog_reset;
+
+        fork
+          forever begin
+            // check the bus interface for any traffic. If any, extend timer for one more
+            // ok_to_end_delay_ns
+            @(ok_to_end or watchdog_reset);
+            if (!ok_to_end && !watchdog_reset) watchdog_reset = 1;
+          end
+          forever begin
+            #(cfg.ok_to_end_delay_ns * 1ns);
+            if (!watchdog_reset) begin
+              break;
+            end else begin
+              `uvm_info(`gfn, "Resetting phase watchdog timer", UVM_HIGH)
+              watchdog_reset = 0;
+            end
+          end
+        join_any;
+        disable fork;
+
+        watchdog_done = 1;
+      end : isolation_fork
+    join
+  endtask
+
+  // this task will be invoked as non-blocking thread when phase first enters phase_ready_to_end
+  // extended class can override this task to update ok_to_end
+  virtual task monitor_ready_to_end();
+  endtask
 endclass
 

--- a/hw/dv/sv/dv_lib/dv_base_test.sv
+++ b/hw/dv/sv/dv_lib/dv_base_test.sv
@@ -65,7 +65,6 @@ class dv_base_test #(type CFG_T = dv_base_env_cfg,
     phase.raise_objection(this, $sformatf("%s objection raised", `gn));
     test_seq.start(env.virtual_sequencer);
     phase.drop_objection(this, $sformatf("%s objection dropped", `gn));
-    phase.phase_done.display_objections();
     `uvm_info(`gfn, {"Finished test sequence ", test_seq_s}, UVM_MEDIUM)
   endtask
 

--- a/hw/dv/sv/i2c_agent/i2c_monitor.sv
+++ b/hw/dv/sv/i2c_agent/i2c_monitor.sv
@@ -9,9 +9,6 @@ class i2c_monitor extends dv_base_monitor #(
   );
   `uvm_component_utils(i2c_monitor)
 
-  // the base class provides the following handles for use:
-  i2c_agent_cfg cfg;
-  i2c_agent_cov cov;
   // analize ports
   uvm_analysis_port #(i2c_item) i2c_analysis_port;
 

--- a/hw/dv/sv/tl_agent/tl_monitor.sv
+++ b/hw/dv/sv/tl_agent/tl_monitor.sv
@@ -16,7 +16,6 @@ class tl_monitor extends dv_base_monitor#(
 
   tl_seq_item    pending_a_req[$];
   string         agent_name;
-  bit            objection_raised;
   uvm_phase      run_phase_h;
 
   uvm_analysis_port #(tl_seq_item) d_chan_port;
@@ -54,10 +53,6 @@ class tl_monitor extends dv_base_monitor#(
       if (cfg.en_cov) cov.m_pending_req_on_rst_cg.sample(pending_a_req.size() != 0);
       @(posedge cfg.vif.rst_n);
       pending_a_req.delete();
-      if (objection_raised) begin
-        run_phase_h.drop_objection(this, $sformatf("%s objection dropped", `gfn));
-        objection_raised = 1'b0;
-      end
     end
   endtask : reset_thread
 
@@ -83,10 +78,6 @@ class tl_monitor extends dv_base_monitor#(
                                         pending_a_req.size()))
           end
           if (cfg.en_cov) cov.m_max_outstanding_cg.sample(pending_a_req.size());
-        end
-        if (!objection_raised) begin
-          run_phase_h.raise_objection(this, $sformatf("%s objection raised", `gfn));
-          objection_raised = 1'b1;
         end
       end
       @(cfg.vif.mon_cb);
@@ -116,10 +107,6 @@ class tl_monitor extends dv_base_monitor#(
                       agent_name, rsp.convert2string()), UVM_HIGH)
             d_chan_port.write(rsp);
             pending_a_req.delete(i);
-            if (pending_a_req.size() == 0) begin
-              run_phase_h.drop_objection(this, $sformatf("%s objection dropped", `gfn));
-              objection_raised = 1'b0;
-            end
             req_found = 1'b1;
             break;
           end
@@ -131,6 +118,15 @@ class tl_monitor extends dv_base_monitor#(
       end
     end
   endtask : d_channel_thread
+
+  // update ok_to_end to prevent sim finish when there is any pending item
+  virtual task monitor_ready_to_end();
+    forever begin
+      if (pending_a_req.size() == 0) ok_to_end = 1;
+      else                           ok_to_end = 0;
+      wait(pending_a_req.size());
+    end
+  endtask
 
   virtual function void report_phase(uvm_phase phase);
     if (pending_a_req.size() > 0) begin

--- a/hw/ip/uart/dv/env/uart_scoreboard.sv
+++ b/hw/ip/uart/dv/env/uart_scoreboard.sv
@@ -85,7 +85,6 @@ class uart_scoreboard extends cip_base_scoreboard #(.CFG_T(uart_env_cfg),
 
       if (tx_q.size() == 0 && tx_processing_item_q.size() == 0) begin
         intr_exp[TxEmpty] = 1;
-        process_objections(1'b0);
       end
     end
   endtask
@@ -196,7 +195,7 @@ class uart_scoreboard extends cip_base_scoreboard #(.CFG_T(uart_env_cfg),
         if (write && channel == AddrChannel) begin
           tx_enabled = ral.ctrl.tx.get_mirrored_value();
           rx_enabled = ral.ctrl.rx.get_mirrored_value();
-          // if tx_q is not empty and tx got enabled, raise objection since we have work to do
+
           if ((tx_q.size > 0 || tx_processing_item_q.size > 0) && tx_enabled) begin
             if (tx_q.size > 0 && tx_processing_item_q.size == 0) begin
               tx_processing_item_q.push_back(tx_q.pop_front());
@@ -205,7 +204,6 @@ class uart_scoreboard extends cip_base_scoreboard #(.CFG_T(uart_env_cfg),
                 predict_tx_watermark_intr();
               end join_none
             end
-            process_objections(1'b1);
           end
         end
       end
@@ -235,8 +233,6 @@ class uart_scoreboard extends cip_base_scoreboard #(.CFG_T(uart_env_cfg),
               end
             end else if (tx_enabled && tx_processing_item_q.size == 0 && tx_q.size > 0) begin
               tx_processing_item_q.push_back(tx_q.pop_front());
-              // raise objection if tx is enabled - there is work to do
-              process_objections(1'b1);
             end
             predict_tx_watermark_intr();
           end join_none
@@ -254,7 +250,6 @@ class uart_scoreboard extends cip_base_scoreboard #(.CFG_T(uart_env_cfg),
             end
             tx_q.delete();
             void'(ral.fifo_ctrl.txrst.predict(.value(0), .kind(UVM_PREDICT_WRITE)));
-            if (!tx_enabled) process_objections(1'b0);
             if (cfg.en_cov) begin
               cov.fifo_level_cg.sample(.dir(UartTx),
                                        .lvl(ral.fifo_status.txlvl.get_mirrored_value()),
@@ -519,7 +514,6 @@ class uart_scoreboard extends cip_base_scoreboard #(.CFG_T(uart_env_cfg),
     rxlvl_exp            = ral.fifo_status.rxlvl.get_reset();
     intr_exp             = ral.intr_state.get_reset();
     rdata_exp            = ral.rdata.get_reset();
-    process_objections(1'b0);
   endfunction
 
   function void check_phase(uvm_phase phase);


### PR DESCRIPTION
1. Implement it in dv_base_monitor, all extended monitors need to drive
`ok_to_end` and no need to raise/drop objections
  - when bus is busy, set `ok_to_end = 1`
  - when item is done and bus isn't busy, set  `ok_to_end = 0`
2. Remove raise/drop objections in scb
3. Test in uart and xbar, see 1.5-3% sim time reduce
4. Need another PR to clean up for the other IPs

Discussed at https://github.com/lowRISC/style-guides/issues/30

Signed-off-by: Weicai Yang <weicai@google.com>