### PR TITLE
[aes] Add intermodule connections and estimated gates for hardening

### DIFF
--- a/hw/ip/aes/aes.core
+++ b/hw/ip/aes/aes.core
@@ -9,6 +9,7 @@ filesets:
     depend:
       - lowrisc:prim:all
       - lowrisc:ip:tlul
+      - lowrisc:ip:keymgr_pkg
     files:
       - rtl/aes_pkg.sv
       - rtl/aes_reg_pkg.sv

--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -7,7 +7,7 @@
   name: "aes",
   clock_primary: "clk_i",
   bus_device: "tlul",
-  regwidth: "32",
+
   # Note: All parameters are local, they are not actually configurable.
   # Selecting values different from the default values below might cause undefined behavior.
   param_list: [
@@ -30,6 +30,26 @@
       local:   "true"
     }
   ],
+
+  inter_signal_list: [
+    { name:    "keymgr_key",
+      type:    "uni",
+      act:     "rcv",
+      package: "keymgr_pkg",
+      struct:  "hw_key_req",
+      width:   "1"
+    }
+    // TODO: CSRNG peripheral interface/RNG distribution network interface needs to be defined first, see https://github.com/lowRISC/opentitan/issues/2693.
+    /*{ name:    "entropy",
+      type:    "req_rsp",
+      act:     "req",
+      package: "csrng_pkg",
+      struct:  "csrng_entropy",
+      width:   "1"
+    },*/
+  ],
+
+  regwidth: "32",
   registers: [
 ##############################################################################
 # initial key registers

--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -7,7 +7,6 @@
   name: "aes",
   clock_primary: "clk_i",
   bus_device: "tlul",
-
   # Note: All parameters are local, they are not actually configurable.
   # Selecting values different from the default values below might cause undefined behavior.
   param_list: [
@@ -30,7 +29,6 @@
       local:   "true"
     }
   ],
-
   inter_signal_list: [
     { name:    "keymgr_key",
       type:    "uni",
@@ -48,7 +46,11 @@
       width:   "1"
     },*/
   ],
-
+  alert_list: [
+    { name: "ctrl_err",
+      desc: "This alert is triggered upon detecting an error in the Control Register",
+    }
+  ],
   regwidth: "32",
   registers: [
 ##############################################################################

--- a/hw/ip/aes/doc/_index.md
+++ b/hw/ip/aes/doc/_index.md
@@ -110,9 +110,6 @@ The initialization vector (IV) register and the register to hold the previous in
 
 ## Hardware Interfaces
 
-In the current implementation, the AES unit has no security alerts.
-These will eventually be added in future versions.
-
 {{< hwcfg "hw/ip/aes/data/aes.hjson" >}}
 
 

--- a/hw/ip/aes/dv/tb/tb.sv
+++ b/hw/ip/aes/dv/tb/tb.sv
@@ -15,6 +15,8 @@ module tb;
 
   wire clk, rst_n;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
+  prim_alert_pkg::alert_rx_t [aes_pkg::NumAlerts-1:0] alert_rx;
+  assign alert_rx[0] = 4'b0101;
 
   // interfaces
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
@@ -31,7 +33,10 @@ module tb;
     .keymgr_key_i         ( '0        ),
 
     .tl_i                 (tl_if.h2d  ),
-    .tl_o                 (tl_if.d2h  )
+    .tl_o                 (tl_if.d2h  ),
+
+    .alert_rx_i           ( alert_rx  ),
+    .alert_tx_o           (           )
   );
 
   initial begin

--- a/hw/ip/aes/dv/tb/tb.sv
+++ b/hw/ip/aes/dv/tb/tb.sv
@@ -28,6 +28,8 @@ module tb;
     .clk_i                (clk        ),
     .rst_ni               (rst_n      ),
 
+    .keymgr_key_i         ( '0        ),
+
     .tl_i                 (tl_if.h2d  ),
     .tl_o                 (tl_if.d2h  )
   );

--- a/hw/ip/aes/rtl/aes.sv
+++ b/hw/ip/aes/rtl/aes.sv
@@ -22,10 +22,15 @@ module aes #(
 
   // Bus interface
   input  tlul_pkg::tl_h2d_t tl_i,
-  output tlul_pkg::tl_d2h_t tl_o
+  output tlul_pkg::tl_d2h_t tl_o,
+
+  // Alerts
+  input  prim_alert_pkg::alert_rx_t [aes_pkg::NumAlerts-1:0] alert_rx_i,
+  output prim_alert_pkg::alert_tx_t [aes_pkg::NumAlerts-1:0] alert_tx_o
 );
 
   import aes_reg_pkg::*;
+  import aes_pkg::*;
 
   aes_reg2hw_t reg2hw;
   aes_hw2reg_t hw2reg;
@@ -80,8 +85,24 @@ module aes #(
     .entropy_i    ( 64'hFEDCBA9876543210 )
   );
 
+  // Generate alert senders for the bronze netlist.
+  logic [NumAlerts-1:0] alert;
+  assign alert = '0;
+  for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
+    prim_alert_sender #(
+      .AsyncOn(AlertAsyncOn[i])
+    ) i_prim_alert_sender (
+      .clk_i      ( clk_i         ),
+      .rst_ni     ( rst_ni        ),
+      .alert_i    ( alert[i]      ),
+      .alert_rx_i ( alert_rx_i[i] ),
+      .alert_tx_o ( alert_tx_o[i] )
+    );
+  end
+
   // All outputs should have a known value after reset
   `ASSERT_KNOWN(TlODValidKnown, tl_o.d_valid)
   `ASSERT_KNOWN(TlOAReadyKnown, tl_o.a_ready)
+  `ASSERT_KNOWN(AlertTxKnown, alert_tx_o)
 
 endmodule

--- a/hw/ip/aes/rtl/aes.sv
+++ b/hw/ip/aes/rtl/aes.sv
@@ -13,12 +13,12 @@ module aes #(
   input                     clk_i,
   input                     rst_ni,
 
+  // Key manager interface
+  input   keymgr_pkg::hw_key_req_t keymgr_key_i,
+
   // Entropy source interface
-  // TODO: This still needs to be connected.
-  // See https://github.com/lowRISC/opentitan/issues/1005
-  //output logic              entropy_req_o,
-  //input  logic              entropy_ack_i,
-  //input  logic [63:0]       entropy_i,
+  // TODO: CSRNG peripheral interface/RNG distribution network interface needs to be defined first,
+  // see https://github.com/lowRISC/opentitan/issues/2693.
 
   // Bus interface
   input  tlul_pkg::tl_h2d_t tl_i,

--- a/hw/ip/aes/rtl/aes_cipher_core.sv
+++ b/hw/ip/aes/rtl/aes_cipher_core.sv
@@ -47,6 +47,32 @@ module aes_cipher_core #(
 
   import aes_pkg::*;
 
+  // Generate gates to represent hardening cost for the bronze netlist.
+  prim_gate_gen #(
+    .DataWidth ( 32    ),
+    .NumGates  ( 43000 )
+  ) aes_cipher_core_hardening (
+    .clk_i   ( clk_i             ),
+    .rst_ni  ( rst_ni            ),
+    .valid_i ( in_valid_i        ),
+    .data_i  ( prng_data_i[31:0] ),
+    .data_o  (                   ),
+    .valid_o (                   )
+  );
+
+  // Generate gates to represent cost of high-bandwidth, local PRNG for the bronze netlist.
+  prim_gate_gen #(
+    .DataWidth ( 32    ),
+    .NumGates  ( 30000 )
+  ) aes_cipher_core_prng (
+    .clk_i   ( clk_i             ),
+    .rst_ni  ( rst_ni            ),
+    .valid_i ( in_valid_i        ),
+    .data_i  ( prng_data_i[31:0] ),
+    .data_o  (                   ),
+    .valid_o (                   )
+  );
+
   // Signals
   logic [3:0][3:0][7:0] state_d;
   logic [3:0][3:0][7:0] state_q;

--- a/hw/ip/aes/rtl/aes_core.sv
+++ b/hw/ip/aes/rtl/aes_core.sv
@@ -179,6 +179,29 @@ module aes_core #(
     end
   end
 
+  // Initial key registers (mask share)
+  // NOTE: These are not functional, we just want the gates for the bronze netlist.
+  logic [7:0]       key_init_share1_we;
+  logic [7:0][31:0] key_init_share1_d;
+  logic [7:0][31:0] key_init_share1_q;
+  assign key_init_share1_we = key_init_we;
+
+  always_comb begin : key_init_share1_mux
+    unique case (key_init_sel)
+      KEY_INIT_INPUT: key_init_share1_d = key_init;
+      KEY_INIT_CLEAR: key_init_share1_d = {prng_data_i, prng_data_i, prng_data_i, prng_data_i};
+      default:        key_init_share1_d = key_init_share1_q;
+    endcase
+  end
+
+  always_ff @(posedge clk_i) begin : key_init_share1_reg
+    for (int i=0; i<8; i++) begin
+      if (key_init_share1_we[i]) begin
+        key_init_share1_q[i] <= key_init_share1_d[i];
+      end
+    end
+  end
+
   // IV registers
   always_comb begin : iv_mux
     unique case (iv_sel)

--- a/hw/ip/aes/rtl/aes_pkg.sv
+++ b/hw/ip/aes/rtl/aes_pkg.sv
@@ -6,6 +6,9 @@
 
 package aes_pkg;
 
+parameter int NumAlerts = 1;
+parameter logic [NumAlerts-1:0] AlertAsyncOn = NumAlerts'(1'b1);
+
 typedef enum logic {
   AES_ENC = 1'b0,
   AES_DEC = 1'b1

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -2068,6 +2068,19 @@
       wakeup_list: []
       scan: "false"
       scan_reset: "false"
+      inter_signal_list:
+      [
+        {
+          name: keymgr_key
+          type: uni
+          act: rcv
+          package: keymgr_pkg
+          struct: hw_key_req
+          width: "1"
+          inst_name: aes
+          index: -1
+        }
+      ]
     }
     {
       name: hmac
@@ -7463,6 +7476,16 @@
         package: pinmux_pkg
         inst_name: lifecycle
         top_signame: lifecycle_strap_sample
+        index: -1
+      }
+      {
+        name: keymgr_key
+        type: uni
+        act: rcv
+        package: keymgr_pkg
+        struct: hw_key_req
+        width: "1"
+        inst_name: aes
         index: -1
       }
       {

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -2064,7 +2064,15 @@
       available_output_list: []
       available_inout_list: []
       interrupt_list: []
-      alert_list: []
+      alert_list:
+      [
+        {
+          name: ctrl_err
+          width: 1
+          type: alert
+          async: 0
+        }
+      ]
       wakeup_list: []
       scan: "false"
       scan_reset: "false"
@@ -6502,6 +6510,7 @@
   ]
   alert_module:
   [
+    aes
     hmac
     kmac
     sensor_ctrl
@@ -6510,6 +6519,13 @@
   ]
   alert:
   [
+    {
+      name: aes_ctrl_err
+      width: 1
+      type: alert
+      async: 0
+      module_name: aes
+    }
     {
       name: hmac_msg_push_sha_disabled
       width: 1

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -533,7 +533,7 @@
   // ===== ALERT HANDLER ======================================================
   // list all modules that expose alerts
   // first item goes to LSB of the interrupt source
-  alert_module: [ "hmac", "kmac", "sensor_ctrl", "otp_ctrl", "otbn"]
+  alert_module: [ "aes", "hmac", "kmac", "sensor_ctrl", "otp_ctrl", "otbn"]
 
   // generated list of alerts:
   alert: [

--- a/hw/top_earlgrey/ip/alert_handler/data/autogen/alert_handler.hjson
+++ b/hw/top_earlgrey/ip/alert_handler/data/autogen/alert_handler.hjson
@@ -29,7 +29,7 @@
     { name: "NAlerts",
       desc: "Number of peripheral inputs",
       type: "int",
-      default: "15",
+      default: "16",
       local: "true"
     },
     { name: "EscCntDw",
@@ -53,7 +53,7 @@
     { name: "AsyncOn",
       desc: "Number of peripheral outputs",
       type: "logic [NAlerts-1:0]",
-      default: "15'b000111000",
+      default: "16'b0001110000",
       local: "true"
     },
     { name: "N_CLASSES",

--- a/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_pkg.sv
@@ -7,11 +7,11 @@
 package alert_handler_reg_pkg;
 
   // Param list
-  parameter int NAlerts = 15;
+  parameter int NAlerts = 16;
   parameter int EscCntDw = 32;
   parameter int AccuCntDw = 16;
   parameter int LfsrSeed = 2147483647;
-  parameter logic [NAlerts-1:0] AsyncOn = 15'b000111000;
+  parameter logic [NAlerts-1:0] AsyncOn = 16'b0001110000;
   parameter int N_CLASSES = 4;
   parameter int N_ESC_SEV = 4;
   parameter int N_PHASES = 4;
@@ -455,14 +455,14 @@ package alert_handler_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    alert_handler_reg2hw_intr_state_reg_t intr_state; // [884:881]
-    alert_handler_reg2hw_intr_enable_reg_t intr_enable; // [880:877]
-    alert_handler_reg2hw_intr_test_reg_t intr_test; // [876:869]
-    alert_handler_reg2hw_regen_reg_t regen; // [868:868]
-    alert_handler_reg2hw_ping_timeout_cyc_reg_t ping_timeout_cyc; // [867:844]
-    alert_handler_reg2hw_alert_en_mreg_t [14:0] alert_en; // [843:829]
-    alert_handler_reg2hw_alert_class_mreg_t [14:0] alert_class; // [828:799]
-    alert_handler_reg2hw_alert_cause_mreg_t [14:0] alert_cause; // [798:784]
+    alert_handler_reg2hw_intr_state_reg_t intr_state; // [888:885]
+    alert_handler_reg2hw_intr_enable_reg_t intr_enable; // [884:881]
+    alert_handler_reg2hw_intr_test_reg_t intr_test; // [880:873]
+    alert_handler_reg2hw_regen_reg_t regen; // [872:872]
+    alert_handler_reg2hw_ping_timeout_cyc_reg_t ping_timeout_cyc; // [871:848]
+    alert_handler_reg2hw_alert_en_mreg_t [15:0] alert_en; // [847:832]
+    alert_handler_reg2hw_alert_class_mreg_t [15:0] alert_class; // [831:800]
+    alert_handler_reg2hw_alert_cause_mreg_t [15:0] alert_cause; // [799:784]
     alert_handler_reg2hw_loc_alert_en_mreg_t [3:0] loc_alert_en; // [783:780]
     alert_handler_reg2hw_loc_alert_class_mreg_t [3:0] loc_alert_class; // [779:772]
     alert_handler_reg2hw_loc_alert_cause_mreg_t [3:0] loc_alert_cause; // [771:768]
@@ -504,8 +504,8 @@ package alert_handler_reg_pkg;
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    alert_handler_hw2reg_intr_state_reg_t intr_state; // [257:254]
-    alert_handler_hw2reg_alert_cause_mreg_t [14:0] alert_cause; // [253:224]
+    alert_handler_hw2reg_intr_state_reg_t intr_state; // [259:256]
+    alert_handler_hw2reg_alert_cause_mreg_t [15:0] alert_cause; // [255:224]
     alert_handler_hw2reg_loc_alert_cause_mreg_t [3:0] loc_alert_cause; // [223:216]
     alert_handler_hw2reg_classa_clren_reg_t classa_clren; // [215:216]
     alert_handler_hw2reg_classa_accum_cnt_reg_t classa_accum_cnt; // [215:216]

--- a/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_top.sv
+++ b/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_top.sv
@@ -154,6 +154,9 @@ module alert_handler_reg_top (
   logic alert_en_en_a14_qs;
   logic alert_en_en_a14_wd;
   logic alert_en_en_a14_we;
+  logic alert_en_en_a15_qs;
+  logic alert_en_en_a15_wd;
+  logic alert_en_en_a15_we;
   logic [1:0] alert_class_class_a0_qs;
   logic [1:0] alert_class_class_a0_wd;
   logic alert_class_class_a0_we;
@@ -199,6 +202,9 @@ module alert_handler_reg_top (
   logic [1:0] alert_class_class_a14_qs;
   logic [1:0] alert_class_class_a14_wd;
   logic alert_class_class_a14_we;
+  logic [1:0] alert_class_class_a15_qs;
+  logic [1:0] alert_class_class_a15_wd;
+  logic alert_class_class_a15_we;
   logic alert_cause_a0_qs;
   logic alert_cause_a0_wd;
   logic alert_cause_a0_we;
@@ -244,6 +250,9 @@ module alert_handler_reg_top (
   logic alert_cause_a14_qs;
   logic alert_cause_a14_wd;
   logic alert_cause_a14_we;
+  logic alert_cause_a15_qs;
+  logic alert_cause_a15_wd;
+  logic alert_cause_a15_we;
   logic loc_alert_en_en_la0_qs;
   logic loc_alert_en_en_la0_wd;
   logic loc_alert_en_en_la0_we;
@@ -1240,6 +1249,32 @@ module alert_handler_reg_top (
   );
 
 
+  // F[en_a15]: 15:15
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_alert_en_en_a15 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (alert_en_en_a15_we & regen_qs),
+    .wd     (alert_en_en_a15_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.alert_en[15].q ),
+
+    // to register interface (read)
+    .qs     (alert_en_en_a15_qs)
+  );
+
+
 
 
   // Subregister 0 of Multireg alert_class
@@ -1635,6 +1670,32 @@ module alert_handler_reg_top (
   );
 
 
+  // F[class_a15]: 31:30
+  prim_subreg #(
+    .DW      (2),
+    .SWACCESS("RW"),
+    .RESVAL  (2'h0)
+  ) u_alert_class_class_a15 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (alert_class_class_a15_we & regen_qs),
+    .wd     (alert_class_class_a15_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.alert_class[15].q ),
+
+    // to register interface (read)
+    .qs     (alert_class_class_a15_qs)
+  );
+
+
 
 
   // Subregister 0 of Multireg alert_cause
@@ -2027,6 +2088,32 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_cause_a14_qs)
+  );
+
+
+  // F[a15]: 15:15
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("W1C"),
+    .RESVAL  (1'h0)
+  ) u_alert_cause_a15 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (alert_cause_a15_we),
+    .wd     (alert_cause_a15_wd),
+
+    // from internal hardware
+    .de     (hw2reg.alert_cause[15].de),
+    .d      (hw2reg.alert_cause[15].d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.alert_cause[15].q ),
+
+    // to register interface (read)
+    .qs     (alert_cause_a15_qs)
   );
 
 
@@ -4677,6 +4764,9 @@ module alert_handler_reg_top (
   assign alert_en_en_a14_we = addr_hit[5] & reg_we & ~wr_err;
   assign alert_en_en_a14_wd = reg_wdata[14];
 
+  assign alert_en_en_a15_we = addr_hit[5] & reg_we & ~wr_err;
+  assign alert_en_en_a15_wd = reg_wdata[15];
+
   assign alert_class_class_a0_we = addr_hit[6] & reg_we & ~wr_err;
   assign alert_class_class_a0_wd = reg_wdata[1:0];
 
@@ -4722,6 +4812,9 @@ module alert_handler_reg_top (
   assign alert_class_class_a14_we = addr_hit[6] & reg_we & ~wr_err;
   assign alert_class_class_a14_wd = reg_wdata[29:28];
 
+  assign alert_class_class_a15_we = addr_hit[6] & reg_we & ~wr_err;
+  assign alert_class_class_a15_wd = reg_wdata[31:30];
+
   assign alert_cause_a0_we = addr_hit[7] & reg_we & ~wr_err;
   assign alert_cause_a0_wd = reg_wdata[0];
 
@@ -4766,6 +4859,9 @@ module alert_handler_reg_top (
 
   assign alert_cause_a14_we = addr_hit[7] & reg_we & ~wr_err;
   assign alert_cause_a14_wd = reg_wdata[14];
+
+  assign alert_cause_a15_we = addr_hit[7] & reg_we & ~wr_err;
+  assign alert_cause_a15_wd = reg_wdata[15];
 
   assign loc_alert_en_en_la0_we = addr_hit[8] & reg_we & ~wr_err;
   assign loc_alert_en_en_la0_wd = reg_wdata[0];
@@ -5092,6 +5188,7 @@ module alert_handler_reg_top (
         reg_rdata_next[12] = alert_en_en_a12_qs;
         reg_rdata_next[13] = alert_en_en_a13_qs;
         reg_rdata_next[14] = alert_en_en_a14_qs;
+        reg_rdata_next[15] = alert_en_en_a15_qs;
       end
 
       addr_hit[6]: begin
@@ -5110,6 +5207,7 @@ module alert_handler_reg_top (
         reg_rdata_next[25:24] = alert_class_class_a12_qs;
         reg_rdata_next[27:26] = alert_class_class_a13_qs;
         reg_rdata_next[29:28] = alert_class_class_a14_qs;
+        reg_rdata_next[31:30] = alert_class_class_a15_qs;
       end
 
       addr_hit[7]: begin
@@ -5128,6 +5226,7 @@ module alert_handler_reg_top (
         reg_rdata_next[12] = alert_cause_a12_qs;
         reg_rdata_next[13] = alert_cause_a13_qs;
         reg_rdata_next[14] = alert_cause_a14_qs;
+        reg_rdata_next[15] = alert_cause_a15_qs;
       end
 
       addr_hit[8]: begin

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -1101,6 +1101,9 @@ module top_earlgrey #(
   aes u_aes (
       .tl_i (tl_aes_d_h2d),
       .tl_o (tl_aes_d_d2h),
+
+      // Inter-module signals
+      .keymgr_key_i(keymgr_pkg::HW_KEY_REQ_DEFAULT),
       .clk_i (clkmgr_aon_clocks.clk_main_aes),
       .rst_ni (rstmgr_aon_resets.rst_sys_n)
   );

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -1102,6 +1102,10 @@ module top_earlgrey #(
       .tl_i (tl_aes_d_h2d),
       .tl_o (tl_aes_d_d2h),
 
+      // [3]: ctrl_err
+      .alert_tx_o  ( alert_tx[3:3] ),
+      .alert_rx_i  ( alert_rx[3:3] ),
+
       // Inter-module signals
       .keymgr_key_i(keymgr_pkg::HW_KEY_REQ_DEFAULT),
       .clk_i (clkmgr_aon_clocks.clk_main_aes),
@@ -1117,9 +1121,9 @@ module top_earlgrey #(
       .intr_fifo_empty_o (intr_hmac_fifo_empty),
       .intr_hmac_err_o   (intr_hmac_hmac_err),
 
-      // [3]: msg_push_sha_disabled
-      .alert_tx_o  ( alert_tx[3:3] ),
-      .alert_rx_i  ( alert_rx[3:3] ),
+      // [4]: msg_push_sha_disabled
+      .alert_tx_o  ( alert_tx[4:4] ),
+      .alert_rx_i  ( alert_rx[4:4] ),
       .clk_i (clkmgr_aon_clocks.clk_main_hmac),
       .rst_ni (rstmgr_aon_resets.rst_sys_n)
   );
@@ -1133,10 +1137,10 @@ module top_earlgrey #(
       .intr_fifo_empty_o (intr_kmac_fifo_empty),
       .intr_kmac_err_o   (intr_kmac_kmac_err),
 
-      // [4]: sram_uncorrectable
-      // [5]: data_parity
-      .alert_tx_o  ( alert_tx[5:4] ),
-      .alert_rx_i  ( alert_rx[5:4] ),
+      // [5]: sram_uncorrectable
+      // [6]: data_parity
+      .alert_tx_o  ( alert_tx[6:5] ),
+      .alert_rx_i  ( alert_rx[6:5] ),
 
       // Inter-module signals
       .keymgr_key_i(keymgr_kmac_key),
@@ -1507,11 +1511,11 @@ module top_earlgrey #(
       .intr_done_o (intr_otbn_done),
       .intr_err_o  (intr_otbn_err),
 
-      // [6]: imem_uncorrectable
-      // [7]: dmem_uncorrectable
-      // [8]: reg_uncorrectable
-      .alert_tx_o  ( alert_tx[8:6] ),
-      .alert_rx_i  ( alert_rx[8:6] ),
+      // [7]: imem_uncorrectable
+      // [8]: dmem_uncorrectable
+      // [9]: reg_uncorrectable
+      .alert_tx_o  ( alert_tx[9:7] ),
+      .alert_rx_i  ( alert_rx[9:7] ),
 
       // Inter-module signals
       .idle_o(),


### PR DESCRIPTION
This adds non-functional changes for the bronze netlist. More precisely, it adds:
- intermodule connections to keymgr and csrng,
- estimated gate count for security hardening,
- gate count estimate for local, high-bandwidth PRNG.
- connection to alert handler (split out from #2152 ).

What is still missing:
- gate count estimate for additional modes (if we decide to go for it)