### PR TITLE
Simplify paths in .hjson files used by dvsim.py

### DIFF
--- a/hw/dv/data/common_sim_cfg.hjson
+++ b/hw/dv/data/common_sim_cfg.hjson
@@ -6,13 +6,16 @@
   doc_server:       docs.opentitan.org
   results_server:   reports.opentitan.org
 
+  // Where to find DV code
+  dv_root:          "{proj_root}/hw/dv"
+
   flow:             sim
-  flow_makefile:    "{proj_root}/hw/dv/data/sim.mk"
+  flow_makefile:    "{dv_root}/data/sim.mk"
 
   import_cfgs:      ["{proj_root}/hw/data/common_project_cfg.hjson",
-                     "{proj_root}/hw/dv/data/common_modes.hjson",
-                     "{proj_root}/hw/dv/data/fusesoc.hjson",
-                     "{proj_root}/hw/dv/data/{tool}/{tool}.hjson"]
+                     "{dv_root}/data/common_modes.hjson",
+                     "{dv_root}/data/fusesoc.hjson",
+                     "{dv_root}/data/{tool}/{tool}.hjson"]
 
   // Default directory structure for the output
   build_dir:          "{scratch_path}/{build_mode}"
@@ -133,7 +136,7 @@
   // Add waves.tcl to the set of sources to be copied over to
   // {tool_srcs_dir}. This can be sourced by the tool-specific TCL
   // script to set up wave dumping.
-  tool_srcs:  ["{proj_root}/hw/dv/tools/waves.tcl"],
+  tool_srcs:  ["{dv_root}/tools/waves.tcl"],
 
   // Project defaults for VCS
   vcs_cov_hier: "-cm_hier {tool_srcs_dir}/cover.cfg"

--- a/hw/dv/data/dsim/dsim.hjson
+++ b/hw/dv/data/dsim/dsim.hjson
@@ -38,7 +38,7 @@
   // Indicate the tool specific helper sources - these are copied over to the
   // {tool_srcs_dir} before running the simulation.
   // TODO, there is no dsim tool file, point to vcs for now to avoid error from script
-  tool_srcs:  ["{proj_root}/hw/dv/tools/vcs/*"]
+  tool_srcs:  ["{dv_root}/tools/vcs/*"]
 
   // TODO: refactor coverage configuration for DSim.
 

--- a/hw/dv/data/vcs/vcs.hjson
+++ b/hw/dv/data/vcs/vcs.hjson
@@ -8,7 +8,7 @@
 
   // Indicate the tool specific helper sources - these are copied over to the
   // {tool_srcs_dir} before running the simulation.
-  tool_srcs:  ["{proj_root}/hw/dv/tools/vcs/*"]
+  tool_srcs:  ["{dv_root}/tools/vcs/*"]
 
   build_opts: ["-sverilog -full64 -licqueue -kdb -ntb_opts uvm-1.2",
                "-timescale=1ns/1ps",

--- a/hw/dv/data/xcelium/xcelium.hjson
+++ b/hw/dv/data/xcelium/xcelium.hjson
@@ -7,7 +7,7 @@
 
   // Indicate the tool specific helper sources - these are copied over to the
   // {tool_srcs_dir} before running the simulation.
-  tool_srcs:  ["{proj_root}/hw/dv/tools/xcelium/*"]
+  tool_srcs:  ["{dv_root}/tools/xcelium/*"]
 
   build_opts: ["-elaborate -64bit -access +r -sv",
                "-licqueue",

--- a/util/dvsim/FlowCfg.py
+++ b/util/dvsim/FlowCfg.py
@@ -115,19 +115,14 @@ class FlowCfg():
         for item in self.deploy:
             item.kill()
 
-    def parse_flow_cfg(self, flow_cfg_file, is_entry_point=True):
-        '''
-        Parse the flow cfg hjson file. This is a private API used within the
-        extended class' __init__ function. This parses the hjson cfg (and
-        imports / use cfgs) and builds an initial dictionary.
+    def _parse_cfg(self, path, is_entry_point):
+        '''Load an hjson config file at path and update self accordingly.
 
-        This method takes 2 args.
-        flow_cfg_file: This is the flow cfg file to be parsed.
-        is_entry_point: the cfg file that is passed on the command line is
-            the entry point cfg. If the cfg file is a part of an import_cfgs
-            or use_cfgs key, then it is not an entry point.
+        If is_entry_point is true, this is the top-level configuration file, so
+        it's possible that this is a master config.
+
         '''
-        hjson_dict = parse_hjson(flow_cfg_file)
+        hjson_dict = parse_hjson(path)
 
         # Check if this is the primary cfg, if this is the entry point cfg file
         if is_entry_point:
@@ -140,10 +135,14 @@ class FlowCfg():
         # Resolve the raw hjson dict to build this object
         self.resolve_hjson_raw(hjson_dict)
 
-    def _post_parse_flow_cfg(self):
-        '''Hook to set some defaults not found in the flow cfg hjson files.
-        This function has to be called manually after calling the parse_flow_cfg().
+    def _parse_flow_cfg(self, path):
+        '''Parse the flow's hjson configuration.
+
+        This is a private API which should be called by the __init__ method of
+        each subclass.
+
         '''
+        self._parse_cfg(path, True)
         if self.rel_path == "":
             self.rel_path = os.path.dirname(self.flow_cfg_file).replace(
                 self.proj_root + '/', '')
@@ -250,7 +249,7 @@ class FlowCfg():
                 # Substitute wildcards in cfg_file files since we need to process
                 # them right away.
                 cfg_file = subst_wildcards(cfg_file, self.__dict__)
-                self.parse_flow_cfg(cfg_file, False)
+                self._parse_cfg(cfg_file, False)
             else:
                 log.error("Cfg file \"%s\" has already been parsed", cfg_file)
 

--- a/util/dvsim/OneShotCfg.py
+++ b/util/dvsim/OneShotCfg.py
@@ -76,8 +76,7 @@ class OneShotCfg(FlowCfg):
         self.deploy = []
         self.cov = args.cov
         # Parse the cfg_file file tree
-        self.parse_flow_cfg(flow_cfg_file)
-        self._post_parse_flow_cfg()
+        self._parse_flow_cfg(flow_cfg_file)
 
         # If build_unique is set, then add current timestamp to uniquify it
         if self.build_unique:

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -165,8 +165,7 @@ class SimCfg(FlowCfg):
         self.cov_deploys = []
 
         # Parse the cfg_file file tree
-        self.parse_flow_cfg(flow_cfg_file)
-        self._post_parse_flow_cfg()
+        self._parse_flow_cfg(flow_cfg_file)
 
         # Choose a dump format now. Note that this has to happen after parsing
         # the configuration format because our choice might depend on the


### PR DESCRIPTION
This patch series makes it so that we can vendor the contents of `hw/dv/data` and `hw/dv/tools` into Ibex properly, rather than using the current fragile "copy across and edit stuff" approach.

There are 3 patches in the series. Patches 1 and 2 are refactorings and code improvements in dvsim.py. Patch 3 defines the `dv_root` variable which makes it easier to vendor the hjson files.

After this patch series, together with the vendor tool changes in #2077, the Ibex project will be able to vendor in the contents of `hw/dv/{data,tools}` and only needs to patch 2 lines to get simulations working (the definition of `dv_root` in `dvsim.py` and the path to `common_project_cfg.hjson` in `common_sim_cfg.hjson`).

Edit: There used to be more patches in the series, but they have been dropped or done in other PRs.