### PR TITLE
[dv] This fixes a padctrl reset issue in the chip level tb

### DIFF
--- a/hw/dv/sv/common_ifs/clk_rst_if.sv
+++ b/hw/dv/sv/common_ifs/clk_rst_if.sv
@@ -159,6 +159,11 @@ interface clk_rst_if #(
     end
   endfunction
 
+  // can be used to override clk/rst pins, e.g. at the beginning of the simulation
+  task automatic drive_rst_pin(logic val = 1'b0);
+    o_rst_n = val;
+  endtask
+
   // apply reset with specified scheme
   // TODO make this enum?
   // rst_n_scheme

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -25,6 +25,13 @@ class chip_base_vseq extends cip_base_vseq #(
   endtask
 
   virtual task apply_reset(string kind = "HARD");
+    // Note: The JTAG reset does not have a dedicated pad and is muxed with other chip IOs.
+    // These IOs have pad attributes that are driven from registers, and as long as
+    // the reset line of those registers is X, the registers and hence the pad outputs
+    // will also be X. This causes the JTAG reset to not properly propagate, and hence we
+    // have to assert the main reset before that (release can happen in a randomized way
+    // via the apply_reset task later on).
+    cfg.clk_rst_vif.drive_rst_pin(1'b0);
     // TODO: Cannot assert different types of resets in parallel; due to randomization
     // resets de-assert at different times. If the main rst_n de-asserts before others,
     // the CPU starts executing right away which can cause breakages.


### PR DESCRIPTION
This is a reset sequencing issue in simulation that I came across during `padctrl` integration (see #2114). 

In particular, the JTAG reset does not have a dedicated pad and is muxed with other chip IOs. These IOs have pad attributes that are driven from registers, and as long as the reset line of those registers is X, the registers and hence the pad outputs will also be X. This causes the JTAG reset to not properly propagate, and hence we have to assert the main reset before that (release can happen in a randomized way via the `apply_reset` task later on).

@sriyerg, let me know if you think we should fix this differently.

Signed-off-by: Michael Schaffner <msf@google.com>