### PR TITLE
[dv] Make UART signals wire types in TBs

### DIFF
--- a/hw/dv/sv/uart_agent/uart_if.sv
+++ b/hw/dv/sv/uart_agent/uart_if.sv
@@ -2,10 +2,11 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-interface uart_if #(time UartDefaultClkPeriodNs = 104166.667ns) ();
-  logic uart_rx;
-  wire uart_tx;
-  logic uart_tx_en;
+interface uart_if #(time UartDefaultClkPeriodNs = 104166.667ns) (
+  output logic uart_rx,
+  input uart_tx,
+  input uart_tx_en
+);
 
   // generate local clk
   time  uart_clk_period_ns = UartDefaultClkPeriodNs;

--- a/hw/ip/uart/dv/tb/tb.sv
+++ b/hw/ip/uart/dv/tb/tb.sv
@@ -24,6 +24,7 @@ module tb;
   wire intr_rx_break_err;
   wire intr_rx_timeout;
   wire intr_rx_parity_err;
+  wire uart_rx, uart_tx, uart_tx_en;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
 
   // interfaces
@@ -31,7 +32,7 @@ module tb;
   pins_if #(NUM_MAX_INTERRUPTS) intr_if(interrupts);
   pins_if #(1) devmode_if(devmode);
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
-  uart_if uart_if();
+  uart_if uart_if(.uart_rx, .uart_tx, .uart_tx_en);
 
   // dut
   uart dut (
@@ -41,9 +42,9 @@ module tb;
     .tl_i                 (tl_if.h2d  ),
     .tl_o                 (tl_if.d2h  ),
 
-    .cio_rx_i             (uart_if.uart_rx    ),
-    .cio_tx_o             (uart_if.uart_tx    ),
-    .cio_tx_en_o          (uart_if.uart_tx_en ),
+    .cio_rx_i             (uart_rx    ),
+    .cio_tx_o             (uart_tx    ),
+    .cio_tx_en_o          (uart_tx_en ),
 
     .intr_tx_watermark_o  (intr_tx_watermark ),
     .intr_rx_watermark_o  (intr_rx_watermark ),

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -39,6 +39,8 @@ module tb;
 
   wire usb_dp0, usb_dn0, usb_sense0, usb_pullup0;
 
+  wire uart_rx, uart_tx;
+
   bit stub_cpu;
 
   // interfaces
@@ -50,7 +52,7 @@ module tb;
   pins_if #(1) bootstrap_if(.pins(bootstrap));
   spi_if spi_if(.rst_n(rst_n));
   tl_if   cpu_d_tl_if(.clk(clk), .rst_n(rst_n));
-  uart_if uart_if();
+  uart_if uart_if(.uart_rx, .uart_tx, .uart_tx_en());
   jtag_if jtag_if();
 
   // backdoors
@@ -75,8 +77,8 @@ module tb;
     .IO_DPS7          (io_dps[7]),
 
     // UART interface
-    .IO_URX           (uart_if.uart_rx),
-    .IO_UTX           (uart_if.uart_tx),
+    .IO_URX           (uart_rx),
+    .IO_UTX           (uart_tx),
 
     // USB interface
     .IO_USB_DP0       (usb_dp0),


### PR DESCRIPTION
This is in preparation for #2114. In particular, all chip IOs need to be wires for this to work.

Signed-off-by: Michael Schaffner <msf@google.com>