### PR TITLE
[doc] Fix spiflash path to fpga binary in docs

### DIFF
--- a/doc/ug/getting_started_fpga.md
+++ b/doc/ug/getting_started_fpga.md
@@ -125,8 +125,7 @@ Please follow the steps shown below.
   $ ./meson_init.sh
   $ ninja -C build-out sw/device/examples/hello_world/hello_world_export_fpga_nexysvideo
   $ ninja -C build-out sw/host/spiflash/spiflash_export
-  $ build-bin/sw/host/spiflash/spiflash \
-      --input build-bin/sw/device/fpga/examples/hello_world/hello_world_fpga_nexysvideo.bin
+  $ build-bin/sw/host/spiflash/spiflash --input build-bin/sw/device/examples/hello_world/hello_world_fpga_nexysvideo.bin
   ```
 
   which should report how the binary is split into frames:


### PR DESCRIPTION
I could be mistaken, but this path appears to be wrong. I had to remove "fpga" to make this work: 
"build-bin/sw/device/**fpga**/examples/hello_world/hello_world_fpga_nexysvideo.bin"

Also, the command wraps in a weird way on the documentation page:
```
$ build-bin/sw/host/spiflash/spiflash \
    --input build-
bin/sw/device/fpga/examples/hello_world/hello_world_fpga_nexysvideo.bin
```
Hence I have removed the backslash and new-line.

Signed-off-by: Michael Schaffner <msf@google.com>