### PR TITLE
[aes] Add shadow CTRL register, interface with alert handler

### DIFF
--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -38,6 +38,11 @@
       width:   "1"
     }
   ],
+  alert_list: [
+    { name: "ctrl_err",
+      desc: "This alert is triggered upon detecting an error in the Control Register",
+    }
+  ],
   regwidth: "32",
   registers: [
 ##############################################################################
@@ -140,15 +145,18 @@
     },
 ##############################################################################
 # control and status registers
-  { name: "CTRL",
+  { name: "CTRL_SHADOWED",
     desc: '''
       Control Register. Can only be updated when the AES unit is idle. If the
       AES unit is non-idle, writes to this register are ignored.
+      This register is shadowed, meaning two subsequent write operations are required to change its content.
+      If the two write operations try to set a different value, a ctrl_err alert is triggered.
     '''
     swaccess: "rw",
     hwaccess: "hrw",
     hwext:    "true",
     hwqe:     "true",
+    shadowed: "true",
     fields: [
       { bits: "0",
         name: "OPERATION",
@@ -156,27 +164,73 @@
           Select encryption(0) or decryption(1) operation of AES unit.
         '''
       }
-      { bits: "3:1",
+      { bits: "4:1",
         name: "MODE",
-        resval: "1",
+        resval: "0x8",
         hwaccess: "hrw",
         desc:  '''
-          3-bit one-hot field to select AES block cipher mode: ECB (3'b001), CBC (3'b010) or CTR (3'b100).
-          Invalid input values, i.e., value with multiple bits set, and value 3'b000 are not supported are mapped to 3'b001.
+          4-bit one-hot field to select AES block cipher mode.
+          Invalid input values, i.e., values with multiple bits set and value 4'b0000, are mapped to AES_NONE (4'b1000).
         '''
+        enum: [
+          { value: "1",
+            name: "AES_ECB",
+            desc: '''
+              4'b0001: Electronic Codebook (ECB) mode.
+            '''
+          },
+          { value: "2",
+            name: "AES_CBC",
+            desc: '''
+              4'b0010: Cipher Block Chaining (CBC) mode.
+            '''
+          },
+          { value: "4",
+            name: "AES_CTR",
+            desc: '''
+              4'b0100: Counter (CTR) mode.
+            '''
+          },
+          { value: "8",
+            name: "AES_NONE",
+            desc: '''
+              4'b1000: Invalid input values, i.e., value with multiple bits set and value 4'b0000, are mapped to AES_NONE.
+            '''
+          }
+        ]
       }
-      { bits: "6:4",
+      { bits: "7:5",
         name: "KEY_LEN",
         resval: "1",
         hwaccess: "hrw",
-        desc:  '''
-          3-bit one-hot field to select AES key length: 128 bit (3'b001), 192 bit (3'b010)
-          or 256 bit (3'b100). Invalid input values, i.e., value with multiple bits set,
-          value 3'b000, and value 3'b010 in case 192-bit keys are not supported (because
-          disabled at compile time) are mapped to 3'b001.
+        desc: '''
+          3-bit one-hot field to select AES key length.
+          Invalid input values, i.e., values with multiple bits set, value 3'b000, and value 3'b010 in case 192-bit keys are not supported (because disabled at compile time) are mapped to AES_256 (3'b100).
         '''
+        enum: [
+          { value: "1",
+            name: "AES_128",
+            desc: '''
+              3'b001: 128-bit key length.
+            '''
+          },
+          { value: "2",
+            name: "AES_192",
+            desc: '''
+              3'b010: 192-bit key length.
+              In case support for 192-bit keys has been disabled at compile time, setting this value results in configuring AES_256 (3'b100).
+            '''
+          },
+          { value: "4",
+            name: "AES_256",
+            desc: '''
+              3'b100: 256-bit key length.
+              Invalid input values, i.e., values with multiple bits set, value 3'b000, and value 3'b010 in case 192-bit keys are not supported (because disabled at compile time) are mapped to AES_256.
+            '''
+          }
+        ]
       }
-      { bits: "7",
+      { bits: "8",
         name: "MANUAL_OPERATION",
         desc:  '''
           Controls whether the AES unit is operated in normal/automatic mode (0) or fully manual mode (1).

--- a/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi.c
+++ b/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi.c
@@ -22,6 +22,10 @@ void c_dpi_aes_crypt_block(const unsigned char impl_i, const unsigned char op_i,
   const unsigned char impl = impl_i & impl_mask;
   const unsigned char op = op_i & op_mask;
   const crypto_mode_t mode = (crypto_mode_t)(*mode_i & mode_mask);
+  if (mode == kCryptoAesNone) {
+    printf("ERROR: Mode kCryptoAesNone not supported by c_dpi_aes_crypt_block");
+    return;
+  }
 
   // key_len_i is one-hot encoded.
   int key_len;
@@ -114,6 +118,11 @@ void c_dpi_aes_crypt_message(unsigned char impl_i, unsigned char op_i,
   const unsigned char impl = impl_i & impl_mask;
   const unsigned char op = op_i & op_mask;
   const crypto_mode_t mode = (crypto_mode_t)(*mode_i & mode_mask);
+  if (mode == kCryptoAesNone) {
+    printf(
+        "ERROR: Mode kCryptoAesNone not supported by c_dpi_aes_crypt_message");
+    return;
+  }
 
   // key_len_i is one-hot encoded.
   int key_len;

--- a/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi.h
+++ b/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi.h
@@ -15,7 +15,7 @@ extern "C" {
 // is undetermined).
 #define impl_mask 0x1
 #define op_mask 0x1
-#define mode_mask 0x7
+#define mode_mask 0xF
 #define key_len_mask 0x7
 #define rcon_mask 0xFF
 #define round_mask 0xF
@@ -25,7 +25,8 @@ extern "C" {
  *
  * @param  impl_i    Select reference impl.: 0 = C model, 1 = OpenSSL/BoringSSL
  * @param  op_i      Operation: 0 = encrypt, 1 = decrypt
- * @param  mode_i    Cipher mode: 3'b001 = ECB, 3'b010 = CBC, 3'b100 = CTR
+ * @param  mode_i    Cipher mode: 4'b0001 = ECB, 4'b0010 = CBC, 4'b0100 = CTR,
+ *                   4'b1000 = NONE
  * @param  iv_i      Initialization vector: 2D matrix (3D packed array in SV)
  * @param  key_len_i Key length: 3'b001 = 128b, 3'b010 = 192b, 3'b100 = 256b
  * @param  key_i     Full input key, 1D array of words (2D packed array in SV)
@@ -43,7 +44,8 @@ void c_dpi_aes_crypt_block(const unsigned char impl_i, const unsigned char op_i,
  *
  * @param  impl_i    Select reference impl.: 0 = C model, 1 = OpenSSL/BoringSSL
  * @param  op_i      Operation: 0 = encrypt, 1 = decrypt
- * @param  mode_i    Cipher mode: 3'b001 = ECB, 3'b010 = CBC, 3'b100 = CTR
+ * @param  mode_i    Cipher mode: 4'b0001 = ECB, 4'b0010 = CBC, 4'b0100 = CTR,
+ *                   4'b1000 = NONE
  * @param  iv_i      Initialization vector: 1D array of words (2D packed array
  *                   in SV)
  * @param  key_len_i Key length: 3'b001 = 128b, 3'b010 = 192b, 3'b100 = 256b

--- a/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi_pkg.sv
+++ b/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi_pkg.sv
@@ -9,7 +9,8 @@ package aes_model_dpi_pkg;
   import "DPI-C" context function void c_dpi_aes_crypt_block(
     input  bit                impl_i,    // 0 = C model, 1 = OpenSSL/BoringSSL
     input  bit                op_i,      // 0 = encrypt, 1 = decrypt
-    input  bit          [2:0] mode_i,    // 3'b001 = ECB, 3'b010 = CBC, 3'b100 = CTR
+    input  bit          [3:0] mode_i,    // 4'b0001 = ECB, 4'b0010 = CBC, 4'b0100 = CTR,
+                                         // 4'b1000 = NONE
     input  bit[3:0][3:0][7:0] iv_i,
     input  bit          [2:0] key_len_i, // 3'b001 = 128b, 3'b010 = 192b, 3'b100 = 256b
     input  bit    [7:0][31:0] key_i,
@@ -20,7 +21,8 @@ package aes_model_dpi_pkg;
   import "DPI-C" context function void c_dpi_aes_crypt_message(
     input  bit              impl_i,    // 0 = C model, 1 = OpenSSL/BoringSSL
     input  bit              op_i,      // 0 = encrypt, 1 = decrypt
-    input  bit        [2:0] mode_i,    // 3'b001 = ECB, 3'b010 = CBC, 3'b100 = CTR
+    input  bit        [3:0] mode_i,    // 4'b0001 = ECB, 4'b0010 = CBC, 4'b0100 = CTR,
+                                       // 4'b1000 = NONE
     input  bit  [3:0][31:0] iv_i,
     input  bit        [2:0] key_len_i, // 3'b001 = 128b, 3'b010 = 192b, 3'b100 = 256b
     input  bit  [7:0][31:0] key_i,
@@ -61,7 +63,8 @@ package aes_model_dpi_pkg;
   function automatic void sv_dpi_aes_crypt_block(
     input  bit             impl_i,    // 0 = C model, 1 = OpenSSL/BoringSSL
     input  bit             op_i,      // 0 = encrypt, 1 = decrypt
-    input  bit       [2:0] mode_i,    // 3'b001 = ECB, 3'b010 = CBC, 3'b100 = CTR
+    input  bit       [3:0] mode_i,    // 4'b0001 = ECB, 4'b0010 = CBC, 4'b0100 = CTR,
+                                      // 4'b1000 = NONE
     input  bit [3:0][31:0] iv_i,
     input  bit       [2:0] key_len_i, // 3'b001 = 128b, 3'b010 = 192b, 3'b100 = 256b
     input  bit [7:0][31:0] key_i,

--- a/hw/ip/aes/dv/env/aes_scoreboard.sv
+++ b/hw/ip/aes/dv/env/aes_scoreboard.sv
@@ -88,19 +88,18 @@ class aes_scoreboard extends cip_base_scoreboard #(
       csr_name = csr.get_name();
       case (1)
         // add individual case item for each csr
-         (!uvm_re_match("ctrl", csr_name)): begin
-
-          input_item.manual_op = item.a_data[7];
-          input_item.key_len   = item.a_data[6:4];
+        (!uvm_re_match("ctrl_shadowed", csr_name)): begin
+          input_item.manual_op = item.a_data[8];
+          input_item.key_len   = item.a_data[7:5];
           `downcast(input_item.operation, item.a_data[0]);
           input_item.valid = 1'b1;
-           
-          case (item.a_data[3:1])
-            3'b001:  input_item.mode = AES_ECB;
-            3'b010:  input_item.mode = AES_CBC;
-            3'b100:  input_item.mode = AES_CTR;
-            default: input_item.mode = AES_ECB;
-          endcase // case item.a_data[3
+          case (item.a_data[4:1])
+            4'b0001:  input_item.mode = AES_ECB;
+            4'b0010:  input_item.mode = AES_CBC;
+            4'b0100:  input_item.mode = AES_CTR;
+            4'b1000:  input_item.mode = AES_NONE;
+            default:  input_item.mode = AES_ECB;
+          endcase // case item.a_data[4:1]
         end
 
         (!uvm_re_match("key*", csr_name)): begin
@@ -171,7 +170,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
               // verify that all 4 data_in and all 8 key are clean
               `uvm_info(`gfn, $sformatf("\n\t ----|data_inv_vld?  %b, key clean ? %b",
                         input_item.data_in_valid(), input_item.key_clean(1) ), UVM_HIGH)
-  
+
               if(input_item.data_in_valid() && input_item.key_clean(1)) begin
                 //clone and add to ref and rec data fifo
                 `uvm_info(`gfn, $sformatf("\n\t ----| OK to clone"), UVM_HIGH)
@@ -193,7 +192,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
               // verify that all 4 data_in and all 8 key  and all 4 IV are clean
               `uvm_info(`gfn, $sformatf("\n\t ----|data_inv_vld?  %b, key clean ? %b",
                                 input_item.data_in_valid(), input_item.key_clean(1) ), UVM_HIGH)
-  
+
               if(input_item.data_in_valid() && input_item.key_clean(1) && input_item.iv_clean(1)) begin
                 //clone and add to ref and rec data fifo
                 `uvm_info(`gfn, $sformatf("\n\t ----| OK to clone"), UVM_HIGH)
@@ -226,7 +225,6 @@ class aes_scoreboard extends cip_base_scoreboard #(
           end
         endcase // case (input_item.mode)
       end // if (input_item.valid)
-      
 
       // forward item to receive side
       if(ok_to_fwd ) begin

--- a/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
@@ -45,34 +45,34 @@ class aes_base_vseq extends cip_base_vseq #(
 
     // initialize control register
     aes_ctrl[0]    = 0;        // set to encryption
-    aes_ctrl[3:1] = aes_pkg::AES_ECB;   //3'b001;   // set to ECB MODE
-    aes_ctrl[6:4]  = aes_pkg::AES_128;   // set to 128b key
-    csr_wr(.csr(ral.ctrl), .value(aes_ctrl));
+    aes_ctrl[4:1]  = aes_pkg::AES_ECB;   // 4'b0001
+    aes_ctrl[7:5]  = aes_pkg::AES_128;   // set to 128b key
+    csr_wr(.csr(ral.ctrl_shadowed), .value(aes_ctrl), .en_shadow_wr(1'b1));
     csr_wr(.csr(ral.trigger), .value(aes_trigger));
   endtask
 
 
   virtual task set_operation(bit operation);
-    ral.ctrl.operation.set(operation);
-    csr_update(.csr(ral.ctrl));
+    ral.ctrl_shadowed.operation.set(operation);
+    csr_update(.csr(ral.ctrl_shadowed), .en_shadow_wr(1'b1));
   endtask // set_operation
 
 
-  virtual task set_mode(bit [2:0] mode);
-    ral.ctrl.mode.set(mode);
-    csr_update(.csr(ral.ctrl));
+  virtual task set_mode(bit [3:0] mode);
+    ral.ctrl_shadowed.mode.set(mode);
+    csr_update(.csr(ral.ctrl_shadowed), .en_shadow_wr(1'b1));
   endtask
 
 
   virtual task set_key_len(bit [2:0] key_len);
-    ral.ctrl.key_len.set(key_len);
-    csr_update(.csr(ral.ctrl));
+    ral.ctrl_shadowed.key_len.set(key_len);
+    csr_update(.csr(ral.ctrl_shadowed), .en_shadow_wr(1'b1));
   endtask
 
 
   virtual task set_manual_operation(bit manual_operation);
-    ral.ctrl.manual_operation.set(manual_operation);
-    csr_update(.csr(ral.ctrl));
+    ral.ctrl_shadowed.manual_operation.set(manual_operation);
+    csr_update(.csr(ral.ctrl_shadowed), .en_shadow_wr(1'b1));
   endtask
 
 

--- a/hw/ip/aes/dv/tb/tb.sv
+++ b/hw/ip/aes/dv/tb/tb.sv
@@ -16,6 +16,8 @@ module tb;
   wire clk, rst_n;
   wire devmode;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
+  prim_alert_pkg::alert_rx_t [aes_pkg::NumAlerts-1:0] alert_rx;
+  assign alert_rx[0] = 4'b0101;
 
   // interfaces
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
@@ -32,7 +34,10 @@ module tb;
     .idle_o               (           ),
 
     .tl_i                 (tl_if.h2d  ),
-    .tl_o                 (tl_if.d2h  )
+    .tl_o                 (tl_if.d2h  ),
+
+    .alert_rx_i           ( alert_rx  ),
+    .alert_tx_o           (           )
   );
 
   initial begin

--- a/hw/ip/aes/model/crypto.h
+++ b/hw/ip/aes/model/crypto.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef CRYPTO_H_
-#define CRYPTO_H_
+#ifndef OPENTITAN_HW_IP_AES_MODEL_CRYPTO_H_
+#define OPENTITAN_HW_IP_AES_MODEL_CRYPTO_H_
 
 /**
  * AES cipher mode
@@ -11,7 +11,8 @@
 typedef enum crypto_mode {
   kCryptoAesEcb = 1 << 0,
   kCryptoAesCbc = 1 << 1,
-  kCryptoAesCtr = 1 << 2
+  kCryptoAesCtr = 1 << 2,
+  kCryptoAesNone = 1 << 3
 } crypto_mode_t;
 
 /**
@@ -48,4 +49,4 @@ int crypto_decrypt(unsigned char *output, const unsigned char *iv,
                    const unsigned char *input, int input_len,
                    const unsigned char *key, int key_len, crypto_mode_t mode);
 
-#endif  // CRYPTO_H_
+#endif  // OPENTITAN_HW_IP_AES_MODEL_CRYPTO_H_

--- a/hw/ip/aes/rtl/aes.sv
+++ b/hw/ip/aes/rtl/aes.sv
@@ -28,10 +28,15 @@ module aes #(
 
   // Bus interface
   input  tlul_pkg::tl_h2d_t tl_i,
-  output tlul_pkg::tl_d2h_t tl_o
+  output tlul_pkg::tl_d2h_t tl_o,
+
+  // Alerts
+  input  prim_alert_pkg::alert_rx_t [aes_pkg::NumAlerts-1:0] alert_rx_i,
+  output prim_alert_pkg::alert_tx_t [aes_pkg::NumAlerts-1:0] alert_tx_o
 );
 
   import aes_reg_pkg::*;
+  import aes_pkg::*;
 
   aes_reg2hw_t reg2hw;
   aes_hw2reg_t hw2reg;
@@ -41,6 +46,8 @@ module aes #(
   logic [63:0] prng_data;
   logic        prng_reseed_req;
   logic        prng_reseed_ack;
+
+  logic [NumAlerts-1:0] alert;
 
   aes_reg_top u_reg (
     .clk_i,
@@ -65,6 +72,8 @@ module aes #(
     .prng_reseed_req_o ( prng_reseed_req ),
     .prng_reseed_ack_i ( prng_reseed_ack ),
 
+    .ctrl_err_o        ( alert[0]        ),
+
     .reg2hw,
     .hw2reg
   );
@@ -88,9 +97,22 @@ module aes #(
 
   assign idle_o = hw2reg.status.idle.d;
 
+  for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
+    prim_alert_sender #(
+      .AsyncOn(AlertAsyncOn[i])
+    ) i_prim_alert_sender (
+      .clk_i      ( clk_i         ),
+      .rst_ni     ( rst_ni        ),
+      .alert_i    ( alert[i]      ),
+      .alert_rx_i ( alert_rx_i[i] ),
+      .alert_tx_o ( alert_tx_o[i] )
+    );
+  end
+
   // All outputs should have a known value after reset
   `ASSERT_KNOWN(TlODValidKnown, tl_o.d_valid)
   `ASSERT_KNOWN(TlOAReadyKnown, tl_o.a_ready)
   `ASSERT_KNOWN(IdleKnown, idle_o)
+  `ASSERT_KNOWN(AlertTxKnown, alert_tx_o)
 
 endmodule

--- a/hw/ip/aes/rtl/aes_pkg.sv
+++ b/hw/ip/aes/rtl/aes_pkg.sv
@@ -6,15 +6,19 @@
 
 package aes_pkg;
 
+parameter int NumAlerts = 1;
+parameter logic [NumAlerts-1:0] AlertAsyncOn = NumAlerts'(1'b1);
+
 typedef enum logic {
   AES_ENC = 1'b0,
   AES_DEC = 1'b1
 } aes_op_e;
 
-typedef enum logic [2:0] {
-  AES_ECB = 3'b001,
-  AES_CBC = 3'b010,
-  AES_CTR = 3'b100
+typedef enum logic [3:0] {
+  AES_ECB  = 4'b0001,
+  AES_CBC  = 4'b0010,
+  AES_CTR  = 4'b0100,
+  AES_NONE = 4'b1000
 } aes_mode_e;
 
 typedef enum logic {
@@ -97,6 +101,20 @@ typedef enum logic [2:0] {
   ADD_SO_IV,
   ADD_SO_DIP
 } add_so_sel_e;
+
+typedef struct packed {
+  aes_op_e   operation;
+  aes_mode_e mode;
+  key_len_e  key_len;
+  logic      manual_operation;
+} ctrl_reg_t;
+
+parameter ctrl_reg_t CTRL_RESET = '{
+  operation:        AES_ENC,
+  mode:             AES_NONE,
+  key_len:          AES_128,
+  manual_operation: '0
+};
 
 // Multiplication by {02} (i.e. x) on GF(2^8)
 // with field generating polynomial {01}{1b} (9'h11b)

--- a/hw/ip/aes/rtl/aes_reg_pkg.sv
+++ b/hw/ip/aes/rtl/aes_reg_pkg.sv
@@ -38,20 +38,24 @@ package aes_reg_pkg;
     struct packed {
       logic        q;
       logic        qe;
+      logic        re;
     } operation;
     struct packed {
-      logic [2:0]  q;
+      logic [3:0]  q;
       logic        qe;
+      logic        re;
     } mode;
     struct packed {
       logic [2:0]  q;
       logic        qe;
+      logic        re;
     } key_len;
     struct packed {
       logic        q;
       logic        qe;
+      logic        re;
     } manual_operation;
-  } aes_reg2hw_ctrl_reg_t;
+  } aes_reg2hw_ctrl_shadowed_reg_t;
 
   typedef struct packed {
     struct packed {
@@ -97,7 +101,7 @@ package aes_reg_pkg;
       logic        d;
     } operation;
     struct packed {
-      logic [2:0]  d;
+      logic [3:0]  d;
     } mode;
     struct packed {
       logic [2:0]  d;
@@ -105,7 +109,7 @@ package aes_reg_pkg;
     struct packed {
       logic        d;
     } manual_operation;
-  } aes_hw2reg_ctrl_reg_t;
+  } aes_hw2reg_ctrl_shadowed_reg_t;
 
   typedef struct packed {
     struct packed {
@@ -158,11 +162,11 @@ package aes_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    aes_reg2hw_key_mreg_t [7:0] key; // [677:414]
-    aes_reg2hw_iv_mreg_t [3:0] iv; // [413:282]
-    aes_reg2hw_data_in_mreg_t [3:0] data_in; // [281:150]
-    aes_reg2hw_data_out_mreg_t [3:0] data_out; // [149:18]
-    aes_reg2hw_ctrl_reg_t ctrl; // [17:6]
+    aes_reg2hw_key_mreg_t [7:0] key; // [678:415]
+    aes_reg2hw_iv_mreg_t [3:0] iv; // [414:283]
+    aes_reg2hw_data_in_mreg_t [3:0] data_in; // [282:151]
+    aes_reg2hw_data_out_mreg_t [3:0] data_out; // [150:19]
+    aes_reg2hw_ctrl_shadowed_reg_t ctrl_shadowed; // [18:6]
     aes_reg2hw_trigger_reg_t trigger; // [5:0]
   } aes_reg2hw_t;
 
@@ -170,11 +174,11 @@ package aes_reg_pkg;
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    aes_hw2reg_key_mreg_t [7:0] key; // [671:416]
-    aes_hw2reg_iv_mreg_t [3:0] iv; // [415:288]
-    aes_hw2reg_data_in_mreg_t [3:0] data_in; // [287:156]
-    aes_hw2reg_data_out_mreg_t [3:0] data_out; // [155:28]
-    aes_hw2reg_ctrl_reg_t ctrl; // [27:16]
+    aes_hw2reg_key_mreg_t [7:0] key; // [672:417]
+    aes_hw2reg_iv_mreg_t [3:0] iv; // [416:289]
+    aes_hw2reg_data_in_mreg_t [3:0] data_in; // [288:157]
+    aes_hw2reg_data_out_mreg_t [3:0] data_out; // [156:29]
+    aes_hw2reg_ctrl_shadowed_reg_t ctrl_shadowed; // [28:16]
     aes_hw2reg_trigger_reg_t trigger; // [15:10]
     aes_hw2reg_status_reg_t status; // [9:10]
   } aes_hw2reg_t;
@@ -200,7 +204,7 @@ package aes_reg_pkg;
   parameter logic [6:0] AES_DATA_OUT1_OFFSET = 7'h 44;
   parameter logic [6:0] AES_DATA_OUT2_OFFSET = 7'h 48;
   parameter logic [6:0] AES_DATA_OUT3_OFFSET = 7'h 4c;
-  parameter logic [6:0] AES_CTRL_OFFSET = 7'h 50;
+  parameter logic [6:0] AES_CTRL_SHADOWED_OFFSET = 7'h 50;
   parameter logic [6:0] AES_TRIGGER_OFFSET = 7'h 54;
   parameter logic [6:0] AES_STATUS_OFFSET = 7'h 58;
 
@@ -227,7 +231,7 @@ package aes_reg_pkg;
     AES_DATA_OUT1,
     AES_DATA_OUT2,
     AES_DATA_OUT3,
-    AES_CTRL,
+    AES_CTRL_SHADOWED,
     AES_TRIGGER,
     AES_STATUS
   } aes_id_e;
@@ -254,7 +258,7 @@ package aes_reg_pkg;
     4'b 1111, // index[17] AES_DATA_OUT1
     4'b 1111, // index[18] AES_DATA_OUT2
     4'b 1111, // index[19] AES_DATA_OUT3
-    4'b 0001, // index[20] AES_CTRL
+    4'b 0011, // index[20] AES_CTRL_SHADOWED
     4'b 0001, // index[21] AES_TRIGGER
     4'b 0001  // index[22] AES_STATUS
   };

--- a/hw/ip/aes/rtl/aes_reg_top.sv
+++ b/hw/ip/aes/rtl/aes_reg_top.sv
@@ -111,22 +111,22 @@ module aes_reg_top (
   logic data_out2_re;
   logic [31:0] data_out3_qs;
   logic data_out3_re;
-  logic ctrl_operation_qs;
-  logic ctrl_operation_wd;
-  logic ctrl_operation_we;
-  logic ctrl_operation_re;
-  logic [2:0] ctrl_mode_qs;
-  logic [2:0] ctrl_mode_wd;
-  logic ctrl_mode_we;
-  logic ctrl_mode_re;
-  logic [2:0] ctrl_key_len_qs;
-  logic [2:0] ctrl_key_len_wd;
-  logic ctrl_key_len_we;
-  logic ctrl_key_len_re;
-  logic ctrl_manual_operation_qs;
-  logic ctrl_manual_operation_wd;
-  logic ctrl_manual_operation_we;
-  logic ctrl_manual_operation_re;
+  logic ctrl_shadowed_operation_qs;
+  logic ctrl_shadowed_operation_wd;
+  logic ctrl_shadowed_operation_we;
+  logic ctrl_shadowed_operation_re;
+  logic [3:0] ctrl_shadowed_mode_qs;
+  logic [3:0] ctrl_shadowed_mode_wd;
+  logic ctrl_shadowed_mode_we;
+  logic ctrl_shadowed_mode_re;
+  logic [2:0] ctrl_shadowed_key_len_qs;
+  logic [2:0] ctrl_shadowed_key_len_wd;
+  logic ctrl_shadowed_key_len_we;
+  logic ctrl_shadowed_key_len_re;
+  logic ctrl_shadowed_manual_operation_qs;
+  logic ctrl_shadowed_manual_operation_wd;
+  logic ctrl_shadowed_manual_operation_we;
+  logic ctrl_shadowed_manual_operation_re;
   logic trigger_start_wd;
   logic trigger_start_we;
   logic trigger_key_clear_wd;
@@ -513,65 +513,65 @@ module aes_reg_top (
   );
 
 
-  // R[ctrl]: V(True)
+  // R[ctrl_shadowed]: V(True)
 
   //   F[operation]: 0:0
   prim_subreg_ext #(
     .DW    (1)
-  ) u_ctrl_operation (
-    .re     (ctrl_operation_re),
-    .we     (ctrl_operation_we),
-    .wd     (ctrl_operation_wd),
-    .d      (hw2reg.ctrl.operation.d),
-    .qre    (),
-    .qe     (reg2hw.ctrl.operation.qe),
-    .q      (reg2hw.ctrl.operation.q ),
-    .qs     (ctrl_operation_qs)
+  ) u_ctrl_shadowed_operation (
+    .re     (ctrl_shadowed_operation_re),
+    .we     (ctrl_shadowed_operation_we),
+    .wd     (ctrl_shadowed_operation_wd),
+    .d      (hw2reg.ctrl_shadowed.operation.d),
+    .qre    (reg2hw.ctrl_shadowed.operation.re),
+    .qe     (reg2hw.ctrl_shadowed.operation.qe),
+    .q      (reg2hw.ctrl_shadowed.operation.q ),
+    .qs     (ctrl_shadowed_operation_qs)
   );
 
 
-  //   F[mode]: 3:1
+  //   F[mode]: 4:1
+  prim_subreg_ext #(
+    .DW    (4)
+  ) u_ctrl_shadowed_mode (
+    .re     (ctrl_shadowed_mode_re),
+    .we     (ctrl_shadowed_mode_we),
+    .wd     (ctrl_shadowed_mode_wd),
+    .d      (hw2reg.ctrl_shadowed.mode.d),
+    .qre    (reg2hw.ctrl_shadowed.mode.re),
+    .qe     (reg2hw.ctrl_shadowed.mode.qe),
+    .q      (reg2hw.ctrl_shadowed.mode.q ),
+    .qs     (ctrl_shadowed_mode_qs)
+  );
+
+
+  //   F[key_len]: 7:5
   prim_subreg_ext #(
     .DW    (3)
-  ) u_ctrl_mode (
-    .re     (ctrl_mode_re),
-    .we     (ctrl_mode_we),
-    .wd     (ctrl_mode_wd),
-    .d      (hw2reg.ctrl.mode.d),
-    .qre    (),
-    .qe     (reg2hw.ctrl.mode.qe),
-    .q      (reg2hw.ctrl.mode.q ),
-    .qs     (ctrl_mode_qs)
+  ) u_ctrl_shadowed_key_len (
+    .re     (ctrl_shadowed_key_len_re),
+    .we     (ctrl_shadowed_key_len_we),
+    .wd     (ctrl_shadowed_key_len_wd),
+    .d      (hw2reg.ctrl_shadowed.key_len.d),
+    .qre    (reg2hw.ctrl_shadowed.key_len.re),
+    .qe     (reg2hw.ctrl_shadowed.key_len.qe),
+    .q      (reg2hw.ctrl_shadowed.key_len.q ),
+    .qs     (ctrl_shadowed_key_len_qs)
   );
 
 
-  //   F[key_len]: 6:4
-  prim_subreg_ext #(
-    .DW    (3)
-  ) u_ctrl_key_len (
-    .re     (ctrl_key_len_re),
-    .we     (ctrl_key_len_we),
-    .wd     (ctrl_key_len_wd),
-    .d      (hw2reg.ctrl.key_len.d),
-    .qre    (),
-    .qe     (reg2hw.ctrl.key_len.qe),
-    .q      (reg2hw.ctrl.key_len.q ),
-    .qs     (ctrl_key_len_qs)
-  );
-
-
-  //   F[manual_operation]: 7:7
+  //   F[manual_operation]: 8:8
   prim_subreg_ext #(
     .DW    (1)
-  ) u_ctrl_manual_operation (
-    .re     (ctrl_manual_operation_re),
-    .we     (ctrl_manual_operation_we),
-    .wd     (ctrl_manual_operation_wd),
-    .d      (hw2reg.ctrl.manual_operation.d),
-    .qre    (),
-    .qe     (reg2hw.ctrl.manual_operation.qe),
-    .q      (reg2hw.ctrl.manual_operation.q ),
-    .qs     (ctrl_manual_operation_qs)
+  ) u_ctrl_shadowed_manual_operation (
+    .re     (ctrl_shadowed_manual_operation_re),
+    .we     (ctrl_shadowed_manual_operation_we),
+    .wd     (ctrl_shadowed_manual_operation_wd),
+    .d      (hw2reg.ctrl_shadowed.manual_operation.d),
+    .qre    (reg2hw.ctrl_shadowed.manual_operation.re),
+    .qe     (reg2hw.ctrl_shadowed.manual_operation.qe),
+    .q      (reg2hw.ctrl_shadowed.manual_operation.q ),
+    .qs     (ctrl_shadowed_manual_operation_qs)
   );
 
 
@@ -854,7 +854,7 @@ module aes_reg_top (
     addr_hit[17] = (reg_addr == AES_DATA_OUT1_OFFSET);
     addr_hit[18] = (reg_addr == AES_DATA_OUT2_OFFSET);
     addr_hit[19] = (reg_addr == AES_DATA_OUT3_OFFSET);
-    addr_hit[20] = (reg_addr == AES_CTRL_OFFSET);
+    addr_hit[20] = (reg_addr == AES_CTRL_SHADOWED_OFFSET);
     addr_hit[21] = (reg_addr == AES_TRIGGER_OFFSET);
     addr_hit[22] = (reg_addr == AES_STATUS_OFFSET);
   end
@@ -945,21 +945,21 @@ module aes_reg_top (
 
   assign data_out3_re = addr_hit[19] && reg_re;
 
-  assign ctrl_operation_we = addr_hit[20] & reg_we & ~wr_err;
-  assign ctrl_operation_wd = reg_wdata[0];
-  assign ctrl_operation_re = addr_hit[20] && reg_re;
+  assign ctrl_shadowed_operation_we = addr_hit[20] & reg_we & ~wr_err;
+  assign ctrl_shadowed_operation_wd = reg_wdata[0];
+  assign ctrl_shadowed_operation_re = addr_hit[20] && reg_re;
 
-  assign ctrl_mode_we = addr_hit[20] & reg_we & ~wr_err;
-  assign ctrl_mode_wd = reg_wdata[3:1];
-  assign ctrl_mode_re = addr_hit[20] && reg_re;
+  assign ctrl_shadowed_mode_we = addr_hit[20] & reg_we & ~wr_err;
+  assign ctrl_shadowed_mode_wd = reg_wdata[4:1];
+  assign ctrl_shadowed_mode_re = addr_hit[20] && reg_re;
 
-  assign ctrl_key_len_we = addr_hit[20] & reg_we & ~wr_err;
-  assign ctrl_key_len_wd = reg_wdata[6:4];
-  assign ctrl_key_len_re = addr_hit[20] && reg_re;
+  assign ctrl_shadowed_key_len_we = addr_hit[20] & reg_we & ~wr_err;
+  assign ctrl_shadowed_key_len_wd = reg_wdata[7:5];
+  assign ctrl_shadowed_key_len_re = addr_hit[20] && reg_re;
 
-  assign ctrl_manual_operation_we = addr_hit[20] & reg_we & ~wr_err;
-  assign ctrl_manual_operation_wd = reg_wdata[7];
-  assign ctrl_manual_operation_re = addr_hit[20] && reg_re;
+  assign ctrl_shadowed_manual_operation_we = addr_hit[20] & reg_we & ~wr_err;
+  assign ctrl_shadowed_manual_operation_wd = reg_wdata[8];
+  assign ctrl_shadowed_manual_operation_re = addr_hit[20] && reg_re;
 
   assign trigger_start_we = addr_hit[21] & reg_we & ~wr_err;
   assign trigger_start_wd = reg_wdata[0];
@@ -1068,10 +1068,10 @@ module aes_reg_top (
       end
 
       addr_hit[20]: begin
-        reg_rdata_next[0] = ctrl_operation_qs;
-        reg_rdata_next[3:1] = ctrl_mode_qs;
-        reg_rdata_next[6:4] = ctrl_key_len_qs;
-        reg_rdata_next[7] = ctrl_manual_operation_qs;
+        reg_rdata_next[0] = ctrl_shadowed_operation_qs;
+        reg_rdata_next[4:1] = ctrl_shadowed_mode_qs;
+        reg_rdata_next[7:5] = ctrl_shadowed_key_len_qs;
+        reg_rdata_next[8] = ctrl_shadowed_manual_operation_qs;
       end
 
       addr_hit[21]: begin

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -723,7 +723,15 @@
       available_output_list: []
       available_inout_list: []
       interrupt_list: []
-      alert_list: []
+      alert_list:
+      [
+        {
+          name: ctrl_err
+          width: 1
+          type: alert
+          async: 0
+        }
+      ]
       wakeup_list: []
       scan: "false"
       scan_reset: "false"
@@ -3278,11 +3286,19 @@
   ]
   alert_module:
   [
+    aes
     hmac
     otbn
   ]
   alert:
   [
+    {
+      name: aes_ctrl_err
+      width: 1
+      type: alert
+      async: 0
+      module_name: aes
+    }
     {
       name: hmac_msg_push_sha_disabled
       width: 1

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -377,7 +377,7 @@
   // ===== ALERT HANDLER ======================================================
   // list all modules that expose alerts
   // first item goes to LSB of the alert source
-  alert_module: [ "hmac", "otbn" ]
+  alert_module: [ "aes", "hmac", "otbn" ]
 
   // generated list of alerts:
   alert: [

--- a/hw/top_earlgrey/ip/alert_handler/data/autogen/alert_handler.hjson
+++ b/hw/top_earlgrey/ip/alert_handler/data/autogen/alert_handler.hjson
@@ -30,7 +30,7 @@
     { name: "NAlerts",
       desc: "Number of peripheral inputs",
       type: "int",
-      default: "4",
+      default: "5",
       local: "true"
     },
     { name: "EscCntDw",
@@ -54,7 +54,7 @@
     { name: "AsyncOn",
       desc: "Number of peripheral outputs",
       type: "logic [NAlerts-1:0]",
-      default: "4'b0000",
+      default: "5'b00000",
       local: "true"
     },
     { name: "N_CLASSES",

--- a/hw/top_earlgrey/ip/alert_handler/dv/alert_handler_env_pkg__params.sv
+++ b/hw/top_earlgrey/ip/alert_handler/dv/alert_handler_env_pkg__params.sv
@@ -10,5 +10,5 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-parameter uint NUM_ALERTS = 4;
-parameter bit [NUM_ALERTS-1:0] ASYNC_ON = 4'b0000;
+parameter uint NUM_ALERTS = 5;
+parameter bit [NUM_ALERTS-1:0] ASYNC_ON = 5'b00000;

--- a/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_pkg.sv
@@ -7,11 +7,11 @@
 package alert_handler_reg_pkg;
 
   // Param list
-  parameter int NAlerts = 4;
+  parameter int NAlerts = 5;
   parameter int EscCntDw = 32;
   parameter int AccuCntDw = 16;
   parameter int LfsrSeed = 2147483647;
-  parameter logic [NAlerts-1:0] AsyncOn = 4'b0000;
+  parameter logic [NAlerts-1:0] AsyncOn = 5'b00000;
   parameter int N_CLASSES = 4;
   parameter int N_ESC_SEV = 4;
   parameter int N_PHASES = 4;
@@ -455,14 +455,14 @@ package alert_handler_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    alert_handler_reg2hw_intr_state_reg_t intr_state; // [840:837]
-    alert_handler_reg2hw_intr_enable_reg_t intr_enable; // [836:833]
-    alert_handler_reg2hw_intr_test_reg_t intr_test; // [832:825]
-    alert_handler_reg2hw_regen_reg_t regen; // [824:824]
-    alert_handler_reg2hw_ping_timeout_cyc_reg_t ping_timeout_cyc; // [823:800]
-    alert_handler_reg2hw_alert_en_mreg_t [3:0] alert_en; // [799:796]
-    alert_handler_reg2hw_alert_class_mreg_t [3:0] alert_class; // [795:788]
-    alert_handler_reg2hw_alert_cause_mreg_t [3:0] alert_cause; // [787:784]
+    alert_handler_reg2hw_intr_state_reg_t intr_state; // [844:841]
+    alert_handler_reg2hw_intr_enable_reg_t intr_enable; // [840:837]
+    alert_handler_reg2hw_intr_test_reg_t intr_test; // [836:829]
+    alert_handler_reg2hw_regen_reg_t regen; // [828:828]
+    alert_handler_reg2hw_ping_timeout_cyc_reg_t ping_timeout_cyc; // [827:804]
+    alert_handler_reg2hw_alert_en_mreg_t [4:0] alert_en; // [803:799]
+    alert_handler_reg2hw_alert_class_mreg_t [4:0] alert_class; // [798:789]
+    alert_handler_reg2hw_alert_cause_mreg_t [4:0] alert_cause; // [788:784]
     alert_handler_reg2hw_loc_alert_en_mreg_t [3:0] loc_alert_en; // [783:780]
     alert_handler_reg2hw_loc_alert_class_mreg_t [3:0] loc_alert_class; // [779:772]
     alert_handler_reg2hw_loc_alert_cause_mreg_t [3:0] loc_alert_cause; // [771:768]
@@ -504,8 +504,8 @@ package alert_handler_reg_pkg;
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    alert_handler_hw2reg_intr_state_reg_t intr_state; // [235:232]
-    alert_handler_hw2reg_alert_cause_mreg_t [3:0] alert_cause; // [231:224]
+    alert_handler_hw2reg_intr_state_reg_t intr_state; // [237:234]
+    alert_handler_hw2reg_alert_cause_mreg_t [4:0] alert_cause; // [233:224]
     alert_handler_hw2reg_loc_alert_cause_mreg_t [3:0] loc_alert_cause; // [223:216]
     alert_handler_hw2reg_classa_clren_reg_t classa_clren; // [215:216]
     alert_handler_hw2reg_classa_accum_cnt_reg_t classa_accum_cnt; // [215:216]
@@ -658,7 +658,7 @@ package alert_handler_reg_pkg;
     4'b 0001, // index[ 3] ALERT_HANDLER_REGEN
     4'b 0111, // index[ 4] ALERT_HANDLER_PING_TIMEOUT_CYC
     4'b 0001, // index[ 5] ALERT_HANDLER_ALERT_EN
-    4'b 0001, // index[ 6] ALERT_HANDLER_ALERT_CLASS
+    4'b 0011, // index[ 6] ALERT_HANDLER_ALERT_CLASS
     4'b 0001, // index[ 7] ALERT_HANDLER_ALERT_CAUSE
     4'b 0001, // index[ 8] ALERT_HANDLER_LOC_ALERT_EN
     4'b 0001, // index[ 9] ALERT_HANDLER_LOC_ALERT_CLASS

--- a/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_top.sv
+++ b/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_top.sv
@@ -121,6 +121,9 @@ module alert_handler_reg_top (
   logic alert_en_en_a3_qs;
   logic alert_en_en_a3_wd;
   logic alert_en_en_a3_we;
+  logic alert_en_en_a4_qs;
+  logic alert_en_en_a4_wd;
+  logic alert_en_en_a4_we;
   logic [1:0] alert_class_class_a0_qs;
   logic [1:0] alert_class_class_a0_wd;
   logic alert_class_class_a0_we;
@@ -133,6 +136,9 @@ module alert_handler_reg_top (
   logic [1:0] alert_class_class_a3_qs;
   logic [1:0] alert_class_class_a3_wd;
   logic alert_class_class_a3_we;
+  logic [1:0] alert_class_class_a4_qs;
+  logic [1:0] alert_class_class_a4_wd;
+  logic alert_class_class_a4_we;
   logic alert_cause_a0_qs;
   logic alert_cause_a0_wd;
   logic alert_cause_a0_we;
@@ -145,6 +151,9 @@ module alert_handler_reg_top (
   logic alert_cause_a3_qs;
   logic alert_cause_a3_wd;
   logic alert_cause_a3_we;
+  logic alert_cause_a4_qs;
+  logic alert_cause_a4_wd;
+  logic alert_cause_a4_we;
   logic loc_alert_en_en_la0_qs;
   logic loc_alert_en_en_la0_wd;
   logic loc_alert_en_en_la0_we;
@@ -855,6 +864,32 @@ module alert_handler_reg_top (
   );
 
 
+  // F[en_a4]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_alert_en_en_a4 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (alert_en_en_a4_we & regen_qs),
+    .wd     (alert_en_en_a4_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.alert_en[4].q ),
+
+    // to register interface (read)
+    .qs     (alert_en_en_a4_qs)
+  );
+
+
 
 
   // Subregister 0 of Multireg alert_class
@@ -964,6 +999,32 @@ module alert_handler_reg_top (
   );
 
 
+  // F[class_a4]: 9:8
+  prim_subreg #(
+    .DW      (2),
+    .SWACCESS("RW"),
+    .RESVAL  (2'h0)
+  ) u_alert_class_class_a4 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (alert_class_class_a4_we & regen_qs),
+    .wd     (alert_class_class_a4_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.alert_class[4].q ),
+
+    // to register interface (read)
+    .qs     (alert_class_class_a4_qs)
+  );
+
+
 
 
   // Subregister 0 of Multireg alert_cause
@@ -1070,6 +1131,32 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_cause_a3_qs)
+  );
+
+
+  // F[a4]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("W1C"),
+    .RESVAL  (1'h0)
+  ) u_alert_cause_a4 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (alert_cause_a4_we),
+    .wd     (alert_cause_a4_wd),
+
+    // from internal hardware
+    .de     (hw2reg.alert_cause[4].de),
+    .d      (hw2reg.alert_cause[4].d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.alert_cause[4].q ),
+
+    // to register interface (read)
+    .qs     (alert_cause_a4_qs)
   );
 
 
@@ -3687,6 +3774,9 @@ module alert_handler_reg_top (
   assign alert_en_en_a3_we = addr_hit[5] & reg_we & ~wr_err;
   assign alert_en_en_a3_wd = reg_wdata[3];
 
+  assign alert_en_en_a4_we = addr_hit[5] & reg_we & ~wr_err;
+  assign alert_en_en_a4_wd = reg_wdata[4];
+
   assign alert_class_class_a0_we = addr_hit[6] & reg_we & ~wr_err;
   assign alert_class_class_a0_wd = reg_wdata[1:0];
 
@@ -3699,6 +3789,9 @@ module alert_handler_reg_top (
   assign alert_class_class_a3_we = addr_hit[6] & reg_we & ~wr_err;
   assign alert_class_class_a3_wd = reg_wdata[7:6];
 
+  assign alert_class_class_a4_we = addr_hit[6] & reg_we & ~wr_err;
+  assign alert_class_class_a4_wd = reg_wdata[9:8];
+
   assign alert_cause_a0_we = addr_hit[7] & reg_we & ~wr_err;
   assign alert_cause_a0_wd = reg_wdata[0];
 
@@ -3710,6 +3803,9 @@ module alert_handler_reg_top (
 
   assign alert_cause_a3_we = addr_hit[7] & reg_we & ~wr_err;
   assign alert_cause_a3_wd = reg_wdata[3];
+
+  assign alert_cause_a4_we = addr_hit[7] & reg_we & ~wr_err;
+  assign alert_cause_a4_wd = reg_wdata[4];
 
   assign loc_alert_en_en_la0_we = addr_hit[8] & reg_we & ~wr_err;
   assign loc_alert_en_en_la0_wd = reg_wdata[0];
@@ -4025,6 +4121,7 @@ module alert_handler_reg_top (
         reg_rdata_next[1] = alert_en_en_a1_qs;
         reg_rdata_next[2] = alert_en_en_a2_qs;
         reg_rdata_next[3] = alert_en_en_a3_qs;
+        reg_rdata_next[4] = alert_en_en_a4_qs;
       end
 
       addr_hit[6]: begin
@@ -4032,6 +4129,7 @@ module alert_handler_reg_top (
         reg_rdata_next[3:2] = alert_class_class_a1_qs;
         reg_rdata_next[5:4] = alert_class_class_a2_qs;
         reg_rdata_next[7:6] = alert_class_class_a3_qs;
+        reg_rdata_next[9:8] = alert_class_class_a4_qs;
       end
 
       addr_hit[7]: begin
@@ -4039,6 +4137,7 @@ module alert_handler_reg_top (
         reg_rdata_next[1] = alert_cause_a1_qs;
         reg_rdata_next[2] = alert_cause_a2_qs;
         reg_rdata_next[3] = alert_cause_a3_qs;
+        reg_rdata_next[4] = alert_cause_a4_qs;
       end
 
       addr_hit[8]: begin

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -646,6 +646,10 @@ module top_earlgrey #(
       .tl_i (tl_aes_d_h2d),
       .tl_o (tl_aes_d_d2h),
 
+      // [0]: ctrl_err
+      .alert_tx_o  ( alert_tx[0:0] ),
+      .alert_rx_i  ( alert_rx[0:0] ),
+
       // Inter-module signals
       .idle_o(aes_idle),
       .clk_i (clkmgr_clocks.clk_main_aes),
@@ -661,9 +665,9 @@ module top_earlgrey #(
       .intr_fifo_empty_o (intr_hmac_fifo_empty),
       .intr_hmac_err_o   (intr_hmac_hmac_err),
 
-      // [0]: msg_push_sha_disabled
-      .alert_tx_o  ( alert_tx[0:0] ),
-      .alert_rx_i  ( alert_rx[0:0] ),
+      // [1]: msg_push_sha_disabled
+      .alert_tx_o  ( alert_tx[1:1] ),
+      .alert_rx_i  ( alert_rx[1:1] ),
       .clk_i (clkmgr_clocks.clk_main_hmac),
       .rst_ni (rstmgr_resets.rst_sys_n)
   );
@@ -897,11 +901,11 @@ module top_earlgrey #(
       .intr_done_o (intr_otbn_done),
       .intr_err_o  (intr_otbn_err),
 
-      // [1]: imem_uncorrectable
-      // [2]: dmem_uncorrectable
-      // [3]: reg_uncorrectable
-      .alert_tx_o  ( alert_tx[3:1] ),
-      .alert_rx_i  ( alert_rx[3:1] ),
+      // [2]: imem_uncorrectable
+      // [3]: dmem_uncorrectable
+      // [4]: reg_uncorrectable
+      .alert_tx_o  ( alert_tx[4:2] ),
+      .alert_rx_i  ( alert_rx[4:2] ),
 
       // Inter-module signals
       .idle_o(),

--- a/sw/device/lib/aes.c
+++ b/sw/device/lib/aes.c
@@ -15,11 +15,15 @@
 #define AES_NUM_REGS_DATA 4
 
 void aes_init(aes_cfg_t aes_cfg) {
-  REG32(AES_CTRL(0)) =
-      (aes_cfg.operation << AES_CTRL_OPERATION) |
-      ((aes_cfg.mode & AES_CTRL_MODE_MASK) << AES_CTRL_MODE_OFFSET) |
-      ((aes_cfg.key_len & AES_CTRL_KEY_LEN_MASK) << AES_CTRL_KEY_LEN_OFFSET) |
-      (aes_cfg.manual_operation << AES_CTRL_MANUAL_OPERATION);
+  uint32_t cfg_val =
+      (aes_cfg.operation << AES_CTRL_SHADOWED_OPERATION) |
+      ((aes_cfg.mode & AES_CTRL_SHADOWED_MODE_MASK)
+       << AES_CTRL_SHADOWED_MODE_OFFSET) |
+      ((aes_cfg.key_len & AES_CTRL_SHADOWED_KEY_LEN_MASK)
+       << AES_CTRL_SHADOWED_KEY_LEN_OFFSET) |
+      (aes_cfg.manual_operation << AES_CTRL_SHADOWED_MANUAL_OPERATION);
+  REG32(AES_CTRL_SHADOWED(0)) = cfg_val;
+  REG32(AES_CTRL_SHADOWED(0)) = cfg_val;
 };
 
 void aes_key_put(const void *key, aes_key_len_t key_len) {
@@ -101,7 +105,9 @@ void aes_clear(void) {
   }
 
   // Disable autostart
-  REG32(AES_CTRL(0)) = 0x1u << AES_CTRL_MANUAL_OPERATION;
+  uint32_t cfg_val = 0x1u << AES_CTRL_SHADOWED_MANUAL_OPERATION;
+  REG32(AES_CTRL_SHADOWED(0)) = cfg_val;
+  REG32(AES_CTRL_SHADOWED(0)) = cfg_val;
 
   // Clear internal key and output registers
   REG32(AES_TRIGGER(0)) = (0x1u << AES_TRIGGER_KEY_CLEAR) |

--- a/sw/device/lib/aes.h
+++ b/sw/device/lib/aes.h
@@ -16,12 +16,14 @@ typedef enum aes_op { kAesEnc = 0, kAesDec = 1 } aes_op_t;
 
 /**
  * Supported AES block cipher modes: ECB, CBC, CTR. The hardware uses a one-hot
- * encoding.
+ * encoding. NONE is not a supported mode but the reset value of the hardware.
+ * The hardware resolves invalid mode values to NONE.
  */
 typedef enum aes_mode {
   kAesEcb = 1 << 0,
   kAesCbc = 1 << 1,
-  kAesCtr = 1 << 2
+  kAesCtr = 1 << 2,
+  kAesNone = 1 << 3
 } aes_mode_t;
 
 /**


### PR DESCRIPTION
This PR adds a shadow CTRL register according to @tjaychen's Shadow Register RFC discussed in lowRISC/OpenTitan#150.

More specifically, two more copies are added for the CTRL register: a shadow register and a staged register. An update to the CTRL register now always takes two subsequent writes. The first write goes into the staged register and the second potentially to the actual and the shadow register.
- If the content of the staged register and the value written to the actual register do not match, this causes an update error and triggers an alert. The register is not updated.
- If the contents of actual and shadow registers differ, this causes a storage error and triggers an alert.
- Invalid mode field values are resolved to the new reset value AES_NONE = 4'b1000.
- The cipher core is not allowed to start or finish unless the mode field is set to a valid value.

~What is missing is the adaption of the UVM-based DV infrastructure.~ The changes have been successfully tested using AES DV, my own Verilator framework and the aes_test.