### PR TITLE
[topgen] Fix relative paths in C header generation

### DIFF
--- a/util/topgen.py
+++ b/util/topgen.py
@@ -32,7 +32,7 @@ genhdr = '''// Copyright lowRISC contributors.
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
 '''
 
-SRCTREE_TOP = Path(__file__).parent.parent
+SRCTREE_TOP = Path(__file__).parent.parent.resolve()
 
 
 def generate_top(top, tpl_filename, **kwargs):
@@ -653,7 +653,7 @@ def main():
         # 'top_earlgrey.h.tpl' -> 'sw/autogen/top_earlgrey.h'
         cheader_path = render_template('top_%s.h',
                                        'sw/autogen',
-                                       c_gen_info=c_gen_info)
+                                       c_gen_info=c_gen_info).resolve()
 
         # Save the relative header path into `c_gen_info`
         rel_header_path = cheader_path.relative_to(SRCTREE_TOP)


### PR DESCRIPTION
The `README.md` file in `hw/top_earlgrey` recommends running topgen from
`hw/top_earlgrey`, which fails with this error message:

```
Traceback (most recent call last):
  File "../../util/topgen.py", line 676, in <module>
    main()
  File "../../util/topgen.py", line 659, in main
    rel_header_path = cheader_path.relative_to(SRCTREE_TOP)
  File "/usr/lib64/python3.8/pathlib.py", line 899, in relative_to
    raise ValueError("{!r} does not start with {!r}"
ValueError: 'sw/autogen/top_earlgrey.h' does not start with '../..'
```

In this case, `SRCTREE_TOP` resolves to `../..`, and `cheader_path` to
`sw/autogen/top_earlgrey.h`. The `relative_to` comparision, however,
needs an absolute path to work properly, as does `subprocess.run()`
below.

Bug report by Stefan Wallentowitz.