### PR TITLE
[sw, tock] Refactor uart driver to use DIFs

### DIFF
--- a/sw/device/tock/chips/earlgrey/src/uart.rs
+++ b/sw/device/tock/chips/earlgrey/src/uart.rs
@@ -1,13 +1,7 @@
-use tock::kernel;
-
-use kernel::common::StaticRef;
-use opentitan_common::uart::{Uart, UartRegisters};
+use opentitan_common::uart::Uart;
 
 use crate::chip;
 use crate::chip_config::DEVICE_CONFIG;
 
 pub static mut UART0_BAUDRATE: u32 = DEVICE_CONFIG.uart_baudrate;
-pub static mut UART0: Uart = Uart::new(UART0_BASE, chip::CHIP_FREQ);
-
-const UART0_BASE: StaticRef<UartRegisters> =
-    unsafe { StaticRef::new(0x4000_0000 as *const UartRegisters) };
+pub static mut UART0: Uart = Uart::new(0x4000_0000, chip::CHIP_FREQ);

--- a/sw/device/tock/chips/opentitan_common/src/uart.rs
+++ b/sw/device/tock/chips/opentitan_common/src/uart.rs
@@ -1,107 +1,19 @@
 //! UART driver.
 
-use tock::kernel;
-
 use core::cell::Cell;
 
-use kernel::common::cells::OptionalCell;
-use kernel::common::cells::TakeCell;
-use kernel::common::registers::{
-    register_bitfields, register_structs, ReadOnly, ReadWrite, WriteOnly,
-};
-use kernel::common::StaticRef;
-use kernel::hil;
-use kernel::ReturnCode;
+use tock::kernel::common::cells::OptionalCell;
+use tock::kernel::common::cells::TakeCell;
+use tock::kernel::hil;
+use tock::kernel::ReturnCode;
 
-register_structs! {
-    pub UartRegisters {
-        (0x000 => intr_state: ReadWrite<u32, intr::Register>),
-        (0x004 => intr_enable: ReadWrite<u32, intr::Register>),
-        (0x008 => intr_test: ReadWrite<u32, intr::Register>),
-        /// UART control register
-        (0x00c => ctrl: ReadWrite<u32, ctrl::Register>),
-        /// UART live status register
-        (0x010 => status: ReadOnly<u32, status::Register>),
-        /// UART read data)
-        (0x014 => rdata: ReadOnly<u32, rdata::Register>),
-        /// UART write data
-        (0x018 => wdata: WriteOnly<u32, wdata::Register>),
-        /// UART FIFO control register")
-        (0x01c => fifo_ctrl: ReadWrite<u32, fifo_ctrl::Register>),
-        /// UART FIFO status register
-        (0x020 => fifo_status: ReadWrite<u32, fifo_status::Register>),
-        /// TX pin override control. Gives direct SW control over TX pin state
-        (0x024 => ovrd: ReadWrite<u32, ovrd::Register>),
-        /// UART oversampled values
-        (0x028 => val: ReadWrite<u32, val::Register>),
-        /// UART RX timeout control
-        (0x02c => timeout_ctrl: ReadWrite<u32, timeout_ctrl::Register>),
-        (0x030 => @END),
-    }
-}
-
-register_bitfields![u32,
-    intr [
-        tx_watermark OFFSET(0) NUMBITS(1) [],
-        rx_watermark OFFSET(1) NUMBITS(1) [],
-        tx_empty OFFSET(2) NUMBITS(1) [],
-        rx_overflow OFFSET(3) NUMBITS(1) [],
-        rx_frame_err OFFSET(4) NUMBITS(1) [],
-        rx_break_err OFFSET(5) NUMBITS(1) [],
-        rx_timeout OFFSET(6) NUMBITS(1) [],
-        rx_parity_err OFFSET(7) NUMBITS(1) []
-    ],
-    ctrl [
-        tx OFFSET(0) NUMBITS(1) [],
-        rx OFFSET(1) NUMBITS(1) [],
-        nf OFFSET(2) NUMBITS(1) [],
-        slpbk OFFSET(4) NUMBITS(1) [],
-        llpbk OFFSET(5) NUMBITS(1) [],
-        parity_en OFFSET(6) NUMBITS(1) [],
-        parity_odd OFFSET(7) NUMBITS(1) [],
-        rxblvl OFFSET(8) NUMBITS(2) [],
-        nco OFFSET(16) NUMBITS(16) []
-    ],
-    status [
-        txfull OFFSET(0) NUMBITS(1) [],
-        rxfull OFFSET(1) NUMBITS(1) [],
-        txempty OFFSET(2) NUMBITS(1) [],
-        txidle OFFSET(3) NUMBITS(1) [],
-        rxidle OFFSET(4) NUMBITS(1) [],
-        rxempty OFFSET(5) NUMBITS(1) []
-    ],
-    rdata [
-        data OFFSET(0) NUMBITS(8) []
-    ],
-    wdata [
-        data OFFSET(0) NUMBITS(8) []
-    ],
-    fifo_ctrl [
-        rxrst OFFSET(0) NUMBITS(1) [],
-        txrst OFFSET(1) NUMBITS(1) [],
-        rxilvl OFFSET(2) NUMBITS(2) [],
-        txilvl OFFSET(5) NUMBITS(2) []
-    ],
-    fifo_status [
-        txlvl OFFSET(0) NUMBITS(5) [],
-        rxlvl OFFSET(16) NUMBITS(5) []
-    ],
-    ovrd [
-        txen OFFSET(0) NUMBITS(1) [],
-        txval OFFSET(1) NUMBITS(1) []
-    ],
-    val [
-        rx OFFSET(0) NUMBITS(16) []
-    ],
-    timeout_ctrl [
-        val OFFSET(0) NUMBITS(23) [],
-        en OFFSET(31) NUMBITS(1) []
-    ]
-];
+use dif::dif_bind::*;
+use dif::riscv32_c_types::*;
 
 pub struct Uart<'a> {
-    registers: StaticRef<UartRegisters>,
+    base_addr: u32,
     clock_frequency: u32,
+    dif_uart: OptionalCell<dif_uart_t>,
     tx_client: OptionalCell<&'a dyn hil::uart::TransmitClient>,
     rx_client: OptionalCell<&'a dyn hil::uart::ReceiveClient>,
     tx_buffer: TakeCell<'static, [u8]>,
@@ -115,10 +27,11 @@ pub struct UartParams {
 }
 
 impl Uart<'a> {
-    pub const fn new(base: StaticRef<UartRegisters>, clock_frequency: u32) -> Uart<'a> {
+    pub const fn new(base_addr: u32, clock_frequency: u32) -> Uart<'a> {
         Uart {
-            registers: base,
+            base_addr: base_addr,
             clock_frequency: clock_frequency,
+            dif_uart: OptionalCell::empty(),
             tx_client: OptionalCell::empty(),
             rx_client: OptionalCell::empty(),
             tx_buffer: TakeCell::empty(),
@@ -127,90 +40,67 @@ impl Uart<'a> {
         }
     }
 
-    fn set_baud_rate(&self, baud_rate: u32) {
-        let regs = self.registers;
-        let uart_ctrl_nco = ((baud_rate as u64) << 20) / self.clock_frequency as u64;
-
-        regs.ctrl
-            .write(ctrl::nco.val((uart_ctrl_nco & 0xffff) as u32));
-        regs.ctrl.modify(ctrl::tx::SET + ctrl::rx::SET);
-
-        regs.fifo_ctrl
-            .write(fifo_ctrl::rxrst::SET + fifo_ctrl::txrst::SET);
+    fn interrupt_enable(
+        &self,
+        interrupt: dif_uart_interrupt_t,
+        enable: dif_uart_enable_t,
+    ) -> ReturnCode {
+        self.dif_uart.map_or(ReturnCode::FAIL, |uart| unsafe {
+            match dif_uart_irq_enable(uart, interrupt, enable) {
+                kDifUartOk => ReturnCode::SUCCESS,
+                _ => ReturnCode::FAIL,
+            }
+        })
     }
 
-    fn enable_tx_interrupt(&self) {
-        let regs = self.registers;
-
-        regs.intr_enable.modify(intr::tx_empty::SET);
+    fn bytes_send(&self, data: *const u8, num_to_send: usize) -> Result<usize, ReturnCode> {
+        self.dif_uart.map_or(Err(ReturnCode::FAIL), |uart| unsafe {
+            let mut bytes_sent: usize = 0;
+            match dif_uart_bytes_send(uart, data, num_to_send, &mut bytes_sent) {
+                kDifUartOk => Ok(bytes_sent),
+                _ => Err(ReturnCode::FAIL),
+            }
+        })
     }
 
-    fn disable_tx_interrupt(&self) {
-        let regs = self.registers;
-
-        regs.intr_enable.modify(intr::tx_empty::CLEAR);
-        // Clear the interrupt bit (by writing 1), if it happens to be set
-        regs.intr_state.write(intr::tx_empty::SET);
+    fn interrupt_state(&self, interrupt: dif_uart_interrupt_t) -> Result<bool, ReturnCode> {
+        self.dif_uart.map_or(Err(ReturnCode::FAIL), |uart| unsafe {
+            let mut state: dif_uart_enable_t = kDifUartDisable;
+            match dif_uart_irq_state_get(uart, interrupt, &mut state) {
+                kDifUartOk => Ok(state == kDifUartEnable),
+                _ => Err(ReturnCode::FAIL),
+            }
+        })
     }
 
-    fn enable_rx_interrupt(&self) {
-        let regs = self.registers;
-
-        // Generate an interrupt if we get any value in the RX buffer
-        regs.intr_enable.modify(intr::rx_watermark::SET);
-        regs.fifo_ctrl.write(fifo_ctrl::rxilvl.val(0 as u32));
+    fn interrupt_clear(&self, interrupt: dif_uart_interrupt_t) -> ReturnCode {
+        self.dif_uart.map_or(ReturnCode::FAIL, |uart| unsafe {
+            match dif_uart_irq_state_clear(uart, interrupt) {
+                kDifUartOk => ReturnCode::SUCCESS,
+                _ => ReturnCode::FAIL,
+            }
+        })
     }
 
-    fn disable_rx_interrupt(&self) {
-        let regs = self.registers;
+    fn tx_buffer_process(&self) {
+        let mut total_bytes_sent = self.tx_index.get();
+        let total_bytes_to_send = self.tx_len.get();
 
-        // Generate an interrupt if we get any value in the RX buffer
-        regs.intr_enable.modify(intr::rx_watermark::CLEAR);
-
-        // Clear the interrupt bit (by writing 1), if it happens to be set
-        regs.intr_state.write(intr::rx_watermark::SET);
-    }
-
-    fn tx_progress(&self) {
-        let regs = self.registers;
-        let idx = self.tx_index.get();
-        let len = self.tx_len.get();
-
-        if idx < len {
+        if total_bytes_sent < total_bytes_to_send {
             self.tx_buffer.map(|tx_buf| {
-                let tx_len = len - idx;
+                let bytes_to_send = total_bytes_to_send - total_bytes_sent;
 
-                for i in 0..tx_len {
-                    if regs.status.is_set(status::txfull) {
-                        break;
+                match self.bytes_send(&tx_buf[total_bytes_sent], bytes_to_send) {
+                    Ok(bytes_sent) => {
+                        total_bytes_sent += bytes_sent;
+                        self.tx_index.set(total_bytes_sent)
                     }
-                    let tx_idx = idx + i;
-                    regs.wdata.write(wdata::data.val(tx_buf[tx_idx] as u32));
-                    self.tx_index.set(tx_idx + 1)
+                    Err(e) => (), // TODO - return error
                 }
             });
-
-            // If the FIFO started empty above, when the first character was written, it would have
-            // been immediately dispatched to the shift register, latching the TX_EMPTY state.
-            // That should be cleared before enabling the interrupt, so a subsequent empty state
-            // will latch the state transition again.
-            regs.intr_state.write(intr::tx_empty::SET);
-
-            // With data queued, (re)enable the TX interrupt if the FIFO is not empty
-            if !regs.status.is_set(status::txempty) {
-                self.enable_tx_interrupt();
-                if !regs.status.is_set(status::txempty) {
-                    // Assuming the FIFO stayed non-empty while the interrupt was being enabled,
-                    // our work here is done
-                    return;
-                } else {
-                    // Otherwise, turn off the interrupt and handle below
-                    self.disable_tx_interrupt();
-                }
-            }
         }
 
-        if self.tx_index.get() == self.tx_len.get() {
+        if total_bytes_sent == total_bytes_to_send {
             self.tx_client.map(|client| {
                 self.tx_buffer.take().map(|tx_buf| {
                     client.transmitted_buffer(tx_buf, self.tx_len.get(), ReturnCode::SUCCESS);
@@ -220,23 +110,29 @@ impl Uart<'a> {
     }
 
     pub fn handle_interrupt(&self) {
-        let regs = self.registers;
-        let intrs = regs.intr_state.extract();
-
-        if intrs.is_set(intr::tx_empty) {
-            self.disable_tx_interrupt();
-            self.tx_progress();
-        } else if intrs.is_set(intr::rx_watermark) {
-            self.disable_rx_interrupt();
-            // TODO: real RX processing
+        let interrupt = kDifUartInterruptTxWatermark;
+        match self.interrupt_state(interrupt) {
+            Ok(set) => {
+                if set {
+                    self.tx_buffer_process();
+                    self.interrupt_clear(interrupt); // TODO return this
+                    () // TODO - return error
+                }
+            }
+            Err(e) => (), // TODO - return error
         }
+
+        // TODO - let interrupt = kDifUartInterruptRxWatermark;
     }
 
     pub fn transmit_sync(&self, bytes: &[u8]) {
-        let regs = self.registers;
-        for b in bytes.iter() {
-            while regs.status.is_set(status::txfull) {}
-            regs.wdata.write(wdata::data.val(*b as u32));
+        for i in 0..bytes.len() {
+            // TODO - error codes (map_or)
+            self.dif_uart.map_or((), |uart| unsafe {
+                if dif_uart_byte_send_polled(uart, bytes[i]) != kDifUartOk {
+                    return (); // TODO - error/success
+                }
+            })
         }
     }
 }
@@ -246,15 +142,33 @@ impl hil::uart::Uart<'a> for Uart<'a> {}
 
 impl hil::uart::Configure for Uart<'a> {
     fn configure(&self, params: hil::uart::Parameters) -> ReturnCode {
-        let regs = self.registers;
-        // We can set the baud rate.
-        self.set_baud_rate(params.baud_rate);
+        let base_addr: mmio_region_t = mmio_region_t {
+            base: self.base_addr as *mut c_void,
+        };
 
-        regs.fifo_ctrl
-            .write(fifo_ctrl::rxrst::SET + fifo_ctrl::txrst::SET);
+        let mut config: dif_uart_config_t = dif_uart_config_t {
+            baudrate: params.baud_rate,
+            clk_freq_hz: self.clock_frequency,
+            parity_enable: kDifUartDisable,
+            parity: kDifUartParityEven,
+        };
 
-        // Disable all interrupts for now
-        regs.intr_enable.set(0 as u32);
+        let mut uart: dif_uart_t = Default::default();
+
+        unsafe {
+            match dif_uart_init(base_addr, &mut config, &mut uart) {
+                kDifUartOk => self.dif_uart.set(uart),
+                _ => return ReturnCode::FAIL,
+            }
+        }
+
+        if self.interrupt_enable(kDifUartInterruptTxWatermark, kDifUartEnable)
+            != ReturnCode::SUCCESS
+        {
+            return ReturnCode::FAIL;
+        }
+
+        // TODO - kDifUartInterruptRxWatermark
 
         ReturnCode::SUCCESS
     }
@@ -280,7 +194,7 @@ impl hil::uart::Transmit<'a> for Uart<'a> {
             self.tx_len.set(tx_len);
             self.tx_index.set(0);
 
-            self.tx_progress();
+            self.tx_buffer_process();
             (ReturnCode::SUCCESS, None)
         }
     }
@@ -305,8 +219,6 @@ impl hil::uart::Receive<'a> for Uart<'a> {
         _rx_buffer: &'static mut [u8],
         _rx_len: usize,
     ) -> (ReturnCode, Option<&'static mut [u8]>) {
-        self.enable_rx_interrupt();
-
         (ReturnCode::FAIL, None)
     }
 
@@ -314,7 +226,7 @@ impl hil::uart::Receive<'a> for Uart<'a> {
         ReturnCode::FAIL
     }
 
-    fn receive_word(&self) -> kernel::ReturnCode {
+    fn receive_word(&self) -> ReturnCode {
         ReturnCode::FAIL
     }
 }

--- a/sw/device/tock/dif/build.rs
+++ b/sw/device/tock/dif/build.rs
@@ -32,7 +32,7 @@ fn main() {
 
     let out_dir = env::var("OUT_DIR").expect("no OUT_DIR env variable");
 
-    generate_bindings(&source_root, &build_root, &out_dir);
+    generate_bindings(&source_root, &out_dir);
 
     // Link against specified OT DIF libraries.
     let dif_path = Path::new(&build_root).join(DIF_RELATIVE_PATH);
@@ -58,13 +58,17 @@ fn libraries_link(path: &str, libs: &[&str]) {
     }
 }
 
-fn generate_bindings(source_root: &str, build_root: &str, out_dir: &str) {
+fn generate_bindings(source_root: &str, out_dir: &str) {
     let mut binding_builder = bindgen::builder()
         .raw_line("use riscv32_c_types;")
         .ctypes_prefix("riscv32_c_types")
         .clang_arg("--target=riscv32")
-        .clang_args(&["-I", source_root])
-        .clang_args(&["-I", build_root]);
+        .clang_args(&["-I", &source_root])
+        .derive_default(true)
+        .prepend_enum_name(false)
+        .rustfmt_bindings(true)
+        .size_t_is_usize(true)
+        .use_core();
 
     let dif_path = Path::new(&source_root).join(DIF_RELATIVE_PATH);
     let dif_build_meson = dif_path.join("meson.build");


### PR DESCRIPTION
This is a part of #2139 

This is my first take on using DIFs in Tock drivers. Please see commit descriptions for more information.

In general, I am not entirely sure whether `OptionalCell` is the best type to hold `dif_uart_t`.

There are also formatting warnings like:
`warning: constant in pattern kDifUartOk should have an upper case name`

Which we need to figure out how to handle (could be that we can easily do this in bindgen, but I couldn't find this option).