### PR TITLE
[doc] Update lint/style lint links on hardware dashboard

### DIFF
--- a/hw/_index.md
+++ b/hw/_index.md
@@ -20,6 +20,7 @@ Finally, we provide the same set of information for all available [top level des
 * [DV simulation summary results, with coverage (nightly)](https://reports.opentitan.org/hw/top_earlgrey/dv/summary.html)
 * FPV summary results (nightly) (TBD)
 * [Lint summary results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/lint/ascentlint/summary.html)
+* [Style lint summary results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/lint/veriblelint/summary.html)
 
 ## Comportable IPs
 
@@ -39,5 +40,6 @@ Finally, we provide the same set of information for all available [top level des
   * DV plan (TBD)
   * [DV simulation results, with coverage (nightly)](https://reports.opentitan.org/hw/top_earlgrey/dv/latest/results.html)
   * FPV results (nightly) (TBD)
-  * [Lint results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/lint/latest/results.html)
+  * [Lint results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/lint/ascentlint/latest/results.html)
+  * [Style lint results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/lint/veriblelint/latest/results.html)
   * [Synthesis results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/syn/latest/results.html)


### PR DESCRIPTION
This adds a link to the Verible style lint results summary to the hardware dashboard, and corrects the link for the AscentLint dashboard.

Signed-off-by: Michael Schaffner <msf@opentitan.org>