### PR TITLE
[openocd] Update rtos name to hwthread

### DIFF
--- a/util/openocd/target/lowrisc-earlgrey.cfg
+++ b/util/openocd/target/lowrisc-earlgrey.cfg
@@ -18,7 +18,7 @@ if { [info exists CPUTAPID ] } {
 
 jtag newtap $_CHIPNAME tap -irlen 5 -expected-id $_CPUTAPID
 set _TARGETNAME $_CHIPNAME.tap
-target create $_TARGETNAME.0 riscv -chain-position $_TARGETNAME -rtos riscv
+target create $_TARGETNAME.0 riscv -chain-position $_TARGETNAME -rtos hwthread
 
 # Configure work area in on-chip SRAM
 $_TARGETNAME.0 configure -work-area-phys 0x80000000 -work-area-size 1000 -work-area-backup 0


### PR DESCRIPTION
OpenOCD shows a warning that -rtos riscv is deprecated. Use suggested -rtos hwthread instead.

Signed-off-by: Maximilian Schiller <schiller.maxi@gmail.com>