### PR TITLE
[dv/alert_handler] clean up counter and adjust settings to increase cov

### DIFF
--- a/hw/dv/sv/alert_esc_agent/esc_monitor.sv
+++ b/hw/dv/sv/alert_esc_agent/esc_monitor.sv
@@ -65,6 +65,8 @@ class esc_monitor extends alert_esc_base_monitor;
         phase.raise_objection(this, $sformatf("%s objection raised", `gfn));
         req = alert_esc_seq_item::type_id::create("req");
         req.sig_cycle_cnt++;
+        if (cfg.vif.get_resp_p() == cfg.vif.get_resp_n()) req.esc_handshake_sta = EscIntFail;
+        else req.esc_handshake_sta = EscRespHi;
         @(cfg.vif.monitor_cb);
         if (cfg.vif.get_esc() === 1'b0) begin
           req.alert_esc_type = AlertEscPingTrans;
@@ -72,7 +74,6 @@ class esc_monitor extends alert_esc_base_monitor;
           alert_esc_port.write(req);
         end else begin
           req.alert_esc_type = AlertEscSigTrans;
-          req.esc_handshake_sta = EscRespHi;
 
           req.sig_cycle_cnt++;
           check_esc_resp(req);
@@ -143,6 +144,9 @@ class esc_monitor extends alert_esc_base_monitor;
         req.esc_handshake_sta = EscRespHi;
       end
     end
+
+    if (cfg.vif.get_resp_p() == cfg.vif.get_resp_n()) req.esc_handshake_sta = EscIntFail;
+
     if (do_wait_clk) begin
       @(cfg.vif.monitor_cb);
       if (cfg.vif.get_esc() === 1) req.sig_cycle_cnt++;

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
@@ -71,6 +71,12 @@ class alert_handler_base_vseq extends cip_base_vseq #(
     csr_wr(.csr(ral.classd_clren), .value(clr_en[3]));
   endtask
 
+  // write regen register if do_lock_config is set. If not set, 50% of chance to write value 0
+  // to regen register.
+  virtual task lock_config(bit do_lock_config);
+    if (do_lock_config || $urandom_range(0,1)) csr_wr(.csr(ral.regen), .value(do_lock_config));
+  endtask
+
   virtual task drive_alert(bit[alert_pkg::NAlerts-1:0] alert_trigger,
                            bit[alert_pkg::NAlerts-1:0] alert_int_err);
     fork

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_entropy_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_entropy_vseq.sv
@@ -28,25 +28,14 @@ class alert_handler_entropy_vseq extends alert_handler_sanity_vseq;
     esc_int_err == 0;
   }
 
+  constraint lock_bit_c {
+    do_lock_config == 1;
+  }
+
   function void pre_randomize();
     this.enable_classa_only_c.constraint_mode(0);
     // set verbosity high to avoid printing out too much information
     verbosity = UVM_HIGH;
   endfunction
-
-  virtual task alert_handler_init(bit [NUM_ALERT_HANDLER_CLASSES-1:0] intr_en = '1,
-                                  bit [alert_pkg::NAlerts-1:0]        alert_en = '1,
-                                  bit [TL_DW-1:0]                     alert_class = 'h0,
-                                  bit [NUM_LOCAL_ALERT-1:0]           loc_alert_en = '1,
-                                  bit [TL_DW-1:0]                     loc_alert_class = 'h0);
-    super.alert_handler_init(intr_en, alert_en, alert_class, loc_alert_en, loc_alert_class);
-    cfg.entropy_vif.drive(drive_entropy);
-    if (ral.regen.get_mirrored_value() == 1) begin
-      `uvm_info(`gfn,
-          $sformatf("init setting: intr_en=%0b, alert_en=%0b, alert_class=%0b, regen=%0b",
-          intr_en, alert_en, alert_class, lock_regen), UVM_LOW)
-    end
-    csr_wr(.csr(ral.regen), .value(lock_regen));
-  endtask
 
 endclass : alert_handler_entropy_vseq

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_sig_int_fail_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_sig_int_fail_vseq.sv
@@ -9,19 +9,14 @@ class alert_handler_sig_int_fail_vseq extends alert_handler_sanity_vseq;
 
   `uvm_object_new
 
+  constraint lock_bit_c {
+    do_lock_config == 1;
+  }
+
   function void pre_randomize();
     this.enable_one_alert_c.constraint_mode(0);
     this.enable_classa_only_c.constraint_mode(0);
     this.sig_int_c.constraint_mode(0);
   endfunction
 
-  virtual task alert_handler_init(bit [NUM_ALERT_HANDLER_CLASSES-1:0] intr_en = '1,
-                                  bit [alert_pkg::NAlerts-1:0]        alert_en = '1,
-                                  bit [TL_DW-1:0]                     alert_class = 'h0,
-                                  bit [NUM_LOCAL_ALERT-1:0]           loc_alert_en = '1,
-                                  bit [TL_DW-1:0]                     loc_alert_class = 'h0);
-    super.alert_handler_init(intr_en, alert_en, alert_class, loc_alert_en, loc_alert_class);
-   // lock regen to avoid changing real config settings during escalation
-    csr_wr(.csr(ral.regen), .value(1));
-  endtask
 endclass : alert_handler_sig_int_fail_vseq


### PR DESCRIPTION
Adjust settings to increase esc signal integrity check
Adjust settings to increase clear esc during escalation phases
Clean up counters for more accurate cycle count

Signed-off-by: Cindy Chen <chencindy@google.com>