### PR TITLE
[dv] Clean up uart_if

### DIFF
--- a/hw/dv/sv/uart_agent/uart_if.sv
+++ b/hw/dv/sv/uart_agent/uart_if.sv
@@ -2,11 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-interface uart_if #(time UartDefaultClkPeriodNs = 104166.667ns) (
-  output logic uart_rx,
-  input uart_tx,
-  input uart_tx_en
-);
+interface uart_if #(time UartDefaultClkPeriodNs = 104166.667ns) ();
+  wire uart_tx;
+  logic uart_rx;
 
   // generate local clk
   time  uart_clk_period_ns = UartDefaultClkPeriodNs;

--- a/hw/ip/uart/dv/tb/tb.sv
+++ b/hw/ip/uart/dv/tb/tb.sv
@@ -28,11 +28,11 @@ module tb;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
 
   // interfaces
-  clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
+  clk_rst_if clk_rst_if(.clk, .rst_n);
   pins_if #(NUM_MAX_INTERRUPTS) intr_if(interrupts);
   pins_if #(1) devmode_if(devmode);
-  tl_if tl_if(.clk(clk), .rst_n(rst_n));
-  uart_if uart_if(.uart_rx, .uart_tx, .uart_tx_en);
+  tl_if tl_if(.clk, .rst_n);
+  uart_if uart_if();
 
   // dut
   uart dut (
@@ -48,7 +48,7 @@ module tb;
 
     .intr_tx_watermark_o  (intr_tx_watermark ),
     .intr_rx_watermark_o  (intr_rx_watermark ),
-    .intr_tx_empty_o      (intr_tx_empty  ),
+    .intr_tx_empty_o      (intr_tx_empty     ),
     .intr_rx_overflow_o   (intr_rx_overflow  ),
     .intr_rx_frame_err_o  (intr_rx_frame_err ),
     .intr_rx_break_err_o  (intr_rx_break_err ),
@@ -65,6 +65,9 @@ module tb;
   assign interrupts[RxTimeout]   = intr_rx_timeout;
   assign interrupts[RxParityErr] = intr_rx_parity_err;
 
+  assign uart_rx = uart_if.uart_rx;
+  assign uart_if.uart_tx = uart_tx;
+
   initial begin
     // drive clk and rst_n from clk_if
     clk_rst_if.set_active();
@@ -76,5 +79,8 @@ module tb;
     $timeformat(-12, 0, " ps", 12);
     run_test();
   end
+
+  // we expect the output enable to be always 1
+  `ASSERT(UartTxEnTiedTo1_A, uart_tx_en, !rst_n, clk)
 
 endmodule

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -44,15 +44,15 @@ module tb;
   bit stub_cpu;
 
   // interfaces
-  clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
+  clk_rst_if clk_rst_if(.clk, .rst_n);
   clk_rst_if usb_clk_rst_if(.clk(usb_clk), .rst_n(usb_rst_n));
   pins_if #(NUM_GPIOS) gpio_if(.pins(gpio_pins));
   pins_if #(1) srst_n_if(.pins(srst_n));
   pins_if #(1) jtag_spi_n_if(.pins(jtag_spi_n));
   pins_if #(1) bootstrap_if(.pins(bootstrap));
-  spi_if spi_if(.rst_n(rst_n));
-  tl_if   cpu_d_tl_if(.clk(clk), .rst_n(rst_n));
-  uart_if uart_if(.uart_rx, .uart_tx, .uart_tx_en());
+  spi_if spi_if(.rst_n);
+  tl_if cpu_d_tl_if(.clk, .rst_n);
+  uart_if uart_if();
   jtag_if jtag_if();
 
   // backdoors
@@ -160,6 +160,9 @@ module tb;
   assign spi_device_csb     = spi_if.csb;
   assign spi_device_mosi_i  = spi_if.mosi;
   assign spi_if.miso        = spi_device_miso_o;
+
+  assign uart_rx = uart_if.uart_rx;
+  assign uart_if.uart_tx = uart_tx;
 
   // TODO: USB-related signals, hookup an interface.
   assign usb_rst_n  = `USBDEV_HIER.rst_usb_48mhz_ni;


### PR DESCRIPTION
This removes the port list from the UART interface to adhere to the convention of not exposing the port direction in interfaces (since they can represent both sender/receiver views in general). I've also removed `uart_tx_en` which was not used, and shortened some port connections that were redundant in the affected TBs (i.e., `.ckl(clk),` -> `.clk,`).

Signed-off-by: Michael Schaffner <msf@google.com>