### PR TITLE
[chip dv] Add coverage cfg file

### DIFF
--- a/hw/dv/data/vcs/vcs.hjson
+++ b/hw/dv/data/vcs/vcs.hjson
@@ -117,6 +117,8 @@
                    "-cm {cov_metrics}",
                    // Set the coverage hierarchy
                    "{vcs_cov_hier}",
+                   // Set the assert coverage hierarchy
+                   "{vcs_cov_assert_hier}",
                    // Cover all continuous assignments
                    "-cm_line contassign",
                    // Dump toggle coverage on mdas, array of structs and on ports only

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -34,6 +34,21 @@
                 "{proj_root}/hw/dv/data/tests/mem_tests.hjson",
                 "{proj_root}/hw/dv/data/tests/tl_access_tests.hjson"]
 
+  // Override the default vcs_cov_hier flag to supply chip specific coverage hierarchies.
+  overrides: [
+    {
+      name: vcs_cov_hier
+      value: "-cm_hier {tool_srcs_dir}/chip_cover.cfg"
+    }
+  ]
+
+  // Set the vcs_cov_assert_hier to supply the chip specific assertion coverage hierarchies.
+  vcs_cov_assert_hier: "-cm_assert_hier {tool_srcs_dir}/chip_assert_cover.cfg"
+
+  // Add these to tool_srcs so that they get copied over.
+  tool_srcs: ["{proj_root}/hw/top_earlgrey/dv/cov/chip_cover.cfg",
+              "{proj_root}/hw/top_earlgrey/dv/cov/chip_assert_cover.cfg"]
+
   // Default iterations for all tests - each test entry can override this.
   reseed: 1
 

--- a/hw/top_earlgrey/dv/cov/chip_assert_cover.cfg
+++ b/hw/top_earlgrey/dv/cov/chip_assert_cover.cfg
@@ -1,0 +1,17 @@
+-tree *
+
+// Include assertions within these modules.
++module tb
++module top_earlgrey_asic
++module top_earlgrey
++module rv_core_ibex
+
+// Enable full assertion coverage collection within these modules including their
+// sub-hierarchies since they are not pre-verified.
++tree tb.dut.padctl
++tree tb.dut.top_earlgrey.u_pinmux
++tree tb.dut.top_earlgrey.u_pwrmgr
++tree tb.dut.top_earlgrey.u_nmi_gen
++tree tb.dut.top_earlgrey.u_rstmgr
++tree tb.dut.top_earlgrey.u_rv_plic
++tree tb.dut.top_earlgrey.u_tl_adapter*

--- a/hw/top_earlgrey/dv/cov/chip_cover.cfg
+++ b/hw/top_earlgrey/dv/cov/chip_cover.cfg
@@ -1,0 +1,28 @@
+-tree *
+
+// Include port toggles of all IOs at these hierarchies.
+begin tgl(portsonly)
+  +module top_earlgrey_asic
+  +module padctl
+  +moduletree top_earlgrey 2
+  +moduletree rv_core_ibex 2
+end
+
+// Enable full coverage collection on these modules to cover the glue logic.
+begin line+cond+fsm+branch
+  +module top_earlgrey_asic
+  +module top_earlgrey
+  +module rv_core_ibex
+end
+
+// Enable full coverage collection on these modules including their sub-hierarchies since they are
+// not pre-verified.
+begin line+cond+fsm+branch
+  +moduletree padctl
+  +moduletree pinmux
+  +moduletree pwrmgr
+  +moduletree nmi_gen
+  +moduletree rstmgr
+  +moduletree rv_plic
+  +tree tb.dut.top_earlgrey.u_tl_adapter*
+end


### PR DESCRIPTION
Currently we collect coveage at all hierarches within the chip. This is
wasteful considering we are several pre-verified IPs that can be
black-boxed from coverage collection. This PR addresses that.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>