### PR TITLE
[chip dv] Add chip CSR tests to sanity

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -187,7 +187,9 @@
   regressions: [
     {
       name: sanity
-      tests: ["chip_sanity"]
+      tests: ["chip_sanity",
+              "chip_csr_hw_reset",
+              "chip_csr_rw"]
     }
     {
       name: sw_access


### PR DESCRIPTION
- This PR adds 2 tests (CSR HW reset and write-read-check) to the sanity
regression. These will be run in CI as well.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>