### PR TITLE
[chip dv] R-enable assert-final checks

### DIFF
--- a/hw/dv/data/vcs/vcs.hjson
+++ b/hw/dv/data/vcs/vcs.hjson
@@ -33,6 +33,12 @@
   run_opts:   ["-licqueue",
                "-ucli -do {tool_srcs_dir}/vcs_{dump}.tcl",
                "+ntb_random_seed={seed}",
+               // Disable the display of the SystemVerilog assert and cover statement summary
+               // at the end of simulation. This summary is list of assertions that started but
+               // did not finish because the simulation terminated, or assertions that did not
+               // fire at all. The latter is analyzed anyway in the collected coverage. Neither
+               // of these is useful in regular simulations.
+               "-assert nopostproc",
                "+UVM_TESTNAME={uvm_test}",
                "+UVM_TEST_SEQ={uvm_test_seq}"]
 
@@ -141,9 +147,7 @@
                    // Don't output cm.log which can be quite large
                    "-cm_log /dev/null",
                    // Provide a name to the coverage collected for this test
-                   "-cm_name {cov_db_test_dir_name}",
-                   // Don't dump all the coverage assertion attempts at the end of simulation
-                   "-assert nopostproc"]
+                   "-cm_name {cov_db_test_dir_name}"]
     }
     {
       name: vcs_xprop

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -61,10 +61,6 @@
   build_opts: [// Use generic implementations of prim modules.
                "+define+PRIM_DEFAULT_IMPL=prim_pkg::ImplGeneric"]
 
-  // Add default run opts.
-  run_opts: [// TODO: temp fix for C based tests.
-             "+disable_assert_final_checks"]
-
   // Add build modes.
   build_modes: [
     {


### PR DESCRIPTION
Assert final checks were disabled in chip dv because SW test did not
have a clear termination before. It could signal a 'pass' or 'fail' but
continue to execute some arbitrary code. This would cause the simulation
to exit while in the middle of a transfer, causing EOT / final assertion
checks to fail.

With recent changes to the SW test methodology, SW completely aborts
after signaling a pass or a fail. So we can safely reenable the
assert_final checks.

Also, this PR sets `-assert nopostproc` switch for VCS to prevent VCS
from displaying 100s of useless messages at the end of simulation like
these:
```
"../src/lowrisc_prim_all_0.1/rtl/prim_arbiter_ppc.sv", 136: tb.dut.top_earlgrey.u_xbar_main.u_sm1_29.gen_arb_ppc.u_reqarb.KStable_M: started at 526352643ps not finished
"../src/lowrisc_prim_all_0.1/rtl/prim_arbiter_ppc.sv", 136: tb.dut.top_earlgrey.u_xbar_main.u_sm1_28.gen_arb_ppc.u_reqarb.KStable_M: started at 526352643ps not finished
```

Signed-off-by: Srikrishna Iyer <sriyer@google.com>