### PR TITLE
[dvsim] Small tidy-ups in dvsim.py command line parsing

### DIFF
--- a/util/dvsim/Modes.py
+++ b/util/dvsim/Modes.py
@@ -107,6 +107,10 @@ class Modes():
         if self_attr_val == mode_attr_val:
             return
 
+        if mode_attr_val is None:
+            # No override here
+            return
+
         default_val = None
         if type(self_attr_val) is int:
             default_val = -1
@@ -265,7 +269,7 @@ class RunModes(Modes):
         self.type = "run"
         if not hasattr(self, "mname"):
             self.mname = "mode"
-        self.reseed = -1
+        self.reseed = None
         self.run_opts = []
         self.uvm_test = ""
         self.uvm_test_seq = ""
@@ -294,7 +298,7 @@ class Tests(RunModes):
 
     # TODO: This info should be passed via hjson
     defaults = {
-        "reseed": -1,
+        "reseed": None,
         "uvm_test": "",
         "uvm_test_seq": "",
         "build_mode": "",
@@ -419,7 +423,7 @@ class Regressions(Modes):
         if not hasattr(self, "mname"):
             self.mname = "regression"
         self.tests = []
-        self.reseed = -1
+        self.reseed = None
         self.test_names = []
         self.excl_tests = []  # TODO: add support for this
         self.en_sim_modes = []
@@ -547,5 +551,5 @@ class Regressions(Modes):
             test.run_opts.extend(self.run_opts)
 
             # Override reseed if available.
-            if self.reseed != -1:
+            if self.reseed is not None:
                 test.reseed = self.reseed

--- a/util/dvsim/OneShotCfg.py
+++ b/util/dvsim/OneShotCfg.py
@@ -23,6 +23,8 @@ class OneShotCfg(FlowCfg):
     def __init__(self, flow_cfg_file, proj_root, args):
         super().__init__(flow_cfg_file, proj_root, args)
 
+        assert args.tool is not None
+
         # Options set from command line
         self.tool = args.tool
         self.verbose = args.verbose


### PR DESCRIPTION
  - Arguments with action 'store_true' already get a default of False,
    so don't bother doing that explicitly.

  - Simplify how we take arguments in the FlowCfg constructor. Note
    that this wouldn't be equivalent code if we modified self.items,
    self.list_items or self.select_cfgs. But we don't.

  - Default to None in -select_cfgs. This means that passing
    -select_cfgs with no arguments is now different from not passing
    it at all, which is probably the behaviour we want.

  - Tidy up the logic in prune_selected_cfgs to allow self.select_cfgs
    to be None. And write the filter as a 1-line list comprehension
    rather than using list's remove method.

  - Print an error if the user wrongly passed -select_cfgs for a
    non-master config (before this patch, we just ignored the argument).

  - Use None as a default reseed value rather than -1. I think it's
    probably better to get an error if we forget to set reseed
    somewhere than to get -1*reseed_multiplier iterations, then loop
    over range(-10) tests (which is the empty sequence) without any
    error.

  - Pull the FlowCfg factory logic into a separate factory function in
    dvsim.py called make_config().

  - Default to None for --tool and print an error if a simulation run
    has no tool on the command line or in the config file. This
    previously failed rather mysteriously when it substituted the
    empty string for {tool} when constructing filenames.

  - Default to None for --profile. We have to default to a string (we
    pick something clearly bogus) in the SimCfg constructor so that
    interpolation works when --profile is not set. This should have no
    effect, because no config file should use {profile} except in a
    profile build_mode. But it's probably good to have something that
    makes it clear what's going on.

  - Slightly change the semantics of --list. If not specified, it does
    nothing. If passed with no arguments (nargs is now *, not +), it
    lists targets for all categories. If passed with some
    categories (now checked against a list of valid options), it lists
    targets that match the categories.

  - Default to None for --branch; move comment into a docstring in the
    resolve_branch function.

  - Use choices=... to force sensible values when using --profile,
    --verbosity or --verbose.