### PR TITLE
Remove redundant include in pinmux.c

### DIFF
--- a/sw/device/lib/pinmux.c
+++ b/sw/device/lib/pinmux.c
@@ -7,7 +7,6 @@
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "sw/device/lib/common.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "pinmux_regs.h"  // Generated.
 
 #define PINMUX0_BASE_ADDR TOP_EARLGREY_PINMUX_BASE_ADDR


### PR DESCRIPTION
This line was added in #2031.