### PR TITLE
[util] Fix run-clang-format.sh

### DIFF
--- a/util/run-clang-format.sh
+++ b/util/run-clang-format.sh
@@ -12,8 +12,14 @@ find sw hw \
 
 # Report on missing curly braces for loops and control statements.
 # clang-format cannot fix them for us, so this requires manual work.
+#
+# This does not cope with `do { ... } while (cond)` as used in macros (without
+# the semicolon).
+#
+# This rule does not use the `.clang-format` file so vendor must be excluded.
 braces_missing=$(
     find sw hw \
+        -not \( -path '*/vendor/*' -prune \) \
         \( -name '*.cpp' \
         -o -name '*.cc' \
         -o -name '*.c' \


### PR DESCRIPTION
Commit 15cae7a6 (#2038) removed all references to `vendor` from this file, as
that commit switched to using `.clang-format` files to avoid formatting
vendored code.

Unfortunately, I removed too many references to `vendor`, and the script
to detect forgotten parentheses has been including issues in the vendor
directories where it should not have been. This fix ensures that it no
longer complains about this issue in vendored code.
