### PR TITLE
[dv/alert_handler] separate esc into two categories

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_seq_item.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_seq_item.sv
@@ -15,6 +15,7 @@ class alert_esc_seq_item extends uvm_sequence_item;
   rand bit r_alert_ping_send;
   rand bit r_esc_rsp;
   rand bit int_err;
+  rand bit standalone_int_err;
   rand bit timeout;
   rand alert_sig_int_err_e alert_int_err_type;
 
@@ -58,6 +59,7 @@ class alert_esc_seq_item extends uvm_sequence_item;
     `uvm_field_int (r_alert_ping_send, UVM_DEFAULT)
     `uvm_field_int (r_esc_rsp,         UVM_DEFAULT)
     `uvm_field_int (int_err,           UVM_DEFAULT)
+    `uvm_field_int (standalone_int_err,UVM_DEFAULT)
     `uvm_field_int (timeout,           UVM_DEFAULT)
     `uvm_field_int (ping_delay,        UVM_DEFAULT)
     `uvm_field_int (ack_delay,         UVM_DEFAULT)

--- a/hw/dv/sv/alert_esc_agent/seq_lib/esc_receiver_base_seq.sv
+++ b/hw/dv/sv/alert_esc_agent/seq_lib/esc_receiver_base_seq.sv
@@ -14,14 +14,16 @@ class esc_receiver_base_seq extends dv_base_seq #(
 
   rand bit int_err;
   rand bit r_esc_rsp;
+  rand bit standalone_int_err;
 
   virtual task body();
     `uvm_info(`gfn, $sformatf("starting escalator receiver transfer"), UVM_HIGH)
     req = alert_esc_seq_item::type_id::create("req");
     start_item(req);
     `DV_CHECK_RANDOMIZE_WITH_FATAL(req,
-        r_esc_rsp  == local::r_esc_rsp;
-        int_err    == local::int_err;
+        r_esc_rsp          == local::r_esc_rsp;
+        int_err            == local::int_err;
+        standalone_int_err == local::standalone_int_err;
     )
     `uvm_info(`gfn, $sformatf("seq_item: esc_rsp=%0b, int_err=%0b",
         req.r_esc_rsp, req.int_err), UVM_MEDIUM)

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_sanity_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_sanity_vseq.sv
@@ -17,6 +17,7 @@ class alert_handler_sanity_vseq extends alert_handler_base_vseq;
   rand bit [NUM_LOCAL_ALERT-1:0]           local_alert_en;
   rand bit [NUM_LOCAL_ALERT*2-1:0]         local_alert_class_map;
   rand bit [alert_pkg::N_ESC_SEV-1:0]      esc_int_err;
+  rand bit [alert_pkg::N_ESC_SEV-1:0]      esc_standalone_int_err;
 
   rand bit do_clr_esc;
   rand bit do_wr_phases_cyc;
@@ -28,6 +29,7 @@ class alert_handler_sanity_vseq extends alert_handler_base_vseq;
   rand bit [TL_DW-1:0] accum_thresh     [NUM_ALERT_HANDLER_CLASSES];
 
   int max_wait_phases_cyc = MIN_CYCLE_PER_PHASE * NUM_ESC_PHASES;
+  int max_intr_timeout_cyc;
 
   uvm_verbosity verbosity = UVM_LOW;
 
@@ -62,13 +64,15 @@ class alert_handler_sanity_vseq extends alert_handler_base_vseq;
   }
 
   constraint sig_int_c {
-    alert_int_err == 0;
-    esc_int_err   == 0;
+    alert_int_err          == 0;
+    esc_int_err            == 0;
+    esc_standalone_int_err == 0;
   }
 
   task body();
     fork
       begin : isolation_fork
+        bit config_locked;
         `DV_CHECK_RANDOMIZE_FATAL(this)
         run_esc_rsp_seq_nonblocking(esc_int_err);
         run_alert_ping_rsp_seq_nonblocking();
@@ -93,11 +97,7 @@ class alert_handler_sanity_vseq extends alert_handler_base_vseq;
 
           // randomly write phase cycle registers
           // always set phase_cycle for the first iteration, in order to pass stress_all test
-          if (do_wr_phases_cyc || i == 1) begin
-            wr_phases_cycle(max_phase_cyc);
-            max_wait_phases_cyc = (max_wait_phases_cyc > (max_phase_cyc * NUM_ESC_PHASES)) ?
-                                   max_wait_phases_cyc : (max_phase_cyc * NUM_ESC_PHASES);
-          end
+          if (do_wr_phases_cyc || i == 1) wr_phases_cycle(max_phase_cyc);
 
           // randomly write interrupt timeout resigers and accumulative threshold registers
           if (do_esc_intr_timeout) wr_intr_timeout_cycle(intr_timeout_cyc);
@@ -109,15 +109,23 @@ class alert_handler_sanity_vseq extends alert_handler_base_vseq;
           // when all configuration registers are set, write lock register
           lock_config(do_lock_config);
 
+          if (esc_standalone_int_err) drive_esc_rsp(esc_standalone_int_err);
           // drive alert
           drive_alert(alert_trigger, alert_int_err);
 
-          if (do_esc_intr_timeout) begin
+          // if config is not locked, update max_intr_timeout and max_wait_phases cycles
+          if (!config_locked) begin
             int max_intr_timeout_cyc;
             foreach (intr_timeout_cyc[i]) begin
               max_intr_timeout_cyc = (max_intr_timeout_cyc > intr_timeout_cyc[i]) ?
                                       max_intr_timeout_cyc : intr_timeout_cyc[i];
             end
+            max_wait_phases_cyc = (max_wait_phases_cyc > (max_phase_cyc * NUM_ESC_PHASES)) ?
+                                   max_wait_phases_cyc : (max_phase_cyc * NUM_ESC_PHASES);
+            if (do_lock_config) config_locked = 1;
+          end
+
+          if (do_esc_intr_timeout) begin
             cfg.clk_rst_vif.wait_clks(max_intr_timeout_cyc);
             read_esc_status();
           end

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_sig_int_fail_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_sig_int_fail_vseq.sv
@@ -9,14 +9,13 @@ class alert_handler_sig_int_fail_vseq extends alert_handler_sanity_vseq;
 
   `uvm_object_new
 
-  constraint lock_bit_c {
-    do_lock_config == 1;
+  constraint sig_int_c {
+    esc_int_err == 0;
   }
 
   function void pre_randomize();
     this.enable_one_alert_c.constraint_mode(0);
     this.enable_classa_only_c.constraint_mode(0);
-    this.sig_int_c.constraint_mode(0);
   endfunction
 
 endclass : alert_handler_sig_int_fail_vseq


### PR DESCRIPTION
Separate escalation integrity error into two categories:
1. standalone escalation resp error
2. escalation resp error during esc_p/n or ping

Signed-off-by: Cindy Chen <chencindy@google.com>