### PR TITLE
[dv/spi_device] Increase timeout timer

### DIFF
--- a/hw/ip/spi_device/dv/tests/spi_device_base_test.sv
+++ b/hw/ip/spi_device/dv/tests/spi_device_base_test.sv
@@ -9,7 +9,7 @@ class spi_device_base_test extends cip_base_test #(.ENV_T(spi_device_env),
 
   virtual function void build_phase(uvm_phase phase);
     max_quit_count  = 50;
-    test_timeout_ns = 600_000_000; // 600ms
+    test_timeout_ns = 1000_000_000; // 1s
     super.build_phase(phase);
     // configure the spi agent to be in Host mode
     cfg.m_spi_agent_cfg.mode = Host;


### PR DESCRIPTION
Very a few tests (< 0.1%) fail due to timeout, increase timer to fix it
Signed-off-by: Weicai Yang <weicai@google.com>