### PR TITLE
[dv] improve cov for alert_handler and rv_timer

### DIFF
--- a/hw/ip/alert_handler/dv/alert_handler_sim_cfg.hjson
+++ b/hw/ip/alert_handler/dv/alert_handler_sim_cfg.hjson
@@ -57,6 +57,7 @@
     {
       name: alert_handler_random_classes
       uvm_test_seq: alert_handler_random_classes_vseq
+      reseed: 200
     }
 
     {

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
@@ -16,8 +16,8 @@
   csr_update(ral.class``i``_phase2_cyc); \
   csr_update(ral.class``i``_phase3_cyc);
 
-`define RAND_WRITE_CLASS_CTRL(i) \
-  `DV_CHECK_RANDOMIZE_WITH_FATAL(ral.class``i``_ctrl, lock.value dist {1:=2, 0:=8};) \
+`define RAND_WRITE_CLASS_CTRL(i, lock_bit) \
+  `DV_CHECK_RANDOMIZE_WITH_FATAL(ral.class``i``_ctrl, lock.value == lock_bit;) \
   csr_wr(.csr(ral.class``i``_ctrl), .value(ral.class``i``_ctrl.get()));
 
 class alert_handler_base_vseq extends cip_base_vseq #(
@@ -56,12 +56,12 @@ class alert_handler_base_vseq extends cip_base_vseq #(
     csr_wr(.csr(ral.loc_alert_class), .value(loc_alert_class));
   endtask
 
-  virtual task alert_handler_rand_wr_class_ctrl(bit [NUM_ALERT_HANDLER_CLASSES-1:0] class_en =
-                                                $urandom());
-    if (class_en[0]) `RAND_WRITE_CLASS_CTRL(a)
-    if (class_en[1]) `RAND_WRITE_CLASS_CTRL(b)
-    if (class_en[2]) `RAND_WRITE_CLASS_CTRL(c)
-    if (class_en[3]) `RAND_WRITE_CLASS_CTRL(d)
+  virtual task alert_handler_rand_wr_class_ctrl(bit [NUM_ALERT_HANDLER_CLASSES-1:0] lock_bit);
+    bit [NUM_ALERT_HANDLER_CLASSES-1:0] class_en = $urandom();
+    if (class_en[0]) `RAND_WRITE_CLASS_CTRL(a, lock_bit[0])
+    if (class_en[1]) `RAND_WRITE_CLASS_CTRL(b, lock_bit[1])
+    if (class_en[2]) `RAND_WRITE_CLASS_CTRL(c, lock_bit[2])
+    if (class_en[3]) `RAND_WRITE_CLASS_CTRL(d, lock_bit[3])
   endtask
 
   virtual task alert_handler_wr_clren_regs(bit [NUM_ALERT_HANDLER_CLASSES-1:0] clr_en);

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_random_alerts_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_random_alerts_vseq.sv
@@ -9,6 +9,11 @@ class alert_handler_random_alerts_vseq extends alert_handler_sanity_vseq;
 
   `uvm_object_new
 
+  constraint clr_en_c {
+    clr_en      == 0;
+    lock_bit_en == 0;
+  }
+
   function void pre_randomize();
     this.enable_one_alert_c.constraint_mode(0);
   endfunction

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_sanity_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_sanity_vseq.sv
@@ -10,6 +10,7 @@ class alert_handler_sanity_vseq extends alert_handler_base_vseq;
 
   rand bit [NUM_ALERT_HANDLER_CLASSES-1:0] intr_en;
   rand bit [NUM_ALERT_HANDLER_CLASSES-1:0] clr_en;
+  rand bit [NUM_ALERT_HANDLER_CLASSES-1:0] lock_bit_en;
   rand bit [alert_pkg::NAlerts-1:0]        alert_trigger;
   rand bit [alert_pkg::NAlerts-1:0]        alert_int_err;
   rand bit [alert_pkg::NAlerts-1:0]        alert_en;
@@ -35,8 +36,9 @@ class alert_handler_sanity_vseq extends alert_handler_base_vseq;
     do_lock_config dist {1 := 1, 0 := 9};
   }
 
-  constraint clr_en_c {
-    clr_en dist {0 := 8, [1:'b1111] := 2};
+  constraint clr_and_lock_en_c {
+    clr_en      dist {0 := 8, [1:'b1111] := 2};
+    lock_bit_en dist {0 := 8, [1:'b1111] := 2};
   }
 
   constraint enable_one_alert_c {
@@ -88,7 +90,7 @@ class alert_handler_sanity_vseq extends alert_handler_base_vseq;
                              .loc_alert_class(local_alert_class_map));
 
           // write class_ctrl and clren_reg
-          alert_handler_rand_wr_class_ctrl();
+          alert_handler_rand_wr_class_ctrl(lock_bit_en);
           alert_handler_wr_clren_regs(clr_en);
 
           // randomly write phase cycle registers

--- a/hw/ip/rv_timer/dv/rv_timer_sim_cfg.hjson
+++ b/hw/ip/rv_timer/dv/rv_timer_sim_cfg.hjson
@@ -47,6 +47,7 @@
     {
       name: rv_timer_sanity
       uvm_test_seq: rv_timer_sanity_vseq
+      reseed: 200
     }
 
     {


### PR DESCRIPTION
1. Increase rv_timer cov by increasing the seed
2. Increase alert_handler esc clear coverage by disable lock bit in some
cases
Signed-off-by: Cindy Chen <chencindy@google.com>