### PR TITLE
Minor pad wrapper updates

### DIFF
--- a/hw/ip/prim_generic/rtl/prim_generic_pad_wrapper.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_pad_wrapper.sv
@@ -40,8 +40,9 @@ module prim_generic_pad_wrapper #(
   assign (strong0, strong1) inout_io = (oe && drv == STRONG_DRIVE) ? out : 1'bz;
   assign (pull0, pull1)     inout_io = (oe && drv == WEAK_DRIVE)   ? out : 1'bz;
   // pullup / pulldown termination
-  assign (highz0, weak1)    inout_io = pu;
-  assign (weak0, highz1)    inout_io = ~pd;
+  // default to high-Z in case both PU and PD are asserted (safety mechanism).
+  assign (highz0, weak1)    inout_io = pu & ~pd;
+  assign (weak0, highz1)    inout_io = pu | ~pd;
   // fake trireg emulation
   assign (weak0, weak1)     inout_io = (kp) ? inout_io : 1'bz;
 `endif

--- a/hw/ip/prim_xilinx/rtl/prim_xilinx_pad_wrapper.sv
+++ b/hw/ip/prim_xilinx/rtl/prim_xilinx_pad_wrapper.sv
@@ -26,13 +26,15 @@ module prim_xilinx_pad_wrapper #(
   assign in_o     = inv ^ in;
 
   // virtual open drain emulation
-  logic oe, out;
+  logic oe_n, out;
   assign out      = out_i ^ inv;
-  assign oe       = oe_i & ((od & ~out) | ~od);
+  // oe_n = 0: enable driver
+  // oe_n = 1: disable driver
+  assign oe_n     = ~oe_i | (out & od);
 
   // driver
   IOBUF i_iobuf (
-    .T(oe),
+    .T(oe_n),
     .I(out),
     .O(in),
     .IO(inout_io)


### PR DESCRIPTION
This introduces two small changes:

1. The polarity to the Xilinx IOBUF T port was wrong
2. The simulation model of the pad wrapper is changed to disallow simultaneous assertion of PD and PU attributes (it just defaults to high-Z in that case). This partially addresses #1831.

