### PR TITLE
[dvsim] Print what cmd is executed in the log

### DIFF
--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -181,6 +181,8 @@ class Deploy():
             os.system("ln -s " + self.odir + " " + self.sim_cfg.links['D'] +
                       '/' + self.odir_ln)
             f = open(self.log, "w", encoding="UTF-8")
+            f.write("[Executing]:\n{}\n\n".format(self.cmd))
+            f.flush()
             self.process = subprocess.Popen(args,
                                             bufsize=4096,
                                             universal_newlines=True,


### PR DESCRIPTION
At the start of the log file, the full command line is printed to
help easily debug / reproduce outside of dvsim.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>