### PR TITLE
[prim] Factor out memory loading into separate file

### DIFF
--- a/hw/ip/prim/prim_util_memload.core
+++ b/hw/ip/prim/prim_util_memload.core
@@ -1,0 +1,17 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:util_memload"
+description: "Memory loaders for simulation. To be included in a memory primitive."
+filesets:
+  files_rtl:
+    files:
+      - rtl/prim_util_memload.sv: {is_include_file: true}
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_rtl

--- a/hw/ip/prim/rtl/prim_util_memload.sv
+++ b/hw/ip/prim/rtl/prim_util_memload.sv
@@ -1,0 +1,59 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Memory loader for simulation
+ *
+ * Include this file in a memory primitive to load a memory array from
+ * simulation.
+ *
+ * Requirements:
+ * - A memory array named `mem`.
+ * - A parameter `Width` giving the memory width (word size) in bit.
+ * - A parameter `Depth` giving the memory depth in words.
+ */
+`ifdef VERILATOR
+  // Task for loading 'mem' with SystemVerilog system task $readmemh()
+  export "DPI-C" task simutil_verilator_memload;
+
+  task simutil_verilator_memload;
+    input string file;
+    $readmemh(file, mem);
+  endtask
+
+  // Width must be a multiple of 32bit for this function to work
+  // Note that the DPI export and function definition must both be in the same generate
+  // context to get the correct name.
+  if ((Width % 32) == 0) begin : gen_set_mem
+    // Function for setting a specific element in |mem|
+    // Returns 1 (true) for success, 0 (false) for errors.
+    export "DPI-C" function simutil_verilator_set_mem;
+
+    function int simutil_verilator_set_mem(input int index,
+                                           input bit [Width-1:0] val);
+      if (index >= Depth) begin
+        return 0;
+      end
+
+      mem[index] = val;
+      return 1;
+    endfunction
+  end else begin : gen_other
+    // Function doesn't work unless Width % 32 so just return 0
+    export "DPI-C" function simutil_verilator_set_mem;
+
+    function int simutil_verilator_set_mem(input int index,
+                                           input bit [Width-1:0] val);
+      return 0;
+    endfunction
+  end
+`endif
+
+`ifdef SRAM_INIT_FILE
+  localparam MEM_FILE = `PRIM_STRINGIFY(`SRAM_INIT_FILE);
+  initial begin
+    $display("Initializing memory from %s", MEM_FILE);
+    $readmemh(MEM_FILE, mem);
+  end
+`endif

--- a/hw/ip/prim_generic/prim_generic_ram_1p.core
+++ b/hw/ip/prim_generic/prim_generic_ram_1p.core
@@ -4,9 +4,11 @@ CAPI=2:
 # SPDX-License-Identifier: Apache-2.0
 
 name: "lowrisc:prim_generic:ram_1p"
-description: "prim"
+description: "Single port RAM"
 filesets:
   files_rtl:
+    depend:
+      - lowrisc:prim:util_memload
     files:
       - rtl/prim_generic_ram_1p.sv
     file_type: systemVerilogSource

--- a/hw/ip/prim_generic/prim_generic_rom.core
+++ b/hw/ip/prim_generic/prim_generic_rom.core
@@ -9,6 +9,7 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:prim:all
+      - lowrisc:prim:util_memload
     files:
       - rtl/prim_generic_rom.sv
     file_type: systemVerilogSource

--- a/hw/ip/prim_generic/prim_generic_rom.core
+++ b/hw/ip/prim_generic/prim_generic_rom.core
@@ -8,7 +8,7 @@ description: "Technology-independent Read-Only Memory (ROM) implementation"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:prim:all
+      - lowrisc:prim:assert
       - lowrisc:prim:util_memload
     files:
       - rtl/prim_generic_rom.sv

--- a/hw/ip/prim_generic/rtl/prim_generic_rom.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_rom.sv
@@ -33,42 +33,12 @@ module prim_generic_rom #(
     end
   end
 
+  `include "prim_util_memload.sv"
+
   ////////////////
   // ASSERTIONS //
   ////////////////
 
   // Control Signals should never be X
   `ASSERT(noXOnCsI, !$isunknown(cs_i), clk_i, '0)
-
-  `ifdef VERILATOR
-    // Task for loading 'mem' with SystemVerilog system task $readmemh()
-    export "DPI-C" task simutil_verilator_memload;
-    // Function for setting a specific 32 bit element in |mem|
-    // Returns 1 (true) for success, 0 (false) for errors.
-    export "DPI-C" function simutil_verilator_set_mem;
-
-    task simutil_verilator_memload;
-      input string file;
-      $readmemh(file, mem);
-    endtask
-
-    // TODO: Allow 'val' to have other widths than 32 bit
-    function int simutil_verilator_set_mem(input int index,
-                                           input logic[31:0] val);
-      if (index >= Depth) begin
-        return 0;
-      end
-
-      mem[index] = val;
-      return 1;
-    endfunction
-  `endif
-
-  `ifdef ROM_INIT_FILE
-    localparam MEM_FILE = `PRIM_STRINGIFY(`ROM_INIT_FILE);
-    initial begin
-      $display("Initializing ROM from %s", MEM_FILE);
-      $readmemh(MEM_FILE, mem);
-    end
-  `endif
 endmodule

--- a/hw/ip/prim_generic/rtl/prim_generic_rom.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_rom.sv
@@ -7,7 +7,7 @@
 module prim_generic_rom #(
   parameter  int Width     = 32,
   parameter  int Depth     = 2048, // 8kB default
-  parameter  int Aw        = $clog2(Depth)
+  localparam int Aw        = $clog2(Depth)
 ) (
   input                        clk_i,
   input                        rst_ni,


### PR DESCRIPTION
Memory loading functionality has been duplicated in various files, which
makes it hard to keep in sync and update. Combine it all into one file,
which is then included by the different memory primitives.

This is an included file and not a separate module to keep synthesis
tools happy; RAM inference works with pattern matching and closely
following the patterns the vendors (e.g. Xilinx) give us. Passing the
`mem` variable to other modules will break inference very likely. Using
an included file avoids that, while still giving us the benefits of
reuse.

... plus some additional cleanups, see the individual commits for full commit messages.