### PR TITLE
[util] Fix Vendor Reset Revision

### DIFF
--- a/util/vendor.py
+++ b/util/vendor.py
@@ -232,7 +232,7 @@ def clone_git_repo(repo_url, clone_dir, rev='master'):
     subprocess.run(cmd, check=True)
 
     # Check out exactly the revision requested
-    cmd = ['git', '-C', str(clone_dir), 'reset', '--hard', rev]
+    cmd = ['git', '-C', str(clone_dir), 'checkout', '--force', rev]
     if not verbose:
         cmd += ['-q']
     subprocess.run(cmd, check=True)


### PR DESCRIPTION
The vendor tool can fail if you try to `git-reset` to a branch that does
not exist. In this case, some of the upstream branches may not exist so
we should prefix the branch checkout with the name of the remote.

---

I think potentially another fix is to use `git checkout --force <branch>` instead,
which will create `<branch>` at the same revision that `origin/<branch>` is at, 
if `<branch>` doesn't exist. This second approach may better cope with mixing
branch names and revisions than the change in this commit, however I found
that using `git checkout --force` was producing different patches for
riscv-compliance than `git reset --hard` (the differences were only whitespace).

Without this change, doing `util/vendor.py --refresh-patches sw/vendor/riscv_compliance.vendor.hjson` fails.