### PR TITLE
[chip dv] Attach mem_bkdr_if to RAM

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -49,7 +49,7 @@ class chip_env_cfg extends cip_base_env_cfg #(.RAL_T(chip_reg_block));
   endfunction : initialize_csr_addr_map_size
 
   virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);
-    chip_mem_e mems[] = {Rom, FlashBank0, FlashBank1};
+    chip_mem_e mems[] = {Rom, Ram, FlashBank0, FlashBank1};
 
     has_devmode = 0;
     // TODO: may need to add scb later

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_test_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_test_base_vseq.sv
@@ -33,10 +33,12 @@ class chip_sw_test_base_vseq extends chip_base_vseq;
     // initialize the sw test status
     cfg.sw_test_status_vif.sw_test_status_addr = SW_DV_TEST_STATUS_ADDR;
 
-    // Backdoor load memories.
-    cfg.mem_bkdr_vifs[Rom].load_mem_from_file(cfg.sw_images["rom"]);
+    // Initialize the flash to all 1s.
     cfg.mem_bkdr_vifs[FlashBank0].set_mem();
     cfg.mem_bkdr_vifs[FlashBank1].set_mem();
+
+    // Backdoor load memories with sw images.
+    cfg.mem_bkdr_vifs[Rom].load_mem_from_file(cfg.sw_images["rom"]);
     // TODO: the location of the main execution image should be randomized for either bank in future
     cfg.mem_bkdr_vifs[FlashBank0].load_mem_from_file(cfg.sw_images["sw"]);
     cfg.sw_test_status_vif.sw_test_status = SwTestStatusBooted;

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -57,6 +57,7 @@ module tb;
 
   // backdoors
   bind `ROM_HIER mem_bkdr_if rom_mem_bkdr_if();
+  bind `RAM_MAIN_HIER mem_bkdr_if ram_mem_bkdr_if();
   bind `FLASH0_MEM_HIER mem_bkdr_if flash0_mem_bkdr_if();
   bind `FLASH1_MEM_HIER mem_bkdr_if flash1_mem_bkdr_if();
 
@@ -196,6 +197,8 @@ module tb;
     // Backdoors
     uvm_config_db#(virtual mem_bkdr_if)::set(
         null, "*.env", "mem_bkdr_vifs[Rom]", `ROM_HIER.rom_mem_bkdr_if);
+    uvm_config_db#(virtual mem_bkdr_if)::set(
+        null, "*.env", "mem_bkdr_vifs[Ram]", `RAM_MAIN_HIER.ram_mem_bkdr_if);
     uvm_config_db#(virtual mem_bkdr_if)::set(
         null, "*.env", "mem_bkdr_vifs[FlashBank0]", `FLASH0_MEM_HIER.flash0_mem_bkdr_if);
     uvm_config_db#(virtual mem_bkdr_if)::set(


### PR DESCRIPTION
- This PR adds `mem_bkdr_if` to the RAM instance so that it can be
manipulated as needed.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>