### PR TITLE
[sw] Add Guidance on DIF Return Codes

### DIFF
--- a/doc/rm/device_interface_functions.md
+++ b/doc/rm/device_interface_functions.md
@@ -25,6 +25,7 @@ DIFs **must** only depend on:
 
 *   the [freestanding C library headers]({{< relref "sw/device/lib/base/freestanding/README.md" >}}),
 *   compiler runtime libraries (e.g. libgcc and compiler-rt),
+*   the bitfield library for manipulating bits in binary values (`sw/device/lib/base/bitfield.h`),
 *   the mmio library for interacting with memory-mapped registers (`sw/device/lib/base/mmio.h`),
 *   the memory library for interacting with non-volatile memory (`sw/device/lib/base/memory.h`), and
 *   any IP-specific register definition files.

--- a/sw/device/lib/dif/README.md
+++ b/sw/device/lib/dif/README.md
@@ -31,6 +31,12 @@ contradict with the guidelines below.
 The guidelines below apply to writing DIFs, and code should be written in a
 similar style to the existing DIF libraries in this directory.
 
+### Definitions
+
+<a name="side-effects"></a>
+**Side-effects** include (but are not limited to) writing to memory, including
+memory-mapped hardware, and modifying processor CSRs.
+
 ### DIF Library Guidance
 
 * DIF libraries must be written in C.
@@ -64,10 +70,10 @@ there are some relaxations of these rules for them described at the end.
     * `kDif<ip>Error`, with value 1, to denote a non-specific error happened
       during the call. This is for the `default:` case of enum switches (as
       noted below), and for assertion errors (usually where the function has
-      already caused side effects so `kDif<ip>BadArg` cannot be used).
+      already caused side-effects so `kDif<ip>BadArg` cannot be used).
     * `kDif<ip>BadArg`, with value 2, to denote that the caller supplied
       incorrect arguments. This value must only be returned if the function has
-      not caused any side effects.
+      not caused any side-effects.
   * DIF libraries should define specific return code enums for operations that
     fail in more specific ways. These specific return code enums can be shared
     between multiple DIFs that fail in the same way.
@@ -96,7 +102,7 @@ there are some relaxations of these rules for them described at the end.
       the hardware in an invalid, unrecoverable state.
     * If a DIF returns `kDif<ip>BadArg`, it must leave the hardware in a valid
       and recoverable state. This is in addition to the rule that this value may
-      only be returned if the function has not caused any side effects.
+      only be returned if the function has not caused any side-effects.
   * DIFs that cannot error and that do not return a value must return `void`.
 
 * DIFs must check their arguments against preconditions using "guard
@@ -109,12 +115,9 @@ there are some relaxations of these rules for them described at the end.
   * DIFs must ensure, if they only accept a subset of an enum, that the argument
     is within that subset. However, DIFs may assume, for checking preconditions,
     that any enum argument is one of the enum constants.
-  * DIFs must not have side-effects before any guard statements.
-
-    Side-effects include (but are not limited to) writing to memory, including
-    memory-mapped hardware, and modifying processor CSRs. This means returning
-    early from a guard statement must not leave the hardware in an invalid or
-    unrecoverable state.
+  * DIFs must not cause any side-effects before any guard statements. This means
+    returning early from a guard statement must not leave the hardware in an
+    invalid or unrecoverable state.
 
 * Switch statements in DIFs must always have a default case, including when
   switching on an enum value (an "enum switch").

--- a/sw/device/lib/dif/README.md
+++ b/sw/device/lib/dif/README.md
@@ -107,8 +107,8 @@ there are some relaxations of these rules for them described at the end.
     is for an optional out-parameter. Arguments typed `mmio_region_t` are not
     pointers, and cannot meaningfully be checked for non-nullness.
   * DIFs must ensure, if they only accept a subset of an enum, that the argument
-    is within that subset. However, DIFs should assume, for checking
-    preconditions, that any enum argument is one of the enum constants.
+    is within that subset. However, DIFs may assume, for checking preconditions,
+    that any enum argument is one of the enum constants.
   * DIFs must not have side-effects before any guard statements.
 
     Side-effects include (but are not limited to) writing to memory, including

--- a/sw/device/lib/dif/README.md
+++ b/sw/device/lib/dif/README.md
@@ -36,6 +36,7 @@ similar style to the existing DIF libraries in this directory.
 * DIF libraries must be written in C.
 * DIF libraries can only depend on the following headers (and their associated
   libraries) from the `sw/device/lib/base` directory:
+  * `sw/device/lib/base/bitfield.h`
   * `sw/device/lib/base/mmio.h`
   * `sw/device/lib/base/memory.h`
 * DIF libraries must not depend on other DIF libraries. Exercising DIF

--- a/sw/device/lib/dif/README.md
+++ b/sw/device/lib/dif/README.md
@@ -42,6 +42,7 @@ similar style to the existing DIF libraries in this directory.
 * DIF libraries must not depend on other DIF libraries. Exercising DIF
   functionality may require an environment set up using another DIF library, but
   DIFs must not call DIFs in other DIF libraries.
+* DIF library headers must be polyglot headers for C and C++.
 
 ### DIF Guidance
 

--- a/sw/device/lib/dif/README.md
+++ b/sw/device/lib/dif/README.md
@@ -55,9 +55,48 @@ there are some relaxations of these rules for them described at the end.
     in DIF signatures.
 
 * DIFs must use enum return codes rather than booleans for reporting errors. If
-  a DIF can either error or instead produce a value, it should return an enum
+  a DIF can either error or instead produce a value, it must return an enum
   return code, and use an out-parameter for returning the produced value.
-  * DIFs that cannot error and that do not return a value should return `void`.
+  * DIF libraries must have a general return code enum called
+    `dif_<ip>_result_t`. It must define the following constants (in this order):
+    * `kDif<ip>Ok`, with value 0, to denote the call succeeded.
+    * `kDif<ip>Error`, with value 1, to denote a non-specific error happened
+      during the call. This is for the `default:` case of enum switches (as
+      noted below), and for assertion errors (usually where the function has
+      already caused side effects so `kDif<ip>BadArg` cannot be used).
+    * `kDif<ip>BadArg`, with value 2, to denote that the caller supplied
+      incorrect arguments. This value must only be returned if the function has
+      not caused any side effects.
+  * DIF libraries should define specific return code enums for operations that
+    fail in more specific ways. These specific return code enums can be shared
+    between multiple DIFs that fail in the same way.
+
+    These more specific return code types must be named
+    `dif_<ip>_<operation>_result_t`, and their constants must be prefixed with
+    `kDif<ip><operation>`. `<operation>` need not correspond to a DIF name if
+    the return codes are shared between DIFs.
+
+    The first three constants in these specific enums must define the following
+    constants:
+    * `kDif<ip><operation>Ok`, with value `kDif<ip>Ok`,
+    * `kDif<ip><operation>Error`, with value `kDif<ip>Error`, and
+    * `kDif<ip><operation>BadArg`, with value `kDif<ip>BadArg`.
+
+    Additional, specific return code constants must all be defined after
+    these three general constants, and may cover more specific forms of the
+    return codes defined above, including more specific reasons arguments are
+    invalid.
+
+  * DIFs must document the meaning of each return code constant, including the
+    required ones above, with a Doxygen comment per declaration. This comment
+    must include whether returning this error code could have left the hardware
+    in an invalid or unrecoverable state.
+    * If a DIF returns `kDif<ip>Error`, it must be assumed to have left
+      the hardware in an invalid, unrecoverable state.
+    * If a DIF returns `kDif<ip>BadArg`, it must leave the hardware in a valid
+      and recoverable state. This is in addition to the rule that this value may
+      only be returned if the function has not caused any side effects.
+  * DIFs that cannot error and that do not return a value must return `void`.
 
 * DIFs must check their arguments against preconditions using "guard
   statements". A guard statement is a simple if statement at the start of a
@@ -68,16 +107,22 @@ there are some relaxations of these rules for them described at the end.
     pointers, and cannot meaningfully be checked for non-nullness.
   * DIFs must ensure, if they only accept a subset of an enum, that the argument
     is within that subset. However, DIFs should assume, for checking
-    preconditions, that any enum argument is one of the enum variants.
-  * DIFs must not have side-effects before any guard statements. Side-effects
-    include (but are not limited to) writing to memory, including memory-mapped
-    hardware, and modifying processor CSRs.
+    preconditions, that any enum argument is one of the enum constants.
+  * DIFs must not have side-effects before any guard statements.
+
+    Side-effects include (but are not limited to) writing to memory, including
+    memory-mapped hardware, and modifying processor CSRs. This means returning
+    early from a guard statement must not leave the hardware in an invalid or
+    unrecoverable state.
 
 * Switch statements in DIFs must always have a default case, including when
   switching on an enum value (an "enum switch").
   * The default case of an enum switch must report an error for values that are
-    not an enum variant.
-  * Enum switches do not need a `case` for enum variants that are unreachable
+    not a constant from that enum. In the absence of more specific information,
+    this should return `kDif<ip>Error` or the equivalent return code value from
+    a more specific return code enum. If the enum switch is part of a guard
+    statement, it may return `kDif<ip>BadArg` instead.
+  * Enum switches do not need a `case` for enum constants that are unreachable
     due to a guard statement.
 
 * DIFs must use `sw/device/lib/base/mmio.h` for accessing memory-mapped


### PR DESCRIPTION
This PR adds the guidance as agreed in the software meeting on 2020-04-14. The guidance is also based on the discussion in #1911. I have also updated the style guide to refer to enum constants by that name (which is used by the standard), rather than "enum variants", which is not.

I have also added `bitfield.h` as an allowed library for DIFs, given it is already used and #2203 is likely to use it even more. 

---

Closes #1911 