### PR TITLE
[entropy_src/dv] Add entropy_src to CI & nightly

### DIFF
--- a/hw/top_earlgrey/dv/top_earlgrey_sim_cfgs.hjson
+++ b/hw/top_earlgrey/dv/top_earlgrey_sim_cfgs.hjson
@@ -12,6 +12,7 @@
 
   use_cfgs: ["{proj_root}/hw/ip/aes/dv/aes_sim_cfg.hjson",
              "{proj_root}/hw/ip/alert_handler/dv/alert_handler_sim_cfg.hjson",
+             "{proj_root}/hw/ip/entropy_src/dv/entropy_src_sim_cfg.hjson",
              "{proj_root}/hw/ip/gpio/dv/gpio_sim_cfg.hjson",
              "{proj_root}/hw/ip/hmac/dv/hmac_sim_cfg.hjson",
              "{proj_root}/hw/ip/i2c/dv/i2c_sim_cfg.hjson",


### PR DESCRIPTION
- entropy_src will now be run as a part of CI as well as the nightly
  regressions

Signed-off-by: Srikrishna Iyer <sriyer@google.com>