### PR TITLE
[sw, dif_plic] Remove redundant code and tidy up the code

### DIFF
--- a/sw/device/lib/dif/dif_plic.h
+++ b/sw/device/lib/dif/dif_plic.h
@@ -10,6 +10,12 @@
 
 #include "sw/device/lib/base/mmio.h"
 
+/** The lowest interrupt priority. */
+extern const uint32_t kDifPlicMinPriority;
+
+/** The highest interrupt priority. */
+extern const uint32_t kDifPlicMaxPriority;
+
 /**
  * PLIC interrupt source identifier.
  *

--- a/sw/device/tests/consecutive_irqs_test.c
+++ b/sw/device/tests/consecutive_irqs_test.c
@@ -16,8 +16,7 @@
 
 #define PLIC_TARGET kTopEarlgreyPlicTargetIbex0
 
-#define PLIC_PRIORITY_MIN 0u
-#define PLIC_PRIORITY_MAX 3u
+#define kDifPlicMinPriority 0u
 
 static dif_plic_t plic0;
 static dif_uart_t uart0;
@@ -163,19 +162,19 @@ static bool plic_configure_irqs(dif_plic_t *plic) {
 
   // Set IRQ priorities to MAX
   if (dif_plic_irq_priority_set(plic, kTopEarlgreyPlicIrqIdUartRxOverflow,
-                                PLIC_PRIORITY_MAX) != kDifPlicOk) {
+                                kDifPlicMaxPriority) != kDifPlicOk) {
     LOG_ERROR("priority set for RX overflow failed!");
     return false;
   }
 
   if (dif_plic_irq_priority_set(plic, kTopEarlgreyPlicIrqIdUartTxEmpty,
-                                PLIC_PRIORITY_MAX) != kDifPlicOk) {
+                                kDifPlicMaxPriority) != kDifPlicOk) {
     LOG_ERROR("priority set for TX empty failed!");
     return false;
   }
 
   // Set Ibex IRQ priority threshold level
-  if (dif_plic_target_threshold_set(&plic0, PLIC_TARGET, PLIC_PRIORITY_MIN) !=
+  if (dif_plic_target_threshold_set(&plic0, PLIC_TARGET, kDifPlicMinPriority) !=
       kDifPlicOk) {
     LOG_ERROR("threshold set failed!");
     return false;


### PR DESCRIPTION
There is no need to calculate the multireg register count and register
width in bits, as these values are now auto generated.

MAX Priority is useful outside of the DIF, so it has been exposed to
the consumers of the DIF.