### PR TITLE
[test] Increase timeout for pytest verilator runs

### DIFF
--- a/test/systemtest/functional_verilator_test.py
+++ b/test/systemtest/functional_verilator_test.py
@@ -47,7 +47,7 @@ class TestFunctionalVerilator:
 
         p_sim.terminate()
 
-    @pytest.mark.timeout(120)
+    @pytest.mark.timeout(240)
     def test_execute_binary(self, sim_top_earlgrey, uart_timeout, logfile):
         """
         Executes the binary and inspects its UART for "PASS!\r\n" or "FAIL!\r\n".


### PR DESCRIPTION
We're seeing intermittent RISC-V compliance CI failures with the 120
timeout so double it to 240.

Signed-off-by: Greg Chadwick <gac@lowrisc.org>