### PR TITLE
[dv/alert_handler] fix ping timeout with regen

### DIFF
--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
@@ -188,10 +188,12 @@ class alert_handler_base_vseq extends cip_base_vseq #(
     csr_wr(.csr(ral.classd_accum_thresh), .value(accum_thresh[3]));
   endtask
 
-  virtual task wr_ping_timeout_cycle(bit[TL_DW-1:0] timeout_val);
+  virtual task wr_ping_timeout_cycle(bit[TL_DW-1:0] timeout_val, bit config_locked);
     csr_wr(.csr(ral.ping_timeout_cyc), .value(timeout_val));
-    foreach (cfg.alert_host_cfg[i]) cfg.alert_host_cfg[i].ping_timeout_cycle = timeout_val;
-    foreach (cfg.esc_device_cfg[i]) cfg.esc_device_cfg[i].ping_timeout_cycle = timeout_val;
+    if (!config_locked) begin
+      foreach (cfg.alert_host_cfg[i]) cfg.alert_host_cfg[i].ping_timeout_cycle = timeout_val;
+      foreach (cfg.esc_device_cfg[i]) cfg.esc_device_cfg[i].ping_timeout_cycle = timeout_val;
+    end
   endtask
 
   // This sequence will automatically response to all escalation ping and esc responses

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_sanity_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_sanity_vseq.sv
@@ -52,8 +52,9 @@ class alert_handler_sanity_vseq extends alert_handler_base_vseq;
     max_phase_cyc inside {[0:1_000]};
   }
 
+  // set min to 32 cycles (default value) to avoid alert ping timeout due to random delay
   constraint ping_timeout_cyc_c {
-    ping_timeout_cyc inside {[0:100]};
+    ping_timeout_cyc inside {[32:100]};
   }
 
   constraint enable_classa_only_c {
@@ -109,7 +110,7 @@ class alert_handler_sanity_vseq extends alert_handler_base_vseq;
           // randomly write interrupt timeout resigers and accumulative threshold registers
           if (do_esc_intr_timeout) wr_intr_timeout_cycle(intr_timeout_cyc);
           wr_class_accum_threshold(accum_thresh);
-          wr_ping_timeout_cycle(ping_timeout_cyc);
+          wr_ping_timeout_cycle(ping_timeout_cyc, config_locked);
 
           //drive entropy
           cfg.entropy_vif.drive(rand_drive_entropy);


### PR DESCRIPTION
Previous commit forget to gate updating ping_timeout cycle with regen.
This PR fix it: when regen is set to 0, ping timeout value won't be
updated

Signed-off-by: Cindy Chen <chencindy@google.com>