### PR TITLE
[tlul] Host adaptor timing fix

### DIFF
--- a/hw/ip/tlul/rtl/tlul_adapter_host.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_host.sv
@@ -97,7 +97,7 @@ module tlul_adapter_host #(
     d_ready:   1'b1
   };
 
-  assign gnt_o   = tl_i.a_ready & req_i;
+  assign gnt_o   = tl_i.a_ready;
 
   assign valid_o = tl_i.d_valid;
   assign rdata_o = tl_i.d_data;


### PR DESCRIPTION
- The memory interface used for the Ibex I/D side and debug module use
  confusingly named req/gnt signalling
- Despite their names, these signals are effectively just a standard
  ready/valid handshake
- Neither Ibex nor the debug module rely on gnt |-> req
- Removing the loopback of req into grant significantly eases timing in
  Ibex and is required for enabling PMP

Signed-off-by: Tom Roberts <tomroberts@lowrisc.org>