### PR TITLE
[DO NOT MERGE] - Add MIO_OUTSEL pinmux exclusion

### DIFF
--- a/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
+++ b/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
@@ -21,7 +21,7 @@
 #  - n_dio_pads:          Number of dedicated IO pads
 #  - n_wkup_detect:       Number of wakeup condition detectors
 #  - wkup_cnt_width:      Width of wakeup counters
-# 
+#
 {
   name: "PINMUX",
   clock_primary: "clk_i",
@@ -193,7 +193,7 @@
                   ]
                   // Random writes to this field may result in pad drive conflicts,
                   // which in turn leads to propagating Xes and assertion failures.
-                  tags: ["excl:CsrNonInitTests:CsrExclWrite"]
+                  tags: ["excl:CsrAllTests:CsrExclWrite"]
                 }
     },
 # sleep behavior of MIO peripheral outputs


### PR DESCRIPTION
Without the additional MIO_OUTSEL exclusion, the csr_hw_reset_test
was creating pin conflicts that caused various assertions to fail.

Signed-off-by: Timothy Chen <timothytim@google.com>