### PR TITLE
[sw] Add bitfield_get_field32 extern declaration

### DIFF
--- a/sw/device/lib/base/bitfield.c
+++ b/sw/device/lib/base/bitfield.c
@@ -8,3 +8,6 @@
 // corresponding header a link location.
 extern uint32_t bitfield_set_field32(uint32_t bitfield,
                                      bitfield_field32_t field);
+
+extern uint32_t bitfield_get_field32(uint32_t bitfield,
+                                     bitfield_field32_t field);


### PR DESCRIPTION
This matches the extern declaration for bitfield_set_field32 that is
required to give the functions a link location.

I ran into a linker error with bitfield_get_field32 whilst working on the padctrl DIF. This fixed it though to be honest I'm slightly surprised it's required, doesn't the compiler just pull in the inline definition of the function from the header file (which was directly included in the dif_padctrl.c file that was getting the error).