### PR TITLE
[dv/alert_handler] fix three corner cases

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_monitor.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_monitor.sv
@@ -36,7 +36,7 @@ class alert_monitor extends alert_esc_base_monitor;
 
   virtual task ping_thread(uvm_phase phase);
     alert_esc_seq_item req;
-    bit                ping_p;
+    bit                ping_p, alert_p;
     forever @(cfg.vif.monitor_cb) begin
       if (ping_p != cfg.vif.get_ping_p()) begin
         phase.raise_objection(this, $sformatf("%s objection raised", `gfn));
@@ -51,6 +51,8 @@ class alert_monitor extends alert_esc_base_monitor;
                 req.timeout = 1'b1;
               end
               begin : wait_ping_handshake
+                // in case there is an alert happened before ping
+                if (alert_p != 0) cfg.vif.wait_alert_complete();
                 cfg.vif.wait_alert();
                 req.alert_handshake_sta = AlertReceived;
                 cfg.vif.wait_ack();
@@ -73,6 +75,7 @@ class alert_monitor extends alert_esc_base_monitor;
         under_ping_rsp = 0;
       end
       ping_p = cfg.vif.get_ping_p();
+      alert_p = cfg.vif.get_alert_p();
     end
   endtask : ping_thread
 

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_ping_rsp_fail_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_ping_rsp_fail_vseq.sv
@@ -9,9 +9,15 @@ class alert_handler_ping_rsp_fail_vseq extends alert_handler_entropy_vseq;
 
   `uvm_object_new
 
+  // always enable clr_en to hit the case when escalation ping interrupted by real esc sig
+  constraint clr_en_c {
+    clr_en      == '1;
+    lock_bit_en == 0;
+  }
+
   constraint sig_int_c {
     esc_int_err == '1;
-    esc_standalone_int_err dist {0 := 9, [1:'b1111] := 1};
+    esc_standalone_int_err dist {0 :/ 9, [1:'b1111] :/ 1};
   }
 
 endclass : alert_handler_ping_rsp_fail_vseq


### PR DESCRIPTION
1. Alert ping happened when alert is firing.
   Solution: monitor wait for alert to finish, then complete ping
   response
2. True escalation happened during escalation ping response.
   Fix: align the expected value according to the design FSM machine
3. Two classes' escalation phases assigned to same escalation signal,
   and the ending time only has one clk cycle difference.
   Solution: use realtime to record the last timing, and use that to
   correct the signal length count.

Signed-off-by: Cindy Chen <chencindy@google.com>