### PR TITLE
[dv/chip] fix csr_hw_reset X assertion issue

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
@@ -14,6 +14,7 @@ class chip_common_vseq extends chip_base_vseq;
     super.pre_start();
     // Select SPI interface.
     cfg.jtag_spi_n_vif.drive(1'b0);
+    enable_asserts_in_hw_reset_rand_wr = 0;
   endtask
 
   virtual task apply_reset(string kind = "HARD");
@@ -21,6 +22,13 @@ class chip_common_vseq extends chip_base_vseq;
     // TODO rstmgr takes some time to release reset for IPs. Need to find a better way to know when
     // reset is released by rstmgr
     cfg.clk_rst_vif.wait_clks(100);
+  endtask
+
+  virtual task dut_init(string reset_kind = "HARD");
+    // make sure jtag rst triggers
+    cfg.jtag_spi_n_vif.drive(1'b1);
+    super.dut_init(reset_kind);
+    cfg.jtag_spi_n_vif.drive(1'b0);
   endtask
 
   virtual task body();


### PR DESCRIPTION
The assertion issue from csr_hw_reset is mainly due to padring and tb
driving conflicts. If tb does not drive it, then high z will cause the
assertions to fire.
This PR attempt to disable the assertions during csr_hw_reset random
write CSRs. Then turn the assertions back on after hw_reset is issued.

I tried to adjust the pins from the tb side, but it does not work - 
1). The main issue is the driving conflicts between `tb` and `padring `(pad_wrapper). When the output of the padring connects to some other modules, say GPIO's `cio_gpio_i`. From there the X propagates to GPIO's `data_in_q.` When writing to GPIO's interrupt `ctrl_en `registers, it goes to `gpio_intr_o`, which is guarded by the assert_known assertions.

2).  From the TB side, the driving pin is: "bootstrap", driving at chip_dv_base.sv: 
 ``` 
 virtual task pre_start(); 
    ........
    // Drive strap signals at the start.
    if (do_strap_pins_init) begin
      cfg.srst_n_vif.drive(1'b1);
      cfg.jtag_spi_n_vif.drive(1'b1); // Select JTAG.
      cfg.bootstrap_vif.drive(1'b0);
    end   ........
  endtask
```

3). From the DESIGN side, the driving force is when: mio_outsel is set to 1: (out is the "mio_outsel" value)
```  assign (strong 0, strong 1) inout_io = (oe && drive == STRONG_DRIVE ) ? out : 1'bz;```

4). For this conflict, from the TB side, either driving 0 or 1 would not solve this conflict, as `mio_outsel` could be assigned to 0 or 1 randomly. If not driving from the tb side, high Z will cause the assertions to fail as well.

Signed-off-by: Cindy Chen <chencindy@google.com>