### PR TITLE
[dv/alert_handler] alert_ping response fail

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_monitor.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_monitor.sv
@@ -47,7 +47,7 @@ class alert_monitor extends alert_esc_base_monitor;
           begin : isolation_fork
             fork
               begin : wait_ping_timeout
-                repeat (cfg.handshake_timeout_cycle) @(cfg.vif.monitor_cb);
+                repeat (cfg.ping_timeout_cycle - 1) @(cfg.vif.monitor_cb);
                 req.timeout = 1'b1;
               end
               begin : wait_ping_handshake
@@ -57,12 +57,7 @@ class alert_monitor extends alert_esc_base_monitor;
                 req.alert_handshake_sta = AlertReceived;
                 cfg.vif.wait_ack();
                 req.alert_handshake_sta = AlertAckReceived;
-                cfg.vif.wait_alert_complete();
-                req.alert_handshake_sta = AlertComplete;
                 under_ping_rsp = 0;
-                // TODO: if now another alert triggered, will both sample the ack signal?
-                cfg.vif.wait_ack_complete();
-                req.alert_handshake_sta = AlertAckComplete;
               end
             join_any
             disable fork;

--- a/hw/dv/sv/alert_esc_agent/alert_sender_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_sender_driver.sv
@@ -60,7 +60,8 @@ class alert_sender_driver extends alert_esc_base_driver;
       cfg.vif.wait_ping();
 
       // TODO: solve this: if alert and ping all this task together
-      drive_alert_pins(req);
+      if (!req.timeout) drive_alert_pins(req);
+      else repeat (cfg.ping_timeout_cycle) @(cfg.vif.sender_cb);
 
       `uvm_info(`gfn,
           $sformatf("finished sending sender item, alert_send=%0b, ping_rsp=%0b, int_err=%0b",

--- a/hw/dv/sv/alert_esc_agent/esc_monitor.sv
+++ b/hw/dv/sv/alert_esc_agent/esc_monitor.sv
@@ -58,8 +58,7 @@ class esc_monitor extends alert_esc_base_monitor;
             ping_cnter ++;
           end
           while (req.esc_handshake_sta != EscRespComplete && ping_cnter < cfg.ping_timeout_cycle &&
-                  !cfg.probe_vif.get_esc_en());
-
+                 !cfg.probe_vif.get_esc_en());
           if (!cfg.probe_vif.get_esc_en()) begin
             if (ping_cnter == cfg.ping_timeout_cycle &&
                 req.esc_handshake_sta != EscRespComplete) begin

--- a/hw/dv/sv/alert_esc_agent/seq_lib/alert_sender_base_seq.sv
+++ b/hw/dv/sv/alert_esc_agent/seq_lib/alert_sender_base_seq.sv
@@ -15,6 +15,7 @@ class alert_sender_base_seq extends dv_base_seq #(
   rand bit s_alert_send;
   rand bit s_alert_ping_rsp;
   rand bit int_err;
+  rand bit timeout;
 
   virtual task body();
     `uvm_info(`gfn, $sformatf("starting alert sender transfer"), UVM_HIGH)
@@ -24,6 +25,7 @@ class alert_sender_base_seq extends dv_base_seq #(
         s_alert_send     == local::s_alert_send;
         s_alert_ping_rsp == local::s_alert_ping_rsp;
         int_err          == local::int_err;
+        timeout          == local::timeout;
     )
     `uvm_info(`gfn, $sformatf("seq_item: send_alert=%0b, ping_rsp=%0b, int_err=%0b",
         req.s_alert_send, req.s_alert_ping_rsp, req.int_err), UVM_MEDIUM)

--- a/hw/dv/sv/alert_esc_agent/seq_lib/alert_sender_seq.sv
+++ b/hw/dv/sv/alert_esc_agent/seq_lib/alert_sender_seq.sv
@@ -11,6 +11,7 @@ class alert_sender_seq extends alert_sender_base_seq;
   constraint alert_sender_seq_c {
     s_alert_send     == 1;
     s_alert_ping_rsp == 0;
+    timeout          == 0;
   }
 
 endclass : alert_sender_seq

--- a/hw/ip/alert_handler/dv/alert_handler_sim_cfg.hjson
+++ b/hw/ip/alert_handler/dv/alert_handler_sim_cfg.hjson
@@ -90,6 +90,7 @@
     {
       name: alert_handler_stress_all
       run_opts: ["+test_timeout_ns=25_000_000_000"]
+      reseed: 100
     }
   ]
 

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_common_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_common_vseq.sv
@@ -11,10 +11,10 @@ class alert_handler_common_vseq extends alert_handler_base_vseq;
 
   constraint delay_to_reset_c {
     delay_to_reset dist {
-        [1         :1000]       :/ 5,
-        [1001      :100_000]    :/ 1,
-        [100_001   :1_000_000]  :/ 1,
-        [1_000_001 :10_000_000] :/ 3
+        [1         :1000]        :/ 5, // reset during alert
+        [1001      :16_500_000]  :/ 2,
+        [16_500_001 :17_000_000] :/ 2, // reset during ping
+        [17_000_001 :18_000_000] :/ 1
     };
   }
 

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_entropy_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_entropy_vseq.sv
@@ -32,7 +32,6 @@ class alert_handler_entropy_vseq extends alert_handler_sanity_vseq;
   }
 
   function void pre_randomize();
-    this.enable_one_alert_c.constraint_mode(0);
     this.enable_classa_only_c.constraint_mode(0);
     verbosity = UVM_HIGH;
   endfunction

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_ping_rsp_fail_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_ping_rsp_fail_vseq.sv
@@ -18,6 +18,10 @@ class alert_handler_ping_rsp_fail_vseq extends alert_handler_entropy_vseq;
   constraint sig_int_c {
     esc_int_err == '1;
     esc_standalone_int_err dist {0 :/ 9, [1:'b1111] :/ 1};
+    alert_ping_timeout == '1;
   }
 
+  constraint ping_timeout_cyc_c {
+    ping_timeout_cyc inside {[0:100]};
+  }
 endclass : alert_handler_ping_rsp_fail_vseq

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_sanity_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_sanity_vseq.sv
@@ -14,6 +14,7 @@ class alert_handler_sanity_vseq extends alert_handler_base_vseq;
   rand bit [alert_pkg::NAlerts-1:0]        alert_trigger;
   rand bit [alert_pkg::NAlerts-1:0]        alert_int_err;
   rand bit [alert_pkg::NAlerts-1:0]        alert_en;
+  rand bit [alert_pkg::NAlerts-1:0]        alert_ping_timeout;
   rand bit [alert_pkg::NAlerts*2-1:0]      alert_class_map;
   rand bit [NUM_LOCAL_ALERT-1:0]           local_alert_en;
   rand bit [NUM_LOCAL_ALERT*2-1:0]         local_alert_class_map;
@@ -80,11 +81,10 @@ class alert_handler_sanity_vseq extends alert_handler_base_vseq;
   task body();
     fork
       begin : isolation_fork
-        bit config_locked;
         `DV_CHECK_RANDOMIZE_FATAL(this)
         run_esc_rsp_seq_nonblocking(esc_int_err);
-        run_alert_ping_rsp_seq_nonblocking();
-        `uvm_info(`gfn, $sformatf("num_trans=%0d", num_trans), UVM_MEDIUM)
+        run_alert_ping_rsp_seq_nonblocking(alert_ping_timeout);
+        `uvm_info(`gfn, $sformatf("num_trans=%0d", num_trans), UVM_LOW)
         for (int i = 1; i <= num_trans; i++) begin
           `DV_CHECK_RANDOMIZE_FATAL(this)
 
@@ -110,7 +110,7 @@ class alert_handler_sanity_vseq extends alert_handler_base_vseq;
           // randomly write interrupt timeout resigers and accumulative threshold registers
           if (do_esc_intr_timeout) wr_intr_timeout_cycle(intr_timeout_cyc);
           wr_class_accum_threshold(accum_thresh);
-          wr_ping_timeout_cycle(ping_timeout_cyc, config_locked);
+          wr_ping_timeout_cycle(ping_timeout_cyc);
 
           //drive entropy
           cfg.entropy_vif.drive(rand_drive_entropy);

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_stress_all_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_stress_all_vseq.sv
@@ -34,8 +34,14 @@ class alert_handler_stress_all_vseq extends alert_handler_base_vseq;
 
       // if upper seq disables do_dut_init for this seq, then can't issue reset
       // as upper seq may drive reset
-      if (do_dut_init) alert_vseq.do_dut_init = $urandom_range(0, 1);
-      else             alert_vseq.do_dut_init = 0;
+      if (do_dut_init) begin
+        alert_vseq.do_dut_init = $urandom_range(0, 1);
+        // config_locked will be set unless reset is issued
+        alert_vseq.config_locked = alert_vseq.do_dut_init ? 0 : config_locked;
+      end else begin
+        alert_vseq.do_dut_init = 0;
+        alert_vseq.config_locked = config_locked;
+      end
 
       alert_vseq.set_sequencer(p_sequencer);
       `DV_CHECK_RANDOMIZE_FATAL(alert_vseq)
@@ -46,6 +52,7 @@ class alert_handler_stress_all_vseq extends alert_handler_base_vseq;
       end
 
       alert_vseq.start(p_sequencer);
+      config_locked = alert_vseq.config_locked;
     end
   endtask : body
 


### PR DESCRIPTION
Alert ping response fail
Fix two issues:
1. regen (config_lock) in stress_all test won't be reset unless issuing
reset
2. interrupt update at negedge clk cycle to avoid race condition between
updating and reading

Signed-off-by: Cindy Chen <chencindy@google.com>