### PR TITLE
[otp_ctrl/formal] add bind file to formal target

### DIFF
--- a/hw/formal/fpv_all
+++ b/hw/formal/fpv_all
@@ -26,6 +26,7 @@ declare -a blocks=(
   "uart"
   "hmac"
   "flash_ctrl"
+  "otp_ctrl"
   "pwrmgr"
   "usbuart"
   "usbdev"

--- a/hw/ip/otp_ctrl/dv/tb/otp_ctrl_bind.sv
+++ b/hw/ip/otp_ctrl/dv/tb/otp_ctrl_bind.sv
@@ -1,0 +1,17 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+module otp_ctrl_bind;
+
+  bind otl_ctrl tlul_assert #(
+    .EndpointType("Device")
+  ) tlul_assert_device (
+    .clk_i,
+    .rst_ni,
+    .h2d  (tl_i),
+    .d2h  (tl_o)
+  );
+
+
+endmodule

--- a/hw/ip/otp_ctrl/otp_ctrl.core
+++ b/hw/ip/otp_ctrl/otp_ctrl.core
@@ -36,6 +36,11 @@ filesets:
       - lint/otp_ctrl.waiver
     file_type: waiver
 
+  files_formal:
+    files:
+      - dv/tb/otp_ctrl_bind.sv
+    file_type: systemVerilogSource
+
 parameters:
   SYNTHESIS:
     datatype: bool

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
@@ -214,7 +214,7 @@ module otp_ctrl
     .rst_ni,
     .data_i  ( {reg2hw.direct_access_wdata[1].q,
                 reg2hw.direct_access_wdata[0].q}    ),
-    .cmd_i   ( reg2hw.direct_access_wdata[1].q[2:0] ),
+    .cmd_i   ( otp_scrmbl_cmd_e'(reg2hw.direct_access_wdata[1].q[2:0]) ),
     .valid_i ( reg2hw.direct_access_wdata[1].qe     ),
     .ready_o (                                      ),
     .data_o  ( otp_scrambler_out                    ),

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv
@@ -38,7 +38,7 @@ package otp_ctrl_pkg;
   // Typedefs for LC Interface //
   ///////////////////////////////
 
-  parameter int NumAlerts = 1;
+  parameter int NumAlerts = 2;
   parameter logic [NumAlerts-1:0] AlertAsyncOn = NumAlerts'(1'b0);
 
   ///////////////////////////////
@@ -54,7 +54,7 @@ package otp_ctrl_pkg;
   } lc_value_e;
 
   // TODO: move to lc_ctrl_pkg
-  typedef enum lc_value_e [5:0] {
+  typedef enum logic [47:0] {
     //                GRP5    GRP4    GRP3    GRP2    GRP1    GRP0
     LcStateRaw     = {6{Value0}},
     LcStateTest    = {Value0, Value0, Value0, Value0, Value0, Value1},


### PR DESCRIPTION
Add otp_ctrl bind file to tb.
Add otp_ctrl to fpv_all run script.

Signed-off-by: Cindy Chen <chencindy@google.com>