### PR TITLE
[prim_ram_2p] Provide read data only if requested 

### DIFF
--- a/hw/ip/prim_generic/rtl/prim_generic_ram_2p.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_ram_2p.sv
@@ -59,8 +59,9 @@ module prim_generic_ram_2p #(
               a_wdata_i[i*DataBitsPerMask +: DataBitsPerMask];
           end
         end
+      end else begin
+        a_rdata_o <= mem[a_addr_i];
       end
-      a_rdata_o <= mem[a_addr_i];
     end
   end
 
@@ -73,8 +74,9 @@ module prim_generic_ram_2p #(
               b_wdata_i[i*DataBitsPerMask +: DataBitsPerMask];
           end
         end
+      end else begin
+        b_rdata_o <= mem[b_addr_i];
       end
-      b_rdata_o <= mem[b_addr_i];
     end
   end
 


### PR DESCRIPTION
Previously, the 2-port RAM primitive returned read data even for writes.
Simplify the primitive by returning read data only if it is explicitly
requested. This aligns the 2p implementation with the 1p RAM primitive.

Fixes #2201
