### PR TITLE
[i2c, dv] Updated documents (pre-V1)

### DIFF
--- a/hw/ip/i2c/data/i2c_testplan.hjson
+++ b/hw/ip/i2c/data/i2c_testplan.hjson
@@ -11,7 +11,7 @@
 
             Stimulus:
               - Enable I2C host.
-              - Clear/Enable interrupt (if nedded).
+              - Clear/Enable interrupt (if needed).
               - Program OVRD, FDATA register.
               - Randomize I2C timing in TIMING 0-4 registers and other parameters such as TL agent delays
               - Randomize address and data for write and read transfers sent to the device.
@@ -23,121 +23,51 @@
       tests: ["i2c_sanity"]
     }
     {
-      name: override
-      desc: '''Test SCL/SDA override
+      name: error
+      desc: '''
+            Program incorrect configuration into DUT register.
 
             Stimulus:
-              - Program OVRD register.
+              - Program negative value into timing registers.
+              - Program incorrect format flags into fdata register.
 
             Checking:
-              - Check scl_o, sda_o override by programmed values in the OVRD register.'''
+              - Check involved interrupts/alerts.
+              - Got timeout in test (scoreboard might not get any transaction for DUT).
+            '''
       milestone: V2
-      tests: ["i2c_override"]
+      tests: ["i2c_error"]
     }
     {
-      name: fmt_watermark
-      desc: '''Test fmt_watermark interrupt.
+      name: stress_all_with_reset
+      desc: '''
+            Pull reset at random times, make sure DUT recover/resets correctly and
+            there is no residual data left in the registers.
 
             Stimulus:
-              - Program random fmt (format) fifo watermark level and keep pushing data out by writing to
-            wdata.
+              - Randomly reset DUT.
+              - Restart send/receive transaction.
 
             Checking:
-              - As the number of pending data entries in the fmt fifo reaches the programmed
-                watermark level, ensure that the fmt watermark interrupt is asserted.
-              - Read the fifo status to cross-check, ensure interrupt stays asserted until cleared.'''
+              - Check if registers are properly reset.
+            '''
       milestone: V2
-      tests: ["i2c_fmt_watermark"]
+      tests: ["i2c_stress_all_with_rand_reset"]
     }
     {
-      name: rx_watermark
-      desc: '''Test rx_watermark interrupt.
+      name: perf
+      desc: '''
+            Send/receive transactions at max bandwidth
 
             Stimulus:
-              - Program random rx watermark level. Keep sending data over rx and read rdata
-                register in parallel with randomized delays large enough to reach a point where
-                the number of pending data items in rx fifo reaches the watermark level.
+              - Reduce access latency for fmt_fifo and rx_fifo.
+              - Issue long read/write transaction (and read rx_fifo as soon as read data valid).
 
             Checking:
-              - When that happens, check that the interrupt is asserted.'''
+              - Check if transaction are transceivered correctly 
+            '''
       milestone: V2
-      tests: ["i2c_rx_watermark"]
-    }
-    {
-      name: fmt_reset
-      desc: '''Test fmt_fifo reset.
-
-            Stimulus:
-              - Fill up the fmt fifo with data to be sent out. After a random number (less than
-                filled fifo size) of bytes shows up on fmt, reset the fifo.
-
-            Checking:
-              - Ensure that the remaining data bytes do not show up after fmt_fifo is reset.'''
-      milestone: V2
-      tests: ["i2c_fmt_reset"]
-    }
-    {
-      name: rx_reset
-      desc: '''Test rx_reset reset.
-
-            Stimulus:
-              - Fill up the rx fifo by sending data bytes in over rx. After a random number
-                (less than filled fifo size) of bytes sent over rx, reset the fifo.
-
-            Checking:
-              - Ensure that reads to rdata register yield 0s after rx_fifo is reset.'''
-      milestone: V2
-      tests: ["i2c_rx_reset"]
-    }
-    {
-      name: fmt_overflow
-      desc: '''Test fmt_overflow interrupt.
-
-            Stimulus:
-              - Keep writing over 32 bytes of data into wdata register.
-
-            Checking:
-              - Ensure excess data bytes are dropped and overflow interrupt is asserted.'''
-      milestone: V2
-      tests: ["i2c_fmt_overflow"]
-    }
-    {
-      name: rx_overflow
-      desc: '''Test rx_overflow interrupt.
-
-            Stimulus:
-              - Keep sending over 32 bytes of data over rx.
-
-            Checking:
-              - Ensure excess data bytes are dropped.'''
-      milestone: V2
-      tests: ["i2c_rx_overflow"]
-    }
-    {
-      name: fmt_rx_fifo_full
-      desc: '''Test fmt_fifo and rx_fifo in full states.
-
-            Stimulus:
-              - Send over 32 bytes of data but stop when fmt/rx fifo is full.
-
-            Checking:
-              - Check full states by reading fifo status register.'''
-      milestone: V2
-      tests: ["i2c_fmt_rx_fifo_full"]
-    }
-    {
-      name: rx_timeout
-      desc: '''Test rx_timeout state.
-
-            Stimulus:
-              - Program timeout_ctrl register to randomize the timeout. Send random number of
-                data over rx and read fewer data than sent and let the DUT sit idle or the
-                programmed timeout duration.
-
-            Checking:
-              - Ensure timeout interrupt fires.'''
-      milestone: V2
-      tests: ["i2c_rx_timeout"]
+      tests: ["i2c_perf"]
     }
     {
       name: stress
@@ -154,6 +84,123 @@
       tests: ["i2c_stress"]
     }
     {
+      name: override
+      desc: '''Test SCL/SDA override
+
+            Stimulus:
+              - Program OVRD register.
+
+            Checking:
+              - Check scl_o, sda_o override by programmed values in the OVRD register.'''
+      milestone: V2
+      tests: [""]
+    }
+    {
+      name: fmt_watermark
+      desc: '''Test fmt_watermark interrupt.
+
+            Stimulus:
+              - Program random fmt (format) fifo watermark level and keep pushing data out by writing to
+            wdata.
+
+            Checking:
+              - As the number of pending data entries in the fmt fifo reaches the programmed
+                watermark level, ensure that the fmt watermark interrupt is asserted.
+              - Read the fifo status to cross-check, ensure interrupt stays asserted until cleared.'''
+      milestone: V2
+      tests: [""]
+    }
+    {
+      name: rx_watermark
+      desc: '''Test rx_watermark interrupt.
+
+            Stimulus:
+              - Program random rx watermark level. Keep sending data over rx and read rdata
+                register in parallel with randomized delays large enough to reach a point where
+                the number of pending data items in rx fifo reaches the watermark level.
+
+            Checking:
+              - When that happens, check that the interrupt is asserted.'''
+      milestone: V2
+      tests: [""]
+    }
+    {
+      name: fmt_reset
+      desc: '''Test fmt_fifo reset.
+
+            Stimulus:
+              - Fill up the fmt fifo with data to be sent out. After a random number (less than
+                filled fifo size) of bytes shows up on fmt, reset the fifo.
+
+            Checking:
+              - Ensure that the remaining data bytes do not show up after fmt_fifo is reset.'''
+      milestone: V2
+      tests: [""]
+    }
+    {
+      name: rx_reset
+      desc: '''Test rx_reset reset.
+
+            Stimulus:
+              - Fill up the rx fifo by sending data bytes in over rx. After a random number
+                (less than filled fifo size) of bytes sent over rx, reset the fifo.
+
+            Checking:
+              - Ensure that reads to rdata register yield 0s after rx_fifo is reset.'''
+      milestone: V2
+      tests: [""]
+    }
+    {
+      name: fmt_overflow
+      desc: '''Test fmt_overflow interrupt.
+
+            Stimulus:
+              - Keep writing over 32 bytes of data into wdata register.
+
+            Checking:
+              - Ensure excess data bytes are dropped and overflow interrupt is asserted.'''
+      milestone: V2
+      tests: [""]
+    }
+    {
+      name: rx_overflow
+      desc: '''Test rx_overflow interrupt.
+
+            Stimulus:
+              - Keep sending over 32 bytes of data over rx.
+
+            Checking:
+              - Ensure excess data bytes are dropped.'''
+      milestone: V2
+      tests: [""]
+    }
+    {
+      name: fmt_rx_fifo_full
+      desc: '''Test fmt_fifo and rx_fifo in full states.
+
+            Stimulus:
+              - Send over 32 bytes of data but stop when fmt/rx fifo is full.
+
+            Checking:
+              - Check full states by reading fifo status register.'''
+      milestone: V2
+      tests: [""]
+    }
+    {
+      name: rx_timeout
+      desc: '''Test rx_timeout state.
+
+            Stimulus:
+              - Program timeout_ctrl register to randomize the timeout. Send random number of
+                data over rx and read fewer data than sent and let the DUT sit idle or the
+                programmed timeout duration.
+
+            Checking:
+              - Ensure timeout interrupt fires.'''
+      milestone: V2
+      tests: [""]
+    }
+    {
       name: rw_loopback
       desc: '''Test write data, read loopback, then compare.
 
@@ -163,7 +210,7 @@
             Checking:
               - After loopback is done, read data should be match with write data.'''
       milestone: V2
-      tests: ["i2c_rw_loopback"]
+      tests: [""]
     }
   ]
 }

--- a/hw/ip/i2c/doc/checklist.md
+++ b/hw/ip/i2c/doc/checklist.md
@@ -1,0 +1,232 @@
+---
+title: "I2C Checklist"
+---
+
+This checklist is for [Hardware Stage][] transitions for the [I2C peripheral.]({{<relref "hw/ip/i2c/doc" >}})
+All checklist items refer to the content in the [Checklist.]({{<relref "/doc/project/checklist.md">}})
+
+[Hardware Stage]: {{<relref "/doc/project/development_stages.md" >}}
+
+## Design Checklist
+
+### D1
+
+Type          | Item                  | Resolution  | Note/Collaterals
+--------------|-----------------------|-------------|------------------
+Documentation | [SPEC_COMPLETE][]     | Done        | [I2C Spec]({{<relref "hw/ip/i2c/doc" >}})
+Documentation | [CSR_DEFINED][]       | Done        |
+RTL           | [CLKRST_CONNECTED][]  | Done        |
+RTL           | [IP_TOP][]            | Done        |
+RTL           | [IP_INSTANTIABLE][]   | Done        |
+RTL           | [MEM_INSTANCED_80][]  | N/A         |
+RTL           | [FUNC_IMPLEMENTED][]  | Done        |
+RTL           | [ASSERT_KNOWN_ADDED][]| Done        |
+Code Quality  | [LINT_SETUP][]        | Done        |
+Review        | Reviewer(s)           | Not Started | 
+Review        | Signoff date          | Not Started | 
+
+
+[SPEC_COMPLETE]:      {{<relref "/doc/project/checklist.md#spec-complete" >}}
+[CSR_DEFINED]:        {{<relref "/doc/project/checklist.md#csr-defined" >}}
+[CLKRST_CONNECTED]:   {{<relref "/doc/project/checklist.md#clkrst-connected" >}}
+[IP_TOP]:             {{<relref "/doc/project/checklist.md#ip-top" >}}
+[IP_INSTANTIABLE]:    {{<relref "/doc/project/checklist.md#ip-instantiable" >}}
+[MEM_INSTANCED_80]:   {{<relref "/doc/project/checklist.md#mem-instanced-80" >}}
+[FUNC_IMPLEMENTED]:   {{<relref "/doc/project/checklist.md#func-implemented" >}}
+[ASSERT_KNOWN_ADDED]: {{<relref "/doc/project/checklist.md#assert-known-added" >}}
+[LINT_SETUP]:         {{<relref "/doc/project/checklist.md#lint-setup" >}}
+
+### D2
+
+Type          | Item                    | Resolution  | Note/Collaterals
+--------------|-------------------------|-------------|------------------
+Documentation | [NEW_FEATURES][]        | Not Started |
+Documentation | [BLOCK_DIAGRAM][]       | Not Started |
+Documentation | [DOC_INTERFACE][]       | Not Started |
+Documentation | [MISSING_FUNC][]        | Not Started |
+Documentation | [FEATURE_FROZEN][]      | Not Started |
+RTL           | [FEATURE_COMPLETE][]    | Not Started |
+RTL           | [AREA_SANITY_CHECK][]   | Not Started | 
+RTL           | [PORT_FROZEN][]         | Not Started |
+RTL           | [ARCHITECTURE_FROZEN][] | Not Started |
+RTL           | [REVIEW_TODO][]         | Not Started |
+RTL           | [STYLE_X][]             | Not Started | 
+Code Quality  | [LINT_PASS][]           | Not Started | 
+Code Quality  | [CDC_SETUP][]           | Not Started | 
+Code Quality  | [FPGA_TIMING][]         | Not Started | 
+Code Quality  | [CDC_SYNCMACRO][]       | Not Started |
+Review        | Reviewer(s)             | Not Started | 
+Review        | Signoff date            | Not Started | 
+
+[NEW_FEATURES]:        {{<relref "/doc/project/checklist.md#new-features" >}}
+[BLOCK_DIAGRAM]:       {{<relref "/doc/project/checklist.md#block-diagram" >}}
+[DOC_INTERFACE]:       {{<relref "/doc/project/checklist.md#doc-interface" >}}
+[MISSING_FUNC]:        {{<relref "/doc/project/checklist.md#missing-func" >}}
+[FEATURE_FROZEN]:      {{<relref "/doc/project/checklist.md#feature-frozen" >}}
+[FEATURE_COMPLETE]:    {{<relref "/doc/project/checklist.md#feature-complete" >}}
+[AREA_SANITY_CHECK]:   {{<relref "/doc/project/checklist.md#area-sanity-check" >}}
+[PORT_FROZEN]:         {{<relref "/doc/project/checklist.md#port-frozen" >}}
+[ARCHITECTURE_FROZEN]: {{<relref "/doc/project/checklist.md#architecture-frozen" >}}
+[REVIEW_TODO]:         {{<relref "/doc/project/checklist.md#review-todo" >}}
+[STYLE_X]:             {{<relref "/doc/project/checklist.md#style-x" >}}
+[LINT_PASS]:           {{<relref "/doc/project/checklist.md#lint-pass" >}}
+[CDC_SETUP]:           {{<relref "/doc/project/checklist.md#cdc-setup" >}}
+[CDC_SYNCMACRO]:       {{<relref "/doc/project/checklist.md#cdc-syncmacro" >}}
+[FPGA_TIMING]:         {{<relref "/doc/project/checklist.md#fpga-timing" >}}
+
+### D3
+
+ Type         | Item                    | Resolution  | Note/Collaterals
+--------------|-------------------------|-------------|------------------
+Documentation | [NEW_FEATURES_D3][]     | Not Started |
+RTL           | [TODO_COMPLETE][]       | Not Started |
+Code Quality  | [LINT_COMPLETE][]       | Not Started |
+Code Quality  | [CDC_COMPLETE][]        | Not Started |
+Review        | [REVIEW_RTL][]          | Not Started |
+Review        | [REVIEW_DELETED_FF][]   | Not Started |
+Review        | [REVIEW_SW_CSR][]       | Not Started |
+Review        | [REVIEW_SW_FATAL_ERR][] | Not Started |
+Review        | [REVIEW_SW_CHANGE][]    | Not Started |
+Review        | [REVIEW_SW_ERRATA][]    | Not Started |
+Review        | Reviewer(s)             | Not Started |
+Review        | Signoff date            | Not Started |
+
+[NEW_FEATURES_D3]:      {{<relref "/doc/project/checklist.md#new-features-d3" >}}
+[TODO_COMPLETE]:        {{<relref "/doc/project/checklist.md#todo-complete" >}}
+[LINT_COMPLETE]:        {{<relref "/doc/project/checklist.md#lint-complete" >}}
+[CDC_COMPLETE]:         {{<relref "/doc/project/checklist.md#cdc-complete" >}}
+[REVIEW_RTL]:           {{<relref "/doc/project/checklist.md#review-rtl" >}}
+[REVIEW_DBG]:           {{<relref "/doc/project/checklist.md#review-dbg" >}}
+[REVIEW_DELETED_FF]:    {{<relref "/doc/project/checklist.md#review-deleted-ff" >}}
+[REVIEW_SW_CSR]:        {{<relref "/doc/project/checklist.md#review-sw-csr" >}}
+[REVIEW_SW_FATAL_ERR]:  {{<relref "/doc/project/checklist.md#review-sw-fatal-err" >}}
+[REVIEW_SW_CHANGE]:     {{<relref "/doc/project/checklist.md#review-sw-change" >}}
+[REVIEW_SW_ERRATA]:     {{<relref "/doc/project/checklist.md#review-sw-errata" >}}
+
+## Verification Checklist
+
+### V1
+
+ Type         | Item                                  | Resolution  | Note/Collaterals
+--------------|---------------------------------------|-------------|------------------
+Documentation | [DV_PLAN_DRAFT_COMPLETED][]           | Done        | [i2c_dv_plan]({{<relref "hw/ip/i2c/doc/dv_plan" >}})
+Documentation | [TESTPLAN_COMPLETED][]                | Done        | [i2c_testplan]({{<relref "hw/ip/i2c/doc/dv_plan/index.md#testplan" >}})
+Testbench     | [TB_TOP_CREATED][]                    | Done        |
+Testbench     | [PRELIMINARY_ASSERTION_CHECKS_ADDED][]| Done        |
+Testbench     | [SIM_TB_ENV_CREATED][]                | Done        |
+Testbench     | [SIM_RAL_MODEL_GEN_AUTOMATED][]       | Done        |
+Testbench     | [CSR_CHECK_GEN_AUTOMATED][]           | waived      | Revisit later. Tool setup in progress.
+Testbench     | [TB_GEN_AUTOMATED][]                  | N/A         |
+Tests         | [SIM_SANITY_TEST_PASSING][]           | Not Started |
+Tests         | [SIM_CSR_MEM_TEST_SUITE_PASSING][]    | Done        |
+Tests         | [FPV_MAIN_ASSERTIONS_PROVEN][]        | N/A         |
+Tool Setup    | [SIM_ALT_TOOL_SETUP][]                | Done        | Xcelium (signoff), VCS (alt)
+Regression    | [SIM_SANITY_REGRESSION_SETUP][]       | Done        | Exception (implemented in local)
+Regression    | [SIM_NIGHTLY_REGRESSION_SETUP][]      | Done        | Exception (implemented in local)
+Regression    | [FPV_REGRESSION_SETUP][]              | N/A         |
+Coverage      | [SIM_COVERAGE_MODEL_ADDED][]          | Done        |
+Integration   | [PRE_VERIFIED_SUB_MODULES_V1][]       | N/A         | Except for IP module
+Review        | [DESIGN_SPEC_REVIEWED][]              | Done        |
+Review        | [DV_PLAN_TESTPLAN_REVIEWED][]         | Not Started |
+Review        | [STD_TEST_CATEGORIES_PLANNED][]       | Done        | Exception (Security, Power, Debug)
+Review        | [V2_CHECKLIST_SCOPED][]               | Done        |
+Review        | Reviewer(s)                           | Not Started | 
+Review        | Signoff date                          | Not Started | 
+
+[DV_PLAN_DRAFT_COMPLETED]:            {{<relref "/doc/project/checklist.md#dv-plan-draft-completed" >}}
+[TESTPLAN_COMPLETED]:                 {{<relref "/doc/project/checklist.md#testplan-completed" >}}
+[TB_TOP_CREATED]:                     {{<relref "/doc/project/checklist.md#tb-top-created" >}}
+[PRELIMINARY_ASSERTION_CHECKS_ADDED]: {{<relref "/doc/project/checklist.md#preliminary-assertion-checks-added" >}}
+[SIM_TB_ENV_CREATED]:                 {{<relref "/doc/project/checklist.md#sim-tb-env-created" >}}
+[SIM_RAL_MODEL_GEN_AUTOMATED]:        {{<relref "/doc/project/checklist.md#sim-ral-model-gen-automated" >}}
+[CSR_CHECK_GEN_AUTOMATED]:            {{<relref "/doc/project/checklist.md#csr-check-gen-automated" >}}
+[TB_GEN_AUTOMATED]:                   {{<relref "/doc/project/checklist.md#tb-gen-automated" >}}
+[SIM_SANITY_TEST_PASSING]:            {{<relref "/doc/project/checklist.md#sim-sanity-test-passing" >}}
+[SIM_CSR_MEM_TEST_SUITE_PASSING]:     {{<relref "/doc/project/checklist.md#sim-csr-mem-test-suite-passing" >}}
+[FPV_MAIN_ASSERTIONS_PROVEN]:         {{<relref "/doc/project/checklist.md#fpv-main-assertions-proven" >}}
+[SIM_ALT_TOOL_SETUP]:                 {{<relref "/doc/project/checklist.md#sim-alt-tool-setup" >}}
+[SIM_SANITY_REGRESSION_SETUP]:        {{<relref "/doc/project/checklist.md#sim-sanity-regression-setup" >}}
+[SIM_NIGHTLY_REGRESSION_SETUP]:       {{<relref "/doc/project/checklist.md#sim-nightly-regression-setup" >}}
+[FPV_REGRESSION_SETUP]:               {{<relref "/doc/project/checklist.md#fpv-regression-setup" >}}
+[SIM_COVERAGE_MODEL_ADDED]:           {{<relref "/doc/project/checklist.md#sim-coverage-model-added" >}}
+[PRE_VERIFIED_SUB_MODULES_V1]:        {{<relref "/doc/project/checklist.md#pre-verified-sub-modules-v1" >}}
+[DESIGN_SPEC_REVIEWED]:               {{<relref "/doc/project/checklist.md#design-spec-reviewed" >}}
+[DV_PLAN_TESTPLAN_REVIEWED]:          {{<relref "/doc/project/checklist.md#dv-plan-testplan-reviewed" >}}
+[STD_TEST_CATEGORIES_PLANNED]:        {{<relref "/doc/project/checklist.md#std-test-categories-planned" >}}
+[V2_CHECKLIST_SCOPED]:                {{<relref "/doc/project/checklist.md#v2-checklist-scoped" >}}
+
+### V2
+
+ Type         | Item                                    | Resolution  | Note/Collaterals
+--------------|-----------------------------------------|-------------|------------------
+Documentation | [DESIGN_DELTAS_CAPTURED_V2][]           | Not started |
+Documentation | [DV_PLAN_COMPLETED][]                   | Not started |
+Testbench     | [ALL_INTERFACES_EXERCISED][]            | Not started |
+Testbench     | [ALL_ASSERTION_CHECKS_ADDED][]          | Not started |
+Testbench     | [SIM_TB_ENV_COMPLETED][]                | Not started |
+Tests         | [SIM_ALL_TESTS_PASSING][]               | Not started |
+Tests         | [FPV_ALL_ASSERTIONS_WRITTEN][]          | Not started |
+Tests         | [FPV_ALL_ASSUMPTIONS_REVIEWED][]        | Not started |
+Tests         | [SIM_FW_SIMULATED][]                    | Not started |
+Regression    | [SIM_NIGHTLY_REGRESSION_V2][]           | Not started |
+Coverage      | [SIM_CODE_COVERAGE_V2][]                | Not started |
+Coverage      | [SIM_FUNCTIONAL_COVERAGE_V2][]          | Not started |
+Coverage      | [FPV_CODE_COVERAGE_V2][]                | Not started |
+Coverage      | [FPV_COI_COVERAGE_V2][]                 | Not started |
+Issues        | [NO_HIGH_PRIORITY_ISSUES_PENDING][]     | Not started |
+Issues        | [ALL_LOW_PRIORITY_ISSUES_ROOT_CAUSED][] | Not started |
+Integration   | [PRE_VERIFIED_SUB_MODULES_V2][]         | Not started |
+Review        | [V3_CHECKLIST_SCOPED][]                 | Not started |
+Review        | Reviewer(s)                             | Not started |
+Review        | Signoff date                            | Not started |
+
+[DESIGN_DELTAS_CAPTURED_V2]:          {{<relref "/doc/project/checklist.md#design-deltas-captured-v2" >}}
+[DV_PLAN_COMPLETED]:                  {{<relref "/doc/project/checklist.md#dv-plan-completed" >}}
+[ALL_INTERFACES_EXERCISED]:           {{<relref "/doc/project/checklist.md#all-interfaces-exercised" >}}
+[ALL_ASSERTION_CHECKS_ADDED]:         {{<relref "/doc/project/checklist.md#all-assertion-checks-added" >}}
+[SIM_TB_ENV_COMPLETED]:               {{<relref "/doc/project/checklist.md#sim-tb-env-completed" >}}
+[SIM_ALL_TESTS_PASSING]:              {{<relref "/doc/project/checklist.md#sim-all-tests-passing" >}}
+[FPV_ALL_ASSERTIONS_WRITTEN]:         {{<relref "/doc/project/checklist.md#fpv-all-assertions-written" >}}
+[FPV_ALL_ASSUMPTIONS_REVIEWED]:       {{<relref "/doc/project/checklist.md#fpv-all-assumptions-reviewed" >}}
+[SIM_FW_SIMULATED]:                   {{<relref "/doc/project/checklist.md#sim-fw-simulated" >}}
+[SIM_NIGHTLY_REGRESSION_V2]:          {{<relref "/doc/project/checklist.md#sim-nightly-regression-v2" >}}
+[SIM_CODE_COVERAGE_V2]:               {{<relref "/doc/project/checklist.md#sim-code-coverage-v2" >}}
+[SIM_FUNCTIONAL_COVERAGE_V2]:         {{<relref "/doc/project/checklist.md#sim-functional-coverage-v2" >}}
+[FPV_CODE_COVERAGE_V2]:               {{<relref "/doc/project/checklist.md#fpv-code-coverage-v2" >}}
+[FPV_COI_COVERAGE_V2]:                {{<relref "/doc/project/checklist.md#fpv-coi-coverage-v2" >}}
+[NO_HIGH_PRIORITY_ISSUES_PENDING]:    {{<relref "/doc/project/checklist.md#no-high-priority-issues-pending" >}}
+[ALL_LOW_PRIORITY_ISSUES_ROOT_CAUSED]:{{<relref "/doc/project/checklist.md#all-low-priority-issues-root-caused" >}}
+[PRE_VERIFIED_SUB_MODULES_V2]:        {{<relref "/doc/project/checklist.md#pre-verified-sub-modules-v2" >}}
+[V3_CHECKLIST_SCOPED]:                {{<relref "/doc/project/checklist.md#v3-checklist-scoped" >}}
+
+### V3
+
+ Type         | Item                              | Resolution  | Note/Collaterals
+--------------|-----------------------------------|-------------|------------------
+Documentation | [DESIGN_DELTAS_CAPTURED_V3][]     | Not started |
+Testbench     | [ALL_TODOS_RESOLVED][]            | Not started |
+Tests         | [X_PROP_ANALYSIS_COMPLETED][]     | Not started |
+Tests         | [FPV_ASSERTIONS_PROVEN_AT_V3][]   | Not started |
+Regression    | [SIM_NIGHTLY_REGRESSION_AT_V3][]  | Not started |
+Coverage      | [SIM_CODE_COVERAGE_AT_100][]      | Not started |
+Coverage      | [SIM_FUNCTIONAL_COVERAGE_AT_100][]| Not started |
+Coverage      | [FPV_CODE_COVERAGE_AT_100][]      | Not started |
+Coverage      | [FPV_COI_COVERAGE_AT_100][]       | Not started |
+Issues        | [NO_ISSUES_PENDING][]             | Not started |
+Code Quality  | [NO_TOOL_WARNINGS_THROWN][]       | Not started |
+Integration   | [PRE_VERIFIED_SUB_MODULES_V3][]   | Not started |
+Review        | Reviewer(s)                       | Not started |
+Review        | Signoff date                      | Not started |
+
+[DESIGN_DELTAS_CAPTURED_V3]:     {{<relref "/doc/project/checklist.md#design-deltas-captured-v3" >}}
+[ALL_TODOS_RESOLVED]:            {{<relref "/doc/project/checklist.md#all-todos-resolved" >}}
+[X_PROP_ANALYSIS_COMPLETED]:     {{<relref "/doc/project/checklist.md#x-prop-analysis-completed" >}}
+[FPV_ASSERTIONS_PROVEN_AT_V3]:   {{<relref "/doc/project/checklist.md#fpv-assertions-proven-at-v3" >}}
+[SIM_NIGHTLY_REGRESSION_AT_V3]:  {{<relref "/doc/project/checklist.md#sim-nightly-regression-at-v3" >}}
+[SIM_CODE_COVERAGE_AT_100]:      {{<relref "/doc/project/checklist.md#sim-code-coverage-at-100" >}}
+[SIM_FUNCTIONAL_COVERAGE_AT_100]:{{<relref "/doc/project/checklist.md#sim-functional-coverage-at-100" >}}
+[FPV_CODE_COVERAGE_AT_100]:      {{<relref "/doc/project/checklist.md#fpv-code-coverage-at-100" >}}
+[FPV_COI_COVERAGE_AT_100]:       {{<relref "/doc/project/checklist.md#fpv-coi-coverage-at-100" >}}
+[NO_ISSUES_PENDING]:             {{<relref "/doc/project/checklist.md#no-issues-pending" >}}
+[NO_TOOL_WARNINGS_THROWN]:       {{<relref "/doc/project/checklist.md#no-tool-warnings-thrown" >}}
+[PRE_VERIFIED_SUB_MODULES_V3]:   {{<relref "/doc/project/checklist.md#pre-verified-sub-modules-v3" >}}

--- a/hw/ip/i2c/doc/dv_plan/index.md
+++ b/hw/ip/i2c/doc/dv_plan/index.md
@@ -54,7 +54,7 @@ which provides the ability to drive and independently monitor random traffic via
 TL host interface into I2C device.
 
 ### I2C agent
-[describe or provide link to I2C agent documentation]
+I2C agent is configured to work device mode and implemented as [reactive slave](https://www.verilab.com/files/mastering_reactive_slaves.pdf)
 
 ### UVM RAL Model
 The I2C RAL model is created with the [`ralgen`]({{< relref "hw/dv/tools/ralgen/README.md" >}}) FuseSoC generator script automatically when the simulation is at the build stage.

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -29,9 +29,8 @@
                 // Common CIP test lists
                 "{proj_root}/hw/dv/data/tests/csr_tests.hjson",
                 "{proj_root}/hw/dv/data/tests/intr_test.hjson",
+                //"{proj_root}/hw/dv/data/tests/stress_tests.hjson",
                 "{proj_root}/hw/dv/data/tests/tl_access_tests.hjson"]
-                // TODO: enable stress tests later.
-                //"{proj_root}/hw/dv/data/tests/stress_tests.hjson"]
 
   // Add additional tops for simulation.
   sim_tops: ["-top i2c_bind"]
@@ -52,11 +51,10 @@
   ]
 
   // List of regressions.
-  regressions: [
-    // TODO: Add i2c_sanity test to the sanity suite once it is passing.
-    // {
-    //   name: sanity
-    //   tests: ["i2c_sanity"]
-    // }
-  ]
+  //regressions: [
+  //  {
+  //     name: sanity
+  //     tests: ["i2c_sanity"]
+  //  }
+  //]
 }


### PR DESCRIPTION
[i2c, dv] Updated documents to reflect dv changes (pre-V1)

  - add definition for error, reset_recovery, and perf test in i2c_testplan.hjson
  - update description for i2c_agent in index.md
  - add i2c_checklist.md (draft)

Signed-off-by: Tung Hoang <tung.hoang.290780@gmail.com>