### PR TITLE
[dv/alert_handler] a few minor fixed and cleanup

### DIFF
--- a/hw/ip/alert_handler/dv/alert_handler_sim_cfg.hjson
+++ b/hw/ip/alert_handler/dv/alert_handler_sim_cfg.hjson
@@ -83,7 +83,7 @@
 
     {
       name: alert_handler_ping_rsp_fail
-      uvm_test_seq: alert_handler_entropy_vseq
+      uvm_test_seq: alert_handler_ping_rsp_fail_vseq
       run_opts: ["+test_timeout_ns=20_000_000_000"]
     }
 

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_entropy_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_entropy_vseq.sv
@@ -9,9 +9,6 @@ class alert_handler_entropy_vseq extends alert_handler_sanity_vseq;
 
   `uvm_object_new
 
-  rand bit drive_entropy;
-  rand bit lock_regen;
-
   // large number of num_trans to make sure covers all alerts and escalation pings
   constraint num_trans_c {
     num_trans inside {[4_000:100_000]};

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_ping_rsp_fail_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_ping_rsp_fail_vseq.sv
@@ -10,7 +10,7 @@ class alert_handler_ping_rsp_fail_vseq extends alert_handler_entropy_vseq;
   `uvm_object_new
 
   // always enable clr_en to hit the case when escalation ping interrupted by real esc sig
-  constraint clr_en_c {
+  constraint clr_and_lock_en_c {
     clr_en      == '1;
     lock_bit_en == 0;
   }

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_sanity_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_sanity_vseq.sv
@@ -41,8 +41,8 @@ class alert_handler_sanity_vseq extends alert_handler_base_vseq;
   }
 
   constraint clr_and_lock_en_c {
-    clr_en      dist {0 :/ 6, [1:'b1111] :/ 4};
-    lock_bit_en dist {0 :/ 6, [1:'b1111] :/ 4};
+    clr_en      dist {'1 :/ 6, [0:'b1110] :/ 4};
+    lock_bit_en dist {0  :/ 6, [1:'b1111] :/ 4};
   }
 
   constraint enable_one_alert_c {


### PR DESCRIPTION
1. Fix runfile linked to a wrong run test
2. Fix ping_rsp_fail test constraint name
3. Clean up unused items in entropy test

Signed-off-by: Cindy Chen <chencindy@google.com>