### PR TITLE
[site] Align parent indicator

### DIFF
--- a/site/docs/assets/scss/_parents.scss
+++ b/site/docs/assets/scss/_parents.scss
@@ -22,7 +22,6 @@
     color: var(--text-color);
     display: block;
     text-decoration: none;
-    line-height: 1.2;
 
     &:hover,
     &:focus {


### PR DESCRIPTION
The first element is rendered differently in Chrome in contrast to
Firefox.
This happens with `list-style-type: none` active for the first element.
Removing the extra line height seems to fix the offset.

Signed-off-by: Tobias Wölfel <tobias.woelfel@mailbox.org>