### PR TITLE
[dvsim] Enable round-trip of environment varialbes into log file

### DIFF
--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -174,13 +174,16 @@ class Deploy():
                 self.odir_limiter(odir=self.odir)
             os.system("mkdir -p " + self.odir)
             # Dump all env variables for ease of debug.
-            with open(self.odir + "/env_vars", "w", encoding="UTF-8") as f:
+            with open(self.odir + "/env_vars",
+                      "w",
+                      encoding="UTF-8",
+                      errors="surrogateescape") as f:
                 for var in sorted(self.exports.keys()):
                     f.write("{}={}\n".format(var, self.exports[var]))
                 f.close()
             os.system("ln -s " + self.odir + " " + self.sim_cfg.links['D'] +
                       '/' + self.odir_ln)
-            f = open(self.log, "w", encoding="UTF-8")
+            f = open(self.log, "w", encoding="UTF-8", errors="surrogateescape")
             f.write("[Executing]:\n{}\n\n".format(self.cmd))
             f.flush()
             self.process = subprocess.Popen(args,


### PR DESCRIPTION
Environment variables are read by the dvsim tool and written back into a
log file. We define this log file as being UTF-8 encoded. The contents
of self.exports (read through os.environ()) are, however, locale-dependent.

Python retains the UTF-8 bytes it cannot decode in the system locale in
the string within a private Unicode coding space. This patch enables
writing them back into the log file.

An orthogonal (and desirable) fix is to change the CI runners to use
UTF-8 locales.