### PR TITLE
[RTL] Fix flash_ctrl dependencies

### DIFF
--- a/hw/ip/flash_ctrl/flash_ctrl.core
+++ b/hw/ip/flash_ctrl/flash_ctrl.core
@@ -10,6 +10,7 @@ filesets:
     depend:
       - lowrisc:ip:tlul
       - lowrisc:prim:all
+      - lowrisc:prim:flash
       - lowrisc:ip:flash_ctrl_pkg
     files:
       - rtl/flash_ctrl_reg_pkg.sv

--- a/hw/ip/prim_generic/prim_generic_flash.core
+++ b/hw/ip/prim_generic/prim_generic_flash.core
@@ -7,6 +7,8 @@ name: "lowrisc:prim_generic:flash"
 description: "prim"
 filesets:
   files_rtl:
+    depend:
+      - lowrisc:prim:ram_1p
     files:
       - rtl/prim_generic_flash.sv
     file_type: systemVerilogSource


### PR DESCRIPTION
- Ran into a compile issue where flash_ctrl fusesoc core adds dependency
on prim:all but needs 1p ram and flash to be able to compile.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>