### PR TITLE
[uvmdvgen] Minor env gen fix

### DIFF
--- a/util/uvmdvgen/env.core.tpl
+++ b/util/uvmdvgen/env.core.tpl
@@ -22,9 +22,7 @@ filesets:
       - ${name}_env_pkg.sv
       - ${name}_env_cfg.sv: {is_include_file: true}
       - ${name}_env_cov.sv: {is_include_file: true}
-% if env_agents != []:
       - ${name}_virtual_sequencer.sv: {is_include_file: true}
-% endif
       - ${name}_scoreboard.sv: {is_include_file: true}
       - ${name}_env.sv: {is_include_file: true}
       - seq_lib/${name}_vseq_list.sv: {is_include_file: true}


### PR DESCRIPTION
- Ran into this when generating the flash ctrl env. We add virtual
sequencer regardless of whether there are downstream agents or not.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>