### PR TITLE
[dv] Initial flash_ctrl DV testbench

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  name: "${name}"
+  name: "flash_ctrl"
   // TODO: remove the common testplans if not applicable
   import_testplans: ["hw/dv/tools/testplans/csr_testplan.hjson",
                      "hw/dv/tools/testplans/mem_testplan.hjson",
@@ -12,7 +12,7 @@
     {
       name: sanity
       desc: '''
-            Basic sanity test acessing a major datapath within the ${name}.
+            Basic sanity test acessing a major datapath within the flash_ctrl.
 
             **Stimulus**:
             - TBD
@@ -21,13 +21,7 @@
             - TBD
             '''
       milestone: V1
-      tests: ["${name}_sanity"]
-    }
-    {
-      name: feature1
-      desc: '''Add more test entries here like above.'''
-      milestone: V1
-      tests: []
+      tests: ["flash_ctrl_sanity"]
     }
   ]
 }

--- a/hw/ip/flash_ctrl/doc/dv_plan/index.md
+++ b/hw/ip/flash_ctrl/doc/dv_plan/index.md
@@ -1,0 +1,98 @@
+---
+title: "FLASH_CTRL DV Plan"
+---
+
+## Goals
+* **DV**
+  * Verify all FLASH_CTRL IP features by running dynamic simulations with a SV/UVM based testbench
+  * Develop and run all tests based on the [testplan](#testplan) below towards closing code and functional coverage on the IP and all of its sub-modules
+* **FPV**
+  * Verify TileLink device protocol compliance with an SVA based testbench
+
+## Current status
+* [Design & verification stage]({{< relref "hw" >}})
+  * [HW development stages]({{< relref "doc/project/development_stages" >}})
+* [Simulation results](https://reports.opentitan.org/hw/ip/flash_ctrl/dv/latest/results.html)
+
+## Design features
+For detailed information on FLASH_CTRL design features, please see the [FLASH_CTRL HWIP technical specification]({{< relref "hw/ip/flash_ctrl/doc" >}}).
+The design under test is a wrapper that instantiates the flash protocol controller, the flash phy controller and the TLUL SRAM adapter.
+This wrapper is currently maintained as a part of the DV testbench tentatively - its reorganization is under review.
+
+## Testbench architecture
+FLASH_CTRL testbench has been constructed based on the [CIP testbench architecture]({{< relref "hw/dv/sv/cip_lib/doc" >}}).
+
+### Block diagram
+![Block diagram](tb.svg)
+
+### Top level testbench
+Top level testbench is located at `hw/ip/flash_ctrl/dv/tb/tb.sv`. It instantiates the FLASH_CTRL DUT module `hw/ip/flash_ctrl/rtl/flash_ctrl.sv`.
+In addition, it instantiates the following interfaces, connects them to the DUT and sets their handle into `uvm_config_db`:
+* [Clock and reset interface]({{< relref "hw/dv/sv/common_ifs" >}})
+* [TileLink host interface for the flash controller]({{< relref "hw/dv/sv/tl_agent/README.md" >}})
+* [TileLink host interface for the eflash]({{< relref "hw/dv/sv/tl_agent/README.md" >}})
+* Interrupts ([`pins_if`]({{< relref "hw/dv/sv/common_ifs" >}})
+* Alerts ([`pins_if`]({{< relref "hw/dv/sv/common_ifs" >}})
+
+### Common DV utility components
+The following utilities provide generic helper tasks and functions to perform activities that are common across the project:
+* [dv_utils_pkg]({{< relref "hw/dv/sv/dv_utils/README.md" >}})
+* [csr_utils_pkg]({{< relref "hw/dv/sv/csr_utils/README.md" >}})
+
+### Global types & methods
+All common types and methods defined at the package level can be found in
+`flash_ctrl_env_pkg`. Some of them in use are:
+```systemverilog
+[list a few parameters, types & methods; no need to mention all]
+```
+### TL_agent
+FLASH_CTRL testbench instantiates (already handled in CIP base env) [tl_agent]({{< relref "hw/dv/sv/tl_agent/README.md" >}})
+which provides the ability to drive and independently monitor random traffic via
+TL host interface into FLASH_CTRL device.
+
+### UVM RAL Model
+The FLASH_CTRL RAL model is created with the [`ralgen`]({{< relref "hw/dv/tools/ralgen/README.md" >}}) FuseSoC generator script automatically when the simulation is at the build stage.
+
+It can be created manually (separately) by running `make` in the the `hw/` area.
+
+### Stimulus strategy
+#### Test sequences
+All test sequences reside in `hw/ip/flash_ctrl/dv/env/seq_lib`.
+The `flash_ctrl_base_vseq` virtual sequence is extended from `cip_base_vseq` and serves as a starting point.
+All test sequences are extended from `flash_ctrl_base_vseq`.
+It provides commonly used handles, variables, functions and tasks that the test sequences can simple use / call.
+Some of the most commonly used tasks / functions are as follows:
+* task 1:
+* task 2:
+
+#### Functional coverage
+To ensure high quality constrained random stimulus, it is necessary to develop a functional coverage model.
+The following covergroups have been developed to prove that the test intent has been adequately met:
+* cg1:
+* cg2:
+
+### Self-checking strategy
+#### Scoreboard
+The `flash_ctrl_scoreboard` is primarily used for end to end checking.
+It creates the following analysis ports to retrieve the data monitored by corresponding interface agents:
+* analysis port1:
+* analysis port2:
+<!-- explain inputs monitored, flow of data and outputs checked -->
+
+#### Assertions
+* TLUL assertions: The `tb/flash_ctrl_bind.sv` binds the `tlul_assert` [assertions]({{< relref "hw/ip/tlul/doc/TlulProtocolChecker.md" >}}) to the IP to ensure TileLink interface protocol compliance.
+* Unknown checks on DUT outputs: The RTL has assertions to ensure all outputs are initialized to known values after coming out of reset.
+* assert prop 1:
+* assert prop 2:
+
+## Building and running tests
+We are using our in-house developed [regression tool]({{< relref "hw/dv/tools/README.md" >}}) for building and running our tests and regressions.
+Please take a look at the link for detailed information on the usage, capabilities, features and known issues.
+Here's how to run a basic sanity test:
+```console
+$ cd hw/ip/flash_ctrl/dv
+$ make TEST_NAME=flash_ctrl_sanity
+```
+
+## Testplan
+{{</* testplan "hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson" */>}}

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.core
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.core
@@ -1,0 +1,39 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:flash_ctrl_env:0.1"
+description: "FLASH_CTRL DV UVM environment"
+filesets:
+  files_dv:
+    depend:
+      - lowrisc:dv:ralgen
+      - lowrisc:dv:cip_lib
+      - lowrisc:dv:mem_bkdr_if
+    files:
+      - flash_ctrl_env_pkg.sv
+      - flash_ctrl_wrapper_reg_block.sv: {is_include_file: true}
+      - flash_ctrl_env_cfg.sv: {is_include_file: true}
+      - flash_ctrl_env_cov.sv: {is_include_file: true}
+      - flash_ctrl_virtual_sequencer.sv: {is_include_file: true}
+      - flash_ctrl_scoreboard.sv: {is_include_file: true}
+      - flash_ctrl_env.sv: {is_include_file: true}
+      - seq_lib/flash_ctrl_vseq_list.sv: {is_include_file: true}
+      - seq_lib/flash_ctrl_base_vseq.sv: {is_include_file: true}
+      - seq_lib/flash_ctrl_common_vseq.sv: {is_include_file: true}
+      - seq_lib/flash_ctrl_sanity_vseq.sv: {is_include_file: true}
+    file_type: systemVerilogSource
+
+generate:
+  ral:
+    generator: ralgen
+    parameters:
+      name: flash_ctrl
+      ip_hjson: ../../data/flash_ctrl.hjson
+
+targets:
+  default:
+    filesets:
+      - files_dv
+    generate:
+      - ral

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.sv
@@ -1,0 +1,67 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class flash_ctrl_env extends cip_base_env #(
+    .CFG_T              (flash_ctrl_env_cfg),
+    .COV_T              (flash_ctrl_env_cov),
+    .VIRTUAL_SEQUENCER_T(flash_ctrl_virtual_sequencer),
+    .SCOREBOARD_T       (flash_ctrl_scoreboard)
+  );
+  `uvm_component_utils(flash_ctrl_env)
+
+  tl_agent        m_eflash_tl_agent;
+  tl_reg_adapter  m_eflash_tl_reg_adapter;
+
+  `uvm_component_new
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    if (cfg.zero_delays) begin
+      cfg.m_eflash_tl_agent_cfg.a_valid_delay_min = 0;
+      cfg.m_eflash_tl_agent_cfg.a_valid_delay_max = 0;
+      cfg.m_eflash_tl_agent_cfg.d_valid_delay_min = 0;
+      cfg.m_eflash_tl_agent_cfg.d_valid_delay_max = 0;
+      cfg.m_eflash_tl_agent_cfg.a_ready_delay_min = 0;
+      cfg.m_eflash_tl_agent_cfg.a_ready_delay_max = 0;
+      cfg.m_eflash_tl_agent_cfg.d_ready_delay_min = 0;
+      cfg.m_eflash_tl_agent_cfg.d_ready_delay_max = 0;
+    end
+
+    // get the vifs from config db
+    foreach (cfg.mem_bkdr_vifs[i]) begin
+      if (!uvm_config_db#(mem_bkdr_vif)::get(this, "", $sformatf("mem_bkdr_vifs[%0d]", i),
+                                             cfg.mem_bkdr_vifs[i])) begin
+        `uvm_fatal(`gfn, $sformatf("failed to get mem_bkdr_vifs[%0d] from uvm_config_db", i))
+      end
+    end
+
+    // create components
+    m_eflash_tl_agent = tl_agent::type_id::create("m_eflash_tl_agent", this);
+    m_eflash_tl_reg_adapter = tl_reg_adapter#()::type_id::create("m_eflash_tl_reg_adapter");
+    uvm_config_db#(tl_agent_cfg)::set(
+        this, "m_eflash_tl_agent*", "cfg", cfg.m_eflash_tl_agent_cfg);
+  endfunction
+
+  function void connect_phase(uvm_phase phase);
+    super.connect_phase(phase);
+    if (cfg.en_scb) begin
+      m_eflash_tl_agent.monitor.a_chan_port.connect(
+          scoreboard.eflash_tl_a_chan_fifo.analysis_export);
+      m_eflash_tl_agent.monitor.d_chan_port.connect(
+          scoreboard.eflash_tl_d_chan_fifo.analysis_export);
+    end
+    if (cfg.is_active) begin
+      virtual_sequencer.eflash_tl_sequencer_h = m_eflash_tl_agent.sequencer;
+    end
+  endfunction
+
+  virtual function void end_of_elaboration_phase(uvm_phase phase);
+    super.end_of_elaboration_phase(phase);
+    // Set the TL adapter / sequencer to the eflash_map.
+    // if (cfg.m_eflash_tl_agent_cfg.is_active) begin
+    //   cfg.ral.eflash_map.set_sequencer(m_eflash_tl_agent.sequencer, m_eflash_tl_reg_adapter);
+    // end
+  endfunction : end_of_elaboration_phase
+
+endclass

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
@@ -1,0 +1,43 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class flash_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(flash_ctrl_wrapper_reg_block));
+
+  // vifs
+  mem_bkdr_vif      mem_bkdr_vifs[NUM_FLASH_BANKS];
+
+  // ext component cfgs
+  rand tl_agent_cfg m_eflash_tl_agent_cfg;
+
+  // knobs
+  // ral.status[init_wip] status is set for the very first clock cycle right out of reset.
+  // This causes problems in the read value especially in CSR tests.
+  int post_reset_delay_clks = 1;
+
+  `uvm_object_utils_begin(flash_ctrl_env_cfg)
+    `uvm_field_object(m_eflash_tl_agent_cfg, UVM_DEFAULT)
+  `uvm_object_utils_end
+
+  `uvm_object_new
+
+  virtual function void initialize_csr_addr_map_size();
+    this.csr_addr_map_size = FLASH_CTRL_ADDR_MAP_SIZE;
+  endfunction : initialize_csr_addr_map_size
+
+  virtual function void initialize(bit [31:0] csr_base_addr = '1);
+    super.initialize(csr_base_addr);
+    // create tl agent config obj
+    m_eflash_tl_agent_cfg = tl_agent_cfg::type_id::create("m_eflash_tl_agent_cfg");
+    m_eflash_tl_agent_cfg.if_mode = dv_utils_pkg::Host;
+
+    // set num_interrupts & num_alerts
+    begin
+      uvm_reg rg = ral.get_reg_by_name("intr_state");
+      if (rg != null) begin
+        num_interrupts = ral.intr_state.get_n_used_bits();
+      end
+    end
+  endfunction
+
+endclass

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cov.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cov.sv
@@ -1,0 +1,32 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Covergoups that are dependent on run-time parameters that may be available
+ * only in build_phase can be defined here
+ * Covergroups may also be wrapped inside helper classes if needed.
+ */
+
+class flash_ctrl_env_cov extends cip_base_env_cov #(.CFG_T(flash_ctrl_env_cfg));
+  `uvm_component_utils(flash_ctrl_env_cov)
+
+  // the base class provides the following handles for use:
+  // flash_ctrl_env_cfg: cfg
+
+  // covergroups
+  // [add covergroups here]
+
+  function new(string name, uvm_component parent);
+    super.new(name, parent);
+    // [instantiate covergroups here]
+  endfunction : new
+
+  virtual function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    // [or instantiate covergroups here]
+    // Please instantiate sticky_intr_cov array of objects for all interrupts that are sticky
+    // See cip_base_env_cov for details
+  endfunction
+
+endclass

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
@@ -1,0 +1,50 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package flash_ctrl_env_pkg;
+  // dep packages
+  import uvm_pkg::*;
+  import top_pkg::*;
+  import dv_utils_pkg::*;
+  import dv_lib_pkg::*;
+  import tl_agent_pkg::*;
+  import cip_base_pkg::*;
+  import csr_utils_pkg::*;
+  import flash_ctrl_ral_pkg::*;
+
+  // macro includes
+  `include "uvm_macros.svh"
+  `include "dv_macros.svh"
+
+  // parameters
+  parameter uint FLASH_CTRL_ADDR_MAP_SIZE = 128;
+
+  // TODO: These might be made into RTL design parameters.
+  parameter NUM_FLASH_BANKS = 2;
+
+  // types
+  typedef enum int {
+    FlashCtrlIntrProgEmpty  = 0,
+    FlashCtrlIntrProgLvl    = 1,
+    FlashCtrlIntrRdFull     = 2,
+    FlashCtrlIntrRdLvl      = 3,
+    FlashCtrlIntrOpDone     = 4,
+    FlashCtrlIntrOpError    = 5,
+    NumFlashCtrlIntr        = 6
+  } flash_ctrl_intr_e;
+
+  typedef virtual mem_bkdr_if mem_bkdr_vif;
+
+  // functions
+
+  // package sources
+  `include "flash_ctrl_wrapper_reg_block.sv"
+  `include "flash_ctrl_env_cfg.sv"
+  `include "flash_ctrl_env_cov.sv"
+  `include "flash_ctrl_virtual_sequencer.sv"
+  `include "flash_ctrl_scoreboard.sv"
+  `include "flash_ctrl_env.sv"
+  `include "flash_ctrl_vseq_list.sv"
+
+endpackage

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
@@ -1,0 +1,115 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class flash_ctrl_scoreboard extends cip_base_scoreboard #(
+    .CFG_T(flash_ctrl_env_cfg),
+    .RAL_T(flash_ctrl_wrapper_reg_block),
+    .COV_T(flash_ctrl_env_cov)
+  );
+  `uvm_component_utils(flash_ctrl_scoreboard)
+
+  // local variables
+
+  // TLM agent fifos
+  uvm_tlm_analysis_fifo #(tl_seq_item)  eflash_tl_a_chan_fifo;
+  uvm_tlm_analysis_fifo #(tl_seq_item)  eflash_tl_d_chan_fifo;
+
+  // local queues to hold incoming packets pending comparison
+
+  `uvm_component_new
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    eflash_tl_a_chan_fifo = new("eflash_tl_a_chan_fifo", this);
+    eflash_tl_d_chan_fifo = new("eflash_tl_d_chan_fifo", this);
+  endfunction
+
+  function void connect_phase(uvm_phase phase);
+    super.connect_phase(phase);
+  endfunction
+
+  task run_phase(uvm_phase phase);
+    super.run_phase(phase);
+    fork
+      process_eflash_tl_a_chan_fifo();
+      process_eflash_tl_d_chan_fifo();
+    join_none
+  endtask
+
+  virtual task process_eflash_tl_a_chan_fifo();
+    tl_seq_item item;
+    forever begin
+      eflash_tl_a_chan_fifo.get(item);
+      if (!cfg.en_scb) continue;
+    end
+  endtask
+
+  virtual task process_eflash_tl_d_chan_fifo();
+    tl_seq_item item;
+    forever begin
+      eflash_tl_d_chan_fifo.get(item);
+      if (!cfg.en_scb) continue;
+      `uvm_info(`gfn, $sformatf("Received eflash_tl d_chan item:\n%0s", item.sprint()), UVM_HIGH)
+      // check tl packet integrity
+      void'(item.is_ok());
+    end
+  endtask
+
+  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel = DataChannel);
+    uvm_reg csr;
+    bit     do_read_check   = 1'b1;
+    bit     write           = item.is_write();
+    uvm_reg_addr_t csr_addr = get_normalized_addr(item.a_addr);
+
+    // if access was to a valid csr, get the csr handle
+    if (csr_addr inside {cfg.csr_addrs}) begin
+      csr = ral.default_map.get_reg_by_offset(csr_addr);
+      `DV_CHECK_NE_FATAL(csr, null)
+    end
+    else begin
+      `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
+    end
+
+    if (channel == AddrChannel) begin
+      // if incoming access is a write to a valid csr, then make updates right away
+      if (write) begin
+        void'(csr.predict(.value(item.a_data), .kind(UVM_PREDICT_WRITE), .be(item.a_mask)));
+      end
+    end
+
+    // process the csr req
+    // for write, update local variable and fifo at address phase
+    // for read, update predication at address phase and compare at data phase
+    case (csr.get_name())
+      // add individual case item for each csr
+      default: begin
+        `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
+      end
+    endcase
+
+    // On reads, if do_read_check, is set, then check mirrored_value against item.d_data
+    if (!write && channel == DataChannel) begin
+      if (do_read_check) begin
+        `DV_CHECK_EQ(csr.get_mirrored_value(), item.d_data,
+                     $sformatf("reg name: %0s", csr.get_full_name()))
+      end
+      void'(csr.predict(.value(item.d_data), .kind(UVM_PREDICT_READ)));
+    end
+  endtask
+
+  virtual function void reset(string kind = "HARD");
+    super.reset(kind);
+    // reset local fifos queues and variables
+    eflash_tl_a_chan_fifo.flush();
+    eflash_tl_d_chan_fifo.flush();
+  endfunction
+
+  function void check_phase(uvm_phase phase);
+    super.check_phase(phase);
+    // post test checks - ensure that all local fifos and queues are empty
+    `DV_EOT_PRINT_TLM_FIFO_CONTENTS(tl_seq_item, eflash_tl_a_chan_fifo)
+    `DV_EOT_PRINT_TLM_FIFO_CONTENTS(tl_seq_item, eflash_tl_d_chan_fifo)
+  endfunction
+
+endclass

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_virtual_sequencer.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_virtual_sequencer.sv
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class flash_ctrl_virtual_sequencer extends cip_base_virtual_sequencer #(
+    .CFG_T(flash_ctrl_env_cfg),
+    .COV_T(flash_ctrl_env_cov)
+  );
+  `uvm_component_utils(flash_ctrl_virtual_sequencer)
+
+  tl_sequencer eflash_tl_sequencer_h;
+
+  `uvm_component_new
+
+endclass

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_wrapper_reg_block.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_wrapper_reg_block.sv
@@ -1,0 +1,53 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Class: eflash_mem
+class eflash_mem extends dv_base_mem;
+
+  `uvm_object_utils(eflash_mem)
+
+  function new(string           name = "eflash_mem",
+               longint unsigned size = 131072,
+               int unsigned     n_bits = 32,
+               string           access = "RW",
+               int              has_coverage = UVM_NO_COVERAGE);
+    super.new(name, size, n_bits, access, has_coverage);
+  endfunction : new
+
+endclass : eflash_mem
+
+// Class: flash_ctrl_wrapper_reg_block
+class flash_ctrl_wrapper_reg_block extends flash_ctrl_reg_block;
+  // Create a separate map for eflash since it is attached to a different TL interface.
+  uvm_reg_map eflash_map;
+
+  // memories
+  rand eflash_mem eflash;
+
+  `uvm_object_utils(flash_ctrl_wrapper_reg_block)
+
+  function new(string name = "flash_ctrl_wrapper_reg_block",
+               int    has_coverage = UVM_NO_COVERAGE);
+    super.new(name, has_coverage);
+  endfunction : new
+
+
+  virtual function void build(uvm_reg_addr_t base_addr,
+                              csr_utils_pkg::csr_excl_item csr_excl = null);
+    super.build(base_addr, csr_excl);
+    // TODO: Uncomment once CSR sequence fixes are made.
+    // // create eflash map
+    // this.eflash_map = create_map(.name("eflash_map"),
+    //                              .base_addr(base_addr),
+    //                              .n_bytes(4),
+    //                              .endian(UVM_LITTLE_ENDIAN));
+    // // create memory
+    // eflash = eflash_mem::type_id::create("eflash");
+    // eflash.configure(.parent(this));
+    // eflash_map.add_mem(.mem(eflash),
+    //                    .offset(32'h0),
+    //                    .rights("RW"));
+  endfunction : build
+
+endclass : flash_ctrl_wrapper_reg_block

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
@@ -1,0 +1,40 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class flash_ctrl_base_vseq extends cip_base_vseq #(
+    .RAL_T               (flash_ctrl_wrapper_reg_block),
+    .CFG_T               (flash_ctrl_env_cfg),
+    .COV_T               (flash_ctrl_env_cov),
+    .VIRTUAL_SEQUENCER_T (flash_ctrl_virtual_sequencer)
+  );
+  `uvm_object_utils(flash_ctrl_base_vseq)
+
+  // various knobs to enable certain routines
+  bit do_flash_ctrl_init = 1'b1;
+
+  `uvm_object_new
+
+  virtual task dut_init(string reset_kind = "HARD");
+    super.dut_init();
+    if (do_flash_ctrl_init) flash_ctrl_init();
+  endtask
+
+  virtual task dut_shutdown();
+    // check for pending flash_ctrl operations and wait for them to complete
+    // TODO
+  endtask
+
+  virtual task apply_reset(string kind = "HARD");
+    super.apply_reset(kind);
+    if (kind == "HARD") begin
+      cfg.clk_rst_vif.wait_clks(cfg.post_reset_delay_clks);
+    end
+  endtask
+
+  // setup basic flash_ctrl features
+  virtual task flash_ctrl_init();
+    //`uvm_error(`gfn, "FIXME")
+  endtask
+
+endclass : flash_ctrl_base_vseq

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_common_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_common_vseq.sv
@@ -1,0 +1,17 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class flash_ctrl_common_vseq extends flash_ctrl_base_vseq;
+  `uvm_object_utils(flash_ctrl_common_vseq)
+
+  constraint num_trans_c {
+    num_trans inside {[1:2]};
+  }
+  `uvm_object_new
+
+  virtual task body();
+    run_common_vseq_wrapper(num_trans);
+  endtask : body
+
+endclass

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_sanity_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_sanity_vseq.sv
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// basic sanity test vseq
+class flash_ctrl_sanity_vseq extends flash_ctrl_base_vseq;
+  `uvm_object_utils(flash_ctrl_sanity_vseq)
+
+  `uvm_object_new
+
+  task body();
+    `uvm_error(`gfn, "FIXME")
+  endtask : body
+
+endclass : flash_ctrl_sanity_vseq

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_vseq_list.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_vseq_list.sv
@@ -1,0 +1,7 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`include "flash_ctrl_base_vseq.sv"
+`include "flash_ctrl_sanity_vseq.sv"
+`include "flash_ctrl_common_vseq.sv"

--- a/hw/ip/flash_ctrl/dv/flash_ctrl_sim.core
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_sim.core
@@ -1,0 +1,31 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:flash_ctrl_sim:0.1"
+description: "FLASH_CTRL DV sim target"
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:ip:tlul
+      - lowrisc:ip:flash_ctrl_pkg
+      - lowrisc:ip:flash_ctrl:0.1
+    files:
+      - tb/flash_ctrl_wrapper.sv
+      - tb/flash_ctrl_bind.sv
+    file_type: systemVerilogSource
+
+  files_dv:
+    depend:
+      - lowrisc:dv:flash_ctrl_test
+    files:
+      - tb/tb.sv
+    file_type: systemVerilogSource
+
+targets:
+  sim:
+    toplevel: tb
+    filesets:
+      - files_rtl
+      - files_dv
+    default_tool: vcs

--- a/hw/ip/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson
@@ -3,10 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   // Name of the sim cfg - typically same as the name of the DUT.
-  name: ${name}
+  name: flash_ctrl
 
   // Top level dut name (sv module).
-  dut: ${name}
+  dut: flash_ctrl
 
   // Top level testbench name (sv module).
   tb: tb
@@ -15,39 +15,23 @@
   tool: vcs
 
   // Fusesoc core file used for building the file list.
-  fusesoc_core: lowrisc:dv:${name}_sim:0.1
+  fusesoc_core: lowrisc:dv:flash_ctrl_sim:0.1
 
   // Testplan hjson file.
-  testplan: "{proj_root}/hw/ip/${name}/data/${name}_testplan.hjson"
+  testplan: "{proj_root}/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson"
 
-% if has_ral:
   // RAL spec - used to generate the RAL model.
-  ral_spec: "{proj_root}/hw/ip/${name}/data/${name}.hjson"
-% endif
+  ral_spec: "{proj_root}/hw/ip/flash_ctrl/data/flash_ctrl.hjson"
 
   // Import additional common sim cfg files.
-  // TODO: remove imported cfgs that do not apply.
-% if is_cip:
   import_cfgs: [// Project wide common sim cfg file
                 "{proj_root}/hw/dv/data/common_sim_cfg.hjson",
                 // Common CIP test lists
-% if has_ral:
                 "{proj_root}/hw/dv/data/tests/csr_tests.hjson",
-% endif
                 "{proj_root}/hw/dv/data/tests/mem_tests.hjson",
-% if has_interrupts:
                 "{proj_root}/hw/dv/data/tests/intr_test.hjson",
-% endif
                 "{proj_root}/hw/dv/data/tests/tl_access_tests.hjson",
                 "{proj_root}/hw/dv/data/tests/stress_tests.hjson"]
-% else:
-  import_cfgs: [// Project wide common sim cfg file
-                "{proj_root}/hw/dv/data/common_sim_cfg.hjson",
-% if has_ral:
-                "{proj_root}/hw/dv/data/tests/csr_tests.hjson",
-                "{proj_root}/hw/dv/data/tests/mem_tests.hjson"]
-% endif
-% endif
 
   // Add additional tops for simulation.
   sim_tops: ["-top {name}_bind"]
@@ -56,24 +40,22 @@
   reseed: 50
 
   // Default UVM test and seq class name.
-  uvm_test: ${name}_base_test
-  uvm_test_seq: ${name}_base_vseq
+  uvm_test: flash_ctrl_base_test
+  uvm_test_seq: flash_ctrl_base_vseq
 
   // List of test specifications.
   tests: [
     {
-      name: ${name}_sanity
-      uvm_test_seq: ${name}_sanity_vseq
+      name: flash_ctrl_sanity
+      uvm_test_seq: flash_ctrl_sanity_vseq
     }
-
-    // TODO: add more tests here
   ]
 
   // List of regressions.
   regressions: [
     {
       name: sanity
-      tests: ["${name}_sanity"]
+      tests: ["flash_ctrl_sanity"]
     }
   ]
 }

--- a/hw/ip/flash_ctrl/dv/tb/flash_ctrl_wrapper.sv
+++ b/hw/ip/flash_ctrl/dv/tb/flash_ctrl_wrapper.sv
@@ -1,0 +1,93 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+module flash_ctrl_wrapper (
+  // Clock and Reset
+  input        clk_i,
+  input        rst_ni,
+
+  // Bus Interface
+  input        tlul_pkg::tl_h2d_t flash_ctrl_tl_i,
+  output       tlul_pkg::tl_d2h_t flash_ctrl_tl_o,
+
+  input        tlul_pkg::tl_h2d_t eflash_tl_i,
+  output       tlul_pkg::tl_d2h_t eflash_tl_o,
+
+  // Interrupts
+  output logic intr_prog_empty_o, // Program fifo is empty
+  output logic intr_prog_lvl_o,   // Program fifo is empty
+  output logic intr_rd_full_o,    // Read fifo is full
+  output logic intr_rd_lvl_o,     // Read fifo is full
+  output logic intr_op_done_o,    // Requested flash operation (wr/erase) done
+  output logic intr_op_error_o    // Requested flash operation (wr/erase) done
+);
+
+  // define inter-module signals
+  flash_ctrl_pkg::flash_req_t     flash_ctrl_flash_req;
+  flash_ctrl_pkg::flash_rsp_t     flash_ctrl_flash_rsp;
+
+  flash_ctrl u_flash_ctrl (
+    .tl_i (flash_ctrl_tl_i),
+    .tl_o (flash_ctrl_tl_o),
+
+    // Interrupt
+    .intr_prog_empty_o(intr_prog_empty_o),
+    .intr_prog_lvl_o  (intr_prog_lvl_o),
+    .intr_rd_full_o   (intr_rd_full_o),
+    .intr_rd_lvl_o    (intr_rd_lvl_o),
+    .intr_op_done_o   (intr_op_done_o),
+    .intr_op_error_o  (intr_op_error_o),
+
+    // Inter-module signals
+    .flash_o  (flash_ctrl_flash_req),
+    .flash_i  (flash_ctrl_flash_rsp),
+
+    .clk_i    (clk_i),
+    .rst_ni   (rst_ni)
+  );
+
+  // host to flash communication
+  logic flash_host_req;
+  logic flash_host_req_rdy;
+  logic flash_host_req_done;
+  logic [flash_ctrl_pkg::BusWidth-1:0] flash_host_rdata;
+  logic [flash_ctrl_pkg::AddrW-1:0] flash_host_addr;
+
+  tlul_adapter_sram #(
+    .SramAw(flash_ctrl_pkg::AddrW),
+    .SramDw(flash_ctrl_pkg::BusWidth),
+    .Outstanding(2),
+    .ByteAccess(0),
+    .ErrOnWrite(1)
+  ) u_tl_adapter_eflash (
+    .clk_i    (clk_i),
+    .rst_ni   (rst_ni),
+
+    .tl_i     (eflash_tl_i),
+    .tl_o     (eflash_tl_o),
+
+    .req_o    (flash_host_req),
+    .gnt_i    (flash_host_req_rdy),
+    .we_o     (),
+    .addr_o   (flash_host_addr),
+    .wdata_o  (),
+    .wmask_o  (),
+    .rdata_i  (flash_host_rdata),
+    .rvalid_i (flash_host_req_done),
+    .rerror_i (2'b00)
+  );
+
+  flash_phy u_flash_eflash (
+    .clk_i           (clk_i),
+    .rst_ni          (rst_ni),
+    .host_req_i      (flash_host_req),
+    .host_addr_i     (flash_host_addr),
+    .host_req_rdy_o  (flash_host_req_rdy),
+    .host_req_done_o (flash_host_req_done),
+    .host_rdata_o    (flash_host_rdata),
+    .flash_ctrl_i    (flash_ctrl_flash_req),
+    .flash_ctrl_o    (flash_ctrl_flash_rsp)
+  );
+
+endmodule

--- a/hw/ip/flash_ctrl/dv/tb/tb.sv
+++ b/hw/ip/flash_ctrl/dv/tb/tb.sv
@@ -1,0 +1,88 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+module tb;
+  // dep packages
+  import uvm_pkg::*;
+  import dv_utils_pkg::*;
+  import flash_ctrl_env_pkg::*;
+  import flash_ctrl_test_pkg::*;
+
+  // macro includes
+  `include "uvm_macros.svh"
+  `include "dv_macros.svh"
+
+  wire clk, rst_n;
+  wire devmode;
+  wire intr_prog_empty;
+  wire intr_prog_lvl;
+  wire intr_rd_full;
+  wire intr_rd_lvl;
+  wire intr_op_done;
+  wire intr_op_error;
+  wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
+
+  // interfaces
+  clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
+  pins_if #(NUM_MAX_INTERRUPTS) intr_if(interrupts);
+  pins_if #(1) devmode_if(devmode);
+  tl_if tl_if(.clk(clk), .rst_n(rst_n));
+  tl_if eflash_tl_if(.clk(clk), .rst_n(rst_n));
+
+  // dut
+  flash_ctrl_wrapper dut (
+    .clk_i                (clk        ),
+    .rst_ni               (rst_n      ),
+
+    .flash_ctrl_tl_i      (tl_if.h2d  ),
+    .flash_ctrl_tl_o      (tl_if.d2h  ),
+
+    .eflash_tl_i          (eflash_tl_if.h2d),
+    .eflash_tl_o          (eflash_tl_if.d2h),
+
+    .intr_prog_empty_o (intr_prog_empty ),
+    .intr_prog_lvl_o   (intr_prog_lvl   ),
+    .intr_rd_full_o    (intr_rd_full    ),
+    .intr_rd_lvl_o     (intr_rd_lvl     ),
+    .intr_op_done_o    (intr_op_done    ),
+    .intr_op_error_o   (intr_op_error   )
+  );
+
+  // bind mem_bkdr_if
+  `define FLASH_MEM_HIER(i) \
+      dut.u_flash_eflash.gen_flash_banks[``i``].i_core.i_flash.gen_generic.u_impl_generic.u_mem
+
+  generate
+    for (genvar i = 0; i < NUM_FLASH_BANKS; i++) begin : mem_bkdr_if_i
+      bind `FLASH_MEM_HIER(i) mem_bkdr_if mem_bkdr_if();
+      initial begin
+        uvm_config_db#(mem_bkdr_vif)::set(null, "*.env", $sformatf("mem_bkdr_vifs[%0d]", i),
+                                          `FLASH_MEM_HIER(i).mem_bkdr_if);
+      end
+    end
+  endgenerate
+
+  `undef FLASH_MEM_HIER
+
+  // Connect the interrupts
+  assign interrupts[FlashCtrlIntrProgEmpty] = intr_prog_empty;
+  assign interrupts[FlashCtrlIntrProgLvl]   = intr_prog_lvl;
+  assign interrupts[FlashCtrlIntrRdFull]    = intr_rd_full;
+  assign interrupts[FlashCtrlIntrRdLvl]     = intr_rd_lvl;
+  assign interrupts[FlashCtrlIntrOpDone]    = intr_op_done;
+  assign interrupts[FlashCtrlIntrOpError]   = intr_op_error;
+
+  initial begin
+    // drive clk and rst_n from clk_if
+    clk_rst_if.set_active();
+    uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
+    uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
+    uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
+    uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
+    uvm_config_db#(virtual tl_if)::set(null, "*.env.m_eflash_tl_agent*", "vif", eflash_tl_if);
+    $timeformat(-12, 0, " ps", 12);
+    run_test();
+  end
+
+endmodule

--- a/hw/ip/flash_ctrl/dv/tests/flash_ctrl_base_test.sv
+++ b/hw/ip/flash_ctrl/dv/tests/flash_ctrl_base_test.sv
@@ -1,0 +1,20 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class flash_ctrl_base_test extends cip_base_test #(
+    .CFG_T(flash_ctrl_env_cfg),
+    .ENV_T(flash_ctrl_env)
+  );
+
+  `uvm_component_utils(flash_ctrl_base_test)
+  `uvm_component_new
+
+  // the base class dv_base_test creates the following instances:
+  // flash_ctrl_env_cfg: cfg
+  // flash_ctrl_env:     env
+
+  // the base class also looks up UVM_TEST_SEQ plusarg to create and run that seq in
+  // the run_phase; as such, nothing more needs to be done
+
+endclass : flash_ctrl_base_test

--- a/hw/ip/flash_ctrl/dv/tests/flash_ctrl_test.core
+++ b/hw/ip/flash_ctrl/dv/tests/flash_ctrl_test.core
@@ -1,0 +1,19 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:flash_ctrl_test:0.1"
+description: "FLASH_CTRL DV UVM test"
+filesets:
+  files_dv:
+    depend:
+      - lowrisc:dv:flash_ctrl_env
+    files:
+      - flash_ctrl_test_pkg.sv
+      - flash_ctrl_base_test.sv: {is_include_file: true}
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_dv

--- a/hw/ip/flash_ctrl/dv/tests/flash_ctrl_test_pkg.sv
+++ b/hw/ip/flash_ctrl/dv/tests/flash_ctrl_test_pkg.sv
@@ -1,0 +1,22 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package flash_ctrl_test_pkg;
+  // dep packages
+  import uvm_pkg::*;
+  import cip_base_pkg::*;
+  import flash_ctrl_env_pkg::*;
+
+  // macro includes
+  `include "uvm_macros.svh"
+  `include "dv_macros.svh"
+
+  // local types
+
+  // functions
+
+  // package sources
+  `include "flash_ctrl_base_test.sv"
+
+endpackage

--- a/util/uvmdvgen/base_test.sv.tpl
+++ b/util/uvmdvgen/base_test.sv.tpl
@@ -23,10 +23,9 @@ class ${name}_base_test extends dv_base_test #(
     super.build_phase(phase);
     cfg.has_ral = 1'b0;
   endfunction
-% endif
 
+% endif
   // the base class also looks up UVM_TEST_SEQ plusarg to create and run that seq in
   // the run_phase; as such, nothing more needs to be done
 
 endclass : ${name}_base_test
-


### PR DESCRIPTION
- Initial dump using `uvmdvgen`
- Added hand-written `flash_ctrl_wrapper` module
- Added hand-written `flash_ctrl_wrapper_reg_block` that adds eflash mem
to the autogenerated RAL model

- This PR needs an additional fix made in #2281.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>