### PR TITLE
[dv/alert_handler] styling and three minor fixes

### DIFF
--- a/hw/ip/alert_handler/dv/env/alert_handler_scoreboard.sv
+++ b/hw/ip/alert_handler/dv/env/alert_handler_scoreboard.sv
@@ -268,7 +268,10 @@ class alert_handler_scoreboard extends cip_base_scoreboard #(
           // disable intr_enable or clear intr_state will clear the interrupt timeout cnter
           "intr_state": begin
             foreach (under_intr_classes[i]) begin
-              if (item.a_data[i]) under_intr_classes[i] = 0;
+              if (item.a_data[i]) begin
+                under_intr_classes[i] = 0;
+                clr_esc_under_intr[i] = 0;
+              end
             end
             fork
               begin
@@ -493,10 +496,10 @@ class alert_handler_scoreboard extends cip_base_scoreboard #(
       begin
         if (under_esc_classes [class_i]) intr_cnter_per_class[class_i] = 0;
         if (under_intr_classes[class_i]) clr_esc_under_intr[class_i] = 1;
-        under_esc_classes[class_i]              = 0;
+        under_esc_classes[class_i] = 0;
         cfg.clk_rst_vif.wait_clks(1);
         last_triggered_alert_per_class[class_i] = $realtime;
-        accum_cnter_per_class[class_i]          = 0;
+        accum_cnter_per_class[class_i] = 0;
       end
     join_none
   endtask

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
@@ -192,6 +192,7 @@ class alert_handler_base_vseq extends cip_base_vseq #(
   virtual task wr_ping_timeout_cycle(bit[TL_DW-1:0] timeout_val);
     csr_wr(.csr(ral.ping_timeout_cyc), .value(timeout_val));
     if (!config_locked) begin
+      if (timeout_val == 0) timeout_val = 1;
       foreach (cfg.alert_host_cfg[i]) cfg.alert_host_cfg[i].ping_timeout_cycle = timeout_val;
       foreach (cfg.esc_device_cfg[i]) cfg.esc_device_cfg[i].ping_timeout_cycle = timeout_val;
     end

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_common_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_common_vseq.sv
@@ -5,6 +5,8 @@
 class alert_handler_common_vseq extends alert_handler_base_vseq;
   `uvm_object_utils(alert_handler_common_vseq)
 
+  rand bit entropy_bit;
+
   constraint num_trans_c {
     num_trans inside {[1:2]};
   }
@@ -21,6 +23,8 @@ class alert_handler_common_vseq extends alert_handler_base_vseq;
   `uvm_object_new
 
   virtual task body();
+    // driven entropy to avoid assertion error in ping_timer
+    cfg.entropy_vif.drive(entropy_bit);
     run_common_vseq_wrapper(num_trans);
   endtask : body
 

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_entropy_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_entropy_vseq.sv
@@ -28,6 +28,10 @@ class alert_handler_entropy_vseq extends alert_handler_sanity_vseq;
     do_lock_config == 1;
   }
 
+  constraint esc_accum_thresh_c {
+    foreach (accum_thresh[i]) {accum_thresh[i] dist {[0:1] :/ 5, [2:10] :/ 5};}
+  }
+
   function void pre_randomize();
     this.enable_classa_only_c.constraint_mode(0);
     verbosity = UVM_HIGH;

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_random_alerts_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_random_alerts_vseq.sv
@@ -9,6 +9,10 @@ class alert_handler_random_alerts_vseq extends alert_handler_sanity_vseq;
 
   `uvm_object_new
 
+  constraint esc_accum_thresh_c {
+    foreach (accum_thresh[i]) {accum_thresh[i] dist {[0:1] :/ 5, [2:5] :/ 5};}
+  }
+
   function void pre_randomize();
     this.enable_one_alert_c.constraint_mode(0);
   endfunction

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_sanity_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_sanity_vseq.sv
@@ -41,8 +41,8 @@ class alert_handler_sanity_vseq extends alert_handler_base_vseq;
   }
 
   constraint clr_and_lock_en_c {
-    clr_en      dist {'1 :/ 6, [0:'b1110] :/ 4};
-    lock_bit_en dist {0  :/ 6, [1:'b1111] :/ 4};
+    clr_en      dist {[0:'b1110] :/ 4, '1         :/ 6};
+    lock_bit_en dist {0          :/ 6, [1:'b1111] :/ 4};
   }
 
   constraint enable_one_alert_c {

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_sig_int_fail_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_sig_int_fail_vseq.sv
@@ -13,6 +13,10 @@ class alert_handler_sig_int_fail_vseq extends alert_handler_sanity_vseq;
     esc_int_err == 0;
   }
 
+  constraint esc_accum_thresh_c {
+    foreach (accum_thresh[i]) {accum_thresh[i] dist {[0:1] :/ 5, [2:10] :/ 5};}
+  }
+
   function void pre_randomize();
     this.enable_one_alert_c.constraint_mode(0);
     this.enable_classa_only_c.constraint_mode(0);


### PR DESCRIPTION
1. Fix nit issue from #2271
2. Adjust constraint to relax accum count threshold
3. Add one more clear conditions in case corner case when interrupt is
cleared right after esc_clr
4. Drive entropy in alert_handler_common_test to avoid assertion errors (only happened if common_test sequences run very long time)

Signed-off-by: Cindy Chen <chencindy@google.com>