### PR TITLE
[fpv/pinmux] fix complie error

### DIFF
--- a/hw/ip/pinmux/fpv/tb/pinmux_fpv.sv
+++ b/hw/ip/pinmux/fpv/tb/pinmux_fpv.sv
@@ -5,19 +5,19 @@
 // Testbench module for pinmux. Intended to use with a formal tool.
 
 module pinmux_fpv (
-  input                                          clk_i,
-  input                                          rst_ni,
-  input  tlul_pkg::tl_h2d_t                      tl_i,
-  output tlul_pkg::tl_d2h_t                      tl_o,
-  input        [pinmux_reg_pkg::NPeriphOut-1:0]  periph_to_mio_i,
-  input        [pinmux_reg_pkg::NPeriphOut-1:0]  periph_to_mio_oe_i,
-  output logic [pinmux_reg_pkg::NPeriphIn-1:0]   mio_to_periph_o,
-  output logic [pinmux_reg_pkg::NMioPads-1:0]    mio_out_o,
-  output logic [pinmux_reg_pkg::NMioPads-1:0]    mio_oe_o,
-  input        [pinmux_reg_pkg::NMioPads-1:0]    mio_in_i,
+  input                                            clk_i,
+  input                                            rst_ni,
+  input  tlul_pkg::tl_h2d_t                        tl_i,
+  output tlul_pkg::tl_d2h_t                        tl_o,
+  input        [pinmux_reg_pkg::NMioPeriphOut-1:0] periph_to_mio_i,
+  input        [pinmux_reg_pkg::NMioPeriphOut-1:0] periph_to_mio_oe_i,
+  output logic [pinmux_reg_pkg::NMioPeriphIn-1:0]  mio_to_periph_o,
+  output logic [pinmux_reg_pkg::NMioPads-1:0]      mio_out_o,
+  output logic [pinmux_reg_pkg::NMioPads-1:0]      mio_oe_o,
+  input        [pinmux_reg_pkg::NMioPads-1:0]      mio_in_i,
   // symbolic inputs for FPV
-  input [$clog2(pinmux_reg_pkg::NPeriphIn)-1:0] periph_sel_i,
-  input [$clog2(pinmux_reg_pkg::NMioPads)-1:0]  mio_sel_i
+  input [$clog2(pinmux_reg_pkg::NMioPeriphIn)-1:0] periph_sel_i,
+  input [$clog2(pinmux_reg_pkg::NMioPads)-1:0]     mio_sel_i
 );
 
   pinmux i_pinmux (

--- a/hw/ip/pinmux/fpv/vip/pinmux_assert_fpv.sv
+++ b/hw/ip/pinmux/fpv/vip/pinmux_assert_fpv.sv
@@ -7,16 +7,16 @@
 `include "prim_assert.sv"
 
 module pinmux_assert_fpv (
-  input                                  clk_i,
-  input                                  rst_ni,
-  input tlul_pkg::tl_h2d_t               tl_i,
-  input tlul_pkg::tl_d2h_t               tl_o,
-  input [pinmux_reg_pkg::NPeriphOut-1:0] periph_to_mio_i,
-  input [pinmux_reg_pkg::NPeriphOut-1:0] periph_to_mio_oe_i,
-  input [pinmux_reg_pkg::NPeriphIn-1:0]  mio_to_periph_o,
-  input [pinmux_reg_pkg::NMioPads-1:0]   mio_out_o,
-  input [pinmux_reg_pkg::NMioPads-1:0]   mio_oe_o,
-  input [pinmux_reg_pkg::NMioPads-1:0]   mio_in_i
+  input                                     clk_i,
+  input                                     rst_ni,
+  input tlul_pkg::tl_h2d_t                  tl_i,
+  input tlul_pkg::tl_d2h_t                  tl_o,
+  input [pinmux_reg_pkg::NMioPeriphOut-1:0] periph_to_mio_i,
+  input [pinmux_reg_pkg::NMioPeriphOut-1:0] periph_to_mio_oe_i,
+  input [pinmux_reg_pkg::NMioPeriphIn-1:0]  mio_to_periph_o,
+  input [pinmux_reg_pkg::NMioPads-1:0]      mio_out_o,
+  input [pinmux_reg_pkg::NMioPads-1:0]      mio_oe_o,
+  input [pinmux_reg_pkg::NMioPads-1:0]      mio_in_i
 );
 
   ///////////////
@@ -24,10 +24,10 @@ module pinmux_assert_fpv (
   ///////////////
 
   // symbolic inputs for FPV
-  logic [$clog2(pinmux_reg_pkg::NPeriphIn)-1:0] periph_sel_i;
+  logic [$clog2(pinmux_reg_pkg::NMioPeriphIn)-1:0] periph_sel_i;
   logic [$clog2(pinmux_reg_pkg::NMioPads)-1:0]  mio_sel_i;
 
-  `ASSUME(PeriphSelRange_M, periph_sel_i < pinmux_reg_pkg::NPeriphIn)
+  `ASSUME(PeriphSelRange_M, periph_sel_i < pinmux_reg_pkg::NMioPeriphIn)
   `ASSUME(PeriphSelStable_M, ##1 $stable(periph_sel_i))
 
   pinmux_reg_pkg::pinmux_reg2hw_periph_insel_mreg_t periph_insel;
@@ -60,9 +60,9 @@ module pinmux_assert_fpv (
       mio_out_o[mio_sel_i] == 1'b1)
   `ASSERT(OutSel2_A, mio_outsel.q == 2 |->
       mio_out_o[mio_sel_i] == 1'b0)
-  `ASSERT(OutSelN_A, mio_outsel.q > 2 && mio_outsel.q < pinmux_reg_pkg::NPeriphOut + 3 |->
+  `ASSERT(OutSelN_A, mio_outsel.q > 2 && mio_outsel.q < pinmux_reg_pkg::NMioPeriphOut + 3 |->
       mio_out_o[mio_sel_i] == periph_to_mio_i[mio_outsel.q - 3])
-  `ASSERT(OutSelOOB_A, mio_outsel.q >= pinmux_reg_pkg::NPeriphOut + 3 |->
+  `ASSERT(OutSelOOB_A, mio_outsel.q >= pinmux_reg_pkg::NMioPeriphOut + 3 |->
       mio_out_o[mio_sel_i] == 0)
   `ASSERT(MioOutO_A, ##1 !$stable(mio_out_o[mio_sel_i]) |->
        !$stable(mio_outsel.q) || !$stable(periph_to_mio_i[mio_outsel.q - 3]))
@@ -73,9 +73,9 @@ module pinmux_assert_fpv (
       mio_oe_o[mio_sel_i] == 1'b1)
   `ASSERT(OutSelOe2_A, mio_outsel.q == 2 |->
       mio_oe_o[mio_sel_i] == 1'b0)
-  `ASSERT(OutSelOeN_A, mio_outsel.q > 2 && mio_outsel.q < pinmux_reg_pkg::NPeriphOut + 3 |->
+  `ASSERT(OutSelOeN_A, mio_outsel.q > 2 && mio_outsel.q < pinmux_reg_pkg::NMioPeriphOut + 3 |->
       mio_oe_o[mio_sel_i] == periph_to_mio_oe_i[mio_outsel.q - 3])
-  `ASSERT(OutSelOeOOB_A, mio_outsel.q >= pinmux_reg_pkg::NPeriphOut + 3 |->
+  `ASSERT(OutSelOeOOB_A, mio_outsel.q >= pinmux_reg_pkg::NMioPeriphOut + 3 |->
       mio_oe_o[mio_sel_i] == 0)
   `ASSERT(MioOeO_A, ##1 !$stable(mio_oe_o[mio_sel_i]) |->
       !$stable(mio_outsel.q) || !$stable(periph_to_mio_oe_i[mio_outsel.q - 3]))

--- a/hw/ip/pinmux/rtl/pinmux.sv
+++ b/hw/ip/pinmux/rtl/pinmux.sv
@@ -228,17 +228,17 @@ module pinmux import pinmux_pkg::*; import pinmux_reg_pkg::*; (
       .clk_aon_i,
       .rst_aon_ni,
       // config signals. these are synched to clk_aon internally
-      .wkup_en_i          ( reg2hw.wkup_detector_en[k].q     ),
-      .filter_en_i        ( reg2hw.wkup_detector[k].filter.q ),
-      .wkup_mode_i        ( reg2hw.wkup_detector[k].mode.q   ),
-      .wkup_cnt_th_i      ( reg2hw.wkup_detector_cnt_th[k].q ),
-      .pin_value_i        ( pin_value                        ),
+      .wkup_en_i          ( reg2hw.wkup_detector_en[k].q                ),
+      .filter_en_i        ( reg2hw.wkup_detector[k].filter.q            ),
+      .wkup_mode_i        ( wkup_mode_e'(reg2hw.wkup_detector[k].mode.q)),
+      .wkup_cnt_th_i      ( reg2hw.wkup_detector_cnt_th[k].q            ),
+      .pin_value_i        ( pin_value                                   ),
       // cause reg signals. these are synched from/to clk_aon internally
-      .wkup_cause_valid_i ( reg2hw.wkup_cause[k].qe          ),
-      .wkup_cause_data_i  ( reg2hw.wkup_cause[k].q           ),
-      .wkup_cause_data_o  ( hw2reg.wkup_cause[k].d           ),
+      .wkup_cause_valid_i ( reg2hw.wkup_cause[k].qe                     ),
+      .wkup_cause_data_i  ( reg2hw.wkup_cause[k].q                      ),
+      .wkup_cause_data_o  ( hw2reg.wkup_cause[k].d                      ),
       // wakeup request signals on clk_aon (level encoded)
-      .aon_wkup_req_o     ( aon_wkup_req[k]                  )
+      .aon_wkup_req_o     ( aon_wkup_req[k]                             )
     );
   end
 


### PR DESCRIPTION
1. Add a enum cast to pinmux wrapper input
2. Fix namings in fpv testbench
I understand the entire pinmux tb needs to be updated, this PR only
fix compile errors so top_earlgrey can compile. There will be following
PR to update fpv tb.

Signed-off-by: Cindy Chen <chencindy@google.com>