### PR TITLE
[dv/alert_handler] fix hjson run option

### DIFF
--- a/hw/ip/alert_handler/dv/alert_handler_sim_cfg.hjson
+++ b/hw/ip/alert_handler/dv/alert_handler_sim_cfg.hjson
@@ -79,21 +79,18 @@
     {
       name: alert_handler_entropy
       uvm_test_seq: alert_handler_entropy_vseq
-      run_opts: ["+test_timeout_ns=20_000_000_000"]
-      run_opts: ["+zero_delays=1"]
+      run_opts: ["+test_timeout_ns=20_000_000_000", "+zero_delays=1"]
     }
 
     {
       name: alert_handler_ping_rsp_fail
       uvm_test_seq: alert_handler_ping_rsp_fail_vseq
-      run_opts: ["+test_timeout_ns=20_000_000_000"]
-      run_opts: ["+zero_delays=1"]
+      run_opts: ["+test_timeout_ns=20_000_000_000", "+zero_delays=1"]
     }
 
     {
       name: alert_handler_stress_all
-      run_opts: ["+test_timeout_ns=25_000_000_000"]
-      run_opts: ["+zero_delays=1"]
+      run_opts: ["+test_timeout_ns=25_000_000_000", "+zero_delays=1"]
     }
 
     {


### PR DESCRIPTION
In the same hjson file, run options needs to be under the same list,
otherwise the previous one will be override.

Signed-off-by: Cindy Chen <chencindy@google.com>