### PR TITLE
[fpv] clean up disable assertion todo in fpv.tcl

### DIFF
--- a/hw/formal/fpv.tcl
+++ b/hw/formal/fpv.tcl
@@ -66,6 +66,14 @@ if {$env(FPV_TOP) == "rv_dm"} {
   reset -expr {!rst_ni}
 }
 
+# use counter abstractions to reduce the run time:
+# alert_handler ping_timer: timer to count until reaches ping threshold
+# hmac sha2: does not check any calculation results, so 64 rounds of calculation can be abstracted
+if {$env(FPV_TOP) == "alert_handler"} {
+  abstract -counter -env i_ping_timer.cnt_q
+} elseif {$env(FPV_TOP) == "hmac"} {
+  abstract -counter -env u_sha2.round
+}
 #-------------------------------------------------------------------------
 # assume properties for inputs
 #-------------------------------------------------------------------------
@@ -81,63 +89,6 @@ assume -from_assert -remove_original {sram2tlul.validNotReady*}
 
 # Input scanmode_i should not be X
 assume -from_assert -remove_original -regexp {^\w*\.scanmodeKnown}
-
-#-------------------------------------------------------------------------
-# TODO: eventually remove below assert disable lines
-# To reduce prohibitive runtimes, below assertions are simply turned off for now
-#-------------------------------------------------------------------------
-
-# spi_device
-assert -disable {*spi_device.u_tlul2sram.tlul_assert_host.responseSize*}
-assert -disable {*spi_device.u_tlul2sram.tlul_assert_host.onlyOnePendingReq*}
-assert -disable {*spi_device.tlul_assert_host.responseMustHaveReq*}
-assert -disable {*spi_device.tlul_assert_host.checkResponseOpcode*}
-assert -disable {*spi_device.u_reg.tlul_assert_host.responseMustHaveReq*}
-assert -disable {*spi_device.u_reg.tlul_assert_host.checkResponseOpcode*}
-assert -disable {*spi_device.u_reg.u_socket.tlul_assert_host.responseMustHaveReq*}
-assert -disable {*spi_device.u_reg.u_socket.tlul_assert_host.checkResponseOpcode*}
-assert -disable {*spi_device.u_reg.u_socket.tlul_assert_device.gen_assert*.tlul_assert.responseSize*}
-assert -disable {*spi_device.u_reg.u_socket.tlul_assert_device.gen_assert*.tlul_assert.onlyOnePendingReq*}
-assert -disable {*spi_device.u_reg.u_socket.tlul_assert_host.responseSizeMustEqualReq*}
-assert -disable {*spi_device.tlul_assert_host.responseSizeMustEqualReq*}
-
-# hmac
-assert -disable {*hmac.u_tlul_adapter.tlul_assert_host.onlyOnePendingReq*}
-assert -disable {*hmac.u_reg.u_socket.tlul_assert_device.gen_assert[0]*onlyOnePendingReq*}
-
-# flash_ctrl
-assert -disable {*flash_ctrl.tlul_assert_host.response*Must*}
-assert -disable {*flash_ctrl.u_reg.u_socket.tlul_assert_*.response*Must*}
-assert -disable {*flash_ctrl.u_reg.u_socket.tlul_assert_device.gen_assert*.tlul_assert.onlyOnePendingReq*}
-
-# xbar
-assert -disable {*xbar_main.tlul_assert_device_*.sizeMatches*}
-assert -disable {*xbar_main.tlul_assert_device_*.legalA*}
-assert -disable {*xbar_main.tlul_assert_device_*.addressAligned*}
-assert -disable {*xbar_main.tlul_assert_device_*.maskMustBeCont*}
-assert -disable {*xbar_main.tlul_assert_host_*.legal*}
-assert -disable {*xbar_main.u_*.tlul_assert_host.legalDParam*}
-assert -disable {*xbar_main.u_*.tlul_assert_device.response*}
-assert -disable {*xbar_main.u_*.tlul_assert_device.legalA*}
-assert -disable {*xbar_main.u_*.tlul_assert_device.addressAligned*}
-assert -disable {*xbar_main.u_*.tlul_assert_device.checkResponseOp*}
-assert -disable {*xbar_main.u_*.tlul_assert_device.maskMustBeCont*}
-assert -disable {*xbar_main.u_*.tlul_assert_device.sizeMatches*}
-assert -disable {*xbar_main.u_*.tlul_assert_*.gen_assert*.tlul_assert.maskMustBeCont*}
-assert -disable {*xbar_main.u_*.tlul_assert_*.gen_assert*.tlul_assert.addressAlignedToSize*}
-assert -disable {*xbar_main.u_*.tlul_assert_*.gen_assert*.tlul_assert.legal*}
-assert -disable {*xbar_main.u_*.tlul_assert_*.gen_assert*.tlul_assert.sizeMatches*}
-
-# top_earlgrey
-assert -disable {top_earlgrey.*addressAligned*}
-assert -disable {top_earlgrey.*tlul_assert*Must*}
-assert -disable {top_earlgrey.*onlyOne*}
-assert -disable {top_earlgrey.*Response*}
-assert -disable {top_earlgrey.*legal*}
-assert -disable {top_earlgrey.u_xbar_main.u_sm1_*.rspIdInRange}
-assert -disable {top_earlgrey.u_xbar_main.*depthShall*}
-assert -disable {top_earlgrey.u_xbar_main.*tlul_assert*DataKnown*}
-assert -disable {top_earlgrey.u_dm_top.*tlul_assert_*DataKnown*}
 
 # TODO: If scanmode is set to 0, then JasperGold errors out complaining
 # about combo loops, which should be debugged further. For now, below


### PR DESCRIPTION
Instead of using disable assert, this PR uses fifo abstraction to reduce
runtime. This finishes one of the TODO items in issue #396

Signed-off-by: Cindy Chen <chencindy@google.com>