### PR TITLE
[prim_ram_2p_adv] Various cleanups

### DIFF
--- a/hw/ip/prim/lint/prim.waiver
+++ b/hw/ip/prim/lint/prim.waiver
@@ -13,10 +13,6 @@ waive -rules {ASSIGN_SIGN} -location {prim_fifo_async.sv} -msg {Signed target 'i
       -comment "Parameter PTR_WIDTH is unsigned, but integer i is signed. This is fine. Changing the integer to unsigned might \
                 cause issues with the for loop never exiting, because an unsigned integer can never become < 0."
 
-# prim_ram_2p_adv
-waive -rules {INPUT_NOT_READ} -location {prim_ram_2p_adv.sv} -msg {Input port 'cfg_i' is not read from in module} \
-      -comment "We will eventually use this input for RTC/WTC or other memory parameters."
-
 # prim_assert
 waive -rules {UNDEF_MACRO_REF} -location {prim_assert.sv} -regexp {Macro definition for 'ASSERT_RPT' includes expansion of undefined macro '__(FILE|LINE)__'} \
       -comment "This is an UVM specific macro inside our assertion shortcuts"

--- a/hw/ip/prim/rtl/prim_ram_2p_adv.sv
+++ b/hw/ip/prim/rtl/prim_ram_2p_adv.sv
@@ -20,6 +20,7 @@ module prim_ram_2p_adv #(
   parameter  int Depth                = 512,
   parameter  int Width                = 32,
   parameter  int CfgW                 = 8, // WTC, RTC, etc
+  parameter      MemInitFile          = "", // VMEM file to initialize the memory with
 
   // Configurations
   parameter  bit EnableECC            = 0,
@@ -92,7 +93,8 @@ module prim_ram_2p_adv #(
 
       .Width           (TotalWidth),
       .Depth           (Depth),
-      .DataBitsPerMask (TotalWidth)
+      .DataBitsPerMask (TotalWidth),
+      .MemInitFile     (MemInitFile)
     ) u_mem (
       .clk_a_i    (clk_i),
       .clk_b_i    (clk_i),
@@ -116,7 +118,8 @@ module prim_ram_2p_adv #(
     prim_ram_2p #(
       .Width           (TotalWidth),
       .Depth           (Depth),
-      .DataBitsPerMask (TotalWidth)
+      .DataBitsPerMask (TotalWidth),
+      .MemInitFile     (MemInitFile)
     ) u_mem (
       .clk_a_i    (clk_i),
       .clk_b_i    (clk_i),

--- a/hw/ip/prim/rtl/prim_ram_2p_adv.sv
+++ b/hw/ip/prim/rtl/prim_ram_2p_adv.sv
@@ -17,41 +17,40 @@
 `include "prim_assert.sv"
 
 module prim_ram_2p_adv #(
-  parameter int Depth = 512,
-  parameter int Width = 32,
-  parameter int CfgW = 8,     // WTC, RTC, etc
+  parameter  int Depth                = 512,
+  parameter  int Width                = 32,
+  parameter  int CfgW                 = 8, // WTC, RTC, etc
 
   // Configurations
-  parameter bit EnableECC            = 0,
-  parameter bit EnableParity         = 0,
-  parameter bit EnableInputPipeline  = 0,
-  parameter bit EnableOutputPipeline = 0,
+  parameter  bit EnableECC            = 0,
+  parameter  bit EnableParity         = 0,
+  parameter  bit EnableInputPipeline  = 0,
+  parameter  bit EnableOutputPipeline = 0,
 
-  parameter MemT = "REGISTER", // can be "REGISTER" or "SRAM"
+  parameter      MemT                 = "REGISTER", // can be "REGISTER" or "SRAM"
 
-  localparam int Aw = $clog2(Depth)
+  localparam int Aw                   = $clog2(Depth)
 ) (
-  input clk_i,
-  input rst_ni,
+  input                     clk_i,
+  input                     rst_ni,
 
   input                     a_req_i,
   input                     a_write_i,
   input        [Aw-1:0]     a_addr_i,
   input        [Width-1:0]  a_wdata_i,
-  output logic              a_rvalid_o,
   output logic [Width-1:0]  a_rdata_o,
-  output logic [1:0]        a_rerror_o,
+  output logic              a_rvalid_o, // read response (a_rdata_o) is valid
+  output logic [1:0]        a_rerror_o, // Bit1: Uncorrectable, Bit0: Correctable
 
   input                     b_req_i,
   input                     b_write_i,
   input        [Aw-1:0]     b_addr_i,
   input        [Width-1:0]  b_wdata_i,
-  output logic              b_rvalid_o,
   output logic [Width-1:0]  b_rdata_o,
+  output logic              b_rvalid_o, // read response (b_rdata_o) is valid
   output logic [1:0]        b_rerror_o, // Bit1: Uncorrectable, Bit0: Correctable
 
-  // config
-  input [CfgW-1:0] cfg_i
+  input        [CfgW-1:0]   cfg_i
 );
 
   // Calculate ECC width

--- a/hw/ip/prim/rtl/prim_ram_2p_adv.sv
+++ b/hw/ip/prim/rtl/prim_ram_2p_adv.sv
@@ -29,14 +29,14 @@ module prim_ram_2p_adv #(
 
   parameter MemT = "REGISTER", // can be "REGISTER" or "SRAM"
 
-  localparam int SramAw = $clog2(Depth)
+  localparam int Aw = $clog2(Depth)
 ) (
   input clk_i,
   input rst_ni,
 
   input                     a_req_i,
   input                     a_write_i,
-  input        [SramAw-1:0] a_addr_i,
+  input        [Aw-1:0]     a_addr_i,
   input        [Width-1:0]  a_wdata_i,
   output logic              a_rvalid_o,
   output logic [Width-1:0]  a_rdata_o,
@@ -44,7 +44,7 @@ module prim_ram_2p_adv #(
 
   input                     b_req_i,
   input                     b_write_i,
-  input        [SramAw-1:0] b_addr_i,
+  input        [Aw-1:0]     b_addr_i,
   input        [Width-1:0]  b_wdata_i,
   output logic              b_rvalid_o,
   output logic [Width-1:0]  b_rdata_o,
@@ -70,7 +70,7 @@ module prim_ram_2p_adv #(
 
   logic                  a_req_q,    a_req_d ;
   logic                  a_write_q,  a_write_d ;
-  logic [SramAw-1:0]     a_addr_q,   a_addr_d ;
+  logic [Aw-1:0]         a_addr_q,   a_addr_d ;
   logic [TotalWidth-1:0] a_wdata_q,  a_wdata_d ;
   logic                  a_rvalid_q, a_rvalid_d, a_rvalid_sram ;
   logic [Width-1:0]      a_rdata_q,  a_rdata_d ;
@@ -79,7 +79,7 @@ module prim_ram_2p_adv #(
 
   logic                  b_req_q,    b_req_d ;
   logic                  b_write_q,  b_write_d ;
-  logic [SramAw-1:0]     b_addr_q,   b_addr_d ;
+  logic [Aw-1:0]         b_addr_q,   b_addr_d ;
   logic [TotalWidth-1:0] b_wdata_q,  b_wdata_d ;
   logic                  b_rvalid_q, b_rvalid_d, b_rvalid_sram ;
   logic [Width-1:0]      b_rdata_q,  b_rdata_d ;

--- a/hw/ip/prim/rtl/prim_ram_2p_adv.sv
+++ b/hw/ip/prim/rtl/prim_ram_2p_adv.sv
@@ -64,6 +64,10 @@ module prim_ram_2p_adv #(
                              (Width <= 120) ? 8 : 8 ;
   localparam int TotalWidth = Width + ParWidth;
 
+  // We will eventually use cfg_i for RTC/WTC or other memory parameters.
+  logic [CfgW-1:0] unused_cfg;
+  assign unused_cfg = cfg_i;
+
   logic                  a_req_q,    a_req_d ;
   logic                  a_write_q,  a_write_d ;
   logic [SramAw-1:0]     a_addr_q,   a_addr_d ;


### PR DESCRIPTION
Various cleanups to the wrapper around the 2p RAM primitive to align it better with the 1p primitive, and with the primitive it wraps (prim_ram_2p). None of the changes should affect functionality.

See the individual commits for longer commit messages.