### PR TITLE
[prim_ram_1p] Move advanced functionality into wrapper

### DIFF
--- a/hw/ip/prim/prim_ram_1p_adv.core
+++ b/hw/ip/prim/prim_ram_1p_adv.core
@@ -1,0 +1,19 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:ram_1p_adv:0.1"
+description: "Single-port RAM primitive with advanced features"
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:prim:ram_1p
+    files:
+      - rtl/prim_ram_1p_adv.sv
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_rtl

--- a/hw/ip/prim/rtl/prim_ram_1p_adv.sv
+++ b/hw/ip/prim/rtl/prim_ram_1p_adv.sv
@@ -1,0 +1,65 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Single-Port SRAM Wrapper
+
+`include "prim_assert.sv"
+
+module prim_ram_1p_adv #(
+  // Parameters passed on the the SRAM primitive.
+  parameter  int Width           = 32, // bit
+  parameter  int Depth           = 128,
+  parameter  int DataBitsPerMask = 1, // Number of data bits per bit of write mask
+  parameter      MemInitFile     = "", // VMEM file to initialize the memory with
+
+  parameter  int CfgW            = 8,     // WTC, RTC, etc
+
+  localparam int Aw              = $clog2(Depth)
+) (
+  input                     clk_i,
+  input                     rst_ni,
+
+  input                     req_i,
+  input                     write_i,
+  input        [Aw-1:0]     addr_i,
+  input        [Width-1:0]  wdata_i,
+  input        [Width-1:0]  wmask_i,
+  output logic [Width-1:0]  rdata_o,
+  output logic              rvalid_o, // read response (rdata_o) is valid
+  output logic [1:0]        rerror_o, // Bit1: Uncorrectable, Bit0: Correctable
+
+  input        [CfgW-1:0]   cfg_i
+);
+
+  // We will eventually use cfg_i for RTC/WTC or other memory parameters.
+  logic [CfgW-1:0] unused_cfg;
+  assign unused_cfg = cfg_i;
+
+  prim_ram_1p #(
+    .Width           (Width),
+    .Depth           (Depth),
+    .DataBitsPerMask (DataBitsPerMask),
+    .MemInitFile     (MemInitFile)
+  ) u_mem (
+    .clk_i,
+
+    .req_i,
+    .write_i,
+    .addr_i,
+    .wdata_i,
+    .wmask_i,
+    .rdata_o
+  );
+
+  always_ff @(posedge clk_i, negedge rst_ni) begin
+    if (!rst_ni) begin
+      rvalid_o <= '0;
+    end else begin
+      rvalid_o <= req_i & ~write_i;
+    end
+  end
+
+  assign rerror_o = 2'b0;
+
+endmodule

--- a/hw/ip/prim_generic/rtl/prim_generic_flash.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_flash.sv
@@ -274,13 +274,11 @@ module prim_generic_flash #(
     .DataBitsPerMask(DataWidth)
   ) u_mem (
     .clk_i,
-    .rst_ni,
     .req_i    (mem_req),
     .write_i  (mem_wr),
     .addr_i   (mem_addr),
     .wdata_i  (mem_wdata),
     .wmask_i  ({DataWidth{1'b1}}),
-    .rvalid_o (),
     .rdata_o  (rd_data_o)
   );
 

--- a/hw/ip/prim_generic/rtl/prim_generic_ram_1p.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_ram_1p.sv
@@ -15,15 +15,13 @@ module prim_generic_ram_1p #(
   localparam int Aw              = $clog2(Depth)  // derived parameter
 ) (
   input  logic             clk_i,
-  input  logic             rst_ni,
 
   input  logic             req_i,
   input  logic             write_i,
   input  logic [Aw-1:0]    addr_i,
   input  logic [Width-1:0] wdata_i,
   input  logic [Width-1:0] wmask_i,
-  output logic             rvalid_o,
-  output logic [Width-1:0] rdata_o
+  output logic [Width-1:0] rdata_o // Read data. Data is returned one cycle after req_i is high.
 );
 
   // Width of internal write mask. Note wmask_i input into the module is always assumed
@@ -53,14 +51,6 @@ module prim_generic_ram_1p #(
       end else begin
         rdata_o <= mem[addr_i];
       end
-    end
-  end
-
-  always_ff @(posedge clk_i, negedge rst_ni) begin
-    if (!rst_ni) begin
-      rvalid_o <= '0;
-    end else begin
-      rvalid_o <= req_i & ~write_i;
     end
   end
 

--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -331,6 +331,7 @@ module top_${top["name"]} #(
   logic ${lib.bitarray(data_width, max_char)} ${m["name"]}_wmask;
   logic ${lib.bitarray(data_width, max_char)} ${m["name"]}_rdata;
   logic ${lib.bitarray(1,          max_char)} ${m["name"]}_rvalid;
+  logic ${lib.bitarray(2,          max_char)} ${m["name"]}_rerror;
 
   tlul_adapter_sram #(
     .SramAw(${addr_width}),
@@ -354,14 +355,15 @@ module top_${top["name"]} #(
     .wmask_o  (${m["name"]}_wmask),
     .rdata_i  (${m["name"]}_rdata),
     .rvalid_i (${m["name"]}_rvalid),
-    .rerror_i (2'b00)
+    .rerror_i (${m["name"]}_rerror)
   );
 
   ## TODO: Instantiate ram_1p model using RAMGEN (currently not available)
-  prim_ram_1p #(
+  prim_ram_1p_adv #(
     .Width(${data_width}),
     .Depth(${sram_depth}),
-    .DataBitsPerMask(${int(data_width/4)})
+    .DataBitsPerMask(${int(data_width/4)}),
+    .CfgW(8)
   ) u_ram1p_${m["name"]} (
     % for key in clocks:
     .${key}   (${clocks[key]}),
@@ -375,8 +377,10 @@ module top_${top["name"]} #(
     .addr_i   (${m["name"]}_addr),
     .wdata_i  (${m["name"]}_wdata),
     .wmask_i  (${m["name"]}_wmask),
+    .rdata_o  (${m["name"]}_rdata),
     .rvalid_o (${m["name"]}_rvalid),
-    .rdata_o  (${m["name"]}_rdata)
+    .rerror_o (${m["name"]}_rerror),
+    .cfg_i    ('0)
   );
   % elif m["type"] == "rom":
 <%

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -57,7 +57,7 @@ module tb;
 
   // backdoors
   bind `ROM_HIER mem_bkdr_if rom_mem_bkdr_if();
-  bind `RAM_MAIN_HIER mem_bkdr_if ram_mem_bkdr_if();
+  bind `RAM_MAIN_HIER.u_mem mem_bkdr_if ram_mem_bkdr_if();
   bind `FLASH0_MEM_HIER mem_bkdr_if flash0_mem_bkdr_if();
   bind `FLASH1_MEM_HIER mem_bkdr_if flash1_mem_bkdr_if();
 
@@ -189,7 +189,7 @@ module tb;
     uvm_config_db#(virtual mem_bkdr_if)::set(
         null, "*.env", "mem_bkdr_vifs[Rom]", `ROM_HIER.rom_mem_bkdr_if);
     uvm_config_db#(virtual mem_bkdr_if)::set(
-        null, "*.env", "mem_bkdr_vifs[Ram]", `RAM_MAIN_HIER.ram_mem_bkdr_if);
+        null, "*.env", "mem_bkdr_vifs[Ram]", `RAM_MAIN_HIER.u_mem.ram_mem_bkdr_if);
     uvm_config_db#(virtual mem_bkdr_if)::set(
         null, "*.env", "mem_bkdr_vifs[FlashBank0]", `FLASH0_MEM_HIER.flash0_mem_bkdr_if);
     uvm_config_db#(virtual mem_bkdr_if)::set(

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -393,6 +393,7 @@ module top_earlgrey #(
   logic [31:0] ram_main_wmask;
   logic [31:0] ram_main_rdata;
   logic        ram_main_rvalid;
+  logic [1:0]  ram_main_rerror;
 
   tlul_adapter_sram #(
     .SramAw(14),
@@ -412,13 +413,14 @@ module top_earlgrey #(
     .wmask_o  (ram_main_wmask),
     .rdata_i  (ram_main_rdata),
     .rvalid_i (ram_main_rvalid),
-    .rerror_i (2'b00)
+    .rerror_i (ram_main_rerror)
   );
 
-  prim_ram_1p #(
+  prim_ram_1p_adv #(
     .Width(32),
     .Depth(16384),
-    .DataBitsPerMask(8)
+    .DataBitsPerMask(8),
+    .CfgW(8)
   ) u_ram1p_ram_main (
     .clk_i   (clkmgr_clocks.clk_main_infra),
     .rst_ni   (rstmgr_resets.rst_sys_n),
@@ -428,8 +430,10 @@ module top_earlgrey #(
     .addr_i   (ram_main_addr),
     .wdata_i  (ram_main_wdata),
     .wmask_i  (ram_main_wmask),
+    .rdata_o  (ram_main_rdata),
     .rvalid_o (ram_main_rvalid),
-    .rdata_o  (ram_main_rdata)
+    .rerror_o (ram_main_rerror),
+    .cfg_i    ('0)
   );
 
   // host to flash communication

--- a/hw/top_earlgrey/top_earlgrey.core
+++ b/hw/top_earlgrey/top_earlgrey.core
@@ -25,7 +25,7 @@ filesets:
       - lowrisc:ip:aes
       - lowrisc:ip:hmac
       - lowrisc:ip:pwrmgr
-      - lowrisc:prim:ram_1p
+      - lowrisc:prim:ram_1p_adv
       - lowrisc:prim:rom
       - lowrisc:ip:rstmgr
       - lowrisc:prim:flash

--- a/hw/top_earlgrey/top_earlgrey_verilator.cc
+++ b/hw/top_earlgrey/top_earlgrey_verilator.cc
@@ -21,7 +21,7 @@ int main(int argc, char **argv) {
       "u_impl_generic");
   memutil.RegisterMemoryArea(
       "ram",
-      "TOP.top_earlgrey_verilator.top_earlgrey.u_ram1p_ram_main."
+      "TOP.top_earlgrey_verilator.top_earlgrey.u_ram1p_ram_main.u_mem."
       "gen_generic.u_impl_generic");
   memutil.RegisterMemoryArea(
       "flash",

--- a/hw/vendor/lowrisc_ibex.vendor.hjson
+++ b/hw/vendor/lowrisc_ibex.vendor.hjson
@@ -4,6 +4,7 @@
 {
   name: "lowrisc_ibex",
   target_dir: "lowrisc_ibex",
+  patch_dir: "patches/lowrisc_ibex",
 
   upstream: {
     url: "https://github.com/lowRISC/ibex.git",

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_icache.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_icache.sv
@@ -297,13 +297,11 @@ module ibex_icache #(
       .Depth    (NUM_LINES)
     ) tag_bank (
       .clk_i    (clk_i),
-      .rst_ni   (rst_ni),
       .req_i    (tag_req_ic0 & tag_banks_ic0[way]),
       .write_i  (tag_write_ic0),
       .wmask_i  ({TAG_SIZE_ECC{1'b1}}),
       .addr_i   (tag_index_ic0),
       .wdata_i  (tag_wdata_ic0),
-      .rvalid_o (),
       .rdata_o  (tag_rdata_ic1[way])
     );
     // Data RAM instantiation
@@ -312,13 +310,11 @@ module ibex_icache #(
       .Depth    (NUM_LINES)
     ) data_bank (
       .clk_i    (clk_i),
-      .rst_ni   (rst_ni),
       .req_i    (data_req_ic0 & data_banks_ic0[way]),
       .write_i  (data_write_ic0),
       .wmask_i  ({LINE_SIZE_ECC{1'b1}}),
       .addr_i   (data_index_ic0),
       .wdata_i  (data_wdata_ic0),
-      .rvalid_o (),
       .rdata_o  (data_rdata_ic1[way])
     );
   end

--- a/hw/vendor/patches/lowrisc_ibex/0001-Adjust-prim_ram_1p-interface.patch
+++ b/hw/vendor/patches/lowrisc_ibex/0001-Adjust-prim_ram_1p-interface.patch
@@ -1,0 +1,35 @@
+prim_ram_1p is vendored into Ibex and used there, and then Ibex is vendored 
+back into OpenTitan. So modifications to the interface produce a circular 
+dependency. To break that, fix Ibex as vendored into OT first with this patch.
+The patch can be removed once prim_ram_1p is updated in Ibex with the version
+used in OT.
+--- a/rtl/ibex_icache.sv
++++ b/rtl/ibex_icache.sv
+@@ -297,13 +297,11 @@ module ibex_icache #(
+       .Depth    (NUM_LINES)
+     ) tag_bank (
+       .clk_i    (clk_i),
+-      .rst_ni   (rst_ni),
+       .req_i    (tag_req_ic0 & tag_banks_ic0[way]),
+       .write_i  (tag_write_ic0),
+       .wmask_i  ({TAG_SIZE_ECC{1'b1}}),
+       .addr_i   (tag_index_ic0),
+       .wdata_i  (tag_wdata_ic0),
+-      .rvalid_o (),
+       .rdata_o  (tag_rdata_ic1[way])
+     );
+     // Data RAM instantiation
+@@ -312,13 +310,11 @@ module ibex_icache #(
+       .Depth    (NUM_LINES)
+     ) data_bank (
+       .clk_i    (clk_i),
+-      .rst_ni   (rst_ni),
+       .req_i    (data_req_ic0 & data_banks_ic0[way]),
+       .write_i  (data_write_ic0),
+       .wmask_i  ({LINE_SIZE_ECC{1'b1}}),
+       .addr_i   (data_index_ic0),
+       .wdata_i  (data_wdata_ic0),
+-      .rvalid_o (),
+       .rdata_o  (data_rdata_ic1[way])
+     );
+   end


### PR DESCRIPTION
Reduce the single-port RAM primitive (prim_ram_1p) to its basic
functionality. This functionality doesn't include a "read data valid"
singal (rvalid), as all data is expected to be returned in the next
cycle.

In line with what was done in the dual-port RAM primitive (prim_ram_2p),
we now have a wrapper for such "advanced" functionality like the rvalid
signal in the form of `prim_ram_1p_adv`.

Currently, this wrapper only provides the same functionality as
prim_ram_1p did provide before with an interface mostly identical to the
one in prim_ram_2p_adv.

Adding advanced functionality which actually lives up to the name (e.g.
ECC and parity) can be done as needed in a follow-up.

For Ibex, we have to go slightly ugly: since Ibex uses prim_ram_1p, we
need to adjust its interfaces as well. We cannot do that in Ibex
upstream directly, as we need to get the prim_ram_1p changes (which are
in this commit) first into OpenTitan. To get out of this cyclic
dependency this commit adds a patch to the vendored Ibex. This patch is
then applied with the vendor tool to give subsequent vendor imports the
same patched interface.

Fixes #2181