### PR TITLE
[pinmux] Address 3 lint errors

### DIFF
--- a/hw/ip/pinmux/rtl/pinmux.sv
+++ b/hw/ip/pinmux/rtl/pinmux.sv
@@ -50,9 +50,12 @@ module pinmux import pinmux_pkg::*; import pinmux_reg_pkg::*; (
   // They have been placed here such that they do not generate
   // warnings in the C header generation step, since logic is not supported
   // as a data type yet.
-  localparam logic [pinmux_reg_pkg::NMioPeriphOut-1:0] MioPeriphHasSleepMode = '1;
-  localparam logic [pinmux_reg_pkg::NDioPads-1:0]      DioPeriphHasSleepMode = '1;
-  localparam logic [pinmux_reg_pkg::NDioPads-1:0]      DioPeriphHasWkup      = '1;
+  localparam logic [pinmux_reg_pkg::NMioPeriphOut-1:0] MioPeriphHasSleepMode
+                   = {pinmux_reg_pkg::NMioPeriphOut{1'b1}};
+  localparam logic [pinmux_reg_pkg::NDioPads-1:0]      DioPeriphHasSleepMode
+                   = {pinmux_reg_pkg::NDioPads{1'b1}};
+  localparam logic [pinmux_reg_pkg::NDioPads-1:0]      DioPeriphHasWkup
+                   = {pinmux_reg_pkg::NDioPads{1'b1}};
 
   //////////////////////////////////
   // Regfile Breakout and Mapping //


### PR DESCRIPTION
Signed-off-by: Satnam Singh <satnam@google.com>

I am not sure if this is worth it since this targets placeholder code that I think will change at some point but regardless we could address 3 out of the 6 lint errors for the pinmux by explicitly specifying the number of "ones" rather than using `'1` (which violates an OpenTitan coding style guideline).