### PR TITLE
[dvsim] Simulation mode for 0-delay loop detection

### DIFF
--- a/hw/dv/data/common_modes.hjson
+++ b/hw/dv/data/common_modes.hjson
@@ -27,6 +27,11 @@
       is_sim_mode: 1
       en_build_modes: ["{tool}_xprop"]
     }
+    {
+      name: loopdetect
+      is_sim_mode: 1
+      en_build_modes: ["{tool}_loopdetect"]
+    }
   ]
 
   run_modes: [

--- a/hw/dv/data/dsim/dsim.hjson
+++ b/hw/dv/data/dsim/dsim.hjson
@@ -120,5 +120,12 @@
       is_sim_mode: 1
       run_opts:   ["-profile"]
     }
+    {
+      // TODO: Add build and run options to enable zero delay loop detection.
+      name: dsim_loopdetect
+      is_sim_mode: 1
+      build_opts: []
+      run_opts:   []
+    }
   ]
 }

--- a/hw/dv/data/vcs/vcs.hjson
+++ b/hw/dv/data/vcs/vcs.hjson
@@ -164,5 +164,11 @@
       build_opts: ["-simprofile"]
       run_opts:   ["-simprofile {profile}"]
     }
+    {
+      name: vcs_loopdetect
+      is_sim_mode: 1
+      build_opts: ["+vcs+loopreport", "+vcs+loopdetect"]
+      run_opts:   ["+vcs+loopreport", "+vcs+loopdetect"]
+    }
   ]
 }

--- a/hw/dv/data/xcelium/xcelium.hjson
+++ b/hw/dv/data/xcelium/xcelium.hjson
@@ -125,5 +125,12 @@
       # -xverbose  << add to see which modules does not have xprop enabled
       build_opts: ["-xprop F"]
     }
+    {
+      // TODO: Add build and run options to enable zero delay loop detection.
+      name: xcelium_loopdetect
+      is_sim_mode: 1
+      build_opts: []
+      run_opts:   []
+    }
   ]
 }


### PR DESCRIPTION
- Only VCS supported for now - support for other tools will be added
later
- Can be enabled on the command line with the following switch:
```
--build-modes loopdetect
```

Signed-off-by: Srikrishna Iyer <sriyer@google.com>