### PR TITLE
[dv] Fix for tl_monitor ok_to_end

### DIFF
--- a/hw/dv/sv/tl_agent/tl_monitor.sv
+++ b/hw/dv/sv/tl_agent/tl_monitor.sv
@@ -122,9 +122,9 @@ class tl_monitor extends dv_base_monitor#(
   // update ok_to_end to prevent sim finish when there is any pending item
   virtual task monitor_ready_to_end();
     forever begin
-      if (pending_a_req.size() == 0) ok_to_end = 1;
-      else                           ok_to_end = 0;
-      wait(pending_a_req.size());
+      ok_to_end = (pending_a_req.size() == 0);
+      if (ok_to_end) wait(pending_a_req.size() > 0);
+      else           wait(pending_a_req.size() == 0);
     end
   endtask
 


### PR DESCRIPTION
If `ok_to_end = 0`, we need to wait for `pending_a_req.size() == 0`

`wait(pending_a_req.size())` implies waiting for the size to be
non-zero, which causes a hang (at chip level DV), when `ok_to_end = 0`
and the `pending_a_req.size()` transitions from 1 to 0.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>