### PR TITLE
[top_earlgrey] Remove outdated comments

### DIFF
--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -358,7 +358,6 @@ module top_${top["name"]} #(
     .rerror_i (${m["name"]}_rerror)
   );
 
-  ## TODO: Instantiate ram_1p model using RAMGEN (currently not available)
   prim_ram_1p_adv #(
     .Width(${data_width}),
     .Depth(${sram_depth}),
@@ -423,7 +422,6 @@ module top_${top["name"]} #(
     .rerror_i (2'b00)
   );
 
-  ## TODO: Replace emulated ROM to real ROM in ASIC SoC
   prim_rom #(
     .Width(${data_width}),
     .Depth(${rom_depth}),


### PR DESCRIPTION
The RAM and ROM primitives will provide ASIC-specific implementations,
which are transparent to the toplevel file. Remove the TODO comments
which indicate something else.