### PR TITLE
[sw] Ensure Generated C Headers Can Be Used By C++

### DIFF
--- a/hw/top_earlgrey/data/top_earlgrey.h.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.h.tpl
@@ -5,6 +5,11 @@
 #ifndef _TOP_${top["name"].upper()}_H_
 #define _TOP_${top["name"].upper()}_H_
 
+// Header Extern Guard  (so header can be used from C and C++)
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define PINMUX_PERIPH_INSEL_IDX_OFFSET 2
 
 // PERIPH_INSEL ranges from 0 to NUM_MIO + 2 -1}
@@ -168,5 +173,10 @@ typedef enum top_${top["name"]}_plic_target {
 % endfor
   kTopEarlgreyPlicTargetLast = ${enum_id - 1}, /**< \internal Final PLIC target */
 } top_${top["name"]}_plic_target_t;
+
+// Header Extern Guard
+#ifdef __cplusplus
+}  // extern "C"
+#endif
 
 #endif  // _TOP_${top["name"].upper()}_H_

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -5,6 +5,11 @@
 #ifndef OPENTITAN_HW_TOP_EARLGREY_SW_AUTOGEN_TOP_EARLGREY_H_
 #define OPENTITAN_HW_TOP_EARLGREY_SW_AUTOGEN_TOP_EARLGREY_H_
 
+// Header Extern Guard  (so header can be used from C and C++)
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define PINMUX_PERIPH_INSEL_IDX_OFFSET 2
 
 // PERIPH_INSEL ranges from 0 to NUM_MIO + 2 -1}
@@ -536,5 +541,10 @@ typedef enum top_earlgrey_plic_target {
   kTopEarlgreyPlicTargetIbex0 = 0, /**< Ibex Core 0 */
   kTopEarlgreyPlicTargetLast = 0, /**< \internal Final PLIC target */
 } top_earlgrey_plic_target_t;
+
+// Header Extern Guard
+#ifdef __cplusplus
+}  // extern "C"
+#endif
 
 #endif  // OPENTITAN_HW_TOP_EARLGREY_SW_AUTOGEN_TOP_EARLGREY_H_

--- a/util/reggen/gen_cheader.py
+++ b/util/reggen/gen_cheader.py
@@ -357,10 +357,26 @@ def gen_cdefines(regs, outfile, src_lic, src_copy):
         for line in src_lic.splitlines():
             genout(outfile, '// ' + line + '\n')
         genout(outfile, '\n')
+
+    # Header Include Guard
     genout(outfile, '#ifndef _' + as_define(component) + '_REG_DEFS_\n')
     genout(outfile, '#define _' + as_define(component) + '_REG_DEFS_\n\n')
+
+    # Header Extern Guard (so header can be used from C and C++)
+    genout(outfile, '#ifdef __cplusplus\n')
+    genout(outfile, 'extern "C" {\n')
+    genout(outfile, '#endif\n')
+
     genout(outfile, generated)
+
+    # Header Extern Guard
+    genout(outfile, '#ifdef __cplusplus\n')
+    genout(outfile, '}  // extern "C"\n')
+    genout(outfile, '#endif\n')
+
+    # Header Include Guard
     genout(outfile, '#endif  // _' + as_define(component) + '_REG_DEFS_\n')
+
     genout(outfile, '// End generated register defines for ' + component)
 
     return


### PR DESCRIPTION
This patch follows up #1958 and adds polyglot extern guards to the
autogenerated headers for register definitions and the top system header.
