### PR TITLE
[prim_ram_2p] Enable memory loading through Verilator

### DIFF
--- a/hw/ip/prim_generic/prim_generic_ram_2p.core
+++ b/hw/ip/prim_generic/prim_generic_ram_2p.core
@@ -7,6 +7,8 @@ name: "lowrisc:prim_generic:ram_2p"
 description: "prim"
 filesets:
   files_rtl:
+    depend:
+      - lowrisc:prim:util_memload
     files:
       - rtl/prim_generic_ram_2p.sv
     file_type: systemVerilogSource

--- a/hw/ip/prim_generic/rtl/prim_generic_ram_2p.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_ram_2p.sv
@@ -81,7 +81,6 @@ module prim_generic_ram_2p #(
     end
   end
 
-  // TODO: Enable once lowRISC/ibex#844 is fixed.
-  //`include "prim_util_memload.sv"
+  `include "prim_util_memload.sv"
 
 endmodule


### PR DESCRIPTION
In #2311 we enabled memory loading for memories with sizes != 32 bit.
This enables us to remove the previous workaround and enable memory
loading also for 2p memories, which are used in OpenTitan with "odd"
Width parameters (due to ECC/parity).