### PR TITLE
[sw, dif_uart] Fix use of wrong enum in return code

### DIFF
--- a/sw/device/lib/dif/dif_uart.c
+++ b/sw/device/lib/dif/dif_uart.c
@@ -170,7 +170,7 @@ dif_uart_config_result_t dif_uart_init(mmio_region_t base_addr,
                                        const dif_uart_config_t *config,
                                        dif_uart_t *uart) {
   if (uart == NULL || config == NULL) {
-    return kDifUartBadArg;
+    return kDifUartConfigBadArg;
   }
 
   uart->base_addr = base_addr;
@@ -181,7 +181,7 @@ dif_uart_config_result_t dif_uart_init(mmio_region_t base_addr,
 dif_uart_config_result_t dif_uart_configure(const dif_uart_t *uart,
                                             const dif_uart_config_t *config) {
   if ((uart == NULL) || (config == NULL)) {
-    return kDifUartBadArg;
+    return kDifUartConfigBadArg;
   }
 
   return uart_configure(uart, config);


### PR DESCRIPTION
Two functions were returning enum values from the wrong enum type. The
numerical value was the same as for the correct enum, so this was only a
latent bug. This was noticed when compiling with Clang, which warns about
the use of mismatching enums.

Signed-off-by: Luís Marques <luismarques@lowrisc.org>