### PR TITLE
[vendor.py] Fix iteration code

### DIFF
--- a/util/vendor.py
+++ b/util/vendor.py
@@ -148,7 +148,7 @@ def produce_shortlog(clone_dir, mapping, old_rev, new_rev):
     # these strings are paths relative to clone_dir, we can just pass them all
     # to git and let it figure out what to do.
     subdirs = (['.'] if mapping is None
-               else [src for (src, _) in mapping.items])
+               else [m.from_path for m in mapping.items])
 
     cmd = (['git', '-C', str(clone_dir), 'log',
            '--pretty=format:%s (%aN)', '--no-merges',


### PR DESCRIPTION
Seems like a left-over from a previous design point where `Mapping` was
actually a list.

```
Traceback (most recent call last):
  File "/home/philipp/src/opentitan/util/vendor.py", line 710, in <module>
    main(sys.argv)
  File "/home/philipp/src/opentitan/util/vendor.py", line 651, in main
    shortlog = produce_shortlog(clone_subdir, desc.mapping,
  File "/home/philipp/src/opentitan/util/vendor.py", line 152, in produce_shortlog
    else [src for (src, _) in mapping.items])
  File "/home/philipp/src/opentitan/util/vendor.py", line 152, in <listcomp>
    else [src for (src, _) in mapping.items])
TypeError: cannot unpack non-iterable Mapping1 object
```