### PR TITLE
[dvsim] Update Xcelium cfg to use CDNS UVM

### DIFF
--- a/hw/dv/data/xcelium/xcelium.hjson
+++ b/hw/dv/data/xcelium/xcelium.hjson
@@ -16,7 +16,7 @@
                "-messages -errormax 50",
                "-timescale 1ns/1ps",
                "-f {sv_flist}",
-               "-uvmhome {UVM_HOME}",
+               "-uvmhome CDNS-1.2",
                "-xmlibdirname {build_dir}/xcelium.d"]
 
   run_opts:   ["-input {tool_srcs_dir}/xcelium_{dump}.tcl",


### PR DESCRIPTION
- Fixes #2305
- Let Xcelium use its own provided UVM installation than rely on an
external path

Signed-off-by: Srikrishna Iyer <sriyer@google.com>