### PR TITLE
[dv] Clean up for phase_read_to_end

### DIFF
--- a/hw/dv/sv/dv_lib/dv_base_scoreboard.sv
+++ b/hw/dv/sv/dv_lib/dv_base_scoreboard.sv
@@ -45,18 +45,6 @@ class dv_base_scoreboard #(type RAL_T = dv_base_reg_block,
     end
   endtask
 
-  // raise / drop objections based on certain events
-  virtual function void process_objections(bit raise);
-    if (raise && !obj_raised) begin
-      m_current_phase.raise_objection(this, $sformatf("%s objection raised", `gfn));
-      obj_raised = 1'b1;
-    end
-    else if (!raise && obj_raised) begin
-      m_current_phase.drop_objection(this, $sformatf("%s objection dropped", `gfn));
-      obj_raised = 1'b0;
-    end
-  endfunction
-
   virtual function void reset(string kind = "HARD");
     // reset the ral model
     if (cfg.has_ral) ral.reset(kind);

--- a/hw/dv/sv/scoreboard/scoreboard.sv
+++ b/hw/dv/sv/scoreboard/scoreboard.sv
@@ -28,7 +28,6 @@ class scoreboard#(type ITEM_T = uvm_object,
   int unsigned                      timeout_check_cycle_interval = 100;
   bit                               enable_logging = 1'b0;
   uvm_phase                         run_phase_h;
-  bit                               objection_raised;
   semaphore                         token;
   string                            log_filename;
   int                               log_fd;
@@ -208,10 +207,6 @@ class scoreboard#(type ITEM_T = uvm_object,
             `uvm_info(get_full_name(), $sformatf(
                       "Scoreboard timeout caused by packet drop, act/exp items = %0d/%0d",
                       num_of_act_item, num_of_exp_item), UVM_LOW)
-            if (objection_raised) begin
-              run_phase_h.drop_objection(this, $sformatf("%s objection dropped", `gfn));
-              objection_raised = 1'b0;
-            end
           end
         end
       end

--- a/hw/dv/sv/spi_agent/spi_monitor.sv
+++ b/hw/dv/sv/spi_agent/spi_monitor.sv
@@ -35,9 +35,7 @@ class spi_monitor extends dv_base_monitor#(
 
     forever begin
       @(negedge cfg.vif.csb);
-      phase.raise_objection(this, $sformatf("%s objection raised", `gfn));
       if (cfg.en_monitor_collect_trans) collect_curr_trans();
-      phase.drop_objection(this, $sformatf("%s objection dropped", `gfn));
     end
   endtask
 
@@ -98,6 +96,13 @@ class spi_monitor extends dv_base_monitor#(
         disable fork;
       end
     join
+  endtask
+
+  virtual task monitor_ready_to_end();
+    forever begin
+      @(cfg.vif.csb);
+      ok_to_end = !cfg.vif.csb;
+    end
   endtask
 
 endclass

--- a/hw/dv/sv/tl_agent/tl_monitor.sv
+++ b/hw/dv/sv/tl_agent/tl_monitor.sv
@@ -45,7 +45,7 @@ class tl_monitor extends dv_base_monitor#(
     @(posedge cfg.vif.rst_n);
   endtask : wait_for_reset_done
 
-  // on reset flush pending request and drop objection
+  // on reset flush pending request
   virtual task reset_thread();
     forever begin
       @(negedge cfg.vif.rst_n);


### PR DESCRIPTION
1. Remove raise/drop objection in scb/mon
2. Update mon to use monitor_ready_to_end
Signed-off-by: Weicai Yang <weicai@google.com>