### PR TITLE
[dv, xcelium] Cleanup a few Xcelium warnings during build

### DIFF
--- a/hw/dv/data/xcelium/xcelium.hjson
+++ b/hw/dv/data/xcelium/xcelium.hjson
@@ -33,6 +33,11 @@
     // Poll for an available license every 1 min.
     CDS_LIC_QUEUE_POLL_INT: 60
 
+    // X-prop related: these were suggested by Xcelium as warnings during the build time.
+    // These enable array corruption when the index is out of range or invalid.
+    VL_ENABLE_INVALID_IDX_XPROP: 1
+    VL_ENABLE_OUTOFRANGE_IDX_XPROP: 1
+
     // Export the cov_report path so that the tcl file can read these as env vars.
     cov_merge_db_dir: "{cov_merge_db_dir}"
     cov_report_dir:   "{cov_report_dir}"
@@ -122,8 +127,7 @@
     {
       name: xcelium_xprop
       is_sim_mode: 1
-      # -xverbose  << add to see which modules does not have xprop enabled
-      build_opts: ["-xprop F"]
+      build_opts: ["-xprop F -xverbose"]
     }
     {
       // TODO: Add build and run options to enable zero delay loop detection.

--- a/hw/dv/sv/dv_lib/dv_base_reg_block.sv
+++ b/hw/dv/sv/dv_lib/dv_base_reg_block.sv
@@ -13,7 +13,8 @@ class dv_base_reg_block extends uvm_reg_block;
   endfunction
 
   // provide build function to supply base addr
-  virtual function void build(uvm_reg_addr_t base_addr, csr_utils_pkg::csr_excl_item csr_excl);
+  virtual function void build(uvm_reg_addr_t base_addr,
+                              csr_utils_pkg::csr_excl_item csr_excl = null);
     `uvm_fatal(`gfn, "this method is not supposed to be called directly!")
   endfunction
 

--- a/hw/ip/aes/dv/tb/tb.sv
+++ b/hw/ip/aes/dv/tb/tb.sv
@@ -14,13 +14,14 @@ module tb;
   `include "dv_macros.svh"
 
   wire clk, rst_n;
+  wire devmode;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
 
   // interfaces
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
   pins_if #(NUM_MAX_INTERRUPTS) intr_if(interrupts);
 
-  pins_if #(1) devmode_if();
+  pins_if #(1) devmode_if(devmode);
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
 
   // dut

--- a/hw/ip/alert_handler/dv/tb/tb.sv
+++ b/hw/ip/alert_handler/dv/tb/tb.sv
@@ -14,6 +14,7 @@ module tb;
   `include "dv_macros.svh"
 
   wire clk, rst_n;
+  wire devmode;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
   wire [NUM_MAX_ESC_SEV-1:0]    esc_en;
   wire entropy;
@@ -22,7 +23,7 @@ module tb;
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
   pins_if #(NUM_MAX_INTERRUPTS) intr_if(interrupts);
   pins_if #(1) entropy_if(entropy);
-  pins_if #(1) devmode_if();
+  pins_if #(1) devmode_if(devmode);
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
   alert_esc_if esc_device_if[alert_pkg::N_ESC_SEV](.clk(clk), .rst_n(rst_n));
   alert_esc_if alert_host_if[alert_pkg::NAlerts](.clk(clk), .rst_n(rst_n));

--- a/hw/ip/entropy_src/dv/tb/tb.sv
+++ b/hw/ip/entropy_src/dv/tb/tb.sv
@@ -14,12 +14,13 @@ module tb;
   `include "dv_macros.svh"
 
   wire clk, rst_n;
+  wire devmode;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
 
   // interfaces
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
   pins_if #(NUM_MAX_INTERRUPTS) intr_if(interrupts);
-  pins_if #(1) devmode_if();
+  pins_if #(1) devmode_if(devmode);
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
 
   // dut

--- a/util/uvmdvgen/tb.sv.tpl
+++ b/util/uvmdvgen/tb.sv.tpl
@@ -14,6 +14,7 @@ module tb;
   `include "dv_macros.svh"
 
   wire clk, rst_n;
+  wire devmode;
 % if is_cip:
 % if has_interrupts:
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
@@ -34,7 +35,7 @@ module tb;
   // TODO: declare alert interfaces according to the list_of_alerts
   alert_if alert_names(.clk(clk), .rst_n(rst_n))
 % endif
-  pins_if #(1) devmode_if();
+  pins_if #(1) devmode_if(devmode);
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
 % endif
 % for agent in env_agents:


### PR DESCRIPTION
The following three warnings are fixed in 3 separate commits:

Commit 1: 
```
xmelab: *W,XPWDIS: There are blocks in the design which have not been enabled for Xprop. To understand the details, user is recommended to run with -xverbose switch at elaboration.
```

Commit 2: 
```
file: ../src/lowrisc_dv_aes_ral_pkg_0/aes_ral_pkg.sv
                                csr_utils_pkg::csr_excl_item csr_excl = null);
                                                                    |
xmvlog: *W,CVMXDV (../src/lowrisc_dv_aes_ral_pkg_0/aes_ral_pkg.sv,964|68): Virtual method 'aes_reg_block::build' has default argument value not present in base class 'dv_base_reg_block'.
```

Commit 3:
```
  pins_if #(1) devmode_if();
                        |
xmelab: *W,CUVWSB (../src/lowrisc_dv_aes_sim_0.1/tb/tb.sv,23|24): 1 inout port was not connected:
xmelab: (../src/lowrisc_dv_pins_if_0/pins_if.sv,13): pins
```