### PR TITLE
[util] Correctly cope with patch_dir and no mapping in vendor.py

### DIFF
--- a/util/vendor.py
+++ b/util/vendor.py
@@ -296,7 +296,7 @@ class Mapping1:
         # there are none to apply. Otherwise, resolve it relative to patch_dir.
         if self.patch_dir is not None:
             patches = (patch_dir / self.patch_dir).glob('*.patch')
-            for patch in patches:
+            for patch in sorted(patches):
                 log.info("Applying patch {} at {}".format(patch, to_path))
                 Mapping1.apply_patch(to_path, patch)
 

--- a/util/vendor.py
+++ b/util/vendor.py
@@ -263,16 +263,18 @@ class Mapping1:
         return Mapping1(from_path, to_path, patch_dir)
 
     @staticmethod
-    def make_default():
+    def make_default(have_patch_dir):
         '''Make a default mapping1, which copies everything straight through'''
-        return Mapping1(Path('.'), Path('.'), None)
+        return Mapping1(Path('.'), Path('.'),
+                        Path('.') if have_patch_dir else None)
 
     @staticmethod
     def apply_patch(basedir, patchfile):
-        cmd = ['git', 'apply', '-p1', str(patchfile)]
+        cmd = ['git', 'apply', '--directory', str(basedir), '-p1',
+               str(patchfile)]
         if verbose:
             cmd += ['--verbose']
-        subprocess.run(cmd, cwd=str(basedir), check=True)
+        subprocess.run(cmd, check=True)
 
     def import_from_upstream(self, upstream_path,
                              target_path, exclude_files, patch_dir):
@@ -424,7 +426,7 @@ class Desc:
         shutil.rmtree(str(self.target_dir), ignore_errors=True)
 
         items = (self.mapping.items if self.mapping is not None
-                 else [Mapping1.make_default()])
+                 else [Mapping1.make_default(self.patch_dir is not None)])
         for map1 in items:
             map1.import_from_upstream(upstream_path,
                                       self.target_dir,


### PR DESCRIPTION
This was broken with my recent patch to add "mapping" support. The fix
passes a boolean flag to Mapping1.make_default saying "please add a
relative patch directory of '.' to the dummy mapping entry you make".

This patch also fixes how we run "git apply" to apply the patches.
It turns out that if you run

    cd subdir/in/repo
    git apply my.patch

then the paths in my_path are interpreted relative to the root of the
repository (and anything that applies to a file outside of
subdir/in/repo is skipped).

Before the recent vendoring changes, we applied the patches before
copying into the target repository. So it was something like

    git clone git://something /tmp/something
    (cd /tmp/something; git apply -p1 /path/to/my.patch)
    cp /tmp/something/* vendor/something

I'm not sure this would work with only_subdir, but it definitely did
work correctly if we were copying from the top of the vendored repo.

The recent vendoring changes alter things to:

    git clone git://something /tmp/something
    cp /tmp/something/* vendor/something
    (cd vendor/something; git apply -p1 /path/to/my.patch)

This doesn't do what you want, because the paths in the patch look
like a/myfile.c rather than a/vendor/something/myfile.c (and the hunks
all get skipped).

We can fix things up again by using the --directory argument to git
apply, which works a bit like you might expect changing directory to
vendor/something would work and changes how the patch paths are
interpreted.