### PR TITLE
[top_earlgrey] Fix typo in C header template

### DIFF
--- a/hw/top_earlgrey/data/top_earlgrey.h.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.h.tpl
@@ -36,7 +36,7 @@
 #define PINMUX_VALUE_Z_OUT 2
 % for i, sig in enumerate(top["pinmux"]["inouts"] + top["pinmux"]["outputs"]):
   % if sig["width"] == 1:
-#define PINMUX_${sig["width"].upper()}_OUT ${offset + i}
+#define PINMUX_${sig["name"].upper()}_OUT ${offset + i}
   % else:
     % for j in range(sig["width"]):
 #define PINMUX_${sig["name"].upper()}_${j}_OUT ${offset + i + j}


### PR DESCRIPTION
`sig["width"]` is integer type. Intention is to use `sig["name"]`