### PR TITLE
[dv] Write SW logs to separate file

### DIFF
--- a/hw/dv/sv/uart_agent/uart_agent_cfg.sv
+++ b/hw/dv/sv/uart_agent/uart_agent_cfg.sv
@@ -17,9 +17,10 @@ class uart_agent_cfg extends dv_base_agent_cfg;
   bit odd_parity;
 
   // Logger settings.
-  bit en_logger         = 1'b0; // enable logger on tx
-  bit use_rx_for_logger = 1'b0; // use rx instead of tx
-  string logger_msg_id  = "UART_LOGGER";
+  bit en_logger           = 1'b0; // enable logger on tx
+  bit use_rx_for_logger   = 1'b0; // use rx instead of tx
+  string logger_id        = "uart_logger";
+  bit write_logs_to_file  = 1'b1;
 
   // reset is controlled at upper seq-level as no reset pin on uart interface
   bit under_reset;

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -11,6 +11,9 @@ class chip_env_cfg extends cip_base_env_cfg #(.RAL_T(chip_reg_block));
   bit                 use_gpio_for_sw_test_status;
   bit                 initialize_ram;
 
+  // Write logs from sw test to separate log file as well, in addition to the simulator log file.
+  bit                 write_sw_logs_to_file = 1'b1;
+
   // chip top interfaces
   virtual clk_rst_if  usb_clk_rst_vif;
   gpio_vif            gpio_vif;

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -25,6 +25,7 @@ class chip_sw_base_vseq extends chip_base_vseq;
       cfg.sw_logger_vif.set_sw_name(cfg.sw_types[i]);
     end
     cfg.sw_logger_vif.sw_log_addr = SW_DV_LOG_ADDR;
+    cfg.sw_logger_vif.write_sw_logs_to_file = cfg.write_sw_logs_to_file;
     cfg.sw_logger_vif.ready();
 
     // initialize the sw test status

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_uart_tx_rx_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_uart_tx_rx_vseq.sv
@@ -65,6 +65,7 @@ class chip_sw_uart_tx_rx_vseq extends chip_sw_base_vseq;
     wait(uart_tx_data_q.size() == exp_uart_tx_data.size());
 
     // Check if we received the right data set over the TX port.
+    `uvm_info(`gfn, "Checking the received UART TX data for consistency.", UVM_LOW)
     foreach (uart_tx_data_q[i]) begin
       `DV_CHECK_EQ(uart_tx_data_q[i], exp_uart_tx_data[i])
     end
@@ -78,7 +79,6 @@ class chip_sw_uart_tx_rx_vseq extends chip_sw_base_vseq;
     uart_default_seq send_rx_seq;
     `uvm_create_on(send_rx_seq, p_sequencer.uart_sequencer_h);
     if (size == -1) size = uart_rx_data.size();
-    `uvm_info(`gfn, "Checking the received UART TX data for consistency.", UVM_LOW)
     for (int i = 0; i < size; i++) begin
       byte rx_data = random ? $urandom : uart_rx_data[i];
       `DV_CHECK_RANDOMIZE_WITH_FATAL(send_rx_seq, data == rx_data;)

--- a/hw/top_earlgrey/dv/tests/chip_base_test.sv
+++ b/hw/top_earlgrey/dv/tests/chip_base_test.sv
@@ -26,10 +26,13 @@ class chip_base_test extends cip_base_test #(
     // Knob to set the UART baud rate (set to 2M by default).
     void'($value$plusargs("uart_baud_rate=%0d", cfg.uart_baud_rate));
 
+    // Knob to configure writing sw logs to a separate file (enabled by default).
+    void'($value$plusargs("write_sw_logs_to_file=%0b", cfg.write_sw_logs_to_file));
+
     // Knob to enable logging over UART (disabled by default).
     void'($value$plusargs("en_uart_logger=%0b", cfg.en_uart_logger));
     cfg.m_uart_agent_cfg.en_logger = cfg.en_uart_logger;
-    cfg.m_uart_agent_cfg.logger_msg_id  = "SW_LOGS";
+    cfg.m_uart_agent_cfg.write_logs_to_file = cfg.write_sw_logs_to_file;
 
     // Knob to set the sw_test_timeout_ns (set to 5ms by default).
     void'($value$plusargs("sw_test_timeout_ns=%0d", cfg.sw_test_timeout_ns));


### PR DESCRIPTION
In chip level DV, is high logging verbosity is used, then it becomes difficult to search for logs from SW (which are quite low volume). This PR enables writing of the logs to a separate file with both, the UART logger as well as the ELF file based `sw_logger_if`, made in separate commits. 