### PR TITLE
Add flake8 to Python requirements

### DIFF
--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Keep sorted.
+flake8
 gitpython
 hjson
 ipyxact >= 0.2.4


### PR DESCRIPTION
flake8 is a potential option used in util/lintpy.py, installing it for
the convenience of our users.