### PR TITLE
[vendor] Refresh patches to target dir

### DIFF
--- a/util/vendor.py
+++ b/util/vendor.py
@@ -456,7 +456,7 @@ def _export_patches(patchrepo_clone_url, target_patch_dir, upstream_rev,
     with tempfile.TemporaryDirectory() as clone_dir:
         clone_git_repo(patchrepo_clone_url, clone_dir, patched_rev)
         rev_range = 'origin/' + upstream_rev + '..' + 'origin/' + patched_rev
-        cmd = ['git', 'format-patch', '-o', str(target_patch_dir), rev_range]
+        cmd = ['git', 'format-patch', '-o', str(target_patch_dir.resolve()), rev_range]
         if not verbose:
             cmd += ['-q']
         subprocess.run(cmd, cwd=str(clone_dir), check=True)


### PR DESCRIPTION
target_patch_dir is a relative directory, and with `cwd` set, it
resolves to the temporary directory. Make it an absolute path to ensure
that patches are actually produced.