### PR TITLE
[vendor] Catch keyboard interrupt for nicer error message

### DIFF
--- a/util/vendor.py
+++ b/util/vendor.py
@@ -715,3 +715,6 @@ if __name__ == '__main__':
                   "STDERR:\n%s\n" %
                   (" ".join(e.cmd), e.returncode, e.stdout, e.stderr))
         raise
+    except KeyboardInterrupt:
+        log.info("Aborting operation on user request.")
+        sys.exit(1)


### PR DESCRIPTION
Avoid printing a stack trace in a user-initiated abort, but print a
"nice" message instead.