### PR TITLE
[sw] Add Header Extern Guards to DIFs and libbase

### DIFF
--- a/sw/device/lib/base/bitfield.h
+++ b/sw/device/lib/base/bitfield.h
@@ -7,6 +7,11 @@
 
 #include <stdint.h>
 
+// Header Extern Guard  (so header can be used from C and C++)
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
 /**
  * Masked field offset for 32-bit bitfields, with optional value.
  *
@@ -62,5 +67,9 @@ inline uint32_t bitfield_set_field32(uint32_t bitfield,
   bitfield |= (field.value & field.mask) << field.index;
   return bitfield;
 }
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_BASE_BITFIELD_H_

--- a/sw/device/lib/base/memory.h
+++ b/sw/device/lib/base/memory.h
@@ -9,6 +9,11 @@
 #include <stddef.h>
 #include <stdint.h>
 
+// Header Extern Guard  (so header can be used from C and C++)
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
 /**
  * Load a word from memory directly, bypassing aliasing rules.
  *
@@ -132,5 +137,9 @@ void *memchr(const void *ptr, int value, size_t len);
  * @return a pointer to the found value, or NULL.
  */
 void *memrchr(const void *ptr, int value, size_t len);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_BASE_MEMORY_H_

--- a/sw/device/lib/base/mmio.h
+++ b/sw/device/lib/base/mmio.h
@@ -5,17 +5,16 @@
 #ifndef OPENTITAN_SW_DEVICE_LIB_BASE_MMIO_H_
 #define OPENTITAN_SW_DEVICE_LIB_BASE_MMIO_H_
 
-// This file is included in C and C++, and, as such, needs to be marked as
-// extern "C" in C++ to make sure linking works out.
-#ifdef __cplusplus
-extern "C" {
-#endif  // __cplusplus
-
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
 #include "sw/device/lib/base/bitfield.h"
+
+// Header Extern Guard  (so header can be used from C and C++)
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
 
 /**
  * Memory-mapped IO functions, which either map to volatile accesses, or can be

--- a/sw/device/lib/dif/dif_gpio.h
+++ b/sw/device/lib/dif/dif_gpio.h
@@ -10,6 +10,11 @@
 
 #include "sw/device/lib/base/mmio.h"
 
+// Header Extern Guard (so header can be used from C and C++)
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
 /**
  * Configuration for initializing a GPIO device.
  */
@@ -342,5 +347,9 @@ dif_gpio_result_t dif_gpio_irq_trigger_masked_disable(const dif_gpio_t *gpio,
 dif_gpio_result_t dif_gpio_irq_trigger_masked_config(const dif_gpio_t *gpio,
                                                      uint32_t mask,
                                                      dif_gpio_irq_t config);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_DIF_DIF_GPIO_H_

--- a/sw/device/lib/dif/dif_plic.h
+++ b/sw/device/lib/dif/dif_plic.h
@@ -10,6 +10,11 @@
 
 #include "sw/device/lib/base/mmio.h"
 
+// Header Extern Guard (so header can be used from C and C++)
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
 /** The lowest interrupt priority. */
 extern const uint32_t kDifPlicMinPriority;
 
@@ -202,5 +207,9 @@ dif_plic_result_t dif_plic_irq_claim(const dif_plic_t *plic,
 dif_plic_result_t dif_plic_irq_complete(const dif_plic_t *plic,
                                         dif_plic_target_t target,
                                         const dif_plic_irq_id_t *complete_data);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_DIF_DIF_PLIC_H_

--- a/sw/device/lib/dif/dif_spi_device.h
+++ b/sw/device/lib/dif/dif_spi_device.h
@@ -10,6 +10,11 @@
 
 #include "sw/device/lib/base/mmio.h"
 
+// Header Extern Guard (so header can be used from C and C++)
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
 /**
  * Represents a signal edge type.
  */
@@ -241,5 +246,9 @@ dif_spi_device_result_t dif_spi_device_recv(const dif_spi_device_t *spi,
 dif_spi_device_result_t dif_spi_device_send(const dif_spi_device_t *spi,
                                             const void *buf, size_t buf_len,
                                             size_t *bytes_sent);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_DIF_DIF_SPI_DEVICE_H_

--- a/sw/device/lib/dif/dif_uart.h
+++ b/sw/device/lib/dif/dif_uart.h
@@ -10,6 +10,11 @@
 
 #include "sw/device/lib/base/mmio.h"
 
+// Header Extern Guard (so header can be used from C and C++)
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
 // The size of UART TX and RX FIFOs in bytes.
 extern const uint32_t kDifUartFifoSizeBytes;
 
@@ -338,5 +343,9 @@ dif_uart_result_t dif_uart_rx_bytes_available(const dif_uart_t *uart,
  */
 dif_uart_result_t dif_uart_tx_bytes_available(const dif_uart_t *uart,
                                               size_t *num_bytes);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_DIF_DIF_UART_H_


### PR DESCRIPTION
This commit adds header extern guards to:
- The parts of libbase that are allowed to be used by DIFs
  - `mmio.h` (it was already present in this file, it's now moved after the `#include` statements).
  - `bitfield.h`
  - `memory.h`
- The existing DIFs (which have C++ tests).