### PR TITLE
Remove flake8 from apt requirements

### DIFF
--- a/apt-requirements.txt
+++ b/apt-requirements.txt
@@ -8,7 +8,6 @@ bison
 build-essential
 clang-format
 curl
-flake8
 flex
 g++
 git


### PR DESCRIPTION
Since 8149d1cf2fd3c5b33e2f8353c30f4d140847b5be we install flake8 through
python-requirements.txt, making it easier installable for users who are
not on Debian/Ubuntu. Therefore we can remove it now from
apt-requirements.txt.