### PR TITLE
[hmac/dv] dsim compile error

### DIFF
--- a/hw/ip/hmac/dv/env/hmac_scoreboard.sv
+++ b/hw/ip/hmac/dv/env/hmac_scoreboard.sv
@@ -58,7 +58,7 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
           update_err_intr_code(SwPushMsgWhenShaDisabled);
         end else if (hmac_start && !cfg.under_reset) begin
           bit [7:0] bytes[4];
-          bit [7:0] msg[];
+          bit [7:0] msg[$];
           {<<byte{bytes}} = item.a_data;
           // do endian swap in the word according to the mask, then push to the queue of msgs
           foreach (item.a_mask[i]) begin


### PR DESCRIPTION
In hmac scoreboard I declared a dynamic array without using new[]
function to allocate its memory. Somehow it works for VCS and Xcelium,
but Dsim throws an array. Fixed it and replaced the dynamic array to a
queue.

Signed-off-by: Cindy Chen <chencindy@google.com>