### PR TITLE
[dv/alert_handler] fix corner case

### DIFF
--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_sanity_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_sanity_vseq.sv
@@ -81,7 +81,7 @@ class alert_handler_sanity_vseq extends alert_handler_base_vseq;
   task body();
     fork
       begin : isolation_fork
-        `DV_CHECK_RANDOMIZE_FATAL(this)
+        `DV_CHECK_MEMBER_RANDOMIZE_FATAL(esc_int_err)
         run_esc_rsp_seq_nonblocking(esc_int_err);
         run_alert_ping_rsp_seq_nonblocking(alert_ping_timeout);
         `uvm_info(`gfn, $sformatf("num_trans=%0d", num_trans), UVM_LOW)


### PR DESCRIPTION
Fix corner case where escalation is triggered in the same cycle as
esc_clear register.
Use DV_CHECK_MEMBER_RANDOMIZE_FATAL to randomize one value, instead of
using DV_CHECK_RANDOMIZE_FATAL

Signed-off-by: Cindy Chen <chencindy@google.com>