### PR TITLE
[usbdev] Document data_toggle_clear as only for hardware debug

### DIFF
--- a/hw/ip/usbdev/data/usbdev.hjson
+++ b/hw/ip/usbdev/data/usbdev.hjson
@@ -482,8 +482,10 @@
             bits: "0",
             name: "clear",
             desc: '''
+                  Only use for hardware debug.
+
                   Writing 1 to this bit will clear the data toggle bit for this endpoint to Data0 in both IN and OUT directions.
-                  The register must no be written again within 200 ns.
+                  The register must not be written again within 200 ns.
                   '''
           }
         ]


### PR DESCRIPTION
---

Closes #2364. 