### PR TITLE
[www] Update copyright years in footer 

### DIFF
--- a/site/docs/layouts/partials/footer.html
+++ b/site/docs/layouts/partials/footer.html
@@ -36,7 +36,7 @@
     </ul>
   </nav>
 
-  <p>© 2019 <a href="https://www.lowrisc.org">lowRISC</a> contributors, <a
+  <p>© 2019 &ndash; {{ now.Format "2006" }} <a href="https://www.lowrisc.org">lowRISC</a> contributors, <a
     href="https://opentitan.org/usage-policy/">Usage Policy</a>, <a
     href="https://opentitan.org/privacy-policy/">Privacy Policy</a>.</p>
   <p>No license is granted for the OpenTitan logo or other trademarks. <a
@@ -59,8 +59,8 @@
     wrapper.setAttribute('class', 'overflow-table');
     table.parentNode.insertBefore(wrapper, table);
     wrapper.appendChild(table);
-  } 
-  
+  }
+
   // Dark and light theme
   document.documentElement.classList.remove('no-js');
   const STORAGE_KEY = 'user-color-scheme';

--- a/site/landing/layouts/index.html
+++ b/site/landing/layouts/index.html
@@ -325,7 +325,7 @@
       </ul>
     </nav>
 
-    <p>© 2019 lowRISC contributors, <a href="/privacy-policy/">Privacy
+    <p>© 2019 &ndash; {{ now.Format "2006" }} lowRISC contributors, <a href="/privacy-policy/">Privacy
       Policy</a>, <a href="/usage-policy/">Usage Policy</a>.</p>
     <p>The text content on this website is licensed under a
     <a href="https://creativecommons.org/licenses/by-sa/4.0/">Creative Commons


### PR DESCRIPTION
It's not 2019 any more (I wouldn't mind it, though).

Dynamically update the copyright year to include the current year
("2019" becomes "2019 - 2020").