### PR TITLE
[doc] Improve code styling

### DIFF
--- a/site/docs/assets/scss/_highlight.scss
+++ b/site/docs/assets/scss/_highlight.scss
@@ -1,4 +1,3 @@
 .highlight {
-  font-size: 10pt;
-  line-height: 12pt;
+  line-height: normal;
 }

--- a/site/docs/assets/scss/_markdown.scss
+++ b/site/docs/assets/scss/_markdown.scss
@@ -25,7 +25,7 @@
       padding-top: 0;
     }
   }
-  
+
   h1.title {
     font-size: 2.5em;
     border: none !important;

--- a/site/docs/config.toml
+++ b/site/docs/config.toml
@@ -57,7 +57,7 @@ ignoreFiles = [
   "COMMITTERS",
 ]
 pygmentsCodeFences = true
-pygmentsStyle = "tango"
+pygmentsStyle = "colorful"
 disableKinds = ["taxonomy", "taxonomyTerm", "RSS", "sitemap"]
 googleAnalytics = "UA-151030466-2"
 


### PR DESCRIPTION
Align the style between highlighted and non-highlighted code boxes, and use a style which better works for our documentation style (a bit of personal preference here as well).