### PR TITLE
[pattgen, dv] Update PATTGEN for v1-bronze

### DIFF
--- a/hw/ip/pattgen/data/pattgen.hjson
+++ b/hw/ip/pattgen/data/pattgen.hjson
@@ -2,141 +2,139 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-{ name: "pattgen"
-  clock_primary: "clk_fixed"
-  bus_device: "tlul"
-  bus_host: "none"
-  estimated_gate: "1k"
+{ name: "pattgen",
+  clock_primary: "clk_fixed",
+  bus_device: "tlul",
+  bus_host: "none",
+  estimated_gate: "1k",
+  regwidth: "32",
   // OUTPUT pins
   available_output_list: [
+    { name: "pda0_tx", desc: "Serial output data bit for pattern generation on channel 0" }
+    { name: "pcl0_tx", desc: "Bit-banging output clock for pattern generation on channel 0" }
     { name: "pda1_tx", desc: "Serial output data bit for pattern generation on channel 1" }
     { name: "pcl1_tx", desc: "Bit-banging output clock for pattern generation on channel 1" }
-    { name: "pda2_tx", desc: "Serial output data bit for pattern generation on channel 2" }
-    { name: "pcl2_tx", desc: "Bit-banging output clock for pattern generation on channel 2" }
   ]
   // INTERRUPT pins
   interrupt_list: [
+    { name: "patt_done0"
+      desc: "raise if pattern generation on channel 0 is complete"
+    }
     { name: "patt_done1"
       desc: "raise if pattern generation on channel 1 is complete"
     }
-    { name: "patt_done2"
-      desc: "raise if pattern generation on channel 2 is complete"
+  ],
+  param_list: [
+    { name:    "NumRegsPrediv",
+      type:    "int",
+      default: "2",
+      desc:    "Number pre-dividers",
+      local:   "true"
     }
-  ]
-
+  ],
   // REGISTER definition
-  regwidth: "32"
   registers: [
     // CTRL register
-    { name: "CTRL"
-      desc: "PATTGEN control register (Functions TBD)"
-      swaccess: "rw"
-      hwaccess: "hro"
+    { name: "CTRL",
+      desc: "PATTGEN control register (Functions TBD)",
+      swaccess: "rw",
+      hwaccess: "hro",
       fields: [
-        { bits: "0"
-          resval: "0"
-          name: "ENABLE"
+        { bits: "0",
+          resval: "0",
+          name: "ENABLE",
           desc: '''
                 Enable pattern generator functionality
                 '''
         }
       ]
     }
-    { name: "START"
-      desc: "PATTGEN start pattern generation"
-      swaccess: "wo"
-      hwaccess: "hro"
-      hwqe: "true"
+    { name: "START",
+      desc: "PATTGEN start pattern generation",
+      swaccess: "wo",
+      hwaccess: "hro",
+      hwqe: "true",
       fields: [
-        { bits: "0"
-          resval: "0"
-          name: "START0"
+        { bits: "0",
+          resval: "0",
+          name: "START0",
+          desc: "Start generating pattern on channel 0"
+        }
+        { bits: "1",
+          resval: "0",
+          name: "START1",
           desc: "Start generating pattern on channel 1"
         }
-        { bits: "1"
-          resval: "0"
-          name: "START1"
-          desc: "Start generating pattern on channel 1"
-        }
       ]
     }
-    { name: "PREDIV1"
-      desc: "PATTGEN pre-divider of I/O clock for chanel 1 (base is 2)"
-      swaccess: "rw"
-      hwaccess: "hro"
-      hwqe: "true"
-      fields: [
-        { bits: "31:0"
-          resval: "0"
-          name: "RATIO"
-          desc: "Dividend ratio for channel 1 (base is 2)"
-        }
-      ]
+    { multireg: {
+        name: "PREDIV",
+        desc: "Pre-divider multi registers",
+        count: "NumRegsPrediv",
+        cname: "PATTGEN",
+        swaccess: "rw",
+        hwaccess: "hro",
+        hwqe: "true",
+        fields: [
+          { bits: "31:0",
+            resval: "0",
+            name: "RATIO",
+            desc: "Dividend ratio from based I/O clock for channel 0 (base is 2)"
+          }
+        ]
+      }
     }
-    { name: "PREDIV2"
-      desc: "PATTGEN pre-divider of I/O clock for chanel 2 (base is 2)"
-      swaccess: "rw"
-      hwaccess: "hro"
-      hwqe: "true"
+    { name: "PATT_LEN",
+      desc: "PATTGEN pattern length (base is 2)",
+      swaccess: "rw",
+      hwaccess: "hro",
+      hwqe: "true",
       fields: [
-        { bits: "31:0"
-          resval: "0"
-          name: "RATIO"
-          desc: "Dividend ratio for channel 2 (base is 2)"
+        { bits: "5:0",
+          resval: "0",
+          name: "LEN0",
+          desc: "Length of pattern generated on channel 0 (base is 2)"
         }
-      ]
-    }
-    { name: "PATT_LEN"
-      desc: "PATTGEN pattern length (base is 2)"
-      swaccess: "rw"
-      hwaccess: "hro"
-      hwqe: "true"
-      fields: [
-        { bits: "5:0"
-          resval: "0"
-          name: "LEN1"
+        { bits: "12:7",
+          resval: "0",
+          name: "LEN1",
           desc: "Length of pattern generated on channel 1 (base is 2)"
         }
-        { bits: "12:7"
-          resval: "0"
-          name: "LEN2"
-          desc: "Length of pattern generated on channel 2 (base is 2)"
-        }
       ]
     }
-    { name: "PATT_LOOP"
-      desc: "PATTGEN number of pattern repeatedly generated before halt (base is 1)"
-      swaccess: "rw"
-      hwaccess: "hro"
-      hwqe: "true"
+    { name: "PATT_LOOP",
+      desc: "PATTGEN number of pattern repeatedly generated before halt (base is 1)",
+      swaccess: "rw",
+      hwaccess: "hro",
+      hwqe: "true",
       fields: [
-        { bits: "9:0"
-          resval: "0"
-          name: "LOOP1"
+        { bits: "9:0",
+          resval: "0",
+          name: "LOOP0",
+          desc: "Pattern repeatedly generated on channel 0 (base is 1)"
+        }
+        { bits: "19:10",
+          resval: "0",
+          name: "LOOP1",
           desc: "Pattern repeatedly generated on channel 1 (base is 1)"
         }
-        { bits: "19:10"
-          resval: "0"
-          name: "LOOP2"
-          desc: "Pattern repeatedly generated on channel 2 (base is 1)"
-        }
       ]
     }
-    { name: "INTR_MASK"
-      desc: "PATTGEN mask registers for channel interrupts"
-      swaccess: "rw"
-      hwaccess: "hro"
-      hwqe: "true"
+    { name: "INTR_MASK",
+      desc: "PATTGEN mask registers for channel interrupts",
+      swaccess: "rw",
+      hwaccess: "hro",
+      hwqe: "true",
       fields: [
-        { bits: "0"
-          resval: "0"
-          name: "MASK1"
-          desc: "Enable pattern_done interrupt of channel 1 if set to 1"
+        { bits: "0",
+          resval: "0",
+          name: "MASK0",
+          desc: "Enable pattern_done interrupt of channel 0 if set to 1"
         }
-        { bits: "1"
-          resval: "0"
-          name: "MASK2"
-          desc: "Enable pattern_done interrupt of channel 2 if set to 1"
+        { bits: "1",
+          resval: "0",
+          name: "MASK1",
+          desc: "Enable pattern_done interrupt of channel 1 if set to 1"
         }
       ]
     }

--- a/hw/ip/pattgen/data/pattgen.prj.hjson
+++ b/hw/ip/pattgen/data/pattgen.prj.hjson
@@ -1,0 +1,13 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+{
+    name:               "pattgen",
+    design_spec:        "hw/ip/pattgen/doc",
+    dv_plan:            "hw/ip/pattgen/doc/dv_plan",
+    version:            "0.5",
+    life_stage:         "L1",
+    design_stage:       "D0",
+    verification_stage: "V0",
+}

--- a/hw/ip/pattgen/data/pattgen_testplan.hjson
+++ b/hw/ip/pattgen/data/pattgen_testplan.hjson
@@ -1,0 +1,18 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  name: "pattgen"
+  // TODO: remove the common testplans if not applicable
+  import_testplans: ["hw/dv/tools/testplans/csr_testplan.hjson",
+                     "hw/dv/tools/testplans/intr_test_testplan.hjson",
+                     "hw/dv/tools/testplans/tl_device_access_types_testplan.hjson"]
+  entries: [
+    {
+      name: sanity
+      desc: TODO
+      milestone: V2
+      tests: ["pattgen_sanity"]
+    }
+  ]
+}

--- a/hw/ip/pattgen/dv/Makefile
+++ b/hw/ip/pattgen/dv/Makefile
@@ -1,0 +1,38 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+# Entry point test Makefile for building and running tests.
+# These are generic set of option groups that apply to all testbenches.
+# This flow requires the following options to be set:
+# DV_DIR       - current dv directory that contains the test Makefile
+# DUT_TOP      - top level dut module name
+# TB_TOP       - top level tb module name
+# DOTF         - .f file used for compilation
+# COMPILE_KEY  - compile option set
+# TEST_NAME    - name of the test to run - this is supplied on the command line
+DV_DIR          := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+export DUT_TOP  := pattgen
+export TB_TOP   := tb
+FUSESOC_CORE    := lowrisc:dv:pattgen_sim:0.1
+COMPILE_KEY     ?= default
+
+##########################################################
+# A D D    I N D I V I D U A L    T E S T S    B E L O W #
+##########################################################
+# common tests/seqs
+include ${DV_DIR}/../../../dv/tools/common_tests.mk
+
+TEST_NAME       ?= pattgen_sanity
+UVM_TEST        ?= pattgen_base_test
+UVM_TEST_SEQ    ?= pattgen_base_vseq
+
+ifeq (${TEST_NAME},pattgen_sanity)
+  UVM_TEST_SEQ   = pattgen_sanity_vseq
+  RUN_OPTS      += +en_scb=0
+endif
+
+####################################
+# Include the tool Makefile below  #
+# Dont add anything else below it! #
+####################################
+include ${DV_DIR}/../../../dv/tools/Makefile

--- a/hw/ip/pattgen/dv/README
+++ b/hw/ip/pattgen/dv/README
@@ -1,0 +1,21 @@
+# UART IP Verification Environment
+UART IP verification environment is extended from the [Comportable IP
+verification environment](/hw/dv/sv/cip_lib/README.md) to leverage a lot of common
+code shared across all IPs that adhere to the
+[Comportable IP](/doc/rm/ComportabilitySpecification.md) specification.
+
+## Environment
+
+### Block Diagram
+
+## Key fetures verified
+
+## Testplan
+
+## How to run simulation
+Please run the following command to build and run tests:
+`make TEST_NAME=<test-name>`
+
+Please see adjoining Makefile file for list of available tests to run. Please
+see `hw/dv/tools/README.md` for additional details on options that can be passed
+(such as enabling waves, running with specific seed etc.).

--- a/hw/ip/pattgen/dv/env/pattgen_env.core
+++ b/hw/ip/pattgen/dv/env/pattgen_env.core
@@ -1,0 +1,37 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:pattgen_env:0.1"
+description: "PATTGEN DV UVM environment"
+filesets:
+  files_dv:
+    depend:
+      - lowrisc:dv:ralgen
+      - lowrisc:dv:cip_lib
+      - lowrisc:ip:pattgen
+    files:
+      - pattgen_env_pkg.sv
+      - pattgen_env_cfg.sv: {is_include_file: true}
+      - pattgen_env_cov.sv: {is_include_file: true}
+      - pattgen_env.sv: {is_include_file: true}
+      - pattgen_scoreboard.sv: {is_include_file: true}
+      - pattgen_virtual_sequencer.sv: {is_include_file: true}
+      - seq_lib/pattgen_vseq_list.sv: {is_include_file: true}
+      - seq_lib/pattgen_base_vseq.sv: {is_include_file: true}
+      - seq_lib/pattgen_common_vseq.sv: {is_include_file: true}
+    file_type: systemVerilogSource
+
+generate:
+  ral:
+    generator: ralgen
+    parameters:
+      name: pattgen
+      ip_hjson: ../../data/pattgen.hjson
+
+targets:
+  default:
+    filesets:
+      - files_dv
+    generate:
+      - ral

--- a/hw/ip/pattgen/dv/env/pattgen_env.sv
+++ b/hw/ip/pattgen/dv/env/pattgen_env.sv
@@ -1,0 +1,23 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class pattgen_env extends dv_base_env #(
+    .CFG_T              (pattgen_env_cfg),
+    .COV_T              (pattgen_env_cov),
+    .VIRTUAL_SEQUENCER_T(pattgen_virtual_sequencer),
+    .SCOREBOARD_T       (pattgen_scoreboard)
+  );
+  `uvm_component_utils(pattgen_env)
+
+  `uvm_component_new
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+  endfunction
+
+  function void connect_phase(uvm_phase phase);
+    super.connect_phase(phase);
+  endfunction
+
+endclass

--- a/hw/ip/pattgen/dv/env/pattgen_env_cfg.sv
+++ b/hw/ip/pattgen/dv/env/pattgen_env_cfg.sv
@@ -1,0 +1,18 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class pattgen_env_cfg extends dv_base_env_cfg;
+
+  // ext component cfgs
+
+  `uvm_object_utils_begin(pattgen_env_cfg)
+  `uvm_object_utils_end
+
+  `uvm_object_new
+
+
+  virtual function void initialize(bit [31:0] csr_base_addr = '1);
+  endfunction
+
+endclass

--- a/hw/ip/pattgen/dv/env/pattgen_env_cov.sv
+++ b/hw/ip/pattgen/dv/env/pattgen_env_cov.sv
@@ -1,0 +1,30 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Covergoups that are dependent on run-time parameters that may be available
+ * only in build_phase can be defined here
+ * Covergroups may also be wrapped inside helper classes if needed.
+ */
+
+class pattgen_env_cov extends dv_base_env_cov #(.CFG_T(pattgen_env_cfg));
+  `uvm_component_utils(pattgen_env_cov)
+
+  // the base class provides the following handles for use:
+  // pattgen_env_cfg: cfg
+
+  // covergroups
+  // [add covergroups here]
+
+  function new(string name, uvm_component parent);
+    super.new(name, parent);
+    // [instantiate covergroups here]
+  endfunction : new
+
+  virtual function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    // [or instantiate covergroups here]
+  endfunction
+
+endclass

--- a/hw/ip/pattgen/dv/env/pattgen_env_pkg.sv
+++ b/hw/ip/pattgen/dv/env/pattgen_env_pkg.sv
@@ -1,0 +1,38 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package pattgen_env_pkg;
+  // dep packages
+  import uvm_pkg::*;
+  import top_pkg::*;
+  import dv_utils_pkg::*;
+  import csr_utils_pkg::*;
+  import tl_agent_pkg::*;
+  import dv_lib_pkg::*;
+  import cip_base_pkg::*;
+  import pattgen_reg_pkg::*;
+  import pattgen_ral_pkg::*;
+
+  // macro includes
+  `include "dv_macros.svh"
+
+  // parameters
+  typedef enum int {
+    PattDone0      = 0,
+    PattDone1      = 1,
+    NumI2cIntr     = 2
+  } pattgen_intr_e;
+
+  // csr and mem total size for IP, TODO confirm below value with spec
+  parameter uint PATTGEN_ADDR_MAP_SIZE = 128;
+
+  // package sources
+  `include "pattgen_env_cfg.sv"
+  `include "pattgen_env_cov.sv"
+  `include "pattgen_virtual_sequencer.sv"
+  `include "pattgen_scoreboard.sv"
+  `include "pattgen_env.sv"
+  `include "pattgen_vseq_list.sv"
+
+endpackage : pattgen_env_pkg

--- a/hw/ip/pattgen/dv/env/pattgen_scoreboard.sv
+++ b/hw/ip/pattgen/dv/env/pattgen_scoreboard.sv
@@ -1,0 +1,43 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class pattgen_scoreboard extends dv_base_scoreboard #(
+    .CFG_T(pattgen_env_cfg),
+    .COV_T(pattgen_env_cov)
+  );
+  `uvm_component_utils(pattgen_scoreboard)
+
+  // local variables
+
+  // TLM agent fifos
+
+  // local queues to hold incoming packets pending comparison
+
+  `uvm_component_new
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+  endfunction
+
+  function void connect_phase(uvm_phase phase);
+    super.connect_phase(phase);
+  endfunction
+
+  task run_phase(uvm_phase phase);
+    super.run_phase(phase);
+    fork
+    join_none
+  endtask
+
+  virtual function void reset(string kind = "HARD");
+    super.reset(kind);
+    // reset local fifos queues and variables
+  endfunction
+
+  function void check_phase(uvm_phase phase);
+    super.check_phase(phase);
+    // post test checks - ensure that all local fifos and queues are empty
+  endfunction
+
+endclass

--- a/hw/ip/pattgen/dv/env/pattgen_virtual_sequencer.sv
+++ b/hw/ip/pattgen/dv/env/pattgen_virtual_sequencer.sv
@@ -1,0 +1,14 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class pattgen_virtual_sequencer extends dv_base_virtual_sequencer #(
+    .CFG_T(pattgen_env_cfg),
+    .COV_T(pattgen_env_cov)
+  );
+  `uvm_component_utils(pattgen_virtual_sequencer)
+
+
+  `uvm_component_new
+
+endclass

--- a/hw/ip/pattgen/dv/env/seq_lib/pattgen_base_vseq.sv
+++ b/hw/ip/pattgen/dv/env/seq_lib/pattgen_base_vseq.sv
@@ -1,0 +1,32 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class pattgen_base_vseq extends dv_base_vseq #(
+    .CFG_T               (pattgen_env_cfg),
+    .COV_T               (pattgen_env_cov),
+    .VIRTUAL_SEQUENCER_T (pattgen_virtual_sequencer)
+  );
+  `uvm_object_utils(pattgen_base_vseq)
+
+  // various knobs to enable certain routines
+  bit do_pattgen_init = 1'b1;
+
+  `uvm_object_new
+
+  virtual task dut_init(string reset_kind = "HARD");
+    super.dut_init();
+    if (do_pattgen_init) pattgen_init();
+  endtask
+
+  virtual task dut_shutdown();
+    // check for pending pattgen operations and wait for them to complete
+    // TODO
+  endtask
+
+  // setup basic pattgen features
+  virtual task pattgen_init();
+    // TODO
+  endtask
+
+endclass : pattgen_base_vseq

--- a/hw/ip/pattgen/dv/env/seq_lib/pattgen_common_vseq.sv
+++ b/hw/ip/pattgen/dv/env/seq_lib/pattgen_common_vseq.sv
@@ -1,0 +1,16 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class pattgen_common_vseq extends pattgen_base_vseq;
+  `uvm_object_utils(pattgen_common_vseq)
+
+  constraint num_trans_c {
+    num_trans inside {[1:2]};
+  }
+  `uvm_object_new
+
+  virtual task body();
+  endtask : body
+
+endclass

--- a/hw/ip/pattgen/dv/env/seq_lib/pattgen_vseq_list.sv
+++ b/hw/ip/pattgen/dv/env/seq_lib/pattgen_vseq_list.sv
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`include "pattgen_base_vseq.sv"
+`include "pattgen_common_vseq.sv"

--- a/hw/ip/pattgen/dv/pattgen_sim.core
+++ b/hw/ip/pattgen/dv/pattgen_sim.core
@@ -1,0 +1,28 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:pattgen_sim:0.1"
+description: "PATTGEN DV sim target"
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:ip:pattgen:0.1
+    files:
+      - tb/pattgen_bind.sv
+    file_type: systemVerilogSource
+
+  files_dv:
+    depend:
+      - lowrisc:dv:pattgen_test
+    files:
+      - tb/tb.sv
+    file_type: systemVerilogSource
+
+targets:
+  sim:
+    toplevel: tb
+    filesets:
+      - files_rtl
+      - files_dv
+    default_tool: vcs

--- a/hw/ip/pattgen/dv/pattgen_sim_cfg.hjson
+++ b/hw/ip/pattgen/dv/pattgen_sim_cfg.hjson
@@ -1,0 +1,63 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  // Name of the sim cfg - typically same as the name of the DUT.
+  name: pattgen
+
+  // Top level dut name (sv module).
+  dut: pattgen
+
+  // Top level testbench name (sv module).
+  tb: tb
+
+  // Simulator used to sign off this block
+  tool: vcs
+
+  // Fusesoc core file used for building the file list.
+  fusesoc_core: lowrisc:dv:pattgen_sim:0.1
+
+  // Testplan hjson file.
+  testplan: "{proj_root}/hw/ip/pattgen/data/pattgen_testplan.hjson"
+
+  // RAL spec - used to generate the RAL model.
+  ral_spec: "{proj_root}/hw/ip/pattgen/data/pattgen_testplan.hjson"
+
+  // Import additional common sim cfg files.
+  // TODO: remove imported cfgs that do not apply.
+  import_cfgs: [// Project wide common sim cfg file
+                "{proj_root}/hw/dv/data/common_sim_cfg.hjson",
+                // Common CIP test lists
+                "{proj_root}/hw/dv/data/tests/csr_tests.hjson",
+                "{proj_root}/hw/dv/data/tests/intr_test.hjson",
+                //TODO: enable later in V2
+                //"{proj_root}/hw/dv/data/tests/stress_tests.hjson",
+                "{proj_root}/hw/dv/data/tests/tl_access_tests.hjson"]
+
+  // Add additional tops for simulation.
+  sim_tops: ["-top pattgen_bind"]
+
+  // Default iterations for all tests - each test entry can override this.
+  reseed: 50
+
+  // Default UVM test and seq class name.
+  uvm_test: pattgen_base_test
+  uvm_test_seq: pattgen_base_vseq
+
+  // List of test specifications.
+  tests: [
+    {
+      name: pattgen_sanity
+      uvm_test_seq: pattgen_sanity_vseq
+    }
+  ]
+
+  // List of regressions.
+  //regressions: [
+  //  {
+  //    name: sanity
+  //    tests: ["pattgen_sanity"]
+  //  }
+  //]
+}
+

--- a/hw/ip/pattgen/dv/tb/pattgen_bind.sv
+++ b/hw/ip/pattgen/dv/tb/pattgen_bind.sv
@@ -1,0 +1,7 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+module pattgen_bind;
+
+endmodule

--- a/hw/ip/pattgen/dv/tb/tb.sv
+++ b/hw/ip/pattgen/dv/tb/tb.sv
@@ -1,0 +1,65 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+module tb;
+  // dep packages
+  import uvm_pkg::*;
+  import dv_utils_pkg::*;
+  import pattgen_env_pkg::*;
+  import pattgen_test_pkg::*;
+
+  // macro includes
+  `include "uvm_macros.svh"
+  `include "dv_macros.svh"
+
+  wire clk, rst_n;
+  wire pda0_tx_o;
+  wire pcl0_tx_o;
+  wire pda1_tx_o;
+  wire pcl1_tx_o;
+
+  wire intr_patt_done0;
+  wire intr_patt_done1;
+  wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
+
+  // interfaces
+  clk_rst_if clk_rst_if(.clk(clk_i), .rst_n(rst_ni));
+  pins_if #(NUM_MAX_INTERRUPTS) intr_if(interrupts);
+  pins_if #(1) devmode_if(devmode);
+
+  tl_if tl_if(.clk(clk_i), .rst_n(rst_ni));
+
+  // dut
+  pattgen dut (
+    .clk_i                (clk       ),
+    .rst_ni               (rst_n     ),
+
+    .tl_i                 (tl_if.h2d ),
+    .tl_o                 (tl_if.d2h ),
+
+    .pda0_tx_o            (pda0_tx_o       ),
+    .pcl0_tx_o            (pcl0_tx_o       ),
+    .pda1_tx_o            (pda1_tx_o       ),
+    .pcl1_tx_o            (pcl1_tx_o       ),
+
+    .intr_patt_done0_o    (intr_patt_done0 ),
+    .intr_patt_done1_o    (intr_patt_done1 )
+  );
+
+  // interrupt
+  assign interrupts[PattDone0]   = intr_patt_done0;
+  assign interrupts[PattDone1]   = intr_patt_done1;
+
+  initial begin
+    // drive clk and rst_n from clk_if
+    clk_rst_if.set_active();
+    uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
+    uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
+    uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
+    uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
+    $timeformat(-12, 0, " ps", 12);
+    run_test();
+  end
+
+endmodule : tb

--- a/hw/ip/pattgen/dv/tests/pattgen_base_test.sv
+++ b/hw/ip/pattgen/dv/tests/pattgen_base_test.sv
@@ -1,0 +1,26 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class pattgen_base_test extends dv_base_test #(
+    .CFG_T(pattgen_env_cfg),
+    .ENV_T(pattgen_env)
+  );
+
+  `uvm_component_utils(pattgen_base_test)
+  `uvm_component_new
+
+  // the base class dv_base_test creates the following instances:
+  // pattgen_env_cfg: cfg
+  // pattgen_env:     env
+
+  virtual function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    cfg.has_ral = 1'b0;
+  endfunction
+
+  // the base class also looks up UVM_TEST_SEQ plusarg to create and run that seq in
+  // the run_phase; as such, nothing more needs to be done
+
+endclass : pattgen_base_test
+

--- a/hw/ip/pattgen/dv/tests/pattgen_test.core
+++ b/hw/ip/pattgen/dv/tests/pattgen_test.core
@@ -1,0 +1,19 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:pattgen_test:0.1"
+description: "PATTGEN DV UVM test"
+filesets:
+  files_dv:
+    depend:
+      - lowrisc:dv:pattgen_env
+    files:
+      - pattgen_test_pkg.sv
+      - pattgen_base_test.sv: {is_include_file: true}
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_dv

--- a/hw/ip/pattgen/dv/tests/pattgen_test_pkg.sv
+++ b/hw/ip/pattgen/dv/tests/pattgen_test_pkg.sv
@@ -1,0 +1,22 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package pattgen_test_pkg;
+  // dep packages
+  import uvm_pkg::*;
+  import dv_lib_pkg::*;
+  import pattgen_env_pkg::*;
+
+  // macro includes
+  `include "uvm_macros.svh"
+  `include "dv_macros.svh"
+
+  // local types
+
+  // functions
+
+  // package sources
+  `include "pattgen_base_test.sv"
+
+endpackage

--- a/hw/ip/pattgen/rtl/pattgen.sv
+++ b/hw/ip/pattgen/rtl/pattgen.sv
@@ -6,23 +6,23 @@
 
 `include "prim_assert.sv"
 
-module pattgen
-  import pattgen_reg_pkg::*;
-(
+module pattgen (
   input  clk_i,
   input  rst_ni,
 
   input  tlul_pkg::tl_h2d_t tl_i,
   output tlul_pkg::tl_d2h_t tl_o,
 
+  output logic  pda0_tx_o,
+  output logic  pcl0_tx_o,
   output logic  pda1_tx_o,
   output logic  pcl1_tx_o,
-  output logic  pda2_tx_o,
-  output logic  pcl2_tx_o,
 
+  output logic  intr_patt_done0_o,
   output logic  intr_patt_done1_o
-  output logic  intr_patt_done2_o
 );
+
+  import pattgen_reg_pkg::*;
 
   pattgen_reg2hw_t reg2hw;
   pattgen_hw2reg_t hw2reg;
@@ -45,22 +45,22 @@ module pattgen
     .reg2hw,
     .hw2reg,
 
+    .pda0_tx(pda0_tx_o),
+    .pcl0_tx(pcl0_tx_o),
     .pda1_tx(pda1_tx_o),
     .pcl1_tx(pcl1_tx_o),
-    .pda2_tx(pda2_tx_o),
-    .pcl2_tx(pcl2_tx_o),
 
-    .intr_patt2_done(intr_patt_done1_o),
-    .intr_patt2_done(intr_patt_done2_o)
+    .intr_patt_done0(intr_patt_done0_o),
+    .intr_patt_done1(intr_patt_done1_o)
   );
 
   // Assertion
   `ASSERT_KNOWN(TlODValidKnown, tl_o.d_valid)
   `ASSERT_KNOWN(TlOAValidKnown, tl_o.a_ready)
-  `ASSERT_KNOWN(Pda1TxKnownO, pda1_tx_o)
-  `ASSERT_KNOWN(Pcl1TxKnownO, pcl1_tx_o)
-  `ASSERT_KNOWN(Pda2TxKnownO, pda2_tx_o)
-  `ASSERT_KNOWN(Pcl2TxKnownO, pcl2_tx_o)
-  `ASSERT_KNOWN(IntrPattDone1KnownO, intr_patt_done1_o)
-  `ASSERT_KNOWN(IntrPattDone2KnownO, intr_patt_done2_o)
+  `ASSERT_KNOWN(Pda1TxKnownO, pda0_tx_o)
+  `ASSERT_KNOWN(Pcl1TxKnownO, pcl0_tx_o)
+  `ASSERT_KNOWN(Pda2TxKnownO, pda1_tx_o)
+  `ASSERT_KNOWN(Pcl2TxKnownO, pcl1_tx_o)
+  `ASSERT_KNOWN(IntrPattDone1KnownO, intr_patt_done0_o)
+  `ASSERT_KNOWN(IntrPattDone2KnownO, intr_patt_done1_o)
 endmodule : pattgen

--- a/hw/ip/pattgen/rtl/pattgen_core.sv
+++ b/hw/ip/pattgen/rtl/pattgen_core.sv
@@ -4,27 +4,27 @@
 //
 // patt core implementation
 
-module patt_core (
-  input                             clk_i,
-  input                             rst_ni,
-  input i2c_reg_pkg::i2c_reg2hw_t   reg2hw,
-  output i2c_reg_pkg::i2c_hw2reg_t  hw2reg,
+module pattgen_core (
+  input  clk_i,
+  input  rst_ni,
+  input  pattgen_reg_pkg::pattgen_reg2hw_t  reg2hw,
+  output pattgen_reg_pkg::pattgen_hw2reg_t  hw2reg,
 
-  output logic                      pda1_tx,
-  output logic                      pcl1_tx,
-  output logic                      pda2_tx,
-  output logic                      pcl2_tx,
+  output logic  pda0_tx,
+  output logic  pcl0_tx,
+  output logic  pda1_tx,
+  output logic  pcl1_tx,
 
-  output logic                      intr_patt_done1,
-  output logic                      intr_patt_done2
+  output logic  intr_patt_done0,
+  output logic  intr_patt_done1
 );
 
   // TODO
+  assign  pda0_tx = 1'b0;
+  assign  pcl0_tx = 1'b0;
   assign  pda1_tx = 1'b0;
   assign  pcl1_tx = 1'b0;
-  assign  pda2_tx = 1'b0;
-  assign  pcl2_tx = 1'b0;
+  assign  intr_patt_done0 = 1'b0;
   assign  intr_patt_done1 = 1'b0;
-  assign  intr_patt_done2 = 1'b0;
 
-endmodule
+endmodule : pattgen_core

--- a/hw/ip/pattgen/rtl/pattgen_reg_pkg.sv
+++ b/hw/ip/pattgen/rtl/pattgen_reg_pkg.sv
@@ -6,36 +6,39 @@
 
 package pattgen_reg_pkg;
 
+  // Param list
+  parameter int NumRegsPrediv = 2;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////
   typedef struct packed {
     struct packed {
       logic        q;
-    } patt_done1;
+    } patt_done0;
     struct packed {
       logic        q;
-    } patt_done2;
+    } patt_done1;
   } pattgen_reg2hw_intr_state_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        q;
-    } patt_done1;
+    } patt_done0;
     struct packed {
       logic        q;
-    } patt_done2;
+    } patt_done1;
   } pattgen_reg2hw_intr_enable_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        q;
       logic        qe;
-    } patt_done1;
+    } patt_done0;
     struct packed {
       logic        q;
       logic        qe;
-    } patt_done2;
+    } patt_done1;
   } pattgen_reg2hw_intr_test_reg_t;
 
   typedef struct packed {
@@ -56,44 +59,39 @@ package pattgen_reg_pkg;
   typedef struct packed {
     logic [31:0] q;
     logic        qe;
-  } pattgen_reg2hw_prediv1_reg_t;
+  } pattgen_reg2hw_prediv_mreg_t;
 
   typedef struct packed {
-    logic [31:0] q;
-    logic        qe;
-  } pattgen_reg2hw_prediv2_reg_t;
-
-  typedef struct packed {
+    struct packed {
+      logic [5:0]  q;
+      logic        qe;
+    } len0;
     struct packed {
       logic [5:0]  q;
       logic        qe;
     } len1;
-    struct packed {
-      logic [5:0]  q;
-      logic        qe;
-    } len2;
   } pattgen_reg2hw_patt_len_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [9:0] q;
       logic        qe;
-    } loop1;
+    } loop0;
     struct packed {
       logic [9:0] q;
       logic        qe;
-    } loop2;
+    } loop1;
   } pattgen_reg2hw_patt_loop_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        q;
       logic        qe;
-    } mask1;
+    } mask0;
     struct packed {
       logic        q;
       logic        qe;
-    } mask2;
+    } mask1;
   } pattgen_reg2hw_intr_mask_reg_t;
 
 
@@ -101,11 +99,11 @@ package pattgen_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } patt_done1;
+    } patt_done0;
     struct packed {
       logic        d;
       logic        de;
-    } patt_done2;
+    } patt_done1;
   } pattgen_hw2reg_intr_state_reg_t;
 
 
@@ -118,8 +116,7 @@ package pattgen_reg_pkg;
     pattgen_reg2hw_intr_test_reg_t intr_test; // [114:111]
     pattgen_reg2hw_ctrl_reg_t ctrl; // [110:110]
     pattgen_reg2hw_start_reg_t start; // [109:106]
-    pattgen_reg2hw_prediv1_reg_t prediv1; // [105:73]
-    pattgen_reg2hw_prediv2_reg_t prediv2; // [72:40]
+    pattgen_reg2hw_prediv_mreg_t [1:0] prediv; // [105:40]
     pattgen_reg2hw_patt_len_reg_t patt_len; // [39:26]
     pattgen_reg2hw_patt_loop_reg_t patt_loop; // [25:4]
     pattgen_reg2hw_intr_mask_reg_t intr_mask; // [3:0]
@@ -138,8 +135,8 @@ package pattgen_reg_pkg;
   parameter logic [5:0] PATTGEN_INTR_TEST_OFFSET = 6'h 8;
   parameter logic [5:0] PATTGEN_CTRL_OFFSET = 6'h c;
   parameter logic [5:0] PATTGEN_START_OFFSET = 6'h 10;
-  parameter logic [5:0] PATTGEN_PREDIV1_OFFSET = 6'h 14;
-  parameter logic [5:0] PATTGEN_PREDIV2_OFFSET = 6'h 18;
+  parameter logic [5:0] PATTGEN_PREDIV0_OFFSET = 6'h 14;
+  parameter logic [5:0] PATTGEN_PREDIV1_OFFSET = 6'h 18;
   parameter logic [5:0] PATTGEN_PATT_LEN_OFFSET = 6'h 1c;
   parameter logic [5:0] PATTGEN_PATT_LOOP_OFFSET = 6'h 20;
   parameter logic [5:0] PATTGEN_INTR_MASK_OFFSET = 6'h 24;
@@ -152,8 +149,8 @@ package pattgen_reg_pkg;
     PATTGEN_INTR_TEST,
     PATTGEN_CTRL,
     PATTGEN_START,
+    PATTGEN_PREDIV0,
     PATTGEN_PREDIV1,
-    PATTGEN_PREDIV2,
     PATTGEN_PATT_LEN,
     PATTGEN_PATT_LOOP,
     PATTGEN_INTR_MASK
@@ -166,8 +163,8 @@ package pattgen_reg_pkg;
     4'b 0001, // index[2] PATTGEN_INTR_TEST
     4'b 0001, // index[3] PATTGEN_CTRL
     4'b 0001, // index[4] PATTGEN_START
-    4'b 1111, // index[5] PATTGEN_PREDIV1
-    4'b 1111, // index[6] PATTGEN_PREDIV2
+    4'b 1111, // index[5] PATTGEN_PREDIV0
+    4'b 1111, // index[6] PATTGEN_PREDIV1
     4'b 0011, // index[7] PATTGEN_PATT_LEN
     4'b 0111, // index[8] PATTGEN_PATT_LOOP
     4'b 0001  // index[9] PATTGEN_INTR_MASK

--- a/hw/ip/pattgen/rtl/pattgen_reg_top.sv
+++ b/hw/ip/pattgen/rtl/pattgen_reg_top.sv
@@ -71,22 +71,22 @@ module pattgen_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
+  logic intr_state_patt_done0_qs;
+  logic intr_state_patt_done0_wd;
+  logic intr_state_patt_done0_we;
   logic intr_state_patt_done1_qs;
   logic intr_state_patt_done1_wd;
   logic intr_state_patt_done1_we;
-  logic intr_state_patt_done2_qs;
-  logic intr_state_patt_done2_wd;
-  logic intr_state_patt_done2_we;
+  logic intr_enable_patt_done0_qs;
+  logic intr_enable_patt_done0_wd;
+  logic intr_enable_patt_done0_we;
   logic intr_enable_patt_done1_qs;
   logic intr_enable_patt_done1_wd;
   logic intr_enable_patt_done1_we;
-  logic intr_enable_patt_done2_qs;
-  logic intr_enable_patt_done2_wd;
-  logic intr_enable_patt_done2_we;
+  logic intr_test_patt_done0_wd;
+  logic intr_test_patt_done0_we;
   logic intr_test_patt_done1_wd;
   logic intr_test_patt_done1_we;
-  logic intr_test_patt_done2_wd;
-  logic intr_test_patt_done2_we;
   logic ctrl_qs;
   logic ctrl_wd;
   logic ctrl_we;
@@ -94,35 +94,61 @@ module pattgen_reg_top (
   logic start_start0_we;
   logic start_start1_wd;
   logic start_start1_we;
+  logic [31:0] prediv0_qs;
+  logic [31:0] prediv0_wd;
+  logic prediv0_we;
   logic [31:0] prediv1_qs;
   logic [31:0] prediv1_wd;
   logic prediv1_we;
-  logic [31:0] prediv2_qs;
-  logic [31:0] prediv2_wd;
-  logic prediv2_we;
+  logic [5:0] patt_len_len0_qs;
+  logic [5:0] patt_len_len0_wd;
+  logic patt_len_len0_we;
   logic [5:0] patt_len_len1_qs;
   logic [5:0] patt_len_len1_wd;
   logic patt_len_len1_we;
-  logic [5:0] patt_len_len2_qs;
-  logic [5:0] patt_len_len2_wd;
-  logic patt_len_len2_we;
+  logic [9:0] patt_loop_loop0_qs;
+  logic [9:0] patt_loop_loop0_wd;
+  logic patt_loop_loop0_we;
   logic [9:0] patt_loop_loop1_qs;
   logic [9:0] patt_loop_loop1_wd;
   logic patt_loop_loop1_we;
-  logic [9:0] patt_loop_loop2_qs;
-  logic [9:0] patt_loop_loop2_wd;
-  logic patt_loop_loop2_we;
+  logic intr_mask_mask0_qs;
+  logic intr_mask_mask0_wd;
+  logic intr_mask_mask0_we;
   logic intr_mask_mask1_qs;
   logic intr_mask_mask1_wd;
   logic intr_mask_mask1_we;
-  logic intr_mask_mask2_qs;
-  logic intr_mask_mask2_wd;
-  logic intr_mask_mask2_we;
 
   // Register instances
   // R[intr_state]: V(False)
 
-  //   F[patt_done1]: 0:0
+  //   F[patt_done0]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("W1C"),
+    .RESVAL  (1'h0)
+  ) u_intr_state_patt_done0 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (intr_state_patt_done0_we),
+    .wd     (intr_state_patt_done0_wd),
+
+    // from internal hardware
+    .de     (hw2reg.intr_state.patt_done0.de),
+    .d      (hw2reg.intr_state.patt_done0.d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.intr_state.patt_done0.q ),
+
+    // to register interface (read)
+    .qs     (intr_state_patt_done0_qs)
+  );
+
+
+  //   F[patt_done1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SWACCESS("W1C"),
@@ -148,35 +174,35 @@ module pattgen_reg_top (
   );
 
 
-  //   F[patt_done2]: 1:1
+  // R[intr_enable]: V(False)
+
+  //   F[patt_done0]: 0:0
   prim_subreg #(
     .DW      (1),
-    .SWACCESS("W1C"),
+    .SWACCESS("RW"),
     .RESVAL  (1'h0)
-  ) u_intr_state_patt_done2 (
+  ) u_intr_enable_patt_done0 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (intr_state_patt_done2_we),
-    .wd     (intr_state_patt_done2_wd),
+    .we     (intr_enable_patt_done0_we),
+    .wd     (intr_enable_patt_done0_wd),
 
     // from internal hardware
-    .de     (hw2reg.intr_state.patt_done2.de),
-    .d      (hw2reg.intr_state.patt_done2.d ),
+    .de     (1'b0),
+    .d      ('0  ),
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_state.patt_done2.q ),
+    .q      (reg2hw.intr_enable.patt_done0.q ),
 
     // to register interface (read)
-    .qs     (intr_state_patt_done2_qs)
+    .qs     (intr_enable_patt_done0_qs)
   );
 
 
-  // R[intr_enable]: V(False)
-
-  //   F[patt_done1]: 0:0
+  //   F[patt_done1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
@@ -202,35 +228,24 @@ module pattgen_reg_top (
   );
 
 
-  //   F[patt_done2]: 1:1
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_intr_enable_patt_done2 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
+  // R[intr_test]: V(True)
 
-    // from register interface
-    .we     (intr_enable_patt_done2_we),
-    .wd     (intr_enable_patt_done2_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.intr_enable.patt_done2.q ),
-
-    // to register interface (read)
-    .qs     (intr_enable_patt_done2_qs)
+  //   F[patt_done0]: 0:0
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_intr_test_patt_done0 (
+    .re     (1'b0),
+    .we     (intr_test_patt_done0_we),
+    .wd     (intr_test_patt_done0_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (reg2hw.intr_test.patt_done0.qe),
+    .q      (reg2hw.intr_test.patt_done0.q ),
+    .qs     ()
   );
 
 
-  // R[intr_test]: V(True)
-
-  //   F[patt_done1]: 0:0
+  //   F[patt_done1]: 1:1
   prim_subreg_ext #(
     .DW    (1)
   ) u_intr_test_patt_done1 (
@@ -241,21 +256,6 @@ module pattgen_reg_top (
     .qre    (),
     .qe     (reg2hw.intr_test.patt_done1.qe),
     .q      (reg2hw.intr_test.patt_done1.q ),
-    .qs     ()
-  );
-
-
-  //   F[patt_done2]: 1:1
-  prim_subreg_ext #(
-    .DW    (1)
-  ) u_intr_test_patt_done2 (
-    .re     (1'b0),
-    .we     (intr_test_patt_done2_we),
-    .wd     (intr_test_patt_done2_wd),
-    .d      ('0),
-    .qre    (),
-    .qe     (reg2hw.intr_test.patt_done2.qe),
-    .q      (reg2hw.intr_test.patt_done2.q ),
     .qs     ()
   );
 
@@ -339,6 +339,35 @@ module pattgen_reg_top (
   );
 
 
+
+  // Subregister 0 of Multireg prediv
+  // R[prediv0]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
+  ) u_prediv0 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (prediv0_we),
+    .wd     (prediv0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (reg2hw.prediv[0].qe),
+    .q      (reg2hw.prediv[0].q ),
+
+    // to register interface (read)
+    .qs     (prediv0_qs)
+  );
+
+  // Subregister 1 of Multireg prediv
   // R[prediv1]: V(False)
 
   prim_subreg #(
@@ -358,44 +387,43 @@ module pattgen_reg_top (
     .d      ('0  ),
 
     // to internal hardware
-    .qe     (reg2hw.prediv1.qe),
-    .q      (reg2hw.prediv1.q ),
+    .qe     (reg2hw.prediv[1].qe),
+    .q      (reg2hw.prediv[1].q ),
 
     // to register interface (read)
     .qs     (prediv1_qs)
   );
 
 
-  // R[prediv2]: V(False)
+  // R[patt_len]: V(False)
 
+  //   F[len0]: 5:0
   prim_subreg #(
-    .DW      (32),
+    .DW      (6),
     .SWACCESS("RW"),
-    .RESVAL  (32'h0)
-  ) u_prediv2 (
+    .RESVAL  (6'h0)
+  ) u_patt_len_len0 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (prediv2_we),
-    .wd     (prediv2_wd),
+    .we     (patt_len_len0_we),
+    .wd     (patt_len_len0_wd),
 
     // from internal hardware
     .de     (1'b0),
     .d      ('0  ),
 
     // to internal hardware
-    .qe     (reg2hw.prediv2.qe),
-    .q      (reg2hw.prediv2.q ),
+    .qe     (reg2hw.patt_len.len0.qe),
+    .q      (reg2hw.patt_len.len0.q ),
 
     // to register interface (read)
-    .qs     (prediv2_qs)
+    .qs     (patt_len_len0_qs)
   );
 
 
-  // R[patt_len]: V(False)
-
-  //   F[len1]: 5:0
+  //   F[len1]: 12:7
   prim_subreg #(
     .DW      (6),
     .SWACCESS("RW"),
@@ -421,35 +449,35 @@ module pattgen_reg_top (
   );
 
 
-  //   F[len2]: 12:7
+  // R[patt_loop]: V(False)
+
+  //   F[loop0]: 9:0
   prim_subreg #(
-    .DW      (6),
+    .DW      (10),
     .SWACCESS("RW"),
-    .RESVAL  (6'h0)
-  ) u_patt_len_len2 (
+    .RESVAL  (10'h0)
+  ) u_patt_loop_loop0 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (patt_len_len2_we),
-    .wd     (patt_len_len2_wd),
+    .we     (patt_loop_loop0_we),
+    .wd     (patt_loop_loop0_wd),
 
     // from internal hardware
     .de     (1'b0),
     .d      ('0  ),
 
     // to internal hardware
-    .qe     (reg2hw.patt_len.len2.qe),
-    .q      (reg2hw.patt_len.len2.q ),
+    .qe     (reg2hw.patt_loop.loop0.qe),
+    .q      (reg2hw.patt_loop.loop0.q ),
 
     // to register interface (read)
-    .qs     (patt_len_len2_qs)
+    .qs     (patt_loop_loop0_qs)
   );
 
 
-  // R[patt_loop]: V(False)
-
-  //   F[loop1]: 9:0
+  //   F[loop1]: 19:10
   prim_subreg #(
     .DW      (10),
     .SWACCESS("RW"),
@@ -475,35 +503,35 @@ module pattgen_reg_top (
   );
 
 
-  //   F[loop2]: 19:10
+  // R[intr_mask]: V(False)
+
+  //   F[mask0]: 0:0
   prim_subreg #(
-    .DW      (10),
+    .DW      (1),
     .SWACCESS("RW"),
-    .RESVAL  (10'h0)
-  ) u_patt_loop_loop2 (
+    .RESVAL  (1'h0)
+  ) u_intr_mask_mask0 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (patt_loop_loop2_we),
-    .wd     (patt_loop_loop2_wd),
+    .we     (intr_mask_mask0_we),
+    .wd     (intr_mask_mask0_wd),
 
     // from internal hardware
     .de     (1'b0),
     .d      ('0  ),
 
     // to internal hardware
-    .qe     (reg2hw.patt_loop.loop2.qe),
-    .q      (reg2hw.patt_loop.loop2.q ),
+    .qe     (reg2hw.intr_mask.mask0.qe),
+    .q      (reg2hw.intr_mask.mask0.q ),
 
     // to register interface (read)
-    .qs     (patt_loop_loop2_qs)
+    .qs     (intr_mask_mask0_qs)
   );
 
 
-  // R[intr_mask]: V(False)
-
-  //   F[mask1]: 0:0
+  //   F[mask1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
@@ -529,32 +557,6 @@ module pattgen_reg_top (
   );
 
 
-  //   F[mask2]: 1:1
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_intr_mask_mask2 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (intr_mask_mask2_we),
-    .wd     (intr_mask_mask2_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (reg2hw.intr_mask.mask2.qe),
-    .q      (reg2hw.intr_mask.mask2.q ),
-
-    // to register interface (read)
-    .qs     (intr_mask_mask2_qs)
-  );
-
-
 
 
   logic [9:0] addr_hit;
@@ -565,8 +567,8 @@ module pattgen_reg_top (
     addr_hit[2] = (reg_addr == PATTGEN_INTR_TEST_OFFSET);
     addr_hit[3] = (reg_addr == PATTGEN_CTRL_OFFSET);
     addr_hit[4] = (reg_addr == PATTGEN_START_OFFSET);
-    addr_hit[5] = (reg_addr == PATTGEN_PREDIV1_OFFSET);
-    addr_hit[6] = (reg_addr == PATTGEN_PREDIV2_OFFSET);
+    addr_hit[5] = (reg_addr == PATTGEN_PREDIV0_OFFSET);
+    addr_hit[6] = (reg_addr == PATTGEN_PREDIV1_OFFSET);
     addr_hit[7] = (reg_addr == PATTGEN_PATT_LEN_OFFSET);
     addr_hit[8] = (reg_addr == PATTGEN_PATT_LOOP_OFFSET);
     addr_hit[9] = (reg_addr == PATTGEN_INTR_MASK_OFFSET);
@@ -589,23 +591,23 @@ module pattgen_reg_top (
     if (addr_hit[9] && reg_we && (PATTGEN_PERMIT[9] != (PATTGEN_PERMIT[9] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign intr_state_patt_done1_we = addr_hit[0] & reg_we & ~wr_err;
-  assign intr_state_patt_done1_wd = reg_wdata[0];
+  assign intr_state_patt_done0_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_patt_done0_wd = reg_wdata[0];
 
-  assign intr_state_patt_done2_we = addr_hit[0] & reg_we & ~wr_err;
-  assign intr_state_patt_done2_wd = reg_wdata[1];
+  assign intr_state_patt_done1_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_patt_done1_wd = reg_wdata[1];
+
+  assign intr_enable_patt_done0_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_patt_done0_wd = reg_wdata[0];
 
   assign intr_enable_patt_done1_we = addr_hit[1] & reg_we & ~wr_err;
-  assign intr_enable_patt_done1_wd = reg_wdata[0];
+  assign intr_enable_patt_done1_wd = reg_wdata[1];
 
-  assign intr_enable_patt_done2_we = addr_hit[1] & reg_we & ~wr_err;
-  assign intr_enable_patt_done2_wd = reg_wdata[1];
+  assign intr_test_patt_done0_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_patt_done0_wd = reg_wdata[0];
 
   assign intr_test_patt_done1_we = addr_hit[2] & reg_we & ~wr_err;
-  assign intr_test_patt_done1_wd = reg_wdata[0];
-
-  assign intr_test_patt_done2_we = addr_hit[2] & reg_we & ~wr_err;
-  assign intr_test_patt_done2_wd = reg_wdata[1];
+  assign intr_test_patt_done1_wd = reg_wdata[1];
 
   assign ctrl_we = addr_hit[3] & reg_we & ~wr_err;
   assign ctrl_wd = reg_wdata[0];
@@ -616,42 +618,42 @@ module pattgen_reg_top (
   assign start_start1_we = addr_hit[4] & reg_we & ~wr_err;
   assign start_start1_wd = reg_wdata[1];
 
-  assign prediv1_we = addr_hit[5] & reg_we & ~wr_err;
+  assign prediv0_we = addr_hit[5] & reg_we & ~wr_err;
+  assign prediv0_wd = reg_wdata[31:0];
+
+  assign prediv1_we = addr_hit[6] & reg_we & ~wr_err;
   assign prediv1_wd = reg_wdata[31:0];
 
-  assign prediv2_we = addr_hit[6] & reg_we & ~wr_err;
-  assign prediv2_wd = reg_wdata[31:0];
+  assign patt_len_len0_we = addr_hit[7] & reg_we & ~wr_err;
+  assign patt_len_len0_wd = reg_wdata[5:0];
 
   assign patt_len_len1_we = addr_hit[7] & reg_we & ~wr_err;
-  assign patt_len_len1_wd = reg_wdata[5:0];
+  assign patt_len_len1_wd = reg_wdata[12:7];
 
-  assign patt_len_len2_we = addr_hit[7] & reg_we & ~wr_err;
-  assign patt_len_len2_wd = reg_wdata[12:7];
+  assign patt_loop_loop0_we = addr_hit[8] & reg_we & ~wr_err;
+  assign patt_loop_loop0_wd = reg_wdata[9:0];
 
   assign patt_loop_loop1_we = addr_hit[8] & reg_we & ~wr_err;
-  assign patt_loop_loop1_wd = reg_wdata[9:0];
+  assign patt_loop_loop1_wd = reg_wdata[19:10];
 
-  assign patt_loop_loop2_we = addr_hit[8] & reg_we & ~wr_err;
-  assign patt_loop_loop2_wd = reg_wdata[19:10];
+  assign intr_mask_mask0_we = addr_hit[9] & reg_we & ~wr_err;
+  assign intr_mask_mask0_wd = reg_wdata[0];
 
   assign intr_mask_mask1_we = addr_hit[9] & reg_we & ~wr_err;
-  assign intr_mask_mask1_wd = reg_wdata[0];
-
-  assign intr_mask_mask2_we = addr_hit[9] & reg_we & ~wr_err;
-  assign intr_mask_mask2_wd = reg_wdata[1];
+  assign intr_mask_mask1_wd = reg_wdata[1];
 
   // Read data return
   always_comb begin
     reg_rdata_next = '0;
     unique case (1'b1)
       addr_hit[0]: begin
-        reg_rdata_next[0] = intr_state_patt_done1_qs;
-        reg_rdata_next[1] = intr_state_patt_done2_qs;
+        reg_rdata_next[0] = intr_state_patt_done0_qs;
+        reg_rdata_next[1] = intr_state_patt_done1_qs;
       end
 
       addr_hit[1]: begin
-        reg_rdata_next[0] = intr_enable_patt_done1_qs;
-        reg_rdata_next[1] = intr_enable_patt_done2_qs;
+        reg_rdata_next[0] = intr_enable_patt_done0_qs;
+        reg_rdata_next[1] = intr_enable_patt_done1_qs;
       end
 
       addr_hit[2]: begin
@@ -669,26 +671,26 @@ module pattgen_reg_top (
       end
 
       addr_hit[5]: begin
-        reg_rdata_next[31:0] = prediv1_qs;
+        reg_rdata_next[31:0] = prediv0_qs;
       end
 
       addr_hit[6]: begin
-        reg_rdata_next[31:0] = prediv2_qs;
+        reg_rdata_next[31:0] = prediv1_qs;
       end
 
       addr_hit[7]: begin
-        reg_rdata_next[5:0] = patt_len_len1_qs;
-        reg_rdata_next[12:7] = patt_len_len2_qs;
+        reg_rdata_next[5:0] = patt_len_len0_qs;
+        reg_rdata_next[12:7] = patt_len_len1_qs;
       end
 
       addr_hit[8]: begin
-        reg_rdata_next[9:0] = patt_loop_loop1_qs;
-        reg_rdata_next[19:10] = patt_loop_loop2_qs;
+        reg_rdata_next[9:0] = patt_loop_loop0_qs;
+        reg_rdata_next[19:10] = patt_loop_loop1_qs;
       end
 
       addr_hit[9]: begin
-        reg_rdata_next[0] = intr_mask_mask1_qs;
-        reg_rdata_next[1] = intr_mask_mask2_qs;
+        reg_rdata_next[0] = intr_mask_mask0_qs;
+        reg_rdata_next[1] = intr_mask_mask1_qs;
       end
 
       default: begin


### PR DESCRIPTION
Various updates and fixes for pattgen (d0)
  - Add dv (v0) is for pattgen (pass all csr_* tests)
  - Use multireg in .hjson
  - Fix syntax errors for rtl
  - Rename chance index (1+2 to 0+1)

Work-in-progress

Signed-off-by: Tung Hoang <tung.hoang.290780@gmail.com>