### PR TITLE
[doc] Use the primary text color

### DIFF
--- a/site/docs/assets/scss/_markdown.scss
+++ b/site/docs/assets/scss/_markdown.scss
@@ -75,8 +75,6 @@
     border-collapse: collapse;
 
     td, th {
-      color: $medium-purple;
-      color: var(--text-second);
       vertical-align: top;
       border: 1px solid var(--text-second);
       padding: 0.5em;
@@ -84,8 +82,6 @@
 
     th {
       font-weight: bold;
-      color: $dark-purple;
-      color: var(--text-color);
     }
   }
 
@@ -98,8 +94,6 @@
   }
 
   ul, ol {
-    color: $medium-purple;
-    color: var(--text-second);
     padding-left: 1em;
 
     > li + li {

--- a/site/docs/assets/scss/_sections.scss
+++ b/site/docs/assets/scss/_sections.scss
@@ -5,12 +5,8 @@
   color: var(--text-color);
 
   .bodytext {
-    color: $medium-purple;
-    color: var(--text-second);
     transition: color 0.5s ease;
   }
 
   transition: color 0.2s ease;
 }
-
-


### PR DESCRIPTION
The documentation main text used a lighter variant of the text color,
which has low contrast compared to the background. Using the primary
color gives us much better contrast, which is important for readability.