### PR TITLE
[doc] Lists: Do not decrease font size

### DIFF
--- a/site/docs/assets/scss/_markdown.scss
+++ b/site/docs/assets/scss/_markdown.scss
@@ -108,7 +108,6 @@
 
     ul,
     ol {
-      font-size: 0.875em;
       margin-top: 0.5em;
     }
   }


### PR DESCRIPTION
There's no typographical reason to decrease the font size as we go down
the hierarchy of ordered/unordered lists. Content on the second
hierarchy level is equally important and should be equally readable as
the normal text. The docs are no PowerPoint presentation.