### PR TITLE
[sw] Add Clang Device Software Build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -164,8 +164,8 @@ jobs:
   - bash: |
       set -x
       sudo util/get-toolchain.py \
-        --target-dir="${TOOLCHAIN_PATH}" \
-        --release-version="${TOOLCHAIN_VERSION}" \
+        --target-dir="$TOOLCHAIN_PATH" \
+        --release-version="$TOOLCHAIN_VERSION" \
         --update
     displayName: Install toolchain
   - bash: |
@@ -173,12 +173,11 @@ jobs:
       ./meson_init.sh -A
       ninja -C "$OBJ_DIR" all
     displayName: Build embedded targets
-  - template: ci/upload-artifacts-template.yml
   - bash: |
       . util/build_consts.sh
       ninja -C "$OBJ_DIR" test
-    displayName: 'Run unit tests'
-  - template: 'ci/upload-artifacts-template.yml'
+    displayName: Run unit tests
+  - template: ci/upload-artifacts-template.yml
     parameters:
       artifact: sw_build
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -181,6 +181,41 @@ jobs:
     parameters:
       artifact: sw_build
 
+# This is a second software build currently building with Clang, to test out the
+# compiler migration. It is a copy of `sw_build` with `continueOnError: true`
+# specified for the main tasks, and `meson_init.sh` configured with the clang
+# toolchain not the default toolchain.
+- job: sw_build_clang
+  displayName: Build Software (with Clang)
+  dependsOn: lint
+  condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'))
+  pool:
+    vmImage: ubuntu-16.04
+  steps:
+  - template: ci/install-package-dependencies.yml
+  - bash: |
+      set -x
+      sudo util/get-toolchain.py \
+        --target-dir="$TOOLCHAIN_PATH" \
+        --release-version="$TOOLCHAIN_VERSION" \
+        --update
+    displayName: Install toolchain
+  - bash: |
+      . util/build_consts.sh
+      ./meson_init.sh -A \
+        -t "$TOOLCHAIN_PATH/meson-riscv32-unknown-elf-clang.txt"
+      ninja -C "$OBJ_DIR" all
+    displayName: Build embedded targets
+    continueOnError: true
+  - bash: |
+      . util/build_consts.sh
+      ninja -C "$OBJ_DIR" test
+    displayName: Run unit tests
+    continueOnError: true
+  - template: ci/upload-artifacts-template.yml
+    parameters:
+      artifact: sw_build_clang
+
 - job: top_earlgrey_verilator
   displayName: Build Verilator simulation of the Earl Grey toplevel design
   dependsOn: lint


### PR DESCRIPTION
This PR adds a second device software build which uses clang (in addition to the GCC build). This build should be able to fail without causing an overall pipeline failure.

This is the next step of the toolchain migration.

(I've added some code to `mmio.h` which ensures that the build will fail on Clang, this should be reverted before this commit is merged).