### PR TITLE
[dv] Enable top-level scb

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -93,6 +93,7 @@
     {
       name: xbar_mode
       run_opts: ["+xbar_mode=1"]
+      reseed: 50
     }
   ]
 

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -58,8 +58,6 @@ class chip_env_cfg extends cip_base_env_cfg #(.RAL_T(chip_reg_block));
     chip_mem_e mems[] = {Rom, Ram, FlashBank0, FlashBank1};
 
     has_devmode = 0;
-    // TODO: may need to add scb later
-    en_scb = 0;
 
     super.initialize(csr_base_addr);
     // create uart agent config obj
@@ -87,6 +85,10 @@ class chip_env_cfg extends cip_base_env_cfg #(.RAL_T(chip_reg_block));
   protected virtual function void apply_ral_fixes();
     // Out of reset, the link is in disconnected state.
     ral.usbdev.intr_state.disconnected.set_reset(1'b1);
+
+    // ram_main mem and hmac mem support partial write
+    ral.ram_main.set_mem_partial_write_support(1);
+    ral.hmac.msg_fifo.set_mem_partial_write_support(1);
   endfunction
 
 endclass

--- a/hw/top_earlgrey/dv/env/chip_scoreboard.sv
+++ b/hw/top_earlgrey/dv/env/chip_scoreboard.sv
@@ -49,6 +49,11 @@ class chip_scoreboard extends cip_base_scoreboard #(
     end
   endtask
 
+  // TODO, may add some checking later
+  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel = DataChannel);
+    return;
+  endtask
+
   virtual function void reset(string kind = "HARD");
     super.reset(kind);
     // reset local fifos queues and variables


### PR DESCRIPTION
1. enable scb
2. enable byte access for main_ram and hmac mem in top-level
3. increase xbar test to 50 seeds
Signed-off-by: Weicai Yang <weicai@google.com>