### PR TITLE
Fix multi-tiered xbar issue

### DIFF
--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -136,13 +136,8 @@ module top_${top["name"]} #(
   xbar_devices = [x for x in xbar["nodes"] if x["type"] == "device" and x["xbar"]]
 %>\
   % for node in xbar_devices:
-  tl_h2d_t tl_${xbar["name"]}_h_h2d;
-  tl_d2h_t tl_${xbar["name"]}_h_d2h;
-  tl_h2d_t tl_${node["name"]}_d_h2d;
-  tl_d2h_t tl_${node["name"]}_d_d2h;
-
-  assign tl_${xbar["name"]}_h_h2d = tl_${node["name"]}_d_h2d;
-  assign tl_${node["name"]}_d_d2h = tl_${xbar["name"]}_h_d2h;
+  tl_h2d_t tl_${xbar["name"]}_${node["name"]}_h2d;
+  tl_d2h_t tl_${xbar["name"]}_${node["name"]}_d2h;
   % endfor
 % endfor
 
@@ -669,12 +664,22 @@ slice = str(alert_idx+w-1) + ":" + str(alert_idx)
     .${k} (${top["reset_paths"][v]}),
   % endfor
   % for node in xbar["nodes"]:
-    % if node["type"] == "device":
+    % if node["xbar"]:
+      % if node["type"] == "device":
+    .tl_${(node["name"]+"_o").ljust(name_len+2)} (tl_${xbar["name"]}_${node["name"]}_h2d),
+    .tl_${(node["name"]+"_i").ljust(name_len+2)} (tl_${xbar["name"]}_${node["name"]}_d2h),
+      % elif node["type"] == "host":
+    .tl_${(node["name"]+"_i").ljust(name_len+2)} (tl_${node["name"]}_${xbar["name"]}_h2d),
+    .tl_${(node["name"]+"_o").ljust(name_len+2)} (tl_${node["name"]}_${xbar["name"]}_d2h),
+      % endif
+    % else:
+      % if node["type"] == "device":
     .tl_${(node["name"]+"_o").ljust(name_len+2)} (tl_${node["name"]}_d_h2d),
     .tl_${(node["name"]+"_i").ljust(name_len+2)} (tl_${node["name"]}_d_d2h),
-    % elif node["type"] == "host":
+      % elif node["type"] == "host":
     .tl_${(node["name"]+"_i").ljust(name_len+2)} (tl_${node["name"]}_h_h2d),
     .tl_${(node["name"]+"_o").ljust(name_len+2)} (tl_${node["name"]}_h_d2h),
+      % endif
     % endif
   % endfor
 

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -113,13 +113,8 @@ module top_earlgrey #(
   tl_h2d_t tl_eflash_d_h2d;
   tl_d2h_t tl_eflash_d_d2h;
 
-  tl_h2d_t tl_main_h_h2d;
-  tl_d2h_t tl_main_h_d2h;
-  tl_h2d_t tl_peri_d_h2d;
-  tl_d2h_t tl_peri_d_d2h;
-
-  assign tl_main_h_h2d = tl_peri_d_h2d;
-  assign tl_peri_d_d2h = tl_main_h_d2h;
+  tl_h2d_t tl_main_peri_h2d;
+  tl_d2h_t tl_main_peri_d2h;
 
   // Signals
   logic [31:0] mio_p2d;
@@ -906,8 +901,8 @@ module top_earlgrey #(
     .tl_ram_main_i      (tl_ram_main_d_d2h),
     .tl_eflash_o        (tl_eflash_d_h2d),
     .tl_eflash_i        (tl_eflash_d_d2h),
-    .tl_peri_o          (tl_peri_d_h2d),
-    .tl_peri_i          (tl_peri_d_d2h),
+    .tl_peri_o          (tl_main_peri_h2d),
+    .tl_peri_i          (tl_main_peri_d2h),
     .tl_flash_ctrl_o    (tl_flash_ctrl_d_h2d),
     .tl_flash_ctrl_i    (tl_flash_ctrl_d_d2h),
     .tl_hmac_o          (tl_hmac_d_h2d),
@@ -930,8 +925,8 @@ module top_earlgrey #(
   xbar_peri u_xbar_peri (
     .clk_peri_i (clkmgr_clocks.clk_io_infra),
     .rst_peri_ni (rstmgr_resets.rst_sys_io_n),
-    .tl_main_i       (tl_main_h_h2d),
-    .tl_main_o       (tl_main_h_d2h),
+    .tl_main_i       (tl_main_peri_h2d),
+    .tl_main_o       (tl_main_peri_d2h),
     .tl_uart_o       (tl_uart_d_h2d),
     .tl_uart_i       (tl_uart_d_d2h),
     .tl_gpio_o       (tl_gpio_d_h2d),


### PR DESCRIPTION
If a crossbar connects to more than one crossbars, the naming collision occurs.

Now the connection between the crossbars has a format:

`tl_{host}_{device}_[h2d|d2h]`

