### PR TITLE
[sw] Use .option push/pop to turn off rvc

### DIFF
--- a/sw/device/boot_rom/irq_vector.S
+++ b/sw/device/boot_rom/irq_vector.S
@@ -17,6 +17,10 @@
   // be exactly word wide in the interrupt vector.
   .option norvc
 
+  // Disable RISC-V linker relaxation, as it can compress instructions at
+  // link-time, which we also really don't want.
+  .option norelax
+
   // Exception handler.
   .org 0x00
   j exception_handler

--- a/sw/device/boot_rom/irq_vector.S
+++ b/sw/device/boot_rom/irq_vector.S
@@ -11,6 +11,7 @@
   // NOTE: The "ax" flag below is necessary to ensure that this section 
   // is allocated executable space in ROM by the linker.
   .section .vectors, "ax"
+  .option push
 
   // Disable RISC-V instruction compression: we need all instructions to 
   // be exactly word wide in the interrupt vector.
@@ -48,7 +49,10 @@
   .org 0x80
   j _reset_start
 
-  .option rvc
+  .option pop
+
+  // Put these handlers in the code section.
+  .text
 /**
  * Default exception handler; loops forever.
  */

--- a/sw/device/exts/common/ibex_interrupt_vectors.S
+++ b/sw/device/exts/common/ibex_interrupt_vectors.S
@@ -7,15 +7,22 @@
  * This file contains Ibex-specific interrupt vectors.
  */
 
-  // NOTE: The "ax" flag below is necessary to ensure that this section
-  // is allocated space in ROM by the linker.
-  .section .vectors, "ax"
-
   // These functions are declared in `sw/device/lib/handler.h`.
   .extern handler_exception
   .extern handler_irq_software
   .extern handler_irq_timer
   .extern handler_irq_external
+
+  // NOTE: The "ax" flag below is necessary to ensure that this section
+  // is allocated space in ROM by the linker.
+  .section .vectors, "ax"
+  .option push
+  // Switch off compressed instructions so we know each instruction below is
+  // exactly 4 bytes (one entry).
+  .option norvc
+  // Switch off linker relaxation so that the linker does not reduce the size of
+  // any entries.
+  .option norelax
 
 /**
  * `crt_interrupt_vector` is the CRT-loaded interrupt vector for Ibex.
@@ -37,11 +44,6 @@
   .balign 256
 crt_interrupt_vector:
   .global crt_interrupt_vector
-
-  // Switch off compressed instructions so we know each instruction below is
-  // exactly 4 bytes (one entry).
-  .option push
-  .option norvc
 
   // exception Handler and user software interrupt
   j handler_exception
@@ -84,8 +86,7 @@ crt_interrupt_vector:
   // vendor interrupts: on Ibex interrupt id 31 is for non-maskable interrupts
   unimp
 
-  // Re-enable compressed instructions
-  .option pop
-
   // Set size so vector can be disassembled
   .size crt_interrupt_vector, .-crt_interrupt_vector
+
+  .option pop


### PR DESCRIPTION
This is a less error-prone way of turning off compressed instructions in assembly sections. Using push/pop ensures that the options changed within that section are not restored incorrectly.