### PR TITLE
[sw] Initial DIF Checklists

### DIFF
--- a/doc/project/sw_checklist.md.tpl
+++ b/doc/project/sw_checklist.md.tpl
@@ -1,14 +1,14 @@
 ---
-title: "${name.upper()} DIF Checklist"
+title: "${display_name} DIF Checklist"
 ---
 
 <!--
 NOTE: This is a template checklist document that is required to be copied over
-to `sw/device/lib/difs/dif_${name.lower()}.md` for a new DIF that transitions
+to `sw/device/lib/dif/dif_${dif_name}.md` for a new DIF that transitions
 from L0 (Specification) to L1 (Development) stage, and updated as needed.
 Once done, please remove this comment before checking it in.
 -->
-This checklist is for [Development Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [${name.upper()} DIF]({{< relref "hw/ip/${name}/doc" >}}).
+This checklist is for [Development Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [${display_name} DIF]({{< relref "hw/ip/${ip_name}/doc" >}}).
 All checklist items refer to the content in the [Checklist]({{< relref "/doc/project/checklist.md" >}}).
 
 ## DIF Checklist

--- a/hw/ip/gpio/data/gpio.prj.hjson
+++ b/hw/ip/gpio/data/gpio.prj.hjson
@@ -7,6 +7,7 @@
     design_spec:        "hw/ip/gpio/doc",
     dv_plan:            "hw/ip/gpio/doc/dv_plan",
     hw_checklist:       "hw/ip/gpio/doc/checklist",
+    sw_checklist:       "sw/device/lib/dif/dif_gpio",
     revisions: [
       {
         version:            "1.0",

--- a/hw/ip/rv_plic/data/rv_plic.prj.hjson
+++ b/hw/ip/rv_plic/data/rv_plic.prj.hjson
@@ -7,6 +7,7 @@
     design_spec:        "hw/ip/rv_plic/doc",
     dv_plan:            "hw/ip/rv_plic/doc/dv_plan",
     hw_checklist:       "hw/ip/rv_plic/doc/checklist",
+    sw_checklist:       "sw/device/lib/dif/dif_plic",
     revisions: [
       {
         version:            "0.5",

--- a/hw/ip/spi_device/data/spi_device.prj.hjson
+++ b/hw/ip/spi_device/data/spi_device.prj.hjson
@@ -7,6 +7,7 @@
     design_spec:        "hw/ip/spi_device/doc",
     dv_plan:            "hw/ip/spi_device/doc/dv_plan",
     hw_checklist:       "hw/ip/spi_device/doc/checklist",
+    sw_checklist:       "sw/device/lib/dif/dif_spi_device",
     revisions: [
       {
         version:            "0.5",

--- a/hw/ip/uart/data/uart.prj.hjson
+++ b/hw/ip/uart/data/uart.prj.hjson
@@ -7,6 +7,7 @@
     design_spec:        "hw/ip/uart/doc",
     dv_plan:            "hw/ip/uart/doc/dv_plan",
     hw_checklist:       "hw/ip/uart/doc/checklist",
+    sw_checklist:       "sw/device/lib/dif/dif_uart",
     revisions: [
       {
         version:            "1.0",

--- a/sw/device/lib/dif/README.md
+++ b/sw/device/lib/dif/README.md
@@ -13,6 +13,12 @@ There is one DIF library per hardware IP, and each one contains the DIFs
 required to actuate all of the specification-required functionality of the
 hardware they are written for.
 
+## Checklists
+
+This directory also contains checklists for each DIF, in markdown format. They
+are linked to from the [Hardware Dashboard]({{< relref "hw" >}}), in the
+Development Stage column.
+
 ## DIF Style Guide
 
 DIFs are very low-level software, so they have a more rigorous coding style than

--- a/sw/device/lib/dif/dif_gpio.md
+++ b/sw/device/lib/dif/dif_gpio.md
@@ -1,0 +1,67 @@
+---
+title: "GPIO DIF Checklist"
+---
+
+This checklist is for [Development Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [GPIO DIF]({{< relref "hw/ip/gpio/doc" >}}).
+All checklist items refer to the content in the [Checklist]({{< relref "/doc/project/checklist.md" >}}).
+
+
+
+Type           | Item                 | Resolution  | Note/Collaterals
+---------------|----------------------|-------------|------------------
+Implementation | [DIF_EXISTS][]       | Not Started |
+Implementation | [DIF_USED_IN_TREE][] | Not Started |
+Tests          | [DIF_TEST_UNIT][]    | Not Started |
+Tests          | [DIF_TEST_SANITY][]  | Not Started |
+Review         | Reviewer(s)          | Not Started |
+Review         | Signoff date         | Not Started |
+
+[DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif-exists" >}}
+[DIF_USED_IN_TREE]: {{< relref "/doc/project/checklist.md#dif-used-in-tree" >}}
+[DIF_TEST_UNIT]:    {{< relref "/doc/project/checklist.md#dif-test-unit" >}}
+[DIF_TEST_SANITY]:  {{< relref "/doc/project/checklist.md#dif-test-sanity" >}}
+
+
+Type           | Item                        | Resolution  | Note/Collaterals
+---------------|-----------------------------|-------------|------------------
+Implementation | [DIF_FEATURES][]            | Not Started |
+Coordination   | [DIF_HW_USAGE_REVIEWED][]   | Not Started |
+Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Not Started | [HW Dashboard]({{<relref "hw" >}})
+Implementation | [DIF_HW_PARAMS][]           | Not Started |
+Documentation  | [DIF_DOC_HW][]              | Not Started |
+Documentation  | [DIF_DOC_API][]             | Not Started |
+Code Quality   | [DIF_CODE_STYLE][]          | Not Started |
+Coordination   | [DIF_DV_TESTS][]            | Not Started |
+Implementation | [DIF_USED_TOCK][]           | Not Started |
+Review         | HW IP Usage Reviewer(s)     | Not Started |
+Review         | Reviewer(s)                 | Not Started |
+Review         | Signoff date                | Not Started |
+
+[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif-features" >}}
+[DIF_HW_USAGE_REVIEWED]:   {{< relref "/doc/project/checklist.md#dif-hw-usage-reviewed" >}}
+[DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif-hw-feature-complete" >}}
+[DIF_HW_PARAMS]:           {{< relref "/doc/project/checklist.md#dif-hw-params" >}}
+[DIF_DOC_HW]:              {{< relref "/doc/project/checklist.md#dif-doc-hw" >}}
+[DIF_DOC_API]:             {{< relref "/doc/project/checklist.md#dif-doc-api" >}}
+[DIF_CODE_STYLE]:          {{< relref "/doc/project/checklist.md#dif-code-style" >}}
+[DIF_DV_TESTS]:            {{< relref "/doc/project/checklist.md#dif-dv-tests" >}}
+[DIF_USED_TOCK]:           {{< relref "/doc/project/checklist.md#dif-used-tock" >}}
+
+
+Type           | Item                             | Resolution  | Note/Collaterals
+---------------|----------------------------------|-------------|------------------
+Coordination   | [DIF_HW_DESIGN_COMPLETE][]       | Not Started |
+Coordination   | [DIF_HW_VERIFICATION_COMPLETE][] | Not Started |
+Review         | [DIF_REVIEW_C_STABLE][]          | Not Started |
+Tests          | [DIF_TEST_UNIT_COMPLETE][]       | Not Started |
+Review         | [DIF_TODO_COMPLETE][]            | Not Started |
+Review         | [DIF_REVIEW_TOCK_STABLE][]       | Not Started |
+Review         | Reviewer(s)                      | Not Started |
+Review         | Signoff date                     | Not Started |
+
+[DIF_HW_DESIGN_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif-hw-design-complete" >}}
+[DIF_HW_VERIFICATION_COMPLETE]: {{< relref "/doc/project/checklist.md#dif-hw-verification-complete" >}}
+[DIF_REVIEW_C_STABLE]:          {{< relref "/doc/project/checklist.md#dif-review-c-stable" >}}
+[DIF_TEST_UNIT_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif-test-unit-complete" >}}
+[DIF_TODO_COMPLETE]:            {{< relref "/doc/project/checklist.md#dif-todo-complete" >}}
+[DIF_REVIEW_TOCK_STABLE]:       {{< relref "/doc/project/checklist.md#dif-review-tock-stable" >}}

--- a/sw/device/lib/dif/dif_plic.md
+++ b/sw/device/lib/dif/dif_plic.md
@@ -1,0 +1,67 @@
+---
+title: "PLIC DIF Checklist"
+---
+
+This checklist is for [Development Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [PLIC DIF]({{< relref "hw/ip/rv_plic/doc" >}}).
+All checklist items refer to the content in the [Checklist]({{< relref "/doc/project/checklist.md" >}}).
+
+
+
+Type           | Item                 | Resolution  | Note/Collaterals
+---------------|----------------------|-------------|------------------
+Implementation | [DIF_EXISTS][]       | Not Started |
+Implementation | [DIF_USED_IN_TREE][] | Not Started |
+Tests          | [DIF_TEST_UNIT][]    | Not Started |
+Tests          | [DIF_TEST_SANITY][]  | Not Started |
+Review         | Reviewer(s)          | Not Started |
+Review         | Signoff date         | Not Started |
+
+[DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif-exists" >}}
+[DIF_USED_IN_TREE]: {{< relref "/doc/project/checklist.md#dif-used-in-tree" >}}
+[DIF_TEST_UNIT]:    {{< relref "/doc/project/checklist.md#dif-test-unit" >}}
+[DIF_TEST_SANITY]:  {{< relref "/doc/project/checklist.md#dif-test-sanity" >}}
+
+
+Type           | Item                        | Resolution  | Note/Collaterals
+---------------|-----------------------------|-------------|------------------
+Implementation | [DIF_FEATURES][]            | Not Started |
+Coordination   | [DIF_HW_USAGE_REVIEWED][]   | Not Started |
+Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Not Started | [HW Dashboard]({{<relref "hw" >}})
+Implementation | [DIF_HW_PARAMS][]           | Not Started |
+Documentation  | [DIF_DOC_HW][]              | Not Started |
+Documentation  | [DIF_DOC_API][]             | Not Started |
+Code Quality   | [DIF_CODE_STYLE][]          | Not Started |
+Coordination   | [DIF_DV_TESTS][]            | Not Started |
+Implementation | [DIF_USED_TOCK][]           | Not Started |
+Review         | HW IP Usage Reviewer(s)     | Not Started |
+Review         | Reviewer(s)                 | Not Started |
+Review         | Signoff date                | Not Started |
+
+[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif-features" >}}
+[DIF_HW_USAGE_REVIEWED]:   {{< relref "/doc/project/checklist.md#dif-hw-usage-reviewed" >}}
+[DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif-hw-feature-complete" >}}
+[DIF_HW_PARAMS]:           {{< relref "/doc/project/checklist.md#dif-hw-params" >}}
+[DIF_DOC_HW]:              {{< relref "/doc/project/checklist.md#dif-doc-hw" >}}
+[DIF_DOC_API]:             {{< relref "/doc/project/checklist.md#dif-doc-api" >}}
+[DIF_CODE_STYLE]:          {{< relref "/doc/project/checklist.md#dif-code-style" >}}
+[DIF_DV_TESTS]:            {{< relref "/doc/project/checklist.md#dif-dv-tests" >}}
+[DIF_USED_TOCK]:           {{< relref "/doc/project/checklist.md#dif-used-tock" >}}
+
+
+Type           | Item                             | Resolution  | Note/Collaterals
+---------------|----------------------------------|-------------|------------------
+Coordination   | [DIF_HW_DESIGN_COMPLETE][]       | Not Started |
+Coordination   | [DIF_HW_VERIFICATION_COMPLETE][] | Not Started |
+Review         | [DIF_REVIEW_C_STABLE][]          | Not Started |
+Tests          | [DIF_TEST_UNIT_COMPLETE][]       | Not Started |
+Review         | [DIF_TODO_COMPLETE][]            | Not Started |
+Review         | [DIF_REVIEW_TOCK_STABLE][]       | Not Started |
+Review         | Reviewer(s)                      | Not Started |
+Review         | Signoff date                     | Not Started |
+
+[DIF_HW_DESIGN_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif-hw-design-complete" >}}
+[DIF_HW_VERIFICATION_COMPLETE]: {{< relref "/doc/project/checklist.md#dif-hw-verification-complete" >}}
+[DIF_REVIEW_C_STABLE]:          {{< relref "/doc/project/checklist.md#dif-review-c-stable" >}}
+[DIF_TEST_UNIT_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif-test-unit-complete" >}}
+[DIF_TODO_COMPLETE]:            {{< relref "/doc/project/checklist.md#dif-todo-complete" >}}
+[DIF_REVIEW_TOCK_STABLE]:       {{< relref "/doc/project/checklist.md#dif-review-tock-stable" >}}

--- a/sw/device/lib/dif/dif_spi_device.md
+++ b/sw/device/lib/dif/dif_spi_device.md
@@ -1,0 +1,67 @@
+---
+title: "SPI Device DIF Checklist"
+---
+
+This checklist is for [Development Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [SPI Device DIF]({{< relref "hw/ip/spi_device/doc" >}}).
+All checklist items refer to the content in the [Checklist]({{< relref "/doc/project/checklist.md" >}}).
+
+
+
+Type           | Item                 | Resolution  | Note/Collaterals
+---------------|----------------------|-------------|------------------
+Implementation | [DIF_EXISTS][]       | Not Started |
+Implementation | [DIF_USED_IN_TREE][] | Not Started |
+Tests          | [DIF_TEST_UNIT][]    | Not Started |
+Tests          | [DIF_TEST_SANITY][]  | Not Started |
+Review         | Reviewer(s)          | Not Started |
+Review         | Signoff date         | Not Started |
+
+[DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif-exists" >}}
+[DIF_USED_IN_TREE]: {{< relref "/doc/project/checklist.md#dif-used-in-tree" >}}
+[DIF_TEST_UNIT]:    {{< relref "/doc/project/checklist.md#dif-test-unit" >}}
+[DIF_TEST_SANITY]:  {{< relref "/doc/project/checklist.md#dif-test-sanity" >}}
+
+
+Type           | Item                        | Resolution  | Note/Collaterals
+---------------|-----------------------------|-------------|------------------
+Implementation | [DIF_FEATURES][]            | Not Started |
+Coordination   | [DIF_HW_USAGE_REVIEWED][]   | Not Started |
+Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Not Started | [HW Dashboard]({{<relref "hw" >}})
+Implementation | [DIF_HW_PARAMS][]           | Not Started |
+Documentation  | [DIF_DOC_HW][]              | Not Started |
+Documentation  | [DIF_DOC_API][]             | Not Started |
+Code Quality   | [DIF_CODE_STYLE][]          | Not Started |
+Coordination   | [DIF_DV_TESTS][]            | Not Started |
+Implementation | [DIF_USED_TOCK][]           | Not Started |
+Review         | HW IP Usage Reviewer(s)     | Not Started |
+Review         | Reviewer(s)                 | Not Started |
+Review         | Signoff date                | Not Started |
+
+[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif-features" >}}
+[DIF_HW_USAGE_REVIEWED]:   {{< relref "/doc/project/checklist.md#dif-hw-usage-reviewed" >}}
+[DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif-hw-feature-complete" >}}
+[DIF_HW_PARAMS]:           {{< relref "/doc/project/checklist.md#dif-hw-params" >}}
+[DIF_DOC_HW]:              {{< relref "/doc/project/checklist.md#dif-doc-hw" >}}
+[DIF_DOC_API]:             {{< relref "/doc/project/checklist.md#dif-doc-api" >}}
+[DIF_CODE_STYLE]:          {{< relref "/doc/project/checklist.md#dif-code-style" >}}
+[DIF_DV_TESTS]:            {{< relref "/doc/project/checklist.md#dif-dv-tests" >}}
+[DIF_USED_TOCK]:           {{< relref "/doc/project/checklist.md#dif-used-tock" >}}
+
+
+Type           | Item                             | Resolution  | Note/Collaterals
+---------------|----------------------------------|-------------|------------------
+Coordination   | [DIF_HW_DESIGN_COMPLETE][]       | Not Started |
+Coordination   | [DIF_HW_VERIFICATION_COMPLETE][] | Not Started |
+Review         | [DIF_REVIEW_C_STABLE][]          | Not Started |
+Tests          | [DIF_TEST_UNIT_COMPLETE][]       | Not Started |
+Review         | [DIF_TODO_COMPLETE][]            | Not Started |
+Review         | [DIF_REVIEW_TOCK_STABLE][]       | Not Started |
+Review         | Reviewer(s)                      | Not Started |
+Review         | Signoff date                     | Not Started |
+
+[DIF_HW_DESIGN_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif-hw-design-complete" >}}
+[DIF_HW_VERIFICATION_COMPLETE]: {{< relref "/doc/project/checklist.md#dif-hw-verification-complete" >}}
+[DIF_REVIEW_C_STABLE]:          {{< relref "/doc/project/checklist.md#dif-review-c-stable" >}}
+[DIF_TEST_UNIT_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif-test-unit-complete" >}}
+[DIF_TODO_COMPLETE]:            {{< relref "/doc/project/checklist.md#dif-todo-complete" >}}
+[DIF_REVIEW_TOCK_STABLE]:       {{< relref "/doc/project/checklist.md#dif-review-tock-stable" >}}

--- a/sw/device/lib/dif/dif_uart.md
+++ b/sw/device/lib/dif/dif_uart.md
@@ -1,0 +1,67 @@
+---
+title: "UART DIF Checklist"
+---
+
+This checklist is for [Development Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [UART DIF]({{< relref "hw/ip/uart/doc" >}}).
+All checklist items refer to the content in the [Checklist]({{< relref "/doc/project/checklist.md" >}}).
+
+
+
+Type           | Item                 | Resolution  | Note/Collaterals
+---------------|----------------------|-------------|------------------
+Implementation | [DIF_EXISTS][]       | Not Started |
+Implementation | [DIF_USED_IN_TREE][] | Not Started |
+Tests          | [DIF_TEST_UNIT][]    | Not Started |
+Tests          | [DIF_TEST_SANITY][]  | Not Started |
+Review         | Reviewer(s)          | Not Started |
+Review         | Signoff date         | Not Started |
+
+[DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif-exists" >}}
+[DIF_USED_IN_TREE]: {{< relref "/doc/project/checklist.md#dif-used-in-tree" >}}
+[DIF_TEST_UNIT]:    {{< relref "/doc/project/checklist.md#dif-test-unit" >}}
+[DIF_TEST_SANITY]:  {{< relref "/doc/project/checklist.md#dif-test-sanity" >}}
+
+
+Type           | Item                        | Resolution  | Note/Collaterals
+---------------|-----------------------------|-------------|------------------
+Implementation | [DIF_FEATURES][]            | Not Started |
+Coordination   | [DIF_HW_USAGE_REVIEWED][]   | Not Started |
+Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Not Started | [HW Dashboard]({{<relref "hw" >}})
+Implementation | [DIF_HW_PARAMS][]           | Not Started |
+Documentation  | [DIF_DOC_HW][]              | Not Started |
+Documentation  | [DIF_DOC_API][]             | Not Started |
+Code Quality   | [DIF_CODE_STYLE][]          | Not Started |
+Coordination   | [DIF_DV_TESTS][]            | Not Started |
+Implementation | [DIF_USED_TOCK][]           | Not Started |
+Review         | HW IP Usage Reviewer(s)     | Not Started |
+Review         | Reviewer(s)                 | Not Started |
+Review         | Signoff date                | Not Started |
+
+[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif-features" >}}
+[DIF_HW_USAGE_REVIEWED]:   {{< relref "/doc/project/checklist.md#dif-hw-usage-reviewed" >}}
+[DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif-hw-feature-complete" >}}
+[DIF_HW_PARAMS]:           {{< relref "/doc/project/checklist.md#dif-hw-params" >}}
+[DIF_DOC_HW]:              {{< relref "/doc/project/checklist.md#dif-doc-hw" >}}
+[DIF_DOC_API]:             {{< relref "/doc/project/checklist.md#dif-doc-api" >}}
+[DIF_CODE_STYLE]:          {{< relref "/doc/project/checklist.md#dif-code-style" >}}
+[DIF_DV_TESTS]:            {{< relref "/doc/project/checklist.md#dif-dv-tests" >}}
+[DIF_USED_TOCK]:           {{< relref "/doc/project/checklist.md#dif-used-tock" >}}
+
+
+Type           | Item                             | Resolution  | Note/Collaterals
+---------------|----------------------------------|-------------|------------------
+Coordination   | [DIF_HW_DESIGN_COMPLETE][]       | Not Started |
+Coordination   | [DIF_HW_VERIFICATION_COMPLETE][] | Not Started |
+Review         | [DIF_REVIEW_C_STABLE][]          | Not Started |
+Tests          | [DIF_TEST_UNIT_COMPLETE][]       | Not Started |
+Review         | [DIF_TODO_COMPLETE][]            | Not Started |
+Review         | [DIF_REVIEW_TOCK_STABLE][]       | Not Started |
+Review         | Reviewer(s)                      | Not Started |
+Review         | Signoff date                     | Not Started |
+
+[DIF_HW_DESIGN_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif-hw-design-complete" >}}
+[DIF_HW_VERIFICATION_COMPLETE]: {{< relref "/doc/project/checklist.md#dif-hw-verification-complete" >}}
+[DIF_REVIEW_C_STABLE]:          {{< relref "/doc/project/checklist.md#dif-review-c-stable" >}}
+[DIF_TEST_UNIT_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif-test-unit-complete" >}}
+[DIF_TODO_COMPLETE]:            {{< relref "/doc/project/checklist.md#dif-todo-complete" >}}
+[DIF_REVIEW_TOCK_STABLE]:       {{< relref "/doc/project/checklist.md#dif-review-tock-stable" >}}


### PR DESCRIPTION
This commit adds empty DIF checklists for the four DIFs which have already been added to the repository. 

These will be used in signoff reviews as some of these DIFs reach S1 status over the coming weeks.