### PR TITLE
[prim_rom] Align port names with prim_ram*

### DIFF
--- a/hw/ip/prim/prim.core
+++ b/hw/ip/prim/prim.core
@@ -9,8 +9,6 @@ description: "Primitives"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:prim:ram_2p # for prim_ram_2p_adv
-      - lowrisc:prim:secded # for prim_ram_2p_adv
       - lowrisc:prim:assert
       - lowrisc:prim:diff_decode # for prim_alert_sender/receiver
       - lowrisc:prim:pad_wrapper

--- a/hw/ip/prim/prim_ram_2p_adv.core
+++ b/hw/ip/prim/prim_ram_2p_adv.core
@@ -3,16 +3,14 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-name: "lowrisc:prim:ram_1p_adv:0.1"
-description: "Single-port RAM primitive with advanced features"
+name: "lowrisc:prim:ram_2p_adv:0.1"
+description: "Dual-port RAM primitive with advanced features"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:prim:assert
-      - lowrisc:prim:secded
-      - lowrisc:prim:ram_1p
+      - lowrisc:prim:ram_2p_async_adv
     files:
-      - rtl/prim_ram_1p_adv.sv
+      - rtl/prim_ram_2p_adv.sv
     file_type: systemVerilogSource
 
 targets:

--- a/hw/ip/prim/prim_ram_2p_async_adv.core
+++ b/hw/ip/prim/prim_ram_2p_async_adv.core
@@ -3,16 +3,16 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-name: "lowrisc:prim:ram_1p_adv:0.1"
-description: "Single-port RAM primitive with advanced features"
+name: "lowrisc:prim:ram_2p_async_adv:0.1"
+description: "Asynchronous dual-port RAM primitive with advanced features"
 filesets:
   files_rtl:
     depend:
       - lowrisc:prim:assert
       - lowrisc:prim:secded
-      - lowrisc:prim:ram_1p
+      - lowrisc:prim:ram_2p
     files:
-      - rtl/prim_ram_1p_adv.sv
+      - rtl/prim_ram_2p_adv.sv
     file_type: systemVerilogSource
 
 targets:

--- a/hw/ip/prim/prim_rom_adv.core
+++ b/hw/ip/prim/prim_rom_adv.core
@@ -3,16 +3,15 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-name: "lowrisc:prim:ram_1p_adv:0.1"
-description: "Single-port RAM primitive with advanced features"
+name: "lowrisc:prim:rom_adv:0.1"
+description: "ROM primitive with advanced features"
 filesets:
   files_rtl:
     depend:
       - lowrisc:prim:assert
-      - lowrisc:prim:secded
-      - lowrisc:prim:ram_1p
+      - lowrisc:prim:rom
     files:
-      - rtl/prim_ram_1p_adv.sv
+      - rtl/prim_rom_adv.sv
     file_type: systemVerilogSource
 
 targets:

--- a/hw/ip/prim/rtl/prim_rom_adv.sv
+++ b/hw/ip/prim/rtl/prim_rom_adv.sv
@@ -1,0 +1,58 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// ROM wrapper with rvalid register
+
+`include "prim_assert.sv"
+
+module prim_rom_adv #(
+  // Parameters passed on the the ROM primitive.
+  parameter  int Width       = 32,
+  parameter  int Depth       = 2048, // 8kB default
+  parameter      MemInitFile = "", // VMEM file to initialize the memory with
+
+  parameter  int CfgW        = 8,     // WTC, RTC, etc
+
+  localparam int Aw          = $clog2(Depth)
+) (
+  input  logic             clk_i,
+  input  logic             rst_ni,
+  input  logic             req_i,
+  input  logic [Aw-1:0]    addr_i,
+  output logic             rvalid_o,
+  output logic [Width-1:0] rdata_o,
+
+  input        [CfgW-1:0]  cfg_i
+);
+
+  // We will eventually use cfg_i for RTC/WTC or other memory parameters.
+  logic [CfgW-1:0] unused_cfg;
+  assign unused_cfg = cfg_i;
+
+  prim_rom #(
+    .Width(Width),
+    .Depth(Depth),
+    .MemInitFile(MemInitFile)
+  ) u_prim_rom (
+    .clk_i,
+    .req_i,
+    .addr_i,
+    .rdata_o
+  );
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      rvalid_o <= 1'b0;
+    end else begin
+      rvalid_o <= req_i;
+    end
+  end
+
+  ////////////////
+  // ASSERTIONS //
+  ////////////////
+
+  // Control Signals should never be X
+  `ASSERT(noXOnCsI, !$isunknown(req_i), clk_i, '0)
+endmodule : prim_rom_adv

--- a/hw/ip/prim_generic/rtl/prim_generic_rom.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_rom.sv
@@ -11,27 +11,17 @@ module prim_generic_rom #(
 
   localparam int Aw          = $clog2(Depth)
 ) (
-  input                        clk_i,
-  input                        rst_ni,
-  input        [Aw-1:0]        addr_i,
-  input                        cs_i,
-  output logic [Width-1:0]     dout_o,
-  output logic                 dvalid_o
+  input  logic             clk_i,
+  input  logic             req_i,
+  input  logic [Aw-1:0]    addr_i,
+  output logic [Width-1:0] rdata_o
 );
 
   logic [Width-1:0] mem [Depth];
 
   always_ff @(posedge clk_i) begin
-    if (cs_i) begin
-      dout_o <= mem[addr_i];
-    end
-  end
-
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      dvalid_o <= 1'b0;
-    end else begin
-      dvalid_o <= cs_i;
+    if (req_i) begin
+      rdata_o <= mem[addr_i];
     end
   end
 
@@ -42,5 +32,5 @@ module prim_generic_rom #(
   ////////////////
 
   // Control Signals should never be X
-  `ASSERT(noXOnCsI, !$isunknown(cs_i), clk_i, '0)
+  `ASSERT(noXOnCsI, !$isunknown(req_i), clk_i, '0)
 endmodule

--- a/hw/ip/spi_device/spi_device.core
+++ b/hw/ip/spi_device/spi_device.core
@@ -11,6 +11,7 @@ filesets:
       - lowrisc:ip:tlul
       - lowrisc:prim:all
       - lowrisc:prim:clock_gating
+      - lowrisc:prim:ram_2p_adv
     files:
       - rtl/spi_device_reg_pkg.sv
       - rtl/spi_device_reg_top.sv

--- a/hw/ip/usbdev/usbdev.core
+++ b/hw/ip/usbdev/usbdev.core
@@ -9,6 +9,7 @@ filesets:
     depend:
       - lowrisc:prim:all
       - lowrisc:ip:tlul
+      - lowrisc:prim:ram_2p_async_adv
       - lowrisc:ip:usb_fs_nb_pe
     files:
       - rtl/usbdev_reg_pkg.sv

--- a/hw/top_earlgrey/data/placement.xdc
+++ b/hw/top_earlgrey/data/placement.xdc
@@ -1,7 +1,7 @@
 # Any change in ROM instances path should be updated in following two files
 # 1. hw/top_earlgrey/data/placement.xdc and
 # 2. hw/top_earlgrey/util/vivado_hook_opt_design_post.tcl
-set_property LOC RAMB36_X4Y18 [get_cells -hierarchical -filter { NAME =~  "*rom_rom*dout_o_reg_0" && PRIMITIVE_TYPE =~ BMEM.*.* }]
-set_property LOC RAMB36_X4Y19 [get_cells -hierarchical -filter { NAME =~  "*rom_rom*dout_o_reg_1" && PRIMITIVE_TYPE =~ BMEM.*.* }]
-set_property LOC RAMB36_X3Y14 [get_cells -hierarchical -filter { NAME =~  "*rom_rom*dout_o_reg_2" && PRIMITIVE_TYPE =~ BMEM.*.* }]
-set_property LOC RAMB36_X3Y15 [get_cells -hierarchical -filter { NAME =~  "*rom_rom*dout_o_reg_3" && PRIMITIVE_TYPE =~ BMEM.*.* }]
+set_property LOC RAMB36_X4Y18 [get_cells -hierarchical -filter { NAME =~  "*rom_rom*rdata_o_reg_0" && PRIMITIVE_TYPE =~ BMEM.*.* }]
+set_property LOC RAMB36_X4Y19 [get_cells -hierarchical -filter { NAME =~  "*rom_rom*rdata_o_reg_1" && PRIMITIVE_TYPE =~ BMEM.*.* }]
+set_property LOC RAMB36_X3Y14 [get_cells -hierarchical -filter { NAME =~  "*rom_rom*rdata_o_reg_2" && PRIMITIVE_TYPE =~ BMEM.*.* }]
+set_property LOC RAMB36_X3Y15 [get_cells -hierarchical -filter { NAME =~  "*rom_rom*rdata_o_reg_3" && PRIMITIVE_TYPE =~ BMEM.*.* }]

--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -420,7 +420,7 @@ module top_${top["name"]} #(
     .rerror_i (2'b00)
   );
 
-  prim_rom #(
+  prim_rom_adv #(
     .Width(${data_width}),
     .Depth(${rom_depth}),
     .MemInitFile(BootRomInitFile)
@@ -431,10 +431,11 @@ module top_${top["name"]} #(
     % for key in resets:
     .${key}   (${top["reset_paths"][resets[key]]}),
     % endfor
-    .cs_i     (${m["name"]}_req),
+    .req_i    (${m["name"]}_req),
     .addr_i   (${m["name"]}_addr),
-    .dout_o   (${m["name"]}_rdata),
-    .dvalid_o (${m["name"]}_rvalid)
+    .rdata_o  (${m["name"]}_rdata),
+    .rvalid_o (${m["name"]}_rvalid),
+    .cfg_i    ('0) // tied off for now
   );
 
   % elif m["type"] == "eflash":

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -57,7 +57,7 @@ module tb;
   jtag_if jtag_if();
 
   // backdoors
-  bind `ROM_HIER mem_bkdr_if rom_mem_bkdr_if();
+  bind `ROM_HIER.u_prim_rom mem_bkdr_if rom_mem_bkdr_if();
   bind `RAM_MAIN_HIER.u_mem mem_bkdr_if ram_mem_bkdr_if();
   bind `FLASH0_MEM_HIER mem_bkdr_if flash0_mem_bkdr_if();
   bind `FLASH1_MEM_HIER mem_bkdr_if flash1_mem_bkdr_if();
@@ -189,7 +189,7 @@ module tb;
 
     // Backdoors
     uvm_config_db#(virtual mem_bkdr_if)::set(
-        null, "*.env", "mem_bkdr_vifs[Rom]", `ROM_HIER.rom_mem_bkdr_if);
+        null, "*.env", "mem_bkdr_vifs[Rom]", `ROM_HIER.u_prim_rom.rom_mem_bkdr_if);
     uvm_config_db#(virtual mem_bkdr_if)::set(
         null, "*.env", "mem_bkdr_vifs[Ram]", `RAM_MAIN_HIER.u_mem.ram_mem_bkdr_if);
     uvm_config_db#(virtual mem_bkdr_if)::set(

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -370,17 +370,18 @@ module top_earlgrey #(
     .rerror_i (2'b00)
   );
 
-  prim_rom #(
+  prim_rom_adv #(
     .Width(32),
     .Depth(4096),
     .MemInitFile(BootRomInitFile)
   ) u_rom_rom (
     .clk_i   (clkmgr_clocks.clk_main_infra),
     .rst_ni   (rstmgr_resets.rst_sys_n),
-    .cs_i     (rom_req),
+    .req_i    (rom_req),
     .addr_i   (rom_addr),
-    .dout_o   (rom_rdata),
-    .dvalid_o (rom_rvalid)
+    .rdata_o  (rom_rdata),
+    .rvalid_o (rom_rvalid),
+    .cfg_i    ('0) // tied off for now
   );
 
   // sram device

--- a/hw/top_earlgrey/top_earlgrey.core
+++ b/hw/top_earlgrey/top_earlgrey.core
@@ -26,7 +26,7 @@ filesets:
       - lowrisc:ip:hmac
       - lowrisc:ip:pwrmgr
       - lowrisc:prim:ram_1p_adv
-      - lowrisc:prim:rom
+      - lowrisc:prim:rom_adv
       - lowrisc:ip:rstmgr
       - lowrisc:prim:flash
       - lowrisc:ip:flash_ctrl:0.1

--- a/hw/top_earlgrey/top_earlgrey_verilator.cc
+++ b/hw/top_earlgrey/top_earlgrey_verilator.cc
@@ -17,8 +17,8 @@ int main(int argc, char **argv) {
 
   memutil.RegisterMemoryArea(
       "rom",
-      "TOP.top_earlgrey_verilator.top_earlgrey.u_rom_rom.gen_generic."
-      "u_impl_generic");
+      "TOP.top_earlgrey_verilator.top_earlgrey.u_rom_rom.u_prim_rom."
+      "gen_generic.u_impl_generic");
   memutil.RegisterMemoryArea(
       "ram",
       "TOP.top_earlgrey_verilator.top_earlgrey.u_ram1p_ram_main.u_mem."

--- a/hw/top_earlgrey/util/vivado_hook_opt_design_post.tcl
+++ b/hw/top_earlgrey/util/vivado_hook_opt_design_post.tcl
@@ -8,8 +8,8 @@
 
 send_msg "Designcheck 2-1" INFO "Checking if ROM memory is mapped to BRAM memory."
 
-if {[catch [get_cells -hierarchical -filter { NAME =~  "*rom_rom*dout_o_reg_0" && PRIMITIVE_TYPE =~ BMEM.*.* }]]\
-&& [catch [get_cells -hierarchical -filter { NAME =~  "*rom_rom*dout_o_reg_1" && PRIMITIVE_TYPE =~ BMEM.*.* }]] } {
+if {[catch [get_cells -hierarchical -filter { NAME =~  "*rom_rom*rdata_o_reg_0" && PRIMITIVE_TYPE =~ BMEM.*.* }]]\
+&& [catch [get_cells -hierarchical -filter { NAME =~  "*rom_rom*rdata_o_reg_1" && PRIMITIVE_TYPE =~ BMEM.*.* }]] } {
   send_msg "Designcheck 2-2" INFO "BRAM implementation found for ROM memory."
 } else {
   send_msg "Designcheck 2-3" ERROR "BRAM implementation not found for ROM memory."


### PR DESCRIPTION
This aligns port names with the RAM wrappers, which makes is more convenient to generate them from a common template.

Signed-off-by: Michael Schaffner <msf@google.com>