### PR TITLE
[doc] Fix Links to hw_checklist

### DIFF
--- a/doc/project/_index.md
+++ b/doc/project/_index.md
@@ -12,7 +12,7 @@ In order to gauge the quality of the different IP that is in our repository, we 
 The current status of different IP is reflected in the [Hardware Dashboard]({{< relref "hw" >}}).
 The final state for developed IP is *Signed Off*, indicating that design and verification is complete, and the IP should be bug free.
 To make it to that stage, a [Hardware Signoff Checklist]({{< relref "checklist.md" >}}) is used to confirm completion.
-[Here](https://github.com/lowRISC/opentitan/blob/master/doc/project/ip_checklist.md.tpl) is a template that can be used as a checklist item.
+[Here](https://github.com/lowRISC/opentitan/blob/master/util/uvmdvgen/checklist.md.tpl) is a template that can be used as a checklist item.
 
 ## Governance
 

--- a/util/dashboard/gen_dashboard_entry.py
+++ b/util/dashboard/gen_dashboard_entry.py
@@ -106,8 +106,11 @@ def get_linked_checklist(obj, rev, stage, is_latest_rev=True):
                                in_page_ref)
     else:
         # There is no checklist available, so point to the template.
+        # doc/project/hw_checklist.md.tpl is a symlink to ip_checklist.md.tpl,
+        # and github doesn't auto-render symlinks, so we have to use the url
+        # where the symlink points to.
         url = "https://github.com/lowrisc/opentitan/tree/master/"
-        url += "doc/project/ip_checklist.md.tpl"
+        url += "util/uvmdvgen/checklist.md.tpl"
 
     return "<a href=\"{}\">{}</a>".format(url, html.escape(rev[stage]))
 


### PR DESCRIPTION
These must have been missed when introducing the software checklist.

However, github doesn't render symlinks, and `doc/project/hw_checklist.md.tpl` is a symlink to `util/uvmdvgen/checklist.md.tpl`, so we need to update URLs to point to the latter template, and not the former.
