### PR TITLE
[sw, dif_aes] Introduce a set of AES changes 

### DIFF
--- a/sw/device/lib/aes.c
+++ b/sw/device/lib/aes.c
@@ -7,6 +7,11 @@
 #include "aes_regs.h"  // Generated.
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
+// TODO:
+// 1) Refactor to use use dif_aes.
+// 2) Verify that test still works.
+// 3) Use dif_aes directly in the test (probably remove this file).
+
 #define AES0_BASE_ADDR TOP_EARLGREY_AES_BASE_ADDR
 #define AES_NUM_REGS_KEY 8
 #define AES_NUM_REGS_IV 4

--- a/sw/device/lib/aes.h
+++ b/sw/device/lib/aes.h
@@ -9,6 +9,11 @@
 #include <stddef.h>
 #include <stdint.h>
 
+// TODO:
+// 1) Refactor to use use dif_aes.
+// 2) Verify that test still works.
+// 3) Use dif_aes directly in the test (probably remove this file).
+
 /**
  * Supported AES operation modes: encode or decode.
  */

--- a/sw/device/lib/dif/dif_aes.c
+++ b/sw/device/lib/dif/dif_aes.c
@@ -1,0 +1,445 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/dif/dif_aes.h"
+
+#include <stddef.h>
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/mmio.h"
+
+#include "aes_regs.h"  // Generated.
+
+/*
+ * From: https://docs.opentitan.org/hw/ip/aes/doc/index.html#register-table,
+ * aes.CTRL.
+ */
+
+/*
+ * Field to select AES block cipher mode.
+ *
+ * Invalid input values, i.e., value with multiple bits set - are mapped to
+ * `kAesModeFieldValNone`.
+ */
+typedef enum aes_mode_field_val {
+  kAesModeFieldValEcb = 0x01,  /**< The Electronic Codebook Mode. */
+  kAesModeFieldValCbc = 0x02,  /**< The Cipher Block Chaining Mode. */
+  kAesModeFieldValCfb = 0x04,  /**< TODO */
+  kAesModeFieldValOfb = 0x08,  /**< TODO */
+  kAesModeFieldValCtr = 0x10,  /**< The Counter Mode. */
+  kAesModeFieldValNone = 0x20, /**< TODO */
+} aes_mode_field_val_t;
+
+/*
+ * Field to select AES key length.
+ *
+ * Invalid input values, i.e., value with multiple bits set, value 3'b000, and
+ * value 3'b010 in case 192-bit keys are not supported (disabled at compile
+ * time) are mapped to `kAesKeyFieldVal256`.
+ */
+typedef enum aes_key_field_val {
+  kAesKeyFieldValInvalid = 0x00,
+  kAesKeyFieldVal128 = 0x01,
+  kAesKeyFieldVal192 = 0x02,
+  kAesKeyFieldVal256 = 0x04,
+} aes_key_field_val_t;
+
+static bool aes_idle(const dif_aes_t *aes) {
+  return mmio_region_get_bit32(aes->params.base_addr, AES_STATUS_REG_OFFSET,
+                               AES_STATUS_IDLE_BIT);
+}
+
+static bool aes_stalled(const dif_aes_t *aes) {
+  return mmio_region_get_bit32(aes->params.base_addr, AES_STATUS_REG_OFFSET,
+                               AES_STATUS_STALL_BIT);
+}
+
+static bool aes_output_lost(const dif_aes_t *aes) {
+  return mmio_region_get_bit32(aes->params.base_addr, AES_STATUS_REG_OFFSET,
+                               AES_STATUS_OUTPUT_LOST_BIT);
+}
+
+static bool aes_output_valid(const dif_aes_t *aes) {
+  return mmio_region_get_bit32(aes->params.base_addr, AES_STATUS_REG_OFFSET,
+                               AES_STATUS_OUTPUT_VALID_BIT);
+}
+
+static bool aes_input_ready(const dif_aes_t *aes) {
+  return mmio_region_get_bit32(aes->params.base_addr, AES_STATUS_REG_OFFSET,
+                               AES_STATUS_INPUT_READY_BIT);
+}
+
+static bool aes_alert_fatal(const dif_aes_t *aes) {
+  return mmio_region_get_bit32(aes->params.base_addr, AES_STATUS_REG_OFFSET,
+                               AES_STATUS_ALERT_FATAL_FAULT_BIT);
+}
+
+static bool aes_alert_recoverable(const dif_aes_t *aes) {
+  return mmio_region_get_bit32(aes->params.base_addr, AES_STATUS_REG_OFFSET,
+                               AES_STATUS_ALERT_RECOV_CTRL_UPDATE_ERR_BIT);
+}
+
+static void aes_shadowed_write(mmio_region_t base, ptrdiff_t offset,
+                               uint32_t value) {
+  mmio_region_write32(base, offset, value);
+  mmio_region_write32(base, offset, value);
+}
+
+static void aes_clear_internal_state(const dif_aes_t *aes) {
+  // Make sure AES is idle before clearing.
+  while (!aes_idle(aes)) {
+  }
+
+  // It should be fine to clobber the Control register. Only
+  // `AES_CTRL_SHADOWED_MANUAL_OPERATION` bit must be set.
+  uint32_t ctrl_reg =
+      bitfield_bit32_write(0, AES_CTRL_SHADOWED_MANUAL_OPERATION_BIT, true);
+
+  aes_shadowed_write(aes->params.base_addr, AES_CTRL_SHADOWED_REG_OFFSET,
+                     ctrl_reg);
+
+  uint32_t trigger_reg =
+      bitfield_bit32_write(0, AES_TRIGGER_KEY_IV_DATA_IN_CLEAR_BIT, true);
+
+  trigger_reg =
+      bitfield_bit32_write(trigger_reg, AES_TRIGGER_DATA_OUT_CLEAR_BIT, true);
+
+  mmio_region_write32(aes->params.base_addr, AES_TRIGGER_REG_OFFSET,
+                      trigger_reg);
+
+  // Make sure AES is cleared before proceeding (may take multiple cycles).
+  while (!aes_idle(aes)) {
+  }
+}
+
+static aes_key_field_val_t key_to_field(dif_aes_key_length_t key) {
+  switch (key) {
+    case kDifAesKey128:
+      return kAesKeyFieldVal128;
+    case kDifAesKey192:
+      return kAesKeyFieldVal192;
+    case kDifAesKey256:
+      return kAesKeyFieldVal256;
+    default:
+      return kAesKeyFieldValInvalid;
+  }
+}
+
+/**
+ * Configures AES. Is used by every `dif_aes_start_<mode>` function.
+ *
+ * @param aes AES state data.
+ * @param transaction Configuration data, common across all Cipher modes.
+ * @param cipher_mode_val Cipher Mode register write value.
+ * @return `dif_aes_start_result_t`.
+ */
+static dif_aes_start_result_t configure(
+    const dif_aes_t *aes, const dif_aes_transaction_t *transaction,
+    aes_mode_field_val_t cipher_mode_val) {
+  aes_key_field_val_t key_len_val = key_to_field(transaction->key_len);
+  if (key_len_val == kAesKeyFieldValInvalid) {
+    return kDifAesStartError;
+  }
+
+  uint32_t reg =
+      bitfield_field32_write(0, AES_CTRL_SHADOWED_KEY_LEN_FIELD, key_len_val);
+
+  reg = bitfield_field32_write(reg, AES_CTRL_SHADOWED_MODE_FIELD,
+                               cipher_mode_val);
+
+  if (transaction->mode == kDifAesModeDecrypt) {
+    reg = bitfield_bit32_write(reg, AES_CTRL_SHADOWED_OPERATION_BIT, true);
+  } else {
+    reg = bitfield_bit32_write(reg, AES_CTRL_SHADOWED_OPERATION_BIT, false);
+  }
+
+  if (transaction->operation == kDifAesOperationManual) {
+    reg =
+        bitfield_bit32_write(reg, AES_CTRL_SHADOWED_MANUAL_OPERATION_BIT, true);
+  } else {
+    reg = bitfield_bit32_write(reg, AES_CTRL_SHADOWED_MANUAL_OPERATION_BIT,
+                               false);
+  }
+
+  if (transaction->masking == kDifAesMaskingForceZero) {
+    reg =
+        bitfield_bit32_write(reg, AES_CTRL_SHADOWED_FORCE_ZERO_MASKS_BIT, true);
+  } else {
+    reg = bitfield_bit32_write(reg, AES_CTRL_SHADOWED_FORCE_ZERO_MASKS_BIT,
+                               false);
+  }
+
+  aes_shadowed_write(aes->params.base_addr, AES_CTRL_SHADOWED_REG_OFFSET, reg);
+
+  return kDifAesStartOk;
+}
+
+/**
+ * Sets all "sub-registers" of `aes.KEY`, `aes.IV` or `aes.DATA_IN` multiregs.
+ *
+ * @param aes AES state data.
+ * @param data Data to be written into multi-reg registers.
+ * @param regs_num Number of "sub-registers" in the multireg.
+ * @param reg0_offset Offset to the "sub-register 0" in the multireg.
+ */
+static void aes_set_multireg(const dif_aes_t *aes, const uint32_t *data,
+                             size_t regs_num, ptrdiff_t reg0_offset) {
+  for (int i = 0; i < regs_num; ++i) {
+    ptrdiff_t offset = reg0_offset + (i * sizeof(uint32_t));
+
+    mmio_region_write32(aes->params.base_addr, offset, data[i]);
+  }
+}
+
+dif_aes_result_t dif_aes_init(dif_aes_params_t params, dif_aes_t *aes) {
+  if (aes == NULL) {
+    return kDifAesBadArg;
+  }
+
+  aes->params = params;
+
+  return kDifAesOk;
+}
+
+dif_aes_reset_result_t dif_aes_reset(const dif_aes_t *aes) {
+  if (aes == NULL) {
+    return kDifAesResetBadArg;
+  }
+
+  aes_clear_internal_state(aes);
+
+  uint32_t reg =
+      bitfield_bit32_write(0, AES_CTRL_SHADOWED_MANUAL_OPERATION_BIT, true);
+
+  // Any values would do, illegal values chosen here.
+  reg = bitfield_field32_write(reg, AES_CTRL_SHADOWED_MODE_FIELD,
+                               AES_CTRL_SHADOWED_MODE_VALUE_AES_NONE);
+
+  reg =
+      bitfield_field32_write(reg, AES_CTRL_SHADOWED_KEY_LEN_FIELD, 0xffffffff);
+
+  aes_shadowed_write(aes->params.base_addr, AES_CTRL_SHADOWED_REG_OFFSET, reg);
+
+  return kDifAesResetOk;
+}
+
+dif_aes_start_result_t dif_aes_start_ecb(
+    const dif_aes_t *aes, const dif_aes_transaction_t *transaction,
+    dif_aes_key_share_t key) {
+  if (aes == NULL || transaction == NULL) {
+    return kDifAesStartBadArg;
+  }
+
+  if (!aes_idle(aes)) {
+    return kDifAesStartBusy;
+  }
+
+  dif_aes_start_result_t result =
+      configure(aes, transaction, kAesModeFieldValEcb);
+  if (result != kDifAesStartOk) {
+    return result;
+  }
+
+  aes_set_multireg(aes, &key.share0[0], AES_KEY_SHARE0_MULTIREG_COUNT,
+                   AES_KEY_SHARE0_0_REG_OFFSET);
+
+  aes_set_multireg(aes, &key.share1[0], AES_KEY_SHARE1_MULTIREG_COUNT,
+                   AES_KEY_SHARE1_0_REG_OFFSET);
+
+  return kDifAesStartOk;
+}
+
+dif_aes_start_result_t dif_aes_start_cbc(
+    const dif_aes_t *aes, const dif_aes_transaction_t *transaction,
+    dif_aes_key_share_t key, dif_aes_iv_t iv) {
+  if (aes == NULL || transaction == NULL) {
+    return kDifAesStartBadArg;
+  }
+
+  if (!aes_idle(aes)) {
+    return kDifAesStartBusy;
+  }
+
+  dif_aes_start_result_t result =
+      configure(aes, transaction, kAesModeFieldValCbc);
+  if (result != kDifAesStartOk) {
+    return result;
+  }
+
+  aes_set_multireg(aes, &key.share0[0], AES_KEY_SHARE0_MULTIREG_COUNT,
+                   AES_KEY_SHARE0_0_REG_OFFSET);
+
+  aes_set_multireg(aes, &key.share1[0], AES_KEY_SHARE1_MULTIREG_COUNT,
+                   AES_KEY_SHARE1_0_REG_OFFSET);
+
+  aes_set_multireg(aes, &iv.iv[0], AES_IV_MULTIREG_COUNT, AES_IV_0_REG_OFFSET);
+
+  return kDifAesStartOk;
+}
+
+dif_aes_start_result_t dif_aes_start_ctr(
+    const dif_aes_t *aes, const dif_aes_transaction_t *transaction,
+    dif_aes_key_share_t key, dif_aes_iv_t iv) {
+  if (aes == NULL || transaction == NULL) {
+    return kDifAesStartBadArg;
+  }
+
+  if (!aes_idle(aes)) {
+    return kDifAesStartBusy;
+  }
+
+  dif_aes_start_result_t result =
+      configure(aes, transaction, kAesModeFieldValCtr);
+  if (result != kDifAesStartOk) {
+    return result;
+  }
+
+  aes_set_multireg(aes, &key.share0[0], AES_KEY_SHARE0_MULTIREG_COUNT,
+                   AES_KEY_SHARE0_0_REG_OFFSET);
+
+  aes_set_multireg(aes, &key.share1[0], AES_KEY_SHARE1_MULTIREG_COUNT,
+                   AES_KEY_SHARE1_0_REG_OFFSET);
+
+  aes_set_multireg(aes, &iv.iv[0], AES_IV_MULTIREG_COUNT, AES_IV_0_REG_OFFSET);
+
+  return kDifAesStartOk;
+}
+
+dif_aes_end_result_t dif_aes_end(const dif_aes_t *aes) {
+  if (aes == NULL) {
+    return kDifAesEndBadArg;
+  }
+
+  if (!aes_idle(aes)) {
+    return kDifAesEndBusy;
+  }
+
+  aes_clear_internal_state(aes);
+
+  return kDifAesEndOk;
+}
+
+dif_aes_load_data_result_t dif_aes_load_data(const dif_aes_t *aes,
+                                             const dif_aes_data_t data) {
+  if (aes == NULL) {
+    return kDifAesLoadDataBadArg;
+  }
+
+  if (!aes_input_ready(aes)) {
+    return kDifAesLoadDataBusy;
+  }
+
+  aes_set_multireg(aes, &data.data[0], AES_DATA_IN_MULTIREG_COUNT,
+                   AES_DATA_IN_0_REG_OFFSET);
+
+  return kDifAesLoadDataOk;
+}
+
+dif_aes_read_output_result_t dif_aes_read_output(const dif_aes_t *aes,
+                                                 dif_aes_data_t *data) {
+  if (aes == NULL || data == NULL) {
+    return kDifAesReadOutputBadArg;
+  }
+
+  if (!aes_output_valid(aes)) {
+    return kDifAesReadOutputInvalid;
+  }
+
+  for (int i = 0; i < AES_DATA_OUT_MULTIREG_COUNT; ++i) {
+    ptrdiff_t offset = AES_DATA_OUT_0_REG_OFFSET + (i * sizeof(uint32_t));
+
+    data->data[i] = mmio_region_read32(aes->params.base_addr, offset);
+  }
+
+  return kDifAesReadOutputOk;
+}
+
+dif_aes_result_t dif_aes_trigger(const dif_aes_t *aes,
+                                 dif_aes_trigger_t trigger) {
+  if (aes == NULL) {
+    return kDifAesBadArg;
+  }
+
+  uint32_t reg;
+  switch (trigger) {
+    case kDifAesTriggerStart:
+      reg = bitfield_bit32_write(0, AES_TRIGGER_START_BIT, true);
+      break;
+    case kDifAesTriggerKeyIvDataInClear:
+      reg = bitfield_bit32_write(0, AES_TRIGGER_KEY_IV_DATA_IN_CLEAR_BIT, true);
+      break;
+    case kDifAesTriggerDataOutClear:
+      reg = bitfield_bit32_write(0, AES_TRIGGER_DATA_OUT_CLEAR_BIT, true);
+      break;
+    case kDifAesTriggerPrngReseed:
+      reg = bitfield_bit32_write(0, AES_TRIGGER_PRNG_RESEED_BIT, true);
+      break;
+    default:
+      return kDifAesError;
+  }
+
+  mmio_region_write32(aes->params.base_addr, AES_TRIGGER_REG_OFFSET, reg);
+
+  return kDifAesOk;
+}
+
+dif_aes_result_t dif_aes_get_status(const dif_aes_t *aes, dif_aes_status_t flag,
+                                    bool *set) {
+  if (aes == NULL || set == NULL) {
+    return kDifAesBadArg;
+  }
+
+  switch (flag) {
+    case kDifAesStatusIdle:
+      *set = aes_idle(aes);
+      break;
+    case kDifAesStatusStall:
+      *set = aes_stalled(aes);
+      break;
+    case kDifAesStatusOutputLost:
+      *set = aes_output_lost(aes);
+      break;
+    case kDifAesStatusOutputValid:
+      *set = aes_output_valid(aes);
+      break;
+    case kDifAesStatusInputReady:
+      *set = aes_input_ready(aes);
+      break;
+    case kDifAesStatusAlertFatalFault:
+      *set = aes_alert_fatal(aes);
+      break;
+    case kDifAesStatusAlertRecovCtrlUpdateErr:
+      *set = aes_alert_recoverable(aes);
+      break;
+    default:
+      return kDifAesError;
+  }
+
+  return kDifAesOk;
+}
+
+DIF_WARN_UNUSED_RESULT
+dif_aes_result_t dif_aes_alert_force(const dif_aes_t *aes,
+                                     dif_aes_alert_t alert) {
+  if (aes == NULL) {
+    return kDifAesBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  switch (alert) {
+    case kDifAlertFatalFault:
+      index = AES_ALERT_TEST_FATAL_FAULT_BIT;
+      break;
+    case kDifAlertRecovCtrlUpdateErr:
+      index = AES_ALERT_TEST_RECOV_CTRL_UPDATE_ERR_BIT;
+      break;
+    default:
+      return kDifAesError;
+  }
+
+  uint32_t reg = bitfield_bit32_write(0, index, true);
+  mmio_region_write32(aes->params.base_addr, AES_ALERT_TEST_REG_OFFSET, reg);
+
+  return kDifAesOk;
+}

--- a/sw/device/lib/dif/dif_aes.h
+++ b/sw/device/lib/dif/dif_aes.h
@@ -1,0 +1,594 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_DIF_AES_H_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_DIF_AES_H_
+
+/**
+ * @file
+ * @brief <a href="/hw/ip/aes/doc/">AES</a> Device Interface Functions
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_warn_unused_result.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * This API assumes transactional nature of work, where the peripheral is
+ * configured once per message (data consisting of 1..N 128-bit blocks), and
+ * then "de-initialised" when this message has been fully encrypted/decrypted.
+ *
+ * The peripheral is configured through one of the cipher mode "start"
+ * functions:
+ * `dif_aes_start_ecb`, `dif_aes_start_cbc`, ... .
+ *
+ * Then the encryption/decryption data is fed one 128-bit block at the
+ * time through `dif_aes_load_data` function. The cipher mode operation details
+ * are described in the description of above mentioned "start" functions. When
+ * configured in "automatic" operation mode, every "load data" call, will
+ * trigger encryption/decryption. This is not true when in "manual" operation
+ * mode, where encryption/decryption is triggered by explicitly setting the
+ * `aes.TRIGGER.START` flag through `dif_aes_trigger` call.
+ *
+ * When an entire requested message has been processed the internal state of
+ * AES registers must be securely cleared, by calling `dif_aes_end`.
+ *
+ * Please see the following documentation for further information:
+ * https://docs.opentitan.org/hw/ip/aes/doc/
+ * https://csrc.nist.gov/csrc/media/publications/fips/197/final/documents/fips-197.pdf
+ * https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38a.pdf
+ */
+
+/**
+ * A typed representation of the AES key share.
+ *
+ * Two part masked AES key, where XOR operation of these two parts results in
+ * the actual key.
+ */
+typedef struct dif_aes_key_share {
+  /**
+   * One share of the key that when XORed with `share1` results in the actual
+   * key.
+   */
+  uint32_t share0[8];
+  /**
+   * One share of the key that when XORed with `share0` results in the actual
+   * key.
+   */
+  uint32_t share1[8];
+} dif_aes_key_share_t;
+
+/**
+ * A typed representation of the AES Initialisation Vector (IV).
+ */
+typedef struct dif_aes_iv {
+  uint32_t iv[4];
+} dif_aes_iv_t;
+
+/**
+ * A typed representation of the AES data.
+ */
+typedef struct dif_aes_data {
+  uint32_t data[4];
+} dif_aes_data_t;
+
+/**
+ * AES key length in bits.
+ */
+typedef enum dif_aes_key_length {
+  /**
+   * 128 bit wide AES key.
+   */
+  kDifAesKey128 = 0,
+  /**
+   * 192 bit wide AES key.
+   */
+  kDifAesKey192,
+  /**
+   * 256 bit wide AES key.
+   */
+  kDifAesKey256,
+} dif_aes_key_length_t;
+
+/**
+ * AES mode.
+ */
+typedef enum dif_aes_mode {
+  /**
+   * AES encryption mode.
+   */
+  kDifAesModeEncrypt = 0,
+  /**
+   * AES decryption mode.
+   */
+  kDifAesModeDecrypt,
+} dif_aes_mode_t;
+
+/**
+ * AES operation.
+ */
+typedef enum dif_aes_operation {
+  /**
+   * AES operates in automatic mode - which means that the encryption/decryption
+   * is automatically triggered on every successful `dif_aes_*_load_data()`.
+   */
+  kDifAesOperationAuto = 0,
+  /**
+   * AES operates in manual mode - which means that the encryption/decryption
+   * is manually triggered by `dif_aes_trigger(kDifAesTriggerStart)`.
+   */
+  kDifAesOperationManual,
+} dif_aes_operation_t;
+
+/**
+ * AES masking.
+ *
+ * NOTE:
+ * This should only be used for development purpose (SCA), and expected to be
+ * removed before the production version.
+ */
+typedef enum dif_aes_masking {
+  /**
+   * Pseudo-random generator is used for masking.
+   */
+  kDifAesMaskingInternalPrng = 0,
+  /**
+   * Completely disables masking by forcing all masks to zero.
+   */
+  kDifAesMaskingForceZero,
+} dif_aes_masking_t;
+
+/**
+ * Parameters for an AES transaction.
+ */
+typedef struct dif_aes_transaction {
+  dif_aes_key_length_t key_len;
+  dif_aes_mode_t mode;
+  dif_aes_operation_t operation;
+  dif_aes_masking_t masking;
+} dif_aes_transaction_t;
+
+/**
+ * An AES alert type.
+ */
+typedef enum dif_aes_alert {
+  /**
+   * Fatal alert conditions include i) storage errors in the Control Register,
+   * and ii) if any internal FSM enters an invalid state.
+   */
+  kDifAlertFatalFault = 0,
+  /**
+   * Recoverable alert conditions include update errors in the Control Register.
+   */
+  kDifAlertRecovCtrlUpdateErr,
+} dif_aes_alert_t;
+
+/**
+ * Hardware instantiation parameters for AES.
+ *
+ * This struct describes information about the underlying hardware that is
+ * not determined until the hardware design is used as part of a top-level
+ * design.
+ */
+typedef struct dif_aes_params {
+  /**
+   * The base address for the AES hardware registers.
+   */
+  mmio_region_t base_addr;
+} dif_aes_params_t;
+
+/**
+ * A handle to AES.
+ *
+ * This type should be treated as opaque by users.
+ */
+typedef struct dif_aes {
+  dif_aes_params_t params;
+} dif_aes_t;
+
+/**
+ * The result of a AES operation.
+ */
+typedef enum dif_aes_result {
+  /**
+   * Indicates that the operation succeeded.
+   */
+  kDifAesOk = 0,
+  /**
+   * Indicates some unspecified failure.
+   */
+  kDifAesError = 1,
+  /**
+   * Indicates that some parameter passed into a function failed a
+   * precondition.
+   *
+   * When this value is returned, no hardware operations occurred.
+   */
+  kDifAesBadArg = 2,
+} dif_aes_result_t;
+
+/**
+ * Creates a new handle for AES.
+ *
+ * This function does not actuate the hardware.
+ *
+ * @param params Hardware instantiation parameters.
+ * @param[out] aes Out param for the initialised handle.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_aes_result_t dif_aes_init(dif_aes_params_t params, dif_aes_t *aes);
+
+/**
+ * The result of a AES reset operation.
+ */
+typedef enum dif_aes_reset_result {
+  /**
+   * Indicates that the operation succeeded.
+   */
+  kDifAesResetOk = kDifAesOk,
+  /**
+   * Indicates some unspecified failure.
+   */
+  kDifAesResetError = kDifAesError,
+  /**
+   * Indicates that some parameter passed into a function failed a
+   * precondition.
+   *
+   * When this value is returned, no hardware operations occurred.
+   */
+  kDifAesResetBadArg = kDifAesBadArg,
+  /**
+   * Device is busy, and cannot perform the requested operation.
+   */
+  kDifAesResetBusy,
+} dif_aes_reset_result_t;
+
+/**
+ * Resets an instance of AES.
+ *
+ * Clears the internal state along with the interface registers.
+ *
+ * @param aes AES state data.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_aes_reset_result_t dif_aes_reset(const dif_aes_t *aes);
+
+/**
+ * The result of a AES start operation.
+ */
+typedef enum dif_aes_start_result {
+  /**
+   * Indicates that the operation succeeded.
+   */
+  kDifAesStartOk = kDifAesOk,
+  /**
+   * Indicates some unspecified failure.
+   */
+  kDifAesStartError = kDifAesError,
+  /**
+   * Indicates that some parameter passed into a function failed a
+   * precondition.
+   *
+   * When this value is returned, no hardware operations occurred.
+   */
+  kDifAesStartBadArg = kDifAesBadArg,
+  /**
+   * Device is busy, and cannot perform the requested operation.
+   */
+  kDifAesStartBusy,
+} dif_aes_start_result_t;
+
+/**
+ * Begins an AES transaction in ECB mode.
+ *
+ * In ECB cipher mode the key must be changed for every new block of data. This
+ * is the only secure way to use ECB cipher mode.
+ *
+ * Each call to this function should be sequenced with a call to
+ * `dif_aes_end()`.
+ *
+ * Note: it is discouraged to use this cipher mode, due to inpractical amount
+ *       of different keys required to encrypt/decrypt multi-block messages.
+ *
+ * The peripheral must be in IDLE state for this operation to take
+ * effect, and will return `kDifAesStartBusy` if this condition is not
+ * met.
+ *
+ * @param aes AES state data.
+ * @param transaction Configuration data.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_aes_start_result_t dif_aes_start_ecb(
+    const dif_aes_t *aes, const dif_aes_transaction_t *transaction,
+    dif_aes_key_share_t key);
+
+/**
+ * Begins an AES transaction in CBC mode.
+ *
+ * In CBC cipher mode, the same key can be used for all messages, however
+ * new Initialisation Vector (IV) must be generated for any new message. The
+ * following condition must be true:
+ *     The IV must be unpredictable (it must not be possible to predict the IV
+ *     that will be associated to the plaintext in advance of the generation of
+ *     the IV).
+ *
+ * With key length less than 256 bits, the excess portion of the `key` can be
+ * written with any data (preferably random).
+ *
+ * The peripheral must be in IDLE state for this operation to take effect, and
+ * will return `kDifAesStartBusy` if this condition is not met.
+ *
+ * @param aes AES state data.
+ * @param transaction Configuration data.
+ * @param key_share Masked AES key.
+ * @param iv AES Initialisation Vector.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_aes_start_result_t dif_aes_start_cbc(
+    const dif_aes_t *aes, const dif_aes_transaction_t *transaction,
+    dif_aes_key_share_t key, dif_aes_iv_t iv);
+
+/**
+ * Begins an AES transaction in CTR mode.
+ *
+ * In CTR cipher mode, the same key can be used for all messages, if the
+ * following condition is true:
+ *     CTR mode requires a unique counter block for each plaintext block that
+ *     is ever encrypted under a given key, across all messages.
+ *
+ * With key length less than 256 bits, the excess portion of the `key` can be
+ * written with any data (preferably random).
+ *
+ * The peripheral must be in IDLE state for this operation to take effect, and
+ * will return `kDifAesStartBusy` if this condition is not met.
+ *
+ * @param aes AES state data.
+ * @param transaction Configuration data.
+ * @paran key Masked AES key.
+ * @param iv AES Initial Counter Value.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_aes_start_result_t dif_aes_start_ctr(
+    const dif_aes_t *aes, const dif_aes_transaction_t *transaction,
+    dif_aes_key_share_t key, dif_aes_iv_t iv);
+
+/**
+ * The result of an AES end operation.
+ */
+typedef enum dif_aes_end_result {
+  /**
+   * Indicates that the operation succeeded.
+   */
+  kDifAesEndOk = kDifAesOk,
+  /**
+   * Indicates some unspecified failure.
+   */
+  kDifAesEndError = kDifAesError,
+  /**
+   * Indicates that some parameter passed into a function failed a
+   * precondition.
+   *
+   * When this value is returned, no hardware operations occurred.
+   */
+  kDifAesEndBadArg = kDifAesBadArg,
+  /**
+   * Device is busy, and cannot perform the requested operation.
+   */
+  kDifAesEndBusy,
+} dif_aes_end_result_t;
+
+/**
+ * Ends an AES transaction.
+ *
+ * This function must be called at the end of every `dif_aes_<mode>_start`
+ * operation.
+ *
+ * The peripheral must be in IDLE state for this operation to take effect, and
+ * will return `kDifAesEndBusy` if this condition is not met.
+ *
+ * @param aes AES state data.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_aes_end_result_t dif_aes_end(const dif_aes_t *aes);
+
+/**
+ * The result of an AES load data operation.
+ */
+typedef enum dif_aes_load_data_result {
+  /**
+   * Indicates that the operation succeeded.
+   */
+  kDifAesLoadDataOk = kDifAesOk,
+  /**
+   * Indicates some unspecified failure.
+   */
+  kDifAesLoadDataError = kDifAesError,
+  /**
+   * Indicates that some parameter passed into a function failed a
+   * precondition.
+   *
+   * When this value is returned, no hardware operations occurred.
+   */
+  kDifAesLoadDataBadArg = kDifAesBadArg,
+  /**
+   * Device is busy, and cannot perform the requested operation.
+   */
+  kDifAesLoadDataBusy,
+} dif_aes_load_data_result_t;
+
+/**
+ * Loads AES Input Data.
+ *
+ * This function will trigger encryption/decryption when configured in
+ * the automatic operation mode.
+ *
+ * The peripheral must be able to accept the input (INPUT_READY set), and
+ * will return `kDifAesLoadDataBusy` if this condition is not met.
+ *
+ * @param aes AES state data.
+ * @param data AES Input Data.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_aes_load_data_result_t dif_aes_load_data(const dif_aes_t *aes,
+                                             const dif_aes_data_t data);
+
+/**
+ * The result of an AES data read operation.
+ */
+typedef enum dif_aes_read_data_result {
+  /**
+   * Indicates that the operation succeeded.
+   */
+  kDifAesReadOutputOk = kDifAesOk,
+  /**
+   * Indicates some unspecified failure.
+   */
+  kDifAesReadOutputError = kDifAesError,
+  /**
+   * Indicates that some parameter passed into a function failed a
+   * precondition.
+   *
+   * When this value is returned, no hardware operations occurred.
+   */
+  kDifAesReadOutputBadArg = kDifAesBadArg,
+  /**
+   * The AES unit has no valid output.
+   */
+  kDifAesReadOutputInvalid,
+} dif_aes_read_output_result_t;
+
+/**
+ * Reads AES Output Data.
+ *
+ * The peripheral must have finished previous encryption/decryption operation,
+ * and have valid data in the output registers (OUTPUT_VALID set), and will
+ * return `kDifAesReadOutputInvalid` if this condition is not met.
+ *
+ * @param aes AES state data.
+ * @param data AES Output Data.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_aes_read_output_result_t dif_aes_read_output(const dif_aes_t *aes,
+                                                 dif_aes_data_t *data);
+
+/**
+ * AES Trigger flags.
+ */
+typedef enum dif_aes_trigger {
+  /**
+   * Trigger encrypt/decrypt.
+   */
+  kDifAesTriggerStart = 0,
+  /**
+   * Clear key, Initialisation Vector/Initial Counter Value and input data.
+   */
+  kDifAesTriggerKeyIvDataInClear,
+  /**
+   * Clear Output Data registers.
+   */
+  kDifAesTriggerDataOutClear,
+  /**
+   * Perform reseed of the internal state.
+   */
+  kDifAesTriggerPrngReseed,
+} dif_aes_trigger_t;
+
+/**
+ * Triggers one of `dif_aes_trigger_t` operations.
+ *
+ * All the triggers are applicable to both (automatic and manual) modes, with
+ * the exception of `kDifAesTriggerStart`, which is ignored in automatic mode.
+ *
+ * @param aes AES state data.
+ * @param trigger AES trigger.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_aes_result_t dif_aes_trigger(const dif_aes_t *aes,
+                                 dif_aes_trigger_t trigger);
+
+/**
+ * AES Status flags.
+ */
+typedef enum dif_aes_status {
+  /**
+   * Device is idle.
+   */
+  kDifAesStatusIdle = 0,
+  /**
+   * Device has stalled (only relevant in automatic
+   * operation mode). Output data overwrite
+   * protection.
+   */
+  kDifAesStatusStall,
+  /**
+   * Output data has been overwritten by the AES unit before the processor
+   * could fully read it. This bit is "sticky" for the entire duration of
+   * the current transaction.
+   */
+  kDifAesStatusOutputLost,
+  /**
+   * Device output is valid/ready. Denotes a
+   * successful encrypt or decrypt operation.
+   */
+  kDifAesStatusOutputValid,
+  /**
+   * Device Input Data registers can be written to
+   * (ready to accept new input data).
+   */
+  kDifAesStatusInputReady,
+  /**
+   * Fatal alert conditions include i) storage errors in the Control Register,
+   * and ii) if any internal FSM enters an invalid state.
+   */
+  kDifAesStatusAlertFatalFault,
+  /**
+   * Recoverable alert conditions include update errors in the Control Register.
+   */
+  kDifAesStatusAlertRecovCtrlUpdateErr,
+} dif_aes_status_t;
+
+/**
+ * Queries the AES status flags.
+ *
+ * @param aes AES state data.
+ * @param flag Status flag to query.
+ * @param set Flag state (set/unset).
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_aes_result_t dif_aes_get_status(const dif_aes_t *aes, dif_aes_status_t flag,
+                                    bool *set);
+
+/**
+ * Forces a particular alert, causing it to be serviced as if hardware had
+ * asserted it.
+ *
+ * @param aes AES state data.
+ * @param alert An alert type.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_aes_result_t dif_aes_alert_force(const dif_aes_t *aes,
+                                     dif_aes_alert_t alert);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_DIF_AES_H_

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -232,3 +232,15 @@ sw_lib_dif_aon_timer = declare_dependency(
     ],
   )
 )
+
+# AES DIF library
+sw_lib_dif_aes = declare_dependency(
+  link_with: static_library(
+    'sw_lib_dif_aes',
+    sources: [
+      hw_ip_aes_reg_h,
+      'dif_aes.c',
+    ],
+    dependencies: [sw_lib_mmio],
+  )
+)

--- a/sw/device/tests/aes_test.c
+++ b/sw/device/tests/aes_test.c
@@ -8,6 +8,9 @@
 #include "sw/device/lib/testing/check.h"
 #include "sw/device/lib/testing/test_main.h"
 
+// TODO:
+// 1) Use the dif_aes directly.
+
 // The following plaintext, key and ciphertext are extracted from Appendix C of
 // the Advanced Encryption Standard (AES) FIPS Publication 197 available at
 // https://www.nist.gov/publications/advanced-encryption-standard-aes

--- a/sw/device/tests/dif/dif_aes_test.cc
+++ b/sw/device/tests/dif/dif_aes_test.cc
@@ -1,0 +1,24 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/dif/dif_aes.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/testing/mock_mmio.h"
+
+extern "C" {
+#include "aes_regs.h"  // Generated.
+}  // extern "C"
+
+namespace dif_aes_test {
+namespace {
+using mock_mmio::MmioTest;
+using mock_mmio::MockDevice;
+using testing::Test;
+
+// CODE HERE
+
+}  // namespace
+}  // namespace dif_aes_test

--- a/sw/device/tests/dif/meson.build
+++ b/sw/device/tests/dif/meson.build
@@ -194,6 +194,22 @@ test('dif_lc_ctrl_unittest', executable(
   cpp_args: ['-DMOCK_MMIO'],
 ))
 
+test('dif_aes_test', executable(
+  'dif_aes_test',
+  sources: [
+    hw_ip_aes_reg_h,
+    meson.source_root() / 'sw/device/lib/dif/dif_aes.c',
+    'dif_aes_test.cc',
+  ],
+  dependencies: [
+    sw_vendor_gtest,
+    sw_lib_testing_mock_mmio,
+  ],
+  native: true,
+  c_args: ['-DMOCK_MMIO'], 
+  cpp_args: ['-DMOCK_MMIO'],
+))
+
 dif_plic_smoketest_lib = declare_dependency(
   link_with: static_library(
     'dif_plic_smoketest_lib',


### PR DESCRIPTION
The aim of this PR is to merge in the main library with other TODOs (**described in #4833 **) addressed in follow-ups.

Please have a look at the #2382 , for the questions and suggestions that I have gathered whilst working my way through the [DIF AES OpenTitan documentation](https://docs.opentitan.org/hw/ip/aes/doc/).

Key points:

- AES API is relatively straight forward, however there is a number of internal conditions that have to be met for correct operation of the peripheral. These are fundamental checks, and should be done at the DIF level rather than the driver level (in my opinion).

- It does not seem practical to bring the input or output data pointers into alignment as it is done in HMAC and SPI. The data that AES operates on is 128-bits wide, and it would be costly to bring it into the alignment for every 128-bit read/write. I think it should be documented that for maximal efficiency the input/output buffers have to be aligned.