### PR TITLE
[usb] Fix default usb_fs_nb_out_pe NumOutEps

### DIFF
--- a/hw/ip/usb_fs_nb_pe/rtl/usb_fs_nb_out_pe.sv
+++ b/hw/ip/usb_fs_nb_pe/rtl/usb_fs_nb_out_pe.sv
@@ -14,7 +14,7 @@
 `include "prim_assert.sv"
 
 module usb_fs_nb_out_pe #(
-  parameter logic [4:0] NumOutEps = 1,
+  parameter logic [4:0] NumOutEps = 2,
   parameter int unsigned MaxOutPktSizeByte = 32,
   localparam int unsigned OutEpW = $clog2(NumOutEps), // derived parameter
   localparam int unsigned PktW = $clog2(MaxOutPktSizeByte) // derived parameter


### PR DESCRIPTION
I have been running an updated version of the LEC flow. The goal of this change is to make this module valid when instantiated with its default parameters to facilitate easier verification.

With `NumOutEps` set to 1, `OutEpW` is 0. `OutEpW` is used as the with of a pair of part selects. Conformal LEC reasonably complains when using the default parameters because of the invalid width. Also note that `usb_fs_nb_pe` already defaults `NumOutEps` to 2.

Please let me know if I've missed anything!