### PR TITLE
[i2c, dv] Fix incorrect bit width definition for timeout value

### DIFF
--- a/hw/dv/sv/i2c_agent/i2c_agent_pkg.sv
+++ b/hw/dv/sv/i2c_agent/i2c_agent_pkg.sv
@@ -34,7 +34,7 @@ package i2c_agent_pkg;
     bit [31:0]  tSetupStop;
     bit [31:0]  tHoldStop;
     bit         enbTimeOut;
-    bit         tTimeOut;
+    bit [30:0]  tTimeOut;
   } timing_cfg_t;
 
   // forward declare classes to allow typedefs below


### PR DESCRIPTION
Change bit width to correct value 31 

Signed-off-by: Tung Hoang <tung.hoang.290780@gmail.com>