### PR TITLE
[sw, dif_uart] Fulfil S1 Checklist DIF_TEST_UNIT requirement

### DIFF
--- a/sw/device/tests/dif/dif_uart_unittest.cc
+++ b/sw/device/tests/dif/dif_uart_unittest.cc
@@ -11,7 +11,7 @@ extern "C" {
 #include "uart_regs.h"  // Generated.
 }  // extern "C"
 
-namespace dif_uart_test {
+namespace dif_uart_unittest {
 namespace {
 using mock_mmio::MmioTest;
 using mock_mmio::MockDevice;
@@ -738,4 +738,4 @@ TEST_F(TxBytesAvailableTest, FifoEmpty) {
 }
 
 }  // namespace
-}  // namespace dif_uart_test
+}  // namespace dif_uart_unittest

--- a/sw/device/tests/dif/meson.build
+++ b/sw/device/tests/dif/meson.build
@@ -18,10 +18,10 @@ test('dif_spi_device_test', executable(
   cpp_args: ['-DMOCK_MMIO'],
 ))
 
-test('dif_uart_test', executable(
-  'dif_uart_test',
+test('dif_uart_unittest', executable(
+  'dif_uart_unittest',
   sources: [
-    'dif_uart_test.cc',
+    'dif_uart_unittest.cc',
     meson.source_root() / 'sw/device/lib/dif/dif_uart.c',
     hw_ip_uart_reg_h,
   ],


### PR DESCRIPTION
DIF_TEST_UNIT:
Software unit tests exist for the DIF in sw/device/tests/dif named dif_*_unittest.cc.

This change renames dif_uart_test.cc to dif_uart_unittest.cc.