### PR TITLE
[sw, dif_plic] Prepare dif_plic for S1 signoff

### DIFF
--- a/ci/run_verilator_pytest.sh
+++ b/ci/run_verilator_pytest.sh
@@ -17,7 +17,7 @@ BOOT_ROM_TARGET="boot_rom/boot_rom_sim_verilator.elf"
 TEST_TARGETS=(
   "examples/hello_usbdev/hello_usbdev_sim_verilator.elf"
   "tests/aes_test_sim_verilator.elf"
-  "tests/consecutive_irqs_test_sim_verilator.elf"
+  "tests/dif_plic_sanitytest_sim_verilator.elf"
   "tests/flash_ctrl_test_sim_verilator.elf"
   "tests/sha256_test_sim_verilator.elf"
   "tests/rv_timer_test_sim_verilator.elf"

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -109,9 +109,9 @@
       sw_test: sw/device/tests/aes_test
     }
     {
-      name: chip_consecutive_irqs_test
+      name: chip_dif_plic_sanitytest
       uvm_test_seq: chip_sw_base_vseq
-      sw_test: sw/device/tests/consecutive_irqs_test
+      sw_test: sw/device/tests/dif/dif_plic_sanitytest
     }
     {
       name: chip_flash_ctrl_test

--- a/sw/device/tests/dif/dif_plic_sanitytest.c
+++ b/sw/device/tests/dif/dif_plic_sanitytest.c
@@ -2,17 +2,19 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
+#include "sw/device/lib/dif/dif_plic.h"
+
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/log.h"
 #include "sw/device/lib/base/mmio.h"
-#include "sw/device/lib/dif/dif_plic.h"
 #include "sw/device/lib/dif/dif_uart.h"
 #include "sw/device/lib/handler.h"
 #include "sw/device/lib/irq.h"
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/testing/test_main.h"
 #include "sw/device/lib/testing/test_status.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
 
 #define PLIC_TARGET kTopEarlgreyPlicTargetIbex0
 

--- a/sw/device/tests/dif/dif_plic_unittest.cc
+++ b/sw/device/tests/dif/dif_plic_unittest.cc
@@ -12,7 +12,7 @@ extern "C" {
 #include "rv_plic_regs.h"  // Generated.
 }  // extern "C"
 
-namespace dif_plic_test_mocked {
+namespace dif_plic_unittest {
 namespace {
 using mock_mmio::MmioTest;
 using mock_mmio::MockDevice;
@@ -376,4 +376,4 @@ TEST_F(IrqCompleteTest, Target0Success) {
 }
 
 }  // namespace
-}  // namespace dif_plic_test_mocked
+}  // namespace dif_plic_unittest

--- a/sw/device/tests/dif/meson.build
+++ b/sw/device/tests/dif/meson.build
@@ -34,12 +34,12 @@ test('dif_uart_test', executable(
   cpp_args: ['-DMOCK_MMIO'],
 ))
 
-test('dif_plic_test', executable(
-  'dif_plic_test',
+test('dif_plic_unittest', executable(
+  'dif_plic_unittest',
   sources: [
     hw_top_earlgrey_rv_plic_reg_h,
     meson.source_root() / 'sw/device/lib/dif/dif_plic.c',
-    'dif_plic_test.cc',
+    'dif_plic_unittest.cc',
   ],
   dependencies: [
     sw_vendor_gtest,

--- a/sw/device/tests/dif/meson.build
+++ b/sw/device/tests/dif/meson.build
@@ -49,3 +49,21 @@ test('dif_plic_unittest', executable(
   c_args: ['-DMOCK_MMIO'], 
   cpp_args: ['-DMOCK_MMIO'],
 ))
+
+dif_plic_sanitytest_lib = declare_dependency(
+  link_with: static_library(
+    'dif_plic_sanitytest_lib',
+    sources: ['dif_plic_sanitytest.c'],
+    dependencies: [
+      dif_uart,
+      dif_plic,
+      sw_lib_irq,
+      sw_lib_mmio,
+      sw_lib_base_log,
+      sw_lib_runtime_hart,
+      sw_lib_testing_test_status,
+    ],
+  ),
+)
+
+sw_tests += { 'dif_plic_sanitytest': dif_plic_sanitytest_lib }

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -18,22 +18,6 @@ aes_test_lib = declare_dependency(
   ),
 )
 
-consecutive_irqs_test_lib = declare_dependency(
-  link_with: static_library(
-    'consecutive_irqs_test_lib',
-    sources: ['consecutive_irqs_test.c'],
-    dependencies: [
-      dif_uart,
-      dif_plic,
-      sw_lib_irq,
-      sw_lib_mmio,
-      sw_lib_base_log,
-      sw_lib_runtime_hart,
-      sw_lib_testing_test_status,
-    ],
-  ),
-)
-
 flash_ctrl_test_lib = declare_dependency(
   link_with: static_library(
     'flash_ctrl_test_lib',
@@ -75,7 +59,6 @@ sha256_test_lib = declare_dependency(
 
 sw_tests += {
   'aes_test': aes_test_lib,
-  'consecutive_irqs_test': consecutive_irqs_test_lib,
   'flash_ctrl_test': flash_ctrl_test_lib,
   'rv_timer_test': rv_timer_test_lib,
   'sha256_test': sha256_test_lib,


### PR DESCRIPTION
This change prepares dif_plic for S1 signeoff. Please refer to the [checklist document](https://docs.opentitan.org/doc/project/checklist/#s1) for S1 signeoff requirements.