### PR TITLE
[prim] Add a "clog2 width" function

### DIFF
--- a/hw/ip/prim/prim_util.core
+++ b/hw/ip/prim/prim_util.core
@@ -1,0 +1,17 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:util:0.1"
+description: "Utilities"
+filesets:
+  files_rtl:
+    files:
+      - rtl/prim_util.svh : {is_include_file : true}
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_rtl

--- a/hw/ip/prim/rtl/prim_util.svh
+++ b/hw/ip/prim/rtl/prim_util.svh
@@ -1,0 +1,47 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Utility macros
+
+`ifndef PRIM_UTIL_SVH
+`define PRIM_UTIL_SVH
+
+/**
+ * Math function: Number of bits needed to address |value| items.
+ *
+ *                  0        for value == 0
+ * vbits =          1        for value == 1
+ *         ceil(log2(value)) for value > 1
+ *
+ *
+ * The primary use case for this function is the definition of registers/arrays
+ * which are wide enough to contain |value| items.
+ *
+ * This function identical to $clog2() for all input values except the value 1;
+ * it could be considered an "enhanced" $clog2() function.
+ *
+ *
+ * Example 1:
+ *   parameter Items = 1;
+ *   localparam ItemsWidth = vbits(Items); // 1
+ *   logic [ItemsWidth-1:0] item_register; // items_register is now [0:0]
+ *
+ * Example 2:
+ *   parameter Items = 64;
+ *   localparam ItemsWidth = vbits(Items); // 6
+ *   logic [ItemsWidth-1:0] item_register; // items_register is now [5:0]
+ *
+ * Note: If you want to store the number "value" inside a register, you need
+ * a register with size vbits(value + 1), since you also need to store
+ * the number 0.
+ *
+ * Example 3:
+ *   logic [vbits(64)-1:0]     store_64_logic_values; // width is [5:0]
+ *   logic [vbits(64 + 1)-1:0] store_number_64;       // width is [6:0]
+ */
+function automatic integer vbits(integer value);
+  return (value == 1) ? 1 : $clog2(value);
+endfunction
+
+`endif // PRIM_UTIL_SVH


### PR DESCRIPTION
`$clog2()` is commonly used to get the number of bits needed to
address a certain number of items, aka the width of a signal.

There's on special case that's often missed: `$clog2(value)` returns 0
if `value == 1`, leading synthesis failures for code like
`logic [$clog2(value)-1:0] signal`.

This commit adds a helper function to cover the `value == 1` case
better by returning `1` in this case.