### PR TITLE
[fpv/prim_packer] Add a FPV TB

### DIFF
--- a/hw/formal/fpv_all
+++ b/hw/formal/fpv_all
@@ -42,6 +42,7 @@ declare -a blocks=(
   "prim_esc_rxtx_fpv"
   "prim_lfsr_fpv"
   "prim_fifo_sync_fpv"
+  "prim_packer_fpv"
   "pinmux_fpv"
   "padctrl_fpv"
   "rv_plic_fpv"

--- a/hw/ip/prim/fpv/prim_packer_fpv.core
+++ b/hw/ip/prim/fpv/prim_packer_fpv.core
@@ -1,0 +1,27 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:fpv:prim_packer_fpv"
+description: "formal Testbench for prim_packer"
+filesets:
+  files_formal:
+    depend:
+      - lowrisc:prim:all
+    files:
+      - ../rtl/prim_packer.sv
+      - tb/prim_packer_fpv.sv
+    file_type: systemVerilogSource
+
+targets:
+  default: &default_target
+    # note, this setting is just used
+    # to generate a file list for jg
+    default_tool: icarus
+    filesets:
+      - files_formal
+    toplevel: prim_packer_fpv
+
+  formal:
+    <<: *default_target

--- a/hw/ip/prim/fpv/tb/prim_packer_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_packer_fpv.sv
@@ -1,0 +1,63 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Testbench module for prim_packer. Intended to be used with a formal tool.
+// To reduce the runtime for prim_packer, we limited the width parameter.
+
+module prim_packer_fpv #(
+  parameter int unsigned MaxInW = 64,
+  parameter int unsigned MaxOutW = 64
+) (
+  input clk_i ,
+  input rst_ni,
+
+  input                      valid_i,
+  input        [MaxInW-1:0]  data_i,
+  input        [MaxInW-1:0]  mask_i,
+  output                     ready_o,
+
+  output logic               valid_o,
+  output logic [MaxOutW-1:0] data_o,
+  output logic [MaxOutW-1:0] mask_o,
+  input                      ready_i,
+
+  input                      flush_i,
+  output logic               flush_done_o
+);
+
+  for (genvar k = 1; k <= 16; k++) begin : gen_prim_packer
+    prim_packer #(.InW(k), .OutW(17-k)
+    ) i_prim_packer (
+      .clk_i,
+      .rst_ni,
+      .valid_i,
+      .data_i (data_i[k-1:0]),
+      .mask_i (mask_i[k-1:0]),
+      .ready_o,
+      .valid_o,
+      .data_o (data_o[16-k:0]),
+      .mask_o (mask_o[16-k:0]),
+      .ready_i,
+      .flush_i,
+      .flush_done_o
+    );
+  end
+
+  prim_packer #(.InW(MaxInW), .OutW(MaxOutW)
+    ) i_prim_packer_max (
+      .clk_i,
+      .rst_ni,
+      .valid_i,
+      .data_i (data_i),
+      .mask_i (mask_i),
+      .ready_o,
+      .valid_o,
+      .data_o (data_o),
+      .mask_o (mask_o),
+      .ready_i,
+      .flush_i,
+      .flush_done_o
+  );
+
+endmodule : prim_packer_fpv

--- a/hw/ip/prim/rtl/prim_packer.sv
+++ b/hw/ip/prim/rtl/prim_packer.sv
@@ -236,10 +236,11 @@ module prim_packer #(
             valid_i |-> $countones(mask_i ^ {mask_i[InW-2:0],1'b0}) <= 2)
   end
 
-  // Assume data pattern to reduce FPV test time
-  //`ASSUME_FPV(FpvDataWithin_M,
-  //            data_i inside {'0, '1, 32'hDEAD_BEEF},
-  //            clk_i, !rst_ni)
+  // Assume data and mask patterns to reduce FPV test time
+  if (InW + OutW > 32) begin : gen_fpv_assumption
+    `ASSUME_FPV(FpvDataWithin_M, data_i inside {'0, '1, 32'hDEAD_BEEF})
+    `ASSUME_FPV(FpvMaskWithin_M, mask_i inside {'0, '1, 32'h08FF_2E41})
+  end
 
   // Flush and Write Enable cannot be asserted same time
   `ASSUME(ExFlushValid_M, flush_i |-> !valid_i)
@@ -252,6 +253,7 @@ module prim_packer #(
   `ASSUME(DataIStable_M,
           ##1 valid_i && $past(valid_i) && !$past(ready_o)
           |-> $stable(data_i) && $stable(mask_i))
+
   `ASSUME(ValidIPairedWithReadyO_M,
           valid_i && !ready_o |=> valid_i)
 

--- a/hw/top_earlgrey/fpv/top_earlgrey_fpv_cfgs.hjson
+++ b/hw/top_earlgrey/fpv/top_earlgrey_fpv_cfgs.hjson
@@ -50,6 +50,11 @@
                import_cfgs: ["{proj_root}/hw/formal/data/common_fpv_cfg.hjson"]
              }
              {
+               name: prim_packer_fpv
+               fusesoc_core: lowrisc:fpv:prim_packer_fpv
+               import_cfgs: ["{proj_root}/hw/formal/data/common_fpv_cfg.hjson"]
+             }
+             {
                name: padctrl_fpv
                fusesoc_core: lowrisc:fpv:padctrl_fpv
                import_cfgs: ["{proj_root}/hw/formal/data/common_fpv_cfg.hjson"]


### PR DESCRIPTION
Made a Formal Testbench for prim_packer, to make the tb converge, we
constraint the input data size from 2 bits to 16 bits, and check the max width 64 bits with extra assumptions
to make sure the FPV testbench can converge.

Signed-off-by: Cindy Chen <chencindy@google.com>