### PR TITLE
[dv] Fix leftover TL items after reset

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_vseq__tl_errors.svh
+++ b/hw/dv/sv/cip_lib/cip_base_vseq__tl_errors.svh
@@ -163,7 +163,13 @@ virtual task run_tl_errors_vseq(int num_times = 1, bit do_wait_clk = 0);
         wait fork;
       end: isolation_fork
     join
-    if (do_wait_clk) cfg.clk_rst_vif.wait_clks($urandom_range(500, 10_000));
+    // when reset occurs, end this seq ASAP to avoid killing seq while sending trans
+    if (do_wait_clk) begin
+      repeat($urandom_range(500, 10_000)) begin
+        if (cfg.under_reset) return;
+        cfg.clk_rst_vif.wait_clks(1);
+      end
+    end
   end // for
   set_tl_assert_en(.enable(1));
 endtask : run_tl_errors_vseq


### PR DESCRIPTION
Stop driving more TL items when reset occurs to fix below error
> UVM_ERROR @ 18604172900 ps: (tl_host_driver.sv:47) uvm_test_top.env.m_tl_agent.driver [uvm_test_top.env.m_tl_agent.driver] Check failed seq_item_port.has_do_available() == 0 (1 [0x1] vs 0 [0x0])
UVM_FATAL @ 18604272900 ps: uvm_test_top.env.m_tl_agent.sequencer [uvm_test_top.env.m_tl_agent.sequencer] Item_done() called with no outstanding requests. Each call to item_done() must be paired with a previous call to get_next_item().

Signed-off-by: Weicai Yang <weicai@google.com>