### PR TITLE
[dv/uart] Fix a corner case

### DIFF
--- a/hw/ip/uart/dv/env/seq_lib/uart_tx_rx_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_tx_rx_vseq.sv
@@ -197,7 +197,6 @@ class uart_tx_rx_vseq extends uart_base_vseq;
                                                [100:10000] :/ 2
                                              };)
           cfg.clk_rst_vif.wait_clks(dly_to_rx_read);
-          wait_when_in_ignored_period(.rx(1));
           rand_read_rx_byte(weight_to_skip_rx_read);
         end
       end


### PR DESCRIPTION
During last bit of uart transfer, shouldn't read rdata to avoid
inaccurate prediction. Here is the change

Original:
`wait_when_in_ignored_period; read N bytes`
Change to:
`repeat (N) {wait_when_in_ignored_period; read one byte}`

Signed-off-by: Weicai Yang <weicai@google.com>