### PR TITLE
[dvsim] Fix --reseed argument

### DIFF
--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -356,7 +356,6 @@ def parse_args():
 
     seedg.add_argument("--reseed", "-r",
                        type=int,
-                       default=-1,
                        metavar="N",
                        help=('Override any reseed value in the test '
                              'configuration and run each test N times, with '


### PR DESCRIPTION
This was broken by commit b7aacc1a (I fluffed splitting up the PR, it
seems). The default should have been None (since e83b55e), but some
rebase to the doc update patch put the default -1 back.