### PR TITLE
[sw, dif_uart] Fulfil S1 Checklist DIF_TEST_SANITY requirement

### DIFF
--- a/ci/run_verilator_pytest.sh
+++ b/ci/run_verilator_pytest.sh
@@ -18,6 +18,7 @@ TEST_TARGETS=(
   "examples/hello_usbdev/hello_usbdev_sim_verilator.elf"
   "tests/aes_test_sim_verilator.elf"
   "tests/dif_plic_sanitytest_sim_verilator.elf"
+  "tests/dif_uart_sanitytest_sim_verilator.elf"
   "tests/flash_ctrl_test_sim_verilator.elf"
   "tests/sha256_test_sim_verilator.elf"
   "tests/rv_timer_test_sim_verilator.elf"

--- a/sw/device/lib/dif/dif_uart.c
+++ b/sw/device/lib/dif/dif_uart.c
@@ -472,3 +472,50 @@ dif_uart_result_t dif_uart_tx_bytes_available(const dif_uart_t *uart,
 
   return kDifUartOk;
 }
+
+dif_uart_result_t dif_uart_fifo_reset(const dif_uart_t *uart,
+                                      dif_uart_fifo_reset_t reset) {
+  if (uart == NULL) {
+    return kDifUartBadArg;
+  }
+
+  uint32_t reg = mmio_region_read32(uart->base_addr, UART_FIFO_CTRL_REG_OFFSET);
+
+  if (reset == kDifUartFifoResetRx || reset == kDifUartFifoResetAll) {
+    reg = bitfield_set_field32(
+        reg, (bitfield_field32_t){
+                 .mask = 0x1, .value = 1, .index = UART_FIFO_CTRL_RXRST,
+             });
+  }
+
+  if (reset == kDifUartFifoResetTx || reset == kDifUartFifoResetAll) {
+    reg = bitfield_set_field32(
+        reg, (bitfield_field32_t){
+                 .mask = 0x1, .value = 1, .index = UART_FIFO_CTRL_TXRST,
+             });
+  }
+
+  mmio_region_write32(uart->base_addr, UART_FIFO_CTRL_REG_OFFSET, reg);
+
+  return kDifUartOk;
+}
+
+dif_uart_result_t dif_uart_loopback_set(const dif_uart_t *uart,
+                                        dif_uart_loopback_t loopback,
+                                        dif_uart_enable_t enable) {
+  if (uart == NULL) {
+    return kDifUartBadArg;
+  }
+
+  bitfield_field32_t field = {
+      .mask = 0x1,
+      .index = loopback ? UART_CTRL_LLPBK : UART_CTRL_SLPBK,
+      .value = enable ? 1 : 0,
+  };
+
+  uint32_t reg = mmio_region_read32(uart->base_addr, UART_CTRL_REG_OFFSET);
+  reg = bitfield_set_field32(reg, field);
+  mmio_region_write32(uart->base_addr, UART_CTRL_REG_OFFSET, reg);
+
+  return kDifUartOk;
+}

--- a/sw/device/lib/dif/dif_uart.h
+++ b/sw/device/lib/dif/dif_uart.h
@@ -60,13 +60,30 @@ typedef enum dif_uart_watermark {
 } dif_uart_watermark_t;
 
 /**
+ * UART TX/RX FIFO reset enumeration.
+ */
+typedef enum dif_uart_fifo_reset {
+  kDifUartFifoResetRx = 0, /**< Reset RX FIFO. */
+  kDifUartFifoResetTx,     /**< Reset TX FIFO. */
+  kDifUartFifoResetAll,    /**< All above. */
+} dif_uart_fifo_reset_t;
+
+/**
+ * UART System/Line loopback enumeration.
+ */
+typedef enum dif_uart_loopback {
+  kDifUartLoopbackSystem = 0, /**< Outgoing TX bits received through RX. */
+  kDifUartLoopbackLine,       /**< Incoming RX bits are forwarded to TX. */
+} dif_uart_loopback_t;
+
+/**
  * Generic enable/disable enumeration.
  *
  * Enumeration used to enable/disable bits, flags, ...
  */
 typedef enum dif_uart_enable {
-  kDifUartEnable = 0, /**< enable. */
-  kDifUartDisable,    /**< disable. */
+  kDifUartDisable = 0, /**< disable. */
+  kDifUartEnable,      /**< enable. */
 } dif_uart_enable_t;
 
 /**
@@ -365,6 +382,41 @@ dif_uart_result_t dif_uart_rx_bytes_available(const dif_uart_t *uart,
 DIF_WARN_UNUSED_RESULT
 dif_uart_result_t dif_uart_tx_bytes_available(const dif_uart_t *uart,
                                               size_t *num_bytes);
+/**
+ * UART TX reset RX/TX FIFO.
+ *
+ * Reset both FIFOs, or the requested one.
+ *
+ * @param uart UART state data.
+ * @param reset FIFO to reset (RX or TX).
+ * @return `dif_uart_result_t`.
+ */
+dif_uart_result_t dif_uart_fifo_reset(const dif_uart_t *uart,
+                                      dif_uart_fifo_reset_t reset);
+
+/**
+ * UART enable/disable transmit/receive loopback.
+ *
+ * This API can be used for testing purpose. For example, to validate transmit
+ * and receive routines.
+ *
+ * Loopback should only be enabled when device is in the IDLE state to prevent
+ * data loss/coruption. Behaviour depends on the `loopback` parameter:
+ *    - `kDifUartLoopbackSystem`:
+ *      Receives the data that is being transmitted. No external data can be
+ *      received (from the RX line). When enabled the TX line goes high.
+ *    - `kDifUartLoopbackLine`:
+ *      Transmits the data that is being received. No internal data can be
+ *      sent out (from the TX FIFO). When enabled the RX line goes high.
+ *
+ * @param uart UART state data.
+ * @param loopback Loopback type (transmit/receive).
+ * @param enable Enable/disable control flag.
+ * @return `dif_uart_result_t`.
+ */
+dif_uart_result_t dif_uart_loopback_set(const dif_uart_t *uart,
+                                        dif_uart_loopback_t loopback,
+                                        dif_uart_enable_t enable);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/testing/test_main.c
+++ b/sw/device/lib/testing/test_main.c
@@ -10,6 +10,9 @@
 #include "sw/device/lib/testing/test_status.h"
 #include "sw/device/lib/uart.h"
 
+// Must be set to `true` in any test that reconfigures UART.
+bool uart_reconfigure_required = false;
+
 int main(int argc, char **argv) {
   test_status_set(kTestStatusInTest);
 
@@ -21,6 +24,12 @@ int main(int argc, char **argv) {
 
   // Run the SW test which is fully contained within `test_main()`.
   bool result = test_main();
+
+  // Must happen before any debug output.
+  if (uart_reconfigure_required) {
+    uart_init(kUartBaudrate);
+  }
+
   test_status_set(result ? kTestStatusPassed : kTestStatusFailed);
 
   // Unreachable code.

--- a/sw/device/lib/testing/test_main.h
+++ b/sw/device/lib/testing/test_main.h
@@ -23,4 +23,12 @@
  */
 extern bool test_main(void);
 
+/**
+ * This flag should be defined in the test runner with the default value,
+ * which then can be overriden by individual tests when required. For example,
+ * when a test configures UART to non-standard settings for internal use, the
+ * flag has to be set to `true` in such test.
+ */
+extern bool uart_reconfigure_required;
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_MAIN_H_

--- a/sw/device/tests/dif/dif_uart_sanitytest.c
+++ b/sw/device/tests/dif/dif_uart_sanitytest.c
@@ -1,0 +1,65 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/dif/dif_uart.h"
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/runtime/hart.h"
+#include "sw/device/lib/testing/test_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
+
+static dif_uart_t uart0;
+static const uint8_t kSendData[] = "Sanity test!";
+
+static bool uart_initialise(mmio_region_t base_addr, dif_uart_t *uart) {
+  dif_uart_config_t config = {
+      .baudrate = kUartBaudrate,
+      .clk_freq_hz = kClockFreqHz,
+      .parity_enable = kDifUartDisable,
+      .parity = kDifUartParityEven,
+  };
+
+  return dif_uart_init(base_addr, &config, uart) == kDifUartConfigOk;
+}
+
+bool test_main(void) {
+  mmio_region_t uart_base_addr =
+      mmio_region_from_addr(TOP_EARLGREY_UART_BASE_ADDR);
+  if (!uart_initialise(uart_base_addr, &uart0)) {
+    return false;
+  }
+
+  // Make sure that the test runner reinitialises UART after this test.
+  uart_reconfigure_required = true;
+
+  if (dif_uart_loopback_set(&uart0, kDifUartLoopbackSystem, kDifUartEnable) !=
+      kDifUartOk) {
+    return false;
+  }
+
+  if (dif_uart_fifo_reset(&uart0, kDifUartFifoResetAll) != kDifUartOk) {
+    return false;
+  }
+
+  // Send all bytes in `kSendData`, and check that they are received via
+  // a loopback mechanism.
+  for (int i = 0; i < sizeof(kSendData); ++i) {
+    if (dif_uart_byte_send_polled(&uart0, kSendData[i]) != kDifUartOk) {
+      return false;
+    }
+
+    uint8_t receive_byte;
+    if (dif_uart_byte_receive_polled(&uart0, &receive_byte) != kDifUartOk) {
+      return false;
+    }
+
+    if (receive_byte != kSendData[i]) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/sw/device/tests/dif/dif_uart_unittest.cc
+++ b/sw/device/tests/dif/dif_uart_unittest.cc
@@ -736,5 +736,62 @@ TEST_F(TxBytesAvailableTest, FifoEmpty) {
   EXPECT_EQ(num_bytes, kDifUartFifoSizeBytes);
 }
 
+class FifoResetTest : public UartTest {};
+
+TEST_F(FifoResetTest, NullArgs) {
+  dif_uart_result_t result = dif_uart_fifo_reset(nullptr, kDifUartFifoResetRx);
+  EXPECT_EQ(result, kDifUartBadArg);
+}
+
+TEST_F(FifoResetTest, Success) {
+  EXPECT_MASK32(UART_FIFO_CTRL_REG_OFFSET, {{UART_FIFO_CTRL_RXRST, 0x1, true}});
+  dif_uart_result_t result =
+      dif_uart_fifo_reset(&dif_uart_, kDifUartFifoResetRx);
+  EXPECT_EQ(result, kDifUartOk);
+
+  EXPECT_MASK32(UART_FIFO_CTRL_REG_OFFSET, {{UART_FIFO_CTRL_TXRST, 0x1, true}});
+  result = dif_uart_fifo_reset(&dif_uart_, kDifUartFifoResetTx);
+  EXPECT_EQ(result, kDifUartOk);
+
+  EXPECT_MASK32(
+      UART_FIFO_CTRL_REG_OFFSET,
+      {
+          {UART_FIFO_CTRL_RXRST, 0x1, true}, {UART_FIFO_CTRL_TXRST, 0x1, true},
+      });
+
+  result = dif_uart_fifo_reset(&dif_uart_, kDifUartFifoResetAll);
+  EXPECT_EQ(result, kDifUartOk);
+}
+
+class LoopbackSetTest : public UartTest {};
+
+TEST_F(LoopbackSetTest, NullArgs) {
+  dif_uart_result_t result =
+      dif_uart_loopback_set(nullptr, kDifUartLoopbackSystem, kDifUartEnable);
+  EXPECT_EQ(result, kDifUartBadArg);
+}
+
+TEST_F(LoopbackSetTest, Success) {
+  EXPECT_MASK32(UART_CTRL_REG_OFFSET, {{UART_CTRL_SLPBK, 0x1, true}});
+  dif_uart_result_t result =
+      dif_uart_loopback_set(&dif_uart_, kDifUartLoopbackSystem, kDifUartEnable);
+  EXPECT_EQ(result, kDifUartOk);
+
+  EXPECT_MASK32(UART_CTRL_REG_OFFSET, {{UART_CTRL_SLPBK, 0x1, false}});
+  result = dif_uart_loopback_set(&dif_uart_, kDifUartLoopbackSystem,
+                                 kDifUartDisable);
+  EXPECT_EQ(result, kDifUartOk);
+
+  EXPECT_MASK32(UART_CTRL_REG_OFFSET, {{UART_CTRL_LLPBK, 0x1, true}});
+  result =
+      dif_uart_loopback_set(&dif_uart_, kDifUartLoopbackLine, kDifUartEnable);
+  EXPECT_EQ(result, kDifUartOk);
+
+  EXPECT_MASK32(UART_CTRL_REG_OFFSET, {{UART_CTRL_LLPBK, 0x1, false}});
+  result =
+      dif_uart_loopback_set(&dif_uart_, kDifUartLoopbackLine, kDifUartDisable);
+  EXPECT_EQ(result, kDifUartOk);
+}
+
 }  // namespace
 }  // namespace dif_uart_unittest

--- a/sw/device/tests/dif/meson.build
+++ b/sw/device/tests/dif/meson.build
@@ -114,4 +114,19 @@ dif_plic_sanitytest_lib = declare_dependency(
   ),
 )
 
-sw_tests += { 'dif_plic_sanitytest': dif_plic_sanitytest_lib }
+dif_uart_sanitytest_lib = declare_dependency(
+  link_with: static_library(
+    'dif_uart_sanitytest_lib',
+    sources: ['dif_uart_sanitytest.c'],
+    dependencies: [
+      dif_uart,
+      sw_lib_mmio,
+      sw_lib_runtime_hart,
+    ],
+  ),
+)
+
+sw_tests += {
+  'dif_plic_sanitytest': dif_plic_sanitytest_lib,
+  'dif_uart_sanitytest': dif_uart_sanitytest_lib,
+}


### PR DESCRIPTION
Closes #2427.

Adds new API to dif_uart that are useful for sanity test, and creates a sanity test, which is then used in chip level DV tests and verilator.

Please see the mentioned issue above, and the commit descriptions for more information.

Turned out to be a bigger change than I initially expected.