### PR TITLE
[aes:testplan] Removed interrupt test from aes regression

### DIFF
--- a/hw/ip/aes/dv/aes_sim_cfg.hjson
+++ b/hw/ip/aes/dv/aes_sim_cfg.hjson
@@ -30,7 +30,6 @@
                 "{proj_root}/hw/ip/aes/model/aes_model_sim_opts.hjson",
                 // Common CIP test lists
                 "{proj_root}/hw/dv/data/tests/csr_tests.hjson",
-                "{proj_root}/hw/dv/data/tests/intr_test.hjson",
                 "{proj_root}/hw/dv/data/tests/tl_access_tests.hjson"]
                 // TODO: enable stress tests later.
                 // "{proj_root}/hw/dv/data/tests/stress_tests.hjson"]


### PR DESCRIPTION
Very small PR that removes the interrupt test from the AES nightly regressions.
as AES does not have any interrupts