### PR TITLE
[rtl] Change instance name of reg module to u_reg

### DIFF
--- a/hw/ip/aes/rtl/aes.sv
+++ b/hw/ip/aes/rtl/aes.sv
@@ -39,7 +39,7 @@ module aes #(
   logic        prng_reseed_req;
   logic        prng_reseed_ack;
 
-  aes_reg_top aes_reg_top (
+  aes_reg_top u_reg (
     .clk_i,
     .rst_ni,
     .tl_i,

--- a/hw/ip/alert_handler/rtl/alert_handler_reg_wrap.sv
+++ b/hw/ip/alert_handler/rtl/alert_handler_reg_wrap.sv
@@ -29,7 +29,7 @@ module alert_handler_reg_wrap import alert_pkg::*; (
   alert_handler_reg_pkg::alert_handler_reg2hw_t reg2hw;
   alert_handler_reg_pkg::alert_handler_hw2reg_t hw2reg;
 
-  alert_handler_reg_top i_reg (
+  alert_handler_reg_top u_reg (
     .clk_i,
     .rst_ni,
     .tl_i,

--- a/hw/ip/clkmgr/data/clkmgr.sv.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.sv.tpl
@@ -52,7 +52,7 @@ module clkmgr import clkmgr_pkg::*; (
   clkmgr_reg_pkg::clkmgr_reg2hw_t reg2hw;
   clkmgr_reg_pkg::clkmgr_hw2reg_t hw2reg;
 
-  clkmgr_reg_top i_reg (
+  clkmgr_reg_top u_reg (
     .clk_i,
     .rst_ni,
     .tl_i,

--- a/hw/ip/clkmgr/rtl/clkmgr.sv
+++ b/hw/ip/clkmgr/rtl/clkmgr.sv
@@ -45,7 +45,7 @@ module clkmgr import clkmgr_pkg::*; (
   clkmgr_reg_pkg::clkmgr_reg2hw_t reg2hw;
   clkmgr_reg_pkg::clkmgr_hw2reg_t hw2reg;
 
-  clkmgr_reg_top i_reg (
+  clkmgr_reg_top u_reg (
     .clk_i,
     .rst_ni,
     .tl_i,

--- a/hw/ip/entropy_src/rtl/entropy_src.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src.sv
@@ -38,7 +38,7 @@ module entropy_src import entropy_src_pkg::*; #(
   entropy_src_reg2hw_t reg2hw;
   entropy_src_hw2reg_t hw2reg;
 
-  entropy_src_reg_top u_entropy_src_reg_top (
+  entropy_src_reg_top u_reg (
     .clk_i,
     .rst_ni,
     .tl_i,

--- a/hw/ip/nmi_gen/rtl/nmi_gen.sv
+++ b/hw/ip/nmi_gen/rtl/nmi_gen.sv
@@ -35,7 +35,7 @@ module nmi_gen
   nmi_gen_reg_pkg::nmi_gen_reg2hw_t reg2hw;
   nmi_gen_reg_pkg::nmi_gen_hw2reg_t hw2reg;
 
-  nmi_gen_reg_top i_reg (
+  nmi_gen_reg_top u_reg (
     .clk_i,
     .rst_ni,
     .tl_i,

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
@@ -50,7 +50,7 @@ module otp_ctrl
   otp_ctrl_reg_pkg::otp_ctrl_reg2hw_t reg2hw;
   otp_ctrl_reg_pkg::otp_ctrl_hw2reg_t hw2reg;
 
-  otp_ctrl_reg_top i_otp_ctrl_reg_top (
+  otp_ctrl_reg_top u_reg (
     .clk_i ,
     .rst_ni,
     .tl_i,

--- a/hw/ip/padctrl/rtl/padctrl.sv
+++ b/hw/ip/padctrl/rtl/padctrl.sv
@@ -52,7 +52,7 @@ module padctrl import padctrl_reg_pkg::*; #(
   padctrl_reg2hw_t reg2hw;
   padctrl_hw2reg_t hw2reg;
 
-  padctrl_reg_top i_reg_top (
+  padctrl_reg_top u_reg (
     .clk_i  ,
     .rst_ni ,
     .tl_i   ,

--- a/hw/ip/pinmux/rtl/pinmux.sv
+++ b/hw/ip/pinmux/rtl/pinmux.sv
@@ -64,7 +64,7 @@ module pinmux import pinmux_pkg::*; import pinmux_reg_pkg::*; (
   pinmux_reg2hw_t reg2hw;
   pinmux_hw2reg_t hw2reg;
 
-  pinmux_reg_top i_reg_top (
+  pinmux_reg_top u_reg (
     .clk_i  ,
     .rst_ni ,
     .tl_i   ,

--- a/hw/ip/pwrmgr/rtl/pwrmgr.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr.sv
@@ -104,7 +104,7 @@ module pwrmgr import pwrmgr_pkg::*;
   logic wkup;
   logic clr_cfg_lock;
 
-  pwrmgr_reg_top i_reg (
+  pwrmgr_reg_top u_reg (
     .clk_i,
     .rst_ni,
     .tl_i,

--- a/hw/ip/rstmgr/rtl/rstmgr.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr.sv
@@ -88,7 +88,7 @@ module rstmgr import rstmgr_pkg::*; (
   rstmgr_reg_pkg::rstmgr_reg2hw_t reg2hw;
   rstmgr_reg_pkg::rstmgr_hw2reg_t hw2reg;
 
-  rstmgr_reg_top i_reg (
+  rstmgr_reg_top u_reg (
     .clk_i,
     .rst_ni(resets_o.rst_por_aon_n),
     .tl_i,

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
@@ -56,7 +56,7 @@ module clkmgr import clkmgr_pkg::*; (
   clkmgr_reg_pkg::clkmgr_reg2hw_t reg2hw;
   clkmgr_reg_pkg::clkmgr_hw2reg_t hw2reg;
 
-  clkmgr_reg_top i_reg (
+  clkmgr_reg_top u_reg (
     .clk_i,
     .rst_ni,
     .tl_i,


### PR DESCRIPTION
Apply this change to all IPs for backdoor access support.
Refer to #2406 for detail

Signed-off-by: Weicai Yang <weicai@google.com>