### PR TITLE
[sw, tests] Initialise UART and print after the test

### DIFF
--- a/sw/device/lib/testing/test_main.c
+++ b/sw/device/lib/testing/test_main.c
@@ -10,6 +10,9 @@
 #include "sw/device/lib/testing/test_status.h"
 #include "sw/device/lib/uart.h"
 
+// Must be set to `true` in any test that reconfigures UART.
+bool uart_reconfigure_required = false;
+
 int main(int argc, char **argv) {
   test_status_set(kTestStatusInTest);
 
@@ -21,6 +24,12 @@ int main(int argc, char **argv) {
 
   // Run the SW test which is fully contained within `test_main()`.
   bool result = test_main();
+
+  // Must happen before any debug output.
+  if (uart_reconfigure_required) {
+    uart_init(kUartBaudrate);
+  }
+
   test_status_set(result ? kTestStatusPassed : kTestStatusFailed);
 
   // Unreachable code.

--- a/sw/device/lib/testing/test_main.h
+++ b/sw/device/lib/testing/test_main.h
@@ -23,4 +23,12 @@
  */
 extern bool test_main(void);
 
+/**
+ * This flag should be defined in the test runner with the default value,
+ * which then can be overriden by individual tests when required. For example,
+ * when a test configures UART to non-standard settings for internal use, the
+ * flag has to be set to `true` in such test.
+ */
+extern bool uart_reconfigure_required;
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_MAIN_H_


### PR DESCRIPTION
Some unittests might require to configure UART
differently (`dif_plic_sanitytest`, `dif_uart_sanitytest`). This means
that the test framework cannot rely on the UART configuration after a
test has finished.

This change moves initialisation from pre-test to post test in
`tests/main.c`, which ensures that UART is initialised correctly.

This issue was discovered in #2442.