### PR TITLE
[sw] Correct Test Target Name

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -98,6 +98,14 @@
   ]
 
   // List of test specifications.
+  //
+  // If you are adding a test that has been generated from the `sw_tests`
+  // dictionary declared in `sw/device/tests/meson.build`, the `sw_test` key
+  // below should contain `sw/device/tests/<sw_test_name>` (without any more
+  // subdirectories) because that is where the meson target is created. For
+  // example `dif_plic_sanitytest` is added to `sw_tests` in
+  // `sw/device/tests/dif/meson.build`, but the final meson targets all start
+  // `sw/device/tests/dif_plic_sanitytest_`.
   tests: [
     {
       name: chip_uart_tx_rx
@@ -112,7 +120,7 @@
     {
       name: chip_dif_plic_sanitytest
       uvm_test_seq: chip_sw_base_vseq
-      sw_test: sw/device/tests/dif/dif_plic_sanitytest
+      sw_test: sw/device/tests/dif_plic_sanitytest
     }
     {
       name: chip_flash_ctrl_test

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -2,7 +2,13 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-sw_tests = {}
+# All tests added to this dictionary will result in build targets that have
+# names starting `sw/device/tests/<test_name>`. They will not contain the
+# subdirectory name, because the build targets are really declared at the bottom
+# of this file, rather than in the subdirectories.
+sw_tests = {
+  # 'test_name': test_lib,
+}
 
 subdir('dif')
 subdir('sim_dv')


### PR DESCRIPTION
The target name was noted as incorrect by @sriyerg in a post-commit
review of #2424.

After investigation, I have added some documentation to both the DV
configuration file and the meson configuration file so that hopefully we
are not caught out by the same problem again.