### PR TITLE
[dv] Move mem checking to scb

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env.sv
@@ -57,10 +57,8 @@ class cip_base_env #(type CFG_T               = cip_base_env_cfg,
 
   virtual function void connect_phase(uvm_phase phase);
     super.connect_phase(phase);
-    if (cfg.en_scb) begin
-      m_tl_agent.monitor.a_chan_port.connect(scoreboard.tl_a_chan_fifo.analysis_export);
-      m_tl_agent.monitor.d_chan_port.connect(scoreboard.tl_d_chan_fifo.analysis_export);
-    end
+    m_tl_agent.monitor.a_chan_port.connect(scoreboard.tl_a_chan_fifo.analysis_export);
+    m_tl_agent.monitor.d_chan_port.connect(scoreboard.tl_d_chan_fifo.analysis_export);
     if (cfg.is_active) begin
       virtual_sequencer.tl_sequencer_h = m_tl_agent.sequencer;
     end

--- a/hw/dv/sv/cip_lib/cip_base_pkg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_pkg.sv
@@ -12,6 +12,7 @@ package cip_base_pkg;
   import dv_base_reg_pkg::*;
   import tl_agent_pkg::*;
   import alert_esc_agent_pkg::*;
+  import mem_model_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"

--- a/hw/dv/sv/cip_lib/cip_lib.core
+++ b/hw/dv/sv/cip_lib/cip_lib.core
@@ -12,6 +12,7 @@ filesets:
       - lowrisc:dv:tl_agent
       - lowrisc:dv:alert_esc_agent
       - lowrisc:dv:dv_base_reg
+      - lowrisc:dv:mem_model
     files:
       - cip_base_pkg.sv
       - cip_base_env_cfg.sv: {is_include_file: true}

--- a/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
+++ b/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
@@ -6,6 +6,8 @@ class dv_base_env_cfg #(type RAL_T = dv_base_reg_block) extends uvm_object;
 
   bit                   is_active    = 1;
   bit                   en_scb       = 1; // can be changed at run-time
+  bit                   en_scb_tl_err_chk = 1;
+  bit                   en_scb_mem_chk    = 1;
   bit                   en_cov       = 1;
   bit                   has_ral      = 1;
   bit                   under_reset  = 0;

--- a/hw/dv/sv/dv_lib/dv_base_test.sv
+++ b/hw/dv/sv/dv_lib/dv_base_test.sv
@@ -32,6 +32,8 @@ class dv_base_test #(type CFG_T = dv_base_env_cfg,
 
     // knob to en/dis scb (enabled by default)
     void'($value$plusargs("en_scb=%0b", cfg.en_scb));
+    void'($value$plusargs("en_scb_tl_err_chk=%0b", cfg.en_scb_tl_err_chk));
+    void'($value$plusargs("en_scb_mem_chk=%0b", cfg.en_scb_mem_chk));
     // knob to cfg all agents with zero delays
     void'($value$plusargs("zero_delays=%0b", cfg.zero_delays));
   endfunction : build_phase

--- a/hw/dv/sv/mem_model/mem_model.sv
+++ b/hw/dv/sv/mem_model/mem_model.sv
@@ -3,55 +3,83 @@
 // SPDX-License-Identifier: Apache-2.0
 
 class mem_model #(int AddrWidth = top_pkg::TL_AW,
-                 int DataWidth = top_pkg::TL_DW) extends uvm_object;
+                  int DataWidth = top_pkg::TL_DW,
+                  int MaskWidth = top_pkg::TL_DBW) extends uvm_object;
 
   typedef bit [AddrWidth-1:0] mem_addr_t;
   typedef bit [DataWidth-1:0] mem_data_t;
+  typedef bit [MaskWidth-1:0] mem_mask_t;
 
   bit [7:0] system_memory[mem_addr_t];
 
   `uvm_object_param_utils(mem_model#(AddrWidth, DataWidth))
 
-  function new(string name="");
-    super.new(name);
+  `uvm_object_new
+
+  function int get_written_bytes();
+    return system_memory.size();
   endfunction
 
   function bit [7:0] read_byte(mem_addr_t addr);
     bit [7:0] data;
     if (system_memory.exists(addr)) begin
       data = system_memory[addr];
-      `uvm_info(get_full_name(),
-                $sformatf("Read Mem  : Addr[0x%0h], Data[0x%0h]", addr, data), UVM_HIGH)
-    end
-    else begin
+      `uvm_info(`gfn, $sformatf("Read Mem  : Addr[0x%0h], Data[0x%0h]", addr, data), UVM_HIGH)
+    end else begin
       `DV_CHECK_STD_RANDOMIZE_FATAL(data)
-      `uvm_error(get_full_name(), $sformatf("read to uninitialzed addr 0x%0h", addr))
+      `uvm_error(`gfn, $sformatf("read to uninitialzed addr 0x%0h", addr))
     end
     return data;
   endfunction
 
   function void write_byte(mem_addr_t addr, bit [7:0] data);
-   `uvm_info(get_full_name(),
-             $sformatf("Write Mem : Addr[0x%0h], Data[0x%0h]", addr, data), UVM_HIGH)
+   `uvm_info(`gfn, $sformatf("Write Mem : Addr[0x%0h], Data[0x%0h]", addr, data), UVM_HIGH)
     system_memory[addr] = data;
   endfunction
 
-  function void write(input mem_addr_t addr, mem_data_t data);
+  function void compare_byte(mem_addr_t addr, bit [7:0] act_data);
+   `uvm_info(`gfn, $sformatf("Compare Mem : Addr[0x%0h], Act Data[0x%0h], Exp Data[0x%0h]",
+                             addr, act_data, system_memory[addr]), UVM_HIGH)
+    system_memory[addr] = act_data;
+    `DV_CHECK_EQ(act_data, system_memory[addr], $sformatf("addr 0x%0h read out mismatch", addr))
+  endfunction
+
+  function void write(input mem_addr_t addr, mem_data_t data, mem_mask_t mask = '1);
     bit [7:0] byte_data;
     for (int i = 0; i < DataWidth / 8; i++) begin
-      byte_data = data[7:0];
-      write_byte(addr + i, byte_data);
+      if (mask[0]) begin
+        byte_data = data[7:0];
+        write_byte(addr + i, byte_data);
+      end
       data = data >> 8;
+      mask = mask >> 1;
     end
   endfunction
 
-  function mem_data_t read(mem_addr_t addr);
+  function mem_data_t read(mem_addr_t addr, mem_mask_t mask = '1);
     mem_data_t data;
     for (int i = DataWidth / 8 - 1; i >= 0; i--) begin
       data = data << 8;
-      data[7:0] = read_byte(addr + i);
+      if (mask[MaskWidth - 1]) data[7:0] = read_byte(addr + i);
+      else                     data[7:0] = 0;
+      mask = mask << 1;
     end
     return data;
+  endfunction
+
+  function void compare(mem_addr_t addr, mem_data_t act_data, mem_mask_t mask = '1);
+    bit [7:0] byte_data;
+    for (int i = 0; i < DataWidth / 8; i++) begin
+      byte_data = act_data[7:0];
+      if (mask[0]) begin
+        compare_byte(addr + i, byte_data);
+      end else begin
+        `DV_CHECK_EQ(byte_data, 0,
+                     $sformatf("addr 0x%0h masked data aren't 0, mask 0x%0h", addr, mask))
+      end
+      act_data = act_data>> 8;
+      mask = mask >> 1;
+    end
   endfunction
 
 endclass


### PR DESCRIPTION
1. Move mem checking from cip_base_vseq to scb and use mem_model
2. Use separate switches to enable/disable tl_err checking and mem
checking
3. Add mask support and compare function in mem_model

Signed-off-by: Weicai Yang <weicai@google.com>