### PR TITLE
[i2c, dv] Updates for both i2c_agent and i2c_sanity

### DIFF
--- a/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
+++ b/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
@@ -4,13 +4,28 @@
 
 class i2c_agent_cfg extends dv_base_agent_cfg;
 
-  bit en_monitor  = 1'b1; // enable monitor
+  bit en_monitor = 1'b1; // enable monitor
+  i2c_target_addr_mode_e target_addr_mode = Addr7BitMode;
 
   timing_cfg_t    timing_cfg;
+
   virtual i2c_if  vif;
 
   `uvm_object_utils_begin(i2c_agent_cfg)
-    `uvm_field_int(en_monitor,    UVM_DEFAULT)
+    `uvm_field_int(en_monitor,                                UVM_DEFAULT)
+    `uvm_field_enum(i2c_target_addr_mode_e, target_addr_mode, UVM_DEFAULT)
+    `uvm_field_int(timing_cfg.tSetupStart,                    UVM_DEFAULT)
+    `uvm_field_int(timing_cfg.tHoldStart,                     UVM_DEFAULT)
+    `uvm_field_int(timing_cfg.tClockStart,                    UVM_DEFAULT)
+    `uvm_field_int(timing_cfg.tClockLow,                      UVM_DEFAULT)
+    `uvm_field_int(timing_cfg.tSetupBit,                      UVM_DEFAULT)
+    `uvm_field_int(timing_cfg.tClockPulse,                    UVM_DEFAULT)
+    `uvm_field_int(timing_cfg.tHoldBit,                       UVM_DEFAULT)
+    `uvm_field_int(timing_cfg.tClockStop,                     UVM_DEFAULT)
+    `uvm_field_int(timing_cfg.tSetupStop,                     UVM_DEFAULT)
+    `uvm_field_int(timing_cfg.tHoldStop,                      UVM_DEFAULT)
+    `uvm_field_int(timing_cfg.tTimeOut,                       UVM_DEFAULT)
+    `uvm_field_int(timing_cfg.enbTimeOut,                     UVM_DEFAULT)
   `uvm_object_utils_end
 
   `uvm_object_new

--- a/hw/dv/sv/i2c_agent/i2c_agent_pkg.sv
+++ b/hw/dv/sv/i2c_agent/i2c_agent_pkg.sv
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+// I2C specification: https://www.nxp.com/docs/en/user-guide/UM10204.pdf
+
 package i2c_agent_pkg;
   // dep packages
   import uvm_pkg::*;
@@ -11,10 +13,6 @@ package i2c_agent_pkg;
   // macro includes
   `include "uvm_macros.svh"
   `include "dv_macros.svh"
-
-  // local macros
-  parameter uint I2C_ADDR_WIDTH = 7;
-  parameter uint I2C_DATA_WIDTH = 8;
 
   typedef enum logic [3:0] {
     None, DevAck, RdData
@@ -36,6 +34,11 @@ package i2c_agent_pkg;
     bit         enbTimeOut;
     bit [30:0]  tTimeOut;
   } timing_cfg_t;
+
+  typedef enum int {
+    Addr7BitMode  = 7,
+    Addr10BitMode = 10
+  } i2c_target_addr_mode_e;
 
   // forward declare classes to allow typedefs below
   typedef class i2c_item;

--- a/hw/dv/sv/i2c_agent/i2c_device_driver.sv
+++ b/hw/dv/sv/i2c_agent/i2c_device_driver.sv
@@ -6,11 +6,9 @@ class i2c_device_driver extends i2c_driver;
   `uvm_component_utils(i2c_device_driver)
   `uvm_component_new
 
-  bit [I2C_DATA_WIDTH-1:0] data;
+  rand bit [7:0] rd_data;
 
-  rand bit [I2C_DATA_WIDTH-1:0] rd_data;
-
-  constraint rd_data_c { rd_data inside {[0 : ((1 << I2C_DATA_WIDTH) - 1)]}; }
+  constraint rd_data_c { rd_data inside {[0 : 127]}; }
 
   virtual task get_and_drive();
     i2c_item rsp_item;
@@ -26,7 +24,7 @@ class i2c_device_driver extends i2c_driver;
         end
         RdData: begin
           `DV_CHECK_MEMBER_RANDOMIZE_FATAL(rd_data)
-          for (int i = I2C_DATA_WIDTH-1; i >= 0; i--) begin
+          for (int i = 7; i >= 0; i--) begin
             cfg.vif.device_send_bit(cfg.timing_cfg, rd_data[i]);
           end
           `uvm_info(`gfn, $sformatf("driver, trans %0d, byte %0d  %0b",

--- a/hw/dv/sv/i2c_agent/i2c_if.sv
+++ b/hw/dv/sv/i2c_agent/i2c_if.sv
@@ -21,7 +21,7 @@ interface i2c_if;
     repeat (dly) @(posedge clk_i);
   endtask : wait_for_dly
 
-  task automatic wait_for_host_start(timing_cfg_t tc);
+  task automatic wait_for_host_start(ref timing_cfg_t tc);
     forever begin
       @(negedge sda_i);
       wait_for_dly(tc.tHoldStart);
@@ -31,8 +31,8 @@ interface i2c_if;
     end
   endtask: wait_for_host_start
 
-  task automatic wait_for_host_rstart(timing_cfg_t tc,
-                                      output bit   rstart);
+  task automatic wait_for_host_rstart(ref timing_cfg_t tc,
+                                      output bit rstart);
     rstart = 1'b0;
     forever begin
       @(posedge scl_i && sda_i);
@@ -48,8 +48,8 @@ interface i2c_if;
     end
   endtask: wait_for_host_rstart
 
-  task automatic wait_for_host_stop(timing_cfg_t tc,
-                                    output bit   stop);
+  task automatic wait_for_host_stop(ref timing_cfg_t tc,
+                                    output bit stop);
     stop = 1'b0;
     forever begin
       @(posedge scl_i);
@@ -76,7 +76,7 @@ interface i2c_if;
     join
   endtask: wait_for_host_stop_or_rstart
 
-  task automatic wait_for_host_ack(timing_cfg_t tc);
+  task automatic wait_for_host_ack(ref timing_cfg_t tc);
     @(negedge sda_i);
     wait_for_dly(tc.tClockLow + tc.tSetupBit);
     forever begin
@@ -89,7 +89,7 @@ interface i2c_if;
     wait_for_dly(tc.tHoldBit);
   endtask: wait_for_host_ack
 
-  task automatic wait_for_host_nack(timing_cfg_t tc);
+  task automatic wait_for_host_nack(ref timing_cfg_t tc);
     @(negedge sda_i);
     wait_for_dly(tc.tClockLow + tc.tSetupBit);
     forever begin
@@ -124,7 +124,7 @@ interface i2c_if;
     join
   endtask: wait_for_host_ack_or_nack
 
-  task automatic wait_for_device_ack(timing_cfg_t tc);
+  task automatic wait_for_device_ack(ref timing_cfg_t tc);
     @(negedge sda_o && scl_o);
     wait_for_dly(tc.tSetupBit);
     forever begin
@@ -137,8 +137,10 @@ interface i2c_if;
     wait_for_dly(tc.tHoldBit);
   endtask: wait_for_device_ack
 
-  task automatic device_send_ack(timing_cfg_t tc);
+  task automatic device_send_ack(ref timing_cfg_t tc);
     device_stretch_clk(tc);
+    sda_o = 1'b1;
+    wait_for_dly(tc.tClockLow);
     sda_o = 1'b0;
     wait_for_dly(tc.tSetupBit);
     @(posedge scl_i);
@@ -146,8 +148,9 @@ interface i2c_if;
     sda_o = 1'b1;
   endtask: device_send_ack
 
-  task automatic device_send_bit(timing_cfg_t tc,
-                                 bit          bit_i);
+  task automatic device_send_bit(ref timing_cfg_t tc,
+                                 input bit bit_i);
+    device_stretch_clk(tc);
     sda_o = 1'b1;
     wait_for_dly(tc.tClockLow);
     sda_o = bit_i;
@@ -157,7 +160,7 @@ interface i2c_if;
     sda_o = 1'b1;
   endtask: device_send_bit
 
-  task automatic device_stretch_clk(timing_cfg_t tc);
+  task automatic device_stretch_clk(ref timing_cfg_t tc);
     if (tc.enbTimeOut) begin
       scl_o = 1'b0;
       wait_for_dly(tc.tTimeOut);
@@ -165,9 +168,9 @@ interface i2c_if;
     end
   endtask : device_stretch_clk
 
-  task automatic get_bit_data(string       src = "host",
-                              timing_cfg_t tc,
-                              output bit   bit_o); 
+  task automatic get_bit_data(string src = "host",
+                              ref timing_cfg_t tc,
+                              output bit bit_o);
     wait_for_dly(tc.tClockLow + tc.tSetupBit);
     @(posedge scl_i);
     bit_o = (src == "host") ? sda_i : sda_o;

--- a/hw/dv/sv/i2c_agent/i2c_item.sv
+++ b/hw/dv/sv/i2c_agent/i2c_item.sv
@@ -5,8 +5,8 @@
 class i2c_item extends uvm_sequence_item;
 
   // transaction data part
-  bit [I2C_DATA_WIDTH-1:0] data_q[$];
-  bit [I2C_ADDR_WIDTH-1:0] addr;
+  bit [7:0]                data_q[$];
+  bit [9:0]                addr; // enough to support both 7 & 10-bit target address
   int                      tran_id;
   int                      num_data;
   bus_op_e                 bus_op;

--- a/hw/dv/sv/i2c_agent/i2c_monitor.sv
+++ b/hw/dv/sv/i2c_agent/i2c_monitor.sv
@@ -13,8 +13,8 @@ class i2c_monitor extends dv_base_monitor #(
   uvm_analysis_port #(i2c_item) wr_item_port;   // used to send complete wr_tran to sb
   uvm_analysis_port #(i2c_item) rd_item_port;   // used to send complete rd_tran to sb
 
-  local bit [I2C_DATA_WIDTH-1:0] mon_data;
-  local uint num_dut_tran;
+  local bit [7:0] mon_data;
+  local uint      num_dut_tran = 0;
   `uvm_component_new
 
   function void build_phase(uvm_phase phase);
@@ -22,7 +22,6 @@ class i2c_monitor extends dv_base_monitor #(
     mon_item_port = new("mon_item_port", this);
     wr_item_port  = new("wr_item_port", this);
     rd_item_port  = new("rd_item_port", this);
-    num_dut_tran  = 0;
   endfunction : build_phase
 
   virtual task wait_for_reset_done();
@@ -39,92 +38,93 @@ class i2c_monitor extends dv_base_monitor #(
   // collect transactions forever
   virtual protected task collect_thread(uvm_phase phase);
     i2c_item   complete_item;
-    i2c_item   partial_item;
+    i2c_item   mon_dut_item;
 
-    partial_item = i2c_item::type_id::create("partial_item", this);
+    mon_dut_item = i2c_item::type_id::create("mon_dut_item", this);
     forever begin
       if (cfg.en_monitor == 1'b1) begin
-        if (partial_item.stop || (!partial_item.stop && !partial_item.start && !partial_item.rstart)) begin
+        if (mon_dut_item.stop || (!mon_dut_item.stop && !mon_dut_item.start && !mon_dut_item.rstart)) begin
           cfg.vif.wait_for_host_start(cfg.timing_cfg);
           `uvm_info(`gfn, $sformatf("monitor, detect HOST START"), UVM_DEBUG)
         end else begin
-          partial_item.rstart = 1'b1;
+          mon_dut_item.rstart = 1'b1;
         end
         num_dut_tran++;
-        partial_item.start = 1'b1;
+        mon_dut_item.start = 1'b1;
         // issue address then rd/wr data
-        address_thread(partial_item, num_dut_tran);
-        if (partial_item.bus_op == BusOpRead) read_thread(partial_item);
-        else                              write_thread(partial_item);
+        address_thread(mon_dut_item, num_dut_tran);
+        if (mon_dut_item.bus_op == BusOpRead) read_thread(mon_dut_item);
+        else                                  write_thread(mon_dut_item);
         // send rsp_item to scoreboard
-        `downcast(complete_item, partial_item.clone());
+        `downcast(complete_item, mon_dut_item.clone());
         complete_item.stop = 1'b1;
         if (complete_item.bus_op == BusOpRead) rd_item_port.write(complete_item);
-        else                                 wr_item_port.write(complete_item);
-        `uvm_info(`gfn, $sformatf("\nmonitor, complete_item\n%s", complete_item.sprint()), UVM_DEBUG)
-        partial_item.clear_data();
+        else                                   wr_item_port.write(complete_item);
+        `uvm_info(`gfn, $sformatf("\nmonitor, complete_item\n%s",
+            complete_item.sprint()), UVM_DEBUG)
+        mon_dut_item.clear_data();
       end begin
         @(cfg.vif.clk_i);
       end
     end
   endtask: collect_thread
 
-  virtual protected task address_thread(i2c_item partial_item, uint id);
+  virtual protected task address_thread(i2c_item mon_dut_item, uint id);
     i2c_item clone_item;
     bit rw_req = 1'b0;
-    
+
     // sample address and r/w bit
-    partial_item.tran_id = id;
-    for (int i = I2C_ADDR_WIDTH-1; i >= 0; i--) begin
-      cfg.vif.get_bit_data("host", cfg.timing_cfg, partial_item.addr[i]);
+    mon_dut_item.tran_id = id;
+    for (int i = cfg.target_addr_mode - 1; i >= 0; i--) begin
+      cfg.vif.get_bit_data("host", cfg.timing_cfg, mon_dut_item.addr[i]);
     end
     cfg.vif.get_bit_data("host", cfg.timing_cfg, rw_req);
-    partial_item.bus_op = (rw_req) ? BusOpRead : BusOpWrite;
+    mon_dut_item.bus_op = (rw_req) ? BusOpRead : BusOpWrite;
     // get ack after transmitting address
-    partial_item.drv_type = DevAck;
-    `downcast(clone_item, partial_item.clone());
+    mon_dut_item.drv_type = DevAck;
+    `downcast(clone_item, mon_dut_item.clone());
     mon_item_port.write(clone_item);
     cfg.vif.wait_for_device_ack(cfg.timing_cfg);
     `uvm_info(`gfn, $sformatf("monitor, address, detect TARGET ACK"), UVM_DEBUG)
   endtask : address_thread
 
-  virtual protected task read_thread(i2c_item partial_item);
+  virtual protected task read_thread(i2c_item mon_dut_item);
     i2c_item clone_item;
     
-    partial_item.stop   = 1'b0;
-    partial_item.rstart = 1'b0;
-    partial_item.ack    = 1'b0;
-    partial_item.nack   = 1'b0;
-    while (!partial_item.stop && !partial_item.rstart) begin
+    mon_dut_item.stop   = 1'b0;
+    mon_dut_item.rstart = 1'b0;
+    mon_dut_item.ack    = 1'b0;
+    mon_dut_item.nack   = 1'b0;
+    while (!mon_dut_item.stop && !mon_dut_item.rstart) begin
       fork
         begin : iso_fork_read
           fork
             begin
               // ask driver response read data
-              partial_item.drv_type = RdData;
-              `downcast(clone_item, partial_item.clone());
+              mon_dut_item.drv_type = RdData;
+              `downcast(clone_item, mon_dut_item.clone());
               mon_item_port.write(clone_item);
               // sample read data
-              for (int i = I2C_DATA_WIDTH-1; i >= 0; i--) begin
+              for (int i = 7; i >= 0; i--) begin
                 cfg.vif.get_bit_data("device", cfg.timing_cfg, mon_data[i]);
                 `uvm_info(`gfn, $sformatf("monitor, rd_data, trans %0d, byte %0d, bit[%0d] %0b",
-                    partial_item.tran_id, partial_item.num_data+1, i, mon_data[i]), UVM_DEBUG)
+                    mon_dut_item.tran_id, mon_dut_item.num_data+1, i, mon_data[i]), UVM_DEBUG)
               end
-              partial_item.data_q.push_back(mon_data);
-              partial_item.num_data++;
+              mon_dut_item.data_q.push_back(mon_data);
+              mon_dut_item.num_data++;
               // sample host ack/nack (in the last byte, nack can be issue if rcont is set)
-              cfg.vif.wait_for_host_ack_or_nack(cfg.timing_cfg, partial_item.ack, partial_item.nack);
-              `DV_CHECK_NE_FATAL({partial_item.ack, partial_item.nack}, 2'b11)
+              cfg.vif.wait_for_host_ack_or_nack(cfg.timing_cfg, mon_dut_item.ack, mon_dut_item.nack);
+              `DV_CHECK_NE_FATAL({mon_dut_item.ack, mon_dut_item.nack}, 2'b11)
               `uvm_info(`gfn, $sformatf("monitor, detect HOST %s",
-                  (partial_item.ack) ? "ACK" : "NO_ACK"), UVM_DEBUG)
+                  (mon_dut_item.ack) ? "ACK" : "NO_ACK"), UVM_DEBUG)
             end
             begin
               cfg.vif.wait_for_host_stop_or_rstart(cfg.timing_cfg,
-                                                   partial_item.rstart,
-                                                   partial_item.stop);
-              `DV_CHECK_NE_FATAL({partial_item.rstart, partial_item.stop}, 2'b11)
+                                                   mon_dut_item.rstart,
+                                                   mon_dut_item.stop);
+              `DV_CHECK_NE_FATAL({mon_dut_item.rstart, mon_dut_item.stop}, 2'b11)
               `uvm_info(`gfn, $sformatf("monitor, rd_data, detect HOST %s",
-                  (partial_item.stop) ? "STOP" : "RSTART"), UVM_DEBUG)
+                  (mon_dut_item.stop) ? "STOP" : "RSTART"), UVM_DEBUG)
             end
           join_any
           disable fork;
@@ -133,34 +133,34 @@ class i2c_monitor extends dv_base_monitor #(
     end
   endtask : read_thread
 
-  virtual protected task write_thread(i2c_item partial_item);
+  virtual protected task write_thread(i2c_item mon_dut_item);
     i2c_item clone_item;
 
-    partial_item.stop   = 1'b0;
-    partial_item.rstart = 1'b0;
-    while (!partial_item.stop && !partial_item.rstart) begin
+    mon_dut_item.stop   = 1'b0;
+    mon_dut_item.rstart = 1'b0;
+    while (!mon_dut_item.stop && !mon_dut_item.rstart) begin
       fork
         begin : iso_fork_write
           fork
             begin
               // ask driver's response a write request
-              for (int i = I2C_DATA_WIDTH-1; i >= 0; i--) begin
+              for (int i = 7; i >= 0; i--) begin
                 cfg.vif.get_bit_data("host", cfg.timing_cfg, mon_data[i]);
               end
-              partial_item.num_data++;
-              partial_item.data_q.push_back(mon_data);
-              partial_item.drv_type = DevAck;
-              `downcast(clone_item, partial_item.clone());
+              mon_dut_item.num_data++;
+              mon_dut_item.data_q.push_back(mon_data);
+              mon_dut_item.drv_type = DevAck;
+              `downcast(clone_item, mon_dut_item.clone());
               mon_item_port.write(clone_item);
               cfg.vif.wait_for_device_ack(cfg.timing_cfg);
             end
             begin
               cfg.vif.wait_for_host_stop_or_rstart(cfg.timing_cfg,
-                                                   partial_item.rstart,
-                                                   partial_item.stop);
-              `DV_CHECK_NE_FATAL({partial_item.rstart, partial_item.stop}, 2'b11)
+                                                   mon_dut_item.rstart,
+                                                   mon_dut_item.stop);
+              `DV_CHECK_NE_FATAL({mon_dut_item.rstart, mon_dut_item.stop}, 2'b11)
               `uvm_info(`gfn, $sformatf("monitor, wr_data, detect HOST %s %0b",
-                  (partial_item.stop) ? "STOP" : "RSTART", partial_item.stop), UVM_DEBUG)
+                  (mon_dut_item.stop) ? "STOP" : "RSTART", mon_dut_item.stop), UVM_DEBUG)
             end
           join_any
           disable fork;
@@ -185,3 +185,4 @@ class i2c_monitor extends dv_base_monitor #(
 
   endtask : process_reset
 endclass : i2c_monitor
+

--- a/hw/ip/i2c/dv/env/i2c_env_cfg.sv
+++ b/hw/ip/i2c/dv/env/i2c_env_cfg.sv
@@ -4,6 +4,8 @@
 
 class i2c_env_cfg extends cip_base_env_cfg #(.RAL_T(i2c_reg_block));
 
+  i2c_target_addr_mode_e target_addr_mode = Addr7BitMode;
+
   // TODO: various knobs to enable certain routines
   bit do_rd_overflow  = 1'b0;
   bit do_wr_overflow  = 1'b0;

--- a/hw/ip/i2c/dv/env/i2c_env_pkg.sv
+++ b/hw/ip/i2c/dv/env/i2c_env_pkg.sv
@@ -47,7 +47,7 @@ package i2c_env_pkg;
   parameter uint I2C_MIN_TIMING  = 1;     // at least 1
   parameter uint I2C_MAX_TIMING  = 5;
   parameter uint I2C_TIME_RANGE  = I2C_MAX_TIMING - I2C_MIN_TIMING;
-  parameter uint I2C_TIMEOUT_ENB = 1;
+  parameter uint I2C_TIMEOUT_ENB = 0;  // TODO: temporaly disable
   parameter uint I2C_MIN_TIMEOUT = 1;
   parameter uint I2C_MAX_TIMEOUT = 2;
   parameter uint I2C_IDLE_TIME   = 1200;

--- a/hw/ip/i2c/dv/env/i2c_scoreboard.sv
+++ b/hw/ip/i2c/dv/env/i2c_scoreboard.sv
@@ -250,7 +250,7 @@ class i2c_scoreboard extends cip_base_scoreboard #(
     if (cfg.en_scb) begin
       str = {$sformatf("\n\n*** SCOREBOARD CHECK\n")};
       str = {str, $sformatf("    - Total checked trans   %0d\n", num_exp_tran)};
-      `uvm_info(`gfn, $sformatf("%s", str), UVM_LOW)
+      `uvm_info(`gfn, $sformatf("%s", str), UVM_DEBUG)
     end
   endfunction : report_phase
 


### PR DESCRIPTION
The main purpose of this PR is to support re-programming registers of DUT during i2c_sanity running (thus improving the coverage of a single test). In addition, some added tasks can be re-used for other tests (i.e. reset/restart, etc.). Minor changes have been made in i2c_agent_cfg to improve its reusability. Finally, redundant code and spaces are cleaned.

Signed-off-by: Tung Hoang <tung.hoang.290780@gmail.com>