### PR TITLE
Enable simulation with Metrics DSim

### DIFF
--- a/hw/dv/data/dsim/dsim.hjson
+++ b/hw/dv/data/dsim/dsim.hjson
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  build_cmd:  "{job_prefix} {DSIM_HOME}/bin/dsim"
-  run_cmd:    "{job_prefix} {DSIM_HOME}/bin/dsim"
+  build_cmd:  "{job_prefix} dsim"
+  run_cmd:    "{job_prefix} dsim"
 
   build_opts: [
                "-work {build_dir}/dsim_out",
@@ -21,7 +21,7 @@
                "+incdir+{build_dir}",
                // Suppress following DSim errors and warnings:
                //   EnumMustBePositive - UVM 1.2 violates this
-               "-suppress EnumMustBePositive -warn NeedExplicitStatic",
+               "-suppress EnumMustBePositive"
               ]
 
   run_opts:   [
@@ -41,7 +41,7 @@
 
   // TODO: refactor coverage configuration for DSim.
 
-  // Coverage related.
+  // COVERAGE related.
   cov_db_dir: "{scratch_path}/coverage/{build_mode}.vdb"
 
   // Individual test specific coverage data - this will be deleted if the test fails
@@ -96,14 +96,14 @@
       is_sim_mode: 1
       build_opts: [
                     "+acc+b"
-		   ]
+                  ]
       run_opts:   [
                     "-waves {wave_file}",
-		    // dsim.probe is currently undefined
+                    // dsim.probe is currently undefined
                     //"-wave-scope-specs {probe_file}",
                     // Dump unpacked structs and arrays.
                     "-dump-agg"
-                    ]
+                  ]
     }
     // TODO: support coverage mode
     // Note: no specific build or run options are required for dsim to produce functional

--- a/hw/dv/data/dsim/dsim.hjson
+++ b/hw/dv/data/dsim/dsim.hjson
@@ -21,7 +21,7 @@
                "+incdir+{build_dir}",
                // Suppress following DSim errors and warnings:
                //   EnumMustBePositive - UVM 1.2 violates this
-               "-suppress EnumMustBePositive",
+               "-suppress EnumMustBePositive -warn NeedExplicitStatic",
               ]
 
   run_opts:   [

--- a/hw/dv/data/dsim/dsim.hjson
+++ b/hw/dv/data/dsim/dsim.hjson
@@ -95,9 +95,12 @@
       name: dsim_waves
       is_sim_mode: 1
       build_opts: [
-                    "+acc+b",
+                    "+acc+b"
+		   ]
+      run_opts:   [
                     "-waves {wave_file}",
-                    "-wave-scope-specs {probe_file}",
+		    // dsim.probe is currently undefined
+                    //"-wave-scope-specs {probe_file}",
                     // Dump unpacked structs and arrays.
                     "-dump-agg"
                     ]

--- a/hw/dv/data/dsim/dsim.hjson
+++ b/hw/dv/data/dsim/dsim.hjson
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  build_cmd:  "{job_prefix} {DSIM_HOME}/dsim"
-  run_cmd:    "{job_prefix} {DSIM_HOME}/dsim"
+  build_cmd:  "{job_prefix} {DSIM_HOME}/bin/dsim"
+  run_cmd:    "{job_prefix} {DSIM_HOME}/bin/dsim"
 
   build_opts: [
                "-work {build_dir}/dsim_out",
@@ -14,11 +14,8 @@
                // UVM
                "+incdir+{UVM_HOME}/src",
                "{UVM_HOME}/src/uvm_pkg.sv",
-               "+acc+rwb -sv_lib {DSIM_HOME}/lib/libuvm_dpi.so",
-
                // Add dpi/vpi include path.
-               "-c_opts -I{DSIM_HOME}/include",
-
+               "-c-opts -I{DSIM_HOME}/include",
                "-timescale 1ns/1ps",
                "-f {sv_flist}",
                "+incdir+{build_dir}",
@@ -31,8 +28,9 @@
                "-work {build_dir}/dsim_out",
                "-image image",
                // UVM DPI
-               "+acc+rwb -sv_lib {DSIM_HOME}/lib/libuvm_dpi.so",
-               "+ntb_random_seed={seed}",
+               "-sv_lib {UVM_HOME}/src/dpi/libuvm_dpi.so",
+               "-sv_seed {seed}",
+               "-linebuf",
                "+UVM_TESTNAME={uvm_test}",
                "+UVM_TEST_SEQ={uvm_test_seq}"]
 
@@ -81,7 +79,7 @@
   ]
 
   // Defaults for DSim
-  cov_metrics:          ""
+  cov_metrics:          "metrics.db"
 
   // pass and fail patterns
   build_fail_patterns: ["^Error-.*$"]
@@ -105,6 +103,8 @@
                     ]
     }
     // TODO: support coverage mode
+    // Note: no specific build or run options are required for dsim to produce functional
+    // coverage. The coverage database is called metrics.db
     {
       name: dsim_cov
       is_sim_mode: 1

--- a/hw/dv/data/dsim/dsim.hjson
+++ b/hw/dv/data/dsim/dsim.hjson
@@ -30,6 +30,7 @@
                // UVM DPI
                "-sv_lib {UVM_HOME}/src/dpi/libuvm_dpi.so",
                "-sv_seed {seed}",
+	       // tell DSim to write line-buffered std output (lines will be written in proper order)
                "-linebuf",
                "+UVM_TESTNAME={uvm_test}",
                "+UVM_TEST_SEQ={uvm_test_seq}"]

--- a/hw/dv/sv/common_ifs/clk_rst_if.sv
+++ b/hw/dv/sv/common_ifs/clk_rst_if.sv
@@ -223,7 +223,7 @@ interface clk_rst_if #(
     // start driving clk only after the first por reset assertion. The fork/join means that we'll
     // wait a whole number of clock periods, which means it's possible for the clock to synchronise
     // with the "expected" timestamps.
-    bit done = 1'b0;
+    bit done;
     fork
       begin
         wait_for_reset(.wait_posedge(1'b0));

--- a/hw/dv/sv/dv_lib/dv_base_env.sv
+++ b/hw/dv/sv/dv_lib/dv_base_env.sv
@@ -27,7 +27,7 @@ class dv_base_env #(type CFG_T               = dv_base_env_cfg,
       `uvm_fatal(get_full_name(), "failed to get clk_rst_if from uvm_config_db")
     end
      
-    cfg.clk_rst_vif.set_freq_mhz($itor(cfg.clk_freq_mhz));
+    cfg.clk_rst_vif.set_freq_mhz(cfg.clk_freq_mhz));
 
     // create components
     if (cfg.en_cov) begin

--- a/hw/dv/sv/dv_lib/dv_base_env.sv
+++ b/hw/dv/sv/dv_lib/dv_base_env.sv
@@ -26,7 +26,7 @@ class dv_base_env #(type CFG_T               = dv_base_env_cfg,
     if (!uvm_config_db#(virtual clk_rst_if)::get(this, "", "clk_rst_vif", cfg.clk_rst_vif)) begin
       `uvm_fatal(get_full_name(), "failed to get clk_rst_if from uvm_config_db")
     end
-    cfg.clk_rst_vif.set_freq_mhz(cfg.clk_freq_mhz);
+    cfg.clk_rst_vif.set_freq_mhz(real'(cfg.clk_freq_mhz));
 
     // create components
     if (cfg.en_cov) begin

--- a/hw/dv/sv/dv_lib/dv_base_env.sv
+++ b/hw/dv/sv/dv_lib/dv_base_env.sv
@@ -26,7 +26,8 @@ class dv_base_env #(type CFG_T               = dv_base_env_cfg,
     if (!uvm_config_db#(virtual clk_rst_if)::get(this, "", "clk_rst_vif", cfg.clk_rst_vif)) begin
       `uvm_fatal(get_full_name(), "failed to get clk_rst_if from uvm_config_db")
     end
-    cfg.clk_rst_vif.set_freq_mhz(real'(cfg.clk_freq_mhz));
+     
+    cfg.clk_rst_vif.set_freq_mhz($itor(cfg.clk_freq_mhz));
 
     // create components
     if (cfg.en_cov) begin

--- a/hw/dv/sv/dv_lib/dv_base_env.sv
+++ b/hw/dv/sv/dv_lib/dv_base_env.sv
@@ -27,7 +27,7 @@ class dv_base_env #(type CFG_T               = dv_base_env_cfg,
       `uvm_fatal(get_full_name(), "failed to get clk_rst_if from uvm_config_db")
     end
      
-    cfg.clk_rst_vif.set_freq_mhz(cfg.clk_freq_mhz));
+    cfg.clk_rst_vif.set_freq_mhz(cfg.clk_freq_mhz);
 
     // create components
     if (cfg.en_cov) begin


### PR DESCRIPTION
Changes to dsim.hjson to enable use of the Metrics simulator with OpenTitan.
One small change to code in dv_base_env.sv: DSim enforces assignment rules strictly, and does not perform an implicit conversion when assigning an integer to a real number. 
Please contact me if you need help testing these changes. 