### PR TITLE
[dv] Add random backdoor for csr_hw_reset

### DIFF
--- a/hw/dv/sv/dv_base_reg/dv_base_reg_field.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_field.sv
@@ -11,10 +11,6 @@ class dv_base_reg_field extends uvm_reg_field;
 
   // when use UVM_PREDICT_WRITE and the CSR access is WO, this function will return the default
   // val of the register, rather than the written value
-  // TODO, need to handle predict value when backdoor write happens WO reg
-  //   1. for read, design ties the read data to default value
-  //   2. when backdoor write updates internal reg, backdoor read can get the written value, but
-  //   frontdoor read always returns the default value.
   virtual function uvm_reg_data_t XpredictX(uvm_reg_data_t cur_val,
                                             uvm_reg_data_t wr_val,
                                             uvm_reg_map map);

--- a/hw/dv/sv/dv_lib/dv_base_vseq.sv
+++ b/hw/dv/sv/dv_lib/dv_base_vseq.sv
@@ -172,6 +172,7 @@ class dv_base_vseq #(type RAL_T               = dv_base_reg_block,
       m_csr_write_seq.models = cfg.ral_models;
       m_csr_write_seq.set_csr_excl_item(csr_excl);
       m_csr_write_seq.external_checker = cfg.en_scb;
+      m_csr_write_seq.en_rand_backdoor_write = 1;
       if (!enable_asserts_in_hw_reset_rand_wr) $assertoff;
       m_csr_write_seq.start(null);
 

--- a/hw/ip/alert_handler/data/alert_handler.hjson
+++ b/hw/ip/alert_handler/data/alert_handler.hjson
@@ -17,6 +17,7 @@
   clock_primary: "clk_i",
   bus_device: "tlul",
   regwidth: "32",
+  hier_path: "i_reg_wrap"
   param_list: [
     { name: "NAlerts",
       desc: "Number of peripheral inputs",

--- a/hw/ip/alert_handler/data/alert_handler.hjson.tpl
+++ b/hw/ip/alert_handler/data/alert_handler.hjson.tpl
@@ -20,6 +20,7 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
   clock_primary: "clk_i",
   bus_device: "tlul",
   regwidth: "32",
+  hier_path: "i_reg_wrap"
 ##############################################################################
   param_list: [
     { name: "NAlerts",

--- a/hw/top_earlgrey/ip/alert_handler/data/autogen/alert_handler.hjson
+++ b/hw/top_earlgrey/ip/alert_handler/data/autogen/alert_handler.hjson
@@ -25,6 +25,7 @@
   clock_primary: "clk_i",
   bus_device: "tlul",
   regwidth: "32",
+  hier_path: "i_reg_wrap"
   param_list: [
     { name: "NAlerts",
       desc: "Number of peripheral inputs",

--- a/util/reggen/data.py
+++ b/util/reggen/data.py
@@ -211,6 +211,7 @@ class Block():
     addr_width = 12
     base_addr = 0
     name = ""
+    hier_path = ""
     regs = []
     wins = []
     blocks = []
@@ -222,6 +223,7 @@ class Block():
         self.addr_width = 12
         self.base_addr = 0
         self.name = ""
+        self.hier_path = ""
         self.regs = []
         self.wins = []
         self.blocks = []

--- a/util/reggen/gen_rtl.py
+++ b/util/reggen/gen_rtl.py
@@ -145,6 +145,8 @@ def json_to_reg(obj):
 
     block.params = obj["param_list"] if "param_list" in obj else []
 
+    block.hier_path = obj["hier_path"] if "hier_path" in obj else ""
+
     for r in obj["registers"]:
         # Check if any exception condition hit
         if 'reserved' in r:


### PR DESCRIPTION
1. Add random backdoor for csr_hw_reset, so that we can test RO register
which is updated by hw
2. Add hier_path for IP that has extra hierarchy for reg block
3. Backdoor support for top-level
4. Add backdoor path check

This relies on #2449 which needs to be merged first. expect CI fails for now.
Signed-off-by: Weicai Yang <weicai@google.com>