### PR TITLE
[spi_device] This enables Byte parity for the memory macro

### DIFF
--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -521,11 +521,11 @@ module spi_device #(
   prim_ram_2p_adv #(
     .Depth (512),
     .Width (SramDw),    // 32 x 512 --> 2kB
-    .DataBitsPerMask (1),
+    .DataBitsPerMask (8),
     .CfgW  (8),
 
-    .EnableECC           (1),
-    .EnableParity        (0),
+    .EnableECC           (0),
+    .EnableParity        (1),
     .EnableInputPipeline (0),
     .EnableOutputPipeline(0)
   ) u_memory_2p (


### PR DESCRIPTION
This PR re-enables Byte parity on the memory inside SPI device. This was initially done on #2418, but we decided to defer that since it led to a weird CI issue with the `hello_usb` Verilator test that for some reason I could not yet reproduce locally.

Signed-off-by: Michael Schaffner <msf@google.com>