### PR TITLE
[memutil] Increase max memory width to 256bit

### DIFF
--- a/hw/dv/verilator/cpp/verilator_memutil.cc
+++ b/hw/dv/verilator/cpp/verilator_memutil.cc
@@ -45,8 +45,8 @@ bool VerilatorMemUtil::RegisterMemoryArea(const std::string name,
                                           size_t width_bit) {
   MemArea mem = {.name = name, .location = location, .width_bit = width_bit};
 
-  assert((width_bit <= 128) &&
-         "TODO: Memory loading only supported up to 128 bits.");
+  assert((width_bit <= 256) &&
+         "TODO: Memory loading only supported up to 256 bits.");
 
   auto ret = mem_register_.emplace(name, mem);
   if (ret.second == false) {

--- a/hw/ip/prim/rtl/prim_util_memload.sv
+++ b/hw/ip/prim/rtl/prim_util_memload.sv
@@ -30,10 +30,10 @@
   export "DPI-C" function simutil_verilator_set_mem;
 
   function int simutil_verilator_set_mem(input int         index,
-                                         input bit [127:0] val);
+                                         input bit [255:0] val);
 
-    // Function will only work for memories <= 128 bits
-    if (Width > 128) begin
+    // Function will only work for memories <= 256 bits
+    if (Width > 256) begin
       return 0;
     end
 


### PR DESCRIPTION
- Required for OTBN memories
- Fixes #2504

Signed-off-by: Tom Roberts <tomroberts@lowrisc.org>