### PR TITLE
[tlgen] Fix wrong depth handling on sockets

### DIFF
--- a/hw/top_earlgrey/ip/xbar_main/rtl/autogen/xbar_main.sv
+++ b/hw/top_earlgrey/ip/xbar_main/rtl/autogen/xbar_main.sv
@@ -517,8 +517,6 @@ end
   tlul_socket_1n #(
     .HReqDepth (4'h0),
     .HRspDepth (4'h0),
-    .DReqDepth ({4{4'h0}}),
-    .DRspDepth ({4{4'h0}}),
     .N         (4)
   ) u_s1n_16 (
     .clk_i        (clk_main_i),
@@ -530,8 +528,6 @@ end
     .dev_select   (dev_sel_s1n_16)
   );
   tlul_socket_m1 #(
-    .HReqDepth ({3{4'h0}}),
-    .HRspDepth ({3{4'h0}}),
     .DReqDepth (4'h0),
     .DRspDepth (4'h0),
     .M         (3)
@@ -544,8 +540,6 @@ end
     .tl_d_i       (tl_sm1_17_ds_d2h)
   );
   tlul_socket_m1 #(
-    .HReqPass  (2'h0),
-    .HRspPass  (2'h0),
     .DReqPass  (1'b0),
     .DRspPass  (1'b0),
     .M         (2)
@@ -558,8 +552,6 @@ end
     .tl_d_i       (tl_sm1_18_ds_d2h)
   );
   tlul_socket_m1 #(
-    .HReqDepth ({3{4'h0}}),
-    .HRspDepth ({3{4'h0}}),
     .DReqDepth (4'h0),
     .DRspDepth (4'h0),
     .M         (3)
@@ -572,8 +564,6 @@ end
     .tl_d_i       (tl_sm1_19_ds_d2h)
   );
   tlul_socket_m1 #(
-    .HReqDepth ({3{4'h0}}),
-    .HRspDepth ({3{4'h0}}),
     .DReqDepth (4'h0),
     .DRspDepth (4'h0),
     .M         (3)
@@ -588,8 +578,6 @@ end
   tlul_socket_1n #(
     .HReqDepth (4'h0),
     .HRspDepth (4'h0),
-    .DReqDepth ({13{4'h0}}),
-    .DRspDepth ({13{4'h0}}),
     .N         (13)
   ) u_s1n_21 (
     .clk_i        (clk_main_i),
@@ -624,8 +612,6 @@ end
     .tl_d_i       (tl_sm1_23_ds_d2h)
   );
   tlul_socket_m1 #(
-    .HReqPass  (2'h0),
-    .HRspPass  (2'h0),
     .DReqPass  (1'b0),
     .DRspPass  (1'b0),
     .M         (2)
@@ -638,8 +624,6 @@ end
     .tl_d_i       (tl_sm1_24_ds_d2h)
   );
   tlul_socket_m1 #(
-    .HReqPass  (2'h0),
-    .HRspPass  (2'h0),
     .DReqPass  (1'b0),
     .DRspPass  (1'b0),
     .M         (2)
@@ -652,8 +636,6 @@ end
     .tl_d_i       (tl_sm1_25_ds_d2h)
   );
   tlul_socket_m1 #(
-    .HReqPass  (2'h0),
-    .HRspPass  (2'h0),
     .DReqPass  (1'b0),
     .DRspPass  (1'b0),
     .M         (2)
@@ -666,8 +648,6 @@ end
     .tl_d_i       (tl_sm1_26_ds_d2h)
   );
   tlul_socket_m1 #(
-    .HReqPass  (2'h0),
-    .HRspPass  (2'h0),
     .DReqPass  (1'b0),
     .DRspPass  (1'b0),
     .M         (2)
@@ -680,8 +660,6 @@ end
     .tl_d_i       (tl_sm1_27_ds_d2h)
   );
   tlul_socket_m1 #(
-    .HReqPass  (2'h0),
-    .HRspPass  (2'h0),
     .DReqPass  (1'b0),
     .DRspPass  (1'b0),
     .M         (2)
@@ -694,8 +672,6 @@ end
     .tl_d_i       (tl_sm1_28_ds_d2h)
   );
   tlul_socket_m1 #(
-    .HReqPass  (2'h0),
-    .HRspPass  (2'h0),
     .DReqPass  (1'b0),
     .DRspPass  (1'b0),
     .M         (2)
@@ -708,8 +684,6 @@ end
     .tl_d_i       (tl_sm1_29_ds_d2h)
   );
   tlul_socket_m1 #(
-    .HReqPass  (2'h0),
-    .HRspPass  (2'h0),
     .DReqPass  (1'b0),
     .DRspPass  (1'b0),
     .M         (2)
@@ -722,8 +696,6 @@ end
     .tl_d_i       (tl_sm1_30_ds_d2h)
   );
   tlul_socket_m1 #(
-    .HReqPass  (2'h0),
-    .HRspPass  (2'h0),
     .DReqPass  (1'b0),
     .DRspPass  (1'b0),
     .M         (2)
@@ -738,8 +710,6 @@ end
   tlul_socket_1n #(
     .HReqPass  (1'b0),
     .HRspPass  (1'b0),
-    .DReqPass  (12'h0),
-    .DRspPass  (12'h0),
     .N         (12)
   ) u_s1n_32 (
     .clk_i        (clk_main_i),

--- a/util/tlgen/elaborate.py
+++ b/util/tlgen/elaborate.py
@@ -142,10 +142,14 @@ def process_pipeline(xbar):
                 1 << idx) if no_bypass else dnode.hpass
 
         # keep variables separate in case we ever need to differentiate
-        dnode.dpass = 0 if no_bypass else dnode.dpass
         dnode.hdepth = 0 if host.pipeline is False else dnode.hdepth
-        dnode.ddepth = dnode.hdepth
 
+        log.info("{name}: {hpass}/ {hdepth} : {dpass} / {ddepth}".format(
+            name=host.name,
+            hpass=dnode.hpass,
+            hdepth=dnode.hdepth,
+            dpass=dnode.dpass,
+            ddepth=dnode.ddepth))
     for device in xbar.devices:
         # go upstream and set DReq/RspPass at the first instance.
         # If it is async, skip
@@ -173,8 +177,12 @@ def process_pipeline(xbar):
             unode.dpass = 0 if no_bypass else unode.dpass
 
         # keep variables separate in case we ever need to differentiate
-        unode.hpass = 0 if no_bypass else unode.hpass
         unode.ddepth = 0 if device.pipeline is False else unode.ddepth
-        unode.hdepth = unode.ddepth
 
+        log.info("{name}: {hpass} / {hdepth} : {dpass} / {ddepth}".format(
+            name=device.name,
+            hpass=unode.hpass,
+            hdepth=unode.hdepth,
+            dpass=unode.dpass,
+            ddepth=unode.ddepth))
     return xbar

--- a/util/tlgen/validate.py
+++ b/util/tlgen/validate.py
@@ -286,16 +286,12 @@ def validate(obj: OrderedDict) -> Xbar:  # OrderedDict -> Xbar
 
         if node.node_type in [NodeType.DEVICE, NodeType.HOST
                               ] and "pipeline" in nodeobj:
-            node.pipeline = True if nodeobj["pipeline"].lower() in [
-                "true", "1"
-            ] else False
+            node.pipeline, err = check_bool(nodeobj["pipeline"], "")
         else:
             node.pipeline = False
         if node.node_type in [NodeType.DEVICE, NodeType.HOST
                               ] and "pipeline_byp" in nodeobj:
-            node.pipeline_byp = True if nodeobj["pipeline_byp"].lower() in [
-                "true", "1"
-            ] else False
+            node.pipeline_byp, err = check_bool(nodeobj["pipeline_byp"], "")
         else:
             node.pipeline_byp = True
         xbar.nodes.append(node)

--- a/util/tlgen/xbar.rtl.sv.tpl
+++ b/util/tlgen/xbar.rtl.sv.tpl
@@ -224,7 +224,7 @@ ${"end" if loop.last else ""}
     .DReqPass  (${len(block.ds)}'h${"%x" % block.dpass}),
     .DRspPass  (${len(block.ds)}'h${"%x" % block.dpass}),
     % endif
-    % if block.hdepth != 2:
+    % if block.ddepth != 2:
     .DReqDepth ({${len(block.ds)}{4'h${block.ddepth}}}),
     .DRspDepth ({${len(block.ds)}{4'h${block.ddepth}}}),
     % endif


### PR DESCRIPTION
If host/device is set to not bypass, it doesn't have to put the pipeline on both ports of sockets.
For host, it needs to put the pipeline on host port of socket_1n or socket_m1. device ports are okay to be bypass.

This PR is related to #2501