### PR TITLE
[rv_core_ibex] Add testsynthesis target

### DIFF
--- a/hw/ip/rv_core_ibex/rv_core_ibex.core
+++ b/hw/ip/rv_core_ibex/rv_core_ibex.core
@@ -78,4 +78,12 @@ targets:
         verilator_options:
           - "-Wall"
 
+  syn:
+    <<: *default_target
+    # TODO: set default to DC once
+    # this option is available
+    # olofk/edalize#89
+    default_tool: icarus
+    parameters:
+      - SYNTHESIS=true
 

--- a/hw/ip/rv_core_ibex/syn/constraints.sdc
+++ b/hw/ip/rv_core_ibex/syn/constraints.sdc
@@ -1,0 +1,46 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Generic constraints file for simple testsynthesis flow
+
+# note that we do not fix hold timing in this flow
+set SETUP_CLOCK_UNCERTAINTY 0.5
+
+puts "Applying constraints for RV Core Ibex"
+
+#####################
+# main clock        #
+#####################
+set MAIN_CLK_PIN clk_i
+set MAIN_RST_PIN rst_ni
+# set main clock to 125 MHz
+set MAIN_TCK  5.0
+set_ideal_network ${MAIN_CLK_PIN}
+set_ideal_network ${MAIN_RST_PIN}
+set_clock_uncertainty ${SETUP_CLOCK_UNCERTAINTY} ${MAIN_CLK_PIN}
+
+# other timing constraint in ns
+set IN_DEL    1.0
+set OUT_DEL   1.0
+set DELAY     ${MAIN_TCK}
+
+create_clock ${MAIN_CLK_PIN} -period ${MAIN_TCK}
+
+# in to out
+set_max_delay ${DELAY} -from [all_inputs] -to [all_outputs]
+# in to reg / reg to out
+set_input_delay ${IN_DEL} [remove_from_collection [all_inputs] {${MAIN_CLK_PIN}}] -clock ${MAIN_CLK_PIN}
+set_output_delay ${OUT_DEL}  [all_outputs] -clock ${MAIN_CLK_PIN}
+
+#####################
+# I/O drive/load    #
+#####################
+
+# attach load and drivers to IOs to get a more realistic estimate
+set_driving_cell  -no_design_rule -lib_cell ${driving_cell} -pin X [all_inputs]
+set_load [load_of ${load_lib}/${load_cell}/A] [all_outputs]
+
+# set a nonzero critical range to be able to spot the violating paths better
+# in the report
+set_critical_range 0.5 ${DUT}

--- a/hw/ip/rv_core_ibex/syn/rv_core_ibex_syn_cfg.hjson
+++ b/hw/ip/rv_core_ibex/syn/rv_core_ibex_syn_cfg.hjson
@@ -3,15 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   // Top level dut name (sv module).
-  name: aes
+  name: rv_core_ibex
 
   // Fusesoc core file used for building the file list.
-  fusesoc_core: lowrisc:ip:aes:0.6
+  fusesoc_core: lowrisc:ip:rv_core_ibex:0.1
 
   import_cfgs: [// Project wide common synthesis config file
                 "{proj_root}/hw/syn/data/common_syn_cfg.hjson"]
 
   // Timing constraints for this module
-  sdc_file: "{proj_root}/hw/ip/aes/syn/constraints.sdc"
+  sdc_file: "{proj_root}/hw/ip/rv_core_ibex/syn/constraints.sdc"
 
  }


### PR DESCRIPTION
This commit adds basic ASIC synthesis support for Ibex using the DVSIM flow (for quick synthesis experiments).

Signed-off-by: Michael Schaffner <msf@google.com>