### PR TITLE
[ci][Do Not Merge] Check Private CI with Clang

### DIFF
--- a/hw/dv/data/sim.mk
+++ b/hw/dv/data/sim.mk
@@ -5,6 +5,7 @@
 .DEFAULT_GOAL := all
 
 LOCK_SW_BUILD ?= flock --timeout 3600 ${sw_build_dir} --command
+TOOLCHAIN_PATH ?= /tools/riscv
 
 all: build run
 
@@ -50,7 +51,8 @@ sw_build: pre_run
 ifneq (${sw_test},)
 	# Initialize meson build system.
 	${LOCK_SW_BUILD} "cd ${proj_root} && \
-		BUILD_ROOT=${sw_build_dir} ${proj_root}/meson_init.sh"
+		BUILD_ROOT=${sw_build_dir} ${proj_root}/meson_init.sh \
+		-t ${TOOLCHAIN_PATH}/meson-riscv32-unknown-elf-clang.txt"
 	# Compile boot rom code and generate the image.
 	${LOCK_SW_BUILD} "ninja -C ${sw_build_dir}/build-out \
 		sw/device/boot_rom/boot_rom_export_${sw_build_device}"

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -166,10 +166,10 @@
 
   // List of regressions.
   // TODO #2405: Waiting for bug fixes in Ibex.
-  // regressions: [
-  //   {
-  //     name: sanity
-  //     tests: ["chip_uart_tx_rx"]
-  //   }
-  // ]
+  regressions: [
+    {
+      name: sanity
+      tests: ["chip_dif_plic_sanitytest"]
+    }
+  ]
 }


### PR DESCRIPTION
The intention of this PR is to cause a build in the Private CI environment that runs the chip-level tests, but builds them with clang rather than GCC (as private CI now has an up-to-date toolchain).

I think I have correctly changed sim.mk to pick up the right toolchain configuration, but I'm not sure any of the tests run on private CI actually build any software. I don't understand `dvsim.py` but also I cannot change the private CI build task in this PR anyway, so this might be pointless.

Let's see if this passes or fails, at any rate.