### PR TITLE
[prim_sram_arbiter] Include the right arbiter submodule

### DIFF
--- a/hw/ip/prim/rtl/prim_sram_arbiter.sv
+++ b/hw/ip/prim/rtl/prim_sram_arbiter.sv
@@ -76,7 +76,7 @@ module prim_sram_arbiter #(
       .ready_i ( 1'b1        )
     );
   end else if (ArbiterImpl == "BINTREE") begin : gen_tree_arb
-    prim_arbiter_arb #(
+    prim_arbiter_tree #(
       .N (N),
       .DW(ARB_DW)
     ) u_reqarb (


### PR DESCRIPTION
prim_arbiter_arb doesn't exist (any more?), we should use
prim_arbiter_tree instead.