### PR TITLE
[lint] Make PINCONNECTEMPTY Verilator waiver common

### DIFF
--- a/hw/ip/aes/pre_dv/aes_sbox_tb/aes_sbox_tb.core
+++ b/hw/ip/aes/pre_dv/aes_sbox_tb/aes_sbox_tb.core
@@ -46,7 +46,6 @@ targets:
           - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=aes_sbox_tb -g -O0"'
           - '-LDFLAGS "-pthread -lutil -lelf"'
           - "-Wall"
-          - "-Wno-PINCONNECTEMPTY"
           # XXX: Cleanup all warnings and remove this option
           # (or make it more fine-grained at least)
           - "-Wno-fatal"

--- a/hw/ip/prim/pre_dv/prim_sync_reqack/prim_sync_reqack_tb.core
+++ b/hw/ip/prim/pre_dv/prim_sync_reqack/prim_sync_reqack_tb.core
@@ -46,7 +46,6 @@ targets:
           - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=prim_sync_reqack_tb -g -O0"'
           - '-LDFLAGS "-pthread -lutil -lelf"'
           - "-Wall"
-          - "-Wno-PINCONNECTEMPTY"
           # XXX: Cleanup all warnings and remove this option
           # (or make it more fine-grained at least)
           - "-Wno-fatal"

--- a/hw/lint/tools/verilator/common.vlt
+++ b/hw/lint/tools/verilator/common.vlt
@@ -4,3 +4,8 @@
 //
 // common waiver rules for verilator
 
+`verilator_config
+
+// Do not warn about unconnected pins in module instantiations, e.g.
+// `.optional_output ()`.
+lint_off -rule PINCONNECTEMPTY

--- a/hw/top_earlgrey/top_earlgrey_verilator.core
+++ b/hw/top_earlgrey/top_earlgrey_verilator.core
@@ -88,7 +88,6 @@ targets:
           - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=top_earlgrey_verilator -g"'
           - '-LDFLAGS "-pthread -lutil -lelf"'
           - "-Wall"
-          - "-Wno-PINCONNECTEMPTY"
           # XXX: Cleanup all warnings and remove this option
           # (or make it more fine-grained at least)
           - "-Wno-fatal"


### PR DESCRIPTION
The PINCONNECTEMPTY lint waiver allows us to use empty port mappings
when instantiating modules, e.g. `.out()`. This use is generally safe,
and we have always had a blanket waiver for this warning. Up to now, we
did pass that waiver to Verilator directly through the command line.
This commit moves it into the common Verilator waiver file.

Benefits include less places to define this file, and clean lint runs for
individual IP blocks which pick up the common waiver file, but have no
special-purpose verilator tool configuration set.