### PR TITLE
[dv/alert] interrupt timeout state cannot be cleared by esc_clr

### DIFF
--- a/hw/ip/alert_handler/dv/env/alert_handler_scoreboard.sv
+++ b/hw/ip/alert_handler/dv/env/alert_handler_scoreboard.sv
@@ -505,7 +505,7 @@ class alert_handler_scoreboard extends cip_base_scoreboard #(
         cfg.clk_rst_vif.wait_n_clks(1);
         last_triggered_alert_per_class[class_i] = $realtime;
         accum_cnter_per_class[class_i] = 0;
-        state_per_class[class_i] = EscStateIdle;
+        if (state_per_class[class_i] != EscStateTimeout) state_per_class[class_i] = EscStateIdle;
       end
     join_none
   endtask


### PR DESCRIPTION
This fix the issue when register set esc_clear: it will only clear
escalation phases (phase0, phase1, phase2, phase3) and clear escalation
accumulation counts. It won't clear timeout_state. The timeout state
cannot be cleared by setting intr_state.

Signed-off-by: Cindy Chen <chencindy@google.com>