### PR TITLE
[dv] Add set_freq_khz in clk_rst_if

### DIFF
--- a/hw/dv/sv/common_ifs/clk_rst_if.sv
+++ b/hw/dv/sv/common_ifs/clk_rst_if.sv
@@ -69,11 +69,16 @@ interface clk_rst_if #(
     if (wait_posedge && (rst_n === 1'b0)) @(posedge rst_n);
   endtask
 
-  // set the clk frequency in mhz
-  function automatic void set_freq_mhz(real freq_mhz);
-    clk_freq_mhz = freq_mhz;
+  // set the clk frequency in khz
+  function automatic void set_freq_khz(int freq_khz);
+    clk_freq_mhz = $itor(freq_khz) / 1000;
     clk_period_ps = 1000_000 / clk_freq_mhz;
     recompute = 1'b1;
+  endfunction
+
+  // set the clk frequency in mhz
+  function automatic void set_freq_mhz(int freq_mhz);
+    set_freq_khz(freq_mhz * 1000);
   endfunction
 
   // call this function at t=0 (from tb top) to enable clk and rst_n to be driven

--- a/hw/top_earlgrey/data/tb__xbar_connect.sv.tpl
+++ b/hw/top_earlgrey/data/tb__xbar_connect.sv.tpl
@@ -53,7 +53,7 @@ initial begin
 
 % for c in clk_freq.keys():
     clk_rst_if_${c}.set_active(.drive_rst_n_val(0));
-    clk_rst_if_${c}.set_freq_mhz(${clk_freq[c]} / 1000_000.0);
+    clk_rst_if_${c}.set_freq_khz(${clk_freq[c]} / 1000);
 % endfor
 
     // bypass clkmgr, force clocks directly

--- a/hw/top_earlgrey/dv/autogen/tb__xbar_connect.sv
+++ b/hw/top_earlgrey/dv/autogen/tb__xbar_connect.sv
@@ -43,9 +43,9 @@ initial begin
     $asserton(0, tb.dut.top_earlgrey.u_xbar_peri);
 
     clk_rst_if_main.set_active(.drive_rst_n_val(0));
-    clk_rst_if_main.set_freq_mhz(100000000 / 1000_000.0);
+    clk_rst_if_main.set_freq_khz(100000000 / 1000);
     clk_rst_if_io.set_active(.drive_rst_n_val(0));
-    clk_rst_if_io.set_freq_mhz(100000000 / 1000_000.0);
+    clk_rst_if_io.set_freq_khz(100000000 / 1000);
 
     // bypass clkmgr, force clocks directly
     force tb.dut.top_earlgrey.u_xbar_main.clk_main_i = clk_main;


### PR DESCRIPTION
As discussed at #2485, use set_freq_khz for freq less than 1mhz
Also update xbar to use set_freq_khz

Signed-off-by: Weicai Yang <weicai@google.com>