### PR TITLE
[alert_handler/rtl] priority between ping_ok and sig_int_err

### DIFF
--- a/hw/dv/sv/alert_esc_agent/esc_monitor.sv
+++ b/hw/dv/sv/alert_esc_agent/esc_monitor.sv
@@ -59,8 +59,6 @@ class esc_monitor extends alert_esc_base_monitor;
               check_esc_resp(.req(req), .is_ping(1), .do_wait_clk(0));
             end
           end
-          // TODO: one corner case still confirming with design: when sig_int_err with esc_en,
-          // which one has priority?
           if (cfg.probe_vif.get_esc_en()) begin
             // wait a clk cycle to enter the esc_p/n mode
             @(cfg.vif.monitor_cb);


### PR DESCRIPTION
In alert_handler spec it is mention that "note that the escalation
signal always takes precedence, and the ping_en_i will just be
ackownledged when `ping_ok_o` in case esc_en_i is already asserted. An
ongoing ping sequence will be aborted immediately."

Through DV regression we found a corner case where if esc_en_i is set
during ping, and the same clk cycle detected a signal_int_err (ping_p
and n has the same value), then `ping_ok_o` won't be set.
After discussed with the designer, we agree to fix it by moving the set
ping_ok_o variable after checking sig_int_err.

This PR also fix an assertion related to this change, and remove the
previous DV TODO comments.

Signed-off-by: Cindy Chen <chencindy@google.com>