### PR TITLE
[COMMITTERS] Update following 17th June 2020 TC meeting

### DIFF
--- a/COMMITTERS
+++ b/COMMITTERS
@@ -20,6 +20,7 @@ Committer list:
 * Dominic Rizzo (domrizz0)
 * Tom Roberts (tomroberts-lowrisc)
 * Michael Schaffner (msfschaffner)
+* Rupert Swarbrick (rswarbrick)
 * Silvestrs Timofejevs (silvestrst)
 * Alphan Ulusoy (alphan)
 * Pirmin Vogel (vogelpi)


### PR DESCRIPTION
Adds @rswarbrick as a committer, as approved at the 17th June 2020 TC
meeting.

Signed-off-by: Alex Bradbury <asb@lowrisc.org>