### PR TITLE
[fpv/prim_packer] fix CI failure due to index out of bound

### DIFF
--- a/hw/ip/prim/rtl/prim_packer.sv
+++ b/hw/ip/prim/rtl/prim_packer.sv
@@ -200,8 +200,10 @@ module prim_packer #(
   // Assumption: mask_i should be contiguous ones
   // e.g: 0011100 --> OK
   //      0100011 --> Not OK
-  `ASSUME(ContiguousOnesMask_M,
-          valid_i |-> $countones(mask_i ^ {mask_i[InW-2:0],1'b0}) <= 2)
+  if (InW > 1) begin
+    `ASSUME(ContiguousOnesMask_M,
+            valid_i |-> $countones(mask_i ^ {mask_i[InW-2:0],1'b0}) <= 2)
+  end
 
   // Assume data pattern to reduce FPV test time
   //`ASSUME_FPV(FpvDataWithin_M,


### PR DESCRIPTION
This PR tries to fix the CI failure in PR: https://github.com/lowRISC/opentitan/pull/2217

One of the assumptions in prim_packer ensures input mask is continous,
thus it uses `InW-2` as index, but entroy_src uses prim_packer with
InW=1, so there is compile error in CI check.
This PR fix it by guarding the assumption with InW>1 condition.

Signed-off-by: Cindy Chen <chencindy@google.com>