### PR TITLE
[tlgen] tlul updates and fixes

### DIFF
--- a/hw/top_earlgrey/ip/xbar_main/rtl/autogen/xbar_main.sv
+++ b/hw/top_earlgrey/ip/xbar_main/rtl/autogen/xbar_main.sv
@@ -517,8 +517,8 @@ end
   tlul_socket_1n #(
     .HReqDepth (4'h0),
     .HRspDepth (4'h0),
-    .DReqDepth ({4{4'h0}}),
-    .DRspDepth ({4{4'h0}}),
+    .DReqDepth (16'h0),
+    .DRspDepth (16'h0),
     .N         (4)
   ) u_s1n_16 (
     .clk_i        (clk_main_i),
@@ -530,8 +530,8 @@ end
     .dev_select   (dev_sel_s1n_16)
   );
   tlul_socket_m1 #(
-    .HReqDepth ({3{4'h0}}),
-    .HRspDepth ({3{4'h0}}),
+    .HReqDepth (12'h0),
+    .HRspDepth (12'h0),
     .DReqDepth (4'h0),
     .DRspDepth (4'h0),
     .M         (3)
@@ -544,8 +544,8 @@ end
     .tl_d_i       (tl_sm1_17_ds_d2h)
   );
   tlul_socket_m1 #(
-    .HReqPass  (2'h0),
-    .HRspPass  (2'h0),
+    .HReqDepth (8'h0),
+    .HRspDepth (8'h0),
     .DReqPass  (1'b0),
     .DRspPass  (1'b0),
     .M         (2)
@@ -558,8 +558,8 @@ end
     .tl_d_i       (tl_sm1_18_ds_d2h)
   );
   tlul_socket_m1 #(
-    .HReqDepth ({3{4'h0}}),
-    .HRspDepth ({3{4'h0}}),
+    .HReqDepth (12'h0),
+    .HRspDepth (12'h0),
     .DReqDepth (4'h0),
     .DRspDepth (4'h0),
     .M         (3)
@@ -572,8 +572,8 @@ end
     .tl_d_i       (tl_sm1_19_ds_d2h)
   );
   tlul_socket_m1 #(
-    .HReqDepth ({3{4'h0}}),
-    .HRspDepth ({3{4'h0}}),
+    .HReqDepth (12'h0),
+    .HRspDepth (12'h0),
     .DReqDepth (4'h0),
     .DRspDepth (4'h0),
     .M         (3)
@@ -588,8 +588,8 @@ end
   tlul_socket_1n #(
     .HReqDepth (4'h0),
     .HRspDepth (4'h0),
-    .DReqDepth ({13{4'h0}}),
-    .DRspDepth ({13{4'h0}}),
+    .DReqDepth (52'h0),
+    .DRspDepth (52'h0),
     .N         (13)
   ) u_s1n_21 (
     .clk_i        (clk_main_i),
@@ -614,6 +614,10 @@ end
     .tl_d_i       (tl_asf_22_ds_d2h)
   );
   tlul_socket_m1 #(
+    .HReqDepth (8'h0),
+    .HRspDepth (8'h0),
+    .DReqDepth (4'h0),
+    .DRspDepth (4'h0),
     .M         (2)
   ) u_sm1_23 (
     .clk_i        (clk_main_i),
@@ -624,8 +628,8 @@ end
     .tl_d_i       (tl_sm1_23_ds_d2h)
   );
   tlul_socket_m1 #(
-    .HReqPass  (2'h0),
-    .HRspPass  (2'h0),
+    .HReqDepth (8'h0),
+    .HRspDepth (8'h0),
     .DReqPass  (1'b0),
     .DRspPass  (1'b0),
     .M         (2)
@@ -638,8 +642,8 @@ end
     .tl_d_i       (tl_sm1_24_ds_d2h)
   );
   tlul_socket_m1 #(
-    .HReqPass  (2'h0),
-    .HRspPass  (2'h0),
+    .HReqDepth (8'h0),
+    .HRspDepth (8'h0),
     .DReqPass  (1'b0),
     .DRspPass  (1'b0),
     .M         (2)
@@ -652,8 +656,8 @@ end
     .tl_d_i       (tl_sm1_25_ds_d2h)
   );
   tlul_socket_m1 #(
-    .HReqPass  (2'h0),
-    .HRspPass  (2'h0),
+    .HReqDepth (8'h0),
+    .HRspDepth (8'h0),
     .DReqPass  (1'b0),
     .DRspPass  (1'b0),
     .M         (2)
@@ -666,8 +670,8 @@ end
     .tl_d_i       (tl_sm1_26_ds_d2h)
   );
   tlul_socket_m1 #(
-    .HReqPass  (2'h0),
-    .HRspPass  (2'h0),
+    .HReqDepth (8'h0),
+    .HRspDepth (8'h0),
     .DReqPass  (1'b0),
     .DRspPass  (1'b0),
     .M         (2)
@@ -680,8 +684,8 @@ end
     .tl_d_i       (tl_sm1_27_ds_d2h)
   );
   tlul_socket_m1 #(
-    .HReqPass  (2'h0),
-    .HRspPass  (2'h0),
+    .HReqDepth (8'h0),
+    .HRspDepth (8'h0),
     .DReqPass  (1'b0),
     .DRspPass  (1'b0),
     .M         (2)
@@ -694,8 +698,8 @@ end
     .tl_d_i       (tl_sm1_28_ds_d2h)
   );
   tlul_socket_m1 #(
-    .HReqPass  (2'h0),
-    .HRspPass  (2'h0),
+    .HReqDepth (8'h0),
+    .HRspDepth (8'h0),
     .DReqPass  (1'b0),
     .DRspPass  (1'b0),
     .M         (2)
@@ -708,8 +712,8 @@ end
     .tl_d_i       (tl_sm1_29_ds_d2h)
   );
   tlul_socket_m1 #(
-    .HReqPass  (2'h0),
-    .HRspPass  (2'h0),
+    .HReqDepth (8'h0),
+    .HRspDepth (8'h0),
     .DReqPass  (1'b0),
     .DRspPass  (1'b0),
     .M         (2)
@@ -722,8 +726,8 @@ end
     .tl_d_i       (tl_sm1_30_ds_d2h)
   );
   tlul_socket_m1 #(
-    .HReqPass  (2'h0),
-    .HRspPass  (2'h0),
+    .HReqDepth (8'h0),
+    .HRspDepth (8'h0),
     .DReqPass  (1'b0),
     .DRspPass  (1'b0),
     .M         (2)
@@ -738,8 +742,8 @@ end
   tlul_socket_1n #(
     .HReqPass  (1'b0),
     .HRspPass  (1'b0),
-    .DReqPass  (12'h0),
-    .DRspPass  (12'h0),
+    .DReqDepth (48'h0),
+    .DRspDepth (48'h0),
     .N         (12)
   ) u_s1n_32 (
     .clk_i        (clk_main_i),

--- a/hw/top_earlgrey/ip/xbar_peri/rtl/autogen/xbar_peri.sv
+++ b/hw/top_earlgrey/ip/xbar_peri/rtl/autogen/xbar_peri.sv
@@ -127,8 +127,8 @@ end
   tlul_socket_1n #(
     .HReqDepth (4'h0),
     .HRspDepth (4'h0),
-    .DReqDepth ({8{4'h0}}),
-    .DRspDepth ({8{4'h0}}),
+    .DReqDepth (32'h0),
+    .DRspDepth (32'h0),
     .N         (8)
   ) u_s1n_9 (
     .clk_i        (clk_peri_i),

--- a/util/tlgen/elaborate.py
+++ b/util/tlgen/elaborate.py
@@ -83,9 +83,12 @@ def process_node(node, xbar):  # node: Node -> xbar: Xbar -> Xbar
                         node_type=NodeType.SOCKET_M1,
                         clock=xbar.clock,
                         reset=xbar.reset)
-        new_node.hdepth = 2
+
+        # By default, assume connecting to SOCKET_1N upstream and bypass all FIFOs
+        # If upstream requires pipelining, it will be added through process pipeline
+        new_node.hdepth = 0
         new_node.hpass = 2**len(node.us) - 1
-        new_node.ddepth = 2
+        new_node.ddepth = 0
         new_node.dpass = 1
         xbar.insert_node(new_node, node)
         process_node(new_node, xbar)
@@ -97,9 +100,12 @@ def process_node(node, xbar):  # node: Node -> xbar: Xbar -> Xbar
                         node_type=NodeType.SOCKET_1N,
                         clock=xbar.clock,
                         reset=xbar.reset)
-        new_node.hdepth = 2
+
+        # By default, assume connecting to SOCKET_M1 downstream and bypass all FIFOs
+        # If upstream requires pipelining, it will be added through process pipeline
+        new_node.hdepth = 0
         new_node.hpass = 1
-        new_node.ddepth = 2
+        new_node.ddepth = 0
         new_node.dpass = 2**len(node.ds) - 1
         xbar.insert_node(new_node, node)
 
@@ -122,29 +128,59 @@ def process_pipeline(xbar):
         # If Socket M1, find position of the host and follow procedure above
         # If it is device, it means host and device are directly connected. Ignore now.
 
-        # After process node is done, always only one downstream exists in any host node
-        if host.pipeline is True and host.pipeline_byp is True:
-            # No need to process, same as default
-            continue
+        log.info("Processing pipeline for host {}".format(host.name))
 
-        no_bypass = (host.pipeline is True and host.pipeline_byp is False)
+        # FIFO present with no passthrough option
+        # FIFO present with passthrough option
+        # FIFO not present and full passthrough
+        full_fifo = False
+        fifo_passthru = False
+        full_passthru = True
+        if host.pipeline is True and host.pipeline_byp is False:
+            full_fifo = True
+
+        elif host.pipeline is True and host.pipeline_byp is True:
+            fifo_passthru = True
+
+        elif host.pipeline is False:
+            full_passthru = True
+
         dnode = host.ds[0].ds
 
         if dnode.node_type == NodeType.ASYNC_FIFO:
             continue
 
         if dnode.node_type == NodeType.SOCKET_1N:
-            dnode.hpass = 0 if no_bypass else dnode.hpass
+            if full_fifo:
+                dnode.hpass = 0
+                dnode.hdepth = 2
+            elif fifo_passthru:
+                dnode.hpass = 0
+                dnode.hdepth = 2
+            elif full_passthru:
+                dnode.hpass = 1
+                dnode.hdepth = 0
+
+            log.info("Finished processing socket1n {}, pass={}, depth={}"
+                     .format(dnode.name, dnode.hpass, dnode.hdepth))
 
         elif dnode.node_type == NodeType.SOCKET_M1:
             idx = dnode.us.index(host.ds)
-            dnode.hpass = dnode.hpass ^ (
-                1 << idx) if no_bypass else dnode.hpass
+            if full_fifo:
+                log.info("fifo present no bypass")
+                dnode.hpass = dnode.hpass & ~(1 << idx)
+                dnode.hdepth = dnode.hdepth | (2 << idx * 4)
+            elif fifo_passthru:
+                log.info("fifo present with bypass")
+                dnode.hpass = dnode.hpass | (1 << idx)
+                dnode.hdepth = dnode.hdepth | (2 << idx * 4)
+            elif full_passthru:
+                log.info("fifo not present")
+                dnode.hpass = dnode.hpass | (1 << idx)
+                dnode.hdepth = dnode.hdepth & ~(0xF << idx * 4)
 
-        # keep variables separate in case we ever need to differentiate
-        dnode.dpass = 0 if no_bypass else dnode.dpass
-        dnode.hdepth = 0 if host.pipeline is False else dnode.hdepth
-        dnode.ddepth = dnode.hdepth
+            log.info("Finished processing socketm1 {}, pass={}, depth={}"
+                     .format(dnode.name, dnode.hpass, dnode.hdepth))
 
     for device in xbar.devices:
         # go upstream and set DReq/RspPass at the first instance.
@@ -155,10 +191,24 @@ def process_pipeline(xbar):
         # If Socket 1N, find position of the device and follow procedure above
         # If it is host, ignore
 
-        if device.pipeline is True and device.pipeline_byp is True:
-            continue
+        log.info("Processing pipeline for device {}".format(device.name))
 
-        no_bypass = (device.pipeline is True and device.pipeline_byp is False)
+        # FIFO present with no passthrough option
+        # FIFO present with passthrough option
+        # FIFO not present and full passthrough
+
+        full_fifo = False
+        fifo_passthru = False
+        full_passthru = True
+        if device.pipeline is True and device.pipeline_byp is False:
+            full_fifo = True
+
+        elif device.pipeline is True and device.pipeline_byp is True:
+            fifo_passthru = True
+
+        elif device.pipeline is False:
+            full_passthru = True
+
         unode = device.us[0].us
 
         if unode.node_type == NodeType.ASYNC_FIFO:
@@ -166,15 +216,35 @@ def process_pipeline(xbar):
 
         if unode.node_type == NodeType.SOCKET_1N:
             idx = unode.ds.index(device.us[0])
-            unode.dpass = unode.dpass ^ (
-                1 << idx) if no_bypass else unode.dpass
+
+            if full_fifo:
+                unode.dpass = unode.dpass & ~(1 << idx)
+                unode.ddepth = unode.ddepth | (2 << idx * 4)
+            elif fifo_passthru:
+                unode.dpass = unode.dpass | (1 << idx)
+                unode.ddepth = unode.ddepth | (2 << idx * 4)
+            elif full_passthru:
+                unode.dpass = unode.dpass | (1 << idx)
+                unode.ddepth = unode.ddepth & ~(0xF << idx * 4)
+
+            log.info("Finished processing socket1n {}, pass={:x}, depth={:x}"
+                     .format(unode.name, unode.dpass, unode.ddepth))
 
         elif unode.node_type == NodeType.SOCKET_M1:
-            unode.dpass = 0 if no_bypass else unode.dpass
+            if full_fifo:
+                log.info("Fifo present with no passthrough")
+                unode.dpass = 0
+                unode.ddepth = 2
+            elif fifo_passthru:
+                log.info("Fifo present with passthrough")
+                unode.dpass = 0
+                unode.ddepth = 2
+            elif full_passthru:
+                log.info("No Fifo")
+                unode.dpass = 1
+                unode.ddepth = 0
 
-        # keep variables separate in case we ever need to differentiate
-        unode.hpass = 0 if no_bypass else unode.hpass
-        unode.ddepth = 0 if device.pipeline is False else unode.ddepth
-        unode.hdepth = unode.ddepth
+            log.info("Finished processing socketm1 {}, pass={:x}, depth={:x}"
+                     .format(unode.name, unode.dpass, unode.ddepth))
 
     return xbar

--- a/util/tlgen/xbar.rtl.sv.tpl
+++ b/util/tlgen/xbar.rtl.sv.tpl
@@ -224,9 +224,9 @@ ${"end" if loop.last else ""}
     .DReqPass  (${len(block.ds)}'h${"%x" % block.dpass}),
     .DRspPass  (${len(block.ds)}'h${"%x" % block.dpass}),
     % endif
-    % if block.hdepth != 2:
-    .DReqDepth ({${len(block.ds)}{4'h${block.ddepth}}}),
-    .DRspDepth ({${len(block.ds)}{4'h${block.ddepth}}}),
+    % if block.ddepth != 2:
+    .DReqDepth (${len(block.ds)*4}'h${"%x" % block.ddepth}),
+    .DRspDepth (${len(block.ds)*4}'h${"%x" % block.ddepth}),
     % endif
     .N         (${len(block.ds)})
   ) u_${block.name} (
@@ -245,16 +245,16 @@ ${"end" if loop.last else ""}
     .HRspPass  (${len(block.us)}'h${"%x" % block.hpass}),
     % endif
     % if block.hdepth != 2:
-    .HReqDepth ({${len(block.us)}{4'h${block.hdepth}}}),
-    .HRspDepth ({${len(block.us)}{4'h${block.hdepth}}}),
-    % endif
-    % if block.ddepth != 2:
-    .DReqDepth (4'h${block.ddepth}),
-    .DRspDepth (4'h${block.ddepth}),
+    .HReqDepth (${len(block.us)*4}'h${"%x" % block.hdepth}),
+    .HRspDepth (${len(block.us)*4}'h${"%x" % block.hdepth}),
     % endif
     % if block.dpass != 1:
     .DReqPass  (1'b${block.dpass}),
     .DRspPass  (1'b${block.dpass}),
+    % endif
+    % if block.ddepth != 2:
+    .DReqDepth (4'h${block.ddepth}),
+    .DRspDepth (4'h${block.ddepth}),
     % endif
     .M         (${len(block.us)})
   ) u_${block.name} (


### PR DESCRIPTION
- De-couples unode / dnode dependencies

- When s1n connects to sm1, always fully passthrough, FIFOs can be
  instantiated at the beginning of s1n, or the end of sm1

Signed-off-by: Timothy Chen <timothytim@google.com>