### PR TITLE
[dv/alert_handler] temp fix interrupt triggered same cycle as clr_intr

### DIFF
--- a/hw/ip/alert_handler/dv/env/alert_handler_scoreboard.sv
+++ b/hw/ip/alert_handler/dv/env/alert_handler_scoreboard.sv
@@ -277,10 +277,12 @@ class alert_handler_scoreboard extends cip_base_scoreboard #(
                 if (!under_esc_classes[i]) state_per_class[i] = EscStateIdle;
               end
             end
-            // TODO: tries to avoid this by constrain sequence
             fork
               begin
-                cfg.clk_rst_vif.wait_clks(1);
+                // TODO: tries to avoid this by constrain sequence
+                // wait two clks: 1. for the register to set
+                // 2. corner case intr was triggered right when intr_state is set, wait one more clk to override it
+                cfg.clk_rst_vif.wait_clks(2);
                 void'(csr.predict(.value(item.a_data), .kind(UVM_PREDICT_WRITE), .be(item.a_mask)));
               end
             join_none


### PR DESCRIPTION
This is a temp fix for cases where issuing clear interrupt happened
right when another interrupt is raised. In this case design won't
trigger an interrupt, but because TB process request in negedge clk
cycle, so interrupt is set in TB.

This is a temp fix. I think eventually I should constrain the sequence
to avoid this corner case.

Signed-off-by: Cindy Chen <chencindy@google.com>