### PR TITLE
[prim] Update ResetValue parameter in prim_flop_2sync

### DIFF
--- a/hw/ip/prim/rtl/prim_diff_decode.sv
+++ b/hw/ip/prim/rtl/prim_diff_decode.sv
@@ -53,7 +53,7 @@ module prim_diff_decode #(
 
     prim_flop_2sync #(
       .Width(1),
-      .ResetValue(0)
+      .ResetValue('0)
     ) i_sync_p (
       .clk_i,
       .rst_ni,
@@ -63,7 +63,7 @@ module prim_diff_decode #(
 
     prim_flop_2sync #(
       .Width(1),
-      .ResetValue(1)
+      .ResetValue(1'b1)
     ) i_sync_n (
       .clk_i,
       .rst_ni,

--- a/hw/ip/prim/rtl/prim_flop_2sync.sv
+++ b/hw/ip/prim/rtl/prim_flop_2sync.sv
@@ -6,7 +6,7 @@
 
 module prim_flop_2sync #(
   parameter int Width      = 16,
-  parameter bit ResetValue = 0
+  parameter logic [Width-1:0] ResetValue = '0
 ) (
   input                    clk_i,    // receive clock
   input                    rst_ni,
@@ -18,8 +18,8 @@ module prim_flop_2sync #(
 
   always_ff @(posedge clk_i or negedge rst_ni)
     if (!rst_ni) begin
-      intq <= {Width{ResetValue}};
-      q    <= {Width{ResetValue}};
+      intq <= ResetValue;
+      q    <= ResetValue;
     end else begin
       intq <= d;
       q    <= intq;

--- a/hw/ip/rstmgr/rtl/rstmgr.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr.sv
@@ -53,7 +53,7 @@ module rstmgr import rstmgr_pkg::*; (
   // POR usage for the clkmgr
   prim_flop_2sync #(
     .Width(1),
-    .ResetValue(0)
+    .ResetValue('0)
   ) i_por_sync (
     .clk_i(clk_main_i),
     .rst_ni(resets_o.rst_por_aon_n),
@@ -63,7 +63,7 @@ module rstmgr import rstmgr_pkg::*; (
 
   prim_flop_2sync #(
     .Width(1),
-    .ResetValue(0)
+    .ResetValue('0)
   ) i_por_io_sync (
     .clk_i(clk_io_i),
     .rst_ni(resets_o.rst_por_aon_n),
@@ -73,7 +73,7 @@ module rstmgr import rstmgr_pkg::*; (
 
   prim_flop_2sync #(
     .Width(1),
-    .ResetValue(0)
+    .ResetValue('0)
   ) i_por_usb_sync (
     .clk_i(clk_usb_i),
     .rst_ni(resets_o.rst_por_aon_n),
@@ -107,7 +107,7 @@ module rstmgr import rstmgr_pkg::*; (
 
   prim_flop_2sync #(
     .Width(1),
-    .ResetValue(0)
+    .ResetValue('0)
   ) i_sync (
     .clk_i,
     .rst_ni(resets_o.rst_por_aon_n),
@@ -161,7 +161,7 @@ module rstmgr import rstmgr_pkg::*; (
 
   prim_flop_2sync #(
     .Width(1),
-    .ResetValue(0)
+    .ResetValue('0)
   ) i_lc (
     .clk_i(clk_io_i),
     .rst_ni(rst_lc_src_n[ALWAYS_ON_SEL]),
@@ -171,7 +171,7 @@ module rstmgr import rstmgr_pkg::*; (
 
   prim_flop_2sync #(
     .Width(1),
-    .ResetValue(0)
+    .ResetValue('0)
   ) i_sys (
     .clk_i(clk_main_i),
     .rst_ni(rst_sys_src_n[ALWAYS_ON_SEL]),
@@ -181,7 +181,7 @@ module rstmgr import rstmgr_pkg::*; (
 
   prim_flop_2sync #(
     .Width(1),
-    .ResetValue(0)
+    .ResetValue('0)
   ) i_sys_io (
     .clk_i(clk_io_i),
     .rst_ni(rst_sys_src_n[ALWAYS_ON_SEL]),
@@ -191,7 +191,7 @@ module rstmgr import rstmgr_pkg::*; (
 
   prim_flop_2sync #(
     .Width(1),
-    .ResetValue(0)
+    .ResetValue('0)
   ) i_spi_device (
     .clk_i(clk_io_i),
     .rst_ni(rst_sys_src_n[ALWAYS_ON_SEL]),
@@ -201,7 +201,7 @@ module rstmgr import rstmgr_pkg::*; (
 
   prim_flop_2sync #(
     .Width(1),
-    .ResetValue(0)
+    .ResetValue('0)
   ) i_usb (
     .clk_i(clk_usb_i),
     .rst_ni(rst_sys_src_n[ALWAYS_ON_SEL]),

--- a/hw/ip/rstmgr/rtl/rstmgr_ctrl.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr_ctrl.sv
@@ -35,7 +35,7 @@ module rstmgr_ctrl import rstmgr_pkg::*; #(
   logic [PowerDomains-1:0] rst_parent_synced;
   prim_flop_2sync #(
     .Width(PowerDomains),
-    .ResetValue(0)
+    .ResetValue('0)
   ) u_lc (
     .clk_i(clk_i),
     .rst_ni(rst_ni),

--- a/hw/ip/rstmgr/rtl/rstmgr_info.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr_info.sv
@@ -26,7 +26,7 @@ module rstmgr_info #(
 
   prim_flop_2sync #(
     .Width(1),
-    .ResetValue(0)
+    .ResetValue('0)
   ) u_cpu_reset_synced (
     .clk_i(clk_i),
     .rst_ni(rst_ni),

--- a/hw/ip/rstmgr/rtl/rstmgr_por.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr_por.sv
@@ -29,7 +29,7 @@ module rstmgr_por #(
   // sync the POR
   prim_flop_2sync #(
     .Width(1),
-    .ResetValue(0)
+    .ResetValue('0)
   ) rst_sync (
     .clk_i(clk_i),
     .rst_ni(rst_ni),

--- a/hw/ip/uart/rtl/uart_core.sv
+++ b/hw/ip/uart/rtl/uart_core.sv
@@ -219,7 +219,7 @@ module uart_core (
   //      sync the incoming data
   prim_flop_2sync #(
     .Width(1),
-    .ResetValue(1)
+    .ResetValue(1'b1)
   ) sync_rx (
     .clk_i,
     .rst_ni,


### PR DESCRIPTION
The parameter now represents the value of the entire module
instead of just an individual bit.

Addresses #2492

Signed-off-by: Timothy Chen <timothytim@google.com>