### PR TITLE
[prim_flash] Add reset to held_part

### DIFF
--- a/hw/ip/prim_generic/rtl/prim_generic_flash.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_flash.sv
@@ -102,6 +102,7 @@ module prim_generic_flash #(
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       held_addr <= '0;
+      held_part <= '0;
       held_wdata <= '0;
     end else if (hold_cmd) begin
       held_addr <= rd_q ? addr_q : addr_i;


### PR DESCRIPTION
`held_part` has no reset. This commit is to add reset value to the
register.
