### PR TITLE
[sw] Upgrade toolchain

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ variables:
   TOOLCHAIN_PATH: /opt/buildcache/riscv
   # Release tag from https://github.com/lowRISC/lowrisc-toolchains/releases
   # if you update this, update the definition in util/container/Dockerfile
-  TOOLCHAIN_VERSION: 20200602-4
+  TOOLCHAIN_VERSION: 20200618-1
   # This controls where builds happen, and gets picked up by build_consts.sh.
   BUILD_ROOT: $(Build.ArtifactStagingDirectory)
 

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -9,7 +9,7 @@
 ARG VERILATOR_VERSION=4.028
 
 # The RISCV toolchain version should match the release tag used in GitHub.
-ARG RISCV_TOOLCHAIN_TAR_VERSION=20200602-4
+ARG RISCV_TOOLCHAIN_TAR_VERSION=20200618-1
 
 # Build OpenOCD
 # OpenOCD is a tool to connect with the target chip over JTAG and similar


### PR DESCRIPTION
This fixes issues where the previously used toolchain had a broken symlink
and required a more recent version of libstdc++ than is available by default
in some distributions.

Signed-off-by: Luís Marques <luismarques@lowrisc.org>