### PR TITLE
[tlul_adapter_sram] Support wider SRAMs than TL-UL words

### DIFF
--- a/hw/ip/tlul/adapter_sram.core
+++ b/hw/ip/tlul/adapter_sram.core
@@ -8,7 +8,8 @@ description: "TL-UL to SRAM adapter (device)"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:prim:all
+      - lowrisc:prim:util
+      - lowrisc:prim:assert
       - lowrisc:tlul:common
     files:
       - rtl/tlul_adapter_sram.sv


### PR DESCRIPTION
Currently, the TL-UL to SRAM adapter assumes that the SRAM word width
matches the TL-UL word width, i.e. 32b. With this commit, the SRAM word
width can be a multiple of the TL-UL word width, i.e. 64b, 128b, etc.