### PR TITLE
[otbn] Fix rendering of WSR table in spec

### DIFF
--- a/hw/ip/otbn/doc/_index.md
+++ b/hw/ip/otbn/doc/_index.md
@@ -264,7 +264,6 @@ In addition to the Wide Data Registers, BN instructions can also access WLEN-siz
         <strong>MOD</strong>
         Modulus.
         To be used in the BN.ADDM and BN.SUBM instructions.
-
         This WSR is mapped to the MOD0 to MOD7 CSRs.
       </td>
     </tr>


### PR DESCRIPTION
The empty line in the spec made our renderer switch from HTML back to
markdown mode, showing the source code of the table instead of the table
itself.