### PR TITLE
[prim_fifo_sync] Use vbits() for simpler code

### DIFF
--- a/hw/ip/prim/prim.core
+++ b/hw/ip/prim/prim.core
@@ -10,6 +10,7 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:prim:assert
+      - lowrisc:prim:util
       - lowrisc:prim:diff_decode # for prim_alert_sender/receiver
       - lowrisc:prim:pad_wrapper
       - lowrisc:prim:prim_pkg

--- a/hw/ip/prim/rtl/prim_fifo_sync.sv
+++ b/hw/ip/prim/rtl/prim_fifo_sync.sv
@@ -5,6 +5,7 @@
 // Generic synchronous fifo for use in a variety of devices.
 
 `include "prim_assert.sv"
+`include "prim_util.svh"
 
 module prim_fifo_sync #(
   parameter int unsigned Width       = 16,
@@ -12,8 +13,7 @@ module prim_fifo_sync #(
   parameter int unsigned Depth       = 4,
   parameter bit OutputZeroIfEmpty    = 1'b1, // if == 1 always output 0 when FIFO is empty
   // derived parameter
-  localparam int unsigned DepthWNorm = $clog2(Depth+1),
-  localparam int unsigned DepthW     = (DepthWNorm == 0) ? 1 : DepthWNorm
+  localparam int          DepthW     = vbits(Depth+1)
 ) (
   input                   clk_i,
   input                   rst_ni,
@@ -51,8 +51,7 @@ module prim_fifo_sync #(
   // Normal FIFO construction
   end else begin : gen_normal_fifo
 
-    // consider Depth == 1 case when $clog2(1) == 0
-    localparam int unsigned PTRV_W    = $clog2(Depth) + ~|$clog2(Depth);
+    localparam int unsigned PTRV_W    = vbits(Depth);
     localparam int unsigned PTR_WIDTH = PTRV_W+1;
 
     logic [PTR_WIDTH-1:0] fifo_wptr, fifo_rptr;


### PR DESCRIPTION
prim_fifo_sync currently uses two different approaches to get the
functionality we now provide in `vbits()`; use this new function
instead.

This change also fixes a Verilator lint error (width mismatch).