### PR TITLE
[prim_ram_*adv] Mark cfg port as unused

### DIFF
--- a/hw/ip/prim/lint/prim.waiver
+++ b/hw/ip/prim/lint/prim.waiver
@@ -57,7 +57,5 @@ waive -rules {HIER_BRANCH_NOT_READ} -location {tlul_fifo_sync.sv} -regexp {Conne
 
 # primitivies: prim_ram_2p_wrapper
 #
-#waive -rules INPUT_NOT_READ -location {prim_ram_*_wrapper*} -regexp {cfg_i} \
-#      -comment "Register model doesn't need config port"
 #waive -rules NOT_READ -location {prim_ram_*_wrapper*} -regexp {(a|b)_rdata_(q|d)\[38} \
 #      -comment "Syndrome is not going out to the interface"

--- a/hw/ip/prim/rtl/prim_ram_1p_adv.sv
+++ b/hw/ip/prim/rtl/prim_ram_1p_adv.sv
@@ -47,6 +47,8 @@ module prim_ram_1p_adv #(
   input [CfgW-1:0] cfg_i
 );
 
+  logic [CfgW-1:0] unused_cfg = cfg_i;
+
   `ASSERT_INIT(CannotHaveEccAndParity_A, !(EnableParity && EnableECC))
 
   // While we require DataBitsPerMask to be per Byte (8) at the interface in case Byte parity is

--- a/hw/ip/prim/rtl/prim_ram_2p_async_adv.sv
+++ b/hw/ip/prim/rtl/prim_ram_2p_async_adv.sv
@@ -58,6 +58,8 @@ module prim_ram_2p_async_adv #(
   input [CfgW-1:0] cfg_i
 );
 
+  logic [CfgW-1:0] unused_cfg = cfg_i;
+
   `ASSERT_INIT(CannotHaveEccAndParity_A, !(EnableParity && EnableECC))
 
   // While we require DataBitsPerMask to be per Byte (8) at the interface in case Byte parity is


### PR DESCRIPTION
We do not use the `cfg` port at the moment, assign it to an `unused_`
variable to signal to our lint tools that this is intentional.