### PR TITLE
[lint] Add more lint waivers

### DIFF
--- a/hw/ip/prim/lint/prim.vlt
+++ b/hw/ip/prim/lint/prim.vlt
@@ -1,4 +1,14 @@
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-//
+
+`verilator_config
+
+// prim_subreg
+// for RO wd is not used
+lint_off -rule UNUSED -file "*/rtl/prim_subreg.sv" -match "Signal is not used: 'wd'"
+
+// prim_fifo_sync
+// In passthrough mode, clk and reset are not read form within this module
+lint_off -rule UNUSED -file "*/rtl/prim_fifo_sync.sv" -match "*clk_i*"
+lint_off -rule UNUSED -file "*/rtl/prim_fifo_sync.sv" -match "*rst_ni*"

--- a/hw/ip/tlul/lint/tlul_common.vlt
+++ b/hw/ip/tlul/lint/tlul_common.vlt
@@ -1,4 +1,9 @@
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-//
+
+`verilator_config
+
+// TLUL Error
+// All error checkings are comb logic and only portion of signals are used
+lint_off -rule UNUSED -file "*/rtl/tlul_err.sv"

--- a/hw/ip/tlul/lint/tlul_socket_1n.vlt
+++ b/hw/ip/tlul/lint/tlul_socket_1n.vlt
@@ -1,4 +1,11 @@
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-//
+
+`verilator_config
+
+// a_ready not needed, goes into FIFO
+lint_off -rule UNUSED -file "*/rtl/tlul_socket_1n.sv" -match "Bits of signal are not used: 'tl_t_p'[0]"
+
+// error response does not require command/address information
+lint_off -rule UNUSED -file "*/rtl/tlul_err_resp.sv" -match "Bits of signal are not used: 'tl_h_i'[97:95,84:1]"


### PR DESCRIPTION
Add lint waivers, in line with the AscentLint waivers for the
appropriate IP blocks, to get them lint-clean. The motivation for those
waivers has been copied over from AscentLint waivers as well.