### PR TITLE
[i2c, rtl] Style Lint fixes

### DIFF
--- a/hw/ip/i2c/rtl/i2c_core.sv
+++ b/hw/ip/i2c/rtl/i2c_core.sv
@@ -160,7 +160,7 @@ module  i2c_core (
       rx_watermark_q  <= rx_watermark_d;
     end
   end
- 
+
   always_comb begin
     unique case(i2c_fifo_fmtilvl)
       2'h0:    fmt_watermark_d = (fmt_fifo_depth <= 6'd1);

--- a/hw/ip/i2c/rtl/i2c_fsm.sv
+++ b/hw/ip/i2c/rtl/i2c_fsm.sv
@@ -97,8 +97,8 @@ module i2c_fsm (
         tClockStop  : tcount_d = t_f_i + tlow_i - thd_dat_i;
         tSetupStop  : tcount_d = t_r_i + tsu_sto_i;
         tHoldStop   : tcount_d = t_r_i + t_buf_i - tsu_sta_i;
-        tNoDelay    : tcount_d = 20'b1;
-        default     : tcount_d = 20'b1;
+        tNoDelay    : tcount_d = 20'h00001;
+        default     : tcount_d = 20'h00001;
       endcase
     end else if (stretch == 0) begin
       tcount_d = tcount_q - 1'b1;


### PR DESCRIPTION
1. Removed a trailing space.
2. Fixed undersized binary literal issues.

Signed-off-by: Igor Kouznetsov <igor.kouznetsov@wdc.com>