### PR TITLE
[otbn] Give IMEM/DMEM a 1 MiB address space each

### DIFF
--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -107,9 +107,9 @@
     } // register : start_addr
 
 
-    // Expansion space for further control/status registers, and to force
-    // alignment of IMEM.
-    { skipto: "0x1000" }
+    // Give IMEM and DMEM 1 MB address space, each, to allow for easy expansion
+    // of the actual IMEM and DMEM sizes without changing the address map.
+    { skipto: "0x100000" }
 
     { window: {
         name: "IMEM"
@@ -125,8 +125,7 @@
       }
     }
 
-    // Expansion space for a total of up to 16 kB of instruction memory (IMEM)
-    { skipto: "0x5000" }
+    { skipto: "0x200000" }
 
     { window: {
         name: "DMEM"


### PR DESCRIPTION
OTBN instruction and data memories (IMEM and DMEM) are currently 4 kB
each. To give us an easy way to modify the memory sizes without
modifications to software, we are currently trying to provide a 16 kB
address space for both IMEM and DMEM. Unfortunately, the way this
address space was defined didn't take into account address prefix
rules, making it hard to properly implement in hardware.

This commit fixes the prefixes/alignment, and also increases the address
space to 1 MB for IMEM and DMEM, each, giving us even more breathing
space. Overall, this makes the OTBN device occupy a 4 MB address space.

Fixes #2540