### PR TITLE
[syn] Print detailed messages to .md if publication is disabled

### DIFF
--- a/hw/syn/data/dc.hjson
+++ b/hw/syn/data/dc.hjson
@@ -24,4 +24,7 @@
                 "--logpath {build_dir} ",
                 "--reppath {build_dir}/REPORTS/ ",
                 "--outdir {build_dir}"]
+
+  // Restrict the maximum message count to 10 in each category
+  max_msg_count: 10
 }

--- a/hw/syn/tools/dc/parse-syn-report.py
+++ b/hw/syn/tools/dc/parse-syn-report.py
@@ -64,7 +64,10 @@ def _extract_messages(full_file, results, key):
     This extracts error and warning messages from the sting buffer full_file.
     """
     err_warn_patterns = [("%s_errors" % key, r"^Error: .*"),
-                         ("%s_warnings" % key, r"^Warning: .*")]
+                         ("%s_errors" % key, r"^ERROR: .*"),
+                         ("%s_errors" % key, r"^.*command not found.*"),
+                         ("%s_warnings" % key, r"^Warning: .*"),
+                         ("%s_warnings" % key, r"^WARNING: .*")]
     _match_strings(full_file, "messages", err_warn_patterns, results)
 
     return results

--- a/hw/syn/tools/dc/run-syn.tcl
+++ b/hw/syn/tools/dc/run-syn.tcl
@@ -12,8 +12,12 @@
 set CONFIG_PATH "./"
 source ${CONFIG_PATH}/setup.tcl
 
-# not exit remained in command line
-set RUN_INTERACTIVE $::env(INTERACTIVE)
+# if in interactive mode, do not exit at the end of the script
+if { [info exists ::env(INTERACTIVE)] } {
+    set RUN_INTERACTIVE 1
+} else {
+	set RUN_INTERACTIVE 0
+}
 
 # path to directory containing the source list file
 set SV_FLIST $::env(SV_FLIST)
@@ -166,7 +170,6 @@ saif_map -type ptpx -write_map ${RESULTDIR}/${DUT}.mapped.SAIF.namemap
 # write_file -format ddc     -hierarchy -output "${DDCDIR}/flat.ddc"
 # write_file -format verilog -hierarchy -output "${VLOGDIR}/flat.v"
 
-if { ![info exists RUN_INTERACTIVE] } {
+if { $RUN_INTERACTIVE == 0 } {
     exit
 }
-

--- a/util/dvsim/FlowCfg.py
+++ b/util/dvsim/FlowCfg.py
@@ -13,7 +13,7 @@ import sys
 import hjson
 
 from Deploy import Deploy
-from utils import VERBOSE, md_results_to_html, parse_hjson, subst_wildcards
+from utils import VERBOSE, md_results_to_html, parse_hjson, print_msg_list, subst_wildcards
 
 
 # Interface class for extensions.

--- a/util/dvsim/LintCfg.py
+++ b/util/dvsim/LintCfg.py
@@ -12,20 +12,7 @@ from pathlib import Path
 from tabulate import tabulate
 
 from OneShotCfg import OneShotCfg
-from utils import subst_wildcards
-
-
-# helper function for printing messages
-def _print_msg_list(msg_list_name, msg_list):
-    md_results = ""
-    if msg_list:
-        md_results += "### %s\n" % msg_list_name
-        md_results += "```\n"
-        for msg in msg_list:
-            md_results += msg + "\n\n"
-        md_results += "```\n"
-    return md_results
-
+from utils import print_msg_list, subst_wildcards
 
 class LintCfg(OneShotCfg):
     """Derivative class for linting purposes.
@@ -185,22 +172,22 @@ class LintCfg(OneShotCfg):
             self.result_summary["lint_errors"] += self.result["lint_errors"]
 
             # Append detailed messages if they exist
-            if sum([
-                    len(self.result["warnings"]),
-                    len(self.result["errors"]),
-                    len(self.result["lint_warnings"]),
-                    len(self.result["lint_errors"])
-            ]):
-                fail_msgs += "\n## Errors and Warnings for Build Mode `'" + mode.name + "'`\n"
-                fail_msgs += _print_msg_list("Tool Errors",
-                                             self.result["errors"])
-                fail_msgs += _print_msg_list("Tool Warnings",
-                                             self.result["warnings"])
-                fail_msgs += _print_msg_list("Lint Errors",
-                                             self.result["lint_errors"])
-                fail_msgs += _print_msg_list("Lint Warnings",
-                                             self.result["lint_warnings"])
-                # fail_msgs += _print_msg_list("Lint Infos", results["lint_infos"])
+            hdr_key_pairs = [("Tool Warnings", "warnings"),
+                             ("Tool Errors", "errors"),
+                             ("Lint Warnings", "lint_warnings"),
+                             ("Lint Errors", "lint_errors")]
+
+            has_msg = False
+            for _, key in hdr_key_pairs:
+                if key in self.result:
+                    has_msg = True
+                    break
+
+            if has_msg:
+                results_str += "\n### Errors and Warnings for Build Mode `'" + mode.name + "'`\n"
+                for hdr, key in hdr_key_pairs:
+                    msgs = self.result.get(key)
+                    results_str += print_msg_list("#### " + hdr, msgs, self.max_msg_count)
 
         if len(table) > 1:
             self.results_md = results_str + tabulate(

--- a/util/dvsim/OneShotCfg.py
+++ b/util/dvsim/OneShotCfg.py
@@ -58,6 +58,7 @@ class OneShotCfg(FlowCfg):
         self.build_modes = []
         self.run_modes = []
         self.regressions = []
+        self.max_msg_count = -1
 
         # Flow results
         self.result = OrderedDict()

--- a/util/dvsim/SynCfg.py
+++ b/util/dvsim/SynCfg.py
@@ -12,7 +12,7 @@ import hjson
 from tabulate import tabulate
 
 from OneShotCfg import OneShotCfg
-from utils import subst_wildcards
+from utils import print_msg_list, subst_wildcards
 
 
 class SynCfg(OneShotCfg):
@@ -342,6 +342,29 @@ class SynCfg(OneShotCfg):
                                             colalign=colalign) + "\n\n"
             else:
                 results_str += "No power report found\n\n"
+
+            # Append detailed messages if they exist
+            # Note that these messages are omitted in publication mode
+            hdr_key_pairs = [("Flow Warnings", "flow_warnings"),
+                             ("Flow Errors", "flow_errors"),
+                             ("Analyze Warnings", "analyze_warnings"),
+                             ("Analyze Errors", "analyze_errors"),
+                             ("Elab Warnings", "elab_warnings"),
+                             ("Elab Errors", "elab_errors"),
+                             ("Compile Warnings", "compile_warnings"),
+                             ("Compile Errors", "compile_errors")]
+
+            has_msg = False
+            for _, key in hdr_key_pairs:
+                if key in self.result['messages']:
+                    has_msg = True
+                    break
+
+            if has_msg and not self.args.publish:
+                results_str += "\n### Errors and Warnings for Build Mode `'" + mode.name + "'`\n"
+                for hdr, key in hdr_key_pairs:
+                    msgs = self.result['messages'].get(key)
+                    results_str += print_msg_list("#### " + hdr, msgs, self.max_msg_count)
 
             # TODO: add support for pie / bar charts for area splits and
             # QoR history

--- a/util/dvsim/utils.py
+++ b/util/dvsim/utils.py
@@ -350,3 +350,30 @@ def htmc_color_pc_cells(text):
         for item in subst_list:
             text = text.replace(item, subst_list[item])
     return text
+
+
+def print_msg_list(msg_list_title, msg_list, max_msg_count=-1):
+    '''This function prints a list of messages to Markdown.
+
+    The argument msg_list_title contains a string for the list title, whereas
+    the msg_list argument contains the actual list of message strings.
+    max_msg_count limits the number of messages to be printed (set to negative
+    number to print all messages).
+
+    Example:
+
+    print_msg_list("### Tool Warnings", ["Message A", "Message B"], 10)
+    '''
+    md_results = ""
+    if msg_list:
+        md_results += msg_list_title
+        md_results += "```\n"
+        for k, msg in enumerate(msg_list):
+            if k <= max_msg_count or max_msg_count < 0:
+                md_results += msg + "\n\n"
+            else:
+                md_results += "Note: %d more messages have been suppressed (max_msg_count = %d) \n\n" % (
+                    len(msg_list) - max_msg_count, max_msg_count)
+                break
+        md_results += "```\n"
+    return md_results


### PR DESCRIPTION
This enables the printout of detailed error and warning messages to the results markdown file of the synthesis flow if the `publish` switch is not set. 

Note that this touches a couple of files, since it also introduces a switch that allows you to set the maximum amount of messages to be printed. For the lint classes, this limit is disabled. For synthesis it is currently set to 10 to reduce clutter.

Signed-off-by: Michael Schaffner <msf@google.com>