### PR TITLE
[fpga] Add support for ChipWhisperer CW305 FPGA

### DIFF
--- a/hw/top_earlgrey/data/pins_cw305.xdc
+++ b/hw/top_earlgrey/data/pins_cw305.xdc
@@ -1,0 +1,127 @@
+## Partially based on https://github.com/newaetech/chipwhisperer/blob/develop/hardware/victims/cw305_artixtarget/fpga/common/cw305_main.xdc
+## Tested with a A100T FPGA configuration.
+
+## Clock Signal
+set_property -dict { PACKAGE_PIN N13 IOSTANDARD LVCMOS33 } [get_ports { IO_CLK }]
+create_clock -add -name sys_clk_pin -period 10.00 -waveform {0 5} [get_ports IO_CLK]
+
+## Output clock to capture board
+set_property -dict { PACKAGE_PIN M16 IOSTANDARD LVCMOS33 } [get_ports TIO_CLKOUT]
+
+## Clock Domain Crossings
+create_generated_clock -name clk_50_unbuf -source [get_pin clkgen/pll/CLKIN1] [get_pin clkgen/pll/CLKOUT0]
+create_generated_clock -name clk_48_unbuf -source [get_pin clkgen/pll/CLKIN1] [get_pin clkgen/pll/CLKOUT1]
+set_clock_groups -group clk_50_unbuf -group clk_48_unbuf -asynchronous
+
+## LEDs
+set_property -dict { PACKAGE_PIN T2  DRIVE 8 IOSTANDARD LVCMOS33 } [get_ports { IO_GP8 }]
+set_property -dict { PACKAGE_PIN T3  DRIVE 8 IOSTANDARD LVCMOS33 } [get_ports { IO_GP9 }]
+set_property -dict { PACKAGE_PIN T4  DRIVE 8 IOSTANDARD LVCMOS33 } [get_ports { IO_GP10 }]
+
+## Buttons
+set_property -dict { PACKAGE_PIN L14 IOSTANDARD LVCMOS33 } [get_ports { IO_RST_N }]; #pushbutton
+
+## Switches
+set_property -dict { PACKAGE_PIN J16 IOSTANDARD LVCMOS33 } [get_ports { IO_GP0 }]; #sw1
+set_property -dict { PACKAGE_PIN K16 IOSTANDARD LVCMOS33 } [get_ports { IO_GP1 }]; #sw2
+set_property -dict { PACKAGE_PIN K15 IOSTANDARD LVCMOS33 } [get_ports { IO_GP2 }]; #sw3
+set_property -dict { PACKAGE_PIN R1  IOSTANDARD LVCMOS33 } [get_ports { IO_GP3 }]; #sw4
+
+## UART
+set_property -dict { PACKAGE_PIN A12  IOSTANDARD LVCMOS33 } [get_ports { IO_UTX }]; #JP3.A12
+set_property -dict { PACKAGE_PIN B12  IOSTANDARD LVCMOS33 } [get_ports { IO_URX }]; #JP3.B12
+
+## SPI/JTAG
+set_property -dict { PACKAGE_PIN A14   IOSTANDARD LVCMOS33 } [get_ports { IO_DPS0 }]; #JP3.A14
+set_property -dict { PACKAGE_PIN A13   IOSTANDARD LVCMOS33 } [get_ports { IO_DPS1 }]; #JP3.A13
+set_property -dict { PACKAGE_PIN A15   IOSTANDARD LVCMOS33 } [get_ports { IO_DPS2 }]; #JP3.A15
+set_property -dict { PACKAGE_PIN B15   IOSTANDARD LVCMOS33 } [get_ports { IO_DPS3 }]; #JP3.B15
+set_property -dict { PACKAGE_PIN C12   IOSTANDARD LVCMOS33 } [get_ports { IO_DPS4 }]; #JP3.C12
+set_property -dict { PACKAGE_PIN C11   IOSTANDARD LVCMOS33 PULLTYPE PULLUP } [get_ports { IO_DPS5 }];   #JP3.C11
+set_property -dict { PACKAGE_PIN B14   IOSTANDARD LVCMOS33 PULLTYPE PULLDOWN } [get_ports { IO_DPS6 }]; #JP3.B14
+set_property -dict { PACKAGE_PIN C14   IOSTANDARD LVCMOS33 PULLTYPE PULLDOWN } [get_ports { IO_DPS7 }]; #JP3.C14
+
+
+## OTHER IO
+set_property -dict { PACKAGE_PIN B16 IOSTANDARD LVCMOS33 } [get_ports { IO_GP4  }]; #JP3.B16
+set_property -dict { PACKAGE_PIN C13 IOSTANDARD LVCMOS33 } [get_ports { IO_GP5  }]; #JP3.C13
+set_property -dict { PACKAGE_PIN D15 IOSTANDARD LVCMOS33 } [get_ports { IO_GP6  }]; #JP3.D15
+set_property -dict { PACKAGE_PIN E15 IOSTANDARD LVCMOS33 } [get_ports { IO_GP7  }]; #JP3.E15
+set_property -dict { PACKAGE_PIN E13 IOSTANDARD LVCMOS33 } [get_ports { IO_GP11 }]; #JP3.E13
+set_property -dict { PACKAGE_PIN F15 IOSTANDARD LVCMOS33 } [get_ports { IO_GP12 }]; #JP3.F15
+set_property -dict { PACKAGE_PIN E11 IOSTANDARD LVCMOS33 } [get_ports { IO_GP13 }]; #JP3.E11
+set_property -dict { PACKAGE_PIN F13 IOSTANDARD LVCMOS33 } [get_ports { IO_GP14 }]; #JP3.F13
+set_property -dict { PACKAGE_PIN F12 IOSTANDARD LVCMOS33 } [get_ports { IO_GP15 }]; #JP3.F12
+
+set_property -dict { PACKAGE_PIN C16 IOSTANDARD LVCMOS33 DRIVE 8 SLEW FAST } [get_ports { IO_USB_DP0 }]; #JP3.C16
+set_property -dict { PACKAGE_PIN D13 IOSTANDARD LVCMOS33 DRIVE 8 SLEW FAST } [get_ports { IO_USB_DN0 }]; #JP3.D13
+set_property -dict { PACKAGE_PIN H16 IOSTANDARD LVCMOS33 } [get_ports { IO_USB_DPPULLUP0 }]; #JP3.H16
+set_property -dict { PACKAGE_PIN D16 IOSTANDARD LVCMOS33 } [get_ports { IO_USB_SENSE0 }]; #JP3.D16
+set_property -dict { PACKAGE_PIN E16 IOSTANDARD LVCMOS33 } [get_ports { IO_USB_DNPULLUP0 }]; #JP3.E16
+
+## 20-Pin Connector
+
+#set_property PACKAGE_PIN T14 [get_ports tio_trigger]
+#set_property PACKAGE_PIN M16 [get_ports tio_clkout]
+#set_property PACKAGE_PIN N14 [get_ports tio_clkin]
+
+## USB Connector
+# TODO: Configure USB capture interface and sync triggers.
+
+#set_property PACKAGE_PIN F5 [get_ports usb_clk]
+
+#set_property IOSTANDARD LVCMOS33 [get_ports *]
+#set_property PACKAGE_PIN A7 [get_ports {usb_data[0]}]
+#set_property PACKAGE_PIN B6 [get_ports {usb_data[1]}]
+#set_property PACKAGE_PIN D3 [get_ports {usb_data[2]}]
+#set_property PACKAGE_PIN E3 [get_ports {usb_data[3]}]
+#set_property PACKAGE_PIN F3 [get_ports {usb_data[4]}]
+#set_property PACKAGE_PIN B5 [get_ports {usb_data[5]}]
+#set_property PACKAGE_PIN K1 [get_ports {usb_data[6]}]
+#set_property PACKAGE_PIN K2 [get_ports {usb_data[7]}]
+
+#set_property PACKAGE_PIN F4 [get_ports {usb_addr[0]}]
+#set_property PACKAGE_PIN G5 [get_ports {usb_addr[1]}]
+#set_property PACKAGE_PIN J1 [get_ports {usb_addr[2]}]
+#set_property PACKAGE_PIN H1 [get_ports {usb_addr[3]}]
+#set_property PACKAGE_PIN H2 [get_ports {usb_addr[4]}]
+#set_property PACKAGE_PIN G1 [get_ports {usb_addr[5]}]
+#set_property PACKAGE_PIN G2 [get_ports {usb_addr[6]}]
+#set_property PACKAGE_PIN F2 [get_ports {usb_addr[7]}]
+#set_property PACKAGE_PIN E1 [get_ports {usb_addr[8]}]
+#set_property PACKAGE_PIN E2 [get_ports {usb_addr[9]}]
+#set_property PACKAGE_PIN D1 [get_ports {usb_addr[10]}]
+#set_property PACKAGE_PIN C1 [get_ports {usb_addr[11]}]
+#set_property PACKAGE_PIN K3 [get_ports {usb_addr[12]}]
+#set_property PACKAGE_PIN L2 [get_ports {usb_addr[13]}]
+#set_property PACKAGE_PIN J3 [get_ports {usb_addr[14]}]
+#set_property PACKAGE_PIN B2 [get_ports {usb_addr[15]}]
+#set_property PACKAGE_PIN C7 [get_ports {usb_addr[16]}]
+#set_property PACKAGE_PIN C6 [get_ports {usb_addr[17]}]
+#set_property PACKAGE_PIN D6 [get_ports {usb_addr[18]}]
+#set_property PACKAGE_PIN C4 [get_ports {usb_addr[19]}]
+#set_property PACKAGE_PIN D5 [get_ports {usb_addr[20]}]
+
+#set_property PACKAGE_PIN A4 [get_ports usb_rdn]
+#set_property PACKAGE_PIN C2 [get_ports usb_wrn]
+#set_property PACKAGE_PIN A3 [get_ports usb_cen]
+
+#set_property PACKAGE_PIN A5 [get_ports usb_trigger]
+
+#set_property CLOCK_DEDICATED_ROUTE FALSE [get_nets usb_clk]
+#set_property CLOCK_DEDICATED_ROUTE FALSE [get_nets crypt_clk]
+
+
+#create_clock -period 10.000 -name usb_clk -waveform {0.000 5.000} [get_nets usb_clk]
+#create_clock -period 10.000 -name tio_clkin -waveform {0.000 5.000} [get_nets tio_clkin]
+#create_clock -period 10.000 -name pll_clk1 -waveform {0.000 5.000} [get_nets pll_clk1]
+
+#set_input_delay -clock [get_clocks -filter { NAME =~  "*usb_clk*" }] 3.000 [get_ports -filter { NAME =~  "*usb_data*" && DIRECTION == "INOUT" }]
+
+#set_property CLOCK_DEDICATED_ROUTE FALSE [get_nets usb_rdn]
+#set_property CLOCK_DEDICATED_ROUTE FALSE [get_nets usb_wrn]
+
+
+## Configuration options, can be used for all designs
+set_property CONFIG_VOLTAGE 3.3 [current_design]
+set_property CFGBVS VCCO [current_design]

--- a/hw/top_earlgrey/rtl/top_earlgrey_cw305.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_cw305.sv
@@ -1,0 +1,262 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+module top_earlgrey_cw305 #(
+  // Path to a VMEM file containing the contents of the boot ROM, which will be
+  // baked into the FPGA bitstream.
+  parameter BootRomInitFile = "boot_rom_fpga_nexysvideo.32.vmem"
+) (
+  // Clock and Reset
+  inout               IO_CLK,
+  inout               IO_RST_N,
+  // JTAG interface
+  inout               IO_DPS0, // IO_JTCK,    IO_SDCK
+  inout               IO_DPS3, // IO_JTMS,    IO_SDCSB
+  inout               IO_DPS1, // IO_JTDI,    IO_SDMOSI
+  inout               IO_DPS4, // IO_JTRST_N,
+  inout               IO_DPS5, // IO_JSRST_N,
+  inout               IO_DPS2, // IO_JTDO,    IO_MISO
+  inout               IO_DPS6, // JTAG=1,     SPI=0
+  inout               IO_DPS7, // BOOTSTRAP=1
+  // UART interface
+  inout               IO_URX,
+  inout               IO_UTX,
+  // USB interface
+  inout               IO_USB_DP0,
+  inout               IO_USB_DN0,
+  inout               IO_USB_SENSE0,
+  inout               IO_USB_DNPULLUP0,
+  inout               IO_USB_DPPULLUP0,
+  // GPIO x 16 interface
+  inout               IO_GP0,
+  inout               IO_GP1,
+  inout               IO_GP2,
+  inout               IO_GP3,
+  inout               IO_GP4,
+  inout               IO_GP5,
+  inout               IO_GP6,
+  inout               IO_GP7,
+  output              IO_GP8,  // XXX: rename as LED
+  output              IO_GP9,  // XXX: rename as LED
+  output              IO_GP10, // XXX: rename as LED
+  inout               IO_GP11,
+  inout               IO_GP12,
+  inout               IO_GP13,
+  inout               IO_GP14,
+  inout               IO_GP15,
+  // chipwhisperer IO
+  output              TIO_CLKOUT
+);
+
+  import top_earlgrey_pkg::*;
+
+  //////////////////////
+  // Padring Instance //
+  //////////////////////
+
+
+  logic clk, clk_usb_48mhz, rst_n;
+  logic [padctrl_reg_pkg::NMioPads-1:0][padctrl_reg_pkg::AttrDw-1:0] mio_attr;
+  logic [padctrl_reg_pkg::NDioPads-1:0][padctrl_reg_pkg::AttrDw-1:0] dio_attr;
+  logic [padctrl_reg_pkg::NMioPads-1:0] mio_out_core, mio_out_padring;
+  logic [padctrl_reg_pkg::NMioPads-1:0] mio_oe_core, mio_oe_padring;
+  logic [padctrl_reg_pkg::NMioPads-1:0] mio_in_core, mio_in_padring;
+  logic [padctrl_reg_pkg::NDioPads-1:0] dio_out_core, dio_out_padring;
+  logic [padctrl_reg_pkg::NDioPads-1:0] dio_oe_core, dio_oe_padring;
+  logic [padctrl_reg_pkg::NDioPads-1:0] dio_in_core, dio_in_padring;
+
+  reg io_utx_reg;
+  always @(posedge clk) begin
+      io_utx_reg <<= (IO_UTX == 1'bz)? 0 : IO_UTX;
+  end
+  assign IO_GP8 = io_utx_reg;
+
+  reg io_urx_reg;
+  always @(posedge clk) begin
+    io_urx_reg <<= (IO_URX == 1'bz)? 0 : IO_URX;
+  end
+  assign IO_GP9 = io_urx_reg;
+
+  assign IO_GP10 = 1'b1;
+
+  assign TIO_CLKOUT = clk;
+
+  padring #(
+    // MIOs 31:20 are currently not
+    // connected to pads and hence tied off
+    .ConnectMioIn  ( 32'h000FF8FF ),
+    .ConnectMioOut ( 32'h000FF8FF ),
+    // Tied off DIOs:
+    // 2: usbdev_d
+    // 3: usbdev_suspend
+    // 4: usbdev_tx_mode
+    // 7: usbdev_se
+    .ConnectDioIn  ( 15'h7F63 ),
+    .ConnectDioOut ( 15'h7F63 )
+  ) padring (
+    // Clk / Rst
+    .clk_pad_i           ( 1'b0 ),
+    .clk_usb_48mhz_pad_i ( 1'b0 ),
+    .rst_pad_ni          ( 1'b0 ),
+    .clk_o               (      ),
+    .clk_usb_48mhz_o     (      ),
+    .rst_no              (      ),
+    // MIO Pads
+    .mio_pad_io          ( { 12'bz,   // Note that 31:20 are currently not mapped
+                             IO_DPS5, // Use GPIO19 to pass JTAG_SRST
+                             IO_DPS4, // Use GPIO18 to pass JTAG_TRST
+                             IO_DPS7, // Use GPIO17 to pass rom boot_strap indication
+                             IO_DPS6, // Use GPIO16 to pass SPI/JTAG control flag
+                             IO_GP15,
+                             IO_GP14,
+                             IO_GP13,
+                             IO_GP12,
+                             IO_GP11,
+                             1'bz,
+                             1'bz,
+                             1'bz,
+                             IO_GP7,
+                             IO_GP6,
+                             IO_GP5,
+                             IO_GP4,
+                             IO_GP3,
+                             IO_GP2,
+                             IO_GP1,
+                             IO_GP0 } ),
+    // DIO Pads
+    .dio_pad_io          ( { IO_DPS0, // SCK, JTAG_TCK
+                             IO_DPS3, // CSB, JTAG_TMS
+                             IO_DPS1, // MOSI, JTAG_TDI
+                             IO_DPS2, // MISO, JTAG_TDO
+                             IO_URX,
+                             IO_UTX,
+                             IO_USB_SENSE0,
+                             1'bz,    // usbdev_se0
+                             IO_USB_DPPULLUP0,
+                             IO_USB_DNPULLUP0,
+                             1'bz,    // usbdev_tx_mode
+                             1'bz,    // usbdev_suspend
+                             1'bz,    // usbdev_d
+                             IO_USB_DP0,
+                             IO_USB_DN0 } ),
+    // Muxed IOs
+    .mio_in_o            ( mio_in_padring   ),
+    .mio_out_i           ( mio_out_padring  ),
+    .mio_oe_i            ( mio_oe_padring   ),
+    // Dedicated IOs
+    .dio_in_o            ( dio_in_padring   ),
+    .dio_out_i           ( dio_out_padring  ),
+    .dio_oe_i            ( dio_oe_padring   ),
+    // Pad Attributes
+    .mio_attr_i          ( mio_attr         ),
+    .dio_attr_i          ( dio_attr         )
+  );
+
+  //////////////////////
+  // JTAG Overlay Mux //
+  //////////////////////
+
+  logic jtag_trst_n, jtag_srst_n;
+  logic jtag_tck, jtag_tms, jtag_tdi, jtag_tdo;
+
+  localparam int NumIOs = padctrl_reg_pkg::NMioPads +
+                          padctrl_reg_pkg::NDioPads;
+
+  // This specifies the tie-off values of the muxed MIO/DIOs
+  // when the JTAG is active. SPI CSB is active low.
+  localparam logic [NumIOs-1:0] TieOffValues = NumIOs'(1'b1 << (
+      padctrl_reg_pkg::NMioPads + top_earlgrey_pkg::TopEarlgreyDioPinSpiDeviceCsb));
+
+  // TODO: this is a temporary solution. JTAG will eventually be selected and
+  // qualified inside the pinmux, based on strap and lifecycle state.
+  // Parameterizeable JTAG overlay mux.
+  // Unaffected indices are just passed through.
+  jtag_mux #(
+    .NumIOs         (                   NumIOs       ),
+    .TieOffValues   (                   TieOffValues ),
+    .JtagEnIdx      (                             16 ), // MIO 16
+    .JtagEnPolarity (                              1 ),
+    .TckIdx         ( padctrl_reg_pkg::NMioPads +
+                      top_earlgrey_pkg::TopEarlgreyDioPinSpiDeviceSck ),
+    .TmsIdx         ( padctrl_reg_pkg::NMioPads +
+                      top_earlgrey_pkg::TopEarlgreyDioPinSpiDeviceCsb ),
+    .TrstIdx        (                             18 ), // MIO 18
+    .SrstIdx        (                             19 ), // MIO 19
+    .TdiIdx         ( padctrl_reg_pkg::NMioPads +
+                      top_earlgrey_pkg::TopEarlgreyDioPinSpiDeviceMosi ),
+    .TdoIdx         ( padctrl_reg_pkg::NMioPads +
+                      top_earlgrey_pkg::TopEarlgreyDioPinSpiDeviceMiso )
+  ) jtag_mux (
+    // To JTAG inside core
+    .jtag_tck_o   ( jtag_tck        ),
+    .jtag_tms_o   ( jtag_tms        ),
+    .jtag_trst_no ( jtag_trst_n     ),
+    .jtag_srst_no ( jtag_srst_n     ),
+    .jtag_tdi_o   ( jtag_tdi        ),
+    .jtag_tdo_i   ( jtag_tdo        ),
+    // To core side
+    .out_core_i   ( {dio_out_core, mio_out_core} ),
+    .oe_core_i    ( {dio_oe_core,  mio_oe_core}  ),
+    .in_core_o    ( {dio_in_core,  mio_in_core}  ),
+    // To padring side
+    .out_padring_o ( {dio_out_padring, mio_out_padring} ),
+    .oe_padring_o  ( {dio_oe_padring , mio_oe_padring } ),
+    .in_padring_i  ( {dio_in_padring , mio_in_padring } )
+  );
+
+  //////////////////
+  // PLL for FPGA //
+  //////////////////
+
+  clkgen_xil7series # (
+    .AddClkBuf(0)
+  ) clkgen (
+      .IO_CLK,
+    .IO_RST_N(IO_RST_N & jtag_srst_n),
+    .clk_sys(clk),
+    .clk_48MHz(clk_usb_48mhz),
+    .rst_sys_n(rst_n)
+  );
+
+  //////////////////////
+  // Top-level design //
+  //////////////////////
+
+  top_earlgrey #(
+    .IbexPipeLine(1),
+    .BootRomInitFile(BootRomInitFile)
+  ) top_earlgrey (
+    // Clocks, resets
+    .clk_i           ( clk           ),
+    .rst_ni          ( rst_n         ),
+    .clk_io_i        ( clk           ),
+    .clk_aon_i       ( clk           ),
+    .clk_usb_i       ( clk_usb_48mhz ),
+
+    // JTAG
+    .jtag_tck_i      ( jtag_tck      ),
+    .jtag_tms_i      ( jtag_tms      ),
+    .jtag_trst_ni    ( jtag_trst_n   ),
+    .jtag_tdi_i      ( jtag_tdi      ),
+    .jtag_tdo_o      ( jtag_tdo      ),
+
+    // Multiplexed I/O
+    .mio_in_i        ( mio_in_core   ),
+    .mio_out_o       ( mio_out_core  ),
+    .mio_oe_o        ( mio_oe_core   ),
+
+    // Dedicated I/O
+    .dio_in_i        ( dio_in_core   ),
+    .dio_out_o       ( dio_out_core  ),
+    .dio_oe_o        ( dio_oe_core   ),
+
+    // Pad attributes
+    .mio_attr_o      ( mio_attr      ),
+    .dio_attr_o      ( dio_attr      ),
+
+    // DFT signals
+    .scanmode_i      ( 1'b0          )
+  );
+
+endmodule : top_earlgrey_cw305

--- a/hw/top_earlgrey/top_earlgrey_cw305.core
+++ b/hw/top_earlgrey/top_earlgrey_cw305.core
@@ -1,0 +1,50 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:systems:top_earlgrey_cw305:0.1"
+description: "Earl Grey toplevel for the ChipWhisperer CW305 board"
+filesets:
+  files_rtl_cw305:
+    depend:
+      - lowrisc:systems:top_earlgrey:0.1
+    files:
+      - rtl/clkgen_xil7series.sv
+      - rtl/top_earlgrey_cw305.sv
+    file_type: systemVerilogSource
+
+  files_constraints:
+    files:
+      - data/pins_cw305.xdc
+    file_type: xdc
+
+parameters:
+  BootRomInitFile:
+    datatype: str
+    description: Boot ROM initialization file in 32 bit vmem hex format
+    default: "../../../../../build-bin/sw/device/boot_rom/boot_rom_fpga_nexysvideo.32.vmem"
+    paramtype: vlogparam
+  # For value definition, please see ip/prim/rtl/prim_pkg.sv
+  PRIM_DEFAULT_IMPL:
+    datatype: str
+    paramtype: vlogdefine
+    description: Primitives implementation to use, e.g. "prim_pkg::ImplGeneric".
+
+targets:
+  default: &default_target
+    filesets:
+      - files_rtl_cw305
+    toplevel: top_earlgrey_cw305
+
+  synth:
+    default_tool: vivado
+    filesets:
+      - files_rtl_cw305
+      - files_constraints
+    toplevel: top_earlgrey_cw305
+    parameters:
+      - BootRomInitFile
+      - PRIM_DEFAULT_IMPL=prim_pkg::ImplXilinx
+    tools:
+      vivado:
+        part: "xc7a100tftg256-2" # CW305 Board


### PR DESCRIPTION
The CW305 Artix FPGA target board is used to perform side channel analysis testing using
the ChipWhisperer capture board and API. This PR adds initial support for the Artix A100T
with a pinout configuration compatible with the CW305.  A reduced flash configuration is
required to fit the current design on the Artix A100T.

Changes required to get the design to fit:
Also see lowrisc/opentitan#2171

`hw/top_earlgrey/data/top_earlgrey.hjson`:

```
    { name: "eflash",
      clock_srcs: {clk_i: "main"},
      clock_group: "infra",
      reset_connections: {rst_ni: "lc"},
      type: "eflash",
      base_addr: "0x20000000",
      swaccess: "ro",
      size: "0x10000",  // <--- Update to this value
```

`hw/top_earlgrey/rtl/top_pkg.sv`:

```
localparam int FLASH_PAGES_PER_BANK=32;
```

To build the design:

```console
$ make -C hw
$ fusesoc --cores-root . pgm lowrisc:systems:top_earlgrey_cw305:0.1
```

To program the image using the ChipWishperer API:

```Python
from chipwhisperer.capture.targets.CW305 import CW305

target = CW305()

print('Connecting and loading FPGA')
target.con(bsfile='lowrisc_systems_top_earlgrey_cw305_0.1.bit', force=True)

target.vccint_set(1.0)

print('Initializing PLL1')
target.pll.pll_enable_set(True)
target.pll.pll_outenable_set(False, 0)
target.pll.pll_outenable_set(True, 1)
target.pll.pll_outenable_set(False, 2)

# run at 50 MHz by setting the input clock at 100MHz:
target.pll.pll_outfreq_set(100E6, 1)
```

Signed-off-by: Miguel Osorio <miguelosorio@google.com>