### PR TITLE
[style] Allow using the `warn_unused_result` attr, and mandate it for DIFs.

### DIFF
--- a/doc/rm/c_cpp_coding_style.md
+++ b/doc/rm/c_cpp_coding_style.md
@@ -329,6 +329,7 @@ The following nonstandard attributes may be used:
 *   `weak` to make a symbol definition have weak linkage.
 *   `interrupt` to ensure a function has the right prolog and epilog for interrupts (this involves saving and restoring more registers than normal).
 *   `packed` to ensure a struct contains no padding.
+*   `warn_unused_result`, to mark functions that return error values that should be checked.
 
 It is recommended that other nonstandard attributes are not used, especially where C11 provides a standard means to accomplish the same thing.
 

--- a/meson.build
+++ b/meson.build
@@ -54,20 +54,24 @@ endif
 add_project_arguments(
   '-I' + meson.source_root(),
   '-I' + meson.build_root(),
+  '-Wno-error=unused-result',  # Remove once we've fully adopted warn_unused_result.
   language: 'cpp', native: false)
 add_project_arguments(
   '-I' + meson.source_root(),
   '-I' + meson.build_root(),
+  '-Wno-error=unused-result',  # Remove once we've fully adopted warn_unused_result.
   language: 'cpp', native: true)
 
 add_project_arguments(
   '-I' + meson.source_root(),
   '-I' + meson.build_root(),
   '-isystem' + meson.source_root() / 'sw/device/lib/base/freestanding',
+  '-Wno-error=unused-result',  # Remove once we've fully adopted warn_unused_result.
   language: 'c', native: false)
 add_project_arguments(
   '-I' + meson.source_root(),
   '-I' + meson.build_root(),
+  '-Wno-error=unused-result',  # Remove once we've fully adopted warn_unused_result.
   language: 'c', native: true)
 
 # The following flags are applied only to cross builds

--- a/sw/device/lib/dif/README.md
+++ b/sw/device/lib/dif/README.md
@@ -103,6 +103,10 @@ there are some relaxations of these rules for them described at the end.
     * If a DIF returns `kDif<ip>BadArg`, it must leave the hardware in a valid
       and recoverable state. This is in addition to the rule that this value may
       only be returned if the function has not caused any side-effects.
+  * DIFs that return an enum return code must be annotated with
+    `__attribute__((warn_unused_result))`, to help minimize mistakes from
+    failing to check a result. This guidance applies to `static` helper
+    functions that return an error of some kind as well.
   * DIFs that cannot error and that do not return a value must return `void`.
 
 * DIFs must check their arguments against preconditions using "guard


### PR DESCRIPTION
I chatted with Sam and we realized that GCC and Clang both support `warn_unused_result`, which is analogous to the standard C++17 `[[must_use_result]]` annotation.

I've run into a couple of places where this annotation would make DIFs a bit easier to review (since I don't need to worry about return values getting checked). Also, the benefit would carry over into Rust: we can set bindgen [1] to convert `warn_unused_result` into Rust's `#[must_use]`, which is analogus.

The changes in this PR should not be construed to apply to in-flight DIFs. You can adopt if you want to but we'll be doing a post-merge cleanup later.

[1] https://docs.rs/bindgen/0.54.0/bindgen/struct.Builder.html#method.enable_function_attribute_detection