### PR TITLE
[i2c, dv] Support chained read requests 

### DIFF
--- a/hw/dv/sv/i2c_agent/i2c_item.sv
+++ b/hw/dv/sv/i2c_agent/i2c_item.sv
@@ -15,15 +15,25 @@ class i2c_item extends uvm_sequence_item;
   bit                      nack;
   bit                      ack;
   bit                      rstart;
-  bit [7:0]                fbyte;
+
   // random flags
+  rand bit [7:0]           fbyte;
   rand bit                 nakok, rcont, read, stop, start;
 
+  constraint fbyte_c     { fbyte      inside {[0 : 127]}; }
   constraint start_c     { start      inside {0, 1}; }
   constraint stop_c      { stop       inside {0, 1}; }
   constraint read_c      { read       inside {0, 1}; }
-  constraint rcont_c     { rcont      inside {0, 1}; }
   constraint nakok_c     { nakok      inside {0, 1}; }
+  constraint rcont_c     {
+     solve read, stop before rcont;
+     if (read) {
+       // rcont must be unset when both read and stop are set
+       rcont  == ~stop;
+     } else {
+       rcont  inside {0, 1};
+     }
+  }
 
   `uvm_object_utils_begin(i2c_item)
     `uvm_field_int(tran_id,                 UVM_DEFAULT)
@@ -35,6 +45,7 @@ class i2c_item extends uvm_sequence_item;
     `uvm_field_int(stop,                    UVM_DEFAULT)
     //------
     `uvm_field_int(rstart,                  UVM_DEFAULT | UVM_NOPRINT | UVM_NOCOMPARE)
+    `uvm_field_int(fbyte,                   UVM_DEFAULT | UVM_NOPRINT | UVM_NOCOMPARE)
     `uvm_field_int(ack,                     UVM_DEFAULT | UVM_NOPRINT | UVM_NOCOMPARE)
     `uvm_field_int(nack,                    UVM_DEFAULT | UVM_NOPRINT | UVM_NOCOMPARE)
     `uvm_field_int(read,                    UVM_DEFAULT | UVM_NOPRINT | UVM_NOCOMPARE)

--- a/hw/dv/sv/i2c_agent/i2c_monitor.sv
+++ b/hw/dv/sv/i2c_agent/i2c_monitor.sv
@@ -51,8 +51,9 @@ class i2c_monitor extends dv_base_monitor #(
         end
         num_dut_tran++;
         mon_dut_item.start = 1'b1;
-        // issue address then rd/wr data
+        // monitor address for non-chained reads
         address_thread(mon_dut_item, num_dut_tran);
+        // monitor read/write data
         if (mon_dut_item.bus_op == BusOpRead) read_thread(mon_dut_item);
         else                                  write_thread(mon_dut_item);
         // send rsp_item to scoreboard

--- a/hw/ip/i2c/dv/env/i2c_env_pkg.sv
+++ b/hw/ip/i2c/dv/env/i2c_env_pkg.sv
@@ -51,6 +51,8 @@ package i2c_env_pkg;
   parameter uint I2C_MIN_TIMEOUT = 1;
   parameter uint I2C_MAX_TIMEOUT = 4;
   parameter uint I2C_IDLE_TIME   = 1200;
+  parameter uint I2C_MAX_RXILVL  = 4;
+  parameter uint I2C_MAX_FMTILVL = 3;
 
   // ok_to_end_delay_ns for EoT
   parameter uint DELAY_FOR_EOT_NS = 5000;

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_rx_tx_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_rx_tx_vseq.sv
@@ -7,22 +7,22 @@ class i2c_rx_tx_vseq extends i2c_base_vseq;
 
   `uvm_object_new
 
-  virtual task host_init();
-    bit             fmtrst,  rxrst;
-    bit [1:0]       fmtilvl, rxilvl;
-    bit [TL_DW-1:0] reg_val;
+  uint total_rd_bytes = 0;
 
+  virtual task host_init();
     super.host_init();
+
     // diable override
     ral.ovrd.txovrden.set(1'b0);
     csr_update(ral.ovrd);
     // reset and set level of rx and fmt fifos
-    rxrst   = 1'b1;
-    fmtrst  = 1'b1;
-    rxilvl  = 2'd3;
-    fmtilvl = 2'd3;
-    reg_val = {24'd0, fmtilvl, rxilvl, fmtrst, rxrst};
-    csr_wr(.csr(ral.fifo_ctrl), .value(reg_val));
+    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(fmtilvl)
+    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(rxilvl)
+    ral.fifo_ctrl.rxrst.set(1'b1);
+    ral.fifo_ctrl.fmtrst.set(1'b1);
+    ral.fifo_ctrl.rxilvl.set(rxilvl);
+    ral.fifo_ctrl.fmtilvl.set(fmtilvl);
+    csr_update(ral.fifo_ctrl);
   endtask : host_init
 
   virtual task host_send_trans(int num_trans);
@@ -40,17 +40,22 @@ class i2c_rx_tx_vseq extends i2c_base_vseq;
         program_timing_regs();
       end
 
+      // program address for
+      if ((cur_tran == 1'b1) ||                       // first read
+          (!fmt_item.read)   ||                       // write trans.
+          (fmt_item.read && !fmt_item.rcont)) begin   // non-chained reads
+        host_program_target_address();
+      end
+
       last_tran = (cur_tran == num_trans) ? 1'b1 : 1'b0;
-      // not program address for chained reads
-      host_program_target_address();
       `uvm_info(`gfn, $sformatf("start sending %s transaction %0d/%0d",
           (rw_bit) ? "READ" : "WRITE", cur_tran, num_trans), UVM_DEBUG)
       if (rw_bit) host_read_trans(last_tran);
       else        host_write_trans(last_tran);
+
       `uvm_info(`gfn, $sformatf("finish sending %s transaction, %0s at the end,  %0d/%0d, ",
           (rw_bit) ? "read" : "write",
           (fmt_item.stop) ? "stop" : "rstart", cur_tran, num_trans), UVM_DEBUG)
-
       // check a completed transaction is programmed to the host/dut (stop bit must be issued)
       // and check if the host/dut is in idle before allow re-programming the timing registers
       if (fmt_item.stop) begin
@@ -60,10 +65,12 @@ class i2c_rx_tx_vseq extends i2c_base_vseq;
   endtask : host_send_trans
 
   virtual task host_program_target_address();
-    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(fmt_item)
-    fmt_item.start = 1'b1;
-    fmt_item.stop  = 1'b0;
-    fmt_item.read  = 1'b0;
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(fmt_item,
+      start == 1'b1;
+      stop  == 1'b0;
+      read  == 1'b0;
+      rcont == 1'b0;
+    )
     if (cfg.target_addr_mode == Addr7BitMode) begin
       fmt_item.fbyte = (rw_bit) ? {addr[6:0], BusOpRead} : {addr[6:0], BusOpWrite};
     end else begin // Addr10BitMode
@@ -74,26 +81,35 @@ class i2c_rx_tx_vseq extends i2c_base_vseq;
 
   virtual task host_read_trans(bit last_tran);
     uint real_rd_bytes;
-    uint total_rd_bytes = 0;
 
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(num_rd_bytes)
     fork
       begin
-        `DV_CHECK_MEMBER_RANDOMIZE_FATAL(fmt_item)
-        fmt_item.fbyte = num_rd_bytes;
-        fmt_item.start = 1'b0;
-        fmt_item.read  = 1'b1;
-        fmt_item.rcont = 1'b0; // TODO: no chained read support
-        // for the last write byte of last tran., stop flag must be set to issue stop bit (stimulus end)
-        // otherwise, stop can be randomly set/unset to issue stop/rstart bit respectively
-        fmt_item.stop  = (last_tran) ? 1'b1 : $urandom_range(0, 1);
+        `DV_CHECK_RANDOMIZE_WITH_FATAL(fmt_item,
+          fbyte == num_rd_bytes;
+          start == 1'b0;
+          read  == 1'b1;
+          // for the last write byte of last tran., stop flag must be set to issue stop bit (stimulus end)
+          // otherwise, stop can be randomly set/unset to issue stop/rstart bit respectively
+          // rcont is derived from stop and read to issue chained/non-chained reads
+          stop  == (last_tran) ? 1'b1 : stop;
+        )
+        `DV_CHECK_EQ(fmt_item.stop | fmt_item.rcont, 1)
+
         real_rd_bytes = (num_rd_bytes) ? num_rd_bytes : 256;
         total_rd_bytes += real_rd_bytes;
+        if (fmt_item.rcont) begin
+          `uvm_info(`gfn, "\nTransaction READ with chaining", UVM_DEBUG)
+        end else begin
+          `uvm_info(`gfn, $sformatf("\nTransaction READ  %0s with ",
+              (fmt_item.stop) ? "STOP end, START after" : "RSTART after"), UVM_DEBUG)
+        end
         program_format_flag(fmt_item, "program number of bytes to read");
       end
       begin
         if (!cfg.do_rd_overflow) begin
-          while (total_rd_bytes > 0) begin
+          // if not a chained read, read out data sent over rx_fifo
+          while (!fmt_item.rcont && total_rd_bytes > 0) begin
             csr_spinwait(.ptr(ral.status.rxempty), .exp_data(1'b0));
             csr_rd(.ptr(ral.rdata), .value(rd_data));
             total_rd_bytes--;
@@ -108,14 +124,19 @@ class i2c_rx_tx_vseq extends i2c_base_vseq;
   virtual task host_write_trans(bit last_tran);
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(num_wr_bytes)
     for (int i = 1; i <= num_wr_bytes; i++) begin
-      `DV_CHECK_MEMBER_RANDOMIZE_FATAL(fmt_item)
-      fmt_item.start = 1'b0;
-      fmt_item.read  = 1'b0;
+      `DV_CHECK_RANDOMIZE_WITH_FATAL(fmt_item,
+        start == 1'b0;
+        read  == 1'b0;
+      )
       `DV_CHECK_MEMBER_RANDOMIZE_FATAL(wr_data)
       fmt_item.fbyte = wr_data;
       // last write byte of last  tran., stop flag must be set to issue stop bit
       // last write byte of other tran., stop is randomly set/unset to issue stop/rstart bit
       fmt_item.stop = (i != num_wr_bytes) ? 1'b0 : ((last_tran) ? 1'b1 : fmt_item.stop);
+      if (i == num_wr_bytes) begin
+        `uvm_info(`gfn, $sformatf("\nTransaction WRITE %0s with",
+            (fmt_item.stop) ? "STOP end, START after" : "RSTART after"), UVM_DEBUG)
+      end
       program_format_flag(fmt_item, "host_write_trans");
     end
   endtask : host_write_trans


### PR DESCRIPTION
NOTE: This PR is ready for review but **should not be merged** until issue #2586 is resolved (it has been tested successfully before rebasing upstream master). Meanwhile, @imphil has submitted PR #2590 (under review) to resolve that issue.

  - Stimulate and verify chained read requests (resolve TODO item in PR #2330 )
  - Constraint randomization to not generate incorrect register values
    For instance read, rcont, and stop bits must not be set simultaneously.
    Currently, DUT does not check incorrect configurations, therefore, SW must program
    DUT's registers to correct values (w.r.t I2C specification)
  - Update/clean DV files

Signed-off-by: Tung Hoang <tung.hoang.290780@gmail.com>