### PR TITLE
[i2c, dv] Add i2c_override test

### DIFF
--- a/hw/ip/i2c/data/i2c_testplan.hjson
+++ b/hw/ip/i2c/data/i2c_testplan.hjson
@@ -98,10 +98,10 @@
               - Program OVRD register
 
             Checking:
-              - Ensure scl_o, sda_o are overriddend
+              - Ensure scl_o, sda_o are overridden
             '''
       milestone: V2
-      tests: [""]
+      tests: ["i2c_override"]
     }
     {
       name: fmt_watermark

--- a/hw/ip/i2c/dv/env/i2c_env.core
+++ b/hw/ip/i2c/dv/env/i2c_env.core
@@ -23,6 +23,7 @@ filesets:
       - seq_lib/i2c_common_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_rx_tx_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_sanity_vseq.sv: {is_include_file: true}
+      - seq_lib/i2c_override_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_override_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_override_vseq.sv
@@ -1,0 +1,54 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class i2c_override_vseq extends i2c_base_vseq;
+  `uvm_object_utils(i2c_override_vseq)
+
+  rand bit sclval;
+  rand bit sdaval;
+  rand bit txovrden;
+
+  constraint num_trans_c { num_trans inside {[10:20]}; }
+
+  `uvm_object_new
+
+  virtual task body();
+    // disable i2c_monitor and i2c_scoreboard since they can not handle this test
+    `uvm_info(`gfn, "disable i2c_monitor and i2c_scoreboard", UVM_DEBUG)
+    cfg.m_i2c_agent_cfg.en_monitor = 1'b0;
+    cfg.en_scb = 1'b0;
+
+    device_init();
+    host_init();
+
+    for (uint cur_tran = 1; cur_tran <= num_trans; cur_tran++) begin
+      `uvm_info(`gfn, $sformatf("\nTransaction %0d", cur_tran), UVM_LOW)
+      // program to enable OVRD reg
+      `DV_CHECK_MEMBER_RANDOMIZE_FATAL(sclval)
+      `DV_CHECK_MEMBER_RANDOMIZE_FATAL(sdaval)
+      `DV_CHECK_MEMBER_RANDOMIZE_FATAL(txovrden)
+      ral.ovrd.txovrden.set(txovrden);
+      ral.ovrd.sclval.set(sclval);
+      ral.ovrd.sdaval.set(sdaval);
+      csr_update(ral.ovrd);
+
+      // checking DUT's scl and sda
+      if (txovrden) begin
+        cfg.m_i2c_agent_cfg.vif.wait_for_dly(1); // fast enough
+        `DV_CHECK_EQ(cfg.m_i2c_agent_cfg.vif.scl_i, sclval)
+        `DV_CHECK_EQ(cfg.m_i2c_agent_cfg.vif.sda_i, sdaval)
+        `uvm_info(`gfn, $sformatf("\n  scl_i %0b sclval %0b",
+            cfg.m_i2c_agent_cfg.vif.scl_i, sclval), UVM_DEBUG)
+        `uvm_info(`gfn, $sformatf("\n  sda_i %0b sdaval %0b",
+            cfg.m_i2c_agent_cfg.vif.sda_i, sdaval), UVM_DEBUG)
+      end
+    end
+  endtask : body
+
+  task post_start();
+    super.post_start();
+    `uvm_info(`gfn, "stop simulation", UVM_DEBUG)
+  endtask : post_start
+
+endclass : i2c_override_vseq

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
@@ -6,3 +6,5 @@
 `include "i2c_common_vseq.sv"
 `include "i2c_rx_tx_vseq.sv"
 `include "i2c_sanity_vseq.sv"
+
+`include "i2c_override_vseq.sv"

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -49,6 +49,11 @@
       name: i2c_sanity
       uvm_test_seq: i2c_sanity_vseq
     }
+
+    {
+      name: i2c_override
+      uvm_test_seq: i2c_override_vseq
+    }
   ]
 
   // List of regressions.


### PR DESCRIPTION
This test checks if the outputs scl and sda of DUT is overridden
  - The test description is provided in `i2c_testplan.hjson` file

Signed-off-by: Tung Hoang <tung.hoang.290780@gmail.com>