### PR TITLE
[sw] MMIO Cleanup

### DIFF
--- a/sw/device/lib/base/bitfield.c
+++ b/sw/device/lib/base/bitfield.c
@@ -6,8 +6,18 @@
 
 // `extern` declarations to give the inline functions in the
 // corresponding header a link location.
-extern uint32_t bitfield_set_field32(uint32_t bitfield,
-                                     bitfield_field32_t field);
 
-extern uint32_t bitfield_get_field32(uint32_t bitfield,
-                                     bitfield_field32_t field);
+extern uint32_t bitfield_field32_read(uint32_t bitfield,
+                                      bitfield_field32_t field);
+extern uint32_t bitfield_field32_write(uint32_t bitfield,
+                                       bitfield_field32_t field,
+                                       uint32_t value);
+
+extern bitfield_field32_t bitfield_bit32_to_field32(
+    bitfield_bit32_index_t bit_index);
+
+extern bool bitfield_bit32_read(uint32_t bitfield,
+                                bitfield_bit32_index_t bit_index);
+extern uint32_t bitfield_bit32_write(uint32_t bitfield,
+                                     bitfield_bit32_index_t bit_index,
+                                     bool value);

--- a/sw/device/lib/base/bitfield.h
+++ b/sw/device/lib/base/bitfield.h
@@ -5,6 +5,7 @@
 #ifndef OPENTITAN_SW_DEVICE_LIB_BASE_BITFIELD_H_
 #define OPENTITAN_SW_DEVICE_LIB_BASE_BITFIELD_H_
 
+#include <stdbool.h>
 #include <stdint.h>
 
 // Header Extern Guard  (so header can be used from C and C++)
@@ -18,59 +19,127 @@ extern "C" {
  */
 
 /**
- * Masked field offset for 32-bit bitfields, with optional value.
+ * All the bitfield functions are pure (they do not modify their arguments), so
+ * the result must be used. We enable warnings to ensure this happens.
+ */
+#define BITFIELD_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
+
+/**
+ * A field of a 32-bit bitfield.
  *
- * `index` represents a shift in bits starting from the 0 bit of a given 32-bit
- * bitfield. It is used to zero the memory inside this bitfield by applying an
- * inverted `mask` at the `index` offset. `value` is then capped by applying
- * `mask` and is shifted to the `index` bits of the bitfield.
+ * The following field definition: `{ .mask = 0b11, .index = 12 }`
  *
- * Example:
- * ```
- * 32-bit bitfield = 0b11111111'11111111'11111111'11111111
- * set_field32( mask = 0b11111111, index = 16, value = 0b01111110 (126) )
- * result 32-bit bitfield = 0b11111111'01111110'11111111'11111111
- * ```
+ * Denotes the X-marked bits in the following 32-bit bitfield:
+ *
+ *     field:  0b--------'--------'--XX----'--------
+ *     index:   31                                 0
+ *
+ * Restrictions: The index plus the width of the mask must not be greater than
+ * 31.
  */
 typedef struct bitfield_field32 {
-  uint32_t mask;  /**< The field mask. */
-  uint32_t index; /**< The field position within a bitfield. */
-  uint32_t
-      value; /**< The field value to be written, if using a `set` function. */
+  /** The field mask. Usually all ones. */
+  uint32_t mask;
+  /** The field position in the bitfield, counting from the zero-bit. */
+  uint32_t index;
 } bitfield_field32_t;
 
 /**
- * Gets `field` in `bitfield`.
+ * Reads a value from `field` in `bitfield`.
  *
- * This function uses the `field` parameter to get a value at the given
- * offset (and mask) in `bitfield`. Only `mask` and `index` are used;
- * `value` is ignored.
+ * This function uses the `field` parameter to read the value from `bitfield`.
+ * The resulting value will be shifted right and zero-extended so the field's
+ * zero-bit is the return value's zero-bit.
  *
  * @param bitfield Bitfield to get the field from.
  * @param field Field to read out from.
- * @return The read value, zero-extended to 32 bits.
+ * @return Zero-extended `field` from `bitfield`.
  */
-inline uint32_t bitfield_get_field32(uint32_t bitfield,
-                                     bitfield_field32_t field) {
+BITFIELD_WARN_UNUSED_RESULT
+inline uint32_t bitfield_field32_read(uint32_t bitfield,
+                                      bitfield_field32_t field) {
   return (bitfield >> field.index) & field.mask;
 }
 
 /**
- * Sets `field` in `bitfield`.
+ * Writes `value` to `field` in `bitfield`.
  *
- * This function uses the `field` parameter to set a value
- * at a given offset in `bitfield`. The relevant portion of `bitfield`
- * is zeroed before the value is set.
+ * This function uses the `field` parameter to set specific bits in `bitfield`.
+ * The relevant portion of `bitfield` is zeroed before the bits are set to
+ * `value`.
  *
  * @param bitfield Bitfield to set the field in.
- * @param field Field within selected register field to be set.
- * @return The 32-bit resulting bitfield.
+ * @param field Field within bitfield to be set.
+ * @param value Value for the new field.
+ * @return `bitfield` with `field` set to `value`.
  */
-inline uint32_t bitfield_set_field32(uint32_t bitfield,
-                                     bitfield_field32_t field) {
+BITFIELD_WARN_UNUSED_RESULT
+inline uint32_t bitfield_field32_write(uint32_t bitfield,
+                                       bitfield_field32_t field,
+                                       uint32_t value) {
   bitfield &= ~(field.mask << field.index);
-  bitfield |= (field.value & field.mask) << field.index;
+  bitfield |= (value & field.mask) << field.index;
   return bitfield;
+}
+
+/**
+ * A single bit in a 32-bit bitfield.
+ *
+ * This denotes the position of a single bit, counting from the zero-bit.
+ *
+ * For instance, `(bitfield_bit_index_t)4` denotes the X-marked bit in the
+ * following 32-bit bitfield:
+ *
+ *     field:  0b--------'--------'--------'---X----
+ *     index:   31                                 0
+ *
+ * Restrictions: The value must not be greater than 31.
+ */
+typedef uint32_t bitfield_bit32_index_t;
+
+/**
+ * Turns a `bitfield_bit32_index_t` into a `bitfield_field32_t` (which is more
+ * general).
+ *
+ * @param bit_index The corresponding single bit to turn into a field.
+ * @return A 1-bit field that corresponds to `bit_index`.
+ */
+BITFIELD_WARN_UNUSED_RESULT
+inline bitfield_field32_t bitfield_bit32_to_field32(
+    bitfield_bit32_index_t bit_index) {
+  return (bitfield_field32_t){
+      .mask = 0x1, .index = bit_index,
+  };
+}
+
+/**
+ * Reads the `bit_index`th bit in `bitfield`.
+ *
+ * @param bitfield Bitfield to get the bit from.
+ * @param bit_index Bit to read.
+ * @return `true` if the bit was one, `false` otherwise.
+ */
+BITFIELD_WARN_UNUSED_RESULT
+inline bool bitfield_bit32_read(uint32_t bitfield,
+                                bitfield_bit32_index_t bit_index) {
+  return bitfield_field32_read(bitfield,
+                               bitfield_bit32_to_field32(bit_index)) == 0x1u;
+}
+
+/**
+ * Writes `value` to the `bit_index`th bit in `bitfield`.
+ *
+ * @param bitfield Bitfield to update the bit in.
+ * @param bit_index Bit to update.
+ * @param value Bit value to write to `bitfield`.
+ * @return `bitfield` with the `bit_index`th bit set to `value`.
+ */
+BITFIELD_WARN_UNUSED_RESULT
+inline uint32_t bitfield_bit32_write(uint32_t bitfield,
+                                     bitfield_bit32_index_t bit_index,
+                                     bool value) {
+  return bitfield_field32_write(bitfield, bitfield_bit32_to_field32(bit_index),
+                                value ? 0x1u : 0x0u);
 }
 
 #ifdef __cplusplus

--- a/sw/device/lib/base/mmio.c
+++ b/sw/device/lib/base/mmio.c
@@ -123,12 +123,9 @@ void mmio_region_memcpy_to_mmio32(mmio_region_t base, uint32_t offset,
 // `extern` declarations to give the inline functions in the
 // corresponding header a link location.
 extern uint8_t mmio_region_read8(mmio_region_t base, ptrdiff_t offset);
-extern uint16_t mmio_region_read16(mmio_region_t base, ptrdiff_t offset);
 extern uint32_t mmio_region_read32(mmio_region_t base, ptrdiff_t offset);
 extern void mmio_region_write8(mmio_region_t base, ptrdiff_t offset,
                                uint8_t value);
-extern void mmio_region_write16(mmio_region_t base, ptrdiff_t offset,
-                                uint16_t value);
 extern void mmio_region_write32(mmio_region_t base, ptrdiff_t offset,
                                 uint32_t value);
 extern uint32_t mmio_region_read_mask32(mmio_region_t base, ptrdiff_t offset,

--- a/sw/device/lib/base/mmio.c
+++ b/sw/device/lib/base/mmio.c
@@ -143,10 +143,12 @@ extern void mmio_region_write_only_set_mask32(mmio_region_t base,
                                               uint32_t mask_index);
 extern void mmio_region_nonatomic_set_field32(mmio_region_t base,
                                               ptrdiff_t offset,
-                                              bitfield_field32_t field);
+                                              bitfield_field32_t field,
+                                              uint32_t value);
 extern void mmio_region_write_only_set_field32(mmio_region_t base,
                                                ptrdiff_t offset,
-                                               bitfield_field32_t field);
+                                               bitfield_field32_t field,
+                                               uint32_t value);
 extern void mmio_region_nonatomic_clear_bit32(mmio_region_t base,
                                               ptrdiff_t offset,
                                               uint32_t bit_index);

--- a/sw/device/lib/base/mmio.h
+++ b/sw/device/lib/base/mmio.h
@@ -64,21 +64,6 @@ inline uint8_t mmio_region_read8(mmio_region_t base, ptrdiff_t offset) {
 }
 
 /**
- * Reads an aligned uint16_t from the MMIO region `base` at the given byte
- * offset.
- *
- * This function is guaranteed to commit a read to memory, and will not be
- * reordered with respect to other MMIO manipulations.
- *
- * @param base the region to read from.
- * @param offset the offset to read at, in bytes.
- * @return the read value.
- */
-inline uint16_t mmio_region_read16(mmio_region_t base, ptrdiff_t offset) {
-  return ((volatile uint16_t *)base.base)[offset / sizeof(uint16_t)];
-}
-
-/**
  * Reads an aligned uint32_t from the MMIO region `base` at the given byte
  * offset.
  *
@@ -107,22 +92,6 @@ inline uint32_t mmio_region_read32(mmio_region_t base, ptrdiff_t offset) {
 inline void mmio_region_write8(mmio_region_t base, ptrdiff_t offset,
                                uint8_t value) {
   ((volatile uint8_t *)base.base)[offset / sizeof(uint8_t)] = value;
-}
-
-/**
- * Writes an aligned uint16_t to the MMIO region `base` at the given byte
- * offset.
- *
- * This function is guaranteed to commit a write to memory, and will not be
- * reordered with respect to other region manipulations.
- *
- * @param base the region to write to.
- * @param offset the offset to write at, in bytes.
- * @param value the value to write.
- */
-inline void mmio_region_write16(mmio_region_t base, ptrdiff_t offset,
-                                uint16_t value) {
-  ((volatile uint16_t *)base.base)[offset / sizeof(uint16_t)] = value;
 }
 
 /**
@@ -155,11 +124,9 @@ typedef struct mmio_region { void *mock; } mmio_region_t;
  * Stubbed-out read/write operations for overriding by a testing library.
  */
 uint8_t mmio_region_read8(mmio_region_t base, ptrdiff_t offset);
-uint16_t mmio_region_read16(mmio_region_t base, ptrdiff_t offset);
 uint32_t mmio_region_read32(mmio_region_t base, ptrdiff_t offset);
 
 void mmio_region_write8(mmio_region_t base, ptrdiff_t offset, uint8_t value);
-void mmio_region_write16(mmio_region_t base, ptrdiff_t offset, uint16_t value);
 void mmio_region_write32(mmio_region_t base, ptrdiff_t offset, uint32_t value);
 #endif  // MOCK_MMIO
 

--- a/sw/device/lib/dif/dif_i2c.c
+++ b/sw/device/lib/dif/dif_i2c.c
@@ -129,74 +129,78 @@ dif_i2c_result_t dif_i2c_compute_timing(const dif_i2c_timing_config_t *config,
 static void write_timing_params(const dif_i2c_t *i2c,
                                 const dif_i2c_timing_params_t *timing) {
   uint32_t timing0 = 0;
-  timing0 = bitfield_set_field32(timing0, (bitfield_field32_t){
-                                              .mask = I2C_TIMING0_THIGH_MASK,
-                                              .index = I2C_TIMING0_THIGH_OFFSET,
-                                              .value = timing->scl_time_high,
-                                          });
-  timing0 = bitfield_set_field32(timing0, (bitfield_field32_t){
-                                              .mask = I2C_TIMING0_TLOW_MASK,
-                                              .index = I2C_TIMING0_TLOW_OFFSET,
-                                              .value = timing->scl_time_low,
-                                          });
+  timing0 = bitfield_field32_write(
+      timing0,
+      (bitfield_field32_t){
+          .mask = I2C_TIMING0_THIGH_MASK, .index = I2C_TIMING0_THIGH_OFFSET,
+      },
+      timing->scl_time_high);
+  timing0 = bitfield_field32_write(
+      timing0,
+      (bitfield_field32_t){
+          .mask = I2C_TIMING0_TLOW_MASK, .index = I2C_TIMING0_TLOW_OFFSET,
+      },
+      timing->scl_time_low);
   mmio_region_write32(i2c->base_addr, I2C_TIMING0_REG_OFFSET, timing0);
 
   uint32_t timing1 = 0;
-  timing1 = bitfield_set_field32(timing1, (bitfield_field32_t){
-                                              .mask = I2C_TIMING1_T_R_MASK,
-                                              .index = I2C_TIMING1_T_R_OFFSET,
-                                              .value = timing->rise_time,
-                                          });
-  timing1 = bitfield_set_field32(timing1, (bitfield_field32_t){
-                                              .mask = I2C_TIMING1_T_F_MASK,
-                                              .index = I2C_TIMING1_T_F_OFFSET,
-                                              .value = timing->fall_time,
-                                          });
+  timing1 = bitfield_field32_write(
+      timing1,
+      (bitfield_field32_t){
+          .mask = I2C_TIMING1_T_R_MASK, .index = I2C_TIMING1_T_R_OFFSET,
+      },
+      timing->rise_time);
+  timing1 = bitfield_field32_write(
+      timing1,
+      (bitfield_field32_t){
+          .mask = I2C_TIMING1_T_F_MASK, .index = I2C_TIMING1_T_F_OFFSET,
+      },
+      timing->fall_time);
   mmio_region_write32(i2c->base_addr, I2C_TIMING1_REG_OFFSET, timing1);
 
   uint32_t timing2 = 0;
-  timing2 = bitfield_set_field32(timing2,
-                                 (bitfield_field32_t){
-                                     .mask = I2C_TIMING2_TSU_STA_MASK,
-                                     .index = I2C_TIMING2_TSU_STA_OFFSET,
-                                     .value = timing->start_signal_setup_time,
-                                 });
-  timing2 =
-      bitfield_set_field32(timing2, (bitfield_field32_t){
-                                        .mask = I2C_TIMING2_THD_STA_MASK,
-                                        .index = I2C_TIMING2_THD_STA_OFFSET,
-                                        .value = timing->start_signal_hold_time,
-                                    });
+  timing2 = bitfield_field32_write(
+      timing2,
+      (bitfield_field32_t){
+          .mask = I2C_TIMING2_TSU_STA_MASK, .index = I2C_TIMING2_TSU_STA_OFFSET,
+      },
+      timing->start_signal_setup_time);
+  timing2 = bitfield_field32_write(
+      timing2,
+      (bitfield_field32_t){
+          .mask = I2C_TIMING2_THD_STA_MASK, .index = I2C_TIMING2_THD_STA_OFFSET,
+      },
+      timing->start_signal_hold_time);
   mmio_region_write32(i2c->base_addr, I2C_TIMING2_REG_OFFSET, timing2);
 
   uint32_t timing3 = 0;
-  timing3 =
-      bitfield_set_field32(timing3, (bitfield_field32_t){
-                                        .mask = I2C_TIMING3_TSU_DAT_MASK,
-                                        .index = I2C_TIMING3_TSU_DAT_OFFSET,
-                                        .value = timing->data_signal_setup_time,
-                                    });
-  timing3 =
-      bitfield_set_field32(timing3, (bitfield_field32_t){
-                                        .mask = I2C_TIMING3_THD_DAT_MASK,
-                                        .index = I2C_TIMING3_THD_DAT_OFFSET,
-                                        .value = timing->data_signal_hold_time,
-                                    });
+  timing3 = bitfield_field32_write(
+      timing3,
+      (bitfield_field32_t){
+          .mask = I2C_TIMING3_TSU_DAT_MASK, .index = I2C_TIMING3_TSU_DAT_OFFSET,
+      },
+      timing->data_signal_setup_time);
+  timing3 = bitfield_field32_write(
+      timing3,
+      (bitfield_field32_t){
+          .mask = I2C_TIMING3_THD_DAT_MASK, .index = I2C_TIMING3_THD_DAT_OFFSET,
+      },
+      timing->data_signal_hold_time);
   mmio_region_write32(i2c->base_addr, I2C_TIMING3_REG_OFFSET, timing3);
 
   uint32_t timing4 = 0;
-  timing4 =
-      bitfield_set_field32(timing4, (bitfield_field32_t){
-                                        .mask = I2C_TIMING4_TSU_STO_MASK,
-                                        .index = I2C_TIMING4_TSU_STO_OFFSET,
-                                        .value = timing->stop_signal_setup_time,
-                                    });
-  timing4 =
-      bitfield_set_field32(timing4, (bitfield_field32_t){
-                                        .mask = I2C_TIMING4_T_BUF_MASK,
-                                        .index = I2C_TIMING4_T_BUF_OFFSET,
-                                        .value = timing->stop_signal_hold_time,
-                                    });
+  timing4 = bitfield_field32_write(
+      timing4,
+      (bitfield_field32_t){
+          .mask = I2C_TIMING4_TSU_STO_MASK, .index = I2C_TIMING4_TSU_STO_OFFSET,
+      },
+      timing->stop_signal_setup_time);
+  timing4 = bitfield_field32_write(
+      timing4,
+      (bitfield_field32_t){
+          .mask = I2C_TIMING4_T_BUF_MASK, .index = I2C_TIMING4_T_BUF_OFFSET,
+      },
+      timing->stop_signal_hold_time);
   mmio_region_write32(i2c->base_addr, I2C_TIMING4_REG_OFFSET, timing4);
 }
 
@@ -310,16 +314,18 @@ dif_i2c_result_t dif_i2c_set_watermarks(const dif_i2c_t *i2c,
 
   uint32_t ctrl_value =
       mmio_region_read32(i2c->base_addr, I2C_FIFO_CTRL_REG_OFFSET);
-  ctrl_value = bitfield_set_field32(
-      ctrl_value, (bitfield_field32_t){.mask = I2C_FIFO_CTRL_RXILVL_MASK,
-                                       .index = I2C_FIFO_CTRL_RXILVL_OFFSET,
-                                       .value = rx_level_value});
-  ctrl_value = bitfield_set_field32(ctrl_value,
-                                    (bitfield_field32_t){
-                                        .mask = I2C_FIFO_CTRL_FMTILVL_MASK,
-                                        .index = I2C_FIFO_CTRL_FMTILVL_OFFSET,
-                                        .value = fmt_level_value,
-                                    });
+  ctrl_value = bitfield_field32_write(ctrl_value,
+                                      (bitfield_field32_t){
+                                          .mask = I2C_FIFO_CTRL_RXILVL_MASK,
+                                          .index = I2C_FIFO_CTRL_RXILVL_OFFSET,
+                                      },
+                                      rx_level_value);
+  ctrl_value = bitfield_field32_write(ctrl_value,
+                                      (bitfield_field32_t){
+                                          .mask = I2C_FIFO_CTRL_FMTILVL_MASK,
+                                          .index = I2C_FIFO_CTRL_FMTILVL_OFFSET,
+                                      },
+                                      fmt_level_value);
   mmio_region_write32(i2c->base_addr, I2C_FIFO_CTRL_REG_OFFSET, ctrl_value);
 
   return kDifI2cOk;
@@ -498,14 +504,8 @@ dif_i2c_result_t dif_i2c_override_drive_pins(const dif_i2c_t *i2c, bool scl,
 
   uint32_t override_val =
       mmio_region_read32(i2c->base_addr, I2C_OVRD_REG_OFFSET);
-  override_val = bitfield_set_field32(
-      override_val, (bitfield_field32_t){
-                        .mask = 1, .index = I2C_OVRD_SCLVAL, .value = scl,
-                    });
-  override_val = bitfield_set_field32(
-      override_val, (bitfield_field32_t){
-                        .mask = 1, .index = I2C_OVRD_SDAVAL, .value = sda,
-                    });
+  override_val = bitfield_bit32_write(override_val, I2C_OVRD_SCLVAL, scl);
+  override_val = bitfield_bit32_write(override_val, I2C_OVRD_SDAVAL, sda);
   mmio_region_write32(i2c->base_addr, I2C_OVRD_REG_OFFSET, override_val);
 
   return kDifI2cOk;
@@ -520,7 +520,7 @@ dif_i2c_result_t dif_i2c_override_sample_pins(const dif_i2c_t *i2c,
 
   uint32_t samples = mmio_region_read32(i2c->base_addr, I2C_VAL_REG_OFFSET);
   if (scl_samples != NULL) {
-    *scl_samples = bitfield_get_field32(
+    *scl_samples = bitfield_field32_read(
         samples,
         (bitfield_field32_t){
             .mask = I2C_VAL_SCL_RX_MASK, .index = I2C_VAL_SCL_RX_OFFSET,
@@ -528,7 +528,7 @@ dif_i2c_result_t dif_i2c_override_sample_pins(const dif_i2c_t *i2c,
   }
 
   if (sda_samples != NULL) {
-    *sda_samples = bitfield_get_field32(
+    *sda_samples = bitfield_field32_read(
         samples,
         (bitfield_field32_t){
             .mask = I2C_VAL_SDA_RX_MASK, .index = I2C_VAL_SDA_RX_OFFSET,
@@ -548,18 +548,18 @@ dif_i2c_result_t dif_i2c_get_fifo_levels(const dif_i2c_t *i2c,
   uint32_t values =
       mmio_region_read32(i2c->base_addr, I2C_FIFO_STATUS_REG_OFFSET);
   if (fmt_fifo_level != NULL) {
-    *fmt_fifo_level =
-        bitfield_get_field32(values, (bitfield_field32_t){
-                                         .mask = I2C_FIFO_STATUS_FMTLVL_MASK,
-                                         .index = I2C_FIFO_STATUS_FMTLVL_OFFSET,
-                                     });
+    *fmt_fifo_level = bitfield_field32_read(
+        values, (bitfield_field32_t){
+                    .mask = I2C_FIFO_STATUS_FMTLVL_MASK,
+                    .index = I2C_FIFO_STATUS_FMTLVL_OFFSET,
+                });
   }
   if (rx_fifo_level != NULL) {
     *rx_fifo_level =
-        bitfield_get_field32(values, (bitfield_field32_t){
-                                         .mask = I2C_FIFO_STATUS_RXLVL_MASK,
-                                         .index = I2C_FIFO_STATUS_RXLVL_OFFSET,
-                                     });
+        bitfield_field32_read(values, (bitfield_field32_t){
+                                          .mask = I2C_FIFO_STATUS_RXLVL_MASK,
+                                          .index = I2C_FIFO_STATUS_RXLVL_OFFSET,
+                                      });
   }
 
   return kDifI2cOk;
@@ -572,10 +572,10 @@ dif_i2c_result_t dif_i2c_read_byte(const dif_i2c_t *i2c, uint8_t *byte) {
 
   uint32_t values = mmio_region_read32(i2c->base_addr, I2C_RDATA_REG_OFFSET);
   if (byte != NULL) {
-    *byte = bitfield_get_field32(values, (bitfield_field32_t){
-                                             .mask = I2C_RDATA_RDATA_MASK,
-                                             .index = I2C_RDATA_RDATA_OFFSET,
-                                         });
+    *byte = bitfield_field32_read(values, (bitfield_field32_t){
+                                              .mask = I2C_RDATA_RDATA_MASK,
+                                              .index = I2C_RDATA_RDATA_OFFSET,
+                                          });
   }
 
   return kDifI2cOk;
@@ -599,33 +599,18 @@ dif_i2c_result_t dif_i2c_write_byte_raw(const dif_i2c_t *i2c, uint8_t byte,
   }
 
   uint32_t fmt_byte = 0;
-  fmt_byte = bitfield_set_field32(fmt_byte, (bitfield_field32_t){
-                                                .mask = I2C_FDATA_FBYTE_MASK,
-                                                .index = I2C_FDATA_FBYTE_OFFSET,
-                                                .value = byte,
-                                            });
-  fmt_byte = bitfield_set_field32(
-      fmt_byte, (bitfield_field32_t){
-                    .mask = 1, .index = I2C_FDATA_START, .value = flags.start,
-                });
-  fmt_byte = bitfield_set_field32(
-      fmt_byte, (bitfield_field32_t){
-                    .mask = 1, .index = I2C_FDATA_STOP, .value = flags.stop,
-                });
-  fmt_byte = bitfield_set_field32(
-      fmt_byte, (bitfield_field32_t){
-                    .mask = 1, .index = I2C_FDATA_READ, .value = flags.read,
-                });
-  fmt_byte = bitfield_set_field32(
+  fmt_byte = bitfield_field32_write(
       fmt_byte,
       (bitfield_field32_t){
-          .mask = 1, .index = I2C_FDATA_RCONT, .value = flags.read_cont,
-      });
-  fmt_byte = bitfield_set_field32(
-      fmt_byte,
-      (bitfield_field32_t){
-          .mask = 1, .index = I2C_FDATA_NAKOK, .value = flags.supress_nak_irq,
-      });
+          .mask = I2C_FDATA_FBYTE_MASK, .index = I2C_FDATA_FBYTE_OFFSET,
+      },
+      byte);
+  fmt_byte = bitfield_bit32_write(fmt_byte, I2C_FDATA_START, flags.start);
+  fmt_byte = bitfield_bit32_write(fmt_byte, I2C_FDATA_STOP, flags.stop);
+  fmt_byte = bitfield_bit32_write(fmt_byte, I2C_FDATA_READ, flags.read);
+  fmt_byte = bitfield_bit32_write(fmt_byte, I2C_FDATA_RCONT, flags.read_cont);
+  fmt_byte =
+      bitfield_bit32_write(fmt_byte, I2C_FDATA_NAKOK, flags.supress_nak_irq);
   mmio_region_write32(i2c->base_addr, I2C_FDATA_REG_OFFSET, fmt_byte);
 
   return kDifI2cOk;

--- a/sw/device/lib/dif/dif_rv_timer.c
+++ b/sw/device/lib/dif/dif_rv_timer.c
@@ -94,18 +94,19 @@ dif_rv_timer_result_t dif_rv_timer_set_tick_params(
   }
 
   uint32_t config_value = 0;
-  config_value = bitfield_set_field32(
-      config_value, (bitfield_field32_t){
-                        .mask = RV_TIMER_CFG0_PRESCALE_MASK,
-                        .index = RV_TIMER_CFG0_PRESCALE_OFFSET,
-                        .value = params.prescale,
-                    });
   config_value =
-      bitfield_set_field32(config_value, (bitfield_field32_t){
-                                             .mask = RV_TIMER_CFG0_STEP_MASK,
-                                             .index = RV_TIMER_CFG0_STEP_OFFSET,
-                                             .value = params.tick_step,
-                                         });
+      bitfield_field32_write(config_value,
+                             (bitfield_field32_t){
+                                 .mask = RV_TIMER_CFG0_PRESCALE_MASK,
+                                 .index = RV_TIMER_CFG0_PRESCALE_OFFSET,
+                             },
+                             params.prescale);
+  config_value = bitfield_field32_write(
+      config_value,
+      (bitfield_field32_t){
+          .mask = RV_TIMER_CFG0_STEP_MASK, .index = RV_TIMER_CFG0_STEP_OFFSET,
+      },
+      params.tick_step);
   mmio_region_write32(timer->base_addr,
                       reg_for_hart(hart_id, RV_TIMER_CFG0_REG_OFFSET),
                       config_value);

--- a/sw/device/lib/dif/dif_spi_device.c
+++ b/sw/device/lib/dif/dif_spi_device.c
@@ -39,12 +39,13 @@ static dif_spi_device_result_t build_control_word(
     *control_word |= 0x1 << SPI_DEVICE_CFG_RX_ORDER;
   }
 
-  *control_word = bitfield_set_field32(
-      *control_word, (bitfield_field32_t){
-                         .mask = SPI_DEVICE_CFG_TIMER_V_MASK,
-                         .index = SPI_DEVICE_CFG_TIMER_V_OFFSET,
-                         .value = config->rx_fifo_timeout,
-                     });
+  *control_word =
+      bitfield_field32_write(*control_word,
+                             (bitfield_field32_t){
+                                 .mask = SPI_DEVICE_CFG_TIMER_V_MASK,
+                                 .index = SPI_DEVICE_CFG_TIMER_V_OFFSET,
+                             },
+                             config->rx_fifo_timeout);
 
   return kDifSpiDeviceResultOk;
 }
@@ -77,32 +78,36 @@ dif_spi_device_result_t dif_spi_device_init(
   }
 
   uint32_t rx_fifo_bounds = 0;
-  rx_fifo_bounds = bitfield_set_field32(
-      rx_fifo_bounds, (bitfield_field32_t){
-                          .mask = SPI_DEVICE_RXF_ADDR_BASE_MASK,
-                          .index = SPI_DEVICE_RXF_ADDR_BASE_OFFSET,
-                          .value = rx_fifo_start,
-                      });
-  rx_fifo_bounds = bitfield_set_field32(
-      rx_fifo_bounds, (bitfield_field32_t){
-                          .mask = SPI_DEVICE_RXF_ADDR_LIMIT_MASK,
-                          .index = SPI_DEVICE_RXF_ADDR_LIMIT_OFFSET,
-                          .value = rx_fifo_end,
-                      });
+  rx_fifo_bounds =
+      bitfield_field32_write(rx_fifo_bounds,
+                             (bitfield_field32_t){
+                                 .mask = SPI_DEVICE_RXF_ADDR_BASE_MASK,
+                                 .index = SPI_DEVICE_RXF_ADDR_BASE_OFFSET,
+                             },
+                             rx_fifo_start);
+  rx_fifo_bounds =
+      bitfield_field32_write(rx_fifo_bounds,
+                             (bitfield_field32_t){
+                                 .mask = SPI_DEVICE_RXF_ADDR_LIMIT_MASK,
+                                 .index = SPI_DEVICE_RXF_ADDR_LIMIT_OFFSET,
+                             },
+                             rx_fifo_end);
 
   uint32_t tx_fifo_bounds = 0;
-  tx_fifo_bounds = bitfield_set_field32(
-      tx_fifo_bounds, (bitfield_field32_t){
-                          .mask = SPI_DEVICE_TXF_ADDR_BASE_MASK,
-                          .index = SPI_DEVICE_TXF_ADDR_BASE_OFFSET,
-                          .value = tx_fifo_start,
-                      });
-  tx_fifo_bounds = bitfield_set_field32(
-      tx_fifo_bounds, (bitfield_field32_t){
-                          .mask = SPI_DEVICE_TXF_ADDR_LIMIT_MASK,
-                          .index = SPI_DEVICE_TXF_ADDR_LIMIT_OFFSET,
-                          .value = tx_fifo_end,
-                      });
+  tx_fifo_bounds =
+      bitfield_field32_write(tx_fifo_bounds,
+                             (bitfield_field32_t){
+                                 .mask = SPI_DEVICE_TXF_ADDR_BASE_MASK,
+                                 .index = SPI_DEVICE_TXF_ADDR_BASE_OFFSET,
+                             },
+                             tx_fifo_start);
+  tx_fifo_bounds =
+      bitfield_field32_write(tx_fifo_bounds,
+                             (bitfield_field32_t){
+                                 .mask = SPI_DEVICE_TXF_ADDR_LIMIT_MASK,
+                                 .index = SPI_DEVICE_TXF_ADDR_LIMIT_OFFSET,
+                             },
+                             tx_fifo_end);
 
   spi->rx_fifo_base = rx_fifo_start;
   spi->rx_fifo_len = config->rx_fifo_len;
@@ -299,18 +304,20 @@ dif_spi_device_result_t dif_spi_device_set_irq_levels(
   }
 
   uint32_t compressed_limit = 0;
-  compressed_limit = bitfield_set_field32(
-      compressed_limit, (bitfield_field32_t){
-                            .mask = SPI_DEVICE_FIFO_LEVEL_RXLVL_MASK,
-                            .index = SPI_DEVICE_FIFO_LEVEL_RXLVL_OFFSET,
-                            .value = rx_level,
-                        });
-  compressed_limit = bitfield_set_field32(
-      compressed_limit, (bitfield_field32_t){
-                            .mask = SPI_DEVICE_FIFO_LEVEL_TXLVL_MASK,
-                            .index = SPI_DEVICE_FIFO_LEVEL_TXLVL_OFFSET,
-                            .value = tx_level,
-                        });
+  compressed_limit =
+      bitfield_field32_write(compressed_limit,
+                             (bitfield_field32_t){
+                                 .mask = SPI_DEVICE_FIFO_LEVEL_RXLVL_MASK,
+                                 .index = SPI_DEVICE_FIFO_LEVEL_RXLVL_OFFSET,
+                             },
+                             rx_level);
+  compressed_limit =
+      bitfield_field32_write(compressed_limit,
+                             (bitfield_field32_t){
+                                 .mask = SPI_DEVICE_FIFO_LEVEL_TXLVL_MASK,
+                                 .index = SPI_DEVICE_FIFO_LEVEL_TXLVL_OFFSET,
+                             },
+                             tx_level);
   mmio_region_write32(spi->base_addr, SPI_DEVICE_FIFO_LEVEL_REG_OFFSET,
                       compressed_limit);
 
@@ -450,16 +457,18 @@ static void compress_ptrs(const dif_spi_device_t *spi, fifo_ptr_params_t params,
   }
 
   uint32_t ptr = 0;
-  ptr = bitfield_set_field32(ptr, (bitfield_field32_t){
-                                      .mask = params.write_mask,
-                                      .index = params.write_offset,
-                                      .value = write_val,
-                                  });
-  ptr = bitfield_set_field32(ptr, (bitfield_field32_t){
-                                      .mask = params.read_mask,
-                                      .index = params.read_offset,
-                                      .value = read_val,
-                                  });
+  ptr = bitfield_field32_write(
+      ptr,
+      (bitfield_field32_t){
+          .mask = params.write_mask, .index = params.write_offset,
+      },
+      write_val);
+  ptr = bitfield_field32_write(
+      ptr,
+      (bitfield_field32_t){
+          .mask = params.read_mask, .index = params.read_offset,
+      },
+      read_val);
   mmio_region_write32(spi->base_addr, params.reg_offset, ptr);
 }
 

--- a/sw/device/lib/dif/dif_uart.c
+++ b/sw/device/lib/dif/dif_uart.c
@@ -6,6 +6,7 @@
 
 #include <stddef.h>
 
+#include "sw/device/lib/base/bitfield.h"
 #include "sw/device/lib/base/mmio.h"
 #include "uart_regs.h"  // Generated.
 
@@ -199,21 +200,22 @@ dif_uart_result_t dif_uart_watermark_rx_set(const dif_uart_t *uart,
   bitfield_field32_t field = {
       .mask = UART_FIFO_CTRL_RXILVL_MASK, .index = UART_FIFO_CTRL_RXILVL_OFFSET,
   };
+  uint32_t value;
   switch (watermark) {
     case kDifUartWatermarkByte1:
-      field.value = UART_FIFO_CTRL_RXILVL_RXLVL1;
+      value = UART_FIFO_CTRL_RXILVL_RXLVL1;
       break;
     case kDifUartWatermarkByte4:
-      field.value = UART_FIFO_CTRL_RXILVL_RXLVL4;
+      value = UART_FIFO_CTRL_RXILVL_RXLVL4;
       break;
     case kDifUartWatermarkByte8:
-      field.value = UART_FIFO_CTRL_RXILVL_RXLVL8;
+      value = UART_FIFO_CTRL_RXILVL_RXLVL8;
       break;
     case kDifUartWatermarkByte16:
-      field.value = UART_FIFO_CTRL_RXILVL_RXLVL16;
+      value = UART_FIFO_CTRL_RXILVL_RXLVL16;
       break;
     case kDifUartWatermarkByte30:
-      field.value = UART_FIFO_CTRL_RXILVL_RXLVL30;
+      value = UART_FIFO_CTRL_RXILVL_RXLVL30;
       break;
     default:
       return kDifUartError;
@@ -221,7 +223,7 @@ dif_uart_result_t dif_uart_watermark_rx_set(const dif_uart_t *uart,
 
   // Set watermark level.
   mmio_region_nonatomic_set_field32(uart->base_addr, UART_FIFO_CTRL_REG_OFFSET,
-                                    field);
+                                    field, value);
 
   return kDifUartOk;
 }
@@ -237,18 +239,19 @@ dif_uart_result_t dif_uart_watermark_tx_set(const dif_uart_t *uart,
   bitfield_field32_t field = {
       .mask = UART_FIFO_CTRL_TXILVL_MASK, .index = UART_FIFO_CTRL_TXILVL_OFFSET,
   };
+  uint32_t value;
   switch (watermark) {
     case kDifUartWatermarkByte1:
-      field.value = UART_FIFO_CTRL_TXILVL_TXLVL1;
+      value = UART_FIFO_CTRL_TXILVL_TXLVL1;
       break;
     case kDifUartWatermarkByte4:
-      field.value = UART_FIFO_CTRL_TXILVL_TXLVL4;
+      value = UART_FIFO_CTRL_TXILVL_TXLVL4;
       break;
     case kDifUartWatermarkByte8:
-      field.value = UART_FIFO_CTRL_TXILVL_TXLVL8;
+      value = UART_FIFO_CTRL_TXILVL_TXLVL8;
       break;
     case kDifUartWatermarkByte16:
-      field.value = UART_FIFO_CTRL_TXILVL_TXLVL16;
+      value = UART_FIFO_CTRL_TXILVL_TXLVL16;
       break;
     default:
       // The minimal TX watermark is 1 byte, maximal 16 bytes.
@@ -257,7 +260,7 @@ dif_uart_result_t dif_uart_watermark_tx_set(const dif_uart_t *uart,
 
   // Set watermark level.
   mmio_region_nonatomic_set_field32(uart->base_addr, UART_FIFO_CTRL_REG_OFFSET,
-                                    field);
+                                    field, value);
 
   return kDifUartOk;
 }
@@ -482,17 +485,19 @@ dif_uart_result_t dif_uart_fifo_reset(const dif_uart_t *uart,
   uint32_t reg = mmio_region_read32(uart->base_addr, UART_FIFO_CTRL_REG_OFFSET);
 
   if (reset == kDifUartFifoResetRx || reset == kDifUartFifoResetAll) {
-    reg = bitfield_set_field32(
-        reg, (bitfield_field32_t){
-                 .mask = 0x1, .value = 1, .index = UART_FIFO_CTRL_RXRST,
-             });
+    reg = bitfield_field32_write(reg,
+                                 (bitfield_field32_t){
+                                     .mask = 0x1, .index = UART_FIFO_CTRL_RXRST,
+                                 },
+                                 1);
   }
 
   if (reset == kDifUartFifoResetTx || reset == kDifUartFifoResetAll) {
-    reg = bitfield_set_field32(
-        reg, (bitfield_field32_t){
-                 .mask = 0x1, .value = 1, .index = UART_FIFO_CTRL_TXRST,
-             });
+    reg = bitfield_field32_write(reg,
+                                 (bitfield_field32_t){
+                                     .mask = 0x1, .index = UART_FIFO_CTRL_TXRST,
+                                 },
+                                 1);
   }
 
   mmio_region_write32(uart->base_addr, UART_FIFO_CTRL_REG_OFFSET, reg);
@@ -510,11 +515,10 @@ dif_uart_result_t dif_uart_loopback_set(const dif_uart_t *uart,
   bitfield_field32_t field = {
       .mask = 0x1,
       .index = loopback ? UART_CTRL_LLPBK : UART_CTRL_SLPBK,
-      .value = enable ? 1 : 0,
   };
 
   uint32_t reg = mmio_region_read32(uart->base_addr, UART_CTRL_REG_OFFSET);
-  reg = bitfield_set_field32(reg, field);
+  reg = bitfield_field32_write(reg, field, enable ? 1 : 0);
   mmio_region_write32(uart->base_addr, UART_CTRL_REG_OFFSET, reg);
 
   return kDifUartOk;

--- a/sw/device/lib/testing/mock_mmio.cc
+++ b/sw/device/lib/testing/mock_mmio.cc
@@ -16,11 +16,6 @@ uint8_t mmio_region_read8(mmio_region_t base, ptrdiff_t offset) {
   return dev->Read8(offset);
 }
 
-uint16_t mmio_region_read16(mmio_region_t base, ptrdiff_t offset) {
-  auto *dev = static_cast<MockDevice *>(base.mock);
-  return dev->Read16(offset);
-}
-
 uint32_t mmio_region_read32(mmio_region_t base, ptrdiff_t offset) {
   auto *dev = static_cast<MockDevice *>(base.mock);
   return dev->Read32(offset);
@@ -29,11 +24,6 @@ uint32_t mmio_region_read32(mmio_region_t base, ptrdiff_t offset) {
 void mmio_region_write8(mmio_region_t base, ptrdiff_t offset, uint8_t value) {
   auto *dev = static_cast<MockDevice *>(base.mock);
   dev->Write8(offset, value);
-}
-
-void mmio_region_write16(mmio_region_t base, ptrdiff_t offset, uint16_t value) {
-  auto *dev = static_cast<MockDevice *>(base.mock);
-  dev->Write16(offset, value);
 }
 
 void mmio_region_write32(mmio_region_t base, ptrdiff_t offset, uint32_t value) {

--- a/sw/device/lib/testing/mock_mmio.h
+++ b/sw/device/lib/testing/mock_mmio.h
@@ -355,32 +355,6 @@ class MmioTest {
   } while (false)
 
 /**
- * Expect an unspecified 8-bit read to the device `dev` at the given offset,
- * followed by a write to the same location, with the same value but with some
- * bits changed; the remaining bits must be untouched.
- *
- * The changed bits are specified by a `std::initializer_list<MaskedBitField>`.
- *
- * This expectation is sequenced with all other `EXPECT_READ` and `EXPECT_WRITE`
- * calls.
- */
-#define EXPECT_MASK8_AT(dev, offset, ...) \
-  EXPECT_MASK_INTERAL_(8, dev, offset, __VA_ARGS__)
-
-/**
- * Expect an unspecified 32-bit read to the device `dev` at the given offset,
- * followed by a write to the same location, with the same value but with some
- * bits changed; the remaining bits must be untouched.
- *
- * The changed bits are specified by a `std::initializer_list<MaskedBitField>`.
- *
- * This expectation is sequenced with all other `EXPECT_READ` and `EXPECT_WRITE`
- * calls.
- */
-#define EXPECT_MASK32_AT(dev, offset, ...) \
-  EXPECT_MASK_INTERAL_(32, dev, offset, __VA_ARGS__)
-
-/**
  * Expect an unspecified 8-bit read at the given offset, followed by a write to
  * the same location, with the same value but with some bits changed; the
  * remaining bits must be untouched.
@@ -394,7 +368,7 @@ class MmioTest {
  * calls.
  */
 #define EXPECT_MASK8(offset, ...) \
-  EXPECT_MASK8_AT(this->dev(), offset, __VA_ARGS__)
+  EXPECT_MASK_INTERAL_(8, this->dev(), offset, __VA_ARGS__)
 
 /**
  * Expect an unspecified 32-bit read at the given offset, followed by a write to
@@ -410,6 +384,6 @@ class MmioTest {
  * calls.
  */
 #define EXPECT_MASK32(offset, ...) \
-  EXPECT_MASK32_AT(this->dev(), offset, __VA_ARGS__)
+  EXPECT_MASK_INTERAL_(32, this->dev(), offset, __VA_ARGS__)
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_MOCK_MMIO_H_

--- a/sw/device/lib/testing/mock_mmio.h
+++ b/sw/device/lib/testing/mock_mmio.h
@@ -334,7 +334,7 @@ class MmioTest {
 #define EXPECT_WRITE32(offset, ...) \
   EXPECT_WRITE32_AT(this->dev(), offset, __VA_ARGS__);
 
-#define EXPECT_MASK_INTERAL_(width, dev, off, ...)                         \
+#define EXPECT_MASK_INTERNAL_(width, dev, off, ...)                        \
   do {                                                                     \
     auto &device = dev;                                                    \
     std::initializer_list<mock_mmio::MaskedBitField> fields = __VA_ARGS__; \
@@ -368,7 +368,7 @@ class MmioTest {
  * calls.
  */
 #define EXPECT_MASK8(offset, ...) \
-  EXPECT_MASK_INTERAL_(8, this->dev(), offset, __VA_ARGS__)
+  EXPECT_MASK_INTERNAL_(8, this->dev(), offset, __VA_ARGS__)
 
 /**
  * Expect an unspecified 32-bit read at the given offset, followed by a write to
@@ -384,6 +384,6 @@ class MmioTest {
  * calls.
  */
 #define EXPECT_MASK32(offset, ...) \
-  EXPECT_MASK_INTERAL_(32, this->dev(), offset, __VA_ARGS__)
+  EXPECT_MASK_INTERNAL_(32, this->dev(), offset, __VA_ARGS__)
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_MOCK_MMIO_H_

--- a/sw/device/lib/testing/mock_mmio.h
+++ b/sw/device/lib/testing/mock_mmio.h
@@ -175,11 +175,9 @@ class MockDevice {
   mmio_region_t region() { return {this}; }
 
   MOCK_METHOD(uint8_t, Read8, (ptrdiff_t offset));
-  MOCK_METHOD(uint16_t, Read16, (ptrdiff_t offset));
   MOCK_METHOD(uint32_t, Read32, (ptrdiff_t offset));
 
   MOCK_METHOD(void, Write8, (ptrdiff_t offset, uint8_t value));
-  MOCK_METHOD(void, Write16, (ptrdiff_t offset, uint16_t value));
   MOCK_METHOD(void, Write32, (ptrdiff_t offset, uint32_t value));
 
   /**
@@ -235,21 +233,6 @@ class MmioTest {
 
 /**
  * Expect a read to the device `dev` at the given offset, returning the given
- * 16-bit value.
- *
- * The value may be given as an integer, a pointer to little-endian data,
- * or a `std::initializer_list<BitField>`.
- *
- * This expectation is sequenced with all other `EXPECT_READ` and `EXPECT_WRITE`
- * calls.
- */
-#define EXPECT_READ16_AT(dev, offset, ...) \
-  EXPECT_CALL(dev, Read16(offset))         \
-      .WillOnce(                           \
-          testing::Return(mock_mmio::internal::ToInt<uint16_t>(__VA_ARGS__)))
-
-/**
- * Expect a read to the device `dev` at the given offset, returning the given
  * 32-bit value.
  *
  * The value may be given as an integer, a pointer to little-endian data,
@@ -276,20 +259,6 @@ class MmioTest {
 #define EXPECT_WRITE8_AT(dev, offset, ...) \
   EXPECT_CALL(                             \
       dev, Write8(offset, mock_mmio::internal::ToInt<uint8_t>(__VA_ARGS__)))
-
-/**
- * Expect a write to the device `dev` at the given offset with the given 16-bit
- * value.
- *
- * The value may be given as an integer, a pointer to little-endian data,
- * or a `std::initializer_list<BitField>`.
- *
- * This expectation is sequenced with all other `EXPECT_READ` and `EXPECT_WRITE`
- * calls.
- */
-#define EXPECT_WRITE16_AT(dev, offset, ...) \
-  EXPECT_CALL(                              \
-      dev, Write16(offset, mock_mmio::internal::ToInt<uint16_t>(__VA_ARGS__)))
 
 /**
  * Expect a write to the device `dev` at the given offset with the given 32-bit
@@ -321,21 +290,6 @@ class MmioTest {
   EXPECT_READ8_AT(this->dev(), offset, __VA_ARGS__)
 
 /**
- * Expect a read at the given offset, returning the given 16-bit value.
- *
- * The value may be given as an integer, a pointer to little-endian data,
- * or a `std::initializer_list<BitField>`.
- *
- * This function is only available in tests using a fixture that derives
- * `MmioTest`.
- *
- * This expectation is sequenced with all other `EXPECT_READ` and `EXPECT_WRITE`
- * calls.
- */
-#define EXPECT_READ16(offset, ...) \
-  EXPECT_READ16_AT(this->dev(), offset, __VA_ARGS__)
-
-/**
  * Expect a read at the given offset, returning the given 32-bit value.
  *
  * The value may be given as an integer, a pointer to little-endian data,
@@ -364,21 +318,6 @@ class MmioTest {
  */
 #define EXPECT_WRITE8(offset, ...) \
   EXPECT_WRITE8_AT(this->dev(), offset, __VA_ARGS__);
-
-/**
- * Expect a write to the given offset with the given 16-bit value.
- *
- * The value may be given as an integer, a pointer to little-endian data,
- * or a `std::initializer_list<BitField>`.
- *
- * This function is only available in tests using a fixture that derives
- * `MmioTest`.
- *
- * This expectation is sequenced with all other `EXPECT_READ` and `EXPECT_WRITE`
- * calls.
- */
-#define EXPECT_WRITE16(offset, ...) \
-  EXPECT_WRITE16_AT(this->dev(), offset, __VA_ARGS__);
 
 /**
  * Expect a write to the given offset with the given 32-bit value.
@@ -429,19 +368,6 @@ class MmioTest {
   EXPECT_MASK_INTERAL_(8, dev, offset, __VA_ARGS__)
 
 /**
- * Expect an unspecified 16-bit read to the device `dev` at the given offset,
- * followed by a write to the same location, with the same value but with some
- * bits changed; the remaining bits must be untouched.
- *
- * The changed bits are specified by a `std::initializer_list<MaskedBitField>`.
- *
- * This expectation is sequenced with all other `EXPECT_READ` and `EXPECT_WRITE`
- * calls.
- */
-#define EXPECT_MASK16_AT(dev, offset, ...) \
-  EXPECT_MASK_INTERAL_(16, dev, offset, __VA_ARGS__)
-
-/**
  * Expect an unspecified 32-bit read to the device `dev` at the given offset,
  * followed by a write to the same location, with the same value but with some
  * bits changed; the remaining bits must be untouched.
@@ -468,22 +394,6 @@ class MmioTest {
  * calls.
  */
 #define EXPECT_MASK8(offset, ...) \
-  EXPECT_MASK32_AT(this->dev(), offset, __VA_ARGS__)
-
-/**
- * Expect an unspecified 16-bit read at the given offset, followed by a write to
- * the same location, with the same value but with some bits changed; the
- * remaining bits must be untouched.
- *
- * The changed bits are specified by a `std::initializer_list<MaskedBitField>`.
- *
- * This function is only available in tests using a fixture that derives
- * `MmioTest`.
- *
- * This expectation is sequenced with all other `EXPECT_READ` and `EXPECT_WRITE`
- * calls.
- */
-#define EXPECT_MASK16(offset, ...) \
   EXPECT_MASK32_AT(this->dev(), offset, __VA_ARGS__)
 
 /**

--- a/sw/device/lib/testing/mock_mmio.h
+++ b/sw/device/lib/testing/mock_mmio.h
@@ -394,7 +394,7 @@ class MmioTest {
  * calls.
  */
 #define EXPECT_MASK8(offset, ...) \
-  EXPECT_MASK32_AT(this->dev(), offset, __VA_ARGS__)
+  EXPECT_MASK8_AT(this->dev(), offset, __VA_ARGS__)
 
 /**
  * Expect an unspecified 32-bit read at the given offset, followed by a write to

--- a/sw/device/lib/testing/mock_mmio_test.cc
+++ b/sw/device/lib/testing/mock_mmio_test.cc
@@ -14,14 +14,16 @@ using ::testing::Test;
 
 /**
  * Exercises the register |dev| by reading a value at offset 0x0,
- * writing its complement to 0x4, and then writing its upper half
- * and lower half to 0x8 and 0xa.
+ * writing its complement to 0x4, and then writing it byte by byte
+ * back over itself, from MSB to LSB.
  */
 uint32_t WriteTwice(mmio_region_t dev) {
   auto value = mmio_region_read32(dev, 0x0);
   mmio_region_write32(dev, 0x4, ~value);
-  mmio_region_write16(dev, 0x8, value >> 16);
-  mmio_region_write16(dev, 0xa, value & 0xffff);
+  mmio_region_write8(dev, 0x12, (value >> 24) & 0xff);
+  mmio_region_write8(dev, 0x8, (value >> 16) & 0xff);
+  mmio_region_write8(dev, 0x4, (value >> 8) & 0xff);
+  mmio_region_write8(dev, 0x0, value & 0xff);
   return value;
 }
 
@@ -29,9 +31,11 @@ class MockMmioTest : public Test, public MmioTest {};
 
 TEST_F(MockMmioTest, WriteTwice) {
   EXPECT_READ32(0x0, 0xdeadbeef);
-  EXPECT_WRITE32(0x4, 0x21524110)
-  EXPECT_WRITE16(0x8, 0xdead);
-  EXPECT_WRITE16(0xa, 0xbeef);
+  EXPECT_WRITE32(0x4, 0x21524110);
+  EXPECT_WRITE8(0x12, 0xde);
+  EXPECT_WRITE8(0x8, 0xad);
+  EXPECT_WRITE8(0x4, 0xbe);
+  EXPECT_WRITE8(0x0, 0xef);
 
   EXPECT_EQ(WriteTwice(dev().region()), 0xdeadbeef);
 }
@@ -56,8 +60,8 @@ TEST_F(MockMmioTest, ExpectWithBits) {
   EXPECT_READ8(0xc, {{0x0, false}, {0x1, true}, {0x3, true}});
   EXPECT_EQ(mmio_region_read8(dev().region(), 0xc), 0b1010);
 
-  EXPECT_WRITE16(0x12, {{0x0, 0xfe}, {0x8, 0xca}});
-  mmio_region_write16(dev().region(), 0x12, 0xcafe);
+  EXPECT_WRITE32(0x12, {{0x0, 0xfe}, {0x8, 0xca}});
+  mmio_region_write32(dev().region(), 0x12, 0xcafe);
 }
 
 TEST_F(MockMmioTest, ExpectMask) {


### PR DESCRIPTION
This set of changes relates to #2203, where we've talked about simplifying the design of the MMIO library, and moving all the bit-manipulation functionality to `bitfield.h`.

In particular:
- I added a pair of new functions in bitfield, `bitfield_bit32_read` and `bitfield_bit32_write` which are used for reads and writes of individual bits. 
- I clarified the bitfield function names to use read/write rather than get/set ("set" can mean overwrite or set to all ones, "write" can only mean the former).
- I split the field/bit addressing parts of bitfield from the value changing, rather than keeping `.value` as optional. This should keep the constant parts (field descriptions) separate from non-constant parts (new value to write).
- I have updated the existing DIFs to use these new APIs, using the single-bit read/write where appropriate.

I've taken the opportunity to also make some deletions in the aim of keeping the APIs smaller:
- Remove the `mmio_region_*16` functions, which are completely unused. We can add them back if we find we need them.
- Remove the `EXPECT_MASK<N>_AT` macros, which are also unused (the other `*_AT` macros are used in `EXPECT_MASK_INTERAL_`).
- Correct a bug in `EXPECT_MASK8` (which will need checking by @mcy).

All the unit tests are still passing. We'll see if CI feels the same way about my changes.

The next steps for these changes are:
- Start moving existing code to explicitly use `read; modify; write` rather than the nonatomic functions. This is why there are some changes to functions in `mmio.h` - to make it easier to show exactly what read/modify/write is happening in the nonatomic functions, without further `mmio.h` calls.
- Mark the `MMIO_DEPRECATED` functions in mmio.h as actually `__attribute__((deprecated))` so that people avoid using them.