### PR TITLE
[Flash] Flash data scrambling

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson
@@ -20,7 +20,15 @@
       name:    "flash",          // flash_o (req), flash_i (rsp)
       act:     "req",
       package: "flash_ctrl_pkg", // Origin package (only needs for the requester)
+    },
+
+    { struct: "otp_flash",
+      type: "uni",
+      name: "otp",
+      act:  "rcv",
+      package: "flash_ctrl_pkg"
     }
+
   ],
 
   param_list: [
@@ -181,6 +189,23 @@
             For page erases, the controller will truncate to the closest lower page aligned
             address.  Similarly for bank erases, the controller will truncate to the closest
             lower bank aligned address.
+            '''
+          resval: "0"
+        },
+      ]
+    },
+
+    { name: "SCRAMBLE_EN",
+      desc: "Scramble enable for flash",
+      swaccess: "rw",
+      hwaccess: "hro",
+      resval: "0",
+      fields: [
+        { bits: "0",
+          name: "VAL",
+          desc: '''
+            Temporary enable bit for flash scramble.
+            See #2630.
             '''
           resval: "0"
         },

--- a/hw/ip/flash_ctrl/flash_ctrl.core
+++ b/hw/ip/flash_ctrl/flash_ctrl.core
@@ -3,7 +3,7 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 name: "lowrisc:ip:flash_ctrl:0.1"
-description: "Faux Flash Controller"
+description: "Flash Controller"
 
 filesets:
   files_rtl:
@@ -11,6 +11,7 @@ filesets:
       - lowrisc:ip:tlul
       - lowrisc:prim:all
       - lowrisc:prim:flash
+      - lowrisc:prim:gf_mult
       - lowrisc:ip:flash_ctrl_pkg
     files:
       - rtl/flash_ctrl_reg_pkg.sv
@@ -25,6 +26,7 @@ filesets:
       - rtl/flash_phy_rd.sv
       - rtl/flash_phy_prog.sv
       - rtl/flash_phy_rd_buffers.sv
+      - rtl/flash_phy_scramble.sv
     file_type: systemVerilogSource
 
   files_verilator_waiver:

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -20,6 +20,9 @@ module flash_ctrl import flash_ctrl_pkg::*; (
   input        flash_rsp_t flash_i,
   output       flash_req_t flash_o,
 
+  // OTP Interface
+  input        otp_flash_t otp_i,
+
   // Interrupts
   output logic intr_prog_empty_o, // Program fifo is empty
   output logic intr_prog_lvl_o,   // Program fifo is empty
@@ -388,6 +391,9 @@ module flash_ctrl import flash_ctrl_pkg::*; (
   assign flash_o.part = flash_part_sel;
   assign flash_o.prog_data = flash_prog_data;
   assign flash_o.prog_last = flash_prog_last;
+  assign flash_o.scramble_en = reg2hw.scramble_en.q;
+  assign flash_o.addr_key = otp_i.addr_key;
+  assign flash_o.data_key = otp_i.data_key;
   assign flash_rd_data = flash_i.rd_data;
   assign init_busy = flash_i.init_busy;
 

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
@@ -77,6 +77,9 @@ package flash_ctrl_pkg;
     logic [BusAddrW-1:0]  addr;
     logic [BusWidth-1:0]  prog_data;
     logic                 prog_last;
+    logic                 scramble_en;
+    logic [127:0]         addr_key;
+    logic [127:0]         data_key;
   } flash_req_t;
 
   // default value of flash_req_t (for dangling ports)
@@ -89,7 +92,10 @@ package flash_ctrl_pkg;
     part:      DataPart,
     addr:      '0,
     prog_data: '0,
-    prog_last: '0
+    prog_last: '0,
+    scramble_en: '0,
+    addr_key:  128'hDEADBEEFBEEFFACEDEADBEEF5A5AA5A5,
+    data_key:  128'hDEADBEEF5A5AA5A5DEADBEEFBEEFFACE
   };
 
   // memory to flash controller
@@ -109,5 +115,23 @@ package flash_ctrl_pkg;
     rd_data:    '0,
     init_busy:  1'b0
   };
+
+  ////////////////////////////
+  // The following inter-module should be moved to OTP
+  ////////////////////////////
+
+  // otp to flash_phy
+  typedef struct packed {
+    logic [127:0] addr_key;
+    logic [127:0] data_key;
+  } otp_flash_t;
+
+  // default value of otp_flash_t
+  parameter otp_flash_t OTP_FLASH_DEFAULT = '{
+    addr_key: 128'hDEADBEEFBEEFFACEDEADBEEF5A5AA5A5,
+    data_key: 128'hDEADBEEF5A5AA5A5DEADBEEFBEEFFACE
+  };
+
+
 
 endpackage : flash_ctrl_pkg

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
@@ -105,6 +105,10 @@ package flash_ctrl_reg_pkg;
   } flash_ctrl_reg2hw_addr_reg_t;
 
   typedef struct packed {
+    logic        q;
+  } flash_ctrl_reg2hw_scramble_en_reg_t;
+
+  typedef struct packed {
     struct packed {
       logic        q;
     } en;
@@ -240,11 +244,12 @@ package flash_ctrl_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    flash_ctrl_reg2hw_intr_state_reg_t intr_state; // [312:307]
-    flash_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [306:301]
-    flash_ctrl_reg2hw_intr_test_reg_t intr_test; // [300:289]
-    flash_ctrl_reg2hw_control_reg_t control; // [288:272]
-    flash_ctrl_reg2hw_addr_reg_t addr; // [271:240]
+    flash_ctrl_reg2hw_intr_state_reg_t intr_state; // [313:308]
+    flash_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [307:302]
+    flash_ctrl_reg2hw_intr_test_reg_t intr_test; // [301:290]
+    flash_ctrl_reg2hw_control_reg_t control; // [289:273]
+    flash_ctrl_reg2hw_addr_reg_t addr; // [272:241]
+    flash_ctrl_reg2hw_scramble_en_reg_t scramble_en; // [240:240]
     flash_ctrl_reg2hw_mp_region_cfg_mreg_t [7:0] mp_region_cfg; // [239:48]
     flash_ctrl_reg2hw_default_region_reg_t default_region; // [47:45]
     flash_ctrl_reg2hw_mp_bank_cfg_mreg_t [1:0] mp_bank_cfg; // [44:43]
@@ -271,28 +276,29 @@ package flash_ctrl_reg_pkg;
   parameter logic [6:0] FLASH_CTRL_CTRL_REGWEN_OFFSET = 7'h c;
   parameter logic [6:0] FLASH_CTRL_CONTROL_OFFSET = 7'h 10;
   parameter logic [6:0] FLASH_CTRL_ADDR_OFFSET = 7'h 14;
-  parameter logic [6:0] FLASH_CTRL_REGION_CFG_REGWEN_OFFSET = 7'h 18;
-  parameter logic [6:0] FLASH_CTRL_MP_REGION_CFG0_OFFSET = 7'h 1c;
-  parameter logic [6:0] FLASH_CTRL_MP_REGION_CFG1_OFFSET = 7'h 20;
-  parameter logic [6:0] FLASH_CTRL_MP_REGION_CFG2_OFFSET = 7'h 24;
-  parameter logic [6:0] FLASH_CTRL_MP_REGION_CFG3_OFFSET = 7'h 28;
-  parameter logic [6:0] FLASH_CTRL_MP_REGION_CFG4_OFFSET = 7'h 2c;
-  parameter logic [6:0] FLASH_CTRL_MP_REGION_CFG5_OFFSET = 7'h 30;
-  parameter logic [6:0] FLASH_CTRL_MP_REGION_CFG6_OFFSET = 7'h 34;
-  parameter logic [6:0] FLASH_CTRL_MP_REGION_CFG7_OFFSET = 7'h 38;
-  parameter logic [6:0] FLASH_CTRL_DEFAULT_REGION_OFFSET = 7'h 3c;
-  parameter logic [6:0] FLASH_CTRL_BANK_CFG_REGWEN_OFFSET = 7'h 40;
-  parameter logic [6:0] FLASH_CTRL_MP_BANK_CFG_OFFSET = 7'h 44;
-  parameter logic [6:0] FLASH_CTRL_OP_STATUS_OFFSET = 7'h 48;
-  parameter logic [6:0] FLASH_CTRL_STATUS_OFFSET = 7'h 4c;
-  parameter logic [6:0] FLASH_CTRL_SCRATCH_OFFSET = 7'h 50;
-  parameter logic [6:0] FLASH_CTRL_FIFO_LVL_OFFSET = 7'h 54;
-  parameter logic [6:0] FLASH_CTRL_FIFO_RST_OFFSET = 7'h 58;
+  parameter logic [6:0] FLASH_CTRL_SCRAMBLE_EN_OFFSET = 7'h 18;
+  parameter logic [6:0] FLASH_CTRL_REGION_CFG_REGWEN_OFFSET = 7'h 1c;
+  parameter logic [6:0] FLASH_CTRL_MP_REGION_CFG0_OFFSET = 7'h 20;
+  parameter logic [6:0] FLASH_CTRL_MP_REGION_CFG1_OFFSET = 7'h 24;
+  parameter logic [6:0] FLASH_CTRL_MP_REGION_CFG2_OFFSET = 7'h 28;
+  parameter logic [6:0] FLASH_CTRL_MP_REGION_CFG3_OFFSET = 7'h 2c;
+  parameter logic [6:0] FLASH_CTRL_MP_REGION_CFG4_OFFSET = 7'h 30;
+  parameter logic [6:0] FLASH_CTRL_MP_REGION_CFG5_OFFSET = 7'h 34;
+  parameter logic [6:0] FLASH_CTRL_MP_REGION_CFG6_OFFSET = 7'h 38;
+  parameter logic [6:0] FLASH_CTRL_MP_REGION_CFG7_OFFSET = 7'h 3c;
+  parameter logic [6:0] FLASH_CTRL_DEFAULT_REGION_OFFSET = 7'h 40;
+  parameter logic [6:0] FLASH_CTRL_BANK_CFG_REGWEN_OFFSET = 7'h 44;
+  parameter logic [6:0] FLASH_CTRL_MP_BANK_CFG_OFFSET = 7'h 48;
+  parameter logic [6:0] FLASH_CTRL_OP_STATUS_OFFSET = 7'h 4c;
+  parameter logic [6:0] FLASH_CTRL_STATUS_OFFSET = 7'h 50;
+  parameter logic [6:0] FLASH_CTRL_SCRATCH_OFFSET = 7'h 54;
+  parameter logic [6:0] FLASH_CTRL_FIFO_LVL_OFFSET = 7'h 58;
+  parameter logic [6:0] FLASH_CTRL_FIFO_RST_OFFSET = 7'h 5c;
 
   // Window parameter
-  parameter logic [6:0] FLASH_CTRL_PROG_FIFO_OFFSET = 7'h 5c;
+  parameter logic [6:0] FLASH_CTRL_PROG_FIFO_OFFSET = 7'h 60;
   parameter logic [6:0] FLASH_CTRL_PROG_FIFO_SIZE   = 7'h 4;
-  parameter logic [6:0] FLASH_CTRL_RD_FIFO_OFFSET = 7'h 60;
+  parameter logic [6:0] FLASH_CTRL_RD_FIFO_OFFSET = 7'h 64;
   parameter logic [6:0] FLASH_CTRL_RD_FIFO_SIZE   = 7'h 4;
 
   // Register Index
@@ -303,6 +309,7 @@ package flash_ctrl_reg_pkg;
     FLASH_CTRL_CTRL_REGWEN,
     FLASH_CTRL_CONTROL,
     FLASH_CTRL_ADDR,
+    FLASH_CTRL_SCRAMBLE_EN,
     FLASH_CTRL_REGION_CFG_REGWEN,
     FLASH_CTRL_MP_REGION_CFG0,
     FLASH_CTRL_MP_REGION_CFG1,
@@ -323,30 +330,31 @@ package flash_ctrl_reg_pkg;
   } flash_ctrl_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] FLASH_CTRL_PERMIT [23] = '{
+  parameter logic [3:0] FLASH_CTRL_PERMIT [24] = '{
     4'b 0001, // index[ 0] FLASH_CTRL_INTR_STATE
     4'b 0001, // index[ 1] FLASH_CTRL_INTR_ENABLE
     4'b 0001, // index[ 2] FLASH_CTRL_INTR_TEST
     4'b 0001, // index[ 3] FLASH_CTRL_CTRL_REGWEN
     4'b 1111, // index[ 4] FLASH_CTRL_CONTROL
     4'b 1111, // index[ 5] FLASH_CTRL_ADDR
-    4'b 0001, // index[ 6] FLASH_CTRL_REGION_CFG_REGWEN
-    4'b 1111, // index[ 7] FLASH_CTRL_MP_REGION_CFG0
-    4'b 1111, // index[ 8] FLASH_CTRL_MP_REGION_CFG1
-    4'b 1111, // index[ 9] FLASH_CTRL_MP_REGION_CFG2
-    4'b 1111, // index[10] FLASH_CTRL_MP_REGION_CFG3
-    4'b 1111, // index[11] FLASH_CTRL_MP_REGION_CFG4
-    4'b 1111, // index[12] FLASH_CTRL_MP_REGION_CFG5
-    4'b 1111, // index[13] FLASH_CTRL_MP_REGION_CFG6
-    4'b 1111, // index[14] FLASH_CTRL_MP_REGION_CFG7
-    4'b 0001, // index[15] FLASH_CTRL_DEFAULT_REGION
-    4'b 0001, // index[16] FLASH_CTRL_BANK_CFG_REGWEN
-    4'b 0001, // index[17] FLASH_CTRL_MP_BANK_CFG
-    4'b 0001, // index[18] FLASH_CTRL_OP_STATUS
-    4'b 0111, // index[19] FLASH_CTRL_STATUS
-    4'b 1111, // index[20] FLASH_CTRL_SCRATCH
-    4'b 0011, // index[21] FLASH_CTRL_FIFO_LVL
-    4'b 0001  // index[22] FLASH_CTRL_FIFO_RST
+    4'b 0001, // index[ 6] FLASH_CTRL_SCRAMBLE_EN
+    4'b 0001, // index[ 7] FLASH_CTRL_REGION_CFG_REGWEN
+    4'b 1111, // index[ 8] FLASH_CTRL_MP_REGION_CFG0
+    4'b 1111, // index[ 9] FLASH_CTRL_MP_REGION_CFG1
+    4'b 1111, // index[10] FLASH_CTRL_MP_REGION_CFG2
+    4'b 1111, // index[11] FLASH_CTRL_MP_REGION_CFG3
+    4'b 1111, // index[12] FLASH_CTRL_MP_REGION_CFG4
+    4'b 1111, // index[13] FLASH_CTRL_MP_REGION_CFG5
+    4'b 1111, // index[14] FLASH_CTRL_MP_REGION_CFG6
+    4'b 1111, // index[15] FLASH_CTRL_MP_REGION_CFG7
+    4'b 0001, // index[16] FLASH_CTRL_DEFAULT_REGION
+    4'b 0001, // index[17] FLASH_CTRL_BANK_CFG_REGWEN
+    4'b 0001, // index[18] FLASH_CTRL_MP_BANK_CFG
+    4'b 0001, // index[19] FLASH_CTRL_OP_STATUS
+    4'b 0111, // index[20] FLASH_CTRL_STATUS
+    4'b 1111, // index[21] FLASH_CTRL_SCRATCH
+    4'b 0011, // index[22] FLASH_CTRL_FIFO_LVL
+    4'b 0001  // index[23] FLASH_CTRL_FIFO_RST
   };
 endpackage
 

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_top.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_top.sv
@@ -88,10 +88,10 @@ module flash_ctrl_reg_top (
     reg_steer = 2;       // Default set to register
 
     // TODO: Can below codes be unique case () inside ?
-    if (tl_i.a_address[AW-1:0] >= 92 && tl_i.a_address[AW-1:0] < 96) begin
+    if (tl_i.a_address[AW-1:0] >= 96 && tl_i.a_address[AW-1:0] < 100) begin
       reg_steer = 0;
     end
-    if (tl_i.a_address[AW-1:0] >= 96 && tl_i.a_address[AW-1:0] < 100) begin
+    if (tl_i.a_address[AW-1:0] >= 100 && tl_i.a_address[AW-1:0] < 104) begin
       reg_steer = 1;
     end
   end
@@ -189,6 +189,9 @@ module flash_ctrl_reg_top (
   logic [31:0] addr_qs;
   logic [31:0] addr_wd;
   logic addr_we;
+  logic scramble_en_qs;
+  logic scramble_en_wd;
+  logic scramble_en_we;
   logic region_cfg_regwen_qs;
   logic region_cfg_regwen_wd;
   logic region_cfg_regwen_we;
@@ -992,6 +995,33 @@ module flash_ctrl_reg_top (
 
     // to register interface (read)
     .qs     (addr_qs)
+  );
+
+
+  // R[scramble_en]: V(False)
+
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_scramble_en (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (scramble_en_we),
+    .wd     (scramble_en_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.scramble_en.q ),
+
+    // to register interface (read)
+    .qs     (scramble_en_qs)
   );
 
 
@@ -2939,7 +2969,7 @@ module flash_ctrl_reg_top (
 
 
 
-  logic [22:0] addr_hit;
+  logic [23:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == FLASH_CTRL_INTR_STATE_OFFSET);
@@ -2948,23 +2978,24 @@ module flash_ctrl_reg_top (
     addr_hit[ 3] = (reg_addr == FLASH_CTRL_CTRL_REGWEN_OFFSET);
     addr_hit[ 4] = (reg_addr == FLASH_CTRL_CONTROL_OFFSET);
     addr_hit[ 5] = (reg_addr == FLASH_CTRL_ADDR_OFFSET);
-    addr_hit[ 6] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_OFFSET);
-    addr_hit[ 7] = (reg_addr == FLASH_CTRL_MP_REGION_CFG0_OFFSET);
-    addr_hit[ 8] = (reg_addr == FLASH_CTRL_MP_REGION_CFG1_OFFSET);
-    addr_hit[ 9] = (reg_addr == FLASH_CTRL_MP_REGION_CFG2_OFFSET);
-    addr_hit[10] = (reg_addr == FLASH_CTRL_MP_REGION_CFG3_OFFSET);
-    addr_hit[11] = (reg_addr == FLASH_CTRL_MP_REGION_CFG4_OFFSET);
-    addr_hit[12] = (reg_addr == FLASH_CTRL_MP_REGION_CFG5_OFFSET);
-    addr_hit[13] = (reg_addr == FLASH_CTRL_MP_REGION_CFG6_OFFSET);
-    addr_hit[14] = (reg_addr == FLASH_CTRL_MP_REGION_CFG7_OFFSET);
-    addr_hit[15] = (reg_addr == FLASH_CTRL_DEFAULT_REGION_OFFSET);
-    addr_hit[16] = (reg_addr == FLASH_CTRL_BANK_CFG_REGWEN_OFFSET);
-    addr_hit[17] = (reg_addr == FLASH_CTRL_MP_BANK_CFG_OFFSET);
-    addr_hit[18] = (reg_addr == FLASH_CTRL_OP_STATUS_OFFSET);
-    addr_hit[19] = (reg_addr == FLASH_CTRL_STATUS_OFFSET);
-    addr_hit[20] = (reg_addr == FLASH_CTRL_SCRATCH_OFFSET);
-    addr_hit[21] = (reg_addr == FLASH_CTRL_FIFO_LVL_OFFSET);
-    addr_hit[22] = (reg_addr == FLASH_CTRL_FIFO_RST_OFFSET);
+    addr_hit[ 6] = (reg_addr == FLASH_CTRL_SCRAMBLE_EN_OFFSET);
+    addr_hit[ 7] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_OFFSET);
+    addr_hit[ 8] = (reg_addr == FLASH_CTRL_MP_REGION_CFG0_OFFSET);
+    addr_hit[ 9] = (reg_addr == FLASH_CTRL_MP_REGION_CFG1_OFFSET);
+    addr_hit[10] = (reg_addr == FLASH_CTRL_MP_REGION_CFG2_OFFSET);
+    addr_hit[11] = (reg_addr == FLASH_CTRL_MP_REGION_CFG3_OFFSET);
+    addr_hit[12] = (reg_addr == FLASH_CTRL_MP_REGION_CFG4_OFFSET);
+    addr_hit[13] = (reg_addr == FLASH_CTRL_MP_REGION_CFG5_OFFSET);
+    addr_hit[14] = (reg_addr == FLASH_CTRL_MP_REGION_CFG6_OFFSET);
+    addr_hit[15] = (reg_addr == FLASH_CTRL_MP_REGION_CFG7_OFFSET);
+    addr_hit[16] = (reg_addr == FLASH_CTRL_DEFAULT_REGION_OFFSET);
+    addr_hit[17] = (reg_addr == FLASH_CTRL_BANK_CFG_REGWEN_OFFSET);
+    addr_hit[18] = (reg_addr == FLASH_CTRL_MP_BANK_CFG_OFFSET);
+    addr_hit[19] = (reg_addr == FLASH_CTRL_OP_STATUS_OFFSET);
+    addr_hit[20] = (reg_addr == FLASH_CTRL_STATUS_OFFSET);
+    addr_hit[21] = (reg_addr == FLASH_CTRL_SCRATCH_OFFSET);
+    addr_hit[22] = (reg_addr == FLASH_CTRL_FIFO_LVL_OFFSET);
+    addr_hit[23] = (reg_addr == FLASH_CTRL_FIFO_RST_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -2995,6 +3026,7 @@ module flash_ctrl_reg_top (
     if (addr_hit[20] && reg_we && (FLASH_CTRL_PERMIT[20] != (FLASH_CTRL_PERMIT[20] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[21] && reg_we && (FLASH_CTRL_PERMIT[21] != (FLASH_CTRL_PERMIT[21] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[22] && reg_we && (FLASH_CTRL_PERMIT[22] != (FLASH_CTRL_PERMIT[22] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[23] && reg_we && (FLASH_CTRL_PERMIT[23] != (FLASH_CTRL_PERMIT[23] & reg_be))) wr_err = 1'b1 ;
   end
 
   assign intr_state_prog_empty_we = addr_hit[0] & reg_we & ~wr_err;
@@ -3071,225 +3103,228 @@ module flash_ctrl_reg_top (
   assign addr_we = addr_hit[5] & reg_we & ~wr_err;
   assign addr_wd = reg_wdata[31:0];
 
-  assign region_cfg_regwen_we = addr_hit[6] & reg_we & ~wr_err;
+  assign scramble_en_we = addr_hit[6] & reg_we & ~wr_err;
+  assign scramble_en_wd = reg_wdata[0];
+
+  assign region_cfg_regwen_we = addr_hit[7] & reg_we & ~wr_err;
   assign region_cfg_regwen_wd = reg_wdata[0];
 
-  assign mp_region_cfg0_en0_we = addr_hit[7] & reg_we & ~wr_err;
+  assign mp_region_cfg0_en0_we = addr_hit[8] & reg_we & ~wr_err;
   assign mp_region_cfg0_en0_wd = reg_wdata[0];
 
-  assign mp_region_cfg0_rd_en0_we = addr_hit[7] & reg_we & ~wr_err;
+  assign mp_region_cfg0_rd_en0_we = addr_hit[8] & reg_we & ~wr_err;
   assign mp_region_cfg0_rd_en0_wd = reg_wdata[1];
 
-  assign mp_region_cfg0_prog_en0_we = addr_hit[7] & reg_we & ~wr_err;
+  assign mp_region_cfg0_prog_en0_we = addr_hit[8] & reg_we & ~wr_err;
   assign mp_region_cfg0_prog_en0_wd = reg_wdata[2];
 
-  assign mp_region_cfg0_erase_en0_we = addr_hit[7] & reg_we & ~wr_err;
+  assign mp_region_cfg0_erase_en0_we = addr_hit[8] & reg_we & ~wr_err;
   assign mp_region_cfg0_erase_en0_wd = reg_wdata[3];
 
-  assign mp_region_cfg0_base0_we = addr_hit[7] & reg_we & ~wr_err;
+  assign mp_region_cfg0_base0_we = addr_hit[8] & reg_we & ~wr_err;
   assign mp_region_cfg0_base0_wd = reg_wdata[12:4];
 
-  assign mp_region_cfg0_size0_we = addr_hit[7] & reg_we & ~wr_err;
+  assign mp_region_cfg0_size0_we = addr_hit[8] & reg_we & ~wr_err;
   assign mp_region_cfg0_size0_wd = reg_wdata[25:16];
 
-  assign mp_region_cfg0_partition0_we = addr_hit[7] & reg_we & ~wr_err;
+  assign mp_region_cfg0_partition0_we = addr_hit[8] & reg_we & ~wr_err;
   assign mp_region_cfg0_partition0_wd = reg_wdata[28];
 
-  assign mp_region_cfg1_en1_we = addr_hit[8] & reg_we & ~wr_err;
+  assign mp_region_cfg1_en1_we = addr_hit[9] & reg_we & ~wr_err;
   assign mp_region_cfg1_en1_wd = reg_wdata[0];
 
-  assign mp_region_cfg1_rd_en1_we = addr_hit[8] & reg_we & ~wr_err;
+  assign mp_region_cfg1_rd_en1_we = addr_hit[9] & reg_we & ~wr_err;
   assign mp_region_cfg1_rd_en1_wd = reg_wdata[1];
 
-  assign mp_region_cfg1_prog_en1_we = addr_hit[8] & reg_we & ~wr_err;
+  assign mp_region_cfg1_prog_en1_we = addr_hit[9] & reg_we & ~wr_err;
   assign mp_region_cfg1_prog_en1_wd = reg_wdata[2];
 
-  assign mp_region_cfg1_erase_en1_we = addr_hit[8] & reg_we & ~wr_err;
+  assign mp_region_cfg1_erase_en1_we = addr_hit[9] & reg_we & ~wr_err;
   assign mp_region_cfg1_erase_en1_wd = reg_wdata[3];
 
-  assign mp_region_cfg1_base1_we = addr_hit[8] & reg_we & ~wr_err;
+  assign mp_region_cfg1_base1_we = addr_hit[9] & reg_we & ~wr_err;
   assign mp_region_cfg1_base1_wd = reg_wdata[12:4];
 
-  assign mp_region_cfg1_size1_we = addr_hit[8] & reg_we & ~wr_err;
+  assign mp_region_cfg1_size1_we = addr_hit[9] & reg_we & ~wr_err;
   assign mp_region_cfg1_size1_wd = reg_wdata[25:16];
 
-  assign mp_region_cfg1_partition1_we = addr_hit[8] & reg_we & ~wr_err;
+  assign mp_region_cfg1_partition1_we = addr_hit[9] & reg_we & ~wr_err;
   assign mp_region_cfg1_partition1_wd = reg_wdata[28];
 
-  assign mp_region_cfg2_en2_we = addr_hit[9] & reg_we & ~wr_err;
+  assign mp_region_cfg2_en2_we = addr_hit[10] & reg_we & ~wr_err;
   assign mp_region_cfg2_en2_wd = reg_wdata[0];
 
-  assign mp_region_cfg2_rd_en2_we = addr_hit[9] & reg_we & ~wr_err;
+  assign mp_region_cfg2_rd_en2_we = addr_hit[10] & reg_we & ~wr_err;
   assign mp_region_cfg2_rd_en2_wd = reg_wdata[1];
 
-  assign mp_region_cfg2_prog_en2_we = addr_hit[9] & reg_we & ~wr_err;
+  assign mp_region_cfg2_prog_en2_we = addr_hit[10] & reg_we & ~wr_err;
   assign mp_region_cfg2_prog_en2_wd = reg_wdata[2];
 
-  assign mp_region_cfg2_erase_en2_we = addr_hit[9] & reg_we & ~wr_err;
+  assign mp_region_cfg2_erase_en2_we = addr_hit[10] & reg_we & ~wr_err;
   assign mp_region_cfg2_erase_en2_wd = reg_wdata[3];
 
-  assign mp_region_cfg2_base2_we = addr_hit[9] & reg_we & ~wr_err;
+  assign mp_region_cfg2_base2_we = addr_hit[10] & reg_we & ~wr_err;
   assign mp_region_cfg2_base2_wd = reg_wdata[12:4];
 
-  assign mp_region_cfg2_size2_we = addr_hit[9] & reg_we & ~wr_err;
+  assign mp_region_cfg2_size2_we = addr_hit[10] & reg_we & ~wr_err;
   assign mp_region_cfg2_size2_wd = reg_wdata[25:16];
 
-  assign mp_region_cfg2_partition2_we = addr_hit[9] & reg_we & ~wr_err;
+  assign mp_region_cfg2_partition2_we = addr_hit[10] & reg_we & ~wr_err;
   assign mp_region_cfg2_partition2_wd = reg_wdata[28];
 
-  assign mp_region_cfg3_en3_we = addr_hit[10] & reg_we & ~wr_err;
+  assign mp_region_cfg3_en3_we = addr_hit[11] & reg_we & ~wr_err;
   assign mp_region_cfg3_en3_wd = reg_wdata[0];
 
-  assign mp_region_cfg3_rd_en3_we = addr_hit[10] & reg_we & ~wr_err;
+  assign mp_region_cfg3_rd_en3_we = addr_hit[11] & reg_we & ~wr_err;
   assign mp_region_cfg3_rd_en3_wd = reg_wdata[1];
 
-  assign mp_region_cfg3_prog_en3_we = addr_hit[10] & reg_we & ~wr_err;
+  assign mp_region_cfg3_prog_en3_we = addr_hit[11] & reg_we & ~wr_err;
   assign mp_region_cfg3_prog_en3_wd = reg_wdata[2];
 
-  assign mp_region_cfg3_erase_en3_we = addr_hit[10] & reg_we & ~wr_err;
+  assign mp_region_cfg3_erase_en3_we = addr_hit[11] & reg_we & ~wr_err;
   assign mp_region_cfg3_erase_en3_wd = reg_wdata[3];
 
-  assign mp_region_cfg3_base3_we = addr_hit[10] & reg_we & ~wr_err;
+  assign mp_region_cfg3_base3_we = addr_hit[11] & reg_we & ~wr_err;
   assign mp_region_cfg3_base3_wd = reg_wdata[12:4];
 
-  assign mp_region_cfg3_size3_we = addr_hit[10] & reg_we & ~wr_err;
+  assign mp_region_cfg3_size3_we = addr_hit[11] & reg_we & ~wr_err;
   assign mp_region_cfg3_size3_wd = reg_wdata[25:16];
 
-  assign mp_region_cfg3_partition3_we = addr_hit[10] & reg_we & ~wr_err;
+  assign mp_region_cfg3_partition3_we = addr_hit[11] & reg_we & ~wr_err;
   assign mp_region_cfg3_partition3_wd = reg_wdata[28];
 
-  assign mp_region_cfg4_en4_we = addr_hit[11] & reg_we & ~wr_err;
+  assign mp_region_cfg4_en4_we = addr_hit[12] & reg_we & ~wr_err;
   assign mp_region_cfg4_en4_wd = reg_wdata[0];
 
-  assign mp_region_cfg4_rd_en4_we = addr_hit[11] & reg_we & ~wr_err;
+  assign mp_region_cfg4_rd_en4_we = addr_hit[12] & reg_we & ~wr_err;
   assign mp_region_cfg4_rd_en4_wd = reg_wdata[1];
 
-  assign mp_region_cfg4_prog_en4_we = addr_hit[11] & reg_we & ~wr_err;
+  assign mp_region_cfg4_prog_en4_we = addr_hit[12] & reg_we & ~wr_err;
   assign mp_region_cfg4_prog_en4_wd = reg_wdata[2];
 
-  assign mp_region_cfg4_erase_en4_we = addr_hit[11] & reg_we & ~wr_err;
+  assign mp_region_cfg4_erase_en4_we = addr_hit[12] & reg_we & ~wr_err;
   assign mp_region_cfg4_erase_en4_wd = reg_wdata[3];
 
-  assign mp_region_cfg4_base4_we = addr_hit[11] & reg_we & ~wr_err;
+  assign mp_region_cfg4_base4_we = addr_hit[12] & reg_we & ~wr_err;
   assign mp_region_cfg4_base4_wd = reg_wdata[12:4];
 
-  assign mp_region_cfg4_size4_we = addr_hit[11] & reg_we & ~wr_err;
+  assign mp_region_cfg4_size4_we = addr_hit[12] & reg_we & ~wr_err;
   assign mp_region_cfg4_size4_wd = reg_wdata[25:16];
 
-  assign mp_region_cfg4_partition4_we = addr_hit[11] & reg_we & ~wr_err;
+  assign mp_region_cfg4_partition4_we = addr_hit[12] & reg_we & ~wr_err;
   assign mp_region_cfg4_partition4_wd = reg_wdata[28];
 
-  assign mp_region_cfg5_en5_we = addr_hit[12] & reg_we & ~wr_err;
+  assign mp_region_cfg5_en5_we = addr_hit[13] & reg_we & ~wr_err;
   assign mp_region_cfg5_en5_wd = reg_wdata[0];
 
-  assign mp_region_cfg5_rd_en5_we = addr_hit[12] & reg_we & ~wr_err;
+  assign mp_region_cfg5_rd_en5_we = addr_hit[13] & reg_we & ~wr_err;
   assign mp_region_cfg5_rd_en5_wd = reg_wdata[1];
 
-  assign mp_region_cfg5_prog_en5_we = addr_hit[12] & reg_we & ~wr_err;
+  assign mp_region_cfg5_prog_en5_we = addr_hit[13] & reg_we & ~wr_err;
   assign mp_region_cfg5_prog_en5_wd = reg_wdata[2];
 
-  assign mp_region_cfg5_erase_en5_we = addr_hit[12] & reg_we & ~wr_err;
+  assign mp_region_cfg5_erase_en5_we = addr_hit[13] & reg_we & ~wr_err;
   assign mp_region_cfg5_erase_en5_wd = reg_wdata[3];
 
-  assign mp_region_cfg5_base5_we = addr_hit[12] & reg_we & ~wr_err;
+  assign mp_region_cfg5_base5_we = addr_hit[13] & reg_we & ~wr_err;
   assign mp_region_cfg5_base5_wd = reg_wdata[12:4];
 
-  assign mp_region_cfg5_size5_we = addr_hit[12] & reg_we & ~wr_err;
+  assign mp_region_cfg5_size5_we = addr_hit[13] & reg_we & ~wr_err;
   assign mp_region_cfg5_size5_wd = reg_wdata[25:16];
 
-  assign mp_region_cfg5_partition5_we = addr_hit[12] & reg_we & ~wr_err;
+  assign mp_region_cfg5_partition5_we = addr_hit[13] & reg_we & ~wr_err;
   assign mp_region_cfg5_partition5_wd = reg_wdata[28];
 
-  assign mp_region_cfg6_en6_we = addr_hit[13] & reg_we & ~wr_err;
+  assign mp_region_cfg6_en6_we = addr_hit[14] & reg_we & ~wr_err;
   assign mp_region_cfg6_en6_wd = reg_wdata[0];
 
-  assign mp_region_cfg6_rd_en6_we = addr_hit[13] & reg_we & ~wr_err;
+  assign mp_region_cfg6_rd_en6_we = addr_hit[14] & reg_we & ~wr_err;
   assign mp_region_cfg6_rd_en6_wd = reg_wdata[1];
 
-  assign mp_region_cfg6_prog_en6_we = addr_hit[13] & reg_we & ~wr_err;
+  assign mp_region_cfg6_prog_en6_we = addr_hit[14] & reg_we & ~wr_err;
   assign mp_region_cfg6_prog_en6_wd = reg_wdata[2];
 
-  assign mp_region_cfg6_erase_en6_we = addr_hit[13] & reg_we & ~wr_err;
+  assign mp_region_cfg6_erase_en6_we = addr_hit[14] & reg_we & ~wr_err;
   assign mp_region_cfg6_erase_en6_wd = reg_wdata[3];
 
-  assign mp_region_cfg6_base6_we = addr_hit[13] & reg_we & ~wr_err;
+  assign mp_region_cfg6_base6_we = addr_hit[14] & reg_we & ~wr_err;
   assign mp_region_cfg6_base6_wd = reg_wdata[12:4];
 
-  assign mp_region_cfg6_size6_we = addr_hit[13] & reg_we & ~wr_err;
+  assign mp_region_cfg6_size6_we = addr_hit[14] & reg_we & ~wr_err;
   assign mp_region_cfg6_size6_wd = reg_wdata[25:16];
 
-  assign mp_region_cfg6_partition6_we = addr_hit[13] & reg_we & ~wr_err;
+  assign mp_region_cfg6_partition6_we = addr_hit[14] & reg_we & ~wr_err;
   assign mp_region_cfg6_partition6_wd = reg_wdata[28];
 
-  assign mp_region_cfg7_en7_we = addr_hit[14] & reg_we & ~wr_err;
+  assign mp_region_cfg7_en7_we = addr_hit[15] & reg_we & ~wr_err;
   assign mp_region_cfg7_en7_wd = reg_wdata[0];
 
-  assign mp_region_cfg7_rd_en7_we = addr_hit[14] & reg_we & ~wr_err;
+  assign mp_region_cfg7_rd_en7_we = addr_hit[15] & reg_we & ~wr_err;
   assign mp_region_cfg7_rd_en7_wd = reg_wdata[1];
 
-  assign mp_region_cfg7_prog_en7_we = addr_hit[14] & reg_we & ~wr_err;
+  assign mp_region_cfg7_prog_en7_we = addr_hit[15] & reg_we & ~wr_err;
   assign mp_region_cfg7_prog_en7_wd = reg_wdata[2];
 
-  assign mp_region_cfg7_erase_en7_we = addr_hit[14] & reg_we & ~wr_err;
+  assign mp_region_cfg7_erase_en7_we = addr_hit[15] & reg_we & ~wr_err;
   assign mp_region_cfg7_erase_en7_wd = reg_wdata[3];
 
-  assign mp_region_cfg7_base7_we = addr_hit[14] & reg_we & ~wr_err;
+  assign mp_region_cfg7_base7_we = addr_hit[15] & reg_we & ~wr_err;
   assign mp_region_cfg7_base7_wd = reg_wdata[12:4];
 
-  assign mp_region_cfg7_size7_we = addr_hit[14] & reg_we & ~wr_err;
+  assign mp_region_cfg7_size7_we = addr_hit[15] & reg_we & ~wr_err;
   assign mp_region_cfg7_size7_wd = reg_wdata[25:16];
 
-  assign mp_region_cfg7_partition7_we = addr_hit[14] & reg_we & ~wr_err;
+  assign mp_region_cfg7_partition7_we = addr_hit[15] & reg_we & ~wr_err;
   assign mp_region_cfg7_partition7_wd = reg_wdata[28];
 
-  assign default_region_rd_en_we = addr_hit[15] & reg_we & ~wr_err;
+  assign default_region_rd_en_we = addr_hit[16] & reg_we & ~wr_err;
   assign default_region_rd_en_wd = reg_wdata[0];
 
-  assign default_region_prog_en_we = addr_hit[15] & reg_we & ~wr_err;
+  assign default_region_prog_en_we = addr_hit[16] & reg_we & ~wr_err;
   assign default_region_prog_en_wd = reg_wdata[1];
 
-  assign default_region_erase_en_we = addr_hit[15] & reg_we & ~wr_err;
+  assign default_region_erase_en_we = addr_hit[16] & reg_we & ~wr_err;
   assign default_region_erase_en_wd = reg_wdata[2];
 
-  assign bank_cfg_regwen_we = addr_hit[16] & reg_we & ~wr_err;
+  assign bank_cfg_regwen_we = addr_hit[17] & reg_we & ~wr_err;
   assign bank_cfg_regwen_wd = reg_wdata[0];
 
-  assign mp_bank_cfg_erase_en0_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mp_bank_cfg_erase_en0_we = addr_hit[18] & reg_we & ~wr_err;
   assign mp_bank_cfg_erase_en0_wd = reg_wdata[0];
 
-  assign mp_bank_cfg_erase_en1_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mp_bank_cfg_erase_en1_we = addr_hit[18] & reg_we & ~wr_err;
   assign mp_bank_cfg_erase_en1_wd = reg_wdata[1];
 
-  assign op_status_done_we = addr_hit[18] & reg_we & ~wr_err;
+  assign op_status_done_we = addr_hit[19] & reg_we & ~wr_err;
   assign op_status_done_wd = reg_wdata[0];
 
-  assign op_status_err_we = addr_hit[18] & reg_we & ~wr_err;
+  assign op_status_err_we = addr_hit[19] & reg_we & ~wr_err;
   assign op_status_err_wd = reg_wdata[1];
 
-  assign status_rd_full_re = addr_hit[19] && reg_re;
+  assign status_rd_full_re = addr_hit[20] && reg_re;
 
-  assign status_rd_empty_re = addr_hit[19] && reg_re;
+  assign status_rd_empty_re = addr_hit[20] && reg_re;
 
-  assign status_prog_full_re = addr_hit[19] && reg_re;
+  assign status_prog_full_re = addr_hit[20] && reg_re;
 
-  assign status_prog_empty_re = addr_hit[19] && reg_re;
+  assign status_prog_empty_re = addr_hit[20] && reg_re;
 
-  assign status_init_wip_re = addr_hit[19] && reg_re;
+  assign status_init_wip_re = addr_hit[20] && reg_re;
 
-  assign status_error_page_re = addr_hit[19] && reg_re;
+  assign status_error_page_re = addr_hit[20] && reg_re;
 
-  assign status_error_bank_re = addr_hit[19] && reg_re;
+  assign status_error_bank_re = addr_hit[20] && reg_re;
 
-  assign scratch_we = addr_hit[20] & reg_we & ~wr_err;
+  assign scratch_we = addr_hit[21] & reg_we & ~wr_err;
   assign scratch_wd = reg_wdata[31:0];
 
-  assign fifo_lvl_prog_we = addr_hit[21] & reg_we & ~wr_err;
+  assign fifo_lvl_prog_we = addr_hit[22] & reg_we & ~wr_err;
   assign fifo_lvl_prog_wd = reg_wdata[4:0];
 
-  assign fifo_lvl_rd_we = addr_hit[21] & reg_we & ~wr_err;
+  assign fifo_lvl_rd_we = addr_hit[22] & reg_we & ~wr_err;
   assign fifo_lvl_rd_wd = reg_wdata[12:8];
 
-  assign fifo_rst_we = addr_hit[22] & reg_we & ~wr_err;
+  assign fifo_rst_we = addr_hit[23] & reg_we & ~wr_err;
   assign fifo_rst_wd = reg_wdata[0];
 
   // Read data return
@@ -3340,10 +3375,14 @@ module flash_ctrl_reg_top (
       end
 
       addr_hit[6]: begin
-        reg_rdata_next[0] = region_cfg_regwen_qs;
+        reg_rdata_next[0] = scramble_en_qs;
       end
 
       addr_hit[7]: begin
+        reg_rdata_next[0] = region_cfg_regwen_qs;
+      end
+
+      addr_hit[8]: begin
         reg_rdata_next[0] = mp_region_cfg0_en0_qs;
         reg_rdata_next[1] = mp_region_cfg0_rd_en0_qs;
         reg_rdata_next[2] = mp_region_cfg0_prog_en0_qs;
@@ -3353,7 +3392,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[28] = mp_region_cfg0_partition0_qs;
       end
 
-      addr_hit[8]: begin
+      addr_hit[9]: begin
         reg_rdata_next[0] = mp_region_cfg1_en1_qs;
         reg_rdata_next[1] = mp_region_cfg1_rd_en1_qs;
         reg_rdata_next[2] = mp_region_cfg1_prog_en1_qs;
@@ -3363,7 +3402,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[28] = mp_region_cfg1_partition1_qs;
       end
 
-      addr_hit[9]: begin
+      addr_hit[10]: begin
         reg_rdata_next[0] = mp_region_cfg2_en2_qs;
         reg_rdata_next[1] = mp_region_cfg2_rd_en2_qs;
         reg_rdata_next[2] = mp_region_cfg2_prog_en2_qs;
@@ -3373,7 +3412,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[28] = mp_region_cfg2_partition2_qs;
       end
 
-      addr_hit[10]: begin
+      addr_hit[11]: begin
         reg_rdata_next[0] = mp_region_cfg3_en3_qs;
         reg_rdata_next[1] = mp_region_cfg3_rd_en3_qs;
         reg_rdata_next[2] = mp_region_cfg3_prog_en3_qs;
@@ -3383,7 +3422,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[28] = mp_region_cfg3_partition3_qs;
       end
 
-      addr_hit[11]: begin
+      addr_hit[12]: begin
         reg_rdata_next[0] = mp_region_cfg4_en4_qs;
         reg_rdata_next[1] = mp_region_cfg4_rd_en4_qs;
         reg_rdata_next[2] = mp_region_cfg4_prog_en4_qs;
@@ -3393,7 +3432,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[28] = mp_region_cfg4_partition4_qs;
       end
 
-      addr_hit[12]: begin
+      addr_hit[13]: begin
         reg_rdata_next[0] = mp_region_cfg5_en5_qs;
         reg_rdata_next[1] = mp_region_cfg5_rd_en5_qs;
         reg_rdata_next[2] = mp_region_cfg5_prog_en5_qs;
@@ -3403,7 +3442,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[28] = mp_region_cfg5_partition5_qs;
       end
 
-      addr_hit[13]: begin
+      addr_hit[14]: begin
         reg_rdata_next[0] = mp_region_cfg6_en6_qs;
         reg_rdata_next[1] = mp_region_cfg6_rd_en6_qs;
         reg_rdata_next[2] = mp_region_cfg6_prog_en6_qs;
@@ -3413,7 +3452,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[28] = mp_region_cfg6_partition6_qs;
       end
 
-      addr_hit[14]: begin
+      addr_hit[15]: begin
         reg_rdata_next[0] = mp_region_cfg7_en7_qs;
         reg_rdata_next[1] = mp_region_cfg7_rd_en7_qs;
         reg_rdata_next[2] = mp_region_cfg7_prog_en7_qs;
@@ -3423,27 +3462,27 @@ module flash_ctrl_reg_top (
         reg_rdata_next[28] = mp_region_cfg7_partition7_qs;
       end
 
-      addr_hit[15]: begin
+      addr_hit[16]: begin
         reg_rdata_next[0] = default_region_rd_en_qs;
         reg_rdata_next[1] = default_region_prog_en_qs;
         reg_rdata_next[2] = default_region_erase_en_qs;
       end
 
-      addr_hit[16]: begin
+      addr_hit[17]: begin
         reg_rdata_next[0] = bank_cfg_regwen_qs;
       end
 
-      addr_hit[17]: begin
+      addr_hit[18]: begin
         reg_rdata_next[0] = mp_bank_cfg_erase_en0_qs;
         reg_rdata_next[1] = mp_bank_cfg_erase_en1_qs;
       end
 
-      addr_hit[18]: begin
+      addr_hit[19]: begin
         reg_rdata_next[0] = op_status_done_qs;
         reg_rdata_next[1] = op_status_err_qs;
       end
 
-      addr_hit[19]: begin
+      addr_hit[20]: begin
         reg_rdata_next[0] = status_rd_full_qs;
         reg_rdata_next[1] = status_rd_empty_qs;
         reg_rdata_next[2] = status_prog_full_qs;
@@ -3453,16 +3492,16 @@ module flash_ctrl_reg_top (
         reg_rdata_next[17] = status_error_bank_qs;
       end
 
-      addr_hit[20]: begin
+      addr_hit[21]: begin
         reg_rdata_next[31:0] = scratch_qs;
       end
 
-      addr_hit[21]: begin
+      addr_hit[22]: begin
         reg_rdata_next[4:0] = fifo_lvl_prog_qs;
         reg_rdata_next[12:8] = fifo_lvl_rd_qs;
       end
 
-      addr_hit[22]: begin
+      addr_hit[23]: begin
         reg_rdata_next[0] = fifo_rst_qs;
       end
 

--- a/hw/ip/flash_ctrl/rtl/flash_phy.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy.sv
@@ -118,13 +118,27 @@ module flash_phy import flash_ctrl_pkg::*; (
       .rdata  (host_rsp_data[bank])
     );
 
+    logic host_req;
+    logic ctrl_req;
+    logic host_scramble_en;
+    logic ctrl_scramble_en;
+
+    assign host_req = host_req_i & (host_bank_sel == bank) & host_rsp_avail[bank];
+    assign ctrl_req = flash_ctrl_i.req & (ctrl_bank_sel == bank);
+
+    // #2630: Temporary scramble enable logic on one of the banks until register configuration
+    // is setup.
+    assign host_scramble_en = host_req & host_addr_i[BusAddrW-1 -: BankW] == 1;
+    assign ctrl_scramble_en = ctrl_req & flash_ctrl_i.addr[BusAddrW-1 -: BankW] == 1;
+
     flash_phy_core i_core (
       .clk_i,
       .rst_ni,
-      .req_i(flash_ctrl_i.req & (ctrl_bank_sel == bank)),
+      .scramble_en_i(flash_ctrl_i.scramble_en & (host_scramble_en | ctrl_scramble_en)),
+      .req_i(ctrl_req),
       // host request must be suppressed if response fifo cannot hold more
       // otherwise the flash_phy_core and flash_phy will get out of sync
-      .host_req_i(host_req_i & (host_bank_sel == bank) & host_rsp_avail[bank]),
+      .host_req_i(host_req),
       .host_addr_i(host_addr_i[0 +: BusBankAddrW]),
       .rd_i(flash_ctrl_i.rd),
       .prog_i(flash_ctrl_i.prog),
@@ -134,6 +148,8 @@ module flash_phy import flash_ctrl_pkg::*; (
       .addr_i(flash_ctrl_i.addr[0 +: BusBankAddrW]),
       .prog_data_i(flash_ctrl_i.prog_data),
       .prog_last_i(flash_ctrl_i.prog_last),
+      .addr_key_i(flash_ctrl_i.addr_key),
+      .data_key_i(flash_ctrl_i.data_key),
       .host_req_rdy_o(host_req_rdy[bank]),
       .host_req_done_o(host_req_done[bank]),
       .rd_done_o(rd_done[bank]),

--- a/hw/ip/flash_ctrl/rtl/flash_phy_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_pkg.sv
@@ -35,6 +35,13 @@ package flash_phy_pkg;
   parameter int LsbAddrBit    = $clog2(WidthMultiple);
   parameter int WordSelW      = WidthMultiple == 1 ? 1 : LsbAddrBit;
 
+  // scramble / de-scramble parameters
+  // Number of cycles the gf_mult is given to complete
+  parameter int KeySize       = 128;
+  parameter int GfMultCycles  = 2;
+  // If this value is greater than 1, constraints must be updated for multicycle paths
+  parameter int CipherCycles  = 2;
+
   // Read buffer metadata
   typedef enum logic [1:0] {
     Invalid     = 2'h0,
@@ -57,6 +64,11 @@ package flash_phy_pkg;
 
   parameter int RspOrderFifoWidth = $bits(rsp_fifo_entry_t);
 
+  typedef struct packed {
+    logic [BankAddrW-1:0] addr;
+    logic descramble;
+  } rd_attr_t;
+
   // Flash Operations Supported
   typedef enum logic [2:0] {
     PhyRead      = 3'h0,
@@ -72,5 +84,10 @@ package flash_phy_pkg;
     Host         = 2'h1,
     Ctrl         = 2'h2
   } flash_phy_op_sel_e;
+
+  typedef enum logic {
+    ScrambleOp   = 1'b0,
+    DeScrambleOp = 1'b1
+  } cipher_ops_e;
 
 endpackage // flash_phy_pkg

--- a/hw/ip/flash_ctrl/rtl/flash_phy_rd.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_rd.sv
@@ -13,18 +13,18 @@
 // upstream to stop issuing instructions, however once issued, the upstream will
 // always accept the response.
 //
-// TBD: Add support for descramble stage
-// The allocate and descramble indication received at read stage must be saved.
+// Support for descramble stage
+// The allocate and descramble indication received at read stage are saved.
 // When the read completes, depending on the 'descramble' indication saved, the
 // data is either stored into FIFO (reg + skid) between read and descramble stage,
 // or forwarded directly to the buffers (no de-scramble)
 //
-// If the storage element between read and de-scramble stages are completely fully
-// for some reason, then the read stage cannot start
+// If the storage element between read and de-scramble stages are completely full
+// for any reason, then the read stage cannot start.
 //
-// When the read stage begins, the galois multiply portion of the de-scramble should
+// When the read stage begins, the galois multiply portion of the de-scramble is
 // also be kicked off. When the galois multiply stage AND read stage completes, the
-// de-scramble is also kicked off (which is really what the de-scramble stage is doing).
+// de-scramble is then kicked off.
 
 module flash_phy_rd import flash_phy_pkg::*; (
   input clk_i,
@@ -32,6 +32,7 @@ module flash_phy_rd import flash_phy_pkg::*; (
 
   // interface with arbitration unit
   input req_i,
+  input descramble_i,
   input prog_i,
   input pg_erase_i,
   input bk_erase_i,
@@ -42,6 +43,16 @@ module flash_phy_rd import flash_phy_pkg::*; (
   output logic [BusWidth-1:0] data_o,
   output logic idle_o, // the entire read pipeline is idle
 
+  // interface with scramble unit
+  output logic calc_req_o,
+  output logic descramble_req_o,
+  output logic [BankAddrW-1:0] calc_addr_o,
+  output logic [DataWidth-1:0] scrambled_data_o,
+  input calc_ack_i,
+  input descramble_ack_i,
+  input [DataWidth-1:0] mask_i,
+  input [DataWidth-1:0] descrambled_data_i,
+
   // interface to actual flash primitive
   output logic req_o,
   input ack_i,
@@ -51,6 +62,12 @@ module flash_phy_rd import flash_phy_pkg::*; (
   /////////////////////////////////
   // Read buffers
   /////////////////////////////////
+
+  // muxed de-scrambled and plain-data
+  logic [DataWidth-1:0] muxed_data;
+
+  // muxed data valid signal that takes scrambling into consideration
+  logic data_valid;
 
   // A buffer allocate is invoked when a new transaction arrives.
   // Alloc only happens if the new transaction does not match an existing entry.
@@ -166,7 +183,7 @@ module flash_phy_rd import flash_phy_pkg::*; (
   // update sets state to valid
   // wipe sets state to invalid - this comes from prog
   for (genvar i = 0; i < NumBuf; i++) begin: gen_bufs
-    flash_phy_rd_buffers i_rd_buf (
+    flash_phy_rd_buffers u_rd_buf (
       .clk_i,
       .rst_ni,
       .alloc_i(rdy_o & alloc[i]),
@@ -174,7 +191,7 @@ module flash_phy_rd import flash_phy_pkg::*; (
       .wipe_i(data_hazard[i]),
       .addr_i(flash_word_addr),
       .part_i(part_i),
-      .data_i(data_i),
+      .data_i(muxed_data),
       .out_o(read_buf[i])
     );
   end
@@ -203,7 +220,13 @@ module flash_phy_rd import flash_phy_pkg::*; (
   logic rd_busy;
   logic rd_done;
   logic [NumBuf-1:0] alloc_q;
+  rd_attr_t rd_attrs;
 
+  // scramble stage ready
+  logic scramble_stage_rdy;
+
+  // read done does not mean data is available.
+  // if the data must be de-scrambled, there is another wait stage
   assign rd_done = rd_busy & ack_i;
 
   // if buffer allocated, that is the return source
@@ -239,10 +262,13 @@ module flash_phy_rd import flash_phy_pkg::*; (
     if (!rst_ni) begin
       rd_busy <= 1'b0;
       alloc_q <= '0;
+      rd_attrs <= '0;
     end else if (req_o) begin
       // read only becomes busy if a buffer is allocated and read
       rd_busy <= 1'b1;
       alloc_q <= alloc;
+      rd_attrs.addr <= addr_i[BusBankAddrW-1:LsbAddrBit];
+      rd_attrs.descramble <= descramble_i;
     end else if (rd_done) begin
       rd_busy <= 1'b0;
     end
@@ -254,7 +280,8 @@ module flash_phy_rd import flash_phy_pkg::*; (
 
   // if no buffers matched, accept only if read state is idle and there is space
   // if buffer is matched, accept as long as there is space in the rsp fifo
-  assign rdy_o = no_match ? rd_stage_idle & rsp_fifo_rdy : rsp_fifo_rdy;
+  assign rdy_o = no_match ? rd_stage_idle & rsp_fifo_rdy & scramble_stage_rdy :
+                            rsp_fifo_rdy & scramble_stage_rdy;
 
   // issue a transaction to flash
   assign req_o = req_i & rdy_o & no_match;
@@ -263,7 +290,111 @@ module flash_phy_rd import flash_phy_pkg::*; (
   // De-scrambling stage
   /////////////////////////////////
 
-  // nothing here yet
+  logic fifo_data_ready;
+  logic fifo_data_valid;
+  logic mask_valid;
+  logic [DataWidth-1:0] fifo_data;
+  logic [DataWidth-1:0] mask;
+  logic data_fifo_rdy;
+  logic mask_fifo_rdy;
+  logic forward;
+  logic hint_forward;
+  logic hint_descram;
+  logic [NumBuf-1:0] alloc_q2;
+
+  assign scramble_stage_rdy = data_fifo_rdy & mask_fifo_rdy;
+
+  // data is consumed when:
+  // 1. When descrambling completes
+  // 2. Immediately consumed when descrambling not required
+  // 3. In both cases, when data has not already been forwarded
+  assign fifo_data_ready = hint_descram ? descramble_req_o & descramble_ack_i & ~hint_forward :
+                                          fifo_data_valid & !hint_forward;
+
+  // data is forwarded whenever it does not require descrambling or if it has been erased
+  // but forwarding is only possible if there are no entries in the FIFO to ensure the current
+  // read cannot run ahead of the descramble.
+  assign forward = rd_done & !fifo_data_valid &
+                   ((data_i == {DataWidth{1'b1}}) | !rd_attrs.descramble);
+
+  // storage for read outputs
+  // This storage element can be fully merged with the fifo below if the time it takes
+  // to do a read is matched to gf_mult.  This is doable and should be considered.
+  // However it would create a dependency on constraints (multicycle) instead of
+  // being correct by construction.
+  //
+  // In addition to potential different completion times, the mask storage may also
+  // be pushed even if it is not required (erase case). The solution for this issue
+  // is that the mask / data are always pushed, it is then selectively popped based
+  // on the forward / de-scrambling hints.
+  //
+  // All these problems could be resolved if the timings matched exactly, however
+  // the user would need to correctly setup constraints on either flash / gf_mult
+  // timing change.
+  prim_fifo_sync #(
+    .Width  (DataWidth + 2 + NumBuf),
+    .Pass   (0),
+    .Depth  (2)
+  ) u_rd_storage (
+    .clk_i,
+    .rst_ni,
+    .clr_i  (1'b0),
+    .wvalid (rd_done),
+    .wready (data_fifo_rdy),
+    .wdata  ({alloc_q, rd_attrs.descramble,forward,data_i}),
+    .depth  (),
+    .rvalid (fifo_data_valid),
+    .rready (fifo_data_ready | hint_forward),
+    .rdata  ({alloc_q2, hint_descram,hint_forward,fifo_data})
+  );
+
+  // storage for mask calculations
+  prim_fifo_sync #(
+      .Width  (DataWidth),
+      .Pass   (0),
+      .Depth  (2)
+  ) u_mask_storage (
+    .clk_i,
+    .rst_ni,
+    .clr_i  (1'b0),
+    .wvalid (calc_req_o & calc_ack_i),
+    .wready (mask_fifo_rdy),
+    .wdata  (mask_i),
+    .depth  (),
+    .rvalid (mask_valid),
+    .rready (fifo_data_ready | hint_forward),
+    .rdata  (mask)
+  );
+
+  // generate the mask calculation request
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      calc_req_o <= '0;
+    end else if (req_o && descramble_i) begin
+      calc_req_o <= 1'b1;
+    end else if (calc_req_o && calc_ack_i) begin
+      calc_req_o <= 1'b0;
+    end
+  end
+
+  // operand to gf_mult
+  assign calc_addr_o = rd_attrs.addr;
+
+  // generate the descramble request whenever both stages are available
+  // and there is a need to descramble
+  assign descramble_req_o = fifo_data_valid & mask_valid & !hint_forward;
+
+  // scrambled data to de-scramble
+  assign scrambled_data_o = fifo_data ^ mask;
+
+  // muxed data
+  assign muxed_data = hint_descram ? descrambled_data_i ^ mask : data_i;
+
+  // muxed data valid
+  // if no de-scramble required, return data on read complete
+  // if data is all empty (erased), also return data on read complete
+  // if descramble is required, return data when descrambler finishes
+  assign data_valid = forward | fifo_data_ready;
 
 
   /////////////////////////////////
@@ -275,10 +406,15 @@ module flash_phy_rd import flash_phy_pkg::*; (
   logic [DataWidth-1:0] buf_rsp_data;
 
   // update buffers
-  assign update = rd_done ? alloc_q : '0;
+  // When forwarding, update entry stored in alloc_q
+  // When de-scrambling however, the contents of alloc_q may have already updated to the next read,
+  // so a different pointer is used.
+  // assign update = data_valid ? alloc_q : '0;
+  assign update = forward         ? alloc_q  :
+                  fifo_data_ready ? alloc_q2 : '0;
 
   // match in flash response when allocated buffer is the same as top of response fifo
-  assign flash_rsp_match = rsp_fifo_vld & rd_done & (rsp_fifo_rdata.buf_sel == alloc_q);
+  assign flash_rsp_match = rsp_fifo_vld & data_valid & (rsp_fifo_rdata.buf_sel == update);
 
   // match in buf response when there is a valid buffer that is the same as top of response fifo
   for (genvar i = 0; i < NumBuf; i++) begin: gen_buf_rsp_match
@@ -287,7 +423,7 @@ module flash_phy_rd import flash_phy_pkg::*; (
 
   // select among the buffers
   always_comb begin
-    buf_rsp_data = data_i;
+    buf_rsp_data = muxed_data;
     for (int i = 0; i < NumBuf; i++) begin
       if (buf_rsp_match[i]) begin
         buf_rsp_data = read_buf[i].data;
@@ -298,21 +434,20 @@ module flash_phy_rd import flash_phy_pkg::*; (
   if (WidthMultiple == 1) begin : gen_width_one_rd
     // When multiple is 1, just pass the read through directly
     logic unused_word_sel;
-    assign data_o = |buf_rsp_match ? buf_rsp_data : data_i;
+    assign data_o = |buf_rsp_match ? buf_rsp_data : muxed_data;
     assign unused_word_sel = rsp_fifo_rdata.word_sel;
 
   end else begin : gen_rd
     // Re-arrange data into packed array to pick the correct one
     logic [WidthMultiple-1:0][BusWidth-1:0] bus_words_packed;
-    assign bus_words_packed = |buf_rsp_match ? buf_rsp_data : data_i;
+    assign bus_words_packed = |buf_rsp_match ? buf_rsp_data : muxed_data;
     assign data_o = bus_words_packed[rsp_fifo_rdata.word_sel];
 
   end
 
   assign data_valid_o = flash_rsp_match | |buf_rsp_match;
 
-
-  // the entire read pipeline is idle when there are no responses to return
+  // the entire read pipeline is idle when there are no responses to return and no
   assign idle_o = ~rsp_fifo_vld;
 
   /////////////////////////////////

--- a/hw/ip/flash_ctrl/rtl/flash_phy_scramble.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_scramble.sv
@@ -1,0 +1,82 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Flash Phy Scramble Module
+//
+// This module implements the flash scramble / de-scramble operation
+// This operation is actually XEX.  However the components are broken
+// in two and separately manipulated by the program and read pipelines.
+//
+
+module flash_phy_scramble import flash_phy_pkg::*; (
+  input clk_i,
+  input rst_ni,
+  input calc_req_i, // calculate galois multiplier mask
+  input op_req_i,   // request primitive operation
+  input cipher_ops_e op_type_i,  // sramble or de-scramble
+  input [BankAddrW-1:0] addr_i,
+  input [DataWidth-1:0] plain_data_i,
+  input [DataWidth-1:0] scrambled_data_i,
+  input [KeySize-1:0] addr_key_i,
+  input [KeySize-1:0] data_key_i,
+  output logic calc_ack_o,
+  output logic op_ack_o,
+  output logic [DataWidth-1:0] mask_o,
+  output logic [DataWidth-1:0] plain_data_o,
+  output logic [DataWidth-1:0] scrambled_data_o
+);
+
+  localparam int AddrPadWidth = DataWidth - BankAddrW;
+  localparam int UnusedWidth = KeySize - AddrPadWidth;
+
+  // unused portion of addr_key
+  logic [UnusedWidth-1:0] unused_key;
+  assign unused_key = addr_key_i[KeySize-1 -: UnusedWidth];
+
+  // Galois Multiply portion
+  prim_gf_mult # (
+    .Width(DataWidth),
+    .StagesPerCycle(DataWidth / GfMultCycles)
+  ) u_mult (
+    .clk_i,
+    .rst_ni,
+    .req_i(calc_req_i),
+    .operand_a_i({addr_key_i[DataWidth +: AddrPadWidth], addr_i}),
+    .operand_b_i(addr_key_i[DataWidth-1:0]),
+    .ack_o(calc_ack_o),
+    .prod_o(mask_o)
+  );
+
+  // Cipher portion
+  logic dec;
+  logic [DataWidth-1:0] data;
+
+  assign dec = op_type_i == DeScrambleOp;
+
+  // Previous discussion settled on PRESENT, using PRINCE here for now
+  // just to get some area idea
+  prim_prince # (
+    .DataWidth(DataWidth),
+    .KeyWidth(KeySize),
+    .UseOldKeySched(1'b1),
+    .HalfwayDataReg(1'b1)
+  ) u_cipher (
+    .clk_i,
+    .rst_ni,
+    .valid_i(op_req_i),
+    .data_i(dec ? scrambled_data_i : plain_data_i),
+    .key_i(data_key_i),
+    .dec_i(dec),
+    .data_o(data),
+    .valid_o(op_ack_o)
+  );
+
+  // if decrypt, output the unscrambled data, feed input through otherwise
+  assign plain_data_o = dec ? data : scrambled_data_i;
+
+  // if encrypt, output the scrambled data, feed input through otherwise
+  assign scrambled_data_o = dec ? plain_data_i : data;
+
+
+endmodule // flash_phy_scramble

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -651,6 +651,15 @@
           top_signame: flash_ctrl_flash
           index: -1
         }
+        {
+          struct: otp_flash
+          type: uni
+          name: otp
+          act: rcv
+          package: flash_ctrl_pkg
+          inst_name: flash_ctrl
+          index: -1
+        }
       ]
     }
     {
@@ -3561,6 +3570,15 @@
         inst_name: flash_ctrl
         width: 1
         top_signame: flash_ctrl_flash
+        index: -1
+      }
+      {
+        struct: otp_flash
+        type: uni
+        name: otp
+        act: rcv
+        package: flash_ctrl_pkg
+        inst_name: flash_ctrl
         index: -1
       }
       {

--- a/hw/top_earlgrey/data/pins_nexysvideo.xdc
+++ b/hw/top_earlgrey/data/pins_nexysvideo.xdc
@@ -11,6 +11,12 @@ create_generated_clock -name clk_50_unbuf -source [get_pin clkgen/pll/CLKIN1] [g
 create_generated_clock -name clk_48_unbuf -source [get_pin clkgen/pll/CLKIN1] [get_pin clkgen/pll/CLKOUT1]
 set_clock_groups -group clk_50_unbuf -group clk_48_unbuf -asynchronous
 
+## Preserve prim_prince modules and setup multi-cycle paths
+## These are no longer required, but kept here as a reference
+## set_property KEEP_HIERARCHY TRUE [get_cells top_earlgrey/u_flash_eflash/gen_flash_banks[*].i_core/u_scramble/u_cipher]
+## set_multicycle_path -setup 2 -through [get_pins -of_objects [get_cells top_earlgrey/u_flash_eflash/gen_flash_banks[*].i_core/u_scramble/u_cipher]]
+## set_multicycle_path -hold 1  -through [get_pins -of_objects [get_cells top_earlgrey/u_flash_eflash/gen_flash_banks[*].i_core/u_scramble/u_cipher]]
+
 #set_property CLOCK_DEDICATED_ROUTE FALSE [get_nets IO_SDCK_IBUF]; # SDCK clock to be ignored
 
 ## FMC Transceiver clocks (Must be set to value provided by Mezzanine card, currently set to 156.25 MHz)

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -310,7 +310,7 @@
           type: "req_rsp",
           name: "flash_ctrl", // flash_ctrl_i (req), flash_ctrl_o (rsp)
           act:  "rsp",
-        }
+        },
       ],
     },
   ],

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -619,6 +619,7 @@ module top_earlgrey #(
       // Inter-module signals
       .flash_o(flash_ctrl_flash_req),
       .flash_i(flash_ctrl_flash_rsp),
+      .otp_i(flash_ctrl_pkg::OTP_FLASH_DEFAULT),
       .clk_i (clkmgr_clocks.clk_main_infra),
       .rst_ni (rstmgr_resets.rst_lc_n)
   );

--- a/sw/device/lib/flash_ctrl.c
+++ b/sw/device/lib/flash_ctrl.c
@@ -3,9 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "sw/device/lib/flash_ctrl.h"
 
+#include "sw/device/lib/common.h"
+
 #include "flash_ctrl_regs.h"  // Generated.
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
-#include "sw/device/lib/common.h"
 
 #define FLASH_CTRL0_BASE_ADDR TOP_EARLGREY_FLASH_CTRL_BASE_ADDR
 
@@ -129,6 +130,10 @@ int flash_read(uint32_t addr, part_type_t part, uint32_t size, uint32_t *data) {
   }
   wait_done_and_ack();
   return get_clr_err();
+}
+
+void flash_cfg_scramble_enable(bool en) {
+  REG32(FLASH_CTRL_SCRAMBLE_EN(0)) = en & 1;
 }
 
 void flash_cfg_bank_erase(bank_index_t bank, bool erase_en) {

--- a/sw/device/lib/flash_ctrl.h
+++ b/sw/device/lib/flash_ctrl.h
@@ -97,6 +97,11 @@ int flash_read(uint32_t addr, part_type_t part, uint32_t size, uint32_t *data);
 void flash_cfg_bank_erase(bank_index_t bank, bool erase_en);
 
 /**
+ * Configure scramble enable
+ */
+void flash_cfg_scramble_enable(bool en);
+
+/**
  * Set flash controller default permissions.
  *
  * @param rd_end Read enable.

--- a/sw/device/tests/flash_ctrl_test.c
+++ b/sw/device/tests/flash_ctrl_test.c
@@ -76,6 +76,12 @@ static void test_basic_io(void) {
                        output_page));
   CHECK_ARRAYS_EQ(output_page, input_page, FLASH_WORDS_PER_PAGE);
 
+  // Check from host side also
+  for (int i = 0; i < FLASH_WORDS_PER_PAGE; i++) {
+    output_page[i] = mmio_region_read32(flash_bank_1, i * sizeof(uint32_t));
+  }
+  CHECK_ARRAYS_EQ(output_page, input_page, FLASH_WORDS_PER_PAGE);
+
   // Similar check for info page
   CHECK_EQZ(flash_page_erase(flash_bank_1_addr, kInfoPartition));
   CHECK_EQZ(flash_write(flash_bank_1_addr, kInfoPartition, input_page,

--- a/sw/device/tests/flash_ctrl_test.c
+++ b/sw/device/tests/flash_ctrl_test.c
@@ -179,6 +179,7 @@ bool test_main(void) {
 
   LOG_INFO("flash test!");
 
+  flash_cfg_scramble_enable(true);
   flash_cfg_bank_erase(FLASH_BANK_0, /*erase_en=*/true);
   flash_cfg_bank_erase(FLASH_BANK_1, /*erase_en=*/true);
 


### PR DESCRIPTION
This adds the prince based flash scrambling to the flash controller.
It has been **lightly** tested by making the 2nd bank scramble / de-scramble always.

The exact programmer's model of flash scrambling and the placement of the address filter is not yet decided, please see #2630 
Since OTP does not exist on master, the connection is also hard-wired instead of coming from flops.

For bronze specifically, we need to update the constraints to inform the tool that `prim_prince` is supposed to be multi-cycle, I haven't looked into that yet. 