### PR TITLE
[dv] Add get_mem DPI function to Verilator simutil

### DIFF
--- a/hw/ip/prim/rtl/prim_util_memload.sv
+++ b/hw/ip/prim/rtl/prim_util_memload.sv
@@ -44,6 +44,26 @@
     mem[index] = val[Width-1:0];
     return 1;
   endfunction
+
+  // Function for getting a specific element in |mem|
+  export "DPI-C" function simutil_verilator_get_mem;
+
+  function int simutil_verilator_get_mem(input int          index,
+                                         output bit [255:0] val);
+
+    // Function will only work for memories <= 256 bits
+    if (Width > 256) begin
+      return 0;
+    end
+
+    if (index >= Depth) begin
+      return 0;
+    end
+
+    val = 0;
+    val[Width-1:0] = mem[index];
+    return 1;
+  endfunction
 `endif
 
 initial begin


### PR DESCRIPTION
Add simutil_verilator_get_mem() to the memload primitives to allow
reading the memory.

Signed-off-by: Stefan Wallentowitz <stefan.wallentowitz@gi-de.com>