### PR TITLE
[lint/entropy_src] Add the entropy source to the lint regression

### DIFF
--- a/hw/lint/Makefile
+++ b/hw/lint/Makefile
@@ -17,6 +17,7 @@ REPORT_DIR ?= reports
 IPS ?=  ip-aes                 \
         ip-alert_handler       \
         ip-clkmgr              \
+        ip-entropy_src         \
         ip-flash_ctrl          \
         ip-gpio                \
         ip-hmac                \

--- a/hw/top_earlgrey/lint/top_earlgrey_lint_cfgs.hjson
+++ b/hw/top_earlgrey/lint/top_earlgrey_lint_cfgs.hjson
@@ -26,6 +26,11 @@
                   import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
                   rel_path: "hw/ip/alert_handler/lint/{tool}"
              },
+             {    name: entropy_src
+                  fusesoc_core: lowrisc:ip:entropy_src
+                  import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/entropy_src/lint/{tool}"
+             },
              {    name: flash_ctrl
                   fusesoc_core: lowrisc:ip:flash_ctrl
                   import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]


### PR DESCRIPTION
This adds the entropy source to the `dvsim` regression config and the legacy makefile.

To run lint or style lint on the entropy source using DVSIM (recommended) do
```bash
$ util/dvsim/dvsim.py -t ascentlint hw/top_earlgrey/lint/top_earlgrey_lint_cfgs.hjson --select-cfg entropy_src
$ util/dvsim/dvsim.py -t veriblelint hw/top_earlgrey/lint/top_earlgrey_lint_cfgs.hjson --select-cfg entropy_src
```

To run lint, style lint or verilator lint via the legacy Makefile flow, cd into `hw/lint` and to
```bash
$ make clean; make ip-entropy_src_lint; make report
$ make clean; make ip-entropy_src_slint
$ make clean; make ip-entropy_src_vlint
```

Note that the Makefile flow will soon be deprecated, as soon as Verilator lint can be called through DVSIM as well.

Signed-off-by: Michael Schaffner <msf@google.com>