### PR TITLE
[sw] Make the Clang-based toolchain the default one

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ variables:
   TOOLCHAIN_PATH: /opt/buildcache/riscv
   # Release tag from https://github.com/lowRISC/lowrisc-toolchains/releases
   # if you update this, update the definition in util/container/Dockerfile
-  TOOLCHAIN_VERSION: 20200618-1
+  TOOLCHAIN_VERSION: 20200626-1
   # This controls where builds happen, and gets picked up by build_consts.sh.
   BUILD_ROOT: $(Build.ArtifactStagingDirectory)
 
@@ -181,11 +181,11 @@ jobs:
     parameters:
       artifact: sw_build
 
-# This is a second software build currently building with Clang, to test out the
-# compiler migration. It is a copy of `sw_build` with `meson_init.sh` configured
-# with the clang toolchain not the default toolchain.
-- job: sw_build_clang
-  displayName: Build Software (with Clang)
+# We continue building with GCC, despite defaulting to Clang. This is a copy of
+# `sw_build` with `meson_init.sh` configured with the GCC toolchain, instead of
+# the default toolchain.
+- job: sw_build_gcc
+  displayName: Build Software (with GCC)
   dependsOn: lint
   condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'))
   pool:
@@ -202,7 +202,7 @@ jobs:
   - bash: |
       . util/build_consts.sh
       ./meson_init.sh -A \
-        -t "$TOOLCHAIN_PATH/meson-riscv32-unknown-elf-clang.txt"
+        -t "$TOOLCHAIN_PATH/meson-riscv32-unknown-elf-gcc.txt"
       ninja -C "$OBJ_DIR" all
     displayName: Build embedded targets
   - bash: |
@@ -211,7 +211,7 @@ jobs:
     displayName: Run unit tests
   - template: ci/upload-artifacts-template.yml
     parameters:
-      artifact: sw_build_clang
+      artifact: sw_build_gcc
 
 - job: top_earlgrey_verilator
   displayName: Build Verilator simulation of the Earl Grey toplevel design

--- a/doc/ug/install_instructions/index.md
+++ b/doc/ug/install_instructions/index.md
@@ -74,20 +74,24 @@ If the `fusesoc` binary is not found, add `~/.local/bin` to your `PATH`, e.g. by
 ### Device compiler toolchain (RV32IMC)
 
 To build device software you need a baremetal RV32IMC compiler toolchain.
-You can either build your own or use a prebuilt one.
-We recommend installing the toolchain to `/tools/riscv`.
+We recommend using a prebuilt toolchain provided by lowRISC.
+Alternatively, you can build your own.
+Whichever option you choose, we recommend installing the toolchain to `/tools/riscv`.
 
-#### Option 1 (recommended): Use the lowRISC-provided prebuilt GCC toolchain
+#### Option 1 (recommended): Use the lowRISC-provided prebuilt toolchain
 
-lowRISC provides a prebuilt GCC toolchain for the OpenTitan project.
-Download the file starting with `lowrisc-toolchain-gcc-rv32imc-` from [GitHub releases](https://github.com/lowRISC/lowrisc-toolchains/releases/latest) and unpack it to `/tools/riscv`.
-
-Or alternatively, use a in-tree helper script.
+lowRISC provides a prebuilt toolchain for the OpenTitan project.
+This toolchain contains both GCC and Clang, targeting RISC-V.
+By default the device software is built with Clang.
+We recommend using the `util/get-toolchain.py` tool to download and install the latest version of this toolchain.
 
 ```cmd
 $ cd $REPO_TOP
 $ ./util/get-toolchain.py
 ```
+
+This tool will automatically adjust the toolchain configuration if you override the installation directory (by using the `--target-dir` option).
+Alternatively, manually download the file starting with `lowrisc-toolchain-rv32imc-` from [GitHub releases](https://github.com/lowRISC/lowrisc-toolchains/releases/latest) and unpack it to `/tools/riscv`.
 
 #### Option 2: Compile your own GCC toolchain
 
@@ -119,7 +123,9 @@ $ ./util/get-toolchain.py
     needs_exe_wrapper = true
     has_function_printf = false
     c_args = ['-march=rv32imc', '-mabi=ilp32', '-mcmodel=medany']
+    c_link_args = ['-march=rv32imc', '-mabi=ilp32', '-mcmodel=medany']
     cpp_args = ['-march=rv32imc', '-mabi=ilp32', '-mcmodel=medany']
+    cpp_link_args = ['-march=rv32imc', '-mabi=ilp32', '-mcmodel=medany']
 
     [host_machine]
     system = 'bare metal'

--- a/meson_init.sh
+++ b/meson_init.sh
@@ -61,7 +61,7 @@ FLAGS_force=false
 FLAGS_reconfigure=""
 FLAGS_keep_includes=false
 FLAGS_specified_toolchain_file=false
-ARG_toolchain_file="${TOOLCHAIN_PATH}/meson-riscv32-unknown-elf-gcc.txt"
+ARG_toolchain_file="${TOOLCHAIN_PATH}/meson-riscv32-unknown-elf-clang.txt"
 ARG_tock_dir=""
 while getopts 'r?:f?:K?:A?:T:t:' flag; do
   case "${flag}" in

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -9,7 +9,7 @@
 ARG VERILATOR_VERSION=4.028
 
 # The RISCV toolchain version should match the release tag used in GitHub.
-ARG RISCV_TOOLCHAIN_TAR_VERSION=20200618-1
+ARG RISCV_TOOLCHAIN_TAR_VERSION=20200626-1
 
 # Build OpenOCD
 # OpenOCD is a tool to connect with the target chip over JTAG and similar


### PR DESCRIPTION
In CI we continue building with both Clang and GCC, but now the default
toolchain in `meson_init.sh` is the Clang-based one.