### PR TITLE
[aes] Update version and hardware design stage

### DIFF
--- a/hw/ip/aes/data/aes.prj.hjson
+++ b/hw/ip/aes/data/aes.prj.hjson
@@ -7,8 +7,8 @@
     design_spec:        "hw/ip/aes/doc",
     dv_plan:            "hw/ip/aes/doc/dv_plan",
     hw_checklist:       "hw/ip/aes/doc/checklist",
-    version:            "0.6",
+    version:            "1.0",
     life_stage:         "L1",
-    design_stage:       "D2",
+    design_stage:       "D1",
     verification_stage: "V1",
 }

--- a/hw/ip/aes/doc/checklist.md
+++ b/hw/ip/aes/doc/checklist.md
@@ -36,25 +36,25 @@ Review        | Signoff date          | Done        | 2019-11-05
 
 Type          | Item                    | Resolution  | Note/Collaterals
 --------------|-------------------------|-------------|------------------
-Documentation | [NEW_FEATURES][]        | N/A         |
-Documentation | [BLOCK_DIAGRAM][]       | N/A         |
-Documentation | [DOC_INTERFACE][]       | N/A         |
-Documentation | [MISSING_FUNC][]        | Done        |
-Documentation | [FEATURE_FROZEN][]      | Done        |
-RTL           | [FEATURE_COMPLETE][]    | Done        |
-RTL           | [AREA_SANITY_CHECK][]   | Done        |
-RTL           | [PORT_FROZEN][]         | Done        |
-RTL           | [ARCHITECTURE_FROZEN][] | Done        |
-RTL           | [REVIEW_TODO][]         | Done        |
-RTL           | [STYLE_X][]             | Done        |
-Code Quality  | [LINT_PASS][]           | Done        |
-Code Quality  | [CDC_SETUP][]           | N/A         |
-Code Quality  | [FPGA_TIMING][]         | Done        |
-Code Quality  | [CDC_SYNCMACRO][]       | N/A         |
+Documentation | [NEW_FEATURES][]        | Not Started |
+Documentation | [BLOCK_DIAGRAM][]       | Not Started |
+Documentation | [DOC_INTERFACE][]       | Not Started |
+Documentation | [MISSING_FUNC][]        | Not Started |
+Documentation | [FEATURE_FROZEN][]      | Not Started |
+RTL           | [FEATURE_COMPLETE][]    | Not Started |
+RTL           | [AREA_SANITY_CHECK][]   | Not Started |
+RTL           | [PORT_FROZEN][]         | Not Started |
+RTL           | [ARCHITECTURE_FROZEN][] | Not Started |
+RTL           | [REVIEW_TODO][]         | Not Started |
+RTL           | [STYLE_X][]             | Not Started |
+Code Quality  | [LINT_PASS][]           | Not Started |
+Code Quality  | [CDC_SETUP][]           | Not Started |
+Code Quality  | [FPGA_TIMING][]         | Not Started |
+Code Quality  | [CDC_SYNCMACRO][]       | Not Started |
 Security      | [SEC_CM_IMPLEMENTED][]  | Not Started |
 Security      | [SEC_NON_RESET_FLOPS][] | Not Started |
 Security      | [SEC_SHADOW_REGS][]     | Not Started |
-Review        | Signoff date            | Done        | 2019-11-05
+Review        | Signoff date            | Not Started |
 
 [NEW_FEATURES]:        {{<relref "/doc/project/checklist.md#new-features" >}}
 [BLOCK_DIAGRAM]:       {{<relref "/doc/project/checklist.md#block-diagram" >}}


### PR DESCRIPTION
We are now working towards the security hardened 1.0 version. This PR ensures this is properly reflected in the checklist and development stages.

This is related to #2605 .