### PR TITLE
[OTBN] Enable OTBN bus device in top_earlgrey

### DIFF
--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -63,6 +63,7 @@
         {
           clk_main_aes: main
           clk_main_hmac: main
+          clk_main_otbn: main
         }
       }
       {
@@ -1664,6 +1665,92 @@
         }
       ]
     }
+    {
+      name: otbn
+      type: otbn
+      clock_srcs:
+      {
+        clk_i: main
+      }
+      clock_group: trans
+      reset_connections:
+      {
+        rst_ni: sys
+      }
+      base_addr: 0x50000000
+      clock_connections:
+      {
+        clk_i: clkmgr_clocks.clk_main_otbn
+      }
+      size: 0x400000
+      bus_device: tlul
+      bus_host: none
+      available_input_list: []
+      available_output_list: []
+      available_inout_list: []
+      interrupt_list:
+      [
+        {
+          name: done
+          width: 1
+          bits: "0"
+          bitinfo:
+          [
+            1
+            1
+            0
+          ]
+          type: interrupt
+        }
+        {
+          name: err
+          width: 1
+          bits: "1"
+          bitinfo:
+          [
+            2
+            1
+            1
+          ]
+          type: interrupt
+        }
+      ]
+      alert_list:
+      [
+        {
+          name: imem_uncorrectable
+          width: 1
+          type: alert
+          async: 0
+        }
+        {
+          name: dmem_uncorrectable
+          width: 1
+          type: alert
+          async: 0
+        }
+        {
+          name: reg_uncorrectable
+          width: 1
+          type: alert
+          async: 0
+        }
+      ]
+      wakeup_list: []
+      scan: "false"
+      inter_signal_list:
+      [
+        {
+          name: idle
+          type: uni
+          struct: logic
+          width: "1"
+          act: req
+          inst_name: otbn
+          index: -1
+        }
+      ]
+    }
   ]
   memory:
   [
@@ -1835,6 +1922,7 @@
           padctrl
           alert_handler
           nmi_gen
+          otbn
         ]
         dm_sba:
         [
@@ -1850,6 +1938,7 @@
           padctrl
           alert_handler
           nmi_gen
+          otbn
         ]
       }
       nodes:
@@ -2134,6 +2223,23 @@
           xbar: false
           pipeline: "true"
         }
+        {
+          name: otbn
+          type: device
+          clock: clk_main_i
+          reset: rst_main_ni
+          pipeline_byp: "false"
+          inst_type: otbn
+          addr_range:
+          [
+            {
+              base_addr: 0x50000000
+              size_byte: 0x400000
+            }
+          ]
+          xbar: false
+          pipeline: "true"
+        }
       ]
       clock: clk_main_i
     }
@@ -2348,6 +2454,7 @@
     nmi_gen
     usbdev
     pwrmgr
+    otbn
   ]
   interrupt:
   [
@@ -2988,10 +3095,37 @@
       type: interrupt
       module_name: pwrmgr
     }
+    {
+      name: otbn_done
+      width: 1
+      bits: "0"
+      bitinfo:
+      [
+        1
+        1
+        0
+      ]
+      type: interrupt
+      module_name: otbn
+    }
+    {
+      name: otbn_err
+      width: 1
+      bits: "1"
+      bitinfo:
+      [
+        2
+        1
+        1
+      ]
+      type: interrupt
+      module_name: otbn
+    }
   ]
   alert_module:
   [
     hmac
+    otbn
   ]
   alert:
   [
@@ -3001,6 +3135,27 @@
       type: alert
       async: 0
       module_name: hmac
+    }
+    {
+      name: otbn_imem_uncorrectable
+      width: 1
+      type: alert
+      async: 0
+      module_name: otbn
+    }
+    {
+      name: otbn_dmem_uncorrectable
+      width: 1
+      type: alert
+      async: 0
+      module_name: otbn
+    }
+    {
+      name: otbn_reg_uncorrectable
+      width: 1
+      type: alert
+      async: 0
+      module_name: otbn
     }
   ]
   pinmux:
@@ -3549,6 +3704,15 @@
         struct: logic
         width: "1"
         inst_name: usbdev
+        index: -1
+      }
+      {
+        name: idle
+        type: uni
+        struct: logic
+        width: "1"
+        act: req
+        inst_name: otbn
         index: -1
       }
       {

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -246,6 +246,13 @@
       reset_connections: {rst_ni: "sys_io", rst_usb_48mhz_ni: "usb"},
       base_addr: "0x40150000",
     },
+    { name: "otbn",
+      type: "otbn",
+      clock_srcs: {clk_i: "main"},
+      clock_group: "trans",
+      reset_connections: {rst_ni: "sys"},
+      base_addr: "0x50000000",
+    },
   ]
 
   // Memories (ROM, RAM, eFlash) are defined at the top.
@@ -341,7 +348,8 @@
   // and include every modules.
   // first item goes to LSB of the interrupt source
   interrupt_module: ["gpio", "uart", "spi_device", "flash_ctrl",
-                     "hmac", "alert_handler", "nmi_gen", "usbdev", "pwrmgr" ]
+                     "hmac", "alert_handler", "nmi_gen", "usbdev", "pwrmgr",
+                     "otbn" ]
 
   // RV_PLIC has two searching algorithm internally to pick the most highest priority interrupt
   // source. "sequential" is smaller but slower, "matrix" is larger but faster.
@@ -353,8 +361,8 @@
 
   // ===== ALERT HANDLER ======================================================
   // list all modules that expose alerts
-  // first item goes to LSB of the interrupt source
-  alert_module: [ "hmac" ]
+  // first item goes to LSB of the alert source
+  alert_module: [ "hmac", "otbn" ]
 
   // generated list of alerts:
   alert: [

--- a/hw/top_earlgrey/data/xbar_main.hjson
+++ b/hw/top_earlgrey/data/xbar_main.hjson
@@ -122,12 +122,18 @@
       inst_type: "nmi_gen",
       pipeline_byp: "false"
     }
+    { name:      "otbn",
+      type:      "device",
+      clock:     "clk_main_i"
+      reset:     "rst_main_ni"
+      pipeline_byp: "false"
+    },
   ],
   connections: {
     corei:  ["rom", "debug_mem", "ram_main", "eflash"],
     cored:  ["rom", "debug_mem", "ram_main", "eflash", "peri", "flash_ctrl",
-    "aes", "hmac", "rv_plic", "pinmux", "padctrl", "alert_handler", "nmi_gen"],
+    "aes", "hmac", "rv_plic", "pinmux", "padctrl", "alert_handler", "nmi_gen", "otbn"],
     dm_sba: ["rom",              "ram_main", "eflash", "peri", "flash_ctrl",
-    "aes", "hmac", "rv_plic", "pinmux", "padctrl", "alert_handler", "nmi_gen"],
+    "aes", "hmac", "rv_plic", "pinmux", "padctrl", "alert_handler", "nmi_gen", "otbn"],
   },
 }

--- a/hw/top_earlgrey/dv/autogen/tb__xbar_connect.sv
+++ b/hw/top_earlgrey/dv/autogen/tb__xbar_connect.sv
@@ -24,6 +24,7 @@ tl_if pinmux_tl_if(clk_main, rst_n);
 tl_if padctrl_tl_if(clk_main, rst_n);
 tl_if alert_handler_tl_if(clk_main, rst_n);
 tl_if nmi_gen_tl_if(clk_main, rst_n);
+tl_if otbn_tl_if(clk_main, rst_n);
 tl_if uart_tl_if(clk_io, rst_n);
 tl_if gpio_tl_if(clk_io, rst_n);
 tl_if spi_device_tl_if(clk_io, rst_n);
@@ -74,6 +75,7 @@ initial begin
     `DRIVE_TL_DEVICE_IF(padctrl, dut.top_earlgrey, clk_main, rst_n, d_d2h, d_h2d)
     `DRIVE_TL_DEVICE_IF(alert_handler, dut.top_earlgrey, clk_main, rst_n, d_d2h, d_h2d)
     `DRIVE_TL_DEVICE_IF(nmi_gen, dut.top_earlgrey, clk_main, rst_n, d_d2h, d_h2d)
+    `DRIVE_TL_DEVICE_IF(otbn, dut.top_earlgrey, clk_main, rst_n, d_d2h, d_h2d)
     `DRIVE_TL_DEVICE_IF(uart, dut.top_earlgrey, clk_io, rst_n, d_d2h, d_h2d)
     `DRIVE_TL_DEVICE_IF(gpio, dut.top_earlgrey, clk_io, rst_n, d_d2h, d_h2d)
     `DRIVE_TL_DEVICE_IF(spi_device, dut.top_earlgrey, clk_io, rst_n, d_d2h, d_h2d)

--- a/hw/top_earlgrey/dv/autogen/xbar_env_pkg__params.sv
+++ b/hw/top_earlgrey/dv/autogen/xbar_env_pkg__params.sv
@@ -43,6 +43,9 @@ tl_device_t xbar_devices[$] = '{
     '{"nmi_gen", '{
         '{32'h40140000, 32'h40140fff}
     }},
+    '{"otbn", '{
+        '{32'h50000000, 32'h503fffff}
+    }},
     '{"uart", '{
         '{32'h40000000, 32'h40000fff}
     }},
@@ -100,7 +103,8 @@ tl_host_t xbar_hosts[$] = '{
         "pinmux",
         "padctrl",
         "alert_handler",
-        "nmi_gen"}}
+        "nmi_gen",
+        "otbn"}}
     ,
     '{"dm_sba", 2, '{
         "rom",
@@ -122,5 +126,6 @@ tl_host_t xbar_hosts[$] = '{
         "pinmux",
         "padctrl",
         "alert_handler",
-        "nmi_gen"}}
+        "nmi_gen",
+        "otbn"}}
 };

--- a/hw/top_earlgrey/ip/alert_handler/data/autogen/alert_handler.hjson
+++ b/hw/top_earlgrey/ip/alert_handler/data/autogen/alert_handler.hjson
@@ -30,7 +30,7 @@
     { name: "NAlerts",
       desc: "Number of peripheral inputs",
       type: "int",
-      default: "1",
+      default: "4",
       local: "true"
     },
     { name: "EscCntDw",
@@ -54,7 +54,7 @@
     { name: "AsyncOn",
       desc: "Number of peripheral outputs",
       type: "logic [NAlerts-1:0]",
-      default: "1'b0",
+      default: "4'b0000",
       local: "true"
     },
     { name: "N_CLASSES",

--- a/hw/top_earlgrey/ip/alert_handler/dv/alert_handler_env_pkg__params.sv
+++ b/hw/top_earlgrey/ip/alert_handler/dv/alert_handler_env_pkg__params.sv
@@ -6,5 +6,5 @@
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
 // util/topgen.py -t hw/top_earlgrey/doc/top_earlgrey.hjson --alert-handler-only -o hw/top_earlgrey/
 
-parameter uint NUM_ALERTS = 1;
-parameter bit [NUM_ALERTS-1:0] ASYNC_ON = 1'b0;
+parameter uint NUM_ALERTS = 4;
+parameter bit [NUM_ALERTS-1:0] ASYNC_ON = 4'b0000;

--- a/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_pkg.sv
@@ -7,11 +7,11 @@
 package alert_handler_reg_pkg;
 
   // Param list
-  parameter int NAlerts = 1;
+  parameter int NAlerts = 4;
   parameter int EscCntDw = 32;
   parameter int AccuCntDw = 16;
   parameter int LfsrSeed = 2147483647;
-  parameter logic [NAlerts-1:0] AsyncOn = 1'b0;
+  parameter logic [NAlerts-1:0] AsyncOn = 4'b0000;
   parameter int N_CLASSES = 4;
   parameter int N_ESC_SEV = 4;
   parameter int N_PHASES = 4;
@@ -455,14 +455,14 @@ package alert_handler_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    alert_handler_reg2hw_intr_state_reg_t intr_state; // [828:825]
-    alert_handler_reg2hw_intr_enable_reg_t intr_enable; // [824:821]
-    alert_handler_reg2hw_intr_test_reg_t intr_test; // [820:813]
-    alert_handler_reg2hw_regen_reg_t regen; // [812:812]
-    alert_handler_reg2hw_ping_timeout_cyc_reg_t ping_timeout_cyc; // [811:788]
-    alert_handler_reg2hw_alert_en_mreg_t [0:0] alert_en; // [787:787]
-    alert_handler_reg2hw_alert_class_mreg_t [0:0] alert_class; // [786:785]
-    alert_handler_reg2hw_alert_cause_mreg_t [0:0] alert_cause; // [784:784]
+    alert_handler_reg2hw_intr_state_reg_t intr_state; // [840:837]
+    alert_handler_reg2hw_intr_enable_reg_t intr_enable; // [836:833]
+    alert_handler_reg2hw_intr_test_reg_t intr_test; // [832:825]
+    alert_handler_reg2hw_regen_reg_t regen; // [824:824]
+    alert_handler_reg2hw_ping_timeout_cyc_reg_t ping_timeout_cyc; // [823:800]
+    alert_handler_reg2hw_alert_en_mreg_t [3:0] alert_en; // [799:796]
+    alert_handler_reg2hw_alert_class_mreg_t [3:0] alert_class; // [795:788]
+    alert_handler_reg2hw_alert_cause_mreg_t [3:0] alert_cause; // [787:784]
     alert_handler_reg2hw_loc_alert_en_mreg_t [3:0] loc_alert_en; // [783:780]
     alert_handler_reg2hw_loc_alert_class_mreg_t [3:0] loc_alert_class; // [779:772]
     alert_handler_reg2hw_loc_alert_cause_mreg_t [3:0] loc_alert_cause; // [771:768]
@@ -504,8 +504,8 @@ package alert_handler_reg_pkg;
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    alert_handler_hw2reg_intr_state_reg_t intr_state; // [229:226]
-    alert_handler_hw2reg_alert_cause_mreg_t [0:0] alert_cause; // [225:224]
+    alert_handler_hw2reg_intr_state_reg_t intr_state; // [235:232]
+    alert_handler_hw2reg_alert_cause_mreg_t [3:0] alert_cause; // [231:224]
     alert_handler_hw2reg_loc_alert_cause_mreg_t [3:0] loc_alert_cause; // [223:216]
     alert_handler_hw2reg_classa_clren_reg_t classa_clren; // [215:216]
     alert_handler_hw2reg_classa_accum_cnt_reg_t classa_accum_cnt; // [215:216]

--- a/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_top.sv
+++ b/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_top.sv
@@ -109,15 +109,42 @@ module alert_handler_reg_top (
   logic [23:0] ping_timeout_cyc_qs;
   logic [23:0] ping_timeout_cyc_wd;
   logic ping_timeout_cyc_we;
-  logic alert_en_qs;
-  logic alert_en_wd;
-  logic alert_en_we;
-  logic [1:0] alert_class_qs;
-  logic [1:0] alert_class_wd;
-  logic alert_class_we;
-  logic alert_cause_qs;
-  logic alert_cause_wd;
-  logic alert_cause_we;
+  logic alert_en_en_a0_qs;
+  logic alert_en_en_a0_wd;
+  logic alert_en_en_a0_we;
+  logic alert_en_en_a1_qs;
+  logic alert_en_en_a1_wd;
+  logic alert_en_en_a1_we;
+  logic alert_en_en_a2_qs;
+  logic alert_en_en_a2_wd;
+  logic alert_en_en_a2_we;
+  logic alert_en_en_a3_qs;
+  logic alert_en_en_a3_wd;
+  logic alert_en_en_a3_we;
+  logic [1:0] alert_class_class_a0_qs;
+  logic [1:0] alert_class_class_a0_wd;
+  logic alert_class_class_a0_we;
+  logic [1:0] alert_class_class_a1_qs;
+  logic [1:0] alert_class_class_a1_wd;
+  logic alert_class_class_a1_we;
+  logic [1:0] alert_class_class_a2_qs;
+  logic [1:0] alert_class_class_a2_wd;
+  logic alert_class_class_a2_we;
+  logic [1:0] alert_class_class_a3_qs;
+  logic [1:0] alert_class_class_a3_wd;
+  logic alert_class_class_a3_we;
+  logic alert_cause_a0_qs;
+  logic alert_cause_a0_wd;
+  logic alert_cause_a0_we;
+  logic alert_cause_a1_qs;
+  logic alert_cause_a1_wd;
+  logic alert_cause_a1_we;
+  logic alert_cause_a2_qs;
+  logic alert_cause_a2_wd;
+  logic alert_cause_a2_we;
+  logic alert_cause_a3_qs;
+  logic alert_cause_a3_wd;
+  logic alert_cause_a3_we;
   logic loc_alert_en_en_la0_qs;
   logic loc_alert_en_en_la0_wd;
   logic loc_alert_en_en_la0_we;
@@ -724,17 +751,18 @@ module alert_handler_reg_top (
   // Subregister 0 of Multireg alert_en
   // R[alert_en]: V(False)
 
+  // F[en_a0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
     .RESVAL  (1'h0)
-  ) u_alert_en (
+  ) u_alert_en_en_a0 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_en_we & regen_qs),
-    .wd     (alert_en_wd),
+    .we     (alert_en_en_a0_we & regen_qs),
+    .wd     (alert_en_en_a0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -745,25 +773,105 @@ module alert_handler_reg_top (
     .q      (reg2hw.alert_en[0].q ),
 
     // to register interface (read)
-    .qs     (alert_en_qs)
+    .qs     (alert_en_en_a0_qs)
   );
+
+
+  // F[en_a1]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_alert_en_en_a1 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (alert_en_en_a1_we & regen_qs),
+    .wd     (alert_en_en_a1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.alert_en[1].q ),
+
+    // to register interface (read)
+    .qs     (alert_en_en_a1_qs)
+  );
+
+
+  // F[en_a2]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_alert_en_en_a2 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (alert_en_en_a2_we & regen_qs),
+    .wd     (alert_en_en_a2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.alert_en[2].q ),
+
+    // to register interface (read)
+    .qs     (alert_en_en_a2_qs)
+  );
+
+
+  // F[en_a3]: 3:3
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_alert_en_en_a3 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (alert_en_en_a3_we & regen_qs),
+    .wd     (alert_en_en_a3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.alert_en[3].q ),
+
+    // to register interface (read)
+    .qs     (alert_en_en_a3_qs)
+  );
+
 
 
 
   // Subregister 0 of Multireg alert_class
   // R[alert_class]: V(False)
 
+  // F[class_a0]: 1:0
   prim_subreg #(
     .DW      (2),
     .SWACCESS("RW"),
     .RESVAL  (2'h0)
-  ) u_alert_class (
+  ) u_alert_class_class_a0 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (alert_class_we & regen_qs),
-    .wd     (alert_class_wd),
+    .we     (alert_class_class_a0_we & regen_qs),
+    .wd     (alert_class_class_a0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -774,25 +882,105 @@ module alert_handler_reg_top (
     .q      (reg2hw.alert_class[0].q ),
 
     // to register interface (read)
-    .qs     (alert_class_qs)
+    .qs     (alert_class_class_a0_qs)
   );
+
+
+  // F[class_a1]: 3:2
+  prim_subreg #(
+    .DW      (2),
+    .SWACCESS("RW"),
+    .RESVAL  (2'h0)
+  ) u_alert_class_class_a1 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (alert_class_class_a1_we & regen_qs),
+    .wd     (alert_class_class_a1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.alert_class[1].q ),
+
+    // to register interface (read)
+    .qs     (alert_class_class_a1_qs)
+  );
+
+
+  // F[class_a2]: 5:4
+  prim_subreg #(
+    .DW      (2),
+    .SWACCESS("RW"),
+    .RESVAL  (2'h0)
+  ) u_alert_class_class_a2 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (alert_class_class_a2_we & regen_qs),
+    .wd     (alert_class_class_a2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.alert_class[2].q ),
+
+    // to register interface (read)
+    .qs     (alert_class_class_a2_qs)
+  );
+
+
+  // F[class_a3]: 7:6
+  prim_subreg #(
+    .DW      (2),
+    .SWACCESS("RW"),
+    .RESVAL  (2'h0)
+  ) u_alert_class_class_a3 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (alert_class_class_a3_we & regen_qs),
+    .wd     (alert_class_class_a3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.alert_class[3].q ),
+
+    // to register interface (read)
+    .qs     (alert_class_class_a3_qs)
+  );
+
 
 
 
   // Subregister 0 of Multireg alert_cause
   // R[alert_cause]: V(False)
 
+  // F[a0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SWACCESS("W1C"),
     .RESVAL  (1'h0)
-  ) u_alert_cause (
+  ) u_alert_cause_a0 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (alert_cause_we),
-    .wd     (alert_cause_wd),
+    .we     (alert_cause_a0_we),
+    .wd     (alert_cause_a0_wd),
 
     // from internal hardware
     .de     (hw2reg.alert_cause[0].de),
@@ -803,8 +991,87 @@ module alert_handler_reg_top (
     .q      (reg2hw.alert_cause[0].q ),
 
     // to register interface (read)
-    .qs     (alert_cause_qs)
+    .qs     (alert_cause_a0_qs)
   );
+
+
+  // F[a1]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("W1C"),
+    .RESVAL  (1'h0)
+  ) u_alert_cause_a1 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (alert_cause_a1_we),
+    .wd     (alert_cause_a1_wd),
+
+    // from internal hardware
+    .de     (hw2reg.alert_cause[1].de),
+    .d      (hw2reg.alert_cause[1].d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.alert_cause[1].q ),
+
+    // to register interface (read)
+    .qs     (alert_cause_a1_qs)
+  );
+
+
+  // F[a2]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("W1C"),
+    .RESVAL  (1'h0)
+  ) u_alert_cause_a2 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (alert_cause_a2_we),
+    .wd     (alert_cause_a2_wd),
+
+    // from internal hardware
+    .de     (hw2reg.alert_cause[2].de),
+    .d      (hw2reg.alert_cause[2].d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.alert_cause[2].q ),
+
+    // to register interface (read)
+    .qs     (alert_cause_a2_qs)
+  );
+
+
+  // F[a3]: 3:3
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("W1C"),
+    .RESVAL  (1'h0)
+  ) u_alert_cause_a3 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (alert_cause_a3_we),
+    .wd     (alert_cause_a3_wd),
+
+    // from internal hardware
+    .de     (hw2reg.alert_cause[3].de),
+    .d      (hw2reg.alert_cause[3].d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.alert_cause[3].q ),
+
+    // to register interface (read)
+    .qs     (alert_cause_a3_qs)
+  );
+
 
 
 
@@ -3408,14 +3675,41 @@ module alert_handler_reg_top (
   assign ping_timeout_cyc_we = addr_hit[4] & reg_we & ~wr_err;
   assign ping_timeout_cyc_wd = reg_wdata[23:0];
 
-  assign alert_en_we = addr_hit[5] & reg_we & ~wr_err;
-  assign alert_en_wd = reg_wdata[0];
+  assign alert_en_en_a0_we = addr_hit[5] & reg_we & ~wr_err;
+  assign alert_en_en_a0_wd = reg_wdata[0];
 
-  assign alert_class_we = addr_hit[6] & reg_we & ~wr_err;
-  assign alert_class_wd = reg_wdata[1:0];
+  assign alert_en_en_a1_we = addr_hit[5] & reg_we & ~wr_err;
+  assign alert_en_en_a1_wd = reg_wdata[1];
 
-  assign alert_cause_we = addr_hit[7] & reg_we & ~wr_err;
-  assign alert_cause_wd = reg_wdata[0];
+  assign alert_en_en_a2_we = addr_hit[5] & reg_we & ~wr_err;
+  assign alert_en_en_a2_wd = reg_wdata[2];
+
+  assign alert_en_en_a3_we = addr_hit[5] & reg_we & ~wr_err;
+  assign alert_en_en_a3_wd = reg_wdata[3];
+
+  assign alert_class_class_a0_we = addr_hit[6] & reg_we & ~wr_err;
+  assign alert_class_class_a0_wd = reg_wdata[1:0];
+
+  assign alert_class_class_a1_we = addr_hit[6] & reg_we & ~wr_err;
+  assign alert_class_class_a1_wd = reg_wdata[3:2];
+
+  assign alert_class_class_a2_we = addr_hit[6] & reg_we & ~wr_err;
+  assign alert_class_class_a2_wd = reg_wdata[5:4];
+
+  assign alert_class_class_a3_we = addr_hit[6] & reg_we & ~wr_err;
+  assign alert_class_class_a3_wd = reg_wdata[7:6];
+
+  assign alert_cause_a0_we = addr_hit[7] & reg_we & ~wr_err;
+  assign alert_cause_a0_wd = reg_wdata[0];
+
+  assign alert_cause_a1_we = addr_hit[7] & reg_we & ~wr_err;
+  assign alert_cause_a1_wd = reg_wdata[1];
+
+  assign alert_cause_a2_we = addr_hit[7] & reg_we & ~wr_err;
+  assign alert_cause_a2_wd = reg_wdata[2];
+
+  assign alert_cause_a3_we = addr_hit[7] & reg_we & ~wr_err;
+  assign alert_cause_a3_wd = reg_wdata[3];
 
   assign loc_alert_en_en_la0_we = addr_hit[8] & reg_we & ~wr_err;
   assign loc_alert_en_en_la0_wd = reg_wdata[0];
@@ -3727,15 +4021,24 @@ module alert_handler_reg_top (
       end
 
       addr_hit[5]: begin
-        reg_rdata_next[0] = alert_en_qs;
+        reg_rdata_next[0] = alert_en_en_a0_qs;
+        reg_rdata_next[1] = alert_en_en_a1_qs;
+        reg_rdata_next[2] = alert_en_en_a2_qs;
+        reg_rdata_next[3] = alert_en_en_a3_qs;
       end
 
       addr_hit[6]: begin
-        reg_rdata_next[1:0] = alert_class_qs;
+        reg_rdata_next[1:0] = alert_class_class_a0_qs;
+        reg_rdata_next[3:2] = alert_class_class_a1_qs;
+        reg_rdata_next[5:4] = alert_class_class_a2_qs;
+        reg_rdata_next[7:6] = alert_class_class_a3_qs;
       end
 
       addr_hit[7]: begin
-        reg_rdata_next[0] = alert_cause_qs;
+        reg_rdata_next[0] = alert_cause_a0_qs;
+        reg_rdata_next[1] = alert_cause_a1_qs;
+        reg_rdata_next[2] = alert_cause_a2_qs;
+        reg_rdata_next[3] = alert_cause_a3_qs;
       end
 
       addr_hit[8]: begin

--- a/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
+++ b/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
@@ -134,6 +134,15 @@
             1 CLK_MAIN_HMAC is enabled.
           '''
         }
+        {
+          bits: "2",
+          name: "CLK_MAIN_OTBN_HINT",
+          resval: 1,
+          desc: '''
+            0 CLK_MAIN_OTBN can be disabled.
+            1 CLK_MAIN_OTBN is enabled.
+          '''
+        }
       ]
       // the CLK_HINT register cannot be written, otherwise there is the potential clocks could be
       // disabled and the system will hang
@@ -165,6 +174,15 @@
           desc: '''
             0 CLK_MAIN_HMAC is disabled.
             1 CLK_MAIN_HMAC is enabled.
+          '''
+        }
+        {
+          bits: "2",
+          name: "CLK_MAIN_OTBN_VAL",
+          resval: 1,
+          desc: '''
+            0 CLK_MAIN_OTBN is disabled.
+            1 CLK_MAIN_OTBN is enabled.
           '''
         }
       ]

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
@@ -209,6 +209,8 @@ module clkmgr import clkmgr_pkg::*; (
   logic clk_main_aes_en;
   logic clk_main_hmac_hint;
   logic clk_main_hmac_en;
+  logic clk_main_otbn_hint;
+  logic clk_main_otbn_en;
 
   assign clk_main_aes_en = clk_main_aes_hint | ~status_i.idle[0];
 
@@ -246,12 +248,32 @@ module clkmgr import clkmgr_pkg::*; (
     .clk_o(clocks_o.clk_main_hmac)
   );
 
+  assign clk_main_otbn_en = clk_main_otbn_hint | ~status_i.idle[2];
+
+  prim_flop_2sync #(
+    .Width(1)
+  ) i_clk_main_otbn_hint_sync (
+    .clk_i(clk_main_i),
+    .rst_ni(rst_main_ni),
+    .d(reg2hw.clk_hints.clk_main_otbn_hint.q),
+    .q(clk_main_otbn_hint)
+  );
+
+  prim_clock_gating i_clk_main_otbn_cg (
+    .clk_i(clk_main_i),
+    .en_i(clk_main_otbn_en & clk_main_en),
+    .test_en_i(dft_i.test_en),
+    .clk_o(clocks_o.clk_main_otbn)
+  );
+
 
   // state readback
   assign hw2reg.clk_hints_status.clk_main_aes_val.de = 1'b1;
   assign hw2reg.clk_hints_status.clk_main_aes_val.d = clk_main_aes_en;
   assign hw2reg.clk_hints_status.clk_main_hmac_val.de = 1'b1;
   assign hw2reg.clk_hints_status.clk_main_hmac_val.d = clk_main_hmac_en;
+  assign hw2reg.clk_hints_status.clk_main_otbn_val.de = 1'b1;
+  assign hw2reg.clk_hints_status.clk_main_otbn_val.d = clk_main_otbn_en;
 
 
   ////////////////////////////////////////////////////

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_pkg.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_pkg.sv
@@ -19,6 +19,7 @@ package clkmgr_pkg;
   typedef struct packed {
   logic clk_main_aes;
   logic clk_main_hmac;
+  logic clk_main_otbn;
   logic clk_main_infra;
   logic clk_io_infra;
   logic clk_io_secure;
@@ -31,11 +32,11 @@ package clkmgr_pkg;
   } clkmgr_out_t;
 
   typedef struct packed {
-    logic [2-1:0] idle;
+    logic [3-1:0] idle;
   } clk_hint_status_t;
 
   parameter clk_hint_status_t CLK_HINT_STATUS_DEFAULT = '{
-    idle: {2{1'b1}}
+    idle: {3{1'b1}}
   };
 
 

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_pkg.sv
@@ -28,6 +28,9 @@ package clkmgr_reg_pkg;
     struct packed {
       logic        q;
     } clk_main_hmac_hint;
+    struct packed {
+      logic        q;
+    } clk_main_otbn_hint;
   } clkmgr_reg2hw_clk_hints_reg_t;
 
 
@@ -40,6 +43,10 @@ package clkmgr_reg_pkg;
       logic        d;
       logic        de;
     } clk_main_hmac_val;
+    struct packed {
+      logic        d;
+      logic        de;
+    } clk_main_otbn_val;
   } clkmgr_hw2reg_clk_hints_status_reg_t;
 
 
@@ -47,15 +54,15 @@ package clkmgr_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    clkmgr_reg2hw_clk_enables_reg_t clk_enables; // [3:2]
-    clkmgr_reg2hw_clk_hints_reg_t clk_hints; // [1:0]
+    clkmgr_reg2hw_clk_enables_reg_t clk_enables; // [4:3]
+    clkmgr_reg2hw_clk_hints_reg_t clk_hints; // [2:0]
   } clkmgr_reg2hw_t;
 
   ///////////////////////////////////////
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    clkmgr_hw2reg_clk_hints_status_reg_t clk_hints_status; // [3:4]
+    clkmgr_hw2reg_clk_hints_status_reg_t clk_hints_status; // [5:6]
   } clkmgr_hw2reg_t;
 
   // Register Address

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
@@ -83,8 +83,12 @@ module clkmgr_reg_top (
   logic clk_hints_clk_main_hmac_hint_qs;
   logic clk_hints_clk_main_hmac_hint_wd;
   logic clk_hints_clk_main_hmac_hint_we;
+  logic clk_hints_clk_main_otbn_hint_qs;
+  logic clk_hints_clk_main_otbn_hint_wd;
+  logic clk_hints_clk_main_otbn_hint_we;
   logic clk_hints_status_clk_main_aes_val_qs;
   logic clk_hints_status_clk_main_hmac_val_qs;
+  logic clk_hints_status_clk_main_otbn_val_qs;
 
   // Register instances
   // R[clk_enables]: V(False)
@@ -195,6 +199,32 @@ module clkmgr_reg_top (
   );
 
 
+  //   F[clk_main_otbn_hint]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h1)
+  ) u_clk_hints_clk_main_otbn_hint (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (clk_hints_clk_main_otbn_hint_we),
+    .wd     (clk_hints_clk_main_otbn_hint_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.clk_hints.clk_main_otbn_hint.q ),
+
+    // to register interface (read)
+    .qs     (clk_hints_clk_main_otbn_hint_qs)
+  );
+
+
   // R[clk_hints_status]: V(False)
 
   //   F[clk_main_aes_val]: 0:0
@@ -247,6 +277,31 @@ module clkmgr_reg_top (
   );
 
 
+  //   F[clk_main_otbn_val]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RO"),
+    .RESVAL  (1'h1)
+  ) u_clk_hints_status_clk_main_otbn_val (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    .we     (1'b0),
+    .wd     ('0  ),
+
+    // from internal hardware
+    .de     (hw2reg.clk_hints_status.clk_main_otbn_val.de),
+    .d      (hw2reg.clk_hints_status.clk_main_otbn_val.d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (clk_hints_status_clk_main_otbn_val_qs)
+  );
+
+
 
 
   logic [2:0] addr_hit;
@@ -279,6 +334,10 @@ module clkmgr_reg_top (
   assign clk_hints_clk_main_hmac_hint_we = addr_hit[1] & reg_we & ~wr_err;
   assign clk_hints_clk_main_hmac_hint_wd = reg_wdata[1];
 
+  assign clk_hints_clk_main_otbn_hint_we = addr_hit[1] & reg_we & ~wr_err;
+  assign clk_hints_clk_main_otbn_hint_wd = reg_wdata[2];
+
+
 
 
   // Read data return
@@ -293,11 +352,13 @@ module clkmgr_reg_top (
       addr_hit[1]: begin
         reg_rdata_next[0] = clk_hints_clk_main_aes_hint_qs;
         reg_rdata_next[1] = clk_hints_clk_main_hmac_hint_qs;
+        reg_rdata_next[2] = clk_hints_clk_main_otbn_hint_qs;
       end
 
       addr_hit[2]: begin
         reg_rdata_next[0] = clk_hints_status_clk_main_aes_val_qs;
         reg_rdata_next[1] = clk_hints_status_clk_main_hmac_val_qs;
+        reg_rdata_next[2] = clk_hints_status_clk_main_otbn_val_qs;
       end
 
       default: begin

--- a/hw/top_earlgrey/ip/rv_plic/data/autogen/rv_plic.hjson
+++ b/hw/top_earlgrey/ip/rv_plic/data/autogen/rv_plic.hjson
@@ -25,7 +25,7 @@
     { name: "NumSrc",
       desc: "Number of interrupt sources",
       type: "int",
-      default: "81",
+      default: "83",
       local: "true"
     },
     { name: "NumTarget",
@@ -705,6 +705,22 @@
     }
     { name: "PRIO80",
       desc: "Interrupt Source 80 Priority",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "1:0" }
+      ],
+    }
+    { name: "PRIO81",
+      desc: "Interrupt Source 81 Priority",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "1:0" }
+      ],
+    }
+    { name: "PRIO82",
+      desc: "Interrupt Source 82 Priority",
       swaccess: "rw",
       hwaccess: "hro",
       fields: [

--- a/hw/top_earlgrey/ip/rv_plic/fpv/autogen/rv_plic_csr_assert_fpv.sv
+++ b/hw/top_earlgrey/ip/rv_plic/fpv/autogen/rv_plic_csr_assert_fpv.sv
@@ -108,8 +108,8 @@ module rv_plic_csr_assert_fpv import tlul_pkg::*; (
 // for all the regsters, declare assertion
 
   // define local fpv variable for the multi_reg
-  logic [80:0] ip_d_fpv;
-  for (genvar s = 0; s <= 80; s++) begin : gen_ip_d
+  logic [82:0] ip_d_fpv;
+  for (genvar s = 0; s <= 82; s++) begin : gen_ip_d
     assign ip_d_fpv[s] = i_rv_plic.hw2reg.ip[s].d;
   end
 
@@ -117,11 +117,11 @@ module rv_plic_csr_assert_fpv import tlul_pkg::*; (
 
   `ASSERT(ip1_rd_A, rd_P(10'h4, ip_d_fpv[63:32]))
 
-  `ASSERT(ip2_rd_A, rd_P(10'h8, ip_d_fpv[80:64]))
+  `ASSERT(ip2_rd_A, rd_P(10'h8, ip_d_fpv[82:64]))
 
   // define local fpv variable for the multi_reg
-  logic [80:0] le_q_fpv;
-  for (genvar s = 0; s <= 80; s++) begin : gen_le_q
+  logic [82:0] le_q_fpv;
+  for (genvar s = 0; s <= 82; s++) begin : gen_le_q
     assign le_q_fpv[s] = 1 ?
         i_rv_plic.reg2hw.le[s].q : le_q_fpv[s];
   end
@@ -132,8 +132,8 @@ module rv_plic_csr_assert_fpv import tlul_pkg::*; (
   `ASSERT(le1_wr_A, wr_P(10'h10, le_q_fpv[63:32], 1, 'hffffffff))
   `ASSERT(le1_rd_A, rd_P(10'h10, le_q_fpv[63:32]))
 
-  `ASSERT(le2_wr_A, wr_P(10'h14, le_q_fpv[80:64], 1, 'h1ffff))
-  `ASSERT(le2_rd_A, rd_P(10'h14, le_q_fpv[80:64]))
+  `ASSERT(le2_wr_A, wr_P(10'h14, le_q_fpv[82:64], 1, 'h7ffff))
+  `ASSERT(le2_rd_A, rd_P(10'h14, le_q_fpv[82:64]))
 
   `ASSERT(prio0_wr_A, wr_P(10'h18, i_rv_plic.reg2hw.prio0.q, 1, 'h3))
   `ASSERT(prio0_rd_A, rd_P(10'h18, i_rv_plic.reg2hw.prio0.q))
@@ -378,9 +378,15 @@ module rv_plic_csr_assert_fpv import tlul_pkg::*; (
   `ASSERT(prio80_wr_A, wr_P(10'h158, i_rv_plic.reg2hw.prio80.q, 1, 'h3))
   `ASSERT(prio80_rd_A, rd_P(10'h158, i_rv_plic.reg2hw.prio80.q))
 
+  `ASSERT(prio81_wr_A, wr_P(10'h15c, i_rv_plic.reg2hw.prio81.q, 1, 'h3))
+  `ASSERT(prio81_rd_A, rd_P(10'h15c, i_rv_plic.reg2hw.prio81.q))
+
+  `ASSERT(prio82_wr_A, wr_P(10'h160, i_rv_plic.reg2hw.prio82.q, 1, 'h3))
+  `ASSERT(prio82_rd_A, rd_P(10'h160, i_rv_plic.reg2hw.prio82.q))
+
   // define local fpv variable for the multi_reg
-  logic [80:0] ie0_q_fpv;
-  for (genvar s = 0; s <= 80; s++) begin : gen_ie0_q
+  logic [82:0] ie0_q_fpv;
+  for (genvar s = 0; s <= 82; s++) begin : gen_ie0_q
     assign ie0_q_fpv[s] = 1 ?
         i_rv_plic.reg2hw.ie0[s].q : ie0_q_fpv[s];
   end
@@ -391,8 +397,8 @@ module rv_plic_csr_assert_fpv import tlul_pkg::*; (
   `ASSERT(ie01_wr_A, wr_P(10'h204, ie0_q_fpv[63:32], 1, 'hffffffff))
   `ASSERT(ie01_rd_A, rd_P(10'h204, ie0_q_fpv[63:32]))
 
-  `ASSERT(ie02_wr_A, wr_P(10'h208, ie0_q_fpv[80:64], 1, 'h1ffff))
-  `ASSERT(ie02_rd_A, rd_P(10'h208, ie0_q_fpv[80:64]))
+  `ASSERT(ie02_wr_A, wr_P(10'h208, ie0_q_fpv[82:64], 1, 'h7ffff))
+  `ASSERT(ie02_rd_A, rd_P(10'h208, ie0_q_fpv[82:64]))
 
   `ASSERT(threshold0_wr_A, wr_P(10'h20c, i_rv_plic.reg2hw.threshold0.q, 1, 'h3))
   `ASSERT(threshold0_rd_A, rd_P(10'h20c, i_rv_plic.reg2hw.threshold0.q))

--- a/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic.sv
+++ b/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic.sv
@@ -175,11 +175,13 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   assign prio[78] = reg2hw.prio78.q;
   assign prio[79] = reg2hw.prio79.q;
   assign prio[80] = reg2hw.prio80.q;
+  assign prio[81] = reg2hw.prio81.q;
+  assign prio[82] = reg2hw.prio82.q;
 
   //////////////////////
   // Interrupt Enable //
   //////////////////////
-  for (genvar s = 0; s < 81; s++) begin : gen_ie0
+  for (genvar s = 0; s < 83; s++) begin : gen_ie0
     assign ie[0][s] = reg2hw.ie0[s].q;
   end
 
@@ -205,7 +207,7 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   ////////
   // IP //
   ////////
-  for (genvar s = 0; s < 81; s++) begin : gen_ip
+  for (genvar s = 0; s < 83; s++) begin : gen_ip
     assign hw2reg.ip[s].de = 1'b1; // Always write
     assign hw2reg.ip[s].d  = ip[s];
   end
@@ -213,7 +215,7 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   ///////////////////////////////////
   // Detection:: 0: Level, 1: Edge //
   ///////////////////////////////////
-  for (genvar s = 0; s < 81; s++) begin : gen_le
+  for (genvar s = 0; s < 83; s++) begin : gen_le
     assign le[s] = reg2hw.le[s].q;
   end
 

--- a/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_pkg.sv
@@ -7,7 +7,7 @@
 package rv_plic_reg_pkg;
 
   // Param list
-  parameter int NumSrc = 81;
+  parameter int NumSrc = 83;
   parameter int NumTarget = 1;
 
   ////////////////////////////
@@ -342,6 +342,14 @@ package rv_plic_reg_pkg;
   } rv_plic_reg2hw_prio80_reg_t;
 
   typedef struct packed {
+    logic [1:0]  q;
+  } rv_plic_reg2hw_prio81_reg_t;
+
+  typedef struct packed {
+    logic [1:0]  q;
+  } rv_plic_reg2hw_prio82_reg_t;
+
+  typedef struct packed {
     logic        q;
   } rv_plic_reg2hw_ie0_mreg_t;
 
@@ -374,89 +382,91 @@ package rv_plic_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    rv_plic_reg2hw_le_mreg_t [80:0] le; // [335:255]
-    rv_plic_reg2hw_prio0_reg_t prio0; // [254:253]
-    rv_plic_reg2hw_prio1_reg_t prio1; // [252:251]
-    rv_plic_reg2hw_prio2_reg_t prio2; // [250:249]
-    rv_plic_reg2hw_prio3_reg_t prio3; // [248:247]
-    rv_plic_reg2hw_prio4_reg_t prio4; // [246:245]
-    rv_plic_reg2hw_prio5_reg_t prio5; // [244:243]
-    rv_plic_reg2hw_prio6_reg_t prio6; // [242:241]
-    rv_plic_reg2hw_prio7_reg_t prio7; // [240:239]
-    rv_plic_reg2hw_prio8_reg_t prio8; // [238:237]
-    rv_plic_reg2hw_prio9_reg_t prio9; // [236:235]
-    rv_plic_reg2hw_prio10_reg_t prio10; // [234:233]
-    rv_plic_reg2hw_prio11_reg_t prio11; // [232:231]
-    rv_plic_reg2hw_prio12_reg_t prio12; // [230:229]
-    rv_plic_reg2hw_prio13_reg_t prio13; // [228:227]
-    rv_plic_reg2hw_prio14_reg_t prio14; // [226:225]
-    rv_plic_reg2hw_prio15_reg_t prio15; // [224:223]
-    rv_plic_reg2hw_prio16_reg_t prio16; // [222:221]
-    rv_plic_reg2hw_prio17_reg_t prio17; // [220:219]
-    rv_plic_reg2hw_prio18_reg_t prio18; // [218:217]
-    rv_plic_reg2hw_prio19_reg_t prio19; // [216:215]
-    rv_plic_reg2hw_prio20_reg_t prio20; // [214:213]
-    rv_plic_reg2hw_prio21_reg_t prio21; // [212:211]
-    rv_plic_reg2hw_prio22_reg_t prio22; // [210:209]
-    rv_plic_reg2hw_prio23_reg_t prio23; // [208:207]
-    rv_plic_reg2hw_prio24_reg_t prio24; // [206:205]
-    rv_plic_reg2hw_prio25_reg_t prio25; // [204:203]
-    rv_plic_reg2hw_prio26_reg_t prio26; // [202:201]
-    rv_plic_reg2hw_prio27_reg_t prio27; // [200:199]
-    rv_plic_reg2hw_prio28_reg_t prio28; // [198:197]
-    rv_plic_reg2hw_prio29_reg_t prio29; // [196:195]
-    rv_plic_reg2hw_prio30_reg_t prio30; // [194:193]
-    rv_plic_reg2hw_prio31_reg_t prio31; // [192:191]
-    rv_plic_reg2hw_prio32_reg_t prio32; // [190:189]
-    rv_plic_reg2hw_prio33_reg_t prio33; // [188:187]
-    rv_plic_reg2hw_prio34_reg_t prio34; // [186:185]
-    rv_plic_reg2hw_prio35_reg_t prio35; // [184:183]
-    rv_plic_reg2hw_prio36_reg_t prio36; // [182:181]
-    rv_plic_reg2hw_prio37_reg_t prio37; // [180:179]
-    rv_plic_reg2hw_prio38_reg_t prio38; // [178:177]
-    rv_plic_reg2hw_prio39_reg_t prio39; // [176:175]
-    rv_plic_reg2hw_prio40_reg_t prio40; // [174:173]
-    rv_plic_reg2hw_prio41_reg_t prio41; // [172:171]
-    rv_plic_reg2hw_prio42_reg_t prio42; // [170:169]
-    rv_plic_reg2hw_prio43_reg_t prio43; // [168:167]
-    rv_plic_reg2hw_prio44_reg_t prio44; // [166:165]
-    rv_plic_reg2hw_prio45_reg_t prio45; // [164:163]
-    rv_plic_reg2hw_prio46_reg_t prio46; // [162:161]
-    rv_plic_reg2hw_prio47_reg_t prio47; // [160:159]
-    rv_plic_reg2hw_prio48_reg_t prio48; // [158:157]
-    rv_plic_reg2hw_prio49_reg_t prio49; // [156:155]
-    rv_plic_reg2hw_prio50_reg_t prio50; // [154:153]
-    rv_plic_reg2hw_prio51_reg_t prio51; // [152:151]
-    rv_plic_reg2hw_prio52_reg_t prio52; // [150:149]
-    rv_plic_reg2hw_prio53_reg_t prio53; // [148:147]
-    rv_plic_reg2hw_prio54_reg_t prio54; // [146:145]
-    rv_plic_reg2hw_prio55_reg_t prio55; // [144:143]
-    rv_plic_reg2hw_prio56_reg_t prio56; // [142:141]
-    rv_plic_reg2hw_prio57_reg_t prio57; // [140:139]
-    rv_plic_reg2hw_prio58_reg_t prio58; // [138:137]
-    rv_plic_reg2hw_prio59_reg_t prio59; // [136:135]
-    rv_plic_reg2hw_prio60_reg_t prio60; // [134:133]
-    rv_plic_reg2hw_prio61_reg_t prio61; // [132:131]
-    rv_plic_reg2hw_prio62_reg_t prio62; // [130:129]
-    rv_plic_reg2hw_prio63_reg_t prio63; // [128:127]
-    rv_plic_reg2hw_prio64_reg_t prio64; // [126:125]
-    rv_plic_reg2hw_prio65_reg_t prio65; // [124:123]
-    rv_plic_reg2hw_prio66_reg_t prio66; // [122:121]
-    rv_plic_reg2hw_prio67_reg_t prio67; // [120:119]
-    rv_plic_reg2hw_prio68_reg_t prio68; // [118:117]
-    rv_plic_reg2hw_prio69_reg_t prio69; // [116:115]
-    rv_plic_reg2hw_prio70_reg_t prio70; // [114:113]
-    rv_plic_reg2hw_prio71_reg_t prio71; // [112:111]
-    rv_plic_reg2hw_prio72_reg_t prio72; // [110:109]
-    rv_plic_reg2hw_prio73_reg_t prio73; // [108:107]
-    rv_plic_reg2hw_prio74_reg_t prio74; // [106:105]
-    rv_plic_reg2hw_prio75_reg_t prio75; // [104:103]
-    rv_plic_reg2hw_prio76_reg_t prio76; // [102:101]
-    rv_plic_reg2hw_prio77_reg_t prio77; // [100:99]
-    rv_plic_reg2hw_prio78_reg_t prio78; // [98:97]
-    rv_plic_reg2hw_prio79_reg_t prio79; // [96:95]
-    rv_plic_reg2hw_prio80_reg_t prio80; // [94:93]
-    rv_plic_reg2hw_ie0_mreg_t [80:0] ie0; // [92:12]
+    rv_plic_reg2hw_le_mreg_t [82:0] le; // [343:261]
+    rv_plic_reg2hw_prio0_reg_t prio0; // [260:259]
+    rv_plic_reg2hw_prio1_reg_t prio1; // [258:257]
+    rv_plic_reg2hw_prio2_reg_t prio2; // [256:255]
+    rv_plic_reg2hw_prio3_reg_t prio3; // [254:253]
+    rv_plic_reg2hw_prio4_reg_t prio4; // [252:251]
+    rv_plic_reg2hw_prio5_reg_t prio5; // [250:249]
+    rv_plic_reg2hw_prio6_reg_t prio6; // [248:247]
+    rv_plic_reg2hw_prio7_reg_t prio7; // [246:245]
+    rv_plic_reg2hw_prio8_reg_t prio8; // [244:243]
+    rv_plic_reg2hw_prio9_reg_t prio9; // [242:241]
+    rv_plic_reg2hw_prio10_reg_t prio10; // [240:239]
+    rv_plic_reg2hw_prio11_reg_t prio11; // [238:237]
+    rv_plic_reg2hw_prio12_reg_t prio12; // [236:235]
+    rv_plic_reg2hw_prio13_reg_t prio13; // [234:233]
+    rv_plic_reg2hw_prio14_reg_t prio14; // [232:231]
+    rv_plic_reg2hw_prio15_reg_t prio15; // [230:229]
+    rv_plic_reg2hw_prio16_reg_t prio16; // [228:227]
+    rv_plic_reg2hw_prio17_reg_t prio17; // [226:225]
+    rv_plic_reg2hw_prio18_reg_t prio18; // [224:223]
+    rv_plic_reg2hw_prio19_reg_t prio19; // [222:221]
+    rv_plic_reg2hw_prio20_reg_t prio20; // [220:219]
+    rv_plic_reg2hw_prio21_reg_t prio21; // [218:217]
+    rv_plic_reg2hw_prio22_reg_t prio22; // [216:215]
+    rv_plic_reg2hw_prio23_reg_t prio23; // [214:213]
+    rv_plic_reg2hw_prio24_reg_t prio24; // [212:211]
+    rv_plic_reg2hw_prio25_reg_t prio25; // [210:209]
+    rv_plic_reg2hw_prio26_reg_t prio26; // [208:207]
+    rv_plic_reg2hw_prio27_reg_t prio27; // [206:205]
+    rv_plic_reg2hw_prio28_reg_t prio28; // [204:203]
+    rv_plic_reg2hw_prio29_reg_t prio29; // [202:201]
+    rv_plic_reg2hw_prio30_reg_t prio30; // [200:199]
+    rv_plic_reg2hw_prio31_reg_t prio31; // [198:197]
+    rv_plic_reg2hw_prio32_reg_t prio32; // [196:195]
+    rv_plic_reg2hw_prio33_reg_t prio33; // [194:193]
+    rv_plic_reg2hw_prio34_reg_t prio34; // [192:191]
+    rv_plic_reg2hw_prio35_reg_t prio35; // [190:189]
+    rv_plic_reg2hw_prio36_reg_t prio36; // [188:187]
+    rv_plic_reg2hw_prio37_reg_t prio37; // [186:185]
+    rv_plic_reg2hw_prio38_reg_t prio38; // [184:183]
+    rv_plic_reg2hw_prio39_reg_t prio39; // [182:181]
+    rv_plic_reg2hw_prio40_reg_t prio40; // [180:179]
+    rv_plic_reg2hw_prio41_reg_t prio41; // [178:177]
+    rv_plic_reg2hw_prio42_reg_t prio42; // [176:175]
+    rv_plic_reg2hw_prio43_reg_t prio43; // [174:173]
+    rv_plic_reg2hw_prio44_reg_t prio44; // [172:171]
+    rv_plic_reg2hw_prio45_reg_t prio45; // [170:169]
+    rv_plic_reg2hw_prio46_reg_t prio46; // [168:167]
+    rv_plic_reg2hw_prio47_reg_t prio47; // [166:165]
+    rv_plic_reg2hw_prio48_reg_t prio48; // [164:163]
+    rv_plic_reg2hw_prio49_reg_t prio49; // [162:161]
+    rv_plic_reg2hw_prio50_reg_t prio50; // [160:159]
+    rv_plic_reg2hw_prio51_reg_t prio51; // [158:157]
+    rv_plic_reg2hw_prio52_reg_t prio52; // [156:155]
+    rv_plic_reg2hw_prio53_reg_t prio53; // [154:153]
+    rv_plic_reg2hw_prio54_reg_t prio54; // [152:151]
+    rv_plic_reg2hw_prio55_reg_t prio55; // [150:149]
+    rv_plic_reg2hw_prio56_reg_t prio56; // [148:147]
+    rv_plic_reg2hw_prio57_reg_t prio57; // [146:145]
+    rv_plic_reg2hw_prio58_reg_t prio58; // [144:143]
+    rv_plic_reg2hw_prio59_reg_t prio59; // [142:141]
+    rv_plic_reg2hw_prio60_reg_t prio60; // [140:139]
+    rv_plic_reg2hw_prio61_reg_t prio61; // [138:137]
+    rv_plic_reg2hw_prio62_reg_t prio62; // [136:135]
+    rv_plic_reg2hw_prio63_reg_t prio63; // [134:133]
+    rv_plic_reg2hw_prio64_reg_t prio64; // [132:131]
+    rv_plic_reg2hw_prio65_reg_t prio65; // [130:129]
+    rv_plic_reg2hw_prio66_reg_t prio66; // [128:127]
+    rv_plic_reg2hw_prio67_reg_t prio67; // [126:125]
+    rv_plic_reg2hw_prio68_reg_t prio68; // [124:123]
+    rv_plic_reg2hw_prio69_reg_t prio69; // [122:121]
+    rv_plic_reg2hw_prio70_reg_t prio70; // [120:119]
+    rv_plic_reg2hw_prio71_reg_t prio71; // [118:117]
+    rv_plic_reg2hw_prio72_reg_t prio72; // [116:115]
+    rv_plic_reg2hw_prio73_reg_t prio73; // [114:113]
+    rv_plic_reg2hw_prio74_reg_t prio74; // [112:111]
+    rv_plic_reg2hw_prio75_reg_t prio75; // [110:109]
+    rv_plic_reg2hw_prio76_reg_t prio76; // [108:107]
+    rv_plic_reg2hw_prio77_reg_t prio77; // [106:105]
+    rv_plic_reg2hw_prio78_reg_t prio78; // [104:103]
+    rv_plic_reg2hw_prio79_reg_t prio79; // [102:101]
+    rv_plic_reg2hw_prio80_reg_t prio80; // [100:99]
+    rv_plic_reg2hw_prio81_reg_t prio81; // [98:97]
+    rv_plic_reg2hw_prio82_reg_t prio82; // [96:95]
+    rv_plic_reg2hw_ie0_mreg_t [82:0] ie0; // [94:12]
     rv_plic_reg2hw_threshold0_reg_t threshold0; // [11:10]
     rv_plic_reg2hw_cc0_reg_t cc0; // [9:1]
     rv_plic_reg2hw_msip0_reg_t msip0; // [0:0]
@@ -466,7 +476,7 @@ package rv_plic_reg_pkg;
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    rv_plic_hw2reg_ip_mreg_t [80:0] ip; // [168:7]
+    rv_plic_hw2reg_ip_mreg_t [82:0] ip; // [172:7]
     rv_plic_hw2reg_cc0_reg_t cc0; // [6:-2]
   } rv_plic_hw2reg_t;
 
@@ -558,6 +568,8 @@ package rv_plic_reg_pkg;
   parameter logic [9:0] RV_PLIC_PRIO78_OFFSET = 10'h 150;
   parameter logic [9:0] RV_PLIC_PRIO79_OFFSET = 10'h 154;
   parameter logic [9:0] RV_PLIC_PRIO80_OFFSET = 10'h 158;
+  parameter logic [9:0] RV_PLIC_PRIO81_OFFSET = 10'h 15c;
+  parameter logic [9:0] RV_PLIC_PRIO82_OFFSET = 10'h 160;
   parameter logic [9:0] RV_PLIC_IE00_OFFSET = 10'h 200;
   parameter logic [9:0] RV_PLIC_IE01_OFFSET = 10'h 204;
   parameter logic [9:0] RV_PLIC_IE02_OFFSET = 10'h 208;
@@ -655,6 +667,8 @@ package rv_plic_reg_pkg;
     RV_PLIC_PRIO78,
     RV_PLIC_PRIO79,
     RV_PLIC_PRIO80,
+    RV_PLIC_PRIO81,
+    RV_PLIC_PRIO82,
     RV_PLIC_IE00,
     RV_PLIC_IE01,
     RV_PLIC_IE02,
@@ -664,7 +678,7 @@ package rv_plic_reg_pkg;
   } rv_plic_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] RV_PLIC_PERMIT [93] = '{
+  parameter logic [3:0] RV_PLIC_PERMIT [95] = '{
     4'b 1111, // index[ 0] RV_PLIC_IP0
     4'b 1111, // index[ 1] RV_PLIC_IP1
     4'b 0111, // index[ 2] RV_PLIC_IP2
@@ -752,12 +766,14 @@ package rv_plic_reg_pkg;
     4'b 0001, // index[84] RV_PLIC_PRIO78
     4'b 0001, // index[85] RV_PLIC_PRIO79
     4'b 0001, // index[86] RV_PLIC_PRIO80
-    4'b 1111, // index[87] RV_PLIC_IE00
-    4'b 1111, // index[88] RV_PLIC_IE01
-    4'b 0111, // index[89] RV_PLIC_IE02
-    4'b 0001, // index[90] RV_PLIC_THRESHOLD0
-    4'b 0001, // index[91] RV_PLIC_CC0
-    4'b 0001  // index[92] RV_PLIC_MSIP0
+    4'b 0001, // index[87] RV_PLIC_PRIO81
+    4'b 0001, // index[88] RV_PLIC_PRIO82
+    4'b 1111, // index[89] RV_PLIC_IE00
+    4'b 1111, // index[90] RV_PLIC_IE01
+    4'b 0111, // index[91] RV_PLIC_IE02
+    4'b 0001, // index[92] RV_PLIC_THRESHOLD0
+    4'b 0001, // index[93] RV_PLIC_CC0
+    4'b 0001  // index[94] RV_PLIC_MSIP0
   };
 endpackage
 

--- a/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_top.sv
+++ b/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_top.sv
@@ -152,6 +152,8 @@ module rv_plic_reg_top (
   logic ip2_p78_qs;
   logic ip2_p79_qs;
   logic ip2_p80_qs;
+  logic ip2_p81_qs;
+  logic ip2_p82_qs;
   logic le0_le0_qs;
   logic le0_le0_wd;
   logic le0_le0_we;
@@ -395,6 +397,12 @@ module rv_plic_reg_top (
   logic le2_le80_qs;
   logic le2_le80_wd;
   logic le2_le80_we;
+  logic le2_le81_qs;
+  logic le2_le81_wd;
+  logic le2_le81_we;
+  logic le2_le82_qs;
+  logic le2_le82_wd;
+  logic le2_le82_we;
   logic [1:0] prio0_qs;
   logic [1:0] prio0_wd;
   logic prio0_we;
@@ -638,6 +646,12 @@ module rv_plic_reg_top (
   logic [1:0] prio80_qs;
   logic [1:0] prio80_wd;
   logic prio80_we;
+  logic [1:0] prio81_qs;
+  logic [1:0] prio81_wd;
+  logic prio81_we;
+  logic [1:0] prio82_qs;
+  logic [1:0] prio82_wd;
+  logic prio82_we;
   logic ie00_e0_qs;
   logic ie00_e0_wd;
   logic ie00_e0_we;
@@ -881,6 +895,12 @@ module rv_plic_reg_top (
   logic ie02_e80_qs;
   logic ie02_e80_wd;
   logic ie02_e80_we;
+  logic ie02_e81_qs;
+  logic ie02_e81_wd;
+  logic ie02_e81_we;
+  logic ie02_e82_qs;
+  logic ie02_e82_wd;
+  logic ie02_e82_we;
   logic [1:0] threshold0_qs;
   logic [1:0] threshold0_wd;
   logic threshold0_we;
@@ -2925,6 +2945,56 @@ module rv_plic_reg_top (
 
     // to register interface (read)
     .qs     (ip2_p80_qs)
+  );
+
+
+  // F[p81]: 17:17
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RO"),
+    .RESVAL  (1'h0)
+  ) u_ip2_p81 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    .we     (1'b0),
+    .wd     ('0  ),
+
+    // from internal hardware
+    .de     (hw2reg.ip[81].de),
+    .d      (hw2reg.ip[81].d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (ip2_p81_qs)
+  );
+
+
+  // F[p82]: 18:18
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RO"),
+    .RESVAL  (1'h0)
+  ) u_ip2_p82 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    .we     (1'b0),
+    .wd     ('0  ),
+
+    // from internal hardware
+    .de     (hw2reg.ip[82].de),
+    .d      (hw2reg.ip[82].d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (ip2_p82_qs)
   );
 
 
@@ -5042,6 +5112,58 @@ module rv_plic_reg_top (
 
     // to register interface (read)
     .qs     (le2_le80_qs)
+  );
+
+
+  // F[le81]: 17:17
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_le2_le81 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (le2_le81_we),
+    .wd     (le2_le81_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.le[81].q ),
+
+    // to register interface (read)
+    .qs     (le2_le81_qs)
+  );
+
+
+  // F[le82]: 18:18
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_le2_le82 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (le2_le82_we),
+    .wd     (le2_le82_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.le[82].q ),
+
+    // to register interface (read)
+    .qs     (le2_le82_qs)
   );
 
 
@@ -7233,6 +7355,60 @@ module rv_plic_reg_top (
   );
 
 
+  // R[prio81]: V(False)
+
+  prim_subreg #(
+    .DW      (2),
+    .SWACCESS("RW"),
+    .RESVAL  (2'h0)
+  ) u_prio81 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (prio81_we),
+    .wd     (prio81_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.prio81.q ),
+
+    // to register interface (read)
+    .qs     (prio81_qs)
+  );
+
+
+  // R[prio82]: V(False)
+
+  prim_subreg #(
+    .DW      (2),
+    .SWACCESS("RW"),
+    .RESVAL  (2'h0)
+  ) u_prio82 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (prio82_we),
+    .wd     (prio82_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.prio82.q ),
+
+    // to register interface (read)
+    .qs     (prio82_qs)
+  );
+
+
 
   // Subregister 0 of Multireg ie0
   // R[ie00]: V(False)
@@ -9349,6 +9525,58 @@ module rv_plic_reg_top (
   );
 
 
+  // F[e81]: 17:17
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_ie02_e81 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ie02_e81_we),
+    .wd     (ie02_e81_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ie0[81].q ),
+
+    // to register interface (read)
+    .qs     (ie02_e81_qs)
+  );
+
+
+  // F[e82]: 18:18
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_ie02_e82 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ie02_e82_we),
+    .wd     (ie02_e82_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ie0[82].q ),
+
+    // to register interface (read)
+    .qs     (ie02_e82_qs)
+  );
+
+
 
   // R[threshold0]: V(False)
 
@@ -9422,7 +9650,7 @@ module rv_plic_reg_top (
 
 
 
-  logic [92:0] addr_hit;
+  logic [94:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == RV_PLIC_IP0_OFFSET);
@@ -9512,12 +9740,14 @@ module rv_plic_reg_top (
     addr_hit[84] = (reg_addr == RV_PLIC_PRIO78_OFFSET);
     addr_hit[85] = (reg_addr == RV_PLIC_PRIO79_OFFSET);
     addr_hit[86] = (reg_addr == RV_PLIC_PRIO80_OFFSET);
-    addr_hit[87] = (reg_addr == RV_PLIC_IE00_OFFSET);
-    addr_hit[88] = (reg_addr == RV_PLIC_IE01_OFFSET);
-    addr_hit[89] = (reg_addr == RV_PLIC_IE02_OFFSET);
-    addr_hit[90] = (reg_addr == RV_PLIC_THRESHOLD0_OFFSET);
-    addr_hit[91] = (reg_addr == RV_PLIC_CC0_OFFSET);
-    addr_hit[92] = (reg_addr == RV_PLIC_MSIP0_OFFSET);
+    addr_hit[87] = (reg_addr == RV_PLIC_PRIO81_OFFSET);
+    addr_hit[88] = (reg_addr == RV_PLIC_PRIO82_OFFSET);
+    addr_hit[89] = (reg_addr == RV_PLIC_IE00_OFFSET);
+    addr_hit[90] = (reg_addr == RV_PLIC_IE01_OFFSET);
+    addr_hit[91] = (reg_addr == RV_PLIC_IE02_OFFSET);
+    addr_hit[92] = (reg_addr == RV_PLIC_THRESHOLD0_OFFSET);
+    addr_hit[93] = (reg_addr == RV_PLIC_CC0_OFFSET);
+    addr_hit[94] = (reg_addr == RV_PLIC_MSIP0_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -9618,7 +9848,11 @@ module rv_plic_reg_top (
     if (addr_hit[90] && reg_we && (RV_PLIC_PERMIT[90] != (RV_PLIC_PERMIT[90] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[91] && reg_we && (RV_PLIC_PERMIT[91] != (RV_PLIC_PERMIT[91] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[92] && reg_we && (RV_PLIC_PERMIT[92] != (RV_PLIC_PERMIT[92] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[93] && reg_we && (RV_PLIC_PERMIT[93] != (RV_PLIC_PERMIT[93] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[94] && reg_we && (RV_PLIC_PERMIT[94] != (RV_PLIC_PERMIT[94] & reg_be))) wr_err = 1'b1 ;
   end
+
+
 
 
 
@@ -9944,6 +10178,12 @@ module rv_plic_reg_top (
   assign le2_le80_we = addr_hit[5] & reg_we & ~wr_err;
   assign le2_le80_wd = reg_wdata[16];
 
+  assign le2_le81_we = addr_hit[5] & reg_we & ~wr_err;
+  assign le2_le81_wd = reg_wdata[17];
+
+  assign le2_le82_we = addr_hit[5] & reg_we & ~wr_err;
+  assign le2_le82_wd = reg_wdata[18];
+
   assign prio0_we = addr_hit[6] & reg_we & ~wr_err;
   assign prio0_wd = reg_wdata[1:0];
 
@@ -10187,257 +10427,269 @@ module rv_plic_reg_top (
   assign prio80_we = addr_hit[86] & reg_we & ~wr_err;
   assign prio80_wd = reg_wdata[1:0];
 
-  assign ie00_e0_we = addr_hit[87] & reg_we & ~wr_err;
+  assign prio81_we = addr_hit[87] & reg_we & ~wr_err;
+  assign prio81_wd = reg_wdata[1:0];
+
+  assign prio82_we = addr_hit[88] & reg_we & ~wr_err;
+  assign prio82_wd = reg_wdata[1:0];
+
+  assign ie00_e0_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie00_e0_wd = reg_wdata[0];
 
-  assign ie00_e1_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie00_e1_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie00_e1_wd = reg_wdata[1];
 
-  assign ie00_e2_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie00_e2_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie00_e2_wd = reg_wdata[2];
 
-  assign ie00_e3_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie00_e3_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie00_e3_wd = reg_wdata[3];
 
-  assign ie00_e4_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie00_e4_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie00_e4_wd = reg_wdata[4];
 
-  assign ie00_e5_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie00_e5_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie00_e5_wd = reg_wdata[5];
 
-  assign ie00_e6_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie00_e6_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie00_e6_wd = reg_wdata[6];
 
-  assign ie00_e7_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie00_e7_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie00_e7_wd = reg_wdata[7];
 
-  assign ie00_e8_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie00_e8_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie00_e8_wd = reg_wdata[8];
 
-  assign ie00_e9_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie00_e9_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie00_e9_wd = reg_wdata[9];
 
-  assign ie00_e10_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie00_e10_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie00_e10_wd = reg_wdata[10];
 
-  assign ie00_e11_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie00_e11_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie00_e11_wd = reg_wdata[11];
 
-  assign ie00_e12_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie00_e12_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie00_e12_wd = reg_wdata[12];
 
-  assign ie00_e13_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie00_e13_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie00_e13_wd = reg_wdata[13];
 
-  assign ie00_e14_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie00_e14_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie00_e14_wd = reg_wdata[14];
 
-  assign ie00_e15_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie00_e15_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie00_e15_wd = reg_wdata[15];
 
-  assign ie00_e16_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie00_e16_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie00_e16_wd = reg_wdata[16];
 
-  assign ie00_e17_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie00_e17_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie00_e17_wd = reg_wdata[17];
 
-  assign ie00_e18_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie00_e18_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie00_e18_wd = reg_wdata[18];
 
-  assign ie00_e19_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie00_e19_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie00_e19_wd = reg_wdata[19];
 
-  assign ie00_e20_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie00_e20_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie00_e20_wd = reg_wdata[20];
 
-  assign ie00_e21_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie00_e21_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie00_e21_wd = reg_wdata[21];
 
-  assign ie00_e22_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie00_e22_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie00_e22_wd = reg_wdata[22];
 
-  assign ie00_e23_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie00_e23_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie00_e23_wd = reg_wdata[23];
 
-  assign ie00_e24_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie00_e24_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie00_e24_wd = reg_wdata[24];
 
-  assign ie00_e25_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie00_e25_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie00_e25_wd = reg_wdata[25];
 
-  assign ie00_e26_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie00_e26_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie00_e26_wd = reg_wdata[26];
 
-  assign ie00_e27_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie00_e27_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie00_e27_wd = reg_wdata[27];
 
-  assign ie00_e28_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie00_e28_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie00_e28_wd = reg_wdata[28];
 
-  assign ie00_e29_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie00_e29_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie00_e29_wd = reg_wdata[29];
 
-  assign ie00_e30_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie00_e30_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie00_e30_wd = reg_wdata[30];
 
-  assign ie00_e31_we = addr_hit[87] & reg_we & ~wr_err;
+  assign ie00_e31_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie00_e31_wd = reg_wdata[31];
 
-  assign ie01_e32_we = addr_hit[88] & reg_we & ~wr_err;
+  assign ie01_e32_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie01_e32_wd = reg_wdata[0];
 
-  assign ie01_e33_we = addr_hit[88] & reg_we & ~wr_err;
+  assign ie01_e33_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie01_e33_wd = reg_wdata[1];
 
-  assign ie01_e34_we = addr_hit[88] & reg_we & ~wr_err;
+  assign ie01_e34_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie01_e34_wd = reg_wdata[2];
 
-  assign ie01_e35_we = addr_hit[88] & reg_we & ~wr_err;
+  assign ie01_e35_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie01_e35_wd = reg_wdata[3];
 
-  assign ie01_e36_we = addr_hit[88] & reg_we & ~wr_err;
+  assign ie01_e36_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie01_e36_wd = reg_wdata[4];
 
-  assign ie01_e37_we = addr_hit[88] & reg_we & ~wr_err;
+  assign ie01_e37_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie01_e37_wd = reg_wdata[5];
 
-  assign ie01_e38_we = addr_hit[88] & reg_we & ~wr_err;
+  assign ie01_e38_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie01_e38_wd = reg_wdata[6];
 
-  assign ie01_e39_we = addr_hit[88] & reg_we & ~wr_err;
+  assign ie01_e39_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie01_e39_wd = reg_wdata[7];
 
-  assign ie01_e40_we = addr_hit[88] & reg_we & ~wr_err;
+  assign ie01_e40_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie01_e40_wd = reg_wdata[8];
 
-  assign ie01_e41_we = addr_hit[88] & reg_we & ~wr_err;
+  assign ie01_e41_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie01_e41_wd = reg_wdata[9];
 
-  assign ie01_e42_we = addr_hit[88] & reg_we & ~wr_err;
+  assign ie01_e42_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie01_e42_wd = reg_wdata[10];
 
-  assign ie01_e43_we = addr_hit[88] & reg_we & ~wr_err;
+  assign ie01_e43_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie01_e43_wd = reg_wdata[11];
 
-  assign ie01_e44_we = addr_hit[88] & reg_we & ~wr_err;
+  assign ie01_e44_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie01_e44_wd = reg_wdata[12];
 
-  assign ie01_e45_we = addr_hit[88] & reg_we & ~wr_err;
+  assign ie01_e45_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie01_e45_wd = reg_wdata[13];
 
-  assign ie01_e46_we = addr_hit[88] & reg_we & ~wr_err;
+  assign ie01_e46_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie01_e46_wd = reg_wdata[14];
 
-  assign ie01_e47_we = addr_hit[88] & reg_we & ~wr_err;
+  assign ie01_e47_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie01_e47_wd = reg_wdata[15];
 
-  assign ie01_e48_we = addr_hit[88] & reg_we & ~wr_err;
+  assign ie01_e48_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie01_e48_wd = reg_wdata[16];
 
-  assign ie01_e49_we = addr_hit[88] & reg_we & ~wr_err;
+  assign ie01_e49_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie01_e49_wd = reg_wdata[17];
 
-  assign ie01_e50_we = addr_hit[88] & reg_we & ~wr_err;
+  assign ie01_e50_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie01_e50_wd = reg_wdata[18];
 
-  assign ie01_e51_we = addr_hit[88] & reg_we & ~wr_err;
+  assign ie01_e51_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie01_e51_wd = reg_wdata[19];
 
-  assign ie01_e52_we = addr_hit[88] & reg_we & ~wr_err;
+  assign ie01_e52_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie01_e52_wd = reg_wdata[20];
 
-  assign ie01_e53_we = addr_hit[88] & reg_we & ~wr_err;
+  assign ie01_e53_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie01_e53_wd = reg_wdata[21];
 
-  assign ie01_e54_we = addr_hit[88] & reg_we & ~wr_err;
+  assign ie01_e54_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie01_e54_wd = reg_wdata[22];
 
-  assign ie01_e55_we = addr_hit[88] & reg_we & ~wr_err;
+  assign ie01_e55_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie01_e55_wd = reg_wdata[23];
 
-  assign ie01_e56_we = addr_hit[88] & reg_we & ~wr_err;
+  assign ie01_e56_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie01_e56_wd = reg_wdata[24];
 
-  assign ie01_e57_we = addr_hit[88] & reg_we & ~wr_err;
+  assign ie01_e57_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie01_e57_wd = reg_wdata[25];
 
-  assign ie01_e58_we = addr_hit[88] & reg_we & ~wr_err;
+  assign ie01_e58_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie01_e58_wd = reg_wdata[26];
 
-  assign ie01_e59_we = addr_hit[88] & reg_we & ~wr_err;
+  assign ie01_e59_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie01_e59_wd = reg_wdata[27];
 
-  assign ie01_e60_we = addr_hit[88] & reg_we & ~wr_err;
+  assign ie01_e60_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie01_e60_wd = reg_wdata[28];
 
-  assign ie01_e61_we = addr_hit[88] & reg_we & ~wr_err;
+  assign ie01_e61_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie01_e61_wd = reg_wdata[29];
 
-  assign ie01_e62_we = addr_hit[88] & reg_we & ~wr_err;
+  assign ie01_e62_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie01_e62_wd = reg_wdata[30];
 
-  assign ie01_e63_we = addr_hit[88] & reg_we & ~wr_err;
+  assign ie01_e63_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie01_e63_wd = reg_wdata[31];
 
-  assign ie02_e64_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie02_e64_we = addr_hit[91] & reg_we & ~wr_err;
   assign ie02_e64_wd = reg_wdata[0];
 
-  assign ie02_e65_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie02_e65_we = addr_hit[91] & reg_we & ~wr_err;
   assign ie02_e65_wd = reg_wdata[1];
 
-  assign ie02_e66_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie02_e66_we = addr_hit[91] & reg_we & ~wr_err;
   assign ie02_e66_wd = reg_wdata[2];
 
-  assign ie02_e67_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie02_e67_we = addr_hit[91] & reg_we & ~wr_err;
   assign ie02_e67_wd = reg_wdata[3];
 
-  assign ie02_e68_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie02_e68_we = addr_hit[91] & reg_we & ~wr_err;
   assign ie02_e68_wd = reg_wdata[4];
 
-  assign ie02_e69_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie02_e69_we = addr_hit[91] & reg_we & ~wr_err;
   assign ie02_e69_wd = reg_wdata[5];
 
-  assign ie02_e70_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie02_e70_we = addr_hit[91] & reg_we & ~wr_err;
   assign ie02_e70_wd = reg_wdata[6];
 
-  assign ie02_e71_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie02_e71_we = addr_hit[91] & reg_we & ~wr_err;
   assign ie02_e71_wd = reg_wdata[7];
 
-  assign ie02_e72_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie02_e72_we = addr_hit[91] & reg_we & ~wr_err;
   assign ie02_e72_wd = reg_wdata[8];
 
-  assign ie02_e73_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie02_e73_we = addr_hit[91] & reg_we & ~wr_err;
   assign ie02_e73_wd = reg_wdata[9];
 
-  assign ie02_e74_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie02_e74_we = addr_hit[91] & reg_we & ~wr_err;
   assign ie02_e74_wd = reg_wdata[10];
 
-  assign ie02_e75_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie02_e75_we = addr_hit[91] & reg_we & ~wr_err;
   assign ie02_e75_wd = reg_wdata[11];
 
-  assign ie02_e76_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie02_e76_we = addr_hit[91] & reg_we & ~wr_err;
   assign ie02_e76_wd = reg_wdata[12];
 
-  assign ie02_e77_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie02_e77_we = addr_hit[91] & reg_we & ~wr_err;
   assign ie02_e77_wd = reg_wdata[13];
 
-  assign ie02_e78_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie02_e78_we = addr_hit[91] & reg_we & ~wr_err;
   assign ie02_e78_wd = reg_wdata[14];
 
-  assign ie02_e79_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie02_e79_we = addr_hit[91] & reg_we & ~wr_err;
   assign ie02_e79_wd = reg_wdata[15];
 
-  assign ie02_e80_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie02_e80_we = addr_hit[91] & reg_we & ~wr_err;
   assign ie02_e80_wd = reg_wdata[16];
 
-  assign threshold0_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie02_e81_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie02_e81_wd = reg_wdata[17];
+
+  assign ie02_e82_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie02_e82_wd = reg_wdata[18];
+
+  assign threshold0_we = addr_hit[92] & reg_we & ~wr_err;
   assign threshold0_wd = reg_wdata[1:0];
 
-  assign cc0_we = addr_hit[91] & reg_we & ~wr_err;
+  assign cc0_we = addr_hit[93] & reg_we & ~wr_err;
   assign cc0_wd = reg_wdata[6:0];
-  assign cc0_re = addr_hit[91] && reg_re;
+  assign cc0_re = addr_hit[93] && reg_re;
 
-  assign msip0_we = addr_hit[92] & reg_we & ~wr_err;
+  assign msip0_we = addr_hit[94] & reg_we & ~wr_err;
   assign msip0_wd = reg_wdata[0];
 
   // Read data return
@@ -10532,6 +10784,8 @@ module rv_plic_reg_top (
         reg_rdata_next[14] = ip2_p78_qs;
         reg_rdata_next[15] = ip2_p79_qs;
         reg_rdata_next[16] = ip2_p80_qs;
+        reg_rdata_next[17] = ip2_p81_qs;
+        reg_rdata_next[18] = ip2_p82_qs;
       end
 
       addr_hit[3]: begin
@@ -10622,6 +10876,8 @@ module rv_plic_reg_top (
         reg_rdata_next[14] = le2_le78_qs;
         reg_rdata_next[15] = le2_le79_qs;
         reg_rdata_next[16] = le2_le80_qs;
+        reg_rdata_next[17] = le2_le81_qs;
+        reg_rdata_next[18] = le2_le82_qs;
       end
 
       addr_hit[6]: begin
@@ -10949,6 +11205,14 @@ module rv_plic_reg_top (
       end
 
       addr_hit[87]: begin
+        reg_rdata_next[1:0] = prio81_qs;
+      end
+
+      addr_hit[88]: begin
+        reg_rdata_next[1:0] = prio82_qs;
+      end
+
+      addr_hit[89]: begin
         reg_rdata_next[0] = ie00_e0_qs;
         reg_rdata_next[1] = ie00_e1_qs;
         reg_rdata_next[2] = ie00_e2_qs;
@@ -10983,7 +11247,7 @@ module rv_plic_reg_top (
         reg_rdata_next[31] = ie00_e31_qs;
       end
 
-      addr_hit[88]: begin
+      addr_hit[90]: begin
         reg_rdata_next[0] = ie01_e32_qs;
         reg_rdata_next[1] = ie01_e33_qs;
         reg_rdata_next[2] = ie01_e34_qs;
@@ -11018,7 +11282,7 @@ module rv_plic_reg_top (
         reg_rdata_next[31] = ie01_e63_qs;
       end
 
-      addr_hit[89]: begin
+      addr_hit[91]: begin
         reg_rdata_next[0] = ie02_e64_qs;
         reg_rdata_next[1] = ie02_e65_qs;
         reg_rdata_next[2] = ie02_e66_qs;
@@ -11036,17 +11300,19 @@ module rv_plic_reg_top (
         reg_rdata_next[14] = ie02_e78_qs;
         reg_rdata_next[15] = ie02_e79_qs;
         reg_rdata_next[16] = ie02_e80_qs;
-      end
-
-      addr_hit[90]: begin
-        reg_rdata_next[1:0] = threshold0_qs;
-      end
-
-      addr_hit[91]: begin
-        reg_rdata_next[6:0] = cc0_qs;
+        reg_rdata_next[17] = ie02_e81_qs;
+        reg_rdata_next[18] = ie02_e82_qs;
       end
 
       addr_hit[92]: begin
+        reg_rdata_next[1:0] = threshold0_qs;
+      end
+
+      addr_hit[93]: begin
+        reg_rdata_next[6:0] = cc0_qs;
+      end
+
+      addr_hit[94]: begin
         reg_rdata_next[0] = msip0_qs;
       end
 

--- a/hw/top_earlgrey/ip/xbar_main/data/autogen/xbar_main.gen.hjson
+++ b/hw/top_earlgrey/ip/xbar_main/data/autogen/xbar_main.gen.hjson
@@ -49,6 +49,7 @@
       padctrl
       alert_handler
       nmi_gen
+      otbn
     ]
     dm_sba:
     [
@@ -64,6 +65,7 @@
       padctrl
       alert_handler
       nmi_gen
+      otbn
     ]
   }
   nodes:
@@ -327,6 +329,23 @@
         {
           base_addr: 0x40140000
           size_byte: 0x1000
+        }
+      ]
+      xbar: false
+      pipeline: "true"
+    }
+    {
+      name: otbn
+      type: device
+      clock: clk_main_i
+      reset: rst_main_ni
+      pipeline_byp: "false"
+      inst_type: otbn
+      addr_range:
+      [
+        {
+          base_addr: 0x50000000
+          size_byte: 0x400000
         }
       ]
       xbar: false

--- a/hw/top_earlgrey/ip/xbar_main/dv/autogen/tb__xbar_connect.sv
+++ b/hw/top_earlgrey/ip/xbar_main/dv/autogen/tb__xbar_connect.sv
@@ -35,3 +35,4 @@ initial force dut.rst_fixed_ni = rst_n;
 `CONNECT_TL_DEVICE_IF(padctrl, dut, clk_main_i, rst_n)
 `CONNECT_TL_DEVICE_IF(alert_handler, dut, clk_main_i, rst_n)
 `CONNECT_TL_DEVICE_IF(nmi_gen, dut, clk_main_i, rst_n)
+`CONNECT_TL_DEVICE_IF(otbn, dut, clk_main_i, rst_n)

--- a/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_env_pkg__params.sv
+++ b/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_env_pkg__params.sv
@@ -49,6 +49,9 @@ tl_device_t xbar_devices[$] = '{
     }},
     '{"nmi_gen", '{
         '{32'h40140000, 32'h40140fff}
+    }},
+    '{"otbn", '{
+        '{32'h50000000, 32'h503fffff}
 }}};
 
   // List of Xbar hosts
@@ -72,7 +75,8 @@ tl_host_t xbar_hosts[$] = '{
         "pinmux",
         "padctrl",
         "alert_handler",
-        "nmi_gen"}}
+        "nmi_gen",
+        "otbn"}}
     ,
     '{"dm_sba", 2, '{
         "rom",
@@ -86,5 +90,6 @@ tl_host_t xbar_hosts[$] = '{
         "pinmux",
         "padctrl",
         "alert_handler",
-        "nmi_gen"}}
+        "nmi_gen",
+        "otbn"}}
 };

--- a/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_main_bind.sv
+++ b/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_main_bind.sv
@@ -104,5 +104,11 @@ module xbar_main_bind;
     .h2d    (tl_nmi_gen_o),
     .d2h    (tl_nmi_gen_i)
   );
+  bind xbar_main tlul_assert #(.EndpointType("Host")) tlul_assert_device_otbn (
+    .clk_i  (clk_main_i),
+    .rst_ni (rst_main_ni),
+    .h2d    (tl_otbn_o),
+    .d2h    (tl_otbn_i)
+  );
 
 endmodule

--- a/hw/top_earlgrey/ip/xbar_main/rtl/autogen/tl_main_pkg.sv
+++ b/hw/top_earlgrey/ip/xbar_main/rtl/autogen/tl_main_pkg.sv
@@ -25,6 +25,7 @@ package tl_main_pkg;
   localparam logic [31:0] ADDR_SPACE_PADCTRL       = 32'h 40160000;
   localparam logic [31:0] ADDR_SPACE_ALERT_HANDLER = 32'h 40130000;
   localparam logic [31:0] ADDR_SPACE_NMI_GEN       = 32'h 40140000;
+  localparam logic [31:0] ADDR_SPACE_OTBN          = 32'h 50000000;
 
   localparam logic [31:0] ADDR_MASK_ROM           = 32'h 00003fff;
   localparam logic [31:0] ADDR_MASK_DEBUG_MEM     = 32'h 00000fff;
@@ -45,9 +46,10 @@ package tl_main_pkg;
   localparam logic [31:0] ADDR_MASK_PADCTRL       = 32'h 00000fff;
   localparam logic [31:0] ADDR_MASK_ALERT_HANDLER = 32'h 00000fff;
   localparam logic [31:0] ADDR_MASK_NMI_GEN       = 32'h 00000fff;
+  localparam logic [31:0] ADDR_MASK_OTBN          = 32'h 003fffff;
 
   localparam int N_HOST   = 3;
-  localparam int N_DEVICE = 13;
+  localparam int N_DEVICE = 14;
 
   typedef enum int {
     TlRom = 0,
@@ -62,7 +64,8 @@ package tl_main_pkg;
     TlPinmux = 9,
     TlPadctrl = 10,
     TlAlertHandler = 11,
-    TlNmiGen = 12
+    TlNmiGen = 12,
+    TlOtbn = 13
   } tl_device_e;
 
   typedef enum int {

--- a/hw/top_earlgrey/ip/xbar_main/rtl/autogen/xbar_main.sv
+++ b/hw/top_earlgrey/ip/xbar_main/rtl/autogen/xbar_main.sv
@@ -7,71 +7,75 @@
 //
 // Interconnect
 // corei
-//   -> s1n_16
-//     -> sm1_17
-//       -> rom
+//   -> s1n_17
 //     -> sm1_18
-//       -> debug_mem
+//       -> rom
 //     -> sm1_19
-//       -> ram_main
+//       -> debug_mem
 //     -> sm1_20
+//       -> ram_main
+//     -> sm1_21
 //       -> eflash
 // cored
-//   -> s1n_21
-//     -> sm1_17
-//       -> rom
+//   -> s1n_22
 //     -> sm1_18
-//       -> debug_mem
-//     -> sm1_19
-//       -> ram_main
-//     -> sm1_20
-//       -> eflash
-//     -> sm1_23
-//       -> asf_22
-//         -> peri
-//     -> sm1_24
-//       -> flash_ctrl
-//     -> sm1_25
-//       -> aes
-//     -> sm1_26
-//       -> hmac
-//     -> sm1_27
-//       -> rv_plic
-//     -> sm1_28
-//       -> pinmux
-//     -> sm1_29
-//       -> padctrl
-//     -> sm1_30
-//       -> alert_handler
-//     -> sm1_31
-//       -> nmi_gen
-// dm_sba
-//   -> s1n_32
-//     -> sm1_17
 //       -> rom
 //     -> sm1_19
-//       -> ram_main
+//       -> debug_mem
 //     -> sm1_20
+//       -> ram_main
+//     -> sm1_21
 //       -> eflash
-//     -> sm1_23
-//       -> asf_22
-//         -> peri
 //     -> sm1_24
-//       -> flash_ctrl
+//       -> asf_23
+//         -> peri
 //     -> sm1_25
-//       -> aes
+//       -> flash_ctrl
 //     -> sm1_26
-//       -> hmac
+//       -> aes
 //     -> sm1_27
-//       -> rv_plic
+//       -> hmac
 //     -> sm1_28
-//       -> pinmux
+//       -> rv_plic
 //     -> sm1_29
-//       -> padctrl
+//       -> pinmux
 //     -> sm1_30
-//       -> alert_handler
+//       -> padctrl
 //     -> sm1_31
+//       -> alert_handler
+//     -> sm1_32
 //       -> nmi_gen
+//     -> sm1_33
+//       -> otbn
+// dm_sba
+//   -> s1n_34
+//     -> sm1_18
+//       -> rom
+//     -> sm1_20
+//       -> ram_main
+//     -> sm1_21
+//       -> eflash
+//     -> sm1_24
+//       -> asf_23
+//         -> peri
+//     -> sm1_25
+//       -> flash_ctrl
+//     -> sm1_26
+//       -> aes
+//     -> sm1_27
+//       -> hmac
+//     -> sm1_28
+//       -> rv_plic
+//     -> sm1_29
+//       -> pinmux
+//     -> sm1_30
+//       -> padctrl
+//     -> sm1_31
+//       -> alert_handler
+//     -> sm1_32
+//       -> nmi_gen
+//     -> sm1_33
+//       -> otbn
 
 module xbar_main (
   input clk_main_i,
@@ -114,6 +118,8 @@ module xbar_main (
   input  tlul_pkg::tl_d2h_t tl_alert_handler_i,
   output tlul_pkg::tl_h2d_t tl_nmi_gen_o,
   input  tlul_pkg::tl_d2h_t tl_nmi_gen_i,
+  output tlul_pkg::tl_h2d_t tl_otbn_o,
+  input  tlul_pkg::tl_d2h_t tl_otbn_i,
 
   input scanmode_i
 );
@@ -126,33 +132,26 @@ module xbar_main (
   logic unused_scanmode;
   assign unused_scanmode = scanmode_i;
 
-  tl_h2d_t tl_s1n_16_us_h2d ;
-  tl_d2h_t tl_s1n_16_us_d2h ;
+  tl_h2d_t tl_s1n_17_us_h2d ;
+  tl_d2h_t tl_s1n_17_us_d2h ;
 
 
-  tl_h2d_t tl_s1n_16_ds_h2d [4];
-  tl_d2h_t tl_s1n_16_ds_d2h [4];
+  tl_h2d_t tl_s1n_17_ds_h2d [4];
+  tl_d2h_t tl_s1n_17_ds_d2h [4];
 
   // Create steering signal
-  logic [2:0] dev_sel_s1n_16;
+  logic [2:0] dev_sel_s1n_17;
 
 
-  tl_h2d_t tl_sm1_17_us_h2d [3];
-  tl_d2h_t tl_sm1_17_us_d2h [3];
-
-  tl_h2d_t tl_sm1_17_ds_h2d ;
-  tl_d2h_t tl_sm1_17_ds_d2h ;
-
-
-  tl_h2d_t tl_sm1_18_us_h2d [2];
-  tl_d2h_t tl_sm1_18_us_d2h [2];
+  tl_h2d_t tl_sm1_18_us_h2d [3];
+  tl_d2h_t tl_sm1_18_us_d2h [3];
 
   tl_h2d_t tl_sm1_18_ds_h2d ;
   tl_d2h_t tl_sm1_18_ds_d2h ;
 
 
-  tl_h2d_t tl_sm1_19_us_h2d [3];
-  tl_d2h_t tl_sm1_19_us_d2h [3];
+  tl_h2d_t tl_sm1_19_us_h2d [2];
+  tl_d2h_t tl_sm1_19_us_d2h [2];
 
   tl_h2d_t tl_sm1_19_ds_h2d ;
   tl_d2h_t tl_sm1_19_ds_d2h ;
@@ -164,27 +163,27 @@ module xbar_main (
   tl_h2d_t tl_sm1_20_ds_h2d ;
   tl_d2h_t tl_sm1_20_ds_d2h ;
 
-  tl_h2d_t tl_s1n_21_us_h2d ;
-  tl_d2h_t tl_s1n_21_us_d2h ;
+
+  tl_h2d_t tl_sm1_21_us_h2d [3];
+  tl_d2h_t tl_sm1_21_us_d2h [3];
+
+  tl_h2d_t tl_sm1_21_ds_h2d ;
+  tl_d2h_t tl_sm1_21_ds_d2h ;
+
+  tl_h2d_t tl_s1n_22_us_h2d ;
+  tl_d2h_t tl_s1n_22_us_d2h ;
 
 
-  tl_h2d_t tl_s1n_21_ds_h2d [13];
-  tl_d2h_t tl_s1n_21_ds_d2h [13];
+  tl_h2d_t tl_s1n_22_ds_h2d [14];
+  tl_d2h_t tl_s1n_22_ds_d2h [14];
 
   // Create steering signal
-  logic [3:0] dev_sel_s1n_21;
+  logic [3:0] dev_sel_s1n_22;
 
-  tl_h2d_t tl_asf_22_us_h2d ;
-  tl_d2h_t tl_asf_22_us_d2h ;
-  tl_h2d_t tl_asf_22_ds_h2d ;
-  tl_d2h_t tl_asf_22_ds_d2h ;
-
-
-  tl_h2d_t tl_sm1_23_us_h2d [2];
-  tl_d2h_t tl_sm1_23_us_d2h [2];
-
-  tl_h2d_t tl_sm1_23_ds_h2d ;
-  tl_d2h_t tl_sm1_23_ds_d2h ;
+  tl_h2d_t tl_asf_23_us_h2d ;
+  tl_d2h_t tl_asf_23_us_d2h ;
+  tl_h2d_t tl_asf_23_ds_h2d ;
+  tl_d2h_t tl_asf_23_ds_d2h ;
 
 
   tl_h2d_t tl_sm1_24_us_h2d [2];
@@ -242,275 +241,304 @@ module xbar_main (
   tl_h2d_t tl_sm1_31_ds_h2d ;
   tl_d2h_t tl_sm1_31_ds_d2h ;
 
-  tl_h2d_t tl_s1n_32_us_h2d ;
-  tl_d2h_t tl_s1n_32_us_d2h ;
+
+  tl_h2d_t tl_sm1_32_us_h2d [2];
+  tl_d2h_t tl_sm1_32_us_d2h [2];
+
+  tl_h2d_t tl_sm1_32_ds_h2d ;
+  tl_d2h_t tl_sm1_32_ds_d2h ;
 
 
-  tl_h2d_t tl_s1n_32_ds_h2d [12];
-  tl_d2h_t tl_s1n_32_ds_d2h [12];
+  tl_h2d_t tl_sm1_33_us_h2d [2];
+  tl_d2h_t tl_sm1_33_us_d2h [2];
+
+  tl_h2d_t tl_sm1_33_ds_h2d ;
+  tl_d2h_t tl_sm1_33_ds_d2h ;
+
+  tl_h2d_t tl_s1n_34_us_h2d ;
+  tl_d2h_t tl_s1n_34_us_d2h ;
+
+
+  tl_h2d_t tl_s1n_34_ds_h2d [13];
+  tl_d2h_t tl_s1n_34_ds_d2h [13];
 
   // Create steering signal
-  logic [3:0] dev_sel_s1n_32;
+  logic [3:0] dev_sel_s1n_34;
 
 
 
-  assign tl_sm1_17_us_h2d[0] = tl_s1n_16_ds_h2d[0];
-  assign tl_s1n_16_ds_d2h[0] = tl_sm1_17_us_d2h[0];
+  assign tl_sm1_18_us_h2d[0] = tl_s1n_17_ds_h2d[0];
+  assign tl_s1n_17_ds_d2h[0] = tl_sm1_18_us_d2h[0];
 
-  assign tl_sm1_18_us_h2d[0] = tl_s1n_16_ds_h2d[1];
-  assign tl_s1n_16_ds_d2h[1] = tl_sm1_18_us_d2h[0];
+  assign tl_sm1_19_us_h2d[0] = tl_s1n_17_ds_h2d[1];
+  assign tl_s1n_17_ds_d2h[1] = tl_sm1_19_us_d2h[0];
 
-  assign tl_sm1_19_us_h2d[0] = tl_s1n_16_ds_h2d[2];
-  assign tl_s1n_16_ds_d2h[2] = tl_sm1_19_us_d2h[0];
+  assign tl_sm1_20_us_h2d[0] = tl_s1n_17_ds_h2d[2];
+  assign tl_s1n_17_ds_d2h[2] = tl_sm1_20_us_d2h[0];
 
-  assign tl_sm1_20_us_h2d[0] = tl_s1n_16_ds_h2d[3];
-  assign tl_s1n_16_ds_d2h[3] = tl_sm1_20_us_d2h[0];
+  assign tl_sm1_21_us_h2d[0] = tl_s1n_17_ds_h2d[3];
+  assign tl_s1n_17_ds_d2h[3] = tl_sm1_21_us_d2h[0];
 
-  assign tl_sm1_17_us_h2d[1] = tl_s1n_21_ds_h2d[0];
-  assign tl_s1n_21_ds_d2h[0] = tl_sm1_17_us_d2h[1];
+  assign tl_sm1_18_us_h2d[1] = tl_s1n_22_ds_h2d[0];
+  assign tl_s1n_22_ds_d2h[0] = tl_sm1_18_us_d2h[1];
 
-  assign tl_sm1_18_us_h2d[1] = tl_s1n_21_ds_h2d[1];
-  assign tl_s1n_21_ds_d2h[1] = tl_sm1_18_us_d2h[1];
+  assign tl_sm1_19_us_h2d[1] = tl_s1n_22_ds_h2d[1];
+  assign tl_s1n_22_ds_d2h[1] = tl_sm1_19_us_d2h[1];
 
-  assign tl_sm1_19_us_h2d[1] = tl_s1n_21_ds_h2d[2];
-  assign tl_s1n_21_ds_d2h[2] = tl_sm1_19_us_d2h[1];
+  assign tl_sm1_20_us_h2d[1] = tl_s1n_22_ds_h2d[2];
+  assign tl_s1n_22_ds_d2h[2] = tl_sm1_20_us_d2h[1];
 
-  assign tl_sm1_20_us_h2d[1] = tl_s1n_21_ds_h2d[3];
-  assign tl_s1n_21_ds_d2h[3] = tl_sm1_20_us_d2h[1];
+  assign tl_sm1_21_us_h2d[1] = tl_s1n_22_ds_h2d[3];
+  assign tl_s1n_22_ds_d2h[3] = tl_sm1_21_us_d2h[1];
 
-  assign tl_sm1_23_us_h2d[0] = tl_s1n_21_ds_h2d[4];
-  assign tl_s1n_21_ds_d2h[4] = tl_sm1_23_us_d2h[0];
+  assign tl_sm1_24_us_h2d[0] = tl_s1n_22_ds_h2d[4];
+  assign tl_s1n_22_ds_d2h[4] = tl_sm1_24_us_d2h[0];
 
-  assign tl_sm1_24_us_h2d[0] = tl_s1n_21_ds_h2d[5];
-  assign tl_s1n_21_ds_d2h[5] = tl_sm1_24_us_d2h[0];
+  assign tl_sm1_25_us_h2d[0] = tl_s1n_22_ds_h2d[5];
+  assign tl_s1n_22_ds_d2h[5] = tl_sm1_25_us_d2h[0];
 
-  assign tl_sm1_25_us_h2d[0] = tl_s1n_21_ds_h2d[6];
-  assign tl_s1n_21_ds_d2h[6] = tl_sm1_25_us_d2h[0];
+  assign tl_sm1_26_us_h2d[0] = tl_s1n_22_ds_h2d[6];
+  assign tl_s1n_22_ds_d2h[6] = tl_sm1_26_us_d2h[0];
 
-  assign tl_sm1_26_us_h2d[0] = tl_s1n_21_ds_h2d[7];
-  assign tl_s1n_21_ds_d2h[7] = tl_sm1_26_us_d2h[0];
+  assign tl_sm1_27_us_h2d[0] = tl_s1n_22_ds_h2d[7];
+  assign tl_s1n_22_ds_d2h[7] = tl_sm1_27_us_d2h[0];
 
-  assign tl_sm1_27_us_h2d[0] = tl_s1n_21_ds_h2d[8];
-  assign tl_s1n_21_ds_d2h[8] = tl_sm1_27_us_d2h[0];
+  assign tl_sm1_28_us_h2d[0] = tl_s1n_22_ds_h2d[8];
+  assign tl_s1n_22_ds_d2h[8] = tl_sm1_28_us_d2h[0];
 
-  assign tl_sm1_28_us_h2d[0] = tl_s1n_21_ds_h2d[9];
-  assign tl_s1n_21_ds_d2h[9] = tl_sm1_28_us_d2h[0];
+  assign tl_sm1_29_us_h2d[0] = tl_s1n_22_ds_h2d[9];
+  assign tl_s1n_22_ds_d2h[9] = tl_sm1_29_us_d2h[0];
 
-  assign tl_sm1_29_us_h2d[0] = tl_s1n_21_ds_h2d[10];
-  assign tl_s1n_21_ds_d2h[10] = tl_sm1_29_us_d2h[0];
+  assign tl_sm1_30_us_h2d[0] = tl_s1n_22_ds_h2d[10];
+  assign tl_s1n_22_ds_d2h[10] = tl_sm1_30_us_d2h[0];
 
-  assign tl_sm1_30_us_h2d[0] = tl_s1n_21_ds_h2d[11];
-  assign tl_s1n_21_ds_d2h[11] = tl_sm1_30_us_d2h[0];
+  assign tl_sm1_31_us_h2d[0] = tl_s1n_22_ds_h2d[11];
+  assign tl_s1n_22_ds_d2h[11] = tl_sm1_31_us_d2h[0];
 
-  assign tl_sm1_31_us_h2d[0] = tl_s1n_21_ds_h2d[12];
-  assign tl_s1n_21_ds_d2h[12] = tl_sm1_31_us_d2h[0];
+  assign tl_sm1_32_us_h2d[0] = tl_s1n_22_ds_h2d[12];
+  assign tl_s1n_22_ds_d2h[12] = tl_sm1_32_us_d2h[0];
 
-  assign tl_sm1_17_us_h2d[2] = tl_s1n_32_ds_h2d[0];
-  assign tl_s1n_32_ds_d2h[0] = tl_sm1_17_us_d2h[2];
+  assign tl_sm1_33_us_h2d[0] = tl_s1n_22_ds_h2d[13];
+  assign tl_s1n_22_ds_d2h[13] = tl_sm1_33_us_d2h[0];
 
-  assign tl_sm1_19_us_h2d[2] = tl_s1n_32_ds_h2d[1];
-  assign tl_s1n_32_ds_d2h[1] = tl_sm1_19_us_d2h[2];
+  assign tl_sm1_18_us_h2d[2] = tl_s1n_34_ds_h2d[0];
+  assign tl_s1n_34_ds_d2h[0] = tl_sm1_18_us_d2h[2];
 
-  assign tl_sm1_20_us_h2d[2] = tl_s1n_32_ds_h2d[2];
-  assign tl_s1n_32_ds_d2h[2] = tl_sm1_20_us_d2h[2];
+  assign tl_sm1_20_us_h2d[2] = tl_s1n_34_ds_h2d[1];
+  assign tl_s1n_34_ds_d2h[1] = tl_sm1_20_us_d2h[2];
 
-  assign tl_sm1_23_us_h2d[1] = tl_s1n_32_ds_h2d[3];
-  assign tl_s1n_32_ds_d2h[3] = tl_sm1_23_us_d2h[1];
+  assign tl_sm1_21_us_h2d[2] = tl_s1n_34_ds_h2d[2];
+  assign tl_s1n_34_ds_d2h[2] = tl_sm1_21_us_d2h[2];
 
-  assign tl_sm1_24_us_h2d[1] = tl_s1n_32_ds_h2d[4];
-  assign tl_s1n_32_ds_d2h[4] = tl_sm1_24_us_d2h[1];
+  assign tl_sm1_24_us_h2d[1] = tl_s1n_34_ds_h2d[3];
+  assign tl_s1n_34_ds_d2h[3] = tl_sm1_24_us_d2h[1];
 
-  assign tl_sm1_25_us_h2d[1] = tl_s1n_32_ds_h2d[5];
-  assign tl_s1n_32_ds_d2h[5] = tl_sm1_25_us_d2h[1];
+  assign tl_sm1_25_us_h2d[1] = tl_s1n_34_ds_h2d[4];
+  assign tl_s1n_34_ds_d2h[4] = tl_sm1_25_us_d2h[1];
 
-  assign tl_sm1_26_us_h2d[1] = tl_s1n_32_ds_h2d[6];
-  assign tl_s1n_32_ds_d2h[6] = tl_sm1_26_us_d2h[1];
+  assign tl_sm1_26_us_h2d[1] = tl_s1n_34_ds_h2d[5];
+  assign tl_s1n_34_ds_d2h[5] = tl_sm1_26_us_d2h[1];
 
-  assign tl_sm1_27_us_h2d[1] = tl_s1n_32_ds_h2d[7];
-  assign tl_s1n_32_ds_d2h[7] = tl_sm1_27_us_d2h[1];
+  assign tl_sm1_27_us_h2d[1] = tl_s1n_34_ds_h2d[6];
+  assign tl_s1n_34_ds_d2h[6] = tl_sm1_27_us_d2h[1];
 
-  assign tl_sm1_28_us_h2d[1] = tl_s1n_32_ds_h2d[8];
-  assign tl_s1n_32_ds_d2h[8] = tl_sm1_28_us_d2h[1];
+  assign tl_sm1_28_us_h2d[1] = tl_s1n_34_ds_h2d[7];
+  assign tl_s1n_34_ds_d2h[7] = tl_sm1_28_us_d2h[1];
 
-  assign tl_sm1_29_us_h2d[1] = tl_s1n_32_ds_h2d[9];
-  assign tl_s1n_32_ds_d2h[9] = tl_sm1_29_us_d2h[1];
+  assign tl_sm1_29_us_h2d[1] = tl_s1n_34_ds_h2d[8];
+  assign tl_s1n_34_ds_d2h[8] = tl_sm1_29_us_d2h[1];
 
-  assign tl_sm1_30_us_h2d[1] = tl_s1n_32_ds_h2d[10];
-  assign tl_s1n_32_ds_d2h[10] = tl_sm1_30_us_d2h[1];
+  assign tl_sm1_30_us_h2d[1] = tl_s1n_34_ds_h2d[9];
+  assign tl_s1n_34_ds_d2h[9] = tl_sm1_30_us_d2h[1];
 
-  assign tl_sm1_31_us_h2d[1] = tl_s1n_32_ds_h2d[11];
-  assign tl_s1n_32_ds_d2h[11] = tl_sm1_31_us_d2h[1];
+  assign tl_sm1_31_us_h2d[1] = tl_s1n_34_ds_h2d[10];
+  assign tl_s1n_34_ds_d2h[10] = tl_sm1_31_us_d2h[1];
 
-  assign tl_s1n_16_us_h2d = tl_corei_i;
-  assign tl_corei_o = tl_s1n_16_us_d2h;
+  assign tl_sm1_32_us_h2d[1] = tl_s1n_34_ds_h2d[11];
+  assign tl_s1n_34_ds_d2h[11] = tl_sm1_32_us_d2h[1];
 
-  assign tl_rom_o = tl_sm1_17_ds_h2d;
-  assign tl_sm1_17_ds_d2h = tl_rom_i;
+  assign tl_sm1_33_us_h2d[1] = tl_s1n_34_ds_h2d[12];
+  assign tl_s1n_34_ds_d2h[12] = tl_sm1_33_us_d2h[1];
 
-  assign tl_debug_mem_o = tl_sm1_18_ds_h2d;
-  assign tl_sm1_18_ds_d2h = tl_debug_mem_i;
+  assign tl_s1n_17_us_h2d = tl_corei_i;
+  assign tl_corei_o = tl_s1n_17_us_d2h;
 
-  assign tl_ram_main_o = tl_sm1_19_ds_h2d;
-  assign tl_sm1_19_ds_d2h = tl_ram_main_i;
+  assign tl_rom_o = tl_sm1_18_ds_h2d;
+  assign tl_sm1_18_ds_d2h = tl_rom_i;
 
-  assign tl_eflash_o = tl_sm1_20_ds_h2d;
-  assign tl_sm1_20_ds_d2h = tl_eflash_i;
+  assign tl_debug_mem_o = tl_sm1_19_ds_h2d;
+  assign tl_sm1_19_ds_d2h = tl_debug_mem_i;
 
-  assign tl_s1n_21_us_h2d = tl_cored_i;
-  assign tl_cored_o = tl_s1n_21_us_d2h;
+  assign tl_ram_main_o = tl_sm1_20_ds_h2d;
+  assign tl_sm1_20_ds_d2h = tl_ram_main_i;
 
-  assign tl_peri_o = tl_asf_22_ds_h2d;
-  assign tl_asf_22_ds_d2h = tl_peri_i;
+  assign tl_eflash_o = tl_sm1_21_ds_h2d;
+  assign tl_sm1_21_ds_d2h = tl_eflash_i;
 
-  assign tl_asf_22_us_h2d = tl_sm1_23_ds_h2d;
-  assign tl_sm1_23_ds_d2h = tl_asf_22_us_d2h;
+  assign tl_s1n_22_us_h2d = tl_cored_i;
+  assign tl_cored_o = tl_s1n_22_us_d2h;
 
-  assign tl_flash_ctrl_o = tl_sm1_24_ds_h2d;
-  assign tl_sm1_24_ds_d2h = tl_flash_ctrl_i;
+  assign tl_peri_o = tl_asf_23_ds_h2d;
+  assign tl_asf_23_ds_d2h = tl_peri_i;
 
-  assign tl_aes_o = tl_sm1_25_ds_h2d;
-  assign tl_sm1_25_ds_d2h = tl_aes_i;
+  assign tl_asf_23_us_h2d = tl_sm1_24_ds_h2d;
+  assign tl_sm1_24_ds_d2h = tl_asf_23_us_d2h;
 
-  assign tl_hmac_o = tl_sm1_26_ds_h2d;
-  assign tl_sm1_26_ds_d2h = tl_hmac_i;
+  assign tl_flash_ctrl_o = tl_sm1_25_ds_h2d;
+  assign tl_sm1_25_ds_d2h = tl_flash_ctrl_i;
 
-  assign tl_rv_plic_o = tl_sm1_27_ds_h2d;
-  assign tl_sm1_27_ds_d2h = tl_rv_plic_i;
+  assign tl_aes_o = tl_sm1_26_ds_h2d;
+  assign tl_sm1_26_ds_d2h = tl_aes_i;
 
-  assign tl_pinmux_o = tl_sm1_28_ds_h2d;
-  assign tl_sm1_28_ds_d2h = tl_pinmux_i;
+  assign tl_hmac_o = tl_sm1_27_ds_h2d;
+  assign tl_sm1_27_ds_d2h = tl_hmac_i;
 
-  assign tl_padctrl_o = tl_sm1_29_ds_h2d;
-  assign tl_sm1_29_ds_d2h = tl_padctrl_i;
+  assign tl_rv_plic_o = tl_sm1_28_ds_h2d;
+  assign tl_sm1_28_ds_d2h = tl_rv_plic_i;
 
-  assign tl_alert_handler_o = tl_sm1_30_ds_h2d;
-  assign tl_sm1_30_ds_d2h = tl_alert_handler_i;
+  assign tl_pinmux_o = tl_sm1_29_ds_h2d;
+  assign tl_sm1_29_ds_d2h = tl_pinmux_i;
 
-  assign tl_nmi_gen_o = tl_sm1_31_ds_h2d;
-  assign tl_sm1_31_ds_d2h = tl_nmi_gen_i;
+  assign tl_padctrl_o = tl_sm1_30_ds_h2d;
+  assign tl_sm1_30_ds_d2h = tl_padctrl_i;
 
-  assign tl_s1n_32_us_h2d = tl_dm_sba_i;
-  assign tl_dm_sba_o = tl_s1n_32_us_d2h;
+  assign tl_alert_handler_o = tl_sm1_31_ds_h2d;
+  assign tl_sm1_31_ds_d2h = tl_alert_handler_i;
+
+  assign tl_nmi_gen_o = tl_sm1_32_ds_h2d;
+  assign tl_sm1_32_ds_d2h = tl_nmi_gen_i;
+
+  assign tl_otbn_o = tl_sm1_33_ds_h2d;
+  assign tl_sm1_33_ds_d2h = tl_otbn_i;
+
+  assign tl_s1n_34_us_h2d = tl_dm_sba_i;
+  assign tl_dm_sba_o = tl_s1n_34_us_d2h;
 
   always_comb begin
     // default steering to generate error response if address is not within the range
-    dev_sel_s1n_16 = 3'd4;
-    if ((tl_s1n_16_us_h2d.a_address & ~(ADDR_MASK_ROM)) == ADDR_SPACE_ROM) begin
-      dev_sel_s1n_16 = 3'd0;
+    dev_sel_s1n_17 = 3'd4;
+    if ((tl_s1n_17_us_h2d.a_address & ~(ADDR_MASK_ROM)) == ADDR_SPACE_ROM) begin
+      dev_sel_s1n_17 = 3'd0;
 
-    end else if ((tl_s1n_16_us_h2d.a_address & ~(ADDR_MASK_DEBUG_MEM)) == ADDR_SPACE_DEBUG_MEM) begin
-      dev_sel_s1n_16 = 3'd1;
+    end else if ((tl_s1n_17_us_h2d.a_address & ~(ADDR_MASK_DEBUG_MEM)) == ADDR_SPACE_DEBUG_MEM) begin
+      dev_sel_s1n_17 = 3'd1;
 
-    end else if ((tl_s1n_16_us_h2d.a_address & ~(ADDR_MASK_RAM_MAIN)) == ADDR_SPACE_RAM_MAIN) begin
-      dev_sel_s1n_16 = 3'd2;
+    end else if ((tl_s1n_17_us_h2d.a_address & ~(ADDR_MASK_RAM_MAIN)) == ADDR_SPACE_RAM_MAIN) begin
+      dev_sel_s1n_17 = 3'd2;
 
-    end else if ((tl_s1n_16_us_h2d.a_address & ~(ADDR_MASK_EFLASH)) == ADDR_SPACE_EFLASH) begin
-      dev_sel_s1n_16 = 3'd3;
+    end else if ((tl_s1n_17_us_h2d.a_address & ~(ADDR_MASK_EFLASH)) == ADDR_SPACE_EFLASH) begin
+      dev_sel_s1n_17 = 3'd3;
 end
   end
 
   always_comb begin
     // default steering to generate error response if address is not within the range
-    dev_sel_s1n_21 = 4'd13;
-    if ((tl_s1n_21_us_h2d.a_address & ~(ADDR_MASK_ROM)) == ADDR_SPACE_ROM) begin
-      dev_sel_s1n_21 = 4'd0;
+    dev_sel_s1n_22 = 4'd14;
+    if ((tl_s1n_22_us_h2d.a_address & ~(ADDR_MASK_ROM)) == ADDR_SPACE_ROM) begin
+      dev_sel_s1n_22 = 4'd0;
 
-    end else if ((tl_s1n_21_us_h2d.a_address & ~(ADDR_MASK_DEBUG_MEM)) == ADDR_SPACE_DEBUG_MEM) begin
-      dev_sel_s1n_21 = 4'd1;
+    end else if ((tl_s1n_22_us_h2d.a_address & ~(ADDR_MASK_DEBUG_MEM)) == ADDR_SPACE_DEBUG_MEM) begin
+      dev_sel_s1n_22 = 4'd1;
 
-    end else if ((tl_s1n_21_us_h2d.a_address & ~(ADDR_MASK_RAM_MAIN)) == ADDR_SPACE_RAM_MAIN) begin
-      dev_sel_s1n_21 = 4'd2;
+    end else if ((tl_s1n_22_us_h2d.a_address & ~(ADDR_MASK_RAM_MAIN)) == ADDR_SPACE_RAM_MAIN) begin
+      dev_sel_s1n_22 = 4'd2;
 
-    end else if ((tl_s1n_21_us_h2d.a_address & ~(ADDR_MASK_EFLASH)) == ADDR_SPACE_EFLASH) begin
-      dev_sel_s1n_21 = 4'd3;
+    end else if ((tl_s1n_22_us_h2d.a_address & ~(ADDR_MASK_EFLASH)) == ADDR_SPACE_EFLASH) begin
+      dev_sel_s1n_22 = 4'd3;
 
     end else if (
-      ((tl_s1n_21_us_h2d.a_address & ~(ADDR_MASK_PERI[0])) == ADDR_SPACE_PERI[0]) ||
-      ((tl_s1n_21_us_h2d.a_address <= (ADDR_MASK_PERI[1] + ADDR_SPACE_PERI[1])) &&
-       (tl_s1n_21_us_h2d.a_address >= ADDR_SPACE_PERI[1])) ||
-      ((tl_s1n_21_us_h2d.a_address <= (ADDR_MASK_PERI[2] + ADDR_SPACE_PERI[2])) &&
-       (tl_s1n_21_us_h2d.a_address >= ADDR_SPACE_PERI[2])) ||
-      ((tl_s1n_21_us_h2d.a_address <= (ADDR_MASK_PERI[3] + ADDR_SPACE_PERI[3])) &&
-       (tl_s1n_21_us_h2d.a_address >= ADDR_SPACE_PERI[3])) ||
-      ((tl_s1n_21_us_h2d.a_address <= (ADDR_MASK_PERI[4] + ADDR_SPACE_PERI[4])) &&
-       (tl_s1n_21_us_h2d.a_address >= ADDR_SPACE_PERI[4]))
+      ((tl_s1n_22_us_h2d.a_address & ~(ADDR_MASK_PERI[0])) == ADDR_SPACE_PERI[0]) ||
+      ((tl_s1n_22_us_h2d.a_address <= (ADDR_MASK_PERI[1] + ADDR_SPACE_PERI[1])) &&
+       (tl_s1n_22_us_h2d.a_address >= ADDR_SPACE_PERI[1])) ||
+      ((tl_s1n_22_us_h2d.a_address <= (ADDR_MASK_PERI[2] + ADDR_SPACE_PERI[2])) &&
+       (tl_s1n_22_us_h2d.a_address >= ADDR_SPACE_PERI[2])) ||
+      ((tl_s1n_22_us_h2d.a_address <= (ADDR_MASK_PERI[3] + ADDR_SPACE_PERI[3])) &&
+       (tl_s1n_22_us_h2d.a_address >= ADDR_SPACE_PERI[3])) ||
+      ((tl_s1n_22_us_h2d.a_address <= (ADDR_MASK_PERI[4] + ADDR_SPACE_PERI[4])) &&
+       (tl_s1n_22_us_h2d.a_address >= ADDR_SPACE_PERI[4]))
     ) begin
-      dev_sel_s1n_21 = 4'd4;
+      dev_sel_s1n_22 = 4'd4;
 
-    end else if ((tl_s1n_21_us_h2d.a_address & ~(ADDR_MASK_FLASH_CTRL)) == ADDR_SPACE_FLASH_CTRL) begin
-      dev_sel_s1n_21 = 4'd5;
+    end else if ((tl_s1n_22_us_h2d.a_address & ~(ADDR_MASK_FLASH_CTRL)) == ADDR_SPACE_FLASH_CTRL) begin
+      dev_sel_s1n_22 = 4'd5;
 
-    end else if ((tl_s1n_21_us_h2d.a_address & ~(ADDR_MASK_AES)) == ADDR_SPACE_AES) begin
-      dev_sel_s1n_21 = 4'd6;
+    end else if ((tl_s1n_22_us_h2d.a_address & ~(ADDR_MASK_AES)) == ADDR_SPACE_AES) begin
+      dev_sel_s1n_22 = 4'd6;
 
-    end else if ((tl_s1n_21_us_h2d.a_address & ~(ADDR_MASK_HMAC)) == ADDR_SPACE_HMAC) begin
-      dev_sel_s1n_21 = 4'd7;
+    end else if ((tl_s1n_22_us_h2d.a_address & ~(ADDR_MASK_HMAC)) == ADDR_SPACE_HMAC) begin
+      dev_sel_s1n_22 = 4'd7;
 
-    end else if ((tl_s1n_21_us_h2d.a_address & ~(ADDR_MASK_RV_PLIC)) == ADDR_SPACE_RV_PLIC) begin
-      dev_sel_s1n_21 = 4'd8;
+    end else if ((tl_s1n_22_us_h2d.a_address & ~(ADDR_MASK_RV_PLIC)) == ADDR_SPACE_RV_PLIC) begin
+      dev_sel_s1n_22 = 4'd8;
 
-    end else if ((tl_s1n_21_us_h2d.a_address & ~(ADDR_MASK_PINMUX)) == ADDR_SPACE_PINMUX) begin
-      dev_sel_s1n_21 = 4'd9;
+    end else if ((tl_s1n_22_us_h2d.a_address & ~(ADDR_MASK_PINMUX)) == ADDR_SPACE_PINMUX) begin
+      dev_sel_s1n_22 = 4'd9;
 
-    end else if ((tl_s1n_21_us_h2d.a_address & ~(ADDR_MASK_PADCTRL)) == ADDR_SPACE_PADCTRL) begin
-      dev_sel_s1n_21 = 4'd10;
+    end else if ((tl_s1n_22_us_h2d.a_address & ~(ADDR_MASK_PADCTRL)) == ADDR_SPACE_PADCTRL) begin
+      dev_sel_s1n_22 = 4'd10;
 
-    end else if ((tl_s1n_21_us_h2d.a_address & ~(ADDR_MASK_ALERT_HANDLER)) == ADDR_SPACE_ALERT_HANDLER) begin
-      dev_sel_s1n_21 = 4'd11;
+    end else if ((tl_s1n_22_us_h2d.a_address & ~(ADDR_MASK_ALERT_HANDLER)) == ADDR_SPACE_ALERT_HANDLER) begin
+      dev_sel_s1n_22 = 4'd11;
 
-    end else if ((tl_s1n_21_us_h2d.a_address & ~(ADDR_MASK_NMI_GEN)) == ADDR_SPACE_NMI_GEN) begin
-      dev_sel_s1n_21 = 4'd12;
+    end else if ((tl_s1n_22_us_h2d.a_address & ~(ADDR_MASK_NMI_GEN)) == ADDR_SPACE_NMI_GEN) begin
+      dev_sel_s1n_22 = 4'd12;
+
+    end else if ((tl_s1n_22_us_h2d.a_address & ~(ADDR_MASK_OTBN)) == ADDR_SPACE_OTBN) begin
+      dev_sel_s1n_22 = 4'd13;
 end
   end
 
   always_comb begin
     // default steering to generate error response if address is not within the range
-    dev_sel_s1n_32 = 4'd12;
-    if ((tl_s1n_32_us_h2d.a_address & ~(ADDR_MASK_ROM)) == ADDR_SPACE_ROM) begin
-      dev_sel_s1n_32 = 4'd0;
+    dev_sel_s1n_34 = 4'd13;
+    if ((tl_s1n_34_us_h2d.a_address & ~(ADDR_MASK_ROM)) == ADDR_SPACE_ROM) begin
+      dev_sel_s1n_34 = 4'd0;
 
-    end else if ((tl_s1n_32_us_h2d.a_address & ~(ADDR_MASK_RAM_MAIN)) == ADDR_SPACE_RAM_MAIN) begin
-      dev_sel_s1n_32 = 4'd1;
+    end else if ((tl_s1n_34_us_h2d.a_address & ~(ADDR_MASK_RAM_MAIN)) == ADDR_SPACE_RAM_MAIN) begin
+      dev_sel_s1n_34 = 4'd1;
 
-    end else if ((tl_s1n_32_us_h2d.a_address & ~(ADDR_MASK_EFLASH)) == ADDR_SPACE_EFLASH) begin
-      dev_sel_s1n_32 = 4'd2;
+    end else if ((tl_s1n_34_us_h2d.a_address & ~(ADDR_MASK_EFLASH)) == ADDR_SPACE_EFLASH) begin
+      dev_sel_s1n_34 = 4'd2;
 
     end else if (
-      ((tl_s1n_32_us_h2d.a_address & ~(ADDR_MASK_PERI[0])) == ADDR_SPACE_PERI[0]) ||
-      ((tl_s1n_32_us_h2d.a_address <= (ADDR_MASK_PERI[1] + ADDR_SPACE_PERI[1])) &&
-       (tl_s1n_32_us_h2d.a_address >= ADDR_SPACE_PERI[1])) ||
-      ((tl_s1n_32_us_h2d.a_address <= (ADDR_MASK_PERI[2] + ADDR_SPACE_PERI[2])) &&
-       (tl_s1n_32_us_h2d.a_address >= ADDR_SPACE_PERI[2])) ||
-      ((tl_s1n_32_us_h2d.a_address <= (ADDR_MASK_PERI[3] + ADDR_SPACE_PERI[3])) &&
-       (tl_s1n_32_us_h2d.a_address >= ADDR_SPACE_PERI[3])) ||
-      ((tl_s1n_32_us_h2d.a_address <= (ADDR_MASK_PERI[4] + ADDR_SPACE_PERI[4])) &&
-       (tl_s1n_32_us_h2d.a_address >= ADDR_SPACE_PERI[4]))
+      ((tl_s1n_34_us_h2d.a_address & ~(ADDR_MASK_PERI[0])) == ADDR_SPACE_PERI[0]) ||
+      ((tl_s1n_34_us_h2d.a_address <= (ADDR_MASK_PERI[1] + ADDR_SPACE_PERI[1])) &&
+       (tl_s1n_34_us_h2d.a_address >= ADDR_SPACE_PERI[1])) ||
+      ((tl_s1n_34_us_h2d.a_address <= (ADDR_MASK_PERI[2] + ADDR_SPACE_PERI[2])) &&
+       (tl_s1n_34_us_h2d.a_address >= ADDR_SPACE_PERI[2])) ||
+      ((tl_s1n_34_us_h2d.a_address <= (ADDR_MASK_PERI[3] + ADDR_SPACE_PERI[3])) &&
+       (tl_s1n_34_us_h2d.a_address >= ADDR_SPACE_PERI[3])) ||
+      ((tl_s1n_34_us_h2d.a_address <= (ADDR_MASK_PERI[4] + ADDR_SPACE_PERI[4])) &&
+       (tl_s1n_34_us_h2d.a_address >= ADDR_SPACE_PERI[4]))
     ) begin
-      dev_sel_s1n_32 = 4'd3;
+      dev_sel_s1n_34 = 4'd3;
 
-    end else if ((tl_s1n_32_us_h2d.a_address & ~(ADDR_MASK_FLASH_CTRL)) == ADDR_SPACE_FLASH_CTRL) begin
-      dev_sel_s1n_32 = 4'd4;
+    end else if ((tl_s1n_34_us_h2d.a_address & ~(ADDR_MASK_FLASH_CTRL)) == ADDR_SPACE_FLASH_CTRL) begin
+      dev_sel_s1n_34 = 4'd4;
 
-    end else if ((tl_s1n_32_us_h2d.a_address & ~(ADDR_MASK_AES)) == ADDR_SPACE_AES) begin
-      dev_sel_s1n_32 = 4'd5;
+    end else if ((tl_s1n_34_us_h2d.a_address & ~(ADDR_MASK_AES)) == ADDR_SPACE_AES) begin
+      dev_sel_s1n_34 = 4'd5;
 
-    end else if ((tl_s1n_32_us_h2d.a_address & ~(ADDR_MASK_HMAC)) == ADDR_SPACE_HMAC) begin
-      dev_sel_s1n_32 = 4'd6;
+    end else if ((tl_s1n_34_us_h2d.a_address & ~(ADDR_MASK_HMAC)) == ADDR_SPACE_HMAC) begin
+      dev_sel_s1n_34 = 4'd6;
 
-    end else if ((tl_s1n_32_us_h2d.a_address & ~(ADDR_MASK_RV_PLIC)) == ADDR_SPACE_RV_PLIC) begin
-      dev_sel_s1n_32 = 4'd7;
+    end else if ((tl_s1n_34_us_h2d.a_address & ~(ADDR_MASK_RV_PLIC)) == ADDR_SPACE_RV_PLIC) begin
+      dev_sel_s1n_34 = 4'd7;
 
-    end else if ((tl_s1n_32_us_h2d.a_address & ~(ADDR_MASK_PINMUX)) == ADDR_SPACE_PINMUX) begin
-      dev_sel_s1n_32 = 4'd8;
+    end else if ((tl_s1n_34_us_h2d.a_address & ~(ADDR_MASK_PINMUX)) == ADDR_SPACE_PINMUX) begin
+      dev_sel_s1n_34 = 4'd8;
 
-    end else if ((tl_s1n_32_us_h2d.a_address & ~(ADDR_MASK_PADCTRL)) == ADDR_SPACE_PADCTRL) begin
-      dev_sel_s1n_32 = 4'd9;
+    end else if ((tl_s1n_34_us_h2d.a_address & ~(ADDR_MASK_PADCTRL)) == ADDR_SPACE_PADCTRL) begin
+      dev_sel_s1n_34 = 4'd9;
 
-    end else if ((tl_s1n_32_us_h2d.a_address & ~(ADDR_MASK_ALERT_HANDLER)) == ADDR_SPACE_ALERT_HANDLER) begin
-      dev_sel_s1n_32 = 4'd10;
+    end else if ((tl_s1n_34_us_h2d.a_address & ~(ADDR_MASK_ALERT_HANDLER)) == ADDR_SPACE_ALERT_HANDLER) begin
+      dev_sel_s1n_34 = 4'd10;
 
-    end else if ((tl_s1n_32_us_h2d.a_address & ~(ADDR_MASK_NMI_GEN)) == ADDR_SPACE_NMI_GEN) begin
-      dev_sel_s1n_32 = 4'd11;
+    end else if ((tl_s1n_34_us_h2d.a_address & ~(ADDR_MASK_NMI_GEN)) == ADDR_SPACE_NMI_GEN) begin
+      dev_sel_s1n_34 = 4'd11;
+
+    end else if ((tl_s1n_34_us_h2d.a_address & ~(ADDR_MASK_OTBN)) == ADDR_SPACE_OTBN) begin
+      dev_sel_s1n_34 = 4'd12;
 end
   end
 
@@ -522,14 +550,14 @@ end
     .DReqDepth (16'h0),
     .DRspDepth (16'h0),
     .N         (4)
-  ) u_s1n_16 (
+  ) u_s1n_17 (
     .clk_i        (clk_main_i),
     .rst_ni       (rst_main_ni),
-    .tl_h_i       (tl_s1n_16_us_h2d),
-    .tl_h_o       (tl_s1n_16_us_d2h),
-    .tl_d_o       (tl_s1n_16_ds_h2d),
-    .tl_d_i       (tl_s1n_16_ds_d2h),
-    .dev_select   (dev_sel_s1n_16)
+    .tl_h_i       (tl_s1n_17_us_h2d),
+    .tl_h_o       (tl_s1n_17_us_d2h),
+    .tl_d_o       (tl_s1n_17_ds_h2d),
+    .tl_d_i       (tl_s1n_17_ds_d2h),
+    .dev_select   (dev_sel_s1n_17)
   );
   tlul_socket_m1 #(
     .HReqDepth (12'h0),
@@ -537,20 +565,6 @@ end
     .DReqDepth (4'h0),
     .DRspDepth (4'h0),
     .M         (3)
-  ) u_sm1_17 (
-    .clk_i        (clk_main_i),
-    .rst_ni       (rst_main_ni),
-    .tl_h_i       (tl_sm1_17_us_h2d),
-    .tl_h_o       (tl_sm1_17_us_d2h),
-    .tl_d_o       (tl_sm1_17_ds_h2d),
-    .tl_d_i       (tl_sm1_17_ds_d2h)
-  );
-  tlul_socket_m1 #(
-    .HReqDepth (8'h0),
-    .HRspDepth (8'h0),
-    .DReqPass  (1'b0),
-    .DRspPass  (1'b0),
-    .M         (2)
   ) u_sm1_18 (
     .clk_i        (clk_main_i),
     .rst_ni       (rst_main_ni),
@@ -560,11 +574,11 @@ end
     .tl_d_i       (tl_sm1_18_ds_d2h)
   );
   tlul_socket_m1 #(
-    .HReqDepth (12'h0),
-    .HRspDepth (12'h0),
-    .DReqDepth (4'h0),
-    .DRspDepth (4'h0),
-    .M         (3)
+    .HReqDepth (8'h0),
+    .HRspDepth (8'h0),
+    .DReqPass  (1'b0),
+    .DRspPass  (1'b0),
+    .M         (2)
   ) u_sm1_19 (
     .clk_i        (clk_main_i),
     .rst_ni       (rst_main_ni),
@@ -587,53 +601,53 @@ end
     .tl_d_o       (tl_sm1_20_ds_h2d),
     .tl_d_i       (tl_sm1_20_ds_d2h)
   );
+  tlul_socket_m1 #(
+    .HReqDepth (12'h0),
+    .HRspDepth (12'h0),
+    .DReqDepth (4'h0),
+    .DRspDepth (4'h0),
+    .M         (3)
+  ) u_sm1_21 (
+    .clk_i        (clk_main_i),
+    .rst_ni       (rst_main_ni),
+    .tl_h_i       (tl_sm1_21_us_h2d),
+    .tl_h_o       (tl_sm1_21_us_d2h),
+    .tl_d_o       (tl_sm1_21_ds_h2d),
+    .tl_d_i       (tl_sm1_21_ds_d2h)
+  );
   tlul_socket_1n #(
     .HReqDepth (4'h0),
     .HRspDepth (4'h0),
-    .DReqDepth (52'h0),
-    .DRspDepth (52'h0),
-    .N         (13)
-  ) u_s1n_21 (
+    .DReqDepth (56'h0),
+    .DRspDepth (56'h0),
+    .N         (14)
+  ) u_s1n_22 (
     .clk_i        (clk_main_i),
     .rst_ni       (rst_main_ni),
-    .tl_h_i       (tl_s1n_21_us_h2d),
-    .tl_h_o       (tl_s1n_21_us_d2h),
-    .tl_d_o       (tl_s1n_21_ds_h2d),
-    .tl_d_i       (tl_s1n_21_ds_d2h),
-    .dev_select   (dev_sel_s1n_21)
+    .tl_h_i       (tl_s1n_22_us_h2d),
+    .tl_h_o       (tl_s1n_22_us_d2h),
+    .tl_d_o       (tl_s1n_22_ds_h2d),
+    .tl_d_i       (tl_s1n_22_ds_d2h),
+    .dev_select   (dev_sel_s1n_22)
   );
   tlul_fifo_async #(
     .ReqDepth        (3),// At least 3 to make async work
     .RspDepth        (3) // At least 3 to make async work
-  ) u_asf_22 (
+  ) u_asf_23 (
     .clk_h_i      (clk_main_i),
     .rst_h_ni     (rst_main_ni),
     .clk_d_i      (clk_fixed_i),
     .rst_d_ni     (rst_fixed_ni),
-    .tl_h_i       (tl_asf_22_us_h2d),
-    .tl_h_o       (tl_asf_22_us_d2h),
-    .tl_d_o       (tl_asf_22_ds_h2d),
-    .tl_d_i       (tl_asf_22_ds_d2h)
+    .tl_h_i       (tl_asf_23_us_h2d),
+    .tl_h_o       (tl_asf_23_us_d2h),
+    .tl_d_o       (tl_asf_23_ds_h2d),
+    .tl_d_i       (tl_asf_23_ds_d2h)
   );
   tlul_socket_m1 #(
     .HReqDepth (8'h0),
     .HRspDepth (8'h0),
     .DReqDepth (4'h0),
     .DRspDepth (4'h0),
-    .M         (2)
-  ) u_sm1_23 (
-    .clk_i        (clk_main_i),
-    .rst_ni       (rst_main_ni),
-    .tl_h_i       (tl_sm1_23_us_h2d),
-    .tl_h_o       (tl_sm1_23_us_d2h),
-    .tl_d_o       (tl_sm1_23_ds_h2d),
-    .tl_d_i       (tl_sm1_23_ds_d2h)
-  );
-  tlul_socket_m1 #(
-    .HReqDepth (8'h0),
-    .HRspDepth (8'h0),
-    .DReqPass  (1'b0),
-    .DRspPass  (1'b0),
     .M         (2)
   ) u_sm1_24 (
     .clk_i        (clk_main_i),
@@ -741,20 +755,48 @@ end
     .tl_d_o       (tl_sm1_31_ds_h2d),
     .tl_d_i       (tl_sm1_31_ds_d2h)
   );
+  tlul_socket_m1 #(
+    .HReqDepth (8'h0),
+    .HRspDepth (8'h0),
+    .DReqPass  (1'b0),
+    .DRspPass  (1'b0),
+    .M         (2)
+  ) u_sm1_32 (
+    .clk_i        (clk_main_i),
+    .rst_ni       (rst_main_ni),
+    .tl_h_i       (tl_sm1_32_us_h2d),
+    .tl_h_o       (tl_sm1_32_us_d2h),
+    .tl_d_o       (tl_sm1_32_ds_h2d),
+    .tl_d_i       (tl_sm1_32_ds_d2h)
+  );
+  tlul_socket_m1 #(
+    .HReqDepth (8'h0),
+    .HRspDepth (8'h0),
+    .DReqPass  (1'b0),
+    .DRspPass  (1'b0),
+    .M         (2)
+  ) u_sm1_33 (
+    .clk_i        (clk_main_i),
+    .rst_ni       (rst_main_ni),
+    .tl_h_i       (tl_sm1_33_us_h2d),
+    .tl_h_o       (tl_sm1_33_us_d2h),
+    .tl_d_o       (tl_sm1_33_ds_h2d),
+    .tl_d_i       (tl_sm1_33_ds_d2h)
+  );
   tlul_socket_1n #(
     .HReqPass  (1'b0),
     .HRspPass  (1'b0),
-    .DReqDepth (48'h0),
-    .DRspDepth (48'h0),
-    .N         (12)
-  ) u_s1n_32 (
+    .DReqDepth (52'h0),
+    .DRspDepth (52'h0),
+    .N         (13)
+  ) u_s1n_34 (
     .clk_i        (clk_main_i),
     .rst_ni       (rst_main_ni),
-    .tl_h_i       (tl_s1n_32_us_h2d),
-    .tl_h_o       (tl_s1n_32_us_d2h),
-    .tl_d_o       (tl_s1n_32_ds_h2d),
-    .tl_d_i       (tl_s1n_32_ds_d2h),
-    .dev_select   (dev_sel_s1n_32)
+    .tl_h_i       (tl_s1n_34_us_h2d),
+    .tl_h_o       (tl_s1n_34_us_d2h),
+    .tl_d_o       (tl_s1n_34_ds_h2d),
+    .tl_d_i       (tl_s1n_34_ds_d2h),
+    .dev_select   (dev_sel_s1n_34)
   );
 
 endmodule

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -105,6 +105,8 @@ module top_earlgrey #(
   tl_d2h_t  tl_nmi_gen_d_d2h;
   tl_h2d_t  tl_usbdev_d_h2d;
   tl_d2h_t  tl_usbdev_d_d2h;
+  tl_h2d_t  tl_otbn_d_h2d;
+  tl_d2h_t  tl_otbn_d_d2h;
 
   tl_h2d_t tl_rom_d_h2d;
   tl_d2h_t tl_rom_d_d2h;
@@ -172,9 +174,10 @@ module top_earlgrey #(
   logic        cio_usbdev_dp_en_d2p;
   logic        cio_usbdev_dn_d2p;
   logic        cio_usbdev_dn_en_d2p;
+  // otbn
 
 
-  logic [80:0]  intr_vector;
+  logic [82:0]  intr_vector;
   // Interrupt source list
   logic intr_uart_tx_watermark;
   logic intr_uart_rx_watermark;
@@ -226,6 +229,8 @@ module top_earlgrey #(
   logic intr_usbdev_rx_bitstuff_err;
   logic intr_usbdev_frame;
   logic intr_usbdev_connected;
+  logic intr_otbn_done;
+  logic intr_otbn_err;
 
 
 
@@ -886,8 +891,31 @@ module top_earlgrey #(
       .rst_usb_48mhz_ni (rstmgr_resets.rst_usb_n)
   );
 
+  otbn u_otbn (
+      .tl_i (tl_otbn_d_h2d),
+      .tl_o (tl_otbn_d_d2h),
+
+      // Interrupt
+      .intr_done_o (intr_otbn_done),
+      .intr_err_o  (intr_otbn_err),
+
+      // [1]: imem_uncorrectable
+      // [2]: dmem_uncorrectable
+      // [3]: reg_uncorrectable
+      .alert_tx_o  ( alert_tx[3:1] ),
+      .alert_rx_i  ( alert_rx[3:1] ),
+
+      // Inter-module signals
+      .idle_o(),
+
+      .clk_i (clkmgr_clocks.clk_main_otbn),
+      .rst_ni (rstmgr_resets.rst_sys_n)
+  );
+
   // interrupt assignments
   assign intr_vector = {
+      intr_otbn_err,
+      intr_otbn_done,
       intr_pwrmgr_wakeup,
       intr_usbdev_connected,
       intr_usbdev_frame,
@@ -978,6 +1006,8 @@ module top_earlgrey #(
     .tl_alert_handler_i (tl_alert_handler_d_d2h),
     .tl_nmi_gen_o       (tl_nmi_gen_d_h2d),
     .tl_nmi_gen_i       (tl_nmi_gen_d_d2h),
+    .tl_otbn_o          (tl_otbn_d_h2d),
+    .tl_otbn_i          (tl_otbn_d_d2h),
 
     .scanmode_i
   );

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey_pkg.sv
@@ -21,6 +21,7 @@ package top_earlgrey_pkg;
   parameter TOP_EARLGREY_CLKMGR_BASE_ADDR = 32'h400C0000;
   parameter TOP_EARLGREY_NMI_GEN_BASE_ADDR = 32'h40140000;
   parameter TOP_EARLGREY_USBDEV_BASE_ADDR = 32'h40150000;
+  parameter TOP_EARLGREY_OTBN_BASE_ADDR = 32'h50000000;
 
   // Enumeration for DIO pins.
   typedef enum {

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.c
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.c
@@ -11,7 +11,7 @@
  * `top_earlgrey_plic_peripheral_t`.
  */
 const top_earlgrey_plic_peripheral_t
-    top_earlgrey_plic_interrupt_for_peripheral[81] = {
+    top_earlgrey_plic_interrupt_for_peripheral[83] = {
   [kTopEarlgreyPlicIrqIdNone] = kTopEarlgreyPlicPeripheralUnknown,
   [kTopEarlgreyPlicIrqIdGpioGpio0] = kTopEarlgreyPlicPeripheralGpio,
   [kTopEarlgreyPlicIrqIdGpioGpio1] = kTopEarlgreyPlicPeripheralGpio,
@@ -93,4 +93,6 @@ const top_earlgrey_plic_peripheral_t
   [kTopEarlgreyPlicIrqIdUsbdevFrame] = kTopEarlgreyPlicPeripheralUsbdev,
   [kTopEarlgreyPlicIrqIdUsbdevConnected] = kTopEarlgreyPlicPeripheralUsbdev,
   [kTopEarlgreyPlicIrqIdPwrmgrWakeup] = kTopEarlgreyPlicPeripheralPwrmgr,
+  [kTopEarlgreyPlicIrqIdOtbnDone] = kTopEarlgreyPlicPeripheralOtbn,
+  [kTopEarlgreyPlicIrqIdOtbnErr] = kTopEarlgreyPlicPeripheralOtbn,
 };

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -379,6 +379,24 @@ extern "C" {
  */
 #define TOP_EARLGREY_USBDEV_SIZE_BYTES 0x1000u
 
+/**
+ * Peripheral base address for otbn in top earlgrey.
+ *
+ * This should be used with #mmio_region_from_addr to access the memory-mapped
+ * registers associated with the peripheral (usually via a DIF).
+ */
+#define TOP_EARLGREY_OTBN_BASE_ADDR 0x50000000u
+
+/**
+ * Peripheral size for otbn in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_OTBN_BASE_ADDR and
+ * `TOP_EARLGREY_OTBN_BASE_ADDR + TOP_EARLGREY_OTBN_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_OTBN_SIZE_BYTES 0x400000u
+
 
 /**
  * Memory base address for rom in top earlgrey.
@@ -438,7 +456,8 @@ typedef enum top_earlgrey_plic_peripheral {
   kTopEarlgreyPlicPeripheralNmiGen = 7, /**< nmi_gen */
   kTopEarlgreyPlicPeripheralUsbdev = 8, /**< usbdev */
   kTopEarlgreyPlicPeripheralPwrmgr = 9, /**< pwrmgr */
-  kTopEarlgreyPlicPeripheralLast = 9, /**< \internal Final PLIC peripheral */
+  kTopEarlgreyPlicPeripheralOtbn = 10, /**< otbn */
+  kTopEarlgreyPlicPeripheralLast = 10, /**< \internal Final PLIC peripheral */
 } top_earlgrey_plic_peripheral_t;
 
 /**
@@ -529,7 +548,9 @@ typedef enum top_earlgrey_plic_irq_id {
   kTopEarlgreyPlicIrqIdUsbdevFrame = 78, /**< usbdev_frame */
   kTopEarlgreyPlicIrqIdUsbdevConnected = 79, /**< usbdev_connected */
   kTopEarlgreyPlicIrqIdPwrmgrWakeup = 80, /**< pwrmgr_wakeup */
-  kTopEarlgreyPlicIrqIdLast = 80, /**< \internal The Last Valid Interrupt ID. */
+  kTopEarlgreyPlicIrqIdOtbnDone = 81, /**< otbn_done */
+  kTopEarlgreyPlicIrqIdOtbnErr = 82, /**< otbn_err */
+  kTopEarlgreyPlicIrqIdLast = 82, /**< \internal The Last Valid Interrupt ID. */
 } top_earlgrey_plic_irq_id_t;
 
 /**
@@ -539,7 +560,7 @@ typedef enum top_earlgrey_plic_irq_id {
  * `top_earlgrey_plic_peripheral_t`.
  */
 extern const top_earlgrey_plic_peripheral_t
-    top_earlgrey_plic_interrupt_for_peripheral[81];
+    top_earlgrey_plic_interrupt_for_peripheral[83];
 
 /**
  * PLIC external interrupt target.

--- a/hw/top_earlgrey/top_earlgrey.core
+++ b/hw/top_earlgrey/top_earlgrey.core
@@ -24,6 +24,7 @@ filesets:
       - lowrisc:ip:spi_device
       - lowrisc:ip:aes
       - lowrisc:ip:hmac
+      - lowrisc:ip:otbn
       - lowrisc:prim:ram_1p_adv
       - lowrisc:prim:rom_adv
       - lowrisc:ip:rstmgr

--- a/sw/device/lib/dif/dif_plic.c
+++ b/sw/device/lib/dif/dif_plic.c
@@ -14,7 +14,7 @@
 // If either of these static assertions fail, then the assumptions in this DIF
 // implementation should be revisited. In particular, `plic_target_reg_offsets`
 // may need updating,
-_Static_assert(RV_PLIC_PARAM_NUMSRC == 81,
+_Static_assert(RV_PLIC_PARAM_NUMSRC == 83,
                "PLIC instantiation parameters have changed.");
 _Static_assert(RV_PLIC_PARAM_NUMTARGET == 1,
                "PLIC instantiation parameters have changed.");

--- a/sw/device/tests/dif/dif_plic_unittest.cc
+++ b/sw/device/tests/dif/dif_plic_unittest.cc
@@ -116,7 +116,7 @@ class IrqEnableSetTest : public IrqTests {
           RV_PLIC_IE01_REG_OFFSET, RV_PLIC_IE01_E63,
       },
       {
-          RV_PLIC_IE02_REG_OFFSET, RV_PLIC_IE02_E80,
+          RV_PLIC_IE02_REG_OFFSET, RV_PLIC_IE02_E82,
       },
   };
 };
@@ -164,7 +164,7 @@ class IrqTriggerTypeSetTest : public IrqTests {
           RV_PLIC_LE1_REG_OFFSET, RV_PLIC_LE1_LE63,
       },
       {
-          RV_PLIC_LE2_REG_OFFSET, RV_PLIC_LE2_LE80,
+          RV_PLIC_LE2_REG_OFFSET, RV_PLIC_LE2_LE82,
       },
   };
 };
@@ -265,7 +265,7 @@ class IrqPendingStatusGetTest : public IrqTests {
           RV_PLIC_IP1_REG_OFFSET, RV_PLIC_IP1_P63,
       },
       {
-          RV_PLIC_IP2_REG_OFFSET, RV_PLIC_IP2_P80,
+          RV_PLIC_IP2_REG_OFFSET, RV_PLIC_IP2_P82,
       },
   };
 };


### PR DESCRIPTION
This enables the (not yet very functional) OTBN device in the Earl Grey toplevel. The bus device interface (register reads and writes) works as expected, however, OTBN doesn't yet execute anything.

Note that this PR contains three commits, only the middle one ("[top_earlgrey] Enable OTBN in toplevel") is important. **Please use the "Commits" tab to select that commit for easier reviewing.**

- "[otbn] Initial OTBN implementation skeleton": This is the OTBN skeleton implementation in #2641. It's included here to break that dependency, but will reviewed in the other PR and removed before merging.
- "[top_earlgrey] Enable OTBN in toplevel": this is the essence of this PR.
- "[OTBN] Regenerate toplevel files" regenerates various files as result of changing the Earl Grey configuration. These changes will be folded into the previous commit before merging to produce an atomic/bisectable commit. I have split the changes out to make it easier for reviewers to focus on the manual changes.