### PR TITLE
[i2c, rtl] Addition of transaction complete interrupt

### DIFF
--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -40,6 +40,9 @@
     { name: "sda_unstable"
       desc: "raised if the target does not assert a constant value of SDA during transmission."
     }
+    { name: "trans_complete"
+      desc: "raised if the host terminates the transaction by issuing STOP or repeated START."
+    }
   ]
 
   // REGISTER definition

--- a/hw/ip/i2c/rtl/i2c.sv
+++ b/hw/ip/i2c/rtl/i2c.sv
@@ -31,7 +31,8 @@ module i2c (
   output logic              intr_scl_interference_o,
   output logic              intr_sda_interference_o,
   output logic              intr_stretch_timeout_o,
-  output logic              intr_sda_unstable_o
+  output logic              intr_sda_unstable_o,
+  output logic              intr_trans_complete_o
 );
 
   import i2c_reg_pkg::*;
@@ -71,7 +72,8 @@ module i2c (
     .intr_scl_interference_o,
     .intr_sda_interference_o,
     .intr_stretch_timeout_o,
-    .intr_sda_unstable_o
+    .intr_sda_unstable_o,
+    .intr_trans_complete_o
   );
 
   // For I2C, in standard, fast and fast-plus modes, outputs simulated as open-drain outputs.
@@ -99,5 +101,6 @@ module i2c (
   `ASSERT_KNOWN(IntrSdaInterfKnownO_A, intr_sda_interference_o)
   `ASSERT_KNOWN(IntrStretchTimeoutKnownO_A, intr_stretch_timeout_o)
   `ASSERT_KNOWN(IntrSdaUnstableKnownO_A, intr_sda_unstable_o)
+  `ASSERT_KNOWN(IntrTransCompleteKnownO_A, intr_trans_complete_o)
 
 endmodule

--- a/hw/ip/i2c/rtl/i2c_reg_pkg.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_pkg.sv
@@ -37,6 +37,9 @@ package i2c_reg_pkg;
     struct packed {
       logic        q;
     } sda_unstable;
+    struct packed {
+      logic        q;
+    } trans_complete;
   } i2c_reg2hw_intr_state_reg_t;
 
   typedef struct packed {
@@ -67,6 +70,9 @@ package i2c_reg_pkg;
     struct packed {
       logic        q;
     } sda_unstable;
+    struct packed {
+      logic        q;
+    } trans_complete;
   } i2c_reg2hw_intr_enable_reg_t;
 
   typedef struct packed {
@@ -106,6 +112,10 @@ package i2c_reg_pkg;
       logic        q;
       logic        qe;
     } sda_unstable;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } trans_complete;
   } i2c_reg2hw_intr_test_reg_t;
 
   typedef struct packed {
@@ -267,6 +277,10 @@ package i2c_reg_pkg;
       logic        d;
       logic        de;
     } sda_unstable;
+    struct packed {
+      logic        d;
+      logic        de;
+    } trans_complete;
   } i2c_hw2reg_intr_state_reg_t;
 
   typedef struct packed {
@@ -317,9 +331,9 @@ package i2c_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    i2c_reg2hw_intr_state_reg_t intr_state; // [270:262]
-    i2c_reg2hw_intr_enable_reg_t intr_enable; // [261:253]
-    i2c_reg2hw_intr_test_reg_t intr_test; // [252:235]
+    i2c_reg2hw_intr_state_reg_t intr_state; // [274:265]
+    i2c_reg2hw_intr_enable_reg_t intr_enable; // [264:255]
+    i2c_reg2hw_intr_test_reg_t intr_test; // [254:235]
     i2c_reg2hw_ctrl_reg_t ctrl; // [234:234]
     i2c_reg2hw_rdata_reg_t rdata; // [233:225]
     i2c_reg2hw_fdata_reg_t fdata; // [224:206]
@@ -337,11 +351,11 @@ package i2c_reg_pkg;
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    i2c_hw2reg_intr_state_reg_t intr_state; // [75:67]
-    i2c_hw2reg_status_reg_t status; // [66:67]
-    i2c_hw2reg_rdata_reg_t rdata; // [66:58]
-    i2c_hw2reg_fifo_status_reg_t fifo_status; // [57:58]
-    i2c_hw2reg_val_reg_t val; // [57:58]
+    i2c_hw2reg_intr_state_reg_t intr_state; // [77:68]
+    i2c_hw2reg_status_reg_t status; // [67:68]
+    i2c_hw2reg_rdata_reg_t rdata; // [67:59]
+    i2c_hw2reg_fifo_status_reg_t fifo_status; // [58:59]
+    i2c_hw2reg_val_reg_t val; // [58:59]
   } i2c_hw2reg_t;
 
   // Register Address

--- a/hw/ip/i2c/rtl/i2c_reg_top.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_top.sv
@@ -98,6 +98,9 @@ module i2c_reg_top (
   logic intr_state_sda_unstable_qs;
   logic intr_state_sda_unstable_wd;
   logic intr_state_sda_unstable_we;
+  logic intr_state_trans_complete_qs;
+  logic intr_state_trans_complete_wd;
+  logic intr_state_trans_complete_we;
   logic intr_enable_fmt_watermark_qs;
   logic intr_enable_fmt_watermark_wd;
   logic intr_enable_fmt_watermark_we;
@@ -125,6 +128,9 @@ module i2c_reg_top (
   logic intr_enable_sda_unstable_qs;
   logic intr_enable_sda_unstable_wd;
   logic intr_enable_sda_unstable_we;
+  logic intr_enable_trans_complete_qs;
+  logic intr_enable_trans_complete_wd;
+  logic intr_enable_trans_complete_we;
   logic intr_test_fmt_watermark_wd;
   logic intr_test_fmt_watermark_we;
   logic intr_test_rx_watermark_wd;
@@ -143,6 +149,8 @@ module i2c_reg_top (
   logic intr_test_stretch_timeout_we;
   logic intr_test_sda_unstable_wd;
   logic intr_test_sda_unstable_we;
+  logic intr_test_trans_complete_wd;
+  logic intr_test_trans_complete_we;
   logic ctrl_qs;
   logic ctrl_wd;
   logic ctrl_we;
@@ -473,6 +481,32 @@ module i2c_reg_top (
   );
 
 
+  //   F[trans_complete]: 9:9
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("W1C"),
+    .RESVAL  (1'h0)
+  ) u_intr_state_trans_complete (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (intr_state_trans_complete_we),
+    .wd     (intr_state_trans_complete_wd),
+
+    // from internal hardware
+    .de     (hw2reg.intr_state.trans_complete.de),
+    .d      (hw2reg.intr_state.trans_complete.d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.intr_state.trans_complete.q ),
+
+    // to register interface (read)
+    .qs     (intr_state_trans_complete_qs)
+  );
+
+
   // R[intr_enable]: V(False)
 
   //   F[fmt_watermark]: 0:0
@@ -709,6 +743,32 @@ module i2c_reg_top (
   );
 
 
+  //   F[trans_complete]: 9:9
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_intr_enable_trans_complete (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (intr_enable_trans_complete_we),
+    .wd     (intr_enable_trans_complete_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.intr_enable.trans_complete.q ),
+
+    // to register interface (read)
+    .qs     (intr_enable_trans_complete_qs)
+  );
+
+
   // R[intr_test]: V(True)
 
   //   F[fmt_watermark]: 0:0
@@ -842,6 +902,21 @@ module i2c_reg_top (
     .qre    (),
     .qe     (reg2hw.intr_test.sda_unstable.qe),
     .q      (reg2hw.intr_test.sda_unstable.q ),
+    .qs     ()
+  );
+
+
+  //   F[trans_complete]: 9:9
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_intr_test_trans_complete (
+    .re     (1'b0),
+    .we     (intr_test_trans_complete_we),
+    .wd     (intr_test_trans_complete_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (reg2hw.intr_test.trans_complete.qe),
+    .q      (reg2hw.intr_test.trans_complete.q ),
     .qs     ()
   );
 
@@ -1780,6 +1855,9 @@ module i2c_reg_top (
   assign intr_state_sda_unstable_we = addr_hit[0] & reg_we & ~wr_err;
   assign intr_state_sda_unstable_wd = reg_wdata[8];
 
+  assign intr_state_trans_complete_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_trans_complete_wd = reg_wdata[9];
+
   assign intr_enable_fmt_watermark_we = addr_hit[1] & reg_we & ~wr_err;
   assign intr_enable_fmt_watermark_wd = reg_wdata[0];
 
@@ -1807,6 +1885,9 @@ module i2c_reg_top (
   assign intr_enable_sda_unstable_we = addr_hit[1] & reg_we & ~wr_err;
   assign intr_enable_sda_unstable_wd = reg_wdata[8];
 
+  assign intr_enable_trans_complete_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_trans_complete_wd = reg_wdata[9];
+
   assign intr_test_fmt_watermark_we = addr_hit[2] & reg_we & ~wr_err;
   assign intr_test_fmt_watermark_wd = reg_wdata[0];
 
@@ -1833,6 +1914,9 @@ module i2c_reg_top (
 
   assign intr_test_sda_unstable_we = addr_hit[2] & reg_we & ~wr_err;
   assign intr_test_sda_unstable_wd = reg_wdata[8];
+
+  assign intr_test_trans_complete_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_trans_complete_wd = reg_wdata[9];
 
   assign ctrl_we = addr_hit[3] & reg_we & ~wr_err;
   assign ctrl_wd = reg_wdata[0];
@@ -1948,6 +2032,7 @@ module i2c_reg_top (
         reg_rdata_next[6] = intr_state_sda_interference_qs;
         reg_rdata_next[7] = intr_state_stretch_timeout_qs;
         reg_rdata_next[8] = intr_state_sda_unstable_qs;
+        reg_rdata_next[9] = intr_state_trans_complete_qs;
       end
 
       addr_hit[1]: begin
@@ -1960,6 +2045,7 @@ module i2c_reg_top (
         reg_rdata_next[6] = intr_enable_sda_interference_qs;
         reg_rdata_next[7] = intr_enable_stretch_timeout_qs;
         reg_rdata_next[8] = intr_enable_sda_unstable_qs;
+        reg_rdata_next[9] = intr_enable_trans_complete_qs;
       end
 
       addr_hit[2]: begin
@@ -1972,6 +2058,7 @@ module i2c_reg_top (
         reg_rdata_next[6] = '0;
         reg_rdata_next[7] = '0;
         reg_rdata_next[8] = '0;
+        reg_rdata_next[9] = '0;
       end
 
       addr_hit[3]: begin


### PR DESCRIPTION
Added event_trans_complete_o (fix to Issue # 1921)
Deleted TODO comment from RX oversampling

Signed-off-by: Igor Kouznetsov <igor.kouznetsov@wdc.com>