### PR TITLE
[aes] Initial key register fixes

### DIFF
--- a/hw/ip/aes/aes.core
+++ b/hw/ip/aes/aes.core
@@ -17,6 +17,7 @@ filesets:
       - rtl/aes_prng.sv
       - rtl/aes_ctr.sv
       - rtl/aes_control.sv
+      - rtl/aes_reg_status.sv
       - rtl/aes_cipher_core.sv
       - rtl/aes_cipher_control.sv
       - rtl/aes_sub_bytes.sv

--- a/hw/ip/aes/rtl/aes_control.sv
+++ b/hw/ip/aes/rtl/aes_control.sv
@@ -422,7 +422,7 @@ module aes_control (
   // Detect new key, new IV, new input, output read.
   // Edge detectors are cleared by the FSM.
   assign key_init_new_d = (dec_key_gen || key_init_clear) ? '0 : (key_init_new_q | key_init_we_o);
-  assign key_init_new   = &key_init_new_d;
+  assign key_init_new   = &key_init_new_q;
 
   // The IV regs can be updated by both software or the counter.
   assign iv_new_d = (iv_load || iv_clear) ? '0 : (iv_new_q | iv_we_o);

--- a/hw/ip/aes/rtl/aes_control.sv
+++ b/hw/ip/aes/rtl/aes_control.sv
@@ -110,17 +110,14 @@ module aes_control (
 
   // Signals
   logic       key_init_clear;
-  logic [7:0] key_init_new_d, key_init_new_q;
   logic       key_init_new;
   logic       dec_key_gen;
+  logic       key_init_ready;
 
   logic [7:0] iv_qe;
   logic       iv_clear;
-  logic [7:0] iv_new_d, iv_new_q;
-  logic       iv_new;
-  logic       iv_clean;
   logic       iv_load;
-  logic       iv_ready_d, iv_ready_q;
+  logic       iv_ready;
 
   logic [3:0] data_in_new_d, data_in_new_q;
   logic       data_in_new;
@@ -143,10 +140,11 @@ module aes_control (
   // If set to start manually, we just wait for the trigger. Otherwise, we start once we have valid
   // data available. If the IV (and counter) is needed, we only start if also the IV (and counter)
   // is ready.
-  assign start = manual_operation_i ? start_i                                  :
-                (mode_i == AES_ECB) ? data_in_new                              :
-                (mode_i == AES_CBC) ? (data_in_new & iv_ready_q)               :
-                (mode_i == AES_CTR) ? (data_in_new & iv_ready_q & ctr_ready_i) : 1'b0;
+  assign start =
+       manual_operation_i ? start_i                                                 :
+      (mode_i == AES_ECB) ? (key_init_ready & data_in_new)                          :
+      (mode_i == AES_CBC) ? (key_init_ready & data_in_new & iv_ready)               :
+      (mode_i == AES_CTR) ? (key_init_ready & data_in_new & iv_ready & ctr_ready_i) : 1'b0;
 
   // If not set to overwrite data, we wait for any previous output data to be read. data_out_read
   // synchronously clears output_valid_q, unless new output data is written in the exact same
@@ -419,16 +417,39 @@ module aes_control (
     end
   end
 
-  // Detect new key, new IV, new input, output read.
+  // We only use clean initial keys. Either software/counter has updated
+  // - all initial key registers, or
+  // - none of the initial key registers but the registers were updated in the past.
+  aes_reg_status #(
+    .Width ( $bits(key_init_we_o) )
+  ) u_reg_status_key_init (
+    .clk_i   ( clk_i          ),
+    .rst_ni  ( rst_ni         ),
+    .we_i    ( key_init_we_o  ),
+    .use_i   ( dec_key_gen    ),
+    .clear_i ( key_init_clear ),
+    .new_o   ( key_init_new   ),
+    .clean_o ( key_init_ready )
+  );
+
+  // We only use clean and unused IVs. Either software/counter has updated
+  // - all IV registers, or
+  // - none of the IV registers but the registers were updated in the past
+  // and this particular IV has not yet been used.
+  aes_reg_status #(
+    .Width ( $bits(iv_we_o) )
+  ) u_reg_status_iv (
+    .clk_i   ( clk_i    ),
+    .rst_ni  ( rst_ni   ),
+    .we_i    ( iv_we_o  ),
+    .use_i   ( iv_load  ),
+    .clear_i ( iv_clear ),
+    .new_o   ( iv_ready ),
+    .clean_o (          )
+  );
+
+  // Detect new input and output read.
   // Edge detectors are cleared by the FSM.
-  assign key_init_new_d = (dec_key_gen || key_init_clear) ? '0 : (key_init_new_q | key_init_we_o);
-  assign key_init_new   = &key_init_new_q;
-
-  // The IV regs can be updated by both software or the counter.
-  assign iv_new_d = (iv_load || iv_clear) ? '0 : (iv_new_q | iv_we_o);
-  assign iv_new   = &iv_new_d; // All of the IV regs have been updated.
-  assign iv_clean = ~(|iv_new_d); // None of the IV regs have been updated.
-
   assign data_in_new_d = (data_in_load || data_in_we_o) ? '0 : (data_in_new_q | data_in_qe_i);
   assign data_in_new   = &data_in_new_d;
 
@@ -439,28 +460,11 @@ module aes_control (
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : reg_edge_detection
     if (!rst_ni) begin
-      key_init_new_q  <= '0;
-      iv_new_q        <= '0;
       data_in_new_q   <= '0;
       data_out_read_q <= '0;
     end else begin
-      key_init_new_q  <= key_init_new_d;
-      iv_new_q        <= iv_new_d;
       data_in_new_q   <= data_in_new_d;
       data_out_read_q <= data_out_read_d;
-    end
-  end
-
-  // We only use complete IVs. Either software/counter has updated
-  // - all IV registers (iv_new), or
-  // - none of the IV registers (iv_clean), but the registers were updated in the past.
-  assign iv_ready_d = (iv_load || iv_clear) ? 1'b0 : iv_new | (iv_clean & iv_ready_q);
-
-  always_ff @(posedge clk_i or negedge rst_ni) begin : reg_iv_ready
-    if (!rst_ni) begin
-      iv_ready_q <= 1'b0;
-    end else begin
-      iv_ready_q <= iv_ready_d;
     end
   end
 

--- a/hw/ip/aes/rtl/aes_reg_status.sv
+++ b/hw/ip/aes/rtl/aes_reg_status.sv
@@ -1,0 +1,69 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// AES reg status
+//
+// This module tracks the collective status of multiple registers.
+
+module aes_reg_status #(
+  parameter int Width = 1
+) (
+  input  logic             clk_i,
+  input  logic             rst_ni,
+
+  input  logic [Width-1:0] we_i,
+  input  logic             use_i,
+  input  logic             clear_i,
+  output logic             new_o,
+  output logic             clean_o
+);
+
+  logic [Width-1:0] we_d, we_q;
+  logic             all_written;
+  logic             none_written;
+  logic             new_d, new_q;
+  logic             clean_d, clean_q;
+
+  // Collect write operations. Upon clear or use, we start over.
+  assign we_d = (clear_i || use_i) ? '0 : (we_q | we_i);
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : reg_we
+    if (!rst_ni) begin
+      we_q <= '0;
+    end else begin
+      we_q <= we_d;
+    end
+  end
+
+  // Status tracking
+  assign all_written  =  &we_d;
+  assign none_written = ~|we_d;
+
+  // We have a complete new value if all registers have been written at least once.
+  assign new_d   = (clear_i || use_i) ? 1'b0 : all_written;
+
+  // We have a clean value, if either:
+  // - all registers have been written at least once, or
+  // - no registers have been written but the value was clean previsously.
+  // A value is NOT clean, if either:
+  // - we get a clear or reset, or
+  // - some but not all registers have been written.
+  assign clean_d = clear_i      ? 1'b0    :
+                   all_written  ? 1'b1    :
+                   none_written ? clean_q : 1'b0;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : reg_status
+    if (!rst_ni) begin
+      new_q   <= 1'b0;
+      clean_q <= 1'b0;
+    end else begin
+      new_q   <= new_d;
+      clean_q <= clean_d;
+    end
+  end
+
+  assign new_o   = new_q;
+  assign clean_o = clean_q;
+
+endmodule


### PR DESCRIPTION
This PR contains two commits:
- The first one fixes a critical path in the design going through the TL-UL into the cipher core (this has previously been fixed on bronze).
- The second one reworks the status tracking for the initial key and IV registers. Previously, the FSM only waited for the key registers to be written at least once when performing decryption (to determine whether the decryption key needs to be generated). With this PR, the FSM only ever starts if all key registers have been written at least once (also when doing encryption) as documented. A lot of the required logic is shared with the IV status tracking. Thus, a new module has been introduced to implement this logic.