### PR TITLE
[prim/present] fix PRESENT decryption bugs

### DIFF
--- a/hw/ip/prim/rtl/prim_cipher_pkg.sv
+++ b/hw/ip/prim/rtl/prim_cipher_pkg.sv
@@ -248,13 +248,13 @@ package prim_cipher_pkg;
                                                            logic [4:0]  round_idx,
                                                            // total number of rounds employed
                                                            logic [4:0]  round_cnt);
-    logic [63:0] key_out;
+    logic [63:0] key_out = key_in;
     // xor in round counter on bits 19 to 15
     key_out[19:15] ^= 6'(round_cnt) + 1 - round_idx;
     // sbox on uppermost 4 bits
     key_out[63 -: 4] = PRESENT_SBOX4_INV[key_out[63 -: 4]];
     // rotate by 61 to the right
-    key_out = 64'(key_in >> 61) | 64'(key_in << (64-61));
+    key_out = 64'(key_out >> 61) | 64'(key_out << (64-61));
     return key_out;
   endfunction : present_inv_update_key64
 
@@ -262,13 +262,13 @@ package prim_cipher_pkg;
                                                            logic [4:0]  round_idx,
                                                            // total number of rounds employed
                                                            logic [4:0]  round_cnt);
-    logic [79:0] key_out;
+    logic [79:0] key_out = key_in;
     // xor in round counter on bits 19 to 15
     key_out[19:15] ^= 6'(round_cnt) + 1 - round_idx;
     // sbox on uppermost 4 bits
     key_out[79 -: 4] = PRESENT_SBOX4_INV[key_out[79 -: 4]];
     // rotate by 61 to the right
-    key_out = 80'(key_in >> 61) | 80'(key_in << (80-61));
+    key_out = 80'(key_out >> 61) | 80'(key_out << (80-61));
     return key_out;
   endfunction : present_inv_update_key80
 
@@ -276,13 +276,15 @@ package prim_cipher_pkg;
                                                              logic [4:0]   round_idx,
                                                              // total number of rounds employed
                                                              logic [4:0]   round_cnt);
-    logic [127:0] key_out;
-    // xor in round counter on bits 19 to 15
-    key_out[19:15] ^= 6'(round_cnt) + 1 - round_idx;
+    logic [127:0] key_out = key_in;
+    // xor in round counter on bits 66 to 62
+    key_out[66:62] ^= 6'(round_cnt) + 1 - round_idx;
+    // sbox on second highest nibble
+    key_out[123 -: 4] = PRESENT_SBOX4_INV[key_out[123 -: 4]];
     // sbox on uppermost 4 bits
     key_out[127 -: 4] = PRESENT_SBOX4_INV[key_out[127 -: 4]];
     // rotate by 61 to the right
-    key_out = 128'(key_in >> 61) | 128'(key_in << (128-61));
+    key_out = 128'(key_out >> 61) | 128'(key_out << (128-61));
     return key_out;
   endfunction : present_inv_update_key128
 


### PR DESCRIPTION
fixes some minor bugs in the PRESENT decryption logic (pretty much just the inverse of the issues in #2651).
All PRESENT tests pass after applying this patch.

Signed-off-by: Udi Jonnalagadda <udij@google.com>