### PR TITLE
[i2c, dv] Exercise interrupt logic in i2c_sanity

### DIFF
--- a/hw/ip/i2c/dv/env/seq_lib/i2c_sanity_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_sanity_vseq.sv
@@ -7,22 +7,24 @@ class i2c_sanity_vseq extends i2c_rx_tx_vseq;
   `uvm_object_utils(i2c_sanity_vseq)
   `uvm_object_new
 
-  constraint num_wr_bytes_c { num_wr_bytes  inside {[1 : 5]}; }
-  constraint num_rd_bytes_c { num_rd_bytes  inside {[1 : 5]}; }
-  constraint num_trans_c    { num_trans     inside {100}; }
-
-  task pre_start();
-    super.pre_start();
-    do_interrupt = 1'b0;
-  endtask : pre_start
+  constraint access_intr_dly_c { access_intr_dly inside {[0 : 10]}; }
+  constraint num_wr_bytes_c    { num_wr_bytes    inside {[1 : 5]}; }
+  constraint num_rd_bytes_c    { num_rd_bytes    inside {[1 : 5]}; }
+  constraint num_trans_c       { num_trans       inside {[50 : 100]}; }
 
   task body();
     device_init();
     host_init();
 
+    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(num_trans)
     fork
-      while (do_interrupt) process_interrupts();
-      host_send_trans(num_trans);
+      begin
+        while (do_interrupt) process_interrupts();
+      end
+      begin
+        host_send_trans(num_trans);
+        do_interrupt = 1'b0; // gracefully stop process_interrupts
+      end
     join
   endtask : body
 


### PR DESCRIPTION
This PR does not verify interrupts (done with other `*_vseq`). It just exercises interrupt's logic within i2c_sanity by reading and randomly clearing interrupt pins if they are set during transceiving transactions.

Signed-off-by: Hoang Tung <Hoang.Tung@wdc.com>