### PR TITLE
[spiflash] Add support to override the FTDI USB device ID

### DIFF
--- a/sw/host/spiflash/README.md
+++ b/sw/host/spiflash/README.md
@@ -1,8 +1,7 @@
 # SPI Flash
 
 `spiflash` is a tool used to update the firmware stored in OpenTitan's embedded flash.
-The tool resets OpenTitan and signals the boot ROM to enter bootstrap mode
-before sending the update payload.
+The tool resets OpenTitan and signals the boot ROM to enter bootstrap mode before sending the update payload.
 
 Currently, the tool supports both Verilator and FPGA targets.
 
@@ -27,16 +26,11 @@ $ ninja -C build-out sw/host/spiflash/spiflash_export
 ## Setup instructions for Verilator and FPGA
 Please refer to [verilator]({{< relref "doc/ug/getting_started_verilator" >}}) and [fpga]({{< relref "doc/ug/getting_started_fpga" >}}) docs for more information.
 
-## Build boot ROM and demo program
+## Build target program
 
-Build `boot_rom`:
-```console
-$ cd ${REPO_TOP}
-$ ./meson_init.sh
-$ ninja -C build-out sw/device/boot_rom/boot_rom_export_${DEVICE}
-```
+In this example, we build the `hello_world` as the target program.
+Set `${FLASH_BIN}` to the path to the generated binary.
 
-Build the `hello_world` program:
 ```console
 $ cd ${REPO_TOP}
 $ ninja -C build-out sw/device/examples/hello_world/hello_world_export_${DEVICE}
@@ -46,22 +40,16 @@ Where ${DEVICE} is one of 'sim_verilator' or 'fpga_nexysvideo'
 
 ## Run the tool in Verilator
 
-Run Verilator with boot_rom enabled:
+Run Verilator with boot_rom enabled as described in the [verilator]({{< relref "doc/ug/getting_started_verilator" >}}) getting started guide.
 
-```console
-$ cd ${REPO_TOP}
-$ build/lowrisc_systems_top_earlgrey_verilator_0.1/sim-verilator/Vtop_earlgrey_verilator \
-  --rominit build-bin/sw/device/boot_rom/boot_rom_sim_verilator.32.vmem
-```
-
-Run spiflash. In this example we use SPI device `/dev/pts/3` as an example.
+Run spiflash.
+In this example we use SPI device `/dev/pts/3` as an example.
 After the transmission is complete, you should be able to see the hello_world output in the UART console.
 
 ```console
 $ cd ${REPO_TOP}
-$ build-bin/sw/host/spiflash/spiflash \
-  --input     build-bin/sw/device/examples/hello_world/hello_world_sim_verilator.bin \
-  --verilator /dev/pts/3
+$ build-bin/sw/host/spiflash/spiflash --input ${FLASH_BIN} \
+   --verilator /dev/pts/3
 ```
 
 ## Run the tool in FPGA
@@ -73,6 +61,15 @@ If there are two FPGAs or multiple valid targets attached at the same time, it i
 
 ```console
 $ cd ${REPO_TOP}
-$ build-bin/sw/host/spiflash/spiflash \
-  --input build-bin/sw/device/examples/hello_world/hello_world_fpga_nexysvideo.bin
+$ build-bin/sw/host/spiflash/spiflash --input ${FLASH_BIN}
+```
+
+The tool supports overriding the FTDI USB device ID and serial number as follows:
+
+```console
+$ cd ${REPO_TOP}
+# --dev-id: "vendor_id:product_id" in hex string format.
+# --dev-sn: Serial number in string format as returned by lsusb command.
+$ build-bin/sw/host/spiflash/spiflash  --dev-id=0403:6014 --dev-sn=FT2U2SK1 \
+   --input=${FLASH_BIN}
 ```

--- a/sw/host/spiflash/ftdi_spi_interface.cc
+++ b/sw/host/spiflash/ftdi_spi_interface.cc
@@ -24,19 +24,22 @@ namespace opentitan {
 namespace spiflash {
 namespace {
 
+/** FTDI MPSSE GPIO Mappings */
 enum FtdiGpioMapping {
-  // SRST_N reset.
+  /** SRST_N reset. */
   kGpioJtagSrstN = GPIOL1,
 
-  // JTAG SPI_N select signal.
+  /** JTAG SPI_N select signal. */
   kGpioJtagSpiN = GPIOL2,
 
-  // Bootstrap pin.
+  /** Bootstrap pin. */
   kBootstrapH = GPIOL3,
 };
 
-// Resets the target to go back to boot_rom. Assumes boot_rom will enter
-// bootstrap mode.
+/**
+ * Resets the target to go back to boot_rom. Assumes boot_rom will enter
+ * bootstrap mode.
+ */
 void ResetTarget(struct mpsse_context *ctx) {
   // Set bootstrap pin high
   PinHigh(ctx, kBootstrapH);
@@ -54,8 +57,10 @@ void ResetTarget(struct mpsse_context *ctx) {
 }
 }  // namespace
 
-// Wrapper struct used to hide mpsse_context since incomplete C struct
-// declarations don't play in forward declarations.
+/**
+ * Wrapper struct used to hide mpsse_context since incomplete C struct
+ * declarations don't play in forward declarations.
+ */
 struct MpsseHandle {
   struct mpsse_context *ctx;
 

--- a/sw/host/spiflash/ftdi_spi_interface.h
+++ b/sw/host/spiflash/ftdi_spi_interface.h
@@ -16,44 +16,42 @@ namespace spiflash {
 // Forward declaration used to hide MPSSE context.
 struct MpsseHandle;
 
-// Implements SPI interface for an OpenTitan design connected via FTDI.
-// FTDI provides an USB interface called Multi-Protocol Synchronous Serial
-// Engine (MPSSE) which gives access to SPI, I2C and JTAG. This class uses
-// MPSSE to communicate with the SPI device IP in OpenTitan.
-// This class is not thread safe.
+/**
+ * Implements SPI interface for an OpenTitan design connected via FTDI.
+ * FTDI provides an USB interface called Multi-Protocol Synchronous Serial
+ * Engine (MPSSE) which gives access to SPI, I2C and JTAG. This class uses
+ * MPSSE to communicate with the SPI device IP in OpenTitan.
+ * This class is not thread safe.
+ */
 class FtdiSpiInterface : public SpiInterface {
  public:
-  // FTDI SPI configuration options.
+  /** FTDI SPI configuration options. */
   struct Options {
-    // USB device vendor ID.
+    /** USB device vendor ID. */
     int32_t device_vendor_id;
 
-    // USB device product ID.
+    /** USB device product ID. */
     int32_t device_product_id;
 
-    // USB device serial number.
+    /** USB device serial number. */
     std::string device_serial_number;
 
-    // Time to wait between attempts to check the hash in nanoseconds.
+    /** Time to wait between attempts to check the hash in nanoseconds. */
     int32_t hash_read_delay_ns = 10000;
 
-    // Time before giving up on looking for the correct hash.
+    /** Time before giving up on looking for the correct hash. */
     int32_t hash_read_timeout_ns = 1000000;
 
-    // FTDI Configuration. This can be made configurable later on if needed.
-    // Default value is 1MHz.
+    /** FTDI Configuration. This can be made configurable later on if needed.
+     * Default value is 1MHz. */
     int32_t spi_frequency = 1000000;
   };
 
   explicit FtdiSpiInterface(Options options);
   ~FtdiSpiInterface() override;
 
-  // Initialize interface.
   bool Init() final;
-
-  // Transmit bytes from `tx` buffer. The number of bytes are defined by `size`.
   bool TransmitFrame(const uint8_t *tx, size_t size) final;
-
   bool CheckHash(const uint8_t *tx, size_t size) final;
 
  private:

--- a/sw/host/spiflash/ftdi_spi_interface.h
+++ b/sw/host/spiflash/ftdi_spi_interface.h
@@ -23,7 +23,29 @@ struct MpsseHandle;
 // This class is not thread safe.
 class FtdiSpiInterface : public SpiInterface {
  public:
-  FtdiSpiInterface();
+  // FTDI SPI configuration options.
+  struct Options {
+    // USB device vendor ID.
+    int32_t device_vendor_id;
+
+    // USB device product ID.
+    int32_t device_product_id;
+
+    // USB device serial number.
+    std::string device_serial_number;
+
+    // Time to wait between attempts to check the hash in nanoseconds.
+    int32_t hash_read_delay_ns = 10000;
+
+    // Time before giving up on looking for the correct hash.
+    int32_t hash_read_timeout_ns = 1000000;
+
+    // FTDI Configuration. This can be made configurable later on if needed.
+    // Default value is 1MHz.
+    int32_t spi_frequency = 1000000;
+  };
+
+  explicit FtdiSpiInterface(Options options);
   ~FtdiSpiInterface() override;
 
   // Initialize interface.
@@ -35,6 +57,7 @@ class FtdiSpiInterface : public SpiInterface {
   bool CheckHash(const uint8_t *tx, size_t size) final;
 
  private:
+  Options options_;
   std::unique_ptr<MpsseHandle> spi_;
 };
 

--- a/sw/host/spiflash/spi_interface.h
+++ b/sw/host/spiflash/spi_interface.h
@@ -11,8 +11,10 @@
 namespace opentitan {
 namespace spiflash {
 
-// This class defines the SPI interface used to communicate with an OpenTitan
-// device.
+/**
+ * This class defines the SPI interface used to communicate with an OpenTitan
+ * device.
+ */
 class SpiInterface {
  public:
   SpiInterface() = default;
@@ -22,16 +24,31 @@ class SpiInterface {
   SpiInterface(const SpiInterface &) = delete;
   SpiInterface &operator=(const SpiInterface &) = delete;
 
-  // Initialize SPI interface. Returns true on success.
+  /** Initialize SPI interface. Returns true on success. */
   virtual bool Init() = 0;
 
-  // Transmit bytes from `tx` buffer. The number of bytes transferred is defined
-  // by `size`.
+  /**
+   * Transmit bytes from `tx` buffer. The number of bytes are defined by `size`.
+   *
+   * @param tx   transmit buffer.
+   * @param size number of bytes to transmit.
+   *
+   * @return true on success, false otherwise.
+   */
   virtual bool TransmitFrame(const uint8_t *tx, size_t size) = 0;
 
-  // Wait until the hash from the previously sent is able to be read. The
-  // previous frame to check the hash for should be provided in `tx` and the
-  // frame's length as `size`.
+  /**
+   * Checks hash response from SPI interface.
+   *
+   * Wait until the hash from the previously sent is able to be read. The
+   * previous frame to check the hash for should be provided in `tx` and the
+   * frame's length as `size`.
+   *
+   * @param tx   transmit buffer.
+   * @param size number of bytes in `tx` buffer.
+   *
+   * @return true if hash matches
+   */
   virtual bool CheckHash(const uint8_t *tx, size_t size) = 0;
 };
 

--- a/sw/host/spiflash/spiflash.cc
+++ b/sw/host/spiflash/spiflash.cc
@@ -25,10 +25,10 @@ constexpr char kUsageString[] = R"R( usage options:
   --input=Input image in binary format.
 
 FTDI Options:
-  [--dev_id="vid:pid"] FTDI device ID.
+  [--dev-id="vid:pid"] FTDI device ID.
     vid: Vendor ID in string hex format.
     pid: Product ID in string hex format.
-  [--dev_sn=string] FTDI serial number. Requires --dev_id to be set.
+  [--dev-sn=string] FTDI serial number. Requires --dev-id to be set.
 
 Verilator Options:
   [--verilator=filehandle] Enables Verilator mode with SPI filehandle.)R";
@@ -84,7 +84,7 @@ static void PrintUsage(int argc, char *argv[]) {
 bool ParseDeviceID(const std::string &device_id, SpiFlashOpts *options) {
   size_t token_pos = device_id.find(':');
   if (token_pos == std::string::npos) {
-    std::cerr << "Unable to find device separator ':' in --device_id."
+    std::cerr << "Unable to find device separator ':' in --device-id."
               << std::endl;
     return false;
   }
@@ -108,8 +108,8 @@ bool ParseArgs(int argc, char **argv, SpiFlashOpts *options) {
   assert(options);
   const struct option long_options[] = {
       {"input", required_argument, nullptr, 'i'},
-      {"dev_id", required_argument, nullptr, 'd'},
-      {"dev_sn", required_argument, nullptr, 'n'},
+      {"dev-id", required_argument, nullptr, 'd'},
+      {"dev-sn", required_argument, nullptr, 'n'},
       {"verilator", required_argument, nullptr, 's'},
       {"help", no_argument, nullptr, 'h'},
       {nullptr, no_argument, nullptr, 0}};

--- a/sw/host/spiflash/spiflash.cc
+++ b/sw/host/spiflash/spiflash.cc
@@ -3,9 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <assert.h>
-#include <getopt.h>
-
 #include <fstream>
+#include <getopt.h>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -24,6 +23,14 @@ using opentitan::spiflash::VerilatorSpiInterface;
 
 constexpr char kUsageString[] = R"R( usage options:
   --input=Input image in binary format.
+
+FTDI Options:
+  [--dev_id="vid:pid"] FTDI device ID.
+    vid: Vendor ID in string hex format.
+    pid: Product ID in string hex format.
+  [--dev_sn=string] FTDI serial number. Requires --dev_id to be set.
+
+Verilator Options:
   [--verilator=filehandle] Enables Verilator mode with SPI filehandle.)R";
 
 // SPI flash configuration options.
@@ -36,6 +43,9 @@ struct SpiFlashOpts {
 
   // Set to true to target Verilator environment.
   bool verilator = false;
+
+  // FTDI configuration options.
+  FtdiSpiInterface::Options ftdi_options;
 };
 
 // Get |filename| contents and store them in |contents|. Using std::string for
@@ -61,17 +71,42 @@ static void PrintUsage(int argc, char *argv[]) {
   std::cerr << argv[0] << kUsageString << std::endl;
 }
 
+// Extracts the vendor and product ID from `device_id` and stores the values
+// in `options`. Returns true on success.
+// This function may throw exceptions.
+bool ParseDeviceID(const std::string &device_id, SpiFlashOpts *options) {
+  size_t token_pos = device_id.find(':');
+  if (token_pos == std::string::npos) {
+    std::cerr << "Unable to find device separator ':' in --device_id."
+              << std::endl;
+    return false;
+  }
+
+  std::string vendor_id = device_id.substr(/*pos=*/0, /*len=*/token_pos);
+  options->ftdi_options.device_vendor_id =
+      std::stoi(vendor_id, /*pos=*/0, /*base=*/16);
+
+  std::string product_id =
+      device_id.substr(/*pos=*/token_pos + 1, /*len=*/std::string::npos);
+  options->ftdi_options.device_product_id =
+      std::stoi(product_id, /*pos=*/0, /*base=*/16);
+
+  return true;
+}
+
 // Parse command line arguments and store results in |options|.
 bool ParseArgs(int argc, char **argv, SpiFlashOpts *options) {
   assert(options);
   const struct option long_options[] = {
       {"input", required_argument, nullptr, 'i'},
+      {"dev_id", required_argument, nullptr, 'd'},
+      {"dev_sn", required_argument, nullptr, 'n'},
       {"verilator", required_argument, nullptr, 's'},
       {"help", no_argument, nullptr, 'h'},
       {nullptr, no_argument, nullptr, 0}};
 
   while (true) {
-    int c = getopt_long(argc, argv, "i:s:h?", long_options, nullptr);
+    int c = getopt_long(argc, argv, "i:d:n:s:h?", long_options, nullptr);
     if (c == -1) {
       return true;
     }
@@ -81,6 +116,14 @@ bool ParseArgs(int argc, char **argv, SpiFlashOpts *options) {
         break;
       case 'i':
         options->input = optarg;
+        break;
+      case 'd':
+        if (!ParseDeviceID(std::string(optarg), options)) {
+          return false;
+        }
+        break;
+      case 'n':
+        options->ftdi_options.device_serial_number = optarg;
         break;
       case 's':
         options->verilator = true;
@@ -108,7 +151,7 @@ int main(int argc, char **argv) {
   if (spi_flash_options.verilator) {
     spi = std::make_unique<VerilatorSpiInterface>(spi_flash_options.target);
   } else {
-    spi = std::make_unique<FtdiSpiInterface>();
+    spi = std::make_unique<FtdiSpiInterface>(spi_flash_options.ftdi_options);
   }
   if (!spi->Init()) {
     return 1;

--- a/sw/host/spiflash/spiflash.cc
+++ b/sw/host/spiflash/spiflash.cc
@@ -33,23 +33,25 @@ FTDI Options:
 Verilator Options:
   [--verilator=filehandle] Enables Verilator mode with SPI filehandle.)R";
 
-// SPI flash configuration options.
+/** SPI flash configuration options. */
 struct SpiFlashOpts {
-  // Input file in binary format.
+  /** Input file in binary format. */
   std::string input;
 
-  // Target SPI device handle.
+  /** Target SPI device handle. */
   std::string target;
 
-  // Set to true to target Verilator environment.
+  /** Set to true to target Verilator environment. */
   bool verilator = false;
 
-  // FTDI configuration options.
+  /** FTDI configuration options. */
   FtdiSpiInterface::Options ftdi_options;
 };
 
-// Get |filename| contents and store them in |contents|. Using std::string for
-// |filename| because underlying open file call requires a C string.
+/**
+ * Get `filename` contents and store them in `contents`. Using std::string for
+ * `filename` because underlying open file call requires a C string.
+ */
 bool GetFileContents(const std::string &filename, std::string *contents) {
   assert(contents);
   std::ifstream file_stream(filename, std::ios::in | std::ios::binary);
@@ -65,15 +67,20 @@ bool GetFileContents(const std::string &filename, std::string *contents) {
   return true;
 }
 
-// Prints help menu.
+/** Print help menu. */
 static void PrintUsage(int argc, char *argv[]) {
   assert(argc >= 1);
   std::cerr << argv[0] << kUsageString << std::endl;
 }
 
-// Extracts the vendor and product ID from `device_id` and stores the values
-// in `options`. Returns true on success.
-// This function may throw exceptions.
+/*
+ * Extract the vendor and product ID from `device_id` and store the values
+ * in `options`.
+ *
+ * This function may throw exceptions.
+ *
+ * @return true on success.
+ */
 bool ParseDeviceID(const std::string &device_id, SpiFlashOpts *options) {
   size_t token_pos = device_id.find(':');
   if (token_pos == std::string::npos) {
@@ -94,7 +101,9 @@ bool ParseDeviceID(const std::string &device_id, SpiFlashOpts *options) {
   return true;
 }
 
-// Parse command line arguments and store results in |options|.
+/*
+ * Parse command line arguments and store results in `options`.
+ */
 bool ParseArgs(int argc, char **argv, SpiFlashOpts *options) {
   assert(options);
   const struct option long_options[] = {

--- a/sw/host/spiflash/updater.cc
+++ b/sw/host/spiflash/updater.cc
@@ -4,18 +4,22 @@
 
 #include "sw/host/spiflash/updater.h"
 
-#include <assert.h>
-
 #include <algorithm>
+#include <assert.h>
 
 namespace opentitan {
 namespace spiflash {
 namespace {
 
-// Populates frame |f| with |frame_number|, |code_offset|, and frame data
-// starting at |code_offset| from |code| buffer. Calculates SHA256 hash of
-// frame payload and it stores it in the frame header. Returns the number of
-// bytes loaded into the frame.
+/**
+ * Populate target frame `f`.
+ *
+ * Populates frame `f` with `frame_number`, `code_offset`, and frame data
+ * starting at `code_offset` from `code` buffer. Calculates SHA256 hash of
+ * frame payload and it stores it in the frame header.
+ *
+ * @return the number of bytes loaded into the frame.
+ */
 uint32_t Populate(uint32_t frame_number, uint32_t code_offset,
                   const std::string &code, Frame *f) {
   assert(f);
@@ -34,7 +38,9 @@ uint32_t Populate(uint32_t frame_number, uint32_t code_offset,
   return copy_size;
 }
 
-// Calculate hash for frame |f| and store it in the frame header hash field.
+/**
+ * Calculate hash for frame `f` and store it in the frame header hash field.
+ */
 void HashFrame(Frame *f) {
   SHA256_CTX sha256;
   SHA256_Init(&sha256);

--- a/sw/host/spiflash/updater.h
+++ b/sw/host/spiflash/updater.h
@@ -21,41 +21,49 @@
 namespace opentitan {
 namespace spiflash {
 
-// Implements the bootstrap SPI frame message.
+/** Implements the bootstrap SPI frame message. */
 struct Frame {
-  // Frame header definition.
+  /** Frame header definition. */
   struct {
-    // SHA2 of the entire frame_t message starting at the `frame_num` offset.
+    /** Hash of the `Frame` message starting at the `frame_num` offset. */
     uint8_t hash[32];
 
-    // Frame number. Starting at 0.
+    /** Frame number. Starting at 0. */
     uint32_t frame_num;
 
-    // Flash target offset.
+    /** Flash target offset. */
     uint32_t offset;
   } hdr;
 
+  /** Frame payload. */
   uint8_t data[1024 - sizeof(hdr)];
 
-  // Returns available the frame available payload size in bytes.
+  /** Returns available the frame available payload size in bytes. */
   size_t PayloadSize() const { return 1024 - sizeof(hdr); }
 };
 
-// Implements SPI flash update protocol.
-//
-// The firmare image is split into frames, and then sent to the SPI device.
-// More details will be added on the ack protocol once implemented.
-// This class is not thread safe due to the spi driver dependency.
+/**
+ * Implements SPI flash update protocol.
+ *
+ * The firmare image is split into frames, and then sent to the SPI device.
+ * More details will be added on the ack protocol once implemented.
+ * This class is not thread safe due to the spi driver dependency.
+ */
 class Updater {
  public:
-  // Updater configuration settings.
+  /** Updater configuration settings. */
   struct Options {
-    // Firmware image in binary format.
+    /** Firmware image in binary format. */
     std::string code;
   };
 
-  // Constructs updater instance with given configuration `options` and `spi`
-  // interface.
+  /**
+   * Constructs updater instance with given configuration `options` and `spi`
+   * interface.
+   *
+   * @param options `Updater` options @see Updater::Options.
+   * @param spi     SPI interface @see SpiInterface.
+   */
   Updater(Options options, std::unique_ptr<SpiInterface> spi)
       : options_(options), spi_(std::move(spi)) {}
   virtual ~Updater() = default;
@@ -64,11 +72,22 @@ class Updater {
   Updater(const Updater &) = delete;
   Updater &operator=(const Updater &) = delete;
 
-  // Runs update flow returning true on success.
+  /**
+   * Runs update flow returning true on success.
+   *
+   * @return true on success, false otherwise.
+   */
   bool Run();
 
  private:
-  // Generates `frames` for `code` image.
+  /**
+   * Generates `frames` from `code` image.
+   *
+   * @param code   software image in binary format.
+   * @param frames output SPI frames.
+   *
+   * @return true on success, false otherwise.
+   */
   bool GenerateFrames(const std::string &code, std::vector<Frame> *frames);
 
   Options options_;

--- a/sw/host/spiflash/verilator_spi_interface.cc
+++ b/sw/host/spiflash/verilator_spi_interface.cc
@@ -18,11 +18,11 @@ namespace opentitan {
 namespace spiflash {
 namespace {
 
-// Required delay to synchronize transactions with simulation environment.
 // TODO: If transmission is not successful, adapt this by an argument.
+/** Required delay to synchronize transactions with simulation environment. */
 constexpr int kWriteReadDelay = 20000000;
 
-// Configure |fd| as a serial port with baud rate 9600.
+/** Configure `fd` as a serial port with baud rate 9600. */
 bool SetTermOpts(int fd) {
   struct termios options;
   if (tcgetattr(fd, &options) != 0) {
@@ -42,9 +42,11 @@ bool SetTermOpts(int fd) {
   return true;
 }
 
-// Returns file handle on success, or nullopt on failure. This function
-// configures de file handle to behave as a serial port with baud rate 9600,
-// which is the baud rate supported by Verilator.
+/**
+ * Returns file handle on success, or -1 on failure. This function
+ * configures de file handle to behave as a serial port with baud rate 9600,
+ * which is the baud rate supported by Verilator.
+ */
 int OpenDevice(const std::string &filename) {
   int fd = open(filename.c_str(), O_RDWR | O_NOCTTY | O_NONBLOCK | O_CLOEXEC);
   if (fd < 0) {
@@ -58,8 +60,10 @@ int OpenDevice(const std::string &filename) {
   return fd;
 }
 
-// Reads |size| bytes into |rx| buffer from |fd|. Returns the number of bytes
-// read.
+/**
+ * Reads `size` bytes into `rx` buffer from `fd`. Returns the number of bytes
+ * read.
+ */
 size_t ReadBytes(int fd, uint8_t *rx, size_t size) {
   size_t bytes_read = 0;
   while (bytes_read != size) {

--- a/sw/host/spiflash/verilator_spi_interface.h
+++ b/sw/host/spiflash/verilator_spi_interface.h
@@ -12,26 +12,26 @@
 namespace opentitan {
 namespace spiflash {
 
-// Implements SPI interface for an OpenTitan instance running on Verilator.
-// The OpenTitan Verilator model provides a file handle for the SPI device
-// interface. This class sends ands recevies data to the device handle, and
-// adds synchronication delays between writes and reads.
-// This class is not thread safe.
+/**
+ * Implements SPI interface for an OpenTitan instance running on Verilator.
+ * The OpenTitan Verilator model provides a file handle for the SPI device
+ * interface. This class sends ands recevies data to the device handle, and
+ * adds synchronication delays between writes and reads.
+ * This class is not thread safe.
+ */
 class VerilatorSpiInterface : public SpiInterface {
  public:
-  // Constructs instance pointing to the `spi_filename` file path.
+  /** Constructs instance pointing to the `spi_filename` file path. */
   explicit VerilatorSpiInterface(std::string spi_filename)
       : spi_filename_(spi_filename), fd_(-1) {}
 
-  // Closes the internal file handle used to communicate with the SPI device.
+  /**
+   * Closes the internal file handle used to communicate with the SPI device.
+   */
   ~VerilatorSpiInterface() override;
 
-  // Initialize interface.
   bool Init() final;
-
-  // Transmit bytes from `tx` buffer. The number of bytes are defined by `size`.
   bool TransmitFrame(const uint8_t *tx, size_t size) final;
-
   bool CheckHash(const uint8_t *tx, size_t size) final;
 
  private:


### PR DESCRIPTION
This PR adds support for overriding the FTDI device ID in spiflash. This is required when working with FTDI MPSSE USB cables or other FPGA boards.

The following command line options are added to spiflash:
  
* `--dev_id`: FTDI USB vendor and product ID.
* `--dev_sn`: FTDI USB serial number.

Other changes:

* Convert documentation to Doxygen format. Simple format conversion.
* Update README.md with instructions on how to override the device ID.