### PR TITLE
Allow different assertion "backends" in prim_assert.sv

### DIFF
--- a/hw/formal/fpv_vcf.tcl
+++ b/hw/formal/fpv_vcf.tcl
@@ -11,7 +11,6 @@
 
 analyze -format sverilog      \
   -vcs "+define+FPV_ON -assert svaext \
-        +define+INC_ASSERT  \
         -f [glob *.scr]"
 
 elaborate -sva $env(FPV_TOP)

--- a/hw/ip/prim/prim_assert.core
+++ b/hw/ip/prim/prim_assert.core
@@ -9,6 +9,9 @@ filesets:
   files_rtl:
     files:
       - rtl/prim_assert.sv : {is_include_file : true}
+      - rtl/prim_assert_dummy_macros.svh : {is_include_file : true}
+      - rtl/prim_assert_yosys_macros.svh : {is_include_file : true}
+      - rtl/prim_assert_standard_macros.svh : {is_include_file : true}
     file_type: systemVerilogSource
 
 targets:

--- a/hw/ip/prim/rtl/prim_assert.sv
+++ b/hw/ip/prim/rtl/prim_assert.sv
@@ -24,101 +24,59 @@
 // Helper macros //
 ///////////////////
 
-// local helper macro to reduce code clutter. undefined at the end of this file
-`ifndef VERILATOR
-`ifndef SYNTHESIS
-`define INC_ASSERT
-`endif
-`endif
-
-// Converts an arbitrary block of code into a Verilog string
-`define PRIM_STRINGIFY(__x) `"__x`"
-
-// ASSERT_RPT is available to change the reporting mechanism when an assert fails
-`define ASSERT_RPT(__name)                                                  \
-`ifdef UVM                                                                  \
-  assert_rpt_pkg::assert_rpt($sformatf("[%m] %s (%s:%0d)",                  \
-                             __name, `__FILE__, `__LINE__));                \
-`else                                                                       \
-  $error("[ASSERT FAILED] [%m] %s (%s:%0d)", __name, `__FILE__, `__LINE__); \
-`endif
-
-///////////////////////////////////////
-// Simple assertion and cover macros //
-///////////////////////////////////////
-
 // Default clk and reset signals used by assertion macros below.
 `define ASSERT_DEFAULT_CLK clk_i
 `define ASSERT_DEFAULT_RST !rst_ni
 
-// Immediate assertion
-// Note that immediate assertions are sensitive to simulation glitches.
-`define ASSERT_I(__name, __prop)           \
-`ifdef INC_ASSERT                          \
-  __name: assert (__prop)                  \
-    else begin                             \
-      `ASSERT_RPT(`PRIM_STRINGIFY(__name)) \
-    end                                    \
-`endif
+// Converts an arbitrary block of code into a Verilog string
+`define PRIM_STRINGIFY(__x) `"__x`"
 
-// Assertion in initial block. Can be used for things like parameter checking.
-`define ASSERT_INIT(__name, __prop)          \
-`ifdef INC_ASSERT                            \
-  initial begin                              \
-    __name: assert (__prop)                  \
-      else begin                             \
-        `ASSERT_RPT(`PRIM_STRINGIFY(__name)) \
-      end                                    \
-  end                                        \
-`endif
+// The basic helper macros are actually defined in "implementation headers". The macros should do
+// the same thing in each case (except for the dummy flavour), but in a way that the respective
+// tools support.
+//
+// If the tool supports assertions in some form, we also define INC_ASSERT (which can be used to
+// hide signal definitions that are only used for assertions).
+//
+// The list of basic macros supported is:
+//
+//  ASSERT_I:     Immediate assertion. Note that immediate assertions are sensitive to simulation
+//                glitches.
+//
+//  ASSERT_INIT:  Assertion in initial block. Can be used for things like parameter checking.
+//
+//  ASSERT_FINAL: Assertion in final block. Can be used for things like queues being empty at end of
+//                sim, all credits returned at end of sim, state machines in idle at end of sim.
+//
+//  ASSERT:       Assert a concurrent property directly. It can be called as a module (or
+//                interface) body item.
+//
+//                Note: We use (__rst !== '0) in the disable iff statements instead of (__rst ==
+//                '1). This properly disables the assertion in cases when reset is X at the
+//                beginning of a simulation. For that case, (reset == '1) does not disable the
+//                assertion.
+//
+//  ASSERT_NEVER: Assert a concurrent property NEVER happens
+//
+//  ASSERT_KNOWN: Assert that signal has a known value (each bit is either '0' or '1') after reset.
+//                It can be called as a module (or interface) body item.
+//
+//  COVER:        Cover a concurrent property
+//
+//  ASSUME:       Assume a concurrent property
+//
+//  ASSUME_I:     Assume an immediate property
 
-// Assertion in final block. Can be used for things like queues being empty
-// at end of sim, all credits returned at end of sim, state machines in idle
-// at end of sim.
-`define ASSERT_FINAL(__name, __prop)                                         \
-`ifdef INC_ASSERT                                                            \
-  final begin                                                                \
-    __name: assert (__prop || $test$plusargs("disable_assert_final_checks")) \
-      else begin                                                             \
-        `ASSERT_RPT(`PRIM_STRINGIFY(__name))                                 \
-      end                                                                    \
-  end                                                                        \
-`endif
-
-// Assert a concurrent property directly.
-// It can be called as a module (or interface) body item.
-`define ASSERT(__name, __prop, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST) \
-`ifdef INC_ASSERT                                                                        \
-  __name: assert property (@(posedge __clk) disable iff ((__rst) !== '0) (__prop))       \
-    else begin                                                                           \
-      `ASSERT_RPT(`PRIM_STRINGIFY(__name))                                               \
-    end                                                                                  \
-`endif
-// Note: Above we use (__rst !== '0) in the disable iff statements instead of
-// (__rst == '1).  This properly disables the assertion in cases when reset is X at
-// the beginning of a simulation. For that case, (reset == '1) does not disable the
-// assertion.
-
-// Assert a concurrent property NEVER happens
-`define ASSERT_NEVER(__name, __prop, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST) \
-`ifdef INC_ASSERT                                                                              \
-  __name: assert property (@(posedge __clk) disable iff ((__rst) !== '0) not (__prop))         \
-    else begin                                                                                 \
-      `ASSERT_RPT(`PRIM_STRINGIFY(__name))                                                     \
-    end                                                                                        \
-`endif
-
-// Assert that signal has a known value (each bit is either '0' or '1') after reset.
-// It can be called as a module (or interface) body item.
-`define ASSERT_KNOWN(__name, __sig, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST) \
-`ifdef INC_ASSERT                                                                             \
-  `ASSERT(__name, !$isunknown(__sig), __clk, __rst)                                           \
-`endif
-
-//  Cover a concurrent property
-`define COVER(__name, __prop, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST) \
-`ifdef INC_ASSERT                                                                       \
-  __name: cover property (@(posedge __clk) disable iff ((__rst) !== '0) (__prop));      \
+`ifdef VERILATOR
+ `include "prim_assert_dummy_macros.svh"
+`elsif SYNTHESIS
+ `include "prim_assert_dummy_macros.svh"
+`elsif YOSYS
+ `include "prim_assert_yosys_macros.svh"
+ `define INC_ASSERT
+`else
+ `include "prim_assert_standard_macros.svh"
+ `define INC_ASSERT
 `endif
 
 //////////////////////////////
@@ -127,46 +85,18 @@
 
 // Assert that signal is an active-high pulse with pulse length of 1 clock cycle
 `define ASSERT_PULSE(__name, __sig, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST) \
-`ifdef INC_ASSERT                                                                             \
-  `ASSERT(__name, $rose(__sig) |=> !(__sig), __clk, __rst)                                    \
-`endif
+  `ASSERT(__name, $rose(__sig) |=> !(__sig), __clk, __rst)
 
 // Assert that a property is true only when an enable signal is set.  It can be called as a module
 // (or interface) body item.
 `define ASSERT_IF(__name, __prop, __enable, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST) \
-`ifdef INC_ASSERT                                                                                     \
-  `ASSERT(__name, (__enable) |-> (__prop), __clk, __rst)                                              \
-`endif
+  `ASSERT(__name, (__enable) |-> (__prop), __clk, __rst)
 
 // Assert that signal has a known value (each bit is either '0' or '1') after reset if enable is
 // set.  It can be called as a module (or interface) body item.
 `define ASSERT_KNOWN_IF(__name, __sig, __enable, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST) \
-`ifdef INC_ASSERT                                                                                          \
   `ASSERT_KNOWN(__name``KnownEnable, __enable, __clk, __rst)                                               \
-  `ASSERT_IF(__name, !$isunknown(__sig), __enable, __clk, __rst)                                           \
-`endif
-
-///////////////////////
-// Assumption macros //
-///////////////////////
-
-// Assume a concurrent property
-`define ASSUME(__name, __prop, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST) \
-`ifdef INC_ASSERT                                                                        \
-  __name: assume property (@(posedge __clk) disable iff ((__rst) !== '0) (__prop))       \
-    else begin                                                                           \
-      `ASSERT_RPT(`PRIM_STRINGIFY(__name))                                               \
-    end                                                                                  \
-`endif
-
-// Assume an immediate property
-`define ASSUME_I(__name, __prop)           \
-`ifdef INC_ASSERT                          \
-  __name: assume (__prop)                  \
-    else begin                             \
-      `ASSERT_RPT(`PRIM_STRINGIFY(__name)) \
-    end                                    \
-`endif
+  `ASSERT_IF(__name, !$isunknown(__sig), __enable, __clk, __rst)
 
 //////////////////////////////////
 // For formal verification only //

--- a/hw/ip/prim/rtl/prim_assert_dummy_macros.svh
+++ b/hw/ip/prim/rtl/prim_assert_dummy_macros.svh
@@ -1,0 +1,16 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Macro bodies included by prim_assert.sv for tools that don't support assertions. See
+// prim_assert.sv for documentation for each of the macros.
+
+`define ASSERT_I(__name, __prop)
+`define ASSERT_INIT(__name, __prop)
+`define ASSERT_FINAL(__name, __prop)
+`define ASSERT(__name, __prop, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST)
+`define ASSERT_NEVER(__name, __prop, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST)
+`define ASSERT_KNOWN(__name, __sig, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST)
+`define COVER(__name, __prop, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST)
+`define ASSUME(__name, __prop, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST)
+`define ASSUME_I(__name, __prop)

--- a/hw/ip/prim/rtl/prim_assert_standard_macros.svh
+++ b/hw/ip/prim/rtl/prim_assert_standard_macros.svh
@@ -1,0 +1,67 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Macro bodies included by prim_assert.sv for tools that support full SystemVerilog and SVA syntax.
+// See prim_assert.sv for documentation for each of the macros.
+
+// ASSERT_RPT is available to change the reporting mechanism when an assert fails
+`define ASSERT_RPT(__name)                                                  \
+`ifdef UVM                                                                  \
+  assert_rpt_pkg::assert_rpt($sformatf("[%m] %s (%s:%0d)",                  \
+                             __name, `__FILE__, `__LINE__));                \
+`else                                                                       \
+  $error("[ASSERT FAILED] [%m] %s (%s:%0d)", __name, `__FILE__, `__LINE__); \
+`endif
+
+`define ASSERT_I(__name, __prop)           \
+  __name: assert (__prop)                  \
+    else begin                             \
+      `ASSERT_RPT(`PRIM_STRINGIFY(__name)) \
+    end
+
+`define ASSERT_INIT(__name, __prop)          \
+  initial begin                              \
+    __name: assert (__prop)                  \
+      else begin                             \
+        `ASSERT_RPT(`PRIM_STRINGIFY(__name)) \
+      end                                    \
+  end
+
+`define ASSERT_FINAL(__name, __prop)                                         \
+  final begin                                                                \
+    __name: assert (__prop || $test$plusargs("disable_assert_final_checks")) \
+      else begin                                                             \
+        `ASSERT_RPT(`PRIM_STRINGIFY(__name))                                 \
+      end                                                                    \
+  end
+
+`define ASSERT(__name, __prop, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST) \
+  __name: assert property (@(posedge __clk) disable iff ((__rst) !== '0) (__prop))       \
+    else begin                                                                           \
+      `ASSERT_RPT(`PRIM_STRINGIFY(__name))                                               \
+    end
+
+`define ASSERT_NEVER(__name, __prop, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST) \
+  __name: assert property (@(posedge __clk) disable iff ((__rst) !== '0) not (__prop))         \
+    else begin                                                                                 \
+      `ASSERT_RPT(`PRIM_STRINGIFY(__name))                                                     \
+    end
+
+`define ASSERT_KNOWN(__name, __sig, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST) \
+  `ASSERT(__name, !$isunknown(__sig), __clk, __rst)
+
+`define COVER(__name, __prop, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST) \
+  __name: cover property (@(posedge __clk) disable iff ((__rst) !== '0) (__prop));
+
+`define ASSUME(__name, __prop, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST) \
+  __name: assume property (@(posedge __clk) disable iff ((__rst) !== '0) (__prop))       \
+    else begin                                                                           \
+      `ASSERT_RPT(`PRIM_STRINGIFY(__name))                                               \
+    end
+
+`define ASSUME_I(__name, __prop)           \
+  __name: assume (__prop)                  \
+    else begin                             \
+      `ASSERT_RPT(`PRIM_STRINGIFY(__name)) \
+    end

--- a/hw/ip/prim/rtl/prim_assert_yosys_macros.svh
+++ b/hw/ip/prim/rtl/prim_assert_yosys_macros.svh
@@ -1,0 +1,47 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Macro bodies included by prim_assert.sv for formal verification with Yosys. See prim_assert.sv
+// for documentation for each of the macros.
+
+`define ASSERT_I(__name, __prop)    \
+  always_comb begin : __name        \
+    assert (__prop);                \
+  end
+
+`define ASSERT_INIT(__name, __prop)    \
+  initial begin : __name               \
+    assert (__prop);                   \
+  end
+
+// This doesn't make much sense for a formal tool (we never get to the final block!)
+`define ASSERT_FINAL(__name, __prop)
+
+`define ASSERT(__name, __prop, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST) \
+  always_ff @(posedge __clk) begin                                                       \
+    if (! (__rst !== '0)) __name: assert (__prop);                                       \
+  end
+
+`define ASSERT_NEVER(__name, __prop, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST) \
+  always_ff @(posedge __clk) begin                                                             \
+    if (! (__rst !== '0)) __name: assert (! (__prop));                                         \
+  end
+
+// Yosys uses 2-state logic, so this doesn't make sense here
+`define ASSERT_KNOWN(__name, __sig, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST)
+
+`define COVER(__name, __prop, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST) \
+  always_ff @(posedge __clk) begin : __name                                             \
+    cover ((! (__rst !== '0)) && (__prop));                                             \
+  end
+
+`define ASSUME(__name, __prop, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST) \
+  always_ff @(posedge __clk) begin                                                       \
+    if (! (__rst !== '0)) __name: assume (__prop);                                       \
+  end
+
+`define ASSUME_I(__name, __prop)              \
+  always_comb begin : __name                  \
+    assume (__prop);                          \
+  end


### PR DESCRIPTION
(PR description edited to match new commit message)

Different tools support different assertions. This splits out the
definitions of the base macros from prim_assert.sv into separate
headers (prim_assert_standard_macros.svh, prim_assert_dummy_macros.svh
and prim_assert_yosys_macros.svh).

The last of the three is new: it's used for Yosys when not
synthesizing (so used when Yosys is being run as a formal tool).

At the moment, Yosys's (System)Verilog frontend doesn't support
concurrent assertions. It does, however, support the immediate form,
so prim_assert_yosys_macros.svh expresses them as such.

For example, ASSERT_I is normally

```systemverilog
   name: assert (expr) else stmt
```

but here it becomes:

```systemverilog
   begin : name
     assert (expr);
   end
```

(The name isn't reported by the error reporting machinery in the Yosys
flow, but at least it makes code a bit easier to figure out if you've
preprocessed your source with sv2v and the line numbers are all
bogus).

Similarly, ASSERT is normally something like:

```systemverilog
   name: assert property (@(posedge clk_i) disable iff rst_ni expr)
```

Here it becomes:

```systemverilog
   always_ff @(posedge clk_i) begin : name
     if (rst_ni) name: assert (prop);
   end
```

These transformations should not change the truth of an assertion, at
least with the Yosys tool (which isn't event based and samples signals
for assertions after everything has settled).
