### PR TITLE
[alert/dv] Support reset logic in alert_esc_agent

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_base_monitor.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_base_monitor.sv
@@ -37,7 +37,14 @@ class alert_esc_base_monitor extends dv_base_monitor#(
       @(negedge cfg.vif.rst_n);
       under_reset = 1;
       @(posedge cfg.vif.rst_n);
+      // reset signals at posedge rst_n to avoid race condition at negedge rst_n
+      reset_signals();
       under_reset = 0;
     end
   endtask : reset_thread
+
+  // this function can be used in derived classes to reset local signals/variables if needed
+  virtual function void reset_signals();
+  endfunction
+
 endclass

--- a/hw/dv/sv/alert_esc_agent/alert_monitor.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_monitor.sv
@@ -26,15 +26,10 @@ class alert_monitor extends alert_esc_base_monitor;
     join_none
   endtask : run_phase
 
-  virtual task reset_thread();
-    forever begin
-      @(negedge cfg.vif.rst_n);
-      under_reset = 1;
-      under_ping_rsp = 0;
-      @(posedge cfg.vif.rst_n);
-      under_reset = 0;
-    end
-  endtask : reset_thread
+  virtual function void reset_signals();
+    under_reset = 1;
+    under_ping_rsp = 0;
+  endfunction : reset_signals
 
   virtual task ping_thread();
     alert_esc_seq_item req;

--- a/hw/dv/sv/alert_esc_agent/esc_monitor.sv
+++ b/hw/dv/sv/alert_esc_agent/esc_monitor.sv
@@ -25,6 +25,10 @@ class esc_monitor extends alert_esc_base_monitor;
     join_none
   endtask : run_phase
 
+  virtual function void reset_signals();
+    under_esc_ping = 0;
+  endfunction
+
   virtual task esc_thread();
     alert_esc_seq_item req, req_clone;
     logic esc_p = get_esc();
@@ -88,10 +92,10 @@ class esc_monitor extends alert_esc_base_monitor;
   virtual task unexpected_resp_thread();
     alert_esc_seq_item req;
     forever @(cfg.vif.monitor_cb) begin
-      while (get_esc() === 1'b0 && !under_esc_ping && !under_reset) begin
+      while (get_esc() === 1'b0 && !under_esc_ping) begin
         @(cfg.vif.monitor_cb);
         if (cfg.vif.monitor_cb.esc_rx.resp_p === 1'b1 &&
-            cfg.vif.monitor_cb.esc_rx.resp_n === 1'b0) begin
+            cfg.vif.monitor_cb.esc_rx.resp_n === 1'b0 && !under_reset) begin
           req = alert_esc_seq_item::type_id::create("req");
           req.alert_esc_type = AlertEscIntFail;
           alert_esc_port.write(req);

--- a/hw/dv/sv/alert_esc_agent/esc_receiver_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/esc_receiver_driver.sv
@@ -16,9 +16,11 @@ class esc_receiver_driver extends alert_esc_base_driver;
   virtual task reset_signals();
     forever begin
       @(negedge cfg.vif.rst_n);
+      under_reset = 1;
       reset_resp();
       is_ping = 0;
       @(posedge cfg.vif.rst_n);
+      under_reset = 0;
     end
   endtask
 
@@ -33,66 +35,87 @@ class esc_receiver_driver extends alert_esc_base_driver;
     forever begin
       int cnt ;
       wait(under_reset == 0);
-      wait_esc();
-      @(cfg.vif.receiver_cb);
-      while (get_esc() == 1) begin
-        cnt++;
-        @(cfg.vif.receiver_cb);
-      end
-      if (cnt == 1) is_ping = 1;
+      fork
+        begin
+          wait_esc();
+          @(cfg.vif.receiver_cb);
+          while (get_esc() == 1) begin
+            cnt++;
+            @(cfg.vif.receiver_cb);
+          end
+          if (cnt == 1) is_ping = 1;
+        end
+        begin
+          wait(under_reset);
+        end
+      join_any
+      disable fork;
     end
   endtask
 
   // This task will response to escalator sender's esc_p and esc_n signal,
   // depending on the signal length and req setting, it will response to
   // ping and real esc signals.
+  // Once a request is received, the task uses non-blocking fork to allow other requests to be
+  // received and processed in parallel.
   virtual task rsp_escalator();
     forever begin
       alert_esc_seq_item req, rsp;
-      wait(r_esc_rsp_q.size() > 0);
+      wait(r_esc_rsp_q.size() > 0 && !under_reset);
       req = r_esc_rsp_q.pop_front();
+      $cast(rsp, req.clone());
+      rsp.set_id_info(req);
+      `uvm_info(`gfn,
+                $sformatf("starting to send receiver item, esc_rsp=%0b int_fail=%0b",
+                req.r_esc_rsp, req.int_err), UVM_HIGH)
       fork
-        begin
-          $cast(rsp, req.clone());
-          rsp.set_id_info(req);
-          `uvm_info(`gfn,
-              $sformatf("starting to send receiver item, esc_rsp=%0b int_fail=%0b",
-              req.r_esc_rsp, req.int_err), UVM_HIGH)
-
-          if (req.standalone_int_err) begin
-            wait_esc_complete();
-            if (!is_ping) begin
-              repeat (req.int_err_cyc) begin
-                if (cfg.vif.esc_tx.esc_p === 1'b0 && !is_ping) begin
-                  random_drive_resp_signal();
-                  @(cfg.vif.receiver_cb);
-                end else begin
-                  break;
-                end
-              end
-              // TODO: missed int_err case at cycle when first cycle of the esc_p set
-              if (!is_ping) reset_resp();
-            end
-          end else begin
-            wait_esc();
-            @(cfg.vif.receiver_cb);
-            while (get_esc() === 1'b1) toggle_resp_signal(req);
-            if (is_ping) begin
-              int toggle_cycle = 1;
-              if (req.int_err) toggle_cycle = $urandom_range(0, cfg.ping_timeout_cycle);
-              repeat (toggle_cycle) toggle_resp_signal(req);
-              is_ping = 0;
-            end
-            if (req.int_err) reset_resp();
-          end
-          `uvm_info(`gfn,
-              $sformatf("finished sending receiver item esc_rsp=%0b int_fail=%0b",
-              req.r_esc_rsp, req.int_err), UVM_HIGH)
+        begin : non_blocking_fork
+          fork
+            drive_esc_resp(req);
+            wait(under_reset);
+          join_any
+          disable fork;
+          `uvm_info(`gfn, $sformatf("finished sending receiver item esc_rsp=%0b int_fail=%0b",
+                    req.r_esc_rsp, req.int_err), UVM_HIGH)
           seq_item_port.put_response(rsp);
         end
       join_none
     end // end forever
   endtask : rsp_escalator
+
+  // this task drives resp_p/n according to the req
+  // if req is "standalone_sig_int_err", will wait until no esc_p/n, then random toggle resp_p/n
+  // if esc_p/n is esc signal, will toggle resp_p/n until esc_p is reset back to 0
+  // if esc_p/n is ping, then will toggle resp_p/n for two clk cycles
+  // if req is "sig_int_err", will random toggle, then reset back to resp_p/n = {0/1}
+  virtual task drive_esc_resp(alert_esc_seq_item req);
+    if (req.standalone_int_err) begin
+      wait_esc_complete();
+      if (!is_ping) begin
+        repeat (req.int_err_cyc) begin
+          if (cfg.vif.esc_tx.esc_p === 1'b0 && !is_ping) begin
+            random_drive_resp_signal();
+            @(cfg.vif.receiver_cb);
+          end else begin
+            break;
+          end
+        end
+        // TODO: missed int_err case at first cycle of the esc_p = 1
+        if (!is_ping) reset_resp();
+      end
+    end else begin
+      wait_esc();
+      @(cfg.vif.receiver_cb);
+      while (get_esc() === 1'b1) toggle_resp_signal(req);
+      if (is_ping) begin
+        int toggle_cycle = 1;
+        if (req.int_err) toggle_cycle = $urandom_range(0, cfg.ping_timeout_cycle);
+          repeat (toggle_cycle) toggle_resp_signal(req);
+          is_ping = 0;
+        end
+      if (req.int_err) reset_resp();
+    end
+  endtask
 
   task toggle_resp_signal(alert_esc_seq_item req);
     if (req.int_err) random_drive_resp_signal();


### PR DESCRIPTION
I was working on special target sequence for alert_handler and found current agent's reset logic is a bit messy. 
This PR cleans up the current reset logic and adding the missing reset support by:
1). Add fork join any to all alert and escalation drivers to handle reset. (instead of using "if `under_reset()`")
2). Avoid duplicated code in monitors by adding a common function `reset_signals` in base_monitor.

Signed-off-by: Cindy Chen <chencindy@google.com>