### PR TITLE
[clkmgr] Initial support for clock division

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr.hjson.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.hjson.tpl
@@ -16,17 +16,16 @@ num_grps = len(grps)
 {
   name: "CLKMGR",
   clock_primary: "clk_i",
-  other_clock_list: [
-% for src in srcs:
-    "clk_${src['name']}_i",
-% endfor
-  ],
+  other_clock_list: [],
   reset_primary: "rst_ni",
   other_reset_list: [
 % for src in srcs:
     % if src['aon'] == 'no':
     "rst_${src['name']}_ni"
     % endif
+% endfor
+% for src in div_srcs:
+    "rst_${src['name']}_ni"
 % endfor
   ]
   bus_device: "tlul",
@@ -40,7 +39,6 @@ num_grps = len(grps)
     },
   ],
 
-  // Define rstmgr struct package
   inter_signal_list: [
     { struct:  "clkmgr_out",
       type:    "uni",
@@ -48,6 +46,16 @@ num_grps = len(grps)
       act:     "req",
       package: "clkmgr_pkg",
     },
+
+  // All clock inputs
+% for src in srcs:
+    { struct:  "logic",
+      type:    "uni",
+      name:    "clk_${src['name']}",
+      act:     "rcv",
+      package: "",
+    },
+% endfor
 
     { struct:  "pwr_clk",
       type:    "req_rsp",

--- a/hw/ip/clkmgr/data/clkmgr.sv.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.sv.tpl
@@ -26,6 +26,12 @@ module clkmgr import clkmgr_pkg::*; (
   % endif
 % endfor
 
+  // Resets for derived clocks
+  // clocks are derived locally
+% for src in div_srcs:
+  input rst_${src['name']}_ni,
+% endfor
+
   // Bus Interface
   input tlul_pkg::tl_h2d_t tl_i,
   output tlul_pkg::tl_d2h_t tl_o,
@@ -62,6 +68,18 @@ module clkmgr import clkmgr_pkg::*; (
     .devmode_i(1'b1)
   );
 
+  ////////////////////////////////////////////////////
+  // Divided clocks
+  ////////////////////////////////////////////////////
+% for src in div_srcs:
+  logic clk_${src['name']}_i;
+% endfor
+
+% for src in div_srcs:
+  assign clk_${src['name']}_i = clk_${src['src']}_i;
+% endfor
+
+
 
   ////////////////////////////////////////////////////
   // Feed through clocks
@@ -72,7 +90,6 @@ module clkmgr import clkmgr_pkg::*; (
 % for k,v in ft_clks.items():
   assign clocks_o.${k} = clk_${v}_i;
 % endfor
-
 
   ////////////////////////////////////////////////////
   // Root gating

--- a/hw/ip/rstmgr/data/rstmgr.hjson
+++ b/hw/ip/rstmgr/data/rstmgr.hjson
@@ -13,7 +13,8 @@
     "clk_main_i",
     "clk_io_i",
     "clk_usb_i",
-    "clk_aon_i"
+    "clk_aon_i",
+    "clk_io_div2_i",
   ],
   bus_device: "tlul",
   regwidth: "32",

--- a/hw/ip/rstmgr/rtl/rstmgr.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr.sv
@@ -15,6 +15,7 @@ module rstmgr import rstmgr_pkg::*; (
   input rst_ni,
   input clk_main_i,
   input clk_io_i,
+  input clk_io_div2_i,
   input clk_usb_i,
   input clk_aon_i,
 
@@ -44,7 +45,7 @@ module rstmgr import rstmgr_pkg::*; (
 
 );
 
-  localparam int NumRsts = 9;
+  localparam int NumRsts = 10;
   logic [NumRsts-1:0] raw_resets, muxed_resets;
   rstmgr_out_t resets_int;
 
@@ -76,6 +77,16 @@ module rstmgr import rstmgr_pkg::*; (
     .rst_ni(resets_o.rst_por_aon_n),
     .d(1'b1),
     .q(resets_int.rst_por_io_n)
+  );
+
+  prim_flop_2sync #(
+    .Width(1),
+    .ResetValue('0)
+  ) i_por_io_div2_sync (
+    .clk_i(clk_io_div2_i),
+    .rst_ni(resets_o.rst_por_aon_n),
+    .d(1'b1),
+    .q(resets_int.rst_por_io_div2_n)
   );
 
   prim_flop_2sync #(
@@ -170,7 +181,7 @@ module rstmgr import rstmgr_pkg::*; (
     .Width(1),
     .ResetValue('0)
   ) i_lc (
-    .clk_i(clk_io_i),
+    .clk_i(clk_io_div2_i),
     .rst_ni(rst_lc_src_n[ALWAYS_ON_SEL]),
     .d(1'b1),
     .q(resets_int.rst_lc_n)
@@ -190,7 +201,7 @@ module rstmgr import rstmgr_pkg::*; (
     .Width(1),
     .ResetValue('0)
   ) i_sys_io (
-    .clk_i(clk_io_i),
+    .clk_i(clk_io_div2_i),
     .rst_ni(rst_sys_src_n[ALWAYS_ON_SEL]),
     .d(1'b1),
     .q(resets_int.rst_sys_io_n)
@@ -200,7 +211,7 @@ module rstmgr import rstmgr_pkg::*; (
     .Width(1),
     .ResetValue('0)
   ) i_spi_device (
-    .clk_i(clk_io_i),
+    .clk_i(clk_io_div2_i),
     .rst_ni(rst_sys_src_n[ALWAYS_ON_SEL]),
     .d(reg2hw.rst_spi_device_n.q),
     .q(resets_int.rst_spi_device_n)
@@ -253,6 +264,7 @@ module rstmgr import rstmgr_pkg::*; (
                       resets_int.rst_por_aon_n,
                       resets_int.rst_por_n,
                       resets_int.rst_por_io_n,
+                      resets_int.rst_por_io_div2_n,
                       resets_int.rst_por_usb_n,
                       resets_int.rst_lc_n,
                       resets_int.rst_sys_io_n,

--- a/hw/ip/rstmgr/rtl/rstmgr_pkg.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr_pkg.sv
@@ -31,6 +31,7 @@ package rstmgr_pkg;
     logic rst_por_aon_n;
     logic rst_por_n;
     logic rst_por_io_n;
+    logic rst_por_io_div2_n;
     logic rst_por_usb_n;
     logic rst_lc_n;
     logic rst_sys_io_n;

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -22,36 +22,55 @@
         name: main
         aon: no
         freq: "100000000"
+        derived: no
+        params: {}
       }
       {
         name: io
         aon: no
         freq: "100000000"
+        derived: no
+        params: {}
       }
       {
         name: usb
         aon: no
         freq: "48000000"
+        derived: no
+        params: {}
       }
       {
         name: aon
         aon: yes
         freq: "200000"
+        derived: no
+        params: {}
+      }
+    ]
+    derived_srcs:
+    [
+      {
+        name: io_div2
+        aon: no
+        div: 2
+        src: io
+        freq: "50000000"
       }
     ]
     groups:
     [
       {
         name: powerup
-        src: ext
+        src: top
         sw_cg: no
         unique: no
         clocks:
         {
-          clk_io_i: io
-          clk_aon_i: aon
-          clk_i: main
-          clk_usb_i: usb
+          clk_io_powerup: io
+          clk_aon_powerup: aon
+          clk_main_powerup: main
+          clk_usb_powerup: usb
+          clk_io_div2_powerup: io_div2
         }
       }
       {
@@ -146,6 +165,12 @@
       clk: io
     }
     {
+      name: por_io_div2
+      type: top
+      root: por_aon
+      clk: io_div2
+    }
+    {
       name: por_usb
       type: top
       root: por_aon
@@ -167,19 +192,19 @@
       name: sys_io
       type: top
       root: sys
-      clk: io
+      clk: io_div2
     }
     {
       name: sys_aon
       type: top
       root: sys
-      clk: io
+      clk: io_div2
     }
     {
       name: spi_device
       type: top
       root: sys
-      clk: io
+      clk: io_div2
       sw: 1
     }
     {
@@ -1004,8 +1029,8 @@
       generated: "true"
       clock_connections:
       {
-        clk_i: clk_io_i
-        clk_slow_i: clk_aon_i
+        clk_i: clkmgr_clocks.clk_io_powerup
+        clk_slow_i: clkmgr_clocks.clk_aon_powerup
       }
       size: 0x1000
       bus_device: tlul
@@ -1137,6 +1162,7 @@
         clk_main_i: main
         clk_io_i: io
         clk_usb_i: usb
+        clk_io_div2_i: io_div2
       }
       clock_group: powerup
       reset_connections:
@@ -1146,11 +1172,12 @@
       base_addr: 0x400B0000
       clock_connections:
       {
-        clk_i: clk_io_i
-        clk_aon_i: clk_aon_i
-        clk_main_i: clk_i
-        clk_io_i: clk_io_i
-        clk_usb_i: clk_usb_i
+        clk_i: clkmgr_clocks.clk_io_powerup
+        clk_aon_i: clkmgr_clocks.clk_aon_powerup
+        clk_main_i: clkmgr_clocks.clk_main_powerup
+        clk_io_i: clkmgr_clocks.clk_io_powerup
+        clk_usb_i: clkmgr_clocks.clk_usb_powerup
+        clk_io_div2_i: clkmgr_clocks.clk_io_div2_powerup
       }
       size: 0x1000
       bus_device: tlul
@@ -1224,10 +1251,6 @@
       clock_srcs:
       {
         clk_i: io
-        clk_main_i: main
-        clk_io_i: io
-        clk_usb_i: usb
-        clk_aon_i: aon
       }
       clock_group: powerup
       reset_connections:
@@ -1236,16 +1259,13 @@
         rst_main_ni: por
         rst_io_ni: por_io
         rst_usb_ni: por_usb
+        rst_io_div2_ni: por_io_div2
       }
       base_addr: 0x400C0000
       generated: "true"
       clock_connections:
       {
-        clk_i: clk_io_i
-        clk_main_i: clk_i
-        clk_io_i: clk_io_i
-        clk_usb_i: clk_usb_i
-        clk_aon_i: clk_aon_i
+        clk_i: clkmgr_clocks.clk_io_powerup
       }
       size: 0x1000
       bus_device: tlul
@@ -1269,6 +1289,50 @@
           inst_name: clkmgr
           width: 1
           top_signame: clkmgr_clocks
+          index: -1
+        }
+        {
+          struct: logic
+          type: uni
+          name: clk_main
+          act: rcv
+          package: ""
+          inst_name: clkmgr
+          width: 1
+          top_signame: clkmgr_clk_main
+          index: -1
+        }
+        {
+          struct: logic
+          type: uni
+          name: clk_io
+          act: rcv
+          package: ""
+          inst_name: clkmgr
+          width: 1
+          top_signame: clkmgr_clk_io
+          index: -1
+        }
+        {
+          struct: logic
+          type: uni
+          name: clk_usb
+          act: rcv
+          package: ""
+          inst_name: clkmgr
+          width: 1
+          top_signame: clkmgr_clk_usb
+          index: -1
+        }
+        {
+          struct: logic
+          type: uni
+          name: clk_aon
+          act: rcv
+          package: ""
+          inst_name: clkmgr
+          width: 1
+          top_signame: clkmgr_clk_aon
           index: -1
         }
         {
@@ -1754,6 +1818,7 @@
       ]
       wakeup_list: []
       scan: "false"
+      scan_reset: "false"
       inter_signal_list:
       [
         {
@@ -1891,7 +1956,13 @@
       pwrmgr.pwr_cpu
       clkmgr.clocks
     ]
-    external: []
+    external:
+    [
+      clkmgr.clk_main
+      clkmgr.clk_io
+      clkmgr.clk_usb
+      clkmgr.clk_aon
+    ]
   }
   xbar:
   [
@@ -3464,6 +3535,7 @@
     por_aon: rstmgr_resets.rst_por_aon_n
     por: rstmgr_resets.rst_por_n
     por_io: rstmgr_resets.rst_por_io_n
+    por_io_div2: rstmgr_resets.rst_por_io_div2_n
     por_usb: rstmgr_resets.rst_por_usb_n
     lc: rstmgr_resets.rst_lc_n
     sys: rstmgr_resets.rst_sys_n
@@ -3674,6 +3746,50 @@
         index: -1
       }
       {
+        struct: logic
+        type: uni
+        name: clk_main
+        act: rcv
+        package: ""
+        inst_name: clkmgr
+        width: 1
+        top_signame: clkmgr_clk_main
+        index: -1
+      }
+      {
+        struct: logic
+        type: uni
+        name: clk_io
+        act: rcv
+        package: ""
+        inst_name: clkmgr
+        width: 1
+        top_signame: clkmgr_clk_io
+        index: -1
+      }
+      {
+        struct: logic
+        type: uni
+        name: clk_usb
+        act: rcv
+        package: ""
+        inst_name: clkmgr
+        width: 1
+        top_signame: clkmgr_clk_usb
+        index: -1
+      }
+      {
+        struct: logic
+        type: uni
+        name: clk_aon
+        act: rcv
+        package: ""
+        inst_name: clkmgr
+        width: 1
+        top_signame: clkmgr_clk_aon
+        index: -1
+      }
+      {
         struct: pwr_clk
         type: req_rsp
         name: pwr
@@ -3743,7 +3859,41 @@
         index: -1
       }
     ]
-    external: []
+    external:
+    [
+      {
+        package: ""
+        struct: logic
+        signame: clkmgr_clk_main
+        width: 1
+        type: uni
+        direction: in
+      }
+      {
+        package: ""
+        struct: logic
+        signame: clkmgr_clk_io
+        width: 1
+        type: uni
+        direction: in
+      }
+      {
+        package: ""
+        struct: logic
+        signame: clkmgr_clk_usb
+        width: 1
+        type: uni
+        direction: in
+      }
+      {
+        package: ""
+        struct: logic
+        signame: clkmgr_clk_aon
+        width: 1
+        type: uni
+        direction: in
+      }
+    ]
     definitions:
     [
       {

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -25,12 +25,22 @@
     // aon:  Whether the clock is free running all the time.
     //       If it is, the clock is not hanlded by clkmgr.
     // freq: Absolute frequency of clk in Hz
-
     srcs: [
       { name: "main", aon: "no",  freq: "100000000" }
       { name: "io",   aon: "no",  freq: "100000000" }
       { name: "usb",  aon: "no",  freq: "48000000" }
       { name: "aon",  aon: "yes", freq: "200000" }
+    ],
+
+    // Derived clock source attributes
+    // name: Name of group.
+    // aon:  Whether the clock is free running all the time.
+    //       If it is, the clock is not hanlded by clkmgr.
+    // freq: Absolute frequency of clk in Hz
+    // src:  From which clock source is the clock derived
+    // div:  Ratio between derived clock and source clock
+    derived_srcs: [
+      { name: "io_div2", aon: "no", div: 2, src: "io", freq: "50000000" }
     ],
 
     // Clock Group attributes
@@ -56,7 +66,8 @@
     // The proc group is not peripheral, and direclty hardwired
 
     groups: [
-      { name: "powerup", src:"ext", sw_cg: "no"                   }
+      // the powerup group is used exclusively by clk/pwr/rstmgr
+      { name: "powerup", src:"top", sw_cg: "no"                   }
       { name: "trans",   src:"top", sw_cg: "hint", unique: "yes", }
       { name: "infra",   src:"top", sw_cg: "no",                  }
       { name: "secure",  src:"top", sw_cg: "no"                   }
@@ -92,12 +103,13 @@
     { name: "por_aon",    type: "top",  root: "rst_ni",  clk: "aon"        }
     { name: "por",        type: "top",  root: "por_aon", clk: "main"       }
     { name: "por_io",     type: "top",  root: "por_aon", clk: "io"         }
+    { name: "por_io_div2",type: "top",  root: "por_aon", clk: "io_div2"    }
     { name: "por_usb",    type: "top",  root: "por_aon", clk: "usb"        }
     { name: "lc",         type: "top",  root: "lc",      clk: "io"         }
     { name: "sys",        type: "top",  root: "sys",     clk: "main"       }
-    { name: "sys_io",     type: "top",  root: "sys",     clk: "io"         }
-    { name: "sys_aon",    type: "top",  root: "sys",     clk: "io"         }
-    { name: "spi_device", type: "top",  root: "sys",     clk: "io",  sw: 1 }
+    { name: "sys_io",     type: "top",  root: "sys",     clk: "io_div2"    }
+    { name: "sys_aon",    type: "top",  root: "sys",     clk: "io_div2"    }
+    { name: "spi_device", type: "top",  root: "sys",     clk: "io_div2",  sw: 1 }
     { name: "usb",        type: "top",  root: "sys",     clk: "usb", sw: 1 }
   ]
 
@@ -217,16 +229,19 @@
     },
     { name: "rstmgr",
       type: "rstmgr",
-      clock_srcs: {clk_i: "io", clk_aon_i: "aon", clk_main_i: "main", clk_io_i: "io", clk_usb_i: "usb"},
+      clock_srcs: {clk_i: "io", clk_aon_i: "aon", clk_main_i: "main", clk_io_i: "io", clk_usb_i: "usb",
+                   clk_io_div2_i: "io_div2"},
       clock_group: "powerup",
       reset_connections: {rst_ni: "rst_ni"},
       base_addr: "0x400B0000",
     },
     { name: "clkmgr",
       type: "clkmgr",
-      clock_srcs: {clk_i: "io", clk_main_i: "main", clk_io_i: "io", clk_usb_i: "usb", clk_aon_i: "aon"},
+      //clock_srcs: {clk_i: "io", clk_main_i: "main", clk_io_i: "io", clk_usb_i: "usb", clk_aon_i: "aon"},
+      clock_srcs: {clk_i: "io"},
       clock_group: "powerup",
-      reset_connections: {rst_ni: "por_io", rst_main_ni: "por", rst_io_ni: "por_io", rst_usb_ni: "por_usb"},
+      reset_connections: {rst_ni: "por_io", rst_main_ni: "por", rst_io_ni: "por_io", rst_usb_ni: "por_usb"
+                          rst_io_div2_ni: "por_io_div2", },
       base_addr: "0x400C0000",
       generated: "true"
     },
@@ -319,7 +334,7 @@
     'top': ['rstmgr.resets', 'rstmgr.cpu', 'pwrmgr.pwr_cpu', 'clkmgr.clocks'],
 
     // ext is to create port in the top.
-    'external': [],
+    'external': ['clkmgr.clk_main', 'clkmgr.clk_io', 'clkmgr.clk_usb', 'clkmgr.clk_aon'],
   },
 
   debug_mem_base_addr: "0x1A110000",

--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -33,18 +33,8 @@ module top_${top["name"]} #(
   parameter bit IbexPipeLine = 0,
   parameter     BootRomInitFile = ""
 ) (
-  // Clock and Reset
-  input               clk_i,
+  // Reset, clocks defined as part of intermodule
   input               rst_ni,
-
-  // Fixed io clock
-  input               clk_io_i,
-
-  // USB clock
-  input               clk_usb_i,
-
-  // aon clock
-  input               clk_aon_i,
 
   // JTAG interface
   input               jtag_tck_i,
@@ -749,6 +739,6 @@ slice = str(alert_idx+w-1) + ":" + str(alert_idx)
 % endif
 
   // make sure scanmode_i is never X (including during reset)
-  `ASSERT_KNOWN(scanmodeKnown, scanmode_i, clk_i, 0)
+  `ASSERT_KNOWN(scanmodeKnown, scanmode_i, clkmgr_clk_main, 0)
 
 endmodule

--- a/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
+++ b/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
@@ -17,17 +17,13 @@
 {
   name: "CLKMGR",
   clock_primary: "clk_i",
-  other_clock_list: [
-    "clk_main_i",
-    "clk_io_i",
-    "clk_usb_i",
-    "clk_aon_i",
-  ],
+  other_clock_list: [],
   reset_primary: "rst_ni",
   other_reset_list: [
     "rst_main_ni"
     "rst_io_ni"
     "rst_usb_ni"
+    "rst_io_div2_ni"
   ]
   bus_device: "tlul",
   regwidth: "32",
@@ -40,13 +36,38 @@
     },
   ],
 
-  // Define rstmgr struct package
   inter_signal_list: [
     { struct:  "clkmgr_out",
       type:    "uni",
       name:    "clocks",
       act:     "req",
       package: "clkmgr_pkg",
+    },
+
+  // All clock inputs
+    { struct:  "logic",
+      type:    "uni",
+      name:    "clk_main",
+      act:     "rcv",
+      package: "",
+    },
+    { struct:  "logic",
+      type:    "uni",
+      name:    "clk_io",
+      act:     "rcv",
+      package: "",
+    },
+    { struct:  "logic",
+      type:    "uni",
+      name:    "clk_usb",
+      act:     "rcv",
+      package: "",
+    },
+    { struct:  "logic",
+      type:    "uni",
+      name:    "clk_aon",
+      act:     "rcv",
+      package: "",
     },
 
     { struct:  "pwr_clk",

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_pkg.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_pkg.sv
@@ -17,7 +17,11 @@ package clkmgr_pkg;
   };
 
   typedef struct packed {
-  logic clk_aon_i;
+  logic clk_io_powerup;
+  logic clk_aon_powerup;
+  logic clk_main_powerup;
+  logic clk_usb_powerup;
+  logic clk_io_div2_powerup;
   logic clk_main_aes;
   logic clk_main_hmac;
   logic clk_main_otbn;

--- a/hw/top_earlgrey/rtl/top_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_asic.sv
@@ -188,11 +188,11 @@ module top_earlgrey_asic (
   //////////////////////
 
   top_earlgrey top_earlgrey (
-    .clk_i           ( clk           ),
     .rst_ni          ( rst_n         ),
-    .clk_io_i        ( clk           ),
-    .clk_usb_i       ( clk_usb_48mhz ),
-    .clk_aon_i       ( clk           ),
+    .clkmgr_clk_main ( clk           ),
+    .clkmgr_clk_io   ( clk           ),
+    .clkmgr_clk_usb  ( clk_usb_48mhz ),
+    .clkmgr_clk_aon  ( clk           ),
 
     // JTAG
     .jtag_tck_i      ( jtag_tck      ),

--- a/hw/top_earlgrey/rtl/top_earlgrey_cw305.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_cw305.sv
@@ -228,11 +228,11 @@ module top_earlgrey_cw305 #(
     .BootRomInitFile(BootRomInitFile)
   ) top_earlgrey (
     // Clocks, resets
-    .clk_i           ( clk           ),
     .rst_ni          ( rst_n         ),
-    .clk_io_i        ( clk           ),
-    .clk_aon_i       ( clk           ),
-    .clk_usb_i       ( clk_usb_48mhz ),
+    .clkmgr_clk_main ( clk           ),
+    .clkmgr_clk_io   ( clk           ),
+    .clkmgr_clk_usb  ( clk_usb_48mhz ),
+    .clkmgr_clk_aon  ( clk           ),
 
     // JTAG
     .jtag_tck_i      ( jtag_tck      ),

--- a/hw/top_earlgrey/rtl/top_earlgrey_nexysvideo.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_nexysvideo.sv
@@ -210,11 +210,11 @@ module top_earlgrey_nexysvideo #(
     .BootRomInitFile(BootRomInitFile)
   ) top_earlgrey (
     // Clocks, resets
-    .clk_i           ( clk           ),
     .rst_ni          ( rst_n         ),
-    .clk_io_i        ( clk           ),
-    .clk_aon_i       ( clk           ),
-    .clk_usb_i       ( clk_usb_48mhz ),
+    .clkmgr_clk_main ( clk           ),
+    .clkmgr_clk_io   ( clk           ),
+    .clkmgr_clk_usb  ( clk_usb_48mhz ),
+    .clkmgr_clk_aon  ( clk           ),
 
     // JTAG
     .jtag_tck_i      ( jtag_tck      ),

--- a/hw/top_earlgrey/rtl/top_earlgrey_verilator.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_verilator.sv
@@ -75,11 +75,11 @@ module top_earlgrey_verilator (
 
   // Top-level design
   top_earlgrey top_earlgrey (
-    .clk_i                      (clk_i),
     .rst_ni                     (rst_ni),
-    .clk_io_i                   (clk_i),
-    .clk_usb_i                  (clk_i),
-    .clk_aon_i                  (clk_i),
+    .clkmgr_clk_main            (clk_i),
+    .clkmgr_clk_io              (clk_i),
+    .clkmgr_clk_usb             (clk_i),
+    .clkmgr_clk_aon             (clk_i),
 
     .jtag_tck_i                 (cio_jtag_tck),
     .jtag_tms_i                 (cio_jtag_tms),

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -520,7 +520,7 @@ def generate_clkmgr(top, cfg_path, out_path):
 
     # construct a dictionary of the aon attribute for easier lookup
     # ie, src_name_A: True, src_name_B: False
-    for src in top['clocks']['srcs']:
+    for src in top['clocks']['srcs'] + top['clocks']['derived_srcs']:
         if src['aon'] == 'yes':
             src_aon_attr[src['name']] = True
         else:
@@ -530,10 +530,13 @@ def generate_clkmgr(top, cfg_path, out_path):
 
     # clocks fed through clkmgr but are not disturbed in any way
     # This maintains the clocking structure consistency
+    # This includes two groups of clocks
+    # Clocks fed from the always-on source
+    # Clocks fed to the powerup group
     ft_clks = {
         clk: src
         for grp in grps for (clk, src) in grp['clocks'].items()
-        if src_aon_attr[src]
+        if src_aon_attr[src] or grp['name'] == 'powerup'
     }
 
     # root-gate clocks
@@ -564,6 +567,7 @@ def generate_clkmgr(top, cfg_path, out_path):
             tpl = Template(fin.read())
             try:
                 out = tpl.render(cfg=top,
+                                 div_srcs=top['clocks']['derived_srcs'],
                                  rg_srcs=rg_srcs,
                                  ft_clks=ft_clks,
                                  rg_clks=rg_clks,

--- a/util/topgen/merge.py
+++ b/util/topgen/merge.py
@@ -443,6 +443,12 @@ def amend_clocks(top: OrderedDict):
     clk_paths = clks_attr['hier_paths']
     groups_in_top = [x["name"].lower() for x in clks_attr['groups']]
 
+    # Assign default parameters to source clocks
+    for src in clks_attr['srcs']:
+        if 'derived' not in src:
+            src['derived'] = "no"
+            src['params'] = {}
+
     # Default assignments
     for group in clks_attr['groups']:
 


### PR DESCRIPTION
- clocks are not divided yet, but this adds support to split the clock path
- change clkmgr source clock inputs to inter-module, this allows separation
  between the derived clocks and the functional clocks
- update merging / validation as required
- manually update rstmgr to match - this module is not yet templated