### PR TITLE
[i2c, dv] Add i2c_fifo_watermark test for rx_fifo and fmt_fifo

### DIFF
--- a/hw/ip/i2c/data/i2c_testplan.hjson
+++ b/hw/ip/i2c/data/i2c_testplan.hjson
@@ -104,38 +104,21 @@
       tests: ["i2c_override"]
     }
     {
-      name: fmt_watermark
+      name: fifo_watermark
       desc: '''
-            Test fmt_watermark interrupt.
+            Test the watermark interrupt of fmt_fifo and rx_fifo.
 
             Stimulus:
-              - Program random fmt watermark level
-              - Program large enough values into timing registers
-              - Write data quickly to fmt_fifo
+              - Program random fmt_fifo and rx_fifo watermark level
+              - Write data quickly to fmt_fifo and rx_fifo for triggering watermark interrupts
 
             Checking:
-              - Ensure the intr_fmt watermark interrupt is asserted
-              - Ensure the intr_fmt watermark interrupt stays asserted until cleared
+              - Ensure the fmt_fifo and rx_fifo watermark interrupts are asserted
+              - Ensure the fmt_fifo and rx_fifo watermark interrupts stay asserted until cleared
+              - Ensure receving correct number of fmt_fifo and rx_fifo watermark interrupts
             '''
       milestone: V2
-      tests: [""]
-    }
-    {
-      name: rx_watermark
-      desc: '''
-            Test rx_watermark interrupt.
-
-            Stimulus:
-              - Program random rx watermark level
-              - Keep sending data over rx
-              - Read data in rx_fifo slowly
-
-            Checking:
-              - Ensure the intr_rx watermark interrupt is asserted
-              - Ensure the intr_rx watermark interrupt stays asserted until cleared
-            '''
-      milestone: V2
-      tests: [""]
+      tests: ["i2c_fifo_watermark"]
     }
     {
       name: fmt_reset
@@ -150,7 +133,7 @@
               - Ensure the remaining entries are not show up after fmt_fifo is reset
             '''
       milestone: V2
-      tests: [""]
+      tests: []
     }
     {
       name: rx_reset
@@ -165,7 +148,7 @@
               - Ensure that reads to rdata register yield 0s after rx_fifo is reset
             '''
       milestone: V2
-      tests: [""]
+      tests: []
     }
     {
       name: fmt_overflow
@@ -180,7 +163,7 @@
               - Ensure intr_fmt_overflow interrupt is asserted
             '''
       milestone: V2
-      tests: [""]
+      tests: []
     }
     {
       name: rx_overflow
@@ -195,7 +178,7 @@
               - Ensure intr_rx_overflow interrupt is asserted
             '''
       milestone: V2
-      tests: [""]
+      tests: []
     }
     {
       name: fmt_rx_fifo_full
@@ -210,7 +193,7 @@
               - Check fifo full states by reading status register
             '''
       milestone: V2
-      tests: [""]
+      tests: []
     }
     {
       name: rx_timeout
@@ -226,7 +209,7 @@
               - Ensure intr_stretch_timeout interrupt is asserted
             '''
       milestone: V2
-      tests: [""]
+      tests: []
     }
     {
       name: rx_oversample
@@ -241,7 +224,7 @@
               - Read rx data oversampled value and ensure it is same as driven value
             '''
       milestone: V2
-      tests: [""]
+      tests: []
     }
     {
       name: rw_loopback
@@ -255,7 +238,7 @@
               - Ensure read data is matched with write data
             '''
       milestone: V2
-      tests: [""]
+      tests: []
     }
   ]
 }

--- a/hw/ip/i2c/dv/env/i2c_env.core
+++ b/hw/ip/i2c/dv/env/i2c_env.core
@@ -24,6 +24,7 @@ filesets:
       - seq_lib/i2c_rx_tx_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_sanity_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_override_vseq.sv: {is_include_file: true}
+      - seq_lib/i2c_fifo_watermark_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/i2c/dv/env/i2c_env_cfg.sv
+++ b/hw/ip/i2c/dv/env/i2c_env_cfg.sv
@@ -6,9 +6,7 @@ class i2c_env_cfg extends cip_base_env_cfg #(.RAL_T(i2c_reg_block));
 
   i2c_target_addr_mode_e target_addr_mode = Addr7BitMode;
 
-  // TODO: various knobs to enable certain routines
-  bit do_rd_overflow  = 1'b0;
-  bit do_wr_overflow  = 1'b0;
+  uint ok_to_end_delay_ns = 5000;
 
   rand i2c_agent_cfg m_i2c_agent_cfg;
 

--- a/hw/ip/i2c/dv/env/i2c_env_pkg.sv
+++ b/hw/ip/i2c/dv/env/i2c_env_pkg.sv
@@ -29,19 +29,22 @@ package i2c_env_pkg;
     SdaInference   = 6,
     StretchTimeout = 7,
     SdaUnstable    = 8,
-    NumI2cIntr     = 9
+    TransComplete  = 9,
+    NumI2cIntr     = 10
   } i2c_intr_e;
 
   // csr and mem total size for IP, TODO confirm below value with spec
-  parameter uint I2C_ADDR_MAP_SIZE = 128;
+  parameter uint I2C_ADDR_MAP_SIZE  = 128;
+  parameter uint I2C_FMT_FIFO_DEPTH = 32;
+  parameter uint I2C_RX_FIFO_DEPTH  = 32;
 
   // for constrains
   parameter uint I2C_MIN_TRAN    = 10;
-  parameter uint I2C_MAX_TRAN    = 200;
+  parameter uint I2C_MAX_TRAN    = 20;
   parameter uint I2C_MIN_ADDR    = 0;
   parameter uint I2C_MAX_ADDR    = 127;
   parameter uint I2C_MIN_DLY     = 0;
-  parameter uint I2C_MAX_DLY     = 2;
+  parameter uint I2C_MAX_DLY     = 5;
   parameter uint I2C_MIN_DATA    = 0;
   parameter uint I2C_MAX_DATA    = 255;
   parameter uint I2C_MIN_TIMING  = 1; // at least 1
@@ -50,42 +53,8 @@ package i2c_env_pkg;
   parameter uint I2C_TIMEOUT_ENB = 1;
   parameter uint I2C_MIN_TIMEOUT = 1;
   parameter uint I2C_MAX_TIMEOUT = 4;
-  parameter uint I2C_IDLE_TIME   = 1200;
-  parameter uint I2C_MAX_RXILVL  = 4;
+  parameter uint I2C_MAX_RXILVL  = 7;
   parameter uint I2C_MAX_FMTILVL = 3;
-
-  // ok_to_end_delay_ns for EoT
-  parameter uint DELAY_FOR_EOT_NS = 5000;
-
-  // functions
-  // get the number of bytes that triggers watermark interrupt
-  function automatic int get_watermark_bytes_by_level(int lvl);
-    case(lvl)
-      0: return 1;
-      1: return 4;
-      2: return 8;
-      3: return 16;
-      4: return 30;
-      default: begin
-        `uvm_fatal("i2c_env_pkg::get_watermark_bytes_by_level",
-                   $sformatf("invalid watermark level value - %0d", lvl))
-      end
-    endcase
-  endfunction : get_watermark_bytes_by_level
-
-  // get the number of bytes that triggers break interrupt
-  function automatic int get_break_bytes_by_level(int lvl);
-    case(lvl)
-      0: return 2;
-      1: return 4;
-      2: return 8;
-      3: return 16;
-      default: begin
-        `uvm_fatal("i2c_env_pkg::get_break_bytes_by_level",
-                   $sformatf("invalid break level value - %0d", lvl))
-      end
-    endcase
-  endfunction : get_break_bytes_by_level
 
   // package sources
   `include "i2c_env_cfg.sv"

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
@@ -11,10 +11,20 @@ class i2c_base_vseq extends cip_base_vseq #(
   `uvm_object_utils(i2c_base_vseq)
 
   // class property
+  bit                         do_interrupt = 1'b1;
+  bit                         under_program_regs = 1'b0;
+  bit                         program_incorrect_regs = 1'b0;
+
+  // bits to control fifos access
+  // delay_read_rx_until_full is unset delay reading rx_fifo until rx_fifo is full or
+  // delay_read_rx_until_full is unset (used in fifo_watermark test)
+  bit                         delay_read_rx_until_full = 1'b1;
+  // avoid_write_fmt_overflow is set to prevent writing to fmt_fifo from overflow,
+  // by checking fmt_fifo is not full (used in fifo_overflow)
+  bit                         avoid_write_fmt_overflow = 1'b1;
+  
   local timing_cfg_t          timing_cfg;
   bit [7:0]                   rd_data;
-  bit                         do_interrupt = 1'b1;
-  bit                         force_use_incorrect_config = 1'b0;
   i2c_item                    fmt_item;
 
   // random property
@@ -22,13 +32,12 @@ class i2c_base_vseq extends cip_base_vseq #(
   rand uint                   rx_fifo_access_dly;
   rand uint                   access_intr_dly;
 
-  rand bit   [NumI2cIntr-1:0] en_intr;
   rand uint                   num_trans;
   rand uint                   num_wr_bytes;
   rand uint                   num_rd_bytes;
+  rand bit                    rw_bit;
   rand bit   [7:0]            wr_data;
   rand bit   [9:0]            addr;  // support both 7-bit and 10-bit target address
-  rand bit                    rw_bit;
   rand bit   [2:0]            rxilvl;
   rand bit   [1:0]            fmtilvl;
 
@@ -47,12 +56,50 @@ class i2c_base_vseq extends cip_base_vseq #(
   rand bit                    e_timeout;  // max time target may stretch the clock
 
   // constraints
-  constraint rw_bit_c    { rw_bit     inside {0, 1}; }
-  constraint addr_c      { addr       inside {[I2C_MIN_ADDR : I2C_MAX_ADDR]}; }
-  constraint wr_data_c   { wr_data    inside {[I2C_MIN_DATA : I2C_MAX_DATA]}; }
-  constraint num_trans_c { num_trans  inside {[I2C_MIN_TRAN : I2C_MAX_TRAN]}; }
-  constraint rxilvl_c    { rxilvl     inside {[0 : I2C_MAX_RXILVL]}; }
-  constraint fmtilvl_c   { fmtilvl    inside {[0 : I2C_MAX_FMTILVL]}; }
+  constraint addr_c         { addr         inside {[I2C_MIN_ADDR : I2C_MAX_ADDR]}; }
+  constraint wr_data_c      { wr_data      inside {[I2C_MIN_DATA : I2C_MAX_DATA]}; }
+  constraint fmtilvl_c      { fmtilvl      inside {[0 : I2C_MAX_FMTILVL]}; }
+  constraint num_trans_c    { num_trans    inside {[I2C_MIN_TRAN : I2C_MAX_TRAN]}; }
+
+  // create uniform assertion distributions of rx_watermark interrupt
+  constraint rxilvl_c {
+    rxilvl dist {
+      0     :/ 17,
+      1     :/ 17,
+      2     :/ 17,
+      3     :/ 16,
+      4     :/ 17,
+      [5:7] :/ 16
+    };
+  }
+  constraint num_wr_bytes_c {
+    num_wr_bytes dist {
+      1       :/ 1,
+      [2:4]   :/ 1,
+      [5:8]   :/ 1,
+      [9:20]  :/ 1
+    };
+  }
+  constraint num_rd_bytes_c {
+    num_rd_bytes dist {
+      1       :/ 17,
+      [2:4]   :/ 17,
+      [5:8]   :/ 17,
+      [9:16]  :/ 16,
+      [17:30] :/ 17,
+      31      :/ 16
+    };
+  }
+
+  constraint access_intr_dly_c {
+    access_intr_dly inside {[I2C_MIN_DLY:I2C_MAX_DLY]};
+  }
+  constraint fmt_fifo_access_dly_c {
+    fmt_fifo_access_dly inside {[I2C_MIN_DLY:I2C_MAX_DLY]};
+  }
+  constraint rx_fifo_access_dly_c {
+    rx_fifo_access_dly inside {[I2C_MIN_DLY:I2C_MAX_DLY]};
+  }
 
   constraint timing_val_c {
     thigh     inside { [I2C_MIN_TIMING : I2C_MAX_TIMING] };
@@ -67,7 +114,7 @@ class i2c_base_vseq extends cip_base_vseq #(
 
     solve t_r, tsu_dat, thd_dat before tlow;
     solve t_r                   before t_buf;
-    if (force_use_incorrect_config) {
+    if (program_incorrect_regs) {
       // force derived timing parameters to be negative (incorrect DUT config)
       tsu_sta == t_r + t_buf + 1;  // negative tHoldStop
       tlow    == 2;                // negative tClockLow
@@ -80,42 +127,6 @@ class i2c_base_vseq extends cip_base_vseq #(
       t_buf    inside { [(tsu_sta - t_r + 1) :
                          (tsu_sta - t_r + 1) + I2C_TIME_RANGE] };
     }
-  }
-
-  constraint access_intr_dly_c {
-    access_intr_dly dist {
-      0                   :/ 1,
-      [1      :100]       :/ 5,
-      [101    :10_000]    :/ 3,
-      [10_001 :1_000_000] :/ 1
-    };
-  }
-
-  constraint num_wr_bytes_c {
-    num_wr_bytes dist {
-      1      :/ 2,
-      [2:5]  :/ 5,
-      [6:9]  :/ 5,
-      [9:12] :/ 2
-    };
-  }
-  constraint num_rd_bytes_c {
-    num_rd_bytes dist {
-      0      :/ 1,
-      1      :/ 2,
-      [2:5]  :/ 5,
-      [6:9]  :/ 5,
-      [9:12] :/ 2
-    };
-  }
-  constraint en_intr_c {
-    en_intr inside {[0: ((1 << NumI2cIntr) - 1)]};
-  }
-  constraint fmt_fifo_access_dly_c {
-    fmt_fifo_access_dly inside {[1:5]};
-  }
-  constraint rx_fifo_access_dly_c {
-    rx_fifo_access_dly inside {[1:5]};
   }
 
   `uvm_object_new
@@ -131,16 +142,24 @@ class i2c_base_vseq extends cip_base_vseq #(
   endtask : device_init
 
   virtual task host_init();
-    `uvm_info(`gfn, "initialize i2c host registers", UVM_DEBUG)
+    bit [TL_DW-1: 0] intr_state;
+
+    `uvm_info(`gfn, "initialize i2c host registers", UVM_LOW)
     ral.ctrl.enablehost.set(1'b1);
     csr_update(ral.ctrl);
-    if (do_interrupt) begin
-      ral.intr_enable.set(en_intr);
-      csr_update(ral.intr_enable);
-      `DV_CHECK_RANDOMIZE_WITH_FATAL(ral.fifo_ctrl.rxilvl, value <= 4;)
-      `DV_CHECK_RANDOMIZE_FATAL(ral.fifo_ctrl.fmtilvl)
-      csr_update(ral.fifo_ctrl);
-    end
+
+    // diable override
+    ral.ovrd.txovrden.set(1'b0);
+    csr_update(ral.ovrd);
+
+    // clear fifos
+    ral.fifo_ctrl.rxrst.set(1'b1);
+    ral.fifo_ctrl.fmtrst.set(1'b1);
+    csr_update(ral.fifo_ctrl);
+
+    //enable then clear interrupts
+    csr_wr(.csr(ral.intr_enable), .value({TL_DW{1'b1}}));
+    csr_wr(.csr(ral.intr_state), .value({TL_DW{1'b0}}));
   endtask : host_init
 
   virtual task check_host_idle();
@@ -168,61 +187,67 @@ class i2c_base_vseq extends cip_base_vseq #(
     timing_cfg.tSetupStop  = t_r + tsu_sto;
     timing_cfg.tHoldStop   = t_r + t_buf - tsu_sta;
     // ensure these parameter must be greater than zeros
-    if (!force_use_incorrect_config) begin
+    if (!program_incorrect_regs) begin
       `DV_CHECK_GT_FATAL(timing_cfg.tClockLow, 0)
       `DV_CHECK_GT_FATAL(timing_cfg.tClockStop, 0)
       `DV_CHECK_GT_FATAL(timing_cfg.tHoldStop, 0)
     end
   endfunction : get_timing_values
 
-  virtual task program_timing_regs();
+  virtual task program_registers();
+    //*** program timing register
     ral.timing0.tlow.set(tlow);
     ral.timing0.thigh.set(thigh);
     csr_update(.csr(ral.timing0));
-
     ral.timing1.t_f.set(t_f);
     ral.timing1.t_r.set(t_r);
     csr_update(.csr(ral.timing1));
-
     ral.timing2.thd_sta.set(thd_sta);
     ral.timing2.tsu_sta.set(tsu_sta);
     csr_update(.csr(ral.timing2));
-
     ral.timing3.thd_dat.set(thd_dat);
     ral.timing3.tsu_dat.set(tsu_dat);
     csr_update(.csr(ral.timing3));
-
     ral.timing4.tsu_sto.set(tsu_sto);
     ral.timing4.t_buf.set(t_buf);
     csr_update(.csr(ral.timing4));
-
     ral.timeout_ctrl.en.set(e_timeout);
     ral.timeout_ctrl.val.set(t_timeout);
     csr_update(.csr(ral.timeout_ctrl));
-
     // configure i2c_agent_cfg
     cfg.m_i2c_agent_cfg.timing_cfg = timing_cfg;
     // set time to stop test
-    cfg.m_i2c_agent_cfg.ok_to_end_delay_ns = DELAY_FOR_EOT_NS;
+    cfg.m_i2c_agent_cfg.ok_to_end_delay_ns = cfg.ok_to_end_delay_ns;
     // config target address mode of agent to the same
     cfg.m_i2c_agent_cfg.target_addr_mode = cfg.target_addr_mode;
-  endtask : program_timing_regs
 
-  virtual task program_format_flag(i2c_item item, string msg="");
-    csr_spinwait(.ptr(ral.status.fmtfull), .exp_data(1'b0));
+    //*** program ilvl
+    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(fmtilvl)
+    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(rxilvl)
+    ral.fifo_ctrl.rxilvl.set(rxilvl);
+    ral.fifo_ctrl.fmtilvl.set(fmtilvl);
+    csr_update(ral.fifo_ctrl);
+  endtask : program_registers
+
+  virtual task program_format_flag(i2c_item item, string msg="");     
     ral.fdata.nakok.set(item.nakok);
     ral.fdata.rcont.set(item.rcont);
     ral.fdata.read.set(item.read);
     ral.fdata.stop.set(item.stop);
     ral.fdata.start.set(item.start);
     ral.fdata.fbyte.set(item.fbyte);
+    // avoid_write_fmt_overflow is set, ensure fmt_fifo is not full before write
+    // otherwise, fmt_fifo can be overflow written
+    if (avoid_write_fmt_overflow) begin
+      csr_spinwait(.ptr(ral.status.fmtfull), .exp_data(1'b0));
+    end  
     csr_update(.csr(ral.fdata));
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(fmt_fifo_access_dly)
-    cfg.m_i2c_agent_cfg.vif.wait_for_dly(fmt_fifo_access_dly);
+    cfg.clk_rst_vif.wait_clks(fmt_fifo_access_dly);
     print_format_flag(item, msg);
   endtask : program_format_flag
 
-  task print_format_flag(i2c_item item, string msg="");
+  task print_format_flag(i2c_item item, string msg = "");
     string str;
 
     str = {str, $sformatf("\n%s, format flags 0x%h \n", msg,

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_fifo_watermark_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_fifo_watermark_vseq.sv
@@ -1,0 +1,124 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// test the watermark interrupt of fmt_fifo and rx_fifo
+class i2c_fifo_watermark_vseq extends i2c_rx_tx_vseq;
+  `uvm_object_utils(i2c_fifo_watermark_vseq)
+
+  `uvm_object_new
+
+  // counting the number of received watermark interrupts
+  local uint num_fmt_watermark;
+  local uint num_rx_watermark;
+
+  // the number of re-programming fmtilvl and rxilvl
+  local rand uint num_reprog_ilvl;
+  constraint num_reprog_ilvl_c { num_reprog_ilvl inside {[8 : 16]}; }
+
+  // fast write data to fmt_fifo to quickly trigger fmt_watermark interrupt
+  constraint fmt_fifo_access_dly_c { fmt_fifo_access_dly == 0;}
+
+  // fast read data from rd_fifo to quickly finish simulation (increasing sim. performance)
+  constraint rx_fifo_access_dly_c { rx_fifo_access_dly == 0;}
+
+  // per each run, send a single read/write transaction
+  constraint num_trans_c { num_trans == 1; }
+
+  // transaction length is long enough (not less than fmt/rx_fifo depth)
+  // in order to cross the watermark levels of rx_fifo and fmt_fifo
+  constraint num_wr_bytes_c { num_wr_bytes == I2C_FMT_FIFO_DEPTH + 5; }
+  constraint num_rd_bytes_c { num_rd_bytes == I2C_RX_FIFO_DEPTH; }
+
+  task body();
+    bit check_fmt_watermark, check_rx_watermark;
+
+    device_init();
+    host_init();
+
+    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(num_reprog_ilvl)
+    for (int i = 0; i < num_reprog_ilvl; i++) begin
+      check_fmt_watermark = 1'b1;
+      check_rx_watermark  = 1'b1;
+      num_fmt_watermark   = 0;
+      num_rx_watermark    = 0;
+
+      fork
+        begin
+          // verify fmt_watermark irq:
+          // -> send write transaction -> pooling and counting fmt_watermark interrupt
+          // -> check write complete -> stop pooling fmt_watermark interrupt
+          // -> verify the number of received fmt_watermark interrupt
+          if (check_fmt_watermark) begin
+            host_send_trans(num_trans, "WriteOnly");
+            csr_spinwait(.ptr(ral.status.fmtempty), .exp_data(1'b1));
+            check_fmt_watermark = 1'b0;
+            // depending the programmed fmtivl, the num_fmt_watermark could be 1 or 2
+            `DV_CHECK_GT(num_fmt_watermark, 0)
+            `DV_CHECK_LE(num_fmt_watermark, 2)
+            `uvm_info(`gfn, $sformatf("\nRun %0d, num_fmt_watermark %0d",
+                i, num_fmt_watermark), UVM_LOW)
+          end
+
+          // verify rx_watermark irq:
+          // -> send read transaction -> pooling and counting rx_watermark interrupt
+          // -> check read complete -> stop pooling rx_watermark interrupt
+          // -> verify the number of received rx_watermark interrupt
+          if (check_rx_watermark) begin
+            // unset delay_read_rx_until_full to quickly fill up rx_fifo so
+            // watermark interrupt is assuredly triggered
+            delay_read_rx_until_full = 1'b0;
+            host_send_trans(num_trans, "ReadOnly");
+            csr_spinwait(.ptr(ral.status.rxempty), .exp_data(1'b1));
+            check_rx_watermark = 1'b0;
+            // for fmtilvl > 4, rx_watermark is disable (num_rx_watermark = 0)
+            // otherwise, num_rx_watermark must be 1
+            if ( rxilvl <= 4) begin
+              `DV_CHECK_EQ(num_rx_watermark, 1)
+            end else begin
+              `DV_CHECK_EQ(num_rx_watermark, 0)
+            end
+            // during a read transaction, fmt_watermark could be triggered (e.g. since
+            // read address and control byte are programmed to fmt_fifo which might cross fmtilvl)
+            // if fmt_watermark is triggered, then clear it to not interfere counting the
+            // fmt_watermark interrupt of next transaction (no need to verify fmt_watermark again)
+            clear_interrupt(FmtWatermark);
+            `uvm_info(`gfn, $sformatf("\nRun %0d, num_fmt_watermark %0d",
+                i, num_fmt_watermark), UVM_LOW)
+          end
+        end
+        begin
+          while (check_fmt_watermark) check_fmt_watermark_intr();
+        end
+        begin
+          while (check_rx_watermark) check_rx_watermark_intr();
+        end
+      join
+    end
+  endtask : body
+
+  task check_fmt_watermark_intr();
+    bit [TL_DW-1:0] intr_state;
+    bit fmt_watermark;
+
+    csr_rd(.ptr(ral.intr_state), .value(intr_state));
+    fmt_watermark = bit'(get_field_val(ral.intr_state.fmt_watermark, intr_state));
+    if (fmt_watermark) begin
+      clear_interrupt(FmtWatermark);
+      num_fmt_watermark++;
+    end
+  endtask : check_fmt_watermark_intr
+
+  task check_rx_watermark_intr();
+    bit [TL_DW-1:0] intr_state;
+    bit rx_watermark;
+
+    csr_rd(.ptr(ral.intr_state), .value(intr_state));
+    rx_watermark = bit'(get_field_val(ral.intr_state.rx_watermark, intr_state));
+    if (rx_watermark) begin
+      clear_interrupt(RxWatermark);
+      num_rx_watermark++;
+    end
+  endtask : check_rx_watermark_intr
+
+endclass : i2c_fifo_watermark_vseq

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_override_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_override_vseq.sv
@@ -9,8 +9,6 @@ class i2c_override_vseq extends i2c_base_vseq;
   rand bit sdaval;
   rand bit txovrden;
 
-  constraint num_trans_c { num_trans inside {[10:20]}; }
-
   `uvm_object_new
 
   virtual task body();
@@ -23,7 +21,7 @@ class i2c_override_vseq extends i2c_base_vseq;
     host_init();
 
     for (uint cur_tran = 1; cur_tran <= num_trans; cur_tran++) begin
-      `uvm_info(`gfn, $sformatf("\nTransaction %0d", cur_tran), UVM_LOW)
+      `uvm_info(`gfn, $sformatf("\nTransaction %0d", cur_tran), UVM_DEBUG)
       // program to enable OVRD reg
       `DV_CHECK_MEMBER_RANDOMIZE_FATAL(sclval)
       `DV_CHECK_MEMBER_RANDOMIZE_FATAL(sdaval)

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
@@ -8,3 +8,4 @@
 `include "i2c_sanity_vseq.sv"
 
 `include "i2c_override_vseq.sv"
+`include "i2c_fifo_watermark_vseq.sv"

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -54,6 +54,11 @@
       name: i2c_override
       uvm_test_seq: i2c_override_vseq
     }
+
+    {
+      name: i2c_fifo_watermark
+      uvm_test_seq: i2c_fifo_watermark_vseq
+    }
   ]
 
   // List of regressions.

--- a/hw/ip/i2c/dv/tb/tb.sv
+++ b/hw/ip/i2c/dv/tb/tb.sv
@@ -24,6 +24,7 @@ module tb;
   wire intr_sda_interference;
   wire intr_stretch_timeout;
   wire intr_sda_unstable;
+  wire intr_trans_complete;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
 
   wire cio_scl_i;
@@ -64,7 +65,8 @@ module tb;
     .intr_scl_interference_o (intr_scl_interference ),
     .intr_sda_interference_o (intr_sda_interference ),
     .intr_stretch_timeout_o  (intr_stretch_timeout  ),
-    .intr_sda_unstable_o     (intr_sda_unstable     )
+    .intr_sda_unstable_o     (intr_sda_unstable     ),
+    .intr_trans_complete_o   (intr_trans_complete   )
   );
 
   // virtual open drain
@@ -87,6 +89,7 @@ module tb;
   assign interrupts[SdaInference]   = intr_sda_interference;
   assign interrupts[StretchTimeout] = intr_stretch_timeout;
   assign interrupts[SdaUnstable]    = intr_sda_unstable;
+  assign interrupts[TransComplete]  = intr_trans_complete;
 
   initial begin
     // drive clk and rst_n from clk_if


### PR DESCRIPTION
The main point of this test is to create constrained stimuli in order to deterministically trigger watermark interrupts which can be predictable and usable for DV

  - Update i2c_testplan.hjson to replace rx_fifo_watermark and
    fmt_fifo_watermark tests by a unified fifo_watermark test
  - Add i2c_fifo_watermark_vseq to verify both fmt_fifo and rx_fifo watermark interrupt
  - Update constraints in i2c_base_vseq
  - Update i2c_env_pkg and tb.sv to refect new intr_trans_complete interrupt (PR #2644 #2662)
  - Code clean

Signed-off-by: Hoang Tung <Hoang.Tung@wdc.com>