### PR TITLE
[dvsim] Fix for #2686 - missing else

### DIFF
--- a/util/dvsim/Modes.py
+++ b/util/dvsim/Modes.py
@@ -536,6 +536,7 @@ class Regressions(Modes):
                         log.error(
                             "Test \"%s\" added to regression \"%s\" not found!",
                             test, regression_obj.name)
+                        continue
                     tests_objs.append(test_obj)
                 regression_obj.tests = tests_objs
 


### PR DESCRIPTION
Testplan milestones (V1, V2, V3) are also regression targets (one can
run all V2 tests for instance by passing the switch `-i V2`). It could
be possible that the tests added to the testplan to one of these
milestones could actually be missing (yet to be developed) in the
simulation config hjson.

When that is true, invoking dvsim results in the error messages reported
in #2686. The fix for this is a missing else clause. With this, the `test_obj` 
is appended to the list of tests within the regression object only if it was
actually constructed (and is not `None`). 

Signed-off-by: Srikrishna Iyer <sriyer@google.com>