### PR TITLE
[alert_esc_agent/dv] clean up alert_esc agent

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_base_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_base_driver.sv
@@ -30,7 +30,7 @@ class alert_esc_base_driver extends dv_base_driver#(alert_esc_seq_item, alert_es
     forever begin
       alert_esc_seq_item req_clone;
       seq_item_port.get(req);
-      $cast(req_clone, req.clone());
+      `downcast(req_clone, req.clone());
       req_clone.set_id_info(req);
       // TODO: if any of the queue size is larger than 2, need additional support
       if (req.r_alert_ping_send) r_alert_ping_send_q.push_back(req_clone);

--- a/hw/dv/sv/alert_esc_agent/alert_monitor.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_monitor.sv
@@ -39,6 +39,7 @@ class alert_monitor extends alert_esc_base_monitor;
         under_ping_rsp = 1;
         req = alert_esc_seq_item::type_id::create("req");
         req.alert_esc_type = AlertEscPingTrans;
+
         fork
           begin : isolation_fork
             fork
@@ -62,6 +63,7 @@ class alert_monitor extends alert_esc_base_monitor;
             disable fork;
           end : isolation_fork
         join
+
         `uvm_info("alert_monitor", $sformatf("[%s]: handshake status is %s",
             req.alert_esc_type.name(), req.alert_handshake_sta.name()), UVM_HIGH)
         if (!under_reset) alert_esc_port.write(req);
@@ -80,10 +82,13 @@ class alert_monitor extends alert_esc_base_monitor;
         req = alert_esc_seq_item::type_id::create("req");
         req.alert_esc_type = AlertEscSigTrans;
         req.alert_handshake_sta = AlertReceived;
+
         // Write alert packet to scb when receiving alert signal
         alert_esc_port.write(req);
+
         // Duplicate req for writing alert packet at the end of alert handshake
         `downcast(req, req.clone())
+
         fork
           begin : isolation_fork
             fork
@@ -106,6 +111,7 @@ class alert_monitor extends alert_esc_base_monitor;
             disable fork;
           end : isolation_fork
         join
+
         `uvm_info("alert_monitor", $sformatf("[%s]: handshake status is %s",
             req.alert_esc_type.name(), req.alert_handshake_sta.name()), UVM_HIGH)
         if (!under_reset) alert_esc_port.write(req);
@@ -156,4 +162,5 @@ class alert_monitor extends alert_esc_base_monitor;
       ok_to_end = !cfg.vif.monitor_cb.alert_tx.alert_p && cfg.vif.monitor_cb.alert_tx.alert_n;
     end
   endtask
+
 endclass : alert_monitor

--- a/hw/dv/sv/alert_esc_agent/alert_receiver_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_receiver_driver.sv
@@ -35,7 +35,7 @@ class alert_receiver_driver extends alert_esc_base_driver;
       alert_esc_seq_item req, rsp;
       wait(r_alert_ping_send_q.size() > 0 && !under_reset);
       req = r_alert_ping_send_q.pop_front();
-      $cast(rsp, req.clone());
+      `downcast(rsp, req.clone());
       rsp.set_id_info(req);
       `uvm_info(`gfn,
           $sformatf("starting to send receiver item, ping_send=%0b, alert_rsp=%0b, int_fail=%0b",
@@ -61,7 +61,7 @@ class alert_receiver_driver extends alert_esc_base_driver;
       alert_esc_seq_item req, rsp;
       wait(r_alert_rsp_q.size() > 0 && !under_reset);
       req = r_alert_rsp_q.pop_front();
-      $cast(rsp, req.clone());
+      `downcast(rsp, req.clone());
       rsp.set_id_info(req);
       `uvm_info(`gfn,
           $sformatf("starting to send receiver item, ping_send=%0b, alert_rsp=%0b, int_fail=%0b",

--- a/hw/dv/sv/alert_esc_agent/esc_monitor.sv
+++ b/hw/dv/sv/alert_esc_agent/esc_monitor.sv
@@ -31,23 +31,23 @@ class esc_monitor extends alert_esc_base_monitor;
 
   virtual task esc_thread();
     alert_esc_seq_item req, req_clone;
-    logic esc_p = get_esc();
     forever @(cfg.vif.monitor_cb) begin
-      if (!under_reset && !esc_p && get_esc() === 1'b1) begin
+      if (!under_reset && get_esc() === 1'b1) begin
         req = alert_esc_seq_item::type_id::create("req");
         req.sig_cycle_cnt++;
         if (is_sig_int_err()) req.esc_handshake_sta = EscIntFail;
         else req.esc_handshake_sta = EscRespHi;
         @(cfg.vif.monitor_cb);
+
         // esc_p/n only goes high for a cycle, detect it is a ping signal
         if (get_esc() === 1'b0) begin
           int ping_cnter = 1;
           under_esc_ping = 1;
           req.alert_esc_type = AlertEscPingTrans;
-          check_esc_resp(.req(req), .is_ping(1), .do_wait_clk(0));
+          check_esc_resp(.req(req), .is_ping(1));
           do begin
             @(cfg.vif.monitor_cb);
-            check_esc_resp(.req(req), .is_ping(1), .do_wait_clk(0));
+            check_esc_resp(.req(req), .is_ping(1));
             ping_cnter ++;
           end
           while (req.esc_handshake_sta != EscRespComplete && ping_cnter < cfg.ping_timeout_cycle &&
@@ -55,12 +55,12 @@ class esc_monitor extends alert_esc_base_monitor;
           if (under_reset) continue;
           if (ping_cnter >= cfg.ping_timeout_cycle) begin
             alert_esc_seq_item req_clone;
-            $cast(req_clone, req.clone());
+            `downcast(req_clone, req.clone());
             req_clone.timeout = 1;
             alert_esc_port.write(req_clone);
             if (!cfg.probe_vif.get_esc_en()) begin
               @(cfg.vif.monitor_cb);
-              check_esc_resp(.req(req), .is_ping(1), .do_wait_clk(0));
+              check_esc_resp(.req(req), .is_ping(1));
             end
           end
           if (cfg.probe_vif.get_esc_en()) begin
@@ -69,21 +69,34 @@ class esc_monitor extends alert_esc_base_monitor;
           end
           under_esc_ping = 0;
         end
-        // when it is not a ping
+
+        // when it is not a ping, there are two preconditions to reach this code:
+        // 1). standalone escalation signals
+        // 2). originally ping response, but interrupted by real escalation signals, then ping
+        // response is aborted, and immediately jumps to escalation responses
         if (get_esc() === 1'b1) begin
           req.alert_esc_type = AlertEscSigTrans;
-          req.sig_cycle_cnt++;
-          check_esc_resp(.req(req), .is_ping(0), .do_wait_clk(1));
-          while (get_esc() === 1) check_esc_resp(.req(req), .is_ping(0), .do_wait_clk(1));
-          check_esc_resp(.req(req), .is_ping(0), .do_wait_clk(0));
-          $cast(req_clone, req.clone());
-          req_clone.esc_handshake_sta = EscRespComplete;
-          alert_esc_port.write(req_clone);
+          `downcast(req_clone, req.clone());
+
+          // check resp_p/n response until esc_p/n completes
+          // Sig_cycle_cnt records how many cycles esc_p stayed high, which is used for scb check
+          // Check_esc_resp() task checks the first cycle when esp_p reset, because esc_receiver
+          // will still drive resp_p/n at this clock cycle
+          while (req.esc_handshake_sta != EscRespComplete) begin
+            req.sig_cycle_cnt++;
+            check_esc_resp(.req(req_clone), .is_ping(0));
+            @(cfg.vif.monitor_cb);
+            if (get_esc() === 1'b0) begin
+              check_esc_resp(.req(req_clone), .is_ping(0));
+              req.esc_handshake_sta = EscRespComplete;
+              alert_esc_port.write(req);
+            end
+          end
         end
+
         `uvm_info("esc_monitor", $sformatf("[%s]: handshake status is %s, timeout=%0b",
             req.alert_esc_type.name(), req.esc_handshake_sta.name(), req.timeout), UVM_HIGH)
       end
-      esc_p = get_esc();
     end
   endtask : esc_thread
 
@@ -116,13 +129,13 @@ class esc_monitor extends alert_esc_base_monitor;
   // this task checks if resp_p/n is correct by:
   // if it is not a ping_response, it should follow: low -> high .. until esc_p goes low.
   // if it is a ping_response, it should follow: low -> high -> low -> high
-  // if any time the pattern is missed, it is expect to go back to "low" state
-  // if waited a clk and it is not a ping_response, sig_cyc_cnt is incremented
-  virtual task check_esc_resp(alert_esc_seq_item req, bit is_ping, bit do_wait_clk);
+  // if any clock cycle resp_p/n does not match the expected pattern, reset back to "low" state
+  // if any clock cycle resp_p/n are not complement, reset back to "low" state
+  virtual task check_esc_resp(alert_esc_seq_item req, bit is_ping);
     if (req.esc_handshake_sta inside {EscIntFail, EscReceived}) begin
       if (cfg.vif.monitor_cb.esc_rx.resp_p !== 0) begin
         alert_esc_seq_item req_clone;
-        $cast(req_clone, req.clone());
+        `downcast(req_clone, req.clone());
         req_clone.esc_handshake_sta = EscIntFail;
         alert_esc_port.write(req_clone);
       end
@@ -165,11 +178,6 @@ class esc_monitor extends alert_esc_base_monitor;
     end
 
     if (is_sig_int_err()) req.esc_handshake_sta = EscIntFail;
-
-    if (do_wait_clk) begin
-      @(cfg.vif.monitor_cb);
-      if (get_esc() === 1 && !is_ping) req.sig_cycle_cnt++;
-    end
   endtask : check_esc_resp
 
   virtual function bit get_esc();


### PR DESCRIPTION
As suggested by @rasmus-madsen  on PR #2667, this PR cleans up alert_esc_agent
by:
1). Separate the wait_clk inside `check_esc_resp` task to make it more readable.
2). Update `$cast` to `downcast` macro
3). Insert a new line before comments and new line before/after large code block
4). In esc_receiver_driver, use repeat to replace some duplicated code

Signed-off-by: Cindy Chen <chencindy@google.com>