### PR TITLE
[bronze] Enable memory scrambling on main memory and otbn

### DIFF
--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -43,6 +43,14 @@
       width:   "1",
       act:     "req",
     },
+
+    //Broadcast to OTBN RAM Scrambler
+    { struct: "otbn_ram_key"
+      type:   "uni"
+      name:   "otp_otbn_ram_key"
+      act:    "rcv"
+      package: "otbn_pkg"
+    }
   ],
 
   regwidth: "32"

--- a/hw/ip/otbn/otbn.core
+++ b/hw/ip/otbn/otbn.core
@@ -13,6 +13,7 @@ filesets:
       - lowrisc:prim:assert
       - lowrisc:prim:util
       - lowrisc:prim:ram_1p_adv
+      - lowrisc:prim:ram_1p_scr
     files:
       - rtl/otbn_pkg.sv
       - rtl/otbn_reg_pkg.sv

--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -18,4 +18,10 @@ package otbn_pkg;
     ErrCodeNoError = 32'h 0000_0000
   } err_code_e;
 
+  typedef struct packed {
+    logic valid;
+    logic [128-1:0] key;
+    logic [256-1:0] nonce;
+  } otbn_ram_key_t;
+
 endpackage

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson
@@ -139,12 +139,26 @@
       act:    "req"
       package: "otp_ctrl_pkg"
     }
-    //Broadcast to SRAM Scramblers
-    { struct: "sram_key"
+    //Broadcast to Main RAM Scrambler
+    { struct: "ram_main_key"
       type:   "uni"
-      name:   "otp_sram_key"
+      name:   "otp_ram_main_key"
       act:    "req"
       package: "otp_ctrl_pkg"
+    }
+    //Broadcast to Retention RAM Scrambler
+    { struct: "ram_ret_aon_key"
+      type:   "uni"
+      name:   "otp_ram_ret_aon_key"
+      act:    "req"
+      package: "otp_ctrl_pkg"
+    }
+    //Broadcast to OTBN RAM Scrambler
+    { struct: "otbn_ram_key"
+      type:   "uni"
+      name:   "otp_otbn_ram_key"
+      act:    "req"
+      package: "otbn_pkg"
     }
   ] // inter_signal_list
 

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson
@@ -93,9 +93,9 @@
     }
     // Status output to power manager
     { struct: "otp_pwr_state"
-      type:   "broadcast"  // no `_req/rsp`
+      type:   "uni"  // no `_req/rsp`
       name:   "otp_pwr_state"
-      act:    "sender"
+      act:    "req"
       package: "otp_ctrl_pkg"
     }
     // LC transition command
@@ -107,35 +107,42 @@
     }
     // Broadcast to LC
     { struct: "otp_lc_data"
-      type:   "broadcast"  // no `_req/rsp`
+      type:   "uni"  // no `_req/rsp`
       name:   "otp_lc_data"
-      act:    "sender"
+      act:    "req"
       package: "otp_ctrl_pkg"
     }
     // Broadcast from LC
-    { struct: "lc_tx_t"
-      type:   "broadcast"  // no `_req/rsp`
+    { struct: "lc_tx"
+      type:   "uni"  // no `_req/rsp`
       name:   "lc_provision_en"
-      act:    "receiver"
+      act:    "rsp"
       package: "otp_ctrl_pkg" // TODO: move to LC package
     }
-    { struct: "lc_tx_t"
-      type:   "broadcast"  // no `_req/rsp`
+    { struct: "lc_tx"
+      type:   "uni"  // no `_req/rsp`
       name:   "lc_test_en"
-      act:    "receiver"
+      act:    "rsp"
       package: "otp_ctrl_pkg" // TODO: move to LC package
     }
     //Broadcast to Key Manager
     { struct: "keymgr_key"
-      type:   "broadcast"  // no `_req/rsp`
+      type:   "uni"  // no `_req/rsp`
       name:   "otp_keymgr_key"
-      act:    "sender"
+      act:    "req"
       package: "otp_ctrl_pkg" // TODO: move this to keymgr package
     }
     //Broadcast to Flash Controller
     { struct: "flash_key"
       type:   "uni"
       name:   "otp_flash_key"
+      act:    "req"
+      package: "otp_ctrl_pkg"
+    }
+    //Broadcast to SRAM Scramblers
+    { struct: "sram_key"
+      type:   "uni"
+      name:   "otp_sram_key"
       act:    "req"
       package: "otp_ctrl_pkg"
     }

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv
@@ -106,7 +106,7 @@ package otp_ctrl_pkg;
     otp_program_cmd_e command;
   } lc_otp_program_req_t;
 
-  parameter lc_otp_program_req_t LC_OTP_PROGRAM_REQ_DEFAULT = {
+  parameter lc_otp_program_req_t LC_OTP_PROGRAM_REQ_DEFAULT = '{
     update: '0,
     command: '0
   };
@@ -126,6 +126,7 @@ package otp_ctrl_pkg;
     lc_tx_e state;
   } lc_tx_t;
 
+  parameter lc_tx_t LC_TX_DEFAULT = '{state: Off};
 
   ////////////////////////////////
   // Typedefs for Key Broadcast //
@@ -146,6 +147,13 @@ package otp_ctrl_pkg;
     logic [FlashKeyWidth-1:0] data_key;
   } flash_key_t;
 
+  // TODO: this is not final. we still need to figure out
+  // how and where key derivation for SRAM should happen.
+  typedef struct packed {
+    logic valid;
+    logic [FlashKeyWidth-1:0] key;
+    logic [64-1:0]            nonce;
+  } sram_key_t;
 
   ////////////////////////////////
   // Power/Reset Ctrl Interface //

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv
@@ -153,7 +153,13 @@ package otp_ctrl_pkg;
     logic valid;
     logic [FlashKeyWidth-1:0] key;
     logic [64-1:0]            nonce;
-  } sram_key_t;
+  } ram_main_key_t;
+
+  typedef struct packed {
+    logic valid;
+    logic [FlashKeyWidth-1:0] key;
+    logic [64-1:0]            nonce;
+  } ram_ret_aon_key_t;
 
   ////////////////////////////////
   // Power/Reset Ctrl Interface //

--- a/hw/ip/prim/prim.core
+++ b/hw/ip/prim/prim.core
@@ -36,6 +36,7 @@ filesets:
       - rtl/prim_cipher_pkg.sv
       - rtl/prim_present.sv
       - rtl/prim_prince.sv
+      - rtl/prim_subst_perm.sv
       - rtl/prim_gate_gen.sv
       - rtl/prim_pulse_sync.sv
       - rtl/prim_filter.sv

--- a/hw/ip/prim/prim_ram_1p_scr.core
+++ b/hw/ip/prim/prim_ram_1p_scr.core
@@ -1,0 +1,22 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:ram_1p_scr:0.1"
+description: "Single-port RAM primitive with data and address scrambling"
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:prim:assert
+      - lowrisc:prim:util
+      - lowrisc:prim:ram_1p_adv
+      - lowrisc:prim:all
+    files:
+      - rtl/prim_ram_1p_scr.sv
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_rtl

--- a/hw/ip/prim/rtl/prim_cipher_pkg.sv
+++ b/hw/ip/prim/rtl/prim_cipher_pkg.sv
@@ -250,7 +250,7 @@ package prim_cipher_pkg;
                                                            logic [4:0]  round_cnt);
     logic [63:0] key_out = key_in;
     // xor in round counter on bits 19 to 15
-    key_out[19:15] ^= 6'(round_cnt) + 1 - round_idx;
+    key_out[19:15] ^= round_cnt + 1 - round_idx;
     // sbox on uppermost 4 bits
     key_out[63 -: 4] = PRESENT_SBOX4_INV[key_out[63 -: 4]];
     // rotate by 61 to the right
@@ -264,7 +264,7 @@ package prim_cipher_pkg;
                                                            logic [4:0]  round_cnt);
     logic [79:0] key_out = key_in;
     // xor in round counter on bits 19 to 15
-    key_out[19:15] ^= 6'(round_cnt) + 1 - round_idx;
+    key_out[19:15] ^= round_cnt + 1 - round_idx;
     // sbox on uppermost 4 bits
     key_out[79 -: 4] = PRESENT_SBOX4_INV[key_out[79 -: 4]];
     // rotate by 61 to the right
@@ -278,7 +278,7 @@ package prim_cipher_pkg;
                                                              logic [4:0]   round_cnt);
     logic [127:0] key_out = key_in;
     // xor in round counter on bits 66 to 62
-    key_out[66:62] ^= 6'(round_cnt) + 1 - round_idx;
+    key_out[66:62] ^= round_cnt + 1 - round_idx;
     // sbox on second highest nibble
     key_out[123 -: 4] = PRESENT_SBOX4_INV[key_out[123 -: 4]];
     // sbox on uppermost 4 bits
@@ -328,6 +328,24 @@ package prim_cipher_pkg;
   // Common Subfunctions //
   /////////////////////////
 
+  function automatic logic [7:0] sbox4_8bit(logic [7:0] state_in, logic [15:0][3:0] sbox4);
+    logic [7:0] state_out;
+    // note that if simulation performance becomes an issue, this loop can be unrolled
+    for (int k = 0; k < 8/4; k++) begin
+      state_out[k*4  +: 4] = sbox4[state_in[k*4  +: 4]];
+    end
+    return state_out;
+  endfunction : sbox4_8bit
+
+  function automatic logic [15:0] sbox4_16bit(logic [15:0] state_in, logic [15:0][3:0] sbox4);
+    logic [15:0] state_out;
+    // note that if simulation performance becomes an issue, this loop can be unrolled
+    for (int k = 0; k < 16/4; k++) begin
+      state_out[k*4  +: 4] = sbox4[state_in[k*4  +: 4]];
+    end
+    return state_out;
+  endfunction : sbox4_16bit
+
   function automatic logic [31:0] sbox4_32bit(logic [31:0] state_in, logic [15:0][3:0] sbox4);
     logic [31:0] state_out;
     // note that if simulation performance becomes an issue, this loop can be unrolled
@@ -346,11 +364,29 @@ package prim_cipher_pkg;
     return state_out;
   endfunction : sbox4_64bit
 
+  function automatic logic [7:0] perm_8bit(logic [7:0] state_in, logic [7:0][2:0] perm);
+    logic [7:0] state_out;
+    // note that if simulation performance becomes an issue, this loop can be unrolled
+    for (int k = 0; k < 8; k++) begin
+      state_out[perm[k]] = state_in[k];
+    end
+    return state_out;
+  endfunction : perm_8bit
+
+    function automatic logic [15:0] perm_16bit(logic [15:0] state_in, logic [15:0][3:0] perm);
+    logic [15:0] state_out;
+    // note that if simulation performance becomes an issue, this loop can be unrolled
+    for (int k = 0; k < 16; k++) begin
+      state_out[perm[k]] = state_in[k];
+    end
+    return state_out;
+  endfunction : perm_16bit
+
   function automatic logic [31:0] perm_32bit(logic [31:0] state_in, logic [31:0][4:0] perm);
     logic [31:0] state_out;
     // note that if simulation performance becomes an issue, this loop can be unrolled
     for (int k = 0; k < 32; k++) begin
-      state_out[k] = state_in[perm[k]];
+      state_out[perm[k]] = state_in[k];
     end
     return state_out;
   endfunction : perm_32bit

--- a/hw/ip/prim/rtl/prim_cipher_pkg.sv
+++ b/hw/ip/prim/rtl/prim_cipher_pkg.sv
@@ -340,8 +340,8 @@ package prim_cipher_pkg;
   function automatic logic [15:0] sbox4_16bit(logic [15:0] state_in, logic [15:0][3:0] sbox4);
     logic [15:0] state_out;
     // note that if simulation performance becomes an issue, this loop can be unrolled
-    for (int k = 0; k < 16/4; k++) begin
-      state_out[k*4  +: 4] = sbox4[state_in[k*4  +: 4]];
+    for (int k = 0; k < 2; k++) begin
+      state_out[k*8  +: 8] = sbox4_8bit(state_in[k*8  +: 8], sbox4);
     end
     return state_out;
   endfunction : sbox4_16bit
@@ -349,8 +349,8 @@ package prim_cipher_pkg;
   function automatic logic [31:0] sbox4_32bit(logic [31:0] state_in, logic [15:0][3:0] sbox4);
     logic [31:0] state_out;
     // note that if simulation performance becomes an issue, this loop can be unrolled
-    for (int k = 0; k < 32/4; k++) begin
-      state_out[k*4  +: 4] = sbox4[state_in[k*4  +: 4]];
+    for (int k = 0; k < 4; k++) begin
+      state_out[k*8  +: 8] = sbox4_8bit(state_in[k*8  +: 8], sbox4);
     end
     return state_out;
   endfunction : sbox4_32bit
@@ -358,8 +358,8 @@ package prim_cipher_pkg;
   function automatic logic [63:0] sbox4_64bit(logic [63:0] state_in, logic [15:0][3:0] sbox4);
     logic [63:0] state_out;
     // note that if simulation performance becomes an issue, this loop can be unrolled
-    for (int k = 0; k < 64/4; k++) begin
-      state_out[k*4  +: 4] = sbox4[state_in[k*4  +: 4]];
+    for (int k = 0; k < 8; k++) begin
+      state_out[k*8  +: 8] = sbox4_8bit(state_in[k*8  +: 8], sbox4);
     end
     return state_out;
   endfunction : sbox4_64bit

--- a/hw/ip/prim/rtl/prim_cipher_pkg.sv
+++ b/hw/ip/prim/rtl/prim_cipher_pkg.sv
@@ -248,13 +248,13 @@ package prim_cipher_pkg;
                                                            logic [4:0]  round_idx,
                                                            // total number of rounds employed
                                                            logic [4:0]  round_cnt);
-    logic [63:0] key_out;
+    logic [63:0] key_out = key_in;
     // xor in round counter on bits 19 to 15
     key_out[19:15] ^= 6'(round_cnt) + 1 - round_idx;
     // sbox on uppermost 4 bits
     key_out[63 -: 4] = PRESENT_SBOX4_INV[key_out[63 -: 4]];
     // rotate by 61 to the right
-    key_out = 64'(key_in >> 61) | 64'(key_in << (64-61));
+    key_out = 64'(key_out >> 61) | 64'(key_out << (64-61));
     return key_out;
   endfunction : present_inv_update_key64
 
@@ -262,13 +262,13 @@ package prim_cipher_pkg;
                                                            logic [4:0]  round_idx,
                                                            // total number of rounds employed
                                                            logic [4:0]  round_cnt);
-    logic [79:0] key_out;
+    logic [79:0] key_out = key_in;
     // xor in round counter on bits 19 to 15
     key_out[19:15] ^= 6'(round_cnt) + 1 - round_idx;
     // sbox on uppermost 4 bits
     key_out[79 -: 4] = PRESENT_SBOX4_INV[key_out[79 -: 4]];
     // rotate by 61 to the right
-    key_out = 80'(key_in >> 61) | 80'(key_in << (80-61));
+    key_out = 80'(key_out >> 61) | 80'(key_out << (80-61));
     return key_out;
   endfunction : present_inv_update_key80
 
@@ -276,13 +276,15 @@ package prim_cipher_pkg;
                                                              logic [4:0]   round_idx,
                                                              // total number of rounds employed
                                                              logic [4:0]   round_cnt);
-    logic [127:0] key_out;
-    // xor in round counter on bits 19 to 15
-    key_out[19:15] ^= 6'(round_cnt) + 1 - round_idx;
+    logic [127:0] key_out = key_in;
+    // xor in round counter on bits 66 to 62
+    key_out[66:62] ^= 6'(round_cnt) + 1 - round_idx;
+    // sbox on second highest nibble
+    key_out[123 -: 4] = PRESENT_SBOX4_INV[key_out[123 -: 4]];
     // sbox on uppermost 4 bits
     key_out[127 -: 4] = PRESENT_SBOX4_INV[key_out[127 -: 4]];
     // rotate by 61 to the right
-    key_out = 128'(key_in >> 61) | 128'(key_in << (128-61));
+    key_out = 128'(key_out >> 61) | 128'(key_out << (128-61));
     return key_out;
   endfunction : present_inv_update_key128
 

--- a/hw/ip/prim/rtl/prim_cipher_pkg.sv
+++ b/hw/ip/prim/rtl/prim_cipher_pkg.sv
@@ -235,8 +235,10 @@ package prim_cipher_pkg;
     key_out = 128'(key_in << 61) | 128'(key_in >> (128-61));
     // sbox on uppermost 4 bits
     key_out[127 -: 4] = PRESENT_SBOX4[key_out[127 -: 4]];
-    // xor in round counter on bits 19 to 15
-    key_out[19:15] ^= round_idx;
+    // sbox on second nibble from top
+    key_out[123 -: 4] = PRESENT_SBOX4[key_out[123 -: 4]];
+    // xor in round counter on bits 66 to 62
+    key_out[66:62] ^= round_idx;
     return key_out;
   endfunction : present_update_key128
 
@@ -355,7 +357,7 @@ package prim_cipher_pkg;
     logic [63:0] state_out;
     // note that if simulation performance becomes an issue, this loop can be unrolled
     for (int k = 0; k < 64; k++) begin
-      state_out[k] = state_in[perm[k]];
+      state_out[perm[k]] = state_in[k];
     end
     return state_out;
   endfunction : perm_64bit

--- a/hw/ip/prim/rtl/prim_fifo_sync.sv
+++ b/hw/ip/prim/rtl/prim_fifo_sync.sv
@@ -10,6 +10,7 @@ module prim_fifo_sync #(
   parameter int unsigned Width       = 16,
   parameter bit Pass                 = 1'b1, // if == 1 allow requests to pass through empty FIFO
   parameter int unsigned Depth       = 4,
+  // derived parameter
   localparam int          DepthW     = prim_util_pkg::vbits(Depth+1)
 ) (
   input                   clk_i,

--- a/hw/ip/prim/rtl/prim_prince.sv
+++ b/hw/ip/prim/rtl/prim_prince.sv
@@ -2,15 +2,14 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// This module is an implementation of the 64bit PRINCE block cipher. It is a
-// fully unrolled combinational implementation with configurable number of
-// rounds. Due to the reflective construction of this cipher, the same circuit
-// can be used for encryption and decryption, as described below. Further, the
-// primitive supports a 32bit block cipher flavor which is not specified in the
-// original paper. It should be noted, however, that the 32bit version is
-// **not** secure and must not be used in a setting where cryptographic cipher
-// strength is required. The 32bit variant is only intended to be used as a
-// lightweight data scrambling device.
+// This module is an implementation of the 64bit PRINCE block cipher. It is a fully unrolled
+// combinational implementation with configurable number of rounds. Optionally, registers for the
+// data and key states can be enabled, if this is required. Due to the reflective construction of
+// this cipher, the same circuit can be used for encryption and decryption, as described below.
+// Further, the primitive supports a 32bit block cipher flavor which is not specified in the
+// original paper. It should be noted, however, that the 32bit version is **not** secure and must
+// not be used in a setting where cryptographic cipher strength is required. The 32bit variant is
+// only intended to be used as a lightweight data scrambling device.
 //
 // See also: prim_present, prim_cipher_pkg
 //
@@ -33,11 +32,20 @@ module prim_prince #(
   parameter int NumRoundsHalf = 5,
   // This primitive uses the new key schedule proposed in https://eprint.iacr.org/2014/656.pdf
   // Setting this parameter to 1 falls back to the original key schedule.
-  parameter bit UseOldKeySched = 1'b0
+  parameter bit UseOldKeySched = 1'b0,
+  // This instantiates a data register halfway in the primitive.
+  parameter bit HalfwayDataReg = 1'b0,
+  // This instantiates a key register halfway in the primitive.
+  parameter bit HalfwayKeyReg = 1'b0
 ) (
+  input                        clk_i,
+  input                        rst_ni,
+
+  input                        valid_i,
   input        [DataWidth-1:0] data_i,
   input        [KeyWidth-1:0]  key_i,
-  input                        dec_i, // set to 1 for decryption
+  input                        dec_i,   // set to 1 for decryption
+  output logic                 valid_o,
   output logic [DataWidth-1:0] data_o
 );
 
@@ -45,26 +53,46 @@ module prim_prince #(
   // key expansion //
   ///////////////////
 
-  logic [DataWidth-1:0] k0, k0_prime, k1, k0_new;
-
+  logic [DataWidth-1:0] k0, k0_prime_d, k1_d, k0_new_d, k0_prime_q, k1_q, k0_new_q;
   always_comb begin : p_key_expansion
-    k0       = key_i[DataWidth-1:0];
-    k0_prime = {k0[0], k0[DataWidth-1:2], k0[DataWidth-1] ^ k0[1]};
-    k1       = key_i[2*DataWidth-1 : DataWidth];
+    k0         = key_i[DataWidth-1:0];
+    k0_prime_d = {k0[0], k0[DataWidth-1:2], k0[DataWidth-1] ^ k0[1]};
+    k1_d       = key_i[2*DataWidth-1 : DataWidth];
 
     // modify key for decryption
     if (dec_i) begin
-      k0       = k0_prime;
-      k0_prime = key_i[DataWidth-1:0];
-      k1       ^= prim_cipher_pkg::PRINCE_ALPHA_CONST[DataWidth-1:0];
+      k0          = k0_prime_d;
+      k0_prime_d  = key_i[DataWidth-1:0];
+      k1_d       ^= prim_cipher_pkg::PRINCE_ALPHA_CONST[DataWidth-1:0];
     end
   end
 
   if (UseOldKeySched) begin : gen_legacy_keyschedule
-    assign k0_new = k1;
+    assign k0_new_d = k1_d;
   end else begin : gen_new_keyschedule
     // improved keyschedule proposed by https://eprint.iacr.org/2014/656.pdf
-    assign k0_new = k0;
+    assign k0_new_d = k0;
+  end
+
+  if (HalfwayKeyReg) begin : gen_key_reg
+    always_ff @(posedge clk_i or negedge rst_ni) begin : p_key_reg
+      if (!rst_ni) begin
+        k1_q       <= '0;
+        k0_prime_q <= '0;
+        k0_new_q   <= '0;
+      end else begin
+        if (valid_i) begin
+          k1_q       <= k1_d;
+          k0_prime_q <= k0_prime_d;
+          k0_new_q   <= k0_new_d;
+        end
+      end
+    end
+  end else begin : gen_no_key_reg
+    // just pass the key through in this case
+    assign k1_q       = k1_d;
+    assign k0_prime_q = k0_prime_d;
+    assign k0_new_q   = k0_new_d;
   end
 
   //////////////
@@ -77,7 +105,7 @@ module prim_prince #(
   // pre-round XOR
   always_comb begin : p_pre_round_xor
     data_state[0] = data_i ^ k0;
-    data_state[0] ^= k1;
+    data_state[0] ^= k1_d;
     data_state[0] ^= prim_cipher_pkg::PRINCE_ROUND_CONST[0][DataWidth-1:0];
   end
 
@@ -105,28 +133,48 @@ module prim_prince #(
     assign data_state_xor = data_state_round ^
                             prim_cipher_pkg::PRINCE_ROUND_CONST[k][DataWidth-1:0];
     // improved keyschedule proposed by https://eprint.iacr.org/2014/656.pdf
-    if (k % 2 == 1) assign data_state[k]  = data_state_xor ^ k0_new;
-    else            assign data_state[k]  = data_state_xor ^ k1;
+    if (k % 2 == 1) assign data_state[k]  = data_state_xor ^ k0_new_d;
+    else            assign data_state[k]  = data_state_xor ^ k1_d;
   end
 
   // middle part
-  logic [DataWidth-1:0] data_state_middle;
+  logic [DataWidth-1:0] data_state_middle_d, data_state_middle_q, data_state_middle;
   if (DataWidth == 64) begin : gen_middle_d64
     always_comb begin : p_middle_d64
-      data_state_middle = prim_cipher_pkg::sbox4_64bit(data_state[NumRoundsHalf],
+      data_state_middle_d = prim_cipher_pkg::sbox4_64bit(data_state[NumRoundsHalf],
           prim_cipher_pkg::PRINCE_SBOX4);
-      data_state_middle = prim_cipher_pkg::prince_mult_prime_64bit(data_state_middle);
+      data_state_middle = prim_cipher_pkg::prince_mult_prime_64bit(data_state_middle_q);
       data_state_middle = prim_cipher_pkg::sbox4_64bit(data_state_middle,
           prim_cipher_pkg::PRINCE_SBOX4_INV);
     end
   end else begin : gen_middle_d32
     always_comb begin : p_middle_d32
-      data_state_middle = prim_cipher_pkg::sbox4_32bit(data_state_middle[NumRoundsHalf],
+      data_state_middle_d = prim_cipher_pkg::sbox4_32bit(data_state_middle[NumRoundsHalf],
           prim_cipher_pkg::PRINCE_SBOX4);
-      data_state_middle = prim_cipher_pkg::prince_mult_prime_32bit(data_state_middle);
+      data_state_middle = prim_cipher_pkg::prince_mult_prime_32bit(data_state_middle_q);
       data_state_middle = prim_cipher_pkg::sbox4_32bit(data_state_middle,
           prim_cipher_pkg::PRINCE_SBOX4_INV);
     end
+  end
+
+  if (HalfwayDataReg) begin : gen_data_reg
+    logic valid_q;
+    always_ff @(posedge clk_i or negedge rst_ni) begin : p_data_reg
+      if (!rst_ni) begin
+        valid_q <= 1'b0;
+        data_state_middle_q <= '0;
+      end else begin
+        valid_q <= valid_i;
+        if (valid_i) begin
+          data_state_middle_q <= data_state_middle_d;
+        end
+      end
+    end
+    assign valid_o = valid_q;
+  end else begin : gen_no_data_reg
+    // just pass data through in this case
+    assign data_state_middle_q = data_state_middle_d;
+    assign valid_o = valid_i;
   end
 
   assign data_state[NumRoundsHalf+1] = data_state_middle;
@@ -135,8 +183,8 @@ module prim_prince #(
   for (genvar k = 1; k <= NumRoundsHalf; k++) begin : gen_bwd_pass
     logic [DataWidth-1:0] data_state_xor0, data_state_xor1;
     // improved keyschedule proposed by https://eprint.iacr.org/2014/656.pdf
-    if (k % 2 == 1) assign data_state_xor0 = data_state[NumRoundsHalf+k] ^ k0_new;
-    else            assign data_state_xor0 = data_state[NumRoundsHalf+k] ^ k1;
+    if (k % 2 == 1) assign data_state_xor0 = data_state[NumRoundsHalf+k] ^ k0_new_q;
+    else            assign data_state_xor0 = data_state[NumRoundsHalf+k] ^ k1_q;
     // the construction is reflective, hence the subtraction with NumRoundsHalf
     assign data_state_xor1 = data_state_xor0 ^
                              prim_cipher_pkg::PRINCE_ROUND_CONST[10-NumRoundsHalf+k][DataWidth-1:0];
@@ -165,8 +213,8 @@ module prim_prince #(
   always_comb begin : p_post_round_xor
     data_o  = data_state[2*NumRoundsHalf+1] ^
               prim_cipher_pkg::PRINCE_ROUND_CONST[11][DataWidth-1:0];
-    data_o ^= k1;
-    data_o ^= k0_prime;
+    data_o ^= k1_q;
+    data_o ^= k0_prime_q;
   end
 
   ////////////////

--- a/hw/ip/prim/rtl/prim_ram_1p_scr.sv
+++ b/hw/ip/prim/rtl/prim_ram_1p_scr.sv
@@ -1,0 +1,330 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// This is a draft implementation of a low-latency memory scrambling mechanism.
+//
+// The module is implemented as a primitive, in the same spirit as similar prim_ram_1p_adv wrappers.
+// Hence, it can be conveniently instantiated by comportable IPs (such as OTBN) or in top_earlgrey
+// for the main system memory.
+//
+// The currently implemented architecture uses a reduced-round PRINCE cipher primitive in CTR mode
+// in order to (weakly) scramble the data written to the memory macro. Plain CTR mode does not
+// diffuse the data since the keystream is just XOR'ed onto it, hence we also we perform Byte-wise
+// diffusion using a (shallow) substitution/permutation network layers in order to provide a limited
+// avalanche effect within a Byte.
+//
+// In order to break the linear addressing space, the address is passed through a bijective
+// scrambling function constructed using a (shallow) substitution/permutation and a nonce. Due to
+// that nonce, the address mapping is not fully baked into RTL and can be changed at runtime as
+// well.
+//
+// Note that this design is not final nor tested, and its main purpose is to be instantiated in
+// Bronze for area and timing estimates.
+//
+// See also: prim_cipher_pkg, prim_prince
+
+`include "prim_assert.sv"
+
+module prim_ram_1p_scr #(
+  parameter  int Depth                = 512, // Needs to be a power of 2 if NumAddrScrRounds > 0.
+  parameter  int Width                = 256, // Needs to be Byte aligned for parity
+  parameter  int DataBitsPerMask      = 8,   // Currently only 8 is supported
+  parameter  int CfgW                 = 8,   // WTC, RTC, etc
+
+  // Scrambling parameters. Note that this needs to be low-latency, hence we have to keep the
+  // amount of cipher rounds low. PRINCE has 5 half rounds in its original form, which corresponds
+  // to 2*5 + 1 effective rounds. Setting this to 2 halves this to approximately 5 effective rounds.
+  parameter  int NumPrinceRoundsHalf  = 2,   // Number of PRINCE half rounds, can be [1..5]
+  // Number of extra intra-Byte diffusion rounds. Setting this to 0 disables intra-Byte diffusion.
+  parameter  int NumByteScrRounds     = 2,
+  // Number of address scrambling rounds. Setting this to 0 disables address scrambling.
+  parameter  int NumAddrScrRounds     = 2,
+  // If set to 1, the same 64bit key stream is replicated if the data port is wider than 64bit.
+  // If set to 0, the cipher primitive is replicated, and together with a wider nonce input,
+  // a unique keystream is generated for the full data width.
+  parameter  bit ReplicateKeyStream   = 1'b0,
+
+  // Derived parameters
+  localparam int AddrWidth            = prim_util_pkg::vbits(Depth),
+  // Depending on the data width, we need to instantiate multiple parallel cipher primitives to
+  // create a keystream that is wide enough (PRINCE has a block size of 64bit)
+  localparam int NumParScr            = (ReplicateKeyStream) ? 1 : (Width + 63) / 64,
+  localparam int NumParKeystr         = (ReplicateKeyStream) ? (Width + 63) / 64 : 1,
+  // This is given by the PRINCE cipher primitive. All parallel cipher modules
+  // use the same key, but they use a different IV
+  localparam int DataKeyWidth         = 128,
+  // Each scrambling primitive requires a 64bit IV composed of {nonce, address}
+  localparam int DataNonceWidth       = (64-AddrWidth) * NumParScr
+) (
+  input                             clk_i,
+  input                             rst_ni,
+
+  input        [DataKeyWidth-1:0]   key_i,
+  input        [DataNonceWidth-1:0] data_nonce_i,
+  input        [AddrWidth-1:0]      addr_nonce_i,
+
+  input                             req_i,
+  input                             write_i,
+  input        [AddrWidth-1:0]      addr_i,
+  input        [Width-1:0]          wdata_i,
+  input        [Width-1:0]          wmask_i,  // Needs to be Byte-aligned for parity
+  output logic [Width-1:0]          rdata_o,
+  output logic                      rvalid_o, // Read response (rdata_o) is valid
+  output logic [1:0]                rerror_o, // Bit1: Uncorrectable, Bit0: Correctable
+
+  // config
+  input [CfgW-1:0]                  cfg_i
+);
+
+  //////////////////////
+  // Parameter Checks //
+  //////////////////////
+
+  // The depth needs to be a power of 2 in case address scrambling is turned on
+  `ASSERT_INIT(DepthPow2Check_A, NumAddrScrRounds <= '0 || 2**$clog2(Depth) == Depth)
+  // The address nonce should be set to 0 if address scrambling is disabled
+  `ASSERT(AddrNonceCheck_A, NumAddrScrRounds <= '0 |-> addr_nonce_i == '0)
+
+  /////////////////////////////////////////
+  // Pending Write and Address Registers //
+  /////////////////////////////////////////
+
+  // Read / write strobes
+  logic read_en, write_en;
+  assign read_en = req_i & ~write_i;
+  assign write_en = req_i & write_i;
+
+  // Writes are delayed by one cycle, such the same keystream generation primitive (prim_prince) can
+  // be reused among reads and writes. Note however that with this arrangement, we have to introduce
+  // a mechanism to hold a pending write transaction in cases where that transaction is immediately
+  // followed by a read. The pending write transaction is written to memory as soon as there is no
+  // new read transaction incoming. The latter is a special case, and if that happens, we return the
+  // data from the write holding register.
+  logic macro_write;
+  logic write_pending_d, write_pending_q;
+  assign write_pending_d =
+      (write_en)                ? 1'b1            : // Set new write request
+      (macro_write)             ? 1'b0            : // Clear pending request when writing to memory
+                                  write_pending_q;  // Keep pending write request alive
+
+  logic collision_d, collision_q;
+  logic [AddrWidth-1:0] waddr_q;
+  assign collision_d = read_en & write_pending_q & (addr_i == waddr_q);
+
+  // Macro requests and write strobe
+  logic macro_req;
+  assign macro_req   = read_en | write_pending_q;
+  // We are allowed to write a pending write transaction to the memory if there is no incoming read
+  assign macro_write = write_pending_q & ~read_en;
+
+  ////////////////////////
+  // Address Scrambling //
+  ////////////////////////
+
+  // TODO: check whether this is good enough for our purposes, or whether we should go for something
+  // else. Also, we may want to input some secret key material into this function as well.
+
+  // We only select the pending write address in case there is no incoming read transaction.
+  logic [AddrWidth-1:0] addr_mux;
+  assign addr_mux = (read_en) ? addr_i : waddr_q;
+
+  // This creates a bijective address mapping using a substitution / permutation network.
+  logic [AddrWidth-1:0] addr_scr;
+  prim_subst_perm #(
+    .DataWidth ( AddrWidth        ),
+    .NumRounds ( NumAddrScrRounds ),
+    .Decrypt   ( 0                )
+  ) i_prim_subst_perm (
+    .data_i ( addr_mux ),
+    .key_i  ( addr_nonce_i ),
+    .data_o ( addr_scr     )
+  );
+
+  //////////////////////////////////////////////
+  // Keystream Generation for Data Scrambling //
+  //////////////////////////////////////////////
+
+  // This encrypts the IV consisting of the nonce and address using the key provided in order to
+  // generate the keystream for the data. Note that we instantiate a register halfway within this
+  // primitive to balance the delay between request and response side.
+  logic [NumParScr*64-1:0] keystream;
+  for (genvar k = 0; k < NumParScr; k++) begin : gen_par_scr
+    prim_prince #(
+      .DataWidth      (64),
+      .KeyWidth       (128),
+      .NumRoundsHalf  (NumPrinceRoundsHalf),
+      .UseOldKeySched (1'b0),
+      .HalfwayDataReg (1'b1), // instantiate a register halfway in the primitive
+      .HalfwayKeyReg  (1'b0)  // no need to instantiate a key register as the key remains static
+    ) u_prim_prince (
+      .clk_i,
+      .rst_ni,
+      .valid_i ( req_i ),
+      // The IV is composed of a nonce and the row address
+      .data_i  ( {data_nonce_i[k * (64 - AddrWidth) +: (64 - AddrWidth)], addr_i} ),
+      // All parallel scramblers use the same key
+      .key_i,
+      // Since we operate in counter mode, this can always be set to encryption mode
+      .dec_i   ( 1'b0 ),
+      // Output keystream to be XOR'ed
+      .data_o  ( keystream[k * 64 +: 64] ),
+      .valid_o ( )
+    );
+  end
+
+  // Replicate keystream if needed
+  logic [Width-1:0] keystream_repl;
+  assign keystream_repl = Width'({NumParKeystr{keystream}});
+
+  /////////////////////
+  // Data Scrambling //
+  /////////////////////
+
+  // Data scrambling is a two step process. First, we XOR the write data with the keystream obtained
+  // by operating a reduced-round PRINCE cipher in CTR-mode. Then, we diffuse data within each Byte
+  // in order to get a limited "avalanche" behavior in case parts of the Bytes are flipped as a
+  // result of a malicious attempt to tamper with the data in memory. We perform the diffusion only
+  // within Bytes in order to maintain the ability to write individual Bytes. Note that the
+  // keystream XOR is performed first for the write path such that it can be performed last for the
+  // read path. This allows us to hide a part of the combinational delay of the PRINCE primitive
+  // behind the propagation delay of the SRAM macro and the per-Byte diffusion step.
+
+  // Write path. Note that since this does not fan out into the interconnect, the write path is not
+  // as critical as the read path below in terms of timing.
+  logic [Width-1:0] wdata_scr_d, wdata_scr_q;
+  for (genvar k = 0; k < Width/8; k++) begin : gen_diffuse_wdata
+    // Apply the keystream first
+    logic [7:0] wdata_xor;
+    assign wdata_xor = wdata_q[k*8 +: 8] ^ keystream_repl[k*8 +: 8];
+
+    // Byte aligned diffusion using a substitution / permutation network
+    prim_subst_perm #(
+      .DataWidth ( 8                ),
+      .NumRounds ( NumByteScrRounds ),
+      .Decrypt   ( 0                )
+    ) i_prim_subst_perm (
+      .data_i ( wdata_xor             ),
+      .key_i  ( '0                    ),
+      .data_o ( wdata_scr_d[k*8 +: 8] )
+    );
+  end
+
+  // Read path. This is timing critical. The keystream XOR operation is performed last in order to
+  // hide the combinational delay of the PRINCE primitive behind the propagation delay of the
+  // SRAM and the Byte diffusion.
+  logic [Width-1:0] rdata_scr, rdata;
+  for (genvar k = 0; k < Width/8; k++) begin : gen_undiffuse_rdata
+    // Reverse diffusion first
+    logic [7:0] rdata_xor;
+    prim_subst_perm #(
+      .DataWidth ( 8                ),
+      .NumRounds ( NumByteScrRounds ),
+      .Decrypt   ( 1                )
+    ) i_prim_subst_perm (
+      .data_i ( rdata_scr[k*8 +: 8]  ),
+      .key_i  ( '0                   ),
+      .data_o ( rdata_xor            )
+    );
+
+    // Apply Keystream, replicate it if needed
+    assign rdata[k*8 +: 8] = rdata_xor ^ keystream_repl[k*8 +: 8];
+  end
+
+  ////////////////////////////////////////////////
+  // Scrambled data register and forwarding mux //
+  ////////////////////////////////////////////////
+
+  // This is the scrambled data holding register for pending writes. This is needed in order to make
+  // back to back patterns of the form WR -> RD -> WR work:
+  //
+  // cycle:          0   |  1   | 2   | 3   |
+  // incoming op:    WR0 |  RD  | WR1 | -   |
+  // prince:         -   |  WR0 | RD  | WR1 |
+  // memory op:      -   |  RD  | WR0 | WR1 |
+  //
+  // The read transaction in cycle 1 interrupts the first write transaction which has already used
+  // the PRINCE primitive for scrambling. If this sequence is followed by another write back-to-back
+  // in cycle 2, we cannot use the PRINCE primitive a second time for the first write, and hence
+  // need an additional holding register that can buffer the scrambled data of the first write in
+  // cycle 1.
+
+  // Clear this if we can write the memory in this cycle, otherwise set if there is a pending write
+  logic write_scr_pending_d, write_scr_pending_q;
+  assign write_scr_pending_d = (macro_write) ? 1'b0 : write_pending_q;
+  // Select the correct scrambled word to be written, based on whether the word in the scrambled
+  // data holding register is valid or not. Note that the write_scr_q register could in theory be
+  // combined with the wdata_q register. We don't do that here for timing reasons, since that would
+  // require another read data mux to inject the scrambled data into the read descrambling path.
+  logic [Width-1:0] wdata_scr;
+  assign wdata_scr = (write_scr_pending_q) ? wdata_scr_q : wdata_scr_d;
+
+  // Output read valid strobe
+  logic rvalid_q;
+  assign rvalid_o = rvalid_q;
+
+  // In case of a collision, we forward the write data from the unscrambled holding register
+  assign rdata_o = (collision_q) ? wdata_q   : // forward pending (unscrambled) write data
+                   (rvalid_q)    ? rdata     : // regular reads
+                                   '0;         // tie to zero otherwise
+
+  ///////////////
+  // Registers //
+  ///////////////
+
+  logic [Width-1:0] wdata_q;
+  logic [Width-1:0] wmask_q;
+  always_ff @(posedge clk_i or negedge rst_ni) begin : p_wdata_buf
+    if (!rst_ni) begin
+      write_pending_q     <= 1'b0;
+      write_scr_pending_q <= 1'b0;
+      collision_q         <= 1'b0;
+      rvalid_q            <= 1'b0;
+      waddr_q             <= '0;
+      wdata_q             <= '0;
+      wdata_scr_q         <= '0;
+      wmask_q             <= '0;
+    end else begin
+      write_scr_pending_q <= write_scr_pending_d;
+      write_pending_q     <= write_pending_d;
+      collision_q         <= collision_d;
+      rvalid_q            <= read_en;
+      if (write_en) begin
+        waddr_q <= addr_i;
+        wmask_q <= wmask_i;
+        wdata_q <= wdata_i;
+      end
+      if (write_scr_pending_d) begin
+        wdata_scr_q <= wdata_scr_d;
+      end
+    end
+  end
+
+  //////////////////
+  // Memory Macro //
+  //////////////////
+
+  prim_ram_1p_adv #(
+    .Depth(Depth),
+    .Width(Width),
+    .DataBitsPerMask(DataBitsPerMask),
+    .CfgW(CfgW),
+    .EnableECC(1'b0),
+    .EnableParity(1'b1), // We are using Byte parity
+    .EnableInputPipeline(1'b0),
+    .EnableOutputPipeline(1'b0)
+  ) u_prim_ram_1p_adv (
+    .clk_i,
+    .rst_ni,
+    .req_i    ( macro_req   ),
+    .write_i  ( macro_write ),
+    .addr_i   ( addr_scr    ),
+    .wdata_i  ( wdata_scr   ),
+    .wmask_i  ( wmask_q     ),
+    .rdata_o  ( rdata_scr   ),
+    .rvalid_o ( ),
+    .rerror_o,
+    .cfg_i
+  );
+
+endmodule : prim_ram_1p_scr

--- a/hw/ip/prim/rtl/prim_ram_1p_scr.sv
+++ b/hw/ip/prim/rtl/prim_ram_1p_scr.sv
@@ -192,7 +192,7 @@ module prim_ram_1p_scr #(
 
   // Write path. Note that since this does not fan out into the interconnect, the write path is not
   // as critical as the read path below in terms of timing.
-  logic [Width-1:0] wdata_scr_d, wdata_scr_q;
+  logic [Width-1:0] wdata_scr_d, wdata_scr_q, wdata_q;
   for (genvar k = 0; k < Width/8; k++) begin : gen_diffuse_wdata
     // Apply the keystream first
     logic [7:0] wdata_xor;
@@ -272,7 +272,6 @@ module prim_ram_1p_scr #(
   // Registers //
   ///////////////
 
-  logic [Width-1:0] wdata_q;
   logic [Width-1:0] wmask_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin : p_wdata_buf
     if (!rst_ni) begin

--- a/hw/ip/prim/rtl/prim_subst_perm.sv
+++ b/hw/ip/prim/rtl/prim_subst_perm.sv
@@ -1,0 +1,84 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// This is a simple data diffusion primitive that is constructed in a similar fashion
+// as the PRESENT cipher (i.e. it uses a substitution/permutation network). Note however
+// that this is **not** cryptographically secure. The main purpose of this primitive is to
+// provide a cheap diffusion mechanism for arbitrarily sized vectors.
+//
+// See also: prim_prince, prim_present, prim_cipher_pkg
+
+module prim_subst_perm #(
+  parameter int DataWidth = 64,
+  parameter int NumRounds = 31,
+  parameter bit Decrypt   = 0    // 0: encrypt, 1: decrypt
+) (
+  input        [DataWidth-1:0] data_i,
+  input        [DataWidth-1:0] key_i,
+  output logic [DataWidth-1:0] data_o
+);
+
+  //////////////
+  // datapath //
+  //////////////
+
+  logic [NumRounds:0][DataWidth-1:0] data_state;
+
+  // initialize
+  assign data_state[0] = data_i;
+
+  for (genvar r = 0; r < NumRounds; r++) begin : gen_round
+    logic [DataWidth-1:0] data_state_sbox, data_state_flipped;
+    ////////////////////////////////
+    // decryption pass, performs inverse permutation and sbox
+    if (Decrypt) begin : gen_dec
+      always_comb begin : p_dec
+        data_state_sbox = data_state[r] ^ key_i;
+        // Reverse odd/even grouping
+        for (int k = 0; k < DataWidth/2; k++) begin
+          data_state_flipped[k * 2]     = data_state_sbox[k];
+          data_state_flipped[k * 2 + 1] = data_state_sbox[k + DataWidth/2];
+        end
+        // Flip vector
+        for (int k = 0; k < DataWidth; k++) begin
+          data_state_flipped[DataWidth - 1 - k] = data_state_sbox[k];
+        end
+        // Inverse SBox layer
+        for (int k = 0; k < DataWidth/4; k++) begin
+          data_state_sbox[k*4 +: 4] = prim_cipher_pkg::PRESENT_SBOX4_INV[data_state_sbox[k*4 +: 4]];
+        end
+        data_state[r + 1] = data_state_sbox;
+      end
+    ////////////////////////////////
+    // encryption pass
+    end else begin : gen_enc
+      always_comb begin : p_dec
+        data_state_sbox = data_state[r] ^ key_i;
+        // This SBox layer is aligned to nibbles, so the uppermost bits may not be affected by this.
+        // However, the permutation below ensures that these bits get shuffled to a different
+        // position when performing multiple rounds.
+        for (int k = 0; k < DataWidth/4; k++) begin
+          data_state_sbox[k*4 +: 4] = prim_cipher_pkg::PRESENT_SBOX4[data_state_sbox[k*4 +: 4]];
+        end
+        // Flip the vector to move the MSB positions into the LSB positions
+        for (int k = 0; k < DataWidth; k++) begin
+          data_state_flipped[DataWidth - 1 - k] = data_state_sbox[k];
+        end
+        // Regroup bits such that all even indices are stacked up first,  followed by all odd
+        // indices, and then flip the vector. Note that if the Width is odd, this is still ok, since
+        // the uppermost bit just stays in place in that case.
+        for (int k = 0; k < DataWidth/2; k++) begin
+          data_state_sbox[k]               = data_state_flipped[k * 2];
+          data_state_sbox[k + DataWidth/2] = data_state_flipped[k * 2 + 1];
+        end
+        data_state[r + 1] = data_state_sbox;
+      end
+    end // gen_enc
+    ////////////////////////////////
+  end // gen_round
+
+  // finalize
+  assign data_o = data_state[NumRounds] ^ key_i;
+
+endmodule : prim_subst_perm

--- a/hw/ip/prim/rtl/prim_subst_perm.sv
+++ b/hw/ip/prim/rtl/prim_subst_perm.sv
@@ -65,7 +65,7 @@ module prim_subst_perm #(
         for (int k = 0; k < DataWidth; k++) begin
           data_state_flipped[DataWidth - 1 - k] = data_state_sbox[k];
         end
-        // Regroup bits such that all even indices are stacked up first,  followed by all odd
+        // Regroup bits such that all even indices are stacked up first, followed by all odd
         // indices, and then flip the vector. Note that if the Width is odd, this is still ok, since
         // the uppermost bit just stays in place in that case.
         for (int k = 0; k < DataWidth/2; k++) begin

--- a/hw/ip/prim_generic/rtl/prim_generic_otp.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_otp.sv
@@ -70,7 +70,7 @@ module prim_generic_otp #(
 
   // using always instead of always_ff to avoid 'ICPD  - illegal combination of drivers' error
   // thrown when using $readmemh system task to backdoor load an image
-  always @(posedge clk_i) begin
+  always_ff @(posedge clk_i) begin
     if (req) begin
       if (write_q) begin
         mem[addr] <= wdata;

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -1731,9 +1731,9 @@
         }
         {
           struct: otp_pwr_state
-          type: broadcast
+          type: uni
           name: otp_pwr_state
-          act: sender
+          act: req
           package: otp_ctrl_pkg
           inst_name: otp_ctrl
           index: -1
@@ -1749,36 +1749,36 @@
         }
         {
           struct: otp_lc_data
-          type: broadcast
+          type: uni
           name: otp_lc_data
-          act: sender
+          act: req
           package: otp_ctrl_pkg
           inst_name: otp_ctrl
           index: -1
         }
         {
-          struct: lc_tx_t
-          type: broadcast
+          struct: lc_tx
+          type: uni
           name: lc_provision_en
-          act: receiver
+          act: rsp
           package: otp_ctrl_pkg
           inst_name: otp_ctrl
           index: -1
         }
         {
-          struct: lc_tx_t
-          type: broadcast
+          struct: lc_tx
+          type: uni
           name: lc_test_en
-          act: receiver
+          act: rsp
           package: otp_ctrl_pkg
           inst_name: otp_ctrl
           index: -1
         }
         {
           struct: keymgr_key
-          type: broadcast
+          type: uni
           name: otp_keymgr_key
-          act: sender
+          act: req
           package: otp_ctrl_pkg
           inst_name: otp_ctrl
           index: -1
@@ -1793,6 +1793,18 @@
           width: 1
           top_type: broadcast
           top_signame: otp_ctrl_otp_flash_key
+          index: -1
+        }
+        {
+          struct: sram_key
+          type: uni
+          name: otp_sram_key
+          act: req
+          package: otp_ctrl_pkg
+          inst_name: otp_ctrl
+          width: 1
+          top_type: broadcast
+          top_signame: otp_ctrl_otp_sram_key
           index: -1
         }
       ]
@@ -3604,6 +3616,7 @@
       [
         flash_ctrl.otp
       ]
+      otp_ctrl.otp_sram_key: []
       pwrmgr_aon.pwr_otp:
       [
         otp_ctrl.pwr_otp_init
@@ -6750,9 +6763,9 @@
       }
       {
         struct: otp_pwr_state
-        type: broadcast
+        type: uni
         name: otp_pwr_state
-        act: sender
+        act: req
         package: otp_ctrl_pkg
         inst_name: otp_ctrl
         index: -1
@@ -6768,36 +6781,36 @@
       }
       {
         struct: otp_lc_data
-        type: broadcast
+        type: uni
         name: otp_lc_data
-        act: sender
+        act: req
         package: otp_ctrl_pkg
         inst_name: otp_ctrl
         index: -1
       }
       {
-        struct: lc_tx_t
-        type: broadcast
+        struct: lc_tx
+        type: uni
         name: lc_provision_en
-        act: receiver
+        act: rsp
         package: otp_ctrl_pkg
         inst_name: otp_ctrl
         index: -1
       }
       {
-        struct: lc_tx_t
-        type: broadcast
+        struct: lc_tx
+        type: uni
         name: lc_test_en
-        act: receiver
+        act: rsp
         package: otp_ctrl_pkg
         inst_name: otp_ctrl
         index: -1
       }
       {
         struct: keymgr_key
-        type: broadcast
+        type: uni
         name: otp_keymgr_key
-        act: sender
+        act: req
         package: otp_ctrl_pkg
         inst_name: otp_ctrl
         index: -1
@@ -6812,6 +6825,18 @@
         width: 1
         top_type: broadcast
         top_signame: otp_ctrl_otp_flash_key
+        index: -1
+      }
+      {
+        struct: sram_key
+        type: uni
+        name: otp_sram_key
+        act: req
+        package: otp_ctrl_pkg
+        inst_name: otp_ctrl
+        width: 1
+        top_type: broadcast
+        top_signame: otp_ctrl_otp_sram_key
         index: -1
       }
       {
@@ -7355,6 +7380,13 @@
         package: otp_ctrl_pkg
         struct: flash_key
         signame: otp_ctrl_otp_flash_key
+        width: 1
+        type: uni
+      }
+      {
+        package: otp_ctrl_pkg
+        struct: sram_key
+        signame: otp_ctrl_otp_sram_key
         width: 1
         type: uni
       }

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -1796,15 +1796,39 @@
           index: -1
         }
         {
-          struct: sram_key
+          struct: ram_main_key
           type: uni
-          name: otp_sram_key
+          name: otp_ram_main_key
           act: req
           package: otp_ctrl_pkg
           inst_name: otp_ctrl
           width: 1
           top_type: broadcast
-          top_signame: otp_ctrl_otp_sram_key
+          top_signame: otp_ctrl_otp_ram_main_key
+          index: -1
+        }
+        {
+          struct: ram_ret_aon_key
+          type: uni
+          name: otp_ram_ret_aon_key
+          act: req
+          package: otp_ctrl_pkg
+          inst_name: otp_ctrl
+          width: 1
+          top_type: broadcast
+          top_signame: otp_ctrl_otp_ram_ret_aon_key
+          index: -1
+        }
+        {
+          struct: otbn_ram_key
+          type: uni
+          name: otp_otbn_ram_key
+          act: req
+          package: otbn_pkg
+          inst_name: otp_ctrl
+          width: 1
+          top_type: broadcast
+          top_signame: otp_ctrl_otp_otbn_ram_key
           index: -1
         }
       ]
@@ -3506,6 +3530,17 @@
           inst_name: otbn
           index: -1
         }
+        {
+          struct: otbn_ram_key
+          type: uni
+          name: otp_otbn_ram_key
+          act: rcv
+          package: otbn_pkg
+          inst_name: otbn
+          width: 1
+          top_signame: otp_ctrl_otp_otbn_ram_key
+          index: -1
+        }
       ]
     }
   ]
@@ -3616,7 +3651,12 @@
       [
         flash_ctrl.otp
       ]
-      otp_ctrl.otp_sram_key: []
+      otp_ctrl.otp_ram_main_key: []
+      otp_ctrl.otp_ram_ret_aon_key: []
+      otp_ctrl.otp_otbn_ram_key:
+      [
+        otbn.otp_otbn_ram_key
+      ]
       pwrmgr_aon.pwr_otp:
       [
         otp_ctrl.pwr_otp_init
@@ -6828,15 +6868,39 @@
         index: -1
       }
       {
-        struct: sram_key
+        struct: ram_main_key
         type: uni
-        name: otp_sram_key
+        name: otp_ram_main_key
         act: req
         package: otp_ctrl_pkg
         inst_name: otp_ctrl
         width: 1
         top_type: broadcast
-        top_signame: otp_ctrl_otp_sram_key
+        top_signame: otp_ctrl_otp_ram_main_key
+        index: -1
+      }
+      {
+        struct: ram_ret_aon_key
+        type: uni
+        name: otp_ram_ret_aon_key
+        act: req
+        package: otp_ctrl_pkg
+        inst_name: otp_ctrl
+        width: 1
+        top_type: broadcast
+        top_signame: otp_ctrl_otp_ram_ret_aon_key
+        index: -1
+      }
+      {
+        struct: otbn_ram_key
+        type: uni
+        name: otp_otbn_ram_key
+        act: req
+        package: otbn_pkg
+        inst_name: otp_ctrl
+        width: 1
+        top_type: broadcast
+        top_signame: otp_ctrl_otp_otbn_ram_key
         index: -1
       }
       {
@@ -7242,6 +7306,17 @@
         index: -1
       }
       {
+        struct: otbn_ram_key
+        type: uni
+        name: otp_otbn_ram_key
+        act: rcv
+        package: otbn_pkg
+        inst_name: otbn
+        width: 1
+        top_signame: otp_ctrl_otp_otbn_ram_key
+        index: -1
+      }
+      {
         struct: flash
         type: req_rsp
         name: flash_ctrl
@@ -7385,8 +7460,22 @@
       }
       {
         package: otp_ctrl_pkg
-        struct: sram_key
-        signame: otp_ctrl_otp_sram_key
+        struct: ram_main_key
+        signame: otp_ctrl_otp_ram_main_key
+        width: 1
+        type: uni
+      }
+      {
+        package: otp_ctrl_pkg
+        struct: ram_ret_aon_key
+        signame: otp_ctrl_otp_ram_ret_aon_key
+        width: 1
+        type: uni
+      }
+      {
+        package: otbn_pkg
+        struct: otbn_ram_key
+        signame: otp_ctrl_otp_otbn_ram_key
         width: 1
         type: uni
       }

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -412,7 +412,9 @@
     'connect': {
       'flash_ctrl.flash': ['eflash.flash_ctrl']
       'otp_ctrl.otp_flash_key': ['flash_ctrl.otp']
-      'otp_ctrl.otp_sram_key': []
+      'otp_ctrl.otp_ram_main_key': []
+      'otp_ctrl.otp_ram_ret_aon_key': []
+      'otp_ctrl.otp_otbn_ram_key': ['otbn.otp_otbn_ram_key']
       'pwrmgr_aon.pwr_otp'  : ['otp_ctrl.pwr_otp_init'],
       'pwrmgr_aon.pwr_rst'  : ['rstmgr_aon.pwr'],
       'pwrmgr_aon.pwr_clk'  : ['clkmgr_aon.pwr'],

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -412,6 +412,7 @@
     'connect': {
       'flash_ctrl.flash': ['eflash.flash_ctrl']
       'otp_ctrl.otp_flash_key': ['flash_ctrl.otp']
+      'otp_ctrl.otp_sram_key': []
       'pwrmgr_aon.pwr_otp'  : ['otp_ctrl.pwr_otp_init'],
       'pwrmgr_aon.pwr_rst'  : ['rstmgr_aon.pwr'],
       'pwrmgr_aon.pwr_clk'  : ['clkmgr_aon.pwr'],

--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -335,9 +335,9 @@ module top_${top["name"]} #(
   logic ${lib.bitarray(addr_width,  max_char)} ${m["name"]}_addr_nonce;
 
   // Note that this connection will change once we move to a fully comportable SRAM IP
-  assign ${m["name"]}_data_nonce = otp_ctrl_otp_sram_key.nonce[${nonce_width}-1:0];
-  assign ${m["name"]}_addr_nonce = otp_ctrl_otp_sram_key.nonce[${nonce_width}+${addr_width}-1:${nonce_width}];
-  assign ${m["name"]}_key = otp_ctrl_otp_sram_key.key;
+  assign ${m["name"]}_data_nonce = otp_ctrl_otp_${m["name"]}_key.nonce[${nonce_width}-1:0];
+  assign ${m["name"]}_addr_nonce = otp_ctrl_otp_${m["name"]}_key.nonce[${nonce_width}+${addr_width}-1:${nonce_width}];
+  assign ${m["name"]}_key = otp_ctrl_otp_${m["name"]}_key.key;
 
   tlul_adapter_sram #(
     .SramAw(${addr_width}),

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -434,7 +434,9 @@ module top_earlgrey #(
   flash_ctrl_pkg::flash_req_t       flash_ctrl_flash_req;
   flash_ctrl_pkg::flash_rsp_t       flash_ctrl_flash_rsp;
   otp_ctrl_pkg::flash_key_t       otp_ctrl_otp_flash_key;
-  otp_ctrl_pkg::sram_key_t       otp_ctrl_otp_sram_key;
+  otp_ctrl_pkg::ram_main_key_t       otp_ctrl_otp_ram_main_key;
+  otp_ctrl_pkg::ram_ret_aon_key_t       otp_ctrl_otp_ram_ret_aon_key;
+  otbn_pkg::otbn_ram_key_t       otp_ctrl_otp_otbn_ram_key;
   pwrmgr_pkg::pwr_otp_req_t       pwrmgr_aon_pwr_otp_req;
   pwrmgr_pkg::pwr_otp_rsp_t       pwrmgr_aon_pwr_otp_rsp;
   pwrmgr_pkg::pwr_rst_req_t       pwrmgr_aon_pwr_rst_req;
@@ -595,9 +597,9 @@ module top_earlgrey #(
   logic [13:0] ram_main_addr_nonce;
 
   // Note that this connection will change once we move to a fully comportable SRAM IP
-  assign ram_main_data_nonce = otp_ctrl_otp_sram_key.nonce[50-1:0];
-  assign ram_main_addr_nonce = otp_ctrl_otp_sram_key.nonce[50+14-1:50];
-  assign ram_main_key = otp_ctrl_otp_sram_key.key;
+  assign ram_main_data_nonce = otp_ctrl_otp_ram_main_key.nonce[50-1:0];
+  assign ram_main_addr_nonce = otp_ctrl_otp_ram_main_key.nonce[50+14-1:50];
+  assign ram_main_key = otp_ctrl_otp_ram_main_key.key;
 
   tlul_adapter_sram #(
     .SramAw(14),
@@ -657,9 +659,9 @@ module top_earlgrey #(
   logic [9:0] ram_ret_aon_addr_nonce;
 
   // Note that this connection will change once we move to a fully comportable SRAM IP
-  assign ram_ret_aon_data_nonce = otp_ctrl_otp_sram_key.nonce[54-1:0];
-  assign ram_ret_aon_addr_nonce = otp_ctrl_otp_sram_key.nonce[54+10-1:54];
-  assign ram_ret_aon_key = otp_ctrl_otp_sram_key.key;
+  assign ram_ret_aon_data_nonce = otp_ctrl_otp_ram_ret_aon_key.nonce[54-1:0];
+  assign ram_ret_aon_addr_nonce = otp_ctrl_otp_ram_ret_aon_key.nonce[54+10-1:54];
+  assign ram_ret_aon_key = otp_ctrl_otp_ram_ret_aon_key.key;
 
   tlul_adapter_sram #(
     .SramAw(10),
@@ -1064,7 +1066,9 @@ module top_earlgrey #(
       .lc_test_en_i(),
       .otp_keymgr_key_o(),
       .otp_flash_key_o(otp_ctrl_otp_flash_key),
-      .otp_sram_key_o(otp_ctrl_otp_sram_key),
+      .otp_ram_main_key_o(otp_ctrl_otp_ram_main_key),
+      .otp_ram_ret_aon_key_o(otp_ctrl_otp_ram_ret_aon_key),
+      .otp_otbn_ram_key_o(otp_ctrl_otp_otbn_ram_key),
 
       .clk_i (clkmgr_aon_clocks.clk_io_secure),
       .rst_ni (rstmgr_aon_resets.rst_lc_n)
@@ -1476,6 +1480,7 @@ module top_earlgrey #(
 
       // Inter-module signals
       .idle_o(),
+      .otp_otbn_ram_key_i(otp_ctrl_otp_otbn_ram_key),
 
       .clk_i (clkmgr_aon_clocks.clk_main_otbn),
       .rst_ni (rstmgr_aon_resets.rst_sys_n)

--- a/hw/top_earlgrey/top_earlgrey.core
+++ b/hw/top_earlgrey/top_earlgrey.core
@@ -29,6 +29,7 @@ filesets:
       - lowrisc:ip:keymgr
       - lowrisc:ip:otbn
       - lowrisc:prim:ram_1p_adv
+      - lowrisc:prim:ram_1p_scr
       - lowrisc:prim:rom_adv
       - lowrisc:ip:rstmgr
       - lowrisc:ip:rbox


### PR DESCRIPTION
This carries over a pile of things related to main memory scrambling.

Note that only the last commit is really bronze-specific, and it replaces the main and AON RAMs with the scrambling primitive.

The commit related to OTP dependencies will be gone once https://github.com/lowRISC/opentitan/pull/2691 has been merged (I've included it here such that I can test synthesis).