### PR TITLE
[reggen] Fix TypeError

### DIFF
--- a/util/reggen/gen_dv.py
+++ b/util/reggen/gen_dv.py
@@ -39,8 +39,7 @@ def miname(m):
 
 # function get base addr in SV syntax
 def sv_base_addr(b):
-    sv_base_addr = b.base_addr.replace("0x", str(b.width) + "'h")
-    return sv_base_addr
+    return "{}'h{:x}".format(b.width, b.base_addr)
 
 
 # function generate dv ral model using raw dict object parsed from hjson

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -667,7 +667,7 @@ def generate_top_ral(top, ip_objs, out_path):
     for block in top_block.blocks:
         for module in top["module"]:
             if block.name == module["name"]:
-                block.base_addr = module["base_addr"]
+                block.base_addr = int(module["base_addr"], 0)
                 break
 
     top_block.blocks.sort(key=lambda block: block.base_addr)


### PR DESCRIPTION
Running reggen (e.g. through `make -C hw`) on the `v1-bronze` branch
fails with the following error message:

```
Traceback (most recent call last):
  File "/home/philipp/src/opentitan/util/topgen.py", line 964, in <module>
    main()
  File "/home/philipp/src/opentitan/util/topgen.py", line 860, in main
    generate_top_ral(completecfg, ip_objs, out_path)
  File "/home/philipp/src/opentitan/util/topgen.py", line 655, in generate_top_ral
    top_block.blocks.sort(key=lambda block: block.base_addr)
TypeError: '<' not supported between instances of 'int' and 'str'
```

Fix that by converting `base_addr` to str/int as necessary in all places
where it is used.