### PR TITLE
[lint] Add blanket waiver for DECLFILENAME with blackboxes

### DIFF
--- a/hw/lint/tools/verilator/common.vlt
+++ b/hw/lint/tools/verilator/common.vlt
@@ -9,3 +9,7 @@
 // Do not warn about unconnected pins in module instantiations, e.g.
 // `.optional_output ()`.
 lint_off -rule PINCONNECTEMPTY
+
+// This warning gives wrong results with blackboxed embedded modules, see
+// https://github.com/verilator/verilator/issues/2430
+lint_off -rule DECLFILENAME -file "*" -match "Filename '*' does not match NOTFOUNDMODULE name:*"


### PR DESCRIPTION
When running Verilator lint with blackboxed modules, we get warnings
like the ones below:

```
%Warning-DECLFILENAME: ../../../vendor/lowrisc_ip/prim_xilinx/rtl/prim_xilinx_clock_gating.sv:12:10: Filename 'prim_xilinx_clock_gating' does not match NOTFOUNDMODULE name: 'BUFGCE'
   12 |   BUFGCE u_bufgce (
      |          ^~~~~~~~
                       ... Use "/* verilator lint_off DECLFILENAME */" and lint_on around source to disable this message.
%Warning-DECLFILENAME: ../../../vendor/lowrisc_ip/prim_xilinx/rtl/prim_xilinx_clock_mux2.sv:17:11: Filename 'prim_xilinx_clock_mux2' does not match NOTFOUNDMODULE name: 'BUFGMUX'
   17 |   BUFGMUX bufgmux_i (
      |           ^~~~~~~~~
%Warning-DECLFILENAME: ../../../vendor/lowrisc_ip/prim_xilinx/rtl/prim_xilinx_pad_wrapper.sv:36:9: Filename 'prim_xilinx_pad_wrapper' does not match NOTFOUNDMODULE name: 'IOBUF'
   36 |   IOBUF i_iobuf (
      |         ^~~~~~~
```

This is due to https://github.com/verilator/verilator/issues/2430. Until
the issue is fixed, disable this lint error.