### PR TITLE
[prim_lfsr] Factor out into a separate core file

### DIFF
--- a/hw/ip/aes/aes.core
+++ b/hw/ip/aes/aes.core
@@ -8,6 +8,7 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:prim:all
+      - lowrisc:prim:lfsr
       - lowrisc:ip:tlul
     files:
       - rtl/aes_pkg.sv
@@ -104,5 +105,3 @@ targets:
     default_tool: icarus
     parameters:
       - SYNTHESIS=true
-
-

--- a/hw/ip/alert_handler/alert_handler_component.core
+++ b/hw/ip/alert_handler/alert_handler_component.core
@@ -10,6 +10,7 @@ filesets:
     depend:
       - lowrisc:ip:tlul
       - lowrisc:prim:all
+      - lowrisc:prim:lfsr
     files:
       - rtl/alert_pkg.sv
       - rtl/alert_handler_reg_wrap.sv

--- a/hw/ip/entropy_src/entropy_src.core
+++ b/hw/ip/entropy_src/entropy_src.core
@@ -9,6 +9,7 @@ filesets:
     depend:
       - lowrisc:constants:top_pkg
       - lowrisc:prim:all
+      - lowrisc:prim:lfsr
       - lowrisc:ip:tlul
     files:
       - rtl/entropy_src_pkg.sv
@@ -62,5 +63,3 @@ targets:
         mode: lint-only
         verilator_options:
           - "-Wall"
-
-

--- a/hw/ip/prim/fpv/prim_lfsr_fpv.core
+++ b/hw/ip/prim/fpv/prim_lfsr_fpv.core
@@ -7,7 +7,7 @@ description: "ALERT_HANDLER FPV target"
 filesets:
   files_formal:
     depend:
-      - lowrisc:prim:all
+      - lowrisc:prim:lfsr
     files:
       - tb/prim_lfsr_fpv.sv
     file_type: systemVerilogSource

--- a/hw/ip/prim/fpv/prim_lfsr_fpv.core
+++ b/hw/ip/prim/fpv/prim_lfsr_fpv.core
@@ -3,7 +3,7 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 name: "lowrisc:fpv:prim_lfsr_fpv:0.1"
-description: "ALERT_HANDLER FPV target"
+description: "LFSR primitive FPV target"
 filesets:
   files_formal:
     depend:

--- a/hw/ip/prim/prim.core
+++ b/hw/ip/prim/prim.core
@@ -32,7 +32,6 @@ filesets:
       - rtl/prim_flop_2sync.sv
       - rtl/prim_sync_reqack.sv
       - rtl/prim_keccak.sv
-      - rtl/prim_lfsr.sv
       - rtl/prim_packer.sv
       - rtl/prim_cipher_pkg.sv
       - rtl/prim_present.sv

--- a/hw/ip/prim/prim_lfsr.core
+++ b/hw/ip/prim/prim_lfsr.core
@@ -1,0 +1,19 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:lfsr:0.1"
+description: "A Linear-Feedback Shift Register (LFSR) primitive"
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:prim:assert
+    files:
+      - rtl/prim_lfsr.sv
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_rtl


### PR DESCRIPTION
The LFSR primitive is curently contained in the "catch all"
"lowrisc:prim:all" core file; factor it out into a separate core file.

This helps Ibex to only depend on the LFSR, not on the other primitives, 
which it doesn't need.