### PR TITLE
Add some missing dependencies on lowrisc:prim:assert

### DIFF
--- a/hw/ip/prim_generic/prim_generic_clock_mux2.core
+++ b/hw/ip/prim_generic/prim_generic_clock_mux2.core
@@ -7,6 +7,8 @@ name: "lowrisc:prim_generic:clock_mux2"
 description: "two-input clock multiplexer primitive"
 filesets:
   files_rtl:
+    depend:
+      - lowrisc:prim:assert
     files:
       - rtl/prim_generic_clock_mux2.sv
     file_type: systemVerilogSource

--- a/hw/ip/prim_generic/prim_generic_pad_wrapper.core
+++ b/hw/ip/prim_generic/prim_generic_pad_wrapper.core
@@ -7,6 +7,8 @@ name: "lowrisc:prim_generic:pad_wrapper"
 description: "Technology-independent pad wrapper implementation (for sim only!)"
 filesets:
   files_rtl:
+    depend:
+      - lowrisc:prim:assert
     files:
       - rtl/prim_generic_pad_wrapper.sv
     file_type: systemVerilogSource

--- a/hw/ip/prim_generic/prim_generic_ram_1p.core
+++ b/hw/ip/prim_generic/prim_generic_ram_1p.core
@@ -8,6 +8,7 @@ description: "Single port RAM"
 filesets:
   files_rtl:
     depend:
+      - lowrisc:prim:assert
       - lowrisc:prim:util_memload
     files:
       - rtl/prim_generic_ram_1p.sv


### PR DESCRIPTION
These are files in hw/ip/prim_generic that include prim_assert.sv, so
their core files should depend on it.
