### PR TITLE
[sw] Use Verilator Stop Address

### DIFF
--- a/sw/device/boot_rom/meson.build
+++ b/sw/device/boot_rom/meson.build
@@ -48,6 +48,7 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
       sw_lib_pinmux,
       sw_lib_dif_gpio,
       sw_lib_hmac,
+      sw_lib_mmio,
       sw_lib_spi_device,
       sw_lib_uart,
       sw_lib_base_log,
@@ -74,4 +75,3 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
     build_by_default: true,
   )
 endforeach
-

--- a/sw/device/exts/common/flash_crt.S
+++ b/sw/device/exts/common/flash_crt.S
@@ -12,6 +12,7 @@
 
   .extern main
   .extern crt_interrupt_vector
+  .extern kDeviceStopAddress
 
 /**
  * Callable entry point for flash.
@@ -88,7 +89,13 @@ data_copy_loop_end:
   li   a1, 0x0  // argv = NULL
   call main
 
+  // Load `kDeviceStopAddress` into `t0`. If it is non-zero, write the return
+  // value from `main` (in `a0`) into it, otherwise, skip to `wfi` loop.
+  lw t0, kDeviceStopAddress
+  beqz t0, wfi_loop
+  sw a0, 0(t0)
+
   // Loop forever if main somehow returns.
-1:
+wfi_loop:
   wfi
-  j 1b
+  j wfi_loop

--- a/sw/device/lib/arch/device.h
+++ b/sw/device/lib/arch/device.h
@@ -57,4 +57,11 @@ extern const uint64_t kClockFreqHz;
  */
 extern const uint64_t kUartBaudrate;
 
+/**
+ * An address to write to to cause execution to stop.
+ *
+ * If this is zero, there is no address you can write to to stop execution.
+ */
+extern const uintptr_t kDeviceStopAddress;
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_ARCH_DEVICE_H_

--- a/sw/device/lib/arch/device_fpga_nexysvideo.c
+++ b/sw/device/lib/arch/device_fpga_nexysvideo.c
@@ -13,3 +13,6 @@ const device_type_t kDeviceType = kDeviceFpgaNexysVideo;
 const uint64_t kClockFreqHz = 50 * 1000 * 1000;  // 50MHz
 
 const uint64_t kUartBaudrate = 230400;
+
+// No Device Stop Address in our FPGA implementation.
+const uintptr_t kDeviceStopAddress = 0;

--- a/sw/device/lib/arch/device_sim_dv.c
+++ b/sw/device/lib/arch/device_sim_dv.c
@@ -16,3 +16,6 @@ const device_type_t kDeviceType = kDeviceSimDV;
 const uint64_t kClockFreqHz = 50 * 1000 * 1000;  // 50MHz
 
 const uint64_t kUartBaudrate = 2 * (1 << 20);  // 2Mib/s
+
+// No Device Stop Address in our DV simulator.
+const uintptr_t kDeviceStopAddress = 0;

--- a/sw/device/lib/arch/device_sim_verilator.c
+++ b/sw/device/lib/arch/device_sim_verilator.c
@@ -13,3 +13,6 @@ const device_type_t kDeviceType = kDeviceSimVerilator;
 const uint64_t kClockFreqHz = 500 * 1000;  // 500kHz
 
 const uint64_t kUartBaudrate = 9600;
+
+// Defined in `hw/top_earlgrey/top_earlgrey_verilator.core`
+const uintptr_t kDeviceStopAddress = 0x10008000;

--- a/sw/device/lib/runtime/meson.build
+++ b/sw/device/lib/runtime/meson.build
@@ -13,6 +13,9 @@ sw_lib_runtime_hart = declare_dependency(
   link_with: static_library(
     'runtime_hart_ot',
     sources: ['hart.c'],
-    dependencies: [sw_lib_runtime_ibex],
+    dependencies: [
+      sw_lib_runtime_ibex,
+      sw_lib_mmio,
+    ],
   )
 )


### PR DESCRIPTION
When run under Verilator, the core has an address to write to which can
stop execution. This has not been used by software until now, for no
good reason.

This commit adds a device-specific definition for this address, and
instantiates it with the correct address on verilator. We use the value
of zero to denote that this address doesn't exist on other device
configurations.
