### PR TITLE
[sw] Fix up all warn_unused_result warnings.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -58,8 +58,6 @@ c_cpp_args = [
   # We use absolute include paths as much as possible.
   '-I' + meson.source_root(),
   '-I' + meson.build_root(),
-  # Remove once we've fully adopted warn_unused_result.
-  '-Wno-error=unused-result',
 ]
 add_project_arguments(c_cpp_args, language: ['c', 'cpp'], native: false)
 add_project_arguments(c_cpp_args, language: ['c', 'cpp'], native: true)

--- a/sw/device/boot_rom/bootstrap.c
+++ b/sw/device/boot_rom/bootstrap.c
@@ -37,10 +37,16 @@ static bool bootstrap_requested(void) {
   dif_gpio_t gpio;
   dif_gpio_config_t gpio_config = {
       .base_addr = mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR)};
-  dif_gpio_init(&gpio_config, &gpio);
+  if (dif_gpio_init(&gpio_config, &gpio) != kDifGpioOk) {
+    LOG_ERROR("Failed to initialize GPIO for bootstrap checking.");
+    return false;
+  }
 
   uint32_t gpio_in;
-  dif_gpio_all_read(&gpio, &gpio_in);
+  if (dif_gpio_all_read(&gpio, &gpio_in) != kDifGpioOk) {
+    LOG_ERROR("Failed to read GPIO for bootstrap checking.");
+    return false;
+  }
   return (gpio_in & GPIO_BOOTSTRAP_BIT_MASK) != 0;
 }
 

--- a/sw/device/examples/demos.c
+++ b/sw/device/examples/demos.c
@@ -9,6 +9,7 @@
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/log.h"
 #include "sw/device/lib/dif/dif_gpio.h"
+#include "sw/device/lib/runtime/check.h"
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/spi_device.h"
 #include "sw/device/lib/uart.h"
@@ -17,12 +18,12 @@ void demo_gpio_startup(dif_gpio_t *gpio) {
   LOG_INFO("Watch the LEDs!");
 
   // Give a LED pattern as startup indicator for 5 seconds.
-  dif_gpio_all_write(gpio, 0xff00);
+  CHECKZ(dif_gpio_all_write(gpio, 0xff00));
   for (int i = 0; i < 32; ++i) {
     usleep(5 * 1000);  // 5 ms
-    dif_gpio_pin_write(gpio, 8 + (i % 8), (i / 8) % 2);
+    CHECKZ(dif_gpio_pin_write(gpio, 8 + (i % 8), (i / 8) % 2));
   }
-  dif_gpio_all_write(gpio, 0x0000);  // All LEDs off.
+  CHECKZ(dif_gpio_all_write(gpio, 0x0000));  // All LEDs off.
 }
 
 /**
@@ -38,7 +39,7 @@ static const uint32_t kFtdiMask = 0x10000;
 
 uint32_t demo_gpio_to_log_echo(dif_gpio_t *gpio, uint32_t prev_gpio_state) {
   uint32_t gpio_state;
-  dif_gpio_all_read(gpio, &gpio_state);
+  CHECKZ(dif_gpio_all_read(gpio, &gpio_state));
   gpio_state &= kGpioMask;
 
   uint32_t state_delta = prev_gpio_state ^ gpio_state;
@@ -75,6 +76,6 @@ void demo_uart_to_uart_and_gpio_echo(dif_gpio_t *gpio) {
   char rcv_char;
   while (uart_rcv_char(&rcv_char) != -1) {
     uart_send_char(rcv_char);
-    dif_gpio_all_write(gpio, rcv_char << 8);
+    CHECKZ(dif_gpio_all_write(gpio, rcv_char << 8));
   }
 }

--- a/sw/device/examples/hello_usbdev/meson.build
+++ b/sw/device/examples/hello_usbdev/meson.build
@@ -23,6 +23,7 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
       riscv_crt,
       sw_lib_irq_handlers,
       device_lib,
+      sw_lib_testing_test_status,
     ],
   )
 

--- a/sw/device/examples/hello_world/hello_world.c
+++ b/sw/device/examples/hello_world/hello_world.c
@@ -7,6 +7,7 @@
 #include "sw/device/lib/base/log.h"
 #include "sw/device/lib/dif/dif_gpio.h"
 #include "sw/device/lib/pinmux.h"
+#include "sw/device/lib/runtime/check.h"
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/spi_device.h"
 #include "sw/device/lib/testing/test_status.h"
@@ -21,11 +22,12 @@ int main(int argc, char **argv) {
   pinmux_init();
   spid_init();
 
-  dif_gpio_config_t gpio_config = {.base_addr =
-                                       mmio_region_from_addr(0x40010000)};
-  dif_gpio_init(&gpio_config, &gpio);
+  dif_gpio_config_t gpio_config = {
+      .base_addr = mmio_region_from_addr(0x40010000),
+  };
+  CHECKZ(dif_gpio_init(&gpio_config, &gpio));
   // Enable GPIO: 0-7 and 16 is input; 8-15 is output.
-  dif_gpio_output_mode_all_set(&gpio, 0x0ff00);
+  CHECKZ(dif_gpio_output_mode_all_set(&gpio, 0x0ff00));
   // Add DATE and TIME because I keep fooling myself with old versions
   LOG_INFO("Hello World!");
   LOG_INFO("Built at: " __DATE__ ", " __TIME__);
@@ -34,7 +36,7 @@ int main(int argc, char **argv) {
 
   // Now have UART <-> Buttons/LEDs demo
   // all LEDs off
-  dif_gpio_all_write(&gpio, 0x0000);
+  CHECKZ(dif_gpio_all_write(&gpio, 0x0000));
   LOG_INFO("Try out the switches on the board");
   LOG_INFO("or type anything into the console window.");
   LOG_INFO("The LEDs show the ASCII code of the last character.");

--- a/sw/device/lib/dif/dif_gpio.c
+++ b/sw/device/lib/dif/dif_gpio.c
@@ -94,7 +94,10 @@ dif_gpio_result_t dif_gpio_init(const dif_gpio_config_t *config,
   // Save internal state in the given `dif_gpio_t` instance.
   gpio->base_addr = config->base_addr;
   // Reset the GPIO device at the given `base_addr`.
-  dif_gpio_reset(gpio);
+  dif_gpio_result_t err = dif_gpio_reset(gpio);
+  if (err != kDifGpioOk) {
+    return err;
+  }
 
   return kDifGpioOk;
 }
@@ -335,7 +338,10 @@ dif_gpio_result_t dif_gpio_irq_trigger_masked_config(const dif_gpio_t *gpio,
   }
 
   // Disable all interrupt triggers for the given mask
-  dif_gpio_irq_trigger_masked_disable(gpio, mask);
+  dif_gpio_result_t error = dif_gpio_irq_trigger_masked_disable(gpio, mask);
+  if (error != kDifGpioOk) {
+    return error;
+  }
 
   switch (config) {
     case kDifGpioIrqEdgeRising:

--- a/sw/device/lib/uart.c
+++ b/sw/device/lib/uart.c
@@ -22,11 +22,19 @@ void uart_init(unsigned int baud) {
   };
 
   mmio_region_t base_addr = mmio_region_from_addr(TOP_EARLGREY_UART_BASE_ADDR);
-  (void)dif_uart_init(base_addr, &config, &uart0);
+  // Note that, due to a GCC bug, we cannot use the standard `(void) expr`
+  // syntax to drop this value on the ground.
+  // See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=25509
+  if (dif_uart_init(base_addr, &config, &uart0)) {
+  }
 }
 
 void uart_send_char(char c) {
-  (void)dif_uart_byte_send_polled(&uart0, (uint8_t)c);
+  // Note that, due to a GCC bug, we cannot use the standard `(void) expr`
+  // syntax to drop this value on the ground.
+  // See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=25509
+  if (dif_uart_byte_send_polled(&uart0, (uint8_t)c)) {
+  }
 }
 
 void uart_send_str(char *str) {

--- a/sw/device/tests/rv_timer_test.c
+++ b/sw/device/tests/rv_timer_test.c
@@ -7,6 +7,7 @@
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "sw/device/lib/base/log.h"
 #include "sw/device/lib/dif/dif_gpio.h"
+#include "sw/device/lib/handler.h"
 #include "sw/device/lib/irq.h"
 #include "sw/device/lib/pinmux.h"
 #include "sw/device/lib/testing/test_main.h"


### PR DESCRIPTION
I haven't upgraded this to a warning yet, though I feel like at this point it would not be unreasonable to ask DIF authors to do due diligence in fixing usages in their PRs; I can tack on a commit that does the upgrade.

In most places I just added a CHECK (since it's in "test" code), but I had to make some executive decisions on hwo to handle the errors.