### PR TITLE
Remove `extern` from imports in various unit tests

### DIFF
--- a/sw/device/lib/base/print_test.cc
+++ b/sw/device/lib/base/print_test.cc
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+// print.h's polyglotness is not part of its public API at the moment; we wrap
+// it in an `extern` here for the time being.
 extern "C" {
 #include "sw/device/lib/base/print.h"
 }  // extern "C"

--- a/sw/device/lib/dif/dif_i2c.h
+++ b/sw/device/lib/dif/dif_i2c.h
@@ -10,6 +10,10 @@
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_warn_unused_result.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
 /**
  * Represents a speed setting for an I2C component: standard, fast, and
  * fast plus, corresponding to 100 kbaud, 400 kbaud, and 1 Mbaud,
@@ -497,5 +501,9 @@ typedef enum dif_i2c_fmt {
 DIF_WARN_UNUSED_RESULT
 dif_i2c_result_t dif_i2c_write_byte(const dif_i2c_t *i2c, uint8_t byte,
                                     dif_i2c_fmt_t code, bool supress_nak_irq);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_DIF_DIF_I2C_H_

--- a/sw/device/tests/dif/dif_gpio_unittest.cc
+++ b/sw/device/tests/dif/dif_gpio_unittest.cc
@@ -4,10 +4,11 @@
 
 #include "sw/device/lib/dif/dif_gpio.h"
 
+#include <limits>
+
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/testing/mock_mmio.h"
-#include <limits>
 
 #include "gpio_regs.h"  // Generated
 

--- a/sw/device/tests/dif/dif_i2c_unittest.cc
+++ b/sw/device/tests/dif/dif_i2c_unittest.cc
@@ -2,18 +2,17 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/dif/dif_i2c.h"
+
 #include <cstring>
 #include <limits>
 #include <ostream>
 
-extern "C" {
-#include "sw/device/lib/dif/dif_i2c.h"
-#include "i2c_regs.h"  // Generated.
-}  // extern "C"
-
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/testing/mock_mmio.h"
+
+#include "i2c_regs.h"  // Generated.
 
 // We define global namespace == and << to make `dif_i2c_timing_params_t` work
 // nicely with EXPECT_EQ.

--- a/sw/device/tests/dif/dif_plic_unittest.cc
+++ b/sw/device/tests/dif/dif_plic_unittest.cc
@@ -2,15 +2,13 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "sw/device/lib/testing/mock_mmio.h"
+#include "sw/device/lib/dif/dif_plic.h"
 
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/testing/mock_mmio.h"
 
-extern "C" {
-#include "sw/device/lib/dif/dif_plic.h"
 #include "rv_plic_regs.h"  // Generated.
-}  // extern "C"
 
 namespace dif_plic_unittest {
 namespace {

--- a/sw/device/tests/dif/dif_spi_device_unittest.cc
+++ b/sw/device/tests/dif/dif_spi_device_unittest.cc
@@ -2,16 +2,15 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#include <limits>
-
-extern "C" {
 #include "sw/device/lib/dif/dif_spi_device.h"
-#include "spi_device_regs.h"  // Generated.
-}  // extern "C"
+
+#include <limits>
 
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/testing/mock_mmio.h"
+
+#include "spi_device_regs.h"  // Generated.
 
 namespace dif_spi_device_unittest {
 namespace {

--- a/sw/device/tests/dif/dif_uart_unittest.cc
+++ b/sw/device/tests/dif/dif_uart_unittest.cc
@@ -2,14 +2,13 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/dif/dif_uart.h"
+
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/testing/mock_mmio.h"
 
-extern "C" {
-#include "sw/device/lib/dif/dif_uart.h"
 #include "uart_regs.h"  // Generated.
-}  // extern "C"
 
 namespace dif_uart_unittest {
 namespace {


### PR DESCRIPTION
This change also fixes include guards in certain headers to be consistent everywhere.