### PR TITLE
[otbn] Fix dmem depth parameter calculation

### DIFF
--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -263,7 +263,7 @@ module otbn
 
   // Data Memory (DMEM) ========================================================
 
-  localparam DmemSizeWords = DmemSizeByte / WLEN / 8;
+  localparam DmemSizeWords = DmemSizeByte / (WLEN / 8);
   localparam DmemIndexWidth = vbits(DmemSizeWords);
 
   // Access select to DMEM: core (1), or bus (0)


### PR DESCRIPTION
The missing parentheses lead to a 2 deep dmem instead of a 128 deep dmem.

Signed-off-by: Michael Schaffner <msf@google.com>