### PR TITLE
[prim] Improve extraction of parameter port list

### DIFF
--- a/hw/ip/prim/util/primgen.py
+++ b/hw/ip/prim/util/primgen.py
@@ -191,7 +191,6 @@ def _parse_parameter_port_list(parameter_port_list):
 def _check_gapi(gapi):
     if not 'cores' in gapi:
         print("Key 'cores' not found in GAPI structure. "
-              "At least FuseSoC 1.11 is needed. "
               "Install a compatible version with "
               "'pip3 install --user -r python-requirements.txt'.")
         return False

--- a/hw/ip/prim/util/primgen.py
+++ b/hw/ip/prim/util/primgen.py
@@ -5,7 +5,6 @@
 import os
 import re
 import shutil
-import subprocess
 import sys
 
 import yaml
@@ -45,6 +44,7 @@ def _prim_cores(cores, prim_name=None):
         if (vlnv['vendor'] == 'lowrisc' and
                 vlnv['library'].startswith('prim_') and
             (prim_name is None or vlnv['name'] == prim_name)):
+
             return core
         return None
 
@@ -197,7 +197,7 @@ def _parse_parameter_port_list(parameter_port_list):
 
 
 def _check_gapi(gapi):
-    if not 'cores' in gapi:
+    if 'cores' not in gapi:
         print("Key 'cores' not found in GAPI structure. "
               "Install a compatible version with "
               "'pip3 install --user -r python-requirements.txt'.")
@@ -300,7 +300,7 @@ def _generate_abstract_impl(gapi):
 
     techlibs = _techlibs(prim_cores)
 
-    if not 'generic' in techlibs:
+    if 'generic' not in techlibs:
         raise ValueError("Techlib generic is required, but not found for "
                          "primitive %s." % prim_name)
     print("Implementations for primitive %s: %s" %

--- a/hw/ip/prim/util/primgen.py
+++ b/hw/ip/prim/util/primgen.py
@@ -159,6 +159,14 @@ def _parse_module_header(generic_impl_filepath, module_name):
     }
 
 
+def test_parse_parameter_port_list():
+    assert _parse_parameter_port_list("parameter integer P") == {'P'}
+    assert _parse_parameter_port_list("parameter logic [W-1:0] P") == {'P'}
+    assert _parse_parameter_port_list("parameter logic [W-1:0] P = '0") == {'P'}
+    assert _parse_parameter_port_list("parameter logic [W-1:0] P = 'b0") == {'P'}
+    assert _parse_parameter_port_list("parameter logic [W-1:0] P = 2'd0") == {'P'}
+
+
 def _parse_parameter_port_list(parameter_port_list):
     """ Parse a list of ports in a module header into individual parameters """
 
@@ -177,9 +185,9 @@ def _parse_parameter_port_list(parameter_port_list):
     # XXX: Not covering the complete grammar, e.g. `parameter x, y`
     RE_PARAMS = (
         r'parameter\s+'
-        r'(?:[a-zA-Z0-9\]\[:\s\$]+\s+)?'  # type
+        r'(?:[a-zA-Z0-9\]\[:\s\$-]+\s+)?'  # type
         r'(?P<name>\w+)'  # name
-        r'(?:\s*=\s*[^,;]+)'  # initial value
+        r'(?:\s*=\s*[^,;]+)?'  # initial value
     )
     re_params = re.compile(RE_PARAMS)
     parameters = set()

--- a/hw/ip/prim/util/primgen.py
+++ b/hw/ip/prim/util/primgen.py
@@ -378,7 +378,8 @@ def _generate_abstract_impl(gapi):
                   f,
                   encoding="utf-8",
                   default_flow_style=False,
-                  sort_keys=False)
+                  sort_keys=False,
+                  Dumper=YamlDumper)
     print("Core file written to %s" % (abstract_prim_core_filepath, ))
 
 


### PR DESCRIPTION
The `_parse_parameter_port_list()` function in primgen extracts the names
of parameters from a parameter port list. The extraction failed for
parameters without an initial value, or with a `-` in the data type 
definition (as in `Width-1`). Fix both cases by updating the regex.

This commit also adds a small inline test, to be run with `pytest`, to make
it easier to improve this code in the future.

Fixes #2679

Also contains a small fix to an error message when using the wrong version of FuseSoC.