### PR TITLE
[pinmux] Fix Inter-module Signal data structure

### DIFF
--- a/hw/ip/pinmux/data/pinmux.hjson
+++ b/hw/ip/pinmux/data/pinmux.hjson
@@ -28,9 +28,15 @@
   bus_device: "tlul",
   regwidth: "32",
 
+  wakeup_list: [
+    { name: "aon_wkup_req",
+      desc: "pin wake request"
+    }
+  ],
+
   inter_signal_list: [
     // Define lc <-> pinmux signal for strap sampling
-    { struct:  "lc_pinmux_strap",
+    { struct:  "lc_strap",
       type:    "req_rsp",
       name:    "lc_pinmux_strap",
       act:     "rsp",

--- a/hw/ip/pinmux/data/pinmux.hjson.tpl
+++ b/hw/ip/pinmux/data/pinmux.hjson.tpl
@@ -36,7 +36,7 @@
 
   inter_signal_list: [
     // Define lc <-> pinmux signal for strap sampling
-    { struct:  "lc_pinmux_strap",
+    { struct:  "lc_strap",
       type:    "req_rsp",
       name:    "lc_pinmux_strap",
       act:     "rsp",

--- a/hw/ip/pinmux/rtl/pinmux_pkg.sv
+++ b/hw/ip/pinmux/rtl/pinmux_pkg.sv
@@ -23,7 +23,7 @@ package pinmux_pkg;
     logic sample_pulse;
   } lc_strap_req_t;
 
-  parameter lc_strap_req_t LC_PINMUX_STRAP_REQ_DEFAULT = '{
+  parameter lc_strap_req_t LC_STRAP_REQ_DEFAULT = '{
     sample_pulse: 1'b0
   };
 
@@ -31,5 +31,10 @@ package pinmux_pkg;
     logic               valid;
     logic [NStraps-1:0] straps;
   } lc_strap_rsp_t;
+
+  parameter lc_strap_rsp_t LC_STRAP_RSP_DEFAULT = '{
+    valid: 1'b0,
+    straps: '0
+  };
 
 endpackage : pinmux_pkg

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -830,7 +830,7 @@
       inter_signal_list:
       [
         {
-          struct: lc_pinmux_strap
+          struct: lc_strap
           type: req_rsp
           name: lc_pinmux_strap
           act: rsp
@@ -3476,7 +3476,7 @@
         index: -1
       }
       {
-        struct: lc_pinmux_strap
+        struct: lc_strap
         type: req_rsp
         name: lc_pinmux_strap
         act: rsp

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
@@ -68,12 +68,17 @@ module clkmgr import clkmgr_pkg::*; (
 
 
   ////////////////////////////////////////////////////
+  // Feed through clocks
+  // Feed through clocks do not actually need to be in clkmgr, as they are
+  // completely untouched. The only reason they are here is for easier
+  // bundling management purposes through clocks_o
+  ////////////////////////////////////////////////////
+  assign clocks_o.clk_aon_i = clk_aon_i;
+
+
+  ////////////////////////////////////////////////////
   // Root gating
   ////////////////////////////////////////////////////
-
-  // the rst_ni connection below is incorrect, need to find a proper reset in the sequence to use
-  // if the clkmgr is always on, can use por synced directly
-  // if not, then need to generate something ahead of lc/sys
 
   logic async_roots_en;
   logic roots_en_q2, roots_en_q1, roots_en_d;
@@ -156,9 +161,6 @@ module clkmgr import clkmgr_pkg::*; (
   // Software direct control group
   ////////////////////////////////////////////////////
 
-  // the rst_ni connection below is incorrect, need to find a proper reset in the sequence to use
-  // if the clkmgr is always on, can use por synced directly
-  // if not, then need to generate something ahead of lc/sys
   logic clk_io_peri_sw_en;
   logic clk_usb_peri_sw_en;
 
@@ -200,10 +202,6 @@ module clkmgr import clkmgr_pkg::*; (
   // The idle hint feedback is assumed to be synchronous to the
   // clock target
   ////////////////////////////////////////////////////
-
-  // the rst_ni connection below is incorrect, need to find a proper reset in the sequence to use
-  // if the clkmgr is always on, can use por synced directly
-  // if not, then need to generate something ahead of lc/sys
 
   logic clk_main_aes_hint;
   logic clk_main_aes_en;

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_pkg.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_pkg.sv
@@ -17,6 +17,7 @@ package clkmgr_pkg;
   };
 
   typedef struct packed {
+  logic clk_aon_i;
   logic clk_main_aes;
   logic clk_main_hmac;
   logic clk_main_otbn;

--- a/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
+++ b/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
@@ -44,7 +44,7 @@
 
   inter_signal_list: [
     // Define lc <-> pinmux signal for strap sampling
-    { struct:  "lc_pinmux_strap",
+    { struct:  "lc_strap",
       type:    "req_rsp",
       name:    "lc_pinmux_strap",
       act:     "rsp",

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -685,7 +685,7 @@ module top_earlgrey #(
       .tl_o (tl_pinmux_d_d2h),
 
       // Inter-module signals
-      .lc_pinmux_strap_i(pinmux_pkg::LC_PINMUX_STRAP_REQ_DEFAULT),
+      .lc_pinmux_strap_i(pinmux_pkg::LC_STRAP_REQ_DEFAULT),
       .lc_pinmux_strap_o(),
       .sleep_en_i('0),
       .aon_wkup_req_o(pwrmgr_wakeups),


### PR DESCRIPTION
pinmux has incorrect inter-module signal data structure defined. It is revised and the default values of those structs are revised accordingly.