### PR TITLE
Instrument AES testing with ChipWhisperer capture board

### DIFF
--- a/hw/top_earlgrey/data/pins_cw305.xdc
+++ b/hw/top_earlgrey/data/pins_cw305.xdc
@@ -5,9 +5,6 @@
 set_property -dict { PACKAGE_PIN N13 IOSTANDARD LVCMOS33 } [get_ports { IO_CLK }]
 create_clock -add -name sys_clk_pin -period 10.00 -waveform {0 5} [get_ports IO_CLK]
 
-## Output clock to capture board
-set_property -dict { PACKAGE_PIN M16 IOSTANDARD LVCMOS33 } [get_ports TIO_CLKOUT]
-
 ## Clock Domain Crossings
 create_generated_clock -name clk_50_unbuf -source [get_pin clkgen/pll/CLKIN1] [get_pin clkgen/pll/CLKOUT0]
 create_generated_clock -name clk_48_unbuf -source [get_pin clkgen/pll/CLKIN1] [get_pin clkgen/pll/CLKOUT1]
@@ -19,17 +16,13 @@ set_property -dict { PACKAGE_PIN T3  DRIVE 8 IOSTANDARD LVCMOS33 } [get_ports { 
 set_property -dict { PACKAGE_PIN T4  DRIVE 8 IOSTANDARD LVCMOS33 } [get_ports { IO_GP10 }]
 
 ## Buttons
-set_property -dict { PACKAGE_PIN L14 IOSTANDARD LVCMOS33 } [get_ports { IO_RST_N }]; #pushbutton
+set_property -dict { PACKAGE_PIN R1 IOSTANDARD LVCMOS33 } [get_ports { IO_RST_N }]; #pushbutton
 
 ## Switches
 set_property -dict { PACKAGE_PIN J16 IOSTANDARD LVCMOS33 } [get_ports { IO_GP0 }]; #sw1
 set_property -dict { PACKAGE_PIN K16 IOSTANDARD LVCMOS33 } [get_ports { IO_GP1 }]; #sw2
 set_property -dict { PACKAGE_PIN K15 IOSTANDARD LVCMOS33 } [get_ports { IO_GP2 }]; #sw3
-set_property -dict { PACKAGE_PIN R1  IOSTANDARD LVCMOS33 } [get_ports { IO_GP3 }]; #sw4
-
-## UART
-set_property -dict { PACKAGE_PIN A12  IOSTANDARD LVCMOS33 } [get_ports { IO_UTX }]; #JP3.A12
-set_property -dict { PACKAGE_PIN B12  IOSTANDARD LVCMOS33 } [get_ports { IO_URX }]; #JP3.B12
+set_property -dict { PACKAGE_PIN L14 IOSTANDARD LVCMOS33 } [get_ports { IO_GP3 }]; #sw4
 
 ## SPI/JTAG
 set_property -dict { PACKAGE_PIN A14   IOSTANDARD LVCMOS33 } [get_ports { IO_DPS0 }]; #JP3.A14
@@ -41,7 +34,6 @@ set_property -dict { PACKAGE_PIN C11   IOSTANDARD LVCMOS33 PULLTYPE PULLUP } [ge
 set_property -dict { PACKAGE_PIN B14   IOSTANDARD LVCMOS33 PULLTYPE PULLDOWN } [get_ports { IO_DPS6 }]; #JP3.B14
 set_property -dict { PACKAGE_PIN C14   IOSTANDARD LVCMOS33 PULLTYPE PULLDOWN } [get_ports { IO_DPS7 }]; #JP3.C14
 
-
 ## OTHER IO
 set_property -dict { PACKAGE_PIN B16 IOSTANDARD LVCMOS33 } [get_ports { IO_GP4  }]; #JP3.B16
 set_property -dict { PACKAGE_PIN C13 IOSTANDARD LVCMOS33 } [get_ports { IO_GP5  }]; #JP3.C13
@@ -51,7 +43,6 @@ set_property -dict { PACKAGE_PIN E13 IOSTANDARD LVCMOS33 } [get_ports { IO_GP11 
 set_property -dict { PACKAGE_PIN F15 IOSTANDARD LVCMOS33 } [get_ports { IO_GP12 }]; #JP3.F15
 set_property -dict { PACKAGE_PIN E11 IOSTANDARD LVCMOS33 } [get_ports { IO_GP13 }]; #JP3.E11
 set_property -dict { PACKAGE_PIN F13 IOSTANDARD LVCMOS33 } [get_ports { IO_GP14 }]; #JP3.F13
-set_property -dict { PACKAGE_PIN F12 IOSTANDARD LVCMOS33 } [get_ports { IO_GP15 }]; #JP3.F12
 
 set_property -dict { PACKAGE_PIN C16 IOSTANDARD LVCMOS33 DRIVE 8 SLEW FAST } [get_ports { IO_USB_DP0 }]; #JP3.C16
 set_property -dict { PACKAGE_PIN D13 IOSTANDARD LVCMOS33 DRIVE 8 SLEW FAST } [get_ports { IO_USB_DN0 }]; #JP3.D13
@@ -59,11 +50,13 @@ set_property -dict { PACKAGE_PIN H16 IOSTANDARD LVCMOS33 } [get_ports { IO_USB_D
 set_property -dict { PACKAGE_PIN D16 IOSTANDARD LVCMOS33 } [get_ports { IO_USB_SENSE0 }]; #JP3.D16
 set_property -dict { PACKAGE_PIN E16 IOSTANDARD LVCMOS33 } [get_ports { IO_USB_DNPULLUP0 }]; #JP3.E16
 
-## 20-Pin Connector
+## 20-Pin Connector (JP1)
 
-#set_property PACKAGE_PIN T14 [get_ports tio_trigger]
-#set_property PACKAGE_PIN M16 [get_ports tio_clkout]
-#set_property PACKAGE_PIN N14 [get_ports tio_clkin]
+set_property -dict { PACKAGE_PIN R16 IOSTANDARD LVCMOS33 } [get_ports { IO_UTX }];     #JP1 PIN 10 (UART)
+set_property -dict { PACKAGE_PIN P16 IOSTANDARD LVCMOS33 } [get_ports { IO_URX }];     #JP1 PIN 12 (UART)
+set_property -dict { PACKAGE_PIN T14 IOSTANDARD LVCMOS33 } [get_ports { IO_GP15 }];    #JP1 PIN 16 TIO4 (Trigger)
+set_property -dict { PACKAGE_PIN M16 IOSTANDARD LVCMOS33 } [get_ports { TIO_CLKOUT }]; #JP1 PIN 4 TIO_HS1. Clock sync capture board.
+
 
 ## USB Connector
 # TODO: Configure USB capture interface and sync triggers.

--- a/hw/top_earlgrey/rtl/top_earlgrey_cw305.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_cw305.sv
@@ -37,9 +37,9 @@ module top_earlgrey_cw305 #(
   inout               IO_GP5,
   inout               IO_GP6,
   inout               IO_GP7,
-  output              IO_GP8,  // XXX: rename as LED
-  output              IO_GP9,  // XXX: rename as LED
-  output              IO_GP10, // XXX: rename as LED
+  inout               IO_GP8,
+  inout               IO_GP9,
+  inout               IO_GP10,
   inout               IO_GP11,
   inout               IO_GP12,
   inout               IO_GP13,
@@ -66,27 +66,13 @@ module top_earlgrey_cw305 #(
   logic [padctrl_reg_pkg::NDioPads-1:0] dio_oe_core, dio_oe_padring;
   logic [padctrl_reg_pkg::NDioPads-1:0] dio_in_core, dio_in_padring;
 
-  reg io_utx_reg;
-  always @(posedge clk) begin
-      io_utx_reg <<= (IO_UTX == 1'bz)? 0 : IO_UTX;
-  end
-  assign IO_GP8 = io_utx_reg;
-
-  reg io_urx_reg;
-  always @(posedge clk) begin
-    io_urx_reg <<= (IO_URX == 1'bz)? 0 : IO_URX;
-  end
-  assign IO_GP9 = io_urx_reg;
-
-  assign IO_GP10 = 1'b1;
-
   assign TIO_CLKOUT = clk;
 
   padring #(
     // MIOs 31:20 are currently not
     // connected to pads and hence tied off
-    .ConnectMioIn  ( 32'h000FF8FF ),
-    .ConnectMioOut ( 32'h000FF8FF ),
+    .ConnectMioIn  ( 32'h000FFFFF ),
+    .ConnectMioOut ( 32'h000FFFFF ),
     // Tied off DIOs:
     // 2: usbdev_d
     // 3: usbdev_suspend
@@ -113,9 +99,9 @@ module top_earlgrey_cw305 #(
                              IO_GP13,
                              IO_GP12,
                              IO_GP11,
-                             1'bz,
-                             1'bz,
-                             1'bz,
+                             IO_GP10,
+                             IO_GP9,
+                             IO_GP8,
                              IO_GP7,
                              IO_GP6,
                              IO_GP5,

--- a/sw/device/lib/aes.c
+++ b/sw/device/lib/aes.c
@@ -95,6 +95,10 @@ bool aes_idle(void) {
   return (REG32(AES_STATUS(0)) & (0x1u << AES_STATUS_IDLE));
 }
 
+void aes_manual_trigger(void) {
+  REG32(AES_TRIGGER(0)) = 0x1u << AES_TRIGGER_START;
+}
+
 void aes_clear(void) {
   // Wait for AES unit to be idle.
   while (!aes_idle()) {

--- a/sw/device/lib/aes.h
+++ b/sw/device/lib/aes.h
@@ -116,6 +116,13 @@ bool aes_data_valid(void);
 bool aes_idle(void);
 
 /**
+ * Set AES manual trigger.
+ *
+ * This is only valid when AES is configured to run in manual mode.
+ */
+void aes_manual_trigger(void);
+
+/**
  * Clear key, input and ouput registers of AES unit.
  */
 void aes_clear(void);

--- a/sw/device/meson.build
+++ b/sw/device/meson.build
@@ -33,6 +33,7 @@ export_embedded_target = [
 subdir('boot_rom')
 subdir('boot_rom2')
 subdir('examples')
+subdir('sca')
 subdir('tests')
 subdir('benchmarks')
 subdir('tock')

--- a/sw/device/sca/aes_serial/aes_serial.c
+++ b/sw/device/sca/aes_serial/aes_serial.c
@@ -1,0 +1,293 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/aes.h"
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/dif/dif_gpio.h"
+#include "sw/device/lib/handler.h"
+#include "sw/device/lib/irq.h"
+#include "sw/device/lib/pinmux.h"
+#include "sw/device/lib/runtime/hart.h"
+#include "sw/device/lib/rv_timer.h"
+#include "sw/device/lib/uart.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+static dif_gpio_t gpio;
+
+// Test buffer maximum buffer sizes
+#define MAX_LENGTH_TEXT 128
+#define MAX_LENGTH_BIN (MAX_LENGTH_TEXT / 2)
+
+// AES Configuration parameters. These values must match the test driving
+// side.
+#define AES_BLOCK_SIZE 16
+#define AES_KEY_SIZE 16
+#define AES_EXEC_COUNTER_CYCLES 10
+
+// Simple serial status codes
+#define SIMPLE_SERIAL_OK 0
+#define SIMPLE_SERIAL_ERROR 1
+
+// Simple serial protocol version 1.1
+#define SIMPLE_PROTOCOL_VERSION 1
+
+// GPIO trigger values
+#define GPIO_SET_TRIGGER_HIGH 0x08200
+#define GPIO_SET_TRIGGER_LOW 0x00000
+
+// TODO: Switch to rv_timer dif.
+// Timer comparator value. Used by interrupt.
+static volatile uint64_t timer_cmp = AES_EXEC_COUNTER_CYCLES;
+
+static const uint32_t hart = (uint32_t)kTopEarlgreyPlicTargetIbex0;
+
+/**
+ * Convert `from` binary `to` hex.
+ *
+ * @param from input value in binary format.
+ * @param to   output value in hex format.
+ *
+ * @return SIMPLE_SERIAL_OK on success, SIMPLE_SERIAL_ERROR otherwise.
+ */
+static uint8_t hex_value(char from, char *to) {
+  if (from >= '0' && from <= '9') {
+    *to = from - '0';
+  } else if (from >= 'A' && from <= 'F') {
+    *to = from - 'A' + 10;
+  } else if (from >= 'a' && from <= 'f') {
+    *to = from - 'a' + 10;
+  } else {
+    return SIMPLE_SERIAL_ERROR;
+  }
+  return SIMPLE_SERIAL_OK;
+}
+
+/**
+ * Convert `num` bytes `from` hex `to` binary format.
+ *
+ * `from` size is expected to by twice as big as `to`.
+ *
+ * @param from input buffer for hex formatted characters.
+ * @param to   output binary buffer.
+ * @param num  number of characters in output buffer.
+ *
+ * @return SIMPLE_SERIAL_OK on success, SIMPLE_SERIAL_ERROR otherwise.
+ */
+static uint8_t a2b_hex(const char *from, char *to, size_t num) {
+  for (int i = 0; i < num; ++i) {
+    char hi, lo;
+    if (hex_value(from[i * 2], &hi) || hex_value(from[i * 2 + 1], &lo)) {
+      return SIMPLE_SERIAL_ERROR;
+    }
+    to[i] = ((hi & 0xFF) << 4) | (lo & 0xFF);
+  }
+  return SIMPLE_SERIAL_OK;
+}
+
+/**
+ * Send `data` to UART in hex byte format.
+ */
+static void print_hex_buffer(const char *data, size_t data_len) {
+  static const char b2a_hex_values[16] = {'0', '1', '2', '3', '4', '5',
+                                          '6', '7', '8', '9', 'A', 'B',
+                                          'C', 'D', 'E', 'F'};
+  for (int i = 0; i < data_len; ++i) {
+    uart_send_char(b2a_hex_values[data[i] >> 4]);
+    uart_send_char(b2a_hex_values[data[i] & 0xF]);
+  }
+}
+
+/**
+ * Send simple serial command response via UART.
+ *
+ * @param cmd_tag  Simple serial command tag.
+ * @param data     Response data. Converted to hex format by this function.
+ * @param data_len data length.
+ */
+static void print_cmd_response(const char cmd_tag, const char *data,
+                               size_t data_len) {
+  uart_send_char(cmd_tag);
+  print_hex_buffer(data, data_len);
+  uart_send_char('\n');
+}
+
+/**
+ * Return number of AES blocks from `plain_text_len`.
+ */
+static size_t get_num_blocks(size_t plain_text_len) {
+  size_t num_blocks = plain_text_len / AES_BLOCK_SIZE;
+  if ((plain_text_len - (num_blocks * AES_BLOCK_SIZE)) > 0) {
+    ++num_blocks;
+  }
+  return num_blocks;
+}
+
+/**
+ * Simple serial set AES key command.
+ *
+ * @param aes_cfg AES configuration object.
+ * @param key     AES key.
+ * @param key_len AES key length.
+ *
+ * @return SIMPLE_SERIAL_OK on success, SIMPLE_SERIAL_ERROR otherwise.
+ */
+static uint8_t simple_serial_set_key(const aes_cfg_t *aes_cfg, const char *key,
+                                     size_t key_len) {
+  if (key_len != AES_KEY_SIZE) {
+    return SIMPLE_SERIAL_ERROR;
+  }
+  aes_clear();
+  while (!aes_idle()) {
+    ;
+  }
+  aes_key_put((const void *)key, aes_cfg->key_len);
+  aes_init(*aes_cfg);
+  return SIMPLE_SERIAL_OK;
+}
+
+/*
+ * Simple serial trigger AES encryption command.
+ *
+ * @param aes_cfg        AES configuration object.
+ * @param plain_text     plain text to be encrypted.
+ * @param plain_text_len plain text length.
+ *
+ * @return SIMPLE_SERIAL_OK on success, SIMPLE_SERIAL_ERROR otherwise.
+ */
+static uint8_t simple_serial_trigger_encryption(const aes_cfg_t *aes_cfg,
+                                                const char *plain_text,
+                                                size_t plain_text_len) {
+  if (plain_text_len > MAX_LENGTH_BIN) {
+    return SIMPLE_SERIAL_ERROR;
+  }
+
+  char cipher_text[MAX_LENGTH_BIN];
+  size_t num_blocks = get_num_blocks(plain_text_len);
+  if (num_blocks != 1) {
+    return SIMPLE_SERIAL_ERROR;
+  }
+
+  // start timer to wake up Ibex after AES is done.
+  rv_timer_set_cmp(hart, timer_cmp);
+  rv_timer_ctrl(hart, true);
+
+  aes_data_put_wait(plain_text);
+  if (dif_gpio_all_write(&gpio, GPIO_SET_TRIGGER_HIGH) != kDifGpioOk) {
+    return SIMPLE_SERIAL_ERROR;
+  }
+  aes_manual_trigger();
+  wait_for_interrupt();
+  if (dif_gpio_all_write(&gpio, GPIO_SET_TRIGGER_LOW) != kDifGpioOk) {
+    return SIMPLE_SERIAL_ERROR;
+  }
+  aes_data_get_wait(cipher_text);
+
+  print_cmd_response('r', cipher_text, plain_text_len);
+  return SIMPLE_SERIAL_OK;
+}
+
+/**
+ * Handle simple seial command.
+ *
+ * @param aes_cfg AES configuration object.
+ * @param cmd     input command buffer.
+ * @param cmd_len number of characters set in input buffer.
+ */
+static void simple_serial_handle_command(const aes_cfg_t *aes_cfg,
+                                         const char *cmd, size_t cmd_len) {
+  char data[MAX_LENGTH_BIN] = {0};
+
+  // Data length is half the size of the hex encoded string.
+  const size_t data_len = cmd_len >> 1;
+  if (data_len >= MAX_LENGTH_BIN) {
+    return;
+  }
+
+  // The simple serial protocol does not expect return status codes for invalid
+  // data, thus it is ok to return early.
+  if (a2b_hex(&cmd[1], data, data_len)) {
+    return;
+  }
+
+  uint8_t result = SIMPLE_SERIAL_OK;
+  switch (cmd[0]) {
+    case 'k':
+      result = simple_serial_set_key(aes_cfg, data, data_len);
+      break;
+    case 'p':
+      result = simple_serial_trigger_encryption(aes_cfg, data, data_len);
+      break;
+    case 'v':
+      result = SIMPLE_PROTOCOL_VERSION;
+      break;
+    default:;
+  }
+  print_cmd_response('z', (const char *)&result, /*data_len=*/1);
+}
+
+int main(int argc, char **argv) {
+  uart_init(kUartBaudrate);
+  base_set_stdout(uart_stdout);
+  pinmux_init();
+
+  irq_global_ctrl(true);
+  irq_timer_ctrl(true);
+  rv_timer_intr_enable(hart, true);
+  rv_timer_set_us_tick(hart);
+
+  dif_gpio_config_t gpio_config = {.base_addr =
+                                       mmio_region_from_addr(0x40010000)};
+
+  if (dif_gpio_init(&gpio_config, &gpio) != kDifGpioOk) {
+    uart_send_str("Fatal error: Unable to initialize GPIO DIF.\r\n");
+    abort();
+  }
+
+  // Enable GPIO 9 and 15 as output.
+  if (dif_gpio_output_mode_all_set(&gpio, 0x08200) != kDifGpioOk) {
+    uart_send_str("Fatal error: Unable to configure GPIO output pins.\r\n");
+    abort();
+  }
+
+  if (dif_gpio_all_write(&gpio, GPIO_SET_TRIGGER_LOW) != kDifGpioOk) {
+    uart_send_str("Fatal error: Unable to set GPIO output pins.\r\n");
+    abort();
+  }
+
+  aes_cfg_t aes_cfg;
+  aes_cfg.key_len = kAes128;
+  aes_cfg.operation = kAesEnc;
+  aes_cfg.mode = kAesEcb;
+  aes_cfg.manual_operation = true;
+
+  char text[MAX_LENGTH_TEXT] = {0};
+  size_t pos = 0;
+  while (true) {
+    if (uart_rcv_char(&text[pos]) == -1) {
+      usleep(50);
+      continue;
+    }
+    if (text[pos] == '\n' || text[pos] == '\r') {
+      // Continue to override line feed (\n) or carriage return (\r). This
+      // way we don't pass empty lines to the handle_command function.
+      if (pos == 0) {
+        continue;
+      }
+      simple_serial_handle_command(&aes_cfg, text, pos - 1);
+      pos = 0;
+    } else {
+      // Going over the maxium buffer size will result in corrupting the input
+      // buffer. This is okay in this case since we control the script used
+      // to drive the UART input.
+      pos = (pos + 1) % MAX_LENGTH_TEXT;
+    }
+  }
+}
+
+void handler_irq_timer(void) {
+  timer_cmp += AES_EXEC_COUNTER_CYCLES;
+  rv_timer_ctrl(hart, false);
+  rv_timer_clr_all_intrs();
+}

--- a/sw/device/sca/aes_serial/meson.build
+++ b/sw/device/sca/aes_serial/meson.build
@@ -1,0 +1,40 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+foreach device_name, device_lib : sw_lib_arch_core_devices
+  aes_serial_elf = executable(
+    'aes_serial_' + device_name,
+    sources: ['aes_serial.c'],
+    name_suffix: 'elf',
+    dependencies: [
+      sw_lib_aes,
+      sw_lib_runtime_hart,
+      sw_lib_pinmux,
+      sw_lib_dif_gpio,
+      sw_lib_irq,
+      sw_lib_rv_timer,
+      sw_lib_uart,
+      riscv_crt,
+      sw_lib_irq_handlers,
+      device_lib,
+    ],
+  )
+
+  aes_serial_embedded = custom_target(
+    'aes_serial_' + device_name,
+    command: make_embedded_target,
+    input: aes_serial_elf,
+    output: make_embedded_target_outputs,
+    build_by_default: true,
+  )
+
+  custom_target(
+    'aes_serial_export_' + device_name,
+    command: export_embedded_target,
+    input: [aes_serial_elf, aes_serial_embedded],
+    output: 'aes_serial_export_' + device_name,
+    build_always_stale: true,
+    build_by_default: true,
+  )
+endforeach

--- a/sw/device/sca/meson.build
+++ b/sw/device/sca/meson.build
@@ -1,0 +1,5 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+subdir('aes_serial')


### PR DESCRIPTION
This pull request updates the CW305 FPGA configuration to work with a ChipWhisperer capture board. The CW305 contains
a 20-pin connector which is used to route the test interface to the capture board. The pinout is compatible with the following
ChipWhisperer CW1200 configuration:

```python
    scope = cw.scope()
    scope.gain.db = 25
    scope.adc.samples = 1800
    scope.adc.offset = 0
    scope.adc.basic_mode = "rising_edge"
    scope.clock.clkgen_freq = 20e6
    scope.clock.adc_src = "extclk_x4"
    scope.trigger.triggers = "tio4"
    scope.io.tio1 = "serial_tx"
    scope.io.tio2 = "serial_rx"
    scope.io.hs2 = "disabled"
```

The [SimpleSerial][1] protocol is used to send encryption commands to OpenTitan via UART.  
`sw/device/examples/aes_serial` implements the client side, restricting AES operation to AES-128-ECB (for now). The test
program drives a trigger GPIO and a status LED when the encryption operation is taking place.

[1]: https://wiki.newae.com/SimpleSerial
