### PR TITLE
[sw] Add Doxygen Headers to More Files

### DIFF
--- a/hw/ip/i2c/doc/_index.md
+++ b/hw/ip/i2c/doc/_index.md
@@ -372,7 +372,10 @@ All other parameters in registers `TIMING2`, `TIMING3`, `TIMING4` are unchanged 
 | TIMING1.T_R     | 0                | 134        | 402            | Atypicallly high line capacitance             |
 | SCL Period      | 1000             | N/A        | 395            | Forced longer than minimum by long T_R        |
 
+## Device Interface Functions (DIFs)
+
+{{< dif_listing "sw/device/lib/dif/dif_i2c.h" >}}
+
 ## Register Table 
 
 {{<registers "hw/ip/i2c/data/i2c.hjson" >}}
-

--- a/hw/ip/rv_timer/doc/_index.md
+++ b/hw/ip/rv_timer/doc/_index.md
@@ -240,6 +240,10 @@ Clearing the interrupt can be done by writing 1 into the Interrupt Status regist
 The RV_TIMER module also follows RISC-V Previliged spec that requires the interrupt to be cleared by updating `mtimecmp` memory-mapped CSRs.
 In this case both {{<regref "COMPARE_LOWER0_0">}} and {{<regref "COMPARE_UPPER0_0">}} can clear the interrupt source.
 
+## Device Interface Functions (DIFs)
+
+{{< dif_listing "sw/device/lib/dif/dif_rv_timer.h" >}}
+
 ## Register Table
 
 {{< registers "hw/ip/rv_timer/data/rv_timer.hjson" >}}

--- a/sw/device/lib/base/bitfield.h
+++ b/sw/device/lib/base/bitfield.h
@@ -13,6 +13,11 @@ extern "C" {
 #endif  // __cplusplus
 
 /**
+ * @file
+ * @brief Bitfield Manipulation Functions
+ */
+
+/**
  * Masked field offset for 32-bit bitfields, with optional value.
  *
  * `index` represents a shift in bits starting from the 0 bit of a given 32-bit

--- a/sw/device/lib/base/log.h
+++ b/sw/device/lib/base/log.h
@@ -12,7 +12,8 @@
 #include "sw/device/lib/base/macros.h"
 
 /**
- * Generic logging APIs
+ * @file
+ * @brief Generic logging APIs
  *
  * The logging APIs below take a format string with a variable number of
  * arguments for the type specifiers. The APIs are designed to provide a way

--- a/sw/device/lib/base/macros.h
+++ b/sw/device/lib/base/macros.h
@@ -6,7 +6,8 @@
 #define OPENTITAN_SW_DEVICE_LIB_BASE_MACROS_H_
 
 /**
- * Generic preprocessor macros that don't really fit anywhere else.
+ * @file
+ * @brief Generic preprocessor macros that don't really fit anywhere else.
  */
 
 /**

--- a/sw/device/lib/base/print.h
+++ b/sw/device/lib/base/print.h
@@ -9,6 +9,9 @@
 #include <stddef.h>
 
 /**
+ * @file
+ * @brief Libc-like printing facilities.
+ *
  * This header provides libc-like printing facilities, which is agnostic of the
  * underlying hardware printing mechanism.
  *

--- a/sw/device/lib/base/stdasm.h
+++ b/sw/device/lib/base/stdasm.h
@@ -7,7 +7,9 @@
 
 /**
  * @file
- * @brief This header simply provides the `asm` keyword, in analogy with the ISO
+ * @brief The `asm` keyword.
+ *
+ * This header simply provides the `asm` keyword, in analogy with the ISO
  * C headers `stdbool.h`, `stdnoreturn.h`, and so on.
  */
 

--- a/sw/device/lib/dif/dif_gpio.h
+++ b/sw/device/lib/dif/dif_gpio.h
@@ -2,13 +2,13 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_DIF_GPIO_H_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_DIF_GPIO_H_
+
 /**
  * @file
  * @brief <a href="/hw/ip/gpio/doc/">GPIO</a> Device Interface Functions
  */
-
-#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_DIF_GPIO_H_
-#define OPENTITAN_SW_DEVICE_LIB_DIF_DIF_GPIO_H_
 
 #include <stddef.h>
 #include <stdint.h>

--- a/sw/device/lib/dif/dif_i2c.h
+++ b/sw/device/lib/dif/dif_i2c.h
@@ -5,6 +5,11 @@
 #ifndef OPENTITAN_SW_DEVICE_LIB_DIF_DIF_I2C_H_
 #define OPENTITAN_SW_DEVICE_LIB_DIF_DIF_I2C_H_
 
+/**
+ * @file
+ * @brief <a href="/hw/ip/i2c/doc/">I2C</a> Device Interface Functions
+ */
+
 #include <stdint.h>
 
 #include "sw/device/lib/base/mmio.h"

--- a/sw/device/lib/dif/dif_plic.h
+++ b/sw/device/lib/dif/dif_plic.h
@@ -5,6 +5,11 @@
 #ifndef OPENTITAN_SW_DEVICE_LIB_DIF_DIF_PLIC_H_
 #define OPENTITAN_SW_DEVICE_LIB_DIF_DIF_PLIC_H_
 
+/**
+ * @file
+ * @brief <a href="/hw/ip/rv_plic/doc/">PLIC</a> Device Interface Functions
+ */
+
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -21,11 +26,6 @@ extern const uint32_t kDifPlicMinPriority;
 
 /** The highest interrupt priority. */
 extern const uint32_t kDifPlicMaxPriority;
-
-/**
- * @file
- * @brief <a href="/hw/ip/rv_plic/doc/">PLIC</a> Device Interface Functions
- */
 
 /**
  * PLIC interrupt source identifier.

--- a/sw/device/lib/dif/dif_rv_timer.h
+++ b/sw/device/lib/dif/dif_rv_timer.h
@@ -5,6 +5,11 @@
 #ifndef OPENTITAN_SW_DEVICE_LIB_DIF_DIF_RV_TIMER_H_
 #define OPENTITAN_SW_DEVICE_LIB_DIF_DIF_RV_TIMER_H_
 
+/**
+ * @file
+ * @brief <a href="/hw/ip/rv_timer/doc/">RV Timer</a> Device Interface Functions
+ */
+
 #include <stdint.h>
 
 #include "sw/device/lib/base/mmio.h"

--- a/sw/device/lib/dif/dif_spi_device.h
+++ b/sw/device/lib/dif/dif_spi_device.h
@@ -5,6 +5,12 @@
 #ifndef OPENTITAN_SW_DEVICE_LIB_DIF_DIF_SPI_DEVICE_H_
 #define OPENTITAN_SW_DEVICE_LIB_DIF_DIF_SPI_DEVICE_H_
 
+/**
+ * @file
+ * @brief <a href="/hw/ip/spi_device/doc/">SPI Device</a> Device Interface
+ * Functions
+ */
+
 #include <stddef.h>
 #include <stdint.h>
 
@@ -15,12 +21,6 @@
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus
-
-/**
- * @file
- * @brief <a href="/hw/ip/spi_device/doc/">SPI Device</a> Device Interface
- * Functions
- */
 
 /**
  * Represents a signal edge type.

--- a/sw/device/lib/dif/dif_uart.h
+++ b/sw/device/lib/dif/dif_uart.h
@@ -2,13 +2,13 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_DIF_UART_H_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_DIF_UART_H_
+
 /**
  * @file
  * @brief <a href="/hw/ip/uart/doc/">UART</a> Device Interface Functions
  */
-
-#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_DIF_UART_H_
-#define OPENTITAN_SW_DEVICE_LIB_DIF_DIF_UART_H_
 
 #include <stdbool.h>
 #include <stdint.h>

--- a/sw/device/lib/dif/dif_warn_unused_result.h
+++ b/sw/device/lib/dif/dif_warn_unused_result.h
@@ -6,6 +6,11 @@
 #define OPENTITAN_SW_DEVICE_LIB_DIF_DIF_WARN_UNUSED_RESULT_H_
 
 /**
+ * @file
+ * @brief Unused Result Warning Macro for DIFs.
+ */
+
+/**
  * Attribute for functions which return errors that must be acknowledged.
  *
  * This attribute must be used to mark all DIFs which return an error value of


### PR DESCRIPTION
These files were missed since the original Doxygen PR was opened.

Some of these changes are to ensure that the `@file` header is in a
coherent place in all DIF headers - it should be immediately after the
header include guard.

---

This PR also adds DIF listings to the rv_timer and the i2c programmer guides, as these DIFs recently landed