### PR TITLE
[tests] Wrap up the test main() function into a library

### DIFF
--- a/sw/device/lib/meson.build
+++ b/sw/device/lib/meson.build
@@ -5,7 +5,6 @@
 subdir('base')
 subdir('arch')
 subdir('runtime')
-subdir('testing')
 subdir('dif')
 
 # UART library (sw_lib_uart)
@@ -21,6 +20,10 @@ sw_lib_uart = declare_dependency(
     ],
   )
 )
+
+# NOTE: this needs to come *after* the UART library for now, until `test_main.c`
+# no longer depends on `uart.c`.
+subdir('testing')
 
 # Flash controller library (sw_lib_flash_ctrl)
 sw_lib_flash_ctrl = declare_dependency(

--- a/sw/device/lib/testing/meson.build
+++ b/sw/device/lib/testing/meson.build
@@ -15,6 +15,18 @@ sw_lib_testing_test_status = declare_dependency(
   )
 )
 
+sw_lib_testing_test_main = declare_dependency(
+  link_with: static_library(
+    'test_main_ot',
+    sources: ['test_main.c'],
+    dependencies: [
+      sw_lib_uart,
+      sw_lib_base_log,
+      sw_lib_testing_test_status,
+    ],
+  )
+)
+
 sw_lib_testing_mock_mmio = declare_dependency(
   link_with: static_library(
     'mock_mmio',

--- a/sw/device/lib/testing/test_main.c
+++ b/sw/device/lib/testing/test_main.c
@@ -2,10 +2,11 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/testing/test_main.h"
+
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/log.h"
 #include "sw/device/lib/base/print.h"
-#include "sw/device/lib/testing/test_main.h"
 #include "sw/device/lib/testing/test_status.h"
 #include "sw/device/lib/uart.h"
 

--- a/sw/device/lib/testing/test_main.h
+++ b/sw/device/lib/testing/test_main.h
@@ -5,14 +5,22 @@
 #ifndef OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_MAIN_H_
 #define OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_MAIN_H_
 
+#include <stdbool.h>
+
 /**
- * Runs the SW test.
- *
- * This method is defined externally in a standalone SW test source linked to
- * `main` as a library. It is a fully contained test in itself.
- *
- * @return success or failure of the test in boolean.
+ * @file
+ * @brief Entrypoint definitions for on-device tests
  */
-bool test_main(void);
+
+/**
+ * Entry point for a SW on-device test.
+ *
+ * This function should be defined externally in a standalone SW test, linked
+ * together with this library. This library provides a `main()` function that
+ * does test harness setup and calls `test_main()`.
+ *
+ * @return success or failure of the test as boolean.
+ */
+extern bool test_main(void);
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_MAIN_H_

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -74,17 +74,13 @@ foreach sw_test_name, sw_test_lib : sw_tests
   foreach device_name, device_lib : sw_lib_arch_core_devices
     sw_test_elf = executable(
       sw_test_name + '_' + device_name,
-      sources: ['main.c'],
       name_suffix: 'elf',
       dependencies: [
         riscv_crt,
         device_lib,
         sw_test_lib,
-        sw_lib_uart,
         sw_lib_irq_handlers,
-        sw_lib_base_log,
-        sw_lib_base_print,
-        sw_lib_testing_test_status,
+        sw_lib_testing_test_main,
       ],
     )
 


### PR DESCRIPTION
This change makes it so the old `main.c` under `sw/device/tests` lives
alongside its header, `test_main.h`, forming a complete library that
pulls in all the relevant dependencies. This makes the linking process
for an on-device test more straightforward.

`main()` doesn't actually need to be in one of the main object files, as
far as our linker scripts care; our CRT requests a `main` symbol, and
that gets pulled in regardless of where it's defined.

Coincidentally, this discovered a missing include in testing.h...