### PR TITLE
[usbdev] Fixes for I/O modes and expand their tests

### DIFF
--- a/hw/dv/dpi/usbdpi/foursim.sh
+++ b/hw/dv/dpi/usbdpi/foursim.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+echo "Simulation with normal pins, singleended"
+build/lowrisc_systems_top_earlgrey_verilator_0.1/sim-verilator/Vtop_earlgrey_verilator   --meminit=rom,build-bin/sw/device/boot_rom/boot_rom_sim_verilator.elf   --meminit=flash,build-bin/sw/device/examples/hello_usbdev/hello_usbdev_sim_verilator.elf -c 695965 &
+sleep 1
+echo 'l01 l00' > /home/mdh/github/opentitan/gpio0-write && cat /home/mdh/github/opentitan/usb0 | tee usb-post-00.log
+cp uart0.log uart-00.log
+
+echo "Simulation with flipped pins, singleended"
+build/lowrisc_systems_top_earlgrey_verilator_0.1/sim-verilator/Vtop_earlgrey_verilator   --meminit=rom,build-bin/sw/device/boot_rom/boot_rom_sim_verilator.elf   --meminit=flash,build-bin/sw/device/examples/hello_usbdev/hello_usbdev_sim_verilator.elf -c 695965 &
+sleep 1
+echo 'l01 h00' > /home/mdh/github/opentitan/gpio0-write && cat /home/mdh/github/opentitan/usb0 | tee usb-post-01.log
+cp uart0.log uart-01.log
+
+echo "Simulation with normal pins, differential"
+build/lowrisc_systems_top_earlgrey_verilator_0.1/sim-verilator/Vtop_earlgrey_verilator   --meminit=rom,build-bin/sw/device/boot_rom/boot_rom_sim_verilator.elf   --meminit=flash,build-bin/sw/device/examples/hello_usbdev/hello_usbdev_sim_verilator.elf -c 695965 &
+sleep 1
+echo 'h01 l00' > /home/mdh/github/opentitan/gpio0-write && cat /home/mdh/github/opentitan/usb0 | tee usb-post-10.log
+cp uart0.log uart-10.log
+
+echo "Simulation with flipped pins, differential"
+build/lowrisc_systems_top_earlgrey_verilator_0.1/sim-verilator/Vtop_earlgrey_verilator   --meminit=rom,build-bin/sw/device/boot_rom/boot_rom_sim_verilator.elf   --meminit=flash,build-bin/sw/device/examples/hello_usbdev/hello_usbdev_sim_verilator.elf -c 695965 &
+sleep 1
+echo 'h01 h00' > /home/mdh/github/opentitan/gpio0-write && cat /home/mdh/github/opentitan/usb0 | tee usb-post-11.log
+cp uart0.log uart-11.log
+
+echo "Check 01 against 00"
+diff usb-post-01.log usb-post-00.log
+diff uart-01.log uart-00.log
+
+echo "Check 10 against 00"
+diff usb-post-10.log usb-post-00.log
+diff uart-10.log uart-00.log
+
+echo "Check 11 against 00"
+diff usb-post-11.log usb-post-00.log
+diff uart-11.log uart-00.log
+
+

--- a/hw/dv/dpi/usbdpi/usbdpi.h
+++ b/hw/dv/dpi/usbdpi/usbdpi.h
@@ -29,16 +29,25 @@
 #define INSERT_ERR_PID 0
 #define INSERT_ERR_BITSTUFF 0
 
-#define D2P_BITS 5
-#define D2P_DP 16
-#define D2P_DP_EN 8
-#define D2P_DN 4
-#define D2P_DN_EN 2
-#define D2P_PU 1
+#define D2P_BITS 11
+#define D2P_DP 1024
+#define D2P_DP_EN 512
+#define D2P_DN 256
+#define D2P_DN_EN 128
+#define D2P_D 64
+#define D2P_D_EN 32
+#define D2P_SE0 16
+#define D2P_SE0_EN 8
+#define D2P_DPPU 4
+#define D2P_DNPU 2
+#define D2P_TXMODE_SE 1
+// Either pullup (dp/dn swapped if the pullup is on DN)
+#define D2P_PU (D2P_DPPU | D2P_DNPU)
 
 #define P2D_SENSE 1
 #define P2D_DN 2
 #define P2D_DP 4
+#define P2D_D 8
 
 #define ST_IDLE 0
 #define ST_SEND 1
@@ -91,6 +100,7 @@ struct usbdpi_ctx {
   int loglevel;
   char fifo_pathname[PATH_MAX];
   void *mon;
+  int last_pu;
   int lastrxpid;
   int tick;
   int tick_bits;

--- a/hw/dv/dpi/usbdpi/usbdpi.sv
+++ b/hw/dv/dpi/usbdpi/usbdpi.sv
@@ -6,6 +6,7 @@
 
 // Bits in LOG_LEVEL sets what is output on socket
 // 0x01 -- monitor_usb (packet level)
+// 0x02 -- more verbose monitor
 // 0x08 -- bit level
 
 module usbdpi #(
@@ -21,21 +22,31 @@ module usbdpi #(
   output logic dn_p2d,
   input  logic dn_d2p,
   input  logic dn_en_d2p,
+  output logic d_p2d,
+  input  logic d_d2p,
+  input  logic d_en_d2p,
+  input  logic se0_d2p,
+  input  logic se0_en_d2p,
+  input  logic txmode_d2p,
+  input  logic txmode_en_d2p,
+
   output logic sense_p2d,
-  input  logic pullup_d2p,
-  input  logic pullup_en_d2p
+  input  logic pullupdp_d2p,
+  input  logic pullupdp_en_d2p,
+  input  logic pullupdn_d2p,
+  input  logic pullupdn_en_d2p
 );
   import "DPI-C" function
     chandle usbdpi_create(input string name, input int loglevel);
 
   import "DPI-C" function
-    void usbdpi_device_to_host(input chandle ctx, input bit [4:0] d2p);
+    void usbdpi_device_to_host(input chandle ctx, input bit [10:0] d2p);
 
   import "DPI-C" function
     void usbdpi_close(input chandle ctx);
 
   import "DPI-C" function
-    byte usbdpi_host_to_device(input chandle ctx, input bit [4:0] d2p);
+    byte usbdpi_host_to_device(input chandle ctx, input bit [10:0] d2p);
 
   chandle ctx;
 
@@ -47,32 +58,39 @@ module usbdpi #(
     usbdpi_close(ctx);
   end
 
-  logic [4:0] d2p;
-  logic [4:0] d2p_r;
+  logic [10:0] d2p;
+  logic [10:0] d2p_r;
   logic       unused_dummy;
   logic       unused_clk = clk_i;
   logic       unused_rst = rst_ni;
-  logic       dp_int, dn_int;
+  logic       dp_int, dn_int, d_int;
 
-  assign d2p = {dp_d2p, dp_en_d2p, dn_d2p, dn_en_d2p, pullup_d2p & pullup_en_d2p};
+  assign d2p = {dp_d2p, dp_en_d2p, dn_d2p, dn_en_d2p, d_d2p, d_en_d2p, se0_d2p, se0_en_d2p, pullupdp_d2p & pullupdp_en_d2p, pullupdn_d2p & pullupdn_en_d2p, txmode_d2p & txmode_en_d2p};
   always_ff @(posedge clk_48MHz_i) begin
-    if (pullup_d2p && pullup_en_d2p) begin
+    if ((pullupdp_d2p && pullupdp_en_d2p) || (pullupdn_d2p && pullupdn_en_d2p)) begin
       automatic byte p2d = usbdpi_host_to_device(ctx, d2p);
+      d_int <= p2d[3];
       dp_int <= p2d[2];
       dn_int <= p2d[1];
       sense_p2d <= p2d[0];
-      unused_dummy <= |p2d[7:3];
+      unused_dummy <= |p2d[7:4];
       d2p_r <= d2p;
       if (d2p_r != d2p) begin
         usbdpi_device_to_host(ctx, d2p);
       end
-    end else begin
+    end else begin // if (pullupdp_d2p && pullupdp_en_d2p)
+      d_int <= 0;
       dp_int <= 0;
       dn_int <= 0;
     end
   end
 
   always_comb begin : proc_data
+    if (d_en_d2p) begin
+      d_p2d = d_d2p;
+    end else begin
+      d_p2d = d_int;
+    end
     if (dp_en_d2p) begin
       dp_p2d = dp_d2p;
     end else begin

--- a/hw/ip/usb_fs_nb_pe/rtl/usb_fs_nb_pe.sv
+++ b/hw/ip/usb_fs_nb_pe/rtl/usb_fs_nb_pe.sv
@@ -26,6 +26,7 @@ module usb_fs_nb_pe #(
   input  logic [6:0]             dev_addr_i,
 
   input  logic                   cfg_eop_single_bit_i, // 1: detect a single SE0 bit as EOP
+  input  logic                   cfg_rx_differential_i, // 1: use differential rx data on usb_d_i
   input  logic                   tx_osc_test_mode_i, // Oscillator test mode (constantly output JK)
   input  logic [NumOutEps-1:0]   data_toggle_clear_i, // Clear the data toggles for an EP
 
@@ -66,17 +67,25 @@ module usb_fs_nb_pe #(
   output logic                   sof_valid_o,
   output logic [10:0]            frame_index_o,
 
+  // RX line status
+  output logic                   rx_se0_det_o,
+  output logic                   rx_jjj_det_o,
+
   // RX errors
   output logic                   rx_crc_err_o,
   output logic                   rx_pid_err_o,
   output logic                   rx_bitstuff_err_o,
 
   ///////////////////////////////////////
-  // USB TX/RX Interface (synchronous) //
+  // USB RX Interface (asynchronous)   //
   ///////////////////////////////////////
   input  logic                   usb_d_i,
-  input  logic                   usb_se0_i,
+  input  logic                   usb_dp_i,
+  input  logic                   usb_dn_i,
 
+  ///////////////////////////////////////
+  // USB TX Interface (synchronous)    //
+  ///////////////////////////////////////
   output logic                   usb_d_o,
   output logic                   usb_se0_o,
   output logic                   usb_oe_o
@@ -203,8 +212,10 @@ module usb_fs_nb_pe #(
     .rst_ni                 (rst_ni),
     .link_reset_i           (link_reset_i),
     .cfg_eop_single_bit_i   (cfg_eop_single_bit_i),
+    .cfg_rx_differential_i  (cfg_rx_differential_i),
     .usb_d_i                (usb_d_i),
-    .usb_se0_i              (usb_se0_i),
+    .usb_dp_i               (usb_dp_i),
+    .usb_dn_i               (usb_dn_i),
     .tx_en_i                (usb_oe),
     .bit_strobe_o           (bit_strobe),
     .pkt_start_o            (rx_pkt_start),
@@ -216,6 +227,8 @@ module usb_fs_nb_pe #(
     .rx_data_put_o          (rx_data_put),
     .rx_data_o              (rx_data),
     .valid_packet_o         (rx_pkt_valid),
+    .rx_se0_det_o           (rx_se0_det_o),
+    .rx_jjj_det_o           (rx_jjj_det_o),
     .crc_error_o            (rx_crc_err_o),
     .pid_error_o            (rx_pid_err_o),
     .bitstuff_error_o       (rx_bitstuff_err_o)

--- a/hw/ip/usb_fs_nb_pe/rtl/usb_fs_nb_pe.sv
+++ b/hw/ip/usb_fs_nb_pe/rtl/usb_fs_nb_pe.sv
@@ -77,7 +77,7 @@ module usb_fs_nb_pe #(
   output logic                   rx_bitstuff_err_o,
 
   ///////////////////////////////////////
-  // USB RX Interface (asynchronous)   //
+  // USB RX Interface (synchronous)    //
   ///////////////////////////////////////
   input  logic                   usb_d_i,
   input  logic                   usb_dp_i,

--- a/hw/ip/usb_fs_nb_pe/rtl/usb_fs_rx.sv
+++ b/hw/ip/usb_fs_nb_pe/rtl/usb_fs_rx.sv
@@ -10,12 +10,14 @@ module usb_fs_rx (
   input  logic rst_ni,
   input  logic link_reset_i,
 
-  // EOP configuration
+  // configuration
   input  logic cfg_eop_single_bit_i,
+  input  logic cfg_rx_differential_i,
 
-  // USB data+ and data- lines (synchronous)
+  // USB data+ and data- lines (asynchronous from pin)
   input  logic usb_d_i,
-  input  logic usb_se0_i,
+  input  logic usb_dp_i,
+  input  logic usb_dn_i,
 
   // Transmit enable disables the receier
   input  logic tx_en_i,
@@ -42,6 +44,10 @@ module usb_fs_rx (
   // Most recent packet passes PID and CRC checks
   output logic valid_packet_o,
 
+  // line status for the status detection (actual rx bits after clock recovery)
+  output logic rx_se0_det_o,
+  output logic rx_jjj_det_o,
+
   // Error detection
   output logic crc_error_o,
   output logic pid_error_o,
@@ -56,12 +62,13 @@ module usb_fs_rx (
   // usb receive path //
   //////////////////////
 
+   
   ///////////////////////////////////////
   // line state recovery state machine //
   ///////////////////////////////////////
 
-  // The receive path doesn't currently use a differential reciever.  because of
-  // this there is a chance that one of the differential pairs will appear to have
+  // If the receive path is set not to use a differential reciever:
+  // There is a chance that one of the differential pairs will appear to have
   // changed to the new state while the other is still in the old state.  the
   // following state machine detects transitions and waits an extra sampling clock
   // before decoding the state on the differential pair.  this transition period
@@ -69,31 +76,51 @@ module usb_fs_rx (
   // if there is enough noise on the line then the data may be corrupted and the
   // packet will fail the data integrity checks.
 
+  // If the receive path uses a differential receiver:
+  // The single ended signals must still be recovered to detect SE0
+  // Note that the spec warns in section 7.1.4.1:
+  // Both D+ and D- may temporarily be less than VIH (min) during differential
+  // signal transitions. This period can be up to 14 ns (TFST) for full-speed
+  // transitions and up to 210 ns (TLST) for low-speed transitions. Logic in the
+  // receiver must ensure that that this is not interpreted as an SE0.
+  // Since the 48MHz sample clock is 20.833ns period we will either miss this or
+  // sample it only once, so it will be covered by line_state=DT and the next
+  // sample will not be SE0 unless this was a real SE0 transition
+  // Note: if it is a real SE0 the differential rx could be doing anything
+
   logic [2:0] line_state_q, line_state_d;
+  logic [2:0] diff_state_q, diff_state_d;
+  logic [2:0] line_state_rx;
+   
   localparam logic [2:0]  DT = 3'b100; // transition state
   localparam logic [2:0]  DJ = 3'b010; // J - idle line state
-  // localparam logic [2:0]  DK = 3'b001; // K - inverse of J
+  localparam logic [2:0]  DK = 3'b001; // K - inverse of J
   localparam logic [2:0] SE0 = 3'b000; // single-ended 0 - end of packet or detached
   // localparam logic [2:0] SE1 = 3'b011; // single-ended 1 - illegal
 
   // Mute the input if we're transmitting
-  logic [1:0] dpair;
+  logic [1:0] dpair, ddiff;
   always_comb begin : proc_dpair_mute
     if (tx_en_i) begin
       dpair = DJ[1:0]; // J
+      ddiff = DJ[1:0]; // J
     end else begin
-      dpair = (usb_se0_i) ? 2'b00 : {usb_d_i, ~usb_d_i};
+      dpair = {usb_dp_i, usb_dn_i};
+      ddiff = usb_d_i ? DJ[1:0] : DK[1:0]; // equiv to {usb_d_i, ~usb_d_i}
     end
   end
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : proc_line_state_q
     if (!rst_ni) begin
       line_state_q <= SE0;
+      diff_state_q <= SE0;
     end else begin
       if (link_reset_i) begin
         line_state_q <= SE0;
+        diff_state_q <= SE0;
       end else begin
         line_state_q <= line_state_d;
+        diff_state_q <= diff_state_d;
       end
     end
   end
@@ -116,6 +143,45 @@ module usb_fs_rx (
     end
   end
 
+  always_comb begin : proc_diff_state_d
+    // Default assignment
+    diff_state_d = diff_state_q;
+
+    if (diff_state_q == DT) begin
+      // if we are in a transition state, then we can sample the diff input and
+      // move to the next corresponding line state
+      diff_state_d = {1'b0, ddiff};
+
+    end else begin
+      // if we are in a valid line state and the value of the diff input changes,
+      // then we need to move to the transition state
+      if (ddiff != diff_state_q[1:0]) begin
+        diff_state_d = DT;
+      end
+    end
+  end
+
+  // The received line state depends on how the receiver is configured:
+  // Single ended only: it is just the line_state_q that was captured
+  //
+  // Differential: recovered from the differential receiver (diff_state_q)
+  //               unless the single ended indicate SE0 when the differential
+  //               receiver could produce any value
+  //
+  // Transition where single ended happens to see SE0 look like (driven by diff DT)
+  // line_state    D? DT D?...
+  // diff_state    Dx DT Dy
+  // Transition to SE0 will look like:
+  // line_state    D? DT SE0 SE0... (DT is the first sample at SE0)
+  // diff_state    Dx DT ??  ??...  (diff saw transition as line went SE0)
+  //    --> out    Dx DT SE0 SE0
+  // line_state    D? DT SE0 SE0... (DT is the first sample at SE0)
+  // diff_state    Dx Dx ??  ??...  (diff no transition as line went SE0)
+  //    --> out    Dx Dx SE0 SE0
+
+  assign line_state_rx = cfg_rx_differential_i ? ((line_state_q == SE0) ? SE0 : diff_state_q) :
+                                                 line_state_q;
+
   ////////////////////
   // clock recovery //
   ////////////////////
@@ -137,7 +203,7 @@ module usb_fs_rx (
   assign bit_strobe_o     = (bit_phase_q == 2'd2);
 
   // keep track of phase within each bit
-  assign bit_phase_d = (line_state_q == DT) ? 0 : bit_phase_q + 1;
+  assign bit_phase_d = (line_state_rx == DT) ? 0 : bit_phase_q + 1;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : proc_bit_phase_q
     if (!rst_ni) begin
@@ -193,7 +259,7 @@ module usb_fs_rx (
   end
 
   // keep a history of the last two states on the line
-  assign line_history_d = line_state_valid ? {line_history_q[9:0], line_state_q[1:0]} :
+  assign line_history_d = line_state_valid ? {line_history_q[9:0], line_state_rx[1:0]} :
                                               line_history_q;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : proc_reg_pkt_line
@@ -211,6 +277,9 @@ module usb_fs_rx (
     end
   end
 
+  // mask out jjj detection when tranmitting (because rx is forced to J)
+  assign rx_se0_det_o = line_history_q[5:0] == 6'b000000; // three SE0s
+  assign rx_jjj_det_o = ~tx_en_i & (line_history_q[5:0] == 6'b101010); // three Js
 
   /////////////////
   // NRZI decode //

--- a/hw/ip/usb_fs_nb_pe/rtl/usb_fs_rx.sv
+++ b/hw/ip/usb_fs_nb_pe/rtl/usb_fs_rx.sv
@@ -14,7 +14,7 @@ module usb_fs_rx (
   input  logic cfg_eop_single_bit_i,
   input  logic cfg_rx_differential_i,
 
-  // USB data+ and data- lines (asynchronous from pin)
+  // USB data+ and data- lines (synchronous)
   input  logic usb_d_i,
   input  logic usb_dp_i,
   input  logic usb_dn_i,
@@ -170,7 +170,7 @@ module usb_fs_rx (
   //
   // Transition where single ended happens to see SE0 look like (driven by diff DT)
   // line_state    D? DT D?...
-  // diff_state    Dx DT Dy
+  // diff_state    Dx DT Dy         (expect Dy to be inverse of Dx since diff changed)
   // Transition to SE0 will look like:
   // line_state    D? DT SE0 SE0... (DT is the first sample at SE0)
   // diff_state    Dx DT ??  ??...  (diff saw transition as line went SE0)
@@ -277,7 +277,7 @@ module usb_fs_rx (
     end
   end
 
-  // mask out jjj detection when tranmitting (because rx is forced to J)
+  // mask out jjj detection when transmitting (because rx is forced to J)
   assign rx_se0_det_o = line_history_q[5:0] == 6'b000000; // three SE0s
   assign rx_jjj_det_o = ~tx_en_i & (line_history_q[5:0] == 6'b101010); // three Js
 

--- a/hw/ip/usbdev/data/usbdev.hjson
+++ b/hw/ip/usbdev/data/usbdev.hjson
@@ -209,14 +209,17 @@
               name: "suspend",
               desc: "Link suspended (constant idle for > 3 ms), was active before becoming suspended"
             },
-
+            { value: "5",
+              name: "active_nosof",
+              desc: "Link active but no SOF has been received since the last reset."
+            },
           ]
         }
         {
           bits: "15",
           name: "sense",
           desc: '''
-                Reflects the state of the sense pin. 1 indicates that the host is providing VBUS.
+                Reflects the state of the sense pin. 1 indicates that the host is providing VBUS. Note that this bit always shows the state of the actual pin and does not take account of the override control.
                 '''
         }
         {

--- a/hw/ip/usbdev/data/usbdev.hjson
+++ b/hw/ip/usbdev/data/usbdev.hjson
@@ -219,7 +219,9 @@
           bits: "15",
           name: "sense",
           desc: '''
-                Reflects the state of the sense pin. 1 indicates that the host is providing VBUS. Note that this bit always shows the state of the actual pin and does not take account of the override control.
+                Reflects the state of the sense pin.
+		1 indicates that the host is providing VBUS.
+		Note that this bit always shows the state of the actual pin and does not take account of the override control.
                 '''
         }
         {

--- a/hw/ip/usbdev/rtl/usbdev.sv
+++ b/hw/ip/usbdev/rtl/usbdev.sv
@@ -141,10 +141,14 @@ module usbdev (
 
 
   /////////////////////////////////
-  // USB IO after CDC & muxing   //
+  // USB IO after muxing (async) //
   /////////////////////////////////
   logic usb_rx_d;
-  logic usb_rx_se0;
+  logic usb_rx_dp;
+  logic usb_rx_dn;
+  /////////////////////////////////
+  // USB IO after CDC & muxing   //
+  /////////////////////////////////
   logic usb_tx_d;
   logic usb_tx_se0;
   logic usb_tx_oe;
@@ -465,7 +469,8 @@ module usbdev (
 
     // Pins
     .usb_d_i              (usb_rx_d),
-    .usb_se0_i            (usb_rx_se0),
+    .usb_dp_i             (usb_rx_dp),
+    .usb_dn_i             (usb_rx_dn),
     .usb_oe_o             (usb_tx_oe),
     .usb_d_o              (usb_tx_d),
     .usb_se0_o            (usb_tx_se0),
@@ -509,6 +514,7 @@ module usbdev (
     .clr_devaddr_o        (usb_clr_devaddr),
     .ep_iso_i             (ep_iso), // cdc ok, quasi-static
     .cfg_eop_single_bit_i (reg2hw.phy_config.eop_single_bit.q), // cdc ok: quasi-static
+    .cfg_rx_differential_i (reg2hw.phy_config.rx_differential_mode.q), // cdc ok: quasi-static
     .tx_osc_test_mode_i   (1'b0), // cdc ok: quasi-static & testmode only
     .data_toggle_clear_i  (usb_data_toggle_clear),
 
@@ -904,7 +910,8 @@ module usbdev (
 
     // Internal interface
     .usb_rx_d_o             (usb_rx_d),
-    .usb_rx_se0_o           (usb_rx_se0),
+    .usb_rx_dp_o            (usb_rx_dp),
+    .usb_rx_dn_o            (usb_rx_dn),
     .usb_tx_d_i             (usb_tx_d),
     .usb_tx_se0_i           (usb_tx_se0),
     .usb_tx_oe_i            (usb_tx_oe),

--- a/hw/ip/usbdev/rtl/usbdev.sv
+++ b/hw/ip/usbdev/rtl/usbdev.sv
@@ -141,7 +141,7 @@ module usbdev (
 
 
   /////////////////////////////////
-  // USB IO after muxing (async) //
+  // USB RX after CDC & muxing   //
   /////////////////////////////////
   logic usb_rx_d;
   logic usb_rx_dp;

--- a/hw/ip/usbdev/rtl/usbdev_linkstate.sv
+++ b/hw/ip/usbdev/rtl/usbdev_linkstate.sv
@@ -10,8 +10,8 @@ module usbdev_linkstate (
   input  logic rst_ni,
   input  logic us_tick_i,
   input  logic usb_sense_i,
-  input  logic usb_rx_d_i,
-  input  logic usb_rx_se0_i,
+  input  logic rx_se0_det_i,
+  input  logic rx_jjj_det_i,
   input  logic sof_valid_i,
   output logic link_disconnect_o,  // level
   output logic link_connect_o,     // level
@@ -35,6 +35,7 @@ module usbdev_linkstate (
     LinkPoweredSuspend = 2,
     // Active states
     LinkActive = 3,
+    LinkActiveNoSOF = 5,
     LinkSuspend = 4
   } link_state_e;
 
@@ -51,8 +52,7 @@ module usbdev_linkstate (
   } link_inac_state_e;
 
   link_state_e  link_state_d, link_state_q;
-  logic         line_se0_raw, line_idle_raw;
-  logic         see_se0, see_idle, see_pwr_sense;
+  logic         see_pwr_sense;
 
   // Reset FSM
   logic [2:0]      link_rst_timer_d, link_rst_timer_q;
@@ -75,31 +75,10 @@ module usbdev_linkstate (
   assign link_connect_o    = (link_state_q != LinkDisconnect);
   assign link_suspend_o    = (link_state_q == LinkSuspend ||
     link_state_q == LinkPoweredSuspend);
-  assign link_active_o     = (link_state_q == LinkActive);
+  assign link_active_o     = (link_state_q == LinkActive) ||
+    (link_state_q == LinkActiveNoSOF);
   // Link state is stable, so we can output it to the register
   assign link_state_o      =  link_state_q;
-
-  assign line_se0_raw = usb_rx_se0_i;
-  assign line_idle_raw = usb_rx_d_i && !usb_rx_se0_i; // same as J
-
-  // four ticks is a bit time
-  // Could completely filter out 2-cycle EOP SE0 here but
-  // does not seem needed
-  prim_filter #(.Cycles(6)) filter_se0 (
-    .clk_i    (clk_48mhz_i),
-    .rst_ni   (rst_ni),
-    .enable_i (1'b1),
-    .filter_i (line_se0_raw),
-    .filter_o (see_se0)
-  );
-
-  prim_filter #(.Cycles(6)) filter_idle (
-    .clk_i    (clk_48mhz_i),
-    .rst_ni   (rst_ni),
-    .enable_i (1'b1),
-    .filter_i (line_idle_raw),
-    .filter_o (see_idle)
-  );
 
   prim_filter #(.Cycles(6)) filter_pwr_sense (
     .clk_i    (clk_48mhz_i),
@@ -110,13 +89,14 @@ module usbdev_linkstate (
   );
 
   // Simple events
-  assign ev_bus_active = !see_idle;
+  assign ev_bus_active = !rx_jjj_det_i;
+   
+  assign monitor_inac = see_pwr_sense ? ((link_state_q == LinkPowered) | link_active_o) :
+                        1'b0;
 
   always_comb begin
     link_state_d = link_state_q;
     link_resume_o = 0;
-    monitor_inac = see_pwr_sense ? ((link_state_q == LinkPowered) | (link_state_q == LinkActive)) :
-                                   1'b0;
 
     // If VBUS ever goes away the link has disconnected
     if (!see_pwr_sense) begin
@@ -132,7 +112,7 @@ module usbdev_linkstate (
 
         LinkPowered: begin
           if (ev_reset) begin
-            link_state_d = LinkActive;
+            link_state_d = LinkActiveNoSOF;
           end else if (ev_bus_inactive) begin
             link_state_d = LinkPoweredSuspend;
           end
@@ -140,7 +120,7 @@ module usbdev_linkstate (
 
         LinkPoweredSuspend: begin
           if (ev_reset) begin
-            link_state_d = LinkActive;
+            link_state_d = LinkActiveNoSOF;
           end else if (ev_bus_active) begin
             link_resume_o = 1;
             link_state_d  = LinkPowered;
@@ -148,14 +128,28 @@ module usbdev_linkstate (
         end
 
         // Active (USB spec: Default / Address / Configured)
+        LinkActiveNoSOF: begin
+          if (ev_bus_inactive) begin
+            link_state_d = LinkSuspend;
+          end else if (sof_valid_i) begin
+            link_state_d = LinkActive;
+          end
+        end
+
+        // Active (USB spec: Default / Address / Configured)
         LinkActive: begin
           if (ev_bus_inactive) begin
             link_state_d = LinkSuspend;
+          end else if (ev_reset) begin
+            link_state_d = LinkActiveNoSOF;
           end
         end
 
         LinkSuspend: begin
-          if (ev_reset || ev_bus_active) begin
+          if (ev_reset) begin
+            link_resume_o = 1;
+            link_state_d  = LinkActiveNoSOF;
+          end else if (ev_bus_active) begin
             link_resume_o = 1;
             link_state_d  = LinkActive;
           end
@@ -191,7 +185,7 @@ module usbdev_linkstate (
     unique case (link_rst_state_q)
       // No reset signal detected
       NoRst: begin
-        if (see_se0) begin
+        if (rx_se0_det_i) begin
           link_rst_state_d = RstCnt;
           link_rst_timer_d = 0;
         end
@@ -199,7 +193,7 @@ module usbdev_linkstate (
 
       // Reset signal detected -> counting
       RstCnt: begin
-        if (!see_se0) begin
+        if (!rx_se0_det_i) begin
           link_rst_state_d = NoRst;
         end else begin
           if (us_tick_i) begin
@@ -214,7 +208,7 @@ module usbdev_linkstate (
 
       // Detected reset -> wait for falling edge
       RstPend: begin
-        if (!see_se0) begin
+        if (!rx_se0_det_i) begin
           link_rst_state_d = NoRst;
           ev_reset = 1'b1;
         end
@@ -251,14 +245,14 @@ module usbdev_linkstate (
       // Active or disabled
       Active: begin
         link_inac_timer_d = 0;
-        if (see_idle && monitor_inac) begin
+        if (!ev_bus_active && monitor_inac) begin
           link_inac_state_d = InactCnt;
         end
       end
 
       // Got an inactivity signal -> count duration
       InactCnt: begin
-        if (!see_idle || !monitor_inac) begin
+        if (ev_bus_active || !monitor_inac) begin
           link_inac_state_d  = Active;
         end else if (us_tick_i) begin
           if (link_inac_timer_q == SUSPEND_TIMEOUT) begin
@@ -272,7 +266,7 @@ module usbdev_linkstate (
 
       // Counter expired & event sent, wait here
       InactPend: begin
-        if (!see_idle || !monitor_inac) begin
+        if (ev_bus_active || !monitor_inac) begin
           link_inac_state_d  = Active;
         end
       end

--- a/hw/ip/usbdev/rtl/usbdev_linkstate.sv
+++ b/hw/ip/usbdev/rtl/usbdev_linkstate.sv
@@ -127,7 +127,10 @@ module usbdev_linkstate (
           end
         end
 
-        // Active (USB spec: Default / Address / Configured)
+        // Active but not yet seen a frame
+	// One reason for getting stuck here is the host thinks it is a LS link
+	// which could happen if the flipped bit does not match the actual pins
+	// Annother is the SI is bad so good data is not recovered from the link
         LinkActiveNoSOF: begin
           if (ev_bus_inactive) begin
             link_state_d = LinkSuspend;

--- a/hw/ip/usbdev/rtl/usbdev_usbif.sv
+++ b/hw/ip/usbdev/rtl/usbdev_usbif.sv
@@ -22,10 +22,12 @@ module usbdev_usbif  #(
   input  logic                     clk_48mhz_i, // 48MHz USB clock
   input  logic                     rst_ni,
 
-  // Pins (synchronous)
+  // Pins (asynchronous)
   input  logic                     usb_d_i,
-  input  logic                     usb_se0_i,
+  input  logic                     usb_dp_i,
+  input  logic                     usb_dn_i,
 
+  // Pins (synchronous)
   output logic                     usb_d_o,
   output logic                     usb_se0_o,
   output logic                     usb_oe_o,
@@ -70,6 +72,7 @@ module usbdev_usbif  #(
   output logic                     clr_devaddr_o,
   input  logic [NEndpoints-1:0]    ep_iso_i,
   input  logic                     cfg_eop_single_bit_i, // 1: detect a single SE0 bit as EOP
+  input  logic                     cfg_rx_differential_i, // 1: use differential rx data on usb_d_i
   input  logic                     tx_osc_test_mode_i, // Oscillator test mode: constant JK output
   input  logic [NEndpoints-1:0]    data_toggle_clear_i, // Clear the data toggles for an EP
 
@@ -253,7 +256,8 @@ module usbdev_usbif  #(
   assign set_sent_o = in_ep_acked;
 
   logic [10:0]     frame_index_raw;
-
+  logic 	   rx_se0_det, rx_jjj_det;
+   
   usb_fs_nb_pe #(
     .NumOutEps      (NEndpoints),
     .NumInEps       (NEndpoints),
@@ -264,11 +268,13 @@ module usbdev_usbif  #(
     .link_reset_i          (link_reset),
 
     .cfg_eop_single_bit_i  (cfg_eop_single_bit_i),
+    .cfg_rx_differential_i (cfg_rx_differential_i),
     .tx_osc_test_mode_i    (tx_osc_test_mode_i),
     .data_toggle_clear_i   (data_toggle_clear_i),
 
     .usb_d_i               (usb_d_i),
-    .usb_se0_i             (usb_se0_i),
+    .usb_dp_i              (usb_dp_i),
+    .usb_dn_i              (usb_dn_i),
     .usb_d_o               (usb_d_o),
     .usb_se0_o             (usb_se0_o),
     .usb_oe_o              (usb_oe_o),
@@ -300,6 +306,10 @@ module usbdev_usbif  #(
     .in_ep_data_i          (in_ep_data),
     .in_ep_data_done_i     (in_ep_data_done),
     .in_ep_iso_i           (ep_iso_i),
+
+    // rx status
+    .rx_se0_det_o          (rx_se0_det),
+    .rx_jjj_det_o          (rx_jjj_det),
 
     // error signals
     .rx_crc_err_o          (rx_crc_err_o),
@@ -344,8 +354,8 @@ module usbdev_usbif  #(
     .rst_ni            (rst_ni),
     .us_tick_i         (us_tick),
     .usb_sense_i       (usb_sense_i),
-    .usb_rx_d_i        (usb_d_i),
-    .usb_rx_se0_i      (usb_se0_i),
+    .rx_se0_det_i      (rx_se0_det),
+    .rx_jjj_det_i      (rx_jjj_det),
     .sof_valid_i       (sof_valid),
     .link_disconnect_o (link_disconnect_o),
     .link_connect_o    (link_connect_o),

--- a/hw/ip/usbdev/rtl/usbdev_usbif.sv
+++ b/hw/ip/usbdev/rtl/usbdev_usbif.sv
@@ -22,12 +22,11 @@ module usbdev_usbif  #(
   input  logic                     clk_48mhz_i, // 48MHz USB clock
   input  logic                     rst_ni,
 
-  // Pins (asynchronous)
+  // Pins (synchronous)
   input  logic                     usb_d_i,
   input  logic                     usb_dp_i,
   input  logic                     usb_dn_i,
 
-  // Pins (synchronous)
   output logic                     usb_d_o,
   output logic                     usb_se0_o,
   output logic                     usb_oe_o,

--- a/hw/top_earlgrey/data/pins_nexysvideo.xdc
+++ b/hw/top_earlgrey/data/pins_nexysvideo.xdc
@@ -121,16 +121,29 @@ set_property -dict { PACKAGE_PIN M17  IOSTANDARD LVCMOS12 } [get_ports { IO_GP7 
 #set_property -dict { PACKAGE_PIN AA18  IOSTANDARD LVCMOS33 } [get_ports { IO_GP7 }]; #IO_L17P_T2_A14_D30_14 Sch=ja[10]
 
 
-## Pmod header JB
+## Pmod header JB -- NORMAL USE
 set_property -dict { PACKAGE_PIN V9    IOSTANDARD LVCMOS33 DRIVE 8 SLEW FAST } [get_ports { IO_USB_DP0 }]; #IO_L21P_T3_DQS_34 Sch=jb_p[1]
 set_property -dict { PACKAGE_PIN V8    IOSTANDARD LVCMOS33 DRIVE 8 SLEW FAST } [get_ports { IO_USB_DN0 }]; #IO_L21N_T3_DQS_34 Sch=jb_n[1]
 set_property -dict { PACKAGE_PIN V7    IOSTANDARD LVCMOS33 } [get_ports { IO_USB_DPPULLUP0 }]; #IO_L19P_T3_34 Sch=jb_p[2]
 set_property -dict { PACKAGE_PIN W7    IOSTANDARD LVCMOS33 } [get_ports { IO_USB_SENSE0 }]; #IO_L19N_T3_VREF_34 Sch=jb_n[2]
+set_property -dict { PACKAGE_PIN Y8    IOSTANDARD LVCMOS33 } [get_ports { IO_USB_DNPULLUP0 }]; #IO_L23P_T3_34 Sch=jb_p[4]
+
+############### DEBUG ONLY ########################
+## Pmod header JB -- USE TO TEST PINFLIP         ##
+## This has D+, D-, DPPULLUP, DNPULLUP swapped   ##
+## Comment out the normal use and uncomment this ##
+## for testing                                   ##
+###################################################
+#set_property -dict { PACKAGE_PIN V9    IOSTANDARD LVCMOS33 DRIVE 8 SLEW FAST } [get_ports { IO_USB_DN0 }]; #IO_L21P_T3_DQS_34 Sch=jb_p[1]
+#set_property -dict { PACKAGE_PIN V8    IOSTANDARD LVCMOS33 DRIVE 8 SLEW FAST } [get_ports { IO_USB_DP0 }]; #IO_L21N_T3_DQS_34 Sch=jb_n[1]
+#set_property -dict { PACKAGE_PIN V7    IOSTANDARD LVCMOS33 } [get_ports { IO_USB_DNPULLUP0 }]; #IO_L19P_T3_34 Sch=jb_p[2]
+#set_property -dict { PACKAGE_PIN W7    IOSTANDARD LVCMOS33 } [get_ports { IO_USB_SENSE0 }]; #IO_L19N_T3_VREF_34 Sch=jb_n[2]
+#set_property -dict { PACKAGE_PIN Y8    IOSTANDARD LVCMOS33 } [get_ports { IO_USB_DPPULLUP0 }]; #IO_L23P_T3_34 Sch=jb_p[4]
+
+## Pmod header JB UNUSED pins (used for testing 2 USB interfaces)
 #set_property -dict { PACKAGE_PIN W9    IOSTANDARD LVCMOS33 DRIVE 8 SLEW FAST } [get_ports { IO_USB_DP1 }]; #IO_L24P_T3_34 Sch=jb_p[3]
 #set_property -dict { PACKAGE_PIN Y9    IOSTANDARD LVCMOS33 DRIVE 8 SLEW FAST } [get_ports { IO_USB_DN1 }]; #IO_L24N_T3_34 Sch=jb_n[3]
-set_property -dict { PACKAGE_PIN Y8    IOSTANDARD LVCMOS33 } [get_ports { IO_USB_DNPULLUP0 }]; #IO_L23P_T3_34 Sch=jb_p[4]
 #set_property -dict { PACKAGE_PIN Y7    IOSTANDARD LVCMOS33 } [get_ports { IO_USB_SENSE1 }]; #IO_L23N_T3_34 Sch=jb_n[4]
-
 
 ## Pmod header JC
 #set_property -dict { PACKAGE_PIN Y6    IOSTANDARD LVCMOS33 } [get_ports { IO_SDCK   }]; #IO_L18P_T2_34 Sch=jc_p[1]

--- a/hw/top_earlgrey/data/pins_nexysvideo.xdc
+++ b/hw/top_earlgrey/data/pins_nexysvideo.xdc
@@ -121,24 +121,12 @@ set_property -dict { PACKAGE_PIN M17  IOSTANDARD LVCMOS12 } [get_ports { IO_GP7 
 #set_property -dict { PACKAGE_PIN AA18  IOSTANDARD LVCMOS33 } [get_ports { IO_GP7 }]; #IO_L17P_T2_A14_D30_14 Sch=ja[10]
 
 
-## Pmod header JB -- NORMAL USE
+## Pmod header JB
 set_property -dict { PACKAGE_PIN V9    IOSTANDARD LVCMOS33 DRIVE 8 SLEW FAST } [get_ports { IO_USB_DP0 }]; #IO_L21P_T3_DQS_34 Sch=jb_p[1]
 set_property -dict { PACKAGE_PIN V8    IOSTANDARD LVCMOS33 DRIVE 8 SLEW FAST } [get_ports { IO_USB_DN0 }]; #IO_L21N_T3_DQS_34 Sch=jb_n[1]
 set_property -dict { PACKAGE_PIN V7    IOSTANDARD LVCMOS33 } [get_ports { IO_USB_DPPULLUP0 }]; #IO_L19P_T3_34 Sch=jb_p[2]
 set_property -dict { PACKAGE_PIN W7    IOSTANDARD LVCMOS33 } [get_ports { IO_USB_SENSE0 }]; #IO_L19N_T3_VREF_34 Sch=jb_n[2]
 set_property -dict { PACKAGE_PIN Y8    IOSTANDARD LVCMOS33 } [get_ports { IO_USB_DNPULLUP0 }]; #IO_L23P_T3_34 Sch=jb_p[4]
-
-############### DEBUG ONLY ########################
-## Pmod header JB -- USE TO TEST PINFLIP         ##
-## This has D+, D-, DPPULLUP, DNPULLUP swapped   ##
-## Comment out the normal use and uncomment this ##
-## for testing                                   ##
-###################################################
-#set_property -dict { PACKAGE_PIN V9    IOSTANDARD LVCMOS33 DRIVE 8 SLEW FAST } [get_ports { IO_USB_DN0 }]; #IO_L21P_T3_DQS_34 Sch=jb_p[1]
-#set_property -dict { PACKAGE_PIN V8    IOSTANDARD LVCMOS33 DRIVE 8 SLEW FAST } [get_ports { IO_USB_DP0 }]; #IO_L21N_T3_DQS_34 Sch=jb_n[1]
-#set_property -dict { PACKAGE_PIN V7    IOSTANDARD LVCMOS33 } [get_ports { IO_USB_DNPULLUP0 }]; #IO_L19P_T3_34 Sch=jb_p[2]
-#set_property -dict { PACKAGE_PIN W7    IOSTANDARD LVCMOS33 } [get_ports { IO_USB_SENSE0 }]; #IO_L19N_T3_VREF_34 Sch=jb_n[2]
-#set_property -dict { PACKAGE_PIN Y8    IOSTANDARD LVCMOS33 } [get_ports { IO_USB_DPPULLUP0 }]; #IO_L23P_T3_34 Sch=jb_p[4]
 
 ## Pmod header JB UNUSED pins (used for testing 2 USB interfaces)
 #set_property -dict { PACKAGE_PIN W9    IOSTANDARD LVCMOS33 DRIVE 8 SLEW FAST } [get_ports { IO_USB_DP1 }]; #IO_L24P_T3_34 Sch=jb_p[3]

--- a/hw/top_earlgrey/rtl/top_earlgrey_verilator.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_verilator.sv
@@ -172,37 +172,33 @@ module top_earlgrey_verilator (
 
   // USB DPI
   usbdpi u_usbdpi (
-    .clk_i         (clk_i),
-    .rst_ni        (rst_ni),
-    .clk_48MHz_i   (clk_i),
-    .sense_p2d     (cio_usbdev_sense_p2d),
-    .pullup_d2p    (cio_usbdev_dp_pullup_d2p),
-    .pullup_en_d2p (cio_usbdev_dp_pullup_en_d2p),
-    .dp_p2d        (cio_usbdev_dp_p2d),
-    .dp_d2p        (cio_usbdev_dp_d2p),
-    .dp_en_d2p     (cio_usbdev_dp_en_d2p),
-    .dn_p2d        (cio_usbdev_dn_p2d),
-    .dn_d2p        (cio_usbdev_dn_d2p),
-    .dn_en_d2p     (cio_usbdev_dn_en_d2p)
+    .clk_i           (clk_i),
+    .rst_ni          (rst_ni),
+    .clk_48MHz_i     (clk_i),
+    .sense_p2d       (cio_usbdev_sense_p2d),
+    .pullupdp_d2p    (cio_usbdev_dp_pullup_d2p),
+    .pullupdp_en_d2p (cio_usbdev_dp_pullup_en_d2p),
+    .pullupdn_d2p    (cio_usbdev_dn_pullup_d2p),
+    .pullupdn_en_d2p (cio_usbdev_dn_pullup_en_d2p),
+    .dp_p2d          (cio_usbdev_dp_p2d),
+    .dp_d2p          (cio_usbdev_dp_d2p),
+    .dp_en_d2p       (cio_usbdev_dp_en_d2p),
+    .dn_p2d          (cio_usbdev_dn_p2d),
+    .dn_d2p          (cio_usbdev_dn_d2p),
+    .dn_en_d2p       (cio_usbdev_dn_en_d2p),
+    .d_p2d           (cio_usbdev_d_p2d),
+    .d_d2p           (cio_usbdev_d_d2p),
+    .d_en_d2p        (cio_usbdev_d_en_d2p),
+    .se0_d2p         (cio_usbdev_se0_d2p),
+    .se0_en_d2p      (cio_usbdev_se0_en_d2p),
+    .txmode_d2p      (cio_usbdev_tx_mode_se_d2p),
+    .txmode_en_d2p   (cio_usbdev_tx_mode_se_en_d2p)
   );
 
   // Tie off unused signals.
-  logic unused_cio_usbdev_se0_d2p, unused_cio_usbdev_se0_en_d2p;
-  logic unused_cio_usbdev_dn_pullup_d2p, unused_cio_usbdev_dn_pullup_en_d2p;
-  logic unused_cio_usbdev_tx_mode_se_d2p, unused_cio_usbdev_tx_mode_se_en_d2p;
   logic unused_cio_usbdev_suspend_d2p, unused_cio_usbdev_suspend_en_d2p;
-  logic unused_cio_usbdev_d_d2p, unused_cio_usbdev_d_en_d2p;
-  assign unused_cio_usbdev_se0_d2p = cio_usbdev_se0_d2p;
-  assign unused_cio_usbdev_se0_en_d2p = cio_usbdev_se0_en_d2p;
-  assign unused_cio_usbdev_dn_pullup_d2p = cio_usbdev_dn_pullup_d2p;
-  assign unused_cio_usbdev_dn_pullup_en_d2p = cio_usbdev_dn_pullup_en_d2p;
-  assign unused_cio_usbdev_tx_mode_se_d2p = cio_usbdev_tx_mode_se_d2p;
-  assign unused_cio_usbdev_tx_mode_se_en_d2p = cio_usbdev_tx_mode_se_en_d2p;
   assign unused_cio_usbdev_suspend_d2p = cio_usbdev_suspend_d2p;
   assign unused_cio_usbdev_suspend_en_d2p = cio_usbdev_suspend_en_d2p;
-  assign cio_usbdev_d_p2d = 1'b0;
-  assign unused_cio_usbdev_d_d2p = cio_usbdev_d_d2p;
-  assign unused_cio_usbdev_d_en_d2p = cio_usbdev_d_en_d2p;
 
   // monitor for termination
 `ifndef END_MON_PATH

--- a/sw/device/lib/usbdev.c
+++ b/sw/device/lib/usbdev.c
@@ -251,7 +251,8 @@ void usbdev_endpoint_setup(usbdev_ctx_t *ctx, int ep, int enableout,
   }
 }
 
-void usbdev_init(usbdev_ctx_t *ctx) {
+void usbdev_init(usbdev_ctx_t *ctx, bool pinflip, bool diff_rx, bool diff_tx) {
+  int phy_config;
   // setup context
   for (int i = 0; i < NUM_ENDPOINTS; i++) {
     usbdev_endpoint_setup(ctx, i, 0, NULL, NULL, NULL, NULL, NULL);
@@ -268,6 +269,10 @@ void usbdev_init(usbdev_ctx_t *ctx) {
 
   REG32(USBDEV_RXENABLE_SETUP()) = (1 << USBDEV_RXENABLE_SETUP_SETUP0);
   REG32(USBDEV_RXENABLE_OUT()) = (1 << USBDEV_RXENABLE_OUT_OUT0);
-
+  phy_config = (((pinflip) ? (1 << USBDEV_PHY_CONFIG_PINFLIP) : 0) |
+		((diff_rx) ? (1 << USBDEV_PHY_CONFIG_RX_DIFFERENTIAL_MODE) : 0) |
+		((diff_tx) ? (1 << USBDEV_PHY_CONFIG_TX_DIFFERENTIAL_MODE) : 0) |
+		(1 << USBDEV_PHY_CONFIG_EOP_SINGLE_BIT));
+  REG32(USBDEV_PHY_CONFIG()) = phy_config;
   REG32(USBDEV_USBCTRL()) = (1 << USBDEV_USBCTRL_ENABLE);
 }

--- a/sw/device/lib/usbdev.c
+++ b/sw/device/lib/usbdev.c
@@ -252,7 +252,6 @@ void usbdev_endpoint_setup(usbdev_ctx_t *ctx, int ep, int enableout,
 }
 
 void usbdev_init(usbdev_ctx_t *ctx, bool pinflip, bool diff_rx, bool diff_tx) {
-  int phy_config;
   // setup context
   for (int i = 0; i < NUM_ENDPOINTS; i++) {
     usbdev_endpoint_setup(ctx, i, 0, NULL, NULL, NULL, NULL, NULL);
@@ -269,10 +268,11 @@ void usbdev_init(usbdev_ctx_t *ctx, bool pinflip, bool diff_rx, bool diff_tx) {
 
   REG32(USBDEV_RXENABLE_SETUP()) = (1 << USBDEV_RXENABLE_SETUP_SETUP0);
   REG32(USBDEV_RXENABLE_OUT()) = (1 << USBDEV_RXENABLE_OUT_OUT0);
-  phy_config = (((pinflip) ? (1 << USBDEV_PHY_CONFIG_PINFLIP) : 0) |
-		((diff_rx) ? (1 << USBDEV_PHY_CONFIG_RX_DIFFERENTIAL_MODE) : 0) |
-		((diff_tx) ? (1 << USBDEV_PHY_CONFIG_TX_DIFFERENTIAL_MODE) : 0) |
-		(1 << USBDEV_PHY_CONFIG_EOP_SINGLE_BIT));
+  uint32_t phy_config;
+  phy_config = (pinflip << USBDEV_PHY_CONFIG_PINFLIP) |
+	       (diff_rx << USBDEV_PHY_CONFIG_RX_DIFFERENTIAL_MODE) |
+	       (diff_tx << USBDEV_PHY_CONFIG_TX_DIFFERENTIAL_MODE) |
+	       (1 << USBDEV_PHY_CONFIG_EOP_SINGLE_BIT);
   REG32(USBDEV_PHY_CONFIG()) = phy_config;
   REG32(USBDEV_USBCTRL()) = (1 << USBDEV_USBCTRL_ENABLE);
 }

--- a/sw/device/lib/usbdev.h
+++ b/sw/device/lib/usbdev.h
@@ -7,6 +7,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 // Hardware parameters
 #define NUM_BUFS 32
@@ -221,8 +222,11 @@ void usbdev_endpoint_setup(usbdev_ctx_t *ctx, int ep, int enableout,
  * Initialize the usbdev interface
  *
  * @param ctx uninitialized usbdev context pointer
+ * @param pinflip boolean to indicate if PHY should be configured for D+/D- flip
+ * @param diff_rx boolean to indicate if PHY uses differential RX
+ * @param diff_tx boolean to indicate if PHY uses differential TX
  */
-void usbdev_init(usbdev_ctx_t *ctx);
+void usbdev_init(usbdev_ctx_t *ctx, bool pinflip, bool diff_rx, bool diff_tx);
 
 // Used for tracing what is going on. This may impact timing which is critical
 // when simulating with the USB DPI module.


### PR DESCRIPTION
The differental mode reception and conversion was being done in the iomux
and potentially not passing all information to the usb_fs_rx module. Reworked
to pass the single ended and differential data to usb_fs_rx, recover them
both and use the configured mode to forward appropriately.

This simplifies the usbdev_iomux to only pinflip I/O and pass async
rx to receive logic.

As part of debug fixed verilator UNOPTFLAT complaint and added a link
state representing the link being active but never seen SOF because this
is where a flipped link gets stuck between FPGA board and Linux. (The
flipped pullup will make it look like a LS not FS link so the 1.5Mbit
chatter is enough to get rx PID erros but also keeps resetting the
link so host_lost never fires).

Update verilator top and usbdpi to manage all the I/Os. And add code
to the usbdpi to be able to simulate pinflip and differential as well
as the normal pin mode. Note that because there is no other signal it
uses the tx_mode_se signal to control use of differential mode in both
tx and rx directions (so it only works if both phy config bits are the
same). It uses the DN PULLUP being asserted to detect flip.

Update hello_usbdev.c to set the phy config from some defines.

Add to the pin file for the FPGA to allow a bitstream to be built to
fake pinflip by swapping the FPGA pins used for D+/D- and their pullups.

Tested with verilator that all four settings of PINFLIP and DIFFIO in
hello_usb.c get the same expected output.

Tested with FPGA that PINFLIP=0,1 both work (with appropriate bitstream)

Fixes 2598

Signed-off-by: Mark Hayter <mark.hayter@gmail.com>