### PR TITLE
[otbn] fix typo in BN.WSRRW instruction

### DIFF
--- a/hw/ip/otbn/doc/_index.md
+++ b/hw/ip/otbn/doc/_index.md
@@ -2206,7 +2206,7 @@ BN.WSRRS <wrd>, <wsr>, <wrs>
 **Atomic Read/Write WSR.**
 
 ```python3
-BN.WSRRW <wrd>, <csr>, <wrs>
+BN.WSRRW <wrd>, <wsr>, <wrs>
 ```
 
 ## Pseudo-Code Functions for BN Instructions


### PR DESCRIPTION
BN.WSRRW instruction only operates on wide registers

Signed-off-by: Felix Miller <felix.miller@gi-de.com>