### PR TITLE
Make the wmask assertion in prim_generic_ram_*p only apply to writes

### DIFF
--- a/hw/ip/prim_generic/rtl/prim_generic_ram_1p.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_ram_1p.sv
@@ -34,8 +34,8 @@ module prim_generic_ram_1p #(
   for (genvar k = 0; k < MaskWidth; k++) begin : gen_wmask
     assign wmask[k] = &wmask_i[k*DataBitsPerMask +: DataBitsPerMask];
 
-    // Ensure that all mask bits within a group have the same value
-    `ASSERT(MaskCheck_A, req_i |->
+    // Ensure that all mask bits within a group have the same value for a write
+    `ASSERT(MaskCheck_A, req_i && write_i |->
         wmask_i[k*DataBitsPerMask +: DataBitsPerMask] inside {{DataBitsPerMask{1'b1}}, '0},
         clk_i, '0)
   end

--- a/hw/ip/prim_generic/rtl/prim_generic_ram_2p.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_ram_2p.sv
@@ -44,11 +44,11 @@ module prim_generic_ram_2p #(
     assign a_wmask[k] = &a_wmask_i[k*DataBitsPerMask +: DataBitsPerMask];
     assign b_wmask[k] = &b_wmask_i[k*DataBitsPerMask +: DataBitsPerMask];
 
-    // Ensure that all mask bits within a group have the same value
-    `ASSERT(MaskCheckPortA_A, a_req_i |->
+    // Ensure that all mask bits within a group have the same value for a write
+    `ASSERT(MaskCheckPortA_A, a_req_i && a_write_i |->
         a_wmask_i[k*DataBitsPerMask +: DataBitsPerMask] inside {{DataBitsPerMask{1'b1}}, '0},
         clk_a_i, '0)
-    `ASSERT(MaskCheckPortB_A, b_req_i |->
+    `ASSERT(MaskCheckPortB_A, b_req_i && b_write_i |->
         b_wmask_i[k*DataBitsPerMask +: DataBitsPerMask] inside {{DataBitsPerMask{1'b1}}, '0},
         clk_b_i, '0)
   end


### PR DESCRIPTION
wmask is a write mask and is ignored for read accesses, so we
shouldn't have an assertion about its value when write_i is false.

This assertion is currently being triggered by chip-level tests poking
at OTBN's DMEM.
