### PR TITLE
[sw, dif] add C/C++ guard to dif_warn_unused_result.h

### DIFF
--- a/sw/device/lib/dif/dif_warn_unused_result.h
+++ b/sw/device/lib/dif/dif_warn_unused_result.h
@@ -10,6 +10,11 @@
  * @brief Unused Result Warning Macro for DIFs.
  */
 
+// Header Extern Guard (so header can be used from C and C++)
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
 /**
  * Attribute for functions which return errors that must be acknowledged.
  *
@@ -18,5 +23,9 @@
  * ground.
  */
 #define DIF_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_DIF_DIF_WARN_UNUSED_RESULT_H_


### PR DESCRIPTION
This change is a part of work to bring up dif_plic to
S2. https://docs.opentitan.org/doc/project/checklist/#s2,
"DIF_CODE_STYLE" which reads as follows:
"DIF follows the DIF-specific guidelines in
sw/device/lib/dif/README.md and the OpenTitan C style guidelines."

https://docs.opentitan.org/doc/rm/c_cpp_coding_style/, "Polyglot
headers" in turn says following:

"Moreover, all non-system #includes in a polyglot header must also be
of other polyglot headers. (In other words, all C system headers may
be assumed to be polyglot, even if they lack guards.)"

In practice this header is not likely to cause any issues, however, it
easier to add the guard than treat it as an exception.

Signed-off-by: Silvestrs Timofejevs <silvestrst@lowrisc.org>