### PR TITLE
[otbn] Correct wmask assertions in OTBN top-level

### DIFF
--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -30,7 +30,6 @@ module otbn_core
 
   // Instruction memory (IMEM)
   output logic                     imem_req_o,
-  output logic                     imem_write_o,
   output logic [ImemAddrWidth-1:0] imem_addr_o,
   output logic [31:0]              imem_wdata_o,
   input  logic [31:0]              imem_rdata_i,


### PR DESCRIPTION
This fixes the assertion about `imem_wmask_bus` so that it only triggers
on a write (a partial wmask on a read is allowed, but ignored).

The patch completely removes `imem_wmask_core`: unlike e.g.
`imem_write_core`, this doesn't come from a port on `otbn_core`, but was
just assigned to and then ignored in otbn.sv.

Since we assume the core never tries to write its IMEM(!), this patch
also adds an assertion to that effect.
