### PR TITLE
[tests] Clean up dif_plic_sanitytest.c

### DIFF
--- a/sw/device/tests/dif/dif_plic_sanitytest.c
+++ b/sw/device/tests/dif/dif_plic_sanitytest.c
@@ -4,21 +4,19 @@
 
 #include "sw/device/lib/dif/dif_plic.h"
 
-#include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/log.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_uart.h"
 #include "sw/device/lib/handler.h"
 #include "sw/device/lib/irq.h"
+#include "sw/device/lib/runtime/check.h"
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/testing/test_main.h"
 #include "sw/device/lib/testing/test_status.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
 
-#define PLIC_TARGET kTopEarlgreyPlicTargetIbex0
-
-#define kDifPlicMinPriority 0u
+static const uint32_t kPlicTarget = kTopEarlgreyPlicTargetIbex0;
 
 static dif_plic_t plic0;
 static dif_uart_t uart0;
@@ -29,14 +27,6 @@ static dif_uart_t uart0;
 // flow.
 static volatile bool uart_rx_overflow_handled;
 static volatile bool uart_tx_empty_handled;
-static volatile bool uart_handled_more_than_once;
-
-#define LOG_FATAL_AND_ABORT(...)        \
-  do {                                  \
-    LOG_FATAL(__VA_ARGS__);             \
-    test_status_set(kTestStatusFailed); \
-    abort();                            \
-  } while (false)
 
 /**
  * UART interrupt handler
@@ -45,37 +35,32 @@ static volatile bool uart_handled_more_than_once;
  * determine success or failure of the test.
  */
 static void handle_uart_isr(const dif_plic_irq_id_t interrupt_id) {
-  const dif_uart_t *uart = &uart0;
+  // NOTE: This initialization is superfluous, since the `default` case below
+  // is effectively noreturn, but the compiler is unable to prove this.
+  dif_uart_interrupt_t uart_irq = 0;
 
-  dif_uart_interrupt_t uart_irq;
   switch (interrupt_id) {
     case kTopEarlgreyPlicIrqIdUartRxOverflow:
-      uart_irq = kDifUartInterruptRxOverflow;
+      CHECK(!uart_rx_overflow_handled,
+            "UART RX overflow IRQ asserted more than once");
 
-      // It is an error if this IRQ is asserted more than once.
-      if (uart_rx_overflow_handled) {
-        uart_handled_more_than_once = true;
-      } else {
-        uart_rx_overflow_handled = true;
-      }
+      uart_irq = kDifUartInterruptRxOverflow;
+      uart_rx_overflow_handled = true;
       break;
     case kTopEarlgreyPlicIrqIdUartTxEmpty:
-      uart_irq = kDifUartInterruptTxEmpty;
+      CHECK(!uart_tx_empty_handled,
+            "UART TX empty IRQ asserted more than once");
 
-      // It is an error if this IRQ is asserted more than once.
-      if (uart_tx_empty_handled) {
-        uart_handled_more_than_once = true;
-      } else {
-        uart_tx_empty_handled = true;
-      }
+      uart_irq = kDifUartInterruptTxEmpty;
+      uart_tx_empty_handled = true;
       break;
     default:
-      LOG_FATAL_AND_ABORT("ISR is not implemented!");
+      LOG_FATAL("ISR is not implemented!");
+      test_status_set(kTestStatusFailed);
   }
 
-  if (dif_uart_irq_state_clear(uart, uart_irq) != kDifUartOk) {
-    LOG_FATAL_AND_ABORT("ISR failed to clear IRQ!");
-  }
+  CHECK(dif_uart_irq_state_clear(&uart0, uart_irq) == kDifUartOk,
+        "ISR failed to clear IRQ!");
 }
 
 /**
@@ -89,23 +74,20 @@ static void handle_uart_isr(const dif_plic_irq_id_t interrupt_id) {
 void handler_irq_external(void) {
   // Claim the IRQ by reading the Ibex specific CC register.
   dif_plic_irq_id_t interrupt_id;
-  if (dif_plic_irq_claim(&plic0, PLIC_TARGET, &interrupt_id) != kDifPlicOk) {
-    LOG_FATAL_AND_ABORT("ISR is not implemented!");
-  }
+  CHECK(dif_plic_irq_claim(&plic0, kPlicTarget, &interrupt_id) == kDifPlicOk,
+        "ISR is not implemented!");
 
   // Check if the interrupted peripheral is UART.
   top_earlgrey_plic_peripheral_t peripheral_id =
       top_earlgrey_plic_interrupt_for_peripheral[interrupt_id];
-  if (peripheral_id != kTopEarlgreyPlicPeripheralUart) {
-    LOG_FATAL_AND_ABORT("ISR interrupted peripheral is not UART!");
-  }
+  CHECK(peripheral_id == kTopEarlgreyPlicPeripheralUart,
+        "ISR interrupted peripheral is not UART!");
   handle_uart_isr(interrupt_id);
 
   // Complete the IRQ by writing the IRQ source to the Ibex specific CC
   // register.
-  if (dif_plic_irq_complete(&plic0, PLIC_TARGET, &interrupt_id) != kDifPlicOk) {
-    LOG_FATAL_AND_ABORT("Unable to complete the IRQ request!");
-  }
+  CHECK(dif_plic_irq_complete(&plic0, kPlicTarget, &interrupt_id) == kDifPlicOk,
+        "Unable to complete the IRQ request!");
 }
 
 static void uart_initialise(mmio_region_t base_addr, dif_uart_t *uart) {
@@ -117,131 +99,82 @@ static void uart_initialise(mmio_region_t base_addr, dif_uart_t *uart) {
   };
 
   // No debug output in case of UART initialisation failure.
-  if (dif_uart_init(base_addr, &config, uart) != kDifUartConfigOk) {
-    LOG_FATAL_AND_ABORT("UART init failed!");
-  }
+  CHECK(dif_uart_init(base_addr, &config, uart) == kDifUartConfigOk,
+        "UART init failed!");
 }
 
 static void plic_initialise(mmio_region_t base_addr, dif_plic_t *plic) {
-  if (dif_plic_init(base_addr, plic) != kDifPlicOk) {
-    LOG_FATAL_AND_ABORT("PLIC init failed!");
-  }
+  CHECK(dif_plic_init(base_addr, plic) == kDifPlicOk, "PLIC init failed!");
 }
 
 /**
  * Configures all the relevant interrupts in UART.
  */
-static bool uart_configure_irqs(dif_uart_t *uart) {
-  if (dif_uart_irq_enable(&uart0, kDifUartInterruptRxOverflow,
-                          kDifUartEnable) != kDifUartOk) {
-    LOG_ERROR("RX overflow IRQ enable failed!");
-    return false;
-  }
-  if (dif_uart_irq_enable(&uart0, kDifUartInterruptTxEmpty, kDifUartEnable) !=
-      kDifUartOk) {
-    LOG_ERROR("TX empty IRQ enable failed!");
-    return false;
-  }
-
-  return true;
+static void uart_configure_irqs(dif_uart_t *uart) {
+  CHECK(dif_uart_irq_enable(&uart0, kDifUartInterruptRxOverflow,
+                            kDifUartEnable) == kDifUartOk,
+        "RX overflow IRQ enable failed!");
+  CHECK(dif_uart_irq_enable(&uart0, kDifUartInterruptTxEmpty, kDifUartEnable) ==
+            kDifUartOk,
+        "TX empty IRQ enable failed!");
 }
 
 /**
  * Configures all the relevant interrupts in PLIC.
  */
-static bool plic_configure_irqs(dif_plic_t *plic) {
+static void plic_configure_irqs(dif_plic_t *plic) {
   // Set IRQ triggers to be level triggered
-  if (dif_plic_irq_trigger_type_set(plic, kTopEarlgreyPlicIrqIdUartRxOverflow,
-                                    kDifPlicDisable) != kDifPlicOk) {
-    LOG_ERROR("RX overflow trigger type set failed!");
-    return false;
-  }
-  if (dif_plic_irq_trigger_type_set(plic, kTopEarlgreyPlicIrqIdUartTxEmpty,
-                                    kDifPlicDisable) != kDifPlicOk) {
-    LOG_ERROR("TX empty trigger type set failed!");
-    return false;
-  }
+  CHECK(dif_plic_irq_trigger_type_set(plic, kTopEarlgreyPlicIrqIdUartRxOverflow,
+                                      kDifPlicDisable) == kDifPlicOk,
+        "RX overflow trigger type set failed!");
+  CHECK(dif_plic_irq_trigger_type_set(plic, kTopEarlgreyPlicIrqIdUartTxEmpty,
+                                      kDifPlicDisable) == kDifPlicOk,
+        "TX empty trigger type set failed!");
 
   // Set IRQ priorities to MAX
-  if (dif_plic_irq_priority_set(plic, kTopEarlgreyPlicIrqIdUartRxOverflow,
-                                kDifPlicMaxPriority) != kDifPlicOk) {
-    LOG_ERROR("priority set for RX overflow failed!");
-    return false;
-  }
+  CHECK(dif_plic_irq_priority_set(plic, kTopEarlgreyPlicIrqIdUartRxOverflow,
+                                  kDifPlicMaxPriority) == kDifPlicOk,
+        "priority set for RX overflow failed!");
 
-  if (dif_plic_irq_priority_set(plic, kTopEarlgreyPlicIrqIdUartTxEmpty,
-                                kDifPlicMaxPriority) != kDifPlicOk) {
-    LOG_ERROR("priority set for TX empty failed!");
-    return false;
-  }
+  CHECK(dif_plic_irq_priority_set(plic, kTopEarlgreyPlicIrqIdUartTxEmpty,
+                                  kDifPlicMaxPriority) == kDifPlicOk,
+        "priority set for TX empty failed!");
 
   // Set Ibex IRQ priority threshold level
-  if (dif_plic_target_threshold_set(&plic0, PLIC_TARGET, kDifPlicMinPriority) !=
-      kDifPlicOk) {
-    LOG_ERROR("threshold set failed!");
-    return false;
-  }
+  CHECK(dif_plic_target_threshold_set(&plic0, kPlicTarget,
+                                      kDifPlicMinPriority) == kDifPlicOk,
+        "threshold set failed!");
 
   // Enable IRQs in PLIC
-  if (dif_plic_irq_enable_set(plic, kTopEarlgreyPlicIrqIdUartRxOverflow,
-                              PLIC_TARGET, kDifPlicEnable) != kDifPlicOk) {
-    LOG_ERROR("interrupt Enable for RX overflow failed!");
-    return false;
-  }
-  if (dif_plic_irq_enable_set(plic, kTopEarlgreyPlicIrqIdUartTxEmpty,
-                              PLIC_TARGET, kDifPlicEnable) != kDifPlicOk) {
-    LOG_ERROR("interrupt Enable for TX empty failed!");
-    return false;
-  }
+  CHECK(dif_plic_irq_enable_set(plic, kTopEarlgreyPlicIrqIdUartRxOverflow,
+                                kPlicTarget, kDifPlicEnable) == kDifPlicOk,
+        "interrupt Enable for RX overflow failed!");
 
-  return true;
+  CHECK(dif_plic_irq_enable_set(plic, kTopEarlgreyPlicIrqIdUartTxEmpty,
+                                kPlicTarget, kDifPlicEnable) == kDifPlicOk,
+        "interrupt Enable for TX empty failed!");
 }
 
-static bool execute_test(dif_uart_t *uart) {
-  // Initialize the global variables.
-  uart_rx_overflow_handled = false;
-  uart_tx_empty_handled = false;
-  uart_handled_more_than_once = false;
-
+static void execute_test(dif_uart_t *uart) {
   // Force UART RX overflow interrupt.
-  if (dif_uart_irq_force(uart, kDifUartInterruptRxOverflow) != kDifUartOk) {
-    LOG_ERROR("failed to force RX overflow IRQ!");
-    return false;
-  }
+  uart_rx_overflow_handled = false;
+  CHECK(dif_uart_irq_force(uart, kDifUartInterruptRxOverflow) == kDifUartOk,
+        "failed to force RX overflow IRQ!");
   // Check if the IRQ has occured and has been handled appropriately.
   if (!uart_rx_overflow_handled) {
     usleep(10);
   }
-  if (!uart_rx_overflow_handled) {
-    LOG_ERROR("RX overflow IRQ has not been handled!");
-    return false;
-  }
-  // Check that the IRQ has not been asserted more than once.
-  if (uart_handled_more_than_once) {
-    LOG_ERROR("RX overflow IRQ was asserted more than once!");
-    return false;
-  }
+  CHECK(uart_rx_overflow_handled, "RX overflow IRQ has not been handled!");
 
   // Force UART TX empty interrupt.
-  if (dif_uart_irq_force(uart, kDifUartInterruptTxEmpty) != kDifUartOk) {
-    LOG_ERROR("failed to force TX empty IRQ!");
-    return false;
-  }
+  uart_tx_empty_handled = false;
+  CHECK(dif_uart_irq_force(uart, kDifUartInterruptTxEmpty) == kDifUartOk,
+        "failed to force TX empty IRQ!");
   // Check if the IRQ has occured and has been handled appropriately.
   if (!uart_tx_empty_handled) {
     usleep(10);
   }
-  if (!uart_tx_empty_handled) {
-    LOG_ERROR("TX empty IRQ has not been handled!");
-    return false;
-  }
-  // Check that the IRQ has not been asserted more than once.
-  if (uart_handled_more_than_once) {
-    LOG_ERROR("TX empty IRQ was asserted more than once!");
-    return false;
-  }
-
-  return true;
+  CHECK(uart_tx_empty_handled, "TX empty IRQ has not been handled!");
 }
 
 const test_config_t kTestConfig = {
@@ -262,9 +195,9 @@ bool test_main(void) {
       mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR);
   plic_initialise(plic_base_addr, &plic0);
 
-  if (!uart_configure_irqs(&uart0) || !plic_configure_irqs(&plic0)) {
-    return false;
-  }
+  uart_configure_irqs(&uart0);
+  plic_configure_irqs(&plic0);
+  execute_test(&uart0);
 
-  return (execute_test(&uart0));
+  return true;
 }


### PR DESCRIPTION
This change makes the PLIC sanity test use a style more consistent with other on-device tests.

Moving around the CHECKs also surfaced a logic error in the test: because we didn't disable the UART interrupts used for testing the PLIC, the test harness would actually trigger them! For now, we clean up IRQ settings at the end of the test, but I actually think that `test_main.c` should *unconditionally* reset-initialize UART after everything is done, since tests should not need to remember to unclobber UART configuration.

I also wonder if we want to make CHECK manually re-initialize UART if a precondition fails...