### PR TITLE
[sw/dif] fix a typo in code comment

### DIFF
--- a/sw/device/lib/dif/dif_spi_device.h
+++ b/sw/device/lib/dif/dif_spi_device.h
@@ -257,7 +257,7 @@ dif_spi_device_result_t dif_spi_device_recv(const dif_spi_device_t *spi,
  * @param spi A SPI device.
  * @param buf A pointer to bytes to be written.
  * @param buf_len The length of the buffer `buf` points to.
- * @param bytes_recved Out param for the number of bytes successfully written;
+ * @param bytes_sent Out param for the number of bytes successfully written;
  * may be null.
  * @return The result of the operation.
  */


### PR DESCRIPTION
Fix a small typo in dif_spi_device.h code comment.

Signed-off-by: Cindy Chen <chencindy@google.com>