### PR TITLE
[flash_ctrl rtl, dv] Reuse params and data structures from RTL pkg

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.core
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.core
@@ -12,6 +12,8 @@ filesets:
       - lowrisc:dv:dv_lib
       - lowrisc:dv:cip_lib
       - lowrisc:dv:mem_bkdr_if
+      - lowrisc:ip:flash_ctrl_pkg
+      - lowrisc:constants:top_pkg
     files:
       - flash_ctrl_env_pkg.sv
       - flash_mem_addr_attrs.sv: {is_include_file: true}

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.sv
@@ -30,7 +30,7 @@ class flash_ctrl_env extends cip_base_env #(
 
     // get the vifs from config db
     begin
-      flash_ctrl_partition_e part = part.first();
+      flash_part_e part = part.first();
       for (int i = 0; i < part.num(); i++, part = part.next()) begin
         foreach (cfg.mem_bkdr_vifs[, bank]) begin
           string vif_name = $sformatf("mem_bkdr_vifs[%0s][%0d]", part.name(), bank);

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
@@ -5,7 +5,7 @@
 class flash_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(flash_ctrl_reg_block));
 
   // vifs
-  mem_bkdr_vif mem_bkdr_vifs[flash_ctrl_partition_e][FLASH_CTRL_NUM_BANKS];
+  mem_bkdr_vif mem_bkdr_vifs[flash_part_e][flash_ctrl_pkg::NumBanks];
 
   // ext component cfgs
   rand tl_agent_cfg m_eflash_tl_agent_cfg;

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
@@ -12,6 +12,7 @@ package flash_ctrl_env_pkg;
   import tl_agent_pkg::*;
   import cip_base_pkg::*;
   import csr_utils_pkg::*;
+  import flash_ctrl_pkg::*;
   import flash_ctrl_ral_pkg::*;
 
   // macro includes
@@ -21,40 +22,27 @@ package flash_ctrl_env_pkg;
   // parameters
   parameter uint FLASH_CTRL_ADDR_MAP_SIZE = 128;
 
-  // TODO: These might be made into RTL design parameters.
-  parameter FLASH_CTRL_NUM_BANKS                = top_pkg::FLASH_BANKS; // 2
-  parameter FLASH_CTRL_NUM_PAGES_PER_BANK       = top_pkg::FLASH_PAGES_PER_BANK; // 256
-  parameter FLASH_CTRL_NUM_PAGES                = FLASH_CTRL_NUM_BANKS *
-                                                  FLASH_CTRL_NUM_PAGES_PER_BANK; // 512
-  parameter FLASH_CTRL_NUM_INFO_PAGES_PER_BANK  = top_pkg::FLASH_INFO_PER_BANK; // 4
-  parameter FLASH_CTRL_NUM_WORDS_PER_PAGE       = top_pkg::FLASH_WORDS_PER_PAGE; // 128
-  parameter FLASH_CTRL_NUM_WORDS                = FLASH_CTRL_NUM_WORDS_PER_PAGE *
-                                                  FLASH_CTRL_NUM_PAGES;
-  parameter FLASH_CTRL_WORD_SIZE_BYTES          = top_pkg::FLASH_DATA_WIDTH / 8; // 8
-  parameter FLASH_CTRL_NUM_BUS_WORDS            = FLASH_CTRL_NUM_WORDS *
-                                                  FLASH_CTRL_WORD_SIZE_BYTES /
-                                                  top_pkg::TL_DBW;
-  parameter FLASH_CTRL_PAGE_NUM_BUS_WORDS       = FLASH_CTRL_NUM_WORDS_PER_PAGE *
-                                                  FLASH_CTRL_WORD_SIZE_BYTES /
-                                                  top_pkg::TL_DBW;
-  parameter FLASH_CTRL_BANK_NUM_BUS_WORDS       = FLASH_CTRL_PAGE_NUM_BUS_WORDS *
-                                                  FLASH_CTRL_NUM_PAGES_PER_BANK;
-  parameter FLASH_CTRL_SIZE_BYTES               = FLASH_CTRL_WORD_SIZE_BYTES *
-                                                  FLASH_CTRL_NUM_WORDS_PER_PAGE *
-                                                  FLASH_CTRL_NUM_PAGES;
-  parameter FLASH_CTRL_NUM_MP_REGIONS           = 8;
-  parameter FLASH_CTRL_FIFO_DEPTH               = 16; // prog or rd fifo
+  parameter uint FlashNumPages            = top_pkg::FLASH_BANKS * top_pkg::FLASH_PAGES_PER_BANK;
+  parameter uint FlashSizeBytes           = FlashNumPages * top_pkg::FLASH_WORDS_PER_PAGE *
+                                            top_pkg::FLASH_DATA_WIDTH / 8;
 
-  // helper params
-  localparam FLASH_CTRL_MEM_ADDR_WORD_MSB       = $clog2(FLASH_CTRL_WORD_SIZE_BYTES) - 1;
-  localparam FLASH_CTRL_MEM_ADDR_WORD_LINE_MSB  = FLASH_CTRL_MEM_ADDR_WORD_MSB +
-                                                  $clog2(FLASH_CTRL_NUM_WORDS_PER_PAGE);
-  localparam FLASH_CTRL_MEM_ADDR_PAGE_MSB       = FLASH_CTRL_MEM_ADDR_WORD_LINE_MSB +
-                                                  $clog2(FLASH_CTRL_NUM_PAGES_PER_BANK);
-  localparam FLASH_CTRL_MEM_ADDR_BANK_MSB       = FLASH_CTRL_MEM_ADDR_PAGE_MSB +
-                                                  $clog2(FLASH_CTRL_NUM_BANKS);
+  parameter uint FlashNumBusWords         = FlashSizeBytes / top_pkg::TL_DBW;
+  parameter uint FlashNumBusWordsPerBank  = FlashNumBusWords / top_pkg::FLASH_BANKS;
+  parameter uint FlashNumBusWordsPerPage  = FlashNumBusWordsPerBank / top_pkg::FLASH_PAGES_PER_BANK;
 
-  // types
+  parameter uint FlashDataByteWidth       = $clog2(top_pkg::FLASH_DATA_WIDTH / 8);
+  parameter uint FlashWordLineWidth       = $clog2(top_pkg::FLASH_WORDS_PER_PAGE);
+  parameter uint FlashPageWidth           = $clog2(top_pkg::FLASH_PAGES_PER_BANK);
+  parameter uint FlashBankWidth           = $clog2(top_pkg::FLASH_BANKS);
+
+  parameter uint FlashMemAddrWordMsbBit   = FlashDataByteWidth - 1;
+  parameter uint FlashMemAddrLineMsbBit   = FlashDataByteWidth + FlashWordLineWidth - 1;
+  parameter uint FlashMemAddrPageMsbBit   = FlashDataByteWidth + FlashWordLineWidth +
+                                            FlashPageWidth - 1;
+  parameter uint FlashMemAddrBankMsbBit   = FlashDataByteWidth + FlashWordLineWidth +
+                                            FlashPageWidth + FlashBankWidth - 1;
+
+// types
   typedef enum int {
     FlashCtrlIntrProgEmpty  = 0,
     FlashCtrlIntrProgLvl    = 1,
@@ -73,40 +61,23 @@ package flash_ctrl_env_pkg;
     FlashMemInitInvalidate  // Initialize with Xs.
   } flash_mem_init_e;
 
-  typedef enum bit [1:0] {
-    FlashCtrlOpRead,
-    FlashCtrlOpProgram,
-    FlashCtrlOpErase,
-    FlashCtrlOpInvalid
-  } flash_ctrl_op_e;
-
-  typedef enum bit {
-    FlashCtrlErasePage,
-    FlashCtrlEraseBank
-  } flash_ctrl_erase_e;
-
-  typedef enum bit {
-    FlashCtrlPartitionData,
-    FlashCtrlPartitionInfo
-  } flash_ctrl_partition_e;
+  typedef struct packed {
+    bit           en;         // enable this region
+    bit           read_en;    // enable reads
+    bit           program_en; // enable write
+    bit           erase_en;   // enable erase
+    flash_part_e  partition;  // info or data
+    uint          num_pages;  // 0:NumPages % start_page
+    uint          start_page; // 0:NumPages-1
+  } flash_mp_region_cfg_t;
 
   typedef struct packed {
-    bit   en;                         // enable this region
-    bit   read_en;                    // enable reads
-    bit   program_en;                 // enable write
-    bit   erase_en;                   // enable erase
-    flash_ctrl_partition_e partition; // info or data
-    uint  num_pages;                  // 0:FLASH_CTRL_NUM_PAGES-1 % start_page
-    uint  start_page;                 // 0:FLASH_CTRL_NUM_PAGES-1
-  } flash_ctrl_mp_region_t;
-
-  typedef struct packed {
-    flash_ctrl_partition_e  partition;  // data or info partition
-    flash_ctrl_erase_e      erase_type; // erase page or the whole bank
-    flash_ctrl_op_e         op;         // read / program or erase
-    uint                    num_words;  // number of words to read or program (TL_DW)
-    bit [TL_AW-1:0]         addr;       // starting addr for the op
-  } flash_ctrl_single_op_t;
+    flash_part_e    partition;  // data or info partition
+    flash_erase_e   erase_type; // erase page or the whole bank
+    flash_op_e      op;         // read / program or erase
+    uint            num_words;  // number of words to read or program (TL_DW)
+    bit [TL_AW-1:0] addr;       // starting addr for the op
+  } flash_op_t;
 
   typedef virtual mem_bkdr_if mem_bkdr_vif;
 

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
@@ -13,7 +13,7 @@ class flash_ctrl_seq_cfg extends uvm_object;
   uint max_num_trans = 20;
 
   // Memory protection configuration.
-  uint num_en_mp_regions = FLASH_CTRL_NUM_MP_REGIONS;
+  uint num_en_mp_regions = flash_ctrl_pkg::MpRegions;
 
   // This enables memory protection regions to overlap.
   bit allow_mp_region_overlap = 1'b0;

--- a/hw/ip/flash_ctrl/dv/env/flash_mem_addr_attrs.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_mem_addr_attrs.sv
@@ -12,7 +12,7 @@ class flash_mem_addr_attrs;
 
     uint            bank;             // The bank the address belongs to.
     uint            page;             // The page within the bank.
-    uint            word_line;        // The word line within the page.
+    uint            line;             // The word line within the page.
 
   function new(bit [TL_AW-1:0] addr = 0);
     set_attrs(addr);
@@ -21,17 +21,15 @@ class flash_mem_addr_attrs;
   // Set attributes from a sample input addr.
   function void set_attrs(bit [TL_AW-1:0] addr);
     this.addr = {addr[TL_AW-1:TL_SZW], {TL_SZW{1'b0}}};
-    bank_addr = this.addr[FLASH_CTRL_MEM_ADDR_PAGE_MSB:0];
+    bank_addr = this.addr[FlashMemAddrPageMsbBit : 0];
 
-    bank_start_addr =
-        {addr[TL_AW-1:FLASH_CTRL_MEM_ADDR_PAGE_MSB+1], {FLASH_CTRL_MEM_ADDR_PAGE_MSB+1{1'b0}}};
-    page_start_addr =
-        {addr[FLASH_CTRL_MEM_ADDR_PAGE_MSB:FLASH_CTRL_MEM_ADDR_WORD_LINE_MSB+1],
-         {FLASH_CTRL_MEM_ADDR_WORD_LINE_MSB+1{1'b0}}};
+    bank_start_addr = {addr[TL_AW-1 : FlashMemAddrPageMsbBit+1], {FlashMemAddrPageMsbBit+1{1'b0}}};
+    page_start_addr = {addr[FlashMemAddrPageMsbBit : FlashMemAddrLineMsbBit+1],
+                       {FlashMemAddrLineMsbBit+1{1'b0}}};
 
-    bank = addr[FLASH_CTRL_MEM_ADDR_BANK_MSB:FLASH_CTRL_MEM_ADDR_PAGE_MSB + 1];
-    page = addr[FLASH_CTRL_MEM_ADDR_PAGE_MSB:FLASH_CTRL_MEM_ADDR_WORD_LINE_MSB + 1];
-    word_line = addr[FLASH_CTRL_MEM_ADDR_WORD_LINE_MSB:FLASH_CTRL_MEM_ADDR_WORD_MSB + 1];
+    bank = addr[FlashMemAddrBankMsbBit : FlashMemAddrPageMsbBit+1];
+    page = addr[FlashMemAddrPageMsbBit : FlashMemAddrLineMsbBit+1];
+    line = addr[FlashMemAddrLineMsbBit : FlashMemAddrWordMsbBit+1];
   endfunction
 
   function void incr(bit [TL_AW-1:0] offset);
@@ -42,9 +40,9 @@ class flash_mem_addr_attrs;
   function string sprint();
     return $sformatf({{"addr_attrs: addr = 0x%0h, bank_addr = 0x%0h "},
                       {"bank_start_addr = 0x%0h, page_start_addr = 0x%0h "},
-                      {"bank = %0d, page = %0d, word_line = %0d"}},
+                      {"bank = %0d, page = %0d, line = %0d"}},
                      addr, bank_addr, bank_start_addr, page_start_addr,
-                     bank, page, word_line);
+                     bank, page, line);
   endfunction
 
 endclass

--- a/hw/ip/flash_ctrl/dv/flash_ctrl_sim.core
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_sim.core
@@ -8,6 +8,7 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:ip:tlul
+      - lowrisc:constants:top_pkg
       - lowrisc:ip:flash_ctrl_pkg
       - lowrisc:ip:flash_ctrl:0.1
     files:

--- a/hw/ip/flash_ctrl/dv/tb/tb.sv
+++ b/hw/ip/flash_ctrl/dv/tb/tb.sv
@@ -5,7 +5,9 @@
 module tb;
   // dep packages
   import uvm_pkg::*;
+  import top_pkg::*;
   import dv_utils_pkg::*;
+  import flash_ctrl_pkg::*;
   import flash_ctrl_env_pkg::*;
   import flash_ctrl_test_pkg::*;
 
@@ -57,16 +59,16 @@ module tb;
       dut.u_flash_eflash.gen_flash_banks[``i``].i_core.i_flash.gen_generic.u_impl_generic.u_info_mem
 
   generate
-    for (genvar i = 0; i < FLASH_CTRL_NUM_BANKS; i++) begin : mem_bkdr_if_i
+    for (genvar i = 0; i < flash_ctrl_pkg::NumBanks; i++) begin : mem_bkdr_if_i
       bind `FLASH_DATA_MEM_HIER(i) mem_bkdr_if mem_bkdr_if();
       bind `FLASH_INFO_MEM_HIER(i) mem_bkdr_if mem_bkdr_if();
       initial begin
-        flash_ctrl_partition_e part;
-        part = FlashCtrlPartitionData;
+        flash_part_e part;
+        part = flash_ctrl_pkg::FlashPartData;
         uvm_config_db#(mem_bkdr_vif)::set(null, "*.env", $sformatf("mem_bkdr_vifs[%0s][%0d]",
             part.name(), i), `FLASH_DATA_MEM_HIER(i).mem_bkdr_if);
 
-        part = FlashCtrlPartitionInfo;
+        part = flash_ctrl_pkg::FlashPartInfo;
         uvm_config_db#(mem_bkdr_vif)::set(null, "*.env", $sformatf("mem_bkdr_vifs[%0s][%0d]",
             part.name(), i), `FLASH_INFO_MEM_HIER(i).mem_bkdr_if);
       end

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -108,9 +108,9 @@ module flash_ctrl import flash_ctrl_pkg::*; (
   logic [AllPagesW-1:0] err_page;
   logic [BankW-1:0] err_bank;
 
-  assign rd_op = reg2hw.control.op.q == FlashRead;
-  assign prog_op = reg2hw.control.op.q == FlashProg;
-  assign erase_op = reg2hw.control.op.q == FlashErase;
+  assign rd_op = reg2hw.control.op.q == FlashOpRead;
+  assign prog_op = reg2hw.control.op.q == FlashOpProgram;
+  assign erase_op = reg2hw.control.op.q == FlashOpErase;
 
   // Program FIFO
   // Since the program and read FIFOs are never used at the same time, it should really be one
@@ -289,15 +289,15 @@ module flash_ctrl import flash_ctrl_pkg::*; (
   // Final muxing to flash macro module
   always_comb begin
     unique case (reg2hw.control.op.q)
-      FlashRead: begin
+      FlashOpRead: begin
         flash_req = rd_flash_req;
         flash_addr = rd_flash_addr;
       end
-      FlashProg: begin
+      FlashOpProgram: begin
         flash_req = prog_flash_req;
         flash_addr = prog_flash_addr;
       end
-      FlashErase: begin
+      FlashOpErase: begin
         flash_req = erase_flash_req;
         flash_addr = erase_flash_addr;
       end
@@ -322,7 +322,7 @@ module flash_ctrl import flash_ctrl_pkg::*; (
   assign region_cfgs[MpRegions].erase_en.q = reg2hw.default_region.erase_en.q;
   // we are allowed to set default accessibility of data partitions
   // however info partitions default to inaccessible
-  assign region_cfgs[MpRegions].partition.q = DataPart;
+  assign region_cfgs[MpRegions].partition.q = FlashPartData;
 
   flash_part_e flash_part_sel;
   assign flash_part_sel = flash_part_e'(reg2hw.control.partition_sel.q);
@@ -350,8 +350,8 @@ module flash_ctrl import flash_ctrl_pkg::*; (
     .req_bk_i(flash_addr[BusAddrW-1 -: BankW]),
     .rd_i(rd_op),
     .prog_i(prog_op),
-    .pg_erase_i(erase_op & (erase_flash_type == PageErase)),
-    .bk_erase_i(erase_op & (erase_flash_type == BankErase)),
+    .pg_erase_i(erase_op & (erase_flash_type == FlashErasePage)),
+    .bk_erase_i(erase_op & (erase_flash_type == FlashEraseBank)),
     .rd_done_o(flash_rd_done),
     .prog_done_o(flash_prog_done),
     .erase_done_o(flash_erase_done),

--- a/hw/ip/flash_ctrl/rtl/flash_erase_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_erase_ctrl.sv
@@ -48,7 +48,7 @@ module flash_erase_ctrl #(
   // Flash Interface assignments
   assign flash_req_o = op_start_i;
   assign flash_op_o = op_type_i;
-  assign flash_addr_o = (op_type_i == PageErase) ?
+  assign flash_addr_o = (op_type_i == FlashErasePage) ?
                         op_addr_i & PageAddrMask :
                         op_addr_i & BankAddrMask;
 

--- a/hw/ip/flash_ctrl/rtl/flash_mp.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_mp.sv
@@ -97,7 +97,7 @@ module flash_mp import flash_ctrl_pkg::*; import flash_ctrl_reg_pkg::*; #(
   always_comb begin
     for (int unsigned i = 0; i < NumBanks; i++) begin: bank_comps
       bk_erase_en[i] = (req_bk_i == i) & bank_cfgs_i[i].q &
-                       (req_part_i == DataPart);
+                       (req_part_i == FlashPartData);
     end
   end
 
@@ -105,13 +105,13 @@ module flash_mp import flash_ctrl_pkg::*; import flash_ctrl_reg_pkg::*; #(
 
   // invalid info page access
   assign invalid_info_access = req_i &
-                               (req_part_i == InfoPart) &
+                               (req_part_i == FlashPartInfo) &
                                (rd_i | prog_i | pg_erase_i) &
                                (req_addr_i[0 +: PageW] > LastValidInfoPage);
 
   // invalid info page erase
   assign invalid_info_erase  = req_i & bk_erase_i &
-                               (req_part_i == InfoPart);
+                               (req_part_i == FlashPartInfo);
 
   assign invalid_info_txn    = invalid_info_access | invalid_info_erase;
 

--- a/hw/ip/flash_ctrl/rtl/flash_phy_core.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_core.sv
@@ -208,7 +208,7 @@ module flash_phy_core import flash_phy_pkg::*; #(
   end // always_comb
 
   assign muxed_addr = host_sel ? host_addr_i : addr_i;
-  assign muxed_part = host_sel ? flash_ctrl_pkg::DataPart : part_i;
+  assign muxed_part = host_sel ? flash_ctrl_pkg::FlashPartData : part_i;
   assign rd_done_o = ctrl_rsp_vld & rd_i;
   assign prog_done_o = ctrl_rsp_vld & prog_i;
   assign erase_done_o = ctrl_rsp_vld & (pg_erase_i | bk_erase_i);

--- a/hw/ip/flash_ctrl/rtl/flash_phy_rd_buffers.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_rd_buffers.sv
@@ -35,7 +35,7 @@ module flash_phy_rd_buffers import flash_phy_pkg::*; (
     if (!rst_ni) begin
       out_o.data <= '0;
       out_o.addr <= '0;
-      out_o.part <= flash_ctrl_pkg::DataPart;
+      out_o.part <= flash_ctrl_pkg::FlashPartData;
       out_o.attr <= Invalid;
     end else if (wipe_i) begin
       out_o.attr <= Invalid;

--- a/hw/ip/prim_generic/rtl/prim_generic_flash.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_flash.sv
@@ -102,7 +102,7 @@ module prim_generic_flash #(
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       held_addr <= '0;
-      held_part <= flash_ctrl_pkg::DataPart;
+      held_part <= flash_ctrl_pkg::FlashPartData;
       held_wdata <= '0;
     end else if (hold_cmd) begin
       held_addr <= rd_q ? addr_q : addr_i;
@@ -155,7 +155,7 @@ module prim_generic_flash #(
     mem_req          = 'h0;
     mem_wr           = 'h0;
     mem_addr         = 'h0;
-    mem_part         = flash_ctrl_pkg::DataPart;
+    mem_part         = flash_ctrl_pkg::FlashPartData;
     mem_wdata        = 'h0;
     time_cnt_inc     = 1'h0;
     time_cnt_clr     = 1'h0;
@@ -291,7 +291,7 @@ module prim_generic_flash #(
     .DataBitsPerMask(DataWidth)
   ) u_mem (
     .clk_i,
-    .req_i    (mem_req & (mem_part == flash_ctrl_pkg::DataPart)),
+    .req_i    (mem_req & (mem_part == flash_ctrl_pkg::FlashPartData)),
     .write_i  (mem_wr),
     .addr_i   (mem_addr),
     .wdata_i  (mem_wdata),
@@ -305,7 +305,7 @@ module prim_generic_flash #(
     .DataBitsPerMask(DataWidth)
   ) u_info_mem (
     .clk_i,
-    .req_i    (mem_req & (mem_part == flash_ctrl_pkg::InfoPart)),
+    .req_i    (mem_req & (mem_part == flash_ctrl_pkg::FlashPartInfo)),
     .write_i  (mem_wr),
     .addr_i   (mem_addr[0 +: InfoAddrW]),
     .wdata_i  (mem_wdata),
@@ -313,6 +313,6 @@ module prim_generic_flash #(
     .rdata_o  (rd_data_info)
   );
 
-  assign rd_data_o = held_part == flash_ctrl_pkg::DataPart ? rd_data_main : rd_data_info;
+  assign rd_data_o = held_part == flash_ctrl_pkg::FlashPartData ? rd_data_main : rd_data_info;
 
 endmodule // prim_generic_flash


### PR DESCRIPTION
- This PR refactors the code to reuse parameters and data structures from the RTL design pkg. 
- There are some cosmetic updates to the existing literals in `flash_ctrl_pkg` 