### PR TITLE
[tool/script] delete clean section in make files

### DIFF
--- a/hw/dv/data/sim.mk
+++ b/hw/dv/data/sim.mk
@@ -122,10 +122,6 @@ cov_report:
 	@echo "[make]: cov_report"
 	${cov_report_cmd} ${cov_report_opts}
 
-clean:
-	echo "[make]: clean"
-	rm -rf ${scratch_root}/${dut}/*
-
 .PHONY: build \
 	run \
 	reg \

--- a/hw/lint/data/lint.mk
+++ b/hw/lint/data/lint.mk
@@ -29,10 +29,6 @@ compile_result: post_compile
 	@echo "[make]: compile_result"
 	${report_cmd} ${report_opts}
 
-clean:
-	echo "[make]: clean"
-	rm -rf ${scratch_root}/${dut}/*
-
 .PHONY: build \
 	run \
 	pre_compile \

--- a/hw/syn/data/syn.mk
+++ b/hw/syn/data/syn.mk
@@ -32,10 +32,6 @@ compile_result: post_compile
 	@echo "[make]: compile_result"
 	${report_cmd} ${report_opts}
 
-clean:
-	echo "[make]: clean"
-	rm -rf ${scratch_root}/${dut}/*
-
 .PHONY: build \
 	gen_sv_flist \
 	pre_compile \


### PR DESCRIPTION
As discusses in PR #2626, we are not using the "clean" function in
makefile. This PR removes the clean section in syn.mk, lint.mk, sim.mk

To make sure the directory is clean before running regression, dvsim has
a switch `-purge` that uses `os.remove` to delete the scratch_root.

Signed-off-by: Cindy Chen <chencindy@google.com>