### PR TITLE
[i2c, dv] Add i2c_perf and i2c_fifo_overflow (v2)

### DIFF
--- a/hw/dv/sv/i2c_agent/i2c_device_driver.sv
+++ b/hw/dv/sv/i2c_agent/i2c_device_driver.sv
@@ -47,6 +47,7 @@ class i2c_device_driver extends i2c_driver;
         RdData: begin
           `DV_CHECK_MEMBER_RANDOMIZE_FATAL(rd_data)
           rd_data_cnt++;
+          `DV_CHECK_LE(rd_data_cnt, 256);
           for (int i = 7; i >= 0; i--) begin
             cfg.vif.device_send_bit(cfg.timing_cfg, rd_data[rd_data_cnt][i]);
           end

--- a/hw/dv/sv/i2c_agent/i2c_item.sv
+++ b/hw/dv/sv/i2c_agent/i2c_item.sv
@@ -6,15 +6,18 @@ class i2c_item extends uvm_sequence_item;
 
   // transaction data part
   bit [7:0]                data_q[$];
-  bit [9:0]                addr; // enough to support both 7 & 10-bit target address
+  bit [9:0]                addr;      // enough to support both 7 & 10-bit target address
   int                      tran_id;
-  int                      num_data;
+  int                      num_data;  // valid data
   bus_op_e                 bus_op;
   drv_type_e               drv_type;
   // transaction control part
   bit                      nack;
   bit                      ack;
   bit                      rstart;
+
+  // queue dropped data due to fmt_overflow
+  bit [7:0]                fmt_ovf_data_q[$];
 
   // random flags
   rand bit [7:0]           fbyte;
@@ -31,13 +34,13 @@ class i2c_item extends uvm_sequence_item;
 
   `uvm_object_utils_begin(i2c_item)
     `uvm_field_int(tran_id,                 UVM_DEFAULT)
-    `uvm_field_enum(bus_op_e,    bus_op,    UVM_DEFAULT)
+    `uvm_field_enum(bus_op_e, bus_op,       UVM_DEFAULT)
     `uvm_field_int(addr,                    UVM_DEFAULT)
     `uvm_field_int(num_data,                UVM_DEFAULT)
-    `uvm_field_queue_int(data_q,            UVM_DEFAULT)
     `uvm_field_int(start,                   UVM_DEFAULT)
     `uvm_field_int(stop,                    UVM_DEFAULT)
-    //------
+    `uvm_field_queue_int(data_q,            UVM_DEFAULT)
+    `uvm_field_queue_int(fmt_ovf_data_q,    UVM_DEFAULT | UVM_NOCOMPARE)
     `uvm_field_int(rstart,                  UVM_DEFAULT | UVM_NOPRINT | UVM_NOCOMPARE)
     `uvm_field_int(fbyte,                   UVM_DEFAULT | UVM_NOPRINT | UVM_NOCOMPARE)
     `uvm_field_int(ack,                     UVM_DEFAULT | UVM_NOPRINT | UVM_NOCOMPARE)
@@ -55,6 +58,7 @@ class i2c_item extends uvm_sequence_item;
     addr     = 0;
     drv_type = None;
     data_q.delete();
+    fmt_ovf_data_q.delete();
   endfunction : clear_data
 
   function void clear_flag();

--- a/hw/ip/i2c/data/i2c_testplan.hjson
+++ b/hw/ip/i2c/data/i2c_testplan.hjson
@@ -121,6 +121,22 @@
       tests: ["i2c_fifo_watermark"]
     }
     {
+      name: fifo_overflow
+      desc: '''
+            Test the overflow interrupt of fmt_fifo and rx_fifo.
+
+            Stimulus:
+              - Keep sending a number of format byte higher than fmt_fifo and rx_fifo depth
+
+            Checking:
+              - Ensure excess format bytes are dropped
+              - Ensure fmt_overflow and rx_overflow interrupt are asserted
+              - Ensure receving correct number of fmt_fifo and rx_fifo watermark interrupts
+            '''
+      milestone: V2
+      tests: ["i2c_fifo_overflow"]
+    }
+    {
       name: fmt_reset
       desc: '''
             Test fmt_fifo reset.
@@ -138,44 +154,14 @@
     {
       name: rx_reset
       desc: '''
-            Test rx_reset reset.
+            Test rx_fifo reset.
 
             Stimulus:
               - Fill up the rx fifo by sending data bytes over rx
-              - Reset the rx_fifo randomly after a random number of bytes shows up on rx_fifo, 
+              - Reset the rx_fifo randomly after a random number of bytes shows up on rx_fifo
 
             Checking:
               - Ensure that reads to rdata register yield 0s after rx_fifo is reset
-            '''
-      milestone: V2
-      tests: []
-    }
-    {
-      name: fmt_overflow
-      desc: '''
-            Test fmt_overflow interrupt.
-
-            Stimulus:
-              - Keep sending a number of format byte higher than fmt_fifo depth, delay the target response
-
-            Checking:
-              - Ensure excess format bytes are dropped
-              - Ensure intr_fmt_overflow interrupt is asserted
-            '''
-      milestone: V2
-      tests: []
-    }
-    {
-      name: rx_overflow
-      desc: '''
-            Test rx_overflow interrupt.
-
-            Stimulus:
-              - Request a number of bytes higher than rx_fifo depth, delay rx_fifo reading
-
-            Checking:
-              - Ensure excess data bytes are dropped
-              - Ensure intr_rx_overflow interrupt is asserted
             '''
       milestone: V2
       tests: []

--- a/hw/ip/i2c/data/i2c_testplan.hjson
+++ b/hw/ip/i2c/data/i2c_testplan.hjson
@@ -67,7 +67,7 @@
               - Reduce access latency for fmt_fifo and rx_fifo
               - Issue long read/write back-to-back transactions 
               - Read rx_fifo as soon as read data valid
-
+              - Clear interrupt quickly
             Checking:
               - Ensure transactions are transceivered correctly
             '''

--- a/hw/ip/i2c/dv/env/i2c_env.core
+++ b/hw/ip/i2c/dv/env/i2c_env.core
@@ -26,6 +26,7 @@ filesets:
       - seq_lib/i2c_override_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_fifo_watermark_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_fifo_overflow_vseq.sv: {is_include_file: true}
+      - seq_lib/i2c_perf_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/i2c/dv/env/i2c_env.core
+++ b/hw/ip/i2c/dv/env/i2c_env.core
@@ -25,6 +25,7 @@ filesets:
       - seq_lib/i2c_sanity_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_override_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_fifo_watermark_vseq.sv: {is_include_file: true}
+      - seq_lib/i2c_fifo_overflow_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/i2c/dv/env/i2c_env_cfg.sv
+++ b/hw/ip/i2c/dv/env/i2c_env_cfg.sv
@@ -5,8 +5,15 @@
 class i2c_env_cfg extends cip_base_env_cfg #(.RAL_T(i2c_reg_block));
 
   i2c_target_addr_mode_e target_addr_mode = Addr7BitMode;
+  uint ok_to_end_delay_ns = I2C_IDLE_TIME;
 
-  uint ok_to_end_delay_ns = 5000;
+  // bits to control fifos access
+  // set en_fmt_overflow to ensure fmt_overflow irq is triggered
+  bit en_fmt_overflow = 1'b0;
+  // set en_rx_overflow to ensure ensure rx_overflow irq is triggered
+  bit en_rx_overflow = 1'b0;
+  // set en_rx_watermark to ensure rx_watermark irq is triggered
+  bit en_rx_watermark = 1'b0;
 
   rand i2c_agent_cfg m_i2c_agent_cfg;
 

--- a/hw/ip/i2c/dv/env/i2c_env_pkg.sv
+++ b/hw/ip/i2c/dv/env/i2c_env_pkg.sv
@@ -56,7 +56,6 @@ package i2c_env_pkg;
   parameter uint I2C_MIN_TIMING  = 1; // at least 1
   parameter uint I2C_MAX_TIMING  = 5;
   parameter uint I2C_TIME_RANGE  = I2C_MAX_TIMING - I2C_MIN_TIMING;
-  parameter uint I2C_TIMEOUT_ENB = 1;
   parameter uint I2C_MIN_TIMEOUT = 1;
   parameter uint I2C_MAX_TIMEOUT = 4;
   parameter uint I2C_MAX_RXILVL  = 7;

--- a/hw/ip/i2c/dv/env/i2c_env_pkg.sv
+++ b/hw/ip/i2c/dv/env/i2c_env_pkg.sv
@@ -33,6 +33,12 @@ package i2c_env_pkg;
     NumI2cIntr     = 10
   } i2c_intr_e;
 
+  typedef enum int {
+    ReadOnly  = 0,
+    WriteOnly = 1,
+    ReadWrite = 2
+  } tran_type_e;
+
   // csr and mem total size for IP, TODO confirm below value with spec
   parameter uint I2C_ADDR_MAP_SIZE  = 128;
   parameter uint I2C_FMT_FIFO_DEPTH = 32;
@@ -55,7 +61,7 @@ package i2c_env_pkg;
   parameter uint I2C_MAX_TIMEOUT = 4;
   parameter uint I2C_MAX_RXILVL  = 7;
   parameter uint I2C_MAX_FMTILVL = 3;
-
+  parameter uint I2C_IDLE_TIME   = 5000;
   // package sources
   `include "i2c_env_cfg.sv"
   `include "i2c_env_cov.sv"

--- a/hw/ip/i2c/dv/env/i2c_scoreboard.sv
+++ b/hw/ip/i2c/dv/env/i2c_scoreboard.sv
@@ -50,8 +50,7 @@ class i2c_scoreboard extends cip_base_scoreboard #(
     uvm_reg   csr;
     i2c_item  sb_exp_wr_item;
     i2c_item  sb_exp_rd_item;
-    bit do_read_check = 1'b0;
-
+    bit do_read_check = 1'b0;    // TODO: Enable this bit later
     bit write = item.is_write();
 
     uvm_reg_addr_t csr_addr = get_normalized_addr(item.a_addr);
@@ -122,6 +121,7 @@ class i2c_scoreboard extends cip_base_scoreboard #(
               // write transaction
               if (exp_wr_item.start && exp_wr_item.bus_op == BusOpWrite) begin
                 cfg.clk_rst_vif.wait_clks(1); // irq appears with one cycle latency
+                // TODO: Gather all irq verification in SCB instead of distribute in vseq
                 if (cfg.intr_vif.pins[FmtOverflow]) begin
                   // fmt_fifo is overflow, capture dropped data
                   exp_wr_item.fmt_ovf_data_q.push_back(fbyte);

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_fifo_overflow_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_fifo_overflow_vseq.sv
@@ -32,7 +32,7 @@ class i2c_fifo_overflow_vseq extends i2c_fifo_watermark_vseq;
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(num_trans)
     for (int i = 0; i < num_trans; i++) begin
       check_fmt_overflow = 1'b1; // set to gracefully stop check_fmt_overflow_intr
-      check_rx_overflow  = 1'b1; // set to gracefully stop check_ex_overflow_intr
+      check_rx_overflow  = 1'b1; // set to gracefully stop check_rx_overflow_intr
       num_fmt_overflow   = 0;
       num_rx_overflow    = 0;
 
@@ -59,14 +59,14 @@ class i2c_fifo_overflow_vseq extends i2c_fifo_watermark_vseq;
           // -> send read transaction -> pooling and counting rx_overflow interrupt
           // -> check write complete -> stop pooling rx_overflow interrupt
           // -> verify the number of received rx_overflow interrupt
-          // TODO: -> verify the rx_data dropped should be performed in scoreboard
+          // -> verify the rx_data dropped is performed in scoreboard
           if (check_rx_overflow) begin
             host_send_trans(.num_trans(1), .trans_type(ReadOnly));
             csr_spinwait(.ptr(ral.status.rxempty), .exp_data(1'b1));
             check_rx_overflow = 1'b0;
             `DV_CHECK_EQ(num_rx_overflow, 1)
             `uvm_info(`gfn, $sformatf("\nRun %0d, num_rx_overflow %d",
-                i, num_rx_overflow), UVM_LOW)
+                i, num_rx_overflow), UVM_DEBUG)
           end
         end
         begin

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_fifo_overflow_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_fifo_overflow_vseq.sv
@@ -1,0 +1,102 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// basic fifo_overflow test vseq
+class i2c_fifo_overflow_vseq extends i2c_fifo_watermark_vseq;
+  `uvm_object_utils(i2c_fifo_overflow_vseq)
+
+  `uvm_object_new
+
+  // counting the number of received overflow interrupts
+  local uint num_fmt_overflow;
+  local uint num_rx_overflow;
+  rand  uint num_data_rx_ovf;
+
+  // send more one data than rx_fifo depth to trigger rx_overflow
+  constraint num_rd_bytes_c {
+    num_rd_bytes == I2C_RX_FIFO_DEPTH + 1;
+  }
+
+  task body();
+    bit check_fmt_overflow;
+    bit check_rx_overflow;
+    bit rxempty = 1'b0;
+    device_init();
+    host_init();
+
+    // config fmt_overflow and rx_overflow tests
+    cfg.en_fmt_overflow = 1'b1;
+    cfg.en_rx_overflow = 1'b1;
+
+    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(num_trans)
+    for (int i = 0; i < num_trans; i++) begin
+      check_fmt_overflow = 1'b1; // set to gracefully stop check_fmt_overflow_intr
+      check_rx_overflow  = 1'b1; // set to gracefully stop check_ex_overflow_intr
+      num_fmt_overflow   = 0;
+      num_rx_overflow    = 0;
+
+      fork
+        begin
+          //*** verify fmt_overflow irq:
+          // -> send write transaction -> pooling and counting fmt_overflow interrupt
+          // -> check write complete -> stop pooling fmt_overflow interrupt
+          // -> verify the number of received fmt_watermark interrupt
+          // -> verify fmt_data dropped is performed scoreboard
+          if (check_fmt_overflow) begin
+            host_send_trans(.num_trans(1), .trans_type(WriteOnly));
+            csr_spinwait(.ptr(ral.status.fmtempty), .exp_data(1'b1));
+            check_fmt_overflow = 1'b0;
+            // number of fmt_overflow received is at most num_data_rx_ovf
+            // since fmt_fifo can be drained thus decreasing num_fmt_overflow counter
+            `DV_CHECK_GT(num_fmt_overflow, 0)
+            `DV_CHECK_LE(num_fmt_overflow, num_data_ovf)
+            `uvm_info(`gfn, $sformatf("\nRun %0d, num_fmt_overflow %0d",
+                i, num_fmt_overflow), UVM_DEBUG)
+          end
+
+          //*** verify rx_overflow irq:
+          // -> send read transaction -> pooling and counting rx_overflow interrupt
+          // -> check write complete -> stop pooling rx_overflow interrupt
+          // -> verify the number of received rx_overflow interrupt
+          // TODO: -> verify the rx_data dropped should be performed in scoreboard
+          if (check_rx_overflow) begin
+            host_send_trans(.num_trans(1), .trans_type(ReadOnly));
+            csr_spinwait(.ptr(ral.status.rxempty), .exp_data(1'b1));
+            check_rx_overflow = 1'b0;
+            `DV_CHECK_EQ(num_rx_overflow, 1)
+            `uvm_info(`gfn, $sformatf("\nRun %0d, num_rx_overflow %d",
+                i, num_rx_overflow), UVM_LOW)
+          end
+        end
+        begin
+          while (check_fmt_overflow) check_fmt_overflow_intr();
+        end
+        begin
+          while (check_rx_overflow) check_rx_overflow_intr();
+        end
+      join
+    end
+  endtask : body
+
+  task check_fmt_overflow_intr();
+    bit fmt_overflow;
+
+    csr_rd(.ptr(ral.intr_state.fmt_overflow), .value(fmt_overflow));
+    if (fmt_overflow) begin
+      clear_interrupt(FmtOverflow);
+      num_fmt_overflow++;
+    end
+  endtask : check_fmt_overflow_intr
+
+  task check_rx_overflow_intr();
+    bit rx_overflow;
+
+    csr_rd(.ptr(ral.intr_state.rx_overflow), .value(rx_overflow));
+    if (rx_overflow) begin
+      clear_interrupt(RxOverflow);
+      num_rx_overflow++;
+    end
+  endtask : check_rx_overflow_intr
+
+endclass : i2c_fifo_overflow_vseq

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_fifo_watermark_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_fifo_watermark_vseq.sv
@@ -120,3 +120,4 @@ class i2c_fifo_watermark_vseq extends i2c_rx_tx_vseq;
   endtask : check_rx_watermark_intr
 
 endclass : i2c_fifo_watermark_vseq
+

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_perf_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_perf_vseq.sv
@@ -1,0 +1,71 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// performance test vseq
+class i2c_perf_vseq extends i2c_rx_tx_vseq;
+  `uvm_object_utils(i2c_perf_vseq)
+  `uvm_object_new
+
+  constraint num_trans_c { num_trans inside {[10 : 16]}; }
+
+  // should have few long transactions
+  constraint num_wr_bytes_c {
+    num_wr_bytes dist {
+      1       :/ 15,
+      [2:8]   :/ 20,
+      [9:32]  :/ 15,
+      256     :/ 50
+    };
+  }
+  // num_rd_bytes = 1: read transaction length is 256b bytes
+  constraint num_rd_bytes_c {
+    num_rd_bytes dist {
+      0       :/ 50,
+      1       :/ 15,
+      [2:8]   :/ 20,
+      [9:32]  :/ 15
+    };
+  }
+  
+  // clear interrupt immediately
+  constraint clear_intr_dly_c { clear_intr_dly == 0; }
+  
+  // zero fifo access latency
+  constraint fmt_fifo_access_dly_c { fmt_fifo_access_dly == 0;}
+  constraint rx_fifo_access_dly_c  { rx_fifo_access_dly  == 0;}
+
+  // fast timing values programmed to registers
+  constraint timing_val_c {
+    thigh     == 1;
+    t_r       == 1;
+    t_f       == 1;
+    thd_sta   == 1;
+    tsu_sto   == 1;
+    tsu_dat   == 1;
+    thd_dat   == 1;
+    t_timeout == 1;
+    e_timeout == 1;
+    tsu_sta   == 1;
+    tlow      == 4;  // min:  (t_r + tsu_dat + thd_dat + 1)
+    t_buf     == 1;  // min:  (tsu_sta - t_r + 1)
+  }
+
+  task body();
+    device_init();
+    host_init();
+
+    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(num_trans)
+    fork
+      begin
+        while (do_interrupt) process_interrupts();
+      end
+      begin
+        host_send_trans(num_trans);
+        do_interrupt = 1'b0; // gracefully stop process_interrupts
+      end
+    join
+  endtask : body
+
+endclass : i2c_perf_vseq
+

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_rx_tx_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_rx_tx_vseq.sv
@@ -84,6 +84,9 @@ class i2c_rx_tx_vseq extends i2c_base_vseq;
           stop  == (last_tran) ? 1'b1 : stop;
         )
         `DV_CHECK_EQ(fmt_item.stop | fmt_item.rcont, 1)
+        if (num_rd_bytes == 0) begin
+          `uvm_info(`gfn, "\nRead transaction length is 256 byte", UVM_DEBUG)
+        end
 
         // accumulate number of read byte
         total_rd_bytes += (num_rd_bytes) ? num_rd_bytes : 256;
@@ -131,6 +134,10 @@ class i2c_rx_tx_vseq extends i2c_base_vseq;
   virtual task host_write_trans(bit last_tran);
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(num_wr_bytes)
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(wr_data)
+    if (num_wr_bytes == 256) begin
+      `uvm_info(`gfn, "\nWrite transaction length is 256 byte", UVM_DEBUG)
+    end
+
     for (int i = 1; i <= num_wr_bytes; i++) begin
       `DV_CHECK_RANDOMIZE_WITH_FATAL(fmt_item,
         start == 1'b0;
@@ -168,8 +175,8 @@ class i2c_rx_tx_vseq extends i2c_base_vseq;
       `uvm_info(`gfn, "\nClearing rx_watermark", UVM_DEBUG)
     end
 
-    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(access_intr_dly)
-    cfg.clk_rst_vif.wait_clks(access_intr_dly);
+    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(clear_intr_dly)
+    cfg.clk_rst_vif.wait_clks(clear_intr_dly);
     csr_wr(.csr(ral.intr_state), .value(intr_clear));
   endtask : process_interrupts
 

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_sanity_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_sanity_vseq.sv
@@ -7,10 +7,10 @@ class i2c_sanity_vseq extends i2c_rx_tx_vseq;
   `uvm_object_utils(i2c_sanity_vseq)
   `uvm_object_new
 
-  constraint access_intr_dly_c { access_intr_dly inside {[0 : 10]}; }
-  constraint num_wr_bytes_c    { num_wr_bytes    inside {[1 : 5]}; }
-  constraint num_rd_bytes_c    { num_rd_bytes    inside {[1 : 5]}; }
-  constraint num_trans_c       { num_trans       inside {[50 : 100]}; }
+  constraint clear_intr_dly_c  { clear_intr_dly inside {[0 : 10]}; }
+  constraint num_wr_bytes_c    { num_wr_bytes   inside {[1 : 5]}; }
+  constraint num_rd_bytes_c    { num_rd_bytes   inside {[1 : 5]}; }
+  constraint num_trans_c       { num_trans      inside {[50 : 100]}; }
 
   task body();
     device_init();

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
@@ -10,3 +10,4 @@
 `include "i2c_override_vseq.sv"
 `include "i2c_fifo_watermark_vseq.sv"
 `include "i2c_fifo_overflow_vseq.sv"
+`include "i2c_perf_vseq.sv"

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
@@ -9,3 +9,4 @@
 
 `include "i2c_override_vseq.sv"
 `include "i2c_fifo_watermark_vseq.sv"
+`include "i2c_fifo_overflow_vseq.sv"

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -64,6 +64,13 @@
       name: i2c_fifo_overflow
       uvm_test_seq: i2c_fifo_overflow_vseq
     }
+
+    {
+      name: i2c_perf
+      // define low reseed due to long simulation time
+      reseed: 5
+      uvm_test_seq: i2c_perf_vseq
+    }
   ]
 
   // List of regressions.

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -59,6 +59,11 @@
       name: i2c_fifo_watermark
       uvm_test_seq: i2c_fifo_watermark_vseq
     }
+
+    {
+      name: i2c_fifo_overflow
+      uvm_test_seq: i2c_fifo_overflow_vseq
+    }
   ]
 
   // List of regressions.


### PR DESCRIPTION
**1. i2c_fifo_overflow**
The main point of this test is to create constraints and sequence in order to deterministically trigger overflow interrupts
which can be predictable and verified by DV
  - Update i2c_testplan.hjson to replace rx_fifo_overflow and fmt_fifo_overflow tests by a unified fifo_overflow test
  - Add i2c_fifo_overflow_vseq to verify fmt_overflow and rx_overflow interrupt
  - Update i2c_scoreboard to verify dropped data due to fifo overflow
  - Minor refactor i2c_fifo_watermark_vseq

**2. i2c_perf**    
This test verified transaction sending and receiving at max bandwidth by   
  - Set access latency of fmt_fifo and rx_fifo to zero
  - Issue long 256-byte read/write back-to-back transactions to utilize bandwidth for data transfer
  - Clear interrupts immediately if asserted
   
Signed-off-by: Tung Hoang <hoang.tung@wdc.com>