### PR TITLE
CHECK library cleanup

### DIFF
--- a/sw/device/examples/demos.c
+++ b/sw/device/examples/demos.c
@@ -18,12 +18,12 @@ void demo_gpio_startup(dif_gpio_t *gpio) {
   LOG_INFO("Watch the LEDs!");
 
   // Give a LED pattern as startup indicator for 5 seconds.
-  CHECKZ(dif_gpio_all_write(gpio, 0xff00));
+  CHECK(dif_gpio_all_write(gpio, 0xff00) == kDifGpioOk);
   for (int i = 0; i < 32; ++i) {
     usleep(5 * 1000);  // 5 ms
-    CHECKZ(dif_gpio_pin_write(gpio, 8 + (i % 8), (i / 8) % 2));
+    CHECK(dif_gpio_pin_write(gpio, 8 + (i % 8), (i / 8) % 2) == kDifGpioOk);
   }
-  CHECKZ(dif_gpio_all_write(gpio, 0x0000));  // All LEDs off.
+  CHECK(dif_gpio_all_write(gpio, 0x0000) == kDifGpioOk);  // All LEDs off.
 }
 
 /**
@@ -39,7 +39,7 @@ static const uint32_t kFtdiMask = 0x10000;
 
 uint32_t demo_gpio_to_log_echo(dif_gpio_t *gpio, uint32_t prev_gpio_state) {
   uint32_t gpio_state;
-  CHECKZ(dif_gpio_all_read(gpio, &gpio_state));
+  CHECK(dif_gpio_all_read(gpio, &gpio_state) == kDifGpioOk);
   gpio_state &= kGpioMask;
 
   uint32_t state_delta = prev_gpio_state ^ gpio_state;
@@ -76,6 +76,6 @@ void demo_uart_to_uart_and_gpio_echo(dif_gpio_t *gpio) {
   char rcv_char;
   while (uart_rcv_char(&rcv_char) != -1) {
     uart_send_char(rcv_char);
-    CHECKZ(dif_gpio_all_write(gpio, rcv_char << 8));
+    CHECK(dif_gpio_all_write(gpio, rcv_char << 8) == kDifGpioOk);
   }
 }

--- a/sw/device/examples/hello_usbdev/hello_usbdev.c
+++ b/sw/device/examples/hello_usbdev/hello_usbdev.c
@@ -88,9 +88,9 @@ int main(int argc, char **argv) {
   dif_gpio_config_t gpio_config = {
       .base_addr = mmio_region_from_addr(0x40010000),
   };
-  CHECKZ(dif_gpio_init(&gpio_config, &gpio));
+  CHECK(dif_gpio_init(&gpio_config, &gpio) == kDifGpioOk);
   // Enable GPIO: 0-7 and 16 is input; 8-15 is output.
-  CHECKZ(dif_gpio_output_mode_all_set(&gpio, 0x0ff00));
+  CHECK(dif_gpio_output_mode_all_set(&gpio, 0x0ff00) == kDifGpioOk);
 
   LOG_INFO("Hello, USB!");
   LOG_INFO("Built at: " __DATE__ ", " __TIME__);
@@ -119,7 +119,7 @@ int main(int argc, char **argv) {
     char rcv_char;
     while (uart_rcv_char(&rcv_char) != -1) {
       uart_send_char(rcv_char);
-      CHECKZ(dif_gpio_all_write(&gpio, rcv_char << 8));
+      CHECK(dif_gpio_all_write(&gpio, rcv_char << 8) == kDifGpioOk);
 
       if (rcv_char == '/') {
         uint32_t usb_irq_state = REG32(USBDEV_INTR_STATE());

--- a/sw/device/examples/hello_world/hello_world.c
+++ b/sw/device/examples/hello_world/hello_world.c
@@ -25,9 +25,9 @@ int main(int argc, char **argv) {
   dif_gpio_config_t gpio_config = {
       .base_addr = mmio_region_from_addr(0x40010000),
   };
-  CHECKZ(dif_gpio_init(&gpio_config, &gpio));
+  CHECK(dif_gpio_init(&gpio_config, &gpio) == kDifGpioOk);
   // Enable GPIO: 0-7 and 16 is input; 8-15 is output.
-  CHECKZ(dif_gpio_output_mode_all_set(&gpio, 0x0ff00));
+  CHECK(dif_gpio_output_mode_all_set(&gpio, 0x0ff00) == kDifGpioOk);
   // Add DATE and TIME because I keep fooling myself with old versions
   LOG_INFO("Hello World!");
   LOG_INFO("Built at: " __DATE__ ", " __TIME__);
@@ -36,7 +36,7 @@ int main(int argc, char **argv) {
 
   // Now have UART <-> Buttons/LEDs demo
   // all LEDs off
-  CHECKZ(dif_gpio_all_write(&gpio, 0x0000));
+  CHECK(dif_gpio_all_write(&gpio, 0x0000) == kDifGpioOk);
   LOG_INFO("Try out the switches on the board");
   LOG_INFO("or type anything into the console window.");
   LOG_INFO("The LEDs show the ASCII code of the last character.");

--- a/sw/device/lib/runtime/check.h
+++ b/sw/device/lib/runtime/check.h
@@ -36,13 +36,4 @@
     }                                         \
   } while (false)
 
-/**
- * Shorthand for CHECK(value == 0).
- *
- * @param condition a value to check.
- * @param ... arguments to a LOG_* macro, which are evaluated if the check
- * fails.
- */
-#define CHECKZ(value, ...) CHECK((value) == 0, ##__VA_ARGS__)
-
 #endif  // OPENTITAN_SW_DEVICE_LIB_RUNTIME_CHECK_H_

--- a/sw/device/lib/runtime/check.h
+++ b/sw/device/lib/runtime/check.h
@@ -8,6 +8,7 @@
 #include <stdbool.h>
 
 #include "sw/device/lib/base/log.h"
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/testing/test_status.h"
 
@@ -23,17 +24,25 @@
  * @param ... arguments to a LOG_* macro, which are evaluated if the check
  * fails.
  */
-#define CHECK(condition, ...)                 \
-  do {                                        \
-    if (!(condition)) {                       \
-      LOG_ERROR("CHECK-fail: " __VA_ARGS__);  \
-      /* Currently, this macro will call into \
-         the test failure code, which logs    \
-         "FAIL" and aborts. In the future,    \
-         we will try to condition on whether  \
-         or not this is a test.*/             \
-      test_status_set(kTestStatusFailed);     \
-    }                                         \
+#define CHECK(condition, ...)                             \
+  do {                                                    \
+    if (!(condition)) {                                   \
+      /* NOTE: because the condition in this if           \
+         statement can be statically determined,          \
+         only one of the below string constants           \
+         will be included in the final binary.*/          \
+      if (GET_NUM_VARIABLE_ARGS(_, ##__VA_ARGS__) == 0) { \
+        LOG_ERROR("CHECK-fail: " #condition);             \
+      } else {                                            \
+        LOG_ERROR("CHECK-fail: " __VA_ARGS__);            \
+      }                                                   \
+      /* Currently, this macro will call into             \
+         the test failure code, which logs                \
+         "FAIL" and aborts. In the future,                \
+         we will try to condition on whether              \
+         or not this is a test.*/                         \
+      test_status_set(kTestStatusFailed);                 \
+    }                                                     \
   } while (false)
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_RUNTIME_CHECK_H_

--- a/sw/device/tests/rv_timer_test.c
+++ b/sw/device/tests/rv_timer_test.c
@@ -27,8 +27,8 @@ bool test_main(void) {
   // Enable GPIO: 0-7 and 16 is input, 8-15 is output
   dif_gpio_config_t gpio_config = {
       .base_addr = mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR)};
-  CHECKZ(dif_gpio_init(&gpio_config, &gpio));
-  CHECKZ(dif_gpio_output_mode_all_set(&gpio, 0xFF00));
+  CHECK(dif_gpio_init(&gpio_config, &gpio) == kDifGpioOk);
+  CHECK(dif_gpio_output_mode_all_set(&gpio, 0xFF00) == kDifGpioOk);
 
   irq_global_ctrl(true);
   irq_timer_ctrl(true);
@@ -39,13 +39,13 @@ bool test_main(void) {
   rv_timer_set_cmp(hart, cmp);
   rv_timer_ctrl(hart, true);
 
-  CHECKZ(dif_gpio_all_write(&gpio, 0xFF00));  // all LEDs on
+  CHECK(dif_gpio_all_write(&gpio, 0xFF00) == kDifGpioOk);  // all LEDs on
 
   while (!intr_handling_success) {
     wait_for_interrupt();
   }
 
-  CHECKZ(dif_gpio_all_write(&gpio, 0xAA00));  // Test Completed
+  CHECK(dif_gpio_all_write(&gpio, 0xAA00) == kDifGpioOk);  // Test Completed
 
   return true;
 }


### PR DESCRIPTION
This change:
- Gets rid of `CHECKZ`, which I regret including in the original `CHECK` library: it looks a lot like `CHECK` at a distance, but with a negation, and no one actually uses it.
- Makes a no-arguments `CHECK` slightly more helpful, by printing out the `CHECK`'d expression. Before, it just printed a line number and abridged file name. (Surprisingly, this does not require any new macro magic.)