### PR TITLE
[aes] Add idle hint signal for clkmgr

### DIFF
--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -37,6 +37,13 @@
       struct:  "hw_key_req",
       width:   "1"
     }
+    { name:    "idle",
+      type:    "uni",
+      act:     "req",
+      package: "",
+      struct:  "logic",
+      width:   "1"
+    }
     // TODO: CSRNG peripheral interface/RNG distribution network interface needs to be defined first, see https://github.com/lowRISC/opentitan/issues/2693.
     /*{ name:    "entropy",
       type:    "req_rsp",

--- a/hw/ip/aes/rtl/aes.sv
+++ b/hw/ip/aes/rtl/aes.sv
@@ -20,6 +20,9 @@ module aes #(
   // TODO: CSRNG peripheral interface/RNG distribution network interface needs to be defined first,
   // see https://github.com/lowRISC/opentitan/issues/2693.
 
+  // Idle indicator for clock manager
+  output logic              idle_o,
+
   // Bus interface
   input  tlul_pkg::tl_h2d_t tl_i,
   output tlul_pkg::tl_d2h_t tl_o,
@@ -100,9 +103,13 @@ module aes #(
     );
   end
 
+  // TODO: idle.d is actually only valid together with idle.de.
+  idle_o = hw2reg.idle.d;
+
   // All outputs should have a known value after reset
   `ASSERT_KNOWN(TlODValidKnown, tl_o.d_valid)
   `ASSERT_KNOWN(TlOAReadyKnown, tl_o.a_ready)
   `ASSERT_KNOWN(AlertTxKnown, alert_tx_o)
+  `ASSERT_KNOWN(IdleKnown, idle_o)
 
 endmodule

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -2088,6 +2088,17 @@
           inst_name: aes
           index: -1
         }
+        {
+          name: idle
+          type: uni
+          act: req
+          package: ""
+          struct: logic
+          width: 1
+          inst_name: aes
+          top_signame: aes_idle
+          index: -1
+        }
       ]
     }
     {
@@ -2850,6 +2861,8 @@
           act: rcv
           package: clkmgr_pkg
           inst_name: clkmgr_aon
+          width: 1
+          top_signame: clkmgr_aon_status
           index: -1
         }
       ]
@@ -4078,6 +4091,8 @@
       pwrmgr_aon.pwr_cpu
       clkmgr_aon.clocks
       csrng.csrng_cmd
+      aes.idle
+      clkmgr_aon.status
     ]
     external:
     [
@@ -7505,6 +7520,17 @@
         index: -1
       }
       {
+        name: idle
+        type: uni
+        act: req
+        package: ""
+        struct: logic
+        width: 1
+        inst_name: aes
+        top_signame: aes_idle
+        index: -1
+      }
+      {
         struct: hw_key_req
         type: uni
         name: keymgr_key
@@ -7789,6 +7815,8 @@
         act: rcv
         package: clkmgr_pkg
         inst_name: clkmgr_aon
+        width: 1
+        top_signame: clkmgr_aon_status
         index: -1
       }
       {
@@ -8348,6 +8376,20 @@
         signame: csrng_csrng_cmd_rsp
         width: 3
         type: req_rsp
+      }
+      {
+        package: ""
+        struct: logic
+        signame: aes_idle
+        width: 1
+        type: uni
+      }
+      {
+        package: clkmgr_pkg
+        struct: clk_hint_status
+        signame: clkmgr_aon_status
+        width: 1
+        type: uni
       }
     ]
   }

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -474,7 +474,7 @@
     // top is to connect to top net/struct.
     // It defines the signal in the top and connect from the module,
     // use of the signal is up to top template
-    'top': ['rstmgr_aon.resets', 'rstmgr_aon.cpu', 'pwrmgr_aon.pwr_cpu', 'clkmgr_aon.clocks', 'csrng.csrng_cmd'],
+    'top': ['rstmgr_aon.resets', 'rstmgr_aon.cpu', 'pwrmgr_aon.pwr_cpu', 'clkmgr_aon.clocks', 'csrng.csrng_cmd', 'aes.idle', 'clkmgr_aon.status'],
 
     // ext is to create port in the top.
     'external': ['sensor_ctrl.ast_host', 'sensor_ctrl.ast_dev', 'sensor_ctrl.ast_status',

--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -210,6 +210,13 @@ module top_${top["name"]} #(
   ${lib.im_defname(sig)} ${lib.bitarray(sig["width"],1)} ${sig["signame"]};
 % endfor
 
+## Inter-module signal collection
+  always_comb begin
+    // TODO: So far just aes is connected
+    clkmgr_aon_status.idle    = clkmgr_pkg::CLK_HINT_STATUS_DEFAULT;
+    clkmgr_aon_status.idle[0] = aes_idle;
+  end
+
 ## TODO: Inter-module signal Temporary connection
   assign csrng_csrng_cmd_req = '0;
 

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -470,6 +470,14 @@ module top_earlgrey #(
   clkmgr_pkg::clkmgr_out_t       clkmgr_aon_clocks;
   csrng_pkg::csrng_req_t [2:0] csrng_csrng_cmd_req;
   csrng_pkg::csrng_rsp_t [2:0] csrng_csrng_cmd_rsp;
+  logic       aes_idle;
+  clkmgr_pkg::clk_hint_status_t       clkmgr_aon_status;
+
+  always_comb begin
+    // TODO: So far just aes is connected
+    clkmgr_aon_status.idle    = clkmgr_pkg::CLK_HINT_STATUS_DEFAULT;
+    clkmgr_aon_status.idle[0] = aes_idle;
+  end
 
   assign csrng_csrng_cmd_req = '0;
 
@@ -1108,6 +1116,7 @@ module top_earlgrey #(
 
       // Inter-module signals
       .keymgr_key_i(keymgr_pkg::HW_KEY_REQ_DEFAULT),
+      .idle_o(aes_idle),
       .clk_i (clkmgr_aon_clocks.clk_main_aes),
       .rst_ni (rstmgr_aon_resets.rst_sys_n)
   );
@@ -1289,7 +1298,7 @@ module top_earlgrey #(
       .pwr_i(pwrmgr_aon_pwr_clk_req),
       .pwr_o(pwrmgr_aon_pwr_clk_rsp),
       .dft_i(clkmgr_pkg::CLK_DFT_DEFAULT),
-      .status_i(clkmgr_pkg::CLK_HINT_STATUS_DEFAULT),
+      .status_i(clkmgr_aon_status),
       .clk_i (clkmgr_aon_clocks.clk_io_div2_powerup),
       .rst_ni (rstmgr_aon_resets.rst_por_io_n),
       .rst_main_ni (rstmgr_aon_resets.rst_por_n),


### PR DESCRIPTION
This PR adds an idle hint signal from aes to clkmgr as requested in #2647. This PR is for `bronze` only.

A separate PR for the main branch will follow, for this also the idle signal generation inside aes will need to be reworked slightly.