### PR TITLE
[otbn,model] Add basic OTBN model specifics

### DIFF
--- a/hw/ip/otbn/dv/model/otbn_model.cc
+++ b/hw/ip/otbn/dv/model/otbn_model.cc
@@ -46,6 +46,7 @@ int run_model(const char *imem_scope, int imem_words, const char *dmem_scope,
   char ifname[] = "/tmp/otbn_XXXXXX/imem";
   char dfname[] = "/tmp/otbn_XXXXXX/dmem";
   char cfname[] = "/tmp/otbn_XXXXXX/cycles";
+  char tfname[] = "/tmp/otbn_XXXXXX/trace";
 
   if (mkdtemp(dir) == nullptr) {
     std::cerr << "Cannot create temporary directory" << std::endl;
@@ -55,6 +56,7 @@ int run_model(const char *imem_scope, int imem_words, const char *dmem_scope,
   std::memcpy(ifname, dir, strlen(dir));
   std::memcpy(dfname, dir, strlen(dir));
   std::memcpy(cfname, dir, strlen(dir));
+  std::memcpy(tfname, dir, strlen(dir));
 
   fp = std::fopen(dfname, "w+");
   if (fp == nullptr) {
@@ -94,7 +96,9 @@ int run_model(const char *imem_scope, int imem_words, const char *dmem_scope,
 
   std::stringstream strstr;
   strstr << "otbn-python-model " << imem_words << " " << ifname << " "
-         << dmem_words << " " << dfname << " " << cfname;
+         << dmem_words << " " << dfname << " " << cfname << " " << tfname;
+
+  std::cout << "Execute OTBN in " << dir << std::endl;
 
   if (std::system(strstr.str().c_str()) != 0) {
     std::cerr << "Cannot execute model" << std::endl;

--- a/util/otbnsim/README.md
+++ b/util/otbnsim/README.md
@@ -1,0 +1,91 @@
+# OpenTitan Big Number Python Model
+
+## Generate documentation
+
+```console
+$ python -m otbnsim.doc
+++++ Instruction Formats
+{'id': 'L',
+ 'fields': [{'name': 'bodysize',
+             'base': 20,
+             'size': 12,
+             'description': '',
+             'static': False,
+             'value': None},
+            {'name': 'funct3',
+             'base': 12,
+             'size': 3,
+             'description': '',
+             'static': True,
+             'value': None},
+
+[...]
+
+++++ Instructions
+{'format': 'L',
+ 'description': 'Loop (indirect)\n'
+                '\n'
+                'Repeat a sequence of code multiple times. The number of '
+                'iterations is a GPR\n'
+                'value. The length of the loop is given as immediate.\n'
+                '\n'
+                'Alternative assembly notation: The size of the loop body is '
+                'given by the\n'
+                'number of instructions in the parentheses.\n'
+                '\n'
+                'LOOP <grs> (\n'
+                '  # loop body\n'
+                ')',
+ 'asm_signature': 'loop <iter>, <bodysize>',
+ 'code': '        model.state.loop_start(int(reg[rs1]), int(bodysize))'}
+
+[...]
+```
+
+## Assembler
+
+Assemble to verify everything works:
+
+```console
+$ otbn-asm << EOF
+> LOOPI 8 (
+>   addi x2, x2, 1
+> )
+> EOF
+loopi 8, 1
+addi x2, x2, 1
+```
+
+Produce different output format, C structs:
+
+```console
+$ otbn-asm -O carray test.S
+static const uint32_t code [] = {
+    0x0010140b, // loopi 8, 1
+    0x00110113, // addi x2, x2, 1
+};
+```
+
+Finally, generate a binary, write to output file:
+
+```console
+$ otbn-asm -O binary test.S test.bin
+$ hexdump test.bin
+0000000 140b 0010 0113 0011
+0000008
+```
+
+## Run standalone test
+
+```console
+$ python -m otbnsim.standalone test.S
+loopi 8, 1                          | [Start LOOP, 8 iterations, bodysize: 1]
+addi x2, x2, 1                      | [x2 = 00000001, pc = 00000004, LOOP iteration 1/8]
+addi x2, x2, 1                      | [x2 = 00000002, pc = 00000004, LOOP iteration 2/8]
+addi x2, x2, 1                      | [x2 = 00000003, pc = 00000004, LOOP iteration 3/8]
+addi x2, x2, 1                      | [x2 = 00000004, pc = 00000004, LOOP iteration 4/8]
+addi x2, x2, 1                      | [x2 = 00000005, pc = 00000004, LOOP iteration 5/8]
+addi x2, x2, 1                      | [x2 = 00000006, pc = 00000004, LOOP iteration 6/8]
+addi x2, x2, 1                      | [x2 = 00000007, pc = 00000004, LOOP iteration 7/8]
+addi x2, x2, 1                      | [x2 = 00000008, LOOP iteration 8/8]
+```

--- a/util/otbnsim/README.md
+++ b/util/otbnsim/README.md
@@ -89,3 +89,41 @@ addi x2, x2, 1                      | [x2 = 00000006, pc = 00000004, LOOP iterat
 addi x2, x2, 1                      | [x2 = 00000007, pc = 00000004, LOOP iteration 7/8]
 addi x2, x2, 1                      | [x2 = 00000008, LOOP iteration 8/8]
 ```
+
+## Run pytest
+
+```console
+$ pytest
+```
+
+Grab model trace for debugging
+
+```console
+$ pytest --model-verbose
+```
+
+## Get program from database of test programs
+
+Test programs are available in a python module. Assembler codes are stored in
+this file and they can be generated as with the assembler.
+
+Examples:
+
+- Produce assembler code
+
+```console
+$ python test/programs.py mul_256x256
+```
+
+Produce C array
+
+
+```console
+$ python test/programs.py -O carray mul_256x256
+```
+
+Produce binary file
+
+```console
+$ python test/programs.py -O binary mul_256x256 program.bin
+```

--- a/util/otbnsim/otbnsim/asm.py
+++ b/util/otbnsim/otbnsim/asm.py
@@ -1,0 +1,170 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+from lark import Lark, Transformer, v_args, Token
+import argparse
+import sys
+from struct import pack
+
+from riscvmodel.isa import reverse_lookup
+from .insn import *
+
+from .variant import RV32IXotbn
+
+otbn_grammar = r"""
+start: statement+
+statement: instruction
+        | loop
+        | "\n"
+
+instruction: MNEMONIC operands? "\n"
+
+operands: operand ("," operand)*
+
+operand: REGNAME
+    | NUMBER
+    | addr_operand
+    | select_operand
+    | shift_operand
+    | fg_operand
+
+shift_operand: SHIFT_TYPE SHIFT_BYTES
+
+fg_operand: "FG0" | "FG1"
+
+select_operand: REGNAME "." SELECT
+
+addr_operand: NUMBER "(" REGNAME ")"
+
+loop: "LOOP"i REGNAME "(" "\n" statement+ ")" "\n"
+    | "LOOPI"i NUMBER "(" "\n" statement+ ")" "\n"
+
+MNEMONIC: ("a".."z" | "A".."Z" | ".")+
+NUMBER: ("0".."9" | "a".."f" | "A".."F" | "x" | "-")+
+REGNAME: "a".."z" NUMBER
+SELECT: ("l" | "u" | "0".."3")
+SHIFT_TYPE: ("<<" | ">>")
+SHIFT_BYTES: NUMBER "B"
+WHITESPACE: (" " | "\t" )+
+COMMENT: "//" /[^\n]*/ "\n" | "/*" /(.|\n)+/ "*/"
+
+%ignore COMMENT
+%ignore WHITESPACE
+"""
+
+
+class lowerLoop:
+    def flatten(stmtlist):
+        flat = []
+        for stmt in stmtlist:
+            if stmt is None:
+                continue
+            if isinstance(stmt, list):
+                flat += lowerLoop.flatten(stmt)
+            else:
+                flat.append(stmt)
+        return flat
+
+    def generate(self, t):
+        if t.data == "start":
+            return lowerLoop.flatten(
+                [self.generate(stmt) for stmt in t.children])
+        elif t.data == "statement":
+            if len(t.children) > 0:
+                return self.generate(t.children[0])
+        elif t.data == "instruction":
+            mnemonic = str(t.children[0]).lower().split(".")
+            if len(mnemonic) == 1:
+                ops = []
+                mnemonic = mnemonic[0]
+            else:
+                # Can only be a "bn.<mnemonic>[.<mod>]+"
+                assert mnemonic[0] == "bn"
+                ops = mnemonic[2:] if len(mnemonic) > 2 else []
+                mnemonic = "{}.{}".format(mnemonic[0], mnemonic[1])
+            cls = reverse_lookup(mnemonic, RV32IXotbn)
+            assert cls, "Unknown instruction: {}".format(mnemonic)
+            insn = cls()
+            if len(t.children) > 1:
+                for o in t.children[1].children:
+                    ops += self.generate(o)
+            insn.ops_from_list(ops)
+            return insn
+        elif t.data == "operand":
+            if isinstance(t.children[0], Token):
+                return [t.children[0].value]
+            else:
+                return self.generate(t.children[0])
+        elif t.data == "addr_operand":
+            return [t.children[0].value, t.children[1].value]
+        elif t.data == "select_operand":
+            return ["{}.{}".format(t.children[0].value, t.children[1].value)]
+        elif t.data == "shift_operand":
+            return [t.children[0].value, t.children[1].value]
+        elif t.data == "fg_operand":
+            return [t.value]
+        elif t.data == "loop":
+            iterations = str(t.children[0])
+            bodysize = len(t.children[1:])
+            if t.children[0].type == "NUMBER":
+                insn = InstructionLOOPI(int(iterations), bodysize)
+            else:
+                insn = InstructionLOOP(iterations, bodysize)
+            insns = [insn]
+            insns += [self.generate(insn) for insn in t.children[1:]]
+            return insns
+        # Fallthrough
+        return None
+
+
+def parse(text):
+    otbn_parser = Lark(otbn_grammar)
+    code = otbn_parser.parse(text)
+    return lowerLoop().generate(code)
+
+
+def output_asm(code, file):
+    file.write("".join(["{}\n".format(insn) for insn in code]))
+
+
+def output_carray(code, file):
+    file.write("static const uint32_t code [] = {\n")
+    code = ["    0x{:08x}, // {}".format(insn.encode(), insn) for insn in code]
+    file.write("\n".join(code) + "\n")
+    file.write("};\n")
+
+
+def output_binary(code, file):
+    for insn in code:
+        file.write(pack("I", insn.encode()))
+
+
+
+def output(code, outfile, format="asm"):
+    output_funcs = {
+        "asm": output_asm,
+        "binary": output_binary,
+        "carray": output_carray
+    }
+    output_funcs[format](code, outfile)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("infile",
+                        nargs="?",
+                        type=argparse.FileType('r'),
+                        default=sys.stdin)
+    parser.add_argument("outfile",
+                        nargs="?",
+                        type=argparse.FileType('wb'),
+                        default=sys.stdout)
+    parser.add_argument("-O",
+                        "--output-format",
+                        choices=["asm", "binary", "carray"],
+                        default="asm")
+
+    args = parser.parse_args()
+    code = parse(args.infile.read())
+    output(code, args.outfile, args.output_format)

--- a/util/otbnsim/otbnsim/doc.py
+++ b/util/otbnsim/otbnsim/doc.py
@@ -1,0 +1,51 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+from .insn import *
+
+import inspect
+from pprint import pp
+
+
+def extract_code(insn):
+    def pretty(line):
+        line = line.replace("model.state.intreg", "reg")
+        line = line.replace("self.", "")
+        return line
+
+    code = inspect.getsource(insn.execute).splitlines()
+    code = [pretty(line) for line in code[1:]]
+    return "\n".join(code)
+
+
+def doc_for_insn(insn):
+    doc = {}
+    doc["format"] = insn.get_isa_format()["id"]
+    doc["description"] = inspect.getdoc(insn)
+    doc["asm_signature"] = insn.asm_signature()
+    doc["code"] = extract_code(insn)
+
+    return doc
+
+
+def doc_for_format(insn):
+    return insn.get_isa_format(asdict=True)
+
+
+print("++++ Instruction Formats")
+pp(doc_for_format(InstructionLType))
+pp(doc_for_format(InstructionLIType))
+pp(doc_for_format(InstructionBNAType))
+pp(doc_for_format(InstructionBNANType))
+pp(doc_for_format(InstructionBNAFType))
+pp(doc_for_format(InstructionBNAIType))
+pp(doc_for_format(InstructionBNAMType))
+pp(doc_for_format(InstructionBNAQType))
+pp(doc_for_format(InstructionBNRType))
+
+print("++++ Instructions")
+pp(doc_for_insn(InstructionLOOP))
+pp(doc_for_insn(InstructionLOOPI))
+pp(doc_for_insn(InstructionBNAND))
+pp(doc_for_insn(InstructionBNMULQACC))

--- a/util/otbnsim/otbnsim/insn.py
+++ b/util/otbnsim/otbnsim/insn.py
@@ -1,0 +1,300 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+from riscvmodel.insn import *
+
+from .isa import *
+from .model import OTBNState, OTBNModel
+
+
+@isa("loop", RV32IXotbn, opcode=0b1111011, funct2=0b00)
+class InstructionLOOP(InstructionLType):
+    """
+    Loop (indirect)
+
+    Repeat a sequence of code multiple times. The number of iterations is a GPR
+    value. The length of the loop is given as immediate.
+
+    Alternative assembly notation: The size of the loop body is given by the
+    number of instructions in the parentheses.
+
+    LOOP <grs> (
+      # loop body
+    )
+    """
+    def execute(self, model: OTBNModel):
+        model.state.loop_start(int(model.state.intreg[self.rs1]),
+                               int(self.bodysize))
+
+
+@isa("loopi", RV32IXotbn, opcode=0b1111011, funct2=0b01)
+class InstructionLOOPI(InstructionLIType):
+    """
+    Loop Immediate
+
+    Repeat a sequence of code multiple times. The number of iterations is given
+    as an immediate, as is the length of the loop. The number of iterations must
+    be larger than zero.
+
+    Alternative assembly notation. The size of the loop body is given by the
+    number of instructions in the parentheses.
+
+    LOOPI <iterations> (
+      # loop body
+    )
+
+    """
+    def execute(self, model: OTBNModel):
+        model.state.loop_start(int(self.iter), int(self.bodysize))
+
+
+@isa("bn.add", RV32IXotbn, opcode=0b0101011, funct3=0b000)
+class InstructionBNADD(InstructionBNAFType):
+    """
+    Add
+
+    Adds two WDR values, writes the result to the destination WDR and updates
+    flags. The content of the second source WDR can be shifted by an immediate
+    before it is consumed by the operation.
+    """
+    def execute(self, model: OTBNModel):
+        b_shifted = ShiftReg(model.state.wreg[self.wrs2], self.shift_type,
+                             self.shift_bytes)
+        a = model.state.wreg[self.wrs1]
+        model.state.wreg[self.wrd] = a + b_shifted
+
+
+@isa("bn.addc", RV32IXotbn, opcode=0b0101011, funct3=0b010)
+class InstructionBNADDC(InstructionBNAFType):
+    def execute(self, model: OTBNModel):
+        pass
+
+
+@isa("bn.addi", RV32IXotbn, opcode=0b0101011, funct3=0b100, funct30=0)
+class InstructionBNADDI(InstructionBNAIType):
+    def execute(self, model: OTBNModel):
+        pass
+
+
+@isa("bn.addm", RV32IXotbn, opcode=0b0101011, funct3=0b101, funct30=0)
+class InstructionBNADDM(InstructionBNAMType):
+    def execute(self, model: OTBNModel):
+        pass
+
+
+@isa("bn.mulqacc", RV32IXotbn, opcode=0b1011011)
+class InstructionBNMULQACC(InstructionBNAQType):
+    """
+    Quarter-word Multiply and Accumulate
+
+    Multiplies two WLEN/4 WDR values and adds the result to an accumulator after
+    shifting it. Optionally shifts some/all of the resulting accumulator value
+    out to a destination WDR.
+    """
+    def execute(self, model: OTBNModel):
+        a_qw = model.get_wr_quarterword(self.wrs1, self.wrs1_qwsel)
+        b_qw = model.get_wr_quarterword(self.wrs2, self.wrs2_qwsel)
+
+        mul_res = a_qw * b_qw
+
+        acc = int(model.state.acc)
+
+        if (self.zero_acc):
+            acc = 0
+
+        acc += (mul_res << (self.acc_shift_imm * 64))
+
+        if self.wb_variant > 0:
+            if self.wb_variant == 1:
+                model.set_wr_halfword(self.wrd, acc, self.wrd_hwsel)
+                acc = acc >> 128
+            elif self.wb_variant == 2:
+                model.state.wreg[self.wrd] = acc
+
+        model.state.acc = acc
+
+
+@isa("bn.sub", RV32IXotbn, opcode=0b0101011, funct3=0b001)
+class InstructionBNSUB(InstructionBNAFType):
+    def execute(self, model: OTBNModel):
+        pass
+
+
+@isa("bn.subb", RV32IXotbn, opcode=0b0101011, funct3=0b011)
+class InstructionBNSUBB(InstructionBNAFType):
+    def execute(self, model: OTBNModel):
+        pass
+
+
+@isa("bn.subi", RV32IXotbn, opcode=0b0101011, funct3=0b100, funct30=1)
+class InstructionBNSUBI(InstructionBNAIType):
+    def execute(self, model: OTBNModel):
+        pass
+
+
+@isa("bn.subm", RV32IXotbn, opcode=0b0101011, funct3=0b101, funct30=1)
+class InstructionBNSUBM(InstructionBNAMType):
+    def execute(self, model: OTBNModel):
+        pass
+
+
+@isa("bn.and", RV32IXotbn, opcode=0b0101011, funct3=0b110, funct31=0)
+class InstructionBNAND(InstructionBNAType):
+    """
+    Bitwise AND
+
+    Performs a bitwise and operation. Takes the values stored in registers
+    referenced by wrs1 and wrs2 and stores the result in the register referenced
+    by wrd. The content of the second source register can be shifted by an
+    immediate before it is consumed by the operation.
+    """
+    def execute(self, model: OTBNModel):
+        b_shifted = ShiftReg(model.state.wreg[self.wrs2], self.shift_type,
+                             self.shift_bytes)
+        a = model.state.wreg[self.wrs1]
+        model.state.wreg[self.wrd] = a & b_shifted
+
+
+@isa("bn.or", RV32IXotbn, opcode=0b0101011, funct3=0b110, funct31=1)
+class InstructionBNOR(InstructionBNAType):
+    """
+    Bitwise OR
+
+    Performs a bitwise or operation. Takes the values stored in WDRs referenced
+    by wrs1 and wrs2 and stores the result in the WDR referenced by wrd. The
+    content of the second source WDR can be shifted by an immediate before it is
+    consumed by the operation.
+    """
+    def execute(self, model: OTBNModel):
+        b_shifted = ShiftReg(model.state.wreg[self.wrs2], self.shift_type,
+                             self.shift_bytes)
+        a = model.state.wreg[self.wrs1]
+        model.state.wreg[self.wrd] = a | b_shifted
+
+
+@isa("bn.not", RV32IXotbn, opcode=0b0101011, funct3=0b111, funct31=0)
+class InstructionBNNOT(InstructionBNANType):
+    """
+    Bitwise NOT
+
+    Negates the value in <wrs>, storing the result into <wrd>. The source value
+    can be shifted by an immediate before it is consumed by the operation.
+    """
+    def execute(self, model: OTBNModel):
+        b_shifted = model.state.wreg[self.wrs1]
+        model.state.wreg[self.wrd] = ~b_shifted
+
+
+@isa("bn.xor", RV32IXotbn, opcode=0b0101011, funct3=0b111, funct31=1)
+class InstructionBNXOR(InstructionBNAType):
+    """
+    Bitwise XOR.
+
+    Performs a bitwise xor operation. Takes the values stored in WDRs referenced
+    by wrs1 and wrs2 and stores the result in the WDR referenced by wrd. The
+    content of the second source WDR can be shifted by an immediate before it is
+    consumed by the operation.
+    """
+    def execute(self, model: OTBNModel):
+        b_shifted = model.state.wreg[self.wrs2]
+        a = model.state.wreg[self.wrs1]
+        model.state.wreg[self.wrd] = a ^ b_shifted
+
+
+@isa("bn.rshi", RV32IXotbn, opcode=0b1111011, funct2=0b11)
+class InstructionBNRSHI(InstructionBNRType):
+    def execute(self, model: OTBNModel):
+        pass
+
+
+@isa("bn.sel", RV32IXotbn, opcode=0b0001011, funct3=0b000)
+class InstructionBNSEL(InstructionBNSType):
+    def execute(self, model: OTBNModel):
+        pass
+
+
+@isa("bn.cmp", RV32IXotbn, opcode=0b0001011, funct3=0b001)
+class InstructionBNCMP(InstructionBNCType):
+    def execute(self, model: OTBNModel):
+        pass
+
+
+@isa("bn.cmpb", RV32IXotbn, opcode=0b0001011, funct3=0b011)
+class InstructionBNCMPB(InstructionBNCType):
+    def execute(self, model: OTBNModel):
+        pass
+
+
+@isa("bn.lid", RV32IXotbn, opcode=0b0001011, funct3=0b100)
+class InstructionBNLID(InstructionBNIType):
+    """
+    Load Word (indirect source, indirect destination)
+
+    Calculates a byte memory address by adding the offset to the value in the
+    GPR grs1. The value from this memory address is then copied into the WDR
+    pointed to by the value in GPR grd.
+
+    After the operation, either the value in the GPR grs1, or the value in grd
+    can be optionally incremented.
+
+    If grs1_inc is set, the value in grs1 is incremented by the value WLEN/8
+    (one word). If grd_inc is set, the value in grd is incremented by the value
+    1.
+    """
+    def execute(self, model: OTBNModel):
+        addr = int(model.state.intreg[self.rs] + int(self.imm) * 32)
+        wrd = int(model.state.intreg[self.rd])
+        word = model.load_wlen_word_from_memory(addr)
+        model.state.wreg[wrd] = word
+
+
+@isa("bn.sid", RV32IXotbn, opcode=0b0001011, funct3=0b101)
+class InstructionBNSID(InstructionBNISType):
+    """
+    Store Word (indirect source, indirect destination)
+
+    Calculates a byte memory address by adding the offset to the value in the
+    GPR grs1. The value from the WDR pointed to by grs2 is then copied into the
+    memory.
+
+    After the operation, either the value in the GPR grs1, or the value in grs2
+    can be optionally incremented.
+
+    If grs1_inc is set, the value in grs1 is incremented by the value WLEN/8
+    (one word). If grs2_inc is set, the value in grs2 is incremented by the
+    value 1.
+    """
+    def execute(self, model: OTBNModel):
+        addr = int(model.state.intreg[self.rs2] + int(self.imm) * 32)
+        wrs = int(model.state.intreg[self.rs1])
+        word = int(model.state.wreg[wrs])
+        model.store_wlen_word_to_memory(addr, word)
+
+
+@isa("bn.mov", RV32IXotbn, opcode=0b0001011, funct3=0b110, funct31=0)
+class InstructionBNMOV(InstructionBNMVType):
+    def execute(self, model: OTBNModel):
+        model.state.wreg[self.wrd] = model.state.wreg[self.wrs]
+
+
+@isa("bn.movr", RV32IXotbn, opcode=0b0001011, funct3=0b110, funct31=1)
+class InstructionBNMOVR(InstructionBNMVRType):
+    def execute(self, model: OTBNModel):
+        pass
+
+
+@isa("bn.wsrrs", RV32IXotbn, opcode=0b0001011, funct3=0b111, funct31=0)
+class InstructionBNWSRRS(InstructionBNCSType):
+    """
+    Atomic Read and Set Bits in WSR
+    """
+    def execute(self, model: OTBNModel):
+        csr = model.state.csr_read(self.wcsr)
+        model.state.wreg[self.wrd] = model.state.wreg[self.wsr] & csr
+
+
+@isa("bn.wsrrw", RV32IXotbn, opcode=0b0001011, funct3=0b111, funct31=1)
+class InstructionBNWSRRW(InstructionBNCSType):
+    def execute(self, model: OTBNModel):
+        pass

--- a/util/otbnsim/otbnsim/isa.py
+++ b/util/otbnsim/otbnsim/isa.py
@@ -1,0 +1,477 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+from riscvmodel.isa import Instruction, InstructionFunct3Type, Field
+from riscvmodel.variant import Variant
+from riscvmodel.model import State
+from riscvmodel.types import Immediate
+
+from .variant import RV32IXotbn
+
+from enum import Enum
+from abc import ABCMeta
+
+
+class InstructionFunct2Type(Instruction):
+    field_funct2 = Field(name="funct2",
+                          base=12,
+                          size=2,
+                          description="",
+                          static=True)
+
+class InstructionFunct31Type(Instruction):
+    field_funct31 = Field(name="funct31",
+                          base=31,
+                          size=1,
+                          description="",
+                          static=True)
+
+class InstructionFunct30Type(Instruction):
+    field_funct30 = Field(name="funct30",
+                          base=30,
+                          size=1,
+                          description="",
+                          static=True)
+
+class InstructionW3Type(Instruction):
+    field_wrd = Field(name="wrd", base=7, size=5)
+    field_wrs1 = Field(name="wrs1", base=15, size=5)
+    field_wrs2 = Field(name="wrs2", base=20, size=5)
+
+
+class InstructionFGType(Instruction):
+    field_fg = Field(
+        name="fg",
+        base=31,
+        size=1,
+        description="Flag group to use. Defaults to 0.\n\nValid range: 0..1")
+
+
+class InstructionShiftType(Instruction):
+    field_shift_type = Field(
+        name="shift_type",
+        base=30,
+        size=1,
+        description="The direction of an optional shift applied to <wrs2>.")
+    field_shift_bytes = Field(
+        name="shift_bytes",
+        base=25,
+        size=5,
+        description=
+        "Number of bytes by which to shift <wrs2>. Defaults to 0.\n\nValid range: 0..31"
+    )
+
+
+class InstructionLType(InstructionFunct2Type):
+    isa_format_id = "L"
+
+    asm_arg_signature = "<iter>, <bodysize>"
+
+    field_rs1 = Field(name="rs1", base=15, size=5, description="")
+    field_bodysize = Field(name="bodysize", base=20, size=12, description="")
+
+    def __init__(self, rs1: int = None, bodysize: int = None):
+        super().__init__()
+        self.rs1 = rs1
+        self.bodysize = Immediate(bits=12, signed=False, init=bodysize)
+
+    def randomize(self, variant: Variant):
+        self.rs1 = randrange(0, variant.intregs)
+        self.bodysize.randomize()
+
+    def __str__(self):
+        return "{} x{}, {}".format(self.mnemonic, self.rs1, self.bodysize)
+
+
+class InstructionLIType(InstructionFunct2Type):
+    isa_format_id = "LI"
+
+    asm_arg_signature = "<rs1>, <bodysize>"
+
+    field_iter = Field(name="iter", base=7, size=5, description="")
+    field_bodysize = Field(name="bodysize", base=20, size=12, description="")
+
+    def __init__(self, iter: int = None, bodysize: int = None):
+        super().__init__()
+        self.iter = Immediate(bits=10, signed=False, init=iter)
+        self.bodysize = Immediate(bits=12, signed=False, init=bodysize)
+
+    def randomize(self, variant: Variant):
+        self.iter.randomize()
+        self.bodysize.randomize()
+
+    def __str__(self):
+        return "{} {}, {}".format(self.mnemonic, self.iter, self.bodysize)
+
+
+class ShiftType(Enum):
+    LSL = 0  # logical shift left
+    LSR = 1  # logical shift right
+
+
+def ShiftReg(reg, shift_type, shift_bytes):
+    if shift_type == ShiftType.LSL:
+        return reg << (shift_bytes.value << 3)
+    else:
+        return reg >> (shift_bytes.value << 3)
+
+
+class InstructionBNAType(InstructionFunct3Type,
+                         InstructionFunct31Type,
+                         InstructionShiftType,
+                         InstructionW3Type,
+                         metaclass=ABCMeta):
+    """
+    :param wrd: Name of the destination WDR
+    :param wrs1: Name of the first source WDR
+    :param wrs2: Name of the second source WDR
+    :param shift_type: The direction of an optional shift applied to <wrs2>.
+    :param shift_bytes: Number of bytes by which to shift <wrs2>. Defaults to 0. Valid range: 0..31.
+    """
+    isa_format_id = "BNA"
+
+    asm_arg_signature = "<wrd>, <wrs1>, <wrs2> [, <shift_type> <shift_bytes>B]"
+
+    def __init__(self,
+                 wrd: int = None,
+                 wrs1: int = None,
+                 wrs2: int = None,
+                 shift_bytes: int = None,
+                 shift_type: int = None):
+        super().__init__()
+        self.wrd = wrd
+        self.wrs1 = wrs1
+        self.wrs2 = wrs2
+        self.shift_bytes = Immediate(bits=5,
+                                     signed=False,
+                                     init=shift_bytes or 0)
+        self.shift_type = shift_type
+
+    def randomize(self, variant):
+        # TODO: shift randomization
+        self.wrd.randomize()
+        self.wrs1.randomize()
+        self.wrs2.randomize()
+
+    def ops_from_string(self, ops):
+        self.ops_from_list([op for op in ops.split(",")])
+
+    def ops_from_list(self, ops):
+        self.wrd = int(ops[0][1:])
+        self.wrs1 = int(ops[1][1:])
+        self.wrs2 = int(ops[2][1:])
+        if len(ops) > 3:
+            self.shift_bytes.set(int(ops[4][:-1]))
+            self.shift_type = ShiftType.LSL if ops[3] == "<<" else ShiftType.LSR
+
+    def __str__(self):
+        asm = "{} w{}, w{}, w{}".format(self.mnemonic, self.wrd, self.wrs1,
+                                        self.wrs2)
+        if int(self.shift_bytes) > 0:
+            asm += ", {} {}B".format(
+                "<<" if self.shift_type == ShiftType.LSL else ">>",
+                self.shift_bytes)
+        return asm
+
+
+class InstructionBNANType(InstructionFunct3Type, InstructionFunct31Type,
+                          InstructionShiftType):
+    isa_format_id = "BNAN"
+
+    asm_arg_signature = "<wrd>, <wrs1> [, <shift_type> <shift_bytes>B]"
+
+    field_wrd = Field(name="wrd", base=7, size=5, description="")
+    field_wrs1 = Field(name="wrs1", base=20, size=5, description="")
+
+    def __init__(self,
+                 wrd: int = None,
+                 wrs1: int = None,
+                 shift_bytes: int = None,
+                 shift_type: int = None):
+        super().__init__()
+        self.wrd = wrd
+        self.wrs1 = wrs1
+        self.shift_bytes = Immediate(bits=5, signed=False, init=shift_bytes)
+        self.shift_type = DecodeShiftType(
+            shift_type) if shift_type is not None else shift_type
+
+    def randomize(self, variant):
+        # TODO: shift randomization
+        self.wrd.randomize()
+        self.wrs1.randomize()
+
+    def ops_from_string(self, ops):
+        ops = ops.split(",")
+
+    def ops_from_list(self, ops):
+        self.wrd = int(ops[0][1:])
+        self.wrs1 = int(ops[1][1:])
+
+    def __str__(self):
+        return "{} w{}, w{}".format(self.mnemonic, self.wrd, self.wrs1)
+
+    def __eq__(self, other):
+        if not super().__eq__(other):
+            return False
+        return self.wrd == other.wrd and self.wrs1 == other.wrs1 and self.shift_bytes == other.shift_bytes and self.shift_type == other.shift_type
+
+
+class InstructionBNCSType(InstructionFunct3Type, InstructionFunct31Type):
+    isa_format_id = "BNCS"
+
+    asm_arg_signature = "<wrd>, <wsr>, <wrs>"
+
+    field_wrd = Field(name="wrd", base=7, size=5)
+    field_wrs = Field(name="wrs", base=15, size=5)
+    field_wcsr = Field(name="wcsr", base=20, size=8)
+
+    def __init__(self, wrd: int = None, wsr: int = None, wcsr: int = None):
+        super().__init__()
+        self.wrd = wrd
+        self.wsr = wsr
+        self.wcsr = Immediate(bits=8, signed=False, init=wcsr)
+
+    def randomize(self, variant: Variant):
+        self.wrd.randomize()
+        self.wsr.randomize()
+        self.wcsr.randomize()
+
+    def ops_from_list(self, ops):
+        self.wrd = int(ops[0][1:])
+        self.wsr = int(ops[1][1:])
+        self.wcsr.set(int(ops[2], 0))
+
+    def __str__(self):
+        return "{} w{}, w{}, {}".format(self.mnemonic, self.wrd, self.wsr,
+                                        self.wcsr)
+
+
+class InstructionBNAFType(InstructionFunct3Type, InstructionW3Type,
+                          InstructionFGType, InstructionShiftType):
+    isa_format_id = "BNAF"
+
+    asm_arg_signature = "<wrd>, <wrs1>, <wrs2> [, <shift_type> <shift_bytes>B] [, FG<flag_group>]"
+
+
+class InstructionBNAIType(InstructionFunct3Type, InstructionFGType, InstructionFunct30Type):
+    isa_format_id = "BNAI"
+
+    field_wrd = Field(name="wrd", base=7, size=5)
+    field_wrs1 = Field(name="wrs1", base=15, size=5)
+    field_imm = Field(name="imm", base=20, size=10)
+    field_sign = Field(name="sign", base=30, size=10)
+
+
+class InstructionBNAMType(InstructionFunct3Type, InstructionW3Type,
+                          InstructionFunct30Type):
+    isa_format_id = "BNAM"
+
+
+class InstructionBNAQType(InstructionW3Type):
+    isa_format_id = "BNAQ"
+
+    asm_arg_signature = "[<wb_variant>][<zero_acc>] [<wrd><wrd_hwsel>,] <wrs1>.<wrs1_qwsel>, <wrs2>.<wrs2_qwsel>, <acc_shift_imm>"
+
+    @classmethod
+    def asm_signature(cls):
+        return cls.mnemonic + cls.asm_arg_signature
+
+    field_wb_variant = Field(name="wb_variant",
+                             base=30,
+                             size=2,
+                             description="""
+Result writeback instruction variant. If no writeback variant is chosen, no
+destination register is written, and the multiplication result is only stored in
+the accumulator.
+
+Valid values:
+
+* .S0 (value 0): Shift out the lower half-word of the value stored in the
+  accumulator to a WLEN/2-sized half-word of the destination WDR. The
+  destination half-word is selected by the wrd_hwsel field.
+
+* .W0 (value 1): Write the value stored in the accumulator to the destination
+  WDR.""")
+    field_zero_acc = Field(name="zero_acc",
+                           base=12,
+                           size=1,
+                           description="""
+Zero the accumulator before accumulating the multiply result.
+
+To specify, use the literal syntax .Z""")
+    field_wrd_hwsel = Field(name="wrd_hwsel", base=29, size=1, description="")
+    field_wrs1_qwsel = Field(name="wrs1_qwsel",
+                             base=27,
+                             size=2,
+                             description="")
+    field_wrs2_qwsel = Field(name="wrs2_qwsel",
+                             base=25,
+                             size=2,
+                             description="")
+    field_acc_shift_imm = Field(name="acc_shift_imm",
+                                base=13,
+                                size=2,
+                                description="")
+
+    def __init__(self,
+                 wrd: int = 0,
+                 wrs1: int = None,
+                 wrs2: int = None,
+                 wb_variant: int = 0,
+                 zero_acc: bool = False,
+                 wrd_hwsel: int = 0,
+                 wrs1_qwsel: int = None,
+                 wrs2_qwsel: int = None,
+                 acc_shift_imm: int = None):
+        self.wrd = wrd
+        self.wrs1 = wrs1
+        self.wrs2 = wrs2
+        self.wb_variant = wb_variant
+        self.zero_acc = zero_acc
+        self.wrd_hwsel = wrd_hwsel
+        self.wrs1_qwsel = wrs1_qwsel
+        self.wrs2_qwsel = wrs2_qwsel
+        self.acc_shift_imm = acc_shift_imm
+
+    def ops_from_list(self, ops):
+        off = 0
+        if ops[off] in ["so", "wo"]:
+            self.wb_variant = 1 if ops[0] == "so" else 2
+            off += 1
+        if ops[off] == "z":
+            self.zero_acc = True
+            off += 1
+        if len(ops[off:]) > 3:
+            assert self.wb_variant is not None
+            wrd = ops[off]
+            self.wrd = int(wrd[1:wrd.rfind(".")])
+            self.wrd_hwsel = 1 if wrd[wrd.rfind(".") + 1] == "u" else 0
+            off += 1
+        wrs = ops[off]
+        self.wrs1 = int(wrs[1:wrs.rfind(".")])
+        self.wrs1_qwsel = int(wrs[wrs.rfind(".") + 1])
+        wrs = ops[off + 1]
+        self.wrs2 = int(wrs[1:wrs.rfind(".")])
+        self.wrs2_qwsel = int(wrs[wrs.rfind(".") + 1])
+        self.acc_shift_imm = int(ops[off + 2]) >> 6
+
+    def __str__(self):
+        istr = self.mnemonic
+        if self.wb_variant > 0:
+            istr += ".so" if self.wb_variant == 1 else ".wo"
+        if self.zero_acc:
+            istr += ".z"
+        istr += " "
+        if self.wb_variant > 0:
+            istr += "w{}".format(self.wrd)
+            if self.wb_variant == 1:
+                istr += ".u" if self.wrd_hwsel == 1 else ".l"
+            istr += ", "
+        istr += "w{}.{}, ".format(self.wrs1, self.wrs1_qwsel)
+        istr += "w{}.{}, ".format(self.wrs2, self.wrs2_qwsel)
+        istr += str(self.acc_shift_imm * 64)
+        return istr
+
+
+class InstructionBNRType(InstructionW3Type, InstructionFunct2Type):
+    isa_format_id = "BNR"
+
+    field_imm = Field(name="imm", base=[14, 25], size=[1, 7], description="")
+
+
+class InstructionBNSType(InstructionW3Type, InstructionFunct3Type,
+                         InstructionFGType):
+    isa_format_id = "BNS"
+
+    field_flag = Field(name="flag", base=25, size=2, description="")
+
+
+class InstructionBNCType(InstructionFunct3Type, InstructionFGType,
+                         InstructionShiftType):
+    isa_format_id = "BNC"
+
+    field_wrs1 = Field(name="wrs1", base=15, size=5)
+    field_wrs2 = Field(name="wrs2", base=20, size=5)
+
+
+class InstructionBNIType(InstructionFunct3Type):
+    isa_format_id = "BNI"
+
+    asm_arg_signature = "<grd>[<grd_inc>], <offset>(<grs1>[<grs1_inc>])"
+
+    field_rd = Field(name="rd", base=7, size=5)
+    field_rs = Field(name="rs", base=15, size=5)
+    field_imm = Field(name="imm", base=22, size=10)
+    field_rd_inc = Field(name="rd_inc", base=20, size=1)
+    field_rs_inc = Field(name="rs_inc", base=21, size=1)
+
+    def __init__(self,
+                 rd: int = None,
+                 rs: int = None,
+                 imm: int = None,
+                 rd_inc: bool = False,
+                 rs_inc: bool = False):
+        self.rd = rd
+        self.rs = rs
+        self.imm = Immediate(bits=10, signed=True)
+        self.rd_inc = rd_inc
+        self.rs_inc = rs_inc
+
+    def ops_from_list(self, ops):
+        self.rd = int(ops[0][1:])
+        self.imm.set(int(ops[1]))
+        self.rs = int(ops[2][1:])
+
+    def __str__(self):
+        return "{} x{}, {}(x{})".format(self.mnemonic, self.rd, self.imm,
+                                        self.rs)
+
+
+class InstructionBNISType(InstructionFunct3Type):
+    isa_format_id = "BNIS"
+
+    asm_arg_signature = "<grs1>[<grs1_inc>], <offset>(<grs2>[<grs2_inc>])"
+
+    field_rs1 = Field(name="rs1", base=7, size=5)
+    field_rs2 = Field(name="rs2", base=15, size=5)
+    field_imm = Field(name="imm", base=22, size=10)
+    field_rs1_inc = Field(name="rs1_inc", base=20, size=1)
+    field_rs2_inc = Field(name="rs2_inc", base=21, size=1)
+
+    def __init__(self,
+                 rs1: int = None,
+                 rs2: int = None,
+                 imm: int = None,
+                 rs1_inc: bool = False,
+                 rs2_inc: bool = False):
+        self.rs1 = rs1
+        self.rs2 = rs2
+        self.imm = Immediate(bits=10, signed=True)
+        self.rs1_inc = rs1_inc
+        self.rs2_inc = rs2_inc
+
+    def ops_from_list(self, ops):
+        self.rs1 = int(ops[0][1:])
+        self.imm.set(int(ops[1]))
+        self.rs2 = int(ops[2][1:])
+
+    def __str__(self):
+        return "{} x{}, {}(x{})".format(self.mnemonic, self.rs1, self.imm,
+                                        self.rs2)
+
+
+class InstructionBNMVType(InstructionFunct3Type, InstructionFunct31Type):
+    isa_format_id = "BNMV"
+
+    field_wrd = Field(name="wrd", base=7, size=5)
+    field_wrs = Field(name="wrs", base=15, size=5)
+
+
+class InstructionBNMVRType(InstructionFunct3Type, InstructionFunct31Type):
+    isa_format_id = "BNMVR"
+
+    field_rd = Field(name="rd", base=7, size=5)
+    field_rs = Field(name="rs", base=15, size=5)
+    field_rd_inc = Field(name="rd_inc", base=20, size=1)
+    field_rs_inc = Field(name="rs_inc", base=21, size=1)

--- a/util/otbnsim/otbnsim/main.py
+++ b/util/otbnsim/otbnsim/main.py
@@ -22,9 +22,10 @@ def main():
     parser.add_argument("dmem_words", type=int)
     parser.add_argument("dmem_file")
     parser.add_argument("cycles_file")
+    parser.add_argument("trace_file")
 
     args = parser.parse_args()
-    sim = Simulator(OTBNModel())
+    sim = Simulator(OTBNModel(verbose=args.trace_file))
 
     sim.load_program(read_from_binary(args.imem_file, stoponerror=True))
     with open(args.dmem_file, "rb") as f:

--- a/util/otbnsim/otbnsim/main.py
+++ b/util/otbnsim/otbnsim/main.py
@@ -5,12 +5,14 @@
 # Execute the simulation
 
 from riscvmodel.sim import Simulator
-from riscvmodel.model import Model
-from riscvmodel.variant import RV32I
 from riscvmodel.code import read_from_binary
 
 import argparse
 import struct
+
+from .model import Model
+from .variant import RV32IXotbn
+from .insn import *
 
 
 def main():
@@ -22,7 +24,7 @@ def main():
     parser.add_argument("cycles_file")
 
     args = parser.parse_args()
-    sim = Simulator(Model(RV32I))
+    sim = Simulator(OTBNModel())
 
     sim.load_program(read_from_binary(args.imem_file, stoponerror=True))
     with open(args.dmem_file, "rb") as f:

--- a/util/otbnsim/otbnsim/model.py
+++ b/util/otbnsim/otbnsim/model.py
@@ -1,0 +1,208 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+from random import randrange
+from collections import deque
+
+from riscvmodel.model import Model, State, Environment
+from riscvmodel.isa import TerminateException
+from riscvmodel.types import RegisterFile, Register, SingleRegister, TraceRegister, TraceIntegerRegister, Trace, TracePC
+
+from .variant import RV32IXotbn
+
+
+class TraceCallStackPush(Trace):
+    def __init__(self, value):
+        self.value = value
+
+    def __str__(self):
+        return "RAS push {:08x}".format(self.value)
+
+
+class TraceCallStackPop(Trace):
+    def __init__(self, value):
+        self.value = value
+
+    def __str__(self):
+        return "RAS pop {:08x}".format(self.value)
+
+
+class TraceLoopStart(Trace):
+    def __init__(self, iterations, bodysize):
+        self.iterations = iterations
+        self.bodysize = bodysize
+
+    def __str__(self):
+        return "Start LOOP, {} iterations, bodysize: {}".format(
+            self.iterations, self.bodysize)
+
+
+class TraceLoopIteration(Trace):
+    def __init__(self, iter, total):
+        self.iter = iter
+        self.total = total
+
+    def __str__(self):
+        return "LOOP iteration {}/{}".format(self.iter, self.total)
+
+
+class OTBNIntRegisterFile(RegisterFile):
+    def __init__(self, num: int, bits: int, immutable: list = {}):
+        super().__init__(num, bits, immutable)
+        self.callstack = deque()
+        self.cs_update = []
+
+    def __setitem__(self, key, value):
+        if key == 1:
+            self.cs_update.append(TraceCallStackPush(value))
+        elif not self.regs[key].immutable:
+            reg = Register(self.bits)
+            reg.set(value)
+            self.regs_updates.append(TraceIntegerRegister(key, reg))
+
+    def __getitem__(self, key):
+        if key == 1:
+            return self.callstack.popleft()
+        return self.regs[key]
+
+    def commit(self):
+        for cs in self.cs_update:
+            self.callstack.appendleft(cs.value)
+        self.cs_update.clear()
+        super().commit()
+
+
+class OTBNState(State):
+    single_regs = ["acc", "flags"]
+
+    def __init__(self):
+        super().__init__(RV32IXotbn)
+        self.intreg = OTBNIntRegisterFile(32, 32, {0: 0})
+        self.wreg = RegisterFile(32, 256, {}, prefix="w")
+        self.acc = SingleRegister(256, "ACC")
+        self.flags = Register(8)
+        self.mod0 = Register(32)
+        self.mod1 = Register(32)
+        self.mod2 = Register(32)
+        self.mod3 = Register(32)
+        self.mod4 = Register(32)
+        self.mod5 = Register(32)
+        self.mod6 = Register(32)
+        self.mod7 = Register(32)
+
+        self.loop_trace = []
+        self.loop = deque()
+
+    def csr_read(self, index):
+        if index == 0x7C0:
+            return int(self.wreg)
+        elif index == 0x7D0:
+            return int(self.mod0)
+        elif index == 0x7D1:
+            return int(self.mod1)
+        elif index == 0x7D2:
+            return int(self.mod2)
+        elif index == 0x7D3:
+            return int(self.mod3)
+        elif index == 0x7D4:
+            return int(self.mod4)
+        elif index == 0x7D5:
+            return int(self.mod5)
+        elif index == 0x7D6:
+            return int(self.mod6)
+        elif index == 0x7D7:
+            return int(self.mod7)
+        elif index == 0xFC0:
+            return randrange(0, 1 << 32)
+        return super().csr_read(self, index)
+
+    def csr_read(self, index):
+        if index == 0:
+            return 0
+        elif index == 1:
+            return randrange(0, 1 << 256)
+
+    def loop_start(self, iterations, bodysize):
+        self.loop.appendleft({
+            "iterations": iterations,
+            "bodysize": bodysize,
+            "count_iterations": 0,
+            "count_instructions": -1
+        })
+        self.loop_trace.append(TraceLoopStart(iterations, bodysize))
+
+    def changes(self):
+        c = super().changes()
+        if len(self.loop) > 0:
+            if self.loop[0][
+                    "count_instructions"] == self.loop[0]["bodysize"] - 1:
+                self.loop_trace.append(
+                    TraceLoopIteration(self.loop[0]["count_iterations"] + 1,
+                                       self.loop[0]["iterations"]))
+                if self.loop[0][
+                        "count_iterations"] == self.loop[0]["iterations"] - 1:
+                    self.loop.popleft()
+                else:
+                    pc = self.pc - (self.loop[0]["bodysize"] - 1) * 4
+                    self.pc_update = pc
+                    c.append(TracePC(pc))
+                    self.loop[0]["count_iterations"] += 1
+                    self.loop[0]["count_instructions"] = 0
+            else:
+                self.loop[0]["count_instructions"] += 1
+        c += self.loop_trace
+        c += self.wreg.changes()
+        c += self.acc.changes()
+        return c
+
+    def commit(self):
+        super().commit()
+        self.wreg.commit()
+        self.acc.commit()
+        self.loop_trace.clear()
+
+
+class OTBNEnvironment(Environment):
+    def call(self, state: OTBNState):
+        raise TerminateException(0)
+
+
+class OTBNModel(Model):
+    def __init__(self, *, verbose=False):
+        super().__init__(RV32IXotbn,
+                         environment=OTBNEnvironment(),
+                         verbose=verbose,
+                         asm_width=35)
+        self.state = OTBNState()
+
+    def get_wr_quarterword(self, wridx, qwsel):
+        return (int(self.state.wreg[wridx]) >>
+                (qwsel * 64)) & 0xffffffffffffffff
+
+    def set_wr_halfword(self, wridx, value, hwsel):
+        mask = ((1 << 128) - 1) << (128 if hwsel == 0 else 0)
+        curr = int(self.state.wreg[wridx]) & mask
+        valpos = (value & ((1 << 128) - 1)) << (128 if hwsel == 1 else 0)
+        self.state.wreg[wridx].set(curr | valpos)
+
+    def load_wlen_word_from_memory(self, addr):
+        word = self.state.memory.lw(addr)
+        word += self.state.memory.lw(addr + 4) << 32
+        word += self.state.memory.lw(addr + 8) << 64
+        word += self.state.memory.lw(addr + 12) << 96
+        word += self.state.memory.lw(addr + 16) << 128
+        word += self.state.memory.lw(addr + 20) << 160
+        word += self.state.memory.lw(addr + 24) << 192
+        word += self.state.memory.lw(addr + 28) << 224
+        return word
+
+    def store_wlen_word_to_memory(self, addr, word):
+        self.state.memory.sw(addr, word & 0xffffffff)
+        self.state.memory.sw(addr + 4, (word >> 32) & 0xffffffff)
+        self.state.memory.sw(addr + 8, (word >> 64) & 0xffffffff)
+        self.state.memory.sw(addr + 12, (word >> 96) & 0xffffffff)
+        self.state.memory.sw(addr + 16, (word >> 128) & 0xffffffff)
+        self.state.memory.sw(addr + 20, (word >> 160) & 0xffffffff)
+        self.state.memory.sw(addr + 24, (word >> 192) & 0xffffffff)
+        self.state.memory.sw(addr + 28, (word >> 224) & 0xffffffff)

--- a/util/otbnsim/otbnsim/standalone.py
+++ b/util/otbnsim/otbnsim/standalone.py
@@ -1,0 +1,35 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+from riscvmodel.sim import Simulator
+from .model import OTBNModel
+from .variant import RV32IXotbn
+from .asm import parse
+
+import argparse
+import sys
+
+
+def run(program, data, *, verbose=True):
+    sim = Simulator(OTBNModel(verbose=verbose))
+    sim.load_program(program)
+    sim.load_data(data)
+    sim.run()
+    return sim.dump_data()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("program",
+                        nargs='?',
+                        type=argparse.FileType('r'),
+                        default=sys.stdin)
+    parser.add_argument("data", nargs='?', type=argparse.FileType('rb'))
+    args = parser.parse_args()
+
+    run(parse(args.program.read()), args.data.read() if args.data else None)
+
+
+if __name__ == "__main__":
+    main()

--- a/util/otbnsim/otbnsim/variant.py
+++ b/util/otbnsim/otbnsim/variant.py
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+from riscvmodel.variant import RV32I, Extension
+
+RV32IXotbn = RV32I + Extension(
+    name="Xotbn", description="OpenTitan BigNum Extension", implies=[])

--- a/util/otbnsim/setup.py
+++ b/util/otbnsim/setup.py
@@ -8,9 +8,10 @@ from setuptools import setup, find_packages
 
 setup(name="otbnsim",
       packages=find_packages(),
-      install_requires=["riscv-model>=0.4.1"],
+      install_requires=["riscv-model>=0.6", "lark-parser"],
       entry_points={
           "console_scripts": [
               "otbn-python-model = otbnsim.main:main",
+              "otbn-asm = otbnsim.asm:main",
           ],
       })

--- a/util/otbnsim/test/data.py
+++ b/util/otbnsim/test/data.py
@@ -1,0 +1,24 @@
+from struct import pack, unpack
+
+
+def pack_list(data: list):
+    bytes = b""
+    for item in data:
+        bytes += pack("Q", item & ((1 << 64) - 1))
+        bytes += pack("Q", (item >> 64) & ((1 << 64) - 1))
+        bytes += pack("Q", (item >> 128) & ((1 << 64) - 1))
+        bytes += pack("Q", (item >> 192) & ((1 << 64) - 1))
+    return bytes
+
+
+def unpack_list(bytes):
+    data = []
+    words = int(len(bytes) / 32)
+    for word in range(words):
+        result = 0
+        for i in range(3, -1, -1):
+            result <<= 64
+            barray = bytes[word * 32 + i * 8:word * 32 + i * 8 + 8]
+            result += unpack("Q", barray)[0]
+        data.append(result)
+    return data

--- a/util/otbnsim/test/programs.py
+++ b/util/otbnsim/test/programs.py
@@ -7,6 +7,11 @@ import sys
 
 from otbnsim.asm import parse, output
 
+# Prolog to load the memory content into w registers
+# w0 <= mem[255:0]
+# w1 <= mem[511:256]
+# w2 <= mem[767:512]
+# w3 <= mem[1023:768]
 w04_prolog = """
 addi x4, x0, 0
 bn.lid x4, 0(x0)
@@ -18,13 +23,18 @@ addi x4, x0, 3
 bn.lid x4, 3(x0)
 """
 
+# Epilog to write w0-w4 registers into memory
+# mem[255:0] <= w0
+# mem[511:256] <= w1
+# mem[767:512] <= w2
+# mem[1023:768] <= w3
 w04_epilog = """
 addi x4, x0, 0
 bn.sid x4, 0(x0)
 addi x4, x0, 1
 bn.sid x4, 1(x0)
 addi x4, x0, 2
-bn.sid x4, 3(x0)
+bn.sid x4, 2(x0)
 addi x4, x0, 3
 bn.sid x4, 3(x0)
 """
@@ -66,7 +76,7 @@ if __name__ == "__main__":
                         default="asm")
 
     args = parser.parse_args()
-    code = parse(globals()["code_"+args.test])
+    code = globals()["code_" + args.test]
     if args.standalone:
         code = w04_prolog + code + w04_epilog
-    output(code, args.outfile, args.output_format)
+    output(parse(code), args.outfile, args.output_format)

--- a/util/otbnsim/test/programs.py
+++ b/util/otbnsim/test/programs.py
@@ -1,0 +1,72 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import sys
+
+from otbnsim.asm import parse, output
+
+w04_prolog = """
+addi x4, x0, 0
+bn.lid x4, 0(x0)
+addi x4, x0, 1
+bn.lid x4, 1(x0)
+addi x4, x0, 2
+bn.lid x4, 2(x0)
+addi x4, x0, 3
+bn.lid x4, 3(x0)
+"""
+
+w04_epilog = """
+addi x4, x0, 0
+bn.sid x4, 0(x0)
+addi x4, x0, 1
+bn.sid x4, 1(x0)
+addi x4, x0, 2
+bn.sid x4, 3(x0)
+addi x4, x0, 3
+bn.sid x4, 3(x0)
+"""
+
+code_mul_256x256 = """
+BN.MULQACC.Z w0.0, w1.0, 0
+BN.MULQACC w0.1, w1.0, 64
+BN.MULQACC.SO w2.l, w0.0, w1.1, 64
+BN.MULQACC w0.2, w1.0, 0
+BN.MULQACC w0.1, w1.1, 0
+BN.MULQACC w0.0, w1.2, 0
+BN.MULQACC w0.3, w1.0, 64
+BN.MULQACC w0.2, w1.1, 64
+BN.MULQACC w0.1, w1.2, 64
+BN.MULQACC.SO w2.u, w0.0, w1.3, 64
+BN.MULQACC w0.3, w1.1, 0
+BN.MULQACC w0.2, w1.2, 0
+BN.MULQACC w0.1, w1.3, 0
+BN.MULQACC w0.3, w1.2, 64
+BN.MULQACC.SO w3.l, w0.2, w1.3, 64
+BN.MULQACC.SO w3.u, w0.3, w1.3, 0
+"""
+
+if __name__ == "__main__":
+    codes = [code[5:] for code in dir() if code.startswith("code_")]
+    parser = argparse.ArgumentParser()
+    parser.add_argument("test", type=str, choices=codes)
+    parser.add_argument("outfile",
+                        nargs="?",
+                        type=argparse.FileType('wb'),
+                        default=sys.stdout)
+    parser.add_argument("-s",
+                        "--standalone",
+                        action="store_true",
+                        help="Generate standalone (w0-w4 calling) code")
+    parser.add_argument("-O",
+                        "--output-format",
+                        choices=["asm", "binary", "carray"],
+                        default="asm")
+
+    args = parser.parse_args()
+    code = parse(globals()["code_"+args.test])
+    if args.standalone:
+        code = w04_prolog + code + w04_epilog
+    output(code, args.outfile, args.output_format)

--- a/util/otbnsim/test/run.py
+++ b/util/otbnsim/test/run.py
@@ -1,0 +1,22 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+from data import pack_list, unpack_list
+
+from otbnsim.standalone import run
+from otbnsim.asm import parse
+
+from programs import w04_epilog, w04_prolog
+
+
+def run_w04(asm, data, *, verbose=False):
+    test = w04_prolog + asm + w04_epilog
+
+    data = pack_list(data)
+
+    rdata = run(parse(test), data, verbose=verbose)
+
+    rdata = unpack_list(rdata)
+
+    return rdata

--- a/util/otbnsim/test/test_mul.py
+++ b/util/otbnsim/test/test_mul.py
@@ -1,0 +1,35 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+from random import getrandbits
+
+from programs import code_mul_256x256
+import pytest
+
+from run import run_w04
+
+
+def run(a, b, verbose=False):
+    rdata = run_w04(code_mul_256x256, [a, b, 0, 0], verbose=verbose)
+    expected = a * b
+    result = rdata[3] << 256 | rdata[2]
+    assert result == expected, "Failed for {:x},{:x}".format(a, b)
+
+
+testdata = [[0, 0], [1, 1], [16253673, 9988176667], [1 << 64, 1 << 64],
+            [1 << 127, 1 << 127], [1 << 128, 1 << 128], [1 << 128, 1 << 192],
+            [1 << 192, 1 << 192], [1 << 256 - 1, 1 << 256 - 1],
+            [
+                214070112180406960094838604134999454453,
+                214070112180406960094838604134999454453
+            ]]
+
+
+@pytest.mark.parametrize("a,b", testdata)
+def test_simple(a, b, modelverbose):
+    run(a, b, verbose=modelverbose)
+
+
+def test_mulrandom(modelverbose):
+    run(getrandbits(256), getrandbits(256), verbose=modelverbose)

--- a/util/otbnsim/test/test_mulqacc.py
+++ b/util/otbnsim/test/test_mulqacc.py
@@ -1,0 +1,26 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from run import run_w04
+
+
+def run(code, a, b, expected, verbose=False):
+    rdata = run_w04(code, [a, b, 0, 0], verbose=verbose)
+    result = rdata[3] << 256 | rdata[2]
+    assert result == expected, "Failed for {:x},{:x}".format(a, b)
+
+
+testdata = [[0, 0], [1, 1], [4, 4], [2**64 - 1, 2], [2**64 - 1, 2**64 - 1],
+            [2**64, 2**64]]
+
+
+@pytest.mark.parametrize("a,b", testdata)
+def test_mulqacc0(a, b, modelverbose):
+    insns = """
+    bn.mulqacc.wo.z w2.l, w0.0, w1.0, 0
+    """
+
+    rdata = run(insns, a, b,
+                (a & 0xffffffffffffffff) * (b & 0xffffffffffffffff))


### PR DESCRIPTION
Add the variant, model and basic instruction support. Not all
instructions are implemented, but it can run the basic mutiplication
of sprint 2.

It also adds the assembler (otbn-asm) that is a minimal assembler that
generates programs for the model as binary or C array.
