### PR TITLE
[usbdev] Enable support for oscillator test mode

### DIFF
--- a/hw/ip/usbdev/data/usbdev.hjson
+++ b/hw/ip/usbdev/data/usbdev.hjson
@@ -555,6 +555,18 @@
 
                 '''
         }
+        {
+          bits: "7",
+          resval: "0",
+          name: "tx_osc_test_mode",
+          desc: '''
+                Disable (0) or enable (1) oscillator test mode.
+                If enabled, the device constantly transmits a J/K pattern, which is useful for testing the USB clock.
+                Note that while in oscillator test mode, the device no longer receives SOFs and consequently does not generate the reference signal for clock synchronization.
+                The clock might drift off.
+
+                '''
+        }
       ]
     }
 

--- a/hw/ip/usbdev/doc/_index.md
+++ b/hw/ip/usbdev/doc/_index.md
@@ -65,6 +65,11 @@ This module features the following output signals to provide a reference for syn
 Both these signals are synchronous to the 48 MHz clock.
 They can be forced to zero by setting {{< regref "phy_config.usb_ref_disable" >}} to `1`.
 
+To externally monitor the 48 MHz clock, the USB device supports an oscillator test mode which can be enabled by setting {{< regref "phy_config.tx_osc_test_mode" >}} to `1`.
+In this mode, the device constantly transmits a J/K pattern but no longer receives SOF packets.
+Consequently, it does not generate reference pulses for clock synchronization.
+The clock might drift off.
+
 Control transfers pass through asynchronous FIFOs or have a ready bit
 synchronized across the clock domain boundary. A dual-port
 asynchronous buffer SRAM is used for data transfers between the bus

--- a/hw/ip/usbdev/rtl/usbdev.sv
+++ b/hw/ip/usbdev/rtl/usbdev.sv
@@ -517,7 +517,7 @@ module usbdev (
     .clr_devaddr_o        (usb_clr_devaddr),
     .ep_iso_i             (ep_iso), // cdc ok, quasi-static
     .cfg_eop_single_bit_i (reg2hw.phy_config.eop_single_bit.q), // cdc ok: quasi-static
-    .tx_osc_test_mode_i   (1'b0), // cdc ok: quasi-static & testmode only
+    .tx_osc_test_mode_i   (reg2hw.phy_config.tx_osc_test_mode.q), // cdc ok: quasi-static
     .data_toggle_clear_i  (usb_data_toggle_clear),
 
     // status

--- a/hw/ip/usbdev/rtl/usbdev_iomux.sv
+++ b/hw/ip/usbdev/rtl/usbdev_iomux.sv
@@ -57,9 +57,11 @@ module usbdev_iomux
   logic pinflip;
   logic unused_eop_single_bit;
   logic unused_usb_ref_disable;
+  logic unused_tx_osc_test_mode;
 
-  assign unused_eop_single_bit  = sys_reg2hw_config_i.eop_single_bit.q;
-  assign unused_usb_ref_disable = sys_reg2hw_config_i.usb_ref_disable.q;
+  assign unused_eop_single_bit   = sys_reg2hw_config_i.eop_single_bit.q;
+  assign unused_usb_ref_disable  = sys_reg2hw_config_i.usb_ref_disable.q;
+  assign unused_tx_osc_test_mode = sys_reg2hw_config_i.tx_osc_test_mode.q;
 
   //////////
   // CDCs //

--- a/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
@@ -272,6 +272,9 @@ package usbdev_reg_pkg;
     struct packed {
       logic        q;
     } usb_ref_disable;
+    struct packed {
+      logic        q;
+    } tx_osc_test_mode;
   } usbdev_reg2hw_phy_config_reg_t;
 
 
@@ -417,19 +420,19 @@ package usbdev_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    usbdev_reg2hw_intr_state_reg_t intr_state; // [345:330]
-    usbdev_reg2hw_intr_enable_reg_t intr_enable; // [329:314]
-    usbdev_reg2hw_intr_test_reg_t intr_test; // [313:282]
-    usbdev_reg2hw_usbctrl_reg_t usbctrl; // [281:274]
-    usbdev_reg2hw_avbuffer_reg_t avbuffer; // [273:268]
-    usbdev_reg2hw_rxfifo_reg_t rxfifo; // [267:247]
-    usbdev_reg2hw_rxenable_setup_mreg_t [11:0] rxenable_setup; // [246:235]
-    usbdev_reg2hw_rxenable_out_mreg_t [11:0] rxenable_out; // [234:223]
-    usbdev_reg2hw_stall_mreg_t [11:0] stall; // [222:211]
-    usbdev_reg2hw_configin_mreg_t [11:0] configin; // [210:43]
-    usbdev_reg2hw_iso_mreg_t [11:0] iso; // [42:31]
-    usbdev_reg2hw_data_toggle_clear_mreg_t [11:0] data_toggle_clear; // [30:7]
-    usbdev_reg2hw_phy_config_reg_t phy_config; // [6:0]
+    usbdev_reg2hw_intr_state_reg_t intr_state; // [346:331]
+    usbdev_reg2hw_intr_enable_reg_t intr_enable; // [330:315]
+    usbdev_reg2hw_intr_test_reg_t intr_test; // [314:283]
+    usbdev_reg2hw_usbctrl_reg_t usbctrl; // [282:275]
+    usbdev_reg2hw_avbuffer_reg_t avbuffer; // [274:269]
+    usbdev_reg2hw_rxfifo_reg_t rxfifo; // [268:248]
+    usbdev_reg2hw_rxenable_setup_mreg_t [11:0] rxenable_setup; // [247:236]
+    usbdev_reg2hw_rxenable_out_mreg_t [11:0] rxenable_out; // [235:224]
+    usbdev_reg2hw_stall_mreg_t [11:0] stall; // [223:212]
+    usbdev_reg2hw_configin_mreg_t [11:0] configin; // [211:44]
+    usbdev_reg2hw_iso_mreg_t [11:0] iso; // [43:32]
+    usbdev_reg2hw_data_toggle_clear_mreg_t [11:0] data_toggle_clear; // [31:8]
+    usbdev_reg2hw_phy_config_reg_t phy_config; // [7:0]
   } usbdev_reg2hw_t;
 
   ///////////////////////////////////////

--- a/hw/ip/usbdev/rtl/usbdev_reg_top.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_top.sv
@@ -646,6 +646,9 @@ module usbdev_reg_top (
   logic phy_config_usb_ref_disable_qs;
   logic phy_config_usb_ref_disable_wd;
   logic phy_config_usb_ref_disable_we;
+  logic phy_config_tx_osc_test_mode_qs;
+  logic phy_config_tx_osc_test_mode_wd;
+  logic phy_config_tx_osc_test_mode_we;
 
   // Register instances
   // R[intr_state]: V(False)
@@ -5350,6 +5353,32 @@ module usbdev_reg_top (
   );
 
 
+  //   F[tx_osc_test_mode]: 7:7
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_phy_config_tx_osc_test_mode (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (phy_config_tx_osc_test_mode_we),
+    .wd     (phy_config_tx_osc_test_mode_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.phy_config.tx_osc_test_mode.q ),
+
+    // to register interface (read)
+    .qs     (phy_config_tx_osc_test_mode_qs)
+  );
+
+
 
 
   logic [25:0] addr_hit;
@@ -5974,6 +6003,9 @@ module usbdev_reg_top (
   assign phy_config_usb_ref_disable_we = addr_hit[25] & reg_we & ~wr_err;
   assign phy_config_usb_ref_disable_wd = reg_wdata[6];
 
+  assign phy_config_tx_osc_test_mode_we = addr_hit[25] & reg_we & ~wr_err;
+  assign phy_config_tx_osc_test_mode_wd = reg_wdata[7];
+
   // Read data return
   always_comb begin
     reg_rdata_next = '0;
@@ -6244,6 +6276,7 @@ module usbdev_reg_top (
         reg_rdata_next[4] = phy_config_override_pwr_sense_val_qs;
         reg_rdata_next[5] = phy_config_pinflip_qs;
         reg_rdata_next[6] = phy_config_usb_ref_disable_qs;
+        reg_rdata_next[7] = phy_config_tx_osc_test_mode_qs;
       end
 
       default: begin

--- a/hw/ip/usbuart/rtl/usbuart_core.sv
+++ b/hw/ip/usbuart/rtl/usbuart_core.sv
@@ -445,6 +445,7 @@ module usbuart_core (
   assign usb_phy_config.override_pwr_sense_en.q  = 1'b0;
   assign usb_phy_config.override_pwr_sense_val.q = 1'b0;
   assign usb_phy_config.usb_ref_disable.q        = 1'b0;
+  assign usb_phy_config.tx_osc_test_mode.q       = 1'b0;
 
   usbdev_iomux i_usbdev_iomux (
     .clk_i                  ( clk_i                  ),


### PR DESCRIPTION
This PR adds a new bit in the phy_config register to enable the oscillator test mode in which the device continuously transmits a J/K pattern. This feature was originally added by @stefanlippuner but in Earlgrey, we constantly disabled it.

This resolves lowRISC/OpenTitan#2703.