### PR TITLE
[flash_ctrl] Cosmetic updates enum literals

### DIFF
--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -108,9 +108,9 @@ module flash_ctrl import flash_ctrl_pkg::*; (
   logic [AllPagesW-1:0] err_page;
   logic [BankW-1:0] err_bank;
 
-  assign rd_op = reg2hw.control.op.q == FlashRead;
-  assign prog_op = reg2hw.control.op.q == FlashProg;
-  assign erase_op = reg2hw.control.op.q == FlashErase;
+  assign rd_op = reg2hw.control.op.q == FlashOpRead;
+  assign prog_op = reg2hw.control.op.q == FlashOpProgram;
+  assign erase_op = reg2hw.control.op.q == FlashOpErase;
 
   // Program FIFO
   // Since the program and read FIFOs are never used at the same time, it should really be one
@@ -289,15 +289,15 @@ module flash_ctrl import flash_ctrl_pkg::*; (
   // Final muxing to flash macro module
   always_comb begin
     unique case (reg2hw.control.op.q)
-      FlashRead: begin
+      FlashOpRead: begin
         flash_req = rd_flash_req;
         flash_addr = rd_flash_addr;
       end
-      FlashProg: begin
+      FlashOpProgram: begin
         flash_req = prog_flash_req;
         flash_addr = prog_flash_addr;
       end
-      FlashErase: begin
+      FlashOpErase: begin
         flash_req = erase_flash_req;
         flash_addr = erase_flash_addr;
       end
@@ -322,7 +322,7 @@ module flash_ctrl import flash_ctrl_pkg::*; (
   assign region_cfgs[MpRegions].erase_en.q = reg2hw.default_region.erase_en.q;
   // we are allowed to set default accessibility of data partitions
   // however info partitions default to inaccessible
-  assign region_cfgs[MpRegions].partition.q = DataPart;
+  assign region_cfgs[MpRegions].partition.q = FlashPartData;
 
   flash_part_e flash_part_sel;
   assign flash_part_sel = flash_part_e'(reg2hw.control.partition_sel.q);
@@ -350,8 +350,8 @@ module flash_ctrl import flash_ctrl_pkg::*; (
     .req_bk_i(flash_addr[BusAddrW-1 -: BankW]),
     .rd_i(rd_op),
     .prog_i(prog_op),
-    .pg_erase_i(erase_op & (erase_flash_type == PageErase)),
-    .bk_erase_i(erase_op & (erase_flash_type == BankErase)),
+    .pg_erase_i(erase_op & (erase_flash_type == FlashErasePage)),
+    .bk_erase_i(erase_op & (erase_flash_type == FlashEraseBank)),
     .rd_done_o(flash_rd_done),
     .prog_done_o(flash_prog_done),
     .erase_done_o(flash_erase_done),

--- a/hw/ip/flash_ctrl/rtl/flash_erase_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_erase_ctrl.sv
@@ -48,7 +48,7 @@ module flash_erase_ctrl #(
   // Flash Interface assignments
   assign flash_req_o = op_start_i;
   assign flash_op_o = op_type_i;
-  assign flash_addr_o = (op_type_i == PageErase) ?
+  assign flash_addr_o = (op_type_i == FlashErasePage) ?
                         op_addr_i & PageAddrMask :
                         op_addr_i & BankAddrMask;
 

--- a/hw/ip/flash_ctrl/rtl/flash_mp.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_mp.sv
@@ -95,7 +95,7 @@ module flash_mp import flash_ctrl_pkg::*; import flash_ctrl_reg_pkg::*; #(
   always_comb begin
     for (int unsigned i = 0; i < NumBanks; i++) begin: bank_comps
       bk_erase_en[i] = (req_bk_i == i) & bank_cfgs_i[i].q &
-                       (req_part_i == DataPart);
+                       (req_part_i == FlashPartData);
     end
   end
 
@@ -103,13 +103,13 @@ module flash_mp import flash_ctrl_pkg::*; import flash_ctrl_reg_pkg::*; #(
 
   // invalid info page access
   assign invalid_info_access = req_i &
-                               (req_part_i == InfoPart) &
+                               (req_part_i == FlashPartInfo) &
                                (rd_i | prog_i | pg_erase_i) &
                                (req_addr_i[0 +: PageW] > LastValidInfoPage);
 
   // invalid info page erase
   assign invalid_info_erase  = req_i & bk_erase_i &
-                               (req_part_i == InfoPart);
+                               (req_part_i == FlashPartInfo);
 
   assign invalid_info_txn    = invalid_info_access | invalid_info_erase;
 

--- a/hw/ip/flash_ctrl/rtl/flash_phy_core.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_core.sv
@@ -208,7 +208,7 @@ module flash_phy_core import flash_phy_pkg::*; #(
   end // always_comb
 
   assign muxed_addr = host_sel ? host_addr_i : addr_i;
-  assign muxed_part = host_sel ? flash_ctrl_pkg::DataPart : part_i;
+  assign muxed_part = host_sel ? flash_ctrl_pkg::FlashPartData : part_i;
   assign rd_done_o = ctrl_rsp_vld & rd_i;
   assign prog_done_o = ctrl_rsp_vld & prog_i;
   assign erase_done_o = ctrl_rsp_vld & (pg_erase_i | bk_erase_i);

--- a/hw/ip/flash_ctrl/rtl/flash_phy_rd_buffers.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_rd_buffers.sv
@@ -35,7 +35,7 @@ module flash_phy_rd_buffers import flash_phy_pkg::*; (
     if (!rst_ni) begin
       out_o.data <= '0;
       out_o.addr <= '0;
-      out_o.part <= flash_ctrl_pkg::DataPart;
+      out_o.part <= flash_ctrl_pkg::FlashPartData;
       out_o.attr <= Invalid;
     end else if (wipe_i) begin
       out_o.attr <= Invalid;

--- a/hw/ip/prim_generic/rtl/prim_generic_flash.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_flash.sv
@@ -102,7 +102,7 @@ module prim_generic_flash #(
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       held_addr <= '0;
-      held_part <= '0;
+      held_part <= flash_ctrl_pkg::FlashPartData;
       held_wdata <= '0;
     end else if (hold_cmd) begin
       held_addr <= rd_q ? addr_q : addr_i;
@@ -155,7 +155,7 @@ module prim_generic_flash #(
     mem_req          = 'h0;
     mem_wr           = 'h0;
     mem_addr         = 'h0;
-    mem_part         = flash_ctrl_pkg::DataPart;
+    mem_part         = flash_ctrl_pkg::FlashPartData;
     mem_wdata        = 'h0;
     time_cnt_inc     = 1'h0;
     time_cnt_clr     = 1'h0;
@@ -291,7 +291,7 @@ module prim_generic_flash #(
     .DataBitsPerMask(DataWidth)
   ) u_mem (
     .clk_i,
-    .req_i    (mem_req & (mem_part == flash_ctrl_pkg::DataPart)),
+    .req_i    (mem_req & (mem_part == flash_ctrl_pkg::FlashPartData)),
     .write_i  (mem_wr),
     .addr_i   (mem_addr),
     .wdata_i  (mem_wdata),
@@ -305,7 +305,7 @@ module prim_generic_flash #(
     .DataBitsPerMask(DataWidth)
   ) u_info_mem (
     .clk_i,
-    .req_i    (mem_req & (mem_part == flash_ctrl_pkg::InfoPart)),
+    .req_i    (mem_req & (mem_part == flash_ctrl_pkg::FlashPartInfo)),
     .write_i  (mem_wr),
     .addr_i   (mem_addr[0 +: InfoAddrW]),
     .wdata_i  (mem_wdata),
@@ -313,6 +313,6 @@ module prim_generic_flash #(
     .rdata_o  (rd_data_info)
   );
 
-  assign rd_data_o = held_part == flash_ctrl_pkg::DataPart ? rd_data_main : rd_data_info;
+  assign rd_data_o = held_part == flash_ctrl_pkg::FlashPartData ? rd_data_main : rd_data_info;
 
 endmodule // prim_generic_flash


### PR DESCRIPTION
- Updated enum literals for type `foo_bar_e` to `FooBarLiteral1` format
- Associated updates to all relevant sources
- No functional change

Signed-off-by: Srikrishna Iyer <sriyer@google.com>
Signed-off-by: Timothy Chen <timothytim@google.com>