### PR TITLE
[aes/dv/dpi] Mask out unused bits passed from the simulator

### DIFF
--- a/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi.c
+++ b/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi.c
@@ -18,21 +18,24 @@ void c_dpi_aes_crypt_block(const unsigned char impl_i, const unsigned char op_i,
                            const svBitVecVal *key_len_i,
                            const svBitVecVal *key_i, const svBitVecVal *data_i,
                            svBitVecVal *data_o) {
-  // get input data from simulator
-  unsigned char *key = aes_key_get(key_i);
-  unsigned char *ref_in = aes_data_get(data_i);
+  // Mask out unused bits as their value is undetermined.
+  const unsigned char impl = impl_i & impl_mask;
+  const unsigned char op = op_i & op_mask;
+  const crypto_mode_t mode = (crypto_mode_t)(*mode_i & mode_mask);
 
-  // key_len_i is one-hot encoded
+  // key_len_i is one-hot encoded.
   int key_len;
-  if (*key_len_i == 0x1) {
+  if ((*key_len_i & key_len_mask) == 0x1) {
     key_len = 16;
-  } else if (*key_len_i == 0x2) {
+  } else if ((*key_len_i & key_len_mask) == 0x2) {
     key_len = 24;
   } else {  // 0x4
     key_len = 32;
   }
 
-  crypto_mode_t mode = (crypto_mode_t)*mode_i;
+  // get input data from simulator
+  unsigned char *key = aes_key_get(key_i);
+  unsigned char *ref_in = aes_data_get(data_i);
 
   // Modes other than ECB require an IV from the simulator.
   unsigned char *iv;
@@ -47,13 +50,13 @@ void c_dpi_aes_crypt_block(const unsigned char impl_i, const unsigned char op_i,
   unsigned char *ref_out = (unsigned char *)malloc(16 * sizeof(unsigned char));
   assert(ref_out);
 
-  if (impl_i == 0) {
+  if (impl == 0) {
     // The C model does ECB only. We "emulate" other modes here.
     unsigned char data_in[16];
     unsigned char data_out[16];
 
     if (mode == kCryptoAesCbc) {
-      if (!op_i) {
+      if (!op) {
         // data_in = ref_in XOR iv (or previous data_out)
         for (int i = 0; i < 16; ++i) {
           data_in[i] = ref_in[i] ^ iv[i];
@@ -76,14 +79,14 @@ void c_dpi_aes_crypt_block(const unsigned char impl_i, const unsigned char op_i,
         ref_out[i] = data_out[i] ^ ref_in[i];
       }
     } else {  // ECB
-      if (!op_i) {
+      if (!op) {
         aes_encrypt_block(ref_in, key, key_len, ref_out);
       } else {
         aes_decrypt_block(ref_in, key, key_len, ref_out);
       }
     }
   } else {  // OpenSSL/BoringSSL
-    if (!op_i) {
+    if (!op) {
       crypto_encrypt(ref_out, iv, ref_in, 16, key, key_len, mode);
     } else {
       crypto_decrypt(ref_out, iv, ref_in, 16, key, key_len, mode);
@@ -107,7 +110,22 @@ void c_dpi_aes_crypt_message(unsigned char impl_i, unsigned char op_i,
                              const svBitVecVal *key_i,
                              const svOpenArrayHandle data_i,
                              svOpenArrayHandle data_o) {
-  if (impl_i == 0) {
+  // Mask out unused bits as their value is undetermined.
+  const unsigned char impl = impl_i & impl_mask;
+  const unsigned char op = op_i & op_mask;
+  const crypto_mode_t mode = (crypto_mode_t)(*mode_i & mode_mask);
+
+  // key_len_i is one-hot encoded.
+  int key_len;
+  if ((*key_len_i & key_len_mask) == 0x1) {
+    key_len = 16;
+  } else if ((*key_len_i & key_len_mask) == 0x2) {
+    key_len = 24;
+  } else {  // 0x4
+    key_len = 32;
+  }
+
+  if (impl == 0) {
     // The C model is currently not supported.
     printf(
         "ERROR: c_dpi_aes_crypt_message() currently supports OpenSSL/BoringSSL "
@@ -117,18 +135,6 @@ void c_dpi_aes_crypt_message(unsigned char impl_i, unsigned char op_i,
 
   // Get key from simulator.
   unsigned char *key = aes_key_get(key_i);
-
-  // key_len_i is one-hot encoded.
-  int key_len;
-  if (*key_len_i == 0x1) {
-    key_len = 16;
-  } else if (*key_len_i == 0x2) {
-    key_len = 24;
-  } else {  // 0x4
-    key_len = 32;
-  }
-
-  crypto_mode_t mode = (crypto_mode_t)*mode_i;
 
   // Modes other than ECB require an IV from the simulator.
   unsigned char *iv = (unsigned char *)malloc(16 * sizeof(unsigned char));
@@ -166,13 +172,13 @@ void c_dpi_aes_crypt_message(unsigned char impl_i, unsigned char op_i,
     return;
   }
 
-  if (impl_i == 0) {
+  if (impl == 0) {
     // The C model is currently not supported.
     printf(
         "ERROR: c_dpi_aes_crypt_message() currently supports OpenSSL/BoringSSL "
         "only\n");
   } else {  // OpenSSL/BoringSSL
-    if (!op_i) {
+    if (!op) {
       crypto_encrypt(ref_out, iv, ref_in, data_len, key, key_len, mode);
     } else {
       crypto_decrypt(ref_out, iv, ref_in, data_len, key, key_len, mode);
@@ -193,7 +199,7 @@ void c_dpi_aes_sub_bytes(const unsigned char op_i, const svBitVecVal *data_i,
   unsigned char *data = aes_data_get(data_i);
 
   // perform sub bytes
-  if (!op_i) {
+  if (!(op_i & op_mask)) {
     aes_sub_bytes(data);
   } else {
     aes_inv_sub_bytes(data);
@@ -211,7 +217,7 @@ void c_dpi_aes_shift_rows(const unsigned char op_i, const svBitVecVal *data_i,
   unsigned char *data = aes_data_get(data_i);
 
   // perform shift rows
-  if (!op_i) {
+  if (!(op_i & op_mask)) {
     aes_shift_rows(data);
   } else {
     aes_inv_shift_rows(data);
@@ -229,7 +235,7 @@ void c_dpi_aes_mix_columns(const unsigned char op_i, const svBitVecVal *data_i,
   unsigned char *data = aes_data_get(data_i);
 
   // perform mix columns
-  if (!op_i) {
+  if (!(op_i & op_mask)) {
     aes_mix_columns(data);
   } else {
     aes_inv_mix_columns(data);
@@ -247,23 +253,26 @@ void c_dpi_aes_key_expand(const unsigned char op_i, const svBitVecVal *rcon_i,
                           const svBitVecVal *key_i, svBitVecVal *key_o) {
   unsigned char round_key[16];  // just used by model
 
-  // get input data
-  unsigned char *key = aes_key_get(key_i);
-  unsigned char rcon = (unsigned char)*rcon_i;
-  int rnd = (int)*round_i;
+  // Mask out unused bits as their value is undetermined.
+  const unsigned char op = op_i & op_mask;
+  unsigned char rcon = (unsigned char)(*rcon_i & rcon_mask);
+  const int rnd = (int)(*round_i & round_mask);
 
-  // key_len_i is one-hot encoded
+  // key_len_i is one-hot encoded.
   int key_len;
-  if (*key_len_i == 0x1) {
+  if ((*key_len_i & key_len_mask) == 0x1) {
     key_len = 16;
-  } else if (*key_len_i == 0x2) {
+  } else if ((*key_len_i & key_len_mask) == 0x2) {
     key_len = 24;
   } else {  // 0x4
     key_len = 32;
   }
 
+  // get input data
+  unsigned char *key = aes_key_get(key_i);
+
   // perform key expand
-  if (!op_i) {
+  if (!op) {
     aes_rcon_prev(&rcon, key_len);
     aes_key_expand(round_key, key, key_len, &rcon, rnd);
   } else {

--- a/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi.h
+++ b/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi.h
@@ -11,6 +11,15 @@
 extern "C" {
 #endif
 
+// Masks for ignoring unused bits in data passed from the simulator (their value
+// is undetermined).
+#define impl_mask 0x1
+#define op_mask 0x1
+#define mode_mask 0x7
+#define key_len_mask 0x7
+#define rcon_mask 0xFF
+#define round_mask 0xF
+
 /**
  * Perform encryption/decryption of one block.
  *


### PR DESCRIPTION
This PR makes sure the DPI model masks out unused bits in input arguments passed from the simulator before use. According to the LRM (Section H.7.7) the values of unused bits is undetermined and they must be masked out on the C-side.

This resolves lowRISC/OpenTitan#2771.