### PR TITLE
[sv/alert] support alert response in cip_lib seq and scb

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env.sv
@@ -42,6 +42,7 @@ class cip_base_env #(type CFG_T               = cip_base_env_cfg,
     // create components
     m_tl_agent = tl_agent::type_id::create("m_tl_agent", this);
     m_tl_reg_adapter = tl_reg_adapter#()::type_id::create("m_tl_reg_adapter");
+
     // create alert agents and cfgs
     foreach(cfg.list_of_alerts[i]) begin
       string alert_name = cfg.list_of_alerts[i];
@@ -52,6 +53,7 @@ class cip_base_env #(type CFG_T               = cip_base_env_cfg,
       uvm_config_db#(alert_esc_agent_cfg)::set(this, agent_name, "cfg",
           cfg.m_alert_agent_cfg[alert_name]);
     end
+
     uvm_config_db#(tl_agent_cfg)::set(this, "m_tl_agent*", "cfg", cfg.m_tl_agent_cfg);
   endfunction
 
@@ -59,6 +61,12 @@ class cip_base_env #(type CFG_T               = cip_base_env_cfg,
     super.connect_phase(phase);
     m_tl_agent.monitor.a_chan_port.connect(scoreboard.tl_a_chan_fifo.analysis_export);
     m_tl_agent.monitor.d_chan_port.connect(scoreboard.tl_d_chan_fifo.analysis_export);
+    foreach (cfg.list_of_alerts[i]) begin
+      string alert_name = cfg.list_of_alerts[i];
+      m_alert_agent[alert_name].monitor.alert_esc_port.connect(
+          scoreboard.alert_fifos[alert_name].analysis_export);
+    end
+
     if (cfg.is_active) begin
       virtual_sequencer.tl_sequencer_h = m_tl_agent.sequencer;
     end

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
@@ -33,15 +33,7 @@ class hmac_base_vseq extends cip_base_vseq #(.CFG_T               (hmac_env_cfg)
 
   virtual task dut_init(string reset_kind = "HARD");
     super.dut_init(reset_kind);
-    alert_send_ping();
     if (do_hmac_init) hmac_init();
-  endtask
-
-  virtual task alert_send_ping();
-    alert_receiver_seq ping_seq;
-    `uvm_create_on(ping_seq, p_sequencer.alert_esc_sequencer_h[cfg.list_of_alerts[0]]);
-    `DV_CHECK_RANDOMIZE_FATAL(ping_seq)
-    `uvm_send(ping_seq)
   endtask
 
   virtual task dut_shutdown();


### PR DESCRIPTION
In cip_base_scoreboard, add the following alert_esc_agent support:
1. Add tlm_analysis port to detect alert sent from DUT
2. Use process_alert_fifos task to filter out illegal alert_items (ping
responses and sig_int_err). If real alert happened, or real alert
handshake finished, both condition will call "process_alert_sig"
function.

In cip_base_vseq, add support:
1. add a knob to en_auto_alerts_response in cip_base_vseq - default on
2. add run_alert_response_nonblocking in dut_init
3. If user disabled the en_auto_alerts_response knob, the nonblocking
sequence will wait for current response to finish then exit
4. If user wants to re-enable the en_auto_alerts_response knob, they
have to also trigger dut_init() again

Signed-off-by: Cindy Chen <chencindy@google.com>