### PR TITLE
[otbn] Allow an insn to have ops without a space after the mnemonic

### DIFF
--- a/hw/ip/otbn/data/insns.yml
+++ b/hw/ip/otbn/data/insns.yml
@@ -411,6 +411,10 @@ encoding-schemes:
 #  note:      Text that should appear in a callout banner at the top of the
 #             instruction documentation. (optional)
 #
+#  glued-ops: A boolean. If true, the first operand in the syntax can appear
+#             immediately after the mnemonic (with no space). Optional,
+#             defaults to false.
+#
 #  trailing-doc: Documentation that should appear after the syntax example but
 #                before the operand table. Useful for things like alternative
 #                assembly syntax, or deviations from the usual meaning of the
@@ -984,6 +988,7 @@ insns:
           How many quarter-words (`WLEN/4` bits) to shift the `WLEN/2`-bit multiply result before accumulating.
     syntax: |
       [<zero_acc>] <wrs1>.<wrs1_qwsel>, <wrs2>.<wrs2_qwsel>, <acc_shift_imm>
+    glued-ops: true
     doc: |
       Multiplies two `WLEN/4` WDR values, shifts the product by `<acc_shift_imm>` and adds the result to the accumulator.
 
@@ -1047,6 +1052,7 @@ insns:
       - *mulqacc-acc-shift-imm
     syntax: |
       [<zero_acc>] <wrd>, <wrs1>.<wrs1_qwsel>, <wrs2>.<wrs2_qwsel>, <acc_shift_imm>
+    glued-ops: true
     doc: |
       Multiplies two `WLEN/4` WDR values, shifts the product by `<acc_shift_imm>` and adds the result to the accumulator.
       Writes the resulting accumulator to `<wrd>`.
@@ -1094,6 +1100,7 @@ insns:
     syntax: |
       [<zero_acc>] <wrd><wrd_hwsel>,
       <wrs1>.<wrs1_qwsel>, <wrs2>.<wrs2_qwsel>, <acc_shift_imm>
+    glued-ops: true
     doc: |
       Multiplies two `WLEN/4` WDR values, shifts the product by `<acc_shift_imm>` and adds the result to the accumulator.
       Next, shifts the resulting accumulator right by half a word.

--- a/hw/ip/otbn/util/insn_yaml.py
+++ b/hw/ip/otbn/util/insn_yaml.py
@@ -930,7 +930,7 @@ class Insn:
                         ['mnemonic', 'operands'],
                         ['group', 'rv32i', 'synopsis',
                          'syntax', 'doc', 'note', 'trailing-doc',
-                         'decode', 'operation', 'encoding'])
+                         'decode', 'operation', 'encoding', 'glued-ops'])
 
         self.mnemonic = check_str(yd['mnemonic'], 'mnemonic for instruction')
 
@@ -952,6 +952,8 @@ class Insn:
 
         self.rv32i = check_bool(yd.get('rv32i', False),
                                 'rv32i flag for ' + what)
+        self.glued_ops = check_bool(yd.get('glued-ops', False),
+                                    'glued-ops flag for ' + what)
         self.synopsis = get_optional_str(yd, 'synopsis', what)
         self.doc = get_optional_str(yd, 'doc', what)
         self.note = get_optional_str(yd, 'note', what)

--- a/hw/ip/otbn/util/yaml_to_doc.py
+++ b/hw/ip/otbn/util/yaml_to_doc.py
@@ -169,7 +169,7 @@ def render_insn(insn: Insn, heading_level: int) -> str:
 
     # Syntax example: either given explicitly or figured out from operands
     parts.append("```\n")
-    parts.append(insn.mnemonic.upper() + ' ')
+    parts.append(insn.mnemonic.upper() + ('' if insn.glued_ops else ' '))
     if insn.syntax is not None:
         parts.append(insn.syntax.raw_string())
     else:


### PR DESCRIPTION
This is used by mulqacc, which has an optional .z suffix that says to
zero the accumulator.

This patch isn't particularly interesting, just improving the
documentation spacing slightly. But the information is also needed by
an assembler, which needs to know what the mnemonic "bn.mulqacc.z"
means.
