### PR TITLE
[otbn] Properly parse optional arguments in instruction YAML

### DIFF
--- a/hw/ip/otbn/data/insns.yml
+++ b/hw/ip/otbn/data/insns.yml
@@ -1098,7 +1098,7 @@ insns:
       - *mulqacc-wrs2-qwsel
       - *mulqacc-acc-shift-imm
     syntax: |
-      [<zero_acc>] <wrd><wrd_hwsel>,
+      [<zero_acc>] <wrd>.<wrd_hwsel>,
       <wrs1>.<wrs1_qwsel>, <wrs2>.<wrs2_qwsel>, <acc_shift_imm>
     glued-ops: true
     doc: |

--- a/hw/ip/otbn/util/yaml_to_doc.py
+++ b/hw/ip/otbn/util/yaml_to_doc.py
@@ -170,10 +170,7 @@ def render_insn(insn: Insn, heading_level: int) -> str:
     # Syntax example: either given explicitly or figured out from operands
     parts.append("```\n")
     parts.append(insn.mnemonic.upper() + ('' if insn.glued_ops else ' '))
-    if insn.syntax is not None:
-        parts.append(insn.syntax.raw_string())
-    else:
-        parts.append(', '.join('<{}>'.format(op.name) for op in insn.operands))
+    parts.append(insn.syntax.raw_string())
     parts.append("\n```\n\n")
 
     # If this came from the RV32I instruction set, say so.

--- a/hw/ip/otbn/util/yaml_to_doc.py
+++ b/hw/ip/otbn/util/yaml_to_doc.py
@@ -170,7 +170,7 @@ def render_insn(insn: Insn, heading_level: int) -> str:
     # Syntax example: either given explicitly or figured out from operands
     parts.append("```\n")
     parts.append(insn.mnemonic.upper() + ('' if insn.glued_ops else ' '))
-    parts.append(insn.syntax.raw_string())
+    parts.append(insn.syntax.render_doc())
     parts.append("\n```\n\n")
 
     # If this came from the RV32I instruction set, say so.


### PR DESCRIPTION
The interesting patch is the second in the series. This teaches `insn_yaml.py` to actually understand the square brackets we have in our instruction syntax.

Note that `bn.mulqacc.so` has changed syntax: the destination register is now written `w0.L` or `w0.U`, rather than just `w0L` or `w0U` as previously. This makes parsing much easier: @GregAC, can you check this looks sane?