### PR TITLE
[vsg] fix _i/_o for rv_plic

### DIFF
--- a/hw/ip/rv_plic/data/rv_plic.sv.tpl
+++ b/hw/ip/rv_plic/data/rv_plic.sv.tpl
@@ -143,18 +143,18 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   // Gateways //
   //////////////
   rv_plic_gateway #(
-    .N_SOURCE (NumSrc)
+    .N_SOURCE   (NumSrc)
   ) u_gateway (
     .clk_i,
     .rst_ni,
 
-    .src (intr_src_i),
-    .le,
+    .src_i      (intr_src_i),
+    .le_i       (le),
 
-    .claim,
-    .complete,
+    .claim_i    (claim),
+    .complete_i (complete),
 
-    .ip
+    .ip_o       (ip)
   );
 
   ///////////////////////////////////
@@ -162,20 +162,20 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   ///////////////////////////////////
   for (genvar i = 0 ; i < NumTarget ; i++) begin : gen_target
     rv_plic_target #(
-      .N_SOURCE (NumSrc),
-      .MAX_PRIO (MAX_PRIO)
+      .N_SOURCE    (NumSrc),
+      .MAX_PRIO    (MAX_PRIO)
     ) u_target (
       .clk_i,
       .rst_ni,
 
-      .ip,
-      .ie        (ie[i]),
+      .ip_i        (ip),
+      .ie_i        (ie[i]),
 
-      .prio,
-      .threshold (threshold[i]),
+      .prio_i      (prio),
+      .threshold_i (threshold[i]),
 
-      .irq       (irq_o[i]),
-      .irq_id    (irq_id_o[i])
+      .irq_o       (irq_o[i]),
+      .irq_id_o    (irq_id_o[i])
 
     );
   end

--- a/hw/ip/rv_plic/rtl/rv_plic.sv
+++ b/hw/ip/rv_plic/rtl/rv_plic.sv
@@ -164,18 +164,18 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   // Gateways //
   //////////////
   rv_plic_gateway #(
-    .N_SOURCE (NumSrc)
+    .N_SOURCE   (NumSrc)
   ) u_gateway (
     .clk_i,
     .rst_ni,
 
-    .src (intr_src_i),
-    .le,
+    .src_i      (intr_src_i),
+    .le_i       (le),
 
-    .claim,
-    .complete,
+    .claim_i    (claim),
+    .complete_i (complete),
 
-    .ip
+    .ip_o       (ip)
   );
 
   ///////////////////////////////////
@@ -183,20 +183,20 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   ///////////////////////////////////
   for (genvar i = 0 ; i < NumTarget ; i++) begin : gen_target
     rv_plic_target #(
-      .N_SOURCE (NumSrc),
-      .MAX_PRIO (MAX_PRIO)
+      .N_SOURCE    (NumSrc),
+      .MAX_PRIO    (MAX_PRIO)
     ) u_target (
       .clk_i,
       .rst_ni,
 
-      .ip,
-      .ie        (ie[i]),
+      .ip_i        (ip),
+      .ie_i        (ie[i]),
 
-      .prio,
-      .threshold (threshold[i]),
+      .prio_i      (prio),
+      .threshold_i (threshold[i]),
 
-      .irq       (irq_o[i]),
-      .irq_id    (irq_id_o[i])
+      .irq_o       (irq_o[i]),
+      .irq_id_o    (irq_id_o[i])
 
     );
   end

--- a/hw/ip/rv_plic/rtl/rv_plic_gateway.sv
+++ b/hw/ip/rv_plic/rtl/rv_plic_gateway.sv
@@ -10,52 +10,52 @@ module rv_plic_gateway #(
   input clk_i,
   input rst_ni,
 
-  input [N_SOURCE-1:0] src,
-  input [N_SOURCE-1:0] le,      // Level0 Edge1
+  input [N_SOURCE-1:0] src_i,
+  input [N_SOURCE-1:0] le_i,      // Level0 Edge1
 
-  input [N_SOURCE-1:0] claim, // $onehot0(claim)
-  input [N_SOURCE-1:0] complete, // $onehot0(complete)
+  input [N_SOURCE-1:0] claim_i, // $onehot0(claim_i)
+  input [N_SOURCE-1:0] complete_i, // $onehot0(complete_i)
 
-  output logic [N_SOURCE-1:0] ip
+  output logic [N_SOURCE-1:0] ip_o
 );
 
   logic [N_SOURCE-1:0] ia;    // Interrupt Active
 
-  logic [N_SOURCE-1:0] set;   // Set: (le) ? src & ~src_d : src ;
-  logic [N_SOURCE-1:0] src_d;
+  logic [N_SOURCE-1:0] set;   // Set: (le_i) ? src_i & ~src_q : src_i ;
+  logic [N_SOURCE-1:0] src_q;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) src_d <= '0;
-    else         src_d <= src;
+    if (!rst_ni) src_q <= '0;
+    else         src_q <= src_i;
   end
 
   always_comb begin
     for (int i = 0 ; i < N_SOURCE; i++) begin
-      set[i] = (le[i]) ? src[i] & ~src_d[i] : src[i] ;
+      set[i] = (le_i[i]) ? src_i[i] & ~src_q[i] : src_i[i] ;
     end
   end
 
-  // Interrupt pending is set by source (depends on le), cleared by claim.
-  // Until interrupt is claimed, set doesn't affect ip.
+  // Interrupt pending is set by source (depends on le_i), cleared by claim_i.
+  // Until interrupt is claimed, set doesn't affect ip_o.
   // RISC-V PLIC spec mentioned it can have counter for edge triggered
   // But skipped the feature as counter consumes substantial logic size.
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      ip <= '0;
+      ip_o <= '0;
     end else begin
-      ip <= (ip | (set & ~ia & ~ip)) & (~(ip & claim));
+      ip_o <= (ip_o | (set & ~ia & ~ip_o)) & (~(ip_o & claim_i));
     end
   end
 
-  // Interrupt active is to control ip. If ip is set then until completed
-  // by target, ip shouldn't be set by source even claim can clear ip.
-  // ia can be cleared only when ia was set. If `set` and `complete` happen
+  // Interrupt active is to control ip_o. If ip_o is set then until completed
+  // by target, ip_o shouldn't be set by source even claim_i can clear ip_o.
+  // ia can be cleared only when ia was set. If `set` and `complete_i` happen
   // at the same time, always `set` wins.
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       ia <= '0;
     end else begin
-      ia <= (ia | (set & ~ia)) & (~(ia & complete & ~ip));
+      ia <= (ia | (set & ~ia)) & (~(ia & complete_i & ~ip_o));
     end
   end
 

--- a/hw/ip/rv_plic/rtl/rv_plic_target.sv
+++ b/hw/ip/rv_plic/rtl/rv_plic_target.sv
@@ -4,7 +4,7 @@
 //
 // RISC-V Platform-Level Interrupt Generator for Target
 //
-// This module basically doing IE & IP based on priority and threshold.
+// This module basically doing IE & IP based on priority and threshold_i.
 // Keep in mind that increasing MAX_PRIO affects logic size a lot.
 //
 // The module implements a binary tree to find the maximal entry. the solution
@@ -25,14 +25,14 @@ module rv_plic_target #(
   input clk_i,
   input rst_ni,
 
-  input [N_SOURCE-1:0]  ip,
-  input [N_SOURCE-1:0]  ie,
+  input [N_SOURCE-1:0]  ip_i,
+  input [N_SOURCE-1:0]  ie_i,
 
-  input [PrioWidth-1:0] prio [N_SOURCE],
-  input [PrioWidth-1:0] threshold,
+  input [PrioWidth-1:0] prio_i [N_SOURCE],
+  input [PrioWidth-1:0] threshold_i,
 
-  output logic            irq,
-  output logic [SrcWidth-1:0] irq_id
+  output logic            irq_o,
+  output logic [SrcWidth-1:0] irq_id_o
 );
 
   // this only works with 2 or more sources
@@ -69,9 +69,9 @@ module rv_plic_target #(
       // corresponding IDs and priorities to the tree leafs
       if (level == NumLevels) begin : gen_leafs
         if (offset < N_SOURCE) begin : gen_assign
-          assign is_tree[Pa]  = ip[offset] & ie[offset];
+          assign is_tree[Pa]  = ip_i[offset] & ie_i[offset];
           assign id_tree[Pa]  = offset;
-          assign max_tree[Pa] = prio[offset];
+          assign max_tree[Pa] = prio_i[offset];
         end else begin : gen_tie_off
           assign is_tree[Pa]  = '0;
           assign id_tree[Pa]  = '0;
@@ -93,7 +93,7 @@ module rv_plic_target #(
         // https://forums.xilinx.com/t5/Synthesis/Simulation-Synthesis-Mismatch-with-Vivado-2018-3/m-p/1065923#M33849
 
         logic sel; // local helper variable
-        // in case only one of the parent has a pending irq, forward that one
+        // in case only one of the parent has a pending irq_o, forward that one
         // in case both irqs are pending, forward the one with higher priority
         assign sel = (~is_tree[C0] & is_tree[C1]) |
                      (is_tree[C0] & is_tree[C1] & logic'(max_tree[C1] > max_tree[C0]));
@@ -109,7 +109,7 @@ module rv_plic_target #(
   logic [SrcWidth-1:0] irq_id_d, irq_id_q;
 
   // the results can be found at the tree root
-  assign irq_d    = (max_tree[0] > threshold) ? is_tree[0] : 1'b0;
+  assign irq_d    = (max_tree[0] > threshold_i) ? is_tree[0] : 1'b0;
   assign irq_id_d = (is_tree[0]) ? id_tree[0] : '0;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : gen_regs
@@ -122,8 +122,8 @@ module rv_plic_target #(
     end
   end
 
-  assign irq    = irq_q;
-  assign irq_id = irq_id_q;
+  assign irq_o    = irq_q;
+  assign irq_id_o = irq_id_q;
 
 endmodule
 

--- a/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic.sv
+++ b/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic.sv
@@ -223,18 +223,18 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   // Gateways //
   //////////////
   rv_plic_gateway #(
-    .N_SOURCE (NumSrc)
+    .N_SOURCE   (NumSrc)
   ) u_gateway (
     .clk_i,
     .rst_ni,
 
-    .src (intr_src_i),
-    .le,
+    .src_i      (intr_src_i),
+    .le_i       (le),
 
-    .claim,
-    .complete,
+    .claim_i    (claim),
+    .complete_i (complete),
 
-    .ip
+    .ip_o       (ip)
   );
 
   ///////////////////////////////////
@@ -242,20 +242,20 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   ///////////////////////////////////
   for (genvar i = 0 ; i < NumTarget ; i++) begin : gen_target
     rv_plic_target #(
-      .N_SOURCE (NumSrc),
-      .MAX_PRIO (MAX_PRIO)
+      .N_SOURCE    (NumSrc),
+      .MAX_PRIO    (MAX_PRIO)
     ) u_target (
       .clk_i,
       .rst_ni,
 
-      .ip,
-      .ie        (ie[i]),
+      .ip_i        (ip),
+      .ie_i        (ie[i]),
 
-      .prio,
-      .threshold (threshold[i]),
+      .prio_i      (prio),
+      .threshold_i (threshold[i]),
 
-      .irq       (irq_o[i]),
-      .irq_id    (irq_id_o[i])
+      .irq_o       (irq_o[i]),
+      .irq_id_o    (irq_id_o[i])
 
     );
   end


### PR DESCRIPTION
Signed-off-by: Scott Johnson <scottdj@google.com>

refers to #34 

Since rv_plic is a very portable design, seems worth fixing the internal usage of _i / _o as per our Verilog Style Guide