### PR TITLE
[otbn] Misc fixes in the OTBN yaml code

### DIFF
--- a/hw/ip/otbn/data/insns.yml
+++ b/hw/ip/otbn/data/insns.yml
@@ -299,7 +299,9 @@ encoding-schemes:
       dh: 29
       qs2: 28-27
       qs1: 26-25
-      acc: 14-13
+      acc:
+        bits: 14-13
+        shift: 6
       z: 12
 
   # Unusual scheme used for bn.rshi (the immediate bleeds into the usual funct3
@@ -813,7 +815,7 @@ insns:
         type: imm1
         doc: Flag group to use. Defaults to 0.
     syntax: &bn-add-syntax |
-      <wrd>, <wrs1>, <wrs2> [, <shift_type> <shift_bytes>B] [, FG<flag_group>]
+      <wrd>, <wrs1>, <wrs2>[<shift_type> <shift_bytes>B][, FG<flag_group>]
     doc: |
       Adds two WDR values, writes the result to the destination WDR and updates
       flags. The content of the second source WDR can be shifted by an
@@ -1144,8 +1146,7 @@ insns:
       - *bn-shift-type-operand
       - *bn-shift-bytes-operand
       - *bn-flag-group-operand
-    syntax: &bn-sub-syntax |
-      <wrd>, <wrs1>, <wrs2> [, <shift_type> <shift_bytes>B] [, FG<flag_group>]
+    syntax: *bn-add-syntax
     doc: |
       Subtracts the second WDR value from the first one, writes the result to the destination WDR and updates flags.
       The content of the second source WDR can be shifted by an immediate before it is consumed by the operation.
@@ -1178,7 +1179,7 @@ insns:
     group: bignum
     synopsis: Subtract with borrow
     operands: *bn-sub-operands
-    syntax: *bn-sub-syntax
+    syntax: *bn-add-syntax
     doc: |
       Subtracts the second WDR value and the Carry from the first one, writes the result to the destination WDR, and updates the flags.
       The content of the second source WDR can be shifted by an immediate before it is consumed by the operation.
@@ -1482,7 +1483,7 @@ insns:
       - *bn-shift-bytes-operand
       - *bn-flag-group-operand
     syntax: &bn-cmp-syntax |
-      <wrs1>, <wrs2> [, <shift_type> <shift_bytes>B] [, FG<flag_group>]
+      <wrs1>, <wrs2>[, <shift_type> <shift_bytes>B][, FG<flag_group>]
     doc: |
       Subtracts the second WDR value from the first one and updates flags.
       This instruction is identical to BN.SUB, except that no result register is written.
@@ -1546,12 +1547,12 @@ insns:
           Offset value.
           Must be WLEN-aligned.
       - name: grs1_inc
-        type: option(+)
+        type: option(++)
         doc: |
           Increment the value in `<grs1>` by WLEN/8 (one word).
           Cannot be specified together with `grd_inc`.
       - name: grd_inc
-        type: option(+)
+        type: option(++)
         doc: |
           Increment the value in `<grd>` by one.
           Cannot be specified together with `grs1_inc`.
@@ -1608,12 +1609,12 @@ insns:
           Offset value.
           Must be WLEN-aligned.
       - name: grs1_inc
-        type: option(+)
+        type: option(++)
         doc: |
           Increment the value in `<grs1>` by WLEN/8 (one word).
           Cannot be specified together with `grs2_inc`.
       - name: grs2_inc
-        type: option(+)
+        type: option(++)
         doc: |
           Increment the value in `<grs2>` by one.
           Cannot be specified together with `grs1_inc`.
@@ -1679,12 +1680,12 @@ insns:
       - name: grs
         doc: Name of the GPR referencing the source WDR.
       - name: grd_inc
-        type: option(+)
+        type: option(++)
         doc: |
           Increment the value in `<grd>` by one.
           Cannot be specified together with `grs_inc`.
       - name: grs_inc
-        type: option(+)
+        type: option(++)
         doc: |
           Increment the value in `<grs>` by one.
           Cannot be specified together with `grd_inc`.

--- a/hw/ip/otbn/data/insns.yml
+++ b/hw/ip/otbn/data/insns.yml
@@ -1098,7 +1098,7 @@ insns:
       - *mulqacc-wrs2-qwsel
       - *mulqacc-acc-shift-imm
     syntax: |
-      [<zero_acc>] <wrd><wrd_hwsel>,
+      [<zero_acc>] <wrd>.<wrd_hwsel>,
       <wrs1>.<wrs1_qwsel>, <wrs2>.<wrs2_qwsel>, <acc_shift_imm>
     glued-ops: true
     doc: |

--- a/hw/ip/otbn/util/insn_yaml.py
+++ b/hw/ip/otbn/util/insn_yaml.py
@@ -1252,6 +1252,9 @@ def load_file(path: str) -> InsnsFile:
     try:
         with open(path, 'r') as handle:
             return InsnsFile(yaml.load(handle, Loader=yaml.SafeLoader))
+    except FileNotFoundError:
+        raise RuntimeError('Cannot find YAML file at {!r}.'
+                           .format(path)) from None
     except yaml.YAMLError as err:
         raise RuntimeError('Failed to parse YAML file at {!r}: {}'
                            .format(path, err)) from None

--- a/hw/ip/otbn/util/yaml_to_doc.py
+++ b/hw/ip/otbn/util/yaml_to_doc.py
@@ -170,10 +170,7 @@ def render_insn(insn: Insn, heading_level: int) -> str:
     # Syntax example: either given explicitly or figured out from operands
     parts.append("```\n")
     parts.append(insn.mnemonic.upper() + ('' if insn.glued_ops else ' '))
-    if insn.syntax is not None:
-        parts.append(insn.syntax.raw_string())
-    else:
-        parts.append(', '.join('<{}>'.format(op.name) for op in insn.operands))
+    parts.append(insn.syntax.raw_string())
     parts.append("\n```\n\n")
 
     # If this came from the RV32I instruction set, say so.

--- a/hw/ip/otbn/util/yaml_to_doc.py
+++ b/hw/ip/otbn/util/yaml_to_doc.py
@@ -170,7 +170,7 @@ def render_insn(insn: Insn, heading_level: int) -> str:
     # Syntax example: either given explicitly or figured out from operands
     parts.append("```\n")
     parts.append(insn.mnemonic.upper() + ('' if insn.glued_ops else ' '))
-    parts.append(insn.syntax.raw_string())
+    parts.append(insn.syntax.render_doc())
     parts.append("\n```\n\n")
 
     # If this came from the RV32I instruction set, say so.


### PR DESCRIPTION
Other than minor bugfixes/tidyups, this PR does the following:

  - Teaches insn_yaml.py to actually understand optional argument syntax like `<op0>[, <op1>][, X<op2>]`.

  - Specifies a shift in the "acc" field for the mulqacc encoding. This means that we can write `BN.MULQACC w28.1, w29.0, 64` rather than `BN.MULQACC w28.1, w29.0, 1`.

  - Removes some stray spaces from syntax examples. The point is that `<foo>[, <bar>]` and `<foo> [, <bar>]` aren't quite the same, because the latter expects some whitespace before the comma.

    Note that an assembler can't just strip out all whitespace, because we have some fields like `<foo> <bar>`.

  - Uses `++` for the "increment this" option. It's what Felix is using in his example code, and I think it makes more sense.
