### PR TITLE
[docs] Address Doc Building Issues

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,6 +71,7 @@ jobs:
     condition: always()
     displayName: Ensure all generated files are clean and up-to-date
   - bash: |
+      set -e
       util/build_docs.py
       # Upload Doxygen Warnings if Present
       if [[ -f "build/docs-generated/sw/doxygen_warnings.log" ]]; then

--- a/hw/ip/usbdev/doc/checklist.md
+++ b/hw/ip/usbdev/doc/checklist.md
@@ -2,7 +2,7 @@
 title: "USB Device Checklist"
 ---
 
-This checklist is for [Hardware Stage]({{< relref "/doc/project/hw_stages.md" >}}) transitions for the [USB Device peripheral.]({{< relref "hw/ip/usbdev/doc" >}})
+This checklist is for [Hardware Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [USB Device peripheral.]({{< relref "hw/ip/usbdev/doc" >}})
 All checklist items refer to the content in the [Checklist.]({{< relref "/doc/project/checklist.md" >}})
 
 ## Design Checklist

--- a/util/build_docs.py
+++ b/util/build_docs.py
@@ -277,18 +277,17 @@ def generate_dif_docs():
         dif_listings_filename = dif_listings_root_path.joinpath(dif_header + ".html")
         dif_listings_filename.parent.mkdir(parents=True, exist_ok=True)
 
-        dif_listings_html = open(str(dif_listings_filename), mode='w')
-        gen_dif_listing.gen_listing_html(combined_xml, dif_header, dif_listings_html)
-        dif_listings_html.close()
+        with open(str(dif_listings_filename), mode='w') as dif_listings_html:
+            gen_dif_listing.gen_listing_html(combined_xml, dif_header,
+                                             dif_listings_html)
 
         difref_functions = gen_dif_listing.get_difref_info(combined_xml, dif_header)
         for function in difref_functions:
             difref_filename = difrefs_root_path.joinpath(function["name"] + '.html')
             difref_filename.parent.mkdir(parents=True, exist_ok=True)
 
-            difref_html = open(str(difref_filename), mode='w')
-            gen_dif_listing.gen_difref_html(function, difref_html)
-            difref_html.close()
+            with open(str(difref_filename), mode='w') as difref_html:
+                gen_dif_listing.gen_difref_html(function, difref_html)
 
         logging.info("Generated DIF Listing for {}".format(dif_header))
 

--- a/util/difgen/gen_dif_listing.py
+++ b/util/difgen/gen_dif_listing.py
@@ -97,6 +97,7 @@ def _get_dif_function_info(compound, file_id):
             # The +2 here is because of the weird `_1` separator
             func_id = func_id[len(file_id) + 2:]
         else:
+            # I think this denotes that this function isn't from this file
             continue
 
         func_info = {}
@@ -105,10 +106,22 @@ def _get_dif_function_info(compound, file_id):
         func_info["local_id"] = func_id
         func_info["full_url"] = "/sw/apis/{}.html#{}".format(file_id, func_id)
 
-        func_info["name"] = m.find("name").text
-        func_info["prototype"] = m.find("definition").text + m.find("argsstring").text
-        func_info["description"] = m.find("briefdescription/para").text
+        func_info["name"] = _get_text_or_empty(m, "name")
+        func_info["prototype"] = _get_text_or_empty(
+            m, "definition") + _get_text_or_empty(m, "argsstring")
+        func_info["description"] = _get_text_or_empty(m,
+                                                      "briefdescription/para")
 
         functions.append(func_info)
 
     return functions
+
+
+def _get_text_or_empty(element, xpath):
+    inner = element.find(xpath)
+    # if the element isn't found, return ""
+    if inner is None:
+        return ""
+
+    # If there's no inner text, return ""
+    return inner.text or ""


### PR DESCRIPTION
Issues when building the SW API Doxygen docs were not being correctly
propagated to fail the build.

This commit contains two changes:
- The first is to ensure we `set -e` in the docs CI bash script, so that
  if the `build_docs.py` errors, the build fails.
- The second is to make the process which extracts information from the
  Doxygen XML dump more robust to failures - returning empty strings
  when information is not available rather than throwing exceptions.

Closes #2813.
