### PR TITLE
[ci] Don't Lint Vendored Python Files

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,8 +57,11 @@ jobs:
     displayName: Display tool versions
   - bash: |
       fork_origin="$(git merge-base --fork-point origin/master)"
-      git diff --name-only "$fork_origin" "*.py" \
-        | xargs -r util/lintpy.py --tools flake8 -f
+      changed_files="$(git diff --name-only --diff-filter=ACMRTUXB "$fork_origin" | grep -v /vendor/ | grep -v /lowrisc_misc-linters/ | grep -E '.py$')"
+      if [[ -n "$changed_files" ]]; then
+        set -e
+        xargs util/lintpy.py --tools flake8 -f <<< "$changed_files" | tee lintpy-output
+      fi
     displayName: Run Python lint
     continueOnError: true
   - bash: |


### PR DESCRIPTION
The aim here is to not lint vendored python files. 

https://dev.azure.com/lowrisc/opentitan/_build/results?buildId=17410&view=results shows a run where `lintpy.py` shows errors on `util/lowrisc_misc-linters/licence-checker/licence-checker.py`, which is a vendored file.

At some point we should do better management of detecting vendored files in our repo (because we know we have a `.vendor.hjson` files for each directory that will be vendored), but for now this brings this part of CI into line with all the other parts of CI that do the same kind of filtering.