### PR TITLE
[vsg] fix _i/_o for several modules

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr.sv.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.sv.tpl
@@ -131,8 +131,8 @@ module clkmgr import clkmgr_pkg::*; (
   ) i_roots_en_sync (
     .clk_i,
     .rst_ni,
-    .d(async_roots_en),
-    .q(roots_en_d)
+    .d_i(async_roots_en),
+    .q_o(roots_en_d)
   );
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
@@ -171,8 +171,8 @@ module clkmgr import clkmgr_pkg::*; (
   ) i_${k}_sw_en_sync (
     .clk_i(clk_${v}_i),
     .rst_ni(rst_${v}_ni),
-    .d(reg2hw.clk_enables.${k}_en.q),
-    .q(${k}_sw_en)
+    .d_i(reg2hw.clk_enables.${k}_en.q),
+    .q_o(${k}_sw_en)
   );
 
   prim_clock_gating i_${k}_cg (
@@ -203,8 +203,8 @@ module clkmgr import clkmgr_pkg::*; (
   ) i_${k}_hint_sync (
     .clk_i(clk_${v}_i),
     .rst_ni(rst_${v}_ni),
-    .d(reg2hw.clk_hints.${k}_hint.q),
-    .q(${k}_hint)
+    .d_i(reg2hw.clk_hints.${k}_hint.q),
+    .q_o(${k}_hint)
   );
 
   prim_clock_gating i_${k}_cg (

--- a/hw/ip/clkmgr/rtl/clkmgr.sv
+++ b/hw/ip/clkmgr/rtl/clkmgr.sv
@@ -112,8 +112,8 @@ module clkmgr import clkmgr_pkg::*; (
   ) i_roots_en_sync (
     .clk_i,
     .rst_ni,
-    .d(async_roots_en),
-    .q(roots_en_d)
+    .d_i(async_roots_en),
+    .q_o(roots_en_d)
   );
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
@@ -156,8 +156,8 @@ module clkmgr import clkmgr_pkg::*; (
   ) i_clk_fixed_peri_sw_en_sync (
     .clk_i(clk_fixed_i),
     .rst_ni(rst_fixed_ni),
-    .d(reg2hw.clk_enables.clk_fixed_peri_en.q),
-    .q(clk_fixed_peri_sw_en)
+    .d_i(reg2hw.clk_enables.clk_fixed_peri_en.q),
+    .q_o(clk_fixed_peri_sw_en)
   );
 
   prim_clock_gating i_clk_fixed_peri_cg (
@@ -172,8 +172,8 @@ module clkmgr import clkmgr_pkg::*; (
   ) i_clk_usb_48mhz_peri_sw_en_sync (
     .clk_i(clk_usb_48mhz_i),
     .rst_ni(rst_usb_48mhz_ni),
-    .d(reg2hw.clk_enables.clk_usb_48mhz_peri_en.q),
-    .q(clk_usb_48mhz_peri_sw_en)
+    .d_i(reg2hw.clk_enables.clk_usb_48mhz_peri_en.q),
+    .q_o(clk_usb_48mhz_peri_sw_en)
   );
 
   prim_clock_gating i_clk_usb_48mhz_peri_cg (
@@ -206,8 +206,8 @@ module clkmgr import clkmgr_pkg::*; (
   ) i_clk_main_aes_hint_sync (
     .clk_i(clk_main_i),
     .rst_ni(rst_main_ni),
-    .d(reg2hw.clk_hints.clk_main_aes_hint.q),
-    .q(clk_main_aes_hint)
+    .d_i(reg2hw.clk_hints.clk_main_aes_hint.q),
+    .q_o(clk_main_aes_hint)
   );
 
   prim_clock_gating i_clk_main_aes_cg (
@@ -224,8 +224,8 @@ module clkmgr import clkmgr_pkg::*; (
   ) i_clk_main_hmac_hint_sync (
     .clk_i(clk_main_i),
     .rst_ni(rst_main_ni),
-    .d(reg2hw.clk_hints.clk_main_hmac_hint.q),
-    .q(clk_main_hmac_hint)
+    .d_i(reg2hw.clk_hints.clk_main_hmac_hint.q),
+    .q_o(clk_main_hmac_hint)
   );
 
   prim_clock_gating i_clk_main_hmac_cg (

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_top.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_top.sv
@@ -80,7 +80,7 @@ module flash_ctrl_reg_top (
     .tl_h_o (tl_o),
     .tl_d_o (tl_socket_h2d),
     .tl_d_i (tl_socket_d2h),
-    .dev_select (reg_steer)
+    .dev_select_i (reg_steer)
   );
 
   // Create steering logic

--- a/hw/ip/hmac/rtl/hmac_reg_top.sv
+++ b/hw/ip/hmac/rtl/hmac_reg_top.sv
@@ -78,7 +78,7 @@ module hmac_reg_top (
     .tl_h_o (tl_o),
     .tl_d_o (tl_socket_h2d),
     .tl_d_i (tl_socket_d2h),
-    .dev_select (reg_steer)
+    .dev_select_i (reg_steer)
   );
 
   // Create steering logic

--- a/hw/ip/otbn/rtl/otbn_reg_top.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_top.sv
@@ -80,7 +80,7 @@ module otbn_reg_top (
     .tl_h_o (tl_o),
     .tl_d_o (tl_socket_h2d),
     .tl_d_i (tl_socket_d2h),
-    .dev_select (reg_steer)
+    .dev_select_i (reg_steer)
   );
 
   // Create steering logic

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_top.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_top.sv
@@ -80,7 +80,7 @@ module otp_ctrl_reg_top (
     .tl_h_o (tl_o),
     .tl_d_o (tl_socket_h2d),
     .tl_d_i (tl_socket_d2h),
-    .dev_select (reg_steer)
+    .dev_select_i (reg_steer)
   );
 
   // Create steering logic

--- a/hw/ip/pinmux/rtl/pinmux_wkup.sv
+++ b/hw/ip/pinmux/rtl/pinmux_wkup.sv
@@ -44,8 +44,8 @@ module pinmux_wkup import pinmux_pkg::*; import pinmux_reg_pkg::*; #(
   ) i_prim_flop_2sync_config (
     .clk_i  ( clk_aon_i      ),
     .rst_ni ( rst_aon_ni     ),
-    .d      ( wkup_en_i     ),
-    .q      ( aon_wkup_en_d )
+    .d_i    ( wkup_en_i     ),
+    .q_o    ( aon_wkup_en_d )
   );
 
   always_ff @(posedge clk_aon_i or negedge rst_aon_ni) begin : p_sync
@@ -93,8 +93,8 @@ module pinmux_wkup import pinmux_pkg::*; import pinmux_reg_pkg::*; #(
   ) i_prim_flop_2sync_filter (
     .clk_i  ( clk_aon_i  ),
     .rst_ni ( rst_aon_ni ),
-    .d      ( aon_filter_out ),
-    .q      ( aon_filter_out_d )
+    .d_i    ( aon_filter_out ),
+    .q_o    ( aon_filter_out_d )
   );
 
   //////////////////////
@@ -157,8 +157,8 @@ module pinmux_wkup import pinmux_pkg::*; import pinmux_reg_pkg::*; #(
   ) i_prim_flop_2sync_cause_in (
     .clk_i  ( clk_aon_i  ),
     .rst_ni ( rst_aon_ni ),
-    .d      ( wkup_cause_data_i   ),
-    .q      ( aon_wkup_cause_data )
+    .d_i    ( wkup_cause_data_i   ),
+    .q_o    ( aon_wkup_cause_data )
   );
 
   prim_pulse_sync i_prim_pulse_sync_cause (
@@ -183,8 +183,8 @@ module pinmux_wkup import pinmux_pkg::*; import pinmux_reg_pkg::*; #(
   ) i_prim_flop_2sync_cause_out (
     .clk_i,
     .rst_ni,
-    .d      ( aon_wkup_cause_q  ),
-    .q      ( wkup_cause_data_o )
+    .d_i    ( aon_wkup_cause_q  ),
+    .q_o    ( wkup_cause_data_o )
   );
 
   always_ff @(posedge clk_aon_i or negedge rst_aon_ni) begin : p_aon_cause

--- a/hw/ip/prim/rtl/prim_clock_gating_sync.sv
+++ b/hw/ip/prim/rtl/prim_clock_gating_sync.sv
@@ -19,8 +19,8 @@ module prim_clock_gating_sync (
   ) i_sync (
     .clk_i,
     .rst_ni,
-    .d(async_en_i),
-    .q(en_o)
+    .d_i(async_en_i),
+    .q_o(en_o)
   );
 
   prim_clock_gating i_cg (

--- a/hw/ip/prim/rtl/prim_diff_decode.sv
+++ b/hw/ip/prim/rtl/prim_diff_decode.sv
@@ -57,8 +57,8 @@ module prim_diff_decode #(
     ) i_sync_p (
       .clk_i,
       .rst_ni,
-      .d(diff_pi),
-      .q(diff_pd)
+      .d_i(diff_pi),
+      .q_o(diff_pd)
     );
 
     prim_flop_2sync #(
@@ -67,8 +67,8 @@ module prim_diff_decode #(
     ) i_sync_n (
       .clk_i,
       .rst_ni,
-      .d(diff_ni),
-      .q(diff_nd)
+      .d_i(diff_ni),
+      .q_o(diff_nd)
     );
 
     // detect level transitions

--- a/hw/ip/prim/rtl/prim_fifo_async.sv
+++ b/hw/ip/prim/rtl/prim_fifo_async.sv
@@ -80,8 +80,8 @@ module prim_fifo_async #(
   prim_flop_2sync #(.Width(PTR_WIDTH)) sync_wptr (
     .clk_i    (clk_rd_i),
     .rst_ni   (rst_rd_ni),
-    .d        (fifo_wptr_gray),
-    .q        (fifo_wptr_gray_sync));
+    .d_i      (fifo_wptr_gray),
+    .q_o      (fifo_wptr_gray_sync));
 
   assign fifo_wptr_sync_combi = gray2dec(fifo_wptr_gray_sync);
 
@@ -115,8 +115,8 @@ module prim_fifo_async #(
   prim_flop_2sync #(.Width(PTR_WIDTH)) sync_rptr (
     .clk_i    (clk_wr_i),
     .rst_ni   (rst_wr_ni),
-    .d        (fifo_rptr_gray),
-    .q        (fifo_rptr_gray_sync));
+    .d_i      (fifo_rptr_gray),
+    .q_o      (fifo_rptr_gray_sync));
 
   always_ff @(posedge clk_wr_i or negedge rst_wr_ni)
     if (!rst_wr_ni) begin

--- a/hw/ip/prim/rtl/prim_pulse_sync.sv
+++ b/hw/ip/prim/rtl/prim_pulse_sync.sv
@@ -39,11 +39,11 @@ module prim_pulse_sync (
 
   prim_flop_2sync #(.Width(1)) prim_flop_2sync (
     // source clock domain
-    .d      (src_level),
+    .d_i    (src_level),
     // destination clock domain
     .clk_i  (clk_dst_i),
     .rst_ni (rst_dst_ni),
-    .q      (dst_level)
+    .q_o    (dst_level)
   );
 
   ////////////////////////////////////////

--- a/hw/ip/prim/rtl/prim_sync_reqack.sv
+++ b/hw/ip/prim/rtl/prim_sync_reqack.sv
@@ -53,8 +53,8 @@ module prim_sync_reqack (
   ) req_sync (
     .clk_i  (clk_dst_i),
     .rst_ni (rst_dst_ni),
-    .d      (src_req_q),
-    .q      (dst_req)
+    .d_i    (src_req_q),
+    .q_o    (dst_req)
   );
 
   // Move ACK over to REQ side.
@@ -63,8 +63,8 @@ module prim_sync_reqack (
   ) ack_sync (
     .clk_i  (clk_src_i),
     .rst_ni (rst_src_ni),
-    .d      (dst_ack_q),
-    .q      (src_ack)
+    .d_i    (dst_ack_q),
+    .q_o    (src_ack)
   );
 
   // REQ-side FSM (source domain)

--- a/hw/ip/prim_generic/rtl/prim_generic_flop_2sync.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_flop_2sync.sv
@@ -13,8 +13,8 @@ module prim_generic_flop_2sync #(
 ) (
   input                    clk_i,       // receive clock
   input                    rst_ni,
-  input        [Width-1:0] d,
-  output logic [Width-1:0] q
+  input        [Width-1:0] d_i,
+  output logic [Width-1:0] q_o
 );
 
   logic [Width-1:0] intq;
@@ -25,7 +25,7 @@ module prim_generic_flop_2sync #(
   ) u_sync_1 (
     .clk_i,
     .rst_ni,
-    .d_i(d),
+    .d_i,
     .q_o(intq)
   );
 
@@ -36,7 +36,7 @@ module prim_generic_flop_2sync #(
     .clk_i,
     .rst_ni,
     .d_i(intq),
-    .q_o(q)
+    .q_o
   );
 
 

--- a/hw/ip/pwrmgr/rtl/pwrmgr_cdc.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_cdc.sv
@@ -66,8 +66,8 @@ module pwrmgr_cdc import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;
   ) i_req_pwrdn_sync (
     .clk_i(clk_slow_i),
     .rst_ni(rst_slow_ni),
-    .d(req_pwrdn_i),
-    .q(slow_req_pwrdn_o)
+    .d_i(req_pwrdn_i),
+    .q_o(slow_req_pwrdn_o)
   );
 
   prim_flop_2sync # (
@@ -75,8 +75,8 @@ module pwrmgr_cdc import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;
   ) i_ack_pwrup_sync (
     .clk_i(clk_slow_i),
     .rst_ni(rst_slow_ni),
-    .d(ack_pwrup_i),
-    .q(slow_ack_pwrup_o)
+    .d_i(ack_pwrup_i),
+    .q_o(slow_ack_pwrup_o)
   );
 
   prim_pulse_sync i_slow_cdc_sync (
@@ -96,8 +96,8 @@ module pwrmgr_cdc import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;
   ) i_slow_ext_req_sync (
     .clk_i  (clk_slow_i),
     .rst_ni (rst_slow_ni),
-    .d      (peri_i),
-    .q      (slow_peri_reqs_o)
+    .d_i    (peri_i),
+    .q_o    (slow_peri_reqs_o)
   );
 
 
@@ -109,8 +109,8 @@ module pwrmgr_cdc import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;
   ) i_ast_sync (
     .clk_i  (clk_slow_i),
     .rst_ni (rst_slow_ni),
-    .d      (ast_i),
-    .q      (slow_ast_q)
+    .d_i    (ast_i),
+    .q_o    (slow_ast_q)
   );
 
   always_ff @(posedge clk_slow_i or negedge rst_slow_ni) begin
@@ -163,8 +163,8 @@ module pwrmgr_cdc import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;
   ) i_req_pwrup_sync (
     .clk_i,
     .rst_ni,
-    .d(slow_req_pwrup_i),
-    .q(req_pwrup_o)
+    .d_i(slow_req_pwrup_i),
+    .q_o(req_pwrup_o)
   );
 
   prim_flop_2sync # (
@@ -172,8 +172,8 @@ module pwrmgr_cdc import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;
   ) i_ack_pwrdn_sync (
     .clk_i,
     .rst_ni,
-    .d(slow_ack_pwrdn_i),
-    .q(ack_pwrdn_o)
+    .d_i(slow_ack_pwrdn_i),
+    .q_o(ack_pwrdn_o)
   );
 
   prim_flop_2sync # (
@@ -181,8 +181,8 @@ module pwrmgr_cdc import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;
   ) i_pwrup_chg_sync (
     .clk_i,
     .rst_ni,
-    .d(slow_pwrup_cause_toggle_i),
-    .q(pwrup_cause_toggle_q)
+    .d_i(slow_pwrup_cause_toggle_i),
+    .q_o(pwrup_cause_toggle_q)
   );
 
   prim_pulse_sync i_scdc_sync (
@@ -217,8 +217,8 @@ module pwrmgr_cdc import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;
   ) i_ext_req_sync (
     .clk_i,
     .rst_ni,
-    .d (slow_peri_reqs_masked_i),
-    .q (peri_reqs_o)
+    .d_i(slow_peri_reqs_masked_i),
+    .q_o(peri_reqs_o)
   );
 
 
@@ -240,8 +240,8 @@ endmodule
   ) i_pwrup_sync (
     .clk_i,
     .rst_ni,
-    .d(slow_req_pwrup),
-    .q(req_pwrup)
+    .d_i(slow_req_pwrup),
+    .q_o(req_pwrup)
   );
 
   pwrmgr_cdc_pulse i_cdc_pulse (
@@ -294,7 +294,7 @@ endmodule
   ) i_pok_sync (
     .clk_i  (clk_slow_i),
     .rst_ni (rst_slow_ni),
-    .d      (pwr_ast_i),
-    .q      (slow_ast_q)
+    .d_i    (pwr_ast_i),
+    .q_o    (slow_ast_q)
   );
 */

--- a/hw/ip/pwrmgr/rtl/pwrmgr_cdc_pulse.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_cdc_pulse.sv
@@ -48,8 +48,8 @@ module pwrmgr_cdc_pulse (
   ) i_pos_sync (
     .clk_i,
     .rst_ni,
-    .d(slow_toggle_pq),
-    .q(clk_slow_pq)
+    .d_i(slow_toggle_pq),
+    .q_o(clk_slow_pq)
   );
 
   prim_flop_2sync # (
@@ -57,8 +57,8 @@ module pwrmgr_cdc_pulse (
   ) i_neg_sync (
     .clk_i,
     .rst_ni,
-    .d(slow_toggle_nq),
-    .q(clk_slow_nq)
+    .d_i(slow_toggle_nq),
+    .q_o(clk_slow_nq)
   );
 
   always_ff @(posedge clk_i or negedge rst_ni) begin

--- a/hw/ip/rstmgr/rtl/rstmgr.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr.sv
@@ -65,8 +65,8 @@ module rstmgr import rstmgr_pkg::*; (
   ) i_por_sync (
     .clk_i(clk_main_i),
     .rst_ni(resets_o.rst_por_aon_n),
-    .d(1'b1),
-    .q(resets_int.rst_por_n)
+    .d_i(1'b1),
+    .q_o(resets_int.rst_por_n)
   );
 
   prim_flop_2sync #(
@@ -75,8 +75,8 @@ module rstmgr import rstmgr_pkg::*; (
   ) i_por_io_sync (
     .clk_i(clk_io_i),
     .rst_ni(resets_o.rst_por_aon_n),
-    .d(1'b1),
-    .q(resets_int.rst_por_io_n)
+    .d_i(1'b1),
+    .q_o(resets_int.rst_por_io_n)
   );
 
   prim_flop_2sync #(
@@ -85,8 +85,8 @@ module rstmgr import rstmgr_pkg::*; (
   ) i_por_io_div2_sync (
     .clk_i(clk_io_div2_i),
     .rst_ni(resets_o.rst_por_aon_n),
-    .d(1'b1),
-    .q(resets_int.rst_por_io_div2_n)
+    .d_i(1'b1),
+    .q_o(resets_int.rst_por_io_div2_n)
   );
 
   prim_flop_2sync #(
@@ -95,8 +95,8 @@ module rstmgr import rstmgr_pkg::*; (
   ) i_por_usb_sync (
     .clk_i(clk_usb_i),
     .rst_ni(resets_o.rst_por_aon_n),
-    .d(1'b1),
-    .q(resets_int.rst_por_usb_n)
+    .d_i(1'b1),
+    .q_o(resets_int.rst_por_usb_n)
   );
 
   ////////////////////////////////////////////////////
@@ -129,8 +129,8 @@ module rstmgr import rstmgr_pkg::*; (
   ) i_sync (
     .clk_i,
     .rst_ni(resets_o.rst_por_aon_n),
-    .d(cpu_i.ndmreset_req),
-    .q(ndmreset_req_q)
+    .d_i(cpu_i.ndmreset_req),
+    .q_o(ndmreset_req_q)
   );
 
   assign ndm_req_valid = ndmreset_req_q & (pwr_i.reset_cause == pwrmgr_pkg::ResetNone);
@@ -183,8 +183,8 @@ module rstmgr import rstmgr_pkg::*; (
   ) i_lc (
     .clk_i(clk_io_div2_i),
     .rst_ni(rst_lc_src_n[ALWAYS_ON_SEL]),
-    .d(1'b1),
-    .q(resets_int.rst_lc_n)
+    .d_i(1'b1),
+    .q_o(resets_int.rst_lc_n)
   );
 
   prim_flop_2sync #(
@@ -193,8 +193,8 @@ module rstmgr import rstmgr_pkg::*; (
   ) i_sys (
     .clk_i(clk_main_i),
     .rst_ni(rst_sys_src_n[ALWAYS_ON_SEL]),
-    .d(1'b1),
-    .q(resets_int.rst_sys_n)
+    .d_i(1'b1),
+    .q_o(resets_int.rst_sys_n)
   );
 
   prim_flop_2sync #(
@@ -203,8 +203,8 @@ module rstmgr import rstmgr_pkg::*; (
   ) i_sys_io (
     .clk_i(clk_io_div2_i),
     .rst_ni(rst_sys_src_n[ALWAYS_ON_SEL]),
-    .d(1'b1),
-    .q(resets_int.rst_sys_io_n)
+    .d_i(1'b1),
+    .q_o(resets_int.rst_sys_io_n)
   );
 
   prim_flop_2sync #(
@@ -213,8 +213,8 @@ module rstmgr import rstmgr_pkg::*; (
   ) i_spi_device (
     .clk_i(clk_io_div2_i),
     .rst_ni(rst_sys_src_n[ALWAYS_ON_SEL]),
-    .d(reg2hw.rst_spi_device_n.q),
-    .q(resets_int.rst_spi_device_n)
+    .d_i(reg2hw.rst_spi_device_n.q),
+    .q_o(resets_int.rst_spi_device_n)
   );
 
   prim_flop_2sync #(
@@ -223,8 +223,8 @@ module rstmgr import rstmgr_pkg::*; (
   ) i_usb (
     .clk_i(clk_usb_i),
     .rst_ni(rst_sys_src_n[ALWAYS_ON_SEL]),
-    .d(reg2hw.rst_usb_n.q),
-    .q(resets_int.rst_usb_n)
+    .d_i(reg2hw.rst_usb_n.q),
+    .q_o(resets_int.rst_usb_n)
   );
 
   ////////////////////////////////////////////////////

--- a/hw/ip/rstmgr/rtl/rstmgr_ctrl.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr_ctrl.sv
@@ -39,8 +39,8 @@ module rstmgr_ctrl import rstmgr_pkg::*; #(
   ) u_lc (
     .clk_i(clk_i),
     .rst_ni(rst_ni),
-    .d(rst_parent_ni),
-    .q(rst_parent_synced)
+    .d_i(rst_parent_ni),
+    .q_o(rst_parent_synced)
   );
 
   // always on handling

--- a/hw/ip/rstmgr/rtl/rstmgr_info.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr_info.sv
@@ -30,8 +30,8 @@ module rstmgr_info #(
   ) u_cpu_reset_synced (
     .clk_i(clk_i),
     .rst_ni(rst_ni),
-    .d(rst_cpu_ni),
-    .q(rst_cpu_nq)
+    .d_i(rst_cpu_ni),
+    .q_o(rst_cpu_nq)
   );
 
   // first reset is a flag that blocks reset recording until first de-assertion

--- a/hw/ip/rstmgr/rtl/rstmgr_por.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr_por.sv
@@ -33,8 +33,8 @@ module rstmgr_por #(
   ) rst_sync (
     .clk_i(clk_i),
     .rst_ni(rst_ni),
-    .d(1'b1),
-    .q(rst_root_n)
+    .d_i(1'b1),
+    .q_o(rst_root_n)
   );
 
   // filter the POR

--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -184,8 +184,8 @@ module spi_device #(
   prim_flop_2sync #(.Width(1)) u_sync_csb (
     .clk_i,
     .rst_ni,
-    .d(cio_csb_i),
-    .q(csb_syncd)
+    .d_i(cio_csb_i),
+    .q_o(csb_syncd)
   );
 
   logic rxf_full_q, txf_empty_q;
@@ -200,14 +200,14 @@ module spi_device #(
   prim_flop_2sync #(.Width(1)) u_sync_rxf (
     .clk_i,
     .rst_ni,
-    .d(rxf_full_q),
-    .q(rxf_full_syncd)
+    .d_i(rxf_full_q),
+    .q_o(rxf_full_syncd)
   );
   prim_flop_2sync #(.Width(1), .ResetValue(1'b1)) u_sync_txe (
     .clk_i,
     .rst_ni,
-    .d(txf_empty_q),
-    .q(txf_empty_syncd)
+    .d_i(txf_empty_q),
+    .q_o(txf_empty_syncd)
   );
 
   assign spi_mode = spi_mode_e'(reg2hw.control.mode.q);
@@ -353,9 +353,9 @@ module spi_device #(
 
     // SPI signal
     .csb_i         (cio_csb_i),
-    .sdi           (cio_sdi_i),
-    .sdo           (cio_sdo_o),
-    .sdo_oe        (cio_sdo_en_o)
+    .sdi_i         (cio_sdi_i),
+    .sdo_o         (cio_sdo_o),
+    .sdo_oe_o      (cio_sdo_en_o)
   );
 
   // FIFO: Connecting FwMode to SRAM CTRLs

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -78,7 +78,7 @@ module spi_device_reg_top (
     .tl_h_o (tl_o),
     .tl_d_o (tl_socket_h2d),
     .tl_d_i (tl_socket_d2h),
-    .dev_select (reg_steer)
+    .dev_select_i (reg_steer)
   );
 
   // Create steering logic

--- a/hw/ip/spi_device/rtl/spi_fwmode.sv
+++ b/hw/ip/spi_device/rtl/spi_fwmode.sv
@@ -35,9 +35,9 @@ module spi_fwmode (
 
   // SPI Interface: clock is given (ckl_in_i, clk_out_i)
   input        csb_i,
-  input        sdi,
-  output logic sdo,
-  output logic sdo_oe
+  input        sdi_i,
+  output logic sdo_o,
+  output logic sdo_oe_o
 );
 
   import spi_device_pkg::*;
@@ -58,9 +58,9 @@ module spi_fwmode (
   // Serial to Parallel
   always_comb begin
     if (cfg_rxorder_i) begin
-      rx_data_d = {sdi, rx_data_q[BITS-1:1]};
+      rx_data_d = {sdi_i, rx_data_q[BITS-1:1]};
     end else begin
-      rx_data_d = {rx_data_q[BITS-2:0], sdi};
+      rx_data_d = {rx_data_q[BITS-2:0], sdi_i};
     end
   end
 
@@ -121,9 +121,9 @@ module spi_fwmode (
     end
   end
 
-  assign sdo = (cfg_txorder_i) ? ((~first_bit) ? sdo_shift[0] : tx_data_i[0]) :
-                (~first_bit) ? sdo_shift[7] : tx_data_i[7] ;
-  assign sdo_oe = ~csb_i;
+  assign sdo_o = (cfg_txorder_i) ? ((~first_bit) ? sdo_shift[0] : tx_data_i[0]) :
+                  (~first_bit) ? sdo_shift[7] : tx_data_i[7] ;
+  assign sdo_oe_o = ~csb_i;
 
   always_ff @(posedge clk_out_i) begin
     if (cfg_txorder_i) begin

--- a/hw/ip/tlul/rtl/sram2tlul.sv
+++ b/hw/ip/tlul/rtl/sram2tlul.sv
@@ -21,13 +21,13 @@ module sram2tlul #(
   input  tlul_pkg::tl_d2h_t tl_i,
 
   // SRAM
-  input                     mem_req,
-  input                     mem_write,
-  input        [SramAw-1:0] mem_addr,
-  input        [SramDw-1:0] mem_wdata,
-  output logic              mem_rvalid,
-  output logic [SramDw-1:0] mem_rdata,
-  output logic        [1:0] mem_error
+  input                     mem_req_i,
+  input                     mem_write_i,
+  input        [SramAw-1:0] mem_addr_i,
+  input        [SramDw-1:0] mem_wdata_i,
+  output logic              mem_rvalid_o,
+  output logic [SramDw-1:0] mem_rdata_o,
+  output logic        [1:0] mem_error_o
 );
 
   import tlul_pkg::*;
@@ -36,22 +36,22 @@ module sram2tlul #(
 
   localparam int unsigned SRAM_DWB = $clog2(SramDw/8);
 
-  assign tl_o.a_valid   = mem_req;
-  assign tl_o.a_opcode  = (mem_write) ? PutFullData : Get;
+  assign tl_o.a_valid   = mem_req_i;
+  assign tl_o.a_opcode  = (mem_write_i) ? PutFullData : Get;
   assign tl_o.a_param   = '0;
   assign tl_o.a_size    = top_pkg::TL_SZW'(SRAM_DWB); // Max Size always
   assign tl_o.a_source  = '0;
   assign tl_o.a_address = TlBaseAddr |
-                          {{(top_pkg::TL_AW-SramAw-SRAM_DWB){1'b0}},mem_addr,{(SRAM_DWB){1'b0}}};
+                          {{(top_pkg::TL_AW-SramAw-SRAM_DWB){1'b0}},mem_addr_i,{(SRAM_DWB){1'b0}}};
   assign tl_o.a_mask    = '1;
-  assign tl_o.a_data    = mem_wdata;
+  assign tl_o.a_data    = mem_wdata_i;
   assign tl_o.a_user    = '0;
 
   assign tl_o.d_ready   = 1'b1;
 
-  assign mem_rvalid     = tl_i.d_valid && (tl_i.d_opcode == AccessAckData);
-  assign mem_rdata      = tl_i.d_data;
-  assign mem_error      = {2{tl_i.d_error}};
+  assign mem_rvalid_o   = tl_i.d_valid && (tl_i.d_opcode == AccessAckData);
+  assign mem_rdata_o    = tl_i.d_data;
+  assign mem_error_o    = {2{tl_i.d_error}};
 
   // below assertion fails when TL-UL doesn't accept request in a cycle,
   // which is currently not supported by sram2tlul

--- a/hw/ip/tlul/rtl/tlul_socket_1n.sv
+++ b/hw/ip/tlul/rtl/tlul_socket_1n.sv
@@ -27,9 +27,9 @@
 // have returned.  Need to keep a counter of all outstanding requests and
 // wait until that counter is zero before switching devices.
 //
-// This module will return a request error if the input value of 'dev_select'
+// This module will return a request error if the input value of 'dev_select_i'
 // is not within the range 0..N-1. Thus the instantiator of the socket
-// can indicate error by any illegal value of dev_select. 4'b1111 is
+// can indicate error by any illegal value of dev_select_i. 4'b1111 is
 // recommended for visibility
 //
 // The maximum value of N is 15
@@ -54,7 +54,7 @@ module tlul_socket_1n #(
   output tlul_pkg::tl_d2h_t tl_h_o,
   output tlul_pkg::tl_h2d_t tl_d_o    [N],
   input  tlul_pkg::tl_d2h_t tl_d_i    [N],
-  input  [NWD-1:0]          dev_select
+  input  [NWD-1:0]          dev_select_i
 );
 
   `ASSERT_INIT(maxN, N < 16)
@@ -83,7 +83,7 @@ module tlul_socket_1n #(
     .tl_h_o,
     .tl_d_o     (tl_t_o),
     .tl_d_i     (tl_t_i),
-    .spare_req_i (dev_select),
+    .spare_req_i (dev_select_i),
     .spare_req_o (dev_select_t),
     .spare_rsp_i (1'b0),
     .spare_rsp_o ());

--- a/hw/ip/uart/rtl/uart_core.sv
+++ b/hw/ip/uart/rtl/uart_core.sv
@@ -223,8 +223,8 @@ module uart_core (
   ) sync_rx (
     .clk_i,
     .rst_ni,
-    .d(rx),
-    .q(rx_sync)
+    .d_i(rx),
+    .q_o(rx_sync)
   );
 
   // Based on: en.wikipedia.org/wiki/Repetition_code mentions the use of a majority filter

--- a/hw/ip/usbdev/rtl/usbdev.sv
+++ b/hw/ip/usbdev/rtl/usbdev.sv
@@ -262,8 +262,8 @@ module usbdev (
   ) usbdev_sync_ep_cfg (
     .clk_i  (clk_usb_48mhz_i),
     .rst_ni (rst_usb_48mhz_ni),
-    .d      ({enable_setup, enable_out, ep_stall}),
-    .q      ({usb_enable_setup, usb_enable_out, usb_ep_stall})
+    .d_i    ({enable_setup, enable_out, ep_stall}),
+    .q_o    ({usb_enable_setup, usb_enable_out, usb_ep_stall})
   );
 
   // CDC: ok, quasi-static
@@ -292,8 +292,8 @@ module usbdev (
   ) usbdev_rdysync (
     .clk_i  (clk_usb_48mhz_i),
     .rst_ni (rst_usb_48mhz_ni),
-    .d      (in_rdy_async),
-    .q      (usb_in_rdy)
+    .d_i    (in_rdy_async),
+    .q_o    (usb_in_rdy)
   );
 
   // CDC: We synchronize the qe (write pulse) and assume that the
@@ -547,8 +547,8 @@ module usbdev (
   ) cdc_usb_to_sys (
     .clk_i  (clk_i),
     .rst_ni (rst_ni),
-    .d      ({usb_link_state,              usb_frame}),
-    .q      ({hw2reg.usbstat.link_state.d, hw2reg.usbstat.frame.d})
+    .d_i    ({usb_link_state,              usb_frame}),
+    .q_o    ({hw2reg.usbstat.link_state.d, hw2reg.usbstat.frame.d})
   );
 
   // sys clk -> USB clk
@@ -557,8 +557,8 @@ module usbdev (
   ) cdc_sys_to_usb (
     .clk_i  (clk_usb_48mhz_i),
     .rst_ni (rst_usb_48mhz_ni),
-    .d      ({reg2hw.usbctrl.enable.q, reg2hw.usbctrl.device_address.q}),
-    .q      ({usb_enable,              usb_device_addr})
+    .d_i    ({reg2hw.usbctrl.enable.q, reg2hw.usbctrl.device_address.q}),
+    .q_o    ({usb_enable,              usb_device_addr})
   );
 
   // CDC for event signals (arguably they are there for a long time so would be ok)
@@ -566,9 +566,9 @@ module usbdev (
   usbdev_flop_2syncpulse #(.Width(5)) syncevent (
     .clk_i  (clk_i),
     .rst_ni (rst_ni),
-    .d      ({usb_event_disconnect, usb_event_link_reset, usb_event_link_suspend,
+    .d_i    ({usb_event_disconnect, usb_event_link_reset, usb_event_link_suspend,
               usb_event_host_lost, usb_event_connect}),
-    .q      ({event_disconnect, event_link_reset, event_link_suspend,
+    .q_o    ({event_disconnect, event_link_reset, event_link_suspend,
               event_host_lost, event_connect})
   );
 
@@ -952,8 +952,8 @@ module usbdev (
   ) usbdev_sync_phy_config (
     .clk_i  (clk_usb_48mhz_i),
     .rst_ni (rst_usb_48mhz_ni),
-    .d      (reg2hw.phy_config.usb_ref_disable.q),
-    .q      (usb_ref_disable)
+    .d_i    (reg2hw.phy_config.usb_ref_disable.q),
+    .q_o    (usb_ref_disable)
   );
 
   // Directly forward the pulse unless disabled.

--- a/hw/ip/usbdev/rtl/usbdev_flop_2syncpulse.sv
+++ b/hw/ip/usbdev/rtl/usbdev_flop_2syncpulse.sv
@@ -9,8 +9,8 @@ module usbdev_flop_2syncpulse #(
 ) (
   input  logic             clk_i,    // receive clock
   input  logic             rst_ni,
-  input  logic [Width-1:0] d,
-  output logic [Width-1:0] q
+  input  logic [Width-1:0] d_i,
+  output logic [Width-1:0] q_o
 );
 
   // double-flop synchronizer cell
@@ -18,8 +18,8 @@ module usbdev_flop_2syncpulse #(
   prim_flop_2sync #(.Width (Width)) prim_flop_2sync (
     .clk_i,
     .rst_ni,
-    .d,
-    .q (d_sync)
+    .d_i,
+    .q_o(d_sync)
   );
 
   // delay d_sync by 1 cycle
@@ -33,6 +33,6 @@ module usbdev_flop_2syncpulse #(
   end
 
   // rising edge detection
-  assign q = d_sync & ~d_sync_q;
+  assign q_o = d_sync & ~d_sync_q;
 
 endmodule

--- a/hw/ip/usbdev/rtl/usbdev_iomux.sv
+++ b/hw/ip/usbdev/rtl/usbdev_iomux.sv
@@ -71,8 +71,8 @@ module usbdev_iomux
   ) cdc_io_to_sys (
     .clk_i  (clk_i),
     .rst_ni (rst_ni),
-    .d      ({cio_usb_sense_i}),
-    .q      ({sys_usb_sense})
+    .d_i    ({cio_usb_sense_i}),
+    .q_o    ({sys_usb_sense})
   );
 
   assign sys_usb_sense_o = sys_usb_sense;
@@ -83,11 +83,11 @@ module usbdev_iomux
   ) cdc_io_to_usb (
     .clk_i  (clk_usb_48mhz_i),
     .rst_ni (rst_usb_48mhz_ni),
-    .d      ({cio_usb_dp_i,
+    .d_i    ({cio_usb_dp_i,
               cio_usb_dn_i,
               cio_usb_d_i,
               async_pwr_sense}),
-    .q      ({cio_usb_dp,
+    .q_o    ({cio_usb_dp,
               cio_usb_dn,
               cio_usb_d,
               usb_pwr_sense_o})

--- a/hw/ip/usbdev/rtl/usbdev_reg_top.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_top.sv
@@ -78,7 +78,7 @@ module usbdev_reg_top (
     .tl_h_o (tl_o),
     .tl_d_o (tl_socket_h2d),
     .tl_d_i (tl_socket_d2h),
-    .dev_select (reg_steer)
+    .dev_select_i (reg_steer)
   );
 
   // Create steering logic

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
@@ -154,8 +154,8 @@ module clkmgr import clkmgr_pkg::*; (
   ) i_roots_en_sync (
     .clk_i,
     .rst_ni,
-    .d(async_roots_en),
-    .q(roots_en_d)
+    .d_i(async_roots_en),
+    .q_o(roots_en_d)
   );
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
@@ -195,8 +195,8 @@ module clkmgr import clkmgr_pkg::*; (
   ) i_clk_io_peri_sw_en_sync (
     .clk_i(clk_io_i),
     .rst_ni(rst_io_ni),
-    .d(reg2hw.clk_enables.clk_io_peri_en.q),
-    .q(clk_io_peri_sw_en)
+    .d_i(reg2hw.clk_enables.clk_io_peri_en.q),
+    .q_o(clk_io_peri_sw_en)
   );
 
   prim_clock_gating i_clk_io_peri_cg (
@@ -211,8 +211,8 @@ module clkmgr import clkmgr_pkg::*; (
   ) i_clk_usb_peri_sw_en_sync (
     .clk_i(clk_usb_i),
     .rst_ni(rst_usb_ni),
-    .d(reg2hw.clk_enables.clk_usb_peri_en.q),
-    .q(clk_usb_peri_sw_en)
+    .d_i(reg2hw.clk_enables.clk_usb_peri_en.q),
+    .q_o(clk_usb_peri_sw_en)
   );
 
   prim_clock_gating i_clk_usb_peri_cg (
@@ -243,8 +243,8 @@ module clkmgr import clkmgr_pkg::*; (
   ) i_clk_main_aes_hint_sync (
     .clk_i(clk_main_i),
     .rst_ni(rst_main_ni),
-    .d(reg2hw.clk_hints.clk_main_aes_hint.q),
-    .q(clk_main_aes_hint)
+    .d_i(reg2hw.clk_hints.clk_main_aes_hint.q),
+    .q_o(clk_main_aes_hint)
   );
 
   prim_clock_gating i_clk_main_aes_cg (
@@ -261,8 +261,8 @@ module clkmgr import clkmgr_pkg::*; (
   ) i_clk_main_hmac_hint_sync (
     .clk_i(clk_main_i),
     .rst_ni(rst_main_ni),
-    .d(reg2hw.clk_hints.clk_main_hmac_hint.q),
-    .q(clk_main_hmac_hint)
+    .d_i(reg2hw.clk_hints.clk_main_hmac_hint.q),
+    .q_o(clk_main_hmac_hint)
   );
 
   prim_clock_gating i_clk_main_hmac_cg (
@@ -279,8 +279,8 @@ module clkmgr import clkmgr_pkg::*; (
   ) i_clk_main_otbn_hint_sync (
     .clk_i(clk_main_i),
     .rst_ni(rst_main_ni),
-    .d(reg2hw.clk_hints.clk_main_otbn_hint.q),
-    .q(clk_main_otbn_hint)
+    .d_i(reg2hw.clk_hints.clk_main_otbn_hint.q),
+    .q_o(clk_main_otbn_hint)
   );
 
   prim_clock_gating i_clk_main_otbn_cg (

--- a/hw/top_earlgrey/ip/xbar_main/rtl/autogen/xbar_main.sv
+++ b/hw/top_earlgrey/ip/xbar_main/rtl/autogen/xbar_main.sv
@@ -557,7 +557,7 @@ end
     .tl_h_o       (tl_s1n_17_us_d2h),
     .tl_d_o       (tl_s1n_17_ds_h2d),
     .tl_d_i       (tl_s1n_17_ds_d2h),
-    .dev_select   (dev_sel_s1n_17)
+    .dev_select_i (dev_sel_s1n_17)
   );
   tlul_socket_m1 #(
     .HReqDepth (12'h0),
@@ -628,7 +628,7 @@ end
     .tl_h_o       (tl_s1n_22_us_d2h),
     .tl_d_o       (tl_s1n_22_ds_h2d),
     .tl_d_i       (tl_s1n_22_ds_d2h),
-    .dev_select   (dev_sel_s1n_22)
+    .dev_select_i (dev_sel_s1n_22)
   );
   tlul_fifo_async #(
     .ReqDepth        (3),// At least 3 to make async work
@@ -796,7 +796,7 @@ end
     .tl_h_o       (tl_s1n_34_us_d2h),
     .tl_d_o       (tl_s1n_34_ds_h2d),
     .tl_d_i       (tl_s1n_34_ds_d2h),
-    .dev_select   (dev_sel_s1n_34)
+    .dev_select_i (dev_sel_s1n_34)
   );
 
 endmodule

--- a/hw/top_earlgrey/ip/xbar_peri/rtl/autogen/xbar_peri.sv
+++ b/hw/top_earlgrey/ip/xbar_peri/rtl/autogen/xbar_peri.sv
@@ -146,7 +146,7 @@ end
     .tl_h_o       (tl_s1n_10_us_d2h),
     .tl_d_o       (tl_s1n_10_ds_h2d),
     .tl_d_i       (tl_s1n_10_ds_d2h),
-    .dev_select   (dev_sel_s1n_10)
+    .dev_select_i (dev_sel_s1n_10)
   );
 
 endmodule

--- a/util/reggen/reg_top.sv.tpl
+++ b/util/reggen/reg_top.sv.tpl
@@ -97,7 +97,7 @@ module ${block.name}_reg_top ${print_param(params)}(
     .tl_h_o (tl_o),
     .tl_d_o (tl_socket_h2d),
     .tl_d_i (tl_socket_d2h),
-    .dev_select (reg_steer)
+    .dev_select_i (reg_steer)
   );
 
   // Create steering logic

--- a/util/tlgen/xbar.rtl.sv.tpl
+++ b/util/tlgen/xbar.rtl.sv.tpl
@@ -236,7 +236,7 @@ ${"end" if loop.last else ""}
     .tl_h_o       (tl_${block.name}_us_d2h),
     .tl_d_o       (tl_${block.name}_ds_h2d),
     .tl_d_i       (tl_${block.name}_ds_d2h),
-    .dev_select   (dev_sel_${block.name})
+    .dev_select_i (dev_sel_${block.name})
   );
   % elif block.node_type.name == "SOCKET_M1":
   tlul_socket_m1 #(


### PR DESCRIPTION
Signed-off-by: Scott Johnson <scottdj@google.com>

Addresses #34 

Fixes _i/_o designations for the following modules: prim_flop_2sync, tlul_socket_1n, and sram2tlul