### PR TITLE
[otbn] Return an error for unmapped register accesses

### DIFF
--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -113,7 +113,7 @@ module otbn
     .reg2hw,
     .hw2reg,
 
-    .devmode_i (1'b0)
+    .devmode_i (1'b1)
   );
 
   // CMD register


### PR DESCRIPTION
This is in line with all other IPs, and helps to prevent errors in the
nightly DV regression, as reported by Cindy.