### PR TITLE
[csrng/fifos] Align ports with *_i/*_o naming convention

### DIFF
--- a/hw/ip/csrng/rtl/csrng_block_encrypt.sv
+++ b/hw/ip/csrng/rtl/csrng_block_encrypt.sv
@@ -112,13 +112,13 @@ module csrng_block_encrypt import aes_pkg::*; #(
        .clk_i    (clk_i),
        .rst_ni   (rst_ni),
        .clr_i    (!block_encrypt_enable_i),
-       .wvalid   (sfifo_blkenc_push),
-       .wready   (sfifo_blkenc_not_full),
-       .wdata    (sfifo_blkenc_wdata),
-       .rvalid   (sfifo_blkenc_not_empty),
-       .rready   (sfifo_blkenc_pop),
-       .rdata    (sfifo_blkenc_rdata),
-       .depth    ()
+       .wvalid_i (sfifo_blkenc_push),
+       .wready_o (sfifo_blkenc_not_full),
+       .wdata_i  (sfifo_blkenc_wdata),
+       .rvalid_o (sfifo_blkenc_not_empty),
+       .rready_i (sfifo_blkenc_pop),
+       .rdata_o  (sfifo_blkenc_rdata),
+       .depth_o  ()
        );
 
   assign sfifo_blkenc_push = block_encrypt_req_i && sfifo_blkenc_not_full;

--- a/hw/ip/csrng/rtl/csrng_cmd_stage.sv
+++ b/hw/ip/csrng/rtl/csrng_cmd_stage.sv
@@ -92,13 +92,13 @@ module csrng_cmd_stage #(
        .clk_i          (clk_i),
        .rst_ni         (rst_ni),
        .clr_i          (!cs_enable_i),
-       .wvalid         (sfifo_cmd_push),
-       .wready         (sfifo_cmd_not_full),
-       .wdata          (sfifo_cmd_wdata),
-       .rvalid         (sfifo_cmd_not_empty),
-       .rready         (sfifo_cmd_pop),
-       .rdata          (sfifo_cmd_rdata),
-       .depth          (sfifo_cmd_depth)
+       .wvalid_i       (sfifo_cmd_push),
+       .wready_o       (sfifo_cmd_not_full),
+       .wdata_i        (sfifo_cmd_wdata),
+       .rvalid_o       (sfifo_cmd_not_empty),
+       .rready_i       (sfifo_cmd_pop),
+       .rdata_o        (sfifo_cmd_rdata),
+       .depth_o        (sfifo_cmd_depth)
        );
 
   assign sfifo_cmd_wdata = cmd_stage_bus_i;
@@ -212,13 +212,13 @@ module csrng_cmd_stage #(
        .clk_i          (clk_i),
        .rst_ni         (rst_ni),
        .clr_i          (!cs_enable_i),
-       .wvalid         (sfifo_genbits_push),
-       .wready         (sfifo_genbits_not_full),
-       .wdata          (sfifo_genbits_wdata),
-       .rvalid         (sfifo_genbits_not_empty),
-       .rready         (sfifo_genbits_pop),
-       .rdata          (sfifo_genbits_rdata),
-       .depth          () // sfifo_genbits_depth)
+       .wvalid_i       (sfifo_genbits_push),
+       .wready_o       (sfifo_genbits_not_full),
+       .wdata_i        (sfifo_genbits_wdata),
+       .rvalid_o       (sfifo_genbits_not_empty),
+       .rready_i       (sfifo_genbits_pop),
+       .rdata_o        (sfifo_genbits_rdata),
+       .depth_o        () // sfifo_genbits_depth)
        );
 
   assign sfifo_genbits_wdata = genbits_bus_i;

--- a/hw/ip/csrng/rtl/csrng_core.sv
+++ b/hw/ip/csrng/rtl/csrng_core.sv
@@ -554,13 +554,13 @@ module csrng_core import csrng_pkg::*; #(
        .clk_i          (clk_i),
        .rst_ni         (rst_ni),
        .clr_i          (!cs_enable),
-       .wvalid         (sfifo_entr_push),
-       .wready         (sfifo_entr_not_full),
-       .wdata          (sfifo_entr_wdata),
-       .rvalid         (sfifo_entr_not_empty),
-       .rready         (sfifo_entr_pop),
-       .rdata          (sfifo_entr_rdata),
-       .depth          (sfifo_entr_depth)
+       .wvalid_i       (sfifo_entr_push),
+       .wready_o       (sfifo_entr_not_full),
+       .wdata_i        (sfifo_entr_wdata),
+       .rvalid_o       (sfifo_entr_not_empty),
+       .rready_i       (sfifo_entr_pop),
+       .rdata_o        (sfifo_entr_rdata),
+       .depth_o        (sfifo_entr_depth)
        );
 
   assign entropy_src_hw_if_o.entropy_src_rdy = cs_enable && sfifo_entr_not_full;
@@ -600,13 +600,13 @@ module csrng_core import csrng_pkg::*; #(
        .clk_i          (clk_i),
        .rst_ni         (rst_ni),
        .clr_i          (!cs_enable),
-       .wvalid         (sfifo_pentr_push),
-       .wready         (sfifo_pentr_not_full),
-       .wdata          (sfifo_pentr_wdata),
-       .rvalid         (sfifo_pentr_not_empty),
-       .rready         (sfifo_pentr_pop),
-       .rdata          (sfifo_pentr_rdata),
-       .depth          (sfifo_pentr_depth)
+       .wvalid_i       (sfifo_pentr_push),
+       .wready_o       (sfifo_pentr_not_full),
+       .wdata_i        (sfifo_pentr_wdata),
+       .rvalid_o       (sfifo_pentr_not_empty),
+       .rready_i       (sfifo_pentr_pop),
+       .rdata_o        (sfifo_pentr_rdata),
+       .depth_o        (sfifo_pentr_depth)
        );
 
   // allow one extra location because of packer
@@ -901,7 +901,7 @@ module csrng_core import csrng_pkg::*; #(
 
   assign     hw2reg.cs_sum_sts.fifo_depth_sts.de = cs_enable;
   assign     hw2reg.cs_sum_sts.fifo_depth_sts.d  =
-             (fifo_sel == 4'h0) ? {{(24-$clog2(EntrFifoDepth)){1'b0}},sfifo_entr_depth} : 
+             (fifo_sel == 4'h0) ? {{(24-$clog2(EntrFifoDepth)){1'b0}},sfifo_entr_depth} :
              24'b0;
 
 

--- a/hw/ip/csrng/rtl/csrng_ctr_drbg_cmd.sv
+++ b/hw/ip/csrng/rtl/csrng_ctr_drbg_cmd.sv
@@ -146,13 +146,13 @@ module csrng_ctr_drbg_cmd #(
        .clk_i          (clk_i),
        .rst_ni         (rst_ni),
        .clr_i          (!ctr_drbg_cmd_enable_i),
-       .wvalid         (sfifo_cmdreq_push),
-       .wready         (sfifo_cmdreq_not_full),
-       .wdata          (sfifo_cmdreq_wdata),
-       .rvalid         (sfifo_cmdreq_not_empty),
-       .rready         (sfifo_cmdreq_pop),
-       .rdata          (sfifo_cmdreq_rdata),
-       .depth          ()
+       .wvalid_i       (sfifo_cmdreq_push),
+       .wready_o       (sfifo_cmdreq_not_full),
+       .wdata_i        (sfifo_cmdreq_wdata),
+       .rvalid_o       (sfifo_cmdreq_not_empty),
+       .rready_i       (sfifo_cmdreq_pop),
+       .rdata_o        (sfifo_cmdreq_rdata),
+       .depth_o        ()
        );
 
   assign sfifo_cmdreq_wdata = {ctr_drbg_cmd_key_i,ctr_drbg_cmd_v_i,ctr_drbg_cmd_rc_i,
@@ -231,13 +231,13 @@ module csrng_ctr_drbg_cmd #(
        .clk_i          (clk_i),
        .rst_ni         (rst_ni),
        .clr_i          (!ctr_drbg_cmd_enable_i),
-       .wvalid         (sfifo_rcstage_push),
-       .wready         (sfifo_rcstage_not_full),
-       .wdata          (sfifo_rcstage_wdata),
-       .rvalid         (sfifo_rcstage_not_empty),
-       .rready         (sfifo_rcstage_pop),
-       .rdata          (sfifo_rcstage_rdata),
-       .depth          ()
+       .wvalid_i       (sfifo_rcstage_push),
+       .wready_o       (sfifo_rcstage_not_full),
+       .wdata_i        (sfifo_rcstage_wdata),
+       .rvalid_o       (sfifo_rcstage_not_empty),
+       .rready_i       (sfifo_rcstage_pop),
+       .rdata_o        (sfifo_rcstage_rdata),
+       .depth_o        ()
        );
 
   assign sfifo_rcstage_push = sfifo_cmdreq_pop;
@@ -262,13 +262,13 @@ module csrng_ctr_drbg_cmd #(
        .clk_i          (clk_i),
        .rst_ni         (rst_ni),
        .clr_i          (!ctr_drbg_cmd_enable_i),
-       .wvalid         (sfifo_keyvrc_push),
-       .wready         (sfifo_keyvrc_not_full),
-       .wdata          (sfifo_keyvrc_wdata),
-       .rvalid         (sfifo_keyvrc_not_empty),
-       .rready         (sfifo_keyvrc_pop),
-       .rdata          (sfifo_keyvrc_rdata),
-       .depth          ()
+       .wvalid_i       (sfifo_keyvrc_push),
+       .wready_o       (sfifo_keyvrc_not_full),
+       .wdata_i        (sfifo_keyvrc_wdata),
+       .rvalid_o       (sfifo_keyvrc_not_empty),
+       .rready_i       (sfifo_keyvrc_pop),
+       .rdata_o        (sfifo_keyvrc_rdata),
+       .depth_o        ()
        );
 
   assign sfifo_keyvrc_push = sfifo_rcstage_pop;

--- a/hw/ip/csrng/rtl/csrng_ctr_drbg_gen.sv
+++ b/hw/ip/csrng/rtl/csrng_ctr_drbg_gen.sv
@@ -159,13 +159,13 @@ module csrng_ctr_drbg_gen #(
        .clk_i          (clk_i),
        .rst_ni         (rst_ni),
        .clr_i          (!ctr_drbg_gen_enable_i),
-       .wvalid         (sfifo_cmdreq_push),
-       .wready         (sfifo_cmdreq_not_full),
-       .wdata          (sfifo_cmdreq_wdata),
-       .rvalid         (sfifo_cmdreq_not_empty),
-       .rready         (sfifo_cmdreq_pop),
-       .rdata          (sfifo_cmdreq_rdata),
-       .depth          ()
+       .wvalid_i       (sfifo_cmdreq_push),
+       .wready_o       (sfifo_cmdreq_not_full),
+       .wdata_i        (sfifo_cmdreq_wdata),
+       .rvalid_o       (sfifo_cmdreq_not_empty),
+       .rready_i       (sfifo_cmdreq_pop),
+       .rdata_o        (sfifo_cmdreq_rdata),
+       .depth_o        ()
        );
 
   assign sfifo_cmdreq_wdata = {ctr_drbg_gen_key_i,ctr_drbg_gen_v_i,ctr_drbg_gen_rc_i,
@@ -241,13 +241,13 @@ module csrng_ctr_drbg_gen #(
        .clk_i          (clk_i),
        .rst_ni         (rst_ni),
        .clr_i          (!ctr_drbg_gen_enable_i),
-       .wvalid         (sfifo_rcstage_push),
-       .wready         (sfifo_rcstage_not_full),
-       .wdata          (sfifo_rcstage_wdata),
-       .rvalid         (sfifo_rcstage_not_empty),
-       .rready         (sfifo_rcstage_pop),
-       .rdata          (sfifo_rcstage_rdata),
-       .depth          ()
+       .wvalid_i       (sfifo_rcstage_push),
+       .wready_o       (sfifo_rcstage_not_full),
+       .wdata_i        (sfifo_rcstage_wdata),
+       .rvalid_o       (sfifo_rcstage_not_empty),
+       .rready_i       (sfifo_rcstage_pop),
+       .rdata_o        (sfifo_rcstage_rdata),
+       .depth_o        ()
        );
 
   assign sfifo_rcstage_push = sfifo_cmdreq_pop;
@@ -272,13 +272,13 @@ module csrng_ctr_drbg_gen #(
        .clk_i          (clk_i),
        .rst_ni         (rst_ni),
        .clr_i          (!ctr_drbg_gen_enable_i),
-       .wvalid         (sfifo_keyvrc_push),
-       .wready         (sfifo_keyvrc_not_full),
-       .wdata          (sfifo_keyvrc_wdata),
-       .rvalid         (sfifo_keyvrc_not_empty),
-       .rready         (sfifo_keyvrc_pop),
-       .rdata          (sfifo_keyvrc_rdata),
-       .depth          ()
+       .wvalid_i       (sfifo_keyvrc_push),
+       .wready_o       (sfifo_keyvrc_not_full),
+       .wdata_i        (sfifo_keyvrc_wdata),
+       .rvalid_o       (sfifo_keyvrc_not_empty),
+       .rready_i       (sfifo_keyvrc_pop),
+       .rdata_o        (sfifo_keyvrc_rdata),
+       .depth_o        ()
        );
 
   assign sfifo_keyvrc_push = sfifo_rcstage_pop;

--- a/hw/ip/csrng/rtl/csrng_ctr_drbg_upd.sv
+++ b/hw/ip/csrng/rtl/csrng_ctr_drbg_upd.sv
@@ -213,13 +213,13 @@ module csrng_ctr_drbg_upd #(
     .clk_i    (clk_i),
     .rst_ni   (rst_ni),
     .clr_i    (!ctr_drbg_upd_enable_i),
-    .wvalid   (sfifo_updreq_push),
-    .wready   (sfifo_updreq_not_full),
-    .wdata    (sfifo_updreq_wdata),
-    .rvalid   (sfifo_updreq_not_empty),
-    .rready   (sfifo_updreq_pop),
-    .rdata    (sfifo_updreq_rdata),
-    .depth    ()
+    .wvalid_i (sfifo_updreq_push),
+    .wready_o (sfifo_updreq_not_full),
+    .wdata_i  (sfifo_updreq_wdata),
+    .rvalid_o (sfifo_updreq_not_empty),
+    .rready_i (sfifo_updreq_pop),
+    .rdata_o  (sfifo_updreq_rdata),
+    .depth_o  ()
   );
 
   assign sfifo_updreq_push = sfifo_updreq_not_full && ctr_drbg_upd_req_i;
@@ -306,13 +306,13 @@ module csrng_ctr_drbg_upd #(
     .clk_i    (clk_i),
     .rst_ni   (rst_ni),
     .clr_i    (!ctr_drbg_upd_enable_i),
-    .wvalid   (sfifo_bencreq_push),
-    .wready   (sfifo_bencreq_not_full),
-    .wdata    (sfifo_bencreq_wdata),
-    .rvalid   (sfifo_bencreq_not_empty),
-    .rready   (sfifo_bencreq_pop),
-    .rdata    (sfifo_bencreq_rdata),
-    .depth    ()
+    .wvalid_i (sfifo_bencreq_push),
+    .wready_o (sfifo_bencreq_not_full),
+    .wdata_i  (sfifo_bencreq_wdata),
+    .rvalid_o (sfifo_bencreq_not_empty),
+    .rready_i (sfifo_bencreq_pop),
+    .rdata_o  (sfifo_bencreq_rdata),
+    .depth_o  ()
   );
 
   assign sfifo_bencreq_pop = block_encrypt_req_o && block_encrypt_rdy_i;
@@ -342,20 +342,20 @@ module csrng_ctr_drbg_upd #(
     .clk_i    (clk_i),
     .rst_ni   (rst_ni),
     .clr_i    (!ctr_drbg_upd_enable_i),
-    .wvalid   (sfifo_bencack_push),
-    .wready   (sfifo_bencack_not_full),
-    .wdata    (sfifo_bencack_wdata),
-    .rvalid   (sfifo_bencack_not_empty),
-    .rready   (sfifo_bencack_pop),
-    .rdata    (sfifo_bencack_rdata),
-    .depth    ()
+    .wvalid_i (sfifo_bencack_push),
+    .wready_o (sfifo_bencack_not_full),
+    .wdata_i  (sfifo_bencack_wdata),
+    .rvalid_o (sfifo_bencack_not_empty),
+    .rready_i (sfifo_bencack_pop),
+    .rdata_o  (sfifo_bencack_rdata),
+    .depth_o  ()
   );
 
   assign sfifo_bencack_push = sfifo_bencack_not_full && block_encrypt_ack_i;
   assign sfifo_bencack_wdata = {block_encrypt_v_i,block_encrypt_inst_id_i,block_encrypt_ccmd_i};
   assign block_encrypt_rdy_o = sfifo_bencack_not_full;
 
-  assign {sfifo_bencack_v,sfifo_bencack_inst_id,sfifo_bencack_ccmd} = sfifo_bencack_rdata; 
+  assign {sfifo_bencack_v,sfifo_bencack_inst_id,sfifo_bencack_ccmd} = sfifo_bencack_rdata;
 
   assign sfifo_bencack_err =
          (sfifo_bencack_push && !sfifo_bencack_not_full) ||
@@ -370,13 +370,13 @@ module csrng_ctr_drbg_upd #(
     .clk_i    (clk_i),
     .rst_ni   (rst_ni),
     .clr_i    (!ctr_drbg_upd_enable_i),
-    .wvalid   (sfifo_pdata_push),
-    .wready   (sfifo_pdata_not_full),
-    .wdata    (sfifo_pdata_wdata),
-    .rvalid   (sfifo_pdata_not_empty),
-    .rready   (sfifo_pdata_pop),
-    .rdata    (sfifo_pdata_rdata),
-    .depth    ()
+    .wvalid_i (sfifo_pdata_push),
+    .wready_o (sfifo_pdata_not_full),
+    .wdata_i  (sfifo_pdata_wdata),
+    .rvalid_o (sfifo_pdata_not_empty),
+    .rready_i (sfifo_pdata_pop),
+    .rdata_o  (sfifo_pdata_rdata),
+    .depth_o  ()
   );
 
   assign sfifo_pdata_wdata = sfifo_updreq_pdata;
@@ -459,18 +459,18 @@ module csrng_ctr_drbg_upd #(
     .clk_i    (clk_i),
     .rst_ni   (rst_ni),
     .clr_i    (!ctr_drbg_upd_enable_i),
-    .wvalid   (sfifo_final_push),
-    .wready   (sfifo_final_not_full),
-    .wdata    (sfifo_final_wdata),
-    .rvalid   (sfifo_final_not_empty),
-    .rready   (sfifo_final_pop),
-    .rdata    (sfifo_final_rdata),
-    .depth    ()
+    .wvalid_i (sfifo_final_push),
+    .wready_o (sfifo_final_not_full),
+    .wdata_i  (sfifo_final_wdata),
+    .rvalid_o (sfifo_final_not_empty),
+    .rready_i (sfifo_final_pop),
+    .rdata_o  (sfifo_final_rdata),
+    .depth_o  ()
   );
 
   assign sfifo_final_wdata = {updated_key_and_v,concat_inst_id_q,concat_ccmd_q};
 
-  assign {sfifo_final_key,sfifo_final_v,sfifo_final_inst_id,sfifo_final_ccmd} = sfifo_final_rdata; 
+  assign {sfifo_final_key,sfifo_final_v,sfifo_final_inst_id,sfifo_final_ccmd} = sfifo_final_rdata;
 
   assign sfifo_final_pop = ctr_drbg_upd_rdy_i && sfifo_final_not_empty;
   assign ctr_drbg_upd_ack_o = sfifo_final_pop;

--- a/hw/ip/csrng/rtl/csrng_state_db.sv
+++ b/hw/ip/csrng/rtl/csrng_state_db.sv
@@ -123,13 +123,13 @@ module csrng_state_db #(
        .clk_i          (clk_i),
        .rst_ni         (rst_ni),
        .clr_i          (!state_db_enable_i),
-       .wvalid         (sfifo_wrreq_push),
-       .wready         (sfifo_wrreq_not_full),
-       .wdata          (sfifo_wrreq_wdata),
-       .rvalid         (sfifo_wrreq_not_empty),
-       .rready         (sfifo_wrreq_pop),
-       .rdata          (sfifo_wrreq_rdata),
-       .depth          ()
+       .wvalid_i       (sfifo_wrreq_push),
+       .wready_o       (sfifo_wrreq_not_full),
+       .wdata_i        (sfifo_wrreq_wdata),
+       .rvalid_o       (sfifo_wrreq_not_empty),
+       .rready_i       (sfifo_wrreq_pop),
+       .rdata_o        (sfifo_wrreq_rdata),
+       .depth_o        ()
        );
 
   assign sfifo_wrreq_wdata = {state_db_wr_key_i,state_db_wr_v_i,state_db_wr_res_ctr_i,


### PR DESCRIPTION
Since we have updated the FIFO interfaces to conform with the `*_i/*_o` naming convention, we have to align all FIFO instances within CSRNG as well.

@mwbranstad: FYI. let me know if this creates conflicts on your end and I can help to resolve them.

Signed-off-by: Michael Schaffner <msf@google.com>