### PR TITLE
[util] Exclude Licence Checker from Licence Checking

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -61,6 +61,7 @@ formal/             @cindychip
 # License related files
 LICENSE*            @asb
 COPYING*            @asb
+/util/licence-checker.hjson  @asb @lenary
 
 # CI and testing
 /ci/                @mcy @imphil

--- a/util/licence-checker.hjson
+++ b/util/licence-checker.hjson
@@ -9,8 +9,9 @@
     SPDX-License-Identifier: Apache-2.0
     ''',
   exclude_paths: [
-    # Exclude anything in vendor directories
+    # Exclude anything in vendored directories
     '*/vendor/*/*',
+    'util/lowrisc_misc-linters/*',
 
     ## Hardware Exclusions
 


### PR DESCRIPTION
This commit also updates the code owners file so that Alex and Sam are
tagged in PRs that change the licence checker configuration file.

---