### PR TITLE
[sw/crt] Fix CRT code clobbering the first word of .bss

### DIFF
--- a/ci/run_verilator_pytest.sh
+++ b/ci/run_verilator_pytest.sh
@@ -17,6 +17,7 @@ BOOT_ROM_TARGET="boot_rom/boot_rom_sim_verilator.elf"
 TEST_TARGETS=(
   "examples/hello_usbdev/hello_usbdev_sim_verilator.elf"
   "tests/aes_test_sim_verilator.elf"
+  "tests/crt_test_sim_verilator.elf"
   "tests/dif_plic_sanitytest_sim_verilator.elf"
   "tests/dif_uart_sanitytest_sim_verilator.elf"
   "tests/flash_ctrl_test_sim_verilator.elf"

--- a/sw/device/boot_rom/rom_crt.S
+++ b/sw/device/boot_rom/rom_crt.S
@@ -82,21 +82,21 @@ _start:
 bss_zero_loop:
   sw    zero, 0(t0)
   addi  t0, t0, 0x4
-  ble   t0, t1, bss_zero_loop
+  blt   t0, t1, bss_zero_loop
 bss_zero_loop_end:
 
   // Zero out the stack
   //
   // We use `t0` and `t1` to represent the start and end pointers of the stack.
   // As the stack grows downwards and we zero going forwards the start pointer
-  // starts as _stack_end and the end pointer at _stack_start - 4
+  // starts as _stack_end and the end pointer at _stack_start
   la  t0, _stack_end
-  la  t1, (_stack_start - 4)
+  la  t1, _stack_start
   bge t0, t1, stack_zero_loop_end
 stack_zero_loop:
   sw    zero, 0(t0)
   addi  t0, t0, 0x4
-  ble   t0, t1, stack_zero_loop
+  blt   t0, t1, stack_zero_loop
 stack_zero_loop_end:
 
   // Initialize the `.data` segment from the `.idata` segment.
@@ -114,7 +114,7 @@ data_copy_loop:
   sw   t3, 0(t0)
   addi t0, t0, 0x4
   addi t2, t2, 0x4
-  ble  t0, t1, data_copy_loop
+  blt  t0, t1, data_copy_loop
 data_copy_loop_end:
 
   // Re-clobber all of the registers from above.

--- a/sw/device/boot_rom/rom_link.ld
+++ b/sw/device/boot_rom/rom_link.ld
@@ -116,6 +116,7 @@ SECTIONS {
      */
     *(.data)
     *(.data.*)
+    . = ALIGN(4);
     _data_end = .;
   } > ram_main
 
@@ -138,6 +139,7 @@ SECTIONS {
     *(.bss)
     *(.bss.*)
     *(COMMON)
+    . = ALIGN(4);
     _bss_end = .;
   } > ram_main
 

--- a/sw/device/exts/common/flash_crt.S
+++ b/sw/device/exts/common/flash_crt.S
@@ -48,21 +48,21 @@ _start:
 bss_zero_loop:
   sw    zero, 0(t0)
   addi  t0, t0, 0x4
-  ble   t0, t1, bss_zero_loop
+  blt   t0, t1, bss_zero_loop
 bss_zero_loop_end:
 
   // Zero out the stack
   //
   // We use `t0` and `t1` to represent the start and end pointers of the stack.
   // As the stack grows downwards and we zero going forwards the start pointer
-  // starts as _stack_end and the end pointer at _stack_start - 4
+  // starts as _stack_end and the end pointer at _stack_start.
   la  t0, _stack_end
-  la  t1, (_stack_start - 4)
+  la  t1, _stack_start
   bge t0, t1, stack_zero_loop_end
 stack_zero_loop:
   sw    zero, 0(t0)
   addi  t0, t0, 0x4
-  ble   t0, t1, stack_zero_loop
+  blt   t0, t1, stack_zero_loop
 stack_zero_loop_end:
 
   // Initialize the `.data` segment from the `.idata` segment.
@@ -80,7 +80,7 @@ data_copy_loop:
   sw   t3, 0(t0)
   addi t0, t0, 0x4
   addi t2, t2, 0x4
-  ble  t0, t1, data_copy_loop
+  blt  t0, t1, data_copy_loop
 data_copy_loop_end:
 
   // Jump into the C program entry point. This is your standard

--- a/sw/device/exts/common/flash_link.ld
+++ b/sw/device/exts/common/flash_link.ld
@@ -112,6 +112,7 @@ SECTIONS {
      */
     *(.data)
     *(.data.*)
+    . = ALIGN(4);
     _data_end = .;
   } > ram_main
 
@@ -127,6 +128,7 @@ SECTIONS {
     *(.bss)
     *(.bss.*)
     *(COMMON)
+    . = ALIGN(4);
     _bss_end = .;
   } > ram_main
 

--- a/sw/device/tests/crt_test.c
+++ b/sw/device/tests/crt_test.c
@@ -1,0 +1,113 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/log.h"
+#include "sw/device/lib/base/print.h"
+#include "sw/device/lib/base/stdasm.h"
+#include "sw/device/lib/runtime/check.h"
+#include "sw/device/lib/testing/test_status.h"
+#include "sw/device/lib/uart.h"
+
+// Symbols defined in sw/device/exts/common/flash_link.ld, which we use to
+// check that the CRT did what it was supposed to.
+extern char _bss_start;
+extern char _bss_end;
+extern char _data_start;
+extern char _data_end;
+extern char _data_init_start;
+
+// The addresses of the values above.
+static const uintptr_t bss_start_addr = (uintptr_t)&_bss_start;
+static const uintptr_t bss_end_addr = (uintptr_t)&_bss_end;
+static const uintptr_t data_start_addr = (uintptr_t)&_data_start;
+static const uintptr_t data_end_addr = (uintptr_t)&_data_end;
+static const uintptr_t data_init_start_addr = (uintptr_t)&_data_init_start;
+
+// Ensure that both .bss and .data are non-empty. The compiler will always keep
+// these symbols, since they're volatile.
+volatile char ensure_data_exists = 42;
+volatile char ensure_bss_exists;
+
+int main(int argc, char **argv) {
+  // NOTE: we cannot call any external functions until all checks of post-CRT
+  // state are complete; this is to ensure that our checks are not tainted by
+  // external functions.
+  //
+  // Among other things, this means we can't CHECK, since we can't initialize
+  // UART. Thus, any critical failures are handled by returning from main.
+  // To minimize the chance of things going wrong, we don't even bother placing
+  // the checks in their own function.
+
+  // Test core assumptions above the five addresses above. The test code
+  // must be able to assume these all hold.
+  //
+  // Note that performing these comparisons on their addresses is UB, and will
+  // cause this entire function to get deleted by the compiler.
+  if (&_bss_start > &_bss_end || &_data_start > &_data_end) {
+    // Something has gone terribly wrong and we have no hope of continuing the
+    // test, so we're going to return and let the test time out.
+    //
+    // The best method for debugging a failure like this is to stare at an
+    // instruction trace.
+    return 1;
+  }
+
+  // Ensure that .bss was *actually* zeroed at the start of execution. If it
+  // wasn't, we note the offset from _bss_start at which it wasn't.
+  char *bss = &_bss_start;
+  ptrdiff_t bss_len = &_bss_end - &_bss_start;
+  int bad_bss_index = -1;
+  for (int i = 0; i < bss_len; ++i) {
+    if (bss[i] != 0) {
+      bad_bss_index = i;
+      break;
+    }
+  }
+
+  // Similarly, ensure that .data has the values in the init section.
+  char *data = &_data_start;
+  char *data_init = &_data_init_start;
+  ptrdiff_t data_len = &_data_end - &_data_start;
+  int bad_data_index = -1;
+  for (int i = 0; i < data_len; ++i) {
+    if (data[i] != data_init[i]) {
+      bad_data_index = i;
+      break;
+    }
+  }
+
+  // End of post-CRT checks; begin actual assertions..
+  test_status_set(kTestStatusInTest);
+  // Initialize the UART to enable logging for non-DV simulation platforms.
+  if (kDeviceType != kDeviceSimDV) {
+    uart_init(kUartBaudrate);
+    base_set_stdout(uart_stdout);
+  }
+
+  CHECK(bss_start_addr % sizeof(uint32_t) == 0,
+        "_bss_start not word-aligned: 0x%08x", bss_start_addr);
+  CHECK(bss_end_addr % sizeof(uint32_t) == 0,
+        "_bss_end not word-aligned: 0x%08x", bss_end_addr);
+  CHECK(data_start_addr % sizeof(uint32_t) == 0,
+        "_data_start not word-aligned: 0x%08x", data_start_addr);
+  CHECK(data_end_addr % sizeof(uint32_t) == 0,
+        "_data_end not word-aligned: 0x%08x", data_end_addr);
+  CHECK(data_init_start_addr % sizeof(uint32_t) == 0,
+        "_data_init_start not word-aligned: 0x%08x", data_init_start_addr);
+
+  CHECK(bad_bss_index == -1, "found non-zero .bss byte at *0x%08x == 0x%02x",
+        bss_start_addr + bad_bss_index, (uint32_t)bss[bad_bss_index]);
+  CHECK(bad_data_index == -1,
+        "found bad .data byte at *0x%08x == 0x%02x, expected 0x%02x",
+        data_start_addr + bad_data_index, (uint32_t)data_init[bad_data_index]);
+
+  test_status_set(kTestStatusPassed);
+
+  // Unreachable code.
+  return 1;
+}

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -102,3 +102,37 @@ foreach sw_test_name, sw_test_lib : sw_tests
     )
   endforeach
 endforeach
+
+foreach device_name, device_lib : sw_lib_arch_core_devices
+  crt_test_elf = executable(
+    'crt_test_' + device_name,
+    name_suffix: 'elf',
+    sources: ['crt_test.c'],
+    dependencies: [
+      riscv_crt,
+      device_lib,
+      sw_lib_irq_handlers,
+      sw_lib_testing_test_status,
+      # Explicitly do not pull in the test main; we need to run right after
+      # the CRT is done executing.
+      # sw_lib_testing_test_main,
+    ],
+  )
+
+  crt_test_embedded = custom_target(
+    'crt_test_' + device_name,
+    command: make_embedded_target,
+    input: crt_test_elf,
+    output: make_embedded_target_outputs,
+    build_by_default: true,
+  )
+
+  custom_target(
+    'crt_test_export_' + device_name,
+    command: export_embedded_target,
+    input: [crt_test_elf, crt_test_embedded],
+    output: 'crt_test_export_' + device_name,
+    build_always_stale: true,
+    build_by_default: true,
+  )
+endforeach


### PR DESCRIPTION
When this assembly was written, an incorrect assumption was made that
the _*_end pointers pointed to the final word in a section, when in
reality, they point one past. Due to how the linker laid out .data and
.bss, .data initialization would clobber the first word of .bss.