### PR TITLE
[top] Change pad variant array to packed logic

### DIFF
--- a/hw/ip/padctrl/rtl/padring.sv
+++ b/hw/ip/padctrl/rtl/padring.sv
@@ -18,8 +18,8 @@ module padring import padctrl_reg_pkg::*; #(
   parameter logic [NDioPads-1:0] ConnectDioOut = '1,
 
   // 0: bidir, 1: input, 2: tolerant, 3: open drain
-  parameter int MioPadVariant [NMioPads] = '{default: 0},
-  parameter int DioPadVariant [NDioPads] = '{default: 0}
+  parameter logic [1:0][NDioPads-1:0] MioPadVariant = '0,
+  parameter logic [1:0][NDioPads-1:0] DioPadVariant = '0
 ) (
   // pad input
   input wire                  clk_pad_i,

--- a/hw/syn/data/dc.hjson
+++ b/hw/syn/data/dc.hjson
@@ -5,7 +5,7 @@
   // The tool sources include the technology setup file,
   // the main synthesis run script and the constraints file
   tool_srcs: ["{proj_root}/hw/foundry/syn/{tool}/setup.tcl"
-  tool_srcs: ["{proj_root}/hw/foundry/syn/{tool}/lib-setup.tcl"
+              "{proj_root}/hw/foundry/syn/{tool}/lib-setup.tcl"
               "{proj_root}/hw/foundry/syn/{tool}/ram-macros-setup.tcl"
               "{proj_root}/hw/syn/tools/{tool}/run-syn.tcl"
               "{sdc_path}/{sdc_file}"]

--- a/hw/top_earlgrey/rtl/top_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_asic.sv
@@ -78,8 +78,8 @@ module top_earlgrey_asic (
     .ConnectDioIn  ( 15'h7F63 ),
     .ConnectDioOut ( 15'h7F63 ),
     // Pad types
-    .MioPadVariant ( '{default: 0} ),
-    .DioPadVariant ( '{default: 0} )
+    .MioPadVariant ( '0 ),
+    .DioPadVariant ( '0 )
   ) padring (
     // Clk / Rst
     .clk_pad_i           ( IO_CLK           ),


### PR DESCRIPTION
Change this array to a packed logic in order to 1) make DC happy in case this is assigned a `'0` default, and 2) keep the assignment order the same as for the ports when using vector concatenation `{..., ..., ...}`.

Signed-off-by: Michael Schaffner <msf@google.com>