### PR TITLE
Seagate partner logo

### DIFF
--- a/site/landing/config.toml
+++ b/site/landing/config.toml
@@ -21,6 +21,7 @@ partner_gd = "https://www.gi-de.com/"
 partner_google = "https://opensource.google/"
 partner_nuvoton = "https://www.nuvoton.com"
 partner_wd = "https://www.westerndigital.com/"
+partner_seagate = "https://www.seagate.com"
 
 [[deployment.targets]]
 name = "staging"

--- a/site/landing/layouts/index.html
+++ b/site/landing/layouts/index.html
@@ -234,7 +234,7 @@
     </section>
 
     <section id="partners" class="partners light-bg">
-      <h2 class="h2">Founding partners</h2>
+      <h2 class="h2">Partners</h2>
       <div class="partner-list">
         <a href="{{ .Site.Params.partner_lowrisc }}" class="partner" target="_blank">
           <img src="https://static.opentitan.org/img/partners/lowrisc.svg" alt="lowRISC">
@@ -253,6 +253,9 @@
         </a>
         <a href="{{ .Site.Params.partner_wd }}" class="partner" target="_blank">
           <img src="https://static.opentitan.org/img/partners/western-digital.svg" alt="Western Digital">
+        </a>
+        <a href="{{ .Site.Params.partner_seagate }}" class="partner" target="_blank">
+          <img src="https://static.opentitan.org/img/partners/seagate.svg" alt="Seagate">
         </a>
       </div>
 

--- a/site/landing/serve.sh
+++ b/site/landing/serve.sh
@@ -5,4 +5,4 @@
 
 set -e
 
-hugo --minify -D server
+hugo -D server


### PR DESCRIPTION
This change adds the Seagate logo to the list of partners on the landing site. The logo is served from the static bucket, which is why it does not appear here.

@moffen for visibility.