### PR TITLE
[dv/cip_lib] devmode fix

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
@@ -11,9 +11,10 @@ class cip_base_env_cfg #(type RAL_T = dv_base_reg_block) extends dv_base_env_cfg
   intr_vif              intr_vif;
   devmode_vif           devmode_vif;
 
-  // only security IP can support devmode. If supported, override it to 1 in initialize()
+  // en_devmode default sets to 1 because all IPs' devmode_i is tied off internally to 1
+  // TODO: enable random drive devmode once design supports
   bit                   has_devmode = 1;
-  bit                   en_devmode = 0;
+  bit                   en_devmode = 1;
 
   uint                  num_interrupts;
   string                list_of_alerts[] = {};

--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -148,8 +148,8 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
 
     if (!is_tl_access_mapped_addr(item)) begin
       is_tl_unmapped_addr = 1;
-      // if devmode is enabled, d_error won't be set
-      if (cfg.en_devmode == 0 || cfg.devmode_vif.sample()) begin
+      // if devmode is enabled, d_error will be set
+      if (cfg.en_devmode || cfg.devmode_vif.sample()) begin
         is_tl_err = 1;
       end
     end

--- a/hw/dv/sv/cip_lib/cip_base_vseq__tl_errors.svh
+++ b/hw/dv/sv/cip_lib/cip_base_vseq__tl_errors.svh
@@ -139,9 +139,11 @@ virtual task run_tl_errors_vseq(int num_times = 1, bit do_wait_clk = 0);
   set_tl_assert_en(.enable(0));
   for (int trans = 1; trans <= num_times; trans++) begin
     `uvm_info(`gfn, $sformatf("Running run_tl_errors_vseq %0d/%0d", trans, num_times), UVM_LOW)
-    if (cfg.en_devmode == 1) begin
-      cfg.devmode_vif.drive($urandom_range(0, 1));
-    end
+    // TODO: once devmode is not tied internally in design, randomly drive devmode_vif
+    // if (cfg.en_devmode == 1) begin
+    //  cfg.devmode_vif.drive($urandom_range(0, 1));
+    // end
+
     // use multiple thread to create outstanding access
     fork
       begin: isolation_fork


### PR DESCRIPTION
In the current DV code, if `devmode_en` is set and `addrmiss` happened,
cip_lib scoreboard expect design to NOT set tl `d_error` bit. However,
in current design, the condition will set `d_error` to 1.
The reason this issue has not caused any mismatch is because: in dv we
assume `devmode_en` = 0, but in RTL, devmode is internally tied to 1.

This PR:
1. Fix the logic that `devmode_en` will trigger `d_error` if `addrmiss`.
2. Temporarily set `devmode_en` to 1 with a TODO note.
3. Comment out the code that drives devmode in tl_error_vseq, and add a
TODO to fix it once `devmode_i` is not internally tied off in RTL.

Signed-off-by: Cindy Chen <chencindy@google.com>