### PR TITLE
Update lowrisc_misc-linters to lowRISC/misc-linters@e538500

### DIFF
--- a/util/lowrisc_misc-linters.lock.hjson
+++ b/util/lowrisc_misc-linters.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/lowRISC/misc-linters.git
-    rev: 637df45dcc7d3012b6715e95f7b5e6d6a828af72
+    rev: e538500ebb7cd1b2cd5a8f18260f1cbafd7187c3
   }
 }


### PR DESCRIPTION
Update code from upstream repository https://github.com/lowRISC/misc-
linters.git to revision e538500ebb7cd1b2cd5a8f18260f1cbafd7187c3

* Allow multiple comment syntaxes for a file type (Rupert Swarbrick)

Signed-off-by: Rupert Swarbrick <rswarbrick@lowrisc.org>