### PR TITLE
Update lowrisc_misc-linters to lowRISC/misc-linters@266d9c3

### DIFF
--- a/util/lowrisc_misc-linters.lock.hjson
+++ b/util/lowrisc_misc-linters.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/lowRISC/misc-linters.git
-    rev: e538500ebb7cd1b2cd5a8f18260f1cbafd7187c3
+    rev: 266d9c3e5bf9652525d3c6cea5c205d43e087433
   }
 }

--- a/util/lowrisc_misc-linters/licence-checker/licence-checker.py
+++ b/util/lowrisc_misc-linters/licence-checker/licence-checker.py
@@ -260,7 +260,8 @@ def check_file_for_licence(licence, results, filepath):
         return
 
     if not isinstance(styles, list):
-        assert isinstance(styles, LineCommentStyle)
+        assert (isinstance(styles, LineCommentStyle) or
+                isinstance(styles, BlockCommentStyle))
         styles = [styles]
 
     problems = []


### PR DESCRIPTION
Update code from upstream repository https://github.com/lowRISC/misc-
linters.git to revision 266d9c3e5bf9652525d3c6cea5c205d43e087433

* Weaken isinstance check in licence-checker.py (Rupert Swarbrick)

---

This was causing issues running the licence checker on the OT repo. Landing this should unblock CI.