### PR TITLE
Add DIF Checklists for i2c, rv_timer, and usbdev

### DIFF
--- a/doc/project/sw_checklist.md.tpl
+++ b/doc/project/sw_checklist.md.tpl
@@ -35,7 +35,7 @@ Type           | Item                        | Resolution  | Note/Collaterals
 ---------------|-----------------------------|-------------|------------------
 Implementation | [DIF_FEATURES][]            | Not Started |
 Coordination   | [DIF_HW_USAGE_REVIEWED][]   | Not Started |
-Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Not Started | [HW Dashboard]({{<relref "hw" >}})
+Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Not Started | [HW Dashboard]({{< relref "hw" >}})
 Implementation | [DIF_HW_PARAMS][]           | Not Started |
 Documentation  | [DIF_DOC_HW][]              | Not Started |
 Documentation  | [DIF_DOC_API][]             | Not Started |

--- a/hw/ip/hmac/data/hmac.prj.hjson
+++ b/hw/ip/hmac/data/hmac.prj.hjson
@@ -7,6 +7,7 @@
     design_spec:        "hw/ip/hmac/doc",
     dv_plan:            "hw/ip/hmac/doc/dv_plan",
     hw_checklist:       "hw/ip/hmac/doc/checklist",
+    sw_checklist:       "sw/device/lib/dif/dif_hmac",
     revisions: [
       {
         version:            "0.5",
@@ -21,6 +22,7 @@
         life_stage:         "L1",
         design_stage:       "D2",
         verification_stage: "V1",
+        dif_stage:          "S0",
         notes:              "Rolled back to D2 in order to add the first alert",
       }
     ]

--- a/hw/ip/i2c/data/i2c.prj.hjson
+++ b/hw/ip/i2c/data/i2c.prj.hjson
@@ -7,6 +7,7 @@
     design_spec:        "hw/ip/i2c/doc",
     dv_plan:            "hw/ip/i2c/doc/dv_plan",
     hw_checklist:       "hw/ip/i2c/doc/checklist",
+    sw_checklist:       "sw/device/lib/dif/dif_i2c",
     revisions: [
       {
         version:            "0.5",

--- a/hw/ip/rv_timer/data/rv_timer.prj.hjson
+++ b/hw/ip/rv_timer/data/rv_timer.prj.hjson
@@ -7,6 +7,7 @@
     design_spec:        "hw/ip/rv_timer/doc",
     dv_plan:            "hw/ip/rv_timer/doc/dv_plan",
     hw_checklist:       "hw/ip/rv_timer/doc/checklist",
+    sw_checklist:       "sw/device/lib/dif/dif_rv_timer",
     revisions: [
       {
         version:            "0.5",
@@ -21,6 +22,7 @@
         life_stage:         "L1",
         design_stage:       "D2",
         verification_stage: "V2",
+        dif_stage:          "S0",
         notes:              "Rolled back to D2 as the register module is updated",
       }
     ]

--- a/hw/ip/usbdev/data/usbdev.prj.hjson
+++ b/hw/ip/usbdev/data/usbdev.prj.hjson
@@ -6,8 +6,10 @@
     name:               "usbdev",
     design_spec:        "hw/ip/usbdev/doc",
     dv_plan:            "hw/ip/usbdev/doc/dv_plan",
+    sw_checklist:       "sw/device/lib/dif/dif_usbdev",
     version:            "0.5",
     life_stage:         "L1",
     design_stage:       "D0",
     verification_stage: "V0",
+    dif_stage:          "S0",
 }

--- a/sw/device/lib/dif/dif_gpio.md
+++ b/sw/device/lib/dif/dif_gpio.md
@@ -26,7 +26,7 @@ Type           | Item                        | Resolution  | Note/Collaterals
 ---------------|-----------------------------|-------------|------------------
 Implementation | [DIF_FEATURES][]            | Not Started |
 Coordination   | [DIF_HW_USAGE_REVIEWED][]   | Not Started |
-Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Not Started | [HW Dashboard]({{<relref "hw" >}})
+Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Not Started | [HW Dashboard]({{< relref "hw" >}})
 Implementation | [DIF_HW_PARAMS][]           | Not Started |
 Documentation  | [DIF_DOC_HW][]              | Not Started |
 Documentation  | [DIF_DOC_API][]             | Not Started |

--- a/sw/device/lib/dif/dif_hmac.md
+++ b/sw/device/lib/dif/dif_hmac.md
@@ -1,0 +1,71 @@
+---
+title: "HMAC DIF Checklist"
+---
+
+This checklist is for [Development Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [HMAC DIF]({{< relref "hw/ip/hmac/doc" >}}).
+All checklist items refer to the content in the [Checklist]({{< relref "/doc/project/checklist.md" >}}).
+
+## DIF Checklist
+
+### S1
+
+Type           | Item                 | Resolution  | Note/Collaterals
+---------------|----------------------|-------------|------------------
+Implementation | [DIF_EXISTS][]       | Not Started |
+Implementation | [DIF_USED_IN_TREE][] | Not Started |
+Tests          | [DIF_TEST_UNIT][]    | Not Started |
+Tests          | [DIF_TEST_SANITY][]  | Not Started |
+Review         | Reviewer(s)          | Not Started |
+Review         | Signoff date         | Not Started |
+
+[DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif-exists" >}}
+[DIF_USED_IN_TREE]: {{< relref "/doc/project/checklist.md#dif-used-in-tree" >}}
+[DIF_TEST_UNIT]:    {{< relref "/doc/project/checklist.md#dif-test-unit" >}}
+[DIF_TEST_SANITY]:  {{< relref "/doc/project/checklist.md#dif-test-sanity" >}}
+
+### S2
+
+Type           | Item                        | Resolution  | Note/Collaterals
+---------------|-----------------------------|-------------|------------------
+Implementation | [DIF_FEATURES][]            | Not Started |
+Coordination   | [DIF_HW_USAGE_REVIEWED][]   | Not Started |
+Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Not Started | [HW Dashboard]({{< relref "hw" >}})
+Implementation | [DIF_HW_PARAMS][]           | Not Started |
+Documentation  | [DIF_DOC_HW][]              | Not Started |
+Documentation  | [DIF_DOC_API][]             | Not Started |
+Code Quality   | [DIF_CODE_STYLE][]          | Not Started |
+Coordination   | [DIF_DV_TESTS][]            | Not Started |
+Implementation | [DIF_USED_TOCK][]           | Not Started |
+Review         | HW IP Usage Reviewer(s)     | Not Started |
+Review         | Reviewer(s)                 | Not Started |
+Review         | Signoff date                | Not Started |
+
+[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif-features" >}}
+[DIF_HW_USAGE_REVIEWED]:   {{< relref "/doc/project/checklist.md#dif-hw-usage-reviewed" >}}
+[DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif-hw-feature-complete" >}}
+[DIF_HW_PARAMS]:           {{< relref "/doc/project/checklist.md#dif-hw-params" >}}
+[DIF_DOC_HW]:              {{< relref "/doc/project/checklist.md#dif-doc-hw" >}}
+[DIF_DOC_API]:             {{< relref "/doc/project/checklist.md#dif-doc-api" >}}
+[DIF_CODE_STYLE]:          {{< relref "/doc/project/checklist.md#dif-code-style" >}}
+[DIF_DV_TESTS]:            {{< relref "/doc/project/checklist.md#dif-dv-tests" >}}
+[DIF_USED_TOCK]:           {{< relref "/doc/project/checklist.md#dif-used-tock" >}}
+
+### S3
+
+Type           | Item                             | Resolution  | Note/Collaterals
+---------------|----------------------------------|-------------|------------------
+Coordination   | [DIF_HW_DESIGN_COMPLETE][]       | Not Started |
+Coordination   | [DIF_HW_VERIFICATION_COMPLETE][] | Not Started |
+Review         | [DIF_REVIEW_C_STABLE][]          | Not Started |
+Tests          | [DIF_TEST_UNIT_COMPLETE][]       | Not Started |
+Review         | [DIF_TODO_COMPLETE][]            | Not Started |
+Review         | [DIF_REVIEW_TOCK_STABLE][]       | Not Started |
+Review         | Reviewer(s)                      | Not Started |
+Review         | Signoff date                     | Not Started |
+
+[DIF_HW_DESIGN_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif-hw-design-complete" >}}
+[DIF_HW_VERIFICATION_COMPLETE]: {{< relref "/doc/project/checklist.md#dif-hw-verification-complete" >}}
+[DIF_REVIEW_C_STABLE]:          {{< relref "/doc/project/checklist.md#dif-review-c-stable" >}}
+[DIF_TEST_UNIT_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif-test-unit-complete" >}}
+[DIF_TODO_COMPLETE]:            {{< relref "/doc/project/checklist.md#dif-todo-complete" >}}
+[DIF_REVIEW_TOCK_STABLE]:       {{< relref "/doc/project/checklist.md#dif-review-tock-stable" >}}

--- a/sw/device/lib/dif/dif_i2c.md
+++ b/sw/device/lib/dif/dif_i2c.md
@@ -1,0 +1,71 @@
+---
+title: "I2C DIF Checklist"
+---
+
+This checklist is for [Development Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [I2C DIF]({{< relref "hw/ip/i2c/doc" >}}).
+All checklist items refer to the content in the [Checklist]({{< relref "/doc/project/checklist.md" >}}).
+
+## DIF Checklist
+
+### S1
+
+Type           | Item                 | Resolution  | Note/Collaterals
+---------------|----------------------|-------------|------------------
+Implementation | [DIF_EXISTS][]       | Not Started |
+Implementation | [DIF_USED_IN_TREE][] | Not Started |
+Tests          | [DIF_TEST_UNIT][]    | Not Started |
+Tests          | [DIF_TEST_SANITY][]  | Not Started |
+Review         | Reviewer(s)          | Not Started |
+Review         | Signoff date         | Not Started |
+
+[DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif-exists" >}}
+[DIF_USED_IN_TREE]: {{< relref "/doc/project/checklist.md#dif-used-in-tree" >}}
+[DIF_TEST_UNIT]:    {{< relref "/doc/project/checklist.md#dif-test-unit" >}}
+[DIF_TEST_SANITY]:  {{< relref "/doc/project/checklist.md#dif-test-sanity" >}}
+
+### S2
+
+Type           | Item                        | Resolution  | Note/Collaterals
+---------------|-----------------------------|-------------|------------------
+Implementation | [DIF_FEATURES][]            | Not Started |
+Coordination   | [DIF_HW_USAGE_REVIEWED][]   | Not Started |
+Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Not Started | [HW Dashboard]({{< relref "hw" >}})
+Implementation | [DIF_HW_PARAMS][]           | Not Started |
+Documentation  | [DIF_DOC_HW][]              | Not Started |
+Documentation  | [DIF_DOC_API][]             | Not Started |
+Code Quality   | [DIF_CODE_STYLE][]          | Not Started |
+Coordination   | [DIF_DV_TESTS][]            | Not Started |
+Implementation | [DIF_USED_TOCK][]           | Not Started |
+Review         | HW IP Usage Reviewer(s)     | Not Started |
+Review         | Reviewer(s)                 | Not Started |
+Review         | Signoff date                | Not Started |
+
+[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif-features" >}}
+[DIF_HW_USAGE_REVIEWED]:   {{< relref "/doc/project/checklist.md#dif-hw-usage-reviewed" >}}
+[DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif-hw-feature-complete" >}}
+[DIF_HW_PARAMS]:           {{< relref "/doc/project/checklist.md#dif-hw-params" >}}
+[DIF_DOC_HW]:              {{< relref "/doc/project/checklist.md#dif-doc-hw" >}}
+[DIF_DOC_API]:             {{< relref "/doc/project/checklist.md#dif-doc-api" >}}
+[DIF_CODE_STYLE]:          {{< relref "/doc/project/checklist.md#dif-code-style" >}}
+[DIF_DV_TESTS]:            {{< relref "/doc/project/checklist.md#dif-dv-tests" >}}
+[DIF_USED_TOCK]:           {{< relref "/doc/project/checklist.md#dif-used-tock" >}}
+
+### S3
+
+Type           | Item                             | Resolution  | Note/Collaterals
+---------------|----------------------------------|-------------|------------------
+Coordination   | [DIF_HW_DESIGN_COMPLETE][]       | Not Started |
+Coordination   | [DIF_HW_VERIFICATION_COMPLETE][] | Not Started |
+Review         | [DIF_REVIEW_C_STABLE][]          | Not Started |
+Tests          | [DIF_TEST_UNIT_COMPLETE][]       | Not Started |
+Review         | [DIF_TODO_COMPLETE][]            | Not Started |
+Review         | [DIF_REVIEW_TOCK_STABLE][]       | Not Started |
+Review         | Reviewer(s)                      | Not Started |
+Review         | Signoff date                     | Not Started |
+
+[DIF_HW_DESIGN_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif-hw-design-complete" >}}
+[DIF_HW_VERIFICATION_COMPLETE]: {{< relref "/doc/project/checklist.md#dif-hw-verification-complete" >}}
+[DIF_REVIEW_C_STABLE]:          {{< relref "/doc/project/checklist.md#dif-review-c-stable" >}}
+[DIF_TEST_UNIT_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif-test-unit-complete" >}}
+[DIF_TODO_COMPLETE]:            {{< relref "/doc/project/checklist.md#dif-todo-complete" >}}
+[DIF_REVIEW_TOCK_STABLE]:       {{< relref "/doc/project/checklist.md#dif-review-tock-stable" >}}

--- a/sw/device/lib/dif/dif_plic.md
+++ b/sw/device/lib/dif/dif_plic.md
@@ -26,7 +26,7 @@ Type           | Item                        | Resolution  | Note/Collaterals
 ---------------|-----------------------------|-------------|------------------
 Implementation | [DIF_FEATURES][]            | Not Started |
 Coordination   | [DIF_HW_USAGE_REVIEWED][]   | Not Started |
-Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Not Started | [HW Dashboard]({{<relref "hw" >}})
+Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Not Started | [HW Dashboard]({{< relref "hw" >}})
 Implementation | [DIF_HW_PARAMS][]           | Not Started |
 Documentation  | [DIF_DOC_HW][]              | Not Started |
 Documentation  | [DIF_DOC_API][]             | Not Started |

--- a/sw/device/lib/dif/dif_rv_timer.md
+++ b/sw/device/lib/dif/dif_rv_timer.md
@@ -1,0 +1,71 @@
+---
+title: "Timer DIF Checklist"
+---
+
+This checklist is for [Development Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [Timer DIF]({{< relref "hw/ip/rv_timer/doc" >}}).
+All checklist items refer to the content in the [Checklist]({{< relref "/doc/project/checklist.md" >}}).
+
+## DIF Checklist
+
+### S1
+
+Type           | Item                 | Resolution  | Note/Collaterals
+---------------|----------------------|-------------|------------------
+Implementation | [DIF_EXISTS][]       | Not Started |
+Implementation | [DIF_USED_IN_TREE][] | Not Started |
+Tests          | [DIF_TEST_UNIT][]    | Not Started |
+Tests          | [DIF_TEST_SANITY][]  | Not Started |
+Review         | Reviewer(s)          | Not Started |
+Review         | Signoff date         | Not Started |
+
+[DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif-exists" >}}
+[DIF_USED_IN_TREE]: {{< relref "/doc/project/checklist.md#dif-used-in-tree" >}}
+[DIF_TEST_UNIT]:    {{< relref "/doc/project/checklist.md#dif-test-unit" >}}
+[DIF_TEST_SANITY]:  {{< relref "/doc/project/checklist.md#dif-test-sanity" >}}
+
+### S2
+
+Type           | Item                        | Resolution  | Note/Collaterals
+---------------|-----------------------------|-------------|------------------
+Implementation | [DIF_FEATURES][]            | Not Started |
+Coordination   | [DIF_HW_USAGE_REVIEWED][]   | Not Started |
+Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Not Started | [HW Dashboard]({{< relref "hw" >}})
+Implementation | [DIF_HW_PARAMS][]           | Not Started |
+Documentation  | [DIF_DOC_HW][]              | Not Started |
+Documentation  | [DIF_DOC_API][]             | Not Started |
+Code Quality   | [DIF_CODE_STYLE][]          | Not Started |
+Coordination   | [DIF_DV_TESTS][]            | Not Started |
+Implementation | [DIF_USED_TOCK][]           | Not Started |
+Review         | HW IP Usage Reviewer(s)     | Not Started |
+Review         | Reviewer(s)                 | Not Started |
+Review         | Signoff date                | Not Started |
+
+[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif-features" >}}
+[DIF_HW_USAGE_REVIEWED]:   {{< relref "/doc/project/checklist.md#dif-hw-usage-reviewed" >}}
+[DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif-hw-feature-complete" >}}
+[DIF_HW_PARAMS]:           {{< relref "/doc/project/checklist.md#dif-hw-params" >}}
+[DIF_DOC_HW]:              {{< relref "/doc/project/checklist.md#dif-doc-hw" >}}
+[DIF_DOC_API]:             {{< relref "/doc/project/checklist.md#dif-doc-api" >}}
+[DIF_CODE_STYLE]:          {{< relref "/doc/project/checklist.md#dif-code-style" >}}
+[DIF_DV_TESTS]:            {{< relref "/doc/project/checklist.md#dif-dv-tests" >}}
+[DIF_USED_TOCK]:           {{< relref "/doc/project/checklist.md#dif-used-tock" >}}
+
+### S3
+
+Type           | Item                             | Resolution  | Note/Collaterals
+---------------|----------------------------------|-------------|------------------
+Coordination   | [DIF_HW_DESIGN_COMPLETE][]       | Not Started |
+Coordination   | [DIF_HW_VERIFICATION_COMPLETE][] | Not Started |
+Review         | [DIF_REVIEW_C_STABLE][]          | Not Started |
+Tests          | [DIF_TEST_UNIT_COMPLETE][]       | Not Started |
+Review         | [DIF_TODO_COMPLETE][]            | Not Started |
+Review         | [DIF_REVIEW_TOCK_STABLE][]       | Not Started |
+Review         | Reviewer(s)                      | Not Started |
+Review         | Signoff date                     | Not Started |
+
+[DIF_HW_DESIGN_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif-hw-design-complete" >}}
+[DIF_HW_VERIFICATION_COMPLETE]: {{< relref "/doc/project/checklist.md#dif-hw-verification-complete" >}}
+[DIF_REVIEW_C_STABLE]:          {{< relref "/doc/project/checklist.md#dif-review-c-stable" >}}
+[DIF_TEST_UNIT_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif-test-unit-complete" >}}
+[DIF_TODO_COMPLETE]:            {{< relref "/doc/project/checklist.md#dif-todo-complete" >}}
+[DIF_REVIEW_TOCK_STABLE]:       {{< relref "/doc/project/checklist.md#dif-review-tock-stable" >}}

--- a/sw/device/lib/dif/dif_spi_device.md
+++ b/sw/device/lib/dif/dif_spi_device.md
@@ -26,7 +26,7 @@ Type           | Item                        | Resolution  | Note/Collaterals
 ---------------|-----------------------------|-------------|------------------
 Implementation | [DIF_FEATURES][]            | Not Started |
 Coordination   | [DIF_HW_USAGE_REVIEWED][]   | Not Started |
-Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Not Started | [HW Dashboard]({{<relref "hw" >}})
+Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Not Started | [HW Dashboard]({{< relref "hw" >}})
 Implementation | [DIF_HW_PARAMS][]           | Not Started |
 Documentation  | [DIF_DOC_HW][]              | Not Started |
 Documentation  | [DIF_DOC_API][]             | Not Started |

--- a/sw/device/lib/dif/dif_uart.md
+++ b/sw/device/lib/dif/dif_uart.md
@@ -26,7 +26,7 @@ Type           | Item                        | Resolution  | Note/Collaterals
 ---------------|-----------------------------|-------------|------------------
 Implementation | [DIF_FEATURES][]            | Not Started |
 Coordination   | [DIF_HW_USAGE_REVIEWED][]   | Not Started |
-Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Not Started | [HW Dashboard]({{<relref "hw" >}})
+Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Not Started | [HW Dashboard]({{< relref "hw" >}})
 Implementation | [DIF_HW_PARAMS][]           | Not Started |
 Documentation  | [DIF_DOC_HW][]              | Not Started |
 Documentation  | [DIF_DOC_API][]             | Not Started |

--- a/sw/device/lib/dif/dif_usbdev.md
+++ b/sw/device/lib/dif/dif_usbdev.md
@@ -1,0 +1,71 @@
+---
+title: "USB Device DIF Checklist"
+---
+
+This checklist is for [Development Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [USB Device DIF]({{< relref "hw/ip/usbdev/doc" >}}).
+All checklist items refer to the content in the [Checklist]({{< relref "/doc/project/checklist.md" >}}).
+
+## DIF Checklist
+
+### S1
+
+Type           | Item                 | Resolution  | Note/Collaterals
+---------------|----------------------|-------------|------------------
+Implementation | [DIF_EXISTS][]       | Not Started |
+Implementation | [DIF_USED_IN_TREE][] | Not Started |
+Tests          | [DIF_TEST_UNIT][]    | Not Started |
+Tests          | [DIF_TEST_SANITY][]  | Not Started |
+Review         | Reviewer(s)          | Not Started |
+Review         | Signoff date         | Not Started |
+
+[DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif-exists" >}}
+[DIF_USED_IN_TREE]: {{< relref "/doc/project/checklist.md#dif-used-in-tree" >}}
+[DIF_TEST_UNIT]:    {{< relref "/doc/project/checklist.md#dif-test-unit" >}}
+[DIF_TEST_SANITY]:  {{< relref "/doc/project/checklist.md#dif-test-sanity" >}}
+
+### S2
+
+Type           | Item                        | Resolution  | Note/Collaterals
+---------------|-----------------------------|-------------|------------------
+Implementation | [DIF_FEATURES][]            | Not Started |
+Coordination   | [DIF_HW_USAGE_REVIEWED][]   | Not Started |
+Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Not Started | [HW Dashboard]({{< relref "hw" >}})
+Implementation | [DIF_HW_PARAMS][]           | Not Started |
+Documentation  | [DIF_DOC_HW][]              | Not Started |
+Documentation  | [DIF_DOC_API][]             | Not Started |
+Code Quality   | [DIF_CODE_STYLE][]          | Not Started |
+Coordination   | [DIF_DV_TESTS][]            | Not Started |
+Implementation | [DIF_USED_TOCK][]           | Not Started |
+Review         | HW IP Usage Reviewer(s)     | Not Started |
+Review         | Reviewer(s)                 | Not Started |
+Review         | Signoff date                | Not Started |
+
+[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif-features" >}}
+[DIF_HW_USAGE_REVIEWED]:   {{< relref "/doc/project/checklist.md#dif-hw-usage-reviewed" >}}
+[DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif-hw-feature-complete" >}}
+[DIF_HW_PARAMS]:           {{< relref "/doc/project/checklist.md#dif-hw-params" >}}
+[DIF_DOC_HW]:              {{< relref "/doc/project/checklist.md#dif-doc-hw" >}}
+[DIF_DOC_API]:             {{< relref "/doc/project/checklist.md#dif-doc-api" >}}
+[DIF_CODE_STYLE]:          {{< relref "/doc/project/checklist.md#dif-code-style" >}}
+[DIF_DV_TESTS]:            {{< relref "/doc/project/checklist.md#dif-dv-tests" >}}
+[DIF_USED_TOCK]:           {{< relref "/doc/project/checklist.md#dif-used-tock" >}}
+
+### S3
+
+Type           | Item                             | Resolution  | Note/Collaterals
+---------------|----------------------------------|-------------|------------------
+Coordination   | [DIF_HW_DESIGN_COMPLETE][]       | Not Started |
+Coordination   | [DIF_HW_VERIFICATION_COMPLETE][] | Not Started |
+Review         | [DIF_REVIEW_C_STABLE][]          | Not Started |
+Tests          | [DIF_TEST_UNIT_COMPLETE][]       | Not Started |
+Review         | [DIF_TODO_COMPLETE][]            | Not Started |
+Review         | [DIF_REVIEW_TOCK_STABLE][]       | Not Started |
+Review         | Reviewer(s)                      | Not Started |
+Review         | Signoff date                     | Not Started |
+
+[DIF_HW_DESIGN_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif-hw-design-complete" >}}
+[DIF_HW_VERIFICATION_COMPLETE]: {{< relref "/doc/project/checklist.md#dif-hw-verification-complete" >}}
+[DIF_REVIEW_C_STABLE]:          {{< relref "/doc/project/checklist.md#dif-review-c-stable" >}}
+[DIF_TEST_UNIT_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif-test-unit-complete" >}}
+[DIF_TODO_COMPLETE]:            {{< relref "/doc/project/checklist.md#dif-todo-complete" >}}
+[DIF_REVIEW_TOCK_STABLE]:       {{< relref "/doc/project/checklist.md#dif-review-tock-stable" >}}


### PR DESCRIPTION
As DIFs have now landed, these are all `S0`, and have the requisite checklist added.