### PR TITLE
[padring/rtl] packed array index fix

### DIFF
--- a/hw/ip/padctrl/rtl/padring.sv
+++ b/hw/ip/padctrl/rtl/padring.sv
@@ -18,8 +18,8 @@ module padring import padctrl_reg_pkg::*; #(
   parameter logic [NDioPads-1:0] ConnectDioOut = '1,
 
   // 0: bidir, 1: input, 2: tolerant, 3: open drain
-  parameter logic [1:0][NDioPads-1:0] MioPadVariant = '0,
-  parameter logic [1:0][NDioPads-1:0] DioPadVariant = '0
+  parameter logic [NMioPads-1:0][1:0] MioPadVariant = '0,
+  parameter logic [NDioPads-1:0][1:0] DioPadVariant = '0
 ) (
   // pad input
   input wire                  clk_pad_i,


### PR DESCRIPTION
1. Fix a small typo on Mio from Dio
2. Fix packed array index. In current line: we do
parameter logic [1:0][NMioPads-1:0] MioPadVariant
In line 109, when we actually index MioPadVariant[k], we are indexing
the first one `[1:0]` rather than `[NMioPads-1:0]. So I changed the
order of the parameter declaration

Signed-off-by: Cindy Chen <chencindy@google.com>