### PR TITLE
[aes] Add idle hint signal for clkmgr

### DIFF
--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -7,7 +7,6 @@
   name: "aes",
   clock_primary: "clk_i",
   bus_device: "tlul",
-  regwidth: "32",
   # Note: All parameters are local, they are not actually configurable.
   # Selecting values different from the default values below might cause undefined behavior.
   param_list: [
@@ -30,6 +29,16 @@
       local:   "true"
     }
   ],
+  inter_signal_list: [
+    { name:    "idle",
+      type:    "uni",
+      act:     "req",
+      package: "",
+      struct:  "logic",
+      width:   "1"
+    }
+  ],
+  regwidth: "32",
   registers: [
 ##############################################################################
 # initial key registers

--- a/hw/ip/aes/dv/tb/tb.sv
+++ b/hw/ip/aes/dv/tb/tb.sv
@@ -29,6 +29,8 @@ module tb;
     .clk_i                (clk        ),
     .rst_ni               (rst_n      ),
 
+    .idle_o               (           ),
+
     .tl_i                 (tl_if.h2d  ),
     .tl_o                 (tl_if.d2h  )
   );

--- a/hw/ip/aes/rtl/aes.sv
+++ b/hw/ip/aes/rtl/aes.sv
@@ -23,6 +23,9 @@ module aes #(
   //input  logic              entropy_ack_i,
   //input  logic [63:0]       entropy_i,
 
+  // Idle indicator for clock manager
+  output logic              idle_o,
+
   // Bus interface
   input  tlul_pkg::tl_h2d_t tl_i,
   output tlul_pkg::tl_d2h_t tl_o
@@ -83,8 +86,11 @@ module aes #(
     .entropy_i    ( 64'hFEDCBA9876543210 )
   );
 
+  assign idle_o = hw2reg.status.idle.d;
+
   // All outputs should have a known value after reset
   `ASSERT_KNOWN(TlODValidKnown, tl_o.d_valid)
   `ASSERT_KNOWN(TlOAReadyKnown, tl_o.a_ready)
+  `ASSERT_KNOWN(IdleKnown, idle_o)
 
 endmodule

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -727,6 +727,21 @@
       wakeup_list: []
       scan: "false"
       scan_reset: "false"
+      inter_signal_list:
+      [
+        {
+          name: idle
+          type: uni
+          act: req
+          package: ""
+          struct: logic
+          width: 1
+          inst_name: aes
+          default: ""
+          top_signame: aes_idle
+          index: -1
+        }
+      ]
     }
     {
       name: hmac
@@ -1408,6 +1423,9 @@
           act: rcv
           package: clkmgr_pkg
           inst_name: clkmgr
+          width: 1
+          default: ""
+          top_signame: clkmgr_status
           index: -1
         }
       ]
@@ -2002,6 +2020,8 @@
       rstmgr.cpu
       pwrmgr.pwr_cpu
       clkmgr.clocks
+      aes.idle
+      clkmgr.status
     ]
     external:
     [
@@ -3621,6 +3641,18 @@
         index: -1
       }
       {
+        name: idle
+        type: uni
+        act: req
+        package: ""
+        struct: logic
+        width: 1
+        inst_name: aes
+        default: ""
+        top_signame: aes_idle
+        index: -1
+      }
+      {
         struct: lc_strap
         type: req_rsp
         name: lc_pinmux_strap
@@ -3909,6 +3941,9 @@
         act: rcv
         package: clkmgr_pkg
         inst_name: clkmgr
+        width: 1
+        default: ""
+        top_signame: clkmgr_status
         index: -1
       }
       {
@@ -4078,6 +4113,22 @@
         package: clkmgr_pkg
         struct: clkmgr_out
         signame: clkmgr_clocks
+        width: 1
+        type: uni
+        default: ""
+      }
+      {
+        package: ""
+        struct: logic
+        signame: aes_idle
+        width: 1
+        type: uni
+        default: ""
+      }
+      {
+        package: clkmgr_pkg
+        struct: clk_hint_status
+        signame: clkmgr_status
         width: 1
         type: uni
         default: ""

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -331,7 +331,7 @@
     // top is to connect to top net/struct.
     // It defines the signal in the top and connect from the module,
     // use of the signal is up to top template
-    'top': ['rstmgr.resets', 'rstmgr.cpu', 'pwrmgr.pwr_cpu', 'clkmgr.clocks'],
+    'top': ['rstmgr.resets', 'rstmgr.cpu', 'pwrmgr.pwr_cpu', 'clkmgr.clocks', 'aes.idle', 'clkmgr.status'],
 
     // ext is to create port in the top.
     'external': ['clkmgr.clk_main', 'clkmgr.clk_io', 'clkmgr.clk_usb', 'clkmgr.clk_aon'],

--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -211,6 +211,13 @@ module top_${top["name"]} #(
   ${lib.im_defname(sig)} ${lib.bitarray(sig["width"],1)} ${sig["signame"]};
 % endfor
 
+## Inter-module signal collection
+  always_comb begin
+    // TODO: So far just aes is connected
+    clkmgr_status.idle    = clkmgr_pkg::CLK_HINT_STATUS_DEFAULT;
+    clkmgr_status.idle[0] = aes_idle;
+  end
+
   // Non-debug module reset == reset for everything except for the debug module
   logic ndmreset_req;
 

--- a/hw/top_earlgrey/ip/alert_handler/dv/alert_handler_env_pkg__params.sv
+++ b/hw/top_earlgrey/ip/alert_handler/dv/alert_handler_env_pkg__params.sv
@@ -6,5 +6,9 @@
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
 // util/topgen.py -t hw/top_earlgrey/doc/top_earlgrey.hjson --alert-handler-only -o hw/top_earlgrey/
 
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
 parameter uint NUM_ALERTS = 4;
 parameter bit [NUM_ALERTS-1:0] ASYNC_ON = 4'b0000;

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_pkg.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_pkg.sv
@@ -4,6 +4,10 @@
 //
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
 
 
 package clkmgr_pkg;

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -258,6 +258,14 @@ module top_earlgrey #(
   rstmgr_pkg::rstmgr_cpu_t       rstmgr_cpu;
   pwrmgr_pkg::pwr_cpu_t       pwrmgr_pwr_cpu;
   clkmgr_pkg::clkmgr_out_t       clkmgr_clocks;
+  logic       aes_idle;
+  clkmgr_pkg::clk_hint_status_t       clkmgr_status;
+
+  always_comb begin
+    // TODO: So far just aes is connected
+    clkmgr_status.idle    = clkmgr_pkg::CLK_HINT_STATUS_DEFAULT;
+    clkmgr_status.idle[0] = aes_idle;
+  end
 
   // Non-debug module reset == reset for everything except for the debug module
   logic ndmreset_req;
@@ -637,6 +645,9 @@ module top_earlgrey #(
   aes u_aes (
       .tl_i (tl_aes_d_h2d),
       .tl_o (tl_aes_d_d2h),
+
+      // Inter-module signals
+      .idle_o(aes_idle),
       .clk_i (clkmgr_clocks.clk_main_aes),
       .rst_ni (rstmgr_resets.rst_sys_n)
   );
@@ -798,7 +809,7 @@ module top_earlgrey #(
       .pwr_i(pwrmgr_pwr_clk_req),
       .pwr_o(pwrmgr_pwr_clk_rsp),
       .dft_i(clkmgr_pkg::CLK_DFT_DEFAULT),
-      .status_i(clkmgr_pkg::CLK_HINT_STATUS_DEFAULT),
+      .status_i(clkmgr_status),
       .clk_i (clkmgr_clocks.clk_io_powerup),
       .rst_ni (rstmgr_resets.rst_por_io_n),
       .rst_main_ni (rstmgr_resets.rst_por_n),


### PR DESCRIPTION
This PR connects the idle hint signal of aes to the clkmgr as requested in lowRISC/OpenTitan#2647.

@tjaychen and I were discussing to maybe template the interconnection of these idle hint signals. The reason for adding this now is that the same signal can serve as a high-precision capture trigger signal for the SCA measurements @moidx is currently setting up. Without this signal, the setup uses a GPIO to trigger the capture which is very imprecise and complicates the alignment of the captured traces.

Note that the top-level signal `aes_idle` introduced with this PR is not only low if an encryption/decryption is running, but also if the module is performing a clearing operation (when it comes out of reset) or when generating the decryption key. This may perturb SCA capture. I thus recommend to actually combine (AND) the previous GPIO trigger signal with `~aes_idle` to not get erroneous captures.