### PR TITLE
[syn] Minor updates to align flow with foundry setup scripts

### DIFF
--- a/hw/syn/tools/dc/run-syn.tcl
+++ b/hw/syn/tools/dc/run-syn.tcl
@@ -84,7 +84,7 @@ check_design                                              > "${REPDIR}/check.rpt
 set_verification_top
 
 write_file -format ddc -hierarchy -output "${DDCDIR}/elab.ddc"
-write_file -format verilog -hierarchy -output "${DDCDIR}/elab.v"
+#write_file -format verilog -hierarchy -output "${DDCDIR}/elab.v"
 
 #############################
 ##   CLOCK GATING SETUP    ##
@@ -138,9 +138,9 @@ report_timing      -nosplit -nworst 1000 -input -net -trans -cap > "${REPDIR}/ti
 ##   NETLIST   ##
 #################
 
-# change_names -rules verilog -hierarchy
-# define_name_rules fixbackslashes -allowed "A-Za-z0-9_" -first_restricted "\\" -remove_chars
-# change_names -rule fixbackslashes -h
+change_names -rules verilog -hierarchy
+define_name_rules fixbackslashes -allowed "A-Za-z0-9_" -first_restricted "\\" -remove_chars
+change_names -rule fixbackslashes -h
 write_file -format ddc     -hierarchy -output "${DDCDIR}/mapped.ddc"
 write_file -format verilog -hierarchy -output "${VLOGDIR}/mapped.v"
 

--- a/hw/top_earlgrey/syn/constraints.sdc
+++ b/hw/top_earlgrey/syn/constraints.sdc
@@ -186,8 +186,8 @@ set_false_path -from dio_in_i[$PORT_UART_RX] -to dio_out_o[$PORT_UART_TX]
 #####################
 
 # attach load and drivers to IOs to get a more realistic estimate
-set_driving_cell  -no_design_rule -lib_cell ${DRIVING_CELL} -pin X [all_inputs]
-set_load [load_of ${LOAD_LIB}/${LOAD_CELL}/A] [all_outputs]
+set_driving_cell  -no_design_rule -lib_cell ${DRIVING_CELL} -pin ${DRIVING_CELL_PIN} [all_inputs]
+set_load [load_of ${LOAD_CELL_LIB}/${LOAD_CELL}/${LOAD_CELL_PIN}] [all_outputs]
 
 # set a nonzero critical range to be able to spot the violating paths better
 # in the report


### PR DESCRIPTION
Some of the variables related to output load / driving strength constraints have changed in the foundry repo, and hence they need to be updated.

Signed-off-by: Michael Schaffner <msf@google.com>