### PR TITLE
[uvmdvgen] Support for setting vendor name in VLNV

### DIFF
--- a/util/uvmdvgen/Makefile.tpl
+++ b/util/uvmdvgen/Makefile.tpl
@@ -16,7 +16,7 @@ ${'#############################################################################
 DV_DIR          := ${'$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))'}
 export DUT_TOP  := ${name}
 export TB_TOP   := tb
-FUSESOC_CORE    := lowrisc:dv:${name}_sim:0.1
+FUSESOC_CORE    := ${vendor}:dv:${name}_sim:0.1
 COMPILE_KEY     ?= default
 
 # Add coverage exclusion file below

--- a/util/uvmdvgen/README.md
+++ b/util/uvmdvgen/README.md
@@ -22,12 +22,13 @@ Running the tool with `-h` switch provides a brief description of all available
 switches.
 ```console
 $ util/uvmdvgen/uvmdvgen.py -h
-usage: uvmdvgen.py [-h] [-a] [-s] [-e] [-c] [-hi] [-ha]
+usage: uvmdvgen.py [-h] [-a] [-s] [-e] [-c] [-hr] [-hi] [-ha]
                    [-ea agt1 agt2 [agt1 agt2 ...]] [-ao [hw/dv/sv]]
-                   [-eo [hw/ip/<ip>/dv]]
+                   [-eo [hw/ip/<ip>]] [-m] [-v VENDOR]
                    [ip/block name]
 
-Command-line tool to autogenerate boilerplate DV testbench code extended from dv_lib / cip_lib
+Command-line tool to autogenerate boilerplate DV testbench code extended from
+dv_lib / cip_lib
 
 positional arguments:
   [ip/block name]       Name of the ip/block for which the UVM TB is being
@@ -35,32 +36,48 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
-  -a, --gen_agent       Generate UVM agent code extended from DV library
-  -s, --has_separate_host_device_driver
+  -a, --gen-agent       Generate UVM agent code extended from DV library
+  -s, --has-separate-host-device-driver
                         IP / block agent creates a separate driver for host
                         and device modes. (ignored if -a switch is not passed)
-  -e, --gen_env         Generate testbench UVM env code
-  -c, --is_cip          Is comportable IP - this will result in code being
+  -e, --gen-env         Generate testbench UVM env code
+  -c, --is-cip          Is comportable IP - this will result in code being
                         extended from CIP library. If switch is not passed,
                         then the code will be extended from DV library
                         instead. (ignored if -e switch is not passed)
-  -hr, --has_ral        Specify whether the DUT has CSRs and thus needs a UVM
-                        RAL model
-  -hi, --has_interrupts
+  -hr, --has-ral        Specify whether the DUT has CSRs and thus needs a UVM
+                        RAL model. This option is required if either --is_cip
+                        or --has_interrupts are enabled.
+  -hi, --has-interrupts
                         CIP has interrupts. Create interrupts interface in tb
-  -ha, --has_alerts     CIP has alerts. Create alerts interface in tb
-  -ea agt1 agt2 [agt1 agt2 ...], --env_agents agt1 agt2 [agt1 agt2 ...]
+  -ha, --has-alerts     CIP has alerts. Create alerts interface in tb
+  -ea agt1 agt2 [agt1 agt2 ...], --env-agents agt1 agt2 [agt1 agt2 ...]
                         Env creates an interface agent specified here. They
                         are assumed to already exist. Note that the list is
                         space-separated, and not comma-separated. (ignored if
                         -e switch is not passed)
-  -ao [hw/dv/sv], --agent_outdir [hw/dv/sv]
+  -ao [hw/dv/sv], --agent-outdir [hw/dv/sv]
                         Path to place the agent code. A directory called
                         <name>_agent is created at this location. (default set
                         to './<name>')
-  -eo [hw/ip/<ip>/dv], --env_outdir [hw/ip/<ip>/dv]
-                        Path to place the env code. 3 directories are created
-                        - env, tb and tests. (default set to './<name>')
+  -eo [hw/ip/<ip>], --env-outdir [hw/ip/<ip>]
+                        Path to place the full tetsbench code. It creates 3
+                        directories - dv, data and doc. The DV plan and the
+                        testplan Hjson files are placed in the doc and data
+                        directories respectively. These are to be merged into
+                        the IP's root directory (with the existing data and
+                        doc directories). Under dv, it creates 3 sub-
+                        directories - env, tb and tests to place all of the
+                        testbench sources. (default set to './<name>')
+  -m, --add-makefile    Tests are now run with dvsim.py tool that requires a
+                        hjson based sim cfg. Setting this option will also
+                        result in the Makefile to be auto-generated (which is
+                        the older way of building and running sims going
+                        through deprecation).
+  -v VENDOR, --vendor VENDOR
+                        Name of the vendor / entity developing the testbench.
+                        This is used to set the VLNV of the FuesSoC core
+                        files.
 ```
 
 ### Generating UVM agent
@@ -288,6 +305,11 @@ provided by `-hi` and `-ha` respectively. By default, these are set to 'False'
 
   This is the initial DV plan document that will describe the entire testbench. This
   is equivalent to the template available [here](https://github.com/lowRISC/opentitan/blob/master/hw/dv/doc/dv_plan_template.md).
+
+The [VLNV](https://fusesoc.readthedocs.io/en/master/user/overview.html#core-naming-rules)
+name in the generated FuseSoC core files is set using the `--vendor` switch for
+the 'vendor' field. By default, it is set to "lowrisc". It can be overridden
+by supplying the `--vendor <vendor-name>` switch on the command line.
 
 #### Examples
 ```console

--- a/util/uvmdvgen/agent.core.tpl
+++ b/util/uvmdvgen/agent.core.tpl
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: "lowrisc:dv:${name}_agent:0.1"
+name: "${vendor}:dv:${name}_agent:0.1"
 description: "${name.upper()} DV UVM agent"
 filesets:
   files_dv:

--- a/util/uvmdvgen/env.core.tpl
+++ b/util/uvmdvgen/env.core.tpl
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: "lowrisc:dv:${name}_env:0.1"
+name: "${vendor}:dv:${name}_env:0.1"
 description: "${name.upper()} DV UVM environment"
 filesets:
   files_dv:
@@ -16,7 +16,7 @@ filesets:
       - lowrisc:dv:dv_lib
 % endif
 % for agent in env_agents:
-      - lowrisc:dv:${agent}_agent
+      - ${vendor}:dv:${agent}_agent
 % endfor
     files:
       - ${name}_env_pkg.sv

--- a/util/uvmdvgen/gen_agent.py
+++ b/util/uvmdvgen/gen_agent.py
@@ -11,7 +11,7 @@ from mako.template import Template
 from pkg_resources import resource_filename
 
 
-def gen_agent(name, has_separate_host_device_driver, root_dir):
+def gen_agent(name, has_separate_host_device_driver, root_dir, vendor):
     # set sub name
     agent_dir = root_dir + "/" + name + "_agent"
 
@@ -57,6 +57,7 @@ def gen_agent(name, has_separate_host_device_driver, root_dir):
                 fout.write(
                     tpl.render(name=name,
                                has_separate_host_device_driver=
-                               has_separate_host_device_driver))
+                               has_separate_host_device_driver,
+                               vendor=vendor))
             except:
                 log.error(exceptions.text_error_template().render())

--- a/util/uvmdvgen/gen_env.py
+++ b/util/uvmdvgen/gen_env.py
@@ -8,10 +8,11 @@ import os
 
 from mako.template import Template
 from pkg_resources import resource_filename
+from uvmdvgen import VENDOR_DEFAULT
 
 
 def gen_env(name, is_cip, has_ral, has_interrupts, has_alerts, env_agents,
-            root_dir, add_makefile):
+            root_dir, add_makefile, vendor):
     # yapf: disable
     # 4-tuple - sub-path, ip name, class name, file ext
     env_srcs = [('dv/env',          name + '_', 'env_cfg',            '.sv'),
@@ -38,6 +39,13 @@ def gen_env(name, is_cip, has_ral, has_interrupts, has_alerts, env_agents,
                 ('data',            name + '_', 'testplan',           '.hjson'),
                 ('dv',              name + '_', 'sim',                '.core')]
     # yapf: enable
+
+    if vendor != VENDOR_DEFAULT and env_agents != []:
+        env_core_path = root_dir + "/dv/env/" + name + "_env.core"
+        print(
+            "WARNING: Both, --vendor and --env-agents switches are supplied "
+            "on the command line. Please check the VLNV names of the "
+            "dependent agents in the generated {} file.".format(env_core_path))
 
     for tup in env_srcs:
         path_dir = root_dir + '/' + tup[0]
@@ -70,6 +78,7 @@ def gen_env(name, is_cip, has_ral, has_interrupts, has_alerts, env_agents,
                                has_ral=has_ral,
                                has_interrupts=has_interrupts,
                                has_alerts=has_alerts,
-                               env_agents=env_agents))
+                               env_agents=env_agents,
+                               vendor=vendor))
             except:
                 log.error(exceptions.text_error_template().render())

--- a/util/uvmdvgen/sim.core.tpl
+++ b/util/uvmdvgen/sim.core.tpl
@@ -2,19 +2,19 @@ CAPI=2:
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: "lowrisc:dv:${name}_sim:0.1"
+name: "${vendor}:dv:${name}_sim:0.1"
 description: "${name.upper()} DV sim target"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:ip:${name}:0.1
+      - ${vendor}:ip:${name}:0.1
     files:
       - tb/${name}_bind.sv
     file_type: systemVerilogSource
 
   files_dv:
     depend:
-      - lowrisc:dv:${name}_test
+      - ${vendor}:dv:${name}_test
     files:
       - tb/tb.sv
     file_type: systemVerilogSource

--- a/util/uvmdvgen/sim_cfg.hjson.tpl
+++ b/util/uvmdvgen/sim_cfg.hjson.tpl
@@ -15,7 +15,7 @@
   tool: vcs
 
   // Fusesoc core file used for building the file list.
-  fusesoc_core: lowrisc:dv:${name}_sim:0.1
+  fusesoc_core: ${vendor}:dv:${name}_sim:0.1
 
   // Testplan hjson file.
   testplan: "{proj_root}/hw/ip/${name}/data/${name}_testplan.hjson"

--- a/util/uvmdvgen/test.core.tpl
+++ b/util/uvmdvgen/test.core.tpl
@@ -2,12 +2,12 @@ CAPI=2:
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: "lowrisc:dv:${name}_test:0.1"
+name: "${vendor}:dv:${name}_test:0.1"
 description: "${name.upper()} DV UVM test"
 filesets:
   files_dv:
     depend:
-      - lowrisc:dv:${name}_env
+      - ${vendor}:dv:${name}_env
     files:
       - ${name}_test_pkg.sv
       - ${name}_base_test.sv: {is_include_file: true}

--- a/util/uvmdvgen/uvmdvgen.py
+++ b/util/uvmdvgen/uvmdvgen.py
@@ -11,6 +11,8 @@ import sys
 import gen_agent
 import gen_env
 
+VENDOR_DEFAULT = "lowrisc"
+
 
 def main():
     parser = argparse.ArgumentParser(
@@ -24,26 +26,26 @@ def main():
 
     parser.add_argument(
         "-a",
-        "--gen_agent",
+        "--gen-agent",
         action='store_true',
         help="Generate UVM agent code extended from DV library")
 
     parser.add_argument(
         "-s",
-        "--has_separate_host_device_driver",
+        "--has-separate-host-device-driver",
         action='store_true',
         help=
         """IP / block agent creates a separate driver for host and device modes.
                               (ignored if -a switch is not passed)""")
 
     parser.add_argument("-e",
-                        "--gen_env",
+                        "--gen-env",
                         action='store_true',
                         help="Generate testbench UVM env code")
 
     parser.add_argument(
         "-c",
-        "--is_cip",
+        "--is-cip",
         action='store_true',
         help=
         """Is comportable IP - this will result in code being extended from CIP
@@ -53,7 +55,7 @@ def main():
 
     parser.add_argument(
         "-hr",
-        "--has_ral",
+        "--has-ral",
         default=False,
         action='store_true',
         help="""Specify whether the DUT has CSRs and thus needs a UVM RAL model.
@@ -62,21 +64,21 @@ def main():
 
     parser.add_argument(
         "-hi",
-        "--has_interrupts",
+        "--has-interrupts",
         default=False,
         action='store_true',
         help="""CIP has interrupts. Create interrupts interface in tb""")
 
     parser.add_argument(
         "-ha",
-        "--has_alerts",
+        "--has-alerts",
         default=False,
         action='store_true',
         help="""CIP has alerts. Create alerts interface in tb""")
 
     parser.add_argument(
         "-ea",
-        "--env_agents",
+        "--env-agents",
         nargs="+",
         metavar="agt1 agt2",
         help="""Env creates an interface agent specified here. They are
@@ -86,7 +88,7 @@ def main():
 
     parser.add_argument(
         "-ao",
-        "--agent_outdir",
+        "--agent-outdir",
         metavar="[hw/dv/sv]",
         help="""Path to place the agent code. A directory called <name>_agent is
                               created at this location. (default set to './<name>')"""
@@ -94,7 +96,7 @@ def main():
 
     parser.add_argument(
         "-eo",
-        "--env_outdir",
+        "--env-outdir",
         metavar="[hw/ip/<ip>]",
         help=
         """Path to place the full tetsbench code. It creates 3 directories - dv, data and doc.
@@ -115,6 +117,14 @@ def main():
              the older way of building and running sims going through deprecation)."""
     )
 
+    parser.add_argument(
+        "-v",
+        "--vendor",
+        default=VENDOR_DEFAULT,
+        help=
+        """Name of the vendor / entity developing the testbench. This is used to set the VLNV
+        of the FuesSoC core files.""")
+
     args = parser.parse_args()
     if not args.agent_outdir: args.agent_outdir = args.name
     if not args.env_outdir: args.env_outdir = args.name
@@ -128,20 +138,14 @@ def main():
               "--is_cip or --has_interrupts is set.")
 
     if args.gen_agent:
-        gen_agent.gen_agent(args.name, \
-                            args.has_separate_host_device_driver, \
-                            args.agent_outdir)
+        gen_agent.gen_agent(args.name, args.has_separate_host_device_driver,
+                            args.agent_outdir, args.vendor)
 
     if args.gen_env:
         if not args.env_agents: args.env_agents = []
-        gen_env.gen_env(args.name, \
-                        args.is_cip, \
-                        args.has_ral, \
-                        args.has_interrupts, \
-                        args.has_alerts, \
-                        args.env_agents, \
-                        args.env_outdir, \
-                        args.add_makefile)
+        gen_env.gen_env(args.name, args.is_cip, args.has_ral,
+                        args.has_interrupts, args.has_alerts, args.env_agents,
+                        args.env_outdir, args.add_makefile, args.vendor)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This adds a `--vendor` switch that can be used to set the vendor name in
the generated FuseSoC core files' VLNV field.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>