### PR TITLE
[dv, dvsim] Support multiple fusesoc cores-root

### DIFF
--- a/hw/dv/data/fusesoc.hjson
+++ b/hw/dv/data/fusesoc.hjson
@@ -4,11 +4,12 @@
 {
   sv_flist_gen_cmd:   fusesoc
   fusesoc_core_:      "{eval_cmd} echo \"{fusesoc_core}\" | tr ':' '_'"
-  sv_flist_gen_opts:  ["--cores-root {proj_root}",
+  sv_flist_gen_opts:  ["{fusesoc_cores_root_dirs}",
                        "run",
                        "--target=sim",
                        "--build-root={build_dir}",
                        "--setup {fusesoc_core}"]
+  fusesoc_cores_root_dirs: ["--cores-root {proj_root}"]
   sv_flist_gen_dir:   "{build_dir}/sim-vcs"
   sv_flist:           "{sv_flist_gen_dir}/{fusesoc_core_}.scr"
 }

--- a/hw/top_earlgrey/dv/vendor_chip_sim_cfg_sample.hjson
+++ b/hw/top_earlgrey/dv/vendor_chip_sim_cfg_sample.hjson
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is not meant to be used with `dvsim` directly for running tests at
+// the chip level. Instead it has been provided as an example to show how an
+// existing infrastructure with `dvsim` can be reused with very minimal changes
+// to run simulations on a modufied design.
+{
+  // Import the chip_sim_cfg.hjson to run the chip level simulations.
+  import_cfgs: ["{proj_root}/hw/top_earlgrey/dv/chip_sim_cfg.hjson"]
+
+  // Override the required keys to customize the simulation flow. For instance,
+  // the FuseSoC core file or the search paths provided to FuseSoC to find the
+  // dependencies can be overridden to customize the design / testbench, while
+  // reusing the rest of the infrastructure.
+  overrides: [
+    // Example 1: override the fusesoc_core to change the top level FuseSoC
+    // target.
+    {
+      name: fusesoc_core
+      value: my:dv:chip_sim:0.1
+    }
+    // Example 2: override the search paths to prioritize the selection of
+    // packages (with the same VLNV). The latter one wins.
+    {
+      name: fusesoc_cores_root_dirs
+      value: ["--cores-root {proj_root}",
+              "--cores-root my-custom-path-1",
+              "--cores-root my-custom-path-2"]
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds ability to completely modify and customize the way fusesoc
cores-root directories are presented to fusesoc.

This is done to support Nuvoton so that they can pick and choose the
'right' dependencies from their closed source repo (swapping for the
opensource fusesoc core with the same vlnv).

The relevant discussion on this can be found here:
https://docs.google.com/document/d/1r5KJ_GrY7XMy9ZITErrEhJMyFwnxOkke-1B-fc7x_D4/edit

A sample `hw/top_earlgrey/dv/vendor_chip_sim_cfg_sample.hjson` is
provided as an example that reuses the chip simulation cfg file (by
importing it) and overridding the `fusesoc_cores_root_dirs` variable to
set the fusesoc search paths as desired. Simulations can then be run
with dvsim by supplying it with this modified simulation cfg hjson
file.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>