### PR TITLE
[CI] Better cope with PRs not targeting "master"

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -180,12 +180,14 @@ jobs:
     condition: always()
     displayName: Check vendored directories are up-to-date
   - bash: |
+      set -e
       only_doc_changes=0
       if [[ "$(Build.Reason)" = "PullRequest" ]]; then
         # Conservative way of checking for documentation-only changes.
         # Only relevant for pipelines triggered from pull requests
         echo "Checking for doc-only changes in this pull request"
         fork_origin="$(git merge-base --fork-point origin/master)"
+        echo "Using $fork_origin as fork point from the target branch."
         only_doc_changes="$(git diff --name-only "$fork_origin" | grep -v '\.md$' -q; echo $?)"
       fi
       echo "##vso[task.setvariable variable=onlyDocChanges;isOutput=true]${only_doc_changes}"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,7 @@ jobs:
       printenv
     displayName: Display environment information
   - bash: |
-      fork_origin="$(git merge-base --fork-point origin/master)"
+      fork_origin="$(git merge-base --fork-point origin/$SYSTEM_PULLREQUEST_TARGETBRANCH)"
       changed_files="$(git diff --name-only --diff-filter=ACMRTUXB "$fork_origin" | grep -v /vendor/ | grep -v /lowrisc_misc-linters/ | grep -E '.py$')"
       if [[ -n "$changed_files" ]]; then
         set -e
@@ -102,7 +102,7 @@ jobs:
       # get reported to GitHub Checks annotations. Upstream bug report:
       # https://developercommunity.visualstudio.com/content/problem/689794/pipelines-logging-command-logissue-does-not-report.html
       #echo "##vso[task.issue type=error;sourcepath=/azure-pipelines.yml;linenumber=45;columnnumber=1;code=100;]Found something that could be a problem."
-      fork_origin="$(git merge-base --fork-point origin/master)"
+      fork_origin="$(git merge-base --fork-point origin/$SYSTEM_PULLREQUEST_TARGETBRANCH)"
       changed_files="$(git diff --name-only "$fork_origin" | grep -v /vendor/ | grep -E '\.(cpp|cc|c|h)$')"
       if [[ -n "$changed_files" ]]; then
         xargs git diff -U0 "$fork_origin" <<< "$changed_files" \
@@ -120,7 +120,7 @@ jobs:
     condition: eq(variables['Build.Reason'], 'PullRequest')
     displayName: Use clang-format to check C/C++ coding style
   - bash: |
-      fork_origin="$(git merge-base --fork-point origin/master)"
+      fork_origin="$(git merge-base --fork-point origin/$SYSTEM_PULLREQUEST_TARGETBRANCH)"
       changed_files="$(git diff --name-only --diff-filter=ACMRTUXB "$fork_origin")"
       if [[ -n "$changed_files" ]]; then
         xargs util/fix_include_guard.py --dry-run <<< "$changed_files" | tee fix-include-guard-output
@@ -143,7 +143,7 @@ jobs:
     condition: eq(variables['Build.Reason'], 'PullRequest')
     displayName: Style-Lint Verilog source files with Verible
   - bash: |
-      commit_range="$(git merge-base --fork-point origin/master)..HEAD"
+      commit_range="$(git merge-base --fork-point origin/$SYSTEM_PULLREQUEST_TARGETBRANCH)..HEAD"
       # Notes:
       # * Merge commits are not checked. We always use rebases instead of
       #   merges to keep a linear history, which makes merge commits disappear
@@ -186,7 +186,7 @@ jobs:
         # Conservative way of checking for documentation-only changes.
         # Only relevant for pipelines triggered from pull requests
         echo "Checking for doc-only changes in this pull request"
-        fork_origin="$(git merge-base --fork-point origin/master)"
+        fork_origin="$(git merge-base --fork-point origin/$SYSTEM_PULLREQUEST_TARGETBRANCH)"
         echo "Using $fork_origin as fork point from the target branch."
         only_doc_changes="$(git diff --name-only "$fork_origin" | grep -v '\.md$' -q; echo $?)"
       fi
@@ -194,7 +194,7 @@ jobs:
     displayName: Check if the commit only contains documentation changes
     name: DetermineBuildType
   - bash: |
-      fork_origin="$(git merge-base --fork-point origin/master)"
+      fork_origin="$(git merge-base --fork-point origin/$SYSTEM_PULLREQUEST_TARGETBRANCH)"
       changed_files="$(git diff --name-only --diff-filter=ACMRTUXB "$fork_origin")"
       licence_checker=util/lowrisc_misc-linters/licence-checker/licence-checker.py
       if [[ -n "$changed_files" ]]; then

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,6 +49,7 @@ jobs:
       echo "##vso[task.setvariable variable=PATH]/tools/verible/bin:$PATH"
     displayName: Install Verible
   - bash: |
+      set -x
       python3 --version
       yapf --version
       isort --version
@@ -58,7 +59,8 @@ jobs:
       meson --version
       doxygen --version
       echo "PATH=$PATH"
-    displayName: Display tool versions
+      printenv
+    displayName: Display environment information
   - bash: |
       fork_origin="$(git merge-base --fork-point origin/master)"
       changed_files="$(git diff --name-only --diff-filter=ACMRTUXB "$fork_origin" | grep -v /vendor/ | grep -v /lowrisc_misc-linters/ | grep -E '.py$')"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,14 +20,14 @@ trigger:
   batch: true
   branches:
     include:
-    - '*'
+    - "*"
   tags:
     include:
     - "*"
 pr:
   branches:
     include:
-    - '*'
+    - "*"
 
 jobs:
 - job: lint


### PR DESCRIPTION
Not all PRs target the master branch; recent examples are PRs for v1-bronze, or PRs for otbn-dev. Assuming all PRs target master breaks various checks, but most fatally the "only doc changes" check. This check returned always "true", skipping all subsequent CI steps because the change was assumed to contain only documentation changes.

This PR also contains a small number of drive-by cleanups in separate commits.