### PR TITLE
[dvsim] Print a more helpful path to coverage dashboard

### DIFF
--- a/hw/dv/data/dsim/dsim.hjson
+++ b/hw/dv/data/dsim/dsim.hjson
@@ -64,7 +64,7 @@
   cov_report_opts:  [
                     ]
   cov_report_txt:   "{cov_report_dir}/dashboard.txt"
-  cov_report_page:  "cov_report/dashboard.html"
+  cov_report_page:  "{cov_report_dir}/dashboard.html"
 
   // Analyzing coverage - this is done by invoking --cov-analyze switch. It opens up the
   // GUI for visual analysis.

--- a/hw/dv/data/vcs/vcs.hjson
+++ b/hw/dv/data/vcs/vcs.hjson
@@ -92,7 +92,7 @@
                         "-elfile {vcs_cov_excl_files}",
                         "-report {cov_report_dir}"]
   cov_report_txt:       "{cov_report_dir}/dashboard.txt"
-  cov_report_page:      "cov_report/dashboard.html"
+  cov_report_page:      "{cov_report_dir}/dashboard.html"
 
   // Analyzing coverage - this is done by invoking --cov-analyze switch. It opens up the
   // GUI for visual analysis.

--- a/hw/dv/data/xcelium/xcelium.hjson
+++ b/hw/dv/data/xcelium/xcelium.hjson
@@ -82,7 +82,7 @@
                      "-licqueue",
                      "-exec {tool_srcs_dir}/cov_report.tcl"]
   cov_report_txt:   "{cov_report_dir}/cov_report.txt"
-  cov_report_page:  "cov_report/index.html"
+  cov_report_page:  "{cov_report_dir}/index.html"
 
   // Analyzing coverage - this is done by invoking --cov-analyze switch. It opens up the
   // GUI for visual analysis.


### PR DESCRIPTION
cov_report_page is used by dvsim's SimCfg.py to print a message to the
console with the path to the dashboard HTML page. Most of these
messages have the full path (useful for copy-pasting), but this one
didn't.

(Adding Udi and Cindy as well as Sri for review: I think this should be pretty uncontentious, and I'd rather it just went in)