### PR TITLE
[aes] Add 2-share implementation of the cipher core for security hardening

### DIFF
--- a/hw/ip/aes/pre_dv/aes_sbox_tb/rtl/aes_sbox_tb.sv
+++ b/hw/ip/aes/pre_dv/aes_sbox_tb/rtl/aes_sbox_tb.sv
@@ -38,17 +38,13 @@ module aes_sbox_tb #(
   assign stimulus = count_q[7:0];
 
   // Instantiate SBox Implementations
-  aes_sbox #(
-    .SBoxImpl ( "lut" )
-  ) aes_sbox_lut (
+  aes_sbox_lut aes_sbox_lut (
     .op_i   ( op           ),
     .data_i ( stimulus     ),
     .data_o ( responses[0] )
   );
 
-  aes_sbox #(
-    .SBoxImpl ( "canright" )
-  ) aes_sbox_canright (
+  aes_sbox_canright aes_sbox_canright (
     .op_i   ( op           ),
     .data_i ( stimulus     ),
     .data_o ( responses[1] )

--- a/hw/ip/aes/rtl/aes_key_expand.sv
+++ b/hw/ip/aes/rtl/aes_key_expand.sv
@@ -6,22 +6,24 @@
 
 `include "prim_assert.sv"
 
-module aes_key_expand #(
-  parameter bit AES192Enable = 1,
-  parameter     SBoxImpl     = "lut"
+module aes_key_expand import aes_pkg::*;
+#(
+  parameter bit         AES192Enable = 1,
+  parameter bit         Masking      = 0,
+  parameter sbox_impl_e SBoxImpl     = SBoxImplLut,
+
+  localparam int        NumShares    = Masking ? 2 : 1 // derived parameter
 ) (
   input  logic              clk_i,
   input  logic              rst_ni,
-  input  aes_pkg::ciph_op_e op_i,
+  input  ciph_op_e          op_i,
   input  logic              step_i,
   input  logic              clear_i,
   input  logic        [3:0] round_i,
-  input  aes_pkg::key_len_e key_len_i,
-  input  logic  [7:0][31:0] key_i,
-  output logic  [7:0][31:0] key_o
+  input  key_len_e          key_len_i,
+  input  logic  [7:0][31:0] key_i [NumShares],
+  output logic  [7:0][31:0] key_o [NumShares]
 );
-
-  import aes_pkg::*;
 
   logic       [7:0] rcon_d, rcon_q;
   logic             rcon_we;
@@ -30,15 +32,18 @@ module aes_key_expand #(
   logic       [3:0] rnd;
   logic       [3:0] rnd_type;
 
-  logic      [31:0] spec_in_128, spec_in_192;
-  logic      [31:0] rot_word_in, rot_word_out;
+  logic      [31:0] spec_in_128 [NumShares];
+  logic      [31:0] spec_in_192 [NumShares];
+  logic      [31:0] rot_word_in [NumShares];
+  logic      [31:0] rot_word_out [NumShares];
   logic             use_rot_word;
   logic      [31:0] sub_word_in, sub_word_out;
+  logic      [31:0] sw_in_mask, sw_out_mask;
   logic       [7:0] rcon_add_in, rcon_add_out;
   logic      [31:0] rcon_added;
 
-  logic      [31:0] irregular;
-  logic [7:0][31:0] regular;
+  logic      [31:0] irregular [NumShares];
+  logic [7:0][31:0] regular [NumShares];
 
   assign rnd = round_i;
 
@@ -104,76 +109,93 @@ module aes_key_expand #(
     end
   end
 
-  // Special input, equivalent to key_o[3] in the used cases
-  assign spec_in_128 = key_i[3] ^ key_i[2];
-  assign spec_in_192 = AES192Enable ? key_i[5] ^ key_i[1] ^ key_i[0] : '0;
+  for (genvar s = 0; s < NumShares; s++) begin : gen_shares_rot_word_out
+    // Special input, equivalent to key_o[3] in the used cases
+    assign spec_in_128[s] = key_i[s][3] ^ key_i[s][2];
+    assign spec_in_192[s] = AES192Enable ? key_i[s][5] ^ key_i[s][1] ^ key_i[s][0] : '0;
 
-  // Select input
-  always_comb begin : rot_word_in_mux
-    unique case (key_len_i)
+    // Select input
+    always_comb begin : rot_word_in_mux
+      unique case (key_len_i)
 
-      /////////////
-      // AES-128 //
-      /////////////
-      AES_128: begin
-        unique case (op_i)
-          CIPH_FWD: rot_word_in = key_i[3];
-          CIPH_INV: rot_word_in = spec_in_128;
-          default:  rot_word_in = key_i[3];
-        endcase
-      end
-
-      /////////////
-      // AES-192 //
-      /////////////
-      AES_192: begin
-        if (AES192Enable) begin
+        /////////////
+        // AES-128 //
+        /////////////
+        AES_128: begin
           unique case (op_i)
-            CIPH_FWD: begin
-              rot_word_in = rnd_type[0] ? key_i[5]    :
-                            rnd_type[2] ? key_i[5]    :
-                            rnd_type[3] ? spec_in_192 : key_i[3];
-            end
-            CIPH_INV: begin
-              rot_word_in = rnd_type[1] ? key_i[3] :
-                            rnd_type[2] ? key_i[1] : key_i[3];
-            end
-            default: rot_word_in = key_i[3];
+            CIPH_FWD: rot_word_in[s] = key_i[s][3];
+            CIPH_INV: rot_word_in[s] = spec_in_128[s];
+            default:  rot_word_in[s] = key_i[s][3];
           endcase
-        end else begin
-          rot_word_in = key_i[3];
         end
-      end
 
-      /////////////
-      // AES-256 //
-      /////////////
-      AES_256: begin
-        unique case (op_i)
-          CIPH_FWD: rot_word_in = key_i[7];
-          CIPH_INV: rot_word_in = key_i[3];
-          default:  rot_word_in = key_i[7];
-        endcase
-      end
+        /////////////
+        // AES-192 //
+        /////////////
+        AES_192: begin
+          if (AES192Enable) begin
+            unique case (op_i)
+              CIPH_FWD: begin
+                rot_word_in[s] = rnd_type[0] ? key_i[s][5]    :
+                                 rnd_type[2] ? key_i[s][5]    :
+                                 rnd_type[3] ? spec_in_192[s] : key_i[s][3];
+              end
+              CIPH_INV: begin
+                rot_word_in[s] = rnd_type[1] ? key_i[s][3] :
+                                 rnd_type[2] ? key_i[s][1] : key_i[s][3];
+              end
+              default: rot_word_in[s] = key_i[s][3];
+            endcase
+          end else begin
+            rot_word_in[s] = key_i[s][3];
+          end
+        end
 
-      default: rot_word_in = key_i[3];
-    endcase
+        /////////////
+        // AES-256 //
+        /////////////
+        AES_256: begin
+          unique case (op_i)
+            CIPH_FWD: rot_word_in[s] = key_i[s][7];
+            CIPH_INV: rot_word_in[s] = key_i[s][3];
+            default:  rot_word_in[s] = key_i[s][7];
+          endcase
+        end
+
+        default: rot_word_in[s] = key_i[s][3];
+      endcase
+    end
+
+    // RotWord: cyclic byte shift
+    assign rot_word_out[s] = aes_circ_byte_shift(rot_word_in[s], 2'h3);
   end
 
-  // RotWord: cyclic byte shift
-  assign rot_word_out = aes_circ_byte_shift(rot_word_in, 2'h3);
-
   // Mux input for SubWord
-  assign sub_word_in = use_rot_word ? rot_word_out : rot_word_in;
+  assign sub_word_in = use_rot_word ? rot_word_out[0] : rot_word_in[0];
+
+  // Masking
+  if (!Masking) begin : gen_no_sw_in_mask
+    // The mask share is ignored anyway, it can be 0.
+    assign sw_in_mask  = '0;
+  end else begin : gen_sw_in_mask
+    // The input mask is the mask share of rot_word_in/out.
+    assign sw_in_mask = use_rot_word ? rot_word_out[1] : rot_word_in[1];
+  end
+
+  // TODO: Use non-constant output masks for SubWord + remove corresponding comment in aes.sv.
+  // See https://github.com/lowRISC/opentitan/issues/1005
+  assign sw_out_mask = 32'h5555_5555;
 
   // SubWord - individually substitute bytes
   for (genvar i = 0; i < 4; i++) begin : gen_sbox
     aes_sbox #(
       .SBoxImpl ( SBoxImpl )
-    ) aes_sbox_i (
-      .op_i   ( CIPH_FWD               ),
-      .data_i ( sub_word_in[8*i +: 8]  ),
-      .data_o ( sub_word_out[8*i +: 8] )
+    ) u_aes_sbox_i (
+      .op_i       ( CIPH_FWD               ),
+      .data_i     ( sub_word_in[8*i +: 8]  ),
+      .in_mask_i  ( sw_in_mask[8*i +: 8]   ),
+      .out_mask_i ( sw_out_mask[8*i +: 8]  ),
+      .data_o     ( sub_word_out[8*i +: 8] )
     );
   end
 
@@ -183,7 +205,15 @@ module aes_key_expand #(
   assign rcon_added   = {sub_word_out[31:8], rcon_add_out};
 
   // Mux output coming from Rcon & SubWord
-  assign irregular = use_rcon ? rcon_added : sub_word_out;
+  for (genvar s = 0; s < NumShares; s++) begin : gen_shares_irregular
+    if (s == 0) begin : gen_irregular_rcon
+      // The (masked) key share
+      assign irregular[s] = use_rcon ? rcon_added : sub_word_out;
+    end else begin : gen_irregular_no_rcon
+      // The mask share
+      assign irregular[s] = sw_out_mask;
+    end
+  end
 
   ///////////////////////////
   // The more regular part //
@@ -191,143 +221,158 @@ module aes_key_expand #(
 
   // To reduce muxing resources, we re-use existing
   // connections for unused words and default cases.
-  always_comb begin : drive_regular
-    unique case (key_len_i)
+  for (genvar s = 0; s < NumShares; s++) begin : gen_shares_regular
+    always_comb begin : drive_regular
+      unique case (key_len_i)
 
-      /////////////
-      // AES-128 //
-      /////////////
-      AES_128: begin
-        // key_o[7:4] not used
-        regular[7:4] = key_i[3:0];
+        /////////////
+        // AES-128 //
+        /////////////
+        AES_128: begin
+          // key_o[7:4] not used
+          regular[s][7:4] = key_i[s][3:0];
 
-        regular[0] = irregular ^ key_i[0];
-        unique case (op_i)
-          CIPH_FWD: begin
-            for (int i=1; i<4; i++) begin
-              regular[i] = regular[i-1] ^ key_i[i];
-            end
-          end
-
-          CIPH_INV: begin
-            for (int i=1; i<4; i++) begin
-              regular[i] = key_i[i-1] ^ key_i[i];
-            end
-          end
-
-          default: regular = {key_i[3:0], key_i[7:4]};
-        endcase
-      end
-
-      /////////////
-      // AES-192 //
-      /////////////
-      AES_192: begin
-        // key_o[7:6] not used
-        regular[7:6] = key_i[3:2];
-
-        if (AES192Enable) begin
+          regular[s][0] = irregular[s] ^ key_i[s][0];
           unique case (op_i)
             CIPH_FWD: begin
-              if (rnd_type[0]) begin
-                // Shift down four upper most words
-                regular[3:0] = key_i[5:2];
-                // Generate Words 6 and 7
-                regular[4]   = irregular  ^ key_i[0];
-                regular[5]   = regular[4] ^ key_i[1];
-              end else begin
-                // Shift down two upper most words
-                regular[1:0] = key_i[5:4];
-                // Generate new upper four words
-                for (int i=0; i<4; i++) begin
-                  if ((i == 0 && rnd_type[2]) ||
-                      (i == 2 && rnd_type[3])) begin
-                    regular[i+2] = irregular    ^ key_i[i];
-                  end else begin
-                    regular[i+2] = regular[i+1] ^ key_i[i];
-                  end
-                end
-              end // rnd_type[0]
+              for (int i=1; i<4; i++) begin
+                regular[s][i] = regular[s][i-1] ^ key_i[s][i];
+              end
             end
 
             CIPH_INV: begin
-              if (rnd_type[0]) begin
-                // Shift up four lowest words
-                regular[5:2] = key_i[3:0];
-                // Generate Word 44 and 45
-                for (int i=0; i<2; i++) begin
-                  regular[i] = key_i[3+i] ^ key_i[3+i+1];
-                end
-              end else begin
-                // Shift up two lowest words
-                regular[5:4] = key_i[1:0];
-                // Generate new lower four words
-                for (int i=0; i<4; i++) begin
-                  if ((i == 2 && rnd_type[1]) ||
-                      (i == 0 && rnd_type[2])) begin
-                    regular[i] = irregular  ^ key_i[i+2];
-                  end else begin
-                    regular[i] = key_i[i+1] ^ key_i[i+2];
-                  end
-                end
-              end // rnd_type[0]
+              for (int i=1; i<4; i++) begin
+                regular[s][i] = key_i[s][i-1] ^ key_i[s][i];
+              end
             end
 
-            default: regular = {key_i[3:0], key_i[7:4]};
+            default: regular[s] = {key_i[s][3:0], key_i[s][7:4]};
           endcase
+        end
 
-        end else begin
-          regular = {key_i[3:0], key_i[7:4]};
-        end // AES192Enable
-      end
+        /////////////
+        // AES-192 //
+        /////////////
+        AES_192: begin
+          // key_o[7:6] not used
+          regular[s][7:6] = key_i[s][3:2];
 
-      /////////////
-      // AES-256 //
-      /////////////
-      AES_256: begin
-        unique case (op_i)
-          CIPH_FWD: begin
-            if (rnd == 0) begin
-              // Round 0: Nothing to be done
-              // The Full Key registers are not updated
-              regular = {key_i[3:0], key_i[7:4]};
-            end else begin
-              // Shift down old upper half
-              regular[3:0] = key_i[7:4];
-              // Generate new upper half
-              regular[4]   = irregular ^ key_i[0];
-              for (int i=1; i<4; i++) begin
-                regular[i+4] = regular[i+4-1] ^ key_i[i];
+          if (AES192Enable) begin
+            unique case (op_i)
+              CIPH_FWD: begin
+                if (rnd_type[0]) begin
+                  // Shift down four upper most words
+                  regular[s][3:0] = key_i[s][5:2];
+                  // Generate Words 6 and 7
+                  regular[s][4]   = irregular[s]  ^ key_i[s][0];
+                  regular[s][5]   = regular[s][4] ^ key_i[s][1];
+                end else begin
+                  // Shift down two upper most words
+                  regular[s][1:0] = key_i[s][5:4];
+                  // Generate new upper four words
+                  for (int i=0; i<4; i++) begin
+                    if ((i == 0 && rnd_type[2]) ||
+                        (i == 2 && rnd_type[3])) begin
+                      regular[s][i+2] = irregular[s]    ^ key_i[s][i];
+                    end else begin
+                      regular[s][i+2] = regular[s][i+1] ^ key_i[s][i];
+                    end
+                  end
+                end // rnd_type[0]
               end
-            end // rnd == 0
-          end
 
-          CIPH_INV: begin
-            if (rnd == 0) begin
-              // Round 0: Nothing to be done
-              // The Full Key registers are not updated
-              regular = {key_i[3:0], key_i[7:4]};
-            end else begin
-              // Shift up old lower half
-              regular[7:4] = key_i[3:0];
-              // Generate new lower half
-              regular[0]   = irregular ^ key_i[4];
-              for (int i=0; i<3; i++) begin
-                regular[i+1] = key_i[4+i] ^ key_i[4+i+1];
+              CIPH_INV: begin
+                if (rnd_type[0]) begin
+                  // Shift up four lowest words
+                  regular[s][5:2] = key_i[s][3:0];
+                  // Generate Word 44 and 45
+                  for (int i=0; i<2; i++) begin
+                    regular[s][i] = key_i[s][3+i] ^ key_i[s][3+i+1];
+                  end
+                end else begin
+                  // Shift up two lowest words
+                  regular[s][5:4] = key_i[s][1:0];
+                  // Generate new lower four words
+                  for (int i=0; i<4; i++) begin
+                    if ((i == 2 && rnd_type[1]) ||
+                        (i == 0 && rnd_type[2])) begin
+                      regular[s][i] = irregular[s]  ^ key_i[s][i+2];
+                    end else begin
+                      regular[s][i] = key_i[s][i+1] ^ key_i[s][i+2];
+                    end
+                  end
+                end // rnd_type[0]
               end
-            end // rnd == 0
-          end
 
-          default: regular = {key_i[3:0], key_i[7:4]};
-        endcase
-      end
+              default: regular[s] = {key_i[s][3:0], key_i[s][7:4]};
+            endcase
 
-      default: regular = {key_i[3:0], key_i[7:4]};
-    endcase // key_len_i
-  end
+          end else begin
+            regular[s] = {key_i[s][3:0], key_i[s][7:4]};
+          end // AES192Enable
+        end
+
+        /////////////
+        // AES-256 //
+        /////////////
+        AES_256: begin
+          unique case (op_i)
+            CIPH_FWD: begin
+              if (rnd == 0) begin
+                // Round 0: Nothing to be done
+                // The Full Key registers are not updated
+                regular[s] = {key_i[s][3:0], key_i[s][7:4]};
+              end else begin
+                // Shift down old upper half
+                regular[s][3:0] = key_i[s][7:4];
+                // Generate new upper half
+                regular[s][4]   = irregular[s] ^ key_i[s][0];
+                for (int i=1; i<4; i++) begin
+                  regular[s][i+4] = regular[s][i+4-1] ^ key_i[s][i];
+                end
+              end // rnd == 0
+            end
+
+            CIPH_INV: begin
+              if (rnd == 0) begin
+                // Round 0: Nothing to be done
+                // The Full Key registers are not updated
+                regular[s] = {key_i[s][3:0], key_i[s][7:4]};
+              end else begin
+                // Shift up old lower half
+                regular[s][7:4] = key_i[s][3:0];
+                // Generate new lower half
+                regular[s][0]   = irregular[s] ^ key_i[s][4];
+                for (int i=0; i<3; i++) begin
+                  regular[s][i+1] = key_i[s][4+i] ^ key_i[s][4+i+1];
+                end
+              end // rnd == 0
+            end
+
+            default: regular[s] = {key_i[s][3:0], key_i[s][7:4]};
+          endcase
+        end
+
+        default: regular[s] = {key_i[s][3:0], key_i[s][7:4]};
+      endcase // key_len_i
+    end // drive_regular
+  end // gen_shares_regular
 
   // Drive output
   assign key_o = regular;
+
+  ////////////////
+  // Assertions //
+  ////////////////
+
+  // Cipher core masking requires a masked SBox and vice versa.
+  `ASSERT_INIT(AesMaskedCoreAndSBox,
+      (Masking &&
+      (SBoxImpl == SBoxImplCanrightMasked ||
+       SBoxImpl == SBoxImplCanrightMaskedNoreuse)) ||
+      (!Masking &&
+      (SBoxImpl == SBoxImplLut ||
+       SBoxImpl == SBoxImplCanright)))
 
   // Selectors must be known/valid
   `ASSERT_KNOWN(AesCiphOpKnown, op_i)

--- a/hw/ip/aes/rtl/aes_mix_columns.sv
+++ b/hw/ip/aes/rtl/aes_mix_columns.sv
@@ -20,7 +20,7 @@ module aes_mix_columns (
 
   // Individually mix columns
   for (genvar i = 0; i < 4; i++) begin : gen_mix_column
-    aes_mix_single_column aes_mix_column_i (
+    aes_mix_single_column u_aes_mix_column_i (
       .op_i   ( op_i                 ),
       .data_i ( data_i_transposed[i] ),
       .data_o ( data_o_transposed[i] )

--- a/hw/ip/aes/rtl/aes_pkg.sv
+++ b/hw/ip/aes/rtl/aes_pkg.sv
@@ -9,6 +9,15 @@ package aes_pkg;
 parameter int NumAlerts = 1;
 parameter logic [NumAlerts-1:0] AlertAsyncOn = NumAlerts'(1'b1);
 
+typedef enum integer {
+  SBoxImplLut,                  // Unmasked LUT-based S-Box
+  SBoxImplCanright,             // Unmasked Canright S-Box, see aes_sbox_canright.sv
+  SBoxImplCanrightMasked,       // First-order masked Canright S-Box
+                                // see aes_sbox_canright_masked.sv
+  SBoxImplCanrightMaskedNoreuse // First-order masked Canright S-Box without mask reuse,
+                                // see aes_sbox_canright_masked_noreuse.sv
+} sbox_impl_e;
+
 typedef enum logic {
   AES_ENC = 1'b0,
   AES_DEC = 1'b1

--- a/hw/ip/aes/rtl/aes_prng.sv
+++ b/hw/ip/aes/rtl/aes_prng.sv
@@ -47,7 +47,7 @@ module aes_prng (
     .LfsrType    ( "GAL_XOR"  ),
     .LfsrDw      ( DATA_WIDTH ),
     .StateOutDw  ( DATA_WIDTH )
-  ) aes_prng_lfsr (
+  ) u_aes_prng_lfsr (
     .clk_i     ( clk_i      ),
     .rst_ni    ( rst_ni     ),
     .seed_en_i ( seed_en    ),

--- a/hw/ip/aes/rtl/aes_sub_bytes.sv
+++ b/hw/ip/aes/rtl/aes_sub_bytes.sv
@@ -4,11 +4,14 @@
 //
 // AES SubBytes
 
-module aes_sub_bytes #(
-  parameter SBoxImpl = "lut"
+module aes_sub_bytes import aes_pkg::*;
+#(
+  parameter sbox_impl_e SBoxImpl = SBoxImplLut
 ) (
-  input  aes_pkg::ciph_op_e    op_i,
+  input  ciph_op_e             op_i,
   input  logic [3:0][3:0][7:0] data_i,
+  input  logic [3:0][3:0][7:0] in_mask_i,
+  input  logic [3:0][3:0][7:0] out_mask_i,
   output logic [3:0][3:0][7:0] data_o
 );
 
@@ -17,10 +20,12 @@ module aes_sub_bytes #(
     for (genvar i = 0; i < 4; i++) begin : gen_sbox_i
       aes_sbox #(
         .SBoxImpl ( SBoxImpl )
-      ) aes_sbox_ij (
-        .op_i   ( op_i         ),
-        .data_i ( data_i[i][j] ),
-        .data_o ( data_o[i][j] )
+      ) u_aes_sbox_ij (
+        .op_i       ( op_i             ),
+        .data_i     ( data_i[i][j]     ),
+        .in_mask_i  ( in_mask_i[i][j]  ),
+        .out_mask_i ( out_mask_i[i][j] ),
+        .data_o     ( data_o[i][j]     )
       );
     end
   end


### PR DESCRIPTION
This PR adds a first version of the first-order masked, 2-share implmemenation of the AES cipher core. The masking can be enabled via a design time parameter. If enabled, both the cipher datapath and and key schedule are masked.

The generation of the masks is not part of this PR but future work. At the moment, constant masks are used. This is of course not secure.

Note that this PR does not contain the work to take in the key from software in two shares. I have decided to split this out into a separate PR here #2933 . Instead this implementation here uses a constant value to mask the key before feeding it into the cipher core.

Other notable changes:
- To select the SBox implementation, a parameter of type enum is now used.
- Added documentation regarding the data format.

This looks like big PR but effectively most of changes involve adding an unpacked dimension to the signals (representing the different shares), packing the linear parts of the circuit into loops (the operate independently on the separate shares). The really important part like interfacing the masked S-Boxes is a small part of the changes in `aes_cipher_core.sv` and `aes_key_expand.sv` as well as most of `aes_sbox.sv`.

The functionality of both the masked and unmasked implementation has been successfully tested using our AES DV and my Verilator testbench.