### PR TITLE
[dv] Flash_ctrl enable polling before read/program

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
@@ -42,7 +42,7 @@ package flash_ctrl_env_pkg;
   parameter uint FlashMemAddrBankMsbBit   = FlashDataByteWidth + FlashWordLineWidth +
                                             FlashPageWidth + FlashBankWidth - 1;
 
-// types
+  // types
   typedef enum int {
     FlashCtrlIntrProgEmpty  = 0,
     FlashCtrlIntrProgLvl    = 1,

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
@@ -41,6 +41,7 @@ class flash_ctrl_seq_cfg extends uvm_object;
   uint op_on_data_partition_pc = 100;
   uint op_erase_type_bank_pc = 0;
   uint op_max_words = 512;
+  bit  op_allow_invalid = 1'b0;
 
   // Poll fifo status before writing to prog_fifo / reading from rd_fifo.
   uint poll_fifo_status_pc = 30;

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
@@ -42,6 +42,9 @@ class flash_ctrl_seq_cfg extends uvm_object;
   uint op_erase_type_bank_pc = 0;
   uint op_max_words = 512;
 
+  // Poll fifo status before writing to prog_fifo / reading from rd_fifo.
+  uint poll_fifo_status_pc = 30;
+
   `uvm_object_new
 
 endclass

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
@@ -113,6 +113,7 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
 
   // Wait for prog fifo to not be full.
   virtual task wait_flash_ctrl_prog_fifo_not_full();
+    // TODO: if intr enabled, then check interrupt, else check status.
     bit prog_full;
     `DV_SPINWAIT(
       do begin
@@ -124,6 +125,7 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
 
   // Wait for rd fifo to not be empty.
   virtual task wait_flash_ctrl_rd_fifo_not_empty();
+    // TODO: if intr enabled, then check interrupt, else check status.
     bit read_empty;
     `DV_SPINWAIT(
       do begin
@@ -149,12 +151,13 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
 
   // Program data into flash, stopping whenever full.
   // The flash op is assumed to have already commenced.
-  virtual task flash_ctrl_write(bit [TL_DW-1:0] data[$]);
+  virtual task flash_ctrl_write(bit [TL_DW-1:0] data[$], bit poll_fifo_status);
     foreach (data[i]) begin
       // Check if prog fifo is full. If yes, then wait for space to become available.
-      // TODO: interface is backpressure enabled, so the above check is not needed atm.
-      // TODO: if intr enabled, then check interrupt, else check status.
-      // wait_flash_ctrl_prog_fifo_not_full();
+      // Note that this polling is not needed since the interface is backpressure enabled.
+      if (poll_fifo_status) begin
+        wait_flash_ctrl_prog_fifo_not_full();
+      end
       mem_wr(.ptr(ral.prog_fifo), .offset(0), .data(data[i]));
       `uvm_info(`gfn, $sformatf("flash_ctrl_write: 0x%0h", data[i]), UVM_MEDIUM)
     end
@@ -162,12 +165,13 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
 
   // Read data from flash, stopping whenever empty.
   // The flash op is assumed to have already commenced.
-  virtual task flash_ctrl_read(uint num_words, ref bit [TL_DW-1:0] data[$]);
+  virtual task flash_ctrl_read(uint num_words, ref bit [TL_DW-1:0] data[$], bit poll_fifo_status);
     for (int i = 0; i < num_words; i++) begin
       // Check if rd fifo is empty. If yes, then wait for data to become available.
-      // TODO: interface is backpressure enabled, so the above check is not needed atm.
-      // TODO: if intr enabled, then check interrupt, else check status.
-      // wait_flash_ctrl_rd_fifo_not_empty();
+      // Note that this polling is not needed since the interface is backpressure enabled.
+      if (poll_fifo_status) begin
+        wait_flash_ctrl_rd_fifo_not_empty();
+      end
       mem_rd(.ptr(ral.rd_fifo), .offset(0), .data(data[i]));
       `uvm_info(`gfn, $sformatf("flash_ctrl_read: 0x%0h", data[i]), UVM_MEDIUM)
     end

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_vseq.sv
@@ -20,7 +20,14 @@ class flash_ctrl_rand_ops_vseq extends flash_ctrl_base_vseq;
   rand flash_op_t flash_op;
 
   constraint flash_op_c {
+    solve flash_op.op before flash_op.erase_type;
+    solve flash_op.op before flash_op.num_words;
+
     flash_op.addr inside {[0:FlashSizeBytes-1]};
+
+    if (!cfg.seq_cfg.op_allow_invalid) {
+      flash_op.op != flash_ctrl_pkg::FlashOpInvalid;
+    }
 
     (flash_op.op == flash_ctrl_pkg::FlashOpErase) ->
         flash_op.erase_type dist {
@@ -217,7 +224,7 @@ class flash_ctrl_rand_ops_vseq extends flash_ctrl_base_vseq;
         `DV_CHECK_MEMBER_RANDOMIZE_FATAL(flash_op_data)
 
         `uvm_info(`gfn, $sformatf("Starting flash_ctrl op: %0d/%0d: %p",
-                                  j, num_flash_ops_per_cfg, flash_op), UVM_MEDIUM)
+                                  j, num_flash_ops_per_cfg, flash_op), UVM_LOW)
 
         // Bkdr initialize the flash mem based on op.
         flash_ctrl_prep_mem(flash_op);

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_sanity_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_sanity_vseq.sv
@@ -29,6 +29,8 @@ class flash_ctrl_sanity_vseq extends flash_ctrl_rand_ops_vseq;
 
     // Allow banks to be erased.
     cfg.seq_cfg.bank_erase_en_pc = 100;
+
+    cfg.seq_cfg.poll_fifo_status_pc = 0;
   endfunction
 
 endclass : flash_ctrl_sanity_vseq

--- a/hw/ip/flash_ctrl/dv/tb/flash_ctrl_wrapper.sv
+++ b/hw/ip/flash_ctrl/dv/tb/flash_ctrl_wrapper.sv
@@ -14,6 +14,9 @@ module flash_ctrl_wrapper (
   input        tlul_pkg::tl_h2d_t eflash_tl_i,
   output       tlul_pkg::tl_d2h_t eflash_tl_o,
 
+  // OTP interface
+  input        flash_ctrl_pkg::otp_flash_t otp_i,
+
   // Interrupts
   output logic intr_prog_empty_o, // Program fifo is empty
   output logic intr_prog_lvl_o,   // Program fifo is empty
@@ -42,6 +45,7 @@ module flash_ctrl_wrapper (
     // Inter-module signals
     .flash_o  (flash_ctrl_flash_req),
     .flash_i  (flash_ctrl_flash_rsp),
+    .otp_i    (otp_i),
 
     .clk_i    (clk_i),
     .rst_ni   (rst_ni)

--- a/hw/ip/flash_ctrl/dv/tb/tb.sv
+++ b/hw/ip/flash_ctrl/dv/tb/tb.sv
@@ -34,21 +34,24 @@ module tb;
 
   // dut
   flash_ctrl_wrapper dut (
-    .clk_i                (clk        ),
-    .rst_ni               (rst_n      ),
+    .clk_i              (clk      ),
+    .rst_ni             (rst_n    ),
 
-    .flash_ctrl_tl_i      (tl_if.h2d  ),
-    .flash_ctrl_tl_o      (tl_if.d2h  ),
+    .flash_ctrl_tl_i    (tl_if.h2d),
+    .flash_ctrl_tl_o    (tl_if.d2h),
 
-    .eflash_tl_i          (eflash_tl_if.h2d),
-    .eflash_tl_o          (eflash_tl_if.d2h),
+    .eflash_tl_i        (eflash_tl_if.h2d),
+    .eflash_tl_o        (eflash_tl_if.d2h),
 
-    .intr_prog_empty_o (intr_prog_empty ),
-    .intr_prog_lvl_o   (intr_prog_lvl   ),
-    .intr_rd_full_o    (intr_rd_full    ),
-    .intr_rd_lvl_o     (intr_rd_lvl     ),
-    .intr_op_done_o    (intr_op_done    ),
-    .intr_op_error_o   (intr_op_error   )
+    // TODO: create and hook this up to an interface.
+    .otp_i              (flash_ctrl_pkg::OTP_FLASH_DEFAULT),
+
+    .intr_prog_empty_o  (intr_prog_empty),
+    .intr_prog_lvl_o    (intr_prog_lvl  ),
+    .intr_rd_full_o     (intr_rd_full   ),
+    .intr_rd_lvl_o      (intr_rd_lvl    ),
+    .intr_op_done_o     (intr_op_done   ),
+    .intr_op_error_o    (intr_op_error  )
   );
 
   // bind mem_bkdr_if


### PR DESCRIPTION
This PR switches randomly between polled reads / writes and
backpressured reads / writes with 30/70 split weights. 

Signed-off-by: Srikrishna Iyer <sriyer@google.com>