### PR TITLE
[top/usb] Provision differential USB input receiver in Bronze

### DIFF
--- a/hw/ip/prim/prim_usb_diff_rx.core
+++ b/hw/ip/prim/prim_usb_diff_rx.core
@@ -1,0 +1,25 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:usb_diff_rx"
+description: "Differential receiver for USB."
+filesets:
+  primgen_dep:
+    depend:
+      - lowrisc:prim:prim_pkg
+      - lowrisc:prim:primgen
+
+generate:
+  impl:
+    generator: primgen
+    parameters:
+      prim_name: usb_diff_rx
+
+targets:
+  default:
+    filesets:
+      - primgen_dep
+    generate:
+      - impl

--- a/hw/ip/prim_generic/prim_generic_usb_diff_rx.core
+++ b/hw/ip/prim_generic/prim_generic_usb_diff_rx.core
@@ -1,0 +1,42 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim_generic:usb_diff_rx"
+description: "Generic differential USB receiver for emulation purposes"
+filesets:
+  files_rtl:
+    files:
+      - rtl/prim_generic_usb_diff_rx.sv
+    file_type: systemVerilogSource
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      #- lint/prim_generic_usb_diff_rx.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      #- lint/prim_generic_usb_diff_rx.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl

--- a/hw/ip/prim_generic/rtl/prim_generic_usb_diff_rx.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_usb_diff_rx.sv
@@ -1,0 +1,32 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Generic differential receiver for USB. Note that this is meant for emulation purposes only, and
+// the pull-up, calibration and pok signals are not connected in this module.
+
+`include "prim_assert.sv"
+
+module prim_generic_usb_diff_rx #(
+  parameter int CalibW = 32
+) (
+  input wire         input_pi,      // differential input
+  input wire         input_ni,      // differential input
+  input              input_en_i,    // input buffer enable
+  input              core_pok_i,    // core power indication at VCC level
+  input              pullup_p_en_i, // pullup enable for P
+  input              pullup_n_en_i, // pullup enable for N
+  input [CalibW-1:0] calibration_i, // calibration input
+  output logic       input_o        // output of differential input buffer
+);
+
+  assign input_o = (input_en_i) ? pullup_p_en_i & ~pullup_n_en_i : 1'b0;
+
+  logic unused_pullup_p_en, unused_pullup_n_en;
+  logic [CalibW-1:0] unused_calibration;
+
+  assign unused_calibration = calibration_i;
+  assign unused_pullup_p_en = pullup_p_en_i;
+  assign unused_pullup_n_en = pullup_n_en_i;
+
+endmodule : prim_generic_usb_diff_rx

--- a/hw/ip/usbdev/data/usbdev.hjson
+++ b/hw/ip/usbdev/data/usbdev.hjson
@@ -38,6 +38,13 @@
       struct:  "logic",
       width:   "1"
     }
+    { name:    "usb_rx_enable",
+      type:    "uni",
+      act:     "req",
+      package: "",
+      struct:  "logic",
+      width:   "1"
+    }
   ]
   param_list: [
     { name:    "NEndpoints",

--- a/hw/ip/usbdev/rtl/usbdev.sv
+++ b/hw/ip/usbdev/rtl/usbdev.sv
@@ -47,6 +47,9 @@ module usbdev (
   output logic       usb_ref_val_o,
   output logic       usb_ref_pulse_o,
 
+  // Enable signal for differential input buffer
+  output logic       usb_rx_enable_o,
+
   // Interrupts
   output logic       intr_pkt_received_o, // Packet received
   output logic       intr_pkt_sent_o, // Packet sent
@@ -138,6 +141,8 @@ module usbdev (
   logic                  usb_data_toggle_clear_en;
   logic [NEndpoints-1:0] usb_data_toggle_clear;
 
+  // This is only for Bronze
+  assign usb_rx_enable_o = reg2hw.phy_config.rx_differential_mode.q;
 
   /////////////////////////////////
   // USB IO after CDC & muxing   //

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -3893,6 +3893,18 @@
           top_signame: usbdev_aon_usb_ref_pulse
           index: -1
         }
+        {
+          name: usb_rx_enable
+          type: uni
+          act: req
+          package: ""
+          struct: logic
+          width: 1
+          inst_name: usbdev_aon
+          default: ""
+          top_signame: usbdev_aon_usb_rx_enable
+          index: -1
+        }
       ]
     }
     {
@@ -4592,6 +4604,7 @@
       rstmgr_aon.ast
       usbdev_aon.usb_ref_pulse
       usbdev_aon.usb_ref_val
+      usbdev_aon.usb_rx_enable
       entropy_src.entropy_src_rng
       clkmgr_aon.clk_main
       clkmgr_aon.clk_io
@@ -8668,6 +8681,18 @@
         index: -1
       }
       {
+        name: usb_rx_enable
+        type: uni
+        act: req
+        package: ""
+        struct: logic
+        width: 1
+        inst_name: usbdev_aon
+        default: ""
+        top_signame: usbdev_aon_usb_rx_enable
+        index: -1
+      }
+      {
         struct: hw_key_req
         type: uni
         name: aes_key
@@ -8935,6 +8960,15 @@
         package: ""
         struct: logic
         signame: usbdev_aon_usb_ref_val
+        width: 1
+        type: uni
+        default: ""
+        direction: out
+      }
+      {
+        package: ""
+        struct: logic
+        signame: usbdev_aon_usb_rx_enable
         width: 1
         type: uni
         default: ""

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -508,7 +508,7 @@
     // ext is to create port in the top.
     'external': ['sensor_ctrl.ast_host', 'sensor_ctrl.ast_dev', 'sensor_ctrl.ast_status',
                  'sensor_ctrl.ast_alert', 'sensor_ctrl.ast_aux', 'pwrmgr_aon.pwr_ast',
-                 'rstmgr_aon.ast', 'usbdev_aon.usb_ref_pulse', 'usbdev_aon.usb_ref_val',
+                 'rstmgr_aon.ast', 'usbdev_aon.usb_ref_pulse', 'usbdev_aon.usb_ref_val', 'usbdev_aon.usb_rx_enable',
                  'entropy_src.entropy_src_rng',
                  'clkmgr_aon.clk_main', 'clkmgr_aon.clk_io', 'clkmgr_aon.clk_usb', 'clkmgr_aon.clk_aon',
                  'dcd_aon.adc'],
@@ -568,7 +568,6 @@
   // generated list of alerts:
   alert: [
   ]
-
   // TODO: PINMUX
   pinmux: {
 

--- a/hw/top_earlgrey/ip/padring/rtl/jtag_mux.sv
+++ b/hw/top_earlgrey/ip/padring/rtl/jtag_mux.sv
@@ -18,7 +18,12 @@ module jtag_mux #(
   parameter int TrstIdx        = 0,
   parameter int SrstIdx        = 0,
   parameter int TdiIdx         = 0,
-  parameter int TdoIdx         = 0
+  parameter int TdoIdx         = 0,
+  // Indices for USB breakout (this is a Bronze workaround)
+  parameter int UsbDpPuIdx     = 0,
+  parameter int UsbDnPuIdx     = 0,
+  parameter int UsbDieIdx      = 0,
+  parameter int UsbDIdx        = 0
 ) (
   // To JTAG inside core
   output logic jtag_tck_o,
@@ -36,7 +41,13 @@ module jtag_mux #(
   // To padring side
   output logic [NumIOs-1:0] out_padring_o,
   output logic [NumIOs-1:0] oe_padring_o,
-  input  logic [NumIOs-1:0] in_padring_i
+  input  logic [NumIOs-1:0] in_padring_i,
+
+  // USB breakouts for bronze
+  output logic usb_input_en_o,
+  output logic usb_pullup_p_en_o,
+  output logic usb_pullup_n_en_o,
+  input  logic usb_diff_input_i
 );
 
   // Note that we do not tie off the enable signal, since it
@@ -56,6 +67,11 @@ module jtag_mux #(
   for (genvar k = 0; k < NumIOs; k++) begin : gen_input_tie_off
     if (k inside {TckIdx, TmsIdx, TrstIdx, SrstIdx, TdiIdx, TdoIdx}) begin : gen_jtag_signal
       assign in_core_o[k] = (jtag_en) ? TieOffValues[k] : in_padring_i[k];
+
+    end else if (k == UsbDIdx) begin : gen_usb_diff_in
+      logic unused_in;
+      assign unused_in = in_padring_i[k];
+      assign in_core_o[k] = usb_diff_input_i;
     end else begin : gen_other_inputs
       assign in_core_o[k] = in_padring_i[k];
     end
@@ -71,6 +87,11 @@ module jtag_mux #(
       assign oe_padring_o[k]  = oe_core_i[k];
     end
   end
+
+  // Other USB output taps for Bronze
+  assign usb_input_en_o    = out_core_i[UsbDieIdx]  & oe_core_i[UsbDieIdx];
+  assign usb_pullup_p_en_o = out_core_i[UsbDpPuIdx] & oe_core_i[UsbDpPuIdx];
+  assign usb_pullup_n_en_o = out_core_i[UsbDnPuIdx] & oe_core_i[UsbDnPuIdx];
 
   ////////////////
   // Assertions //

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -43,6 +43,7 @@ module top_earlgrey #(
   input  ast_wrapper_pkg::ast_rst_t       rstmgr_aon_ast,
   output logic       usbdev_aon_usb_ref_pulse,
   output logic       usbdev_aon_usb_ref_val,
+  output logic       usbdev_aon_usb_rx_enable,
   output entropy_src_pkg::entropy_src_rng_req_t       entropy_src_entropy_src_rng_req,
   input  entropy_src_pkg::entropy_src_rng_rsp_t       entropy_src_entropy_src_rng_rsp,
   input  logic       clkmgr_aon_clk_main,
@@ -1561,6 +1562,7 @@ module top_earlgrey #(
       // Inter-module signals
       .usb_ref_val_o(usbdev_aon_usb_ref_val),
       .usb_ref_pulse_o(usbdev_aon_usb_ref_pulse),
+      .usb_rx_enable_o(usbdev_aon_usb_rx_enable),
       .clk_i (clkmgr_aon_clocks.clk_io_peri),
       .clk_usb_48mhz_i (clkmgr_aon_clocks.clk_usb_peri),
       .rst_ni (rstmgr_aon_resets.rst_sys_io_n),

--- a/hw/top_earlgrey/top_earlgrey_asic.core
+++ b/hw/top_earlgrey/top_earlgrey_asic.core
@@ -7,6 +7,7 @@ description: "Earl Grey toplevel for DV simulations"
 filesets:
   files_rtl:
     depend:
+      - lowrisc:prim:usb_diff_rx
       - lowrisc:systems:top_earlgrey:0.1
       - lowrisc:systems:ast
     files:


### PR DESCRIPTION
This adds a tech-dependent primitive for the differential USB receiver, and wires it up in `top_earlgrey_asic`. 
The differential receiver exposes an input enable, which is simply hooked up to the `rx_differential_mode` CSR within `usbdev` at the moment. Let me know if you think this should be wired up differently.

The generic view of the primitive is only meant to provide the timing paths from diff inputs and input enable to the output of the differential receiver. Nuvoton will replace this module with the actual analog design.

Note that the signal breakout within the `jtag_mux` is only a temporary workaround to get "manual" access to the DIO signals, since the differential receiver does not entirely fit the DIO/MIO model we currently have. This will be re-structured in the `pinmux`/`padctrl` overhaul after Bronze.

Also note that this module is not meant to be instantiated in the FPGA top. In the FPGA case, the differential receiver and pull-ups reside outside on a add-on PCB, and hence the corresponding signals are connected to FPGA ports.
