### PR TITLE
[top/pinout] Pinout finetuning

### DIFF
--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -7346,7 +7346,7 @@
   ]
   pinmux:
   {
-    num_mio: 47
+    num_mio: 44
     dio_modules:
     [
       {

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -575,7 +575,7 @@
     //  All the input/outputs from IPs are muxed in pinmux, and it has # of I/O
     //  talks to the outside of top_earlgrey.
     //  This field will be replaced to the length of PAD if padctrl is defined
-    num_mio: 47
+    num_mio: 44
 
     // Dedicated IO modules. The in/out ports of the modules below are connected
     //  to TOP IO port through PADS directly. It bypasses PINMUX multiplexers

--- a/hw/top_earlgrey/ip/padctrl/data/autogen/padctrl.hjson
+++ b/hw/top_earlgrey/ip/padctrl/data/autogen/padctrl.hjson
@@ -31,7 +31,7 @@
     { name: "NMioPads",
       desc: "Number of muxed IO pads",
       type: "int",
-      default: "47",
+      default: "44",
       local: "true"
     },
     { name: "AttrDw",

--- a/hw/top_earlgrey/ip/padctrl/rtl/autogen/padctrl_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/padctrl/rtl/autogen/padctrl_reg_pkg.sv
@@ -8,7 +8,7 @@ package padctrl_reg_pkg;
 
   // Param list
   parameter int NDioPads = 21;
-  parameter int NMioPads = 47;
+  parameter int NMioPads = 44;
   parameter int AttrDw = 10;
 
   ////////////////////////////
@@ -38,16 +38,16 @@ package padctrl_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    padctrl_reg2hw_dio_pads_mreg_t [20:0] dio_pads; // [747:517]
-    padctrl_reg2hw_mio_pads_mreg_t [46:0] mio_pads; // [516:0]
+    padctrl_reg2hw_dio_pads_mreg_t [20:0] dio_pads; // [714:484]
+    padctrl_reg2hw_mio_pads_mreg_t [43:0] mio_pads; // [483:0]
   } padctrl_reg2hw_t;
 
   ///////////////////////////////////////
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    padctrl_hw2reg_dio_pads_mreg_t [20:0] dio_pads; // [679:470]
-    padctrl_hw2reg_mio_pads_mreg_t [46:0] mio_pads; // [469:0]
+    padctrl_hw2reg_dio_pads_mreg_t [20:0] dio_pads; // [649:440]
+    padctrl_hw2reg_mio_pads_mreg_t [43:0] mio_pads; // [439:0]
   } padctrl_hw2reg_t;
 
   // Register Address
@@ -74,7 +74,6 @@ package padctrl_reg_pkg;
   parameter logic [6:0] PADCTRL_MIO_PADS12_OFFSET = 7'h 50;
   parameter logic [6:0] PADCTRL_MIO_PADS13_OFFSET = 7'h 54;
   parameter logic [6:0] PADCTRL_MIO_PADS14_OFFSET = 7'h 58;
-  parameter logic [6:0] PADCTRL_MIO_PADS15_OFFSET = 7'h 5c;
 
 
   // Register Index
@@ -101,12 +100,11 @@ package padctrl_reg_pkg;
     PADCTRL_MIO_PADS11,
     PADCTRL_MIO_PADS12,
     PADCTRL_MIO_PADS13,
-    PADCTRL_MIO_PADS14,
-    PADCTRL_MIO_PADS15
+    PADCTRL_MIO_PADS14
   } padctrl_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] PADCTRL_PERMIT [24] = '{
+  parameter logic [3:0] PADCTRL_PERMIT [23] = '{
     4'b 0001, // index[ 0] PADCTRL_REGEN
     4'b 1111, // index[ 1] PADCTRL_DIO_PADS0
     4'b 1111, // index[ 2] PADCTRL_DIO_PADS1
@@ -129,8 +127,7 @@ package padctrl_reg_pkg;
     4'b 1111, // index[19] PADCTRL_MIO_PADS11
     4'b 1111, // index[20] PADCTRL_MIO_PADS12
     4'b 1111, // index[21] PADCTRL_MIO_PADS13
-    4'b 1111, // index[22] PADCTRL_MIO_PADS14
-    4'b 0111  // index[23] PADCTRL_MIO_PADS15
+    4'b 0111  // index[22] PADCTRL_MIO_PADS14
   };
 endpackage
 

--- a/hw/top_earlgrey/ip/padctrl/rtl/autogen/padctrl_reg_top.sv
+++ b/hw/top_earlgrey/ip/padctrl/rtl/autogen/padctrl_reg_top.sv
@@ -334,18 +334,6 @@ module padctrl_reg_top (
   logic [9:0] mio_pads14_attr43_wd;
   logic mio_pads14_attr43_we;
   logic mio_pads14_attr43_re;
-  logic [9:0] mio_pads14_attr44_qs;
-  logic [9:0] mio_pads14_attr44_wd;
-  logic mio_pads14_attr44_we;
-  logic mio_pads14_attr44_re;
-  logic [9:0] mio_pads15_attr45_qs;
-  logic [9:0] mio_pads15_attr45_wd;
-  logic mio_pads15_attr45_we;
-  logic mio_pads15_attr45_re;
-  logic [9:0] mio_pads15_attr46_qs;
-  logic [9:0] mio_pads15_attr46_wd;
-  logic mio_pads15_attr46_we;
-  logic mio_pads15_attr46_re;
 
   // Register instances
   // R[regen]: V(False)
@@ -1484,61 +1472,10 @@ module padctrl_reg_top (
   );
 
 
-  // F[attr44]: 29:20
-  prim_subreg_ext #(
-    .DW    (10)
-  ) u_mio_pads14_attr44 (
-    .re     (mio_pads14_attr44_re),
-    // qualified with register enable
-    .we     (mio_pads14_attr44_we & regen_qs),
-    .wd     (mio_pads14_attr44_wd),
-    .d      (hw2reg.mio_pads[44].d),
-    .qre    (),
-    .qe     (reg2hw.mio_pads[44].qe),
-    .q      (reg2hw.mio_pads[44].q ),
-    .qs     (mio_pads14_attr44_qs)
-  );
-
-
-  // Subregister 45 of Multireg mio_pads
-  // R[mio_pads15]: V(True)
-
-  // F[attr45]: 9:0
-  prim_subreg_ext #(
-    .DW    (10)
-  ) u_mio_pads15_attr45 (
-    .re     (mio_pads15_attr45_re),
-    // qualified with register enable
-    .we     (mio_pads15_attr45_we & regen_qs),
-    .wd     (mio_pads15_attr45_wd),
-    .d      (hw2reg.mio_pads[45].d),
-    .qre    (),
-    .qe     (reg2hw.mio_pads[45].qe),
-    .q      (reg2hw.mio_pads[45].q ),
-    .qs     (mio_pads15_attr45_qs)
-  );
-
-
-  // F[attr46]: 19:10
-  prim_subreg_ext #(
-    .DW    (10)
-  ) u_mio_pads15_attr46 (
-    .re     (mio_pads15_attr46_re),
-    // qualified with register enable
-    .we     (mio_pads15_attr46_we & regen_qs),
-    .wd     (mio_pads15_attr46_wd),
-    .d      (hw2reg.mio_pads[46].d),
-    .qre    (),
-    .qe     (reg2hw.mio_pads[46].qe),
-    .q      (reg2hw.mio_pads[46].q ),
-    .qs     (mio_pads15_attr46_qs)
-  );
 
 
 
-
-
-  logic [23:0] addr_hit;
+  logic [22:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == PADCTRL_REGEN_OFFSET);
@@ -1564,7 +1501,6 @@ module padctrl_reg_top (
     addr_hit[20] = (reg_addr == PADCTRL_MIO_PADS12_OFFSET);
     addr_hit[21] = (reg_addr == PADCTRL_MIO_PADS13_OFFSET);
     addr_hit[22] = (reg_addr == PADCTRL_MIO_PADS14_OFFSET);
-    addr_hit[23] = (reg_addr == PADCTRL_MIO_PADS15_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -1595,7 +1531,6 @@ module padctrl_reg_top (
     if (addr_hit[20] && reg_we && (PADCTRL_PERMIT[20] != (PADCTRL_PERMIT[20] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[21] && reg_we && (PADCTRL_PERMIT[21] != (PADCTRL_PERMIT[21] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[22] && reg_we && (PADCTRL_PERMIT[22] != (PADCTRL_PERMIT[22] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[23] && reg_we && (PADCTRL_PERMIT[23] != (PADCTRL_PERMIT[23] & reg_be))) wr_err = 1'b1 ;
   end
 
   assign regen_we = addr_hit[0] & reg_we & ~wr_err;
@@ -1861,18 +1796,6 @@ module padctrl_reg_top (
   assign mio_pads14_attr43_wd = reg_wdata[19:10];
   assign mio_pads14_attr43_re = addr_hit[22] && reg_re;
 
-  assign mio_pads14_attr44_we = addr_hit[22] & reg_we & ~wr_err;
-  assign mio_pads14_attr44_wd = reg_wdata[29:20];
-  assign mio_pads14_attr44_re = addr_hit[22] && reg_re;
-
-  assign mio_pads15_attr45_we = addr_hit[23] & reg_we & ~wr_err;
-  assign mio_pads15_attr45_wd = reg_wdata[9:0];
-  assign mio_pads15_attr45_re = addr_hit[23] && reg_re;
-
-  assign mio_pads15_attr46_we = addr_hit[23] & reg_we & ~wr_err;
-  assign mio_pads15_attr46_wd = reg_wdata[19:10];
-  assign mio_pads15_attr46_re = addr_hit[23] && reg_re;
-
   // Read data return
   always_comb begin
     reg_rdata_next = '0;
@@ -2010,12 +1933,6 @@ module padctrl_reg_top (
       addr_hit[22]: begin
         reg_rdata_next[9:0] = mio_pads14_attr42_qs;
         reg_rdata_next[19:10] = mio_pads14_attr43_qs;
-        reg_rdata_next[29:20] = mio_pads14_attr44_qs;
-      end
-
-      addr_hit[23]: begin
-        reg_rdata_next[9:0] = mio_pads15_attr45_qs;
-        reg_rdata_next[19:10] = mio_pads15_attr46_qs;
       end
 
       default: begin

--- a/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
+++ b/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
@@ -100,7 +100,7 @@
     { name: "NMioPads",
       desc: "Number of muxed IO pads",
       type: "int",
-      default: "47",
+      default: "44",
       local: "true"
     },
     { name: "NDioPads",

--- a/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_pkg.sv
@@ -9,7 +9,7 @@ package pinmux_reg_pkg;
   // Param list
   parameter int NMioPeriphIn = 52;
   parameter int NMioPeriphOut = 65;
-  parameter int NMioPads = 47;
+  parameter int NMioPads = 44;
   parameter int NDioPads = 21;
   parameter int NWkupDetect = 8;
   parameter int WkupCntWidth = 8;
@@ -77,9 +77,9 @@ package pinmux_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    pinmux_reg2hw_periph_insel_mreg_t [51:0] periph_insel; // [973:662]
-    pinmux_reg2hw_mio_outsel_mreg_t [46:0] mio_outsel; // [661:333]
-    pinmux_reg2hw_mio_out_sleep_val_mreg_t [46:0] mio_out_sleep_val; // [332:239]
+    pinmux_reg2hw_periph_insel_mreg_t [51:0] periph_insel; // [946:635]
+    pinmux_reg2hw_mio_outsel_mreg_t [43:0] mio_outsel; // [634:327]
+    pinmux_reg2hw_mio_out_sleep_val_mreg_t [43:0] mio_out_sleep_val; // [326:239]
     pinmux_reg2hw_dio_out_sleep_val_mreg_t [20:0] dio_out_sleep_val; // [238:176]
     pinmux_reg2hw_wkup_detector_en_mreg_t [7:0] wkup_detector_en; // [175:168]
     pinmux_reg2hw_wkup_detector_mreg_t [7:0] wkup_detector; // [167:128]
@@ -120,26 +120,25 @@ package pinmux_reg_pkg;
   parameter logic [7:0] PINMUX_MIO_OUTSEL8_OFFSET = 8'h 50;
   parameter logic [7:0] PINMUX_MIO_OUTSEL9_OFFSET = 8'h 54;
   parameter logic [7:0] PINMUX_MIO_OUTSEL10_OFFSET = 8'h 58;
-  parameter logic [7:0] PINMUX_MIO_OUTSEL11_OFFSET = 8'h 5c;
-  parameter logic [7:0] PINMUX_MIO_OUT_SLEEP_VAL0_OFFSET = 8'h 60;
-  parameter logic [7:0] PINMUX_MIO_OUT_SLEEP_VAL1_OFFSET = 8'h 64;
-  parameter logic [7:0] PINMUX_MIO_OUT_SLEEP_VAL2_OFFSET = 8'h 68;
-  parameter logic [7:0] PINMUX_DIO_OUT_SLEEP_VAL0_OFFSET = 8'h 6c;
-  parameter logic [7:0] PINMUX_DIO_OUT_SLEEP_VAL1_OFFSET = 8'h 70;
-  parameter logic [7:0] PINMUX_WKUP_DETECTOR_EN_OFFSET = 8'h 74;
-  parameter logic [7:0] PINMUX_WKUP_DETECTOR0_OFFSET = 8'h 78;
-  parameter logic [7:0] PINMUX_WKUP_DETECTOR1_OFFSET = 8'h 7c;
-  parameter logic [7:0] PINMUX_WKUP_DETECTOR2_OFFSET = 8'h 80;
-  parameter logic [7:0] PINMUX_WKUP_DETECTOR3_OFFSET = 8'h 84;
-  parameter logic [7:0] PINMUX_WKUP_DETECTOR4_OFFSET = 8'h 88;
-  parameter logic [7:0] PINMUX_WKUP_DETECTOR5_OFFSET = 8'h 8c;
-  parameter logic [7:0] PINMUX_WKUP_DETECTOR6_OFFSET = 8'h 90;
-  parameter logic [7:0] PINMUX_WKUP_DETECTOR7_OFFSET = 8'h 94;
-  parameter logic [7:0] PINMUX_WKUP_DETECTOR_CNT_TH0_OFFSET = 8'h 98;
-  parameter logic [7:0] PINMUX_WKUP_DETECTOR_CNT_TH1_OFFSET = 8'h 9c;
-  parameter logic [7:0] PINMUX_WKUP_DETECTOR_PADSEL0_OFFSET = 8'h a0;
-  parameter logic [7:0] PINMUX_WKUP_DETECTOR_PADSEL1_OFFSET = 8'h a4;
-  parameter logic [7:0] PINMUX_WKUP_CAUSE_OFFSET = 8'h a8;
+  parameter logic [7:0] PINMUX_MIO_OUT_SLEEP_VAL0_OFFSET = 8'h 5c;
+  parameter logic [7:0] PINMUX_MIO_OUT_SLEEP_VAL1_OFFSET = 8'h 60;
+  parameter logic [7:0] PINMUX_MIO_OUT_SLEEP_VAL2_OFFSET = 8'h 64;
+  parameter logic [7:0] PINMUX_DIO_OUT_SLEEP_VAL0_OFFSET = 8'h 68;
+  parameter logic [7:0] PINMUX_DIO_OUT_SLEEP_VAL1_OFFSET = 8'h 6c;
+  parameter logic [7:0] PINMUX_WKUP_DETECTOR_EN_OFFSET = 8'h 70;
+  parameter logic [7:0] PINMUX_WKUP_DETECTOR0_OFFSET = 8'h 74;
+  parameter logic [7:0] PINMUX_WKUP_DETECTOR1_OFFSET = 8'h 78;
+  parameter logic [7:0] PINMUX_WKUP_DETECTOR2_OFFSET = 8'h 7c;
+  parameter logic [7:0] PINMUX_WKUP_DETECTOR3_OFFSET = 8'h 80;
+  parameter logic [7:0] PINMUX_WKUP_DETECTOR4_OFFSET = 8'h 84;
+  parameter logic [7:0] PINMUX_WKUP_DETECTOR5_OFFSET = 8'h 88;
+  parameter logic [7:0] PINMUX_WKUP_DETECTOR6_OFFSET = 8'h 8c;
+  parameter logic [7:0] PINMUX_WKUP_DETECTOR7_OFFSET = 8'h 90;
+  parameter logic [7:0] PINMUX_WKUP_DETECTOR_CNT_TH0_OFFSET = 8'h 94;
+  parameter logic [7:0] PINMUX_WKUP_DETECTOR_CNT_TH1_OFFSET = 8'h 98;
+  parameter logic [7:0] PINMUX_WKUP_DETECTOR_PADSEL0_OFFSET = 8'h 9c;
+  parameter logic [7:0] PINMUX_WKUP_DETECTOR_PADSEL1_OFFSET = 8'h a0;
+  parameter logic [7:0] PINMUX_WKUP_CAUSE_OFFSET = 8'h a4;
 
 
   // Register Index
@@ -167,7 +166,6 @@ package pinmux_reg_pkg;
     PINMUX_MIO_OUTSEL8,
     PINMUX_MIO_OUTSEL9,
     PINMUX_MIO_OUTSEL10,
-    PINMUX_MIO_OUTSEL11,
     PINMUX_MIO_OUT_SLEEP_VAL0,
     PINMUX_MIO_OUT_SLEEP_VAL1,
     PINMUX_MIO_OUT_SLEEP_VAL2,
@@ -190,7 +188,7 @@ package pinmux_reg_pkg;
   } pinmux_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] PINMUX_PERMIT [43] = '{
+  parameter logic [3:0] PINMUX_PERMIT [42] = '{
     4'b 0001, // index[ 0] PINMUX_REGEN
     4'b 1111, // index[ 1] PINMUX_PERIPH_INSEL0
     4'b 1111, // index[ 2] PINMUX_PERIPH_INSEL1
@@ -214,26 +212,25 @@ package pinmux_reg_pkg;
     4'b 1111, // index[20] PINMUX_MIO_OUTSEL8
     4'b 1111, // index[21] PINMUX_MIO_OUTSEL9
     4'b 1111, // index[22] PINMUX_MIO_OUTSEL10
-    4'b 0111, // index[23] PINMUX_MIO_OUTSEL11
-    4'b 1111, // index[24] PINMUX_MIO_OUT_SLEEP_VAL0
-    4'b 1111, // index[25] PINMUX_MIO_OUT_SLEEP_VAL1
-    4'b 1111, // index[26] PINMUX_MIO_OUT_SLEEP_VAL2
-    4'b 1111, // index[27] PINMUX_DIO_OUT_SLEEP_VAL0
-    4'b 0011, // index[28] PINMUX_DIO_OUT_SLEEP_VAL1
-    4'b 0001, // index[29] PINMUX_WKUP_DETECTOR_EN
-    4'b 0001, // index[30] PINMUX_WKUP_DETECTOR0
-    4'b 0001, // index[31] PINMUX_WKUP_DETECTOR1
-    4'b 0001, // index[32] PINMUX_WKUP_DETECTOR2
-    4'b 0001, // index[33] PINMUX_WKUP_DETECTOR3
-    4'b 0001, // index[34] PINMUX_WKUP_DETECTOR4
-    4'b 0001, // index[35] PINMUX_WKUP_DETECTOR5
-    4'b 0001, // index[36] PINMUX_WKUP_DETECTOR6
-    4'b 0001, // index[37] PINMUX_WKUP_DETECTOR7
-    4'b 1111, // index[38] PINMUX_WKUP_DETECTOR_CNT_TH0
-    4'b 1111, // index[39] PINMUX_WKUP_DETECTOR_CNT_TH1
-    4'b 1111, // index[40] PINMUX_WKUP_DETECTOR_PADSEL0
-    4'b 0111, // index[41] PINMUX_WKUP_DETECTOR_PADSEL1
-    4'b 0001  // index[42] PINMUX_WKUP_CAUSE
+    4'b 1111, // index[23] PINMUX_MIO_OUT_SLEEP_VAL0
+    4'b 1111, // index[24] PINMUX_MIO_OUT_SLEEP_VAL1
+    4'b 0111, // index[25] PINMUX_MIO_OUT_SLEEP_VAL2
+    4'b 1111, // index[26] PINMUX_DIO_OUT_SLEEP_VAL0
+    4'b 0011, // index[27] PINMUX_DIO_OUT_SLEEP_VAL1
+    4'b 0001, // index[28] PINMUX_WKUP_DETECTOR_EN
+    4'b 0001, // index[29] PINMUX_WKUP_DETECTOR0
+    4'b 0001, // index[30] PINMUX_WKUP_DETECTOR1
+    4'b 0001, // index[31] PINMUX_WKUP_DETECTOR2
+    4'b 0001, // index[32] PINMUX_WKUP_DETECTOR3
+    4'b 0001, // index[33] PINMUX_WKUP_DETECTOR4
+    4'b 0001, // index[34] PINMUX_WKUP_DETECTOR5
+    4'b 0001, // index[35] PINMUX_WKUP_DETECTOR6
+    4'b 0001, // index[36] PINMUX_WKUP_DETECTOR7
+    4'b 1111, // index[37] PINMUX_WKUP_DETECTOR_CNT_TH0
+    4'b 1111, // index[38] PINMUX_WKUP_DETECTOR_CNT_TH1
+    4'b 1111, // index[39] PINMUX_WKUP_DETECTOR_PADSEL0
+    4'b 0111, // index[40] PINMUX_WKUP_DETECTOR_PADSEL1
+    4'b 0001  // index[41] PINMUX_WKUP_CAUSE
   };
 endpackage
 

--- a/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_top.sv
+++ b/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_top.sv
@@ -362,15 +362,6 @@ module pinmux_reg_top (
   logic [6:0] mio_outsel10_out43_qs;
   logic [6:0] mio_outsel10_out43_wd;
   logic mio_outsel10_out43_we;
-  logic [6:0] mio_outsel11_out44_qs;
-  logic [6:0] mio_outsel11_out44_wd;
-  logic mio_outsel11_out44_we;
-  logic [6:0] mio_outsel11_out45_qs;
-  logic [6:0] mio_outsel11_out45_wd;
-  logic mio_outsel11_out45_we;
-  logic [6:0] mio_outsel11_out46_qs;
-  logic [6:0] mio_outsel11_out46_wd;
-  logic mio_outsel11_out46_we;
   logic [1:0] mio_out_sleep_val0_out0_qs;
   logic [1:0] mio_out_sleep_val0_out0_wd;
   logic mio_out_sleep_val0_out0_we;
@@ -503,15 +494,6 @@ module pinmux_reg_top (
   logic [1:0] mio_out_sleep_val2_out43_qs;
   logic [1:0] mio_out_sleep_val2_out43_wd;
   logic mio_out_sleep_val2_out43_we;
-  logic [1:0] mio_out_sleep_val2_out44_qs;
-  logic [1:0] mio_out_sleep_val2_out44_wd;
-  logic mio_out_sleep_val2_out44_we;
-  logic [1:0] mio_out_sleep_val2_out45_qs;
-  logic [1:0] mio_out_sleep_val2_out45_wd;
-  logic mio_out_sleep_val2_out45_we;
-  logic [1:0] mio_out_sleep_val2_out46_qs;
-  logic [1:0] mio_out_sleep_val2_out46_wd;
-  logic mio_out_sleep_val2_out46_we;
   logic [1:0] dio_out_sleep_val0_out0_qs;
   logic [1:0] dio_out_sleep_val0_out0_wd;
   logic dio_out_sleep_val0_out0_we;
@@ -3366,87 +3348,6 @@ module pinmux_reg_top (
   );
 
 
-  // Subregister 44 of Multireg mio_outsel
-  // R[mio_outsel11]: V(False)
-
-  // F[out44]: 6:0
-  prim_subreg #(
-    .DW      (7),
-    .SWACCESS("RW"),
-    .RESVAL  (7'h2)
-  ) u_mio_outsel11_out44 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (mio_outsel11_out44_we & regen_qs),
-    .wd     (mio_outsel11_out44_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.mio_outsel[44].q ),
-
-    // to register interface (read)
-    .qs     (mio_outsel11_out44_qs)
-  );
-
-
-  // F[out45]: 13:7
-  prim_subreg #(
-    .DW      (7),
-    .SWACCESS("RW"),
-    .RESVAL  (7'h2)
-  ) u_mio_outsel11_out45 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (mio_outsel11_out45_we & regen_qs),
-    .wd     (mio_outsel11_out45_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.mio_outsel[45].q ),
-
-    // to register interface (read)
-    .qs     (mio_outsel11_out45_qs)
-  );
-
-
-  // F[out46]: 20:14
-  prim_subreg #(
-    .DW      (7),
-    .SWACCESS("RW"),
-    .RESVAL  (7'h2)
-  ) u_mio_outsel11_out46 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (mio_outsel11_out46_we & regen_qs),
-    .wd     (mio_outsel11_out46_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.mio_outsel[46].q ),
-
-    // to register interface (read)
-    .qs     (mio_outsel11_out46_qs)
-  );
-
-
 
 
   // Subregister 0 of Multireg mio_out_sleep_val
@@ -4599,84 +4500,6 @@ module pinmux_reg_top (
 
     // to register interface (read)
     .qs     (mio_out_sleep_val2_out43_qs)
-  );
-
-
-  // F[out44]: 25:24
-  prim_subreg #(
-    .DW      (2),
-    .SWACCESS("RW"),
-    .RESVAL  (2'h2)
-  ) u_mio_out_sleep_val2_out44 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val2_out44_we & regen_qs),
-    .wd     (mio_out_sleep_val2_out44_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.mio_out_sleep_val[44].q ),
-
-    // to register interface (read)
-    .qs     (mio_out_sleep_val2_out44_qs)
-  );
-
-
-  // F[out45]: 27:26
-  prim_subreg #(
-    .DW      (2),
-    .SWACCESS("RW"),
-    .RESVAL  (2'h2)
-  ) u_mio_out_sleep_val2_out45 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val2_out45_we & regen_qs),
-    .wd     (mio_out_sleep_val2_out45_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.mio_out_sleep_val[45].q ),
-
-    // to register interface (read)
-    .qs     (mio_out_sleep_val2_out45_qs)
-  );
-
-
-  // F[out46]: 29:28
-  prim_subreg #(
-    .DW      (2),
-    .SWACCESS("RW"),
-    .RESVAL  (2'h2)
-  ) u_mio_out_sleep_val2_out46 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (mio_out_sleep_val2_out46_we & regen_qs),
-    .wd     (mio_out_sleep_val2_out46_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.mio_out_sleep_val[46].q ),
-
-    // to register interface (read)
-    .qs     (mio_out_sleep_val2_out46_qs)
   );
 
 
@@ -6455,7 +6278,7 @@ module pinmux_reg_top (
 
 
 
-  logic [42:0] addr_hit;
+  logic [41:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == PINMUX_REGEN_OFFSET);
@@ -6481,26 +6304,25 @@ module pinmux_reg_top (
     addr_hit[20] = (reg_addr == PINMUX_MIO_OUTSEL8_OFFSET);
     addr_hit[21] = (reg_addr == PINMUX_MIO_OUTSEL9_OFFSET);
     addr_hit[22] = (reg_addr == PINMUX_MIO_OUTSEL10_OFFSET);
-    addr_hit[23] = (reg_addr == PINMUX_MIO_OUTSEL11_OFFSET);
-    addr_hit[24] = (reg_addr == PINMUX_MIO_OUT_SLEEP_VAL0_OFFSET);
-    addr_hit[25] = (reg_addr == PINMUX_MIO_OUT_SLEEP_VAL1_OFFSET);
-    addr_hit[26] = (reg_addr == PINMUX_MIO_OUT_SLEEP_VAL2_OFFSET);
-    addr_hit[27] = (reg_addr == PINMUX_DIO_OUT_SLEEP_VAL0_OFFSET);
-    addr_hit[28] = (reg_addr == PINMUX_DIO_OUT_SLEEP_VAL1_OFFSET);
-    addr_hit[29] = (reg_addr == PINMUX_WKUP_DETECTOR_EN_OFFSET);
-    addr_hit[30] = (reg_addr == PINMUX_WKUP_DETECTOR0_OFFSET);
-    addr_hit[31] = (reg_addr == PINMUX_WKUP_DETECTOR1_OFFSET);
-    addr_hit[32] = (reg_addr == PINMUX_WKUP_DETECTOR2_OFFSET);
-    addr_hit[33] = (reg_addr == PINMUX_WKUP_DETECTOR3_OFFSET);
-    addr_hit[34] = (reg_addr == PINMUX_WKUP_DETECTOR4_OFFSET);
-    addr_hit[35] = (reg_addr == PINMUX_WKUP_DETECTOR5_OFFSET);
-    addr_hit[36] = (reg_addr == PINMUX_WKUP_DETECTOR6_OFFSET);
-    addr_hit[37] = (reg_addr == PINMUX_WKUP_DETECTOR7_OFFSET);
-    addr_hit[38] = (reg_addr == PINMUX_WKUP_DETECTOR_CNT_TH0_OFFSET);
-    addr_hit[39] = (reg_addr == PINMUX_WKUP_DETECTOR_CNT_TH1_OFFSET);
-    addr_hit[40] = (reg_addr == PINMUX_WKUP_DETECTOR_PADSEL0_OFFSET);
-    addr_hit[41] = (reg_addr == PINMUX_WKUP_DETECTOR_PADSEL1_OFFSET);
-    addr_hit[42] = (reg_addr == PINMUX_WKUP_CAUSE_OFFSET);
+    addr_hit[23] = (reg_addr == PINMUX_MIO_OUT_SLEEP_VAL0_OFFSET);
+    addr_hit[24] = (reg_addr == PINMUX_MIO_OUT_SLEEP_VAL1_OFFSET);
+    addr_hit[25] = (reg_addr == PINMUX_MIO_OUT_SLEEP_VAL2_OFFSET);
+    addr_hit[26] = (reg_addr == PINMUX_DIO_OUT_SLEEP_VAL0_OFFSET);
+    addr_hit[27] = (reg_addr == PINMUX_DIO_OUT_SLEEP_VAL1_OFFSET);
+    addr_hit[28] = (reg_addr == PINMUX_WKUP_DETECTOR_EN_OFFSET);
+    addr_hit[29] = (reg_addr == PINMUX_WKUP_DETECTOR0_OFFSET);
+    addr_hit[30] = (reg_addr == PINMUX_WKUP_DETECTOR1_OFFSET);
+    addr_hit[31] = (reg_addr == PINMUX_WKUP_DETECTOR2_OFFSET);
+    addr_hit[32] = (reg_addr == PINMUX_WKUP_DETECTOR3_OFFSET);
+    addr_hit[33] = (reg_addr == PINMUX_WKUP_DETECTOR4_OFFSET);
+    addr_hit[34] = (reg_addr == PINMUX_WKUP_DETECTOR5_OFFSET);
+    addr_hit[35] = (reg_addr == PINMUX_WKUP_DETECTOR6_OFFSET);
+    addr_hit[36] = (reg_addr == PINMUX_WKUP_DETECTOR7_OFFSET);
+    addr_hit[37] = (reg_addr == PINMUX_WKUP_DETECTOR_CNT_TH0_OFFSET);
+    addr_hit[38] = (reg_addr == PINMUX_WKUP_DETECTOR_CNT_TH1_OFFSET);
+    addr_hit[39] = (reg_addr == PINMUX_WKUP_DETECTOR_PADSEL0_OFFSET);
+    addr_hit[40] = (reg_addr == PINMUX_WKUP_DETECTOR_PADSEL1_OFFSET);
+    addr_hit[41] = (reg_addr == PINMUX_WKUP_CAUSE_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -6550,7 +6372,6 @@ module pinmux_reg_top (
     if (addr_hit[39] && reg_we && (PINMUX_PERMIT[39] != (PINMUX_PERMIT[39] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[40] && reg_we && (PINMUX_PERMIT[40] != (PINMUX_PERMIT[40] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[41] && reg_we && (PINMUX_PERMIT[41] != (PINMUX_PERMIT[41] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[42] && reg_we && (PINMUX_PERMIT[42] != (PINMUX_PERMIT[42] & reg_be))) wr_err = 1'b1 ;
   end
 
   assign regen_we = addr_hit[0] & reg_we & ~wr_err;
@@ -6844,415 +6665,397 @@ module pinmux_reg_top (
   assign mio_outsel10_out43_we = addr_hit[22] & reg_we & ~wr_err;
   assign mio_outsel10_out43_wd = reg_wdata[27:21];
 
-  assign mio_outsel11_out44_we = addr_hit[23] & reg_we & ~wr_err;
-  assign mio_outsel11_out44_wd = reg_wdata[6:0];
-
-  assign mio_outsel11_out45_we = addr_hit[23] & reg_we & ~wr_err;
-  assign mio_outsel11_out45_wd = reg_wdata[13:7];
-
-  assign mio_outsel11_out46_we = addr_hit[23] & reg_we & ~wr_err;
-  assign mio_outsel11_out46_wd = reg_wdata[20:14];
-
-  assign mio_out_sleep_val0_out0_we = addr_hit[24] & reg_we & ~wr_err;
+  assign mio_out_sleep_val0_out0_we = addr_hit[23] & reg_we & ~wr_err;
   assign mio_out_sleep_val0_out0_wd = reg_wdata[1:0];
 
-  assign mio_out_sleep_val0_out1_we = addr_hit[24] & reg_we & ~wr_err;
+  assign mio_out_sleep_val0_out1_we = addr_hit[23] & reg_we & ~wr_err;
   assign mio_out_sleep_val0_out1_wd = reg_wdata[3:2];
 
-  assign mio_out_sleep_val0_out2_we = addr_hit[24] & reg_we & ~wr_err;
+  assign mio_out_sleep_val0_out2_we = addr_hit[23] & reg_we & ~wr_err;
   assign mio_out_sleep_val0_out2_wd = reg_wdata[5:4];
 
-  assign mio_out_sleep_val0_out3_we = addr_hit[24] & reg_we & ~wr_err;
+  assign mio_out_sleep_val0_out3_we = addr_hit[23] & reg_we & ~wr_err;
   assign mio_out_sleep_val0_out3_wd = reg_wdata[7:6];
 
-  assign mio_out_sleep_val0_out4_we = addr_hit[24] & reg_we & ~wr_err;
+  assign mio_out_sleep_val0_out4_we = addr_hit[23] & reg_we & ~wr_err;
   assign mio_out_sleep_val0_out4_wd = reg_wdata[9:8];
 
-  assign mio_out_sleep_val0_out5_we = addr_hit[24] & reg_we & ~wr_err;
+  assign mio_out_sleep_val0_out5_we = addr_hit[23] & reg_we & ~wr_err;
   assign mio_out_sleep_val0_out5_wd = reg_wdata[11:10];
 
-  assign mio_out_sleep_val0_out6_we = addr_hit[24] & reg_we & ~wr_err;
+  assign mio_out_sleep_val0_out6_we = addr_hit[23] & reg_we & ~wr_err;
   assign mio_out_sleep_val0_out6_wd = reg_wdata[13:12];
 
-  assign mio_out_sleep_val0_out7_we = addr_hit[24] & reg_we & ~wr_err;
+  assign mio_out_sleep_val0_out7_we = addr_hit[23] & reg_we & ~wr_err;
   assign mio_out_sleep_val0_out7_wd = reg_wdata[15:14];
 
-  assign mio_out_sleep_val0_out8_we = addr_hit[24] & reg_we & ~wr_err;
+  assign mio_out_sleep_val0_out8_we = addr_hit[23] & reg_we & ~wr_err;
   assign mio_out_sleep_val0_out8_wd = reg_wdata[17:16];
 
-  assign mio_out_sleep_val0_out9_we = addr_hit[24] & reg_we & ~wr_err;
+  assign mio_out_sleep_val0_out9_we = addr_hit[23] & reg_we & ~wr_err;
   assign mio_out_sleep_val0_out9_wd = reg_wdata[19:18];
 
-  assign mio_out_sleep_val0_out10_we = addr_hit[24] & reg_we & ~wr_err;
+  assign mio_out_sleep_val0_out10_we = addr_hit[23] & reg_we & ~wr_err;
   assign mio_out_sleep_val0_out10_wd = reg_wdata[21:20];
 
-  assign mio_out_sleep_val0_out11_we = addr_hit[24] & reg_we & ~wr_err;
+  assign mio_out_sleep_val0_out11_we = addr_hit[23] & reg_we & ~wr_err;
   assign mio_out_sleep_val0_out11_wd = reg_wdata[23:22];
 
-  assign mio_out_sleep_val0_out12_we = addr_hit[24] & reg_we & ~wr_err;
+  assign mio_out_sleep_val0_out12_we = addr_hit[23] & reg_we & ~wr_err;
   assign mio_out_sleep_val0_out12_wd = reg_wdata[25:24];
 
-  assign mio_out_sleep_val0_out13_we = addr_hit[24] & reg_we & ~wr_err;
+  assign mio_out_sleep_val0_out13_we = addr_hit[23] & reg_we & ~wr_err;
   assign mio_out_sleep_val0_out13_wd = reg_wdata[27:26];
 
-  assign mio_out_sleep_val0_out14_we = addr_hit[24] & reg_we & ~wr_err;
+  assign mio_out_sleep_val0_out14_we = addr_hit[23] & reg_we & ~wr_err;
   assign mio_out_sleep_val0_out14_wd = reg_wdata[29:28];
 
-  assign mio_out_sleep_val0_out15_we = addr_hit[24] & reg_we & ~wr_err;
+  assign mio_out_sleep_val0_out15_we = addr_hit[23] & reg_we & ~wr_err;
   assign mio_out_sleep_val0_out15_wd = reg_wdata[31:30];
 
-  assign mio_out_sleep_val1_out16_we = addr_hit[25] & reg_we & ~wr_err;
+  assign mio_out_sleep_val1_out16_we = addr_hit[24] & reg_we & ~wr_err;
   assign mio_out_sleep_val1_out16_wd = reg_wdata[1:0];
 
-  assign mio_out_sleep_val1_out17_we = addr_hit[25] & reg_we & ~wr_err;
+  assign mio_out_sleep_val1_out17_we = addr_hit[24] & reg_we & ~wr_err;
   assign mio_out_sleep_val1_out17_wd = reg_wdata[3:2];
 
-  assign mio_out_sleep_val1_out18_we = addr_hit[25] & reg_we & ~wr_err;
+  assign mio_out_sleep_val1_out18_we = addr_hit[24] & reg_we & ~wr_err;
   assign mio_out_sleep_val1_out18_wd = reg_wdata[5:4];
 
-  assign mio_out_sleep_val1_out19_we = addr_hit[25] & reg_we & ~wr_err;
+  assign mio_out_sleep_val1_out19_we = addr_hit[24] & reg_we & ~wr_err;
   assign mio_out_sleep_val1_out19_wd = reg_wdata[7:6];
 
-  assign mio_out_sleep_val1_out20_we = addr_hit[25] & reg_we & ~wr_err;
+  assign mio_out_sleep_val1_out20_we = addr_hit[24] & reg_we & ~wr_err;
   assign mio_out_sleep_val1_out20_wd = reg_wdata[9:8];
 
-  assign mio_out_sleep_val1_out21_we = addr_hit[25] & reg_we & ~wr_err;
+  assign mio_out_sleep_val1_out21_we = addr_hit[24] & reg_we & ~wr_err;
   assign mio_out_sleep_val1_out21_wd = reg_wdata[11:10];
 
-  assign mio_out_sleep_val1_out22_we = addr_hit[25] & reg_we & ~wr_err;
+  assign mio_out_sleep_val1_out22_we = addr_hit[24] & reg_we & ~wr_err;
   assign mio_out_sleep_val1_out22_wd = reg_wdata[13:12];
 
-  assign mio_out_sleep_val1_out23_we = addr_hit[25] & reg_we & ~wr_err;
+  assign mio_out_sleep_val1_out23_we = addr_hit[24] & reg_we & ~wr_err;
   assign mio_out_sleep_val1_out23_wd = reg_wdata[15:14];
 
-  assign mio_out_sleep_val1_out24_we = addr_hit[25] & reg_we & ~wr_err;
+  assign mio_out_sleep_val1_out24_we = addr_hit[24] & reg_we & ~wr_err;
   assign mio_out_sleep_val1_out24_wd = reg_wdata[17:16];
 
-  assign mio_out_sleep_val1_out25_we = addr_hit[25] & reg_we & ~wr_err;
+  assign mio_out_sleep_val1_out25_we = addr_hit[24] & reg_we & ~wr_err;
   assign mio_out_sleep_val1_out25_wd = reg_wdata[19:18];
 
-  assign mio_out_sleep_val1_out26_we = addr_hit[25] & reg_we & ~wr_err;
+  assign mio_out_sleep_val1_out26_we = addr_hit[24] & reg_we & ~wr_err;
   assign mio_out_sleep_val1_out26_wd = reg_wdata[21:20];
 
-  assign mio_out_sleep_val1_out27_we = addr_hit[25] & reg_we & ~wr_err;
+  assign mio_out_sleep_val1_out27_we = addr_hit[24] & reg_we & ~wr_err;
   assign mio_out_sleep_val1_out27_wd = reg_wdata[23:22];
 
-  assign mio_out_sleep_val1_out28_we = addr_hit[25] & reg_we & ~wr_err;
+  assign mio_out_sleep_val1_out28_we = addr_hit[24] & reg_we & ~wr_err;
   assign mio_out_sleep_val1_out28_wd = reg_wdata[25:24];
 
-  assign mio_out_sleep_val1_out29_we = addr_hit[25] & reg_we & ~wr_err;
+  assign mio_out_sleep_val1_out29_we = addr_hit[24] & reg_we & ~wr_err;
   assign mio_out_sleep_val1_out29_wd = reg_wdata[27:26];
 
-  assign mio_out_sleep_val1_out30_we = addr_hit[25] & reg_we & ~wr_err;
+  assign mio_out_sleep_val1_out30_we = addr_hit[24] & reg_we & ~wr_err;
   assign mio_out_sleep_val1_out30_wd = reg_wdata[29:28];
 
-  assign mio_out_sleep_val1_out31_we = addr_hit[25] & reg_we & ~wr_err;
+  assign mio_out_sleep_val1_out31_we = addr_hit[24] & reg_we & ~wr_err;
   assign mio_out_sleep_val1_out31_wd = reg_wdata[31:30];
 
-  assign mio_out_sleep_val2_out32_we = addr_hit[26] & reg_we & ~wr_err;
+  assign mio_out_sleep_val2_out32_we = addr_hit[25] & reg_we & ~wr_err;
   assign mio_out_sleep_val2_out32_wd = reg_wdata[1:0];
 
-  assign mio_out_sleep_val2_out33_we = addr_hit[26] & reg_we & ~wr_err;
+  assign mio_out_sleep_val2_out33_we = addr_hit[25] & reg_we & ~wr_err;
   assign mio_out_sleep_val2_out33_wd = reg_wdata[3:2];
 
-  assign mio_out_sleep_val2_out34_we = addr_hit[26] & reg_we & ~wr_err;
+  assign mio_out_sleep_val2_out34_we = addr_hit[25] & reg_we & ~wr_err;
   assign mio_out_sleep_val2_out34_wd = reg_wdata[5:4];
 
-  assign mio_out_sleep_val2_out35_we = addr_hit[26] & reg_we & ~wr_err;
+  assign mio_out_sleep_val2_out35_we = addr_hit[25] & reg_we & ~wr_err;
   assign mio_out_sleep_val2_out35_wd = reg_wdata[7:6];
 
-  assign mio_out_sleep_val2_out36_we = addr_hit[26] & reg_we & ~wr_err;
+  assign mio_out_sleep_val2_out36_we = addr_hit[25] & reg_we & ~wr_err;
   assign mio_out_sleep_val2_out36_wd = reg_wdata[9:8];
 
-  assign mio_out_sleep_val2_out37_we = addr_hit[26] & reg_we & ~wr_err;
+  assign mio_out_sleep_val2_out37_we = addr_hit[25] & reg_we & ~wr_err;
   assign mio_out_sleep_val2_out37_wd = reg_wdata[11:10];
 
-  assign mio_out_sleep_val2_out38_we = addr_hit[26] & reg_we & ~wr_err;
+  assign mio_out_sleep_val2_out38_we = addr_hit[25] & reg_we & ~wr_err;
   assign mio_out_sleep_val2_out38_wd = reg_wdata[13:12];
 
-  assign mio_out_sleep_val2_out39_we = addr_hit[26] & reg_we & ~wr_err;
+  assign mio_out_sleep_val2_out39_we = addr_hit[25] & reg_we & ~wr_err;
   assign mio_out_sleep_val2_out39_wd = reg_wdata[15:14];
 
-  assign mio_out_sleep_val2_out40_we = addr_hit[26] & reg_we & ~wr_err;
+  assign mio_out_sleep_val2_out40_we = addr_hit[25] & reg_we & ~wr_err;
   assign mio_out_sleep_val2_out40_wd = reg_wdata[17:16];
 
-  assign mio_out_sleep_val2_out41_we = addr_hit[26] & reg_we & ~wr_err;
+  assign mio_out_sleep_val2_out41_we = addr_hit[25] & reg_we & ~wr_err;
   assign mio_out_sleep_val2_out41_wd = reg_wdata[19:18];
 
-  assign mio_out_sleep_val2_out42_we = addr_hit[26] & reg_we & ~wr_err;
+  assign mio_out_sleep_val2_out42_we = addr_hit[25] & reg_we & ~wr_err;
   assign mio_out_sleep_val2_out42_wd = reg_wdata[21:20];
 
-  assign mio_out_sleep_val2_out43_we = addr_hit[26] & reg_we & ~wr_err;
+  assign mio_out_sleep_val2_out43_we = addr_hit[25] & reg_we & ~wr_err;
   assign mio_out_sleep_val2_out43_wd = reg_wdata[23:22];
 
-  assign mio_out_sleep_val2_out44_we = addr_hit[26] & reg_we & ~wr_err;
-  assign mio_out_sleep_val2_out44_wd = reg_wdata[25:24];
-
-  assign mio_out_sleep_val2_out45_we = addr_hit[26] & reg_we & ~wr_err;
-  assign mio_out_sleep_val2_out45_wd = reg_wdata[27:26];
-
-  assign mio_out_sleep_val2_out46_we = addr_hit[26] & reg_we & ~wr_err;
-  assign mio_out_sleep_val2_out46_wd = reg_wdata[29:28];
-
-  assign dio_out_sleep_val0_out0_we = addr_hit[27] & reg_we & ~wr_err;
+  assign dio_out_sleep_val0_out0_we = addr_hit[26] & reg_we & ~wr_err;
   assign dio_out_sleep_val0_out0_wd = reg_wdata[1:0];
-  assign dio_out_sleep_val0_out0_re = addr_hit[27] && reg_re;
+  assign dio_out_sleep_val0_out0_re = addr_hit[26] && reg_re;
 
-  assign dio_out_sleep_val0_out1_we = addr_hit[27] & reg_we & ~wr_err;
+  assign dio_out_sleep_val0_out1_we = addr_hit[26] & reg_we & ~wr_err;
   assign dio_out_sleep_val0_out1_wd = reg_wdata[3:2];
-  assign dio_out_sleep_val0_out1_re = addr_hit[27] && reg_re;
+  assign dio_out_sleep_val0_out1_re = addr_hit[26] && reg_re;
 
-  assign dio_out_sleep_val0_out2_we = addr_hit[27] & reg_we & ~wr_err;
+  assign dio_out_sleep_val0_out2_we = addr_hit[26] & reg_we & ~wr_err;
   assign dio_out_sleep_val0_out2_wd = reg_wdata[5:4];
-  assign dio_out_sleep_val0_out2_re = addr_hit[27] && reg_re;
+  assign dio_out_sleep_val0_out2_re = addr_hit[26] && reg_re;
 
-  assign dio_out_sleep_val0_out3_we = addr_hit[27] & reg_we & ~wr_err;
+  assign dio_out_sleep_val0_out3_we = addr_hit[26] & reg_we & ~wr_err;
   assign dio_out_sleep_val0_out3_wd = reg_wdata[7:6];
-  assign dio_out_sleep_val0_out3_re = addr_hit[27] && reg_re;
+  assign dio_out_sleep_val0_out3_re = addr_hit[26] && reg_re;
 
-  assign dio_out_sleep_val0_out4_we = addr_hit[27] & reg_we & ~wr_err;
+  assign dio_out_sleep_val0_out4_we = addr_hit[26] & reg_we & ~wr_err;
   assign dio_out_sleep_val0_out4_wd = reg_wdata[9:8];
-  assign dio_out_sleep_val0_out4_re = addr_hit[27] && reg_re;
+  assign dio_out_sleep_val0_out4_re = addr_hit[26] && reg_re;
 
-  assign dio_out_sleep_val0_out5_we = addr_hit[27] & reg_we & ~wr_err;
+  assign dio_out_sleep_val0_out5_we = addr_hit[26] & reg_we & ~wr_err;
   assign dio_out_sleep_val0_out5_wd = reg_wdata[11:10];
-  assign dio_out_sleep_val0_out5_re = addr_hit[27] && reg_re;
+  assign dio_out_sleep_val0_out5_re = addr_hit[26] && reg_re;
 
-  assign dio_out_sleep_val0_out6_we = addr_hit[27] & reg_we & ~wr_err;
+  assign dio_out_sleep_val0_out6_we = addr_hit[26] & reg_we & ~wr_err;
   assign dio_out_sleep_val0_out6_wd = reg_wdata[13:12];
-  assign dio_out_sleep_val0_out6_re = addr_hit[27] && reg_re;
+  assign dio_out_sleep_val0_out6_re = addr_hit[26] && reg_re;
 
-  assign dio_out_sleep_val0_out7_we = addr_hit[27] & reg_we & ~wr_err;
+  assign dio_out_sleep_val0_out7_we = addr_hit[26] & reg_we & ~wr_err;
   assign dio_out_sleep_val0_out7_wd = reg_wdata[15:14];
-  assign dio_out_sleep_val0_out7_re = addr_hit[27] && reg_re;
+  assign dio_out_sleep_val0_out7_re = addr_hit[26] && reg_re;
 
-  assign dio_out_sleep_val0_out8_we = addr_hit[27] & reg_we & ~wr_err;
+  assign dio_out_sleep_val0_out8_we = addr_hit[26] & reg_we & ~wr_err;
   assign dio_out_sleep_val0_out8_wd = reg_wdata[17:16];
-  assign dio_out_sleep_val0_out8_re = addr_hit[27] && reg_re;
+  assign dio_out_sleep_val0_out8_re = addr_hit[26] && reg_re;
 
-  assign dio_out_sleep_val0_out9_we = addr_hit[27] & reg_we & ~wr_err;
+  assign dio_out_sleep_val0_out9_we = addr_hit[26] & reg_we & ~wr_err;
   assign dio_out_sleep_val0_out9_wd = reg_wdata[19:18];
-  assign dio_out_sleep_val0_out9_re = addr_hit[27] && reg_re;
+  assign dio_out_sleep_val0_out9_re = addr_hit[26] && reg_re;
 
-  assign dio_out_sleep_val0_out10_we = addr_hit[27] & reg_we & ~wr_err;
+  assign dio_out_sleep_val0_out10_we = addr_hit[26] & reg_we & ~wr_err;
   assign dio_out_sleep_val0_out10_wd = reg_wdata[21:20];
-  assign dio_out_sleep_val0_out10_re = addr_hit[27] && reg_re;
+  assign dio_out_sleep_val0_out10_re = addr_hit[26] && reg_re;
 
-  assign dio_out_sleep_val0_out11_we = addr_hit[27] & reg_we & ~wr_err;
+  assign dio_out_sleep_val0_out11_we = addr_hit[26] & reg_we & ~wr_err;
   assign dio_out_sleep_val0_out11_wd = reg_wdata[23:22];
-  assign dio_out_sleep_val0_out11_re = addr_hit[27] && reg_re;
+  assign dio_out_sleep_val0_out11_re = addr_hit[26] && reg_re;
 
-  assign dio_out_sleep_val0_out12_we = addr_hit[27] & reg_we & ~wr_err;
+  assign dio_out_sleep_val0_out12_we = addr_hit[26] & reg_we & ~wr_err;
   assign dio_out_sleep_val0_out12_wd = reg_wdata[25:24];
-  assign dio_out_sleep_val0_out12_re = addr_hit[27] && reg_re;
+  assign dio_out_sleep_val0_out12_re = addr_hit[26] && reg_re;
 
-  assign dio_out_sleep_val0_out13_we = addr_hit[27] & reg_we & ~wr_err;
+  assign dio_out_sleep_val0_out13_we = addr_hit[26] & reg_we & ~wr_err;
   assign dio_out_sleep_val0_out13_wd = reg_wdata[27:26];
-  assign dio_out_sleep_val0_out13_re = addr_hit[27] && reg_re;
+  assign dio_out_sleep_val0_out13_re = addr_hit[26] && reg_re;
 
-  assign dio_out_sleep_val0_out14_we = addr_hit[27] & reg_we & ~wr_err;
+  assign dio_out_sleep_val0_out14_we = addr_hit[26] & reg_we & ~wr_err;
   assign dio_out_sleep_val0_out14_wd = reg_wdata[29:28];
-  assign dio_out_sleep_val0_out14_re = addr_hit[27] && reg_re;
+  assign dio_out_sleep_val0_out14_re = addr_hit[26] && reg_re;
 
-  assign dio_out_sleep_val0_out15_we = addr_hit[27] & reg_we & ~wr_err;
+  assign dio_out_sleep_val0_out15_we = addr_hit[26] & reg_we & ~wr_err;
   assign dio_out_sleep_val0_out15_wd = reg_wdata[31:30];
-  assign dio_out_sleep_val0_out15_re = addr_hit[27] && reg_re;
+  assign dio_out_sleep_val0_out15_re = addr_hit[26] && reg_re;
 
-  assign dio_out_sleep_val1_out16_we = addr_hit[28] & reg_we & ~wr_err;
+  assign dio_out_sleep_val1_out16_we = addr_hit[27] & reg_we & ~wr_err;
   assign dio_out_sleep_val1_out16_wd = reg_wdata[1:0];
-  assign dio_out_sleep_val1_out16_re = addr_hit[28] && reg_re;
+  assign dio_out_sleep_val1_out16_re = addr_hit[27] && reg_re;
 
-  assign dio_out_sleep_val1_out17_we = addr_hit[28] & reg_we & ~wr_err;
+  assign dio_out_sleep_val1_out17_we = addr_hit[27] & reg_we & ~wr_err;
   assign dio_out_sleep_val1_out17_wd = reg_wdata[3:2];
-  assign dio_out_sleep_val1_out17_re = addr_hit[28] && reg_re;
+  assign dio_out_sleep_val1_out17_re = addr_hit[27] && reg_re;
 
-  assign dio_out_sleep_val1_out18_we = addr_hit[28] & reg_we & ~wr_err;
+  assign dio_out_sleep_val1_out18_we = addr_hit[27] & reg_we & ~wr_err;
   assign dio_out_sleep_val1_out18_wd = reg_wdata[5:4];
-  assign dio_out_sleep_val1_out18_re = addr_hit[28] && reg_re;
+  assign dio_out_sleep_val1_out18_re = addr_hit[27] && reg_re;
 
-  assign dio_out_sleep_val1_out19_we = addr_hit[28] & reg_we & ~wr_err;
+  assign dio_out_sleep_val1_out19_we = addr_hit[27] & reg_we & ~wr_err;
   assign dio_out_sleep_val1_out19_wd = reg_wdata[7:6];
-  assign dio_out_sleep_val1_out19_re = addr_hit[28] && reg_re;
+  assign dio_out_sleep_val1_out19_re = addr_hit[27] && reg_re;
 
-  assign dio_out_sleep_val1_out20_we = addr_hit[28] & reg_we & ~wr_err;
+  assign dio_out_sleep_val1_out20_we = addr_hit[27] & reg_we & ~wr_err;
   assign dio_out_sleep_val1_out20_wd = reg_wdata[9:8];
-  assign dio_out_sleep_val1_out20_re = addr_hit[28] && reg_re;
+  assign dio_out_sleep_val1_out20_re = addr_hit[27] && reg_re;
 
-  assign wkup_detector_en_en0_we = addr_hit[29] & reg_we & ~wr_err;
+  assign wkup_detector_en_en0_we = addr_hit[28] & reg_we & ~wr_err;
   assign wkup_detector_en_en0_wd = reg_wdata[0];
 
-  assign wkup_detector_en_en1_we = addr_hit[29] & reg_we & ~wr_err;
+  assign wkup_detector_en_en1_we = addr_hit[28] & reg_we & ~wr_err;
   assign wkup_detector_en_en1_wd = reg_wdata[1];
 
-  assign wkup_detector_en_en2_we = addr_hit[29] & reg_we & ~wr_err;
+  assign wkup_detector_en_en2_we = addr_hit[28] & reg_we & ~wr_err;
   assign wkup_detector_en_en2_wd = reg_wdata[2];
 
-  assign wkup_detector_en_en3_we = addr_hit[29] & reg_we & ~wr_err;
+  assign wkup_detector_en_en3_we = addr_hit[28] & reg_we & ~wr_err;
   assign wkup_detector_en_en3_wd = reg_wdata[3];
 
-  assign wkup_detector_en_en4_we = addr_hit[29] & reg_we & ~wr_err;
+  assign wkup_detector_en_en4_we = addr_hit[28] & reg_we & ~wr_err;
   assign wkup_detector_en_en4_wd = reg_wdata[4];
 
-  assign wkup_detector_en_en5_we = addr_hit[29] & reg_we & ~wr_err;
+  assign wkup_detector_en_en5_we = addr_hit[28] & reg_we & ~wr_err;
   assign wkup_detector_en_en5_wd = reg_wdata[5];
 
-  assign wkup_detector_en_en6_we = addr_hit[29] & reg_we & ~wr_err;
+  assign wkup_detector_en_en6_we = addr_hit[28] & reg_we & ~wr_err;
   assign wkup_detector_en_en6_wd = reg_wdata[6];
 
-  assign wkup_detector_en_en7_we = addr_hit[29] & reg_we & ~wr_err;
+  assign wkup_detector_en_en7_we = addr_hit[28] & reg_we & ~wr_err;
   assign wkup_detector_en_en7_wd = reg_wdata[7];
 
-  assign wkup_detector0_mode0_we = addr_hit[30] & reg_we & ~wr_err;
+  assign wkup_detector0_mode0_we = addr_hit[29] & reg_we & ~wr_err;
   assign wkup_detector0_mode0_wd = reg_wdata[2:0];
 
-  assign wkup_detector0_filter0_we = addr_hit[30] & reg_we & ~wr_err;
+  assign wkup_detector0_filter0_we = addr_hit[29] & reg_we & ~wr_err;
   assign wkup_detector0_filter0_wd = reg_wdata[3];
 
-  assign wkup_detector0_miodio0_we = addr_hit[30] & reg_we & ~wr_err;
+  assign wkup_detector0_miodio0_we = addr_hit[29] & reg_we & ~wr_err;
   assign wkup_detector0_miodio0_wd = reg_wdata[4];
 
-  assign wkup_detector1_mode1_we = addr_hit[31] & reg_we & ~wr_err;
+  assign wkup_detector1_mode1_we = addr_hit[30] & reg_we & ~wr_err;
   assign wkup_detector1_mode1_wd = reg_wdata[2:0];
 
-  assign wkup_detector1_filter1_we = addr_hit[31] & reg_we & ~wr_err;
+  assign wkup_detector1_filter1_we = addr_hit[30] & reg_we & ~wr_err;
   assign wkup_detector1_filter1_wd = reg_wdata[3];
 
-  assign wkup_detector1_miodio1_we = addr_hit[31] & reg_we & ~wr_err;
+  assign wkup_detector1_miodio1_we = addr_hit[30] & reg_we & ~wr_err;
   assign wkup_detector1_miodio1_wd = reg_wdata[4];
 
-  assign wkup_detector2_mode2_we = addr_hit[32] & reg_we & ~wr_err;
+  assign wkup_detector2_mode2_we = addr_hit[31] & reg_we & ~wr_err;
   assign wkup_detector2_mode2_wd = reg_wdata[2:0];
 
-  assign wkup_detector2_filter2_we = addr_hit[32] & reg_we & ~wr_err;
+  assign wkup_detector2_filter2_we = addr_hit[31] & reg_we & ~wr_err;
   assign wkup_detector2_filter2_wd = reg_wdata[3];
 
-  assign wkup_detector2_miodio2_we = addr_hit[32] & reg_we & ~wr_err;
+  assign wkup_detector2_miodio2_we = addr_hit[31] & reg_we & ~wr_err;
   assign wkup_detector2_miodio2_wd = reg_wdata[4];
 
-  assign wkup_detector3_mode3_we = addr_hit[33] & reg_we & ~wr_err;
+  assign wkup_detector3_mode3_we = addr_hit[32] & reg_we & ~wr_err;
   assign wkup_detector3_mode3_wd = reg_wdata[2:0];
 
-  assign wkup_detector3_filter3_we = addr_hit[33] & reg_we & ~wr_err;
+  assign wkup_detector3_filter3_we = addr_hit[32] & reg_we & ~wr_err;
   assign wkup_detector3_filter3_wd = reg_wdata[3];
 
-  assign wkup_detector3_miodio3_we = addr_hit[33] & reg_we & ~wr_err;
+  assign wkup_detector3_miodio3_we = addr_hit[32] & reg_we & ~wr_err;
   assign wkup_detector3_miodio3_wd = reg_wdata[4];
 
-  assign wkup_detector4_mode4_we = addr_hit[34] & reg_we & ~wr_err;
+  assign wkup_detector4_mode4_we = addr_hit[33] & reg_we & ~wr_err;
   assign wkup_detector4_mode4_wd = reg_wdata[2:0];
 
-  assign wkup_detector4_filter4_we = addr_hit[34] & reg_we & ~wr_err;
+  assign wkup_detector4_filter4_we = addr_hit[33] & reg_we & ~wr_err;
   assign wkup_detector4_filter4_wd = reg_wdata[3];
 
-  assign wkup_detector4_miodio4_we = addr_hit[34] & reg_we & ~wr_err;
+  assign wkup_detector4_miodio4_we = addr_hit[33] & reg_we & ~wr_err;
   assign wkup_detector4_miodio4_wd = reg_wdata[4];
 
-  assign wkup_detector5_mode5_we = addr_hit[35] & reg_we & ~wr_err;
+  assign wkup_detector5_mode5_we = addr_hit[34] & reg_we & ~wr_err;
   assign wkup_detector5_mode5_wd = reg_wdata[2:0];
 
-  assign wkup_detector5_filter5_we = addr_hit[35] & reg_we & ~wr_err;
+  assign wkup_detector5_filter5_we = addr_hit[34] & reg_we & ~wr_err;
   assign wkup_detector5_filter5_wd = reg_wdata[3];
 
-  assign wkup_detector5_miodio5_we = addr_hit[35] & reg_we & ~wr_err;
+  assign wkup_detector5_miodio5_we = addr_hit[34] & reg_we & ~wr_err;
   assign wkup_detector5_miodio5_wd = reg_wdata[4];
 
-  assign wkup_detector6_mode6_we = addr_hit[36] & reg_we & ~wr_err;
+  assign wkup_detector6_mode6_we = addr_hit[35] & reg_we & ~wr_err;
   assign wkup_detector6_mode6_wd = reg_wdata[2:0];
 
-  assign wkup_detector6_filter6_we = addr_hit[36] & reg_we & ~wr_err;
+  assign wkup_detector6_filter6_we = addr_hit[35] & reg_we & ~wr_err;
   assign wkup_detector6_filter6_wd = reg_wdata[3];
 
-  assign wkup_detector6_miodio6_we = addr_hit[36] & reg_we & ~wr_err;
+  assign wkup_detector6_miodio6_we = addr_hit[35] & reg_we & ~wr_err;
   assign wkup_detector6_miodio6_wd = reg_wdata[4];
 
-  assign wkup_detector7_mode7_we = addr_hit[37] & reg_we & ~wr_err;
+  assign wkup_detector7_mode7_we = addr_hit[36] & reg_we & ~wr_err;
   assign wkup_detector7_mode7_wd = reg_wdata[2:0];
 
-  assign wkup_detector7_filter7_we = addr_hit[37] & reg_we & ~wr_err;
+  assign wkup_detector7_filter7_we = addr_hit[36] & reg_we & ~wr_err;
   assign wkup_detector7_filter7_wd = reg_wdata[3];
 
-  assign wkup_detector7_miodio7_we = addr_hit[37] & reg_we & ~wr_err;
+  assign wkup_detector7_miodio7_we = addr_hit[36] & reg_we & ~wr_err;
   assign wkup_detector7_miodio7_wd = reg_wdata[4];
 
-  assign wkup_detector_cnt_th0_th0_we = addr_hit[38] & reg_we & ~wr_err;
+  assign wkup_detector_cnt_th0_th0_we = addr_hit[37] & reg_we & ~wr_err;
   assign wkup_detector_cnt_th0_th0_wd = reg_wdata[7:0];
 
-  assign wkup_detector_cnt_th0_th1_we = addr_hit[38] & reg_we & ~wr_err;
+  assign wkup_detector_cnt_th0_th1_we = addr_hit[37] & reg_we & ~wr_err;
   assign wkup_detector_cnt_th0_th1_wd = reg_wdata[15:8];
 
-  assign wkup_detector_cnt_th0_th2_we = addr_hit[38] & reg_we & ~wr_err;
+  assign wkup_detector_cnt_th0_th2_we = addr_hit[37] & reg_we & ~wr_err;
   assign wkup_detector_cnt_th0_th2_wd = reg_wdata[23:16];
 
-  assign wkup_detector_cnt_th0_th3_we = addr_hit[38] & reg_we & ~wr_err;
+  assign wkup_detector_cnt_th0_th3_we = addr_hit[37] & reg_we & ~wr_err;
   assign wkup_detector_cnt_th0_th3_wd = reg_wdata[31:24];
 
-  assign wkup_detector_cnt_th1_th4_we = addr_hit[39] & reg_we & ~wr_err;
+  assign wkup_detector_cnt_th1_th4_we = addr_hit[38] & reg_we & ~wr_err;
   assign wkup_detector_cnt_th1_th4_wd = reg_wdata[7:0];
 
-  assign wkup_detector_cnt_th1_th5_we = addr_hit[39] & reg_we & ~wr_err;
+  assign wkup_detector_cnt_th1_th5_we = addr_hit[38] & reg_we & ~wr_err;
   assign wkup_detector_cnt_th1_th5_wd = reg_wdata[15:8];
 
-  assign wkup_detector_cnt_th1_th6_we = addr_hit[39] & reg_we & ~wr_err;
+  assign wkup_detector_cnt_th1_th6_we = addr_hit[38] & reg_we & ~wr_err;
   assign wkup_detector_cnt_th1_th6_wd = reg_wdata[23:16];
 
-  assign wkup_detector_cnt_th1_th7_we = addr_hit[39] & reg_we & ~wr_err;
+  assign wkup_detector_cnt_th1_th7_we = addr_hit[38] & reg_we & ~wr_err;
   assign wkup_detector_cnt_th1_th7_wd = reg_wdata[31:24];
 
-  assign wkup_detector_padsel0_sel0_we = addr_hit[40] & reg_we & ~wr_err;
+  assign wkup_detector_padsel0_sel0_we = addr_hit[39] & reg_we & ~wr_err;
   assign wkup_detector_padsel0_sel0_wd = reg_wdata[5:0];
 
-  assign wkup_detector_padsel0_sel1_we = addr_hit[40] & reg_we & ~wr_err;
+  assign wkup_detector_padsel0_sel1_we = addr_hit[39] & reg_we & ~wr_err;
   assign wkup_detector_padsel0_sel1_wd = reg_wdata[11:6];
 
-  assign wkup_detector_padsel0_sel2_we = addr_hit[40] & reg_we & ~wr_err;
+  assign wkup_detector_padsel0_sel2_we = addr_hit[39] & reg_we & ~wr_err;
   assign wkup_detector_padsel0_sel2_wd = reg_wdata[17:12];
 
-  assign wkup_detector_padsel0_sel3_we = addr_hit[40] & reg_we & ~wr_err;
+  assign wkup_detector_padsel0_sel3_we = addr_hit[39] & reg_we & ~wr_err;
   assign wkup_detector_padsel0_sel3_wd = reg_wdata[23:18];
 
-  assign wkup_detector_padsel0_sel4_we = addr_hit[40] & reg_we & ~wr_err;
+  assign wkup_detector_padsel0_sel4_we = addr_hit[39] & reg_we & ~wr_err;
   assign wkup_detector_padsel0_sel4_wd = reg_wdata[29:24];
 
-  assign wkup_detector_padsel1_sel5_we = addr_hit[41] & reg_we & ~wr_err;
+  assign wkup_detector_padsel1_sel5_we = addr_hit[40] & reg_we & ~wr_err;
   assign wkup_detector_padsel1_sel5_wd = reg_wdata[5:0];
 
-  assign wkup_detector_padsel1_sel6_we = addr_hit[41] & reg_we & ~wr_err;
+  assign wkup_detector_padsel1_sel6_we = addr_hit[40] & reg_we & ~wr_err;
   assign wkup_detector_padsel1_sel6_wd = reg_wdata[11:6];
 
-  assign wkup_detector_padsel1_sel7_we = addr_hit[41] & reg_we & ~wr_err;
+  assign wkup_detector_padsel1_sel7_we = addr_hit[40] & reg_we & ~wr_err;
   assign wkup_detector_padsel1_sel7_wd = reg_wdata[17:12];
 
-  assign wkup_cause_cause0_we = addr_hit[42] & reg_we & ~wr_err;
+  assign wkup_cause_cause0_we = addr_hit[41] & reg_we & ~wr_err;
   assign wkup_cause_cause0_wd = reg_wdata[0];
-  assign wkup_cause_cause0_re = addr_hit[42] && reg_re;
+  assign wkup_cause_cause0_re = addr_hit[41] && reg_re;
 
-  assign wkup_cause_cause1_we = addr_hit[42] & reg_we & ~wr_err;
+  assign wkup_cause_cause1_we = addr_hit[41] & reg_we & ~wr_err;
   assign wkup_cause_cause1_wd = reg_wdata[1];
-  assign wkup_cause_cause1_re = addr_hit[42] && reg_re;
+  assign wkup_cause_cause1_re = addr_hit[41] && reg_re;
 
-  assign wkup_cause_cause2_we = addr_hit[42] & reg_we & ~wr_err;
+  assign wkup_cause_cause2_we = addr_hit[41] & reg_we & ~wr_err;
   assign wkup_cause_cause2_wd = reg_wdata[2];
-  assign wkup_cause_cause2_re = addr_hit[42] && reg_re;
+  assign wkup_cause_cause2_re = addr_hit[41] && reg_re;
 
-  assign wkup_cause_cause3_we = addr_hit[42] & reg_we & ~wr_err;
+  assign wkup_cause_cause3_we = addr_hit[41] & reg_we & ~wr_err;
   assign wkup_cause_cause3_wd = reg_wdata[3];
-  assign wkup_cause_cause3_re = addr_hit[42] && reg_re;
+  assign wkup_cause_cause3_re = addr_hit[41] && reg_re;
 
-  assign wkup_cause_cause4_we = addr_hit[42] & reg_we & ~wr_err;
+  assign wkup_cause_cause4_we = addr_hit[41] & reg_we & ~wr_err;
   assign wkup_cause_cause4_wd = reg_wdata[4];
-  assign wkup_cause_cause4_re = addr_hit[42] && reg_re;
+  assign wkup_cause_cause4_re = addr_hit[41] && reg_re;
 
-  assign wkup_cause_cause5_we = addr_hit[42] & reg_we & ~wr_err;
+  assign wkup_cause_cause5_we = addr_hit[41] & reg_we & ~wr_err;
   assign wkup_cause_cause5_wd = reg_wdata[5];
-  assign wkup_cause_cause5_re = addr_hit[42] && reg_re;
+  assign wkup_cause_cause5_re = addr_hit[41] && reg_re;
 
-  assign wkup_cause_cause6_we = addr_hit[42] & reg_we & ~wr_err;
+  assign wkup_cause_cause6_we = addr_hit[41] & reg_we & ~wr_err;
   assign wkup_cause_cause6_wd = reg_wdata[6];
-  assign wkup_cause_cause6_re = addr_hit[42] && reg_re;
+  assign wkup_cause_cause6_re = addr_hit[41] && reg_re;
 
-  assign wkup_cause_cause7_we = addr_hit[42] & reg_we & ~wr_err;
+  assign wkup_cause_cause7_we = addr_hit[41] & reg_we & ~wr_err;
   assign wkup_cause_cause7_wd = reg_wdata[7];
-  assign wkup_cause_cause7_re = addr_hit[42] && reg_re;
+  assign wkup_cause_cause7_re = addr_hit[41] && reg_re;
 
   // Read data return
   always_comb begin
@@ -7425,12 +7228,6 @@ module pinmux_reg_top (
       end
 
       addr_hit[23]: begin
-        reg_rdata_next[6:0] = mio_outsel11_out44_qs;
-        reg_rdata_next[13:7] = mio_outsel11_out45_qs;
-        reg_rdata_next[20:14] = mio_outsel11_out46_qs;
-      end
-
-      addr_hit[24]: begin
         reg_rdata_next[1:0] = mio_out_sleep_val0_out0_qs;
         reg_rdata_next[3:2] = mio_out_sleep_val0_out1_qs;
         reg_rdata_next[5:4] = mio_out_sleep_val0_out2_qs;
@@ -7449,7 +7246,7 @@ module pinmux_reg_top (
         reg_rdata_next[31:30] = mio_out_sleep_val0_out15_qs;
       end
 
-      addr_hit[25]: begin
+      addr_hit[24]: begin
         reg_rdata_next[1:0] = mio_out_sleep_val1_out16_qs;
         reg_rdata_next[3:2] = mio_out_sleep_val1_out17_qs;
         reg_rdata_next[5:4] = mio_out_sleep_val1_out18_qs;
@@ -7468,7 +7265,7 @@ module pinmux_reg_top (
         reg_rdata_next[31:30] = mio_out_sleep_val1_out31_qs;
       end
 
-      addr_hit[26]: begin
+      addr_hit[25]: begin
         reg_rdata_next[1:0] = mio_out_sleep_val2_out32_qs;
         reg_rdata_next[3:2] = mio_out_sleep_val2_out33_qs;
         reg_rdata_next[5:4] = mio_out_sleep_val2_out34_qs;
@@ -7481,12 +7278,9 @@ module pinmux_reg_top (
         reg_rdata_next[19:18] = mio_out_sleep_val2_out41_qs;
         reg_rdata_next[21:20] = mio_out_sleep_val2_out42_qs;
         reg_rdata_next[23:22] = mio_out_sleep_val2_out43_qs;
-        reg_rdata_next[25:24] = mio_out_sleep_val2_out44_qs;
-        reg_rdata_next[27:26] = mio_out_sleep_val2_out45_qs;
-        reg_rdata_next[29:28] = mio_out_sleep_val2_out46_qs;
       end
 
-      addr_hit[27]: begin
+      addr_hit[26]: begin
         reg_rdata_next[1:0] = dio_out_sleep_val0_out0_qs;
         reg_rdata_next[3:2] = dio_out_sleep_val0_out1_qs;
         reg_rdata_next[5:4] = dio_out_sleep_val0_out2_qs;
@@ -7505,7 +7299,7 @@ module pinmux_reg_top (
         reg_rdata_next[31:30] = dio_out_sleep_val0_out15_qs;
       end
 
-      addr_hit[28]: begin
+      addr_hit[27]: begin
         reg_rdata_next[1:0] = dio_out_sleep_val1_out16_qs;
         reg_rdata_next[3:2] = dio_out_sleep_val1_out17_qs;
         reg_rdata_next[5:4] = dio_out_sleep_val1_out18_qs;
@@ -7513,7 +7307,7 @@ module pinmux_reg_top (
         reg_rdata_next[9:8] = dio_out_sleep_val1_out20_qs;
       end
 
-      addr_hit[29]: begin
+      addr_hit[28]: begin
         reg_rdata_next[0] = wkup_detector_en_en0_qs;
         reg_rdata_next[1] = wkup_detector_en_en1_qs;
         reg_rdata_next[2] = wkup_detector_en_en2_qs;
@@ -7524,69 +7318,69 @@ module pinmux_reg_top (
         reg_rdata_next[7] = wkup_detector_en_en7_qs;
       end
 
-      addr_hit[30]: begin
+      addr_hit[29]: begin
         reg_rdata_next[2:0] = wkup_detector0_mode0_qs;
         reg_rdata_next[3] = wkup_detector0_filter0_qs;
         reg_rdata_next[4] = wkup_detector0_miodio0_qs;
       end
 
-      addr_hit[31]: begin
+      addr_hit[30]: begin
         reg_rdata_next[2:0] = wkup_detector1_mode1_qs;
         reg_rdata_next[3] = wkup_detector1_filter1_qs;
         reg_rdata_next[4] = wkup_detector1_miodio1_qs;
       end
 
-      addr_hit[32]: begin
+      addr_hit[31]: begin
         reg_rdata_next[2:0] = wkup_detector2_mode2_qs;
         reg_rdata_next[3] = wkup_detector2_filter2_qs;
         reg_rdata_next[4] = wkup_detector2_miodio2_qs;
       end
 
-      addr_hit[33]: begin
+      addr_hit[32]: begin
         reg_rdata_next[2:0] = wkup_detector3_mode3_qs;
         reg_rdata_next[3] = wkup_detector3_filter3_qs;
         reg_rdata_next[4] = wkup_detector3_miodio3_qs;
       end
 
-      addr_hit[34]: begin
+      addr_hit[33]: begin
         reg_rdata_next[2:0] = wkup_detector4_mode4_qs;
         reg_rdata_next[3] = wkup_detector4_filter4_qs;
         reg_rdata_next[4] = wkup_detector4_miodio4_qs;
       end
 
-      addr_hit[35]: begin
+      addr_hit[34]: begin
         reg_rdata_next[2:0] = wkup_detector5_mode5_qs;
         reg_rdata_next[3] = wkup_detector5_filter5_qs;
         reg_rdata_next[4] = wkup_detector5_miodio5_qs;
       end
 
-      addr_hit[36]: begin
+      addr_hit[35]: begin
         reg_rdata_next[2:0] = wkup_detector6_mode6_qs;
         reg_rdata_next[3] = wkup_detector6_filter6_qs;
         reg_rdata_next[4] = wkup_detector6_miodio6_qs;
       end
 
-      addr_hit[37]: begin
+      addr_hit[36]: begin
         reg_rdata_next[2:0] = wkup_detector7_mode7_qs;
         reg_rdata_next[3] = wkup_detector7_filter7_qs;
         reg_rdata_next[4] = wkup_detector7_miodio7_qs;
       end
 
-      addr_hit[38]: begin
+      addr_hit[37]: begin
         reg_rdata_next[7:0] = wkup_detector_cnt_th0_th0_qs;
         reg_rdata_next[15:8] = wkup_detector_cnt_th0_th1_qs;
         reg_rdata_next[23:16] = wkup_detector_cnt_th0_th2_qs;
         reg_rdata_next[31:24] = wkup_detector_cnt_th0_th3_qs;
       end
 
-      addr_hit[39]: begin
+      addr_hit[38]: begin
         reg_rdata_next[7:0] = wkup_detector_cnt_th1_th4_qs;
         reg_rdata_next[15:8] = wkup_detector_cnt_th1_th5_qs;
         reg_rdata_next[23:16] = wkup_detector_cnt_th1_th6_qs;
         reg_rdata_next[31:24] = wkup_detector_cnt_th1_th7_qs;
       end
 
-      addr_hit[40]: begin
+      addr_hit[39]: begin
         reg_rdata_next[5:0] = wkup_detector_padsel0_sel0_qs;
         reg_rdata_next[11:6] = wkup_detector_padsel0_sel1_qs;
         reg_rdata_next[17:12] = wkup_detector_padsel0_sel2_qs;
@@ -7594,13 +7388,13 @@ module pinmux_reg_top (
         reg_rdata_next[29:24] = wkup_detector_padsel0_sel4_qs;
       end
 
-      addr_hit[41]: begin
+      addr_hit[40]: begin
         reg_rdata_next[5:0] = wkup_detector_padsel1_sel5_qs;
         reg_rdata_next[11:6] = wkup_detector_padsel1_sel6_qs;
         reg_rdata_next[17:12] = wkup_detector_padsel1_sel7_qs;
       end
 
-      addr_hit[42]: begin
+      addr_hit[41]: begin
         reg_rdata_next[0] = wkup_cause_cause0_qs;
         reg_rdata_next[1] = wkup_cause_cause1_qs;
         reg_rdata_next[2] = wkup_cause_cause2_qs;

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -16,9 +16,9 @@ module top_earlgrey #(
   output              jtag_tdo_o,
 
   // Multiplexed I/O
-  input        [46:0] mio_in_i,
-  output logic [46:0] mio_out_o,
-  output logic [46:0] mio_oe_o,
+  input        [43:0] mio_in_i,
+  output logic [43:0] mio_out_o,
+  output logic [43:0] mio_oe_o,
   // Dedicated I/O
   input        [20:0] dio_in_i,
   output logic [20:0] dio_out_o,

--- a/hw/top_earlgrey/rtl/top_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_asic.sv
@@ -8,24 +8,26 @@ module top_earlgrey_asic (
   // will then be muxed in via another port.
   inout               IO_CLK,
   inout               IO_RST_N,
-  // Bank A
-  inout               IOA0,  // SPI Host Data 0
-  inout               IOA1,  // SPI Host Data 1
-  inout               IOA2,  // SPI Host Data 2
-  inout               IOA3,  // SPI Host Data 3
-  inout               IOA4,  // SPI Host CS_L
-  inout               IOA5,  // SPI Host CLK
-  inout               IOA6,  // SPI Device S0
-  inout               IOA7,  // SPI Device S1
-  inout               IOA8,  // SPI Device CS_L
-  inout               IOA9,  // SPI Device CLK
-  inout               IOA10, // MIO 0
-  inout               IOA11, // MIO 1
-  inout               IOA12, // MIO 2
-  inout               IOA13, // MIO 3
-  inout               IOA14, // MIO 4
-  inout               IOA15, // MIO 5
-  // Bank B
+  // Bank A (VIOA domain)
+  inout               SPI_HOST_D0,
+  inout               SPI_HOST_D1,
+  inout               SPI_HOST_D2,
+  inout               SPI_HOST_D3,
+  inout               SPI_HOST_CLK,
+  inout               SPI_HOST_CS_L,
+  inout               SPI_DEV_D0,
+  inout               SPI_DEV_D1,
+  inout               SPI_DEV_D2,
+  inout               SPI_DEV_D3,
+  inout               SPI_DEV_CLK,
+  inout               SPI_DEV_CS_L,
+  inout               IOA0,  // MIO 0
+  inout               IOA1,  // MIO 1
+  inout               IOA2,  // MIO 2
+  inout               IOA3,  // MIO 3
+  inout               IOA4,  // MIO 4
+  inout               IOA5,  // MIO 5
+  // Bank B (VIOB domain)
   inout               IOB0,  // MIO 6
   inout               IOB1,  // MIO 7
   inout               IOB2,  // MIO 8
@@ -38,7 +40,7 @@ module top_earlgrey_asic (
   inout               IOB9,  // MIO 15
   inout               IOB10, // MIO 16
   inout               IOB11, // MIO 17
-  // Bank C
+  // Bank C (VCC domain)
   inout               IOC0,  // MIO 18
   inout               IOC1,  // MIO 19
   inout               IOC2,  // MIO 20
@@ -51,28 +53,28 @@ module top_earlgrey_asic (
   inout               IOC9,  // MIO 27
   inout               IOC10, // MIO 28
   inout               IOC11, // MIO 29
-  inout               IOC12, // MIO 30
-  inout               IOC13, // MIO 31
-  inout               IOC14, // MIO 32
-  inout               IOC15, // CC1
-  inout               IOC16, // CC2
-  inout               IOC17, // USB_P
-  inout               IOC18, // USB_N
-  // Bank R
-  inout               IOR0,  // EcRstL
-  inout               IOR1,  // PwrBI
-  inout               IOR2,  // EcEnteringRw
-  inout               IOR3,  // AcPresent
-  inout               IOR4,  // FlashWpL
-  inout               IOR5,  // PwrBO
-  inout               IOR6,  // EcInRw
-  inout               IOR7,  // BatEn
-  inout               IOR8,  // Key0I (volup, column out from EC in laptop)
-  inout               IOR9,  // Key1I (voldown, row input from keyboard matrix in laptop)
-  inout               IOR10, // Key2I (tbd, row input from keyboard matrix in laptop)
-  inout               IOR11, // Key0O (passthrough from Key0I)
-  inout               IOR12, // Key1O (passthrough from Key1I)
-  inout               IOR13  // Key2O (passthrough from Key2I)
+  // Bank R (VCC domain)
+  inout               IOR0,  // MIO 30
+  inout               IOR1,  // MIO 31
+  inout               IOR2,  // MIO 32
+  inout               IOR3,  // MIO 33
+  inout               IOR4,  // MIO 34
+  inout               IOR5,  // MIO 35
+  inout               IOR6,  // MIO 36
+  inout               IOR7,  // MIO 37
+  inout               IOR8,  // MIO 38
+  inout               IOR9,  // MIO 39
+  inout               IOR10, // MIO 40
+  inout               IOR11, // MIO 41
+  inout               IOR12, // MIO 42
+  inout               IOR13, // MIO 43
+  // DCD (VCC domain)
+  inout               CC1,
+  inout               CC2,
+  // USB (VCC domain)
+  inout               USB_P,
+  inout               USB_N
+
 );
 
   import top_earlgrey_pkg::*;
@@ -102,88 +104,86 @@ module top_earlgrey_asic (
   wire unused_usbdev_dp_pullup_en, unused_usbdev_dn_pullup_en;
   wire unused_spi_device_s2, unused_spi_device_s3;
 
-  // TODO: hook these up once both the SPI host and device are present
-  logic [3:0] unused_spi;
-  assign unused_spi = {IOA9, IOA8, IOA7, IOA6};
-  assign {IOA9, IOA8, IOA7, IOA6} = '0;
-
   padring #(
     // All MIOs are connected
-    .ConnectMioIn  ( 47'h7FFF_FFFF_FFFF ),
-    .ConnectMioOut ( 47'h7FFF_FFFF_FFFF ),
+    .ConnectMioIn  ( 44'hFFF_FFFF_FFFF ),
+    .ConnectMioOut ( 44'hFFF_FFFF_FFFF ),
     // Tied off DIOs:
     // 2-8 (USB)
     .ConnectDioIn  ( 15'h7E03 ),
     .ConnectDioOut ( 15'h7E03 ),
     // MIO pad types
     .MioPadVariant ( { // RBox
-                       2'd0, // IOR13   -- bidir
-                       2'd0, // IOR12   -- bidir
-                       2'd0, // IOR11   -- bidir
-                       2'd0, // IOR10   -- bidir
-                       2'd0, // IOR9    -- bidir
-                       2'd0, // IOR8    -- bidir
-                       2'd3, // IOR7    -- open drain
-                       2'd3, // IOR6    -- open drain
-                       2'd3, // IOR5    -- open drain
-                       2'd3, // IOR4    -- open drain
-                       2'd3, // IOR3    -- open drain
+                       2'd3, // IOR13   -- open drain
+                       2'd3, // IOR12   -- open drain
+                       2'd3, // IOR11   -- open drain
+                       2'd3, // IOR10   -- open drain
+                       2'd3, // IOR9    -- open drain
+                       2'd3, // IOR8    -- open drain
+                       2'd0, // IOR7    -- bidir
+                       2'd0, // IOR6    -- bidir
+                       2'd0, // IOR5    -- bidir
+                       2'd0, // IOR4    -- bidir
+                       2'd0, // IOR3    -- bidir
                        2'd0, // IOR2    -- bidir
-                       2'd3, // IOR1    -- open drain
-                       2'd3, // IOR0    -- open drain
+                       2'd0, // IOR1    -- bidir
+                       2'd0, // IOR0    -- bidir
                        // Bank C
-                       2'd0, // IOC14   -- bidir
-                       2'd0, // IOC13   -- bidir
-                       2'd0, // IOC12   -- bidir
-                       2'd0, // IOC11   -- bidir
-                       2'd0, // IOC10   -- bidir
+                       2'd3, // IOC11   -- open drain
+                       2'd3, // IOC10   -- open drain
                        2'd3, // IOC9    -- open drain
-                       2'd0, // IOC8    -- bidir
-                       2'd3, // IOC7    -- open drain
-                       2'd3, // IOC6    -- open drain
-                       2'd3, // IOC5    -- open drain
+                       2'd3, // IOC8    -- open drain
+                       2'd0, // IOC7    -- bidir
+                       2'd0, // IOC6    -- bidir
+                       2'd0, // IOC5    -- bidir
                        2'd0, // IOC4    -- bidir
                        2'd0, // IOC3    -- bidir
                        2'd0, // IOC2    -- bidir
                        2'd0, // IOC1    -- bidir
                        2'd0, // IOC0    -- bidir
                        // Bank B
-                       2'd0, // IOB11   -- bidir
-                       2'd0, // IOB10   -- bidir
-                       2'd0, // IOB9    -- bidir
-                       2'd0, // IOB8    -- bidir
-                       2'd3, // IOB7    -- open drain
-                       2'd3, // IOB6    -- open drain
-                       2'd3, // IOB5    -- open drain
-                       2'd3, // IOB4    -- open drain
+                       2'd3, // IOB11   -- open drain
+                       2'd3, // IOB10   -- open drain
+                       2'd3, // IOB9    -- open drain
+                       2'd3, // IOB8    -- open drain
+                       2'd0, // IOB7    -- birid
+                       2'd0, // IOB6    -- birid
+                       2'd0, // IOB5    -- birid
+                       2'd0, // IOB4    -- birid
                        2'd0, // IOB3    -- bidir
                        2'd0, // IOB2    -- bidir
                        2'd0, // IOB1    -- bidir
                        2'd0, // IOB0    -- bidir
                        // Bank A
-                       2'd0, // IOA15   -- bidir
-                       2'd0, // IOA14   -- bidir
-                       2'd0, // IOA13   -- bidir
-                       2'd0, // IOA12   -- bidir
-                       2'd3, // IOA11   -- open drain
-                       2'd3  // IOA10   -- open drain
+                       2'd3, // IOA5    -- open drain
+                       2'd3, // IOA4    -- open drain
+                       2'd0, // IOA3    -- bidir
+                       2'd0, // IOA2    -- bidir
+                       2'd0, // IOA1    -- bidir
+                       2'd0  // IOA0    -- bidir
                       } ),
     // DIO pad types
-    .DioPadVariant ( { 2'd0, // IOA4     -- bidir
-                       2'd0, // IOA5     -- bidir
-                       2'd0, // IOA3     -- bidir
-                       2'd0, // IOA2     -- bidir
-                       2'd0, // IOA1     -- bidir
-                       2'd0, // IOA0     -- bidir
-                       2'd0, // unused
-                       2'd0, // unused
-                       2'd0, // IOC15    -- bidir
-                       2'd0, // IOC16    -- bidir
-                       2'd0, // unused
-                       2'd0, // unused
-                       2'd0, // unused
-                       2'd2, // USB_P   -- tolerant
-                       2'd2  // USB_N   -- tolerant
+    .DioPadVariant (  { 2'd1, // SPI_DEV_CLK    -- input only
+                        2'd1, // SPI_DEV_CS_L   -- input only
+                        2'd0, // SPI_DEV_D3     -- bidir
+                        2'd0, // SPI_DEV_D2     -- bidir
+                        2'd0, // SPI_DEV_D1     -- bidir
+                        2'd0, // SPI_DEV_D0     -- bidir
+                        2'd0, // SPI_HOST_CLK   -- bidir
+                        2'd0, // SPI_HOST_CS_L  -- bidir
+                        2'd0, // SPI_HOST_D3    -- bidir
+                        2'd0, // SPI_HOST_D2    -- bidir
+                        2'd0, // SPI_HOST_D1    -- bidir
+                        2'd0, // SPI_HOST_D0    -- bidir
+                        2'd0, // unused
+                        2'd0, // unused
+                        2'd0, // unused
+                        2'd0, // unused
+                        2'd0, // unused
+                        2'd0, // unused
+                        2'd0, // unused
+                        2'd2, // USB_P          -- tolerant
+                        2'd2  // USB_N          -- tolerant
                       } )
   ) padring (
     // Clk / Rst
@@ -191,29 +191,26 @@ module top_earlgrey_asic (
     .rst_pad_ni          ( IO_RST_N         ),
     .clk_o               ( clk              ),
     .rst_no              ( rst_n            ),
-    .cc1_i               ( IOC15            ),
-    .cc2_i               ( IOC16            ),
+    .cc1_i               ( CC1              ),
+    .cc2_i               ( CC2              ),
     // "special"
     // MIO Pads
     .mio_pad_io          ( { // RBox
-                             IOR13, // MIO 46
-                             IOR12, // MIO 45
-                             IOR11, // MIO 44
-                             IOR10, // MIO 43
-                             IOR9,  // MIO 42
-                             IOR8,  // MIO 41
-                             IOR7,  // MIO 40
-                             IOR6,  // MIO 39
-                             IOR5,  // MIO 38
-                             IOR4,  // MIO 37
-                             IOR3,  // MIO 36
-                             IOR2,  // MIO 35
-                             IOR1,  // MIO 34
-                             IOR0,  // MIO 33
+                             IOR13, // MIO 43
+                             IOR12, // MIO 42
+                             IOR11, // MIO 41
+                             IOR10, // MIO 40
+                             IOR9,  // MIO 39
+                             IOR8,  // MIO 38
+                             IOR7,  // MIO 37
+                             IOR6,  // MIO 36
+                             IOR5,  // MIO 35
+                             IOR4,  // MIO 34
+                             IOR3,  // MIO 33
+                             IOR2,  // MIO 32
+                             IOR1,  // MIO 31
+                             IOR0,  // MIO 30
                              // Bank C
-                             IOC14, // MIO 32
-                             IOC13, // MIO 31
-                             IOC12, // MIO 30
                              IOC11, // MIO 29
                              IOC10, // MIO 28
                              IOC9,  // MIO 27
@@ -240,37 +237,35 @@ module top_earlgrey_asic (
                              IOB1,  // MIO 7
                              IOB0,  // MIO 6
                              // Bank A
-                             IOA15, // MIO 5
-                             IOA14, // MIO 4
-                             IOA13, // MIO 3
-                             IOA12, // MIO 2
-                             IOA11, // MIO 1
-                             IOA10  // MIO 0
+                             IOA5,  // MIO 5
+                             IOA4,  // MIO 4
+                             IOA3,  // MIO 3
+                             IOA2,  // MIO 2
+                             IOA1,  // MIO 1
+                             IOA0   // MIO 0
                             } ),
     // DIO Pads
-    // TODO: the SPI mapping is not correct since the SPI host is missing, and we still need
-    // to free up 2 pads to squeeze in a 4x SPI device.
-    .dio_pad_io          ( { IOA9,  // cio_spi_device_sck_p2d
-                             IOA8,  // cio_spi_device_csb_p2d
-                             unused_spi_device_s3, // cio_spi_device_s_p2d[3]
-                             unused_spi_device_s2, // cio_spi_device_s_p2d[2]
-                             IOA7,  // cio_spi_device_s_p2d[1]
-                             IOA6,  // cio_spi_device_s_p2d[0]
-                             IOA5,  // cio_spi_host0_sck_p2d
-                             IOA4,  // cio_spi_host0_csb_p2d
-                             IOA3,  // cio_spi_host0_s_p2d[3]
-                             IOA2,  // cio_spi_host0_s_p2d[2]
-                             IOA1,  // cio_spi_host0_s_p2d[1]
-                             IOA0,  // cio_spi_host0_s_p2d[0]
-                             unused_usbdev_aon_sense, //usbdev_aon_sense
-                             unused_usbdev_se0, // usbdev_se0
-                             unused_usbdev_dp_pullup_en,  // USB dp pullup
-                             unused_usbdev_dn_pullup_en,  // USB dn pullup
-                             unused_usbdev_tx_mode, // usbdev_tx_mode
-                             unused_usbdev_suspend, // usbdev_suspend
-                             unused_usbdev_d,       // usbdev_d
-                             IOC17,  // USB_P
-                             IOC18   // USB_N
+    .dio_pad_io          ( { SPI_DEV_CLK,                 // cio_spi_device_sck_p2d
+                             SPI_DEV_CS_L,                // cio_spi_device_csb_p2d
+                             SPI_DEV_D3,                  // cio_spi_device_s_p2d[3]
+                             SPI_DEV_D2,                  // cio_spi_device_s_p2d[2]
+                             SPI_DEV_D1,                  // cio_spi_device_s_p2d[1]
+                             SPI_DEV_D0,                  // cio_spi_device_s_p2d[0]
+                             SPI_HOST_CLK,                // cio_spi_host0_sck_p2d
+                             SPI_HOST_CS_L,               // cio_spi_host0_csb_p2d
+                             SPI_HOST_D3,                 // cio_spi_host0_s_p2d[3]
+                             SPI_HOST_D2,                 // cio_spi_host0_s_p2d[2]
+                             SPI_HOST_D1,                 // cio_spi_host0_s_p2d[1]
+                             SPI_HOST_D0,                 // cio_spi_host0_s_p2d[0]
+                             unused_usbdev_aon_sense,     // cio_usbdev_aon_sense_p2d
+                             unused_usbdev_se0,           // cio_usbdev_aon_se0
+                             unused_usbdev_dp_pullup_en,  // cio_usbdev_aon_dp_pullup
+                             unused_usbdev_dn_pullup_en,  // cio_usbdev_aon_dn_pullup
+                             unused_usbdev_tx_mode,       // cio_usbdev_aon_tx_mode_se
+                             unused_usbdev_suspend,       // cio_usbdev_aon_suspend
+                             unused_usbdev_d,             // cio_usbdev_aon_d_p2d
+                             USB_P,                       // cio_usbdev_aon_dp_p2d
+                             USB_N                        // cio_usbdev_aon_dn_p2d
                            } ),
     // Muxed IOs
     .mio_in_o            ( mio_in_padring   ),
@@ -300,14 +295,14 @@ module top_earlgrey_asic (
   prim_usb_diff_rx #(
     .CalibW(32)
   ) i_prim_usb_diff_rx (
-    .input_pi      ( IOC17               ),
-    .input_ni      ( IOC18               ),
-    .input_en_i    ( usbdev_aon_usb_rx_enable        ),
-    .core_pok_i    ( ast_usb_core_pok    ),
-    .pullup_p_en_i ( usb_pullup_p_en     ),
-    .pullup_n_en_i ( usb_pullup_n_en     ),
-    .calibration_i ( ast_usb_calibration ),
-    .input_o       ( usb_diff_input      )
+    .input_pi      ( USB_P                    ),
+    .input_ni      ( USB_N                    ),
+    .input_en_i    ( usbdev_aon_usb_rx_enable ),
+    .core_pok_i    ( ast_usb_core_pok         ),
+    .pullup_p_en_i ( usb_pullup_p_en          ),
+    .pullup_n_en_i ( usb_pullup_n_en          ),
+    .calibration_i ( ast_usb_calibration      ),
+    .input_o       ( usb_diff_input           )
   );
 
   //////////////////////

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -9,7 +9,7 @@
 
 // PERIPH_INSEL ranges from 0 to NUM_MIO + 2 -1}
 //  0 and 1 are tied to value 0 and 1
-#define NUM_MIO 47
+#define NUM_MIO 44
 #define NUM_DIO 21
 
 #define PINMUX_GPIO_GPIO_0_IN 0


### PR DESCRIPTION
Some additional fine tuning of the pinout according to our recent [cleaned up version](https://docs.google.com/spreadsheets/d/159h3LXlrOnhFFcu6rM-OeFmJsimcKn2mbGcGFotWGk4). 
This also allows to connect all `spidev` x4 data IOs properly, since two additional pads have been freed up.

~~Note that this PR depends on changes introduced in #2945, and hence the first commits up to `[top] Pinout tuning according to latest changes` can be ignored (they disappear after the next rebase).~~

