### PR TITLE
Otbn alu sim

### DIFF
--- a/hw/ip/otbn/README.md
+++ b/hw/ip/otbn/README.md
@@ -13,11 +13,37 @@ through the [GitHub issue tracker](https://github.com/lowRISC/opentitan/issues).
 
 ## Develop OTBN
 
-### Build the RTL implementation
+### Run the standalone simulation
 
-To build the RTL implementation of OTBN in a simulation, run `fusesoc` without
-passing the `OTBN_MODEL` flag. For example, the Verilator simulation can be
-compiled as follows.
+*Note that OTBN is still in the early development stages so this simulation will
+do very little currently*
+
+A standalone environment to run OTBN alone in verilator is included. It is built
+with `fusesoc`:
+
+```sh
+fusesoc --cores-root=. run --target=sim --setup --build lowrisc:ip:otbn_top_sim
+```
+
+It includes functionality to set the initial DMem and IMem contents with a .vmem
+or .elf file. The start address is hard coded to 0. Modify the `ImemStartAddr`
+parameter in `./dv/verilator/otbn_top_sim.sv` to change this. The simulation is
+run as follows:
+
+```sh
+./build/lowrisc_ip_otbn_top_sim_0.1/sim-verilator/Votbn_top_sim -t \
+  --meminit=imem,imem_contents.vmem --meminit=dmem,dmem_contents.vmem
+```
+
+This will initialise the IMem with `imem_contents.vmem` and the DMem with
+`dmem_contents.vmem`. The `-t` argument enables tracing. The simulation
+automatically halts on an `ecall` instruction.
+
+### Build the RTL implementation in OT earlgrey simulation
+
+To build the RTL implementation of OTBN in an earlgrey simulation, run `fusesoc`
+without passing the `OTBN_MODEL` flag. For example, the Verilator simulation can
+be compiled as follows.
 
 ```sh
 fusesoc --cores-root=. run --target=sim --setup --build lowrisc:systems:top_earlgrey_verilator

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.cc
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.cc
@@ -1,0 +1,58 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <svdpi.h>
+
+#include "verilated_toplevel.h"
+#include "verilator_memutil.h"
+#include "verilator_sim_ctrl.h"
+
+extern "C" {
+extern unsigned int otbn_base_reg_get(int index);
+}
+
+int main(int argc, char **argv) {
+  otbn_top_sim top;
+  VerilatorMemUtil memutil;
+  VerilatorSimCtrl &simctrl = VerilatorSimCtrl::GetInstance();
+  simctrl.SetTop(&top, &top.IO_CLK, &top.IO_RST_N,
+                 VerilatorSimCtrlFlags::ResetPolarityNegative);
+
+  memutil.RegisterMemoryArea(
+      "dmem", "TOP.otbn_top_sim.u_dmem.u_mem.gen_generic.u_impl_generic");
+  memutil.RegisterMemoryArea(
+      "imem", "TOP.otbn_top_sim.u_imem.u_mem.gen_generic.u_impl_generic");
+  simctrl.RegisterExtension(&memutil);
+
+  bool exit_app = false;
+  int ret_code = simctrl.ParseCommandArgs(argc, argv, exit_app);
+  if (exit_app) {
+    return ret_code;
+  }
+
+  std::cout << "Simulation of OTBN" << std::endl
+            << "==================" << std::endl
+            << std::endl;
+
+  simctrl.RunSimulation();
+
+  if (!simctrl.WasSimulationSuccessful()) {
+    return 1;
+  }
+
+  svSetScope(svGetScopeFromName("TOP.otbn_top_sim"));
+  std::cout << "Final Register Values:" << std::endl;
+  std::cout << "Reg | Value" << std::endl;
+  std::cout << "----------------" << std::endl;
+  for (int i = 1; i < 32; ++i) {
+    std::cout << std::dec << std::setw(2) << std::setfill(' ') << i << "  | 0x"
+              << std::hex << std::setw(8) << std::setfill('0')
+              << otbn_base_reg_get(i) << std::endl;
+  }
+
+  return 0;
+}

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.core
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.core
@@ -1,0 +1,67 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:ip:otbn_top_sim:0.1"
+description: "Standalone OpenTitan Big Number Accelerator (OTBN) simulation"
+
+filesets:
+  files_otbn:
+    depend:
+      - lowrisc:ip:otbn:0.1
+  files_verilator:
+    depend:
+      - lowrisc:dv_verilator:memutil_verilator
+      - lowrisc:dv_verilator:simutil_verilator
+    files:
+      - otbn_top_sim.cc: { file_type: cppSource }
+      - otbn_top_sim.sv: { file_type: systemVerilogSource }
+  files_verilator_waiver:
+    files:
+      - otbn_top_sim_waivers.vlt
+    file_type: vlt
+
+targets:
+  default: &default_target
+    filesets:
+      - files_verilator_waiver
+      - files_otbn
+      - files_verilator
+    toplevel: otbn_top_sim
+
+  lint:
+    <<: *default_target
+    default_tool: verilator
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"
+          # RAM primitives wider than 64bit (required for ECC) fail to build in
+          # Verilator without increasing the unroll count (see Verilator#1266)
+          - "--unroll-count 72"
+
+  sim:
+    <<: *default_target
+    default_tool: verilator
+    tools:
+      vcs:
+        vcs_options:
+          - '-xlrm uniq_prior_final'
+          - '-debug_access+r'
+      verilator:
+        mode: cc
+        verilator_options:
+          # Disabling tracing reduces compile times but doesn't have a
+          # huge influence on runtime performance.
+          - '--trace'
+          - '--trace-fst' # this requires -DVM_TRACE_FMT_FST in CFLAGS below!
+          - '--trace-structs'
+          - '--trace-params'
+          - '--trace-max-array 1024'
+          - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=otbn_top_sim"'
+          - '-LDFLAGS "-pthread -lutil -lelf"'
+          - "-Wall"
+          # RAM primitives wider than 64bit (required for ECC) fail to build in
+          # Verilator without increasing the unroll count (see Verilator#1266)
+          - "--unroll-count 72"

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -1,0 +1,170 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+module otbn_top_sim (
+  input IO_CLK,
+  input IO_RST_N
+);
+  import otbn_pkg::*;
+
+  // Size of the instruction memory, in bytes
+  parameter int ImemSizeByte = otbn_reg_pkg::OTBN_IMEM_SIZE;
+  // Size of the data memory, in bytes
+  parameter int DmemSizeByte = otbn_reg_pkg::OTBN_DMEM_SIZE;
+  // Start address of first instruction in IMem
+  parameter int ImemStartAddr = 32'h0;
+
+  localparam int ImemAddrWidth = prim_util_pkg::vbits(ImemSizeByte);
+  localparam int DmemAddrWidth = prim_util_pkg::vbits(DmemSizeByte);
+
+  logic otbn_done;
+  logic otbn_start;
+  logic otbn_start_done;
+
+  // Instruction memory (IMEM) signals
+  logic                     imem_req;
+  logic [ImemAddrWidth-1:0] imem_addr;
+  logic [31:0]              imem_rdata;
+  logic                     imem_rvalid;
+  logic [1:0]               imem_rerror;
+
+  // Data memory (DMEM) signals
+  logic                     dmem_req;
+  logic                     dmem_write;
+  logic [DmemAddrWidth-1:0] dmem_addr;
+  logic [WLEN-1:0]          dmem_wdata;
+  logic [WLEN-1:0]          dmem_wmask;
+  logic [WLEN-1:0]          dmem_rdata;
+  logic                     dmem_rvalid;
+  logic [1:0]               dmem_rerror;
+
+
+  otbn_core #(
+    .ImemSizeByte ( ImemSizeByte ),
+    .DmemSizeByte ( DmemSizeByte )
+  ) u_otbn_core (
+    .clk_i         ( IO_CLK        ),
+    .rst_ni        ( IO_RST_N      ),
+
+    .start_i       ( otbn_start    ),
+    .done_o        ( otbn_done     ),
+
+    .start_addr_i  ( ImemStartAddr ),
+
+    .imem_req_o    ( imem_req      ),
+    .imem_addr_o   ( imem_addr     ),
+    .imem_wdata_o  (               ),
+    .imem_rdata_i  ( imem_rdata    ),
+    .imem_rvalid_i ( imem_rvalid   ),
+    .imem_rerror_i ( imem_rerror   ),
+
+    .dmem_req_o    ( dmem_req      ),
+    .dmem_write_o  ( dmem_write    ),
+    .dmem_addr_o   ( dmem_addr     ),
+    .dmem_wdata_o  ( dmem_wdata    ),
+    .dmem_wmask_o  ( dmem_wmask    ),
+    .dmem_rdata_i  ( dmem_rdata    ),
+    .dmem_rvalid_i ( dmem_rvalid   ),
+    .dmem_rerror_i ( dmem_rerror   )
+  );
+
+  // Pulse otbn_start for 1 cycle immediately out of reset
+  always @(posedge IO_CLK or negedge IO_RST_N) begin
+    if(!IO_RST_N) begin
+      otbn_start      <= 1'b0;
+      otbn_start_done <= 1'b0;
+    end else begin
+      if (!otbn_start_done) begin
+        otbn_start      <= 1'b1;
+        otbn_start_done <= 1'b1;
+      end else if (otbn_start) begin
+        otbn_start <= 1'b0;
+      end
+    end
+  end
+
+  localparam int DmemSizeWords = DmemSizeByte / (WLEN / 8);
+  localparam int DmemIndexWidth = prim_util_pkg::vbits(DmemSizeWords);
+
+  logic [DmemIndexWidth-1:0] dmem_index;
+  logic [DmemAddrWidth-DmemIndexWidth-1:0] unused_dmem_addr;
+
+  assign dmem_index = dmem_addr[DmemAddrWidth-1:DmemAddrWidth-DmemIndexWidth];
+  assign unused_dmem_addr = dmem_addr[DmemAddrWidth-DmemIndexWidth-1:0];
+
+  prim_ram_1p_adv #(
+    .Width           ( WLEN          ),
+    .Depth           ( DmemSizeWords ),
+    .DataBitsPerMask ( 32            ),
+    .CfgW            ( 8             )
+  ) u_dmem (
+    .clk_i    ( IO_CLK      ),
+    .rst_ni   ( IO_RST_N    ),
+    .req_i    ( dmem_req    ),
+    .write_i  ( dmem_write  ),
+    .addr_i   ( dmem_index  ),
+    .wdata_i  ( dmem_wdata  ),
+    .wmask_i  ( dmem_wmask  ),
+    .rdata_o  ( dmem_rdata  ),
+    .rvalid_o ( dmem_rvalid ),
+    .rerror_o ( dmem_rerror ),
+    .cfg_i    ( '0          )
+  );
+
+  localparam int ImemSizeWords = ImemSizeByte / 4;
+  localparam int ImemIndexWidth = prim_util_pkg::vbits(ImemSizeWords);
+
+  logic [ImemIndexWidth-1:0] imem_index;
+  logic [1:0] unused_imem_addr;
+
+  assign imem_index = imem_addr[ImemAddrWidth-1:2];
+  assign unused_imem_addr = imem_addr[1:0];
+
+  prim_ram_1p_adv #(
+    .Width           ( 32            ),
+    .Depth           ( ImemSizeWords ),
+    .DataBitsPerMask ( 32            ),
+    .CfgW            ( 8             )
+  ) u_imem (
+    .clk_i    ( IO_CLK      ),
+    .rst_ni   ( IO_RST_N    ),
+    .req_i    ( imem_req    ),
+    .write_i  ( 1'b0        ),
+    .addr_i   ( imem_index  ),
+    .wdata_i  ( '0          ),
+    .wmask_i  ( '0          ),
+    .rdata_o  ( imem_rdata  ),
+    .rvalid_o ( imem_rvalid ),
+    .rerror_o ( imem_rerror ),
+    .cfg_i    ( '0          )
+  );
+
+
+  // When OTBN is done let a few more cycles run then finish simulation
+  logic [1:0] finish_counter;
+
+  always @(posedge IO_CLK or negedge IO_RST_N) begin
+    if (!IO_RST_N) begin
+      finish_counter <= 2'd0;
+    end else begin
+      if (otbn_done) begin
+        finish_counter <= 2'd1;
+      end
+
+      if (finish_counter != 0) begin
+        finish_counter <= finish_counter + 2'd1;
+      end
+
+      if (finish_counter == 2'd3) begin
+        $finish;
+      end
+    end
+  end
+
+  export "DPI-C" function otbn_base_reg_get;
+
+  function automatic int unsigned otbn_base_reg_get(int index);
+    return u_otbn_core.u_otbn_rf_base.rf_reg[index];
+  endfunction
+endmodule

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim_waivers.vlt
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim_waivers.vlt
@@ -1,0 +1,9 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`verilator_config
+
+lint_off -rule WIDTH -file "*/otbn_top_sim.sv" -match "*'OTBN_IMEM_SIZE' generates 22 bits*"
+lint_off -rule WIDTH -file "*/otbn_top_sim.sv" -match "*'OTBN_DMEM_SIZE' generates 22 bits*"
+lint_off -rule WIDTH -file "*/otbn_top_sim.sv" -match "*'ImemStartAddr' generates 32 bits*"

--- a/hw/ip/otbn/lint/otbn.vlt
+++ b/hw/ip/otbn/lint/otbn.vlt
@@ -1,0 +1,10 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`verilator_config
+
+// Temporary rule to turn off all unused warnings until implementation is more
+// complete
+lint_off -rule UNUSED -file "*/rtl/otbn_*"
+

--- a/hw/ip/otbn/otbn.core
+++ b/hw/ip/otbn/otbn.core
@@ -47,6 +47,15 @@ filesets:
       - dv/model/otbn_core_model.sv
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/otbn.vlt
+    file_type: vlt
+
 parameters:
   SYNTHESIS:
     datatype: bool
@@ -55,6 +64,7 @@ parameters:
 targets:
   default: &default_target
     filesets:
+      - tool_verilator ? (files_verilator_waiver)
       - files_rtl_pkg
       - files_rtl_core
       - files_rtl_top

--- a/hw/ip/otbn/rtl/otbn_alu_base.sv
+++ b/hw/ip/otbn/rtl/otbn_alu_base.sv
@@ -17,21 +17,99 @@ module otbn_alu_base
   input  logic                 rst_ni,
 
   input  alu_base_operation_t  operation_i,
+  input  alu_base_comparison_t comparison_i,
 
-  output logic [31:0]          result_o,
+  output logic [31:0]          operation_result_o,
   output logic                 comparison_result_o
 );
 
+  logic [32:0] adder_op_a, adder_op_b;
+  logic        adder_op_b_negate;
+  logic [33:0] adder_result;
+
+  logic [31:0] and_result;
+  logic [31:0] or_result;
+  logic [31:0] xor_result;
+  logic [31:0] not_result;
+
+  logic  is_equal;
+
+  ///////////
+  // Adder //
+  ///////////
+
+  // Adder takes in 33-bit operands. The addition of the input operands occurs on bits [32:1],
+  // setting addr_op_b_negate will cause a carry-in into bit 1. Combined with an inversion of
+  // operation_i.operand_b this gives a two's-complement negation (~b + 1)
+
+  assign adder_op_b_negate = operation_i.op == AluOpSub;
+
+  assign adder_op_a = {operation_i.operand_a, 1'b1};
+  assign adder_op_b = adder_op_b_negate ? {~operation_i.operand_b, 1'b1} : {operation_i.operand_b, 1'b0};
+
+  assign adder_result = adder_op_a + adder_op_b;
+
+  //////////////////////////
+  // Bit-wise logical ops //
+  //////////////////////////
+
+  assign and_result = operation_i.operand_a & operation_i.operand_b;
+  assign or_result  = operation_i.operand_a | operation_i.operand_b;
+  assign xor_result = operation_i.operand_a ^ operation_i.operand_b;
+  assign not_result = ~operation_i.operand_a;
+
+  /////////////
+  // Shifter //
+  /////////////
+
+  logic [32:0] shift_in;
+  logic [4:0]  shift_amt;
+  logic [31:0] operand_a_reverse;
+  logic [32:0] shift_out;
+  logic [31:0] shift_out_reverse;
+
+  for (genvar i = 0;i < 32; i++) begin : g_shifter_reverses
+    assign operand_a_reverse[i] = operation_i.operand_a[31-i];
+    assign shift_out_reverse[i] = shift_out[31-i];
+  end
+
+  assign shift_amt = operation_i.operand_b[4:0];
+  // Shifter performs right arithmetic 33-bit shifts. Force top bit to 0 to get logical shifting
+  // otherwise replicate top bit of shift_in. Left shifts performed by reversing the input and
+  // output.
+  assign shift_in[31:0] = (operation_i.op == AluOpSll) ? operand_a_reverse : operation_i.operand_a;
+  assign shift_in[32] = (operation_i.op == AluOpSra) ? operation_i.operand_a[31] : 1'b0;
+
+  assign shift_out = signed'(shift_in) >>> shift_amt;
+
+  ////////////////
+  // Output Mux //
+  ////////////////
+
   always_comb begin
+    operation_result_o = adder_result[32:1];
+
     unique case (operation_i.op)
-      AluOpAdd: begin
-        result_o = operation_i.operand_a + operation_i.operand_b;
-        comparison_result_o = operation_i.operand_a == operation_i.operand_b;
-      end
-      default: begin
-        result_o = '0;
-        comparison_result_o = 1'b0;
-      end
+      AluOpAnd: operation_result_o = and_result;
+      AluOpOr:  operation_result_o = or_result;
+      AluOpXor: operation_result_o = xor_result;
+      AluOpNot: operation_result_o = not_result;
+      AluOpSra: operation_result_o = shift_out[31:0];
+      AluOpSrl: operation_result_o = shift_out[31:0];
+      AluOpSll: operation_result_o = shift_out_reverse;
+      default: ;
     endcase
   end
+
+  /////////////////
+  // Comparisons //
+  /////////////////
+
+  // Dedicated comparator to deal with branches. As only Equal/Not-Equal is required no need to use
+  // the adder (which frees it to compute the branch target in the same cycle). No point in using
+  // existing XOR logic as area added from extra mux to choose xor operands negates area saving from
+  // avoiding an dedicated comparator.
+  assign is_equal = comparison_i.operand_a == comparison_i.operand_b;
+
+  assign comparison_result_o = (comparison_i.op == ComparisonOpEq) ? is_equal : ~is_equal;
 endmodule

--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -32,7 +32,6 @@ module otbn_controller
   // Fetched/decoded instruction
   input  logic                     insn_valid_i,
   input  logic [ImemAddrWidth-1:0] insn_addr_i,
-  input  insn_op_e                 insn_op_i,
 
   // Decoded instruction data, matching the "Decoding" section of the specification.
   input insn_dec_base_t       insn_dec_base_i,
@@ -59,9 +58,7 @@ module otbn_controller
 
   logic running_q, running_d;
 
-  // TODO: Using insn_op_i here is easy, potentially should move to dedicated control signals from
-  // the decoder in the future.
-  assign done_o = insn_valid_i && insn_op_i == InsnOpEcall;
+  assign done_o = insn_valid_i && insn_dec_ctrl_i.ecall_insn;
 
   always_comb begin
     running_d              = running_q;
@@ -125,9 +122,9 @@ module otbn_controller
   assign alu_base_comparison_o.op = ComparisonOpEq;
 
   // Register file write MUX
-  // TODO: Switch between CSR and EX writeback.
-  assign rf_base_wr_en_o = 1'b0;
-  assign rf_base_wr_addr_o = '0;
-  assign rf_base_wr_data_o = '0;
+  // TODO: Switch between CSR/ALU/LSU writeback.
+  assign rf_base_wr_en_o   = insn_dec_ctrl_i.rf_we;
+  assign rf_base_wr_addr_o = insn_dec_base_i.d;
+  assign rf_base_wr_data_o = alu_base_operation_result_i;
 
 endmodule

--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -127,5 +127,7 @@ module otbn_controller
   // Register file write MUX
   // TODO: Switch between CSR and EX writeback.
   assign rf_base_wr_en_o = 1'b0;
+  assign rf_base_wr_addr_o = '0;
+  assign rf_base_wr_data_o = '0;
 
 endmodule

--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -50,9 +50,10 @@ module otbn_controller
   input  logic [31:0]  rf_base_rd_data_b_i,
 
   // Execution units
-  output alu_base_operation_t alu_base_operation_o,
-  input  logic [31:0]         alu_base_result_i,
-  input  logic                alu_base_comparison_result_i
+  output alu_base_operation_t  alu_base_operation_o,
+  output alu_base_comparison_t alu_base_comparison_o,
+  input  logic [31:0]          alu_base_operation_result_i,
+  input  logic                 alu_base_comparison_result_i
 );
 
   // TODO: Using insn_op_i here is easy, potentially should move to dedicated control signals from
@@ -96,6 +97,11 @@ module otbn_controller
   end
 
   assign alu_base_operation_o.op = insn_dec_ctrl_i.alu_op;
+
+  assign alu_base_comparison_o.operand_a = rf_base_rd_data_a_i;
+  assign alu_base_comparison_o.operand_b = rf_base_rd_data_b_i;
+  // TODO: Choose comparison required for branch
+  assign alu_base_comparison_o.op = ComparisonOpEq;
 
   // Register file write MUX
   // TODO: Switch between CSR and EX writeback.

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -116,6 +116,8 @@ module otbn_core
     .insn_fetch_resp_data_o  (insn_fetch_resp_data)
   );
 
+  assign imem_wdata_o = '0;
+
   // Instruction decoder
   otbn_decoder u_otbn_decoder (
     // The decoder is combinatorial; clk and rst are only used for assertions.

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -81,9 +81,10 @@ module otbn_core
   logic [4:0]   rf_base_rd_addr_b;
   logic [31:0]  rf_base_rd_data_b;
 
-  alu_base_operation_t alu_base_operation;
-  logic [31:0]         alu_base_result;
-  logic                alu_base_comparison_result;
+  alu_base_operation_t  alu_base_operation;
+  alu_base_comparison_t alu_base_comparison;
+  logic [31:0]          alu_base_operation_result;
+  logic                 alu_base_comparison_result;
 
   // Depending on its usage, the instruction address (program counter) is qualified by two valid
   // signals: insn_fetch_resp_valid (together with the undecoded instruction data), and insn_valid
@@ -169,7 +170,8 @@ module otbn_core
 
     // To/from base ALU
     .alu_base_operation_o         (alu_base_operation),
-    .alu_base_result_i            (alu_base_result),
+    .alu_base_comparison_o        (alu_base_comparison),
+    .alu_base_operation_result_i  (alu_base_operation_result),
     .alu_base_comparison_result_i (alu_base_comparison_result)
   );
 
@@ -226,7 +228,8 @@ module otbn_core
     .rst_ni,
 
     .operation_i         (alu_base_operation),
-    .result_o            (alu_base_result),
+    .comparison_i        (alu_base_comparison),
+    .operation_result_o  (alu_base_operation_result),
     .comparison_result_o (alu_base_comparison_result)
   );
 

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -67,8 +67,8 @@ module otbn_core
 
   // The currently executed instruction.
   logic                     insn_valid;
+  logic                     insn_illegal;
   logic [ImemAddrWidth-1:0] insn_addr;
-  insn_op_e                 insn_op;
   insn_dec_base_t           insn_dec_base;
 
   insn_dec_ctrl_t insn_dec_ctrl;
@@ -130,7 +130,7 @@ module otbn_core
 
     // Decoded instruction
     .insn_valid_o    (insn_valid),
-    .insn_op_o       (insn_op),
+    .insn_illegal_o  (insn_illegal),
     .insn_dec_base_o (insn_dec_base),
     .insn_dec_ctrl_o (insn_dec_ctrl)
   );
@@ -155,7 +155,6 @@ module otbn_core
     // The current instruction
     .insn_valid_i (insn_valid),
     .insn_addr_i  (insn_addr),
-    .insn_op_i    (insn_op),
 
     // Decoded instruction from decoder
     .insn_dec_base_i (insn_dec_base),

--- a/hw/ip/otbn/rtl/otbn_decoder.sv
+++ b/hw/ip/otbn/rtl/otbn_decoder.sv
@@ -5,7 +5,7 @@
 `include "prim_assert.sv"
 
 /**
- * OTBN Instruction Decoder
+ * OTBN instruction Decoder
  */
 module otbn_decoder
   import otbn_pkg::*;
@@ -14,7 +14,7 @@ module otbn_decoder
   input  logic                 clk_i,
   input  logic                 rst_ni,
 
-  // Instruction data to be decoded
+  // instruction data to be decoded
   input  logic [31:0]          insn_fetch_resp_data_i,
   input  logic                 insn_fetch_resp_valid_i,
 
@@ -29,21 +29,319 @@ module otbn_decoder
   output insn_dec_ctrl_t       insn_dec_ctrl_o
 );
 
-  // Example: ADD
-  assign insn_valid_o = insn_fetch_resp_valid_i;
-  assign insn_op_o    = InsnOpAlu;
+  logic        illegal_insn;
+  logic        rf_we;
+
+  logic [31:0] insn;
+  logic [31:0] insn_alu;
+
+  // Source/Destination register instruction index
+  logic [4:0] insn_rs1;
+  logic [4:0] insn_rs2;
+  logic [4:0] insn_rd;
+
+  insn_opcode_e     opcode;
+  insn_opcode_e     opcode_alu;
+
+  // To help timing the flops containing the current instruction are replicated to reduce fan-out.
+  // insn_alu is used to determine the ALU control logic and associated operand/imm select signals
+  // as the ALU is often on the more critical timing paths. insn is used for everything else.
+  // TODO: Actually replicate flops, if needed.
+  assign insn     = insn_fetch_resp_data_i;
+  assign insn_alu = insn_fetch_resp_data_i;
+
+  //////////////////////////////////////
+  // Register and immediate selection //
+  //////////////////////////////////////
+  imm_a_sel_e  imm_a_mux_sel;       // immediate selection for operand a
+  imm_b_sel_e  imm_b_mux_sel;       // immediate selection for operand b
+
+  logic [31:0] imm_i_type;
+  logic [31:0] imm_s_type;
+  logic [31:0] imm_b_type;
+  logic [31:0] imm_u_type;
+  logic [31:0] imm_j_type;
+
+  alu_op_e    alu_operator;        // ALU operation selection
+  op_a_sel_e  alu_op_a_mux_sel;    // operand a selection: reg value, PC, immediate or zero
+  op_b_sel_e  alu_op_b_mux_sel;    // operand b selection: reg value or immediate
+
+  logic rf_ren_a;
+  logic rf_ren_b;
+
+  // immediate extraction and sign extension
+  assign imm_i_type = { {20{insn[31]}}, insn[31:20] };
+  assign imm_s_type = { {20{insn[31]}}, insn[31:25], insn[11:7] };
+  assign imm_b_type = { {19{insn[31]}}, insn[31], insn[7], insn[30:25], insn[11:8], 1'b0 };
+  assign imm_u_type = { insn[31:12], 12'b0 };
+  assign imm_j_type = { {12{insn[31]}}, insn[19:12], insn[20], insn[30:21], 1'b0 };
+
+  // source registers
+  assign insn_rs1 = insn[19:15];
+  assign insn_rs2 = insn[24:20];
+
+  // destination register
+  assign insn_rd = insn[11:7];
+
+  insn_subset_e insn_subset;
+  rf_wd_sel_e rf_wdata_sel;
+
+  logic ecall_insn;
+
+  // Reduced main ALU immediate MUX for Operand B
+  logic [31:0] imm_b;
+  always_comb begin : immediate_b_mux
+    unique case (imm_b_mux_sel)
+      ImmBI:         imm_b = imm_i_type;
+      ImmBS:         imm_b = imm_s_type;
+      ImmBU:         imm_b = imm_u_type;
+      default:       imm_b = 32'h4;
+    endcase
+  end
+
+  assign insn_valid_o = ~illegal_insn;
+
+  // TODO: Completely remove?
+  assign insn_op_o = InsnOpAlu;
 
   assign insn_dec_base_o = '{
-    d: insn_fetch_resp_data_i[11:7],
-    a: insn_fetch_resp_data_i[19:15],
-    b: insn_fetch_resp_data_i[24:20],
-    i: '0
+    a: insn_rs1,
+    b: insn_rs2,
+    d: insn_rd,
+    i: imm_b
   };
 
   assign insn_dec_ctrl_o = '{
-    subset:   InsnSubsetBase,
-    op_a_sel: OpASelRegister,
-    op_b_sel: OpBSelRegister,
-    alu_op:   AluOpAdd
+    subset:       insn_subset,
+    op_a_sel:     alu_op_a_mux_sel,
+    op_b_sel:     alu_op_b_mux_sel,
+    alu_op:       alu_operator,
+    rf_we:        rf_we,
+    rf_wdata_sel: rf_wdata_sel,
+    ecall_insn:   ecall_insn
   };
+
+  /////////////
+  // Decoder //
+  /////////////
+
+  always_comb begin
+    rf_wdata_sel          = RfWdSelEx;
+    rf_we                 = 1'b0;
+    rf_ren_a              = 1'b0;
+    rf_ren_b              = 1'b0;
+
+    illegal_insn          = 1'b0;
+    ecall_insn            = 1'b0;
+
+    opcode                = insn_opcode_e'(insn[6:0]);
+
+    unique case (opcode)
+      /////////
+      // ALU //
+      /////////
+
+      InsnOpcodeBaseLui: begin  // Load Upper Immediate
+        insn_subset      = InsnSubsetBase;
+        rf_we            = 1'b1;
+      end
+
+      InsnOpcodeBaseOpImm: begin // Register-Immediate ALU Operations
+        insn_subset      = InsnSubsetBase;
+        rf_ren_a         = 1'b1;
+        rf_we            = 1'b1;
+
+        unique case (insn[14:12])
+          3'b000,
+          3'b010,
+          3'b011,
+          3'b100,
+          3'b110,
+          3'b111: illegal_insn = 1'b0;
+
+          3'b001: begin
+            unique case (insn[31:27])
+              5'b0_0000: illegal_insn = 1'b0;                                         // slli
+              default: illegal_insn = 1'b1;
+            endcase
+          end
+
+          3'b101: begin
+            if (!insn[26]) begin
+              unique case (insn[31:27])
+                5'b0_0000,                                                             // srli
+                5'b0_1000: illegal_insn = 1'b0;                                        // srai
+
+                default: illegal_insn = 1'b1;
+              endcase
+            end
+          end
+
+          default: illegal_insn = 1'b1;
+        endcase
+      end
+
+      InsnOpcodeBaseOp: begin  // Register-Register ALU operation
+        insn_subset     = InsnSubsetBase;
+        rf_ren_a        = 1'b1;
+        rf_ren_b        = 1'b1;
+        rf_we           = 1'b1;
+        if ({insn[26], insn[13:12]} != {1'b1, 2'b01}) begin
+          unique case ({insn[31:25], insn[14:12]})
+            // RV32I ALU operations
+            {7'b000_0000, 3'b000},
+            {7'b010_0000, 3'b000},
+            {7'b000_0000, 3'b010},
+            {7'b000_0000, 3'b011},
+            {7'b000_0000, 3'b100},
+            {7'b000_0000, 3'b110},
+            {7'b000_0000, 3'b111},
+            {7'b000_0000, 3'b001},
+            {7'b000_0000, 3'b101},
+            {7'b010_0000, 3'b101}: illegal_insn = 1'b0;
+            default: begin
+              illegal_insn = 1'b1;
+            end
+          endcase
+        end
+      end
+
+
+      InsnOpcodeBaseSystem: begin
+        insn_subset = InsnSubsetBase;
+        if (insn[14:12] == 3'b000) begin
+          // non CSR related SYSTEM instructions
+          unique case (insn[31:20])
+            12'h000:  // ECALL
+              ecall_insn = 1'b1;
+
+            default:
+              illegal_insn = 1'b1;
+          endcase
+
+          // rs1 and rd must be 0
+          if (insn_rs1 != 5'b0 || insn_rd != 5'b0) begin
+            illegal_insn = 1'b1;
+          end
+        end else begin
+          illegal_insn = 1'b1;
+        end
+      end
+
+      default: illegal_insn = 1'b1;
+    endcase
+
+
+    // make sure illegal instructions detected in the decoder do not propagate from decoder
+    // NOTE: instructions can also be detected to be illegal inside the CSRs (upon accesses with
+    // insufficient privileges). These cases are not handled here.
+    if (illegal_insn) begin
+      rf_we           = 1'b0;
+    end
+  end
+
+  /////////////////////////////
+  // Decoder for ALU control //
+  /////////////////////////////
+
+  always_comb begin
+    alu_operator     = AluOpAdd;
+    alu_op_a_mux_sel = OpASelImmediate;
+    alu_op_b_mux_sel = OpBSelImmediate;
+
+    imm_a_mux_sel    = ImmAZero;
+    imm_b_mux_sel    = ImmBI;
+
+    opcode_alu         = insn_opcode_e'(insn_alu[6:0]);
+
+    unique case (opcode_alu)
+      /////////
+      // ALU //
+      /////////
+
+      InsnOpcodeBaseLui: begin  // Load Upper Immediate
+        alu_op_a_mux_sel  = OpASelImmediate;
+        alu_op_b_mux_sel  = OpBSelImmediate;
+        imm_a_mux_sel     = ImmAZero;
+        imm_b_mux_sel     = ImmBU;
+        alu_operator      = AluOpAdd;
+      end
+
+      InsnOpcodeBaseAuipc: begin  // Add Upper Immediate to PC
+        alu_op_a_mux_sel  = OpASelCurrPc;
+        alu_op_b_mux_sel  = OpBSelImmediate;
+        imm_b_mux_sel     = ImmBU;
+        alu_operator      = AluOpAdd;
+      end
+
+      InsnOpcodeBaseOpImm: begin // Register-Immediate ALU Operations
+        alu_op_a_mux_sel  = OpASelRegister;
+        alu_op_b_mux_sel  = OpBSelImmediate;
+        imm_b_mux_sel     = ImmBI;
+
+        unique case (insn_alu[14:12])
+          3'b000: alu_operator = AluOpAdd;  // Add Immediate
+          3'b100: alu_operator = AluOpXor;  // Exclusive Or with Immediate
+          3'b110: alu_operator = AluOpOr;   // Or with Immediate
+          3'b111: alu_operator = AluOpAnd;  // And with Immediate
+
+          3'b001: begin
+            alu_operator = AluOpSll; // Shift Left Logical by Immediate
+          end
+
+          3'b101: begin
+            if (insn_alu[31:27] == 5'b0_0000) begin
+              alu_operator = AluOpSrl;               // Shift Right Logical by Immediate
+            end else if (insn_alu[31:27] == 5'b0_1000) begin
+              alu_operator = AluOpSra;               // Shift Right Arithmetically by Immediate
+            end
+          end
+
+          default: ;
+        endcase
+      end
+
+      InsnOpcodeBaseOp: begin  // Register-Register ALU operation
+        alu_op_a_mux_sel = OpASelRegister;
+        alu_op_b_mux_sel = OpBSelRegister;
+
+        if (!insn_alu[26]) begin
+          unique case ({insn_alu[31:25], insn_alu[14:12]})
+            // RV32I ALU operations
+            {7'b000_0000, 3'b000}: alu_operator = AluOpAdd;   // Add
+            {7'b010_0000, 3'b000}: alu_operator = AluOpSub;   // Sub
+            {7'b000_0000, 3'b100}: alu_operator = AluOpXor;   // Xor
+            {7'b000_0000, 3'b110}: alu_operator = AluOpOr;    // Or
+            {7'b000_0000, 3'b111}: alu_operator = AluOpAnd;   // And
+            {7'b000_0000, 3'b001}: alu_operator = AluOpSll;   // Shift Left Logical
+            {7'b000_0000, 3'b101}: alu_operator = AluOpSrl;   // Shift Right Logical
+            {7'b010_0000, 3'b101}: alu_operator = AluOpSra;   // Shift Right Arithmetic
+            default: ;
+          endcase
+        end
+      end
+
+      /////////////
+      // Special //
+      /////////////
+
+      InsnOpcodeBaseSystem: begin
+        if (insn_alu[14:12] == 3'b000) begin
+          // non CSR related SYSTEM instructions
+          alu_op_a_mux_sel = OpASelRegister;
+          alu_op_b_mux_sel = OpBSelImmediate;
+        end
+
+      end
+      default: ;
+    endcase
+  end
+
+  ////////////////
+  // Assertions //
+  ////////////////
+
+  // Selectors must be known/valid.
+  `ASSERT(IbexRegImmAluOpKnown, (opcode == InsnOpcodeBaseOpImm) |->
+      !$isunknown(insn[14:12]))
 endmodule

--- a/hw/ip/otbn/rtl/otbn_decoder.sv
+++ b/hw/ip/otbn/rtl/otbn_decoder.sv
@@ -31,7 +31,7 @@ module otbn_decoder
 
   // Example: ADD
   assign insn_valid_o = insn_fetch_resp_valid_i;
-  assign insn_op_o = InsnOpAdd;
+  assign insn_op_o    = InsnOpAlu;
 
   assign insn_dec_base_o = '{
     d: insn_fetch_resp_data_i[11:7],
@@ -44,6 +44,6 @@ module otbn_decoder
     subset:   InsnSubsetBase,
     op_a_sel: OpASelRegister,
     op_b_sel: OpBSelRegister,
-    alu_op: AluOpAdd
+    alu_op:   AluOpAdd
   };
 endmodule

--- a/hw/ip/otbn/rtl/otbn_decoder.sv
+++ b/hw/ip/otbn/rtl/otbn_decoder.sv
@@ -20,7 +20,7 @@ module otbn_decoder
 
   // Decoded instruction
   output logic                 insn_valid_o,
-  output insn_op_e             insn_op_o,
+  output logic                 insn_illegal_o,
 
   // Decoded instruction data, matching the "Decoding" section of the specification.
   output insn_dec_base_t       insn_dec_base_o,
@@ -99,10 +99,8 @@ module otbn_decoder
     endcase
   end
 
-  assign insn_valid_o = ~illegal_insn;
-
-  // TODO: Completely remove?
-  assign insn_op_o = InsnOpAlu;
+  assign insn_valid_o   = insn_fetch_resp_valid_i & ~illegal_insn;
+  assign insn_illegal_o = insn_fetch_resp_valid_i & illegal_insn;
 
   assign insn_dec_base_o = '{
     a: insn_rs1,

--- a/hw/ip/otbn/rtl/otbn_lsu.sv
+++ b/hw/ip/otbn/rtl/otbn_lsu.sv
@@ -36,6 +36,11 @@ module otbn_lsu
 
 );
 
+  // tie-off to 0 to prevent warnings until implementation is done
   assign dmem_req_o = 1'b0;
+  assign dmem_write_o = 1'b0;
+  assign dmem_addr_o = '0;
+  assign dmem_wdata_o = '0;
+  assign dmem_wmask_o = '0;
 
 endmodule

--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -52,7 +52,7 @@ package otbn_pkg;
   // Instructions
   // TODO: Extend and add an explicit type.
   typedef enum {
-    InsnOpAdd,
+    InsnOpAlu,
     InsnOpEcall
   } insn_op_e;
 

--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -49,6 +49,22 @@ package otbn_pkg;
     InsnSubsetBignum = 1'b1 // Big Number (BN/Wide) Instruction Subset
   } insn_subset_e;
 
+  // Opcodes (field [6:0] in the instruction), matching the RISC-V specification for the base
+  // instruction subset.
+  typedef enum logic [6:0] {
+    InsnOpcodeBaseLoad     = 7'h03,
+    InsnOpcodeBaseMemMisc  = 7'h0f,
+    InsnOpcodeBaseOpImm    = 7'h13,
+    InsnOpcodeBaseAuipc    = 7'h17,
+    InsnOpcodeBaseStore    = 7'h23,
+    InsnOpcodeBaseOp       = 7'h33,
+    InsnOpcodeBaseLui      = 7'h37,
+    InsnOpcodeBaseBranch   = 7'h63,
+    InsnOpcodeBaseJalr     = 7'h67,
+    InsnOpcodeBaseJal      = 7'h6f,
+    InsnOpcodeBaseSystem   = 7'h73
+  } insn_opcode_e;
+
   // Instructions
   // TODO: Extend and add an explicit type.
   typedef enum {
@@ -65,6 +81,9 @@ package otbn_pkg;
     AluOpAnd,
     AluOpNot,
 
+    AluOpEq,
+    AluOpNe,
+
     AluOpSra,
     AluOpSrl,
     AluOpSll
@@ -76,9 +95,11 @@ package otbn_pkg;
   } comparison_op_e;
 
   // Operand a source selection
-  typedef enum logic {
-    OpASelRegister  = 1'b0,
-    OpASelImmediate = 1'b1
+  typedef enum logic [1:0] {
+    OpASelRegister  = 'd0,
+    OpASelImmediate = 'd1,
+    OpASelFwd = 'd2,
+    OpASelCurrPc = 'd3
   } op_a_sel_e;
 
   // Operand b source selection
@@ -86,6 +107,26 @@ package otbn_pkg;
     OpBSelRegister  = 1'b0,
     OpBSelImmediate = 1'b1
   } op_b_sel_e;
+
+
+  // Immediate a selection
+  typedef enum logic {
+    ImmAZero
+  } imm_a_sel_e;
+
+  // Immediate b selection
+  typedef enum logic [2:0] {
+    ImmBI,
+    ImmBS,
+    ImmBB,
+    ImmBU,
+    ImmBJ
+  } imm_b_sel_e;
+
+  // Regfile write data selection
+  typedef enum logic {
+    RfWdSelEx
+  } rf_wd_sel_e;
 
   // Control and Status Registers (CSRs)
   parameter int CsrNumWidth = 12;
@@ -101,7 +142,6 @@ package otbn_pkg;
     CsrMod7  = 12'h7D7,
     CsrRnd   = 12'hFC0
   } csr_e;
-
 
   // Wide Special Purpose Registers (WSRs)
   parameter int NWsr = 3; // Number of WSRs
@@ -133,6 +173,9 @@ package otbn_pkg;
     op_a_sel_e    op_a_sel;
     op_b_sel_e    op_b_sel;
     alu_op_e      alu_op;
+    logic         rf_we;
+    rf_wd_sel_e   rf_wdata_sel;
+    logic         ecall_insn;
   } insn_dec_ctrl_t;
 
   typedef struct packed {

--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -65,9 +65,15 @@ package otbn_pkg;
     AluOpAnd,
     AluOpNot,
 
-    AluOpEq,
-    AluOpNeq
+    AluOpSra,
+    AluOpSrl,
+    AluOpSll
   } alu_op_e;
+
+  typedef enum logic {
+    ComparisonOpEq,
+    ComparisonOpNeq
+  } comparison_op_e;
 
   // Operand a source selection
   typedef enum logic {
@@ -134,5 +140,11 @@ package otbn_pkg;
     logic [31:0] operand_a;
     logic [31:0] operand_b;
   } alu_base_operation_t;
+
+  typedef struct packed {
+    comparison_op_e op;
+    logic [31:0] operand_a;
+    logic [31:0] operand_b;
+  } alu_base_comparison_t;
 
 endpackage

--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -65,13 +65,7 @@ package otbn_pkg;
     InsnOpcodeBaseSystem   = 7'h73
   } insn_opcode_e;
 
-  // Instructions
-  // TODO: Extend and add an explicit type.
-  typedef enum {
-    InsnOpAlu,
-    InsnOpEcall
-  } insn_op_e;
-
+  // ALU Operations
   typedef enum logic [3:0] {
     AluOpAdd,
     AluOpSub,
@@ -80,9 +74,6 @@ package otbn_pkg;
     AluOpOr,
     AluOpAnd,
     AluOpNot,
-
-    AluOpEq,
-    AluOpNe,
 
     AluOpSra,
     AluOpSrl,


### PR DESCRIPTION
This adds an ALU implementation that will give us the functionality required to implement all of the RV32I subset we are using (I think, I could be wrong!).

In addition it adds a basic verilator simulation to allow you to run OTBN standalone, I have included a lint target and waivers. OTBN is lint clean with this PR (though I've waived all UNUSED warnings as given it's an implementation skeleton we've got quite a few!).

I have got a version running that uses a 'fake' decoder with a couple of other tweaks that successfully runs code, I don't see the point in including this in otbn-dev but for anyone interested you can find it here: https://github.com/GregAC/opentitan/tree/otbn-fake-decode/hw/ip/otbn