### PR TITLE
[otbn] Auto-generate linker script based on otbn.hjson

### DIFF
--- a/hw/ip/otbn/data/otbn.ld.tpl
+++ b/hw/ip/otbn/data/otbn.ld.tpl
@@ -6,19 +6,18 @@
   OTBN has a pure Harvard architecture, with instruction and data
   memory both starting at address 0.
 
-  We give each 1MiB of space: too much for the eventual chip - let's
-  come back to this once we know how much space we'll have or (harder)
-  auto-generate it from the address map.
+  This linker script template is interpolated by otbn-ld after it gets
+  the LMAs and memory sizes from otbn.hjson.
 
 */
 MEMORY
 {
-    imem (x)  : ORIGIN = 0, LENGTH = 1M
-    dmem (rw) : ORIGIN = 0, LENGTH = 1M
+    imem (x)  : ORIGIN = 0, LENGTH = ${imem_length}
+    dmem (rw) : ORIGIN = 0, LENGTH = ${dmem_length}
 
     /* LMA addresses (for VMAs in imem/dmem, respectively) */
-    imem_load (rw) : ORIGIN = 1M, LENGTH = 1M
-    dmem_load (rw) : ORIGIN = 1M, LENGTH = 1M
+    imem_load (rw) : ORIGIN = ${imem_lma}, LENGTH = ${imem_length}
+    dmem_load (rw) : ORIGIN = ${dmem_lma}, LENGTH = ${dmem_length}
 }
 
 SECTIONS

--- a/hw/ip/otbn/util/Makefile
+++ b/hw/ip/otbn/util/Makefile
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-pylibs := insn_yaml.py
+pylibs := insn_yaml.py mem_layout.py
 pyscripts := yaml_to_doc.py otbn-as otbn-ld otbn-objdump
 
 .PHONY: all
@@ -13,7 +13,7 @@ lint-targets := $(addprefix lint-,$(pyscripts))
 lint: $(lint-targets)
 
 $(lint-targets): lint-%:
-	mypy --strict $*
+	mypy --strict $* $(pylibs)
 
 
 asm-snippets := $(notdir $(wildcard ../code-snippets/*.S))

--- a/hw/ip/otbn/util/mem_layout.py
+++ b/hw/ip/otbn/util/mem_layout.py
@@ -1,0 +1,139 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+'''Simple code that understands enough of otbn.hjson to get a memory layout
+
+Each memory will have an associated "window" entry, which has an offset from
+the start of the IP block's register space. This offset will be treated as an
+LMA for this memory and these memory LMAs will be used uniformly in
+OTBN-specific tooling. This avoids the result depending on the address layout
+of the wider chip.
+
+In particular, note that OTBN ELF binaries will use these LMAs (the VMAs are in
+OTBN's address space, with both IMEM and DMEM starting at 0). A tool that takes
+such binaries and incorporates them into a top-level image will need to do
+address translation (essentially, just adding the base address of the OTBN IP
+block).
+
+'''
+
+import os
+import sys
+from typing import Dict, List, Mapping, Tuple
+
+import hjson  # type: ignore
+
+# We use reggen to read the hjson file. Since that lives somewhere completely
+# different from this script (and there aren't __init__.py files scattered all
+# over the OpenTitan repository), we have to do sys.path hacks to find it.
+_OLD_SYS_PATH = sys.path
+try:
+    _UTIL_PATH = os.path.join(os.path.dirname(__file__),
+                              '..', '..', '..', '..', 'util')
+    sys.path = [_UTIL_PATH] + _OLD_SYS_PATH
+    from reggen.validate import checking_dict, validate   # type: ignore
+finally:
+    sys.path = _OLD_SYS_PATH
+
+
+# An hjson dict is actually an OrderedDict, but typing/mypy support for that is
+# a little spotty, so we'll use a generic Mapping type.
+_HjsonDict = Mapping[str, object]
+
+# A window is represented as (offset, size)
+_Window = Tuple[int, int]
+
+
+def load_registers(path: str) -> Tuple[int, List[_HjsonDict]]:
+    '''Load hjson file at path with reggen
+
+    Return its register width and list of registers.
+
+    '''
+    try:
+        with open(path, 'r') as handle:
+            obj = hjson.loads(handle.read(),
+                              use_decimal=True,
+                              object_pairs_hook=checking_dict)
+    except ValueError as err:
+        raise RuntimeError('Failed to parse {!r}: {}'.format(path, err))
+
+    # Unconditionally run second validation pass
+    num_errs = validate(obj)
+    if num_errs:
+        raise RuntimeError('Reggen second validation pass failed for {!r} '
+                           '({} errors).'
+                           .format(path, num_errs))
+
+    reg_bit_width = int(obj.get('regwidth', 32))
+    assert isinstance(reg_bit_width, int) and reg_bit_width >= 0
+    reg_byte_width = reg_bit_width // 8
+
+    # obj should be an OrderedDict and should contain a registers entry
+    # (checked by validate). This is a list of registers which we'll return.
+    # The validation code would also have exploded if it wasn't a list of
+    # dictionaries, so we can assert the type safely.
+    registers = obj['registers']
+    assert isinstance(registers, list)
+    return (reg_byte_width, registers)
+
+
+def extract_windows(reg_byte_width: int,
+                    registers: List[_HjsonDict]) -> Dict[str, _Window]:
+    '''Make sense of the list of register definitions and extract memories'''
+
+    # Conveniently, reggen's validate method stores 'genoffset' (the offset to
+    # the start) for each window, so we can just look that up.
+    windows = {}
+
+    for reg in registers:
+        assert isinstance(reg, dict)
+        window = reg.get('window')
+        if window is None:
+            continue
+
+        assert isinstance(window, dict)
+
+        offset = window['genoffset']
+        assert isinstance(offset, int)
+
+        items = int(window['items'])
+        window_name = window.get('name', 'Window at +{:#x}'.format(offset))
+        assert isinstance(window_name, str)
+        if window_name in windows:
+            raise ValueError('Duplicate window entry with name {!r}.'
+                             .format(window_name))
+
+        windows[window_name] = (offset, items * reg_byte_width)
+
+    return windows
+
+
+def get_memory_layout() -> Dict[str, Tuple[int, int]]:
+    '''Read otbn.hjson to get IMEM / DMEM layout
+
+    Returns a dictionary with two entries, keyed 'IMEM' and 'DMEM'. The value
+    at each entry is a pair (offset, size_in_bytes).
+
+    '''
+    hjson_path = os.path.join(os.path.dirname(__file__),
+                              '..', 'data', 'otbn.hjson')
+    reg_byte_width, registers = load_registers(hjson_path)
+    windows = extract_windows(reg_byte_width, registers)
+
+    xmem_names = {'IMEM', 'DMEM'}
+    for name in xmem_names:
+        if name not in windows:
+            raise RuntimeError("otbn.hjson doesn't have a window called {}."
+                               .format(name))
+    if len(windows) != 2:
+        raise RuntimeError("Unexpected windows in otbn.hjson: {}"
+                           .format(list(set(windows.keys()) - xmem_names)))
+
+    return windows
+
+
+if __name__ == '__main__':
+    for name, (off, width) in get_memory_layout().items():
+        print('{}: {} bytes; LMA {:#x}'.format(name, width, off))

--- a/hw/ip/otbn/util/otbn-ld
+++ b/hw/ip/otbn/util/otbn-ld
@@ -11,24 +11,58 @@ linker.'''
 import os
 import subprocess
 import sys
+import tempfile
+
+from mako.template import Template  # type: ignore
+from mako import exceptions  # type: ignore
+
+import mem_layout
+
+
+def interpolate_linker_script(in_path: str, out_path: str) -> None:
+    mems = mem_layout.get_memory_layout()
+
+    try:
+        template = Template(filename=in_path)
+        rendered = template.render(imem_lma = mems['IMEM'][0],
+                                   imem_length = mems['IMEM'][1],
+                                   dmem_lma = mems['DMEM'][0],
+                                   dmem_length = mems['DMEM'][1])
+    except OSError as err:
+        raise RuntimeError(str(err)) from None
+    except:  # noqa: 722
+        raise RuntimeError(exceptions.text_error_template().render()) from None
+
+    try:
+        with open(out_path, 'w') as out_file:
+            out_file.write(rendered)
+    except FileNotFoundError:
+        raise RuntimeError('Failed to open output file at {!r}.'
+                           .format(out_path)) from None
 
 
 def main() -> int:
-    ld_script = os.path.normpath(os.path.join(os.path.dirname(__file__),
-                                              '..', 'data', 'otbn.ld'))
-    if not os.path.exists(ld_script):
-        sys.stderr.write('Default linker script ({!r}) does not exist.'
-                         .format(ld_script))
+    ld_in = os.path.normpath(os.path.join(os.path.dirname(__file__),
+                                          '..', 'data', 'otbn.ld.tpl'))
 
-    try:
-        ld_name = 'riscv32-unknown-elf-ld'
-        cmd = [ld_name, '--script={}'.format(ld_script)] + sys.argv[1:]
-        return subprocess.run(cmd).returncode
-    except FileNotFoundError:
-        sys.stderr.write('Unknown command: {!r}. '
-                         '(is it installed and on your PATH?)\n'
-                         .format(ld_name))
-        return 127
+    with tempfile.TemporaryDirectory(prefix='otbn-ld-') as tmpdir:
+        ld_out = os.path.join(tmpdir, 'otbn.ld')
+        try:
+            interpolate_linker_script(ld_in, ld_out)
+        except RuntimeError as err:
+            sys.stderr.write('Failed to interpolate linker script: {}\n'
+                             .format(err))
+            return 1
+
+        try:
+            ld_name = 'riscv32-unknown-elf-ld'
+            cmd = [ld_name, '--script={}'.format(ld_out)] + sys.argv[1:]
+            return subprocess.run(cmd).returncode
+        except FileNotFoundError:
+            sys.stderr.write('Unknown command: {!r}. '
+                             '(is it installed and on your PATH?)\n'
+                             .format(ld_name))
+            return 127
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This patch creates mem_layout.py, which uses reggen and the data in
otbn.hjson to find the memory layout for the block. We then use this
in otbn-ld to automatically make a linker script with the right
layout.

We'll also want to use it in the simulator (which needs to know the
size of memory) and when we load up ELF files in a block-level
testbench (which needs to know which LMAs correspond to imem and
dmem).
