### PR TITLE
Teach otbn-as about some pseudo-operations

### DIFF
--- a/hw/ip/otbn/code-snippets/pseudo-ops.S
+++ b/hw/ip/otbn/code-snippets/pseudo-ops.S
@@ -1,0 +1,33 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+    An example of the pseudo-operations supported by the OTBN ISA
+*/
+
+nop_example:
+    /* NOP is a no-op, and expands to addi x0, x0, 0 */
+    nop
+
+ret_example:
+    /* RET is a return and expands to jalr x0, x1, 0 */
+    ret
+
+li_example:
+    /* LI is a bit more complicated. With a small immediate, it turns
+       into just addi */
+    li x2, 1230
+    li x2, -123
+
+    /* With a big immediate which happens to have nothing set in the
+       lower 20 bits, it turns into just a LUI */
+    li x2, 1048576
+    li x2, -0x800000
+
+    /* With a big immediate in general, we need 2 instructions.
+       Firstly, a LUI to set up the upper bits, then an ADDI to sort out
+       the lower ones. */
+    li x2, 0x10000042
+
+    li x2, 123456789
+    li x2, 0x7fffffff

--- a/hw/ip/otbn/data/insns.yml
+++ b/hw/ip/otbn/data/insns.yml
@@ -436,6 +436,17 @@ encoding-schemes:
 #                assembly syntax, or deviations from the usual meaning of the
 #                instruction. (optional)
 #
+#  literal-pseudo-op: This instruction is a pseudo-operation that expands into
+#                     a list of underlying RISC-V operations, given as a list.
+#                     Optional. Can't be specified with encoding or
+#                     python-pseudo-op.
+#
+#  python-pseudo-op: A boolean. If true then this instruction is a
+#                    pseudo-operation but is complicated to describe. The
+#                    assembler has some hardcoded logic to deal with it.
+#                    Optional, default false. Can't be true if encoding or
+#                    literal-pseudo-op is specified.
+#
 # The operands field should be a list, corresponding to the operands in the
 # order they will appear in the syntax. Each operand is either a string (the
 # operand name) or a dictionary. In the latter case, it has the following
@@ -909,6 +920,32 @@ insns:
       mapping:
         bodysize: bodysize
         iterations: iterations
+
+  - mnemonic: nop
+    synopsis: No Operation
+    rv32i: true
+    operands: []
+    doc: A pseudo-operation that has no effect.
+    literal-pseudo-op:
+      - addi x0, x0, 0
+
+  - mnemonic: li
+    synopsis: Load Immediate
+    rv32i: true
+    operands: [grd, imm]
+    doc: |
+      Load a 32b immediate value into a GPR. This uses ADDI and LUI, expanding
+      to one or two instructions, depending on the immediate (small immediates
+      or immediates with all lower bits zero can be loaded with just ADDI or
+      LUI, respectively; general immediates need a LUI followed by an ADDI).
+    python-pseudo-op: true
+
+  - mnemonic: ret
+    synopsis: Return from subroutine
+    rv32i: true
+    operands: []
+    literal-pseudo-op:
+      - JALR x0, x1, 0
 
   - mnemonic: bn.add
     group: bignum

--- a/hw/ip/otbn/util/otbn-as
+++ b/hw/ip/otbn/util/otbn-as
@@ -24,7 +24,8 @@ import sys
 import tempfile
 from typing import Dict, List, Optional, Set, TextIO, Tuple
 
-from insn_yaml import BitRanges, Encoding, Insn, InsnsFile, Operand, load_file
+from insn_yaml import (BitRanges, Encoding, Insn, InsnsFile, Operand,
+                       RegOperandType, load_file)
 
 
 class RVFmt:
@@ -424,6 +425,83 @@ def parse_positionals(argv: List[str]) -> Tuple[List[str], List[str], Set[str]]:
     return (positionals, others, flags)
 
 
+def expand_li(where: str, op_to_expr: Dict[str, Optional[str]]) -> List[str]:
+    '''Expand the li pseudo-op'''
+    if set(op_to_expr.keys()) != {'grd', 'imm'}:
+        raise RuntimeError('When expanding LI, got wrong op_to_expr keys '
+                           '({}). This is a mismatch between expand_li in '
+                           'otbn-as and the operands for LI in insns.yml.'
+                           .format(list(op_to_expr.keys())))
+
+    grd = op_to_expr['grd']
+    imm = op_to_expr['imm']
+    if grd is None:
+        raise RuntimeError('When expanding LI, got <grd> = None. Is the '
+                           '<grd> operand wrongly marked as optional in '
+                           'insns.yml?')
+    if imm is None:
+        raise RuntimeError('When expanding LI, got <imm> = None. Is the '
+                           '<imm> operand wrongly marked as optional in '
+                           'insns.yml?')
+
+    try:
+        gpr_type = RegOperandType('gpr', True)
+        grd_int = gpr_type.read_index(grd)
+    except ValueError as err:
+        raise RuntimeError('{}: When parsing LI instruction, <grd> '
+                           'operand is wrong: {}'
+                           .format(where, err))
+
+    grd_txt = gpr_type.render_val(grd_int)
+
+    try:
+        imm_int = int(imm, 0)
+    except ValueError:
+        raise RuntimeError('{}: Cannot parse {!r}, the immediate for an LI '
+                           'instruction, as an integer.'
+                           .format(where, imm))
+
+    # imm_int had better be representable as an i32.
+    if imm_int < -(1 << 32) or 1 << 32 <= imm_int:
+        raise RuntimeError('{}: The immediate for an LI instruction is {}, '
+                           'which does not fit in a signed 32-bit integer.'
+                           .format(where, imm))
+
+    # If imm_int is representable as an i12, we can just generate an addi
+    if -(1 << 12) <= imm_int < (1 << 12):
+        return ['addi {}, x0, {}'.format(grd_txt, imm_int)]
+
+    imm_uint = imm_int if imm_int > 0 else (1 << 32) + imm_int
+    assert imm_uint >= 0
+    assert (imm_uint >> 32) == 0
+
+    # Otherwise, we'll have to start with LUI. Extract the 12-bit constant as a
+    # signed integer.
+    mask_12 = (1 << 12) - 1
+    imm_12 = mask_12 & imm_uint
+    if imm_12 >> 11:
+        imm_12 = imm_12 - (1 << 12)
+
+    if imm_12 == 0:
+        # We can just generate an LUI here
+        return ['lui {}, {:#x}'.format(grd_txt, imm_uint >> 12)]
+
+    if imm_12 > 0:
+        # LUI; ADDI with a positive constant
+        return ['lui {}, {:#x}'.format(grd_txt, imm_uint >> 12),
+                'addi {}, {}, {:#x}'.format(grd_txt, grd_txt, imm_12)]
+
+    # LUI; ADDI with a negative constant. Add 1 to the upper immediate to
+    # subtract from it.
+    return ['lui {}, {:#x}'.format(grd_txt, 1 + (imm_uint >> 12)),
+            'addi {}, {}, {}'.format(grd_txt, grd_txt, imm_12)]
+
+
+_PSEUDO_OP_ASSEMBLERS = {
+    'li': expand_li
+}
+
+
 class Transformer:
     '''A simple parser/transformer for OTBN input files
 
@@ -618,6 +696,28 @@ class Transformer:
                  op_to_expr: Dict[str, Optional[str]]) -> None:
         '''Build and write out a line for this instruction'''
         assert self.key_sym is not None
+
+        expansion = None
+
+        # If this instruction is a pseudo-operation with a literal expansion,
+        # dump that literal expansion.
+        if insn.literal_pseudo_op is not None:
+            expansion = insn.literal_pseudo_op
+
+        # If this instruction has a special-case in the assembler, use it. We
+        # checked when loading our instruction definitions that if the
+        # instruction claims to have a special-case assembler, it really does.
+        if insn.python_pseudo_op:
+            where = '{}:{}'.format(self.in_path, self.line_number)
+            expansion = _PSEUDO_OP_ASSEMBLERS[insn.mnemonic](where, op_to_expr)
+
+        if expansion is not None:
+            for idx, entry in enumerate(expansion):
+                self.out_handle.write('{} # {}{}'
+                                      .format(entry,
+                                              self.key_sym,
+                                              ''.join(self.acc)))
+            return
 
         # If this instruction comes from the rv32i instruction set, we can just
         # pass it straight through.
@@ -1026,6 +1126,17 @@ def main() -> int:
         if insn.glued_ops:
             glued_insns_dec_len.append(insn)
     glued_insns_dec_len.sort(key=lambda insn: len(insn.mnemonic), reverse=True)
+
+    # Check that any instruction that claims to have a Python pseudo-op
+    # assembler really does.
+    for insn in insns_file.insns:
+        if insn.python_pseudo_op:
+            if insn.mnemonic not in _PSEUDO_OP_ASSEMBLERS:
+                sys.stderr.write("Instruction {!r} has python-pseudo-op true, "
+                                 "but otbn-as doesn't have a custom assembler "
+                                 "for it.\n"
+                                 .format(insn.mnemonic))
+                return 1
 
     # Try to match up OTBN instruction encodings with .insn schemes (as stored
     # in RISCV_FORMATS).

--- a/hw/ip/otbn/util/otbn-as
+++ b/hw/ip/otbn/util/otbn-as
@@ -665,9 +665,11 @@ class Transformer:
         # Search from pos for */
         idx = line.find('*/', pos)
 
-        # If there is no such index, return EOL (and leave self.in_comment set)
+        # If there is no such index, return EOL (and leave self.in_comment
+        # set). Don't eat the \n at the end of the line: that will be added by
+        # take_line.
         if idx == -1:
-            self.acc.append(line[pos:])
+            self.acc.append(line[pos:-1])
             return len(line) - 1
 
         # Otherwise, update pos to just after it and then eat any trailing
@@ -881,6 +883,7 @@ class Transformer:
 
             pos = self._continue_block_comment(line, pos)
             if self.in_comment:
+                self.acc.append('\n')
                 return
 
         # Finish up any nested string

--- a/hw/ip/otbn/util/yaml_to_doc.py
+++ b/hw/ip/otbn/util/yaml_to_doc.py
@@ -7,6 +7,7 @@
 
 import argparse
 import sys
+from typing import List
 
 from insn_yaml import (BoolLiteral, Encoding, Insn, InsnsFile, Operand,
                        load_file)
@@ -134,6 +135,18 @@ def render_encoding(mnemonic: str, encoding: Encoding) -> str:
     return ''.join(parts)
 
 
+def render_literal_pseudo_op(rewrite: List[str]) -> str:
+    '''Generate documentation with expansion of a pseudo op'''
+    parts = []
+    parts.append('This instruction is a pseudo-operation and expands to the '
+                 'following instruction sequence:\n```\n')
+    for line in rewrite:
+        parts.append(line)
+        parts.append('\n')
+    parts.append('```\n\n')
+    return ''.join(parts)
+
+
 def render_insn(insn: Insn, heading_level: int) -> str:
     '''Generate the documentation for an instruction
 
@@ -192,6 +205,10 @@ def render_insn(insn: Insn, heading_level: int) -> str:
     # Show encoding if we have one
     if insn.encoding is not None:
         parts.append(render_encoding(insn.mnemonic, insn.encoding))
+
+    # If this is a pseudo-op with a literal translation, show it
+    if insn.literal_pseudo_op is not None:
+        parts.append(render_literal_pseudo_op(insn.literal_pseudo_op))
 
     # Show decode pseudo-code if given
     if insn.decode is not None:


### PR DESCRIPTION
This adds support for `nop`, `ret` and `li`. See #2967 for discussion. This doesn't quite close that ticket, because I haven't added `loop_until` or `loopi_until`.