### PR TITLE
[regtool] Add `_` in multireg name if the base name ends on a number

### DIFF
--- a/sw/device/lib/dif/dif_plic.c
+++ b/sw/device/lib/dif/dif_plic.c
@@ -53,13 +53,13 @@ typedef struct plic_target_reg_offset {
 // target, so there should be `RV_PLIC_PARAM_NUMTARGET` entries in this array.
 // The `i`th entry should contain the offsets of the `i`th target specific
 // registers:
-// - `RV_PLIC_IE<i>0_REG_OFFSET` (the first IE reg for target `i`).
+// - `RV_PLIC_IE<i>_0_REG_OFFSET` (the first IE reg for target `i`).
 // - `RV_PLIC_CC<i>_REG_OFFSET`
 // - `RV_PLIC_THRESHOLD<i>_REG_OFFSET`
 static const plic_target_reg_offset_t plic_target_reg_offsets[] = {
         [0] =
             {
-                .ie = RV_PLIC_IE00_REG_OFFSET,
+                .ie = RV_PLIC_IE0_0_REG_OFFSET,
                 .cc = RV_PLIC_CC0_REG_OFFSET,
                 .threshold = RV_PLIC_THRESHOLD0_REG_OFFSET,
             },
@@ -70,7 +70,7 @@ _Static_assert(
     "There should be an entry in plic_target_reg_offsets for every target");
 
 /**
- * Get an IE, IP or LE register offset (IE00, IE01, ...) from an IRQ source ID.
+ * Get an IE, IP or LE register offset (IE0_0, IE01, ...) from an IRQ source ID.
  *
  * With more than 32 IRQ sources, there is a multiple of these registers to
  * accommodate all the bits (1 bit per IRQ source). This function calculates
@@ -146,7 +146,7 @@ static ptrdiff_t plic_priority_reg_offset(dif_plic_irq_id_t irq) {
 static void plic_reset(const dif_plic_t *plic) {
   // Clear all of the Interrupt Enable registers.
   for (int i = 0; i < RV_PLIC_IE0_MULTIREG_COUNT; ++i) {
-    ptrdiff_t offset = RV_PLIC_IE00_REG_OFFSET + (i * sizeof(uint32_t));
+    ptrdiff_t offset = RV_PLIC_IE0_0_REG_OFFSET + (i * sizeof(uint32_t));
     mmio_region_write32(plic->base_addr, offset, 0);
   }
 

--- a/sw/device/tests/dif/dif_plic_unittest.cc
+++ b/sw/device/tests/dif/dif_plic_unittest.cc
@@ -31,9 +31,9 @@ class InitTest : public PlicTest {
  protected:
   void ExpectInitReset() {
     // Interupt enable multireg.
-    EXPECT_WRITE32(RV_PLIC_IE00_REG_OFFSET, 0);
-    EXPECT_WRITE32(RV_PLIC_IE01_REG_OFFSET, 0);
-    EXPECT_WRITE32(RV_PLIC_IE02_REG_OFFSET, 0);
+    EXPECT_WRITE32(RV_PLIC_IE0_0_REG_OFFSET, 0);
+    EXPECT_WRITE32(RV_PLIC_IE0_1_REG_OFFSET, 0);
+    EXPECT_WRITE32(RV_PLIC_IE0_2_REG_OFFSET, 0);
 
     // Level/edge multireg.
     EXPECT_WRITE32(RV_PLIC_LE0_REG_OFFSET, 0);
@@ -108,13 +108,13 @@ class IrqEnableSetTest : public IrqTests {
 
   std::vector<Register> registers_{
       {
-          RV_PLIC_IE00_REG_OFFSET, RV_PLIC_IE00_E31,
+          RV_PLIC_IE0_0_REG_OFFSET, RV_PLIC_IE0_0_E31,
       },
       {
-          RV_PLIC_IE01_REG_OFFSET, RV_PLIC_IE01_E63,
+          RV_PLIC_IE0_1_REG_OFFSET, RV_PLIC_IE0_1_E63,
       },
       {
-          RV_PLIC_IE02_REG_OFFSET, RV_PLIC_IE02_E82,
+          RV_PLIC_IE0_2_REG_OFFSET, RV_PLIC_IE0_2_E82,
       },
   };
 };

--- a/util/reggen/validate.py
+++ b/util/reggen/validate.py
@@ -1097,6 +1097,8 @@ def validate_multi(mreg, offset, addrsep, width, top):
             genreg = {}
             if shadowed is True:
                 genreg['name'] = mrname[:idx] + str(rnum) + mrname[idx:]
+            elif mrname[-1].isnumeric() and mcount > 1:
+                genreg['name'] = mrname + "_" + str(rnum)
             else:
                 genreg['name'] = mrname + str(rnum)
             genreg['desc'] = mreg['desc']


### PR DESCRIPTION
This PR contains a single commit to cause the regtool to insert a `_` to separate the base name of the multireg from the register index if the base name ends on a number. This improves readability when dealing with multiple multiregs. For example a multireg named `KEY_SHARE1` now leads to registers
- `KEY_SHARE1_0`, ..., `KEY_SHARE1_7` instead of
- `KEY_SHARE10`, ..., `KEY_SHARE17`.
