### PR TITLE
[vendor/rtl] add prim_clock_inv to pulp_riscv_debug.core

### DIFF
--- a/hw/vendor/pulp_riscv_dbg.core
+++ b/hw/vendor/pulp_riscv_dbg.core
@@ -9,6 +9,7 @@ filesets:
   files_src:
     depend:
       - lowrisc:prim:all
+      - lowrisc:prim:clock_inv
     files:
       - pulp_riscv_dbg/debug_rom/debug_rom.sv
       - pulp_riscv_dbg/debug_rom/debug_rom_one_scratch.sv


### PR DESCRIPTION
Followed the suggestion on issue: https://github.com/lowRISC/opentitan/issues/2983
This PR adds a `prim_clock_inv` core file to the `pulp_riscv_debug.core` depend lib

Signed-off-by: Cindy Chen <chencindy@google.com>