### PR TITLE
[rv_core_ibex] Add escalation receiver and hook up NMI

### DIFF
--- a/hw/ip/nmi_gen/data/nmi_gen.hjson
+++ b/hw/ip/nmi_gen/data/nmi_gen.hjson
@@ -24,11 +24,6 @@
             Escalation interrupt 2
             ''',
     },
-    { name: "esc3",
-      desc: '''
-            Escalation interrupt 3
-            ''',
-    },
   ],
   registers: [
   ],

--- a/hw/ip/nmi_gen/rtl/nmi_gen.sv
+++ b/hw/ip/nmi_gen/rtl/nmi_gen.sv
@@ -10,7 +10,7 @@ module nmi_gen
   import prim_esc_pkg::*;
 #(
   // leave constant
-  localparam int unsigned N_ESC_SEV = 4
+  localparam int unsigned N_ESC_SEV = 3
 ) (
   input                           clk_i,
   input                           rst_ni,
@@ -21,7 +21,6 @@ module nmi_gen
   output logic                    intr_esc0_o,
   output logic                    intr_esc1_o,
   output logic                    intr_esc2_o,
-  output logic                    intr_esc3_o,
   // Escalation outputs
   input  esc_tx_t [N_ESC_SEV-1:0] esc_tx_i,
   output esc_rx_t [N_ESC_SEV-1:0] esc_rx_o
@@ -86,19 +85,6 @@ module nmi_gen
     .hw2reg_intr_state_de_o ( hw2reg.intr_state.esc2.de  ),
     .hw2reg_intr_state_d_o  ( hw2reg.intr_state.esc2.d   ),
     .intr_o                 ( intr_esc2_o                )
-  );
-
-  prim_intr_hw #(
-    .Width(1)
-  ) i_intr_esc3 (
-    .event_intr_i           ( esc_en[3]                  ),
-    .reg2hw_intr_enable_q_i ( reg2hw.intr_enable.esc3.q  ),
-    .reg2hw_intr_test_q_i   ( reg2hw.intr_test.esc3.q    ),
-    .reg2hw_intr_test_qe_i  ( reg2hw.intr_test.esc3.qe   ),
-    .reg2hw_intr_state_q_i  ( reg2hw.intr_state.esc3.q   ),
-    .hw2reg_intr_state_de_o ( hw2reg.intr_state.esc3.de  ),
-    .hw2reg_intr_state_d_o  ( hw2reg.intr_state.esc3.d   ),
-    .intr_o                 ( intr_esc3_o                )
   );
 
   /////////////////////////////////////////

--- a/hw/ip/nmi_gen/rtl/nmi_gen_reg_pkg.sv
+++ b/hw/ip/nmi_gen/rtl/nmi_gen_reg_pkg.sv
@@ -19,9 +19,6 @@ package nmi_gen_reg_pkg;
     struct packed {
       logic        q;
     } esc2;
-    struct packed {
-      logic        q;
-    } esc3;
   } nmi_gen_reg2hw_intr_state_reg_t;
 
   typedef struct packed {
@@ -34,9 +31,6 @@ package nmi_gen_reg_pkg;
     struct packed {
       logic        q;
     } esc2;
-    struct packed {
-      logic        q;
-    } esc3;
   } nmi_gen_reg2hw_intr_enable_reg_t;
 
   typedef struct packed {
@@ -52,10 +46,6 @@ package nmi_gen_reg_pkg;
       logic        q;
       logic        qe;
     } esc2;
-    struct packed {
-      logic        q;
-      logic        qe;
-    } esc3;
   } nmi_gen_reg2hw_intr_test_reg_t;
 
 
@@ -72,10 +62,6 @@ package nmi_gen_reg_pkg;
       logic        d;
       logic        de;
     } esc2;
-    struct packed {
-      logic        d;
-      logic        de;
-    } esc3;
   } nmi_gen_hw2reg_intr_state_reg_t;
 
 
@@ -83,16 +69,16 @@ package nmi_gen_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    nmi_gen_reg2hw_intr_state_reg_t intr_state; // [15:12]
-    nmi_gen_reg2hw_intr_enable_reg_t intr_enable; // [11:8]
-    nmi_gen_reg2hw_intr_test_reg_t intr_test; // [7:0]
+    nmi_gen_reg2hw_intr_state_reg_t intr_state; // [11:9]
+    nmi_gen_reg2hw_intr_enable_reg_t intr_enable; // [8:6]
+    nmi_gen_reg2hw_intr_test_reg_t intr_test; // [5:0]
   } nmi_gen_reg2hw_t;
 
   ///////////////////////////////////////
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    nmi_gen_hw2reg_intr_state_reg_t intr_state; // [7:4]
+    nmi_gen_hw2reg_intr_state_reg_t intr_state; // [5:3]
   } nmi_gen_hw2reg_t;
 
   // Register Address

--- a/hw/ip/nmi_gen/rtl/nmi_gen_reg_top.sv
+++ b/hw/ip/nmi_gen/rtl/nmi_gen_reg_top.sv
@@ -80,9 +80,6 @@ module nmi_gen_reg_top (
   logic intr_state_esc2_qs;
   logic intr_state_esc2_wd;
   logic intr_state_esc2_we;
-  logic intr_state_esc3_qs;
-  logic intr_state_esc3_wd;
-  logic intr_state_esc3_we;
   logic intr_enable_esc0_qs;
   logic intr_enable_esc0_wd;
   logic intr_enable_esc0_we;
@@ -92,17 +89,12 @@ module nmi_gen_reg_top (
   logic intr_enable_esc2_qs;
   logic intr_enable_esc2_wd;
   logic intr_enable_esc2_we;
-  logic intr_enable_esc3_qs;
-  logic intr_enable_esc3_wd;
-  logic intr_enable_esc3_we;
   logic intr_test_esc0_wd;
   logic intr_test_esc0_we;
   logic intr_test_esc1_wd;
   logic intr_test_esc1_we;
   logic intr_test_esc2_wd;
   logic intr_test_esc2_we;
-  logic intr_test_esc3_wd;
-  logic intr_test_esc3_we;
 
   // Register instances
   // R[intr_state]: V(False)
@@ -182,32 +174,6 @@ module nmi_gen_reg_top (
 
     // to register interface (read)
     .qs     (intr_state_esc2_qs)
-  );
-
-
-  //   F[esc3]: 3:3
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("W1C"),
-    .RESVAL  (1'h0)
-  ) u_intr_state_esc3 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (intr_state_esc3_we),
-    .wd     (intr_state_esc3_wd),
-
-    // from internal hardware
-    .de     (hw2reg.intr_state.esc3.de),
-    .d      (hw2reg.intr_state.esc3.d ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.intr_state.esc3.q ),
-
-    // to register interface (read)
-    .qs     (intr_state_esc3_qs)
   );
 
 
@@ -291,32 +257,6 @@ module nmi_gen_reg_top (
   );
 
 
-  //   F[esc3]: 3:3
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_intr_enable_esc3 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (intr_enable_esc3_we),
-    .wd     (intr_enable_esc3_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.intr_enable.esc3.q ),
-
-    // to register interface (read)
-    .qs     (intr_enable_esc3_qs)
-  );
-
-
   // R[intr_test]: V(True)
 
   //   F[esc0]: 0:0
@@ -364,21 +304,6 @@ module nmi_gen_reg_top (
   );
 
 
-  //   F[esc3]: 3:3
-  prim_subreg_ext #(
-    .DW    (1)
-  ) u_intr_test_esc3 (
-    .re     (1'b0),
-    .we     (intr_test_esc3_we),
-    .wd     (intr_test_esc3_wd),
-    .d      ('0),
-    .qre    (),
-    .qe     (reg2hw.intr_test.esc3.qe),
-    .q      (reg2hw.intr_test.esc3.q ),
-    .qs     ()
-  );
-
-
 
 
   logic [2:0] addr_hit;
@@ -408,9 +333,6 @@ module nmi_gen_reg_top (
   assign intr_state_esc2_we = addr_hit[0] & reg_we & ~wr_err;
   assign intr_state_esc2_wd = reg_wdata[2];
 
-  assign intr_state_esc3_we = addr_hit[0] & reg_we & ~wr_err;
-  assign intr_state_esc3_wd = reg_wdata[3];
-
   assign intr_enable_esc0_we = addr_hit[1] & reg_we & ~wr_err;
   assign intr_enable_esc0_wd = reg_wdata[0];
 
@@ -419,9 +341,6 @@ module nmi_gen_reg_top (
 
   assign intr_enable_esc2_we = addr_hit[1] & reg_we & ~wr_err;
   assign intr_enable_esc2_wd = reg_wdata[2];
-
-  assign intr_enable_esc3_we = addr_hit[1] & reg_we & ~wr_err;
-  assign intr_enable_esc3_wd = reg_wdata[3];
 
   assign intr_test_esc0_we = addr_hit[2] & reg_we & ~wr_err;
   assign intr_test_esc0_wd = reg_wdata[0];
@@ -432,9 +351,6 @@ module nmi_gen_reg_top (
   assign intr_test_esc2_we = addr_hit[2] & reg_we & ~wr_err;
   assign intr_test_esc2_wd = reg_wdata[2];
 
-  assign intr_test_esc3_we = addr_hit[2] & reg_we & ~wr_err;
-  assign intr_test_esc3_wd = reg_wdata[3];
-
   // Read data return
   always_comb begin
     reg_rdata_next = '0;
@@ -443,21 +359,18 @@ module nmi_gen_reg_top (
         reg_rdata_next[0] = intr_state_esc0_qs;
         reg_rdata_next[1] = intr_state_esc1_qs;
         reg_rdata_next[2] = intr_state_esc2_qs;
-        reg_rdata_next[3] = intr_state_esc3_qs;
       end
 
       addr_hit[1]: begin
         reg_rdata_next[0] = intr_enable_esc0_qs;
         reg_rdata_next[1] = intr_enable_esc1_qs;
         reg_rdata_next[2] = intr_enable_esc2_qs;
-        reg_rdata_next[3] = intr_enable_esc3_qs;
       end
 
       addr_hit[2]: begin
         reg_rdata_next[0] = '0;
         reg_rdata_next[1] = '0;
         reg_rdata_next[2] = '0;
-        reg_rdata_next[3] = '0;
       end
 
       default: begin

--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -48,8 +48,10 @@ module rv_core_ibex #(
   input  logic        irq_software_i,
   input  logic        irq_timer_i,
   input  logic        irq_external_i,
-  input  logic [14:0] irq_fast_i,
-  input  logic        irq_nm_i,
+
+  // Escalation input for NMI
+  input  prim_esc_pkg::esc_tx_t esc_tx_i,
+  output prim_esc_pkg::esc_rx_t esc_rx_o,
 
   // Debug Interface
   input  logic        debug_req_i,
@@ -118,6 +120,17 @@ module rv_core_ibex #(
   logic [31:0] rvfi_mem_wdata;
 `endif
 
+  // Escalation receiver that converts differential
+  // protocol into single ended signal.
+  logic irq_nm;
+  prim_esc_receiver i_prim_esc_receiver (
+    .clk_i,
+    .rst_ni,
+    .esc_en_o ( irq_nm   ),
+    .esc_rx_o,
+    .esc_tx_i
+  );
+
   ibex_core #(
     .PMPEnable                ( PMPEnable                ),
     .PMPGranularity           ( PMPGranularity           ),
@@ -164,8 +177,8 @@ module rv_core_ibex #(
     .irq_software_i,
     .irq_timer_i,
     .irq_external_i,
-    .irq_fast_i,
-    .irq_nm_i,
+    .irq_fast_i     ( '0           ),
+    .irq_nm_i       ( irq_nm       ),
 
     .debug_req_i,
 

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -1695,18 +1695,6 @@
           ]
           type: interrupt
         }
-        {
-          name: esc3
-          width: 1
-          bits: "3"
-          bitinfo:
-          [
-            8
-            1
-            3
-          ]
-          type: interrupt
-        }
       ]
       alert_list: []
       wakeup_list: []
@@ -3719,19 +3707,6 @@
         4
         1
         2
-      ]
-      type: interrupt
-      module_name: nmi_gen
-    }
-    {
-      name: nmi_gen_esc3
-      width: 1
-      bits: "3"
-      bitinfo:
-      [
-        8
-        1
-        3
       ]
       type: interrupt
       module_name: nmi_gen

--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -220,8 +220,9 @@ module top_${top["name"]} #(
     .irq_software_i       (msip),
     .irq_timer_i          (intr_rv_timer_timer_expired_0_0),
     .irq_external_i       (irq_plic),
-    .irq_fast_i           (15'b0),// PLIC handles all peripheral interrupts
-    .irq_nm_i             (1'b0),// TODO - add and connect alert responder
+    // escalation input from alert handler (NMI)
+    .esc_tx_i             (esc_tx[0]),
+    .esc_rx_o             (esc_rx[0]),
     // debug interface
     .debug_req_i          (debug_req),
     // CPU control signals
@@ -580,8 +581,8 @@ slice = str(alert_idx+w-1) + ":" + str(alert_idx)
     % endif
     % if m["type"] == "nmi_gen":
       // escalation signal inputs
-      .esc_rx_o    ( esc_rx   ),
-      .esc_tx_i    ( esc_tx   ),
+      .esc_rx_o    ( esc_rx[3:1] ),
+      .esc_tx_i    ( esc_tx[3:1] ),
     % endif
     % if m["scan"] == "true":
       .scanmode_i   (scanmode_i),

--- a/hw/top_earlgrey/ip/rv_plic/data/autogen/rv_plic.hjson
+++ b/hw/top_earlgrey/ip/rv_plic/data/autogen/rv_plic.hjson
@@ -25,7 +25,7 @@
     { name: "NumSrc",
       desc: "Number of interrupt sources",
       type: "int",
-      default: "83",
+      default: "82",
       local: "true"
     },
     { name: "NumTarget",
@@ -719,14 +719,6 @@
     }
     { name: "PRIO81",
       desc: "Interrupt Source 81 Priority",
-      swaccess: "rw",
-      hwaccess: "hro",
-      fields: [
-        { bits: "1:0" }
-      ],
-    }
-    { name: "PRIO82",
-      desc: "Interrupt Source 82 Priority",
       swaccess: "rw",
       hwaccess: "hro",
       fields: [

--- a/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic.sv
+++ b/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic.sv
@@ -176,12 +176,11 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   assign prio[79] = reg2hw.prio79.q;
   assign prio[80] = reg2hw.prio80.q;
   assign prio[81] = reg2hw.prio81.q;
-  assign prio[82] = reg2hw.prio82.q;
 
   //////////////////////
   // Interrupt Enable //
   //////////////////////
-  for (genvar s = 0; s < 83; s++) begin : gen_ie0
+  for (genvar s = 0; s < 82; s++) begin : gen_ie0
     assign ie[0][s] = reg2hw.ie0[s].q;
   end
 
@@ -207,7 +206,7 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   ////////
   // IP //
   ////////
-  for (genvar s = 0; s < 83; s++) begin : gen_ip
+  for (genvar s = 0; s < 82; s++) begin : gen_ip
     assign hw2reg.ip[s].de = 1'b1; // Always write
     assign hw2reg.ip[s].d  = ip[s];
   end
@@ -215,7 +214,7 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   ///////////////////////////////////
   // Detection:: 0: Level, 1: Edge //
   ///////////////////////////////////
-  for (genvar s = 0; s < 83; s++) begin : gen_le
+  for (genvar s = 0; s < 82; s++) begin : gen_le
     assign le[s] = reg2hw.le[s].q;
   end
 

--- a/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_pkg.sv
@@ -7,7 +7,7 @@
 package rv_plic_reg_pkg;
 
   // Param list
-  parameter int NumSrc = 83;
+  parameter int NumSrc = 82;
   parameter int NumTarget = 1;
   parameter int PrioWidth = 2;
 
@@ -347,10 +347,6 @@ package rv_plic_reg_pkg;
   } rv_plic_reg2hw_prio81_reg_t;
 
   typedef struct packed {
-    logic [1:0]  q;
-  } rv_plic_reg2hw_prio82_reg_t;
-
-  typedef struct packed {
     logic        q;
   } rv_plic_reg2hw_ie0_mreg_t;
 
@@ -383,91 +379,90 @@ package rv_plic_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    rv_plic_reg2hw_le_mreg_t [82:0] le; // [343:261]
-    rv_plic_reg2hw_prio0_reg_t prio0; // [260:259]
-    rv_plic_reg2hw_prio1_reg_t prio1; // [258:257]
-    rv_plic_reg2hw_prio2_reg_t prio2; // [256:255]
-    rv_plic_reg2hw_prio3_reg_t prio3; // [254:253]
-    rv_plic_reg2hw_prio4_reg_t prio4; // [252:251]
-    rv_plic_reg2hw_prio5_reg_t prio5; // [250:249]
-    rv_plic_reg2hw_prio6_reg_t prio6; // [248:247]
-    rv_plic_reg2hw_prio7_reg_t prio7; // [246:245]
-    rv_plic_reg2hw_prio8_reg_t prio8; // [244:243]
-    rv_plic_reg2hw_prio9_reg_t prio9; // [242:241]
-    rv_plic_reg2hw_prio10_reg_t prio10; // [240:239]
-    rv_plic_reg2hw_prio11_reg_t prio11; // [238:237]
-    rv_plic_reg2hw_prio12_reg_t prio12; // [236:235]
-    rv_plic_reg2hw_prio13_reg_t prio13; // [234:233]
-    rv_plic_reg2hw_prio14_reg_t prio14; // [232:231]
-    rv_plic_reg2hw_prio15_reg_t prio15; // [230:229]
-    rv_plic_reg2hw_prio16_reg_t prio16; // [228:227]
-    rv_plic_reg2hw_prio17_reg_t prio17; // [226:225]
-    rv_plic_reg2hw_prio18_reg_t prio18; // [224:223]
-    rv_plic_reg2hw_prio19_reg_t prio19; // [222:221]
-    rv_plic_reg2hw_prio20_reg_t prio20; // [220:219]
-    rv_plic_reg2hw_prio21_reg_t prio21; // [218:217]
-    rv_plic_reg2hw_prio22_reg_t prio22; // [216:215]
-    rv_plic_reg2hw_prio23_reg_t prio23; // [214:213]
-    rv_plic_reg2hw_prio24_reg_t prio24; // [212:211]
-    rv_plic_reg2hw_prio25_reg_t prio25; // [210:209]
-    rv_plic_reg2hw_prio26_reg_t prio26; // [208:207]
-    rv_plic_reg2hw_prio27_reg_t prio27; // [206:205]
-    rv_plic_reg2hw_prio28_reg_t prio28; // [204:203]
-    rv_plic_reg2hw_prio29_reg_t prio29; // [202:201]
-    rv_plic_reg2hw_prio30_reg_t prio30; // [200:199]
-    rv_plic_reg2hw_prio31_reg_t prio31; // [198:197]
-    rv_plic_reg2hw_prio32_reg_t prio32; // [196:195]
-    rv_plic_reg2hw_prio33_reg_t prio33; // [194:193]
-    rv_plic_reg2hw_prio34_reg_t prio34; // [192:191]
-    rv_plic_reg2hw_prio35_reg_t prio35; // [190:189]
-    rv_plic_reg2hw_prio36_reg_t prio36; // [188:187]
-    rv_plic_reg2hw_prio37_reg_t prio37; // [186:185]
-    rv_plic_reg2hw_prio38_reg_t prio38; // [184:183]
-    rv_plic_reg2hw_prio39_reg_t prio39; // [182:181]
-    rv_plic_reg2hw_prio40_reg_t prio40; // [180:179]
-    rv_plic_reg2hw_prio41_reg_t prio41; // [178:177]
-    rv_plic_reg2hw_prio42_reg_t prio42; // [176:175]
-    rv_plic_reg2hw_prio43_reg_t prio43; // [174:173]
-    rv_plic_reg2hw_prio44_reg_t prio44; // [172:171]
-    rv_plic_reg2hw_prio45_reg_t prio45; // [170:169]
-    rv_plic_reg2hw_prio46_reg_t prio46; // [168:167]
-    rv_plic_reg2hw_prio47_reg_t prio47; // [166:165]
-    rv_plic_reg2hw_prio48_reg_t prio48; // [164:163]
-    rv_plic_reg2hw_prio49_reg_t prio49; // [162:161]
-    rv_plic_reg2hw_prio50_reg_t prio50; // [160:159]
-    rv_plic_reg2hw_prio51_reg_t prio51; // [158:157]
-    rv_plic_reg2hw_prio52_reg_t prio52; // [156:155]
-    rv_plic_reg2hw_prio53_reg_t prio53; // [154:153]
-    rv_plic_reg2hw_prio54_reg_t prio54; // [152:151]
-    rv_plic_reg2hw_prio55_reg_t prio55; // [150:149]
-    rv_plic_reg2hw_prio56_reg_t prio56; // [148:147]
-    rv_plic_reg2hw_prio57_reg_t prio57; // [146:145]
-    rv_plic_reg2hw_prio58_reg_t prio58; // [144:143]
-    rv_plic_reg2hw_prio59_reg_t prio59; // [142:141]
-    rv_plic_reg2hw_prio60_reg_t prio60; // [140:139]
-    rv_plic_reg2hw_prio61_reg_t prio61; // [138:137]
-    rv_plic_reg2hw_prio62_reg_t prio62; // [136:135]
-    rv_plic_reg2hw_prio63_reg_t prio63; // [134:133]
-    rv_plic_reg2hw_prio64_reg_t prio64; // [132:131]
-    rv_plic_reg2hw_prio65_reg_t prio65; // [130:129]
-    rv_plic_reg2hw_prio66_reg_t prio66; // [128:127]
-    rv_plic_reg2hw_prio67_reg_t prio67; // [126:125]
-    rv_plic_reg2hw_prio68_reg_t prio68; // [124:123]
-    rv_plic_reg2hw_prio69_reg_t prio69; // [122:121]
-    rv_plic_reg2hw_prio70_reg_t prio70; // [120:119]
-    rv_plic_reg2hw_prio71_reg_t prio71; // [118:117]
-    rv_plic_reg2hw_prio72_reg_t prio72; // [116:115]
-    rv_plic_reg2hw_prio73_reg_t prio73; // [114:113]
-    rv_plic_reg2hw_prio74_reg_t prio74; // [112:111]
-    rv_plic_reg2hw_prio75_reg_t prio75; // [110:109]
-    rv_plic_reg2hw_prio76_reg_t prio76; // [108:107]
-    rv_plic_reg2hw_prio77_reg_t prio77; // [106:105]
-    rv_plic_reg2hw_prio78_reg_t prio78; // [104:103]
-    rv_plic_reg2hw_prio79_reg_t prio79; // [102:101]
-    rv_plic_reg2hw_prio80_reg_t prio80; // [100:99]
-    rv_plic_reg2hw_prio81_reg_t prio81; // [98:97]
-    rv_plic_reg2hw_prio82_reg_t prio82; // [96:95]
-    rv_plic_reg2hw_ie0_mreg_t [82:0] ie0; // [94:12]
+    rv_plic_reg2hw_le_mreg_t [81:0] le; // [339:258]
+    rv_plic_reg2hw_prio0_reg_t prio0; // [257:256]
+    rv_plic_reg2hw_prio1_reg_t prio1; // [255:254]
+    rv_plic_reg2hw_prio2_reg_t prio2; // [253:252]
+    rv_plic_reg2hw_prio3_reg_t prio3; // [251:250]
+    rv_plic_reg2hw_prio4_reg_t prio4; // [249:248]
+    rv_plic_reg2hw_prio5_reg_t prio5; // [247:246]
+    rv_plic_reg2hw_prio6_reg_t prio6; // [245:244]
+    rv_plic_reg2hw_prio7_reg_t prio7; // [243:242]
+    rv_plic_reg2hw_prio8_reg_t prio8; // [241:240]
+    rv_plic_reg2hw_prio9_reg_t prio9; // [239:238]
+    rv_plic_reg2hw_prio10_reg_t prio10; // [237:236]
+    rv_plic_reg2hw_prio11_reg_t prio11; // [235:234]
+    rv_plic_reg2hw_prio12_reg_t prio12; // [233:232]
+    rv_plic_reg2hw_prio13_reg_t prio13; // [231:230]
+    rv_plic_reg2hw_prio14_reg_t prio14; // [229:228]
+    rv_plic_reg2hw_prio15_reg_t prio15; // [227:226]
+    rv_plic_reg2hw_prio16_reg_t prio16; // [225:224]
+    rv_plic_reg2hw_prio17_reg_t prio17; // [223:222]
+    rv_plic_reg2hw_prio18_reg_t prio18; // [221:220]
+    rv_plic_reg2hw_prio19_reg_t prio19; // [219:218]
+    rv_plic_reg2hw_prio20_reg_t prio20; // [217:216]
+    rv_plic_reg2hw_prio21_reg_t prio21; // [215:214]
+    rv_plic_reg2hw_prio22_reg_t prio22; // [213:212]
+    rv_plic_reg2hw_prio23_reg_t prio23; // [211:210]
+    rv_plic_reg2hw_prio24_reg_t prio24; // [209:208]
+    rv_plic_reg2hw_prio25_reg_t prio25; // [207:206]
+    rv_plic_reg2hw_prio26_reg_t prio26; // [205:204]
+    rv_plic_reg2hw_prio27_reg_t prio27; // [203:202]
+    rv_plic_reg2hw_prio28_reg_t prio28; // [201:200]
+    rv_plic_reg2hw_prio29_reg_t prio29; // [199:198]
+    rv_plic_reg2hw_prio30_reg_t prio30; // [197:196]
+    rv_plic_reg2hw_prio31_reg_t prio31; // [195:194]
+    rv_plic_reg2hw_prio32_reg_t prio32; // [193:192]
+    rv_plic_reg2hw_prio33_reg_t prio33; // [191:190]
+    rv_plic_reg2hw_prio34_reg_t prio34; // [189:188]
+    rv_plic_reg2hw_prio35_reg_t prio35; // [187:186]
+    rv_plic_reg2hw_prio36_reg_t prio36; // [185:184]
+    rv_plic_reg2hw_prio37_reg_t prio37; // [183:182]
+    rv_plic_reg2hw_prio38_reg_t prio38; // [181:180]
+    rv_plic_reg2hw_prio39_reg_t prio39; // [179:178]
+    rv_plic_reg2hw_prio40_reg_t prio40; // [177:176]
+    rv_plic_reg2hw_prio41_reg_t prio41; // [175:174]
+    rv_plic_reg2hw_prio42_reg_t prio42; // [173:172]
+    rv_plic_reg2hw_prio43_reg_t prio43; // [171:170]
+    rv_plic_reg2hw_prio44_reg_t prio44; // [169:168]
+    rv_plic_reg2hw_prio45_reg_t prio45; // [167:166]
+    rv_plic_reg2hw_prio46_reg_t prio46; // [165:164]
+    rv_plic_reg2hw_prio47_reg_t prio47; // [163:162]
+    rv_plic_reg2hw_prio48_reg_t prio48; // [161:160]
+    rv_plic_reg2hw_prio49_reg_t prio49; // [159:158]
+    rv_plic_reg2hw_prio50_reg_t prio50; // [157:156]
+    rv_plic_reg2hw_prio51_reg_t prio51; // [155:154]
+    rv_plic_reg2hw_prio52_reg_t prio52; // [153:152]
+    rv_plic_reg2hw_prio53_reg_t prio53; // [151:150]
+    rv_plic_reg2hw_prio54_reg_t prio54; // [149:148]
+    rv_plic_reg2hw_prio55_reg_t prio55; // [147:146]
+    rv_plic_reg2hw_prio56_reg_t prio56; // [145:144]
+    rv_plic_reg2hw_prio57_reg_t prio57; // [143:142]
+    rv_plic_reg2hw_prio58_reg_t prio58; // [141:140]
+    rv_plic_reg2hw_prio59_reg_t prio59; // [139:138]
+    rv_plic_reg2hw_prio60_reg_t prio60; // [137:136]
+    rv_plic_reg2hw_prio61_reg_t prio61; // [135:134]
+    rv_plic_reg2hw_prio62_reg_t prio62; // [133:132]
+    rv_plic_reg2hw_prio63_reg_t prio63; // [131:130]
+    rv_plic_reg2hw_prio64_reg_t prio64; // [129:128]
+    rv_plic_reg2hw_prio65_reg_t prio65; // [127:126]
+    rv_plic_reg2hw_prio66_reg_t prio66; // [125:124]
+    rv_plic_reg2hw_prio67_reg_t prio67; // [123:122]
+    rv_plic_reg2hw_prio68_reg_t prio68; // [121:120]
+    rv_plic_reg2hw_prio69_reg_t prio69; // [119:118]
+    rv_plic_reg2hw_prio70_reg_t prio70; // [117:116]
+    rv_plic_reg2hw_prio71_reg_t prio71; // [115:114]
+    rv_plic_reg2hw_prio72_reg_t prio72; // [113:112]
+    rv_plic_reg2hw_prio73_reg_t prio73; // [111:110]
+    rv_plic_reg2hw_prio74_reg_t prio74; // [109:108]
+    rv_plic_reg2hw_prio75_reg_t prio75; // [107:106]
+    rv_plic_reg2hw_prio76_reg_t prio76; // [105:104]
+    rv_plic_reg2hw_prio77_reg_t prio77; // [103:102]
+    rv_plic_reg2hw_prio78_reg_t prio78; // [101:100]
+    rv_plic_reg2hw_prio79_reg_t prio79; // [99:98]
+    rv_plic_reg2hw_prio80_reg_t prio80; // [97:96]
+    rv_plic_reg2hw_prio81_reg_t prio81; // [95:94]
+    rv_plic_reg2hw_ie0_mreg_t [81:0] ie0; // [93:12]
     rv_plic_reg2hw_threshold0_reg_t threshold0; // [11:10]
     rv_plic_reg2hw_cc0_reg_t cc0; // [9:1]
     rv_plic_reg2hw_msip0_reg_t msip0; // [0:0]
@@ -477,7 +472,7 @@ package rv_plic_reg_pkg;
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    rv_plic_hw2reg_ip_mreg_t [82:0] ip; // [172:7]
+    rv_plic_hw2reg_ip_mreg_t [81:0] ip; // [170:7]
     rv_plic_hw2reg_cc0_reg_t cc0; // [6:-2]
   } rv_plic_hw2reg_t;
 
@@ -570,7 +565,6 @@ package rv_plic_reg_pkg;
   parameter logic [9:0] RV_PLIC_PRIO79_OFFSET = 10'h 154;
   parameter logic [9:0] RV_PLIC_PRIO80_OFFSET = 10'h 158;
   parameter logic [9:0] RV_PLIC_PRIO81_OFFSET = 10'h 15c;
-  parameter logic [9:0] RV_PLIC_PRIO82_OFFSET = 10'h 160;
   parameter logic [9:0] RV_PLIC_IE0_0_OFFSET = 10'h 200;
   parameter logic [9:0] RV_PLIC_IE0_1_OFFSET = 10'h 204;
   parameter logic [9:0] RV_PLIC_IE0_2_OFFSET = 10'h 208;
@@ -669,7 +663,6 @@ package rv_plic_reg_pkg;
     RV_PLIC_PRIO79,
     RV_PLIC_PRIO80,
     RV_PLIC_PRIO81,
-    RV_PLIC_PRIO82,
     RV_PLIC_IE0_0,
     RV_PLIC_IE0_1,
     RV_PLIC_IE0_2,
@@ -679,7 +672,7 @@ package rv_plic_reg_pkg;
   } rv_plic_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] RV_PLIC_PERMIT [95] = '{
+  parameter logic [3:0] RV_PLIC_PERMIT [94] = '{
     4'b 1111, // index[ 0] RV_PLIC_IP_0
     4'b 1111, // index[ 1] RV_PLIC_IP_1
     4'b 0111, // index[ 2] RV_PLIC_IP_2
@@ -768,13 +761,12 @@ package rv_plic_reg_pkg;
     4'b 0001, // index[85] RV_PLIC_PRIO79
     4'b 0001, // index[86] RV_PLIC_PRIO80
     4'b 0001, // index[87] RV_PLIC_PRIO81
-    4'b 0001, // index[88] RV_PLIC_PRIO82
-    4'b 1111, // index[89] RV_PLIC_IE0_0
-    4'b 1111, // index[90] RV_PLIC_IE0_1
-    4'b 0111, // index[91] RV_PLIC_IE0_2
-    4'b 0001, // index[92] RV_PLIC_THRESHOLD0
-    4'b 0001, // index[93] RV_PLIC_CC0
-    4'b 0001  // index[94] RV_PLIC_MSIP0
+    4'b 1111, // index[88] RV_PLIC_IE0_0
+    4'b 1111, // index[89] RV_PLIC_IE0_1
+    4'b 0111, // index[90] RV_PLIC_IE0_2
+    4'b 0001, // index[91] RV_PLIC_THRESHOLD0
+    4'b 0001, // index[92] RV_PLIC_CC0
+    4'b 0001  // index[93] RV_PLIC_MSIP0
   };
 endpackage
 

--- a/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_top.sv
+++ b/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_top.sv
@@ -153,7 +153,6 @@ module rv_plic_reg_top (
   logic ip_2_p_79_qs;
   logic ip_2_p_80_qs;
   logic ip_2_p_81_qs;
-  logic ip_2_p_82_qs;
   logic le_0_le_0_qs;
   logic le_0_le_0_wd;
   logic le_0_le_0_we;
@@ -400,9 +399,6 @@ module rv_plic_reg_top (
   logic le_2_le_81_qs;
   logic le_2_le_81_wd;
   logic le_2_le_81_we;
-  logic le_2_le_82_qs;
-  logic le_2_le_82_wd;
-  logic le_2_le_82_we;
   logic [1:0] prio0_qs;
   logic [1:0] prio0_wd;
   logic prio0_we;
@@ -649,9 +645,6 @@ module rv_plic_reg_top (
   logic [1:0] prio81_qs;
   logic [1:0] prio81_wd;
   logic prio81_we;
-  logic [1:0] prio82_qs;
-  logic [1:0] prio82_wd;
-  logic prio82_we;
   logic ie0_0_e_0_qs;
   logic ie0_0_e_0_wd;
   logic ie0_0_e_0_we;
@@ -898,9 +891,6 @@ module rv_plic_reg_top (
   logic ie0_2_e_81_qs;
   logic ie0_2_e_81_wd;
   logic ie0_2_e_81_we;
-  logic ie0_2_e_82_qs;
-  logic ie0_2_e_82_wd;
-  logic ie0_2_e_82_we;
   logic [1:0] threshold0_qs;
   logic [1:0] threshold0_wd;
   logic threshold0_we;
@@ -2970,31 +2960,6 @@ module rv_plic_reg_top (
 
     // to register interface (read)
     .qs     (ip_2_p_81_qs)
-  );
-
-
-  // F[p_82]: 18:18
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RO"),
-    .RESVAL  (1'h0)
-  ) u_ip_2_p_82 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    .we     (1'b0),
-    .wd     ('0  ),
-
-    // from internal hardware
-    .de     (hw2reg.ip[82].de),
-    .d      (hw2reg.ip[82].d ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (ip_2_p_82_qs)
   );
 
 
@@ -5138,32 +5103,6 @@ module rv_plic_reg_top (
 
     // to register interface (read)
     .qs     (le_2_le_81_qs)
-  );
-
-
-  // F[le_82]: 18:18
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_le_2_le_82 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (le_2_le_82_we),
-    .wd     (le_2_le_82_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.le[82].q ),
-
-    // to register interface (read)
-    .qs     (le_2_le_82_qs)
   );
 
 
@@ -7382,33 +7321,6 @@ module rv_plic_reg_top (
   );
 
 
-  // R[prio82]: V(False)
-
-  prim_subreg #(
-    .DW      (2),
-    .SWACCESS("RW"),
-    .RESVAL  (2'h0)
-  ) u_prio82 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (prio82_we),
-    .wd     (prio82_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.prio82.q ),
-
-    // to register interface (read)
-    .qs     (prio82_qs)
-  );
-
-
 
   // Subregister 0 of Multireg ie0
   // R[ie0_0]: V(False)
@@ -9551,32 +9463,6 @@ module rv_plic_reg_top (
   );
 
 
-  // F[e_82]: 18:18
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_ie0_2_e_82 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (ie0_2_e_82_we),
-    .wd     (ie0_2_e_82_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.ie0[82].q ),
-
-    // to register interface (read)
-    .qs     (ie0_2_e_82_qs)
-  );
-
-
 
   // R[threshold0]: V(False)
 
@@ -9650,7 +9536,7 @@ module rv_plic_reg_top (
 
 
 
-  logic [94:0] addr_hit;
+  logic [93:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == RV_PLIC_IP_0_OFFSET);
@@ -9741,13 +9627,12 @@ module rv_plic_reg_top (
     addr_hit[85] = (reg_addr == RV_PLIC_PRIO79_OFFSET);
     addr_hit[86] = (reg_addr == RV_PLIC_PRIO80_OFFSET);
     addr_hit[87] = (reg_addr == RV_PLIC_PRIO81_OFFSET);
-    addr_hit[88] = (reg_addr == RV_PLIC_PRIO82_OFFSET);
-    addr_hit[89] = (reg_addr == RV_PLIC_IE0_0_OFFSET);
-    addr_hit[90] = (reg_addr == RV_PLIC_IE0_1_OFFSET);
-    addr_hit[91] = (reg_addr == RV_PLIC_IE0_2_OFFSET);
-    addr_hit[92] = (reg_addr == RV_PLIC_THRESHOLD0_OFFSET);
-    addr_hit[93] = (reg_addr == RV_PLIC_CC0_OFFSET);
-    addr_hit[94] = (reg_addr == RV_PLIC_MSIP0_OFFSET);
+    addr_hit[88] = (reg_addr == RV_PLIC_IE0_0_OFFSET);
+    addr_hit[89] = (reg_addr == RV_PLIC_IE0_1_OFFSET);
+    addr_hit[90] = (reg_addr == RV_PLIC_IE0_2_OFFSET);
+    addr_hit[91] = (reg_addr == RV_PLIC_THRESHOLD0_OFFSET);
+    addr_hit[92] = (reg_addr == RV_PLIC_CC0_OFFSET);
+    addr_hit[93] = (reg_addr == RV_PLIC_MSIP0_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -9849,9 +9734,7 @@ module rv_plic_reg_top (
     if (addr_hit[91] && reg_we && (RV_PLIC_PERMIT[91] != (RV_PLIC_PERMIT[91] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[92] && reg_we && (RV_PLIC_PERMIT[92] != (RV_PLIC_PERMIT[92] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[93] && reg_we && (RV_PLIC_PERMIT[93] != (RV_PLIC_PERMIT[93] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[94] && reg_we && (RV_PLIC_PERMIT[94] != (RV_PLIC_PERMIT[94] & reg_be))) wr_err = 1'b1 ;
   end
-
 
 
 
@@ -10181,9 +10064,6 @@ module rv_plic_reg_top (
   assign le_2_le_81_we = addr_hit[5] & reg_we & ~wr_err;
   assign le_2_le_81_wd = reg_wdata[17];
 
-  assign le_2_le_82_we = addr_hit[5] & reg_we & ~wr_err;
-  assign le_2_le_82_wd = reg_wdata[18];
-
   assign prio0_we = addr_hit[6] & reg_we & ~wr_err;
   assign prio0_wd = reg_wdata[1:0];
 
@@ -10430,266 +10310,260 @@ module rv_plic_reg_top (
   assign prio81_we = addr_hit[87] & reg_we & ~wr_err;
   assign prio81_wd = reg_wdata[1:0];
 
-  assign prio82_we = addr_hit[88] & reg_we & ~wr_err;
-  assign prio82_wd = reg_wdata[1:0];
-
-  assign ie0_0_e_0_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie0_0_e_0_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie0_0_e_0_wd = reg_wdata[0];
 
-  assign ie0_0_e_1_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie0_0_e_1_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie0_0_e_1_wd = reg_wdata[1];
 
-  assign ie0_0_e_2_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie0_0_e_2_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie0_0_e_2_wd = reg_wdata[2];
 
-  assign ie0_0_e_3_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie0_0_e_3_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie0_0_e_3_wd = reg_wdata[3];
 
-  assign ie0_0_e_4_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie0_0_e_4_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie0_0_e_4_wd = reg_wdata[4];
 
-  assign ie0_0_e_5_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie0_0_e_5_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie0_0_e_5_wd = reg_wdata[5];
 
-  assign ie0_0_e_6_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie0_0_e_6_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie0_0_e_6_wd = reg_wdata[6];
 
-  assign ie0_0_e_7_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie0_0_e_7_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie0_0_e_7_wd = reg_wdata[7];
 
-  assign ie0_0_e_8_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie0_0_e_8_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie0_0_e_8_wd = reg_wdata[8];
 
-  assign ie0_0_e_9_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie0_0_e_9_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie0_0_e_9_wd = reg_wdata[9];
 
-  assign ie0_0_e_10_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie0_0_e_10_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie0_0_e_10_wd = reg_wdata[10];
 
-  assign ie0_0_e_11_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie0_0_e_11_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie0_0_e_11_wd = reg_wdata[11];
 
-  assign ie0_0_e_12_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie0_0_e_12_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie0_0_e_12_wd = reg_wdata[12];
 
-  assign ie0_0_e_13_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie0_0_e_13_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie0_0_e_13_wd = reg_wdata[13];
 
-  assign ie0_0_e_14_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie0_0_e_14_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie0_0_e_14_wd = reg_wdata[14];
 
-  assign ie0_0_e_15_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie0_0_e_15_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie0_0_e_15_wd = reg_wdata[15];
 
-  assign ie0_0_e_16_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie0_0_e_16_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie0_0_e_16_wd = reg_wdata[16];
 
-  assign ie0_0_e_17_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie0_0_e_17_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie0_0_e_17_wd = reg_wdata[17];
 
-  assign ie0_0_e_18_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie0_0_e_18_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie0_0_e_18_wd = reg_wdata[18];
 
-  assign ie0_0_e_19_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie0_0_e_19_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie0_0_e_19_wd = reg_wdata[19];
 
-  assign ie0_0_e_20_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie0_0_e_20_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie0_0_e_20_wd = reg_wdata[20];
 
-  assign ie0_0_e_21_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie0_0_e_21_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie0_0_e_21_wd = reg_wdata[21];
 
-  assign ie0_0_e_22_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie0_0_e_22_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie0_0_e_22_wd = reg_wdata[22];
 
-  assign ie0_0_e_23_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie0_0_e_23_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie0_0_e_23_wd = reg_wdata[23];
 
-  assign ie0_0_e_24_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie0_0_e_24_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie0_0_e_24_wd = reg_wdata[24];
 
-  assign ie0_0_e_25_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie0_0_e_25_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie0_0_e_25_wd = reg_wdata[25];
 
-  assign ie0_0_e_26_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie0_0_e_26_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie0_0_e_26_wd = reg_wdata[26];
 
-  assign ie0_0_e_27_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie0_0_e_27_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie0_0_e_27_wd = reg_wdata[27];
 
-  assign ie0_0_e_28_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie0_0_e_28_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie0_0_e_28_wd = reg_wdata[28];
 
-  assign ie0_0_e_29_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie0_0_e_29_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie0_0_e_29_wd = reg_wdata[29];
 
-  assign ie0_0_e_30_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie0_0_e_30_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie0_0_e_30_wd = reg_wdata[30];
 
-  assign ie0_0_e_31_we = addr_hit[89] & reg_we & ~wr_err;
+  assign ie0_0_e_31_we = addr_hit[88] & reg_we & ~wr_err;
   assign ie0_0_e_31_wd = reg_wdata[31];
 
-  assign ie0_1_e_32_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_1_e_32_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie0_1_e_32_wd = reg_wdata[0];
 
-  assign ie0_1_e_33_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_1_e_33_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie0_1_e_33_wd = reg_wdata[1];
 
-  assign ie0_1_e_34_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_1_e_34_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie0_1_e_34_wd = reg_wdata[2];
 
-  assign ie0_1_e_35_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_1_e_35_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie0_1_e_35_wd = reg_wdata[3];
 
-  assign ie0_1_e_36_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_1_e_36_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie0_1_e_36_wd = reg_wdata[4];
 
-  assign ie0_1_e_37_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_1_e_37_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie0_1_e_37_wd = reg_wdata[5];
 
-  assign ie0_1_e_38_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_1_e_38_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie0_1_e_38_wd = reg_wdata[6];
 
-  assign ie0_1_e_39_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_1_e_39_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie0_1_e_39_wd = reg_wdata[7];
 
-  assign ie0_1_e_40_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_1_e_40_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie0_1_e_40_wd = reg_wdata[8];
 
-  assign ie0_1_e_41_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_1_e_41_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie0_1_e_41_wd = reg_wdata[9];
 
-  assign ie0_1_e_42_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_1_e_42_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie0_1_e_42_wd = reg_wdata[10];
 
-  assign ie0_1_e_43_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_1_e_43_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie0_1_e_43_wd = reg_wdata[11];
 
-  assign ie0_1_e_44_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_1_e_44_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie0_1_e_44_wd = reg_wdata[12];
 
-  assign ie0_1_e_45_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_1_e_45_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie0_1_e_45_wd = reg_wdata[13];
 
-  assign ie0_1_e_46_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_1_e_46_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie0_1_e_46_wd = reg_wdata[14];
 
-  assign ie0_1_e_47_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_1_e_47_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie0_1_e_47_wd = reg_wdata[15];
 
-  assign ie0_1_e_48_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_1_e_48_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie0_1_e_48_wd = reg_wdata[16];
 
-  assign ie0_1_e_49_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_1_e_49_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie0_1_e_49_wd = reg_wdata[17];
 
-  assign ie0_1_e_50_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_1_e_50_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie0_1_e_50_wd = reg_wdata[18];
 
-  assign ie0_1_e_51_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_1_e_51_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie0_1_e_51_wd = reg_wdata[19];
 
-  assign ie0_1_e_52_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_1_e_52_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie0_1_e_52_wd = reg_wdata[20];
 
-  assign ie0_1_e_53_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_1_e_53_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie0_1_e_53_wd = reg_wdata[21];
 
-  assign ie0_1_e_54_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_1_e_54_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie0_1_e_54_wd = reg_wdata[22];
 
-  assign ie0_1_e_55_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_1_e_55_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie0_1_e_55_wd = reg_wdata[23];
 
-  assign ie0_1_e_56_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_1_e_56_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie0_1_e_56_wd = reg_wdata[24];
 
-  assign ie0_1_e_57_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_1_e_57_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie0_1_e_57_wd = reg_wdata[25];
 
-  assign ie0_1_e_58_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_1_e_58_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie0_1_e_58_wd = reg_wdata[26];
 
-  assign ie0_1_e_59_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_1_e_59_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie0_1_e_59_wd = reg_wdata[27];
 
-  assign ie0_1_e_60_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_1_e_60_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie0_1_e_60_wd = reg_wdata[28];
 
-  assign ie0_1_e_61_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_1_e_61_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie0_1_e_61_wd = reg_wdata[29];
 
-  assign ie0_1_e_62_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_1_e_62_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie0_1_e_62_wd = reg_wdata[30];
 
-  assign ie0_1_e_63_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_1_e_63_we = addr_hit[89] & reg_we & ~wr_err;
   assign ie0_1_e_63_wd = reg_wdata[31];
 
-  assign ie0_2_e_64_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_2_e_64_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie0_2_e_64_wd = reg_wdata[0];
 
-  assign ie0_2_e_65_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_2_e_65_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie0_2_e_65_wd = reg_wdata[1];
 
-  assign ie0_2_e_66_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_2_e_66_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie0_2_e_66_wd = reg_wdata[2];
 
-  assign ie0_2_e_67_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_2_e_67_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie0_2_e_67_wd = reg_wdata[3];
 
-  assign ie0_2_e_68_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_2_e_68_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie0_2_e_68_wd = reg_wdata[4];
 
-  assign ie0_2_e_69_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_2_e_69_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie0_2_e_69_wd = reg_wdata[5];
 
-  assign ie0_2_e_70_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_2_e_70_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie0_2_e_70_wd = reg_wdata[6];
 
-  assign ie0_2_e_71_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_2_e_71_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie0_2_e_71_wd = reg_wdata[7];
 
-  assign ie0_2_e_72_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_2_e_72_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie0_2_e_72_wd = reg_wdata[8];
 
-  assign ie0_2_e_73_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_2_e_73_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie0_2_e_73_wd = reg_wdata[9];
 
-  assign ie0_2_e_74_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_2_e_74_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie0_2_e_74_wd = reg_wdata[10];
 
-  assign ie0_2_e_75_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_2_e_75_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie0_2_e_75_wd = reg_wdata[11];
 
-  assign ie0_2_e_76_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_2_e_76_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie0_2_e_76_wd = reg_wdata[12];
 
-  assign ie0_2_e_77_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_2_e_77_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie0_2_e_77_wd = reg_wdata[13];
 
-  assign ie0_2_e_78_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_2_e_78_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie0_2_e_78_wd = reg_wdata[14];
 
-  assign ie0_2_e_79_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_2_e_79_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie0_2_e_79_wd = reg_wdata[15];
 
-  assign ie0_2_e_80_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_2_e_80_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie0_2_e_80_wd = reg_wdata[16];
 
-  assign ie0_2_e_81_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_2_e_81_we = addr_hit[90] & reg_we & ~wr_err;
   assign ie0_2_e_81_wd = reg_wdata[17];
 
-  assign ie0_2_e_82_we = addr_hit[91] & reg_we & ~wr_err;
-  assign ie0_2_e_82_wd = reg_wdata[18];
-
-  assign threshold0_we = addr_hit[92] & reg_we & ~wr_err;
+  assign threshold0_we = addr_hit[91] & reg_we & ~wr_err;
   assign threshold0_wd = reg_wdata[1:0];
 
-  assign cc0_we = addr_hit[93] & reg_we & ~wr_err;
+  assign cc0_we = addr_hit[92] & reg_we & ~wr_err;
   assign cc0_wd = reg_wdata[6:0];
-  assign cc0_re = addr_hit[93] && reg_re;
+  assign cc0_re = addr_hit[92] && reg_re;
 
-  assign msip0_we = addr_hit[94] & reg_we & ~wr_err;
+  assign msip0_we = addr_hit[93] & reg_we & ~wr_err;
   assign msip0_wd = reg_wdata[0];
 
   // Read data return
@@ -10785,7 +10659,6 @@ module rv_plic_reg_top (
         reg_rdata_next[15] = ip_2_p_79_qs;
         reg_rdata_next[16] = ip_2_p_80_qs;
         reg_rdata_next[17] = ip_2_p_81_qs;
-        reg_rdata_next[18] = ip_2_p_82_qs;
       end
 
       addr_hit[3]: begin
@@ -10877,7 +10750,6 @@ module rv_plic_reg_top (
         reg_rdata_next[15] = le_2_le_79_qs;
         reg_rdata_next[16] = le_2_le_80_qs;
         reg_rdata_next[17] = le_2_le_81_qs;
-        reg_rdata_next[18] = le_2_le_82_qs;
       end
 
       addr_hit[6]: begin
@@ -11209,10 +11081,6 @@ module rv_plic_reg_top (
       end
 
       addr_hit[88]: begin
-        reg_rdata_next[1:0] = prio82_qs;
-      end
-
-      addr_hit[89]: begin
         reg_rdata_next[0] = ie0_0_e_0_qs;
         reg_rdata_next[1] = ie0_0_e_1_qs;
         reg_rdata_next[2] = ie0_0_e_2_qs;
@@ -11247,7 +11115,7 @@ module rv_plic_reg_top (
         reg_rdata_next[31] = ie0_0_e_31_qs;
       end
 
-      addr_hit[90]: begin
+      addr_hit[89]: begin
         reg_rdata_next[0] = ie0_1_e_32_qs;
         reg_rdata_next[1] = ie0_1_e_33_qs;
         reg_rdata_next[2] = ie0_1_e_34_qs;
@@ -11282,7 +11150,7 @@ module rv_plic_reg_top (
         reg_rdata_next[31] = ie0_1_e_63_qs;
       end
 
-      addr_hit[91]: begin
+      addr_hit[90]: begin
         reg_rdata_next[0] = ie0_2_e_64_qs;
         reg_rdata_next[1] = ie0_2_e_65_qs;
         reg_rdata_next[2] = ie0_2_e_66_qs;
@@ -11301,18 +11169,17 @@ module rv_plic_reg_top (
         reg_rdata_next[15] = ie0_2_e_79_qs;
         reg_rdata_next[16] = ie0_2_e_80_qs;
         reg_rdata_next[17] = ie0_2_e_81_qs;
-        reg_rdata_next[18] = ie0_2_e_82_qs;
       end
 
-      addr_hit[92]: begin
+      addr_hit[91]: begin
         reg_rdata_next[1:0] = threshold0_qs;
       end
 
-      addr_hit[93]: begin
+      addr_hit[92]: begin
         reg_rdata_next[6:0] = cc0_qs;
       end
 
-      addr_hit[94]: begin
+      addr_hit[93]: begin
         reg_rdata_next[0] = msip0_qs;
       end
 

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -303,7 +303,9 @@ module top_earlgrey #(
     .irq_timer_i          (intr_rv_timer_timer_expired_0_0),
     .irq_external_i       (irq_plic),
     .irq_fast_i           (15'b0),// PLIC handles all peripheral interrupts
-    .irq_nm_i             (1'b0),// TODO - add and connect alert responder
+    // escalation input from alert handler (NMI)
+    .esc_tx_i             (esc_tx[0]),
+    .esc_rx_o             (esc_rx[0]),
     // debug interface
     .debug_req_i          (debug_req),
     // CPU control signals
@@ -843,8 +845,8 @@ module top_earlgrey #(
       .tl_i(nmi_gen_tl_req),
       .tl_o(nmi_gen_tl_rsp),
       // escalation signal inputs
-      .esc_rx_o    ( esc_rx   ),
-      .esc_tx_i    ( esc_tx   ),
+      .esc_rx_o    ( esc_rx[3:1] ),
+      .esc_tx_i    ( esc_tx[3:1] ),
       .clk_i (clkmgr_clocks.clk_main_secure),
       .rst_ni (rstmgr_resets.rst_sys_n)
   );

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -114,7 +114,7 @@ module top_earlgrey #(
   // otbn
 
 
-  logic [82:0]  intr_vector;
+  logic [81:0]  intr_vector;
   // Interrupt source list
   logic intr_uart_tx_watermark;
   logic intr_uart_rx_watermark;
@@ -149,7 +149,6 @@ module top_earlgrey #(
   logic intr_nmi_gen_esc0;
   logic intr_nmi_gen_esc1;
   logic intr_nmi_gen_esc2;
-  logic intr_nmi_gen_esc3;
   logic intr_usbdev_pkt_received;
   logic intr_usbdev_pkt_sent;
   logic intr_usbdev_disconnected;
@@ -302,7 +301,6 @@ module top_earlgrey #(
     .irq_software_i       (msip),
     .irq_timer_i          (intr_rv_timer_timer_expired_0_0),
     .irq_external_i       (irq_plic),
-    .irq_fast_i           (15'b0),// PLIC handles all peripheral interrupts
     // escalation input from alert handler (NMI)
     .esc_tx_i             (esc_tx[0]),
     .esc_rx_o             (esc_rx[0]),
@@ -839,7 +837,6 @@ module top_earlgrey #(
       .intr_esc0_o (intr_nmi_gen_esc0),
       .intr_esc1_o (intr_nmi_gen_esc1),
       .intr_esc2_o (intr_nmi_gen_esc2),
-      .intr_esc3_o (intr_nmi_gen_esc3),
 
       // Inter-module signals
       .tl_i(nmi_gen_tl_req),
@@ -947,7 +944,6 @@ module top_earlgrey #(
       intr_usbdev_disconnected,
       intr_usbdev_pkt_sent,
       intr_usbdev_pkt_received,
-      intr_nmi_gen_esc3,
       intr_nmi_gen_esc2,
       intr_nmi_gen_esc1,
       intr_nmi_gen_esc0,

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.c
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.c
@@ -11,7 +11,7 @@
  * `top_earlgrey_plic_peripheral_t`.
  */
 const top_earlgrey_plic_peripheral_t
-    top_earlgrey_plic_interrupt_for_peripheral[83] = {
+    top_earlgrey_plic_interrupt_for_peripheral[82] = {
   [kTopEarlgreyPlicIrqIdNone] = kTopEarlgreyPlicPeripheralUnknown,
   [kTopEarlgreyPlicIrqIdGpioGpio0] = kTopEarlgreyPlicPeripheralGpio,
   [kTopEarlgreyPlicIrqIdGpioGpio1] = kTopEarlgreyPlicPeripheralGpio,
@@ -75,7 +75,6 @@ const top_earlgrey_plic_peripheral_t
   [kTopEarlgreyPlicIrqIdNmiGenEsc0] = kTopEarlgreyPlicPeripheralNmiGen,
   [kTopEarlgreyPlicIrqIdNmiGenEsc1] = kTopEarlgreyPlicPeripheralNmiGen,
   [kTopEarlgreyPlicIrqIdNmiGenEsc2] = kTopEarlgreyPlicPeripheralNmiGen,
-  [kTopEarlgreyPlicIrqIdNmiGenEsc3] = kTopEarlgreyPlicPeripheralNmiGen,
   [kTopEarlgreyPlicIrqIdUsbdevPktReceived] = kTopEarlgreyPlicPeripheralUsbdev,
   [kTopEarlgreyPlicIrqIdUsbdevPktSent] = kTopEarlgreyPlicPeripheralUsbdev,
   [kTopEarlgreyPlicIrqIdUsbdevDisconnected] = kTopEarlgreyPlicPeripheralUsbdev,

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -530,27 +530,26 @@ typedef enum top_earlgrey_plic_irq_id {
   kTopEarlgreyPlicIrqIdNmiGenEsc0 = 60, /**< nmi_gen_esc0 */
   kTopEarlgreyPlicIrqIdNmiGenEsc1 = 61, /**< nmi_gen_esc1 */
   kTopEarlgreyPlicIrqIdNmiGenEsc2 = 62, /**< nmi_gen_esc2 */
-  kTopEarlgreyPlicIrqIdNmiGenEsc3 = 63, /**< nmi_gen_esc3 */
-  kTopEarlgreyPlicIrqIdUsbdevPktReceived = 64, /**< usbdev_pkt_received */
-  kTopEarlgreyPlicIrqIdUsbdevPktSent = 65, /**< usbdev_pkt_sent */
-  kTopEarlgreyPlicIrqIdUsbdevDisconnected = 66, /**< usbdev_disconnected */
-  kTopEarlgreyPlicIrqIdUsbdevHostLost = 67, /**< usbdev_host_lost */
-  kTopEarlgreyPlicIrqIdUsbdevLinkReset = 68, /**< usbdev_link_reset */
-  kTopEarlgreyPlicIrqIdUsbdevLinkSuspend = 69, /**< usbdev_link_suspend */
-  kTopEarlgreyPlicIrqIdUsbdevLinkResume = 70, /**< usbdev_link_resume */
-  kTopEarlgreyPlicIrqIdUsbdevAvEmpty = 71, /**< usbdev_av_empty */
-  kTopEarlgreyPlicIrqIdUsbdevRxFull = 72, /**< usbdev_rx_full */
-  kTopEarlgreyPlicIrqIdUsbdevAvOverflow = 73, /**< usbdev_av_overflow */
-  kTopEarlgreyPlicIrqIdUsbdevLinkInErr = 74, /**< usbdev_link_in_err */
-  kTopEarlgreyPlicIrqIdUsbdevRxCrcErr = 75, /**< usbdev_rx_crc_err */
-  kTopEarlgreyPlicIrqIdUsbdevRxPidErr = 76, /**< usbdev_rx_pid_err */
-  kTopEarlgreyPlicIrqIdUsbdevRxBitstuffErr = 77, /**< usbdev_rx_bitstuff_err */
-  kTopEarlgreyPlicIrqIdUsbdevFrame = 78, /**< usbdev_frame */
-  kTopEarlgreyPlicIrqIdUsbdevConnected = 79, /**< usbdev_connected */
-  kTopEarlgreyPlicIrqIdPwrmgrWakeup = 80, /**< pwrmgr_wakeup */
-  kTopEarlgreyPlicIrqIdOtbnDone = 81, /**< otbn_done */
-  kTopEarlgreyPlicIrqIdOtbnErr = 82, /**< otbn_err */
-  kTopEarlgreyPlicIrqIdLast = 82, /**< \internal The Last Valid Interrupt ID. */
+  kTopEarlgreyPlicIrqIdUsbdevPktReceived = 63, /**< usbdev_pkt_received */
+  kTopEarlgreyPlicIrqIdUsbdevPktSent = 64, /**< usbdev_pkt_sent */
+  kTopEarlgreyPlicIrqIdUsbdevDisconnected = 65, /**< usbdev_disconnected */
+  kTopEarlgreyPlicIrqIdUsbdevHostLost = 66, /**< usbdev_host_lost */
+  kTopEarlgreyPlicIrqIdUsbdevLinkReset = 67, /**< usbdev_link_reset */
+  kTopEarlgreyPlicIrqIdUsbdevLinkSuspend = 68, /**< usbdev_link_suspend */
+  kTopEarlgreyPlicIrqIdUsbdevLinkResume = 69, /**< usbdev_link_resume */
+  kTopEarlgreyPlicIrqIdUsbdevAvEmpty = 70, /**< usbdev_av_empty */
+  kTopEarlgreyPlicIrqIdUsbdevRxFull = 71, /**< usbdev_rx_full */
+  kTopEarlgreyPlicIrqIdUsbdevAvOverflow = 72, /**< usbdev_av_overflow */
+  kTopEarlgreyPlicIrqIdUsbdevLinkInErr = 73, /**< usbdev_link_in_err */
+  kTopEarlgreyPlicIrqIdUsbdevRxCrcErr = 74, /**< usbdev_rx_crc_err */
+  kTopEarlgreyPlicIrqIdUsbdevRxPidErr = 75, /**< usbdev_rx_pid_err */
+  kTopEarlgreyPlicIrqIdUsbdevRxBitstuffErr = 76, /**< usbdev_rx_bitstuff_err */
+  kTopEarlgreyPlicIrqIdUsbdevFrame = 77, /**< usbdev_frame */
+  kTopEarlgreyPlicIrqIdUsbdevConnected = 78, /**< usbdev_connected */
+  kTopEarlgreyPlicIrqIdPwrmgrWakeup = 79, /**< pwrmgr_wakeup */
+  kTopEarlgreyPlicIrqIdOtbnDone = 80, /**< otbn_done */
+  kTopEarlgreyPlicIrqIdOtbnErr = 81, /**< otbn_err */
+  kTopEarlgreyPlicIrqIdLast = 81, /**< \internal The Last Valid Interrupt ID. */
 } top_earlgrey_plic_irq_id_t;
 
 /**
@@ -560,7 +559,7 @@ typedef enum top_earlgrey_plic_irq_id {
  * `top_earlgrey_plic_peripheral_t`.
  */
 extern const top_earlgrey_plic_peripheral_t
-    top_earlgrey_plic_interrupt_for_peripheral[83];
+    top_earlgrey_plic_interrupt_for_peripheral[82];
 
 /**
  * PLIC external interrupt target.

--- a/sw/device/lib/dif/dif_plic.c
+++ b/sw/device/lib/dif/dif_plic.c
@@ -14,7 +14,7 @@
 // If either of these static assertions fail, then the assumptions in this DIF
 // implementation should be revisited. In particular, `plic_target_reg_offsets`
 // may need updating,
-_Static_assert(RV_PLIC_PARAM_NUMSRC == 83,
+_Static_assert(RV_PLIC_PARAM_NUMSRC == 82,
                "PLIC instantiation parameters have changed.");
 _Static_assert(RV_PLIC_PARAM_NUMTARGET == 1,
                "PLIC instantiation parameters have changed.");

--- a/sw/device/tests/dif/dif_plic_unittest.cc
+++ b/sw/device/tests/dif/dif_plic_unittest.cc
@@ -114,7 +114,7 @@ class IrqEnableSetTest : public IrqTests {
           RV_PLIC_IE0_1_REG_OFFSET, RV_PLIC_IE0_1_E_63,
       },
       {
-          RV_PLIC_IE0_2_REG_OFFSET, RV_PLIC_IE0_2_E_82,
+          RV_PLIC_IE0_2_REG_OFFSET, RV_PLIC_IE0_2_E_81,
       },
   };
 };
@@ -162,7 +162,7 @@ class IrqTriggerTypeSetTest : public IrqTests {
           RV_PLIC_LE_1_REG_OFFSET, RV_PLIC_LE_1_LE_63,
       },
       {
-          RV_PLIC_LE_2_REG_OFFSET, RV_PLIC_LE_2_LE_82,
+          RV_PLIC_LE_2_REG_OFFSET, RV_PLIC_LE_2_LE_81,
       },
   };
 };
@@ -263,7 +263,7 @@ class IrqPendingStatusGetTest : public IrqTests {
           RV_PLIC_IP_1_REG_OFFSET, RV_PLIC_IP_1_P_63,
       },
       {
-          RV_PLIC_IP_2_REG_OFFSET, RV_PLIC_IP_2_P_82,
+          RV_PLIC_IP_2_REG_OFFSET, RV_PLIC_IP_2_P_81,
       },
   };
 };


### PR DESCRIPTION
This is a draft PR to prototype the NMI connection from the alert handler to Ibex. 

What we basically need to do here is convert the differential escalation protocol into a single ended level signal, and it would be preferrable to perform that conversion as physically close as possible to the processor core. Hence, I think it would probably be best to instantiate the escalation receiver right inside the `rv_core_ibex` wrapper.

Another point we should consider is the encoding of the NMI itself (the `.esc_en_o ( irq_nm   )` signal) - see #2990 for more details.

Signed-off-by: Michael Schaffner <msf@opentitan.org>