### PR TITLE
[otbn] default increment dmem pointer

### DIFF
--- a/hw/ip/otbn/code-snippets/modexp.S
+++ b/hw/ip/otbn/code-snippets/modexp.S
@@ -103,8 +103,8 @@ JAL x1, selcxSub
 ADDI x0, x0, 0
 ADDI x8, x0, 5
 LOOP x30, 2
-BN.SID x8++, 0(x18)
-ADDI x18, x18, 1
+BN.SID x8, 0(x18++)
+ADDI x8, x8, 1
 JALR x0, x1, 0
 
 dmXd0:
@@ -265,8 +265,8 @@ ADD x19, x5, x0
 ADD x20, x6, x0
 ADDI x8, x0, 4
 LOOP x30, 2
-BN.SID x8++, 0(x21)
-ADDI x21, x21, 1
+BN.SID x8, 0(x21++)
+ADDI x8, x8, 1
 ADDI x8, x0, 4
 JALR x0, x1, 0
 
@@ -361,8 +361,8 @@ ADDI x19, x7, 0
 ADDI x10, x0, 4
 ADDI x8, x0, 4
 LOOP x30, 2
-BN.SID x8++, 0(x21)
-ADDI x21, x21, 1
+BN.SID x8, 0(x21++)
+ADDI x8, x8, 1
 ADDI x8, x0, 4
 ADDI x10, x0, 4
 LW x12, 4(x0)


### PR DESCRIPTION
for dmem access operations with two pointer increments
(reg pointer and dmem) pointer only one increment can be
handled in the load/store instruction. The other increment
is handeled in a subsequent `addi`. This adjusts the increments
such that always the dmem pointer is incremented in the load/store
and the reg pointer in the `addi`. This has the advantage that an
immediate of `1` can be used for the `addi` instruction regardless
of the type of addressing used for dmem.

This fixes #3001 

Signed-off-by: Felix Miller <felix.miller@gi-de.com>