### PR TITLE
[sw] Unsigned Comparisons in Address Loops

### DIFF
--- a/sw/device/boot_rom/rom_crt.S
+++ b/sw/device/boot_rom/rom_crt.S
@@ -76,13 +76,13 @@ _start:
   //
   // We use `t0` and `t1` to represent the start and end pointers
   // of `.bss`.
-  la  t0, _bss_start
-  la  t1, _bss_end
-  bge t0, t1, bss_zero_loop_end
+  la   t0, _bss_start
+  la   t1, _bss_end
+  bgeu t0, t1, bss_zero_loop_end
 bss_zero_loop:
   sw    zero, 0(t0)
   addi  t0, t0, 0x4
-  blt   t0, t1, bss_zero_loop
+  bltu  t0, t1, bss_zero_loop
 bss_zero_loop_end:
 
   // Zero out the stack
@@ -90,13 +90,13 @@ bss_zero_loop_end:
   // We use `t0` and `t1` to represent the start and end pointers of the stack.
   // As the stack grows downwards and we zero going forwards the start pointer
   // starts as _stack_end and the end pointer at _stack_start
-  la  t0, _stack_end
-  la  t1, _stack_start
-  bge t0, t1, stack_zero_loop_end
+  la   t0, _stack_end
+  la   t1, _stack_start
+  bgeu t0, t1, stack_zero_loop_end
 stack_zero_loop:
   sw    zero, 0(t0)
   addi  t0, t0, 0x4
-  blt   t0, t1, stack_zero_loop
+  bltu  t0, t1, stack_zero_loop
 stack_zero_loop_end:
 
   // Initialize the `.data` segment from the `.idata` segment.
@@ -105,16 +105,16 @@ stack_zero_loop_end:
   // of `.data`, `t2` to represent the start pointer of `.idata`
   // (which has the same length as `.data`) and `t3` is a scratch
   // register for the copy.
-  la  t0, _data_start
-  la  t1, _data_end
-  la  t2, _data_init_start
-  bge t0, t1, data_copy_loop_end
+  la   t0, _data_start
+  la   t1, _data_end
+  la   t2, _data_init_start
+  bgeu t0, t1, data_copy_loop_end
 data_copy_loop:
   lw   t3, 0(t2)
   sw   t3, 0(t0)
   addi t0, t0, 0x4
   addi t2, t2, 0x4
-  blt  t0, t1, data_copy_loop
+  bltu t0, t1, data_copy_loop
 data_copy_loop_end:
 
   // Re-clobber all of the registers from above.

--- a/sw/device/exts/common/flash_crt.S
+++ b/sw/device/exts/common/flash_crt.S
@@ -42,13 +42,13 @@ _start:
   //
   // We use `t0` and `t1` to represent the start and end pointers
   // of `.bss`.
-  la  t0, _bss_start
-  la  t1, _bss_end
-  bge t0, t1, bss_zero_loop_end
+  la   t0, _bss_start
+  la   t1, _bss_end
+  bgeu t0, t1, bss_zero_loop_end
 bss_zero_loop:
   sw    zero, 0(t0)
   addi  t0, t0, 0x4
-  blt   t0, t1, bss_zero_loop
+  bltu  t0, t1, bss_zero_loop
 bss_zero_loop_end:
 
   // Zero out the stack
@@ -56,13 +56,13 @@ bss_zero_loop_end:
   // We use `t0` and `t1` to represent the start and end pointers of the stack.
   // As the stack grows downwards and we zero going forwards the start pointer
   // starts as _stack_end and the end pointer at _stack_start.
-  la  t0, _stack_end
-  la  t1, _stack_start
-  bge t0, t1, stack_zero_loop_end
+  la   t0, _stack_end
+  la   t1, _stack_start
+  bgeu t0, t1, stack_zero_loop_end
 stack_zero_loop:
   sw    zero, 0(t0)
   addi  t0, t0, 0x4
-  blt   t0, t1, stack_zero_loop
+  bltu  t0, t1, stack_zero_loop
 stack_zero_loop_end:
 
   // Initialize the `.data` segment from the `.idata` segment.
@@ -71,16 +71,16 @@ stack_zero_loop_end:
   // of `.data`, `t2` to represent the start pointer of `.idata`
   // (which has the same length as `.data`) and `t3` is a scratch
   // register for the copy.
-  la  t0, _data_start
-  la  t1, _data_end
-  la  t2, _data_init_start
-  bge t0, t1, data_copy_loop_end
+  la   t0, _data_start
+  la   t1, _data_end
+  la   t2, _data_init_start
+  bgeu t0, t1, data_copy_loop_end
 data_copy_loop:
   lw   t3, 0(t2)
   sw   t3, 0(t0)
   addi t0, t0, 0x4
   addi t2, t2, 0x4
-  blt  t0, t1, data_copy_loop
+  bltu t0, t1, data_copy_loop
 data_copy_loop_end:
 
   // Jump into the C program entry point. This is your standard


### PR DESCRIPTION
Both CRTs use signed comparisons for their data clearing/loading loops.

However, these loops use addresses as their induction variables, and
addresses are unsigned, so the comparisons must be unsigned. This was
noticed by @alphan in the review of #2991, and this change applies it to
the existing CRTs.

