### PR TITLE
[lint/dv] Create lint targets for testbench environments

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -137,11 +137,21 @@ jobs:
         --tool=veriblelint
       if [ $? != 0 ]; then
         echo -n "##vso[task.logissue type=error]"
-        echo "Verilog style lint with Verible failed. Run 'util/dvsim/dvsim.py -t veriblelint hw/top_earlgrey/lint/top_earlgrey_lint_cfgs.hjson' to check and fix all errors."
+        echo "Verilog style lint of RTL sources with Verible failed. Run 'util/dvsim/dvsim.py -t veriblelint hw/top_earlgrey/lint/top_earlgrey_lint_cfgs.hjson' to check and fix all errors."
         exit 1
       fi
     condition: eq(variables['Build.Reason'], 'PullRequest')
-    displayName: Style-Lint Verilog source files with Verible
+    displayName: Style-Lint RTL Verilog source files with Verible
+  - bash: |
+      util/dvsim/dvsim.py hw/top_earlgrey/lint/top_earlgrey_dv_lint_cfgs.hjson \
+        --tool=veriblelint
+      if [ $? != 0 ]; then
+        echo -n "##vso[task.logissue type=error]"
+        echo "Verilog style lint of DV sources with Verible failed. Run 'util/dvsim/dvsim.py -t veriblelint hw/top_earlgrey/lint/top_earlgrey_dv_lint_cfgs.hjson' to check and fix all errors."
+        exit 1
+      fi
+    condition: eq(variables['Build.Reason'], 'PullRequest')
+    displayName: Style-Lint DV Verilog source files with Verible
   - bash: |
       commit_range="$(git merge-base --fork-point origin/$SYSTEM_PULLREQUEST_TARGETBRANCH)..HEAD"
       # Notes:

--- a/hw/_index.md
+++ b/hw/_index.md
@@ -22,6 +22,7 @@ Finally, we provide the same set of information for all available [top level des
 * [AscentLint summary results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/lint/ascentlint/summary.html)
 * [Verilator lint summary results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/lint/verilator/summary.html)
 * [Style lint summary results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/lint/veriblelint/summary.html)
+* [DV Style lint summary results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/dv/lint/veriblelint/summary.html)
 
 ## Comportable IPs
 
@@ -44,4 +45,5 @@ Finally, we provide the same set of information for all available [top level des
   * [AscentLint results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/lint/ascentlint/latest/results.html)
   * [Verilator lint results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/lint/verilator/latest/results.html)
   * [Style lint results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/lint/veriblelint/latest/results.html)
+  * [DV Style lint results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/dv/lint/veriblelint/latest/results.html)
   * [Synthesis results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/syn/latest/results.html)

--- a/hw/ip/aes/dv/aes_sim.core
+++ b/hw/ip/aes/dv/aes_sim.core
@@ -18,9 +18,21 @@ filesets:
     file_type: systemVerilogSource
 
 targets:
-  sim:
+  sim: &sim_target
     toplevel: tb
     filesets:
       - files_rtl
       - files_dv
     default_tool: vcs
+
+  lint:
+    <<: *sim_target
+    default_tool: verilator
+    tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"

--- a/hw/ip/alert_handler/dv/alert_handler_generic_sim.core
+++ b/hw/ip/alert_handler/dv/alert_handler_generic_sim.core
@@ -26,7 +26,7 @@ generate:
       ip_hjson: ../data/alert_handler.hjson
 
 targets:
-  sim:
+  sim: &sim_target
     toplevel: tb
     filesets:
       - files_rtl
@@ -34,3 +34,15 @@ targets:
     generate:
       - ral
     default_tool: vcs
+
+  lint:
+    <<: *sim_target
+    default_tool: verilator
+    tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"

--- a/hw/ip/entropy_src/dv/entropy_src_sim.core
+++ b/hw/ip/entropy_src/dv/entropy_src_sim.core
@@ -18,9 +18,21 @@ filesets:
     file_type: systemVerilogSource
 
 targets:
-  sim:
+  sim: &sim_target
     toplevel: tb
     filesets:
       - files_rtl
       - files_dv
     default_tool: vcs
+
+  lint:
+    <<: *sim_target
+    default_tool: verilator
+    tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"

--- a/hw/ip/flash_ctrl/dv/flash_ctrl_sim.core
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_sim.core
@@ -24,9 +24,21 @@ filesets:
     file_type: systemVerilogSource
 
 targets:
-  sim:
+  sim: &sim_target
     toplevel: tb
     filesets:
       - files_rtl
       - files_dv
     default_tool: vcs
+
+  lint:
+    <<: *sim_target
+    default_tool: verilator
+    tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"

--- a/hw/ip/gpio/dv/gpio_sim.core
+++ b/hw/ip/gpio/dv/gpio_sim.core
@@ -18,9 +18,22 @@ filesets:
     file_type: systemVerilogSource
 
 targets:
-  sim:
+  sim: &sim_target
     toplevel: tb
     filesets:
       - files_rtl
       - files_dv
     default_tool: vcs
+
+  lint:
+    <<: *sim_target
+    default_tool: verilator
+    tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"
+

--- a/hw/ip/hmac/dv/hmac_sim.core
+++ b/hw/ip/hmac/dv/hmac_sim.core
@@ -18,9 +18,22 @@ filesets:
     file_type: systemVerilogSource
 
 targets:
-  sim:
+  sim: &sim_target
     toplevel: tb
     filesets:
       - files_rtl
       - files_dv
     default_tool: vcs
+
+  lint:
+    <<: *sim_target
+    default_tool: verilator
+    tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"
+

--- a/hw/ip/i2c/dv/i2c_sim.core
+++ b/hw/ip/i2c/dv/i2c_sim.core
@@ -18,9 +18,21 @@ filesets:
     file_type: systemVerilogSource
 
 targets:
-  sim:
+  sim: &sim_target
     toplevel: tb
     filesets:
       - files_rtl
       - files_dv
     default_tool: vcs
+
+  lint:
+    <<: *sim_target
+    default_tool: verilator
+    tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"

--- a/hw/ip/rv_timer/dv/rv_timer_sim.core
+++ b/hw/ip/rv_timer/dv/rv_timer_sim.core
@@ -18,9 +18,22 @@ filesets:
     file_type: systemVerilogSource
 
 targets:
-  sim:
+  sim: &sim_target
     toplevel: tb
     filesets:
       - files_rtl
       - files_dv
     default_tool: vcs
+
+  lint:
+    <<: *sim_target
+    default_tool: verilator
+    tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"
+

--- a/hw/ip/spi_device/dv/spi_device_sim.core
+++ b/hw/ip/spi_device/dv/spi_device_sim.core
@@ -18,9 +18,21 @@ filesets:
     file_type: systemVerilogSource
 
 targets:
-  sim:
+  sim: &sim_target
     toplevel: tb
     filesets:
       - files_rtl
       - files_dv
     default_tool: vcs
+
+  lint:
+    <<: *sim_target
+    default_tool: verilator
+    tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"

--- a/hw/ip/trial1/dv/trial1_sim.core
+++ b/hw/ip/trial1/dv/trial1_sim.core
@@ -23,9 +23,22 @@ filesets:
     file_type: systemVerilogSource
 
 targets:
-  sim:
+  sim: &sim_target
     toplevel: tb
     filesets:
       - files_rtl
       - files_dv
     default_tool: vcs
+
+  lint:
+    <<: *sim_target
+    default_tool: verilator
+    tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"
+

--- a/hw/ip/uart/dv/uart_sim.core
+++ b/hw/ip/uart/dv/uart_sim.core
@@ -18,9 +18,21 @@ filesets:
     file_type: systemVerilogSource
 
 targets:
-  sim:
+  sim: &sim_target
     toplevel: tb
     filesets:
       - files_rtl
       - files_dv
     default_tool: vcs
+
+  lint:
+    <<: *sim_target
+    default_tool: verilator
+    tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"

--- a/hw/ip/usbdev/dv/usbdev_sim.core
+++ b/hw/ip/usbdev/dv/usbdev_sim.core
@@ -18,9 +18,21 @@ filesets:
     file_type: systemVerilogSource
 
 targets:
-  sim:
+  sim: &sim_target
     toplevel: tb
     filesets:
       - files_rtl
       - files_dv
     default_tool: vcs
+
+  lint:
+    <<: *sim_target
+    default_tool: verilator
+    tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"

--- a/hw/lint/tools/ascentlint/parse-lint-report.py
+++ b/hw/lint/tools/ascentlint/parse-lint-report.py
@@ -5,6 +5,7 @@
 r"""Parses lint report and dump filtered messages in hjson format.
 """
 import argparse
+import logging as log
 import re
 import sys
 from pathlib import Path
@@ -109,16 +110,15 @@ def main():
 
     # return nonzero status if any warnings or errors are present
     # lint infos do not count as failures
-    nr_errors = len(results["errors"]) + len(results["lint_errors"])
-    nr_warnings = len(results["warnings"]) + len(results["lint_warnings"])
-    if nr_errors > 0 or nr_warnings > 0:
-        print("Lint not successful, got %d warnings and %d errors." %
-              (nr_warnings, nr_errors))
+    n_errors = len(results["errors"]) + len(results["lint_errors"])
+    n_warnings = len(results["warnings"]) + len(results["lint_warnings"])
+    if n_errors > 0 or n_warnings > 0:
+        log.info("Found %d lint errors and %d lint warnings", n_errors, n_warnings)
         sys.exit(1)
 
-    print("Lint successful, got %d warnings and %d errors." %
-          (nr_warnings, nr_errors))
+    log.info("Lint logfile parsed succesfully")
     sys.exit(0)
+
 
 
 if __name__ == "__main__":

--- a/hw/lint/tools/veriblelint/parse-lint-report.py
+++ b/hw/lint/tools/veriblelint/parse-lint-report.py
@@ -5,6 +5,7 @@
 r"""Parses lint report and dump filtered messages in hjson format.
 """
 import argparse
+import logging as log
 import re
 import sys
 from pathlib import Path
@@ -51,6 +52,7 @@ def get_results(resdir):
                  r"^(?!ERROR: Failed to run .* Lint failed)ERROR: .*"),
                 ("errors", r"^Error: .*"),
                 ("errors", r"^E .*"),
+                ("errors", r"^F .*"),
                 # TODO(https://github.com/olofk/edalize/issues/90):
                 # this is a workaround until we actually have native Edalize
                 # support for JasperGold and "formal" targets
@@ -117,12 +119,13 @@ def main():
 
     # return nonzero status if any warnings or errors are present
     # lint infos do not count as failures
-    nr_errors = len(results["errors"]) + len(results["lint_errors"])
-    nr_warnings = len(results["warnings"]) + len(results["lint_warnings"])
-    print("Lint not successful, got %d warnings and %d errors." %
-          (nr_warnings, nr_errors))
-    if nr_errors > 0 or nr_warnings > 0:
+    n_errors = len(results["errors"]) + len(results["lint_errors"])
+    n_warnings = len(results["warnings"]) + len(results["lint_warnings"])
+    if n_errors > 0 or n_warnings > 0:
+        log.info("Found %d lint errors and %d lint warnings", n_errors, n_warnings)
         sys.exit(1)
+
+    log.info("Lint logfile parsed succesfully")
     sys.exit(0)
 
 

--- a/hw/lint/tools/verilator/parse-lint-report.py
+++ b/hw/lint/tools/verilator/parse-lint-report.py
@@ -38,7 +38,9 @@ def parse_lint_log(str_buffer):
         # and we decided not to report it in the dashboard.
         ("errors",
          r"^(?!ERROR: Failed to build .* 'make' exited with an error code)ERROR: .*"),
-        ("errors", r"^Error: .*"),
+        ("errors",
+        # This is a redundant Verilator error that we ignore for the same reason as above.
+         r"^(?!%Error: Exiting due to .* warning.*)%Error: .*"),
         # TODO(https://github.com/olofk/edalize/issues/90):
         # this is a workaround until we actually have native Edalize
         # support for JasperGold and "formal" targets
@@ -48,7 +50,7 @@ def parse_lint_log(str_buffer):
          # remove once this has been fixed in Edalize or in the corefile.
          r"^(?!WARNING: Unknown item symbiyosis in section Target)WARNING: .*"
          ),
-        ("warnings", r"^Warning: .* "),
+        ("warnings", r"^%Warning: .* "),
         ("lint_errors", r"^%Error-.*"),
         ("lint_warnings", r"^%Warning-.*"),
     }

--- a/hw/top_earlgrey/dv/chip_sim.core
+++ b/hw/top_earlgrey/dv/chip_sim.core
@@ -24,11 +24,23 @@ filesets:
       - tb/tb.sv
     file_type: systemVerilogSource
 
-
 targets:
-  sim:
+  sim: &sim_target
     toplevel: tb
     filesets:
       - files_rtl
       - files_dv
     default_tool: vcs
+
+  lint:
+    <<: *sim_target
+    default_tool: verilator
+    tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"
+

--- a/hw/top_earlgrey/ip/alert_handler/dv/alert_handler_sim.core
+++ b/hw/top_earlgrey/ip/alert_handler/dv/alert_handler_sim.core
@@ -27,7 +27,7 @@ generate:
       ip_hjson: ../data/autogen/alert_handler.hjson
 
 targets:
-  sim:
+  sim: &sim_target
     toplevel: tb
     filesets:
       - files_rtl
@@ -35,3 +35,16 @@ targets:
     generate:
       - ral
     default_tool: vcs
+
+  lint:
+    <<: *sim_target
+    default_tool: verilator
+    tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"
+

--- a/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_main_sim.core
+++ b/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_main_sim.core
@@ -20,8 +20,21 @@ filesets:
 
 
 targets:
-  sim:
+  sim: &sim_target
     toplevel: xbar_tb_top
     filesets:
       - files_dv
     default_tool: vcs
+
+  lint:
+    <<: *sim_target
+    default_tool: verilator
+    tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"
+

--- a/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_peri_sim.core
+++ b/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_peri_sim.core
@@ -20,8 +20,21 @@ filesets:
 
 
 targets:
-  sim:
+  sim: &sim_target
     toplevel: xbar_tb_top
     filesets:
       - files_dv
     default_tool: vcs
+
+  lint:
+    <<: *sim_target
+    default_tool: verilator
+    tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"
+

--- a/hw/top_earlgrey/lint/top_earlgrey_dv_lint_cfgs.hjson
+++ b/hw/top_earlgrey/lint/top_earlgrey_dv_lint_cfgs.hjson
@@ -1,0 +1,90 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+
+  // This is the primary cfg hjson for DV linting. It imports ALL individual lint
+  // cfgs of the IPs DV environments and the full chip DV environment for top_earlgrey.
+  // This enables to run them all as a regression in one shot.
+  name: top_earlgrey_dv_batch
+
+  import_cfgs:      [// common server configuration for results upload
+                     "{proj_root}/hw/data/common_project_cfg.hjson"
+                     // tool-specific configuration
+                     "{proj_root}/hw/lint/data/{tool}.hjson"]
+
+  // Different dashboard output path for each tool
+  rel_path: "hw/top_earlgrey/dv/lint/{tool}"
+
+  use_cfgs: [{    name: aes
+                  fusesoc_core: lowrisc:dv:aes_sim
+                  import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/aes/dv/lint/{tool}"
+             },
+             {    name: alert_handler
+                  fusesoc_core: lowrisc:dv:alert_handler_sim
+                  import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
+                  rel_path: "hw/top_earlgrey/ip/alert_handler/dv/lint/{tool}"
+             },
+             {    name: entropy_src
+                  fusesoc_core: lowrisc:dv:entropy_src_sim
+                  import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/entropy_src/dv/lint/{tool}"
+             },
+             {    name: flash_ctrl
+                  fusesoc_core: lowrisc:dv:flash_ctrl_sim
+                  import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/flash_ctrl/dv/lint/{tool}"
+             },
+             {    name: gpio
+                  fusesoc_core: lowrisc:dv:gpio_sim
+                  import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/gpio/dv/lint/{tool}"
+             },
+             {    name: hmac
+                  fusesoc_core: lowrisc:dv:hmac_sim
+                  import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/hmac/dv/lint/{tool}"
+             },
+             {    name: i2c
+                  fusesoc_core: lowrisc:dv:i2c_sim
+                  import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/i2c/dv/lint/{tool}"
+             },
+             {    name: rv_timer
+                  fusesoc_core: lowrisc:dv:rv_timer_sim
+                  import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/rv_timer/dv/lint/{tool}"
+             },
+             {    name: spi_device
+                  fusesoc_core: lowrisc:dv:spi_device_sim
+                  import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/spi_device/dv/lint/{tool}"
+             },
+             {    name: uart
+                  fusesoc_core: lowrisc:dv:uart_sim
+                  import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/uart/dv/lint/{tool}"
+             },
+             {    name: usbdev
+                  fusesoc_core: lowrisc:dv:usbdev_sim
+                  import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/usbdev/dv/lint/{tool}"
+             },
+             {    name: xbar_main
+                  fusesoc_core: lowrisc:dv:xbar_main_sim
+                  import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
+                  rel_path: "hw/top_earlgrey/ip/xbar_main/dv/lint/{tool}"
+             },
+             {    name: xbar_peri
+                  fusesoc_core: lowrisc:dv:xbar_peri_sim
+                  import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
+                  rel_path: "hw/top_earlgrey/ip/xbar_peri/dv/lint/{tool}"
+             },
+             {    name: chip
+                  fusesoc_core: lowrisc:dv:chip_sim
+                  import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
+                  rel_path: "hw/top_earlgrey/dv/lint/{tool}"
+             },
+            ]
+}

--- a/util/tlgen/xbar.sim.core.tpl
+++ b/util/tlgen/xbar.sim.core.tpl
@@ -20,8 +20,21 @@ filesets:
 
 
 targets:
-  sim:
+  sim: &sim_target
     toplevel: xbar_tb_top
     filesets:
       - files_dv
     default_tool: vcs
+
+  lint:
+    <<: *sim_target
+    default_tool: verilator
+    tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"
+


### PR DESCRIPTION
This adds available DV environment targets to the overarching lint configs list such that these targets can also benefit from linting.

Style lint is going to block this PR since it has been integrated with CI. For those, we need to merge the fixes into upstream and rebase this PR, or pile additional lint fixes onto this PR in order to get it clean.

Could you help me go through the DV code that you own and clean these Style lint warnings up? There are not too left many at this point, but some might need waivers. I can add the waiver files, but it would be good if you could triage warnings and fix the fixable ones.

If you have Verible installed (as explained [here](https://docs.opentitan.org/doc/ug/install_instructions/#verible)), you can run it locally by checking out this PR and calling:
```
$ util/dvsim/dvsim.py -t veriblelint hw/top_earlgrey/lint/top_earlgrey_lint_cfgs.hjson --purge
```

Alternatively you can also look at [this](https://reports.opentitan.org/hw/top_earlgrey/dvlint/veriblelint/summary.html) results summary page. Note that this is not from the nightlies (hence I need to rerun manually, if needed).

Just ping me whenever you made an edit (and/or CC me on the PR). 

Thanks!

Signed-off-by: Michael Schaffner <msf@opentitan.org>