### PR TITLE
[doc] Add expectation that TC members proactively identify possible committers

### DIFF
--- a/doc/project/technical_committee.md
+++ b/doc/project/technical_committee.md
@@ -15,6 +15,7 @@ Expectations of Technical Committee members include the following:
 * Put aside sufficient time on a week-by-week basis to active proposals and give feedback.
 * Act in the best interests of the OpenTitan project.
 * Collaborate to deliver on the responsibilities of the Technical Committee (see above).
+* Proactively seek to identify contributors who should be nominated for committer status.
 
 ## Membership
 The OpenTitan Technical Committee membership is:


### PR DESCRIPTION
As discussed at the TC, we felt it would be good to add an expectation that TC members proactively seek to identify contributors who should be nominated for committer status.

Precise wording to be further discussed in the TC meeting today.