### PR TITLE
[sw/dif_usbdev] Expose device buffers to clients

### DIFF
--- a/sw/device/lib/dif/dif_usbdev.c
+++ b/sw/device/lib/dif/dif_usbdev.c
@@ -269,7 +269,9 @@ dif_usbdev_result_t dif_usbdev_init(dif_usbdev_config_t *config,
   if (!is_valid_toggle(config->differential_rx) ||
       !is_valid_toggle(config->differential_tx) ||
       !is_valid_toggle(config->single_bit_eop) ||
-      !is_valid_power_sense_override(config->power_sense_override)) {
+      !is_valid_power_sense_override(config->power_sense_override) ||
+      !is_valid_toggle(config->pin_flip) ||
+      !is_valid_toggle(config->clock_sync_signals)) {
     return kDifUsbdevBadArg;
   }
 
@@ -330,6 +332,24 @@ dif_usbdev_result_t dif_usbdev_init(dif_usbdev_config_t *config,
         phy_config_val,
         (bitfield_field32_t){
             .mask = 1, .index = USBDEV_PHY_CONFIG_OVERRIDE_PWR_SENSE_EN,
+        },
+        1);
+  }
+
+  if (config->pin_flip == kDifUsbdevToggleEnable) {
+    phy_config_val = bitfield_field32_write(
+        phy_config_val,
+        (bitfield_field32_t){
+            .mask = 1, .index = USBDEV_PHY_CONFIG_PINFLIP,
+        },
+        1);
+  }
+
+  if (config->clock_sync_signals == kDifUsbdevToggleDisable) {
+    phy_config_val = bitfield_field32_write(
+        phy_config_val,
+        (bitfield_field32_t){
+            .mask = 1, .index = USBDEV_PHY_CONFIG_USB_REF_DISABLE,
         },
         1);
   }

--- a/sw/device/lib/dif/dif_usbdev.h
+++ b/sw/device/lib/dif/dif_usbdev.h
@@ -146,6 +146,14 @@ typedef struct dif_usbdev_config {
    * Override USB power sense.
    */
   dif_usbdev_power_sense_override_t power_sense_override;
+  /**
+   * Flip the D+/D- pins.
+   */
+  dif_usbdev_toggle_t pin_flip;
+  /**
+   * Reference signal generation for clock synchronization.
+   */
+  dif_usbdev_toggle_t clock_sync_signals;
 } dif_usbdev_config_t;
 
 /**


### PR DESCRIPTION
This change exposes USB device buffers to clients, as recommended by @lenary and @gkelly in #2093, so that they can build a backlog of incoming and outgoing packets.

See also: lowRISC/opentitan#1601 (tracking).

Note: This PR also includes another commit that adds two new phy config options that were introduced after #2093.

Signed-off-by: Alphan Ulusoy <alphan@google.com>
