### PR TITLE
[mask rom] Describe Mask ROM Interface Structures

### DIFF
--- a/sw/device/mask_rom/boot.md
+++ b/sw/device/mask_rom/boot.md
@@ -1,10 +1,30 @@
 # Pseudo-code for Mask ROM Secure Boot Process
 
+*   [Secure Boot Process](#secure-boot-process)
+*   [Modules](#modules)
+    +   [Boot Policy](#boot-policy)
+        -   [Read Boot Policy](#read-boot-policy)
+    +   [ROM_EXT Manifest](#rom-ext-manifest)
+    +   [Bootstrap](#bootstrap)
+        -   [Manufacturing boot-strapping intervention](#manufacturing-boot-strapping-intervention)
+    +   [Keys and Signature](#keys-and-signature)
+    +   [Chip-specific Startup](#chip-specific-startup)
+    +   [Lockdown](#lockdown)
+        -   [Locking Down Peripherals](#locking-down-peripherals)
+    +   [Hardened Jump](#hardened-jump)
+    +   [System State](#system-state)
+        -   [Cleaning Device State](#cleaning-device-state)
+    +   [CRT (C Runtime)](#crt--c-runtime-)
+        -   [CRT Initialization](#crt-initialization)
+*   [Interface Data](#interface-data)
+    +   [Key Management Data](#key-management-data)
+    +   [Boot Policy Structure](#boot-policy-structure)
+    +   [ROM_EXT Manifest Structure](#rom-ext-manifest-structure)
+
 This file should be read in conjunction with the secure boot specification.
 References to that document are included.
 
-Sub-procedures and data structures are documented below the main `boot`
-function.
+## Secure Boot Process
 
 1. Power on (entirely in hardware)
 

--- a/sw/device/mask_rom/boot.md
+++ b/sw/device/mask_rom/boot.md
@@ -28,15 +28,15 @@ function.
 
 ```c
 void boot(void) {
-  boot_reason = read_boot_reason();
+  boot_reason = read_boot_reason(); // Boot Policy Module
 
   // Clean Device State Part 2.
   // See "Cleaning Device State" Below.
-  clean_device_state_part_2(boot_reason);
+  clean_device_state_part_2(boot_reason); // Chip-Specific Startup Module
 
   // Enable Memory Protection
   // - PMP Initial Region (if not done in power on)
-  enable_memory_protection();
+  enable_memory_protection();  // Lockdown Module
 
   // Chip-specific startup functionality
   // **Open Q:** Proprietary Software Strategy.
@@ -44,27 +44,40 @@ void boot(void) {
   // - AST / Entropy.
   // - Flash
   // - Fuses
-  chip_specific_startup();
+  chip_specific_startup(); // Chip-Specific Startup Module
 
   // Manufacturing boot-strapping intervention.
   // **Open Q:** How does the Mask ROM deal with chip recovery?
   // **Open Q:** Pin Strapping Configuration.
-  manufacturing_boot_strap();
+  manufacturing_boot_strap(boot_policy, boot_reason); // Bootstrap Module
 
   // Read Boot Policy for ROM_EXTs from flash (2.b)
-  boot_policy = read_boot_policy();
+  boot_policy = read_boot_policy(boot_reason); // Boot Policy Module
 
   // Determine which ROM_EXT slot is prioritised (2.b, 2.c.i)
-  for ( current_rom_ext_manifest in rom_ext_manifests_to_try(boot_policy) ) {
+  for ( current_rom_ext_manifest in rom_ext_manifests_to_try(boot_policy) ) { // Boot Policy Module
 
     // Sanity Check ROM_EXT Manifest (2.c.ii)
     // **Open Q:** Integration with Secure Boot Hardware
-    // - Header Format
-    // - Plausible Key
-    // - Initial Digest Checks
+    // - Header Format (ROM_EXT Manifest Module)
+    // - Plausible Key (??)
+    // - Initial Digest Checks (Keys + Signature Module)
+    // - **Open Q**: ROM_EXT Anti-rollback (??)
     if (!check_rom_ext_manifest(current_rom_ext_manifest)) {
-      // Boot Failure (check policy)
-      if (try_next_on_manifest_failed(boot_policy))
+      // Manifest Failure (check Boot Policy)
+      if (try_next_on_manifest_failed(boot_policy)) // Boot Policy Module
+        continue
+      else
+        break
+    }
+
+    // Find Public Key for ROM_EXT Image Signature (2.c.iii)
+    // **Open Q:** Key Selection method/mechanism.
+    rom_ext_pub_key = read_pub_key(current_rom_ext_manifest); // ROM_EXT Manifest Module
+    rom_ext_pub_key_id = calculate_key_id(rom_ext_pub_key); // Keys + Signature Module
+    if (!check_pub_key_id_valid(rom_ext_pub_key_id)) { // Keys + Signature Module
+      // Manifest failure (Check Boot Policy)
+      if (try_next_on_manifest_failed(boot_policy))  // Boot Policy Module
         continue
       else
         break
@@ -72,18 +85,20 @@ void boot(void) {
 
     // Verify ROM_EXT Image Signature (2.c.iii)
     // **Open Q:** Integration with Secure Boot Hardware, OTBN
-    // **Open Q:** Key Selection method/mechanism.
-    verified = verify_rom_ext_signature(pub_key_selector(...),
-                                        current_rom_ext_manifest);
-    if (!verified) {
+    if (!verify_rom_ext_signature(rom_ext_pub_key,
+                                  current_rom_ext_manifest)) { // Hardened Jump Module
       // Manifest Failure (check Boot Policy)
       // **Open Q:** Does this need different logic to the check after
       //   `check_rom_ext_manifest`?
-      if (try_next_on_manifest_failed(boot_policy))
+      if (try_next_on_manifest_failed(boot_policy)) // Boot Policy Module
         continue
       else
         break
     }
+
+    // Update Boot Policy on Successful Signature
+    // **Open Q:** Does this ensure ROM_EXT Anti-rollback is updated?
+    update_next_boot_policy(boot_policy, current_rom_ext_manifest); // Boot Policy Module
 
     // Beyond this point, you know `current_rom_ext_manifest` is valid and the
     // signature has been authenticated.
@@ -97,8 +112,8 @@ void boot(void) {
     // undo the changes, for instance to write-enable bits).
 
     // System State Measurements (2.c.iv)
-    measurements = perform_system_state_measurements();
-    if (!boot_allowed_with_state(measurements)) {
+    measurements = perform_system_state_measurements(); // System State Module
+    if (!boot_allowed_with_state(measurements)) { // System State Module
       // Lifecycle failure (no policy check)
       break
     }
@@ -106,35 +121,33 @@ void boot(void) {
     // CreatorRootKey (2.c.iv)
     // - This is only allowed to be done if we have verified the signature on
     //   the current ROM_EXT.
-    root_key_identity = derive_and_lock_creator_root_key_inputs(measurements);
-
     // **Open Q:** Does Mask ROM just lock down key manager inputs, and let the
     //             ROM_EXT load the key?
-    load_root_key(root_key_identity);
+    derive_and_lock_creator_root_key_inputs(measurements); // System State Module
 
     // Lock down Peripherals based on descriptors in ROM_EXT manifest.
     // - This does not cover key-related lockdown, which is done in
     //   `derive_and_lock_creator_root_key_inputs`.
-    peripheral_lockdown(current_rom_ext_manifest);
+    peripheral_lockdown(current_rom_ext_manifest); // Lockdown Module
 
     // PMP Region for ROM_EXT (2.c.v)
     // **Open Q:** Integration with Secure Boot Hardware
     // **Open Q:** Do we need to prevent access to Mask ROM after final jump?
-    pmp_unlock_rom_ext();
+    pmp_unlock_rom_ext(); // Hardened Jump Module.
 
     // Transfer Execution to ROM_EXT (2.c.vi)
     // **Open Q:** Integration with Secure Boot Hardware
     // **Open Q:** Accumulated measurements to tie manifest to hardware config.
-    if (!final_jump_to_rom_ext(current_rom_ext_manifest)) {
+    if (!final_jump_to_rom_ext(current_rom_ext_manifest)) { // Hardened Jump Module
       // Boot Failure (no policy check)
       // - Because we may have locked some write-enable bits that any following
       //   manifest cannot change if it needs to, we have to just reboot here.
-      boot_failed(boot_policy, current_rom_ext_manifest);
+      boot_failed(boot_policy, current_rom_ext_manifest); // Boot Policy Module
     }
   }
 
   // Boot failed for all ROM_EXTs allowed by boot policy
-  boot_failed(boot_policy);
+  boot_failed(boot_policy); // Boot Policy Module
 }
 ```
 
@@ -142,9 +155,205 @@ void boot(void) {
 
    Not covered by this document. Refer to Secure Boot document instead.
 
-## Subroutines
+## Modules
 
-### Cleaning Device State
+We've tried to divide the Mask ROM into self-contained modules that can be
+tested separately, rather than having to test the whole boot system at once.
+
+The module descriptions below also include descriptions of: the DIFs that are
+required for that module to be implemented fully; the functionality expected at
+various milestones of the Mask ROM's development; and, optionally, pseudo-code
+for any subroutines that make up their implementation.
+
+### Boot Policy
+
+This manages reading the boot policy, updating the boot policy
+if required, and making decisions based on that policy. Most Boot Policy
+choices also depend on the Boot Reason, so reading and acting on that is
+part of this module's responsibility too.
+
+DIFs Needed:
+
+*   Flash Controller
+*   Reset Manager
+
+Milestone Expectations:
+
+*   *v0.5:* Reading/Updating Boot Policy
+*   *v0.9:* Reading Boot Reason
+
+#### Read Boot Policy
+
+```c
+read_boot_policy() {
+  // Parameters:
+  // - initilized flash_ctrl DIF (for accessing flash info page)
+  // Returns:
+  // - Boot Policy Structure (see below)
+
+  // 1. Uses dif_flash_ctrl to issue read of boot info page.
+  // 2. Pull this into a struct to return.
+}
+```
+
+### ROM_EXT Manifest
+
+This manages reading and parsing ROM_EXT manifests.
+
+DIFs Needed:
+
+*   Flash Controller
+
+Milestone Expectations:
+
+*   *v0.5:* Chosen Manifest, Reading Manifest,
+    Tooling to assemble ROM_EXT image with Manifest,
+    Tooling to ensure ROM_EXT is loaded at boot.
+*   v0.9: Nothing more (Bootstrap should work in v0.9).
+
+### Bootstrap
+
+This manages boot-strapping, chip recovery, and manufacturer loading of ROM_EXT
+images.
+
+DIFs Needed:
+
+*   GPIO
+*   Pinmux
+*   Padctrl
+*   SPI Device / I2C Device
+*   Flash Controller
+*   Lifecycle Manager
+
+Milestone Expectations
+
+*   *v0.5:* Nothing (images pre-loaded into Memory)
+*   *v0.9:* Full Strapping (ROM_EXT images loaded over SPI)
+
+#### Manufacturing boot-strapping intervention
+
+This is where, depending on lifecycle state, new flash images may be loaded onto
+the device (usually during manufacturing).
+
+**Open Q:** Do we want hardware hardening for this?
+  There are suggestions around having the hardware return `nop` when reading
+  this memory if we're not in the correct lifecycle state.
+
+```c
+manufacturing_boot_strap() {
+  // 1. Read lifecycle state to establish whether bootstrapping is allowed.
+  // 2. Determine what kind of bootstrapping is being requested.
+  // 3. Clear Flash (Both Banks) and SRAM (Retention)
+  //    **Open Q:** How much is cleared? Is the Creator Certificate cleared?
+  // 4. Load ROM_EXT image into flash if allowed.
+  // 5. Reboot device (causing loaded ROM_EXT to be verified then executed).
+}
+```
+
+### Keys and Signature
+
+This manages public key selection (for ROM_EXT validation), and calculating the
+digest and signature of the ROM_EXT image itself.
+
+DIFs Needed:
+
+*   OTBN
+*   HMAC
+*   Key Manager
+*   Lifecycle Manager
+
+Milestone Expectations:
+
+*   *v0.5:* HMAC Digests, Software Implementations of RSA Verify
+*   *v0.9:* OTBN Implementations of RSA Verify
+
+### Chip-specific Startup
+
+This deals with how to initialize and clear any chip-specific hardware.
+
+DIFs Needed:
+
+*   Flash
+*   OTP / Fuses
+*   AST?
+*   Entropy?
+*   Clocks
+
+### Lockdown
+
+This is responsible for managing memory protection regions as well as
+disallowing reconfiguration of peripherals. Some memory protection regions are
+also handled by the Hardened Jump module.
+
+DIFs Needed:
+
+*   "PMP" (Not actually a DIF, but something similar will be required)
+*   Flash Controller
+*   SRAM Scrambling Sequence (Not a DIF, but will need to be shared with DV)
+*   Pinmux / Padctrl / Alert Handler
+
+Milestone Expectations:
+
+*   *v0.5:* PMP, Flash Controller
+*   *v0.9:* SRAM Scrambling, Lockdown Profiles Defined
+
+#### Locking Down Peripherals
+
+```c
+peripheral_lockdown() {
+  // Parameters:
+  // - ROM_EXT manifest
+  // - Handles for Peripheral DIFs
+
+  // **Open Q:** When and How do we lock down peripheral configuration?
+  // - We configure based on ROM_EXT manifest (signed)
+  // - Only locks down these peripherals if info is provided.
+
+  // What do we want to allow lockdown of?
+  // - Alert Manager
+  // - Pinmux / Padctrl
+  // - Entropy Configuration
+  // - Anything Else?
+
+  // This is explicitly a separate step from locking the key manager inputs. In
+  // particular, this depends on the ROM_EXT's choices, whereas the key manager
+  // inputs getting locked is not something the ROM_EXT can choose.
+}
+```
+
+### Hardened Jump
+
+This module is responsible for managing the state associated with the hardware
+support for the jump into ROM_EXT.
+
+DIFs Needed:
+
+*   Secure Boot (which implements Hardened Jump)
+
+Milestone Expectations:
+
+*   *v0.5:* Unhardened Jump (entirely in SW)
+*   *v0.9:* HW-support Hardened Jump
+
+### System State
+
+This deals with taking the system state measurements which are used to derive
+the `CreatorRootKey`. Some of these measurements may cause boot to be halted.
+
+DIFs Needed:
+
+*   Key Manager
+*   Lifecycle Manager
+*   Flash Controller
+*   OTP
+*   **Open Q:** ROM Integrity Measurement?
+
+Milestone Expectations:
+
+*   *v0.5:* Software Binding Properties, OTP Bits.
+*   *v0.9:* Full `CreatorRootKey` derivation.
+
+#### Cleaning Device State
 
 Part of this process is done before we can execute any C code. In particular, we
 have to clear all registers and all of the main RAM before we setup the CRT
@@ -195,7 +404,17 @@ clean_device_state_part_2() {
 
 ### CRT (C Runtime)
 
-We cannot execute any C code until we have set up the CRT.
+This sets up execution so we can run C functions. We cannot execute any C code
+until we have setup the CRT.
+
+DIFs Needed: None
+
+Milestone Expectations:
+
+*   *v0.5:* Can Execute C functions.
+*   *v0.9:* SRAM Scrambling.
+
+#### CRT Initialization
 
 Setting up the CRT involves: loading the `.data` and `.bss` sections, and
 setting up the stack and `gp` (`gp` may be used for referencing some data).
@@ -213,75 +432,52 @@ crt_init() {
 }
 ```
 
-### Manufacturing boot-strapping intervention
+## Interface Data
 
-This is where, depending on lifecycle state, new flash images may be loaded onto
-the device (usually during manufacturing).
-
-**Open Q:** Do we want hardware hardening for this?
-  There are suggestions around having the hardware return `nop` when reading
-  this memory if we're not in the correct lifecycle state.
-
-```c
-manufacturing_boot_strap() {
-  // 1. Read lifecycle state to establish whether bootstrapping is allowed.
-  // 2. Determine what kind of bootstrapping is being requested.
-  // 3. Load ROM_EXT image into flash if allowed.
-  // 4. Reboot device (causing loaded ROM_EXT to be verified then executed).
-}
-```
-
-### Read Boot Policy
-
-```c
-read_boot_policy() {
-  // Parameters:
-  // - initilized flash_ctrl DIF (for accessing flash info page)
-  // Returns:
-  // - Boot Policy Structure (see below)
-
-  // 1. Uses dif_flash_ctrl to issue read of boot info page.
-  // 2. Pull this into a struct to return.
-}
-```
-
-### Lock Down Peripherals
-
-```c
-peripheral_lockdown() {
-  // Parameters:
-  // - ROM_EXT manifest
-  // - Handles for Peripheral DIFs
-
-  // **Open Q:** When and How do we lock down peripheral configuration?
-  // - We configure based on ROM_EXT manifest (signed)
-  // - Only locks down these peripherals if info is provided.
-
-  // What do we want to allow lockdown of?
-  // - Alert Manager
-  // - Pinmux / Padctrl
-  // - Entropy Configuration
-  // - Anything Else?
-
-  // This is explicitly a separate step from locking the key manager inputs. In
-  // particular, this depends on the ROM_EXT's choices, whereas the key manager
-  // inputs getting locked is not something the ROM_EXT can choose.
-}
-```
-
-## Info Structures
-
-There are two main info structures used by the Mask ROM:
+There is some data that is accessed by more than just the Mask ROM:
 
 *   The Boot Policy structure, used to choose a ROM_EXT to boot.
 *   The ROM_EXT manifest, used to contain information about a specific ROM_EXT.
+*   The Key Management data, used to validate Root Keys.
 
 In order to keep the Mask ROM simple, a particular Mask ROM version will only
 support one version each of the following structures. This means they must be
 carefully designed to be extensible if the other systems accessing them may
 require additional data in these formats.
 
+### Key Management Data
+
+This is the storage for the IDs of keys that are used to sign a ROM_EXT. The
+ROM_EXT image contains the full key, this stores only the key id (which can be
+computed from the full key), and uses OTPs to decide whether a key is allowed to
+be used to validate a ROM_EXT.
+
+Accessed by:
+
+*   Mask ROM (to identify public key is Valid).
+*   ROM_EXT (to prevent use of public key).
+
+Needs to contain:
+
+*   Read-only list of public key ids.
+*   OTP fuses to say whether a key id is revoked or not (keys start not revoked).
+
+Stored In: OTP and ROM
+
+Extensibility: None. A ROM_EXT can disable the use of a key, but cannot add new
+valid root key IDs. There will be a fixed set of root key IDs as part of a given
+Mask ROM version.
+
 ### Boot Policy Structure
+
+This is the in-flash structure that defines which ROM_EXT should be booted next,
+whether it should fall back to the other ROM_EXT if it fails to boot, and/or
+whether it should be marked as the primary ROM_EXT if it succeeds to validate.
+
+This structure merely controls which ROM_EXT is validated and executed -- it
+does not contain any executable code. This means it does not need to be
+protected as securely as the ROM_EXT images, which contain code and are signed
+and validated before execution.
 
 Accessed by:
 
@@ -312,6 +508,9 @@ Extensibility: None. This info only controls the actions of the Mask ROM. You
 cannot add functionality to the Mask ROM of a given chip, so there's no way to
 add other information to this structure.
 
+The in-RAM representation also contains the boot reason (reset manager), because
+it needs to be checked most times the boot policy is also read.
+
 ### ROM_EXT Manifest Structure
 
 Accessed by:
@@ -335,6 +534,13 @@ Needs to contain:
     *   ROM_EXT PMP Region Information
         **Open Q:** Is this fixed or programmable? Field not needed if fixed.
 
+    *   Key Selection Area
+        *   Signature Algorithm Identifier
+            **Open Q:** Will the Mask ROM support more than one signature
+            scheme?
+
+        *   Public Key
+
     *   Software Binding Properties:
         *   ROM_EXT Version
             This is the version of the image contained in the ROM_EXT.
@@ -346,14 +552,17 @@ Needs to contain:
             (Interpretation governed by ROM_EXT/BL0 Version).
             **Open Q:** Does this satisfy the previous usecases?
 
-            This is likely to be a fixed number of `(pointer, checksum)` pairs,
-            where the pointer points to a structure somewhere within the ROM_EXT
+            This is likely to be a fixed number of `(offset, checksum)` pairs,
+            where the offset points to a structure somewhere within the ROM_EXT
             image. This should help us avoid running out of space, while also
             ensuring these structures do not become corrupted (note the image
             and the read-only extension area are also signed). This approach
             does allow the pointed-to structure to be variable-length, as it is
             down to the ROM_EXT/BL0 to interpret the data and validate the
             checksum.
+
+            **Open Q:** Should we require these offsets to be word- or
+            page-aligned?
 
             For a given ROM_EXT manifest version, the number of these slots
             cannot be changed, but different manifest versions can add to the


### PR DESCRIPTION
This change describes the two main Mask ROM structures, which are also used
as interfaces with other parts of the Secure Boot process.

These structures are the Boot Policy structure, and the ROM_EXT manifest
structure.

This change settles some open questions:
- How do we protect the Boot Policy structure: We'll use a checksum.
- Can the Boot Policy choose different actions upon failing to parse a
  ROM_EXT manifest vs upon failing to authenticate the signature? No,
  the boot policy chooses the same action in both eventualities. These
  actions are coarse: either try the next ROM_EXT, or fail to boot. What
  these actions require the code to do may change depending on which
  step failed.
- How do we end up versioning the ROM_EXT manifest: The versioning only
  changes how the BL0 area is parsed, the rest of the manifest has to
  be static as it is accessed by the Mask ROM (which cannot be updated).
  The BL0 area is still signed, but the OT Mask ROM makes no
  requirements on what information it includes. The ROM_EXT manifest
  version is outside the BL0 area as it is one of the software binding
  properties.

This change introduces two new Open Questions:
- Do we allow ROM_EXT manifests to choose their own entry point, or is
  the entry-point a hard-coded offset within the image?
- Do we allow ROM_EXT manifests to set their own PMP region extents, or
  are these extents hard-coded too?

---

This is based of a meeting I had with @gkelly this afternoon.