### PR TITLE
[aes/rtl] Add a delay to the manual start trigger signal for SCA

### DIFF
--- a/hw/ip/aes/rtl/aes.sv
+++ b/hw/ip/aes/rtl/aes.sv
@@ -7,12 +7,18 @@
 `include "prim_assert.sv"
 
 module aes import aes_pkg::*; #(
-  parameter bit     AES192Enable = 1, // Can be 0 (disable), or 1 (enable).
-  parameter bit     Masking      = 0, // Can be 0 (no masking), or 1 (first-order masking) of the
-                                      // cipher core. Masking requires the use of a masked S-Box,
-                                      // see SBoxImpl parameter. Note: currently, constant masks
-                                      // are used, this is of course not secure.
-  parameter sbox_impl_e SBoxImpl = SBoxImplLut // See aes_pkg.sv
+  parameter bit          AES192Enable               = 1, // Can be 0 (disable), or 1 (enable).
+  parameter bit          Masking                    = 0, // Can be 0 (no masking), or
+                                                         // 1 (first-order masking) of the cipher
+                                                         // core. Masking requires the use of a
+                                                         // masked S-Box, see SBoxImpl parameter.
+                                                         // Note: currently, constant masks are
+                                                         // used, this is of course not secure.
+  parameter sbox_impl_e  SBoxImpl                   = SBoxImplLut, // See aes_pkg.sv
+  parameter int unsigned NumDelayCyclesStartTrigger = 0 // Manual start trigger delay, useful for
+                                                        // SCA measurements. A value of e.g. 40
+                                                        // allows the processor to go into sleep
+                                                        // before AES starts operation.
 ) (
   input                     clk_i,
   input                     rst_ni,
@@ -60,9 +66,10 @@ module aes import aes_pkg::*; #(
   );
 
   aes_core #(
-    .AES192Enable ( AES192Enable ),
-    .Masking      ( Masking      ),
-    .SBoxImpl     ( SBoxImpl     )
+    .AES192Enable               ( AES192Enable               ),
+    .Masking                    ( Masking                    ),
+    .SBoxImpl                   ( SBoxImpl                   ),
+    .NumDelayCyclesStartTrigger ( NumDelayCyclesStartTrigger )
   ) u_aes_core (
     .clk_i,
     .rst_ni,

--- a/hw/ip/aes/rtl/aes_core.sv
+++ b/hw/ip/aes/rtl/aes_core.sv
@@ -8,11 +8,12 @@
 
 module aes_core import aes_pkg::*;
 #(
-  parameter bit     AES192Enable = 1,
-  parameter bit     Masking      = 0,
-  parameter sbox_impl_e SBoxImpl = SBoxImplLut,
+  parameter bit          AES192Enable               = 1,
+  parameter bit          Masking                    = 0,
+  parameter sbox_impl_e  SBoxImpl                   = SBoxImplLut,
+  parameter int unsigned NumDelayCyclesStartTrigger = 0,
 
-  localparam int    NumShares    = Masking ? 2 : 1 // derived parameter
+  localparam int         NumShares                  = Masking ? 2 : 1 // derived parameter
 ) (
   input  logic                     clk_i,
   input  logic                     rst_ni,
@@ -399,7 +400,9 @@ module aes_core import aes_pkg::*;
   /////////////
 
   // Control
-  aes_control u_aes_control (
+  aes_control #(
+    .NumDelayCyclesStartTrigger ( NumDelayCyclesStartTrigger )
+  ) u_aes_control (
     .clk_i                   ( clk_i                            ),
     .rst_ni                  ( rst_ni                           ),
 


### PR DESCRIPTION
This PR contains a commit to add a delay to the manual start trigger signal. ~The delay can be changed by adjusting the parameter `NumDelayCycles` inside `aes_control.sv`.~ The delay can be changed by adjusting the top-level parameter `NumDelayCyclesStartTrigger`.

~This is not meant to be merged but we need to reduce the noise in the SCA setup~. Having this delay allows Ibex to go into sleep before AES starts to operate. This helps to reduce noise in the SCA setup.