### PR TITLE
Revert "[dvsim] Print a more helpful path to coverage dashboard"

### DIFF
--- a/hw/dv/data/dsim/dsim.hjson
+++ b/hw/dv/data/dsim/dsim.hjson
@@ -64,7 +64,7 @@
   cov_report_opts:  [
                     ]
   cov_report_txt:   "{cov_report_dir}/dashboard.txt"
-  cov_report_page:  "{cov_report_dir}/dashboard.html"
+  cov_report_page:  "cov_report/dashboard.html"
 
   // Analyzing coverage - this is done by invoking --cov-analyze switch. It opens up the
   // GUI for visual analysis.

--- a/hw/dv/data/vcs/vcs.hjson
+++ b/hw/dv/data/vcs/vcs.hjson
@@ -92,7 +92,7 @@
                         "-elfile {vcs_cov_excl_files}",
                         "-report {cov_report_dir}"]
   cov_report_txt:       "{cov_report_dir}/dashboard.txt"
-  cov_report_page:      "{cov_report_dir}/dashboard.html"
+  cov_report_page:      "cov_report/dashboard.html"
 
   // Analyzing coverage - this is done by invoking --cov-analyze switch. It opens up the
   // GUI for visual analysis.

--- a/hw/dv/data/xcelium/xcelium.hjson
+++ b/hw/dv/data/xcelium/xcelium.hjson
@@ -82,7 +82,7 @@
                      "-licqueue",
                      "-exec {tool_srcs_dir}/cov_report.tcl"]
   cov_report_txt:   "{cov_report_dir}/cov_report.txt"
-  cov_report_page:  "{cov_report_dir}/index.html"
+  cov_report_page:  "cov_report/index.html"
 
   // Analyzing coverage - this is done by invoking --cov-analyze switch. It opens up the
   // GUI for visual analysis.


### PR DESCRIPTION
Reverts lowRISC/opentitan#2934

The `cov_report_page` is used to link the webpage in the reports.opentitan.org area. This PR ended up breaking it: 
https://reports.opentitan.org/hw/ip/flash_ctrl/dv/latest/results.html

In the above report page, the link to Coverage Dashboard is broken (and likewise in all other reports).

Signed-off-by: Srikrishna Iyer <sriyer@google.com>                                                  