### PR TITLE
[dv/shadow_reg] shadow_reg update error

### DIFF
--- a/hw/dv/data/tests/shadow_reg_errors_tests.hjson
+++ b/hw/dv/data/tests/shadow_reg_errors_tests.hjson
@@ -1,0 +1,28 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  run_modes: [
+    {
+      name: csr_tests_mode
+      uvm_test_seq: "{name}_common_vseq"
+      run_opts: ["+en_scb=0"]
+    }
+  ]
+
+  tests: [
+    {
+      // this hjson should be imported by all IPs containing shadowed CSRs
+      name: "{name}_shadow_reg_errors"
+      run_opts: ["+run_shadow_reg_errors"]
+      en_run_modes: ["csr_tests_mode"]
+    }
+  ]
+
+  regressions: [
+    {
+      name: sw_access
+      tests: ["{name}_shadow_reg_errors"]
+    }
+  ]
+}

--- a/hw/dv/tools/testplans/shadow_reg_errors_testplan.hjson
+++ b/hw/dv/tools/testplans/shadow_reg_errors_testplan.hjson
@@ -1,0 +1,31 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  entries: [
+    {
+      // this testplan should be imported by all IPs containing shadowed CSRs
+      name: shadow_reg_errors
+      desc: '''
+            Verify shadow registers' update and storage errors.
+            - Issue reset at random to clear all the internal stored values and phases trackers
+              in shadow registers.
+            - Select all the shadow registers and a random amount of the rest of the non-excluded
+              registers. Shuffle and write random values to the selected registers.
+              For shadow registers, the second write is not enabled.
+              There is a 50% possibility that the shadow register's write value is identical to its
+              previous write value.
+              If shadow register's second write value does not match the first write value,
+              ensure that the update error alert is triggered.
+            - Randomly inject storage errors by modifying the shadow register's staged or committed
+              values via backdoor method. Ensure that the storage error alert is triggered.
+            - Randomly decide to read all the non-excluded registers or fields. Then check the read
+              values against predicted values.
+              A read on a shadow register will clear its phase tracker.
+            - Repeat the above steps a bunch of times.
+            '''
+      milestone: V1
+      tests: ["{name}_shadow_reg_errors"]
+    }
+  ]
+}

--- a/hw/ip/aes/data/aes_testplan.hjson
+++ b/hw/ip/aes/data/aes_testplan.hjson
@@ -4,6 +4,7 @@
 {
   name: "aes"
   import_testplans: ["hw/dv/tools/testplans/csr_testplan.hjson",
+                     "hw/dv/tools/testplans/shadow_reg_errors_testplan.hjson",
                      "hw/dv/tools/testplans/tl_device_access_types_testplan.hjson"]
   entries: [
    // {

--- a/hw/ip/aes/dv/aes_sim_cfg.hjson
+++ b/hw/ip/aes/dv/aes_sim_cfg.hjson
@@ -30,6 +30,7 @@
                 "{proj_root}/hw/ip/aes/model/aes_model_sim_opts.hjson",
                 // Common CIP test lists
                 "{proj_root}/hw/dv/data/tests/csr_tests.hjson",
+                "{proj_root}/hw/dv/data/tests/shadow_reg_errors_tests.hjson",
                 "{proj_root}/hw/dv/data/tests/tl_access_tests.hjson"]
                 // TODO: enable stress tests later.
                 // "{proj_root}/hw/dv/data/tests/stress_tests.hjson"]

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -4,6 +4,7 @@
 {
   name: "chip"
   import_testplans: ["hw/dv/tools/testplans/csr_testplan.hjson",
+                     "hw/dv/tools/testplans/shadow_reg_errors_testplan.hjson",
                      "hw/dv/tools/testplans/mem_testplan.hjson",
                      "hw/dv/tools/testplans/tl_device_access_types_testplan.hjson",
                      "hw/ip/tlul/data/tlul_testplan.hjson"]

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -32,6 +32,7 @@
                 "{proj_root}/hw/dv/data/common_sim_cfg.hjson",
                 // Common CIP test lists
                 "{proj_root}/hw/dv/data/tests/csr_tests.hjson",
+                "{proj_root}/hw/dv/data/tests/shadow_reg_errors_tests.hjson",
                 "{proj_root}/hw/dv/data/tests/mem_tests.hjson",
                 "{proj_root}/hw/dv/data/tests/tl_access_tests.hjson",
                 // xbar tests


### PR DESCRIPTION
This is the first PR that create a sequence to run shadow_reg error
test. This test currently will
1. write registers and randomly create
update error by writing a different value during the second write.
2. randomly read registers and check against the predicted values. If
reading a shadow register, its phase tracker will be cleared.
3. randomly insert RESET before write registers to check if reset will
clear the internal stored values for shadow reg.

Following PRs will finish the rest of the TODOS:
1. check alerts after storage or update errors.
2. backdoor write and create storage error cases.

Signed-off-by: Cindy Chen <chencindy@google.com>