### PR TITLE
[aes] Clear all reg status trackers on writes to control reg

### DIFF
--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -151,6 +151,9 @@
       AES unit is non-idle, writes to this register are ignored.
       This register is shadowed, meaning two subsequent write operations are required to change its content.
       If the two write operations try to set a different value, a ctrl_err alert is triggered.
+      Any write operation to this register will clear the status tracking required for automatic mode (See MANUAL_OPERATION field).
+      A write to the Control Register is considered the start of a new message.
+      Hence, software needs to provide new key, IV and input data afterwards.
     '''
     swaccess: "rw",
     hwaccess: "hrw",
@@ -236,6 +239,7 @@
           Controls whether the AES unit is operated in normal/automatic mode (0) or fully manual mode (1).
           In automatic mode (0), the AES unit automatically i) starts to encrypt/decrypt when it receives new input data, and ii) stalls during the last encryption/decryption cycle if the previous output data has not yet been read.
           This is the most efficient mode to operate in.
+          Note that the corresponding status tracking is automatically cleared upon a write to the Control Register.
           In manual mode (1), the AES unit i) only starts to encrypt/decrypt after receiving a start trigger (see Trigger Register), and ii) overwrites previous output data irrespective of whether it has been read out or not.
           This mode is useful if software needs full control over the AES unit.
         '''

--- a/hw/ip/aes/doc/_index.md
+++ b/hw/ip/aes/doc/_index.md
@@ -138,7 +138,9 @@ The following description explains how the AES unit operates, i.e., how the oper
 Phrases in italics apply to peculiarities of different block cipher modes.
 For a general introduction into these cipher modes, refer to [Recommendation for Block Cipher Modes of Operation](https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38a.pdf).
 
-1. The initial key and configuration is provided to the AES unit via a set of control and status registers (CSRs) accessible by the processor via TL-UL bus interface.
+1. The configuration and initial key is provided to the AES unit via a set of control and status registers (CSRs) accessible by the processor via TL-UL bus interface.
+   The processor must first provide the configuration to the {{< regref "CTRL_SHADOWED" >}} register.
+   Then follows the initial key.
    Each key register must be written at least once.
    The order in which the registers are written does not matter.
 1. _The processor provides the initialization vector (IV) or initial counter value to the four IV registers via TL-UL bus interface in CBC or CTR mode, respectively.

--- a/hw/ip/aes/rtl/aes_core.sv
+++ b/hw/ip/aes/rtl/aes_core.sv
@@ -321,7 +321,6 @@ module aes_core #(
       reg2hw.ctrl_shadowed.key_len.re & reg2hw.ctrl_shadowed.manual_operation.re;
   assign ctrl_qe = reg2hw.ctrl_shadowed.operation.qe & reg2hw.ctrl_shadowed.mode.qe &
       reg2hw.ctrl_shadowed.key_len.qe & reg2hw.ctrl_shadowed.manual_operation.qe;
-  assign ctrl_we = ctrl_qe & hw2reg.status.idle.d;
 
   // Shadowed register primitve
   prim_subreg_shadow #(
@@ -360,11 +359,13 @@ module aes_core #(
     .clk_i                   ( clk_i                            ),
     .rst_ni                  ( rst_ni                           ),
 
+    .ctrl_qe_i               ( ctrl_qe                          ),
+    .ctrl_we_o               ( ctrl_we                          ),
+    .ctrl_err_i              ( ctrl_err_storage                 ),
     .op_i                    ( aes_op_q                         ),
     .mode_i                  ( aes_mode_q                       ),
     .cipher_op_i             ( cipher_op                        ),
     .manual_operation_i      ( manual_operation_q               ),
-    .ctrl_err_i              ( ctrl_err_storage                 ),
     .start_i                 ( reg2hw.trigger.start.q           ),
     .key_clear_i             ( reg2hw.trigger.key_clear.q       ),
     .iv_clear_i              ( reg2hw.trigger.iv_clear.q        ),

--- a/sw/device/tests/aes_test.c
+++ b/sw/device/tests/aes_test.c
@@ -41,11 +41,10 @@ bool test_main(void) {
       .mode = kAesEcb, .key_len = kAes256, .manual_operation = false,
   };
 
-  aes_key_put(key_32_1, aes_cfg.key_len);
-
   // Encode
   aes_cfg.operation = kAesEnc;
   aes_init(aes_cfg);
+  aes_key_put(key_32_1, aes_cfg.key_len);
   aes_data_put_wait(plain_text_1);
   aes_data_get_wait(buffer);
 
@@ -59,6 +58,7 @@ bool test_main(void) {
   // Decode
   aes_cfg.operation = kAesDec;
   aes_init(aes_cfg);
+  aes_key_put(key_32_1, aes_cfg.key_len);
   aes_data_put_wait(buffer);
   aes_data_get_wait(buffer);
 


### PR DESCRIPTION
With the commit contained in this PR, any write to the control register will clear the status tracking for the initial key, IV, data input and data output registers. As a result, software has to provide a fresh key, IV, input data whenever the control register is updated and the unit is operated in automatic mode. Without this commit and unless software initiated a clear of these registers with random data, it is possible to:
- re-use the key of a previous message,
- re-use the last content of the IV registers (can be the CTR value) of the previous message.
Note that the actual registers are not cleared upon a write to the control register. This clearing with random data should be initiated by software.

This is related to lowRISC/OpenTitan#2913.