### PR TITLE
[dvsim] Fix coverage dashboard link

### DIFF
--- a/hw/dv/data/dsim/dsim.hjson
+++ b/hw/dv/data/dsim/dsim.hjson
@@ -64,7 +64,7 @@
   cov_report_opts:  [
                     ]
   cov_report_txt:   "{cov_report_dir}/dashboard.txt"
-  cov_report_page:  "{cov_report_dir}/dashboard.html"
+  cov_report_page:  "dashboard.html"
 
   // Analyzing coverage - this is done by invoking --cov-analyze switch. It opens up the
   // GUI for visual analysis.

--- a/hw/dv/data/vcs/vcs.hjson
+++ b/hw/dv/data/vcs/vcs.hjson
@@ -92,7 +92,7 @@
                         "-elfile {vcs_cov_excl_files}",
                         "-report {cov_report_dir}"]
   cov_report_txt:       "{cov_report_dir}/dashboard.txt"
-  cov_report_page:      "{cov_report_dir}/dashboard.html"
+  cov_report_page:      "dashboard.html"
 
   // Analyzing coverage - this is done by invoking --cov-analyze switch. It opens up the
   // GUI for visual analysis.

--- a/hw/dv/data/xcelium/xcelium.hjson
+++ b/hw/dv/data/xcelium/xcelium.hjson
@@ -82,7 +82,7 @@
                      "-licqueue",
                      "-exec {tool_srcs_dir}/cov_report.tcl"]
   cov_report_txt:   "{cov_report_dir}/cov_report.txt"
-  cov_report_page:  "{cov_report_dir}/index.html"
+  cov_report_page:  "index.html"
 
   // Analyzing coverage - this is done by invoking --cov-analyze switch. It opens up the
   // GUI for visual analysis.

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -608,7 +608,12 @@ class SimCfg(FlowCfg):
                     # Link the dashboard page using "cov_report_page" value.
                     if hasattr(self, "cov_report_page"):
                         results_str += "\n### [Coverage Dashboard]"
-                        results_str += "({})\n\n".format(self.cov_report_page)
+                        if self.args.publish:
+                            cov_report_page_path = "cov_report"
+                        else:
+                            cov_report_page_path = self.cov_report_dir
+                        cov_report_page_path += "/" + self.cov_report_page
+                        results_str += "({})\n\n".format(cov_report_page_path)
                     results_str += self.cov_report_deploy.cov_results
                     self.results_summary[
                         "Coverage"] = self.cov_report_deploy.cov_total
@@ -670,7 +675,7 @@ class SimCfg(FlowCfg):
             log.info("Publishing coverage results to %s",
                      results_server_dir_url)
             cmd = (self.results_server_cmd + " -m cp -R " +
-                   self.cov_report_deploy.cov_report_dir + " " + self.results_server_dir)
+                   self.cov_report_dir + " " + self.results_server_dir)
             try:
                 cmd_output = subprocess.run(args=cmd,
                                             shell=True,


### PR DESCRIPTION
PR #2934 introduced a bug causing coverage report page link in the
reports.opentitan.org area to be broken.
This PR fixes that, while also preserving the intent of #2934.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>