### PR TITLE
Lint cleanup

### DIFF
--- a/hw/dv/sv/common_ifs/clk_rst_if.sv
+++ b/hw/dv/sv/common_ifs/clk_rst_if.sv
@@ -185,7 +185,7 @@ interface clk_rst_if #(
   // 2 - async assert, async dessert
   // 3 - clk gated when reset asserted
   // Note: for power on reset, please ensure pre_reset_dly_clks is set to 0
-  // TODO #2338 issue workaround - $urandom call moved from default argument value to function body 
+  // TODO #2338 issue workaround - $urandom call moved from default argument value to function body
   task automatic apply_reset(int pre_reset_dly_clks   = 0,
                              integer reset_width_clks = 'x,
                              int post_reset_dly_clks  = 0,
@@ -213,6 +213,13 @@ interface clk_rst_if #(
         dly_ps = $urandom_range(0, clk_period_ps);
         #(dly_ps * 1ps);
         o_rst_n <= 1'b1;
+      end
+      default: begin
+`ifdef VERILATOR
+        $error({msg_id, $sformatf("rst_n_scheme %0d not supported", rst_n_scheme)});
+`else
+        `uvm_fatal(msg_id, $sformatf("rst_n_scheme %0d not supported", rst_n_scheme))
+`endif
       end
     endcase
     wait_clks(post_reset_dly_clks);

--- a/hw/dv/sv/csr_utils/csr_utils_pkg.sv
+++ b/hw/dv/sv/csr_utils/csr_utils_pkg.sv
@@ -27,7 +27,7 @@ package csr_utils_pkg;
     uvm_reg_field   field;
     uvm_reg_data_t  mask;
     uint            shift;
-  } csr_field_s;
+  } csr_field_t;
 
   function automatic void increment_outstanding_access();
     outstanding_accesses++;
@@ -119,11 +119,11 @@ package csr_utils_pkg;
   endfunction : get_reg_fld_mirror_value
 
   // This function attempts to cast a given uvm_object ptr into uvm_reg or uvm_reg_field. If cast
-  // is successful on either, then set the appropriate csr_field_s return values.
-  function automatic csr_field_s decode_csr_or_field(input uvm_object ptr);
+  // is successful on either, then set the appropriate csr_field_t return values.
+  function automatic csr_field_t decode_csr_or_field(input uvm_object ptr);
     uvm_reg       csr;
     uvm_reg_field fld;
-    csr_field_s   result;
+    csr_field_t   result;
     string        msg_id = {csr_utils_pkg::msg_id, "::decode_csr_or_field"};
 
     if ($cast(csr, ptr)) begin
@@ -367,7 +367,7 @@ package csr_utils_pkg;
                             input  uvm_reg_map    map = null);
     fork
       begin : isolation_fork
-        csr_field_s   csr_or_fld;
+        csr_field_t   csr_or_fld;
         uvm_status_e  status;
         string        msg_id = {csr_utils_pkg::msg_id, "::csr_rd"};
 
@@ -404,7 +404,7 @@ package csr_utils_pkg;
                           output uvm_reg_data_t value,
                           input uvm_check_e     check = UVM_CHECK);
     string      msg_id = {csr_utils_pkg::msg_id, "::csr_peek"};
-    csr_field_s csr_or_fld = decode_csr_or_field(ptr);
+    csr_field_t csr_or_fld = decode_csr_or_field(ptr);
     uvm_reg     csr = csr_or_fld.csr;
 
     if (csr.has_hdl_path()) begin
@@ -444,7 +444,7 @@ package csr_utils_pkg;
       begin : isolation_fork
         fork
           begin
-            csr_field_s     csr_or_fld;
+            csr_field_t     csr_or_fld;
             uvm_status_e    status;
             uvm_reg_data_t  obs;
             uvm_reg_data_t  exp;
@@ -498,7 +498,7 @@ package csr_utils_pkg;
                               input uvm_verbosity   verbosity = UVM_HIGH);
     fork
       begin : isolation_fork
-        csr_field_s     csr_or_fld;
+        csr_field_t     csr_or_fld;
         uvm_reg_data_t  read_data;
         string          msg_id = {csr_utils_pkg::msg_id, "::csr_spinwait"};
 
@@ -643,7 +643,7 @@ package csr_utils_pkg;
     get_mask_excl_fields = '1;
     foreach (flds[i]) begin
       if (m_csr_excl_item.is_excl(flds[i], csr_excl_type, csr_test_type)) begin
-        csr_field_s fld_params = decode_csr_or_field(flds[i]);
+        csr_field_t fld_params = decode_csr_or_field(flds[i]);
         `uvm_info(msg_id, $sformatf("Skipping field %0s due to %0s exclusion",
                                   flds[i].get_full_name(), csr_excl_type.name()), UVM_MEDIUM)
         get_mask_excl_fields &= ~(fld_params.mask << fld_params.shift);

--- a/hw/dv/sv/uart_agent/uart_agent_pkg.sv
+++ b/hw/dv/sv/uart_agent/uart_agent_pkg.sv
@@ -45,6 +45,7 @@ package uart_agent_pkg;
       BaudRate230400: return 4340.278;
       BaudRate1Mbps : return 953.674;
       BaudRate2Mbps : return 476.837;
+      default: `uvm_fatal("uart_agent_pkg", {"Unsupported baud_rate: ", baud_rate.name})
     endcase
   endfunction
 

--- a/hw/ip/entropy_src/dv/tb/tb.sv
+++ b/hw/ip/entropy_src/dv/tb/tb.sv
@@ -38,7 +38,7 @@ module tb;
     .tl_o                 (tl_if.d2h  ),
 
     .efuse_es_sw_reg_en_i (efuse_es_sw_reg_en),
-  
+
     .entropy_src_hw_if_o  (),
     .entropy_src_hw_if_i  (),
 

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
@@ -213,7 +213,7 @@ class spi_device_base_vseq extends cip_base_vseq #(
   // write spi device data to send when incoming host traffic arrives
   virtual task write_device_words_to_send(bit [31:0] device_data[$]);
     bit [TL_DW-1:0] tx_wptr;
-    uint tx_sram_size_bytes = `get_tx_allocated_sram_size_bytes;
+    uint tx_sram_size_bytes = `GET_TX_ALLOCATED_SRAM_SIZE_BYTES;
 
     // write data to tx base address + curr tx wptr
     tx_wptr = ral.txf_ptr.wptr.get_mirrored_value();
@@ -243,7 +243,7 @@ class spi_device_base_vseq extends cip_base_vseq #(
   // read spi host data received from the host
   virtual task read_host_words_rcvd(uint num_words, ref bit [31:0] host_data[$]);
     bit [TL_DW-1:0] rx_rptr;
-    uint rx_sram_size_bytes = `get_rx_allocated_sram_size_bytes;
+    uint rx_sram_size_bytes = `GET_RX_ALLOCATED_SRAM_SIZE_BYTES;
 
     // read data from rx base address + curr rptr
     rx_rptr = ral.rxf_ptr.rptr.get_mirrored_value();
@@ -273,7 +273,7 @@ class spi_device_base_vseq extends cip_base_vseq #(
   virtual task read_tx_avail_bytes(sram_avail_type_e avail_type, ref uint avail_bytes);
     bit [TL_DW-1:0] rptr;
     bit [TL_DW-1:0] wptr;
-    uint            sram_size_bytes = `get_tx_allocated_sram_size_bytes;
+    uint            sram_size_bytes = `GET_TX_ALLOCATED_SRAM_SIZE_BYTES;
 
     csr_rd(.ptr(ral.txf_ptr.rptr), .value(rptr));
     wptr = ral.txf_ptr.wptr.get_mirrored_value();
@@ -298,7 +298,7 @@ class spi_device_base_vseq extends cip_base_vseq #(
   virtual task read_rx_avail_bytes(sram_avail_type_e avail_type, ref uint avail_bytes);
     bit [TL_DW-1:0] rptr;
     bit [TL_DW-1:0] wptr;
-    uint            sram_size_bytes = `get_rx_allocated_sram_size_bytes;
+    uint            sram_size_bytes = `GET_RX_ALLOCATED_SRAM_SIZE_BYTES;
 
     csr_rd(.ptr(ral.rxf_ptr.wptr), .value(wptr));
     rptr = ral.rxf_ptr.rptr.get_mirrored_value();

--- a/hw/ip/spi_device/dv/env/spi_device_env_pkg.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env_pkg.sv
@@ -99,11 +99,11 @@ package spi_device_env_pkg;
   endfunction
 
   // macros
-  `define get_tx_allocated_sram_size_bytes \
+  `define GET_TX_ALLOCATED_SRAM_SIZE_BYTES \
     get_allocated_sram_size_bytes(ral.txf_addr.base.get_mirrored_value(), \
                                   ral.txf_addr.limit.get_mirrored_value())
 
-  `define get_rx_allocated_sram_size_bytes \
+  `define GET_RX_ALLOCATED_SRAM_SIZE_BYTES \
     get_allocated_sram_size_bytes(ral.rxf_addr.base.get_mirrored_value(), \
                                   ral.rxf_addr.limit.get_mirrored_value())
 
@@ -115,6 +115,6 @@ package spi_device_env_pkg;
   `include "spi_device_env.sv"
   `include "spi_device_vseq_list.sv"
 
-  `undef get_tx_allocated_sram_size_bytes
-  `undef get_rx_allocated_sram_size_bytes
+  `undef GET_TX_ALLOCATED_SRAM_SIZE_BYTES
+  `undef GET_RX_ALLOCATED_SRAM_SIZE_BYTES
 endpackage

--- a/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
@@ -156,7 +156,7 @@ class spi_device_scoreboard extends cip_base_scoreboard #(.CFG_T (spi_device_env
                                tx_rptr_exp, tx_mem.read(tx_rptr_exp[SRAM_MSB:0])), UVM_MEDIUM)
       tx_rptr_exp = get_sram_new_ptr(.ptr(tx_rptr_exp),
                                      .increment(SRAM_WORD_SIZE),
-                                     .sram_size_bytes(`get_tx_allocated_sram_size_bytes));
+                                     .sram_size_bytes(`GET_TX_ALLOCATED_SRAM_SIZE_BYTES));
       filled_bytes -= SRAM_WORD_SIZE;
     end
   endfunction
@@ -198,7 +198,7 @@ class spi_device_scoreboard extends cip_base_scoreboard #(.CFG_T (spi_device_env
                                 rx_wptr_exp, data), UVM_MEDIUM)
       rx_wptr_exp = get_sram_new_ptr(.ptr(rx_wptr_exp),
                                      .increment(SRAM_WORD_SIZE),
-                                     .sram_size_bytes(`get_rx_allocated_sram_size_bytes));
+                                     .sram_size_bytes(`GET_RX_ALLOCATED_SRAM_SIZE_BYTES));
       space_bytes -= SRAM_WORD_SIZE;
     end
   endfunction
@@ -207,7 +207,7 @@ class spi_device_scoreboard extends cip_base_scoreboard #(.CFG_T (spi_device_env
     uint tx_wptr      = ral.txf_ptr.wptr.get_mirrored_value();
     uint filled_bytes = get_sram_filled_bytes(tx_wptr,
                                               tx_rptr_exp,
-                                              `get_tx_allocated_sram_size_bytes,
+                                              `GET_TX_ALLOCATED_SRAM_SIZE_BYTES,
                                               {`gfn, "::get_tx_sram_filled_bytes"});
     return filled_bytes;
   endfunction
@@ -216,7 +216,7 @@ class spi_device_scoreboard extends cip_base_scoreboard #(.CFG_T (spi_device_env
     uint rx_rptr     = ral.rxf_ptr.rptr.get_mirrored_value();
     uint space_bytes = get_sram_space_bytes(rx_wptr_exp,
                                             rx_rptr,
-                                            `get_rx_allocated_sram_size_bytes,
+                                            `GET_RX_ALLOCATED_SRAM_SIZE_BYTES,
                                             {`gfn, "::get_rx_sram_space_bytes"});
     return space_bytes;
   endfunction

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -23,7 +23,7 @@ package chip_env_pkg;
   `include "dv_macros.svh"
 
   // local parameters and types
-  parameter NUM_GPIOS = 16;
+  parameter uint NUM_GPIOS = 16;
 
   // SW constants
   parameter bit [TL_AW-1:0] SW_DV_LOG_ADDR = 32'h1000fffc;

--- a/util/reggen/uvm_reg.sv.tpl
+++ b/util/reggen/uvm_reg.sv.tpl
@@ -272,4 +272,8 @@ package ${block.name}_ral_pkg;
 
 endpackage\
 </%def>\
+
+// verilog_lint: waive-start package-filename
 ${construct_classes(block)}
+
+// verilog_lint: waive-stop package-filename


### PR DESCRIPTION
Lint errors were reported in the DV code thanks to @msfschaffner's work in #3005. 

Some of the cleanup done are as follows:
- removed trailing white spaces
- capitalized macro names (wherever possible)
- added default case to case statements
- updated struct typedefs to have _t suffix 
- parameters must have a type specifier
- Package name must reflect file name (waived in autogenerated RAL)