### PR TITLE
[dv/alert_handler] add exclusions for top_level alert

### DIFF
--- a/hw/ip/alert_handler/data/alert_handler.hjson.tpl
+++ b/hw/ip/alert_handler/data/alert_handler.hjson.tpl
@@ -197,7 +197,10 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
       hwaccess: "hrw",
       fields: [
         { bits: "0", name: "A", desc: "Cause bit " }
-      ]
+      ],
+      tags: [// the value of this register is determined by triggering different kinds of alerts
+             // cannot be auto-predicted so excluded from read check
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
       }
     },
 ##############################################################################
@@ -369,7 +372,10 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
       hwext:    "true",
       fields: [
         { bits: "${accu_cnt_dw - 1}:0" }
-      ]
+      ],
+      tags: [// this value of this register is determined by how many alerts have been triggered
+             // could not be auto-predicted so it is excluded from read check
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
     { name:     "CLASS${chars[i]}_ACCUM_THRESH",
       desc:     '''
@@ -441,7 +447,10 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
           is set to false (either by SW or by HW via the !!CLASS${chars[i]}_CTRL.LOCK feature).
           '''
         }
-      ]
+      ],
+      tags: [// the value of this register is determined by counting how many cycles the escalation
+             // phase has lasted. This can not be auto-predicted so excluded from read check
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
     { name:     "CLASS${chars[i]}_STATE",
       desc:     '''
@@ -462,7 +471,10 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
                   { value: "0b111", name: "Phase3",   desc: "Escalation Phase3 is active." }
                 ]
         }
-      ]
+      ],
+      tags: [// the current escalation state cannot be auto-predicted
+             // so this register is excluded from read check
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
 % endfor
   ],

--- a/hw/top_earlgrey/ip/alert_handler/data/autogen/alert_handler.hjson
+++ b/hw/top_earlgrey/ip/alert_handler/data/autogen/alert_handler.hjson
@@ -4,7 +4,7 @@
 //
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
-// util/topgen.py -t hw/top_earlgrey/doc/top_earlgrey.hjson --alert-handler-only -o hw/top_earlgrey/
+// util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson --alert-handler-only -o hw/top_earlgrey/
 
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
@@ -212,7 +212,10 @@
       hwaccess: "hrw",
       fields: [
         { bits: "0", name: "A", desc: "Cause bit " }
-      ]
+      ],
+      tags: [// the value of this register is determined by triggering different kinds of alerts
+             // cannot be auto-predicted so excluded from read check
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
       }
     },
 # local alerts
@@ -382,7 +385,10 @@
       hwext:    "true",
       fields: [
         { bits: "15:0" }
-      ]
+      ],
+      tags: [// this value of this register is determined by how many alerts have been triggered
+             // could not be auto-predicted so it is excluded from read check
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
     { name:     "CLASSA_ACCUM_THRESH",
       desc:     '''
@@ -494,7 +500,10 @@
           is set to false (either by SW or by HW via the !!CLASSA_CTRL.LOCK feature).
           '''
         }
-      ]
+      ],
+      tags: [// the value of this register is determined by counting how many cycles the escalation
+             // phase has lasted. This can not be auto-predicted so excluded from read check
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
     { name:     "CLASSA_STATE",
       desc:     '''
@@ -515,7 +524,10 @@
                   { value: "0b111", name: "Phase3",   desc: "Escalation Phase3 is active." }
                 ]
         }
-      ]
+      ],
+      tags: [// the current escalation state cannot be auto-predicted
+             // so this register is excluded from read check
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
 
     { name:     "CLASSB_CTRL",
@@ -626,7 +638,10 @@
       hwext:    "true",
       fields: [
         { bits: "15:0" }
-      ]
+      ],
+      tags: [// this value of this register is determined by how many alerts have been triggered
+             // could not be auto-predicted so it is excluded from read check
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
     { name:     "CLASSB_ACCUM_THRESH",
       desc:     '''
@@ -738,7 +753,10 @@
           is set to false (either by SW or by HW via the !!CLASSB_CTRL.LOCK feature).
           '''
         }
-      ]
+      ],
+      tags: [// the value of this register is determined by counting how many cycles the escalation
+             // phase has lasted. This can not be auto-predicted so excluded from read check
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
     { name:     "CLASSB_STATE",
       desc:     '''
@@ -759,7 +777,10 @@
                   { value: "0b111", name: "Phase3",   desc: "Escalation Phase3 is active." }
                 ]
         }
-      ]
+      ],
+      tags: [// the current escalation state cannot be auto-predicted
+             // so this register is excluded from read check
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
 
     { name:     "CLASSC_CTRL",
@@ -870,7 +891,10 @@
       hwext:    "true",
       fields: [
         { bits: "15:0" }
-      ]
+      ],
+      tags: [// this value of this register is determined by how many alerts have been triggered
+             // could not be auto-predicted so it is excluded from read check
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
     { name:     "CLASSC_ACCUM_THRESH",
       desc:     '''
@@ -982,7 +1006,10 @@
           is set to false (either by SW or by HW via the !!CLASSC_CTRL.LOCK feature).
           '''
         }
-      ]
+      ],
+      tags: [// the value of this register is determined by counting how many cycles the escalation
+             // phase has lasted. This can not be auto-predicted so excluded from read check
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
     { name:     "CLASSC_STATE",
       desc:     '''
@@ -1003,7 +1030,10 @@
                   { value: "0b111", name: "Phase3",   desc: "Escalation Phase3 is active." }
                 ]
         }
-      ]
+      ],
+      tags: [// the current escalation state cannot be auto-predicted
+             // so this register is excluded from read check
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
 
     { name:     "CLASSD_CTRL",
@@ -1114,7 +1144,10 @@
       hwext:    "true",
       fields: [
         { bits: "15:0" }
-      ]
+      ],
+      tags: [// this value of this register is determined by how many alerts have been triggered
+             // could not be auto-predicted so it is excluded from read check
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
     { name:     "CLASSD_ACCUM_THRESH",
       desc:     '''
@@ -1226,7 +1259,10 @@
           is set to false (either by SW or by HW via the !!CLASSD_CTRL.LOCK feature).
           '''
         }
-      ]
+      ],
+      tags: [// the value of this register is determined by counting how many cycles the escalation
+             // phase has lasted. This can not be auto-predicted so excluded from read check
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
     { name:     "CLASSD_STATE",
       desc:     '''
@@ -1247,7 +1283,10 @@
                   { value: "0b111", name: "Phase3",   desc: "Escalation Phase3 is active." }
                 ]
         }
-      ]
+      ],
+      tags: [// the current escalation state cannot be auto-predicted
+             // so this register is excluded from read check
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
   ],
 }

--- a/hw/top_earlgrey/ip/alert_handler/dv/alert_handler_env_pkg__params.sv
+++ b/hw/top_earlgrey/ip/alert_handler/dv/alert_handler_env_pkg__params.sv
@@ -4,7 +4,7 @@
 //
 // ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
-// util/topgen.py -t hw/top_earlgrey/doc/top_earlgrey.hjson --alert-handler-only -o hw/top_earlgrey/
+// util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson --alert-handler-only -o hw/top_earlgrey/
 
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -178,7 +178,7 @@ def generate_alert_handler(top, out_path):
 
     hjson_gen_path = doc_path / "alert_handler.hjson"
     gencmd = (
-        "// util/topgen.py -t hw/top_{topname}/doc/top_{topname}.hjson --alert-handler-only "
+        "// util/topgen.py -t hw/top_{topname}/data/top_{topname}.hjson --alert-handler-only "
         "-o hw/top_{topname}/\n\n".format(topname=topname))
     with hjson_gen_path.open(mode='w', encoding='UTF-8') as fout:
         fout.write(genhdr + gencmd + out)


### PR DESCRIPTION
In PR #3017, the shadow register's update and storage errors will cause
alert to trigger. When alert triggered, some of the alert_handler's
registers need to be excluded. These registers included: alert_cause,
alert_state, alert_accum_cnt, esc_cnt.

This pr also fix a small typo in topgen: the path to top_earlgrey.hjson
should be in `hw/top_earlgrey/data` but not `hw/top_earlgrey/doc`.

Signed-off-by: Cindy Chen <chencindy@google.com>