### PR TITLE
[rtl/alert] change the naming from _en_i to _req_i

### DIFF
--- a/hw/ip/alert_handler/dv/tb/tb.sv
+++ b/hw/ip/alert_handler/dv/tb/tb.sv
@@ -55,7 +55,7 @@ module tb;
     assign esc_device_if[k].esc_tx.esc_p = esc_tx[k].esc_p;
     assign esc_device_if[k].esc_tx.esc_n = esc_tx[k].esc_n;
     // TODO: add assertions to check the probed signal
-    assign probe_if[k].esc_en = dut.esc_sig_en[k];
+    assign probe_if[k].esc_en = dut.esc_sig_req[k];
     initial begin
       uvm_config_db#(virtual alert_esc_if)::set(null, $sformatf("*.env.esc_device_agent[%0d]", k),
                                                 "vif", esc_device_if[k]);

--- a/hw/ip/alert_handler/rtl/alert_handler_esc_timer.sv
+++ b/hw/ip/alert_handler/rtl/alert_handler_esc_timer.sv
@@ -33,7 +33,7 @@ module alert_handler_esc_timer import alert_pkg::*; (
                [EscCntDw-1:0]  phase_cyc_i,    // cycle counts of individual phases
   output logic                 esc_trig_o,     // asserted if escalation triggers
   output logic [EscCntDw-1:0]  esc_cnt_o,      // current timeout / escalation count
-  output logic [N_ESC_SEV-1:0] esc_sig_en_o,   // escalation signal outputs
+  output logic [N_ESC_SEV-1:0] esc_sig_req_o,  // escalation signal outputs
   // current state output
   // 000: idle, 001: irq timeout counting 100: phase0, 101: phase1, 110: phase2, 111: phase3
   output cstate_e              esc_state_o
@@ -191,7 +191,7 @@ module alert_handler_esc_timer import alert_pkg::*; (
     // generate configuration mask for escalation enable signals
     assign esc_map_oh[k] = N_ESC_SEV'(esc_en_i[k]) << esc_map_i[k];
     // mask reduce current phase state vector
-    assign esc_sig_en_o[k] = |(esc_map_oh[k] & phase_oh);
+    assign esc_sig_req_o[k] = |(esc_map_oh[k] & phase_oh);
   end
 
   ///////////////

--- a/hw/ip/alert_handler/rtl/alert_handler_ping_timer.sv
+++ b/hw/ip/alert_handler/rtl/alert_handler_ping_timer.sv
@@ -36,8 +36,8 @@ module alert_handler_ping_timer import alert_pkg::*; #(
   input        [NAlerts-1:0]     alert_en_i,         // determines which alerts to ping
   input        [PING_CNT_DW-1:0] ping_timeout_cyc_i, // timeout in cycles
   input        [PING_CNT_DW-1:0] wait_cyc_mask_i,    // wait cycles mask
-  output logic [NAlerts-1:0]     alert_ping_en_o,    // enable to alert receivers
-  output logic [N_ESC_SEV-1:0]   esc_ping_en_o,      // enable to esc senders
+  output logic [NAlerts-1:0]     alert_ping_req_o,   // request to alert receivers
+  output logic [N_ESC_SEV-1:0]   esc_ping_req_o,     // enable to esc senders
   input        [NAlerts-1:0]     alert_ping_ok_i,    // response from alert receivers
   input        [N_ESC_SEV-1:0]   esc_ping_ok_i,      // response from esc senders
   output logic                   alert_ping_fail_o,  // any of the alert receivers failed
@@ -137,8 +137,8 @@ module alert_handler_ping_timer import alert_pkg::*; #(
 
   // generate ping enable vector
   assign ping_sel        = NModsToPing'(ping_en) << id_to_ping;
-  assign alert_ping_en_o = ping_sel[NAlerts-1:0];
-  assign esc_ping_en_o   = ping_sel[NModsToPing-1:NAlerts];
+  assign alert_ping_req_o = ping_sel[NAlerts-1:0];
+  assign esc_ping_req_o   = ping_sel[NModsToPing-1:NAlerts];
 
   // mask out response
   assign ping_ok             = |({esc_ping_ok_i, alert_ping_ok_i} & ping_sel);


### PR DESCRIPTION
This PR changes alert_handler related RTL files.
It changes variable namings in from `_en` to `_req` according to the suggestion from PR #2534

Signed-off-by: Cindy Chen <chencindy@google.com>