### PR TITLE
Miscellaneous OTBN linker fixes

### DIFF
--- a/hw/ip/otbn/data/otbn.ld.tpl
+++ b/hw/ip/otbn/data/otbn.ld.tpl
@@ -22,15 +22,15 @@ MEMORY
 
 SECTIONS
 {
-    .text ALIGN(4) :
+    .text ORIGIN(imem) : ALIGN(4)
     {
         *(.text*)
-    } >imem AT >imem_load
+    } >imem AT>imem_load
 
-    .data ALIGN(32) :
+    .data ORIGIN(dmem) : ALIGN(32)
     {
         *(.data*)
         . = ALIGN(32);
         *(.bss*)
-    } >dmem AT >dmem_load
+    } >dmem AT>dmem_load
 }

--- a/hw/ip/otbn/data/otbn.ld.tpl
+++ b/hw/ip/otbn/data/otbn.ld.tpl
@@ -25,6 +25,11 @@ SECTIONS
     .text ORIGIN(imem) : ALIGN(4)
     {
         *(.text*)
+
+        /* Align section end. Shouldn't really matter, but might make binary
+           blobs a bit easier to work with. */
+        . = ALIGN(4);
+
     } >imem AT>imem_load
 
     .data ORIGIN(dmem) : ALIGN(32)
@@ -32,5 +37,9 @@ SECTIONS
         *(.data*)
         . = ALIGN(32);
         *(.bss*)
+
+        /* Align section end (see note in .text section) */
+        . = ALIGN(4);
+
     } >dmem AT>dmem_load
 }

--- a/hw/ip/otbn/util/otbn-as
+++ b/hw/ip/otbn/util/otbn-as
@@ -1089,7 +1089,13 @@ def run_binutils_as(other_args: List[str], inputs: List[str]) -> int:
 
     '''
     assembler_name = 'riscv32-unknown-elf-as'
-    cmd = [assembler_name] + other_args + inputs
+
+    # Don't ask the linker to do relaxation because, in some cases, this might
+    # generate a GP-relative load. OTBN doesn't treat x3 (gp) specially, so
+    # this won't work.
+    default_args = ['-mno-relax']
+
+    cmd = [assembler_name] + default_args + other_args + inputs
     try:
         return subprocess.run(cmd).returncode
     except FileNotFoundError:


### PR DESCRIPTION
These commits:

  1. Generate data sections with the right VMA
  1. Align section ends to allow 32-bit loads from Ibex
  1. Disable linker relaxation (which assumes things about `x3` that aren't true for OTBN)