### PR TITLE
[aes:dv] added functionality to aes DV

### DIFF
--- a/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi.c
+++ b/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi.c
@@ -129,11 +129,7 @@ void c_dpi_aes_crypt_message(unsigned char impl_i, unsigned char op_i,
   const unsigned char op = op_i & op_mask;
   const crypto_mode_t mode = (crypto_mode_t)(*mode_i & mode_mask);
   if (mode == kCryptoAesNone) {
-    printf(
         "ERROR: Mode kCryptoAesNone not supported by c_dpi_aes_crypt_message");
-    return;
-  }
-
   // key_len_i is one-hot encoded.
   int key_len;
   if ((*key_len_i & key_len_mask) == 0x1) {

--- a/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi.c
+++ b/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi.c
@@ -129,7 +129,11 @@ void c_dpi_aes_crypt_message(unsigned char impl_i, unsigned char op_i,
   const unsigned char op = op_i & op_mask;
   const crypto_mode_t mode = (crypto_mode_t)(*mode_i & mode_mask);
   if (mode == kCryptoAesNone) {
+    printf(
         "ERROR: Mode kCryptoAesNone not supported by c_dpi_aes_crypt_message");
+    return;
+  }
+
   // key_len_i is one-hot encoded.
   int key_len;
   if ((*key_len_i & key_len_mask) == 0x1) {

--- a/hw/ip/aes/dv/env/aes_env_cfg.sv
+++ b/hw/ip/aes/dv/env/aes_env_cfg.sv
@@ -9,29 +9,44 @@ class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block));
 
   `uvm_object_new
 
+  // TODO sort knobs into test/SEQUENCE/message/item 
+    
   // Knobs //
-  int          num_messages_min   = 1;
-  int          num_messages_max   = 1;
-  int          message_len_min    = 128;
-  int          message_len_max    = 128;
-  bit          use_key_mask       = 0;
-  bit          use_c_model_pct    = 0;
-  bit          errors_en          = 0;
+  int          num_messages_min     = 1;
+  int          num_messages_max     = 1;
+  int          message_len_min      = 128;
+  int          message_len_max      = 128;
+  bit          use_key_mask         = 0;
+  bit          use_c_model_pct      = 0;
+  bit          errors_en            = 0;
   // Mode distribution //
   // chance of selection ecb_mode
   // ecb_mode /(ecb_mode + cbc_mode + ctr_mode)
   // with the defaults 10/30 = 1/3 (33%)
-  int          ecb_weight         = 10;
-  int          cbc_weight         = 10;
-  int          ctr_weight         = 10;
+  int          ecb_weight           = 10;
+  int          cbc_weight           = 10;
+  int          ctr_weight           = 10;
   // KEYLEN weights
   // change of selecting 128b key
   //  128b/(128+192+256) = 10/30 = (33%)
-  int          key_128b_weight    = 10;
-  int          key_192b_weight    = 10;
-  int          key_256b_weight    = 10;
+  int          key_128b_weight      = 10;
+  int          key_192b_weight      = 10;
+  int          key_256b_weight      = 10;
 
-  bit  [2:0]   error_types        = 3'b111;      //   001: configuration errors
+  int          manual_operation_pct = 10;
+
+  // debug / directed test knobs
+  // use fixed key
+  bit    fixed_key_en               = 0;
+  // use fixed data (same data for each block in a message
+  bit    fixed_data_en              = 0;
+  // fixed operation
+  bit    fixed_operation_en         = 0;
+  bit    fixed_operation            = 0;
+  bit    fixed_keylen_en            = 0;
+  bit [2:0] fixed_keylen            = 3'b001;
+  
+  bit  [2:0]   error_types          = 3'b111;      //   001: configuration errors
                                                  //   010: malicous injection
                                                  //   100: random resets
 
@@ -65,7 +80,8 @@ class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block));
     str = {str,  $sformatf("\n\t ----| num_messages # %d \t ", num_messages) };
     str = {str,  $sformatf("\n\t ----| ECB Weight: %d         \t ", ecb_weight) };
     str = {str,  $sformatf("\n\t ----| CBC Weight: %d         \t ", cbc_weight) };   
-    str = {str,  $sformatf("\n\t ----| CTR Weight: %d         \t ", ctr_weight) }; 
+    str = {str,  $sformatf("\n\t ----| CTR Weight: %d         \t ", ctr_weight) };
+    str = {str,  $sformatf("\n\t ----| key mask:   %b         \t ", key_mask)}; 
     str = {str, "\n"};
     return str;
   endfunction

--- a/hw/ip/aes/dv/env/aes_env_cfg.sv
+++ b/hw/ip/aes/dv/env/aes_env_cfg.sv
@@ -9,48 +9,63 @@ class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block));
 
   `uvm_object_new
 
-  // TODO sort knobs into test/SEQUENCE/message/item 
-    
-  // Knobs //
-  int          num_messages_min     = 1;
-  int          num_messages_max     = 1;
-  int          message_len_min      = 128;
-  int          message_len_max      = 128;
-  bit          use_key_mask         = 0;
-  bit          use_c_model_pct      = 0;
-  bit          errors_en            = 0;
+  // TODO sort knobs into test/SEQUENCE/message/item
+
+  // test environment constraints //
+
+
+    // PER Message Knobs //
+  int            num_messages_min            = 1;
+  int            num_messages_max            = 1;
+  int            message_len_min             = 128;
+  int            message_len_max             = 128;
+  bit            use_key_mask                = 0;
+  bit            use_c_model_pct             = 0;
+  bit            errors_en                   = 0;
+  // clear registers with 0's or rand
+  bit            clear_reg_w_rand            = 1;
+  // if set the order of which key iv and data is written will be randomized and interleaved
+  bit            random_data_key_iv_order    = 1;
+
   // Mode distribution //
   // chance of selection ecb_mode
-  // ecb_mode /(ecb_mode + cbc_mode + ctr_mode)
-  // with the defaults 10/30 = 1/3 (33%)
-  int          ecb_weight           = 10;
-  int          cbc_weight           = 10;
-  int          ctr_weight           = 10;
+  // ecb_mode /(ecb_mode + cbc_mode + ctr_mode + cfb_mode + ofb_mode)
+  // with the defaults 10/50 = 1/5 (20%)
+  int            ecb_weight                 = 10;
+  int            cbc_weight                 = 10;
+  int            ofb_weight                 = 10;
+  int            cfb_weight                 = 10;
+  int            ctr_weight                 = 10;
+
   // KEYLEN weights
   // change of selecting 128b key
   //  128b/(128+192+256) = 10/30 = (33%)
-  int          key_128b_weight      = 10;
-  int          key_192b_weight      = 10;
-  int          key_256b_weight      = 10;
+  int            key_128b_weight            = 10;
+  int            key_192b_weight            = 10;
+  int            key_256b_weight            = 10;
 
-  int          manual_operation_pct = 10;
+  // use manual operation mode percentage
+  int            manual_operation_pct       = 10;
 
   // debug / directed test knobs
   // use fixed key
-  bit    fixed_key_en               = 0;
+  bit            fixed_key_en               = 0;
   // use fixed data (same data for each block in a message
-  bit    fixed_data_en              = 0;
+  bit            fixed_data_en              = 0;
   // fixed operation
-  bit    fixed_operation_en         = 0;
-  bit    fixed_operation            = 0;
-  bit    fixed_keylen_en            = 0;
-  bit [2:0] fixed_keylen            = 3'b001;
-  
-  bit  [2:0]   error_types          = 3'b111;      //   001: configuration errors
-                                                 //   010: malicous injection
-                                                 //   100: random resets
+  bit            fixed_operation_en         = 0;
+  bit            fixed_operation            = 1'b0;  // ecb
+  // fixed iv (will set all to 0)
+  bit            fixed_iv_en                = 0;
 
-  int          config_error_pct;                 // percentage of configuration errors
+  bit            fixed_keylen_en            = 0;
+  bit [2:0]      fixed_keylen               = 3'b001;
+
+  bit [2:0]      error_types                = 3'b111;      //   001: configuration errors
+                                                           //   010: malicous injection
+                                                           //   100: random resets
+
+  int            config_error_pct           = 10;        // percentage of configuration errors
   // rand variables
   rand bit     ref_model;                        // 0: C model 1: OPEN_SSL/BORING_SSL
   rand bit     key_mask;                         // randomly select if we force unused key bits to 0
@@ -79,9 +94,11 @@ class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block));
          (ref_model==0) ? "C-MODEL" : "OPEN_SSL" ) };
     str = {str,  $sformatf("\n\t ----| num_messages # %d \t ", num_messages) };
     str = {str,  $sformatf("\n\t ----| ECB Weight: %d         \t ", ecb_weight) };
-    str = {str,  $sformatf("\n\t ----| CBC Weight: %d         \t ", cbc_weight) };   
+    str = {str,  $sformatf("\n\t ----| CBC Weight: %d         \t ", cbc_weight) };
+    str = {str,  $sformatf("\n\t ----| CFB Weight: %d         \t ", cfb_weight) };
+    str = {str,  $sformatf("\n\t ----| OFB Weight: %d         \t ", ofb_weight) };
     str = {str,  $sformatf("\n\t ----| CTR Weight: %d         \t ", ctr_weight) };
-    str = {str,  $sformatf("\n\t ----| key mask:   %b         \t ", key_mask)}; 
+    str = {str,  $sformatf("\n\t ----| key mask:   %b         \t ", key_mask)};
     str = {str, "\n"};
     return str;
   endfunction

--- a/hw/ip/aes/dv/env/aes_scoreboard.sv
+++ b/hw/ip/aes/dv/env/aes_scoreboard.sv
@@ -172,7 +172,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
               // verify that all 4 data_in and all 8 key are clean
               `uvm_info(`gfn, $sformatf("\n\t ----|data_inv_vld?  %b, key clean ? %b",
                         input_item.data_in_valid(), input_item.key_clean(1) ), UVM_HIGH)
-
+  
               if(input_item.data_in_valid() && input_item.key_clean(1)) begin
                 //clone and add to ref and rec data fifo
                 `uvm_info(`gfn, $sformatf("\n\t ----| OK to clone"), UVM_HIGH)
@@ -194,7 +194,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
               // verify that all 4 data_in and all 8 key  and all 4 IV are clean
               `uvm_info(`gfn, $sformatf("\n\t ----|data_inv_vld?  %b, key clean ? %b",
                                 input_item.data_in_valid(), input_item.key_clean(1) ), UVM_HIGH)
-
+  
               if(input_item.data_in_valid() && input_item.key_clean(1) && input_item.iv_clean(1)) begin
                 //clone and add to ref and rec data fifo
                 `uvm_info(`gfn, $sformatf("\n\t ----| OK to clone"), UVM_HIGH)
@@ -271,6 +271,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
           end
         endcase // case (input_item.mode)
       end // if (input_item.valid)
+      
 
       // forward item to receive side
       if(ok_to_fwd ) begin

--- a/hw/ip/aes/dv/env/aes_scoreboard.sv
+++ b/hw/ip/aes/dv/env/aes_scoreboard.sv
@@ -160,6 +160,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
       if(input_item.valid) begin
         case (input_item.mode)
           AES_ECB: begin
+            `uvm_info(`gfn, $sformatf("\n\t ----| ECB mode"), UVM_HIGH)
             if(aes_from_rst) begin
               // verify that all 4 data_in and all 8 key have been updated
               if(input_item.data_in_valid() && input_item.key_clean(0)) begin
@@ -182,6 +183,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
           end
   
           AES_CBC: begin
+            `uvm_info(`gfn, $sformatf("\n\t ----| CBC mode"), UVM_HIGH)            
             if(aes_from_rst) begin
               // verify that all 4 data_in and all 8 key and all 4 IV have been updated
               if(input_item.data_in_valid() && input_item.key_clean(0) && input_item.iv_clean(0)) begin
@@ -248,6 +250,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
           end
 
           AES_CTR: begin
+            `uvm_info(`gfn, $sformatf("\n\t ----| CTR mode"), UVM_HIGH)            
             if(aes_from_rst) begin
               // verify that all 4 data_in and all 8 key and all 4 IV have been updated
               if(input_item.data_in_valid() && input_item.key_clean(0) && input_item.iv_clean(0)) begin
@@ -413,7 +416,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
       msg.alloc_predicted_msg();
       //ref-model      / opration     / chipher mode /    IV   / key_len    / key /data i /data o //
       c_dpi_aes_crypt_message(cfg.ref_model, msg.aes_operation, msg.aes_mode, msg.aes_iv, 
-                              msg.aes_keylen, msg.aes_key, msg.input_msg, msg.predicted_msg);
+                            msg.aes_keylen, msg.aes_key, msg.input_msg, msg.predicted_msg);
 
       `uvm_info(`gfn, $sformatf("\n\t ----| printing MESSAGE %s", msg.convert2string() )
                 , UVM_HIGH)
@@ -424,6 +427,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
       end
 
       `uvm_info(`gfn, $sformatf("\n\t input \t output \t predicted %s",txt), UVM_HIGH)
+
 
       for( int n =0 ; n < msg.input_msg.size(); n++) begin
         if( msg.output_msg[n] != msg.predicted_msg[n]) begin

--- a/hw/ip/aes/dv/env/aes_scoreboard.sv
+++ b/hw/ip/aes/dv/env/aes_scoreboard.sv
@@ -52,7 +52,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
 
   task run_phase(uvm_phase phase);
     super.run_phase(phase);
-    `uvm_info(`gfn, $sformatf("%s", cfg.convert2string()), UVM_HIGH)
+    `uvm_info(`gfn, $sformatf("%s", cfg.convert2string()), UVM_MEDIUM)
     if(cfg.en_scb) begin
       fork
         compare();
@@ -84,7 +84,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
       if (write) begin
         void'(csr.predict(.value(item.a_data), .kind(UVM_PREDICT_WRITE), .be(item.a_mask)));
       end
-      `uvm_info(`gfn, $sformatf("ITEM received reg name : %s",csr.get_name() ), UVM_HIGH)
+      `uvm_info(`gfn, $sformatf("\n\t ----| ITEM received reg name : %s",csr.get_name() ), UVM_MEDIUM)
       csr_name = csr.get_name();
       case (1)
         // add individual case item for each csr
@@ -134,22 +134,58 @@ class aes_scoreboard extends cip_base_scoreboard #(
           end
        end
 
-     //    TODO
-     //   "trigger": begin
-     //     if (item.a_data[0]) begin
-     //       //            `downcast(ref_item, input_item.clone());
-     //       //            ref_fifo.put(ref_item);
-     //     end
-     //   end
-     //
-     //   "status": begin
-     //     //TBD
-     //   end
-
-        default: begin
-          // DO nothing- trying to write to a read only register
+      (!uvm_re_match("trigger", csr_name)): begin
+        //start triggered
+        if (item.a_data[0]) begin
+           ok_to_fwd    = 1;
+           aes_from_rst = 0;
         end
-      endcase
+        // clear key
+        if (item.a_data[1]) begin
+          if(cfg.clear_reg_w_rand) begin
+            input_item.key = {8{$urandom()}};
+          end else begin
+            input_item.key = '0;
+          end
+        end
+        // clear IV
+        if (item.a_data[2]) begin
+          if(cfg.clear_reg_w_rand) begin
+            input_item.iv = {4{$urandom()}};
+          end else begin
+            input_item.iv = '0;
+          end
+        end
+        // clear data_in
+        if (item.a_data[3]) begin
+          if(cfg.clear_reg_w_rand) begin
+            input_item.data_in = {4{$urandom()}};
+          end else begin
+            input_item.data_in = '0;
+          end
+        end
+        // clear data out
+        if (item.a_data[4]) begin
+          if(cfg.clear_reg_w_rand) begin
+            input_item.data_out = {4{$urandom()}};
+          end else begin
+            input_item.data_out = '0;
+          end
+        end
+        // reseed
+         if (item.a_data[5]) begin
+           // nothing to do for DV
+        end
+       end
+
+      // "status": begin
+      //   //TBD
+      // end
+
+       default: begin
+         // DO nothing- trying to write to a read only register
+       end
+     endcase
 
 
       ///////////////////////////////////////
@@ -157,54 +193,50 @@ class aes_scoreboard extends cip_base_scoreboard #(
       ///////////////////////////////////////
 
       // check that the item is valid - all registers clean base on mode //
-      if(input_item.valid) begin
+      if(input_item.valid && !input_item.manual_op) begin
         case (input_item.mode)
           AES_ECB: begin
-            `uvm_info(`gfn, $sformatf("\n\t ----| ECB mode"), UVM_HIGH)
+            `uvm_info(`gfn, $sformatf("\n\t ----| ECB mode"), UVM_MEDIUM)
             if(aes_from_rst) begin
               // verify that all 4 data_in and all 8 key have been updated
               if(input_item.data_in_valid() && input_item.key_clean(0)) begin
                 //clone and add to ref and rec data fifo
                 ok_to_fwd    = 1;
                 aes_from_rst = 0;
-                `uvm_info(`gfn, $sformatf("\n\t ----| First ITEM created  OK to clone"), UVM_HIGH)
               end
             end else begin
               // verify that all 4 data_in and all 8 key are clean
               `uvm_info(`gfn, $sformatf("\n\t ----|data_inv_vld?  %b, key clean ? %b",
-                        input_item.data_in_valid(), input_item.key_clean(1) ), UVM_HIGH)
-  
+                        input_item.data_in_valid(), input_item.key_clean(1) ), UVM_MEDIUM)
+
               if(input_item.data_in_valid() && input_item.key_clean(1)) begin
                 //clone and add to ref and rec data fifo
-                `uvm_info(`gfn, $sformatf("\n\t ----| OK to clone"), UVM_HIGH)
                 ok_to_fwd = 1;
               end
             end
           end
-  
+
           AES_CBC: begin
-            `uvm_info(`gfn, $sformatf("\n\t ----| CBC mode"), UVM_HIGH)            
+            `uvm_info(`gfn, $sformatf("\n\t ----| CBC mode"), UVM_MEDIUM)
             if(aes_from_rst) begin
               // verify that all 4 data_in and all 8 key and all 4 IV have been updated
               if(input_item.data_in_valid() && input_item.key_clean(0) && input_item.iv_clean(0)) begin
                 //clone and add to ref and rec data fifo
                 ok_to_fwd    = 1;
                 aes_from_rst = 0;
-                `uvm_info(`gfn, $sformatf("\n\t ----| First ITEM created  OK to clone"), UVM_HIGH)
               end
             end else begin
               // verify that all 4 data_in and all 8 key  and all 4 IV are clean
               `uvm_info(`gfn, $sformatf("\n\t ----|data_inv_vld?  %b, key clean ? %b",
-                                input_item.data_in_valid(), input_item.key_clean(1) ), UVM_HIGH)
-  
+                                input_item.data_in_valid(), input_item.key_clean(1) ), UVM_MEDIUM)
+
               if(input_item.data_in_valid() && input_item.key_clean(1) && input_item.iv_clean(1)) begin
                 //clone and add to ref and rec data fifo
-                `uvm_info(`gfn, $sformatf("\n\t ----| OK to clone"), UVM_HIGH)
                 ok_to_fwd = 1;
               end
             end
           end
-  
+
           AES_CFB: begin
             if(aes_from_rst) begin
               // verify that all 4 data_in and all 8 key and all 4 IV have been updated
@@ -212,7 +244,6 @@ class aes_scoreboard extends cip_base_scoreboard #(
                 //clone and add to ref and rec data fifo
                 ok_to_fwd    = 1;
                 aes_from_rst = 0;
-                `uvm_info(`gfn, $sformatf("\n\t ----| First ITEM created  OK to clone"), UVM_HIGH)
               end
             end else begin
               // verify that all 4 data_in and all 8 key  and all 4 IV are clean
@@ -221,7 +252,6 @@ class aes_scoreboard extends cip_base_scoreboard #(
 
               if(input_item.data_in_valid() && input_item.key_clean(1) && input_item.iv_clean(1)) begin
                 //clone and add to ref and rec data fifo
-                `uvm_info(`gfn, $sformatf("\n\t ----| OK to clone"), UVM_HIGH)
                 ok_to_fwd = 1;
               end
             end
@@ -234,7 +264,6 @@ class aes_scoreboard extends cip_base_scoreboard #(
                 //clone and add to ref and rec data fifo
                 ok_to_fwd    = 1;
                 aes_from_rst = 0;
-                `uvm_info(`gfn, $sformatf("\n\t ----| First ITEM created  OK to clone"), UVM_HIGH)
               end
             end else begin
               // verify that all 4 data_in and all 8 key  and all 4 IV are clean
@@ -243,28 +272,25 @@ class aes_scoreboard extends cip_base_scoreboard #(
 
               if(input_item.data_in_valid() && input_item.key_clean(1) && input_item.iv_clean(1)) begin
                 //clone and add to ref and rec data fifo
-                `uvm_info(`gfn, $sformatf("\n\t ----| OK to clone"), UVM_HIGH)
                 ok_to_fwd = 1;
               end
             end
           end
 
           AES_CTR: begin
-            `uvm_info(`gfn, $sformatf("\n\t ----| CTR mode"), UVM_HIGH)            
+            `uvm_info(`gfn, $sformatf("\n\t ----| CTR mode"), UVM_MEDIUM)
             if(aes_from_rst) begin
               // verify that all 4 data_in and all 8 key and all 4 IV have been updated
               if(input_item.data_in_valid() && input_item.key_clean(0) && input_item.iv_clean(0)) begin
                 //clone and add to ref and rec data fifo
                 ok_to_fwd    = 1;
                 aes_from_rst = 0;
-                `uvm_info(`gfn, $sformatf("\n\t ----| First ITEM created  OK to clone"), UVM_HIGH)
               end
             end else begin
               // verify that all 4 data_in and all 8 and all 4 IV  key are clean
-              `uvm_info(`gfn, $sformatf("\n\t ----|data_inv_vld?  %b, key clean ? %b",input_item.data_in_valid(), input_item.key_clean(1) ), UVM_HIGH)
+              `uvm_info(`gfn, $sformatf("\n\t ----|data_inv_vld?  %b, key clean ? %b",input_item.data_in_valid(), input_item.key_clean(1) ), UVM_MEDIUM)
               if(input_item.data_in_valid() && input_item.key_clean(1) && input_item.iv_clean(1)) begin
                 //clone and add to ref and rec data fifo
-                `uvm_info(`gfn, $sformatf("\n\t ----| OK to clone"), UVM_HIGH)
                 ok_to_fwd = 1;
               end
             end
@@ -274,13 +300,13 @@ class aes_scoreboard extends cip_base_scoreboard #(
           end
         endcase // case (input_item.mode)
       end // if (input_item.valid)
-      
+
 
       // forward item to receive side
       if(ok_to_fwd ) begin
         ok_to_fwd = 0;
         `downcast(input_clone, input_item.clone());
-        `uvm_info(`gfn, $sformatf("\n\t AES INPUT ITEM RECEIVED - \n %s", input_clone.convert2string()), UVM_HIGH)
+        `uvm_info(`gfn, $sformatf("\n\t AES INPUT ITEM RECEIVED - \n %s", input_clone.convert2string()), UVM_MEDIUM)
         rcv_item_q.push_front(input_clone);
         input_item.clean();
       end
@@ -291,7 +317,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
     // get an item from the rcv queue and wait for all output data to be received
     //////////////////////////////////////////////////////////////////////////////
 
-    `uvm_info(`gfn, $sformatf("\n\t ---| channel  %h", channel), UVM_HIGH)
+    `uvm_info(`gfn, $sformatf("\n\t ---| channel  %h", channel), UVM_DEBUG)
     if (!write && channel == DataChannel) begin
       if (do_read_check) begin
         `DV_CHECK_EQ(csr.get_mirrored_value(), item.d_data,
@@ -299,7 +325,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
       end
       void'(csr.predict(.value(item.d_data), .kind(UVM_PREDICT_READ)));
       `uvm_info(`gfn, $sformatf("\n\t ----| SAW READ - %s data %02h",csr.get_name(),  item.d_data)
-                , UVM_HIGH)
+                , UVM_MEDIUM)
 
       case (csr.get_name())
         "data_out0": begin
@@ -335,7 +361,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
         complete_item              = new();
         `uvm_info(`gfn,
           $sformatf("\n\t ----|added data to item_fifo (output received) fifo entries %d", 
-                   item_fifo.num()), UVM_HIGH)
+                   item_fifo.num()), UVM_MEDIUM)
       end
     end
   endtask // process_tl_access
@@ -387,8 +413,8 @@ class aes_scoreboard extends cip_base_scoreboard #(
 
       begin
         wait( finish_message )
-        `uvm_info(`gfn, $sformatf("\n\t ----|Finish test received adding message item to mg_fifo")
-         , UVM_HIGH)
+        `uvm_info(`gfn, $sformatf("\n\t ----| Finish test received adding message item to mg_fifo")
+         , UVM_MEDIUM)
 
         `downcast(msg_clone, message.clone());
         msg_fifo.put(msg_clone);
@@ -405,28 +431,25 @@ class aes_scoreboard extends cip_base_scoreboard #(
     forever begin
       aes_message_item msg;
 
-      `uvm_info(`gfn, $sformatf("\n\t ----| TRYING to get item "), UVM_HIGH)
       msg_fifo.get(msg);
-
-      `uvm_info(`gfn, $sformatf("\n\t ----| GOT item "), UVM_HIGH)
       `uvm_info(`gfn, $sformatf("model %b, operation: %b, mode %06b, IV %h, key_len %03b, key %h ",
                                 cfg.ref_model, msg.aes_operation, msg.aes_mode, msg.aes_iv, msg.aes_keylen, msg.aes_key)
-                , UVM_HIGH)
+                , UVM_MEDIUM)
 
       msg.alloc_predicted_msg();
       //ref-model      / opration     / chipher mode /    IV   / key_len    / key /data i /data o //
-      c_dpi_aes_crypt_message(cfg.ref_model, msg.aes_operation, msg.aes_mode, msg.aes_iv, 
+      c_dpi_aes_crypt_message(cfg.ref_model, msg.aes_operation, msg.aes_mode, msg.aes_iv,
                             msg.aes_keylen, msg.aes_key, msg.input_msg, msg.predicted_msg);
 
       `uvm_info(`gfn, $sformatf("\n\t ----| printing MESSAGE %s", msg.convert2string() )
-                , UVM_HIGH)
+                , UVM_MEDIUM)
       txt = "";
       foreach(msg.input_msg[i]) begin
         txt = { txt, $sformatf("\n\t  %h \t %h \t %h",
                                msg.input_msg[i],msg.output_msg[i], msg.predicted_msg[i])};
       end
 
-      `uvm_info(`gfn, $sformatf("\n\t input \t output \t predicted %s",txt), UVM_HIGH)
+      `uvm_info(`gfn, $sformatf("\n\t input \t output \t predicted %s",txt), UVM_MEDIUM)
 
 
       for( int n =0 ; n < msg.input_msg.size(); n++) begin
@@ -439,7 +462,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
           `uvm_fatal(`gfn, $sformatf(" # %d  \n\t %s \n",message_cnt, txt))
         end
       end
-      `uvm_info(`gfn, $sformatf("\n\t ----|   MESSAGE #%d MATCHED    |-----",message_cnt), UVM_HIGH)
+      `uvm_info(`gfn, $sformatf("\n\t ----|   MESSAGE #%0d MATCHED    |-----",message_cnt), UVM_MEDIUM)
       message_cnt++;
     end
   endtask
@@ -450,7 +473,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
 
     // the message currently being reassembled is should be sent for scoring
     finish_message = 1;
-    `uvm_info(`gfn, $sformatf("Finish message: %b", finish_message), UVM_HIGH)
+    `uvm_info(`gfn, $sformatf("Finish message: %b", finish_message), UVM_MEDIUM)
 
     // AEs needs this objection - because PHASE READY TO END
     // is the only way to know that the very last message is now complete
@@ -464,7 +487,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
 
 
   virtual task wait_fifo_empty();
-    `uvm_info(`gfn, $sformatf("item fifo entries %d", item_fifo.num()), UVM_HIGH)
+    `uvm_info(`gfn, $sformatf("item fifo entries %d", item_fifo.num()), UVM_MEDIUM)
     wait (rcv_item_q.size() == 0 );
     wait (item_fifo.num()   == 0 );
     wait (msg_fifo.num()    == 0 );
@@ -479,13 +502,20 @@ class aes_scoreboard extends cip_base_scoreboard #(
 
   function void check_phase(uvm_phase phase);
     string txt =  "";
+    uvm_report_server rpt_srvr;
+
     if (cfg.en_scb) begin
       super.check_phase(phase);
       `DV_EOT_PRINT_MAILBOX_CONTENTS(aes_message_item, msg_fifo)
       `DV_EOT_PRINT_MAILBOX_CONTENTS(aes_seq_item, item_fifo)
       `DV_EOT_PRINT_Q_CONTENTS(aes_seq_item, rcv_item_q)
       if(message_cnt != cfg.num_messages) begin
-        txt = "\n\t ----| NO FAILURES BUT DIDN*T SEE ALL EXPECTED MESSAGES";
+        rpt_srvr = uvm_report_server::get_server();
+        if(rpt_srvr.get_severity_count(UVM_FATAL)+rpt_srvr.get_severity_count(UVM_ERROR) == 0) begin
+          txt = "\n\t ----| NO FAILURES BUT DIDN*T SEE ALL EXPECTED MESSAGES";
+        end else begin
+          txt = "\n\t ----| TEST FAILED";
+          end
         txt = { txt, $sformatf(" \n\t ----| expected %d, seen: %d", cfg.num_messages, message_cnt ) };
         `uvm_fatal(`gfn, $sformatf("%s", txt) )
       end
@@ -513,7 +543,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
       txt = { txt,"\n\t----            TEST PASSED        ----"};
       txt = { txt,"\n\t---------------------------------------"};
     end
-    `uvm_info(`gfn, $sformatf("%s", txt), UVM_HIGH)
+    `uvm_info(`gfn, $sformatf("%s", txt), UVM_MEDIUM)
 
   endfunction // report_phase
 endclass

--- a/hw/ip/aes/dv/env/aes_seq_item.sv
+++ b/hw/ip/aes/dv/env/aes_seq_item.sv
@@ -20,8 +20,7 @@ class aes_seq_item extends uvm_sequence_item;
   // 0: auto mode 1: manual start
   bit             manual_op;
   // 0: output data cannot be overwritten
-  // 1: new output will overwrite old output even if not read.
-  bit             allow_data_ovrwrt;
+
   // lenth of plaintext / cypher (max is 128b/16b per block)
   // used to mask bits that are not part of the data vector
   bit [3:0]       data_len            = 0;
@@ -198,6 +197,8 @@ class aes_seq_item extends uvm_sequence_item;
     iv_vld       = rhs_.iv_vld;
     data_out     = rhs_.data_out;
     data_len     = rhs_.data_len;
+    manual_op    = rhs_.manual_op;
+    key_mask     = rhs_.key_mask;
   endfunction // copy
 
 
@@ -231,6 +232,7 @@ class aes_seq_item extends uvm_sequence_item;
     for(int i=0; i <8; i++) begin
       str = {str, $psprintf("%h ",key[i])};
     end
+    str = {str,  $psprintf("\n\t ----| key_mask: \t %d |----\t  \t", key_mask) };
     str = {str,  $psprintf("\n\t ----| Data Length: \t %d |----\t  \t", data_len) };
     str = {str,  $psprintf("\n\t ----| Input data:  \t %h |----\t ", data_in) };
     str = {str,  $psprintf("\n\t ----| Output data: \t %h |----\t ", data_out) };

--- a/hw/ip/aes/dv/env/aes_seq_item.sv
+++ b/hw/ip/aes/dv/env/aes_seq_item.sv
@@ -99,7 +99,7 @@ class aes_seq_item extends uvm_sequence_item;
   // have been updated.
   function bit data_in_valid();
     `uvm_info(`gfn, $sformatf("\n\t ----| Checking if ALL data is updated %4b", data_in_vld)
-              , UVM_FULL)
+              , UVM_MEDIUM)
 
     return &data_in_vld;
   endfunction // data_in_valid
@@ -118,7 +118,7 @@ class aes_seq_item extends uvm_sequence_item;
   // if ret_celan = 1
   // return 1 if all or none of the registers have been written
   function bit key_clean(bit ret_clean);
-    `uvm_info(`gfn, $sformatf("\n\t ----| Key status %b", key_vld), UVM_HIGH)
+    `uvm_info(`gfn, $sformatf("\n\t ----| Key status %b", key_vld), UVM_MEDIUM)
     if(ret_clean) begin
       return ( (&key_vld) || ~(|key_vld));
     end else begin
@@ -143,12 +143,12 @@ class aes_seq_item extends uvm_sequence_item;
   function bit message_start();
     case(mode)
       AES_ECB: begin
-        `uvm_info(`gfn, $sformatf("return key vld(%b) %b",key_vld, &key_vld), UVM_HIGH)
+        `uvm_info(`gfn, $sformatf("return key vld(%b) %b",key_vld, &key_vld), UVM_MEDIUM)
         return (&key_vld);
       end
       AES_CBC: begin
         `uvm_info(`gfn, $sformatf("return key vld(%b) %b AND iv (%b) &b",
-                   key_vld, &key_vld, iv_vld, &iv_vld), UVM_HIGH)
+                   key_vld, &key_vld, iv_vld, &iv_vld), UVM_MEDIUM)
         return (&key_vld && &iv_vld);
       end
       AES_CFB: begin
@@ -163,7 +163,7 @@ class aes_seq_item extends uvm_sequence_item;
       end
       AES_CTR: begin
         `uvm_info(`gfn, $sformatf("return key vld(%b) %b AND iv (%b) &b",
-                   key_vld, &key_vld, iv_vld, &iv_vld), UVM_HIGH)
+                   key_vld, &key_vld, iv_vld, &iv_vld), UVM_MEDIUM)
         return (&key_vld && &iv_vld);
       end
       default: begin
@@ -231,6 +231,10 @@ class aes_seq_item extends uvm_sequence_item;
     str = {str,  $psprintf("\n\t ----| Key:         \t ") };
     for(int i=0; i <8; i++) begin
       str = {str, $psprintf("%h ",key[i])};
+    end
+    str = {str,  $sformatf("\n\t ----| Initializaion vector:         \t ") };
+    for(int i=0; i <4; i++) begin
+      str = {str, $sformatf("%h ",iv[i])};
     end
     str = {str,  $psprintf("\n\t ----| key_mask: \t %d |----\t  \t", key_mask) };
     str = {str,  $psprintf("\n\t ----| Data Length: \t %d |----\t  \t", data_len) };

--- a/hw/ip/aes/dv/env/seq_lib/aes_stress_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_stress_vseq.sv
@@ -22,10 +22,14 @@ class aes_stress_vseq extends aes_base_vseq;
       my_message = message_queue.pop_back();
 
       // for this message generate configuration
-      // and data items (split message into blocks)
+      // and data items (split message into blocks)2
       generate_aes_item_queue(my_message);
-      // setup and transmit
-      transmit_message_with_rd_back();
+      // setup and transmit based on settings
+      if(my_message.manual_operation) begin
+        transmit_message_manual_op();        
+      end else begin       
+        transmit_message_with_rd_back();
+      end      
     end
   endtask : body
 endclass

--- a/hw/ip/aes/dv/env/seq_lib/aes_stress_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_stress_vseq.sv
@@ -26,10 +26,10 @@ class aes_stress_vseq extends aes_base_vseq;
       generate_aes_item_queue(my_message);
       // setup and transmit based on settings
       if(my_message.manual_operation) begin
-        transmit_message_manual_op();        
-      end else begin       
+        transmit_message_manual_op();
+      end else begin
         transmit_message_with_rd_back();
-      end      
+      end
     end
   endtask : body
 endclass

--- a/hw/ip/aes/dv/env/seq_lib/aes_wake_up_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_wake_up_vseq.sv
@@ -46,6 +46,7 @@ class aes_wake_up_vseq extends aes_base_vseq;
     `uvm_info(`gfn, $sformatf("\n\t ---| Polling for data register %s",
                               ral.status.convert2string()), UVM_DEBUG)
 
+    csr_spinwait(.ptr(ral.status.output_valid) , .exp_data(1'b1));
     read_data(cypher_text);
     // read output
     `uvm_info(`gfn, $sformatf("\n\t ------|WAIT 0 |-------"), UVM_HIGH)
@@ -65,7 +66,7 @@ class aes_wake_up_vseq extends aes_base_vseq;
               UVM_DEBUG)
 
     cfg.clk_rst_vif.wait_clks(20);
-
+    csr_spinwait(.ptr(ral.status.output_valid) , .exp_data(1'b1));
     read_data(decrypted_text);
     //need scoreboard disable
     foreach(plain_text[i]) begin

--- a/hw/ip/aes/dv/tests/aes_base_test.sv
+++ b/hw/ip/aes/dv/tests/aes_base_test.sv
@@ -15,21 +15,62 @@ class aes_base_test extends cip_base_test #(
    endfunction // build_phase
 
 
+
+  //this will serve as the default setting.
+  // overrides should happen in the specific testcase.
   virtual function void configure_env();
     // cfg.ref_model          = OpenSSL;
-    // env related knobs
 
-    cfg.errors_en          = 0;
-    cfg.num_messages_min   = 3;
-    cfg.num_messages_max   = 3;
-    // message related knobs
-    cfg.ecb_weight         = 100;
-    cfg.cbc_weight         = 0;
-    cfg.ctr_weight         = 0;
-    cfg.message_len_min    = 1;   // bytes
-    cfg.message_len_max    = 599; // bytes
-    `DV_CHECK_RANDOMIZE_FATAL(cfg)
+    cfg.num_messages_min            = 1;
+    cfg.num_messages_max            = 31;
+    cfg.message_len_min             = 1;
+    cfg.message_len_max             = 599;
+    cfg.use_key_mask                = 0;
+    cfg.use_c_model_pct             = 0;
+    cfg.errors_en                   = 0;
+  // clear registers with 0's or rand
+    cfg.clear_reg_w_rand            = 1;
+  // if set the order of which key iv and data is written will be randomized and interleaved
+    cfg.random_data_key_iv_order    = 1;
+
+  // Mode distribution //
+  // chance of selection ecb_mode
+  // ecb_mode /(ecb_mode + cbc_mode + ctr_mode + cfb_mode + ofb_mode)
+  // with the defaults 10/50 = 1/5 (20%)
+    cfg.ecb_weight                 = 10;
+    cfg.cbc_weight                 = 10;
+    cfg.ofb_weight                 = 10;
+    cfg.cfb_weight                 = 10;
+    cfg.ctr_weight                 = 10;
+
+  // KEYLEN weights
+  // change of selecting 128b key
+  //  128b/(128+192+256) = 10/30 = (33%)
+    cfg.key_128b_weight            = 10;
+    cfg.key_192b_weight            = 10;
+    cfg.key_256b_weight            = 10;
+
+  // use manual operation mode percentage
+    cfg.manual_operation_pct       = 10;
+
+  // debug / directed test knobs //
+  // use fixed key
+    cfg.fixed_key_en                = 0;
+  // use fixed data (same data for each block in a message
+    cfg.fixed_data_en               = 0;
+  // fixed operation (enc or dec)
+    cfg.fixed_operation_en          = 0;
+    cfg.fixed_operation             = 1'b0;  
+  // fixed iv (will set all to 0)
+    cfg.fixed_iv_en                 = 0;
+    cfg.fixed_keylen_en             = 0;
+    cfg.fixed_keylen                = 3'b001;
+
+    cfg.error_types                 = 3'b111;      //   001: configuration errors
+                                                   //   010: malicous injection
+                                                   //   100: random resets
+
+    cfg.config_error_pct            = 0;           // percentage of configuration errors
+ `DV_CHECK_RANDOMIZE_FATAL(cfg)
   endfunction
-
-
 endclass : aes_base_test

--- a/hw/ip/aes/dv/tests/aes_sanity_test.sv
+++ b/hw/ip/aes/dv/tests/aes_sanity_test.sv
@@ -13,17 +13,32 @@ class aes_sanity_test extends aes_base_test;
   endfunction
 
   function void configure_env();
-     super.configure_env();
-     cfg.errors_en          = 0;     // no errors in sanity test
-     cfg.num_messages_min   = 2;
-     cfg.num_messages_max   = 2;
-     // message related knobs
-     cfg.ecb_weight         = 100;   // only eCB
-     cfg.cbc_weight         = 0;
-     cfg.ctr_weight         = 0;
-     cfg.message_len_min    = 16;    // one block (16bytes=128bits)
-     cfg.message_len_max    = 16;    //
+    super.configure_env();
+    cfg.errors_en            = 0;     // no errors in sanity test
+    cfg.num_messages_min     = 2;
+    cfg.num_messages_max     = 2;
+    // message related knobs
+    cfg.ecb_weight           = 100;   // only eCB
+    cfg.cbc_weight           = 0;
+    cfg.ctr_weight           = 0;
+    cfg.message_len_min      = 16;    // one block (16bytes=128bits)
+    cfg.message_len_max      = 16;    //
+    cfg.manual_operation_pct = 100;
+    cfg.use_key_mask         = 1;
 
+    cfg.fixed_data_en        = 1;
+    cfg.fixed_key_en         = 0;
+
+
+    cfg.fixed_operation_en   = 1;
+    cfg.fixed_operation      = 0;
+
+    cfg.fixed_keylen_en      = 0;
+    cfg.fixed_keylen         = 3'b010;
+
+    // cfg.key_128b_weight    = 0;
+    // cfg.key_192b_weight    = 100;
+    // cfg.key_256b_weight    = 0;
     `DV_CHECK_RANDOMIZE_FATAL(cfg)
   endfunction
 endclass : aes_sanity_test

--- a/hw/ip/aes/dv/tests/aes_sanity_test.sv
+++ b/hw/ip/aes/dv/tests/aes_sanity_test.sv
@@ -14,31 +14,31 @@ class aes_sanity_test extends aes_base_test;
 
   function void configure_env();
     super.configure_env();
-    cfg.errors_en            = 0;     // no errors in sanity test
-    cfg.num_messages_min     = 2;
-    cfg.num_messages_max     = 2;
+    cfg.errors_en                = 0;     // no errors in sanity test
+    cfg.num_messages_min         = 2;
+    cfg.num_messages_max         = 2;
     // message related knobs
-    cfg.ecb_weight           = 100;   // only eCB
-    cfg.cbc_weight           = 0;
-    cfg.ctr_weight           = 0;
-    cfg.message_len_min      = 16;    // one block (16bytes=128bits)
-    cfg.message_len_max      = 16;    //
-    cfg.manual_operation_pct = 100;
-    cfg.use_key_mask         = 1;
+    cfg.ecb_weight               = 10;   // only eCB
+    cfg.cbc_weight               = 10;
+    cfg.ctr_weight               = 10;
+    cfg.message_len_min          = 16;    // one block (16bytes=128bits)
+    cfg.message_len_max          = 32;    //
+    cfg.manual_operation_pct     = 0;
+    cfg.use_key_mask             = 0;
 
-    cfg.fixed_data_en        = 1;
-    cfg.fixed_key_en         = 0;
+    cfg.fixed_data_en            = 0;
+    cfg.fixed_key_en             = 0;
 
+    cfg.fixed_operation_en       = 0;
+    cfg.fixed_operation          = 0;
 
-    cfg.fixed_operation_en   = 1;
-    cfg.fixed_operation      = 0;
+    cfg.fixed_keylen_en          = 1;
+    cfg.fixed_keylen             = 3'b001;
 
-    cfg.fixed_keylen_en      = 0;
-    cfg.fixed_keylen         = 3'b010;
+    cfg.fixed_iv_en              = 0;
 
-    // cfg.key_128b_weight    = 0;
-    // cfg.key_192b_weight    = 100;
-    // cfg.key_256b_weight    = 0;
+    cfg.random_data_key_iv_order = 0;
+
     `DV_CHECK_RANDOMIZE_FATAL(cfg)
   endfunction
 endclass : aes_sanity_test

--- a/hw/ip/aes/dv/tests/aes_stress_test.sv
+++ b/hw/ip/aes/dv/tests/aes_stress_test.sv
@@ -16,14 +16,30 @@ class aes_stress_test extends aes_base_test;
     // env related knobs
 
     cfg.errors_en          = 0;
-    cfg.num_messages_min   = 5;
-    cfg.num_messages_max   = 5;
+    cfg.num_messages_min   = 1;
+    cfg.num_messages_max   = 50;
     // message related knobs
     cfg.ecb_weight         = 10;
-    cfg.cbc_weight         = 40;
-    cfg.ctr_weight         = 40;
+    cfg.cbc_weight         = 10;
+    cfg.ctr_weight         = 10;
     cfg.message_len_min    = 7;   // bytes
-    cfg.message_len_max    = 251; // bytes
+    cfg.message_len_max    = 1023; // bytes
+
+    cfg.fixed_data_en            = 0;
+    cfg.fixed_key_en             = 0;
+
+    cfg.fixed_operation_en       = 0;
+    cfg.fixed_operation          = 0;
+
+    cfg.fixed_keylen_en          = 0;
+    cfg.fixed_keylen             = 3'b010;
+
+    cfg.fixed_iv_en              = 0;
+
+    cfg.random_data_key_iv_order = 1;
+
+    cfg.manual_operation_pct     = 30;
+
     `DV_CHECK_RANDOMIZE_FATAL(cfg)
   endfunction
 endclass : aes_stress_test

--- a/hw/ip/aes/dv/tests/aes_wake_up_test.sv
+++ b/hw/ip/aes/dv/tests/aes_wake_up_test.sv
@@ -19,7 +19,10 @@ class aes_wake_up_test extends aes_base_test;
      cfg.ctr_weight         = 0;
      cfg.num_messages_min   = 2;
      cfg.num_messages_max   = 2;
-
+     cfg.errors_en          = 0;
+    // cfg.key_128b_weight    = 0;
+    // cfg.key_192b_weight    = 100;
+    // cfg.key_256b_weight    = 0;
     `DV_CHECK_RANDOMIZE_FATAL(cfg)
   endfunction
 endclass : aes_wake_up_test


### PR DESCRIPTION
These commits contain a fairly large update to DV with manual mode added,
also the interleaving of data/iv/key is added.
also added a mode where reads and writes to DUT is split into parallel processes such that the arbitration is done by the sequencer and timing is less predictable (write/read/write/read ) sequential mode is still an option.

the aes_stress test is failing for some seeds which is being debugged.
but I want to get this in as more changes to AES is coming.
