### PR TITLE
[ci] Pass str not path to shutil.rmtree

### DIFF
--- a/util/get-toolchain.py
+++ b/util/get-toolchain.py
@@ -201,7 +201,7 @@ def main():
         if args.update and target_dir.exists():
             # We only reach this point if |target_dir| contained a toolchain
             # before, so removing it is reasonably safe.
-            shutil.rmtree(target_dir)
+            shutil.rmtree(str(target_dir))
 
         install(archive_file, target_dir)
         postinstall_rewrite_configs(target_dir.resolve())


### PR DESCRIPTION
The machine used by azure to run verilator builds can't run
get_toolchain.py when a path object is passed to shutil.rmtree.
Converting it to a str allows get_toolchain.py to be used on that
machine.

There may be a better way to deal with this but this seemed the simplest and this change is required to enable the OTBN smoke test.