### PR TITLE
[Aes:dv] adding manual mode and  several debug knobs 

### DIFF
--- a/hw/ip/aes/dv/env/aes_env_cfg.sv
+++ b/hw/ip/aes/dv/env/aes_env_cfg.sv
@@ -9,37 +9,72 @@ class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block));
 
   `uvm_object_new
 
-  // Knobs //
-  int          num_messages_min   = 1;
-  int          num_messages_max   = 1;
-  int          message_len_min    = 128;
-  int          message_len_max    = 128;
-  bit          use_key_mask       = 0;
-  bit          use_c_model_pct    = 0;
-  bit          errors_en          = 0;
+  // TODO sort knobs into test/SEQUENCE/message/item
+
+  // test environment constraints //
+
+
+    //  Message Knobs //
+  int            num_messages_min            = 1;
+  int            num_messages_max            = 1;
+  int            message_len_min             = 128;
+  int            message_len_max             = 128;
+  bit            use_key_mask                = 0;
+  bit            use_c_model_pct             = 0;
+  bit            errors_en                   = 0;
+  // clear registers with 0's or rand
+  bit            clear_reg_w_rand            = 1;
+  // if set the order of which key iv and data is written will be randomized and interleaved
+  bit            random_data_key_iv_order    = 1;
+
   // Mode distribution //
-  // chance of selection ecb_mode
-  // ecb_mode /(ecb_mode + cbc_mode + ctr_mode)
-  // with the defaults 10/30 = 1/3 (33%)
-  int          ecb_weight         = 10;
-  int          cbc_weight         = 10;
-  int          ctr_weight         = 10;
+  // There are 5 modes (ecb, cbc, ofb, cfb, ctr). The weight for mode X is called X_weight. By
+  // default, all weights are set equal at 10 (so each is selected 10/50 = 20% of the time).
+  int            ecb_weight                 = 10;
+  int            cbc_weight                 = 10;
+  int            ofb_weight                 = 10;
+  int            cfb_weight                 = 10;
+  int            ctr_weight                 = 10;
+
   // KEYLEN weights
   // change of selecting 128b key
   //  128b/(128+192+256) = 10/30 = (33%)
-  int          key_128b_weight    = 10;
-  int          key_192b_weight    = 10;
-  int          key_256b_weight    = 10;
+  int            key_128b_weight            = 10;
+  int            key_192b_weight            = 10;
+  int            key_256b_weight            = 10;
 
-  bit  [2:0]   error_types        = 3'b111;      //   001: configuration errors
-                                                 //   010: malicous injection
-                                                 //   100: random resets
+  // use manual operation mode percentage
+  int            manual_operation_pct       = 10;
 
-  int          config_error_pct;                 // percentage of configuration errors
+  // debug / directed test knobs
+  // use fixed key
+  bit            fixed_key_en               = 0;
+  // use fixed data (same data for each block in a message)
+  bit            fixed_data_en              = 0;
+  // fixed operation
+  bit            fixed_operation_en         = 0;
+  bit            fixed_operation            = 1'b0;
+  // fixed iv (will set all to bits 0)
+  bit            fixed_iv_en                = 0;
+
+  bit            fixed_keylen_en            = 0;
+  bit [2:0]      fixed_keylen               = 3'b001;
+
+
+  //   001: configuration errors
+  //   010: malicous injection
+  //   100: random resets
+  bit [2:0]      error_types                = 3'b111;
+  // percentage of configuration errors
+  int            config_error_pct           = 10;
+
   // rand variables
-  rand bit     ref_model;                        // 0: C model 1: OPEN_SSL/BORING_SSL
-  rand bit     key_mask;                         // randomly select if we force unused key bits to 0
-  rand int     num_messages;                     // number of messages to encrypt/decrypt
+  // 0: C model 1: OPEN_SSL/BORING_SSL
+  rand bit     ref_model;
+  // randomly select if we force unused key bits to 0
+  rand bit     key_mask;
+  // number of messages to encrypt/decrypt
+  rand int     num_messages;
 
 
    // constraints
@@ -64,8 +99,11 @@ class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block));
          (ref_model==0) ? "C-MODEL" : "OPEN_SSL" ) };
     str = {str,  $sformatf("\n\t ----| num_messages # %d \t ", num_messages) };
     str = {str,  $sformatf("\n\t ----| ECB Weight: %d         \t ", ecb_weight) };
-    str = {str,  $sformatf("\n\t ----| CBC Weight: %d         \t ", cbc_weight) };   
-    str = {str,  $sformatf("\n\t ----| CTR Weight: %d         \t ", ctr_weight) }; 
+    str = {str,  $sformatf("\n\t ----| CBC Weight: %d         \t ", cbc_weight) };
+    str = {str,  $sformatf("\n\t ----| CFB Weight: %d         \t ", cfb_weight) };
+    str = {str,  $sformatf("\n\t ----| OFB Weight: %d         \t ", ofb_weight) };
+    str = {str,  $sformatf("\n\t ----| CTR Weight: %d         \t ", ctr_weight) };
+    str = {str,  $sformatf("\n\t ----| key mask:   %b         \t ", key_mask)};
     str = {str, "\n"};
     return str;
   endfunction

--- a/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
@@ -48,8 +48,12 @@ class aes_base_vseq extends cip_base_vseq #(
     aes_ctrl[6:1]  = aes_pkg::AES_ECB;   // 6'b00_0001
     aes_ctrl[9:7]  = aes_pkg::AES_128;   // set to 128b key
     csr_wr(.csr(ral.ctrl_shadowed), .value(aes_ctrl), .en_shadow_wr(1'b1));
-    csr_wr(.csr(ral.trigger), .value(aes_trigger));
-  endtask
+  endtask // aes_init
+
+
+  virtual task trigger();
+      csr_wr(.csr(ral.trigger), .value(32'h00000001));
+  endtask // trigger
 
 
   virtual task set_operation(bit operation);
@@ -97,15 +101,30 @@ class aes_base_vseq extends cip_base_vseq #(
 
 
   virtual task add_data(ref bit [3:0] [31:0] data);
-    `uvm_info(`gfn, $sformatf("\n\t ----| ADDING DATA TO DUT %h ", data), UVM_HIGH)
-    `uvm_info(`gfn, $sformatf("\n\t ----| DATA_in0: %h ", data[0][31:0]), UVM_HIGH)
-    `uvm_info(`gfn, $sformatf("\n\t ----| DATA_in1: %h ", data[1][31:0]), UVM_HIGH)
-    `uvm_info(`gfn, $sformatf("\n\t ----| DATA_in2: %h ", data[2][31:0]), UVM_HIGH)
-    `uvm_info(`gfn, $sformatf("\n\t ----| DATA_in3: %h ", data[3][31:0]), UVM_HIGH)     
+    `uvm_info(`gfn, $sformatf("\n\t ----| ADDING DATA TO DUT %h ", data), UVM_MEDIUM)
+    `uvm_info(`gfn, $sformatf("\n\t ----| DATA_in0: %h ", data[0][31:0]), UVM_MEDIUM)
+    `uvm_info(`gfn, $sformatf("\n\t ----| DATA_in1: %h ", data[1][31:0]), UVM_MEDIUM)
+    `uvm_info(`gfn, $sformatf("\n\t ----| DATA_in2: %h ", data[2][31:0]), UVM_MEDIUM)
+    `uvm_info(`gfn, $sformatf("\n\t ----| DATA_in3: %h ", data[3][31:0]), UVM_MEDIUM)
     csr_wr(.csr(ral.data_in0), .value(data[0][31:0]) );
     csr_wr(.csr(ral.data_in1), .value(data[1][31:0]) );
     csr_wr(.csr(ral.data_in2), .value(data[2][31:0]) );
     csr_wr(.csr(ral.data_in3), .value(data[3][31:0]) );
+  endtask // add_data
+
+
+  virtual task read_data(ref bit [3:0] [31:0] cypher_txt);
+    csr_rd(.ptr(ral.data_out0), .value(cypher_txt[0][31:0]));
+    csr_rd(.ptr(ral.data_out1), .value(cypher_txt[1][31:0]));
+    csr_rd(.ptr(ral.data_out2), .value(cypher_txt[2][31:0]));
+    csr_rd(.ptr(ral.data_out3), .value(cypher_txt[3][31:0]));
+
+    `uvm_info(`gfn, $sformatf("\n\t ----| READ OUPUT DATA"), UVM_MEDIUM)
+    `uvm_info(`gfn, $sformatf("\n\t ----| ADDING DATA TO DUT %h ", cypher_txt),  UVM_MEDIUM)
+    `uvm_info(`gfn, $sformatf("\n\t ----| DATA_out0: %h ", cypher_txt[0][31:0]), UVM_MEDIUM)
+    `uvm_info(`gfn, $sformatf("\n\t ----| DATA_out1: %h ", cypher_txt[1][31:0]), UVM_MEDIUM)
+    `uvm_info(`gfn, $sformatf("\n\t ----| DATA_out2: %h ", cypher_txt[2][31:0]), UVM_MEDIUM)
+    `uvm_info(`gfn, $sformatf("\n\t ----| DATA_out3: %h ", cypher_txt[3][31:0]), UVM_MEDIUM)
   endtask
 
 
@@ -113,45 +132,32 @@ class aes_base_vseq extends cip_base_vseq #(
   // ADVANCED TASKS                    //
   ///////////////////////////////////////
 
-  virtual task read_data(ref bit [3:0] [31:0] cypher_txt);
-    bit [3:0] [31:0] rd_txt;
-
-    `uvm_info(`gfn, $sformatf("\n\t ----| POLLING FOR DATA"), UVM_DEBUG)
-    csr_spinwait(.ptr(ral.status.output_valid) , .exp_data(1'b1));    // poll for data valid
-
-    csr_rd(.ptr(ral.data_out0), .value(cypher_txt[0][31:0]));
-    csr_rd(.ptr(ral.data_out1), .value(cypher_txt[1][31:0]));
-    csr_rd(.ptr(ral.data_out2), .value(cypher_txt[2][31:0]));
-    csr_rd(.ptr(ral.data_out3), .value(cypher_txt[3][31:0]));
-
-    `uvm_info(`gfn, $sformatf("\n\t ----| READ OUPUT DATA"), UVM_MEDIUM)
-    `uvm_info(`gfn, $sformatf("\n\t ----| ADDING DATA TO DUT %h ", cypher_txt),  UVM_HIGH)
-    `uvm_info(`gfn, $sformatf("\n\t ----| DATA_out0: %h ", cypher_txt[0][31:0]), UVM_HIGH)
-    `uvm_info(`gfn, $sformatf("\n\t ----| DATA_out1: %h ", cypher_txt[1][31:0]), UVM_HIGH)
-    `uvm_info(`gfn, $sformatf("\n\t ----| DATA_out2: %h ", cypher_txt[2][31:0]), UVM_HIGH)
-    `uvm_info(`gfn, $sformatf("\n\t ----| DATA_out3: %h ", cypher_txt[3][31:0]), UVM_HIGH)       
-  endtask
-
 
   virtual task setup_dut(aes_seq_item item);
+    //CTRL reg
     set_operation(item.operation);
     set_mode(item.mode);
     set_key_len(item.key_len);
-    write_key(item.key);
-    write_iv(item.iv);
+    set_manual_operation(item.manual_op);
+    if(!cfg.random_data_key_iv_order) begin
+      write_key(item.key);
+      if ( item.mode != AES_ECB) write_iv(item.iv);
+    end
   endtask
 
 
-  // TODO add missing functions
   virtual task generate_aes_item_queue(ref aes_message_item msg_item);
-    aes_seq_item item_clone;
 
+    // init aes item
+    aes_item_init(msg_item);
     // generate DUT cfg
-    aes_ctrl_item_init(msg_item);
+    generate_ctrl_item();
     generate_data_stream(msg_item);
 
+    // TODO
     // aes_generate_err_inj();
 
+    // TODO
     // aes_generate_rnd_rst();
 
     aes_print_item_queue(aes_item_queue);
@@ -161,11 +167,18 @@ class aes_base_vseq extends cip_base_vseq #(
   virtual task generate_data_stream(ref aes_message_item msg_item);
     aes_seq_item item_clone;
 
+    aes_item.item_type = AES_DATA;
+
     // generate an item for each 128b message block
+    `uvm_info(`gfn, $sformatf("\n\t ----| FIXED DATA ENABLED? : %0b", msg_item.fixed_data_en), UVM_LOW)
     for (int n=0; n<msg_item.message_length - 15; n += 16 ) begin
-      `DV_CHECK_RANDOMIZE_FATAL(aes_item)
-      aes_item.item_type = AES_DATA;
-      `uvm_info(`gfn, $sformatf("\n ----| DATA AES ITEM %s", aes_item.convert2string()), UVM_FULL)
+      if(msg_item.fixed_data_en) begin
+        `DV_CHECK_RANDOMIZE_WITH_FATAL(aes_item, data_in == msg_item.fixed_data; )
+      end else begin
+        `DV_CHECK_RANDOMIZE_FATAL(aes_item)
+      end
+
+      `uvm_info(`gfn, $sformatf("\n ----| DATA AES ITEM %s", aes_item.convert2string()), UVM_MEDIUM)
       `downcast(item_clone, aes_item.clone());
       aes_item_queue.push_front(item_clone);
       `uvm_info(`gfn, $sformatf("\n ----| generating data item %d", n), UVM_MEDIUM)
@@ -175,12 +188,52 @@ class aes_base_vseq extends cip_base_vseq #(
     if( msg_item.message_length[3:0] != 4'd0) begin
       `uvm_info(`gfn, $sformatf("\n ----| generating runt "), UVM_MEDIUM)
       aes_item.data_len = msg_item.message_length[3:0];
-      `DV_CHECK_RANDOMIZE_FATAL(aes_item)
+      if(msg_item.fixed_data_en) begin
+        `DV_CHECK_RANDOMIZE_WITH_FATAL(aes_item, data_in == msg_item.fixed_data; )
+      end else begin
+        `DV_CHECK_RANDOMIZE_FATAL(aes_item)
+      end
       aes_item.item_type = AES_DATA;
       `downcast(item_clone, aes_item.clone());
       aes_item_queue.push_front(item_clone);
     end
-  endtask
+  endtask // generate_data_stream
+
+
+  virtual task write_interleaved_data_key_iv( bit [7:0] [31:0] key, [3:0] [31:0] iv, [3:0] [31:0] data );
+    string txt="";
+    string interleave_queue[] = '{ "key0", "key1", "key2", "key3", "key4", "key5", "key6", "key7",
+                                   "data_in0", "data_in1", "data_in2", "data_in3",
+                                   "iv0", "iv1", "iv2", "iv3" };
+
+    interleave_queue.shuffle();
+
+   foreach ( interleave_queue[i] ) begin
+     txt = {txt, $sformatf("----|\n \t %s", interleave_queue[i]) };
+
+     case (interleave_queue[i])
+       "key0": csr_wr(.csr(ral.key0), .value(key[0]));
+       "key1": csr_wr(.csr(ral.key1), .value(key[1]));
+       "key2": csr_wr(.csr(ral.key2), .value(key[2]));
+       "key3": csr_wr(.csr(ral.key3), .value(key[3]));
+       "key4": csr_wr(.csr(ral.key4), .value(key[4]));
+       "key5": csr_wr(.csr(ral.key5), .value(key[5]));
+       "key6": csr_wr(.csr(ral.key6), .value(key[6]));
+       "key7": csr_wr(.csr(ral.key7), .value(key[7]));
+
+       "iv0": csr_wr(.csr(ral.iv0), .value(iv[0]));
+       "iv1": csr_wr(.csr(ral.iv1), .value(iv[1]));
+       "iv2": csr_wr(.csr(ral.iv2), .value(iv[2]));
+       "iv3": csr_wr(.csr(ral.iv3), .value(iv[3]));
+
+       "data_in0": csr_wr(.csr(ral.data_in0), .value(data[0][31:0]) );
+       "data_in1": csr_wr(.csr(ral.data_in1), .value(data[1][31:0]) );
+       "data_in2": csr_wr(.csr(ral.data_in2), .value(data[2][31:0]) );
+       "data_in3": csr_wr(.csr(ral.data_in3), .value(data[3][31:0]) );
+     endcase // case interleave_queue[i]
+   end
+    `uvm_info(`gfn, $sformatf("\n\t ----| Configuring the DUT in the following order:  %s",txt), UVM_MEDIUM)
+  endtask // write_interleaved_data_key_iv
 
 
   // TODO
@@ -192,36 +245,121 @@ class aes_base_vseq extends cip_base_vseq #(
   // endtask
 
 
-  // this function starst the transmission of items to the dut,
-  // while at the same time offloads the output when ready
+  // This function starts an operation and waits for the result of a block
+  // before proceeding with the next block
   virtual task transmit_message_with_rd_back();
     aes_seq_item nxt_item = new();
+    aes_seq_item last_item = new();
     nxt_item = aes_item_queue.pop_back();
-    setup_dut(aes_item);
+    setup_dut(nxt_item);
+
+    // interleave data key and IV in random matter
+    if ( cfg.random_data_key_iv_order) begin
+      last_item = nxt_item;
+      nxt_item = aes_item_queue.pop_back();
+      write_interleaved_data_key_iv(last_item.key, last_item.iv, nxt_item.data_in);
+
+      csr_spinwait(.ptr(ral.status.output_valid) , .exp_data(1'b1));    // poll for data valid
+      read_data(nxt_item.data_out);
+    end
 
     while(aes_item_queue.size() > 0) begin
       nxt_item = aes_item_queue.pop_back();
       add_data(nxt_item.data_in);
+
+      `uvm_info(`gfn, $sformatf("\n\t ----| POLLING FOR DATA"), UVM_DEBUG)
+      csr_spinwait(.ptr(ral.status.output_valid) , .exp_data(1'b1));    // poll for data valid
       read_data(nxt_item.data_out);
     end
 
   endtask // transmit_message_with_rd_back
 
+  // transmits data as fast as input ready is set
+  // readback happens with random delay
+  virtual task transmit_message_with_rand_rd_back();
+   // TODO
 
-  // TODO think about how to randomize error objects vs normal that
-  // are not randomized at this level!
-  function void aes_ctrl_item_init(ref aes_message_item message_item);
-    aes_seq_item item_clone;
+  endtask // transmit_message_with_rxd_back
+
+
+  // Transmit using manual mode of operation
+  // if errors are enabled it will overwrite output
+  // for some blocks (not read the output)
+  virtual task transmit_message_manual_op();
+    aes_seq_item nxt_item   = new();
+    aes_seq_item last_item  = new();
+    logic [31:0] status     = 32'd0;
+    bit   [31:0] num_blocks = 0;
+
+    if (aes_item_queue.size() < 1) begin
+      `uvm_fatal(`gfn, $sformatf("\n\t -| TRYING TO READ FROM AN EMPTY QUEUE |-"))
+    end
+    num_blocks = aes_item_queue.size() -1;  // subtract cfg item
+    nxt_item   = aes_item_queue.pop_back();
+
+    setup_dut(nxt_item);
+    `uvm_info(`gfn, $sformatf("\n\t ....| STARTING MANUAL OPERATION |...."), UVM_LOW)
+    if ( cfg.random_data_key_iv_order) begin
+      last_item = nxt_item;
+      nxt_item = aes_item_queue.pop_back();
+      write_interleaved_data_key_iv(last_item.key, last_item.iv, nxt_item.data_in);
+      trigger();
+    end
+
+    while(num_blocks > 0) begin // until all block has been processed and read out
+      `uvm_info(`gfn, $sformatf("\n\t ....| missing output from %d blocks |....",num_blocks), UVM_MEDIUM)
+
+      csr_rd(.ptr(ral.status), .value(status));
+      `uvm_info(`gfn, $sformatf("\n\t ....| POLLED STATUS %h |....",status), UVM_MEDIUM)
+      `uvm_info(`gfn, $sformatf("\n\t ....| blocks left in message %d |....",aes_item_queue.size()), UVM_MEDIUM)
+      // If the DUT is ready new input and also has new output
+      // this will produce the two request at the same time
+      // and leave it to the sequencer to arbritrate
+      // hence randomizing the order
+      fork
+        begin : write_next_block
+           if(status[3] &&  (aes_item_queue.size() >0)  ) begin
+             nxt_item = aes_item_queue.pop_back();
+             add_data(nxt_item.data_in);
+             trigger();
+           end
+        end
+
+        begin : read_output
+          if(status[2]) begin
+            read_data(nxt_item.data_out);
+            num_blocks -= 1;
+          end
+        end
+      join
+    end
+  endtask // transmit_message_with_rd_back
+
+
+  // initialize the global sequence item
+  // with values from the message item (happens once per message item
+  function void aes_item_init(ref aes_message_item message_item);
+
     aes_item = new();
-
-    `uvm_info(`gfn, $sformatf("\n Generating configuration item for message of size %d", message_item.message_length), UVM_MEDIUM)
-    `uvm_info(`gfn, $sformatf("\n Message \n %s", message_item.convert2string()), UVM_MEDIUM)
-
-    aes_item.item_type = AES_CFG;
     aes_item.operation = message_item.aes_operation;
     aes_item.mode      = message_item.aes_mode;
     aes_item.key_len   = message_item.aes_keylen;
     aes_item.key       = message_item.aes_key;
+    aes_item.iv        = message_item.aes_iv;
+    aes_item.manual_op = message_item.manual_operation;
+    aes_item.key_mask  = message_item.keymask;
+
+  endfunction // aes_item_init
+
+
+  // TODO think about how to randomize error objects vs normal that
+  // are not randomized at this level!
+  function void generate_ctrl_item();
+    aes_seq_item item_clone;
+
+    aes_item.item_type = AES_CFG;
+
+    `DV_CHECK_RANDOMIZE_FATAL(aes_item)
     `uvm_info(`gfn, $sformatf("----| CONFIG  AES ITEM %s", aes_item.convert2string()), UVM_MEDIUM)
 
     `downcast(item_clone, aes_item.clone());
@@ -232,16 +370,27 @@ class aes_base_vseq extends cip_base_vseq #(
   // init the first message - following will rerandomize with the same constraints
   function void aes_message_init();
     aes_message = new();
-    aes_message.ecb_weight        = cfg.ecb_weight;
-    aes_message.cbc_weight        = cfg.cbc_weight;
-    aes_message.ctr_weight        = cfg.ctr_weight;
-    aes_message.key_128b_weight   = cfg.key_128b_weight;
-    aes_message.key_192b_weight   = cfg.key_192b_weight;
-    aes_message.key_256b_weight   = cfg.key_256b_weight;
-    aes_message.message_len_max   = cfg.message_len_max;
-    aes_message.message_len_min   = cfg.message_len_min;
-    aes_message.config_error_pct  = cfg.config_error_pct;
-    aes_message.errors_en         = cfg.errors_en;
+    aes_message.ecb_weight           = cfg.ecb_weight;
+    aes_message.cbc_weight           = cfg.cbc_weight;
+    aes_message.ofb_weight           = cfg.ofb_weight;
+    aes_message.cfb_weight           = cfg.cfb_weight;
+    aes_message.ctr_weight           = cfg.ctr_weight;
+    aes_message.key_128b_weight      = cfg.key_128b_weight;
+    aes_message.key_192b_weight      = cfg.key_192b_weight;
+    aes_message.key_256b_weight      = cfg.key_256b_weight;
+    aes_message.message_len_max      = cfg.message_len_max;
+    aes_message.message_len_min      = cfg.message_len_min;
+    aes_message.config_error_pct     = cfg.config_error_pct;
+    aes_message.errors_en            = cfg.errors_en;
+    aes_message.manual_operation_pct = cfg.manual_operation_pct;
+    aes_message.keymask              = cfg.key_mask;
+    aes_message.fixed_key_en         = cfg.fixed_key_en;
+    aes_message.fixed_data_en        = cfg.fixed_data_en;
+    aes_message.fixed_operation_en   = cfg.fixed_operation_en;
+    aes_message.fixed_operation      = cfg.fixed_operation;
+    aes_message.fixed_keylen_en      = cfg.fixed_keylen_en;
+    aes_message.fixed_keylen         = cfg.fixed_keylen;
+    aes_message.fixed_iv_en          = cfg.fixed_iv_en;
   endfunction
 
 
@@ -254,6 +403,7 @@ class aes_base_vseq extends cip_base_vseq #(
       message_queue.push_front(cloned_message);
       `uvm_info(`gfn, $sformatf("\n message # %d \n %s",i, cloned_message.convert2string()), UVM_MEDIUM)
     end
+
   endfunction
 
 

--- a/hw/ip/aes/dv/env/seq_lib/aes_stress_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_stress_vseq.sv
@@ -24,8 +24,12 @@ class aes_stress_vseq extends aes_base_vseq;
       // for this message generate configuration
       // and data items (split message into blocks)
       generate_aes_item_queue(my_message);
-      // setup and transmit
-      transmit_message_with_rd_back();
+      // setup and transmit based on settings
+      if(my_message.manual_operation) begin
+        transmit_message_manual_op();
+      end else begin
+        transmit_message_with_rd_back();
+      end
     end
   endtask : body
 endclass

--- a/hw/ip/aes/dv/env/seq_lib/aes_wake_up_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_wake_up_vseq.sv
@@ -19,13 +19,13 @@ class aes_wake_up_vseq extends aes_base_vseq;
   bit [3:0] [31:0]    decrypted_text;
   logic [3:0] [31:0]  read_text;
   string              str="";
-  
+
 
   task body();
 
     `uvm_info(`gfn, $sformatf("STARTING AES SEQUENCE"), UVM_LOW)
-  
-    
+
+
     `DV_CHECK_RANDOMIZE_FATAL(this)
 
     `uvm_info(`gfn, $sformatf(" \n\t ---|setting operation to encrypt"), UVM_HIGH)
@@ -46,6 +46,7 @@ class aes_wake_up_vseq extends aes_base_vseq;
     `uvm_info(`gfn, $sformatf("\n\t ---| Polling for data register %s",
                               ral.status.convert2string()), UVM_DEBUG)
 
+    csr_spinwait(.ptr(ral.status.output_valid) , .exp_data(1'b1));
     read_data(cypher_text);
     // read output
     `uvm_info(`gfn, $sformatf("\n\t ------|WAIT 0 |-------"), UVM_HIGH)
@@ -65,7 +66,7 @@ class aes_wake_up_vseq extends aes_base_vseq;
               UVM_DEBUG)
 
     cfg.clk_rst_vif.wait_clks(20);
-
+    csr_spinwait(.ptr(ral.status.output_valid) , .exp_data(1'b1));
     read_data(decrypted_text);
     //need scoreboard disable
     foreach(plain_text[i]) begin
@@ -74,7 +75,7 @@ class aes_wake_up_vseq extends aes_base_vseq;
                         i, decrypted_text[i], plain_text[i]);
         `uvm_fatal(`gfn, $sformatf("%s",str));
       end
-    
+
     end
     foreach(decrypted_text[i]) begin
       `uvm_info(`gfn,

--- a/hw/ip/aes/dv/tests/aes_base_test.sv
+++ b/hw/ip/aes/dv/tests/aes_base_test.sv
@@ -15,21 +15,64 @@ class aes_base_test extends cip_base_test #(
    endfunction // build_phase
 
 
+
+  //this will serve as the default setting.
+  // overrides should happen in the specific testcase.
   virtual function void configure_env();
     // cfg.ref_model          = OpenSSL;
-    // env related knobs
 
-    cfg.errors_en          = 0;
-    cfg.num_messages_min   = 3;
-    cfg.num_messages_max   = 3;
-    // message related knobs
-    cfg.ecb_weight         = 100;
-    cfg.cbc_weight         = 0;
-    cfg.ctr_weight         = 0;
-    cfg.message_len_min    = 1;   // bytes
-    cfg.message_len_max    = 599; // bytes
-    `DV_CHECK_RANDOMIZE_FATAL(cfg)
+    cfg.num_messages_min            = 1;
+    cfg.num_messages_max            = 31;
+    cfg.message_len_min             = 1;
+    cfg.message_len_max             = 599;
+    cfg.use_key_mask                = 0;
+    cfg.use_c_model_pct             = 0;
+    cfg.errors_en                   = 0;
+  // clear registers with 0's or rand
+    cfg.clear_reg_w_rand            = 1;
+  // if set the order of which key iv and data is written will be randomized and interleaved
+    cfg.random_data_key_iv_order    = 1;
+
+  // Mode distribution //
+  // chance of selection ecb_mode
+  // ecb_mode /(ecb_mode + cbc_mode + ctr_mode + cfb_mode + ofb_mode)
+  // with the defaults 10/50 = 1/5 (20%)
+    cfg.ecb_weight                 = 10;
+    cfg.cbc_weight                 = 10;
+    cfg.ofb_weight                 = 10;
+    cfg.cfb_weight                 = 10;
+    cfg.ctr_weight                 = 10;
+
+  // KEYLEN weights
+  // change of selecting 128b key
+  //  128b/(128+192+256) = 10/30 = (33%)
+    cfg.key_128b_weight            = 10;
+    cfg.key_192b_weight            = 10;
+    cfg.key_256b_weight            = 10;
+
+  // use manual operation mode percentage
+    cfg.manual_operation_pct       = 10;
+
+  // debug / directed test knobs //
+  // use fixed key
+    cfg.fixed_key_en                = 0;
+  // use fixed data (same data for each block in a message
+    cfg.fixed_data_en               = 0;
+  // fixed operation (enc or dec)
+    cfg.fixed_operation_en          = 0;
+    cfg.fixed_operation             = 1'b0;
+  // fixed iv (will set all to 0)
+    cfg.fixed_iv_en                 = 0;
+    cfg.fixed_keylen_en             = 0;
+    cfg.fixed_keylen                = 3'b001;
+
+  //    1: error type enabled, 0: error type disabled
+  //  001: configuration errors
+  //  010: malicous injection
+  //  100: random resets
+    cfg.error_types                 = 3'b111;
+
+    cfg.config_error_pct            = 0;           // percentage of configuration errors
+ `DV_CHECK_RANDOMIZE_FATAL(cfg)
   endfunction
-
-
 endclass : aes_base_test

--- a/hw/ip/aes/dv/tests/aes_sanity_test.sv
+++ b/hw/ip/aes/dv/tests/aes_sanity_test.sv
@@ -13,16 +13,34 @@ class aes_sanity_test extends aes_base_test;
   endfunction
 
   function void configure_env();
-     super.configure_env();
-     cfg.errors_en          = 0;     // no errors in sanity test
-     cfg.num_messages_min   = 2;
-     cfg.num_messages_max   = 2;
-     // message related knobs
-     cfg.ecb_weight         = 100;   // only eCB
-     cfg.cbc_weight         = 0;
-     cfg.ctr_weight         = 0;
-     cfg.message_len_min    = 16;    // one block (16bytes=128bits)
-     cfg.message_len_max    = 16;    //
+    super.configure_env();
+    cfg.errors_en                = 0;     // no errors in sanity test
+    cfg.num_messages_min         = 2;
+    cfg.num_messages_max         = 2;
+    // message related knobs
+    cfg.ecb_weight               = 10;
+    cfg.cbc_weight               = 10;
+    cfg.ctr_weight               = 10;
+    cfg.ofb_weight               = 10;
+    cfg.cfb_weight               = 10;
+
+    cfg.message_len_min          = 16;    // one block (16bytes=128bits)
+    cfg.message_len_max          = 32;    //
+    cfg.manual_operation_pct     = 0;
+    cfg.use_key_mask             = 0;
+
+    cfg.fixed_data_en            = 0;
+    cfg.fixed_key_en             = 0;
+
+    cfg.fixed_operation_en       = 0;
+    cfg.fixed_operation          = 0;
+
+    cfg.fixed_keylen_en          = 0;
+    cfg.fixed_keylen             = 3'b001;
+
+    cfg.fixed_iv_en              = 0;
+
+    cfg.random_data_key_iv_order = 0;
 
     `DV_CHECK_RANDOMIZE_FATAL(cfg)
   endfunction

--- a/hw/ip/aes/dv/tests/aes_stress_test.sv
+++ b/hw/ip/aes/dv/tests/aes_stress_test.sv
@@ -15,15 +15,34 @@ class aes_stress_test extends aes_base_test;
     //   cfg.ref_model          = OpenSSL;
     // env related knobs
 
-    cfg.errors_en          = 0;
-    cfg.num_messages_min   = 5;
-    cfg.num_messages_max   = 5;
+    cfg.errors_en                = 0;
+    cfg.num_messages_min         = 1;
+    cfg.num_messages_max         = 50;
     // message related knobs
-    cfg.ecb_weight         = 10;
-    cfg.cbc_weight         = 40;
-    cfg.ctr_weight         = 40;
-    cfg.message_len_min    = 7;   // bytes
-    cfg.message_len_max    = 251; // bytes
+    cfg.ecb_weight               = 10;
+    cfg.cbc_weight               = 10;
+    cfg.ctr_weight               = 10;
+    cfg.ofb_weight               = 10;
+    cfg.cfb_weight               = 10;
+
+    cfg.message_len_min          = 7;   // bytes
+    cfg.message_len_max          = 1023; // bytes
+
+    cfg.fixed_data_en            = 0;
+    cfg.fixed_key_en             = 0;
+
+    cfg.fixed_operation_en       = 0;
+    cfg.fixed_operation          = 0;
+
+    cfg.fixed_keylen_en          = 0;
+    cfg.fixed_keylen             = 3'b010;
+
+    cfg.fixed_iv_en              = 0;
+
+    cfg.random_data_key_iv_order = 1;
+
+    cfg.manual_operation_pct     = 30;
+
     `DV_CHECK_RANDOMIZE_FATAL(cfg)
   endfunction
 endclass : aes_stress_test

--- a/hw/ip/aes/dv/tests/aes_wake_up_test.sv
+++ b/hw/ip/aes/dv/tests/aes_wake_up_test.sv
@@ -13,13 +13,12 @@ class aes_wake_up_test extends aes_base_test;
   endfunction
 
   virtual function void configure_env();
-    // cfg.en_scb = 0;
      cfg.ecb_weight         = 100;
      cfg.cbc_weight         = 0;
      cfg.ctr_weight         = 0;
      cfg.num_messages_min   = 2;
      cfg.num_messages_max   = 2;
-
+     cfg.errors_en          = 0;
     `DV_CHECK_RANDOMIZE_FATAL(cfg)
   endfunction
 endclass : aes_wake_up_test


### PR DESCRIPTION
This PR is adds Manual mode to the tested functionality along with randomized writing to data/IV/and Key registers
it also adds a task that forces the sequencer to arbitrate between TL reads and writes to the DUT.

This was originally several commits but a rebase when all wrong and doubled some of the commits so I accidently squashed some that wasn't supposed to be squashed and kept some that had half a change in it.
the easy thing was to create a single commit rather than playing with reflog.