### PR TITLE
[dvsim] Change cores-root to avoid conflicts with autogen'd core files

### DIFF
--- a/hw/dv/data/fusesoc.hjson
+++ b/hw/dv/data/fusesoc.hjson
@@ -10,7 +10,7 @@
                        "--target=sim",
                        "--build-root={build_dir}",
                        "--setup {fusesoc_core}"]
-  fusesoc_cores_root_dirs: ["--cores-root {proj_root}"]
+  fusesoc_cores_root_dirs: ["--cores-root {proj_root}/hw"]
   sv_flist_gen_dir:   "{build_dir}/sim-vcs"
   sv_flist:           "{sv_flist_gen_dir}/{fusesoc_core_}.scr"
 }

--- a/hw/formal/data/common_fpv_cfg.hjson
+++ b/hw/formal/data/common_fpv_cfg.hjson
@@ -18,7 +18,7 @@
 
   // TODO: switch the tool to formal once the corresponding edalize backend is avaiable
 
-  sv_flist_gen_opts: ["--cores-root {proj_root}",
+  sv_flist_gen_opts: ["--cores-root {proj_root}/hw",
                       "run",
                       "--flag=fileset_{design_level}",
                       "--tool=icarus",

--- a/hw/lint/data/common_lint_cfg.hjson
+++ b/hw/lint/data/common_lint_cfg.hjson
@@ -18,7 +18,7 @@
   build_log:  "{build_dir}/lint.log"
   // We rely on fusesoc to run lint for us
   build_cmd:  "fusesoc"
-  build_opts: ["--cores-root {proj_root}",
+  build_opts: ["--cores-root {proj_root}/hw",
                "run",
                "--flag=fileset_{design_level}",
                "--target={flow}",

--- a/hw/syn/data/common_syn_cfg.hjson
+++ b/hw/syn/data/common_syn_cfg.hjson
@@ -22,7 +22,7 @@
   fusesoc_core_:      "{eval_cmd} echo \"{fusesoc_core}\" | tr ':' '_'"
 
   // TODO: switch the tool to dc once the corresponding edalize backend is available
-  sv_flist_gen_opts:  ["--cores-root {proj_root}",
+  sv_flist_gen_opts:  ["--cores-root {proj_root}/hw",
                        "run"
                        "--flag=fileset_{design_level}",
                        "--target={flow}",


### PR DESCRIPTION
The `$SCRATCH_ROOT` defaults to `$PROJ_ROOT/scratch` the way we invoke dvsim, if `$SCRATCH_ROOT` is not defined. This may cause core file conflicts with autogen'd core files in that build scratch, since all dvsim flows use `$PROJ_ROOT` as the `cores-root` path. This patch changes the `cores-root` to `$PROJ_ROOT/hw` to avoid that from happending.

Fix #3049

Signed-off-by: Michael Schaffner <msf@opentitan.org>