### PR TITLE
[packer] Revise the implementation

### DIFF
--- a/hw/ip/hmac/rtl/hmac.sv
+++ b/hw/ip/hmac/rtl/hmac.sv
@@ -259,7 +259,7 @@ module hmac
 
   prim_fifo_sync #(
     .Width   ($bits(sha_fifo_t)),
-    .Pass    (1'b0),
+    .Pass    (1'b1),
     .Depth   (MsgFifoDepth)
   ) u_msg_fifo (
     .clk_i,

--- a/hw/ip/hmac/rtl/sha2_pad.sv
+++ b/hw/ip/hmac/rtl/sha2_pad.sv
@@ -309,8 +309,4 @@ module sha2_pad import hmac_pkg::*; (
   // State machine is in Idle only when it meets tx_count == message length
   assign msg_feed_complete = hash_process_flag && (st_q == StIdle);
 
-  // When fifo_partial, fifo shouldn't be empty and hash_process was set
-  `ASSERT(ValidPartialConditionAssert,
-          fifo_partial && fifo_rvalid |-> hash_process_flag)
-
 endmodule


### PR DESCRIPTION
Previous prim_packer focused on to reduce register FF usage. On the side
effect, it creates the timing path from valid_i --> ready_o, ready_i -->
ready_o, and valid_i --> valid_o.

Now the ready_o and valid_i is computed based on the current storage
condition, which results in the valid_o asserting at the next cycle of
valid_i earliest.

Current implementation also doesn't maximize the storage utilization
when mask_i is not full 1.

**Note**: Debugging HMAC test failure now.