### PR TITLE
[lint] Minor update of ERROR patterns in parser script

### DIFF
--- a/hw/lint/tools/ascentlint/parse-lint-report.py
+++ b/hw/lint/tools/ascentlint/parse-lint-report.py
@@ -44,6 +44,7 @@ def get_results(resdir):
             full_file = f.read()
             err_warn_patterns = [("errors", r"^FlexNet Licensing error.*"),
                                  ("errors", r"^Error: .*"),
+                                 ("errors", r"^ERROR.*"),
                                  ("errors", r"^  ERR .*"),
                                  ("warnings", r"^Warning: .*"),
                                  ("warnings", r"^  WARN .*")]


### PR DESCRIPTION
I came across a new error pattern (due to waiver regexp that cannot be compiled). These messages have a different signature, hence the filter update.

Signed-off-by: Michael Schaffner <msf@google.com>