### PR TITLE
[dvsim] Update `tests` key behavior in regressions

### DIFF
--- a/hw/dv/data/common_sim_cfg.hjson
+++ b/hw/dv/data/common_sim_cfg.hjson
@@ -109,23 +109,21 @@
   regressions: [
     {
       name: sanity
+      tests: []
       reseed: 1
     }
 
     {
       name: all
-      tests: []
     }
 
     {
       name: all_once
       reseed: 1
-      tests: []
     }
 
     {
       name: nightly
-      tests: []
       en_sim_modes: ["cov"]
     }
   ]

--- a/util/dvsim/Modes.py
+++ b/util/dvsim/Modes.py
@@ -84,7 +84,7 @@ class Modes():
             self_attr_val = getattr(self, attr)
             mode_attr_val = getattr(mode, attr)
 
-            if type(self_attr_val) is list:
+            if type(self_attr_val) is list and type(mode_attr_val) is list:
                 self_attr_val.extend(mode_attr_val)
                 setattr(self, attr, self_attr_val)
 
@@ -422,7 +422,7 @@ class Regressions(Modes):
         self.type = ""
         if not hasattr(self, "mname"):
             self.mname = "regression"
-        self.tests = []
+        self.tests = None
         self.reseed = None
         self.test_names = []
         self.excl_tests = []  # TODO: add support for this
@@ -520,7 +520,7 @@ class Regressions(Modes):
                 regression_obj.run_opts.extend(run_mode_obj.run_opts)
 
             # Unpack tests
-            if regression_obj.tests == []:
+            if regression_obj.tests is None:
                 log.log(VERBOSE,
                         "Unpacking all tests in scope for regression \"%s\"",
                         regression_obj.name)


### PR DESCRIPTION
This was encountered in #3040. The `common_sim_cfg.hjson` adds a
`sanity` regression target without specifying the `tests` key, with the
assumption that each individual IP's cfg hjson will update the `sanity`
regression with the required list of tests. In PR #3040, the sanity
tests in some of the IPs had to be commented out due to some other
issues. But on doing so, running `sanity` regression ended up adding ALL
available tests for regression for that particular DUT, since the `tests`
key remained empty list (originally intended behavior). This caused the
private CI to blow past the 20 minute time limit and fail. This PR fixes
that behavior. 

Previous behavior of the `tests` key was as follows:
- `tests` member of class `Regression` in `Modes.py` defaulted to empty
  list
- If in regressions (in the hjson), it continues to remain an empty
  list after all hjson source are parsed, then ALL available tests are
  run

New behavior is as follows:
- `tests` member of class `Regression` in `Modes.py` now defaults to
  `None`
- If in regressions (in the hjson) it is set to an empty list, and
  eventually remains an empty list after all hjson sources are parsed,
  then no tests are run
- If in regressions (in the hjson) it is entirely omitted, such that
  after all hjson sources are parsed, it continues to hold the value of
  `None`, then ALL available tests are run

Signed-off-by: Srikrishna Iyer <sriyer@google.com>