### PR TITLE
[rom_ext] Initial ROM_EXT Manifest Format

### DIFF
--- a/sw/device/mask_rom/boot.md
+++ b/sw/device/mask_rom/boot.md
@@ -220,15 +220,18 @@ read_boot_policy() {
 
 This manages reading and parsing ROM_EXT manifests.
 
+The manifest format is defined in [ROM_EXT Manifest Format](../rom_exts/manifest)
+
 DIFs Needed:
 
-*   Flash Controller
+*   None. This is read out of flash using ibex loads/stores.
 
 Milestone Expectations:
 
-*   *v0.5:* Chosen Manifest, Reading Manifest,
-    Tooling to assemble ROM_EXT image with Manifest,
-    Tooling to ensure ROM_EXT is loaded at boot.
+*   *v0.5:* Initial Manifest Format, Initial Parser, Simple Tooling for
+    assembling ROM_EXT Slot A images.
+*   *v0.7:* Tooling to ensure ROM_EXT is loaded at boot. Tooling for assembling
+    Slot B images.
 *   v0.9: Nothing more (Bootstrap should work in v0.9).
 
 ### Bootstrap

--- a/sw/device/meson.build
+++ b/sw/device/meson.build
@@ -32,6 +32,7 @@ export_embedded_target = [
 
 subdir('boot_rom')
 subdir('mask_rom')
+subdir('rom_exts')
 subdir('examples')
 subdir('sca')
 subdir('tests')

--- a/sw/device/rom_exts/manifest.md
+++ b/sw/device/rom_exts/manifest.md
@@ -1,0 +1,349 @@
+# ROM_EXT Manifest Format
+
+Based on the requirements outlined in [boot.md](./boot)
+
+```
+ 0                   1                   2                   3
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                  ROM_EXT Manifest Identifier                  |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                            Reserved                           |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                                                               |
++                                                               +
+|                                                               |
++                  Image Signature (3072 bits)                  +
+|                                                               |
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  break  ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+|                                                               |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                          Image Length                         |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                         Image Version                         |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                                                               |
++                        Image Timestamp                        +
+|                                                               |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                 Signature Algorithm Identifier                |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                       Signature Exponent                      |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                    Usage Constraints (TBC)                    |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                            Reserved                           |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                                                               |
++                                                               +
+|                                                               |
++                   Software Binding Tag (TBC)                  +
+|                                                               |
++                                                               +
+|                                                               |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                                                               |
++                                                               +
+|                                                               |
++                 Peripheral Lockdown Info (TBC)                +
+|                                                               |
++                                                               +
+|                                                               |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                                                               |
++                                                               +
+|                                                               |
++                Signature Public Key (3072 bits)               +
+|                                                               |
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  break  ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+|                                                               |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                       Extension0 Offset                       |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                      Extension0 Checksum                      |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                       Extension1 Offset                       |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                      Extension1 Checksum                      |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                       Extension2 Offset                       |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                      Extension2 Checksum                      |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                       Extension3 Offset                       |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                      Extension3 Checksum                      |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                                                               |
++                                                               +
+|                                                               |
++                           Code Image                          +
+|                                                               |
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  break  ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+|                                                               |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+```
+
+Notes:
+
+*   All Offsets in the manifest are specified in bytes from the beginning of the
+    `ROM_EXT Manifest Identifier` field.
+
+*   All numeric and enumeration field values are stored little-endian. Fields
+    below are noted as one of:
+
+    *   a N-bit (signed or unsigned) numeric value;
+    *   a N-bit enumeration value;
+    *   a sequence of N-bit (signed or unsigned) numeric values; or
+    *   a sequence of bytes.
+
+    All numeric and enumeration values are stored little-endian.
+
+    A byte only ever means an 8-bit data value, whose interpretation is
+    undefined.
+
+*   All fields below are 32-bit (4-byte) aligned unless otherwise specified.
+
+    **Open Q**: The ordering below is still subject to alignment requirements
+    for different fields, and may change in future.
+
+*   The `Image Signature`, `ROM_EXT Signature Public Key` and `Image` are not
+    shown to scale. This is denoted using `~~~ break ~~~` lines, which specify a
+    truncation of field size displayed in the diagram, not that a new field has
+    started.
+
+    *   The Signature and Public Key are each 3072 bits long (they are
+        notionally `int32_t[96]`s).
+
+    *   The Code Image itself is variable length, where the length of the entire
+        image (including the manifest) is given in the `Length` field.
+
+*   Reserved areas are not documented below. Conforming implementations will not
+    parse these fields, but will produce images where those bits are all zero.
+    Reserved areas remain read-only, as they are signed as part of the image.
+    Updating these fields will fail validation.
+
+    Reserved fields have fixed size and unspecified alignment.
+
+## Field Descriptions
+
+1.  **ROM_EXT Manifest Identifier** This is a 32-bit enumeration value which is
+    used by the Mask ROM to identify that an image with the above format is
+    resident in flash. A particular Mask ROM version can only parse one ROM_EXT
+    image format, there is no expected support for differing behaviour based on
+    this field, beyond erroring when ROM_EXT images are missing from flash
+    storage.
+
+    This is used by any ROM_EXT image parsers to identify a ROM_EXT image.
+
+1.  **Image Signature** This is a RSA 3k signature of all the fields that follow
+    the signature. This a sequence of 32-bit values. There is no data in the
+    image which is not signed, except the signature itself and the ROM_EXT
+    manifest identifier.
+
+    This is used by the Mask ROM during secure boot to validate that a ROM_EXT
+    image has been produced by a Silicon Creator for this chip. This is also
+    validated at other times, including during firmware update.
+
+    If the image signature is a sequence of all zeroes, the image is unsigned.
+    Unsigned images **must not** be booted.
+
+1.  **Image Length** This denotes the Offset of the end of the image, in bytes.
+    As with other offsets, this is calculated from the start of the `ROM_EXT
+    Manifest Identifier` field. This is a 32-bit unsigned numeric value.
+
+    This is used when signing, validating, and loading the image. This happens
+    in the Mask ROM, as well as during firmware update.
+
+1.  **Image Version** This is a version number for the ROM_EXT image. It
+    is a 32-bit unsigned numeric value.
+
+    **Open Q** How will we use this?
+
+1.  **Image Timestamp** This is a Unix Timestamp describing when the ROM_EXT
+    image was prepared, in seconds since 00:00:00 UTC on 1 January 1970 (the
+    Unix Epoch). This is a 64-bit signed numeric value.
+
+    This is not used by the Mask ROM when validating the image.
+
+    *Alignment* This is 64-bit aligned.
+
+1.  **Signature Algorithm Identifier** This identifies which algorithm has been
+    used to sign the ROM_EXT Image. This is a 32-bit enumeration value.
+
+    **Open Q**: Are we supporting multiple signing algorithms for ROM_EXTs? This
+    complicates the Mask ROM significantly.
+
+    `0x0` denotes an unsigned image. Unsigned images **must not** be booted.
+
+    This is used when signing and validating the image. This happens in the
+    Mask ROM, as well as during firmware update.
+
+1.  **Signature Exponent** This is the RSA exponent to be used during the RSA
+    3K Signature Scheme. This is a 32-bit numeric value.
+
+    This is used when signing and validating the image. This happens in the
+    Mask ROM, as well as during firmware update.
+
+1.  **Usage Constraints** This is a 32-bit enumeration value which denotes what
+    kinds of devices the ROM_EXT image may be used on.
+
+    This is used by the Mask ROM to validate the image is running on the right
+    kind of hardware.
+
+    **Open Q** What possible values should this have?
+
+1.  **Software Binding Tag** This is a 128-bit enumeration value which is used
+    so the software helps to seed CreatorRootKey.
+
+    **Open Q** Is this the right size?
+
+    This is separate from the *Image Version* and the *Image Signature*, so that
+    images can be updated and still derive the same CreatorRootKey.
+
+    This is used by the Mask ROM as an input for the key manager.
+
+    **Open Q** Required Alignment. Assuming 32-bit for the moment.
+
+1.  **Peripheral Lockdown Info** This is a 128-bit value which describes how
+    some peripherals should be configured, before the write-enable bits for
+    their configuration registers are cleared.
+
+    This is used by the Mask ROM to configure specific peripherals (including,
+    for example, pinmux and padctrl), in such a way that their configuration
+    cannot be updated by the ROM_EXT or any other later firmware.
+
+    **Open Q** We don't have inifnite space for this, so what configurations
+    might we want to make and then lock?
+
+    **Open Q** Required Alignment. Assuming 32-bit for the moment. We're
+    currently tight for space, so this may turn into an Offset to later in the
+    image.
+
+1.  **Signature Public Key** This is a RSA 3k public key, as used by the image
+    signature. This is a sequence of 32-bit values.
+
+    This is used when signing and validating the image. This happens in the
+    Mask ROM, as well as during firmware update.
+
+1.  **Extensions** This is a sequence of 4 `(Offset, Checksum)` pairs. These
+    allow for the ROM_EXT manifest format to be extended without redesigning the
+    manifest entirely.
+
+    Extensions are ignored by the Mask ROM. They may be parsed by the ROM_EXT
+    itself and any later firmware stages.
+
+    The Offset field denotes the byte offset in the image (including the
+    manifest) where the extension can be found. The length of the respective
+    data is defined by the extension itself (it can have either a static or
+    variable length), but the manifest includes a Checksum field which must be
+    used to store a checksum of the extension's data, using CRC32.
+
+    Each Offset field is a 32-bit unsigned numeric value. Each Checksum field is
+    a 32-bit numeric value.
+
+    **Open Q** It makes sense, once we fully understand the alignment
+    requirements, to fill the rest of the manifest with these pairs, so we may
+    end with more than 4 of these entries in the first production Mask ROM.
+
+    These extensions will not be allocated in the initial version of the
+    ROM_EXT. Once an Extension slot has an allocated use, it will not be used
+    for any other use, for a given Manifest Image Identifier. In this way, the
+    Identifier also works as a versioning token for the manifest format.
+
+    These fields should be treated as Reserved until they are allocated.
+
+1.  **Code Image** This is a sequence of bytes that make up the code and data of
+    the ROM_EXT image. This data will include any data required for Extensions.
+
+    **Execution begins** at the address 128 bytes beyond the first 256-byte aligned
+    offset at the start of the ROM_EXT code image (measuring the offset from the
+    start of the ROM_EXT image). This leaves the possibility of the Mask ROM
+    initializing `mtvec` with the first 256-byte aligned offset in the ROM_EXT
+    code image, before jumping into ROM_EXT code. This matches how Ibex boots.
+
+    The total manifest length is currently 872 bytes, so the first valid mtvec
+    address is at offset `0x400` (1024) bytes from the beginning of the ROM_EXT
+    image, and the entry address is therefore `0x480`  (1152) bytes from the
+    beginning of the ROM_EXT image.
+
+    This does leave 152 bytes between the end of the manifest and the first
+    valid mtvec. It is up to the image as to how this is used--it could be used
+    for extension data or for routines. We could also reserve this space so the
+    manifest can be extended later, but this is the intention of the Extension
+    entries.
+
+    **Open Q** Do we want to relax the requirement to match how ibex boots? It
+    makes sense to me to have a static entry address
+
+### Data Not in the Header
+
+*   `.data` + `.bss` section sizes, for establishing PMP regions. The PMP
+    regions should be established by the ROM_EXT image as it sets up its own
+    execution. This is not the responsibility of Mask ROM, as of yet.
+
+*   `.idata` section offset, for copying initialization values into `.data`
+    section in RAM, as again, this is the responsibility of the ROM_EXT image,
+    not Mask ROM.
+
+## Development Versions (Subject to Change)
+
+**ROM_EXT Manifest Identifier**: `0x4552544F` (Reads "OTRE" when Disassembled --
+OpenTitan ROM_EXT)
+
+**Signature Algorithm Identifier**: `0x1` denotes RSA 3K.
+
+**Signature Exponent**: TBC
+
+**Signature Key Pair**: TBC. We will create a dummy key pair for development,
+but this will not be used in production software.
+
+**Extension Allocation**:
+
+Extension 0: Not Allocated
+
+Extension 1: Not Allocated
+
+Extension 2: Not Allocated
+
+Extension 3: Not Allocated
+
+
+## Software Deliverables
+
+*   A C Library for parsing/extracting this image format on-device.
+
+    This should take a Base Address, and parse using offsets from that, rather
+    than a fixed address at the start of flash. This is so we can parse both
+    ROM_EXT Slot A and Slot B using the same library.
+
+*   A linker script (and assembly files) that can create a ROM_EXT ELF file
+    containing all the code and data.
+
+    The aim is to use absolute addresses for the stack and any in-RAM data, so
+    that we end up mostly position-independent.
+
+    **Open Q**: The ROM_EXT may need to be told which address the current image
+    starts at when it boots.
+
+*   A developer utility for taking a ROM_EXT ELF file and turning it into
+    a correctly signed image for loading into either slot using the existing
+    spiflash utility. This utility should also be able to validate a signed
+    ROM_EXT image, to ensure that what we signed can be validated both on- and
+    off-device.
+
+    This utility will also have to take a Software Binding Tag and other
+    metadata as input, for injecting into the image. It should almost certainly
+    also create a receipt of the information it just signed, in a
+    machine-parseable format.
+
+*   (Potentially) a developer utility for assembling binary images that contain
+    the entire contents of flash (ROM_EXT + BL0 + Owner Firmware + Persisted
+    Data, for each of Slot A and B), for testing.
+
+**Open Q** There are lots of open questions about position-independent code
+issues and requirements, as we want to load the same image into Slot A or Slot
+B, without having to re-link or re-compile the image (note we only have one
+entry address). At least initially, we will only create images that can work
+from Slot A, and later we will add support ensuring these images are linked in
+a way that they can run from Slot B without modification.

--- a/sw/device/rom_exts/meson.build
+++ b/sw/device/rom_exts/meson.build
@@ -1,0 +1,48 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Mask ROM Linker Parameters
+#
+# See sw/device/exts/common/flash_link.ld for additional info about these
+# parameters.
+rom_ext_linkfile = files(['rom_ext.ld'])
+rom_ext_link_args = [
+  '-Wl,-L,@0@'.format(meson.source_root()),
+  '-Wl,-T,@0@/@1@'.format(meson.source_root(), rom_ext_linkfile[0]),
+  '-Wl,--build-id=none',
+]
+rom_ext_link_deps = [rom_ext_linkfile]
+
+foreach device_name, device_lib : sw_lib_arch_core_devices
+  rom_ext_elf = executable(
+    'rom_ext_' + device_name,
+    sources: [
+      'rom_ext_manifest.S',
+      'rom_ext_start.S',
+    ],
+    name_suffix: 'elf',
+    link_args: rom_ext_link_args,
+    link_depends: rom_ext_link_deps,
+    dependencies: [
+      device_lib,
+    ],
+  )
+
+  rom_ext_embedded = custom_target(
+    'rom_ext_' + device_name,
+    command: make_embedded_target,
+    input: rom_ext_elf,
+    output: make_embedded_target_outputs,
+    build_by_default: true,
+  )
+
+  custom_target(
+    'rom_ext_export_' + device_name,
+    command: export_embedded_target,
+    input: [rom_ext_elf, rom_ext_embedded],
+    output: 'rom_ext_export_' + device_name,
+    build_always_stale: true,
+    build_by_default: true,
+  )
+endforeach

--- a/sw/device/rom_exts/rom_ext.ld
+++ b/sw/device/rom_exts/rom_ext.ld
@@ -1,0 +1,206 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * Linker script for an OpenTitan ROM_EXT.
+ *
+ * Portions of this file are Ibex-specific.
+ *
+ * The ROM_EXT is actually kept in flash, rather than ROM. While a ROM_EXT can
+ * be loaded into either Slot A (the start of flash), or Slot B (the start of
+ * the upper half of flash), this linker script only targets Slot A, and we hope
+ * not to need to re-link our images for Slot B.
+ *
+ * TODO: Slot B Support, if needed.
+ */
+
+OUTPUT_ARCH(riscv)
+GROUP(-lgcc)
+
+/**
+ * Indicate that there are no dynamic libraries, whatsoever.
+ */
+__DYNAMIC = 0;
+
+INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+
+/* Reserving 32 bytes at the top of the RAM for test utils. */
+_test_reserved_size  = 0x20;
+_test_reserved_end   = ORIGIN(ram_main) + LENGTH(ram_main);
+_test_reserved_start = _test_reserved_end - _test_reserved_size;
+
+/* Reserving space near the top of the RAM for the stack. */
+_stack_size  = 0x2000 - _test_reserved_size;
+_stack_end   = _test_reserved_start;
+_stack_start = _stack_end - _stack_size;
+
+/**
+ * Marking the entrypoint correctly for the ELF file. In reality, we will end up
+ * using a hard-coded offset from the slot start, as we don't have the ELF info
+ * around once we have the image, and the entry offset is static in the image
+ * format.
+ */
+ENTRY(_rom_ext_start_boot)
+
+/**
+ * NOTE: We have to align each section to word boundaries as our current
+ * s19->slm conversion scripts are not able to handle non-word aligned sections.
+ */
+SECTIONS {
+  .rom_ext_manifest ORIGIN(eflash) : {
+    /* This is used to calculate the full image size, including the manifest. */
+    rom_ext_full_image_start = .;
+
+    KEEP(*(.rom_ext_manifest))
+  } > eflash
+
+  /**
+   * Ibex interrupt vector.
+   *
+   * This has to be set up at a 256-byte offset, so that we can use it with
+   * Ibex. This section includes the ROM_EXT entry address.
+   */
+  .vectors : ALIGN(256) {
+    KEEP(*(.vectors))
+  } > eflash
+
+  /**
+   * C runtime (CRT) section, containing program initialization code.
+   *
+   * This is a separate section to `.text` so that the jumps inside `.vectors`
+   * will fit into the instruction encoding.
+   */
+  .crt : ALIGN(4) {
+    KEEP(*(.crt))
+  } > eflash
+
+  /**
+   * Standard text section, containing program code.
+   */
+  .text : ALIGN(4) {
+    *(.text)
+    *(.text.*)
+  } > eflash
+
+  /**
+   * Read-only data section, containing all large compile-time constants, like
+   * strings.
+   */
+  .rodata : ALIGN(4) {
+    /* Small read-only data comes before regular read-only data for the same
+     * reasons as in the data section */
+    *(.srodata)
+    *(.srodata.*)
+    *(.rodata)
+    *(.rodata.*)
+  } > eflash
+
+  /**
+   * Mutable data section, at the bottom of ram_main. This will be initialized
+   * from flash at runtime by the CRT.
+   *
+   * Load this by copying the bytes from [_data_init_start, _data_init_end] into
+   * the range [_data_start, _data_end].
+   */
+  .data ORIGIN(ram_main) : ALIGN(4) {
+    _data_start = .;
+    _data_init_start = LOADADDR(.data);
+
+    /* This will get loaded into `gp`, and the linker will use that register for
+     * accessing data within [-2048,2047] of `__global_pointer$`.
+     *
+     * This is much cheaper (for small data) than materializing the
+     * address and loading from that (which will take one extra instruction).
+     */
+    __global_pointer$ = . + 2048;
+
+    /* Small data should come before larger data. This helps to ensure small
+     * globals are within 2048 bytes of the value of `gp`, making their accesses
+     * hopefully only take one instruction. */
+    *(.sdata)
+    *(.sdata.*)
+
+    /* Other data will likely need multiple instructions to load, so we're less
+     * concerned about address materialisation taking more than one instruction.
+     */
+    *(.data)
+    *(.data.*)
+
+    /* Ensure section end is word-aligned. */
+    . = ALIGN(4);
+    _data_end = .;
+    _data_init_end = LOADADDR(.data) + SIZEOF(.data);
+
+    /* This puts it in ram_main at runtime (for the VMA), but puts the section
+     * into flash for load time (for the LMA). This is why `_data_init_*` uses
+     * `LOADADDR`.
+     *
+     * Using `AT>` means we don't have to keep track of the next free part of
+     * flash, as we do in our other linker scripts. */
+  } > ram_main AT> eflash
+
+  /**
+   * Standard BSS section. This will be zeroed at runtime by the CRT.
+   */
+  .bss : ALIGN(4) {
+    _bss_start = .;
+
+    /* Small BSS comes before regular BSS for the same reasons as in the data
+     * section */
+    *(.sbss)
+    *(.sbss.*)
+    *(.bss)
+    *(.bss.*)
+
+    /* Any other uninitialized data. */
+    *(COMMON)
+
+    /* Ensure section end is word-aligned. */
+    . = ALIGN(4);
+    _bss_end = .;
+  } > ram_main
+
+  .rom_ext_end : ALIGN(4) {
+    /* This is the last part of the image that resides in flash, so we need to
+     * set `rom_ext_image_end` for the ROM_EXT manifest.
+     *
+     * If you add more sections to eflash, ensure they come before this section.
+     */
+    rom_ext_full_image_size = ABSOLUTE(. - rom_ext_image_start);
+  } > eflash
+
+  /**
+   * STAB debug table.
+   */
+  .stab 0x0 (NOLOAD): {
+    [.stab]
+  }
+
+  /**
+   * STAB debug strings.
+   */
+  .stabstr 0x0 (NOLOAD): {
+    [.stabstr]
+  }
+
+  /**
+   * The following sections are used by DV to implement logging in an
+   * alternate way, which enables simulation speed up by completely avoiding
+   * any string format processing or even the actual transmission of log data
+   * to a real peripheral.
+   *
+   * These sections are marked as dummy so that they can still be extracted
+   * using readelf or similar utilities. As such, the content in these sections
+   * is not relevant for the actual SW code and can be safely discarded.
+   */
+
+  /**
+   * The following section contains log fields constructed from the logs using
+   * the log_fields_t struct defined in sw/device/lib/base/log.h. The size of
+   * each log field is fixed - 20 bytes, which is used as the delimiter.
+   */
+  .logs.fields 0x0 (DSECT): {
+    *(.logs.fields)
+  }
+}

--- a/sw/device/rom_exts/rom_ext.ld
+++ b/sw/device/rom_exts/rom_ext.ld
@@ -49,9 +49,6 @@ ENTRY(_rom_ext_start_boot)
  */
 SECTIONS {
   .rom_ext_manifest ORIGIN(eflash) : {
-    /* This is used to calculate the full image size, including the manifest. */
-    rom_ext_full_image_start = .;
-
     KEEP(*(.rom_ext_manifest))
   } > eflash
 
@@ -161,13 +158,19 @@ SECTIONS {
     _bss_end = .;
   } > ram_main
 
+  /**
+   * ROM_EXT Image End Section.
+   *
+   * This is a dummy section required for correctly calculating the ROM_EXT
+   * image length, for the manifest. See the comments in `rom_ext_manifest.S`
+   * for more information.
+   *
+   * If you add more sections to eflash, ensure they come before this section.
+   *
+   * This section must be LOAD, or the image size won't be calculated correctly.
+   */
   .rom_ext_end : ALIGN(4) {
-    /* This is the last part of the image that resides in flash, so we need to
-     * set `rom_ext_image_end` for the ROM_EXT manifest.
-     *
-     * If you add more sections to eflash, ensure they come before this section.
-     */
-    rom_ext_full_image_size = ABSOLUTE(. - rom_ext_image_start);
+    KEEP(*(.rom_ext_end))
   } > eflash
 
   /**

--- a/sw/device/rom_exts/rom_ext_manifest.S
+++ b/sw/device/rom_exts/rom_ext_manifest.S
@@ -7,7 +7,6 @@
  */
   .section .rom_ext_manifest, "a"
 
-  .globl rom_ext_image_start
 rom_ext_image_start:
 
 // Constant
@@ -25,12 +24,11 @@ image_signature:
 
 // Everything beyond this point is signed.
 
-  .extern rom_ext_full_image_size
 // Calculated by linker
 image_length:
   // This should be the whole image length (of the flash part, including the
   // manifest).
-  .word rom_ext_full_image_size
+  .word (rom_ext_image_end - rom_ext_image_start)
 
 // Overriden by signing script
 image_version:
@@ -80,6 +78,41 @@ extensions:
   .word 0x0
   .endr
 
-  .globl image_code_contents
 // Code Image starts here
 image_code_contents:
+
+
+/**
+ * ROM_EXT Image End Section.
+ *
+ * We're having trouble with `objcopy` not honouring the FileSiz and MemSiz as
+ * given in the final elf, and we want the files to be produced as rounded to
+ * the next word-size up.
+ *
+ * The ELF Segments correctly reflect the FileSiz and MemSiz are rounded up by
+ * the ALIGN(4) directives in the linker script. However, in some cases, objcopy
+ * produces a binary file that is shorter than the segment FileSiz (this seems
+ * to happen when the last section that contains data does not have a size
+ * rounded to the next word-size). This is confusing and we don't want to have
+ * to pad the binary in post-processing, so instead we added this dummy section.
+ *
+ * The idea behind this section is that it must be word-sized, and word-aligned.
+ * It also provides a local symbol which can be used to calculate the whole
+ * image length. This symbol must come after some data in the section, or the
+ * padding word will not have the intended effect.
+ *
+ * We cannot do this in the linker script, as an output section in the linker
+ * script with only symbol and data definitions (and no input section
+ * inclusions) gets weird flags that we have no control over, which can lead to
+ * strange segment assignments. In an assembly file, we can specify section
+ * flags that will propagate in the linker script from the input section to the
+ * output section.
+ *
+ * The particular value of the dummy `.word` does not matter, but is included in
+ * the signed part of the image so will be validated by the signature.
+ */
+  .section .rom_ext_end, "a"
+  .p2align 2
+  .word 0x0
+
+rom_ext_image_end:

--- a/sw/device/rom_exts/rom_ext_manifest.S
+++ b/sw/device/rom_exts/rom_ext_manifest.S
@@ -1,0 +1,85 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * ROM_EXT Manifest Format
+ */
+  .section .rom_ext_manifest, "a"
+
+  .globl rom_ext_image_start
+rom_ext_image_start:
+
+// Constant
+rom_ext_identifier:
+  .word 0x4552544F
+
+// Reserved
+  .word 0x0
+
+// Will be overidden by signing script
+image_signature:
+  .rept 96
+  .word 0x0
+  .endr
+
+// Everything beyond this point is signed.
+
+  .extern rom_ext_full_image_size
+// Calculated by linker
+image_length:
+  // This should be the whole image length (of the flash part, including the
+  // manifest).
+  .word rom_ext_full_image_size
+
+// Overriden by signing script
+image_version:
+  .word 0x0
+
+// Overriden by signing script
+image_timestamp:
+  .dword 0x0
+
+// Overridden by signing script
+image_signature_algorithm:
+  .word 0x0
+
+// Overriden by signing script
+image_signature_exponent:
+  .word 0x0
+
+// Maybe: Overriden by signing script?
+image_usage_constraints:
+  .word 0x0
+
+// Reserved
+  .word 0x0
+
+// Overriden by signing script
+image_software_binding_tag:
+  .rept 16
+  .byte 0x0
+  .endr
+
+// Maybe: Overriden by signing script?
+image_peripheral_lockdown_info:
+  .rept 16
+  .byte 0x0
+  .endr
+
+// Overriden by signing script
+signature_public_key:
+  .rept 96
+  .word 0x0
+  .endr
+
+// Extensions
+extensions:
+  .rept 4
+  .word 0x0
+  .word 0x0
+  .endr
+
+  .globl image_code_contents
+// Code Image starts here
+image_code_contents:

--- a/sw/device/rom_exts/rom_ext_manifest.protocol.sh
+++ b/sw/device/rom_exts/rom_ext_manifest.protocol.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# This is a file for the python `protocol` [1] tool which can produce an ASCII
+# diagram for a protocol header.
+#
+# [1]: https://github.com/luismartingarcia/protocol
+
+# We break some fields at a given length, so that the image format description
+# is kept relatively short. I have been adding the break-line manually
+# after-the-fact.
+BROKEN_LENGTH=128
+
+
+# The format here is lines of `<FIELD NAME>:<LENGTH IN BITS>,\n`.
+# Lines containing only `\n` are allowed.
+read -r -d '' FIELDS <<-FIELDS
+ROM_EXT Manifest Identifier:32,
+Reserved:32,
+Image Signature (3072 bits):${BROKEN_LENGTH},
+
+Image Length:32,
+Image Version:32,
+Image Timestamp:64,
+
+Signature Algorithm Identifier:32,
+Signature Exponent:32,
+Usage Constraints (TBC):32,
+Reserved:32,
+
+Software Binding Tag (TBC):128,
+Peripheral Lockdown Info (TBC):128,
+
+Signature Public Key (3072 bits):${BROKEN_LENGTH},
+
+Extension0 Offset:32,
+Extension0 Checksum:32,
+Extension1 Offset:32,
+Extension1 Checksum:32,
+Extension2 Offset:32,
+Extension2 Checksum:32,
+Extension3 Offset:32,
+Extension3 Checksum:32,
+
+Code Image:${BROKEN_LENGTH}
+FIELDS
+
+arg=$(echo "${FIELDS}" | tr -d '\n')
+
+protocol --bits 32 "${arg}"

--- a/sw/device/rom_exts/rom_ext_start.S
+++ b/sw/device/rom_exts/rom_ext_start.S
@@ -1,0 +1,128 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h"
+
+/**
+ * ROM_EXT Interrupt Vector
+ */
+  .section .vectors, "ax"
+  .option push
+
+  // Disable RISC-V instruction compression: we need all instructions to
+  // be exactly word wide in the interrupt vector.
+  .option norvc
+
+  // Disable RISC-V linker relaxation, as it can compress instructions at
+  // link-time, which we also really don't want.
+  .option norelax
+
+/**
+ * `_rom_ext_interrupt_vector` is an ibex-compatible interrupt vector.
+ *
+ * Interrupt vectors in Ibex have 32 entries for 32 possible interrupts. The
+ * vector must be 256-byte aligned, as Ibex's vectoring mechanism requires that.
+ *
+ * The ROM_EXT uses the address directly after the first possible interrupt
+ * vector when starting execution after Mask ROM, which we choose to make look
+ * like an extra entry. This is designed to match how Ibex chooses to implement
+ * its initial execution address after boot.
+ *
+ * Thus this vector has exactly 33 4-byte entries.
+ *
+ * Only the following will be used by Ibex:
+ * - Exception Handler (Entry 0)
+ * - Machine Software Interrupt Handler (Entry 3)
+ * - Machine Timer Interrupt Handler (Entry 7)
+ * - Machine External Interrupt Handler (Entry 11)
+ * - Vendor Interrupt Handlers (Entries 16-31)
+ * - Reset Handler (Entry 32)
+ *
+ * More information about Ibex's interrupts can be found here:
+ *   https://ibex-core.readthedocs.io/en/latest/exception_interrupts.html
+ */
+  .balign 256
+  .globl _rom_ext_interrupt_vector
+  .type _rom_ext_interrupt_vector, @function
+_rom_ext_interrupt_vector:
+
+  // RISC-V Standard (Vectored) Interrupt Handlers:
+
+  // Exception and User Software Interrupt Handler.
+  unimp
+  // Supervisor Software Interrupt Handler.
+  unimp
+  // Reserved.
+  unimp
+  // Machine Software Interrupt Handler.
+  unimp
+
+  // User Timer Interrupt Handler.
+  unimp
+  // Supervisor Timer Interrupt Handler.
+  unimp
+  // Reserved.
+  unimp
+  // Machine Timer Interrupt Handler.
+  unimp
+
+  // User External Interrupt Handler.
+  unimp
+  // Supervisor External Interrupt Handler.
+  unimp
+  // Reserved.
+  unimp
+  // Machine External Interrupt Handler.
+  unimp
+
+  // Reserved.
+  unimp
+  unimp
+  unimp
+  unimp
+
+  // Vendor Interrupt Handlers:
+
+  // On Ibex interrupt ids 30-16 are for "fast" interrupts.
+  .rept 15
+  unimp
+  .endr
+
+  // On Ibex interrupt id 31 is for non-maskable interrupts.
+  unimp
+
+  // Ibex Reset Handler:
+  j _rom_ext_start_boot
+
+  // Set size so this vector can be disassembled.
+  .size _rom_ext_interrupt_vector, .-_rom_ext_interrupt_vector
+
+  // Re-enable compressed instructions, linker relaxation.
+  .option pop
+
+
+/**
+ * ROM_EXT runtime initialization code.
+ */
+
+  // NOTE: The "ax" flag below is necessary to ensure that this section
+  // is allocated executable space in ROM by the linker.
+  .section .crt, "ax"
+
+  // Linker Relaxation is disabled until `__global_pointer$` is setup, below,
+  // because otherwise some sequences may be turned into gp-relative sequences,
+  // which is incorrect when `gp` is not initialized.
+  .option push
+  .option norelax
+
+/**
+ * Entry point after reset. This symbol is jumped to from the handler
+ * for IRQ 32.
+ *
+ * At the moment, this should just fault, until we have a CRT we can use.
+ */
+  .globl _rom_ext_start_boot
+  .type _rom_ext_start_boot, @function
+_rom_ext_start_boot:
+  unimp


### PR DESCRIPTION
This PR adds:
- A document describing the ROM_EXT manifest
- A linker script and assembly that can put together a manifest (but not sign it)

Still Required (will come in follow-up PRs)
- A script that can inject the right information into the manifest
- Some code for the ROM_EXT to actually execute (a CRT and probably enough to print 'Hello World' over a UART)