### PR TITLE
[bronze/otp] Minor updates for OTP instantiation in the foundry repo

### DIFF
--- a/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
@@ -139,7 +139,7 @@ module otp_ctrl
   // OTP Macro //
   ///////////////
 
-  localparam int OtpWidth     = 8;
+  localparam int OtpWidth     = 16;
   localparam int OtpDepth     = 1024;
   localparam int OtpAddrWidth = $clog2(OtpDepth);
   localparam int OtpErrWidth  = 8;
@@ -276,7 +276,7 @@ module otp_ctrl
      hw2reg.direct_access_rdata[1].d} = otp_scrambler_out ^ {gate_gen_out, gate_gen_out};
     hw2reg.direct_access_rdata[0].de = gate_gen_out_valid ^ otp_scrambler_out_valid;
     hw2reg.direct_access_rdata[1].de = gate_gen_out_valid ^ otp_scrambler_out_valid;
-    hw2reg.lc_state[0]               = otp_rdata ^ {8{otp_rvalid}};
+    hw2reg.lc_state[OtpWidth/8-1:0]  = otp_rdata ^ {OtpWidth{otp_rvalid}};
   end
 
   // Dummy registers for flash key

--- a/hw/ip/prim_generic/rtl/prim_generic_otp.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_otp.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module prim_generic_otp #(
-  parameter  int Width     = 8,
+  parameter  int Width     = 16,
   parameter  int Depth     = 1024,
   parameter  int ErrWidth  = 8,
   localparam int AddrWidth = $clog2(Depth)

--- a/hw/syn/data/common_syn_cfg.hjson
+++ b/hw/syn/data/common_syn_cfg.hjson
@@ -23,7 +23,6 @@
 
   // TODO: switch the tool to dc once the corresponding edalize backend is available
   sv_flist_gen_opts:  ["--cores-root {proj_root}",
-                       "--cores-root {TECH_LIB_PATH}/flash",
                        "run"
                        "--target={flow}",
                        "--tool icarus",


### PR DESCRIPTION
This aligns some of the bitwidths of `prim_otp` with the underlying macro, and removes the additional `cores-root` for synthesis, since we now check the vendor IP into the foundry repo.