### PR TITLE
[sw] Use KEEP Correctly in Linker Scripts

### DIFF
--- a/sw/device/boot_rom/rom_link.ld
+++ b/sw/device/boot_rom/rom_link.ld
@@ -57,7 +57,6 @@ SECTIONS {
    */
   .vectors _boot_address : ALIGN(4) {
     KEEP(*(.vectors))
-    *(.vectors)
   } > rom
 
   /**
@@ -65,7 +64,6 @@ SECTIONS {
    */
   .crt : ALIGN(4) {
     KEEP(*(.crt))
-    *(.crt)
   } > rom
 
   /**

--- a/sw/device/exts/common/flash_link.ld
+++ b/sw/device/exts/common/flash_link.ld
@@ -53,7 +53,6 @@ SECTIONS {
    */
   .crt : ALIGN(4) {
     KEEP(*(.crt))
-    *(.crt)
   } > eflash
 
   /**

--- a/sw/device/mask_rom/mask_rom.ld
+++ b/sw/device/mask_rom/mask_rom.ld
@@ -52,7 +52,6 @@ SECTIONS {
    */
   .vectors _mask_rom_boot_address : ALIGN(256) {
     KEEP(*(.vectors))
-    *(.vectors)
   } > rom
 
   /**
@@ -63,7 +62,6 @@ SECTIONS {
    */
   .crt : ALIGN(4) {
     KEEP(*(.crt))
-    *(.crt)
   } > rom
 
   /**
@@ -159,7 +157,6 @@ SECTIONS {
    */
   .chip_info _chip_info_start : ALIGN(4) {
     KEEP(*(.chip_info))
-    *(.chip_info)
   } > rom
 
   /**


### PR DESCRIPTION
`KEEP(<wildcard>)` will ensure input sections matching `<wildcard>` are
added to a given output section, and not removed if `--gc-sections` is
passed and there are no references to said input sections from other
sections.

However, there is no need to repeat `<wildcard>`, as the input sections
matching the wildcard are included by the KEEP invocation [1].

[1]: http://sourceware.org/binutils/docs-2.35/ld/Input-Section-Keep.html