### PR TITLE
[dvsim] Add support for second-level indirection

### DIFF
--- a/util/dvsim/Modes.py
+++ b/util/dvsim/Modes.py
@@ -448,9 +448,10 @@ class Regressions(Modes):
 
             # Check for name conflicts with tests before merging
             if new_regression.name in Tests.item_names:
-                log.error("Test names and regression names are required to be unique. "
-                          "The regression \"%s\" bears the same name with an existing test. ",
-                          new_regression.name)
+                log.error(
+                    "Test names and regression names are required to be unique. "
+                    "The regression \"%s\" bears the same name with an existing test. ",
+                    new_regression.name)
                 sys.exit(1)
 
             for regression in regressions_objs:
@@ -492,9 +493,11 @@ class Regressions(Modes):
                 # Throw an error and exit.
                 for sim_mode_obj_sub in sim_mode_obj.en_build_modes:
                     if sim_mode_obj_sub in regression_obj.en_sim_modes:
-                        log.error("Regression \"%s\" enables sim_modes \"%s\" and \"%s\". "
-                                  "The former is already a sub_mode of the latter.",
-                                  regression_obj.name, sim_mode_obj_sub, sim_mode_obj.name)
+                        log.error(
+                            "Regression \"%s\" enables sim_modes \"%s\" and \"%s\". "
+                            "The former is already a sub_mode of the latter.",
+                            regression_obj.name, sim_mode_obj_sub,
+                            sim_mode_obj.name)
                         sys.exit(1)
 
                 # Check if sim_mode_obj is also passed on the command line, in

--- a/util/dvsim/utils.py
+++ b/util/dvsim/utils.py
@@ -161,8 +161,8 @@ def subst_wildcards(var, mdict, ignored_wildcards=[], ignore_error=False):
             # We need to now substitute {p_xyz_q}, so that the final value of
             # var is 'baz'.
             if not (ignored_wildcards_found or no_substitutions_found):
-                var =  subst_wildcards(var, mdict, ignored_wildcards,
-                                       ignore_error)
+                var = subst_wildcards(var, mdict, ignored_wildcards,
+                                      ignore_error)
     return var
 
 
@@ -289,7 +289,9 @@ def htmc_color_pc_cells(text):
 
     patterns = fp_patterns + '|' + na_list_patterns
     indicators = "%|%u|G|B|E|W|EN|WN"
-    match = re.findall(r"(<td.*>\s*(" + patterns + r")\s+(" + indicators + r")\s*</td>)", text)
+    match = re.findall(
+        r"(<td.*>\s*(" + patterns + r")\s+(" + indicators + r")\s*</td>)",
+        text)
     if len(match) > 0:
         subst_list = {}
         fp_nums = []
@@ -310,8 +312,9 @@ def htmc_color_pc_cells(text):
                 try:
                     fp = float(fp_num)
                 except ValueError:
-                    log.error("Percentage item \"%s\" in cell \"%s\" is not an "
-                              "integer or a floating point number", fp_num, cell)
+                    log.error(
+                        "Percentage item \"%s\" in cell \"%s\" is not an "
+                        "integer or a floating point number", fp_num, cell)
                     continue
                 # Percentage, colored.
                 if indicator == "%":
@@ -390,8 +393,9 @@ def print_msg_list(msg_list_title, msg_list, max_msg_count=-1):
             if k <= max_msg_count or max_msg_count < 0:
                 md_results += msg + "\n\n"
             else:
-                md_results += "Note: %d more messages have been suppressed (max_msg_count = %d) \n\n" % (
-                    len(msg_list) - max_msg_count, max_msg_count)
+                md_results += "Note: %d more messages have been suppressed " % (
+                    len(msg_list) - max_msg_count)
+                md_results += "(max_msg_count = %d) \n\n" % (max_msg_count)
                 break
         md_results += "```\n"
     return md_results


### PR DESCRIPTION
This adds support for a second level of indirection with the key-value
pairs in the HJson.

For example: lets say we supply the dict:
`{var: '{{foo}_xyz{bar}}', foo: p, bar: q, p_xyz_q: baz}`

Then after the substitutions above: `{var: '{p_xyz_q}', ...}`
We need to now substitute {p_xyz_q}, so that the final value of
`{var: 'baz', ...}`.

We will use this mechanism to set compile time values to keys that need
to be differentiated for each build. An example of where this will be
required to be done is setting different coverage collection hierarchy
files to different builds for the same DUT. In a subsequent PR, CSR
tests will have its own build and the coverage collected on those tests
will be significantly reduced. That PR will make this change probably a
bit clearer.

The second commit only contains lint cleanup items. There is no functional change. 

Signed-off-by: Srikrishna Iyer <sriyer@google.com>