### PR TITLE
[topgen] Xbar autoconnect

### DIFF
--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -2305,6 +2305,10 @@
       [
         clkmgr.pwr
       ]
+      pwrmgr.wakeups:
+      [
+        pinmux.aon_wkup_req
+      ]
       rom.tl:
       [
         main.tl_rom
@@ -2392,10 +2396,6 @@
       ram_ret.tl:
       [
         peri.tl_ram_ret
-      ]
-      pwrmgr.wakeups:
-      [
-        pinmux.aon_wkup_req
       ]
     }
     top:
@@ -5366,6 +5366,14 @@
         default: ""
       }
       {
+        package: ""
+        struct: logic
+        signame: pwrmgr_wakeups
+        width: 1
+        type: uni
+        default: ""
+      }
+      {
         package: tlul_pkg
         struct: tl_h2d
         signame: rom_tl_req
@@ -5715,14 +5723,6 @@
         signame: ram_ret_tl_rsp
         width: 1
         type: req_rsp
-        default: ""
-      }
-      {
-        package: ""
-        struct: logic
-        signame: pwrmgr_wakeups
-        width: 1
-        type: uni
         default: ""
       }
       {

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -358,33 +358,6 @@
       'pwrmgr.pwr_rst'  : ['rstmgr.pwr'],
       'pwrmgr.pwr_clk'  : ['clkmgr.pwr'],
 
-      // TODO: Temporary XBAR connection
-      //  main xbar
-      //   TODO: corei, cored, dm_sba, debug_mem
-      'rom.tl': ['main.tl_rom'],
-      'ram_main.tl': ['main.tl_ram_main'],
-      'eflash.tl': ['main.tl_eflash'],
-      'main.tl_peri': ['peri.tl_main'],
-      'flash_ctrl.tl': ['main.tl_flash_ctrl'],
-      'hmac.tl': ['main.tl_hmac'],
-      'aes.tl': ['main.tl_aes'],
-      'rv_plic.tl': ['main.tl_rv_plic'],
-      'pinmux.tl': ['main.tl_pinmux'],
-      'padctrl.tl': ['main.tl_padctrl'],
-      'alert_handler.tl': ['main.tl_alert_handler'],
-      'nmi_gen.tl': ['main.tl_nmi_gen'],
-      'otbn.tl': ['main.tl_otbn'],
-
-      //  peri xbar
-      'uart.tl': ['peri.tl_uart'],
-      'gpio.tl': ['peri.tl_gpio'],
-      'spi_device.tl': ['peri.tl_spi_device'],
-      'rv_timer.tl': ['peri.tl_rv_timer'],
-      'usbdev.tl': ['peri.tl_usbdev'],
-      'pwrmgr.tl': ['peri.tl_pwrmgr'],
-      'rstmgr.tl': ['peri.tl_rstmgr'],
-      'clkmgr.tl': ['peri.tl_clkmgr'],
-      'ram_ret.tl': ['peri.tl_ram_ret'],
     }
 
     // top is to connect to top net/struct.

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -194,6 +194,7 @@ module top_earlgrey #(
   pwrmgr_pkg::pwr_rst_rsp_t       pwrmgr_pwr_rst_rsp;
   pwrmgr_pkg::pwr_clk_req_t       pwrmgr_pwr_clk_req;
   pwrmgr_pkg::pwr_clk_rsp_t       pwrmgr_pwr_clk_rsp;
+  logic       pwrmgr_wakeups;
   tlul_pkg::tl_h2d_t       rom_tl_req;
   tlul_pkg::tl_d2h_t       rom_tl_rsp;
   tlul_pkg::tl_h2d_t       ram_main_tl_req;
@@ -238,7 +239,6 @@ module top_earlgrey #(
   tlul_pkg::tl_d2h_t       clkmgr_tl_rsp;
   tlul_pkg::tl_h2d_t       ram_ret_tl_req;
   tlul_pkg::tl_d2h_t       ram_ret_tl_rsp;
-  logic       pwrmgr_wakeups;
   rstmgr_pkg::rstmgr_out_t       rstmgr_resets;
   rstmgr_pkg::rstmgr_cpu_t       rstmgr_cpu;
   pwrmgr_pkg::pwr_cpu_t       pwrmgr_pwr_cpu;

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -21,7 +21,7 @@ import tlgen
 from reggen import gen_dv, gen_rtl, validate
 from topgen import (amend_clocks, get_hjsonobj_xbars, merge_top, search_ips,
                     validate_top)
-from topgen.intermodule import elab_intermodule
+from topgen import intermodule as im
 
 # Common header for generated files
 genhdr = '''// Copyright lowRISC contributors.
@@ -866,7 +866,11 @@ def main():
         generate_xbars(completecfg, out_path)
 
     # All IPs are generated. Connect phase now
-    elab_intermodule(completecfg)
+    # Find {memory, module} <-> {xbar} connections first.
+    im.autoconnect(completecfg)
+
+    # Generic Inter-module connection
+    im.elab_intermodule(completecfg)
 
     top_name = completecfg["name"]
 


### PR DESCRIPTION
Previously, the connection between the module, memory list and the xbar port shall be described manually in `top["inter_module"]["connect"]`.

Now topgen, after generating the Xbar ips, adds the connections if doesn't exist. It loops the node in every crossbars and check if it comes from the module or connects to the other xbars. Then it adds connection based on the information.

To make it easier and to not create double connection case, `add_intermodule_connect()` function is added. The function checks if the connection already exists and add if not.