### PR TITLE
[sw] Fix flash_header section attributes

### DIFF
--- a/sw/device/exts/common/flash_crt.S
+++ b/sw/device/exts/common/flash_crt.S
@@ -3,12 +3,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
+ * Flash header.
+ *
+ * Contains the address of the entry point.
+ */
+  .section .flash_header, "a", @progbits
+  .4byte _start
+
+/**
  * Flash executable runtime initialization code.
  */
 
   // NOTE: The "ax" flag below is necessary to ensure that this section
   // is allocated space in ROM by the linker.
-  .section .crt, "ax"
+  .section .crt, "ax", @progbits
 
   .extern main
   .extern crt_interrupt_vector

--- a/sw/device/exts/common/flash_link.ld
+++ b/sw/device/exts/common/flash_link.ld
@@ -38,11 +38,7 @@ SECTIONS {
    * signature, but for now it's just the entry point at offset zero.
    */
   .flash_header ORIGIN(eflash) : ALIGN(4) {
-    /**
-     * NOTE:ld scripts do not provide a mechanism to refer to ENTRY,
-     * so we just harcode the _start symbol.
-     */
-    LONG(_start)
+    KEEP(*(.flash_header))
   } > eflash
 
   /**


### PR DESCRIPTION
Moving the flash_header section from the linker script to an assembly file
allows us to specify that section's attributes and ensure it's not
writeable. This prevents the segment containing the code and other
read-only data to also be flagged as writeable.

Hat tip to @lenary for suggesting this approach.

This patch was originally motivated by the fact that GDB isn't recognizing the code as read-only, and therefore doesn't automatically use hardware breakpoints (it tries to use software breakpoints and fails to patch the instructions). This patch isn't enough to address that issue but it's still a desirable change on its own.