### PR TITLE
[openocd] Always use hardware breakpoints

### DIFF
--- a/util/openocd/target/lowrisc-earlgrey.cfg
+++ b/util/openocd/target/lowrisc-earlgrey.cfg
@@ -31,3 +31,10 @@ riscv set_prefer_sba on
 # Be verbose about GDB errors
 gdb_report_data_abort enable
 gdb_report_register_access_error enable
+
+# Always use hardware breakpoints. Since we don't use `flash bank` commands,
+# OpenOCD won't provide a memory map to GDB. This means that GDB isn't be aware
+# that the code resides in a read-only memory, and therefore should use hardware
+# breakpoints. This setting makes OpenOCD convert the software breakpoints into
+# hardware ones.
+gdb_breakpoint_override hard


### PR DESCRIPTION
Since we don't use OpenOCD `flash bank` commands, OpenOCD won't provide a
memory map to GDB. This means that GDB isn't aware that the code resides in
read-only memory, and therefore should use hardware breakpoints. This is
especially problematic for implicitly-set breakpoints, such as when
stepping over code. This can be worked around in GDB by setting the
appropriate memory ranges as ready-only, but that isn't particularly user
friendly. As an alternative, this sets the OpenOCD `gdb_breakpoint_override`
option to `hard`, automatically converting software breakpoints into
hardware ones at the OpenOCD level.

I would prefer to have proper memory maps, but I'm not sure that is possible. At the OpenOCD level, I don't think we can artificially use any of the `flash bank` commands to obtain the desired behavior. A more realistic alternative would be to have our own script to launch the debugger and automatically run various configuration commands, but that also has its own downsides.

In any case, I have found that having a single hardware breakpoint in Ibex is limiting. For instance, if you set a breakpoint and then step over code you can easily find yourself implicitly trying to set two hardware breakpoints. GDB won't be smart enough to temporarily disable the other one. Unfortunately, at the moment Ibex only supports one hardware breakpoint. Another option would be to have a debug target configuration where code resides in writeable memory.