### PR TITLE
[topgen] Custom external port name

### DIFF
--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -1544,7 +1544,8 @@
           inst_name: clkmgr
           width: 1
           default: ""
-          top_signame: clkmgr_clk_main
+          external: true
+          top_signame: clk_main
           index: -1
         }
         {
@@ -1556,7 +1557,8 @@
           inst_name: clkmgr
           width: 1
           default: ""
-          top_signame: clkmgr_clk_io
+          external: true
+          top_signame: clk_io
           index: -1
         }
         {
@@ -1568,7 +1570,8 @@
           inst_name: clkmgr
           width: 1
           default: ""
-          top_signame: clkmgr_clk_usb
+          external: true
+          top_signame: clk_usb
           index: -1
         }
         {
@@ -1580,7 +1583,8 @@
           inst_name: clkmgr
           width: 1
           default: ""
-          top_signame: clkmgr_clk_aon
+          external: true
+          top_signame: clk_aon
           index: -1
         }
         {
@@ -2412,12 +2416,12 @@
       main.tl_debug_mem
     ]
     external:
-    [
-      clkmgr.clk_main
-      clkmgr.clk_io
-      clkmgr.clk_usb
-      clkmgr.clk_aon
-    ]
+    {
+      clkmgr.clk_main: clk_main
+      clkmgr.clk_io: clk_io
+      clkmgr.clk_usb: clk_usb
+      clkmgr.clk_aon: clk_aon
+    }
   }
   xbar:
   [
@@ -4742,7 +4746,8 @@
         inst_name: clkmgr
         width: 1
         default: ""
-        top_signame: clkmgr_clk_main
+        external: true
+        top_signame: clk_main
         index: -1
       }
       {
@@ -4754,7 +4759,8 @@
         inst_name: clkmgr
         width: 1
         default: ""
-        top_signame: clkmgr_clk_io
+        external: true
+        top_signame: clk_io
         index: -1
       }
       {
@@ -4766,7 +4772,8 @@
         inst_name: clkmgr
         width: 1
         default: ""
-        top_signame: clkmgr_clk_usb
+        external: true
+        top_signame: clk_usb
         index: -1
       }
       {
@@ -4778,7 +4785,8 @@
         inst_name: clkmgr
         width: 1
         default: ""
-        top_signame: clkmgr_clk_aon
+        external: true
+        top_signame: clk_aon
         index: -1
       }
       {
@@ -5281,7 +5289,7 @@
       {
         package: ""
         struct: logic
-        signame: clkmgr_clk_main
+        signame: clk_main_i
         width: 1
         type: uni
         default: ""
@@ -5290,7 +5298,7 @@
       {
         package: ""
         struct: logic
-        signame: clkmgr_clk_io
+        signame: clk_io_i
         width: 1
         type: uni
         default: ""
@@ -5299,7 +5307,7 @@
       {
         package: ""
         struct: logic
-        signame: clkmgr_clk_usb
+        signame: clk_usb_i
         width: 1
         type: uni
         default: ""
@@ -5308,7 +5316,7 @@
       {
         package: ""
         struct: logic
-        signame: clkmgr_clk_aon
+        signame: clk_aon_i
         width: 1
         type: uni
         default: ""

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -372,7 +372,12 @@
     ],
 
     // ext is to create port in the top.
-    'external': ['clkmgr.clk_main', 'clkmgr.clk_io', 'clkmgr.clk_usb', 'clkmgr.clk_aon'],
+    'external': {
+        'clkmgr.clk_main': 'clk_main',
+        'clkmgr.clk_io': 'clk_io',
+        'clkmgr.clk_usb': 'clk_usb',
+        'clkmgr.clk_aon': 'clk_aon'
+    },
   },
 
   debug_mem_base_addr: "0x1A110000",

--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -689,6 +689,6 @@ slice = str(alert_idx+w-1) + ":" + str(alert_idx)
 % endif
 
   // make sure scanmode_i is never X (including during reset)
-  `ASSERT_KNOWN(scanmodeKnown, scanmode_i, clkmgr_clk_main, 0)
+  `ASSERT_KNOWN(scanmodeKnown, scanmode_i, clk_main_i, 0)
 
 endmodule

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -33,10 +33,10 @@ module top_earlgrey #(
 
 
   // Inter-module Signal External type
-  input  logic       clkmgr_clk_main,
-  input  logic       clkmgr_clk_io,
-  input  logic       clkmgr_clk_usb,
-  input  logic       clkmgr_clk_aon,
+  input  logic       clk_main_i,
+  input  logic       clk_io_i,
+  input  logic       clk_usb_i,
+  input  logic       clk_aon_i,
   input               scan_rst_ni, // reset used for test mode
   input               scanmode_i   // 1 for Scan
 );
@@ -813,10 +813,10 @@ module top_earlgrey #(
 
       // Inter-module signals
       .clocks_o(clkmgr_clocks),
-      .clk_main_i(clkmgr_clk_main),
-      .clk_io_i(clkmgr_clk_io),
-      .clk_usb_i(clkmgr_clk_usb),
-      .clk_aon_i(clkmgr_clk_aon),
+      .clk_main_i(clk_main_i),
+      .clk_io_i(clk_io_i),
+      .clk_usb_i(clk_usb_i),
+      .clk_aon_i(clk_aon_i),
       .pwr_i(pwrmgr_pwr_clk_req),
       .pwr_o(pwrmgr_pwr_clk_rsp),
       .dft_i(clkmgr_pkg::CLK_DFT_DEFAULT),
@@ -1173,6 +1173,6 @@ module top_earlgrey #(
   assign cio_usbdev_dn_p2d         = dio_p2d[0]; // DIO0
 
   // make sure scanmode_i is never X (including during reset)
-  `ASSERT_KNOWN(scanmodeKnown, scanmode_i, clkmgr_clk_main, 0)
+  `ASSERT_KNOWN(scanmodeKnown, scanmode_i, clk_main_i, 0)
 
 endmodule

--- a/hw/top_earlgrey/rtl/top_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_asic.sv
@@ -197,10 +197,10 @@ module top_earlgrey_asic (
 
   top_earlgrey top_earlgrey (
     .rst_ni          ( rst_n         ),
-    .clkmgr_clk_main ( clk           ),
-    .clkmgr_clk_io   ( clk           ),
-    .clkmgr_clk_usb  ( clk_usb_48mhz ),
-    .clkmgr_clk_aon  ( clk           ),
+    .clk_main_i      ( clk           ),
+    .clk_io_i        ( clk           ),
+    .clk_usb_i       ( clk_usb_48mhz ),
+    .clk_aon_i       ( clk           ),
 
     // JTAG
     .jtag_tck_i      ( jtag_tck      ),

--- a/hw/top_earlgrey/rtl/top_earlgrey_nexysvideo.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_nexysvideo.sv
@@ -211,10 +211,10 @@ module top_earlgrey_nexysvideo #(
   ) top_earlgrey (
     // Clocks, resets
     .rst_ni          ( rst_n         ),
-    .clkmgr_clk_main ( clk           ),
-    .clkmgr_clk_io   ( clk           ),
-    .clkmgr_clk_usb  ( clk_usb_48mhz ),
-    .clkmgr_clk_aon  ( clk           ),
+    .clk_main_i      ( clk           ),
+    .clk_io_i        ( clk           ),
+    .clk_usb_i       ( clk_usb_48mhz ),
+    .clk_aon_i       ( clk           ),
 
     // JTAG
     .jtag_tck_i      ( jtag_tck      ),

--- a/hw/top_earlgrey/rtl/top_earlgrey_verilator.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_verilator.sv
@@ -76,10 +76,10 @@ module top_earlgrey_verilator (
   // Top-level design
   top_earlgrey top_earlgrey (
     .rst_ni                     (rst_ni),
-    .clkmgr_clk_main            (clk_i),
-    .clkmgr_clk_io              (clk_i),
-    .clkmgr_clk_usb             (clk_i),
-    .clkmgr_clk_aon             (clk_i),
+    .clk_main_i                 (clk_i),
+    .clk_io_i                   (clk_i),
+    .clk_usb_i                  (clk_i),
+    .clk_aon_i                  (clk_i),
 
     .jtag_tck_i                 (cio_jtag_tck),
     .jtag_tms_i                 (cio_jtag_tms),


### PR DESCRIPTION
Current Inter-module signal has fixed naming rule for every inter-module signals. It creates weird naming format for external ports. External ports doesn't have `_o`, `_i` suffixes and also it always has the instance name in front of the signal name such as `clkmgr_clk_main`.

This commit is to support custom top signal name for external type (other type will be addressed in following PRs). To support it, top_earlgrey.hjson format is slightly revised. Please see the `inter_module`.`external` data field.

This is related to Issue #3095
