### PR TITLE
[otbn] Teach tooling about signed immediate operands

### DIFF
--- a/hw/ip/otbn/data/insns.yml
+++ b/hw/ip/otbn/data/insns.yml
@@ -473,8 +473,11 @@ encoding-schemes:
 #
 #  wsr:       The name of a WSR. Syntax "wsr" (always considered a destination)
 #
-#  immediate: An immediate operand. Syntax "imm<n>" where n is the number of
-#             bits or just imm for an unspecified width.
+#  simm:      A signed immediate operand. Syntax "simm<n>" where n is the
+#             number of bits or just simm for an unspecified width.
+#
+#  uimm:      An unsigned immediate operand. Syntax "uimm<n>" where n is the
+#             number of bits or just uimm for an unspecified width.
 #
 #  enum:      An immediate with weird syntax. The syntax is "enum(a,b,c,d)"
 #             where a..d are the different possible syntaxes that can be used.
@@ -493,8 +496,8 @@ encoding-schemes:
 #  wrs, wrs<n> WDR source
 #  csr         CSR name
 #  wsr         WSR name
-#  imm, imm<n> Immediate
-#  offset      Immediate (unspecified width)
+#  imm, imm<n> Signed immediate (width <n> if specified)
+#  offset      Signed immediate (unspecified width)
 
 insns:
   - mnemonic: add
@@ -527,7 +530,10 @@ insns:
   - mnemonic: lui
     rv32i: true
     synopsis: Load Upper Immediate
-    operands: [grd, imm]
+    operands:
+      - grd
+      - name: imm
+        type: uimm
     encoding:
       scheme: U
       mapping:
@@ -571,7 +577,7 @@ insns:
       - grs1
       - &shamt-operand
         name: shamt
-        type: imm
+        type: uimm
     encoding:
       scheme: Is
       mapping:
@@ -869,7 +875,7 @@ insns:
         doc: Name of the GPR containing the number of iterations
       - &bodysize-operand
         name: bodysize
-        type: imm
+        type: uimm
         doc: Number of instructions in the loop body
     note: &loop-note |
       The LOOP and LOOPI instructions are under-specified, and improvements
@@ -890,14 +896,15 @@ insns:
     synopsis: Loop Immediate
     operands:
       - name: iterations
-        type: imm
+        type: uimm
         doc: Number of iterations
       - *bodysize-operand
     note: *loop-note
     doc: |
-      Repeat a sequence of code multiple times. The `<iterations>` immediate
-      operand gives the number of iterations and the `<bodysize>` immediate
-      operand gives the number of instructions in the body.
+      Repeat a sequence of code multiple times. The `<iterations>`
+      unsigned immediate operand gives the number of iterations and
+      the `<bodysize>` unsigned immediate operand gives the number of
+      instructions in the body.
     encoding:
       scheme: loopi
       mapping:
@@ -917,10 +924,11 @@ insns:
     rv32i: true
     operands: [grd, imm]
     doc: |
-      Load a 32b immediate value into a GPR. This uses ADDI and LUI, expanding
-      to one or two instructions, depending on the immediate (small immediates
-      or immediates with all lower bits zero can be loaded with just ADDI or
-      LUI, respectively; general immediates need a LUI followed by an ADDI).
+      Load a 32b signed immediate value into a GPR. This uses ADDI and LUI,
+      expanding to one or two instructions, depending on the immediate (small
+      non-negative immediates or immediates with all lower bits zero can be
+      loaded with just ADDI or LUI, respectively; general immediates need a LUI
+      followed by an ADDI).
     python-pseudo-op: true
 
   - mnemonic: ret
@@ -947,18 +955,18 @@ insns:
           The direction of an optional shift applied to `<wrs2>`.
       - &bn-shift-bytes-operand
         name: shift_bytes
-        type: imm5
+        type: uimm5
         doc: |
           Number of bytes by which to shift `<wrs2>`. Defaults to 0.
       - &bn-flag-group-operand
         name: flag_group
-        type: imm1
+        type: uimm1
         doc: Flag group to use. Defaults to 0.
     syntax: &bn-add-syntax |
       <wrd>, <wrs1>, <wrs2>[<shift_type> <shift_bytes>B][, FG<flag_group>]
     doc: |
       Adds two WDR values, writes the result to the destination WDR and updates
-      flags. The content of the second source WDR can be shifted by an
+      flags. The content of the second source WDR can be shifted by an unsigned
       immediate before it is consumed by the operation.
     decode: |
       d = UInt(wrd)
@@ -993,7 +1001,7 @@ insns:
     doc: |
       Adds two WDR values and the Carry flag value, writes the result to the
       destination WDR, and updates the flags. The content of the second source
-      WDR can be shifted by an immediate before it is consumed by the
+      WDR can be shifted by an unsigned immediate before it is consumed by the
       operation.
     decode: |
       d = UInt(wrd)
@@ -1029,13 +1037,14 @@ insns:
       - name: wrs
         doc: Name of the source WDR
       - name: imm
+        type: uimm
         doc: Immediate value
       - *bn-flag-group-operand
     syntax: |
       <wrd>, <wrs>, <imm> [, FG<flag_group>]
     doc: |
-      Adds a zero-extended immediate to the value of a WDR, writes the result
-      to the destination WDR, and updates the flags.
+      Adds a zero-extended unsigned immediate to the value of a WDR, writes the
+      result to the destination WDR, and updates the flags.
     decode: |
       d = UInt(wrd)
       a = UInt(wrs1)
@@ -1100,7 +1109,7 @@ insns:
         doc: First source WDR
       - &mulqacc-wrs1-qwsel
         name: wrs1_qwsel
-        type: imm2
+        type: uimm2
         doc: |
           Quarter-word select for `<wrs1>`.
 
@@ -1114,7 +1123,7 @@ insns:
         doc: Second source WDR
       - &mulqacc-wrs2-qwsel
         name: wrs2_qwsel
-        type: imm2
+        type: uimm2
         doc: |
           Quarter-word select for `<wrs2>`.
 
@@ -1125,9 +1134,10 @@ insns:
           - `3`: Select `wrs1[WLEN-1:WLEN/4*3]` (most significant quarter-word)
       - &mulqacc-acc-shift-imm
         name: acc_shift_imm
-        type: imm2
+        type: uimm2
         doc: |
-          How many quarter-words (`WLEN/4` bits) to shift the `WLEN/2`-bit multiply result before accumulating.
+          The number of quarter-words (`WLEN/4` bits) to shift the `WLEN/2`-bit
+          multiply result before accumulating.
     syntax: |
       [<zero_acc>] <wrs1>.<wrs1_qwsel>, <wrs2>.<wrs2_qwsel>, <acc_shift_imm>
     glued-ops: true
@@ -1289,7 +1299,7 @@ insns:
     syntax: *bn-add-syntax
     doc: |
       Subtracts the second WDR value from the first one, writes the result to the destination WDR and updates flags.
-      The content of the second source WDR can be shifted by an immediate before it is consumed by the operation.
+      The content of the second source WDR can be shifted by an unsigned immediate before it is consumed by the operation.
     decode: &bn-sub-decode |
       d = UInt(wrd)
       a = UInt(wrs1)
@@ -1322,7 +1332,7 @@ insns:
     syntax: *bn-add-syntax
     doc: |
       Subtracts the second WDR value and the Carry from the first one, writes the result to the destination WDR, and updates the flags.
-      The content of the second source WDR can be shifted by an immediate before it is consumed by the operation.
+      The content of the second source WDR can be shifted by an unsigned immediate before it is consumed by the operation.
     decode: *bn-sub-decode
     operation: |
       b_shifted = ShiftReg(b, st, sb)
@@ -1350,11 +1360,13 @@ insns:
       - name: wrs
         doc: Name of the source WDR
       - name: imm
+        type: uimm
         doc: Immediate value
       - *bn-flag-group-operand
     syntax: <wrd>, <wrs>, <imm> [, FG<flag_group>]
     doc: |
-      Subtracts a zero-extended immediate from the value of a WDR, writes the result to the destination WDR, and updates the flags.
+      Subtracts a zero-extended unsigned immediate from the value of a WDR,
+      writes the result to the destination WDR, and updates the flags.
     decode: |
       d = UInt(wrd)
       a = UInt(wrs1)
@@ -1546,6 +1558,7 @@ insns:
       - name: wrs2
         doc: Name of the second source WDR
       - name: imm
+        type: uimm
         doc: |
           Number of bits to shift the second source register by. Valid range: 0..(WLEN-1).
     syntax: |

--- a/hw/ip/otbn/util/otbn-as
+++ b/hw/ip/otbn/util/otbn-as
@@ -27,7 +27,7 @@ from typing import Dict, List, Optional, Set, TextIO, Tuple
 from shared.bit_ranges import BitRanges
 from shared.encoding import Encoding
 from shared.insn_yaml import Insn, InsnsFile, load_file
-from shared.operand import RegOperandType, Operand
+from shared.operand import ImmOperandType, RegOperandType, Operand
 
 
 class RVFmt:
@@ -54,7 +54,8 @@ class RVFmt:
 
         f<n>:    An n-bit literal value.
         r:       A 5-bit register name.
-        i<n>:    An n-bit (signed) immediate
+        i<n>:    An n-bit signed immediate
+        u<n>:    An n-bit unsigned immediate
 
     The syntax should be a list of NAMEs. When an immediate in the encoding is
     split into multiple fields, they can be recombined here with a pipe symbol.
@@ -80,7 +81,7 @@ class RVFmt:
         for field in bitfields:
             name, fmt_width = field.split(':')
             fmt = fmt_width[0]
-            assert fmt in ['f', 'r', 'i']
+            assert fmt in ['f', 'r', 'i', 'u']
             width = 5 if fmt == 'r' else int(fmt_width[1:])
 
             assert name not in name_to_triple
@@ -148,7 +149,7 @@ class RVFmt:
 
 def rv_render(fmt: str, num: int) -> str:
     '''Render a number as expected by a RISC-V .insn field'''
-    if fmt in ['f', 'i']:
+    if fmt in ['f', 'i', 'u']:
         return '{:#x}'.format(num)
 
     assert fmt == 'r'
@@ -203,9 +204,17 @@ RISCV_FORMATS = [
           ['imm12:i1', 'imm105:i6', 'rs2:r', 'rs1:r', 'func3:f3',
            'imm41:i4', 'imm11:i1', 'opcode:f7'],
           ['opcode', 'func3', 'rs2', 'rs1', 'imm12|imm11|imm105|imm41<<1']),
+
+    # The "U" format is used for LUI. The immediate operand gives imm[31:12]
+    # for some imm. Confusingly, the spec implies that this is a signed
+    # immediate, probably because it *is* sign-extended for the 64-bit
+    # architecture. For a 32-bit architecture, the top bit is the sign, so
+    # there is no sign extension to be done. The binutils assembler rejects
+    # things like "lui x1, -1", treating the immediate as unsigned.
     RVFmt('u',
-          ['simm20:i20', 'rd:r', 'opcode:f7'],
-          ['opcode', 'rd', 'simm20']),
+          ['imm20:u20', 'rd:r', 'opcode:f7'],
+          ['opcode', 'rd', 'imm20']),
+
     RVFmt('j',
           ['i20:i1', 'i101:i10', 'i11:i1', 'i1912:i8', 'rd:r', 'opcode:f7'],
           ['opcode', 'rd', 'i20|i1912|i11|i101<<1'])
@@ -242,9 +251,16 @@ def find_rv_encoding(enc: Encoding,
         if not isinstance(field.value, str):
             continue
 
-        operand = name_to_operand[field.value]
-        if operand.op_type.syntax_determines_value():
+        op_type = name_to_operand[field.value].op_type
+        if op_type.syntax_determines_value():
             continue
+
+        # We only support immediate operands (ImmOperandType) below here,
+        # because we need to extract the "signed" field. If this instruction
+        # uses some weird new operand type whose syntax doesn't determine its
+        # value, we'll have to give up.
+        if not isinstance(op_type, ImmOperandType):
+            return None
 
         assert field.value not in full_ops
         full_ops.add(field.value)
@@ -263,8 +279,15 @@ def find_rv_encoding(enc: Encoding,
         if match_fmt is None:
             return None
 
-        # These "difficult" operands can only be encoded in immediate fields.
-        if match_fmt != 'i':
+        # These "difficult" operands can only be encoded in immediate fields of
+        # the correct sign.
+        if match_fmt == 'i':
+            if not op_type.signed:
+                return None
+        elif match_fmt == 'u':
+            if op_type.signed:
+                return None
+        else:
             return None
 
         rv_field_to_op[rv_name] = field.value


### PR DESCRIPTION
There are two patches in the PR, but the first actually comes from #3088 (merge that first!) and we should just be able to review the second patch. That patch has the following commit message:

```
[otbn] Handle signed immediate operands properly in tooling

Now, the ISA data in insns.yml specifies whether an immediate operand
is signed or not (usually not, except for RV32I instructions).

The .insn-matching logic in otbn-as fixes things up accordingly and we
actually lose one instruction: LOOP no longer fits in a RISC-V
standard encoding.

Finally, objdump should now disassemble signed immediates correctly.
```

The change is an improvement in general, but is a prerequisite for some of the instruction generator work I'm doing (which needs to know about operand ranges in order to synthesize random values for them).