### PR TITLE
[otbn] Clarify what happens on out-of-bounds or unaligned load/store

### DIFF
--- a/hw/ip/otbn/data/insns.yml
+++ b/hw/ip/otbn/data/insns.yml
@@ -744,9 +744,10 @@ insns:
         funct3: b010
         rd: grd
         opcode: b00000
-    trailing-doc: |
-      Unaligned accesses are not supported.
-      Any unaligned access will result in an error.
+    doc: |
+      Load a 32b word from address `<offset> + <grs1>` in data memory, writing the result to `<grd>`.
+      Unaligned loads are not supported.
+      Any address that is unaligned or is above the top of memory will result in an error (with error code `ErrCodeBadDataAddr`).
 
   - mnemonic: sw
     rv32i: true
@@ -761,9 +762,10 @@ insns:
         rs1: grs1
         funct3: b010
         opcode: b01000
-    trailing-doc: |
-      Unaligned accesses are not supported.
-      Any unaligned access will result in an error.
+    doc: |
+      Store a 32b word in `<grs2>` to address `<offset> + <grs1>` in data memory.
+      Unaligned stores are not supported.
+      Any address that is unaligned or is above the top of memory will result in an error (with error code `ErrCodeBadDataAddr`).
 
   - mnemonic: beq
     rv32i: true
@@ -1720,10 +1722,8 @@ insns:
       - If `grs1_inc` is set, the value in `grs1` is incremented by the value WLEN/8 (one word).
       - If `grd_inc` is set, the value in `grd` is incremented by the value 1.
 
-      Only aligned (to WLEN sized regions) accesses are supported.
-      Any unaligned access will result in an error.
-
-      TODO: how to handle overflows?
+      The memory address must be aligned to WLEN bytes.
+      Any address that is unaligned or is above the top of memory will result in an error (with error code `ErrCodeBadDataAddr`).
     decode: |
       rd = UInt(grd)
       rs1 = UInt(grs1)
@@ -1732,10 +1732,9 @@ insns:
       mem_addr = GPR[rs1] + offset
       wdr_dest = GPR[rd]
 
-      if grs1_inc and grd_inc:
-          raise Unsupported() # prevented in encoding
-      if mem_addr % (WLEN / 8):
-          raise Unaligned()
+      assert not (grs1_inc and grd_inc)  # prevented in encoding
+      if mem_addr % (WLEN / 8) or mem_addr + WLEN > DMEM_SIZE:
+          raise BadDataAddr()
 
       mem_index = mem_addr // (WLEN / 8)
 
@@ -1790,8 +1789,8 @@ insns:
       - If `grs1_inc` is set, the value in `grs1` is incremented by the value WLEN/8 (one word).
       - If `grs2_inc` is set, the value in `grs2` is incremented by the value 1.
 
-      Only aligned (to WLEN sized regions) accesses are supported.
-      Any unaligned access will result in an error.
+      The memory address must be aligned to WLEN bytes.
+      Any address that is unaligned or is above the top of memory will result in an error (with error code `ErrCodeBadDataAddr`).
     decode: |
       rs1 = UInt(grs1)
       rs2 = UInt(grs2)
@@ -1800,10 +1799,9 @@ insns:
       mem_addr = GPR[rs1] + offset
       wdr_src = GPR[rs2]
 
-      if grs1_inc and grs2_inc:
-          raise Unsupported() # prevented in encoding
-      if mem_addr % (WLEN / 8):
-          raise Unaligned()
+      assert not (grs1_inc and grd_inc)  # prevented in encoding
+      if mem_addr % (WLEN / 8) or mem_addr + WLEN > DMEM_SIZE:
+          raise BadDataAddr()
 
       mem_index = mem_addr // (WLEN / 8)
 

--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -109,7 +109,8 @@
 
             Possible values:
 
-            - 0x0 (ErrCodeNoError): No error occurred.
+            - 0x0 (ErrCodeNoError):     No error occurred.
+            - 0x1 (ErrCodeBadDataAddr): Load or store to invalid address
           '''
         }
       ]

--- a/hw/ip/otbn/doc/_index.md
+++ b/hw/ip/otbn/doc/_index.md
@@ -480,6 +480,9 @@ def StoreWlenWordToMemory(byteaddr: integer, storedata: Bits(WLEN)):
   To be filled in as we create the implementation.
 </div>
 
+By design, OTBN is a simple processor and has essentially no error handling support.
+When anything goes wrong (an out-of-bounds memory operation, an invalid instruction encoding, etc.), OTBN will stop fetching instructions, and set the `ERR_CODE` register and the `err` bit of the `INTR_STATE` register.
+
 # Programmers Guide
 
 <div class="bd-callout bd-callout-warning">

--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -39,7 +39,8 @@ package otbn_pkg;
 
   // Error codes
   typedef enum logic [31:0] {
-    ErrCodeNoError = 32'h 0000_0000
+    ErrCodeNoError     = 32'h 0000_0000,
+    ErrCodeBadDataAddr = 32'h 0000_0001
   } err_code_e;
 
   // Constants =====================================================================================


### PR DESCRIPTION
Allocate an error code for "bad data access" and refer to it in the
docs: this can totally change as we implement the design, but it's
much easier to say something and change it later.

This patch also slightly expands the general notes about what happens
on an error ("We stop and set an error flag": see `_index.md`). I think
this should be pretty uncontentious. Obviously, there are more details
to add in future!

Closes #3094.