### PR TITLE
[DV] Coverage collection enhancements

### DIFF
--- a/hw/dv/data/common_sim_cfg.hjson
+++ b/hw/dv/data/common_sim_cfg.hjson
@@ -100,6 +100,9 @@
                  "+rbar2u=2",
                  "+rbar3u=3"]
     }
+    {
+      name: cover_reg_top
+    }
   ]
 
   // Regressions are tests that can be grouped together and run in one shot
@@ -137,10 +140,18 @@
   tool_srcs:  ["{dv_root}/tools/waves.tcl"],
 
   // Project defaults for VCS
-  vcs_cov_hier: "-cm_hier {tool_srcs_dir}/cover.cfg"
+  vcs_cov_hier: "{{build_mode}_vcs_cov_hier}"
   vcs_cov_excl_files: ["{tool_srcs_dir}/common_cov_excl.el"]
 
+  // Build-specific coverage cfg files for VCS.
+  default_vcs_cov_hier: "-cm_hier {tool_srcs_dir}/cover.cfg"
+  cover_reg_top_vcs_cov_hier: "-cm_hier {tool_srcs_dir}/cover_reg_top.cfg"
+
   // Project defaults for Xcelium
-  // xcelium_cov_cfg_file: "-covfile {tool_srcs_dir}/cover.ccf"
-  // xcelium_cov_refine_file: ["{tool_srcs_dir}/common_cov.vRefine"]
+  // xcelium_cov_cfg_file: "{{build_mode}_xcelium_cov_cfg_file}"
+  // xcelium_cov_refine_files: ["{tool_srcs_dir}/common_cov.vRefine"]
+
+  // Build-specific coverage cfg files for Xcelium.
+  // default_xcelium_cov_cfg_file: "-covfile {tool_srcs_dir}/cover.ccf"
+  // default_xcelium_cov_cfg_file: "-covfile {tool_srcs_dir}/cover_reg_top.ccf"
 }

--- a/hw/dv/data/tests/csr_tests.hjson
+++ b/hw/dv/data/tests/csr_tests.hjson
@@ -2,6 +2,12 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
+  build_modes: [
+    {
+      name: cover_reg_top
+    }
+  ]
+
   run_modes: [
     {
       name: csr_tests_mode
@@ -13,37 +19,42 @@
   tests: [
     {
       name: "{name}_csr_hw_reset"
+      build_mode: "cover_reg_top"
       run_opts: ["+csr_hw_reset"]
       en_run_modes: ["csr_tests_mode"]
     }
 
     {
       name: "{name}_csr_rw"
+      build_mode: "cover_reg_top"
       run_opts: ["+csr_rw"]
       en_run_modes: ["csr_tests_mode"]
     }
 
     {
       name: "{name}_csr_bit_bash"
+      build_mode: "cover_reg_top"
       run_opts: ["+csr_bit_bash"]
       en_run_modes: ["csr_tests_mode"]
     }
 
     {
       name: "{name}_csr_aliasing"
+      build_mode: "cover_reg_top"
       run_opts: ["+csr_aliasing"]
       en_run_modes: ["csr_tests_mode"]
     }
 
     {
       name: "{name}_same_csr_outstanding"
+      build_mode: "cover_reg_top"
       run_opts: ["+run_same_csr_outstanding"]
       en_run_modes: ["csr_tests_mode"]
     }
 
     {
       name: "{name}_csr_mem_rw_with_rand_reset"
-      uvm_test_seq: "{name}_common_vseq"
+      build_mode: "cover_reg_top"
       run_opts: ["+run_csr_mem_rw_with_rand_reset", "+test_timeout_ns=10000000000"]
       en_run_modes: ["csr_tests_mode"]
     }

--- a/hw/dv/data/tests/intr_test.hjson
+++ b/hw/dv/data/tests/intr_test.hjson
@@ -2,9 +2,16 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
+  build_modes: [
+    {
+      name: cover_reg_top
+    }
+  ]
+
   tests: [
     {
       name: "{name}_intr_test"
+      build_mode: "cover_reg_top"
       uvm_test_seq: "{name}_common_vseq"
       run_opts: ["+run_intr_test"]
       reseed: 50

--- a/hw/dv/data/tests/mem_tests.hjson
+++ b/hw/dv/data/tests/mem_tests.hjson
@@ -2,6 +2,12 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
+  build_modes: [
+    {
+      name: cover_reg_top
+    }
+  ]
+
   run_modes: [
     {
       name: mem_tests_mode
@@ -13,12 +19,14 @@
   tests: [
     {
       name: "{name}_mem_walk"
+      build_mode: "cover_reg_top"
       en_run_modes: ["mem_tests_mode"]
       run_opts: ["+csr_mem_walk"]
     }
 
     {
       name: "{name}_mem_partial_access"
+      build_mode: "cover_reg_top"
       en_run_modes: ["mem_tests_mode"]
       run_opts: ["+run_mem_partial_access"]
     }

--- a/hw/dv/data/tests/shadow_reg_errors_tests.hjson
+++ b/hw/dv/data/tests/shadow_reg_errors_tests.hjson
@@ -2,6 +2,12 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
+  build_modes: [
+    {
+      name: cover_reg_top
+    }
+  ]
+
   run_modes: [
     {
       name: csr_tests_mode
@@ -14,6 +20,7 @@
     {
       // this hjson should be imported by all IPs containing shadowed CSRs
       name: "{name}_shadow_reg_errors"
+      build_mode: "cover_reg_top"
       run_opts: ["+run_shadow_reg_errors"]
       en_run_modes: ["csr_tests_mode"]
     }

--- a/hw/dv/data/tests/tl_access_tests.hjson
+++ b/hw/dv/data/tests/tl_access_tests.hjson
@@ -2,9 +2,16 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
+  build_modes: [
+    {
+      name: cover_reg_top
+    }
+  ]
+
   tests: [
     {
       name: "{name}_tl_errors"
+      build_mode: "cover_reg_top"
       uvm_test_seq: "{name}_common_vseq"
       run_opts: ["+run_tl_errors"]
       reseed: 20

--- a/hw/dv/tools/vcs/cover.cfg
+++ b/hw/dv/tools/vcs/cover.cfg
@@ -1,9 +1,15 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Enables coverage on the entire DUT. Limits the port only toggle coverage to
+// the DUT IOs.
+
 +tree tb.dut
-begin tgl(portsonly)
+-module pins_if     // DV construct.
+-module clk_rst_if  // DV construct.
+
+begin tgl
   -tree tb
   +tree tb.dut 1
-end
-// pins_if is used in tlul_assert which is binded to dut, should remove it in coverage
-begin
-  line+cond+branch -module pins_if
 end

--- a/hw/dv/tools/vcs/cover_reg_top.cfg
+++ b/hw/dv/tools/vcs/cover_reg_top.cfg
@@ -1,0 +1,14 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Limits coverage collection only to the *_reg_top module and the TL interface
+// of the DUT.
+
++moduletree *_reg_top
++node tb.dut tl_*
+
+// Remove everything else from toggle coverage.
+begin tgl
+  -tree tb
+end

--- a/hw/ip/aes/dv/aes_sim_cfg.hjson
+++ b/hw/ip/aes/dv/aes_sim_cfg.hjson
@@ -45,13 +45,8 @@
   uvm_test: aes_base_test
   uvm_test_seq: aes_wake_up_vseq
 
-  // Update the default build mode to add options specific to AES C model compilation.
-  build_modes: [
-    {
-      name: default
-      en_build_modes: ["{tool}_aes_model_build_opts"]
-    }
-  ]
+  // Update all builds to add options specific to AES C model compilation.
+  en_build_modes: ["{tool}_aes_model_build_opts"]
 
   // List of test specifications.
   tests: [

--- a/hw/ip/prim/dv/prim_lfsr/prim_lfsr_sim_cfg.hjson
+++ b/hw/ip/prim/dv/prim_lfsr/prim_lfsr_sim_cfg.hjson
@@ -37,6 +37,11 @@
     }
   ]
 
+  // TODO: each build_mode needs to supply {build_mode}_vcs_cov_hier, else the
+  // build breaks.
+  prim_lfsr_dw_8_vcs_cov_hier: ""
+  prim_lfsr_dw_24_vcs_cov_hier: ""
+
   // List of test specifications.
   tests: [
     {

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -39,24 +39,43 @@
                 "{proj_root}/hw/ip/tlul/generic_dv/xbar_tests.hjson"
                 ]
 
-  // Override the default vcs_cov_hier flag to supply chip specific coverage hierarchies.
+  // Override existing project defaults to supply chip-specific values.
   overrides: [
+    // Chip level design is markedly different from our Comportable IPs (and so
+    // is our coverage goals). The coverage goals also differ between 'default'
+    // and the 'cover_reg_top' (used by common tests) builds. We override the
+    // variables below to swap the coverage cfg files used for the Comportable
+    // IPs with chip-specific ones. See `doc/ug/dv_methodology.md` for more
+    // details.
+
+    // Used by all chip level functional test. Collects coverage on the IO
+    // boundary of all pre-verified IPs and full coverage on non-pre-verified
+    // IPs. See `hw/dv/data/common_sim_cfg.hjson` for the default value.
     {
-      name: vcs_cov_hier
+      name: default_vcs_cov_hier
       value: "-cm_hier {tool_srcs_dir}/chip_cover.cfg"
     }
+    // Used by 'cover_reg_top' only builds - we only cover the *_reg_top of
+    // the non-pre-verified modules at the chip level. See
+    // `hw/dv/data//common_sim_cfg.hjson` for the default value.
+    {
+      name: cover_reg_top_vcs_cov_hier
+      value: "-cm_hier {tool_srcs_dir}/chip_cover_reg_top.cfg"
+    }
+
+    // This defaults to 'ip' in `hw/data/common_project_cfg.hjson`.
     {
       name: design_level
       value: "top"
     }
   ]
 
-  // Set the vcs_cov_assert_hier to supply the chip specific assertion coverage hierarchies.
+  // Set the vcs_cov_assert_hier to supply the chip specific assertion coverage
+  // hierarchies.
   vcs_cov_assert_hier: "-cm_assert_hier {tool_srcs_dir}/chip_assert_cover.cfg"
 
   // Add these to tool_srcs so that they get copied over.
-  tool_srcs: ["{proj_root}/hw/top_earlgrey/dv/cov/chip_cover.cfg",
-              "{proj_root}/hw/top_earlgrey/dv/cov/chip_assert_cover.cfg"]
+  tool_srcs: ["{proj_root}/hw/top_earlgrey/dv/cov/*"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 1
@@ -161,8 +180,9 @@
       sw_test: sw/device/tock/prebuilt/opentitan
       sw_test_is_prebuilt: 1
       run_opts: ["+en_uart_logger=1",
-                 // TODO #2241: tock reads an uninitialized part of stack, which causes
-                 // assertion errors to be thrown. This is a temporary workaround.
+                 // TODO #2241: tock reads an un-initialized part of stack,
+                 // which causes assertion errors to be thrown. This is a
+                 // temporary workaround.
                  "+initialize_ram=1",
                  "+sw_test_timeout_ns=50000000"]
     }

--- a/hw/top_earlgrey/dv/cov/chip_assert_cover.cfg
+++ b/hw/top_earlgrey/dv/cov/chip_assert_cover.cfg
@@ -1,4 +1,6 @@
--tree *
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
 
 // Include assertions within these modules.
 +module tb
@@ -8,10 +10,15 @@
 
 // Enable full assertion coverage collection within these modules including their
 // sub-hierarchies since they are not pre-verified.
-+tree tb.dut.padctl
++tree tb.dut.padring
+
++tree tb.dut.top_earlgrey.u_clkmgr
++tree tb.dut.top_earlgrey.u_nmi_gen
++tree tb.dut.top_earlgrey.u_padctrl
 +tree tb.dut.top_earlgrey.u_pinmux
 +tree tb.dut.top_earlgrey.u_pwrmgr
-+tree tb.dut.top_earlgrey.u_nmi_gen
 +tree tb.dut.top_earlgrey.u_rstmgr
 +tree tb.dut.top_earlgrey.u_rv_plic
-+tree tb.dut.top_earlgrey.u_tl_adapter*
++tree tb.dut.top_earlgrey.u_tl_adapter_rom
++tree tb.dut.top_earlgrey.u_tl_adapter_ram_main
++tree tb.dut.top_earlgrey.u_tl_adapter_ram_ret

--- a/hw/top_earlgrey/dv/cov/chip_cover.cfg
+++ b/hw/top_earlgrey/dv/cov/chip_cover.cfg
@@ -1,9 +1,15 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
 -tree *
+-module pins_if     // DV construct.
+-module clk_rst_if  // DV construct.
 
 // Include port toggles of all IOs at these hierarchies.
 begin tgl(portsonly)
   +module top_earlgrey_asic
-  +module padctl
+  +module padring
   +moduletree top_earlgrey 2
   +moduletree rv_core_ibex 2
 end
@@ -15,14 +21,19 @@ begin line+cond+fsm+branch
   +module rv_core_ibex
 end
 
-// Enable full coverage collection on these modules including their sub-hierarchies since they are
-// not pre-verified.
+// Enable full coverage collection on these modules including their
+// sub-hierarchies since they are not pre-verified.
 begin line+cond+fsm+branch
-  +moduletree padctl
+  +moduletree padring
+
+  +moduletree clkmgr
+  +moduletree nmi_gen
+  +moduletree padctrl
   +moduletree pinmux
   +moduletree pwrmgr
-  +moduletree nmi_gen
   +moduletree rstmgr
   +moduletree rv_plic
-  +tree tb.dut.top_earlgrey.u_tl_adapter*
+  +tree tb.dut.top_earlgrey.u_tl_adapter_rom
+  +tree tb.dut.top_earlgrey.u_tl_adapter_ram_main
+  +tree tb.dut.top_earlgrey.u_tl_adapter_ram_ret
 end

--- a/hw/top_earlgrey/dv/cov/chip_cover_reg_top.cfg
+++ b/hw/top_earlgrey/dv/cov/chip_cover_reg_top.cfg
@@ -1,0 +1,23 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Only cover the `u_reg` instance of un-pre-verified modules.
+-tree *
++tree tb.dut.top_earlgrey.u_clkmgr.u_reg
++tree tb.dut.top_earlgrey.u_nmi_gen.u_reg
++tree tb.dut.top_earlgrey.u_padctrl.u_reg
++tree tb.dut.top_earlgrey.u_pinmux.u_reg
++tree tb.dut.top_earlgrey.u_pwrmgr.u_reg
++tree tb.dut.top_earlgrey.u_rstmgr.u_reg
++tree tb.dut.top_earlgrey.u_rv_plic.u_reg
+
+// Only cover the TL interface of all sub-modules.
++node tb.dut.top_earlgrey.u_*.tl_*
+
+// TODO: Add TL interface of top_earlgrey and AST when available.
+
+// Remove everything else from toggle coverage.
+begin tgl
+  -tree tb
+end


### PR DESCRIPTION
The first commit enhances the DVSim tool such that it can automatically figure out if a uniquely specific build is indeed unique or not (it could be unique only under specific conditions such as coverage being enabled, but otherwise be identical to an existing build). This saves compute resources, especially in our private CI. 

The second commit reorganizes and splits the collected coverage for IPs between functional tests (full DUT coverage collected) and the common tests (CSR/MEM/intr/TL access) (only *_reg_top and the TL interface). 

The third commit does the same for the top level. 