### PR TITLE
[bronze/dvsim/lint] General tooling update

### DIFF
--- a/hw/data/common_project_cfg.hjson
+++ b/hw/data/common_project_cfg.hjson
@@ -25,4 +25,12 @@
 
   results_summary_server_html: "summary.html"
   results_summary_server_page: "{results_server_path}/{results_summary_server_html}"
+
+  // If defined, this is printed into the results md files
+  revision_string: '''{eval_cmd}
+      COMMIT_SHORT=`git log -n 1 --abbrev-commit | head -n 1 | awk -F ' ' '{print $2}'`;                         \
+      COMMIT_LONG=`git log -n 1 | head -n 1 | awk -F ' ' '{print $2}'`;                                          \
+      BRANCH=`git rev-parse --abbrev-ref HEAD`;                                                                  \
+      echo "Revision: [\`$COMMIT_SHORT\`](https://github.com/lowrisc/opentitan/tree/$COMMIT_LONG) on \`$BRANCH\`";
+      '''
 }

--- a/hw/ip/aes/aes.core
+++ b/hw/ip/aes/aes.core
@@ -88,6 +88,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/alert_handler/alert_handler.core
+++ b/hw/ip/alert_handler/alert_handler.core
@@ -41,6 +41,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/clkmgr/clkmgr.core
+++ b/hw/ip/clkmgr/clkmgr.core
@@ -56,6 +56,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/csrng/csrng.core
+++ b/hw/ip/csrng/csrng.core
@@ -66,6 +66,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/dcd/dcd.core
+++ b/hw/ip/dcd/dcd.core
@@ -36,6 +36,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/entropy_src/entropy_src.core
+++ b/hw/ip/entropy_src/entropy_src.core
@@ -58,6 +58,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/flash_ctrl/flash_ctrl.core
+++ b/hw/ip/flash_ctrl/flash_ctrl.core
@@ -86,6 +86,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/gpio/gpio.core
+++ b/hw/ip/gpio/gpio.core
@@ -72,6 +72,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/hmac/hmac.core
+++ b/hw/ip/hmac/hmac.core
@@ -76,6 +76,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/i2c/i2c.core
+++ b/hw/ip/i2c/i2c.core
@@ -75,6 +75,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/keymgr/keymgr.core
+++ b/hw/ip/keymgr/keymgr.core
@@ -72,6 +72,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/kmac/kmac.core
+++ b/hw/ip/kmac/kmac.core
@@ -35,6 +35,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/lifecycle/lifecycle.core
+++ b/hw/ip/lifecycle/lifecycle.core
@@ -66,6 +66,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/lifecycle/lifecycle_top.core
+++ b/hw/ip/lifecycle/lifecycle_top.core
@@ -58,6 +58,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/nmi_gen/nmi_gen.core
+++ b/hw/ip/nmi_gen/nmi_gen.core
@@ -62,6 +62,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/otbn/otbn.core
+++ b/hw/ip/otbn/otbn.core
@@ -39,6 +39,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/otp_ctrl/otp_ctrl.core
+++ b/hw/ip/otp_ctrl/otp_ctrl.core
@@ -66,6 +66,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/otp_ctrl/otp_ctrl_component.core
+++ b/hw/ip/otp_ctrl/otp_ctrl_component.core
@@ -64,6 +64,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/padctrl/padctrl.core
+++ b/hw/ip/padctrl/padctrl.core
@@ -29,6 +29,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/pattgen/pattgen.core
+++ b/hw/ip/pattgen/pattgen.core
@@ -35,6 +35,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/pinmux/pinmux.core
+++ b/hw/ip/pinmux/pinmux.core
@@ -29,6 +29,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/pwm/pwm.core
+++ b/hw/ip/pwm/pwm.core
@@ -55,6 +55,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/pwrmgr/pwrmgr.core
+++ b/hw/ip/pwrmgr/pwrmgr.core
@@ -69,6 +69,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/rbox/rbox.core
+++ b/hw/ip/rbox/rbox.core
@@ -34,6 +34,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/rstmgr/rstmgr.core
+++ b/hw/ip/rstmgr/rstmgr.core
@@ -58,6 +58,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/rv_core_ibex/rv_core_ibex.core
+++ b/hw/ip/rv_core_ibex/rv_core_ibex.core
@@ -73,6 +73,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/rv_dm/rv_dm.core
+++ b/hw/ip/rv_dm/rv_dm.core
@@ -78,6 +78,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/rv_plic/rv_plic.core
+++ b/hw/ip/rv_plic/rv_plic.core
@@ -34,6 +34,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/rv_timer/rv_timer.core
+++ b/hw/ip/rv_timer/rv_timer.core
@@ -73,6 +73,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/sensor_ctrl/sensor_ctrl.core
+++ b/hw/ip/sensor_ctrl/sensor_ctrl.core
@@ -54,6 +54,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/spi_device/spi_device.core
+++ b/hw/ip/spi_device/spi_device.core
@@ -81,6 +81,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/spi_device/spi_pkg.core
+++ b/hw/ip/spi_device/spi_pkg.core
@@ -19,6 +19,9 @@ targets:
     <<: *default_target
     default_tool: verilator
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/spi_host/spi_host.core
+++ b/hw/ip/spi_host/spi_host.core
@@ -81,6 +81,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/tlul/adapter_host.core
+++ b/hw/ip/tlul/adapter_host.core
@@ -58,6 +58,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/tlul/adapter_reg.core
+++ b/hw/ip/tlul/adapter_reg.core
@@ -57,6 +57,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/tlul/adapter_sram.core
+++ b/hw/ip/tlul/adapter_sram.core
@@ -58,6 +58,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/tlul/socket_1n.core
+++ b/hw/ip/tlul/socket_1n.core
@@ -59,6 +59,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/tlul/socket_m1.core
+++ b/hw/ip/tlul/socket_m1.core
@@ -58,6 +58,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/tlul/sram2tlul.core
+++ b/hw/ip/tlul/sram2tlul.core
@@ -57,6 +57,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/uart/uart.core
+++ b/hw/ip/uart/uart.core
@@ -76,6 +76,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/usb_fs_nb_pe/usbfs_nb_pe.core
+++ b/hw/ip/usb_fs_nb_pe/usbfs_nb_pe.core
@@ -63,6 +63,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/usbdev/usbdev.core
+++ b/hw/ip/usbdev/usbdev.core
@@ -78,6 +78,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/usbuart/usbuart.core
+++ b/hw/ip/usbuart/usbuart.core
@@ -79,6 +79,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/lint/data/common_lint_cfg.hjson
+++ b/hw/lint/data/common_lint_cfg.hjson
@@ -18,9 +18,8 @@
   build_log:  "{build_dir}/lint.log"
   // We rely on fusesoc to run lint for us
   build_cmd:  "fusesoc"
-  build_opts: ["--cores-root {proj_root}/hw",
+  build_opts: ["--cores-root {proj_root}",
                "run",
-               "--flag=fileset_{design_level}",
                "--target={flow}",
                "--tool={tool}",
                "--build-root={build_dir}",

--- a/hw/lint/doc/README.md
+++ b/hw/lint/doc/README.md
@@ -59,6 +59,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/syn/data/dc.hjson
+++ b/hw/syn/data/dc.hjson
@@ -28,6 +28,9 @@
                 "--reppath {build_dir}/REPORTS/ ",
                 "--outdir {build_dir}"]
 
-  // Restrict the maximum message count to 10 in each category
-  max_msg_count: 10
+  // Restrict the maximum message count in each category
+  max_msg_count: 20
+  // Do not sanitize regression mails, but do sanitize the published report
+  sanitize_email_results:   false
+  sanitize_publish_results: true
 }

--- a/hw/syn/data/syn.mk
+++ b/hw/syn/data/syn.mk
@@ -32,10 +32,6 @@ compile_result: post_compile
 	@echo "[make]: compile_result"
 	${report_cmd} ${report_opts}
 
-clean:
-	echo "[make]: clean"
-	rm -rf ${scratch_root}/${dut}/*
-
 .PHONY: build \
 	gen_sv_flist \
 	pre_compile \

--- a/hw/top_earlgrey/ip/ast/ast.core
+++ b/hw/top_earlgrey/ip/ast/ast.core
@@ -25,6 +25,9 @@ targets:
     <<: *default_target
     default_tool: verilator
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/top_earlgrey/lint/top_earlgrey_lint_cfgs.hjson
+++ b/hw/top_earlgrey/lint/top_earlgrey_lint_cfgs.hjson
@@ -26,6 +26,16 @@
                   import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
                   rel_path: "hw/ip/alert_handler/lint/{tool}/v1-bronze"
              },
+             {    name: csrng
+                  fusesoc_core: lowrisc:ip:csrng
+                  import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/csrng/lint/{tool}/v1-bronze"
+             },
+             {    name: entropy_src
+                  fusesoc_core: lowrisc:ip:entropy_src
+                  import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/entropy_src/lint/{tool}/v1-bronze"
+             },
              {    name: flash_ctrl
                   fusesoc_core: lowrisc:ip:flash_ctrl
                   import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
@@ -51,10 +61,20 @@
                   import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
                   rel_path: "hw/ip/nmi_gen/lint/{tool}/v1-bronze"
              },
+             {    name: otbn
+                  fusesoc_core: lowrisc:ip:otbn
+                  import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/otbn/lint/{tool}/v1-bronze"
+             },
              {    name: padctrl
                   fusesoc_core: lowrisc:ip:padctrl
                   import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
                   rel_path: "hw/ip/padctrl/lint/{tool}/v1-bronze"
+             },
+             {    name: pattgen
+                  fusesoc_core: lowrisc:ip:pattgen
+                  import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/pattgen/lint/{tool}/v1-bronze"
              },
              {    name: pinmux
                   fusesoc_core: lowrisc:ip:pinmux
@@ -145,12 +165,12 @@
              //{    name: top_earlgrey_nexysvideo
              //     fusesoc_core: lowrisc:systems:top_earlgrey_nexysvideo
              //     import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
-             //     rel_path: "hw/top_earlgrey_nexysvideo/lint/{tool}"
+             //     rel_path: "hw/top_earlgrey_nexysvideo/lint/{tool}/v1-bronze"
              //},
              //{    name: top_earlgrey_verilator
              //     fusesoc_core: lowrisc:systems:top_earlgrey_verilator
              //     import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
-             //     rel_path: "hw/top_earlgrey_verilator/lint/{tool}"
+             //     rel_path: "hw/top_earlgrey_verilator/lint/{tool}/v1-bronze"
              //},
             ]
 }

--- a/hw/top_earlgrey/top_earlgrey.core
+++ b/hw/top_earlgrey/top_earlgrey.core
@@ -126,6 +126,9 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/top_earlgrey/top_earlgrey_asic.core
+++ b/hw/top_earlgrey/top_earlgrey_asic.core
@@ -36,6 +36,9 @@ targets:
     <<: *default_target
     default_tool: verilator
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/top_earlgrey/top_earlgrey_nexysvideo.core
+++ b/hw/top_earlgrey/top_earlgrey_nexysvideo.core
@@ -69,6 +69,9 @@ targets:
     <<: *default_target
     default_tool: verilator
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/top_earlgrey/top_earlgrey_verilator.core
+++ b/hw/top_earlgrey/top_earlgrey_verilator.core
@@ -102,6 +102,9 @@ targets:
     <<: *default_target
     default_tool: verilator
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/vendor/lowrisc_ibex/ibex_core.core
+++ b/hw/vendor/lowrisc_ibex/ibex_core.core
@@ -126,6 +126,9 @@ targets:
     default_tool: verilator
     toplevel: ibex_core
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/vendor/lowrisc_ibex/ibex_core_tracing.core
+++ b/hw/vendor/lowrisc_ibex/ibex_core_tracing.core
@@ -111,6 +111,9 @@ targets:
     default_tool: verilator
     toplevel: ibex_core_tracing
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:


### PR DESCRIPTION
This carries over all recent patches that went into `dvsim` on `master`, and aligns the lint and synthesis flows accordingly.

Also, IPs that have been missing from the over-arching lint cfg (like `otbn`, `entropy_src`, `csrng` and `pattgen`) are added in this PR.

The results of a manual run of this lint batch can be found here:

https://reports.opentitan.org/hw/top_earlgrey/lint/ascentlint/v1-bronze/summary.html

If needed, I can enable the `v1-bronze` lint patch in regressions to help designers fix their blocks. 

(Note that even though this is built on bronze, it only contains the generic views and hence not proprietary info from `/hw/foundry` is published here).
