### PR TITLE
[fpv/tlul] syntax error fix

### DIFF
--- a/hw/ip/tlul/rtl/tlul_pkg.sv
+++ b/hw/ip/tlul/rtl/tlul_pkg.sv
@@ -44,8 +44,10 @@ package tlul_pkg;
   } tl_h2d_t;
 
   localparam tl_h2d_t TL_H2D_DEFAULT = '{
-    d_ready: 1'b1,
-    default: '0
+    d_ready:  1'b1,
+    a_opcode: tl_a_op_e'('0),
+    a_user:   tl_a_user_t'('0),
+    default:  '0
   };
 
   typedef struct packed {
@@ -63,7 +65,8 @@ package tlul_pkg;
   } tl_d2h_t;
 
   localparam tl_d2h_t TL_D2H_DEFAULT = '{
-    a_ready: 1'b1,
-    default: '0
+    a_ready:  1'b1,
+    d_opcode: tl_d_op_e'('0),
+    default:  '0
   };
 endpackage


### PR DESCRIPTION
FPV gives error for this syntax:
` ../src/lowrisc_tlul_headers_0.1/rtl/tlul_pkg.sv(49): an enum variable
may only be assigned the same enum typed variable or one of its values`

DV also throws warning:
`file: ../src/lowrisc_tlul_headers_0.1/rtl/tlul_pkg.sv
    default: '0
              |
xmvlog: *W,ENUMERR (../src/lowrisc_tlul_headers_0.1/rtl/tlul_pkg.sv,48|14): This assignment is a violation of SystemVerilog strong typing rules for enumeration datatypes.
`
This PR tries to fix this compile error by casting the enums.
Please feel free to let me know if you prefer some other ways to fix it.

Signed-off-by: Cindy Chen <chencindy@google.com>