### PR TITLE
[dv] Renable chip sanity test

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -176,11 +176,10 @@
   ]
 
   // List of regressions.
-  // TODO #2405: Waiting for bug fixes in Ibex.
-  // regressions: [
-  //   {
-  //     name: sanity
-  //     tests: ["chip_uart_tx_rx"]
-  //   }
-  // ]
+  regressions: [
+    {
+      name: sanity
+      tests: ["chip_uart_tx_rx"]
+    }
+  ]
 }


### PR DESCRIPTION
This reenables chip level sanity test that was temporarily disabled due
to #2405, for which fixes now seem to be in place.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>