### PR TITLE
[dv/alert] temp hack for top_level async alert

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent_cfg.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent_cfg.sv
@@ -10,6 +10,7 @@ class alert_esc_agent_cfg extends dv_base_agent_cfg;
   virtual alert_esc_if vif;
   virtual alert_esc_probe_if probe_vif;
   bit is_alert = 1;
+  bit is_async = 0;
 
   // sender mode
   bit use_seq_item_alert_delay;

--- a/hw/dv/sv/alert_esc_agent/alert_monitor.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_monitor.sv
@@ -90,6 +90,11 @@ class alert_monitor extends alert_esc_base_monitor;
     bit                alert_p;
     forever @(cfg.vif.monitor_cb) begin
       if (!alert_p && is_valid_alert() && !under_ping_rsp) begin
+        // TODO: temp solution for alert async mode - it adds another diff_reg to pass the
+        // alert_trigger signal. Needs more testing on different clk freqs.
+        if (cfg.is_async) begin
+          repeat (2) @(cfg.vif.monitor_cb);
+        end
         req = alert_esc_seq_item::type_id::create("req");
         req.alert_esc_type = AlertEscSigTrans;
         req.alert_handshake_sta = AlertReceived;

--- a/hw/ip/alert_handler/dv/env/alert_handler_env_cfg.sv
+++ b/hw/ip/alert_handler/dv/env/alert_handler_env_cfg.sv
@@ -38,6 +38,7 @@ class alert_handler_env_cfg extends cip_base_env_cfg #(.RAL_T(alert_handler_reg_
       alert_host_cfg[i] =
           alert_esc_agent_cfg::type_id::create($sformatf("alert_host_cfg[%0d]", i));
       alert_host_cfg[i].if_mode = dv_utils_pkg::Host;
+      alert_host_cfg[i].is_async = ASYNC_ON[i];
     end
     foreach (esc_device_cfg[i]) begin
       esc_device_cfg[i] =


### PR DESCRIPTION
This PR provides a temp solution for async alert in top_level. 
This PR adds a two clock cycles delay to match design behavior for async alerts.
This PR only tries unblock CI failures(in case it blocks any PR). 
More comprehensive support for async alert will be implemented in a separate PR.

Signed-off-by: Cindy Chen <chencindy@google.com>