### PR TITLE
[dvsim] Force an ordering when constructing command in Deploy object

### DIFF
--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -154,8 +154,7 @@ class Deploy():
         cmd = "make -f " + self.flow_makefile + " " + self.target
         if self.dry_run is True:
             cmd += " -n"
-        for attr in self.mandatory_cmd_attrs.keys():
-            value = getattr(self, attr)
+        for attr, value in sorted(self.mandatory_cmd_attrs.items()):
             if type(value) is list:
                 pretty_value = []
                 for item in value:


### PR DESCRIPTION
A Deploy object has an effect by running some command. This command is
constructed as a string in `Deploy.construct_cmd` by iterating over
"mandatory command attributes". These are stored in a dict. We don't
really care about the exact ordering, but it does need to be
consistent (and not depend on Dict's internal hashing).

One way to do this is to make `mandatory_cmd_attrs` an `OrderedDict`, but
there are several definitions of `mandatory_cmd_attrs`, which all need
to be updated correctly. Since we don't care about the order, and only
care that it's consistent, it seems simpler just to iterate over the
attributes in sorted order.

Note that `sorted(my_dict.items())` does the right thing (ordering by
key) because the default sort on tuples is lexicographic, so we'll
alphabetically sort the list of keys. Indeed, this has no duplicates,
so we'll never inspect the values.

This is related to PR #3111. The inconsistent ordering from iterating over a Dict caused problems there, but I think this needs fixing either way: hopefully our tooling doesn't care about the order of its input arguments, but this way it'll be much easier to debug disasters if it does!

I think this approach is a bit simpler than using an `OrderedDict` as proposed there and moves the job of forcing an ordering to just one line.