### PR TITLE
[dvsim] Force an ordering when constructing command in Deploy object

### DIFF
--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -154,7 +154,7 @@ class Deploy():
         cmd = "make -f " + self.flow_makefile + " " + self.target
         if self.dry_run is True:
             cmd += " -n"
-        for attr in self.mandatory_cmd_attrs.keys():
+        for attr in sorted(self.mandatory_cmd_attrs.keys()):
             value = getattr(self, attr)
             if type(value) is list:
                 pretty_value = []


### PR DESCRIPTION
A Deploy object has an effect by running some command. This command is
constructed as a string in Deploy.construct_cmd and is of the form

```sh
make -f ... A=1 B=2 C=3
```

where the `A`, `B`, `C` parameters are found by iterating over
"mandatory command attributes". These are stored in a dict. We don't
really care about the exact ordering, but it does need to be
consistent (and not depend on `Dict`'s internal hashing).

One way to do this is to make `mandatory_cmd_attrs` an `OrderedDict`, but
there are several definitions of `mandatory_cmd_attrs`, which all need
to be updated correctly. Since we don't care about the order, and only
care that it's consistent, it seems simpler just to iterate over the
attributes in sorted order.

This is related to PR #3111. The inconsistent ordering from iterating over a Dict caused problems there, but I think this needs fixing either way: even if Make doesn't care about the order we give it parameter values, it's rather cleaner to do it the same every time.

I think this approach is a bit simpler than using an `OrderedDict` as proposed there and moves the job of forcing an ordering to just one line.