### PR TITLE
[aes, usbdev] Bronze lint fixes

### DIFF
--- a/hw/ip/aes/rtl/aes.sv
+++ b/hw/ip/aes/rtl/aes.sv
@@ -67,6 +67,8 @@ module aes #(
     .prng_reseed_req_o ( prng_reseed_req ),
     .prng_reseed_ack_i ( prng_reseed_ack ),
 
+    .keymgr_key_i,
+
     .reg2hw,
     .hw2reg
   );

--- a/hw/ip/aes/rtl/aes_core.sv
+++ b/hw/ip/aes/rtl/aes_core.sv
@@ -21,6 +21,9 @@ module aes_core #(
   output logic                     prng_reseed_req_o,
   input  logic                     prng_reseed_ack_i,
 
+  // Key manager interface
+  input  keymgr_pkg::hw_key_req_t  keymgr_key_i,
+
   // Bus Interface
   input  aes_reg_pkg::aes_reg2hw_t reg2hw,
   output aes_reg_pkg::aes_hw2reg_t hw2reg
@@ -184,11 +187,11 @@ module aes_core #(
   logic [7:0]       key_init_share1_we;
   logic [7:0][31:0] key_init_share1_d;
   logic [7:0][31:0] key_init_share1_q;
-  assign key_init_share1_we = key_init_we;
+  assign key_init_share1_we = {8{keymgr_key_i.valid}};
 
   always_comb begin : key_init_share1_mux
     unique case (key_init_sel)
-      KEY_INIT_INPUT: key_init_share1_d = key_init;
+      KEY_INIT_INPUT: key_init_share1_d = keymgr_key_i.key_share0 ^ keymgr_key_i.key_share1;
       KEY_INIT_CLEAR: key_init_share1_d = {prng_data_i, prng_data_i, prng_data_i, prng_data_i};
       default:        key_init_share1_d = key_init_share1_q;
     endcase

--- a/hw/ip/usbdev/rtl/usbdev.sv
+++ b/hw/ip/usbdev/rtl/usbdev.sv
@@ -138,6 +138,7 @@ module usbdev (
   logic              usb_enable;
   logic [6:0]        usb_device_addr;
 
+  logic                  data_toggle_clear_qe;
   logic                  usb_data_toggle_clear_en;
   logic [NEndpoints-1:0] usb_data_toggle_clear;
 
@@ -164,6 +165,7 @@ module usbdev (
   logic              usb_av_rvalid, usb_av_rready;
   logic              usb_rx_wvalid, usb_rx_wready;
   logic              rx_fifo_rvalid;
+  logic              rx_fifo_re;
 
   logic [AVFifoWidth - 1:0] usb_av_rdata;
   logic [RXFifoWidth - 1:0] usb_rx_wdata, rx_rdata_raw, rx_rdata;
@@ -192,6 +194,9 @@ module usbdev (
     .rdepth_o  () // only using empty
   );
 
+  assign rx_fifo_re = reg2hw.rxfifo.ep.re | reg2hw.rxfifo.setup.re |
+                      reg2hw.rxfifo.size.re | reg2hw.rxfifo.buffer.re;
+
   prim_fifo_async #(
     .Width(RXFifoWidth),
     .Depth(RXFifoDepth)
@@ -207,7 +212,7 @@ module usbdev (
     .clk_rd_i  (clk_i),
     .rst_rd_ni (rst_ni),
     .rvalid_o  (rx_fifo_rvalid),
-    .rready_i  (reg2hw.rxfifo.buffer.re),
+    .rready_i  (rx_fifo_re),
     .rdata_o   (rx_rdata_raw),
     .rdepth_o  (hw2reg.usbstat.rx_depth.d)
   );
@@ -219,8 +224,11 @@ module usbdev (
   assign hw2reg.rxfifo.size.d = rx_rdata[11:5];
   assign hw2reg.rxfifo.buffer.d = rx_rdata[4:0];
   assign event_pkt_received = rx_fifo_rvalid;
-  logic [2:0]               unused_re;
-  assign unused_re = {reg2hw.rxfifo.ep.re, reg2hw.rxfifo.setup.re, reg2hw.rxfifo.size.re};
+
+  // The rxfifo register is hrw, but we just need the read enables.
+  logic [16:0] unused_rxfifo_q;
+  assign unused_rxfifo_q = {reg2hw.rxfifo.ep.q, reg2hw.rxfifo.setup.q,
+                            reg2hw.rxfifo.size.q, reg2hw.rxfifo.buffer.q};
 
   ////////////////////////////////////
   // IN (Transmit) interface config //
@@ -293,12 +301,19 @@ module usbdev (
 
   // CDC: We synchronize the qe (write pulse) and assume that the
   // rest of the register remains stable
+  always_comb begin : proc_data_toggle_clear_qe
+    data_toggle_clear_qe = 1'b0;
+    for (int i = 0; i < NEndpoints; i++) begin
+      data_toggle_clear_qe |= reg2hw.data_toggle_clear[i].qe;
+    end
+  end
+
   prim_pulse_sync usbdev_data_toggle_clear (
     .clk_src_i   (clk_i),
     .clk_dst_i   (clk_usb_48mhz_i),
     .rst_src_ni  (rst_ni),
     .rst_dst_ni  (rst_usb_48mhz_ni),
-    .src_pulse_i (reg2hw.data_toggle_clear[0].qe),
+    .src_pulse_i (data_toggle_clear_qe),
     .dst_pulse_o (usb_data_toggle_clear_en)
   );
 
@@ -604,7 +619,7 @@ module usbdev (
   always_comb begin : proc_stall_tieoff
     for (int i = 0; i < NEndpoints; i++) begin
       hw2reg.stall[i].d  = 1'b0;
-      if (setup_received && usb_out_endpoint == 4'(i)) begin
+      if (setup_received && usb_out_endpoint == 4'(unsigned'(i))) begin
         hw2reg.stall[i].de = 1'b1;
       end else begin
         hw2reg.stall[i].de = 1'b0;

--- a/hw/ip/usbdev/rtl/usbdev_iomux.sv
+++ b/hw/ip/usbdev/rtl/usbdev_iomux.sv
@@ -60,6 +60,14 @@ module usbdev_iomux
   logic cio_usb_dp, cio_usb_dn, cio_usb_d;
   logic usb_rx_dp, usb_rx_dn, usb_rx_d;
 
+  logic unused_eop_single_bit;
+  assign unused_eop_single_bit = sys_reg2hw_config_i.eop_single_bit.q;
+  logic unused_pinflip;
+  assign unused_pinflip = sys_reg2hw_config_i.pinflip.q;
+  logic unused_rx_diff, unused_tx_diff;
+  assign unused_rx_diff = sys_reg2hw_config_i.rx_differential_mode.q;
+  assign unused_tx_diff = sys_reg2hw_config_i.tx_differential_mode.q;
+
   //////////
   // CDCs //
   //////////

--- a/hw/ip/usbdev/rtl/usbdev_usbif.sv
+++ b/hw/ip/usbdev/rtl/usbdev_usbif.sv
@@ -123,7 +123,7 @@ module usbdev_usbif  #(
       // Following all ones out_max_used_q will get 1,00..00 and 1,00..01 to cover
       // one and two bytes of the CRC overflowing, then stick at 1,00..01
       if (out_max_used_q < MaxPktSizeByte - 1) begin
-        out_max_used_d = out_ep_put_addr;
+        out_max_used_d = {1'b0, out_ep_put_addr};
       end else if (out_max_used_q < MaxPktSizeByte + 1) begin
         out_max_used_d = out_max_used_q + 1;
       end else begin
@@ -161,6 +161,9 @@ module usbdev_usbif  #(
           end
           3: begin
             wdata[31:24] <= out_ep_data;
+          end
+          default: begin
+            wdata[7:0] <= out_ep_data;
           end
         endcase
       end


### PR DESCRIPTION
This PR hopefully fixes some more lint errors on `v1-bronze`.

Question: Both on the main branch and on `v1-bronze` I see lint errors for aes related to primitives (actually just the autogenerated wrappers for the generic primitives) that are not used inside aes at all. Examples include:
```
E   INPUT_NOT_READ:   prim_flop.sv:20         Input port 'clk_i' is not read from in module 'prim_flop'
E   INPUT_NOT_READ:   prim_flop.sv:21         Input port 'rst_ni' is not read from in module 'prim_flop'
```
Do you know how to fix this?