### PR TITLE
Instrument captures on C305 FPGA with ChipWhisperer

### DIFF
--- a/hw/top_earlgrey/data/pins_cw305.xdc
+++ b/hw/top_earlgrey/data/pins_cw305.xdc
@@ -5,9 +5,6 @@
 set_property -dict { PACKAGE_PIN N13 IOSTANDARD LVCMOS33 } [get_ports { IO_CLK }]
 create_clock -add -name sys_clk_pin -period 10.00 -waveform {0 5} [get_ports IO_CLK]
 
-## Output clock to capture board
-set_property -dict { PACKAGE_PIN M16 IOSTANDARD LVCMOS33 } [get_ports TIO_CLKOUT]
-
 ## Clock Domain Crossings
 create_generated_clock -name clk_50_unbuf -source [get_pin clkgen/pll/CLKIN1] [get_pin clkgen/pll/CLKOUT0]
 create_generated_clock -name clk_48_unbuf -source [get_pin clkgen/pll/CLKIN1] [get_pin clkgen/pll/CLKOUT1]
@@ -19,17 +16,13 @@ set_property -dict { PACKAGE_PIN T3  DRIVE 8 IOSTANDARD LVCMOS33 } [get_ports { 
 set_property -dict { PACKAGE_PIN T4  DRIVE 8 IOSTANDARD LVCMOS33 } [get_ports { IO_GP10 }]
 
 ## Buttons
-set_property -dict { PACKAGE_PIN L14 IOSTANDARD LVCMOS33 } [get_ports { IO_RST_N }]; #pushbutton
+set_property -dict { PACKAGE_PIN R1 IOSTANDARD LVCMOS33 } [get_ports { IO_RST_N }]; #pushbutton
 
 ## Switches
 set_property -dict { PACKAGE_PIN J16 IOSTANDARD LVCMOS33 } [get_ports { IO_GP0 }]; #sw1
 set_property -dict { PACKAGE_PIN K16 IOSTANDARD LVCMOS33 } [get_ports { IO_GP1 }]; #sw2
 set_property -dict { PACKAGE_PIN K15 IOSTANDARD LVCMOS33 } [get_ports { IO_GP2 }]; #sw3
-set_property -dict { PACKAGE_PIN R1  IOSTANDARD LVCMOS33 } [get_ports { IO_GP3 }]; #sw4
-
-## UART
-set_property -dict { PACKAGE_PIN A12  IOSTANDARD LVCMOS33 } [get_ports { IO_UTX }]; #JP3.A12
-set_property -dict { PACKAGE_PIN B12  IOSTANDARD LVCMOS33 } [get_ports { IO_URX }]; #JP3.B12
+set_property -dict { PACKAGE_PIN L14 IOSTANDARD LVCMOS33 } [get_ports { IO_GP3 }]; #sw4
 
 ## SPI/JTAG
 set_property -dict { PACKAGE_PIN A14   IOSTANDARD LVCMOS33 } [get_ports { IO_DPS0 }]; #JP3.A14
@@ -41,7 +34,6 @@ set_property -dict { PACKAGE_PIN C11   IOSTANDARD LVCMOS33 PULLTYPE PULLUP } [ge
 set_property -dict { PACKAGE_PIN B14   IOSTANDARD LVCMOS33 PULLTYPE PULLDOWN } [get_ports { IO_DPS6 }]; #JP3.B14
 set_property -dict { PACKAGE_PIN C14   IOSTANDARD LVCMOS33 PULLTYPE PULLDOWN } [get_ports { IO_DPS7 }]; #JP3.C14
 
-
 ## OTHER IO
 set_property -dict { PACKAGE_PIN B16 IOSTANDARD LVCMOS33 } [get_ports { IO_GP4  }]; #JP3.B16
 set_property -dict { PACKAGE_PIN C13 IOSTANDARD LVCMOS33 } [get_ports { IO_GP5  }]; #JP3.C13
@@ -51,7 +43,6 @@ set_property -dict { PACKAGE_PIN E13 IOSTANDARD LVCMOS33 } [get_ports { IO_GP11 
 set_property -dict { PACKAGE_PIN F15 IOSTANDARD LVCMOS33 } [get_ports { IO_GP12 }]; #JP3.F15
 set_property -dict { PACKAGE_PIN E11 IOSTANDARD LVCMOS33 } [get_ports { IO_GP13 }]; #JP3.E11
 set_property -dict { PACKAGE_PIN F13 IOSTANDARD LVCMOS33 } [get_ports { IO_GP14 }]; #JP3.F13
-set_property -dict { PACKAGE_PIN F12 IOSTANDARD LVCMOS33 } [get_ports { IO_GP15 }]; #JP3.F12
 
 set_property -dict { PACKAGE_PIN C16 IOSTANDARD LVCMOS33 DRIVE 8 SLEW FAST } [get_ports { IO_USB_DP0 }]; #JP3.C16
 set_property -dict { PACKAGE_PIN D13 IOSTANDARD LVCMOS33 DRIVE 8 SLEW FAST } [get_ports { IO_USB_DN0 }]; #JP3.D13
@@ -59,11 +50,13 @@ set_property -dict { PACKAGE_PIN H16 IOSTANDARD LVCMOS33 } [get_ports { IO_USB_D
 set_property -dict { PACKAGE_PIN D16 IOSTANDARD LVCMOS33 } [get_ports { IO_USB_SENSE0 }]; #JP3.D16
 set_property -dict { PACKAGE_PIN E16 IOSTANDARD LVCMOS33 } [get_ports { IO_USB_DNPULLUP0 }]; #JP3.E16
 
-## 20-Pin Connector
+## 20-Pin Connector (JP1)
 
-#set_property PACKAGE_PIN T14 [get_ports tio_trigger]
-#set_property PACKAGE_PIN M16 [get_ports tio_clkout]
-#set_property PACKAGE_PIN N14 [get_ports tio_clkin]
+set_property -dict { PACKAGE_PIN R16 IOSTANDARD LVCMOS33 } [get_ports { IO_UTX }];     #JP1 PIN 10 (UART)
+set_property -dict { PACKAGE_PIN P16 IOSTANDARD LVCMOS33 } [get_ports { IO_URX }];     #JP1 PIN 12 (UART)
+set_property -dict { PACKAGE_PIN T14 IOSTANDARD LVCMOS33 } [get_ports { IO_GP15 }];    #JP1 PIN 16 TIO4 (Trigger)
+set_property -dict { PACKAGE_PIN M16 IOSTANDARD LVCMOS33 } [get_ports { TIO_CLKOUT }]; #JP1 PIN 4 TIO_HS1. Clock sync capture board.
+
 
 ## USB Connector
 # TODO: Configure USB capture interface and sync triggers.

--- a/hw/top_earlgrey/rtl/top_earlgrey_cw305.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_cw305.sv
@@ -37,9 +37,9 @@ module top_earlgrey_cw305 #(
   inout               IO_GP5,
   inout               IO_GP6,
   inout               IO_GP7,
-  output              IO_GP8,  // XXX: rename as LED
-  output              IO_GP9,  // XXX: rename as LED
-  output              IO_GP10, // XXX: rename as LED
+  inout               IO_GP8,
+  inout               IO_GP9,
+  inout               IO_GP10,
   inout               IO_GP11,
   inout               IO_GP12,
   inout               IO_GP13,
@@ -66,27 +66,13 @@ module top_earlgrey_cw305 #(
   logic [padctrl_reg_pkg::NDioPads-1:0] dio_oe_core, dio_oe_padring;
   logic [padctrl_reg_pkg::NDioPads-1:0] dio_in_core, dio_in_padring;
 
-  reg io_utx_reg;
-  always @(posedge clk) begin
-      io_utx_reg <<= (IO_UTX == 1'bz)? 0 : IO_UTX;
-  end
-  assign IO_GP8 = io_utx_reg;
-
-  reg io_urx_reg;
-  always @(posedge clk) begin
-    io_urx_reg <<= (IO_URX == 1'bz)? 0 : IO_URX;
-  end
-  assign IO_GP9 = io_urx_reg;
-
-  assign IO_GP10 = 1'b1;
-
-  assign TIO_CLKOUT = clk;
+  assign TIO_CLKOUT = IO_CLK;
 
   padring #(
     // MIOs 31:20 are currently not
     // connected to pads and hence tied off
-    .ConnectMioIn  ( 32'h000FF8FF ),
-    .ConnectMioOut ( 32'h000FF8FF ),
+    .ConnectMioIn  ( 32'h000FFFFF ),
+    .ConnectMioOut ( 32'h000FFFFF ),
     // Tied off DIOs:
     // 2: usbdev_d
     // 3: usbdev_suspend
@@ -113,9 +99,9 @@ module top_earlgrey_cw305 #(
                              IO_GP13,
                              IO_GP12,
                              IO_GP11,
-                             1'bz,
-                             1'bz,
-                             1'bz,
+                             IO_GP10,
+                             IO_GP9,
+                             IO_GP8,
                              IO_GP7,
                              IO_GP6,
                              IO_GP5,

--- a/hw/top_earlgrey/rtl/top_earlgrey_cw305.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_cw305.sv
@@ -215,10 +215,10 @@ module top_earlgrey_cw305 #(
   ) top_earlgrey (
     // Clocks, resets
     .rst_ni          ( rst_n         ),
-    .clkmgr_clk_main ( clk           ),
-    .clkmgr_clk_io   ( clk           ),
-    .clkmgr_clk_usb  ( clk_usb_48mhz ),
-    .clkmgr_clk_aon  ( clk           ),
+    .clk_main_i      ( clk           ),
+    .clk_io_i        ( clk           ),
+    .clk_usb_i       ( clk_usb_48mhz ),
+    .clk_aon_i       ( clk           ),
 
     // JTAG
     .jtag_tck_i      ( jtag_tck      ),

--- a/hw/top_earlgrey/rtl/top_earlgrey_cw305.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_cw305.sv
@@ -208,6 +208,18 @@ module top_earlgrey_cw305 #(
   //////////////////////
   // Top-level design //
   //////////////////////
+  pwrmgr_pkg::pwr_ast_rsp_t ast_base_pwr;
+  ast_wrapper_pkg::ast_alert_req_t ast_base_alerts;
+  ast_wrapper_pkg::ast_status_t ast_base_status;
+
+  assign ast_base_pwr.slow_clk_val = 2'b10;
+  assign ast_base_pwr.core_clk_val = 2'b10;
+  assign ast_base_pwr.io_clk_val   = 2'b10;
+  assign ast_base_pwr.main_pok     = 1'b1;
+
+  assign ast_base_alerts.alerts_p  = '0;
+  assign ast_base_alerts.alerts_n  = {ast_wrapper_pkg::NumAlerts{1'b1}};
+  assign ast_base_status.io_pok    = {ast_wrapper_pkg::NumIoRails{1'b1}};
 
   top_earlgrey #(
     .IbexPipeLine(1),
@@ -219,6 +231,14 @@ module top_earlgrey_cw305 #(
     .clk_io_i        ( clk           ),
     .clk_usb_i       ( clk_usb_48mhz ),
     .clk_aon_i       ( clk           ),
+    .rstmgr_ast_i                ( 1'b1            ),
+    .pwrmgr_pwr_ast_req_o        (                 ),
+    .pwrmgr_pwr_ast_rsp_i        ( ast_base_pwr    ),
+    .sensor_ctrl_ast_alert_req_i ( ast_base_alerts ),
+    .sensor_ctrl_ast_alert_rsp_o (                 ),
+    .sensor_ctrl_ast_status_i    ( ast_base_status ),
+    .usbdev_usb_ref_val_o        (                 ),
+    .usbdev_usb_ref_pulse_o      (                 ),
 
     // JTAG
     .jtag_tck_i      ( jtag_tck      ),


### PR DESCRIPTION

Changes:

* Update CW305 pinout to route UART and trigger GPIO via 20-pin target connector.
* Route input CLK directly to output CLK used to synchronize capture
* Other changes to bring CW305 to working state with TOR.

Manually Tested:

* Reduce flash configuration to fit inside Artix-7.
* Ran spiflash to load test program.