### PR TITLE
[ast_wrapper] update ast_wrapper core file names

### DIFF
--- a/hw/ip/dcd/dcd.core
+++ b/hw/ip/dcd/dcd.core
@@ -10,7 +10,7 @@ filesets:
       - lowrisc:constants:top_pkg
       - lowrisc:prim:all
       - lowrisc:ip:tlul
-      - lowrisc:systems:ast_pkg
+      - lowrisc:systems:ast_wrapper_pkg
     files:
       - rtl/dcd_reg_pkg.sv
       - rtl/dcd_reg_top.sv
@@ -43,5 +43,3 @@ targets:
         mode: lint-only
         verilator_options:
           - "-Wall"
-
-

--- a/hw/ip/pinmux/pinmux_component.core
+++ b/hw/ip/pinmux/pinmux_component.core
@@ -13,7 +13,7 @@ filesets:
     depend:
       - lowrisc:ip:tlul
       - lowrisc:prim:all
-      - lowrisc:systems:ast_pkg
+      - lowrisc:systems:ast_wrapper_pkg
       - lowrisc:top_earlgrey:pinmux_reg
     files:
       - rtl/pinmux_pkg.sv

--- a/hw/ip/sensor_ctrl/sensor_ctrl.core
+++ b/hw/ip/sensor_ctrl/sensor_ctrl.core
@@ -12,7 +12,7 @@ filesets:
       - lowrisc:prim:all
       - lowrisc:ip:sensor_ctrl_reg
       - lowrisc:ip:sensor_ctrl_pkg
-      - lowrisc:systems:ast_pkg
+      - lowrisc:systems:ast_wrapper_pkg
     files:
       - rtl/sensor_ctrl.sv
     file_type: systemVerilogSource

--- a/hw/top_earlgrey/ip/ast/ast_wrapper.core
+++ b/hw/top_earlgrey/ip/ast/ast_wrapper.core
@@ -2,12 +2,12 @@ CAPI=2:
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: "lowrisc:systems:ast:0.1"
+name: "lowrisc:systems:ast_wrapper:0.1"
 description: "Earl Grey toplevel for DV simulations"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:systems:ast_pkg
+      - lowrisc:systems:ast_wrapper_pkg
       - lowrisc:prim:clock_buf
     files:
       - rtl/ast.sv

--- a/hw/top_earlgrey/ip/ast/ast_wrapper_pkg.core
+++ b/hw/top_earlgrey/ip/ast/ast_wrapper_pkg.core
@@ -3,7 +3,7 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-name: "lowrisc:systems:ast_pkg"
+name: "lowrisc:systems:ast_wrapper_pkg"
 description: "Toplevel-wide constants for Earl Grey"
 filesets:
   files_rtl:

--- a/hw/top_earlgrey/top_earlgrey.core
+++ b/hw/top_earlgrey/top_earlgrey.core
@@ -57,7 +57,7 @@ filesets:
       - lowrisc:ip:otp_ctrl_component
       - lowrisc:ip:lifecycle_top
       - lowrisc:tlul:headers
-      - lowrisc:systems:ast_pkg
+      - lowrisc:systems:ast_wrapper_pkg
       - lowrisc:prim:all
     files:
       - rtl/autogen/top_earlgrey_pkg.sv

--- a/hw/top_earlgrey/top_earlgrey_asic.core
+++ b/hw/top_earlgrey/top_earlgrey_asic.core
@@ -9,7 +9,7 @@ filesets:
     depend:
       - lowrisc:prim:usb_diff_rx
       - lowrisc:systems:top_earlgrey:0.1
-      - lowrisc:systems:ast
+      - lowrisc:systems:ast_wrapper
     files:
       - rtl/top_earlgrey_asic.sv
     file_type: systemVerilogSource


### PR DESCRIPTION
Resolve naming conflict for Nuvoton ast drop in bronze

Signed-off-by: Timothy Chen <timothytim@google.com>