### PR TITLE
[ast] re-name currently synthesizeable ast to something else

### DIFF
--- a/hw/ip/prim/util/primgen.py
+++ b/hw/ip/prim/util/primgen.py
@@ -207,8 +207,11 @@ def _generate_prim_pkg(gapi):
     # Insert the required generic library first to ensure it gets enum value 0
     techlib_enums.append(_enum_name_for_techlib('generic', qualified=False))
 
+    # Temporary library to dv specific prims
+    techlib_enums.append(_enum_name_for_techlib('dv', qualified=False))
+
     for techlib in techlibs:
-        if techlib == 'generic':
+        if techlib in ['generic', 'dv']:
             # The generic implementation is required and handled separately.
             continue
         techlib_enums.append(_enum_name_for_techlib(techlib, qualified=False))

--- a/hw/top_earlgrey/ip/ast/ast_wrapper.core
+++ b/hw/top_earlgrey/ip/ast/ast_wrapper.core
@@ -10,7 +10,7 @@ filesets:
       - lowrisc:systems:ast_wrapper_pkg
       - lowrisc:prim:clock_buf
     files:
-      - rtl/ast.sv
+      - rtl/ast_syn.sv
       - rtl/ast_wrapper.sv
     file_type: systemVerilogSource
 

--- a/hw/top_earlgrey/ip/ast/rtl/ast_syn.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_syn.sv
@@ -6,7 +6,7 @@
 // therefore it is self contained and does not reference any packages or other modules from the
 // open source repository.
 
-module ast #(
+module ast_syn #(
   parameter int EntropyStreams  = 4,
   parameter int AdcChannels     = 4,
   parameter int AdcDataWidth    = 10,

--- a/hw/top_earlgrey/ip/ast/rtl/ast_wrapper.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_wrapper.sv
@@ -71,7 +71,7 @@ module ast_wrapper import ast_wrapper_pkg::*;
   assign pwr_o.slow_clk_val[0] = ~pwr_o.slow_clk_val[1];
   assign pwr_o.io_clk_val[0]   = ~pwr_o.io_clk_val[1];
 
-  ast #(
+  ast_syn #(
     .EntropyStreams(EntropyStreams),
     .AdcChannels(AdcChannels),
     .AdcDataWidth(AdcDataWidth),


### PR DESCRIPTION
- Introduce a ImplDv flag to handle models that are used for DV but not synthesizeable

Signed-off-by: Timothy Chen <timothytim@google.com>