### PR TITLE
[top/fpga] Add scripts to reduce and check flash size for small FPGAs

### DIFF
--- a/hw/top_earlgrey/top_earlgrey_artys7-50.core
+++ b/hw/top_earlgrey/top_earlgrey_artys7-50.core
@@ -8,6 +8,7 @@ filesets:
   files_rtl_artys7:
     depend:
       - lowrisc:systems:top_earlgrey:0.1
+      - lowrisc:tool:opentitan_earlgrey_flash_size_check:0.1
     files:
       - rtl/clkgen_xil7series.sv
       - rtl/top_earlgrey_artys7.sv

--- a/hw/top_earlgrey/top_earlgrey_cw305.core
+++ b/hw/top_earlgrey/top_earlgrey_cw305.core
@@ -4,10 +4,12 @@ CAPI=2:
 # SPDX-License-Identifier: Apache-2.0
 name: "lowrisc:systems:top_earlgrey_cw305:0.1"
 description: "Earl Grey toplevel for the ChipWhisperer CW305 board"
+
 filesets:
   files_rtl_cw305:
     depend:
       - lowrisc:systems:top_earlgrey:0.1
+      - lowrisc:tool:opentitan_earlgrey_flash_size_check:0.1
     files:
       - rtl/clkgen_xil7series.sv
       - rtl/top_earlgrey_cw305.sv

--- a/hw/top_earlgrey/util/opentitan_earlgrey_flash_size_check.core
+++ b/hw/top_earlgrey/util/opentitan_earlgrey_flash_size_check.core
@@ -1,0 +1,30 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:tool:opentitan_earlgrey_flash_size_check:0.1"
+description: "Check if flash size has been reduced for smaller FPGA targets"
+
+filesets:
+  files_opentitan_earlgrey_flash_size_check:
+    files:
+      - ./opentitan_earlgrey_flash_size_check.py : { copyto: util/opentitan_earlgrey_flash_size_check.py }
+
+scripts:
+  opentitan_earlgrey_flash_size_check:
+    cmd:
+      - python3
+      - util/opentitan_earlgrey_flash_size_check.py
+    # TODO: Use this syntax once https://github.com/olofk/fusesoc/issues/353 is
+    # fixed. Remove the filesets from the default target, and also remove the
+    # copyto.
+    #filesets:
+    #  - opentitan_earlgrey_flash_size_check
+
+targets:
+  default:
+    filesets:
+      - files_opentitan_earlgrey_flash_size_check
+    hooks:
+      pre_build:
+        - opentitan_earlgrey_flash_size_check

--- a/hw/top_earlgrey/util/opentitan_earlgrey_flash_size_check.py
+++ b/hw/top_earlgrey/util/opentitan_earlgrey_flash_size_check.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+"""Script used to check if the size of the embedded flash has already been reduced for smaller FPGA
+devices.
+
+This script checks two SystemVerilog source files (of which one is auto generated) to see if the
+size of the embedded flash has been reduced.
+"""
+
+import logging as log
+import os
+import sys
+import re
+
+# Display INFO log messages and up.
+log.basicConfig(level=log.INFO, format="%(levelname)s: %(message)s")
+
+
+def find_file(name, path):
+    for root, dirs, files in os.walk(path):
+        if name in files:
+            return os.path.join(root, name)
+
+
+def main():
+
+    # Check for the following regular expressions in the following source files.
+    files = ["top_pkg.sv", "tl_main_pkg.sv"]
+    match = [
+        r"localparam\s+int\s+FLASH_PAGES_PER_BANK\s*=\s*32;",
+        r"localparam\s+logic\s*\[\s*31\s*:\s*0\s*\]\s+ADDR_MASK_EFLASH\s*=\s*32'h\s*0000ffff;"
+    ]
+
+    all_good = True
+    for idx in range(len(files)):
+        file_path = find_file(files[idx], "../")
+        if not file_path:
+            log.error("Could not find file " + files[idx] +
+                      " in work directory.")
+            return 1
+
+        with open(file_path, 'r') as file:
+            text = file.read()
+            if not re.search(match[idx], text):
+                all_good = False
+
+    if not all_good:
+        log.error(
+            "It seems that the size of the embedded flash has not been adjusted for the targeted " +
+            "FPGA device. The design might not fit. \n" +
+            "Please run hw/top_earlgrey/util/opentitan_earlgrey_flash_size_reduce.py before " +
+            "running this fusesoc core."
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hw/top_earlgrey/util/opentitan_earlgrey_flash_size_reduce.py
+++ b/hw/top_earlgrey/util/opentitan_earlgrey_flash_size_reduce.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+"""Script used to reduce the size of the embedded flash for smaller FPGA devices.
+
+This script modifies two source files to reduce the size of the embedded flash and then regenerates
+all auto-generated files. The flash size is reduced in a way that does not impact the register
+interface of the flash controller and is thus more or less transparent to software.
+"""
+
+import logging as log
+import subprocess
+import sys
+import os
+import re
+
+# Display INFO log messages and up.
+log.basicConfig(level=log.INFO, format="%(levelname)s: %(message)s")
+
+
+def main():
+
+    # Get path to top-level directory
+    top_path = os.path.normpath(os.path.join(os.path.dirname(__file__), "../../.."))
+
+    # Change the following expressions in the following source files.
+    files = [
+        top_path + "/hw/top_earlgrey/rtl/top_pkg.sv",
+        top_path + "/hw/top_earlgrey/data/top_earlgrey.hjson"
+    ]
+    match = [
+        r"(localparam\s+int\s+FLASH_PAGES_PER_BANK\s*=\s*)\d+(\s*;)",
+        r"({\s*name:\s*\"eflash\"," +
+        r"\s*clock_srcs:\s*{clk_i:\s*\"main\"}," +
+        r"\s*clock_group:\s*\"infra\"," +
+        r"\s*reset_connections:\s*{rst_ni:\s*\"lc\"}," +
+        r"\s*type:\s*\"eflash\"," +
+        r"\s*base_addr:\s*\"0x\w+\"," +
+        r"\s*swaccess:\s*\"ro\"," +
+        r"\s*size:\s*\"0x)\w+"
+    ]
+    replace = [
+        r"\g<1>32\g<2>",  # Change FLASH_PAGES_PER_BANK to 32
+        r"\g<1>10000"     # Change size to 0x10000
+    ]
+
+    # Change source files
+    for idx in range(len(files)):
+        with open(files[idx], 'r+') as file:
+            text = file.read()
+            text, num = re.subn(match[idx], replace[idx], text)
+            if num == 0:
+                print("ERROR: Cannot find regular expression " + match[idx] +
+                      " in " + files[idx] + ". "
+                      "Aborting")
+                sys.exit(1)
+            else:
+                print("Modifying " + files[idx])
+                file.seek(0)
+                file.write(text)
+                file.truncate()
+
+    # Regenerate auto-generated files
+    print("Regenerating all auto-generated files...")
+    cmd = ["make", "-C", top_path + "/hw"]
+    try:
+        subprocess.run(cmd,
+                       check=True,
+                       stdout=subprocess.PIPE,
+                       stderr=subprocess.STDOUT,
+                       universal_newlines=True)
+
+    except subprocess.CalledProcessError as e:
+        log.error("Failed to regenerate auto-generated files: " + str(e))
+        log.error(e.stdout)
+        sys.exit(1)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This PR contains two scripts:
1. The first one to reduce the flash size for smaller FPGAs (different from the NexysVideo we normally use).
2. The second one to check that the flash size has been reduced and corresponding auto-gen files have been regenerated. This one can be added as a hook to smaller FPGA targets.

~This is very rough and I don't intend to merge it at the moment. The hope is that this help the discussion related to #2171.~

Update: this method for reducing the flash size may be fragile but it is sufficient as a temporary workaround and simplifies the setup of the SCA setup where are currently limited by a smaller FPGA.