### PR TITLE
[pattgen, lint] Fixed linting errors in pattgen for top_early_gray (v1-bronze)

### DIFF
--- a/hw/ip/pattgen/data/pattgen.hjson
+++ b/hw/ip/pattgen/data/pattgen.hjson
@@ -17,10 +17,10 @@
   ]
   // INTERRUPT pins
   interrupt_list: [
-    { name: "patt_done0"
+    { name: "intr_patt_done_ch0",
       desc: "raise if pattern generation on channel 0 is complete"
     }
-    { name: "patt_done1"
+    { name: "intr_patt_done_ch1",
       desc: "raise if pattern generation on channel 1 is complete"
     }
   ],
@@ -28,54 +28,52 @@
     { name:    "NumRegsPrediv",
       type:    "int",
       default: "2",
-      desc:    "Number pre-dividers reg",
+      desc:    "Number pre-dividers egister",
       local:   "true"
     }
     { name:    "NumRegsData",
       type:    "int",
       default: "2",
-      desc:    "Number data_out reg per each pattern",
+      desc:    "Number data register per each channel",
       local:   "true"
     }
   ],
   // REGISTER definition
   registers: [
     // CTRL register
-    { name: "CTRL",
-      desc: "PATTGEN control register (Functions TBD)",
+    { name: "PATT_CTRL",
+      desc: "PATTGEN control register (function tbd ...)",
       swaccess: "rw",
       hwaccess: "hro",
       fields: [
         { bits: "0",
           resval: "0",
-          name: "START",
-          desc: '''
-                Start pattern generator functionality
-                '''
+          name: "ENABLE",
+          desc: "Enable pattern generator functionality"
         }
       ]
     }
-    { name: "START",
-      desc: "PATTGEN start pattern generation",
+    { name: "PATT_START",
+      desc: "PATTGEN start generating patterns on output channels",
       swaccess: "wo",
       hwaccess: "hro",
       hwqe: "true",
       fields: [
         { bits: "0",
           resval: "0",
-          name: "START0",
+          name: "CH0_START",
           desc: "Start generating pattern on channel 0"
         }
         { bits: "1",
           resval: "0",
-          name: "START1",
+          name: "CH1_START",
           desc: "Start generating pattern on channel 1"
         }
       ]
     }
     { multireg: {
-        name: "PREDIV",
-        desc: "Pre-divider multi registers",
+        name: "PATT_PREDIV",
+        desc: "PATTGEN pre-divider multi-registers",
         count: "NumRegsPrediv",
         cname: "PATTGEN",
         swaccess: "wo",
@@ -84,15 +82,15 @@
         fields: [
           { bits: "31:0",
             resval: "0",
-            name: "RATIO",
+            name: "CLK_RATIO",
             desc: "Dividend ratio from based I/O clock for channel 0 (base is 2)"
           }
         ]
       }
     },
     { multireg: {
-        name: "PATT0_DATA",
-        desc: "Data_out registers for channel 0",
+        name: "PATT_DATA_CH0",
+        desc: "PATTGEN Seed pattern multi-registers for channel 0",
         count: "NumRegsData",
         cname: "PATTGEN",
         swaccess: "wo",
@@ -102,14 +100,14 @@
           { bits: "31:0",
             resval: "0",
             name: "DATA",
-            desc: "Data generated on channel 0 (length is defined by patt_len.len0 register)"
+            desc: "Seed pattern for channel 0 (2-64 bits)"
           }
         ]
       }
     },
     { multireg: {
-        name: "PATT1_DATA",
-        desc: "Data_out registers for channel 1",
+        name: "PATT_DATA_CH1",
+        desc: "PATTGEN Seed pattern multi-registers for channel 1",
         count: "NumRegsData",
         cname: "PATTGEN",
         swaccess: "wo",
@@ -119,7 +117,7 @@
           { bits: "31:0",
             resval: "0",
             name: "DATA",
-            desc: "Data generated on channel 1 (length is defined by patt_len.len1 register)"
+            desc: "Seed pattern for channel 1 (2-64 bits)"
           }
         ]
       }
@@ -132,13 +130,13 @@
       fields: [
         { bits: "5:0",
           resval: "0",
-          name: "LEN0",
-          desc: "Data generated on channel 1 (length is define by patt_len.len1 register)"
+          name: "CH0_LEN",
+          desc: "Length of the seed pattern for channel 0 (2-64 bits)"
         }
         { bits: "12:7",
           resval: "0",
-          name: "LEN1",
-          desc: "Length of pattern generated on channel 1 (base is 2)"
+          name: "CH1_LEN",
+          desc: "Length of the seed pattern for channel 1 (2-64 bits)"
         }
       ]
     }
@@ -150,31 +148,13 @@
       fields: [
         { bits: "9:0",
           resval: "0",
-          name: "LOOP0",
-          desc: "Pattern repeatedly generated on channel 0 (base is 1)"
+          name: "CH0_LOOP",
+          desc: "Number of the seed patterns repeatedly generated on channel 0 (base is 1)"
         }
         { bits: "19:10",
           resval: "0",
-          name: "LOOP1",
-          desc: "Pattern repeatedly generated on channel 1 (base is 1)"
-        }
-      ]
-    }
-    { name: "INTR_MASK",
-      desc: "PATTGEN mask registers for channel interrupts",
-      swaccess: "wo",
-      hwaccess: "hro",
-      hwqe: "true",
-      fields: [
-        { bits: "0",
-          resval: "0",
-          name: "MASK0",
-          desc: "Enable pattern_done interrupt of channel 0 if set to 1"
-        }
-        { bits: "1",
-          resval: "0",
-          name: "MASK1",
-          desc: "Enable pattern_done interrupt of channel 1 if set to 1"
+          name: "CH1_LOOP",
+          desc: "Number of the seed patterns repeatedly generated on channel 1 (base is 1)"
         }
       ]
     }

--- a/hw/ip/pattgen/data/pattgen.prj.hjson
+++ b/hw/ip/pattgen/data/pattgen.prj.hjson
@@ -3,11 +3,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 {
-    name:               "pattgen",
-    design_spec:        "hw/ip/pattgen/doc",
-    dv_plan:            "hw/ip/pattgen/doc/dv_plan",
-    version:            "0.5",
-    life_stage:         "L1",
-    design_stage:       "D0",
-    verification_stage: "V0",
+    name:               "pattern",
+    design_spec:        "hw/ip/pattern/doc",
+    dv_plan:            "hw/ip/pattern/doc/dv_plan",
+    hw_checklist:       "hw/ip/pattern/doc/checklist",
+    revisions: [
+      {
+        version:            "0.5",
+        life_stage:         "L1",
+        design_stage:       "D1",
+        verification_stage: "V1",
+        dif_stage:          "S0",
+        commit_id:          "ff9c06167bc34d921974839017dec54f0fb8347a",
+        notes:              ""
+      }
+    ]
 }

--- a/hw/ip/pattgen/data/pattgen_testplan.hjson
+++ b/hw/ip/pattgen/data/pattgen_testplan.hjson
@@ -3,14 +3,21 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   name: "pattgen"
-  // TODO: remove the common testplans if not applicable
   import_testplans: ["hw/dv/tools/testplans/csr_testplan.hjson",
                      "hw/dv/tools/testplans/intr_test_testplan.hjson",
                      "hw/dv/tools/testplans/tl_device_access_types_testplan.hjson"]
   entries: [
     {
       name: sanity
-      desc: TODO
+      desc: '''
+            ...
+
+            Stimulus:
+              ...
+
+            Checking:
+              ...
+            '''
       milestone: V2
       tests: ["pattgen_sanity"]
     }

--- a/hw/ip/pattgen/dv/env/pattgen_env_pkg.sv
+++ b/hw/ip/pattgen/dv/env/pattgen_env_pkg.sv
@@ -19,8 +19,8 @@ package pattgen_env_pkg;
 
   // parameters
   typedef enum int {
-    PattDone0      = 0,
-    PattDone1      = 1,
+    PattDoneCh0      = 0,
+    PattDoneCh1      = 1,
     NumI2cIntr     = 2
   } pattgen_intr_e;
 

--- a/hw/ip/pattgen/dv/tb/tb.sv
+++ b/hw/ip/pattgen/dv/tb/tb.sv
@@ -25,8 +25,8 @@ module tb;
   wire cio_pcl1_tx_en_o;
 
 
-  wire intr_patt_done0;
-  wire intr_patt_done1;
+  wire intr_patt_done_ch0;
+  wire intr_patt_done_ch1;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
 
   // interfaces
@@ -44,23 +44,23 @@ module tb;
     .tl_i                 (tl_if.h2d ),
     .tl_o                 (tl_if.d2h ),
 
-    .cio_pda0_tx_o        (cio_pda0_tx_o     ),
-    .cio_pda0_tx_en_o     (cio_pda0_tx_en_o  ),
-    .cio_pcl0_tx_o        (cio_pcl0_tx_o     ),
-    .cio_pcl0_tx_en_o     (cio_pcl0_tx_en_o  ),
+    .cio_pda0_tx_o        (cio_pda0_tx_o      ),
+    .cio_pda0_tx_en_o     (cio_pda0_tx_en_o   ),
+    .cio_pcl0_tx_o        (cio_pcl0_tx_o      ),
+    .cio_pcl0_tx_en_o     (cio_pcl0_tx_en_o   ),
 
-    .cio_pda1_tx_o        (cio_pda1_tx_o     ),
-    .cio_pda1_tx_en_o     (cio_pda1_tx_en_o  ),
-    .cio_pcl1_tx_o        (cio_pcl1_tx_o     ),
-    .cio_pcl1_tx_en_o     (cio_pcl1_tx_en_o  ),
+    .cio_pda1_tx_o        (cio_pda1_tx_o      ),
+    .cio_pda1_tx_en_o     (cio_pda1_tx_en_o   ),
+    .cio_pcl1_tx_o        (cio_pcl1_tx_o      ),
+    .cio_pcl1_tx_en_o     (cio_pcl1_tx_en_o   ),
 
-    .intr_patt_done0_o    (intr_patt_done0 ),
-    .intr_patt_done1_o    (intr_patt_done1 )
+    .intr_patt_done_ch0_o (intr_patt_done_ch0 ),
+    .intr_patt_done_ch1_o (intr_patt_done_ch1 )
   );
 
   // interrupt
-  assign interrupts[PattDone0]   = intr_patt_done0;
-  assign interrupts[PattDone1]   = intr_patt_done1;
+  assign interrupts[PattDoneCh0] = intr_patt_done_ch0;
+  assign interrupts[PattDoneCh1] = intr_patt_done_ch1;
 
   initial begin
     // drive clk and rst_n from clk_if

--- a/hw/ip/pattgen/lint/pattgen.vlt
+++ b/hw/ip/pattgen/lint/pattgen.vlt
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// waiver file for pattgen
+

--- a/hw/ip/pattgen/lint/pattgen.waiver
+++ b/hw/ip/pattgen/lint/pattgen.waiver
@@ -1,0 +1,5 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for PATTGEN lint

--- a/hw/ip/pattgen/pattgen.core
+++ b/hw/ip/pattgen/pattgen.core
@@ -35,9 +35,6 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
-      ascentlint:
-        ascentlint_options:
-          - "-wait_license"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/pattgen/rtl/pattgen.sv
+++ b/hw/ip/pattgen/rtl/pattgen.sv
@@ -22,8 +22,8 @@ module pattgen (
   output logic  cio_pcl1_tx_o,
   output logic  cio_pcl1_tx_en_o,
 
-  output logic  intr_patt_done0_o,
-  output logic  intr_patt_done1_o
+  output logic  intr_patt_done_ch0_o,
+  output logic  intr_patt_done_ch1_o
 );
 
   import pattgen_reg_pkg::*;
@@ -46,22 +46,24 @@ module pattgen (
   pattgen_core pattgen_core (
     .clk_i,
     .rst_ni,
+
     .reg2hw,
     .hw2reg,
 
-    .pda0_tx(cio_pda0_tx_o),
-    .pcl0_tx(cio_pcl0_tx_o),
-    .pda1_tx(cio_pda1_tx_o),
-    .pcl1_tx(cio_pcl1_tx_o),
+    .pda0_tx_o(cio_pda0_tx_o),
+    .pcl0_tx_o(cio_pcl0_tx_o),
+    .pda1_tx_o(cio_pda1_tx_o),
+    .pcl1_tx_o(cio_pcl1_tx_o),
 
-    .intr_patt_done0(intr_patt_done0_o),
-    .intr_patt_done1(intr_patt_done1_o)
+    .intr_patt_done_ch0_o(intr_patt_done_ch0_o),
+    .intr_patt_done_ch1_o(intr_patt_done_ch1_o)
   );
 
   assign cio_pda0_tx_en_o = 1'b1;
   assign cio_pcl0_tx_en_o = 1'b1;
   assign cio_pda1_tx_en_o = 1'b1;
   assign cio_pcl1_tx_en_o = 1'b1;
+
   // Assertion
   `ASSERT_KNOWN(TlODValidKnown, tl_o.d_valid)
   `ASSERT_KNOWN(TlOAValidKnown, tl_o.a_ready)
@@ -69,6 +71,6 @@ module pattgen (
   `ASSERT_KNOWN(Pcl1TxKnownO, cio_pcl0_tx_en_o)
   `ASSERT_KNOWN(Pda2TxKnownO, cio_pda1_tx_en_o)
   `ASSERT_KNOWN(Pcl2TxKnownO, cio_pcl1_tx_en_o)
-  `ASSERT_KNOWN(IntrPattDone1KnownO, intr_patt_done0_o)
-  `ASSERT_KNOWN(IntrPattDone2KnownO, intr_patt_done1_o)
+  `ASSERT_KNOWN(IntrPattDone1KnownO, intr_patt_done_ch0_o)
+  `ASSERT_KNOWN(IntrPattDone2KnownO, intr_patt_done_ch1_o)
 endmodule : pattgen

--- a/hw/ip/pattgen/rtl/pattgen_core.sv
+++ b/hw/ip/pattgen/rtl/pattgen_core.sv
@@ -10,29 +10,55 @@ module pattgen_core (
   input  pattgen_reg_pkg::pattgen_reg2hw_t  reg2hw,
   output pattgen_reg_pkg::pattgen_hw2reg_t  hw2reg,
 
-  output logic  pda0_tx,
-  output logic  pcl0_tx,
-  output logic  pda1_tx,
-  output logic  pcl1_tx,
+  output logic  pda0_tx_o,
+  output logic  pcl0_tx_o,
+  output logic  pda1_tx_o,
+  output logic  pcl1_tx_o,
 
-  output logic  intr_patt_done0,
-  output logic  intr_patt_done1
+  output logic  intr_patt_done_ch0_o,
+  output logic  intr_patt_done_ch1_o
 );
 
   // TODO: to be replaced later by true rtl
-  localparam DataWidth = 4;
-  localparam NumGates  = 1000;
+  localparam DataWidth = 32;
+  // use less than estimated 1K due to glue logics
+  localparam NumGates  = 800;
 
   logic [DataWidth-1:0] data_i;
   logic [DataWidth-1:0] data_o;
-  logic valid_i;
-  logic valid_o;
+  logic data_ch0, data_ch1;
+  logic prediv_ch0, prediv_ch1;
 
-  assign valid_i    = reg2hw.start.start0 | reg2hw.start.start1;
-  assign data_i[0]  = reg2hw.patt_len.len0[0];
-  assign data_i[1]  = reg2hw.patt_len.len1[0];
-  assign data_i[2]  = reg2hw.patt_loop.loop0[0];
-  assign data_i[3]  = reg2hw.patt_loop.loop1[0];
+  logic valid_o;
+  logic valid_i;
+  logic event_intr_patt_done_ch0;
+  logic event_intr_patt_done_ch1;
+
+
+  assign data_ch0   = &(reg2hw.patt_data_ch0[0].q | reg2hw.patt_data_ch0[1].q) &
+                      reg2hw.patt_data_ch0[0].qe & reg2hw.patt_data_ch0[1].qe;
+  assign data_ch1   = &(reg2hw.patt_data_ch1[0].q | reg2hw.patt_data_ch1[1].q) &
+                      reg2hw.patt_data_ch1[0].qe & reg2hw.patt_data_ch1[1].qe;
+
+  assign prediv_ch0 = (&reg2hw.patt_prediv[0].q)  | reg2hw.patt_prediv[0].qe;
+  assign prediv_ch1 = (&reg2hw.patt_prediv[1].q)  | reg2hw.patt_prediv[1].qe;
+
+  assign valid_i   = (reg2hw.patt_start.ch0_start.q & reg2hw.patt_start.ch0_start.qe) |
+                     (reg2hw.patt_start.ch1_start.q & reg2hw.patt_start.ch1_start.qe) &
+                     reg2hw.patt_ctrl.q;
+
+  assign data_i[0] = (^reg2hw.patt_len.ch0_len.q)   & reg2hw.patt_len.ch0_len.qe;
+  assign data_i[1] = (^reg2hw.patt_len.ch1_len.q)   & reg2hw.patt_len.ch1_len.qe;
+  assign data_i[2] = (|reg2hw.patt_loop.ch0_loop.q) & reg2hw.patt_loop.ch0_loop.qe;
+  assign data_i[3] = (|reg2hw.patt_loop.ch1_loop.q) & reg2hw.patt_loop.ch1_loop.qe;
+  assign data_i[4] = data_ch0;
+  assign data_i[5] = data_ch1;
+  assign data_i[6] = prediv_ch0;
+  assign data_i[7] = prediv_ch1;
+  assign data_i[13:8]  = {6{data_ch0}};
+  assign data_i[19:14] = {6{data_ch1}};
+  assign data_i[25:20] = {6{prediv_ch0}};
+  assign data_i[31:26] = {6{prediv_ch1}};
 
   // TODO: pseudo-logic 1kGE is added
   prim_gate_gen  #(
@@ -47,11 +73,34 @@ module pattgen_core (
     .valid_o   (valid_o )
   );
 
-  assign  pda0_tx         = data_o[0];
-  assign  pcl0_tx         = data_o[1];
-  assign  pda1_tx         = data_o[2];
-  assign  pcl1_tx         = data_o[3];
-  assign  intr_patt_done0 = valid_o | data_o[1];
-  assign  intr_patt_done1 = valid_o ^ data_o[0];
+  assign pda0_tx_o       = ^data_o;
+  assign pcl0_tx_o       = ~|data_o;
+  assign pda1_tx_o       = ~&data_o;
+  assign pcl1_tx_o       = &data_o;
 
+  assign event_intr_patt_done_ch0 = valid_o | (^data_o);
+  assign event_intr_patt_done_ch1 = valid_o ^ (&data_o);
+
+  prim_intr_hw #(.Width(1)) intr_hw_intr_patt_done_ch0_o (
+    .event_intr_i           (event_intr_patt_done_ch0),
+    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.intr_patt_done_ch0.q),
+    .reg2hw_intr_test_q_i   (reg2hw.intr_test.intr_patt_done_ch0.q),
+    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.intr_patt_done_ch0.qe),
+    .reg2hw_intr_state_q_i  (reg2hw.intr_state.intr_patt_done_ch0.q),
+    .hw2reg_intr_state_de_o (hw2reg.intr_state.intr_patt_done_ch0.de),
+    .hw2reg_intr_state_d_o  (hw2reg.intr_state.intr_patt_done_ch0.d),
+    .intr_o                 (intr_patt_done_ch0_o)
+  );
+
+  prim_intr_hw #(.Width(1)) intr_hw_intr_patt_done_ch1_o (
+    .event_intr_i           (event_intr_patt_done_ch1),
+    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.intr_patt_done_ch1.q),
+    .reg2hw_intr_test_q_i   (reg2hw.intr_test.intr_patt_done_ch1.q),
+    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.intr_patt_done_ch1.qe),
+    .reg2hw_intr_state_q_i  (reg2hw.intr_state.intr_patt_done_ch1.q),
+    .hw2reg_intr_state_de_o (hw2reg.intr_state.intr_patt_done_ch1.de),
+    .hw2reg_intr_state_d_o  (hw2reg.intr_state.intr_patt_done_ch1.d),
+    .intr_o                 (intr_patt_done_ch1_o)
+  );
+  
 endmodule : pattgen_core

--- a/hw/ip/pattgen/rtl/pattgen_reg_pkg.sv
+++ b/hw/ip/pattgen/rtl/pattgen_reg_pkg.sv
@@ -16,105 +16,94 @@ package pattgen_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        q;
-    } patt_done0;
+    } intr_patt_done_ch0;
     struct packed {
       logic        q;
-    } patt_done1;
+    } intr_patt_done_ch1;
   } pattgen_reg2hw_intr_state_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        q;
-    } patt_done0;
+    } intr_patt_done_ch0;
     struct packed {
       logic        q;
-    } patt_done1;
+    } intr_patt_done_ch1;
   } pattgen_reg2hw_intr_enable_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        q;
       logic        qe;
-    } patt_done0;
+    } intr_patt_done_ch0;
     struct packed {
       logic        q;
       logic        qe;
-    } patt_done1;
+    } intr_patt_done_ch1;
   } pattgen_reg2hw_intr_test_reg_t;
 
   typedef struct packed {
     logic        q;
-  } pattgen_reg2hw_ctrl_reg_t;
+  } pattgen_reg2hw_patt_ctrl_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        q;
       logic        qe;
-    } start0;
+    } ch0_start;
     struct packed {
       logic        q;
       logic        qe;
-    } start1;
-  } pattgen_reg2hw_start_reg_t;
+    } ch1_start;
+  } pattgen_reg2hw_patt_start_reg_t;
 
   typedef struct packed {
     logic [31:0] q;
     logic        qe;
-  } pattgen_reg2hw_prediv_mreg_t;
+  } pattgen_reg2hw_patt_prediv_mreg_t;
 
   typedef struct packed {
     logic [31:0] q;
     logic        qe;
-  } pattgen_reg2hw_patt0_data_mreg_t;
+  } pattgen_reg2hw_patt_data_ch0_mreg_t;
 
   typedef struct packed {
     logic [31:0] q;
     logic        qe;
-  } pattgen_reg2hw_patt1_data_mreg_t;
+  } pattgen_reg2hw_patt_data_ch1_mreg_t;
 
   typedef struct packed {
     struct packed {
       logic [5:0]  q;
       logic        qe;
-    } len0;
+    } ch0_len;
     struct packed {
       logic [5:0]  q;
       logic        qe;
-    } len1;
+    } ch1_len;
   } pattgen_reg2hw_patt_len_reg_t;
 
   typedef struct packed {
     struct packed {
       logic [9:0] q;
       logic        qe;
-    } loop0;
+    } ch0_loop;
     struct packed {
       logic [9:0] q;
       logic        qe;
-    } loop1;
+    } ch1_loop;
   } pattgen_reg2hw_patt_loop_reg_t;
 
-  typedef struct packed {
-    struct packed {
-      logic        q;
-      logic        qe;
-    } mask0;
-    struct packed {
-      logic        q;
-      logic        qe;
-    } mask1;
-  } pattgen_reg2hw_intr_mask_reg_t;
-
 
   typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
-    } patt_done0;
+    } intr_patt_done_ch0;
     struct packed {
       logic        d;
       logic        de;
-    } patt_done1;
+    } intr_patt_done_ch1;
   } pattgen_hw2reg_intr_state_reg_t;
 
 
@@ -122,17 +111,16 @@ package pattgen_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    pattgen_reg2hw_intr_state_reg_t intr_state; // [250:249]
-    pattgen_reg2hw_intr_enable_reg_t intr_enable; // [248:247]
-    pattgen_reg2hw_intr_test_reg_t intr_test; // [246:243]
-    pattgen_reg2hw_ctrl_reg_t ctrl; // [242:242]
-    pattgen_reg2hw_start_reg_t start; // [241:238]
-    pattgen_reg2hw_prediv_mreg_t [1:0] prediv; // [237:172]
-    pattgen_reg2hw_patt0_data_mreg_t [1:0] patt0_data; // [171:106]
-    pattgen_reg2hw_patt1_data_mreg_t [1:0] patt1_data; // [105:40]
-    pattgen_reg2hw_patt_len_reg_t patt_len; // [39:26]
-    pattgen_reg2hw_patt_loop_reg_t patt_loop; // [25:4]
-    pattgen_reg2hw_intr_mask_reg_t intr_mask; // [3:0]
+    pattgen_reg2hw_intr_state_reg_t intr_state; // [246:245]
+    pattgen_reg2hw_intr_enable_reg_t intr_enable; // [244:243]
+    pattgen_reg2hw_intr_test_reg_t intr_test; // [242:239]
+    pattgen_reg2hw_patt_ctrl_reg_t patt_ctrl; // [238:238]
+    pattgen_reg2hw_patt_start_reg_t patt_start; // [237:234]
+    pattgen_reg2hw_patt_prediv_mreg_t [1:0] patt_prediv; // [233:168]
+    pattgen_reg2hw_patt_data_ch0_mreg_t [1:0] patt_data_ch0; // [167:102]
+    pattgen_reg2hw_patt_data_ch1_mreg_t [1:0] patt_data_ch1; // [101:36]
+    pattgen_reg2hw_patt_len_reg_t patt_len; // [35:22]
+    pattgen_reg2hw_patt_loop_reg_t patt_loop; // [21:0]
   } pattgen_reg2hw_t;
 
   ///////////////////////////////////////
@@ -146,17 +134,16 @@ package pattgen_reg_pkg;
   parameter logic [5:0] PATTGEN_INTR_STATE_OFFSET = 6'h 0;
   parameter logic [5:0] PATTGEN_INTR_ENABLE_OFFSET = 6'h 4;
   parameter logic [5:0] PATTGEN_INTR_TEST_OFFSET = 6'h 8;
-  parameter logic [5:0] PATTGEN_CTRL_OFFSET = 6'h c;
-  parameter logic [5:0] PATTGEN_START_OFFSET = 6'h 10;
-  parameter logic [5:0] PATTGEN_PREDIV0_OFFSET = 6'h 14;
-  parameter logic [5:0] PATTGEN_PREDIV1_OFFSET = 6'h 18;
-  parameter logic [5:0] PATTGEN_PATT0_DATA0_OFFSET = 6'h 1c;
-  parameter logic [5:0] PATTGEN_PATT0_DATA1_OFFSET = 6'h 20;
-  parameter logic [5:0] PATTGEN_PATT1_DATA0_OFFSET = 6'h 24;
-  parameter logic [5:0] PATTGEN_PATT1_DATA1_OFFSET = 6'h 28;
+  parameter logic [5:0] PATTGEN_PATT_CTRL_OFFSET = 6'h c;
+  parameter logic [5:0] PATTGEN_PATT_START_OFFSET = 6'h 10;
+  parameter logic [5:0] PATTGEN_PATT_PREDIV0_OFFSET = 6'h 14;
+  parameter logic [5:0] PATTGEN_PATT_PREDIV1_OFFSET = 6'h 18;
+  parameter logic [5:0] PATTGEN_PATT_DATA_CH00_OFFSET = 6'h 1c;
+  parameter logic [5:0] PATTGEN_PATT_DATA_CH01_OFFSET = 6'h 20;
+  parameter logic [5:0] PATTGEN_PATT_DATA_CH10_OFFSET = 6'h 24;
+  parameter logic [5:0] PATTGEN_PATT_DATA_CH11_OFFSET = 6'h 28;
   parameter logic [5:0] PATTGEN_PATT_LEN_OFFSET = 6'h 2c;
   parameter logic [5:0] PATTGEN_PATT_LOOP_OFFSET = 6'h 30;
-  parameter logic [5:0] PATTGEN_INTR_MASK_OFFSET = 6'h 34;
 
 
   // Register Index
@@ -164,35 +151,33 @@ package pattgen_reg_pkg;
     PATTGEN_INTR_STATE,
     PATTGEN_INTR_ENABLE,
     PATTGEN_INTR_TEST,
-    PATTGEN_CTRL,
-    PATTGEN_START,
-    PATTGEN_PREDIV0,
-    PATTGEN_PREDIV1,
-    PATTGEN_PATT0_DATA0,
-    PATTGEN_PATT0_DATA1,
-    PATTGEN_PATT1_DATA0,
-    PATTGEN_PATT1_DATA1,
+    PATTGEN_PATT_CTRL,
+    PATTGEN_PATT_START,
+    PATTGEN_PATT_PREDIV0,
+    PATTGEN_PATT_PREDIV1,
+    PATTGEN_PATT_DATA_CH00,
+    PATTGEN_PATT_DATA_CH01,
+    PATTGEN_PATT_DATA_CH10,
+    PATTGEN_PATT_DATA_CH11,
     PATTGEN_PATT_LEN,
-    PATTGEN_PATT_LOOP,
-    PATTGEN_INTR_MASK
+    PATTGEN_PATT_LOOP
   } pattgen_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] PATTGEN_PERMIT [14] = '{
+  parameter logic [3:0] PATTGEN_PERMIT [13] = '{
     4'b 0001, // index[ 0] PATTGEN_INTR_STATE
     4'b 0001, // index[ 1] PATTGEN_INTR_ENABLE
     4'b 0001, // index[ 2] PATTGEN_INTR_TEST
-    4'b 0001, // index[ 3] PATTGEN_CTRL
-    4'b 0001, // index[ 4] PATTGEN_START
-    4'b 1111, // index[ 5] PATTGEN_PREDIV0
-    4'b 1111, // index[ 6] PATTGEN_PREDIV1
-    4'b 1111, // index[ 7] PATTGEN_PATT0_DATA0
-    4'b 1111, // index[ 8] PATTGEN_PATT0_DATA1
-    4'b 1111, // index[ 9] PATTGEN_PATT1_DATA0
-    4'b 1111, // index[10] PATTGEN_PATT1_DATA1
+    4'b 0001, // index[ 3] PATTGEN_PATT_CTRL
+    4'b 0001, // index[ 4] PATTGEN_PATT_START
+    4'b 1111, // index[ 5] PATTGEN_PATT_PREDIV0
+    4'b 1111, // index[ 6] PATTGEN_PATT_PREDIV1
+    4'b 1111, // index[ 7] PATTGEN_PATT_DATA_CH00
+    4'b 1111, // index[ 8] PATTGEN_PATT_DATA_CH01
+    4'b 1111, // index[ 9] PATTGEN_PATT_DATA_CH10
+    4'b 1111, // index[10] PATTGEN_PATT_DATA_CH11
     4'b 0011, // index[11] PATTGEN_PATT_LEN
-    4'b 0111, // index[12] PATTGEN_PATT_LOOP
-    4'b 0001  // index[13] PATTGEN_INTR_MASK
+    4'b 0111  // index[12] PATTGEN_PATT_LOOP
   };
 endpackage
 

--- a/hw/ip/pattgen/rtl/pattgen_reg_top.sv
+++ b/hw/ip/pattgen/rtl/pattgen_reg_top.sv
@@ -71,123 +71,119 @@ module pattgen_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
-  logic intr_state_patt_done0_qs;
-  logic intr_state_patt_done0_wd;
-  logic intr_state_patt_done0_we;
-  logic intr_state_patt_done1_qs;
-  logic intr_state_patt_done1_wd;
-  logic intr_state_patt_done1_we;
-  logic intr_enable_patt_done0_qs;
-  logic intr_enable_patt_done0_wd;
-  logic intr_enable_patt_done0_we;
-  logic intr_enable_patt_done1_qs;
-  logic intr_enable_patt_done1_wd;
-  logic intr_enable_patt_done1_we;
-  logic intr_test_patt_done0_wd;
-  logic intr_test_patt_done0_we;
-  logic intr_test_patt_done1_wd;
-  logic intr_test_patt_done1_we;
-  logic ctrl_qs;
-  logic ctrl_wd;
-  logic ctrl_we;
-  logic start_start0_wd;
-  logic start_start0_we;
-  logic start_start1_wd;
-  logic start_start1_we;
-  logic [31:0] prediv0_wd;
-  logic prediv0_we;
-  logic [31:0] prediv1_wd;
-  logic prediv1_we;
-  logic [31:0] patt0_data0_wd;
-  logic patt0_data0_we;
-  logic [31:0] patt0_data1_wd;
-  logic patt0_data1_we;
-  logic [31:0] patt1_data0_wd;
-  logic patt1_data0_we;
-  logic [31:0] patt1_data1_wd;
-  logic patt1_data1_we;
-  logic [5:0] patt_len_len0_wd;
-  logic patt_len_len0_we;
-  logic [5:0] patt_len_len1_wd;
-  logic patt_len_len1_we;
-  logic [9:0] patt_loop_loop0_wd;
-  logic patt_loop_loop0_we;
-  logic [9:0] patt_loop_loop1_wd;
-  logic patt_loop_loop1_we;
-  logic intr_mask_mask0_wd;
-  logic intr_mask_mask0_we;
-  logic intr_mask_mask1_wd;
-  logic intr_mask_mask1_we;
+  logic intr_state_intr_patt_done_ch0_qs;
+  logic intr_state_intr_patt_done_ch0_wd;
+  logic intr_state_intr_patt_done_ch0_we;
+  logic intr_state_intr_patt_done_ch1_qs;
+  logic intr_state_intr_patt_done_ch1_wd;
+  logic intr_state_intr_patt_done_ch1_we;
+  logic intr_enable_intr_patt_done_ch0_qs;
+  logic intr_enable_intr_patt_done_ch0_wd;
+  logic intr_enable_intr_patt_done_ch0_we;
+  logic intr_enable_intr_patt_done_ch1_qs;
+  logic intr_enable_intr_patt_done_ch1_wd;
+  logic intr_enable_intr_patt_done_ch1_we;
+  logic intr_test_intr_patt_done_ch0_wd;
+  logic intr_test_intr_patt_done_ch0_we;
+  logic intr_test_intr_patt_done_ch1_wd;
+  logic intr_test_intr_patt_done_ch1_we;
+  logic patt_ctrl_qs;
+  logic patt_ctrl_wd;
+  logic patt_ctrl_we;
+  logic patt_start_ch0_start_wd;
+  logic patt_start_ch0_start_we;
+  logic patt_start_ch1_start_wd;
+  logic patt_start_ch1_start_we;
+  logic [31:0] patt_prediv0_wd;
+  logic patt_prediv0_we;
+  logic [31:0] patt_prediv1_wd;
+  logic patt_prediv1_we;
+  logic [31:0] patt_data_ch00_wd;
+  logic patt_data_ch00_we;
+  logic [31:0] patt_data_ch01_wd;
+  logic patt_data_ch01_we;
+  logic [31:0] patt_data_ch10_wd;
+  logic patt_data_ch10_we;
+  logic [31:0] patt_data_ch11_wd;
+  logic patt_data_ch11_we;
+  logic [5:0] patt_len_ch0_len_wd;
+  logic patt_len_ch0_len_we;
+  logic [5:0] patt_len_ch1_len_wd;
+  logic patt_len_ch1_len_we;
+  logic [9:0] patt_loop_ch0_loop_wd;
+  logic patt_loop_ch0_loop_we;
+  logic [9:0] patt_loop_ch1_loop_wd;
+  logic patt_loop_ch1_loop_we;
 
   // Register instances
   // R[intr_state]: V(False)
 
-  //   F[patt_done0]: 0:0
+  //   F[intr_patt_done_ch0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SWACCESS("W1C"),
     .RESVAL  (1'h0)
-  ) u_intr_state_patt_done0 (
+  ) u_intr_state_intr_patt_done_ch0 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (intr_state_patt_done0_we),
-    .wd     (intr_state_patt_done0_wd),
+    .we     (intr_state_intr_patt_done_ch0_we),
+    .wd     (intr_state_intr_patt_done_ch0_wd),
 
     // from internal hardware
-    .de     (hw2reg.intr_state.patt_done0.de),
-    .d      (hw2reg.intr_state.patt_done0.d ),
+    .de     (hw2reg.intr_state.intr_patt_done_ch0.de),
+    .d      (hw2reg.intr_state.intr_patt_done_ch0.d ),
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_state.patt_done0.q ),
+    .q      (reg2hw.intr_state.intr_patt_done_ch0.q ),
 
     // to register interface (read)
-    .qs     (intr_state_patt_done0_qs)
+    .qs     (intr_state_intr_patt_done_ch0_qs)
   );
 
 
-  //   F[patt_done1]: 1:1
+  //   F[intr_patt_done_ch1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SWACCESS("W1C"),
     .RESVAL  (1'h0)
-  ) u_intr_state_patt_done1 (
+  ) u_intr_state_intr_patt_done_ch1 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (intr_state_patt_done1_we),
-    .wd     (intr_state_patt_done1_wd),
+    .we     (intr_state_intr_patt_done_ch1_we),
+    .wd     (intr_state_intr_patt_done_ch1_wd),
 
     // from internal hardware
-    .de     (hw2reg.intr_state.patt_done1.de),
-    .d      (hw2reg.intr_state.patt_done1.d ),
+    .de     (hw2reg.intr_state.intr_patt_done_ch1.de),
+    .d      (hw2reg.intr_state.intr_patt_done_ch1.d ),
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_state.patt_done1.q ),
+    .q      (reg2hw.intr_state.intr_patt_done_ch1.q ),
 
     // to register interface (read)
-    .qs     (intr_state_patt_done1_qs)
+    .qs     (intr_state_intr_patt_done_ch1_qs)
   );
 
 
   // R[intr_enable]: V(False)
 
-  //   F[patt_done0]: 0:0
+  //   F[intr_patt_done_ch0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
     .RESVAL  (1'h0)
-  ) u_intr_enable_patt_done0 (
+  ) u_intr_enable_intr_patt_done_ch0 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (intr_enable_patt_done0_we),
-    .wd     (intr_enable_patt_done0_wd),
+    .we     (intr_enable_intr_patt_done_ch0_we),
+    .wd     (intr_enable_intr_patt_done_ch0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -195,25 +191,25 @@ module pattgen_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_enable.patt_done0.q ),
+    .q      (reg2hw.intr_enable.intr_patt_done_ch0.q ),
 
     // to register interface (read)
-    .qs     (intr_enable_patt_done0_qs)
+    .qs     (intr_enable_intr_patt_done_ch0_qs)
   );
 
 
-  //   F[patt_done1]: 1:1
+  //   F[intr_patt_done_ch1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
     .RESVAL  (1'h0)
-  ) u_intr_enable_patt_done1 (
+  ) u_intr_enable_intr_patt_done_ch1 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (intr_enable_patt_done1_we),
-    .wd     (intr_enable_patt_done1_wd),
+    .we     (intr_enable_intr_patt_done_ch1_we),
+    .wd     (intr_enable_intr_patt_done_ch1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -221,58 +217,58 @@ module pattgen_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_enable.patt_done1.q ),
+    .q      (reg2hw.intr_enable.intr_patt_done_ch1.q ),
 
     // to register interface (read)
-    .qs     (intr_enable_patt_done1_qs)
+    .qs     (intr_enable_intr_patt_done_ch1_qs)
   );
 
 
   // R[intr_test]: V(True)
 
-  //   F[patt_done0]: 0:0
+  //   F[intr_patt_done_ch0]: 0:0
   prim_subreg_ext #(
     .DW    (1)
-  ) u_intr_test_patt_done0 (
+  ) u_intr_test_intr_patt_done_ch0 (
     .re     (1'b0),
-    .we     (intr_test_patt_done0_we),
-    .wd     (intr_test_patt_done0_wd),
+    .we     (intr_test_intr_patt_done_ch0_we),
+    .wd     (intr_test_intr_patt_done_ch0_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.patt_done0.qe),
-    .q      (reg2hw.intr_test.patt_done0.q ),
+    .qe     (reg2hw.intr_test.intr_patt_done_ch0.qe),
+    .q      (reg2hw.intr_test.intr_patt_done_ch0.q ),
     .qs     ()
   );
 
 
-  //   F[patt_done1]: 1:1
+  //   F[intr_patt_done_ch1]: 1:1
   prim_subreg_ext #(
     .DW    (1)
-  ) u_intr_test_patt_done1 (
+  ) u_intr_test_intr_patt_done_ch1 (
     .re     (1'b0),
-    .we     (intr_test_patt_done1_we),
-    .wd     (intr_test_patt_done1_wd),
+    .we     (intr_test_intr_patt_done_ch1_we),
+    .wd     (intr_test_intr_patt_done_ch1_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.patt_done1.qe),
-    .q      (reg2hw.intr_test.patt_done1.q ),
+    .qe     (reg2hw.intr_test.intr_patt_done_ch1.qe),
+    .q      (reg2hw.intr_test.intr_patt_done_ch1.q ),
     .qs     ()
   );
 
 
-  // R[ctrl]: V(False)
+  // R[patt_ctrl]: V(False)
 
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
     .RESVAL  (1'h0)
-  ) u_ctrl (
+  ) u_patt_ctrl (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (ctrl_we),
-    .wd     (ctrl_wd),
+    .we     (patt_ctrl_we),
+    .wd     (patt_ctrl_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -280,222 +276,222 @@ module pattgen_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.ctrl.q ),
+    .q      (reg2hw.patt_ctrl.q ),
 
     // to register interface (read)
-    .qs     (ctrl_qs)
+    .qs     (patt_ctrl_qs)
   );
 
 
-  // R[start]: V(False)
+  // R[patt_start]: V(False)
 
-  //   F[start0]: 0:0
+  //   F[ch0_start]: 0:0
   prim_subreg #(
     .DW      (1),
     .SWACCESS("WO"),
     .RESVAL  (1'h0)
-  ) u_start_start0 (
+  ) u_patt_start_ch0_start (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (start_start0_we),
-    .wd     (start_start0_wd),
+    .we     (patt_start_ch0_start_we),
+    .wd     (patt_start_ch0_start_wd),
 
     // from internal hardware
     .de     (1'b0),
     .d      ('0  ),
 
     // to internal hardware
-    .qe     (reg2hw.start.start0.qe),
-    .q      (reg2hw.start.start0.q ),
+    .qe     (reg2hw.patt_start.ch0_start.qe),
+    .q      (reg2hw.patt_start.ch0_start.q ),
 
     .qs     ()
   );
 
 
-  //   F[start1]: 1:1
+  //   F[ch1_start]: 1:1
   prim_subreg #(
     .DW      (1),
     .SWACCESS("WO"),
     .RESVAL  (1'h0)
-  ) u_start_start1 (
+  ) u_patt_start_ch1_start (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (start_start1_we),
-    .wd     (start_start1_wd),
+    .we     (patt_start_ch1_start_we),
+    .wd     (patt_start_ch1_start_wd),
 
     // from internal hardware
     .de     (1'b0),
     .d      ('0  ),
 
     // to internal hardware
-    .qe     (reg2hw.start.start1.qe),
-    .q      (reg2hw.start.start1.q ),
+    .qe     (reg2hw.patt_start.ch1_start.qe),
+    .q      (reg2hw.patt_start.ch1_start.q ),
 
     .qs     ()
   );
 
 
 
-  // Subregister 0 of Multireg prediv
-  // R[prediv0]: V(False)
+  // Subregister 0 of Multireg patt_prediv
+  // R[patt_prediv0]: V(False)
 
   prim_subreg #(
     .DW      (32),
     .SWACCESS("WO"),
     .RESVAL  (32'h0)
-  ) u_prediv0 (
+  ) u_patt_prediv0 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (prediv0_we),
-    .wd     (prediv0_wd),
+    .we     (patt_prediv0_we),
+    .wd     (patt_prediv0_wd),
 
     // from internal hardware
     .de     (1'b0),
     .d      ('0  ),
 
     // to internal hardware
-    .qe     (reg2hw.prediv[0].qe),
-    .q      (reg2hw.prediv[0].q ),
+    .qe     (reg2hw.patt_prediv[0].qe),
+    .q      (reg2hw.patt_prediv[0].q ),
 
     .qs     ()
   );
 
-  // Subregister 1 of Multireg prediv
-  // R[prediv1]: V(False)
+  // Subregister 1 of Multireg patt_prediv
+  // R[patt_prediv1]: V(False)
 
   prim_subreg #(
     .DW      (32),
     .SWACCESS("WO"),
     .RESVAL  (32'h0)
-  ) u_prediv1 (
+  ) u_patt_prediv1 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (prediv1_we),
-    .wd     (prediv1_wd),
+    .we     (patt_prediv1_we),
+    .wd     (patt_prediv1_wd),
 
     // from internal hardware
     .de     (1'b0),
     .d      ('0  ),
 
     // to internal hardware
-    .qe     (reg2hw.prediv[1].qe),
-    .q      (reg2hw.prediv[1].q ),
-
-    .qs     ()
-  );
-
-
-
-  // Subregister 0 of Multireg patt0_data
-  // R[patt0_data0]: V(False)
-
-  prim_subreg #(
-    .DW      (32),
-    .SWACCESS("WO"),
-    .RESVAL  (32'h0)
-  ) u_patt0_data0 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (patt0_data0_we),
-    .wd     (patt0_data0_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (reg2hw.patt0_data[0].qe),
-    .q      (reg2hw.patt0_data[0].q ),
-
-    .qs     ()
-  );
-
-  // Subregister 1 of Multireg patt0_data
-  // R[patt0_data1]: V(False)
-
-  prim_subreg #(
-    .DW      (32),
-    .SWACCESS("WO"),
-    .RESVAL  (32'h0)
-  ) u_patt0_data1 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (patt0_data1_we),
-    .wd     (patt0_data1_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (reg2hw.patt0_data[1].qe),
-    .q      (reg2hw.patt0_data[1].q ),
+    .qe     (reg2hw.patt_prediv[1].qe),
+    .q      (reg2hw.patt_prediv[1].q ),
 
     .qs     ()
   );
 
 
 
-  // Subregister 0 of Multireg patt1_data
-  // R[patt1_data0]: V(False)
+  // Subregister 0 of Multireg patt_data_ch0
+  // R[patt_data_ch00]: V(False)
 
   prim_subreg #(
     .DW      (32),
     .SWACCESS("WO"),
     .RESVAL  (32'h0)
-  ) u_patt1_data0 (
+  ) u_patt_data_ch00 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (patt1_data0_we),
-    .wd     (patt1_data0_wd),
+    .we     (patt_data_ch00_we),
+    .wd     (patt_data_ch00_wd),
 
     // from internal hardware
     .de     (1'b0),
     .d      ('0  ),
 
     // to internal hardware
-    .qe     (reg2hw.patt1_data[0].qe),
-    .q      (reg2hw.patt1_data[0].q ),
+    .qe     (reg2hw.patt_data_ch0[0].qe),
+    .q      (reg2hw.patt_data_ch0[0].q ),
 
     .qs     ()
   );
 
-  // Subregister 1 of Multireg patt1_data
-  // R[patt1_data1]: V(False)
+  // Subregister 1 of Multireg patt_data_ch0
+  // R[patt_data_ch01]: V(False)
 
   prim_subreg #(
     .DW      (32),
     .SWACCESS("WO"),
     .RESVAL  (32'h0)
-  ) u_patt1_data1 (
+  ) u_patt_data_ch01 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (patt1_data1_we),
-    .wd     (patt1_data1_wd),
+    .we     (patt_data_ch01_we),
+    .wd     (patt_data_ch01_wd),
 
     // from internal hardware
     .de     (1'b0),
     .d      ('0  ),
 
     // to internal hardware
-    .qe     (reg2hw.patt1_data[1].qe),
-    .q      (reg2hw.patt1_data[1].q ),
+    .qe     (reg2hw.patt_data_ch0[1].qe),
+    .q      (reg2hw.patt_data_ch0[1].q ),
+
+    .qs     ()
+  );
+
+
+
+  // Subregister 0 of Multireg patt_data_ch1
+  // R[patt_data_ch10]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("WO"),
+    .RESVAL  (32'h0)
+  ) u_patt_data_ch10 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (patt_data_ch10_we),
+    .wd     (patt_data_ch10_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (reg2hw.patt_data_ch1[0].qe),
+    .q      (reg2hw.patt_data_ch1[0].q ),
+
+    .qs     ()
+  );
+
+  // Subregister 1 of Multireg patt_data_ch1
+  // R[patt_data_ch11]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("WO"),
+    .RESVAL  (32'h0)
+  ) u_patt_data_ch11 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (patt_data_ch11_we),
+    .wd     (patt_data_ch11_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (reg2hw.patt_data_ch1[1].qe),
+    .q      (reg2hw.patt_data_ch1[1].q ),
 
     .qs     ()
   );
@@ -503,51 +499,51 @@ module pattgen_reg_top (
 
   // R[patt_len]: V(False)
 
-  //   F[len0]: 5:0
+  //   F[ch0_len]: 5:0
   prim_subreg #(
     .DW      (6),
     .SWACCESS("WO"),
     .RESVAL  (6'h0)
-  ) u_patt_len_len0 (
+  ) u_patt_len_ch0_len (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (patt_len_len0_we),
-    .wd     (patt_len_len0_wd),
+    .we     (patt_len_ch0_len_we),
+    .wd     (patt_len_ch0_len_wd),
 
     // from internal hardware
     .de     (1'b0),
     .d      ('0  ),
 
     // to internal hardware
-    .qe     (reg2hw.patt_len.len0.qe),
-    .q      (reg2hw.patt_len.len0.q ),
+    .qe     (reg2hw.patt_len.ch0_len.qe),
+    .q      (reg2hw.patt_len.ch0_len.q ),
 
     .qs     ()
   );
 
 
-  //   F[len1]: 12:7
+  //   F[ch1_len]: 12:7
   prim_subreg #(
     .DW      (6),
     .SWACCESS("WO"),
     .RESVAL  (6'h0)
-  ) u_patt_len_len1 (
+  ) u_patt_len_ch1_len (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (patt_len_len1_we),
-    .wd     (patt_len_len1_wd),
+    .we     (patt_len_ch1_len_we),
+    .wd     (patt_len_ch1_len_wd),
 
     // from internal hardware
     .de     (1'b0),
     .d      ('0  ),
 
     // to internal hardware
-    .qe     (reg2hw.patt_len.len1.qe),
-    .q      (reg2hw.patt_len.len1.q ),
+    .qe     (reg2hw.patt_len.ch1_len.qe),
+    .q      (reg2hw.patt_len.ch1_len.q ),
 
     .qs     ()
   );
@@ -555,127 +551,72 @@ module pattgen_reg_top (
 
   // R[patt_loop]: V(False)
 
-  //   F[loop0]: 9:0
+  //   F[ch0_loop]: 9:0
   prim_subreg #(
     .DW      (10),
     .SWACCESS("WO"),
     .RESVAL  (10'h0)
-  ) u_patt_loop_loop0 (
+  ) u_patt_loop_ch0_loop (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (patt_loop_loop0_we),
-    .wd     (patt_loop_loop0_wd),
+    .we     (patt_loop_ch0_loop_we),
+    .wd     (patt_loop_ch0_loop_wd),
 
     // from internal hardware
     .de     (1'b0),
     .d      ('0  ),
 
     // to internal hardware
-    .qe     (reg2hw.patt_loop.loop0.qe),
-    .q      (reg2hw.patt_loop.loop0.q ),
+    .qe     (reg2hw.patt_loop.ch0_loop.qe),
+    .q      (reg2hw.patt_loop.ch0_loop.q ),
 
     .qs     ()
   );
 
 
-  //   F[loop1]: 19:10
+  //   F[ch1_loop]: 19:10
   prim_subreg #(
     .DW      (10),
     .SWACCESS("WO"),
     .RESVAL  (10'h0)
-  ) u_patt_loop_loop1 (
+  ) u_patt_loop_ch1_loop (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (patt_loop_loop1_we),
-    .wd     (patt_loop_loop1_wd),
+    .we     (patt_loop_ch1_loop_we),
+    .wd     (patt_loop_ch1_loop_wd),
 
     // from internal hardware
     .de     (1'b0),
     .d      ('0  ),
 
     // to internal hardware
-    .qe     (reg2hw.patt_loop.loop1.qe),
-    .q      (reg2hw.patt_loop.loop1.q ),
+    .qe     (reg2hw.patt_loop.ch1_loop.qe),
+    .q      (reg2hw.patt_loop.ch1_loop.q ),
 
     .qs     ()
   );
 
 
-  // R[intr_mask]: V(False)
-
-  //   F[mask0]: 0:0
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("WO"),
-    .RESVAL  (1'h0)
-  ) u_intr_mask_mask0 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (intr_mask_mask0_we),
-    .wd     (intr_mask_mask0_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (reg2hw.intr_mask.mask0.qe),
-    .q      (reg2hw.intr_mask.mask0.q ),
-
-    .qs     ()
-  );
-
-
-  //   F[mask1]: 1:1
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("WO"),
-    .RESVAL  (1'h0)
-  ) u_intr_mask_mask1 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (intr_mask_mask1_we),
-    .wd     (intr_mask_mask1_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (reg2hw.intr_mask.mask1.qe),
-    .q      (reg2hw.intr_mask.mask1.q ),
-
-    .qs     ()
-  );
-
-
-
-
-  logic [13:0] addr_hit;
+  logic [12:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == PATTGEN_INTR_STATE_OFFSET);
     addr_hit[ 1] = (reg_addr == PATTGEN_INTR_ENABLE_OFFSET);
     addr_hit[ 2] = (reg_addr == PATTGEN_INTR_TEST_OFFSET);
-    addr_hit[ 3] = (reg_addr == PATTGEN_CTRL_OFFSET);
-    addr_hit[ 4] = (reg_addr == PATTGEN_START_OFFSET);
-    addr_hit[ 5] = (reg_addr == PATTGEN_PREDIV0_OFFSET);
-    addr_hit[ 6] = (reg_addr == PATTGEN_PREDIV1_OFFSET);
-    addr_hit[ 7] = (reg_addr == PATTGEN_PATT0_DATA0_OFFSET);
-    addr_hit[ 8] = (reg_addr == PATTGEN_PATT0_DATA1_OFFSET);
-    addr_hit[ 9] = (reg_addr == PATTGEN_PATT1_DATA0_OFFSET);
-    addr_hit[10] = (reg_addr == PATTGEN_PATT1_DATA1_OFFSET);
+    addr_hit[ 3] = (reg_addr == PATTGEN_PATT_CTRL_OFFSET);
+    addr_hit[ 4] = (reg_addr == PATTGEN_PATT_START_OFFSET);
+    addr_hit[ 5] = (reg_addr == PATTGEN_PATT_PREDIV0_OFFSET);
+    addr_hit[ 6] = (reg_addr == PATTGEN_PATT_PREDIV1_OFFSET);
+    addr_hit[ 7] = (reg_addr == PATTGEN_PATT_DATA_CH00_OFFSET);
+    addr_hit[ 8] = (reg_addr == PATTGEN_PATT_DATA_CH01_OFFSET);
+    addr_hit[ 9] = (reg_addr == PATTGEN_PATT_DATA_CH10_OFFSET);
+    addr_hit[10] = (reg_addr == PATTGEN_PATT_DATA_CH11_OFFSET);
     addr_hit[11] = (reg_addr == PATTGEN_PATT_LEN_OFFSET);
     addr_hit[12] = (reg_addr == PATTGEN_PATT_LOOP_OFFSET);
-    addr_hit[13] = (reg_addr == PATTGEN_INTR_MASK_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -683,97 +624,103 @@ module pattgen_reg_top (
   // Check sub-word write is permitted
   always_comb begin
     wr_err = 1'b0;
-    if (addr_hit[ 0] && reg_we && (PATTGEN_PERMIT[ 0] != (PATTGEN_PERMIT[ 0] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 1] && reg_we && (PATTGEN_PERMIT[ 1] != (PATTGEN_PERMIT[ 1] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 2] && reg_we && (PATTGEN_PERMIT[ 2] != (PATTGEN_PERMIT[ 2] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 3] && reg_we && (PATTGEN_PERMIT[ 3] != (PATTGEN_PERMIT[ 3] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 4] && reg_we && (PATTGEN_PERMIT[ 4] != (PATTGEN_PERMIT[ 4] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 5] && reg_we && (PATTGEN_PERMIT[ 5] != (PATTGEN_PERMIT[ 5] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 6] && reg_we && (PATTGEN_PERMIT[ 6] != (PATTGEN_PERMIT[ 6] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 7] && reg_we && (PATTGEN_PERMIT[ 7] != (PATTGEN_PERMIT[ 7] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 8] && reg_we && (PATTGEN_PERMIT[ 8] != (PATTGEN_PERMIT[ 8] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[ 9] && reg_we && (PATTGEN_PERMIT[ 9] != (PATTGEN_PERMIT[ 9] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[10] && reg_we && (PATTGEN_PERMIT[10] != (PATTGEN_PERMIT[10] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[11] && reg_we && (PATTGEN_PERMIT[11] != (PATTGEN_PERMIT[11] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[12] && reg_we && (PATTGEN_PERMIT[12] != (PATTGEN_PERMIT[12] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[13] && reg_we && (PATTGEN_PERMIT[13] != (PATTGEN_PERMIT[13] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[ 0] && reg_we &&
+      (PATTGEN_PERMIT[ 0] != (PATTGEN_PERMIT[ 0] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[ 1] && reg_we &&
+      (PATTGEN_PERMIT[ 1] != (PATTGEN_PERMIT[ 1] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[ 2] && reg_we &&
+      (PATTGEN_PERMIT[ 2] != (PATTGEN_PERMIT[ 2] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[ 3] && reg_we &&
+      (PATTGEN_PERMIT[ 3] != (PATTGEN_PERMIT[ 3] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[ 4] && reg_we &&
+      (PATTGEN_PERMIT[ 4] != (PATTGEN_PERMIT[ 4] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[ 5] && reg_we &&
+      (PATTGEN_PERMIT[ 5] != (PATTGEN_PERMIT[ 5] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[ 6] && reg_we &&
+      (PATTGEN_PERMIT[ 6] != (PATTGEN_PERMIT[ 6] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[ 7] && reg_we &&
+      (PATTGEN_PERMIT[ 7] != (PATTGEN_PERMIT[ 7] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[ 8] && reg_we &&
+      (PATTGEN_PERMIT[ 8] != (PATTGEN_PERMIT[ 8] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[ 9] && reg_we &&
+      (PATTGEN_PERMIT[ 9] != (PATTGEN_PERMIT[ 9] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[10] && reg_we &&
+      (PATTGEN_PERMIT[10] != (PATTGEN_PERMIT[10] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[11] && reg_we &&
+      (PATTGEN_PERMIT[11] != (PATTGEN_PERMIT[11] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[12] && reg_we &&
+      (PATTGEN_PERMIT[12] != (PATTGEN_PERMIT[12] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign intr_state_patt_done0_we = addr_hit[0] & reg_we & ~wr_err;
-  assign intr_state_patt_done0_wd = reg_wdata[0];
+  assign intr_state_intr_patt_done_ch0_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_intr_patt_done_ch0_wd = reg_wdata[0];
 
-  assign intr_state_patt_done1_we = addr_hit[0] & reg_we & ~wr_err;
-  assign intr_state_patt_done1_wd = reg_wdata[1];
+  assign intr_state_intr_patt_done_ch1_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_intr_patt_done_ch1_wd = reg_wdata[1];
 
-  assign intr_enable_patt_done0_we = addr_hit[1] & reg_we & ~wr_err;
-  assign intr_enable_patt_done0_wd = reg_wdata[0];
+  assign intr_enable_intr_patt_done_ch0_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_intr_patt_done_ch0_wd = reg_wdata[0];
 
-  assign intr_enable_patt_done1_we = addr_hit[1] & reg_we & ~wr_err;
-  assign intr_enable_patt_done1_wd = reg_wdata[1];
+  assign intr_enable_intr_patt_done_ch1_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_intr_patt_done_ch1_wd = reg_wdata[1];
 
-  assign intr_test_patt_done0_we = addr_hit[2] & reg_we & ~wr_err;
-  assign intr_test_patt_done0_wd = reg_wdata[0];
+  assign intr_test_intr_patt_done_ch0_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_intr_patt_done_ch0_wd = reg_wdata[0];
 
-  assign intr_test_patt_done1_we = addr_hit[2] & reg_we & ~wr_err;
-  assign intr_test_patt_done1_wd = reg_wdata[1];
+  assign intr_test_intr_patt_done_ch1_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_intr_patt_done_ch1_wd = reg_wdata[1];
 
-  assign ctrl_we = addr_hit[3] & reg_we & ~wr_err;
-  assign ctrl_wd = reg_wdata[0];
+  assign patt_ctrl_we = addr_hit[3] & reg_we & ~wr_err;
+  assign patt_ctrl_wd = reg_wdata[0];
 
-  assign start_start0_we = addr_hit[4] & reg_we & ~wr_err;
-  assign start_start0_wd = reg_wdata[0];
+  assign patt_start_ch0_start_we = addr_hit[4] & reg_we & ~wr_err;
+  assign patt_start_ch0_start_wd = reg_wdata[0];
 
-  assign start_start1_we = addr_hit[4] & reg_we & ~wr_err;
-  assign start_start1_wd = reg_wdata[1];
+  assign patt_start_ch1_start_we = addr_hit[4] & reg_we & ~wr_err;
+  assign patt_start_ch1_start_wd = reg_wdata[1];
 
-  assign prediv0_we = addr_hit[5] & reg_we & ~wr_err;
-  assign prediv0_wd = reg_wdata[31:0];
+  assign patt_prediv0_we = addr_hit[5] & reg_we & ~wr_err;
+  assign patt_prediv0_wd = reg_wdata[31:0];
 
-  assign prediv1_we = addr_hit[6] & reg_we & ~wr_err;
-  assign prediv1_wd = reg_wdata[31:0];
+  assign patt_prediv1_we = addr_hit[6] & reg_we & ~wr_err;
+  assign patt_prediv1_wd = reg_wdata[31:0];
 
-  assign patt0_data0_we = addr_hit[7] & reg_we & ~wr_err;
-  assign patt0_data0_wd = reg_wdata[31:0];
+  assign patt_data_ch00_we = addr_hit[7] & reg_we & ~wr_err;
+  assign patt_data_ch00_wd = reg_wdata[31:0];
 
-  assign patt0_data1_we = addr_hit[8] & reg_we & ~wr_err;
-  assign patt0_data1_wd = reg_wdata[31:0];
+  assign patt_data_ch01_we = addr_hit[8] & reg_we & ~wr_err;
+  assign patt_data_ch01_wd = reg_wdata[31:0];
 
-  assign patt1_data0_we = addr_hit[9] & reg_we & ~wr_err;
-  assign patt1_data0_wd = reg_wdata[31:0];
+  assign patt_data_ch10_we = addr_hit[9] & reg_we & ~wr_err;
+  assign patt_data_ch10_wd = reg_wdata[31:0];
 
-  assign patt1_data1_we = addr_hit[10] & reg_we & ~wr_err;
-  assign patt1_data1_wd = reg_wdata[31:0];
+  assign patt_data_ch11_we = addr_hit[10] & reg_we & ~wr_err;
+  assign patt_data_ch11_wd = reg_wdata[31:0];
 
-  assign patt_len_len0_we = addr_hit[11] & reg_we & ~wr_err;
-  assign patt_len_len0_wd = reg_wdata[5:0];
+  assign patt_len_ch0_len_we = addr_hit[11] & reg_we & ~wr_err;
+  assign patt_len_ch0_len_wd = reg_wdata[5:0];
 
-  assign patt_len_len1_we = addr_hit[11] & reg_we & ~wr_err;
-  assign patt_len_len1_wd = reg_wdata[12:7];
+  assign patt_len_ch1_len_we = addr_hit[11] & reg_we & ~wr_err;
+  assign patt_len_ch1_len_wd = reg_wdata[12:7];
 
-  assign patt_loop_loop0_we = addr_hit[12] & reg_we & ~wr_err;
-  assign patt_loop_loop0_wd = reg_wdata[9:0];
+  assign patt_loop_ch0_loop_we = addr_hit[12] & reg_we & ~wr_err;
+  assign patt_loop_ch0_loop_wd = reg_wdata[9:0];
 
-  assign patt_loop_loop1_we = addr_hit[12] & reg_we & ~wr_err;
-  assign patt_loop_loop1_wd = reg_wdata[19:10];
-
-  assign intr_mask_mask0_we = addr_hit[13] & reg_we & ~wr_err;
-  assign intr_mask_mask0_wd = reg_wdata[0];
-
-  assign intr_mask_mask1_we = addr_hit[13] & reg_we & ~wr_err;
-  assign intr_mask_mask1_wd = reg_wdata[1];
+  assign patt_loop_ch1_loop_we = addr_hit[12] & reg_we & ~wr_err;
+  assign patt_loop_ch1_loop_wd = reg_wdata[19:10];
 
   // Read data return
   always_comb begin
     reg_rdata_next = '0;
     unique case (1'b1)
       addr_hit[0]: begin
-        reg_rdata_next[0] = intr_state_patt_done0_qs;
-        reg_rdata_next[1] = intr_state_patt_done1_qs;
+        reg_rdata_next[0] = intr_state_intr_patt_done_ch0_qs;
+        reg_rdata_next[1] = intr_state_intr_patt_done_ch1_qs;
       end
 
       addr_hit[1]: begin
-        reg_rdata_next[0] = intr_enable_patt_done0_qs;
-        reg_rdata_next[1] = intr_enable_patt_done1_qs;
+        reg_rdata_next[0] = intr_enable_intr_patt_done_ch0_qs;
+        reg_rdata_next[1] = intr_enable_intr_patt_done_ch1_qs;
       end
 
       addr_hit[2]: begin
@@ -782,7 +729,7 @@ module pattgen_reg_top (
       end
 
       addr_hit[3]: begin
-        reg_rdata_next[0] = ctrl_qs;
+        reg_rdata_next[0] = patt_ctrl_qs;
       end
 
       addr_hit[4]: begin
@@ -822,11 +769,6 @@ module pattgen_reg_top (
       addr_hit[12]: begin
         reg_rdata_next[9:0] = '0;
         reg_rdata_next[19:10] = '0;
-      end
-
-      addr_hit[13]: begin
-        reg_rdata_next[0] = '0;
-        reg_rdata_next[1] = '0;
       end
 
       default: begin


### PR DESCRIPTION
This PR connects prim_gate with register interface to eliminate linting errors

Signed-off-by: Tung Hoang <hoang.tung@wdc.com>