### PR TITLE
[dv/alert] add top level exclusions

### DIFF
--- a/hw/ip/alert_handler/data/alert_handler.hjson
+++ b/hw/ip/alert_handler/data/alert_handler.hjson
@@ -204,7 +204,10 @@
       hwaccess: "hrw",
       fields: [
         { bits: "0", name: "A", desc: "Cause bit " }
-      ]
+      ],
+      tags: [// The value of this register is determined by triggering different kinds of alerts
+             // Cannot be auto-predicted so excluded from read check
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
       }
     },
 # local alerts
@@ -346,7 +349,11 @@
           ''',
           resval: 1,
         }
-      ]
+      ],
+      tags: [// The value of this register is set to false only by hardware,
+             // under the condition that escalation is triggered and the corresponding lock bit is true
+             // Cannot not be auto-predicted so it is excluded from read check
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
     { name:     "CLASSA_CLR",
       desc:     '''
@@ -374,7 +381,10 @@
       hwext:    "true",
       fields: [
         { bits: "15:0" }
-      ]
+      ],
+      tags: [// The value of this register is determined by how many alerts have been triggered
+             // Cannot be auto-predicted so it is excluded from read check
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
     { name:     "CLASSA_ACCUM_THRESH",
       desc:     '''
@@ -486,7 +496,10 @@
           is set to false (either by SW or by HW via the !!CLASSA_CTRL.LOCK feature).
           '''
         }
-      ]
+      ],
+      tags: [// The value of this register is determined by counting how many cycles the escalation phase has lasted
+             // Cannot be auto-predicted so excluded from read check
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
     { name:     "CLASSA_STATE",
       desc:     '''
@@ -507,7 +520,10 @@
                   { value: "0b111", name: "Phase3",   desc: "Escalation Phase3 is active." }
                 ]
         }
-      ]
+      ],
+      tags: [// The current escalation state cannot be auto-predicted
+             // so this register is excluded from read check
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
 
     { name:     "CLASSB_CTRL",
@@ -590,7 +606,11 @@
           ''',
           resval: 1,
         }
-      ]
+      ],
+      tags: [// The value of this register is set to false only by hardware,
+             // under the condition that escalation is triggered and the corresponding lock bit is true
+             // Cannot not be auto-predicted so it is excluded from read check
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
     { name:     "CLASSB_CLR",
       desc:     '''
@@ -618,7 +638,10 @@
       hwext:    "true",
       fields: [
         { bits: "15:0" }
-      ]
+      ],
+      tags: [// The value of this register is determined by how many alerts have been triggered
+             // Cannot be auto-predicted so it is excluded from read check
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
     { name:     "CLASSB_ACCUM_THRESH",
       desc:     '''
@@ -730,7 +753,10 @@
           is set to false (either by SW or by HW via the !!CLASSB_CTRL.LOCK feature).
           '''
         }
-      ]
+      ],
+      tags: [// The value of this register is determined by counting how many cycles the escalation phase has lasted
+             // Cannot be auto-predicted so excluded from read check
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
     { name:     "CLASSB_STATE",
       desc:     '''
@@ -751,7 +777,10 @@
                   { value: "0b111", name: "Phase3",   desc: "Escalation Phase3 is active." }
                 ]
         }
-      ]
+      ],
+      tags: [// The current escalation state cannot be auto-predicted
+             // so this register is excluded from read check
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
 
     { name:     "CLASSC_CTRL",
@@ -834,7 +863,11 @@
           ''',
           resval: 1,
         }
-      ]
+      ],
+      tags: [// The value of this register is set to false only by hardware,
+             // under the condition that escalation is triggered and the corresponding lock bit is true
+             // Cannot not be auto-predicted so it is excluded from read check
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
     { name:     "CLASSC_CLR",
       desc:     '''
@@ -862,7 +895,10 @@
       hwext:    "true",
       fields: [
         { bits: "15:0" }
-      ]
+      ],
+      tags: [// The value of this register is determined by how many alerts have been triggered
+             // Cannot be auto-predicted so it is excluded from read check
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
     { name:     "CLASSC_ACCUM_THRESH",
       desc:     '''
@@ -974,7 +1010,10 @@
           is set to false (either by SW or by HW via the !!CLASSC_CTRL.LOCK feature).
           '''
         }
-      ]
+      ],
+      tags: [// The value of this register is determined by counting how many cycles the escalation phase has lasted
+             // Cannot be auto-predicted so excluded from read check
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
     { name:     "CLASSC_STATE",
       desc:     '''
@@ -995,7 +1034,10 @@
                   { value: "0b111", name: "Phase3",   desc: "Escalation Phase3 is active." }
                 ]
         }
-      ]
+      ],
+      tags: [// The current escalation state cannot be auto-predicted
+             // so this register is excluded from read check
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
 
     { name:     "CLASSD_CTRL",
@@ -1078,7 +1120,11 @@
           ''',
           resval: 1,
         }
-      ]
+      ],
+      tags: [// The value of this register is set to false only by hardware,
+             // under the condition that escalation is triggered and the corresponding lock bit is true
+             // Cannot not be auto-predicted so it is excluded from read check
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
     { name:     "CLASSD_CLR",
       desc:     '''
@@ -1106,7 +1152,10 @@
       hwext:    "true",
       fields: [
         { bits: "15:0" }
-      ]
+      ],
+      tags: [// The value of this register is determined by how many alerts have been triggered
+             // Cannot be auto-predicted so it is excluded from read check
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
     { name:     "CLASSD_ACCUM_THRESH",
       desc:     '''
@@ -1218,7 +1267,10 @@
           is set to false (either by SW or by HW via the !!CLASSD_CTRL.LOCK feature).
           '''
         }
-      ]
+      ],
+      tags: [// The value of this register is determined by counting how many cycles the escalation phase has lasted
+             // Cannot be auto-predicted so excluded from read check
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
     { name:     "CLASSD_STATE",
       desc:     '''
@@ -1239,7 +1291,10 @@
                   { value: "0b111", name: "Phase3",   desc: "Escalation Phase3 is active." }
                 ]
         }
-      ]
+      ],
+      tags: [// The current escalation state cannot be auto-predicted
+             // so this register is excluded from read check
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
   ],
 }

--- a/hw/ip/alert_handler/data/alert_handler.hjson.tpl
+++ b/hw/ip/alert_handler/data/alert_handler.hjson.tpl
@@ -198,8 +198,8 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
       fields: [
         { bits: "0", name: "A", desc: "Cause bit " }
       ],
-      tags: [// the value of this register is determined by triggering different kinds of alerts
-             // cannot be auto-predicted so excluded from read check
+      tags: [// The value of this register is determined by triggering different kinds of alerts
+             // Cannot be auto-predicted so excluded from read check
              "excl:CsrNonInitTests:CsrExclWriteCheck"]
       }
     },
@@ -344,7 +344,11 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
           ''',
           resval: 1,
         }
-      ]
+      ],
+      tags: [// The value of this register is set to false only by hardware,
+             // under the condition that escalation is triggered and the corresponding lock bit is true
+             // Cannot not be auto-predicted so it is excluded from read check
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
     { name:     "CLASS${chars[i]}_CLR",
       desc:     '''
@@ -373,8 +377,8 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
       fields: [
         { bits: "${accu_cnt_dw - 1}:0" }
       ],
-      tags: [// this value of this register is determined by how many alerts have been triggered
-             // could not be auto-predicted so it is excluded from read check
+      tags: [// The value of this register is determined by how many alerts have been triggered
+             // Cannot be auto-predicted so it is excluded from read check
              "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
     { name:     "CLASS${chars[i]}_ACCUM_THRESH",
@@ -448,8 +452,8 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
           '''
         }
       ],
-      tags: [// the value of this register is determined by counting how many cycles the escalation
-             // phase has lasted. This can not be auto-predicted so excluded from read check
+      tags: [// The value of this register is determined by counting how many cycles the escalation phase has lasted
+             // Cannot be auto-predicted so excluded from read check
              "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
     { name:     "CLASS${chars[i]}_STATE",
@@ -472,7 +476,7 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
                 ]
         }
       ],
-      tags: [// the current escalation state cannot be auto-predicted
+      tags: [// The current escalation state cannot be auto-predicted
              // so this register is excluded from read check
              "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },

--- a/hw/top_earlgrey/ip/alert_handler/data/autogen/alert_handler.hjson
+++ b/hw/top_earlgrey/ip/alert_handler/data/autogen/alert_handler.hjson
@@ -213,8 +213,8 @@
       fields: [
         { bits: "0", name: "A", desc: "Cause bit " }
       ],
-      tags: [// the value of this register is determined by triggering different kinds of alerts
-             // cannot be auto-predicted so excluded from read check
+      tags: [// The value of this register is determined by triggering different kinds of alerts
+             // Cannot be auto-predicted so excluded from read check
              "excl:CsrNonInitTests:CsrExclWriteCheck"]
       }
     },
@@ -357,7 +357,11 @@
           ''',
           resval: 1,
         }
-      ]
+      ],
+      tags: [// The value of this register is set to false only by hardware,
+             // under the condition that escalation is triggered and the corresponding lock bit is true
+             // Cannot not be auto-predicted so it is excluded from read check
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
     { name:     "CLASSA_CLR",
       desc:     '''
@@ -386,8 +390,8 @@
       fields: [
         { bits: "15:0" }
       ],
-      tags: [// this value of this register is determined by how many alerts have been triggered
-             // could not be auto-predicted so it is excluded from read check
+      tags: [// The value of this register is determined by how many alerts have been triggered
+             // Cannot be auto-predicted so it is excluded from read check
              "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
     { name:     "CLASSA_ACCUM_THRESH",
@@ -501,8 +505,8 @@
           '''
         }
       ],
-      tags: [// the value of this register is determined by counting how many cycles the escalation
-             // phase has lasted. This can not be auto-predicted so excluded from read check
+      tags: [// The value of this register is determined by counting how many cycles the escalation phase has lasted
+             // Cannot be auto-predicted so excluded from read check
              "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
     { name:     "CLASSA_STATE",
@@ -525,7 +529,7 @@
                 ]
         }
       ],
-      tags: [// the current escalation state cannot be auto-predicted
+      tags: [// The current escalation state cannot be auto-predicted
              // so this register is excluded from read check
              "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
@@ -610,7 +614,11 @@
           ''',
           resval: 1,
         }
-      ]
+      ],
+      tags: [// The value of this register is set to false only by hardware,
+             // under the condition that escalation is triggered and the corresponding lock bit is true
+             // Cannot not be auto-predicted so it is excluded from read check
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
     { name:     "CLASSB_CLR",
       desc:     '''
@@ -639,8 +647,8 @@
       fields: [
         { bits: "15:0" }
       ],
-      tags: [// this value of this register is determined by how many alerts have been triggered
-             // could not be auto-predicted so it is excluded from read check
+      tags: [// The value of this register is determined by how many alerts have been triggered
+             // Cannot be auto-predicted so it is excluded from read check
              "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
     { name:     "CLASSB_ACCUM_THRESH",
@@ -754,8 +762,8 @@
           '''
         }
       ],
-      tags: [// the value of this register is determined by counting how many cycles the escalation
-             // phase has lasted. This can not be auto-predicted so excluded from read check
+      tags: [// The value of this register is determined by counting how many cycles the escalation phase has lasted
+             // Cannot be auto-predicted so excluded from read check
              "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
     { name:     "CLASSB_STATE",
@@ -778,7 +786,7 @@
                 ]
         }
       ],
-      tags: [// the current escalation state cannot be auto-predicted
+      tags: [// The current escalation state cannot be auto-predicted
              // so this register is excluded from read check
              "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
@@ -863,7 +871,11 @@
           ''',
           resval: 1,
         }
-      ]
+      ],
+      tags: [// The value of this register is set to false only by hardware,
+             // under the condition that escalation is triggered and the corresponding lock bit is true
+             // Cannot not be auto-predicted so it is excluded from read check
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
     { name:     "CLASSC_CLR",
       desc:     '''
@@ -892,8 +904,8 @@
       fields: [
         { bits: "15:0" }
       ],
-      tags: [// this value of this register is determined by how many alerts have been triggered
-             // could not be auto-predicted so it is excluded from read check
+      tags: [// The value of this register is determined by how many alerts have been triggered
+             // Cannot be auto-predicted so it is excluded from read check
              "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
     { name:     "CLASSC_ACCUM_THRESH",
@@ -1007,8 +1019,8 @@
           '''
         }
       ],
-      tags: [// the value of this register is determined by counting how many cycles the escalation
-             // phase has lasted. This can not be auto-predicted so excluded from read check
+      tags: [// The value of this register is determined by counting how many cycles the escalation phase has lasted
+             // Cannot be auto-predicted so excluded from read check
              "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
     { name:     "CLASSC_STATE",
@@ -1031,7 +1043,7 @@
                 ]
         }
       ],
-      tags: [// the current escalation state cannot be auto-predicted
+      tags: [// The current escalation state cannot be auto-predicted
              // so this register is excluded from read check
              "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
@@ -1116,7 +1128,11 @@
           ''',
           resval: 1,
         }
-      ]
+      ],
+      tags: [// The value of this register is set to false only by hardware,
+             // under the condition that escalation is triggered and the corresponding lock bit is true
+             // Cannot not be auto-predicted so it is excluded from read check
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
     { name:     "CLASSD_CLR",
       desc:     '''
@@ -1145,8 +1161,8 @@
       fields: [
         { bits: "15:0" }
       ],
-      tags: [// this value of this register is determined by how many alerts have been triggered
-             // could not be auto-predicted so it is excluded from read check
+      tags: [// The value of this register is determined by how many alerts have been triggered
+             // Cannot be auto-predicted so it is excluded from read check
              "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
     { name:     "CLASSD_ACCUM_THRESH",
@@ -1260,8 +1276,8 @@
           '''
         }
       ],
-      tags: [// the value of this register is determined by counting how many cycles the escalation
-             // phase has lasted. This can not be auto-predicted so excluded from read check
+      tags: [// The value of this register is determined by counting how many cycles the escalation phase has lasted
+             // Cannot be auto-predicted so excluded from read check
              "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
     { name:     "CLASSD_STATE",
@@ -1284,7 +1300,7 @@
                 ]
         }
       ],
-      tags: [// the current escalation state cannot be auto-predicted
+      tags: [// The current escalation state cannot be auto-predicted
              // so this register is excluded from read check
              "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },


### PR DESCRIPTION
This PR adds one more exclusion to the alert_handler top level
automation test. It excludes `clren` which is reset to 0 by internal
hardware under the condition - escalation triggered and corresponded
lock bit is enabled.

Signed-off-by: Cindy Chen <chencindy@google.com>