### PR TITLE
[dv/top] Temp disable pinmux assertion

### DIFF
--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -214,6 +214,11 @@ module tb;
     uvm_config_db#(virtual sw_test_status_if)::set(
         null, "*.env", "sw_test_status_vif", sw_test_status_if);
 
+    // temp disable pinmux assertion AonWkupReqKnownO_A because driving X in spi_device.sdi and
+    // WkupPadSel choose IO_DPS1 in MIO will trigger this assertion
+    // TODO: remove this assertion once pinmux is templatized
+    $assertoff(0, dut.top_earlgrey.u_pinmux.AonWkupReqKnownO_A);
+
     $timeformat(-12, 0, " ps", 12);
     run_test();
   end


### PR DESCRIPTION
Pinmux has an assertion to ensure that `AonWkupReqKnownO` is not X.
However `spi_device.sdi_i` could be X if simply means no input data.
If `wkup_padsel` selects the SDI signal, which is connected to MIO input
`IO_DPS1` if `jtag_en=0`.
Since pinmux will be re-write soon, we are temp disable this assertion
in all the automation tests. It will be removed once the pinmux is
rewritten.

Signed-off-by: Cindy Chen <chencindy@google.com>