### PR TITLE
[flash_ctrl] - Add aribtration between hardware / software interfaces

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson
@@ -431,7 +431,6 @@
       desc: "Flash Controller Status",
       swaccess: "ro",
       hwaccess: "hwo",
-      hwext: "true",
       fields: [
         { bits: "0",    name: "rd_full",    desc: "Flash read FIFO full, software must consume data"},
         { bits: "1",    name: "rd_empty",   desc: "Flash read FIFO empty", resval: "1"},

--- a/hw/ip/flash_ctrl/flash_ctrl.core
+++ b/hw/ip/flash_ctrl/flash_ctrl.core
@@ -20,6 +20,7 @@ filesets:
       - rtl/flash_erase_ctrl.sv
       - rtl/flash_prog_ctrl.sv
       - rtl/flash_rd_ctrl.sv
+      - rtl/flash_ctrl_arb.sv
       - rtl/flash_mp.sv
       - rtl/flash_phy.sv
       - rtl/flash_phy_core.sv

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_arb.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_arb.sv
@@ -1,0 +1,212 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Flash Controllber Arbiter for read
+//
+
+`include "prim_assert.sv"
+
+// flash read and erase functionality is shared betewen the hardware (life cycle
+// and key manager) and software interfaces.
+//
+// This module arbitrates and muxes the controls between the two interfaces.
+
+module flash_ctrl_arb import flash_ctrl_pkg::*; (
+  input clk_i,
+  input rst_ni,
+
+  // software interface to rd_ctrl / erase_ctrl
+  input flash_ctrl_reg_pkg::flash_ctrl_reg2hw_control_reg_t sw_ctrl_i,
+  input [31:0] sw_addr_i,
+  output logic sw_ack_o,
+  output logic sw_err_o,
+
+  // software interface to rd_fifo
+  output logic sw_rvalid_o,
+  input sw_rready_i,
+
+  // software interface to prog_fifo
+  input sw_wvalid_i,
+  output logic sw_wready_o,
+
+  // hardware interface to rd_ctrl / erase_ctrl
+  input hw_req_i,
+  input flash_ctrl_reg_pkg::flash_ctrl_reg2hw_control_reg_t hw_ctrl_i,
+  input [31:0] hw_addr_i,
+  output logic hw_ack_o,
+  output logic hw_err_o,
+
+  // hardware interface to rd_fifo
+  output logic hw_rvalid_o,
+  input hw_rready_i,
+
+  // muxed interface to rd_ctrl / erase_ctrl
+  output flash_ctrl_reg_pkg::flash_ctrl_reg2hw_control_reg_t muxed_ctrl_o,
+  output logic [31:0] muxed_addr_o,
+  input prog_ack_i,
+  input prog_err_i,
+  input rd_ack_i,
+  input rd_err_i,
+  input erase_ack_i,
+  input erase_err_i,
+
+  // muxed interface to rd_fifo
+  input rd_fifo_rvalid_i,
+  output logic rd_fifo_rready_o,
+
+  // muxed interface to prog_fifo
+  output logic prog_fifo_wvalid_o,
+  input logic prog_fifo_wready_i,
+
+  // flash phy initilization ongoing
+  input logic flash_phy_busy_i,
+
+  // clear fifo contents
+  output logic fifo_clr_o,
+
+  // indication that sw has been selected
+  output logic sw_sel_o
+);
+
+  // arbitration FSM
+  typedef enum logic [1:0] {
+    StReset,  // at reset wait for flash phy to be ready
+    StHw,
+    StSwActive,
+    StSwIdle
+  } state_e;
+
+  flash_sel_e func_sel;
+  state_e state_q, state_d;
+
+  logic sw_req;
+  assign sw_req = sw_ctrl_i.start.q;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      state_q <= StReset;
+    end else begin
+      state_q <= state_d;
+    end
+  end
+
+  always_comb begin
+    func_sel = NoneSel;
+    fifo_clr_o = 1'b0;
+    state_d = state_q;
+
+    unique case (state_q)
+      StReset: begin
+        if (!flash_phy_busy_i) begin
+          // after flash is ready, the HW interface always takes
+          // precedence for flash controll initiliazation
+          state_d = StHw;
+        end
+      end
+
+      StHw: begin
+        func_sel = HwSel;
+
+        if (!hw_req_i) begin
+          state_d = StSwIdle;
+        end
+      end
+
+      StSwIdle: begin
+        // software is still selected to enable access to Fifos
+        func_sel = SwSel;
+
+        // if hardware request comes in the middle, wipe fifos and enable
+        // switch to hardware interface
+        if (hw_req_i) begin
+          fifo_clr_o = 1'b1;
+          state_d = StHw;
+        end else if (sw_req) begin
+          state_d = StSwActive;
+        end
+      end
+
+      StSwActive: begin
+        func_sel = SwSel;
+
+        // Stay in software active mode until operation completes.
+        // While operations are ongoing, the interface cannot be switched
+        if (prog_ack_i || rd_ack_i || erase_ack_i) begin
+          state_d = StSwIdle;
+        end
+      end
+
+      default:;
+    endcase // unique case (state_q)
+  end // always_comb
+
+  logic ctrl_ack, ctrl_err;
+
+  always_comb begin
+    muxed_ctrl_o = '0;
+    muxed_addr_o = '0;
+    sw_ack_o = 1'b0;
+    sw_err_o = 1'b0;
+    sw_rvalid_o = 1'b0;
+    sw_wready_o = 1'b0;
+    hw_ack_o = 1'b0;
+    hw_err_o = 1'b0;
+    hw_rvalid_o = 1'b0;
+
+    prog_fifo_wvalid_o = 1'b0;
+    rd_fifo_rready_o = 1'b0;
+    sw_sel_o = 1'b0;
+
+    unique case (func_sel)
+      HwSel: begin
+        // ctrl related muxing
+        muxed_ctrl_o = hw_ctrl_i;
+        muxed_addr_o = hw_addr_i;
+        hw_ack_o = ctrl_ack;
+        hw_err_o = ctrl_err;
+
+        // fifo related muxing
+        hw_rvalid_o = rd_fifo_rvalid_i;
+        rd_fifo_rready_o = hw_rready_i;
+      end
+
+      SwSel: begin
+        sw_sel_o = 1'b1;
+
+        // ctrl related muxing
+        muxed_ctrl_o = sw_ctrl_i;
+        muxed_addr_o = sw_addr_i;
+        sw_ack_o = ctrl_ack;
+        sw_err_o = ctrl_err;
+
+        // fifo related muxing
+        sw_rvalid_o = rd_fifo_rvalid_i;
+        sw_wready_o = prog_fifo_wready_i;
+        prog_fifo_wvalid_o = sw_wvalid_i;
+        rd_fifo_rready_o = sw_rready_i;
+      end
+
+      default:;
+    endcase // unique case (func_sel)
+  end
+
+  // pick appropriate feedback
+  always_comb begin
+    ctrl_ack = '0;
+    ctrl_err = '0;
+    if (muxed_ctrl_o.op.q == FlashOpProgram) begin
+      ctrl_ack = prog_ack_i;
+      ctrl_err = prog_err_i;
+    end else if (muxed_ctrl_o.op.q == FlashOpErase) begin
+      ctrl_ack = erase_ack_i;
+      ctrl_err = erase_err_i;
+    end else if (muxed_ctrl_o.op.q == FlashOpRead) begin
+      ctrl_ack = rd_ack_i;
+      ctrl_err = rd_err_i;
+    end
+  end
+
+
+
+endmodule // flash_ctrl_rd_arb

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
@@ -12,7 +12,7 @@ package flash_ctrl_pkg;
   parameter int NumBanks        = top_pkg::FLASH_BANKS;
   parameter int InfosPerBank    = top_pkg::FLASH_INFO_PER_BANK;  // Info pages per bank
   parameter int PagesPerBank    = top_pkg::FLASH_PAGES_PER_BANK; // Data pages per bank
-  parameter int WordsPerPage    = top_pkg::FLASH_WORDS_PER_PAGE; // Number of bus words per page
+  parameter int WordsPerPage    = top_pkg::FLASH_WORDS_PER_PAGE; // Number of flash words per page
   parameter int BusWidth        = top_pkg::TL_DW;
   parameter int MpRegions       = 8;  // flash controller protection regions
   parameter int FifoDepth       = 16; // rd / prog fifos
@@ -20,6 +20,7 @@ package flash_ctrl_pkg;
   // flash phy parameters
   parameter int DataByteWidth   = $clog2(DataWidth / 8);
   parameter int BankW           = $clog2(NumBanks);
+  parameter int InfoPageW       = $clog2(InfosPerBank);
   parameter int PageW           = $clog2(PagesPerBank);
   parameter int WordW           = $clog2(WordsPerPage);
   parameter int AddrW           = BankW + PageW + WordW; // all flash range
@@ -39,6 +40,18 @@ package flash_ctrl_pkg;
   // fifo parameters
   parameter int FifoDepthW      = $clog2(FifoDepth+1);
 
+  // flash life cycle / key manager management constants
+  // One page for creator seeds
+  // One page for owner seeds
+  parameter int NumSeeds = 2;
+  parameter int CreatorInfoPage = 2;
+  parameter int OwnerInfoPage = 2;
+  parameter logic [NumSeeds-1:0][InfoPageW-1:0] SeedInfoPageSel =
+    {
+      CreatorInfoPage,
+      OwnerInfoPage
+    };
+
   // Flash Operations Supported
   typedef enum logic [1:0] {
     FlashOpRead     = 2'h0,
@@ -54,6 +67,13 @@ package flash_ctrl_pkg;
   } flash_erase_e;
 
   parameter int EraseBitWidth = $bits(flash_erase_e);
+
+  // Flash function select
+  typedef enum logic [1:0] {
+    NoneSel,
+    SwSel,
+    HwSel
+  } flash_sel_e;
 
   // Flash tlul to fifo direction
   typedef enum logic  {

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
@@ -218,24 +218,31 @@ package flash_ctrl_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        d;
+      logic        de;
     } rd_full;
     struct packed {
       logic        d;
+      logic        de;
     } rd_empty;
     struct packed {
       logic        d;
+      logic        de;
     } prog_full;
     struct packed {
       logic        d;
+      logic        de;
     } prog_empty;
     struct packed {
       logic        d;
+      logic        de;
     } init_wip;
     struct packed {
       logic [8:0]  d;
+      logic        de;
     } error_page;
     struct packed {
       logic        d;
+      logic        de;
     } error_bank;
   } flash_ctrl_hw2reg_status_reg_t;
 
@@ -262,11 +269,11 @@ package flash_ctrl_reg_pkg;
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [33:28]
-    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [27:28]
-    flash_ctrl_hw2reg_control_reg_t control; // [27:11]
-    flash_ctrl_hw2reg_op_status_reg_t op_status; // [10:11]
-    flash_ctrl_hw2reg_status_reg_t status; // [10:11]
+    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [40:35]
+    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [34:35]
+    flash_ctrl_hw2reg_control_reg_t control; // [34:18]
+    flash_ctrl_hw2reg_op_status_reg_t op_status; // [17:18]
+    flash_ctrl_hw2reg_status_reg_t status; // [17:18]
   } flash_ctrl_hw2reg_t;
 
   // Register Address

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_top.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_top.sv
@@ -388,19 +388,12 @@ module flash_ctrl_reg_top (
   logic op_status_err_wd;
   logic op_status_err_we;
   logic status_rd_full_qs;
-  logic status_rd_full_re;
   logic status_rd_empty_qs;
-  logic status_rd_empty_re;
   logic status_prog_full_qs;
-  logic status_prog_full_re;
   logic status_prog_empty_qs;
-  logic status_prog_empty_re;
   logic status_init_wip_qs;
-  logic status_init_wip_re;
   logic [8:0] status_error_page_qs;
-  logic status_error_page_re;
   logic status_error_bank_qs;
-  logic status_error_bank_re;
   logic [31:0] scratch_qs;
   logic [31:0] scratch_wd;
   logic scratch_we;
@@ -2752,109 +2745,179 @@ module flash_ctrl_reg_top (
   );
 
 
-  // R[status]: V(True)
+  // R[status]: V(False)
 
   //   F[rd_full]: 0:0
-  prim_subreg_ext #(
-    .DW    (1)
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RO"),
+    .RESVAL  (1'h0)
   ) u_status_rd_full (
-    .re     (status_rd_full_re),
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
     .we     (1'b0),
-    .wd     ('0),
-    .d      (hw2reg.status.rd_full.d),
-    .qre    (),
+    .wd     ('0  ),
+
+    // from internal hardware
+    .de     (hw2reg.status.rd_full.de),
+    .d      (hw2reg.status.rd_full.d ),
+
+    // to internal hardware
     .qe     (),
     .q      (),
+
+    // to register interface (read)
     .qs     (status_rd_full_qs)
   );
 
 
   //   F[rd_empty]: 1:1
-  prim_subreg_ext #(
-    .DW    (1)
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RO"),
+    .RESVAL  (1'h1)
   ) u_status_rd_empty (
-    .re     (status_rd_empty_re),
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
     .we     (1'b0),
-    .wd     ('0),
-    .d      (hw2reg.status.rd_empty.d),
-    .qre    (),
+    .wd     ('0  ),
+
+    // from internal hardware
+    .de     (hw2reg.status.rd_empty.de),
+    .d      (hw2reg.status.rd_empty.d ),
+
+    // to internal hardware
     .qe     (),
     .q      (),
+
+    // to register interface (read)
     .qs     (status_rd_empty_qs)
   );
 
 
   //   F[prog_full]: 2:2
-  prim_subreg_ext #(
-    .DW    (1)
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RO"),
+    .RESVAL  (1'h0)
   ) u_status_prog_full (
-    .re     (status_prog_full_re),
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
     .we     (1'b0),
-    .wd     ('0),
-    .d      (hw2reg.status.prog_full.d),
-    .qre    (),
+    .wd     ('0  ),
+
+    // from internal hardware
+    .de     (hw2reg.status.prog_full.de),
+    .d      (hw2reg.status.prog_full.d ),
+
+    // to internal hardware
     .qe     (),
     .q      (),
+
+    // to register interface (read)
     .qs     (status_prog_full_qs)
   );
 
 
   //   F[prog_empty]: 3:3
-  prim_subreg_ext #(
-    .DW    (1)
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RO"),
+    .RESVAL  (1'h1)
   ) u_status_prog_empty (
-    .re     (status_prog_empty_re),
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
     .we     (1'b0),
-    .wd     ('0),
-    .d      (hw2reg.status.prog_empty.d),
-    .qre    (),
+    .wd     ('0  ),
+
+    // from internal hardware
+    .de     (hw2reg.status.prog_empty.de),
+    .d      (hw2reg.status.prog_empty.d ),
+
+    // to internal hardware
     .qe     (),
     .q      (),
+
+    // to register interface (read)
     .qs     (status_prog_empty_qs)
   );
 
 
   //   F[init_wip]: 4:4
-  prim_subreg_ext #(
-    .DW    (1)
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RO"),
+    .RESVAL  (1'h0)
   ) u_status_init_wip (
-    .re     (status_init_wip_re),
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
     .we     (1'b0),
-    .wd     ('0),
-    .d      (hw2reg.status.init_wip.d),
-    .qre    (),
+    .wd     ('0  ),
+
+    // from internal hardware
+    .de     (hw2reg.status.init_wip.de),
+    .d      (hw2reg.status.init_wip.d ),
+
+    // to internal hardware
     .qe     (),
     .q      (),
+
+    // to register interface (read)
     .qs     (status_init_wip_qs)
   );
 
 
   //   F[error_page]: 16:8
-  prim_subreg_ext #(
-    .DW    (9)
+  prim_subreg #(
+    .DW      (9),
+    .SWACCESS("RO"),
+    .RESVAL  (9'h0)
   ) u_status_error_page (
-    .re     (status_error_page_re),
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
     .we     (1'b0),
-    .wd     ('0),
-    .d      (hw2reg.status.error_page.d),
-    .qre    (),
+    .wd     ('0  ),
+
+    // from internal hardware
+    .de     (hw2reg.status.error_page.de),
+    .d      (hw2reg.status.error_page.d ),
+
+    // to internal hardware
     .qe     (),
     .q      (),
+
+    // to register interface (read)
     .qs     (status_error_page_qs)
   );
 
 
   //   F[error_bank]: 17:17
-  prim_subreg_ext #(
-    .DW    (1)
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RO"),
+    .RESVAL  (1'h0)
   ) u_status_error_bank (
-    .re     (status_error_bank_re),
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
     .we     (1'b0),
-    .wd     ('0),
-    .d      (hw2reg.status.error_bank.d),
-    .qre    (),
+    .wd     ('0  ),
+
+    // from internal hardware
+    .de     (hw2reg.status.error_bank.de),
+    .d      (hw2reg.status.error_bank.d ),
+
+    // to internal hardware
     .qe     (),
     .q      (),
+
+    // to register interface (read)
     .qs     (status_error_bank_qs)
   );
 
@@ -3301,19 +3364,12 @@ module flash_ctrl_reg_top (
   assign op_status_err_we = addr_hit[19] & reg_we & ~wr_err;
   assign op_status_err_wd = reg_wdata[1];
 
-  assign status_rd_full_re = addr_hit[20] && reg_re;
 
-  assign status_rd_empty_re = addr_hit[20] && reg_re;
 
-  assign status_prog_full_re = addr_hit[20] && reg_re;
 
-  assign status_prog_empty_re = addr_hit[20] && reg_re;
 
-  assign status_init_wip_re = addr_hit[20] && reg_re;
 
-  assign status_error_page_re = addr_hit[20] && reg_re;
 
-  assign status_error_bank_re = addr_hit[20] && reg_re;
 
   assign scratch_we = addr_hit[21] & reg_we & ~wr_err;
   assign scratch_wd = reg_wdata[31:0];


### PR DESCRIPTION
Initial refactoring to add support for life cycle / key manager type functions.

In the future, flash access is arbitrated between a software interface (regfile) and a hardware interface (module not yet added).
The hardware interface will read out keys and perform functions such as rma entry.