### PR TITLE
[lint/prim*] Waive STAR_PORT_CONN_USE errors in generated prims

### DIFF
--- a/hw/ip/prim/lint/prim_clock_buf.waiver
+++ b/hw/ip/prim/lint/prim_clock_buf.waiver
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_clock_buf
+
+waive -rules {STAR_PORT_CONN_USE} -location {prim_clock_buf.sv} -regexp {.*wild card port connection encountered on instance.*} \
+      -comment "Generated prims may have wildcard connections."

--- a/hw/ip/prim/lint/prim_clock_gating.waiver
+++ b/hw/ip/prim/lint/prim_clock_gating.waiver
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_clock_gating
+
+waive -rules {STAR_PORT_CONN_USE} -location {prim_clock_gating.sv} -regexp {.*wild card port connection encountered on instance.*} \
+      -comment "Generated prims may have wildcard connections."

--- a/hw/ip/prim/lint/prim_clock_inv.waiver
+++ b/hw/ip/prim/lint/prim_clock_inv.waiver
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_clock_inv
+
+waive -rules {STAR_PORT_CONN_USE} -location {prim_clock_inv.sv} -regexp {.*wild card port connection encountered on instance.*} \
+      -comment "Generated prims may have wildcard connections."

--- a/hw/ip/prim/lint/prim_clock_mux2.waiver
+++ b/hw/ip/prim/lint/prim_clock_mux2.waiver
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_clock_mux2
+
+waive -rules {STAR_PORT_CONN_USE} -location {prim_clock_mux2.sv} -regexp {.*wild card port connection encountered on instance.*} \
+      -comment "Generated prims may have wildcard connections."

--- a/hw/ip/prim/lint/prim_flash.waiver
+++ b/hw/ip/prim/lint/prim_flash.waiver
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_flash
+
+waive -rules {STAR_PORT_CONN_USE} -location {prim_flash.sv} -regexp {.*wild card port connection encountered on instance.*} \
+      -comment "Generated prims may have wildcard connections."

--- a/hw/ip/prim/lint/prim_flop.waiver
+++ b/hw/ip/prim/lint/prim_flop.waiver
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_flop
+
+waive -rules {STAR_PORT_CONN_USE} -location {prim_flop.sv} -regexp {.*wild card port connection encountered on instance.*} \
+      -comment "Generated prims may have wildcard connections."

--- a/hw/ip/prim/lint/prim_flop_2sync.waiver
+++ b/hw/ip/prim/lint/prim_flop_2sync.waiver
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_flop_2sync
+
+waive -rules {STAR_PORT_CONN_USE} -location {prim_flop_2sync.sv} -regexp {.*wild card port connection encountered on instance.*} \
+      -comment "Generated prims may have wildcard connections."

--- a/hw/ip/prim/lint/prim_otp.waiver
+++ b/hw/ip/prim/lint/prim_otp.waiver
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_otp
+
+waive -rules {STAR_PORT_CONN_USE} -location {prim_otp.sv} -regexp {.*wild card port connection encountered on instance.*} \
+      -comment "Generated prims may have wildcard connections."

--- a/hw/ip/prim/lint/prim_pad_wrapper.waiver
+++ b/hw/ip/prim/lint/prim_pad_wrapper.waiver
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_pad_wrapper
+
+waive -rules {STAR_PORT_CONN_USE} -location {prim_pad_wrapper.sv} -regexp {.*wild card port connection encountered on instance.*} \
+      -comment "Generated prims may have wildcard connections."

--- a/hw/ip/prim/lint/prim_ram_1p.waiver
+++ b/hw/ip/prim/lint/prim_ram_1p.waiver
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_ram_1p
+
+waive -rules {STAR_PORT_CONN_USE} -location {prim_ram_1p.sv} -regexp {.*wild card port connection encountered on instance.*} \
+      -comment "Generated prims may have wildcard connections."

--- a/hw/ip/prim/lint/prim_ram_2p.waiver
+++ b/hw/ip/prim/lint/prim_ram_2p.waiver
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_ram_2p
+
+waive -rules {STAR_PORT_CONN_USE} -location {prim_ram_2p.sv} -regexp {.*wild card port connection encountered on instance.*} \
+      -comment "Generated prims may have wildcard connections."

--- a/hw/ip/prim/lint/prim_rom.waiver
+++ b/hw/ip/prim/lint/prim_rom.waiver
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_rom
+
+waive -rules {STAR_PORT_CONN_USE} -location {prim_rom.sv} -regexp {.*wild card port connection encountered on instance.*} \
+      -comment "Generated prims may have wildcard connections."

--- a/hw/ip/prim/lint/prim_usb_diff_rx.waiver
+++ b/hw/ip/prim/lint/prim_usb_diff_rx.waiver
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_usb_diff_rx
+
+waive -rules {STAR_PORT_CONN_USE} -location {prim_usb_diff_rx.sv} -regexp {.*wild card port connection encountered on instance.*} \
+      -comment "Generated prims may have wildcard connections."

--- a/hw/ip/prim/prim_clock_buf.core
+++ b/hw/ip/prim/prim_clock_buf.core
@@ -11,6 +11,28 @@ filesets:
       - lowrisc:prim:prim_pkg
       - lowrisc:prim:primgen
 
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_clock_buf.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+
 generate:
   impl:
     generator: primgen
@@ -20,6 +42,9 @@ generate:
 targets:
   default:
     filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
       - primgen_dep
     generate:
       - impl

--- a/hw/ip/prim/prim_clock_gating.core
+++ b/hw/ip/prim/prim_clock_gating.core
@@ -11,6 +11,28 @@ filesets:
       - lowrisc:prim:prim_pkg
       - lowrisc:prim:primgen
 
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_clock_gating.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+
 generate:
   impl:
     generator: primgen
@@ -20,6 +42,9 @@ generate:
 targets:
   default:
     filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
       - primgen_dep
     generate:
       - impl

--- a/hw/ip/prim/prim_clock_inv.core
+++ b/hw/ip/prim/prim_clock_inv.core
@@ -11,6 +11,28 @@ filesets:
       - lowrisc:prim:prim_pkg
       - lowrisc:prim:primgen
 
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_clock_inv.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+
 generate:
   impl:
     generator: primgen
@@ -20,6 +42,9 @@ generate:
 targets:
   default:
     filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
       - primgen_dep
     generate:
       - impl

--- a/hw/ip/prim/prim_clock_mux2.core
+++ b/hw/ip/prim/prim_clock_mux2.core
@@ -11,6 +11,28 @@ filesets:
       - lowrisc:prim:prim_pkg
       - lowrisc:prim:primgen
 
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_clock_mux2.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+
 generate:
   impl:
     generator: primgen
@@ -20,6 +42,9 @@ generate:
 targets:
   default:
     filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
       - primgen_dep
     generate:
       - impl

--- a/hw/ip/prim/prim_flash.core
+++ b/hw/ip/prim/prim_flash.core
@@ -14,6 +14,28 @@ filesets:
       # However, the generator for the prim:ram1p does not kick in, causing compile errors.
       - lowrisc:prim:ram_1p
 
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_flash.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+
 generate:
   impl:
     generator: primgen
@@ -23,6 +45,9 @@ generate:
 targets:
   default:
     filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
       - primgen_dep
     generate:
       - impl

--- a/hw/ip/prim/prim_flop.core
+++ b/hw/ip/prim/prim_flop.core
@@ -11,6 +11,27 @@ filesets:
       - lowrisc:prim:prim_pkg
       - lowrisc:prim:primgen
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_flop.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+
 generate:
   impl:
     generator: primgen
@@ -20,6 +41,9 @@ generate:
 targets:
   default:
     filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
       - primgen_dep
     generate:
       - impl

--- a/hw/ip/prim/prim_flop_2sync.core
+++ b/hw/ip/prim/prim_flop_2sync.core
@@ -11,6 +11,28 @@ filesets:
       - lowrisc:prim:prim_pkg
       - lowrisc:prim:primgen
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_flop_2sync.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+
+
 generate:
   impl:
     generator: primgen
@@ -20,6 +42,10 @@ generate:
 targets:
   default:
     filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
       - primgen_dep
     generate:
       - impl
+

--- a/hw/ip/prim/prim_otp.core
+++ b/hw/ip/prim/prim_otp.core
@@ -11,6 +11,28 @@ filesets:
       - lowrisc:prim:prim_pkg
       - lowrisc:prim:primgen
 
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_otp.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+
 generate:
   impl:
     generator: primgen
@@ -20,6 +42,9 @@ generate:
 targets:
   default:
     filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
       - primgen_dep
     generate:
       - impl

--- a/hw/ip/prim/prim_pad_wrapper.core
+++ b/hw/ip/prim/prim_pad_wrapper.core
@@ -11,6 +11,28 @@ filesets:
       - lowrisc:prim:prim_pkg
       - lowrisc:prim:primgen
 
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_pad_wrapper.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+
 generate:
   impl:
     generator: primgen
@@ -20,6 +42,9 @@ generate:
 targets:
   default:
     filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
       - primgen_dep
     generate:
       - impl

--- a/hw/ip/prim/prim_ram_1p.core
+++ b/hw/ip/prim/prim_ram_1p.core
@@ -11,6 +11,28 @@ filesets:
       - lowrisc:prim:prim_pkg
       - lowrisc:prim:primgen
 
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_ram_1p.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+
 generate:
   impl:
     generator: primgen
@@ -20,6 +42,9 @@ generate:
 targets:
   default:
     filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
       - primgen_dep
     generate:
       - impl

--- a/hw/ip/prim/prim_ram_2p.core
+++ b/hw/ip/prim/prim_ram_2p.core
@@ -11,6 +11,28 @@ filesets:
       - lowrisc:prim:prim_pkg
       - lowrisc:prim:primgen
 
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_ram_2p.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+
 generate:
   impl:
     generator: primgen
@@ -20,6 +42,9 @@ generate:
 targets:
   default:
     filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
       - primgen_dep
     generate:
       - impl

--- a/hw/ip/prim/prim_rom.core
+++ b/hw/ip/prim/prim_rom.core
@@ -11,6 +11,28 @@ filesets:
       - lowrisc:prim:prim_pkg
       - lowrisc:prim:primgen
 
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_rom.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+
 generate:
   impl:
     generator: primgen
@@ -20,6 +42,9 @@ generate:
 targets:
   default:
     filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
       - primgen_dep
     generate:
       - impl

--- a/hw/ip/prim/prim_usb_diff_rx.core
+++ b/hw/ip/prim/prim_usb_diff_rx.core
@@ -11,6 +11,28 @@ filesets:
       - lowrisc:prim:prim_pkg
       - lowrisc:prim:primgen
 
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_usb_diff_rx.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+
 generate:
   impl:
     generator: primgen
@@ -20,6 +42,9 @@ generate:
 targets:
   default:
     filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
       - primgen_dep
     generate:
       - impl


### PR DESCRIPTION
This came up while fixing lint errors in https://github.com/lowRISC/opentitan/pull/3127.

Signed-off-by: Michael Schaffner <msf@google.com>