### PR TITLE
[prim_usb_diff_rx] Carry over wrapper for USB diff receiver

### DIFF
--- a/hw/ip/prim/lint/prim_usb_diff_rx.waiver
+++ b/hw/ip/prim/lint/prim_usb_diff_rx.waiver
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_usb_diff_rx
+
+waive -rules {STAR_PORT_CONN_USE} -location {prim_usb_diff_rx.sv} -regexp {.*wild card port connection encountered on instance.*} \
+      -comment "Generated prims may have wildcard connections."

--- a/hw/ip/prim/prim_usb_diff_rx.core
+++ b/hw/ip/prim/prim_usb_diff_rx.core
@@ -1,0 +1,50 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:usb_diff_rx"
+description: "Differential receiver for USB."
+filesets:
+  primgen_dep:
+    depend:
+      - lowrisc:prim:prim_pkg
+      - lowrisc:prim:primgen
+
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_usb_diff_rx.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+
+generate:
+  impl:
+    generator: primgen
+    parameters:
+      prim_name: usb_diff_rx
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - primgen_dep
+    generate:
+      - impl

--- a/hw/ip/prim_generic/prim_generic_usb_diff_rx.core
+++ b/hw/ip/prim_generic/prim_generic_usb_diff_rx.core
@@ -1,0 +1,42 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim_generic:usb_diff_rx"
+description: "Generic differential USB receiver for emulation purposes"
+filesets:
+  files_rtl:
+    files:
+      - rtl/prim_generic_usb_diff_rx.sv
+    file_type: systemVerilogSource
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      #- lint/prim_generic_usb_diff_rx.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      #- lint/prim_generic_usb_diff_rx.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl

--- a/hw/ip/prim_generic/rtl/prim_generic_usb_diff_rx.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_usb_diff_rx.sv
@@ -1,0 +1,32 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Generic differential receiver for USB. Note that this is meant for emulation purposes only, and
+// the pull-up, calibration and pok signals are not connected in this module.
+
+`include "prim_assert.sv"
+
+module prim_generic_usb_diff_rx #(
+  parameter int CalibW = 32
+) (
+  input wire         input_pi,      // differential input
+  input wire         input_ni,      // differential input
+  input              input_en_i,    // input buffer enable
+  input              core_pok_i,    // core power indication at VCC level
+  input              pullup_p_en_i, // pullup enable for P
+  input              pullup_n_en_i, // pullup enable for N
+  input [CalibW-1:0] calibration_i, // calibration input
+  output logic       input_o        // output of differential input buffer
+);
+
+  assign input_o = (input_en_i) ? input_pi & ~input_ni : 1'b0;
+
+  logic unused_pullup_p_en, unused_pullup_n_en;
+  logic [CalibW-1:0] unused_calibration;
+
+  assign unused_calibration = calibration_i;
+  assign unused_pullup_p_en = pullup_p_en_i;
+  assign unused_pullup_n_en = pullup_n_en_i;
+
+endmodule : prim_generic_usb_diff_rx


### PR DESCRIPTION
This carries over the wrapper primitive for the USB differential receiver from Bronze.

The generic version is a very basic implementation that does not support pullups for instance.

We have however an internal version that wraps the actual technology primitive.

Signed-off-by: Michael Schaffner <msf@google.com>