### PR TITLE
[lint/prim*] Waiver updates

### DIFF
--- a/hw/ip/prim/lint/prim_clock_buf.waiver
+++ b/hw/ip/prim/lint/prim_clock_buf.waiver
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_clock_buf
+
+waive -rules {STAR_PORT_CONN_USE} -location {prim_clock_buf.sv} -regexp {.*wild card port connection encountered on instance.*} \
+      -comment "Generated prims may have wildcard connections."

--- a/hw/ip/prim/lint/prim_clock_gating.waiver
+++ b/hw/ip/prim/lint/prim_clock_gating.waiver
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_clock_gating
+
+waive -rules {STAR_PORT_CONN_USE} -location {prim_clock_gating.sv} -regexp {.*wild card port connection encountered on instance.*} \
+      -comment "Generated prims may have wildcard connections."

--- a/hw/ip/prim/lint/prim_clock_inv.waiver
+++ b/hw/ip/prim/lint/prim_clock_inv.waiver
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_clock_inv
+
+waive -rules {STAR_PORT_CONN_USE} -location {prim_clock_inv.sv} -regexp {.*wild card port connection encountered on instance.*} \
+      -comment "Generated prims may have wildcard connections."

--- a/hw/ip/prim/lint/prim_clock_mux2.waiver
+++ b/hw/ip/prim/lint/prim_clock_mux2.waiver
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_clock_mux2
+
+waive -rules {STAR_PORT_CONN_USE} -location {prim_clock_mux2.sv} -regexp {.*wild card port connection encountered on instance.*} \
+      -comment "Generated prims may have wildcard connections."

--- a/hw/ip/prim/lint/prim_flash.waiver
+++ b/hw/ip/prim/lint/prim_flash.waiver
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_flash
+
+waive -rules {STAR_PORT_CONN_USE} -location {prim_flash.sv} -regexp {.*wild card port connection encountered on instance.*} \
+      -comment "Generated prims may have wildcard connections."

--- a/hw/ip/prim/lint/prim_flop.waiver
+++ b/hw/ip/prim/lint/prim_flop.waiver
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_flop
+
+waive -rules {STAR_PORT_CONN_USE} -location {prim_flop.sv} -regexp {.*wild card port connection encountered on instance.*} \
+      -comment "Generated prims may have wildcard connections."

--- a/hw/ip/prim/lint/prim_flop_2sync.waiver
+++ b/hw/ip/prim/lint/prim_flop_2sync.waiver
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_flop_2sync
+
+waive -rules {STAR_PORT_CONN_USE} -location {prim_flop_2sync.sv} -regexp {.*wild card port connection encountered on instance.*} \
+      -comment "Generated prims may have wildcard connections."

--- a/hw/ip/prim/lint/prim_otp.waiver
+++ b/hw/ip/prim/lint/prim_otp.waiver
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_otp
+
+waive -rules {STAR_PORT_CONN_USE} -location {prim_otp.sv} -regexp {.*wild card port connection encountered on instance.*} \
+      -comment "Generated prims may have wildcard connections."

--- a/hw/ip/prim/lint/prim_pad_wrapper.waiver
+++ b/hw/ip/prim/lint/prim_pad_wrapper.waiver
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_pad_wrapper
+
+waive -rules {STAR_PORT_CONN_USE} -location {prim_pad_wrapper.sv} -regexp {.*wild card port connection encountered on instance.*} \
+      -comment "Generated prims may have wildcard connections."

--- a/hw/ip/prim/lint/prim_ram_1p.waiver
+++ b/hw/ip/prim/lint/prim_ram_1p.waiver
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_ram_1p
+
+waive -rules {STAR_PORT_CONN_USE} -location {prim_ram_1p.sv} -regexp {.*wild card port connection encountered on instance.*} \
+      -comment "Generated prims may have wildcard connections."

--- a/hw/ip/prim/lint/prim_ram_2p.waiver
+++ b/hw/ip/prim/lint/prim_ram_2p.waiver
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_ram_2p
+
+waive -rules {STAR_PORT_CONN_USE} -location {prim_ram_2p.sv} -regexp {.*wild card port connection encountered on instance.*} \
+      -comment "Generated prims may have wildcard connections."

--- a/hw/ip/prim/lint/prim_rom.waiver
+++ b/hw/ip/prim/lint/prim_rom.waiver
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_rom
+
+waive -rules {STAR_PORT_CONN_USE} -location {prim_rom.sv} -regexp {.*wild card port connection encountered on instance.*} \
+      -comment "Generated prims may have wildcard connections."

--- a/hw/ip/prim/lint/prim_usb_diff_rx.waiver
+++ b/hw/ip/prim/lint/prim_usb_diff_rx.waiver
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_usb_diff_rx
+
+waive -rules {STAR_PORT_CONN_USE} -location {prim_usb_diff_rx.sv} -regexp {.*wild card port connection encountered on instance.*} \
+      -comment "Generated prims may have wildcard connections."

--- a/hw/ip/prim/prim_clock_buf.core
+++ b/hw/ip/prim/prim_clock_buf.core
@@ -11,6 +11,28 @@ filesets:
       - lowrisc:prim:prim_pkg
       - lowrisc:prim:primgen
 
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_clock_buf.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+
 generate:
   impl:
     generator: primgen
@@ -20,6 +42,9 @@ generate:
 targets:
   default:
     filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
       - primgen_dep
     generate:
       - impl

--- a/hw/ip/prim/prim_clock_gating.core
+++ b/hw/ip/prim/prim_clock_gating.core
@@ -11,6 +11,28 @@ filesets:
       - lowrisc:prim:prim_pkg
       - lowrisc:prim:primgen
 
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_clock_gating.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+
 generate:
   impl:
     generator: primgen
@@ -20,6 +42,9 @@ generate:
 targets:
   default:
     filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
       - primgen_dep
     generate:
       - impl

--- a/hw/ip/prim/prim_clock_inv.core
+++ b/hw/ip/prim/prim_clock_inv.core
@@ -11,6 +11,28 @@ filesets:
       - lowrisc:prim:prim_pkg
       - lowrisc:prim:primgen
 
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_clock_inv.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+
 generate:
   impl:
     generator: primgen
@@ -20,6 +42,9 @@ generate:
 targets:
   default:
     filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
       - primgen_dep
     generate:
       - impl

--- a/hw/ip/prim/prim_clock_mux2.core
+++ b/hw/ip/prim/prim_clock_mux2.core
@@ -11,6 +11,28 @@ filesets:
       - lowrisc:prim:prim_pkg
       - lowrisc:prim:primgen
 
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_clock_mux2.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+
 generate:
   impl:
     generator: primgen
@@ -20,6 +42,9 @@ generate:
 targets:
   default:
     filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
       - primgen_dep
     generate:
       - impl

--- a/hw/ip/prim/prim_flash.core
+++ b/hw/ip/prim/prim_flash.core
@@ -14,6 +14,28 @@ filesets:
       # However, the generator for the prim:ram1p does not kick in, causing compile errors.
       - lowrisc:prim:ram_1p
 
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_flash.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+
 generate:
   impl:
     generator: primgen
@@ -23,6 +45,9 @@ generate:
 targets:
   default:
     filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
       - primgen_dep
     generate:
       - impl

--- a/hw/ip/prim/prim_flop.core
+++ b/hw/ip/prim/prim_flop.core
@@ -11,6 +11,27 @@ filesets:
       - lowrisc:prim:prim_pkg
       - lowrisc:prim:primgen
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_flop.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+
 generate:
   impl:
     generator: primgen
@@ -20,6 +41,9 @@ generate:
 targets:
   default:
     filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
       - primgen_dep
     generate:
       - impl

--- a/hw/ip/prim/prim_flop_2sync.core
+++ b/hw/ip/prim/prim_flop_2sync.core
@@ -11,6 +11,28 @@ filesets:
       - lowrisc:prim:prim_pkg
       - lowrisc:prim:primgen
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_flop_2sync.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+
+
 generate:
   impl:
     generator: primgen
@@ -20,6 +42,10 @@ generate:
 targets:
   default:
     filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
       - primgen_dep
     generate:
       - impl
+

--- a/hw/ip/prim/prim_otp.core
+++ b/hw/ip/prim/prim_otp.core
@@ -11,6 +11,28 @@ filesets:
       - lowrisc:prim:prim_pkg
       - lowrisc:prim:primgen
 
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_otp.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+
 generate:
   impl:
     generator: primgen
@@ -20,6 +42,9 @@ generate:
 targets:
   default:
     filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
       - primgen_dep
     generate:
       - impl

--- a/hw/ip/prim/prim_pad_wrapper.core
+++ b/hw/ip/prim/prim_pad_wrapper.core
@@ -11,6 +11,28 @@ filesets:
       - lowrisc:prim:prim_pkg
       - lowrisc:prim:primgen
 
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_pad_wrapper.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+
 generate:
   impl:
     generator: primgen
@@ -20,6 +42,9 @@ generate:
 targets:
   default:
     filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
       - primgen_dep
     generate:
       - impl

--- a/hw/ip/prim/prim_ram_1p.core
+++ b/hw/ip/prim/prim_ram_1p.core
@@ -11,6 +11,28 @@ filesets:
       - lowrisc:prim:prim_pkg
       - lowrisc:prim:primgen
 
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_ram_1p.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+
 generate:
   impl:
     generator: primgen
@@ -20,6 +42,9 @@ generate:
 targets:
   default:
     filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
       - primgen_dep
     generate:
       - impl

--- a/hw/ip/prim/prim_ram_2p.core
+++ b/hw/ip/prim/prim_ram_2p.core
@@ -11,6 +11,28 @@ filesets:
       - lowrisc:prim:prim_pkg
       - lowrisc:prim:primgen
 
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_ram_2p.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+
 generate:
   impl:
     generator: primgen
@@ -20,6 +42,9 @@ generate:
 targets:
   default:
     filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
       - primgen_dep
     generate:
       - impl

--- a/hw/ip/prim/prim_rom.core
+++ b/hw/ip/prim/prim_rom.core
@@ -11,6 +11,28 @@ filesets:
       - lowrisc:prim:prim_pkg
       - lowrisc:prim:primgen
 
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_rom.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+
 generate:
   impl:
     generator: primgen
@@ -20,6 +42,9 @@ generate:
 targets:
   default:
     filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
       - primgen_dep
     generate:
       - impl

--- a/hw/ip/prim/prim_usb_diff_rx.core
+++ b/hw/ip/prim/prim_usb_diff_rx.core
@@ -1,0 +1,50 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:usb_diff_rx"
+description: "Differential receiver for USB."
+filesets:
+  primgen_dep:
+    depend:
+      - lowrisc:prim:prim_pkg
+      - lowrisc:prim:primgen
+
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_usb_diff_rx.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+
+generate:
+  impl:
+    generator: primgen
+    parameters:
+      prim_name: usb_diff_rx
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - primgen_dep
+    generate:
+      - impl

--- a/hw/ip/prim_generic/prim_generic_usb_diff_rx.core
+++ b/hw/ip/prim_generic/prim_generic_usb_diff_rx.core
@@ -1,0 +1,42 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim_generic:usb_diff_rx"
+description: "Generic differential USB receiver for emulation purposes"
+filesets:
+  files_rtl:
+    files:
+      - rtl/prim_generic_usb_diff_rx.sv
+    file_type: systemVerilogSource
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      #- lint/prim_generic_usb_diff_rx.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      #- lint/prim_generic_usb_diff_rx.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl

--- a/hw/ip/prim_generic/rtl/prim_generic_usb_diff_rx.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_usb_diff_rx.sv
@@ -1,0 +1,32 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Generic differential receiver for USB. Note that this is meant for emulation purposes only, and
+// the pull-up, calibration and pok signals are not connected in this module.
+
+`include "prim_assert.sv"
+
+module prim_generic_usb_diff_rx #(
+  parameter int CalibW = 32
+) (
+  input wire         input_pi,      // differential input
+  input wire         input_ni,      // differential input
+  input              input_en_i,    // input buffer enable
+  input              core_pok_i,    // core power indication at VCC level
+  input              pullup_p_en_i, // pullup enable for P
+  input              pullup_n_en_i, // pullup enable for N
+  input [CalibW-1:0] calibration_i, // calibration input
+  output logic       input_o        // output of differential input buffer
+);
+
+  assign input_o = (input_en_i) ? input_pi & ~input_ni : 1'b0;
+
+  logic unused_pullup_p_en, unused_pullup_n_en;
+  logic [CalibW-1:0] unused_calibration;
+
+  assign unused_calibration = calibration_i;
+  assign unused_pullup_p_en = pullup_p_en_i;
+  assign unused_pullup_n_en = pullup_n_en_i;
+
+endmodule : prim_generic_usb_diff_rx


### PR DESCRIPTION
This mirrors the waiver update for generated prims on Bronze: #3159
Note that this is dependent on #3160, which will make the first commit go away.