### PR TITLE
[otbn] Support TOOLCHAIN_PATH in otbn-as, otbn-ld and otbn-objdump

### DIFF
--- a/hw/ip/otbn/util/otbn-as
+++ b/hw/ip/otbn/util/otbn-as
@@ -28,6 +28,7 @@ from shared.bit_ranges import BitRanges
 from shared.encoding import Encoding
 from shared.insn_yaml import Insn, InsnsFile, load_file
 from shared.operand import ImmOperandType, RegOperandType, Operand
+from shared.toolchain import find_tool
 
 
 class RVFmt:
@@ -760,7 +761,7 @@ class Transformer:
         # A custom instruction. We have two possible approaches.
         #
         #  1. Generate a .insn line. This is fine if the encoding happens to
-        #     map on to one of the encodings that riscv-unknown-elf-as
+        #     map on to one of the encodings that riscv32-unknown-elf-as
         #     supports, but won't work otherwise.
         #
         #  2. Just generate the bits by hand. This is fine if we can resolve
@@ -1113,20 +1114,19 @@ def run_binutils_as(other_args: List[str], inputs: List[str]) -> int:
     Performs no output redirection and returns the process's exit code.
 
     '''
-    assembler_name = 'riscv32-unknown-elf-as'
+    as_name = find_tool('as')
 
     # Don't ask the linker to do relaxation because, in some cases, this might
     # generate a GP-relative load. OTBN doesn't treat x3 (gp) specially, so
     # this won't work.
     default_args = ['-mno-relax']
 
-    cmd = [assembler_name] + default_args + other_args + inputs
+    cmd = [as_name] + default_args + other_args + inputs
     try:
         return subprocess.run(cmd).returncode
     except FileNotFoundError:
-        sys.stderr.write('Unknown command: {!r}. '
-                         '(is it installed and on your PATH?)\n'
-                         .format(assembler_name))
+        sys.stderr.write('Unknown command: {!r}.\n'
+                         .format(as_name))
         return 127
 
 

--- a/hw/ip/otbn/util/otbn-ld
+++ b/hw/ip/otbn/util/otbn-ld
@@ -19,6 +19,7 @@ from mako.template import Template  # type: ignore
 from mako import exceptions  # type: ignore
 
 from shared.mem_layout import get_memory_layout
+from shared.toolchain import find_tool
 
 
 def interpolate_linker_script(in_path: str, out_path: str) -> None:
@@ -61,7 +62,7 @@ def mk_linker_script() -> Iterator[str]:
 
 def run_ld(ld_script: Optional[str], args: List[str]) -> int:
     '''Run the underlying linker and return the status code'''
-    ld_name = 'riscv32-unknown-elf-ld'
+    ld_name = find_tool('ld')
     cmd = [ld_name]
     if ld_script is not None:
         cmd.append('--script={}'.format(ld_script))

--- a/hw/ip/otbn/util/otbn-objdump
+++ b/hw/ip/otbn/util/otbn-objdump
@@ -13,6 +13,7 @@ from typing import Dict, List, Optional, Tuple
 
 from shared.encoding import Encoding
 from shared.insn_yaml import Insn, InsnsFile, load_file
+from shared.toolchain import find_tool
 
 
 def snoop_disasm_flags(argv: List[str]) -> bool:
@@ -135,8 +136,8 @@ def main() -> int:
     args = sys.argv[1:]
     has_disasm = snoop_disasm_flags(args)
 
-    objdump_name = 'riscv32-unknown-elf-objdump'
-    cmd = [objdump_name] + args
+    objdump = find_tool('objdump')
+    cmd = [objdump] + args
     try:
         if not has_disasm:
             return subprocess.run(cmd).returncode
@@ -147,9 +148,8 @@ def main() -> int:
                 sys.stdout.write(proc.stdout)
                 return proc.returncode
     except FileNotFoundError:
-        sys.stderr.write('Unknown command: {!r}. '
-                         '(is it installed and on your PATH?)\n'
-                         .format(objdump_name))
+        sys.stderr.write('Unknown command: {!r}.\n'
+                         .format(objdump))
         return 127
 
     insns_yml = os.path.normpath(os.path.join(os.path.dirname(__file__),

--- a/hw/ip/otbn/util/shared/toolchain.py
+++ b/hw/ip/otbn/util/shared/toolchain.py
@@ -1,0 +1,32 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+
+def find_tool(tool_name: str) -> str:
+    '''Return a string describing how to invoke the given RISC-V tool
+
+    If TOOLCHAIN_PATH is not set, we resolve FOO to riscv32-unknown-elf-FOO
+    (which will be searched for on $PATH). If it is set, we resolve foo to
+    $TOOLCHAIN_PATH/bin/riscv32-unknown-elf-FOO.
+
+    In the latter case, we also do a sanity check that the file exists. This
+    allows us to print a more helpful error if it doesn't (saying we were
+    looking at TOOLCHAIN_PATH).
+
+    '''
+    expanded = 'riscv32-unknown-elf-' + tool_name
+    toolchain_path = os.environ.get('TOOLCHAIN_PATH')
+    if toolchain_path is None:
+        return expanded
+
+    tool_path = os.path.join(toolchain_path, 'bin', expanded)
+    if not os.path.exists(tool_path):
+        raise RuntimeError('No such file: {!r} (derived from the '
+                           'TOOLCHAIN_PATH environment variable when trying '
+                           'to find the {!r} tool).'
+                           .format(tool_path, tool_name))
+
+    return tool_path


### PR DESCRIPTION
This means we behave the same as the rest of the software toolchain (I think), picking tools from `$TOOLCHAIN_PATH/bin` if defined and looking on `$PATH` otherwise.