### PR TITLE
[CI] Require Verilator 4.040

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@
 # Documentation at https://aka.ms/yaml
 
 variables:
-  VERILATOR_VERSION: 4.028
+  VERILATOR_VERSION: 4.040
   VERILATOR_PATH: /opt/buildcache/verilator/$(VERILATOR_VERSION)
   TOOLCHAIN_PATH: /opt/buildcache/riscv
   VERIBLE_VERSION: v0.0-520-g650c6cc

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -347,10 +347,14 @@ jobs:
       mkdir -p "$BIN_DIR/hw/top_earlgrey"
 
       export PATH="$VERILATOR_PATH/bin:$PATH"
+      # Compile the simulation without threading; the runners provided by
+      # Azure provide two virtual CPUs, which seems to equal one physical
+      # CPU (at most); the use of threading slows down the simulation.
       fusesoc --cores-root=. \
         run --flag=fileset_top --target=sim --setup --build \
         --build-root="$OBJ_DIR/hw" \
-        lowrisc:systems:top_earlgrey_verilator
+        lowrisc:systems:top_earlgrey_verilator \
+        --verilator_options="--no-threads"
 
       cp "$OBJ_DIR/hw/sim-verilator/Vtop_earlgrey_verilator" \
         "$BIN_DIR/hw/top_earlgrey"

--- a/hw/top_earlgrey/top_earlgrey_verilator.core
+++ b/hw/top_earlgrey/top_earlgrey_verilator.core
@@ -81,7 +81,7 @@ targets:
           # huge influence on runtime performance.
           - '--trace'
           - '--trace-fst' # this requires -DVM_TRACE_FMT_FST in CFLAGS below!
-          # Remove FST options for VCD trace (~100 x faster but larger files)
+          # Remove FST options for VCD trace
           - '--trace-structs'
           - '--trace-params'
           - '--trace-max-array 1024'
@@ -91,11 +91,6 @@ targets:
           # XXX: Cleanup all warnings and remove this option
           # (or make it more fine-grained at least)
           - "-Wno-fatal"
-        make_options:
-          # Optimization levels have a large impact on the runtime performance
-          # of the simulation model. -O2 and -O3 are pretty similar, -Os is
-          # slower than -O2/-O3
-          - OPT_FAST="-O2"
 
   lint:
     <<: *default_target

--- a/hw/top_earlgrey/top_earlgrey_verilator.core
+++ b/hw/top_earlgrey/top_earlgrey_verilator.core
@@ -87,10 +87,16 @@ targets:
           - '--trace-max-array 1024'
           - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=top_earlgrey_verilator -g"'
           - '-LDFLAGS "-pthread -lutil -lelf"'
-          - "-Wall"
+          - '-Wall'
+          # Execute simulation with four threads by default, which works best
+          # with four physical CPU cores.
+          # Users can override this setting by appending e.g.
+          # --verilator_options '--threads 2'
+          # to the end of the fusesoc invocation when compiling the simulation.
+          - '--threads 4'
           # XXX: Cleanup all warnings and remove this option
           # (or make it more fine-grained at least)
-          - "-Wno-fatal"
+          - '-Wno-fatal'
 
   lint:
     <<: *default_target

--- a/tool_requirements.py
+++ b/tool_requirements.py
@@ -5,7 +5,7 @@
 # Version requirements for various tools. Checked by tooling (e.g. fusesoc),
 # and inserted into the documentation.
 __TOOL_REQUIREMENTS__ = {
-    'verilator': '4.028',
+    'verilator': '4.040',
     'edalize': '0.2.0',
     'verible': '0.0-520-g650c6cc',
 }


### PR DESCRIPTION
With this PR building Verilator simulations will require at least Verilator 4.040.


Verilator has seen significant performance improvements over the last releases, both in compile time and in runtime performance. In my experiments on a laptop with four physical cores (Core i7, 8th generation), the compile time is reduced by roughly 45 percent, while the simulation of OpenTitan's top_earlgrey runs 3.5x faster.

As if that wasn't enough, the most significant change is seen when waveform (FST) tracing is enabled: previously, the simulation slowed down by roughly 300x, making it barely usable for larger software runs. After merging the PR, a simulation with full waveform dumping enabled is only 15x slower than one without waveform tracing.

Or on other words, on my system, a top_earlgrey simulation without tracing runs at roughly 52 kHz, and with signal tracing I get 3.4 kHz simulation performance.

In CI, we unfortunately don't see the same speed-ups, as the machines provided only provide roughly one physical CPU core, and we already parallelize some test jobs in different ways.


Updating Verilator isn't too hard: you can either compile it from source (which is rather painless in our experience), or use a packaged version. If your distribution doesn't provide one yet, you can use my versioned Verilator builds from https://software.opensuse.org//download.html?project=home%3Aphiwag%3Aedatools&package=verilator-4.040 for a variety of Linux distributions, including CentOS/RHEL 6/7/8 and Ubuntu LTS versions.