### PR TITLE
[dv/alert] support async alert

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent.sv
@@ -58,7 +58,16 @@ class alert_esc_agent extends dv_base_agent#(
         `uvm_fatal(`gfn, "failed to get probe_vif handle from uvm_config_db")
       end
     end
-
+    // set async alert clock frequency
+    if (cfg.is_alert && cfg.is_async) begin
+      cfg.vif.clk_rst_async_if.set_active(.drive_rst_n_val(0));
+      if (cfg.clk_freq_mhz > 0) begin
+        int min_freq_mhz = (cfg.clk_freq_mhz / 10) ? (cfg.clk_freq_mhz / 10) : 1;
+        cfg.vif.clk_rst_async_if.set_freq_mhz($urandom_range(min_freq_mhz, cfg.clk_freq_mhz * 10));
+      end else begin
+        cfg.vif.clk_rst_async_if.set_freq_mhz($urandom_range(1, 200));
+      end
+    end
   endfunction
 
 endclass : alert_esc_agent

--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent_cfg.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent_cfg.sv
@@ -11,6 +11,8 @@ class alert_esc_agent_cfg extends dv_base_agent_cfg;
   virtual alert_esc_probe_if probe_vif;
   bit is_alert = 1;
   bit is_async = 0;
+  // dut clk frequency, used to generate alert async_clk frequency
+  int clk_freq_mhz;
 
   // sender mode
   bit use_seq_item_alert_delay;

--- a/hw/dv/sv/alert_esc_agent/alert_esc_if.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_if.sv
@@ -10,6 +10,10 @@ interface alert_esc_if(input clk, input rst_n);
   wire prim_alert_pkg::alert_rx_t alert_rx;
   wire prim_esc_pkg::esc_tx_t esc_tx;
   wire prim_esc_pkg::esc_rx_t esc_rx;
+  wire clk_async;
+  clk_rst_if clk_rst_async_if(.clk(clk_async), .rst_n(rst_n));
+
+  // dut clk freq, used to generate async alert frequency
 
   clocking sender_cb @(posedge clk);
     input  rst_n;
@@ -17,6 +21,13 @@ interface alert_esc_if(input clk, input rst_n);
     input  alert_rx;
     output esc_tx;
     input  esc_rx;
+  endclocking
+
+  // only alert has async mode, escalator only has sync mode
+  clocking sender_async_cb @(posedge clk_async);
+    input  rst_n;
+    output alert_tx;
+    input  alert_rx;
   endclocking
 
   clocking receiver_cb @(posedge clk);
@@ -42,4 +53,5 @@ interface alert_esc_if(input clk, input rst_n);
   task automatic wait_esc_complete();
     while (esc_tx.esc_p === 1'b1 && esc_tx.esc_n === 1'b0) @(monitor_cb);
   endtask : wait_esc_complete
+
 endinterface: alert_esc_if

--- a/hw/dv/sv/alert_esc_agent/esc_monitor.sv
+++ b/hw/dv/sv/alert_esc_agent/esc_monitor.sv
@@ -15,7 +15,6 @@ class esc_monitor extends alert_esc_base_monitor;
 
   bit under_esc_ping;
 
-  //TODO: currently only support sync mode
   virtual task run_phase(uvm_phase phase);
     fork
       esc_thread();

--- a/hw/ip/alert_handler/dv/env/alert_handler_env.sv
+++ b/hw/ip/alert_handler/dv/env/alert_handler_env.sv
@@ -25,6 +25,7 @@ class alert_handler_env extends cip_base_env #(
           $sformatf("alert_host_agent[%0d]", i), this);
       uvm_config_db#(alert_esc_agent_cfg)::set(this,
           $sformatf("alert_host_agent[%0d]", i), "cfg", cfg.alert_host_cfg[i]);
+      cfg.alert_host_cfg[i].clk_freq_mhz = int'(cfg.clk_freq_mhz);
     end
     // build escalator agents
     esc_device_agent                    = new[NUM_ESCS];

--- a/hw/ip/alert_handler/dv/tb/tb.sv
+++ b/hw/ip/alert_handler/dv/tb/tb.sv
@@ -1,7 +1,7 @@
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-//
+
 module tb;
   // dep packages
   import uvm_pkg::*;


### PR DESCRIPTION
This PR intends to solve issue #3135
To support async alert:
1). Add two clk cycle delays when alert is detected if the alert async mode is on
2). If signal int error detected, and it is the first clock cycle,
ignore this error because it could potentially be a `clk_skew`
3). In TB add async clocks (randomly generate freqs) and reset (currently
tied to rst_n)

Signed-off-by: Cindy Chen <chencindy@google.com>