### PR TITLE
[fpv/alert] update namings for FPV tb

### DIFF
--- a/hw/ip/prim/fpv/tb/prim_alert_rxtx_async_bind_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_alert_rxtx_async_bind_fpv.sv
@@ -19,7 +19,7 @@ module prim_alert_rxtx_async_bind_fpv;
     .alert_err_ni,
     .alert_skew_i,
     .alert_i,
-    .ping_en_i,
+    .ping_req_i,
     .ping_ok_o,
     .integ_fail_o,
     .alert_o

--- a/hw/ip/prim/fpv/tb/prim_alert_rxtx_async_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_alert_rxtx_async_fpv.sv
@@ -23,7 +23,7 @@ module prim_alert_rxtx_async_fpv
   input [1:0]  alert_skew_i,
   // normal I/Os
   input        alert_i,
-  input        ping_en_i,
+  input        ping_req_i,
   output logic ping_ok_o,
   output logic integ_fail_o,
   output logic alert_o
@@ -80,7 +80,7 @@ module prim_alert_rxtx_async_fpv
   ) i_prim_alert_receiver (
     .clk_i        ,
     .rst_ni       ,
-    .ping_en_i    ,
+    .ping_req_i    ,
     .ping_ok_o    ,
     .integ_fail_o ,
     .alert_o      ,

--- a/hw/ip/prim/fpv/tb/prim_alert_rxtx_bind_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_alert_rxtx_bind_fpv.sv
@@ -16,7 +16,7 @@ module prim_alert_rxtx_bind_fpv;
     .alert_err_pi,
     .alert_err_ni,
     .alert_i,
-    .ping_en_i,
+    .ping_req_i,
     .ping_ok_o,
     .integ_fail_o,
     .alert_o

--- a/hw/ip/prim/fpv/tb/prim_alert_rxtx_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_alert_rxtx_fpv.sv
@@ -20,7 +20,7 @@ module prim_alert_rxtx_fpv
   input        alert_err_ni,
   // normal I/Os
   input        alert_i,
-  input        ping_en_i,
+  input        ping_req_i,
   output logic ping_ok_o,
   output logic integ_fail_o,
   output logic alert_o
@@ -55,7 +55,7 @@ module prim_alert_rxtx_fpv
   ) i_prim_alert_receiver (
     .clk_i        ,
     .rst_ni       ,
-    .ping_en_i    ,
+    .ping_req_i    ,
     .ping_ok_o    ,
     .integ_fail_o ,
     .alert_o      ,

--- a/hw/ip/prim/fpv/tb/prim_esc_rxtx_bind_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_esc_rxtx_bind_fpv.sv
@@ -13,8 +13,8 @@ module prim_esc_rxtx_bind_fpv;
     .resp_err_ni ,
     .esc_err_pi  ,
     .esc_err_ni  ,
-    .esc_en_i    ,
-    .ping_en_i   ,
+    .esc_req_i   ,
+    .ping_req_i  ,
     .ping_ok_o   ,
     .integ_fail_o,
     .esc_en_o

--- a/hw/ip/prim/fpv/tb/prim_esc_rxtx_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_esc_rxtx_fpv.sv
@@ -17,8 +17,8 @@ module prim_esc_rxtx_fpv
   input        esc_err_pi,
   input        esc_err_ni,
   // normal I/Os
-  input        esc_en_i,
-  input        ping_en_i,
+  input        esc_req_i,
+  input        ping_req_i,
   output logic ping_ok_o,
   output logic integ_fail_o,
   output logic esc_en_o
@@ -35,10 +35,10 @@ module prim_esc_rxtx_fpv
   prim_esc_sender i_prim_esc_sender (
     .clk_i        ,
     .rst_ni       ,
-    .ping_en_i    ,
+    .ping_req_i   ,
     .ping_ok_o    ,
     .integ_fail_o ,
-    .esc_en_i     ,
+    .esc_req_i    ,
     .esc_rx_i     ( esc_rx_in  ),
     .esc_tx_o     ( esc_tx_out )
   );


### PR DESCRIPTION
Based on PR #3033
Update alert/esc ping naming from `ping_en_i` to `ping_req_i`

Signed-off-by: Cindy Chen <chencindy@google.com>