### PR TITLE
[CI] Use packaged Verilator

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -311,7 +311,8 @@ jobs:
   displayName: Build Verilator simulation of the Earl Grey toplevel design
   dependsOn: lint
   condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'))
-  pool: Default
+  pool:
+    vmImage: ubuntu-16.04
   steps:
   - template: ci/install-package-dependencies.yml
   - bash: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,6 @@
 
 variables:
   VERILATOR_VERSION: 4.040
-  VERILATOR_PATH: /opt/buildcache/verilator/$(VERILATOR_VERSION)
   TOOLCHAIN_PATH: /opt/buildcache/riscv
   VERIBLE_VERSION: v0.0-520-g650c6cc
   # Release tag from https://github.com/lowRISC/lowrisc-toolchains/releases
@@ -316,27 +315,6 @@ jobs:
   steps:
   - template: ci/install-package-dependencies.yml
   - bash: |
-      set -e
-      if [[ ! -d "$(VERILATOR_PATH)" ]]; then
-        echo "Building verilator (no cached build found)"
-
-        mkdir -p build/verilator
-        cd build/verilator
-        curl -Ls -o verilator.tgz \
-          "https://www.veripool.org/ftp/verilator-$(VERILATOR_VERSION).tgz"
-        tar -xf verilator.tgz
-
-        cd "verilator-$(VERILATOR_VERSION)"
-        ./configure --prefix="$(VERILATOR_PATH)"
-        make -j$(nproc)
-        mkdir -p "$VERILATOR_PATH"
-        make install
-      else
-        echo "Re-using cached verilator build"
-      fi
-    displayName: Build and install Verilator
-  - bash: |
-      export PATH="$VERILATOR_PATH/bin:$PATH"
       python3 --version
       fusesoc --version
       verilator --version
@@ -346,7 +324,6 @@ jobs:
       mkdir -p "$OBJ_DIR/hw"
       mkdir -p "$BIN_DIR/hw/top_earlgrey"
 
-      export PATH="$VERILATOR_PATH/bin:$PATH"
       # Compile the simulation without threading; the runners provided by
       # Azure provide two virtual CPUs, which seems to equal one physical
       # CPU (at most); the use of threading slows down the simulation.

--- a/ci/install-package-dependencies.yml
+++ b/ci/install-package-dependencies.yml
@@ -33,12 +33,24 @@ steps:
 
       cd "${{ parameters.REPO_TOP }}"
 
+      # Install verilator from experimental OBS repository
+      # apt-requirements.txt doesn't cover this dependency as we don't support
+      # using the repository below for anything but our CI (yet).
+      EDATOOLS_REPO_KEY="https://download.opensuse.org/repositories/home:phiwag:edatools/xUbuntu_16.04/Release.key"
+      EDATOOLS_REPO="deb http://download.opensuse.org/repositories/home:/phiwag:/edatools/xUbuntu_16.04/ /"
+      curl -sL "$EDATOOLS_REPO_KEY" | sudo apt-key add -
+      sudo sh -c "echo \"$EDATOOLS_REPO\" > /etc/apt/sources.list.d/edatools.list"
+
+      cp apt-requirements.txt apt-requirements-ci.txt
+      echo "verilator-$(VERILATOR_VERSION)" >> apt-requirements-ci.txt
+      cat apt-requirements-ci.txt
+
       # Ensure apt package index is up-to-date.
       sudo $APT_CMD update
 
-      # NOTE: We use sed to remove all comments from apt-requirements.txt,
+      # NOTE: We use sed to remove all comments from apt-requirements-ci.txt,
       # since apt-get/apt-fast doesn't actually provide such a feature.
-      sed 's/#.*//' apt-requirements.txt \
+      sed 's/#.*//' apt-requirements-ci.txt \
         | xargs sudo $APT_CMD install -y
 
       # Python requirements are installed to the local user directory so prepend


### PR DESCRIPTION
Currently, our CI setup runs the build of the Verilator-based simulation on a machine hosted by lowRISC, known as the "Default" runner. This runner isn't scalable, and also needed for the Vivado build. We did use this runner to avoid re-compiling Verilator with every CI job, which takes a couple minutes.

With this PR, CI uses a packaged build of Verilator to avoid the compilation step. In consequence, the CI job can run on an Azure-provided runner, freeing resources on the "Default" runner.Since many device software test jobs depend on the Verilator build job, including the long-running RISC-V Compliance Test jobs, we can expect a significantly reduced CI latency in high-load situations, as we see them often in the European late evening/US mid-day.

The Verilator package is provided by an experimental repository from
Open Build Service (OBS), which is maintained by me. The repository
differs from "traditional" distribution repositories, as it provides
multiple versioned packages (e.g. verilator-4.032), as opposed to only a
single version. This allows CI to choose and pin exactly one version,
without having to follow the latest releases.

All of this infrastructure is currently experimental and not supported
anywhere except for the use in CI; however, it has been used
successfully in Ibex for multiple months and has proven to work well.