### PR TITLE
[aes] Disable SVAs checking key length/mode in case of storage errors

### DIFF
--- a/hw/ip/aes/rtl/aes_cipher_control.sv
+++ b/hw/ip/aes/rtl/aes_cipher_control.sv
@@ -21,6 +21,7 @@ module aes_cipher_control (
   input  logic                    out_ready_i,
 
   // Control and sync signals
+  input  logic                    cfg_valid_i,
   input  aes_pkg::ciph_op_e       op_i,
   input  aes_pkg::key_len_e       key_len_i,
   input  logic                    crypt_i,
@@ -67,6 +68,10 @@ module aes_cipher_control (
   logic       dec_key_gen_d, dec_key_gen_q;
   logic       key_clear_d, key_clear_q;
   logic       data_out_clear_d, data_out_clear_q;
+
+  // cfg_valid_i is used for gating assertions only.
+  logic       unused_cfg_valid;
+  assign unused_cfg_valid = cfg_valid_i;
 
   // FSM
   always_comb begin : aes_cipher_ctrl_fsm
@@ -310,7 +315,7 @@ module aes_cipher_control (
 
   // Selectors must be known/valid
   `ASSERT_KNOWN(AesCiphOpKnown, op_i)
-  `ASSERT(AesKeyLenValid, key_len_i inside {
+  `ASSERT(AesKeyLenValid, cfg_valid_i |-> key_len_i inside {
       AES_128,
       AES_192,
       AES_256

--- a/hw/ip/aes/rtl/aes_cipher_core.sv
+++ b/hw/ip/aes/rtl/aes_cipher_core.sv
@@ -112,6 +112,7 @@ module aes_cipher_core import aes_pkg::*;
   input  logic                 out_ready_i,
 
   // Control and sync signals
+  input  logic                 cfg_valid_i, // Used for gating assertions only.
   input  ciph_op_e             op_i,
   input  key_len_e             key_len_i,
   input  logic                 crypt_i,
@@ -293,15 +294,16 @@ module aes_cipher_core import aes_pkg::*;
     .Masking      ( Masking      ),
     .SBoxImpl     ( SBoxImpl     )
   ) u_aes_key_expand (
-    .clk_i     ( clk_i            ),
-    .rst_ni    ( rst_ni           ),
-    .op_i      ( key_expand_op    ),
-    .step_i    ( key_expand_step  ),
-    .clear_i   ( key_expand_clear ),
-    .round_i   ( key_expand_round ),
-    .key_len_i ( key_len_i        ),
-    .key_i     ( key_full_q       ),
-    .key_o     ( key_expand_out   )
+    .clk_i       ( clk_i            ),
+    .rst_ni      ( rst_ni           ),
+    .cfg_valid_i ( cfg_valid_i      ),
+    .op_i        ( key_expand_op    ),
+    .step_i      ( key_expand_step  ),
+    .clear_i     ( key_expand_clear ),
+    .round_i     ( key_expand_round ),
+    .key_len_i   ( key_len_i        ),
+    .key_i       ( key_full_q       ),
+    .key_o       ( key_expand_out   )
   );
 
   for (genvar s = 0; s < NumShares; s++) begin : gen_shares_round_key
@@ -344,8 +346,11 @@ module aes_cipher_core import aes_pkg::*;
 
     .in_valid_i             ( in_valid_i           ),
     .in_ready_o             ( in_ready_o           ),
+
     .out_valid_o            ( out_valid_o          ),
     .out_ready_i            ( out_ready_i          ),
+
+    .cfg_valid_i            ( cfg_valid_i          ),
     .op_i                   ( op_i                 ),
     .key_len_i              ( key_len_i            ),
     .crypt_i                ( crypt_i              ),
@@ -360,6 +365,7 @@ module aes_cipher_core import aes_pkg::*;
     .state_sel_o            ( state_sel            ),
     .state_we_o             ( state_we             ),
     .add_rk_sel_o           ( add_round_key_in_sel ),
+
     .key_expand_op_o        ( key_expand_op        ),
     .key_full_sel_o         ( key_full_sel         ),
     .key_full_we_o          ( key_full_we          ),

--- a/hw/ip/aes/rtl/aes_control.sv
+++ b/hw/ip/aes/rtl/aes_control.sv
@@ -624,7 +624,7 @@ module aes_control
   assign prng_reseed_o    = 1'b0;
 
   // Selectors must be known/valid
-  `ASSERT(AesModeValid, mode_i inside {
+  `ASSERT(AesModeValid, !ctrl_err_storage_i |-> mode_i inside {
       AES_ECB,
       AES_CBC,
       AES_CFB,

--- a/hw/ip/aes/rtl/aes_core.sv
+++ b/hw/ip/aes/rtl/aes_core.sv
@@ -292,8 +292,11 @@ module aes_core import aes_pkg::*;
 
     .in_valid_i       ( cipher_in_valid            ),
     .in_ready_o       ( cipher_in_ready            ),
+
     .out_valid_o      ( cipher_out_valid           ),
     .out_ready_i      ( cipher_out_ready           ),
+
+    .cfg_valid_i      ( ~ctrl_err_storage_o        ),
     .op_i             ( cipher_op                  ),
     .key_len_i        ( key_len_q                  ),
     .crypt_i          ( cipher_crypt               ),
@@ -548,7 +551,7 @@ module aes_core import aes_pkg::*;
       IV_CLEAR
       })
   `ASSERT_KNOWN(AesDataInPrevSelKnown, data_in_prev_sel)
-  `ASSERT(AesModeValid, aes_mode_q inside {
+  `ASSERT(AesModeValid, !ctrl_err_storage_o |-> aes_mode_q inside {
       AES_ECB,
       AES_CBC,
       AES_CFB,

--- a/hw/ip/aes/rtl/aes_key_expand.sv
+++ b/hw/ip/aes/rtl/aes_key_expand.sv
@@ -16,6 +16,7 @@ module aes_key_expand import aes_pkg::*;
 ) (
   input  logic              clk_i,
   input  logic              rst_ni,
+  input  logic              cfg_valid_i,
   input  ciph_op_e          op_i,
   input  logic              step_i,
   input  logic              clear_i,
@@ -45,6 +46,11 @@ module aes_key_expand import aes_pkg::*;
   logic      [31:0] irregular [NumShares];
   logic [7:0][31:0] regular [NumShares];
 
+  // cfg_valid_i is used for gating assertions only.
+  logic             unused_cfg_valid;
+  assign unused_cfg_valid = cfg_valid_i;
+
+  // Get a shorter reference.
   assign rnd = round_i;
 
   // For AES-192, there are four different types of rounds.
@@ -376,7 +382,7 @@ module aes_key_expand import aes_pkg::*;
 
   // Selectors must be known/valid
   `ASSERT_KNOWN(AesCiphOpKnown, op_i)
-  `ASSERT(AesKeyLenValid, key_len_i inside {
+  `ASSERT(AesKeyLenValid, cfg_valid_i |-> key_len_i inside {
       AES_128,
       AES_192,
       AES_256


### PR DESCRIPTION
In the case of storage errors in the shadowed control register, the AES module might be confronted with invalid key length and mode values (such as all-zero values or if multiple bits are set). Since such storage errors need to be handled by the RTL, the SVAs checking the key length and mode values seen by the module must be disabled in case of storage errors.

This is related to https://github.com/lowRISC/opentitan/pull/3163/files#r471586486