### PR TITLE
[otbn] Initial OTBN python simulator

### DIFF
--- a/hw/ip/otbn/README.md
+++ b/hw/ip/otbn/README.md
@@ -36,6 +36,20 @@ Will assemble and link `prog.S` and produce various outputs using
 `prog_bin/prog` as a prefix for all output filenames. Run
 `./hw/ip/otbn/util/build.sh` without arguments for more information.
 
+### Work with the ISA
+
+The instruction set is described in machine readable form in
+`data/insns.yml`. This is parsed by Python code in
+`util/insn_yaml.py`, which runs various sanity checks on the data. The
+binutils-based toolchain described above uses this information. Other
+users include:
+
+  - `util/yaml_to_doc.py`: Generates a Markdown snippet which is included in
+    the OTBN specification.
+
+  - `util/otbn-rig`: A random instruction generator for OTBN. See
+    util/rig/README.md for further information.
+
 ### Run the standalone simulation
 *Note that OTBN is still in the early development stages so this simulation does
 not support the full ISA*
@@ -83,21 +97,29 @@ hw/ip/otbn/dv/smoke/run_smoke.sh
 This will build the standalone simulation, build the smoke test binary, run it
 and check the results are as expected.
 
-### Build the RTL implementation in OT earlgrey simulation
+### Run OT earlgrey simulation with the OTBN model, rather than the RTL design
 
-To build the RTL implementation of OTBN in an earlgrey simulation, run `fusesoc`
-without passing the `OTBN_MODEL` flag. For example, the Verilator simulation can
-be compiled as follows.
+The default behaviour is that the OTBN block contains the RTL design.
+If you wish to run system-level testing against the Python-based
+simulator instead of the RTL, you need to pass the `OTBN_MODEL` flag.
+For example, to compile the Verilator simulation, use:
 
 ```sh
-fusesoc --cores-root=. run --target=sim --setup --build lowrisc:systems:top_earlgrey_verilator
+fusesoc --cores-root=. run \
+  --flag=fileset_top --target=sim --setup --build \
+  lowrisc:systems:top_earlgrey_verilator --OTBN_MODEL
 ```
 
-### Work with the ISA
+### Update the OTBN model (the instruction-set simulator, ISS)
 
-The instruction set is described in machine readable form in `data/insns.yml`.
-This is parsed by Python code in `util/insn_yaml.py`, which runs various sanity
-checks on the data. Current tooling that uses this information:
+The OTBN model is an instruction set simulator written in Python. It lives
+in the `opentitan` repository in the `util/otbnsim` directory, but builds on top
+of the `riscv-model` Python package. The code for this package can be found at
+https://github.com/wallento/riscv-python-model.
 
-  - `util/yaml_to_doc.py`: Generates a Markdown snippet which is included in
-    the OTBN specification.
+To update the model to the latest recommended version run `pip`.
+
+```sh
+# Ensure you have the latest Python dependencies installed
+pip3 install --user -U python-requirements.txt
+```

--- a/hw/ip/otbn/dv/model/otbn_core_model.sv
+++ b/hw/ip/otbn/dv/model/otbn_core_model.sv
@@ -1,0 +1,86 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`include "prim_assert.sv"
+
+/**
+ * OpenTitan Big Number Accelerator (OTBN) Core
+ *
+ * This module is the top-level of the OTBN processing core.
+ */
+module otbn_core_model
+  import otbn_pkg::*;
+#(
+  // Size of the instruction memory, in bytes
+  parameter int ImemSizeByte = 4096,
+  // Size of the data memory, in bytes
+  parameter int DmemSizeByte = 4096,
+
+  // Scope of the instruction memory (for DPI)
+  parameter string ImemScope = "",
+  // Scope of the data memory (for DPI)
+  parameter string DmemScope = "",
+
+  localparam int ImemAddrWidth = prim_util_pkg::vbits(ImemSizeByte),
+  localparam int DmemAddrWidth = prim_util_pkg::vbits(DmemSizeByte)
+)(
+  input  logic  clk_i,
+  input  logic  rst_ni,
+
+  input  logic  start_i, // start the operation
+  output logic  done_o,  // operation done
+
+  input  logic [ImemAddrWidth-1:0] start_addr_i, // start byte address in IMEM
+
+  // Instruction memory (IMEM)
+  output logic                     imem_req_o,
+  output logic                     imem_write_o,
+  output logic [ImemAddrWidth-1:0] imem_addr_o,
+  output logic [31:0]              imem_wdata_o,
+  input  logic [31:0]              imem_rdata_i,
+  input  logic                     imem_rvalid_i,
+  input  logic [1:0]               imem_rerror_i,
+
+  // Data memory (DMEM)
+  output logic                     dmem_req_o,
+  output logic                     dmem_write_o,
+  output logic [DmemAddrWidth-1:0] dmem_addr_o,
+  output logic [WLEN-1:0]          dmem_wdata_o,
+  output logic [WLEN-1:0]          dmem_wmask_o,
+  input  logic [WLEN-1:0]          dmem_rdata_i,
+  input  logic                     dmem_rvalid_i,
+  input  logic [1:0]               dmem_rerror_i
+);
+
+  import "DPI-C" context function int run_model(string imem_scope,
+                                                int    imem_size,
+                                                string dmem_scope,
+                                                int    dmem_size);
+
+  localparam ImemSizeWords = ImemSizeByte / 4;
+  localparam DmemSizeWords = DmemSizeByte / (WLEN / 8);
+
+  int count;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : model_run
+    if (!rst_ni) begin
+      done_o <= 1'b0;
+      count <= -1;
+    end else begin
+      if (start_i) begin
+        count <= run_model(ImemScope, ImemSizeWords, DmemScope, DmemSizeWords);
+        done_o <= 1'b0;
+      end else begin
+        if (count == 0) begin
+          done_o <= 1'b1;
+          count <= -1;
+        end else begin
+          done_o <= 1'b0;
+          count <= count - 1;
+        end
+      end
+    end
+  end
+
+endmodule

--- a/hw/ip/otbn/dv/model/otbn_model.cc
+++ b/hw/ip/otbn/dv/model/otbn_model.cc
@@ -1,0 +1,294 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cassert>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <string>
+
+#include <svdpi.h>
+#include <sys/stat.h>
+
+// Candidate for hw/dv/verilator/cpp
+/**
+ * Guard class for SV Scope
+ *
+ * This guard ensures that all functions in the context where it is instantiated
+ * are executed in an SVScope. It will restore the previous scope at destruction
+ * and thereby make sure that the previous scope will be restored for all paths
+ * that exit the scope.
+ */
+class SVScoped {
+ private:
+  svScope prev_scope_ = 0;
+
+ public:
+  SVScoped(std::string scopeName) : SVScoped(scopeName.c_str()) {}
+  SVScoped(const char *scopeName) : SVScoped(svGetScopeFromName(scopeName)) {}
+
+  SVScoped(svScope scope) { prev_scope_ = svSetScope(scope); }
+  ~SVScoped() { svSetScope(prev_scope_); }
+};
+
+// Guard class to safely delete C strings
+struct CStrDeleter {
+  void operator()(char *p) const { std::free(p); }
+};
+typedef std::unique_ptr<char, CStrDeleter> c_str_ptr;
+
+extern "C" int simutil_verilator_get_mem(int index, const svBitVecVal *val);
+extern "C" int simutil_verilator_set_mem(int index, const svBitVecVal *val);
+
+// Use simutil_verilator_get_mem to read data one word at a time from the given
+// scope, writing it to a file at path. Each word is word_size bytes long.
+//
+// Raises a runtime_error on failure.
+static void
+dump_memory(const char *path,
+            const char *scope,
+            size_t      num_words,
+            size_t      word_size)
+{
+  std::filebuf fb;
+  if (!fb.open(path, std::ios::out | std::ios::binary)) {
+    std::ostringstream oss;
+    oss << "Cannot open the file '" << path << "'.";
+    throw std::runtime_error(oss.str());
+  }
+
+  SVScoped scoped(scope);
+
+  // simutil_verilator_get_mem passes data as a packed array of svBitVecVal
+  // words. It only works for memories of size at most 256 bits, so we can just
+  // allocate 256/8 = 32 bytes as 32/sizeof(svBitVecVal) words on the stack.
+  assert (word_size <= 256 / 8);
+  svBitVecVal buf[256 / 8 / sizeof(svBitVecVal)];
+
+  for (size_t w = 0; w < num_words; w++) {
+    if (!simutil_verilator_get_mem(w, buf)) {
+      std::ostringstream oss;
+      oss << "Cannot get memory at word " << w
+          << " from scope " << scope << ".\n";
+      throw std::runtime_error(oss.str());
+    }
+
+    // Write out the first word_size bytes of data
+    std::streamsize chars_out =
+      fb.sputn(reinterpret_cast<const char *>(buf), word_size);
+
+    if (chars_out != word_size) {
+      std::ostringstream oss;
+      oss << "Cannot write word " << w << " to '" << path << "'.\n";
+      throw std::runtime_error(oss.str());
+    }
+  }
+}
+
+// Read data from the given file and then use simutil_verilator_set_mem to
+// write it into the simulation one word at a time. Each word is word_size
+// bytes long.
+//
+// Raises a runtime_error on failure.
+static void
+load_memory(const char *path,
+            const char *scope,
+            size_t      num_words,
+            size_t      word_size)
+{
+  std::filebuf fb;
+  if (!fb.open(path, std::ios::in | std::ios::binary)) {
+    std::ostringstream oss;
+    oss << "Cannot open the file '" << path << "'.";
+    throw std::runtime_error(oss.str());
+  }
+
+  SVScoped scoped(scope);
+
+  // See dump_memory, above, for why this array is sized like this.
+  assert (word_size <= 256 / 8);
+  svBitVecVal buf[256 / 8 / sizeof(svBitVecVal)];
+
+  for (size_t w = 0; w < num_words; w++) {
+    std::streamsize chars_in =
+      fb.sgetn(reinterpret_cast<char *>(buf), word_size);
+
+    if (chars_in != word_size) {
+      std::ostringstream oss;
+      oss << "Cannot read word " << w << " from '" << path << "'.\n";
+      throw std::runtime_error(oss.str());
+    }
+
+    if (!simutil_verilator_set_mem(w, buf)) {
+      std::ostringstream oss;
+      oss << "Cannot set memory at word " << w
+          << " for scope " << scope << ".\n";
+      throw std::runtime_error(oss.str());
+    }
+  }
+}
+
+// Read a 4-byte little-endian unsigned value from the given file which is
+// supposed to represent the number of cycles taken by the simulation and
+// return it.
+//
+// Raises a runtime_error on failure.
+static uint32_t
+load_cycles(const char *path)
+{
+  std::filebuf fb;
+  if (!fb.open(path, std::ios::in | std::ios::binary)) {
+    std::ostringstream oss;
+    oss << "Cannot open the file '" << path << "'.";
+    throw std::runtime_error(oss.str());
+  }
+
+  char buf[4];
+  if (fb.sgetn(buf, 4) != 4) {
+    std::ostringstream oss;
+    oss << "Failed to read 4 bytes from '" << path << "'.";
+    throw std::runtime_error(oss.str());
+  }
+
+  // Re-pack the little-endian value we just read.
+  uint32_t ret = 0;
+  for (int i = 0; i < 4; ++i) {
+    ret += (uint32_t)buf[i] << 8 * i;
+  }
+  return ret;
+}
+
+// Find the otbn Python model, based on our executable path, and
+// return it. On failure, throw a std::runtime_error with a
+// description of what went wrong.
+//
+// This works by searching upwards from the binary location to find a git
+// directory (which is assumed to be the OpenTitan toplevel). It won't work if
+// you copy the binary somewhere else: if we need to support that sort of
+// thing, we'll have to figure out a "proper" installation procedure.
+static std::string find_otbn_model()
+{
+  c_str_ptr self_path(realpath("/proc/self/exe", NULL));
+  if (!self_path) {
+    std::ostringstream oss;
+    oss << "Cannot resolve /proc/self/exe: " << strerror(errno);
+    throw std::runtime_error(oss.str());
+  }
+
+  // Take a copy of self_path as a std::string and modify it, walking backwards
+  // over '/' characters and appending .git each time. After the first
+  // iteration, last_pos is the position of the character before the final
+  // slash (where the path looks something like "/path/to/check/.git")
+  std::string path_buf(self_path.get());
+
+  struct stat git_dir_stat;
+
+  size_t last_pos = std::string::npos;
+  for (;;) {
+    size_t last_slash = path_buf.find_last_of('/', last_pos);
+
+    // self_path was absolute, so there should always be a '/' at position
+    // zero.
+    assert(last_slash != std::string::npos);
+    if (last_slash == 0) {
+      // We've got to the slash at the start of an absolute path (and "/.git"
+      // is probably not the path we want!). Give up.
+      std::ostringstream oss;
+      oss << "Cannot find a git top-level directory containing "
+          << self_path.get() << ".\n";
+      throw std::runtime_error(oss.str());
+    }
+
+    // Replace everything after last_slash with ".git". The first time around,
+    // this will turn "/path/to/elf-file" to "/path/to/.git". After that, it
+    // will turn "/path/to/check/.git" to "/path/to/.git". Note that last_slash
+    // is strictly less than the string length (because it's an element index),
+    // so last_slash + 1 won't fall off the end.
+    path_buf.replace(last_slash + 1, std::string::npos, ".git");
+    last_pos = last_slash - 1;
+
+    // Does path_buf name a directory? If so, we've found the enclosing git
+    // directory.
+    if (stat(path_buf.c_str(), &git_dir_stat) == 0 &&
+        S_ISDIR(git_dir_stat.st_mode)) {
+      break;
+    }
+  }
+
+  // If we get here, path_buf points at a .git directory. Resolve from there to
+  // the expected model name, then use realpath to canonicalise the path. If it
+  // fails, there was no script there.
+  path_buf += "/../hw/ip/otbn/dv/otbnsim/otbnsim.py";
+  char *model_path = realpath(path_buf.c_str(), NULL);
+  if (!model_path) {
+      std::ostringstream oss;
+      oss << "Cannot find otbnsim.py, at '"
+          << path_buf << "' (guessed by searching upwards from '"
+          << self_path.get() << "').\n";
+      throw std::runtime_error(oss.str());
+  }
+
+  return std::string(model_path);
+}
+
+extern "C" int
+run_model(const char *imem_scope, int imem_words,
+          const char *dmem_scope, int dmem_words)
+{
+  assert (imem_words >= 0);
+  assert (dmem_words >= 0);
+
+  char dir[] = "/tmp/otbn_XXXXXX";
+  char ifname[] = "/tmp/otbn_XXXXXX/imem";
+  char dfname[] = "/tmp/otbn_XXXXXX/dmem";
+  char cfname[] = "/tmp/otbn_XXXXXX/cycles";
+
+  if (mkdtemp(dir) == nullptr) {
+    std::cerr << "Cannot create temporary directory" << std::endl;
+    return 0;
+  }
+
+  std::memcpy(ifname, dir, strlen(dir));
+  std::memcpy(dfname, dir, strlen(dir));
+  std::memcpy(cfname, dir, strlen(dir));
+
+  try {
+    dump_memory(dfname, dmem_scope, dmem_words, 32);
+    dump_memory(ifname, imem_scope, imem_words, 4);
+  }
+  catch (const std::runtime_error &err) {
+    std::cerr << "Error when dumping memory contents: " << err.what() << "\n";
+    return 0;
+  }
+
+  std::string model_path;
+  try {
+    model_path = find_otbn_model();
+  }
+  catch (const std::runtime_error &err) {
+    std::cerr << "Error when searching for OTBN model: " << err.what() << "\n";
+    return 0;
+  }
+
+  std::ostringstream cmd;
+  cmd << model_path << " " << imem_words << " " << ifname << " "
+      << dmem_words << " " << dfname << " " << cfname;
+
+  if (std::system(cmd.str().c_str()) != 0) {
+    std::cerr << "Failed to execute model (cmd was: '" << cmd.str() << "').\n";
+    return 0;
+  }
+
+  try {
+    load_memory(dfname, dmem_scope, dmem_words, 32);
+    return load_cycles(cfname);
+  }
+  catch (const std::runtime_error &err) {
+    std::cerr << "Error when loading sim results: " << err.what() << "\n";
+    return 0;
+  }
+}

--- a/hw/ip/otbn/dv/otbnsim/otbnsim.py
+++ b/hw/ip/otbn/dv/otbnsim/otbnsim.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Execute the simulation
+
+import argparse
+import struct
+
+from riscvmodel.sim import Simulator
+from riscvmodel.model import Model
+from riscvmodel.variant import RV32I
+from riscvmodel.code import read_from_binary
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("imem_words", type=int)
+    parser.add_argument("imem_file")
+    parser.add_argument("dmem_words", type=int)
+    parser.add_argument("dmem_file")
+    parser.add_argument("cycles_file")
+
+    args = parser.parse_args()
+    sim = Simulator(Model(RV32I))
+
+    sim.load_program(read_from_binary(args.imem_file, stoponerror=True))
+    with open(args.dmem_file, "rb") as f:
+        sim.load_data(f.read())
+
+    cycles = sim.run()
+
+    with open(args.dmem_file, "wb") as f:
+        f.write(sim.dump_data())
+
+    with open(args.cycles_file, "wb") as f:
+        f.write(struct.pack("<L", cycles))
+
+
+if __name__ == '__main__':
+    main()

--- a/hw/ip/otbn/otbn.core
+++ b/hw/ip/otbn/otbn.core
@@ -41,6 +41,12 @@ filesets:
       - rtl/otbn.sv
     file_type: systemVerilogSource
 
+  files_model:
+    files:
+      - dv/model/otbn_model.cc: { file_type: cppSource }
+      - dv/model/otbn_core_model.sv
+    file_type: systemVerilogSource
+
   files_verilator_waiver:
     depend:
       # common waivers
@@ -62,6 +68,7 @@ targets:
       - files_rtl_pkg
       - files_rtl_core
       - files_rtl_top
+      - tool_verilator ? (files_model)
     toplevel: otbn
 
   lint:

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -43,6 +43,12 @@ module otbn
   localparam int ImemAddrWidth = vbits(ImemSizeByte);
   localparam int DmemAddrWidth = vbits(DmemSizeByte);
 
+`ifdef OTBN_MODEL
+  localparam int OTBNModel = 1;
+`else
+  localparam int OTBNModel = 0;
+`endif
+
   logic start;
   logic busy_d, busy_q;
   logic done;
@@ -411,34 +417,70 @@ module otbn
   end
   assign busy_d = (busy_q | start) & ~done;
 
-  otbn_core #(
-    .DmemSizeByte(DmemSizeByte),
-    .ImemSizeByte(ImemSizeByte)
-  ) u_otbn_core (
-    .clk_i,
-    .rst_ni,
+  if (OTBNModel) begin : gen_impl_model
+    localparam ImemScope = "TOP.top_earlgrey_verilator.top_earlgrey.u_otbn.u_imem.u_mem.gen_generic.u_impl_generic";
+    localparam DmemScope = "TOP.top_earlgrey_verilator.top_earlgrey.u_otbn.u_dmem.u_mem.gen_generic.u_impl_generic";
 
-    .start_i (start),
-    .done_o  (done),
+    otbn_core_model #(
+      .DmemSizeByte(DmemSizeByte),
+      .ImemSizeByte(ImemSizeByte),
+      .DmemScope(DmemScope),
+      .ImemScope(ImemScope)
+    ) u_otbn_core_model (
+      .clk_i,
+      .rst_ni,
 
-    .start_addr_i  (start_addr),
+      .start_i (start),
+      .done_o  (done),
 
-    .imem_req_o    (imem_req_core),
-    .imem_addr_o   (imem_addr_core),
-    .imem_wdata_o  (imem_wdata_core),
-    .imem_rdata_i  (imem_rdata_core),
-    .imem_rvalid_i (imem_rvalid_core),
-    .imem_rerror_i (imem_rerror_core),
+      .start_addr_i  (start_addr),
 
-    .dmem_req_o    (dmem_req_core),
-    .dmem_write_o  (dmem_write_core),
-    .dmem_addr_o   (dmem_addr_core),
-    .dmem_wdata_o  (dmem_wdata_core),
-    .dmem_wmask_o  (dmem_wmask_core),
-    .dmem_rdata_i  (dmem_rdata_core),
-    .dmem_rvalid_i (dmem_rvalid_core),
-    .dmem_rerror_i (dmem_rerror_core)
-  );
+      .imem_req_o    (imem_req_core),
+      .imem_addr_o   (imem_addr_core),
+      .imem_wdata_o  (imem_wdata_core),
+      .imem_rdata_i  (imem_rdata_core),
+      .imem_rvalid_i (imem_rvalid_core),
+      .imem_rerror_i (imem_rerror_core),
+
+      .dmem_req_o    (dmem_req_core),
+      .dmem_write_o  (dmem_write_core),
+      .dmem_addr_o   (dmem_addr_core),
+      .dmem_wdata_o  (dmem_wdata_core),
+      .dmem_wmask_o  (dmem_wmask_core),
+      .dmem_rdata_i  (dmem_rdata_core),
+      .dmem_rvalid_i (dmem_rvalid_core),
+      .dmem_rerror_i (dmem_rerror_core)
+    );
+  end else begin : gen_impl_rtl
+    otbn_core #(
+      .DmemSizeByte(DmemSizeByte),
+      .ImemSizeByte(ImemSizeByte)
+    ) u_otbn_core (
+      .clk_i,
+      .rst_ni,
+
+      .start_i (start),
+      .done_o  (done),
+
+      .start_addr_i  (start_addr),
+
+      .imem_req_o    (imem_req_core),
+      .imem_addr_o   (imem_addr_core),
+      .imem_wdata_o  (imem_wdata_core),
+      .imem_rdata_i  (imem_rdata_core),
+      .imem_rvalid_i (imem_rvalid_core),
+      .imem_rerror_i (imem_rerror_core),
+
+      .dmem_req_o    (dmem_req_core),
+      .dmem_write_o  (dmem_write_core),
+      .dmem_addr_o   (dmem_addr_core),
+      .dmem_wdata_o  (dmem_wdata_core),
+      .dmem_wmask_o  (dmem_wmask_core),
+      .dmem_rdata_i  (dmem_rdata_core),
+      .dmem_rvalid_i (dmem_rvalid_core),
+      .dmem_rerror_i (dmem_rerror_core)
+    );
+  end
 
   // The core can never signal a write to IMEM
   assign imem_write_core = 1'b0;

--- a/hw/top_earlgrey/top_earlgrey_verilator.core
+++ b/hw/top_earlgrey/top_earlgrey_verilator.core
@@ -53,6 +53,10 @@ parameters:
     paramtype: vlogdefine
     default: true
     description: Replace JTAG TAP with an OpenOCD direct connection
+  OTBN_MODEL:
+    datatype: bool
+    paramtype: vlogdefine
+    description: Use the OTBN model instead of the RTL implementation (development only)
 
 targets:
   default: &default_target
@@ -69,6 +73,7 @@ targets:
       - flashinit
       - rominit
       - DMIDirectTAP
+      - OTBN_MODEL
     default_tool: verilator
     filesets:
       - files_sim_verilator

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -26,6 +26,9 @@ pyyaml
 tabulate
 yapf
 
+# Used by OTBN simulator
+riscv-model >= 0.4.1
+
 # Development version with OT-specific changes
 git+https://github.com/lowRISC/fusesoc.git@ot#egg=fusesoc >= 1.11.0
 


### PR DESCRIPTION
This adds the first iteration of the python instruction set
simulator (ISS) for OTBN. Right now it only has RV32I, but it lays the
fundamental groundwork.

The base model is an external dependency ("riscv-model", which is
hosted on pypi and will be installed by pip as part of
python-requirements.txt). The OTBN model is currently a small wrapper
that loads up imem and dmem contents, instantiates the base model,
runs that, and dumps some results to files. This will expand as we add
support for the rest of the OTBN instruction set.

As well as including a basic ISS, this patch has a C++ wrapper that
can be used through DPI to run the ISS inside an RTL simulation. The
wrapper grabs imem and dmem contents from the simulation and dumps
them to files. It then finds the path to the Python simulator (based
on the location of the binary) and runs that. Finally it grabs the
contents of dmem after the run, together with the number of cycles
taken by the simulation (which it returns).

Use `fusesoc ... --OTBN_MODEL` to use this OTBN model instead of the
RTL implementation.

Signed-off-by: Stefan Wallentowitz <stefan.wallentowitz@gi-de.com>
Co-authored-by: Rupert Swarbrick <rswarbrick@lowrisc.org>
Co-authored-by: Philipp Wagner <phw@lowrisc.org>