### PR TITLE
[keccak] Add valid signal to random value

### DIFF
--- a/hw/ip/kmac/rtl/keccak_2share.sv
+++ b/hw/ip/kmac/rtl/keccak_2share.sv
@@ -12,8 +12,8 @@ module keccak_2share #(
   // Derived
   localparam int W        = Width/25,
   localparam int L        = $clog2(W),
-  localparam int MaxRound = 12 + 2*L,         // Keccak-f only
-  localparam int RndW     = $clog2(MaxRound), // Representing up to MaxRound-1
+  localparam int MaxRound = 12 + 2*L,           // Keccak-f only
+  localparam int RndW     = $clog2(MaxRound+1), // Representing up to MaxRound
 
   // Control parameters
   parameter  int EnMasking = 0,                // Enable secure hardening
@@ -23,6 +23,7 @@ module keccak_2share #(
   input rst_ni,
 
   input        [RndW-1:0]  rnd_i,   // Current Round
+  input                    rand_valid_i,
   input        [Width-1:0] rand_i,  // Random values. Used when 2Share enabled
   input                    sel_i,   // Select input/output mux. Used when EnMasking := 1
   input        [Width-1:0] s_i      [Share],
@@ -166,14 +167,15 @@ module keccak_2share #(
         .clk_i,
         .rst_ni,
 
-        .a0_i (a0),
-        .a1_i (a1),
-        .b0_i (b0),
-        .b1_i (b1),
-        .c0_i (c0),
-        .c1_i (c1),
-        .q0_o (q0),
-        .q1_o (q1)
+        .a0_i      (a0),
+        .a1_i      (a1),
+        .b0_i      (b0),
+        .b1_i      (b1),
+        .c_valid_i (rand_valid_i),
+        .c0_i      (c0),
+        .c1_i      (c1),
+        .q0_o      (q0),
+        .q1_o      (q1)
       );
 
       // Convert q0, q1 to sheet_t

--- a/hw/ip/prim/rtl/prim_dom_and_2share.sv
+++ b/hw/ip/prim/rtl/prim_dom_and_2share.sv
@@ -36,6 +36,7 @@ module prim_dom_and_2share #(
   input [DW-1:0] a1_i, // share1 of a
   input [DW-1:0] b0_i, // share0 of b
   input [DW-1:0] b1_i, // share1 of b
+  input          c_valid_i, // random number input validity
   input [DW-1:0] c0_i, // share0 of random number
   input [DW-1:0] c1_i, // share1 of random number
 
@@ -61,7 +62,7 @@ module prim_dom_and_2share #(
       if (!rst_ni) begin
         t0_q <= '0;
         t1_q <= '0;
-      end else begin
+      end else if (c_valid_i) begin
         t0_q <= t0_d;
         t1_q <= t1_d;
       end
@@ -71,7 +72,7 @@ module prim_dom_and_2share #(
       if (!rst_ni) begin
         t0_q <= '0;
         t1_q <= '0;
-      end else begin
+      end else if (c_valid_i) begin
         t0_q <= t0_d;
         t1_q <= t1_d;
       end
@@ -86,6 +87,11 @@ module prim_dom_and_2share #(
   // DOM AND should be same as unmasked computation
   if ( !(EnNegedge == 0)) begin: gen_andchk
     `ASSERT(UnmaskedValue_A, q0_o ^ q1_o == (a0_i ^ a1_i) & (b0_i & b1_i), clk_i, !rst_ni)
+  end else begin : gen_andchk_rand
+    `ASSERT(UnmaskedValue_Rand_A,
+      c_valid_i |=> q0_o ^ q1_o == ($past(a0_i) ^ $past(a1_i))
+                                 & ($past(b0_i) ^ $past(b1_i)),
+      clk_i, !rst_ni)
   end
 
 endmodule

--- a/hw/ip/prim/rtl/prim_keccak.sv
+++ b/hw/ip/prim/rtl/prim_keccak.sv
@@ -11,7 +11,7 @@ module prim_keccak #(
   localparam int W        = Width/25,
   localparam int L        = $clog2(W),
   localparam int MaxRound = 12 + 2*L, // Keccak-f only
-  localparam int RndW     = $clog2(MaxRound) // Representing up to MaxRound-1
+  localparam int RndW     = $clog2(MaxRound+1) // Representing up to MaxRound
 ) (
   input        [RndW-1:0]  rnd_i,   // Current Round
   input        [Width-1:0] s_i,


### PR DESCRIPTION
keccak_2share and its DOM AND operation requires 1600bits of random
value in each round. It currently takes 3 cycle in the masked keccak.
Preparing 1600 bits of entropy is hard to be done in 3 cycles.

There're a couple of options to prepare the entropy. One is reuse the
share of adjacent sheets, which is weaker than true entropy. Second is
to use smaller bits of entropy and expands it to 1600b. Another option
is to stack the entropy to become 1600b. To support the last scenario
(regardless of making true 1600b or smaller set then expanding to
1600b), now DOM has `c_valid_i` port. DOM latches internal registers
only when `c_valid_i` is high.

So outside of keccak_2share, the stimuli can indicate when the entropy
is good enough to be consumed.
