### PR TITLE
[dv/shadow_reg] change reset task

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/cip_base_vseq.sv
@@ -503,7 +503,7 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
                      non_shadowed_csrs[0: $urandom_range(0, non_shadowed_csrs.size()-1)]};
         test_csrs.shuffle();
 
-        if ($urandom_range(1, 10) == 10) apply_reset("HARD");
+        if ($urandom_range(1, 10) == 10) dut_init("HARD");
 
         foreach (test_csrs[i]) begin
           // check if parent block or register is excluded from write


### PR DESCRIPTION
Original code use `apply_reset` for issuing reset in shadow-reg.
`apply_reset` will finish right when reset_deasserted. However, in
tl_host_driver, there is a check for seq_item.has_do_available that
checks there is no items after reset_deasserted.
This could cause a race condition.
So here I change the reset command to `dut_init` to avoid the race
condition.

Signed-off-by: Cindy Chen <chencindy@google.com>