### PR TITLE
[prim_fifo_async] Make async FIFO output zero when empty

### DIFF
--- a/hw/ip/prim/rtl/prim_fifo_async.sv
+++ b/hw/ip/prim/rtl/prim_fifo_async.sv
@@ -9,6 +9,7 @@
 module prim_fifo_async #(
   parameter  int unsigned Width  = 16,
   parameter  int unsigned Depth  = 4,
+  parameter  bit OutputZeroIfEmpty = 1'b0, // if == 1 always output 0 when FIFO is empty
   localparam int unsigned DepthW = $clog2(Depth+1) // derived parameter representing [0..Depth]
 ) (
   // write port
@@ -171,6 +172,7 @@ module prim_fifo_async #(
   // Storage //
   /////////////
 
+  logic [Width-1:0] rdata_int;
   if (Depth > 1) begin : g_storage_mux
 
     always_ff @(posedge clk_wr_i) begin
@@ -179,7 +181,7 @@ module prim_fifo_async #(
       end
     end
 
-    assign rdata_o = storage[fifo_rptr_q[PTRV_W-1:0]];
+    assign rdata_int = storage[fifo_rptr_q[PTRV_W-1:0]];
 
   end else begin : g_storage_simple
 
@@ -189,8 +191,14 @@ module prim_fifo_async #(
       end
     end
 
-    assign rdata_o = storage[0];
+    assign rdata_int = storage[0];
 
+  end
+
+  if (OutputZeroIfEmpty == 1'b1) begin : gen_output_zero
+    assign rdata_o = empty_rclk ? '0 : rdata_int;
+  end else begin : gen_no_output_zero
+    assign rdata_o = rdata_int;
   end
 
   //////////////////////////////////////


### PR DESCRIPTION
Hi,

I'm proposing a change to the async FIFO primitive that would gate its output so that it always returns zero when the FIFO is empty. This is related to a change I made a while ago, PR #2420, for the synchronous FIFO primitive. The motivation behind this change was to prevent communication peripherals that use this primitive from leaking stale/garbage data (see the discussion in the linked PR for a bit more context). 

I recently realized the async FIFO has the same data-leakage behavior as the sync FIFO used to have, so I was wondering if the maintainers would be interested in a similar patch for this primitive. The main value I see here would be that it prevents stale data from leaking from the SPI peripheral if a host initiates a transaction before OpenTitan software has initialized the peripheral. 

Thanks!