### PR TITLE
[doc/ci] Require xz-utils for toolchain builds

### DIFF
--- a/apt-requirements.txt
+++ b/apt-requirements.txt
@@ -32,3 +32,4 @@ srecord
 tree
 xsltproc
 zlib1g-dev
+xz-utils


### PR DESCRIPTION
Toolchains are distributed as .tar.xz, ensure that CI runners and our
users have support for it installed.