### PR TITLE
[otbn] Handle shifts better in tooling and documentation

### DIFF
--- a/hw/ip/otbn/data/base-insns.yml
+++ b/hw/ip/otbn/data/base-insns.yml
@@ -283,7 +283,12 @@
 - mnemonic: beq
   rv32i: true
   synopsis: Branch Equal
-  operands: [grs1, grs2, offset]
+  operands: &beq-operands
+    - grs1
+    - grs2
+    - &branch-offset-operand
+      name: offset
+      type: simm<<1
   straight-line: false
   encoding:
     scheme: B
@@ -297,7 +302,7 @@
 - mnemonic: bne
   rv32i: true
   synopsis: Branch Not Equal
-  operands: [grs1, grs2, offset]
+  operands: *beq-operands
   straight-line: false
   encoding:
     scheme: B
@@ -311,7 +316,9 @@
 - mnemonic: jal
   rv32i: true
   synopsis: Jump And Link
-  operands: [grd, offset]
+  operands:
+    - grd
+    - *branch-offset-operand
   straight-line: false
   trailing-doc: |
     The JAL instruction has the same behavior as in RV32I, jumping by the given offset and writing `PC+4` as a link address to the destination register.

--- a/hw/ip/otbn/data/bignum-insns.yml
+++ b/hw/ip/otbn/data/bignum-insns.yml
@@ -196,10 +196,9 @@
         - `3`: Select `wrs1[WLEN-1:WLEN/4*3]` (most significant quarter-word)
     - &mulqacc-acc-shift-imm
       name: acc_shift_imm
-      type: uimm2
+      type: uimm2<<6
       doc: |
-        The number of quarter-words (`WLEN/4` bits) to shift the `WLEN/2`-bit
-        multiply result before accumulating.
+        The number of bits to shift the `WLEN/2`-bit multiply result before accumulating.
   syntax: |
     [<zero_acc>] <wrs1>.<wrs1_qwsel>, <wrs2>.<wrs2_qwsel>, <acc_shift_imm>
   glued-ops: true
@@ -227,7 +226,7 @@
     if zero_accumulator:
       ACC = 0
 
-    ACC = ACC + (mul_res << (acc_shift_imm * WLEN / 4))
+    ACC = ACC + (mul_res << acc_shift_imm)
 
     if writeback_variant == 'shiftout':
       if d_hwsel == 'L':
@@ -746,6 +745,7 @@
       doc: |
         Offset value.
         Must be WLEN-aligned.
+      type: simm<<4
     - name: grs1_inc
       type: option(++)
       doc: |
@@ -816,6 +816,7 @@
       doc: |
         Offset value.
         Must be WLEN-aligned.
+      type: simm<<4
     - name: grs1_inc
       type: option(++)
       doc: |

--- a/hw/ip/otbn/data/enc-schemes.yml
+++ b/hw/ip/otbn/data/enc-schemes.yml
@@ -23,11 +23,8 @@
 #         ignored (to make it easier to show grouping) and 'x' means don't
 #         care.
 #
-#  shift: Optional. If specified, this is the number of bits to shift the
-#         encoded value left to get the logical value.
-#
-# For brevity, if value and shift have their default values, the bits string
-# can be used as the value for the field.
+# For brevity, if there's no literal value, the field can be represented as
+# just its bits string.
 #
 # A scheme can inherit from other schemes by listing their names in a 'parents'
 # attribute. If the child scheme needs to set the value of a parents' field to
@@ -109,9 +106,7 @@ B:
     - rv
     - funct3
   fields:
-    imm:
-      bits: 31,7,30-25,11-8
-      shift: 1
+    imm: 31,7,30-25,11-8
     rs2: 24-20
     rs1: 19-15
 
@@ -120,9 +115,7 @@ U:
   parents:
     - rv
   fields:
-    imm:
-      bits: 31-12
-      shift: 12
+    imm: 31-12
     rd: 11-7
 
 # RISC-V "J-type" encoding (like U, but different immediate layout; used for
@@ -131,9 +124,7 @@ J:
   parents:
     - rv
   fields:
-    imm:
-      bits: 31,19-12,20,30-21
-      shift: 1
+    imm: 31,19-12,20,30-21
     rd: 11-7
 
 # A partial scheme for custom instructions with opcode b00010
@@ -285,9 +276,7 @@ bnaq:
     dh: 29
     qs2: 28-27
     qs1: 26-25
-    acc:
-      bits: 14-13
-      shift: 6
+    acc: 14-13
     z: 12
 
 # Unusual scheme used for bn.rshi (the immediate bleeds into the usual funct3
@@ -328,9 +317,7 @@ bnxid:
     - custom0
     - funct3
   fields:
-    imm:
-      bits: 24-22,31-25
-      shift: 4
+    imm: 24-22,31-25
     spp: 21
     dpp: 20
     rs: 19-15

--- a/hw/ip/otbn/data/insns.yml
+++ b/hw/ip/otbn/data/insns.yml
@@ -108,11 +108,15 @@ encoding-schemes: enc-schemes.yml
 #
 #  wsr:       The name of a WSR. Syntax "wsr" (always considered a destination)
 #
-#  simm:      A signed immediate operand. Syntax "simm<n>" where n is the
-#             number of bits or just simm for an unspecified width.
+#  simm:      A signed immediate operand. The full syntax is simm12<<3 to mean
+#             a signed immediate of width 12 which must be divisible by 2**3
+#             and is encoded by shifting right by 3. If there is no shift, the
+#             syntax simm12 is the same as simm12<<0. Similarly, if there is no
+#             known width (which should be inferred from any encoding scheme),
+#             it can be written as just simm or simm<<3.
 #
-#  uimm:      An unsigned immediate operand. Syntax "uimm<n>" where n is the
-#             number of bits or just uimm for an unspecified width.
+#  uimm:      An unsigned immediate operand. Syntax as with simm, but starting
+#             with "uimm".
 #
 #  enum:      An immediate with weird syntax. The syntax is "enum(a,b,c,d)"
 #             where a..d are the different possible syntaxes that can be used.

--- a/hw/ip/otbn/util/otbn-as
+++ b/hw/ip/otbn/util/otbn-as
@@ -268,24 +268,28 @@ def find_rv_encoding(enc: Encoding,
 
         # Try to find a non-fixed field in rvfmt with the same bit ranges as
         # those in the encoding field.
-        match_fmt = None
-        for rv_name, (fmt, _, rv_bits) in rvfmt.op_data.items():
+        match = None
+        for rv_name, (fmt, shift, rv_bits) in rvfmt.op_data.items():
             if fmt == 'f':
                 continue
             if field.scheme_field.bits == rv_bits:
-                match_fmt = fmt
+                match = (fmt, shift)
                 break
 
         # If we didn't find a field in rvfmt for this field, we've failed.
-        if match_fmt is None:
+        if match is None:
             return None
 
+        fmt, shift = match
+
         # These "difficult" operands can only be encoded in immediate fields of
-        # the correct sign.
-        if match_fmt == 'i':
+        # the correct shift and sign.
+        if shift != op_type.shift:
+            return None
+        if fmt == 'i':
             if not op_type.signed:
                 return None
-        elif match_fmt == 'u':
+        elif fmt == 'u':
             if op_type.signed:
                 return None
         else:
@@ -622,7 +626,8 @@ class Transformer:
         assert insn.encoding is not None
 
         # Generate a mapping from operand name to an integer value. Note that
-        # read_index checks that the value fits in the operand type.
+        # read_index checks that the value fits in the operand type and
+        # converts to the value that should be encoded.
         op_to_idx = {}
         for op_name, expr in op_to_expr.items():
             op = insn.name_to_operand[op_name]

--- a/hw/ip/otbn/util/shared/encoding.py
+++ b/hw/ip/otbn/util/shared/encoding.py
@@ -163,31 +163,20 @@ class Encoding:
             # optional operand, we might not have one, and just encode zero.
             field_val = op_to_idx.get(field.value, 0)
 
-            # Are there any low bits that shouldn't be there?
-            shift_mask = (1 << field.scheme_field.shift) - 1
-            if field_val & shift_mask:
-                raise ValueError("operand field {} has a shift of {}, "
-                                 "so can't represent the value {:#x}."
-                                 .format(field.value,
-                                         field.scheme_field.shift,
-                                         field_val))
-
-            shifted = field_val >> field.scheme_field.shift
+            # The encoding process should already have converted anything
+            # negative to a 2's complement representation.
+            assert field_val >= 0
 
             # Is the number too big? At the moment, we are assuming immediates
             # are unsigned (because the OTBN big number instructions all have
             # unsigned immediates).
-            if shifted >> field.scheme_field.bits.width:
-                shift_msg = ((' (shifted right by {} bits from {:#x})'
-                              .format(field.scheme_field.shift, field_val))
-                             if field.scheme_field.shift
-                             else '')
+            if field_val >> field.scheme_field.bits.width:
                 raise ValueError("operand field {} has a width of {}, "
-                                 "so can't represent the value {:#x}{}."
+                                 "so can't represent the value {:#x}."
                                  .format(field.value,
                                          field.scheme_field.bits.width,
-                                         shifted, shift_msg))
+                                         field_val))
 
-            val |= field.scheme_field.bits.encode(shifted)
+            val |= field.scheme_field.bits.encode(field_val)
 
         return val

--- a/hw/ip/otbn/util/shared/encoding_scheme.py
+++ b/hw/ip/otbn/util/shared/encoding_scheme.py
@@ -16,23 +16,18 @@ class EncSchemeField:
     '''Represents a single field in an encoding scheme'''
     def __init__(self,
                  bits: BitRanges,
-                 value: Optional[BoolLiteral],
-                 shift: int) -> None:
+                 value: Optional[BoolLiteral]) -> None:
         self.bits = bits
         self.value = value
-        self.shift = shift
 
     @staticmethod
     def from_yaml(yml: object, what: str) -> 'EncSchemeField':
         # This is either represented as a dict in the YAML or as a bare string.
         bits_what = 'bits for {}'.format(what)
         value_what = 'value for {}'.format(what)
-        shift_what = 'shift for {}'.format(what)
-
-        shift = 0
 
         if isinstance(yml, dict):
-            yd = check_keys(yml, what, ['bits'], ['value', 'shift'])
+            yd = check_keys(yml, what, ['bits'], ['value'])
 
             bits_yml = yd['bits']
             if not (isinstance(bits_yml, str) or isinstance(bits_yml, int)):
@@ -54,27 +49,6 @@ class EncSchemeField:
                                              type(val_yml).__name__))
                 raw_value = val_yml
 
-            # shift, on the other hand, is written in base 10. Allow an
-            # integer.
-            shift_yml = yd.get('shift')
-            if shift_yml is None:
-                pass
-            elif isinstance(shift_yml, str):
-                if not re.match(r'[0-9]+$', shift_yml):
-                    raise ValueError('{} is {!r} but should be a '
-                                     'non-negative integer.'
-                                     .format(shift_what, shift_yml))
-                shift = int(shift_yml)
-            elif isinstance(shift_yml, int):
-                if shift_yml < 0:
-                    raise ValueError('{} is {!r} but should be a '
-                                     'non-negative integer.'
-                                     .format(shift_what, shift_yml))
-                shift = shift_yml
-            else:
-                raise ValueError("{} is of type {}, but must be a string "
-                                 "or non-negative integer."
-                                 .format(shift_what, type(shift_yml).__name__))
         elif isinstance(yml, str) or isinstance(yml, int):
             bits_yml = yml
             raw_value = None
@@ -97,7 +71,7 @@ class EncSchemeField:
                                  'a value with width {}.'
                                  .format(what, bits.width, value.width))
 
-        return EncSchemeField(bits, value, shift)
+        return EncSchemeField(bits, value)
 
 
 class EncSchemeImport:
@@ -169,9 +143,7 @@ class EncSchemeImport:
                                  .format(what, name, self.parent,
                                          literal.width, old_field.bits.width))
 
-            fields[name] = EncSchemeField(old_field.bits,
-                                          literal,
-                                          old_field.shift)
+            fields[name] = EncSchemeField(old_field.bits, literal)
 
         # Copy anything else
         op_fields = set()


### PR DESCRIPTION
This PR has two commits. The first is a tidy-up patch, making the way we handle widths in the encoding and operands more sensible. The second is the more interesting one. It's commit message is below.

This PR closes #3195 and closes #3201 (both with the second commit).

**[otbn] Move shift information from encoding to operand**

Some operands get encoded with a "shift". For example, the following
line of assembly

    bn.mulqacc w30.1, w25.0, 64

has an `acc_shift_imm` operand of `64`. This is actually encoded as `1`: the
operand is shifted down by `6` bits before encoding.

This sort of thing is supported by the RISC-V instruction set too, and
their ISA specifies these shifts as part of the list of encoding
schemes. Until now, we did the same thing (copying them!)

In general, there are two jobs that need doing when converting from
the string representation in the assembly file to a number that can be
put in the encoding.

  - 2's complement encoding for signed immediates
  - Shifting down appropriately

Before this commit, the signedness information for an operand was
stored on the `OperandType` object and the shift was stored on the
`EncSchemeField` object. This is a bit silly: surely it would make more
sense to put them together! In fact, it's worse: we could specify a
register operand with a shift. With a shift of `1`, you'd be able to
write `x0`, `x2`, `x4` and `x62`(!) but not `x1` or `x3`.

So this commit moves the shift to the `OperandType` object. Now our
`OperandType.read_index` function does both of the jobs above, and it is
the inverse operation of `OperandType.render_val`. Much nicer!

As a bonus, this now means it's easy for an operand's type to be more
precise about the range of values it supports. So `acc_shift_imm` used
to say "Valid range: 0..3". Now it says "Valid range: 0..196 in steps
of 64".

While writing this patch, I noticed that `OperandType.read_index` also
didn't support signed operands correctly, which this also fixes.

As a sanity check, I compared the assembled (and disassembled) code
snippet examples before and after this patch. The assembled snippets
are identical. The differences in the objdump disassembly are exactly
from fixing the rendering of shifted operands as in the example above.

Similarly, the only differences in generated documentation are from
the fixed ranges described above and a fixed text string for `mulqacc`'s
`acc_shift_imm` operand.

