### PR TITLE
[dv/IPs] change from using apply_reset to dut_init

### DIFF
--- a/hw/ip/gpio/dv/env/seq_lib/gpio_full_random_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_full_random_vseq.sv
@@ -85,7 +85,7 @@ class gpio_full_random_vseq extends gpio_random_long_reg_writes_reg_reads_vseq;
           `DV_CHECK_MEMBER_RANDOMIZE_FATAL(delay)
           cfg.clk_rst_vif.wait_clks(delay);
           csr_utils_pkg::wait_no_outstanding_access();
-          apply_reset("HARD");
+          dut_init("HARD");
           data_out = '0;
           data_oe  = '0;
         end

--- a/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_sanity_vseq.sv
+++ b/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_sanity_vseq.sv
@@ -114,7 +114,7 @@ class rv_timer_sanity_vseq extends rv_timer_base_vseq;
             if (assert_reset) begin
               `DV_CHECK_MEMBER_RANDOMIZE_FATAL(delay)
               cfg.clk_rst_vif.wait_clks(delay);
-              apply_reset("HARD");
+              dut_init("HARD");
             end
           join_none
 


### PR DESCRIPTION
In daily regression, there are failures for GPIO and RV_TIMER as below:
`7175067 ps: (tl_host_driver.sv:50) uvm_test_top.env.m_tl_agent.driver [uvm_test_top.env.m_tl_agent.driver] Check failed seq_item_port.has_do_available() == 0 (1 [0x1] vs 0 [0x0])`

In GPIO and RV_TIMER, there are similar issues as PR#3198.
Directly using apply_reset will cause a race condition for the check
`seq_item.hasdo_available`.This PR changes from `apply_reset` to
`dut_init` to avoid this issue.

Signed-off-by: Cindy Chen <chencindy@google.com>