### PR TITLE
[top, clkmgr] Enable divided clocks in design

### DIFF
--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -73,12 +73,12 @@
         unique: no
         clocks:
         {
-          clk_io_powerup: io
+          clk_io_div4_powerup: io_div4
           clk_aon_powerup: aon
           clk_main_powerup: main
+          clk_io_powerup: io
           clk_usb_powerup: usb
           clk_io_div2_powerup: io_div2
-          clk_io_div4_powerup: io_div4
         }
       }
       {
@@ -101,7 +101,7 @@
         clocks:
         {
           clk_main_infra: main
-          clk_io_infra: io
+          clk_io_div4_infra: io_div4
         }
       }
       {
@@ -111,8 +111,9 @@
         unique: no
         clocks:
         {
-          clk_io_secure: io
+          clk_io_div4_secure: io_div4
           clk_main_secure: main
+          clk_aon_secure: aon
         }
       }
       {
@@ -122,7 +123,7 @@
         unique: no
         clocks:
         {
-          clk_io_peri: io
+          clk_io_div4_peri: io_div4
           clk_usb_peri: usb
         }
       }
@@ -133,7 +134,7 @@
         unique: no
         clocks:
         {
-          clk_io_timers: io
+          clk_io_div4_timers: io_div4
         }
       }
       {
@@ -224,7 +225,15 @@
         type: top
         domain: "0"
         parent: lc_src
-        clk: io_div2
+        clk: main
+      }
+      {
+        name: lc_io
+        gen: true
+        type: top
+        domain: "0"
+        parent: lc_src
+        clk: io_div4
       }
       {
         name: sys
@@ -241,6 +250,14 @@
         domain: "0"
         parent: sys_src
         clk: io_div2
+      }
+      {
+        name: sys_io_div4
+        gen: true
+        type: top
+        domain: "0"
+        parent: sys_src
+        clk: io_div4
       }
       {
         name: sys_aon
@@ -278,18 +295,18 @@
       type: uart
       clock_srcs:
       {
-        clk_i: io
+        clk_i: io_div4
       }
       reset_connections:
       {
-        rst_ni: sys_io
+        rst_ni: sys_io_div4
       }
       base_addr: 0x40000000
       clock_reset_export: []
       clock_group: secure
       clock_connections:
       {
-        clk_i: clkmgr_clocks.clk_io_secure
+        clk_i: clkmgr_clocks.clk_io_div4_secure
       }
       size: 0x1000
       bus_device: tlul
@@ -435,18 +452,18 @@
       type: gpio
       clock_srcs:
       {
-        clk_i: io
+        clk_i: io_div4
       }
       clock_group: peri
       reset_connections:
       {
-        rst_ni: sys_io
+        rst_ni: sys_io_div4
       }
       base_addr: 0x40010000
       clock_reset_export: []
       clock_connections:
       {
-        clk_i: clkmgr_clocks.clk_io_peri
+        clk_i: clkmgr_clocks.clk_io_div4_peri
       }
       size: 0x1000
       bus_device: tlul
@@ -501,7 +518,7 @@
       type: spi_device
       clock_srcs:
       {
-        clk_i: io
+        clk_i: io_div4
       }
       clock_group: peri
       reset_connections:
@@ -512,7 +529,7 @@
       clock_reset_export: []
       clock_connections:
       {
-        clk_i: clkmgr_clocks.clk_io_peri
+        clk_i: clkmgr_clocks.clk_io_div4_peri
       }
       size: 0x1000
       bus_device: tlul
@@ -784,18 +801,18 @@
       type: rv_timer
       clock_srcs:
       {
-        clk_i: io
+        clk_i: io_div4
       }
       clock_group: timers
       reset_connections:
       {
-        rst_ni: sys_io
+        rst_ni: sys_io_div4
       }
       base_addr: 0x40080000
       clock_reset_export: []
       clock_connections:
       {
-        clk_i: clkmgr_clocks.clk_io_timers
+        clk_i: clkmgr_clocks.clk_io_div4_timers
       }
       size: 0x1000
       bus_device: tlul
@@ -1046,13 +1063,13 @@
       clock_srcs:
       {
         clk_i: main
-        clk_aon_i: io
+        clk_aon_i: aon
       }
       clock_group: secure
       reset_connections:
       {
         rst_ni: sys
-        rst_aon_ni: sys_io
+        rst_aon_ni: sys_aon
       }
       base_addr: 0x40070000
       generated: "true"
@@ -1060,7 +1077,7 @@
       clock_connections:
       {
         clk_i: clkmgr_clocks.clk_main_secure
-        clk_aon_i: clkmgr_clocks.clk_io_secure
+        clk_aon_i: clkmgr_clocks.clk_aon_secure
       }
       size: 0x1000
       bus_device: tlul
@@ -1301,7 +1318,7 @@
       type: pwrmgr
       clock_srcs:
       {
-        clk_i: io
+        clk_i: io_div4
         clk_slow_i: aon
       }
       clock_group: powerup
@@ -1315,7 +1332,7 @@
       clock_reset_export: []
       clock_connections:
       {
-        clk_i: clkmgr_clocks.clk_io_powerup
+        clk_i: clkmgr_clocks.clk_io_div4_powerup
         clk_slow_i: clkmgr_clocks.clk_aon_powerup
       }
       size: 0x1000
@@ -1463,7 +1480,7 @@
       type: rstmgr
       clock_srcs:
       {
-        clk_i: io
+        clk_i: io_div4
         clk_aon_i: aon
         clk_main_i: main
         clk_io_i: io
@@ -1481,7 +1498,7 @@
       clock_reset_export: []
       clock_connections:
       {
-        clk_i: clkmgr_clocks.clk_io_powerup
+        clk_i: clkmgr_clocks.clk_io_div4_powerup
         clk_aon_i: clkmgr_clocks.clk_aon_powerup
         clk_main_i: clkmgr_clocks.clk_main_powerup
         clk_io_i: clkmgr_clocks.clk_io_powerup
@@ -1592,7 +1609,7 @@
       type: clkmgr
       clock_srcs:
       {
-        clk_i: io
+        clk_i: io_div4
       }
       clock_group: powerup
       reset_connections:
@@ -1609,7 +1626,7 @@
       clock_reset_export: []
       clock_connections:
       {
-        clk_i: clkmgr_clocks.clk_io_powerup
+        clk_i: clkmgr_clocks.clk_io_div4_powerup
       }
       size: 0x1000
       bus_device: tlul
@@ -1836,7 +1853,7 @@
       type: usbdev
       clock_srcs:
       {
-        clk_i: io
+        clk_i: io_div4
         clk_usb_48mhz_i: usb
       }
       clock_group: peri
@@ -1846,13 +1863,13 @@
       ]
       reset_connections:
       {
-        rst_ni: sys_io
+        rst_ni: sys_io_div4
         rst_usb_48mhz_ni: usb
       }
       base_addr: 0x40150000
       clock_connections:
       {
-        clk_i: clkmgr_clocks.clk_io_peri
+        clk_i: clkmgr_clocks.clk_io_div4_peri
         clk_usb_48mhz_i: clkmgr_clocks.clk_usb_peri
       }
       size: 0x1000
@@ -2158,7 +2175,7 @@
       type: sensor_ctrl
       clock_srcs:
       {
-        clk_i: io
+        clk_i: io_div4
       }
       clock_group: secure
       clock_reset_export:
@@ -2167,13 +2184,13 @@
       ]
       reset_connections:
       {
-        rst_ni: sys_io
+        rst_ni: sys_io_div4
       }
       base_addr: 0x40170000
       top_only: "true"
       clock_connections:
       {
-        clk_i: clkmgr_clocks.clk_io_secure
+        clk_i: clkmgr_clocks.clk_io_div4_secure
       }
       size: 0x1000
       bus_device: tlul
@@ -2414,12 +2431,12 @@
       name: ram_ret
       clock_srcs:
       {
-        clk_i: io
+        clk_i: io_div4
       }
       clock_group: infra
       reset_connections:
       {
-        rst_ni: sys_io
+        rst_ni: sys_io_div4
       }
       type: ram_1p
       base_addr: 0x18000000
@@ -2442,7 +2459,7 @@
       clock_reset_export: []
       clock_connections:
       {
-        clk_i: clkmgr_clocks.clk_io_infra
+        clk_i: clkmgr_clocks.clk_io_div4_infra
       }
     }
     {
@@ -2644,20 +2661,20 @@
       clock_srcs:
       {
         clk_main_i: main
-        clk_fixed_i: io
+        clk_fixed_i: io_div4
       }
       clock_group: infra
       reset: rst_main_ni
       reset_connections:
       {
         rst_main_ni: sys
-        rst_fixed_ni: sys_io
+        rst_fixed_ni: sys_io_div4
       }
       clock_reset_export: []
       clock_connections:
       {
         clk_main_i: clkmgr_clocks.clk_main_infra
-        clk_fixed_i: clkmgr_clocks.clk_io_infra
+        clk_fixed_i: clkmgr_clocks.clk_io_div4_infra
       }
       connections:
       {
@@ -3221,18 +3238,18 @@
       name: peri
       clock_srcs:
       {
-        clk_peri_i: io
+        clk_peri_i: io_div4
       }
       clock_group: infra
       reset: rst_peri_ni
       reset_connections:
       {
-        rst_peri_ni: sys_io
+        rst_peri_ni: sys_io_div4
       }
       clock_reset_export: []
       clock_connections:
       {
-        clk_peri_i: clkmgr_clocks.clk_io_infra
+        clk_peri_i: clkmgr_clocks.clk_io_div4_infra
       }
       connections:
       {
@@ -4629,12 +4646,12 @@
     {
       usbdev:
       [
-        io_peri
+        io_div4_peri
         usb_peri
       ]
       sensor_ctrl:
       [
-        io_secure
+        io_div4_secure
       ]
     }
   }
@@ -4648,8 +4665,10 @@
     por_io_div4: rstmgr_resets.rst_por_io_div4_n
     por_usb: rstmgr_resets.rst_por_usb_n
     lc: rstmgr_resets.rst_lc_n
+    lc_io: rstmgr_resets.rst_lc_io_n
     sys: rstmgr_resets.rst_sys_n
     sys_io: rstmgr_resets.rst_sys_io_n
+    sys_io_div4: rstmgr_resets.rst_sys_io_div4_n
     sys_aon: rstmgr_resets.rst_sys_aon_n
     spi_device: rstmgr_resets.rst_spi_device_n
     usb: rstmgr_resets.rst_usb_n
@@ -4660,12 +4679,12 @@
     {
       usbdev:
       [
-        sys_io
+        sys_io_div4
         usb
       ]
       sensor_ctrl:
       [
-        sys_io
+        sys_io_div4
       ]
     }
   }

--- a/hw/top_earlgrey/data/clocks.xdc
+++ b/hw/top_earlgrey/data/clocks.xdc
@@ -1,0 +1,22 @@
+## Copyright lowRISC contributors.
+## Licensed under the Apache License, Version 2.0, see LICENSE for details.
+## SPDX-License-Identifier: Apache-2.0
+
+## Clock Signal
+create_clock -add -name sys_clk_pin -period 10.00 -waveform {0 5} [get_ports IO_CLK]
+
+## Clock Domain Crossings
+set clks_50_unbuf [get_clocks -of_objects [get_pin clkgen/pll/CLKOUT0]]
+set clks_48_unbuf [get_clocks -of_objects [get_pin clkgen/pll/CLKOUT1]]
+
+## Divided clock
+## This is not really recommended per Vivado's guidelines, but hopefully these clocks are slow enough and their
+## destination flops few enough.
+
+set div2_cell [get_cells top_earlgrey/u_clkmgr/u_io_div2_div/gen_div2.u_div2/gen_generic.u_impl_generic/q_o_reg[0]]
+create_generated_clock -name clk_io_div2 -source [get_pin ${div2_cell}/C] -divide_by 2 [get_pin ${div2_cell}/Q]
+
+set div4_cell [get_cells top_earlgrey/u_clkmgr/u_io_div4_div/gen_div.clk_int_reg]
+create_generated_clock -name clk_io_div4 -source [get_pin ${div4_cell}/C] -divide_by 4 [get_pin ${div4_cell}/Q]
+
+set_clock_groups -group ${clks_50_unbuf} -group ${clks_48_unbuf} -group clk_io_div2 -group clk_io_div4 -asynchronous

--- a/hw/top_earlgrey/data/pins_cw305.xdc
+++ b/hw/top_earlgrey/data/pins_cw305.xdc
@@ -3,12 +3,9 @@
 
 ## Clock Signal
 set_property -dict { PACKAGE_PIN N13 IOSTANDARD LVCMOS33 } [get_ports { IO_CLK }]
-create_clock -add -name sys_clk_pin -period 10.00 -waveform {0 5} [get_ports IO_CLK]
 
-## Clock Domain Crossings
-create_generated_clock -name clk_50_unbuf -source [get_pin clkgen/pll/CLKIN1] [get_pin clkgen/pll/CLKOUT0]
-create_generated_clock -name clk_48_unbuf -source [get_pin clkgen/pll/CLKIN1] [get_pin clkgen/pll/CLKOUT1]
-set_clock_groups -group clk_50_unbuf -group clk_48_unbuf -asynchronous
+## Clock constraints
+## set via clocks.xdc
 
 ## LEDs
 set_property -dict { PACKAGE_PIN T2  DRIVE 8 IOSTANDARD LVCMOS33 } [get_ports { IO_GP8 }]

--- a/hw/top_earlgrey/data/pins_nexysvideo.xdc
+++ b/hw/top_earlgrey/data/pins_nexysvideo.xdc
@@ -6,10 +6,8 @@
 set_property -dict { PACKAGE_PIN R4    IOSTANDARD LVCMOS33 } [get_ports { IO_CLK }]; #IO_L13P_T2_MRCC_34 Sch=sysclk
 create_clock -add -name sys_clk_pin -period 10.00 -waveform {0 5} [get_ports IO_CLK]
 
-## Clock Domain Crossings
-create_generated_clock -name clk_50_unbuf -source [get_pin clkgen/pll/CLKIN1] [get_pin clkgen/pll/CLKOUT0]
-create_generated_clock -name clk_48_unbuf -source [get_pin clkgen/pll/CLKIN1] [get_pin clkgen/pll/CLKOUT1]
-set_clock_groups -group clk_50_unbuf -group clk_48_unbuf -asynchronous
+## Clock constraints
+## set via clocks.xdc
 
 ## Preserve prim_prince modules and setup multi-cycle paths
 ## These are no longer required, but kept here as a reference

--- a/hw/top_earlgrey/data/tb__xbar_connect.sv.tpl
+++ b/hw/top_earlgrey/data/tb__xbar_connect.sv.tpl
@@ -16,7 +16,7 @@ for xbar in top["xbar"]:
     clk_src[clk] = src
 
 clk_freq = OrderedDict()
-for clock in top["clocks"]["srcs"]:
+for clock in top["clocks"]["srcs"] + top["clocks"]["derived_srcs"]:
   if clock["name"] in clk_src.values():
     clk_freq[clock["name"]] = clock["freq"]
 

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -123,7 +123,7 @@
     // likely external or generated from a voltage comparator
     //
     nodes: [
-      { name: "rst_ni",      gen: false, type: "ext"                                                  }
+      { name: "rst_ni",      gen: false, type: "ext"                                                    }
       { name: "por_aon",     gen: false, type: "top",              parent: "rst_ni",  clk: "aon"        }
       { name: "lc_src",      gen: false, type: "int",              parent: "por",     clk: "io_div2"    }
       { name: "sys_src",     gen: false, type: "int",              parent: "por",     clk: "io_div2"    }
@@ -132,12 +132,14 @@
       { name: "por_io_div2", gen: true,  type: "top",              parent: "por_aon", clk: "io_div2"    }
       { name: "por_io_div4", gen: true , type: "top",              parent: "por_aon", clk: "io_div4"    }
       { name: "por_usb",     gen: true,  type: "top",              parent: "por_aon", clk: "usb"        }
-      { name: "lc",          gen: true,  type: "top", domain: "0", parent: "lc_src",  clk: "io_div2"    }
+      { name: "lc",          gen: true,  type: "top", domain: "0", parent: "lc_src",  clk: "main"       }
+      { name: "lc_io",       gen: true,  type: "top", domain: "0", parent: "lc_src",  clk: "io_div4"    }
       { name: "sys",         gen: true,  type: "top", domain: "0", parent: "sys_src", clk: "main"       }
       { name: "sys_io",      gen: true,  type: "top", domain: "0", parent: "sys_src", clk: "io_div2"    }
+      { name: "sys_io_div4", gen: true,  type: "top", domain: "0", parent: "sys_src", clk: "io_div4"    }
       { name: "sys_aon",     gen: true,  type: "top", domain: "0", parent: "sys_src", clk: "aon"        }
-      { name: "spi_device",  gen: true,  type: "top", domain: "0", parent: "sys_src", clk: "io_div2",  sw: 1 }
-      { name: "usb",         gen: true,  type: "top", domain: "0", parent: "sys_src", clk: "usb", sw: 1 }
+      { name: "spi_device",  gen: true,  type: "top", domain: "0", parent: "sys_src", clk: "io_div2", sw: 1 }
+      { name: "usb",         gen: true,  type: "top", domain: "0", parent: "sys_src", clk: "usb",     sw: 1 }
     ]
   }
 
@@ -157,26 +159,26 @@
       // clock connections defines the port to top level clock connection
       // the ip.hjson will declare the clock port names
       // If none are defined at ip.hjson, clk_i is used by default
-      clock_srcs: {clk_i: "io"},
+      clock_srcs: {clk_i: "io_div4"},
 
       // reset connections defines the port to top level reset connection
       // the ip.hjson will declare the reset port names
       // If none are defined at ip.hjson, rst_ni is used by default
-      reset_connections: {rst_ni: "sys_io"},
+      reset_connections: {rst_ni: "sys_io_div4"},
 
       base_addr: "0x40000000",
     },
     { name: "gpio",
       type: "gpio",
-      clock_srcs: {clk_i: "io"},
+      clock_srcs: {clk_i: "io_div4"},
       clock_group: "peri",
-      reset_connections: {rst_ni: "sys_io"},
+      reset_connections: {rst_ni: "sys_io_div4"},
       base_addr: "0x40010000",
     }
 
     { name: "spi_device",
       type: "spi_device",
-      clock_srcs: {clk_i: "io"},
+      clock_srcs: {clk_i: "io_div4"},
       clock_group: "peri",
       reset_connections: {rst_ni: "spi_device"},
       base_addr: "0x40020000",
@@ -190,9 +192,9 @@
     },
     { name: "rv_timer",
       type: "rv_timer",
-      clock_srcs: {clk_i: "io"},
+      clock_srcs: {clk_i: "io_div4"},
       clock_group: "timers",
-      reset_connections: {rst_ni: "sys_io"},
+      reset_connections: {rst_ni: "sys_io_div4"},
       base_addr: "0x40080000",
     },
     { name: "aes",
@@ -217,15 +219,18 @@
       base_addr: "0x40090000",
       generated: "true"         // Indicate this module is generated in the topgen
     }
+    // pinmux is currently allocated to main fabric,
+    // however this should probably be moved to peri fabric
     { name: "pinmux",
       type: "pinmux",
       clock: "main",
-      clock_srcs: {clk_i: "main", clk_aon_i: "io"},
+      clock_srcs: {clk_i: "main", clk_aon_i: "aon"},
       clock_group: "secure",
-      reset_connections: {rst_ni: "sys", rst_aon_ni: "sys_io"},
+      reset_connections: {rst_ni: "sys", rst_aon_ni: "sys_aon"},
       base_addr: "0x40070000",
       generated: "true"
     },
+    // see comment regarding pinmux above
     { name: "padctrl",
       type: "padctrl",
       clock: "main",
@@ -250,7 +255,7 @@
     }
     { name: "pwrmgr",
       type: "pwrmgr",
-      clock_srcs: {clk_i: "io", clk_slow_i: "aon"},
+      clock_srcs: {clk_i: "io_div4", clk_slow_i: "aon"},
       clock_group: "powerup",
       reset_connections: {rst_ni: "por", rst_slow_ni: "por_aon"},
       base_addr: "0x400A0000",
@@ -259,7 +264,7 @@
     },
     { name: "rstmgr",
       type: "rstmgr",
-      clock_srcs: {clk_i: "io", clk_aon_i: "aon", clk_main_i: "main", clk_io_i: "io", clk_usb_i: "usb",
+      clock_srcs: {clk_i: "io_div4", clk_aon_i: "aon", clk_main_i: "main", clk_io_i: "io", clk_usb_i: "usb",
                    clk_io_div2_i: "io_div2", clk_io_div4_i: "io_div4"},
       clock_group: "powerup",
       reset_connections: {rst_ni: "rst_ni"},
@@ -268,8 +273,7 @@
     },
     { name: "clkmgr",
       type: "clkmgr",
-      //clock_srcs: {clk_i: "io", clk_main_i: "main", clk_io_i: "io", clk_usb_i: "usb", clk_aon_i: "aon"},
-      clock_srcs: {clk_i: "io"},
+      clock_srcs: {clk_i: "io_div4"},
       clock_group: "powerup",
       reset_connections: {rst_ni: "por_io", rst_main_ni: "por", rst_io_ni: "por_io", rst_usb_ni: "por_usb"
                           rst_io_div2_ni: "por_io_div2", rst_io_div4_ni: "por_io_div4"},
@@ -287,18 +291,18 @@
     }
     { name: "usbdev",
       type: "usbdev",
-      clock_srcs: {clk_i: "io", clk_usb_48mhz_i: "usb"},
+      clock_srcs: {clk_i: "io_div4", clk_usb_48mhz_i: "usb"},
       clock_group: "peri",
       clock_reset_export: ["ast"],
-      reset_connections: {rst_ni: "sys_io", rst_usb_48mhz_ni: "usb"},
+      reset_connections: {rst_ni: "sys_io_div4", rst_usb_48mhz_ni: "usb"},
       base_addr: "0x40150000",
     },
     { name: "sensor_ctrl",
       type: "sensor_ctrl",
-      clock_srcs: {clk_i: "io"},
+      clock_srcs: {clk_i: "io_div4"},
       clock_group: "secure",
       clock_reset_export: ["ast"],
-      reset_connections: {rst_ni: "sys_io"},
+      reset_connections: {rst_ni: "sys_io_div4"},
       base_addr: "0x40170000",
       top_only: "true"
     },
@@ -348,9 +352,9 @@
       ]
     },
     { name: "ram_ret",
-      clock_srcs: {clk_i: "io"},
+      clock_srcs: {clk_i: "io_div4"},
       clock_group: "infra",
-      reset_connections: {rst_ni: "sys_io"},
+      reset_connections: {rst_ni: "sys_io_div4"},
       type: "ram_1p",
       base_addr: "0x18000000",
       size: "0x1000"
@@ -435,16 +439,16 @@
   // Assume xbar.hjson is located in the same directory of top.hjson
   xbar: [
     { name: "main",
-      clock_srcs: {clk_main_i: "main", clk_fixed_i: "io"},
+      clock_srcs: {clk_main_i: "main", clk_fixed_i: "io_div4"},
       clock_group: "infra",
       reset: "sys",
-      reset_connections: {rst_main_ni: "sys", rst_fixed_ni: "sys_io"}
+      reset_connections: {rst_main_ni: "sys", rst_fixed_ni: "sys_io_div4"}
     },
     { name: "peri",
-      clock_srcs: {clk_peri_i: "io"},
+      clock_srcs: {clk_peri_i: "io_div4"},
       clock_group: "infra",
-      reset: "sys_io",
-      reset_connections: {rst_peri_ni: "sys_io"},
+      reset: "sys_io_div4",
+      reset_connections: {rst_peri_ni: "sys_io_div4"},
     }
   ],
 

--- a/hw/top_earlgrey/dv/autogen/tb__xbar_connect.sv
+++ b/hw/top_earlgrey/dv/autogen/tb__xbar_connect.sv
@@ -24,8 +24,8 @@
 
 wire clk_main;
 clk_rst_if clk_rst_if_main(.clk(clk_main), .rst_n(rst_n));
-wire clk_io;
-clk_rst_if clk_rst_if_io(.clk(clk_io), .rst_n(rst_n));
+wire clk_io_div4;
+clk_rst_if clk_rst_if_io_div4(.clk(clk_io_div4), .rst_n(rst_n));
 
 tl_if corei_tl_if(clk_main, rst_n);
 tl_if cored_tl_if(clk_main, rst_n);
@@ -44,17 +44,17 @@ tl_if padctrl_tl_if(clk_main, rst_n);
 tl_if alert_handler_tl_if(clk_main, rst_n);
 tl_if nmi_gen_tl_if(clk_main, rst_n);
 tl_if otbn_tl_if(clk_main, rst_n);
-tl_if uart_tl_if(clk_io, rst_n);
-tl_if gpio_tl_if(clk_io, rst_n);
-tl_if spi_device_tl_if(clk_io, rst_n);
-tl_if rv_timer_tl_if(clk_io, rst_n);
-tl_if usbdev_tl_if(clk_io, rst_n);
-tl_if pwrmgr_tl_if(clk_io, rst_n);
-tl_if rstmgr_tl_if(clk_io, rst_n);
-tl_if clkmgr_tl_if(clk_io, rst_n);
-tl_if ram_ret_tl_if(clk_io, rst_n);
-tl_if sensor_ctrl_tl_if(clk_io, rst_n);
-tl_if ast_wrapper_tl_if(clk_io, rst_n);
+tl_if uart_tl_if(clk_io_div4, rst_n);
+tl_if gpio_tl_if(clk_io_div4, rst_n);
+tl_if spi_device_tl_if(clk_io_div4, rst_n);
+tl_if rv_timer_tl_if(clk_io_div4, rst_n);
+tl_if usbdev_tl_if(clk_io_div4, rst_n);
+tl_if pwrmgr_tl_if(clk_io_div4, rst_n);
+tl_if rstmgr_tl_if(clk_io_div4, rst_n);
+tl_if clkmgr_tl_if(clk_io_div4, rst_n);
+tl_if ram_ret_tl_if(clk_io_div4, rst_n);
+tl_if sensor_ctrl_tl_if(clk_io_div4, rst_n);
+tl_if ast_wrapper_tl_if(clk_io_div4, rst_n);
 
 initial begin
   bit xbar_mode;
@@ -67,13 +67,13 @@ initial begin
 
     clk_rst_if_main.set_active(.drive_rst_n_val(0));
     clk_rst_if_main.set_freq_khz(100000000 / 1000);
-    clk_rst_if_io.set_active(.drive_rst_n_val(0));
-    clk_rst_if_io.set_freq_khz(96000000 / 1000);
+    clk_rst_if_io_div4.set_active(.drive_rst_n_val(0));
+    clk_rst_if_io_div4.set_freq_khz(24000000 / 1000);
 
     // bypass clkmgr, force clocks directly
     force tb.dut.top_earlgrey.u_xbar_main.clk_main_i = clk_main;
-    force tb.dut.top_earlgrey.u_xbar_main.clk_fixed_i = clk_io;
-    force tb.dut.top_earlgrey.u_xbar_peri.clk_peri_i = clk_io;
+    force tb.dut.top_earlgrey.u_xbar_main.clk_fixed_i = clk_io_div4;
+    force tb.dut.top_earlgrey.u_xbar_peri.clk_peri_i = clk_io_div4;
 
     // bypass rstmgr, force resets directly
     force tb.dut.top_earlgrey.u_xbar_main.rst_main_ni = rst_n;

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -7,7 +7,7 @@ class chip_env_cfg extends cip_base_env_cfg #(.RAL_T(chip_reg_block));
   // Testbench settings
   bit                 stub_cpu;
   bit                 en_uart_logger;
-  int                 uart_baud_rate = uart_agent_pkg::BaudRate2Mbps;
+  int                 uart_baud_rate = uart_agent_pkg::BaudRate1Mbps;
   bit                 use_gpio_for_sw_test_status;
   bit                 initialize_ram;
 

--- a/hw/top_earlgrey/ip/ast/rtl/aon_osc.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/aon_osc.sv
@@ -24,9 +24,9 @@ module aon_osc #(
 
 // localparam real AON_CLK_PERIOD = 5000; // 5000ns (200Khz)
 // TBD
-// This is a temporary work-around until the design fully supports
-// async clocks as part of a different PR.
-localparam real AON_CLK_PERIOD = 20;
+// sped up to 200ns by default.
+// There should be a DV hook here so that the test can choose the actual frequency
+   localparam real AON_CLK_PERIOD = 200;
 
 logic init_start, clk;
 

--- a/hw/top_earlgrey/ip/ast/rtl/ast_wrapper.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_wrapper.sv
@@ -84,14 +84,14 @@ module ast_wrapper import ast_wrapper_pkg::*;
     .clk_ast_usb_i(clks_ast_i.clk_ast_usbdev_usb_peri),
     .clk_ast_es_i(1'b0),   // not yet in design
     // sensor control acts as both the alert interface and the tlul     // front-end
-    .clk_ast_alert_i(clks_ast_i.clk_ast_sensor_ctrl_io_secure),
-    .clk_ast_tlul_i(clks_ast_i.clk_ast_sensor_ctrl_io_secure),
+    .clk_ast_alert_i(clks_ast_i.clk_ast_sensor_ctrl_io_div4_secure),
+    .clk_ast_tlul_i(clks_ast_i.clk_ast_sensor_ctrl_io_div4_secure),
     .rst_ast_adc_ni(1'b0), // not yet in design
     .rst_ast_rng_ni(1'b0), // not yet in design
     .rst_ast_usb_ni(rsts_ast_i.rst_ast_usbdev_usb_n),
     .rst_ast_es_ni(1'b0),
-    .rst_ast_alert_ni(rsts_ast_i.rst_ast_sensor_ctrl_sys_io_n),
-    .rst_ast_tlul_ni(rsts_ast_i.rst_ast_sensor_ctrl_sys_io_n),
+    .rst_ast_alert_ni(rsts_ast_i.rst_ast_sensor_ctrl_sys_io_div4_n),
+    .rst_ast_tlul_ni(rsts_ast_i.rst_ast_sensor_ctrl_sys_io_div4_n),
 
     // tlul if
     .tl_i(bus_i),

--- a/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
+++ b/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
@@ -112,11 +112,11 @@
       fields: [
         {
           bits: "0",
-          name: "CLK_IO_PERI_EN",
+          name: "CLK_IO_DIV4_PERI_EN",
           resval: 1,
           desc: '''
-            0 CLK_IO_PERI is disabled.
-            1 CLK_IO_PERI is enabled.
+            0 CLK_IO_DIV4_PERI is disabled.
+            1 CLK_IO_DIV4_PERI is enabled.
           '''
         }
         {

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
@@ -100,12 +100,13 @@ module clkmgr import clkmgr_pkg::*; (
   // completely untouched. The only reason they are here is for easier
   // bundling management purposes through clocks_o
   ////////////////////////////////////////////////////
-  assign clocks_o.clk_io_powerup = clk_io_i;
+  assign clocks_o.clk_io_div4_powerup = clk_io_div4_i;
   assign clocks_o.clk_aon_powerup = clk_aon_i;
   assign clocks_o.clk_main_powerup = clk_main_i;
+  assign clocks_o.clk_io_powerup = clk_io_i;
   assign clocks_o.clk_usb_powerup = clk_usb_i;
   assign clocks_o.clk_io_div2_powerup = clk_io_div2_i;
-  assign clocks_o.clk_io_div4_powerup = clk_io_div4_i;
+  assign clocks_o.clk_aon_secure = clk_aon_i;
 
   ////////////////////////////////////////////////////
   // Root gating
@@ -204,33 +205,33 @@ module clkmgr import clkmgr_pkg::*; (
   // Clocks with only root gate
   ////////////////////////////////////////////////////
   assign clocks_o.clk_main_infra = clk_main_root;
-  assign clocks_o.clk_io_infra = clk_io_root;
-  assign clocks_o.clk_io_secure = clk_io_root;
+  assign clocks_o.clk_io_div4_infra = clk_io_div4_root;
+  assign clocks_o.clk_io_div4_secure = clk_io_div4_root;
   assign clocks_o.clk_main_secure = clk_main_root;
-  assign clocks_o.clk_io_timers = clk_io_root;
+  assign clocks_o.clk_io_div4_timers = clk_io_div4_root;
   assign clocks_o.clk_proc_main = clk_main_root;
 
   ////////////////////////////////////////////////////
   // Software direct control group
   ////////////////////////////////////////////////////
 
-  logic clk_io_peri_sw_en;
+  logic clk_io_div4_peri_sw_en;
   logic clk_usb_peri_sw_en;
 
   prim_flop_2sync #(
     .Width(1)
-  ) u_clk_io_peri_sw_en_sync (
-    .clk_i(clk_io_i),
-    .rst_ni(rst_io_ni),
-    .d_i(reg2hw.clk_enables.clk_io_peri_en.q),
-    .q_o(clk_io_peri_sw_en)
+  ) u_clk_io_div4_peri_sw_en_sync (
+    .clk_i(clk_io_div4_i),
+    .rst_ni(rst_io_div4_ni),
+    .d_i(reg2hw.clk_enables.clk_io_div4_peri_en.q),
+    .q_o(clk_io_div4_peri_sw_en)
   );
 
-  prim_clock_gating u_clk_io_peri_cg (
-    .clk_i(clk_io_i),
-    .en_i(clk_io_peri_sw_en & clk_io_en),
+  prim_clock_gating u_clk_io_div4_peri_cg (
+    .clk_i(clk_io_div4_i),
+    .en_i(clk_io_div4_peri_sw_en & clk_io_div4_en),
     .test_en_i(dft_i.test_en),
-    .clk_o(clocks_o.clk_io_peri)
+    .clk_o(clocks_o.clk_io_div4_peri)
   );
 
   prim_flop_2sync #(
@@ -330,9 +331,9 @@ module clkmgr import clkmgr_pkg::*; (
   // Exported clocks
   ////////////////////////////////////////////////////
 
-  assign clocks_ast_o.clk_ast_usbdev_io_peri = clocks_o.clk_io_peri;
+  assign clocks_ast_o.clk_ast_usbdev_io_div4_peri = clocks_o.clk_io_div4_peri;
   assign clocks_ast_o.clk_ast_usbdev_usb_peri = clocks_o.clk_usb_peri;
-  assign clocks_ast_o.clk_ast_sensor_ctrl_io_secure = clocks_o.clk_io_secure;
+  assign clocks_ast_o.clk_ast_sensor_ctrl_io_div4_secure = clocks_o.clk_io_div4_secure;
 
   ////////////////////////////////////////////////////
   // Assertions

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_pkg.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_pkg.sv
@@ -21,30 +21,31 @@ package clkmgr_pkg;
   };
 
   typedef struct packed {
-  logic clk_io_powerup;
+  logic clk_io_div4_powerup;
   logic clk_aon_powerup;
   logic clk_main_powerup;
+  logic clk_io_powerup;
   logic clk_usb_powerup;
   logic clk_io_div2_powerup;
-  logic clk_io_div4_powerup;
+  logic clk_aon_secure;
   logic clk_main_aes;
   logic clk_main_hmac;
   logic clk_main_otbn;
   logic clk_main_infra;
-  logic clk_io_infra;
-  logic clk_io_secure;
+  logic clk_io_div4_infra;
+  logic clk_io_div4_secure;
   logic clk_main_secure;
-  logic clk_io_timers;
+  logic clk_io_div4_timers;
   logic clk_proc_main;
-  logic clk_io_peri;
+  logic clk_io_div4_peri;
   logic clk_usb_peri;
 
   } clkmgr_out_t;
 
   typedef struct packed {
-    logic clk_ast_usbdev_io_peri;
+    logic clk_ast_usbdev_io_div4_peri;
     logic clk_ast_usbdev_usb_peri;
-    logic clk_ast_sensor_ctrl_io_secure;
+    logic clk_ast_sensor_ctrl_io_div4_secure;
   } clkmgr_ast_out_t;
 
   typedef struct packed {

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_pkg.sv
@@ -15,7 +15,7 @@ package clkmgr_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        q;
-    } clk_io_peri_en;
+    } clk_io_div4_peri_en;
     struct packed {
       logic        q;
     } clk_usb_peri_en;

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
@@ -71,9 +71,9 @@ module clkmgr_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
-  logic clk_enables_clk_io_peri_en_qs;
-  logic clk_enables_clk_io_peri_en_wd;
-  logic clk_enables_clk_io_peri_en_we;
+  logic clk_enables_clk_io_div4_peri_en_qs;
+  logic clk_enables_clk_io_div4_peri_en_wd;
+  logic clk_enables_clk_io_div4_peri_en_we;
   logic clk_enables_clk_usb_peri_en_qs;
   logic clk_enables_clk_usb_peri_en_wd;
   logic clk_enables_clk_usb_peri_en_we;
@@ -93,18 +93,18 @@ module clkmgr_reg_top (
   // Register instances
   // R[clk_enables]: V(False)
 
-  //   F[clk_io_peri_en]: 0:0
+  //   F[clk_io_div4_peri_en]: 0:0
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
     .RESVAL  (1'h1)
-  ) u_clk_enables_clk_io_peri_en (
+  ) u_clk_enables_clk_io_div4_peri_en (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (clk_enables_clk_io_peri_en_we),
-    .wd     (clk_enables_clk_io_peri_en_wd),
+    .we     (clk_enables_clk_io_div4_peri_en_we),
+    .wd     (clk_enables_clk_io_div4_peri_en_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -112,10 +112,10 @@ module clkmgr_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.clk_enables.clk_io_peri_en.q ),
+    .q      (reg2hw.clk_enables.clk_io_div4_peri_en.q ),
 
     // to register interface (read)
-    .qs     (clk_enables_clk_io_peri_en_qs)
+    .qs     (clk_enables_clk_io_div4_peri_en_qs)
   );
 
 
@@ -322,8 +322,8 @@ module clkmgr_reg_top (
     if (addr_hit[2] && reg_we && (CLKMGR_PERMIT[2] != (CLKMGR_PERMIT[2] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign clk_enables_clk_io_peri_en_we = addr_hit[0] & reg_we & ~wr_err;
-  assign clk_enables_clk_io_peri_en_wd = reg_wdata[0];
+  assign clk_enables_clk_io_div4_peri_en_we = addr_hit[0] & reg_we & ~wr_err;
+  assign clk_enables_clk_io_div4_peri_en_wd = reg_wdata[0];
 
   assign clk_enables_clk_usb_peri_en_we = addr_hit[0] & reg_we & ~wr_err;
   assign clk_enables_clk_usb_peri_en_wd = reg_wdata[1];
@@ -345,7 +345,7 @@ module clkmgr_reg_top (
     reg_rdata_next = '0;
     unique case (1'b1)
       addr_hit[0]: begin
-        reg_rdata_next[0] = clk_enables_clk_io_peri_en_qs;
+        reg_rdata_next[0] = clk_enables_clk_io_div4_peri_en_qs;
         reg_rdata_next[1] = clk_enables_clk_usb_peri_en_qs;
       end
 

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
@@ -196,10 +196,20 @@ module rstmgr import rstmgr_pkg::*; (
     .Width(1),
     .ResetValue('0)
   ) u_lc (
-    .clk_i(clk_io_div2_i),
+    .clk_i(clk_main_i),
     .rst_ni(rst_lc_src_n[0]),
     .d_i(1'b1),
     .q_o(resets_o.rst_lc_n)
+  );
+
+  prim_flop_2sync #(
+    .Width(1),
+    .ResetValue('0)
+  ) u_lc_io (
+    .clk_i(clk_io_div4_i),
+    .rst_ni(rst_lc_src_n[0]),
+    .d_i(1'b1),
+    .q_o(resets_o.rst_lc_io_n)
   );
 
   prim_flop_2sync #(
@@ -220,6 +230,16 @@ module rstmgr import rstmgr_pkg::*; (
     .rst_ni(rst_sys_src_n[0]),
     .d_i(1'b1),
     .q_o(resets_o.rst_sys_io_n)
+  );
+
+  prim_flop_2sync #(
+    .Width(1),
+    .ResetValue('0)
+  ) u_sys_io_div4 (
+    .clk_i(clk_io_div4_i),
+    .rst_ni(rst_sys_src_n[0]),
+    .d_i(1'b1),
+    .q_o(resets_o.rst_sys_io_div4_n)
   );
 
   prim_flop_2sync #(
@@ -285,9 +305,9 @@ module rstmgr import rstmgr_pkg::*; (
   ////////////////////////////////////////////////////
   // Exported resets                                //
   ////////////////////////////////////////////////////
-  assign resets_ast_o.rst_ast_usbdev_sys_io_n = resets_o.rst_sys_io_n;
+  assign resets_ast_o.rst_ast_usbdev_sys_io_div4_n = resets_o.rst_sys_io_div4_n;
   assign resets_ast_o.rst_ast_usbdev_usb_n = resets_o.rst_usb_n;
-  assign resets_ast_o.rst_ast_sensor_ctrl_sys_io_n = resets_o.rst_sys_io_n;
+  assign resets_ast_o.rst_ast_sensor_ctrl_sys_io_div4_n = resets_o.rst_sys_io_div4_n;
 
   ////////////////////////////////////////////////////
   // Assertions                                     //

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_pkg.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_pkg.sv
@@ -47,8 +47,10 @@ package rstmgr_pkg;
     logic rst_por_io_div4_n;
     logic rst_por_usb_n;
     logic rst_lc_n;
+    logic rst_lc_io_n;
     logic rst_sys_n;
     logic rst_sys_io_n;
+    logic rst_sys_io_div4_n;
     logic rst_sys_aon_n;
     logic rst_spi_device_n;
     logic rst_usb_n;
@@ -62,9 +64,9 @@ package rstmgr_pkg;
 
   // exported resets
   typedef struct packed {
-    logic rst_ast_usbdev_sys_io_n;
+    logic rst_ast_usbdev_sys_io_div4_n;
     logic rst_ast_usbdev_usb_n;
-    logic rst_ast_sensor_ctrl_sys_io_n;
+    logic rst_ast_sensor_ctrl_sys_io_div4_n;
   } rstmgr_ast_out_t;
 
   // default value for rstmgr_ast_rsp_t (for dangling ports)

--- a/hw/top_earlgrey/ip/xbar_main/data/autogen/xbar_main.gen.hjson
+++ b/hw/top_earlgrey/ip/xbar_main/data/autogen/xbar_main.gen.hjson
@@ -11,20 +11,20 @@
   clock_srcs:
   {
     clk_main_i: main
-    clk_fixed_i: io
+    clk_fixed_i: io_div4
   }
   clock_group: infra
   reset: rst_main_ni
   reset_connections:
   {
     rst_main_ni: sys
-    rst_fixed_ni: sys_io
+    rst_fixed_ni: sys_io_div4
   }
   clock_reset_export: []
   clock_connections:
   {
     clk_main_i: clkmgr_clocks.clk_main_infra
-    clk_fixed_i: clkmgr_clocks.clk_io_infra
+    clk_fixed_i: clkmgr_clocks.clk_io_div4_infra
   }
   connections:
   {

--- a/hw/top_earlgrey/ip/xbar_peri/data/autogen/xbar_peri.gen.hjson
+++ b/hw/top_earlgrey/ip/xbar_peri/data/autogen/xbar_peri.gen.hjson
@@ -10,18 +10,18 @@
   name: peri
   clock_srcs:
   {
-    clk_peri_i: io
+    clk_peri_i: io_div4
   }
   clock_group: infra
   reset: rst_peri_ni
   reset_connections:
   {
-    rst_peri_ni: sys_io
+    rst_peri_ni: sys_io_div4
   }
   clock_reset_export: []
   clock_connections:
   {
-    clk_peri_i: clkmgr_clocks.clk_io_infra
+    clk_peri_i: clkmgr_clocks.clk_io_div4_infra
   }
   connections:
   {

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -473,8 +473,8 @@ module top_earlgrey #(
     .SramDw(32),
     .Outstanding(2)
   ) u_tl_adapter_ram_ret (
-    .clk_i   (clkmgr_clocks.clk_io_infra),
-    .rst_ni   (rstmgr_resets.rst_sys_io_n),
+    .clk_i   (clkmgr_clocks.clk_io_div4_infra),
+    .rst_ni   (rstmgr_resets.rst_sys_io_div4_n),
     .tl_i     (ram_ret_tl_req),
     .tl_o     (ram_ret_tl_rsp),
 
@@ -497,8 +497,8 @@ module top_earlgrey #(
     // TODO: enable parity once supported by the simulation infrastructure
     .EnableParity(0)
   ) u_ram1p_ram_ret (
-    .clk_i   (clkmgr_clocks.clk_io_infra),
-    .rst_ni   (rstmgr_resets.rst_sys_io_n),
+    .clk_i   (clkmgr_clocks.clk_io_div4_infra),
+    .rst_ni   (rstmgr_resets.rst_sys_io_div4_n),
 
     .req_i    (ram_ret_req),
     .write_i  (ram_ret_we),
@@ -578,8 +578,8 @@ module top_earlgrey #(
       // Inter-module signals
       .tl_i(uart_tl_req),
       .tl_o(uart_tl_rsp),
-      .clk_i (clkmgr_clocks.clk_io_secure),
-      .rst_ni (rstmgr_resets.rst_sys_io_n)
+      .clk_i (clkmgr_clocks.clk_io_div4_secure),
+      .rst_ni (rstmgr_resets.rst_sys_io_div4_n)
   );
 
   gpio u_gpio (
@@ -597,8 +597,8 @@ module top_earlgrey #(
       // Inter-module signals
       .tl_i(gpio_tl_req),
       .tl_o(gpio_tl_rsp),
-      .clk_i (clkmgr_clocks.clk_io_peri),
-      .rst_ni (rstmgr_resets.rst_sys_io_n)
+      .clk_i (clkmgr_clocks.clk_io_div4_peri),
+      .rst_ni (rstmgr_resets.rst_sys_io_div4_n)
   );
 
   spi_device u_spi_device (
@@ -624,7 +624,7 @@ module top_earlgrey #(
       .tl_i(spi_device_tl_req),
       .tl_o(spi_device_tl_rsp),
       .scanmode_i   (scanmode_i),
-      .clk_i (clkmgr_clocks.clk_io_peri),
+      .clk_i (clkmgr_clocks.clk_io_div4_peri),
       .rst_ni (rstmgr_resets.rst_spi_device_n)
   );
 
@@ -656,8 +656,8 @@ module top_earlgrey #(
       // Inter-module signals
       .tl_i(rv_timer_tl_req),
       .tl_o(rv_timer_tl_rsp),
-      .clk_i (clkmgr_clocks.clk_io_timers),
-      .rst_ni (rstmgr_resets.rst_sys_io_n)
+      .clk_i (clkmgr_clocks.clk_io_div4_timers),
+      .rst_ni (rstmgr_resets.rst_sys_io_div4_n)
   );
 
   aes u_aes (
@@ -735,9 +735,9 @@ module top_earlgrey #(
       .dio_oe_o,
       .dio_in_i,
       .clk_i (clkmgr_clocks.clk_main_secure),
-      .clk_aon_i (clkmgr_clocks.clk_io_secure),
+      .clk_aon_i (clkmgr_clocks.clk_aon_secure),
       .rst_ni (rstmgr_resets.rst_sys_n),
-      .rst_aon_ni (rstmgr_resets.rst_sys_io_n)
+      .rst_aon_ni (rstmgr_resets.rst_sys_aon_n)
   );
 
   padctrl u_padctrl (
@@ -799,7 +799,7 @@ module top_earlgrey #(
       .rstreqs_i('0),
       .tl_i(pwrmgr_tl_req),
       .tl_o(pwrmgr_tl_rsp),
-      .clk_i (clkmgr_clocks.clk_io_powerup),
+      .clk_i (clkmgr_clocks.clk_io_div4_powerup),
       .clk_slow_i (clkmgr_clocks.clk_aon_powerup),
       .rst_ni (rstmgr_resets.rst_por_n),
       .rst_slow_ni (rstmgr_resets.rst_por_aon_n)
@@ -817,7 +817,7 @@ module top_earlgrey #(
       .resets_ast_o(rsts_ast_o),
       .tl_i(rstmgr_tl_req),
       .tl_o(rstmgr_tl_rsp),
-      .clk_i (clkmgr_clocks.clk_io_powerup),
+      .clk_i (clkmgr_clocks.clk_io_div4_powerup),
       .clk_aon_i (clkmgr_clocks.clk_aon_powerup),
       .clk_main_i (clkmgr_clocks.clk_main_powerup),
       .clk_io_i (clkmgr_clocks.clk_io_powerup),
@@ -842,7 +842,7 @@ module top_earlgrey #(
       .status_i(clkmgr_status),
       .tl_i(clkmgr_tl_req),
       .tl_o(clkmgr_tl_rsp),
-      .clk_i (clkmgr_clocks.clk_io_powerup),
+      .clk_i (clkmgr_clocks.clk_io_div4_powerup),
       .rst_ni (rstmgr_resets.rst_por_io_n),
       .rst_main_ni (rstmgr_resets.rst_por_n),
       .rst_io_ni (rstmgr_resets.rst_por_io_n),
@@ -917,9 +917,9 @@ module top_earlgrey #(
       .usb_ref_pulse_o(usbdev_usb_ref_pulse_o),
       .tl_i(usbdev_tl_req),
       .tl_o(usbdev_tl_rsp),
-      .clk_i (clkmgr_clocks.clk_io_peri),
+      .clk_i (clkmgr_clocks.clk_io_div4_peri),
       .clk_usb_48mhz_i (clkmgr_clocks.clk_usb_peri),
-      .rst_ni (rstmgr_resets.rst_sys_io_n),
+      .rst_ni (rstmgr_resets.rst_sys_io_div4_n),
       .rst_usb_48mhz_ni (rstmgr_resets.rst_usb_n)
   );
 
@@ -941,8 +941,8 @@ module top_earlgrey #(
       .ast_status_i(sensor_ctrl_ast_status_i),
       .tl_i(sensor_ctrl_tl_req),
       .tl_o(sensor_ctrl_tl_rsp),
-      .clk_i (clkmgr_clocks.clk_io_secure),
-      .rst_ni (rstmgr_resets.rst_sys_io_n)
+      .clk_i (clkmgr_clocks.clk_io_div4_secure),
+      .rst_ni (rstmgr_resets.rst_sys_io_div4_n)
   );
 
   otbn u_otbn (
@@ -1023,9 +1023,9 @@ module top_earlgrey #(
   // TL-UL Crossbar
   xbar_main u_xbar_main (
     .clk_main_i (clkmgr_clocks.clk_main_infra),
-    .clk_fixed_i (clkmgr_clocks.clk_io_infra),
+    .clk_fixed_i (clkmgr_clocks.clk_io_div4_infra),
     .rst_main_ni (rstmgr_resets.rst_sys_n),
-    .rst_fixed_ni (rstmgr_resets.rst_sys_io_n),
+    .rst_fixed_ni (rstmgr_resets.rst_sys_io_div4_n),
 
     // port: tl_corei
     .tl_corei_i(main_tl_corei_req),
@@ -1099,8 +1099,8 @@ module top_earlgrey #(
     .scanmode_i
   );
   xbar_peri u_xbar_peri (
-    .clk_peri_i (clkmgr_clocks.clk_io_infra),
-    .rst_peri_ni (rstmgr_resets.rst_sys_io_n),
+    .clk_peri_i (clkmgr_clocks.clk_io_div4_infra),
+    .rst_peri_ni (rstmgr_resets.rst_sys_io_div4_n),
 
     // port: tl_main
     .tl_main_i(main_tl_peri_req),

--- a/hw/top_earlgrey/rtl/top_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_asic.sv
@@ -244,10 +244,10 @@ module top_earlgrey_asic (
   top_earlgrey top_earlgrey (
     .rst_ni          ( rst_n         ),
     // ast connections
-    .clk_main_i      ( clk           ),
-    .clk_io_i        ( clk           ),
-    .clk_usb_i       ( clk_usb_48mhz ),
-    .clk_aon_i       ( clk           ),
+    .clk_main_i      ( ast_base_clks.clk_sys ),
+    .clk_io_i        ( ast_base_clks.clk_io  ),
+    .clk_usb_i       ( ast_base_clks.clk_usb ),
+    .clk_aon_i       ( ast_base_clks.clk_aon ),
     .clks_ast_o      ( clks_ast      ),
     .rstmgr_ast_i                ( ast_base_rst          ),
     .rsts_ast_o                  ( rsts_ast              ),

--- a/hw/top_earlgrey/rtl/top_earlgrey_verilator.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_verilator.sv
@@ -150,7 +150,7 @@ module top_earlgrey_verilator (
   // Both baud rate and frequency must match the settings used in the on-chip
   // software.
   uartdpi #(
-    .BAUD('d9_600),
+    .BAUD('d7_200),
     .FREQ('d500_000)
   ) u_uart (
     .clk_i  (clk_i),

--- a/hw/top_earlgrey/top_earlgrey_cw305.core
+++ b/hw/top_earlgrey/top_earlgrey_cw305.core
@@ -18,6 +18,7 @@ filesets:
   files_constraints:
     files:
       - data/pins_cw305.xdc
+      - data/clocks.xdc
     file_type: xdc
 
 parameters:

--- a/hw/top_earlgrey/top_earlgrey_nexysvideo.core
+++ b/hw/top_earlgrey/top_earlgrey_nexysvideo.core
@@ -15,6 +15,7 @@ filesets:
 
   files_constraints:
     files:
+      - data/clocks.xdc
       - data/pins_nexysvideo.xdc
       - data/placement.xdc
     file_type: xdc

--- a/sw/device/lib/arch/device_fpga_nexysvideo.c
+++ b/sw/device/lib/arch/device_fpga_nexysvideo.c
@@ -13,7 +13,7 @@ const device_type_t kDeviceType = kDeviceFpgaNexysVideo;
 
 const uint64_t kClockFreqCpuHz = 50 * 1000 * 1000;  // 50MHz
 
-const uint64_t kClockFreqPeripheralHz = 50 * 1000 * 1000;  // 50MHz
+const uint64_t kClockFreqPeripheralHz = 125 * 100 * 1000;  // 12.5MHz
 
 const uint64_t kClockFreqUsbHz = 48 * 1000 * 1000;  // 48MHz
 

--- a/sw/device/lib/arch/device_sim_dv.c
+++ b/sw/device/lib/arch/device_sim_dv.c
@@ -19,7 +19,7 @@ const uint64_t kClockFreqPeripheralHz = 24 * 1000 * 1000;  // 24MHz
 
 const uint64_t kClockFreqUsbHz = 48 * 1000 * 1000;  // 48MHz
 
-const uint64_t kUartBaudrate = 1 << 20;  // 1Mbps
+const uint64_t kUartBaudrate = 1 * (1 << 20);  // 1Mbps
 
 // No Device Stop Address in our DV simulator.
 const uintptr_t kDeviceStopAddress = 0;

--- a/sw/device/lib/arch/device_sim_dv.c
+++ b/sw/device/lib/arch/device_sim_dv.c
@@ -13,13 +13,13 @@ const device_type_t kDeviceType = kDeviceSimDV;
 // TODO: DV testbench completely randomizes these. Need to add code to
 // retrieve these from a preloaded memory location set by the testbench.
 
-const uint64_t kClockFreqCpuHz = 50 * 1000 * 1000;  // 50MHz
+const uint64_t kClockFreqCpuHz = 100 * 1000 * 1000;  // 100MHz
 
-const uint64_t kClockFreqPeripheralHz = 50 * 1000 * 1000;  // 50MHz
+const uint64_t kClockFreqPeripheralHz = 24 * 1000 * 1000;  // 24MHz
 
 const uint64_t kClockFreqUsbHz = 48 * 1000 * 1000;  // 48MHz
 
-const uint64_t kUartBaudrate = 2 * (1 << 20);  // 2Mib/s
+const uint64_t kUartBaudrate = 1 << 20;  // 1Mbps
 
 // No Device Stop Address in our DV simulator.
 const uintptr_t kDeviceStopAddress = 0;

--- a/sw/device/lib/arch/device_sim_verilator.c
+++ b/sw/device/lib/arch/device_sim_verilator.c
@@ -13,11 +13,11 @@ const device_type_t kDeviceType = kDeviceSimVerilator;
 
 const uint64_t kClockFreqCpuHz = 500 * 1000;  // 500kHz
 
-const uint64_t kClockFreqPeripheralHz = 500 * 1000;  // 500kHz
+const uint64_t kClockFreqPeripheralHz = 125 * 1000;  // 125kHz
 
 const uint64_t kClockFreqUsbHz = 500 * 1000;  // 500kHz
 
-const uint64_t kUartBaudrate = 9600;
+const uint64_t kUartBaudrate = 7200;
 
 // Defined in `hw/top_earlgrey/top_earlgrey_verilator.core`
 const uintptr_t kDeviceStopAddress = 0x10008000;

--- a/sw/device/tests/dif/dif_rv_timer_sanitytest.c
+++ b/sw/device/tests/dif/dif_rv_timer_sanitytest.c
@@ -86,8 +86,8 @@ bool test_main(void) {
   CHECK(dif_rv_timer_counter_set_enabled(&timer, kHart, kDifRvTimerEnabled) ==
         kDifRvTimerOk);
 
+  LOG_INFO("Waiting...");
   while (!irq_fired) {
-    LOG_INFO("Waiting...");
     wait_for_interrupt();
   }
 

--- a/sw/device/tests/sim_dv/uart_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/uart_tx_rx_test.c
@@ -14,6 +14,7 @@
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/testing/test_main.h"
 #include "sw/device/lib/testing/test_status.h"
+
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 #define UART_DATASET_SIZE 128
@@ -417,7 +418,12 @@ static bool execute_test(const dif_uart_t *uart) {
     }
 
     // Wait for the next interrupt to arrive.
-    wait_for_interrupt();
+    // This check here is necessary as rx interrupts may sometimes occur ahead
+    // of tx interrupts.  When this happens, the tx handling code above is not
+    // triggerd and as a result an unexpected tx_empty interrupt is fired later.
+    if (!uart_irq_rx_watermark_fired && !uart_irq_tx_watermark_fired) {
+      wait_for_interrupt();
+    }
   }
 
   // Check data consistency.

--- a/sw/host/spiflash/ftdi_spi_interface.h
+++ b/sw/host/spiflash/ftdi_spi_interface.h
@@ -44,7 +44,7 @@ class FtdiSpiInterface : public SpiInterface {
 
     /** FTDI Configuration. This can be made configurable later on if needed.
      * Default value is 1MHz. */
-    int32_t spi_frequency = 1000000;
+    int32_t spi_frequency = 400000;
   };
 
   explicit FtdiSpiInterface(Options options);


### PR DESCRIPTION
This works for DV / verilator, and MAYBE for FPGA (i'm not able to try).
This PR is related to #3251 .

If that one is merged first, this will need to be rebased and updated. If this one is merged first, #3251 will be updated to reflect the separate clocks. 

