### PR TITLE
[dv/rv_timer] fix regression corner case

### DIFF
--- a/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_sanity_vseq.sv
+++ b/hw/ip/rv_timer/dv/env/seq_lib/rv_timer_sanity_vseq.sv
@@ -122,10 +122,14 @@ class rv_timer_sanity_vseq extends rv_timer_base_vseq;
             automatic int a_i = i;
             fork
               // poll a intr_status continuously until it reads the expected value
+              // in `timeout_ns` the delay value is mulitplied by two due to the
+              // `intr_state_spinwait` task: if interrupt is set right after csr_rd, then the worst
+              // case the code will wait for two `spinwait_delay_ns` before hitting the break
+              // statement
               if (en_harts[a_i]) begin
                 `DV_CHECK_MEMBER_RANDOMIZE_FATAL(delay)
                 intr_state_spinwait(.hart(a_i), .exp_data(en_timers), .spinwait_delay_ns(delay),
-                                    .timeout_ns(delay + (max_clks_until_expiry *
+                                    .timeout_ns(delay * 2 + (max_clks_until_expiry *
                                         (cfg.clk_rst_vif.clk_period_ps / 1000.0))));
               end
             join_none


### PR DESCRIPTION
There is a regression failure regarding timer timeout. The issue is
because the while loop is constructed :
```
          while (1) begin
            csr_rd(.ptr(intr_state_rg), .value(read_data));
            if (spinwait_delay_ns) #(spinwait_delay_ns * 1ns);
            if ((read_data == exp_data) | (reset_asserted == 1)) break;
          end
```
So in the worst case scenario, the interrupt is set right after csr_rd,
then the wait time should be twice of the spinwait_delay_ns.

This PR fixed this timeout issue by multiply the delay with 2.

Signed-off-by: Cindy Chen <chencindy@google.com>