### PR TITLE
[dv/lib] clear csr_outstanding_access after reset

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/cip_base_vseq.sv
@@ -408,7 +408,6 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
               apply_reset("HARD");
               ongoing_reset = 1'b0;
               do_read_and_check_all_csrs = 1'b1;
-              csr_utils_pkg::clear_outstanding_access();
             end
           join_any
           p_sequencer.tl_sequencer_h.stop_sequences();

--- a/hw/dv/sv/dv_lib/dv_base_vseq.sv
+++ b/hw/dv/sv/dv_lib/dv_base_vseq.sv
@@ -88,6 +88,7 @@ class dv_base_vseq #(type RAL_T               = dv_base_reg_block,
     if (kind == "HARD") begin
       csr_utils_pkg::reset_asserted();
       cfg.clk_rst_vif.apply_reset();
+      csr_utils_pkg::clear_outstanding_access();
       csr_utils_pkg::reset_deasserted();
     end
     if (cfg.has_ral) begin


### PR DESCRIPTION
This PR moves the clear_csr_outstanding_access inside dut_init()
so after reset asserted, the csr_outstanding_access will be
cleared, and no need to clear again in individual sequence.

Signed-off-by: Cindy Chen <chencindy@google.com>