### PR TITLE
[sw/host/spiflash] Add support to dump frames

### DIFF
--- a/sw/host/spiflash/spiflash.cc
+++ b/sw/host/spiflash/spiflash.cc
@@ -1,10 +1,10 @@
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-
 #include <assert.h>
 #include <fstream>
 #include <getopt.h>
+#include <iterator>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -16,6 +16,7 @@
 
 namespace {
 
+using opentitan::spiflash::Frame;
 using opentitan::spiflash::FtdiSpiInterface;
 using opentitan::spiflash::SpiInterface;
 using opentitan::spiflash::Updater;
@@ -31,7 +32,26 @@ FTDI Options:
   [--dev-sn=string] FTDI serial number. Requires --dev-id to be set.
 
 Verilator Options:
-  [--verilator=filehandle] Enables Verilator mode with SPI filehandle.)R";
+  [--verilator=filehandle] Enables Verilator mode with SPI filehandle.
+
+DV Options:
+  [--dump-frames=filehandle] Dump binary SPI flash frames in binary format.
+)R";
+
+/** SPI flash list of supported command actions. */
+enum class SpiFlashAction {
+  /** Invalid command action. */
+  kInvalid = 0,
+
+  /** Run SPI flash in FTDI mode. */
+  kFtdi,
+
+  /** Run SPI flash in Verilator mode. */
+  kVerilator,
+
+  /** Covert input binrary into frames. */
+  kDumpFrames
+};
 
 /** SPI flash configuration options. */
 struct SpiFlashOpts {
@@ -41,8 +61,11 @@ struct SpiFlashOpts {
   /** Target SPI device handle. */
   std::string target;
 
-  /** Set to true to target Verilator environment. */
-  bool verilator = false;
+  /** Output filename to dump SPI frames */
+  std::string output_filename;
+
+  /** Set to SPI flash  mode of operation */
+  SpiFlashAction action = SpiFlashAction::kInvalid;
 
   /** FTDI configuration options. */
   FtdiSpiInterface::Options ftdi_options;
@@ -64,6 +87,35 @@ bool GetFileContents(const std::string &filename, std::string *contents) {
   in_stream << file_stream.rdbuf();
   file_stream.close();
   *contents = in_stream.str();
+  return true;
+}
+
+/**
+ * Store the contetns of `code` formatted int SPI flash frame binary format
+ * into `output_filename`
+ */
+bool DumpFramesToFile(const std::string &code,
+                      const std::string &output_filename) {
+  std::vector<Frame> frames;
+  if (!Updater::GenerateFrames(code, &frames)) {
+    return false;
+  }
+  std::ofstream out_stream;
+  out_stream.open(output_filename, std::ofstream::out | std::ofstream::binary);
+  if (!out_stream.good()) {
+    std::cerr << "Unable to open file: " << output_filename << std::endl;
+    return false;
+  }
+  for (const Frame &f : frames) {
+    out_stream.write(reinterpret_cast<const char *>(&f), sizeof(Frame));
+    if (!out_stream.good()) {
+      std::cerr << "Detected write error. Output file may be corrupted."
+                << std::endl;
+      out_stream.close();
+      return false;
+    }
+  }
+  out_stream.close();
   return true;
 }
 
@@ -110,12 +162,13 @@ bool ParseArgs(int argc, char **argv, SpiFlashOpts *options) {
       {"input", required_argument, nullptr, 'i'},
       {"dev-id", required_argument, nullptr, 'd'},
       {"dev-sn", required_argument, nullptr, 'n'},
+      {"dump-frames", required_argument, nullptr, 'x'},
       {"verilator", required_argument, nullptr, 's'},
       {"help", no_argument, nullptr, 'h'},
       {nullptr, no_argument, nullptr, 0}};
 
   while (true) {
-    int c = getopt_long(argc, argv, "i:d:n:s:h?", long_options, nullptr);
+    int c = getopt_long(argc, argv, "i:d:n:s:x:h?", long_options, nullptr);
     if (c == -1) {
       return true;
     }
@@ -132,11 +185,16 @@ bool ParseArgs(int argc, char **argv, SpiFlashOpts *options) {
         }
         break;
       case 'n':
+        options->action = SpiFlashAction::kFtdi;
         options->ftdi_options.device_serial_number = optarg;
         break;
       case 's':
-        options->verilator = true;
+        options->action = SpiFlashAction::kVerilator;
         options->target = optarg;
+        break;
+      case 'x':
+        options->action = SpiFlashAction::kDumpFrames;
+        options->output_filename = optarg;
         break;
       case '?':
       case 'h':
@@ -156,8 +214,23 @@ int main(int argc, char **argv) {
     return 1;
   }
 
+  if (spi_flash_options.action == SpiFlashAction::kInvalid) {
+    std::cerr << "Unable to detect valid command line arguments." << std::endl;
+    PrintUsage(argc, argv);
+    return 1;
+  }
+
+  std::string code;
+  if (!GetFileContents(spi_flash_options.input, &code)) {
+    return 1;
+  }
+
+  if (spi_flash_options.action == SpiFlashAction::kDumpFrames) {
+    return DumpFramesToFile(code, spi_flash_options.output_filename) ? 0 : 1;
+  }
+
   std::unique_ptr<SpiInterface> spi;
-  if (spi_flash_options.verilator) {
+  if (spi_flash_options.action == SpiFlashAction::kVerilator) {
     spi = std::make_unique<VerilatorSpiInterface>(spi_flash_options.target);
   } else {
     spi = std::make_unique<FtdiSpiInterface>(spi_flash_options.ftdi_options);
@@ -167,9 +240,8 @@ int main(int argc, char **argv) {
   }
 
   Updater::Options options;
-  if (!GetFileContents(spi_flash_options.input, &options.code)) {
-    return 1;
-  }
+  options.code = code;
+
   Updater updater(options, std::move(spi));
   return updater.Run() ? 0 : 1;
 }

--- a/sw/host/spiflash/updater.h
+++ b/sw/host/spiflash/updater.h
@@ -79,7 +79,6 @@ class Updater {
    */
   bool Run();
 
- private:
   /**
    * Generates `frames` from `code` image.
    *
@@ -88,8 +87,10 @@ class Updater {
    *
    * @return true on success, false otherwise.
    */
-  bool GenerateFrames(const std::string &code, std::vector<Frame> *frames);
+  static bool GenerateFrames(const std::string &code,
+                             std::vector<Frame> *frames);
 
+ private:
   Options options_;
   std::unique_ptr<SpiInterface> spi_;
 };


### PR DESCRIPTION
Dump frames into an output file using the --dump-frames option.
Example:

```console
$ build-bin/sw/host/spiflash/spiflash --input=foo.bin \
  --dump-frames=foo.bin.frames
```

Related to issue lowrisc/opentitan#3203