### PR TITLE
[otbn] Further ISS improvements (illegal instruction support; ELF file support)

### DIFF
--- a/hw/ip/otbn/README.md
+++ b/hw/ip/otbn/README.md
@@ -101,8 +101,9 @@ and check the results are as expected.
 
 The default behaviour is that the OTBN block contains the RTL design.
 If you wish to run system-level testing against the Python-based
-simulator instead of the RTL, you need to pass the `OTBN_MODEL` flag.
-For example, to compile the Verilator simulation, use:
+instruction set simulator instead of the RTL (hereafter called the
+ISS), you need to pass the `OTBN_MODEL` flag. For example, to compile
+the Verilator simulation, use:
 
 ```sh
 fusesoc --cores-root=. run \
@@ -110,14 +111,30 @@ fusesoc --cores-root=. run \
   lowrisc:systems:top_earlgrey_verilator --OTBN_MODEL
 ```
 
-### Update the OTBN model (the instruction-set simulator, ISS)
+### Run the ISS on its own
+
+There are currently two versions of the ISS and they can be found in
+`dv/otbnsim`. The easiest to use is `dv/otbnsim/standalone.py`. This
+takes an OTBN binary as an ELF file (as produced by the standard
+linker script for `otbn-ld`) and can dump the resulting DMEM if given
+the `--dmem-dump` argument. To see an instruction trace, pass the
+`--verbose` flag.
+
+There is also `dv/otbnsim/otbnsim.py`. This takes flat binary files
+with the contents of IMEM and DMEM and, when finished, generates a
+cycle count and dumps DMEM contents. This is used to implement the
+model inside of simulation, but is probably not very convenient for
+command-line use otherwise.
+
+
+### Update the RISC-V part of the ISS
 
 The OTBN model is an instruction set simulator written in Python. It lives
 in the `opentitan` repository in the `util/otbnsim` directory, but builds on top
 of the `riscv-model` Python package. The code for this package can be found at
 https://github.com/wallento/riscv-python-model.
 
-To update the model to the latest recommended version run `pip`.
+To update the model to the latest recommended version, run `pip`.
 
 ```sh
 # Ensure you have the latest Python dependencies installed

--- a/hw/ip/otbn/dv/otbnsim/Makefile
+++ b/hw/ip/otbn/dv/otbnsim/Makefile
@@ -13,11 +13,15 @@ build-dir := $(repo-top)/build-bin/otbn/otbnsim
 $(build-dir):
 	mkdir -p $@
 
-pycode := $(wildcard *.py)
+py-scripts := otbnsim.py
+py-files   := $(wildcard *.py otbnsim/*.py)
+py-libs    := $(filter-out $(py-scripts),$(py-files))
 
-$(build-dir)/lint.stamp: $(pycode) | $(build-dir)
-	mypy --strict $(pycode)
+lint-stamps := $(foreach scr,$(py-scripts),$(build-dir)/$(scr).stamp)
+
+$(lint-stamps): $(build-dir)/%.stamp: % $(py-libs)
+	env MYPYPATH="$$MYPYPATH:../../util" mypy --strict $< $(py-libs)
 	touch $@
 
 .PHONY: lint
-lint: $(build-dir)/lint.stamp
+lint: $(lint-stamps)

--- a/hw/ip/otbn/dv/otbnsim/Makefile
+++ b/hw/ip/otbn/dv/otbnsim/Makefile
@@ -1,0 +1,23 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+.PHONY: all
+all: lint
+
+# We need a directory to build stuff and use the "otbn/otbnsim" namespace
+# in the top-level build-bin directory.
+repo-top := ../../../..
+build-dir := $(repo-top)/build-bin/otbn/otbnsim
+
+$(build-dir):
+	mkdir -p $@
+
+pycode := $(wildcard *.py)
+
+$(build-dir)/lint.stamp: $(pycode) | $(build-dir)
+	mypy --strict $(pycode)
+	touch $@
+
+.PHONY: lint
+lint: $(build-dir)/lint.stamp

--- a/hw/ip/otbn/dv/otbnsim/Makefile
+++ b/hw/ip/otbn/dv/otbnsim/Makefile
@@ -13,7 +13,7 @@ build-dir := $(repo-top)/build-bin/otbn/otbnsim
 $(build-dir):
 	mkdir -p $@
 
-py-scripts := otbnsim.py
+py-scripts := otbnsim.py standalone.py
 py-files   := $(wildcard *.py otbnsim/*.py)
 py-libs    := $(filter-out $(py-scripts),$(py-files))
 

--- a/hw/ip/otbn/dv/otbnsim/otbnsim.py
+++ b/hw/ip/otbn/dv/otbnsim/otbnsim.py
@@ -7,14 +7,15 @@
 
 import argparse
 import struct
+import sys
 
-from riscvmodel.sim import Simulator
-from riscvmodel.model import Model
-from riscvmodel.variant import RV32I
-from riscvmodel.code import read_from_binary
+from riscvmodel.sim import Simulator  # type: ignore
+from riscvmodel.model import Model  # type: ignore
+from riscvmodel.variant import RV32I  # type: ignore
+from riscvmodel.code import read_from_binary  # type: ignore
 
 
-def main():
+def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("imem_words", type=int)
     parser.add_argument("imem_file")
@@ -37,6 +38,8 @@ def main():
     with open(args.cycles_file, "wb") as f:
         f.write(struct.pack("<L", cycles))
 
+    return 0
+
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())

--- a/hw/ip/otbn/dv/otbnsim/otbnsim.py
+++ b/hw/ip/otbn/dv/otbnsim/otbnsim.py
@@ -12,7 +12,8 @@ import sys
 from riscvmodel.sim import Simulator  # type: ignore
 from riscvmodel.model import Model  # type: ignore
 from riscvmodel.variant import RV32I  # type: ignore
-from riscvmodel.code import read_from_binary  # type: ignore
+
+from sim.decode import decode_file
 
 
 def main() -> int:
@@ -26,7 +27,7 @@ def main() -> int:
     args = parser.parse_args()
     sim = Simulator(Model(RV32I))
 
-    sim.load_program(read_from_binary(args.imem_file, stoponerror=True))
+    sim.load_program(decode_file(args.imem_file, RV32I))
     with open(args.dmem_file, "rb") as f:
         sim.load_data(f.read())
 

--- a/hw/ip/otbn/dv/otbnsim/sim/__init__.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/__init__.py
@@ -1,0 +1,12 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+
+# Ensure that the OTBN util directory is on sys.path. This allows us to import
+# modules "shared.foo" to get the OTBN shared code.
+sys.path.append(os.path.normpath(os.path.join(os.path.dirname(__file__),
+                                              '../../../util')))

--- a/hw/ip/otbn/dv/otbnsim/sim/decode.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/decode.py
@@ -1,0 +1,68 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+'''Code to load instruction words into a simulator'''
+
+# Lots of this probably belongs in the upstream riscv-python-sim simulator, but
+# let's get everything working first and then try to push anything sensible
+# afterwards.
+
+import struct
+from typing import List, TypeVar
+
+from riscvmodel.insn import get_insns  # type: ignore
+from riscvmodel.isa import Instruction, isa  # type: ignore
+from riscvmodel.model import Model  # type: ignore
+from riscvmodel.variant import Variant, RV32I  # type: ignore
+
+# A subclass of Instruction
+_InsnSubclass = TypeVar('_InsnSubclass', bound=Instruction)
+
+
+@isa(".bogus-insn", RV32I, opcode=0)
+class IllegalInsn(Instruction):  # type: ignore
+    '''A catch-all subclass of Instruction for bad data
+
+    This handles anything that doesn't decode correctly. Doing so for OTBN is
+    much easier than if we wanted to support compressed-mode (RV32IC), because
+    we don't need to worry about whether we have 16 or 32 bits of rubbish.
+
+    Note that we declare this with an opcode of zero. Note that this implies
+    the bottom two bits are 0, which would imply a compressed instruction, so
+    we know this doesn't match any real instruction.
+
+    '''
+    def execute(self, model: Model) -> None:
+        raise RuntimeError('Illegal instruction at PC {:#010x}.'
+                           .format(model.state.pc))
+
+
+def _decode_word(word_off: int,
+                 word: int,
+                 insn_classes: List[_InsnSubclass]) -> Instruction:
+    opcode = word & 0x7f
+    for cls in insn_classes:
+        if cls.field_opcode.value != opcode:
+            continue
+        if not cls.match(word):
+            continue
+
+        insn = cls()
+        insn.decode(word)
+        return insn
+
+    return IllegalInsn()
+
+
+def decode_bytes(data: bytes, variant: Variant) -> List[Instruction]:
+    '''Decode instruction bytes as instructions'''
+    insn_classes = get_insns(variant=variant)
+    assert len(data) & 3 == 0
+    return [_decode_word(offset, int_val[0], insn_classes)
+            for offset, int_val in enumerate(struct.iter_unpack('<I', data))]
+
+
+def decode_file(path: str, variant: Variant) -> List[Instruction]:
+    with open(path, 'rb') as handle:
+        return decode_bytes(handle.read(), variant)

--- a/hw/ip/otbn/dv/otbnsim/sim/elf.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/elf.py
@@ -1,0 +1,141 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+'''OTBN ELF file handling'''
+
+from typing import List, Tuple
+
+from elftools.elf.elffile import ELFFile  # type: ignore
+
+from riscvmodel.sim import Simulator  # type: ignore
+from riscvmodel.variant import RV32I  # type: ignore
+
+from shared.mem_layout import get_memory_layout
+
+from .decode import decode_bytes
+
+_SegList = List[Tuple[int, bytes]]
+
+# A _MemDesc is a pair (lma, length). length should be non-negative.
+_MemDesc = Tuple[int, int]
+
+
+def _flatten_segments(segments: _SegList, mem_desc: _MemDesc) -> bytes:
+    '''Write the given ELF segments to a block of bytes
+
+    Let (block_lma, block_len) = _MemDesc. The segments are assumed to be
+    disjoint. The segment with the smallest address is assumed to start
+    somewhere above block_lma and the segment with the highest address is
+    assumed to finish less than block_len bytes above block_lma.
+
+    The returned block of bytes will have length at most block_len. Any
+    internal gaps are padded with zeroes.
+
+    '''
+    block_lma, block_len = mem_desc
+    assert 0 <= block_len
+
+    lma = block_lma
+    chunks = []
+
+    # Walk through the segments in increasing order of LMA.
+    for seg_lma, seg_data in sorted(segments, key=lambda pr: pr[0]):
+        assert lma <= seg_lma
+        if lma < seg_lma:
+            chunks.append(b'\x00' * (seg_lma - lma))
+            lma = seg_lma
+
+        chunks.append(seg_data)
+        lma += len(seg_data)
+
+    assert block_lma <= lma
+
+    block_top = block_lma + block_len
+    assert lma <= block_top
+
+    return b''.join(chunks)
+
+
+def _get_elf_segments(path: str,
+                      imem_desc: _MemDesc,
+                      dmem_desc: _MemDesc) -> Tuple[_SegList, _SegList]:
+    '''Load the ELF file at path and get imem/dmem segments'''
+    imem_segments = []
+    dmem_segments = []
+
+    imem_lma, imem_len = imem_desc
+    dmem_lma, dmem_len = dmem_desc
+
+    imem_top = imem_lma + imem_len
+    dmem_top = dmem_lma + dmem_len
+
+    assert imem_lma <= imem_top
+    assert dmem_lma <= dmem_top
+
+    with open(path, 'rb') as handle:
+        elf_file = ELFFile(handle)
+        for segment in elf_file.iter_segments():
+            seg_type = segment['p_type']
+
+            # We're only interested in PT_LOAD segments
+            if seg_type != 'PT_LOAD':
+                continue
+
+            seg_lma = segment['p_paddr']
+            seg_top = seg_lma + segment['p_memsz']
+
+            # Does this match an expected imem or dmem address?
+            if imem_lma <= seg_lma <= imem_top:
+                if seg_top > imem_top:
+                    raise RuntimeError('Segment has LMA range {:#x}..{:#x}, '
+                                       'which intersects the IMEM range '
+                                       '({:#x}..{:#x}), but is not fully '
+                                       'contained in it.'
+                                       .format(seg_lma, seg_top,
+                                               imem_lma, imem_top))
+                imem_segments.append((seg_lma, segment.data()))
+                continue
+
+            if dmem_lma <= seg_lma <= dmem_top:
+                if seg_top > dmem_top:
+                    raise RuntimeError('Segment has LMA range {:#x}..{:#x}, '
+                                       'which intersects the DMEM range '
+                                       '({:#x}..{:#x}), but is not fully '
+                                       'contained in it.'
+                                       .format(seg_lma, seg_top,
+                                               dmem_lma, dmem_top))
+                dmem_segments.append((seg_lma, segment.data()))
+                continue
+
+            # We shouldn't have any loadable segments that don't look like
+            # either IMEM or DMEM.
+            raise RuntimeError("Segment has LMA {:#x}, which doesn't start in "
+                               "IMEM range (base {:#x}) or DMEM range "
+                               "(base {:#x})."
+                               .format(seg_lma, imem_lma, dmem_lma))
+
+    return (imem_segments, dmem_segments)
+
+
+def load_elf(sim: Simulator, path: str) -> None:
+    '''Load contents of ELF file at path'''
+    mems = get_memory_layout()
+    imem_desc = mems['IMEM']
+    dmem_desc = mems['DMEM']
+
+    imem_segs, dmem_segs = _get_elf_segments(path, imem_desc, dmem_desc)
+
+    imem_bytes = _flatten_segments(imem_segs, imem_desc)
+    dmem_bytes = _flatten_segments(dmem_segs, dmem_desc)
+
+    assert len(imem_bytes) <= imem_desc[1]
+    if len(imem_bytes) & 3:
+        raise RuntimeError('ELF file at {!r} has imem data of length {}: '
+                           'not a multiple of 4.'
+                           .format(path, len(imem_bytes)))
+
+    imem_insns = decode_bytes(imem_bytes, RV32I)
+
+    sim.load_program(imem_insns)
+    sim.load_data(dmem_bytes)

--- a/hw/ip/otbn/dv/otbnsim/standalone.py
+++ b/hw/ip/otbn/dv/otbnsim/standalone.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import sys
+
+from riscvmodel.sim import Simulator  # type: ignore
+from riscvmodel.model import Model  # type: ignore
+from riscvmodel.variant import RV32I  # type: ignore
+
+from sim.elf import load_elf
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('elf')
+    parser.add_argument('-v', '--verbose', action='store_true')
+    parser.add_argument('--dmem-dump')
+
+    args = parser.parse_args()
+
+    sim = Simulator(Model(RV32I, verbose=args.verbose))
+    load_elf(sim, args.elf)
+
+    sim.run()
+
+    if args.dmem_dump is not None:
+        try:
+            with open(args.dmem_dump, 'wb') as dmem_file:
+                dmem_file.write(sim.dump_data())
+        except OSError as err:
+            sys.stderr.write('Failed to write DMEM to {!r}: {}.'
+                             .format(args.dmem_dump, err))
+            return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
~~This PR depends on #3199, and the first commit is the commit in that PR. Merge that first and rebase.~~ (That's now in master, and the PR is rebased)

The other three commits:

  - Add mypy linting. This is new code: let's get it right.
  - Teach the simulator about illegal instructions (closes #2965)
  - Add a standalone mode for the simulator

The last one won't be used directly for block-level testing (we're going to want to run the RTL and ISS in lock-step, so need to be able to step), but I suspect it will be handy for things like testing software.