### PR TITLE
[sw, runtime] Introduce "DIF" like PMP library

### DIFF
--- a/ci/run_verilator_pytest.sh
+++ b/ci/run_verilator_pytest.sh
@@ -21,6 +21,8 @@ TEST_TARGETS=(
   "tests/dif_rv_timer_sanitytest_sim_verilator.elf"
   "tests/dif_uart_sanitytest_sim_verilator.elf"
   "tests/flash_ctrl_test_sim_verilator.elf"
+  "tests/pmp_sanitytest_napot_sim_verilator.elf"
+  "tests/pmp_sanitytest_tor_sim_verilator.elf"
   "tests/sha256_test_sim_verilator.elf"
   "tests/usbdev_test_sim_verilator.elf"
 )

--- a/sw/device/lib/runtime/meson.build
+++ b/sw/device/lib/runtime/meson.build
@@ -19,3 +19,13 @@ sw_lib_runtime_hart = declare_dependency(
     ],
   )
 )
+
+sw_lib_runtime_pmp = declare_dependency(
+  link_with: static_library(
+    'runtime_pmp_ot',
+    sources: ['pmp.c'],
+    dependencies: [
+      sw_lib_bitfield,
+    ],
+  )
+)

--- a/sw/device/lib/runtime/pmp.c
+++ b/sw/device/lib/runtime/pmp.c
@@ -1,0 +1,573 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/runtime/pmp.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/stdasm.h"
+
+// "Volume II: RISC-V Privileged Architectures V20190608-Priv-MSU-Ratified",
+// "3.6.1 Physical Memory Protection CSRs",
+// "Figure 3.28: PMP configuration register format".
+#define PMP_CFG_CSR_R 0
+#define PMP_CFG_CSR_W 1
+#define PMP_CFG_CSR_X 2
+#define PMP_CFG_CSR_A 3
+#define PMP_CFG_CSR_L 7
+
+#define PMP_CFG_FIELDS_PER_REG 4
+#define PMP_CFG_FIELD_WIDTH 8
+#define PMP_CFG_FIELD_MASK 0xff
+
+// "Volume II: RISC-V Privileged Architectures V20190608-Priv-MSU-Ratified",
+// "3.6.1 Physical Memory Protection CSRs", "Address Matching".
+#define PMP_CFG_CSR_MODE_OFF 0
+#define PMP_CFG_CSR_MODE_TOR 1
+#define PMP_CFG_CSR_MODE_NA4 2
+#define PMP_CFG_CSR_MODE_NAPOT 3
+#define PMP_CFG_CSR_MODE_MASK 0x3
+
+typedef enum pmp_csr_access_type {
+  kPmpCsrAccessTypeRead = 0,
+  kPmpCsrAccessTypeWrite,
+} pmp_csr_access_type_t;
+
+// Because CSRs are encoded into the instructions, `pmpcfg` and `pmpaddr` cannot
+// be runtime values (must be constexpr). This set of macros allows to read
+// and write `pmpcfg` and `pmpaddr` CSRs in a common way. The alternative would
+// be to create an access function for every `pmpcfg` and `pmpaddr`
+// (20 or 40 together, dependent on the implementation).
+#define PMP_CSR_WRITE(csr, var) asm volatile("csrw " #csr ", %0;" : : "r"(var))
+
+#define PMP_CSR_READ(csr, var) asm volatile("csrr %0, " #csr ";" : "=r"(var) :)
+
+#define PMP_CSR_RW(access, csr, var)       \
+  do {                                     \
+    uint32_t csr_value;                    \
+    if (access == kPmpCsrAccessTypeRead) { \
+      PMP_CSR_READ(csr, csr_value);        \
+      *var = csr_value;                    \
+    } else {                               \
+      csr_value = *var;                    \
+      PMP_CSR_WRITE(csr, csr_value);       \
+    }                                      \
+  } while (false)
+
+static const bitfield_field32_t kPmpCfgModeField = {
+    .mask = PMP_CFG_CSR_MODE_MASK, .index = PMP_CFG_CSR_A,
+};
+
+/**
+ * Reads/writes to a `pmpcfgN` CSR.
+ *
+ * `N` is derived from a `region` (a single `pmpcfg` CSR contains configuration
+ * information for `PMP_CFG_FIELDS_PER_REG` regions).
+ *
+ * @param region PMP region ID to get/set.
+ * @param access CSR access type read/write.
+ * @param value Read value from a CSR, or value to write into a CSR.
+ * @return `pmp_region_configure_result_t`.
+ */
+PMP_WARN_UNUSED_RESULT
+static pmp_region_configure_result_t pmp_cfg_csr_rw(
+    pmp_region_index_t region, pmp_csr_access_type_t access, uint32_t *value) {
+  switch (region) {
+    case 0:
+    case 1:
+    case 2:
+    case 3:
+      PMP_CSR_RW(access, pmpcfg0, value);
+      break;
+    case 4:
+    case 5:
+    case 6:
+    case 7:
+      PMP_CSR_RW(access, pmpcfg1, value);
+      break;
+    case 8:
+    case 9:
+    case 10:
+    case 11:
+      PMP_CSR_RW(access, pmpcfg2, value);
+      break;
+    case 12:
+    case 13:
+    case 14:
+    case 15:
+      PMP_CSR_RW(access, pmpcfg3, value);
+      break;
+    default:
+      return false;
+  }
+
+  return true;
+}
+
+/**
+ * Reads/writes to a `pmpaddrN` CSR.
+ *
+ * `N` is derived from a `region` (a single `pmpaddr` CSR conatins an address
+ * for a single region).
+ *
+ * @param region PMP region ID to get/set.
+ * @param access CSR access type read/write.
+ * @param value Read value from a CSR, or value to write into a CSR.
+ * @return `true` on success, `false` on failure.
+ */
+PMP_WARN_UNUSED_RESULT
+static bool pmp_addr_csr_rw(pmp_region_index_t region,
+                            pmp_csr_access_type_t access, uint32_t *value) {
+  switch (region) {
+    case 0:
+      PMP_CSR_RW(access, pmpaddr0, value);
+      break;
+    case 1:
+      PMP_CSR_RW(access, pmpaddr1, value);
+      break;
+    case 2:
+      PMP_CSR_RW(access, pmpaddr2, value);
+      break;
+    case 3:
+      PMP_CSR_RW(access, pmpaddr3, value);
+      break;
+    case 4:
+      PMP_CSR_RW(access, pmpaddr4, value);
+      break;
+    case 5:
+      PMP_CSR_RW(access, pmpaddr5, value);
+      break;
+    case 6:
+      PMP_CSR_RW(access, pmpaddr6, value);
+      break;
+    case 7:
+      PMP_CSR_RW(access, pmpaddr7, value);
+      break;
+    case 8:
+      PMP_CSR_RW(access, pmpaddr8, value);
+      break;
+    case 9:
+      PMP_CSR_RW(access, pmpaddr9, value);
+      break;
+    case 10:
+      PMP_CSR_RW(access, pmpaddr10, value);
+      break;
+    case 11:
+      PMP_CSR_RW(access, pmpaddr11, value);
+      break;
+    case 12:
+      PMP_CSR_RW(access, pmpaddr12, value);
+      break;
+    case 13:
+      PMP_CSR_RW(access, pmpaddr13, value);
+      break;
+    case 14:
+      PMP_CSR_RW(access, pmpaddr14, value);
+      break;
+    case 15:
+      PMP_CSR_RW(access, pmpaddr15, value);
+      break;
+    default:
+      return false;
+  }
+
+  return true;
+}
+
+/**
+ * Retrievs configuration information for the requested `region`.
+ *
+ * A single `pmpcfg` CSR packs configuration information for `N` regions.
+ *
+ * @param region PMP region ID.
+ * @param field_value Configuration information for the `region`.
+ * @return `pmp_region_configure_result_t`.
+ */
+PMP_WARN_UNUSED_RESULT
+static pmp_region_configure_result_t pmp_csr_cfg_field_read(
+    pmp_region_index_t region, uint32_t *field_value) {
+  uint32_t cfg_csr_original;
+  if (!pmp_cfg_csr_rw(region, kPmpCsrAccessTypeRead, &cfg_csr_original)) {
+    return kPmpRegionConfigureError;
+  }
+
+  size_t field_index = (region % PMP_CFG_FIELDS_PER_REG) * PMP_CFG_FIELD_WIDTH;
+  bitfield_field32_t pmp_csr_cfg_field = {
+      .mask = PMP_CFG_FIELD_MASK, .index = field_index,
+  };
+
+  *field_value = bitfield_field32_read(cfg_csr_original, pmp_csr_cfg_field);
+
+  return kPmpRegionConfigureOk;
+}
+
+/**
+ * Writes configuration information for the requested `region`.
+ *
+ * A single `pmpcfg` CSR packs configuration information for `N` regions.
+ *
+ * @param region PMP region ID.
+ * @param field_value Configuration information for the `region`.
+ * @return `pmp_region_configure_result_t`.
+ */
+PMP_WARN_UNUSED_RESULT
+static pmp_region_configure_result_t pmp_csr_cfg_field_write(
+    pmp_region_index_t region, uint32_t field_value) {
+  uint32_t cfg_csr_current;
+  if (!pmp_cfg_csr_rw(region, kPmpCsrAccessTypeRead, &cfg_csr_current)) {
+    return kPmpRegionConfigureError;
+  }
+
+  // Determine the pmpcfg field index based on the `region`.
+  size_t field_index = (region % PMP_CFG_FIELDS_PER_REG) * PMP_CFG_FIELD_WIDTH;
+  bitfield_field32_t pmp_csr_cfg_field = {
+      .mask = PMP_CFG_FIELD_MASK, .index = field_index,
+  };
+
+  uint32_t cfg_csr_new =
+      bitfield_field32_write(cfg_csr_current, pmp_csr_cfg_field, field_value);
+
+  if (!pmp_cfg_csr_rw(region, kPmpCsrAccessTypeWrite, &cfg_csr_new)) {
+    return kPmpRegionConfigureError;
+  }
+
+  if (!pmp_cfg_csr_rw(region, kPmpCsrAccessTypeRead, &cfg_csr_current)) {
+    return kPmpRegionConfigureError;
+  }
+
+  if (cfg_csr_current != cfg_csr_new) {
+    return kPmpRegionConfigureWarlError;
+  }
+
+  return kPmpRegionConfigureOk;
+}
+
+/**
+ * Writes `address` to a pmpaddr CSRs.
+ *
+ * The corresponding pmpaddrN index N is determined by `region`.
+ *
+ * PMP address must be at least 4bytes aligned, and pmpaddr holds only bits
+ * 33:2. This means that before writing an address to a pmpaddr CSR, it must be
+ * shifted 2 bits to the right.
+ *
+ * Please see:
+ * "Volume II: RISC-V Privileged Architectures V20190608-Priv-MSU-Ratified",
+ * "3.6.1 Physical Memory Protection CSRs",
+ * "Figure 3.26: PMP address register format, RV32".
+ *
+ * @param region PMP region to configure and set address for.
+ * @param address Address to be set.
+ * @return `pmp_region_configure_result_t`.
+ */
+pmp_region_configure_result_t pmp_csr_address_write(pmp_region_index_t region,
+                                                    uintptr_t address) {
+  uint32_t address_shifted = address >> PMP_ADDRESS_SHIFT;
+  if (!pmp_addr_csr_rw(region, kPmpCsrAccessTypeWrite, &address_shifted)) {
+    return kPmpRegionConfigureError;
+  }
+
+  uint32_t addr_csr_after_write;
+  if (!pmp_addr_csr_rw(region, kPmpCsrAccessTypeRead, &addr_csr_after_write)) {
+    return kPmpRegionConfigureError;
+  }
+
+  if (address_shifted != addr_csr_after_write) {
+    return kPmpRegionConfigureWarlError;
+  }
+
+  return kPmpRegionConfigureOk;
+}
+
+/**
+ * Set PMP region permissions.
+ *
+ * @param perm Memory access permissions.
+ * @param bitfield Bitfield to set.
+ * @return `true` on success, `false` on failure.
+ */
+PMP_WARN_UNUSED_RESULT
+static bool pmp_cfg_permissions_set(pmp_region_permissions_t perm,
+                                    uint32_t *bitfield) {
+  switch (perm) {
+    case kPmpRegionPermissionsNone:
+      // No access is allowed.
+      break;
+    case kPmpRegionPermissionsReadOnly:
+      *bitfield = bitfield_bit32_write(*bitfield, PMP_CFG_CSR_R, true);
+      break;
+    case kPmpRegionPermissionsExecuteOnly:
+      *bitfield = bitfield_bit32_write(*bitfield, PMP_CFG_CSR_X, true);
+      break;
+    case kPmpRegionPermissionsReadExecute:
+      *bitfield = bitfield_bit32_write(*bitfield, PMP_CFG_CSR_R, true);
+      *bitfield = bitfield_bit32_write(*bitfield, PMP_CFG_CSR_X, true);
+      break;
+    case kPmpRegionPermissionsReadWrite:
+      *bitfield = bitfield_bit32_write(*bitfield, PMP_CFG_CSR_R, true);
+      *bitfield = bitfield_bit32_write(*bitfield, PMP_CFG_CSR_W, true);
+      break;
+    case kPmpRegionPermissionsReadWriteExecute:
+      *bitfield = bitfield_bit32_write(*bitfield, PMP_CFG_CSR_R, true);
+      *bitfield = bitfield_bit32_write(*bitfield, PMP_CFG_CSR_W, true);
+      *bitfield = bitfield_bit32_write(*bitfield, PMP_CFG_CSR_X, true);
+      break;
+    default:
+      return false;
+  }
+
+  return true;
+}
+
+/**
+ * Set PMP region lock.
+ *
+ * @param lock Lock to indicate whether the region must be locked.
+ * @param bitfield Bitfield to set.
+ */
+static void pmp_cfg_mode_lock_set(pmp_region_lock_t lock, uint32_t *bitfield) {
+  bool flag = (lock == kPmpRegionLockLocked) ? true : false;
+  *bitfield = bitfield_bit32_write(*bitfield, PMP_CFG_CSR_L, flag);
+}
+
+/**
+ * Check whether `address` is correctly aligned.
+ *
+ * The alignment depend on the granularity, which is implementation specific,
+ * and for Ibex is `PMP_GRANULARITY_IBEX`. Default granularity "G" is 0, which
+ * means a minimal alignment of 4bytes. Please see:
+ * "Volume II: RISC-V Privileged Architectures V20190608-Priv-MSU-Ratified",
+ * "3.6 Physical Memory Protection", "Figure 3.26" and section
+ * "Address Matching".
+ *
+ * @param address System address.
+ * @return `true` on success, `false` on failure.
+ */
+static bool pmp_address_aligned(uintptr_t address) {
+  return address == (address & PMP_ADDRESS_ALIGNMENT_INVERTED_MASK);
+}
+
+/**
+ * Constructs a NAPOT address from the requested system address and size.
+ *
+ * This function makes sure that the `address` and `size` are valid, and then
+ * constructs a corresponding NAPOT address. Please see:
+ * "Volume II: RISC-V Privileged Architectures V20190608-Priv-MSU-Ratified",
+ * "3.6 Physical Memory Protection", "Figure 3.26" and "Table 3.10".
+ *
+ * @param address Conventional system address.
+ * @param size The size of a range to protect.
+ * @param napot_address Constructed NAPOT address.
+ * @return `pmp_region_configure_napot_result_t`.
+ */
+PMP_WARN_UNUSED_RESULT
+static pmp_region_configure_napot_result_t pmp_napot_address_construct(
+    uintptr_t address, uint32_t size, uintptr_t *pmp_address_napot) {
+  // Must be at least the size of the minimal alignment adjusted for
+  // granularity, and the minimal allowed size for the NAPOT mode.
+  if (size < PMP_ADDRESS_ALIGNMENT || size < PMP_ADDRESS_MIN_ALIGNMENT_NAPOT) {
+    return kPmpRegionConfigureNapotBadAddress;
+  }
+
+  // Check if the `size` is a Power Of Two.
+  uint32_t size_mask = size - 1;
+  if ((size & size_mask) != 0) {
+    return kPmpRegionConfigureNapotBadSize;
+  }
+
+  // Check if the address is aligned to the `size`.
+  if (address != (address & (~size_mask))) {
+    return kPmpRegionConfigureNapotBadAddress;
+  }
+
+  // `size_mask` must be right shifted, as the minimal legal size in NAPOT
+  // mode is 8 bytes.
+  *pmp_address_napot = address | (size_mask >> 1);
+
+  return kPmpRegionConfigureNapotOk;
+}
+
+pmp_region_configure_result_t pmp_region_configure_off(
+    pmp_region_index_t region, uintptr_t address) {
+  if (region >= PMP_REGIONS_NUM) {
+    return kPmpRegionConfigureBadRegion;
+  }
+
+  if (!pmp_address_aligned(address)) {
+    return kPmpRegionConfigureBadAddress;
+  }
+
+  // Address registers must be written prior to the configuration registers to
+  // ensure that they are not locked.
+  pmp_region_configure_result_t result = pmp_csr_address_write(region, address);
+  if (result != kPmpRegionConfigureOk) {
+    return result;
+  }
+
+  // Clear the appropriate region field of the pmpcfg CSR.
+  result = pmp_csr_cfg_field_write(region, 0);
+  if (result != kPmpRegionConfigureOk) {
+    return result;
+  }
+
+  return kPmpRegionConfigureOk;
+}
+
+pmp_region_configure_na4_result_t pmp_region_configure_na4(
+    pmp_region_index_t region, pmp_region_config_t config, uintptr_t address) {
+  if (PMP_GRANULARITY_IBEX > 0) {
+    return kPmpRegionConfigureNa4Unavailable;
+  }
+
+  if (region >= PMP_REGIONS_NUM) {
+    return kPmpRegionConfigureNa4BadRegion;
+  }
+
+  if (!pmp_address_aligned(address)) {
+    return kPmpRegionConfigureNa4BadAddress;
+  }
+
+  uint32_t field_value = 0;
+  if (!pmp_cfg_permissions_set(config.permissions, &field_value)) {
+    return kPmpRegionConfigureNa4Error;
+  }
+
+  pmp_cfg_mode_lock_set(config.lock, &field_value);
+
+  field_value = bitfield_field32_write(field_value, kPmpCfgModeField,
+                                       PMP_CFG_CSR_MODE_NA4);
+
+  // Address registers must be written prior to the configuration registers to
+  // ensure that they are not locked.
+  pmp_region_configure_result_t result = pmp_csr_address_write(region, address);
+  if (result != kPmpRegionConfigureOk) {
+    return (pmp_region_configure_na4_result_t)result;
+  }
+
+  result = pmp_csr_cfg_field_write(region, field_value);
+  if (result != kPmpRegionConfigureOk) {
+    return (pmp_region_configure_na4_result_t)result;
+  }
+
+  return kPmpRegionConfigureNa4Ok;
+}
+
+pmp_region_configure_napot_result_t pmp_region_configure_napot(
+    pmp_region_index_t region, pmp_region_config_t config, uintptr_t address,
+    uint32_t size) {
+  if (region >= PMP_REGIONS_NUM) {
+    return kPmpRegionConfigureNapotBadRegion;
+  }
+
+  uintptr_t napot_address;
+  pmp_region_configure_napot_result_t napot_result =
+      pmp_napot_address_construct(address, size, &napot_address);
+  if (napot_result != kPmpRegionConfigureNapotOk) {
+    return napot_result;
+  }
+
+  uint32_t field_value = 0;
+  if (!pmp_cfg_permissions_set(config.permissions, &field_value)) {
+    return kPmpRegionConfigureNapotError;
+  }
+
+  pmp_cfg_mode_lock_set(config.lock, &field_value);
+
+  field_value = bitfield_field32_write(field_value, kPmpCfgModeField,
+                                       PMP_CFG_CSR_MODE_NAPOT);
+
+  // Address registers must be written prior to the configuration registers to
+  // ensure that they are not locked.
+  pmp_region_configure_result_t result =
+      pmp_csr_address_write(region, napot_address);
+  if (result != kPmpRegionConfigureOk) {
+    return (pmp_region_configure_napot_result_t)result;
+  }
+
+  result = pmp_csr_cfg_field_write(region, field_value);
+  if (result != kPmpRegionConfigureOk) {
+    return (pmp_region_configure_napot_result_t)result;
+  }
+
+  return kPmpRegionConfigureNapotOk;
+}
+
+pmp_region_configure_result_t pmp_region_configure_tor(
+    pmp_region_index_t region_end, pmp_region_config_t config,
+    uintptr_t address_start, uintptr_t address_end) {
+  if (region_end >= PMP_REGIONS_NUM) {
+    return kPmpRegionConfigureBadRegion;
+  }
+
+  if (region_end == 0 && address_start > 0) {
+    return kPmpRegionConfigureBadAddress;
+  }
+
+  if (region_end > 0 && !pmp_address_aligned(address_start)) {
+    return kPmpRegionConfigureBadAddress;
+  }
+
+  if (!pmp_address_aligned(address_end)) {
+    return kPmpRegionConfigureBadAddress;
+  }
+
+  uint32_t field_value = 0;
+  if (!pmp_cfg_permissions_set(config.permissions, &field_value)) {
+    return kPmpRegionConfigureError;
+  }
+
+  pmp_cfg_mode_lock_set(config.lock, &field_value);
+
+  field_value = bitfield_field32_write(field_value, kPmpCfgModeField,
+                                       PMP_CFG_CSR_MODE_TOR);
+
+  // Address registers must be written prior to the configuration registers to
+  // ensure that they are not locked.
+  if (region_end != 0) {
+    pmp_region_configure_result_t result =
+        pmp_csr_address_write(region_end - 1, address_start);
+    if (result != kPmpRegionConfigureOk) {
+      return result;
+    }
+  }
+
+  pmp_region_configure_result_t result =
+      pmp_csr_address_write(region_end, address_end);
+  if (result != kPmpRegionConfigureOk) {
+    return result;
+  }
+
+  result = pmp_csr_cfg_field_write(region_end, field_value);
+  if (result != kPmpRegionConfigureOk) {
+    return result;
+  }
+
+  return kPmpRegionConfigureOk;
+}
+
+pmp_region_configure_result_t pmp_cfg_mode_lock_status_get(
+    pmp_region_index_t region, pmp_region_lock_t *lock) {
+  if (region >= PMP_REGIONS_NUM) {
+    return kPmpRegionConfigureBadRegion;
+  }
+
+  if (lock == NULL) {
+    return kPmpRegionConfigureBadArg;
+  }
+
+  uint32_t field_value;
+  pmp_region_configure_result_t result =
+      pmp_csr_cfg_field_read(region, &field_value);
+  if (result != kPmpRegionConfigureOk) {
+    return result;
+  }
+
+  bool flag = bitfield_bit32_read(field_value, PMP_CFG_CSR_L);
+  *lock = flag ? kPmpRegionLockLocked : kPmpRegionLockUnlocked;
+
+  return kPmpRegionConfigureOk;
+}

--- a/sw/device/lib/runtime/pmp.h
+++ b/sw/device/lib/runtime/pmp.h
@@ -1,0 +1,306 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_RUNTIME_PMP_H_
+#define OPENTITAN_SW_DEVICE_LIB_RUNTIME_PMP_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/**
+ * RISC-V PMP address matching modes.
+ *
+ * PMP address matching modes, how protected regions are formed and
+ * implementation defined granularity information is described in:
+ * "Volume II: RISC-V Privileged Architectures V20190608-Priv-MSU-Ratified",
+ * "3.6.1 Physical Memory Protection CSRs", "Address Matching".
+ *
+ * PMP regions matching logic and prioritisation is described in the
+ * "Priority and Matching Logic" paragraph of the section "3.6.1".
+ *
+ * Note that granularity is implementation defined (default G=0, making the
+ * minimal PMP region size as 2^(G+2) = 4 bytes), and with G >= 1, the
+ * NA4 is not available. Granularity also determines the minimal region size in
+ * TOR and NAPOT modes.
+ */
+
+/**
+ * Attribute for functions which return errors that must be acknowledged.
+ *
+ * This attribute must be used to mark all PMP API that return an error value of
+ * some kind, to ensure that callers do not accidentally drop the error on the
+ * ground.
+ */
+#define PMP_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
+
+/**
+ * RV32 PMP CSR definitions.
+ *
+ * The values for these defines have been taken from the:
+ * "Volume II: RISC-V Privileged Architectures V20190608-Priv-MSU-Ratified",
+ * "3.6.1 Physical Memory Protection CSRs".
+ */
+#define PMP_REGIONS_NUM 16
+
+/**
+ * Ibex PMP address granularity.
+ *
+ * Please see:
+ * https://ibex-core.readthedocs.io/en/latest/pmp.html#pmp-granularity .
+ */
+#define PMP_GRANULARITY_IBEX 0
+
+/**
+ * RISC-V PMP address alignment and granularity.
+ *
+ * The values have been taken from the:
+ * "Volume II: RISC-V Privileged Architectures V20190608-Priv-MSU-Ratified",
+ * "3.6.1 Physical Memory Protection CSRs", section "Address Matching".
+ *
+ * "PMP mechanism supports regions as small as four bytes, platforms may
+ * specify coarser PMP regions."
+ */
+#define PMP_ADDRESS_MIN_ALIGNMENT 4
+#define PMP_ADDRESS_MIN_ALIGNMENT_NAPOT 8
+#define PMP_ADDRESS_ALIGNMENT (4 << PMP_GRANULARITY_IBEX)
+#define PMP_ADDRESS_ALIGNMENT_MASK (PMP_ADDRESS_ALIGNMENT - 1)
+#define PMP_ADDRESS_ALIGNMENT_INVERTED_MASK (~PMP_ADDRESS_ALIGNMENT_MASK)
+#define PMP_ADDRESS_SHIFT 2
+#define PMP_ADDRESS_SHIFT_NAPOT 3
+
+/**
+ * PMP region access permissions.
+ *
+ * PMP permissions are described in:
+ * "Volume II: RISC-V Privileged Architectures V20190608-Priv-MSU-Ratified",
+ * "3.6.1 Physical Memory Protection CSRs", "Locking and Privilege Mode".
+ *
+ * Note that "The combination R=0 and W=1 is reserved for future use".
+ *
+ * When a region is configured with `kPmpRegionLockUnlocked` then these
+ * permissions only apply to RISC-V "U" and "S" privilege modes, and have no
+ * effect in the "M" mode.
+ */
+typedef enum pmp_region_permissions {
+  kPmpRegionPermissionsNone = 0,         /**< No access permitted .*/
+  kPmpRegionPermissionsReadOnly,         /**< Only read access. */
+  kPmpRegionPermissionsExecuteOnly,      /**< Only execute access. */
+  kPmpRegionPermissionsReadExecute,      /**< Read and execute access. */
+  kPmpRegionPermissionsReadWrite,        /**< Read and write access. */
+  kPmpRegionPermissionsReadWriteExecute, /**< Read, write and execute access. */
+} pmp_region_permissions_t;
+
+/**
+ * PMP region locking.
+ *
+ * PMP locking is described in:
+ * "Volume II: RISC-V Privileged Architectures V20190608-Priv-MSU-Ratified",
+ * "3.6.1 Physical Memory Protection CSRs", "Locking and Privilege Mode".
+ *
+ * When a region is configured with `kPmpRegionLockLocked`, this region cannot
+ * be accessed even by the machine "M" privilege code, and can be only unlocked
+ * by the system reset. Additionally it also forces the
+ * `pmp_region_permissions_t` access restrictions for the corresponding region
+ * in machine "M" mode, which otherwise are ignored.
+ */
+typedef enum pmp_region_lock {
+  kPmpRegionLockUnlocked = 0, /**< The region is unlocked. */
+  kPmpRegionLockLocked,       /**< The region is locked. */
+} pmp_region_lock_t;
+
+/**
+ * PMP region index is used to identify one of `PMP_REGIONS_NUM` PMP regions.
+ */
+typedef uint32_t pmp_region_index_t;
+
+/**
+ * PMP region configuration information.
+ */
+typedef struct pmp_region_config {
+  pmp_region_lock_t lock; /**< Region lock for "M" privilege mode.*/
+  pmp_region_permissions_t permissions; /**< Region access permissions. */
+} pmp_region_config_t;
+
+/**
+ * PMP generic status codes.
+ *
+ * These error codes can be used by any function. However if a function
+ * requires additional status codes, it must define a set of status codes to
+ * be used exclusively by such function.
+ */
+typedef enum pmp_result {
+  kPmpOk = 0, /**< Success. */
+  kPmpError,  /**< General error. */
+  kPmpBadArg, /**< Input parameter is not valid. */
+} pmp_result_t;
+
+/**
+ * PMP region access and address configuration result.
+ */
+typedef enum pmp_region_configure_result {
+  kPmpRegionConfigureOk = kPmpOk,
+  kPmpRegionConfigureError = kPmpError,
+  kPmpRegionConfigureBadArg = kPmpBadArg,
+  /**
+   * The requested region is invalid.
+   */
+  kPmpRegionConfigureBadRegion,
+  /**
+   * The requested address is invalid.
+   */
+  kPmpRegionConfigureBadAddress,
+  /**
+   * The requested region was not configured correctly. From the "Volume II:
+   * RISC-V Privileged Architectures V20190608-Priv-MSU-Ratified":
+   * "Implementations will not raise an exception on writes of unsupported
+   * values to a WARL field. Implementations can return any legal value on the
+   * read of a WARL field when the last write was of an illegal value, but the
+   * legal value returned should deterministically depend on the illegal
+   * written value and the value of the field prior to the write"
+   */
+  kPmpRegionConfigureWarlError,
+} pmp_region_configure_result_t;
+
+/**
+ * Disables PMP address matching.
+ *
+ * Address matching is disabled for `region`, however the corresponding
+ * pmpaddr can still be used as a TOR range start address. For example, when
+ * pmpcfgN is set to TOR, but pmpcfgN-1 is set to OFF, then pmpaddrN-1 can
+ * be used as TOR range start address.
+ *
+ * Please see the PMP specification reference and general information at the
+ * top of this header file.
+ *
+ * Note: this function will clear PMP `region` configuration.
+ *
+ * @param region PMP region to configure and set address for.
+ * @param address System address.
+ * @return `pmp_region_configure_result_t`.
+ */
+PMP_WARN_UNUSED_RESULT
+pmp_region_configure_result_t pmp_region_configure_off(
+    pmp_region_index_t region, uintptr_t address);
+
+/**
+ * PMP region access and address NA4 configuration result.
+ */
+typedef enum pmp_region_configure_na4_result {
+  kPmpRegionConfigureNa4Ok = kPmpRegionConfigureOk,
+  kPmpRegionConfigureNa4Error = kPmpRegionConfigureError,
+  kPmpRegionConfigureNa4BadArg = kPmpRegionConfigureBadArg,
+  kPmpRegionConfigureNa4BadRegion = kPmpRegionConfigureBadRegion,
+  kPmpRegionConfigureNa4BadAddress = kPmpRegionConfigureBadAddress,
+  kPmpRegionConfigureNa4WarlError = kPmpRegionConfigureWarlError,
+  /**
+   * NA4 is not available with granularity "G" > 0. Please see:
+   * "Volume II: RISC-V Privileged Architectures V20190608-Priv-MSU-Ratified",
+   * "3.6.1 Physical Memory Protection CSRs", "Table 3.10" and section
+   * "Address Matching".
+   */
+  kPmpRegionConfigureNa4Unavailable,
+} pmp_region_configure_na4_result_t;
+
+/**
+ * Configures PMP address matching to Naturally aligned four-byte (NA4).
+ *
+ * When pmpcfgN is set to NA4 then the protected region range is formed from
+ * pmpaddrN and extends to the next 4 bytes.
+ *
+ * Please see the PMP specification reference and general information at the
+ * top of this header file.
+ *
+ * @param region PMP region to configure and set the address for.
+ * @param config PMP region configuration information.
+ * @param address Range start system address.
+ * @return `pmp_region_configure_na4_result_t`.
+ */
+PMP_WARN_UNUSED_RESULT
+pmp_region_configure_na4_result_t pmp_region_configure_na4(
+    pmp_region_index_t region, const pmp_region_config_t config,
+    uintptr_t address);
+
+/**
+ * PMP region access and address NAPOT configuration result.
+ */
+typedef enum pmp_region_configure_napot_result {
+  kPmpRegionConfigureNapotOk = kPmpRegionConfigureOk,
+  kPmpRegionConfigureNapotError = kPmpRegionConfigureError,
+  kPmpRegionConfigureNapotBadArg = kPmpRegionConfigureBadArg,
+  kPmpRegionConfigureNapotBadRegion = kPmpRegionConfigureBadRegion,
+  kPmpRegionConfigureNapotBadAddress = kPmpRegionConfigureBadAddress,
+  kPmpRegionConfigureNapotWarlError = kPmpRegionConfigureWarlError,
+  /**
+   * NAPOT size must be at least 8bytes and Power Of Two. NAPOT address
+   * must be aligned to the size. Please see:
+   * "Volume II: RISC-V Privileged Architectures V20190608-Priv-MSU-Ratified",
+   * "3.6.1 Physical Memory Protection CSRs", "Table 3.10" and section
+   * "Address Matching".
+   */
+  kPmpRegionConfigureNapotBadSize,
+} pmp_region_configure_napot_result_t;
+
+/**
+ * Configures PMP address matching to Naturally aligned power-of-two (NAPOT).
+ *
+ * Size ≥ 8 bytes. When pmpcfgN is set to NAPOT then the protected region range
+ * is formed from a single encoded pmpaddrN address. NAPOT ranges make use of
+ * the low-order bits of the associated address register to encode the size of
+ * the range, please see the table "3.10" of the "Address Matching" section of
+ * the specification mentioned above.
+ *
+ * Example: NAPOT encoded address of yyyy011 describes the
+ * yyyy00000 .. yyyy11111 range. The index of the first "0", determines the
+ * range size ( 2^(3 + index) ).
+ *
+ * Please see the PMP specification reference and general information at the
+ * top of this header file.
+ *
+ * @param region PMP region to configure and set the address for.
+ * @param config PMP region configuration information.
+ * @param address Range start system address (must be aligned to `size`).
+ * @param size Address range size (must be power-of-two).
+ * @return `pmp_region_configure_napot_result_t`.
+ */
+PMP_WARN_UNUSED_RESULT
+pmp_region_configure_napot_result_t pmp_region_configure_napot(
+    pmp_region_index_t region, const pmp_region_config_t config,
+    uintptr_t address, uint32_t size);
+
+/**
+ * Configures PMP address matching to Top Of the Range (TOR).
+ *
+ * When pmpcfgN is set to TOR, the protected address range is formed from the
+ * pmpaddrN-1 and pmpaddrN registers. Note that the combination of pmpcfgN set
+ * to TOR and pmpcfgN-1 set to NAPOT does not form any meaningful range for TOR
+ * addressing mode. pmpcfgN TOR mode will take the bottom of the range
+ * pmpaddrN-1 address as is, without decoding the NAPOT address.
+ *
+ * Please see the PMP specification reference and general information at the
+ * top of this header file.
+ *
+ * @param region_end PMP region to configure and set the address for.
+ * @param config PMP region configuration information.
+ * @param address_start Bottom of the range system address. Must be
+ *        0 for the "0" region.
+ * @param address_end Top of the range system address.
+ * @return `pmp_region_configure_result_t`.
+ */
+PMP_WARN_UNUSED_RESULT
+pmp_region_configure_result_t pmp_region_configure_tor(
+    pmp_region_index_t region_end, const pmp_region_config_t config,
+    uintptr_t address_start, uintptr_t address_end);
+
+/**
+ * Queries the lock status for the requested region.
+ *
+ * @param region PMP region to query the lock information for.
+ * @param lock State of the PMP region (locked/unlocked).
+ * @return `pmp_region_configure_result_t`.
+ */
+PMP_WARN_UNUSED_RESULT
+pmp_region_configure_result_t pmp_region_lock_status_get(
+    pmp_region_index_t region, pmp_region_lock_t *lock);
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_RUNTIME_PMP_H_

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -71,12 +71,42 @@ coverage_test_lib = declare_dependency(
   ),
 )
 
+pmp_sanitytest_napot_lib = declare_dependency(
+  link_with: static_library(
+    'pmp_sanitytest_napot_lib',
+    sources: ['pmp_sanitytest_napot.c'],
+    dependencies: [
+      sw_lib_irq,
+      sw_lib_base_log,
+      sw_lib_runtime_hart,
+      sw_lib_runtime_pmp,
+      sw_lib_testing_test_status,
+    ],
+  ),
+)
+
+pmp_sanitytest_tor_lib = declare_dependency(
+  link_with: static_library(
+    'pmp_sanitytest_tor_lib',
+    sources: ['pmp_sanitytest_tor.c'],
+    dependencies: [
+      sw_lib_irq,
+      sw_lib_base_log,
+      sw_lib_runtime_hart,
+      sw_lib_runtime_pmp,
+      sw_lib_testing_test_status,
+    ],
+  ),
+)
+
 sw_tests += {
   'aes_test': aes_test_lib,
   'flash_ctrl_test': flash_ctrl_test_lib,
   'sha256_test': sha256_test_lib,
   'usbdev_test': usbdev_test_lib,
   'coverage_test': coverage_test_lib,
+  'pmp_sanitytest_napot': pmp_sanitytest_napot_lib,
+  'pmp_sanitytest_tor': pmp_sanitytest_tor_lib,
 }
 
 foreach sw_test_name, sw_test_lib : sw_tests

--- a/sw/device/tests/pmp_sanitytest_napot.c
+++ b/sw/device/tests/pmp_sanitytest_napot.c
@@ -1,0 +1,108 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/runtime/pmp.h"
+
+#include "sw/device/lib/handler.h"
+#include "sw/device/lib/irq.h"
+#include "sw/device/lib/runtime/check.h"
+#include "sw/device/lib/runtime/hart.h"
+#include "sw/device/lib/testing/test_main.h"
+#include "sw/device/lib/testing/test_status.h"
+
+#define PMP_LOAD_REGION_ID 0
+
+#define PMP_LOAD_RANGE_BUFFER_SIZE 2048
+#define PMP_LOAD_RANGE_SIZE 1024
+#define PMP_LOAD_RANGE_BOTTOM_OFFSET 0
+#define PMP_LOAD_RANGE_TOP_OFFSET 1023
+
+// These flags are used in the test routine to verify that a corresponding
+// interrupt has elapsed, and has been serviced. These are declared as volatile
+// since they are referenced in the ISR routine as well as in the main program
+// flow.
+static volatile bool pmp_load_exception;
+
+/**
+ * The buffer that is used for load/store access violation test.
+ */
+__attribute__((aligned(PMP_LOAD_RANGE_SIZE)))  //
+static volatile char pmp_load_store_test_data[PMP_LOAD_RANGE_BUFFER_SIZE];
+
+static uint32_t get_mepc(void) {
+  uint32_t mepc;
+  asm volatile("csrr %0, mepc" : "=r"(mepc) :);
+  return mepc;
+}
+
+static void set_mepc(uint32_t mepc) {
+  asm volatile("csrw mepc, %0" : : "r"(mepc));
+}
+
+void handler_lsu_fault(void) {
+  pmp_load_exception = true;
+
+  uint32_t mepc = get_mepc();
+  LOG_INFO("Load fault exception handler: mepc = 0x%x", mepc);
+
+  // Check if the two least significant bits of the instruction are b11 (0x3),
+  // which means that the trapped instruction is not compressed
+  // (32bits = 4bytes), otherwise (16bits = 2bytes).
+  //
+  // NOTE:
+  // with RISC-V "c" (compressed instructions extension), 32bit
+  // instructions can start on 16bit boundary.
+  //
+  // Please see:
+  // "“C” Standard Extension for Compressed Instructions, Version 2.0",
+  // section 16.1.
+  uint32_t fault_instruction = *((uint32_t *)mepc);
+  bool not_compressed = (fault_instruction & 0x3) == 0x3;
+  mepc = not_compressed ? (mepc + 4) : (mepc + 2);
+  set_mepc(mepc);
+}
+
+static void pmp_configure_load_napot(void) {
+  uintptr_t load_range_start =
+      (uintptr_t)&pmp_load_store_test_data[PMP_LOAD_RANGE_BOTTOM_OFFSET];
+
+  pmp_region_config_t config = {
+      .lock = kPmpRegionLockLocked, .permissions = kPmpRegionPermissionsNone,
+  };
+
+  pmp_region_configure_napot_result_t result = pmp_region_configure_napot(
+      PMP_LOAD_REGION_ID, config, load_range_start, PMP_LOAD_RANGE_SIZE);
+  CHECK(result == kPmpRegionConfigureNapotOk,
+        "Load configuration failed, error code = %d", result);
+}
+
+const test_config_t kTestConfig = {
+    .can_clobber_uart = false,
+};
+
+bool test_main(void) {
+  pmp_load_exception = false;
+  char load = pmp_load_store_test_data[PMP_LOAD_RANGE_BOTTOM_OFFSET];
+  CHECK(!pmp_load_exception, "Load access violation before PMP configuration");
+
+  pmp_configure_load_napot();
+
+  pmp_load_exception = false;
+  load = pmp_load_store_test_data[PMP_LOAD_RANGE_BOTTOM_OFFSET];
+  CHECK(pmp_load_exception,
+        "No load access violation on the bottom of the range load");
+
+  pmp_load_exception = false;
+  load = pmp_load_store_test_data[PMP_LOAD_RANGE_TOP_OFFSET];
+  CHECK(pmp_load_exception,
+        "No load access violation on the top of the range load");
+
+  pmp_load_exception = false;
+  load = pmp_load_store_test_data[PMP_LOAD_RANGE_TOP_OFFSET + 1];
+  CHECK(!pmp_load_exception, "Load access violation on top of the range + 1");
+
+  (void)load;
+
+  return true;
+}

--- a/sw/device/tests/pmp_sanitytest_tor.c
+++ b/sw/device/tests/pmp_sanitytest_tor.c
@@ -1,0 +1,127 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/runtime/pmp.h"
+
+#include "sw/device/lib/handler.h"
+#include "sw/device/lib/irq.h"
+#include "sw/device/lib/runtime/check.h"
+#include "sw/device/lib/runtime/hart.h"
+#include "sw/device/lib/testing/test_main.h"
+#include "sw/device/lib/testing/test_status.h"
+
+/**
+ * PMP regions that are used for load/store and execution permission violation
+ * tests.
+ *
+ * "Volume II: RISC-V Privileged Architectures V20190608-Priv-MSU-Ratified",
+ * "3.6 Physical Memory Protection", "Address Matching":
+ *
+ * "If PMP entry i’s A field is set to TOR, the entry matches any address y
+ * such that pmpaddri−1 <= y < pmpaddri. If PMP entry 0’s A field is set to TOR,
+ * zero is used for the lower bound, and so it matches any address
+ * y < pmpaddr0."
+ *
+ * To prtotect an address range that starts above 0 address, the first region
+ * we can use is 1.
+ */
+#define PMP_LOAD_REGION_ID 2
+
+#define PMP_LOAD_RANGE_BUFFER_SIZE 2048
+#define PMP_LOAD_RANGE_SIZE 1024
+#define PMP_LOAD_RANGE_BOTTOM_OFFSET 0
+#define PMP_LOAD_RANGE_TOP_OFFSET 1023
+
+// These flags are used in the test routine to verify that a corresponding
+// interrupt has elapsed, and has been serviced. These are declared as volatile
+// since they are referenced in the ISR routine as well as in the main program
+// flow.
+static volatile bool pmp_load_exception;
+
+/**
+ * The buffer that is used for load/store access violation test.
+ */
+__attribute__((aligned(PMP_LOAD_RANGE_SIZE)))  //
+static volatile char pmp_load_test_data[PMP_LOAD_RANGE_BUFFER_SIZE];
+
+static uint32_t get_mepc(void) {
+  uint32_t mepc;
+  asm volatile("csrr %0, mepc" : "=r"(mepc) :);
+  return mepc;
+}
+
+static void set_mepc(uint32_t mepc) {
+  asm volatile("csrw mepc, %0" : : "r"(mepc));
+}
+
+void handler_lsu_fault(void) {
+  pmp_load_exception = true;
+
+  uint32_t mepc = get_mepc();
+  LOG_INFO("Load fault exception handler: mepc = 0x%x", mepc);
+
+  // Check if the two least significant bits of the instruction are b11 (0x3),
+  // which means that the trapped instruction is not compressed
+  // (32bits = 4bytes), otherwise (16bits = 2bytes).
+  //
+  // NOTE:
+  // with RISC-V "c" (compressed instructions extension), 32bit
+  // instructions can start on 16bit boundary.
+  //
+  // Please see:
+  // "“C” Standard Extension for Compressed Instructions, Version 2.0",
+  // section 16.1.
+  uint32_t fault_instruction = *((uint32_t *)mepc);
+  bool not_compressed = (fault_instruction & 0x3) == 0x3;
+  mepc = not_compressed ? (mepc + 4) : (mepc + 2);
+  set_mepc(mepc);
+}
+
+static void pmp_configure_load_tor(void) {
+  uintptr_t load_range_start =
+      (uintptr_t)&pmp_load_test_data[PMP_LOAD_RANGE_BOTTOM_OFFSET];
+
+  // Non-inclusive
+  uintptr_t load_range_end =
+      (uintptr_t)&pmp_load_test_data[PMP_LOAD_RANGE_SIZE];
+
+  pmp_region_config_t config = {
+      .lock = kPmpRegionLockLocked, .permissions = kPmpRegionPermissionsNone,
+  };
+
+  pmp_region_configure_result_t result = pmp_region_configure_tor(
+      PMP_LOAD_REGION_ID, config, load_range_start, load_range_end);
+  CHECK(result == kPmpRegionConfigureOk,
+        "Load configuration failed, error code = %d", result);
+}
+
+const test_config_t kTestConfig = {
+    .can_clobber_uart = false,
+};
+
+bool test_main(void) {
+  pmp_load_exception = false;
+  char load = pmp_load_test_data[PMP_LOAD_RANGE_BOTTOM_OFFSET];
+  CHECK(!pmp_load_exception, "Load access violation before PMP configuration");
+
+  pmp_configure_load_tor();
+
+  pmp_load_exception = false;
+  load = pmp_load_test_data[PMP_LOAD_RANGE_BOTTOM_OFFSET];
+  CHECK(pmp_load_exception,
+        "No load access violation on the bottom of the range load");
+
+  pmp_load_exception = false;
+  load = pmp_load_test_data[PMP_LOAD_RANGE_TOP_OFFSET];
+  CHECK(pmp_load_exception,
+        "No load access violation on the top of the range load");
+
+  pmp_load_exception = false;
+  load = pmp_load_test_data[PMP_LOAD_RANGE_TOP_OFFSET + 1];
+  CHECK(!pmp_load_exception, "Load access violation on top of the range + 1");
+
+  (void)load;
+
+  return true;
+}


### PR DESCRIPTION
This PR introduces the PMP access library which follows design principles of DIFs (low level HW manipulation API that higher level code builds upon). For more information please see the descriptions in this PR commits.

At the moment only TOR mode is minimally tested.

TODOs:

- Test NA4.

- Add more function descriptions in the source file.

- Hook up to verilator CI tests.

- Return from the fault handler.