### PR TITLE
Remove unicode character from `test_coverage_llvm.c`

### DIFF
--- a/sw/device/lib/testing/test_coverage_llvm.c
+++ b/sw/device/lib/testing/test_coverage_llvm.c
@@ -10,7 +10,7 @@
 
 /**
  * When the linker finds a definition of this symbol, it knows to skip loading
- * the object which contains the profiling runtime’s static initializer. See
+ * the object which contains the profiling runtime's static initializer. See
  * https://clang.llvm.org/docs/SourceBasedCodeCoverage.html#using-the-profiling-runtime-without-static-initializers
  * for more information.
  */


### PR DESCRIPTION
Its presence breaks doxygen generation, so switch to a normal
apostrophe.

Signed-off-by: Garret Kelly <gdk@google.com>