### PR TITLE
site/docs: Pin builder container to Ubuntu 16.04

### DIFF
--- a/site/docs/builder.Dockerfile
+++ b/site/docs/builder.Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ubuntu:18.04
+FROM ubuntu:16.04
 
 RUN apt-get update && \
   apt-get install -y git curl doxygen python3 python3-pip xsltproc && \


### PR DESCRIPTION
We specify Ubuntu 16.04 as the base distribution, so it doesn't make
sense to be building with a newer developer-untested version for the
docs container.

Signed-off-by: Garret Kelly <gdk@google.com>