### PR TITLE
[dv, testplanner] Attempt to expand the descr col

### DIFF
--- a/util/dvsim/testplanner/README.md
+++ b/util/dvsim/testplanner/README.md
@@ -171,7 +171,7 @@ a starting point.
 In addition, see the [UART DV Plan]({{< relref "hw/ip/uart/doc/dv_plan" >}}) for a
 real 'production' example of inline expansion of an imported testplan as a table
 within the DV Plan document.
-The [UART testplan](https://github.com/lowRISC/opentitan/blob/master/hw/ip/uart/data/uart_testplan.hjson)
+The [UART testplan in HJson](https://github.com/lowRISC/opentitan/blob/master/hw/ip/uart/data/uart_testplan.hjson)
 imports the shared testplans located at `hw/dv/tools/testplans` area.
 
 ### Limitations
@@ -188,23 +188,26 @@ The following limitations currently hold:
 
 Generate the testplan table in HTML to stdout:
 ```console
-$ util/dvsim/testplanner.py testplanner/examples/foo_testplan.hjson
+$ util/dvsim/testplanner.py util/dvsim/testplanner/examples/foo_testplan.hjson
 ```
 
 Generate the testplan table in HTML to a file:
 ```console
-$ util/dvsim/testplanner.py testplanner/examples/foo_testplan.hjson -o /tmp/foo_testplan_table.html
+$ util/dvsim/testplanner.py util/dvsim/testplanner/examples/foo_testplan.hjson \
+    -o /tmp/foo_testplan_table.html
 ```
 
 Generate regression results table in HTML to stdout:
 ```console
-$ util/dvsim/testplanner.py testplanner/examples/foo_testplan.hjson -r testplanner/examples/foo_regr_results.hjson
+$ util/dvsim/testplanner.py util/dvsim/testplanner/examples/foo_testplan.hjson \
+    -r util/dvsim/testplanner/examples/foo_regr_results.hjson
 ```
 
 Generate regression results table in HTML to a file:
 ```console
-$ util/dvsim/testplanner.py testplanner/examples/foo_testplan.hjson \
-    -r testplanner/examples/foo_regr_results.hjson -o /tmp/foo_regr_results.html
+$ util/dvsim/testplanner.py util/dvsim/testplanner/examples/foo_testplan.hjson \
+    -r util/dvsim/testplanner/examples/foo_regr_results.hjson \
+    -o /tmp/foo_regr_results.html
 ```
 
 ### APIs for external tools
@@ -216,7 +219,8 @@ plan document. This is done by invoking:
 $ ./util/build_docs.py
 ```
 The output for each testplan will be saved into `build/docs-generated`.
-For example the path to the GPIO IP testplan is `build/docs-generated/hw/ip/gpio/data/gpio_testplan.hjson.testplan`.
+For example the path to the GPIO IP testplan is
+`build/docs-generated/hw/ip/gpio/data/gpio_testplan.hjson.testplan`.
 
 See following snippet of code for the APIs in use:
 ```python
@@ -232,5 +236,3 @@ from testplanner import class_defs, testplan_utils
 * Allow DUT and imported testplans have the same name for the planned test as
   long as they are in separate files
   * If the same name exists, then append the list of tests together
-* Split the regression results table generation into a separate `dashboard_gen`
-  script which will also cater to generating results table for `lint` and `fpv`

--- a/util/dvsim/testplanner/class_defs.py
+++ b/util/dvsim/testplanner/class_defs.py
@@ -294,7 +294,7 @@ class Testplan():
         '''Generate testplan table from hjson entries in the format specified
         by the 'fmt' arg.
         '''
-        table = [["Milestone", "Name", "Description", "Tests"]]
+        table = [["Milestone", "Name", "Tests", "Description"]]
         colalign = ("center", "center", "left", "left")
         for entry in self.entries:
             tests = ""
@@ -303,7 +303,7 @@ class Testplan():
             desc = entry.desc.strip()
             if fmt == "html":
                 desc = mistletoe.markdown(desc)
-            table.append([entry.milestone, entry.name, desc, tests])
+            table.append([entry.milestone, entry.name, tests, desc])
         result = tabulate(table,
                           headers="firstrow",
                           tablefmt=fmt,

--- a/util/dvsim/testplanner/testplan_utils.py
+++ b/util/dvsim/testplanner/testplan_utils.py
@@ -56,13 +56,14 @@ def gen_html_indent(lvl):
 def gen_html_write_style(outbuf):
     outbuf.write("<style>\n")
     outbuf.write("table.dv {\n")
+    outbuf.write("    width: 100%;\n")
     outbuf.write("    border: 1px solid black;\n")
     outbuf.write("    border-collapse: collapse;\n")
     outbuf.write("    text-align: left;\n")
     outbuf.write("    vertical-align: middle;\n")
     outbuf.write("    display: table;\n")
     outbuf.write("}\n")
-    outbuf.write("th, td {\n")
+    outbuf.write("table.dv th, td {\n")
     outbuf.write("    border: 1px solid black;\n")
     outbuf.write("}\n")
     outbuf.write("</style>\n")
@@ -74,7 +75,12 @@ def gen_html_testplan_table(testplan, outbuf):
     '''
 
     text = testplan.testplan_table(fmt="html")
-    text = text.replace("<table>", "<table class=\"dv\">")
+    table_class = "<table class=\"dv\">\n"
+    table_class += "  <col width=\"10%\">\n"
+    table_class += "  <col width=\"20%\">\n"
+    table_class += "  <col width=\"20%\">\n"
+    table_class += "  <col width=\"50%\">"
+    text = text.replace("<table>", table_class)
     gen_html_write_style(outbuf)
     outbuf.write(text)
     return


### PR DESCRIPTION
This PR *unsuccessfully* attempts to expand the description column in
the Hugo generated documentation.
The change allocates widths 10%, 20%, 20%, 50% to Milestone, Name, Tests
and Description column of the generated testplan.
This works when running the command 'bare' without the Hugo-fication.
```console
util/dvsim/testplanner.py util/dvsim/testplanner/examples/foo_testplan.hjson -o /tmp/foo_testplan_table.html
```

Signed-off-by: Srikrishna Iyer <sriyer@google.com>

