### PR TITLE
[dv/common] Add generic push/pull interface agent

### DIFF
--- a/hw/dv/sv/push_pull_agent/README.md
+++ b/hw/dv/sv/push_pull_agent/README.md
@@ -1,0 +1,13 @@
+# PUSH_PULL UVM Agent
+
+PUSH_PULL UVM Agent is extended from DV library agent classes.
+
+## Description
+
+This agent implements both Push (ready/valid) and Pull (req/ack) interface
+protocols, and can be configured to behave in both host and device modes.
+
+The agent configuration object (`push_pull_agent_cfg`) contains an enum `agent_type`
+that is used to select either push or pull modes.
+To configure the agent to use the ready/valid protocol, set `agent_type = PushAgent`, and
+to configure the agent to use the req/ack protocol, set `agent_type = PullAgent`.

--- a/hw/dv/sv/push_pull_agent/push_pull_agent.core
+++ b/hw/dv/sv/push_pull_agent/push_pull_agent.core
@@ -1,0 +1,33 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:push_pull_agent:0.1"
+description: "PUSH_PULL DV UVM agent"
+filesets:
+  files_dv:
+    depend:
+      - lowrisc:dv:dv_utils
+      - lowrisc:dv:dv_lib
+    files:
+      - push_pull_if.sv
+      - push_pull_agent_pkg.sv
+      - push_pull_item.sv: {is_include_file: true}
+      - push_pull_agent_cfg.sv: {is_include_file: true}
+      - push_pull_agent_cov.sv: {is_include_file: true}
+      - push_pull_driver.sv: {is_include_file: true}
+      - push_pull_host_driver.sv: {is_include_file: true}
+      - push_pull_device_driver.sv: {is_include_file: true}
+      - push_pull_monitor.sv: {is_include_file: true}
+      - push_pull_sequencer.sv: {is_include_file: true}
+      - push_pull_agent.sv: {is_include_file: true}
+      - seq_lib/push_pull_base_seq.sv: {is_include_file: true}
+      - seq_lib/push_pull_host_seq.sv: {is_include_file: true}
+      - seq_lib/push_pull_device_seq.sv: {is_include_file: true}
+      - seq_lib/push_pull_seq_list.sv: {is_include_file: true}
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_dv

--- a/hw/dv/sv/push_pull_agent/push_pull_agent.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_agent.sv
@@ -1,0 +1,47 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class push_pull_agent #(parameter int DataWidth = 32) extends dv_base_agent #(
+  .CFG_T          (push_pull_agent_cfg#(DataWidth)),
+  .DRIVER_T       (push_pull_driver#(DataWidth)),
+  .HOST_DRIVER_T  (push_pull_host_driver#(DataWidth)),
+  .DEVICE_DRIVER_T(push_pull_device_driver#(DataWidth)),
+  .SEQUENCER_T    (push_pull_sequencer#(DataWidth)),
+  .MONITOR_T      (push_pull_monitor#(DataWidth)),
+  .COV_T          (push_pull_agent_cov#(DataWidth))
+);
+
+  `uvm_component_param_utils(push_pull_agent#(DataWidth))
+
+  `uvm_component_new
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    // get push_pull_if handle
+    if (!uvm_config_db#(virtual push_pull_if#(DataWidth))::get(this, "", "vif", cfg.vif)) begin
+      `uvm_fatal(`gfn, "failed to get push_pull_if handle from uvm_config_db")
+    end
+    cfg.vif.is_push_agent = (cfg.agent_type == PushAgent);
+  endfunction
+
+  function void connect_phase(uvm_phase phase);
+    super.connect_phase(phase);
+    if (cfg.if_mode == dv_utils_pkg::Device) begin
+      monitor.req_port.connect(sequencer.req_fifo.analysis_export);
+    end
+  endfunction
+
+  virtual task run_phase(uvm_phase phase);
+    push_pull_device_seq#(DataWidth) m_seq =
+      push_pull_device_seq#(DataWidth)::type_id::create("m_seq", this);
+    if (cfg.if_mode == dv_utils_pkg::Device && cfg.start_default_device_seq) begin
+      uvm_config_db#(uvm_object_wrapper)::set(null,
+                                             {sequencer.get_full_name(), ".run_phase"},
+                                             "default_sequence",
+                                             m_seq.get_type());
+      sequencer.start_phase_sequence(phase);
+    end
+  endtask
+
+endclass

--- a/hw/dv/sv/push_pull_agent/push_pull_agent_cfg.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_agent_cfg.sv
@@ -1,0 +1,46 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class push_pull_agent_cfg #(parameter int DataWidth = 32) extends dv_base_agent_cfg;
+
+  // interface handle used by driver, monitor & the sequencer, via cfg handle
+  virtual push_pull_if#(DataWidth) vif;
+
+  // Determines whether this agent is configured as push or pull.
+  // Should be set from the IP level environment.
+  push_pull_agent_e agent_type;
+
+  // Device-side delay range for both Push/Pull protocols.
+  int unsigned device_delay_min = 0;
+  int unsigned device_delay_max = 10;
+
+  // Host-side delay range for both Push/Pull protocols.
+  int unsigned host_delay_min = 0;
+  int unsigned host_delay_max = 10;
+
+  // Enables/disable all protocol delays.
+  rand bit zero_delays;
+
+  // Enable starting the device sequence by default if configured in Device mode.
+  bit start_default_device_seq = 1;
+
+  // Bias randomization in favor of enabling zero delays less often.
+  constraint zero_delays_c {
+    zero_delays dist { 0 := 7,
+                       1 := 3 };
+  }
+
+  `uvm_object_param_utils_begin(push_pull_agent_cfg#(DataWidth))
+    `uvm_field_enum(push_pull_agent_e, agent_type, UVM_DEFAULT)
+    `uvm_field_int(device_delay_min,               UVM_DEFAULT)
+    `uvm_field_int(device_delay_max,               UVM_DEFAULT)
+    `uvm_field_int(host_delay_min,                 UVM_DEFAULT)
+    `uvm_field_int(host_delay_max,                 UVM_DEFAULT)
+    `uvm_field_int(zero_delays,                    UVM_DEFAULT)
+    `uvm_field_int(start_default_device_seq,       UVM_DEFAULT)
+  `uvm_object_utils_end
+
+  `uvm_object_new
+
+endclass

--- a/hw/dv/sv/push_pull_agent/push_pull_agent_cov.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_agent_cov.sv
@@ -1,0 +1,21 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class push_pull_agent_cov #(parameter int DataWidth = 32) extends dv_base_agent_cov #(
+    push_pull_agent_cfg#(DataWidth)
+);
+
+  `uvm_component_param_utils(push_pull_agent_cov#(DataWidth))
+
+  // the base class provides the following handles for use:
+  // push_pull_agent_cfg: cfg
+
+  // covergroups
+
+  function new(string name, uvm_component parent);
+    super.new(name, parent);
+    // instantiate all covergroups here
+  endfunction : new
+
+endclass

--- a/hw/dv/sv/push_pull_agent/push_pull_agent_pkg.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_agent_pkg.sv
@@ -1,0 +1,32 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package push_pull_agent_pkg;
+  // dep packages
+  import uvm_pkg::*;
+  import dv_utils_pkg::*;
+  import dv_lib_pkg::*;
+
+  // macro includes
+  `include "uvm_macros.svh"
+  `include "dv_macros.svh"
+
+  // Instantiated in agent's config object.
+  typedef enum {
+    PushAgent,
+    PullAgent
+  } push_pull_agent_e;
+
+  `include "push_pull_item.sv"
+  `include "push_pull_agent_cfg.sv"
+  `include "push_pull_agent_cov.sv"
+  `include "push_pull_driver.sv"
+  `include "push_pull_host_driver.sv"
+  `include "push_pull_device_driver.sv"
+  `include "push_pull_monitor.sv"
+  `include "push_pull_sequencer.sv"
+  `include "push_pull_seq_list.sv"
+  `include "push_pull_agent.sv"
+
+endpackage: push_pull_agent_pkg

--- a/hw/dv/sv/push_pull_agent/push_pull_device_driver.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_device_driver.sv
@@ -1,0 +1,82 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`define PUSH_DRIVER cfg.vif.device_push_cb
+`define PULL_DRIVER cfg.vif.device_pull_cb
+
+class push_pull_device_driver #(parameter int DataWidth = 32) extends push_pull_driver #(DataWidth);
+
+  `uvm_component_param_utils(push_pull_device_driver#(DataWidth))
+
+  // the base class provides the following handles for use:
+  // push_pull_agent_cfg: cfg
+
+  `uvm_component_new
+
+  virtual task do_reset();
+    if (cfg.agent_type == PushAgent) begin
+      cfg.vif.ready <= '0;
+    end else begin
+      cfg.vif.ack   <= '0;
+      cfg.vif.data  <= 'x;
+    end
+  endtask
+
+  virtual task get_and_drive();
+    // wait for initial reset to pass
+    @(posedge cfg.vif.rst_n);
+    forever begin
+      seq_item_port.get_next_item(req);
+      `uvm_info(`gfn, $sformatf("driver rcvd item:\n%0s", req.convert2string()), UVM_HIGH)
+      if (!in_reset) begin
+        if (cfg.agent_type == PushAgent) begin
+          drive_push();
+        end else if (cfg.agent_type == PullAgent) begin
+          drive_pull();
+        end else begin
+          `uvm_fatal(`gfn, $sformatf("%0s is an invalid driver protocol!", cfg.agent_type))
+        end
+      end
+      seq_item_port.item_done(req);
+    end
+  endtask
+
+  // Drives device side of ready/valid protocol.
+  virtual task drive_push();
+    repeat (req.device_delay) begin
+      if (in_reset) break;
+      @(`PUSH_DRIVER);
+    end
+    if (!in_reset) begin
+      `PUSH_DRIVER.ready <= 1'b1;
+    end
+    @(`PUSH_DRIVER);
+    if (!in_reset) begin
+      `PUSH_DRIVER.ready <= 1'b0;
+    end
+  endtask
+
+  virtual task drive_pull();
+    while (!`PULL_DRIVER.req && !in_reset) begin
+      @(`PULL_DRIVER);
+    end
+    repeat (req.device_delay) begin
+      if (in_reset) break;
+      @(`PULL_DRIVER);
+    end
+    if (!in_reset) begin
+      `PULL_DRIVER.ack  <= 1'b1;
+      `PULL_DRIVER.data <= req.data;
+    end
+    @(`PULL_DRIVER);
+    if (!in_reset) begin
+      `PULL_DRIVER.ack  <= 1'b0;
+      `PULL_DRIVER.data <= 'x;
+    end
+  endtask
+
+endclass
+
+`undef PULL_DRIVER
+`undef PUSH_DRIVER

--- a/hw/dv/sv/push_pull_agent/push_pull_driver.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_driver.sv
@@ -1,0 +1,41 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class push_pull_driver #(parameter int DataWidth = 32) extends dv_base_driver #(
+    .ITEM_T(push_pull_item#(DataWidth)),
+    .CFG_T(push_pull_agent_cfg#(DataWidth))
+);
+
+  bit in_reset = 1'b0;
+
+  `uvm_component_param_utils(push_pull_driver#(DataWidth))
+  `uvm_component_new
+
+  virtual task reset_signals();
+    // initial reset at start of test
+    do_reset();
+    forever begin
+      @(negedge cfg.vif.rst_n);
+      `uvm_info(`gfn, "driver is resetting", UVM_HIGH)
+      in_reset = 1'b1;
+      do_reset();
+      @(posedge cfg.vif.rst_n);
+      `uvm_info(`gfn, "driver is out of reset", UVM_HIGH)
+      in_reset = 1'b0;
+    end
+  endtask
+
+  virtual task do_reset();
+    `uvm_fatal(`gfn, "Must implement in host/device driver")
+  endtask
+
+  virtual task drive_pull();
+    `uvm_fatal(`gfn, "Must implement in host/device driver")
+  endtask
+
+  virtual task drive_push();
+    `uvm_fatal(`gfn, "Must implement in host/device driver")
+  endtask
+
+endclass

--- a/hw/dv/sv/push_pull_agent/push_pull_host_driver.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_host_driver.sv
@@ -1,0 +1,89 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`define PUSH_DRIVER cfg.vif.host_push_cb
+`define PULL_DRIVER cfg.vif.host_pull_cb
+
+class push_pull_host_driver #(parameter int DataWidth = 32) extends push_pull_driver #(DataWidth);
+
+  `uvm_component_param_utils(push_pull_host_driver#(DataWidth))
+
+  // the base class provides the following handles for use:
+  // push_pull_agent_cfg: cfg
+
+  `uvm_component_new
+
+  virtual task do_reset();
+    if (cfg.agent_type == PushAgent) begin
+      cfg.vif.valid <= '0;
+      cfg.vif.data  <= 'x;
+    end else begin
+      cfg.vif.req <= '0;
+    end
+  endtask
+
+  // drive trans received from sequencer
+  virtual task get_and_drive();
+    // wait for the initial reset to pass
+    @(posedge cfg.vif.rst_n);
+    forever begin
+      seq_item_port.try_next_item(req);
+      if (req != null) begin
+        `uvm_info(`gfn, $sformatf("rcvd item:\n%0s", req.convert2string()), UVM_HIGH)
+        if (!in_reset) begin
+          if (cfg.agent_type == PushAgent) begin
+            drive_push();
+          end else if (cfg.agent_type == PullAgent) begin
+            drive_pull();
+          end else begin
+            `uvm_fatal(`gfn, $sformatf("%0s is an invalid driver protocol!", cfg.agent_type))
+          end
+        end
+        seq_item_port.item_done(req);
+      end else begin
+        cfg.vif.wait_clks(1);
+      end
+    end
+  endtask
+
+  // Drives host side of ready/valid protocol
+  virtual task drive_push();
+    repeat (req.host_delay) begin
+      if (in_reset) break;
+      @(`PUSH_DRIVER);
+    end
+    if (!in_reset) begin
+      `PUSH_DRIVER.valid <= 1'b1;
+      `PUSH_DRIVER.data  <= req.data;
+    end
+    do begin
+      @(`PUSH_DRIVER);
+    end while (!`PUSH_DRIVER.ready && !in_reset);
+    if (!in_reset) begin
+      `PUSH_DRIVER.valid <= 1'b0;
+      `PUSH_DRIVER.data  <= 'x;
+    end
+  endtask
+
+  // Drives host side of req/ack protocol
+  virtual task drive_pull();
+    repeat (req.host_delay) begin
+      if (in_reset) break;
+      @(`PULL_DRIVER);
+    end
+    if (!in_reset) begin
+      `PULL_DRIVER.req <= 1'b1;
+    end
+    do begin
+      @(`PULL_DRIVER);
+    end while (!`PULL_DRIVER.ack && !in_reset);
+    if (!in_reset) begin
+      `PULL_DRIVER.req <= 1'b0;
+    end
+  endtask
+
+endclass
+
+`undef PULL_DRIVER
+`undef PUSH_DRIVER

--- a/hw/dv/sv/push_pull_agent/push_pull_if.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_if.sv
@@ -1,0 +1,110 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`include "prim_assert.sv"
+
+interface push_pull_if #(parameter int DataWidth = 32) (input wire clk, input wire rst_n);
+
+  // Pins for the push handshake (ready/valid)
+  logic ready;
+  logic valid;
+
+  // Pins for the pull handshake (req/ack)
+  logic req;
+  logic ack;
+
+  // Parameterized width data payload
+  logic [DataWidth-1:0] data;
+
+  // This bit controls what protocol assertions will be enabled,
+  // e.g. if the agent is configured in Push mode, we do not want to
+  // enable assertions relating to the Pull protocol.
+  //
+  // This bit is set to the appropriate value in push_pull_agent::build_phase().
+  bit is_push_agent;
+
+  // clocking blocks
+  clocking host_push_cb @(posedge clk);
+    input   ready;
+    output  valid;
+    output  data;
+  endclocking
+
+  clocking device_push_cb @(posedge clk);
+    output  ready;
+    input   valid;
+    input   data;
+  endclocking
+
+  clocking host_pull_cb @(posedge clk);
+    output  req;
+    input   ack;
+    input   data;
+  endclocking
+
+  clocking device_pull_cb @(posedge clk);
+    input   req;
+    output  ack;
+    output  data;
+  endclocking
+
+  clocking mon_cb @(posedge clk);
+    input ready;
+    input valid;
+    input req;
+    input ack;
+    input data;
+  endclocking
+
+  // utility tasks
+  task automatic wait_clks(input int num);
+    repeat (num) @(posedge clk);
+  endtask : wait_clks
+
+  task automatic wait_n_clks(input int num);
+    repeat (num) @(negedge clk);
+  endtask : wait_n_clks
+
+  // Assertions for ready/valid protocol.
+
+  // The ready and valid signals should always have known values.
+  `ASSERT_KNOWN_IF(ReadyIsKnown_A, ready, is_push_agent, clk, !rst_n)
+  `ASSERT_KNOWN_IF(ValidIsKnown_A, valid, is_push_agent, clk, !rst_n)
+
+  // Whenever valid is asserted, the data must have a known value.
+  `ASSERT_KNOWN_IF(DataKnownWhenValid_A, data, valid && is_push_agent, clk, !rst_n)
+
+  // When valid is asserted but ready is low the data must stay stable.
+  `ASSERT_IF(DataStableWhenValidAndNotReady_A, (valid && !ready) |=> $stable(data),
+             is_push_agent, clk, !rst_n)
+
+  // When valid is asserted, it must stay high until seeing ready be asserted.
+  `ASSERT_IF(ValidHighUntilReady_A, $rose(valid) |-> (valid throughout ready [->1]),
+             is_push_agent, clk, !rst_n)
+
+  // Assertions for req/ack protocol.
+
+  // The req and ack signals should always have known values.
+  `ASSERT_KNOWN_IF(ReqIsKnown_A, req, !is_push_agent, clk, !rst_n)
+  `ASSERT_KNOWN_IF(AckIsKnown_A, ack, !is_push_agent, clk, !rst_n)
+
+  // When ack is asserted, the data must have a known value.
+  `ASSERT_KNOWN_IF(DataKnownWhenAck_A, data, ack && !is_push_agent, clk, !rst_n)
+
+  // TODO: The following two assertions make a rather important assumption about the req/ack
+  //       protocol that will be used for the key/csrng interfaces, which is that no requests
+  //       are allowed to be dropped by the network. This issue is made more complex by the
+  //       fact that several of the IPs connected to this network may be in different clock
+  //       domains, requiring CDC.
+  //       Based on the final decision on this issue, these assertions may have to be removed
+  //       if it is allowed for requests to be dropped.
+
+  // ack cannot be 1 if req is not 1.
+  `ASSERT_IF(AckAssertedOnlyWhenReqAsserted_A, ack |-> req, !is_push_agent, clk, !rst_n)
+
+  // When req is asserted, it must stay high until a corresponding ack is seen.
+  `ASSERT_IF(ReqHighUntilAck_A, $rose(req) |-> (req throughout ack [->1]),
+             !is_push_agent, clk, !rst_n)
+
+endinterface

--- a/hw/dv/sv/push_pull_agent/push_pull_item.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_item.sv
@@ -1,0 +1,29 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class push_pull_item #(parameter int DataWidth = 32) extends uvm_sequence_item;
+
+  rand bit [DataWidth-1:0] data;
+
+  // Host-side delay for both Push/Pull protocols.
+  rand int unsigned host_delay;
+
+  // Device-side delay for both Push/Pull protocols.
+  rand int unsigned device_delay;
+
+  `uvm_object_param_utils_begin(push_pull_item#(DataWidth))
+    `uvm_field_int(data,         UVM_DEFAULT)
+    `uvm_field_int(host_delay,   UVM_DEFAULT)
+    `uvm_field_int(device_delay, UVM_DEFAULT)
+  `uvm_object_utils_end
+
+  `uvm_object_new
+
+  virtual function string convert2string();
+    return {$sformatf("data = 0x%0x ", data),
+            $sformatf("host_delay = 0x%0x ", host_delay),
+            $sformatf("device_delay = 0x%0x ", device_delay)};
+  endfunction
+
+endclass

--- a/hw/dv/sv/push_pull_agent/push_pull_monitor.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_monitor.sv
@@ -1,0 +1,114 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class push_pull_monitor #(parameter int DataWidth = 32) extends dv_base_monitor #(
+    .ITEM_T (push_pull_item#(DataWidth)),
+    .CFG_T  (push_pull_agent_cfg#(DataWidth)),
+    .COV_T  (push_pull_agent_cov#(DataWidth))
+  );
+  `uvm_component_param_utils(push_pull_monitor#(DataWidth))
+
+  // the base class provides the following handles for use:
+  // push_pull_agent_cfg: cfg
+  // push_pull_agent_cov: cov
+  // uvm_analysis_port #(push_pull_item): analysis_port
+
+  // connected to sequencer to send request responses
+  uvm_analysis_port #(push_pull_item#(DataWidth)) req_port;
+
+  `uvm_component_new
+
+  bit valid_txn;
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    req_port = new("req_port", this);
+  endfunction
+
+  task run_phase(uvm_phase phase);
+    @(posedge cfg.vif.rst_n);
+    fork
+      handle_reset();
+      collect_valid_trans();
+      // We only need to monitor incoming requests if the agent is configured
+      // in device mode and is using Pull protocol.
+      if (cfg.if_mode == dv_utils_pkg::Device &&
+          cfg.agent_type == PullAgent) begin
+        collect_request();
+      end
+    join_none
+  endtask
+
+  virtual protected task handle_reset();
+    forever begin
+      @(negedge cfg.vif.rst_n);
+      // TODO: sample any reset-related covergroups
+      @(posedge cfg.vif.rst_n);
+    end
+  endtask
+
+  // TODO : sample covergroups
+  virtual protected task collect_valid_trans();
+    push_pull_item#(DataWidth) item;
+    forever begin
+      @(cfg.vif.mon_cb);
+      if (cfg.agent_type == PushAgent) begin
+        if (cfg.vif.mon_cb.ready && cfg.vif.mon_cb.valid) begin
+          valid_txn = 1'b1;
+          // TODO: sample covergroups
+        end
+      end else begin
+        if (cfg.vif.mon_cb.req && cfg.vif.mon_cb.ack) begin
+          valid_txn = 1'b1;
+          // TODO: sample covergroups
+        end
+      end
+      if (valid_txn) begin
+        item = push_pull_item#(DataWidth)::type_id::create("item");
+        item.data = cfg.vif.mon_cb.data;
+        `uvm_info(`gfn, $sformatf("[%0s] transaction detected: data = 0x%0x",
+                                  cfg.agent_type, item.data), UVM_HIGH)
+        analysis_port.write(item);
+        valid_txn = 1'b0;
+      end
+    end
+  endtask
+
+  // This task is only used for device agents using the Pull protocol.
+  // It will pick up any incoming requests from the DUT and send a signal to the
+  // sequencer (in the form of a sequence item), which will then be forwarded to
+  // the sequence, which then generates the appropriate response item.
+  //
+  // TODO: This assumes no requests can be dropped, and might need to be fixed
+  //       if this is not allowed.
+  virtual protected task collect_request();
+    push_pull_item#(DataWidth) item;
+    forever begin
+      @(cfg.vif.mon_cb);
+      if (cfg.vif.req) begin
+        `uvm_info(`gfn, "detected pull request", UVM_HIGH)
+        // TODO: sample any covergroups
+        item = push_pull_item#(DataWidth)::type_id::create("item");
+        req_port.write(item);
+        // After picking up a request, wait until a response is sent before
+        // detecting another request, as this is not a pipelined protocol.
+        @(negedge valid_txn);
+      end
+    end
+  endtask
+
+  // update ok_to_end to prevent simulation from finishing when
+  // there is any activity on the bus.
+  virtual task monitor_ready_to_end();
+    forever begin
+      @(cfg.vif.mon_cb);
+      if (cfg.agent_type == PushAgent) begin
+        ok_to_end = (cfg.vif.valid == 0);
+      end else begin
+        ok_to_end = (cfg.vif.req == 0) && (cfg.vif.ack == 0);
+      end
+    end
+  endtask
+
+endclass

--- a/hw/dv/sv/push_pull_agent/push_pull_sequencer.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_sequencer.sv
@@ -1,0 +1,24 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class push_pull_sequencer #(parameter int DataWidth = 32) extends dv_base_sequencer #(
+    .ITEM_T (push_pull_item#(DataWidth)),
+    .CFG_T  (push_pull_agent_cfg#(DataWidth))
+);
+  `uvm_component_param_utils(push_pull_sequencer#(DataWidth))
+
+  // Analysis port through which device monitors can send transactions
+  // to the sequencer.
+  uvm_tlm_analysis_fifo #(push_pull_item#(DataWidth)) req_fifo;
+
+  `uvm_component_new
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    if (cfg.if_mode == dv_utils_pkg::Device) begin
+      req_fifo = new("req_fifo");
+    end
+  endfunction : build_phase
+
+endclass

--- a/hw/dv/sv/push_pull_agent/seq_lib/push_pull_base_seq.sv
+++ b/hw/dv/sv/push_pull_agent/seq_lib/push_pull_base_seq.sv
@@ -1,0 +1,18 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class push_pull_base_seq #(parameter int DataWidth = 32) extends dv_base_seq #(
+    .REQ         (push_pull_item#(DataWidth)),
+    .CFG_T       (push_pull_agent_cfg#(DataWidth)),
+    .SEQUENCER_T (push_pull_sequencer#(DataWidth))
+  );
+  `uvm_object_param_utils(push_pull_base_seq#(DataWidth))
+
+  `uvm_object_new
+
+  virtual task body();
+    `uvm_fatal(`gtn, "Need to override this when you extend from this class!")
+  endtask
+
+endclass

--- a/hw/dv/sv/push_pull_agent/seq_lib/push_pull_device_seq.sv
+++ b/hw/dv/sv/push_pull_agent/seq_lib/push_pull_device_seq.sv
@@ -1,0 +1,63 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Response sequence for Push and Pull protocols.
+// This sequence will infinitely pol for any DUT requests detected by
+// the monitor, and trigger the response driver anytime a request is detected.
+
+class push_pull_device_seq #(parameter int DataWidth = 32) extends push_pull_base_seq #(DataWidth);
+
+  `uvm_object_param_utils(push_pull_device_seq#(DataWidth))
+
+  `uvm_object_new
+
+  mailbox #(push_pull_item#(DataWidth)) req_mailbox;
+
+  virtual task body();
+    req_mailbox = new();
+
+    if (cfg.agent_type == PushAgent) begin
+      // In Push mode, continuously send an empty but randomized sequence item
+      // to the device driver (which just needs to assert ready).
+      forever begin
+        req = push_pull_item#(DataWidth)::type_id::create("req");
+        start_item(req);
+        `DV_CHECK_RANDOMIZE_WITH_FATAL(req,
+          if (cfg.zero_delays) {
+            device_delay == 0;
+          } else {
+            device_delay inside {[cfg.device_delay_min : cfg.device_delay_max]};
+          }
+        )
+        finish_item(req);
+        get_response(rsp);
+        `uvm_info(`gfn, $sformatf("Received response: %0s", rsp.convert2string()), UVM_HIGH)
+      end
+    end else begin
+      fork
+        forever begin : collect_req
+          // We indefinitely poll for any traffic sent from the monitor and store it to a mailbox.
+          p_sequencer.req_fifo.get(req);
+          req_mailbox.put(req);
+        end : collect_req
+        forever begin : send_req
+          // Collect transactions stored in the mailbox and send them to the driver.
+          req_mailbox.get(rsp);
+          start_item(rsp);
+          `DV_CHECK_RANDOMIZE_WITH_FATAL(rsp,
+            if (cfg.zero_delays) {
+              device_delay == 0;
+            } else {
+              device_delay inside {[cfg.device_delay_min : cfg.device_delay_max]};
+            }
+          )
+          finish_item(rsp);
+          get_response(rsp);
+          `uvm_info(`gfn, $sformatf("Received response: %0s", rsp.convert2string()), UVM_HIGH)
+        end : send_req
+      join
+    end
+  endtask
+
+endclass

--- a/hw/dv/sv/push_pull_agent/seq_lib/push_pull_host_seq.sv
+++ b/hw/dv/sv/push_pull_agent/seq_lib/push_pull_host_seq.sv
@@ -1,0 +1,37 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Request sequence for Push and Pull protocols.
+// This sequence will send num_trans requests to the DUT.
+
+class push_pull_host_seq #(parameter int DataWidth = 32) extends push_pull_base_seq #(DataWidth);
+
+  `uvm_object_param_utils(push_pull_host_seq#(DataWidth))
+
+  `uvm_object_new
+
+  // Default to send 1 transactions.
+  // Can be overridden at a higher layer.
+  int unsigned num_trans = 1;
+
+  virtual task body();
+    for (int i = 0; i < num_trans; i++) begin : send_req
+      req = push_pull_item#(DataWidth)::type_id::create($sformatf("req[%0d]", i));
+      start_item(req);
+      `DV_CHECK_RANDOMIZE_WITH_FATAL(req,
+        if (cfg.zero_delays) {
+          host_delay == 0;
+        } else {
+          host_delay inside {[cfg.host_delay_min : cfg.host_delay_max]};
+        }
+      )
+      `uvm_info(`gfn, $sformatf("Starting sequence item: %0s", req.convert2string()), UVM_HIGH)
+      // We don't care about response data here, the monitor will log all complete transactions.
+      finish_item(req);
+      get_response(rsp);
+      `uvm_info(`gfn, $sformatf("Received response: %0s", rsp.convert2string()), UVM_HIGH)
+    end : send_req
+  endtask
+
+endclass

--- a/hw/dv/sv/push_pull_agent/seq_lib/push_pull_seq_list.sv
+++ b/hw/dv/sv/push_pull_agent/seq_lib/push_pull_seq_list.sv
@@ -1,0 +1,7 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`include "push_pull_base_seq.sv"
+`include "push_pull_host_seq.sv"
+`include "push_pull_device_seq.sv"


### PR DESCRIPTION
This PR creates a generic push_pull_agent, where "push" denotes a
ready/valid interface protocol and "pull" denotes a req/ack interface
protocol.

This agent can be configured to either Push or Pull modes via the p_type
enum field in the push_pull_agent_cfg object, and both protocols support
host and device operation modes.

Functional covergroups have not yet been implemented, but will be added in a follow-up PR.

Signed-off-by: Udi Jonnalagadda <udij@google.com>