### PR TITLE
Chip level regression test fixes

### DIFF
--- a/hw/ip/prim_generic/rtl/prim_generic_pad_wrapper.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_pad_wrapper.sv
@@ -79,8 +79,7 @@ module prim_generic_pad_wrapper #(
     assign (strong0, strong1) inout_io = (oe && drv != DRIVE_00) ? out : 1'bz;
     assign (pull0, pull1)     inout_io = (oe && drv == DRIVE_00) ? out : 1'bz;
     // pullup / pulldown termination
-    assign (highz0, weak1)    inout_io = pe & ps;  // enabled and select = 1
-    assign (weak0, highz1)    inout_io = pe & ~ps; // enabled and select = 0
+    assign (weak0, weak1)     inout_io = pe ? ps : 1'bz;
     // fake trireg emulation
     assign (weak0, weak1)     inout_io = (kp) ? inout_io : 1'bz;
     // received data driver

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -138,7 +138,7 @@
       sw_test: sw/device/tests/uart_tx_rx_test
     }
     {
-      name: chip_aes_test
+      name: chip_aes_encr
       uvm_test_seq: chip_sw_base_vseq
       sw_test: sw/device/tests/aes_test
     }
@@ -153,19 +153,20 @@
       sw_test: sw/device/tests/dif_plic_sanitytest
     }
     {
-      name: chip_flash_ctrl_test
+      name: chip_flash_ctrl_access
       uvm_test_seq: chip_sw_base_vseq
       sw_test: sw/device/tests/flash_ctrl_test
     }
     {
-      name: chip_sha256_test
+      name: chip_hmac_sha256_encr
       uvm_test_seq: chip_sw_base_vseq
       sw_test: sw/device/tests/sha256_test
     }
     {
-      name: chip_rv_timer_test
+      name: chip_rv_timer_irq
       uvm_test_seq: chip_sw_base_vseq
-      sw_test: sw/device/tests/rv_timer_test
+      sw_test: sw/device/tests/dif_rv_timer_sanitytest
+      run_opts: ["+sw_test_timeout_ns=12000000"]
     }
     {
       name: chip_coremark

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_gpio_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_gpio_vseq.sv
@@ -16,6 +16,10 @@ class chip_sw_gpio_vseq extends chip_sw_base_vseq;
     // Wait until we reach the SW test state.
     wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest);
 
+    // Disable pullups and pulldowns on GPIOs.
+    cfg.gpio_vif.set_pulldown_en({chip_env_pkg::NUM_GPIOS{1'b0}});
+    cfg.gpio_vif.set_pullup_en({chip_env_pkg::NUM_GPIOS{1'b0}});
+
     // Run the GPIO output tests.
     gpio_output_test();
 
@@ -73,10 +77,6 @@ class chip_sw_gpio_vseq extends chip_sw_base_vseq;
   endtask
 
   virtual task gpio_input_test();
-    // Disable pullups and pulldowns on GPIOs.
-    cfg.gpio_vif.set_pulldown_en({chip_env_pkg::NUM_GPIOS{1'b0}});
-    cfg.gpio_vif.set_pullup_en({chip_env_pkg::NUM_GPIOS{1'b0}});
-
     // Wait and check all zs - this indicates it is safe to drive GPIOs as inputs.
     `DV_SPINWAIT(wait(cfg.gpio_vif.pins === {NUM_GPIOS{1'bz}});,
                  $sformatf("Timed out waiting for GPIOs == %0h", {NUM_GPIOS{1'bz}}),

--- a/sw/device/tests/dif/dif_rv_timer_sanitytest.c
+++ b/sw/device/tests/dif/dif_rv_timer_sanitytest.c
@@ -28,7 +28,7 @@ static const uint32_t kHart = (uint32_t)kTopEarlgreyPlicTargetIbex0;
 static const uint32_t kComparator = 0;
 
 static const uint64_t kTickFreqHz = 1000 * 1000;  // 1 MHz.
-static const uint64_t kDeadline = 0x10000;        // 10 ms.
+static const uint64_t kDeadline = 30000;          // 30 ms.
 
 static void test_handler(void) {
   CHECK(!irq_fired, "Entered IRQ handler, but `irq_fired` was not false!");


### PR DESCRIPTION
This PR bundles some HW, SW and DV fixes for the RV timer and GPIO tests that were failing at the chip level. These are only run in the nightly regressions and not in the sanity (private CI). The fixes have had to be made because of the changes introduced in other places. 

These are as follows: 

1. Generic pad wrapper fix as described in #3236 
2. Fix in pins_if` to get it to behave correctly when no pull up or pull down is enabled
3. SW fix and a minor update to the `dif_rv_timer_sanitytest.c` 
4. Fix in the `chip_sim_cfg.hjson` to set the path to the SW test correctly, extend the timeout and some name fixes 