### PR TITLE
[docs] Address Doxygen Issues

### DIFF
--- a/hw/top_earlgrey/data/top_earlgrey.h.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.h.tpl
@@ -5,6 +5,22 @@
 #ifndef _TOP_${top["name"].upper()}_H_
 #define _TOP_${top["name"].upper()}_H_
 
+/**
+ * @file
+ * @brief Top-specific Definitions
+ *
+ * This file contains preprocessor and type definitions for use within the
+ * device C/C++ codebase.
+ *
+ * These definitions are for information that depends on the top-specific chip
+ * configuration, which includes:
+ * - Device Memory Information (for Peripherals and Memory)
+ * - PLIC Interrupt ID Names and Source Mappings
+ * - Alert ID Names and Source Mappings
+ * - Pinmux Pin/Select Names
+ * - Power Manager Wakeups
+ */
+
 // Header Extern Guard  (so header can be used from C and C++)
 #ifdef __cplusplus
 extern "C" {

--- a/hw/top_earlgrey/data/top_earlgrey_memory.h.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey_memory.h.tpl
@@ -7,13 +7,13 @@
 
 /**
  * @file
- * @brief Assembler-only Generated Definitions.
+ * @brief Assembler-only Top-Specific Definitions.
  *
  * This file contains preprocessor definitions for use within assembly code.
- * These are not shared with C/C++ code because these are only allowed to be
- * preprocessor definitions, no data or type declarations are allowed.
  *
- * The assembler is also stricter about literals (not allowing suffixes for
+ * These are not shared with C/C++ code because these are only allowed to be
+ * preprocessor definitions, no data or type declarations are allowed. The
+ * assembler is also stricter about literals (not allowing suffixes for
  * signed/unsigned which are sensible to use for unsigned values in C/C++).
  */
 

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -5,6 +5,22 @@
 #ifndef OPENTITAN_HW_TOP_EARLGREY_SW_AUTOGEN_TOP_EARLGREY_H_
 #define OPENTITAN_HW_TOP_EARLGREY_SW_AUTOGEN_TOP_EARLGREY_H_
 
+/**
+ * @file
+ * @brief Top-specific Definitions
+ *
+ * This file contains preprocessor and type definitions for use within the
+ * device C/C++ codebase.
+ *
+ * These definitions are for information that depends on the top-specific chip
+ * configuration, which includes:
+ * - Device Memory Information (for Peripherals and Memory)
+ * - PLIC Interrupt ID Names and Source Mappings
+ * - Alert ID Names and Source Mappings
+ * - Pinmux Pin/Select Names
+ * - Power Manager Wakeups
+ */
+
 // Header Extern Guard  (so header can be used from C and C++)
 #ifdef __cplusplus
 extern "C" {

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h
@@ -7,13 +7,13 @@
 
 /**
  * @file
- * @brief Assembler-only Generated Definitions.
+ * @brief Assembler-only Top-Specific Definitions.
  *
  * This file contains preprocessor definitions for use within assembly code.
- * These are not shared with C/C++ code because these are only allowed to be
- * preprocessor definitions, no data or type declarations are allowed.
  *
- * The assembler is also stricter about literals (not allowing suffixes for
+ * These are not shared with C/C++ code because these are only allowed to be
+ * preprocessor definitions, no data or type declarations are allowed. The
+ * assembler is also stricter about literals (not allowing suffixes for
  * signed/unsigned which are sensible to use for unsigned values in C/C++).
  */
 

--- a/util/doxygen/Doxyfile
+++ b/util/doxygen/Doxyfile
@@ -44,7 +44,7 @@ GENERATE_BUGLIST       = NO
 SHOW_USED_FILES        = NO
 SHOW_NAMESPACES        = NO
 
-FILE_VERSION_FILTER    = "git log --format='%h' -1 --"
+FILE_VERSION_FILTER    = "git -C '$(SRCTREE_TOP)' log --format='%h' -1 --"
 
 LAYOUT_FILE            = "$(SRCTREE_TOP)/site/docs/doxygen/layout.xml"
 

--- a/util/doxygen/Doxyfile
+++ b/util/doxygen/Doxyfile
@@ -61,6 +61,7 @@ WARN_LOGFILE           = "$(DOXYGEN_OUT)/doxygen_warnings.log"
 
 # Absolute path using $(SRCTREE_TOP)
 INPUT                  = "$(SRCTREE_TOP)/sw" \
+                         "$(SRCTREE_TOP)/hw/top_earlgrey/sw" \
                          "$(SRCTREE_TOP)/site/docs/doxygen/main_page.md"
 
 USE_MDFILE_AS_MAINPAGE = "$(SRCTREE_TOP)/site/docs/doxygen/main_page.md"


### PR DESCRIPTION
This PR contains two changes:
- The first addresses some errors that are present only in the google cloud docs build.
- The second adds the topgen'd definitions to the Software API docs.

More details are available in each commit message.