### PR TITLE
[sw] separate clock frequency enums

### DIFF
--- a/sw/device/lib/arch/device.h
+++ b/sw/device/lib/arch/device.h
@@ -51,9 +51,24 @@ typedef enum device_type {
 extern const device_type_t kDeviceType;
 
 /**
- * The clock frequency of the device, in hertz.
+ * The CPU clock frequency of the device, in hertz.
+ * This is the operating clock for the main processing host.
  */
-extern const uint64_t kClockFreqHz;
+extern const uint64_t kClockFreqCpuHz;
+
+/**
+ * The peripheral clock frequency of the device, in hertz.
+ * This is the operating clock used by timers, uarts,
+ * other peripheral interfaces and the software interface
+ * to the USB controller.
+ */
+extern const uint64_t kClockFreqPeripheralHz;
+
+/**
+ * The USB clock frequency of the device, in hertz.
+ * This is the operating clock used by the USB phy interface.
+ */
+extern const uint64_t kClockFreqUsbHz;
 
 /**
  * The baudrate of the UART peripheral (if such a thing is present).

--- a/sw/device/lib/arch/device_fpga_nexysvideo.c
+++ b/sw/device/lib/arch/device_fpga_nexysvideo.c
@@ -11,7 +11,11 @@
 
 const device_type_t kDeviceType = kDeviceFpgaNexysVideo;
 
-const uint64_t kClockFreqHz = 50 * 1000 * 1000;  // 50MHz
+const uint64_t kClockFreqCpuHz = 50 * 1000 * 1000;  // 50MHz
+
+const uint64_t kClockFreqPeripheralHz = 50 * 1000 * 1000;  // 50MHz
+
+const uint64_t kClockFreqUsbHz = 48 * 1000 * 1000;  // 48MHz
 
 const uint64_t kUartBaudrate = 230400;
 

--- a/sw/device/lib/arch/device_sim_dv.c
+++ b/sw/device/lib/arch/device_sim_dv.c
@@ -13,7 +13,11 @@ const device_type_t kDeviceType = kDeviceSimDV;
 // TODO: DV testbench completely randomizes these. Need to add code to
 // retrieve these from a preloaded memory location set by the testbench.
 
-const uint64_t kClockFreqHz = 50 * 1000 * 1000;  // 50MHz
+const uint64_t kClockFreqCpuHz = 50 * 1000 * 1000;  // 50MHz
+
+const uint64_t kClockFreqPeripheralHz = 50 * 1000 * 1000;  // 50MHz
+
+const uint64_t kClockFreqUsbHz = 48 * 1000 * 1000;  // 48MHz
 
 const uint64_t kUartBaudrate = 2 * (1 << 20);  // 2Mib/s
 

--- a/sw/device/lib/arch/device_sim_verilator.c
+++ b/sw/device/lib/arch/device_sim_verilator.c
@@ -11,7 +11,11 @@
 
 const device_type_t kDeviceType = kDeviceSimVerilator;
 
-const uint64_t kClockFreqHz = 500 * 1000;  // 500kHz
+const uint64_t kClockFreqCpuHz = 500 * 1000;  // 500kHz
+
+const uint64_t kClockFreqPeripheralHz = 500 * 1000;  // 500kHz
+
+const uint64_t kClockFreqUsbHz = 500 * 1000;  // 500kHz
 
 const uint64_t kUartBaudrate = 9600;
 

--- a/sw/device/lib/runtime/hart.c
+++ b/sw/device/lib/runtime/hart.c
@@ -13,7 +13,7 @@
 extern void wait_for_interrupt(void);
 
 void usleep(uint32_t usec) {
-  uint64_t cycles = kClockFreqHz * usec / 1000000;
+  uint64_t cycles = kClockFreqCpuHz * usec / 1000000;
   uint64_t start = ibex_mcycle_read();
   while ((ibex_mcycle_read() - start) < cycles) {
   }

--- a/sw/device/lib/uart.c
+++ b/sw/device/lib/uart.c
@@ -16,7 +16,7 @@ static dif_uart_t uart0;
 void uart_init(unsigned int baud) {
   dif_uart_config_t config = {
       .baudrate = baud,
-      .clk_freq_hz = kClockFreqHz,
+      .clk_freq_hz = kClockFreqPeripheralHz,
       .parity_enable = kDifUartDisable,
       .parity = kDifUartParityEven,
   };

--- a/sw/device/sca/aes_serial/aes_serial.c
+++ b/sw/device/sca/aes_serial/aes_serial.c
@@ -280,8 +280,8 @@ int main(int argc, char **argv) {
             (dif_rv_timer_config_t){.hart_count = 1, .comparator_count = 1},
             &timer) == kDifRvTimerOk);
   dif_rv_timer_tick_params_t tick_params;
-  CHECK(dif_rv_timer_approximate_tick_params(kClockFreqHz, kTickFreqHz,
-                                             &tick_params) ==
+  CHECK(dif_rv_timer_approximate_tick_params(kClockFreqPeripheralHz,
+                                             kTickFreqHz, &tick_params) ==
         kDifRvTimerApproximateTickParamsOk);
   CHECK(dif_rv_timer_set_tick_params(&timer, kHart, tick_params) ==
         kDifRvTimerOk);

--- a/sw/device/tests/dif/dif_plic_sanitytest.c
+++ b/sw/device/tests/dif/dif_plic_sanitytest.c
@@ -93,7 +93,7 @@ void handler_irq_external(void) {
 static void uart_initialise(mmio_region_t base_addr, dif_uart_t *uart) {
   dif_uart_config_t config = {
       .baudrate = kUartBaudrate,
-      .clk_freq_hz = kClockFreqHz,
+      .clk_freq_hz = kClockFreqPeripheralHz,
       .parity_enable = kDifUartDisable,
       .parity = kDifUartParityEven,
   };

--- a/sw/device/tests/dif/dif_rv_timer_sanitytest.c
+++ b/sw/device/tests/dif/dif_rv_timer_sanitytest.c
@@ -66,8 +66,8 @@ bool test_main(void) {
             &timer) == kDifRvTimerOk);
 
   dif_rv_timer_tick_params_t tick_params;
-  CHECK(dif_rv_timer_approximate_tick_params(kClockFreqHz, kTickFreqHz,
-                                             &tick_params) ==
+  CHECK(dif_rv_timer_approximate_tick_params(kClockFreqPeripheralHz,
+                                             kTickFreqHz, &tick_params) ==
         kDifRvTimerApproximateTickParamsOk);
   CHECK(dif_rv_timer_set_tick_params(&timer, kHart, tick_params) ==
         kDifRvTimerOk);

--- a/sw/device/tests/dif/dif_uart_sanitytest.c
+++ b/sw/device/tests/dif/dif_uart_sanitytest.c
@@ -17,7 +17,7 @@ static const uint8_t kSendData[] = "Sanity test!";
 static bool uart_initialise(mmio_region_t base_addr, dif_uart_t *uart) {
   dif_uart_config_t config = {
       .baudrate = kUartBaudrate,
-      .clk_freq_hz = kClockFreqHz,
+      .clk_freq_hz = kClockFreqPeripheralHz,
       .parity_enable = kDifUartDisable,
       .parity = kDifUartParityEven,
   };

--- a/sw/device/tests/sim_dv/uart_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/uart_tx_rx_test.c
@@ -168,7 +168,7 @@ static void uart_init_with_irqs(mmio_region_t base_addr, dif_uart_t *uart) {
 
   dif_uart_config_t config = {
       .baudrate = kUartBaudrate,
-      .clk_freq_hz = kClockFreqHz,
+      .clk_freq_hz = kClockFreqPeripheralHz,
       .parity_enable = kDifUartDisable,
       .parity = kDifUartParityEven,
   };


### PR DESCRIPTION
- This is needed to for divided clocks in the design. See #3211

Signed-off-by: Timothy Chen <timothytim@google.com>