### PR TITLE
[uart/dv] end tx item earilier to avoid accumulating freq diff

### DIFF
--- a/hw/dv/sv/uart_agent/uart_agent_pkg.sv
+++ b/hw/dv/sv/uart_agent/uart_agent_pkg.sv
@@ -29,13 +29,6 @@ package uart_agent_pkg;
     BaudRate2Mbps   = 2097152
   } baud_rate_e;
 
-  typedef enum {
-    UartIdle,
-    UartStart,
-    UartData,
-    UartStop
-  } uart_state_e;
-
   // functions
   function automatic real get_baud_rate_period_ns(baud_rate_e baud_rate);
     // return 10^9 / baud_rate ns upto 3 decimal places

--- a/hw/dv/sv/uart_agent/uart_if.sv
+++ b/hw/dv/sv/uart_agent/uart_if.sv
@@ -2,12 +2,12 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-interface uart_if #(time UartDefaultClkPeriodNs = 104166.667ns) ();
+interface uart_if #(realtime UartDefaultClkPeriodNs = 104166.667ns) ();
   wire uart_tx;
   logic uart_rx;
 
   // generate local clk
-  time  uart_clk_period_ns = UartDefaultClkPeriodNs;
+  realtime uart_clk_period_ns = UartDefaultClkPeriodNs;
   bit   uart_tx_clk = 1'b1;
   int   uart_tx_clk_pulses = 0;
   bit   uart_rx_clk = 1'b1;

--- a/hw/dv/sv/uart_agent/uart_monitor.sv
+++ b/hw/dv/sv/uart_agent/uart_monitor.sv
@@ -139,7 +139,12 @@ class uart_monitor extends dv_base_monitor#(
       if (cfg.vif.uart_tx_clk_pulses > 0) begin
         #(cfg.vif.uart_clk_period_ns / 2);
         cfg.vif.uart_tx_clk = ~cfg.vif.uart_tx_clk;
-        #(cfg.vif.uart_clk_period_ns / 2);
+        // last cycle only use 0.5 period as design and agent aren't using same clock. If agent freq
+        // is slower and design continues sending tx item, the freq diff will be accumulated.
+        // Ending current item after latch STOP bit to allow agent to re-establish clock to sample
+        // the START bit of next item
+        if (cfg.vif.uart_tx_clk_pulses == 1) #1ns;
+        else                                 #(cfg.vif.uart_clk_period_ns / 2);
         cfg.vif.uart_tx_clk = ~cfg.vif.uart_tx_clk;
         cfg.vif.uart_tx_clk_pulses--;
       end else begin

--- a/hw/ip/uart/dv/env/seq_lib/uart_sanity_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_sanity_vseq.sv
@@ -39,6 +39,7 @@ class uart_sanity_vseq extends uart_tx_rx_vseq;
     for (int j = 1; j <= num_tx_bytes; j++) begin
       byte tx_byte;
 
+      wait_when_in_ignored_period(.tx(1));
       `DV_CHECK_STD_RANDOMIZE_FATAL(tx_byte)
       send_tx_byte(tx_byte);
       // if no delay in TL-UL trans, DUT takes 1 more cycle to update status reg


### PR DESCRIPTION
Use only 0.9 period for the last cycle as design and agent aren't
using same clock. If agent freq is slower and design continues
sending tx item, the freq diff will be accumulated.
Ending current item earlier to allow agent to re-establish clock
to sample next item

another 2 minor updates
1. use realtime as period contains decimal value
2. clean up unused code

Signed-off-by: Weicai Yang <weicai@google.com>