### PR TITLE
[otbn] Properly generate multi-section output in otbn-rig

### DIFF
--- a/hw/ip/otbn/util/otbn-rig
+++ b/hw/ip/otbn/util/otbn-rig
@@ -27,6 +27,8 @@ def main() -> int:
                         help='Path for JSON output of generated snippets')
     parser.add_argument('--asm-output',
                         help='Optional path for generated program')
+    parser.add_argument('--ld-output',
+                        help='Optional path for generated linker script')
     parser.add_argument('--seed', type=int, default=0,
                         help='Random seed. Defaults to 0.')
     parser.add_argument('--size', type=int, default=100,
@@ -67,6 +69,16 @@ def main() -> int:
         except OSError as err:
             sys.stderr.write('Failed to open assembly output file {!r}: {}.'
                              .format(args.asm_output, err))
+            return 1
+
+    # If a linker script was requested, dump that here
+    if args.ld_output is not None:
+        try:
+            with open(args.ld_output, 'w') as out_file:
+                program.dump_linker_script(out_file)
+        except OSError as err:
+            sys.stderr.write('Failed to open ld script output file {!r}: {}.'
+                             .format(args.ld_output, err))
             return 1
 
     return 0

--- a/hw/ip/otbn/util/rig/rig.py
+++ b/hw/ip/otbn/util/rig/rig.py
@@ -31,13 +31,13 @@ def gen_program(start_addr: int,
     # at address 0: a strict Harvard architecture. (mems[x][0] is the LMA
     # for memory x, not the VMA)
     mems = get_memory_layout()
-    imem_size = mems['IMEM'][1]
+    imem_lma, imem_size = mems['IMEM']
     dmem_size = mems['DMEM'][1]
 
     assert start_addr <= imem_size - 4
     assert start_addr & 3 == 0
 
-    program = Program(imem_size)
+    program = Program(imem_lma, imem_size)
     model = Model(dmem_size, start_addr)
 
     generators = SnippetGens(insns_file)


### PR DESCRIPTION
The code was trying to use the `.offset` assembler directive to tell it
where to put things, but this turns out not to work at all. So we now
generate a linker script as well as the assembly code.

The command line is pretty horrible, but will be tidied up
soon (splitting up "generate me some snippets" and "turn them into
assembly"). For now, you can run it as

    ./hw/ip/otbn/util/otbn-rig \
      --asm-output gen.S \
      --ld-output gen.ld \
      -o gen.json

The resulting gen.S looks something like this:

    /* Section 0 (addresses [0x0000..0x0007]) */
    .section .text.sec0000
    addi          x30, x0, 1269
    jal           x6, 3320

    /* Section 1 (addresses [0x02d4..0x0333]) */
    .section .text.sec0001
    lui           x29, 29447
    srl           x18, x30, x30
    slli          x17, x24, 5
    ori           x16, x17, -1155
    or            x3, x16, x29
    sub           x25, x18, x29
    or            x6, x6, x0
    lui           x21, 273100
    and           x25, x24, x24
    ...

and gen.ld looks something like this:

    SECTIONS
    {
        /* Section 0 (addresses [0x0000..0x0007]) */
        .text.sec0000 0x0 : AT(0x100000)
        {
            *(.text.sec0000)
        }

        /* Section 1 (addresses [0x02d4..0x0333]) */
        .text.sec0001 0x2d4 : AT(0x1002d4)
        {
            *(.text.sec0001)
        }
    ...
