### PR TITLE
[otbn] Fix shift in encoding for bn.lid and bn.sid

### DIFF
--- a/hw/ip/otbn/data/bignum-insns.yml
+++ b/hw/ip/otbn/data/bignum-insns.yml
@@ -745,7 +745,7 @@
       doc: |
         Offset value.
         Must be WLEN-aligned.
-      type: simm<<4
+      type: simm<<5
     - name: grs1_inc
       type: option(++)
       doc: |
@@ -816,7 +816,7 @@
       doc: |
         Offset value.
         Must be WLEN-aligned.
-      type: simm<<4
+      type: simm<<5
     - name: grs1_inc
       type: option(++)
       doc: |

--- a/hw/ip/otbn/dv/otbnsim/sim/insn.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/insn.py
@@ -333,7 +333,7 @@ class InstructionBNLID(InstructionBNIType):
         assert self.rs is not None
         assert self.rd is not None
 
-        addr = int(model.state.intreg[self.rs] + int(self.imm) * 32)
+        addr = int(model.state.intreg[self.rs] + int(self.imm))
         wrd = int(model.state.intreg[self.rd])
         word = model.load_wlen_word_from_memory(addr)
         model.state.wreg[wrd] = word
@@ -359,7 +359,7 @@ class InstructionBNSID(InstructionBNISType):
         assert self.rs2 is not None
         assert self.rs1 is not None
 
-        addr = int(model.state.intreg[self.rs2] + int(self.imm) * 32)
+        addr = int(model.state.intreg[self.rs2] + int(self.imm))
         wrs = int(model.state.intreg[self.rs1])
         word = int(model.state.wreg[wrs])
         model.store_wlen_word_to_memory(addr, word)

--- a/hw/ip/otbn/dv/otbnsim/sim/isa.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/isa.py
@@ -421,7 +421,7 @@ class InstructionBNIType(InstructionFunct3Type):  # type: ignore
 
     field_rd = Field(name="rd", base=7, size=5)
     field_rs = Field(name="rs", base=15, size=5)
-    field_imm = Field(name="imm", base=22, size=10)
+    field_imm = Field(name="imm", base=[25, 22], size=[7, 3], offset=4)
     field_rd_inc = Field(name="rd_inc", base=20, size=1)
     field_rs_inc = Field(name="rs_inc", base=21, size=1)
 

--- a/hw/ip/otbn/dv/otbnsim/sim/isa.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/isa.py
@@ -421,7 +421,7 @@ class InstructionBNIType(InstructionFunct3Type):  # type: ignore
 
     field_rd = Field(name="rd", base=7, size=5)
     field_rs = Field(name="rs", base=15, size=5)
-    field_imm = Field(name="imm", base=[25, 22], size=[7, 3], offset=4)
+    field_imm = Field(name="imm", base=[25, 22], size=[7, 3], offset=5)
     field_rd_inc = Field(name="rd_inc", base=20, size=1)
     field_rs_inc = Field(name="rs_inc", base=21, size=1)
 

--- a/hw/ip/otbn/util/shared/yaml_parse_helpers.py
+++ b/hw/ip/otbn/util/shared/yaml_parse_helpers.py
@@ -140,7 +140,7 @@ def load_yaml(path: str, what: Optional[str]) -> object:
     a RuntimeError. If what is not None, it will be used in the error message.
 
     '''
-    for_msg = 'for ' + what if what is not None else ''
+    for_msg = ' for ' + what if what is not None else ''
     try:
         with open(path, 'r') as handle:
             return yaml.load(handle, Loader=yaml.SafeLoader)


### PR DESCRIPTION
The first commit fixes a typo. The ~~second~~ third one is the interesting one, whose commit message is reproduced at the bottom.

Hopefully, this sort of mistake should be more obvious once PR #3207 is merged. ~~Note that the simulator will need a corresponding fix, which I'll sort out once PR #3247 is merged (if that PR gets merged first, I'll sort out the shifts as part of this one).~~

EDIT: Now the simulator is merged, I've pushed up a fix for it as part of this PR (now the second commit of 3).

**[otbn] Fix encoding for bn.lid and bn.sid**

The offset is required in the documentation to be a multiple of `WLEN`
(32 bytes), but the scheme had a shift of 4 on the immediate,
multiplying by 16 rather than 32.