### PR TITLE
[otbn] Strip trailing space when matching an instruction in otbn-as

### DIFF
--- a/hw/ip/otbn/util/otbn-as
+++ b/hw/ip/otbn/util/otbn-as
@@ -949,7 +949,7 @@ class Transformer:
         # glued operands) as a string.
         operands_str = self.key_sym[len(insn.mnemonic):] + ''.join(self.acc)
 
-        match = insn.asm_pattern.match(operands_str)
+        match = insn.asm_pattern.match(operands_str.strip())
         if match is None:
             raise RuntimeError('{}:{}: Cannot match syntax for {!r} ({!r}).'
                                .format(self.in_path, self.line_number,


### PR DESCRIPTION
Rather embarrassingly, the code:

```
  nop /* my comment */
```

failed before this, because `operands_str` was `" "` and we were checking
whether it matched the empty regex.
