### PR TITLE
[rstmgr] Update pok usage in rstmgr_por

### DIFF
--- a/hw/ip/rstmgr/data/rstmgr.sv.tpl
+++ b/hw/ip/rstmgr/data/rstmgr.sv.tpl
@@ -46,8 +46,7 @@ module rstmgr import rstmgr_pkg::*; (
   logic rst_por_aon_n;
   rstmgr_por u_rst_por_aon (
     .clk_i(clk_aon_i),
-    .rst_ni,
-    .pok_i(ast_i.aon_pok),
+    .rst_ni(ast_i.aon_pok),
     .rst_no(rst_por_aon_n)
   );
 

--- a/hw/ip/rstmgr/rtl/rstmgr_por.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr_por.sv
@@ -13,8 +13,6 @@ module rstmgr_por #(
 ) (
   input clk_i,
   input rst_ni,
-  input pok_i, // TODO: This should not be an actual separate port but the POR itself
-               // However, this cannot be done until AST integration is done.
   output logic rst_no
 );
   localparam int CtrWidth = $clog2(StretchCount+1);
@@ -41,7 +39,7 @@ module rstmgr_por #(
   always_ff @(posedge clk_i or negedge rst_root_n) begin
     if (!rst_root_n) begin
       rst_filter_n <= '0;
-    end else if (pok_i) begin // once AST is in, this conditional should not be here.
+    end else begin
       rst_filter_n <= {rst_filter_n[0 +: FilterStages-1], 1'b1};
     end
   end

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
@@ -55,8 +55,7 @@ module rstmgr import rstmgr_pkg::*; (
   logic rst_por_aon_n;
   rstmgr_por u_rst_por_aon (
     .clk_i(clk_aon_i),
-    .rst_ni,
-    .pok_i(ast_i.aon_pok),
+    .rst_ni(ast_i.aon_pok),
     .rst_no(rst_por_aon_n)
   );
 

--- a/hw/top_earlgrey/rtl/top_earlgrey_nexysvideo.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_nexysvideo.sv
@@ -205,6 +205,7 @@ module top_earlgrey_nexysvideo #(
   // Top-level design //
   //////////////////////
   pwrmgr_pkg::pwr_ast_rsp_t ast_base_pwr;
+  ast_wrapper_pkg::ast_rst_t ast_base_rst;
   ast_wrapper_pkg::ast_alert_req_t ast_base_alerts;
   ast_wrapper_pkg::ast_status_t ast_base_status;
 
@@ -217,6 +218,10 @@ module top_earlgrey_nexysvideo #(
   assign ast_base_alerts.alerts_n  = {ast_wrapper_pkg::NumAlerts{1'b1}};
   assign ast_base_status.io_pok    = {ast_wrapper_pkg::NumIoRails{1'b1}};
 
+  // the rst_ni pin only goes to AST
+  // the rest of the logic generates reset based on the 'pok' signal.
+  // for verilator purposes, make these two the same.
+  assign ast_base_rst.aon_pok      = rst_n;
   top_earlgrey #(
     .IbexPipeLine(1),
     .BootRomInitFile(BootRomInitFile)
@@ -227,7 +232,7 @@ module top_earlgrey_nexysvideo #(
     .clk_io_i        ( clk           ),
     .clk_usb_i       ( clk_usb_48mhz ),
     .clk_aon_i       ( clk           ),
-    .rstmgr_ast_i                ( 1'b1            ),
+    .rstmgr_ast_i                ( ast_base_rst    ),
     .pwrmgr_pwr_ast_req_o        (                 ),
     .pwrmgr_pwr_ast_rsp_i        ( ast_base_pwr    ),
     .sensor_ctrl_ast_alert_req_i ( ast_base_alerts ),

--- a/hw/top_earlgrey/rtl/top_earlgrey_verilator.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_verilator.sv
@@ -75,6 +75,7 @@ module top_earlgrey_verilator (
 
   // dummy ast connections
   pwrmgr_pkg::pwr_ast_rsp_t ast_base_pwr;
+  ast_wrapper_pkg::ast_rst_t ast_base_rst;
   ast_wrapper_pkg::ast_alert_req_t ast_base_alerts;
   ast_wrapper_pkg::ast_status_t ast_base_status;
 
@@ -87,6 +88,10 @@ module top_earlgrey_verilator (
   assign ast_base_alerts.alerts_n  = {ast_wrapper_pkg::NumAlerts{1'b1}};
   assign ast_base_status.io_pok    = {ast_wrapper_pkg::NumIoRails{1'b1}};
 
+  // the rst_ni pin only goes to AST
+  // the rest of the logic generates reset based on the 'pok' signal.
+  // for verilator purposes, make these two the same.
+  assign ast_base_rst.aon_pok      = rst_ni;
   // Top-level design
   top_earlgrey top_earlgrey (
     .rst_ni                     (rst_ni),
@@ -94,7 +99,7 @@ module top_earlgrey_verilator (
     .clk_io_i                   (clk_i),
     .clk_usb_i                  (clk_i),
     .clk_aon_i                  (clk_i),
-    .rstmgr_ast_i                 (1'b1),
+    .rstmgr_ast_i                 (ast_base_rst),
     .pwrmgr_pwr_ast_req_o         (),
     .pwrmgr_pwr_ast_rsp_i         (ast_base_pwr),
     .sensor_ctrl_ast_alert_req_i  (ast_base_alerts),


### PR DESCRIPTION
POR should use the AST output directly instead of the IO reset.

The IO reset causes the POR signal to assert and then reset the device. 