### PR TITLE
[fpv/doc] README syntax fix

### DIFF
--- a/hw/formal/README.md
+++ b/hw/formal/README.md
@@ -324,9 +324,6 @@ which lists the total number of assertions and the number of proven, vacuous,
 covered and failing assertions for each block. CRASH identifies modules that
 fail to run VC Formal.
 
-...
-```
-
 ## Naming Convenctions
 For assertions, it is preferred to use postfix `_A` for assertions,
 `_M` for assumptions, `_P` for properties, and `_S` for sequences.


### PR DESCRIPTION
FPV README has syntax issue, there are a few extra lines that messed up
with the README syntax.
This PR removes this extra lines.

Signed-off-by: Cindy Chen <chencindy@google.com>