### PR TITLE
[kmac] Keccak_f : Full 24 rounds

### DIFF
--- a/hw/ip/kmac/fpv/keccak_round_fpv.core
+++ b/hw/ip/kmac/fpv/keccak_round_fpv.core
@@ -1,0 +1,27 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:fpv:keccak_round_fpv:0.1"
+description: "Keccak_f FPV target"
+filesets:
+  files_formal:
+    depend:
+      - lowrisc:prim:all
+      - lowrisc:ip:kmac
+    files:
+      - tb/keccak_round_fpv.sv
+    file_type: systemVerilogSource
+
+targets:
+  default: &default_target
+    # note, this setting is just used
+    # to generate a file list for jg
+    default_tool: icarus
+    filesets:
+      - files_formal
+    toplevel:
+      - keccak_round_fpv
+
+  formal:
+    <<: *default_target

--- a/hw/ip/kmac/fpv/tb/keccak_round_fpv.sv
+++ b/hw/ip/kmac/fpv/tb/keccak_round_fpv.sv
@@ -1,0 +1,209 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Testbench module for keccak_f. Intended to be used with a formal tool.
+
+module keccak_round_fpv #(
+  parameter int Width = 1600
+) (
+  input                    clk_i,
+  input                    rst_ni,
+  input                    valid_i,
+  input                    rand_valid_i,
+  input        [Width-1:0] rand_i,
+  output logic             done_o
+);
+
+  localparam int W        = Width/25;
+  localparam int L        = $clog2(W);
+  localparam int NumRound = 12 + 2*L; // Keccak-f only
+  localparam int RndW     = $clog2(NumRound+1);
+
+  // Feed parameters
+  localparam int DInWidth = 64; // currently only 64bit supported
+  localparam int DInEntry = Width / DInWidth;
+  localparam int DInAddr  = $clog2(DInEntry);
+
+  logic [Width-1:0] masked_state   [2];
+  logic [Width-1:0] masked_state_d [2];
+  logic [Width-1:0] unmasked_state  [1];
+  logic [Width-1:0] unmasked_state_d[1];
+
+  // Data input
+  logic                msg_valid;
+  logic [DInAddr-1:0]  msg_addr;
+  logic [DInWidth-1:0] msg_data;
+
+  logic run, clear, masked_complete, unmasked_complete;
+
+  // Masked Keccak round
+
+  keccak_round #(
+    .Width      (Width),
+    .EnMasking  (1),
+    .ReuseShare (0)
+  ) u_masked (
+    .clk_i,
+    .rst_ni,
+
+    .valid_i (msg_valid),
+    .addr_i  (msg_addr),
+    .data_i  ({'0, msg_data}),
+
+    .run_i   (run),
+    .rand_valid_i (1'b1),
+    .rand_data_i  ('0),
+    .rand_consumed_o (),
+
+    .complete_o (masked_complete),
+    .state_o    (masked_state),
+    .clear_i    (clear)
+  );
+
+  keccak_round #(
+    .Width      (Width),
+    .EnMasking  (0)
+  ) u_unmasked (
+    .clk_i,
+    .rst_ni,
+
+    .valid_i (msg_valid),
+    .addr_i  (msg_addr),
+    .data_i  ('{msg_data}),
+
+    .run_i   (run),
+    .rand_valid_i (1'b1),
+    .rand_data_i  ('0),
+    .rand_consumed_o (),
+
+    .complete_o (unmasked_complete),
+    .state_o    (unmasked_state),
+    .clear_i    (clear)
+  );
+
+  logic [Width-1:0] compare_states;
+
+  assign compare_states = unmasked_state[0] ^ (masked_state[0] ^ masked_state[1]);
+
+  // Test with value 0
+  logic [1599:0] data_0 ;
+  always_comb begin
+    data_0 = '0;
+    // SHA3-256 ==> r : 1088
+    data_0[1087] = 1'b 1;
+    data_0[2:0] = 3'b 110;
+  end
+
+  // Data input : SHA3-256
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      msg_addr <= '0;
+    end else if (msg_valid) begin
+      msg_addr <= msg_addr + 1'b 1;
+    end else if (run) begin
+      msg_addr <= '0;
+    end
+  end
+
+  assign msg_data = data_0[64*msg_addr+:64];
+
+  logic in_progress;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      in_progress <= 1'b0;
+    end else if (valid_i) begin
+      in_progress <= 1'b 1;
+    end else if (done_o) begin
+      in_progress <= 1'b 0;
+    end
+  end
+
+  typedef enum logic [2:0] {
+    StIdle,
+    StMsg,
+    StRun,
+    StComplete
+  } st_e;
+
+  st_e st, st_d;
+
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      st <= StIdle;
+    end else begin
+      st <= st_d;
+    end
+  end
+
+  always_comb begin
+    st_d = st;
+
+    run = 1'b0;
+    msg_valid = 1'b0;
+    done_o = 1'b0;
+
+    clear = 1'b 0;
+
+    unique case (st)
+      StIdle: begin
+        if (valid_i) begin
+          st_d = StMsg;
+        end
+      end
+
+      StMsg: begin
+        if (msg_addr == 1088/64) begin
+          st_d = StRun;
+
+          run = 1'b1;
+        end else begin
+          st_d = StMsg;
+
+          msg_valid = 1'b1;
+        end
+      end
+
+      StRun: begin
+        if (masked_complete) begin
+          st_d = StComplete;
+        end else begin
+          st_d = StRun;
+        end
+      end
+
+      StComplete: begin
+        st_d = StIdle;
+        clear = 1'b1;
+        done_o = 1'b1;
+      end
+
+      default: begin
+        st_d = StIdle;
+      end
+    endcase
+  end
+
+  //`ASSUME_FPV(DataNotPushWhenProgress_A, msg_valid |-> !in_progress && !valid_i)
+  `ASSUME_FPV(ValidPulse_A, ##1 valid_i |=> !valid_i, clk_i, !rst_ni)
+
+
+  logic [255:0] digest_0;
+  // Big-Endian a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a
+  assign digest_0 = 256'h 4a43_f880_4b0a_d882_fa49_3be4_4dff_80f5_62d6_61a0_5647_c151_66d7_1ebf_f8c6_ffa7;
+  `ASSUME_FPV(FixedRandomValue_A, rand_i == '1)
+  `ASSUME_FPV(FixedRandomValid_A, rand_valid_i == '1)
+  `ASSERT(DigestForData0TestSHA3_256_Masked_A,
+          masked_complete |-> (masked_state[0][255:0] ^ masked_state[1][255:0]) == digest_0,
+          clk_i, !rst_ni)
+  `ASSERT(DigestForData0TestSHA3_256_Unmasked_A,
+          unmasked_complete |-> unmasked_state[0][255:0] == digest_0,
+          clk_i, !rst_ni)
+
+  // After a round is completed or at the beginning, golden value and keccak 2share shall be same
+  `ASSERT(MaskedSameToUnmasked_A, masked_complete |-> compare_states == '0, clk_i, !rst_ni)
+
+endmodule
+

--- a/hw/ip/kmac/kmac.core
+++ b/hw/ip/kmac/kmac.core
@@ -11,6 +11,7 @@ filesets:
       - lowrisc:prim:prim_dom_and_2share
       - lowrisc:prim:assert
     files:
+      - rtl/keccak_round.sv
       - rtl/keccak_2share.sv
     file_type: systemVerilogSource
 

--- a/hw/ip/kmac/rtl/keccak_round.sv
+++ b/hw/ip/kmac/rtl/keccak_round.sv
@@ -1,0 +1,400 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Keccak full round logic based on given input `Width`
+// e.g. Width 800 requires 22 rounds
+
+`include "prim_assert.sv"
+
+module keccak_round #(
+  parameter int Width = 1600, // b= {25, 50, 100, 200, 400, 800, 1600}
+
+  // Derived
+  localparam int W        = Width/25,
+  localparam int L        = $clog2(W),
+  localparam int MaxRound = 12 + 2*L,           // Keccak-f only
+  localparam int RndW     = $clog2(MaxRound+1), // Representing up to MaxRound-1
+
+  // Feed parameters
+  parameter  int DInWidth = 64, // currently only 64bit supported
+  localparam int DInEntry = Width / DInWidth,
+  localparam int DInAddr  = $clog2(DInEntry),
+
+  // Control parameters
+  parameter  int EnMasking = 0,  // Enable secure hardening
+  localparam int Share     = EnMasking ? 2 : 1,
+
+  // If ReuseShare is not 0, the logic will use unused sheet as an entropy
+  // at Chi stage. It still needs small portion of the fresh entropy from
+  // rand_data_i but the amount required are significantly small.
+  // TODO: Implement the feature inside keccak_2share
+  parameter  int ReuseShare = 0  // Re-use adjacent share for entropy
+) (
+  input clk_i,
+  input rst_ni,
+
+  // Message Feed
+  input                valid_i,
+  input [DInAddr-1:0]  addr_i,
+  input [DInWidth-1:0] data_i [Share],
+
+  // In-process control
+  input                    run_i,  // Pulse signal to initiates Keccak full round
+  input                    rand_valid_i,
+  input        [Width-1:0] rand_data_i,
+  output logic             rand_consumed_o,
+
+  output logic             complete_o, // Indicates full round is done
+
+  // State out. This can be used as Digest
+  output logic [Width-1:0] state_o [Share],
+
+  input                    clear_i     // Clear internal state to '0
+);
+
+  /////////////////////
+  // Control signals //
+  /////////////////////
+
+  // Update storage register
+  logic update_storage;
+
+  // Reset the storage to 0 to initiate new Hash operation
+  logic rst_storage;
+
+  // XOR message into storage register
+  // It only does based on the given DInWidth.
+  // If DInWidth < Width, it takes multiple cycles to XOR all message
+  logic xor_message;
+
+  // Select Keccak_p datapath
+  // 0: Select Phase1 (Theta -> Rho -> Pi)
+  // 1: Select Phase2 (Chi -> Iota)
+  // `sel_mux` need to be asserted until the Chi stage is consumed,
+  // It means sel_mux should be 1 until one cycle after `rand_valid_i` is asserted.
+  logic sel_mux;
+
+
+  // Increase/ Reset Round number
+  logic inc_rnd_num;
+  logic rst_rnd_num;
+
+  // Round reaches end
+  // This signal indicates the round reaches desired number, which is MaxRound -1.
+  // MaxRound is dependant on the Width. In case of SHA3/SHAKE, MaxRound is 24.
+  logic rnd_eq_end;
+
+  // Complete of Keccak_f
+  // State machine asserts `complete_d` when it reaches at the end of round and
+  // operation (Phase3 if Masked). The the stage, the storage still doesn't have
+  // the valid states. So precisely it is not completed yet.
+  // State generated `complete_d` is latched with the clock and creates a pulse
+  // signal one cycle later. The signal is the indication of completion.
+  //
+  // Intentionally removed any intermediate step (so called StComplete) in order
+  // to save a clock to proceeds next round.
+  logic complete_d;
+
+  //////////////////////
+  // Datapath Signals //
+  //////////////////////
+
+  // Single round keccak output data
+  logic [Width-1:0] keccak_out [Share];
+
+  // Keccak Round indicator: range from 0 .. MaxRound
+  logic [RndW-1:0] round, round_d;
+
+  // Random value and valid signal used in Keccak_p
+  // There's plan to make random value generation configurable.
+  // 1. Tied to 0 in case of random value is not needed. It means the Keccak
+  //    doesn't need to be masked and throughput is the most important thing.
+  // 2. Receive random value from entropy source. This requires to fill 1600b
+  //    of entropy. It takes long time so generally it will have smaller bits
+  //    from tru entropy source and expands to 1600b (Width).
+  // 3. Reuse Share. This option is to reuse the other part of share. Chi stage
+  //    uses 3 sheets to create a sheet. (newX = X ^ (~(X+1) & (X+2))). So the
+  //    other two shares (X-1, X-2) can be assumed as random values, and may be
+  //    used as entropy source. It is weaker than the use of true entropy, but
+  //    much faster.
+  logic             keccak_rand_valid, keccak_rand_consumed;
+  logic [Width-1:0] keccak_rand_data;
+
+  //////////////////////
+  // Keccak Round FSM //
+  //////////////////////
+
+  // state inputs
+  assign rnd_eq_end = (round == MaxRound - 1);
+
+  typedef enum logic [2:0] {
+      StIdle,
+
+      // Active state is used in Unmasked version only.
+      // It handles keccak round in a cycle
+      StActive,
+
+      // Phase1 --> Phase2 --> Phase3
+      // Activated only in Masked version.
+      // Phase1 processes Theta, Rho, Pi steps in a cycle and stores the states
+      // into storage. It unconditionally moves to Phase2.
+      StPhase1,
+
+      // First half part of Chi step. It waits random value is ready
+      // then move to Phase 3.
+      StPhase2,
+
+      // Second half of Chi step and Iota step.
+      // This state doesn't require random value as it is XORed into the states
+      // in Phase2. If round is reached to the end (MaxRound -1) then it
+      // completes the process and goes back to Idle. If not, repeats the Phase
+      // again.
+      StPhase3,
+
+      // Error state. Not clearly defined yet.
+      // Intention is if any unexpected input in the process, state moves to
+      // here and report through the error fifo with debugging information.
+      StError
+  } keccak_st_e;
+  keccak_st_e keccak_st, keccak_st_d;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      keccak_st <= StIdle;
+    end else begin
+      keccak_st <= keccak_st_d;
+    end
+  end
+
+  // Next state logic and output logic
+  always_comb begin
+    // Default values
+    keccak_st_d = StIdle;
+
+    xor_message    = 1'b 0;
+    update_storage = 1'b 0;
+    rst_storage    = 1'b 0;
+
+    inc_rnd_num = 1'b 0;
+    rst_rnd_num = 1'b 0;
+
+    keccak_rand_consumed = 1'b 0;
+
+    sel_mux = 1'b 0;
+
+    complete_d = 1'b 0;
+
+    unique case (keccak_st)
+      StIdle: begin
+        if (valid_i) begin
+          // State machine allows Sponge Absorbing only in Idle state.
+          keccak_st_d = StIdle;
+
+          xor_message    = 1'b 1;
+          update_storage = 1'b 1;
+        end else if (clear_i) begin
+          // Opt1. State machine allows resetting the storage only in Idle
+          // Opt2. storage resets regardless of states but clear_i
+          // Both are added in the design at this time. Will choose the
+          // direction later.
+          keccak_st_d = StIdle;
+
+          rst_storage = 1'b 1;
+        end else if (EnMasking && run_i) begin
+          // Masked version of Keccak handling
+          keccak_st_d = StPhase1;
+        end else if (!EnMasking && run_i) begin
+          // Unmasked version of Keccak handling
+          keccak_st_d = StActive;
+        end else begin
+          keccak_st_d = StIdle;
+        end
+      end
+
+      StActive: begin
+        // Run Keccak single round logic until it reaches MaxRound - 1
+        update_storage = 1'b 1;
+
+        if (rnd_eq_end) begin
+          keccak_st_d = StIdle;
+
+          rst_rnd_num = 1'b 1;
+          complete_d  = 1'b 1;
+        end else begin
+          keccak_st_d = StActive;
+
+          inc_rnd_num = 1'b 1;
+        end
+      end
+
+      StPhase1: begin
+        // Unconditionally move to next phase.
+        keccak_st_d = StPhase2;
+
+        update_storage = 1'b 1;
+        sel_mux        = 1'b 0;
+      end
+
+      StPhase2: begin
+        // Second phase (Chi 1/2)
+        sel_mux = 1'b 1;
+
+        if (keccak_rand_valid) begin
+          keccak_st_d = StPhase3;
+
+          keccak_rand_consumed = 1'b 1;
+        end else begin
+          keccak_st_d = StPhase2;
+        end
+      end
+
+      StPhase3: begin
+        sel_mux = 1'b 1;
+        update_storage = 1'b 1;
+
+        if (rnd_eq_end) begin
+          keccak_st_d = StIdle;
+
+          rst_rnd_num    = 1'b 1;
+          complete_d     = 1'b 1;
+        end else begin
+          keccak_st_d = StPhase1;
+
+          inc_rnd_num = 1'b 1;
+        end
+      end
+
+      StError: begin
+        keccak_st_d = StIdle;
+      end
+
+      default: begin
+        keccak_st_d = StError;
+      end
+    endcase
+  end
+
+  ////////////////////////////
+  // Keccak state registers //
+  ////////////////////////////
+  logic [Width-1:0] storage   [Share];
+  logic [Width-1:0] storage_d [Share];
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      storage <= '{default:'0};
+    end else if (clear_i) begin
+      storage <= '{default:'0};
+    end else if (update_storage) begin
+      storage <= storage_d;
+    end
+  end
+
+  assign state_o = storage;
+
+  // Storage register input
+  // The incoming message is XORed with the existing storage registers.
+  // The logic can accept not a block size incoming message chunk but
+  // the size defined in `DInWidth` parameter with its position.
+
+  always_comb begin
+    storage_d = keccak_out;
+    if (xor_message) begin
+      for (int j = 0 ; j < Share ; j++) begin
+        for (int i = 0 ; i < DInEntry ; i++) begin
+          // TODO: handle If Width is not integer divisable by DInWidth
+          // Currently it is not allowed to have partial write
+          // Please see the Assertion `WidthDivisableByDInWidth_A`
+          if (addr_i == $unsigned(i)) begin
+            storage_d[j][i*DInWidth+:DInWidth] =
+              storage[j][i*DInWidth+:DInWidth] ^ data_i[j];
+          end else begin
+            storage_d[j][i*DInWidth+:DInWidth] = storage[j][i*DInWidth+:DInWidth];
+          end
+        end // for i
+      end // for j
+    end // if xor_message
+  end
+
+  //////////////
+  // Datapath //
+  //////////////
+  keccak_2share #(
+    .Width     (Width),
+    .EnMasking (EnMasking)
+  ) u_keccak_p (
+    .clk_i,
+    .rst_ni,
+
+    .rnd_i           (round),
+    .rand_valid_i    (keccak_rand_valid),
+    .rand_i          (keccak_rand_data),
+    .sel_i           (sel_mux),
+    .s_i             (storage),
+    .s_o             (keccak_out)
+  );
+
+  // keccak entropy handling
+  // TODO: Consider reuse of internal share
+  assign keccak_rand_valid = rand_valid_i;
+  assign rand_consumed_o = keccak_rand_consumed;
+
+  assign keccak_rand_data = rand_data_i;
+  `ASSERT_INIT(NoReuseShare_A, ReuseShare == 0)
+
+  // Round number
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      round <= '0;
+    end else if (rst_rnd_num) begin
+      round <= '0;
+    end else if (inc_rnd_num) begin
+      round <= round + 1'b 1;
+    end
+  end
+
+  // completion signal
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      complete_o <= 1'b 0;
+    end else begin
+      complete_o <= complete_d;
+    end
+  end
+
+  ////////////////
+  // Assertions //
+  ////////////////
+
+  // Only allow `DInWidth` that `Width` is integer divisable by `DInWidth`
+  `ASSERT_INIT(WidthDivisableByDInWidth_A, (Width % DInWidth) == 0)
+
+  // If `run_i` triggerred, it shall complete
+  //`ASSERT(RunResultComplete_A, run_i ##[MaxRound:] complete_o, clk_i, !rst_ni)
+
+  // valid_i and run_i cannot be asserted at the same time
+  `ASSUME(OneHot0ValidAndRun_A, $onehot0({valid_i, run_i}), clk_i, !rst_ni)
+
+  // valid_i, run_i only asserted in Idle state
+  `ASSUME(ValidRunAssertStIdle_A, valid_i || run_i |-> keccak_st == StIdle, clk_i, !rst_ni)
+
+  // clear_i is assumed to be asserted in Idle state
+  `ASSUME(ClearAssertStIdle_A, clear_i |-> keccak_st == StIdle, clk_i, !rst_ni)
+
+  // EnMasking controls the valid states
+  if (EnMasking) begin : gen_mask_st_chk
+    `ASSERT(EnMaskingValidStates_A, keccak_st != StActive, clk_i, !rst_ni)
+  end else begin : gen_unmask_st_chk
+    `ASSERT(UnmaskValidStates_A, !(keccak_st inside {StPhase1, StPhase2, StPhase3}),
+            clk_i, !rst_ni)
+  end
+
+  // If message is fed, it shall start from 0
+  // TODO: Handle the case `addr_i` changes prior to `valid_i`
+  //`ASSUME(MsgStartFrom0_A, valid_i |->
+  //                         (addr_i == 0) || (addr_i == $past(addr_i) + 1),
+  //        clk_i,!rst_ni)
+
+
+endmodule
+


### PR DESCRIPTION
This PR implements the full round of Keccak_f computation and its basic FPV testbench too. `keccak_round` module supports all configurations of Width from 25 to 1600bits. But only 1600b is used in KMAC. The `Width` parameter determines the number of rounds. For instance, `keccak_round` runs 22 rounds with 800bits of `Width` (12 + L) as defined in the SHA-3 standard.

This implementation has the keccak states registers inside the `keccak_round` module. To absorb the message, `keccak_round` module has data feed interface. The input interface width is configurable. The limitation is the input width `DInWidth` should be able to divide `Width`. e.g. 50b `Width` case, `DInWidth` can be 25b but not 27b.

FPV in this PR only checks the result digest of the empty message on SHA3-256 operation.