### PR TITLE
[otbn] Further tweaks to assembly syntax

### DIFF
--- a/hw/ip/otbn/data/bignum-insns.yml
+++ b/hw/ip/otbn/data/bignum-insns.yml
@@ -105,7 +105,7 @@
       doc: Immediate value
     - *bn-flag-group-operand
   syntax: |
-    <wrd>, <wrs>, <imm> [, FG<flag_group>]
+    <wrd>, <wrs>, <imm>[, FG<flag_group>]
   doc: |
     Adds a zero-extended unsigned immediate to the value of a WDR, writes the
     result to the destination WDR, and updates the flags.
@@ -420,7 +420,7 @@
       type: uimm
       doc: Immediate value
     - *bn-flag-group-operand
-  syntax: <wrd>, <wrs>, <imm> [, FG<flag_group>]
+  syntax: <wrd>, <wrs>, <imm>[, FG<flag_group>]
   doc: |
     Subtracts a zero-extended unsigned immediate from the value of a WDR,
     writes the result to the destination WDR, and updates the flags.
@@ -485,7 +485,7 @@
     - *bn-shift-type-operand
     - *bn-shift-bytes-operand
   syntax: &bn-and-syntax |
-    <wrd>, <wrs1>, <wrs2> [, <shift_type> <shift_bytes>B]
+    <wrd>, <wrs1>, <wrs2>[, <shift_type> <shift_bytes>B]
   doc: |
     Performs a bitwise and operation.
     Takes the values stored in registers referenced by `wrs1` and `wrs2` and stores the result in the register referenced by `wrd`.
@@ -548,7 +548,7 @@
     - *bn-shift-type-operand
     - *bn-shift-bytes-operand
   syntax: |
-    <wrd>, <wrs> [, <shift_type> <shift_bytes>B]
+    <wrd>, <wrs>[, <shift_type> <shift_bytes>B]
   doc: |
     Negates the value in `<wrs>`, storing the result into `<wrd>`.
     The source value can be shifted by an immediate before it is consumed by the operation.

--- a/hw/ip/otbn/util/otbn-as
+++ b/hw/ip/otbn/util/otbn-as
@@ -949,7 +949,7 @@ class Transformer:
         # glued operands) as a string.
         operands_str = self.key_sym[len(insn.mnemonic):] + ''.join(self.acc)
 
-        match = insn.asm_pattern.match(operands_str.strip())
+        match = insn.asm_pattern.match(operands_str.rstrip())
         if match is None:
             raise RuntimeError('{}:{}: Cannot match syntax for {!r} ({!r}).'
                                .format(self.in_path, self.line_number,


### PR DESCRIPTION
Apparently, I didn't check commit d82e48d carefully enough. We
definitely want to strip spaces from the right of the operand string,
but not from the left. Or at least, not without doing some other work.
The problem is the syntax for mulqacc, which looks something like
this:

    [<z>] <wrs1>.<wrs1_qwsel>, <wrs2>.<wrs2_qwsel>, <imm>

If you strip the input string completely, an instruction like this

    BN.MULQACC w28.1, w29.0, 64

means we try to match "w28.1, w29.0, 64". The problem is that the
current matching logic requires the space after the optional ".Z".

Maybe the proper fix is to change the matching regex to be cleverer
and ignore whitespace between optional and required syntax, but that's
not completely trivial. For example, this syntax:

```
<foo> [<bar>] <baz>
```

probably should need a space between <foo> and <baz> if <bar> isn't
supplied.

While I looking at this, I've also fixed a few more syntaxes for the
bignum instructions, removing stray spaces. This is needed to parse
correctly if we strip on the right for a similar reason. If the syntax
is:

    <wrd>, <wrs>, <imm> [, FG<flag_group>]

and you use the form without a flag group, the matching code expects
some trailing whitespace. Before stripping the input, there was a
newline that matched nicely. Afterwards, it failed. But I think it's
perfectly reasonable for that to fail, and the syntax

    <wrd>, <wrs>, <imm>[, FG<flag_group>]

looks nicer in the docs anyway.
