### PR TITLE
[otbn] Automatically pass "-M numeric" in otbn-objdump

### DIFF
--- a/hw/ip/otbn/util/otbn-objdump
+++ b/hw/ip/otbn/util/otbn-objdump
@@ -137,11 +137,12 @@ def main() -> int:
     has_disasm = snoop_disasm_flags(args)
 
     objdump = find_tool('objdump')
-    cmd = [objdump] + args
     try:
         if not has_disasm:
+            cmd = [objdump] + args
             return subprocess.run(cmd).returncode
         else:
+            cmd = [objdump, '-M', 'numeric,no-aliases'] + args
             proc = subprocess.run(cmd, capture_output=True, text=True)
             if proc.returncode:
                 # Dump any lines that objdump wrote before it died


### PR DESCRIPTION
This stops the underlying disassembler from using RISC-V ABI names.
Since we aren't using the RISC-V ABI, we just want x0, x1 etc.
