### PR TITLE
[otbn] Small fixes in ISS and RIG

### DIFF
--- a/hw/ip/otbn/data/base-insns.yml
+++ b/hw/ip/otbn/data/base-insns.yml
@@ -288,6 +288,7 @@
     - grs2
     - &branch-offset-operand
       name: offset
+      pc-rel: true
       type: simm<<1
   straight-line: false
   encoding:

--- a/hw/ip/otbn/data/insns.yml
+++ b/hw/ip/otbn/data/insns.yml
@@ -96,6 +96,10 @@ encoding-schemes: enc-schemes.yml
 #
 #  doc:       A fragment of markdown that documents the operand
 #
+#  pc-rel:    Only valid for immediate operands. If true, this operand is
+#             encoded relative to the current PC. Optional boolean,
+#             defaults to false.
+#
 # The valid operand types are as follows:
 #
 #  gpr:       The name of a general purpose register. Syntax "grs" for a

--- a/hw/ip/otbn/dv/otbnsim/sim/model.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/model.py
@@ -166,9 +166,8 @@ class LoopStack:
 
         return None
 
-    def step(self, cur_pc: int) -> int:
-        '''Calculate the next PC and update loop stack'''
-        next_pc = cur_pc + 4
+    def step(self, next_pc: int) -> Optional[int]:
+        '''Update loop stack. If we should loop, return new PC'''
         if self.stack:
             top = self.stack[-1]
             if next_pc == top.match_addr:
@@ -267,7 +266,9 @@ class OTBNState(State):  # type: ignore
             self.pc_update.set(skip_pc)
 
     def loop_step(self) -> None:
-        self.pc_update.set(self.loop_stack.step(int(self.pc)))
+        back_pc = self.loop_stack.step(int(self.pc_update))
+        if back_pc is not None:
+            self.pc = back_pc
 
     def changes(self) -> List[Trace]:
         c = cast(List[Trace], super().changes())

--- a/hw/ip/otbn/util/otbn-as
+++ b/hw/ip/otbn/util/otbn-as
@@ -482,7 +482,7 @@ def expand_li(where: str, op_to_expr: Dict[str, Optional[str]]) -> List[str]:
                            'operand is wrong: {}'
                            .format(where, err))
 
-    grd_txt = gpr_type.render_val(grd_int)
+    grd_txt = gpr_type.render_val(grd_int, None)
 
     try:
         imm_int = int(imm, 0)

--- a/hw/ip/otbn/util/otbn-objdump
+++ b/hw/ip/otbn/util/otbn-objdump
@@ -76,7 +76,7 @@ def extract_operands(raw: int, encoding: Encoding) -> Dict[str, int]:
 #
 #   6d0:   0000418b                0x418b
 #
-_RAW_INSN_RE = re.compile(r'([\s]*[0-9a-f]+:[\s]+([0-9a-f]{8})[\s]+)'
+_RAW_INSN_RE = re.compile(r'([\s]*([0-9a-f]+):[\s]+([0-9a-f]{8})[\s]+)'
                           r'0x[0-9a-f]+\s*$')
 
 
@@ -87,15 +87,18 @@ def transform_disasm_line(line: str,
     if match is None:
         return line
 
-    # Parse match.group(2) as an integer. It was exactly 8 hex characters, so
-    # will fit in a u32.
-    raw = int(match.group(2), 16)
+    # match.group(3) is the raw instruction word. Parse it as an integer. It
+    # was exactly 8 hex characters, so will fit in a u32.
+    raw = int(match.group(3), 16)
     assert 0 <= raw < (1 << 32)
 
     insn = get_insn(raw, masks)
     if insn is None:
         # No match for this instruction pattern. Leave as-is.
         return line
+
+    # match.group(2) is the PC in hex.
+    pc = int(match.group(2), 16)
 
     # Extract operand values. We know we have an encoding (otherwise
     # get_insn_masks wouldn't have added the instruction to the masks list).
@@ -108,7 +111,8 @@ def transform_disasm_line(line: str,
     return('{}{:7}{}{}'.format(match.group(1), insn.mnemonic,
                                '' if insn.glued_ops else ' ',
                                insn.syntax.render_vals(op_vals,
-                                                       insn.name_to_operand)))
+                                                       insn.name_to_operand,
+                                                       pc)))
 
 
 def get_insn_masks(insns_file: InsnsFile) -> List[Tuple[int, int, Insn]]:

--- a/hw/ip/otbn/util/shared/operand.py
+++ b/hw/ip/otbn/util/shared/operand.py
@@ -311,8 +311,6 @@ class EnumOperandType(ImmOperandType):
                                          len(items), min_width))
             width = scheme_field.bits.width
 
-            # TODO  shift check  
-
         super().__init__(width, 0, False)
         self.items = items
 
@@ -366,8 +364,6 @@ class OptionOperandType(ImmOperandType):
         if scheme_field is not None:
             assert width <= scheme_field.bits.width
             width = scheme_field.bits.width
-
-        # todo shift check  
 
         super().__init__(width, 0, False)
         self.option = option

--- a/hw/ip/otbn/util/shared/syntax.py
+++ b/hw/ip/otbn/util/shared/syntax.py
@@ -78,7 +78,8 @@ class SyntaxToken:
 
     def render_vals(self,
                     op_vals: Dict[str, int],
-                    operands: Dict[str, Operand]) -> str:
+                    operands: Dict[str, Operand],
+                    cur_pc: int) -> str:
         '''Return an assembly listing for the given operand fields
 
         '''
@@ -88,7 +89,8 @@ class SyntaxToken:
         assert self.text in op_vals
         assert self.text in operands
 
-        return operands[self.text].op_type.render_val(op_vals[self.text])
+        op_type = operands[self.text].op_type
+        return op_type.render_val(op_vals[self.text], cur_pc)
 
 
 class SyntaxHunk:
@@ -186,7 +188,8 @@ class SyntaxHunk:
 
     def render_vals(self,
                     op_vals: Dict[str, int],
-                    operands: Dict[str, Operand]) -> str:
+                    operands: Dict[str, Operand],
+                    cur_pc: int) -> str:
         '''Return an assembly listing for the hunk given operand values
 
         If this hunk is optional and all its operands are zero, the hunk is
@@ -203,7 +206,7 @@ class SyntaxHunk:
             if not required:
                 return ''
 
-        return ''.join(token.render_vals(op_vals, operands)
+        return ''.join(token.render_vals(op_vals, operands, cur_pc)
                        for token in self.tokens)
 
 
@@ -346,9 +349,10 @@ class InsnSyntax:
 
     def render_vals(self,
                     op_vals: Dict[str, int],
-                    operands: Dict[str, Operand]) -> str:
+                    operands: Dict[str, Operand],
+                    cur_pc: int) -> str:
         '''Return an assembly listing for the given operand fields'''
         parts = []
         for hunk in self.hunks:
-            parts.append(hunk.render_vals(op_vals, operands))
+            parts.append(hunk.render_vals(op_vals, operands, cur_pc))
         return ''.join(parts)

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -27,7 +27,7 @@ tabulate
 yapf
 
 # Used by OTBN simulator
-riscv-model >= 0.6.4
+riscv-model == 0.6.5
 
 # Development version with OT-specific changes
 git+https://github.com/lowRISC/fusesoc.git@ot#egg=fusesoc >= 1.11.0


### PR DESCRIPTION
With these patches, we can generate and run a tiny example:

```shell
$ hw/ip/otbn/util/otbn-rig gen --size 10 -o gen.json
$ hw/ip/otbn/util/otbn-rig asm -o gen gen.json
$ hw/ip/otbn/util/otbn-as gen.S -o gen.o
$ hw/ip/otbn/util/otbn-ld -o gen -T gen.ld gen.o
$ hw/ip/otbn/dv/otbnsim/standalone.py -v gen
addi x30, x0, 1269                  | [x30 = 000004f5]
jal x6, .+3320                      | [x6 = 00000008, pc = 3324]
andi x24, x0, 4                     | [x24 = 00000000]
jal x3, .-2604                      | [x3 = 00000d04, pc = 724]
lui x29, 29447                      | [x29 = 07307000]
srl x18, x30, x30                   | [x18 = 00000000]
slli x17, x24, 0x05                 | [x17 = 00000000]
```

It's alive!