### PR TITLE
[otbn] Print error messages on failure in otbn-objdump

### DIFF
--- a/hw/ip/otbn/util/otbn-objdump
+++ b/hw/ip/otbn/util/otbn-objdump
@@ -146,6 +146,7 @@ def main() -> int:
             proc = subprocess.run(cmd, capture_output=True, text=True)
             if proc.returncode:
                 # Dump any lines that objdump wrote before it died
+                sys.stderr.write(proc.stderr)
                 sys.stdout.write(proc.stdout)
                 return proc.returncode
     except FileNotFoundError:


### PR DESCRIPTION
`subprocess.run(...., capture_output=True)` captures both stdout and
stderr for the child process. We need to capture stdout because we
want to alter it if all went well. But we need to make sure that
everything makes it to the console if something explodes and I'd
forgotten the captured stderr.
