### PR TITLE
[rv_core_ibex] Select Ibex register file implementation based on target

### DIFF
--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -38,6 +38,7 @@ module top_${top["name"]} #(
 % endfor
 
   // Manually defined parameters
+  parameter ibex_pkg::regfile_e IbexRegFile = ibex_pkg::RegFileFF,
   parameter bit IbexPipeLine = 0,
   parameter     BootRomInitFile = ""
 ) (
@@ -202,7 +203,7 @@ module top_${top["name"]} #(
     .RV32E                    (0),
     .RV32M                    (ibex_pkg::RV32MSingleCycle),
     .RV32B                    (ibex_pkg::RV32BNone),
-    .RegFile                  (ibex_pkg::RegFileFF),
+    .RegFile                  (IbexRegFile),
     .BranchTargetALU          (1),
     .WritebackStage           (1),
     .ICache                   (0),

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -9,6 +9,7 @@ module top_earlgrey #(
   parameter int unsigned SecAesStartTriggerDelay = 0,
 
   // Manually defined parameters
+  parameter ibex_pkg::regfile_e IbexRegFile = ibex_pkg::RegFileFF,
   parameter bit IbexPipeLine = 0,
   parameter     BootRomInitFile = ""
 ) (
@@ -304,7 +305,7 @@ module top_earlgrey #(
     .RV32E                    (0),
     .RV32M                    (ibex_pkg::RV32MSingleCycle),
     .RV32B                    (ibex_pkg::RV32BNone),
-    .RegFile                  (ibex_pkg::RegFileFF),
+    .RegFile                  (IbexRegFile),
     .BranchTargetALU          (1),
     .WritebackStage           (1),
     .ICache                   (0),

--- a/hw/top_earlgrey/rtl/top_earlgrey_artys7.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_artys7.sv
@@ -168,6 +168,7 @@ module top_earlgrey_artys7  #(
     .AesMasking(1'b0),
     .AesSBoxImpl(aes_pkg::SBoxImplLut),
     .SecAesStartTriggerDelay(0),
+    .IbexRegFile(ibex_pkg::RegFileFPGA),
     .IbexPipeLine(1),
     .BootRomInitFile(BootRomInitFile)
   ) top_earlgrey (

--- a/hw/top_earlgrey/rtl/top_earlgrey_cw305.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_cw305.sv
@@ -230,6 +230,7 @@ module top_earlgrey_cw305 #(
     .AesMasking(1'b0),
     .AesSBoxImpl(aes_pkg::SBoxImplLut),
     .SecAesStartTriggerDelay(40),
+    .IbexRegFile(ibex_pkg::RegFileFPGA),
     .IbexPipeLine(1),
     .BootRomInitFile(BootRomInitFile)
   ) top_earlgrey (

--- a/hw/top_earlgrey/rtl/top_earlgrey_nexysvideo.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_nexysvideo.sv
@@ -226,6 +226,7 @@ module top_earlgrey_nexysvideo #(
     .AesMasking(1'b0),
     .AesSBoxImpl(aes_pkg::SBoxImplLut),
     .SecAesStartTriggerDelay(0),
+    .IbexRegFile(ibex_pkg::RegFileFPGA),
     .IbexPipeLine(1),
     .BootRomInitFile(BootRomInitFile)
   ) top_earlgrey (


### PR DESCRIPTION
This is a first step towards selecting the register file implementation of Ibex based on the target. The register file itself has a big impact on the overall area of Ibex (~30%) and we have different implementations for ASIC (Latches), FPGA (LUTRAM) and a generic FF-based implementation.

~~This commit modifies rv_core_ibex to select the register file implementation based on the Impl parameter that we also use to select the implementation for technology-specific primitives.~~
This PR propagates the register file selection parameter of rv_core_ibex up to the top to allow selecting a variant based on the target. All FPGA tops now use the FPGA register file. We keep using the FF-based generic implementation for ASIC targets and RTL simulation (see lowRISC/OpenTitan#2650).