### PR TITLE
[dv/top-level] use SPI to load bootstrap

### DIFF
--- a/hw/dv/data/sim.mk
+++ b/hw/dv/data/sim.mk
@@ -76,6 +76,15 @@ else
 	# Compile the sw test code and generate the image.
 	${LOCK_SW_BUILD} "ninja -C ${sw_build_dir}/build-out \
 		${sw_test}_export_${sw_build_device}"
+	# Convert sw image to frame format
+	# TODO only needed for loading sw image through SPI. Can enhance this later
+	${LOCK_SW_BUILD} "ninja -C ${sw_build_dir}/build-out sw/host/spiflash/spiflash_export"
+	${LOCK_SW_BUILD} "${sw_build_dir}/build-bin/sw/host/spiflash/spiflash --input \
+		${sw_build_dir}/build-bin/${sw_test}_${sw_build_device}.bin \
+		--dump-frames=${run_dir}/sw.frames.bin"
+	${LOCK_SW_BUILD} "srec_cat ${run_dir}/sw.frames.bin --binary \
+		--offset 0x0 --byte-swap 4 --fill 0xff -within ${run_dir}/sw.frames.bin -binary -range-pad 4 \
+		--output ${run_dir}/sw.frames.vmem --vmem"
 	# Extract the sw test logs.
 	${proj_root}/util/device_sw_utils/extract_sw_logs.py \
 		-e "${sw_build_dir}/build-out/${sw_test}_${sw_build_device}.elf" \

--- a/hw/dv/sv/spi_agent/spi_agent_cfg.sv
+++ b/hw/dv/sv/spi_agent/spi_agent_cfg.sv
@@ -23,11 +23,13 @@ class spi_agent_cfg extends dv_base_agent_cfg;
 
   // enable randomly injecting extra delay between 2 sck/word
   bit  en_extra_dly_btw_sck;
+  uint min_extra_dly_ns_btw_sck     = 1;
   uint max_extra_dly_ns_btw_sck     = 100;  // small delay to avoid transfer timeout
   uint extra_dly_chance_pc_btw_sck  = 5;    // percentage of extra delay btw each spi clock edge
   // Note: can't handle word delay, if a word is splitted into multiple csb.
   // In that case, control delay in seq level
   bit  en_extra_dly_btw_word;
+  uint min_extra_dly_ns_btw_word    = 1;
   uint max_extra_dly_ns_btw_word    = 1000; // no timeout btw word
   uint extra_dly_chance_pc_btw_word = 5;    // percentage of extra delay btw each word
 

--- a/hw/dv/sv/spi_agent/spi_host_driver.sv
+++ b/hw/dv/sv/spi_agent/spi_host_driver.sv
@@ -128,7 +128,7 @@ class spi_host_driver extends spi_driver;
 
   function uint get_rand_extra_delay_ns_btw_sck();
     if (cfg.en_extra_dly_btw_sck && ($urandom % 100) < cfg.extra_dly_chance_pc_btw_sck) begin
-      return $urandom_range(1, cfg.max_extra_dly_ns_btw_sck);
+      return $urandom_range(cfg.min_extra_dly_ns_btw_sck, cfg.max_extra_dly_ns_btw_sck);
     end else begin
       return 0;
     end
@@ -136,7 +136,7 @@ class spi_host_driver extends spi_driver;
 
   function uint get_rand_extra_delay_ns_btw_word();
     if (cfg.en_extra_dly_btw_word && ($urandom % 100) < cfg.extra_dly_chance_pc_btw_word) begin
-      return $urandom_range(1, cfg.max_extra_dly_ns_btw_word);
+      return $urandom_range(cfg.min_extra_dly_ns_btw_word, cfg.max_extra_dly_ns_btw_word);
     end else begin
       return 0;
     end

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -138,6 +138,12 @@
       sw_test: sw/device/tests/uart_tx_rx_test
     }
     {
+      name: chip_uart_tx_rx_bootstrap
+      uvm_test_seq: chip_sw_uart_tx_rx_vseq
+      sw_test: sw/device/tests/uart_tx_rx_test
+      run_opts: ["+use_spi_load_bootstrap=1"]
+    }
+    {
       name: chip_aes_encr
       uvm_test_seq: chip_sw_base_vseq
       sw_test: sw/device/tests/aes_test

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -14,6 +14,9 @@ class chip_env_cfg extends cip_base_env_cfg #(.RAL_T(chip_reg_block));
   // Write logs from sw test to separate log file as well, in addition to the simulator log file.
   bit                 write_sw_logs_to_file = 1'b1;
 
+  // use spi or backdoor to load bootstrap
+  bit                 use_spi_load_bootstrap = 0;
+
   // chip top interfaces
   virtual clk_rst_if  usb_clk_rst_vif;
   gpio_vif            gpio_vif;
@@ -28,6 +31,7 @@ class chip_env_cfg extends cip_base_env_cfg #(.RAL_T(chip_reg_block));
   sw_logger_vif             sw_logger_vif;
   int sw_image_widths[]     = '{32, 64};
   string                    sw_images[string];
+  string                    sw_frame_image = "sw.frames.vmem";
   virtual sw_test_status_if sw_test_status_vif;
   uint                      sw_test_timeout_ns = 5_000_000; // 5ms
 

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -27,6 +27,7 @@ package chip_env_pkg;
 
   // local parameters and types
   parameter uint NUM_GPIOS = 16;
+  parameter uint SPI_FRAME_BYTE_SIZE = 1024;
 
   // SW constants
   parameter bit [TL_AW-1:0] SW_DV_LOG_ADDR = 32'h1000fffc;

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -70,7 +70,7 @@ class chip_base_vseq extends cip_base_vseq #(
     if (do_strap_pins_init) begin
       cfg.srst_n_vif.drive(1'b1);
       cfg.jtag_spi_n_vif.drive(1'b1); // Select JTAG.
-      cfg.bootstrap_vif.drive(1'b0);
+      cfg.bootstrap_vif.drive(cfg.use_spi_load_bootstrap);
     end
 
     // Now safe to do DUT init.

--- a/hw/top_earlgrey/dv/tests/chip_base_test.sv
+++ b/hw/top_earlgrey/dv/tests/chip_base_test.sv
@@ -39,6 +39,10 @@ class chip_base_test extends cip_base_test #(
 
     // Knob to pre-initialize RAM to 0s (disabled by default).
     void'($value$plusargs("initialize_ram=%0b", cfg.initialize_ram));
+
+    // Knob to use spi or backdoor to load bootstrap
+    void'($value$plusargs("use_spi_load_bootstrap=%0b", cfg.use_spi_load_bootstrap));
+
   endfunction : build_phase
 
 endclass : chip_base_test


### PR DESCRIPTION
Use spi to load sw image, but its sim time is 10x more than using
backdoor. Only apply to uart test for now

related to #3203

Signed-off-by: Weicai Yang <weicai@google.com>