### PR TITLE
[CI] License checker: show full command line

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -234,10 +234,10 @@ jobs:
   - bash: |
       fork_origin="$(git merge-base --fork-point origin/$SYSTEM_PULLREQUEST_TARGETBRANCH)"
       changed_files="$(git diff --name-only --diff-filter=ACMRTUXB "$fork_origin")"
-      licence_checker=util/lowrisc_misc-linters/licence-checker/licence-checker.py
+      licence_checker="util/lowrisc_misc-linters/licence-checker/licence-checker.py --config util/licence-checker.hjson"
       if [[ -n "$changed_files" ]]; then
         set -o pipefail
-        xargs "$licence_checker" --config util/licence-checker.hjson <<< "$changed_files" | tee licence-checker-output
+        xargs $licence_checker <<< "$changed_files" | tee licence-checker-output
         if [[ $? != 0 ]]; then
           echo -n "##vso[task.logissue type=error]"
           echo "Licence header check failed. Please check output of $licence_checker on the noted failures."


### PR DESCRIPTION
If the license checker fails, it shows an error message in CI:

"Licence header check failed. Please check output of
util/lowrisc_misc-linters/licence-checker/licence-checker.py on
the noted failures.".

This commit makes the message more actionable for the user confronted
with this message by showing the full invocation, including the config
file.