### PR TITLE
[dv/alert_handler] reduce entropy test runtime

### DIFF
--- a/hw/ip/alert_handler/dv/alert_handler_generic_sim_cfg.hjson
+++ b/hw/ip/alert_handler/dv/alert_handler_generic_sim_cfg.hjson
@@ -76,18 +76,18 @@
     {
       name: alert_handler_entropy
       uvm_test_seq: alert_handler_entropy_vseq
-      run_opts: ["+test_timeout_ns=20_000_000_000", "+zero_delays=1"]
+      run_opts: ["+test_timeout_ns=10_000_000_000", "+zero_delays=1"]
     }
 
     {
       name: alert_handler_ping_rsp_fail
       uvm_test_seq: alert_handler_ping_rsp_fail_vseq
-      run_opts: ["+test_timeout_ns=20_000_000_000", "+zero_delays=1"]
+      run_opts: ["+test_timeout_ns=10_000_000_000", "+zero_delays=1"]
     }
 
     {
       name: alert_handler_stress_all
-      run_opts: ["+test_timeout_ns=25_000_000_000", "+zero_delays=1"]
+      run_opts: ["+test_timeout_ns=15_000_000_000", "+zero_delays=1"]
     }
 
     {

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_entropy_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_entropy_vseq.sv
@@ -11,7 +11,7 @@ class alert_handler_entropy_vseq extends alert_handler_sanity_vseq;
 
   // large number of num_trans to make sure covers all alerts and escalation pings
   constraint num_trans_c {
-    num_trans inside {[4_000:100_000]};
+    num_trans inside {[4_000:50_000]};
   }
 
   // increase the possibility to enable more alerts, because alert_handler only sends ping on


### PR DESCRIPTION
Due to PR #3285 that forces the signal `wait_cyc_mask_i`, we no longer
need to run to hit all corner cases in this entropy test. So I shorten
the run time of this test by half.

Signed-off-by: Cindy Chen <chencindy@google.com>