### PR TITLE
[dv/alert_agent] simplify the async logic

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent.sv
@@ -58,6 +58,9 @@ class alert_esc_agent extends dv_base_agent#(
         `uvm_fatal(`gfn, "failed to get probe_vif handle from uvm_config_db")
       end
     end
+
+    // set async mode to alert_esc interface
+    cfg.vif.is_async = cfg.is_async;
     // set async alert clock frequency
     if (cfg.is_alert && cfg.is_async) begin
       cfg.vif.clk_rst_async_if.set_active(.drive_rst_n_val(0));

--- a/hw/dv/sv/alert_esc_agent/alert_esc_if.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_if.sv
@@ -10,24 +10,20 @@ interface alert_esc_if(input clk, input rst_n);
   wire prim_alert_pkg::alert_rx_t alert_rx;
   wire prim_esc_pkg::esc_tx_t esc_tx;
   wire prim_esc_pkg::esc_rx_t esc_rx;
-  wire clk_async;
-  clk_rst_if clk_rst_async_if(.clk(clk_async), .rst_n(rst_n));
+  wire sender_clk;
+  bit  is_async;
+  clk_rst_if clk_rst_async_if(.clk(sender_clk), .rst_n(rst_n));
 
-  // dut clk freq, used to generate async alert frequency
+  // if alert sender is async mode, the clock will be drived in alert_esc_agent,
+  // if it is sync mode, will assign to dut clk here
+  assign sender_clk = (is_async) ? 'z : clk ;
 
-  clocking sender_cb @(posedge clk);
+  clocking sender_cb @(posedge sender_clk);
     input  rst_n;
     output alert_tx;
     input  alert_rx;
     output esc_tx;
     input  esc_rx;
-  endclocking
-
-  // only alert has async mode, escalator only has sync mode
-  clocking sender_async_cb @(posedge clk_async);
-    input  rst_n;
-    output alert_tx;
-    input  alert_rx;
   endclocking
 
   clocking receiver_cb @(posedge clk);

--- a/hw/dv/sv/alert_esc_agent/alert_sender_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_sender_driver.sv
@@ -179,43 +179,23 @@ class alert_sender_driver extends alert_esc_base_driver;
   endtask : random_drive_int_fail
 
   virtual task set_alert();
-    if (cfg.is_async) begin
-      cfg.vif.sender_async_cb.alert_tx.alert_p <= 1'b1;
-      cfg.vif.sender_async_cb.alert_tx.alert_n <= 1'b0;
-    end else begin
-      cfg.vif.sender_cb.alert_tx.alert_p <= 1'b1;
-      cfg.vif.sender_cb.alert_tx.alert_n <= 1'b0;
-    end
+    cfg.vif.sender_cb.alert_tx.alert_p <= 1'b1;
+    cfg.vif.sender_cb.alert_tx.alert_n <= 1'b0;
   endtask
 
   virtual task reset_alert();
-    if (cfg.is_async) begin
-      cfg.vif.sender_async_cb.alert_tx.alert_p <= 1'b0;
-      cfg.vif.sender_async_cb.alert_tx.alert_n <= 1'b1;
-    end else begin
-      cfg.vif.sender_cb.alert_tx.alert_p <= 1'b0;
-      cfg.vif.sender_cb.alert_tx.alert_n <= 1'b1;
-    end
+    cfg.vif.sender_cb.alert_tx.alert_p <= 1'b0;
+    cfg.vif.sender_cb.alert_tx.alert_n <= 1'b1;
   endtask
 
   virtual task drive_alerts_high();
-    if (cfg.is_async) begin
-      cfg.vif.sender_async_cb.alert_tx.alert_p <= 1'b1;
-      cfg.vif.sender_async_cb.alert_tx.alert_n <= 1'b1;
-    end else begin
-      cfg.vif.sender_cb.alert_tx.alert_p <= 1'b1;
-      cfg.vif.sender_cb.alert_tx.alert_n <= 1'b1;
-    end
+    cfg.vif.sender_cb.alert_tx.alert_p <= 1'b1;
+    cfg.vif.sender_cb.alert_tx.alert_n <= 1'b1;
   endtask
 
   virtual task drive_alerts_low();
-    if (cfg.is_async) begin
-      cfg.vif.sender_async_cb.alert_tx.alert_p <= 1'b0;
-      cfg.vif.sender_async_cb.alert_tx.alert_n <= 1'b0;
-    end else begin
-      cfg.vif.sender_cb.alert_tx.alert_p <= 1'b0;
-      cfg.vif.sender_cb.alert_tx.alert_n <= 1'b0;
-    end
+    cfg.vif.sender_cb.alert_tx.alert_p <= 1'b0;
+    cfg.vif.sender_cb.alert_tx.alert_n <= 1'b0;
   endtask
 
   virtual task wait_ping();
@@ -227,8 +207,7 @@ class alert_sender_driver extends alert_esc_base_driver;
   endtask : wait_ping
 
   virtual task wait_sender_clk();
-    if (cfg.is_async) @(cfg.vif.sender_async_cb);
-    else @(cfg.vif.sender_cb);
+    @(cfg.vif.sender_cb);
   endtask
 
 endclass : alert_sender_driver


### PR DESCRIPTION
In alert_esc_if, there used to be two alert_sender clocking blocks: one
for async and one for sync mode. This PR unify them into one clocking
block thus reduce the switching logic in `alert_sender_driver`.

Signed-off-by: Cindy Chen <chencindy@google.com>