### PR TITLE
[dv/alert_agent] async reset fix

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent.sv
@@ -59,8 +59,10 @@ class alert_esc_agent extends dv_base_agent#(
       end
     end
 
-    // set async mode to alert_esc interface
+    // set variables to alert_esc interface
     cfg.vif.is_async = cfg.is_async;
+    cfg.vif.is_alert = cfg.is_alert;
+    cfg.vif.if_mode  = cfg.if_mode;
     // set async alert clock frequency
     if (cfg.is_alert && cfg.is_async) begin
       cfg.vif.clk_rst_async_if.set_active(.drive_rst_n_val(0));

--- a/hw/dv/sv/alert_esc_agent/alert_esc_base_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_base_driver.sv
@@ -27,6 +27,7 @@ class alert_esc_base_driver extends dv_base_driver#(alert_esc_seq_item, alert_es
   endtask
 
   virtual task get_req();
+    @(posedge cfg.vif.rst_n);
     forever begin
       alert_esc_seq_item req_clone;
       seq_item_port.get(req);

--- a/hw/dv/sv/alert_esc_agent/alert_esc_if.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_if.sv
@@ -8,10 +8,16 @@
 interface alert_esc_if(input clk, input rst_n);
   wire prim_alert_pkg::alert_tx_t alert_tx;
   wire prim_alert_pkg::alert_rx_t alert_rx;
-  wire prim_esc_pkg::esc_tx_t esc_tx;
-  wire prim_esc_pkg::esc_rx_t esc_rx;
-  wire sender_clk;
-  bit  is_async;
+  wire prim_esc_pkg::esc_tx_t     esc_tx;
+  wire prim_esc_pkg::esc_rx_t     esc_rx;
+  prim_alert_pkg::alert_tx_t      alert_tx_int; // internal alert_tx
+  prim_alert_pkg::alert_rx_t      alert_rx_int; // internal alert_rx
+  prim_esc_pkg::esc_tx_t          esc_tx_int;   // internal esc_tx
+  prim_esc_pkg::esc_rx_t          esc_rx_int;   // internal esc_rx
+
+  wire       sender_clk;
+  bit        is_async, is_alert;
+  dv_utils_pkg::if_mode_e  if_mode;
   clk_rst_if clk_rst_async_if(.clk(sender_clk), .rst_n(rst_n));
 
   // if alert sender is async mode, the clock will be drived in alert_esc_agent,
@@ -20,18 +26,18 @@ interface alert_esc_if(input clk, input rst_n);
 
   clocking sender_cb @(posedge sender_clk);
     input  rst_n;
-    output alert_tx;
+    output alert_tx_int;
     input  alert_rx;
-    output esc_tx;
+    output esc_tx_int;
     input  esc_rx;
   endclocking
 
   clocking receiver_cb @(posedge clk);
     input  rst_n;
     input  alert_tx;
-    output alert_rx;
+    output alert_rx_int;
     input  esc_tx;
-    output esc_rx;
+    output esc_rx_int;
   endclocking
 
   clocking monitor_cb @(posedge clk);
@@ -49,5 +55,10 @@ interface alert_esc_if(input clk, input rst_n);
   task automatic wait_esc_complete();
     while (esc_tx.esc_p === 1'b1 && esc_tx.esc_n === 1'b0) @(monitor_cb);
   endtask : wait_esc_complete
+
+  assign alert_tx = (if_mode == dv_utils_pkg::Host && is_alert)    ? alert_tx_int : 'z;
+  assign alert_rx = (if_mode == dv_utils_pkg::Device && is_alert)  ? alert_rx_int : 'z;
+  assign esc_tx   = (if_mode == dv_utils_pkg::Host && !is_alert)   ? esc_tx_int   : 'z;
+  assign esc_rx   = (if_mode == dv_utils_pkg::Device && !is_alert) ? esc_rx_int   : 'z;
 
 endinterface: alert_esc_if

--- a/hw/dv/sv/alert_esc_agent/alert_receiver_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_receiver_driver.sv
@@ -20,11 +20,11 @@ class alert_receiver_driver extends alert_esc_base_driver;
   endtask : drive_req
 
   virtual task reset_signals();
+    do_reset();
     forever begin
       @(negedge cfg.vif.rst_n);
       under_reset = 1;
-      reset_ping();
-      reset_ack();
+      do_reset();
       @(posedge cfg.vif.rst_n);
       under_reset = 0;
     end
@@ -148,18 +148,18 @@ class alert_receiver_driver extends alert_esc_base_driver;
   endtask : set_ack_pins
 
   virtual task set_ack();
-    cfg.vif.receiver_cb.alert_rx.ack_p <= 1'b1;
-    cfg.vif.receiver_cb.alert_rx.ack_n <= 1'b0;
+    cfg.vif.receiver_cb.alert_rx_int.ack_p <= 1'b1;
+    cfg.vif.receiver_cb.alert_rx_int.ack_n <= 1'b0;
   endtask
 
   virtual task reset_ack();
-    cfg.vif.receiver_cb.alert_rx.ack_p <= 1'b0;
-    cfg.vif.receiver_cb.alert_rx.ack_n <= 1'b1;
+    cfg.vif.receiver_cb.alert_rx_int.ack_p <= 1'b0;
+    cfg.vif.receiver_cb.alert_rx_int.ack_n <= 1'b1;
   endtask
 
   virtual task set_ping();
-    cfg.vif.receiver_cb.alert_rx.ping_p <= !cfg.vif.alert_rx.ping_p;
-    cfg.vif.receiver_cb.alert_rx.ping_n <= !cfg.vif.alert_rx.ping_n;
+    cfg.vif.receiver_cb.alert_rx_int.ping_p <= !cfg.vif.alert_rx.ping_p;
+    cfg.vif.receiver_cb.alert_rx_int.ping_n <= !cfg.vif.alert_rx.ping_n;
   endtask
 
   virtual task wait_alert();
@@ -167,7 +167,15 @@ class alert_receiver_driver extends alert_esc_base_driver;
   endtask : wait_alert
 
   virtual task reset_ping();
-    cfg.vif.receiver_cb.alert_rx.ping_p <= 1'b0;
-    cfg.vif.receiver_cb.alert_rx.ping_n <= 1'b1;
+    cfg.vif.receiver_cb.alert_rx_int.ping_p <= 1'b0;
+    cfg.vif.receiver_cb.alert_rx_int.ping_n <= 1'b1;
   endtask
+
+  virtual task do_reset();
+    cfg.vif.alert_rx_int.ping_p <= 1'b0;
+    cfg.vif.alert_rx_int.ping_n <= 1'b1;
+    cfg.vif.alert_rx_int.ack_p <= 1'b0;
+    cfg.vif.alert_rx_int.ack_n <= 1'b1;
+  endtask
+
 endclass : alert_receiver_driver

--- a/hw/dv/sv/alert_esc_agent/alert_sender_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_sender_driver.sv
@@ -16,12 +16,13 @@ class alert_sender_driver extends alert_esc_base_driver;
   semaphore alert_atomic = new(1);
 
   virtual task reset_signals();
+    do_reset();
     forever begin
       @(negedge cfg.vif.rst_n);
       under_reset = 1;
       void'(alert_atomic.try_get(1));
       alert_atomic.put(1);
-      reset_alert();
+      do_reset();
       @(posedge cfg.vif.rst_n);
       under_reset = 0;
     end
@@ -179,23 +180,23 @@ class alert_sender_driver extends alert_esc_base_driver;
   endtask : random_drive_int_fail
 
   virtual task set_alert();
-    cfg.vif.sender_cb.alert_tx.alert_p <= 1'b1;
-    cfg.vif.sender_cb.alert_tx.alert_n <= 1'b0;
+    cfg.vif.sender_cb.alert_tx_int.alert_p <= 1'b1;
+    cfg.vif.sender_cb.alert_tx_int.alert_n <= 1'b0;
   endtask
 
   virtual task reset_alert();
-    cfg.vif.sender_cb.alert_tx.alert_p <= 1'b0;
-    cfg.vif.sender_cb.alert_tx.alert_n <= 1'b1;
+    cfg.vif.sender_cb.alert_tx_int.alert_p <= 1'b0;
+    cfg.vif.sender_cb.alert_tx_int.alert_n <= 1'b1;
   endtask
 
   virtual task drive_alerts_high();
-    cfg.vif.sender_cb.alert_tx.alert_p <= 1'b1;
-    cfg.vif.sender_cb.alert_tx.alert_n <= 1'b1;
+    cfg.vif.sender_cb.alert_tx_int.alert_p <= 1'b1;
+    cfg.vif.sender_cb.alert_tx_int.alert_n <= 1'b1;
   endtask
 
   virtual task drive_alerts_low();
-    cfg.vif.sender_cb.alert_tx.alert_p <= 1'b0;
-    cfg.vif.sender_cb.alert_tx.alert_n <= 1'b0;
+    cfg.vif.sender_cb.alert_tx_int.alert_p <= 1'b0;
+    cfg.vif.sender_cb.alert_tx_int.alert_n <= 1'b0;
   endtask
 
   virtual task wait_ping();
@@ -208,6 +209,11 @@ class alert_sender_driver extends alert_esc_base_driver;
 
   virtual task wait_sender_clk();
     @(cfg.vif.sender_cb);
+  endtask
+
+  virtual task do_reset();
+    cfg.vif.alert_tx_int.alert_p <= 1'b0;
+    cfg.vif.alert_tx_int.alert_n <= 1'b1;
   endtask
 
 endclass : alert_sender_driver

--- a/hw/dv/sv/alert_esc_agent/esc_receiver_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/esc_receiver_driver.sv
@@ -14,10 +14,11 @@ class esc_receiver_driver extends alert_esc_base_driver;
   bit is_ping;
 
   virtual task reset_signals();
+    do_reset();
     forever begin
       @(negedge cfg.vif.rst_n);
       under_reset = 1;
-      reset_resp();
+      do_reset();
       is_ping = 0;
       @(posedge cfg.vif.rst_n);
       under_reset = 0;
@@ -160,23 +161,23 @@ class esc_receiver_driver extends alert_esc_base_driver;
   endtask
 
   virtual task set_resp();
-    cfg.vif.receiver_cb.esc_rx.resp_p <= 1'b1;
-    cfg.vif.receiver_cb.esc_rx.resp_n <= 1'b0;
+    cfg.vif.receiver_cb.esc_rx_int.resp_p <= 1'b1;
+    cfg.vif.receiver_cb.esc_rx_int.resp_n <= 1'b0;
   endtask
 
   virtual task reset_resp();
-    cfg.vif.receiver_cb.esc_rx.resp_p <= 1'b0;
-    cfg.vif.receiver_cb.esc_rx.resp_n <= 1'b1;
+    cfg.vif.receiver_cb.esc_rx_int.resp_p <= 1'b0;
+    cfg.vif.receiver_cb.esc_rx_int.resp_n <= 1'b1;
   endtask
 
   virtual task set_resp_both_high();
-    cfg.vif.receiver_cb.esc_rx.resp_p <= 1'b1;
-    cfg.vif.receiver_cb.esc_rx.resp_n <= 1'b1;
+    cfg.vif.receiver_cb.esc_rx_int.resp_p <= 1'b1;
+    cfg.vif.receiver_cb.esc_rx_int.resp_n <= 1'b1;
   endtask
 
   virtual task set_resp_both_low();
-    cfg.vif.receiver_cb.esc_rx.resp_p <= 1'b0;
-    cfg.vif.receiver_cb.esc_rx.resp_n <= 1'b0;
+    cfg.vif.receiver_cb.esc_rx_int.resp_p <= 1'b0;
+    cfg.vif.receiver_cb.esc_rx_int.resp_n <= 1'b0;
   endtask
 
   virtual function bit get_esc();
@@ -190,5 +191,10 @@ class esc_receiver_driver extends alert_esc_base_driver;
   virtual task wait_esc();
     while (cfg.vif.esc_tx.esc_p === 1'b0 && cfg.vif.esc_tx.esc_n === 1'b1) @(cfg.vif.receiver_cb);
   endtask : wait_esc
+
+  virtual task do_reset();
+    cfg.vif.esc_rx_int.resp_p <= 1'b0;
+    cfg.vif.esc_rx_int.resp_n <= 1'b1;
+  endtask
 
 endclass : esc_receiver_driver


### PR DESCRIPTION
Previously reset is issued with the clocking block. So if async mode is
on and one of the clock goes very slow, then there is a corner case
where all the reset of the signals are reset, but the slow clock's
interface is not.
To fix this issue, reset signals needs to be async (not driving through
the clocking block). To allow this, the input of the alert_esc_interface
is set to logic instead of wire.

Signed-off-by: Cindy Chen <chencindy@google.com>