### PR TITLE
[i2c,dv] Fix the incorrect assertions of sda_interference interrupt

### DIFF
--- a/hw/dv/sv/i2c_agent/i2c_agent_pkg.sv
+++ b/hw/dv/sv/i2c_agent/i2c_agent_pkg.sv
@@ -21,18 +21,19 @@ package i2c_agent_pkg;
   // register values
   typedef struct {
     // derived parameters
-    bit [31:0]  tSetupStart;
-    bit [31:0]  tHoldStart;
-    bit [31:0]  tClockStart;
-    bit [31:0]  tClockLow;
-    bit [31:0]  tSetupBit;
-    bit [31:0]  tClockPulse;
-    bit [31:0]  tHoldBit;
-    bit [31:0]  tClockStop;
-    bit [31:0]  tSetupStop;
-    bit [31:0]  tHoldStop;
-    bit         enbTimeOut;
-    bit [30:0]  tTimeOut;
+    bit  [31:0]  tSetupStart;
+    bit  [31:0]  tHoldStart;
+    bit  [31:0]  tClockStart;
+    bit  [31:0]  tClockLow;
+    bit  [31:0]  tSetupBit;
+    bit  [31:0]  tClockPulse;
+    bit  [31:0]  tHoldBit;
+    bit  [31:0]  tClockStop;
+    bit  [31:0]  tSetupStop;
+    bit  [31:0]  tHoldStop;
+    bit          enbTimeOut;
+    bit  [30:0]  tTimeOut;
+    uint         tStretchHostClock;
   } timing_cfg_t;
 
   typedef enum int {

--- a/hw/dv/sv/i2c_agent/i2c_if.sv
+++ b/hw/dv/sv/i2c_agent/i2c_if.sv
@@ -144,6 +144,9 @@ interface i2c_if;
     wait_for_dly(tc.tSetupBit);
     @(posedge scl_i);
     wait_for_dly(tc.tClockPulse + tc.tHoldBit);
+    if (tc.enbTimeOut) begin
+      wait_for_dly(tc.tStretchHostClock);
+    end
     sda_o = 1'b1;
   endtask: device_send_ack
 
@@ -158,12 +161,13 @@ interface i2c_if;
     sda_o = 1'b1;
   endtask: device_send_bit
 
-  task automatic device_stretch_host_clk(ref timing_cfg_t tc,
-                                         input int num_stretch_host_clks);
-    wait_for_dly(tc.tClockLow + tc.tSetupBit);
-    scl_o = 1'b0;
-    wait_for_dly(num_stretch_host_clks);
-    scl_o = 1'b1;
+  task automatic device_stretch_host_clk(ref timing_cfg_t tc);
+    if (tc.enbTimeOut) begin
+      wait_for_dly(tc.tClockLow + tc.tSetupBit);
+      scl_o = 1'b0;
+      wait_for_dly(tc.tStretchHostClock);
+      scl_o = 1'b1;
+    end
   endtask : device_stretch_host_clk
 
   task automatic get_bit_data(string src = "host",


### PR DESCRIPTION
[i2c,dv] Patches for the incorrect assertion of sda_interference and sda_unstable
    
  - Fix sda interference occurred in the address phase of read transaction
  - Fix sda not remain (unstable) during clock pulse

Signed-off-by: Tung Hoang <hoang.tung@wdc.com>