### PR TITLE
[DIF] Small cleanups

### DIFF
--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # UART DIF library (dif_uart)
-dif_uart = declare_dependency(
+sw_lib_dif_uart = declare_dependency(
   link_with: static_library(
     'uart_ot',
     sources: [
@@ -17,7 +17,7 @@ dif_uart = declare_dependency(
 )
 
 # PLIC DIF library (dif_plic)
-dif_plic = declare_dependency(
+sw_lib_dif_plic = declare_dependency(
   link_with: static_library(
     'dif_plic_ot',
     sources: [
@@ -57,7 +57,7 @@ sw_lib_dif_spi_device = declare_dependency(
 )
 
 # RISC-V Timer DIF library (dif_rv_timer)
-dif_rv_timer = declare_dependency(
+sw_lib_dif_rv_timer = declare_dependency(
   link_with: static_library(
     'dif_rv_timer_ot',
     sources: [
@@ -100,7 +100,7 @@ sw_lib_dif_usbdev = declare_dependency(
 )
 
 # HMAC device DIF library
-sw_dif_hmac = declare_dependency(
+sw_lib_dif_hmac = declare_dependency(
   link_with: static_library(
     'sw_dif_hmac',
     sources: [

--- a/sw/device/lib/meson.build
+++ b/sw/device/lib/meson.build
@@ -15,7 +15,7 @@ sw_lib_uart = declare_dependency(
     dependencies: [
       sw_lib_base_print,
       sw_lib_runtime_ibex,
-      dif_uart,
+      sw_lib_dif_uart,
       top_earlgrey,
     ],
   )

--- a/sw/device/sca/aes_serial/meson.build
+++ b/sw/device/sca/aes_serial/meson.build
@@ -9,7 +9,7 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
     name_suffix: 'elf',
     dependencies: [
       device_lib,
-      dif_rv_timer,
+      sw_lib_dif_rv_timer,
       riscv_crt,
       sw_lib_aes,
       sw_lib_base_log,

--- a/sw/device/tests/dif/dif_hmac_sanitytest.c
+++ b/sw/device/tests/dif/dif_hmac_sanitytest.c
@@ -12,7 +12,8 @@
 #include "sw/device/lib/testing/test_main.h"
 #include "sw/device/lib/uart.h"
 
-#define HMAC0_BASE_ADDR 0x40120000
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
 #define MAX_FIFO_FILL 10
 
 const test_config_t kTestConfig = {
@@ -181,7 +182,7 @@ bool test_main() {
   LOG_INFO("Running HMAC DIF test...");
 
   dif_hmac_config_t hmac_config = {
-      .base_addr = mmio_region_from_addr(HMAC0_BASE_ADDR),
+      .base_addr = mmio_region_from_addr(TOP_EARLGREY_HMAC_BASE_ADDR),
       .digest_endianness = kDifHmacEndiannessBig,
       .message_endianness = kDifHmacEndiannessBig,
   };

--- a/sw/device/tests/dif/meson.build
+++ b/sw/device/tests/dif/meson.build
@@ -119,8 +119,8 @@ dif_plic_sanitytest_lib = declare_dependency(
     'dif_plic_sanitytest_lib',
     sources: ['dif_plic_sanitytest.c'],
     dependencies: [
-      dif_uart,
-      dif_plic,
+      sw_lib_dif_uart,
+      sw_lib_dif_plic,
       sw_lib_irq,
       sw_lib_mmio,
       sw_lib_base_log,
@@ -136,7 +136,7 @@ dif_uart_sanitytest_lib = declare_dependency(
     'dif_uart_sanitytest_lib',
     sources: ['dif_uart_sanitytest.c'],
     dependencies: [
-      dif_uart,
+      sw_lib_dif_uart,
       sw_lib_mmio,
       sw_lib_runtime_hart,
     ],
@@ -149,7 +149,7 @@ dif_rv_timer_sanitytest_lib = declare_dependency(
     'dif_rv_timer_sanitytest_lib',
     sources: ['dif_rv_timer_sanitytest.c'],
     dependencies: [
-      dif_rv_timer,
+      sw_lib_dif_rv_timer,
       sw_lib_base_log,
       sw_lib_mmio,
       sw_lib_runtime_hart,
@@ -164,7 +164,7 @@ dif_hmac_sanitytest_lib = declare_dependency(
     'dif_hmac_sanitytest_lib',
     sources: ['dif_hmac_sanitytest.c'],
     dependencies: [
-      sw_dif_hmac,
+      sw_lib_dif_hmac,
       sw_lib_base_log,
       sw_lib_mmio,
       sw_lib_runtime_hart,

--- a/sw/device/tests/sim_dv/meson.build
+++ b/sw/device/tests/sim_dv/meson.build
@@ -7,8 +7,8 @@ uart_tx_rx_test_lib = declare_dependency(
     'uart_tx_rx_test_lib',
     sources: ['uart_tx_rx_test.c'],
     dependencies: [
-      dif_uart,
-      dif_plic,
+      sw_lib_dif_uart,
+      sw_lib_dif_plic,
       sw_lib_irq,
       sw_lib_mmio,
       sw_lib_uart,
@@ -26,7 +26,7 @@ gpio_test_lib = declare_dependency(
     sources: ['gpio_test.c'],
     dependencies: [
       sw_lib_dif_gpio,
-      dif_plic,
+      sw_lib_dif_plic,
       sw_lib_irq,
       sw_lib_mmio,
       sw_lib_pinmux,


### PR DESCRIPTION
* Consistently name DIF build targets.
* Use generated constants in HMAC sanity.