### PR TITLE
[ci] Force setuptools version < 50.0.0

### DIFF
--- a/ci/install-package-dependencies.yml
+++ b/ci/install-package-dependencies.yml
@@ -67,7 +67,13 @@ steps:
       # specify that an older version of a package must be used for a certain
       # Python version. If that information is not read, pip installs the latest
       # version, which then fails to run.
-      pip3 install --user -U setuptools pip six
+      pip3 install --user -U pip six
+
+      # There's been a bit of a kerfuffle about setuptools version 50, which
+      # breaks importing distutils on Debian/Ubuntu systems. Make sure we don't
+      # pick it up until the dust has settled and things work again.
+      pip3 install --user -U 'setuptools < 50.0.0'
+
       pip3 install --user -U -r python-requirements.txt
 
       # Propagate PATH changes to all subsequent steps of the job


### PR DESCRIPTION
There's a long and painful discussion on the setuptools issues
list (I count 9 issues raised the day after the release). This is all
to do with how Debian/Ubuntu installs stuff with pip.

There's an "official" workaround that involves setting things in your
environment, but that looks a bit fiddly with the Azure pipelines
stuff and this has been such a disaster that I'm pretty certain the
setuptools maintainers will release something more sensible soon.

See e.g.
https://github.com/pypa/setuptools/issues/2350#issuecomment-683512526
for a careful description of what's going on.