### PR TITLE
[alert/dv] add coverage in alert_esc_agent

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent_cfg.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent_cfg.sv
@@ -9,8 +9,9 @@
 class alert_esc_agent_cfg extends dv_base_agent_cfg;
   virtual alert_esc_if vif;
   virtual alert_esc_probe_if probe_vif;
-  bit is_alert = 1;
-  bit is_async = 0;
+  bit is_alert     = 1;
+  bit is_async     = 0;
+  bit en_ping_cov  = 1;
   // dut clk frequency, used to generate alert async_clk frequency
   int clk_freq_mhz;
 

--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent_cov.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent_cov.sv
@@ -2,12 +2,59 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+covergroup alert_handshake_complete_cg with function sample(alert_esc_trans_type_e trans,
+                                                            alert_handshake_e      status);
+  option.per_instance = 1;
+
+  cp_handshake_complete: coverpoint status {
+    bins complete = {AlertAckComplete};
+  }
+  cp_trans_type: coverpoint trans {
+    bins alert_triggered = {AlertEscSigTrans};
+  }
+
+  alert_handshake_complete: cross cp_handshake_complete, cp_trans_type;
+endgroup : alert_handshake_complete_cg
+
+covergroup esc_handshake_complete_cg with function sample(alert_esc_trans_type_e trans,
+                                                          esc_handshake_e        status);
+  option.per_instance = 1;
+
+  cp_handshake_complete: coverpoint status {
+    bins complete = {EscRespComplete};
+  }
+  cp_trans_type: coverpoint trans {
+    bins esc_triggered = {AlertEscSigTrans};
+  }
+
+  esc_handshake_complete: cross cp_handshake_complete, cp_trans_type;
+endgroup : esc_handshake_complete_cg
+
+covergroup alert_esc_trans_cg with function sample(alert_esc_trans_type_e trans);
+  option.per_instance = 1;
+
+  cp_handshake_complete: coverpoint trans {
+    bins alert_esc_trans = {AlertEscSigTrans};
+    bins ping_trans      = {AlertEscPingTrans};
+  }
+endgroup : alert_esc_trans_cg
+
+// If a module contains alert or escalation ports, these covergroups can check if all
+// alerts/escalations/pings have been completed.
 class alert_esc_agent_cov extends dv_base_agent_cov #(alert_esc_agent_cfg);
 
-  `uvm_component_utils(alert_esc_agent_cov)
+  alert_handshake_complete_cg m_alert_handshake_complete_cg;
+  esc_handshake_complete_cg   m_esc_handshake_complete_cg;
+  alert_esc_trans_cg          m_alert_esc_trans_cg;
 
-  function new(string name, uvm_component parent);
-    super.new(name, parent);
-  endfunction : new
+  `uvm_component_utils(alert_esc_agent_cov)
+  `uvm_component_new
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    if (cfg.en_ping_cov) m_alert_esc_trans_cg = new();
+    if (cfg.is_alert)    m_alert_handshake_complete_cg = new();
+    else                 m_esc_handshake_complete_cg = new();
+  endfunction : build_phase
 
 endclass

--- a/hw/dv/sv/alert_esc_agent/alert_monitor.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_monitor.sv
@@ -70,6 +70,8 @@ class alert_monitor extends alert_esc_base_monitor;
             req.alert_esc_type.name(), req.alert_handshake_sta.name()), UVM_HIGH)
         if (!under_reset) begin
           alert_esc_port.write(req);
+          if (cfg.en_cov && cfg.en_ping_cov) cov.m_alert_esc_trans_cg.sample(req.alert_esc_type);
+
           // spurious alert error, can only happen one clock after timeout. Detail please see
           // discussion on Issue #2321
           if (req.timeout && req.alert_handshake_sta == AlertReceived) begin
@@ -126,6 +128,10 @@ class alert_monitor extends alert_esc_base_monitor;
         `uvm_info("alert_monitor", $sformatf("[%s]: handshake status is %s",
             req.alert_esc_type.name(), req.alert_handshake_sta.name()), UVM_HIGH)
         if (!under_reset) alert_esc_port.write(req);
+        if (cfg.en_cov) begin
+          cov.m_alert_handshake_complete_cg.sample(req.alert_esc_type, req.alert_handshake_sta);
+          if (cfg.en_ping_cov) cov.m_alert_esc_trans_cg.sample(req.alert_esc_type);
+        end
       end
       alert_p = cfg.vif.monitor_cb.alert_tx.alert_p;
     end

--- a/hw/dv/sv/alert_esc_agent/esc_monitor.sv
+++ b/hw/dv/sv/alert_esc_agent/esc_monitor.sv
@@ -98,6 +98,10 @@ class esc_monitor extends alert_esc_base_monitor;
 
         `uvm_info("esc_monitor", $sformatf("[%s]: handshake status is %s, timeout=%0b",
             req.alert_esc_type.name(), req.esc_handshake_sta.name(), req.timeout), UVM_HIGH)
+         if (cfg.en_cov) begin
+           cov.m_esc_handshake_complete_cg.sample(req.alert_esc_type, req.esc_handshake_sta);
+           if (cfg.en_ping_cov) cov.m_alert_esc_trans_cg.sample(req.alert_esc_type);
+         end
       end
     end
   endtask : esc_thread

--- a/hw/dv/sv/cip_lib/cip_base_env.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env.sv
@@ -50,6 +50,8 @@ class cip_base_env #(type CFG_T               = cip_base_env_cfg,
       m_alert_agent[alert_name] = alert_esc_agent::type_id::create(agent_name, this);
       cfg.m_alert_agent_cfg[alert_name] = alert_esc_agent_cfg::type_id::create("m_alert_agent_cfg");
       cfg.m_alert_agent_cfg[alert_name].if_mode = dv_utils_pkg::Device;
+      // seq won't send ping request because they are covered in alert_handler testbench
+      cfg.m_alert_agent_cfg[alert_name].en_ping_cov = 0;
       if (cfg.zero_delays) begin
         cfg.m_alert_agent_cfg[alert_name].alert_delay_min = 0;
         cfg.m_alert_agent_cfg[alert_name].alert_delay_max = 0;


### PR DESCRIPTION
Some modules have alert or escalation signals, but do not have a
full test to cover all the alert/escalation corner cases and to hit all
the code coverages. If excluding the alert/escalation RTL module in
coverage collection, this build-in functional coverage can check:
1). If alert/escalation handshake has been triggered and completed: via
covergroup `alert_handshake_complete_cg` and `esc_handshake_complete_cg`
2). If alert/escalation ping has been triggered: via covergroup
`alert_esc_trans_cg`. This coverage collection is on only when
`cfg.en_ping_cov` is set, because in some modules, we won't trigger any
ping sequences.

Signed-off-by: Cindy Chen <chencindy@google.com>