### PR TITLE
[sw] Add assembler (as) to toolchain.txt

### DIFF
--- a/doc/ug/install_instructions/index.md
+++ b/doc/ug/install_instructions/index.md
@@ -118,6 +118,7 @@ Alternatively, manually download the file starting with `lowrisc-toolchain-rv32i
     objdump = '/tools/riscv/bin/riscv32-unknown-elf-objdump'
     objcopy = '/tools/riscv/bin/riscv32-unknown-elf-objcopy'
     strip = '/tools/riscv/bin/riscv32-unknown-elf-strip'
+    as = '/tools/riscv/bin/riscv32-unknown-elf-as'
 
     [properties]
     needs_exe_wrapper = true

--- a/toolchain.txt
+++ b/toolchain.txt
@@ -17,6 +17,7 @@ ld = '/tools/riscv/bin/riscv32-unknown-elf-ld'
 objdump = '/tools/riscv/bin/riscv32-unknown-elf-objdump'
 objcopy = '/tools/riscv/bin/riscv32-unknown-elf-objcopy'
 strip = '/tools/riscv/bin/riscv32-unknown-elf-strip'
+as = '/tools/riscv/bin/riscv32-unknown-elf-as'
 
 [properties]
 has_function_printf = false


### PR DESCRIPTION
An assembler is part of the toolchain, and we need to make it available
for OTBN tooling.