### PR TITLE
[otbn] Enable specifying RV32 tool paths through env var

### DIFF
--- a/hw/ip/otbn/util/shared/toolchain.py
+++ b/hw/ip/otbn/util/shared/toolchain.py
@@ -8,15 +8,27 @@ import os
 def find_tool(tool_name: str) -> str:
     '''Return a string describing how to invoke the given RISC-V tool
 
-    If TOOLCHAIN_PATH is not set, we resolve FOO to riscv32-unknown-elf-FOO
-    (which will be searched for on $PATH). If it is set, we resolve foo to
-    $TOOLCHAIN_PATH/bin/riscv32-unknown-elf-FOO.
+    Try to resolve the tool in the following way, stopping after the first
+    match:
 
-    In the latter case, we also do a sanity check that the file exists. This
-    allows us to print a more helpful error if it doesn't (saying we were
-    looking at TOOLCHAIN_PATH).
+    1. Use the path set in the RV32_TOOL_<tool_name> environment variable.
+    2. Use the path set in $TOOLCHAIN_PATH/bin/riscv32-unknown-elf-<tool_name>.
+    3. Use riscv32-unknown-elf-<tool_name> and expect it to be in PATH.
 
+    In cases (1) and (2), the file path is checked if it exists, and if not, an
+    error message is printed.
     '''
+    tool_env_var = 'RV32_TOOL_' + tool_name.upper()
+    configured_tool_path = os.environ.get(tool_env_var)
+    if configured_tool_path is not None:
+        if not os.path.exists(configured_tool_path):
+            raise RuntimeError('No such file: {!r} (derived from the '
+                               '{!r} environment variable when trying '
+                               'to find the {!r} tool).'.format(
+                                   configured_tool_path, tool_env_var,
+                                   tool_name))
+        return configured_tool_path
+
     expanded = 'riscv32-unknown-elf-' + tool_name
     toolchain_path = os.environ.get('TOOLCHAIN_PATH')
     if toolchain_path is None:


### PR DESCRIPTION
Provide an environment variable `RV32_TOOL_<tool_name>`, with
`<tool_name>` being e.g. `as` or `gcc`. This environment variable should
contain the full path to the corresponding RV32 toolchain component.