### PR TITLE
[otbn] Fix TOC headings for OTBN ISA documentation

### DIFF
--- a/hw/ip/otbn/doc/_index.md
+++ b/hw/ip/otbn/doc/_index.md
@@ -339,7 +339,11 @@ All instructions are a fixed 32b in length and must be aligned on a four byte-bo
 </div>
 
 <!-- Documentation for the instructions in the ISA. Generated from ../data/insns.yml. -->
-{{< otbn_isa >}}
+## Base Instruction Subset
+{{< otbn_isa base >}}
+
+## Big Number Instruction Subset
+{{< otbn_isa bignum >}}
 
 ## Pseudo-Code Functions for BN Instructions
 

--- a/site/docs/layouts/shortcodes/otbn_isa.html
+++ b/site/docs/layouts/shortcodes/otbn_isa.html
@@ -1,6 +1,7 @@
-{{ $path := path.Join .Site.Params.generatedRoot "otbn-isa.md" }}
+{{ $group := .Get 0 }}
+{{ $basename := (print $group ".md") }}
+{{ $path := path.Join .Site.Params.generatedRoot "otbn-isa" $basename }}
 {{ if not (fileExists $path) }}
-  {{ errorf "otbn-isa.md has not been generated" }}
+  {{ errorf "%s has not been generated" $path }}
 {{ end }}
-
 {{ readFile $path | markdownify }}

--- a/util/build_docs.py
+++ b/util/build_docs.py
@@ -305,9 +305,8 @@ def generate_otbn_isa():
     script = otbn_dir / 'util/yaml_to_doc.py'
     yaml_file = otbn_dir / 'data/insns.yml'
 
-    out_path = config['outdir-generated'].joinpath('otbn-isa.md')
-    with open(str(out_path), 'w') as handle:
-        subprocess.run([str(script), str(yaml_file)], stdout=handle, check=True)
+    out_dir = config['outdir-generated'].joinpath('otbn-isa')
+    subprocess.run([str(script), str(yaml_file), str(out_dir)], check=True)
 
 
 def hugo_match_version(hugo_bin_path, version):


### PR DESCRIPTION
It seems that you can't use readFile in a shortcode to read in
Markdown contents and then have them appear in the top-level table of
contents. See [1] for another disappointed customer!

Fortunately, we don't really need it because we only have two headings
we care about. So now the yaml_to_doc.py script generates a Markdown
fragment for each instruction group, which gets included explicitly by
the documentation. It feels a little less magic, but hey ho.

[1] https://github.com/gohugoio/hugo/issues/6690

Closes #2808.