### PR TITLE
[flash_ctrl] Update memory protection to latest definition

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson
@@ -437,8 +437,7 @@
         { bits: "2",    name: "prog_full",  desc: "Flash program FIFO full"},
         { bits: "3",    name: "prog_empty", desc: "Flash program FIFO empty, software must provide data", resval: "1"},
         { bits: "4",    name: "init_wip",   desc: "Flash controller undergoing init"},
-        { bits: "16:8", name: "error_page", desc: "Flash controller error page."},
-        { bits: "17",   name: "error_bank", desc: "Flash controller error bank."},
+        { bits: "16:8", name: "error_addr", desc: "Flash controller error addrress."},
       ]
     },
     { name: "Scratch",

--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson
@@ -44,6 +44,12 @@
       default: "8",
       local: "true"
     },
+    { name: "NumInfos",
+      desc: "Number of configurable flash info pages",
+      type: "int",
+      default: "4",
+      local: "true"
+    },
   ],
 
   regwidth: "32",
@@ -277,7 +283,7 @@
     { multireg: {
         cname: "FLASH_CTRL",
         name: "MP_REGION_CFG",
-        desc: "Memory protection configuration",
+        desc: "Memory protection configuration for data partition",
         count: "NumRegions",
         swaccess: "rw",
         hwaccess: "hro",
@@ -325,16 +331,97 @@
               ''',
               resval: "0"
             },
-            { bits: "28",
-              name: "PARTITION",
-              desc: '''
-                Region partition select
+        ],
+      },
+    },
 
-                0 selects data partition
-                1 selects info partition
+    // TBD, need to update lock register to individual and separated
+    // TBD, nested multi-reg is not supported, so each bank is done manually
+
+    { multireg: {
+        cname: "FLASH_CTRL",
+        name: "BANK0_INFO_PAGE_CFG",
+        desc: '''
+                Memory protection configuration for info partition in bank0,
+                Unlike data partition, each page is individually protected.
+              '''
+        count: "NumInfos",
+        swaccess: "rw",
+        hwaccess: "hro",
+        regwen: "REGION_CFG_REGWEN",
+        fields: [
+            { bits: "0",
+              name: "EN",
+              desc: '''
+                Region enabled, following fields apply
               ''',
               resval: "0"
             },
+            { bits: "1",
+              name: "RD_EN",
+              desc: '''
+                Region can be read
+              ''',
+              resval: "0"
+            },
+            { bits: "2",
+              name: "PROG_EN",
+              desc: '''
+                Region can be programmed
+              ''',
+              resval: "0"
+            }
+            { bits: "3",
+              name: "ERASE_EN",
+              desc: '''
+                Region can be erased
+              ''',
+              resval: "0"
+            }
+        ],
+      },
+    },
+
+    { multireg: {
+        cname: "FLASH_CTRL",
+        name: "BANK1_INFO_PAGE_CFG",
+        desc: '''
+                Memory protection configuration for info partition in bank1,
+                Unlike data partition, each page is individually protected.
+              '''
+        count: "NumInfos",
+        swaccess: "rw",
+        hwaccess: "hro",
+        regwen: "REGION_CFG_REGWEN",
+        fields: [
+            { bits: "0",
+              name: "EN",
+              desc: '''
+                Region enabled, following fields apply
+              ''',
+              resval: "0"
+            },
+            { bits: "1",
+              name: "RD_EN",
+              desc: '''
+                Region can be read
+              ''',
+              resval: "0"
+            },
+            { bits: "2",
+              name: "PROG_EN",
+              desc: '''
+                Region can be programmed
+              ''',
+              resval: "0"
+            }
+            { bits: "3",
+              name: "ERASE_EN",
+              desc: '''
+                Region can be erased
+              ''',
+              resval: "0"
+            }
         ],
       },
     },
@@ -437,7 +524,7 @@
         { bits: "2",    name: "prog_full",  desc: "Flash program FIFO full"},
         { bits: "3",    name: "prog_empty", desc: "Flash program FIFO empty, software must provide data", resval: "1"},
         { bits: "4",    name: "init_wip",   desc: "Flash controller undergoing init"},
-        { bits: "16:8", name: "error_addr", desc: "Flash controller error addrress."},
+        { bits: "16:8", name: "error_addr", desc: "Flash controller error address."},
       ]
     },
     { name: "Scratch",

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
@@ -20,7 +20,7 @@ package flash_ctrl_env_pkg;
   `include "dv_macros.svh"
 
   // parameters
-  parameter uint FLASH_CTRL_ADDR_MAP_SIZE = 128;
+  parameter uint FLASH_CTRL_ADDR_MAP_SIZE = 256;
 
   parameter uint FlashNumPages            = top_pkg::FLASH_BANKS * top_pkg::FLASH_PAGES_PER_BANK;
   parameter uint FlashSizeBytes           = FlashNumPages * top_pkg::FLASH_WORDS_PER_PAGE *

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
@@ -48,8 +48,7 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
         get_csr_val_with_updated_field(ral.mp_region_cfg_0.prog_en_0, data, region_cfg.program_en) |
         get_csr_val_with_updated_field(ral.mp_region_cfg_0.erase_en_0, data, region_cfg.erase_en) |
         get_csr_val_with_updated_field(ral.mp_region_cfg_0.base_0, data, region_cfg.start_page) |
-        get_csr_val_with_updated_field(ral.mp_region_cfg_0.size_0, data, region_cfg.num_pages) |
-        get_csr_val_with_updated_field(ral.mp_region_cfg_0.partition_0, data, region_cfg.partition);
+        get_csr_val_with_updated_field(ral.mp_region_cfg_0.size_0, data, region_cfg.num_pages);
     csr = ral.get_reg_by_name($sformatf("mp_region_cfg_%0d", index));
     csr_wr(.csr(csr), .value(data));
   endtask

--- a/hw/ip/flash_ctrl/flash_ctrl.core
+++ b/hw/ip/flash_ctrl/flash_ctrl.core
@@ -14,7 +14,6 @@ filesets:
       - lowrisc:prim:gf_mult
       - lowrisc:ip:flash_ctrl_pkg
     files:
-      - rtl/flash_ctrl_reg_pkg.sv
       - rtl/flash_ctrl_reg_top.sv
       - rtl/flash_ctrl.sv
       - rtl/flash_ctrl_erase.sv

--- a/hw/ip/flash_ctrl/flash_ctrl.core
+++ b/hw/ip/flash_ctrl/flash_ctrl.core
@@ -17,9 +17,9 @@ filesets:
       - rtl/flash_ctrl_reg_pkg.sv
       - rtl/flash_ctrl_reg_top.sv
       - rtl/flash_ctrl.sv
-      - rtl/flash_erase_ctrl.sv
-      - rtl/flash_prog_ctrl.sv
-      - rtl/flash_rd_ctrl.sv
+      - rtl/flash_ctrl_erase.sv
+      - rtl/flash_ctrl_prog.sv
+      - rtl/flash_ctrl_rd.sv
       - rtl/flash_ctrl_arb.sv
       - rtl/flash_ctrl_lcmgr.sv
       - rtl/flash_mp.sv

--- a/hw/ip/flash_ctrl/flash_ctrl_pkg.core
+++ b/hw/ip/flash_ctrl/flash_ctrl_pkg.core
@@ -10,6 +10,7 @@ filesets:
     depend:
       - lowrisc:constants:top_pkg
     files:
+      - rtl/flash_ctrl_reg_pkg.sv
       - rtl/flash_ctrl_pkg.sv
       - rtl/flash_phy_pkg.sv
     file_type: systemVerilogSource

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -296,10 +296,7 @@ module flash_ctrl import flash_ctrl_pkg::*; (
   );
 
   // Program handler is consumer of prog_fifo
-  flash_ctrl_prog #(
-    .DataW(BusWidth),
-    .AddrW(BusAddrW)
-  ) u_flash_ctrl_prog (
+  flash_ctrl_prog u_flash_ctrl_prog (
     .clk_i,
     .rst_ni,
 
@@ -375,10 +372,7 @@ module flash_ctrl import flash_ctrl_pkg::*; (
   );
 
   // Read handler is consumer of rd_fifo
-  flash_ctrl_rd #(
-    .DataW(BusWidth),
-    .AddrW(BusAddrW)
-  ) u_flash_ctrl_rd (
+  flash_ctrl_rd  u_flash_ctrl_rd (
     .clk_i,
     .rst_ni,
 
@@ -404,12 +398,7 @@ module flash_ctrl import flash_ctrl_pkg::*; (
   );
 
   // Erase handler does not consume fifo
-  flash_ctrl_erase #(
-    .AddrW(BusAddrW),
-    .PagesPerBank(PagesPerBank),
-    .WordsPerPage(BusWordsPerPage),
-    .EraseBitWidth(EraseBitWidth)
-  ) u_flash_ctrl_erase (
+  flash_ctrl_erase u_flash_ctrl_erase (
     // Software Interface
     .op_start_i     (op_start & erase_op),
     .op_type_i      (op_erase_type),
@@ -469,11 +458,7 @@ module flash_ctrl import flash_ctrl_pkg::*; (
   // Flash memory protection
   // Memory protection is page based and thus should use phy addressing
   // This should move to flash_phy long term
-  flash_mp #(
-    .MpRegions(MpRegions),
-    .NumBanks(NumBanks),
-    .AllPagesW(AllPagesW)
-  ) u_flash_mp (
+  flash_mp u_flash_mp (
     .clk_i,
     .rst_ni,
 

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -112,7 +112,7 @@ module flash_ctrl import flash_ctrl_pkg::*; (
   // Flash control arbitration connections to hardware interface
   flash_ctrl_reg2hw_control_reg_t hw_ctrl;
   logic hw_req;
-  logic [BusAddrW-1:0] hw_addr;
+  logic [top_pkg::TL_AW-1:0] hw_addr;
   logic hw_done;
   logic hw_err;
   logic hw_rvalid;
@@ -126,7 +126,7 @@ module flash_ctrl import flash_ctrl_pkg::*; (
 
   // Flash control muxed connections
   flash_ctrl_reg2hw_control_reg_t muxed_ctrl;
-  logic [31:0] muxed_addr;
+  logic [top_pkg::TL_AW-1:0] muxed_addr;
   logic op_start;
   logic [11:0] op_num_words;
   logic [BusAddrW-1:0] op_addr;
@@ -166,7 +166,9 @@ module flash_ctrl import flash_ctrl_pkg::*; (
     // hardware interface to rd_ctrl / erase_ctrl
     .hw_req_i(hw_req),
     .hw_ctrl_i(hw_ctrl),
-    .hw_addr_i(top_pkg::TL_AW'(hw_addr)),
+
+    // hardware works on word address, however software expects byte address
+    .hw_addr_i(hw_addr),
     .hw_ack_o(hw_done),
     .hw_err_o(hw_err),
 
@@ -614,13 +616,13 @@ module flash_ctrl import flash_ctrl_pkg::*; (
 
   // Unused bits
   logic [BusByteWidth-1:0] unused_byte_sel;
-  logic [31-BusAddrW:0] unused_higher_addr_bits;
-  logic [31:0] unused_scratch;
+  logic [top_pkg::TL_AW-1-BusAddrW:0] unused_higher_addr_bits;
+  logic [top_pkg::TL_AW-1:0] unused_scratch;
 
 
   // Unused signals
   assign unused_byte_sel = muxed_addr[BusByteWidth-1:0];
-  assign unused_higher_addr_bits = muxed_addr[31:BusAddrW];
+  assign unused_higher_addr_bits = muxed_addr[top_pkg::TL_AW-1:BusAddrW];
   assign unused_scratch = reg2hw.scratch;
 
 

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -106,8 +106,7 @@ module flash_ctrl import flash_ctrl_pkg::*; (
   logic rd_op;
   logic prog_op;
   logic erase_op;
-  logic [AllPagesW-1:0] err_page;
-  logic [BankW-1:0] err_bank;
+  logic [AllPagesW-1:0] err_addr;
 
   // Flash control arbitration connections to hardware interface
   flash_ctrl_reg2hw_control_reg_t hw_ctrl;
@@ -474,7 +473,6 @@ module flash_ctrl import flash_ctrl_pkg::*; (
     .req_addr_i(flash_addr[BusAddrW-1 -: AllPagesW]),
     .req_part_i(flash_part_sel),
     .addr_ovfl_i(rd_flash_ovfl | prog_flash_ovfl),
-    .req_bk_i(flash_addr[BusAddrW-1 -: BankW]),
     .rd_i(rd_op),
     .prog_i(prog_op),
     .pg_erase_i(erase_op & (erase_flash_type == FlashErasePage)),
@@ -483,8 +481,7 @@ module flash_ctrl import flash_ctrl_pkg::*; (
     .prog_done_o(flash_prog_done),
     .erase_done_o(flash_erase_done),
     .error_o(flash_error),
-    .err_addr_o(err_page),
-    .err_bank_o(err_bank),
+    .err_addr_o(err_addr),
 
     // flash phy interface
     .req_o(flash_o.req),
@@ -515,10 +512,8 @@ module flash_ctrl import flash_ctrl_pkg::*; (
   assign hw2reg.status.prog_empty.de = sw_sel;
   assign hw2reg.status.init_wip.d    = flash_phy_busy | ctrl_init_busy;
   assign hw2reg.status.init_wip.de   = 1'b1;
-  assign hw2reg.status.error_page.d  = err_page;
-  assign hw2reg.status.error_page.de = sw_sel;
-  assign hw2reg.status.error_bank.d  = err_bank;
-  assign hw2reg.status.error_bank.de = sw_sel;
+  assign hw2reg.status.error_addr.d  = err_addr;
+  assign hw2reg.status.error_addr.de = sw_sel;
   assign hw2reg.control.start.d      = 1'b0;
   assign hw2reg.control.start.de     = sw_ctrl_done;
   // if software operation selected, based on transaction start

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -294,10 +294,10 @@ module flash_ctrl import flash_ctrl_pkg::*; (
   );
 
   // Program handler is consumer of prog_fifo
-  flash_prog_ctrl #(
+  flash_ctrl_prog #(
     .DataW(BusWidth),
     .AddrW(BusAddrW)
-  ) u_flash_prog_ctrl (
+  ) u_flash_ctrl_prog (
     .clk_i,
     .rst_ni,
 
@@ -373,10 +373,10 @@ module flash_ctrl import flash_ctrl_pkg::*; (
   );
 
   // Read handler is consumer of rd_fifo
-  flash_rd_ctrl #(
+  flash_ctrl_rd #(
     .DataW(BusWidth),
     .AddrW(BusAddrW)
-  ) u_flash_rd_ctrl (
+  ) u_flash_ctrl_rd (
     .clk_i,
     .rst_ni,
 
@@ -402,12 +402,12 @@ module flash_ctrl import flash_ctrl_pkg::*; (
   );
 
   // Erase handler does not consume fifo
-  flash_erase_ctrl #(
+  flash_ctrl_erase #(
     .AddrW(BusAddrW),
     .PagesPerBank(PagesPerBank),
     .WordsPerPage(BusWordsPerPage),
     .EraseBitWidth(EraseBitWidth)
-  ) u_flash_erase_ctrl (
+  ) u_flash_ctrl_erase (
     // Software Interface
     .op_start_i     (op_start & erase_op),
     .op_type_i      (op_erase_type),

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_erase.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_erase.sv
@@ -5,7 +5,7 @@
 // Faux Flash Erase Control
 //
 
-module flash_erase_ctrl #(
+module flash_ctrl_erase #(
   parameter int AddrW = 10,
   parameter int WordsPerPage = 256,
   parameter int PagesPerBank = 256,
@@ -56,4 +56,4 @@ module flash_erase_ctrl #(
   logic [WordsBitWidth-1:0] unused_addr_i;
   assign unused_addr_i = op_addr_i[WordsBitWidth-1:0];
 
-endmodule // flash_erase_ctrl
+endmodule // flash_ctrl_erase

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_erase.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_erase.sv
@@ -5,22 +5,17 @@
 // Faux Flash Erase Control
 //
 
-module flash_ctrl_erase #(
-  parameter int AddrW = 10,
-  parameter int WordsPerPage = 256,
-  parameter int PagesPerBank = 256,
-  parameter int EraseBitWidth = 1
-) (
+module flash_ctrl_erase import flash_ctrl_pkg::*; (
   // Software Interface
   input                     op_start_i,
   input [EraseBitWidth-1:0] op_type_i,
-  input [AddrW-1:0]         op_addr_i,
+  input [BusAddrW-1:0]         op_addr_i,
   output logic              op_done_o,
   output logic              op_err_o,
 
   // Flash Macro Interface
   output logic             flash_req_o,
-  output logic [AddrW-1:0] flash_addr_o,
+  output logic [BusAddrW-1:0] flash_addr_o,
   output logic [EraseBitWidth-1:0] flash_op_o,
   input                    flash_done_i,
   input                    flash_error_i
@@ -28,7 +23,7 @@ module flash_ctrl_erase #(
 
   import flash_ctrl_pkg::*;
 
-  localparam int WordsBitWidth = $clog2(WordsPerPage);
+  localparam int WordsBitWidth = $clog2(BusWordsPerPage);
   localparam int PagesBitWidth = $clog2(PagesPerBank);
 
   // The *AddrMask below masks out the bits that are not required
@@ -38,8 +33,8 @@ module flash_ctrl_erase #(
   // PageAddrMask would be 0xF_FFFF_0000
   // BankAddrMask would be 0xF_0000_0000
   //
-  localparam logic[AddrW-1:0] PageAddrMask = ~(('h1 << WordsBitWidth) - 1'b1);
-  localparam logic[AddrW-1:0] BankAddrMask = ~(('h1 << (PagesBitWidth + WordsBitWidth)) - 1'b1);
+  localparam logic[BusAddrW-1:0] PageAddrMask = ~(('h1 << WordsBitWidth) - 1'b1);
+  localparam logic[BusAddrW-1:0] BankAddrMask = ~(('h1 << (PagesBitWidth + WordsBitWidth)) - 1'b1);
 
   // IO assignments
   assign op_done_o = flash_req_o & flash_done_i;

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_lcmgr.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_lcmgr.sv
@@ -12,7 +12,7 @@ module flash_ctrl_lcmgr import flash_ctrl_pkg::*; (
   // interface to ctrl arb control ports
   output flash_ctrl_reg_pkg::flash_ctrl_reg2hw_control_reg_t ctrl_o,
   output logic req_o,
-  output logic [BusAddrW-1:0] addr_o,
+  output logic [top_pkg::TL_AW-1:0] addr_o,
   input done_i,
   input err_i,
 
@@ -290,7 +290,8 @@ module flash_ctrl_lcmgr import flash_ctrl_pkg::*; (
   assign ctrl_o.erase_sel.q = erase_type;
   assign ctrl_o.partition_sel.q = part_sel;
   assign ctrl_o.num = num_words;
-  assign addr_o = addr;
+  // address is consistent with software width format (full bus)
+  assign addr_o = top_pkg::TL_AW'({addr, {BusByteWidth{1'b0}}});
   assign init_busy_o = seed_phase;
   assign req_o = seed_phase | rma_phase;
   assign rready_o = 1'b1;

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
@@ -50,10 +50,10 @@ package flash_ctrl_pkg;
   parameter int TotalPartitionsWidth = $clog2(TotalPartitions);
 
   // The end address in bus words for each kind of partition in each bank
-  parameter logic [BusBankAddrW-1:0] PartitionEndAddr [0:TotalPartitions-1] =
+  parameter logic [PageW-1:0] PartitionEndAddr [0:TotalPartitions-1] =
     {
-      PagesPerBank * BusWordsPerPage - 1,
-      InfosPerBank * BusWordsPerPage - 1
+      PagesPerBank - 1,
+      InfosPerBank - 1
     };
 
   // flash life cycle / key manager management constants

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
@@ -50,11 +50,11 @@ package flash_ctrl_pkg;
   parameter int TotalPartitionsWidth = $clog2(TotalPartitions);
 
   // The end address in bus words for each kind of partition in each bank
-  parameter logic [PageW-1:0] PartitionEndAddr [0:TotalPartitions-1] =
-    {
+  parameter logic [PageW-1:0] PartitionEndAddr [TotalPartitions] =
+    '{
       PagesPerBank - 1,
       InfosPerBank - 1
-    };
+     };
 
   // flash life cycle / key manager management constants
   // One page for creator seeds
@@ -62,11 +62,14 @@ package flash_ctrl_pkg;
   parameter int NumSeeds = 2;
   parameter int CreatorInfoPage = 1;
   parameter int OwnerInfoPage = 2;
-  parameter logic [InfoPageW-1:0] SeedInfoPageSel [0:NumSeeds-1] =
-    {
+  parameter logic [InfoPageW-1:0] SeedInfoPageSel [NumSeeds] =
+    '{
       CreatorInfoPage,
       OwnerInfoPage
-    };
+     };
+
+  // alias for super long reg_pkg typedef
+  typedef flash_ctrl_reg_pkg::flash_ctrl_reg2hw_bank0_info_page_cfg_mreg_t info_page_cfg_t;
 
   // Flash Operations Supported
   typedef enum logic [1:0] {

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_prog.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_prog.sv
@@ -5,10 +5,7 @@
 // Faux Flash Prog Control
 //
 
-module flash_ctrl_prog #(
-  parameter int AddrW = 10,
-  parameter int DataW = 32
-) (
+module flash_ctrl_prog import flash_ctrl_pkg::*; (
   input clk_i,
   input rst_ni,
 
@@ -17,18 +14,18 @@ module flash_ctrl_prog #(
   input  [11:0]            op_num_words_i,
   output logic             op_done_o,
   output logic             op_err_o,
-  input [AddrW-1:0]        op_addr_i,
+  input [BusAddrW-1:0]        op_addr_i,
 
   // FIFO Interface
   input                    data_rdy_i,
-  input  [DataW-1:0]       data_i,
+  input  [BusWidth-1:0]       data_i,
   output logic             data_rd_o,
 
   // Flash Macro Interface
   output logic             flash_req_o,
-  output logic [AddrW-1:0] flash_addr_o,
+  output logic [BusAddrW-1:0] flash_addr_o,
   output logic             flash_ovfl_o,
-  output logic [DataW-1:0] flash_data_o,
+  output logic [BusWidth-1:0] flash_data_o,
   output logic             flash_last_o, // last beat of prog data
   input                    flash_done_i,
   input                    flash_error_i
@@ -42,7 +39,7 @@ module flash_ctrl_prog #(
   state_e st, st_nxt;
   logic [11:0] cnt, cnt_nxt;
   logic cnt_hit;
-  logic [AddrW:0] int_addr;
+  logic [BusAddrW:0] int_addr;
   logic txn_done;
 
 
@@ -102,9 +99,9 @@ module flash_ctrl_prog #(
   end
 
   assign flash_data_o = data_i;
-  assign int_addr = op_addr_i + AddrW'(cnt);
-  assign flash_addr_o = int_addr[0 +: AddrW];
-  assign flash_ovfl_o = int_addr[AddrW];
+  assign int_addr = op_addr_i + BusAddrW'(cnt);
+  assign flash_addr_o = int_addr[0 +: BusAddrW];
+  assign flash_ovfl_o = int_addr[BusAddrW];
   assign flash_last_o = flash_req_o & cnt_hit;
 
 endmodule // flash_ctrl_prog

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_prog.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_prog.sv
@@ -5,7 +5,7 @@
 // Faux Flash Prog Control
 //
 
-module flash_prog_ctrl #(
+module flash_ctrl_prog #(
   parameter int AddrW = 10,
   parameter int DataW = 32
 ) (
@@ -107,4 +107,4 @@ module flash_prog_ctrl #(
   assign flash_ovfl_o = int_addr[AddrW];
   assign flash_last_o = flash_req_o & cnt_hit;
 
-endmodule // flash_prog_ctrl
+endmodule // flash_ctrl_prog

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_rd.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_rd.sv
@@ -5,7 +5,7 @@
 // Faux Flash Read Control
 //
 
-module flash_rd_ctrl #(
+module flash_ctrl_rd #(
   parameter int AddrW = 10,
   parameter int DataW = 32
 ) (
@@ -112,4 +112,4 @@ module flash_rd_ctrl #(
   assign data_o = err_sel ? {DataW{1'b1}} : flash_data_i;
 
 
-endmodule // flash_rd_ctrl
+endmodule // flash_ctrl_rd

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_rd.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_rd.sv
@@ -5,10 +5,7 @@
 // Faux Flash Read Control
 //
 
-module flash_ctrl_rd #(
-  parameter int AddrW = 10,
-  parameter int DataW = 32
-) (
+module flash_ctrl_rd import flash_ctrl_pkg::*; (
   input clk_i,
   input rst_ni,
 
@@ -17,18 +14,18 @@ module flash_ctrl_rd #(
   input  [11:0]            op_num_words_i,
   output logic             op_done_o,
   output logic             op_err_o,
-  input [AddrW-1:0]        op_addr_i,
+  input [BusAddrW-1:0]        op_addr_i,
 
   // FIFO Interface
   input                    data_rdy_i,
-  output logic [DataW-1:0] data_o,
+  output logic [BusWidth-1:0] data_o,
   output logic             data_wr_o,
 
   // Flash Macro Interface
   output logic             flash_req_o,
-  output logic [AddrW-1:0] flash_addr_o,
+  output logic [BusAddrW-1:0] flash_addr_o,
   output logic             flash_ovfl_o,
-  input [DataW-1:0]        flash_data_i,
+  input [BusWidth-1:0]        flash_data_i,
   input                    flash_done_i,
   input                    flash_error_i
 );
@@ -41,7 +38,7 @@ module flash_ctrl_rd #(
   state_e st, st_nxt;
   logic [11:0] cnt, cnt_nxt;
   logic cnt_hit;
-  logic [AddrW:0] int_addr;
+  logic [BusAddrW:0] int_addr;
   logic txn_done;
   logic err_sel; //1 selects error data, 0 selects normal data
 
@@ -105,11 +102,11 @@ module flash_ctrl_rd #(
   end
 
   // overflow error detection is not here, but instead handled at memory protection
-  assign int_addr = op_addr_i + AddrW'(cnt);
-  assign flash_addr_o = int_addr[0 +: AddrW];
-  assign flash_ovfl_o = int_addr[AddrW];
+  assign int_addr = op_addr_i + BusAddrW'(cnt);
+  assign flash_addr_o = int_addr[0 +: BusAddrW];
+  assign flash_ovfl_o = int_addr[BusAddrW];
   // if error, return "empty" data
-  assign data_o = err_sel ? {DataW{1'b1}} : flash_data_i;
+  assign data_o = err_sel ? {BusWidth{1'b1}} : flash_data_i;
 
 
 endmodule // flash_ctrl_rd

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
@@ -9,6 +9,7 @@ package flash_ctrl_reg_pkg;
   // Param list
   parameter int NBanks = 2;
   parameter int NumRegions = 8;
+  parameter int NumInfos = 4;
 
   ////////////////////////////
   // Typedefs for registers //
@@ -127,10 +128,37 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic [9:0] q;
     } size;
+  } flash_ctrl_reg2hw_mp_region_cfg_mreg_t;
+
+  typedef struct packed {
     struct packed {
       logic        q;
-    } partition;
-  } flash_ctrl_reg2hw_mp_region_cfg_mreg_t;
+    } en;
+    struct packed {
+      logic        q;
+    } rd_en;
+    struct packed {
+      logic        q;
+    } prog_en;
+    struct packed {
+      logic        q;
+    } erase_en;
+  } flash_ctrl_reg2hw_bank0_info_page_cfg_mreg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        q;
+    } en;
+    struct packed {
+      logic        q;
+    } rd_en;
+    struct packed {
+      logic        q;
+    } prog_en;
+    struct packed {
+      logic        q;
+    } erase_en;
+  } flash_ctrl_reg2hw_bank1_info_page_cfg_mreg_t;
 
   typedef struct packed {
     struct packed {
@@ -239,11 +267,7 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic [8:0]  d;
       logic        de;
-    } error_page;
-    struct packed {
-      logic        d;
-      logic        de;
-    } error_bank;
+    } error_addr;
   } flash_ctrl_hw2reg_status_reg_t;
 
 
@@ -251,13 +275,15 @@ package flash_ctrl_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    flash_ctrl_reg2hw_intr_state_reg_t intr_state; // [313:308]
-    flash_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [307:302]
-    flash_ctrl_reg2hw_intr_test_reg_t intr_test; // [301:290]
-    flash_ctrl_reg2hw_control_reg_t control; // [289:273]
-    flash_ctrl_reg2hw_addr_reg_t addr; // [272:241]
-    flash_ctrl_reg2hw_scramble_en_reg_t scramble_en; // [240:240]
-    flash_ctrl_reg2hw_mp_region_cfg_mreg_t [7:0] mp_region_cfg; // [239:48]
+    flash_ctrl_reg2hw_intr_state_reg_t intr_state; // [337:332]
+    flash_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [331:326]
+    flash_ctrl_reg2hw_intr_test_reg_t intr_test; // [325:314]
+    flash_ctrl_reg2hw_control_reg_t control; // [313:297]
+    flash_ctrl_reg2hw_addr_reg_t addr; // [296:265]
+    flash_ctrl_reg2hw_scramble_en_reg_t scramble_en; // [264:264]
+    flash_ctrl_reg2hw_mp_region_cfg_mreg_t [7:0] mp_region_cfg; // [263:80]
+    flash_ctrl_reg2hw_bank0_info_page_cfg_mreg_t [3:0] bank0_info_page_cfg; // [79:64]
+    flash_ctrl_reg2hw_bank1_info_page_cfg_mreg_t [3:0] bank1_info_page_cfg; // [63:48]
     flash_ctrl_reg2hw_default_region_reg_t default_region; // [47:45]
     flash_ctrl_reg2hw_mp_bank_cfg_mreg_t [1:0] mp_bank_cfg; // [44:43]
     flash_ctrl_reg2hw_scratch_reg_t scratch; // [42:11]
@@ -269,44 +295,52 @@ package flash_ctrl_reg_pkg;
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [40:35]
-    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [34:35]
-    flash_ctrl_hw2reg_control_reg_t control; // [34:18]
-    flash_ctrl_hw2reg_op_status_reg_t op_status; // [17:18]
-    flash_ctrl_hw2reg_status_reg_t status; // [17:18]
+    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [38:33]
+    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [32:33]
+    flash_ctrl_hw2reg_control_reg_t control; // [32:16]
+    flash_ctrl_hw2reg_op_status_reg_t op_status; // [15:16]
+    flash_ctrl_hw2reg_status_reg_t status; // [15:16]
   } flash_ctrl_hw2reg_t;
 
   // Register Address
-  parameter logic [6:0] FLASH_CTRL_INTR_STATE_OFFSET = 7'h 0;
-  parameter logic [6:0] FLASH_CTRL_INTR_ENABLE_OFFSET = 7'h 4;
-  parameter logic [6:0] FLASH_CTRL_INTR_TEST_OFFSET = 7'h 8;
-  parameter logic [6:0] FLASH_CTRL_CTRL_REGWEN_OFFSET = 7'h c;
-  parameter logic [6:0] FLASH_CTRL_CONTROL_OFFSET = 7'h 10;
-  parameter logic [6:0] FLASH_CTRL_ADDR_OFFSET = 7'h 14;
-  parameter logic [6:0] FLASH_CTRL_SCRAMBLE_EN_OFFSET = 7'h 18;
-  parameter logic [6:0] FLASH_CTRL_REGION_CFG_REGWEN_OFFSET = 7'h 1c;
-  parameter logic [6:0] FLASH_CTRL_MP_REGION_CFG_0_OFFSET = 7'h 20;
-  parameter logic [6:0] FLASH_CTRL_MP_REGION_CFG_1_OFFSET = 7'h 24;
-  parameter logic [6:0] FLASH_CTRL_MP_REGION_CFG_2_OFFSET = 7'h 28;
-  parameter logic [6:0] FLASH_CTRL_MP_REGION_CFG_3_OFFSET = 7'h 2c;
-  parameter logic [6:0] FLASH_CTRL_MP_REGION_CFG_4_OFFSET = 7'h 30;
-  parameter logic [6:0] FLASH_CTRL_MP_REGION_CFG_5_OFFSET = 7'h 34;
-  parameter logic [6:0] FLASH_CTRL_MP_REGION_CFG_6_OFFSET = 7'h 38;
-  parameter logic [6:0] FLASH_CTRL_MP_REGION_CFG_7_OFFSET = 7'h 3c;
-  parameter logic [6:0] FLASH_CTRL_DEFAULT_REGION_OFFSET = 7'h 40;
-  parameter logic [6:0] FLASH_CTRL_BANK_CFG_REGWEN_OFFSET = 7'h 44;
-  parameter logic [6:0] FLASH_CTRL_MP_BANK_CFG_OFFSET = 7'h 48;
-  parameter logic [6:0] FLASH_CTRL_OP_STATUS_OFFSET = 7'h 4c;
-  parameter logic [6:0] FLASH_CTRL_STATUS_OFFSET = 7'h 50;
-  parameter logic [6:0] FLASH_CTRL_SCRATCH_OFFSET = 7'h 54;
-  parameter logic [6:0] FLASH_CTRL_FIFO_LVL_OFFSET = 7'h 58;
-  parameter logic [6:0] FLASH_CTRL_FIFO_RST_OFFSET = 7'h 5c;
+  parameter logic [7:0] FLASH_CTRL_INTR_STATE_OFFSET = 8'h 0;
+  parameter logic [7:0] FLASH_CTRL_INTR_ENABLE_OFFSET = 8'h 4;
+  parameter logic [7:0] FLASH_CTRL_INTR_TEST_OFFSET = 8'h 8;
+  parameter logic [7:0] FLASH_CTRL_CTRL_REGWEN_OFFSET = 8'h c;
+  parameter logic [7:0] FLASH_CTRL_CONTROL_OFFSET = 8'h 10;
+  parameter logic [7:0] FLASH_CTRL_ADDR_OFFSET = 8'h 14;
+  parameter logic [7:0] FLASH_CTRL_SCRAMBLE_EN_OFFSET = 8'h 18;
+  parameter logic [7:0] FLASH_CTRL_REGION_CFG_REGWEN_OFFSET = 8'h 1c;
+  parameter logic [7:0] FLASH_CTRL_MP_REGION_CFG_0_OFFSET = 8'h 20;
+  parameter logic [7:0] FLASH_CTRL_MP_REGION_CFG_1_OFFSET = 8'h 24;
+  parameter logic [7:0] FLASH_CTRL_MP_REGION_CFG_2_OFFSET = 8'h 28;
+  parameter logic [7:0] FLASH_CTRL_MP_REGION_CFG_3_OFFSET = 8'h 2c;
+  parameter logic [7:0] FLASH_CTRL_MP_REGION_CFG_4_OFFSET = 8'h 30;
+  parameter logic [7:0] FLASH_CTRL_MP_REGION_CFG_5_OFFSET = 8'h 34;
+  parameter logic [7:0] FLASH_CTRL_MP_REGION_CFG_6_OFFSET = 8'h 38;
+  parameter logic [7:0] FLASH_CTRL_MP_REGION_CFG_7_OFFSET = 8'h 3c;
+  parameter logic [7:0] FLASH_CTRL_BANK0_INFO_PAGE_CFG_0_OFFSET = 8'h 40;
+  parameter logic [7:0] FLASH_CTRL_BANK0_INFO_PAGE_CFG_1_OFFSET = 8'h 44;
+  parameter logic [7:0] FLASH_CTRL_BANK0_INFO_PAGE_CFG_2_OFFSET = 8'h 48;
+  parameter logic [7:0] FLASH_CTRL_BANK0_INFO_PAGE_CFG_3_OFFSET = 8'h 4c;
+  parameter logic [7:0] FLASH_CTRL_BANK1_INFO_PAGE_CFG_0_OFFSET = 8'h 50;
+  parameter logic [7:0] FLASH_CTRL_BANK1_INFO_PAGE_CFG_1_OFFSET = 8'h 54;
+  parameter logic [7:0] FLASH_CTRL_BANK1_INFO_PAGE_CFG_2_OFFSET = 8'h 58;
+  parameter logic [7:0] FLASH_CTRL_BANK1_INFO_PAGE_CFG_3_OFFSET = 8'h 5c;
+  parameter logic [7:0] FLASH_CTRL_DEFAULT_REGION_OFFSET = 8'h 60;
+  parameter logic [7:0] FLASH_CTRL_BANK_CFG_REGWEN_OFFSET = 8'h 64;
+  parameter logic [7:0] FLASH_CTRL_MP_BANK_CFG_OFFSET = 8'h 68;
+  parameter logic [7:0] FLASH_CTRL_OP_STATUS_OFFSET = 8'h 6c;
+  parameter logic [7:0] FLASH_CTRL_STATUS_OFFSET = 8'h 70;
+  parameter logic [7:0] FLASH_CTRL_SCRATCH_OFFSET = 8'h 74;
+  parameter logic [7:0] FLASH_CTRL_FIFO_LVL_OFFSET = 8'h 78;
+  parameter logic [7:0] FLASH_CTRL_FIFO_RST_OFFSET = 8'h 7c;
 
   // Window parameter
-  parameter logic [6:0] FLASH_CTRL_PROG_FIFO_OFFSET = 7'h 60;
-  parameter logic [6:0] FLASH_CTRL_PROG_FIFO_SIZE   = 7'h 4;
-  parameter logic [6:0] FLASH_CTRL_RD_FIFO_OFFSET = 7'h 64;
-  parameter logic [6:0] FLASH_CTRL_RD_FIFO_SIZE   = 7'h 4;
+  parameter logic [7:0] FLASH_CTRL_PROG_FIFO_OFFSET = 8'h 80;
+  parameter logic [7:0] FLASH_CTRL_PROG_FIFO_SIZE   = 8'h 4;
+  parameter logic [7:0] FLASH_CTRL_RD_FIFO_OFFSET = 8'h 84;
+  parameter logic [7:0] FLASH_CTRL_RD_FIFO_SIZE   = 8'h 4;
 
   // Register Index
   typedef enum int {
@@ -326,6 +360,14 @@ package flash_ctrl_reg_pkg;
     FLASH_CTRL_MP_REGION_CFG_5,
     FLASH_CTRL_MP_REGION_CFG_6,
     FLASH_CTRL_MP_REGION_CFG_7,
+    FLASH_CTRL_BANK0_INFO_PAGE_CFG_0,
+    FLASH_CTRL_BANK0_INFO_PAGE_CFG_1,
+    FLASH_CTRL_BANK0_INFO_PAGE_CFG_2,
+    FLASH_CTRL_BANK0_INFO_PAGE_CFG_3,
+    FLASH_CTRL_BANK1_INFO_PAGE_CFG_0,
+    FLASH_CTRL_BANK1_INFO_PAGE_CFG_1,
+    FLASH_CTRL_BANK1_INFO_PAGE_CFG_2,
+    FLASH_CTRL_BANK1_INFO_PAGE_CFG_3,
     FLASH_CTRL_DEFAULT_REGION,
     FLASH_CTRL_BANK_CFG_REGWEN,
     FLASH_CTRL_MP_BANK_CFG,
@@ -337,7 +379,7 @@ package flash_ctrl_reg_pkg;
   } flash_ctrl_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] FLASH_CTRL_PERMIT [24] = '{
+  parameter logic [3:0] FLASH_CTRL_PERMIT [32] = '{
     4'b 0001, // index[ 0] FLASH_CTRL_INTR_STATE
     4'b 0001, // index[ 1] FLASH_CTRL_INTR_ENABLE
     4'b 0001, // index[ 2] FLASH_CTRL_INTR_TEST
@@ -354,14 +396,22 @@ package flash_ctrl_reg_pkg;
     4'b 1111, // index[13] FLASH_CTRL_MP_REGION_CFG_5
     4'b 1111, // index[14] FLASH_CTRL_MP_REGION_CFG_6
     4'b 1111, // index[15] FLASH_CTRL_MP_REGION_CFG_7
-    4'b 0001, // index[16] FLASH_CTRL_DEFAULT_REGION
-    4'b 0001, // index[17] FLASH_CTRL_BANK_CFG_REGWEN
-    4'b 0001, // index[18] FLASH_CTRL_MP_BANK_CFG
-    4'b 0001, // index[19] FLASH_CTRL_OP_STATUS
-    4'b 0111, // index[20] FLASH_CTRL_STATUS
-    4'b 1111, // index[21] FLASH_CTRL_SCRATCH
-    4'b 0011, // index[22] FLASH_CTRL_FIFO_LVL
-    4'b 0001  // index[23] FLASH_CTRL_FIFO_RST
+    4'b 0001, // index[16] FLASH_CTRL_BANK0_INFO_PAGE_CFG_0
+    4'b 0001, // index[17] FLASH_CTRL_BANK0_INFO_PAGE_CFG_1
+    4'b 0001, // index[18] FLASH_CTRL_BANK0_INFO_PAGE_CFG_2
+    4'b 0001, // index[19] FLASH_CTRL_BANK0_INFO_PAGE_CFG_3
+    4'b 0001, // index[20] FLASH_CTRL_BANK1_INFO_PAGE_CFG_0
+    4'b 0001, // index[21] FLASH_CTRL_BANK1_INFO_PAGE_CFG_1
+    4'b 0001, // index[22] FLASH_CTRL_BANK1_INFO_PAGE_CFG_2
+    4'b 0001, // index[23] FLASH_CTRL_BANK1_INFO_PAGE_CFG_3
+    4'b 0001, // index[24] FLASH_CTRL_DEFAULT_REGION
+    4'b 0001, // index[25] FLASH_CTRL_BANK_CFG_REGWEN
+    4'b 0001, // index[26] FLASH_CTRL_MP_BANK_CFG
+    4'b 0001, // index[27] FLASH_CTRL_OP_STATUS
+    4'b 0111, // index[28] FLASH_CTRL_STATUS
+    4'b 1111, // index[29] FLASH_CTRL_SCRATCH
+    4'b 0011, // index[30] FLASH_CTRL_FIFO_LVL
+    4'b 0001  // index[31] FLASH_CTRL_FIFO_RST
   };
 endpackage
 

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_top.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_top.sv
@@ -28,7 +28,7 @@ module flash_ctrl_reg_top (
 
   import flash_ctrl_reg_pkg::* ;
 
-  localparam int AW = 7;
+  localparam int AW = 8;
   localparam int DW = 32;
   localparam int DBW = DW/8;                    // Byte Width
 
@@ -88,10 +88,10 @@ module flash_ctrl_reg_top (
     reg_steer = 2;       // Default set to register
 
     // TODO: Can below codes be unique case () inside ?
-    if (tl_i.a_address[AW-1:0] >= 96 && tl_i.a_address[AW-1:0] < 100) begin
+    if (tl_i.a_address[AW-1:0] >= 128 && tl_i.a_address[AW-1:0] < 132) begin
       reg_steer = 0;
     end
-    if (tl_i.a_address[AW-1:0] >= 100 && tl_i.a_address[AW-1:0] < 104) begin
+    if (tl_i.a_address[AW-1:0] >= 132 && tl_i.a_address[AW-1:0] < 136) begin
       reg_steer = 1;
     end
   end
@@ -213,9 +213,6 @@ module flash_ctrl_reg_top (
   logic [9:0] mp_region_cfg_0_size_0_qs;
   logic [9:0] mp_region_cfg_0_size_0_wd;
   logic mp_region_cfg_0_size_0_we;
-  logic mp_region_cfg_0_partition_0_qs;
-  logic mp_region_cfg_0_partition_0_wd;
-  logic mp_region_cfg_0_partition_0_we;
   logic mp_region_cfg_1_en_1_qs;
   logic mp_region_cfg_1_en_1_wd;
   logic mp_region_cfg_1_en_1_we;
@@ -234,9 +231,6 @@ module flash_ctrl_reg_top (
   logic [9:0] mp_region_cfg_1_size_1_qs;
   logic [9:0] mp_region_cfg_1_size_1_wd;
   logic mp_region_cfg_1_size_1_we;
-  logic mp_region_cfg_1_partition_1_qs;
-  logic mp_region_cfg_1_partition_1_wd;
-  logic mp_region_cfg_1_partition_1_we;
   logic mp_region_cfg_2_en_2_qs;
   logic mp_region_cfg_2_en_2_wd;
   logic mp_region_cfg_2_en_2_we;
@@ -255,9 +249,6 @@ module flash_ctrl_reg_top (
   logic [9:0] mp_region_cfg_2_size_2_qs;
   logic [9:0] mp_region_cfg_2_size_2_wd;
   logic mp_region_cfg_2_size_2_we;
-  logic mp_region_cfg_2_partition_2_qs;
-  logic mp_region_cfg_2_partition_2_wd;
-  logic mp_region_cfg_2_partition_2_we;
   logic mp_region_cfg_3_en_3_qs;
   logic mp_region_cfg_3_en_3_wd;
   logic mp_region_cfg_3_en_3_we;
@@ -276,9 +267,6 @@ module flash_ctrl_reg_top (
   logic [9:0] mp_region_cfg_3_size_3_qs;
   logic [9:0] mp_region_cfg_3_size_3_wd;
   logic mp_region_cfg_3_size_3_we;
-  logic mp_region_cfg_3_partition_3_qs;
-  logic mp_region_cfg_3_partition_3_wd;
-  logic mp_region_cfg_3_partition_3_we;
   logic mp_region_cfg_4_en_4_qs;
   logic mp_region_cfg_4_en_4_wd;
   logic mp_region_cfg_4_en_4_we;
@@ -297,9 +285,6 @@ module flash_ctrl_reg_top (
   logic [9:0] mp_region_cfg_4_size_4_qs;
   logic [9:0] mp_region_cfg_4_size_4_wd;
   logic mp_region_cfg_4_size_4_we;
-  logic mp_region_cfg_4_partition_4_qs;
-  logic mp_region_cfg_4_partition_4_wd;
-  logic mp_region_cfg_4_partition_4_we;
   logic mp_region_cfg_5_en_5_qs;
   logic mp_region_cfg_5_en_5_wd;
   logic mp_region_cfg_5_en_5_we;
@@ -318,9 +303,6 @@ module flash_ctrl_reg_top (
   logic [9:0] mp_region_cfg_5_size_5_qs;
   logic [9:0] mp_region_cfg_5_size_5_wd;
   logic mp_region_cfg_5_size_5_we;
-  logic mp_region_cfg_5_partition_5_qs;
-  logic mp_region_cfg_5_partition_5_wd;
-  logic mp_region_cfg_5_partition_5_we;
   logic mp_region_cfg_6_en_6_qs;
   logic mp_region_cfg_6_en_6_wd;
   logic mp_region_cfg_6_en_6_we;
@@ -339,9 +321,6 @@ module flash_ctrl_reg_top (
   logic [9:0] mp_region_cfg_6_size_6_qs;
   logic [9:0] mp_region_cfg_6_size_6_wd;
   logic mp_region_cfg_6_size_6_we;
-  logic mp_region_cfg_6_partition_6_qs;
-  logic mp_region_cfg_6_partition_6_wd;
-  logic mp_region_cfg_6_partition_6_we;
   logic mp_region_cfg_7_en_7_qs;
   logic mp_region_cfg_7_en_7_wd;
   logic mp_region_cfg_7_en_7_we;
@@ -360,9 +339,102 @@ module flash_ctrl_reg_top (
   logic [9:0] mp_region_cfg_7_size_7_qs;
   logic [9:0] mp_region_cfg_7_size_7_wd;
   logic mp_region_cfg_7_size_7_we;
-  logic mp_region_cfg_7_partition_7_qs;
-  logic mp_region_cfg_7_partition_7_wd;
-  logic mp_region_cfg_7_partition_7_we;
+  logic bank0_info_page_cfg_0_en_0_qs;
+  logic bank0_info_page_cfg_0_en_0_wd;
+  logic bank0_info_page_cfg_0_en_0_we;
+  logic bank0_info_page_cfg_0_rd_en_0_qs;
+  logic bank0_info_page_cfg_0_rd_en_0_wd;
+  logic bank0_info_page_cfg_0_rd_en_0_we;
+  logic bank0_info_page_cfg_0_prog_en_0_qs;
+  logic bank0_info_page_cfg_0_prog_en_0_wd;
+  logic bank0_info_page_cfg_0_prog_en_0_we;
+  logic bank0_info_page_cfg_0_erase_en_0_qs;
+  logic bank0_info_page_cfg_0_erase_en_0_wd;
+  logic bank0_info_page_cfg_0_erase_en_0_we;
+  logic bank0_info_page_cfg_1_en_1_qs;
+  logic bank0_info_page_cfg_1_en_1_wd;
+  logic bank0_info_page_cfg_1_en_1_we;
+  logic bank0_info_page_cfg_1_rd_en_1_qs;
+  logic bank0_info_page_cfg_1_rd_en_1_wd;
+  logic bank0_info_page_cfg_1_rd_en_1_we;
+  logic bank0_info_page_cfg_1_prog_en_1_qs;
+  logic bank0_info_page_cfg_1_prog_en_1_wd;
+  logic bank0_info_page_cfg_1_prog_en_1_we;
+  logic bank0_info_page_cfg_1_erase_en_1_qs;
+  logic bank0_info_page_cfg_1_erase_en_1_wd;
+  logic bank0_info_page_cfg_1_erase_en_1_we;
+  logic bank0_info_page_cfg_2_en_2_qs;
+  logic bank0_info_page_cfg_2_en_2_wd;
+  logic bank0_info_page_cfg_2_en_2_we;
+  logic bank0_info_page_cfg_2_rd_en_2_qs;
+  logic bank0_info_page_cfg_2_rd_en_2_wd;
+  logic bank0_info_page_cfg_2_rd_en_2_we;
+  logic bank0_info_page_cfg_2_prog_en_2_qs;
+  logic bank0_info_page_cfg_2_prog_en_2_wd;
+  logic bank0_info_page_cfg_2_prog_en_2_we;
+  logic bank0_info_page_cfg_2_erase_en_2_qs;
+  logic bank0_info_page_cfg_2_erase_en_2_wd;
+  logic bank0_info_page_cfg_2_erase_en_2_we;
+  logic bank0_info_page_cfg_3_en_3_qs;
+  logic bank0_info_page_cfg_3_en_3_wd;
+  logic bank0_info_page_cfg_3_en_3_we;
+  logic bank0_info_page_cfg_3_rd_en_3_qs;
+  logic bank0_info_page_cfg_3_rd_en_3_wd;
+  logic bank0_info_page_cfg_3_rd_en_3_we;
+  logic bank0_info_page_cfg_3_prog_en_3_qs;
+  logic bank0_info_page_cfg_3_prog_en_3_wd;
+  logic bank0_info_page_cfg_3_prog_en_3_we;
+  logic bank0_info_page_cfg_3_erase_en_3_qs;
+  logic bank0_info_page_cfg_3_erase_en_3_wd;
+  logic bank0_info_page_cfg_3_erase_en_3_we;
+  logic bank1_info_page_cfg_0_en_0_qs;
+  logic bank1_info_page_cfg_0_en_0_wd;
+  logic bank1_info_page_cfg_0_en_0_we;
+  logic bank1_info_page_cfg_0_rd_en_0_qs;
+  logic bank1_info_page_cfg_0_rd_en_0_wd;
+  logic bank1_info_page_cfg_0_rd_en_0_we;
+  logic bank1_info_page_cfg_0_prog_en_0_qs;
+  logic bank1_info_page_cfg_0_prog_en_0_wd;
+  logic bank1_info_page_cfg_0_prog_en_0_we;
+  logic bank1_info_page_cfg_0_erase_en_0_qs;
+  logic bank1_info_page_cfg_0_erase_en_0_wd;
+  logic bank1_info_page_cfg_0_erase_en_0_we;
+  logic bank1_info_page_cfg_1_en_1_qs;
+  logic bank1_info_page_cfg_1_en_1_wd;
+  logic bank1_info_page_cfg_1_en_1_we;
+  logic bank1_info_page_cfg_1_rd_en_1_qs;
+  logic bank1_info_page_cfg_1_rd_en_1_wd;
+  logic bank1_info_page_cfg_1_rd_en_1_we;
+  logic bank1_info_page_cfg_1_prog_en_1_qs;
+  logic bank1_info_page_cfg_1_prog_en_1_wd;
+  logic bank1_info_page_cfg_1_prog_en_1_we;
+  logic bank1_info_page_cfg_1_erase_en_1_qs;
+  logic bank1_info_page_cfg_1_erase_en_1_wd;
+  logic bank1_info_page_cfg_1_erase_en_1_we;
+  logic bank1_info_page_cfg_2_en_2_qs;
+  logic bank1_info_page_cfg_2_en_2_wd;
+  logic bank1_info_page_cfg_2_en_2_we;
+  logic bank1_info_page_cfg_2_rd_en_2_qs;
+  logic bank1_info_page_cfg_2_rd_en_2_wd;
+  logic bank1_info_page_cfg_2_rd_en_2_we;
+  logic bank1_info_page_cfg_2_prog_en_2_qs;
+  logic bank1_info_page_cfg_2_prog_en_2_wd;
+  logic bank1_info_page_cfg_2_prog_en_2_we;
+  logic bank1_info_page_cfg_2_erase_en_2_qs;
+  logic bank1_info_page_cfg_2_erase_en_2_wd;
+  logic bank1_info_page_cfg_2_erase_en_2_we;
+  logic bank1_info_page_cfg_3_en_3_qs;
+  logic bank1_info_page_cfg_3_en_3_wd;
+  logic bank1_info_page_cfg_3_en_3_we;
+  logic bank1_info_page_cfg_3_rd_en_3_qs;
+  logic bank1_info_page_cfg_3_rd_en_3_wd;
+  logic bank1_info_page_cfg_3_rd_en_3_we;
+  logic bank1_info_page_cfg_3_prog_en_3_qs;
+  logic bank1_info_page_cfg_3_prog_en_3_wd;
+  logic bank1_info_page_cfg_3_prog_en_3_we;
+  logic bank1_info_page_cfg_3_erase_en_3_qs;
+  logic bank1_info_page_cfg_3_erase_en_3_wd;
+  logic bank1_info_page_cfg_3_erase_en_3_we;
   logic default_region_rd_en_qs;
   logic default_region_rd_en_wd;
   logic default_region_rd_en_we;
@@ -392,8 +464,7 @@ module flash_ctrl_reg_top (
   logic status_prog_full_qs;
   logic status_prog_empty_qs;
   logic status_init_wip_qs;
-  logic [8:0] status_error_page_qs;
-  logic status_error_bank_qs;
+  logic [8:0] status_error_addr_qs;
   logic [31:0] scratch_qs;
   logic [31:0] scratch_wd;
   logic scratch_we;
@@ -1205,32 +1276,6 @@ module flash_ctrl_reg_top (
   );
 
 
-  // F[partition_0]: 28:28
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_mp_region_cfg_0_partition_0 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (mp_region_cfg_0_partition_0_we & region_cfg_regwen_qs),
-    .wd     (mp_region_cfg_0_partition_0_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.mp_region_cfg[0].partition.q ),
-
-    // to register interface (read)
-    .qs     (mp_region_cfg_0_partition_0_qs)
-  );
-
-
   // Subregister 1 of Multireg mp_region_cfg
   // R[mp_region_cfg_1]: V(False)
 
@@ -1387,32 +1432,6 @@ module flash_ctrl_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_1_size_1_qs)
-  );
-
-
-  // F[partition_1]: 28:28
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_mp_region_cfg_1_partition_1 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (mp_region_cfg_1_partition_1_we & region_cfg_regwen_qs),
-    .wd     (mp_region_cfg_1_partition_1_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.mp_region_cfg[1].partition.q ),
-
-    // to register interface (read)
-    .qs     (mp_region_cfg_1_partition_1_qs)
   );
 
 
@@ -1575,32 +1594,6 @@ module flash_ctrl_reg_top (
   );
 
 
-  // F[partition_2]: 28:28
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_mp_region_cfg_2_partition_2 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (mp_region_cfg_2_partition_2_we & region_cfg_regwen_qs),
-    .wd     (mp_region_cfg_2_partition_2_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.mp_region_cfg[2].partition.q ),
-
-    // to register interface (read)
-    .qs     (mp_region_cfg_2_partition_2_qs)
-  );
-
-
   // Subregister 3 of Multireg mp_region_cfg
   // R[mp_region_cfg_3]: V(False)
 
@@ -1757,32 +1750,6 @@ module flash_ctrl_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_3_size_3_qs)
-  );
-
-
-  // F[partition_3]: 28:28
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_mp_region_cfg_3_partition_3 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (mp_region_cfg_3_partition_3_we & region_cfg_regwen_qs),
-    .wd     (mp_region_cfg_3_partition_3_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.mp_region_cfg[3].partition.q ),
-
-    // to register interface (read)
-    .qs     (mp_region_cfg_3_partition_3_qs)
   );
 
 
@@ -1945,32 +1912,6 @@ module flash_ctrl_reg_top (
   );
 
 
-  // F[partition_4]: 28:28
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_mp_region_cfg_4_partition_4 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (mp_region_cfg_4_partition_4_we & region_cfg_regwen_qs),
-    .wd     (mp_region_cfg_4_partition_4_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.mp_region_cfg[4].partition.q ),
-
-    // to register interface (read)
-    .qs     (mp_region_cfg_4_partition_4_qs)
-  );
-
-
   // Subregister 5 of Multireg mp_region_cfg
   // R[mp_region_cfg_5]: V(False)
 
@@ -2127,32 +2068,6 @@ module flash_ctrl_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_5_size_5_qs)
-  );
-
-
-  // F[partition_5]: 28:28
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_mp_region_cfg_5_partition_5 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (mp_region_cfg_5_partition_5_we & region_cfg_regwen_qs),
-    .wd     (mp_region_cfg_5_partition_5_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.mp_region_cfg[5].partition.q ),
-
-    // to register interface (read)
-    .qs     (mp_region_cfg_5_partition_5_qs)
   );
 
 
@@ -2315,32 +2230,6 @@ module flash_ctrl_reg_top (
   );
 
 
-  // F[partition_6]: 28:28
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_mp_region_cfg_6_partition_6 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (mp_region_cfg_6_partition_6_we & region_cfg_regwen_qs),
-    .wd     (mp_region_cfg_6_partition_6_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.mp_region_cfg[6].partition.q ),
-
-    // to register interface (read)
-    .qs     (mp_region_cfg_6_partition_6_qs)
-  );
-
-
   // Subregister 7 of Multireg mp_region_cfg
   // R[mp_region_cfg_7]: V(False)
 
@@ -2500,18 +2389,23 @@ module flash_ctrl_reg_top (
   );
 
 
-  // F[partition_7]: 28:28
+
+
+  // Subregister 0 of Multireg bank0_info_page_cfg
+  // R[bank0_info_page_cfg_0]: V(False)
+
+  // F[en_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_7_partition_7 (
+  ) u_bank0_info_page_cfg_0_en_0 (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (mp_region_cfg_7_partition_7_we & region_cfg_regwen_qs),
-    .wd     (mp_region_cfg_7_partition_7_wd),
+    .we     (bank0_info_page_cfg_0_en_0_we & region_cfg_regwen_qs),
+    .wd     (bank0_info_page_cfg_0_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2519,10 +2413,839 @@ module flash_ctrl_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[7].partition.q ),
+    .q      (reg2hw.bank0_info_page_cfg[0].en.q ),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_7_partition_7_qs)
+    .qs     (bank0_info_page_cfg_0_en_0_qs)
+  );
+
+
+  // F[rd_en_0]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank0_info_page_cfg_0_rd_en_0 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank0_info_page_cfg_0_rd_en_0_we & region_cfg_regwen_qs),
+    .wd     (bank0_info_page_cfg_0_rd_en_0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank0_info_page_cfg[0].rd_en.q ),
+
+    // to register interface (read)
+    .qs     (bank0_info_page_cfg_0_rd_en_0_qs)
+  );
+
+
+  // F[prog_en_0]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank0_info_page_cfg_0_prog_en_0 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank0_info_page_cfg_0_prog_en_0_we & region_cfg_regwen_qs),
+    .wd     (bank0_info_page_cfg_0_prog_en_0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank0_info_page_cfg[0].prog_en.q ),
+
+    // to register interface (read)
+    .qs     (bank0_info_page_cfg_0_prog_en_0_qs)
+  );
+
+
+  // F[erase_en_0]: 3:3
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank0_info_page_cfg_0_erase_en_0 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank0_info_page_cfg_0_erase_en_0_we & region_cfg_regwen_qs),
+    .wd     (bank0_info_page_cfg_0_erase_en_0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank0_info_page_cfg[0].erase_en.q ),
+
+    // to register interface (read)
+    .qs     (bank0_info_page_cfg_0_erase_en_0_qs)
+  );
+
+
+  // Subregister 1 of Multireg bank0_info_page_cfg
+  // R[bank0_info_page_cfg_1]: V(False)
+
+  // F[en_1]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank0_info_page_cfg_1_en_1 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank0_info_page_cfg_1_en_1_we & region_cfg_regwen_qs),
+    .wd     (bank0_info_page_cfg_1_en_1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank0_info_page_cfg[1].en.q ),
+
+    // to register interface (read)
+    .qs     (bank0_info_page_cfg_1_en_1_qs)
+  );
+
+
+  // F[rd_en_1]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank0_info_page_cfg_1_rd_en_1 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank0_info_page_cfg_1_rd_en_1_we & region_cfg_regwen_qs),
+    .wd     (bank0_info_page_cfg_1_rd_en_1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank0_info_page_cfg[1].rd_en.q ),
+
+    // to register interface (read)
+    .qs     (bank0_info_page_cfg_1_rd_en_1_qs)
+  );
+
+
+  // F[prog_en_1]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank0_info_page_cfg_1_prog_en_1 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank0_info_page_cfg_1_prog_en_1_we & region_cfg_regwen_qs),
+    .wd     (bank0_info_page_cfg_1_prog_en_1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank0_info_page_cfg[1].prog_en.q ),
+
+    // to register interface (read)
+    .qs     (bank0_info_page_cfg_1_prog_en_1_qs)
+  );
+
+
+  // F[erase_en_1]: 3:3
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank0_info_page_cfg_1_erase_en_1 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank0_info_page_cfg_1_erase_en_1_we & region_cfg_regwen_qs),
+    .wd     (bank0_info_page_cfg_1_erase_en_1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank0_info_page_cfg[1].erase_en.q ),
+
+    // to register interface (read)
+    .qs     (bank0_info_page_cfg_1_erase_en_1_qs)
+  );
+
+
+  // Subregister 2 of Multireg bank0_info_page_cfg
+  // R[bank0_info_page_cfg_2]: V(False)
+
+  // F[en_2]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank0_info_page_cfg_2_en_2 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank0_info_page_cfg_2_en_2_we & region_cfg_regwen_qs),
+    .wd     (bank0_info_page_cfg_2_en_2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank0_info_page_cfg[2].en.q ),
+
+    // to register interface (read)
+    .qs     (bank0_info_page_cfg_2_en_2_qs)
+  );
+
+
+  // F[rd_en_2]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank0_info_page_cfg_2_rd_en_2 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank0_info_page_cfg_2_rd_en_2_we & region_cfg_regwen_qs),
+    .wd     (bank0_info_page_cfg_2_rd_en_2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank0_info_page_cfg[2].rd_en.q ),
+
+    // to register interface (read)
+    .qs     (bank0_info_page_cfg_2_rd_en_2_qs)
+  );
+
+
+  // F[prog_en_2]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank0_info_page_cfg_2_prog_en_2 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank0_info_page_cfg_2_prog_en_2_we & region_cfg_regwen_qs),
+    .wd     (bank0_info_page_cfg_2_prog_en_2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank0_info_page_cfg[2].prog_en.q ),
+
+    // to register interface (read)
+    .qs     (bank0_info_page_cfg_2_prog_en_2_qs)
+  );
+
+
+  // F[erase_en_2]: 3:3
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank0_info_page_cfg_2_erase_en_2 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank0_info_page_cfg_2_erase_en_2_we & region_cfg_regwen_qs),
+    .wd     (bank0_info_page_cfg_2_erase_en_2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank0_info_page_cfg[2].erase_en.q ),
+
+    // to register interface (read)
+    .qs     (bank0_info_page_cfg_2_erase_en_2_qs)
+  );
+
+
+  // Subregister 3 of Multireg bank0_info_page_cfg
+  // R[bank0_info_page_cfg_3]: V(False)
+
+  // F[en_3]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank0_info_page_cfg_3_en_3 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank0_info_page_cfg_3_en_3_we & region_cfg_regwen_qs),
+    .wd     (bank0_info_page_cfg_3_en_3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank0_info_page_cfg[3].en.q ),
+
+    // to register interface (read)
+    .qs     (bank0_info_page_cfg_3_en_3_qs)
+  );
+
+
+  // F[rd_en_3]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank0_info_page_cfg_3_rd_en_3 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank0_info_page_cfg_3_rd_en_3_we & region_cfg_regwen_qs),
+    .wd     (bank0_info_page_cfg_3_rd_en_3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank0_info_page_cfg[3].rd_en.q ),
+
+    // to register interface (read)
+    .qs     (bank0_info_page_cfg_3_rd_en_3_qs)
+  );
+
+
+  // F[prog_en_3]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank0_info_page_cfg_3_prog_en_3 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank0_info_page_cfg_3_prog_en_3_we & region_cfg_regwen_qs),
+    .wd     (bank0_info_page_cfg_3_prog_en_3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank0_info_page_cfg[3].prog_en.q ),
+
+    // to register interface (read)
+    .qs     (bank0_info_page_cfg_3_prog_en_3_qs)
+  );
+
+
+  // F[erase_en_3]: 3:3
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank0_info_page_cfg_3_erase_en_3 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank0_info_page_cfg_3_erase_en_3_we & region_cfg_regwen_qs),
+    .wd     (bank0_info_page_cfg_3_erase_en_3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank0_info_page_cfg[3].erase_en.q ),
+
+    // to register interface (read)
+    .qs     (bank0_info_page_cfg_3_erase_en_3_qs)
+  );
+
+
+
+
+  // Subregister 0 of Multireg bank1_info_page_cfg
+  // R[bank1_info_page_cfg_0]: V(False)
+
+  // F[en_0]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank1_info_page_cfg_0_en_0 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank1_info_page_cfg_0_en_0_we & region_cfg_regwen_qs),
+    .wd     (bank1_info_page_cfg_0_en_0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank1_info_page_cfg[0].en.q ),
+
+    // to register interface (read)
+    .qs     (bank1_info_page_cfg_0_en_0_qs)
+  );
+
+
+  // F[rd_en_0]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank1_info_page_cfg_0_rd_en_0 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank1_info_page_cfg_0_rd_en_0_we & region_cfg_regwen_qs),
+    .wd     (bank1_info_page_cfg_0_rd_en_0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank1_info_page_cfg[0].rd_en.q ),
+
+    // to register interface (read)
+    .qs     (bank1_info_page_cfg_0_rd_en_0_qs)
+  );
+
+
+  // F[prog_en_0]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank1_info_page_cfg_0_prog_en_0 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank1_info_page_cfg_0_prog_en_0_we & region_cfg_regwen_qs),
+    .wd     (bank1_info_page_cfg_0_prog_en_0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank1_info_page_cfg[0].prog_en.q ),
+
+    // to register interface (read)
+    .qs     (bank1_info_page_cfg_0_prog_en_0_qs)
+  );
+
+
+  // F[erase_en_0]: 3:3
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank1_info_page_cfg_0_erase_en_0 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank1_info_page_cfg_0_erase_en_0_we & region_cfg_regwen_qs),
+    .wd     (bank1_info_page_cfg_0_erase_en_0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank1_info_page_cfg[0].erase_en.q ),
+
+    // to register interface (read)
+    .qs     (bank1_info_page_cfg_0_erase_en_0_qs)
+  );
+
+
+  // Subregister 1 of Multireg bank1_info_page_cfg
+  // R[bank1_info_page_cfg_1]: V(False)
+
+  // F[en_1]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank1_info_page_cfg_1_en_1 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank1_info_page_cfg_1_en_1_we & region_cfg_regwen_qs),
+    .wd     (bank1_info_page_cfg_1_en_1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank1_info_page_cfg[1].en.q ),
+
+    // to register interface (read)
+    .qs     (bank1_info_page_cfg_1_en_1_qs)
+  );
+
+
+  // F[rd_en_1]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank1_info_page_cfg_1_rd_en_1 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank1_info_page_cfg_1_rd_en_1_we & region_cfg_regwen_qs),
+    .wd     (bank1_info_page_cfg_1_rd_en_1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank1_info_page_cfg[1].rd_en.q ),
+
+    // to register interface (read)
+    .qs     (bank1_info_page_cfg_1_rd_en_1_qs)
+  );
+
+
+  // F[prog_en_1]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank1_info_page_cfg_1_prog_en_1 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank1_info_page_cfg_1_prog_en_1_we & region_cfg_regwen_qs),
+    .wd     (bank1_info_page_cfg_1_prog_en_1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank1_info_page_cfg[1].prog_en.q ),
+
+    // to register interface (read)
+    .qs     (bank1_info_page_cfg_1_prog_en_1_qs)
+  );
+
+
+  // F[erase_en_1]: 3:3
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank1_info_page_cfg_1_erase_en_1 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank1_info_page_cfg_1_erase_en_1_we & region_cfg_regwen_qs),
+    .wd     (bank1_info_page_cfg_1_erase_en_1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank1_info_page_cfg[1].erase_en.q ),
+
+    // to register interface (read)
+    .qs     (bank1_info_page_cfg_1_erase_en_1_qs)
+  );
+
+
+  // Subregister 2 of Multireg bank1_info_page_cfg
+  // R[bank1_info_page_cfg_2]: V(False)
+
+  // F[en_2]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank1_info_page_cfg_2_en_2 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank1_info_page_cfg_2_en_2_we & region_cfg_regwen_qs),
+    .wd     (bank1_info_page_cfg_2_en_2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank1_info_page_cfg[2].en.q ),
+
+    // to register interface (read)
+    .qs     (bank1_info_page_cfg_2_en_2_qs)
+  );
+
+
+  // F[rd_en_2]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank1_info_page_cfg_2_rd_en_2 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank1_info_page_cfg_2_rd_en_2_we & region_cfg_regwen_qs),
+    .wd     (bank1_info_page_cfg_2_rd_en_2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank1_info_page_cfg[2].rd_en.q ),
+
+    // to register interface (read)
+    .qs     (bank1_info_page_cfg_2_rd_en_2_qs)
+  );
+
+
+  // F[prog_en_2]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank1_info_page_cfg_2_prog_en_2 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank1_info_page_cfg_2_prog_en_2_we & region_cfg_regwen_qs),
+    .wd     (bank1_info_page_cfg_2_prog_en_2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank1_info_page_cfg[2].prog_en.q ),
+
+    // to register interface (read)
+    .qs     (bank1_info_page_cfg_2_prog_en_2_qs)
+  );
+
+
+  // F[erase_en_2]: 3:3
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank1_info_page_cfg_2_erase_en_2 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank1_info_page_cfg_2_erase_en_2_we & region_cfg_regwen_qs),
+    .wd     (bank1_info_page_cfg_2_erase_en_2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank1_info_page_cfg[2].erase_en.q ),
+
+    // to register interface (read)
+    .qs     (bank1_info_page_cfg_2_erase_en_2_qs)
+  );
+
+
+  // Subregister 3 of Multireg bank1_info_page_cfg
+  // R[bank1_info_page_cfg_3]: V(False)
+
+  // F[en_3]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank1_info_page_cfg_3_en_3 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank1_info_page_cfg_3_en_3_we & region_cfg_regwen_qs),
+    .wd     (bank1_info_page_cfg_3_en_3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank1_info_page_cfg[3].en.q ),
+
+    // to register interface (read)
+    .qs     (bank1_info_page_cfg_3_en_3_qs)
+  );
+
+
+  // F[rd_en_3]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank1_info_page_cfg_3_rd_en_3 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank1_info_page_cfg_3_rd_en_3_we & region_cfg_regwen_qs),
+    .wd     (bank1_info_page_cfg_3_rd_en_3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank1_info_page_cfg[3].rd_en.q ),
+
+    // to register interface (read)
+    .qs     (bank1_info_page_cfg_3_rd_en_3_qs)
+  );
+
+
+  // F[prog_en_3]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank1_info_page_cfg_3_prog_en_3 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank1_info_page_cfg_3_prog_en_3_we & region_cfg_regwen_qs),
+    .wd     (bank1_info_page_cfg_3_prog_en_3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank1_info_page_cfg[3].prog_en.q ),
+
+    // to register interface (read)
+    .qs     (bank1_info_page_cfg_3_prog_en_3_qs)
+  );
+
+
+  // F[erase_en_3]: 3:3
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank1_info_page_cfg_3_erase_en_3 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank1_info_page_cfg_3_erase_en_3_we & region_cfg_regwen_qs),
+    .wd     (bank1_info_page_cfg_3_erase_en_3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank1_info_page_cfg[3].erase_en.q ),
+
+    // to register interface (read)
+    .qs     (bank1_info_page_cfg_3_erase_en_3_qs)
   );
 
 
@@ -2872,12 +3595,12 @@ module flash_ctrl_reg_top (
   );
 
 
-  //   F[error_page]: 16:8
+  //   F[error_addr]: 16:8
   prim_subreg #(
     .DW      (9),
     .SWACCESS("RO"),
     .RESVAL  (9'h0)
-  ) u_status_error_page (
+  ) u_status_error_addr (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
@@ -2885,40 +3608,15 @@ module flash_ctrl_reg_top (
     .wd     ('0  ),
 
     // from internal hardware
-    .de     (hw2reg.status.error_page.de),
-    .d      (hw2reg.status.error_page.d ),
+    .de     (hw2reg.status.error_addr.de),
+    .d      (hw2reg.status.error_addr.d ),
 
     // to internal hardware
     .qe     (),
     .q      (),
 
     // to register interface (read)
-    .qs     (status_error_page_qs)
-  );
-
-
-  //   F[error_bank]: 17:17
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RO"),
-    .RESVAL  (1'h0)
-  ) u_status_error_bank (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    .we     (1'b0),
-    .wd     ('0  ),
-
-    // from internal hardware
-    .de     (hw2reg.status.error_bank.de),
-    .d      (hw2reg.status.error_bank.d ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (status_error_bank_qs)
+    .qs     (status_error_addr_qs)
   );
 
 
@@ -3032,7 +3730,7 @@ module flash_ctrl_reg_top (
 
 
 
-  logic [23:0] addr_hit;
+  logic [31:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == FLASH_CTRL_INTR_STATE_OFFSET);
@@ -3051,14 +3749,22 @@ module flash_ctrl_reg_top (
     addr_hit[13] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_5_OFFSET);
     addr_hit[14] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_6_OFFSET);
     addr_hit[15] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_7_OFFSET);
-    addr_hit[16] = (reg_addr == FLASH_CTRL_DEFAULT_REGION_OFFSET);
-    addr_hit[17] = (reg_addr == FLASH_CTRL_BANK_CFG_REGWEN_OFFSET);
-    addr_hit[18] = (reg_addr == FLASH_CTRL_MP_BANK_CFG_OFFSET);
-    addr_hit[19] = (reg_addr == FLASH_CTRL_OP_STATUS_OFFSET);
-    addr_hit[20] = (reg_addr == FLASH_CTRL_STATUS_OFFSET);
-    addr_hit[21] = (reg_addr == FLASH_CTRL_SCRATCH_OFFSET);
-    addr_hit[22] = (reg_addr == FLASH_CTRL_FIFO_LVL_OFFSET);
-    addr_hit[23] = (reg_addr == FLASH_CTRL_FIFO_RST_OFFSET);
+    addr_hit[16] = (reg_addr == FLASH_CTRL_BANK0_INFO_PAGE_CFG_0_OFFSET);
+    addr_hit[17] = (reg_addr == FLASH_CTRL_BANK0_INFO_PAGE_CFG_1_OFFSET);
+    addr_hit[18] = (reg_addr == FLASH_CTRL_BANK0_INFO_PAGE_CFG_2_OFFSET);
+    addr_hit[19] = (reg_addr == FLASH_CTRL_BANK0_INFO_PAGE_CFG_3_OFFSET);
+    addr_hit[20] = (reg_addr == FLASH_CTRL_BANK1_INFO_PAGE_CFG_0_OFFSET);
+    addr_hit[21] = (reg_addr == FLASH_CTRL_BANK1_INFO_PAGE_CFG_1_OFFSET);
+    addr_hit[22] = (reg_addr == FLASH_CTRL_BANK1_INFO_PAGE_CFG_2_OFFSET);
+    addr_hit[23] = (reg_addr == FLASH_CTRL_BANK1_INFO_PAGE_CFG_3_OFFSET);
+    addr_hit[24] = (reg_addr == FLASH_CTRL_DEFAULT_REGION_OFFSET);
+    addr_hit[25] = (reg_addr == FLASH_CTRL_BANK_CFG_REGWEN_OFFSET);
+    addr_hit[26] = (reg_addr == FLASH_CTRL_MP_BANK_CFG_OFFSET);
+    addr_hit[27] = (reg_addr == FLASH_CTRL_OP_STATUS_OFFSET);
+    addr_hit[28] = (reg_addr == FLASH_CTRL_STATUS_OFFSET);
+    addr_hit[29] = (reg_addr == FLASH_CTRL_SCRATCH_OFFSET);
+    addr_hit[30] = (reg_addr == FLASH_CTRL_FIFO_LVL_OFFSET);
+    addr_hit[31] = (reg_addr == FLASH_CTRL_FIFO_RST_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -3090,6 +3796,14 @@ module flash_ctrl_reg_top (
     if (addr_hit[21] && reg_we && (FLASH_CTRL_PERMIT[21] != (FLASH_CTRL_PERMIT[21] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[22] && reg_we && (FLASH_CTRL_PERMIT[22] != (FLASH_CTRL_PERMIT[22] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[23] && reg_we && (FLASH_CTRL_PERMIT[23] != (FLASH_CTRL_PERMIT[23] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[24] && reg_we && (FLASH_CTRL_PERMIT[24] != (FLASH_CTRL_PERMIT[24] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[25] && reg_we && (FLASH_CTRL_PERMIT[25] != (FLASH_CTRL_PERMIT[25] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[26] && reg_we && (FLASH_CTRL_PERMIT[26] != (FLASH_CTRL_PERMIT[26] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[27] && reg_we && (FLASH_CTRL_PERMIT[27] != (FLASH_CTRL_PERMIT[27] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[28] && reg_we && (FLASH_CTRL_PERMIT[28] != (FLASH_CTRL_PERMIT[28] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[29] && reg_we && (FLASH_CTRL_PERMIT[29] != (FLASH_CTRL_PERMIT[29] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[30] && reg_we && (FLASH_CTRL_PERMIT[30] != (FLASH_CTRL_PERMIT[30] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[31] && reg_we && (FLASH_CTRL_PERMIT[31] != (FLASH_CTRL_PERMIT[31] & reg_be))) wr_err = 1'b1 ;
   end
 
   assign intr_state_prog_empty_we = addr_hit[0] & reg_we & ~wr_err;
@@ -3190,9 +3904,6 @@ module flash_ctrl_reg_top (
   assign mp_region_cfg_0_size_0_we = addr_hit[8] & reg_we & ~wr_err;
   assign mp_region_cfg_0_size_0_wd = reg_wdata[25:16];
 
-  assign mp_region_cfg_0_partition_0_we = addr_hit[8] & reg_we & ~wr_err;
-  assign mp_region_cfg_0_partition_0_wd = reg_wdata[28];
-
   assign mp_region_cfg_1_en_1_we = addr_hit[9] & reg_we & ~wr_err;
   assign mp_region_cfg_1_en_1_wd = reg_wdata[0];
 
@@ -3210,9 +3921,6 @@ module flash_ctrl_reg_top (
 
   assign mp_region_cfg_1_size_1_we = addr_hit[9] & reg_we & ~wr_err;
   assign mp_region_cfg_1_size_1_wd = reg_wdata[25:16];
-
-  assign mp_region_cfg_1_partition_1_we = addr_hit[9] & reg_we & ~wr_err;
-  assign mp_region_cfg_1_partition_1_wd = reg_wdata[28];
 
   assign mp_region_cfg_2_en_2_we = addr_hit[10] & reg_we & ~wr_err;
   assign mp_region_cfg_2_en_2_wd = reg_wdata[0];
@@ -3232,9 +3940,6 @@ module flash_ctrl_reg_top (
   assign mp_region_cfg_2_size_2_we = addr_hit[10] & reg_we & ~wr_err;
   assign mp_region_cfg_2_size_2_wd = reg_wdata[25:16];
 
-  assign mp_region_cfg_2_partition_2_we = addr_hit[10] & reg_we & ~wr_err;
-  assign mp_region_cfg_2_partition_2_wd = reg_wdata[28];
-
   assign mp_region_cfg_3_en_3_we = addr_hit[11] & reg_we & ~wr_err;
   assign mp_region_cfg_3_en_3_wd = reg_wdata[0];
 
@@ -3252,9 +3957,6 @@ module flash_ctrl_reg_top (
 
   assign mp_region_cfg_3_size_3_we = addr_hit[11] & reg_we & ~wr_err;
   assign mp_region_cfg_3_size_3_wd = reg_wdata[25:16];
-
-  assign mp_region_cfg_3_partition_3_we = addr_hit[11] & reg_we & ~wr_err;
-  assign mp_region_cfg_3_partition_3_wd = reg_wdata[28];
 
   assign mp_region_cfg_4_en_4_we = addr_hit[12] & reg_we & ~wr_err;
   assign mp_region_cfg_4_en_4_wd = reg_wdata[0];
@@ -3274,9 +3976,6 @@ module flash_ctrl_reg_top (
   assign mp_region_cfg_4_size_4_we = addr_hit[12] & reg_we & ~wr_err;
   assign mp_region_cfg_4_size_4_wd = reg_wdata[25:16];
 
-  assign mp_region_cfg_4_partition_4_we = addr_hit[12] & reg_we & ~wr_err;
-  assign mp_region_cfg_4_partition_4_wd = reg_wdata[28];
-
   assign mp_region_cfg_5_en_5_we = addr_hit[13] & reg_we & ~wr_err;
   assign mp_region_cfg_5_en_5_wd = reg_wdata[0];
 
@@ -3294,9 +3993,6 @@ module flash_ctrl_reg_top (
 
   assign mp_region_cfg_5_size_5_we = addr_hit[13] & reg_we & ~wr_err;
   assign mp_region_cfg_5_size_5_wd = reg_wdata[25:16];
-
-  assign mp_region_cfg_5_partition_5_we = addr_hit[13] & reg_we & ~wr_err;
-  assign mp_region_cfg_5_partition_5_wd = reg_wdata[28];
 
   assign mp_region_cfg_6_en_6_we = addr_hit[14] & reg_we & ~wr_err;
   assign mp_region_cfg_6_en_6_wd = reg_wdata[0];
@@ -3316,9 +4012,6 @@ module flash_ctrl_reg_top (
   assign mp_region_cfg_6_size_6_we = addr_hit[14] & reg_we & ~wr_err;
   assign mp_region_cfg_6_size_6_wd = reg_wdata[25:16];
 
-  assign mp_region_cfg_6_partition_6_we = addr_hit[14] & reg_we & ~wr_err;
-  assign mp_region_cfg_6_partition_6_wd = reg_wdata[28];
-
   assign mp_region_cfg_7_en_7_we = addr_hit[15] & reg_we & ~wr_err;
   assign mp_region_cfg_7_en_7_wd = reg_wdata[0];
 
@@ -3337,31 +4030,124 @@ module flash_ctrl_reg_top (
   assign mp_region_cfg_7_size_7_we = addr_hit[15] & reg_we & ~wr_err;
   assign mp_region_cfg_7_size_7_wd = reg_wdata[25:16];
 
-  assign mp_region_cfg_7_partition_7_we = addr_hit[15] & reg_we & ~wr_err;
-  assign mp_region_cfg_7_partition_7_wd = reg_wdata[28];
+  assign bank0_info_page_cfg_0_en_0_we = addr_hit[16] & reg_we & ~wr_err;
+  assign bank0_info_page_cfg_0_en_0_wd = reg_wdata[0];
 
-  assign default_region_rd_en_we = addr_hit[16] & reg_we & ~wr_err;
+  assign bank0_info_page_cfg_0_rd_en_0_we = addr_hit[16] & reg_we & ~wr_err;
+  assign bank0_info_page_cfg_0_rd_en_0_wd = reg_wdata[1];
+
+  assign bank0_info_page_cfg_0_prog_en_0_we = addr_hit[16] & reg_we & ~wr_err;
+  assign bank0_info_page_cfg_0_prog_en_0_wd = reg_wdata[2];
+
+  assign bank0_info_page_cfg_0_erase_en_0_we = addr_hit[16] & reg_we & ~wr_err;
+  assign bank0_info_page_cfg_0_erase_en_0_wd = reg_wdata[3];
+
+  assign bank0_info_page_cfg_1_en_1_we = addr_hit[17] & reg_we & ~wr_err;
+  assign bank0_info_page_cfg_1_en_1_wd = reg_wdata[0];
+
+  assign bank0_info_page_cfg_1_rd_en_1_we = addr_hit[17] & reg_we & ~wr_err;
+  assign bank0_info_page_cfg_1_rd_en_1_wd = reg_wdata[1];
+
+  assign bank0_info_page_cfg_1_prog_en_1_we = addr_hit[17] & reg_we & ~wr_err;
+  assign bank0_info_page_cfg_1_prog_en_1_wd = reg_wdata[2];
+
+  assign bank0_info_page_cfg_1_erase_en_1_we = addr_hit[17] & reg_we & ~wr_err;
+  assign bank0_info_page_cfg_1_erase_en_1_wd = reg_wdata[3];
+
+  assign bank0_info_page_cfg_2_en_2_we = addr_hit[18] & reg_we & ~wr_err;
+  assign bank0_info_page_cfg_2_en_2_wd = reg_wdata[0];
+
+  assign bank0_info_page_cfg_2_rd_en_2_we = addr_hit[18] & reg_we & ~wr_err;
+  assign bank0_info_page_cfg_2_rd_en_2_wd = reg_wdata[1];
+
+  assign bank0_info_page_cfg_2_prog_en_2_we = addr_hit[18] & reg_we & ~wr_err;
+  assign bank0_info_page_cfg_2_prog_en_2_wd = reg_wdata[2];
+
+  assign bank0_info_page_cfg_2_erase_en_2_we = addr_hit[18] & reg_we & ~wr_err;
+  assign bank0_info_page_cfg_2_erase_en_2_wd = reg_wdata[3];
+
+  assign bank0_info_page_cfg_3_en_3_we = addr_hit[19] & reg_we & ~wr_err;
+  assign bank0_info_page_cfg_3_en_3_wd = reg_wdata[0];
+
+  assign bank0_info_page_cfg_3_rd_en_3_we = addr_hit[19] & reg_we & ~wr_err;
+  assign bank0_info_page_cfg_3_rd_en_3_wd = reg_wdata[1];
+
+  assign bank0_info_page_cfg_3_prog_en_3_we = addr_hit[19] & reg_we & ~wr_err;
+  assign bank0_info_page_cfg_3_prog_en_3_wd = reg_wdata[2];
+
+  assign bank0_info_page_cfg_3_erase_en_3_we = addr_hit[19] & reg_we & ~wr_err;
+  assign bank0_info_page_cfg_3_erase_en_3_wd = reg_wdata[3];
+
+  assign bank1_info_page_cfg_0_en_0_we = addr_hit[20] & reg_we & ~wr_err;
+  assign bank1_info_page_cfg_0_en_0_wd = reg_wdata[0];
+
+  assign bank1_info_page_cfg_0_rd_en_0_we = addr_hit[20] & reg_we & ~wr_err;
+  assign bank1_info_page_cfg_0_rd_en_0_wd = reg_wdata[1];
+
+  assign bank1_info_page_cfg_0_prog_en_0_we = addr_hit[20] & reg_we & ~wr_err;
+  assign bank1_info_page_cfg_0_prog_en_0_wd = reg_wdata[2];
+
+  assign bank1_info_page_cfg_0_erase_en_0_we = addr_hit[20] & reg_we & ~wr_err;
+  assign bank1_info_page_cfg_0_erase_en_0_wd = reg_wdata[3];
+
+  assign bank1_info_page_cfg_1_en_1_we = addr_hit[21] & reg_we & ~wr_err;
+  assign bank1_info_page_cfg_1_en_1_wd = reg_wdata[0];
+
+  assign bank1_info_page_cfg_1_rd_en_1_we = addr_hit[21] & reg_we & ~wr_err;
+  assign bank1_info_page_cfg_1_rd_en_1_wd = reg_wdata[1];
+
+  assign bank1_info_page_cfg_1_prog_en_1_we = addr_hit[21] & reg_we & ~wr_err;
+  assign bank1_info_page_cfg_1_prog_en_1_wd = reg_wdata[2];
+
+  assign bank1_info_page_cfg_1_erase_en_1_we = addr_hit[21] & reg_we & ~wr_err;
+  assign bank1_info_page_cfg_1_erase_en_1_wd = reg_wdata[3];
+
+  assign bank1_info_page_cfg_2_en_2_we = addr_hit[22] & reg_we & ~wr_err;
+  assign bank1_info_page_cfg_2_en_2_wd = reg_wdata[0];
+
+  assign bank1_info_page_cfg_2_rd_en_2_we = addr_hit[22] & reg_we & ~wr_err;
+  assign bank1_info_page_cfg_2_rd_en_2_wd = reg_wdata[1];
+
+  assign bank1_info_page_cfg_2_prog_en_2_we = addr_hit[22] & reg_we & ~wr_err;
+  assign bank1_info_page_cfg_2_prog_en_2_wd = reg_wdata[2];
+
+  assign bank1_info_page_cfg_2_erase_en_2_we = addr_hit[22] & reg_we & ~wr_err;
+  assign bank1_info_page_cfg_2_erase_en_2_wd = reg_wdata[3];
+
+  assign bank1_info_page_cfg_3_en_3_we = addr_hit[23] & reg_we & ~wr_err;
+  assign bank1_info_page_cfg_3_en_3_wd = reg_wdata[0];
+
+  assign bank1_info_page_cfg_3_rd_en_3_we = addr_hit[23] & reg_we & ~wr_err;
+  assign bank1_info_page_cfg_3_rd_en_3_wd = reg_wdata[1];
+
+  assign bank1_info_page_cfg_3_prog_en_3_we = addr_hit[23] & reg_we & ~wr_err;
+  assign bank1_info_page_cfg_3_prog_en_3_wd = reg_wdata[2];
+
+  assign bank1_info_page_cfg_3_erase_en_3_we = addr_hit[23] & reg_we & ~wr_err;
+  assign bank1_info_page_cfg_3_erase_en_3_wd = reg_wdata[3];
+
+  assign default_region_rd_en_we = addr_hit[24] & reg_we & ~wr_err;
   assign default_region_rd_en_wd = reg_wdata[0];
 
-  assign default_region_prog_en_we = addr_hit[16] & reg_we & ~wr_err;
+  assign default_region_prog_en_we = addr_hit[24] & reg_we & ~wr_err;
   assign default_region_prog_en_wd = reg_wdata[1];
 
-  assign default_region_erase_en_we = addr_hit[16] & reg_we & ~wr_err;
+  assign default_region_erase_en_we = addr_hit[24] & reg_we & ~wr_err;
   assign default_region_erase_en_wd = reg_wdata[2];
 
-  assign bank_cfg_regwen_we = addr_hit[17] & reg_we & ~wr_err;
+  assign bank_cfg_regwen_we = addr_hit[25] & reg_we & ~wr_err;
   assign bank_cfg_regwen_wd = reg_wdata[0];
 
-  assign mp_bank_cfg_erase_en_0_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mp_bank_cfg_erase_en_0_we = addr_hit[26] & reg_we & ~wr_err;
   assign mp_bank_cfg_erase_en_0_wd = reg_wdata[0];
 
-  assign mp_bank_cfg_erase_en_1_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mp_bank_cfg_erase_en_1_we = addr_hit[26] & reg_we & ~wr_err;
   assign mp_bank_cfg_erase_en_1_wd = reg_wdata[1];
 
-  assign op_status_done_we = addr_hit[19] & reg_we & ~wr_err;
+  assign op_status_done_we = addr_hit[27] & reg_we & ~wr_err;
   assign op_status_done_wd = reg_wdata[0];
 
-  assign op_status_err_we = addr_hit[19] & reg_we & ~wr_err;
+  assign op_status_err_we = addr_hit[27] & reg_we & ~wr_err;
   assign op_status_err_wd = reg_wdata[1];
 
 
@@ -3370,17 +4156,16 @@ module flash_ctrl_reg_top (
 
 
 
-
-  assign scratch_we = addr_hit[21] & reg_we & ~wr_err;
+  assign scratch_we = addr_hit[29] & reg_we & ~wr_err;
   assign scratch_wd = reg_wdata[31:0];
 
-  assign fifo_lvl_prog_we = addr_hit[22] & reg_we & ~wr_err;
+  assign fifo_lvl_prog_we = addr_hit[30] & reg_we & ~wr_err;
   assign fifo_lvl_prog_wd = reg_wdata[4:0];
 
-  assign fifo_lvl_rd_we = addr_hit[22] & reg_we & ~wr_err;
+  assign fifo_lvl_rd_we = addr_hit[30] & reg_we & ~wr_err;
   assign fifo_lvl_rd_wd = reg_wdata[12:8];
 
-  assign fifo_rst_we = addr_hit[23] & reg_we & ~wr_err;
+  assign fifo_rst_we = addr_hit[31] & reg_we & ~wr_err;
   assign fifo_rst_wd = reg_wdata[0];
 
   // Read data return
@@ -3445,7 +4230,6 @@ module flash_ctrl_reg_top (
         reg_rdata_next[3] = mp_region_cfg_0_erase_en_0_qs;
         reg_rdata_next[12:4] = mp_region_cfg_0_base_0_qs;
         reg_rdata_next[25:16] = mp_region_cfg_0_size_0_qs;
-        reg_rdata_next[28] = mp_region_cfg_0_partition_0_qs;
       end
 
       addr_hit[9]: begin
@@ -3455,7 +4239,6 @@ module flash_ctrl_reg_top (
         reg_rdata_next[3] = mp_region_cfg_1_erase_en_1_qs;
         reg_rdata_next[12:4] = mp_region_cfg_1_base_1_qs;
         reg_rdata_next[25:16] = mp_region_cfg_1_size_1_qs;
-        reg_rdata_next[28] = mp_region_cfg_1_partition_1_qs;
       end
 
       addr_hit[10]: begin
@@ -3465,7 +4248,6 @@ module flash_ctrl_reg_top (
         reg_rdata_next[3] = mp_region_cfg_2_erase_en_2_qs;
         reg_rdata_next[12:4] = mp_region_cfg_2_base_2_qs;
         reg_rdata_next[25:16] = mp_region_cfg_2_size_2_qs;
-        reg_rdata_next[28] = mp_region_cfg_2_partition_2_qs;
       end
 
       addr_hit[11]: begin
@@ -3475,7 +4257,6 @@ module flash_ctrl_reg_top (
         reg_rdata_next[3] = mp_region_cfg_3_erase_en_3_qs;
         reg_rdata_next[12:4] = mp_region_cfg_3_base_3_qs;
         reg_rdata_next[25:16] = mp_region_cfg_3_size_3_qs;
-        reg_rdata_next[28] = mp_region_cfg_3_partition_3_qs;
       end
 
       addr_hit[12]: begin
@@ -3485,7 +4266,6 @@ module flash_ctrl_reg_top (
         reg_rdata_next[3] = mp_region_cfg_4_erase_en_4_qs;
         reg_rdata_next[12:4] = mp_region_cfg_4_base_4_qs;
         reg_rdata_next[25:16] = mp_region_cfg_4_size_4_qs;
-        reg_rdata_next[28] = mp_region_cfg_4_partition_4_qs;
       end
 
       addr_hit[13]: begin
@@ -3495,7 +4275,6 @@ module flash_ctrl_reg_top (
         reg_rdata_next[3] = mp_region_cfg_5_erase_en_5_qs;
         reg_rdata_next[12:4] = mp_region_cfg_5_base_5_qs;
         reg_rdata_next[25:16] = mp_region_cfg_5_size_5_qs;
-        reg_rdata_next[28] = mp_region_cfg_5_partition_5_qs;
       end
 
       addr_hit[14]: begin
@@ -3505,7 +4284,6 @@ module flash_ctrl_reg_top (
         reg_rdata_next[3] = mp_region_cfg_6_erase_en_6_qs;
         reg_rdata_next[12:4] = mp_region_cfg_6_base_6_qs;
         reg_rdata_next[25:16] = mp_region_cfg_6_size_6_qs;
-        reg_rdata_next[28] = mp_region_cfg_6_partition_6_qs;
       end
 
       addr_hit[15]: begin
@@ -3515,49 +4293,103 @@ module flash_ctrl_reg_top (
         reg_rdata_next[3] = mp_region_cfg_7_erase_en_7_qs;
         reg_rdata_next[12:4] = mp_region_cfg_7_base_7_qs;
         reg_rdata_next[25:16] = mp_region_cfg_7_size_7_qs;
-        reg_rdata_next[28] = mp_region_cfg_7_partition_7_qs;
       end
 
       addr_hit[16]: begin
+        reg_rdata_next[0] = bank0_info_page_cfg_0_en_0_qs;
+        reg_rdata_next[1] = bank0_info_page_cfg_0_rd_en_0_qs;
+        reg_rdata_next[2] = bank0_info_page_cfg_0_prog_en_0_qs;
+        reg_rdata_next[3] = bank0_info_page_cfg_0_erase_en_0_qs;
+      end
+
+      addr_hit[17]: begin
+        reg_rdata_next[0] = bank0_info_page_cfg_1_en_1_qs;
+        reg_rdata_next[1] = bank0_info_page_cfg_1_rd_en_1_qs;
+        reg_rdata_next[2] = bank0_info_page_cfg_1_prog_en_1_qs;
+        reg_rdata_next[3] = bank0_info_page_cfg_1_erase_en_1_qs;
+      end
+
+      addr_hit[18]: begin
+        reg_rdata_next[0] = bank0_info_page_cfg_2_en_2_qs;
+        reg_rdata_next[1] = bank0_info_page_cfg_2_rd_en_2_qs;
+        reg_rdata_next[2] = bank0_info_page_cfg_2_prog_en_2_qs;
+        reg_rdata_next[3] = bank0_info_page_cfg_2_erase_en_2_qs;
+      end
+
+      addr_hit[19]: begin
+        reg_rdata_next[0] = bank0_info_page_cfg_3_en_3_qs;
+        reg_rdata_next[1] = bank0_info_page_cfg_3_rd_en_3_qs;
+        reg_rdata_next[2] = bank0_info_page_cfg_3_prog_en_3_qs;
+        reg_rdata_next[3] = bank0_info_page_cfg_3_erase_en_3_qs;
+      end
+
+      addr_hit[20]: begin
+        reg_rdata_next[0] = bank1_info_page_cfg_0_en_0_qs;
+        reg_rdata_next[1] = bank1_info_page_cfg_0_rd_en_0_qs;
+        reg_rdata_next[2] = bank1_info_page_cfg_0_prog_en_0_qs;
+        reg_rdata_next[3] = bank1_info_page_cfg_0_erase_en_0_qs;
+      end
+
+      addr_hit[21]: begin
+        reg_rdata_next[0] = bank1_info_page_cfg_1_en_1_qs;
+        reg_rdata_next[1] = bank1_info_page_cfg_1_rd_en_1_qs;
+        reg_rdata_next[2] = bank1_info_page_cfg_1_prog_en_1_qs;
+        reg_rdata_next[3] = bank1_info_page_cfg_1_erase_en_1_qs;
+      end
+
+      addr_hit[22]: begin
+        reg_rdata_next[0] = bank1_info_page_cfg_2_en_2_qs;
+        reg_rdata_next[1] = bank1_info_page_cfg_2_rd_en_2_qs;
+        reg_rdata_next[2] = bank1_info_page_cfg_2_prog_en_2_qs;
+        reg_rdata_next[3] = bank1_info_page_cfg_2_erase_en_2_qs;
+      end
+
+      addr_hit[23]: begin
+        reg_rdata_next[0] = bank1_info_page_cfg_3_en_3_qs;
+        reg_rdata_next[1] = bank1_info_page_cfg_3_rd_en_3_qs;
+        reg_rdata_next[2] = bank1_info_page_cfg_3_prog_en_3_qs;
+        reg_rdata_next[3] = bank1_info_page_cfg_3_erase_en_3_qs;
+      end
+
+      addr_hit[24]: begin
         reg_rdata_next[0] = default_region_rd_en_qs;
         reg_rdata_next[1] = default_region_prog_en_qs;
         reg_rdata_next[2] = default_region_erase_en_qs;
       end
 
-      addr_hit[17]: begin
+      addr_hit[25]: begin
         reg_rdata_next[0] = bank_cfg_regwen_qs;
       end
 
-      addr_hit[18]: begin
+      addr_hit[26]: begin
         reg_rdata_next[0] = mp_bank_cfg_erase_en_0_qs;
         reg_rdata_next[1] = mp_bank_cfg_erase_en_1_qs;
       end
 
-      addr_hit[19]: begin
+      addr_hit[27]: begin
         reg_rdata_next[0] = op_status_done_qs;
         reg_rdata_next[1] = op_status_err_qs;
       end
 
-      addr_hit[20]: begin
+      addr_hit[28]: begin
         reg_rdata_next[0] = status_rd_full_qs;
         reg_rdata_next[1] = status_rd_empty_qs;
         reg_rdata_next[2] = status_prog_full_qs;
         reg_rdata_next[3] = status_prog_empty_qs;
         reg_rdata_next[4] = status_init_wip_qs;
-        reg_rdata_next[16:8] = status_error_page_qs;
-        reg_rdata_next[17] = status_error_bank_qs;
+        reg_rdata_next[16:8] = status_error_addr_qs;
       end
 
-      addr_hit[21]: begin
+      addr_hit[29]: begin
         reg_rdata_next[31:0] = scratch_qs;
       end
 
-      addr_hit[22]: begin
+      addr_hit[30]: begin
         reg_rdata_next[4:0] = fifo_lvl_prog_qs;
         reg_rdata_next[12:8] = fifo_lvl_rd_qs;
       end
 
-      addr_hit[23]: begin
+      addr_hit[31]: begin
         reg_rdata_next[0] = fifo_rst_qs;
       end
 

--- a/hw/ip/flash_ctrl/rtl/flash_mp.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_mp.sv
@@ -17,6 +17,7 @@ module flash_mp import flash_ctrl_pkg::*; import flash_ctrl_reg_pkg::*; (
   // configuration from sw
   input flash_ctrl_reg2hw_mp_region_cfg_mreg_t [MpRegions:0] region_cfgs_i,
   input flash_ctrl_reg2hw_mp_bank_cfg_mreg_t [NumBanks-1:0] bank_cfgs_i,
+  input info_page_cfg_t [NumBanks-1:0][InfosPerBank-1:0] info_page_cfgs_i,
 
   // interface signals to/from *_ctrl
   input req_i,
@@ -59,7 +60,7 @@ module flash_mp import flash_ctrl_pkg::*; import flash_ctrl_reg_pkg::*; (
   assign page_addr = req_addr_i[PageW-1:0];
 
   // There could be multiple region matches due to region overlap
-  // region_end is +1 bit from however bits are needed to address regions
+  // region_end is +1 bit from however many bits are needed to address regions
   logic [AllPagesW:0] region_end[TotalRegions];
   logic [TotalRegions-1:0] region_match;
   logic [TotalRegions-1:0] region_sel;
@@ -67,12 +68,21 @@ module flash_mp import flash_ctrl_pkg::*; import flash_ctrl_reg_pkg::*; (
   logic [TotalRegions-1:0] prog_en;
   logic [TotalRegions-1:0] pg_erase_en;
   logic [NumBanks-1:0] bk_erase_en;
-  logic final_rd_en;
-  logic final_prog_en;
-  logic final_pg_erase_en;
-  logic final_bk_erase_en;
+  logic data_rd_en;
+  logic data_prog_en;
+  logic data_pg_erase_en;
+  logic data_bk_erase_en;
+  logic info_rd_en;
+  logic info_prog_en;
+  logic info_erase_en;
 
+  // TBD handle memory protection for hardware initiated transactions
+  logic hw_sel;
+
+  ////////////////////////////////////////
   // Check address out of bounds
+  // Applies for all partitions
+  ////////////////////////////////////////
   logic addr_invalid;
   logic bank_invalid;
   logic [PageW-1:0] end_addr;
@@ -91,11 +101,18 @@ module flash_mp import flash_ctrl_pkg::*; import flash_ctrl_reg_pkg::*; (
   // the bank selection is invalid
   // if the address overflowed the control counters
   assign end_addr = PartitionEndAddr[req_part_i];
-  assign addr_invalid = page_addr > end_addr |
-                        bank_invalid |
-                        addr_ovfl_i;
+  assign addr_invalid = req_i &
+                        (page_addr > end_addr |
+                         bank_invalid |
+                         addr_ovfl_i
+                        );
 
+  ////////////////////////////////////////
+  // Check data partition access
+  ////////////////////////////////////////
   // Lower indices always have priority
+  logic invalid_data_txn;
+
   assign region_sel[0] = region_match[0];
   for (genvar i = 1; i < TotalRegions; i++) begin: gen_region_priority
     assign region_sel[i] = region_match[i] & ~|region_match[i-1:0];
@@ -107,9 +124,8 @@ module flash_mp import flash_ctrl_pkg::*; import flash_ctrl_reg_pkg::*; (
       region_end[i] = {1'b0, region_cfgs_i[i].base.q} + region_cfgs_i[i].size.q;
 
       // region matches if address within range and if the partition matches
-      region_match[i] = bank_page_addr >= region_cfgs_i[i].base.q &
-                        {1'b0, bank_page_addr} < region_end[i] &
-                        req_part_i == region_cfgs_i[i].partition.q &
+      region_match[i] = (bank_page_addr >= region_cfgs_i[i].base.q) &
+                        ({1'b0, bank_page_addr} < region_end[i]) &
                         region_cfgs_i[i].en.q &
                         req_i;
 
@@ -123,48 +139,63 @@ module flash_mp import flash_ctrl_pkg::*; import flash_ctrl_reg_pkg::*; (
   // bank erase allowed for only data partition
   always_comb begin
     for (int unsigned i = 0; i < NumBanks; i++) begin: bank_comps
-      bk_erase_en[i] = (bank_addr == i) & bank_cfgs_i[i].q &
-                       (req_part_i == FlashPartData);
+      bk_erase_en[i] = (bank_addr == i) & bank_cfgs_i[i].q;
     end
   end
 
-  logic invalid_info_erase, invalid_info_txn;
+  assign data_rd_en = rd_i & |rd_en;
+  assign data_prog_en = prog_i & |prog_en;
+  assign data_pg_erase_en = pg_erase_i & |pg_erase_en;
+  assign data_bk_erase_en = bk_erase_i & |bk_erase_en;
 
-  // bank erase cannot be issued to info page
-  assign invalid_info_erase  = req_i & bk_erase_i &
-                               (req_part_i == FlashPartInfo);
+  // temporarily suppress errors on the hardware interface
+  assign invalid_data_txn = req_i & req_part_i == FlashPartData & ~hw_sel &
+                            ~(data_rd_en |
+                              data_prog_en |
+                              data_pg_erase_en |
+                              data_bk_erase_en
+                             );
 
-  assign invalid_info_txn    = invalid_info_erase;
+  ////////////////////////////////////////
+  // Check info partition access
+  ////////////////////////////////////////
+  logic [InfoPageW-1:0] info_page_addr;
+  info_page_cfg_t page_cfg;
+  logic info_en;
+  logic invalid_info_txn;
+
+  assign info_page_addr = req_addr_i[InfoPageW-1:0];
+  assign page_cfg = info_page_cfgs_i[bank_addr][info_page_addr];
+
+  assign info_en = page_cfg.en.q;
+  assign info_rd_en = info_en & rd_i & page_cfg.rd_en.q;
+  assign info_prog_en = info_en & prog_i & page_cfg.prog_en.q;
+  assign info_erase_en = info_en & pg_erase_i & page_cfg.erase_en.q;
+
+  assign invalid_info_txn = req_i & req_part_i == FlashPartInfo & ~hw_sel &
+                            ~(info_rd_en | info_prog_en | info_erase_en);
 
 
-  assign final_rd_en = rd_i & |rd_en;
-  assign final_prog_en = prog_i & |prog_en;
-  assign final_pg_erase_en = pg_erase_i & |pg_erase_en;
-  assign final_bk_erase_en = bk_erase_i & |bk_erase_en;
-
+  ////////////////////////////////////////
+  // Combine all check results
+  ////////////////////////////////////////
   // TBD properly account for hardware interface later
   // right now, hardwire transaction to go through
-  logic hw_sel;
   logic hw_rd_en;
   logic hw_erase_en;
   assign hw_sel = if_sel_i == HwSel;
   assign hw_rd_en = rd_i & hw_sel;
   assign hw_erase_en = pg_erase_i & hw_sel;
 
-  assign rd_o = req_i & (final_rd_en | hw_rd_en);
-  assign prog_o = req_i & final_prog_en;
-  assign pg_erase_o = req_i & (final_pg_erase_en | hw_erase_en);
-  assign bk_erase_o = req_i & final_bk_erase_en;
+  assign rd_o = req_i & (data_rd_en | info_rd_en | hw_rd_en);
+  assign prog_o = req_i & data_prog_en;
+  assign pg_erase_o = req_i & (data_pg_erase_en | info_erase_en | hw_erase_en);
+  assign bk_erase_o = req_i & data_bk_erase_en;
   assign req_o = rd_o | prog_o | pg_erase_o | bk_erase_o;
 
   logic txn_err;
-  logic txn_ens;
   logic no_allowed_txn;
-  assign txn_ens = final_rd_en | final_prog_en | final_pg_erase_en | final_bk_erase_en;
-  // if incoming address overflowed or is invalid or no transaction enables, error back
-  // TBD: for now, when if_sel == HwSel, then transaction attributes are not checked.
-  // This should eventually be updated to hw interface specific checks.
-  assign no_allowed_txn = req_i & (addr_invalid | invalid_info_txn | ~txn_ens & ~hw_sel);
+  assign no_allowed_txn = req_i & (addr_invalid | invalid_data_txn | invalid_info_txn);
 
   // return done and error the next cycle
   always_ff @(posedge clk_i or negedge rst_ni) begin
@@ -193,5 +224,7 @@ module flash_mp import flash_ctrl_pkg::*; import flash_ctrl_reg_pkg::*; (
   `ASSERT(bkEraseEnOnehot_a, (req_o & bk_erase_o) |-> $onehot(bk_erase_en))
   // Requests can only happen one at a time
   `ASSERT(requestTypesOnehot_a, req_o |-> $onehot({rd_o, prog_o, pg_erase_o, bk_erase_o}))
+  // Info / data errors are mutually exclusive
+  `ASSERT(invalidReqOnehot_a, req_o |-> $onehot0({invalid_data_txn, invalid_info_txn}))
 
 endmodule // flash_erase_ctrl

--- a/hw/ip/flash_ctrl/rtl/flash_mp.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_mp.sv
@@ -7,13 +7,7 @@
 
 `include "prim_assert.sv"
 
-module flash_mp import flash_ctrl_pkg::*; import flash_ctrl_reg_pkg::*; #(
-  parameter int MpRegions = 8,
-  parameter int NumBanks = 2,
-  parameter int AllPagesW = 16,
-  localparam int TotalRegions = MpRegions+1,
-  localparam int BankW = $clog2(NumBanks)
-) (
+module flash_mp import flash_ctrl_pkg::*; import flash_ctrl_reg_pkg::*; (
   input clk_i,
   input rst_ni,
 
@@ -21,7 +15,7 @@ module flash_mp import flash_ctrl_pkg::*; import flash_ctrl_reg_pkg::*; #(
   input flash_sel_e if_sel_i,
 
   // configuration from sw
-  input flash_ctrl_reg2hw_mp_region_cfg_mreg_t [TotalRegions-1:0] region_cfgs_i,
+  input flash_ctrl_reg2hw_mp_region_cfg_mreg_t [MpRegions:0] region_cfgs_i,
   input flash_ctrl_reg2hw_mp_bank_cfg_mreg_t [NumBanks-1:0] bank_cfgs_i,
 
   // interface signals to/from *_ctrl
@@ -53,6 +47,8 @@ module flash_mp import flash_ctrl_pkg::*; import flash_ctrl_reg_pkg::*; #(
 
 );
 
+  // Total number of regions including default region
+  localparam int TotalRegions = MpRegions+1;
 
   // Address range checks
   localparam int LastValidInfoPage = InfosPerBank - 1;

--- a/hw/top_earlgrey/rtl/top_pkg.sv
+++ b/hw/top_earlgrey/rtl/top_pkg.sv
@@ -15,7 +15,6 @@ localparam int TL_SZW=$clog2($clog2(TL_DBW)+1);
 localparam int FLASH_BANKS=2;
 localparam int FLASH_PAGES_PER_BANK=256;
 localparam int FLASH_WORDS_PER_PAGE=128;
-localparam int FLASH_BYTES_PER_WORD=TL_DBW;
 localparam int FLASH_INFO_PER_BANK=4;
 localparam int FLASH_DATA_WIDTH=64;
 localparam int NUM_AST_ALERTS=7;

--- a/sw/device/lib/flash_ctrl.c
+++ b/sw/device/lib/flash_ctrl.c
@@ -150,14 +150,33 @@ void flash_default_region_access(bool rd_en, bool prog_en, bool erase_en) {
 }
 
 void flash_cfg_region(const mp_region_t *region_cfg) {
-  REG32(FLASH_CTRL_MP_REGION_CFG_0(0) + region_cfg->num * 4) =
-      region_cfg->base << FLASH_CTRL_MP_REGION_CFG_0_BASE_0_OFFSET |
-      region_cfg->size << FLASH_CTRL_MP_REGION_CFG_0_SIZE_0_OFFSET |
-      region_cfg->part << FLASH_CTRL_MP_REGION_CFG_0_PARTITION_0 |
-      region_cfg->rd_en << FLASH_CTRL_MP_REGION_CFG_0_RD_EN_0 |
-      region_cfg->prog_en << FLASH_CTRL_MP_REGION_CFG_0_PROG_EN_0 |
-      region_cfg->erase_en << FLASH_CTRL_MP_REGION_CFG_0_ERASE_EN_0 |
-      0x1 << FLASH_CTRL_MP_REGION_CFG_0_EN_0;
+  uint32_t reg_value;
+  bank_index_t bank_sel;
+
+  if (region_cfg->part == kDataPartition) {
+    REG32(FLASH_CTRL_MP_REGION_CFG_0(0) + region_cfg->num * 4) =
+        region_cfg->base << FLASH_CTRL_MP_REGION_CFG_0_BASE_0_OFFSET |
+        region_cfg->size << FLASH_CTRL_MP_REGION_CFG_0_SIZE_0_OFFSET |
+        region_cfg->rd_en << FLASH_CTRL_MP_REGION_CFG_0_RD_EN_0 |
+        region_cfg->prog_en << FLASH_CTRL_MP_REGION_CFG_0_PROG_EN_0 |
+        region_cfg->erase_en << FLASH_CTRL_MP_REGION_CFG_0_ERASE_EN_0 |
+        0x1 << FLASH_CTRL_MP_REGION_CFG_0_EN_0;
+  } else if (region_cfg->part == kInfoPartition) {
+    reg_value =
+        region_cfg->rd_en << FLASH_CTRL_BANK0_INFO_PAGE_CFG_0_RD_EN_0 |
+        region_cfg->prog_en << FLASH_CTRL_BANK0_INFO_PAGE_CFG_0_PROG_EN_0 |
+        region_cfg->erase_en << FLASH_CTRL_BANK0_INFO_PAGE_CFG_0_ERASE_EN_0 |
+        0x1 << FLASH_CTRL_BANK0_INFO_PAGE_CFG_0_EN_0;
+
+    bank_sel = region_cfg->base / FLASH_PAGES_PER_BANK;
+    if (bank_sel == FLASH_BANK_0) {
+      REG32(FLASH_CTRL_BANK0_INFO_PAGE_CFG_0(0) + region_cfg->num * 4) =
+          reg_value;
+    } else {
+      REG32(FLASH_CTRL_BANK1_INFO_PAGE_CFG_0(0) + region_cfg->num * 4) =
+          reg_value;
+    }
+  }
 }
 
 void flash_write_scratch_reg(uint32_t value) {

--- a/sw/device/lib/flash_ctrl.h
+++ b/sw/device/lib/flash_ctrl.h
@@ -31,9 +31,12 @@ typedef enum partition_type {
 
 /**
  * Memory protection configuration options.
+ * Data partitions and Info partitions are handled differently.
  */
 typedef struct mp_region {
-  /** Which region to program. */
+  /** Which region to program for data partition.
+      Which page to program for info partition.
+   */
   uint32_t num;
   /** Region offset. */
   uint32_t base;


### PR DESCRIPTION
This PR really should be split into two. (I can do that if people think it's easier to review).

The first 3 commits are just flash control cleanup.  Most importantly, the parameter usage is cleaned up a bit to avoid confusion.  Instead of passing them in, they now directly reference the package file.

The remaining commits update flash's memory protection scheme as follows

- Each info page now has its own set of controls, and are not directly controlled by the memory protection regions
- The memory protection module is also updated to more flexibly detect whether a transaction has accessed beyond the maximum range (since each partition has a different end address).

The flash_ctrl files are updated to reflect the change.  The changes are not very elegant, but since there is a DIF ongoing, I didn't think these mattered a whole lot.  

This PR is yet another example that flash_ctrl needs to be templated.  Since we do not have nested multi-reg support right now, the register controls for info pages are duplicated for each bank separately.  This will get worse in the future when I introduce the concept of different kinds of info partitions. 

A separate PR will update the documentation to match. 