### PR TITLE
[pwrmgr, clkmgr] Feedback clock status to power manager

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr.sv.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.sv.tpl
@@ -103,8 +103,13 @@ module clkmgr import clkmgr_pkg::*; (
   // Root gating
   ////////////////////////////////////////////////////
 
-  logic async_roots_en;
-  logic roots_en_q2, roots_en_q1, roots_en_d;
+  logic wait_enable;
+  logic wait_disable;
+  logic en_status_d;
+  logic dis_status_d;
+  logic [1:0] en_status_q;
+  logic [1:0] dis_status_q;
+  logic clk_status;
 % for src in rg_srcs:
   logic clk_${src}_root;
   logic clk_${src}_en;
@@ -121,8 +126,20 @@ module clkmgr import clkmgr_pkg::*; (
   );
 % endfor
 
+  // an async AND of all the synchronized enables
+  // return feedback to pwrmgr only when all clocks are enabled
+  assign wait_enable =
+% for src in rg_srcs:
+    % if loop.last:
+    clk_${src}_en;
+    % else:
+    clk_${src}_en &
+    % endif
+% endfor
+
   // an async OR of all the synchronized enables
-  assign async_roots_en =
+  // return feedback to pwrmgr only when all clocks are disabled
+  assign wait_disable =
 % for src in rg_srcs:
     % if loop.last:
     clk_${src}_en;
@@ -131,32 +148,45 @@ module clkmgr import clkmgr_pkg::*; (
     % endif
 % endfor
 
-  // Sync the OR back into clkmgr domain for feedback to pwrmgr.
+  // Sync clkmgr domain for feedback to pwrmgr.
   // Since the signal is combo / converged on the other side, de-bounce
   // the signal prior to output
   prim_flop_2sync #(
     .Width(1)
-  ) u_roots_en_sync (
+  ) u_roots_en_status_sync (
     .clk_i,
     .rst_ni,
-    .d_i(async_roots_en),
-    .q_o(roots_en_d)
+    .d_i(wait_enable),
+    .q_o(en_status_d)
+  );
+
+  prim_flop_2sync #(
+    .Width(1)
+  ) u_roots_or_sync (
+    .clk_i,
+    .rst_ni,
+    .d_i(wait_disable),
+    .q_o(dis_status_d)
   );
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      roots_en_q1 <= 1'b0;
-      roots_en_q2 <= 1'b0;
+      en_status_q <= '0;
+      dis_status_q <= '0;
+      clk_status <= '0;
     end else begin
-      roots_en_q1 <= roots_en_d;
+      en_status_q <= {en_status_q[0], en_status_d};
+      dis_status_q <= {dis_status_q[0], dis_status_d};
 
-      if (roots_en_q1 == roots_en_d) begin
-        roots_en_q2 <= roots_en_q1;
+      if (&en_status_q) begin
+        clk_status <= 1'b1;
+      end else if (|dis_status_q == '0) begin
+        clk_status <= 1'b0;
       end
     end
   end
 
-  assign pwr_o.roots_en = roots_en_q2;
+  assign pwr_o.clk_status = clk_status;
 
   ////////////////////////////////////////////////////
   // Clocks with only root gate

--- a/hw/ip/pwrmgr/rtl/pwrmgr.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr.sv
@@ -278,6 +278,7 @@ module pwrmgr import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;
 
     // clkmgr
     .ips_clk_en_o      (pwr_clk_o.ip_clk_en),
+    .clk_en_status_i   (pwr_clk_i.clk_status),
 
     // otp
     .otp_init_o        (pwr_otp_o.otp_init),

--- a/hw/ip/pwrmgr/rtl/pwrmgr_fsm.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_fsm.sv
@@ -35,6 +35,7 @@ module pwrmgr_fsm import pwrmgr_pkg::*; (
 
   // clkmgr
   output logic ips_clk_en_o,
+  input clk_en_status_i,
 
   // otp
   output logic otp_init_o,
@@ -108,7 +109,6 @@ module pwrmgr_fsm import pwrmgr_pkg::*; (
   assign reset_valid = reset_cause_q == LowPwrEntry ? main_pd_ni | pd_n_rsts_asserted :
                        reset_cause_q == HwReq       ? all_rsts_asserted : 1'b0;
 
-
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       state_q <= StLowPower;
@@ -161,7 +161,7 @@ module pwrmgr_fsm import pwrmgr_pkg::*; (
       StEnableClocks: begin
         ip_clk_en_d = 1'b1;
 
-        if (1'b1) begin // TODO, add a feedback signal to check clocks are enabled
+        if (clk_en_status_i) begin
           state_d = StReleaseLcRst;
         end
       end
@@ -218,7 +218,7 @@ module pwrmgr_fsm import pwrmgr_pkg::*; (
       StDisClks: begin
         ip_clk_en_d = 1'b0;
 
-        if (1'b1) begin // TODO, add something to check that clocks are disabled
+        if (!clk_en_status_i) begin
           state_d = reset_req_i ? StNvmShutDown : StFallThrough;
           wkup_record_o = !reset_req_i;
         end

--- a/hw/ip/pwrmgr/rtl/pwrmgr_pkg.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_pkg.sv
@@ -83,7 +83,7 @@ package pwrmgr_pkg;
 
   // clkmgr to powrmgr
   typedef struct packed {
-    logic roots_en;
+    logic clk_status;
   } pwr_clk_rsp_t;
 
   // pwrmgr to otp

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
@@ -111,8 +111,13 @@ module clkmgr import clkmgr_pkg::*; (
   // Root gating
   ////////////////////////////////////////////////////
 
-  logic async_roots_en;
-  logic roots_en_q2, roots_en_q1, roots_en_d;
+  logic wait_enable;
+  logic wait_disable;
+  logic en_status_d;
+  logic dis_status_d;
+  logic [1:0] en_status_q;
+  logic [1:0] dis_status_q;
+  logic clk_status;
   logic clk_main_root;
   logic clk_main_en;
   logic clk_io_root;
@@ -165,40 +170,63 @@ module clkmgr import clkmgr_pkg::*; (
     .clk_o(clk_io_div4_root)
   );
 
+  // an async AND of all the synchronized enables
+  // return feedback to pwrmgr only when all clocks are enabled
+  assign wait_enable =
+    clk_main_en &
+    clk_io_en &
+    clk_usb_en &
+    clk_io_div2_en &
+    clk_io_div4_en;
+
   // an async OR of all the synchronized enables
-  assign async_roots_en =
+  // return feedback to pwrmgr only when all clocks are disabled
+  assign wait_disable =
     clk_main_en |
     clk_io_en |
     clk_usb_en |
     clk_io_div2_en |
     clk_io_div4_en;
 
-  // Sync the OR back into clkmgr domain for feedback to pwrmgr.
+  // Sync clkmgr domain for feedback to pwrmgr.
   // Since the signal is combo / converged on the other side, de-bounce
   // the signal prior to output
   prim_flop_2sync #(
     .Width(1)
-  ) u_roots_en_sync (
+  ) u_roots_en_status_sync (
     .clk_i,
     .rst_ni,
-    .d_i(async_roots_en),
-    .q_o(roots_en_d)
+    .d_i(wait_enable),
+    .q_o(en_status_d)
+  );
+
+  prim_flop_2sync #(
+    .Width(1)
+  ) u_roots_or_sync (
+    .clk_i,
+    .rst_ni,
+    .d_i(wait_disable),
+    .q_o(dis_status_d)
   );
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      roots_en_q1 <= 1'b0;
-      roots_en_q2 <= 1'b0;
+      en_status_q <= '0;
+      dis_status_q <= '0;
+      clk_status <= '0;
     end else begin
-      roots_en_q1 <= roots_en_d;
+      en_status_q <= {en_status_q[0], en_status_d};
+      dis_status_q <= {dis_status_q[0], dis_status_d};
 
-      if (roots_en_q1 == roots_en_d) begin
-        roots_en_q2 <= roots_en_q1;
+      if (&en_status_q) begin
+        clk_status <= 1'b1;
+      end else if (|dis_status_q == '0) begin
+        clk_status <= 1'b0;
       end
     end
   end
 
-  assign pwr_o.roots_en = roots_en_q2;
+  assign pwr_o.clk_status = clk_status;
 
   ////////////////////////////////////////////////////
   // Clocks with only root gate


### PR DESCRIPTION
The current state of the root clock enables are fed back to power manager from clock manager.

When the enables are all 1's, it is considered enabled.
When the enables are all 0's, it is considered disabled. 

All mixed state will maintain the previous value. 