### PR TITLE
[dv/aes] connect alert_agent to AES testbench

### DIFF
--- a/hw/ip/aes/dv/env/aes_env_cfg.sv
+++ b/hw/ip/aes/dv/env/aes_env_cfg.sv
@@ -113,8 +113,9 @@ class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block));
     this.csr_addr_map_size = AES_ADDR_MAP_SIZE;
   endfunction : initialize_csr_addr_map_size
 
-  virtual   function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);
+  virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);
     super.initialize(csr_base_addr);
+    list_of_alerts = aes_env_pkg::LIST_OF_ALERTS;
   endfunction
 
 endclass

--- a/hw/ip/aes/dv/env/aes_env_pkg.sv
+++ b/hw/ip/aes/dv/env/aes_env_pkg.sv
@@ -21,8 +21,9 @@ package aes_env_pkg;
   `include "dv_macros.svh"
 
   // parameters
-
-  parameter uint AES_ADDR_MAP_SIZE      = 128;
+  parameter string LIST_OF_ALERTS[] = {"ctrl_err_update", "ctrl_err_storage"};
+  parameter uint NUM_ALERTS = 2;
+  parameter uint AES_ADDR_MAP_SIZE  = 128;
 
   typedef enum int { AES_CFG=0, AES_DATA=1, AES_ERR_INJ=2 } aes_item_type_e;
 

--- a/hw/ip/aes/dv/tb/tb.sv
+++ b/hw/ip/aes/dv/tb/tb.sv
@@ -16,9 +16,9 @@ module tb;
   wire clk, rst_n;
   wire devmode;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
-  prim_alert_pkg::alert_rx_t [aes_reg_pkg::NumAlerts-1:0] alert_rx;
-  assign alert_rx[0] = 4'b0101;
-  assign alert_rx[1] = 4'b0101;
+  alert_esc_if alert_if[NUM_ALERTS](.clk(clk), .rst_n(rst_n));
+  prim_alert_pkg::alert_rx_t [NUM_ALERTS-1:0] alert_rx;
+  prim_alert_pkg::alert_tx_t [NUM_ALERTS-1:0] alert_tx;
 
   // interfaces
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
@@ -26,6 +26,15 @@ module tb;
 
   pins_if #(1) devmode_if(devmode);
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
+
+  for (genvar k = 0; k < NUM_ALERTS; k++) begin : connect_alerts_pins
+    assign alert_rx[k] = alert_if[k].alert_rx;
+    assign alert_if[k].alert_tx = alert_tx[k];
+    initial begin
+      uvm_config_db#(virtual alert_esc_if)::set(null, $sformatf("*.env.m_alert_agent_%0s",
+          LIST_OF_ALERTS[k]), "vif", alert_if[k]);
+    end
+  end
 
   // dut
   aes dut (
@@ -38,7 +47,7 @@ module tb;
     .tl_o                 (tl_if.d2h  ),
 
     .alert_rx_i           ( alert_rx  ),
-    .alert_tx_o           (           )
+    .alert_tx_o           ( alert_tx  )
   );
 
   initial begin


### PR DESCRIPTION
Connect alert_esc_agent to drive alert_rx responses when alert
triggered.

This is all the code needed to plug in alert receivers in a IP. If
reviewers are okay with the flow, next PR will update the uvmgen to
automatically genenrate the code as much as possible.

Signed-off-by: Cindy Chen <chencindy@google.com>