### PR TITLE
Tidy-ups in dvsim.py command line handling and wildcard substitution

### DIFF
--- a/util/dvsim/FlowCfg.py
+++ b/util/dvsim/FlowCfg.py
@@ -24,9 +24,6 @@ class FlowCfg():
     def __str__(self):
         return pprint.pformat(self.__dict__)
 
-    def __repr__(self):
-        return pprint.pformat(self.__dict__)
-
     def __init__(self, flow_cfg_file, proj_root, args):
         # Options set from command line
         self.items = args.items

--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -146,11 +146,11 @@ def make_config(args, proj_root):
     # the tool by reading the config file. At the moment, this forces a
     # simulation target (TODO?)
     factories = {
-        'ascentlint'  : LintCfg.LintCfg,
-        'veriblelint' : LintCfg.LintCfg,
-        'verilator'   : LintCfg.LintCfg,
-        'dc'          : SynCfg.SynCfg,
-        'jaspergold'  : FpvCfg.FpvCfg
+        'ascentlint': LintCfg.LintCfg,
+        'veriblelint': LintCfg.LintCfg,
+        'verilator': LintCfg.LintCfg,
+        'dc': SynCfg.SynCfg,
+        'jaspergold': FpvCfg.FpvCfg
     }
 
     factory = factories.get(args.tool, SimCfg.SimCfg)


### PR DESCRIPTION
These tidy-ups were spurred by issue #3322. The last patch "fixes" things for that (improving the error message from completely inscrutable to just slightly confusing). The other patches are assorted tidy-ups that I made while trying to trace my way through what was going on.

The big change to `subst_wildcards` was in a previous PR (#2458), which seems to have been completely ignored. I'm re-proposing it here, because it's a heck of a lot easier to follow the code, and it already supports the functionality that was added a couple of months later in commit `dba5d79` (I wish I'd noticed when this PR came up!)