### PR TITLE
[otbn] Fix register naming in BN.SID

### DIFF
--- a/hw/ip/otbn/data/bignum-insns.yml
+++ b/hw/ip/otbn/data/bignum-insns.yml
@@ -828,7 +828,7 @@
         Increment the value in `<grs2>` by one.
         Cannot be specified together with `grs1_inc`.
   syntax: |
-    <grs1>[<grs1_inc>], <offset>(<grs2>[<grs2_inc>])
+    <grs2>[<grs2_inc>], <offset>(<grs1>[<grs1_inc>])
   doc: |
     Calculates a byte memory address by adding the offset to the value in the GPR `grs1`.
     The value from the WDR pointed to by `grs2` is then copied into the memory.


### PR DESCRIPTION
`grs1` is always the memory address, and always the second item in the
assembly (as in RISC-V). Fix the assembly syntax to match the
description.