### PR TITLE
[dv] Fix up prototype of dv_base_reg_block::build

### DIFF
--- a/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
@@ -13,8 +13,7 @@ class dv_base_reg_block extends uvm_reg_block;
   endfunction
 
   // provide build function to supply base addr
-  virtual function void build(uvm_reg_addr_t base_addr,
-                              csr_excl_item csr_excl = null);
+  virtual function void build(uvm_reg_addr_t base_addr, csr_excl_item csr_excl);
     `uvm_fatal(`gfn, "this method is not supposed to be called directly!")
   endfunction
 

--- a/hw/ip/nmi_gen/dv/env/nmi_gen_reg_block.sv
+++ b/hw/ip/nmi_gen/dv/env/nmi_gen_reg_block.sv
@@ -227,7 +227,7 @@ class nmi_gen_reg_block extends dv_base_reg_block;
     super.new(name, has_coverage);
   endfunction : new
 
-  virtual function void build(uvm_reg_addr_t base_addr);
+  virtual function void build(uvm_reg_addr_t base_addr, csr_excl_item csr_excl);
     // create default map
     this.default_map = create_map(.name("default_map"),
                                   .base_addr(base_addr),

--- a/hw/ip/rv_dm/dv/env/rv_dm_reg_block.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_reg_block.sv
@@ -9,7 +9,7 @@ class rv_dm_reg_block extends dv_base_reg_block;
     super.new(name, has_coverage);
   endfunction : new
 
-  virtual function void build(uvm_reg_addr_t base_addr);
+  virtual function void build(uvm_reg_addr_t base_addr, csr_excl_item csr_excl);
     `uvm_info(`gfn, "no-ral", UVM_LOW)
   endfunction : build
 

--- a/util/reggen/uvm_reg.sv.tpl
+++ b/util/reggen/uvm_reg.sv.tpl
@@ -193,8 +193,7 @@ package ${block.name}_ral_pkg;
       super.new(name, has_coverage);
     endfunction : new
 
-    virtual function void build(uvm_reg_addr_t base_addr,
-                                csr_excl_item csr_excl = null);
+    virtual function void build(uvm_reg_addr_t base_addr, csr_excl_item csr_excl);
       // create default map
       this.default_map = create_map(.name("default_map"),
                                     .base_addr(base_addr),


### PR DESCRIPTION
This gained a "csr_excl" parameter in commit 85aca77, but we forgot to
update all deriving classes to have the same prototype. VCS seems to
allow us to be slapdash like this, but Xcelium shouted. We "fixed"
that by giving the base class implementation a default argument in
commit 1b1f2ec. This shut Xcelium up, but seems not to actually follow
the IEEE 1800-2017 standard (see section 8.20 "Virtual methods").

This patch removes the default value from csr_excl (since it didn't
help anyway, we may as well remove the magic) and fixes up the
deriving classes.

See discussion in issue #3300.