### PR TITLE
[dv/common] TLUL same cycle response

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
@@ -32,6 +32,8 @@ class cip_base_env_cfg #(type RAL_T = dv_base_reg_block) extends dv_base_env_cfg
     // create tl agent config obj
     m_tl_agent_cfg = tl_agent_cfg::type_id::create("m_tl_agent_cfg");
     m_tl_agent_cfg.if_mode = dv_utils_pkg::Host;
+    // host can't support device same cycle response and host may drive d_ready=0 when a_valid=1
+    m_tl_agent_cfg.host_can_stall_rsp_when_a_valid_high = $urandom_range(0, 1);
   endfunction
 
 endclass

--- a/hw/dv/sv/tl_agent/seq_lib/tl_host_seq.sv
+++ b/hw/dv/sv/tl_agent/seq_lib/tl_host_seq.sv
@@ -50,10 +50,10 @@ class tl_host_seq extends dv_base_seq #(.REQ        (tl_seq_item),
           pre_start_item(req);
           start_item(req);
           randomize_req(req, i);
+          pending_req.push_back(req); // in case of device same cycle response
           finish_item(req);
           `uvm_info(`gfn, $sformatf("Sent req[%0d] : %0s",
                                      i, req.convert2string()), UVM_HIGH)
-          pending_req.push_back(req);
         end
       end : request_thread
     join

--- a/hw/dv/sv/tl_agent/tl_agent.sv
+++ b/hw/dv/sv/tl_agent/tl_agent.sv
@@ -31,7 +31,11 @@ class tl_agent extends dv_base_agent#(
   function void connect_phase(uvm_phase phase);
     super.connect_phase(phase);
     if (cfg.if_mode == dv_utils_pkg::Device) begin
-      monitor.a_chan_port.connect(sequencer.a_chan_req_fifo.analysis_export);
+      if (cfg.device_can_rsp_on_same_cycle) begin
+        monitor.a_chan_same_cycle_rsp_port.connect(sequencer.a_chan_req_fifo.analysis_export);
+      end else begin
+        monitor.a_chan_port.connect(sequencer.a_chan_req_fifo.analysis_export);
+      end
     end
   endfunction
 endclass : tl_agent

--- a/hw/dv/sv/tl_agent/tl_agent_cfg.sv
+++ b/hw/dv/sv/tl_agent/tl_agent_cfg.sv
@@ -40,6 +40,16 @@ class tl_agent_cfg extends dv_base_agent_cfg;
   int unsigned d_valid_delay_min = 0;
   int unsigned d_valid_delay_max = 10;
 
+  // TL spec requires host to set d_ready = 1 when a_valid = 1, but some design may not follow this
+  // rule. Details at #3208. Use below knob to control
+  bit host_can_stall_rsp_when_a_valid_high = 0;
+  // knob for device to enable/disable same cycle response
+  bit device_can_rsp_on_same_cycle = 0;
+  // for same cycle response, need to know when a_valid and other data/control are available, so
+  // that monitor can sample it, then send to sequence to get data for response in the same cycle
+  // 10 means 10% of TL clock period. This var is only use when device_can_rsp_on_same_cycle = 1
+  time time_a_valid_avail_after_sample_edge = 1ns;
+
   `uvm_object_utils_begin(tl_agent_cfg)
     `uvm_field_int(max_outstanding_req,   UVM_DEFAULT)
     `uvm_field_enum(tl_level_e, tl_level, UVM_DEFAULT)

--- a/hw/dv/sv/tl_agent/tl_device_driver.sv
+++ b/hw/dv/sv/tl_agent/tl_device_driver.sv
@@ -63,15 +63,15 @@ class tl_device_driver extends tl_base_driver;
         else @(cfg.vif.device_cb);
       end
       if (cfg.vif.rst_n) begin
-        cfg.vif.device_cb.d2h_int.d_valid  <= 1'b1;
-        cfg.vif.device_cb.d2h_int.d_opcode <= tl_d_op_e'(rsp.d_opcode);
-        cfg.vif.device_cb.d2h_int.d_data   <= rsp.d_data;
-        cfg.vif.device_cb.d2h_int.d_source <= rsp.d_source;
-        cfg.vif.device_cb.d2h_int.d_param  <= rsp.d_param;
-        cfg.vif.device_cb.d2h_int.d_error  <= rsp.d_error;
-        cfg.vif.device_cb.d2h_int.d_sink   <= rsp.d_sink;
-        cfg.vif.device_cb.d2h_int.d_user   <= rsp.d_user;
-        cfg.vif.device_cb.d2h_int.d_size   <= rsp.d_size;
+        cfg.vif.d2h_int.d_valid  <= 1'b1;
+        cfg.vif.d2h_int.d_opcode <= tl_d_op_e'(rsp.d_opcode);
+        cfg.vif.d2h_int.d_data   <= rsp.d_data;
+        cfg.vif.d2h_int.d_source <= rsp.d_source;
+        cfg.vif.d2h_int.d_param  <= rsp.d_param;
+        cfg.vif.d2h_int.d_error  <= rsp.d_error;
+        cfg.vif.d2h_int.d_sink   <= rsp.d_sink;
+        cfg.vif.d2h_int.d_user   <= rsp.d_user;
+        cfg.vif.d2h_int.d_size   <= rsp.d_size;
         // bypass delay in case of reset
         @(cfg.vif.device_cb);
       end

--- a/hw/ip/tlul/generic_dv/env/xbar_env_cfg.sv
+++ b/hw/ip/tlul/generic_dv/env/xbar_env_cfg.sv
@@ -45,6 +45,7 @@ class xbar_env_cfg extends dv_base_env_cfg;
                           create($sformatf("%0s_agent_cfg", xbar_hosts[i].host_name));
       host_agent_cfg[i].if_mode = dv_utils_pkg::Host;
       host_agent_cfg[i].max_outstanding_req = 1 << valid_host_id_width;
+      host_agent_cfg[i].host_can_stall_rsp_when_a_valid_high = $urandom_range(0, 1);
     end
     // Device TL agent cfg
     num_devices      = xbar_devices.size();


### PR DESCRIPTION
As discussed #3208, add 2 knobs and supports in TLUL agent
1. support_device_same_cycle_response, device may respond d_valid in the
same cycle as a_valid. This is turned off in opentitan
2. support_a_valid_high_d_ready_low, spec requires d_ready=1 when
a_valid=1, Add this knob as our design doesn't obey this rule. This knob
is randomized

This PR won't change current TLUL behavior but only increase the chance of
`a_valid=1 & d_ready=1`.

Signed-off-by: Weicai Yang <weicai@google.com>