### PR TITLE
[dv/hmac] fix regression failure

### DIFF
--- a/hw/ip/hmac/dv/env/seq_lib/hmac_sanity_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_sanity_vseq.sv
@@ -104,9 +104,16 @@ class hmac_sanity_vseq extends hmac_base_vseq;
         // msg stream in finished, start hash
         if (do_hash_start) trigger_process();
 
-        // there is one clk cycle differenct for scb to predict fifo_empty interrupt, thus wait to
-        // ignore the difference.
-        cfg.clk_rst_vif.wait_clks(HMAC_KEY_PROCESS_CYCLES);
+        // there is one clk cycle difference between scb and design when predict fifo_empty,
+        // it could happen when input message length is not a multiple of 4, then in design
+        // the `sha2_pad.st_q` will transit from `StFifoReceive` to `StPad80`.
+        // If the last two fifo_rds are back-to-back, then design will have one cycle delay before
+        // the last fifo_rd in order to switch the state.
+        // If the last two fifo_rds are not back-to-back, then there won't be any delay for the
+        // last fifo_rd
+        // the wait_clk below is implemented to avoid checking intr_state during this corner case
+        cfg.clk_rst_vif.wait_clks((msg.size() % 4) ? HMAC_KEY_PROCESS_CYCLES * 2 :
+                                  $urandom_range(0, HMAC_KEY_PROCESS_CYCLES * 2));
 
         if (do_hash_start) begin
           // wait for interrupt to assert, check status and clear it


### PR DESCRIPTION
Hmac regression found one corner cases regarding fifo_empty.
After hash_process is issued, if message input is not a multiple
of 4, there is a period of time sequence won't check fifo_empty
interrupt because it is hard for scb to align.
Now since prim_packer can hold one more data, the ignored period of time
needs to be extended.

Signed-off-by: Cindy Chen <chencindy@google.com>