### PR TITLE
[OTBN] ISS: Make Z flag only look at carryless result

### DIFF
--- a/hw/ip/otbn/doc/_index.md
+++ b/hw/ip/otbn/doc/_index.md
@@ -306,6 +306,8 @@ Each flag is a single bit.
 - `Z` (Zero Flag)
   Set to 1 if the result of the last operation was zero; otherwise 0.
 
+The `L`, `M`, and `Z` flags are determined based on the result of the operation as it is written back into the result register, without considering the overflow bit.
+
 ### Loop Stack
 
 The LOOP instruction allows for nested loops; the active loops are stored on the loop stack.
@@ -435,7 +437,7 @@ def AddWithCarry(a: Bits(WLEN), b: Bits(WLEN), carry_in: Bits(1)) -> (Bits(WLEN)
   flags_out.C = result[WLEN]
   flags_out.L = result[0]
   flags_out.M = result[WLEN-1]
-  flags_out.Z = (result == 0)
+  flags_out.Z = (result[WLEN-1:0] == 0)
 
   return (result[WLEN-1:0], flags_out)
 

--- a/hw/ip/otbn/dv/otbnsim/sim/model.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/model.py
@@ -340,12 +340,13 @@ class OTBNModel(Model):  # type: ignore
     def add_with_carry(a: int, b: int, carry_in: int) -> Tuple[int, int]:
         result = a + b + carry_in
 
+        carryless_result = result & ((1 << 256) - 1)
         flags_out = AttrDict({"C": (result >> 256) & 1,
                               "L": result & 1,
                               "M": (result >> 255) & 1,
-                              "Z": 1 if result == 0 else 0})
+                              "Z": 1 if carryless_result == 0 else 0})
 
-        return (result & ((1 << 256) - 1), flags_out)
+        return (carryless_result, flags_out)
 
     def issue(self, insn: Instruction) -> List[Trace]:
         '''An overridden version of riscvmodel's Model.issue


### PR DESCRIPTION
Update the OTBN spec and the ISS to clarify the behavior of the Z flag, see #3336 for a long explanation by @felixmiller why this behavior is good.