### PR TITLE
[dv/gpio] fix regression failure

### DIFF
--- a/hw/ip/gpio/dv/env/gpio_scoreboard.sv
+++ b/hw/ip/gpio/dv/env/gpio_scoreboard.sv
@@ -73,13 +73,13 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
     // grab completed transactions from data channel; ignore packets from address channel
     if (channel == AddrChannel) begin
       // Clock period in nano seconds (timeunit)
-      int clk_period = cfg.clk_rst_vif.clk_period_ps / 1000;
+      real clk_period = cfg.clk_rst_vif.clk_period_ps / 1000;
       time crnt_time = $time;
 
       // apply pending update for interrupt state
       if (data_in_update_queue.size() > 0) begin
         if (data_in_update_queue[$].needs_update == 1'b1 &&
-            ((crnt_time - data_in_update_queue[$].eval_time) / clk_period) > 1) begin
+            (int'((crnt_time - data_in_update_queue[$].eval_time) / clk_period)) > 1) begin
           void'(ral.data_in.predict(.value(data_in_update_queue[$].reg_value),
                                     .kind(UVM_PREDICT_READ)));
         end else if(data_in_update_queue[$ - 1].needs_update == 1'b1) begin
@@ -95,7 +95,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
         // read on same or next clock will not give latest updated value. So, look for time stamp
         // of latest update to decide which value to predict for "intr_state" mirrored value
         if (intr_state_update_queue[$].needs_update == 1'b1 &&
-            ((crnt_time - intr_state_update_queue[$].eval_time) / clk_period) > 1) begin
+            (int'((crnt_time - intr_state_update_queue[$].eval_time) / clk_period)) > 1) begin
           void'(ral.intr_state.predict(.value(intr_state_update_queue[$].reg_value),
                                        .kind(UVM_PREDICT_READ)));
         end else if(intr_state_update_queue[$ - 1].needs_update == 1'b1) begin


### PR DESCRIPTION
The daily regression GPIO failure on `gpio_sanity_no_pullup_pulldown`
was due to a round up corner case:
For the statement in GPIO scb line 82:
`((crnt_time - data_in_update_queue[$].eval_time) / clk_period) > 1`
In the corner case, the crnt_time is 434ns, the eval_time is 395ns,
and the clk period is 20ns. So (434-395)/20 = 39/20 is 1.
However, the eval_time should be: 394499ps which should round down to
394ns instead of 395ns. I think it might because of async rst_n caused a
little bit delay.
So the solution I propose in this PR is to: change the `clk_period` from
`int` to `real` and allow rounding for the division value. In this
corner case, 1.95 will be round up to 2.

Signed-off-by: Cindy Chen <chencindy@google.com>