### PR TITLE
[flash_ctrl] Add memory protection functionality for hardware interface

### DIFF
--- a/hw/ip/flash_ctrl/flash_ctrl.core
+++ b/hw/ip/flash_ctrl/flash_ctrl.core
@@ -22,6 +22,7 @@ filesets:
       - rtl/flash_ctrl_arb.sv
       - rtl/flash_ctrl_lcmgr.sv
       - rtl/flash_mp.sv
+      - rtl/flash_mp_data_region_sel.sv
       - rtl/flash_phy.sv
       - rtl/flash_phy_core.sv
       - rtl/flash_phy_rd.sv

--- a/hw/ip/flash_ctrl/lint/flash_ctrl.waiver
+++ b/hw/ip/flash_ctrl/lint/flash_ctrl.waiver
@@ -5,5 +5,5 @@
 # waiver file for Flash Controller
 
 # All leaf resets have a reset multiplex
-waive -rules TERMINAL_STATE -location {flash_ctrl_lcmgr.sv} -regexp {.*StRmaRsp.*} \
+waive -rules TERMINAL_STATE -location {flash_ctrl_lcmgr.sv} -regexp {.*StInvalid.*} \
       -comment "StRmaRsp is intended to be a terminal state"

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -107,6 +107,7 @@ module flash_ctrl import flash_ctrl_pkg::*; (
   logic prog_op;
   logic erase_op;
   logic [AllPagesW-1:0] err_addr;
+  flash_lcmgr_phase_e phase;
 
   // Flash control arbitration connections to hardware interface
   flash_ctrl_reg2hw_control_reg_t hw_ctrl;
@@ -118,6 +119,7 @@ module flash_ctrl import flash_ctrl_pkg::*; (
   logic hw_rready;
   flash_sel_e if_sel;
   logic sw_sel;
+  flash_lcmgr_phase_e hw_phase;
 
   // Flash control arbitration connections to software interface
   logic sw_ctrl_done;
@@ -166,6 +168,9 @@ module flash_ctrl import flash_ctrl_pkg::*; (
     .hw_req_i(hw_req),
     .hw_ctrl_i(hw_ctrl),
 
+    // hardware interface indicating operation phase
+    .hw_phase_i(hw_phase),
+
     // hardware works on word address, however software expects byte address
     .hw_addr_i(hw_addr),
     .hw_ack_o(hw_done),
@@ -200,6 +205,9 @@ module flash_ctrl import flash_ctrl_pkg::*; (
 
     // clear fifos
     .fifo_clr_o(fifo_clr),
+
+    // phase indication
+    .phase_o(phase),
 
     // indication that sw has been selected
     .sel_o(if_sel)
@@ -246,6 +254,10 @@ module flash_ctrl import flash_ctrl_pkg::*; (
 
     // outgoing seeds
     .seeds_o(),
+    .seed_err_o(), // TBD hook-up to Err code register
+
+    // phase indication
+    .phase_o(hw_phase),
 
     // init ongoing
     .init_busy_o(ctrl_init_busy)
@@ -487,6 +499,7 @@ module flash_ctrl import flash_ctrl_pkg::*; (
 
     // read / prog / erase controls
     .req_i(flash_req),
+    .phase_i(phase),
     .req_addr_i(flash_addr[BusAddrW-1 -: AllPagesW]),
     .req_part_i(flash_part_sel),
     .addr_ovfl_i(rd_flash_ovfl | prog_flash_ovfl),

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_arb.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_arb.sv
@@ -33,6 +33,7 @@ module flash_ctrl_arb import flash_ctrl_pkg::*; (
   // hardware interface to rd_ctrl / erase_ctrl
   input hw_req_i,
   input flash_ctrl_reg_pkg::flash_ctrl_reg2hw_control_reg_t hw_ctrl_i,
+  input flash_lcmgr_phase_e hw_phase_i,
   input [31:0] hw_addr_i,
   output logic hw_ack_o,
   output logic hw_err_o,
@@ -64,6 +65,9 @@ module flash_ctrl_arb import flash_ctrl_pkg::*; (
 
   // clear fifo contents
   output logic fifo_clr_o,
+
+  // output to memory protection
+  output flash_lcmgr_phase_e phase_o,
 
   // indication that sw has been selected
   output flash_sel_e sel_o
@@ -206,5 +210,8 @@ module flash_ctrl_arb import flash_ctrl_pkg::*; (
   end
 
   assign sel_o = func_sel;
+
+  // At the moment there is no software control indicating phase.
+  assign phase_o = func_sel == SwSel ? PhaseInvalid : hw_phase_i;
 
 endmodule // flash_ctrl_rd_arb

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_lcmgr.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_lcmgr.sv
@@ -216,7 +216,7 @@ module flash_ctrl_lcmgr import flash_ctrl_pkg::*; (
         // current seed reading is complete
         // error is intentionally not used here, as we do not want read seed
         // failures to stop the software from using flash
-        // When there are upstream failures, the data returned in simply all 1's.
+        // When there are upstream failures, the data returned is simply all 1's.
         // So instead of doing anything explicit, a status is indicated for software.
         end else if (done_i) begin
           addr_cnt_clr = 1'b1;

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
@@ -68,8 +68,13 @@ package flash_ctrl_pkg;
       OwnerInfoPage
      };
 
-  // alias for super long reg_pkg typedef
-  typedef flash_ctrl_reg_pkg::flash_ctrl_reg2hw_bank0_info_page_cfg_mreg_t info_page_cfg_t;
+  // lcmgr phase enum
+  typedef enum logic [1:0] {
+    PhaseSeed,
+    PhaseRma,
+    PhaseNone,
+    PhaseInvalid
+  } flash_lcmgr_phase_e;
 
   // Flash Operations Supported
   typedef enum logic [1:0] {
@@ -105,6 +110,24 @@ package flash_ctrl_pkg;
     FlashPartData = 1'b0,
     FlashPartInfo = 1'b1
   } flash_part_e;
+
+  // memory protection specific structs
+
+  // alias for super long reg_pkg typedef
+  typedef flash_ctrl_reg_pkg::flash_ctrl_reg2hw_bank0_info_page_cfg_mreg_t info_page_cfg_t;
+  typedef flash_ctrl_reg_pkg::flash_ctrl_reg2hw_mp_region_cfg_mreg_t mp_region_cfg_t;
+
+  typedef struct packed {
+    logic [AllPagesW-1:0] page;
+    flash_lcmgr_phase_e   phase;
+    info_page_cfg_t       cfg;
+  } info_page_attr_t;
+
+  typedef struct packed {
+    flash_lcmgr_phase_e   phase;
+    mp_region_cfg_t cfg;
+  } data_region_attr_t;
+
 
   // Flash controller to memory
   typedef struct packed {

--- a/hw/ip/flash_ctrl/rtl/flash_mp_data_region_sel.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_mp_data_region_sel.sv
@@ -7,7 +7,7 @@
 
 `include "prim_assert.sv"
 
-module flash_mp_data_region_sel import flash_ctrl_pkg::*; # (
+module flash_mp_data_region_sel import flash_ctrl_pkg::*; #(
   parameter int Regions = 4
 ) (
   input req_i,
@@ -31,7 +31,7 @@ module flash_mp_data_region_sel import flash_ctrl_pkg::*; # (
 
   // check for region match
   always_comb begin
-    for (int unsigned i = 0; i < Regions; i++) begin: gen_region_comps
+    for (int i = 0; i < Regions; i++) begin: gen_region_comps
       region_end[i] = {1'b0, region_attrs_i[i].cfg.base.q} + region_attrs_i[i].cfg.size.q;
 
       // region matches if address within range and if the partition matches
@@ -46,7 +46,7 @@ module flash_mp_data_region_sel import flash_ctrl_pkg::*; # (
   // select appropriate region configuration
   always_comb begin
     sel_cfg_o = '0;
-    for (int unsigned i = 0; i < Regions; i++) begin: gen_region_sel
+    for (int i = 0; i < Regions; i++) begin: gen_region_sel
       if (region_sel[i]) begin
         sel_cfg_o = region_attrs_i[i].cfg;
       end

--- a/hw/ip/flash_ctrl/rtl/flash_mp_data_region_sel.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_mp_data_region_sel.sv
@@ -13,7 +13,7 @@ module flash_mp_data_region_sel import flash_ctrl_pkg::*; # (
   input req_i,
   input flash_lcmgr_phase_e phase_i,
   input [AllPagesW-1:0] addr_i,
-  input data_region_attr_t[Regions-1:0] region_attrs_i,
+  input data_region_attr_t region_attrs_i [Regions] ,
   output mp_region_cfg_t sel_cfg_o
 );
 

--- a/hw/ip/flash_ctrl/rtl/flash_mp_data_region_sel.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_mp_data_region_sel.sv
@@ -1,0 +1,57 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Flash Memory Protection
+//
+
+`include "prim_assert.sv"
+
+module flash_mp_data_region_sel import flash_ctrl_pkg::*; # (
+  parameter int Regions = 4
+) (
+  input req_i,
+  input flash_lcmgr_phase_e phase_i,
+  input [AllPagesW-1:0] addr_i,
+  input data_region_attr_t[Regions-1:0] region_attrs_i,
+  output mp_region_cfg_t sel_cfg_o
+);
+
+  // There could be multiple region matches due to region overlap
+  // Lower indices always have priority
+  logic [AllPagesW:0] region_end[Regions];
+  logic [Regions-1:0] region_match;
+  logic [Regions-1:0] region_sel;
+
+  // decode for software interface region
+  assign region_sel[0] = region_match[0];
+  for (genvar i = 1; i < Regions; i++) begin: gen_region_priority
+    assign region_sel[i] = region_match[i] & ~|region_match[i-1:0];
+  end
+
+  // check for region match
+  always_comb begin
+    for (int unsigned i = 0; i < Regions; i++) begin: gen_region_comps
+      region_end[i] = {1'b0, region_attrs_i[i].cfg.base.q} + region_attrs_i[i].cfg.size.q;
+
+      // region matches if address within range and if the partition matches
+      region_match[i] = addr_i >= region_attrs_i[i].cfg.base.q &
+                        {1'b0, addr_i} < region_end[i] &
+                        phase_i == region_attrs_i[i].phase &
+                        region_attrs_i[i].cfg.en.q &
+                        req_i;
+    end
+  end
+
+  // select appropriate region configuration
+  always_comb begin
+    sel_cfg_o = '0;
+    for (int unsigned i = 0; i < Regions; i++) begin: gen_region_sel
+      if (region_sel[i]) begin
+        sel_cfg_o = region_attrs_i[i].cfg;
+      end
+    end
+  end
+
+
+endmodule // flash_mp_data_region_sel


### PR DESCRIPTION
This PR adds memory protection to the hardware interface. 
Previously only the software interface had memory protection.

The spec update is still in progress. 