### PR TITLE
[otbn] Rename grs1 operand to grs for insns with only one source GPR

### DIFF
--- a/hw/ip/otbn/data/base-insns.yml
+++ b/hw/ip/otbn/data/base-insns.yml
@@ -22,12 +22,12 @@
 - mnemonic: addi
   rv32i: true
   synopsis: Add Immediate
-  operands: [grd, grs1, imm]
+  operands: [grd, grs, imm]
   encoding:
     scheme: I
     mapping:
       imm: imm
-      rs1: grs1
+      rs1: grs
       funct3: b000
       rd: grd
       opcode: b00100
@@ -77,18 +77,17 @@
 - mnemonic: slli
   rv32i: true
   synopsis: Logical left shift with Immediate
-  operands:
+  operands: &shifti-operands
     - grd
-    - grs1
-    - &shamt-operand
-      name: shamt
+    - grs
+    - name: shamt
       type: uimm
   encoding:
     scheme: Is
     mapping:
       arithmetic: b0
       shamt: shamt
-      rs1: grs1
+      rs1: grs
       funct3: b001
       rd: grd
       opcode: b00100
@@ -110,16 +109,13 @@
 - mnemonic: srli
   rv32i: true
   synopsis: Logical right shift with Immediate
-  operands:
-    - grd
-    - grs1
-    - *shamt-operand
+  operands: *shifti-operands
   encoding:
     scheme: Is
     mapping:
       arithmetic: b0
       shamt: shamt
-      rs1: grs1
+      rs1: grs
       funct3: b101
       rd: grd
       opcode: b00100
@@ -141,16 +137,13 @@
 - mnemonic: srai
   rv32i: true
   synopsis: Arithmetic right shift with Immediate
-  operands:
-    - grd
-    - grs1
-    - *shamt-operand
+  operands: *shifti-operands
   encoding:
     scheme: Is
     mapping:
       arithmetic: b1
       shamt: shamt
-      rs1: grs1
+      rs1: grs
       funct3: b101
       rd: grd
       opcode: b00100
@@ -172,12 +165,12 @@
 - mnemonic: andi
   rv32i: true
   synopsis: Bitwise AND with Immediate
-  operands: [grd, grs1, imm]
+  operands: [grd, grs, imm]
   encoding:
     scheme: I
     mapping:
       imm: imm
-      rs1: grs1
+      rs1: grs
       funct3: b111
       rd: grd
       opcode: b00100
@@ -199,12 +192,12 @@
 - mnemonic: ori
   rv32i: true
   synopsis: Bitwise OR with Immediate
-  operands: [grd, grs1, imm]
+  operands: [grd, grs, imm]
   encoding:
     scheme: I
     mapping:
       imm: imm
-      rs1: grs1
+      rs1: grs
       funct3: b110
       rd: grd
       opcode: b00100
@@ -226,12 +219,12 @@
 - mnemonic: xori
   rv32i: true
   synopsis: Bitwise XOR with Immediate
-  operands: [grd, grs1, imm]
+  operands: [grd, grs, imm]
   encoding:
     scheme: I
     mapping:
       imm: imm
-      rs1: grs1
+      rs1: grs
       funct3: b100
       rd: grd
       opcode: b00100
@@ -239,23 +232,23 @@
 - mnemonic: lw
   rv32i: true
   synopsis: Load Word
-  operands: [grd, offset, grs1]
-  syntax: <grd>, <offset>(<grs1>)
+  operands: [grd, offset, grs]
+  syntax: <grd>, <offset>(<grs>)
   encoding:
     scheme: I
     mapping:
       imm: offset
-      rs1: grs1
+      rs1: grs
       funct3: b010
       rd: grd
       opcode: b00000
   doc: |
-    Load a 32b word from address `<offset> + <grs1>` in data memory, writing the result to `<grd>`.
+    Load a 32b word from address `<offset> + <grs>` in data memory, writing the result to `<grd>`.
     Unaligned loads are not supported.
     Any address that is unaligned or is above the top of memory will result in an error (with error code `ErrCodeBadDataAddr`).
   lsu:
     type: mem-load
-    target: [offset, grs1]
+    target: [offset, grs]
     bytes: 4
 
 - mnemonic: sw
@@ -335,20 +328,20 @@
 - mnemonic: jalr
   rv32i: true
   synopsis: Jump And Link Register
-  operands: [grd, grs1, offset]
+  operands: [grd, grs, offset]
   straight-line: false
   trailing-doc: |
-    The JALR instruction has the same behavior as in RV32I, jumping by `<grs1> + <offset>` and writing `PC+4` as a link address to the destination register.
+    The JALR instruction has the same behavior as in RV32I, jumping by `<grs> + <offset>` and writing `PC+4` as a link address to the destination register.
     OTBN has a hardware managed call stack, accessed through `x1`, which should be used when calling and returning from subroutines.
     To return from a subroutine, use `jalr x0, x1, 0`.
     This pops a link address from the call stack and branches to it.
-    To call a subroutine through a function pointer, use `jalr x1, <grs1>, 0`.
-    This jumps to the address in `<grs1>` and pushes the link address onto the call stack.
+    To call a subroutine through a function pointer, use `jalr x1, <grs>, 0`.
+    This jumps to the address in `<grs>` and pushes the link address onto the call stack.
   encoding:
     scheme: I
     mapping:
       imm: offset
-      rs1: grs1
+      rs1: grs
       funct3: b000
       rd: grd
       opcode: b11001

--- a/hw/ip/otbn/data/bignum-insns.yml
+++ b/hw/ip/otbn/data/bignum-insns.yml
@@ -737,7 +737,7 @@
   operands:
     - name: grd
       doc: Name of the GPR referencing the destination WDR
-    - name: grs1
+    - name: grs
       doc: |
         Name of the GPR containing the memory byte address.
         The value contained in the referenced GPR must be WLEN-aligned.
@@ -746,38 +746,38 @@
         Offset value.
         Must be WLEN-aligned.
       type: simm<<5
-    - name: grs1_inc
+    - name: grs_inc
       type: option(++)
       doc: |
-        Increment the value in `<grs1>` by WLEN/8 (one word).
+        Increment the value in `<grs>` by WLEN/8 (one word).
         Cannot be specified together with `grd_inc`.
     - name: grd_inc
       type: option(++)
       doc: |
         Increment the value in `<grd>` by one.
-        Cannot be specified together with `grs1_inc`.
+        Cannot be specified together with `grs_inc`.
   syntax: |
-    <grd>[<grd_inc>], <offset>(<grs1>[<grs1_inc>])
+    <grd>[<grd_inc>], <offset>(<grs>[<grs_inc>])
   doc: |
-    Calculates a byte memory address by adding the offset to the value in the GPR `grs1`.
+    Calculates a byte memory address by adding the offset to the value in the GPR `grs`.
     The value from this memory address is then copied into the WDR pointed to by the value in GPR `grd`.
 
-    After the operation, either the value in the GPR `grs1`, or the value in `grd` can be optionally incremented.
+    After the operation, either the value in the GPR `grs`, or the value in `grd` can be optionally incremented.
 
-    - If `grs1_inc` is set, the value in `grs1` is incremented by the value WLEN/8 (one word).
+    - If `grs_inc` is set, the value in `grs` is incremented by the value WLEN/8 (one word).
     - If `grd_inc` is set, the value in `grd` is incremented by the value 1.
 
     The memory address must be aligned to WLEN bytes.
     Any address that is unaligned or is above the top of memory will result in an error (with error code `ErrCodeBadDataAddr`).
   decode: |
     rd = UInt(grd)
-    rs1 = UInt(grs1)
+    rs1 = UInt(grs)
     offset = UInt(offset)
   operation: |
     mem_addr = GPR[rs1] + offset
     wdr_dest = GPR[rd]
 
-    assert not (grs1_inc and grd_inc)  # prevented in encoding
+    assert not (grs_inc and grd_inc)  # prevented in encoding
     if mem_addr % (WLEN / 8) or mem_addr + WLEN > DMEM_SIZE:
         raise BadDataAddr()
 
@@ -785,21 +785,21 @@
 
     WDR[wdr_dest] = LoadWlenWordFromMemory(mem_index)
 
-    if grs1_inc:
+    if grs_inc:
         GPR[rs1] = GPR[rs1] + (WLEN / 8)
     if grd_inc:
         GPR[rd] = GPR[rd] + 1
   lsu:
     type: mem-load
-    target: [offset, grs1]
+    target: [offset, grs]
     bytes: 32
   encoding:
     scheme: bnxid
     mapping:
       imm: offset
-      spp: grs1_inc
+      spp: grs_inc
       dpp: grd_inc
-      rs: grs1
+      rs: grs
       funct3: b100
       rd: grd
 

--- a/hw/ip/otbn/dv/otbnsim/sim/insn.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/insn.py
@@ -23,7 +23,7 @@ class ADDI(RV32RegImm):
     insn = insn_for_mnemonic('addi', 3)
 
     def execute(self, model: OTBNModel) -> None:
-        val1 = model.state.intreg[self.grs1]
+        val1 = model.state.intreg[self.grs]
         model.state.intreg[self.grd] = val1 + self.imm
 
 
@@ -61,7 +61,7 @@ class SLLI(RV32ImmShift):
     insn = insn_for_mnemonic('slli', 3)
 
     def execute(self, model: OTBNModel) -> None:
-        val1 = model.state.intreg[self.grs1]
+        val1 = model.state.intreg[self.grs]
         model.state.intreg[self.grd] = val1 << self.shamt
 
 
@@ -78,7 +78,7 @@ class SRLI(RV32ImmShift):
     insn = insn_for_mnemonic('srli', 3)
 
     def execute(self, model: OTBNModel) -> None:
-        val1 = model.state.intreg[self.grs1]
+        val1 = model.state.intreg[self.grs]
         model.state.intreg[self.grd] = val1 >> self.shamt
 
 
@@ -101,7 +101,7 @@ class SRAI(RV32ImmShift):
     insn = insn_for_mnemonic('srai', 3)
 
     def execute(self, model: OTBNModel) -> None:
-        usrc = model.state.intreg[self.grs1].unsigned()
+        usrc = model.state.intreg[self.grs].unsigned()
         shift = self.shamt
         if usrc >> 31:
             to_clear = 32 - shift
@@ -125,7 +125,7 @@ class ANDI(RV32RegImm):
     insn = insn_for_mnemonic('andi', 3)
 
     def execute(self, model: OTBNModel) -> None:
-        val1 = model.state.intreg[self.grs1]
+        val1 = model.state.intreg[self.grs]
         model.state.intreg[self.grd] = val1 & self.imm
 
 
@@ -142,7 +142,7 @@ class ORI(RV32RegImm):
     insn = insn_for_mnemonic('ori', 3)
 
     def execute(self, model: OTBNModel) -> None:
-        val1 = model.state.intreg[self.grs1]
+        val1 = model.state.intreg[self.grs]
         model.state.intreg[self.grd] = val1 | self.imm
 
 
@@ -159,7 +159,7 @@ class XORI(RV32RegImm):
     insn = insn_for_mnemonic('xori', 3)
 
     def execute(self, model: OTBNModel) -> None:
-        val1 = model.state.intreg[self.grs1]
+        val1 = model.state.intreg[self.grs]
         model.state.intreg[self.grd] = val1 | self.imm
 
 
@@ -170,10 +170,10 @@ class LW(OTBNInsn):
         super().__init__(op_vals)
         self.grd = op_vals['grd']
         self.offset = op_vals['offset']
-        self.grs1 = op_vals['grs1']
+        self.grs = op_vals['grs']
 
     def execute(self, model: OTBNModel) -> None:
-        addr = (model.state.intreg[self.grs1] + self.offset).unsigned()
+        addr = (model.state.intreg[self.grs] + self.offset).unsigned()
         data = model.state.memory.lw(addr)
         model.state.intreg[self.grd] = data
 
@@ -244,12 +244,12 @@ class JALR(OTBNInsn):
     def __init__(self, op_vals: Dict[str, int]):
         super().__init__(op_vals)
         self.grd = op_vals['grd']
-        self.grs1 = op_vals['grs1']
+        self.grs = op_vals['grs']
         self.offset = op_vals['offset']
 
     def execute(self, model: OTBNModel) -> None:
         model.state.intreg[self.grd] = model.state.pc + 4
-        model.state.pc = model.state.intreg[self.grs1] + self.offset
+        model.state.pc = model.state.intreg[self.grs] + self.offset
 
 
 class CSRRS(OTBNInsn):
@@ -720,19 +720,19 @@ class BNLID(OTBNInsn):
         self.grd = op_vals['grd']
         self.grd_inc = op_vals['grd_inc']
         self.offset = op_vals['offset']
-        self.grs1 = op_vals['grs1']
-        self.grs1_inc = op_vals['grs1_inc']
+        self.grs = op_vals['grs']
+        self.grs_inc = op_vals['grs_inc']
 
     def execute(self, model: OTBNModel) -> None:
-        addr = int(model.state.intreg[self.grs1] + int(self.offset))
+        addr = int(model.state.intreg[self.grs] + int(self.offset))
         wrd = int(model.state.intreg[self.grd])
         word = model.load_wlen_word_from_memory(addr)
         model.state.wreg[wrd] = word
 
         if self.grd_inc:
             model.state.intreg[self.grd] += 1
-        if self.grs1_inc:
-            model.state.intreg[self.grs1] += 32
+        if self.grs_inc:
+            model.state.intreg[self.grs] += 32
 
 
 class BNSID(OTBNInsn):

--- a/hw/ip/otbn/dv/otbnsim/sim/isa.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/isa.py
@@ -96,7 +96,7 @@ class RV32RegImm(OTBNInsn):
     def __init__(self, op_vals: Dict[str, int]):
         super().__init__(op_vals)
         self.grd = op_vals['grd']
-        self.grs1 = op_vals['grs1']
+        self.grs = op_vals['grs']
         self.imm = op_vals['imm']
 
 
@@ -105,7 +105,7 @@ class RV32ImmShift(OTBNInsn):
     def __init__(self, op_vals: Dict[str, int]):
         super().__init__(op_vals)
         self.grd = op_vals['grd']
-        self.grs1 = op_vals['grs1']
+        self.grs = op_vals['grs']
         self.shamt = op_vals['shamt']
 
 


### PR DESCRIPTION
I think that there's some more renaming that would help: for example,
`LW` and `SW` could talk about `<base>` for their base address. But that can
wait for a separate patch.
