### PR TITLE
[dv/alert_esc_agent] fix vcs warning

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_probe_if.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_probe_if.sv
@@ -21,4 +21,8 @@ interface alert_esc_probe_if(input clk, input rst_n);
     return monitor_cb.esc_en;
   endfunction
 
+  task automatic wait_esc_en();
+    while (esc_en !== 1'b1) @(monitor_cb);
+  endtask
+
 endinterface

--- a/hw/dv/sv/alert_esc_agent/esc_receiver_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/esc_receiver_driver.sv
@@ -120,7 +120,7 @@ class esc_receiver_driver extends alert_esc_base_driver;
           begin : isolation_fork
             fork
               repeat (toggle_cycle) toggle_resp_signal(req);
-              wait(cfg.probe_vif.get_esc_en());
+              cfg.probe_vif.wait_esc_en();
             join_any
             disable fork;
           end


### PR DESCRIPTION
VCS throws a warning for the wait statement below:
`wait(cfg.probe_vif.get_esc_en());` and VCS throws a warning:
`Warning-[FCWAIEW] FuncCall Without Arguments In Wait/Event`

To fix this, I moved the wait task inside the interface.

Signed-off-by: Cindy Chen <chencindy@google.com>