### PR TITLE
[dvsim] Rename verbosity wildcards to something more informative

### DIFF
--- a/hw/dv/data/common_sim_cfg.hjson
+++ b/hw/dv/data/common_sim_cfg.hjson
@@ -41,11 +41,15 @@
   tl_dbw: 4
 
   // Default UVM verbosity settings
-  n: UVM_NONE
-  l: UVM_LOW
-  m: UVM_MEDIUM
-  h: UVM_HIGH
-  d: UVM_DEBUG
+  expand_uvm_verbosity_n: UVM_NONE
+  expand_uvm_verbosity_l: UVM_LOW
+  expand_uvm_verbosity_m: UVM_MEDIUM
+  expand_uvm_verbosity_h: UVM_HIGH
+  expand_uvm_verbosity_d: UVM_DEBUG
+
+  // Default simulation verbosity (l => UVM_LOW). Can be overridden by
+  // the --verbosity command-line argument.
+  verbosity: l
 
   // Path to the dut instance (this is used in a couple of places such as coverage cfg
   // file, xprop cfg file etc. If this is different for your block, then override it with
@@ -67,7 +71,7 @@
                "+define+UVM_REG_BYTENABLE_WIDTH={tl_dbw}"]
 
   run_opts: ["+UVM_NO_RELNOTES",
-             "+UVM_VERBOSITY={verbosity}"]
+             "+UVM_VERBOSITY={expand_uvm_verbosity_{verbosity}}"]
 
   // Default list of things to export to shell
   exports: [

--- a/util/dvsim/FlowCfg.py
+++ b/util/dvsim/FlowCfg.py
@@ -16,7 +16,7 @@ from Deploy import Deploy
 from utils import VERBOSE, md_results_to_html, parse_hjson, subst_wildcards
 
 # A set of fields that can be overridden on the command line.
-_CMDLINE_FIELDS = {'tool'}
+_CMDLINE_FIELDS = {'tool', 'verbosity'}
 
 
 # Interface class for extensions.

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -105,7 +105,10 @@ class SimCfg(FlowCfg):
         self.profile = args.profile or '(cfg uses profile without --profile)'
         self.xprop_off = args.xprop_off
         self.no_rerun = args.no_rerun
-        self.verbosity = "{" + args.verbosity + "}"
+        # Single-character verbosity setting (n, l, m, h, d). args.verbosity
+        # might be None, in which case we'll pick up a default value from
+        # configuration files.
+        self.verbosity = args.verbosity
         self.verbose = args.verbose
         self.dry_run = args.dry_run
         self.map_full_testplan = args.map_full_testplan

--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -367,12 +367,11 @@ def parse_args():
                             "enabled."))
 
     rung.add_argument("--verbosity", "-v",
-                      default="l",
                       choices=['n', 'l', 'm', 'h', 'd'],
                       metavar='V',
-                      help=('Set UVM verbosity to none (n), low (l; the '
-                            'default), medium (m), high (h) or debug (d). '
-                            'This overrides any setting in the config files.'))
+                      help=('Set tool/simulation verbosity to none (n), low '
+                            '(l), medium (m), high (h) or debug (d). '
+                            'The default value is set in config files.'))
 
     seedg = parser.add_argument_group('Test seeds')
 


### PR DESCRIPTION
Having expansions for `{l}` and similar (to something UVM-specific)
seems like a bad idea. The names aren't used by any handwritten code
anyway, so let's make them more descriptive.
