### PR TITLE
Potential fix for spiflash

### DIFF
--- a/sw/host/spiflash/ftdi_spi_interface.h
+++ b/sw/host/spiflash/ftdi_spi_interface.h
@@ -28,10 +28,10 @@ class FtdiSpiInterface : public SpiInterface {
   /** FTDI SPI configuration options. */
   struct Options {
     /** USB device vendor ID. */
-    int32_t device_vendor_id;
+    int32_t device_vendor_id = 0;
 
     /** USB device product ID. */
-    int32_t device_product_id;
+    int32_t device_product_id = 0;
 
     /** USB device serial number. */
     std::string device_serial_number;

--- a/sw/host/spiflash/spiflash.cc
+++ b/sw/host/spiflash/spiflash.cc
@@ -170,6 +170,11 @@ bool ParseArgs(int argc, char **argv, SpiFlashOpts *options) {
   while (true) {
     int c = getopt_long(argc, argv, "i:d:n:s:x:h?", long_options, nullptr);
     if (c == -1) {
+      // if only input file was given default to using FTDI
+      if (!options->input.empty() &&
+          options->action == SpiFlashAction::kInvalid) {
+        options->action = SpiFlashAction::kFtdi;
+      }
       return true;
     }
 


### PR DESCRIPTION
Recent change to spiflash made all args required and some conflict.
This fixes it for me to use the base spiflash --input=foo.bin and
I don't think it breaks the new use cases.

Hope this PR is helpful. I would happily abandon it if there is
a fix from the software side!

Fixes 3315

Signed-off-by: Mark Hayter <mark.hayter@gmail.com>