### PR TITLE
[usbdev] Fixes for I/O modes and expand their tests

### DIFF
--- a/hw/dv/dpi/usbdpi/monitor_usb.c
+++ b/hw/dv/dpi/usbdpi/monitor_usb.c
@@ -97,22 +97,43 @@ void monitor_usb(void *mon_void, FILE *mon_file, int loglevel, int tick,
   log = (loglevel & 0x2);
   compact = (loglevel & 0x1);
 
-  if ((d2p & D2P_DP_EN) || (d2p & D2P_DN_EN)) {
+  if ((d2p & D2P_DP_EN) || (d2p & D2P_DN_EN) || (d2p & D2P_D_EN)) {
     if (hdrive) {
       fprintf(mon_file, "mon: %8d: Bus clash\n", tick);
     }
-    dp = ((d2p & D2P_DP_EN) && (d2p & D2P_DP)) ? 1 : 0;
-    dn = ((d2p & D2P_DN_EN) && (d2p & D2P_DN)) ? 1 : 0;
+    if (d2p & D2P_TXMODE_SE) {
+      dp = ((d2p & D2P_DP_EN) && (d2p & D2P_DP)) ? 1 : 0;
+      dn = ((d2p & D2P_DN_EN) && (d2p & D2P_DN)) ? 1 : 0;
+    } else {
+      if ((d2p & D2P_SE0) || !(d2p & D2P_D_EN)) {
+        dp = 0;
+        dn = 0;
+      } else {
+        dp = (d2p & D2P_D) ? 1 : 0;
+        dn = (d2p & D2P_D) ? 0 : 1;
+      }
+    }
     mon->driver = M_DEVICE;
   } else if (hdrive) {
-    dp = (p2d & P2D_DP) ? 1 : 0;
-    dn = (p2d & P2D_DN) ? 1 : 0;
+    if (d2p & D2P_TXMODE_SE) {
+      dp = (p2d & P2D_DP) ? 1 : 0;
+      dn = (p2d & P2D_DN) ? 1 : 0;
+    } else {
+      if (p2d & (P2D_DP | P2D_DN)) {
+        dp = (p2d & P2D_D) ? 1 : 0;
+        dn = (p2d & P2D_D) ? 0 : 1;
+      } else {
+        dp = 0;
+        dn = 0;
+      }
+    }
     mon->driver = M_HOST;
   } else {
     if ((mon->driver != M_NONE) || (mon->pu != (d2p & D2P_PU))) {
       if (log) {
         if (d2p & D2P_PU) {
-          fprintf(mon_file, "mon: %8d: Idle, FS resistor\n", tick);
+          fprintf(mon_file, "mon: %8d: Idle, FS resistor (d2p 0x%x)\n", tick,
+                  d2p);
         } else {
           fprintf(mon_file, "mon: %8d: Idle, SE0\n", tick);
         }
@@ -122,6 +143,12 @@ void monitor_usb(void *mon_void, FILE *mon_file, int loglevel, int tick,
     }
     mon->line = 0;
     return;
+  }
+  // If the DN pullup is there then swap
+  if (d2p & D2P_DNPU) {
+    int tmp = dp;
+    dp = dn;
+    dn = tmp;
   }
   mon->line = (mon->line << 2) | dp << 1 | dn;
 

--- a/hw/dv/dpi/usbdpi/usbdpi.c
+++ b/hw/dv/dpi/usbdpi/usbdpi.c
@@ -21,6 +21,14 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+// Historically the simulation started too fast to connect to all
+// the fifos and terminals without loss of output. So a delay was added.
+// Today the startup is slow enough this does not seem to be needed.
+// In case things change again Im going to leave this behind a define
+// for now, but if this continues not to be needed the code can be deleted.
+// Uncomment next line if you need the delay
+// #define NEED_SLEEP
+
 static const char *st_states[] = {"ST_IDLE 0", "ST_SEND 1", "ST_GET 2",
                                   "ST_SYNC 3", "ST_EOP 4",  "ST_EOP0 5"};
 
@@ -39,6 +47,7 @@ void *usbdpi_create(const char *name, int loglevel) {
   ctx->frame = 0;
   ctx->framepend = 0;
   ctx->lastframe = 0;
+  ctx->last_pu = 0;
   ctx->inframe = 4;
   ctx->state = ST_IDLE;
   ctx->driving = 0;
@@ -86,13 +95,13 @@ void usbdpi_device_to_host(void *ctx_void, const svBitVecVal *usb_d2p) {
   char raw_str[D2P_BITS + 1];
   {
     int i;
-    for (i = 0; i < 5; i++) {
-      raw_str[5 - i - 1] = !!(d2p & (1 << i)) + '0';
+    for (i = 0; i < D2P_BITS; i++) {
+      raw_str[D2P_BITS - i - 1] = d2p & (1 << i) ? '1' : '0';
     }
   }
   raw_str[D2P_BITS] = 0;
 
-  if (d2p & (D2P_DP_EN | D2P_DN_EN)) {
+  if (d2p & (D2P_DP_EN | D2P_DN_EN | D2P_D_EN)) {
     if (ctx->state == ST_SEND) {
       printf("USB: %4x %8d error state %s hs %s and device drives\n",
              ctx->frame, ctx->tick, st_states[ctx->state],
@@ -105,17 +114,56 @@ void usbdpi_device_to_host(void *ctx_void, const svBitVecVal *usb_d2p) {
     }
   }
 
-  dp = (((d2p & D2P_DP_EN) && (d2p & D2P_DP)) ||
-        (!(d2p & D2P_DP_EN) && (d2p & D2P_PU)))
-           ? 1
-           : 0;
-
-  dn = ((d2p & D2P_DN_EN) && (d2p & D2P_DN)) ? 1 : 0;
+  if ((d2p & D2P_DNPU) && (d2p & D2P_DPPU)) {
+    printf("USB: %4x %8d error both pullups are driven\n", ctx->frame,
+           ctx->tick);
+  }
+  if ((d2p & D2P_PU) != ctx->last_pu) {
+    n = snprintf(obuf, MAX_OBUF, "%4x %8d Pullup change to %s%s%s\n",
+                 ctx->frame, ctx->tick, (d2p & D2P_DPPU) ? "DP Pulled up " : "",
+                 (d2p & D2P_DNPU) ? "DN Pulled up " : "",
+                 (d2p & D2P_TXMODE_SE) ? "SingleEnded" : "Differential");
+    ssize_t written = fwrite(obuf, sizeof(char), (size_t)n, ctx->mon_file);
+    assert(written == n);
+    ctx->last_pu = d2p & D2P_PU;
+  }
+  if (d2p & D2P_TXMODE_SE) {
+    // Normal D+/D- mode
+    if (d2p & D2P_DNPU) {
+      // DN pullup would say DP and DN are swapped
+      dp = ((d2p & D2P_DN_EN) && (d2p & D2P_DN)) ||
+           (!(d2p & D2P_DN_EN) && (d2p & D2P_DNPU));
+      dn = (d2p & D2P_DP_EN) && (d2p & D2P_DP);
+    } else {
+      // No DN pullup so normal orientation
+      dp = ((d2p & D2P_DP_EN) && (d2p & D2P_DP)) ||
+           (!(d2p & D2P_DP_EN) && (d2p & D2P_DPPU));
+      dn = (d2p & D2P_DN_EN) && (d2p & D2P_DN);
+    }
+  } else {
+    // "differential" mode uses D and SE0
+    if (d2p & D2P_D_EN) {
+      if (d2p & D2P_DNPU) {
+        // Pullup says swap i.e. D is inverted
+        dp = (d2p & D2P_SE0) ? 0 : ((d2p & D2P_D) ? 0 : 1);
+        dn = (d2p & D2P_SE0) ? 0 : ((d2p & D2P_D) ? 1 : 0);
+      } else {
+        dp = (d2p & D2P_SE0) ? 0 : ((d2p & D2P_D) ? 1 : 0);
+        dn = (d2p & D2P_SE0) ? 0 : ((d2p & D2P_D) ? 0 : 1);
+      }
+    } else {
+      dp = (d2p & D2P_PU) ? 1 : 0;
+      dn = 0;
+    }
+  }
 
   if (ctx->loglevel & LOG_BIT) {
-    n = snprintf(obuf, MAX_OBUF, "%4x %8d %s %s %s\n", ctx->frame, ctx->tick,
-                 raw_str, (d2p & D2P_PU) ? "PU" : "  ",
-                 (ctx->state == ST_GET) ? decode_usb[dp << 1 | dn] : "ZZ ");
+    const char *pullup = (d2p & D2P_PU) ? "PU" : "  ";
+    const char *state =
+        (ctx->state == ST_GET) ? decode_usb[dp << 1 | dn] : "ZZ ";
+
+    n = snprintf(obuf, MAX_OBUF, "%4x %8d %s %s %s %x\n", ctx->frame, ctx->tick,
+                 raw_str, pullup, state, d2p);
     ssize_t written = fwrite(obuf, sizeof(char), (size_t)n, ctx->mon_file);
     assert(written == n);
   }
@@ -605,6 +653,37 @@ void testUnimplEp(struct usbdpi_ctx *ctx, uint8_t pid) {
   }
 }
 
+int set_driving(struct usbdpi_ctx *ctx, int d2p, int newval) {
+  if (d2p & D2P_DNPU) {
+    if (d2p & D2P_TXMODE_SE) {
+      return (ctx->driving & P2D_SENSE) | ((newval & P2D_DP) ? P2D_DN : 0) |
+             ((newval & P2D_DN) ? P2D_DP : 0);
+    }
+    if (newval & (P2D_DP | P2D_DN)) {
+      // sets single ended lines to K after swapping
+      return (ctx->driving & P2D_SENSE) | P2D_DP |
+             ((newval & P2D_DN) ? P2D_D : 0);
+    }
+    // SE0 so D could be anything (make it 1 after swapping)
+    return ctx->driving & P2D_SENSE;
+  }
+  if (d2p & D2P_TXMODE_SE) {
+    return (ctx->driving & P2D_SENSE) | newval;
+  }
+  if (newval & (P2D_DP | P2D_DN)) {
+    // sets single ended lines to K
+    return (ctx->driving & P2D_SENSE) | P2D_DN |
+           ((newval & P2D_DP) ? P2D_D : 0);
+  }
+  // SE0 so D could be anything (make it 1)
+  return (ctx->driving & P2D_SENSE) | P2D_D;
+}
+
+int inv_driving(struct usbdpi_ctx *ctx, int d2p) {
+  // works for either orientation
+  return ctx->driving ^ ((d2p & D2P_TXMODE_SE) ? (P2D_DP | P2D_DN) : P2D_D);
+}
+
 char usbdpi_host_to_device(void *ctx_void, const svBitVecVal *usb_d2p) {
   struct usbdpi_ctx *ctx = (struct usbdpi_ctx *)ctx_void;
   assert(ctx);
@@ -615,10 +694,12 @@ char usbdpi_host_to_device(void *ctx_void, const svBitVecVal *usb_d2p) {
 
   if (ctx->tick == 0) {
     int i;
+#ifdef NEED_SLEEP
     for (i = 7; i > 0; i--) {
       printf("Sleep %d...\n", i);
       sleep(1);
     }
+#endif
   }
   ctx->tick++;
   ctx->tick_bits = ctx->tick >> 2;
@@ -727,7 +808,7 @@ char usbdpi_host_to_device(void *ctx_void, const svBitVecVal *usb_d2p) {
 
     case ST_SYNC:
       dat = ((USB_SYNC & ctx->bit)) ? P2D_DP : P2D_DN;
-      ctx->driving = (ctx->driving & P2D_SENSE) | dat;
+      ctx->driving = set_driving(ctx, d2p, dat);
       force_stat = 1;
       ctx->bit <<= 1;
       if (ctx->bit == 0x100) {
@@ -741,19 +822,19 @@ char usbdpi_host_to_device(void *ctx_void, const svBitVecVal *usb_d2p) {
       if ((ctx->linebits & 0x3f) == 0x3f &&
           !INSERT_ERR_BITSTUFF) {  // sent 6 ones
         // bit stuff and force a transition
-        ctx->driving ^= (P2D_DP | P2D_DN);
+        ctx->driving = inv_driving(ctx, d2p);
         force_stat = 1;
         ctx->linebits = (ctx->linebits << 1);
       } else if (ctx->byte >= ctx->bytes) {
         ctx->state = ST_EOP;
-        ctx->driving = ctx->driving & P2D_SENSE;  // SE0
+        ctx->driving = set_driving(ctx, d2p, 0);  // SE0
         ctx->bit = 1;
         force_stat = 1;
       } else {
         int nextbit;
         nextbit = (ctx->data[ctx->byte] & ctx->bit) ? 1 : 0;
         if (nextbit == 0) {
-          ctx->driving ^= (P2D_DP | P2D_DN);
+          ctx->driving = inv_driving(ctx, d2p);
         }
         ctx->linebits = (ctx->linebits << 1) | nextbit;
         force_stat = 1;
@@ -769,18 +850,17 @@ char usbdpi_host_to_device(void *ctx_void, const svBitVecVal *usb_d2p) {
       break;
 
     case ST_EOP0:
-      ctx->driving = ctx->driving & P2D_SENSE;  // SE0
+      ctx->driving = set_driving(ctx, d2p, 0);  // SE0
       ctx->state = ST_EOP;
       break;
 
     case ST_EOP:  // SE0 SE0 J
       if (ctx->bit == 4) {
-        ctx->driving = (ctx->driving & P2D_SENSE) | P2D_DP;  // J
+        ctx->driving = set_driving(ctx, d2p, P2D_DP);  // J
       }
       if (ctx->bit == 8) {
-        ctx->driving = (d2p & D2P_PU) ? (ctx->driving & P2D_SENSE) | P2D_DP
-                                      :               // Z + pullup
-                           ctx->driving & P2D_SENSE;  // z without pullup = SE0
+        // Stop driving: host pulldown to SE0 unless there is a pullup on DP
+        ctx->driving = set_driving(ctx, d2p, (d2p & D2P_PU) ? P2D_DP : 0);
         if (ctx->byte == ctx->datastart) {
           ctx->bit = 1;
           ctx->state = ST_SYNC;

--- a/hw/dv/dpi/usbdpi/usbdpi.h
+++ b/hw/dv/dpi/usbdpi/usbdpi.h
@@ -33,16 +33,25 @@
 // Index of the unimplemented endpoint to test
 #define UNIMPL_EP_ID 15
 
-#define D2P_BITS 5
-#define D2P_DP 16
-#define D2P_DP_EN 8
-#define D2P_DN 4
-#define D2P_DN_EN 2
-#define D2P_PU 1
+#define D2P_BITS 11
+#define D2P_DP 1024
+#define D2P_DP_EN 512
+#define D2P_DN 256
+#define D2P_DN_EN 128
+#define D2P_D 64
+#define D2P_D_EN 32
+#define D2P_SE0 16
+#define D2P_SE0_EN 8
+#define D2P_DPPU 4
+#define D2P_DNPU 2
+#define D2P_TXMODE_SE 1
+// Either pullup (dp/dn swapped if the pullup is on DN)
+#define D2P_PU (D2P_DPPU | D2P_DNPU)
 
 #define P2D_SENSE 1
 #define P2D_DN 2
 #define P2D_DP 4
+#define P2D_D 8
 
 #define ST_IDLE 0
 #define ST_SEND 1
@@ -95,6 +104,7 @@ struct usbdpi_ctx {
   FILE *mon_file;
   char mon_pathname[PATH_MAX];
   void *mon;
+  int last_pu;
   int lastrxpid;
   int tick;
   int tick_bits;

--- a/hw/dv/dpi/usbdpi/usbdpi.sv
+++ b/hw/dv/dpi/usbdpi/usbdpi.sv
@@ -6,6 +6,7 @@
 
 // Bits in LOG_LEVEL sets what is output on socket
 // 0x01 -- monitor_usb (packet level)
+// 0x02 -- more verbose monitor
 // 0x08 -- bit level
 
 module usbdpi #(
@@ -21,21 +22,31 @@ module usbdpi #(
   output logic dn_p2d,
   input  logic dn_d2p,
   input  logic dn_en_d2p,
+  output logic d_p2d,
+  input  logic d_d2p,
+  input  logic d_en_d2p,
+  input  logic se0_d2p,
+  input  logic se0_en_d2p,
+  input  logic txmode_d2p,
+  input  logic txmode_en_d2p,
+
   output logic sense_p2d,
-  input  logic pullup_d2p,
-  input  logic pullup_en_d2p
+  input  logic pullupdp_d2p,
+  input  logic pullupdp_en_d2p,
+  input  logic pullupdn_d2p,
+  input  logic pullupdn_en_d2p
 );
   import "DPI-C" function
     chandle usbdpi_create(input string name, input int loglevel);
 
   import "DPI-C" function
-    void usbdpi_device_to_host(input chandle ctx, input bit [4:0] d2p);
+    void usbdpi_device_to_host(input chandle ctx, input bit [10:0] d2p);
 
   import "DPI-C" function
     void usbdpi_close(input chandle ctx);
 
   import "DPI-C" function
-    byte usbdpi_host_to_device(input chandle ctx, input bit [4:0] d2p);
+    byte usbdpi_host_to_device(input chandle ctx, input bit [10:0] d2p);
 
   chandle ctx;
 
@@ -47,32 +58,39 @@ module usbdpi #(
     usbdpi_close(ctx);
   end
 
-  logic [4:0] d2p;
-  logic [4:0] d2p_r;
+  logic [10:0] d2p;
+  logic [10:0] d2p_r;
   logic       unused_dummy;
   logic       unused_clk = clk_i;
   logic       unused_rst = rst_ni;
-  logic       dp_int, dn_int;
+  logic       dp_int, dn_int, d_int;
 
-  assign d2p = {dp_d2p, dp_en_d2p, dn_d2p, dn_en_d2p, pullup_d2p & pullup_en_d2p};
+  assign d2p = {dp_d2p, dp_en_d2p, dn_d2p, dn_en_d2p, d_d2p, d_en_d2p, se0_d2p, se0_en_d2p, pullupdp_d2p & pullupdp_en_d2p, pullupdn_d2p & pullupdn_en_d2p, txmode_d2p & txmode_en_d2p};
   always_ff @(posedge clk_48MHz_i) begin
-    if (pullup_d2p && pullup_en_d2p) begin
+    if ((pullupdp_d2p && pullupdp_en_d2p) || (pullupdn_d2p && pullupdn_en_d2p)) begin
       automatic byte p2d = usbdpi_host_to_device(ctx, d2p);
+      d_int <= p2d[3];
       dp_int <= p2d[2];
       dn_int <= p2d[1];
       sense_p2d <= p2d[0];
-      unused_dummy <= |p2d[7:3];
+      unused_dummy <= |p2d[7:4];
       d2p_r <= d2p;
       if (d2p_r != d2p) begin
         usbdpi_device_to_host(ctx, d2p);
       end
-    end else begin
+    end else begin // if (pullupdp_d2p && pullupdp_en_d2p)
+      d_int <= 0;
       dp_int <= 0;
       dn_int <= 0;
     end
   end
 
   always_comb begin : proc_data
+    if (d_en_d2p) begin
+      d_p2d = d_d2p;
+    end else begin
+      d_p2d = d_int;
+    end
     if (dp_en_d2p) begin
       dp_p2d = dp_d2p;
     end else begin

--- a/hw/ip/usb_fs_nb_pe/rtl/usb_fs_nb_pe.sv
+++ b/hw/ip/usb_fs_nb_pe/rtl/usb_fs_nb_pe.sv
@@ -26,6 +26,7 @@ module usb_fs_nb_pe #(
   input  logic [6:0]             dev_addr_i,
 
   input  logic                   cfg_eop_single_bit_i, // 1: detect a single SE0 bit as EOP
+  input  logic                   cfg_rx_differential_i, // 1: use differential rx data on usb_d_i
   input  logic                   tx_osc_test_mode_i, // Oscillator test mode (constantly output JK)
   input  logic [NumOutEps-1:0]   data_toggle_clear_i, // Clear the data toggles for an EP
 
@@ -66,17 +67,25 @@ module usb_fs_nb_pe #(
   output logic                   sof_valid_o,
   output logic [10:0]            frame_index_o,
 
+  // RX line status
+  output logic                   rx_se0_det_o,
+  output logic                   rx_jjj_det_o,
+
   // RX errors
   output logic                   rx_crc_err_o,
   output logic                   rx_pid_err_o,
   output logic                   rx_bitstuff_err_o,
 
   ///////////////////////////////////////
-  // USB TX/RX Interface (synchronous) //
+  // USB RX Interface (synchronous)    //
   ///////////////////////////////////////
   input  logic                   usb_d_i,
-  input  logic                   usb_se0_i,
+  input  logic                   usb_dp_i,
+  input  logic                   usb_dn_i,
 
+  ///////////////////////////////////////
+  // USB TX Interface (synchronous)    //
+  ///////////////////////////////////////
   output logic                   usb_d_o,
   output logic                   usb_se0_o,
   output logic                   usb_oe_o
@@ -203,8 +212,10 @@ module usb_fs_nb_pe #(
     .rst_ni                 (rst_ni),
     .link_reset_i           (link_reset_i),
     .cfg_eop_single_bit_i   (cfg_eop_single_bit_i),
+    .cfg_rx_differential_i  (cfg_rx_differential_i),
     .usb_d_i                (usb_d_i),
-    .usb_se0_i              (usb_se0_i),
+    .usb_dp_i               (usb_dp_i),
+    .usb_dn_i               (usb_dn_i),
     .tx_en_i                (usb_oe),
     .bit_strobe_o           (bit_strobe),
     .pkt_start_o            (rx_pkt_start),
@@ -216,6 +227,8 @@ module usb_fs_nb_pe #(
     .rx_data_put_o          (rx_data_put),
     .rx_data_o              (rx_data),
     .valid_packet_o         (rx_pkt_valid),
+    .rx_se0_det_o           (rx_se0_det_o),
+    .rx_jjj_det_o           (rx_jjj_det_o),
     .crc_error_o            (rx_crc_err_o),
     .pid_error_o            (rx_pid_err_o),
     .bitstuff_error_o       (rx_bitstuff_err_o)

--- a/hw/ip/usb_fs_nb_pe/rtl/usb_fs_rx.sv
+++ b/hw/ip/usb_fs_nb_pe/rtl/usb_fs_rx.sv
@@ -10,12 +10,14 @@ module usb_fs_rx (
   input  logic rst_ni,
   input  logic link_reset_i,
 
-  // EOP configuration
+  // configuration
   input  logic cfg_eop_single_bit_i,
+  input  logic cfg_rx_differential_i,
 
   // USB data+ and data- lines (synchronous)
   input  logic usb_d_i,
-  input  logic usb_se0_i,
+  input  logic usb_dp_i,
+  input  logic usb_dn_i,
 
   // Transmit enable disables the receier
   input  logic tx_en_i,
@@ -42,6 +44,10 @@ module usb_fs_rx (
   // Most recent packet passes PID and CRC checks
   output logic valid_packet_o,
 
+  // line status for the status detection (actual rx bits after clock recovery)
+  output logic rx_se0_det_o,
+  output logic rx_jjj_det_o,
+
   // Error detection
   output logic crc_error_o,
   output logic pid_error_o,
@@ -56,12 +62,13 @@ module usb_fs_rx (
   // usb receive path //
   //////////////////////
 
+
   ///////////////////////////////////////
   // line state recovery state machine //
   ///////////////////////////////////////
 
-  // The receive path doesn't currently use a differential reciever.  because of
-  // this there is a chance that one of the differential pairs will appear to have
+  // If the receive path is set not to use a differential reciever:
+  // There is a chance that one of the differential pairs will appear to have
   // changed to the new state while the other is still in the old state.  the
   // following state machine detects transitions and waits an extra sampling clock
   // before decoding the state on the differential pair.  this transition period
@@ -69,31 +76,55 @@ module usb_fs_rx (
   // if there is enough noise on the line then the data may be corrupted and the
   // packet will fail the data integrity checks.
 
-  logic [2:0] line_state_q, line_state_d;
+  // If the receive path uses a differential receiver:
+  // The single ended signals must still be recovered to detect SE0
+  // Note that the spec warns in section 7.1.4.1:
+  // Both D+ and D- may temporarily be less than VIH (min) during differential
+  // signal transitions. This period can be up to 14 ns (TFST) for full-speed
+  // transitions and up to 210 ns (TLST) for low-speed transitions. Logic in the
+  // receiver must ensure that that this is not interpreted as an SE0.
+  // Since the 48MHz sample clock is 20.833ns period we will either miss this or
+  // sample it only once, so it will be covered by line_state=DT and the next
+  // sample will not be SE0 unless this was a real SE0 transition
+  // Note: if it is a real SE0 the differential rx could be doing anything
+
+  logic [2:0] line_state_qq, line_state_q, line_state_d;
+  logic [2:0] diff_state_q, diff_state_d;
+  logic [2:0] line_state_rx;
+  logic       use_se;
+
   localparam logic [2:0]  DT = 3'b100; // transition state
   localparam logic [2:0]  DJ = 3'b010; // J - idle line state
-  // localparam logic [2:0]  DK = 3'b001; // K - inverse of J
+  localparam logic [2:0]  DK = 3'b001; // K - inverse of J
   localparam logic [2:0] SE0 = 3'b000; // single-ended 0 - end of packet or detached
   // localparam logic [2:0] SE1 = 3'b011; // single-ended 1 - illegal
 
   // Mute the input if we're transmitting
-  logic [1:0] dpair;
+  logic [1:0] dpair, ddiff;
   always_comb begin : proc_dpair_mute
     if (tx_en_i) begin
       dpair = DJ[1:0]; // J
+      ddiff = DJ[1:0]; // J
     end else begin
-      dpair = (usb_se0_i) ? 2'b00 : {usb_d_i, ~usb_d_i};
+      dpair = {usb_dp_i, usb_dn_i};
+      ddiff = usb_d_i ? DJ[1:0] : DK[1:0]; // equiv to {usb_d_i, ~usb_d_i}
     end
   end
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : proc_line_state_q
     if (!rst_ni) begin
       line_state_q <= SE0;
+      line_state_qq <= SE0;
+      diff_state_q <= SE0;
     end else begin
       if (link_reset_i) begin
         line_state_q <= SE0;
+        line_state_qq <= SE0;
+        diff_state_q <= SE0;
       end else begin
         line_state_q <= line_state_d;
+        line_state_qq <= line_state_q;
+        diff_state_q <= diff_state_d;
       end
     end
   end
@@ -116,6 +147,64 @@ module usb_fs_rx (
     end
   end
 
+  always_comb begin : proc_diff_state_d
+    // Default assignment
+    diff_state_d = diff_state_q;
+
+    if (diff_state_q == DT) begin
+      // if we are in a transition state, then we can sample the diff input and
+      // move to the next corresponding line state
+      diff_state_d = {1'b0, ddiff};
+
+    end else begin
+      // if we are in a valid line state and the value of the diff input changes,
+      // then we need to move to the transition state
+      if (ddiff != diff_state_q[1:0]) begin
+        diff_state_d = DT;
+      end
+    end
+  end
+
+  // The received line state depends on how the receiver is configured:
+  // Single ended only: it is just the line_state_q that was captured
+  //
+  // Differential: recovered from the differential receiver (diff_state_q)
+  //               unless the single ended indicate SE0 when the differential
+  //               receiver could produce any value
+  //
+  // Transition where single ended happens to see SE0 look like (driven by diff DT)
+  // line_state    D? DT D?...
+  // diff_state    Dx DT Dy         (expect Dy to be inverse of Dx since diff changed)
+  //
+  // Transition to SE0 when differential changes will look like:
+  // line_state    DT D? D? D? DT SE0 SE0... (DT is the first sample at SE0)
+  // diff_state    DT Dx Dx Dx DT ??  ??...  (diff saw transition as line went SE0)
+  //    --> out    DT Dx Dx Dx DT SE0 SE0    (if no transition then DT would be Dx and n=3)
+  // bit_phase      n  0  1  2  3  0   1     (n=3 unless there was a clock resync)
+  //
+  // Transition to SE0 when differential does not change will look like:
+  // line_state    DT D? D? D? DT SE0 SE0... (DT is the first sample at SE0)
+  // diff_state    DT Dx Dx Dx Dx ??  ??...  (diff no transition as line went SE0)
+  //    --> out    DT Dx Dx Dx Dx SE0 SE0    (if no transition then DT would be Dx and n=3)
+  // bit_phase      n  0  1  2  3  0   1     (n=3 unless there was a clock resync)
+  //
+  // Transition to SE0 when differential does not change and clock resync earlier:
+  // line_state    DT D? D? DT SE0 SE0 SE0... (DT is the first sample at SE0, should resync clock)
+  // diff_state    DT Dx Dx Dx Dx  ??  ??...  (diff no transition as line went SE0)
+  //    --> out    DT Dx Dx Dx SE0 SE0 SE0    (if no transition then DT would be Dx and n=3)
+  // bit_phase      n  0  1  2  3   0   1     (n=3 unless there was a clock resync)
+  //
+  // On transition back from SE0 want to generate a DT to resync the clock
+  // since SE0 could have gone on a while no idea what bit_phase is
+  // line_state    SE0 SE0 DT D? D? D?
+  // diff_state    ??  ??  ?? Dx Dx Dx
+  //   --> out     SE0 SE0 DT Dx Dx Dx
+  // bit_phase      ?   ?   ?  0  1  2
+
+  assign use_se = (line_state_q == SE0) || ((line_state_q == DT) && (line_state_qq == SE0));
+  assign line_state_rx = cfg_rx_differential_i ? (use_se ? line_state_q : diff_state_q) :
+                                                 line_state_q;
+
   ////////////////////
   // clock recovery //
   ////////////////////
@@ -137,7 +226,7 @@ module usb_fs_rx (
   assign bit_strobe_o     = (bit_phase_q == 2'd2);
 
   // keep track of phase within each bit
-  assign bit_phase_d = (line_state_q == DT) ? 0 : bit_phase_q + 1;
+  assign bit_phase_d = (line_state_rx == DT) ? 0 : bit_phase_q + 1;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : proc_bit_phase_q
     if (!rst_ni) begin
@@ -193,7 +282,7 @@ module usb_fs_rx (
   end
 
   // keep a history of the last two states on the line
-  assign line_history_d = line_state_valid ? {line_history_q[9:0], line_state_q[1:0]} :
+  assign line_history_d = line_state_valid ? {line_history_q[9:0], line_state_rx[1:0]} :
                                               line_history_q;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : proc_reg_pkt_line
@@ -211,6 +300,9 @@ module usb_fs_rx (
     end
   end
 
+  // mask out jjj detection when transmitting (because rx is forced to J)
+  assign rx_se0_det_o = line_history_q[5:0] == 6'b000000; // three SE0s
+  assign rx_jjj_det_o = ~tx_en_i & (line_history_q[5:0] == 6'b101010); // three Js
 
   /////////////////
   // NRZI decode //

--- a/hw/ip/usbdev/data/usbdev.hjson
+++ b/hw/ip/usbdev/data/usbdev.hjson
@@ -209,14 +209,19 @@
               name: "suspend",
               desc: "Link suspended (constant idle for > 3 ms), was active before becoming suspended"
             },
-
+            { value: "5",
+              name: "active_nosof",
+              desc: "Link active but no SOF has been received since the last reset."
+            },
           ]
         }
         {
           bits: "15",
           name: "sense",
           desc: '''
-                Reflects the state of the sense pin. 1 indicates that the host is providing VBUS.
+                Reflects the state of the sense pin.
+		1 indicates that the host is providing VBUS.
+		Note that this bit always shows the state of the actual pin and does not take account of the override control.
                 '''
         }
         {

--- a/hw/ip/usbdev/rtl/usbdev.sv
+++ b/hw/ip/usbdev/rtl/usbdev.sv
@@ -141,13 +141,20 @@ module usbdev (
 
 
   /////////////////////////////////
-  // USB IO after CDC & muxing   //
+  // USB RX after CDC & muxing   //
   /////////////////////////////////
   logic usb_rx_d;
-  logic usb_rx_se0;
+  logic usb_rx_dp;
+  logic usb_rx_dn;
+  /////////////////////////////////
+  // USB TX after CDC & muxing   //
+  /////////////////////////////////
   logic usb_tx_d;
   logic usb_tx_se0;
   logic usb_tx_oe;
+  /////////////////////////////////
+  // USB contol pins after CDC   //
+  /////////////////////////////////
   logic usb_pwr_sense;
   logic usb_pullup_en;
 
@@ -471,7 +478,8 @@ module usbdev (
 
     // Pins
     .usb_d_i              (usb_rx_d),
-    .usb_se0_i            (usb_rx_se0),
+    .usb_dp_i             (usb_rx_dp),
+    .usb_dn_i             (usb_rx_dn),
     .usb_oe_o             (usb_tx_oe),
     .usb_d_o              (usb_tx_d),
     .usb_se0_o            (usb_tx_se0),
@@ -518,6 +526,7 @@ module usbdev (
     .ep_iso_i             (ep_iso), // cdc ok, quasi-static
     .cfg_eop_single_bit_i (reg2hw.phy_config.eop_single_bit.q), // cdc ok: quasi-static
     .tx_osc_test_mode_i   (reg2hw.phy_config.tx_osc_test_mode.q), // cdc ok: quasi-static
+    .cfg_rx_differential_i (reg2hw.phy_config.rx_differential_mode.q), // cdc ok: quasi-static
     .data_toggle_clear_i  (usb_data_toggle_clear),
 
     // status
@@ -944,7 +953,8 @@ module usbdev (
 
     // Internal interface
     .usb_rx_d_o             (usb_rx_d),
-    .usb_rx_se0_o           (usb_rx_se0),
+    .usb_rx_dp_o            (usb_rx_dp),
+    .usb_rx_dn_o            (usb_rx_dn),
     .usb_tx_d_i             (usb_tx_d),
     .usb_tx_se0_i           (usb_tx_se0),
     .usb_tx_oe_i            (usb_tx_oe),

--- a/hw/ip/usbdev/rtl/usbdev_iomux.sv
+++ b/hw/ip/usbdev/rtl/usbdev_iomux.sv
@@ -40,12 +40,11 @@ module usbdev_iomux
 
   // Internal USB Interface (usb clk)
   output logic                          usb_rx_d_o,
-  output logic                          usb_rx_se0_o,
-
+  output logic                          usb_rx_dp_o,
+  output logic                          usb_rx_dn_o,
   input  logic                          usb_tx_d_i,
   input  logic                          usb_tx_se0_i,
   input  logic                          usb_tx_oe_i,
-
   output logic                          usb_pwr_sense_o,
   input  logic                          usb_pullup_en_i,
   input  logic                          usb_suspend_i
@@ -53,15 +52,16 @@ module usbdev_iomux
 
   logic async_pwr_sense, sys_usb_sense;
   logic cio_usb_dp, cio_usb_dn, cio_usb_d;
-  logic usb_rx_dp, usb_rx_dn, usb_rx_d;
   logic pinflip;
   logic unused_eop_single_bit;
+  logic unused_rx_differential_mode;
   logic unused_usb_ref_disable;
   logic unused_tx_osc_test_mode;
 
-  assign unused_eop_single_bit   = sys_reg2hw_config_i.eop_single_bit.q;
-  assign unused_usb_ref_disable  = sys_reg2hw_config_i.usb_ref_disable.q;
-  assign unused_tx_osc_test_mode = sys_reg2hw_config_i.tx_osc_test_mode.q;
+  assign unused_eop_single_bit       = sys_reg2hw_config_i.eop_single_bit.q;
+  assign unused_usb_ref_disable      = sys_reg2hw_config_i.usb_ref_disable.q;
+  assign unused_tx_osc_test_mode     = sys_reg2hw_config_i.tx_osc_test_mode.q;
+  assign unused_rx_differential_mode = sys_reg2hw_config_i.rx_differential_mode.q;
 
   //////////
   // CDCs //
@@ -113,11 +113,12 @@ module usbdev_iomux
 
     // The single-ended signals are only driven in single-ended mode.
     if (sys_reg2hw_config_i.tx_differential_mode.q) begin
-      // Differential TX mode
+      // Differential TX mode (physical IO takes d and se0)
+      // i.e. expect the "else" logic to be in the physical interface
       cio_usb_tx_mode_se_o   = 1'b0;
 
     end else begin
-      // Single-ended TX mode
+      // Single-ended TX mode (physical IO takes dp and dn)
       cio_usb_tx_mode_se_o   = 1'b1;
       if (usb_tx_se0_i) begin
         cio_usb_dp_o = 1'b0;
@@ -139,26 +140,10 @@ module usbdev_iomux
   // USB input pin mux //
   ///////////////////////
 
-  // Note that while transmitting, we fix the receive line to 1. If the receive line isn't fixed,
-  // we are trying to regenerate the bit clock from the bit clock we are regenerating, rather than
-  // just holding the phase.
   // D+/D- can be swapped based on a config register.
-  assign usb_rx_dp = usb_tx_oe_i ? 1'b1 : (pinflip ?  cio_usb_dn : cio_usb_dp);
-  assign usb_rx_dn = usb_tx_oe_i ? 1'b0 : (pinflip ?  cio_usb_dp : cio_usb_dn);
-  assign usb_rx_d  = usb_tx_oe_i ? 1'b1 : (pinflip ? ~cio_usb_d  : cio_usb_d);
-
-  always_comb begin : proc_diff_se_mux_in
-    usb_rx_se0_o = ~usb_rx_dp & ~usb_rx_dn;
-
-    if (sys_reg2hw_config_i.rx_differential_mode.q) begin
-      // Differential RX mode
-      usb_rx_d_o = usb_rx_d;
-
-    end else begin
-      // Single-ended RX mode
-      usb_rx_d_o = usb_rx_dp; // SE1 is interpreted as differential 1
-    end
-  end
+  assign usb_rx_dp_o = pinflip ?  cio_usb_dn : cio_usb_dp;
+  assign usb_rx_dn_o = pinflip ?  cio_usb_dp : cio_usb_dn;
+  assign usb_rx_d_o  = pinflip ? ~cio_usb_d  : cio_usb_d;
 
   // Power sense mux
   always_comb begin : proc_mux_pwr_sense

--- a/hw/ip/usbdev/rtl/usbdev_linkstate.sv
+++ b/hw/ip/usbdev/rtl/usbdev_linkstate.sv
@@ -10,8 +10,8 @@ module usbdev_linkstate (
   input  logic rst_ni,
   input  logic us_tick_i,
   input  logic usb_sense_i,
-  input  logic usb_rx_d_i,
-  input  logic usb_rx_se0_i,
+  input  logic rx_se0_det_i,
+  input  logic rx_jjj_det_i,
   input  logic sof_valid_i,
   output logic link_disconnect_o,  // level
   output logic link_connect_o,     // level
@@ -35,6 +35,7 @@ module usbdev_linkstate (
     LinkPoweredSuspend = 2,
     // Active states
     LinkActive = 3,
+    LinkActiveNoSOF = 5,
     LinkSuspend = 4
   } link_state_e;
 
@@ -51,8 +52,7 @@ module usbdev_linkstate (
   } link_inac_state_e;
 
   link_state_e  link_state_d, link_state_q;
-  logic         line_se0_raw, line_idle_raw;
-  logic         see_se0, see_idle, see_pwr_sense;
+  logic         see_pwr_sense;
 
   // Reset FSM
   logic [2:0]      link_rst_timer_d, link_rst_timer_q;
@@ -75,31 +75,10 @@ module usbdev_linkstate (
   assign link_connect_o    = (link_state_q != LinkDisconnect);
   assign link_suspend_o    = (link_state_q == LinkSuspend ||
     link_state_q == LinkPoweredSuspend);
-  assign link_active_o     = (link_state_q == LinkActive);
+  assign link_active_o     = (link_state_q == LinkActive) ||
+    (link_state_q == LinkActiveNoSOF);
   // Link state is stable, so we can output it to the register
   assign link_state_o      =  link_state_q;
-
-  assign line_se0_raw = usb_rx_se0_i;
-  assign line_idle_raw = usb_rx_d_i && !usb_rx_se0_i; // same as J
-
-  // four ticks is a bit time
-  // Could completely filter out 2-cycle EOP SE0 here but
-  // does not seem needed
-  prim_filter #(.Cycles(6)) filter_se0 (
-    .clk_i    (clk_48mhz_i),
-    .rst_ni   (rst_ni),
-    .enable_i (1'b1),
-    .filter_i (line_se0_raw),
-    .filter_o (see_se0)
-  );
-
-  prim_filter #(.Cycles(6)) filter_idle (
-    .clk_i    (clk_48mhz_i),
-    .rst_ni   (rst_ni),
-    .enable_i (1'b1),
-    .filter_i (line_idle_raw),
-    .filter_o (see_idle)
-  );
 
   prim_filter #(.Cycles(6)) filter_pwr_sense (
     .clk_i    (clk_48mhz_i),
@@ -110,13 +89,14 @@ module usbdev_linkstate (
   );
 
   // Simple events
-  assign ev_bus_active = !see_idle;
+  assign ev_bus_active = !rx_jjj_det_i;
+
+  assign monitor_inac = see_pwr_sense ? ((link_state_q == LinkPowered) | link_active_o) :
+                        1'b0;
 
   always_comb begin
     link_state_d = link_state_q;
     link_resume_o = 0;
-    monitor_inac = see_pwr_sense ? ((link_state_q == LinkPowered) | (link_state_q == LinkActive)) :
-                                   1'b0;
 
     // If VBUS ever goes away the link has disconnected
     if (!see_pwr_sense) begin
@@ -132,7 +112,7 @@ module usbdev_linkstate (
 
         LinkPowered: begin
           if (ev_reset) begin
-            link_state_d = LinkActive;
+            link_state_d = LinkActiveNoSOF;
           end else if (ev_bus_inactive) begin
             link_state_d = LinkPoweredSuspend;
           end
@@ -140,10 +120,22 @@ module usbdev_linkstate (
 
         LinkPoweredSuspend: begin
           if (ev_reset) begin
-            link_state_d = LinkActive;
+            link_state_d = LinkActiveNoSOF;
           end else if (ev_bus_active) begin
             link_resume_o = 1;
             link_state_d  = LinkPowered;
+          end
+        end
+
+        // Active but not yet seen a frame
+        // One reason for getting stuck here is the host thinks it is a LS link
+        // which could happen if the flipped bit does not match the actual pins
+        // Annother is the SI is bad so good data is not recovered from the link
+        LinkActiveNoSOF: begin
+          if (ev_bus_inactive) begin
+            link_state_d = LinkSuspend;
+          end else if (sof_valid_i) begin
+            link_state_d = LinkActive;
           end
         end
 
@@ -151,11 +143,16 @@ module usbdev_linkstate (
         LinkActive: begin
           if (ev_bus_inactive) begin
             link_state_d = LinkSuspend;
+          end else if (ev_reset) begin
+            link_state_d = LinkActiveNoSOF;
           end
         end
 
         LinkSuspend: begin
-          if (ev_reset || ev_bus_active) begin
+          if (ev_reset) begin
+            link_resume_o = 1;
+            link_state_d  = LinkActiveNoSOF;
+          end else if (ev_bus_active) begin
             link_resume_o = 1;
             link_state_d  = LinkActive;
           end
@@ -191,7 +188,7 @@ module usbdev_linkstate (
     unique case (link_rst_state_q)
       // No reset signal detected
       NoRst: begin
-        if (see_se0) begin
+        if (rx_se0_det_i) begin
           link_rst_state_d = RstCnt;
           link_rst_timer_d = 0;
         end
@@ -199,7 +196,7 @@ module usbdev_linkstate (
 
       // Reset signal detected -> counting
       RstCnt: begin
-        if (!see_se0) begin
+        if (!rx_se0_det_i) begin
           link_rst_state_d = NoRst;
         end else begin
           if (us_tick_i) begin
@@ -214,7 +211,7 @@ module usbdev_linkstate (
 
       // Detected reset -> wait for falling edge
       RstPend: begin
-        if (!see_se0) begin
+        if (!rx_se0_det_i) begin
           link_rst_state_d = NoRst;
           ev_reset = 1'b1;
         end
@@ -251,14 +248,14 @@ module usbdev_linkstate (
       // Active or disabled
       Active: begin
         link_inac_timer_d = 0;
-        if (see_idle && monitor_inac) begin
+        if (!ev_bus_active && monitor_inac) begin
           link_inac_state_d = InactCnt;
         end
       end
 
       // Got an inactivity signal -> count duration
       InactCnt: begin
-        if (!see_idle || !monitor_inac) begin
+        if (ev_bus_active || !monitor_inac) begin
           link_inac_state_d  = Active;
         end else if (us_tick_i) begin
           if (link_inac_timer_q == SUSPEND_TIMEOUT) begin
@@ -272,7 +269,7 @@ module usbdev_linkstate (
 
       // Counter expired & event sent, wait here
       InactPend: begin
-        if (!see_idle || !monitor_inac) begin
+        if (ev_bus_active || !monitor_inac) begin
           link_inac_state_d  = Active;
         end
       end

--- a/hw/ip/usbdev/rtl/usbdev_usbif.sv
+++ b/hw/ip/usbdev/rtl/usbdev_usbif.sv
@@ -24,7 +24,8 @@ module usbdev_usbif  #(
 
   // Pins (synchronous)
   input  logic                     usb_d_i,
-  input  logic                     usb_se0_i,
+  input  logic                     usb_dp_i,
+  input  logic                     usb_dn_i,
 
   output logic                     usb_d_o,
   output logic                     usb_se0_o,
@@ -72,6 +73,7 @@ module usbdev_usbif  #(
   output logic                     clr_devaddr_o,
   input  logic [NEndpoints-1:0]    ep_iso_i,
   input  logic                     cfg_eop_single_bit_i, // 1: detect a single SE0 bit as EOP
+  input  logic                     cfg_rx_differential_i, // 1: use differential rx data on usb_d_i
   input  logic                     tx_osc_test_mode_i, // Oscillator test mode: constant JK output
   input  logic [NEndpoints-1:0]    data_toggle_clear_i, // Clear the data toggles for an EP
 
@@ -258,6 +260,7 @@ module usbdev_usbif  #(
   assign set_sent_o = in_ep_acked;
 
   logic [10:0]     frame_index_raw;
+  logic            rx_se0_det, rx_jjj_det;
 
   usb_fs_nb_pe #(
     .NumOutEps      (NEndpoints),
@@ -269,11 +272,13 @@ module usbdev_usbif  #(
     .link_reset_i          (link_reset),
 
     .cfg_eop_single_bit_i  (cfg_eop_single_bit_i),
+    .cfg_rx_differential_i (cfg_rx_differential_i),
     .tx_osc_test_mode_i    (tx_osc_test_mode_i),
     .data_toggle_clear_i   (data_toggle_clear_i),
 
     .usb_d_i               (usb_d_i),
-    .usb_se0_i             (usb_se0_i),
+    .usb_dp_i              (usb_dp_i),
+    .usb_dn_i              (usb_dn_i),
     .usb_d_o               (usb_d_o),
     .usb_se0_o             (usb_se0_o),
     .usb_oe_o              (usb_oe_o),
@@ -305,6 +310,10 @@ module usbdev_usbif  #(
     .in_ep_data_i          (in_ep_data),
     .in_ep_data_done_i     (in_ep_data_done),
     .in_ep_iso_i           (ep_iso_i),
+
+    // rx status
+    .rx_se0_det_o          (rx_se0_det),
+    .rx_jjj_det_o          (rx_jjj_det),
 
     // error signals
     .rx_crc_err_o          (rx_crc_err_o),
@@ -349,8 +358,8 @@ module usbdev_usbif  #(
     .rst_ni            (rst_ni),
     .us_tick_i         (us_tick),
     .usb_sense_i       (usb_sense_i),
-    .usb_rx_d_i        (usb_d_i),
-    .usb_rx_se0_i      (usb_se0_i),
+    .rx_se0_det_i      (rx_se0_det),
+    .rx_jjj_det_i      (rx_jjj_det),
     .sof_valid_i       (sof_valid),
     .link_disconnect_o (link_disconnect_o),
     .link_connect_o    (link_connect_o),

--- a/hw/top_earlgrey/data/pins_nexysvideo.xdc
+++ b/hw/top_earlgrey/data/pins_nexysvideo.xdc
@@ -130,11 +130,12 @@ set_property -dict { PACKAGE_PIN V9    IOSTANDARD LVCMOS33 DRIVE 8 SLEW FAST } [
 set_property -dict { PACKAGE_PIN V8    IOSTANDARD LVCMOS33 DRIVE 8 SLEW FAST } [get_ports { IO_USB_DN0 }]; #IO_L21N_T3_DQS_34 Sch=jb_n[1]
 set_property -dict { PACKAGE_PIN V7    IOSTANDARD LVCMOS33 } [get_ports { IO_USB_DPPULLUP0 }]; #IO_L19P_T3_34 Sch=jb_p[2]
 set_property -dict { PACKAGE_PIN W7    IOSTANDARD LVCMOS33 } [get_ports { IO_USB_SENSE0 }]; #IO_L19N_T3_VREF_34 Sch=jb_n[2]
+set_property -dict { PACKAGE_PIN Y8    IOSTANDARD LVCMOS33 } [get_ports { IO_USB_DNPULLUP0 }]; #IO_L23P_T3_34 Sch=jb_p[4]
+
+## Pmod header JB UNUSED pins (used for testing 2 USB interfaces)
 #set_property -dict { PACKAGE_PIN W9    IOSTANDARD LVCMOS33 DRIVE 8 SLEW FAST } [get_ports { IO_USB_DP1 }]; #IO_L24P_T3_34 Sch=jb_p[3]
 #set_property -dict { PACKAGE_PIN Y9    IOSTANDARD LVCMOS33 DRIVE 8 SLEW FAST } [get_ports { IO_USB_DN1 }]; #IO_L24N_T3_34 Sch=jb_n[3]
-set_property -dict { PACKAGE_PIN Y8    IOSTANDARD LVCMOS33 } [get_ports { IO_USB_DNPULLUP0 }]; #IO_L23P_T3_34 Sch=jb_p[4]
 #set_property -dict { PACKAGE_PIN Y7    IOSTANDARD LVCMOS33 } [get_ports { IO_USB_SENSE1 }]; #IO_L23N_T3_34 Sch=jb_n[4]
-
 
 ## Pmod header JC
 #set_property -dict { PACKAGE_PIN Y6    IOSTANDARD LVCMOS33 } [get_ports { IO_SDCK   }]; #IO_L18P_T2_34 Sch=jc_p[1]

--- a/hw/top_earlgrey/rtl/top_earlgrey_nexysvideo.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_nexysvideo.sv
@@ -60,9 +60,9 @@ module top_earlgrey_nexysvideo #(
   logic [padctrl_reg_pkg::NMioPads-1:0] mio_out_core, mio_out_padring;
   logic [padctrl_reg_pkg::NMioPads-1:0] mio_oe_core, mio_oe_padring;
   logic [padctrl_reg_pkg::NMioPads-1:0] mio_in_core, mio_in_padring;
-  logic [padctrl_reg_pkg::NDioPads-1:0] dio_out_core, dio_out_padring;
-  logic [padctrl_reg_pkg::NDioPads-1:0] dio_oe_core, dio_oe_padring;
-  logic [padctrl_reg_pkg::NDioPads-1:0] dio_in_core, dio_in_padring;
+  logic [padctrl_reg_pkg::NDioPads-1:0] dio_out_core, dio_out_umux, dio_out_padring;
+  logic [padctrl_reg_pkg::NDioPads-1:0] dio_oe_core, dio_oe_umux, dio_oe_padring;
+  logic [padctrl_reg_pkg::NDioPads-1:0] dio_in_core, dio_in_umux, dio_in_padring;
 
   padring #(
     // MIOs 31:20 are currently not
@@ -177,15 +177,70 @@ module top_earlgrey_nexysvideo #(
     .jtag_srst_no ( jtag_srst_n     ),
     .jtag_tdi_o   ( jtag_tdi        ),
     .jtag_tdo_i   ( jtag_tdo        ),
-    // To core side
-    .out_core_i   ( {dio_out_core, mio_out_core} ),
-    .oe_core_i    ( {dio_oe_core,  mio_oe_core}  ),
-    .in_core_o    ( {dio_in_core,  mio_in_core}  ),
+    // To core side via usbmux for DIOs
+    .out_core_i   ( {dio_out_umux, mio_out_core} ),
+    .oe_core_i    ( {dio_oe_umux,  mio_oe_core}  ),
+    .in_core_o    ( {dio_in_umux,  mio_in_core}  ),
     // To padring side
     .out_padring_o ( {dio_out_padring, mio_out_padring} ),
-    .oe_padring_o  ( {dio_oe_padring , mio_oe_padring } ),
-    .in_padring_i  ( {dio_in_padring , mio_in_padring } )
+    .oe_padring_o  ( {dio_oe_padring, mio_oe_padring } ),
+    .in_padring_i  ( {dio_in_padring, mio_in_padring } )
   );
+
+  // Software can enable the pinflip feature inside usbdev.
+  // The example hello_usbdev does this based on GPIO0 (a switch on the board)
+  //
+  // Here, we use the state of the DN pullup to effectively undo the
+  // swapping such that the PCB always sees the unflipped D+/D-. We
+  // could do the same inside the .xdc file but then two FPGA
+  // bitstreams would be needed for testing.
+  //
+  // dio_in/out/oe map is: PADS <- _padring <- JTAG mux -> _umux -> USB mux -> _core
+  localparam int DioIdxUsbDn0 = top_earlgrey_pkg::TopEarlgreyDioPinUsbdevDn;
+  localparam int DioIdxUsbDp0 = top_earlgrey_pkg::TopEarlgreyDioPinUsbdevDp;
+  localparam int DioIdxUsbDnPullup0 = top_earlgrey_pkg::TopEarlgreyDioPinUsbdevDnPullup;
+  localparam int DioIdxUsbDpPullup0 = top_earlgrey_pkg::TopEarlgreyDioPinUsbdevDpPullup;
+
+  // The output enable for IO_USB_DNPULLUP0 is used to decide whether we need to undo the swapping.
+  logic undo_swap;
+  assign undo_swap = dio_oe_core[DioIdxUsbDnPullup0];
+
+  for (genvar i = 0; i < padctrl_reg_pkg::NDioPads; i++) begin : gen_dio
+    if (i == DioIdxUsbDn0) begin
+      assign dio_out_umux[i] = undo_swap ? dio_out_core[DioIdxUsbDp0] :
+                                           dio_out_core[DioIdxUsbDn0];
+      assign dio_oe_umux[i]  = undo_swap ? dio_oe_core[DioIdxUsbDp0] :
+                                           dio_oe_core[DioIdxUsbDn0];
+      assign dio_in_core[i]  = undo_swap ? dio_in_umux[DioIdxUsbDp0] :
+                                           dio_in_umux[DioIdxUsbDn0];
+    end else if (i == DioIdxUsbDp0) begin
+      assign dio_out_umux[i] = undo_swap ? dio_out_core[DioIdxUsbDn0] :
+                                           dio_out_core[DioIdxUsbDp0];
+      assign dio_oe_umux[i]  = undo_swap ? dio_oe_core[DioIdxUsbDn0] :
+                                           dio_oe_core[DioIdxUsbDp0];
+      assign dio_in_core[i]  = undo_swap ? dio_in_umux[DioIdxUsbDn0] :
+                                           dio_in_umux[DioIdxUsbDp0];
+    end else if (i == DioIdxUsbDnPullup0) begin
+      assign dio_out_umux[i] = undo_swap ? dio_out_core[DioIdxUsbDpPullup0] :
+                                           dio_out_core[DioIdxUsbDnPullup0];
+      assign dio_oe_umux[i]  = undo_swap ? dio_oe_core[DioIdxUsbDpPullup0] :
+                                           dio_oe_core[DioIdxUsbDnPullup0];
+      assign dio_in_core[i]  = dio_in_umux[i];
+    end else if (i == DioIdxUsbDpPullup0) begin
+      assign dio_out_umux[i] = undo_swap ? dio_out_core[DioIdxUsbDnPullup0] :
+                                           dio_out_core[DioIdxUsbDpPullup0];
+      assign dio_oe_umux[i]  = undo_swap ? dio_oe_core[DioIdxUsbDnPullup0] :
+                                           dio_oe_core[DioIdxUsbDpPullup0];
+      assign dio_in_core[i]  = dio_in_umux[i];
+    end else begin
+      assign dio_out_umux[i] = dio_out_core[i];
+      assign dio_oe_umux[i]  = dio_oe_core[i];
+      assign dio_in_core[i]  = dio_in_umux[i];
+    end
+  end
+
+
+
 
   //////////////////
   // PLL for FPGA //

--- a/hw/top_earlgrey/rtl/top_earlgrey_verilator.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_verilator.sv
@@ -204,37 +204,33 @@ module top_earlgrey_verilator (
 
   // USB DPI
   usbdpi u_usbdpi (
-    .clk_i         (clk_i),
-    .rst_ni        (rst_ni),
-    .clk_48MHz_i   (clk_i),
-    .sense_p2d     (cio_usbdev_sense_p2d),
-    .pullup_d2p    (cio_usbdev_dp_pullup_d2p),
-    .pullup_en_d2p (cio_usbdev_dp_pullup_en_d2p),
-    .dp_p2d        (cio_usbdev_dp_p2d),
-    .dp_d2p        (cio_usbdev_dp_d2p),
-    .dp_en_d2p     (cio_usbdev_dp_en_d2p),
-    .dn_p2d        (cio_usbdev_dn_p2d),
-    .dn_d2p        (cio_usbdev_dn_d2p),
-    .dn_en_d2p     (cio_usbdev_dn_en_d2p)
+    .clk_i           (clk_i),
+    .rst_ni          (rst_ni),
+    .clk_48MHz_i     (clk_i),
+    .sense_p2d       (cio_usbdev_sense_p2d),
+    .pullupdp_d2p    (cio_usbdev_dp_pullup_d2p),
+    .pullupdp_en_d2p (cio_usbdev_dp_pullup_en_d2p),
+    .pullupdn_d2p    (cio_usbdev_dn_pullup_d2p),
+    .pullupdn_en_d2p (cio_usbdev_dn_pullup_en_d2p),
+    .dp_p2d          (cio_usbdev_dp_p2d),
+    .dp_d2p          (cio_usbdev_dp_d2p),
+    .dp_en_d2p       (cio_usbdev_dp_en_d2p),
+    .dn_p2d          (cio_usbdev_dn_p2d),
+    .dn_d2p          (cio_usbdev_dn_d2p),
+    .dn_en_d2p       (cio_usbdev_dn_en_d2p),
+    .d_p2d           (cio_usbdev_d_p2d),
+    .d_d2p           (cio_usbdev_d_d2p),
+    .d_en_d2p        (cio_usbdev_d_en_d2p),
+    .se0_d2p         (cio_usbdev_se0_d2p),
+    .se0_en_d2p      (cio_usbdev_se0_en_d2p),
+    .txmode_d2p      (cio_usbdev_tx_mode_se_d2p),
+    .txmode_en_d2p   (cio_usbdev_tx_mode_se_en_d2p)
   );
 
   // Tie off unused signals.
-  logic unused_cio_usbdev_se0_d2p, unused_cio_usbdev_se0_en_d2p;
-  logic unused_cio_usbdev_dn_pullup_d2p, unused_cio_usbdev_dn_pullup_en_d2p;
-  logic unused_cio_usbdev_tx_mode_se_d2p, unused_cio_usbdev_tx_mode_se_en_d2p;
   logic unused_cio_usbdev_suspend_d2p, unused_cio_usbdev_suspend_en_d2p;
-  logic unused_cio_usbdev_d_d2p, unused_cio_usbdev_d_en_d2p;
-  assign unused_cio_usbdev_se0_d2p = cio_usbdev_se0_d2p;
-  assign unused_cio_usbdev_se0_en_d2p = cio_usbdev_se0_en_d2p;
-  assign unused_cio_usbdev_dn_pullup_d2p = cio_usbdev_dn_pullup_d2p;
-  assign unused_cio_usbdev_dn_pullup_en_d2p = cio_usbdev_dn_pullup_en_d2p;
-  assign unused_cio_usbdev_tx_mode_se_d2p = cio_usbdev_tx_mode_se_d2p;
-  assign unused_cio_usbdev_tx_mode_se_en_d2p = cio_usbdev_tx_mode_se_en_d2p;
   assign unused_cio_usbdev_suspend_d2p = cio_usbdev_suspend_d2p;
   assign unused_cio_usbdev_suspend_en_d2p = cio_usbdev_suspend_en_d2p;
-  assign cio_usbdev_d_p2d = 1'b0;
-  assign unused_cio_usbdev_d_d2p = cio_usbdev_d_d2p;
-  assign unused_cio_usbdev_d_en_d2p = cio_usbdev_d_en_d2p;
 
   // monitor for termination
 `ifndef END_MON_PATH

--- a/hw/top_earlgrey/util/opentitan_earlgrey_usbdev_pin_config_sim.sh
+++ b/hw/top_earlgrey/util/opentitan_earlgrey_usbdev_pin_config_sim.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Simulator executable
+VERILATOR=build/lowrisc_systems_top_earlgrey_verilator_0.1/sim-verilator/Vtop_earlgrey_verilator
+
+# Code to load
+ROMCODE=build-bin/sw/device/boot_rom/boot_rom_sim_verilator.elf
+FLASH=build-bin/sw/device/examples/hello_usbdev/hello_usbdev_sim_verilator.elf
+
+# Where simulator output or control fifos are put
+VFILE_DIR=.
+
+# How long to simulate
+SIM_CYCLES=700000
+
+# Expected output
+EXPECT_USB=hw/top_earlgrey/util/opentitan_earlgrey_usbdev_expected-usb.log
+EXPECT_UART=hw/top_earlgrey/util/opentitan_earlgrey_usbdev_expected-uart.log
+
+# Expected differences in output between noflip se and the others
+IGNORE_USB="-I Pullup.change"
+IGNORE_UART="-I PHY.settings"
+
+echo "Simulation with normal pins, singleended"
+$VERILATOR --meminit=rom,$ROMCODE --meminit=flash,$FLASH -c $SIM_CYCLES &
+sleep 1
+echo 'l01 l00' > $VFILE_DIR/gpio0-write && cat $VFILE_DIR/gpio0-read
+cp $VFILE_DIR/usb0.log $VFILE_DIR/usb-noflip-se.log
+cp $VFILE_DIR/uart0.log $VFILE_DIR/uart-noflip-se.log
+
+
+echo "Simulation with flipped pins, singleended"
+$VERILATOR --meminit=rom,$ROMCODE --meminit=flash,$FLASH -c $SIM_CYCLES &
+sleep 1
+echo 'l01 h00' > $VFILE_DIR/gpio0-write && cat $VFILE_DIR/gpio0-read
+cp $VFILE_DIR/usb0.log $VFILE_DIR/usb-flip-se.log
+cp $VFILE_DIR/uart0.log $VFILE_DIR/uart-flip-se.log
+
+echo "Simulation with normal pins, differential"
+$VERILATOR --meminit=rom,$ROMCODE --meminit=flash,$FLASH -c $SIM_CYCLES &
+sleep 1
+echo 'h01 l00' > $VFILE_DIR/gpio0-write && cat $VFILE_DIR/gpio0-read
+cp $VFILE_DIR/usb0.log $VFILE_DIR/usb-noflip-diff.log
+cp $VFILE_DIR/uart0.log $VFILE_DIR/uart-noflip-diff.log
+
+echo "Simulation with flipped pins, differential"
+$VERILATOR --meminit=rom,$ROMCODE --meminit=flash,$FLASH -c $SIM_CYCLES &
+sleep 1
+echo 'h01 h00' > $VFILE_DIR/gpio0-write && cat $VFILE_DIR/gpio0-read
+cp $VFILE_DIR/usb0.log $VFILE_DIR/usb-flip-diff.log
+cp $VFILE_DIR/uart0.log $VFILE_DIR/uart-flip-diff.log
+
+echo "Check No Flip Single Ended against expected logs"
+diff $VFILE_DIR/usb-noflip-se.log $EXPECT_USB
+diff $VFILE_DIR/uart-noflip-se.log $EXPECT_UART
+
+echo "Check Flipped Single Ended against No Flip Single Ended"
+diff $IGNORE_USB $VFILE_DIR/usb-flip-se.log $VFILE_DIR/usb-noflip-se.log
+diff $IGNORE_UART $VFILE_DIR/uart-flip-se.log $VFILE_DIR/uart-noflip-se.log
+
+echo "Check No Flip differential against No Flip Single Ended"
+diff $IGNORE_USB $VFILE_DIR/usb-noflip-diff.log $VFILE_DIR/usb-noflip-se.log
+diff $IGNORE_UART $VFILE_DIR/uart-noflip-diff.log $VFILE_DIR/uart-noflip-se.log
+
+echo "Check Flipped differential against No Flip Single Ended"
+diff $IGNORE_USB $VFILE_DIR/usb-flip-diff.log $VFILE_DIR/usb-noflip-se.log
+diff $IGNORE_UART $VFILE_DIR/uart-flip-diff.log $VFILE_DIR/uart-noflip-se.log

--- a/sw/device/lib/usbdev.c
+++ b/sw/device/lib/usbdev.c
@@ -251,7 +251,7 @@ void usbdev_endpoint_setup(usbdev_ctx_t *ctx, int ep, int enableout,
   }
 }
 
-void usbdev_init(usbdev_ctx_t *ctx) {
+void usbdev_init(usbdev_ctx_t *ctx, bool pinflip, bool diff_rx, bool diff_tx) {
   // setup context
   for (int i = 0; i < NUM_ENDPOINTS; i++) {
     usbdev_endpoint_setup(ctx, i, 0, NULL, NULL, NULL, NULL, NULL);
@@ -268,6 +268,12 @@ void usbdev_init(usbdev_ctx_t *ctx) {
 
   REG32(USBDEV_RXENABLE_SETUP()) = (1 << USBDEV_RXENABLE_SETUP_SETUP_0);
   REG32(USBDEV_RXENABLE_OUT()) = (1 << USBDEV_RXENABLE_OUT_OUT_0);
+
+  uint32_t phy_config = (pinflip << USBDEV_PHY_CONFIG_PINFLIP) |
+                        (diff_rx << USBDEV_PHY_CONFIG_RX_DIFFERENTIAL_MODE) |
+                        (diff_tx << USBDEV_PHY_CONFIG_TX_DIFFERENTIAL_MODE) |
+                        (1 << USBDEV_PHY_CONFIG_EOP_SINGLE_BIT);
+  REG32(USBDEV_PHY_CONFIG()) = phy_config;
 
   REG32(USBDEV_USBCTRL()) = (1 << USBDEV_USBCTRL_ENABLE);
 }

--- a/sw/device/lib/usbdev.h
+++ b/sw/device/lib/usbdev.h
@@ -5,6 +5,7 @@
 #ifndef OPENTITAN_SW_DEVICE_LIB_USBDEV_H_
 #define OPENTITAN_SW_DEVICE_LIB_USBDEV_H_
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -221,8 +222,11 @@ void usbdev_endpoint_setup(usbdev_ctx_t *ctx, int ep, int enableout,
  * Initialize the usbdev interface
  *
  * @param ctx uninitialized usbdev context pointer
+ * @param pinflip boolean to indicate if PHY should be configured for D+/D- flip
+ * @param diff_rx boolean to indicate if PHY uses differential RX
+ * @param diff_tx boolean to indicate if PHY uses differential TX
  */
-void usbdev_init(usbdev_ctx_t *ctx);
+void usbdev_init(usbdev_ctx_t *ctx, bool pinflip, bool diff_rx, bool diff_tx);
 
 // Used for tracing what is going on. This may impact timing which is critical
 // when simulating with the USB DPI module.

--- a/sw/device/tests/usbdev_test.c
+++ b/sw/device/tests/usbdev_test.c
@@ -89,7 +89,8 @@ bool test_main(void) {
   // Call `usbdev_init` here so that DPI will not start until the
   // simulation has finished all of the printing, which takes a while
   // if `--trace` was passed in.
-  usbdev_init(&usbdev);
+  usbdev_init(&usbdev, /* pinflip= */ false, /* rx_diff= */ false,
+              /* tx_diff= */ false);
   usb_controlep_init(&usbdev_control, &usbdev, 0, config_descriptors,
                      sizeof(config_descriptors));
   usb_simpleserial_init(&simple_serial, &usbdev, 1, usb_receipt_callback);


### PR DESCRIPTION
The differental mode reception and conversion was being done in the iomux
and potentially not passing all information to the usb_fs_rx module. Reworked
to pass the single ended and differential data to usb_fs_rx, recover them
both and use the configured mode to forward appropriately.

This changes the usbdev_iomux to only synchronize and pinflip I/O and
pass the rx d, d+ and d- to receive logic.

As part of debug fixed verilator UNOPTFLAT complaint and added a link
state representing the link being active but never seen SOF because this
is where a flipped link gets stuck between FPGA board and Linux. (The
flipped pullup will make it look like a LS not FS link so the 1.5Mbit
chatter is enough to get rx PID erros but also keeps resetting the
link so host_lost never fires).

Update verilator top and usbdpi to manage all the I/Os. And add code
to the usbdpi to be able to simulate pinflip and differential as well
as the normal pin mode. Note that because there is no other signal it
uses the tx_mode_se signal to control use of differential mode in both
tx and rx directions (so it only works if both phy config bits are the
same). It uses the DN PULLUP being asserted to detect flip.

Update hello_usbdev.c to set the phy config from gpio pins. These
are switches on the nexysvideo and can be set using gpio-dpi in
verilator.

Update top_earlgrey_nexysvideo to be able to fake swapping of USB pins.
Uses DN pullup to cause the pins used for DP and DN to be swapped, allows
testing of both flip options with one FPGA build.

Tested with verilator that all four settings of PINFLIP and DIFFIO in
hello_usb.c get the same expected output. Added a script to run all
four simulations (setting the GPIOs to control).

Tested with FPGA that PINFLIP=0,1 both work by setting the switch.

Included changes requested in software and hardware reviews.

Fixes 2598

Signed-off-by: Mark Hayter <mark.hayter@gmail.com>