### PR TITLE
[util] Rejig how we load hjson configurations for dvsim.py

### DIFF
--- a/hw/dv/tools/dvsim/common_sim_cfg.hjson
+++ b/hw/dv/tools/dvsim/common_sim_cfg.hjson
@@ -2,11 +2,11 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  // Where to find DV code
-  dv_root:          "{proj_root}/hw/dv"
-
   flow:             sim
   flow_makefile:    "{dv_root}/tools/dvsim/sim.mk"
+
+  // Where to find DV code
+  dv_root:          "{proj_root}/hw/dv"
 
   import_cfgs:      ["{proj_root}/hw/data/common_project_cfg.hjson",
                      "{dv_root}/tools/dvsim/common_modes.hjson",

--- a/hw/formal/tools/dvsim/common_fpv_cfg.hjson
+++ b/hw/formal/tools/dvsim/common_fpv_cfg.hjson
@@ -9,6 +9,8 @@
                      "{proj_root}/hw/data/common_project_cfg.hjson",
                      "{proj_root}/hw/formal/tools/{tool}/{tool}.hjson"]
 
+  tool:             "jaspergold"
+
   // Default directory structure for the output
   dut:              "{name}"
   build_dir:        "{scratch_path}/{build_mode}"

--- a/hw/syn/tools/dvsim/common_syn_cfg.hjson
+++ b/hw/syn/tools/dvsim/common_syn_cfg.hjson
@@ -17,6 +17,8 @@
   build_dir:        "{scratch_path}/{build_mode}"
   build_log:        "{build_dir}/synthesis.log"
 
+  tool:             "dc"
+
   // We rely on Fusesoc to generate the file list for us
   sv_flist_gen_cmd:   "fusesoc"
   fusesoc_core_:      "{eval_cmd} echo \"{fusesoc_core}\" | tr ':' '_'"

--- a/hw/top_earlgrey/dv/top_earlgrey_sim_cfgs.hjson
+++ b/hw/top_earlgrey/dv/top_earlgrey_sim_cfgs.hjson
@@ -10,6 +10,8 @@
   import_cfgs: [// Project wide common cfg file
                 "{proj_root}/hw/data/common_project_cfg.hjson"]
 
+  flow: sim
+
   use_cfgs: ["{proj_root}/hw/ip/aes/dv/aes_sim_cfg.hjson",
              "{proj_root}/hw/ip/entropy_src/dv/entropy_src_sim_cfg.hjson",
              "{proj_root}/hw/ip/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson",

--- a/hw/top_earlgrey/fpv/top_earlgrey_fpv_cfgs.hjson
+++ b/hw/top_earlgrey/fpv/top_earlgrey_fpv_cfgs.hjson
@@ -11,6 +11,8 @@
   import_cfgs: [// common server configuration for results upload
                 "{proj_root}/hw/data/common_project_cfg.hjson"]
 
+  flow: "fpv"
+
   use_cfgs: [// TODO: implement some switch to only select "_fpv" testbenches
              // TODO: if we default "_fpv" cov to be on, and the rest of the tbs cov off, need a
              // command-line switch to disable cov.

--- a/hw/top_earlgrey/lint/top_earlgrey_dv_lint_cfgs.hjson
+++ b/hw/top_earlgrey/lint/top_earlgrey_dv_lint_cfgs.hjson
@@ -13,6 +13,8 @@
                      // tool-specific configuration
                      "{proj_root}/hw/lint/tools/dvsim/{tool}.hjson"]
 
+  flow: "lint"
+
   // Different dashboard output path for each tool
   rel_path: "hw/top_earlgrey/dv/lint/{tool}"
 

--- a/hw/top_earlgrey/lint/top_earlgrey_lint_cfgs.hjson
+++ b/hw/top_earlgrey/lint/top_earlgrey_lint_cfgs.hjson
@@ -8,6 +8,8 @@
   // them all as a regression in one shot.
   name: top_earlgrey_batch
 
+  flow: lint
+
   import_cfgs:      [// common server configuration for results upload
                      "{proj_root}/hw/data/common_project_cfg.hjson"
                      // tool-specific configuration

--- a/util/dvsim/CfgFactory.py
+++ b/util/dvsim/CfgFactory.py
@@ -1,0 +1,100 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import logging as log
+import sys
+
+from CfgJson import load_hjson
+
+import FpvCfg
+import LintCfg
+import SimCfg
+import SynCfg
+
+
+def _load_cfg(path, initial_values):
+    '''Worker function for make_cfg.
+
+    initial_values is passed to load_hjson (see documentation there).
+
+    Returns a pair (cls, hjson_data) on success or raises a RuntimeError on
+    failure.
+
+    '''
+    # Start by loading up the hjson file and any included files
+    hjson_data = load_hjson(path, initial_values)
+
+    # Look up the value of flow in the loaded data. This is a required field,
+    # and tells us what sort of FlowCfg to make.
+    flow = hjson_data.get('flow')
+    if flow is None:
+        raise RuntimeError('{!r}: No value for the "flow" key. Are you sure '
+                           'this is a dvsim configuration file?'
+                           .format(path))
+
+    classes = [
+        LintCfg.LintCfg,
+        SynCfg.SynCfg,
+        FpvCfg.FpvCfg,
+        SimCfg.SimCfg
+    ]
+    found_cls = None
+    known_types = []
+    for cls in classes:
+        assert cls.flow is not None
+        known_types.append(cls.flow)
+        if cls.flow == flow:
+            found_cls = cls
+            break
+    if found_cls is None:
+        raise RuntimeError('{}: Configuration file sets "flow" to {!r}, but '
+                           'this is not a known flow (known: {}).'
+                           .format(path, flow, ', '.join(known_types)))
+
+    return (found_cls, hjson_data)
+
+
+def _make_child_cfg(path, args, initial_values):
+    try:
+        cls, hjson_data = _load_cfg(path, initial_values)
+    except RuntimeError as err:
+        log.error(str(err))
+        sys.exit(1)
+
+    # Since this is a child configuration (from some primary configuration),
+    # make sure that we aren't ourselves a primary configuration. We don't need
+    # multi-level hierarchies and this avoids circular dependencies.
+    if 'use_cfgs' in hjson_data:
+        raise RuntimeError('{}: Configuration file has use_cfgs, but is '
+                           'itself included from another configuration.'
+                           .format(path))
+
+    # Call cls as a constructor. Note that we pass None as the mk_config
+    # argument: this is not supposed to load anything else.
+    return cls(path, hjson_data, args, None)
+
+
+def make_cfg(path, args, proj_root):
+    '''Make a flow config by loading the config file at path
+
+    args is the arguments passed to the dvsim.py tool and proj_root is the top
+    of the project.
+
+    '''
+    initial_values = {'proj_root': proj_root}
+    if args.tool is not None:
+        initial_values['tool'] = args.tool
+
+    try:
+        cls, hjson_data = _load_cfg(path, initial_values)
+    except RuntimeError as err:
+        log.error(str(err))
+        sys.exit(1)
+
+    def factory(child_path):
+        child_ivs = initial_values.copy()
+        child_ivs['flow'] = hjson_data['flow']
+        return _make_child_cfg(child_path, args, child_ivs)
+
+    return cls(path, hjson_data, args, factory)

--- a/util/dvsim/CfgJson.py
+++ b/util/dvsim/CfgJson.py
@@ -1,0 +1,172 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+'''A wrapper for loading hjson files as used by dvsim's FlowCfg'''
+
+from utils import parse_hjson, subst_wildcards
+
+
+# A set of fields that can be overridden on the command line and shouldn't be
+# loaded from the hjson in that case.
+_CMDLINE_FIELDS = {'tool'}
+
+
+def load_hjson(path, initial_values):
+    '''Load an hjson file and any includes
+
+    Combines them all into a single dictionary, which is then returned. This
+    does wildcard substitution on include names (since it might be needed to
+    find included files), but not otherwise.
+
+    initial_values is a starting point for the dictionary to be returned (which
+    is not modified). It needs to contain values for anything needed to resolve
+    include files (typically, this is 'proj_root' and 'tool' (if set)).
+
+    '''
+    worklist = [path]
+    seen = {path}
+    ret = initial_values.copy()
+    is_first = True
+
+    # Figure out a list of fields that had a value from the command line. These
+    # should have been passed in as part of initial_values and we need to know
+    # that we can safely ignore updates.
+    arg_keys = _CMDLINE_FIELDS & initial_values.keys()
+
+    while worklist:
+        next_path = worklist.pop()
+        new_paths = _load_single_file(ret, next_path, is_first, arg_keys)
+        if set(new_paths) & seen:
+            raise RuntimeError('{!r}: The file {!r} appears more than once '
+                               'when processing includes.'
+                               .format(path, next_path))
+        seen |= set(new_paths)
+        worklist += new_paths
+        is_first = False
+
+    return ret
+
+
+def _load_single_file(target, path, is_first, arg_keys):
+    '''Load a single hjson file, merging its keys into target
+
+    Returns a list of further includes that should be loaded.
+
+    '''
+    hjson = parse_hjson(path)
+    if not isinstance(hjson, dict):
+        raise RuntimeError('{!r}: Top-level hjson object is not a dictionary.'
+                           .format(path))
+
+    import_cfgs = []
+    for key, dict_val in hjson.items():
+        # If this key got set at the start of time and we want to ignore any
+        # updates: ignore them!
+        if key in arg_keys:
+            continue
+
+        # If key is 'import_cfgs', this should be a list. Add each item to the
+        # list of cfgs to process
+        if key == 'import_cfgs':
+            if not isinstance(dict_val, list):
+                raise RuntimeError('{!r}: import_cfgs value is {!r}, but '
+                                   'should be a list.'
+                                   .format(path, dict_val))
+            import_cfgs += dict_val
+            continue
+
+        # 'use_cfgs' is a bit like 'import_cfgs', but is only used for primary
+        # config files (where it is a list of the child configs). This
+        # shouldn't be used except at top-level (the first configuration file
+        # to be loaded).
+        #
+        # If defined, check that it's a list, but then allow it to be set in
+        # the target dictionary as usual.
+        if key == 'use_cfgs':
+            if not is_first:
+                raise RuntimeError('{!r}: File is included by another one, '
+                                   'but defines "use_cfgs".'
+                                   .format(path))
+            if not isinstance(dict_val, list):
+                raise RuntimeError('{!r}: use_cfgs must be a list. Saw {!r}.'
+                                   .format(path, dict_val))
+
+        # Otherwise, update target with this attribute
+        set_target_attribute(path, target, key, dict_val)
+
+    # Expand the names of imported configuration files as we return them
+    return [subst_wildcards(cfg_path,
+                            target,
+                            ignored_wildcards=[],
+                            ignore_error=False)
+            for cfg_path in import_cfgs]
+
+
+def set_target_attribute(path, target, key, dict_val):
+    '''Set an attribute on the target dictionary
+
+    This performs checks for conflicting values and merges lists /
+    dictionaries.
+
+    '''
+    old_val = target.get(key)
+    if old_val is None:
+        # A new attribute (or the old value was None, in which case it's
+        # just a placeholder and needs writing). Set it and return.
+        target[key] = dict_val
+        return
+
+    if isinstance(old_val, list):
+        if not isinstance(dict_val, list):
+            raise RuntimeError('{!r}: Conflicting types for key {!r}: was '
+                               '{!r}, a list, but loaded value is {!r}, '
+                               'of type {}.'
+                               .format(path, key, old_val, dict_val,
+                                       type(dict_val).__name__))
+
+        # Lists are merged by concatenation
+        target[key] += dict_val
+        return
+
+    # The other types we support are "scalar" types.
+    scalar_types = [(str, [""]), (int, [0, -1]), (bool, [False])]
+    defaults = None
+    for st_type, st_defaults in scalar_types:
+        if isinstance(dict_val, st_type):
+            defaults = st_defaults
+            break
+    if defaults is None:
+        raise RuntimeError('{!r}: Value for key {!r} is {!r}, of '
+                           'unknown type {}.'
+                           .format(path, key, dict_val,
+                                   type(dict_val).__name__))
+    if not isinstance(old_val, st_type):
+        raise RuntimeError('{!r}: Value for key {!r} is {!r}, but '
+                           'we already had the value {!r}, of an '
+                           'incompatible type.'
+                           .format(path, key, dict_val, old_val))
+
+    # The types are compatible. If the values are equal, there's nothing more
+    # to do
+    if old_val == dict_val:
+        return
+
+    old_is_default = old_val in defaults
+    new_is_default = dict_val in defaults
+
+    # Similarly, if new value looks like a default, ignore it (regardless
+    # of whether the current value looks like a default).
+    if new_is_default:
+        return
+
+    # If the existing value looks like a default and the new value doesn't,
+    # take the new value.
+    if old_is_default:
+        target[key] = dict_val
+        return
+
+    # Neither value looks like a default. Raise an error.
+    raise RuntimeError('{!r}: Value for key {!r} is {!r}, but '
+                       'we already had a conflicting value of {!r}.'
+                       .format(path, key, dict_val, old_val))

--- a/util/dvsim/FpvCfg.py
+++ b/util/dvsim/FpvCfg.py
@@ -15,14 +15,14 @@ from utils import VERBOSE, subst_wildcards
 class FpvCfg(OneShotCfg):
     """Derivative class for FPV purposes.
     """
-    def __init__(self, flow_cfg_file, proj_root, args):
-        super().__init__(flow_cfg_file, proj_root, args)
+
+    flow = 'fpv'
+
+    def __init__(self, flow_cfg_file, hjson_data, args, mk_config):
+        super().__init__(flow_cfg_file, hjson_data, args, mk_config)
         self.header = ["name", "errors", "warnings", "proven", "cex", "undetermined",
                        "covered", "unreachable", "pass_rate", "cov_rate"]
         self.summary_header = ["name", "pass_rate", "stimuli_cov", "coi_cov", "prove_cov"]
-
-    def __post_init__(self):
-        super().__post_init__()
         self.results_title = self.name.upper() + " FPV Results"
 
     def parse_dict_to_str(self, input_dict, excl_keys = []):

--- a/util/dvsim/LintCfg.py
+++ b/util/dvsim/LintCfg.py
@@ -18,13 +18,13 @@ from utils import VERBOSE, print_msg_list, subst_wildcards
 class LintCfg(OneShotCfg):
     """Derivative class for linting purposes.
     """
-    def __init__(self, flow_cfg_file, proj_root, args):
+
+    flow = 'lint'
+
+    def __init__(self, flow_cfg_file, hjson_data, args, mk_config):
         # This is a lint-specific attribute
         self.is_style_lint = ""
-        super().__init__(flow_cfg_file, proj_root, args)
-
-    def __post_init__(self):
-        super().__post_init__()
+        super().__init__(flow_cfg_file, hjson_data, args, mk_config)
 
         # Convert to boolean
         if self.is_style_lint == "True":
@@ -52,7 +52,6 @@ class LintCfg(OneShotCfg):
             results_str += "### " + self.revision + "\n"
         results_str += "### Branch: " + self.branch + "\n"
         results_str += "\n"
-
 
         header = [
             "Name", "Tool Warnings", "Tool Errors", "Lint Warnings",
@@ -185,7 +184,6 @@ class LintCfg(OneShotCfg):
                              ("Tool Errors", "errors"),
                              ("Lint Warnings", "lint_warnings"),
                              ("Lint Errors", "lint_errors")]
-
 
             # Lint fails if any warning or error message has occurred
             self.errors_seen = False

--- a/util/dvsim/SynCfg.py
+++ b/util/dvsim/SynCfg.py
@@ -18,11 +18,11 @@ from utils import VERBOSE, print_msg_list, subst_wildcards
 class SynCfg(OneShotCfg):
     """Derivative class for synthesis purposes.
     """
-    def __init__(self, flow_cfg_file, proj_root, args):
-        super().__init__(flow_cfg_file, proj_root, args)
 
-    def __post_init__(self):
-        super().__post_init__()
+    flow = 'syn'
+
+    def __init__(self, flow_cfg_file, hjson_data, args, mk_config):
+        super().__init__(flow_cfg_file, hjson_data, args, mk_config)
         # Set the title for synthesis results.
         self.results_title = self.name.upper() + " Synthesis Results"
 

--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -28,11 +28,8 @@ import sys
 import textwrap
 from signal import SIGINT, signal
 
+from CfgFactory import make_cfg
 import Deploy
-import FpvCfg
-import LintCfg
-import SimCfg
-import SynCfg
 import utils
 
 # TODO: add dvsim_cfg.hjson to retrieve this info
@@ -134,26 +131,6 @@ def resolve_branch(branch):
         branch = "default"
 
     return branch
-
-
-def make_config(args, proj_root):
-    '''A factory method for FlowCfg objects'''
-
-    # Look up the tool in a dictionary, defaulting to SimCfg.
-    #
-    # If --tool was not passed (so args.tool is None), we have to figure out
-    # the tool by reading the config file. At the moment, this forces a
-    # simulation target (TODO?)
-    factories = {
-        'ascentlint': LintCfg.LintCfg,
-        'veriblelint': LintCfg.LintCfg,
-        'verilator': LintCfg.LintCfg,
-        'dc': SynCfg.SynCfg,
-        'jaspergold': FpvCfg.FpvCfg
-    }
-
-    factory = factories.get(args.tool, SimCfg.SimCfg)
-    return factory(args.cfg, proj_root, args)
 
 
 # Get the project root directory path - this is used to construct the full paths
@@ -590,7 +567,7 @@ def main():
         proj_root = get_proj_root()
 
     global cfg
-    cfg = make_config(args, proj_root)
+    cfg = make_cfg(args.cfg, args, proj_root)
 
     # Handle Ctrl-C exit.
     signal(SIGINT, sigint_handler)


### PR DESCRIPTION
The main new feature from this patch is that a dvsim configuration
should now set a `dvsim_cfg_type` value. This value is used to decide
which subclass of `FlowCfg` to construct (in `CfgFactory.py`).

There are two upsides to this:

  1. You can now run a lint or synthesis run without specifying the
     tool on the command line (before, the code made a `SimCfg` unless
     it recognised the tool).

  2. If you run `dvsim.py` on some other random hjson file, you get a
     somewhat helpful error message. Before, you'd get something
     cryptic about expanding verbosity flags.

There is also a downside:

  1. Every configuration needs to specify `dvsim_cfg_type`. In practice,
     this isn't so bad, because this can be done in the included
     `common_*_cfg.hjson`.

Note that "every configuration" here includes primary configurations.
This is kind of silly, because a "primary configuration" is really
just a list of other things to run. In later patches, we can split
these out into their own type, which should clean up quite a lot of
the code, and get rid of this requirement. However, you can't do that
splitting without the change in this patch (I tried!), so I've done
this patch first.

To make sense of how this all works:

  - `dvsim.py` calls `CfgFactory.make_config`

  - This uses `CfgJson.load_hjson` to load an hjson file and everything
    it includes.

  - After loading the file, `make_config` looks at `dvsim_cfg_type` (which
    must have a value) to decide which subclass of `FlowCfg` to
    instantiate.

  - The constructor for `FlowCfg` gets passed `hjson_data`. It sets up
    a whole list of attributes, then calls `self._merge_hjson` to merge
    the data from `hjson_data` into itself. It then calls `self._expand`
    to expand all the wildcards. Subclasses can hook in to these two
    methods if they need things to happen at specific times.

The only slight complication is from primary configs: configurations
that have a list of children to be loaded and run. These need to load
up some new hjson files. They can do so by calling back to the
factory (passed in as an argument to avoid circular dependencies).
