### PR TITLE
[OTBN/DIF] Add an error code to the DIF

### DIFF
--- a/sw/device/lib/dif/dif_otbn.c
+++ b/sw/device/lib/dif/dif_otbn.c
@@ -216,7 +216,7 @@ dif_otbn_result_t dif_otbn_get_err_code(const dif_otbn_t *otbn,
   // Ensure that all values returned from hardware match explicitly defined
   // values in the DIF.
   switch (err_code_raw) {
-    case 0:  // kDifOtbnErrorCodeNoError
+    case kDifOtbnErrCodeNoError:
       *err_code = (dif_otbn_err_code_t)err_code_raw;
       return kDifOtbnOk;
 

--- a/sw/device/lib/dif/dif_otbn.c
+++ b/sw/device/lib/dif/dif_otbn.c
@@ -217,6 +217,7 @@ dif_otbn_result_t dif_otbn_get_err_code(const dif_otbn_t *otbn,
   // values in the DIF.
   switch (err_code_raw) {
     case kDifOtbnErrCodeNoError:
+    case kDifOtbnErrCodeBadDataAddr:
       *err_code = (dif_otbn_err_code_t)err_code_raw;
       return kDifOtbnOk;
 

--- a/sw/device/lib/dif/dif_otbn.h
+++ b/sw/device/lib/dif/dif_otbn.h
@@ -78,7 +78,7 @@ typedef enum dif_otbn_result {
 typedef enum dif_otbn_err_code {
   // Keep error codes in sync with the hardware!
   /** No error occurred. */
-  kDifOtbnErrorCodeNoError = 0x0,
+  kDifOtbnErrCodeNoError = 0x0,
 } dif_otbn_err_code_t;
 
 /**

--- a/sw/device/lib/dif/dif_otbn.h
+++ b/sw/device/lib/dif/dif_otbn.h
@@ -79,6 +79,8 @@ typedef enum dif_otbn_err_code {
   // Keep error codes in sync with the hardware!
   /** No error occurred. */
   kDifOtbnErrCodeNoError = 0x0,
+  /** Load or store to invalid address. */
+  kDifOtbnErrCodeBadDataAddr = 0x1,
 } dif_otbn_err_code_t;
 
 /**

--- a/sw/device/tests/dif/dif_otbn_unittest.cc
+++ b/sw/device/tests/dif/dif_otbn_unittest.cc
@@ -332,19 +332,19 @@ TEST_F(GetErrCodeTest, NullArgs) {
   result = dif_otbn_get_err_code(&dif_otbn_, nullptr);
   EXPECT_EQ(result, kDifOtbnBadArg);
 
-  err_code = kDifOtbnErrCodeNoError;
+  err_code = kDifOtbnErrCodeBadDataAddr;
   result = dif_otbn_get_err_code(nullptr, &err_code);
   EXPECT_EQ(result, kDifOtbnBadArg);
-  EXPECT_EQ(err_code, kDifOtbnErrCodeNoError);
+  EXPECT_EQ(err_code, kDifOtbnErrCodeBadDataAddr);
 }
 
 TEST_F(GetErrCodeTest, Success) {
-  EXPECT_READ32(OTBN_ERR_CODE_REG_OFFSET, kDifOtbnErrCodeNoError);
+  EXPECT_READ32(OTBN_ERR_CODE_REG_OFFSET, kDifOtbnErrCodeBadDataAddr);
 
   dif_otbn_err_code_t err_code;
   dif_otbn_result_t result = dif_otbn_get_err_code(&dif_otbn_, &err_code);
   EXPECT_EQ(result, kDifOtbnOk);
-  EXPECT_EQ(err_code, kDifOtbnErrCodeNoError);
+  EXPECT_EQ(err_code, kDifOtbnErrCodeBadDataAddr);
 }
 
 TEST_F(GetErrCodeTest, HardwareReturnsUnknownErrorCode) {
@@ -352,12 +352,12 @@ TEST_F(GetErrCodeTest, HardwareReturnsUnknownErrorCode) {
   // error code.
   EXPECT_READ32(OTBN_ERR_CODE_REG_OFFSET, 1234);
 
-  dif_otbn_err_code_t err_code = kDifOtbnErrCodeNoError;
+  dif_otbn_err_code_t err_code = kDifOtbnErrCodeBadDataAddr;
   dif_otbn_result_t result = dif_otbn_get_err_code(&dif_otbn_, &err_code);
   EXPECT_EQ(result, kDifOtbnUnexpectedData);
 
   // Should stay unchanged.
-  EXPECT_EQ(err_code, kDifOtbnErrCodeNoError);
+  EXPECT_EQ(err_code, kDifOtbnErrCodeBadDataAddr);
 }
 
 class ImemWriteTest : public OtbnTest {};

--- a/sw/device/tests/dif/dif_otbn_unittest.cc
+++ b/sw/device/tests/dif/dif_otbn_unittest.cc
@@ -332,19 +332,19 @@ TEST_F(GetErrCodeTest, NullArgs) {
   result = dif_otbn_get_err_code(&dif_otbn_, nullptr);
   EXPECT_EQ(result, kDifOtbnBadArg);
 
-  err_code = kDifOtbnErrorCodeNoError;
+  err_code = kDifOtbnErrCodeNoError;
   result = dif_otbn_get_err_code(nullptr, &err_code);
   EXPECT_EQ(result, kDifOtbnBadArg);
-  EXPECT_EQ(err_code, kDifOtbnErrorCodeNoError);
+  EXPECT_EQ(err_code, kDifOtbnErrCodeNoError);
 }
 
 TEST_F(GetErrCodeTest, Success) {
-  EXPECT_READ32(OTBN_ERR_CODE_REG_OFFSET, kDifOtbnErrorCodeNoError);
+  EXPECT_READ32(OTBN_ERR_CODE_REG_OFFSET, kDifOtbnErrCodeNoError);
 
   dif_otbn_err_code_t err_code;
   dif_otbn_result_t result = dif_otbn_get_err_code(&dif_otbn_, &err_code);
   EXPECT_EQ(result, kDifOtbnOk);
-  EXPECT_EQ(err_code, kDifOtbnErrorCodeNoError);
+  EXPECT_EQ(err_code, kDifOtbnErrCodeNoError);
 }
 
 TEST_F(GetErrCodeTest, HardwareReturnsUnknownErrorCode) {
@@ -352,12 +352,12 @@ TEST_F(GetErrCodeTest, HardwareReturnsUnknownErrorCode) {
   // error code.
   EXPECT_READ32(OTBN_ERR_CODE_REG_OFFSET, 1234);
 
-  dif_otbn_err_code_t err_code = kDifOtbnErrorCodeNoError;
+  dif_otbn_err_code_t err_code = kDifOtbnErrCodeNoError;
   dif_otbn_result_t result = dif_otbn_get_err_code(&dif_otbn_, &err_code);
   EXPECT_EQ(result, kDifOtbnUnexpectedData);
 
   // Should stay unchanged.
-  EXPECT_EQ(err_code, kDifOtbnErrorCodeNoError);
+  EXPECT_EQ(err_code, kDifOtbnErrCodeNoError);
 }
 
 class ImemWriteTest : public OtbnTest {};


### PR DESCRIPTION
Add a new error code to the OTBN DIF which was recently added to the hardware. And do some cleanups along the way.