### PR TITLE
[OTBN] Remove paragraph about unspecified instruction encoding

### DIFF
--- a/hw/ip/otbn/doc/_index.md
+++ b/hw/ip/otbn/doc/_index.md
@@ -327,17 +327,6 @@ Writing to `x1` pushes to the call stack, reading from it pops an item.
 
 A WLEN bit wide accumulator used by the BN.MULQACC instruction.
 
-## Instruction Format
-
-All instructions are a fixed 32b in length and must be aligned on a four byte-boundary in memory.
-
-<div class="bd-callout bd-callout-warning">
-  <h5>Note</h5>
-
-  The instruction encoding has not been finalized yet.
-  See [issue #2391](https://github.com/lowRISC/opentitan/issues/2391) for the current status.
-</div>
-
 <!-- Documentation for the instructions in the ISA. Generated from ../data/insns.yml. -->
 ## Base Instruction Subset
 {{< otbn_isa base >}}


### PR DESCRIPTION
The instruction encoding is now documented, remove the paragraph saying
it's not. The instruction alignment isn't really an ISA requirement,
it's an implementation requirement for our instruction fetch unit, it
was out of place in this section.

Fixes #2864