### PR TITLE
[otbn] fix specification of bn.subm instruction

### DIFF
--- a/hw/ip/otbn/data/bignum-insns.yml
+++ b/hw/ip/otbn/data/bignum-insns.yml
@@ -459,8 +459,8 @@
   operation: |
     (result, ) = AddWithCarry(a, -b, "0")
 
-    if result >= MOD:
-      result = result - MOD
+    if result < 0:
+      result = MOD + result
 
     WDR[d] = result
   encoding:

--- a/hw/ip/otbn/dv/otbnsim/sim/insn.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/insn.py
@@ -559,8 +559,8 @@ class BNSUBM(OTBNInsn):
         a = int(model.state.wreg[self.wrs1])
         b = int(model.state.wreg[self.wrs2])
         result, _ = model.add_with_carry(a, -b, 0)
-        if result >= model.state.mod:
-            result -= model.state.mod
+        if result < 0:
+            result += model.state.mod
         model.state.wreg[self.wrd] = result
 
 


### PR DESCRIPTION
With the `bn.addm` instruction the result is expected to
be in the range of `0` to `MOD-1` even if the non-modular
result is only in the range of `0` to `2*MOD-1`. For this,
in case the result is greater or equal `MOD` it needs to be
corrected by subtracting `MOD` once.
So far we had the same defintion for `bn.subm` which is wrong.
Here, the non-modular result is tolerable in the range
of `-MOD+1` to `MOD-1`. In case it is smaller than 0 it
needs to be corrected by adding the result to `MOD` such that
the final result is also between `0` and `MOD-1`.

Signed-off-by: Felix Miller <felix.miller@gi-de.com>