### PR TITLE
[kmac] SHA3/SHAKE/cSHAKE Padding Logic

### DIFF
--- a/hw/ip/kmac/fpv/sha3pad_fpv.core
+++ b/hw/ip/kmac/fpv/sha3pad_fpv.core
@@ -1,0 +1,27 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:fpv:sha3pad_fpv:0.1"
+description: "SHA3 family FPV target"
+filesets:
+  files_formal:
+    depend:
+      - lowrisc:prim:all
+      - lowrisc:ip:kmac
+    files:
+      - tb/sha3pad_fpv.sv
+    file_type: systemVerilogSource
+
+targets:
+  default: &default_target
+    # note, this setting is just used
+    # to generate a file list for jg
+    default_tool: icarus
+    filesets:
+      - files_formal
+    toplevel:
+      - sha3pad_fpv.sv
+
+  formal:
+    <<: *default_target

--- a/hw/ip/kmac/fpv/tb/sha3pad_fpv.sv
+++ b/hw/ip/kmac/fpv/tb/sha3pad_fpv.sv
@@ -1,0 +1,151 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+module sha3pad_fpv
+  import kmac_pkg::*;
+#(
+  parameter int EnMasking = 0,
+  localparam int Share = (EnMasking) ? 2 : 1
+) (
+  input clk_i,
+  input rst_ni,
+
+  // Message interface (FIFO)
+  input                       msg_valid_i,
+  input        [MsgWidth-1:0] msg_data_i [Share],
+  input        [MsgStrbW-1:0] msg_mask_i,         // one masking for shares
+  output logic                msg_ready_o,
+
+  // N, S: Used in cSHAKE mode only
+  input [NSRegisterSize*8-1:0] ns_data_i, // See kmac_pkg for details
+
+  // Entropy source
+  input                       entropy_valid_i,
+  input        [MsgWidth-1:0] entropy_data_i,
+  output logic                entropy_consumed_o,
+
+  // configurations
+  input sha3_mode_e       mode_i,
+  // strength_i is used in bytepad operation. bytepad() is used in cSHAKE only.
+  // SHA3, SHAKE doesn't have encode_N,S
+  input keccak_strength_e strength_i,
+
+  // control signal
+  input start_i,
+  input process_i,
+  input done_i,
+
+  // Indicate one block is pushed via keccak_* signal
+  // For cSHAKE, even keccak_addr_o doesn't reach to the block size,
+  // block_pushed_o can be asserted at first.
+  // `bytepad(encode_string(N) || encode_string(S), {168 or 136})` can be done
+  // earlier and rely on keccak stroage initial value `0`
+  output logic block_pushed_o
+);
+
+  logic                      keccak_valid;
+  logic                      keccak_ready;
+  logic [KeccakMsgAddrW-1:0] keccak_addr;
+  logic [MsgWidth-1:0]          keccak_data [Share];
+
+  logic keccak_run, keccak_complete;
+
+  logic [1599:0] state [Share];
+
+  logic rand_valid, rand_consumed;
+  logic [1599:0] rand_data;
+
+  sha3pad #(
+    .EnMasking(EnMasking)
+  ) u_pad (
+    .keccak_valid_o (keccak_valid),
+    .keccak_ready_i (keccak_ready),
+    .keccak_addr_o  (keccak_addr),
+    .keccak_data_o  (keccak_data),
+
+    .keccak_run_o      (keccak_run),
+    .keccak_complete_i (keccak_complete),
+
+    .*
+  );
+
+  keccak_round #(
+    .Width     (1600),
+    .DInWidth  (MsgWidth),
+    .EnMasking (EnMasking)
+  ) u_keccak (
+    .valid_i    (keccak_valid),
+    .ready_o    (keccak_ready),
+    .addr_i     (keccak_addr),
+    .data_i     (keccak_data),
+
+    .run_i      (keccak_run),
+    .complete_o (keccak_complete),
+
+    .rand_valid_i    (rand_valid),
+    .rand_data_i     (rand_data),
+    .rand_consumed_o (rand_consumed),
+
+    .state_o    (state),
+
+    .clear_i    (1'b 0),
+
+    .*
+  );
+
+  // Test vectors (big-endian)
+  // "" (empty string):
+  // SHA3-224 6b4e03423667dbb7 3b6e15454f0eb1ab d4597f9a1b078e3f 5b5a6bc7
+  // SHA3-256 a7ffc6f8bf1ed766 51c14756a061d662 f580ff4de43b49fa 82d80a4b80f8434a
+  // SHA3-384 0c63a75b845e4f7d 01107d852e4c2485 c51a50aaaa94fc61 995e71bbee983a2a
+  //          c3713831264adb47 fb6bd1e058d5f004
+  // SHA3-512 a69f73cca23a9ac5 c8b567dc185a756e 97c982164fe25859 e0d1dcc1475c80a6
+  //          15b2123af1f5f94c 11e3e9402c3ac558 f500199d95b6d3e3 01758586281dcd26
+  //
+  // "abc" (0x616263) :
+  // SHA3-224 e642824c3f8cf24a d09234ee7d3c766f c9a3a5168d0c94ad 73b46fdf
+  // SHA3-256 3a985da74fe225b2 045c172d6bd390bd 855f086e3e9d525b 46bfe24511431532
+  // SHA3-384 ec01498288516fc9 26459f58e2c6ad8d f9b473cb0fc08c25 96da7cf0e49be4b2
+  //          98d88cea927ac7f5 39f1edf228376d25
+  // SHA3-512 b751850b1a57168a 5693cd924b6b096e 08f621827444f70d 884f5d0240d2712e
+  //          10e116e9192af3c9 1a7ec57647e39340 57340b4cf408d5a5 6592f8274eec53f0
+  //
+  // "abcdefgh" (0x6162636465666768)
+  // SHA3-224 48bf2e8640cffe77 b67c6182a6a47f8b 5af73f60bd204ef3 48371d03
+  // SHA3-256 3e2020725a38a48e b3bbf75767f03a22 c6b3f41f459c8313 09b06433ec649779
+  // SHA3-384 f4d9fc5e9f44eb87 fe968fc8e4e4691e b1dab6d821fb7755 0b527f71ccfb1ba0
+  //          43851bb054f28136 4c44d8541904db5a
+  // SHA3-512 c9f25eee75ab4cf9 a8cfd44f4992b282 079b64d94647edbd 88e818e44f701ede
+  //          b450818f7272cba7 a20205b3671ce199 1ce9a6d2df8dbad6 e0bb3e50493d7fa7
+
+  `ASSUME(Sha3Mode_A, mode_i == Sha3)
+  `ASSUME(KeccakStrength_A, strength_i == L256)
+
+  //property empty_vector;
+  //endproperty
+  // `ASSUME(EmptyInputVector_A, start_i |=> !start_i ##2 process_i ##1 !process_i)
+  // `ASSUME(EmptyInputVectorData_A, msg_valid_i == 1'b 0)
+
+  // `ASSERT(EmptyVector_A, keccak_complete |->
+  //   state[0][255:0] == 256'h 4a43_f880_4b0a_d882_fa49_3be4_4dff_80f5_62d6_61a0_5647_c151_66d7_1ebf_f8c6_ffa7)
+
+  // "abcdefgh"
+  //`ASSUME(AbcdefghInputVector_A, start_i |=> !start_i ##2 (msg_valid_i == 1'b1 && msg_data_i[0] == 64'h
+  //68676665_64636261 ##1 msg_valid_i == 1'b0) ##1 process_i && $stable(msg_valid_i) ##1 !process_i)
+  //`ASSUME(AbcdefghInputMask_A, msg_mask_i == '1)
+
+  //`ASSERT(AbcdefghVector_A, keccak_complete |->
+  //256'({<<8{state[0][255:0]}}) == 256'h 3e2020725a38a48e_b3bbf75767f03a22_c6b3f41f459c8313_09b06433ec649779)
+
+  // "abc"
+  `ASSUME(AbcInputVector_A, start_i |=> !start_i ##2 (msg_valid_i == 1'b1 && msg_data_i[0] == 64'h
+  68676665_64636261 ##1 msg_valid_i == 1'b0) ##1 process_i && $stable(msg_valid_i) ##1 !process_i &&
+$stable(msg_valid_i) ##[0:$] $stable(msg_valid_i))
+  `ASSUME(AbcInputMask_A, msg_mask_i == 8'b 0000_0111)
+
+  `ASSERT(AbcVector_A, keccak_complete |->
+  256'({<<8{state[0][255:0]}}) == 256'h 3a985da74fe225b2_045c172d6bd390bd_855f086e3e9d525b_46bfe24511431532)
+
+endmodule

--- a/hw/ip/kmac/kmac.core
+++ b/hw/ip/kmac/kmac.core
@@ -11,6 +11,8 @@ filesets:
       - lowrisc:prim:prim_dom_and_2share
       - lowrisc:prim:assert
     files:
+      - rtl/kmac_pkg.sv
+      - rtl/sha3pad.sv
       - rtl/keccak_round.sv
       - rtl/keccak_2share.sv
     file_type: systemVerilogSource

--- a/hw/ip/kmac/rtl/kmac_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_pkg.sv
@@ -1,0 +1,105 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// kmac_pkg
+
+package kmac_pkg;
+
+  // Function Name (N) and Customzation String (S) shall be
+  // smaller than 2**256 bits and integer divisiable by 8.
+  parameter int FnWidth = 32;  // up to 32bit Function Name
+  parameter int MaxFnEncodeSize = $clog2(FnWidth+1)/8 + 2;
+  parameter int CsWidth = 256; // up to 256bit Customization Input
+  parameter int MaxCsEncodeSize = $clog2(CsWidth+1)/8 + 2;
+
+  parameter int NSRegisterSize = FnWidth/8       + CsWidth/8
+                               + MaxFnEncodeSize + MaxCsEncodeSize;
+
+  // Prefix represents bytepad(encode_string(N) || encode_string(S), 168 or 136)
+  // +2 represents left_encoding(168 or 136) which could be either:
+  // 10000000 || 00010101 // 168
+  // 10000000 || 00010001 // 136
+  parameter int PrefixSize = NSRegisterSize + 2;
+
+  // index width for `N` and `S`
+  parameter int PrefixIndexW = $clog2(PrefixSize/64);
+
+  // Datapath width in KMAC, this also affects the output of MSG_FIFO
+  parameter int MsgWidth = 64;
+  parameter int MsgStrbW = MsgWidth / 8;
+
+  // Message FIFO depth
+  //
+  // Assume entropy is ready always (if Share is reused as an entropy in Chi)
+  // Then it takes 72 cycles to complete the Keccak round. While Keccak is in
+  // operation, the module need to store the incoming messages to not degrade
+  // the throughput.
+  //
+  // Based on the observation from HMAC case, the core usually takes 5 clocks
+  // to fetch data and store into KMAC. So the core can push at most 14.5 X 4B
+  // which is 58B. After that, Keccak can fetch the data from MSG_FIFO faster
+  // rate than the core can push. To fetch 58B, it takes around 7~8 cycles.
+  // For that time, the core only can push at most 2 DW. After that Keccak
+  // waits the incoming message.
+  //
+  // So Message FIFO doesn't need full block size except the KMAC case, which
+  // is delayed the operation by processing Function Name N, customization S,
+  // and secret keys. But KMAC doesn't need high throughput anyway (72Mb/s).
+  parameter int RegIntfWidth = 32; // 32bit interface
+  parameter int RegLatency   = 5;  // 5 cycle to write one Word
+  parameter int Sha3Latency  = 72; // Expected masked sha3 processing time 24x3
+
+  // Total required buffer size while SHA3 is in processing
+  parameter int BufferCycles   = (Sha3Latency + RegLatency - 1)/RegLatency;
+  parameter int BufferSizeBits = RegIntfWidth * BufferCycles;
+
+  // Required MsgFifoDepth. Adding slightly more buffer for margin
+  parameter int MsgFifoDepth   = 2 + ((BufferSizeBits + MsgWidth - 1)/MsgWidth);
+
+  // Keccak module supports SHA3, SHAKE, cSHAKE function.
+  // This mode determines if the module uses encoded N and S or not.
+  // Also it chooses the padding value.
+  //
+  //    mode   |  little-endian
+  //    -------|----------------
+  //    Sha3   |  2'b   10
+  //    Shake  |  4'b 1111
+  //    CShake |  2'b   00
+  //
+  // Please remind that if input strings N and S are empty, SW shall
+  // choose SHAKE even for cSHAKE operation.
+  typedef enum logic[1:0] {
+    Sha3   = 2'b 00,
+    Shake  = 2'b 10,
+    CShake = 2'b 11
+  } sha3_mode_e;
+
+  // keccak_strength_e determines the security strength against collision attack
+  // This value decides the _rate_ and _capacity_ of the keccak states.
+  // It affects the sha3pad module too. the padding module implements
+  // `bytepad(X,168)` for L128, `bytepad(X,136)` for L256 in cSHAKE
+  typedef enum logic [2:0] {
+    L128 = 3'b 000, // rate: 1344 bit / capacity:  256 bit Keccak[ 256](, 128)
+    L224 = 3'b 001, // rate: 1152 bit / capacity:  448 bit Keccak[ 448](, 224)
+    L256 = 3'b 010, // rate: 1088 bit / capacity:  512 bit Keccak[ 512](, 256)
+    L384 = 3'b 011, // rate:  832 bit / capacity:  768 bit Keccak[ 768](, 384)
+    L512 = 3'b 100  // rate:  576 bit / capacity: 1024 bit Keccak[1024](, 512)
+  } keccak_strength_e;
+
+  parameter int KeccakRate [5] = '{
+    1344/MsgWidth,  // 21 depth := (1600 - 128*2)
+    1152/MsgWidth,  // 18 depth := (1600 - 224*2)
+    1088/MsgWidth,  // 17 depth := (1600 - 256*2)
+     832/MsgWidth,  // 13 depth := (1600 - 384*2)
+     576/MsgWidth   //  9 depth := (1600 - 512*2)
+  };
+
+  parameter int MaxBlockSize = KeccakRate[0];
+
+  parameter int KeccakEntries = 1600/MsgWidth;
+  parameter int KeccakMsgAddrW = $clog2(KeccakEntries);
+
+  parameter int KeccakCountW = $clog2(KeccakEntries+1);
+
+endpackage : kmac_pkg

--- a/hw/ip/kmac/rtl/sha3pad.sv
+++ b/hw/ip/kmac/rtl/sha3pad.sv
@@ -1,0 +1,741 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// SHA3 padding logic
+
+`include "prim_assert.sv"
+
+module sha3pad
+  import kmac_pkg::*;
+#(
+  parameter int EnMasking = 0,
+  localparam int Share = (EnMasking) ? 2 : 1
+) (
+  input clk_i,
+  input rst_ni,
+
+  // Message interface (FIFO)
+  input                       msg_valid_i,
+  input        [MsgWidth-1:0] msg_data_i [Share],
+  input        [MsgStrbW-1:0] msg_mask_i,         // one masking for shares
+  output logic                msg_ready_o,
+
+  // N, S: Used in cSHAKE mode only
+  input [NSRegisterSize*8-1:0] ns_data_i, // See kmac_pkg for details
+
+  // Entropy source
+  input                       entropy_valid_i,
+  input        [MsgWidth-1:0] entropy_data_i,
+  output logic                entropy_consumed_o,
+
+  // output to keccak_round: message path
+  output logic                       keccak_valid_o,
+  output logic [KeccakMsgAddrW-1:0]  keccak_addr_o,
+  output logic [MsgWidth-1:0]        keccak_data_o [Share],
+  input  logic                       keccak_ready_i,
+
+  // keccak_round control and status
+  // `run` initiates the keccak_round to process full keccak_f (24rounds).
+  // `complete` is an input from keccak round showing the current keccak_f is
+  // completed.
+  output logic keccak_run_o,
+  input        keccak_complete_i,
+
+  // configurations
+  input sha3_mode_e       mode_i,
+  // strength_i is used in bytepad operation. bytepad() is used in cSHAKE only.
+  // SHA3, SHAKE doesn't have encode_N,S
+  input keccak_strength_e strength_i,
+
+  // control signal
+  // start_i is a pulse signal triggers the padding logic (and the rest of SHA)
+  // to accept the incoming messages. This signal is used in the pad module,
+  // to initiate the prefix transmitting to keccak_round
+  input start_i,
+  // process_i is a pulse signal triggers the pad logic to stop receiving the
+  // message from MSG_FIFO and pad the trailing bits specified in the SHA3
+  // standard. Look at `funcpad` signal for the values.
+  input process_i,
+  // done_i is a pulse signal to make the pad logic to clear internal variables
+  // and to move back to the Idle state for next hashing process.
+  // done_i may not needed if sw controls the keccak_round directly.
+  input done_i,
+
+  // Indicate one block is pushed via keccak_* signal
+  // For cSHAKE, even keccak_addr_o doesn't reach to the block size,
+  // block_pushed_o can be asserted at first.
+  // `bytepad(encode_string(N) || encode_string(S), {168 or 136})` can be done
+  // earlier and rely on keccak stroage initial value `0`
+  output logic block_pushed_o
+);
+
+  /////////////////
+  // Definitions //
+  /////////////////
+
+  // Padding States
+  // TODO: Make it has Hamming Distance >= 3 to be resistent to glitch attacks.
+  typedef enum logic [3:0] {
+    StIdle,
+
+    // Sending a block of prefix, if cSHAKE mode is turned on. For the rest
+    // (SHA3, SHAKE), sending prefix is not needed. FSM moves from Idle to
+    // Message directly in that case.
+    //
+    // As prim_slicer is instantiated, zerofill after the actual prefix is done
+    // by the module.
+    StPrefix,
+    StPrefixWait,
+
+    // Sending Message. In this state, it directly forwards the incoming data
+    // to Keccak round module. If `process_i` is asserted, then the rest of the
+    // messages will be discarded until new `start_i` is asserted.
+    //
+    // The incoming data can be partial write. Padding logic counts the number
+    // of bytes received and pause if a block size is transferred.
+    StMessage,
+    StMessageWait,
+
+    // After sending the messages, then `process_i` is set, the FSM pads at the
+    // end of the message based on `mode_i`. If this is the last byte of the
+    // block, then it pads [7] to 1 to complete `pad10*1()` function.
+    StPad,
+    StPadRun,
+
+    // If the padding isn't the end of the block byte (which will be rare case),
+    // FSM moves to another zerofill state. In contrast to StZerofill, this state
+    StPad01,
+
+    // Flushing the internal packers in front of the Keccak data output port.
+    StFlush
+  } pad_st_e;
+
+  typedef enum logic [2:0] {
+    MuxNone    = 3'b 000,
+    MuxFifo    = 3'b 001,
+    MuxPrefix  = 3'b 010,
+    MuxFuncPad = 3'b 011,
+    MuxZeroEnd = 3'b 100
+  } mux_sel_e;
+
+  ////////////////////
+  // Configurations //
+  ////////////////////
+
+  logic [KeccakCountW-1:0] block_addr_limit;
+
+  // Block size based on the address.
+  // This is used for bytepad() and also pad10*1()
+  // assign block_addr_limit = KeccakRate[strength_i];
+  // but below is easier to understand
+  always_comb begin
+    unique case (strength_i)
+      L128: block_addr_limit = KeccakRate[L128];
+      L224: block_addr_limit = KeccakRate[L224];
+      L256: block_addr_limit = KeccakRate[L256];
+      L384: block_addr_limit = KeccakRate[L384];
+      L512: block_addr_limit = KeccakRate[L512];
+
+      default: block_addr_limit = '0;
+    endcase
+  end
+
+  /////////////////////
+  // Control Signals //
+  /////////////////////
+
+  // `sel_mux` selects the output data among the incoming or internally generated data.
+  // MuxFifo:    data from external (msg_data_i)
+  // MuxPrefix:  bytepad(encode_string(N)||encode_string(S), )
+  // MuxFuncPad: function_pad with end of message
+  // MuxZeroEnd: all 0
+  mux_sel_e sel_mux;
+
+  // `sent_message` indicates the number of entries sent to keccak round per
+  // block. The value shall be enough to cover Maximum entry of the Keccak
+  // storage as defined in kmac_pkg, `$clog2(KeccakEntries+1)`. Logically,
+  // it is not needed to have more than KeccakEntries but for safety in case of
+  // SHA3 context switch resuming the SHA3 from the middle of sponge
+  // construction. If needed, the software should be able to write whole 1600
+  // bits. The `sent_message` is used to check sent_blocksize.
+  logic [KeccakCountW-1:0] sent_message;
+  logic inc_sentmsg, clr_sentmsg;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni)          sent_message <= '0;
+    else if (clr_sentmsg) sent_message <= '0;
+    else if (inc_sentmsg) sent_message <= sent_message + 1'b 1;
+  end
+
+  assign inc_sentmsg = keccak_valid_o & keccak_ready_i ;
+
+  // Prefix index to slice the `prefix` n-bits into multiple of 64bit.
+  logic [KeccakMsgAddrW-1:0] prefix_index;
+  assign prefix_index = (sent_message < block_addr_limit) ? sent_message : '0;
+
+  // fsm_keccak_valid is an output signal from FSM which to send data generated
+  // inside the pad logic to keccak_round
+  logic fsm_keccak_valid;
+
+  // hold_msg to prevent message from being forwarded into keccak_round and
+  // acked. Mainly the usage is to hold the message and initiates the
+  // keccak_round for current block.
+  logic hold_msg;
+
+  // latch the partial write. Latched data is used for funcpad_merged
+  logic en_msgbuf;
+  logic clr_msgbuf;
+
+  ///////////////////
+  // State Machine //
+  ///////////////////
+
+  // Inputs
+
+  // FSM moves to StPrefix only when cSHAKE is enabled
+  logic mode_eq_cshake;
+  assign mode_eq_cshake = (mode_i == CShake) ? 1'b 1 : 1'b 0;
+
+  // `sent_blocksize` indicates the pad logic pushed block size data into
+  // keccak round logic.
+  logic sent_blocksize;
+
+  assign sent_blocksize = (sent_message == block_addr_limit) ? 1'b 1 : 1'b 0;
+
+  // `keccak_ack` indicates the request is accepted in keccak_round
+  logic keccak_ack;
+
+  assign keccak_ack = keccak_valid_o & keccak_ready_i ;
+
+  // msg_partial indicates the incoming message is partial write or not.
+  // This is used to check if the incoming message need to be latched inside or
+  // not. If no partial message is at the end, msg_buf doesn't have to latch
+  // msg_data_i. It is assumed that the partial message is permitted only at
+  // the end of the message. So if (msg_valid_i && msg_partial && msg_ready_o),
+  // there will be no msg_valid_i till process_latched.
+  // Shall be used with msg_valid_i together.
+  logic msg_partial;
+  assign msg_partial = (&msg_mask_i != 1'b 1);
+
+
+  // `process_latched` latches the `process_i` input before it is seen in the
+  // FSM. `process_i` may follow `start_i` too fast so that the FSM may not
+  // see it fast enought in case of cSHAKE mode. cSHAKE needs to process the
+  // prefix prior to see the process indicator.
+  logic process_latched;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      process_latched <= 1'b 0;
+    // TODO: Reconsider the set condition, what if process_i comes without
+    // `start_i` ?
+    end else if (process_i) begin
+      process_latched <= 1'b 1;
+    // TODO: Reconsider the clear indicator, done_i is good enough?
+    end else if (done_i) begin
+      process_latched <= 1'b0;
+    end
+  end
+
+  // State Register ===========================================================
+  pad_st_e st, st_d;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      st <= StIdle;
+    end else begin
+      st <= st_d;
+    end
+  end
+
+  // Next logic and output logic ==============================================
+  always_comb begin
+    st_d = StIdle;
+
+    // FSM output : default values
+    keccak_run_o = 1'b 0;
+    sel_mux      = MuxNone;
+
+    fsm_keccak_valid = 1'b 0;
+
+    hold_msg = 1'b 0;
+    clr_sentmsg = 1'b 0;
+
+    en_msgbuf = 1'b 0;
+    clr_msgbuf = 1'b 0;
+
+    unique case (st)
+
+      // In Idle state, the FSM checks if the software (or upper FSM) initiates
+      // the hash process. If `start_i` is asserted (assume it is pulse), FSM
+      // starts to push the data into the keccak round logic. Depending on the
+      // hashing mode, FSM may push additional prefex in front of the actual
+      // message. It means, the message could be back-pressured until the first
+      // prefix is processed.
+      StIdle: begin
+        if (start_i) begin
+          // If cSHAKE, move to Prefix state
+          // TODO: Reset sent_message to count on next states
+          if (mode_eq_cshake) begin
+            st_d = StPrefix;
+          end else begin
+            st_d = StMessage;
+          end
+        end else begin
+          st_d = StIdle;
+        end
+      end
+
+      // At Prefix state, FSM pushes
+      // `bytepad(encode_string(N)||encode_string(S), 168or136)`. The software
+      // already prepared `encode_string(N) || encode_string(S)` in the regs.
+      // So, the FSM adds 2Byte in front of ns_data_i, which is an encoded
+      // block size (see `encoded_bytepad` below)
+      // After pushing the prefix, it initiates the hash process and move to
+      // Message state.
+      StPrefix: begin
+        sel_mux = MuxPrefix;
+
+        if (sent_blocksize) begin
+          st_d = StPrefixWait;
+
+          // TODO: Set keccak to run, drop the keccak valid
+          keccak_run_o = 1'b 1;
+          fsm_keccak_valid = 1'b 0;
+          clr_sentmsg = 1'b 1;
+        end else begin
+          st_d = StPrefix;
+
+          fsm_keccak_valid = 1'b 1;
+        end
+      end
+
+      StPrefixWait: begin
+        if (keccak_complete_i) begin
+          st_d = StMessage;
+        end else begin
+          st_d = StPrefixWait;
+        end
+      end
+
+      // Message state pushes the incoming message into keccak round logic.
+      // It forwards the message while counting the data and if it reaches
+      // the block size, it triggers the keccak round to run. If `process` is
+      // set, it moves to Pad state.
+      StMessage: begin
+        sel_mux = MuxFifo;
+
+        if (msg_valid_i && msg_partial) begin
+          st_d = StMessage;
+
+          en_msgbuf = 1'b 1;
+        end else if (sent_blocksize) begin
+          // Check block completion first even process is set.
+          st_d = StMessageWait;
+
+          keccak_run_o = 1'b 1;
+          clr_sentmsg = 1'b 1;
+          hold_msg = 1'b 1;
+        end else if (process_latched) begin
+          st_d = StPad;
+        end else begin
+          st_d = StMessage;
+
+        end
+      end
+
+      StMessageWait: begin
+        hold_msg = 1'b 1;
+
+        if (keccak_complete_i) begin
+          st_d = StMessage;
+        end else begin
+          st_d = StMessageWait;
+        end
+      end
+
+      // Pad state just pushes the ending suffix. Depending on the mode, the
+      // padding value is unique. SHA3 adds 2'b10, SHAKE adds 4'b1111, and
+      // cSHAKE adds 2'b 00. Refer `function_pad`. The signal has one more bit
+      // defined to accomodate first 1 bit of `pad10*1()` function.
+      StPad: begin
+        sel_mux = MuxFuncPad;
+
+        fsm_keccak_valid = 1'b 1;
+
+        if (keccak_ack && end_of_block) begin
+          // If padding is the last block, don't have to move to StPad01, just
+          // run Keccak and complete
+          st_d = StPadRun;
+
+          // always clear the latched msgbuf
+          clr_msgbuf = 1'b 1;
+        end else if (keccak_ack) begin
+          st_d = StPad01;
+          clr_msgbuf = 1'b 1;
+        end else begin
+          st_d = StPad;
+        end
+      end
+
+      StPadRun: begin
+        st_d = StFlush;
+
+        keccak_run_o = 1'b 1;
+        clr_sentmsg = 1'b 1;
+      end
+
+      // Pad01 pushes the end bit of pad10*1() function. As keccak accepts byte
+      // size only, StPad always pushes partial (5bits). So at this state, it
+      // pushes rest of 3bits. If the data pushed in StPad is the last byte of
+      // the block, then Pad01 pushes to the same byte, if not, it first
+      // zero-fill the block then pad 1 to the end.
+      StPad01: begin
+        sel_mux = MuxZeroEnd;
+
+        fsm_keccak_valid = 1'b 1;
+
+        // There's no chance StPad01 can be a start of the block. So can be
+        // discard that the sent_blocksize is set at the beginning.
+        if (sent_blocksize) begin
+          st_d = StFlush;
+
+          // TODO: Trigger keccak_round
+          keccak_run_o = 1'b 1;
+          clr_sentmsg = 1'b 1;
+        end else begin
+          st_d = StPad01;
+        end
+      end
+
+      StFlush: begin
+        // Wait completion from keccak_round or wait SW indicator.
+        if (keccak_complete_i) begin
+          st_d = StIdle;
+          // TODO: Clear internal variables to fresh start
+        end else begin
+          st_d = StFlush;
+        end
+      end
+
+      default: begin
+        st_d = StIdle;
+      end
+
+    endcase
+  end
+
+  //////////////
+  // Datapath //
+  //////////////
+
+  // `encode_bytepad` represents the first two bytes of bytepad()
+  // It depends on the block size. We can reuse KeccakRate
+  // 10000000 || 00010101 // 168
+  // 10000000 || 00010001 // 136
+  logic [15:0] encode_bytepad;
+
+  always_comb begin
+    unique case (strength_i)
+      L128: encode_bytepad = 16'h A801; // cSHAKE128
+      L224: encode_bytepad = 16'h 9001; // not used
+      L256: encode_bytepad = 16'h 8801; // cSHAKE256
+      L384: encode_bytepad = 16'h 6801; // not used
+      L512: encode_bytepad = 16'h 4801; // not used
+
+      default: encode_bytepad = 16'h 0000;
+    endcase
+  end
+
+
+  // Prefix size ==============================================================
+  // Prefix represents bytepad(encode_string(N) || encode_string(S), 168 or 136)
+  // encode_string(N) || encode_string(S) is prepared by the software and given
+  // through `ns_data_i`. The first part of bytepad is determined by the
+  // `strength_i` and stored into `encode_bytepad`.
+
+  // It is assumed that the prefix always smaller than the block size.
+  logic [PrefixSize*8-1:0] prefix;
+
+  assign prefix = {ns_data_i, encode_bytepad};
+
+  logic [MsgWidth-1:0] prefix_sliced;
+  logic [MsgWidth-1:0] prefix_data [Share];
+
+  prim_slicer #(
+    .InW (PrefixSize*8),
+    .IndexW(KeccakMsgAddrW),
+    .OutW(MsgWidth)
+  ) u_prefix_slicer (
+    .sel_i  (prefix_index),
+    .data_i (prefix),
+    .data_o (prefix_sliced)
+  );
+
+  if (EnMasking) begin : gen_prefix_masked
+    // If Masking is enabled, prefix is two share.
+    assign prefix_data[0] = '0;
+    assign prefix_data[1] = prefix_sliced;
+  end else begin : gen_prefix_unmasked
+    // If Unmasked, only one share exists.
+    assign prefix_data[0] = prefix_sliced;
+  end
+
+  // ==========================================================================
+  // function_pad is the unique value padded at the end of the message based on
+  // the function among SHA3, SHAKE, cSHAKE. The standard mentioned that SHA3
+  // pads `01` , SHAKE pads `1111`, and cSHAKE pads `00`.
+  //
+  // Then pad10*1() function follows. It adds `1` first then fill 0 until it
+  // reaches the block size -1, then adds `1`.
+  //
+  // It means always `1` is followed by the function pad.
+  logic [4:0] funcpad;
+
+  logic [MsgWidth-1:0] funcpad_merged [Share];
+  logic [MsgWidth-1:0] funcpad_data [Share];
+
+  always_comb begin
+    unique case (mode_i)
+      Sha3:   funcpad = 5'b 00110;
+      Shake:  funcpad = 5'b 11111;
+      CShake: funcpad = 5'b 00100;
+
+      default: begin
+        // Just create non-padding but pad10*1 only
+        funcpad = 5'b 00001;
+      end
+    endcase
+  end
+
+  // `end_of_block` indicates current beat is end of the block
+  // It shall set when the address reaches to the end of the block. End address
+  // is set by the strength_i, which is `block_addr_limit`.
+  // TODO: Decide if it needs to compare with the FSM in {StPad, StPad01} or not
+  logic end_of_block;
+
+  assign end_of_block = ((sent_message+1) == block_addr_limit) ? 1'b 1 : 1'b 0;
+
+  // ==========================================================================
+  // `zero_with_endbit` contains all zero unless the message is for the last
+  // MsgWidth beat in the block. If it is the end of the block, the last bit
+  // will be set to complete pad10*1() functionality.
+  logic [MsgWidth-1:0] zero_with_endbit [Share];
+
+  if (EnMasking) begin : gen_zeroend_masked;
+    assign zero_with_endbit[0]               = '0;
+    assign zero_with_endbit[1][MsgWidth-1]   = end_of_block;
+    assign zero_with_endbit[1][MsgWidth-2:0] = '0;
+  end else begin : gen_zeroend_unmasked;
+    assign zero_with_endbit[0][MsgWidth-1]   = end_of_block;
+    assign zero_with_endbit[0][MsgWidth-2:0] = '0;
+  end
+
+  // ==========================================================================
+  // Data mux for output data
+
+  assign keccak_addr_o = (sent_message < block_addr_limit) ? sent_message : '0;
+
+  always_comb begin
+    unique case (sel_mux)
+      MuxFifo:    keccak_data_o = msg_data_i;
+      MuxPrefix:  keccak_data_o = prefix_data;
+      MuxFuncPad: keccak_data_o = funcpad_data;
+      MuxZeroEnd: keccak_data_o = zero_with_endbit;
+
+      // MuxNone
+      default:  keccak_data_o = '{default:'0};
+    endcase
+  end
+
+  // TODO: keccak_valid_o mux
+  always_comb begin
+    unique case (sel_mux)
+      MuxFifo:    keccak_valid_o = msg_valid_i & ~hold_msg & ~en_msgbuf;
+      MuxPrefix:  keccak_valid_o = fsm_keccak_valid;
+      MuxFuncPad: keccak_valid_o = fsm_keccak_valid;
+      MuxZeroEnd: keccak_valid_o = fsm_keccak_valid;
+
+      // MuxNone
+      default:  keccak_valid_o = 1'b 0;
+    endcase
+  end
+
+  // TODO: msg_ready_o mux
+  always_comb begin
+    unique case (sel_mux)
+      MuxFifo:    msg_ready_o = en_msgbuf | (keccak_ready_i & ~hold_msg);
+      MuxPrefix:  msg_ready_o = 1'b 0;
+      MuxFuncPad: msg_ready_o = 1'b 0;
+      MuxZeroEnd: msg_ready_o = 1'b 0;
+
+      // MuxNone
+      default: msg_ready_o = 1'b 1;
+    endcase
+  end
+
+  // prim_packer : packing to 64bit to update keccak storage
+  // two prim_packer in this module are used to pack the data received from
+  // upper layer (KMAC core) and also the 5bit padding bits.
+  // It is assumed that the message from upper layer could be partial at the
+  // end of the message. Then the 2 or 4bit padding is required. It can be
+  // handled by some custom logic or could be done by prim_packer.
+  // If packer is used, the MSG_FIFO doesn't have to have another prim_packer
+  // in front of the FIFO. This logic can handle the partial writes from the
+  // software.
+  //
+  // If a custom logic is implemented here, prim_packer is necessary in front
+  // of the FIFO, as this logic only appends at the end of the message when
+  // `process_i` is asserted. Also, in this case, even prim_packer is not
+  // needed, still 64bit registers to latch the partial write is required.
+  // If not, the logic has to delay the acceptance of the incoming write
+  // accesses. It may trigger the back-pressuring in some case which may result
+  // that the software(or upper layer) may not set process_i.
+  //
+  // For custom logic, it could be implemented by the 8 mux selection.
+  // for instance: (subject to be changed)
+  //   unique case (sent_byte[2:0]) // generated from msg_mask_i
+  //     3'b 000: funcpad_merged = {end_of_block, 63'(function_pad)                  };
+  //     3'b 001: funcpad_merged = {end_of_block, 55'(function_pad), msg_data_i[ 7:0]};
+  //     3'b 010: funcpad_merged = {end_of_block, 47'(function_pad), msg_data_i[15:0]};
+  //     3'b 011: funcpad_merged = {end_of_block, 39'(function_pad), msg_data_i[23:0]};
+  //     3'b 100: funcpad_merged = {end_of_block, 31'(function_pad), msg_data_i[31:0]};
+  //     3'b 101: funcpad_merged = {end_of_block, 23'(function_pad), msg_data_i[39:0]};
+  //     3'b 110: funcpad_merged = {end_of_block, 15'(function_pad), msg_data_i[47:0]};
+  //     3'b 111: funcpad_merged = {end_of_block,  7'(function_pad), msg_data_i[55:0]};
+  //     default: funcpad_merged = '0;
+  //   endcase
+
+  // internal buffer to store partial write. It doesn't have to store last byte as it
+  // stores only when partial write.
+  logic [MsgWidth-8-1:0] msg_buf [Share];
+  logic [MsgStrbW-1-1:0] msg_mask;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      msg_buf  <= '{default:'0};
+      msg_mask <= '0;
+    end else if (en_msgbuf) begin
+      for (int i = 0 ; i < Share ; i++) begin
+        msg_buf[i]  <= msg_data_i[i][0+:(MsgWidth-8)];
+      end
+      msg_mask <= msg_mask_i[0+:(MsgStrbW-1)];
+    end else if (clr_msgbuf) begin
+      msg_buf  <= '{default:'0};
+      msg_mask <= '0;
+    end
+  end
+
+  if (EnMasking) begin : gen_funcpad_data_masked
+    always_comb begin
+      unique case (msg_mask)
+        7'b 000_0000: begin
+          funcpad_data[0] = '0;
+          funcpad_data[1] = {end_of_block, 63'(funcpad)                  };
+        end
+        7'b 000_0001: begin
+          funcpad_data[0] = {56'h0,                      msg_buf[0][ 7:0]};
+          funcpad_data[1] = {end_of_block, 55'(funcpad), msg_buf[1][ 7:0]};
+        end
+        7'b 000_0011: begin
+          funcpad_data[0] = {48'h0,                      msg_buf[0][15:0]};
+          funcpad_data[1] = {end_of_block, 47'(funcpad), msg_buf[1][15:0]};
+        end
+        7'b 000_0111: begin
+          funcpad_data[0] = {40'h0,                      msg_buf[0][23:0]};
+          funcpad_data[1] = {end_of_block, 39'(funcpad), msg_buf[1][23:0]};
+        end
+        7'b 000_1111: begin
+          funcpad_data[0] = {32'h0,                      msg_buf[0][31:0]};
+          funcpad_data[1] = {end_of_block, 31'(funcpad), msg_buf[1][31:0]};
+        end
+        7'b 001_1111: begin
+          funcpad_data[0] = {24'h0,                      msg_buf[0][39:0]};
+          funcpad_data[1] = {end_of_block, 23'(funcpad), msg_buf[1][39:0]};
+        end
+        7'b 011_1111: begin
+          funcpad_data[0] = {16'h0,                      msg_buf[0][47:0]};
+          funcpad_data[1] = {end_of_block, 15'(funcpad), msg_buf[1][47:0]};
+        end
+        7'b 111_1111: begin
+          funcpad_data[0] = { 8'h0,                      msg_buf[0][55:0]};
+          funcpad_data[1] = {end_of_block,  7'(funcpad), msg_buf[1][55:0]};
+        end
+
+        default: funcpad_data = '{default:'0};
+      endcase
+    end
+  end else begin : gen_funcpad_data_unmasked
+    always_comb begin
+      unique case (msg_mask)
+        7'b 000_0000: funcpad_data[0] = {end_of_block, 63'(funcpad)                  };
+        7'b 000_0001: funcpad_data[0] = {end_of_block, 55'(funcpad), msg_buf[0][ 7:0]};
+        7'b 000_0011: funcpad_data[0] = {end_of_block, 47'(funcpad), msg_buf[0][15:0]};
+        7'b 000_0111: funcpad_data[0] = {end_of_block, 39'(funcpad), msg_buf[0][23:0]};
+        7'b 000_1111: funcpad_data[0] = {end_of_block, 31'(funcpad), msg_buf[0][31:0]};
+        7'b 001_1111: funcpad_data[0] = {end_of_block, 23'(funcpad), msg_buf[0][39:0]};
+        7'b 011_1111: funcpad_data[0] = {end_of_block, 15'(funcpad), msg_buf[0][47:0]};
+        7'b 111_1111: funcpad_data[0] = {end_of_block,  7'(funcpad), msg_buf[0][55:0]};
+
+        default: funcpad_data = '{default:'0};
+      endcase
+    end
+  end
+
+  ////////////////
+  // Assertions //
+  ////////////////
+
+  // Prefix size is smaller than the smallest Keccak Block Size, which is 72 bytes.
+  `ASSERT_INIT(PrefixLessThanBlock_A, PrefixSize/8 < KeccakRate[4])
+
+  // Some part of datapath in sha3pad assumes Data width as 64bit.
+  // If data width need to be changed, funcpad_data part should be changed too.
+  // Also, The blocksize shall be divided by MsgWidth, which means, MsgWidth
+  // can be {16, 32, 64} even funcpad_data mux is fully flexible.
+  `ASSERT_INIT(MsgWidthidth_A, MsgWidth == 64)
+
+  // Assumption of input mode_i and strength_i
+  // SHA3 variants: SHA3-224, SHA3-256, SHA3-384, SHA3-512
+  // SHAKE, cSHAKE variants: SHAKE128, SHAKE256, cSHAKE128, cSHAKE256
+  `ASSUME(ModeStrengthCombinations_A,
+    $changed(mode_i) || $changed(strength_i) |->
+      (mode_i == Sha3 && (strength_i inside {L224, L256, L384, L512})) ||
+      ((mode_i == Shake || mode_i == CShake) && (strength_i inside {L128, L256})),
+    clk_i, !rst_ni)
+
+  // Keccak control interface
+  // Keccak run triggered -> completion should come
+  `ASSUME(RunThenComplete_A,
+    keccak_run_o |=> ##[1:$] keccak_complete_i, clk_i, !rst_ni)
+
+  // No partial write is allowed for Message FIFO interface
+  `ASSUME(NoPartialMsgFifo_A,
+    keccak_valid_o && (sel_mux == MuxFifo) |-> (&msg_mask_i) == 1'b1,
+    clk_i, !rst_ni)
+
+  // When transaction is stored into msg_buf, it shall be partial write.
+  `ASSUME(AlwaysPartialMsgBuf_A,
+    en_msgbuf |-> msg_valid_i && (msg_mask_i[MsgStrbW-1] == 1'b0),
+    clk_i, !rst_ni)
+
+  // if partial write comes and is acked, then no more msg_valid_i until
+  // next message
+  `ASSUME(PartialEndOfMsg_A,
+    keccak_ack && msg_partial |=>
+      !msg_valid_i ##[1:$] $stable(msg_valid_i) ##1 process_latched,
+    clk_i, !rst_ni)
+
+  // At the first clock in StPad01 state, sent_blocksize shall not be set
+  `ASSERT(Pad01NotAttheEndOfBlock_A,
+    (st == StPad && st_d == StPad01) |-> !end_of_block,
+    clk_i, !rst_ni)
+
+  // When data sent to the keccak_round, the address should be in the range
+  `ASSERT(KeccakAddrInRange_A,
+    keccak_valid_o |-> keccak_addr_o < KeccakRate[strength_i],
+    clk_i, !rst_ni)
+
+endmodule
+

--- a/hw/ip/prim/prim.core
+++ b/hw/ip/prim/prim.core
@@ -32,6 +32,7 @@ filesets:
       - rtl/prim_sram_arbiter.sv
       - rtl/prim_fifo_async.sv
       - rtl/prim_fifo_sync.sv
+      - rtl/prim_slicer.sv
       - rtl/prim_sync_reqack.sv
       - rtl/prim_keccak.sv
       - rtl/prim_packer.sv

--- a/hw/ip/prim/rtl/prim_slicer.sv
+++ b/hw/ip/prim/rtl/prim_slicer.sv
@@ -1,0 +1,42 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Slicer chops the incoming bitstring into OutW granularity.
+// It supports fractional InW/OutW which fills 0 at the end of message.
+
+`include "prim_assert.sv"
+
+module prim_slicer #(
+  parameter int InW = 64,
+  parameter int OutW = 8,
+
+  parameter int IndexW = 4
+) (
+  input        [IndexW-1:0] sel_i,
+  input        [InW-1:0]    data_i,
+  output logic [OutW-1:0]   data_o
+);
+
+  // Find number of entries imitating ceil function
+  localparam int Entries = (InW + OutW -1)/OutW;
+  localparam int Partial = (InW % OutW != 0) ? 1 : 0;
+
+  always_comb begin
+    data_o = '0;
+    if (sel_i < Entries) begin
+      for (int i = 0 ; i < Entries ; i++) begin
+        if (i == sel_i) begin
+          if (Partial && i == (Entries-1)) begin
+            // last message that is partial
+            data_o = OutW'(data_i[InW-1:(Entries-1)*OutW]);
+          end else begin
+            data_o = data_i[i*OutW+:OutW];
+          end
+        end
+      end
+    end
+  end
+
+endmodule
+


### PR DESCRIPTION
This PR implements SHA3/SHAKE/cSHAKE padding logic. cSHAKE needds extra inputs to add Function-name `N` and Customization string `S`. Other than that, SHA3/SHAKE/cSHAKE shares similar datapath except the last part added to the end of the message. SHA3 adds 2'b10 (little-endian), SHAKE adds 4'b1111, cSHAKE adds 2'b00. `pad10*1()` follows the function pad bits.

Interface between this padding logic and the MSG_FIFO follows conventional FIFO interface. This module talks to Keccak round logic with more memory-like interface (having address port)