### PR TITLE
[otbn] Remove unused signals from otbn_core_model

### DIFF
--- a/hw/ip/otbn/dv/model/otbn_core_model.sv
+++ b/hw/ip/otbn/dv/model/otbn_core_model.sv
@@ -31,25 +31,7 @@ module otbn_core_model
   input  logic  start_i, // start the operation
   output logic  done_o,  // operation done
 
-  input  logic [ImemAddrWidth-1:0] start_addr_i, // start byte address in IMEM
-
-  // Instruction memory (IMEM)
-  output logic                     imem_req_o,
-  output logic [ImemAddrWidth-1:0] imem_addr_o,
-  output logic [31:0]              imem_wdata_o,
-  input  logic [31:0]              imem_rdata_i,
-  input  logic                     imem_rvalid_i,
-  input  logic [1:0]               imem_rerror_i,
-
-  // Data memory (DMEM)
-  output logic                     dmem_req_o,
-  output logic                     dmem_write_o,
-  output logic [DmemAddrWidth-1:0] dmem_addr_o,
-  output logic [WLEN-1:0]          dmem_wdata_o,
-  output logic [WLEN-1:0]          dmem_wmask_o,
-  input  logic [WLEN-1:0]          dmem_rdata_i,
-  input  logic                     dmem_rvalid_i,
-  input  logic [1:0]               dmem_rerror_i
+  input  logic [ImemAddrWidth-1:0] start_addr_i // start byte address in IMEM
 );
 
   import "DPI-C" context function int run_model(string imem_scope,

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -435,23 +435,7 @@ module otbn
       .start_i (start),
       .done_o  (done),
 
-      .start_addr_i  (start_addr),
-
-      .imem_req_o    (imem_req_core),
-      .imem_addr_o   (imem_addr_core),
-      .imem_wdata_o  (imem_wdata_core),
-      .imem_rdata_i  (imem_rdata_core),
-      .imem_rvalid_i (imem_rvalid_core),
-      .imem_rerror_i (imem_rerror_core),
-
-      .dmem_req_o    (dmem_req_core),
-      .dmem_write_o  (dmem_write_core),
-      .dmem_addr_o   (dmem_addr_core),
-      .dmem_wdata_o  (dmem_wdata_core),
-      .dmem_wmask_o  (dmem_wmask_core),
-      .dmem_rdata_i  (dmem_rdata_core),
-      .dmem_rvalid_i (dmem_rvalid_core),
-      .dmem_rerror_i (dmem_rerror_core)
+      .start_addr_i  (start_addr)
     );
   end else begin : gen_impl_rtl
     otbn_core #(


### PR DESCRIPTION
otbn_core_model wraps the ISS, a Python instruction set simulator.
This includes memories: the model works by snapshotting the contents
of the memories when it starts, and writing them back when it's done.
