### PR TITLE
[dv/top-level] Disable ibex clock to avoid too much print

### DIFF
--- a/hw/top_earlgrey/data/tb__xbar_connect.sv.tpl
+++ b/hw/top_earlgrey/data/tb__xbar_connect.sv.tpl
@@ -66,6 +66,8 @@ initial begin
   bit xbar_mode;
   void'($value$plusargs("xbar_mode=%0b", xbar_mode));
   if (xbar_mode) begin
+    // disable ibex clock to avoid printting too much useless log from ibex
+    force `CPU_HIER.clk_i = 1'b0;
     // only enable assertions in xbar as many pins are unconnected
     $assertoff(0, tb);
 % for xbar in top["xbar"]:

--- a/hw/top_earlgrey/dv/autogen/tb__xbar_connect.sv
+++ b/hw/top_earlgrey/dv/autogen/tb__xbar_connect.sv
@@ -60,6 +60,8 @@ initial begin
   bit xbar_mode;
   void'($value$plusargs("xbar_mode=%0b", xbar_mode));
   if (xbar_mode) begin
+    // disable ibex clock to avoid printting too much useless log from ibex
+    force `CPU_HIER.clk_i = 1'b0;
     // only enable assertions in xbar as many pins are unconnected
     $assertoff(0, tb);
     $asserton(0, tb.dut.top_earlgrey.u_xbar_main);


### PR DESCRIPTION
as Cindy pointed out Ibex printed a lot of "Illegal instruction" in xbar test
Ibex isn't tested chip xbar test, disable its clock to avoid printing log

Signed-off-by: Weicai Yang <weicai@google.com>