### PR TITLE
[dv/hmac] corner case for error sequences

### DIFF
--- a/hw/ip/hmac/dv/env/seq_lib/hmac_sanity_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_sanity_vseq.sv
@@ -112,7 +112,8 @@ class hmac_sanity_vseq extends hmac_base_vseq;
         // If the last two fifo_rds are not back-to-back, then there won't be any delay for the
         // last fifo_rd
         // the wait_clk below is implemented to avoid checking intr_state during this corner case
-        cfg.clk_rst_vif.wait_clks((msg.size() % 4) ? HMAC_KEY_PROCESS_CYCLES * 2 :
+        cfg.clk_rst_vif.wait_clks((msg.size() % 4 || !legal_seq_c.constraint_mode()) ?
+                                  HMAC_KEY_PROCESS_CYCLES * 2 :
                                   $urandom_range(0, HMAC_KEY_PROCESS_CYCLES * 2));
 
         if (do_hash_start) begin


### PR DESCRIPTION
While modifying hmac scb I found a corner case in `hmac_error`
sequence.
In sanity sequence, if hmac streamed-in msg is partial (length is not
a multiple of 4), there is one clock cycle that is wavied to check
fifo_empty interrupt. So in sanity sequence I used `msg_q % 4` to gate it.
But in `hmac_error` seq, we are not always streaming in `msg_q`: if we found
the sequence causes an error, we will resend some other random messages.
This could potentially stream in partial message. So this PR resolves
this issue by gating the `hmac_error` sequence as well.

Signed-off-by: Cindy Chen <chencindy@google.com>