### PR TITLE
[docker] Ensure Containers use UTF-8

### DIFF
--- a/site/docs/builder.Dockerfile
+++ b/site/docs/builder.Dockerfile
@@ -5,7 +5,12 @@
 FROM ubuntu:16.04
 
 RUN apt-get update && \
-  apt-get install -y git curl doxygen python3 python3-pip xsltproc && \
+  apt-get install -y locales locales-all git curl doxygen python3 python3-pip xsltproc && \
   apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
+
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+
 COPY python-requirements.txt ./
 RUN pip3 install -r python-requirements.txt

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -64,11 +64,16 @@ COPY --from=verilator /tools/verilator/${VERILATOR_VERSION} verilator/${VERILATO
 # Install (and cleanup) required packages (from apt-requirements.txt)
 # The list of extra packages is leftover from before this Dockerfile used
 # apt-requirements.txt
+#
+# This also adds `locales` and `locales-all` so we can set the locale to utf-8
 COPY apt-requirements.txt /tmp/apt-requirements.txt
 RUN apt-get update && \
     sed 's/#.*//' /tmp/apt-requirements.txt \
         | xargs apt-get install -y && \
+    apt-get install -y  && \
     apt-get install -y \
+        locales \
+        locales-all \
         gnupg2 \
         libc6-i386 \
         libtool \
@@ -76,6 +81,11 @@ RUN apt-get update && \
         screen && \
     apt-get clean ; \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
+
+# Set Locale to utf-8 everywhere
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
 
 # Copy repository into tmp directory to execute additional install steps.
 COPY python-requirements.txt /tmp/python-requirements.txt


### PR DESCRIPTION
We've had issues in the past with trying to build documentation with
non-ASCII characters in the document comments.

This sets the locale to UTF-8, so that python chooses utf-8 by default
too. This ensures that parsing files in python with non-ascii characters
will succeed, as long as those characters are valid utf-8.