### PR TITLE
[ci] Add Task To Build Docker Containers

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -469,3 +469,31 @@ jobs:
       addChangeLog: false
       assets: |
           $(Build.ArtifactStagingDirectory)/dist-final/*
+
+
+- job: build_docker_containers
+  displayName: "Build Docker Containers"
+  pool:
+    vmImage: ubuntu-16.04
+  dependsOn:
+    - lint
+  steps:
+  - task: Docker@2
+    displayName: Build Developer Utility Container
+    inputs:
+      command: build
+      Dockerfile: ./util/container/Dockerfile
+      buildContext: .
+  - task: Docker@2
+    displayName: Build Documentation Builder Container
+    inputs:
+      command: build
+      tags: gcr.io/active-premise-257318/builder
+      Dockerfile: ./site/docs/builder.Dockerfile
+      buildContext: .
+  - task: Docker@2
+    displayName: Build Documentation Redirector Container
+    inputs:
+      command: build
+      Dockerfile: ./site/redirector/Dockerfile
+      buildContext: ./site/redirector


### PR DESCRIPTION
We currently do no checking or automated updating of the Dockerfiles
committed to the repository. This makes a step along that path, with a
task that will at least attempt to build the three containers.

In the future, we may turn on some kind of automated updating for
commits to the master branch, but that's a lot more dangerous than this.