### PR TITLE
[kmac] Add ready_o to keccak_round

### DIFF
--- a/hw/ip/kmac/fpv/tb/keccak_round_fpv.sv
+++ b/hw/ip/kmac/fpv/tb/keccak_round_fpv.sv
@@ -34,6 +34,7 @@ module keccak_round_fpv #(
   logic                msg_valid;
   logic [DInAddr-1:0]  msg_addr;
   logic [DInWidth-1:0] msg_data;
+  logic                msg_ready_masked, msg_ready_unmasked;
 
   logic run, clear, masked_complete, unmasked_complete;
 
@@ -50,6 +51,7 @@ module keccak_round_fpv #(
     .valid_i (msg_valid),
     .addr_i  (msg_addr),
     .data_i  ({'0, msg_data}),
+    .ready_o (msg_ready_masked),
 
     .run_i   (run),
     .rand_valid_i (1'b1),
@@ -71,6 +73,7 @@ module keccak_round_fpv #(
     .valid_i (msg_valid),
     .addr_i  (msg_addr),
     .data_i  ('{msg_data}),
+    .ready_o (msg_ready_unmasked),
 
     .run_i   (run),
     .rand_valid_i (1'b1),

--- a/hw/ip/kmac/rtl/keccak_round.sv
+++ b/hw/ip/kmac/rtl/keccak_round.sv
@@ -38,6 +38,7 @@ module keccak_round #(
   input                valid_i,
   input [DInAddr-1:0]  addr_i,
   input [DInWidth-1:0] data_i [Share],
+  output               ready_o,
 
   // In-process control
   input                    run_i,  // Pulse signal to initiates Keccak full round
@@ -274,6 +275,11 @@ module keccak_round #(
       end
     endcase
   end
+
+  // Ready indicates the keccak_round is able to receive new message.
+  // While keccak_round is processing the data, it blocks the new message to be
+  // XORed into the current state.
+  assign ready_o = (keccak_st == StIdle) ? 1'b 1 : 1'b 0;
 
   ////////////////////////////
   // Keccak state registers //


### PR DESCRIPTION
To handle the data feed interface easier in SHA3 padding logic, added
ready output port in keccak_round to indicate the internal state being
ready to accept new message bitstream.
