### PR TITLE
Require pyyaml >= 5.1

### DIFF
--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -22,7 +22,7 @@ pyftdi
 pygments
 pytest
 pytest-timeout
-pyyaml
+pyyaml >= 5.1
 tabulate
 yapf
 


### PR DESCRIPTION
This is needed by primgen.py, which uses the sort_keys argument to
dump_all (which was only added in this release).

See issue #3407 for what happens without it!