### PR TITLE
[dv/common] Use random data in TLUL when valid=1 & ready=0

### DIFF
--- a/hw/dv/sv/tl_agent/tl_agent.sv
+++ b/hw/dv/sv/tl_agent/tl_agent.sv
@@ -26,6 +26,10 @@ class tl_agent extends dv_base_agent#(
       `uvm_fatal(`gfn, "failed to get tl_if handle from uvm_config_db")
     end
     cfg.vif.if_mode = cfg.if_mode;
+    cfg.vif.randomize_data_ctrl_when_ready_low = cfg.randomize_data_ctrl_when_ready_low;
+    cfg.vif.randomize_addr_when_ready_low = cfg.randomize_addr_when_ready_low;
+    cfg.vif.a_source_randomize_mask_when_ready_low = cfg.a_source_randomize_mask_when_ready_low;
+    cfg.vif.d_source_randomize_mask_when_ready_low = cfg.d_source_randomize_mask_when_ready_low;
   endfunction
 
   function void connect_phase(uvm_phase phase);

--- a/hw/dv/sv/tl_agent/tl_agent_cfg.sv
+++ b/hw/dv/sv/tl_agent/tl_agent_cfg.sv
@@ -40,6 +40,12 @@ class tl_agent_cfg extends dv_base_agent_cfg;
   int unsigned d_valid_delay_min = 0;
   int unsigned d_valid_delay_max = 10;
 
+  // use random data when valid = 1 and ready = 0
+  bit randomize_data_ctrl_when_ready_low = 1;
+  bit randomize_addr_when_ready_low = 1;
+  bit [bus_params_pkg::BUS_AIW-1:0] a_source_randomize_mask_when_ready_low = '1;
+  bit [bus_params_pkg::BUS_AIW-1:0] d_source_randomize_mask_when_ready_low = '1;
+
   `uvm_object_utils_begin(tl_agent_cfg)
     `uvm_field_int(max_outstanding_req,   UVM_DEFAULT)
     `uvm_field_enum(tl_level_e, tl_level, UVM_DEFAULT)

--- a/hw/dv/sv/tl_agent/tl_if.sv
+++ b/hw/dv/sv/tl_agent/tl_if.sv
@@ -13,6 +13,18 @@ interface tl_if(input clk, input rst_n);
   tlul_pkg::tl_h2d_t h2d_int; // req (internal)
   tlul_pkg::tl_d2h_t d2h_int; // rsp (internal)
 
+  tlul_pkg::tl_h2d_t h2d_int_final; // req (internal, with randomize data when ready is low)
+  tlul_pkg::tl_d2h_t d2h_int_final; // rsp (internal, with randomize data when ready is low)
+  tlul_pkg::tl_h2d_t h2d_int_rand; // req (internal, contain randomize data)
+  tlul_pkg::tl_d2h_t d2h_int_rand; // rsp (internal, contain randomize data)
+  // knobs to randomize data control info when ready is low
+  bit randomize_data_ctrl_when_ready_low = 1;
+  // xbar may use addr and source to route the item to device and set ready, randomize source may
+  // create deadloop
+  bit randomize_addr_when_ready_low = 1;
+  bit [bus_params_pkg::BUS_AIW-1:0] a_source_randomize_mask_when_ready_low = '1;
+  bit [bus_params_pkg::BUS_AIW-1:0] d_source_randomize_mask_when_ready_low = '1;
+
   dv_utils_pkg::if_mode_e if_mode; // interface mode - Host or Device
 
   modport dut_host_mp(output h2d_int, input d2h_int);
@@ -39,7 +51,72 @@ interface tl_if(input clk, input rst_n);
   endclocking
   modport mon_mp(clocking mon_cb);
 
-  assign h2d = (if_mode == dv_utils_pkg::Host) ? h2d_int : 'z;
-  assign d2h = (if_mode == dv_utils_pkg::Device) ? d2h_int : 'z;
+  assign h2d = (if_mode == dv_utils_pkg::Host) ? h2d_int_final : 'z;
+  assign d2h = (if_mode == dv_utils_pkg::Device) ? d2h_int_final : 'z;
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n || randomize_data_ctrl_when_ready_low && h2d_int.a_valid && d2h.a_ready) begin
+      h2d_int_rand.a_address <= $urandom;
+      h2d_int_rand.a_opcode  <= $urandom;
+      h2d_int_rand.a_size    <= $urandom;
+      h2d_int_rand.a_param   <= $urandom;
+      h2d_int_rand.a_data    <= $urandom;
+      h2d_int_rand.a_mask    <= $urandom;
+      h2d_int_rand.a_source  <= $urandom;
+    end
+  end
+
+  always_comb begin
+    if (if_mode == dv_utils_pkg::Host) begin
+      h2d_int_final.a_valid = h2d_int.a_valid;
+      h2d_int_final.d_ready = h2d_int.d_ready;
+      h2d_int_final.a_user  = h2d_int.a_user;
+      if (!randomize_data_ctrl_when_ready_low || !h2d_int.a_valid || d2h.a_ready) begin
+        h2d_int_final = h2d_int;
+      end else if (h2d_int.a_valid && !d2h.a_ready) begin
+        h2d_int_final.a_address = randomize_addr_when_ready_low ? h2d_int_rand.a_address :
+                                                                  h2d_int.a_address;
+        h2d_int_final.a_opcode  = h2d_int_rand.a_opcode;
+        h2d_int_final.a_size    = h2d_int_rand.a_size;
+        h2d_int_final.a_param   = h2d_int_rand.a_param;
+        h2d_int_final.a_data    = h2d_int_rand.a_data;
+        h2d_int_final.a_mask    = h2d_int_rand.a_mask;
+        h2d_int_final.a_source  = (a_source_randomize_mask_when_ready_low & h2d_int_rand.a_source) |
+                                  (~a_source_randomize_mask_when_ready_low & h2d_int.a_source);
+      end
+    end
+  end
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n || randomize_data_ctrl_when_ready_low && d2h_int.d_valid && h2d.d_ready) begin
+      d2h_int_rand.d_opcode <= $urandom;
+      d2h_int_rand.d_data   <= $urandom;
+      d2h_int_rand.d_param  <= $urandom;
+      d2h_int_rand.d_error  <= $urandom;
+      d2h_int_rand.d_sink   <= $urandom;
+      d2h_int_rand.d_size   <= $urandom;
+      d2h_int_rand.d_source <= $urandom;
+    end
+  end
+
+  always_comb begin
+    if (if_mode == dv_utils_pkg::Device) begin
+      d2h_int_final.d_valid = d2h_int.d_valid;
+      d2h_int_final.a_ready = d2h_int.a_ready;
+      d2h_int_final.d_user  = d2h_int.d_user;
+      if (!randomize_data_ctrl_when_ready_low || !d2h_int.d_valid || h2d.d_ready) begin
+        d2h_int_final = d2h_int;
+      end else if (d2h_int.d_valid && !h2d.d_ready) begin
+        d2h_int_final.d_opcode = d2h_int_rand.d_opcode;
+        d2h_int_final.d_data   = d2h_int_rand.d_data;
+        d2h_int_final.d_param  = d2h_int_rand.d_param;
+        d2h_int_final.d_error  = d2h_int_rand.d_error;
+        d2h_int_final.d_sink   = d2h_int_rand.d_sink;
+        d2h_int_final.d_size   = d2h_int_rand.d_size;
+        d2h_int_final.d_source = (d_source_randomize_mask_when_ready_low & d2h_int_rand.d_source) |
+                                 (~d_source_randomize_mask_when_ready_low & d2h_int.d_source);
+      end
+    end
+  end
 
 endinterface : tl_if

--- a/hw/ip/tlul/generic_dv/env/xbar_env.sv
+++ b/hw/ip/tlul/generic_dv/env/xbar_env.sv
@@ -60,6 +60,10 @@ class xbar_env extends dv_base_env#(.CFG_T              (xbar_env_cfg),
       scoreboard.add_item_queue({"d_chan_", xbar_devices[i].device_name},
                          scoreboard_pkg::kOutOfOrderCheck);
     end
+
+    // when driver sends illegal data during ready=0, these data will be passed to the other side
+    // of the xbar. Need to disable checking when ready is low
+    uvm_config_db#(bit)::set(null, "*", "disable_tlul_assert_when_ready_low", 1);
   endfunction : build_phase
 
   function void connect_phase(uvm_phase phase);

--- a/hw/ip/tlul/generic_dv/env/xbar_env_cfg.sv
+++ b/hw/ip/tlul/generic_dv/env/xbar_env_cfg.sv
@@ -45,6 +45,8 @@ class xbar_env_cfg extends dv_base_env_cfg;
                           create($sformatf("%0s_agent_cfg", xbar_hosts[i].host_name));
       host_agent_cfg[i].if_mode = dv_utils_pkg::Host;
       host_agent_cfg[i].max_outstanding_req = 1 << valid_host_id_width;
+      host_agent_cfg[i].randomize_addr_when_ready_low = 0;
+      host_agent_cfg[i].a_source_randomize_mask_when_ready_low = (1 << valid_host_id_width) - 1;
     end
     // Device TL agent cfg
     num_devices      = xbar_devices.size();
@@ -56,6 +58,7 @@ class xbar_env_cfg extends dv_base_env_cfg;
       // the max_outstanding_req depends on how many hosts can access the device
       // device.max_outstanding_req = sum(all its hosts max_outstanding_req)
       device_agent_cfg[i].max_outstanding_req = 0; // clear default value
+      device_agent_cfg[i].d_source_randomize_mask_when_ready_low = 0;
       foreach (xbar_hosts[j]) begin
         if (xbar_devices[i].device_name inside {xbar_hosts[j].valid_devices}) begin
           device_agent_cfg[i].max_outstanding_req += host_agent_cfg[j].max_outstanding_req;


### PR DESCRIPTION
According to tl spec, driver just needs to provide meaningful data when
valid&ready=1. Connect data/control signals to random value when ready
is low
> the sender may change the contents of the control and data signals when a message
was not accepted.
If ready is LOW, the receiver must not process the beat and the sender must not consider the
beat processed.

With this change, the meaningful data only last one cycle. can get
tl_if.h2d_int signal for host interface to debug, it doesn't contain random value
when ready is low

related to #3383

Signed-off-by: Weicai Yang <weicai@google.com>