### PR TITLE
[dv/alert] disable coverage collection for ping_corner_case seq

### DIFF
--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_ping_corner_cases_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_ping_corner_cases_vseq.sv
@@ -42,6 +42,9 @@ class alert_handler_ping_corner_cases_vseq extends alert_handler_entropy_vseq;
   virtual task pre_start();
     super.pre_start();
     num_ping_trans.rand_mode(0);
+    // disable alert/esc build-in coverage, because this test forced original design variable
+    for (int i = 0; i < NUM_ALERTS; i++) cfg.alert_host_cfg[i].en_cov = 0;
+    for (int i = 0; i < NUM_ESCS; i++)   cfg.esc_device_cfg[i].en_cov = 0;
   endtask
 
   virtual task body();


### PR DESCRIPTION
The `alert_handler_ping_corner_case_vseq.sv` forced design internal
signal in order to hit all corner cases in a reasonable amount of time.
To ensure the original design's ping timer is able to ping all alert and
escalation ports, we will disable the build-in alert/esc functional
covearge in this `alert_handler_ping_corner_case` test. In this way, the
functional coverage only collects the real design variables.

Signed-off-by: Cindy Chen <chencindy@google.com>