### PR TITLE
[dv:tTL UL agent] updated tl_ul to select transctions ID from fifo ti support b2b transactions

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env.sv
@@ -18,6 +18,7 @@ class cip_base_env #(type CFG_T               = cip_base_env_cfg,
 
   virtual function void build_phase(uvm_phase phase);
     super.build_phase(phase);
+
     if (cfg.zero_delays) begin
       cfg.m_tl_agent_cfg.a_valid_delay_min = 0;
       cfg.m_tl_agent_cfg.a_valid_delay_max = 0;

--- a/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
+++ b/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
@@ -11,13 +11,14 @@ class dv_base_env_cfg #(type RAL_T = dv_base_reg_block) extends uvm_object;
   bit en_cov            = 1;
   bit has_ral           = 1;
   bit under_reset       = 0;
-
+  int zero_delay_pct    = 40;
+  
   // bit to configure all uvcs with zero delays to create high bw test
   rand bit zero_delays;
 
   // set zero_delays 40% of the time
   constraint zero_delays_c {
-    zero_delays dist {1'b0 := 6, 1'b1 := 4};
+    zero_delays dist {1'b0 :/ (100-zero_delay_pct), 1'b1 :/ zero_delay_pct};
   }
 
   // reg model & q of valid csr addresses

--- a/hw/dv/sv/tl_agent/tl_agent_cfg.sv
+++ b/hw/dv/sv/tl_agent/tl_agent_cfg.sv
@@ -22,7 +22,6 @@ class tl_agent_cfg extends dv_base_agent_cfg;
   // Then compare this value with designers to check if it meets their expectation
   int unsigned max_outstanding_req = 16;
 
-
   // TileLink channel valid delay (host mode)
   bit use_seq_item_a_valid_delay;
   int unsigned a_valid_delay_min = 0;

--- a/hw/dv/sv/tl_agent/tl_agent_cfg.sv
+++ b/hw/dv/sv/tl_agent/tl_agent_cfg.sv
@@ -22,6 +22,7 @@ class tl_agent_cfg extends dv_base_agent_cfg;
   // Then compare this value with designers to check if it meets their expectation
   int unsigned max_outstanding_req = 16;
 
+
   // TileLink channel valid delay (host mode)
   bit use_seq_item_a_valid_delay;
   int unsigned a_valid_delay_min = 0;
@@ -40,6 +41,16 @@ class tl_agent_cfg extends dv_base_agent_cfg;
   int unsigned d_valid_delay_min = 0;
   int unsigned d_valid_delay_max = 10;
 
+  // make a fifo with available req IDs
+  rand int unsigned outstanding_req_fifo[$];
+
+  constraint c_outstanding_req_fifo {
+    outstanding_req_fifo.size() == max_outstanding_req;
+    unique{outstanding_req_fifo};
+    foreach(outstanding_req_fifo[i])
+       outstanding_req_fifo[i] inside {[0:max_outstanding_req-1]};
+  };
+
   `uvm_object_utils_begin(tl_agent_cfg)
     `uvm_field_int(max_outstanding_req,   UVM_DEFAULT)
     `uvm_field_enum(tl_level_e, tl_level, UVM_DEFAULT)
@@ -47,6 +58,7 @@ class tl_agent_cfg extends dv_base_agent_cfg;
     `uvm_field_int(a_ready_delay_max,     UVM_DEFAULT)
     `uvm_field_int(d_ready_delay_min,     UVM_DEFAULT)
     `uvm_field_int(d_ready_delay_max,     UVM_DEFAULT)
+    `uvm_field_queue_int(outstanding_req_fifo,  UVM_DEFAULT)
   `uvm_object_utils_end
   `uvm_object_new
 

--- a/hw/dv/sv/tl_agent/tl_monitor.sv
+++ b/hw/dv/sv/tl_agent/tl_monitor.sv
@@ -108,6 +108,8 @@ class tl_monitor extends dv_base_monitor#(
             d_chan_port.write(rsp);
             pending_a_req.delete(i);
             req_found = 1'b1;
+            cfg.outstanding_req_fifo.push_back(rsp.d_source);
+            
             break;
           end
         end

--- a/hw/ip/aes/dv/env/aes_scoreboard.sv
+++ b/hw/ip/aes/dv/env/aes_scoreboard.sv
@@ -53,6 +53,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
   task run_phase(uvm_phase phase);
     super.run_phase(phase);
     `uvm_info(`gfn, $sformatf("%s", cfg.convert2string()), UVM_MEDIUM)
+    `uvm_info(`gfn, $sformatf("\n\t Enable scoreboard: %d", cfg.en_scb), UVM_MEDIUM)
     if(cfg.en_scb) begin
       fork
         compare();

--- a/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
@@ -82,31 +82,31 @@ class aes_base_vseq extends cip_base_vseq #(
 
   virtual task write_key(bit [7:0][31:0] key [2]);
     // Share 0 (the masked key share = key ^ mask)
-    csr_wr(.csr(ral.key_share0_0), .value(key[0][0]));
-    csr_wr(.csr(ral.key_share0_1), .value(key[0][1]));
-    csr_wr(.csr(ral.key_share0_2), .value(key[0][2]));
-    csr_wr(.csr(ral.key_share0_3), .value(key[0][3]));
-    csr_wr(.csr(ral.key_share0_4), .value(key[0][4]));
-    csr_wr(.csr(ral.key_share0_5), .value(key[0][5]));
-    csr_wr(.csr(ral.key_share0_6), .value(key[0][6]));
-    csr_wr(.csr(ral.key_share0_7), .value(key[0][7]));
+    csr_wr(.csr(ral.key_share0_0), .value(key[0][0]), .blocking(0));
+    csr_wr(.csr(ral.key_share0_1), .value(key[0][1]), .blocking(0));
+    csr_wr(.csr(ral.key_share0_2), .value(key[0][2]), .blocking(0));
+    csr_wr(.csr(ral.key_share0_3), .value(key[0][3]), .blocking(0));
+    csr_wr(.csr(ral.key_share0_4), .value(key[0][4]), .blocking(0));
+    csr_wr(.csr(ral.key_share0_5), .value(key[0][5]), .blocking(0));
+    csr_wr(.csr(ral.key_share0_6), .value(key[0][6]), .blocking(0));
+    csr_wr(.csr(ral.key_share0_7), .value(key[0][7]), .blocking(0));
     // Share 1 (the mask share)
-    csr_wr(.csr(ral.key_share1_0), .value(key[1][0]));
-    csr_wr(.csr(ral.key_share1_1), .value(key[1][1]));
-    csr_wr(.csr(ral.key_share1_2), .value(key[1][2]));
-    csr_wr(.csr(ral.key_share1_3), .value(key[1][3]));
-    csr_wr(.csr(ral.key_share1_4), .value(key[1][4]));
-    csr_wr(.csr(ral.key_share1_5), .value(key[1][5]));
-    csr_wr(.csr(ral.key_share1_6), .value(key[1][6]));
-    csr_wr(.csr(ral.key_share1_7), .value(key[1][7]));
+    csr_wr(.csr(ral.key_share1_0), .value(key[1][0]), .blocking(0));
+    csr_wr(.csr(ral.key_share1_1), .value(key[1][1]), .blocking(0));
+    csr_wr(.csr(ral.key_share1_2), .value(key[1][2]), .blocking(0));
+    csr_wr(.csr(ral.key_share1_3), .value(key[1][3]), .blocking(0));
+    csr_wr(.csr(ral.key_share1_4), .value(key[1][4]), .blocking(0));
+    csr_wr(.csr(ral.key_share1_5), .value(key[1][5]), .blocking(0));
+    csr_wr(.csr(ral.key_share1_6), .value(key[1][6]), .blocking(0));
+    csr_wr(.csr(ral.key_share1_7), .value(key[1][7]), .blocking(0));
   endtask // write_key
 
 
   virtual task write_iv(bit  [3:0][31:0] iv);
-    csr_wr(.csr(ral.iv_0), .value(iv[0]));
-    csr_wr(.csr(ral.iv_1), .value(iv[1]));
-    csr_wr(.csr(ral.iv_2), .value(iv[2]));
-    csr_wr(.csr(ral.iv_3), .value(iv[3]));
+    csr_wr(.csr(ral.iv_0), .value(iv[0]), .blocking(0) );
+    csr_wr(.csr(ral.iv_1), .value(iv[1]), .blocking(0) );
+    csr_wr(.csr(ral.iv_2), .value(iv[2]), .blocking(0) );
+    csr_wr(.csr(ral.iv_3), .value(iv[3]), .blocking(0) );
   endtask
 
 
@@ -116,20 +116,19 @@ class aes_base_vseq extends cip_base_vseq #(
     `uvm_info(`gfn, $sformatf("\n\t ----| DATA_IN_1: %h ", data[1][31:0]), UVM_MEDIUM)
     `uvm_info(`gfn, $sformatf("\n\t ----| DATA_IN_2: %h ", data[2][31:0]), UVM_MEDIUM)
     `uvm_info(`gfn, $sformatf("\n\t ----| DATA_IN_3: %h ", data[3][31:0]), UVM_MEDIUM)
-    csr_wr(.csr(ral.data_in_0), .value(data[0][31:0]) );
-    csr_wr(.csr(ral.data_in_1), .value(data[1][31:0]) );
-    csr_wr(.csr(ral.data_in_2), .value(data[2][31:0]) );
-    csr_wr(.csr(ral.data_in_3), .value(data[3][31:0]) );
+    csr_wr(.csr(ral.data_in_0), .value(data[0][31:0]), .blocking(0) );
+    csr_wr(.csr(ral.data_in_1), .value(data[1][31:0]), .blocking(0) );
+    csr_wr(.csr(ral.data_in_2), .value(data[2][31:0]), .blocking(0) );
+    csr_wr(.csr(ral.data_in_3), .value(data[3][31:0]), .blocking(0) );
   endtask
 
   virtual task read_data(ref bit [3:0] [31:0] cypher_txt);
-    csr_rd(.ptr(ral.data_out_0), .value(cypher_txt[0][31:0]));
-    csr_rd(.ptr(ral.data_out_1), .value(cypher_txt[1][31:0]));
-    csr_rd(.ptr(ral.data_out_2), .value(cypher_txt[2][31:0]));
-    csr_rd(.ptr(ral.data_out_3), .value(cypher_txt[3][31:0]));
+    csr_rd(.ptr(ral.data_out_0), .value(cypher_txt[0][31:0]), .blocking(1));
+    csr_rd(.ptr(ral.data_out_1), .value(cypher_txt[1][31:0]), .blocking(1));
+    csr_rd(.ptr(ral.data_out_2), .value(cypher_txt[2][31:0]), .blocking(1));
+    csr_rd(.ptr(ral.data_out_3), .value(cypher_txt[3][31:0]), .blocking(1));
 
     `uvm_info(`gfn, $sformatf("\n\t ----| READ OUTPUT DATA"), UVM_MEDIUM)
-    `uvm_info(`gfn, $sformatf("\n\t ----| ADDING DATA TO DUT %h ", cypher_txt),   UVM_MEDIUM)
     `uvm_info(`gfn, $sformatf("\n\t ----| DATA_OUT_0: %h ", cypher_txt[0][31:0]), UVM_MEDIUM)
     `uvm_info(`gfn, $sformatf("\n\t ----| DATA_OUT_1: %h ", cypher_txt[1][31:0]), UVM_MEDIUM)
     `uvm_info(`gfn, $sformatf("\n\t ----| DATA_OUT_2: %h ", cypher_txt[2][31:0]), UVM_MEDIUM)

--- a/hw/ip/aes/dv/tests/aes_base_test.sv
+++ b/hw/ip/aes/dv/tests/aes_base_test.sv
@@ -73,6 +73,5 @@ class aes_base_test extends cip_base_test #(
     cfg.error_types                 = 3'b111;
 
     cfg.config_error_pct            = 0;           // percentage of configuration errors
- `DV_CHECK_RANDOMIZE_FATAL(cfg)
   endfunction
 endclass : aes_base_test

--- a/hw/ip/aes/dv/tests/aes_sanity_test.sv
+++ b/hw/ip/aes/dv/tests/aes_sanity_test.sv
@@ -7,13 +7,17 @@ class aes_sanity_test extends aes_base_test;
   `uvm_component_utils(aes_sanity_test)
   `uvm_component_new
 
-   virtual function void build_phase(uvm_phase phase);
-     super.build_phase(phase);
-     configure_env();
+
+  virtual function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    configure_env();
   endfunction
 
   function void configure_env();
     super.configure_env();
+
+    cfg.zero_delay_pct           = 100;
+    
     cfg.errors_en                = 0;     // no errors in sanity test
     cfg.num_messages_min         = 2;
     cfg.num_messages_max         = 2;

--- a/hw/ip/aes/dv/tests/aes_wake_up_test.sv
+++ b/hw/ip/aes/dv/tests/aes_wake_up_test.sv
@@ -13,6 +13,7 @@ class aes_wake_up_test extends aes_base_test;
   endfunction
 
   virtual function void configure_env();
+     cfg.en_scb             = 0;    
      cfg.ecb_weight         = 100;
      cfg.cbc_weight         = 0;
      cfg.ctr_weight         = 0;


### PR DESCRIPTION
This PR contains The update that I was tasked with in the TL UL meeting and addresses the problem described in #3303  + a fix to zero delays. 

A queue is added to the tl_agent_cfg. The queue contains available transaction IDs from [0 : Max_outstanding_req-1] and is randomized before the test starts.

when the driver sends a transaction it pops an available ID from the queue,
when the Transaction is completed by the device the monitor will push the ID back into the queue.

Q: currently Ids are Popped from the front and pushed in the back.
this means all ID's will be cycled. another option is to push and pop on the same side of the queue which will only use the first few IDs

Q: currently the queue is randomized before the test starts, I don't think this hurts us - but realistically a host will probably start with id=0 and increment.


with this PR I also added a knob to control the pct of which zero_delays will be set 
this allows a designer to control the value from a test or a higher level config item.

there is also a little AES clean up that came about in the process of debugging an issue with controlling zero_delays.

should we merge this until we have a better suggestion or should we wait for @sriyerg and @weicaiyang solutions?
Aes is not blocked but scribbled as long as B2b is not an option
