### PR TITLE
[i2c, dv] Support on-the-fly reset, add error_intr, and fix fifo_overflow

### DIFF
--- a/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
+++ b/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
@@ -26,6 +26,10 @@ class i2c_agent_cfg extends dv_base_agent_cfg;
     `uvm_field_int(timing_cfg.tHoldStop,                      UVM_DEFAULT)
     `uvm_field_int(timing_cfg.tTimeOut,                       UVM_DEFAULT)
     `uvm_field_int(timing_cfg.enbTimeOut,                     UVM_DEFAULT)
+    `uvm_field_int(timing_cfg.tStretchHostClock,              UVM_DEFAULT)
+    `uvm_field_int(timing_cfg.tSdaUnstable,                   UVM_DEFAULT)
+    `uvm_field_int(timing_cfg.tSdaInterference,               UVM_DEFAULT)
+    `uvm_field_int(timing_cfg.tSclInterference,               UVM_DEFAULT)
   `uvm_object_utils_end
 
   `uvm_object_new

--- a/hw/dv/sv/i2c_agent/i2c_agent_pkg.sv
+++ b/hw/dv/sv/i2c_agent/i2c_agent_pkg.sv
@@ -14,8 +14,9 @@ package i2c_agent_pkg;
   `include "uvm_macros.svh"
   `include "dv_macros.svh"
 
+  // TODO: optimize later
   typedef enum logic [3:0] {
-    None, DevAck, RdData
+    None, DevAck, RdData, WrData
   } drv_type_e;
 
   // register values
@@ -34,6 +35,16 @@ package i2c_agent_pkg;
     bit          enbTimeOut;
     bit  [30:0]  tTimeOut;
     uint         tStretchHostClock;
+
+    // sda_unstable interrupt will be asserted if
+    // tSdaUnstable is set to a non-zero value, otherwise
+    uint         tSdaUnstable;
+    // scl_interference interrupt will be asserted if
+    // tSclInterference is set to a zero value, otherwise
+    uint         tSclInterference;
+    // sda_interference interrupt will be asserted if
+    // tSdaInterference is set to a zero value, otherwise
+    uint         tSdaInterference;
   } timing_cfg_t;
 
   typedef enum int {

--- a/hw/dv/sv/i2c_agent/i2c_device_driver.sv
+++ b/hw/dv/sv/i2c_agent/i2c_device_driver.sv
@@ -8,10 +8,20 @@ class i2c_device_driver extends i2c_driver;
 
   rand bit [7:0] rd_data[256]; // max length of read transaction
 
+  bit [7:0] wr_data;
+  bit [7:0] address;
+
   // get an array with unique read data
   constraint rd_data_c {
     unique { rd_data };
   }
+
+  virtual task process_reset();
+    @(negedge cfg.vif.rst_ni);
+    cfg.vif.scl_o = 1'b1;
+    cfg.vif.sda_o = 1'b1;
+    `uvm_info(`gfn, "\ndevice driver is reset", UVM_DEBUG)
+  endtask : process_reset
 
   virtual task get_and_drive();
     bit [7:0] rd_data_cnt = 8'd0;
@@ -23,34 +33,48 @@ class i2c_device_driver extends i2c_driver;
       cfg.vif.sda_o = 1'b1;
       // device driver responses to dut
       seq_item_port.get_next_item(rsp_item);
-      unique case (rsp_item.drv_type)
-        DevAck: begin
-          cfg.timing_cfg.tStretchHostClock = gen_num_stretch_host_clks(cfg.timing_cfg);
-          fork
-            // host clock stretching allows a high-speed host to communicate
-            // with a low-speed device by setting TIMEOUT_CTRL.EN bit
-            // the device ask host clock stretching its clock scl_i by pulling down scl_o
-            // the host clock pulse is extended until device scl_o is pulled up
-            // once scl_o is pulled down longer than TIMEOUT_CTRL.VAL field,
-            // intr_stretch_timeout_o is asserted (ref. https://www.i2c-bus.org/clock-stretching)
-            cfg.vif.device_stretch_host_clk(cfg.timing_cfg);
-            cfg.vif.device_send_ack(cfg.timing_cfg);
-          join
-        end
-        RdData: begin
-          if (rd_data_cnt == 8'd0) `DV_CHECK_MEMBER_RANDOMIZE_FATAL(rd_data)
-          for (int i = 7; i >= 0; i--) begin
-            cfg.vif.device_send_bit(cfg.timing_cfg, rd_data[rd_data_cnt][i]);
+      fork
+        unique case (rsp_item.drv_type)
+          DevAck: begin
+            cfg.timing_cfg.tStretchHostClock = gen_num_stretch_host_clks(cfg.timing_cfg);
+            fork
+              // host clock stretching allows a high-speed host to communicate
+              // with a low-speed device by setting TIMEOUT_CTRL.EN bit
+              // the device asks host stretching its scl_i by pulling down scl_o
+              // the host clock pulse is extended until device scl_o is pulled up
+              // once scl_o is pulled down longer than TIMEOUT_CTRL.VAL field,
+              // intr_stretch_timeout_o is asserted (ref. https://www.i2c-bus.org/clock-stretching)
+              cfg.vif.device_stretch_host_clk(cfg.timing_cfg);
+              cfg.vif.device_send_ack(cfg.timing_cfg);
+            join
           end
-          // rd_data_cnt is rollled back (no overflow) after reading 256 bytes
-          rd_data_cnt++;
-          `uvm_info(`gfn, $sformatf("driver, trans %0d, byte %0d  %0x",
-              rsp_item.tran_id, rsp_item.num_data+1, rd_data[rd_data_cnt]), UVM_DEBUG)
+          RdData: begin
+            if (rd_data_cnt == 8'd0) `DV_CHECK_MEMBER_RANDOMIZE_FATAL(rd_data)
+            for (int i = 7; i >= 0; i--) begin
+              cfg.vif.device_send_bit(cfg.timing_cfg, rd_data[rd_data_cnt][i]);
+            end
+            `uvm_info(`gfn, $sformatf("\ndriver, trans %0d, byte %0d  %0x",
+                rsp_item.tran_id, rsp_item.num_data+1, rd_data[rd_data_cnt]), UVM_DEBUG)
+            // rd_data_cnt is rollled back (no overflow) after reading 256 bytes
+            rd_data_cnt++;
+          end
+          WrData:
+            // TODO: consider adding memory (associative array) in device_driver
+            for (int i = 7; i >= 0; i--) begin
+              cfg.vif.get_bit_data("host", cfg.timing_cfg, wr_data[i]);
+            end
+          default: begin
+            `uvm_fatal(`gfn, $sformatf("\ndriver, received invalid request from monitor/seq"))
+          end
+        endcase
+
+        // handle on-the-fly reset
+        begin
+          process_reset();
+          rsp_item.clear_all();
         end
-        default: begin
-          `uvm_fatal(`gfn, $sformatf("driver, received invalid request from monitor/seq"))
-        end
-      endcase
+      join_any
+      disable fork;
       seq_item_port.item_done();
     end
   endtask : get_and_drive

--- a/hw/dv/sv/i2c_agent/i2c_driver.sv
+++ b/hw/dv/sv/i2c_agent/i2c_driver.sv
@@ -8,12 +8,14 @@ class i2c_driver extends dv_base_driver #(i2c_item, i2c_agent_cfg);
   `uvm_component_new
 
   virtual task reset_signals();
-    `uvm_info(`gfn, "\ndriver in reset progress", UVM_HIGH)
-    @(negedge cfg.vif.rst_ni);
-    cfg.vif.scl_o <= 1'b1;
-    cfg.vif.sda_o <= 1'b1;
-    @(posedge cfg.vif.rst_ni);
-    `uvm_info(`gfn, "\ndriver out of reset", UVM_HIGH)
+    forever begin
+      @(negedge cfg.vif.rst_ni);
+      `uvm_info(`gfn, "\ndriver in reset progress", UVM_DEBUG)
+      cfg.vif.scl_o <= 1'b1;
+      cfg.vif.sda_o <= 1'b1;
+      @(posedge cfg.vif.rst_ni);
+      `uvm_info(`gfn, "\ndriver out of reset", UVM_DEBUG)
+    end
   endtask : reset_signals
 
 endclass : i2c_driver

--- a/hw/dv/sv/i2c_agent/i2c_if.sv
+++ b/hw/dv/sv/i2c_agent/i2c_if.sv
@@ -137,19 +137,9 @@ interface i2c_if;
     wait_for_dly(tc.tHoldBit);
   endtask: wait_for_device_ack
 
-  task automatic device_send_ack(ref timing_cfg_t tc);
-    sda_o = 1'b1;
-    wait_for_dly(tc.tClockLow);
-    sda_o = 1'b0;
-    wait_for_dly(tc.tSetupBit);
-    @(posedge scl_i);
-    wait_for_dly(tc.tClockPulse + tc.tHoldBit);
-    if (tc.enbTimeOut) begin
-      wait_for_dly(tc.tStretchHostClock);
-    end
-    sda_o = 1'b1;
-  endtask: device_send_ack
-
+  // the `sda_unstable` interrupt is asserted if, when receiving data or ,
+  // ack pulse (device_send_ack) the value of the target sda signal does not
+  // remain constant over the duration of the scl pulse.
   task automatic device_send_bit(ref timing_cfg_t tc,
                                  input bit bit_i);
     sda_o = 1'b1;
@@ -157,27 +147,51 @@ interface i2c_if;
     sda_o = bit_i;
     wait_for_dly(tc.tSetupBit);
     @(posedge scl_i);
-    wait_for_dly(tc.tClockPulse + tc.tHoldBit);
+    // flip sda_target2host during the clock pulse of scl_host2target causes sda_unstable irq
+    sda_o = ~sda_o;
+    wait_for_dly(tc.tSdaUnstable);
+    sda_o = ~sda_o;
+    wait_for_dly(tc.tClockPulse + tc.tHoldBit - tc.tSdaUnstable);
+    // not release/change sda_o until host clock stretch passes
+    if (tc.enbTimeOut) wait(!scl_i);
     sda_o = 1'b1;
   endtask: device_send_bit
 
+  task automatic device_send_ack(ref timing_cfg_t tc);
+    device_send_bit(tc, 1'b0); // special case
+  endtask: device_send_ack
+
+  // when the I2C module is in transmit mode, `scl_interference` interrupt
+  // will be asserted if the IP identifies that some other device (host or target) on the bus
+  // is forcing scl low and interfering with the transmission.
   task automatic device_stretch_host_clk(ref timing_cfg_t tc);
     if (tc.enbTimeOut) begin
-      wait_for_dly(tc.tClockLow + tc.tSetupBit);
+      wait_for_dly(tc.tClockLow + tc.tSetupBit + tc.tSclInterference - 1);
       scl_o = 1'b0;
-      wait_for_dly(tc.tStretchHostClock);
+      wait_for_dly(tc.tStretchHostClock - tc.tSclInterference + 1);
       scl_o = 1'b1;
     end
   endtask : device_stretch_host_clk
 
+  // when the I2C module is in transmit mode, `sda_interference` interrupt
+  // will be asserted if the IP identifies that some other device (host or target) on the bus
+  // is forcing sda low and interfering with the transmission.
   task automatic get_bit_data(string src = "host",
                               ref timing_cfg_t tc,
                               output bit bit_o);
     wait_for_dly(tc.tClockLow + tc.tSetupBit);
     @(posedge scl_i);
-    bit_o = (src == "host") ? sda_i : sda_o;
-    wait_for_dly(tc.tClockPulse + tc.tHoldBit);
+    if (src == "host") begin // host transmits data (addr/wr_data)
+      bit_o = sda_i;
+      // force sda_target2host low during the clock pulse of scl_host2target
+      sda_o = 1'b0;
+      wait_for_dly(tc.tSdaInterference);
+      sda_o = 1'b1;
+      wait_for_dly(tc.tClockPulse + tc.tHoldBit - tc.tSdaInterference);
+    end else begin // target transmits data (rd_data)
+      bit_o = sda_o;
+      wait_for_dly(tc.tClockPulse + tc.tHoldBit);
+    end
   endtask: get_bit_data
-
 
 endinterface : i2c_if

--- a/hw/dv/sv/tl_agent/tl_host_driver.sv
+++ b/hw/dv/sv/tl_agent/tl_host_driver.sv
@@ -133,7 +133,7 @@ class tl_host_driver extends tl_base_driver;
           end
         end
 
-        if (!req_found) begin
+        if (!req_found && !reset_asserted) begin
           `uvm_error(get_full_name(), $sformatf(
                      "Cannot find request matching d_source 0x%0x", cfg.vif.host_cb.d2h.d_source))
         end

--- a/hw/ip/i2c/data/i2c_testplan.hjson
+++ b/hw/ip/i2c/data/i2c_testplan.hjson
@@ -28,19 +28,26 @@
       tests: ["i2c_sanity"]
     }
     {
-      name: error
+      name: error_intr
       desc: '''
-            Test if the host receives interference and unstable scl and sda.
+            Test error interrupts are asserted by the host due to interference and unstable signals on bus.
 
             Stimulus:
-              - Within the clock pulse of the host scl, the device randomly asserts/deasserts its scl and sda
-
+              - In host transmit mode, device (target/host) forces sda or scl signal low within the
+                clock pulse of host scl that asserts `sda_interference` or `scl_interference` interrupts
+              - In host receiving mode (data or ack bits), SDA signal is changed with the
+                clock pulse of host scl that asserts `intr_sda_unstable` interrupts
+              - When error interrupt assertions are detected, dut, agent, and scoreboard will be reset on-the-fly
+                then new transaction can be continue programming
             Checking:
-              - Ensure all intr_scl_interference, intr_sda_interference, and intr_sda_unstable interrupts are asserted
-              - Ensure all intr_scl_interference, intr_sda_interference, and intr_sda_unstable interrupts stay asserted until cleared
+              - Ensure all intr_scl_interference, intr_sda_interference, and
+                intr_sda_unstable interrupts are asserted
+              - Ensure all intr_scl_interference, intr_sda_interference, and
+                intr_sda_unstable interrupts stay asserted until cleared
+              - Ensure IP operation get back normal after on-the-fly reset finished
             '''
       milestone: V2
-      tests: ["i2c_error"]
+      tests: ["i2c_error_intr"]
     }
     {
       name: stress_all_with_reset
@@ -80,7 +87,8 @@
             Test multiple interrupts asserted.
 
             Stimulus:
-              - Do combinations of multiple of above scenarios to get multiple interrupts asserted at the same time
+              - Do combinations of multiple of above scenarios to get
+                multiple interrupts asserted at the same time
               - Scoreboard should be robust enough to deal with all scenarios
 
             Checking:

--- a/hw/ip/i2c/dv/env/i2c_env.core
+++ b/hw/ip/i2c/dv/env/i2c_env.core
@@ -30,6 +30,7 @@ filesets:
       - seq_lib/i2c_fifo_full_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_perf_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_stretch_timeout_vseq.sv: {is_include_file: true}
+      - seq_lib/i2c_error_intr_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/i2c/dv/env/i2c_env_cfg.sv
+++ b/hw/ip/i2c/dv/env/i2c_env_cfg.sv
@@ -4,16 +4,30 @@
 
 class i2c_env_cfg extends cip_base_env_cfg #(.RAL_T(i2c_reg_block));
 
+  // i2c address mode (only support 7-bit address for targets)
   i2c_target_addr_mode_e target_addr_mode = Addr7BitMode;
+
+  // drained time of phase_ready_to_end
   uint ok_to_end_delay_ns = 5000;
+
+  // set start_dev_seq at the first time m_dev_seq is started
+  bit start_dev_seq       = 1'b0;
 
   // bits to control fifos access
   // set en_fmt_overflow to ensure fmt_overflow irq is triggered
-  bit en_fmt_overflow = 1'b0;
+  bit en_fmt_overflow     = 1'b0;
   // set en_rx_overflow to ensure ensure rx_overflow irq is triggered
-  bit en_rx_overflow = 1'b0;
+  bit en_rx_overflow      = 1'b0;
   // set en_rx_watermark to ensure rx_watermark irq is triggered
-  bit en_rx_watermark = 1'b0;
+  bit en_rx_watermark     = 1'b0;
+
+  // bits to control interference and unstable interrupts
+  // set en_sda_unstable to allow sda_unstable irq is triggered
+  bit en_sda_unstable     = 1'b0;
+  // set en_scl_interference to allow scl_interference irq is triggered
+  bit en_scl_interference = 1'b0;
+  // set en_sda_interference to allow sda_interference irq is triggered
+  bit en_sda_interference = 1'b0;
 
   // i2c_agent cfg
   rand i2c_agent_cfg m_i2c_agent_cfg;

--- a/hw/ip/i2c/dv/env/i2c_seq_cfg.sv
+++ b/hw/ip/i2c/dv/env/i2c_seq_cfg.sv
@@ -10,23 +10,31 @@ class i2c_seq_cfg extends uvm_object;
 
   // TODO: This should move to `dv_base_seq_cfg`.
   // maximun number of times the vseq is randomized and rerun.
-  uint min_num_trans     = 30;
-  uint max_num_trans     = 50;
+  uint i2c_min_num_trans         = 10;
+  uint i2c_max_num_trans         = 20;
 
   // parameters configured at test level for *_vseq
-  uint i2c_min_addr      = 0;
-  uint i2c_max_addr      = 127;
-  uint i2c_min_data      = 0;
-  uint i2c_max_data      = 255;
-  uint i2c_min_dly       = 0;
-  uint i2c_max_dly       = 5;
-  uint i2c_min_timing    = 1; // at least 1
-  uint i2c_max_timing    = 5;
-  uint i2c_time_range    = i2c_max_timing - i2c_min_timing;
-  uint i2c_min_timeout   = 1;
-  uint i2c_max_timeout   = 4;
-  uint i2c_max_rxilvl    = 7;
-  uint i2c_max_fmtilvl   = 3;
+  uint i2c_min_addr              = 0;
+  uint i2c_max_addr              = 127;
+  uint i2c_min_data              = 0;
+  uint i2c_max_data              = 255;
+  uint i2c_min_dly               = 0;
+  uint i2c_max_dly               = 5;
+  uint i2c_min_timing            = 1; // at least 1
+  uint i2c_max_timing            = 5;
+  uint i2c_time_range            = i2c_max_timing - i2c_min_timing;
+  uint i2c_min_timeout           = 1;
+  uint i2c_max_timeout           = 4;
+  uint i2c_max_rxilvl            = 7;
+  uint i2c_max_fmtilvl           = 3;
+
+  // assertion probability of sda_interference, scl_interference, and
+  // sda_unstable interrupts (in percentage)
+  uint i2c_prob_sda_unstable     = 10;
+  uint i2c_prob_sda_interference = 10;
+  uint i2c_prob_scl_interference = 50;
+  uint i2c_min_num_resets        = 30;
+  uint i2c_max_num_resets        = 50;
 
   `uvm_object_new
 

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_error_intr_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_error_intr_vseq.sv
@@ -1,0 +1,76 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// basic error_intr test vseq
+// - start sending transaction and concurrently check the occurance of error irqs
+//   such as sda_interference, scl_interference, sda_unstable irqs
+// - do on-the-fly reset dut and dv if error irqs are asserted
+// - continue sending transactions and verify dut works as normal
+class i2c_error_intr_vseq extends i2c_sanity_vseq;
+  `uvm_object_utils(i2c_error_intr_vseq)
+  `uvm_object_new
+
+  bit do_reset = 1'b0;
+
+  // increase num_trans to cover error interrupts
+  constraint num_trans_c { num_trans inside {[50 : 100]}; }
+
+  virtual task body();
+    // allow agent/target creating interference and unstable signals so
+    // sda_interference, scl_interference, sda_unstable are asserted
+    cfg.en_sda_unstable     = 1'b1;
+    cfg.en_sda_interference = 1'b1;
+    cfg.en_scl_interference = 1'b1;
+
+    device_init();
+    host_init();
+    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(num_resets)
+    for (int run = 0; run < num_resets; run++) begin
+      `uvm_info(`gfn, $sformatf("\n****** RUN %0d ******", run), UVM_DEBUG)
+      `DV_CHECK_MEMBER_RANDOMIZE_FATAL(num_trans)
+      fork
+        begin
+          // issue trans. and check the occourances of error irqs
+          fork
+            begin
+              process_error_interrupts();
+              apply_reset("HARD");
+              `uvm_info(`gfn, $sformatf("\n>>>Reset ended"), UVM_DEBUG)
+            end
+            host_send_trans(num_trans);
+          join_any
+          // stop all tl_seqs
+          p_sequencer.tl_sequencer_h.stop_sequences();
+          disable fork;
+          // delay to avoid race condition when sending item and
+          // checking no item after reset occur at the same time
+          #1ps;
+          // handle on-the-fly reset
+          if (do_reset) begin
+            host_init();
+            do_reset = 1'b0;
+          end
+        end
+      join
+    end
+  endtask : body
+
+  virtual task process_error_interrupts();
+
+    forever begin
+      @(posedge cfg.clk_rst_vif.clk) begin
+        if (cfg.intr_vif.pins[SclInference] ||
+            cfg.intr_vif.pins[SdaInference] ||
+            cfg.intr_vif.pins[SdaUnstable]) begin
+          `uvm_info(`gfn, $sformatf("\n>>>Get error interrupts SclIrf %b, SdaIrf %b, SdaUns %b",
+              cfg.intr_vif.pins[SclInference], cfg.intr_vif.pins[SdaInference],
+              cfg.intr_vif.pins[SdaUnstable]), UVM_DEBUG)
+          do_reset = 1'b1;
+          break;
+        end
+      end
+    end
+  endtask : process_error_interrupts
+
+endclass : i2c_error_intr_vseq

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_fifo_overflow_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_fifo_overflow_vseq.sv
@@ -80,20 +80,24 @@ class i2c_fifo_overflow_vseq extends i2c_fifo_watermark_vseq;
   task process_fmt_overflow_intr();
     bit fmt_overflow;
 
-    @(posedge cfg.clk_rst_vif.clk);
-    if (cfg.intr_vif.pins[FmtOverflow]) begin
+    csr_rd(.ptr(ral.intr_state.fmt_overflow), .value(fmt_overflow), .backdoor(1'b1));
+    if (fmt_overflow) begin
       clear_interrupt(FmtOverflow);
       cnt_fmt_overflow++;
+    end else begin
+      cfg.clk_rst_vif.wait_clks(1);
     end
   endtask : process_fmt_overflow_intr
 
   task process_rx_overflow_intr();
     bit rx_overflow;
 
-    @(posedge cfg.clk_rst_vif.clk);
-    if (cfg.intr_vif.pins[RxOverflow]) begin
+    csr_rd(.ptr(ral.intr_state.rx_overflow), .value(rx_overflow), .backdoor(1'b1));
+    if (rx_overflow) begin
       clear_interrupt(RxOverflow);
       cnt_rx_overflow++;
+    end else begin
+      cfg.clk_rst_vif.wait_clks(1);
     end
   endtask : process_rx_overflow_intr
 

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_rx_tx_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_rx_tx_vseq.sv
@@ -15,11 +15,15 @@ class i2c_rx_tx_vseq extends i2c_base_vseq;
 
     fmt_item = new("fmt_item");
     total_rd_bytes = 0;
-
     fork
       begin
         complete_program_fmt_fifo = 1'b0;
         for (uint cur_tran = 1; cur_tran <= num_trans; cur_tran++) begin
+          // randomize knobs for error interrupts
+          `DV_CHECK_MEMBER_RANDOMIZE_FATAL(prob_sda_unstable)
+          `DV_CHECK_MEMBER_RANDOMIZE_FATAL(prob_sda_interference)
+          `DV_CHECK_MEMBER_RANDOMIZE_FATAL(prob_scl_interference)
+
           // re-programming timing registers for the first transaction
           // or when the previous transaction is completed
           if (fmt_item.stop || cur_tran == 1) begin

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
@@ -13,4 +13,5 @@
 `include "i2c_fifo_full_vseq.sv"
 `include "i2c_perf_vseq.sv"
 `include "i2c_stretch_timeout_vseq.sv"
+`include "i2c_error_intr_vseq.sv"
 

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -80,6 +80,12 @@
       name: i2c_stretch_timeout
       uvm_test_seq: i2c_stretch_timeout_vseq
     }
+
+    {
+      name: i2c_error_intr
+      reseed: 10
+      uvm_test_seq: i2c_error_intr_vseq
+    }
   ]
 
   // List of regressions.


### PR DESCRIPTION
This PR includes
    - Update i2c_agent to assert error interrupts (e.g. sda_interference, scl_inteference, and sda_unstable)
    - Install on-the-fly reset for i2c_agent and scoreboard to allow dut and dv are reset then re-started when the error interrupts are triggered
    - Add error_intr test
    - Disable checking request match in tl_host_driveri (tl_agent) when reset is in progress
    - Fix i2c_fifo_overflow test to address PR #3422 
