### PR TITLE
[pattgen, dv] Add initial pattgen_testplan.md for pattgen ip

### DIFF
--- a/hw/ip/pattgen/data/pattgen_testplan.hjson
+++ b/hw/ip/pattgen/data/pattgen_testplan.hjson
@@ -1,0 +1,84 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  name: "pattgen"
+  import_testplans: ["hw/dv/tools/testplans/csr_testplan.hjson",
+                     "hw/dv/tools/testplans/intr_test_testplan.hjson",
+                     "hw/dv/tools/testplans/stress_all_with_reset_testplan.hjson",
+                     "hw/dv/tools/testplans/tl_device_access_types_testplan.hjson"],
+  entries: [
+    {
+      name: sanity
+      desc: '''
+            Basic sanity test for pattgen ip in which dut is randomly programmed 
+            to generate random patterns on output channels.
+
+            Stimulus:
+              - Program the configuration registers of the output channels
+              - Randomly activate the output channels
+              - Re-program the configuration registers of the output channels once 
+                completion interrupts are asserted
+
+            Checking:
+              - Check divided clock rate for the active channels
+                matching with the values of pre-divider registers
+              - Check generated pattern matching on the active channels
+                matching with the values of pattern data registers
+              - Check completion interrupts are asserted once a pattern
+                is completely generated on the active channels
+            '''
+      milestone: V1
+      tests: ["pattgen_sanity"]
+    }
+    {
+      name: intr_perf
+      desc: '''
+            Checking ip operation at min/max bandwidth
+
+            Stimulus:
+              - Program the pre-divider registers to highest/lowest values (lowest/highest data rate)
+              - Program the pattern data registers, the pattern length per output, and 
+                repeat counter registers to smallest values
+              - Clear interrupts quickly
+
+            Checking:
+              - Ensure patterns are correctly generated
+              - Ensure interrupts are robust asserted and cleared (e.g. at the highest data rate)
+            '''
+      milestone: V2
+      tests: ["pattgen_perf"]
+    }   
+    {
+      name: error
+      desc: '''
+            Reset then re-start the output channel on the fly.
+
+            Stimulus:
+              - Programm the configuration registers of the output channels
+              - Randomly reset the output channel in progress
+              - Re-program the configuration registers of the output channels
+
+            Checking:
+              - Ensure patterns are dropped when reset
+              - Ensure the output channels get back normal after reset
+            '''
+      milestone: V2
+      tests: ["pattgen_error"]
+    }
+    {
+      name: stress_all
+      desc: '''
+            Combine above sequences in one test to run sequentially,
+
+            Stimulus:
+              - Start sequences and randomly add reset between each sequence
+
+            Checking:
+              - All sequences should be finished and checked by the scoreboard
+      '''
+      milestone: V2
+      tests: ["pattgen_stress_all"]
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds an initial pattgen_testplan.md file for pattgen IP which is built upon on the latest specification PR #3235 

Signed-off-by: Tung Hoang <hoang.tung@wdc.com>