### PR TITLE
[sw, tests] Create directory for Mask ROM unit/sanity tests

### DIFF
--- a/sw/device/tests/mask_rom/meson.build
+++ b/sw/device/tests/mask_rom/meson.build
@@ -1,0 +1,4 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -11,6 +11,7 @@ sw_tests = {
 }
 
 subdir('dif')
+subdir('mask_rom')
 subdir('sim_dv')
 
 aes_test_lib = declare_dependency(


### PR DESCRIPTION
This change simply creates a directory with an empty `meson.build`
file. Mask ROM unittests should reside in this directory.