### PR TITLE
[dif] Refactor dif_gpio.h to use new-style names

### DIFF
--- a/sw/device/boot_rom/bootstrap.c
+++ b/sw/device/boot_rom/bootstrap.c
@@ -38,12 +38,12 @@ static bool bootstrap_requested(void) {
 
   // Initialize GPIO device.
   dif_gpio_t gpio;
-  dif_gpio_config_t gpio_config = {
+  dif_gpio_params_t gpio_params = {
       .base_addr = mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR)};
-  CHECK(dif_gpio_init(&gpio_config, &gpio) == kDifGpioOk);
+  CHECK(dif_gpio_init(gpio_params, &gpio) == kDifGpioOk);
 
-  uint32_t gpio_in;
-  CHECK(dif_gpio_all_read(&gpio, &gpio_in) == kDifGpioOk);
+  dif_gpio_state_t gpio_in;
+  CHECK(dif_gpio_read_all(&gpio, &gpio_in) == kDifGpioOk);
   return (gpio_in & GPIO_BOOTSTRAP_BIT_MASK) != 0;
 }
 

--- a/sw/device/examples/demos.c
+++ b/sw/device/examples/demos.c
@@ -18,12 +18,12 @@ void demo_gpio_startup(dif_gpio_t *gpio) {
   LOG_INFO("Watch the LEDs!");
 
   // Give a LED pattern as startup indicator for 5 seconds.
-  CHECK(dif_gpio_all_write(gpio, 0xff00) == kDifGpioOk);
+  CHECK(dif_gpio_write_all(gpio, 0xff00) == kDifGpioOk);
   for (int i = 0; i < 32; ++i) {
     usleep(5 * 1000);  // 5 ms
-    CHECK(dif_gpio_pin_write(gpio, 8 + (i % 8), (i / 8) % 2) == kDifGpioOk);
+    CHECK(dif_gpio_write(gpio, 8 + (i % 8), (i / 8) % 2) == kDifGpioOk);
   }
-  CHECK(dif_gpio_all_write(gpio, 0x0000) == kDifGpioOk);  // All LEDs off.
+  CHECK(dif_gpio_write_all(gpio, 0x0000) == kDifGpioOk);  // All LEDs off.
 }
 
 /**
@@ -39,7 +39,7 @@ static const uint32_t kFtdiMask = 0x10000;
 
 uint32_t demo_gpio_to_log_echo(dif_gpio_t *gpio, uint32_t prev_gpio_state) {
   uint32_t gpio_state;
-  CHECK(dif_gpio_all_read(gpio, &gpio_state) == kDifGpioOk);
+  CHECK(dif_gpio_read_all(gpio, &gpio_state) == kDifGpioOk);
   gpio_state &= kGpioMask;
 
   uint32_t state_delta = prev_gpio_state ^ gpio_state;
@@ -79,6 +79,6 @@ void demo_uart_to_uart_and_gpio_echo(dif_gpio_t *gpio) {
   char rcv_char;
   while (uart_rcv_char(&rcv_char) != -1) {
     uart_send_char(rcv_char);
-    CHECK(dif_gpio_all_write(gpio, rcv_char << 8) == kDifGpioOk);
+    CHECK(dif_gpio_write_all(gpio, rcv_char << 8) == kDifGpioOk);
   }
 }

--- a/sw/device/examples/hello_usbdev/hello_usbdev.c
+++ b/sw/device/examples/hello_usbdev/hello_usbdev.c
@@ -98,12 +98,12 @@ int main(int argc, char **argv) {
   CHECK(dif_spi_device_init(spi_reg, &spi_config, &spi) ==
         kDifSpiDeviceResultOk);
 
-  dif_gpio_config_t gpio_config = {
+  dif_gpio_params_t gpio_params = {
       .base_addr = mmio_region_from_addr(0x40010000),
   };
-  CHECK(dif_gpio_init(&gpio_config, &gpio) == kDifGpioOk);
+  CHECK(dif_gpio_init(gpio_params, &gpio) == kDifGpioOk);
   // Enable GPIO: 0-7 and 16 is input; 8-15 is output.
-  CHECK(dif_gpio_output_mode_all_set(&gpio, 0x0ff00) == kDifGpioOk);
+  CHECK(dif_gpio_output_set_enabled_all(&gpio, 0x0ff00) == kDifGpioOk);
 
   LOG_INFO("Hello, USB!");
   LOG_INFO("Built at: " __DATE__ ", " __TIME__);
@@ -133,7 +133,7 @@ int main(int argc, char **argv) {
     char rcv_char;
     while (uart_rcv_char(&rcv_char) != -1) {
       uart_send_char(rcv_char);
-      CHECK(dif_gpio_all_write(&gpio, rcv_char << 8) == kDifGpioOk);
+      CHECK(dif_gpio_write_all(&gpio, rcv_char << 8) == kDifGpioOk);
 
       if (rcv_char == '/') {
         uint32_t usb_irq_state = REG32(USBDEV_INTR_STATE());

--- a/sw/device/examples/hello_world/hello_world.c
+++ b/sw/device/examples/hello_world/hello_world.c
@@ -35,12 +35,13 @@ int main(int argc, char **argv) {
   CHECK(dif_spi_device_init(spi_reg, &spi_config, &spi) ==
         kDifSpiDeviceResultOk);
 
-  dif_gpio_config_t gpio_config = {
+  dif_gpio_params_t gpio_params = {
       .base_addr = mmio_region_from_addr(0x40010000),
   };
-  CHECK(dif_gpio_init(&gpio_config, &gpio) == kDifGpioOk);
+  CHECK(dif_gpio_init(gpio_params, &gpio) == kDifGpioOk);
   // Enable GPIO: 0-7 and 16 is input; 8-15 is output.
-  CHECK(dif_gpio_output_mode_all_set(&gpio, 0x0ff00) == kDifGpioOk);
+  CHECK(dif_gpio_output_set_enabled_all(&gpio, 0x0ff00) == kDifGpioOk);
+
   // Add DATE and TIME because I keep fooling myself with old versions
   LOG_INFO("Hello World!");
   LOG_INFO("Built at: " __DATE__ ", " __TIME__);
@@ -49,7 +50,7 @@ int main(int argc, char **argv) {
 
   // Now have UART <-> Buttons/LEDs demo
   // all LEDs off
-  CHECK(dif_gpio_all_write(&gpio, 0x0000) == kDifGpioOk);
+  CHECK(dif_gpio_write_all(&gpio, 0x0000) == kDifGpioOk);
   LOG_INFO("Try out the switches on the board");
   LOG_INFO("or type anything into the console window.");
   LOG_INFO("The LEDs show the ASCII code of the last character.");

--- a/sw/device/sca/aes_serial/aes_serial.c
+++ b/sw/device/sca/aes_serial/aes_serial.c
@@ -210,12 +210,12 @@ static simple_serial_result_t simple_serial_trigger_encryption(
                &timer, kHart, kDifRvTimerEnabled) == kDifRvTimerOk);
 
   aes_data_put_wait(plain_text);
-  SS_CHECK(dif_gpio_all_write(&gpio, kGpioCaptureTriggerHigh) == kDifGpioOk);
+  SS_CHECK(dif_gpio_write_all(&gpio, kGpioCaptureTriggerHigh) == kDifGpioOk);
 
   aes_manual_trigger();
   wait_for_interrupt();
 
-  SS_CHECK(dif_gpio_all_write(&gpio, kGpioCaptureTriggerLow) == kDifGpioOk);
+  SS_CHECK(dif_gpio_write_all(&gpio, kGpioCaptureTriggerLow) == kDifGpioOk);
   aes_data_get_wait(cipher_text);
 
   print_cmd_response('r', cipher_text, plain_text_len);
@@ -288,11 +288,11 @@ int main(int argc, char **argv) {
   CHECK(dif_rv_timer_irq_enable(&timer, kHart, kComparator,
                                 kDifRvTimerEnabled) == kDifRvTimerOk);
 
-  dif_gpio_config_t gpio_config = {.base_addr =
+  dif_gpio_params_t gpio_params = {.base_addr =
                                        mmio_region_from_addr(0x40010000)};
-  CHECK(dif_gpio_init(&gpio_config, &gpio) == kDifGpioOk);
-  CHECK(dif_gpio_output_mode_all_set(&gpio, 0x08200) == kDifGpioOk);
-  CHECK(dif_gpio_all_write(&gpio, kGpioCaptureTriggerLow) == kDifGpioOk);
+  CHECK(dif_gpio_init(gpio_params, &gpio) == kDifGpioOk);
+  CHECK(dif_gpio_output_set_enabled_all(&gpio, 0x08200) == kDifGpioOk);
+  CHECK(dif_gpio_write_all(&gpio, kGpioCaptureTriggerLow) == kDifGpioOk);
 
   aes_cfg_t aes_cfg;
   aes_cfg.key_len = kAes128;


### PR DESCRIPTION
Note that the tests have incomplete coverage right now, since I had to add some new IRQ functions not in the original header. I apologize for the enormous diff in the header and C implementation, but I had to rewrite a lot of it from scratch.

@alphan there's a couple of places in the new header where I need your feedback marked by TODOs. Could you comment on those?

(This change also renames functions whose names are not specified by the naming guide, but makes them consistent with the required names.)