### PR TITLE
[flash_ctrl] Add ECC to program / erase datapaths

### DIFF
--- a/hw/ip/flash_ctrl/flash_ctrl.core
+++ b/hw/ip/flash_ctrl/flash_ctrl.core
@@ -10,6 +10,7 @@ filesets:
     depend:
       - lowrisc:ip:tlul
       - lowrisc:prim:all
+      - lowrisc:prim:secded
       - lowrisc:prim:flash
       - lowrisc:prim:gf_mult
       - lowrisc:ip:flash_ctrl_pkg

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -101,11 +101,12 @@ module flash_ctrl import flash_ctrl_pkg::*; (
   logic [BusAddrW-1:0] flash_addr;
   logic flash_req;
   logic flash_rd_done, flash_prog_done, flash_erase_done;
-  logic flash_error;
+  logic flash_mp_error;
   logic [BusWidth-1:0] flash_prog_data;
   logic flash_prog_last;
   flash_prog_e flash_prog_type;
   logic [BusWidth-1:0] flash_rd_data;
+  logic flash_rd_err;
   logic flash_phy_busy;
   logic rd_op;
   logic prog_op;
@@ -358,7 +359,7 @@ module flash_ctrl import flash_ctrl_pkg::*; (
     .flash_last_o   (flash_prog_last),
     .flash_type_o   (flash_prog_type),
     .flash_done_i   (flash_prog_done),
-    .flash_error_i  (flash_error)
+    .flash_error_i  (flash_mp_error)
   );
 
   // Read FIFO
@@ -433,7 +434,7 @@ module flash_ctrl import flash_ctrl_pkg::*; (
     .flash_ovfl_o   (rd_flash_ovfl),
     .flash_data_i   (flash_rd_data),
     .flash_done_i   (flash_rd_done),
-    .flash_error_i  (flash_error)
+    .flash_error_i  (flash_mp_error | flash_rd_err)
   );
 
   // Erase handler does not consume fifo
@@ -450,7 +451,7 @@ module flash_ctrl import flash_ctrl_pkg::*; (
     .flash_addr_o   (erase_flash_addr),
     .flash_op_o     (erase_flash_type),
     .flash_done_i   (flash_erase_done),
-    .flash_error_i  (flash_error)
+    .flash_error_i  (flash_mp_error)
   );
 
   // Final muxing to flash macro module
@@ -551,7 +552,7 @@ module flash_ctrl import flash_ctrl_pkg::*; (
     .rd_done_o(flash_rd_done),
     .prog_done_o(flash_prog_done),
     .erase_done_o(flash_erase_done),
-    .error_o(flash_error),
+    .error_o(flash_mp_error),
     .err_addr_o(err_addr),
 
     // flash phy interface
@@ -608,6 +609,7 @@ module flash_ctrl import flash_ctrl_pkg::*; (
   assign flash_o.scramble_en = reg2hw.scramble_en.q;
   assign flash_o.addr_key = otp_i.addr_key;
   assign flash_o.data_key = otp_i.data_key;
+  assign flash_rd_err = flash_i.rd_err;
   assign flash_rd_data = flash_i.rd_data;
   assign flash_phy_busy = flash_i.init_busy;
 

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
@@ -239,6 +239,7 @@ package flash_ctrl_pkg;
     logic                rd_done;
     logic                prog_done;
     logic                erase_done;
+    logic                rd_err;
     logic [BusWidth-1:0] rd_data;
     logic                init_busy;
   } flash_rsp_t;
@@ -249,6 +250,7 @@ package flash_ctrl_pkg;
     rd_done:    1'b0,
     prog_done:  1'b0,
     erase_done: 1'b0,
+    rd_err:     '0,
     rd_data:    '0,
     init_busy:  1'b0
   };

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_rd.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_rd.sv
@@ -14,7 +14,7 @@ module flash_ctrl_rd import flash_ctrl_pkg::*; (
   input  [11:0]            op_num_words_i,
   output logic             op_done_o,
   output logic             op_err_o,
-  input [BusAddrW-1:0]        op_addr_i,
+  input [BusAddrW-1:0]     op_addr_i,
 
   // FIFO Interface
   input                    data_rdy_i,
@@ -25,7 +25,7 @@ module flash_ctrl_rd import flash_ctrl_pkg::*; (
   output logic             flash_req_o,
   output logic [BusAddrW-1:0] flash_addr_o,
   output logic             flash_ovfl_o,
-  input [BusWidth-1:0]        flash_data_i,
+  input [BusWidth-1:0]     flash_data_i,
   input                    flash_done_i,
   input                    flash_error_i
 );

--- a/hw/ip/flash_ctrl/rtl/flash_phy_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_pkg.sv
@@ -17,10 +17,14 @@ package flash_phy_pkg;
   parameter int WordW         = flash_ctrl_pkg::WordW;
   parameter int BankAddrW     = flash_ctrl_pkg::BankAddrW;
   parameter int DataWidth     = flash_ctrl_pkg::DataWidth;
+  parameter int EccWidth      = 8;
+  parameter int MetaDataWidth = top_pkg::FLASH_METADATA_WIDTH;
   parameter int WidthMultiple = flash_ctrl_pkg::WidthMultiple;
   parameter int NumBuf        = 4; // number of flash read buffers
   parameter int RspOrderDepth = 2; // this should be DataWidth / BusWidth
                                    // will switch to this after bus widening
+  parameter int ScrDataWidth  = DataWidth + EccWidth;
+  parameter int FullDataWidth = DataWidth + MetaDataWidth;
 
   // flash ctrl / bus parameters
   parameter int BusWidth       = flash_ctrl_pkg::BusWidth;

--- a/hw/ip/prim/rtl/prim_secded_72_64_dec.sv
+++ b/hw/ip/prim/rtl/prim_secded_72_64_dec.sv
@@ -16,36 +16,36 @@ module prim_secded_72_64_dec (
   // Syndrome calculation
   assign syndrome_o[0] = in[64] ^ in[0] ^ in[1] ^ in[2] ^ in[3] ^ in[4] ^ in[5] ^ in[6] ^ in[7]
                        ^ in[8] ^ in[9] ^ in[10] ^ in[11] ^ in[12] ^ in[13] ^ in[14] ^ in[15]
-                       ^ in[16] ^ in[17] ^ in[18] ^ in[19] ^ in[20] ^ in[57] ^ in[58] ^ in[61]
-                       ^ in[62] ^ in[63];
+                       ^ in[16] ^ in[17] ^ in[18] ^ in[19] ^ in[20] ^ in[57] ^ in[59] ^ in[60]
+                       ^ in[61] ^ in[62];
   assign syndrome_o[1] = in[65] ^ in[0] ^ in[1] ^ in[2] ^ in[3] ^ in[4] ^ in[5] ^ in[21] ^ in[22]
                        ^ in[23] ^ in[24] ^ in[25] ^ in[26] ^ in[27] ^ in[28] ^ in[29] ^ in[30]
-                       ^ in[31] ^ in[32] ^ in[33] ^ in[34] ^ in[35] ^ in[58] ^ in[59] ^ in[60]
+                       ^ in[31] ^ in[32] ^ in[33] ^ in[34] ^ in[35] ^ in[56] ^ in[57] ^ in[60]
                        ^ in[62] ^ in[63];
   assign syndrome_o[2] = in[66] ^ in[0] ^ in[6] ^ in[7] ^ in[8] ^ in[9] ^ in[10] ^ in[21] ^ in[22]
                        ^ in[23] ^ in[24] ^ in[25] ^ in[36] ^ in[37] ^ in[38] ^ in[39] ^ in[40]
-                       ^ in[41] ^ in[42] ^ in[43] ^ in[44] ^ in[45] ^ in[56] ^ in[57] ^ in[59]
-                       ^ in[60] ^ in[63];
+                       ^ in[41] ^ in[42] ^ in[43] ^ in[44] ^ in[45] ^ in[56] ^ in[57] ^ in[58]
+                       ^ in[61] ^ in[62];
   assign syndrome_o[3] = in[67] ^ in[1] ^ in[6] ^ in[11] ^ in[12] ^ in[13] ^ in[14] ^ in[21]
                        ^ in[26] ^ in[27] ^ in[28] ^ in[29] ^ in[36] ^ in[37] ^ in[38] ^ in[39]
-                       ^ in[46] ^ in[47] ^ in[48] ^ in[49] ^ in[50] ^ in[51] ^ in[56] ^ in[57]
-                       ^ in[58] ^ in[61] ^ in[63];
+                       ^ in[46] ^ in[47] ^ in[48] ^ in[49] ^ in[50] ^ in[51] ^ in[56] ^ in[58]
+                       ^ in[59] ^ in[62] ^ in[63];
   assign syndrome_o[4] = in[68] ^ in[2] ^ in[7] ^ in[11] ^ in[15] ^ in[16] ^ in[17] ^ in[22]
                        ^ in[26] ^ in[30] ^ in[31] ^ in[32] ^ in[36] ^ in[40] ^ in[41] ^ in[42]
-                       ^ in[46] ^ in[47] ^ in[48] ^ in[52] ^ in[53] ^ in[54] ^ in[56] ^ in[58]
-                       ^ in[59] ^ in[61] ^ in[62];
+                       ^ in[46] ^ in[47] ^ in[48] ^ in[52] ^ in[53] ^ in[54] ^ in[58] ^ in[59]
+                       ^ in[60] ^ in[61] ^ in[63];
   assign syndrome_o[5] = in[69] ^ in[3] ^ in[8] ^ in[12] ^ in[15] ^ in[18] ^ in[19] ^ in[23]
                        ^ in[27] ^ in[30] ^ in[33] ^ in[34] ^ in[37] ^ in[40] ^ in[43] ^ in[44]
                        ^ in[46] ^ in[49] ^ in[50] ^ in[52] ^ in[53] ^ in[55] ^ in[56] ^ in[57]
-                       ^ in[59] ^ in[60] ^ in[61];
+                       ^ in[58] ^ in[60] ^ in[63];
   assign syndrome_o[6] = in[70] ^ in[4] ^ in[9] ^ in[13] ^ in[16] ^ in[18] ^ in[20] ^ in[24]
                        ^ in[28] ^ in[31] ^ in[33] ^ in[35] ^ in[38] ^ in[41] ^ in[43] ^ in[45]
-                       ^ in[47] ^ in[49] ^ in[51] ^ in[52] ^ in[54] ^ in[55] ^ in[56] ^ in[59]
-                       ^ in[60] ^ in[61] ^ in[62];
+                       ^ in[47] ^ in[49] ^ in[51] ^ in[52] ^ in[54] ^ in[55] ^ in[56] ^ in[57]
+                       ^ in[59] ^ in[61] ^ in[63];
   assign syndrome_o[7] = in[71] ^ in[5] ^ in[10] ^ in[14] ^ in[17] ^ in[19] ^ in[20] ^ in[25]
                        ^ in[29] ^ in[32] ^ in[34] ^ in[35] ^ in[39] ^ in[42] ^ in[44] ^ in[45]
-                       ^ in[48] ^ in[50] ^ in[51] ^ in[53] ^ in[54] ^ in[55] ^ in[57] ^ in[58]
-                       ^ in[60] ^ in[62] ^ in[63];
+                       ^ in[48] ^ in[50] ^ in[51] ^ in[53] ^ in[54] ^ in[55] ^ in[58] ^ in[59]
+                       ^ in[60] ^ in[61] ^ in[62];
 
   // Corrected output calculation
   assign d_o[0] = (syndrome_o == 8'h7) ^ in[0];
@@ -104,14 +104,14 @@ module prim_secded_72_64_dec (
   assign d_o[53] = (syndrome_o == 8'hb0) ^ in[53];
   assign d_o[54] = (syndrome_o == 8'hd0) ^ in[54];
   assign d_o[55] = (syndrome_o == 8'he0) ^ in[55];
-  assign d_o[56] = (syndrome_o == 8'h7c) ^ in[56];
-  assign d_o[57] = (syndrome_o == 8'had) ^ in[57];
-  assign d_o[58] = (syndrome_o == 8'h9b) ^ in[58];
-  assign d_o[59] = (syndrome_o == 8'h76) ^ in[59];
-  assign d_o[60] = (syndrome_o == 8'he6) ^ in[60];
-  assign d_o[61] = (syndrome_o == 8'h79) ^ in[61];
-  assign d_o[62] = (syndrome_o == 8'hd3) ^ in[62];
-  assign d_o[63] = (syndrome_o == 8'h8f) ^ in[63];
+  assign d_o[56] = (syndrome_o == 8'h6e) ^ in[56];
+  assign d_o[57] = (syndrome_o == 8'h67) ^ in[57];
+  assign d_o[58] = (syndrome_o == 8'hbc) ^ in[58];
+  assign d_o[59] = (syndrome_o == 8'hd9) ^ in[59];
+  assign d_o[60] = (syndrome_o == 8'hb3) ^ in[60];
+  assign d_o[61] = (syndrome_o == 8'hd5) ^ in[61];
+  assign d_o[62] = (syndrome_o == 8'h8f) ^ in[62];
+  assign d_o[63] = (syndrome_o == 8'h7a) ^ in[63];
 
   // err_o calc. bit0: single error, bit1: double error
   assign single_error = ^syndrome_o;

--- a/hw/ip/prim/rtl/prim_secded_72_64_enc.sv
+++ b/hw/ip/prim/rtl/prim_secded_72_64_enc.sv
@@ -75,27 +75,27 @@ module prim_secded_72_64_enc (
   assign out[63] = in[63] ;
   assign out[64] = in[0] ^ in[1] ^ in[2] ^ in[3] ^ in[4] ^ in[5] ^ in[6] ^ in[7] ^ in[8] ^ in[9]
                  ^ in[10] ^ in[11] ^ in[12] ^ in[13] ^ in[14] ^ in[15] ^ in[16] ^ in[17] ^ in[18]
-                 ^ in[19] ^ in[20] ^ in[57] ^ in[58] ^ in[61] ^ in[62] ^ in[63];
+                 ^ in[19] ^ in[20] ^ in[57] ^ in[59] ^ in[60] ^ in[61] ^ in[62];
   assign out[65] = in[0] ^ in[1] ^ in[2] ^ in[3] ^ in[4] ^ in[5] ^ in[21] ^ in[22] ^ in[23] ^ in[24]
                  ^ in[25] ^ in[26] ^ in[27] ^ in[28] ^ in[29] ^ in[30] ^ in[31] ^ in[32] ^ in[33]
-                 ^ in[34] ^ in[35] ^ in[58] ^ in[59] ^ in[60] ^ in[62] ^ in[63];
+                 ^ in[34] ^ in[35] ^ in[56] ^ in[57] ^ in[60] ^ in[62] ^ in[63];
   assign out[66] = in[0] ^ in[6] ^ in[7] ^ in[8] ^ in[9] ^ in[10] ^ in[21] ^ in[22] ^ in[23]
                  ^ in[24] ^ in[25] ^ in[36] ^ in[37] ^ in[38] ^ in[39] ^ in[40] ^ in[41] ^ in[42]
-                 ^ in[43] ^ in[44] ^ in[45] ^ in[56] ^ in[57] ^ in[59] ^ in[60] ^ in[63];
+                 ^ in[43] ^ in[44] ^ in[45] ^ in[56] ^ in[57] ^ in[58] ^ in[61] ^ in[62];
   assign out[67] = in[1] ^ in[6] ^ in[11] ^ in[12] ^ in[13] ^ in[14] ^ in[21] ^ in[26] ^ in[27]
                  ^ in[28] ^ in[29] ^ in[36] ^ in[37] ^ in[38] ^ in[39] ^ in[46] ^ in[47] ^ in[48]
-                 ^ in[49] ^ in[50] ^ in[51] ^ in[56] ^ in[57] ^ in[58] ^ in[61] ^ in[63];
+                 ^ in[49] ^ in[50] ^ in[51] ^ in[56] ^ in[58] ^ in[59] ^ in[62] ^ in[63];
   assign out[68] = in[2] ^ in[7] ^ in[11] ^ in[15] ^ in[16] ^ in[17] ^ in[22] ^ in[26] ^ in[30]
                  ^ in[31] ^ in[32] ^ in[36] ^ in[40] ^ in[41] ^ in[42] ^ in[46] ^ in[47] ^ in[48]
-                 ^ in[52] ^ in[53] ^ in[54] ^ in[56] ^ in[58] ^ in[59] ^ in[61] ^ in[62];
+                 ^ in[52] ^ in[53] ^ in[54] ^ in[58] ^ in[59] ^ in[60] ^ in[61] ^ in[63];
   assign out[69] = in[3] ^ in[8] ^ in[12] ^ in[15] ^ in[18] ^ in[19] ^ in[23] ^ in[27] ^ in[30]
                  ^ in[33] ^ in[34] ^ in[37] ^ in[40] ^ in[43] ^ in[44] ^ in[46] ^ in[49] ^ in[50]
-                 ^ in[52] ^ in[53] ^ in[55] ^ in[56] ^ in[57] ^ in[59] ^ in[60] ^ in[61];
+                 ^ in[52] ^ in[53] ^ in[55] ^ in[56] ^ in[57] ^ in[58] ^ in[60] ^ in[63];
   assign out[70] = in[4] ^ in[9] ^ in[13] ^ in[16] ^ in[18] ^ in[20] ^ in[24] ^ in[28] ^ in[31]
                  ^ in[33] ^ in[35] ^ in[38] ^ in[41] ^ in[43] ^ in[45] ^ in[47] ^ in[49] ^ in[51]
-                 ^ in[52] ^ in[54] ^ in[55] ^ in[56] ^ in[59] ^ in[60] ^ in[61] ^ in[62];
+                 ^ in[52] ^ in[54] ^ in[55] ^ in[56] ^ in[57] ^ in[59] ^ in[61] ^ in[63];
   assign out[71] = in[5] ^ in[10] ^ in[14] ^ in[17] ^ in[19] ^ in[20] ^ in[25] ^ in[29] ^ in[32]
                  ^ in[34] ^ in[35] ^ in[39] ^ in[42] ^ in[44] ^ in[45] ^ in[48] ^ in[50] ^ in[51]
-                 ^ in[53] ^ in[54] ^ in[55] ^ in[57] ^ in[58] ^ in[60] ^ in[62] ^ in[63];
+                 ^ in[53] ^ in[54] ^ in[55] ^ in[58] ^ in[59] ^ in[60] ^ in[61] ^ in[62];
 endmodule
 

--- a/hw/ip/prim_generic/rtl/prim_generic_flash.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_flash.sv
@@ -10,6 +10,7 @@ module prim_generic_flash #(
   parameter int PagesPerBank = 256, // data pages per bank
   parameter int WordsPerPage = 256, // words per page
   parameter int DataWidth   = 32,   // bits per word
+  parameter int MetaDataWidth = 12, // this is a temporary parameter to work around ECC issues
   parameter bit SkipInit = 1,       // this is an option to reset flash to all F's at reset
 
   // Derived parameters
@@ -297,36 +298,70 @@ module prim_generic_flash #(
     endcase // unique case (st_q)
   end // always_comb
 
+  localparam int MemWidth = DataWidth - MetaDataWidth;
+
   logic [DataWidth-1:0] rd_data_main, rd_data_info;
+  logic [MemWidth-1:0] rd_nom_data_main, rd_nom_data_info;
+  logic [MetaDataWidth-1:0] rd_meta_data_main, rd_meta_data_info;
 
   prim_ram_1p #(
-    .Width(DataWidth),
+    .Width(MemWidth),
     .Depth(WordsPerBank),
-    .DataBitsPerMask(DataWidth)
+    .DataBitsPerMask(MemWidth)
   ) u_mem (
     .clk_i,
     .req_i    (mem_req & (mem_part == flash_ctrl_pkg::FlashPartData)),
     .write_i  (mem_wr),
     .addr_i   (mem_addr),
-    .wdata_i  (mem_wdata),
-    .wmask_i  ({DataWidth{1'b1}}),
-    .rdata_o  (rd_data_main)
+    .wdata_i  (mem_wdata[MemWidth-1:0]),
+    .wmask_i  ({MemWidth{1'b1}}),
+    .rdata_o  (rd_nom_data_main)
   );
 
   prim_ram_1p #(
-    .Width(DataWidth),
+    .Width(MetaDataWidth),
+    .Depth(WordsPerBank),
+    .DataBitsPerMask(MetaDataWidth)
+  ) u_mem_meta (
+    .clk_i,
+    .req_i    (mem_req & (mem_part == flash_ctrl_pkg::FlashPartData)),
+    .write_i  (mem_wr),
+    .addr_i   (mem_addr),
+    .wdata_i  (mem_wdata[MemWidth +: MetaDataWidth]),
+    .wmask_i  ({MetaDataWidth{1'b1}}),
+    .rdata_o  (rd_meta_data_main)
+  );
+
+  prim_ram_1p #(
+    .Width(MemWidth),
     .Depth(WordsPerInfoBank),
-    .DataBitsPerMask(DataWidth)
+    .DataBitsPerMask(MemWidth)
   ) u_info_mem (
     .clk_i,
     .req_i    (mem_req & (mem_part == flash_ctrl_pkg::FlashPartInfo)),
     .write_i  (mem_wr),
     .addr_i   (mem_addr[0 +: InfoAddrW]),
-    .wdata_i  (mem_wdata),
-    .wmask_i  ({DataWidth{1'b1}}),
-    .rdata_o  (rd_data_info)
+    .wdata_i  (mem_wdata[MemWidth-1:0]),
+    .wmask_i  ({MemWidth{1'b1}}),
+    .rdata_o  (rd_nom_data_info)
   );
 
+  prim_ram_1p #(
+    .Width(MetaDataWidth),
+    .Depth(WordsPerInfoBank),
+    .DataBitsPerMask(MetaDataWidth)
+  ) u_info_mem_meta (
+    .clk_i,
+    .req_i    (mem_req & (mem_part == flash_ctrl_pkg::FlashPartInfo)),
+    .write_i  (mem_wr),
+    .addr_i   (mem_addr[0 +: InfoAddrW]),
+    .wdata_i  (mem_wdata[MemWidth +: MetaDataWidth]),
+    .wmask_i  ({MetaDataWidth{1'b1}}),
+    .rdata_o  (rd_meta_data_info)
+  );
+
+  assign rd_data_main = {rd_meta_data_main, rd_nom_data_main};
+  assign rd_data_info = {rd_meta_data_info, rd_nom_data_info};
   assign rd_data_o = held_part == flash_ctrl_pkg::FlashPartData ? rd_data_main : rd_data_info;
 
   // hard-wire assignment for now

--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -406,6 +406,7 @@ module top_${top["name"]} #(
   logic flash_host_req;
   logic flash_host_req_rdy;
   logic flash_host_req_done;
+  logic flash_host_rderr;
   logic [flash_ctrl_pkg::BusWidth-1:0] flash_host_rdata;
   logic [flash_ctrl_pkg::BusAddrW-1:0] flash_host_addr;
 
@@ -434,7 +435,7 @@ module top_${top["name"]} #(
     .wmask_o  (),
     .rdata_i  (flash_host_rdata),
     .rvalid_i (flash_host_req_done),
-    .rerror_i (2'b00)
+    .rerror_i ({flash_host_rderr,1'b0})
   );
 
   flash_phy u_flash_${m["name"]} (
@@ -448,6 +449,7 @@ module top_${top["name"]} #(
     .host_addr_i     (flash_host_addr),
     .host_req_rdy_o  (flash_host_req_rdy),
     .host_req_done_o (flash_host_req_done),
+    .host_rderr_o    (flash_host_rderr),
     .host_rdata_o    (flash_host_rdata),
     .flash_ctrl_i    (${m["inter_signal_list"][0]["top_signame"]}_req),
     .flash_ctrl_o    (${m["inter_signal_list"][0]["top_signame"]}_rsp)

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -515,6 +515,7 @@ module top_earlgrey #(
   logic flash_host_req;
   logic flash_host_req_rdy;
   logic flash_host_req_done;
+  logic flash_host_rderr;
   logic [flash_ctrl_pkg::BusWidth-1:0] flash_host_rdata;
   logic [flash_ctrl_pkg::BusAddrW-1:0] flash_host_addr;
 
@@ -539,7 +540,7 @@ module top_earlgrey #(
     .wmask_o  (),
     .rdata_i  (flash_host_rdata),
     .rvalid_i (flash_host_req_done),
-    .rerror_i (2'b00)
+    .rerror_i ({flash_host_rderr,1'b0})
   );
 
   flash_phy u_flash_eflash (
@@ -549,6 +550,7 @@ module top_earlgrey #(
     .host_addr_i     (flash_host_addr),
     .host_req_rdy_o  (flash_host_req_rdy),
     .host_req_done_o (flash_host_req_done),
+    .host_rderr_o    (flash_host_rderr),
     .host_rdata_o    (flash_host_rdata),
     .flash_ctrl_i    (flash_ctrl_flash_req),
     .flash_ctrl_o    (flash_ctrl_flash_rsp)

--- a/hw/top_earlgrey/rtl/top_pkg.sv
+++ b/hw/top_earlgrey/rtl/top_pkg.sv
@@ -17,6 +17,7 @@ localparam int FLASH_PAGES_PER_BANK=256;
 localparam int FLASH_WORDS_PER_PAGE=128;
 localparam int FLASH_INFO_PER_BANK=4;
 localparam int FLASH_DATA_WIDTH=64;
+localparam int FLASH_METADATA_WIDTH=12;
 localparam int NUM_AST_ALERTS=7;
 localparam int NUM_IO_RAILS=2;
 localparam int ENTROPY_STREAM=4;


### PR DESCRIPTION
- New parameters are defined to represent the "metadata" of flas
  - Software only has direct access to data portion
  - Metadata area is used for empty detection as well as ECC
  - There are currently no plans to make metadata directly accessible to
    software, although that can be done.
- ECC and scramble are always disabled / enabled at the same time.
- ECC is calculated on the scrambled data.
- There is no good DV / verilator support yet, To get around the issue,
  prim_generic_flash instantiates a memory for main, and another for metadata.
  - long term there will need to be a better backdoor solution to flash.
- ECC uncorrectable errors are forwarded up to both the host / controller
- When an uncorrectable error occurs, all F's are returned to the reading agent.
