### PR TITLE
[mask_rom] First draft of System State

### DIFF
--- a/sw/device/mask_rom/meson.build
+++ b/sw/device/mask_rom/meson.build
@@ -2,6 +2,12 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+mask_rom_sys_state = declare_dependency(
+  link_with: static_library(
+    'sys_state',
+    sources: ['sys_state.c'],
+  )
+)
 # Mask ROM Linker Parameters
 #
 # See sw/device/exts/common/flash_link.ld for additional info about these

--- a/sw/device/mask_rom/sys_state.c
+++ b/sw/device/mask_rom/sys_state.c
@@ -1,0 +1,213 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/mask_rom/sys_state.h"
+
+#include <stddef.h>
+
+#include "sw/device/lib/base/memory.h"
+
+enum { kUninitBits = 0xaaaaaaaa };
+
+// Open Q: I think we want this to *not* be static, so that tests can reach
+// into this symbol and emulate glitching.
+//
+// For now, I'm giving it a trailing underscore and a "uniqueish" name, to match
+// how we might write a private member of a class in C++, since that's kind of
+// what this is.
+static rom_ext_manifest_tag_t sys_state_rom_ext_desc_;
+// Open Q: It feels like the easiest way to safely track is_initialized is to
+// fill it with some weird bit pattern and zero it once it's been initialized.
+// The "is initialized" state is then "is this in any value but the weird
+// bit-pattern one"?
+//
+// That way, an attacker can easily glitch into the "is initialized" state, but
+// that's fine, because that triggers a check against freshly-read data, and
+// they shouldn't be able to mess with that.
+static uint32_t sys_state_rom_ext_desc_is_init_ = kUninitBits;
+
+sys_state_result_t sys_state_rom_ext_security_descriptor(
+    const rom_ext_manifest_tag_t **ptr) {
+  rom_ext_manifest_tag_t measure;
+  // TODO: Fill `measure` with data.
+
+  rom_ext_manifest_tag_t *storage = &sys_state_rom_ext_desc_;
+  if (sys_state_rom_ext_desc_is_init_ == kUninitBits) {
+    memcpy(storage, &measure, sizeof(measure));
+    sys_state_rom_ext_desc_is_init_ = 0;
+  } else if (memcmp(storage, &measure, sizeof(measure)) != 0) {
+    return kSysStateCorrupt;
+  }
+
+  if (ptr != NULL) {
+    *ptr = storage;
+  }
+
+  return kSysStateOk;
+}
+
+static sys_state_device_id_t sys_state_device_id_;
+static uint32_t sys_state_device_id_is_init_ = kUninitBits;
+
+sys_state_result_t sys_state_device_id(const sys_state_device_id_t **ptr) {
+  sys_state_device_id_t measure;
+  // TODO: Fill `measure` with data.
+
+  sys_state_device_id_t *storage = &sys_state_device_id_;
+  if (sys_state_device_id_is_init_ == kUninitBits) {
+    memcpy(storage, &measure, sizeof(measure));
+    sys_state_device_id_is_init_ = 0;
+  } else if (memcmp(storage, &measure, sizeof(measure)) != 0) {
+    return kSysStateCorrupt;
+  }
+
+  if (ptr != NULL) {
+    *ptr = storage;
+  }
+
+  return kSysStateOk;
+}
+
+static dif_lifecycle_state_t sys_state_lc_state_;
+static uint32_t sys_state_lc_state_is_init_ = kUninitBits;
+
+sys_state_result_t sys_state_lifecycle_state(
+    const dif_lifecycle_state_t **ptr) {
+  dif_lifecycle_state_t measure;
+  // TODO: Fill `measure` with data.
+
+  dif_lifecycle_state_t *storage = &sys_state_lc_state_;
+  if (sys_state_lc_state_is_init_ == kUninitBits) {
+    memcpy(storage, &measure, sizeof(measure));
+    sys_state_lc_state_is_init_ = 0;
+  } else if (memcmp(storage, &measure, sizeof(measure)) != 0) {
+    return kSysStateCorrupt;
+  }
+
+  if (ptr != NULL) {
+    *ptr = storage;
+  }
+
+  return kSysStateOk;
+}
+
+static dif_lifecycle_debug_state_t sys_state_debug_state_;
+static uint32_t sys_state_debug_state_is_init_ = kUninitBits;
+
+sys_state_result_t sys_state_debug_state(
+    const dif_lifecycle_debug_state_t **ptr) {
+  dif_lifecycle_debug_state_t measure;
+  // TODO: Fill `measure` with data.
+
+  dif_lifecycle_debug_state_t *storage = &sys_state_debug_state_;
+  if (sys_state_debug_state_is_init_ == kUninitBits) {
+    memcpy(storage, &measure, sizeof(measure));
+    sys_state_debug_state_is_init_ = 0;
+  } else if (memcmp(storage, &measure, sizeof(measure)) != 0) {
+    return kSysStateCorrupt;
+  }
+
+  if (ptr != NULL) {
+    *ptr = storage;
+  }
+
+  return kSysStateOk;
+}
+
+// Open Q: How are we getting this value here? Should it be passed in as an
+// argument? Should the module just create it? It's a bit problematic, since
+// other modules might want to use HMAC, and having multiple handles lying
+// around seems problematic.
+extern dif_hmac_t hmac;
+
+static sys_state_result_t write_to_hmac(const void *data, size_t len) {
+  const char *data8 = (const char *)data;
+  size_t data_left = len;
+  while (data_left > 0) {
+    size_t bytes_sent;
+    switch (dif_hmac_fifo_push(&hmac, data8, data_left, &bytes_sent)) {
+      case kDifHmacFifoOk:
+        return kSysStateOk;
+      case kDifHmacFifoFull:
+        data8 += bytes_sent;
+        data_left -= bytes_sent;
+        continue;
+      default:
+        return kSysStateExternError;
+    }
+  }
+  return kSysStateOk;
+}
+
+static dif_hmac_digest_t sys_state_health_state_;
+static uint32_t sys_state_health_state_is_init_ = kUninitBits;
+
+/**
+ * Takes a measurement of the health state, by hashing the lc state and the
+ * debug state together.
+ */
+static sys_state_result_t compute_health_state(dif_hmac_digest_t *measure) {
+  sys_state_result_t err;
+
+  const dif_lifecycle_state_t *lc;
+  err = sys_state_lifecycle_state(&lc);
+  if (err != kSysStateOk) {
+    return err;
+  }
+
+  const dif_lifecycle_debug_state_t *debug;
+  err = sys_state_debug_state(&debug);
+  if (err != kSysStateOk) {
+    return err;
+  }
+
+  if (dif_hmac_mode_sha256_start(&hmac) != kDifHmacOk) {
+    return kSysStateExternError;
+  }
+
+  err = write_to_hmac(lc, sizeof(*lc));
+  if (err != kSysStateOk) {
+    return err;
+  }
+  err = write_to_hmac(debug, sizeof(*debug));
+  if (err != kSysStateOk) {
+    return err;
+  }
+
+  if (dif_hmac_process(&hmac) != kDifHmacOk) {
+    return kSysStateExternError;
+  }
+
+  dif_hmac_digest_result_t digest_result = kDifHmacDigestProcessing;
+  while (digest_result == kDifHmacDigestProcessing) {
+    digest_result = dif_hmac_digest_read(&hmac, measure);
+  }
+  if (digest_result != kDifHmacDigestOk) {
+    return kSysStateExternError;
+  }
+
+  return kSysStateOk;
+}
+
+sys_state_result_t sys_state_health_state(const dif_hmac_digest_t **ptr) {
+  dif_hmac_digest_t measure;
+  sys_state_result_t err = compute_health_state(&measure);
+  if (err != kSysStateOk) {
+    return err;
+  }
+
+  dif_hmac_digest_t *storage = &sys_state_health_state_;
+  if (sys_state_health_state_is_init_ == kUninitBits) {
+    memcpy(storage, &measure, sizeof(measure));
+    sys_state_health_state_is_init_ = 0;
+  } else if (memcmp(storage, &measure, sizeof(measure)) != 0) {
+    return kSysStateCorrupt;
+  }
+
+  if (ptr != NULL) {
+    *ptr = storage;
+  }
+
+  return kSysStateOk;
+}

--- a/sw/device/mask_rom/sys_state.h
+++ b/sw/device/mask_rom/sys_state.h
@@ -1,0 +1,187 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_MASK_ROM_SYS_STATE_H_
+#define OPENTITAN_SW_DEVICE_MASK_ROM_SYS_STATE_H_
+
+#include <stdalign.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/dif/dif_hmac.h"
+
+// Header Extern Guard (so header can be used from C and C++)
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+#define SYS_STATE_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
+
+// NOTE: This header has pending depenencies; the type definitions below exist
+// as a stop gap until they exist.
+typedef uint32_t rom_ext_manifest_tag_t;
+typedef uint32_t dif_lifecycle_state_t;
+typedef uint32_t dif_lifecycle_debug_state_t;
+
+/**
+ * The Device ID, a 256-bit blob stored in OTP.
+ */
+typedef struct sys_state_device_id {
+  /**
+   * The bytes that make up the blob.
+   */
+  alignas(uint32_t) uint8_t bytes[256 / 8];
+} sys_state_device_id_t;
+
+/**
+ * The result of a System State operation.
+ */
+typedef enum sys_state_result {
+  /**
+   * Indicates that the operation succeeded.
+   */
+  kSysStateOk = 0,
+  /**
+   * Indicates an error coming from an external operation.
+   *
+   * For example, failures at the DIF level become this error.
+   */
+  kSysStateExternError,
+  /**
+   * Indicates that cached system state data was corrupt.
+   *
+   * Note that this function may be returned even when calling a getter for the
+   * first time, since it may indicate that a *different* cached value, or some
+   * book-keeping data, is corrupt.
+   */
+  kSysStateCorrupt,
+} sys_state_result_t;
+
+/**
+ * Returns a pointer to the ROM_EXT security descriptor.
+ *
+ * The first time this function is called, it will initialize the underlying
+ * RAM storage for this system state datum. On every following call, it will
+ * recompute the datum; if it does not match the stored value,
+ * `kSysStateCorrupt` will be returned.
+ *
+ * The returned pointer should be stored only for as long as it is desired to
+ * not re-check the RAM-cached value. In other words, the lifetime of the
+ * returned pointer should only be as long as a caller feels it is acceptable to
+ * use the value without re-checking it.
+ *
+ * The `ptr` out param may be NULL; this will perform a check without needing to
+ * allocate space for the return value.
+ *
+ * @param[out] ptr Out-param for the pointed to the cached value (may be NULL).
+ * @return The result of the operation.
+ */
+SYS_STATE_WARN_UNUSED_RESULT
+sys_state_result_t sys_state_rom_ext_security_descriptor(
+    const rom_ext_manifest_tag_t **ptr);
+
+/**
+ * Returns a pointer to the Device ID, read from OTP.
+ *
+ * The first time this function is called, it will initialize the underlying
+ * RAM storage for this system state datum. On every following call, it will
+ * recompute the datum; if it does not match the stored value,
+ * `kSysStateCorrupt` will be returned.
+ *
+ * The returned pointer should be stored only for as long as it is desired to
+ * not re-check the RAM-cached value. In other words, the lifetime of the
+ * returned pointer should only be as long as a caller feels it is acceptable to
+ * use the value without re-checking it.
+ *
+ * The `ptr` out param may be NULL; this will perform a check without needing to
+ * allocate space for the return value.
+ *
+ * @param[out] ptr Out-param for the pointed to the cached value (may be NULL).
+ * @return The result of the operation.
+ */
+SYS_STATE_WARN_UNUSED_RESULT
+sys_state_result_t sys_state_device_id(const sys_state_device_id_t **ptr);
+
+/**
+ * Returns a pointer to the current lifecycle state.
+ *
+ * The first time this function is called, it will initialize the underlying
+ * RAM storage for this system state datum. On every following call, it will
+ * recompute the datum; if it does not match the stored value,
+ * `kSysStateCorrupt` will be returned.
+ *
+ * The returned pointer should be stored only for as long as it is desired to
+ * not re-check the RAM-cached value. In other words, the lifetime of the
+ * returned pointer should only be as long as a caller feels it is acceptable to
+ * use the value without re-checking it.
+ *
+ * The `ptr` out param may be NULL; this will perform a check without needing to
+ * allocate space for the return value.
+ *
+ * @param[out] ptr Out-param for the pointed to the cached value (may be NULL).
+ * @return The result of the operation.
+ */
+SYS_STATE_WARN_UNUSED_RESULT
+sys_state_result_t sys_state_lifecycle_state(const dif_lifecycle_state_t **ptr);
+
+/**
+ * Returns a pointer to the current debug state.
+ *
+ * The first time this function is called, it will initialize the underlying
+ * RAM storage for this system state datum. On every following call, it will
+ * recompute the datum; if it does not match the stored value,
+ * `kSysStateCorrupt` will be returned.
+ *
+ * The returned pointer should be stored only for as long as it is desired to
+ * not re-check the RAM-cached value. In other words, the lifetime of the
+ * returned pointer should only be as long as a caller feels it is acceptable to
+ * use the value without re-checking it.
+ *
+ * The `ptr` out param may be NULL; this will perform a check without needing to
+ * allocate space for the return value.
+ *
+ * @param[out] ptr Out-param for the pointed to the cached value (may be NULL).
+ * @return The result of the operation.
+ */
+SYS_STATE_WARN_UNUSED_RESULT
+sys_state_result_t sys_state_debug_state(
+    const dif_lifecycle_debug_state_t **ptr);
+
+/**
+ * Returns a pointer to the health state, which is a combined measurement of the
+ * lifecycle and debug states.
+ *
+ * The first time this function is called, it will initialize the underlying
+ * RAM storage for this system state datum. On every following call, it will
+ * recompute the datum; if it does not match the stored value,
+ * `kSysStateCorrupt` will be returned.
+ *
+ * The returned pointer should be stored only for as long as it is desired to
+ * not re-check the RAM-cached value. In other words, the lifetime of the
+ * returned pointer should only be as long as a caller feels it is acceptable to
+ * use the value without re-checking it.
+ *
+ * The `ptr` out param may be NULL; this will perform a check without needing to
+ * allocate space for the return value.
+ *
+ * @param[out] ptr Out-param for the pointed to the cached value (may be NULL).
+ * @return The result of the operation.
+ */
+SYS_STATE_WARN_UNUSED_RESULT
+sys_state_result_t sys_state_health_state(const dif_hmac_digest_t **ptr);
+
+/**
+ * Dumps all cached state into the Key Manager.
+ *
+ * (This function will remain unimplemented for now, since it is not part of
+ * v0.5).
+ */
+SYS_STATE_WARN_UNUSED_RESULT
+sys_state_result_t sys_state_build_creator_root_key(void);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_MASK_ROM_SYS_STATE_H_


### PR DESCRIPTION
This PR adds the "first draft" of the System State module. It reflects an updated version of the design sketched in https://docs.google.com/document/d/1r45oTIzcceiBWXJ0ZAHfIx7hqBqtdlukMoi8D7bhot0/edit.

~~It's not actually complete, since I'm considering changing the API to be as follows:~~
- ~~Each measurement that System State records has an associated getter, like in the current design.~~
- ~~Unlike the current design, there is no `check_fresh` parameter. Instead:~~
  - ~~When called for the first time, each getter initializes its corresponding global by performing the measurement.~~
  - ~~On subsequent calls, the getter performs the measurement again, and signals an error if it does not produce the same result as is stored in the current global.~~

~~This alternate API has the advantage that it eliminates `init()` and the `check_fresh` parameter, and potentially the `check_fresh()` function itself as well, and makes the lifetime of the "known integrity" of a measurement explicit, since it is tied to a specific pointer value returned by the getter (that the getter always returns the same pointer on success notwhithstanding...).~~

(Garret and I decided the alternative API was a better choice.)

Also, we are considering whether remeasuring each measurement is necessary at all, and if storing a sufficiently big checksum of each measurement is good enough (e.g. an adler32 or whatever we think is security-appropriate).

@moidx Garret and I would like your opinion on the above open questions.