### PR TITLE
[topgen/reggen] Add support for module parametrization at the top level

### DIFF
--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -7,9 +7,56 @@
   name: "aes",
   clock_primary: "clk_i",
   bus_device: "tlul",
-  # Note: All parameters are local, they are not actually configurable.
-  # Selecting values different from the default values below might cause undefined behavior.
   param_list: [
+    { name:    "AES192Enable",
+      type:    "bit",
+      default: "1'b1",
+      desc:    '''
+        Disable (0) or enable (1) support for 192-bit key lengths (AES-192).
+      '''
+      local:   "false",
+      expose:  "false"
+    },
+    { name:    "Masking",
+      type:    "bit",
+      default: "1'b0",
+      desc:    '''
+        Disable (0) or enable (1) first-order masking of the AES cipher core.
+        Masking requires the use of a masked S-Box, see SBoxImpl parameter.
+      '''
+      local:   "false",
+      expose:  "true"
+    },
+    { name:    "SBoxImpl",
+      type:    "aes_pkg::sbox_impl_e",
+      default: "aes_pkg::SBoxImplLut",
+      desc:    '''
+        Selection of the S-Box implementation. See aes_pkg.sv.
+      '''
+      local:   "false",
+      expose:  "true"
+    },
+    { name:    "SecStartTriggerDelay",
+      type:    "int unsigned",
+      default: "0",
+      desc:    '''
+        Manual start trigger delay, useful for SCA measurements.
+        A value of e.g. 40 allows the processor to go into sleep before AES starts operation.
+      '''
+      local:   "false",
+      expose:  "true"
+    },
+    { name:    "AlertAsyncOn",
+      type:    "logic [aes_reg_pkg::NumAlerts-1:0]",
+      default: "{aes_reg_pkg::NumAlerts{1'b1}}",
+      desc:    '''
+        One bit per alert specifying whether the corresponding sender in the AES module and the receiver in the alert handler are in the same clock domain (0) or whether there is an asynchronous boundary in between (1).
+      '''
+      local:   "false",
+      expose:  "false"
+    },
+    # Note: All parameters below are local, they are not actually configurable.
+    # Selecting values different from the default values below might cause undefined behavior.
     { name:    "NumRegsKey",
       type:    "int",
       default: "8",
@@ -21,7 +68,7 @@
       default: "4",
       desc:    "Number registers for initialization vector",
       local:   "true"
-    }
+    },
     { name:    "NumRegsData",
       type:    "int",
       default: "4",

--- a/hw/ip/aes/rtl/aes.sv
+++ b/hw/ip/aes/rtl/aes.sv
@@ -10,19 +10,19 @@ module aes
   import aes_pkg::*;
   import aes_reg_pkg::*;
 #(
-  parameter bit          AES192Enable               = 1, // Can be 0 (disable), or 1 (enable).
-  parameter bit          Masking                    = 0, // Can be 0 (no masking), or
-                                                         // 1 (first-order masking) of the cipher
-                                                         // core. Masking requires the use of a
-                                                         // masked S-Box, see SBoxImpl parameter.
-                                                         // Note: currently, constant masks are
-                                                         // used, this is of course not secure.
-  parameter sbox_impl_e  SBoxImpl                   = SBoxImplLut, // See aes_pkg.sv
-  parameter int unsigned NumDelayCyclesStartTrigger = 0, // Manual start trigger delay, useful for
-                                                         // SCA measurements. A value of e.g. 40
-                                                         // allows the processor to go into sleep
-                                                         // before AES starts operation.
-  parameter logic [NumAlerts-1:0] AlertAsyncOn      = {NumAlerts{1'b1}}
+  parameter bit          AES192Enable          = 1, // Can be 0 (disable), or 1 (enable).
+  parameter bit          Masking               = 0, // Can be 0 (no masking), or
+                                                    // 1 (first-order masking) of the cipher
+                                                    // core. Masking requires the use of a
+                                                    // masked S-Box, see SBoxImpl parameter.
+                                                    // Note: currently, constant masks are
+                                                    // used, this is of course not secure.
+  parameter sbox_impl_e  SBoxImpl              = SBoxImplLut, // See aes_pkg.sv
+  parameter int unsigned SecStartTriggerDelay  = 0, // Manual start trigger delay, useful for
+                                                    // SCA measurements. A value of e.g. 40
+                                                    // allows the processor to go into sleep
+                                                    // before AES starts operation.
+  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}}
 ) (
   input                     clk_i,
   input                     rst_ni,
@@ -68,10 +68,10 @@ module aes
   );
 
   aes_core #(
-    .AES192Enable               ( AES192Enable               ),
-    .Masking                    ( Masking                    ),
-    .SBoxImpl                   ( SBoxImpl                   ),
-    .NumDelayCyclesStartTrigger ( NumDelayCyclesStartTrigger )
+    .AES192Enable         ( AES192Enable         ),
+    .Masking              ( Masking              ),
+    .SBoxImpl             ( SBoxImpl             ),
+    .SecStartTriggerDelay ( SecStartTriggerDelay )
   ) u_aes_core (
     .clk_i,
     .rst_ni,

--- a/hw/ip/aes/rtl/aes_control.sv
+++ b/hw/ip/aes/rtl/aes_control.sv
@@ -10,7 +10,7 @@
 
 module aes_control
 #(
-  parameter int unsigned NumDelayCyclesStartTrigger = 0
+  parameter int unsigned SecStartTriggerDelay = 0
 ) (
   input  logic                    clk_i,
   input  logic                    rst_ni,
@@ -147,15 +147,15 @@ module aes_control
   logic       ctrl_we_q;
   logic       clear_in_out_status;
 
-  if (NumDelayCyclesStartTrigger > 0) begin : gen_start_delay
+  if (SecStartTriggerDelay > 0) begin : gen_start_delay
     // Delay the manual start trigger input for SCA measurements.
-    localparam int unsigned WidthCounter = $clog2(NumDelayCyclesStartTrigger+1);
+    localparam int unsigned WidthCounter = $clog2(SecStartTriggerDelay+1);
     logic [WidthCounter-1:0] count_d, count_q;
 
     // Clear counter when input goes low. Keep value if the specified delay is reached.
     assign count_d = !start_i       ? '0      :
                       start_trigger ? count_q : count_q + 1'b1;
-    assign start_trigger = (count_q == NumDelayCyclesStartTrigger[WidthCounter-1:0]) ? 1'b1 : 1'b0;
+    assign start_trigger = (count_q == SecStartTriggerDelay[WidthCounter-1:0]) ? 1'b1 : 1'b0;
 
     always_ff @(posedge clk_i or negedge rst_ni) begin
       if (!rst_ni) begin

--- a/hw/ip/aes/rtl/aes_core.sv
+++ b/hw/ip/aes/rtl/aes_core.sv
@@ -8,12 +8,12 @@
 
 module aes_core import aes_pkg::*;
 #(
-  parameter bit          AES192Enable               = 1,
-  parameter bit          Masking                    = 0,
-  parameter sbox_impl_e  SBoxImpl                   = SBoxImplLut,
-  parameter int unsigned NumDelayCyclesStartTrigger = 0,
+  parameter bit          AES192Enable         = 1,
+  parameter bit          Masking              = 0,
+  parameter sbox_impl_e  SBoxImpl             = SBoxImplLut,
+  parameter int unsigned SecStartTriggerDelay = 0,
 
-  localparam int         NumShares                  = Masking ? 2 : 1 // derived parameter
+  localparam int         NumShares            = Masking ? 2 : 1 // derived parameter
 ) (
   input  logic                     clk_i,
   input  logic                     rst_ni,
@@ -409,7 +409,7 @@ module aes_core import aes_pkg::*;
 
   // Control
   aes_control #(
-    .NumDelayCyclesStartTrigger ( NumDelayCyclesStartTrigger )
+    .SecStartTriggerDelay ( SecStartTriggerDelay )
   ) u_aes_control (
     .clk_i                   ( clk_i                            ),
     .rst_ni                  ( rst_ni                           ),

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -328,6 +328,7 @@
         }
       ]
       available_inout_list: []
+      param_list: []
       interrupt_list:
       [
         {
@@ -478,6 +479,7 @@
           type: inout
         }
       ]
+      param_list: []
       interrupt_list:
       [
         {
@@ -561,6 +563,7 @@
         }
       ]
       available_inout_list: []
+      param_list: []
       interrupt_list:
       [
         {
@@ -680,6 +683,7 @@
       available_input_list: []
       available_output_list: []
       available_inout_list: []
+      param_list: []
       interrupt_list:
       [
         {
@@ -850,6 +854,7 @@
       available_input_list: []
       available_output_list: []
       available_inout_list: []
+      param_list: []
       interrupt_list:
       [
         {
@@ -902,6 +907,33 @@
       available_input_list: []
       available_output_list: []
       available_inout_list: []
+      param_list:
+      [
+        {
+          name: Masking
+          type: bit
+          default: 1'b0
+          local: "false"
+          expose: "true"
+          name_top: AesMasking
+        }
+        {
+          name: SBoxImpl
+          type: aes_pkg::sbox_impl_e
+          default: aes_pkg::SBoxImplLut
+          local: "false"
+          expose: "true"
+          name_top: AesSBoxImpl
+        }
+        {
+          name: SecStartTriggerDelay
+          type: int unsigned
+          default: "0"
+          local: "false"
+          expose: "true"
+          name_top: SecAesStartTriggerDelay
+        }
+      ]
       interrupt_list: []
       alert_list:
       [
@@ -973,6 +1005,7 @@
       available_input_list: []
       available_output_list: []
       available_inout_list: []
+      param_list: []
       interrupt_list:
       [
         {
@@ -1065,6 +1098,7 @@
       available_input_list: []
       available_output_list: []
       available_inout_list: []
+      param_list: []
       interrupt_list: []
       alert_list: []
       wakeup_list: []
@@ -1115,6 +1149,7 @@
       available_input_list: []
       available_output_list: []
       available_inout_list: []
+      param_list: []
       interrupt_list: []
       alert_list: []
       wakeup_list:
@@ -1220,6 +1255,7 @@
       available_input_list: []
       available_output_list: []
       available_inout_list: []
+      param_list: []
       interrupt_list: []
       alert_list: []
       wakeup_list: []
@@ -1272,6 +1308,7 @@
       available_input_list: []
       available_output_list: []
       available_inout_list: []
+      param_list: []
       interrupt_list:
       [
         {
@@ -1371,6 +1408,7 @@
       available_input_list: []
       available_output_list: []
       available_inout_list: []
+      param_list: []
       interrupt_list:
       [
         {
@@ -1545,6 +1583,7 @@
       available_input_list: []
       available_output_list: []
       available_inout_list: []
+      param_list: []
       interrupt_list: []
       alert_list: []
       wakeup_list: []
@@ -1667,6 +1706,7 @@
       available_input_list: []
       available_output_list: []
       available_inout_list: []
+      param_list: []
       interrupt_list: []
       alert_list: []
       wakeup_list: []
@@ -1822,6 +1862,7 @@
       available_input_list: []
       available_output_list: []
       available_inout_list: []
+      param_list: []
       interrupt_list:
       [
         {
@@ -1962,6 +2003,7 @@
           type: inout
         }
       ]
+      param_list: []
       interrupt_list:
       [
         {
@@ -2231,6 +2273,7 @@
       available_input_list: []
       available_output_list: []
       available_inout_list: []
+      param_list: []
       interrupt_list: []
       alert_list:
       [
@@ -2310,6 +2353,7 @@
       available_input_list: []
       available_output_list: []
       available_inout_list: []
+      param_list: []
       interrupt_list:
       [
         {

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -910,6 +910,14 @@
       param_list:
       [
         {
+          name: AES192Enable
+          type: bit
+          default: 1'b1
+          local: "false"
+          expose: "false"
+          name_top: AesAES192Enable
+        }
+        {
           name: Masking
           type: bit
           default: 1'b0
@@ -932,6 +940,14 @@
           local: "false"
           expose: "true"
           name_top: SecAesStartTriggerDelay
+        }
+        {
+          name: AlertAsyncOn
+          type: logic [aes_reg_pkg::NumAlerts-1:0]
+          default: "{aes_reg_pkg::NumAlerts{1'b1}}"
+          local: "false"
+          expose: "false"
+          name_top: AesAlertAsyncOn
         }
       ]
       interrupt_list: []

--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -30,6 +30,14 @@ cpu_rst = top["reset_paths"]["sys"]
 dm_rst = top["reset_paths"]["lc"]
 %>\
 module top_${top["name"]} #(
+  // Auto-inferred parameters
+% for m in top["module"]:
+  % for p in m["param_list"]:
+  parameter ${p["type"]} ${p["name_top"]} = ${p["default"]},
+  % endfor
+% endfor
+
+  // Manually defined parameters
   parameter bit IbexPipeLine = 0,
   parameter     BootRomInitFile = ""
 ) (
@@ -477,14 +485,10 @@ else:
     max_intrwidth = max([len(x["name"]) for x
         in m["interrupt_list"]])
 %>\
-  % if "parameter" in m:
+  % if m["param_list"]:
   ${m["type"]} #(
-    % for k, v in m["parameter"].items():
-        % if loop.last:
-    .${k}(${v | lib.parameterize})
-        % else:
-    .${k}(${v | lib.parameterize}),
-        % endif
+    % for i in m["param_list"]:
+    .${i["name"]}(${i["name_top"]})${"," if not loop.last else ""}
     % endfor
   ) u_${m["name"]} (
   % else:

--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -32,8 +32,8 @@ dm_rst = top["reset_paths"]["lc"]
 module top_${top["name"]} #(
   // Auto-inferred parameters
 % for m in top["module"]:
-  % for p in m["param_list"]:
-  parameter ${p["type"]} ${p["name_top"]} = ${p["default"]},
+  % for p_exp in filter(lambda p: p["expose"] == "true", m["param_list"]):
+  parameter ${p_exp["type"]} ${p_exp["name_top"]} = ${p_exp["default"]},
   % endfor
 % endfor
 
@@ -488,7 +488,7 @@ else:
   % if m["param_list"]:
   ${m["type"]} #(
     % for i in m["param_list"]:
-    .${i["name"]}(${i["name_top"]})${"," if not loop.last else ""}
+    .${i["name"]}(${i["name_top" if i["expose"] == "true" else "default"]})${"," if not loop.last else ""}
     % endfor
   ) u_${m["name"]} (
   % else:

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -676,9 +676,11 @@ module top_earlgrey #(
   );
 
   aes #(
+    .AES192Enable(1'b1),
     .Masking(AesMasking),
     .SBoxImpl(AesSBoxImpl),
-    .SecStartTriggerDelay(SecAesStartTriggerDelay)
+    .SecStartTriggerDelay(SecAesStartTriggerDelay),
+    .AlertAsyncOn({aes_reg_pkg::NumAlerts{1'b1}})
   ) u_aes (
 
       // [0]: ctrl_err_update

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -3,6 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module top_earlgrey #(
+  // Auto-inferred parameters
+  parameter bit AesMasking = 1'b0,
+  parameter aes_pkg::sbox_impl_e AesSBoxImpl = aes_pkg::SBoxImplLut,
+  parameter int unsigned SecAesStartTriggerDelay = 0,
+
+  // Manually defined parameters
   parameter bit IbexPipeLine = 0,
   parameter     BootRomInitFile = ""
 ) (
@@ -669,7 +675,11 @@ module top_earlgrey #(
       .rst_ni (rstmgr_resets.rst_sys_io_div4_n)
   );
 
-  aes u_aes (
+  aes #(
+    .Masking(AesMasking),
+    .SBoxImpl(AesSBoxImpl),
+    .SecStartTriggerDelay(SecAesStartTriggerDelay)
+  ) u_aes (
 
       // [0]: ctrl_err_update
       // [1]: ctrl_err_storage

--- a/hw/top_earlgrey/rtl/top_earlgrey_artys7.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_artys7.sv
@@ -165,6 +165,9 @@ module top_earlgrey_artys7  #(
   //////////////////////
 
   top_earlgrey #(
+    .AesMasking(1'b0),
+    .AesSBoxImpl(aes_pkg::SBoxImplLut),
+    .SecAesStartTriggerDelay(0),
     .IbexPipeLine(1),
     .BootRomInitFile(BootRomInitFile)
   ) top_earlgrey (

--- a/hw/top_earlgrey/rtl/top_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_asic.sv
@@ -241,7 +241,11 @@ module top_earlgrey_asic (
   // Top-level design //
   //////////////////////
 
-  top_earlgrey top_earlgrey (
+  top_earlgrey #(
+    .AesMasking(1'b0),
+    .AesSBoxImpl(aes_pkg::SBoxImplCanright),
+    .SecAesStartTriggerDelay(0)
+  ) top_earlgrey (
     .rst_ni          ( rst_n         ),
     // ast connections
     .clk_main_i      ( ast_base_clks.clk_sys ),

--- a/hw/top_earlgrey/rtl/top_earlgrey_cw305.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_cw305.sv
@@ -227,6 +227,9 @@ module top_earlgrey_cw305 #(
   // for verilator purposes, make these two the same.
   assign ast_base_rst.aon_pok      = rst_n;
   top_earlgrey #(
+    .AesMasking(1'b0),
+    .AesSBoxImpl(aes_pkg::SBoxImplLut),
+    .SecAesStartTriggerDelay(40),
     .IbexPipeLine(1),
     .BootRomInitFile(BootRomInitFile)
   ) top_earlgrey (

--- a/hw/top_earlgrey/rtl/top_earlgrey_nexysvideo.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_nexysvideo.sv
@@ -223,6 +223,9 @@ module top_earlgrey_nexysvideo #(
   // for verilator purposes, make these two the same.
   assign ast_base_rst.aon_pok      = rst_n;
   top_earlgrey #(
+    .AesMasking(1'b0),
+    .AesSBoxImpl(aes_pkg::SBoxImplLut),
+    .SecAesStartTriggerDelay(0),
     .IbexPipeLine(1),
     .BootRomInitFile(BootRomInitFile)
   ) top_earlgrey (

--- a/util/reggen/reg_top.sv.tpl
+++ b/util/reggen/reg_top.sv.tpl
@@ -7,13 +7,12 @@
   num_wins = len(block.wins)
   num_wins_width = ((num_wins+1).bit_length()) - 1
   num_dsp  = num_wins + 1
-  params = [p for p in block.params if p["local"] == "false"]
   max_regs_char = len("{}".format(block.get_n_regs_flat()-1))
   regs_flat = block.get_regs_flat()
 %>
 `include "prim_assert.sv"
 
-module ${block.name}_reg_top ${print_param(params)}(
+module ${block.name}_reg_top (
   input clk_i,
   input rst_ni,
 
@@ -561,15 +560,5 @@ ${msb}\
         reg_rdata_next[${str_bits_sv(msb,lsb)}] = ${sig_name}_qs;
 % else:
         reg_rdata_next[${str_bits_sv(msb,lsb)}] = '0;
-% endif
-</%def>\
-<%def name="print_param(params)">\
-<% num_params = len(params) %>\
-% if num_params != 0:
-#(
-% for i,p in enumerate(params):
-  parameter ${p["type"]} ${p["name"]} = ${p["default"]}${"," if i != num_params-1 else ""}
-% endfor
-) \
 % endif
 </%def>\

--- a/util/topgen/merge.py
+++ b/util/topgen/merge.py
@@ -93,18 +93,18 @@ def amend_ip(top, ip):
         # param_list
         if "param_list" in ip:
             ip_module["param_list"] = deepcopy(ip["param_list"])
-            # Removing parameters that aren't exposed at the top level.
+            # Removing local parameters.
             for i in ip["param_list"]:
-                if i["expose"] == "false":
+                if i["local"] == "true":
                     ip_module["param_list"].remove(i)
-                    if i["name"].lower().startswith("sec"):
-                        log.warning(
-                            mod_name + " has security-critical" +
-                            " parameter " + i["name"] + " not exposed to top")
-            # Removing descriptors and adding a top-level name.
+            # Removing descriptors, checking for security-relevant parameters
+            # that are not exposed, adding a top-level name.
             for i in ip_module["param_list"]:
                 i.pop("desc", None)
                 par_name = i["name"]
+                if par_name.lower().startswith("sec"):
+                    log.warning("{} has security-critical parameter {} "
+                                "not exposed to top".format(mod_name, par_name))
                 i["name_top"] = ("Sec" + mod_name.capitalize() + par_name[3:]
                                  if par_name.lower().startswith("sec")
                                  else mod_name.capitalize() + par_name)


### PR DESCRIPTION
This PR enables support for changing the parameterization of peripherals at the top level, which is useful e.g. for SCA analysis where we use a different configuration of AES, or if a different target (technology) asks for a different parameterization. The PR contains a series of commits to achieve the following:
- Designers can specify module-level parameters in the module hjson and declare if they should be exposed to the top.
- reggen processes the parameter list and for example checks that parameters exposed at the top-level have a default.
- topgen gets the parameter list, adds them to the module instantiation and exposes them at the top. To get unique parameter names at the top-level, topgen prefixes the parameter name with the module name. 

In addition, reggen and topgen treat parameters starting with `Sec` as security critical. They make sure that such parameters remain prefixed with `Sec` when extending the name. In addition, if such a parameter is not exposed at the top-level, a warning is printed. @cdgori and @rswarbrick suggested that we should somehow keep track of security-critical parameters. This is a first step in that direction.

This is a draft. I am open for feedback. As an example, this PR exposes some parameters of AES and then uses different values in the target-specific top levels. In a next step, some of these target-specific top levels could be consolidated by driving the parameters via fusesoc. This PR also does not yet support parameters that are not transparent to software, i.e., there is no way for the software build to infer what parameterization is selected. I view this as follow-up work.