### PR TITLE
[otbn] Fix branch address for BEQ/BNE

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/insn.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/insn.py
@@ -205,7 +205,7 @@ class BEQ(OTBNInsn):
         val1 = model.state.intreg[self.grs1].value
         val2 = model.state.intreg[self.grs2].value
         if val1 == val2:
-            model.state.pc_next = model.state.pc.unsigned() + self.offset
+            model.state.pc_next = self.offset
 
 
 class BNE(OTBNInsn):
@@ -221,7 +221,7 @@ class BNE(OTBNInsn):
         val1 = model.state.intreg[self.grs1].value
         val2 = model.state.intreg[self.grs2].value
         if val1 != val2:
-            model.state.pc_next = model.state.pc.unsigned() + self.offset
+            model.state.pc_next = self.offset
 
 
 class JAL(OTBNInsn):


### PR DESCRIPTION
The immediate operand is PC-relative, but the `+ pc` operation happens
as part of decoding, so we don't need to add it on again as part of
the instruction body.

Maybe we should rename the operand to something like "dest", since the
assembly code is written with the destination, rather than the offset.
But let's leave that for later, sticking with the RISC-V naming for
now.
