### PR TITLE
[otbn] Remove otbnsim.py from list of scripts in a lint target

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/Makefile
+++ b/hw/ip/otbn/dv/otbnsim/Makefile
@@ -13,7 +13,7 @@ build-dir := $(repo-top)/build-bin/otbn/otbnsim
 $(build-dir):
 	mkdir -p $@
 
-py-scripts := otbnsim.py standalone.py stepped.py
+py-scripts := standalone.py stepped.py
 py-files   := $(wildcard *.py sim/*.py)
 py-libs    := $(filter-out $(py-scripts),$(py-files))
 


### PR DESCRIPTION
This was removed in a previous commit (dd431e96), but I forgot to
remove it from the linting target
