### PR TITLE
[doc] Remove review lines from non-final HW stages

### DIFF
--- a/util/uvmdvgen/checklist.md.tpl
+++ b/util/uvmdvgen/checklist.md.tpl
@@ -25,8 +25,6 @@ RTL           | [MEM_INSTANCED_80][]  | Not Started |
 RTL           | [FUNC_IMPLEMENTED][]  | Not Started |
 RTL           | [ASSERT_KNOWN_ADDED][]| Not Started |
 Code Quality  | [LINT_SETUP][]        | Not Started |
-Review        | Reviewer(s)           | Not Started |
-Review        | Signoff date          | Not Started |
 
 [SPEC_COMPLETE]:      {{<relref "/doc/project/checklist.md#spec-complete" >}}
 [CSR_DEFINED]:        {{<relref "/doc/project/checklist.md#csr-defined" >}}
@@ -60,8 +58,6 @@ Code Quality  | [CDC_SYNCMACRO][]       | Not Started |
 Security      | [SEC_CM_IMPLEMENTED][]  | Not Started |
 Security      | [SEC_NON_RESET_FLOPS][] | Not Started |
 Security      | [SEC_SHADOW_REGS][]     | Not Started |
-Review        | Reviewer(s)             | Not Started |
-Review        | Signoff date            | Not Started |
 
 [NEW_FEATURES]:        {{<relref "/doc/project/checklist.md#new-features" >}}
 [BLOCK_DIAGRAM]:       {{<relref "/doc/project/checklist.md#block-diagram" >}}
@@ -138,8 +134,6 @@ Review        | [DESIGN_SPEC_REVIEWED][]              | Not Started |
 Review        | [DV_PLAN_TESTPLAN_REVIEWED][]         | Not Started |
 Review        | [STD_TEST_CATEGORIES_PLANNED][]       | Not Started | Exception (?)
 Review        | [V2_CHECKLIST_SCOPED][]               | Not Started |
-Review        | Reviewer(s)                           | Not Started |
-Review        | Signoff date                          | Not Started |
 
 [DV_PLAN_DRAFT_COMPLETED]:            {{<relref "/doc/project/checklist.md#dv-plan-draft-completed" >}}
 [TESTPLAN_COMPLETED]:                 {{<relref "/doc/project/checklist.md#testplan-completed" >}}
@@ -185,8 +179,6 @@ Issues        | [NO_HIGH_PRIORITY_ISSUES_PENDING][]     | Not started |
 Issues        | [ALL_LOW_PRIORITY_ISSUES_ROOT_CAUSED][] | Not started |
 Integration   | [PRE_VERIFIED_SUB_MODULES_V2][]         | Not started |
 Review        | [V3_CHECKLIST_SCOPED][]                 | Not started |
-Review        | Reviewer(s)                             | Not started |
-Review        | Signoff date                            | Not started |
 
 [DESIGN_DELTAS_CAPTURED_V2]:          {{<relref "/doc/project/checklist.md#design-deltas-captured-v2" >}}
 [DV_PLAN_COMPLETED]:                  {{<relref "/doc/project/checklist.md#dv-plan-completed" >}}


### PR DESCRIPTION
The "OpenTitan Hardware Development Stages" documentation at
https://docs.opentitan.org/doc/project/development_stages/ distinguishes
between a signoff review to reach the last development stage in
hardware and verification (D3 and V3) from the review required to move
between the in-between stages (e.g. D0 to D1).

The final signoff review is done by the Technical Committee with
clearly assigned reviewers (and typically in a review meeting).

Other stage transitions are done through normal PR reviews.

Currently, the hardware checklist template doesn't distinguish between
these types of review, but adds a review date and reviewers field to all
stages. This PR removes this information from the checklist for all but
the final stage, under the following motivation:

* Clearly spell out reviewers for the final stage transition, and
  indicate that this review is different from other stage transition
  reviews.
* Ease the stage transitions for all other stages by avoiding to capture
  information twice: the date and the reviewers of a stage transition
  are recorded in the GitHub pull request and the commit itself which
  makes the transition; updating the text file after it has been
  reviewed to capture who reviewed it feels unnecessary.
* Remove the wording "signoff" from all non-final stages; the
  documentation sees "signoff review" as something that is only done for
  the final stage.


---

This PR is meant to spark the discussion around this topic. Notes:

- I didn't update the existing checklists for IP blocks; I'll do so if/when we have reached agreement on a way forward.
- The SW checklist contains review dates and reviewers for non-final stages. Since the SW process is slightly different from the HW/DV one I didn't touch that part.