### PR TITLE
[otbn] Add ASSERT_KNOWN to idle output

### DIFF
--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -490,5 +490,6 @@ module otbn
   `ASSERT_KNOWN(IntrDoneOKnown_A, intr_done_o)
   `ASSERT_KNOWN(IntrErrOKnown_A, intr_err_o)
   `ASSERT_KNOWN(AlertTxOKnown_A, alert_tx_o)
+  `ASSERT_KNOWN(IdleOKnown_A, idle_o)
 
 endmodule


### PR DESCRIPTION
All outputs of the top-level OTBN module need to have known values after
reset, and ensure that using ASSERT_KNOWN (according to
ASSERT_KNOWN_ADDED as documented at
https://docs.opentitan.org/doc/project/checklist/index.html). Add the
last assertion that's missing.