### PR TITLE
[doc] Clarify the use of the term "RFC" in the D2 checklist

### DIFF
--- a/doc/project/checklist.md
+++ b/doc/project/checklist.md
@@ -52,7 +52,7 @@ warnings at this stage.
 ### NEW_FEATURES
 
 Any new features added since D1 are documented, reviewed with DV/SW/FPGA.
-Github Issue for RFC should be linked in `Notes` section.
+The GitHub Issue, Pull Request, or RFC where the feature was discussed should be linked in the `Notes` section.
 
 ### BLOCK_DIAGRAM
 


### PR DESCRIPTION
The term RFC in OpenTitan context typically means an RFC which is
discussed within the Technical Committee. In the context of the
development lifecycle checklist, there shouldn't be the need for an RFC
handled by the TC when features are added between D1 and D2 stages.
(There *is* TC involvement when transitioning to the final development
stage. That's unchanged.)