### PR TITLE
Otbn fixes

### DIFF
--- a/hw/ip/otbn/data/bignum-insns.yml
+++ b/hw/ip/otbn/data/bignum-insns.yml
@@ -368,7 +368,7 @@
     st = DecodeShiftType(shift_type)
   operation: |
     b_shifted = ShiftReg(b, st, sb)
-    (result, flags_out) = AddWithCarry(a, -b_shifted, "0")
+    (result, flags_out) = SubtractWithBorrow(a, b_shifted, 0)
 
     WDR[d] = result
     FLAGS[flag_group] = flags_out
@@ -393,7 +393,7 @@
   decode: *bn-sub-decode
   operation: |
     b_shifted = ShiftReg(b, st, sb)
-    (result, flags_out) = AddWithCarry(a, -b_shifted, ~FLAGS[flag_group].C)
+    (result, flags_out) = SubtractWithBorrow(a, b_shifted, FLAGS[flag_group].C)
 
     WDR[d] = result
     FLAGS[flag_group] = flags_out
@@ -430,7 +430,7 @@
     fg = DecodeFlagGroup(flag_group)
     i = ZeroExtend(imm, WLEN)
   operation: |
-    (result, flags_out) = AddWithCarry(a, -i, "0")
+    (result, flags_out) = SubtractWithBorrow(a, i, 0)
 
     WDR[d] = result
     FLAGS[flag_group] = flags_out
@@ -457,7 +457,7 @@
     a = UInt(wrs1)
     b = UInt(wrs2)
   operation: |
-    (result, ) = AddWithCarry(a, -b, "0")
+    (result, ) = SubtractWithBorrow(a, b, 0)
 
     if result < 0:
       result = MOD + result
@@ -709,7 +709,7 @@
     st = DecodeShiftType(shift_type)
   operation: |
     b_shifted = ShiftReg(b, st, sb)
-    (, flags_out) = AddWithCarry(a, -b_shifted, "0")
+    (, flags_out) = SubtractWithBorrow(a, b_shifted, 0)
 
     FLAGS[flag_group] = flags_out
   encoding:
@@ -731,7 +731,7 @@
     This instruction is identical to BN.SUBB, except that no result register is written.
   decode: *bn-cmp-decode
   operation: |
-    (, flags_out) = AddWithCarry(a, -b, ~FLAGS[flag_group].C)
+    (, flags_out) = SubtractWithBorrow(a, b, FLAGS[flag_group].C)
 
     FLAGS[flag_group] = flags_out
   encoding:

--- a/hw/ip/otbn/doc/_index.md
+++ b/hw/ip/otbn/doc/_index.md
@@ -437,6 +437,17 @@ def AddWithCarry(a: Bits(WLEN), b: Bits(WLEN), carry_in: Bits(1)) -> (Bits(WLEN)
 
   return (result[WLEN-1:0], flags_out)
 
+def SubtractWithBorrow(a: Bits(WLEN), b: Bits(WLEN), borrow_in: Bits(1)) -> (Bits(WLEN), FlagGroup):
+  result: Bits[WLEN+1] = a - b - borrow_in
+
+  flags_out = FlagGroup()
+  flags_out.C = result[WLEN]
+  flags_out.L = result[0]
+  flags_out.M = result[WLEN-1]
+  flags_out.Z = (result[WLEN-1:0] == 0)
+
+  return (result[WLEN-1:0], flags_out)
+
 def DecodeHalfWordSelect(hwsel: Bits(1)) -> HalfWord:
   if hwsel == 0:
     return HalfWord.LOWER

--- a/hw/ip/otbn/dv/otbnsim/sim/insn.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/insn.py
@@ -507,7 +507,7 @@ class BNSUB(OTBNInsn):
         a = int(state.wreg[self.wrs1])
         b_shifted = ShiftReg(int(state.wreg[self.wrs2]), self.shift_type,
                              self.shift_bytes)
-        (result, flags) = state.add_with_carry(a, -b_shifted, 0)
+        (result, flags) = state.subtract_with_borrow(a, b_shifted, 0)
         state.wreg[self.wrd] = result
         state.flags[self.flag_group] = flags
 
@@ -525,12 +525,14 @@ class BNSUBB(OTBNInsn):
         self.flag_group = op_vals['flag_group']
 
     def execute(self, state: OTBNState) -> None:
+        assert (state.flags[self.flag_group].C == 0 or
+                state.flags[self.flag_group].C == 1)
+
         a = int(state.wreg[self.wrs1])
         b_shifted = ShiftReg(int(state.wreg[self.wrs2]), self.shift_type,
                              self.shift_bytes)
-        (result,
-         flags) = state.add_with_carry(a, -b_shifted,
-                                       1 - state.flags[self.flag_group].C)
+        flag_c = state.flags[self.flag_group].C
+        (result, flags) = state.subtract_with_borrow(a, b_shifted, flag_c)
         state.wreg[self.wrd] = result
         state.flags[self.flag_group] = flags
 
@@ -548,7 +550,7 @@ class BNSUBI(OTBNInsn):
     def execute(self, state: OTBNState) -> None:
         a = int(state.wreg[self.wrs])
         b = int(self.imm)
-        (result, flags) = state.add_with_carry(a, -b, 0)
+        (result, flags) = state.subtract_with_borrow(a, b, 0)
         state.wreg[self.wrd] = result
         state.flags[self.flag_group] = flags
 
@@ -565,7 +567,7 @@ class BNSUBM(OTBNInsn):
     def execute(self, state: OTBNState) -> None:
         a = int(state.wreg[self.wrs1])
         b = int(state.wreg[self.wrs2])
-        result, _ = state.add_with_carry(a, -b, 0)
+        result, _ = state.subtract_with_borrow(a, b, 0)
         if result < 0:
             result += state.mod
         state.wreg[self.wrd] = result
@@ -698,7 +700,7 @@ class BNCMP(OTBNInsn):
         a = int(state.wreg[self.wrs1])
         b_shifted = ShiftReg(int(state.wreg[self.wrs2]), self.shift_type,
                              self.shift_bytes)
-        (_, flags) = state.add_with_carry(a, -b_shifted, 0)
+        (_, flags) = state.subtract_with_borrow(a, b_shifted, 0)
         state.flags[self.flag_group] = flags
 
 
@@ -714,11 +716,13 @@ class BNCMPB(OTBNInsn):
         self.flag_group = op_vals['flag_group']
 
     def execute(self, state: OTBNState) -> None:
+        assert (state.flags[self.flag_group].C == 0 or
+                state.flags[self.flag_group].C == 1)
         a = int(state.wreg[self.wrs1])
         b_shifted = ShiftReg(int(state.wreg[self.wrs2]), self.shift_type,
                              self.shift_bytes)
-        carry_flag = 1 - state.flags[self.flag_group].C
-        (_, flags) = state.add_with_carry(a, -b_shifted, carry_flag)
+        flag_c = state.flags[self.flag_group].C
+        (_, flags) = state.subtract_with_borrow(a, b_shifted, flag_c)
         state.flags[self.flag_group] = flags
 
 

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -407,6 +407,14 @@ class OTBNState:
 
         return (carryless_result, FlagReg.mlz_for_result(C, carryless_result))
 
+    @staticmethod
+    def subtract_with_borrow(a: int, b: int, borrow_in: int) -> Tuple[int, FlagReg]:
+        result = a - b - borrow_in
+        carryless_result = result & ((1 << 256) - 1)
+        C = bool((result >> 256) & 1)
+
+        return (carryless_result, FlagReg.mlz_for_result(C, carryless_result))
+
     def update_mlz_flags(self, fg: int, result: int) -> None:
         '''Update M, L, Z flags for the given result'''
         self.flags[fg] = FlagReg.mlz_for_result(self.flags[fg].C, result)

--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -167,6 +167,8 @@ module otbn_controller
     unique case (insn_dec_ctrl_i.op_a_sel)
       OpASelRegister:
         alu_base_operation_o.operand_a = rf_base_rd_data_a_i;
+      OpASelZero:
+        alu_base_operation_o.operand_a = '0;
       OpASelCurrPc:
         alu_base_operation_o.operand_a = {{(32 - ImemAddrWidth){1'b0}}, insn_addr_i};
       default:

--- a/hw/ip/otbn/rtl/otbn_decoder.sv
+++ b/hw/ip/otbn/rtl/otbn_decoder.sv
@@ -327,7 +327,7 @@ module otbn_decoder
   always_comb begin
     alu_operator        = AluOpAdd;
     comparison_operator = ComparisonOpEq;
-    alu_op_a_mux_sel    = OpASelImmediate;
+    alu_op_a_mux_sel    = OpASelRegister;
     alu_op_b_mux_sel    = OpBSelImmediate;
 
     imm_a_mux_sel       = ImmAZero;
@@ -341,7 +341,7 @@ module otbn_decoder
       /////////
 
       InsnOpcodeBaseLui: begin  // Load Upper Immediate
-        alu_op_a_mux_sel  = OpASelImmediate;
+        alu_op_a_mux_sel  = OpASelZero;
         alu_op_b_mux_sel  = OpBSelImmediate;
         imm_a_mux_sel     = ImmAZero;
         imm_b_mux_sel     = ImmBU;

--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -84,7 +84,7 @@ package otbn_pkg;
   // Operand a source selection
   typedef enum logic [1:0] {
     OpASelRegister  = 'd0,
-    OpASelImmediate = 'd1,
+    OpASelZero = 'd1,
     OpASelFwd = 'd2,
     OpASelCurrPc = 'd3
   } op_a_sel_e;

--- a/hw/ip/otbn/util/build.sh
+++ b/hw/ip/otbn/util/build.sh
@@ -27,6 +27,6 @@ OTBN_UTIL_DIR=$(dirname "$SCRIPT_FILE")
 
 $OTBN_UTIL_DIR/otbn-as $1 -o $2.o
 $OTBN_UTIL_DIR/otbn-ld $2.o -o $2.elf
-$OTBN_UTIL_DIR/otbn-objdump -fhSD $2.elf > $2.dis
+$OTBN_UTIL_DIR/otbn-objdump -f -h -S -D $2.elf > $2.dis
 riscv32-unknown-elf-objcopy -j .text $2.elf $2_imem.elf
 riscv32-unknown-elf-objcopy -j .data $2.elf $2_dmem.elf

--- a/hw/ip/otbn/util/otbn-objdump
+++ b/hw/ip/otbn/util/otbn-objdump
@@ -132,7 +132,10 @@ def main() -> int:
             return subprocess.run(cmd).returncode
         else:
             cmd = [objdump, '-M', 'numeric,no-aliases'] + args
-            proc = subprocess.run(cmd, capture_output=True, text=True)
+            proc = subprocess.run(cmd,
+                                  stdout=subprocess.PIPE,
+                                  stderr=subprocess.PIPE,
+                                  universal_newlines=True)
             if proc.returncode:
                 # Dump any lines that objdump wrote before it died
                 sys.stderr.write(proc.stderr)


### PR DESCRIPTION
Various little things I came across whilst working on the bignum ALU.

@felixmiller could you check what I did to the 'subb' and 'cmpb' behaviour in the simulator (the change in  hw/ip/otbn/dv/otbnsim/sim/insn.py)? This is what I've ended up implementing in RTL. If carry set that's interpreted as a borrow flag so any 'subb' or 'cmpb' needs to subtract 1 off what it computes. Previously the python would just flip 0 to 1 and vice versa so  you'd compute a - b + 0 or a - b + 1 which didn't seem to make sense. Certainly the behaviour added here matches what wikipedia says about borrow flags (https://en.wikipedia.org/wiki/Carry_flag#Vs._borrow_flag)