### PR TITLE
[dv/common] TLUL self-check testbench

### DIFF
--- a/hw/dv/sv/tl_agent/dv/env/seq_lib/tl_agent_base_vseq.sv
+++ b/hw/dv/sv/tl_agent/dv/env/seq_lib/tl_agent_base_vseq.sv
@@ -1,0 +1,43 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// ---------------------------------------------
+// tl_agent environment virtual sequence
+// ---------------------------------------------
+class tl_agent_base_vseq extends dv_base_vseq #(.CFG_T               (tl_agent_env_cfg),
+                                                .COV_T               (tl_agent_env_cov),
+                                                .VIRTUAL_SEQUENCER_T (tl_agent_virtual_sequencer));
+  uint min_req_cnt = 100;
+  uint max_req_cnt = 200;
+
+  rand bit out_of_order_rsp = 1;
+
+  `uvm_object_utils(tl_agent_base_vseq)
+  `uvm_object_new
+
+  virtual task run_device_seq_nonblocking();
+    fork begin
+      tl_device_seq device_seq;
+      device_seq = tl_device_seq::type_id::create("device_seq");
+      `DV_CHECK_RANDOMIZE_FATAL(device_seq)
+      device_seq.out_of_order_rsp = out_of_order_rsp;
+      device_seq.start(p_sequencer.device_seqr);
+    end join_none
+  endtask
+
+  virtual task run_host_seq();
+    tl_host_seq host_seq;
+    host_seq = tl_host_seq::type_id::create("host_seq");
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(host_seq,
+                                   req_cnt inside {[min_req_cnt : max_req_cnt]};)
+    host_seq.start(p_sequencer.host_seqr);
+    `uvm_info(`gfn, $sformatf("host_seq finished sending %0d requests", host_seq.req_cnt), UVM_LOW)
+  endtask
+
+  virtual task body();
+    run_device_seq_nonblocking();
+    repeat (num_trans) run_host_seq();
+  endtask
+
+endclass

--- a/hw/dv/sv/tl_agent/dv/env/seq_lib/tl_agent_vseq_list.sv
+++ b/hw/dv/sv/tl_agent/dv/env/seq_lib/tl_agent_vseq_list.sv
@@ -1,0 +1,5 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`include "tl_agent_base_vseq.sv"

--- a/hw/dv/sv/tl_agent/dv/env/tl_agent_env.core
+++ b/hw/dv/sv/tl_agent/dv/env/tl_agent_env.core
@@ -1,0 +1,26 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:tl_agent_env:0.1"
+description: "tl_agent DV UVM environmnt"
+filesets:
+  files_dv:
+    depend:
+      - lowrisc:dv:dv_lib
+      - lowrisc:dv:tl_agent
+      - lowrisc:dv:scoreboard
+    files:
+      - tl_agent_env_pkg.sv
+      - tl_agent_env_cfg.sv: {is_include_file: true}
+      - tl_agent_virtual_sequencer.sv: {is_include_file: true}
+      - tl_agent_env.sv: {is_include_file: true}
+      - tl_agent_scoreboard.sv: {is_include_file: true}
+      - seq_lib/tl_agent_vseq_list.sv: {is_include_file: true}
+      - seq_lib/tl_agent_base_vseq.sv: {is_include_file: true}
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_dv

--- a/hw/dv/sv/tl_agent/dv/env/tl_agent_env.sv
+++ b/hw/dv/sv/tl_agent/dv/env/tl_agent_env.sv
@@ -1,0 +1,68 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// ---------------------------------------------
+// tl_agent environment class
+// ---------------------------------------------
+class tl_agent_env extends dv_base_env #(.CFG_T               (tl_agent_env_cfg),
+                                         .VIRTUAL_SEQUENCER_T (tl_agent_virtual_sequencer),
+                                         .SCOREBOARD_T        (tl_agent_scoreboard),
+                                         .COV_T               (tl_agent_env_cov));
+
+  tl_agent host_agent;
+  tl_agent device_agent;
+
+  `uvm_component_utils(tl_agent_env)
+  `uvm_component_new
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    // Connect TileLink host and device agents
+    host_agent = tl_agent::type_id::create("host_agent", this);
+    uvm_config_db#(tl_agent_cfg)::set(this, "host_agent", "cfg", cfg.host_agent_cfg);
+
+    device_agent = tl_agent::type_id::create("device_agent", this);
+    uvm_config_db#(tl_agent_cfg)::set(this, "device_agent", "cfg", cfg.device_agent_cfg);
+
+    if (cfg.zero_delays) begin
+      cfg.host_agent_cfg.a_valid_delay_min = 0;
+      cfg.host_agent_cfg.a_valid_delay_max = 0;
+      cfg.host_agent_cfg.d_ready_delay_min = 0;
+      cfg.host_agent_cfg.d_ready_delay_max = 0;
+      cfg.device_agent_cfg.d_valid_delay_min = 0;
+      cfg.device_agent_cfg.d_valid_delay_max = 0;
+      cfg.device_agent_cfg.a_ready_delay_min = 0;
+      cfg.device_agent_cfg.a_ready_delay_max = 0;
+    end
+
+    // create analysis_fifos and scoreboard_queue
+    scoreboard.add_item_port("host_req_chan", scoreboard_pkg::kSrcPort);
+    scoreboard.add_item_port("host_rsp_chan", scoreboard_pkg::kDstPort);
+
+    scoreboard.add_item_port("device_req_chan", scoreboard_pkg::kDstPort);
+    scoreboard.add_item_port("device_rsp_chan", scoreboard_pkg::kSrcPort);
+
+    scoreboard.add_item_queue("req_chan", scoreboard_pkg::kInOrderCheck);
+    scoreboard.add_item_queue("rsp_chan", scoreboard_pkg::kInOrderCheck);
+  endfunction : build_phase
+
+  function void connect_phase(uvm_phase phase);
+    super.connect_phase(phase);
+    // Connect virtual sequencer
+    if (cfg.is_active) begin
+      virtual_sequencer.host_seqr = host_agent.sequencer;
+      virtual_sequencer.device_seqr = device_agent.sequencer;
+    end
+    // Connect scoreboard
+    host_agent.monitor.a_chan_port.connect(
+          scoreboard.item_fifos["host_req_chan"].analysis_export);
+    host_agent.monitor.d_chan_port.connect(
+        scoreboard.item_fifos["host_rsp_chan"].analysis_export);
+    device_agent.monitor.a_chan_port.connect(
+        scoreboard.item_fifos["device_req_chan"].analysis_export);
+    device_agent.monitor.d_chan_port.connect(
+        scoreboard.item_fifos["device_rsp_chan"].analysis_export);
+  endfunction : connect_phase
+
+endclass

--- a/hw/dv/sv/tl_agent/dv/env/tl_agent_env_cfg.sv
+++ b/hw/dv/sv/tl_agent/dv/env/tl_agent_env_cfg.sv
@@ -1,0 +1,32 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// ---------------------------------------------
+// tl_agent environment configuration class
+// ---------------------------------------------
+class tl_agent_env_cfg extends dv_base_env_cfg;
+
+  rand tl_agent_cfg  host_agent_cfg;
+  rand tl_agent_cfg  device_agent_cfg;
+
+  `uvm_object_utils_begin(tl_agent_env_cfg)
+    `uvm_field_object(host_agent_cfg,    UVM_DEFAULT)
+    `uvm_field_object(device_agent_cfg,  UVM_DEFAULT)
+  `uvm_object_utils_end
+
+  `uvm_object_new
+
+  virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);
+    has_ral = 0; // no csr in tl_agent
+    host_agent_cfg = tl_agent_cfg::type_id::create("host_agent_cfg");
+    host_agent_cfg.max_outstanding_req = 1 << SourceWidth;
+    host_agent_cfg.if_mode = dv_utils_pkg::Host;
+
+    device_agent_cfg = tl_agent_cfg::type_id::create("device_agent_cfg");
+    device_agent_cfg.if_mode = dv_utils_pkg::Device;
+    device_agent_cfg.max_outstanding_req = 1 << SourceWidth;
+    device_agent_cfg.device_can_rsp_on_same_cycle = 1;
+  endfunction
+
+endclass

--- a/hw/dv/sv/tl_agent/dv/env/tl_agent_env_pkg.sv
+++ b/hw/dv/sv/tl_agent/dv/env/tl_agent_env_pkg.sv
@@ -1,0 +1,25 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// ---------------------------------------------
+// tl_agent environment package
+// ---------------------------------------------
+package tl_agent_env_pkg;
+
+  import uvm_pkg::*;
+  import top_pkg::*;
+  import dv_utils_pkg::*;
+  import tl_agent_pkg::*;
+  import dv_lib_pkg::*;
+
+  typedef class tl_agent_env_cfg;
+  typedef dv_base_env_cov #(.CFG_T(tl_agent_env_cfg)) tl_agent_env_cov;
+
+  `include "tl_agent_env_cfg.sv"
+  `include "tl_agent_virtual_sequencer.sv"
+  `include "tl_agent_scoreboard.sv"
+  `include "tl_agent_env.sv"
+  `include "tl_agent_vseq_list.sv"
+
+endpackage

--- a/hw/dv/sv/tl_agent/dv/env/tl_agent_scoreboard.sv
+++ b/hw/dv/sv/tl_agent/dv/env/tl_agent_scoreboard.sv
@@ -1,0 +1,25 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// ------------------------------------------------------------------------
+// tl_agent scoreboard class
+// Extend from common multi-streams scoreboard
+// Use the device address map to determine the queue ID
+// ------------------------------------------------------------------------
+class tl_agent_scoreboard extends scoreboard_pkg::scoreboard #(.ITEM_T(tl_seq_item),
+                                                               .CFG_T (tl_agent_env_cfg),
+                                                               .COV_T (tl_agent_env_cov));
+  int chan_prefix_len = 7;
+
+  `uvm_component_utils(tl_agent_scoreboard)
+  `uvm_component_new
+
+  // "host_req_chan", "device_req_chan" -> queue "req_chan"
+  // "host_rsp_chan", "device_rsp_chan" -> queue "rsp_chan"
+  virtual function string get_queue_name(tl_seq_item tr, string port_name);
+    if (port_name inside {"host_req_chan", "device_req_chan"}) return "req_chan";
+    else                                                       return "rsp_chan";
+  endfunction
+
+endclass

--- a/hw/dv/sv/tl_agent/dv/env/tl_agent_virtual_sequencer.sv
+++ b/hw/dv/sv/tl_agent/dv/env/tl_agent_virtual_sequencer.sv
@@ -1,0 +1,16 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// ---------------------------------------------
+// tl_agent environment virtual sequencer
+// ---------------------------------------------
+class tl_agent_virtual_sequencer extends dv_base_virtual_sequencer #(.CFG_T(tl_agent_env_cfg),
+                                                                     .COV_T(tl_agent_env_cov));
+
+  tl_sequencer host_seqr;
+  tl_sequencer device_seqr;
+
+  `uvm_component_utils(tl_agent_virtual_sequencer)
+  `uvm_component_new
+endclass

--- a/hw/dv/sv/tl_agent/dv/tb/tb.sv
+++ b/hw/dv/sv/tl_agent/dv/tb/tb.sv
@@ -1,0 +1,34 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+module tb;
+  // dep packages
+  import uvm_pkg::*;
+  import dv_utils_pkg::*;
+  import tl_agent_pkg::*;
+  import tl_agent_env_pkg::*;
+
+  // macro includes
+  `include "uvm_macros.svh"
+  `include "dv_macros.svh"
+
+  wire clk, rst_n;
+  clk_rst_if clk_rst_if(.clk, .rst_n);
+  tl_if tl_host_if(.clk, .rst_n);
+  tl_if tl_device_if(.clk, .rst_n);
+
+  assign tl_device_if.h2d = tl_host_if.h2d;
+  assign tl_host_if.d2h   = tl_device_if.d2h;
+
+  initial begin
+    // drive clk and rst_n from clk_if
+    clk_rst_if.set_active();
+    uvm_config_db#(virtual clk_rst_if)::set(null, "*.env*", "clk_rst_vif", clk_rst_if);
+    uvm_config_db#(virtual tl_if)::set(null, "*.env.host_agent*", "vif", tl_host_if);
+    uvm_config_db#(virtual tl_if)::set(null, "*.env.device_agent*", "vif", tl_device_if);
+    $timeformat(-12, 0, " ps", 12);
+    run_test();
+  end
+
+endmodule

--- a/hw/dv/sv/tl_agent/dv/tests/tl_agent_base_test.sv
+++ b/hw/dv/sv/tl_agent/dv/tests/tl_agent_base_test.sv
@@ -1,0 +1,10 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class tl_agent_base_test extends dv_base_test #(.ENV_T(tl_agent_env), .CFG_T(tl_agent_env_cfg));
+  `uvm_component_utils(tl_agent_base_test)
+  `uvm_component_new
+
+endclass : tl_agent_base_test
+

--- a/hw/dv/sv/tl_agent/dv/tests/tl_agent_test.core
+++ b/hw/dv/sv/tl_agent/dv/tests/tl_agent_test.core
@@ -1,0 +1,19 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:tl_agent_test:0.1"
+description: "tl_agent DV UVM test"
+filesets:
+  files_dv:
+    depend:
+      - lowrisc:dv:tl_agent_env
+    files:
+      - tl_agent_test_pkg.sv
+      - tl_agent_base_test.sv: {is_include_file: true}
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_dv

--- a/hw/dv/sv/tl_agent/dv/tests/tl_agent_test_pkg.sv
+++ b/hw/dv/sv/tl_agent/dv/tests/tl_agent_test_pkg.sv
@@ -1,0 +1,17 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package tl_agent_test_pkg;
+  // dep packages
+  import uvm_pkg::*;
+  import dv_lib_pkg::*;
+  import tl_agent_env_pkg::*;
+
+  // macro includes
+  `include "uvm_macros.svh"
+  `include "dv_macros.svh"
+
+  // package sources
+  `include "tl_agent_base_test.sv"
+endpackage

--- a/hw/dv/sv/tl_agent/dv/tl_agent_sim.core
+++ b/hw/dv/sv/tl_agent/dv/tl_agent_sim.core
@@ -1,0 +1,20 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:tl_agent_sim:0.1"
+description: "tl_agent DV sim target"
+filesets:
+  files_dv:
+    depend:
+      - lowrisc:dv:tl_agent_test
+    files:
+      - tb/tb.sv
+    file_type: systemVerilogSource
+
+targets:
+  sim: &sim_target
+    toplevel: tb
+    filesets:
+      - files_dv
+    default_tool: vcs

--- a/hw/dv/sv/tl_agent/dv/tl_agent_sim_cfg.hjson
+++ b/hw/dv/sv/tl_agent/dv/tl_agent_sim_cfg.hjson
@@ -1,0 +1,46 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  // Name of the sim cfg - typically same as the name of the DUT.
+  name: tl_agent
+
+  // Top level dut name (sv module).
+  dut: tl_host_if
+
+  // Top level testbench name (sv module).
+  tb: tb
+
+  // Simulator used to sign off this block
+  tool: vcs
+
+  // Fusesoc core file used for building the file list.
+  fusesoc_core: lowrisc:dv:tl_agent_sim:0.1
+
+  // Import additional common sim cfg files.
+  import_cfgs: [// Project wide common sim cfg file
+                "{proj_root}/hw/dv/data/common_sim_cfg.hjson"]
+
+  // Default iterations for all tests - each test entry can override this.
+  reseed: 50
+
+  // Default UVM test and seq class name.
+  uvm_test: tl_agent_base_test
+  uvm_test_seq: tl_agent_base_vseq
+
+  // List of test specifications.
+  tests: [
+    {
+      name: tl_agent_sanity
+      uvm_test_seq: tl_agent_base_vseq
+    }
+  ]
+
+  // List of regressions.
+  regressions: [
+    {
+      name: sanity
+      tests: ["tl_agent_sanity"]
+    }
+  ]
+}


### PR DESCRIPTION
Create a TB in order to verify some features which isn't supported by
design, like device same cycle response

This TB contains a scoreboard to check if req/rsp are correct
Can be used for reference to develop the other agent TB

Here is the waveform with +zero_delays=1 and same cycle response enabled
![Screen Shot 2020-09-17 at 4 08 28 PM](https://user-images.githubusercontent.com/49293026/93537545-a44c4700-f900-11ea-98d2-5a7ba1411907.png)

Signed-off-by: Weicai Yang <weicai@google.com>