### PR TITLE
[dv/common] TL agent to drop valid without ready

### DIFF
--- a/hw/dv/sv/tl_agent/tl_agent_cfg.sv
+++ b/hw/dv/sv/tl_agent/tl_agent_cfg.sv
@@ -22,6 +22,25 @@ class tl_agent_cfg extends dv_base_agent_cfg;
   // Then compare this value with designers to check if it meets their expectation
   int unsigned max_outstanding_req = 16;
 
+  // If allow_a_valid_drop_wo_a_ready then the host can de-assert valid if there is no response from
+  // the device on the A channel. The other knobs control how this works. Each transaction has a
+  // "valid_len". If the host hasn't seen a ready after holding valid high for that many cycles, it
+  // will de-assert valid for a time before retrying.
+  //
+  // If use_seq_item_a_valid_len is true then valid_len will be read from the sequence item (field
+  // a_valid_len). If not, it will be picked uniformly between a_valid_len_min and a_valid_len_max.
+  bit allow_a_valid_drop_wo_a_ready = 1;
+  bit use_seq_item_a_valid_len;
+  int unsigned a_valid_len_min = 1;
+  int unsigned a_valid_len_max = 10;
+
+  // Knobs controlling when we de-assert valid in device mode: see above for the host mode
+  // equivalent.
+  bit use_seq_item_d_valid_len;
+  bit allow_d_valid_drop_wo_d_ready;
+  int unsigned d_valid_len_min = 1;
+  int unsigned d_valid_len_max = 10;
+
   // TileLink channel valid delay (host mode)
   bit use_seq_item_a_valid_delay;
   int unsigned a_valid_delay_min = 0;

--- a/hw/dv/sv/tl_agent/tl_device_driver.sv
+++ b/hw/dv/sv/tl_agent/tl_device_driver.sv
@@ -50,32 +50,57 @@ class tl_device_driver extends tl_base_driver;
     tl_seq_item rsp;
 
     forever begin
-      int unsigned d_valid_delay;
+      int unsigned d_valid_delay, d_valid_len, d_valid_cnt;
+      bit rsp_done;
       seq_item_port.get_next_item(rsp);
-      if (cfg.use_seq_item_d_valid_delay) begin
-        d_valid_delay = rsp.d_valid_delay;
-      end else begin
-        d_valid_delay = $urandom_range(cfg.d_valid_delay_min, cfg.d_valid_delay_max);
-      end
-      // break delay loop if reset asserted to release blocking
-      repeat (d_valid_delay) begin
-        if (!cfg.vif.rst_n) break;
-        else @(cfg.vif.device_cb);
-      end
-      if (cfg.vif.rst_n) begin
-        cfg.vif.d2h_int.d_valid  <= 1'b1;
-        cfg.vif.d2h_int.d_opcode <= tl_d_op_e'(rsp.d_opcode);
-        cfg.vif.d2h_int.d_data   <= rsp.d_data;
-        cfg.vif.d2h_int.d_source <= rsp.d_source;
-        cfg.vif.d2h_int.d_param  <= rsp.d_param;
-        cfg.vif.d2h_int.d_error  <= rsp.d_error;
-        cfg.vif.d2h_int.d_sink   <= rsp.d_sink;
-        cfg.vif.d2h_int.d_user   <= rsp.d_user;
-        cfg.vif.d2h_int.d_size   <= rsp.d_size;
-        // bypass delay in case of reset
-        @(cfg.vif.device_cb);
-      end
-      while (!cfg.vif.device_cb.h2d.d_ready && cfg.vif.rst_n) @(cfg.vif.device_cb);
+
+      while (!rsp_done && cfg.vif.rst_n) begin
+        if (cfg.use_seq_item_d_valid_delay) begin
+          d_valid_delay = rsp.d_valid_delay;
+        end else begin
+          d_valid_delay = $urandom_range(cfg.d_valid_delay_min, cfg.d_valid_delay_max);
+        end
+
+        if (cfg.allow_d_valid_drop_wo_d_ready) begin
+          if (cfg.use_seq_item_d_valid_len) begin
+            d_valid_len = rsp.d_valid_len;
+          end else begin
+            d_valid_len = $urandom_range(cfg.d_valid_len_min, cfg.d_valid_len_max);
+          end
+        end
+
+        // break delay loop if reset asserted to release blocking
+        repeat (d_valid_delay) begin
+          if (!cfg.vif.rst_n) break;
+          else @(cfg.vif.device_cb);
+        end
+        if (cfg.vif.rst_n) begin
+          cfg.vif.d2h_int.d_valid  <= 1'b1;
+          cfg.vif.d2h_int.d_opcode <= tl_d_op_e'(rsp.d_opcode);
+          cfg.vif.d2h_int.d_data   <= rsp.d_data;
+          cfg.vif.d2h_int.d_source <= rsp.d_source;
+          cfg.vif.d2h_int.d_param  <= rsp.d_param;
+          cfg.vif.d2h_int.d_error  <= rsp.d_error;
+          cfg.vif.d2h_int.d_sink   <= rsp.d_sink;
+          cfg.vif.d2h_int.d_user   <= rsp.d_user;
+          cfg.vif.d2h_int.d_size   <= rsp.d_size;
+        end
+
+        // wait for ready or reaching d_valid_len
+        d_valid_cnt = 0;
+        while (cfg.vif.rst_n) begin
+          @(cfg.vif.device_cb);
+          d_valid_cnt++;
+          if (cfg.vif.device_cb.h2d.d_ready) begin
+            rsp_done = 1;
+            break;
+          end else if (cfg.allow_d_valid_drop_wo_d_ready && d_valid_cnt >= d_valid_len) begin
+            invalidate_d_channel();
+            if (!cfg.vif.rst_n) @(cfg.vif.device_cb);
+            break;
+          end
+        end // while (!cfg.vif.rst_n)
+      end // while (!rsp_done && cfg.vif.rst_n)
       invalidate_d_channel();
       seq_item_port.item_done();
     end

--- a/hw/dv/sv/tl_agent/tl_seq_item.sv
+++ b/hw/dv/sv/tl_agent/tl_seq_item.sv
@@ -56,9 +56,11 @@ class tl_seq_item extends uvm_sequence_item;
 
   // host mode delays
   rand int unsigned               a_valid_delay;
+  rand int unsigned               a_valid_len;
 
   // device mode delays
   rand int unsigned               d_valid_delay;
+  rand int unsigned               d_valid_len;
 
   // param is reserved for future use, must be zero
   constraint param_c {
@@ -68,6 +70,14 @@ class tl_seq_item extends uvm_sequence_item;
 
   constraint no_d_error_c {
     soft d_error == 0;
+  }
+
+  constraint a_valid_len_c {
+    soft a_valid_len inside {[1:10]};
+  }
+
+  constraint d_valid_len_c {
+    soft d_valid_len inside {[1:10]};
   }
 
   constraint valid_delay_c {

--- a/hw/ip/tlul/generic_dv/env/xbar_env_cfg.sv
+++ b/hw/ip/tlul/generic_dv/env/xbar_env_cfg.sv
@@ -14,6 +14,13 @@ class xbar_env_cfg extends dv_base_env_cfg;
   uint               num_enabled_hosts;
   // Num of valid host source id bits, the upper bits should be tied to zero
   uint               valid_host_id_width;
+  // enable to drop valid without ready
+  rand bit           allow_host_drop_valid_wo_ready;
+  rand bit           allow_device_drop_valid_wo_ready;
+  uint               min_host_valid_len   = 1;
+  uint               max_host_valid_len   = 50;
+  uint               min_device_valid_len = 1;
+  uint               max_device_valid_len = 50;
   // delays for TL transaction
   uint               min_host_req_delay   = 0;
   uint               max_host_req_delay   = 20;
@@ -54,6 +61,7 @@ class xbar_env_cfg extends dv_base_env_cfg;
       device_agent_cfg[i] = tl_agent_cfg::type_id::
                             create($sformatf("%0s_agent_cfg", xbar_devices[i].device_name));
       device_agent_cfg[i].if_mode = dv_utils_pkg::Device;
+      device_agent_cfg[i].allow_d_valid_drop_wo_d_ready = allow_device_drop_valid_wo_ready;
       // the max_outstanding_req depends on how many hosts can access the device
       // device.max_outstanding_req = sum(all its hosts max_outstanding_req)
       device_agent_cfg[i].max_outstanding_req = 0; // clear default value
@@ -63,5 +71,27 @@ class xbar_env_cfg extends dv_base_env_cfg;
         end
       end // foreach (xbar_hosts[j])
     end // foreach (device_agent_cfg[i])
+  endfunction
+
+  // update TLUL agent cfg according to this env cfg. These values may be updated in test
+  virtual function void update_agent_cfg();
+    foreach (host_agent_cfg[i]) begin
+      host_agent_cfg[i].allow_a_valid_drop_wo_a_ready = allow_host_drop_valid_wo_ready;
+      host_agent_cfg[i].a_valid_len_min   = min_host_valid_len;
+      host_agent_cfg[i].a_valid_len_max   = max_host_valid_len;
+      host_agent_cfg[i].a_valid_delay_min = min_host_req_delay;
+      host_agent_cfg[i].a_valid_delay_max = max_host_req_delay;
+      host_agent_cfg[i].d_ready_delay_min = min_host_rsp_delay;
+      host_agent_cfg[i].d_ready_delay_max = max_host_rsp_delay;
+    end
+    foreach (device_agent_cfg[i]) begin
+      device_agent_cfg[i].allow_d_valid_drop_wo_d_ready = allow_device_drop_valid_wo_ready;
+      device_agent_cfg[i].d_valid_len_min   = min_device_valid_len;
+      device_agent_cfg[i].d_valid_len_max   = max_device_valid_len;
+      device_agent_cfg[i].d_valid_delay_min = min_device_req_delay;
+      device_agent_cfg[i].d_valid_delay_max = max_device_req_delay;
+      device_agent_cfg[i].a_ready_delay_min = min_device_rsp_delay;
+      device_agent_cfg[i].a_ready_delay_max = max_device_rsp_delay;
+    end
   endfunction
 endclass

--- a/hw/ip/tlul/generic_dv/tests/xbar_base_test.sv
+++ b/hw/ip/tlul/generic_dv/tests/xbar_base_test.sv
@@ -12,6 +12,8 @@ class xbar_base_test extends dv_base_test #(.ENV_T(xbar_env), .CFG_T(xbar_env_cf
     super.build_phase(phase);
 
     if (cfg.zero_delays) begin
+      cfg.allow_host_drop_valid_wo_ready = 0;
+      cfg.allow_device_drop_valid_wo_ready = 0;
       cfg.min_host_req_delay   = 0;
       cfg.max_host_req_delay   = 0;
       cfg.min_host_rsp_delay   = 0;
@@ -21,7 +23,14 @@ class xbar_base_test extends dv_base_test #(.ENV_T(xbar_env), .CFG_T(xbar_env_cf
       cfg.min_device_rsp_delay = 0;
       cfg.max_device_rsp_delay = 0;
     end
-    void'($value$plusargs("min_host_req_delay=%d",   cfg.min_host_req_delay));
+    void'($value$plusargs("allow_host_drop_valid_wo_ready=%d",
+                          cfg.allow_host_drop_valid_wo_ready));
+    void'($value$plusargs("allow_device_drop_valid_wo_ready=%d",
+                          cfg.allow_device_drop_valid_wo_ready));
+    void'($value$plusargs("min_host_valid_len=%d",   cfg.min_host_valid_len));
+    void'($value$plusargs("max_host_valid_len=%d",   cfg.max_host_valid_len));
+    void'($value$plusargs("min_device_valid_len=%d", cfg.min_device_valid_len));
+    void'($value$plusargs("max_device_valid_len=%d", cfg.max_device_valid_len));
     void'($value$plusargs("max_host_req_delay=%d",   cfg.max_host_req_delay));
     void'($value$plusargs("min_host_rsp_delay=%d",   cfg.min_host_rsp_delay));
     void'($value$plusargs("max_host_rsp_delay=%d",   cfg.max_host_rsp_delay));
@@ -30,18 +39,7 @@ class xbar_base_test extends dv_base_test #(.ENV_T(xbar_env), .CFG_T(xbar_env_cf
     void'($value$plusargs("min_device_rsp_delay=%d", cfg.min_device_rsp_delay));
     void'($value$plusargs("max_device_rsp_delay=%d", cfg.max_device_rsp_delay));
     void'($value$plusargs("num_enabled_hosts=%d",    cfg.num_enabled_hosts));
-    foreach (cfg.host_agent_cfg[i]) begin
-      cfg.host_agent_cfg[i].a_valid_delay_min = cfg.min_host_req_delay;
-      cfg.host_agent_cfg[i].a_valid_delay_max = cfg.max_host_req_delay;
-      cfg.host_agent_cfg[i].d_ready_delay_min = cfg.min_host_rsp_delay;
-      cfg.host_agent_cfg[i].d_ready_delay_max = cfg.max_host_rsp_delay;
-    end
-    foreach (cfg.device_agent_cfg[i]) begin
-      cfg.device_agent_cfg[i].d_valid_delay_min = cfg.min_device_req_delay;
-      cfg.device_agent_cfg[i].d_valid_delay_max = cfg.max_device_req_delay;
-      cfg.device_agent_cfg[i].a_ready_delay_min = cfg.min_device_rsp_delay;
-      cfg.device_agent_cfg[i].a_ready_delay_max = cfg.max_device_rsp_delay;
-    end
+    cfg.update_agent_cfg();
   endfunction : build_phase
 
 endclass : xbar_base_test

--- a/hw/ip/tlul/generic_dv/xbar_tests.hjson
+++ b/hw/ip/tlul/generic_dv/xbar_tests.hjson
@@ -34,7 +34,9 @@
       run_opts: ["+max_host_req_delay=1000",
                  "+max_host_rsp_delay=1000",
                  "+max_device_req_delay=1000",
-                 "+max_device_rsp_delay=1000"]
+                 "+max_device_rsp_delay=1000",
+                 "+max_host_valid_len=2000",
+                 "+max_device_valid_len=2000"]
     }
 
     {
@@ -45,7 +47,9 @@
       run_opts: ["+max_host_req_delay=10",
                  "+max_host_rsp_delay=1000",
                  "+max_device_req_delay=1000",
-                 "+max_device_rsp_delay=10"]
+                 "+max_device_rsp_delay=10",
+                 "+max_host_valid_len=2000",
+                 "+max_device_valid_len=2000"]
     }
 
     {
@@ -71,7 +75,9 @@
       run_opts: ["+max_host_req_delay=1000",
                  "+max_host_rsp_delay=1000",
                  "+max_device_req_delay=1000",
-                 "+max_device_rsp_delay=1000"]
+                 "+max_device_rsp_delay=1000",
+                 "+max_host_valid_len=2000",
+                 "+max_device_valid_len=2000"]
     }
 
     {
@@ -82,7 +88,9 @@
       run_opts: ["+max_host_req_delay=10",
                  "+max_host_rsp_delay=1000",
                  "+max_device_req_delay=1000",
-                 "+max_device_rsp_delay=10"]
+                 "+max_device_rsp_delay=10",
+                 "+max_host_valid_len=2000",
+                 "+max_device_valid_len=2000"]
     }
 
     {
@@ -100,7 +108,9 @@
       run_opts: ["+max_host_req_delay=10",
                  "+max_host_rsp_delay=1000",
                  "+max_device_req_delay=1000",
-                 "+max_device_rsp_delay=10"]
+                 "+max_device_rsp_delay=10",
+                 "+max_host_valid_len=2000",
+                 "+max_device_valid_len=2000"]
     }
 
     {


### PR DESCRIPTION
Relate to #3383 item 1.
Drop VALID when it lasts for given length even it's not accepted, then re-issue VALID again after a random delay
length of VALID and delay for each time is random and controlled through cfg or seq_item
![Screen Shot 2020-09-17 at 4 35 44 PM](https://user-images.githubusercontent.com/49293026/93538792-dc08be00-f903-11ea-97c8-3f3d5476bad3.png)

In next PR, will implement drop req to end the transaction, in order to
cover #3383 item 2.



Signed-off-by: Weicai Yang <weicai@google.com>