### PR TITLE
[otbn] Add stall support to the ISS

### DIFF
--- a/hw/ip/otbn/data/base-insns.yml
+++ b/hw/ip/otbn/data/base-insns.yml
@@ -253,6 +253,7 @@
     Loads a 32b word from address `offset + grs1` in data memory, writing the result to `grd`.
     Unaligned loads are not supported.
     Any address that is unaligned or is above the top of memory will result in an error (with error code `ErrCodeBadDataAddr`).
+  cycles: 2
   lsu:
     type: mem-load
     target: [offset, grs1]

--- a/hw/ip/otbn/data/bignum-insns.yml
+++ b/hw/ip/otbn/data/bignum-insns.yml
@@ -769,6 +769,7 @@
 
     The memory address must be aligned to WLEN bytes.
     Any address that is unaligned or is above the top of memory will result in an error (with error code `ErrCodeBadDataAddr`).
+  cycles: 2
   decode: |
     rd = UInt(grd)
     rs1 = UInt(grs1)

--- a/hw/ip/otbn/data/insns.yml
+++ b/hw/ip/otbn/data/insns.yml
@@ -82,6 +82,9 @@ encoding-schemes: enc-schemes.yml
 #  straight-line: A boolean. If true, this instruction has no effect on control
 #                 flow. Optional, default true.
 #
+#  insn-cycles: A positive integer, giving the number of cycles that the
+#               instruction takes to execute. Optional, default 1.
+#
 # The operands field should be a list, corresponding to the operands in the
 # order they will appear in the syntax. Each operand is either a string (the
 # operand name) or a dictionary. In the latter case, it has the following

--- a/hw/ip/otbn/dv/otbnsim/sim/decode.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/decode.py
@@ -13,7 +13,7 @@ from typing import List, Optional, Tuple, Type
 
 from .isa import OTBNInsn
 from .insn import INSN_CLASSES
-from .model import OTBNModel
+from .state import OTBNState
 
 # A tuple as returned by get_insn_masks: an element (m0, m1, cls) means "if a
 # word has all the bits in m0 clear and all the bits in m1 set, then you should
@@ -36,9 +36,9 @@ class IllegalInsn(OTBNInsn):
     def __init__(self, word: int) -> None:
         self.word = word
 
-    def execute(self, model: OTBNModel) -> None:
+    def execute(self, state: OTBNState) -> None:
         raise RuntimeError('Illegal instruction at {:#x}: encoding {:#010x}.'
-                           .format(int(model.state.pc), self.word))
+                           .format(int(state.pc), self.word))
 
 
 MASK_TUPLES = None  # type: Optional[List[_MaskTuple]]

--- a/hw/ip/otbn/dv/otbnsim/sim/dmem.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/dmem.py
@@ -129,7 +129,7 @@ class Dmem:
         words are themselves packed little-endian into 256-bit words.
 
         '''
-        u32s = []
+        u32s = []  # type: List[int]
         for idx in range(len(self.data)):
             # As in load_le_words, we also have to reverse each set of 8 words
             # because we're little-endian at this scale too.

--- a/hw/ip/otbn/dv/otbnsim/sim/insn.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/insn.py
@@ -4,7 +4,7 @@
 
 from typing import Dict
 
-from .model import OTBNModel
+from .state import OTBNState
 from .isa import (OTBNInsn, RV32RegReg, RV32RegImm, RV32ImmShift,
                   insn_for_mnemonic,
                   ShiftReg)
@@ -13,18 +13,18 @@ from .isa import (OTBNInsn, RV32RegReg, RV32RegImm, RV32ImmShift,
 class ADD(RV32RegReg):
     insn = insn_for_mnemonic('add', 3)
 
-    def execute(self, model: OTBNModel) -> None:
-        val1 = model.state.intreg[self.grs1]
-        val2 = model.state.intreg[self.grs2]
-        model.state.intreg[self.grd] = val1 + val2
+    def execute(self, state: OTBNState) -> None:
+        val1 = state.intreg[self.grs1]
+        val2 = state.intreg[self.grs2]
+        state.intreg[self.grd] = val1 + val2
 
 
 class ADDI(RV32RegImm):
     insn = insn_for_mnemonic('addi', 3)
 
-    def execute(self, model: OTBNModel) -> None:
-        val1 = model.state.intreg[self.grs1]
-        model.state.intreg[self.grd] = val1 + self.imm
+    def execute(self, state: OTBNState) -> None:
+        val1 = state.intreg[self.grs1]
+        state.intreg[self.grd] = val1 + self.imm
 
 
 class LUI(OTBNInsn):
@@ -35,73 +35,73 @@ class LUI(OTBNInsn):
         self.grd = op_vals['grd']
         self.imm = op_vals['imm']
 
-    def execute(self, model: OTBNModel) -> None:
-        model.state.intreg[self.grd] = (self.imm << 12)
+    def execute(self, state: OTBNState) -> None:
+        state.intreg[self.grd] = (self.imm << 12)
 
 
 class SUB(RV32RegReg):
     insn = insn_for_mnemonic('sub', 3)
 
-    def execute(self, model: OTBNModel) -> None:
-        val1 = model.state.intreg[self.grs1]
-        val2 = model.state.intreg[self.grs2]
-        model.state.intreg[self.grd] = val1 - val2
+    def execute(self, state: OTBNState) -> None:
+        val1 = state.intreg[self.grs1]
+        val2 = state.intreg[self.grs2]
+        state.intreg[self.grd] = val1 - val2
 
 
 class SLL(RV32RegReg):
     insn = insn_for_mnemonic('sll', 3)
 
-    def execute(self, model: OTBNModel) -> None:
-        val1 = model.state.intreg[self.grs1]
-        val2 = model.state.intreg[self.grs2] & 0x1f
-        model.state.intreg[self.grd] = val1 << val2
+    def execute(self, state: OTBNState) -> None:
+        val1 = state.intreg[self.grs1]
+        val2 = state.intreg[self.grs2] & 0x1f
+        state.intreg[self.grd] = val1 << val2
 
 
 class SLLI(RV32ImmShift):
     insn = insn_for_mnemonic('slli', 3)
 
-    def execute(self, model: OTBNModel) -> None:
-        val1 = model.state.intreg[self.grs1]
-        model.state.intreg[self.grd] = val1 << self.shamt
+    def execute(self, state: OTBNState) -> None:
+        val1 = state.intreg[self.grs1]
+        state.intreg[self.grd] = val1 << self.shamt
 
 
 class SRL(RV32RegReg):
     insn = insn_for_mnemonic('srl', 3)
 
-    def execute(self, model: OTBNModel) -> None:
-        val1 = model.state.intreg[self.grs1]
-        val2 = model.state.intreg[self.grs2] & 0x1f
-        model.state.intreg[self.grd] = val1 >> val2
+    def execute(self, state: OTBNState) -> None:
+        val1 = state.intreg[self.grs1]
+        val2 = state.intreg[self.grs2] & 0x1f
+        state.intreg[self.grd] = val1 >> val2
 
 
 class SRLI(RV32ImmShift):
     insn = insn_for_mnemonic('srli', 3)
 
-    def execute(self, model: OTBNModel) -> None:
-        val1 = model.state.intreg[self.grs1]
-        model.state.intreg[self.grd] = val1 >> self.shamt
+    def execute(self, state: OTBNState) -> None:
+        val1 = state.intreg[self.grs1]
+        state.intreg[self.grd] = val1 >> self.shamt
 
 
 class SRA(RV32RegReg):
     insn = insn_for_mnemonic('sra', 3)
 
-    def execute(self, model: OTBNModel) -> None:
-        usrc = model.state.intreg[self.grs1].unsigned()
-        shift = model.state.intreg[self.grs2].unsigned() & 0x1f
+    def execute(self, state: OTBNState) -> None:
+        usrc = state.intreg[self.grs1].unsigned()
+        shift = state.intreg[self.grs2].unsigned() & 0x1f
         if usrc >> 31:
             to_clear = 32 - shift
             sign_mask = (((1 << 32) - 1) >> to_clear) << to_clear
         else:
             sign_mask = 0
 
-        model.state.intreg[self.grd] = sign_mask | (usrc >> shift)
+        state.intreg[self.grd] = sign_mask | (usrc >> shift)
 
 
 class SRAI(RV32ImmShift):
     insn = insn_for_mnemonic('srai', 3)
 
-    def execute(self, model: OTBNModel) -> None:
-        usrc = model.state.intreg[self.grs1].unsigned()
+    def execute(self, state: OTBNState) -> None:
+        usrc = state.intreg[self.grs1].unsigned()
         shift = self.shamt
         if usrc >> 31:
             to_clear = 32 - shift
@@ -109,58 +109,58 @@ class SRAI(RV32ImmShift):
         else:
             sign_mask = 0
 
-        model.state.intreg[self.grd] = sign_mask | (usrc >> shift)
+        state.intreg[self.grd] = sign_mask | (usrc >> shift)
 
 
 class AND(RV32RegReg):
     insn = insn_for_mnemonic('and', 3)
 
-    def execute(self, model: OTBNModel) -> None:
-        val1 = model.state.intreg[self.grs1]
-        val2 = model.state.intreg[self.grs2]
-        model.state.intreg[self.grd] = val1 & val2
+    def execute(self, state: OTBNState) -> None:
+        val1 = state.intreg[self.grs1]
+        val2 = state.intreg[self.grs2]
+        state.intreg[self.grd] = val1 & val2
 
 
 class ANDI(RV32RegImm):
     insn = insn_for_mnemonic('andi', 3)
 
-    def execute(self, model: OTBNModel) -> None:
-        val1 = model.state.intreg[self.grs1]
-        model.state.intreg[self.grd] = val1 & self.imm
+    def execute(self, state: OTBNState) -> None:
+        val1 = state.intreg[self.grs1]
+        state.intreg[self.grd] = val1 & self.imm
 
 
 class OR(RV32RegReg):
     insn = insn_for_mnemonic('or', 3)
 
-    def execute(self, model: OTBNModel) -> None:
-        val1 = model.state.intreg[self.grs1]
-        val2 = model.state.intreg[self.grs2]
-        model.state.intreg[self.grd] = val1 | val2
+    def execute(self, state: OTBNState) -> None:
+        val1 = state.intreg[self.grs1]
+        val2 = state.intreg[self.grs2]
+        state.intreg[self.grd] = val1 | val2
 
 
 class ORI(RV32RegImm):
     insn = insn_for_mnemonic('ori', 3)
 
-    def execute(self, model: OTBNModel) -> None:
-        val1 = model.state.intreg[self.grs1]
-        model.state.intreg[self.grd] = val1 | self.imm
+    def execute(self, state: OTBNState) -> None:
+        val1 = state.intreg[self.grs1]
+        state.intreg[self.grd] = val1 | self.imm
 
 
 class XOR(RV32RegReg):
     insn = insn_for_mnemonic('xor', 3)
 
-    def execute(self, model: OTBNModel) -> None:
-        val1 = model.state.intreg[self.grs1]
-        val2 = model.state.intreg[self.grs2]
-        model.state.intreg[self.grd] = val1 | val2
+    def execute(self, state: OTBNState) -> None:
+        val1 = state.intreg[self.grs1]
+        val2 = state.intreg[self.grs2]
+        state.intreg[self.grd] = val1 | val2
 
 
 class XORI(RV32RegImm):
     insn = insn_for_mnemonic('xori', 3)
 
-    def execute(self, model: OTBNModel) -> None:
-        val1 = model.state.intreg[self.grs1]
-        model.state.intreg[self.grd] = val1 | self.imm
+    def execute(self, state: OTBNState) -> None:
+        val1 = state.intreg[self.grs1]
+        state.intreg[self.grd] = val1 | self.imm
 
 
 class LW(OTBNInsn):
@@ -172,9 +172,9 @@ class LW(OTBNInsn):
         self.offset = op_vals['offset']
         self.grs1 = op_vals['grs1']
 
-    def execute(self, model: OTBNModel) -> None:
-        addr = (model.state.intreg[self.grs1] + self.offset).unsigned()
-        model.state.intreg[self.grd] = model.state.dmem.load_i32(addr)
+    def execute(self, state: OTBNState) -> None:
+        addr = (state.intreg[self.grs1] + self.offset).unsigned()
+        state.intreg[self.grd] = state.dmem.load_i32(addr)
 
 
 class SW(OTBNInsn):
@@ -186,10 +186,10 @@ class SW(OTBNInsn):
         self.offset = op_vals['offset']
         self.grs1 = op_vals['grs1']
 
-    def execute(self, model: OTBNModel) -> None:
-        addr = (model.state.intreg[self.grs1] + self.offset).unsigned()
-        value = int(model.state.intreg[self.grs2])
-        model.state.dmem.store_i32(addr, value)
+    def execute(self, state: OTBNState) -> None:
+        addr = (state.intreg[self.grs1] + self.offset).unsigned()
+        value = int(state.intreg[self.grs2])
+        state.dmem.store_i32(addr, value)
 
 
 class BEQ(OTBNInsn):
@@ -201,11 +201,11 @@ class BEQ(OTBNInsn):
         self.grs2 = op_vals['grs2']
         self.offset = op_vals['offset']
 
-    def execute(self, model: OTBNModel) -> None:
-        val1 = model.state.intreg[self.grs1].value
-        val2 = model.state.intreg[self.grs2].value
+    def execute(self, state: OTBNState) -> None:
+        val1 = state.intreg[self.grs1].value
+        val2 = state.intreg[self.grs2].value
         if val1 == val2:
-            model.state.pc_next = self.offset
+            state.pc_next = self.offset
 
 
 class BNE(OTBNInsn):
@@ -217,11 +217,11 @@ class BNE(OTBNInsn):
         self.grs2 = op_vals['grs2']
         self.offset = op_vals['offset']
 
-    def execute(self, model: OTBNModel) -> None:
-        val1 = model.state.intreg[self.grs1].value
-        val2 = model.state.intreg[self.grs2].value
+    def execute(self, state: OTBNState) -> None:
+        val1 = state.intreg[self.grs1].value
+        val2 = state.intreg[self.grs2].value
         if val1 != val2:
-            model.state.pc_next = self.offset
+            state.pc_next = self.offset
 
 
 class JAL(OTBNInsn):
@@ -232,9 +232,9 @@ class JAL(OTBNInsn):
         self.grd = op_vals['grd']
         self.offset = op_vals['offset']
 
-    def execute(self, model: OTBNModel) -> None:
-        model.state.intreg[self.grd] = model.state.pc + 4
-        model.state.pc_next = self.offset
+    def execute(self, state: OTBNState) -> None:
+        state.intreg[self.grd] = state.pc + 4
+        state.pc_next = self.offset
 
 
 class JALR(OTBNInsn):
@@ -246,9 +246,9 @@ class JALR(OTBNInsn):
         self.grs1 = op_vals['grs1']
         self.offset = op_vals['offset']
 
-    def execute(self, model: OTBNModel) -> None:
-        model.state.intreg[self.grd] = model.state.pc + 4
-        model.state.pc_next = model.state.intreg[self.grs1] + self.offset
+    def execute(self, state: OTBNState) -> None:
+        state.intreg[self.grd] = state.pc + 4
+        state.pc_next = state.intreg[self.grs1] + self.offset
 
 
 class CSRRS(OTBNInsn):
@@ -260,7 +260,7 @@ class CSRRS(OTBNInsn):
         self.csr = op_vals['csr']
         self.grs = op_vals['grs']
 
-    def execute(self, model: OTBNModel) -> None:
+    def execute(self, state: OTBNState) -> None:
         raise NotImplementedError('csrrs.execute')
 
 
@@ -273,7 +273,7 @@ class CSRRW(OTBNInsn):
         self.csr = op_vals['csr']
         self.grs = op_vals['grs']
 
-    def execute(self, model: OTBNModel) -> None:
+    def execute(self, state: OTBNState) -> None:
         raise NotImplementedError('csrrw.execute')
 
 
@@ -284,16 +284,16 @@ class ECALL(OTBNInsn):
         super().__init__(op_vals)
         pass
 
-    def execute(self, model: OTBNModel) -> None:
+    def execute(self, state: OTBNState) -> None:
         # INTR_STATE is the interrupt state register. Bit 0 (which is being
         # set) is the 'done' flag.
-        model.state.ext_regs.set_bits('INTR_STATE', 1 << 0)
+        state.ext_regs.set_bits('INTR_STATE', 1 << 0)
         # STATUS is a status register. Bit 0 (being cleared) is the 'busy' flag
-        model.state.ext_regs.clear_bits('STATUS', 1 << 0)
+        state.ext_regs.clear_bits('STATUS', 1 << 0)
 
         # As well as the external register, clear an internal 'running' flag to
         # tell the simulation to stop.
-        model.state.running = False
+        state.running = False
 
 
 class LOOP(OTBNInsn):
@@ -304,9 +304,9 @@ class LOOP(OTBNInsn):
         self.grs = op_vals['grs']
         self.bodysize = op_vals['bodysize']
 
-    def execute(self, model: OTBNModel) -> None:
-        num_iters = model.state.intreg[self.grs].unsigned()
-        model.state.loop_start(num_iters, self.bodysize)
+    def execute(self, state: OTBNState) -> None:
+        num_iters = state.intreg[self.grs].unsigned()
+        state.loop_start(num_iters, self.bodysize)
 
 
 class LOOPI(OTBNInsn):
@@ -317,8 +317,8 @@ class LOOPI(OTBNInsn):
         self.iterations = op_vals['iterations']
         self.bodysize = op_vals['bodysize']
 
-    def execute(self, model: OTBNModel) -> None:
-        model.state.loop_start(self.iterations, self.bodysize)
+    def execute(self, state: OTBNState) -> None:
+        state.loop_start(self.iterations, self.bodysize)
 
 
 class BNADD(OTBNInsn):
@@ -333,13 +333,13 @@ class BNADD(OTBNInsn):
         self.shift_bytes = op_vals['shift_bytes']
         self.flag_group = op_vals['flag_group']
 
-    def execute(self, model: OTBNModel) -> None:
-        a = int(model.state.wreg[self.wrs1].unsigned())
-        b_shifted = ShiftReg(int(model.state.wreg[self.wrs2].unsigned()),
+    def execute(self, state: OTBNState) -> None:
+        a = int(state.wreg[self.wrs1].unsigned())
+        b_shifted = ShiftReg(int(state.wreg[self.wrs2].unsigned()),
                              self.shift_type, self.shift_bytes)
-        (result, flags) = model.add_with_carry(a, b_shifted, 0)
-        model.state.wreg[self.wrd] = result
-        model.state.flags[self.flag_group] = flags
+        (result, flags) = state.add_with_carry(a, b_shifted, 0)
+        state.wreg[self.wrd] = result
+        state.flags[self.flag_group] = flags
 
 
 class BNADDC(OTBNInsn):
@@ -354,14 +354,14 @@ class BNADDC(OTBNInsn):
         self.shift_bytes = op_vals['shift_bytes']
         self.flag_group = op_vals['flag_group']
 
-    def execute(self, model: OTBNModel) -> None:
-        a = int(model.state.wreg[self.wrs1].unsigned())
-        b_shifted = ShiftReg(int(model.state.wreg[self.wrs2].unsigned()),
+    def execute(self, state: OTBNState) -> None:
+        a = int(state.wreg[self.wrs1].unsigned())
+        b_shifted = ShiftReg(int(state.wreg[self.wrs2].unsigned()),
                              self.shift_type, self.shift_bytes)
-        flag_c = model.state.flags[self.flag_group].C
-        (result, flags) = model.add_with_carry(a, b_shifted, flag_c)
-        model.state.wreg[self.wrd] = result
-        model.state.flags[self.flag_group] = flags
+        flag_c = state.flags[self.flag_group].C
+        (result, flags) = state.add_with_carry(a, b_shifted, flag_c)
+        state.wreg[self.wrd] = result
+        state.flags[self.flag_group] = flags
 
 
 class BNADDI(OTBNInsn):
@@ -374,12 +374,12 @@ class BNADDI(OTBNInsn):
         self.imm = op_vals['imm']
         self.flag_group = op_vals['flag_group']
 
-    def execute(self, model: OTBNModel) -> None:
-        a = int(model.state.wreg[self.wrs].unsigned())
+    def execute(self, state: OTBNState) -> None:
+        a = int(state.wreg[self.wrs].unsigned())
         b = int(self.imm)
-        (result, flags) = model.add_with_carry(a, b, 0)
-        model.state.wreg[self.wrd] = result
-        model.state.flags[self.flag_group] = flags
+        (result, flags) = state.add_with_carry(a, b, 0)
+        state.wreg[self.wrd] = result
+        state.flags[self.flag_group] = flags
 
 
 class BNADDM(OTBNInsn):
@@ -391,13 +391,13 @@ class BNADDM(OTBNInsn):
         self.wrs1 = op_vals['wrs1']
         self.wrs2 = op_vals['wrs2']
 
-    def execute(self, model: OTBNModel) -> None:
-        a = int(model.state.wreg[self.wrs1].unsigned())
-        b = int(model.state.wreg[self.wrs2].unsigned())
-        (result, _) = model.add_with_carry(a, b, 0)
-        if result >= int(model.state.mod):
-            result -= int(model.state.mod)
-        model.state.wreg[self.wrd] = result
+    def execute(self, state: OTBNState) -> None:
+        a = int(state.wreg[self.wrs1].unsigned())
+        b = int(state.wreg[self.wrs2].unsigned())
+        (result, _) = state.add_with_carry(a, b, 0)
+        if result >= int(state.mod):
+            result -= int(state.mod)
+        state.wreg[self.wrd] = result
 
 
 class BNMULQACC(OTBNInsn):
@@ -412,19 +412,19 @@ class BNMULQACC(OTBNInsn):
         self.wrs2_qwsel = op_vals['wrs2_qwsel']
         self.acc_shift_imm = op_vals['acc_shift_imm']
 
-    def execute(self, model: OTBNModel) -> None:
-        a_qw = model.get_wr_quarterword(self.wrs1, self.wrs1_qwsel)
-        b_qw = model.get_wr_quarterword(self.wrs2, self.wrs2_qwsel)
+    def execute(self, state: OTBNState) -> None:
+        a_qw = state.get_wr_quarterword(self.wrs1, self.wrs1_qwsel)
+        b_qw = state.get_wr_quarterword(self.wrs2, self.wrs2_qwsel)
 
         mul_res = a_qw * b_qw
 
-        acc = int(model.state.single_regs['acc'])
+        acc = int(state.single_regs['acc'])
         if self.zero_acc:
             acc = 0
 
         acc += (mul_res << self.acc_shift_imm)
 
-        model.state.single_regs['acc'].update(acc)
+        state.single_regs['acc'].update(acc)
 
 
 class BNMULQACCWO(OTBNInsn):
@@ -440,21 +440,21 @@ class BNMULQACCWO(OTBNInsn):
         self.wrs2_qwsel = op_vals['wrs2_qwsel']
         self.acc_shift_imm = op_vals['acc_shift_imm']
 
-    def execute(self, model: OTBNModel) -> None:
-        a_qw = model.get_wr_quarterword(self.wrs1, self.wrs1_qwsel)
-        b_qw = model.get_wr_quarterword(self.wrs2, self.wrs2_qwsel)
+    def execute(self, state: OTBNState) -> None:
+        a_qw = state.get_wr_quarterword(self.wrs1, self.wrs1_qwsel)
+        b_qw = state.get_wr_quarterword(self.wrs2, self.wrs2_qwsel)
 
         mul_res = a_qw * b_qw
 
-        acc = int(model.state.single_regs['acc'])
+        acc = int(state.single_regs['acc'])
         if self.zero_acc:
             acc = 0
 
         acc += (mul_res << self.acc_shift_imm)
 
-        model.state.wreg[self.wrd].set(acc)
+        state.wreg[self.wrd].set(acc)
 
-        model.state.single_regs['acc'].update(acc)
+        state.single_regs['acc'].update(acc)
 
 
 class BNMULQACCSO(OTBNInsn):
@@ -471,13 +471,13 @@ class BNMULQACCSO(OTBNInsn):
         self.wrs2_qwsel = op_vals['wrs2_qwsel']
         self.acc_shift_imm = op_vals['acc_shift_imm']
 
-    def execute(self, model: OTBNModel) -> None:
-        a_qw = model.get_wr_quarterword(self.wrs1, self.wrs1_qwsel)
-        b_qw = model.get_wr_quarterword(self.wrs2, self.wrs2_qwsel)
+    def execute(self, state: OTBNState) -> None:
+        a_qw = state.get_wr_quarterword(self.wrs1, self.wrs1_qwsel)
+        b_qw = state.get_wr_quarterword(self.wrs2, self.wrs2_qwsel)
 
         mul_res = a_qw * b_qw
 
-        acc = int(model.state.single_regs['acc'])
+        acc = int(state.single_regs['acc'])
         if self.zero_acc:
             acc = 0
 
@@ -485,10 +485,10 @@ class BNMULQACCSO(OTBNInsn):
 
         # set_wr_halfword expects 0 in upper 128 bits
         acc_lower = acc & ((1 << 128) - 1)
-        model.set_wr_halfword(self.wrd, acc_lower, self.wrd_hwsel)
+        state.set_wr_halfword(self.wrd, acc_lower, self.wrd_hwsel)
         acc = acc >> 128
 
-        model.state.single_regs['acc'].update(acc)
+        state.single_regs['acc'].update(acc)
 
 
 class BNSUB(OTBNInsn):
@@ -503,13 +503,13 @@ class BNSUB(OTBNInsn):
         self.shift_bytes = op_vals['shift_bytes']
         self.flag_group = op_vals['flag_group']
 
-    def execute(self, model: OTBNModel) -> None:
-        a = int(model.state.wreg[self.wrs1])
-        b_shifted = ShiftReg(int(model.state.wreg[self.wrs2]), self.shift_type,
+    def execute(self, state: OTBNState) -> None:
+        a = int(state.wreg[self.wrs1])
+        b_shifted = ShiftReg(int(state.wreg[self.wrs2]), self.shift_type,
                              self.shift_bytes)
-        (result, flags) = model.add_with_carry(a, -b_shifted, 0)
-        model.state.wreg[self.wrd] = result
-        model.state.flags[self.flag_group] = flags
+        (result, flags) = state.add_with_carry(a, -b_shifted, 0)
+        state.wreg[self.wrd] = result
+        state.flags[self.flag_group] = flags
 
 
 class BNSUBB(OTBNInsn):
@@ -524,15 +524,15 @@ class BNSUBB(OTBNInsn):
         self.shift_bytes = op_vals['shift_bytes']
         self.flag_group = op_vals['flag_group']
 
-    def execute(self, model: OTBNModel) -> None:
-        a = int(model.state.wreg[self.wrs1])
-        b_shifted = ShiftReg(int(model.state.wreg[self.wrs2]), self.shift_type,
+    def execute(self, state: OTBNState) -> None:
+        a = int(state.wreg[self.wrs1])
+        b_shifted = ShiftReg(int(state.wreg[self.wrs2]), self.shift_type,
                              self.shift_bytes)
         (result,
-         flags) = model.add_with_carry(a, -b_shifted,
-                                       1 - model.state.flags[self.flag_group].C)
-        model.state.wreg[self.wrd] = result
-        model.state.flags[self.flag_group] = flags
+         flags) = state.add_with_carry(a, -b_shifted,
+                                       1 - state.flags[self.flag_group].C)
+        state.wreg[self.wrd] = result
+        state.flags[self.flag_group] = flags
 
 
 class BNSUBI(OTBNInsn):
@@ -545,12 +545,12 @@ class BNSUBI(OTBNInsn):
         self.imm = op_vals['imm']
         self.flag_group = op_vals['flag_group']
 
-    def execute(self, model: OTBNModel) -> None:
-        a = int(model.state.wreg[self.wrs])
+    def execute(self, state: OTBNState) -> None:
+        a = int(state.wreg[self.wrs])
         b = int(self.imm)
-        (result, flags) = model.add_with_carry(a, -b, 0)
-        model.state.wreg[self.wrd] = result
-        model.state.flags[self.flag_group] = flags
+        (result, flags) = state.add_with_carry(a, -b, 0)
+        state.wreg[self.wrd] = result
+        state.flags[self.flag_group] = flags
 
 
 class BNSUBM(OTBNInsn):
@@ -562,13 +562,13 @@ class BNSUBM(OTBNInsn):
         self.wrs1 = op_vals['wrs1']
         self.wrs2 = op_vals['wrs2']
 
-    def execute(self, model: OTBNModel) -> None:
-        a = int(model.state.wreg[self.wrs1])
-        b = int(model.state.wreg[self.wrs2])
-        result, _ = model.add_with_carry(a, -b, 0)
+    def execute(self, state: OTBNState) -> None:
+        a = int(state.wreg[self.wrs1])
+        b = int(state.wreg[self.wrs2])
+        result, _ = state.add_with_carry(a, -b, 0)
         if result < 0:
-            result += model.state.mod
-        model.state.wreg[self.wrd] = result
+            result += state.mod
+        state.wreg[self.wrd] = result
 
 
 class BNAND(OTBNInsn):
@@ -582,11 +582,11 @@ class BNAND(OTBNInsn):
         self.shift_type = op_vals['shift_type']
         self.shift_bytes = op_vals['shift_bytes']
 
-    def execute(self, model: OTBNModel) -> None:
-        b_shifted = ShiftReg(model.state.wreg[self.wrs2],
+    def execute(self, state: OTBNState) -> None:
+        b_shifted = ShiftReg(state.wreg[self.wrs2],
                              self.shift_type, self.shift_bytes)
-        a = model.state.wreg[self.wrs1]
-        model.state.wreg[self.wrd] = a & b_shifted
+        a = state.wreg[self.wrs1]
+        state.wreg[self.wrd] = a & b_shifted
 
 
 class BNOR(OTBNInsn):
@@ -600,11 +600,11 @@ class BNOR(OTBNInsn):
         self.shift_type = op_vals['shift_type']
         self.shift_bytes = op_vals['shift_bytes']
 
-    def execute(self, model: OTBNModel) -> None:
-        b_shifted = ShiftReg(model.state.wreg[self.wrs2],
+    def execute(self, state: OTBNState) -> None:
+        b_shifted = ShiftReg(state.wreg[self.wrs2],
                              self.shift_type, self.shift_bytes)
-        a = model.state.wreg[self.wrs1]
-        model.state.wreg[self.wrd] = a | b_shifted
+        a = state.wreg[self.wrs1]
+        state.wreg[self.wrd] = a | b_shifted
 
 
 class BNNOT(OTBNInsn):
@@ -617,10 +617,10 @@ class BNNOT(OTBNInsn):
         self.shift_type = op_vals['shift_type']
         self.shift_bytes = op_vals['shift_bytes']
 
-    def execute(self, model: OTBNModel) -> None:
-        b_shifted = ShiftReg(model.state.wreg[self.wrs],
+    def execute(self, state: OTBNState) -> None:
+        b_shifted = ShiftReg(state.wreg[self.wrs],
                              self.shift_type, self.shift_bytes)
-        model.state.wreg[self.wrd] = ~b_shifted
+        state.wreg[self.wrd] = ~b_shifted
 
 
 class BNXOR(OTBNInsn):
@@ -634,11 +634,11 @@ class BNXOR(OTBNInsn):
         self.shift_type = op_vals['shift_type']
         self.shift_bytes = op_vals['shift_bytes']
 
-    def execute(self, model: OTBNModel) -> None:
-        b_shifted = ShiftReg(model.state.wreg[self.wrs2],
+    def execute(self, state: OTBNState) -> None:
+        b_shifted = ShiftReg(state.wreg[self.wrs2],
                              self.shift_type, self.shift_bytes)
-        a = model.state.wreg[self.wrs1]
-        model.state.wreg[self.wrd] = a ^ b_shifted
+        a = state.wreg[self.wrs1]
+        state.wreg[self.wrd] = a ^ b_shifted
 
 
 class BNRSHI(OTBNInsn):
@@ -651,11 +651,11 @@ class BNRSHI(OTBNInsn):
         self.wrs2 = op_vals['wrs2']
         self.imm = op_vals['imm']
 
-    def execute(self, model: OTBNModel) -> None:
-        a = int(model.state.wreg[self.wrs1])
-        b = int(model.state.wreg[self.wrs2])
+    def execute(self, state: OTBNState) -> None:
+        a = int(state.wreg[self.wrs1])
+        b = int(state.wreg[self.wrs2])
         shifted = ((a << 256) | b) >> self.imm
-        model.state.wreg[self.wrd] = shifted & ((1 << 256) - 1)
+        state.wreg[self.wrd] = shifted & ((1 << 256) - 1)
 
 
 class BNRSEL(OTBNInsn):
@@ -669,10 +669,10 @@ class BNRSEL(OTBNInsn):
         self.flag_group = op_vals['flag_group']
         self.flag = op_vals['flag']
 
-    def execute(self, model: OTBNModel) -> None:
-        flag_is_set = model.state.flags[self.flag_group].get_by_idx(self.flag)
-        val = model.state.wreg[self.wrs1 if flag_is_set else self.wrs2]
-        model.state.wreg[self.wrd] = val
+    def execute(self, state: OTBNState) -> None:
+        flag_is_set = state.flags[self.flag_group].get_by_idx(self.flag)
+        val = state.wreg[self.wrs1 if flag_is_set else self.wrs2]
+        state.wreg[self.wrd] = val
 
 
 class BNCMP(OTBNInsn):
@@ -686,12 +686,12 @@ class BNCMP(OTBNInsn):
         self.shift_bytes = op_vals['shift_bytes']
         self.flag_group = op_vals['flag_group']
 
-    def execute(self, model: OTBNModel) -> None:
-        a = int(model.state.wreg[self.wrs1])
-        b_shifted = ShiftReg(int(model.state.wreg[self.wrs2]), self.shift_type,
+    def execute(self, state: OTBNState) -> None:
+        a = int(state.wreg[self.wrs1])
+        b_shifted = ShiftReg(int(state.wreg[self.wrs2]), self.shift_type,
                              self.shift_bytes)
-        (_, flags) = model.add_with_carry(a, -b_shifted, 0)
-        model.state.flags[self.flag_group] = flags
+        (_, flags) = state.add_with_carry(a, -b_shifted, 0)
+        state.flags[self.flag_group] = flags
 
 
 class BNCMPB(OTBNInsn):
@@ -705,13 +705,13 @@ class BNCMPB(OTBNInsn):
         self.shift_bytes = op_vals['shift_bytes']
         self.flag_group = op_vals['flag_group']
 
-    def execute(self, model: OTBNModel) -> None:
-        a = int(model.state.wreg[self.wrs1])
-        b_shifted = ShiftReg(int(model.state.wreg[self.wrs2]), self.shift_type,
+    def execute(self, state: OTBNState) -> None:
+        a = int(state.wreg[self.wrs1])
+        b_shifted = ShiftReg(int(state.wreg[self.wrs2]), self.shift_type,
                              self.shift_bytes)
-        carry_flag = 1 - model.state.flags[self.flag_group].C
-        (_, flags) = model.add_with_carry(a, -b_shifted, carry_flag)
-        model.state.flags[self.flag_group] = flags
+        carry_flag = 1 - state.flags[self.flag_group].C
+        (_, flags) = state.add_with_carry(a, -b_shifted, carry_flag)
+        state.flags[self.flag_group] = flags
 
 
 class BNLID(OTBNInsn):
@@ -725,15 +725,15 @@ class BNLID(OTBNInsn):
         self.grs1 = op_vals['grs1']
         self.grs1_inc = op_vals['grs1_inc']
 
-    def execute(self, model: OTBNModel) -> None:
-        addr = int(model.state.intreg[self.grs1] + int(self.offset))
-        wrd = int(model.state.intreg[self.grd])
-        model.state.wreg[wrd] = model.state.dmem.load_i256(addr)
+    def execute(self, state: OTBNState) -> None:
+        addr = int(state.intreg[self.grs1] + int(self.offset))
+        wrd = int(state.intreg[self.grd])
+        state.wreg[wrd] = state.dmem.load_i256(addr)
 
         if self.grd_inc:
-            model.state.intreg[self.grd] += 1
+            state.intreg[self.grd] += 1
         if self.grs1_inc:
-            model.state.intreg[self.grs1] += 32
+            state.intreg[self.grs1] += 32
 
 
 class BNSID(OTBNInsn):
@@ -747,17 +747,17 @@ class BNSID(OTBNInsn):
         self.grs1 = op_vals['grs1']
         self.grs1_inc = op_vals['grs1_inc']
 
-    def execute(self, model: OTBNModel) -> None:
-        idx = int(model.state.intreg[self.grs2])
-        addr = int(model.state.intreg[self.grs1] + int(self.offset))
+    def execute(self, state: OTBNState) -> None:
+        idx = int(state.intreg[self.grs2])
+        addr = int(state.intreg[self.grs1] + int(self.offset))
 
-        wrs = model.state.wreg[idx]
-        model.state.dmem.store_i256(addr, int(wrs))
+        wrs = state.wreg[idx]
+        state.dmem.store_i256(addr, int(wrs))
 
         if self.grs2_inc:
-            model.state.intreg[self.grs2] += 1
+            state.intreg[self.grs2] += 1
         if self.grs1_inc:
-            model.state.intreg[self.grs1] += 32
+            state.intreg[self.grs1] += 32
 
 
 class BNMOV(OTBNInsn):
@@ -768,8 +768,8 @@ class BNMOV(OTBNInsn):
         self.wrd = op_vals['wrd']
         self.wrs = op_vals['wrs']
 
-    def execute(self, model: OTBNModel) -> None:
-        model.state.wreg[self.wrd] = model.state.wreg[self.wrs]
+    def execute(self, state: OTBNState) -> None:
+        state.wreg[self.wrd] = state.wreg[self.wrs]
 
 
 class BNMOVR(OTBNInsn):
@@ -782,15 +782,15 @@ class BNMOVR(OTBNInsn):
         self.grs = op_vals['grs']
         self.grs_inc = op_vals['grs_inc']
 
-    def execute(self, model: OTBNModel) -> None:
-        wrd = int(model.state.intreg[self.grd])
-        wrs = int(model.state.intreg[self.grs])
-        model.state.wreg[wrd] = model.state.wreg[wrs]
+    def execute(self, state: OTBNState) -> None:
+        wrd = int(state.intreg[self.grd])
+        wrs = int(state.intreg[self.grs])
+        state.wreg[wrd] = state.wreg[wrs]
 
         if self.grd_inc:
-            model.state.intreg[self.grd] += 1
+            state.intreg[self.grd] += 1
         if self.grs_inc:
-            model.state.intreg[self.grs] += 1
+            state.intreg[self.grs] += 1
 
 
 class BNWSRRS(OTBNInsn):
@@ -802,13 +802,13 @@ class BNWSRRS(OTBNInsn):
         self.wsr = op_vals['wsr']
         self.wrs = op_vals['wrs']
 
-    def execute(self, model: OTBNModel) -> None:
+    def execute(self, state: OTBNState) -> None:
         idx = self.wsr
-        old_val = model.state.wcsr_read(idx)
-        new_val = old_val | model.state.wreg[self.wrs]
+        old_val = state.wcsr_read(idx)
+        new_val = old_val | state.wreg[self.wrs]
 
-        model.state.wreg[self.wrd] = old_val
-        model.state.wcsr_write(idx, new_val)
+        state.wreg[self.wrd] = old_val
+        state.wcsr_write(idx, new_val)
 
 
 class BNWSRRW(OTBNInsn):
@@ -820,13 +820,13 @@ class BNWSRRW(OTBNInsn):
         self.wsr = op_vals['wsr']
         self.wrs = op_vals['wrs']
 
-    def execute(self, model: OTBNModel) -> None:
+    def execute(self, state: OTBNState) -> None:
         idx = self.wsr
-        old_val = model.state.wcsr_read(idx)
-        new_val = model.state.wreg[self.wrs]
+        old_val = state.wcsr_read(idx)
+        new_val = state.wreg[self.wrs]
 
-        model.state.wreg[self.wrd] = old_val
-        model.state.wcsr_write(idx, new_val)
+        state.wreg[self.wrd] = old_val
+        state.wcsr_write(idx, new_val)
 
 
 INSN_CLASSES = [

--- a/hw/ip/otbn/dv/otbnsim/sim/isa.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/isa.py
@@ -10,7 +10,7 @@ from riscvmodel.types import Immediate  # type: ignore
 
 from shared.insn_yaml import Insn, load_insns_yaml
 
-from .model import OTBNModel
+from .state import OTBNState
 
 
 # Load the insns.yml file at module load time: we'll use its data while
@@ -74,7 +74,7 @@ class OTBNInsn:
     def __init__(self, op_vals: Dict[str, int]):
         self.op_vals = op_vals
 
-    def execute(self, model: OTBNModel) -> None:
+    def execute(self, state: OTBNState) -> None:
         raise NotImplementedError('OTBNInsn.execute')
 
     def disassemble(self, pc: int) -> str:

--- a/hw/ip/otbn/dv/otbnsim/sim/model.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/model.py
@@ -345,9 +345,8 @@ class OTBNState:
 
 
 class OTBNModel:
-    def __init__(self, verbose: bool):
+    def __init__(self) -> None:
         self.state = OTBNState()
-        self.verbose = verbose
 
     def get_wr_quarterword(self, wridx: int, qwsel: int) -> int:
         assert 0 <= wridx <= 31
@@ -381,9 +380,3 @@ class OTBNModel:
         '''Update state after running an instruction but before commit'''
         self.state.loop_step()
         self.state.intreg.post_insn()
-
-    def print_trace(self, disasm: str) -> None:
-        '''Print a trace of the current instruction to verbose_file'''
-        assert self.verbose
-        changes_str = ', '.join([str(t) for t in self.state.changes()])
-        print('{:35} | [{}]'.format(disasm, changes_str))

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -343,16 +343,11 @@ class OTBNState:
         self.ext_regs.set_bits('STATUS', 1 << 0)
         self.running = True
 
-
-class OTBNModel:
-    def __init__(self) -> None:
-        self.state = OTBNState()
-
     def get_wr_quarterword(self, wridx: int, qwsel: int) -> int:
         assert 0 <= wridx <= 31
         assert 0 <= qwsel <= 3
         mask = (1 << 64) - 1
-        return (int(self.state.wreg[wridx]) >> (qwsel * 64)) & mask
+        return (int(self.wreg[wridx]) >> (qwsel * 64)) & mask
 
     def set_wr_halfword(self, wridx: int, value: int, hwsel: int) -> None:
         assert 0 <= wridx <= 31
@@ -360,9 +355,9 @@ class OTBNModel:
         assert 0 <= hwsel <= 1
 
         mask = ((1 << 128) - 1) << (0 if hwsel else 128)
-        curr = int(self.state.wreg[wridx]) & mask
+        curr = int(self.wreg[wridx]) & mask
         valpos = value << 128 if hwsel else value
-        self.state.wreg[wridx] = curr | valpos
+        self.wreg[wridx] = curr | valpos
 
     @staticmethod
     def add_with_carry(a: int, b: int, carry_in: int) -> Tuple[int, FlagReg]:
@@ -378,5 +373,5 @@ class OTBNModel:
 
     def post_insn(self) -> None:
         '''Update state after running an instruction but before commit'''
-        self.state.loop_step()
-        self.state.intreg.post_insn()
+        self.loop_step()
+        self.intreg.post_insn()

--- a/hw/ip/otbn/dv/otbnsim/standalone.py
+++ b/hw/ip/otbn/dv/otbnsim/standalone.py
@@ -7,7 +7,6 @@ import argparse
 import sys
 
 from sim.elf import load_elf
-from sim.model import OTBNModel
 from sim.sim import OTBNSim
 
 
@@ -19,11 +18,10 @@ def main() -> int:
 
     args = parser.parse_args()
 
-    model = OTBNModel(verbose=args.verbose)
-    sim = OTBNSim(model)
+    sim = OTBNSim()
     load_elf(sim, args.elf)
 
-    sim.run(start_addr=0)
+    sim.run(start_addr=0, verbose=args.verbose)
 
     if args.dmem_dump is not None:
         try:

--- a/hw/ip/otbn/dv/otbnsim/stepped.py
+++ b/hw/ip/otbn/dv/otbnsim/stepped.py
@@ -32,7 +32,6 @@ import sys
 from typing import List
 
 from sim.decode import decode_file
-from sim.model import OTBNModel
 from sim.sim import OTBNSim
 
 
@@ -82,8 +81,9 @@ def on_step(sim: OTBNSim, args: List[str]) -> None:
     pc = int(sim.model.state.pc)
 
     assert 0 == pc & 3
-    print('EXEC {:#08x}'.format(pc))
-    changes = sim.step()
+    insn, changes = sim.step(verbose=False)
+    disasm = '(not running)' if insn is None else insn.disassemble(pc)
+    print('EXEC {:#08x}:     {}'.format(pc, disasm))
     for trace in changes:
         print('  {}'.format(trace))
 
@@ -152,7 +152,7 @@ def on_input(sim: OTBNSim, line: str) -> None:
 
 
 def main() -> int:
-    sim = OTBNSim(OTBNModel(verbose=False))
+    sim = OTBNSim()
     for line in sys.stdin:
         on_input(sim, line)
     return 0

--- a/hw/ip/otbn/dv/otbnsim/stepped.py
+++ b/hw/ip/otbn/dv/otbnsim/stepped.py
@@ -68,8 +68,8 @@ def on_start(sim: OTBNSim, args: List[str]) -> None:
                          .format(addr))
 
     print('START {:#08x}'.format(addr))
-    sim.model.state.pc.set(addr)
-    sim.model.state.start()
+    sim.state.pc.set(addr)
+    sim.state.start()
 
 
 def on_step(sim: OTBNSim, args: List[str]) -> None:
@@ -78,7 +78,7 @@ def on_step(sim: OTBNSim, args: List[str]) -> None:
         raise ValueError('step expects zero arguments. Got {}.'
                          .format(args))
 
-    pc = int(sim.model.state.pc)
+    pc = int(sim.state.pc)
 
     assert 0 == pc & 3
     insn, changes = sim.step(verbose=False)
@@ -121,7 +121,7 @@ def on_dump_d(sim: OTBNSim, args: List[str]) -> None:
     print('DUMP_D {!r}'.format(path))
 
     with open(path, 'wb') as handle:
-        handle.write(sim.model.state.dmem.dump_le_words())
+        handle.write(sim.state.dmem.dump_le_words())
 
 
 _HANDLERS = {

--- a/hw/ip/otbn/util/shared/insn_yaml.py
+++ b/hw/ip/otbn/util/shared/insn_yaml.py
@@ -14,7 +14,7 @@ from .encoding_scheme import EncSchemes
 from .lsu_desc import LSUDesc
 from .operand import Operand
 from .syntax import InsnSyntax
-from .yaml_parse_helpers import (check_keys, check_str, check_bool,
+from .yaml_parse_helpers import (check_keys, check_str, check_bool, check_int,
                                  check_list, index_list, get_optional_str,
                                  load_yaml)
 
@@ -29,7 +29,7 @@ class Insn:
                          'syntax', 'doc', 'note', 'trailing-doc',
                          'decode', 'operation', 'encoding', 'glued-ops',
                          'literal-pseudo-op', 'python-pseudo-op', 'lsu',
-                         'straight-line'])
+                         'straight-line', 'cycles'])
 
         self.mnemonic = check_str(yd['mnemonic'], 'mnemonic for instruction')
 
@@ -139,6 +139,12 @@ class Insn:
                                      .format(idx, what, op_name))
 
         self.straight_line = yd.get('straight-line', True)
+
+        self.cycles = check_int(yd.get('cycles', 1),
+                                'cycles field for ' + what)
+        if self.cycles <= 0:
+            raise ValueError('cycles field for {} is not positive.'
+                             .format(what))
 
     def enc_vals_to_op_vals(self,
                             cur_pc: int,

--- a/hw/ip/otbn/util/yaml_to_doc.py
+++ b/hw/ip/otbn/util/yaml_to_doc.py
@@ -199,6 +199,11 @@ def render_insn(insn: Insn, heading_level: int) -> str:
     if insn.rv32i:
         parts.append('This instruction is defined in the RV32I instruction set.\n\n')
 
+    # If this takes more than a single cycle, say so.
+    if insn.cycles > 1:
+        parts.append('This instruction takes {} cycles.\n\n'
+                     .format(insn.cycles))
+
     # Show any trailing documentation (stuff that should come after the syntax
     # example but before the operand table).
     if insn.trailing_doc is not None:


### PR DESCRIPTION
With these patches, the ISS knows to stall for a cycle on LW and BN.LID. The first two patches in the queue are semi-unrelated cleanups, but they clash with the stalling patch, so it seemed easiest to push everything up together.

@GregAC: I think that LW and BN.LID are the only instructions that stall at the moment. Have I missed anything?