### PR TITLE
[otbn] Run OTBN in lock-step in block-level simulation

### DIFF
--- a/hw/ip/otbn/dv/model/iss_wrapper.cc
+++ b/hw/ip/otbn/dv/model/iss_wrapper.cc
@@ -275,18 +275,10 @@ void ISSWrapper::start(uint32_t addr) {
   run_command(oss.str(), nullptr);
 }
 
-size_t ISSWrapper::run() {
-  size_t cycles = 0;
+bool ISSWrapper::step() {
   std::vector<std::string> lines;
-
-  for (;;) {
-    ++cycles;
-    lines.clear();
-    run_command("step\n", &lines);
-    if (saw_busy_cleared(lines))
-      break;
-  }
-  return cycles;
+  run_command("step\n", &lines);
+  return saw_busy_cleared(lines);
 }
 
 std::string ISSWrapper::make_tmp_path(const std::string &relative) const {

--- a/hw/ip/otbn/dv/model/iss_wrapper.h
+++ b/hw/ip/otbn/dv/model/iss_wrapper.h
@@ -29,9 +29,9 @@ struct ISSWrapper {
   // Jump to a new address and start running
   void start(uint32_t addr);
 
-  // Run simulation until ECALL or error. Return the number of cycles
-  // until that happened.
-  size_t run();
+  // Run simulation for a single cycle. Return true if it is now
+  // finished (ECALL or error).
+  bool step();
 
   // Resolve a path relative to the convenience temporary directory.
   // relative should be a relative path (it is just appended to the

--- a/hw/ip/otbn/dv/model/iss_wrapper.h
+++ b/hw/ip/otbn/dv/model/iss_wrapper.h
@@ -6,25 +6,25 @@
 
 #include <cstdint>
 #include <cstdio>
+#include <memory>
 #include <string>
 #include <unistd.h>
 #include <vector>
+
+// Forward declaration (the implementation is private in iss_wrapper.cc)
+struct TmpDir;
 
 // An object wrapping the ISS subprocess.
 struct ISSWrapper {
   ISSWrapper();
   ~ISSWrapper();
 
-  // No copy constructor or assignments: we're wrapping a child process.
-  ISSWrapper(const ISSWrapper &) = delete;
-  ISSWrapper &operator=(const ISSWrapper &) = delete;
-
   // Load new contents of DMEM / IMEM
-  void load_d(const char *path);
-  void load_i(const char *path);
+  void load_d(const std::string &path);
+  void load_i(const std::string &path);
 
   // Dump the contents of DMEM to a file
-  void dump_d(const char *path) const;
+  void dump_d(const std::string &path) const;
 
   // Jump to a new address and start running
   void start(uint32_t addr);
@@ -32,6 +32,11 @@ struct ISSWrapper {
   // Run simulation until ECALL or error. Return the number of cycles
   // until that happened.
   size_t run();
+
+  // Resolve a path relative to the convenience temporary directory.
+  // relative should be a relative path (it is just appended to the
+  // path of the temporary directory).
+  std::string make_tmp_path(const std::string &relative) const;
 
  private:
   // Read line by line from the child process until we get ".\n".
@@ -50,4 +55,7 @@ struct ISSWrapper {
   pid_t child_pid;
   FILE *child_write_file;
   FILE *child_read_file;
+
+  // A temporary directory for communicating with the child process
+  std::unique_ptr<TmpDir> tmpdir;
 };

--- a/hw/ip/otbn/dv/model/otbn_core_model.sv
+++ b/hw/ip/otbn/dv/model/otbn_core_model.sv
@@ -22,6 +22,11 @@ module otbn_core_model
   // Scope of the data memory (for DPI)
   parameter string DmemScope = "",
 
+  // True if this is a "standalone" model, which should write DMEM on completion. If false, we
+  // assume there's a real implementation running alongside and we check that the DMEM contents
+  // match on completion.
+  parameter bit StandaloneModel = 1'b0,
+
   localparam int ImemAddrWidth = prim_util_pkg::vbits(ImemSizeByte),
   localparam int DmemAddrWidth = prim_util_pkg::vbits(DmemSizeByte)
 )(
@@ -37,6 +42,22 @@ module otbn_core_model
 
   import "DPI-C" function chandle otbn_model_init();
   import "DPI-C" function void otbn_model_destroy(chandle handle);
+  import "DPI-C" context function
+    int otbn_model_start(chandle model,
+                         string  imem_scope,
+                         int     imem_size,
+                         string  dmem_scope,
+                         int     dmem_size,
+                         int     start_addr);
+  import "DPI-C" function int otbn_model_step(chandle model);
+  import "DPI-C" context function
+    int otbn_model_load_dmem(chandle model,
+                             string  dmem_scope,
+                             int     dmem_size);
+  import "DPI-C" context function
+    int otbn_model_check_dmem(chandle model,
+                              string  dmem_scope,
+                              int     dmem_size);
 
   chandle model_handle;
   initial begin
@@ -48,44 +69,73 @@ module otbn_core_model
     model_handle = 0;
   end
 
-  import "DPI-C" context function
-    int otbn_model_run(chandle model,
-                       string  imem_scope,
-                       int     imem_size,
-                       string  dmem_scope,
-                       int     dmem_size,
-                       int     start_addr);
 
   localparam ImemSizeWords = ImemSizeByte / 4;
   localparam DmemSizeWords = DmemSizeByte / (WLEN / 8);
-
-  int count;
 
   `ASSERT_INIT(StartAddr32_A, ImemAddrWidth <= 32);
   logic [31:0] start_addr_32;
   assign start_addr_32 = {{32 - ImemAddrWidth{1'b0}}, start_addr_i};
 
-  always_ff @(posedge clk_i or negedge rst_ni) begin : model_run
-    if (!rst_ni) begin
-      done_o <= 1'b0;
-      count <= -1;
-    end else begin
-      if (start_i) begin
-        count <= otbn_model_run(model_handle,
-                                ImemScope, ImemSizeWords,
-                                DmemScope, DmemSizeWords,
-                                start_addr_32);
-        done_o <= 1'b0;
-      end else begin
-        if (count == 0) begin
-          done_o <= 1'b1;
-          count <= -1;
+  // The control loop for the model. We track whether we're currently running in the running
+  // variable. The step_iss function is run every cycle when not in reset. It steps the ISS if
+  // necessary and returns the new value for running.
+  function automatic bit step_iss(bit running);
+    int retcode;
+    bit new_run = running;
+
+    // If start_i is asserted, start again (regardless of whether we're currently running).
+    if (start_i) begin
+      retcode = otbn_model_start(model_handle,
+                                 ImemScope, ImemSizeWords,
+                                 DmemScope, DmemSizeWords,
+                                 start_addr_32);
+      unique case (retcode)
+        0:       new_run = 1'b1;
+        // Something went wrong. Assume we didn't manage to start.
+        default: new_run = 1'b0;
+      endcase
+    end
+
+    // Otherwise, if we aren't currently running then there's nothing more to do.
+    if (!new_run) begin
+      return 1'b0;
+    end
+
+    // We are running. Step by one instruction.
+    retcode = otbn_model_step(model_handle);
+    unique case (retcode)
+      0: new_run = 1'b1;
+      1: begin
+        // The model has just finished running. If this is a standalone model, write the ISS's DMEM
+        // contents back to the simulation. Otherwise, check the ISS and simulation agree (TODO: We
+        // don't do error handling properly at the moment; for now, the C++ code just prints error
+        // messages to stderr).
+        if (StandaloneModel) begin
+          void'(otbn_model_load_dmem(model_handle, DmemScope, DmemSizeWords));
         end else begin
-          done_o <= 1'b0;
-          count <= count - 1;
+          void'(otbn_model_check_dmem(model_handle, DmemScope, DmemSizeWords));
         end
+        new_run = 1'b0;
       end
+      // Something went wrong. Assume we've stopped.
+      default: new_run = 1'b0;
+    endcase
+    return new_run;
+  endfunction
+
+  bit running, running_r;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      running   <= 1'b0;
+      running_r <= 1'b0;
+    end else begin
+      running   <= step_iss(running);
+      running_r <= running;
     end
   end
+
+  // Track negedges of running and expose that as a "done" output.
+  assign done_o = running_r & ~running;
 
 endmodule

--- a/hw/ip/otbn/dv/model/otbn_model.cc
+++ b/hw/ip/otbn/dv/model/otbn_model.cc
@@ -3,16 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cassert>
-#include <cstdlib>
-#include <cstring>
 #include <fstream>
-#include <ftw.h>
 #include <iostream>
-#include <memory>
 #include <sstream>
 #include <string>
 #include <svdpi.h>
-#include <sys/stat.h>
 
 #include "iss_wrapper.h"
 
@@ -120,88 +115,6 @@ static void load_memory(const std::string &path, const char *scope,
   }
 }
 
-// Guard class to create (and possibly delete) temporary directories.
-struct TmpDir {
-  std::string path;
-
-  ~TmpDir() { cleanup(); }
-
-  // Construct a temporary directory. Throw a runtime_error if something goes
-  // wrong.
-  void make() {
-    // Clean up anything we had already.
-    cleanup();
-    path = TmpDir::make_tmp_dir();
-  }
-
- private:
-  // A wrapper around mkdtemp that respects TMPDIR
-  static std::string make_tmp_dir() {
-    const char *tmpdir = getenv("TMPDIR");
-    if (!tmpdir)
-      tmpdir = "/tmp";
-
-    std::string tmp_template(tmpdir);
-    tmp_template += "/otbn_XXXXXX";
-
-    if (!mkdtemp(&tmp_template.at(0))) {
-      std::ostringstream oss;
-      oss << ("Cannot create temporary directory for OTBN simulation "
-              "with template ")
-          << tmp_template << ": " << strerror(errno);
-      throw std::runtime_error(oss.str());
-    }
-
-    // The backing string for tmp_template will have been populated by mkdtemp.
-    return tmp_template;
-  }
-
-  // Return true if the OTBN_MODEL_KEEP_TMP environment variable is set to 1.
-  static bool should_keep_tmp() {
-    const char *keep_str = getenv("OTBN_MODEL_KEEP_TMP");
-    if (!keep_str)
-      return false;
-    return (strcmp(keep_str, "1") == 0) ? true : false;
-  }
-
-  // Called by nftw when we're deleting the temporary directory
-  static int ftw_callback(const char *fpath, const struct stat *sb,
-                          int typeflag, struct FTW *ftwbuf) {
-    // The libc remove() function calls unlink or rmdir as necessary. Ignore
-    // any failures: we'll check that we managed to delete the directory when
-    // nftw finishes.
-    remove(fpath);
-
-    // Tell nftw to keep going
-    return 0;
-  }
-
-  // Recursively delete the temporary directory
-  void cleanup() {
-    if (path.empty())
-      return;
-
-    if (TmpDir::should_keep_tmp()) {
-      std::cerr << "Keeping temporary directory at " << path
-                << " because OTBN_MODEL_KEEP_TMP=1.\n";
-      return;
-    }
-
-    // We're not supposed to keep the directory. Try to delete it and its
-    // contents. Ignore any failures: we'll just check whether it's gone
-    // afterwards.
-    nftw(path.c_str(), TmpDir::ftw_callback, 4, FTW_DEPTH | FTW_PHYS);
-
-    // Is there still anything at path? If so, we failed. Print something to
-    // stderr to tell the user what's going on.
-    struct stat statbuf;
-    if (stat(path.c_str(), &statbuf) == 0) {
-      std::cerr << "ERROR: Failed to delete OTBN temporary directory at "
-                << path << ".\n";
-    }
-  }
-};
-
 extern "C" ISSWrapper *otbn_model_init() {
   try {
     return new ISSWrapper();
@@ -221,17 +134,8 @@ extern "C" int otbn_model_run(ISSWrapper *model, const char *imem_scope,
   assert(dmem_words >= 0);
   assert(start_addr >= 0 && start_addr < (imem_words * 4));
 
-  TmpDir tmpdir;
-  try {
-    tmpdir.make();
-  } catch (const std::runtime_error &err) {
-    std::cerr << err.what() << "\n";
-    return 0;
-  }
-
-  std::string ifname(tmpdir.path + "/imem");
-  std::string dfname(tmpdir.path + "/dmem");
-  std::string tfname(tmpdir.path + "/trace");
+  std::string ifname(model->make_tmp_path("imem"));
+  std::string dfname(model->make_tmp_path("dmem"));
 
   try {
     dump_memory(dfname, dmem_scope, dmem_words, 32);

--- a/hw/ip/otbn/dv/model/otbn_model.cc
+++ b/hw/ip/otbn/dv/model/otbn_model.cc
@@ -2,8 +2,11 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include <algorithm>
 #include <cassert>
+#include <cstring>
 #include <fstream>
+#include <iomanip>
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -36,18 +39,9 @@ extern "C" int simutil_verilator_get_mem(int index, const svBitVecVal *val);
 extern "C" int simutil_verilator_set_mem(int index, const svBitVecVal *val);
 
 // Use simutil_verilator_get_mem to read data one word at a time from the given
-// scope, writing it to a file at path. Each word is word_size bytes long.
-//
-// Raises a runtime_error on failure.
-static void dump_memory(const std::string &path, const char *scope,
-                        size_t num_words, size_t word_size) {
-  std::filebuf fb;
-  if (!fb.open(path.c_str(), std::ios::out | std::ios::binary)) {
-    std::ostringstream oss;
-    oss << "Cannot open the file '" << path << "'.";
-    throw std::runtime_error(oss.str());
-  }
-
+// scope and collect the results up in a vector of uint8_t values.
+static std::vector<uint8_t> get_sim_memory(const char *scope, size_t num_words,
+                                           size_t word_size) {
   SVScoped scoped(scope);
 
   // simutil_verilator_get_mem passes data as a packed array of svBitVecVal
@@ -55,6 +49,8 @@ static void dump_memory(const std::string &path, const char *scope,
   // allocate 256/8 = 32 bytes as 32/sizeof(svBitVecVal) words on the stack.
   assert(word_size <= 256 / 8);
   svBitVecVal buf[256 / 8 / sizeof(svBitVecVal)];
+
+  std::vector<uint8_t> ret;
 
   for (size_t w = 0; w < num_words; w++) {
     if (!simutil_verilator_get_mem(w, buf)) {
@@ -64,47 +60,29 @@ static void dump_memory(const std::string &path, const char *scope,
       throw std::runtime_error(oss.str());
     }
 
-    // Write out the first word_size bytes of data
-    std::streamsize chars_out =
-        fb.sputn(reinterpret_cast<const char *>(buf), word_size);
-
-    if (chars_out != word_size) {
-      std::ostringstream oss;
-      oss << "Cannot write word " << w << " to '" << path << "'.\n";
-      throw std::runtime_error(oss.str());
-    }
+    // Append the first word_size bytes of data to ret.
+    std::copy_n(reinterpret_cast<const char *>(buf), word_size,
+                std::back_inserter(ret));
   }
+
+  return ret;
 }
 
-// Read data from the given file and then use simutil_verilator_set_mem to
-// write it into the simulation one word at a time. Each word is word_size
-// bytes long.
-//
-// Raises a runtime_error on failure.
-static void load_memory(const std::string &path, const char *scope,
-                        size_t num_words, size_t word_size) {
-  std::filebuf fb;
-  if (!fb.open(path.c_str(), std::ios::in | std::ios::binary)) {
-    std::ostringstream oss;
-    oss << "Cannot open the file '" << path << "'.";
-    throw std::runtime_error(oss.str());
-  }
-
+// Use simutil_verilator_get_mem to write data one word at a time to the given
+// scope.
+static void set_sim_memory(const std::vector<uint8_t> &data, const char *scope,
+                           size_t num_words, size_t word_size) {
   SVScoped scoped(scope);
 
-  // See dump_memory, above, for why this array is sized like this.
+  assert(num_words * word_size == data.size());
+
+  // See get_sim_memory for why this array is sized like this.
   assert(word_size <= 256 / 8);
   svBitVecVal buf[256 / 8 / sizeof(svBitVecVal)];
 
   for (size_t w = 0; w < num_words; w++) {
-    std::streamsize chars_in =
-        fb.sgetn(reinterpret_cast<char *>(buf), word_size);
-
-    if (chars_in != word_size) {
-      std::ostringstream oss;
-      oss << "Cannot read word " << w << " from '" << path << "'.\n";
-      throw std::runtime_error(oss.str());
-    }
+    const uint8_t *p = &data[w * word_size];
+    memcpy(buf, p, word_size);
 
     if (!simutil_verilator_set_mem(w, buf)) {
       std::ostringstream oss;
@@ -113,6 +91,68 @@ static void load_memory(const std::string &path, const char *scope,
       throw std::runtime_error(oss.str());
     }
   }
+}
+
+// Read (the start of) the contents of a file at path as a vector of bytes.
+// Expects num_bytes bytes of data.
+static std::vector<uint8_t> read_vector_from_file(const std::string &path,
+                                                  size_t num_bytes) {
+  std::filebuf fb;
+  if (!fb.open(path.c_str(), std::ios::in | std::ios::binary)) {
+    std::ostringstream oss;
+    oss << "Cannot open the file '" << path << "'.";
+    throw std::runtime_error(oss.str());
+  }
+
+  std::vector<uint8_t> buf(num_bytes);
+  std::streamsize chars_in =
+      fb.sgetn(reinterpret_cast<char *>(&buf[0]), num_bytes);
+
+  if (chars_in != num_bytes) {
+    std::ostringstream oss;
+    oss << "Cannot read " << num_bytes << " bytes of memory data from " << path
+        << " (actually got " << chars_in << ").";
+    throw std::runtime_error(oss.str());
+  }
+
+  return buf;
+}
+
+// Write a vector of bytes to a new file at path
+static void write_vector_to_file(const std::string &path,
+                                 const std::vector<uint8_t> &data) {
+  std::filebuf fb;
+  if (!fb.open(path.c_str(), std::ios::out | std::ios::binary)) {
+    std::ostringstream oss;
+    oss << "Cannot open the file '" << path << "'.";
+    throw std::runtime_error(oss.str());
+  }
+
+  // Write out the data
+  std::streamsize chars_out =
+      fb.sputn(reinterpret_cast<const char *>(&data[0]), data.size());
+
+  if (chars_out != data.size()) {
+    std::ostringstream oss;
+    oss << "Cannot write " << data.size() << " bytes of memory data to " << path
+        << "' (actually wrote " << chars_out << ").";
+    throw std::runtime_error(oss.str());
+  }
+}
+
+// Dump the memory at the given scope to a file at path.
+static void dump_memory_to_file(const std::string &path, const char *scope,
+                                size_t num_words, size_t word_size) {
+  write_vector_to_file(path, get_sim_memory(scope, num_words, word_size));
+}
+
+// Read data from the given file and then write it into the memory at the given
+// scope.
+static void load_memory_from_file(const std::string &path, const char *scope,
+                                  size_t num_words, size_t word_size) {
+  size_t num_bytes = num_words * word_size;
+  set_sim_memory(read_vector_from_file(path, num_bytes), scope, num_words,
+                 word_size);
 }
 
 extern "C" ISSWrapper *otbn_model_init() {
@@ -126,9 +166,11 @@ extern "C" ISSWrapper *otbn_model_init() {
 
 extern "C" void otbn_model_destroy(ISSWrapper *model) { delete model; }
 
-extern "C" int otbn_model_run(ISSWrapper *model, const char *imem_scope,
-                              int imem_words, const char *dmem_scope,
-                              int dmem_words, int start_addr) {
+// Start a new run with the model, writing IMEM/DMEM and jumping to the given
+// start address. Returns 0 on success; -1 on failure.
+extern "C" int otbn_model_start(ISSWrapper *model, const char *imem_scope,
+                                int imem_words, const char *dmem_scope,
+                                int dmem_words, int start_addr) {
   assert(model);
   assert(imem_words >= 0);
   assert(dmem_words >= 0);
@@ -138,25 +180,99 @@ extern "C" int otbn_model_run(ISSWrapper *model, const char *imem_scope,
   std::string dfname(model->make_tmp_path("dmem"));
 
   try {
-    dump_memory(dfname, dmem_scope, dmem_words, 32);
-    dump_memory(ifname, imem_scope, imem_words, 4);
+    dump_memory_to_file(dfname, dmem_scope, dmem_words, 32);
+    dump_memory_to_file(ifname, imem_scope, imem_words, 4);
   } catch (const std::runtime_error &err) {
     std::cerr << "Error when dumping memory contents: " << err.what() << "\n";
-    return 0;
+    return -1;
   }
 
   try {
-    model->load_d(dfname.c_str());
-    model->load_i(ifname.c_str());
+    model->load_d(dfname);
+    model->load_i(ifname);
     model->start(start_addr);
-    unsigned cycles = model->run();
-    model->dump_d(dfname.c_str());
+  } catch (const std::runtime_error &err) {
+    std::cerr << "Error when starting ISS: " << err.what() << "\n";
+    return -1;
+  }
 
-    load_memory(dfname, dmem_scope, dmem_words, 32);
-    return cycles;
+  return 0;
+}
+
+// Step once in the model. Returns 1 if the model has finished, 0 if not and -1
+// on failure.
+extern "C" int otbn_model_step(ISSWrapper *model) {
+  assert(model);
+  try {
+    return model->step() ? 1 : 0;
+  } catch (const std::runtime_error &err) {
+    std::cerr << "Error when stepping ISS: " << err.what() << "\n";
+    return -1;
+  }
+}
+
+// Grab contents of dmem from the model and load it back into the RTL. Returns
+// 0 on success; -1 on failure.
+extern "C" int otbn_model_load_dmem(ISSWrapper *model, const char *dmem_scope,
+                                    int dmem_words) {
+  assert(model);
+  std::string dfname(model->make_tmp_path("dmem_out"));
+  try {
+    model->dump_d(dfname);
+    load_memory_from_file(dfname, dmem_scope, dmem_words, 32);
+  } catch (const std::runtime_error &err) {
+    std::cerr << "Error when loading dmem from ISS: " << err.what() << "\n";
+    return -1;
+  }
+  return 0;
+}
+
+// Grab contents of dmem from the model and compare it with the RTL. Prints
+// messages to stderr on failure or mismatch. Returns 1 for a match, 0 for a
+// mismatch, -1 for some other failure.
+extern "C" int otbn_model_check_dmem(ISSWrapper *model, const char *dmem_scope,
+                                     int dmem_words) {
+  assert(model);
+  assert(dmem_words >= 0);
+
+  size_t dmem_bytes = dmem_words * 32;
+  std::string dfname(model->make_tmp_path("dmem_out"));
+  try {
+    model->dump_d(dfname);
+    std::vector<uint8_t> iss_data = read_vector_from_file(dfname, dmem_bytes);
+    assert(iss_data.size() == dmem_bytes);
+
+    std::vector<uint8_t> rtl_data = get_sim_memory(dmem_scope, dmem_words, 32);
+    assert(rtl_data.size() == dmem_bytes);
+
+    // If the arrays match, we're done.
+    if (0 == memcmp(&iss_data[0], &rtl_data[0], dmem_bytes))
+      return 1;
+
+    // If not, print out the first 10 mismatches
+    std::ios old_state(nullptr);
+    old_state.copyfmt(std::cerr);
+    std::cerr << "ERROR: Mismatches in dmem data:\n"
+              << std::hex << std::setfill('0');
+    int bad_count = 0;
+    for (size_t i = 0; i < dmem_bytes; ++i) {
+      if (iss_data[i] != rtl_data[i]) {
+        std::cerr << " @offset 0x" << std::setw(3) << i << ": rtl has 0x"
+                  << std::setw(2) << (int)rtl_data[i] << "; iss has 0x"
+                  << std::setw(2) << (int)iss_data[i] << "\n";
+        ++bad_count;
+
+        if (bad_count == 10) {
+          std::cerr << " (skipping further errors...)\n";
+          break;
+        }
+      }
+    }
+    std::cerr.copyfmt(old_state);
+    return 0;
 
   } catch (const std::runtime_error &err) {
-    std::cerr << "Error when running ISS: " << err.what() << "\n";
-    return 0;
+    std::cerr << "Error when loading dmem from ISS: " << err.what() << "\n";
+    return -1;
   }
 }

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -179,10 +179,11 @@ module otbn_top_sim (
   logic otbn_model_done;
 
   otbn_core_model #(
-    .DmemSizeByte ( DmemSizeByte ),
-    .ImemSizeByte ( ImemSizeByte ),
-    .DmemScope    ( DmemScope ),
-    .ImemScope    ( ImemScope )
+    .DmemSizeByte    ( DmemSizeByte ),
+    .ImemSizeByte    ( ImemSizeByte ),
+    .DmemScope       ( DmemScope ),
+    .ImemScope       ( ImemScope ),
+    .StandaloneModel ( 1'b0 )
   ) u_otbn_core_model (
     .clk_i        ( IO_CLK ),
     .rst_ni       ( IO_RST_N ),

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -431,7 +431,8 @@ module otbn
       .DmemSizeByte(DmemSizeByte),
       .ImemSizeByte(ImemSizeByte),
       .DmemScope(DmemScope),
-      .ImemScope(ImemScope)
+      .ImemScope(ImemScope),
+      .StandaloneModel(1'b1)
     ) u_otbn_core_model (
       .clk_i,
       .rst_ni,


### PR DESCRIPTION
This series of patches gets us to the state where we can run the ISS alongside the RTL and do some (super-basic) sanity checks on the result. The error reporting is a bit rubbish as it stands: it just dumps a message to stderr, so we'll need to improve that reasonably soon. There is also not that much checking between the two implementations: see the commit message for the last patch for more information.

As pushed, this reports errors in the smoke test (although the wrapper doesn't actually see them, so the test still passes: see previous note about dealing better with errors!). These are fixed with the patches in PRs #3485 and #3486, but the changes are otherwise independent so I've pushed up this change without waiting for them to be merged.

I'd especially appreciate comments on SystemVerilog style in the last patch: there might be a much nicer way to write this!