### PR TITLE
[uartdpi] Accept log file name through plusarg

### DIFF
--- a/doc/ug/getting_started_verilator.md
+++ b/doc/ug/getting_started_verilator.md
@@ -93,6 +93,20 @@ I00004 hello_world.c:45] or type anything into the console window.
 I00005 hello_world.c:46] The LEDs show the ASCII code of the last character.
 ```
 
+Instead of interacting with the UART through a pseudo-terminal, the UART output can be written to a log file, or to STDOUT.
+This is done by passing the `UARTDPI_LOG_uart0` plus argument ("plusarg") to the verilated simulation at runtime.
+To write all UART output to STDOUT, pass `+UARTDPI_LOG_uart0=-` to the simulation.
+To write all UART output to a file called `your-log-file.log`, pass `+UARTDPI_LOG_uart0=your-log-file.log`.
+
+A full command-line invocation of the simulation could then look like that:
+```console
+$ cd $REPO_TOP
+$ build/lowrisc_systems_top_earlgrey_verilator_0.1/sim-verilator/Vtop_earlgrey_verilator \
+  --meminit=rom,build-bin/sw/device/boot_rom/boot_rom_sim_verilator.elf \
+  --meminit=flash,build-bin/sw/device/examples/hello_world/hello_world_sim_verilator.elf \
+  +UARTDPI_LOG_uart0=-
+```
+
 ## Interact with GPIO
 
 The simulation includes a DPI module to map general-purpose I/O (GPIO) pins to two POSIX FIFO files: one for input, and one for output.

--- a/hw/dv/dpi/uartdpi/uartdpi.c
+++ b/hw/dv/dpi/uartdpi/uartdpi.c
@@ -46,6 +46,18 @@ void *uartdpi_create(const char *name) {
   return (void *)ctx;
 }
 
+void uartdpi_close(void *ctx_void) {
+  struct uartdpi_ctx *ctx = (struct uartdpi_ctx *)ctx_void;
+  if (!ctx) {
+    return;
+  }
+
+  close(ctx->host);
+  close(ctx->device);
+
+  free(ctx);
+}
+
 int uartdpi_can_read(void *ctx_void) {
   struct uartdpi_ctx *ctx = (struct uartdpi_ctx *)ctx_void;
 

--- a/hw/dv/dpi/uartdpi/uartdpi.h
+++ b/hw/dv/dpi/uartdpi/uartdpi.h
@@ -4,16 +4,20 @@
 
 #ifndef OPENTITAN_HW_DV_DPI_UARTDPI_UARTDPI_H_
 #define OPENTITAN_HW_DV_DPI_UARTDPI_UARTDPI_H_
+
 extern "C" {
+
+#include <stdio.h>
 
 struct uartdpi_ctx {
   char ptyname[64];
   int host;
   int device;
   char tmp_read;
+  FILE *log_file;
 };
 
-void *uartdpi_create(const char *name);
+void *uartdpi_create(const char *name, const char *log_file_path);
 void uartdpi_close(void *ctx_void);
 int uartdpi_can_read(void *ctx_void);
 char uartdpi_read(void *ctx_void);

--- a/hw/dv/dpi/uartdpi/uartdpi.h
+++ b/hw/dv/dpi/uartdpi/uartdpi.h
@@ -14,6 +14,7 @@ struct uartdpi_ctx {
 };
 
 void *uartdpi_create(const char *name);
+void uartdpi_close(void *ctx_void);
 int uartdpi_can_read(void *ctx_void);
 char uartdpi_read(void *ctx_void);
 void uartdpi_write(void *ctx_void, char c);

--- a/hw/dv/dpi/uartdpi/uartdpi.sv
+++ b/hw/dv/dpi/uartdpi/uartdpi.sv
@@ -13,11 +13,13 @@ module uartdpi #(
   output logic tx_o,
   input  logic rx_i
 );
+  // Path to a log file. Used if none is specified through the `UARTDPI_LOG_<name>` plusarg.
+  localparam string DEFAULT_LOG_FILE = {NAME, ".log"};
 
   localparam int CYCLES_PER_SYMBOL = FREQ / BAUD;
 
   import "DPI-C" function
-    chandle uartdpi_create(input string name);
+    chandle uartdpi_create(input string name, input string log_file_path);
 
   import "DPI-C" function
     void uartdpi_close(input chandle ctx);
@@ -32,13 +34,11 @@ module uartdpi #(
     void uartdpi_write(input chandle ctx, int data);
 
   chandle ctx;
-  int file_handle;
-  string file_name;
+  string log_file_path = DEFAULT_LOG_FILE;
 
   initial begin
-    ctx = uartdpi_create(NAME);
-    $sformat(file_name, "%s.log", NAME);
-    file_handle = $fopen(file_name, "w");
+    $value$plusargs({"UARTDPI_LOG_", NAME, "=%s"}, log_file_path);
+    ctx = uartdpi_create(NAME, log_file_path);
   end
 
   final begin
@@ -119,7 +119,6 @@ module uartdpi #(
             rxactive <= 0;
             if (rx_i) begin
               uartdpi_write(ctx, rxsymbol);
-              $fwrite(file_handle, "%c", rxsymbol);
             end
           end
         end

--- a/hw/dv/dpi/uartdpi/uartdpi.sv
+++ b/hw/dv/dpi/uartdpi/uartdpi.sv
@@ -14,7 +14,7 @@ module uartdpi #(
   input  logic rx_i
 );
 
-  localparam CYCLES_PER_SYMBOL = FREQ/BAUD;
+  localparam int CYCLES_PER_SYMBOL = FREQ / BAUD;
 
   import "DPI-C" function
     chandle uartdpi_create(input string name);
@@ -53,7 +53,7 @@ module uartdpi #(
   reg [9:0] txsymbol;
 
   always_ff @(negedge clk_i or negedge rst_ni) begin
-    if (~rst_ni) begin
+    if (!rst_ni) begin
       tx_o <= 1;
       txactive <= 0;
     end else begin
@@ -89,7 +89,7 @@ module uartdpi #(
   always_ff @(negedge clk_i or negedge rst_ni) begin
     rxcyccount <= rxcyccount + 1;
 
-    if (~rst_ni) begin
+    if (!rst_ni) begin
       rxactive <= 0;
     end else begin
       if (!rxactive) begin
@@ -124,7 +124,7 @@ module uartdpi #(
           end
         end
       end
-    end // else: !if(rst)
+    end
   end
 
 endmodule

--- a/hw/dv/dpi/uartdpi/uartdpi.sv
+++ b/hw/dv/dpi/uartdpi/uartdpi.sv
@@ -20,6 +20,9 @@ module uartdpi #(
     chandle uartdpi_create(input string name);
 
   import "DPI-C" function
+    void uartdpi_close(input chandle ctx);
+
+  import "DPI-C" function
     byte uartdpi_read(input chandle ctx);
 
   import "DPI-C" function
@@ -36,6 +39,11 @@ module uartdpi #(
     ctx = uartdpi_create(NAME);
     $sformat(file_name, "%s.log", NAME);
     file_handle = $fopen(file_name, "w");
+  end
+
+  final begin
+    uartdpi_close(ctx);
+    ctx = 0;
   end
 
   // TX

--- a/hw/top_earlgrey/top_earlgrey_verilator.core
+++ b/hw/top_earlgrey/top_earlgrey_verilator.core
@@ -57,6 +57,10 @@ parameters:
     datatype: bool
     paramtype: vlogdefine
     description: Use the OTBN model instead of the RTL implementation (development only)
+  UART_LOG_uart0:
+    datatype: string
+    paramtype: plusarg
+    description: Write a log of output from uart0 to the given log file. Use "-" for stdout.
 
 targets:
   default: &default_target


### PR DESCRIPTION
The UARTDPI module simulates an UART device by creating a pseudo-terminal
(e.g. /dev/pts/N). Additionally, each written character is also written to
a log file, in our case always `uart0.log` in the current directory.

This patch adds the ability to specify the path of the log file through a
plus argument (plusarg). The defaults remain unchanged: calling the 
simulation without special arguents writes an `uart0.log` file.

As a new feature, the log file can now also be given as "-", which writes
UART logs directly to STDOUT. In this case, the running simulation directly
shows all output printed from device software, e.g. from `LOG()` macros,
making the life of software developers much easier.

To write all logs of uart0 (the one and only UART in an Earl Grey system),
use a command like the following:

``` 
build/lowrisc_systems_top_earlgrey_verilator_0.1/sim-verilator/Vtop_earlgrey_verilator \
  --meminit=rom,build-bin/sw/device/boot_rom/boot_rom_sim_verilator.elf  \
  --meminit=flash,build-bin/sw/device/tests/dif_hmac_sanitytest_sim_verilator.elf \
  +UARTDPI_LOG_uart0=-
```

To implement this functionality, the log writing was refactored from 
SystemVerilog to C (DPI) code.