### PR TITLE
[otbn] Implement flag groups more explicitly in ISS

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/insn.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/insn.py
@@ -670,12 +670,7 @@ class BNRSEL(OTBNInsn):
         self.flag = op_vals['flag']
 
     def execute(self, model: OTBNModel) -> None:
-        # self.flag gives a number (0-3), which we need to convert to a flag
-        # name for use with BitflagRegister.
-        assert 0 <= self.flag <= 3
-        flag_name = ['C', 'L', 'M', 'Z'][self.flag]
-
-        flag_is_set = model.state.flags[self.flag_group].get(flag_name)
+        flag_is_set = model.state.flags[self.flag_group].get_by_idx(self.flag)
         val = model.state.wreg[self.wrs1 if flag_is_set else self.wrs2]
         model.state.wreg[self.wrd] = val
 


### PR DESCRIPTION
The behaviour is reasonably similar to what was there before, but is
now a bit more explicit and no longer uses AttrDict (from the attrdict
Python package that we had a missing dependency on) or
BitflagRegister (from riscvmodel.types).

There are some failing smoke tests (e.g. in PR #3487) that are caused by the missing dependency. Squinting a bit at what was going on, I decided that just implementing it by hand was actually clearer than relying on the dictionary magic.