### PR TITLE
[flash_ctrl] Flash ctrl scramble address lookup

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson
@@ -253,23 +253,6 @@
       ]
     },
 
-    { name: "SCRAMBLE_EN",
-      desc: "Scramble enable for flash",
-      swaccess: "rw",
-      hwaccess: "hro",
-      resval: "0",
-      fields: [
-        { bits: "0",
-          name: "VAL",
-          desc: '''
-            Temporary enable bit for flash scramble.
-            See #2630.
-            '''
-          resval: "0"
-        },
-      ]
-    },
-
 // TODO(#1412):
 // This multireg is temporarily removed until the nested multireg compact feature is fully implemented.
 // Until then, use only one register wen for all flash regions.
@@ -369,14 +352,21 @@
               ''',
               resval: "0"
             }
-            { bits: "12:4",
+            { bits: "4",
+              name: "SCRAMBLE_EN",
+              desc: '''
+                Region is scramble and ECC enabled.
+              ''',
+              resval: "0"
+            }
+            { bits: "16:8",
               name: "BASE",
               desc: '''
                 Region base page. Note the granularity is page, not byte or word
               ''',
               resval: "0"
             },
-            { bits: "25:16", // need to template this term long term for flash size
+            { bits: "29:20", // need to template this term long term for flash size
               name: "SIZE",
               desc: '''
                 Region size in number of pages
@@ -430,6 +420,13 @@
               ''',
               resval: "0"
             }
+            { bits: "4",
+              name: "SCRAMBLE_EN",
+              desc: '''
+                Region is scramble and ECC enabled.
+              ''',
+              resval: "0"
+            }
         ],
       },
     },
@@ -471,6 +468,13 @@
               name: "ERASE_EN",
               desc: '''
                 Region can be erased
+              ''',
+              resval: "0"
+            }
+            { bits: "4",
+              name: "SCRAMBLE_EN",
+              desc: '''
+                Region is scramble and ECC enabled.
               ''',
               resval: "0"
             }
@@ -518,6 +522,13 @@
               ''',
               resval: "0"
             }
+            { bits: "4",
+              name: "SCRAMBLE_EN",
+              desc: '''
+                Region is scramble and ECC enabled.
+              ''',
+              resval: "0"
+            }
         ],
       },
     },
@@ -562,6 +573,13 @@
               ''',
               resval: "0"
             }
+            { bits: "4",
+              name: "SCRAMBLE_EN",
+              desc: '''
+                Region is scramble and ECC enabled.
+              ''',
+              resval: "0"
+            }
         ],
       },
     },
@@ -590,6 +608,13 @@
           name: "ERASE_EN",
           desc: '''
             Region can be erased
+          ''',
+          resval: "0"
+        },
+        { bits: "3",
+          name: "SCRAMBLE_EN",
+          desc: '''
+            Region is scramble and ECC enabled
           ''',
           resval: "0"
         }

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -504,7 +504,7 @@ module flash_ctrl import flash_ctrl_pkg::*; (
   // Data partition protection configuration
   //////////////////////////////////////
   // extra region is the default region
-  flash_ctrl_reg2hw_mp_region_cfg_mreg_t [MpRegions:0] region_cfgs;
+  mp_region_cfg_t [MpRegions:0] region_cfgs;
   assign region_cfgs[MpRegions-1:0] = reg2hw.mp_region_cfg[MpRegions-1:0];
 
   //default region
@@ -514,6 +514,7 @@ module flash_ctrl import flash_ctrl_pkg::*; (
   assign region_cfgs[MpRegions].rd_en.q = reg2hw.default_region.rd_en.q;
   assign region_cfgs[MpRegions].prog_en.q = reg2hw.default_region.prog_en.q;
   assign region_cfgs[MpRegions].erase_en.q = reg2hw.default_region.erase_en.q;
+  assign region_cfgs[MpRegions].scramble_en.q = reg2hw.default_region.scramble_en.q;
 
   //////////////////////////////////////
   // Info partition protection configuration
@@ -589,6 +590,7 @@ module flash_ctrl import flash_ctrl_pkg::*; (
 
     // flash phy interface
     .req_o(flash_o.req),
+    .scramble_en_o(flash_o.scramble_en),
     .rd_o(flash_o.rd),
     .prog_o(flash_o.prog),
     .pg_erase_o(flash_o.pg_erase),
@@ -638,7 +640,7 @@ module flash_ctrl import flash_ctrl_pkg::*; (
   assign flash_o.prog_type = flash_prog_type;
   assign flash_o.prog_data = flash_prog_data;
   assign flash_o.prog_last = flash_prog_last;
-  assign flash_o.scramble_en = reg2hw.scramble_en.q;
+  assign flash_o.region_cfgs = region_cfgs;
   assign flash_o.addr_key = otp_i.addr_key;
   assign flash_o.data_key = otp_i.data_key;
   assign flash_rd_err = flash_i.rd_err;

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
@@ -125,17 +125,19 @@ package flash_ctrl_pkg;
   parameter int HwDataRules = 1;
 
   parameter info_page_cfg_t CfgAllowRead = '{
-    en: 1'b1,
-    rd_en: 1'b1,
-    prog_en: 1'b0,
-    erase_en: 1'b0
+    en:          1'b1,
+    rd_en:       1'b1,
+    prog_en:     1'b0,
+    erase_en:    1'b0,
+    scramble_en: 1'b0  // TBD, update to 1 once tb supports ECC
   };
 
   parameter info_page_cfg_t CfgAllowReadErase = '{
-    en: 1'b1,
-    rd_en: 1'b1,
-    prog_en: 1'b0,
-    erase_en: 1'b1
+    en:          1'b1,
+    rd_en:       1'b1,
+    prog_en:     1'b0,
+    erase_en:    1'b1,
+    scramble_en: 1'b0  // TBD, update to 1 once tb supports ECC
   };
 
   parameter info_page_attr_t HwInfoPageAttr[HwInfoRules] = '{
@@ -162,12 +164,13 @@ package flash_ctrl_pkg;
     '{
        phase: PhaseRma,
        cfg:   '{
-                 en:       1'b1,
-                 rd_en:    1'b1,
-                 prog_en:  1'b0,
-                 erase_en: 1'b1,
-                 base:     '0,
-                 size:     '{default:'1}
+                 en:          1'b1,
+                 rd_en:       1'b1,
+                 prog_en:     1'b0,
+                 erase_en:    1'b1,
+                 scramble_en: 1'b0,
+                 base:        '0,
+                 size:        '{default:'1}
                 }
      }
   };
@@ -220,6 +223,7 @@ package flash_ctrl_pkg;
   // Flash controller to memory
   typedef struct packed {
     logic                 req;
+    logic                 scramble_en;
     logic                 rd;
     logic                 prog;
     logic                 pg_erase;
@@ -229,26 +233,27 @@ package flash_ctrl_pkg;
     logic [BusWidth-1:0]  prog_data;
     logic                 prog_last;
     flash_prog_e          prog_type;
-    logic                 scramble_en;
+    mp_region_cfg_t [MpRegions:0] region_cfgs;
     logic [127:0]         addr_key;
     logic [127:0]         data_key;
   } flash_req_t;
 
   // default value of flash_req_t (for dangling ports)
   parameter flash_req_t FLASH_REQ_DEFAULT = '{
-    req:       1'b0,
-    rd:        1'b0,
-    prog:      1'b0,
-    pg_erase:  1'b0,
-    bk_erase:  1'b0,
-    part:      FlashPartData,
-    addr:      '0,
-    prog_data: '0,
-    prog_last: '0,
-    prog_type: FlashProgNormal,
-    scramble_en: '0,
-    addr_key:  128'hDEADBEEFBEEFFACEDEADBEEF5A5AA5A5,
-    data_key:  128'hDEADBEEF5A5AA5A5DEADBEEFBEEFFACE
+    req:         1'b0,
+    scramble_en: 1'b0,
+    rd:          1'b0,
+    prog:        1'b0,
+    pg_erase:    1'b0,
+    bk_erase:    1'b0,
+    part:        FlashPartData,
+    addr:        '0,
+    prog_data:   '0,
+    prog_last:   '0,
+    prog_type:   FlashProgNormal,
+    region_cfgs: '0,
+    addr_key:    128'hDEADBEEFBEEFFACEDEADBEEF5A5AA5A5,
+    data_key:    128'hDEADBEEF5A5AA5A5DEADBEEFBEEFFACE
   };
 
   // memory to flash controller

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
@@ -112,10 +112,6 @@ package flash_ctrl_reg_pkg;
   } flash_ctrl_reg2hw_addr_reg_t;
 
   typedef struct packed {
-    logic        q;
-  } flash_ctrl_reg2hw_scramble_en_reg_t;
-
-  typedef struct packed {
     struct packed {
       logic        q;
     } en;
@@ -128,6 +124,9 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        q;
     } erase_en;
+    struct packed {
+      logic        q;
+    } scramble_en;
     struct packed {
       logic [8:0]  q;
     } base;
@@ -149,6 +148,9 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        q;
     } erase_en;
+    struct packed {
+      logic        q;
+    } scramble_en;
   } flash_ctrl_reg2hw_bank0_info0_page_cfg_mreg_t;
 
   typedef struct packed {
@@ -164,6 +166,9 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        q;
     } erase_en;
+    struct packed {
+      logic        q;
+    } scramble_en;
   } flash_ctrl_reg2hw_bank0_info1_page_cfg_mreg_t;
 
   typedef struct packed {
@@ -179,6 +184,9 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        q;
     } erase_en;
+    struct packed {
+      logic        q;
+    } scramble_en;
   } flash_ctrl_reg2hw_bank1_info0_page_cfg_mreg_t;
 
   typedef struct packed {
@@ -194,6 +202,9 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        q;
     } erase_en;
+    struct packed {
+      logic        q;
+    } scramble_en;
   } flash_ctrl_reg2hw_bank1_info1_page_cfg_mreg_t;
 
   typedef struct packed {
@@ -206,6 +217,9 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        q;
     } erase_en;
+    struct packed {
+      logic        q;
+    } scramble_en;
   } flash_ctrl_reg2hw_default_region_reg_t;
 
   typedef struct packed {
@@ -326,18 +340,17 @@ package flash_ctrl_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    flash_ctrl_reg2hw_intr_state_reg_t intr_state; // [371:366]
-    flash_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [365:360]
-    flash_ctrl_reg2hw_intr_test_reg_t intr_test; // [359:348]
-    flash_ctrl_reg2hw_control_reg_t control; // [347:329]
-    flash_ctrl_reg2hw_addr_reg_t addr; // [328:297]
-    flash_ctrl_reg2hw_scramble_en_reg_t scramble_en; // [296:296]
-    flash_ctrl_reg2hw_mp_region_cfg_mreg_t [7:0] mp_region_cfg; // [295:112]
-    flash_ctrl_reg2hw_bank0_info0_page_cfg_mreg_t [3:0] bank0_info0_page_cfg; // [111:96]
-    flash_ctrl_reg2hw_bank0_info1_page_cfg_mreg_t [3:0] bank0_info1_page_cfg; // [95:80]
-    flash_ctrl_reg2hw_bank1_info0_page_cfg_mreg_t [3:0] bank1_info0_page_cfg; // [79:64]
-    flash_ctrl_reg2hw_bank1_info1_page_cfg_mreg_t [3:0] bank1_info1_page_cfg; // [63:48]
-    flash_ctrl_reg2hw_default_region_reg_t default_region; // [47:45]
+    flash_ctrl_reg2hw_intr_state_reg_t intr_state; // [395:390]
+    flash_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [389:384]
+    flash_ctrl_reg2hw_intr_test_reg_t intr_test; // [383:372]
+    flash_ctrl_reg2hw_control_reg_t control; // [371:353]
+    flash_ctrl_reg2hw_addr_reg_t addr; // [352:321]
+    flash_ctrl_reg2hw_mp_region_cfg_mreg_t [7:0] mp_region_cfg; // [320:129]
+    flash_ctrl_reg2hw_bank0_info0_page_cfg_mreg_t [3:0] bank0_info0_page_cfg; // [128:109]
+    flash_ctrl_reg2hw_bank0_info1_page_cfg_mreg_t [3:0] bank0_info1_page_cfg; // [108:89]
+    flash_ctrl_reg2hw_bank1_info0_page_cfg_mreg_t [3:0] bank1_info0_page_cfg; // [88:69]
+    flash_ctrl_reg2hw_bank1_info1_page_cfg_mreg_t [3:0] bank1_info1_page_cfg; // [68:49]
+    flash_ctrl_reg2hw_default_region_reg_t default_region; // [48:45]
     flash_ctrl_reg2hw_mp_bank_cfg_mreg_t [1:0] mp_bank_cfg; // [44:43]
     flash_ctrl_reg2hw_scratch_reg_t scratch; // [42:11]
     flash_ctrl_reg2hw_fifo_lvl_reg_t fifo_lvl; // [10:1]
@@ -363,46 +376,45 @@ package flash_ctrl_reg_pkg;
   parameter logic [7:0] FLASH_CTRL_CTRL_REGWEN_OFFSET = 8'h c;
   parameter logic [7:0] FLASH_CTRL_CONTROL_OFFSET = 8'h 10;
   parameter logic [7:0] FLASH_CTRL_ADDR_OFFSET = 8'h 14;
-  parameter logic [7:0] FLASH_CTRL_SCRAMBLE_EN_OFFSET = 8'h 18;
-  parameter logic [7:0] FLASH_CTRL_REGION_CFG_REGWEN_OFFSET = 8'h 1c;
-  parameter logic [7:0] FLASH_CTRL_MP_REGION_CFG_0_OFFSET = 8'h 20;
-  parameter logic [7:0] FLASH_CTRL_MP_REGION_CFG_1_OFFSET = 8'h 24;
-  parameter logic [7:0] FLASH_CTRL_MP_REGION_CFG_2_OFFSET = 8'h 28;
-  parameter logic [7:0] FLASH_CTRL_MP_REGION_CFG_3_OFFSET = 8'h 2c;
-  parameter logic [7:0] FLASH_CTRL_MP_REGION_CFG_4_OFFSET = 8'h 30;
-  parameter logic [7:0] FLASH_CTRL_MP_REGION_CFG_5_OFFSET = 8'h 34;
-  parameter logic [7:0] FLASH_CTRL_MP_REGION_CFG_6_OFFSET = 8'h 38;
-  parameter logic [7:0] FLASH_CTRL_MP_REGION_CFG_7_OFFSET = 8'h 3c;
-  parameter logic [7:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0_OFFSET = 8'h 40;
-  parameter logic [7:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_1_OFFSET = 8'h 44;
-  parameter logic [7:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_2_OFFSET = 8'h 48;
-  parameter logic [7:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_3_OFFSET = 8'h 4c;
-  parameter logic [7:0] FLASH_CTRL_BANK0_INFO1_PAGE_CFG_0_OFFSET = 8'h 50;
-  parameter logic [7:0] FLASH_CTRL_BANK0_INFO1_PAGE_CFG_1_OFFSET = 8'h 54;
-  parameter logic [7:0] FLASH_CTRL_BANK0_INFO1_PAGE_CFG_2_OFFSET = 8'h 58;
-  parameter logic [7:0] FLASH_CTRL_BANK0_INFO1_PAGE_CFG_3_OFFSET = 8'h 5c;
-  parameter logic [7:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_0_OFFSET = 8'h 60;
-  parameter logic [7:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_1_OFFSET = 8'h 64;
-  parameter logic [7:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_2_OFFSET = 8'h 68;
-  parameter logic [7:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_3_OFFSET = 8'h 6c;
-  parameter logic [7:0] FLASH_CTRL_BANK1_INFO1_PAGE_CFG_0_OFFSET = 8'h 70;
-  parameter logic [7:0] FLASH_CTRL_BANK1_INFO1_PAGE_CFG_1_OFFSET = 8'h 74;
-  parameter logic [7:0] FLASH_CTRL_BANK1_INFO1_PAGE_CFG_2_OFFSET = 8'h 78;
-  parameter logic [7:0] FLASH_CTRL_BANK1_INFO1_PAGE_CFG_3_OFFSET = 8'h 7c;
-  parameter logic [7:0] FLASH_CTRL_DEFAULT_REGION_OFFSET = 8'h 80;
-  parameter logic [7:0] FLASH_CTRL_BANK_CFG_REGWEN_OFFSET = 8'h 84;
-  parameter logic [7:0] FLASH_CTRL_MP_BANK_CFG_OFFSET = 8'h 88;
-  parameter logic [7:0] FLASH_CTRL_OP_STATUS_OFFSET = 8'h 8c;
-  parameter logic [7:0] FLASH_CTRL_STATUS_OFFSET = 8'h 90;
-  parameter logic [7:0] FLASH_CTRL_PHY_STATUS_OFFSET = 8'h 94;
-  parameter logic [7:0] FLASH_CTRL_SCRATCH_OFFSET = 8'h 98;
-  parameter logic [7:0] FLASH_CTRL_FIFO_LVL_OFFSET = 8'h 9c;
-  parameter logic [7:0] FLASH_CTRL_FIFO_RST_OFFSET = 8'h a0;
+  parameter logic [7:0] FLASH_CTRL_REGION_CFG_REGWEN_OFFSET = 8'h 18;
+  parameter logic [7:0] FLASH_CTRL_MP_REGION_CFG_0_OFFSET = 8'h 1c;
+  parameter logic [7:0] FLASH_CTRL_MP_REGION_CFG_1_OFFSET = 8'h 20;
+  parameter logic [7:0] FLASH_CTRL_MP_REGION_CFG_2_OFFSET = 8'h 24;
+  parameter logic [7:0] FLASH_CTRL_MP_REGION_CFG_3_OFFSET = 8'h 28;
+  parameter logic [7:0] FLASH_CTRL_MP_REGION_CFG_4_OFFSET = 8'h 2c;
+  parameter logic [7:0] FLASH_CTRL_MP_REGION_CFG_5_OFFSET = 8'h 30;
+  parameter logic [7:0] FLASH_CTRL_MP_REGION_CFG_6_OFFSET = 8'h 34;
+  parameter logic [7:0] FLASH_CTRL_MP_REGION_CFG_7_OFFSET = 8'h 38;
+  parameter logic [7:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0_OFFSET = 8'h 3c;
+  parameter logic [7:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_1_OFFSET = 8'h 40;
+  parameter logic [7:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_2_OFFSET = 8'h 44;
+  parameter logic [7:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_3_OFFSET = 8'h 48;
+  parameter logic [7:0] FLASH_CTRL_BANK0_INFO1_PAGE_CFG_0_OFFSET = 8'h 4c;
+  parameter logic [7:0] FLASH_CTRL_BANK0_INFO1_PAGE_CFG_1_OFFSET = 8'h 50;
+  parameter logic [7:0] FLASH_CTRL_BANK0_INFO1_PAGE_CFG_2_OFFSET = 8'h 54;
+  parameter logic [7:0] FLASH_CTRL_BANK0_INFO1_PAGE_CFG_3_OFFSET = 8'h 58;
+  parameter logic [7:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_0_OFFSET = 8'h 5c;
+  parameter logic [7:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_1_OFFSET = 8'h 60;
+  parameter logic [7:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_2_OFFSET = 8'h 64;
+  parameter logic [7:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_3_OFFSET = 8'h 68;
+  parameter logic [7:0] FLASH_CTRL_BANK1_INFO1_PAGE_CFG_0_OFFSET = 8'h 6c;
+  parameter logic [7:0] FLASH_CTRL_BANK1_INFO1_PAGE_CFG_1_OFFSET = 8'h 70;
+  parameter logic [7:0] FLASH_CTRL_BANK1_INFO1_PAGE_CFG_2_OFFSET = 8'h 74;
+  parameter logic [7:0] FLASH_CTRL_BANK1_INFO1_PAGE_CFG_3_OFFSET = 8'h 78;
+  parameter logic [7:0] FLASH_CTRL_DEFAULT_REGION_OFFSET = 8'h 7c;
+  parameter logic [7:0] FLASH_CTRL_BANK_CFG_REGWEN_OFFSET = 8'h 80;
+  parameter logic [7:0] FLASH_CTRL_MP_BANK_CFG_OFFSET = 8'h 84;
+  parameter logic [7:0] FLASH_CTRL_OP_STATUS_OFFSET = 8'h 88;
+  parameter logic [7:0] FLASH_CTRL_STATUS_OFFSET = 8'h 8c;
+  parameter logic [7:0] FLASH_CTRL_PHY_STATUS_OFFSET = 8'h 90;
+  parameter logic [7:0] FLASH_CTRL_SCRATCH_OFFSET = 8'h 94;
+  parameter logic [7:0] FLASH_CTRL_FIFO_LVL_OFFSET = 8'h 98;
+  parameter logic [7:0] FLASH_CTRL_FIFO_RST_OFFSET = 8'h 9c;
 
   // Window parameter
-  parameter logic [7:0] FLASH_CTRL_PROG_FIFO_OFFSET = 8'h a4;
+  parameter logic [7:0] FLASH_CTRL_PROG_FIFO_OFFSET = 8'h a0;
   parameter logic [7:0] FLASH_CTRL_PROG_FIFO_SIZE   = 8'h 4;
-  parameter logic [7:0] FLASH_CTRL_RD_FIFO_OFFSET = 8'h a8;
+  parameter logic [7:0] FLASH_CTRL_RD_FIFO_OFFSET = 8'h a4;
   parameter logic [7:0] FLASH_CTRL_RD_FIFO_SIZE   = 8'h 4;
 
   // Register Index
@@ -413,7 +425,6 @@ package flash_ctrl_reg_pkg;
     FLASH_CTRL_CTRL_REGWEN,
     FLASH_CTRL_CONTROL,
     FLASH_CTRL_ADDR,
-    FLASH_CTRL_SCRAMBLE_EN,
     FLASH_CTRL_REGION_CFG_REGWEN,
     FLASH_CTRL_MP_REGION_CFG_0,
     FLASH_CTRL_MP_REGION_CFG_1,
@@ -451,48 +462,47 @@ package flash_ctrl_reg_pkg;
   } flash_ctrl_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] FLASH_CTRL_PERMIT [41] = '{
+  parameter logic [3:0] FLASH_CTRL_PERMIT [40] = '{
     4'b 0001, // index[ 0] FLASH_CTRL_INTR_STATE
     4'b 0001, // index[ 1] FLASH_CTRL_INTR_ENABLE
     4'b 0001, // index[ 2] FLASH_CTRL_INTR_TEST
     4'b 0001, // index[ 3] FLASH_CTRL_CTRL_REGWEN
     4'b 1111, // index[ 4] FLASH_CTRL_CONTROL
     4'b 1111, // index[ 5] FLASH_CTRL_ADDR
-    4'b 0001, // index[ 6] FLASH_CTRL_SCRAMBLE_EN
-    4'b 0001, // index[ 7] FLASH_CTRL_REGION_CFG_REGWEN
-    4'b 1111, // index[ 8] FLASH_CTRL_MP_REGION_CFG_0
-    4'b 1111, // index[ 9] FLASH_CTRL_MP_REGION_CFG_1
-    4'b 1111, // index[10] FLASH_CTRL_MP_REGION_CFG_2
-    4'b 1111, // index[11] FLASH_CTRL_MP_REGION_CFG_3
-    4'b 1111, // index[12] FLASH_CTRL_MP_REGION_CFG_4
-    4'b 1111, // index[13] FLASH_CTRL_MP_REGION_CFG_5
-    4'b 1111, // index[14] FLASH_CTRL_MP_REGION_CFG_6
-    4'b 1111, // index[15] FLASH_CTRL_MP_REGION_CFG_7
-    4'b 0001, // index[16] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0
-    4'b 0001, // index[17] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_1
-    4'b 0001, // index[18] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_2
-    4'b 0001, // index[19] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_3
-    4'b 0001, // index[20] FLASH_CTRL_BANK0_INFO1_PAGE_CFG_0
-    4'b 0001, // index[21] FLASH_CTRL_BANK0_INFO1_PAGE_CFG_1
-    4'b 0001, // index[22] FLASH_CTRL_BANK0_INFO1_PAGE_CFG_2
-    4'b 0001, // index[23] FLASH_CTRL_BANK0_INFO1_PAGE_CFG_3
-    4'b 0001, // index[24] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_0
-    4'b 0001, // index[25] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_1
-    4'b 0001, // index[26] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_2
-    4'b 0001, // index[27] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_3
-    4'b 0001, // index[28] FLASH_CTRL_BANK1_INFO1_PAGE_CFG_0
-    4'b 0001, // index[29] FLASH_CTRL_BANK1_INFO1_PAGE_CFG_1
-    4'b 0001, // index[30] FLASH_CTRL_BANK1_INFO1_PAGE_CFG_2
-    4'b 0001, // index[31] FLASH_CTRL_BANK1_INFO1_PAGE_CFG_3
-    4'b 0001, // index[32] FLASH_CTRL_DEFAULT_REGION
-    4'b 0001, // index[33] FLASH_CTRL_BANK_CFG_REGWEN
-    4'b 0001, // index[34] FLASH_CTRL_MP_BANK_CFG
-    4'b 0001, // index[35] FLASH_CTRL_OP_STATUS
-    4'b 0111, // index[36] FLASH_CTRL_STATUS
-    4'b 0001, // index[37] FLASH_CTRL_PHY_STATUS
-    4'b 1111, // index[38] FLASH_CTRL_SCRATCH
-    4'b 0011, // index[39] FLASH_CTRL_FIFO_LVL
-    4'b 0001  // index[40] FLASH_CTRL_FIFO_RST
+    4'b 0001, // index[ 6] FLASH_CTRL_REGION_CFG_REGWEN
+    4'b 1111, // index[ 7] FLASH_CTRL_MP_REGION_CFG_0
+    4'b 1111, // index[ 8] FLASH_CTRL_MP_REGION_CFG_1
+    4'b 1111, // index[ 9] FLASH_CTRL_MP_REGION_CFG_2
+    4'b 1111, // index[10] FLASH_CTRL_MP_REGION_CFG_3
+    4'b 1111, // index[11] FLASH_CTRL_MP_REGION_CFG_4
+    4'b 1111, // index[12] FLASH_CTRL_MP_REGION_CFG_5
+    4'b 1111, // index[13] FLASH_CTRL_MP_REGION_CFG_6
+    4'b 1111, // index[14] FLASH_CTRL_MP_REGION_CFG_7
+    4'b 0001, // index[15] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0
+    4'b 0001, // index[16] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_1
+    4'b 0001, // index[17] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_2
+    4'b 0001, // index[18] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_3
+    4'b 0001, // index[19] FLASH_CTRL_BANK0_INFO1_PAGE_CFG_0
+    4'b 0001, // index[20] FLASH_CTRL_BANK0_INFO1_PAGE_CFG_1
+    4'b 0001, // index[21] FLASH_CTRL_BANK0_INFO1_PAGE_CFG_2
+    4'b 0001, // index[22] FLASH_CTRL_BANK0_INFO1_PAGE_CFG_3
+    4'b 0001, // index[23] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_0
+    4'b 0001, // index[24] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_1
+    4'b 0001, // index[25] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_2
+    4'b 0001, // index[26] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_3
+    4'b 0001, // index[27] FLASH_CTRL_BANK1_INFO1_PAGE_CFG_0
+    4'b 0001, // index[28] FLASH_CTRL_BANK1_INFO1_PAGE_CFG_1
+    4'b 0001, // index[29] FLASH_CTRL_BANK1_INFO1_PAGE_CFG_2
+    4'b 0001, // index[30] FLASH_CTRL_BANK1_INFO1_PAGE_CFG_3
+    4'b 0001, // index[31] FLASH_CTRL_DEFAULT_REGION
+    4'b 0001, // index[32] FLASH_CTRL_BANK_CFG_REGWEN
+    4'b 0001, // index[33] FLASH_CTRL_MP_BANK_CFG
+    4'b 0001, // index[34] FLASH_CTRL_OP_STATUS
+    4'b 0111, // index[35] FLASH_CTRL_STATUS
+    4'b 0001, // index[36] FLASH_CTRL_PHY_STATUS
+    4'b 1111, // index[37] FLASH_CTRL_SCRATCH
+    4'b 0011, // index[38] FLASH_CTRL_FIFO_LVL
+    4'b 0001  // index[39] FLASH_CTRL_FIFO_RST
   };
 endpackage
 

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_top.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_top.sv
@@ -88,10 +88,10 @@ module flash_ctrl_reg_top (
     reg_steer = 2;       // Default set to register
 
     // TODO: Can below codes be unique case () inside ?
-    if (tl_i.a_address[AW-1:0] >= 164 && tl_i.a_address[AW-1:0] < 168) begin
+    if (tl_i.a_address[AW-1:0] >= 160 && tl_i.a_address[AW-1:0] < 164) begin
       reg_steer = 0;
     end
-    if (tl_i.a_address[AW-1:0] >= 168 && tl_i.a_address[AW-1:0] < 172) begin
+    if (tl_i.a_address[AW-1:0] >= 164 && tl_i.a_address[AW-1:0] < 168) begin
       reg_steer = 1;
     end
   end
@@ -195,9 +195,6 @@ module flash_ctrl_reg_top (
   logic [31:0] addr_qs;
   logic [31:0] addr_wd;
   logic addr_we;
-  logic scramble_en_qs;
-  logic scramble_en_wd;
-  logic scramble_en_we;
   logic region_cfg_regwen_qs;
   logic region_cfg_regwen_wd;
   logic region_cfg_regwen_we;
@@ -213,6 +210,9 @@ module flash_ctrl_reg_top (
   logic mp_region_cfg_0_erase_en_0_qs;
   logic mp_region_cfg_0_erase_en_0_wd;
   logic mp_region_cfg_0_erase_en_0_we;
+  logic mp_region_cfg_0_scramble_en_0_qs;
+  logic mp_region_cfg_0_scramble_en_0_wd;
+  logic mp_region_cfg_0_scramble_en_0_we;
   logic [8:0] mp_region_cfg_0_base_0_qs;
   logic [8:0] mp_region_cfg_0_base_0_wd;
   logic mp_region_cfg_0_base_0_we;
@@ -231,6 +231,9 @@ module flash_ctrl_reg_top (
   logic mp_region_cfg_1_erase_en_1_qs;
   logic mp_region_cfg_1_erase_en_1_wd;
   logic mp_region_cfg_1_erase_en_1_we;
+  logic mp_region_cfg_1_scramble_en_1_qs;
+  logic mp_region_cfg_1_scramble_en_1_wd;
+  logic mp_region_cfg_1_scramble_en_1_we;
   logic [8:0] mp_region_cfg_1_base_1_qs;
   logic [8:0] mp_region_cfg_1_base_1_wd;
   logic mp_region_cfg_1_base_1_we;
@@ -249,6 +252,9 @@ module flash_ctrl_reg_top (
   logic mp_region_cfg_2_erase_en_2_qs;
   logic mp_region_cfg_2_erase_en_2_wd;
   logic mp_region_cfg_2_erase_en_2_we;
+  logic mp_region_cfg_2_scramble_en_2_qs;
+  logic mp_region_cfg_2_scramble_en_2_wd;
+  logic mp_region_cfg_2_scramble_en_2_we;
   logic [8:0] mp_region_cfg_2_base_2_qs;
   logic [8:0] mp_region_cfg_2_base_2_wd;
   logic mp_region_cfg_2_base_2_we;
@@ -267,6 +273,9 @@ module flash_ctrl_reg_top (
   logic mp_region_cfg_3_erase_en_3_qs;
   logic mp_region_cfg_3_erase_en_3_wd;
   logic mp_region_cfg_3_erase_en_3_we;
+  logic mp_region_cfg_3_scramble_en_3_qs;
+  logic mp_region_cfg_3_scramble_en_3_wd;
+  logic mp_region_cfg_3_scramble_en_3_we;
   logic [8:0] mp_region_cfg_3_base_3_qs;
   logic [8:0] mp_region_cfg_3_base_3_wd;
   logic mp_region_cfg_3_base_3_we;
@@ -285,6 +294,9 @@ module flash_ctrl_reg_top (
   logic mp_region_cfg_4_erase_en_4_qs;
   logic mp_region_cfg_4_erase_en_4_wd;
   logic mp_region_cfg_4_erase_en_4_we;
+  logic mp_region_cfg_4_scramble_en_4_qs;
+  logic mp_region_cfg_4_scramble_en_4_wd;
+  logic mp_region_cfg_4_scramble_en_4_we;
   logic [8:0] mp_region_cfg_4_base_4_qs;
   logic [8:0] mp_region_cfg_4_base_4_wd;
   logic mp_region_cfg_4_base_4_we;
@@ -303,6 +315,9 @@ module flash_ctrl_reg_top (
   logic mp_region_cfg_5_erase_en_5_qs;
   logic mp_region_cfg_5_erase_en_5_wd;
   logic mp_region_cfg_5_erase_en_5_we;
+  logic mp_region_cfg_5_scramble_en_5_qs;
+  logic mp_region_cfg_5_scramble_en_5_wd;
+  logic mp_region_cfg_5_scramble_en_5_we;
   logic [8:0] mp_region_cfg_5_base_5_qs;
   logic [8:0] mp_region_cfg_5_base_5_wd;
   logic mp_region_cfg_5_base_5_we;
@@ -321,6 +336,9 @@ module flash_ctrl_reg_top (
   logic mp_region_cfg_6_erase_en_6_qs;
   logic mp_region_cfg_6_erase_en_6_wd;
   logic mp_region_cfg_6_erase_en_6_we;
+  logic mp_region_cfg_6_scramble_en_6_qs;
+  logic mp_region_cfg_6_scramble_en_6_wd;
+  logic mp_region_cfg_6_scramble_en_6_we;
   logic [8:0] mp_region_cfg_6_base_6_qs;
   logic [8:0] mp_region_cfg_6_base_6_wd;
   logic mp_region_cfg_6_base_6_we;
@@ -339,6 +357,9 @@ module flash_ctrl_reg_top (
   logic mp_region_cfg_7_erase_en_7_qs;
   logic mp_region_cfg_7_erase_en_7_wd;
   logic mp_region_cfg_7_erase_en_7_we;
+  logic mp_region_cfg_7_scramble_en_7_qs;
+  logic mp_region_cfg_7_scramble_en_7_wd;
+  logic mp_region_cfg_7_scramble_en_7_we;
   logic [8:0] mp_region_cfg_7_base_7_qs;
   logic [8:0] mp_region_cfg_7_base_7_wd;
   logic mp_region_cfg_7_base_7_we;
@@ -357,6 +378,9 @@ module flash_ctrl_reg_top (
   logic bank0_info0_page_cfg_0_erase_en_0_qs;
   logic bank0_info0_page_cfg_0_erase_en_0_wd;
   logic bank0_info0_page_cfg_0_erase_en_0_we;
+  logic bank0_info0_page_cfg_0_scramble_en_0_qs;
+  logic bank0_info0_page_cfg_0_scramble_en_0_wd;
+  logic bank0_info0_page_cfg_0_scramble_en_0_we;
   logic bank0_info0_page_cfg_1_en_1_qs;
   logic bank0_info0_page_cfg_1_en_1_wd;
   logic bank0_info0_page_cfg_1_en_1_we;
@@ -369,6 +393,9 @@ module flash_ctrl_reg_top (
   logic bank0_info0_page_cfg_1_erase_en_1_qs;
   logic bank0_info0_page_cfg_1_erase_en_1_wd;
   logic bank0_info0_page_cfg_1_erase_en_1_we;
+  logic bank0_info0_page_cfg_1_scramble_en_1_qs;
+  logic bank0_info0_page_cfg_1_scramble_en_1_wd;
+  logic bank0_info0_page_cfg_1_scramble_en_1_we;
   logic bank0_info0_page_cfg_2_en_2_qs;
   logic bank0_info0_page_cfg_2_en_2_wd;
   logic bank0_info0_page_cfg_2_en_2_we;
@@ -381,6 +408,9 @@ module flash_ctrl_reg_top (
   logic bank0_info0_page_cfg_2_erase_en_2_qs;
   logic bank0_info0_page_cfg_2_erase_en_2_wd;
   logic bank0_info0_page_cfg_2_erase_en_2_we;
+  logic bank0_info0_page_cfg_2_scramble_en_2_qs;
+  logic bank0_info0_page_cfg_2_scramble_en_2_wd;
+  logic bank0_info0_page_cfg_2_scramble_en_2_we;
   logic bank0_info0_page_cfg_3_en_3_qs;
   logic bank0_info0_page_cfg_3_en_3_wd;
   logic bank0_info0_page_cfg_3_en_3_we;
@@ -393,6 +423,9 @@ module flash_ctrl_reg_top (
   logic bank0_info0_page_cfg_3_erase_en_3_qs;
   logic bank0_info0_page_cfg_3_erase_en_3_wd;
   logic bank0_info0_page_cfg_3_erase_en_3_we;
+  logic bank0_info0_page_cfg_3_scramble_en_3_qs;
+  logic bank0_info0_page_cfg_3_scramble_en_3_wd;
+  logic bank0_info0_page_cfg_3_scramble_en_3_we;
   logic bank0_info1_page_cfg_0_en_0_qs;
   logic bank0_info1_page_cfg_0_en_0_wd;
   logic bank0_info1_page_cfg_0_en_0_we;
@@ -405,6 +438,9 @@ module flash_ctrl_reg_top (
   logic bank0_info1_page_cfg_0_erase_en_0_qs;
   logic bank0_info1_page_cfg_0_erase_en_0_wd;
   logic bank0_info1_page_cfg_0_erase_en_0_we;
+  logic bank0_info1_page_cfg_0_scramble_en_0_qs;
+  logic bank0_info1_page_cfg_0_scramble_en_0_wd;
+  logic bank0_info1_page_cfg_0_scramble_en_0_we;
   logic bank0_info1_page_cfg_1_en_1_qs;
   logic bank0_info1_page_cfg_1_en_1_wd;
   logic bank0_info1_page_cfg_1_en_1_we;
@@ -417,6 +453,9 @@ module flash_ctrl_reg_top (
   logic bank0_info1_page_cfg_1_erase_en_1_qs;
   logic bank0_info1_page_cfg_1_erase_en_1_wd;
   logic bank0_info1_page_cfg_1_erase_en_1_we;
+  logic bank0_info1_page_cfg_1_scramble_en_1_qs;
+  logic bank0_info1_page_cfg_1_scramble_en_1_wd;
+  logic bank0_info1_page_cfg_1_scramble_en_1_we;
   logic bank0_info1_page_cfg_2_en_2_qs;
   logic bank0_info1_page_cfg_2_en_2_wd;
   logic bank0_info1_page_cfg_2_en_2_we;
@@ -429,6 +468,9 @@ module flash_ctrl_reg_top (
   logic bank0_info1_page_cfg_2_erase_en_2_qs;
   logic bank0_info1_page_cfg_2_erase_en_2_wd;
   logic bank0_info1_page_cfg_2_erase_en_2_we;
+  logic bank0_info1_page_cfg_2_scramble_en_2_qs;
+  logic bank0_info1_page_cfg_2_scramble_en_2_wd;
+  logic bank0_info1_page_cfg_2_scramble_en_2_we;
   logic bank0_info1_page_cfg_3_en_3_qs;
   logic bank0_info1_page_cfg_3_en_3_wd;
   logic bank0_info1_page_cfg_3_en_3_we;
@@ -441,6 +483,9 @@ module flash_ctrl_reg_top (
   logic bank0_info1_page_cfg_3_erase_en_3_qs;
   logic bank0_info1_page_cfg_3_erase_en_3_wd;
   logic bank0_info1_page_cfg_3_erase_en_3_we;
+  logic bank0_info1_page_cfg_3_scramble_en_3_qs;
+  logic bank0_info1_page_cfg_3_scramble_en_3_wd;
+  logic bank0_info1_page_cfg_3_scramble_en_3_we;
   logic bank1_info0_page_cfg_0_en_0_qs;
   logic bank1_info0_page_cfg_0_en_0_wd;
   logic bank1_info0_page_cfg_0_en_0_we;
@@ -453,6 +498,9 @@ module flash_ctrl_reg_top (
   logic bank1_info0_page_cfg_0_erase_en_0_qs;
   logic bank1_info0_page_cfg_0_erase_en_0_wd;
   logic bank1_info0_page_cfg_0_erase_en_0_we;
+  logic bank1_info0_page_cfg_0_scramble_en_0_qs;
+  logic bank1_info0_page_cfg_0_scramble_en_0_wd;
+  logic bank1_info0_page_cfg_0_scramble_en_0_we;
   logic bank1_info0_page_cfg_1_en_1_qs;
   logic bank1_info0_page_cfg_1_en_1_wd;
   logic bank1_info0_page_cfg_1_en_1_we;
@@ -465,6 +513,9 @@ module flash_ctrl_reg_top (
   logic bank1_info0_page_cfg_1_erase_en_1_qs;
   logic bank1_info0_page_cfg_1_erase_en_1_wd;
   logic bank1_info0_page_cfg_1_erase_en_1_we;
+  logic bank1_info0_page_cfg_1_scramble_en_1_qs;
+  logic bank1_info0_page_cfg_1_scramble_en_1_wd;
+  logic bank1_info0_page_cfg_1_scramble_en_1_we;
   logic bank1_info0_page_cfg_2_en_2_qs;
   logic bank1_info0_page_cfg_2_en_2_wd;
   logic bank1_info0_page_cfg_2_en_2_we;
@@ -477,6 +528,9 @@ module flash_ctrl_reg_top (
   logic bank1_info0_page_cfg_2_erase_en_2_qs;
   logic bank1_info0_page_cfg_2_erase_en_2_wd;
   logic bank1_info0_page_cfg_2_erase_en_2_we;
+  logic bank1_info0_page_cfg_2_scramble_en_2_qs;
+  logic bank1_info0_page_cfg_2_scramble_en_2_wd;
+  logic bank1_info0_page_cfg_2_scramble_en_2_we;
   logic bank1_info0_page_cfg_3_en_3_qs;
   logic bank1_info0_page_cfg_3_en_3_wd;
   logic bank1_info0_page_cfg_3_en_3_we;
@@ -489,6 +543,9 @@ module flash_ctrl_reg_top (
   logic bank1_info0_page_cfg_3_erase_en_3_qs;
   logic bank1_info0_page_cfg_3_erase_en_3_wd;
   logic bank1_info0_page_cfg_3_erase_en_3_we;
+  logic bank1_info0_page_cfg_3_scramble_en_3_qs;
+  logic bank1_info0_page_cfg_3_scramble_en_3_wd;
+  logic bank1_info0_page_cfg_3_scramble_en_3_we;
   logic bank1_info1_page_cfg_0_en_0_qs;
   logic bank1_info1_page_cfg_0_en_0_wd;
   logic bank1_info1_page_cfg_0_en_0_we;
@@ -501,6 +558,9 @@ module flash_ctrl_reg_top (
   logic bank1_info1_page_cfg_0_erase_en_0_qs;
   logic bank1_info1_page_cfg_0_erase_en_0_wd;
   logic bank1_info1_page_cfg_0_erase_en_0_we;
+  logic bank1_info1_page_cfg_0_scramble_en_0_qs;
+  logic bank1_info1_page_cfg_0_scramble_en_0_wd;
+  logic bank1_info1_page_cfg_0_scramble_en_0_we;
   logic bank1_info1_page_cfg_1_en_1_qs;
   logic bank1_info1_page_cfg_1_en_1_wd;
   logic bank1_info1_page_cfg_1_en_1_we;
@@ -513,6 +573,9 @@ module flash_ctrl_reg_top (
   logic bank1_info1_page_cfg_1_erase_en_1_qs;
   logic bank1_info1_page_cfg_1_erase_en_1_wd;
   logic bank1_info1_page_cfg_1_erase_en_1_we;
+  logic bank1_info1_page_cfg_1_scramble_en_1_qs;
+  logic bank1_info1_page_cfg_1_scramble_en_1_wd;
+  logic bank1_info1_page_cfg_1_scramble_en_1_we;
   logic bank1_info1_page_cfg_2_en_2_qs;
   logic bank1_info1_page_cfg_2_en_2_wd;
   logic bank1_info1_page_cfg_2_en_2_we;
@@ -525,6 +588,9 @@ module flash_ctrl_reg_top (
   logic bank1_info1_page_cfg_2_erase_en_2_qs;
   logic bank1_info1_page_cfg_2_erase_en_2_wd;
   logic bank1_info1_page_cfg_2_erase_en_2_we;
+  logic bank1_info1_page_cfg_2_scramble_en_2_qs;
+  logic bank1_info1_page_cfg_2_scramble_en_2_wd;
+  logic bank1_info1_page_cfg_2_scramble_en_2_we;
   logic bank1_info1_page_cfg_3_en_3_qs;
   logic bank1_info1_page_cfg_3_en_3_wd;
   logic bank1_info1_page_cfg_3_en_3_we;
@@ -537,6 +603,9 @@ module flash_ctrl_reg_top (
   logic bank1_info1_page_cfg_3_erase_en_3_qs;
   logic bank1_info1_page_cfg_3_erase_en_3_wd;
   logic bank1_info1_page_cfg_3_erase_en_3_we;
+  logic bank1_info1_page_cfg_3_scramble_en_3_qs;
+  logic bank1_info1_page_cfg_3_scramble_en_3_wd;
+  logic bank1_info1_page_cfg_3_scramble_en_3_we;
   logic default_region_rd_en_qs;
   logic default_region_rd_en_wd;
   logic default_region_rd_en_we;
@@ -546,6 +615,9 @@ module flash_ctrl_reg_top (
   logic default_region_erase_en_qs;
   logic default_region_erase_en_wd;
   logic default_region_erase_en_we;
+  logic default_region_scramble_en_qs;
+  logic default_region_scramble_en_wd;
+  logic default_region_scramble_en_we;
   logic bank_cfg_regwen_qs;
   logic bank_cfg_regwen_wd;
   logic bank_cfg_regwen_we;
@@ -1219,33 +1291,6 @@ module flash_ctrl_reg_top (
   );
 
 
-  // R[scramble_en]: V(False)
-
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_scramble_en (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (scramble_en_we),
-    .wd     (scramble_en_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.scramble_en.q ),
-
-    // to register interface (read)
-    .qs     (scramble_en_qs)
-  );
-
-
   // R[region_cfg_regwen]: V(False)
 
   prim_subreg #(
@@ -1381,7 +1426,33 @@ module flash_ctrl_reg_top (
   );
 
 
-  // F[base_0]: 12:4
+  // F[scramble_en_0]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_mp_region_cfg_0_scramble_en_0 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (mp_region_cfg_0_scramble_en_0_we & region_cfg_regwen_qs),
+    .wd     (mp_region_cfg_0_scramble_en_0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.mp_region_cfg[0].scramble_en.q ),
+
+    // to register interface (read)
+    .qs     (mp_region_cfg_0_scramble_en_0_qs)
+  );
+
+
+  // F[base_0]: 16:8
   prim_subreg #(
     .DW      (9),
     .SWACCESS("RW"),
@@ -1407,7 +1478,7 @@ module flash_ctrl_reg_top (
   );
 
 
-  // F[size_0]: 25:16
+  // F[size_0]: 29:20
   prim_subreg #(
     .DW      (10),
     .SWACCESS("RW"),
@@ -1540,7 +1611,33 @@ module flash_ctrl_reg_top (
   );
 
 
-  // F[base_1]: 12:4
+  // F[scramble_en_1]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_mp_region_cfg_1_scramble_en_1 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (mp_region_cfg_1_scramble_en_1_we & region_cfg_regwen_qs),
+    .wd     (mp_region_cfg_1_scramble_en_1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.mp_region_cfg[1].scramble_en.q ),
+
+    // to register interface (read)
+    .qs     (mp_region_cfg_1_scramble_en_1_qs)
+  );
+
+
+  // F[base_1]: 16:8
   prim_subreg #(
     .DW      (9),
     .SWACCESS("RW"),
@@ -1566,7 +1663,7 @@ module flash_ctrl_reg_top (
   );
 
 
-  // F[size_1]: 25:16
+  // F[size_1]: 29:20
   prim_subreg #(
     .DW      (10),
     .SWACCESS("RW"),
@@ -1699,7 +1796,33 @@ module flash_ctrl_reg_top (
   );
 
 
-  // F[base_2]: 12:4
+  // F[scramble_en_2]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_mp_region_cfg_2_scramble_en_2 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (mp_region_cfg_2_scramble_en_2_we & region_cfg_regwen_qs),
+    .wd     (mp_region_cfg_2_scramble_en_2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.mp_region_cfg[2].scramble_en.q ),
+
+    // to register interface (read)
+    .qs     (mp_region_cfg_2_scramble_en_2_qs)
+  );
+
+
+  // F[base_2]: 16:8
   prim_subreg #(
     .DW      (9),
     .SWACCESS("RW"),
@@ -1725,7 +1848,7 @@ module flash_ctrl_reg_top (
   );
 
 
-  // F[size_2]: 25:16
+  // F[size_2]: 29:20
   prim_subreg #(
     .DW      (10),
     .SWACCESS("RW"),
@@ -1858,7 +1981,33 @@ module flash_ctrl_reg_top (
   );
 
 
-  // F[base_3]: 12:4
+  // F[scramble_en_3]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_mp_region_cfg_3_scramble_en_3 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (mp_region_cfg_3_scramble_en_3_we & region_cfg_regwen_qs),
+    .wd     (mp_region_cfg_3_scramble_en_3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.mp_region_cfg[3].scramble_en.q ),
+
+    // to register interface (read)
+    .qs     (mp_region_cfg_3_scramble_en_3_qs)
+  );
+
+
+  // F[base_3]: 16:8
   prim_subreg #(
     .DW      (9),
     .SWACCESS("RW"),
@@ -1884,7 +2033,7 @@ module flash_ctrl_reg_top (
   );
 
 
-  // F[size_3]: 25:16
+  // F[size_3]: 29:20
   prim_subreg #(
     .DW      (10),
     .SWACCESS("RW"),
@@ -2017,7 +2166,33 @@ module flash_ctrl_reg_top (
   );
 
 
-  // F[base_4]: 12:4
+  // F[scramble_en_4]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_mp_region_cfg_4_scramble_en_4 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (mp_region_cfg_4_scramble_en_4_we & region_cfg_regwen_qs),
+    .wd     (mp_region_cfg_4_scramble_en_4_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.mp_region_cfg[4].scramble_en.q ),
+
+    // to register interface (read)
+    .qs     (mp_region_cfg_4_scramble_en_4_qs)
+  );
+
+
+  // F[base_4]: 16:8
   prim_subreg #(
     .DW      (9),
     .SWACCESS("RW"),
@@ -2043,7 +2218,7 @@ module flash_ctrl_reg_top (
   );
 
 
-  // F[size_4]: 25:16
+  // F[size_4]: 29:20
   prim_subreg #(
     .DW      (10),
     .SWACCESS("RW"),
@@ -2176,7 +2351,33 @@ module flash_ctrl_reg_top (
   );
 
 
-  // F[base_5]: 12:4
+  // F[scramble_en_5]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_mp_region_cfg_5_scramble_en_5 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (mp_region_cfg_5_scramble_en_5_we & region_cfg_regwen_qs),
+    .wd     (mp_region_cfg_5_scramble_en_5_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.mp_region_cfg[5].scramble_en.q ),
+
+    // to register interface (read)
+    .qs     (mp_region_cfg_5_scramble_en_5_qs)
+  );
+
+
+  // F[base_5]: 16:8
   prim_subreg #(
     .DW      (9),
     .SWACCESS("RW"),
@@ -2202,7 +2403,7 @@ module flash_ctrl_reg_top (
   );
 
 
-  // F[size_5]: 25:16
+  // F[size_5]: 29:20
   prim_subreg #(
     .DW      (10),
     .SWACCESS("RW"),
@@ -2335,7 +2536,33 @@ module flash_ctrl_reg_top (
   );
 
 
-  // F[base_6]: 12:4
+  // F[scramble_en_6]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_mp_region_cfg_6_scramble_en_6 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (mp_region_cfg_6_scramble_en_6_we & region_cfg_regwen_qs),
+    .wd     (mp_region_cfg_6_scramble_en_6_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.mp_region_cfg[6].scramble_en.q ),
+
+    // to register interface (read)
+    .qs     (mp_region_cfg_6_scramble_en_6_qs)
+  );
+
+
+  // F[base_6]: 16:8
   prim_subreg #(
     .DW      (9),
     .SWACCESS("RW"),
@@ -2361,7 +2588,7 @@ module flash_ctrl_reg_top (
   );
 
 
-  // F[size_6]: 25:16
+  // F[size_6]: 29:20
   prim_subreg #(
     .DW      (10),
     .SWACCESS("RW"),
@@ -2494,7 +2721,33 @@ module flash_ctrl_reg_top (
   );
 
 
-  // F[base_7]: 12:4
+  // F[scramble_en_7]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_mp_region_cfg_7_scramble_en_7 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (mp_region_cfg_7_scramble_en_7_we & region_cfg_regwen_qs),
+    .wd     (mp_region_cfg_7_scramble_en_7_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.mp_region_cfg[7].scramble_en.q ),
+
+    // to register interface (read)
+    .qs     (mp_region_cfg_7_scramble_en_7_qs)
+  );
+
+
+  // F[base_7]: 16:8
   prim_subreg #(
     .DW      (9),
     .SWACCESS("RW"),
@@ -2520,7 +2773,7 @@ module flash_ctrl_reg_top (
   );
 
 
-  // F[size_7]: 25:16
+  // F[size_7]: 29:20
   prim_subreg #(
     .DW      (10),
     .SWACCESS("RW"),
@@ -2655,6 +2908,32 @@ module flash_ctrl_reg_top (
   );
 
 
+  // F[scramble_en_0]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank0_info0_page_cfg_0_scramble_en_0 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank0_info0_page_cfg_0_scramble_en_0_we & region_cfg_regwen_qs),
+    .wd     (bank0_info0_page_cfg_0_scramble_en_0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank0_info0_page_cfg[0].scramble_en.q ),
+
+    // to register interface (read)
+    .qs     (bank0_info0_page_cfg_0_scramble_en_0_qs)
+  );
+
+
   // Subregister 1 of Multireg bank0_info0_page_cfg
   // R[bank0_info0_page_cfg_1]: V(False)
 
@@ -2759,6 +3038,32 @@ module flash_ctrl_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_1_erase_en_1_qs)
+  );
+
+
+  // F[scramble_en_1]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank0_info0_page_cfg_1_scramble_en_1 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank0_info0_page_cfg_1_scramble_en_1_we & region_cfg_regwen_qs),
+    .wd     (bank0_info0_page_cfg_1_scramble_en_1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank0_info0_page_cfg[1].scramble_en.q ),
+
+    // to register interface (read)
+    .qs     (bank0_info0_page_cfg_1_scramble_en_1_qs)
   );
 
 
@@ -2869,6 +3174,32 @@ module flash_ctrl_reg_top (
   );
 
 
+  // F[scramble_en_2]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank0_info0_page_cfg_2_scramble_en_2 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank0_info0_page_cfg_2_scramble_en_2_we & region_cfg_regwen_qs),
+    .wd     (bank0_info0_page_cfg_2_scramble_en_2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank0_info0_page_cfg[2].scramble_en.q ),
+
+    // to register interface (read)
+    .qs     (bank0_info0_page_cfg_2_scramble_en_2_qs)
+  );
+
+
   // Subregister 3 of Multireg bank0_info0_page_cfg
   // R[bank0_info0_page_cfg_3]: V(False)
 
@@ -2973,6 +3304,32 @@ module flash_ctrl_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_3_erase_en_3_qs)
+  );
+
+
+  // F[scramble_en_3]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank0_info0_page_cfg_3_scramble_en_3 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank0_info0_page_cfg_3_scramble_en_3_we & region_cfg_regwen_qs),
+    .wd     (bank0_info0_page_cfg_3_scramble_en_3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank0_info0_page_cfg[3].scramble_en.q ),
+
+    // to register interface (read)
+    .qs     (bank0_info0_page_cfg_3_scramble_en_3_qs)
   );
 
 
@@ -3085,6 +3442,32 @@ module flash_ctrl_reg_top (
   );
 
 
+  // F[scramble_en_0]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank0_info1_page_cfg_0_scramble_en_0 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank0_info1_page_cfg_0_scramble_en_0_we & region_cfg_regwen_qs),
+    .wd     (bank0_info1_page_cfg_0_scramble_en_0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank0_info1_page_cfg[0].scramble_en.q ),
+
+    // to register interface (read)
+    .qs     (bank0_info1_page_cfg_0_scramble_en_0_qs)
+  );
+
+
   // Subregister 1 of Multireg bank0_info1_page_cfg
   // R[bank0_info1_page_cfg_1]: V(False)
 
@@ -3189,6 +3572,32 @@ module flash_ctrl_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info1_page_cfg_1_erase_en_1_qs)
+  );
+
+
+  // F[scramble_en_1]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank0_info1_page_cfg_1_scramble_en_1 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank0_info1_page_cfg_1_scramble_en_1_we & region_cfg_regwen_qs),
+    .wd     (bank0_info1_page_cfg_1_scramble_en_1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank0_info1_page_cfg[1].scramble_en.q ),
+
+    // to register interface (read)
+    .qs     (bank0_info1_page_cfg_1_scramble_en_1_qs)
   );
 
 
@@ -3299,6 +3708,32 @@ module flash_ctrl_reg_top (
   );
 
 
+  // F[scramble_en_2]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank0_info1_page_cfg_2_scramble_en_2 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank0_info1_page_cfg_2_scramble_en_2_we & region_cfg_regwen_qs),
+    .wd     (bank0_info1_page_cfg_2_scramble_en_2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank0_info1_page_cfg[2].scramble_en.q ),
+
+    // to register interface (read)
+    .qs     (bank0_info1_page_cfg_2_scramble_en_2_qs)
+  );
+
+
   // Subregister 3 of Multireg bank0_info1_page_cfg
   // R[bank0_info1_page_cfg_3]: V(False)
 
@@ -3403,6 +3838,32 @@ module flash_ctrl_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info1_page_cfg_3_erase_en_3_qs)
+  );
+
+
+  // F[scramble_en_3]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank0_info1_page_cfg_3_scramble_en_3 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank0_info1_page_cfg_3_scramble_en_3_we & region_cfg_regwen_qs),
+    .wd     (bank0_info1_page_cfg_3_scramble_en_3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank0_info1_page_cfg[3].scramble_en.q ),
+
+    // to register interface (read)
+    .qs     (bank0_info1_page_cfg_3_scramble_en_3_qs)
   );
 
 
@@ -3515,6 +3976,32 @@ module flash_ctrl_reg_top (
   );
 
 
+  // F[scramble_en_0]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank1_info0_page_cfg_0_scramble_en_0 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank1_info0_page_cfg_0_scramble_en_0_we & region_cfg_regwen_qs),
+    .wd     (bank1_info0_page_cfg_0_scramble_en_0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank1_info0_page_cfg[0].scramble_en.q ),
+
+    // to register interface (read)
+    .qs     (bank1_info0_page_cfg_0_scramble_en_0_qs)
+  );
+
+
   // Subregister 1 of Multireg bank1_info0_page_cfg
   // R[bank1_info0_page_cfg_1]: V(False)
 
@@ -3619,6 +4106,32 @@ module flash_ctrl_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_1_erase_en_1_qs)
+  );
+
+
+  // F[scramble_en_1]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank1_info0_page_cfg_1_scramble_en_1 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank1_info0_page_cfg_1_scramble_en_1_we & region_cfg_regwen_qs),
+    .wd     (bank1_info0_page_cfg_1_scramble_en_1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank1_info0_page_cfg[1].scramble_en.q ),
+
+    // to register interface (read)
+    .qs     (bank1_info0_page_cfg_1_scramble_en_1_qs)
   );
 
 
@@ -3729,6 +4242,32 @@ module flash_ctrl_reg_top (
   );
 
 
+  // F[scramble_en_2]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank1_info0_page_cfg_2_scramble_en_2 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank1_info0_page_cfg_2_scramble_en_2_we & region_cfg_regwen_qs),
+    .wd     (bank1_info0_page_cfg_2_scramble_en_2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank1_info0_page_cfg[2].scramble_en.q ),
+
+    // to register interface (read)
+    .qs     (bank1_info0_page_cfg_2_scramble_en_2_qs)
+  );
+
+
   // Subregister 3 of Multireg bank1_info0_page_cfg
   // R[bank1_info0_page_cfg_3]: V(False)
 
@@ -3833,6 +4372,32 @@ module flash_ctrl_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_3_erase_en_3_qs)
+  );
+
+
+  // F[scramble_en_3]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank1_info0_page_cfg_3_scramble_en_3 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank1_info0_page_cfg_3_scramble_en_3_we & region_cfg_regwen_qs),
+    .wd     (bank1_info0_page_cfg_3_scramble_en_3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank1_info0_page_cfg[3].scramble_en.q ),
+
+    // to register interface (read)
+    .qs     (bank1_info0_page_cfg_3_scramble_en_3_qs)
   );
 
 
@@ -3945,6 +4510,32 @@ module flash_ctrl_reg_top (
   );
 
 
+  // F[scramble_en_0]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank1_info1_page_cfg_0_scramble_en_0 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank1_info1_page_cfg_0_scramble_en_0_we & region_cfg_regwen_qs),
+    .wd     (bank1_info1_page_cfg_0_scramble_en_0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank1_info1_page_cfg[0].scramble_en.q ),
+
+    // to register interface (read)
+    .qs     (bank1_info1_page_cfg_0_scramble_en_0_qs)
+  );
+
+
   // Subregister 1 of Multireg bank1_info1_page_cfg
   // R[bank1_info1_page_cfg_1]: V(False)
 
@@ -4049,6 +4640,32 @@ module flash_ctrl_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info1_page_cfg_1_erase_en_1_qs)
+  );
+
+
+  // F[scramble_en_1]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank1_info1_page_cfg_1_scramble_en_1 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank1_info1_page_cfg_1_scramble_en_1_we & region_cfg_regwen_qs),
+    .wd     (bank1_info1_page_cfg_1_scramble_en_1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank1_info1_page_cfg[1].scramble_en.q ),
+
+    // to register interface (read)
+    .qs     (bank1_info1_page_cfg_1_scramble_en_1_qs)
   );
 
 
@@ -4159,6 +4776,32 @@ module flash_ctrl_reg_top (
   );
 
 
+  // F[scramble_en_2]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank1_info1_page_cfg_2_scramble_en_2 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank1_info1_page_cfg_2_scramble_en_2_we & region_cfg_regwen_qs),
+    .wd     (bank1_info1_page_cfg_2_scramble_en_2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank1_info1_page_cfg[2].scramble_en.q ),
+
+    // to register interface (read)
+    .qs     (bank1_info1_page_cfg_2_scramble_en_2_qs)
+  );
+
+
   // Subregister 3 of Multireg bank1_info1_page_cfg
   // R[bank1_info1_page_cfg_3]: V(False)
 
@@ -4266,6 +4909,32 @@ module flash_ctrl_reg_top (
   );
 
 
+  // F[scramble_en_3]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank1_info1_page_cfg_3_scramble_en_3 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank1_info1_page_cfg_3_scramble_en_3_we & region_cfg_regwen_qs),
+    .wd     (bank1_info1_page_cfg_3_scramble_en_3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank1_info1_page_cfg[3].scramble_en.q ),
+
+    // to register interface (read)
+    .qs     (bank1_info1_page_cfg_3_scramble_en_3_qs)
+  );
+
+
 
   // R[default_region]: V(False)
 
@@ -4344,6 +5013,32 @@ module flash_ctrl_reg_top (
 
     // to register interface (read)
     .qs     (default_region_erase_en_qs)
+  );
+
+
+  //   F[scramble_en]: 3:3
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_default_region_scramble_en (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (default_region_scramble_en_we),
+    .wd     (default_region_scramble_en_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.default_region.scramble_en.q ),
+
+    // to register interface (read)
+    .qs     (default_region_scramble_en_qs)
   );
 
 
@@ -4824,7 +5519,7 @@ module flash_ctrl_reg_top (
 
 
 
-  logic [40:0] addr_hit;
+  logic [39:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == FLASH_CTRL_INTR_STATE_OFFSET);
@@ -4833,41 +5528,40 @@ module flash_ctrl_reg_top (
     addr_hit[ 3] = (reg_addr == FLASH_CTRL_CTRL_REGWEN_OFFSET);
     addr_hit[ 4] = (reg_addr == FLASH_CTRL_CONTROL_OFFSET);
     addr_hit[ 5] = (reg_addr == FLASH_CTRL_ADDR_OFFSET);
-    addr_hit[ 6] = (reg_addr == FLASH_CTRL_SCRAMBLE_EN_OFFSET);
-    addr_hit[ 7] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_OFFSET);
-    addr_hit[ 8] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_0_OFFSET);
-    addr_hit[ 9] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_1_OFFSET);
-    addr_hit[10] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_2_OFFSET);
-    addr_hit[11] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_3_OFFSET);
-    addr_hit[12] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_4_OFFSET);
-    addr_hit[13] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_5_OFFSET);
-    addr_hit[14] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_6_OFFSET);
-    addr_hit[15] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_7_OFFSET);
-    addr_hit[16] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0_OFFSET);
-    addr_hit[17] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_1_OFFSET);
-    addr_hit[18] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_2_OFFSET);
-    addr_hit[19] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_3_OFFSET);
-    addr_hit[20] = (reg_addr == FLASH_CTRL_BANK0_INFO1_PAGE_CFG_0_OFFSET);
-    addr_hit[21] = (reg_addr == FLASH_CTRL_BANK0_INFO1_PAGE_CFG_1_OFFSET);
-    addr_hit[22] = (reg_addr == FLASH_CTRL_BANK0_INFO1_PAGE_CFG_2_OFFSET);
-    addr_hit[23] = (reg_addr == FLASH_CTRL_BANK0_INFO1_PAGE_CFG_3_OFFSET);
-    addr_hit[24] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_0_OFFSET);
-    addr_hit[25] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_1_OFFSET);
-    addr_hit[26] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_2_OFFSET);
-    addr_hit[27] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_3_OFFSET);
-    addr_hit[28] = (reg_addr == FLASH_CTRL_BANK1_INFO1_PAGE_CFG_0_OFFSET);
-    addr_hit[29] = (reg_addr == FLASH_CTRL_BANK1_INFO1_PAGE_CFG_1_OFFSET);
-    addr_hit[30] = (reg_addr == FLASH_CTRL_BANK1_INFO1_PAGE_CFG_2_OFFSET);
-    addr_hit[31] = (reg_addr == FLASH_CTRL_BANK1_INFO1_PAGE_CFG_3_OFFSET);
-    addr_hit[32] = (reg_addr == FLASH_CTRL_DEFAULT_REGION_OFFSET);
-    addr_hit[33] = (reg_addr == FLASH_CTRL_BANK_CFG_REGWEN_OFFSET);
-    addr_hit[34] = (reg_addr == FLASH_CTRL_MP_BANK_CFG_OFFSET);
-    addr_hit[35] = (reg_addr == FLASH_CTRL_OP_STATUS_OFFSET);
-    addr_hit[36] = (reg_addr == FLASH_CTRL_STATUS_OFFSET);
-    addr_hit[37] = (reg_addr == FLASH_CTRL_PHY_STATUS_OFFSET);
-    addr_hit[38] = (reg_addr == FLASH_CTRL_SCRATCH_OFFSET);
-    addr_hit[39] = (reg_addr == FLASH_CTRL_FIFO_LVL_OFFSET);
-    addr_hit[40] = (reg_addr == FLASH_CTRL_FIFO_RST_OFFSET);
+    addr_hit[ 6] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_OFFSET);
+    addr_hit[ 7] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_0_OFFSET);
+    addr_hit[ 8] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_1_OFFSET);
+    addr_hit[ 9] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_2_OFFSET);
+    addr_hit[10] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_3_OFFSET);
+    addr_hit[11] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_4_OFFSET);
+    addr_hit[12] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_5_OFFSET);
+    addr_hit[13] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_6_OFFSET);
+    addr_hit[14] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_7_OFFSET);
+    addr_hit[15] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0_OFFSET);
+    addr_hit[16] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_1_OFFSET);
+    addr_hit[17] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_2_OFFSET);
+    addr_hit[18] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_3_OFFSET);
+    addr_hit[19] = (reg_addr == FLASH_CTRL_BANK0_INFO1_PAGE_CFG_0_OFFSET);
+    addr_hit[20] = (reg_addr == FLASH_CTRL_BANK0_INFO1_PAGE_CFG_1_OFFSET);
+    addr_hit[21] = (reg_addr == FLASH_CTRL_BANK0_INFO1_PAGE_CFG_2_OFFSET);
+    addr_hit[22] = (reg_addr == FLASH_CTRL_BANK0_INFO1_PAGE_CFG_3_OFFSET);
+    addr_hit[23] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_0_OFFSET);
+    addr_hit[24] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_1_OFFSET);
+    addr_hit[25] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_2_OFFSET);
+    addr_hit[26] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_3_OFFSET);
+    addr_hit[27] = (reg_addr == FLASH_CTRL_BANK1_INFO1_PAGE_CFG_0_OFFSET);
+    addr_hit[28] = (reg_addr == FLASH_CTRL_BANK1_INFO1_PAGE_CFG_1_OFFSET);
+    addr_hit[29] = (reg_addr == FLASH_CTRL_BANK1_INFO1_PAGE_CFG_2_OFFSET);
+    addr_hit[30] = (reg_addr == FLASH_CTRL_BANK1_INFO1_PAGE_CFG_3_OFFSET);
+    addr_hit[31] = (reg_addr == FLASH_CTRL_DEFAULT_REGION_OFFSET);
+    addr_hit[32] = (reg_addr == FLASH_CTRL_BANK_CFG_REGWEN_OFFSET);
+    addr_hit[33] = (reg_addr == FLASH_CTRL_MP_BANK_CFG_OFFSET);
+    addr_hit[34] = (reg_addr == FLASH_CTRL_OP_STATUS_OFFSET);
+    addr_hit[35] = (reg_addr == FLASH_CTRL_STATUS_OFFSET);
+    addr_hit[36] = (reg_addr == FLASH_CTRL_PHY_STATUS_OFFSET);
+    addr_hit[37] = (reg_addr == FLASH_CTRL_SCRATCH_OFFSET);
+    addr_hit[38] = (reg_addr == FLASH_CTRL_FIFO_LVL_OFFSET);
+    addr_hit[39] = (reg_addr == FLASH_CTRL_FIFO_RST_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -4915,7 +5609,6 @@ module flash_ctrl_reg_top (
     if (addr_hit[37] && reg_we && (FLASH_CTRL_PERMIT[37] != (FLASH_CTRL_PERMIT[37] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[38] && reg_we && (FLASH_CTRL_PERMIT[38] != (FLASH_CTRL_PERMIT[38] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[39] && reg_we && (FLASH_CTRL_PERMIT[39] != (FLASH_CTRL_PERMIT[39] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[40] && reg_we && (FLASH_CTRL_PERMIT[40] != (FLASH_CTRL_PERMIT[40] & reg_be))) wr_err = 1'b1 ;
   end
 
   assign intr_state_prog_empty_we = addr_hit[0] & reg_we & ~wr_err;
@@ -4998,370 +5691,442 @@ module flash_ctrl_reg_top (
   assign addr_we = addr_hit[5] & reg_we & ~wr_err;
   assign addr_wd = reg_wdata[31:0];
 
-  assign scramble_en_we = addr_hit[6] & reg_we & ~wr_err;
-  assign scramble_en_wd = reg_wdata[0];
-
-  assign region_cfg_regwen_we = addr_hit[7] & reg_we & ~wr_err;
+  assign region_cfg_regwen_we = addr_hit[6] & reg_we & ~wr_err;
   assign region_cfg_regwen_wd = reg_wdata[0];
 
-  assign mp_region_cfg_0_en_0_we = addr_hit[8] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_en_0_we = addr_hit[7] & reg_we & ~wr_err;
   assign mp_region_cfg_0_en_0_wd = reg_wdata[0];
 
-  assign mp_region_cfg_0_rd_en_0_we = addr_hit[8] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_rd_en_0_we = addr_hit[7] & reg_we & ~wr_err;
   assign mp_region_cfg_0_rd_en_0_wd = reg_wdata[1];
 
-  assign mp_region_cfg_0_prog_en_0_we = addr_hit[8] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_prog_en_0_we = addr_hit[7] & reg_we & ~wr_err;
   assign mp_region_cfg_0_prog_en_0_wd = reg_wdata[2];
 
-  assign mp_region_cfg_0_erase_en_0_we = addr_hit[8] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_erase_en_0_we = addr_hit[7] & reg_we & ~wr_err;
   assign mp_region_cfg_0_erase_en_0_wd = reg_wdata[3];
 
-  assign mp_region_cfg_0_base_0_we = addr_hit[8] & reg_we & ~wr_err;
-  assign mp_region_cfg_0_base_0_wd = reg_wdata[12:4];
+  assign mp_region_cfg_0_scramble_en_0_we = addr_hit[7] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_scramble_en_0_wd = reg_wdata[4];
 
-  assign mp_region_cfg_0_size_0_we = addr_hit[8] & reg_we & ~wr_err;
-  assign mp_region_cfg_0_size_0_wd = reg_wdata[25:16];
+  assign mp_region_cfg_0_base_0_we = addr_hit[7] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_base_0_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_1_en_1_we = addr_hit[9] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_size_0_we = addr_hit[7] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_size_0_wd = reg_wdata[29:20];
+
+  assign mp_region_cfg_1_en_1_we = addr_hit[8] & reg_we & ~wr_err;
   assign mp_region_cfg_1_en_1_wd = reg_wdata[0];
 
-  assign mp_region_cfg_1_rd_en_1_we = addr_hit[9] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_rd_en_1_we = addr_hit[8] & reg_we & ~wr_err;
   assign mp_region_cfg_1_rd_en_1_wd = reg_wdata[1];
 
-  assign mp_region_cfg_1_prog_en_1_we = addr_hit[9] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_prog_en_1_we = addr_hit[8] & reg_we & ~wr_err;
   assign mp_region_cfg_1_prog_en_1_wd = reg_wdata[2];
 
-  assign mp_region_cfg_1_erase_en_1_we = addr_hit[9] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_erase_en_1_we = addr_hit[8] & reg_we & ~wr_err;
   assign mp_region_cfg_1_erase_en_1_wd = reg_wdata[3];
 
-  assign mp_region_cfg_1_base_1_we = addr_hit[9] & reg_we & ~wr_err;
-  assign mp_region_cfg_1_base_1_wd = reg_wdata[12:4];
+  assign mp_region_cfg_1_scramble_en_1_we = addr_hit[8] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_scramble_en_1_wd = reg_wdata[4];
 
-  assign mp_region_cfg_1_size_1_we = addr_hit[9] & reg_we & ~wr_err;
-  assign mp_region_cfg_1_size_1_wd = reg_wdata[25:16];
+  assign mp_region_cfg_1_base_1_we = addr_hit[8] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_base_1_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_2_en_2_we = addr_hit[10] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_size_1_we = addr_hit[8] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_size_1_wd = reg_wdata[29:20];
+
+  assign mp_region_cfg_2_en_2_we = addr_hit[9] & reg_we & ~wr_err;
   assign mp_region_cfg_2_en_2_wd = reg_wdata[0];
 
-  assign mp_region_cfg_2_rd_en_2_we = addr_hit[10] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_rd_en_2_we = addr_hit[9] & reg_we & ~wr_err;
   assign mp_region_cfg_2_rd_en_2_wd = reg_wdata[1];
 
-  assign mp_region_cfg_2_prog_en_2_we = addr_hit[10] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_prog_en_2_we = addr_hit[9] & reg_we & ~wr_err;
   assign mp_region_cfg_2_prog_en_2_wd = reg_wdata[2];
 
-  assign mp_region_cfg_2_erase_en_2_we = addr_hit[10] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_erase_en_2_we = addr_hit[9] & reg_we & ~wr_err;
   assign mp_region_cfg_2_erase_en_2_wd = reg_wdata[3];
 
-  assign mp_region_cfg_2_base_2_we = addr_hit[10] & reg_we & ~wr_err;
-  assign mp_region_cfg_2_base_2_wd = reg_wdata[12:4];
+  assign mp_region_cfg_2_scramble_en_2_we = addr_hit[9] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_scramble_en_2_wd = reg_wdata[4];
 
-  assign mp_region_cfg_2_size_2_we = addr_hit[10] & reg_we & ~wr_err;
-  assign mp_region_cfg_2_size_2_wd = reg_wdata[25:16];
+  assign mp_region_cfg_2_base_2_we = addr_hit[9] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_base_2_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_3_en_3_we = addr_hit[11] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_size_2_we = addr_hit[9] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_size_2_wd = reg_wdata[29:20];
+
+  assign mp_region_cfg_3_en_3_we = addr_hit[10] & reg_we & ~wr_err;
   assign mp_region_cfg_3_en_3_wd = reg_wdata[0];
 
-  assign mp_region_cfg_3_rd_en_3_we = addr_hit[11] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_rd_en_3_we = addr_hit[10] & reg_we & ~wr_err;
   assign mp_region_cfg_3_rd_en_3_wd = reg_wdata[1];
 
-  assign mp_region_cfg_3_prog_en_3_we = addr_hit[11] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_prog_en_3_we = addr_hit[10] & reg_we & ~wr_err;
   assign mp_region_cfg_3_prog_en_3_wd = reg_wdata[2];
 
-  assign mp_region_cfg_3_erase_en_3_we = addr_hit[11] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_erase_en_3_we = addr_hit[10] & reg_we & ~wr_err;
   assign mp_region_cfg_3_erase_en_3_wd = reg_wdata[3];
 
-  assign mp_region_cfg_3_base_3_we = addr_hit[11] & reg_we & ~wr_err;
-  assign mp_region_cfg_3_base_3_wd = reg_wdata[12:4];
+  assign mp_region_cfg_3_scramble_en_3_we = addr_hit[10] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_scramble_en_3_wd = reg_wdata[4];
 
-  assign mp_region_cfg_3_size_3_we = addr_hit[11] & reg_we & ~wr_err;
-  assign mp_region_cfg_3_size_3_wd = reg_wdata[25:16];
+  assign mp_region_cfg_3_base_3_we = addr_hit[10] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_base_3_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_4_en_4_we = addr_hit[12] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_size_3_we = addr_hit[10] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_size_3_wd = reg_wdata[29:20];
+
+  assign mp_region_cfg_4_en_4_we = addr_hit[11] & reg_we & ~wr_err;
   assign mp_region_cfg_4_en_4_wd = reg_wdata[0];
 
-  assign mp_region_cfg_4_rd_en_4_we = addr_hit[12] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_rd_en_4_we = addr_hit[11] & reg_we & ~wr_err;
   assign mp_region_cfg_4_rd_en_4_wd = reg_wdata[1];
 
-  assign mp_region_cfg_4_prog_en_4_we = addr_hit[12] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_prog_en_4_we = addr_hit[11] & reg_we & ~wr_err;
   assign mp_region_cfg_4_prog_en_4_wd = reg_wdata[2];
 
-  assign mp_region_cfg_4_erase_en_4_we = addr_hit[12] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_erase_en_4_we = addr_hit[11] & reg_we & ~wr_err;
   assign mp_region_cfg_4_erase_en_4_wd = reg_wdata[3];
 
-  assign mp_region_cfg_4_base_4_we = addr_hit[12] & reg_we & ~wr_err;
-  assign mp_region_cfg_4_base_4_wd = reg_wdata[12:4];
+  assign mp_region_cfg_4_scramble_en_4_we = addr_hit[11] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_scramble_en_4_wd = reg_wdata[4];
 
-  assign mp_region_cfg_4_size_4_we = addr_hit[12] & reg_we & ~wr_err;
-  assign mp_region_cfg_4_size_4_wd = reg_wdata[25:16];
+  assign mp_region_cfg_4_base_4_we = addr_hit[11] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_base_4_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_5_en_5_we = addr_hit[13] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_size_4_we = addr_hit[11] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_size_4_wd = reg_wdata[29:20];
+
+  assign mp_region_cfg_5_en_5_we = addr_hit[12] & reg_we & ~wr_err;
   assign mp_region_cfg_5_en_5_wd = reg_wdata[0];
 
-  assign mp_region_cfg_5_rd_en_5_we = addr_hit[13] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_rd_en_5_we = addr_hit[12] & reg_we & ~wr_err;
   assign mp_region_cfg_5_rd_en_5_wd = reg_wdata[1];
 
-  assign mp_region_cfg_5_prog_en_5_we = addr_hit[13] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_prog_en_5_we = addr_hit[12] & reg_we & ~wr_err;
   assign mp_region_cfg_5_prog_en_5_wd = reg_wdata[2];
 
-  assign mp_region_cfg_5_erase_en_5_we = addr_hit[13] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_erase_en_5_we = addr_hit[12] & reg_we & ~wr_err;
   assign mp_region_cfg_5_erase_en_5_wd = reg_wdata[3];
 
-  assign mp_region_cfg_5_base_5_we = addr_hit[13] & reg_we & ~wr_err;
-  assign mp_region_cfg_5_base_5_wd = reg_wdata[12:4];
+  assign mp_region_cfg_5_scramble_en_5_we = addr_hit[12] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_scramble_en_5_wd = reg_wdata[4];
 
-  assign mp_region_cfg_5_size_5_we = addr_hit[13] & reg_we & ~wr_err;
-  assign mp_region_cfg_5_size_5_wd = reg_wdata[25:16];
+  assign mp_region_cfg_5_base_5_we = addr_hit[12] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_base_5_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_6_en_6_we = addr_hit[14] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_size_5_we = addr_hit[12] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_size_5_wd = reg_wdata[29:20];
+
+  assign mp_region_cfg_6_en_6_we = addr_hit[13] & reg_we & ~wr_err;
   assign mp_region_cfg_6_en_6_wd = reg_wdata[0];
 
-  assign mp_region_cfg_6_rd_en_6_we = addr_hit[14] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_rd_en_6_we = addr_hit[13] & reg_we & ~wr_err;
   assign mp_region_cfg_6_rd_en_6_wd = reg_wdata[1];
 
-  assign mp_region_cfg_6_prog_en_6_we = addr_hit[14] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_prog_en_6_we = addr_hit[13] & reg_we & ~wr_err;
   assign mp_region_cfg_6_prog_en_6_wd = reg_wdata[2];
 
-  assign mp_region_cfg_6_erase_en_6_we = addr_hit[14] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_erase_en_6_we = addr_hit[13] & reg_we & ~wr_err;
   assign mp_region_cfg_6_erase_en_6_wd = reg_wdata[3];
 
-  assign mp_region_cfg_6_base_6_we = addr_hit[14] & reg_we & ~wr_err;
-  assign mp_region_cfg_6_base_6_wd = reg_wdata[12:4];
+  assign mp_region_cfg_6_scramble_en_6_we = addr_hit[13] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_scramble_en_6_wd = reg_wdata[4];
 
-  assign mp_region_cfg_6_size_6_we = addr_hit[14] & reg_we & ~wr_err;
-  assign mp_region_cfg_6_size_6_wd = reg_wdata[25:16];
+  assign mp_region_cfg_6_base_6_we = addr_hit[13] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_base_6_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_7_en_7_we = addr_hit[15] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_size_6_we = addr_hit[13] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_size_6_wd = reg_wdata[29:20];
+
+  assign mp_region_cfg_7_en_7_we = addr_hit[14] & reg_we & ~wr_err;
   assign mp_region_cfg_7_en_7_wd = reg_wdata[0];
 
-  assign mp_region_cfg_7_rd_en_7_we = addr_hit[15] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_rd_en_7_we = addr_hit[14] & reg_we & ~wr_err;
   assign mp_region_cfg_7_rd_en_7_wd = reg_wdata[1];
 
-  assign mp_region_cfg_7_prog_en_7_we = addr_hit[15] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_prog_en_7_we = addr_hit[14] & reg_we & ~wr_err;
   assign mp_region_cfg_7_prog_en_7_wd = reg_wdata[2];
 
-  assign mp_region_cfg_7_erase_en_7_we = addr_hit[15] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_erase_en_7_we = addr_hit[14] & reg_we & ~wr_err;
   assign mp_region_cfg_7_erase_en_7_wd = reg_wdata[3];
 
-  assign mp_region_cfg_7_base_7_we = addr_hit[15] & reg_we & ~wr_err;
-  assign mp_region_cfg_7_base_7_wd = reg_wdata[12:4];
+  assign mp_region_cfg_7_scramble_en_7_we = addr_hit[14] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_scramble_en_7_wd = reg_wdata[4];
 
-  assign mp_region_cfg_7_size_7_we = addr_hit[15] & reg_we & ~wr_err;
-  assign mp_region_cfg_7_size_7_wd = reg_wdata[25:16];
+  assign mp_region_cfg_7_base_7_we = addr_hit[14] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_base_7_wd = reg_wdata[16:8];
 
-  assign bank0_info0_page_cfg_0_en_0_we = addr_hit[16] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_size_7_we = addr_hit[14] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_size_7_wd = reg_wdata[29:20];
+
+  assign bank0_info0_page_cfg_0_en_0_we = addr_hit[15] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_0_en_0_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_0_rd_en_0_we = addr_hit[16] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_0_rd_en_0_we = addr_hit[15] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_0_rd_en_0_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_0_prog_en_0_we = addr_hit[16] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_0_prog_en_0_we = addr_hit[15] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_0_prog_en_0_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_0_erase_en_0_we = addr_hit[16] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_0_erase_en_0_we = addr_hit[15] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_0_erase_en_0_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_1_en_1_we = addr_hit[17] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_0_scramble_en_0_we = addr_hit[15] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
+
+  assign bank0_info0_page_cfg_1_en_1_we = addr_hit[16] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_1_en_1_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_1_rd_en_1_we = addr_hit[17] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_1_rd_en_1_we = addr_hit[16] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_1_rd_en_1_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_1_prog_en_1_we = addr_hit[17] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_1_prog_en_1_we = addr_hit[16] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_1_prog_en_1_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_1_erase_en_1_we = addr_hit[17] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_1_erase_en_1_we = addr_hit[16] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_1_erase_en_1_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_2_en_2_we = addr_hit[18] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_1_scramble_en_1_we = addr_hit[16] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
+
+  assign bank0_info0_page_cfg_2_en_2_we = addr_hit[17] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_2_en_2_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_2_rd_en_2_we = addr_hit[18] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_2_rd_en_2_we = addr_hit[17] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_2_rd_en_2_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_2_prog_en_2_we = addr_hit[18] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_2_prog_en_2_we = addr_hit[17] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_2_prog_en_2_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_2_erase_en_2_we = addr_hit[18] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_2_erase_en_2_we = addr_hit[17] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_2_erase_en_2_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_3_en_3_we = addr_hit[19] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_2_scramble_en_2_we = addr_hit[17] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_2_scramble_en_2_wd = reg_wdata[4];
+
+  assign bank0_info0_page_cfg_3_en_3_we = addr_hit[18] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_3_en_3_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_3_rd_en_3_we = addr_hit[19] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_3_rd_en_3_we = addr_hit[18] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_3_rd_en_3_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_3_prog_en_3_we = addr_hit[19] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_3_prog_en_3_we = addr_hit[18] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_3_prog_en_3_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_3_erase_en_3_we = addr_hit[19] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_3_erase_en_3_we = addr_hit[18] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_3_erase_en_3_wd = reg_wdata[3];
 
-  assign bank0_info1_page_cfg_0_en_0_we = addr_hit[20] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_3_scramble_en_3_we = addr_hit[18] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_3_scramble_en_3_wd = reg_wdata[4];
+
+  assign bank0_info1_page_cfg_0_en_0_we = addr_hit[19] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_0_en_0_wd = reg_wdata[0];
 
-  assign bank0_info1_page_cfg_0_rd_en_0_we = addr_hit[20] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_0_rd_en_0_we = addr_hit[19] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_0_rd_en_0_wd = reg_wdata[1];
 
-  assign bank0_info1_page_cfg_0_prog_en_0_we = addr_hit[20] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_0_prog_en_0_we = addr_hit[19] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_0_prog_en_0_wd = reg_wdata[2];
 
-  assign bank0_info1_page_cfg_0_erase_en_0_we = addr_hit[20] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_0_erase_en_0_we = addr_hit[19] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_0_erase_en_0_wd = reg_wdata[3];
 
-  assign bank0_info1_page_cfg_1_en_1_we = addr_hit[21] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_0_scramble_en_0_we = addr_hit[19] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
+
+  assign bank0_info1_page_cfg_1_en_1_we = addr_hit[20] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_1_en_1_wd = reg_wdata[0];
 
-  assign bank0_info1_page_cfg_1_rd_en_1_we = addr_hit[21] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_1_rd_en_1_we = addr_hit[20] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_1_rd_en_1_wd = reg_wdata[1];
 
-  assign bank0_info1_page_cfg_1_prog_en_1_we = addr_hit[21] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_1_prog_en_1_we = addr_hit[20] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_1_prog_en_1_wd = reg_wdata[2];
 
-  assign bank0_info1_page_cfg_1_erase_en_1_we = addr_hit[21] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_1_erase_en_1_we = addr_hit[20] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_1_erase_en_1_wd = reg_wdata[3];
 
-  assign bank0_info1_page_cfg_2_en_2_we = addr_hit[22] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_1_scramble_en_1_we = addr_hit[20] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
+
+  assign bank0_info1_page_cfg_2_en_2_we = addr_hit[21] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_2_en_2_wd = reg_wdata[0];
 
-  assign bank0_info1_page_cfg_2_rd_en_2_we = addr_hit[22] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_2_rd_en_2_we = addr_hit[21] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_2_rd_en_2_wd = reg_wdata[1];
 
-  assign bank0_info1_page_cfg_2_prog_en_2_we = addr_hit[22] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_2_prog_en_2_we = addr_hit[21] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_2_prog_en_2_wd = reg_wdata[2];
 
-  assign bank0_info1_page_cfg_2_erase_en_2_we = addr_hit[22] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_2_erase_en_2_we = addr_hit[21] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_2_erase_en_2_wd = reg_wdata[3];
 
-  assign bank0_info1_page_cfg_3_en_3_we = addr_hit[23] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_2_scramble_en_2_we = addr_hit[21] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_2_scramble_en_2_wd = reg_wdata[4];
+
+  assign bank0_info1_page_cfg_3_en_3_we = addr_hit[22] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_3_en_3_wd = reg_wdata[0];
 
-  assign bank0_info1_page_cfg_3_rd_en_3_we = addr_hit[23] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_3_rd_en_3_we = addr_hit[22] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_3_rd_en_3_wd = reg_wdata[1];
 
-  assign bank0_info1_page_cfg_3_prog_en_3_we = addr_hit[23] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_3_prog_en_3_we = addr_hit[22] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_3_prog_en_3_wd = reg_wdata[2];
 
-  assign bank0_info1_page_cfg_3_erase_en_3_we = addr_hit[23] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_3_erase_en_3_we = addr_hit[22] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_3_erase_en_3_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_0_en_0_we = addr_hit[24] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_3_scramble_en_3_we = addr_hit[22] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_3_scramble_en_3_wd = reg_wdata[4];
+
+  assign bank1_info0_page_cfg_0_en_0_we = addr_hit[23] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_0_en_0_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_0_rd_en_0_we = addr_hit[24] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_0_rd_en_0_we = addr_hit[23] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_0_rd_en_0_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_0_prog_en_0_we = addr_hit[24] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_0_prog_en_0_we = addr_hit[23] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_0_prog_en_0_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_0_erase_en_0_we = addr_hit[24] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_0_erase_en_0_we = addr_hit[23] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_0_erase_en_0_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_1_en_1_we = addr_hit[25] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_0_scramble_en_0_we = addr_hit[23] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
+
+  assign bank1_info0_page_cfg_1_en_1_we = addr_hit[24] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_1_en_1_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_1_rd_en_1_we = addr_hit[25] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_1_rd_en_1_we = addr_hit[24] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_1_rd_en_1_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_1_prog_en_1_we = addr_hit[25] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_1_prog_en_1_we = addr_hit[24] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_1_prog_en_1_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_1_erase_en_1_we = addr_hit[25] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_1_erase_en_1_we = addr_hit[24] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_1_erase_en_1_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_2_en_2_we = addr_hit[26] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_1_scramble_en_1_we = addr_hit[24] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
+
+  assign bank1_info0_page_cfg_2_en_2_we = addr_hit[25] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_2_en_2_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_2_rd_en_2_we = addr_hit[26] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_2_rd_en_2_we = addr_hit[25] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_2_rd_en_2_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_2_prog_en_2_we = addr_hit[26] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_2_prog_en_2_we = addr_hit[25] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_2_prog_en_2_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_2_erase_en_2_we = addr_hit[26] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_2_erase_en_2_we = addr_hit[25] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_2_erase_en_2_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_3_en_3_we = addr_hit[27] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_2_scramble_en_2_we = addr_hit[25] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_2_scramble_en_2_wd = reg_wdata[4];
+
+  assign bank1_info0_page_cfg_3_en_3_we = addr_hit[26] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_3_en_3_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_3_rd_en_3_we = addr_hit[27] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_3_rd_en_3_we = addr_hit[26] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_3_rd_en_3_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_3_prog_en_3_we = addr_hit[27] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_3_prog_en_3_we = addr_hit[26] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_3_prog_en_3_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_3_erase_en_3_we = addr_hit[27] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_3_erase_en_3_we = addr_hit[26] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_3_erase_en_3_wd = reg_wdata[3];
 
-  assign bank1_info1_page_cfg_0_en_0_we = addr_hit[28] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_3_scramble_en_3_we = addr_hit[26] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_3_scramble_en_3_wd = reg_wdata[4];
+
+  assign bank1_info1_page_cfg_0_en_0_we = addr_hit[27] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_0_en_0_wd = reg_wdata[0];
 
-  assign bank1_info1_page_cfg_0_rd_en_0_we = addr_hit[28] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_0_rd_en_0_we = addr_hit[27] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_0_rd_en_0_wd = reg_wdata[1];
 
-  assign bank1_info1_page_cfg_0_prog_en_0_we = addr_hit[28] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_0_prog_en_0_we = addr_hit[27] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_0_prog_en_0_wd = reg_wdata[2];
 
-  assign bank1_info1_page_cfg_0_erase_en_0_we = addr_hit[28] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_0_erase_en_0_we = addr_hit[27] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_0_erase_en_0_wd = reg_wdata[3];
 
-  assign bank1_info1_page_cfg_1_en_1_we = addr_hit[29] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_0_scramble_en_0_we = addr_hit[27] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
+
+  assign bank1_info1_page_cfg_1_en_1_we = addr_hit[28] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_1_en_1_wd = reg_wdata[0];
 
-  assign bank1_info1_page_cfg_1_rd_en_1_we = addr_hit[29] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_1_rd_en_1_we = addr_hit[28] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_1_rd_en_1_wd = reg_wdata[1];
 
-  assign bank1_info1_page_cfg_1_prog_en_1_we = addr_hit[29] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_1_prog_en_1_we = addr_hit[28] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_1_prog_en_1_wd = reg_wdata[2];
 
-  assign bank1_info1_page_cfg_1_erase_en_1_we = addr_hit[29] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_1_erase_en_1_we = addr_hit[28] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_1_erase_en_1_wd = reg_wdata[3];
 
-  assign bank1_info1_page_cfg_2_en_2_we = addr_hit[30] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_1_scramble_en_1_we = addr_hit[28] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
+
+  assign bank1_info1_page_cfg_2_en_2_we = addr_hit[29] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_2_en_2_wd = reg_wdata[0];
 
-  assign bank1_info1_page_cfg_2_rd_en_2_we = addr_hit[30] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_2_rd_en_2_we = addr_hit[29] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_2_rd_en_2_wd = reg_wdata[1];
 
-  assign bank1_info1_page_cfg_2_prog_en_2_we = addr_hit[30] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_2_prog_en_2_we = addr_hit[29] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_2_prog_en_2_wd = reg_wdata[2];
 
-  assign bank1_info1_page_cfg_2_erase_en_2_we = addr_hit[30] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_2_erase_en_2_we = addr_hit[29] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_2_erase_en_2_wd = reg_wdata[3];
 
-  assign bank1_info1_page_cfg_3_en_3_we = addr_hit[31] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_2_scramble_en_2_we = addr_hit[29] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_2_scramble_en_2_wd = reg_wdata[4];
+
+  assign bank1_info1_page_cfg_3_en_3_we = addr_hit[30] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_3_en_3_wd = reg_wdata[0];
 
-  assign bank1_info1_page_cfg_3_rd_en_3_we = addr_hit[31] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_3_rd_en_3_we = addr_hit[30] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_3_rd_en_3_wd = reg_wdata[1];
 
-  assign bank1_info1_page_cfg_3_prog_en_3_we = addr_hit[31] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_3_prog_en_3_we = addr_hit[30] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_3_prog_en_3_wd = reg_wdata[2];
 
-  assign bank1_info1_page_cfg_3_erase_en_3_we = addr_hit[31] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_3_erase_en_3_we = addr_hit[30] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_3_erase_en_3_wd = reg_wdata[3];
 
-  assign default_region_rd_en_we = addr_hit[32] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_3_scramble_en_3_we = addr_hit[30] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_3_scramble_en_3_wd = reg_wdata[4];
+
+  assign default_region_rd_en_we = addr_hit[31] & reg_we & ~wr_err;
   assign default_region_rd_en_wd = reg_wdata[0];
 
-  assign default_region_prog_en_we = addr_hit[32] & reg_we & ~wr_err;
+  assign default_region_prog_en_we = addr_hit[31] & reg_we & ~wr_err;
   assign default_region_prog_en_wd = reg_wdata[1];
 
-  assign default_region_erase_en_we = addr_hit[32] & reg_we & ~wr_err;
+  assign default_region_erase_en_we = addr_hit[31] & reg_we & ~wr_err;
   assign default_region_erase_en_wd = reg_wdata[2];
 
-  assign bank_cfg_regwen_we = addr_hit[33] & reg_we & ~wr_err;
+  assign default_region_scramble_en_we = addr_hit[31] & reg_we & ~wr_err;
+  assign default_region_scramble_en_wd = reg_wdata[3];
+
+  assign bank_cfg_regwen_we = addr_hit[32] & reg_we & ~wr_err;
   assign bank_cfg_regwen_wd = reg_wdata[0];
 
-  assign mp_bank_cfg_erase_en_0_we = addr_hit[34] & reg_we & ~wr_err;
+  assign mp_bank_cfg_erase_en_0_we = addr_hit[33] & reg_we & ~wr_err;
   assign mp_bank_cfg_erase_en_0_wd = reg_wdata[0];
 
-  assign mp_bank_cfg_erase_en_1_we = addr_hit[34] & reg_we & ~wr_err;
+  assign mp_bank_cfg_erase_en_1_we = addr_hit[33] & reg_we & ~wr_err;
   assign mp_bank_cfg_erase_en_1_wd = reg_wdata[1];
 
-  assign op_status_done_we = addr_hit[35] & reg_we & ~wr_err;
+  assign op_status_done_we = addr_hit[34] & reg_we & ~wr_err;
   assign op_status_done_wd = reg_wdata[0];
 
-  assign op_status_err_we = addr_hit[35] & reg_we & ~wr_err;
+  assign op_status_err_we = addr_hit[34] & reg_we & ~wr_err;
   assign op_status_err_wd = reg_wdata[1];
 
 
@@ -5373,16 +6138,16 @@ module flash_ctrl_reg_top (
 
 
 
-  assign scratch_we = addr_hit[38] & reg_we & ~wr_err;
+  assign scratch_we = addr_hit[37] & reg_we & ~wr_err;
   assign scratch_wd = reg_wdata[31:0];
 
-  assign fifo_lvl_prog_we = addr_hit[39] & reg_we & ~wr_err;
+  assign fifo_lvl_prog_we = addr_hit[38] & reg_we & ~wr_err;
   assign fifo_lvl_prog_wd = reg_wdata[4:0];
 
-  assign fifo_lvl_rd_we = addr_hit[39] & reg_we & ~wr_err;
+  assign fifo_lvl_rd_we = addr_hit[38] & reg_we & ~wr_err;
   assign fifo_lvl_rd_wd = reg_wdata[12:8];
 
-  assign fifo_rst_we = addr_hit[40] & reg_we & ~wr_err;
+  assign fifo_rst_we = addr_hit[39] & reg_we & ~wr_err;
   assign fifo_rst_wd = reg_wdata[0];
 
   // Read data return
@@ -5435,218 +6200,239 @@ module flash_ctrl_reg_top (
       end
 
       addr_hit[6]: begin
-        reg_rdata_next[0] = scramble_en_qs;
-      end
-
-      addr_hit[7]: begin
         reg_rdata_next[0] = region_cfg_regwen_qs;
       end
 
-      addr_hit[8]: begin
+      addr_hit[7]: begin
         reg_rdata_next[0] = mp_region_cfg_0_en_0_qs;
         reg_rdata_next[1] = mp_region_cfg_0_rd_en_0_qs;
         reg_rdata_next[2] = mp_region_cfg_0_prog_en_0_qs;
         reg_rdata_next[3] = mp_region_cfg_0_erase_en_0_qs;
-        reg_rdata_next[12:4] = mp_region_cfg_0_base_0_qs;
-        reg_rdata_next[25:16] = mp_region_cfg_0_size_0_qs;
+        reg_rdata_next[4] = mp_region_cfg_0_scramble_en_0_qs;
+        reg_rdata_next[16:8] = mp_region_cfg_0_base_0_qs;
+        reg_rdata_next[29:20] = mp_region_cfg_0_size_0_qs;
       end
 
-      addr_hit[9]: begin
+      addr_hit[8]: begin
         reg_rdata_next[0] = mp_region_cfg_1_en_1_qs;
         reg_rdata_next[1] = mp_region_cfg_1_rd_en_1_qs;
         reg_rdata_next[2] = mp_region_cfg_1_prog_en_1_qs;
         reg_rdata_next[3] = mp_region_cfg_1_erase_en_1_qs;
-        reg_rdata_next[12:4] = mp_region_cfg_1_base_1_qs;
-        reg_rdata_next[25:16] = mp_region_cfg_1_size_1_qs;
+        reg_rdata_next[4] = mp_region_cfg_1_scramble_en_1_qs;
+        reg_rdata_next[16:8] = mp_region_cfg_1_base_1_qs;
+        reg_rdata_next[29:20] = mp_region_cfg_1_size_1_qs;
       end
 
-      addr_hit[10]: begin
+      addr_hit[9]: begin
         reg_rdata_next[0] = mp_region_cfg_2_en_2_qs;
         reg_rdata_next[1] = mp_region_cfg_2_rd_en_2_qs;
         reg_rdata_next[2] = mp_region_cfg_2_prog_en_2_qs;
         reg_rdata_next[3] = mp_region_cfg_2_erase_en_2_qs;
-        reg_rdata_next[12:4] = mp_region_cfg_2_base_2_qs;
-        reg_rdata_next[25:16] = mp_region_cfg_2_size_2_qs;
+        reg_rdata_next[4] = mp_region_cfg_2_scramble_en_2_qs;
+        reg_rdata_next[16:8] = mp_region_cfg_2_base_2_qs;
+        reg_rdata_next[29:20] = mp_region_cfg_2_size_2_qs;
       end
 
-      addr_hit[11]: begin
+      addr_hit[10]: begin
         reg_rdata_next[0] = mp_region_cfg_3_en_3_qs;
         reg_rdata_next[1] = mp_region_cfg_3_rd_en_3_qs;
         reg_rdata_next[2] = mp_region_cfg_3_prog_en_3_qs;
         reg_rdata_next[3] = mp_region_cfg_3_erase_en_3_qs;
-        reg_rdata_next[12:4] = mp_region_cfg_3_base_3_qs;
-        reg_rdata_next[25:16] = mp_region_cfg_3_size_3_qs;
+        reg_rdata_next[4] = mp_region_cfg_3_scramble_en_3_qs;
+        reg_rdata_next[16:8] = mp_region_cfg_3_base_3_qs;
+        reg_rdata_next[29:20] = mp_region_cfg_3_size_3_qs;
       end
 
-      addr_hit[12]: begin
+      addr_hit[11]: begin
         reg_rdata_next[0] = mp_region_cfg_4_en_4_qs;
         reg_rdata_next[1] = mp_region_cfg_4_rd_en_4_qs;
         reg_rdata_next[2] = mp_region_cfg_4_prog_en_4_qs;
         reg_rdata_next[3] = mp_region_cfg_4_erase_en_4_qs;
-        reg_rdata_next[12:4] = mp_region_cfg_4_base_4_qs;
-        reg_rdata_next[25:16] = mp_region_cfg_4_size_4_qs;
+        reg_rdata_next[4] = mp_region_cfg_4_scramble_en_4_qs;
+        reg_rdata_next[16:8] = mp_region_cfg_4_base_4_qs;
+        reg_rdata_next[29:20] = mp_region_cfg_4_size_4_qs;
       end
 
-      addr_hit[13]: begin
+      addr_hit[12]: begin
         reg_rdata_next[0] = mp_region_cfg_5_en_5_qs;
         reg_rdata_next[1] = mp_region_cfg_5_rd_en_5_qs;
         reg_rdata_next[2] = mp_region_cfg_5_prog_en_5_qs;
         reg_rdata_next[3] = mp_region_cfg_5_erase_en_5_qs;
-        reg_rdata_next[12:4] = mp_region_cfg_5_base_5_qs;
-        reg_rdata_next[25:16] = mp_region_cfg_5_size_5_qs;
+        reg_rdata_next[4] = mp_region_cfg_5_scramble_en_5_qs;
+        reg_rdata_next[16:8] = mp_region_cfg_5_base_5_qs;
+        reg_rdata_next[29:20] = mp_region_cfg_5_size_5_qs;
       end
 
-      addr_hit[14]: begin
+      addr_hit[13]: begin
         reg_rdata_next[0] = mp_region_cfg_6_en_6_qs;
         reg_rdata_next[1] = mp_region_cfg_6_rd_en_6_qs;
         reg_rdata_next[2] = mp_region_cfg_6_prog_en_6_qs;
         reg_rdata_next[3] = mp_region_cfg_6_erase_en_6_qs;
-        reg_rdata_next[12:4] = mp_region_cfg_6_base_6_qs;
-        reg_rdata_next[25:16] = mp_region_cfg_6_size_6_qs;
+        reg_rdata_next[4] = mp_region_cfg_6_scramble_en_6_qs;
+        reg_rdata_next[16:8] = mp_region_cfg_6_base_6_qs;
+        reg_rdata_next[29:20] = mp_region_cfg_6_size_6_qs;
       end
 
-      addr_hit[15]: begin
+      addr_hit[14]: begin
         reg_rdata_next[0] = mp_region_cfg_7_en_7_qs;
         reg_rdata_next[1] = mp_region_cfg_7_rd_en_7_qs;
         reg_rdata_next[2] = mp_region_cfg_7_prog_en_7_qs;
         reg_rdata_next[3] = mp_region_cfg_7_erase_en_7_qs;
-        reg_rdata_next[12:4] = mp_region_cfg_7_base_7_qs;
-        reg_rdata_next[25:16] = mp_region_cfg_7_size_7_qs;
+        reg_rdata_next[4] = mp_region_cfg_7_scramble_en_7_qs;
+        reg_rdata_next[16:8] = mp_region_cfg_7_base_7_qs;
+        reg_rdata_next[29:20] = mp_region_cfg_7_size_7_qs;
       end
 
-      addr_hit[16]: begin
+      addr_hit[15]: begin
         reg_rdata_next[0] = bank0_info0_page_cfg_0_en_0_qs;
         reg_rdata_next[1] = bank0_info0_page_cfg_0_rd_en_0_qs;
         reg_rdata_next[2] = bank0_info0_page_cfg_0_prog_en_0_qs;
         reg_rdata_next[3] = bank0_info0_page_cfg_0_erase_en_0_qs;
+        reg_rdata_next[4] = bank0_info0_page_cfg_0_scramble_en_0_qs;
       end
 
-      addr_hit[17]: begin
+      addr_hit[16]: begin
         reg_rdata_next[0] = bank0_info0_page_cfg_1_en_1_qs;
         reg_rdata_next[1] = bank0_info0_page_cfg_1_rd_en_1_qs;
         reg_rdata_next[2] = bank0_info0_page_cfg_1_prog_en_1_qs;
         reg_rdata_next[3] = bank0_info0_page_cfg_1_erase_en_1_qs;
+        reg_rdata_next[4] = bank0_info0_page_cfg_1_scramble_en_1_qs;
       end
 
-      addr_hit[18]: begin
+      addr_hit[17]: begin
         reg_rdata_next[0] = bank0_info0_page_cfg_2_en_2_qs;
         reg_rdata_next[1] = bank0_info0_page_cfg_2_rd_en_2_qs;
         reg_rdata_next[2] = bank0_info0_page_cfg_2_prog_en_2_qs;
         reg_rdata_next[3] = bank0_info0_page_cfg_2_erase_en_2_qs;
+        reg_rdata_next[4] = bank0_info0_page_cfg_2_scramble_en_2_qs;
       end
 
-      addr_hit[19]: begin
+      addr_hit[18]: begin
         reg_rdata_next[0] = bank0_info0_page_cfg_3_en_3_qs;
         reg_rdata_next[1] = bank0_info0_page_cfg_3_rd_en_3_qs;
         reg_rdata_next[2] = bank0_info0_page_cfg_3_prog_en_3_qs;
         reg_rdata_next[3] = bank0_info0_page_cfg_3_erase_en_3_qs;
+        reg_rdata_next[4] = bank0_info0_page_cfg_3_scramble_en_3_qs;
       end
 
-      addr_hit[20]: begin
+      addr_hit[19]: begin
         reg_rdata_next[0] = bank0_info1_page_cfg_0_en_0_qs;
         reg_rdata_next[1] = bank0_info1_page_cfg_0_rd_en_0_qs;
         reg_rdata_next[2] = bank0_info1_page_cfg_0_prog_en_0_qs;
         reg_rdata_next[3] = bank0_info1_page_cfg_0_erase_en_0_qs;
+        reg_rdata_next[4] = bank0_info1_page_cfg_0_scramble_en_0_qs;
       end
 
-      addr_hit[21]: begin
+      addr_hit[20]: begin
         reg_rdata_next[0] = bank0_info1_page_cfg_1_en_1_qs;
         reg_rdata_next[1] = bank0_info1_page_cfg_1_rd_en_1_qs;
         reg_rdata_next[2] = bank0_info1_page_cfg_1_prog_en_1_qs;
         reg_rdata_next[3] = bank0_info1_page_cfg_1_erase_en_1_qs;
+        reg_rdata_next[4] = bank0_info1_page_cfg_1_scramble_en_1_qs;
       end
 
-      addr_hit[22]: begin
+      addr_hit[21]: begin
         reg_rdata_next[0] = bank0_info1_page_cfg_2_en_2_qs;
         reg_rdata_next[1] = bank0_info1_page_cfg_2_rd_en_2_qs;
         reg_rdata_next[2] = bank0_info1_page_cfg_2_prog_en_2_qs;
         reg_rdata_next[3] = bank0_info1_page_cfg_2_erase_en_2_qs;
+        reg_rdata_next[4] = bank0_info1_page_cfg_2_scramble_en_2_qs;
       end
 
-      addr_hit[23]: begin
+      addr_hit[22]: begin
         reg_rdata_next[0] = bank0_info1_page_cfg_3_en_3_qs;
         reg_rdata_next[1] = bank0_info1_page_cfg_3_rd_en_3_qs;
         reg_rdata_next[2] = bank0_info1_page_cfg_3_prog_en_3_qs;
         reg_rdata_next[3] = bank0_info1_page_cfg_3_erase_en_3_qs;
+        reg_rdata_next[4] = bank0_info1_page_cfg_3_scramble_en_3_qs;
       end
 
-      addr_hit[24]: begin
+      addr_hit[23]: begin
         reg_rdata_next[0] = bank1_info0_page_cfg_0_en_0_qs;
         reg_rdata_next[1] = bank1_info0_page_cfg_0_rd_en_0_qs;
         reg_rdata_next[2] = bank1_info0_page_cfg_0_prog_en_0_qs;
         reg_rdata_next[3] = bank1_info0_page_cfg_0_erase_en_0_qs;
+        reg_rdata_next[4] = bank1_info0_page_cfg_0_scramble_en_0_qs;
       end
 
-      addr_hit[25]: begin
+      addr_hit[24]: begin
         reg_rdata_next[0] = bank1_info0_page_cfg_1_en_1_qs;
         reg_rdata_next[1] = bank1_info0_page_cfg_1_rd_en_1_qs;
         reg_rdata_next[2] = bank1_info0_page_cfg_1_prog_en_1_qs;
         reg_rdata_next[3] = bank1_info0_page_cfg_1_erase_en_1_qs;
+        reg_rdata_next[4] = bank1_info0_page_cfg_1_scramble_en_1_qs;
       end
 
-      addr_hit[26]: begin
+      addr_hit[25]: begin
         reg_rdata_next[0] = bank1_info0_page_cfg_2_en_2_qs;
         reg_rdata_next[1] = bank1_info0_page_cfg_2_rd_en_2_qs;
         reg_rdata_next[2] = bank1_info0_page_cfg_2_prog_en_2_qs;
         reg_rdata_next[3] = bank1_info0_page_cfg_2_erase_en_2_qs;
+        reg_rdata_next[4] = bank1_info0_page_cfg_2_scramble_en_2_qs;
       end
 
-      addr_hit[27]: begin
+      addr_hit[26]: begin
         reg_rdata_next[0] = bank1_info0_page_cfg_3_en_3_qs;
         reg_rdata_next[1] = bank1_info0_page_cfg_3_rd_en_3_qs;
         reg_rdata_next[2] = bank1_info0_page_cfg_3_prog_en_3_qs;
         reg_rdata_next[3] = bank1_info0_page_cfg_3_erase_en_3_qs;
+        reg_rdata_next[4] = bank1_info0_page_cfg_3_scramble_en_3_qs;
       end
 
-      addr_hit[28]: begin
+      addr_hit[27]: begin
         reg_rdata_next[0] = bank1_info1_page_cfg_0_en_0_qs;
         reg_rdata_next[1] = bank1_info1_page_cfg_0_rd_en_0_qs;
         reg_rdata_next[2] = bank1_info1_page_cfg_0_prog_en_0_qs;
         reg_rdata_next[3] = bank1_info1_page_cfg_0_erase_en_0_qs;
+        reg_rdata_next[4] = bank1_info1_page_cfg_0_scramble_en_0_qs;
       end
 
-      addr_hit[29]: begin
+      addr_hit[28]: begin
         reg_rdata_next[0] = bank1_info1_page_cfg_1_en_1_qs;
         reg_rdata_next[1] = bank1_info1_page_cfg_1_rd_en_1_qs;
         reg_rdata_next[2] = bank1_info1_page_cfg_1_prog_en_1_qs;
         reg_rdata_next[3] = bank1_info1_page_cfg_1_erase_en_1_qs;
+        reg_rdata_next[4] = bank1_info1_page_cfg_1_scramble_en_1_qs;
       end
 
-      addr_hit[30]: begin
+      addr_hit[29]: begin
         reg_rdata_next[0] = bank1_info1_page_cfg_2_en_2_qs;
         reg_rdata_next[1] = bank1_info1_page_cfg_2_rd_en_2_qs;
         reg_rdata_next[2] = bank1_info1_page_cfg_2_prog_en_2_qs;
         reg_rdata_next[3] = bank1_info1_page_cfg_2_erase_en_2_qs;
+        reg_rdata_next[4] = bank1_info1_page_cfg_2_scramble_en_2_qs;
       end
 
-      addr_hit[31]: begin
+      addr_hit[30]: begin
         reg_rdata_next[0] = bank1_info1_page_cfg_3_en_3_qs;
         reg_rdata_next[1] = bank1_info1_page_cfg_3_rd_en_3_qs;
         reg_rdata_next[2] = bank1_info1_page_cfg_3_prog_en_3_qs;
         reg_rdata_next[3] = bank1_info1_page_cfg_3_erase_en_3_qs;
+        reg_rdata_next[4] = bank1_info1_page_cfg_3_scramble_en_3_qs;
       end
 
-      addr_hit[32]: begin
+      addr_hit[31]: begin
         reg_rdata_next[0] = default_region_rd_en_qs;
         reg_rdata_next[1] = default_region_prog_en_qs;
         reg_rdata_next[2] = default_region_erase_en_qs;
+        reg_rdata_next[3] = default_region_scramble_en_qs;
       end
 
-      addr_hit[33]: begin
+      addr_hit[32]: begin
         reg_rdata_next[0] = bank_cfg_regwen_qs;
       end
 
-      addr_hit[34]: begin
+      addr_hit[33]: begin
         reg_rdata_next[0] = mp_bank_cfg_erase_en_0_qs;
         reg_rdata_next[1] = mp_bank_cfg_erase_en_1_qs;
       end
 
-      addr_hit[35]: begin
+      addr_hit[34]: begin
         reg_rdata_next[0] = op_status_done_qs;
         reg_rdata_next[1] = op_status_err_qs;
       end
 
-      addr_hit[36]: begin
+      addr_hit[35]: begin
         reg_rdata_next[0] = status_rd_full_qs;
         reg_rdata_next[1] = status_rd_empty_qs;
         reg_rdata_next[2] = status_prog_full_qs;
@@ -5655,22 +6441,22 @@ module flash_ctrl_reg_top (
         reg_rdata_next[16:8] = status_error_addr_qs;
       end
 
-      addr_hit[37]: begin
+      addr_hit[36]: begin
         reg_rdata_next[0] = phy_status_init_wip_qs;
         reg_rdata_next[1] = phy_status_prog_normal_avail_qs;
         reg_rdata_next[2] = phy_status_prog_repair_avail_qs;
       end
 
-      addr_hit[38]: begin
+      addr_hit[37]: begin
         reg_rdata_next[31:0] = scratch_qs;
       end
 
-      addr_hit[39]: begin
+      addr_hit[38]: begin
         reg_rdata_next[4:0] = fifo_lvl_prog_qs;
         reg_rdata_next[12:8] = fifo_lvl_rd_qs;
       end
 
-      addr_hit[40]: begin
+      addr_hit[39]: begin
         reg_rdata_next[0] = fifo_rst_qs;
       end
 

--- a/sw/device/lib/flash_ctrl.c
+++ b/sw/device/lib/flash_ctrl.c
@@ -132,10 +132,6 @@ int flash_read(uint32_t addr, part_type_t part, uint32_t size, uint32_t *data) {
   return get_clr_err();
 }
 
-void flash_cfg_scramble_enable(bool en) {
-  REG32(FLASH_CTRL_SCRAMBLE_EN(0)) = en & 1;
-}
-
 void flash_cfg_bank_erase(bank_index_t bank, bool erase_en) {
   REG32(FLASH_CTRL_MP_BANK_CFG(0)) =
       (erase_en) ? SETBIT(REG32(FLASH_CTRL_MP_BANK_CFG(0)), bank)
@@ -160,12 +156,15 @@ void flash_cfg_region(const mp_region_t *region_cfg) {
         region_cfg->rd_en << FLASH_CTRL_MP_REGION_CFG_0_RD_EN_0 |
         region_cfg->prog_en << FLASH_CTRL_MP_REGION_CFG_0_PROG_EN_0 |
         region_cfg->erase_en << FLASH_CTRL_MP_REGION_CFG_0_ERASE_EN_0 |
+        region_cfg->scramble_en << FLASH_CTRL_MP_REGION_CFG_0_SCRAMBLE_EN_0 |
         0x1 << FLASH_CTRL_MP_REGION_CFG_0_EN_0;
   } else if (region_cfg->part == kInfoPartition) {
     reg_value =
         region_cfg->rd_en << FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0_RD_EN_0 |
         region_cfg->prog_en << FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0_PROG_EN_0 |
         region_cfg->erase_en << FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0_ERASE_EN_0 |
+        region_cfg->scramble_en
+            << FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0_SCRAMBLE_EN_0 |
         0x1 << FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0_EN_0;
 
     bank_sel = region_cfg->base / FLASH_PAGES_PER_BANK;

--- a/sw/device/lib/flash_ctrl.h
+++ b/sw/device/lib/flash_ctrl.h
@@ -50,6 +50,8 @@ typedef struct mp_region {
   uint32_t prog_en;
   /** Erase enable flag. */
   uint32_t erase_en;
+  /** Scramble / ECC enable flag. */
+  uint32_t scramble_en;
 } mp_region_t;
 
 /**
@@ -98,11 +100,6 @@ int flash_read(uint32_t addr, part_type_t part, uint32_t size, uint32_t *data);
  * Configure bank erase enable
  */
 void flash_cfg_bank_erase(bank_index_t bank, bool erase_en);
-
-/**
- * Configure scramble enable
- */
-void flash_cfg_scramble_enable(bool en);
 
 /**
  * Set flash controller default permissions.

--- a/sw/device/tests/flash_ctrl_test.c
+++ b/sw/device/tests/flash_ctrl_test.c
@@ -34,16 +34,26 @@ static void test_basic_io(void) {
                               /*erase_en=*/true);
 
   // info partition has no default access, specifically setup a region
-  mp_region_t info_region = {
-      .num = 0x0,
-      .base = FLASH_PAGES_PER_BANK,
-      .size = 0x1,
-      .part = kInfoPartition,
-      .rd_en = true,
-      .prog_en = true,
-      .erase_en = true,
-  };
+  mp_region_t info_region = {.num = 0x0,
+                             .base = FLASH_PAGES_PER_BANK,
+                             .size = 0x1,
+                             .part = kInfoPartition,
+                             .rd_en = true,
+                             .prog_en = true,
+                             .erase_en = true,
+                             .scramble_en = true};
   flash_cfg_region(&info_region);
+
+  // also setup data region to enable scrambling
+  mp_region_t data_region = {.num = 0x0,
+                             .base = FLASH_PAGES_PER_BANK,
+                             .size = 0x1,
+                             .part = kDataPartition,
+                             .rd_en = true,
+                             .prog_en = true,
+                             .erase_en = true,
+                             .scramble_en = true};
+  flash_cfg_region(&data_region);
 
   uintptr_t flash_bank_1_addr = FLASH_MEM_BASE_ADDR + FLASH_BANK_SZ;
   mmio_region_t flash_bank_1 = mmio_region_from_addr(flash_bank_1_addr);
@@ -112,15 +122,14 @@ static void test_memory_protection(void) {
                               /*erase_en=*/true);
 
   // A memory protection region representing the first page of the second bank.
-  mp_region_t protection_region = {
-      .num = 0x0,
-      .base = FLASH_PAGES_PER_BANK,
-      .size = 0x1,
-      .part = kDataPartition,
-      .rd_en = true,
-      .prog_en = true,
-      .erase_en = true,
-  };
+  mp_region_t protection_region = {.num = 0x0,
+                                   .base = FLASH_PAGES_PER_BANK,
+                                   .size = 0x1,
+                                   .part = kDataPartition,
+                                   .rd_en = true,
+                                   .prog_en = true,
+                                   .erase_en = true,
+                                   .scramble_en = false};
 
   uintptr_t ok_region_start =
       FLASH_MEM_BASE_ADDR + (protection_region.base * FLASH_PAGE_SZ);
@@ -181,7 +190,6 @@ bool test_main(void) {
 
   LOG_INFO("flash test!");
 
-  flash_cfg_scramble_enable(true);
   flash_cfg_bank_erase(FLASH_BANK_0, /*erase_en=*/true);
   flash_cfg_bank_erase(FLASH_BANK_1, /*erase_en=*/true);
 


### PR DESCRIPTION
Add address lookup to determine whether an access should be scramble / ECC enabled.
There are two address look-ups (although the configuration is shared). One look-up is done inside the flash controller for flash controller initiated accesses.

The other look-up is done along the host read path.  The host read path cannot access information partitions and is thus only a reduced set. 

A separate PR will update the documentation to reflect this change. 