### PR TITLE
[otp_ctrl] Implement consistency/integrity check timer

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson
@@ -194,69 +194,77 @@
         { bits: "0"
           name: "CREATOR_SW_CFG_ERROR"
           desc: '''
-                Set to 1 if an error occurred in this partition. If set to 1, SW should
-                check the !!ERR_CODE register at the corresponding index to root-cause the error.
+                Set to 1 if an error occurred in this partition.
+                If set to 1, SW should check the !!ERR_CODE register at the corresponding index.
                 '''
         }
         { bits: "1"
           name: "OWNER_SW_CFG_ERROR"
           desc: '''
-                Set to 1 if an error occurred in this partition. If set to 1, SW should
-                check the !!ERR_CODE register at the corresponding index to root-cause the error.
+                Set to 1 if an error occurred in this partition.
+                If set to 1, SW should check the !!ERR_CODE register at the corresponding index.
                 '''
         }
         { bits: "2"
           name: "HW_CFG_ERROR"
           desc: '''
-                Set to 1 if an error occurred in this partition. If set to 1, SW should
-                check the !!ERR_CODE register at the corresponding index to root-cause the error.
+                Set to 1 if an error occurred in this partition.
+                If set to 1, SW should check the !!ERR_CODE register at the corresponding index.
                 '''
         }
         { bits: "3"
-          name: "SECRET0"
+          name: "SECRET0_ERROR"
           desc: '''
-                Set to 1 if an error occurred in this partition. If set to 1, SW should
-                check the !!ERR_CODE register at the corresponding index to root-cause the error.
+                Set to 1 if an error occurred in this partition.
+                If set to 1, SW should check the !!ERR_CODE register at the corresponding index.
                 '''
         }
         { bits: "4"
-          name: "SECRET1"
+          name: "SECRET1_ERROR"
           desc: '''
-                Set to 1 if an error occurred in this partition. If set to 1, SW should
-                check the !!ERR_CODE register at the corresponding index to root-cause the error.
+                Set to 1 if an error occurred in this partition.
+                If set to 1, SW should check the !!ERR_CODE register at the corresponding index.
                 '''
         }
         { bits: "5"
-          name: "SECRET2"
+          name: "SECRET2_ERROR"
           desc: '''
-                Set to 1 if an error occurred in this partition. If set to 1, SW should
-                check the !!ERR_CODE register at the corresponding index to root-cause the error.
+                Set to 1 if an error occurred in this partition.
+                If set to 1, SW should check the !!ERR_CODE register at the corresponding index.
                 '''
         }
         { bits: "6"
-          name: "LIFE_CYCLE"
+          name: "LIFE_CYCLE_ERROR"
           desc: '''
-                Set to 1 if an error occurred in this partition. If set to 1, SW should
-                check the !!ERR_CODE register at the corresponding index to root-cause the error.
+                Set to 1 if an error occurred in this partition.
+                If set to 1, SW should check the !!ERR_CODE register at the corresponding index.
                 '''
         }
         { bits: "7"
           name: "DAI_ERROR"
           desc: '''
-                Set to 1 if an error occurred in the DAI. If set to 1, SW should
-                check the !!ERR_CODE register at the corresponding index to root-cause the error.
+                Set to 1 if an error occurred in the DAI.
+                If set to 1, SW should check the !!ERR_CODE register at the corresponding index.
                 '''
         }
         { bits: "8"
           name: "LCI_ERROR"
           desc: '''
-                Set to 1 if an error occurred in the LCI. If set to 1, SW should
-                check the !!ERR_CODE register at the corresponding index to root-cause the error.
+                Set to 1 if an error occurred in the LCI.
+                If set to 1, SW should check the !!ERR_CODE register at the corresponding index.
                 '''
         }
         { bits: "9"
+          name: "TIMEOUT_ERROR"
+          desc: "Set to 1 if an integrity or consistency check times out. This raises an otp_check_failed alert and is an unrecoverable error condition."
+        }
+        { bits: "10"
           name: "DAI_IDLE"
           desc: "Set to 1 if the DAI is idle and ready to accept commands."
+        }
+        { bits: "11"
+          name: "CHECK_PENDING"
+          desc: "Set to 1 if an integrity or consistency check triggered by the LFSR timer or via !!CHECK_TRIGGER is pending."
         }
       ]
     }
@@ -513,58 +521,130 @@
         ]
       }
     },
-    { name: "CHECK_PERIOD_REGEN",
+
+    //////////////////////////////////////
+    // Integrity and Consistency Checks //
+    //////////////////////////////////////
+    { name: "CHECK_TRIGGER_REGWEN",
       desc: '''
-            Register write enable for !!INTEGRITY_CHECK_PERIOD_MSB and !!CONSISTENCY_CHECK_PERIOD_MSB.
+            Register write enable for !!CHECK_TRIGGER.
             ''',
       swaccess: "rw1c",
       hwaccess: "hro",
       fields: [
         { bits:   "0",
           desc: '''
-          When true, !!INTEGRITY_CHECK_PERIOD_MSB and !!CONSISTENCY_CHECK_PERIOD_MSB registers cannot be written anymore.
+          When cleared to 0, the !!CHECK_TRIGGER register cannot be written anymore.
+          Write 1 to clear this bit.
           '''
           resval: 1,
         },
       ]
     },
-    { name: "INTEGRITY_CHECK_PERIOD_MSB",
+    { name: "CHECK_TRIGGER",
+      desc: "Command register for direct accesses.",
+      swaccess: "r0w1c",
+      hwaccess: "hro",
+      hwqe:     "true",
+      regwen:   "CHECK_TRIGGER_REGWEN",
+      fields: [
+        { bits: "0",
+          name: "INTEGRITY",
+          desc: '''
+          Writing 1 to this bit triggers an integrity check. SW should monitor !!STATUS.CHECK_PENDING
+          and wait until the check has been completed. If there are any errors, those will be flagged
+          in the !!STATUS and !!ERR_CODE registers, and via the interrupts and alerts.
+          '''
+        }
+        { bits: "1",
+          name: "CONSISTENCY",
+          desc: '''
+          Writing 1 to this bit triggers a consistency check. SW should monitor !!STATUS.CHECK_PENDING
+          and wait until the check has been completed. If there are any errors, those will be flagged
+          in the !!STATUS and !!ERR_CODE registers, and via interrupts and alerts.
+          '''
+        }
+      ]
+    },
+    { name: "CHECK_REGWEN",
+      desc: '''
+            Register write enable for !!INTEGRITY_CHECK_PERIOD and !!CONSISTENCY_CHECK_PERIOD.
+            ''',
+      swaccess: "rw1c",
+      hwaccess: "hro",
+      fields: [
+        { bits:   "0",
+          desc: '''
+          When cleared to 0, !!INTEGRITY_CHECK_PERIOD and !!CONSISTENCY_CHECK_PERIOD registers cannot be written anymore.
+          Write 1 to clear this bit.
+          '''
+          resval: 1,
+        },
+      ]
+    },
+    { name: "CHECK_TIMEOUT",
+      desc: '''
+            Timeout value for the integrity and consistency checks.
+            ''',
+      swaccess: "rw",
+      hwaccess: "hro",
+      regwen:   "CHECK_REGWEN",
+      fields: [
+        { bits: "31:0",
+          desc: '''
+          Timeout value in cycles for the for the integrity and consistency checks. If an integrity or consistency
+          check does not complete within the timeout window, an error will be flagged in the !!STATUS register,
+          an otp_error interrupt will be raised, and an otp_check_failed alert will be sent out. The timeout should
+          be set to a large value to stay on the safe side. The maximum check time can be upper bounded by the
+          number of cycles it takes to readout, scramble and digest the entire OTP array. Since this amounts to
+          roughly 25k cycles, it is recommended to set this value to at least 100'000 cycles in order to stay on the
+          safe side. A value of zero disables the timeout mechanism (default).
+          '''
+          resval: 0,
+        },
+      ]
+    },
+    { name: "INTEGRITY_CHECK_PERIOD",
       desc: '''
             This value specifies the maximum period that can be generated pseudo-randomly.
-            Only applies to the HW_CFG and SECRET partitions if they are locked.
+            Only applies to the HW_CFG and SECRET* partitions, once they are locked.
             '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "CHECK_PERIOD_REGEN",
+      regwen:   "CHECK_REGWEN",
       fields: [
-        { bits: "5:0",
+        { bits: "31:0",
           desc: '''
-          The pseudo-random period is generated using a 40bit LFSR internally, and this value defines
-          the bit mask to be applied to the LFSR output in order to limit its range. A value of N will generate
-          an internal mask of 2^N-1. So for N=16 this would allow the maximum pseudo-random period to be 0xFFFF cycles.
-          The default value has been set to 25, which corresponds to a maximum period of a bit more than 1.3s at 25MHz.
+          The pseudo-random period is generated using a 40bit LFSR internally, and this register defines
+          the bit mask to be applied to the LFSR output in order to limit its range. The value of this
+          register is left shifted by 8bits and the lower bits are set to 8'hFF in order to form the 40bit mask.
+          A recommended value is 0x3_FFFF, corresponding to a maximum period of ~2.8s at 24MHz.
+          A value of zero disables the timer (default). Note that a one-off check can always be triggered via
+          !!CHECK_TRIGGER.INTEGRITY.
           '''
-          resval: "25"
+          resval: "0"
         }
       ]
     }
-    { name: "CONSISTENCY_CHECK_PERIOD_MSB",
+    { name: "CONSISTENCY_CHECK_PERIOD",
       desc: '''
             This value specifies the maximum period that can be generated pseudo-randomly.
-            This applies to the LIFE_CYCLE partition and the HW_CFG and SECRET partitions (but only if they are locked).
+            This applies to the LIFE_CYCLE partition and the HW_CFG and SECRET* partitions, once they are locked.
             '''
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "CHECK_PERIOD_REGEN",
+      regwen:   "CHECK_REGWEN",
       fields: [
-        { bits: "5:0",
+        { bits: "31:0",
           desc: '''
-          The pseudo-random period is generated using a 40bit LFSR internally, and this value defines
-          the bit mask to be applied to the LFSR output in order to limit its range. A value of N will generate
-          an internal mask of 2^N-1. So for N=16 this would allow the maximum pseudo-random period to be 0xFFFF cycles.
-          The default value has been set to 34, which corresponds to a maximum period of a bit more than 687s at 25MHz.
+          The pseudo-random period is generated using a 40bit LFSR internally, and this register defines
+          the bit mask to be applied to the LFSR output in order to limit its range. The value of this
+          register is left shifted by 8bits and the lower bits are set to 8'hFF in order to form the 40bit mask.
+          A recommended value is 0x3FF_FFFF, corresponding to a maximum period of ~716s at 24MHz.
+          A value of zero disables the timer (default). Note that a one-off check can always be triggered via
+          !!CHECK_TRIGGER.CONSISTENCY.
           '''
-          resval: "34"
+          resval: "0"
         }
       ]
     }
@@ -581,7 +661,8 @@
       fields: [
         { bits:   "0",
           desc: '''
-          When true, read access to the !!CREATOR_SW_CFG partition is locked.
+          When cleared to 0, read access to the !!CREATOR_SW_CFG partition is locked.
+          Write 1 to clear this bit.
           '''
           resval: 1,
         },
@@ -596,7 +677,8 @@
       fields: [
         { bits:   "0",
           desc: '''
-          When true, read access to the !!OWNER_SW_CFG partition is locked.
+          When cleared to 0, read access to the !!OWNER_SW_CFG partition is locked.
+          Write 1 to clear this bit.
           '''
           resval: 1,
         },

--- a/hw/ip/otp_ctrl/otp_ctrl.core
+++ b/hw/ip/otp_ctrl/otp_ctrl.core
@@ -12,6 +12,7 @@ filesets:
       - lowrisc:prim:all
       - lowrisc:prim:ram_1p
       - lowrisc:prim:otp
+      - lowrisc:prim:lfsr
       - lowrisc:ip:otp_ctrl_pkg
     files:
       - rtl/otp_ctrl_reg_top.sv
@@ -21,6 +22,7 @@ filesets:
       - rtl/otp_ctrl_lci.sv
       - rtl/otp_ctrl_part_unbuf.sv
       - rtl/otp_ctrl_part_buf.sv
+      - rtl/otp_ctrl_lfsr_timer.sv
       - rtl/otp_ctrl.sv
     file_type: systemVerilogSource
 

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv
@@ -14,6 +14,8 @@ package otp_ctrl_pkg;
 
   parameter int NumPart = 7;
   parameter int NumPartWidth = vbits(NumPart);
+  // This defines the width of the check timers and LFSR
+  parameter int TimerWidth = 40;
 
   // TODO: may need to tune this and make sure that this encoding not optimized away.
   // Redundantly encoded and complementary values are used to for signalling to the partition
@@ -185,6 +187,17 @@ package otp_ctrl_pkg;
   // add these at the end of certain arrays.
   parameter int DaiIdx = 7;
   parameter int LciIdx = 8;
+
+  parameter int NumUnbuffered = 2;
+
+  ////////////////////////
+  // Typedefs for CSRNG //
+  ////////////////////////
+
+  typedef struct packed {
+    logic        en;
+    logic [31:0] data;
+  } otp_entropy_t;
 
   ///////////////////////////////
   // Typedefs for LC Interface //

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
@@ -74,15 +74,34 @@ package otp_ctrl_reg_pkg;
 
   typedef struct packed {
     logic        q;
-  } otp_ctrl_reg2hw_check_period_regen_reg_t;
+  } otp_ctrl_reg2hw_check_trigger_regwen_reg_t;
 
   typedef struct packed {
-    logic [5:0]  q;
-  } otp_ctrl_reg2hw_integrity_check_period_msb_reg_t;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } integrity;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } consistency;
+  } otp_ctrl_reg2hw_check_trigger_reg_t;
 
   typedef struct packed {
-    logic [5:0]  q;
-  } otp_ctrl_reg2hw_consistency_check_period_msb_reg_t;
+    logic        q;
+  } otp_ctrl_reg2hw_check_regwen_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } otp_ctrl_reg2hw_check_timeout_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } otp_ctrl_reg2hw_integrity_check_period_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } otp_ctrl_reg2hw_consistency_check_period_reg_t;
 
   typedef struct packed {
     logic        q;
@@ -116,16 +135,16 @@ package otp_ctrl_reg_pkg;
     } hw_cfg_error;
     struct packed {
       logic        d;
-    } secret0;
+    } secret0_error;
     struct packed {
       logic        d;
-    } secret1;
+    } secret1_error;
     struct packed {
       logic        d;
-    } secret2;
+    } secret2_error;
     struct packed {
       logic        d;
-    } life_cycle;
+    } life_cycle_error;
     struct packed {
       logic        d;
     } dai_error;
@@ -134,7 +153,13 @@ package otp_ctrl_reg_pkg;
     } lci_error;
     struct packed {
       logic        d;
+    } timeout_error;
+    struct packed {
+      logic        d;
     } dai_idle;
+    struct packed {
+      logic        d;
+    } check_pending;
   } otp_ctrl_hw2reg_status_reg_t;
 
   typedef struct packed {
@@ -188,15 +213,18 @@ package otp_ctrl_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    otp_ctrl_reg2hw_intr_state_reg_t intr_state; // [103:102]
-    otp_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [101:100]
-    otp_ctrl_reg2hw_intr_test_reg_t intr_test; // [99:96]
-    otp_ctrl_reg2hw_direct_access_cmd_reg_t direct_access_cmd; // [95:90]
-    otp_ctrl_reg2hw_direct_access_address_reg_t direct_access_address; // [89:79]
-    otp_ctrl_reg2hw_direct_access_wdata_mreg_t [1:0] direct_access_wdata; // [78:15]
-    otp_ctrl_reg2hw_check_period_regen_reg_t check_period_regen; // [14:14]
-    otp_ctrl_reg2hw_integrity_check_period_msb_reg_t integrity_check_period_msb; // [13:8]
-    otp_ctrl_reg2hw_consistency_check_period_msb_reg_t consistency_check_period_msb; // [7:2]
+    otp_ctrl_reg2hw_intr_state_reg_t intr_state; // [192:191]
+    otp_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [190:189]
+    otp_ctrl_reg2hw_intr_test_reg_t intr_test; // [188:185]
+    otp_ctrl_reg2hw_direct_access_cmd_reg_t direct_access_cmd; // [184:179]
+    otp_ctrl_reg2hw_direct_access_address_reg_t direct_access_address; // [178:168]
+    otp_ctrl_reg2hw_direct_access_wdata_mreg_t [1:0] direct_access_wdata; // [167:104]
+    otp_ctrl_reg2hw_check_trigger_regwen_reg_t check_trigger_regwen; // [103:103]
+    otp_ctrl_reg2hw_check_trigger_reg_t check_trigger; // [102:99]
+    otp_ctrl_reg2hw_check_regwen_reg_t check_regwen; // [98:98]
+    otp_ctrl_reg2hw_check_timeout_reg_t check_timeout; // [97:66]
+    otp_ctrl_reg2hw_integrity_check_period_reg_t integrity_check_period; // [65:34]
+    otp_ctrl_reg2hw_consistency_check_period_reg_t consistency_check_period; // [33:2]
     otp_ctrl_reg2hw_creator_sw_cfg_read_lock_reg_t creator_sw_cfg_read_lock; // [1:1]
     otp_ctrl_reg2hw_owner_sw_cfg_read_lock_reg_t owner_sw_cfg_read_lock; // [0:0]
   } otp_ctrl_reg2hw_t;
@@ -205,19 +233,19 @@ package otp_ctrl_reg_pkg;
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    otp_ctrl_hw2reg_intr_state_reg_t intr_state; // [735:734]
-    otp_ctrl_hw2reg_status_reg_t status; // [733:734]
-    otp_ctrl_hw2reg_err_code_mreg_t [8:0] err_code; // [733:698]
-    otp_ctrl_hw2reg_direct_access_regwen_reg_t direct_access_regwen; // [697:698]
-    otp_ctrl_hw2reg_direct_access_rdata_mreg_t [1:0] direct_access_rdata; // [697:634]
-    otp_ctrl_hw2reg_creator_sw_cfg_digest_mreg_t [1:0] creator_sw_cfg_digest; // [633:570]
-    otp_ctrl_hw2reg_owner_sw_cfg_digest_mreg_t [1:0] owner_sw_cfg_digest; // [569:506]
-    otp_ctrl_hw2reg_hw_cfg_digest_mreg_t [1:0] hw_cfg_digest; // [505:442]
-    otp_ctrl_hw2reg_secret0_digest_mreg_t [1:0] secret0_digest; // [441:378]
-    otp_ctrl_hw2reg_secret1_digest_mreg_t [1:0] secret1_digest; // [377:314]
-    otp_ctrl_hw2reg_secret2_digest_mreg_t [1:0] secret2_digest; // [313:250]
-    otp_ctrl_hw2reg_lc_state_mreg_t [11:0] lc_state; // [249:46]
-    otp_ctrl_hw2reg_lc_transition_cnt_reg_t lc_transition_cnt; // [45:46]
+    otp_ctrl_hw2reg_intr_state_reg_t intr_state; // [737:736]
+    otp_ctrl_hw2reg_status_reg_t status; // [735:736]
+    otp_ctrl_hw2reg_err_code_mreg_t [8:0] err_code; // [735:700]
+    otp_ctrl_hw2reg_direct_access_regwen_reg_t direct_access_regwen; // [699:700]
+    otp_ctrl_hw2reg_direct_access_rdata_mreg_t [1:0] direct_access_rdata; // [699:636]
+    otp_ctrl_hw2reg_creator_sw_cfg_digest_mreg_t [1:0] creator_sw_cfg_digest; // [635:572]
+    otp_ctrl_hw2reg_owner_sw_cfg_digest_mreg_t [1:0] owner_sw_cfg_digest; // [571:508]
+    otp_ctrl_hw2reg_hw_cfg_digest_mreg_t [1:0] hw_cfg_digest; // [507:444]
+    otp_ctrl_hw2reg_secret0_digest_mreg_t [1:0] secret0_digest; // [443:380]
+    otp_ctrl_hw2reg_secret1_digest_mreg_t [1:0] secret1_digest; // [379:316]
+    otp_ctrl_hw2reg_secret2_digest_mreg_t [1:0] secret2_digest; // [315:252]
+    otp_ctrl_hw2reg_lc_state_mreg_t [11:0] lc_state; // [251:48]
+    otp_ctrl_hw2reg_lc_transition_cnt_reg_t lc_transition_cnt; // [47:48]
   } otp_ctrl_hw2reg_t;
 
   // Register Address
@@ -234,30 +262,33 @@ package otp_ctrl_reg_pkg;
   parameter logic [12:0] OTP_CTRL_DIRECT_ACCESS_WDATA_1_OFFSET = 13'h 28;
   parameter logic [12:0] OTP_CTRL_DIRECT_ACCESS_RDATA_0_OFFSET = 13'h 2c;
   parameter logic [12:0] OTP_CTRL_DIRECT_ACCESS_RDATA_1_OFFSET = 13'h 30;
-  parameter logic [12:0] OTP_CTRL_CHECK_PERIOD_REGEN_OFFSET = 13'h 34;
-  parameter logic [12:0] OTP_CTRL_INTEGRITY_CHECK_PERIOD_MSB_OFFSET = 13'h 38;
-  parameter logic [12:0] OTP_CTRL_CONSISTENCY_CHECK_PERIOD_MSB_OFFSET = 13'h 3c;
-  parameter logic [12:0] OTP_CTRL_CREATOR_SW_CFG_READ_LOCK_OFFSET = 13'h 40;
-  parameter logic [12:0] OTP_CTRL_OWNER_SW_CFG_READ_LOCK_OFFSET = 13'h 44;
-  parameter logic [12:0] OTP_CTRL_CREATOR_SW_CFG_DIGEST_0_OFFSET = 13'h 48;
-  parameter logic [12:0] OTP_CTRL_CREATOR_SW_CFG_DIGEST_1_OFFSET = 13'h 4c;
-  parameter logic [12:0] OTP_CTRL_OWNER_SW_CFG_DIGEST_0_OFFSET = 13'h 50;
-  parameter logic [12:0] OTP_CTRL_OWNER_SW_CFG_DIGEST_1_OFFSET = 13'h 54;
-  parameter logic [12:0] OTP_CTRL_HW_CFG_DIGEST_0_OFFSET = 13'h 58;
-  parameter logic [12:0] OTP_CTRL_HW_CFG_DIGEST_1_OFFSET = 13'h 5c;
-  parameter logic [12:0] OTP_CTRL_SECRET0_DIGEST_0_OFFSET = 13'h 60;
-  parameter logic [12:0] OTP_CTRL_SECRET0_DIGEST_1_OFFSET = 13'h 64;
-  parameter logic [12:0] OTP_CTRL_SECRET1_DIGEST_0_OFFSET = 13'h 68;
-  parameter logic [12:0] OTP_CTRL_SECRET1_DIGEST_1_OFFSET = 13'h 6c;
-  parameter logic [12:0] OTP_CTRL_SECRET2_DIGEST_0_OFFSET = 13'h 70;
-  parameter logic [12:0] OTP_CTRL_SECRET2_DIGEST_1_OFFSET = 13'h 74;
-  parameter logic [12:0] OTP_CTRL_LC_STATE_0_OFFSET = 13'h 78;
-  parameter logic [12:0] OTP_CTRL_LC_STATE_1_OFFSET = 13'h 7c;
-  parameter logic [12:0] OTP_CTRL_LC_STATE_2_OFFSET = 13'h 80;
-  parameter logic [12:0] OTP_CTRL_LC_STATE_3_OFFSET = 13'h 84;
-  parameter logic [12:0] OTP_CTRL_LC_STATE_4_OFFSET = 13'h 88;
-  parameter logic [12:0] OTP_CTRL_LC_STATE_5_OFFSET = 13'h 8c;
-  parameter logic [12:0] OTP_CTRL_LC_TRANSITION_CNT_OFFSET = 13'h 90;
+  parameter logic [12:0] OTP_CTRL_CHECK_TRIGGER_REGWEN_OFFSET = 13'h 34;
+  parameter logic [12:0] OTP_CTRL_CHECK_TRIGGER_OFFSET = 13'h 38;
+  parameter logic [12:0] OTP_CTRL_CHECK_REGWEN_OFFSET = 13'h 3c;
+  parameter logic [12:0] OTP_CTRL_CHECK_TIMEOUT_OFFSET = 13'h 40;
+  parameter logic [12:0] OTP_CTRL_INTEGRITY_CHECK_PERIOD_OFFSET = 13'h 44;
+  parameter logic [12:0] OTP_CTRL_CONSISTENCY_CHECK_PERIOD_OFFSET = 13'h 48;
+  parameter logic [12:0] OTP_CTRL_CREATOR_SW_CFG_READ_LOCK_OFFSET = 13'h 4c;
+  parameter logic [12:0] OTP_CTRL_OWNER_SW_CFG_READ_LOCK_OFFSET = 13'h 50;
+  parameter logic [12:0] OTP_CTRL_CREATOR_SW_CFG_DIGEST_0_OFFSET = 13'h 54;
+  parameter logic [12:0] OTP_CTRL_CREATOR_SW_CFG_DIGEST_1_OFFSET = 13'h 58;
+  parameter logic [12:0] OTP_CTRL_OWNER_SW_CFG_DIGEST_0_OFFSET = 13'h 5c;
+  parameter logic [12:0] OTP_CTRL_OWNER_SW_CFG_DIGEST_1_OFFSET = 13'h 60;
+  parameter logic [12:0] OTP_CTRL_HW_CFG_DIGEST_0_OFFSET = 13'h 64;
+  parameter logic [12:0] OTP_CTRL_HW_CFG_DIGEST_1_OFFSET = 13'h 68;
+  parameter logic [12:0] OTP_CTRL_SECRET0_DIGEST_0_OFFSET = 13'h 6c;
+  parameter logic [12:0] OTP_CTRL_SECRET0_DIGEST_1_OFFSET = 13'h 70;
+  parameter logic [12:0] OTP_CTRL_SECRET1_DIGEST_0_OFFSET = 13'h 74;
+  parameter logic [12:0] OTP_CTRL_SECRET1_DIGEST_1_OFFSET = 13'h 78;
+  parameter logic [12:0] OTP_CTRL_SECRET2_DIGEST_0_OFFSET = 13'h 7c;
+  parameter logic [12:0] OTP_CTRL_SECRET2_DIGEST_1_OFFSET = 13'h 80;
+  parameter logic [12:0] OTP_CTRL_LC_STATE_0_OFFSET = 13'h 84;
+  parameter logic [12:0] OTP_CTRL_LC_STATE_1_OFFSET = 13'h 88;
+  parameter logic [12:0] OTP_CTRL_LC_STATE_2_OFFSET = 13'h 8c;
+  parameter logic [12:0] OTP_CTRL_LC_STATE_3_OFFSET = 13'h 90;
+  parameter logic [12:0] OTP_CTRL_LC_STATE_4_OFFSET = 13'h 94;
+  parameter logic [12:0] OTP_CTRL_LC_STATE_5_OFFSET = 13'h 98;
+  parameter logic [12:0] OTP_CTRL_LC_TRANSITION_CNT_OFFSET = 13'h 9c;
 
   // Window parameter
   parameter logic [12:0] OTP_CTRL_CREATOR_SW_CFG_OFFSET = 13'h 400;
@@ -282,9 +313,12 @@ package otp_ctrl_reg_pkg;
     OTP_CTRL_DIRECT_ACCESS_WDATA_1,
     OTP_CTRL_DIRECT_ACCESS_RDATA_0,
     OTP_CTRL_DIRECT_ACCESS_RDATA_1,
-    OTP_CTRL_CHECK_PERIOD_REGEN,
-    OTP_CTRL_INTEGRITY_CHECK_PERIOD_MSB,
-    OTP_CTRL_CONSISTENCY_CHECK_PERIOD_MSB,
+    OTP_CTRL_CHECK_TRIGGER_REGWEN,
+    OTP_CTRL_CHECK_TRIGGER,
+    OTP_CTRL_CHECK_REGWEN,
+    OTP_CTRL_CHECK_TIMEOUT,
+    OTP_CTRL_INTEGRITY_CHECK_PERIOD,
+    OTP_CTRL_CONSISTENCY_CHECK_PERIOD,
     OTP_CTRL_CREATOR_SW_CFG_READ_LOCK,
     OTP_CTRL_OWNER_SW_CFG_READ_LOCK,
     OTP_CTRL_CREATOR_SW_CFG_DIGEST_0,
@@ -309,7 +343,7 @@ package otp_ctrl_reg_pkg;
   } otp_ctrl_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] OTP_CTRL_PERMIT [37] = '{
+  parameter logic [3:0] OTP_CTRL_PERMIT [40] = '{
     4'b 0001, // index[ 0] OTP_CTRL_INTR_STATE
     4'b 0001, // index[ 1] OTP_CTRL_INTR_ENABLE
     4'b 0001, // index[ 2] OTP_CTRL_INTR_TEST
@@ -323,30 +357,33 @@ package otp_ctrl_reg_pkg;
     4'b 1111, // index[10] OTP_CTRL_DIRECT_ACCESS_WDATA_1
     4'b 1111, // index[11] OTP_CTRL_DIRECT_ACCESS_RDATA_0
     4'b 1111, // index[12] OTP_CTRL_DIRECT_ACCESS_RDATA_1
-    4'b 0001, // index[13] OTP_CTRL_CHECK_PERIOD_REGEN
-    4'b 0001, // index[14] OTP_CTRL_INTEGRITY_CHECK_PERIOD_MSB
-    4'b 0001, // index[15] OTP_CTRL_CONSISTENCY_CHECK_PERIOD_MSB
-    4'b 0001, // index[16] OTP_CTRL_CREATOR_SW_CFG_READ_LOCK
-    4'b 0001, // index[17] OTP_CTRL_OWNER_SW_CFG_READ_LOCK
-    4'b 1111, // index[18] OTP_CTRL_CREATOR_SW_CFG_DIGEST_0
-    4'b 1111, // index[19] OTP_CTRL_CREATOR_SW_CFG_DIGEST_1
-    4'b 1111, // index[20] OTP_CTRL_OWNER_SW_CFG_DIGEST_0
-    4'b 1111, // index[21] OTP_CTRL_OWNER_SW_CFG_DIGEST_1
-    4'b 1111, // index[22] OTP_CTRL_HW_CFG_DIGEST_0
-    4'b 1111, // index[23] OTP_CTRL_HW_CFG_DIGEST_1
-    4'b 1111, // index[24] OTP_CTRL_SECRET0_DIGEST_0
-    4'b 1111, // index[25] OTP_CTRL_SECRET0_DIGEST_1
-    4'b 1111, // index[26] OTP_CTRL_SECRET1_DIGEST_0
-    4'b 1111, // index[27] OTP_CTRL_SECRET1_DIGEST_1
-    4'b 1111, // index[28] OTP_CTRL_SECRET2_DIGEST_0
-    4'b 1111, // index[29] OTP_CTRL_SECRET2_DIGEST_1
-    4'b 1111, // index[30] OTP_CTRL_LC_STATE_0
-    4'b 1111, // index[31] OTP_CTRL_LC_STATE_1
-    4'b 1111, // index[32] OTP_CTRL_LC_STATE_2
-    4'b 1111, // index[33] OTP_CTRL_LC_STATE_3
-    4'b 1111, // index[34] OTP_CTRL_LC_STATE_4
-    4'b 1111, // index[35] OTP_CTRL_LC_STATE_5
-    4'b 1111  // index[36] OTP_CTRL_LC_TRANSITION_CNT
+    4'b 0001, // index[13] OTP_CTRL_CHECK_TRIGGER_REGWEN
+    4'b 0001, // index[14] OTP_CTRL_CHECK_TRIGGER
+    4'b 0001, // index[15] OTP_CTRL_CHECK_REGWEN
+    4'b 1111, // index[16] OTP_CTRL_CHECK_TIMEOUT
+    4'b 1111, // index[17] OTP_CTRL_INTEGRITY_CHECK_PERIOD
+    4'b 1111, // index[18] OTP_CTRL_CONSISTENCY_CHECK_PERIOD
+    4'b 0001, // index[19] OTP_CTRL_CREATOR_SW_CFG_READ_LOCK
+    4'b 0001, // index[20] OTP_CTRL_OWNER_SW_CFG_READ_LOCK
+    4'b 1111, // index[21] OTP_CTRL_CREATOR_SW_CFG_DIGEST_0
+    4'b 1111, // index[22] OTP_CTRL_CREATOR_SW_CFG_DIGEST_1
+    4'b 1111, // index[23] OTP_CTRL_OWNER_SW_CFG_DIGEST_0
+    4'b 1111, // index[24] OTP_CTRL_OWNER_SW_CFG_DIGEST_1
+    4'b 1111, // index[25] OTP_CTRL_HW_CFG_DIGEST_0
+    4'b 1111, // index[26] OTP_CTRL_HW_CFG_DIGEST_1
+    4'b 1111, // index[27] OTP_CTRL_SECRET0_DIGEST_0
+    4'b 1111, // index[28] OTP_CTRL_SECRET0_DIGEST_1
+    4'b 1111, // index[29] OTP_CTRL_SECRET1_DIGEST_0
+    4'b 1111, // index[30] OTP_CTRL_SECRET1_DIGEST_1
+    4'b 1111, // index[31] OTP_CTRL_SECRET2_DIGEST_0
+    4'b 1111, // index[32] OTP_CTRL_SECRET2_DIGEST_1
+    4'b 1111, // index[33] OTP_CTRL_LC_STATE_0
+    4'b 1111, // index[34] OTP_CTRL_LC_STATE_1
+    4'b 1111, // index[35] OTP_CTRL_LC_STATE_2
+    4'b 1111, // index[36] OTP_CTRL_LC_STATE_3
+    4'b 1111, // index[37] OTP_CTRL_LC_STATE_4
+    4'b 1111, // index[38] OTP_CTRL_LC_STATE_5
+    4'b 1111  // index[39] OTP_CTRL_LC_TRANSITION_CNT
   };
 endpackage
 

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_top.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_top.sv
@@ -148,20 +148,24 @@ module otp_ctrl_reg_top (
   logic status_owner_sw_cfg_error_re;
   logic status_hw_cfg_error_qs;
   logic status_hw_cfg_error_re;
-  logic status_secret0_qs;
-  logic status_secret0_re;
-  logic status_secret1_qs;
-  logic status_secret1_re;
-  logic status_secret2_qs;
-  logic status_secret2_re;
-  logic status_life_cycle_qs;
-  logic status_life_cycle_re;
+  logic status_secret0_error_qs;
+  logic status_secret0_error_re;
+  logic status_secret1_error_qs;
+  logic status_secret1_error_re;
+  logic status_secret2_error_qs;
+  logic status_secret2_error_re;
+  logic status_life_cycle_error_qs;
+  logic status_life_cycle_error_re;
   logic status_dai_error_qs;
   logic status_dai_error_re;
   logic status_lci_error_qs;
   logic status_lci_error_re;
+  logic status_timeout_error_qs;
+  logic status_timeout_error_re;
   logic status_dai_idle_qs;
   logic status_dai_idle_re;
+  logic status_check_pending_qs;
+  logic status_check_pending_re;
   logic [3:0] err_code_0_err_code_0_qs;
   logic err_code_0_err_code_0_re;
   logic [3:0] err_code_0_err_code_1_qs;
@@ -201,15 +205,25 @@ module otp_ctrl_reg_top (
   logic direct_access_rdata_0_re;
   logic [31:0] direct_access_rdata_1_qs;
   logic direct_access_rdata_1_re;
-  logic check_period_regen_qs;
-  logic check_period_regen_wd;
-  logic check_period_regen_we;
-  logic [5:0] integrity_check_period_msb_qs;
-  logic [5:0] integrity_check_period_msb_wd;
-  logic integrity_check_period_msb_we;
-  logic [5:0] consistency_check_period_msb_qs;
-  logic [5:0] consistency_check_period_msb_wd;
-  logic consistency_check_period_msb_we;
+  logic check_trigger_regwen_qs;
+  logic check_trigger_regwen_wd;
+  logic check_trigger_regwen_we;
+  logic check_trigger_integrity_wd;
+  logic check_trigger_integrity_we;
+  logic check_trigger_consistency_wd;
+  logic check_trigger_consistency_we;
+  logic check_regwen_qs;
+  logic check_regwen_wd;
+  logic check_regwen_we;
+  logic [31:0] check_timeout_qs;
+  logic [31:0] check_timeout_wd;
+  logic check_timeout_we;
+  logic [31:0] integrity_check_period_qs;
+  logic [31:0] integrity_check_period_wd;
+  logic integrity_check_period_we;
+  logic [31:0] consistency_check_period_qs;
+  logic [31:0] consistency_check_period_wd;
+  logic consistency_check_period_we;
   logic creator_sw_cfg_read_lock_qs;
   logic creator_sw_cfg_read_lock_wd;
   logic creator_sw_cfg_read_lock_we;
@@ -442,63 +456,63 @@ module otp_ctrl_reg_top (
   );
 
 
-  //   F[secret0]: 3:3
+  //   F[secret0_error]: 3:3
   prim_subreg_ext #(
     .DW    (1)
-  ) u_status_secret0 (
-    .re     (status_secret0_re),
+  ) u_status_secret0_error (
+    .re     (status_secret0_error_re),
     .we     (1'b0),
     .wd     ('0),
-    .d      (hw2reg.status.secret0.d),
+    .d      (hw2reg.status.secret0_error.d),
     .qre    (),
     .qe     (),
     .q      (),
-    .qs     (status_secret0_qs)
+    .qs     (status_secret0_error_qs)
   );
 
 
-  //   F[secret1]: 4:4
+  //   F[secret1_error]: 4:4
   prim_subreg_ext #(
     .DW    (1)
-  ) u_status_secret1 (
-    .re     (status_secret1_re),
+  ) u_status_secret1_error (
+    .re     (status_secret1_error_re),
     .we     (1'b0),
     .wd     ('0),
-    .d      (hw2reg.status.secret1.d),
+    .d      (hw2reg.status.secret1_error.d),
     .qre    (),
     .qe     (),
     .q      (),
-    .qs     (status_secret1_qs)
+    .qs     (status_secret1_error_qs)
   );
 
 
-  //   F[secret2]: 5:5
+  //   F[secret2_error]: 5:5
   prim_subreg_ext #(
     .DW    (1)
-  ) u_status_secret2 (
-    .re     (status_secret2_re),
+  ) u_status_secret2_error (
+    .re     (status_secret2_error_re),
     .we     (1'b0),
     .wd     ('0),
-    .d      (hw2reg.status.secret2.d),
+    .d      (hw2reg.status.secret2_error.d),
     .qre    (),
     .qe     (),
     .q      (),
-    .qs     (status_secret2_qs)
+    .qs     (status_secret2_error_qs)
   );
 
 
-  //   F[life_cycle]: 6:6
+  //   F[life_cycle_error]: 6:6
   prim_subreg_ext #(
     .DW    (1)
-  ) u_status_life_cycle (
-    .re     (status_life_cycle_re),
+  ) u_status_life_cycle_error (
+    .re     (status_life_cycle_error_re),
     .we     (1'b0),
     .wd     ('0),
-    .d      (hw2reg.status.life_cycle.d),
+    .d      (hw2reg.status.life_cycle_error.d),
     .qre    (),
     .qe     (),
     .q      (),
-    .qs     (status_life_cycle_qs)
+    .qs     (status_life_cycle_error_qs)
   );
 
 
@@ -532,7 +546,22 @@ module otp_ctrl_reg_top (
   );
 
 
-  //   F[dai_idle]: 9:9
+  //   F[timeout_error]: 9:9
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_status_timeout_error (
+    .re     (status_timeout_error_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.status.timeout_error.d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (status_timeout_error_qs)
+  );
+
+
+  //   F[dai_idle]: 10:10
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_dai_idle (
@@ -544,6 +573,21 @@ module otp_ctrl_reg_top (
     .qe     (),
     .q      (),
     .qs     (status_dai_idle_qs)
+  );
+
+
+  //   F[check_pending]: 11:11
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_status_check_pending (
+    .re     (status_check_pending_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.status.check_pending.d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (status_check_pending_qs)
   );
 
 
@@ -898,19 +942,19 @@ module otp_ctrl_reg_top (
   );
 
 
-  // R[check_period_regen]: V(False)
+  // R[check_trigger_regwen]: V(False)
 
   prim_subreg #(
     .DW      (1),
     .SWACCESS("W1C"),
     .RESVAL  (1'h1)
-  ) u_check_period_regen (
+  ) u_check_trigger_regwen (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (check_period_regen_we),
-    .wd     (check_period_regen_wd),
+    .we     (check_trigger_regwen_we),
+    .wd     (check_trigger_regwen_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -918,53 +962,78 @@ module otp_ctrl_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.check_period_regen.q ),
+    .q      (reg2hw.check_trigger_regwen.q ),
 
     // to register interface (read)
-    .qs     (check_period_regen_qs)
+    .qs     (check_trigger_regwen_qs)
   );
 
 
-  // R[integrity_check_period_msb]: V(False)
+  // R[check_trigger]: V(False)
 
+  //   F[integrity]: 0:0
   prim_subreg #(
-    .DW      (6),
-    .SWACCESS("RW"),
-    .RESVAL  (6'h19)
-  ) u_integrity_check_period_msb (
+    .DW      (1),
+    .SWACCESS("W1C"),
+    .RESVAL  (1'h0)
+  ) u_check_trigger_integrity (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (integrity_check_period_msb_we & check_period_regen_qs),
-    .wd     (integrity_check_period_msb_wd),
+    .we     (check_trigger_integrity_we & check_trigger_regwen_qs),
+    .wd     (check_trigger_integrity_wd),
 
     // from internal hardware
     .de     (1'b0),
     .d      ('0  ),
 
     // to internal hardware
-    .qe     (),
-    .q      (reg2hw.integrity_check_period_msb.q ),
+    .qe     (reg2hw.check_trigger.integrity.qe),
+    .q      (reg2hw.check_trigger.integrity.q ),
 
-    // to register interface (read)
-    .qs     (integrity_check_period_msb_qs)
+    .qs     ()
   );
 
 
-  // R[consistency_check_period_msb]: V(False)
-
+  //   F[consistency]: 1:1
   prim_subreg #(
-    .DW      (6),
-    .SWACCESS("RW"),
-    .RESVAL  (6'h22)
-  ) u_consistency_check_period_msb (
+    .DW      (1),
+    .SWACCESS("W1C"),
+    .RESVAL  (1'h0)
+  ) u_check_trigger_consistency (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (consistency_check_period_msb_we & check_period_regen_qs),
-    .wd     (consistency_check_period_msb_wd),
+    .we     (check_trigger_consistency_we & check_trigger_regwen_qs),
+    .wd     (check_trigger_consistency_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (reg2hw.check_trigger.consistency.qe),
+    .q      (reg2hw.check_trigger.consistency.q ),
+
+    .qs     ()
+  );
+
+
+  // R[check_regwen]: V(False)
+
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("W1C"),
+    .RESVAL  (1'h1)
+  ) u_check_regwen (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (check_regwen_we),
+    .wd     (check_regwen_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -972,10 +1041,91 @@ module otp_ctrl_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.consistency_check_period_msb.q ),
+    .q      (reg2hw.check_regwen.q ),
 
     // to register interface (read)
-    .qs     (consistency_check_period_msb_qs)
+    .qs     (check_regwen_qs)
+  );
+
+
+  // R[check_timeout]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
+  ) u_check_timeout (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (check_timeout_we & check_regwen_qs),
+    .wd     (check_timeout_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.check_timeout.q ),
+
+    // to register interface (read)
+    .qs     (check_timeout_qs)
+  );
+
+
+  // R[integrity_check_period]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
+  ) u_integrity_check_period (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (integrity_check_period_we & check_regwen_qs),
+    .wd     (integrity_check_period_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.integrity_check_period.q ),
+
+    // to register interface (read)
+    .qs     (integrity_check_period_qs)
+  );
+
+
+  // R[consistency_check_period]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SWACCESS("RW"),
+    .RESVAL  (32'h0)
+  ) u_consistency_check_period (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (consistency_check_period_we & check_regwen_qs),
+    .wd     (consistency_check_period_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.consistency_check_period.q ),
+
+    // to register interface (read)
+    .qs     (consistency_check_period_qs)
   );
 
 
@@ -1585,7 +1735,7 @@ module otp_ctrl_reg_top (
 
 
 
-  logic [36:0] addr_hit;
+  logic [39:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == OTP_CTRL_INTR_STATE_OFFSET);
@@ -1601,30 +1751,33 @@ module otp_ctrl_reg_top (
     addr_hit[10] = (reg_addr == OTP_CTRL_DIRECT_ACCESS_WDATA_1_OFFSET);
     addr_hit[11] = (reg_addr == OTP_CTRL_DIRECT_ACCESS_RDATA_0_OFFSET);
     addr_hit[12] = (reg_addr == OTP_CTRL_DIRECT_ACCESS_RDATA_1_OFFSET);
-    addr_hit[13] = (reg_addr == OTP_CTRL_CHECK_PERIOD_REGEN_OFFSET);
-    addr_hit[14] = (reg_addr == OTP_CTRL_INTEGRITY_CHECK_PERIOD_MSB_OFFSET);
-    addr_hit[15] = (reg_addr == OTP_CTRL_CONSISTENCY_CHECK_PERIOD_MSB_OFFSET);
-    addr_hit[16] = (reg_addr == OTP_CTRL_CREATOR_SW_CFG_READ_LOCK_OFFSET);
-    addr_hit[17] = (reg_addr == OTP_CTRL_OWNER_SW_CFG_READ_LOCK_OFFSET);
-    addr_hit[18] = (reg_addr == OTP_CTRL_CREATOR_SW_CFG_DIGEST_0_OFFSET);
-    addr_hit[19] = (reg_addr == OTP_CTRL_CREATOR_SW_CFG_DIGEST_1_OFFSET);
-    addr_hit[20] = (reg_addr == OTP_CTRL_OWNER_SW_CFG_DIGEST_0_OFFSET);
-    addr_hit[21] = (reg_addr == OTP_CTRL_OWNER_SW_CFG_DIGEST_1_OFFSET);
-    addr_hit[22] = (reg_addr == OTP_CTRL_HW_CFG_DIGEST_0_OFFSET);
-    addr_hit[23] = (reg_addr == OTP_CTRL_HW_CFG_DIGEST_1_OFFSET);
-    addr_hit[24] = (reg_addr == OTP_CTRL_SECRET0_DIGEST_0_OFFSET);
-    addr_hit[25] = (reg_addr == OTP_CTRL_SECRET0_DIGEST_1_OFFSET);
-    addr_hit[26] = (reg_addr == OTP_CTRL_SECRET1_DIGEST_0_OFFSET);
-    addr_hit[27] = (reg_addr == OTP_CTRL_SECRET1_DIGEST_1_OFFSET);
-    addr_hit[28] = (reg_addr == OTP_CTRL_SECRET2_DIGEST_0_OFFSET);
-    addr_hit[29] = (reg_addr == OTP_CTRL_SECRET2_DIGEST_1_OFFSET);
-    addr_hit[30] = (reg_addr == OTP_CTRL_LC_STATE_0_OFFSET);
-    addr_hit[31] = (reg_addr == OTP_CTRL_LC_STATE_1_OFFSET);
-    addr_hit[32] = (reg_addr == OTP_CTRL_LC_STATE_2_OFFSET);
-    addr_hit[33] = (reg_addr == OTP_CTRL_LC_STATE_3_OFFSET);
-    addr_hit[34] = (reg_addr == OTP_CTRL_LC_STATE_4_OFFSET);
-    addr_hit[35] = (reg_addr == OTP_CTRL_LC_STATE_5_OFFSET);
-    addr_hit[36] = (reg_addr == OTP_CTRL_LC_TRANSITION_CNT_OFFSET);
+    addr_hit[13] = (reg_addr == OTP_CTRL_CHECK_TRIGGER_REGWEN_OFFSET);
+    addr_hit[14] = (reg_addr == OTP_CTRL_CHECK_TRIGGER_OFFSET);
+    addr_hit[15] = (reg_addr == OTP_CTRL_CHECK_REGWEN_OFFSET);
+    addr_hit[16] = (reg_addr == OTP_CTRL_CHECK_TIMEOUT_OFFSET);
+    addr_hit[17] = (reg_addr == OTP_CTRL_INTEGRITY_CHECK_PERIOD_OFFSET);
+    addr_hit[18] = (reg_addr == OTP_CTRL_CONSISTENCY_CHECK_PERIOD_OFFSET);
+    addr_hit[19] = (reg_addr == OTP_CTRL_CREATOR_SW_CFG_READ_LOCK_OFFSET);
+    addr_hit[20] = (reg_addr == OTP_CTRL_OWNER_SW_CFG_READ_LOCK_OFFSET);
+    addr_hit[21] = (reg_addr == OTP_CTRL_CREATOR_SW_CFG_DIGEST_0_OFFSET);
+    addr_hit[22] = (reg_addr == OTP_CTRL_CREATOR_SW_CFG_DIGEST_1_OFFSET);
+    addr_hit[23] = (reg_addr == OTP_CTRL_OWNER_SW_CFG_DIGEST_0_OFFSET);
+    addr_hit[24] = (reg_addr == OTP_CTRL_OWNER_SW_CFG_DIGEST_1_OFFSET);
+    addr_hit[25] = (reg_addr == OTP_CTRL_HW_CFG_DIGEST_0_OFFSET);
+    addr_hit[26] = (reg_addr == OTP_CTRL_HW_CFG_DIGEST_1_OFFSET);
+    addr_hit[27] = (reg_addr == OTP_CTRL_SECRET0_DIGEST_0_OFFSET);
+    addr_hit[28] = (reg_addr == OTP_CTRL_SECRET0_DIGEST_1_OFFSET);
+    addr_hit[29] = (reg_addr == OTP_CTRL_SECRET1_DIGEST_0_OFFSET);
+    addr_hit[30] = (reg_addr == OTP_CTRL_SECRET1_DIGEST_1_OFFSET);
+    addr_hit[31] = (reg_addr == OTP_CTRL_SECRET2_DIGEST_0_OFFSET);
+    addr_hit[32] = (reg_addr == OTP_CTRL_SECRET2_DIGEST_1_OFFSET);
+    addr_hit[33] = (reg_addr == OTP_CTRL_LC_STATE_0_OFFSET);
+    addr_hit[34] = (reg_addr == OTP_CTRL_LC_STATE_1_OFFSET);
+    addr_hit[35] = (reg_addr == OTP_CTRL_LC_STATE_2_OFFSET);
+    addr_hit[36] = (reg_addr == OTP_CTRL_LC_STATE_3_OFFSET);
+    addr_hit[37] = (reg_addr == OTP_CTRL_LC_STATE_4_OFFSET);
+    addr_hit[38] = (reg_addr == OTP_CTRL_LC_STATE_5_OFFSET);
+    addr_hit[39] = (reg_addr == OTP_CTRL_LC_TRANSITION_CNT_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -1669,6 +1822,9 @@ module otp_ctrl_reg_top (
     if (addr_hit[34] && reg_we && (OTP_CTRL_PERMIT[34] != (OTP_CTRL_PERMIT[34] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[35] && reg_we && (OTP_CTRL_PERMIT[35] != (OTP_CTRL_PERMIT[35] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[36] && reg_we && (OTP_CTRL_PERMIT[36] != (OTP_CTRL_PERMIT[36] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[37] && reg_we && (OTP_CTRL_PERMIT[37] != (OTP_CTRL_PERMIT[37] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[38] && reg_we && (OTP_CTRL_PERMIT[38] != (OTP_CTRL_PERMIT[38] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[39] && reg_we && (OTP_CTRL_PERMIT[39] != (OTP_CTRL_PERMIT[39] & reg_be))) wr_err = 1'b1 ;
   end
 
   assign intr_state_otp_operation_done_we = addr_hit[0] & reg_we & ~wr_err;
@@ -1695,19 +1851,23 @@ module otp_ctrl_reg_top (
 
   assign status_hw_cfg_error_re = addr_hit[3] && reg_re;
 
-  assign status_secret0_re = addr_hit[3] && reg_re;
+  assign status_secret0_error_re = addr_hit[3] && reg_re;
 
-  assign status_secret1_re = addr_hit[3] && reg_re;
+  assign status_secret1_error_re = addr_hit[3] && reg_re;
 
-  assign status_secret2_re = addr_hit[3] && reg_re;
+  assign status_secret2_error_re = addr_hit[3] && reg_re;
 
-  assign status_life_cycle_re = addr_hit[3] && reg_re;
+  assign status_life_cycle_error_re = addr_hit[3] && reg_re;
 
   assign status_dai_error_re = addr_hit[3] && reg_re;
 
   assign status_lci_error_re = addr_hit[3] && reg_re;
 
+  assign status_timeout_error_re = addr_hit[3] && reg_re;
+
   assign status_dai_idle_re = addr_hit[3] && reg_re;
+
+  assign status_check_pending_re = addr_hit[3] && reg_re;
 
   assign err_code_0_err_code_0_re = addr_hit[4] && reg_re;
 
@@ -1751,44 +1911,56 @@ module otp_ctrl_reg_top (
 
   assign direct_access_rdata_1_re = addr_hit[12] && reg_re;
 
-  assign check_period_regen_we = addr_hit[13] & reg_we & ~wr_err;
-  assign check_period_regen_wd = reg_wdata[0];
+  assign check_trigger_regwen_we = addr_hit[13] & reg_we & ~wr_err;
+  assign check_trigger_regwen_wd = reg_wdata[0];
 
-  assign integrity_check_period_msb_we = addr_hit[14] & reg_we & ~wr_err;
-  assign integrity_check_period_msb_wd = reg_wdata[5:0];
+  assign check_trigger_integrity_we = addr_hit[14] & reg_we & ~wr_err;
+  assign check_trigger_integrity_wd = reg_wdata[0];
 
-  assign consistency_check_period_msb_we = addr_hit[15] & reg_we & ~wr_err;
-  assign consistency_check_period_msb_wd = reg_wdata[5:0];
+  assign check_trigger_consistency_we = addr_hit[14] & reg_we & ~wr_err;
+  assign check_trigger_consistency_wd = reg_wdata[1];
 
-  assign creator_sw_cfg_read_lock_we = addr_hit[16] & reg_we & ~wr_err;
+  assign check_regwen_we = addr_hit[15] & reg_we & ~wr_err;
+  assign check_regwen_wd = reg_wdata[0];
+
+  assign check_timeout_we = addr_hit[16] & reg_we & ~wr_err;
+  assign check_timeout_wd = reg_wdata[31:0];
+
+  assign integrity_check_period_we = addr_hit[17] & reg_we & ~wr_err;
+  assign integrity_check_period_wd = reg_wdata[31:0];
+
+  assign consistency_check_period_we = addr_hit[18] & reg_we & ~wr_err;
+  assign consistency_check_period_wd = reg_wdata[31:0];
+
+  assign creator_sw_cfg_read_lock_we = addr_hit[19] & reg_we & ~wr_err;
   assign creator_sw_cfg_read_lock_wd = reg_wdata[0];
 
-  assign owner_sw_cfg_read_lock_we = addr_hit[17] & reg_we & ~wr_err;
+  assign owner_sw_cfg_read_lock_we = addr_hit[20] & reg_we & ~wr_err;
   assign owner_sw_cfg_read_lock_wd = reg_wdata[0];
 
-  assign creator_sw_cfg_digest_0_re = addr_hit[18] && reg_re;
+  assign creator_sw_cfg_digest_0_re = addr_hit[21] && reg_re;
 
-  assign creator_sw_cfg_digest_1_re = addr_hit[19] && reg_re;
+  assign creator_sw_cfg_digest_1_re = addr_hit[22] && reg_re;
 
-  assign owner_sw_cfg_digest_0_re = addr_hit[20] && reg_re;
+  assign owner_sw_cfg_digest_0_re = addr_hit[23] && reg_re;
 
-  assign owner_sw_cfg_digest_1_re = addr_hit[21] && reg_re;
+  assign owner_sw_cfg_digest_1_re = addr_hit[24] && reg_re;
 
-  assign hw_cfg_digest_0_re = addr_hit[22] && reg_re;
+  assign hw_cfg_digest_0_re = addr_hit[25] && reg_re;
 
-  assign hw_cfg_digest_1_re = addr_hit[23] && reg_re;
+  assign hw_cfg_digest_1_re = addr_hit[26] && reg_re;
 
-  assign secret0_digest_0_re = addr_hit[24] && reg_re;
+  assign secret0_digest_0_re = addr_hit[27] && reg_re;
 
-  assign secret0_digest_1_re = addr_hit[25] && reg_re;
+  assign secret0_digest_1_re = addr_hit[28] && reg_re;
 
-  assign secret1_digest_0_re = addr_hit[26] && reg_re;
+  assign secret1_digest_0_re = addr_hit[29] && reg_re;
 
-  assign secret1_digest_1_re = addr_hit[27] && reg_re;
+  assign secret1_digest_1_re = addr_hit[30] && reg_re;
 
-  assign secret2_digest_0_re = addr_hit[28] && reg_re;
+  assign secret2_digest_0_re = addr_hit[31] && reg_re;
 
-  assign secret2_digest_1_re = addr_hit[29] && reg_re;
+  assign secret2_digest_1_re = addr_hit[32] && reg_re;
 
 
 
@@ -1826,13 +1998,15 @@ module otp_ctrl_reg_top (
         reg_rdata_next[0] = status_creator_sw_cfg_error_qs;
         reg_rdata_next[1] = status_owner_sw_cfg_error_qs;
         reg_rdata_next[2] = status_hw_cfg_error_qs;
-        reg_rdata_next[3] = status_secret0_qs;
-        reg_rdata_next[4] = status_secret1_qs;
-        reg_rdata_next[5] = status_secret2_qs;
-        reg_rdata_next[6] = status_life_cycle_qs;
+        reg_rdata_next[3] = status_secret0_error_qs;
+        reg_rdata_next[4] = status_secret1_error_qs;
+        reg_rdata_next[5] = status_secret2_error_qs;
+        reg_rdata_next[6] = status_life_cycle_error_qs;
         reg_rdata_next[7] = status_dai_error_qs;
         reg_rdata_next[8] = status_lci_error_qs;
-        reg_rdata_next[9] = status_dai_idle_qs;
+        reg_rdata_next[9] = status_timeout_error_qs;
+        reg_rdata_next[10] = status_dai_idle_qs;
+        reg_rdata_next[11] = status_check_pending_qs;
       end
 
       addr_hit[4]: begin
@@ -1881,104 +2055,117 @@ module otp_ctrl_reg_top (
       end
 
       addr_hit[13]: begin
-        reg_rdata_next[0] = check_period_regen_qs;
+        reg_rdata_next[0] = check_trigger_regwen_qs;
       end
 
       addr_hit[14]: begin
-        reg_rdata_next[5:0] = integrity_check_period_msb_qs;
+        reg_rdata_next[0] = '0;
+        reg_rdata_next[1] = '0;
       end
 
       addr_hit[15]: begin
-        reg_rdata_next[5:0] = consistency_check_period_msb_qs;
+        reg_rdata_next[0] = check_regwen_qs;
       end
 
       addr_hit[16]: begin
-        reg_rdata_next[0] = creator_sw_cfg_read_lock_qs;
+        reg_rdata_next[31:0] = check_timeout_qs;
       end
 
       addr_hit[17]: begin
-        reg_rdata_next[0] = owner_sw_cfg_read_lock_qs;
+        reg_rdata_next[31:0] = integrity_check_period_qs;
       end
 
       addr_hit[18]: begin
-        reg_rdata_next[31:0] = creator_sw_cfg_digest_0_qs;
+        reg_rdata_next[31:0] = consistency_check_period_qs;
       end
 
       addr_hit[19]: begin
-        reg_rdata_next[31:0] = creator_sw_cfg_digest_1_qs;
+        reg_rdata_next[0] = creator_sw_cfg_read_lock_qs;
       end
 
       addr_hit[20]: begin
-        reg_rdata_next[31:0] = owner_sw_cfg_digest_0_qs;
+        reg_rdata_next[0] = owner_sw_cfg_read_lock_qs;
       end
 
       addr_hit[21]: begin
-        reg_rdata_next[31:0] = owner_sw_cfg_digest_1_qs;
+        reg_rdata_next[31:0] = creator_sw_cfg_digest_0_qs;
       end
 
       addr_hit[22]: begin
-        reg_rdata_next[31:0] = hw_cfg_digest_0_qs;
+        reg_rdata_next[31:0] = creator_sw_cfg_digest_1_qs;
       end
 
       addr_hit[23]: begin
-        reg_rdata_next[31:0] = hw_cfg_digest_1_qs;
+        reg_rdata_next[31:0] = owner_sw_cfg_digest_0_qs;
       end
 
       addr_hit[24]: begin
-        reg_rdata_next[31:0] = secret0_digest_0_qs;
+        reg_rdata_next[31:0] = owner_sw_cfg_digest_1_qs;
       end
 
       addr_hit[25]: begin
-        reg_rdata_next[31:0] = secret0_digest_1_qs;
+        reg_rdata_next[31:0] = hw_cfg_digest_0_qs;
       end
 
       addr_hit[26]: begin
-        reg_rdata_next[31:0] = secret1_digest_0_qs;
+        reg_rdata_next[31:0] = hw_cfg_digest_1_qs;
       end
 
       addr_hit[27]: begin
-        reg_rdata_next[31:0] = secret1_digest_1_qs;
+        reg_rdata_next[31:0] = secret0_digest_0_qs;
       end
 
       addr_hit[28]: begin
-        reg_rdata_next[31:0] = secret2_digest_0_qs;
+        reg_rdata_next[31:0] = secret0_digest_1_qs;
       end
 
       addr_hit[29]: begin
-        reg_rdata_next[31:0] = secret2_digest_1_qs;
+        reg_rdata_next[31:0] = secret1_digest_0_qs;
       end
 
       addr_hit[30]: begin
+        reg_rdata_next[31:0] = secret1_digest_1_qs;
+      end
+
+      addr_hit[31]: begin
+        reg_rdata_next[31:0] = secret2_digest_0_qs;
+      end
+
+      addr_hit[32]: begin
+        reg_rdata_next[31:0] = secret2_digest_1_qs;
+      end
+
+      addr_hit[33]: begin
         reg_rdata_next[15:0] = lc_state_0_lc_state_0_qs;
         reg_rdata_next[31:16] = lc_state_0_lc_state_1_qs;
       end
 
-      addr_hit[31]: begin
+      addr_hit[34]: begin
         reg_rdata_next[15:0] = lc_state_1_lc_state_2_qs;
         reg_rdata_next[31:16] = lc_state_1_lc_state_3_qs;
       end
 
-      addr_hit[32]: begin
+      addr_hit[35]: begin
         reg_rdata_next[15:0] = lc_state_2_lc_state_4_qs;
         reg_rdata_next[31:16] = lc_state_2_lc_state_5_qs;
       end
 
-      addr_hit[33]: begin
+      addr_hit[36]: begin
         reg_rdata_next[15:0] = lc_state_3_lc_state_6_qs;
         reg_rdata_next[31:16] = lc_state_3_lc_state_7_qs;
       end
 
-      addr_hit[34]: begin
+      addr_hit[37]: begin
         reg_rdata_next[15:0] = lc_state_4_lc_state_8_qs;
         reg_rdata_next[31:16] = lc_state_4_lc_state_9_qs;
       end
 
-      addr_hit[35]: begin
+      addr_hit[38]: begin
         reg_rdata_next[15:0] = lc_state_5_lc_state_10_qs;
         reg_rdata_next[31:16] = lc_state_5_lc_state_11_qs;
       end
 
-      addr_hit[36]: begin
+      addr_hit[39]: begin
         reg_rdata_next[31:0] = lc_transition_cnt_qs;
       end
 

--- a/hw/syn/tools/dc/testsynth.tcl
+++ b/hw/syn/tools/dc/testsynth.tcl
@@ -27,16 +27,21 @@ define_design_lib WORK -path $WORKLIB
 ##  DESIGN SOURCES  ###
 #######################
 
-set DUT "rv_plic_target"
+set DUT "otp_ctrl_lfsr_timer"
 
 lappend search_path "../../../ip/prim/rtl/"
-set SRC {  "../../../ip/rv_plic/rtl/rv_plic_target.sv" }
+set SRC {  "../../../ip/prim/rtl/prim_util_pkg.sv"           \
+           "../../../ip/prim/rtl/prim_assert.sv"             \
+           "../../../ip/prim/rtl/prim_lfsr.sv"               \
+           "../../../ip/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv"    \
+           "../../../ip/otp_ctrl/rtl/otp_ctrl_pkg.sv"        \
+           "../../../ip/otp_ctrl/rtl/otp_ctrl_lfsr_timer.sv" }
 
 # additional defines
 set DEFINE ""
 
 # additional parameters
-set PARAMS "N_SOURCE=128"
+set PARAMS ""
 
 ###########################
 ##   ELABORATE DESIGN    ##
@@ -52,7 +57,6 @@ link                                           > "${REPDIR}/${DUT}_link.rpt"
 check_design                                   > "${REPDIR}/${DUT}_check.rpt"
 
 write_file -format ddc -hierarchy -output "${DDCDIR}/${DUT}_elab.ddc"
-write_file -format verilog -hierarchy -output "${DDCDIR}/${DUT}_elab.v"
 
 ###########################
 ##   APPLY CONSTRAINTS   ##
@@ -77,8 +81,10 @@ set_max_delay ${DELAY} -from [all_inputs] -to [all_outputs]
 set_input_delay ${IN_DEL} [remove_from_collection [all_inputs] {${CLK_PIN}}] -clock ${CLK_PIN}
 set_output_delay ${OUT_DEL}  [all_outputs] -clock ${CLK_PIN}
 
-set_driving_cell  -no_design_rule -lib_cell ${DRIVING_CELL} -pin X [all_inputs]
-set_load [load_of ${LOAD_LIB}/${LOAD_CELL}/A] [all_outputs]
+# attach load and drivers to IOs to get a more realistic estimate
+set_driving_cell  -no_design_rule -lib_cell ${DRIVING_CELL} -pin ${DRIVING_CELL_PIN} [all_inputs]
+set_load [load_of ${LOAD_CELL_LIB}/${LOAD_CELL}/${LOAD_CELL_PIN}] [all_outputs]
+
 
 # set a nonzero critical range to be able to spot the violating paths better
 # in the report
@@ -109,6 +115,6 @@ report_timing      -nosplit -nworst 1000 -input -net -trans -cap > "${REPDIR}/${
 ##   NETLIST   ##
 #################
 
-# change_names -rules verilog -hierarchy
+change_names -rules verilog -hierarchy
 write_file -format ddc     -hierarchy -output "${DDCDIR}/${DUT}_mapped.ddc"
 write_file -format verilog -hierarchy -output "${VLOGDIR}/${DUT}_mapped.v"


### PR DESCRIPTION
This module implements the LFSR timer for triggering periodic consistency and integrity checks in OTP. The timer works in a similar way as the ping timer in the alert handler, and draws pseudo random wait counts from a 40bit LFSR in between integrity and consistency checks. 

Once a particular check timer has expired, the module will send out a check request to all partitions and wait for an acknowledgement. If a particular partition encounters an integrity or consistency mismatch, this will be reported in the error CSRs and trigger an alert.

In order to guard against wedged partition controllers or arbitration lock ups due to tampering attempts, this check timer module also supports a 32bit timeout that can optionally be programmed. If a particular check times out, this will raise an alert.

The LFSR can be reseeded with fresh entropy from the CSRNG (the interface is a mock up and will be aligned once the EDN is available).

Note that  the check timer is disabled by default, and needs to be explicitly enabled by SW.
It is also possible to trigger one-off checks via the CSRs, which can be useful if SW chooses to leave the periodic checks disabled.
