### PR TITLE
[cip, dv] Fix variable printed by uvm_info

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/cip_base_vseq.sv
@@ -399,12 +399,12 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
                 end
               join
               wait(ongoing_reset == 0);
-              `uvm_info(`gfn, $sformatf("Finished run %0d/%0d w/o reset", i, num_trans), UVM_LOW)
+              `uvm_info(`gfn, $sformatf("Finished run %0d/%0d w/o reset", i, num_times), UVM_LOW)
             end
             begin : issue_rand_reset
               cfg.clk_rst_vif.wait_clks(delay_to_reset);
               ongoing_reset = 1'b1;
-              `uvm_info(`gfn, $sformatf("Reset is issued for run %0d/%0d", i, num_trans), UVM_LOW)
+              `uvm_info(`gfn, $sformatf("Reset is issued for run %0d/%0d", i, num_times), UVM_LOW)
               apply_reset("HARD");
               ongoing_reset = 1'b0;
               do_read_and_check_all_csrs = 1'b1;
@@ -412,7 +412,7 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
           join_any
           p_sequencer.tl_sequencer_h.stop_sequences();
           disable fork;
-          `uvm_info(`gfn, $sformatf("Stress w/ reset is done for run %0d/%0d", i, num_trans),
+          `uvm_info(`gfn, $sformatf("Stress w/ reset is done for run %0d/%0d", i, num_times),
                     UVM_LOW)
           // delay to avoid race condition when sending item and checking no item after reset occur
           // at the same time


### PR DESCRIPTION
Minor fix to print correct variables with uvm_info

Signed-off-by: Tung Hoang <hoang.tung@wdc.com>