### PR TITLE
[otbn] fix issues in simulator

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/dmem.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/dmem.py
@@ -204,7 +204,7 @@ class Dmem:
 
         # Replace the word we're setting
         assert 0 <= item.value <= (1 << 32) - 1
-        u32s[offW] = item.value
+        u32s[7-offW] = item.value
 
         # And write back
         self._set_u32s(idxW, u32s)

--- a/hw/ip/otbn/dv/otbnsim/sim/dmem.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/dmem.py
@@ -168,7 +168,7 @@ class Dmem:
 
         uword = self.data[idxW]
         # Extract the right 32-bit unsigned value
-        u32 = (uword >> 8 * offW) & ((1 << 32) - 1)
+        u32 = (uword >> 32 * offW) & ((1 << 32) - 1)
         # Now convert back to signed and return
         return u32 - (1 << 32) if u32 >> 31 else u32
 

--- a/hw/ip/otbn/dv/otbnsim/sim/insn.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/insn.py
@@ -258,7 +258,7 @@ class CSRRS(OTBNInsn):
         super().__init__(op_vals)
         self.grd = op_vals['grd']
         self.csr = op_vals['csr']
-        self.grs = op_vals['grs']
+        self.grs = op_vals['grs1']
 
     def execute(self, model: OTBNModel) -> None:
         raise NotImplementedError('csrrs.execute')
@@ -271,7 +271,7 @@ class CSRRW(OTBNInsn):
         super().__init__(op_vals)
         self.grd = op_vals['grd']
         self.csr = op_vals['csr']
-        self.grs = op_vals['grs']
+        self.grs = op_vals['grs1']
 
     def execute(self, model: OTBNModel) -> None:
         raise NotImplementedError('csrrw.execute')

--- a/hw/ip/otbn/dv/otbnsim/sim/insn.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/insn.py
@@ -673,7 +673,7 @@ class BNRSEL(OTBNInsn):
         # self.flag gives a number (0-3), which we need to convert to a flag
         # name for use with BitflagRegister.
         assert 0 <= self.flag <= 3
-        flag_name = ['C', 'L', 'M', 'Z'][self.flag]
+        flag_name = ['C', 'M', 'L', 'Z'][self.flag]
 
         flag_is_set = model.state.flags[self.flag_group].get(flag_name)
         val = model.state.wreg[self.wrs1 if flag_is_set else self.wrs2]

--- a/hw/ip/otbn/dv/otbnsim/sim/insn.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/insn.py
@@ -810,7 +810,7 @@ class BNWSRRS(OTBNInsn):
     def execute(self, model: OTBNModel) -> None:
         idx = self.wsr
         old_val = model.state.wcsr_read(idx)
-        new_val = old_val | model.state.wreg[self.wrs]
+        new_val = model.state.wreg[self.wrs] | old_val
 
         model.state.wreg[self.wrd] = old_val
         model.state.wcsr_write(idx, new_val)

--- a/hw/ip/otbn/dv/otbnsim/sim/model.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/model.py
@@ -193,8 +193,8 @@ class LoopStack:
 class FlagGroups:
     def __init__(self) -> None:
         self.groups = {
-            0: BitflagRegister(["C", "L", "M", "Z"], prefix = "FG0."),
-            1: BitflagRegister(["C", "L", "M", "Z"], prefix = "FG1.")
+            0: BitflagRegister(["C", "M", "L", "Z"], prefix = "FG0."),
+            1: BitflagRegister(["C", "M", "L", "Z"], prefix = "FG1.")
         }
 
     def __getitem__(self, key: int) -> BitflagRegister:


### PR DESCRIPTION
Some issues I came across when running RSA on the new simulator:

- shift amount in load method in dmem model (see #3505)
- operand oder with bitwise OR (see #3506)
- register field names for `CSR` instructions (see #3507)
- order of flag names in lists (#3508)
- list iteration in dmem model for commit method (see #3509)