### PR TITLE
[otbn] Fix silly typo in comment

### DIFF
--- a/hw/ip/otbn/data/insns.yml
+++ b/hw/ip/otbn/data/insns.yml
@@ -82,8 +82,8 @@ encoding-schemes: enc-schemes.yml
 #  straight-line: A boolean. If true, this instruction has no effect on control
 #                 flow. Optional, default true.
 #
-#  insn-cycles: A positive integer, giving the number of cycles that the
-#               instruction takes to execute. Optional, default 1.
+#  cycles:    A positive integer, giving the number of cycles that the
+#             instruction takes to execute. Optional, default 1.
 #
 # The operands field should be a list, corresponding to the operands in the
 # order they will appear in the syntax. Each operand is either a string (the


### PR DESCRIPTION
I'd spent a while oscillating between the two names, and came down on
one side in the code and the other in the documentation. Get
everything in sync.
