### PR TITLE
[otbn] Add fg to wide logical coding

### DIFF
--- a/hw/ip/otbn/data/bignum-insns.yml
+++ b/hw/ip/otbn/data/bignum-insns.yml
@@ -483,8 +483,9 @@
       doc: Name of the second source WDR
     - *bn-shift-type-operand
     - *bn-shift-bytes-operand
+    - *bn-flag-group-operand
   syntax: &bn-and-syntax |
-    <wrd>, <wrs1>, <wrs2>[, <shift_type> <shift_bytes>B]
+    <wrd>, <wrs1>, <wrs2>[, <shift_type> <shift_bytes>B][, FG<flag_group>]
   doc: |
     Performs a bitwise and operation.
     Takes the values stored in registers referenced by `wrs1` and `wrs2` and stores the result in the register referenced by `wrd`.
@@ -496,20 +497,24 @@
 
     sb = UInt(shift_bytes)
     st = DecodeShiftType(shift_type)
+    fg = DecodeFlagGroup(flag_group)
   operation: |
     b_shifted = ShiftReg(b, st, sb)
     result = a & b_shifted
 
     WDR[d] = result
+    FLAGS[flag_group].L = result[0]
+    FLAGS[flag_group].M = result[255]
+    FLAGS[flag_group].Z = (result == 0)
   encoding:
     scheme: bna
     mapping:
-      funct31: b0
+      fg: flag_group
       shift_type: shift_type
       shift_bytes: shift_bytes
       wrs2: wrs2
       wrs1: wrs1
-      funct3: b110
+      funct3: b010
       wrd: wrd
 
 - mnemonic: bn.or
@@ -526,15 +531,16 @@
     result = a | b_shifted
 
     WDR[d] = result
+    FLAGS[flag_group] = FlagsFromValue(result)
   encoding:
     scheme: bna
     mapping:
-      funct31: b1
+      fg: flag_group
       shift_type: shift_type
       shift_bytes: shift_bytes
       wrs2: wrs2
       wrs1: wrs1
-      funct3: b110
+      funct3: b100
       wrd: wrd
 
 - mnemonic: bn.not
@@ -546,8 +552,9 @@
       doc: Name of the source WDR
     - *bn-shift-type-operand
     - *bn-shift-bytes-operand
+    - *bn-flag-group-operand
   syntax: |
-    <wrd>, <wrs>[, <shift_type> <shift_bytes>B]
+    <wrd>, <wrs>[, <shift_type> <shift_bytes>B][, FG<flag_group>]
   doc: |
     Negates the value in `wrs` and stores the result in the register referenced by `wrd`.
     The source value can be shifted by an immediate before it is consumed by the operation.
@@ -557,20 +564,23 @@
 
     sb = UInt(shift_bytes)
     st = DecodeShiftType(shift_type)
+    fg = DecodeFlagGroup(flag_group)
   operation: |
     a_shifted = ShiftReg(a, st, sb)
     result = ~a_shifted
 
     WDR[d] = result
+    FLAGS[flag_group].L = result[0]
+    FLAGS[flag_group].M = result[255]
+    FLAGS[flag_group].Z = (result == 0)
   encoding:
-    scheme: bna
+    scheme: bnan
     mapping:
-      funct31: b0
+      fg: flag_group
       shift_type: shift_type
       shift_bytes: shift_bytes
-      wrs2: wrs
-      wrs1: bxxxxx
-      funct3: b111
+      wrs1: wrs
+      funct3: b101
       wrd: wrd
 
 - mnemonic: bn.xor
@@ -587,15 +597,18 @@
     result = a ^ b_shifted
 
     WDR[d] = result
+    FLAGS[flag_group].L = result[0]
+    FLAGS[flag_group].M = result[255]
+    FLAGS[flag_group].Z = (result == 0)
   encoding:
-    scheme: bnaf
+    scheme: bna
     mapping:
-      fg: b1
+      fg: flag_group
       shift_type: shift_type
       shift_bytes: shift_bytes
       wrs2: wrs2
       wrs1: wrs1
-      funct3: b111
+      funct3: b110
       wrd: wrd
 
 - mnemonic: bn.rshi

--- a/hw/ip/otbn/data/enc-schemes.yml
+++ b/hw/ip/otbn/data/enc-schemes.yml
@@ -190,42 +190,40 @@ funct2:
 loop:
   parents:
     - custom3
-    - funct2(funct2=b00)
+    - funct3(funct3=b000)
   fields:
     bodysize: 31-20
     grs: 19-15
     fixed:
-      bits: 14,11-7
-      value: bxxxxxx
+      bits: 11-7
+      value: bxxxxx
 
 # A specialised encoding for the loopi instruction (which, unusually, has 2
 # immediates)
 loopi:
   parents:
     - custom3
-    - funct2(funct2=b01)
+    - funct3(funct3=b001)
   fields:
     bodysize: 31-20
     iterations: 19-15,11-7
-    fixed:
-      bits: 14
-      value: bx
 
 # Used wide logical operations (bn.and, bn.or, bn.xor).
 bna:
   parents:
-    - custom1
+    - custom3
     - wdr3
     - funct3
     - shift
-    - funct31
+    - fg
 
 # Used for bn.not (no second source reg).
 bnan:
   parents:
-    - custom1
+    - custom3
+    - funct3
     - shift
-    - funct31
+    - fg
     - wrd
   fields:
     wrs1: 24-20


### PR DESCRIPTION
Add the field group field to the coding of the wide logical instructions. Flag C remains untouched. Coding moves to custom3.