### PR TITLE
[rom_ext] Remove Software Binding Tag

### DIFF
--- a/sw/device/rom_exts/rom_ext_manifest.S
+++ b/sw/device/rom_exts/rom_ext_manifest.S
@@ -53,12 +53,6 @@ image_usage_constraints:
 // Reserved
   .word 0x0
 
-// Overriden by signing script
-image_software_binding_tag:
-  .rept 16
-  .byte 0x0
-  .endr
-
 // Maybe: Overriden by signing script?
 image_peripheral_lockdown_info:
   .rept 16

--- a/sw/device/rom_exts/rom_ext_manifest.protocol.sh
+++ b/sw/device/rom_exts/rom_ext_manifest.protocol.sh
@@ -30,7 +30,6 @@ Signature Exponent:32,
 Usage Constraints (TBC):32,
 Reserved:32,
 
-Software Binding Tag (TBC):128,
 Peripheral Lockdown Info (TBC):128,
 
 Signature Public Key (3072 bits):${BROKEN_LENGTH},


### PR DESCRIPTION
In discussions about the key manager, it has been agreed that the key
manager will use a 256-bit hash of the ROM_EXT, rather than an
image-provided blob. This PR removes the image-provided blob, as it is
no longer needed.