### PR TITLE
[vendor] Do not include diffstat and signature in patches

### DIFF
--- a/util/vendor.py
+++ b/util/vendor.py
@@ -485,7 +485,15 @@ def _export_patches(patchrepo_clone_url, target_patch_dir, upstream_rev,
     with tempfile.TemporaryDirectory() as clone_dir:
         clone_git_repo(patchrepo_clone_url, clone_dir, patched_rev)
         rev_range = 'origin/' + upstream_rev + '..' + 'origin/' + patched_rev
-        cmd = ['git', 'format-patch', '-o', str(target_patch_dir.resolve()), rev_range]
+        cmd = [
+            'git',
+            'format-patch',
+            '--no-signature',
+            '--no-stat',
+            '-o',
+            str(target_patch_dir.resolve()),
+            rev_range
+        ]
         if not verbose:
             cmd += ['-q']
         subprocess.run(cmd, cwd=str(clone_dir), check=True)


### PR DESCRIPTION
The signature line contains, by default, the git version number. Every
time we re-run vendor.py on a patch repo with a newer git version, the
patches change without actually changing content-wise. The git version
number serves no other purpose, so we can simply remove it.

Also remove the diffstat, which is not very meaningful in committed
patches, but also adds noise when updating patches.