### PR TITLE
[mask_rom] Resolve some Open Questions

### DIFF
--- a/sw/device/mask_rom/boot.md
+++ b/sw/device/mask_rom/boot.md
@@ -538,68 +538,18 @@ it needs to be checked most times the boot policy is also read.
 
 Accessed by:
 
-*   Mask ROM (to validate ROM_EXT)
+*   Mask ROM (to validate ROM_EXT).
+*   ROM_EXT (potentially).
 *   BL0 Kernel (during firmware update).
 
-Needs to contain:
+The manifest format is defined in [ROM_EXT Manifest Format](../rom_exts/manifest).
 
-*   Unsigned Area:
-    *   Identifier (so we know we're reading the right thing)
-        This also acts as a ROM_EXT manifest version (ie, the version of the
-        layout of the header).
-
-    *   Signature
-*   Signed Area:
-    *   Image Length
-    *   Entry Point
-        **Open Q:** Is this fixed or programmable? Field not needed if fixed.
-
-    *   ROM_EXT PMP Region Information
-        **Open Q:** Is this fixed or programmable? Field not needed if fixed.
-
-    *   Key Selection Area
-        *   Signature Algorithm Identifier
-            **Open Q:** Will the Mask ROM support more than one signature
-            scheme?
-
-        *   Public Key
-
-    *   Software Binding Properties:
-        *   ROM_EXT Version
-            This is the version of the image contained in the ROM_EXT.
-
-        *   Usage Constraints
-        *   Peripheral Lockdown Information
-    *   Read-only Extension Area:
-        *   Several words for ROM_EXT/BL0 use only.
-            (Interpretation governed by ROM_EXT/BL0 Version).
-            **Open Q:** Does this satisfy the previous usecases?
-
-            This is likely to be a fixed number of `(offset, checksum)` pairs,
-            where the offset points to a structure somewhere within the ROM_EXT
-            image. This should help us avoid running out of space, while also
-            ensuring these structures do not become corrupted (note the image
-            and the read-only extension area are also signed). This approach
-            does allow the pointed-to structure to be variable-length, as it is
-            down to the ROM_EXT/BL0 to interpret the data and validate the
-            checksum.
-
-            **Open Q:** Should we require these offsets to be word- or
-            page-aligned?
-
-            For a given ROM_EXT manifest version, the number of these slots
-            cannot be changed, but different manifest versions can add to the
-            number of slots. Each slot in a manifest version should only be
-            allocated for a single use, and once allocated should not be
-            re-allocated.
-
-    *   ROM_EXT Code Image.
-
-Stored in: Flash
+Stored in: Flash (at one of two fixed, memory-mapped, addresses)
 
 Extensibility:
+
 *   Mask ROM: None
 *   ROM_EXT/BL0:
-    *   Uses the "Extension Area" for additional read-only data if required.
+    *   Uses the Extension fields for additional read-only data if required.
         This is not interpreted by the Mask ROM, but may be used by ROM_EXT or
         BL0 if required.

--- a/sw/device/rom_exts/manifest.md
+++ b/sw/device/rom_exts/manifest.md
@@ -171,13 +171,20 @@ Notes:
 1.  **Signature Algorithm Identifier** This identifies which algorithm has been
     used to sign the ROM_EXT Image. This is a 32-bit enumeration value.
 
-    **Open Q**: Are we supporting multiple signing algorithms for ROM_EXTs? This
-    complicates the Mask ROM significantly.
+    This is used when signing and validating the image. This happens in the
+    Mask ROM, as well as during firmware update.
 
     `0x0` denotes an unsigned image. Unsigned images **must not** be booted.
 
-    This is used when signing and validating the image. This happens in the
-    Mask ROM, as well as during firmware update.
+    The initial version of the Mask ROM will support the following message
+    digest algorithms:
+
+    *   SHA2-265
+    *   SHA2-384
+    *   SHA2-512
+
+    The specific signature scheme is as yet undefined, but will be based on
+    RSA-3k, and one of the message digest algorithms above.
 
 1.  **Signature Exponent** This is the RSA exponent to be used during the RSA
     3K Signature Scheme. This is a 32-bit numeric value.
@@ -242,16 +249,18 @@ Notes:
     Each Offset field is a 32-bit unsigned numeric value. Each Checksum field is
     a 32-bit numeric value.
 
-    **Open Q** It makes sense, once we fully understand the alignment
-    requirements, to fill the rest of the manifest with these pairs, so we may
-    end with more than 4 of these entries in the first production Mask ROM.
+    Extension pairs may be *allocated* a specific use. These fields should be
+    treated as Reserved until they are allocated. Once an extension pair has an
+    allocated use, it will not be used for any other use, unless the Manifest
+    Image Identifier also changes (In this way, the Identifier also works as a
+    versioning token for the manifest format). When an extension pair is
+    allocated, the extension may define an alignment requirement for the its
+    data. The extension's data must be at least byte-aligned.
 
-    These extensions will not be allocated in the initial version of the
-    ROM_EXT. Once an Extension slot has an allocated use, it will not be used
-    for any other use, for a given Manifest Image Identifier. In this way, the
-    Identifier also works as a versioning token for the manifest format.
-
-    These fields should be treated as Reserved until they are allocated.
+    **Open Q** We could allocate more of these pairs, as we have quite a few
+    bytes between the end of the last pair, and the first 256-byte-aligned
+    address in the code image (see the Code Image field description.). Do we
+    want to?
 
 1.  **Code Image** This is a sequence of bytes that make up the code and data of
     the ROM_EXT image. This data will include any data required for Extensions.
@@ -291,7 +300,7 @@ Notes:
 **ROM_EXT Manifest Identifier**: `0x4552544F` (Reads "OTRE" when Disassembled --
 OpenTitan ROM_EXT)
 
-**Signature Algorithm Identifier**: `0x1` denotes RSA 3K.
+**Signature Algorithm Identifier**: TBC
 
 **Signature Exponent**: TBC
 
@@ -300,13 +309,13 @@ but this will not be used in production software.
 
 **Extension Allocation**:
 
-Extension 0: Not Allocated
+| Identifier   | Pair | Use           | Length | Alignment |
+|--------------|------|---------------|--------|-----------|
+| `0x4552544F` | 0    | *Unallocated* |        |           |
+| `0x4552544F` | 1    | *Unallocated* |        |           |
+| `0x4552544F` | 2    | *Unallocated* |        |           |
+| `0x4552544F` | 3    | *Unallocated* |        |           |
 
-Extension 1: Not Allocated
-
-Extension 2: Not Allocated
-
-Extension 3: Not Allocated
 
 
 ## Software Deliverables


### PR DESCRIPTION
This commit:
- Deduplicates the ROM_EXT manifest definitions, pointing everywhere to
  the canonical definition in `sw/device/rom_exts/manifest.md`
- Resolves an open question in the ROM_EXT manifest about signing
  schemes. This was answered by Garret Kelly in the Keys + Signatures
  module document.
- Resolves an open question about the alignment of the extension
  offsets, and more clearly states the open question about how many
  extension pairs we should include.

