### PR TITLE
[sw/vendor] Pull OT-specific C code out of sw/vendor/riscv_compliance

### DIFF
--- a/ci/run-riscv-compliance.yml
+++ b/ci/run-riscv-compliance.yml
@@ -26,13 +26,5 @@ jobs:
     - ${{ each test_suite in parameters.rvc_test_suites }}:
       - bash: |
           set -e
-          . util/build_consts.sh
-          export TARGET_SIM="$BIN_DIR/hw/top_earlgrey/Vtop_earlgrey_verilator"
-          export RISCV_DEVICE=rv32imc
-          export RISCV_TARGET=opentitan
-          export OT_BIN="$BIN_DIR"
-          export OT_TARGET=sim_verilator
-          export OT_TOOLS="$TOOLCHAIN_PATH/bin"
-          cd sw/vendor/riscv_compliance
-          make RISCV_ISA=${{ test_suite }} VERBOSE=1
+          ci/run_riscv_compliance.sh ${{ test_suite }}
         displayName: Execute ${{ test_suite }}

--- a/ci/run_riscv_compliance.sh
+++ b/ci/run_riscv_compliance.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+set -e
+
+. util/build_consts.sh
+
+export TARGET_SIM="$BIN_DIR/hw/top_earlgrey/Vtop_earlgrey_verilator"
+export RISCV_DEVICE=rv32imc
+export RISCV_TARGET=opentitan
+export OT_BIN="$BIN_DIR"
+export OT_TARGET=sim_verilator
+export OT_TOOLS="${TOOLCHAIN_PATH:-/tools/riscv}/bin"
+
+make -C "$REPO_TOP/sw/vendor/riscv_compliance" RISCV_ISA="$1" VERBOSE=1
+

--- a/sw/device/riscv_compliance_support/meson.build
+++ b/sw/device/riscv_compliance_support/meson.build
@@ -10,20 +10,19 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
   # library produces what we need.
   riscv_compliance_support_inner = static_library(
     'ot_riscv_compliance_support_inner_' + device_name,
-    dependencies : [
+    sources: ['support.c'],
+    dependencies: [
       sw_lib_uart,
       sw_lib_base_print,
       sw_lib_irq_handlers,
       sw_lib_mem,
       device_lib,
-    ]
+    ],
   )
 
   riscv_compliance_support = static_library(
     'ot_riscv_compliance_support_' + device_name,
-    link_whole : [
-      riscv_compliance_support_inner,
-    ],
+    link_whole: [riscv_compliance_support_inner],
   )
 
   custom_target(

--- a/sw/device/riscv_compliance_support/support.c
+++ b/sw/device/riscv_compliance_support/support.c
@@ -1,0 +1,27 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stddef.h>
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/uart.h"
+
+// These symbopls are provided by the riscv-compliance libraries.
+extern void run_rvc_test(void);
+extern volatile uint32_t begin_signature[];
+extern volatile uint32_t end_signature[];
+
+int opentitan_compliance_main(int argc, char **argv) {
+  uart_init(kUartBaudrate);
+  base_set_stdout(uart_stdout);
+
+  run_rvc_test();
+
+  ptrdiff_t size = end_signature - begin_signature;
+  for (int i = 0; i < size; ++i) {
+    base_printf("SIG: %08x\r\n", begin_signature[i]);
+  }
+
+  return 0;
+}

--- a/sw/device/riscv_compliance_support/support.h
+++ b/sw/device/riscv_compliance_support/support.h
@@ -1,0 +1,19 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * @brief OpenTitan-specific wrapper for RISC-V Compliance
+ *
+ * This header provides a single function, `ot_compliance_main`, which is
+ * intentionally outside of the `sw/vendor` directory, so changes in OpenTitan
+ * libraries do not require generating patches for `riscv-compliance`.
+ */
+
+// NOTE: **DO NOT** #include any files here, since that will leak OpenTitan
+// library interfaces past the vendoring boundary.
+
+/**
+ * Main function for RISC-V Compliance, provided as an out-of-band.
+ */
+int opentitan_compliance_main(int argc, char **argv);

--- a/sw/vendor/patches/riscv_compliance/0001-Add-configurable-trap-alignment-and-entry-point-to-p.patch
+++ b/sw/vendor/patches/riscv_compliance/0001-Add-configurable-trap-alignment-and-entry-point-to-p.patch
@@ -4,11 +4,6 @@ Date: Wed, 15 Apr 2020 15:45:31 +0100
 Subject: [PATCH 1/3] Add configurable trap alignment and entry point to p
  test-env
 
----
- riscv-test-env/p/riscv_test.h            | 20 ++++++++++++++------
- riscv-test-suite/rv32i/src/I-EBREAK-01.S |  1 +
- riscv-test-suite/rv32i/src/I-ECALL-01.S  |  1 +
- 3 files changed, 16 insertions(+), 6 deletions(-)
 
 diff --git a/riscv-test-env/p/riscv_test.h b/riscv-test-env/p/riscv_test.h
 index eaa6758..9423523 100644
@@ -94,6 +89,3 @@ index 5278207..0bdee2a 100644
  _trap_handler:
      # increment return address
      csrr    x30, mepc
--- 
-2.28.0
-

--- a/sw/vendor/patches/riscv_compliance/0002-Add-OpenTitan-target.patch
+++ b/sw/vendor/patches/riscv_compliance/0002-Add-OpenTitan-target.patch
@@ -1,27 +1,8 @@
-From 4d25ba90b659be25aaa441e7dfad6eed9c7f4af3 Mon Sep 17 00:00:00 2001
+From 1b37cf8ea5468c9bdf17e8633507fc595a8858b2 Mon Sep 17 00:00:00 2001
 From: Greg Chadwick <gac@lowrisc.org>
 Date: Wed, 15 Apr 2020 15:44:54 +0100
 Subject: [PATCH 2/3] Add OpenTitan target
 
----
- Makefile                                      |   6 +-
- riscv-target/opentitan/README.md              | 152 ++++++++++++++++++
- riscv-target/opentitan/compliance_io.h        |  22 +++
- riscv-target/opentitan/compliance_test.h      |  35 ++++
- .../opentitan/device/rv32imc/Makefile.include |  75 +++++++++
- .../opentitan/device/rv32imc/isa.yaml         |  49 ++++++
- riscv-target/opentitan/device/rv32imc/main.c  |  32 ++++
- .../opentitan/device/rv32imc/platform.yaml    |  10 ++
- .../opentitan/device/rv32imc/run_rvc_test.S   |  85 ++++++++++
- 9 files changed, 465 insertions(+), 1 deletion(-)
- create mode 100644 riscv-target/opentitan/README.md
- create mode 100644 riscv-target/opentitan/compliance_io.h
- create mode 100644 riscv-target/opentitan/compliance_test.h
- create mode 100644 riscv-target/opentitan/device/rv32imc/Makefile.include
- create mode 100644 riscv-target/opentitan/device/rv32imc/isa.yaml
- create mode 100644 riscv-target/opentitan/device/rv32imc/main.c
- create mode 100644 riscv-target/opentitan/device/rv32imc/platform.yaml
- create mode 100644 riscv-target/opentitan/device/rv32imc/run_rvc_test.S
 
 diff --git a/Makefile b/Makefile
 index 25557c1..a6fd315 100644
@@ -409,41 +390,22 @@ index 0000000..c526fec
 +  implemented: true
 diff --git a/riscv-target/opentitan/device/rv32imc/main.c b/riscv-target/opentitan/device/rv32imc/main.c
 new file mode 100644
-index 0000000..ad5ca31
+index 0000000..8d67e4e
 --- /dev/null
 +++ b/riscv-target/opentitan/device/rv32imc/main.c
-@@ -0,0 +1,32 @@
+@@ -0,0 +1,13 @@
 +// Copyright lowRISC contributors.
 +// Licensed under the Apache License, Version 2.0, see LICENSE for details.
 +// SPDX-License-Identifier: Apache-2.0
 +
-+// Wrapper for RISC-V compliance tests, it saves architectural state before
-+// jumping into the test (via run_rvc_test). After the test completes it dumps
-+// the signature out via the UART.
-+
-+#include "sw/device/lib/uart.h"
-+#include "sw/device/lib/arch/device.h"
-+#include "sw/device/lib/base/print.h"
-+#include "sw/device/lib/common.h"
-+
-+extern void run_rvc_test(void);
-+
-+extern uint32_t begin_signature[];
-+extern uint32_t end_signature[];
++// NOTE: This is the only header from OpenTitan that can be imported here. Any
++// OpenTitan-specific work should be done in support.c, instead.
++// Doing this avoids having to create patches for this file any time
++// requirements for the wrapper change.
++#include "sw/device/riscv_compliance_support/support.h"
 +
 +int main(int argc, char **argv) {
-+  uart_init(kUartBaudrate);
-+  base_set_stdout(uart_stdout);
-+
-+  run_rvc_test();
-+
-+  uint32_t size = end_signature - begin_signature;
-+
-+  for (uint32_t i = 0; i < size; ++i) {
-+    base_printf("SIG: %08x\r\n", REG32(begin_signature + i));
-+  }
-+
-+  return 0;
++  return opentitan_compliance_main(argc, argv);
 +}
 diff --git a/riscv-target/opentitan/device/rv32imc/platform.yaml b/riscv-target/opentitan/device/rv32imc/platform.yaml
 new file mode 100644
@@ -552,6 +514,3 @@ index 0000000..1b1b5c7
 +
 +  // jump to the handler from the OT library
 +  j crt_interrupt_vector
--- 
-2.28.0
-

--- a/sw/vendor/patches/riscv_compliance/0003-Remove-tests-that-do-not-pass-on-OpenTitan.patch
+++ b/sw/vendor/patches/riscv_compliance/0003-Remove-tests-that-do-not-pass-on-OpenTitan.patch
@@ -1,11 +1,8 @@
-From 7ada51301b9ef34982d8a05bdcc63d98e162243a Mon Sep 17 00:00:00 2001
+From f36a2c5d29559193c8a976bff2870539169f4893 Mon Sep 17 00:00:00 2001
 From: Greg Chadwick <gac@lowrisc.org>
 Date: Wed, 15 Apr 2020 18:39:08 +0100
 Subject: [PATCH 3/3] Remove tests that do not pass on OpenTitan
 
----
- riscv-test-suite/rv32i/Makefrag | 7 +++++--
- 1 file changed, 5 insertions(+), 2 deletions(-)
 
 diff --git a/riscv-test-suite/rv32i/Makefrag b/riscv-test-suite/rv32i/Makefrag
 index a19fff8..e27b7ac 100644
@@ -32,6 +29,3 @@ index a19fff8..e27b7ac 100644
  
  rv32i_tests = $(addsuffix .elf, $(rv32i_sc_tests))
  
--- 
-2.28.0
-

--- a/sw/vendor/riscv_compliance/riscv-target/opentitan/device/rv32imc/main.c
+++ b/sw/vendor/riscv_compliance/riscv-target/opentitan/device/rv32imc/main.c
@@ -2,31 +2,12 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// Wrapper for RISC-V compliance tests, it saves architectural state before
-// jumping into the test (via run_rvc_test). After the test completes it dumps
-// the signature out via the UART.
-
-#include "sw/device/lib/uart.h"
-#include "sw/device/lib/arch/device.h"
-#include "sw/device/lib/base/print.h"
-#include "sw/device/lib/common.h"
-
-extern void run_rvc_test(void);
-
-extern uint32_t begin_signature[];
-extern uint32_t end_signature[];
+// NOTE: This is the only header from OpenTitan that can be imported here. Any
+// OpenTitan-specific work should be done in support.c, instead.
+// Doing this avoids having to create patches for this file any time
+// requirements for the wrapper change.
+#include "sw/device/riscv_compliance_support/support.h"
 
 int main(int argc, char **argv) {
-  uart_init(kUartBaudrate);
-  base_set_stdout(uart_stdout);
-
-  run_rvc_test();
-
-  uint32_t size = end_signature - begin_signature;
-
-  for (uint32_t i = 0; i < size; ++i) {
-    base_printf("SIG: %08x\r\n", REG32(begin_signature + i));
-  }
-
-  return 0;
+  return opentitan_compliance_main(argc, argv);
 }


### PR DESCRIPTION
This change makes it so that all OT-specific code that needs to run to make the compliance tests work is outside of the vendor boundary, making it easier to make changes to OT libraries without having to do a vendor patch update in lockstep (which makes diffs quite messy).