### PR TITLE
[pwrmgr] Add pwrmgr d1 items

### DIFF
--- a/hw/ip/pwrmgr/data/pwrmgr.hjson.tpl
+++ b/hw/ip/pwrmgr/data/pwrmgr.hjson.tpl
@@ -206,6 +206,46 @@
         },
 
         { bits: "6",
+          name: "USB_CLK_EN_LP",
+          desc: "USB clock enable during low power state",
+          resval: "0",
+          enum: [
+            { value: "0",
+              name: "Disabled",
+              desc: '''
+                USB clock disabled during low power state
+                '''
+            },
+            { value: "1",
+              name: "Enabled",
+              desc: '''
+                USB clock enabled during low power state
+                '''
+            },
+          ]
+        },
+
+        { bits: "7",
+          name: "USB_CLK_EN_ACTIVE",
+          desc: "USB clock enable during active power state",
+          resval: "1"
+          enum: [
+            { value: "0",
+              name: "Disabled",
+              desc: '''
+                USB clock disabled during active power state
+                '''
+            },
+            { value: "1",
+              name: "Enabled",
+              desc: '''
+                USB clock enabled during active power state
+                '''
+            },
+          ]
+        },
+
+        { bits: "8",
           name: "MAIN_PD_N",
           desc: "Active low, main power domain power down",
           resval: "1"
@@ -226,6 +266,8 @@
             },
           ]
         },
+
+
       ],
     },
 

--- a/hw/ip/pwrmgr/rtl/pwrmgr.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr.sv
@@ -103,6 +103,8 @@ module pwrmgr import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;
   logic slow_main_pd_n;
   logic slow_io_clk_en;
   logic slow_core_clk_en;
+  logic slow_usb_clk_en_lp;
+  logic slow_usb_clk_en_active;
 
   ////////////////////////////
   ///  Register module
@@ -160,6 +162,8 @@ module pwrmgr import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;
     .slow_main_pd_no(slow_main_pd_n),
     .slow_io_clk_en_o(slow_io_clk_en),
     .slow_core_clk_en_o(slow_core_clk_en),
+    .slow_usb_clk_en_lp_o(slow_usb_clk_en_lp),
+    .slow_usb_clk_en_active_o(slow_usb_clk_en_active),
     .slow_req_pwrdn_o(slow_req_pwrdn),
     .slow_ack_pwrup_o(slow_ack_pwrup),
     .slow_ast_o(slow_ast),
@@ -176,6 +180,8 @@ module pwrmgr import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;
     .main_pd_ni(reg2hw.control.main_pd_n.q),
     .io_clk_en_i(reg2hw.control.io_clk_en.q),
     .core_clk_en_i(reg2hw.control.core_clk_en.q),
+    .usb_clk_en_lp_i(reg2hw.control.usb_clk_en_lp.q),
+    .usb_clk_en_active_i(reg2hw.control.usb_clk_en_active.q),
     .ack_pwrdn_o(ack_pwrdn),
     .req_pwrup_o(req_pwrup),
     .pwrup_cause_o(pwrup_cause),
@@ -251,6 +257,8 @@ module pwrmgr import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;
     .main_pd_ni           (slow_main_pd_n),
     .io_clk_en_i          (slow_io_clk_en),
     .core_clk_en_i        (slow_core_clk_en),
+    .usb_clk_en_lp_i      (slow_usb_clk_en_lp),
+    .usb_clk_en_active_i  (slow_usb_clk_en_active),
 
     // outputs to AST - These are on the slow clock domain
     // TBD - need to check this with partners

--- a/hw/ip/pwrmgr/rtl/pwrmgr_cdc.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_cdc.sv
@@ -25,6 +25,8 @@ module pwrmgr_cdc import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;
   output logic slow_main_pd_no,
   output logic slow_io_clk_en_o,
   output logic slow_core_clk_en_o,
+  output logic slow_usb_clk_en_lp_o,
+  output logic slow_usb_clk_en_active_o,
   output logic slow_req_pwrdn_o,
   output logic slow_ack_pwrup_o,
   output pwr_ast_rsp_t slow_ast_o,
@@ -40,6 +42,8 @@ module pwrmgr_cdc import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;
   input main_pd_ni,
   input io_clk_en_i,
   input core_clk_en_i,
+  input usb_clk_en_lp_i,
+  input usb_clk_en_active_i,
   output logic ack_pwrdn_o,
   output logic req_pwrup_o,
   output pwrup_cause_e pwrup_cause_o,
@@ -144,12 +148,16 @@ module pwrmgr_cdc import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;
       slow_main_pd_no <= '0;
       slow_io_clk_en_o <= '0;
       slow_core_clk_en_o <= '0;
+      slow_usb_clk_en_lp_o <= '0;
+      slow_usb_clk_en_active_o <= 1'b1;
     end else if (slow_cdc_sync) begin
       slow_wakeup_en_o <= wakeup_en_i;
       slow_reset_en_o <= reset_en_i;
       slow_main_pd_no <= main_pd_ni;
       slow_io_clk_en_o <= io_clk_en_i;
       slow_core_clk_en_o <= core_clk_en_i;
+      slow_usb_clk_en_lp_o <= usb_clk_en_lp_i;
+      slow_usb_clk_en_active_o <= usb_clk_en_active_i;
     end
   end
 

--- a/hw/ip/pwrmgr/rtl/pwrmgr_pkg.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_pkg.sv
@@ -16,6 +16,12 @@ package pwrmgr_pkg;
   // variables referenced only by pwrmgr
   localparam int TotalWakeWidth = pwrmgr_reg_pkg::NumWkups + 2; // Abort and fall through are added
 
+  // The following structs should eventually be relocted to other modules
+  typedef enum logic [1:0] {
+    DiffValid = 2'b10,
+    DiffInvalid = 2'b01
+  } pwrmgr_diff_e;
+
   // pwrmgr to ast
   typedef struct packed {
     logic main_pd_n;
@@ -23,27 +29,31 @@ package pwrmgr_pkg;
     logic slow_clk_en;
     logic core_clk_en;
     logic io_clk_en;
+    logic usb_clk_en;
   } pwr_ast_req_t;
 
   typedef struct packed {
-    logic [1:0] slow_clk_val;
-    logic [1:0] core_clk_val;
-    logic [1:0] io_clk_val;
+    pwrmgr_diff_e slow_clk_val;
+    pwrmgr_diff_e core_clk_val;
+    pwrmgr_diff_e io_clk_val;
+    pwrmgr_diff_e usb_clk_val;
     logic main_pok;
   } pwr_ast_rsp_t;
 
   // default value of pwr_ast_rsp (for dangling ports)
   parameter pwr_ast_rsp_t PWR_AST_RSP_DEFAULT = '{
-    slow_clk_val: 2'b10,
-    core_clk_val: 2'b10,
-    io_clk_val: 2'b10,
+    slow_clk_val: DiffValid,
+    core_clk_val: DiffValid,
+    io_clk_val: DiffValid,
+    usb_clk_val: DiffValid,
     main_pok: 1'b1
   };
 
   parameter pwr_ast_rsp_t PWR_AST_RSP_SYNC_DEFAULT = '{
-    slow_clk_val: 2'b01,
-    core_clk_val: 2'b01,
-    io_clk_val: 2'b10,
+    slow_clk_val: DiffInvalid,
+    core_clk_val: DiffInvalid,
+    io_clk_val: DiffInvalid,
+    usb_clk_val: DiffInvalid,
     main_pok: 1'b0
   };
 

--- a/hw/top_earlgrey/ip/ast/rtl/ast_wrapper.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_wrapper.sv
@@ -67,10 +67,16 @@ module ast_wrapper import ast_wrapper_pkg::*;
   // AST instantiation
   ///////////////////////////
 
-  // temporary assignments until pwrmgr interface is updated
-  assign pwr_o.core_clk_val[0] = ~pwr_o.core_clk_val[1];
-  assign pwr_o.slow_clk_val[0] = ~pwr_o.slow_clk_val[1];
-  assign pwr_o.io_clk_val[0]   = ~pwr_o.io_clk_val[1];
+  // Switch these to prim_mux cells
+  logic core_clk_val;
+  logic slow_clk_val;
+  logic io_clk_val;
+  logic usb_clk_val;
+
+  assign pwr_o.core_clk_val = core_clk_val ? pwrmgr_pkg::DiffValid : pwrmgr_pkg::DiffInvalid;
+  assign pwr_o.slow_clk_val = slow_clk_val ? pwrmgr_pkg::DiffValid : pwrmgr_pkg::DiffInvalid;
+  assign pwr_o.io_clk_val   = io_clk_val   ? pwrmgr_pkg::DiffValid : pwrmgr_pkg::DiffInvalid;
+  assign pwr_o.usb_clk_val  = usb_clk_val  ? pwrmgr_pkg::DiffValid : pwrmgr_pkg::DiffInvalid;
 
   ast #(
     .EntropyStreams(EntropyStreams),
@@ -115,19 +121,19 @@ module ast_wrapper import ast_wrapper_pkg::*;
 
     // output clocks and associated controls
     .clk_src_sys_o(clks_o.clk_sys),
-    .clk_src_sys_val_o(pwr_o.core_clk_val[1]),
+    .clk_src_sys_val_o(core_clk_val),
     .clk_src_sys_en_i(pwr_i.core_clk_en),
     .clk_src_sys_jen_i(1'b0),                 // need to add function in clkmgr
 
     .clk_src_aon_o(clks_o.clk_aon),
-    .clk_src_aon_val_o(pwr_o.slow_clk_val[1]),
+    .clk_src_aon_val_o(slow_clk_val),
 
     .clk_src_usb_o(clks_o.clk_usb),
-    .clk_src_usb_val_o(),                      // need to hookup later
-    .clk_src_usb_en_i(1'b1),                   // need to hookup later
+    .clk_src_usb_val_o(usb_clk_val),
+    .clk_src_usb_en_i(pwr_i.usb_clk_en),
 
     .clk_src_io_o(clks_o.clk_io),
-    .clk_src_io_val_o(pwr_o.io_clk_val[1]),
+    .clk_src_io_val_o(io_clk_val),
     .clk_src_io_en_i(pwr_i.io_clk_en),
 
     // input clock and references for calibration

--- a/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr.hjson
+++ b/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr.hjson
@@ -212,6 +212,46 @@
         },
 
         { bits: "6",
+          name: "USB_CLK_EN_LP",
+          desc: "USB clock enable during low power state",
+          resval: "0",
+          enum: [
+            { value: "0",
+              name: "Disabled",
+              desc: '''
+                USB clock disabled during low power state
+                '''
+            },
+            { value: "1",
+              name: "Enabled",
+              desc: '''
+                USB clock enabled during low power state
+                '''
+            },
+          ]
+        },
+
+        { bits: "7",
+          name: "USB_CLK_EN_ACTIVE",
+          desc: "USB clock enable during active power state",
+          resval: "1"
+          enum: [
+            { value: "0",
+              name: "Disabled",
+              desc: '''
+                USB clock disabled during active power state
+                '''
+            },
+            { value: "1",
+              name: "Enabled",
+              desc: '''
+                USB clock enabled during active power state
+                '''
+            },
+          ]
+        },
+
+        { bits: "8",
           name: "MAIN_PD_N",
           desc: "Active low, main power domain power down",
           resval: "1"
@@ -232,6 +272,8 @@
             },
           ]
         },
+
+
       ],
     },
 

--- a/hw/top_earlgrey/ip/pwrmgr/rtl/autogen/pwrmgr_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/pwrmgr/rtl/autogen/pwrmgr_reg_pkg.sv
@@ -38,6 +38,12 @@ package pwrmgr_reg_pkg;
     } io_clk_en;
     struct packed {
       logic        q;
+    } usb_clk_en_lp;
+    struct packed {
+      logic        q;
+    } usb_clk_en_active;
+    struct packed {
+      logic        q;
     } main_pd_n;
   } pwrmgr_reg2hw_control_reg_t;
 
@@ -122,10 +128,10 @@ package pwrmgr_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    pwrmgr_reg2hw_intr_state_reg_t intr_state; // [18:18]
-    pwrmgr_reg2hw_intr_enable_reg_t intr_enable; // [17:17]
-    pwrmgr_reg2hw_intr_test_reg_t intr_test; // [16:15]
-    pwrmgr_reg2hw_control_reg_t control; // [14:11]
+    pwrmgr_reg2hw_intr_state_reg_t intr_state; // [20:20]
+    pwrmgr_reg2hw_intr_enable_reg_t intr_enable; // [19:19]
+    pwrmgr_reg2hw_intr_test_reg_t intr_test; // [18:17]
+    pwrmgr_reg2hw_control_reg_t control; // [16:11]
     pwrmgr_reg2hw_cfg_cdc_sync_reg_t cfg_cdc_sync; // [10:9]
     pwrmgr_reg2hw_wakeup_en_mreg_t [0:0] wakeup_en; // [8:8]
     pwrmgr_reg2hw_reset_en_mreg_t [0:0] reset_en; // [7:7]
@@ -139,11 +145,11 @@ package pwrmgr_reg_pkg;
   typedef struct packed {
     pwrmgr_hw2reg_intr_state_reg_t intr_state; // [13:13]
     pwrmgr_hw2reg_ctrl_cfg_regwen_reg_t ctrl_cfg_regwen; // [12:13]
-    pwrmgr_hw2reg_control_reg_t control; // [12:9]
-    pwrmgr_hw2reg_cfg_cdc_sync_reg_t cfg_cdc_sync; // [8:7]
-    pwrmgr_hw2reg_wake_status_mreg_t [0:0] wake_status; // [6:5]
-    pwrmgr_hw2reg_reset_status_mreg_t [0:0] reset_status; // [4:3]
-    pwrmgr_hw2reg_wake_info_reg_t wake_info; // [2:-3]
+    pwrmgr_hw2reg_control_reg_t control; // [12:7]
+    pwrmgr_hw2reg_cfg_cdc_sync_reg_t cfg_cdc_sync; // [6:5]
+    pwrmgr_hw2reg_wake_status_mreg_t [0:0] wake_status; // [4:3]
+    pwrmgr_hw2reg_reset_status_mreg_t [0:0] reset_status; // [2:1]
+    pwrmgr_hw2reg_wake_info_reg_t wake_info; // [0:-5]
   } pwrmgr_hw2reg_t;
 
   // Register Address
@@ -187,7 +193,7 @@ package pwrmgr_reg_pkg;
     4'b 0001, // index[ 1] PWRMGR_INTR_ENABLE
     4'b 0001, // index[ 2] PWRMGR_INTR_TEST
     4'b 0001, // index[ 3] PWRMGR_CTRL_CFG_REGWEN
-    4'b 0001, // index[ 4] PWRMGR_CONTROL
+    4'b 0011, // index[ 4] PWRMGR_CONTROL
     4'b 0001, // index[ 5] PWRMGR_CFG_CDC_SYNC
     4'b 0001, // index[ 6] PWRMGR_WAKEUP_EN_REGWEN
     4'b 0001, // index[ 7] PWRMGR_WAKEUP_EN

--- a/hw/top_earlgrey/ip/pwrmgr/rtl/autogen/pwrmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/pwrmgr/rtl/autogen/pwrmgr_reg_top.sv
@@ -90,6 +90,12 @@ module pwrmgr_reg_top (
   logic control_io_clk_en_qs;
   logic control_io_clk_en_wd;
   logic control_io_clk_en_we;
+  logic control_usb_clk_en_lp_qs;
+  logic control_usb_clk_en_lp_wd;
+  logic control_usb_clk_en_lp_we;
+  logic control_usb_clk_en_active_qs;
+  logic control_usb_clk_en_active_wd;
+  logic control_usb_clk_en_active_we;
   logic control_main_pd_n_qs;
   logic control_main_pd_n_wd;
   logic control_main_pd_n_we;
@@ -293,7 +299,59 @@ module pwrmgr_reg_top (
   );
 
 
-  //   F[main_pd_n]: 6:6
+  //   F[usb_clk_en_lp]: 6:6
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_control_usb_clk_en_lp (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (control_usb_clk_en_lp_we & ctrl_cfg_regwen_qs),
+    .wd     (control_usb_clk_en_lp_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.control.usb_clk_en_lp.q ),
+
+    // to register interface (read)
+    .qs     (control_usb_clk_en_lp_qs)
+  );
+
+
+  //   F[usb_clk_en_active]: 7:7
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h1)
+  ) u_control_usb_clk_en_active (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (control_usb_clk_en_active_we & ctrl_cfg_regwen_qs),
+    .wd     (control_usb_clk_en_active_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.control.usb_clk_en_active.q ),
+
+    // to register interface (read)
+    .qs     (control_usb_clk_en_active_qs)
+  );
+
+
+  //   F[main_pd_n]: 8:8
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
@@ -650,8 +708,14 @@ module pwrmgr_reg_top (
   assign control_io_clk_en_we = addr_hit[4] & reg_we & ~wr_err;
   assign control_io_clk_en_wd = reg_wdata[5];
 
+  assign control_usb_clk_en_lp_we = addr_hit[4] & reg_we & ~wr_err;
+  assign control_usb_clk_en_lp_wd = reg_wdata[6];
+
+  assign control_usb_clk_en_active_we = addr_hit[4] & reg_we & ~wr_err;
+  assign control_usb_clk_en_active_wd = reg_wdata[7];
+
   assign control_main_pd_n_we = addr_hit[4] & reg_we & ~wr_err;
-  assign control_main_pd_n_wd = reg_wdata[6];
+  assign control_main_pd_n_wd = reg_wdata[8];
 
   assign cfg_cdc_sync_we = addr_hit[5] & reg_we & ~wr_err;
   assign cfg_cdc_sync_wd = reg_wdata[0];
@@ -709,7 +773,9 @@ module pwrmgr_reg_top (
         reg_rdata_next[0] = control_low_power_hint_qs;
         reg_rdata_next[4] = control_core_clk_en_qs;
         reg_rdata_next[5] = control_io_clk_en_qs;
-        reg_rdata_next[6] = control_main_pd_n_qs;
+        reg_rdata_next[6] = control_usb_clk_en_lp_qs;
+        reg_rdata_next[7] = control_usb_clk_en_active_qs;
+        reg_rdata_next[8] = control_main_pd_n_qs;
       end
 
       addr_hit[5]: begin

--- a/hw/top_earlgrey/lint/top_earlgrey_lint_cfgs.hjson
+++ b/hw/top_earlgrey/lint/top_earlgrey_lint_cfgs.hjson
@@ -87,6 +87,17 @@
                   import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
                   rel_path: "hw/ip/pinmux/lint/{tool}"
              },
+             {    name: pwrmgr
+                  fusesoc_core: lowrisc:ip:pwrmgr
+                  import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"],
+                  rel_path: "hw/ip/pwrmgr/lint/{tool}",
+                  overrides: [
+                    {
+                      name: design_level
+                      value: "top"
+                    }
+                  ]
+             },
              {    name: rv_core_ibex
                   fusesoc_core: lowrisc:ip:rv_core_ibex
                   import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]

--- a/hw/top_earlgrey/rtl/top_earlgrey_cw305.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_cw305.sv
@@ -213,9 +213,10 @@ module top_earlgrey_cw305 #(
   ast_wrapper_pkg::ast_alert_req_t ast_base_alerts;
   ast_wrapper_pkg::ast_status_t ast_base_status;
 
-  assign ast_base_pwr.slow_clk_val = 2'b10;
-  assign ast_base_pwr.core_clk_val = 2'b10;
-  assign ast_base_pwr.io_clk_val   = 2'b10;
+  assign ast_base_pwr.slow_clk_val = pwrmgr_pkg::DiffValid;
+  assign ast_base_pwr.core_clk_val = pwrmgr_pkg::DiffValid;
+  assign ast_base_pwr.io_clk_val   = pwrmgr_pkg::DiffValid;
+  assign ast_base_pwr.usb_clk_val  = pwrmgr_pkg::DiffValid;
   assign ast_base_pwr.main_pok     = 1'b1;
 
   assign ast_base_alerts.alerts_p  = '0;

--- a/hw/top_earlgrey/rtl/top_earlgrey_nexysvideo.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_nexysvideo.sv
@@ -209,9 +209,10 @@ module top_earlgrey_nexysvideo #(
   ast_wrapper_pkg::ast_alert_req_t ast_base_alerts;
   ast_wrapper_pkg::ast_status_t ast_base_status;
 
-  assign ast_base_pwr.slow_clk_val = 2'b10;
-  assign ast_base_pwr.core_clk_val = 2'b10;
-  assign ast_base_pwr.io_clk_val   = 2'b10;
+  assign ast_base_pwr.slow_clk_val = pwrmgr_pkg::DiffValid;
+  assign ast_base_pwr.core_clk_val = pwrmgr_pkg::DiffValid;
+  assign ast_base_pwr.io_clk_val   = pwrmgr_pkg::DiffValid;
+  assign ast_base_pwr.usb_clk_val  = pwrmgr_pkg::DiffValid;
   assign ast_base_pwr.main_pok     = 1'b1;
 
   assign ast_base_alerts.alerts_p  = '0;

--- a/hw/top_earlgrey/rtl/top_earlgrey_verilator.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_verilator.sv
@@ -79,9 +79,10 @@ module top_earlgrey_verilator (
   ast_wrapper_pkg::ast_alert_req_t ast_base_alerts;
   ast_wrapper_pkg::ast_status_t ast_base_status;
 
-  assign ast_base_pwr.slow_clk_val = 2'b10;
-  assign ast_base_pwr.core_clk_val = 2'b10;
-  assign ast_base_pwr.io_clk_val   = 2'b10;
+  assign ast_base_pwr.slow_clk_val = pwrmgr_pkg::DiffValid;
+  assign ast_base_pwr.core_clk_val = pwrmgr_pkg::DiffValid;
+  assign ast_base_pwr.io_clk_val   = pwrmgr_pkg::DiffValid;
+  assign ast_base_pwr.usb_clk_val  = pwrmgr_pkg::DiffValid;
   assign ast_base_pwr.main_pok     = 1'b1;
 
   assign ast_base_alerts.alerts_p  = '0;


### PR DESCRIPTION
- Add usb clock controls
  - unlike other clocks, usb controls can be made during both active and low power modes

- Add differential typedef for decoding / encoding differential signals. 