### PR TITLE
[top] Add missing empty `param_list` for keymgr

### DIFF
--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -2382,6 +2382,7 @@
       available_input_list: []
       available_output_list: []
       available_inout_list: []
+      param_list: []
       interrupt_list:
       [
         {


### PR DESCRIPTION
This PR adds a missing empty `param_list` to the auto-generated `top_earlgrey.gen.hjson`. The parameter list was missing as keymgr got integrated into the top-level just before merging lowRISC/OpenTitan#3453, which added the parameter list.