### PR TITLE
[uart/dv] avoid zero delay during reset

### DIFF
--- a/hw/ip/uart/dv/env/seq_lib/uart_tx_rx_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_tx_rx_vseq.sv
@@ -135,6 +135,9 @@ class uart_tx_rx_vseq extends uart_base_vseq;
   task process_interrupts();
     bit [TL_DW-1:0] intr_status, clear_intr;
     bit clear_rx_intr, clear_tx_intr;
+
+    // avoid zero delay loop during reset
+    wait(!cfg.under_reset);
     // read interrupt
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(dly_to_access_intr)
     cfg.clk_rst_vif.wait_clks(dly_to_access_intr);
@@ -194,7 +197,7 @@ class uart_tx_rx_vseq extends uart_base_vseq;
         send_rx_done = 1; // to end reading RX thread
       end
       begin // read RX data through register
-        while (!send_rx_done) begin
+        while (!send_rx_done && !cfg.under_reset) begin
           // csr read is much faster than uart transfer, use bigger delay
           `DV_CHECK_MEMBER_RANDOMIZE_FATAL(dly_to_rx_read)
           cfg.clk_rst_vif.wait_clks(dly_to_rx_read);


### PR DESCRIPTION
Fix regression failure
Add `wait(!cfg.under_reset)` in forever loop in case delay is set to 0
and reset occurs

Signed-off-by: Weicai Yang <weicai@google.com>