### PR TITLE
[otp_ctrl] Add key derivation interface stub and make design lint clean

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson
@@ -256,13 +256,37 @@
         }
         { bits: "9"
           name: "TIMEOUT_ERROR"
-          desc: "Set to 1 if an integrity or consistency check times out. This raises an otp_check_failed alert and is an unrecoverable error condition."
+          desc: '''
+                Set to 1 if an integrity or consistency check times out.
+                This raises an otp_check_failed alert and is an unrecoverable error condition.
+                '''
         }
         { bits: "10"
+          name: "LFSR_FSM_ERROR"
+          desc: '''
+                Set to 1 if the LFSR timer FSM has reached an invalid state.
+                This raises an otp_check_failed alert and is an unrecoverable error condition.
+                '''
+        }
+        { bits: "11"
+          name: "SCRAMBLING_FSM_ERROR"
+          desc: '''
+                Set to 1 if the scrambling datapath FSM has reached an invalid state.
+                This raises an otp_check_failed alert and is an unrecoverable error condition.
+                '''
+        }
+        { bits: "12"
+          name: "KEY_DERIV_FSM_ERROR"
+          desc: '''
+                Set to 1 if the key derivation FSM has reached an invalid state.
+                This raises an otp_check_failed alert and is an unrecoverable error condition.
+                '''
+        }
+        { bits: "13"
           name: "DAI_IDLE"
           desc: "Set to 1 if the DAI is idle and ready to accept commands."
         }
-        { bits: "11"
+        { bits: "14"
           name: "CHECK_PENDING"
           desc: "Set to 1 if an integrity or consistency check triggered by the LFSR timer or via !!CHECK_TRIGGER is pending."
         }
@@ -530,7 +554,7 @@
             Register write enable for !!CHECK_TRIGGER.
             ''',
       swaccess: "rw1c",
-      hwaccess: "hro",
+      hwaccess: "none",
       fields: [
         { bits:   "0",
           desc: '''
@@ -571,7 +595,7 @@
             Register write enable for !!INTEGRITY_CHECK_PERIOD and !!CONSISTENCY_CHECK_PERIOD.
             ''',
       swaccess: "rw1c",
-      hwaccess: "hro",
+      hwaccess: "none",
       fields: [
         { bits:   "0",
           desc: '''

--- a/hw/ip/otp_ctrl/lint/otp_ctrl.waiver
+++ b/hw/ip/otp_ctrl/lint/otp_ctrl.waiver
@@ -4,4 +4,14 @@
 #
 # waiver file for OTP controller
 
+waive -rules {TERMINAL_STATE} -location {otp_ctrl_dai.sv \
+                                         otp_ctrl_lci.sv \
+                                         otp_ctrl_lfsr_timer.sv \
+                                         otp_ctrl_part_buf.sv \
+                                         otp_ctrl_part_unbuf.sv \
+                                         otp_ctrl_scrmbl.sv} \
+      -msg {Terminal state 'ErrorSt' is detected. Next state register 'state_d' is not assigned in this state.} \
+      -comment "All these FSMs have a valid, terminal error state."
 
+waive -rules {INVALID_COMPARE} -location {otp_ctrl_dai.sv} -regexp {.*dai_addr_i >= PartInfo\[0\]\.offset.*} \
+      -comment "This invalid compare is due to the first partition offset being zero."

--- a/hw/ip/otp_ctrl/otp_ctrl.core
+++ b/hw/ip/otp_ctrl/otp_ctrl.core
@@ -18,11 +18,12 @@ filesets:
       - rtl/otp_ctrl_reg_top.sv
       - rtl/otp_ctrl_parity_reg.sv
       - rtl/otp_ctrl_scrmbl.sv
-      - rtl/otp_ctrl_dai.sv
-      - rtl/otp_ctrl_lci.sv
+      - rtl/otp_ctrl_lfsr_timer.sv
       - rtl/otp_ctrl_part_unbuf.sv
       - rtl/otp_ctrl_part_buf.sv
-      - rtl/otp_ctrl_lfsr_timer.sv
+      - rtl/otp_ctrl_dai.sv
+      - rtl/otp_ctrl_kdi.sv
+      - rtl/otp_ctrl_lci.sv
       - rtl/otp_ctrl.sv
     file_type: systemVerilogSource
 

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_dai.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_dai.sv
@@ -68,8 +68,8 @@ module otp_ctrl_dai
   localparam int CntWidth = OtpByteAddrWidth - $clog2(ScrmblBlockWidth/8);
 
   // Integration checks for parameters.
-  `ASSERT_INIT(CheckNativeOtpWidth0_A, ScrmblBlockWidth % OtpWidth == 0)
-  `ASSERT_INIT(CheckNativeOtpWidth1_A, 32 % OtpWidth == 0)
+  `ASSERT_INIT(CheckNativeOtpWidth0_A, (ScrmblBlockWidth % OtpWidth) == 0)
+  `ASSERT_INIT(CheckNativeOtpWidth1_A, (32 % OtpWidth) == 0)
 
   /////////////////////
   // DAI Control FSM //

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_kdi.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_kdi.sv
@@ -13,7 +13,7 @@ module otp_ctrl_kdi
 #(
   // Number of SRAM key requestor slots. All of them will use the same key seed.
   // However, each request will generate a new key seed.
-  parameter int NumSramKeyReqSlots = 3
+  parameter int NumSramKeyReqSlots = 2
 ) (
   input                                              clk_i,
   input                                              rst_ni,
@@ -23,7 +23,7 @@ module otp_ctrl_kdi
   // Escalation input. This moves the FSM into a terminal state.
   input  lc_tx_t                                     escalate_en_i,
   // FSM is in error state
-  output otp_err_e                                   fsm_err_o,
+  output logic                                       fsm_err_o,
   // Key seed inputs from OTP
   input  logic                                       scrmbl_key_seed_valid_i,
   input  logic [FlashKeySeedWidth-1:0]               flash_data_key_seed_i,
@@ -55,5 +55,42 @@ module otp_ctrl_kdi
   input  logic [ScrmblBlockWidth-1:0]                scrmbl_data_i
 );
 
+  // tie-off and unused assignments for preventing lint messages
+  assign fsm_err_o = 1'b0;
+  assign otp_edn_req_o = '0;
+  assign lc_otp_token_rsp_o = '0;
+  assign flash_otp_key_rsp_o = '0;
+  assign sram_otp_key_rsp_o = '0;
+  assign otbn_otp_key_rsp_o = '0;
+  assign scrmbl_mtx_req_o = '0;
+  assign scrmbl_cmd_o = '0;
+  assign scrmbl_sel_o = '0;
+  assign scrmbl_data_o = '0;
+  assign scrmbl_valid_o = '0;
+
+  logic unused_sigs_d, unused_sigs_q;
+  assign unused_sigs_d = ^{key_deriv_en_i,
+                           escalate_en_i,
+                           scrmbl_key_seed_valid_i,
+                           flash_data_key_seed_i,
+                           flash_addr_key_seed_i,
+                           sram_data_key_seed_i,
+                           otp_edn_rsp_i,
+                           lc_otp_token_req_i,
+                           flash_otp_key_req_i,
+                           sram_otp_key_req_i,
+                           otbn_otp_key_req_i,
+                           scrmbl_mtx_gnt_i,
+                           scrmbl_ready_i,
+                           scrmbl_valid_i,
+                           scrmbl_data_i};
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs
+    if (!rst_ni) begin
+      unused_sigs_q <= '0;
+    end else begin
+      unused_sigs_q <= unused_sigs_d;
+    end
+  end
 
 endmodule : otp_ctrl_kdi

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_kdi.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_kdi.sv
@@ -1,0 +1,59 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Scrambling key derivation module for OTP.
+//
+
+`include "prim_assert.sv"
+
+module otp_ctrl_kdi
+  import otp_ctrl_pkg::*;
+  import otp_ctrl_reg_pkg::*;
+#(
+  // Number of SRAM key requestor slots. All of them will use the same key seed.
+  // However, each request will generate a new key seed.
+  parameter int NumSramKeyReqSlots = 3
+) (
+  input                                              clk_i,
+  input                                              rst_ni,
+  // Pulse to enable this module after OTP partitions have
+  // been initialized.
+  input                                              key_deriv_en_i,
+  // Escalation input. This moves the FSM into a terminal state.
+  input  lc_tx_t                                     escalate_en_i,
+  // FSM is in error state
+  output otp_err_e                                   fsm_err_o,
+  // Key seed inputs from OTP
+  input  logic                                       scrmbl_key_seed_valid_i,
+  input  logic [FlashKeySeedWidth-1:0]               flash_data_key_seed_i,
+  input  logic [FlashKeySeedWidth-1:0]               flash_addr_key_seed_i,
+  input  logic [SramKeySeedWidth-1:0]                sram_data_key_seed_i,
+  // EDN interface for requesting entropy
+  output otp_edn_req_t                               otp_edn_req_o,
+  input  otp_edn_rsp_t                               otp_edn_rsp_i,
+  // Lifecycle hashing request
+  input  lc_otp_token_rsp_t                          lc_otp_token_req_i,
+  output lc_otp_token_rsp_t                          lc_otp_token_rsp_o,
+  // Scrambling key requests
+  input  flash_otp_key_req_t                         flash_otp_key_req_i,
+  output flash_otp_key_rsp_t                         flash_otp_key_rsp_o,
+  input  sram_otp_key_req_t [NumSramKeyReqSlots-1:0] sram_otp_key_req_i,
+  output sram_otp_key_rsp_t [NumSramKeyReqSlots-1:0] sram_otp_key_rsp_o,
+  input  otbn_otp_key_req_t                          otbn_otp_key_req_i,
+  output otbn_otp_key_rsp_t                          otbn_otp_key_rsp_o,
+  // Scrambling mutex request
+  output logic                                       scrmbl_mtx_req_o,
+  input                                              scrmbl_mtx_gnt_i,
+  // Scrambling datapath interface
+  output otp_scrmbl_cmd_e                            scrmbl_cmd_o,
+  output logic [ConstSelWidth-1:0]                   scrmbl_sel_o,
+  output logic [ScrmblBlockWidth-1:0]                scrmbl_data_o,
+  output logic                                       scrmbl_valid_o,
+  input  logic                                       scrmbl_ready_i,
+  input  logic                                       scrmbl_valid_i,
+  input  logic [ScrmblBlockWidth-1:0]                scrmbl_data_i
+);
+
+
+endmodule : otp_ctrl_kdi

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_lfsr_timer.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_lfsr_timer.sv
@@ -98,13 +98,13 @@ module otp_ctrl_lfsr_timer import otp_ctrl_pkg::*; #(
   assign cnsty_mask  = {cnsty_period_msk_i, {TimerWidth-32{1'b1}}};
 
   assign integ_cnt_d = (integ_load_period)  ? lfsr_state & integ_mask :
-                       (integ_load_timeout) ? timeout_i               :
+                       (integ_load_timeout) ? TimerWidth'(timeout_i)  :
                        (integ_cnt_zero)     ? '0                      :
                                               integ_cnt_q - 1'b1;
 
 
   assign cnsty_cnt_d = (cnsty_load_period)  ? lfsr_state & cnsty_mask :
-                       (cnsty_load_timeout) ? timeout_i               :
+                       (cnsty_load_timeout) ? TimerWidth'(timeout_i)  :
                        (cnsty_cnt_zero)     ? '0                      :
                                               cnsty_cnt_q - 1'b1;
 
@@ -178,7 +178,7 @@ module otp_ctrl_lfsr_timer import otp_ctrl_pkg::*; #(
     set_all_cnsty_reqs = '0;
 
     // Status signals going to CSRs and error logic.
-    chk_timeout_o = 1'b0;
+    chk_timeout_d = 1'b0;
     chk_pending_o = 1'b0;
     fsm_err_o = 1'b0;
 

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_buf.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_buf.sv
@@ -72,8 +72,8 @@ module otp_ctrl_part_buf
   localparam int CntWidth = vbits(NumScrmblBlocks);
 
   // Integration checks for parameters.
-  `ASSERT_INIT(OffsetMustBeBlockAligned_A, Info.offset % ScrmblBlockWidth/8 == 0)
-  `ASSERT_INIT(SizeMustBeBlockAligned_A, Info.size % ScrmblBlockWidth/8 == 0)
+  `ASSERT_INIT(OffsetMustBeBlockAligned_A, (Info.offset % (ScrmblBlockWidth/8)) == 0)
+  `ASSERT_INIT(SizeMustBeBlockAligned_A, (Info.size % (ScrmblBlockWidth/8)) == 0)
   `ASSERT(ScrambledImpliesDigest_A, Info.scrambled |-> Info.hw_digest)
   `ASSERT(WriteLockImpliesDigest_A, Info.read_lock |-> Info.hw_digest)
   `ASSERT(ReadLockImpliesDigest_A, Info.write_lock |-> Info.hw_digest)

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_buf.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_buf.sv
@@ -611,17 +611,23 @@ module otp_ctrl_part_buf
   ////////////////
 
   // Known assertions
-  `ASSERT_KNOWN(InitDoneKnown_A,  init_done_o)
-  `ASSERT_KNOWN(ErrorKnown_A,     error_o)
-  `ASSERT_KNOWN(AccessKnown_A,    access_o)
-  `ASSERT_KNOWN(DataKnown_A,      data_o)
-  `ASSERT_KNOWN(DigestKnown_A,    digest_o)
-
-  `ASSERT_KNOWN(OtpReqKnown_A,    otp_req_o)
-  `ASSERT_KNOWN(OtpCmdKnown_A,    otp_cmd_o)
-  `ASSERT_KNOWN(OtpSizeKnown_A,   otp_size_o)
-  `ASSERT_KNOWN(OtpWdataKnown_A,  otp_wdata_o)
-  `ASSERT_KNOWN(OtpAddrKnown_A,   otp_addr_o)
+  `ASSERT_KNOWN(InitDoneKnown_A,     init_done_o)
+  `ASSERT_KNOWN(IntegChkAckKnown_A,  integ_chk_ack_o)
+  `ASSERT_KNOWN(CnstyChkAckKnown_A,  cnsty_chk_ack_o)
+  `ASSERT_KNOWN(ErrorKnown_A,        error_o)
+  `ASSERT_KNOWN(AccessKnown_A,       access_o)
+  `ASSERT_KNOWN(DigestKnown_A,       digest_o)
+  `ASSERT_KNOWN(DataKnown_A,         data_o)
+  `ASSERT_KNOWN(OtpReqKnown_A,       otp_req_o)
+  `ASSERT_KNOWN(OtpCmdKnown_A,       otp_cmd_o)
+  `ASSERT_KNOWN(OtpSizeKnown_A,      otp_size_o)
+  `ASSERT_KNOWN(OtpWdataKnown_A,     otp_wdata_o)
+  `ASSERT_KNOWN(OtpAddrKnown_A,      otp_addr_o)
+  `ASSERT_KNOWN(ScrmblMtxReqKnown_A, scrmbl_mtx_req_o)
+  `ASSERT_KNOWN(ScrmblCmdKnown_A,    scrmbl_cmd_o)
+  `ASSERT_KNOWN(ScrmblSelKnown_A,    scrmbl_sel_o)
+  `ASSERT_KNOWN(ScrmblDataKnown_A,   scrmbl_data_o)
+  `ASSERT_KNOWN(ScrmblValidKnown_A,  scrmbl_valid_o)
 
   // Uninitialized partitions should always be locked, no matter what.
   `ASSERT(InitWriteLocksPartition_A,

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
@@ -56,8 +56,8 @@ module otp_ctrl_part_unbuf
   localparam int DigestOffset = (Info.offset + (Info.size - (ScrmblBlockWidth/8)));
 
   // Integration checks for parameters.
-  `ASSERT_INIT(OffsetMustBeBlockAligned_A, Info.offset % ScrmblBlockWidth/8 == 0)
-  `ASSERT_INIT(SizeMustBeBlockAligned_A, Info.size % ScrmblBlockWidth/8 == 0)
+  `ASSERT_INIT(OffsetMustBeBlockAligned_A, (Info.offset % (ScrmblBlockWidth/8)) == 0)
+  `ASSERT_INIT(SizeMustBeBlockAligned_A, (Info.size % (ScrmblBlockWidth/8)) == 0)
 
   ///////////////////////
   // OTP Partition FSM //
@@ -195,7 +195,7 @@ module otp_ctrl_part_unbuf
       // these checks pass, an OTP word is requested.
       ReadSt: begin
         init_done_o = 1'b1;
-        if (OtpByteAddrWidth'({tlul_addr_q, 2'b00} < Info.size) &&
+        if (OtpByteAddrWidth'({tlul_addr_q, 2'b00}) < Info.size &&
             access_o.read_lock == Unlocked) begin
           otp_req_o = 1'b1;
           otp_addr_sel = DataAddr;

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv
@@ -190,9 +190,10 @@ package otp_ctrl_pkg;
     LciIdx,
     KdiIdx,
     // Number of agents is the last idx+1.
-    NumAgents
+    NumAgentsIdx
   } part_idx_e;
 
+  parameter int NumAgents = int'(NumAgentsIdx);
   parameter int NumHwCfgBits = PartInfo[HwCfgIdx].size*8;
 
   ////////////////////////
@@ -261,8 +262,8 @@ package otp_ctrl_pkg;
   } otp_lc_data_t;
 
   typedef struct packed {
-    logic         req;
-    otp_lc_data_t state_diff;
+    logic      req;
+    lc_state_e state_diff;
     lc_value_e [NumLcCountValues-1:0] count_diff;
   } lc_otp_program_req_t;
 

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
@@ -73,10 +73,6 @@ package otp_ctrl_reg_pkg;
   } otp_ctrl_reg2hw_direct_access_wdata_mreg_t;
 
   typedef struct packed {
-    logic        q;
-  } otp_ctrl_reg2hw_check_trigger_regwen_reg_t;
-
-  typedef struct packed {
     struct packed {
       logic        q;
       logic        qe;
@@ -86,10 +82,6 @@ package otp_ctrl_reg_pkg;
       logic        qe;
     } consistency;
   } otp_ctrl_reg2hw_check_trigger_reg_t;
-
-  typedef struct packed {
-    logic        q;
-  } otp_ctrl_reg2hw_check_regwen_reg_t;
 
   typedef struct packed {
     logic [31:0] q;
@@ -156,6 +148,15 @@ package otp_ctrl_reg_pkg;
     } timeout_error;
     struct packed {
       logic        d;
+    } lfsr_fsm_error;
+    struct packed {
+      logic        d;
+    } scrambling_fsm_error;
+    struct packed {
+      logic        d;
+    } key_deriv_fsm_error;
+    struct packed {
+      logic        d;
     } dai_idle;
     struct packed {
       logic        d;
@@ -213,15 +214,13 @@ package otp_ctrl_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    otp_ctrl_reg2hw_intr_state_reg_t intr_state; // [192:191]
-    otp_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [190:189]
-    otp_ctrl_reg2hw_intr_test_reg_t intr_test; // [188:185]
-    otp_ctrl_reg2hw_direct_access_cmd_reg_t direct_access_cmd; // [184:179]
-    otp_ctrl_reg2hw_direct_access_address_reg_t direct_access_address; // [178:168]
-    otp_ctrl_reg2hw_direct_access_wdata_mreg_t [1:0] direct_access_wdata; // [167:104]
-    otp_ctrl_reg2hw_check_trigger_regwen_reg_t check_trigger_regwen; // [103:103]
-    otp_ctrl_reg2hw_check_trigger_reg_t check_trigger; // [102:99]
-    otp_ctrl_reg2hw_check_regwen_reg_t check_regwen; // [98:98]
+    otp_ctrl_reg2hw_intr_state_reg_t intr_state; // [190:189]
+    otp_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [188:187]
+    otp_ctrl_reg2hw_intr_test_reg_t intr_test; // [186:183]
+    otp_ctrl_reg2hw_direct_access_cmd_reg_t direct_access_cmd; // [182:177]
+    otp_ctrl_reg2hw_direct_access_address_reg_t direct_access_address; // [176:166]
+    otp_ctrl_reg2hw_direct_access_wdata_mreg_t [1:0] direct_access_wdata; // [165:102]
+    otp_ctrl_reg2hw_check_trigger_reg_t check_trigger; // [101:98]
     otp_ctrl_reg2hw_check_timeout_reg_t check_timeout; // [97:66]
     otp_ctrl_reg2hw_integrity_check_period_reg_t integrity_check_period; // [65:34]
     otp_ctrl_reg2hw_consistency_check_period_reg_t consistency_check_period; // [33:2]
@@ -233,19 +232,19 @@ package otp_ctrl_reg_pkg;
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    otp_ctrl_hw2reg_intr_state_reg_t intr_state; // [737:736]
-    otp_ctrl_hw2reg_status_reg_t status; // [735:736]
-    otp_ctrl_hw2reg_err_code_mreg_t [8:0] err_code; // [735:700]
-    otp_ctrl_hw2reg_direct_access_regwen_reg_t direct_access_regwen; // [699:700]
-    otp_ctrl_hw2reg_direct_access_rdata_mreg_t [1:0] direct_access_rdata; // [699:636]
-    otp_ctrl_hw2reg_creator_sw_cfg_digest_mreg_t [1:0] creator_sw_cfg_digest; // [635:572]
-    otp_ctrl_hw2reg_owner_sw_cfg_digest_mreg_t [1:0] owner_sw_cfg_digest; // [571:508]
-    otp_ctrl_hw2reg_hw_cfg_digest_mreg_t [1:0] hw_cfg_digest; // [507:444]
-    otp_ctrl_hw2reg_secret0_digest_mreg_t [1:0] secret0_digest; // [443:380]
-    otp_ctrl_hw2reg_secret1_digest_mreg_t [1:0] secret1_digest; // [379:316]
-    otp_ctrl_hw2reg_secret2_digest_mreg_t [1:0] secret2_digest; // [315:252]
-    otp_ctrl_hw2reg_lc_state_mreg_t [11:0] lc_state; // [251:48]
-    otp_ctrl_hw2reg_lc_transition_cnt_reg_t lc_transition_cnt; // [47:48]
+    otp_ctrl_hw2reg_intr_state_reg_t intr_state; // [740:739]
+    otp_ctrl_hw2reg_status_reg_t status; // [738:739]
+    otp_ctrl_hw2reg_err_code_mreg_t [8:0] err_code; // [738:703]
+    otp_ctrl_hw2reg_direct_access_regwen_reg_t direct_access_regwen; // [702:703]
+    otp_ctrl_hw2reg_direct_access_rdata_mreg_t [1:0] direct_access_rdata; // [702:639]
+    otp_ctrl_hw2reg_creator_sw_cfg_digest_mreg_t [1:0] creator_sw_cfg_digest; // [638:575]
+    otp_ctrl_hw2reg_owner_sw_cfg_digest_mreg_t [1:0] owner_sw_cfg_digest; // [574:511]
+    otp_ctrl_hw2reg_hw_cfg_digest_mreg_t [1:0] hw_cfg_digest; // [510:447]
+    otp_ctrl_hw2reg_secret0_digest_mreg_t [1:0] secret0_digest; // [446:383]
+    otp_ctrl_hw2reg_secret1_digest_mreg_t [1:0] secret1_digest; // [382:319]
+    otp_ctrl_hw2reg_secret2_digest_mreg_t [1:0] secret2_digest; // [318:255]
+    otp_ctrl_hw2reg_lc_state_mreg_t [11:0] lc_state; // [254:51]
+    otp_ctrl_hw2reg_lc_transition_cnt_reg_t lc_transition_cnt; // [50:51]
   } otp_ctrl_hw2reg_t;
 
   // Register Address

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_top.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_top.sv
@@ -162,6 +162,12 @@ module otp_ctrl_reg_top (
   logic status_lci_error_re;
   logic status_timeout_error_qs;
   logic status_timeout_error_re;
+  logic status_lfsr_fsm_error_qs;
+  logic status_lfsr_fsm_error_re;
+  logic status_scrambling_fsm_error_qs;
+  logic status_scrambling_fsm_error_re;
+  logic status_key_deriv_fsm_error_qs;
+  logic status_key_deriv_fsm_error_re;
   logic status_dai_idle_qs;
   logic status_dai_idle_re;
   logic status_check_pending_qs;
@@ -561,7 +567,52 @@ module otp_ctrl_reg_top (
   );
 
 
-  //   F[dai_idle]: 10:10
+  //   F[lfsr_fsm_error]: 10:10
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_status_lfsr_fsm_error (
+    .re     (status_lfsr_fsm_error_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.status.lfsr_fsm_error.d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (status_lfsr_fsm_error_qs)
+  );
+
+
+  //   F[scrambling_fsm_error]: 11:11
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_status_scrambling_fsm_error (
+    .re     (status_scrambling_fsm_error_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.status.scrambling_fsm_error.d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (status_scrambling_fsm_error_qs)
+  );
+
+
+  //   F[key_deriv_fsm_error]: 12:12
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_status_key_deriv_fsm_error (
+    .re     (status_key_deriv_fsm_error_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.status.key_deriv_fsm_error.d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (status_key_deriv_fsm_error_qs)
+  );
+
+
+  //   F[dai_idle]: 13:13
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_dai_idle (
@@ -576,7 +627,7 @@ module otp_ctrl_reg_top (
   );
 
 
-  //   F[check_pending]: 11:11
+  //   F[check_pending]: 14:14
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_check_pending (
@@ -962,7 +1013,7 @@ module otp_ctrl_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.check_trigger_regwen.q ),
+    .q      (),
 
     // to register interface (read)
     .qs     (check_trigger_regwen_qs)
@@ -1041,7 +1092,7 @@ module otp_ctrl_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.check_regwen.q ),
+    .q      (),
 
     // to register interface (read)
     .qs     (check_regwen_qs)
@@ -1865,6 +1916,12 @@ module otp_ctrl_reg_top (
 
   assign status_timeout_error_re = addr_hit[3] && reg_re;
 
+  assign status_lfsr_fsm_error_re = addr_hit[3] && reg_re;
+
+  assign status_scrambling_fsm_error_re = addr_hit[3] && reg_re;
+
+  assign status_key_deriv_fsm_error_re = addr_hit[3] && reg_re;
+
   assign status_dai_idle_re = addr_hit[3] && reg_re;
 
   assign status_check_pending_re = addr_hit[3] && reg_re;
@@ -2005,8 +2062,11 @@ module otp_ctrl_reg_top (
         reg_rdata_next[7] = status_dai_error_qs;
         reg_rdata_next[8] = status_lci_error_qs;
         reg_rdata_next[9] = status_timeout_error_qs;
-        reg_rdata_next[10] = status_dai_idle_qs;
-        reg_rdata_next[11] = status_check_pending_qs;
+        reg_rdata_next[10] = status_lfsr_fsm_error_qs;
+        reg_rdata_next[11] = status_scrambling_fsm_error_qs;
+        reg_rdata_next[12] = status_key_deriv_fsm_error_qs;
+        reg_rdata_next[13] = status_dai_idle_qs;
+        reg_rdata_next[14] = status_check_pending_qs;
       end
 
       addr_hit[4]: begin

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_scrmbl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_scrmbl.sv
@@ -79,9 +79,11 @@ module otp_ctrl_scrmbl import otp_ctrl_pkg::*; (
   output logic [ScrmblBlockWidth-1:0] data_o,
   output logic                        valid_o,
   // escalation input and FSM error indication
-  input  logic                        escalate_en_i,
+  input  lc_tx_t                      escalate_en_i,
   output logic                        fsm_err_o
 );
+
+  import prim_util_pkg::vbits;
 
   ////////////////////////
   // Decryption Key LUT //
@@ -142,10 +144,14 @@ module otp_ctrl_scrmbl import otp_ctrl_pkg::*; (
   logic [ConstSelWidth-1:0] sel_d, sel_q;
   otp_digest_mode_e digest_mode_d, digest_mode_q;
 
-  assign otp_enc_key_mux      = (sel_d < NumScrmblKeys) ? OtpKey[sel_d]          : '0;
-  assign otp_dec_key_mux      = (sel_d < NumScrmblKeys) ? otp_dec_key_lut[sel_d] : '0;
-  assign otp_digest_const_mux = (sel_d < NumDigestSets) ? OtpDigestConst[sel_d]  : '0;
-  assign otp_digest_iv_mux    = (sel_d < NumDigestSets) ? OtpDigestIV[sel_d]     : '0;
+  assign otp_enc_key_mux      = (sel_d < NumScrmblKeys) ?
+                                OtpKey[sel_d[vbits(NumScrmblKeys)-1:0]]          : '0;
+  assign otp_dec_key_mux      = (sel_d < NumScrmblKeys) ?
+                                otp_dec_key_lut[sel_d[vbits(NumScrmblKeys)-1:0]] : '0;
+  assign otp_digest_const_mux = (sel_d < NumDigestSets) ?
+                                OtpDigestConst[sel_d[vbits(NumDigestSets)-1:0]]  : '0;
+  assign otp_digest_iv_mux    = (sel_d < NumDigestSets) ?
+                                OtpDigestIV[sel_d[vbits(NumDigestSets)-1:0]]     : '0;
 
   // Make sure we always select a valid key / digest constant.
   `ASSERT(CheckNumEncKeys_A, data_state_sel == SelEncKeyInit  |-> sel_d < NumScrmblKeys)


### PR DESCRIPTION
This is a preparatory step before adding the key derivation interface (KDI). I.e., this PR makes the following changes:

- Add key derivation req/ack signals
- Add KDI stub and tie signals off 
- Augment the redundant FSM reporting, and add an error in the CSRs for the auxiliary FSMs that did not report parasitic states before (like the scrambling datapath, LFSR timer and KDI)
- Big lint cleanup in order to get the current state of the OTP controller lint clean

This depends on #3503 and #3552. Hence, only the last 3 commits in this PR are relevant.