### PR TITLE
[rstmgr] Finish off some rstmgr D1 items.

### DIFF
--- a/hw/ip/alert_handler/data/alert_handler.hjson.tpl
+++ b/hw/ip/alert_handler/data/alert_handler.hjson.tpl
@@ -89,6 +89,15 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
       local: "true"
     },
   ],
+
+  inter_signal_list: [
+    { struct:  "alert_crashdump",
+      type:    "uni",
+      name:    "crashdump",
+      act:     "req",
+      package: "alert_pkg"
+    },
+  ]
 ##############################################################################
 # interrupt registers for the classes
   interrupt_list: [

--- a/hw/ip/rstmgr/data/rstmgr.hjson.tpl
+++ b/hw/ip/rstmgr/data/rstmgr.hjson.tpl
@@ -18,7 +18,22 @@
   ],
   bus_device: "tlul",
   regwidth: "32",
+  scan: "true",
+  scan_reset: "true",
   param_list: [
+    { name: "RdWidth",
+      desc: "Read width for crash info",
+      type: "int",
+      default: "32",
+      local: "true"
+    },
+
+    { name: "IdxWidth",
+      desc: "Index width for crash info",
+      type: "int",
+      default: "4",
+      local: "true"
+    },
   ],
 
   // Define rstmgr struct package
@@ -106,6 +121,77 @@
         },
       ]
     },
+
+    { name: "ALERT_INFO_CTRL",
+      desc: '''
+            Alert info dump controls.
+            ''',
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "0",
+          name: "EN",
+          hwaccess: "hrw",
+          desc: '''
+            Enable alert dump to capture new information.
+            This field is automatically set to 0 upon system reset (even if rstmgr is not reset).
+            '''
+          resval: "0"
+        },
+
+        { bits: "4+IdxWidth-1:4",
+          name: "INDEX",
+          desc: '''
+            Controls which 32-bit value to read.
+            '''
+          resval: "0"
+        },
+      ]
+    },
+
+    { name: "ALERT_INFO_ATTR",
+      desc: '''
+            Alert info dump attributes.
+            ''',
+      swaccess: "ro",
+      hwaccess: "hwo",
+      hwext: "true",
+      fields: [
+        { bits: "IdxWidth-1:0",
+          name: "CNT_AVAIL",
+          swaccess: "ro",
+          hwaccess: "hwo",
+          desc: '''
+            The number of 32-bit values contained in the alert info dump.
+            '''
+          resval: "0",
+          tags: [// This field only reflects the status of the design, thus the
+                 // default value is likely to change and not remain 0
+                 "excl:CsrAllTests:CsrExclCheck"]
+        },
+      ]
+    },
+
+    { name: "ALERT_INFO",
+      desc: '''
+              Alert dump information prior to last reset.
+              Which value read is controlled by the ALERT_INFO_CTRL register.
+            ''',
+      swaccess: "ro",
+      hwaccess: "hwo",
+      hwext: "true",
+      fields: [
+        { bits: "31:0",
+          name: "VALUE",
+          desc: '''
+            The current 32-bit value of alert crash dump.
+            '''
+          resval: "0",
+        },
+      ]
+    },
+
+
 
     ########################
     # Templated registers for software control

--- a/hw/ip/rstmgr/data/rstmgr.hjson.tpl
+++ b/hw/ip/rstmgr/data/rstmgr.hjson.tpl
@@ -65,6 +65,13 @@
       package: "rstmgr_pkg", // Origin package (only needs for the req)
     },
 
+    { struct:  "alert_crashdump",
+      type:    "uni",
+      name:    "alert_dump",
+      act:     "rcv",
+      package: "alert_pkg",
+    },
+
     // Exported resets
 % for intf in export_rsts:
     { struct:  "rstmgr_${intf}_out",

--- a/hw/ip/rstmgr/data/rstmgr.sv.tpl
+++ b/hw/ip/rstmgr/data/rstmgr.sv.tpl
@@ -32,6 +32,11 @@ module rstmgr import rstmgr_pkg::*; (
   input rstmgr_cpu_t cpu_i,
 
   // Interface to alert handler
+  input alert_pkg::alert_crashdump_t alert_dump_i,
+
+  // dft bypass
+  input scan_rst_ni,
+  input scanmode_i,
 
   // reset outputs
 % for intf in export_rsts:
@@ -41,6 +46,8 @@ module rstmgr import rstmgr_pkg::*; (
 
 );
 
+  import rstmgr_reg_pkg::*;
+
   // receive POR and stretch
   // The por is at first stretched and synced on clk_aon
   // The rst_ni and pok_i input will be changed once AST is integrated
@@ -48,10 +55,17 @@ module rstmgr import rstmgr_pkg::*; (
   rstmgr_por u_rst_por_aon (
     .clk_i(clk_aon_i),
     .rst_ni(ast_i.aon_pok),
+    .scan_rst_ni,
+    .scanmode_i,
     .rst_no(rst_por_aon_n)
   );
 
-  assign resets_o.rst_por_aon_n = rst_por_aon_n;
+  prim_clock_mux2 u_rst_por_aon_n_mux (
+    .clk0_i(rst_por_aon_n),
+    .clk1_i(scan_rst_ni),
+    .sel_i(scanmode_i),
+    .clk_o(resets_o.rst_por_aon_n)
+  );
 
   ////////////////////////////////////////////////////
   // Register Interface                             //
@@ -106,6 +120,7 @@ module rstmgr import rstmgr_pkg::*; (
   logic [PowerDomains-1:0] rst_lc_src_n;
   logic [PowerDomains-1:0] rst_sys_src_n;
 
+
   // lc reset sources
   rstmgr_ctrl #(
     .PowerDomains(PowerDomains)
@@ -137,6 +152,8 @@ module rstmgr import rstmgr_pkg::*; (
   ////////////////////////////////////////////////////
 
 % for rst in leaf_rsts:
+  logic rst_${rst['name']}_n;
+
   prim_flop_2sync #(
     .Width(1),
     .ResetValue('0)
@@ -152,7 +169,14 @@ module rstmgr import rstmgr_pkg::*; (
   % else:
     .d_i(1'b1),
   % endif
-    .q_o(resets_o.rst_${rst['name']}_n)
+    .q_o(rst_${rst['name']}_n)
+  );
+
+  prim_clock_mux2 u_${rst['name']}_mux (
+    .clk0_i(rst_${rst['name']}_n),
+    .clk1_i(scan_rst_ni),
+    .sel_i(scanmode_i),
+    .clk_o(resets_o.rst_${rst['name']}_n)
   );
 
 % endfor
@@ -218,8 +242,58 @@ module rstmgr import rstmgr_pkg::*; (
 % endfor
 
   ////////////////////////////////////////////////////
+  // Crash info capture                             //
+  ////////////////////////////////////////////////////
+  localparam int CrashRemainder = $bits(alert_pkg::alert_crashdump_t) % RdWidth > 0 ? 1 : 0;
+  localparam int CrashStoreSlot = $bits(alert_pkg::alert_crashdump_t) / RdWidth +
+      CrashRemainder;
+  localparam int TotalWidth     = CrashStoreSlot * RdWidth;
+  localparam int SlotCntWidth   = $clog2(CrashStoreSlot);
+
+  logic dump_capture;
+  logic [2**SlotCntWidth-1:0][RdWidth-1:0] slots;
+  logic [CrashStoreSlot-1:0][RdWidth-1:0] slots_q;
+
+  // capture on any legal reset request
+  assign dump_capture = reg2hw.alert_info_ctrl.en.q &
+                        (rst_hw_req | rst_ndm | rst_low_power);
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      slots_q <= '0;
+    end else if (dump_capture) begin
+      slots_q <= TotalWidth'(alert_dump_i);
+    end
+  end
+
+  always_comb begin
+    slots = '0;
+    slots[CrashStoreSlot-1:0] = slots_q;
+  end
+
+  // once dump is captured, no more information is captured until
+  // re-eanbled by software.
+  assign hw2reg.alert_info_ctrl.en.d  = 1'b0;
+  assign hw2reg.alert_info_ctrl.en.de = dump_capture;
+
+  // number of segments to read
+  assign hw2reg.alert_info_attr.d = CrashStoreSlot;
+
+  // the actual dump data
+  assign hw2reg.alert_info.d = slots[reg2hw.alert_info_ctrl.index.q[SlotCntWidth-1:0]];
+
+  if (SlotCntWidth < IdxWidth) begin : gen_tieoffs
+    logic [IdxWidth-SlotCntWidth-1:0] unused_idx;
+    assign unused_idx = reg2hw.alert_info_ctrl.index.q[IdxWidth-1:SlotCntWidth];
+  end
+
+
+  ////////////////////////////////////////////////////
   // Assertions                                     //
   ////////////////////////////////////////////////////
+
+  // Make sure the crash dump isn't excessively large
+  `ASSERT_INIT(CntWidth_A, SlotCntWidth <= IdxWidth)
 
   // when upstream resets, downstream must also reset
 

--- a/hw/ip/rstmgr/rstmgr_component.core
+++ b/hw/ip/rstmgr/rstmgr_component.core
@@ -9,6 +9,7 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:ip:tlul
+      - lowrisc:prim:clock_mux2
       - lowrisc:ip:rstmgr_pkg
     files:
       - rtl/rstmgr_ctrl.sv

--- a/hw/ip/rstmgr/rtl/rstmgr_por.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr_por.sv
@@ -13,6 +13,8 @@ module rstmgr_por #(
 ) (
   input clk_i,
   input rst_ni,
+  input scan_rst_ni,
+  input scanmode_i,
   output logic rst_no
 );
   localparam int CtrWidth = $clog2(StretchCount+1);
@@ -46,7 +48,14 @@ module rstmgr_por #(
 
   // The stable is a vote of all filter stages.
   // Only when all the stages agree is the reset considered stable and count allowed.
-  assign rst_clean_n = rst_filter_n[FilterStages-1];
+
+  prim_clock_mux2 u_rst_clean_mux (
+    .clk0_i(rst_filter_n[FilterStages-1]),
+    .clk1_i(scan_rst_ni),
+    .sel_i(scanmode_i),
+    .clk_o(rst_clean_n)
+  );
+
   assign rst_stable = &rst_filter_n;
   assign cnt_en = rst_stable & !rst_no;
 

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -1407,6 +1407,19 @@
       inter_signal_list:
       [
         {
+          struct: alert_crashdump
+          type: uni
+          name: crashdump
+          act: req
+          package: alert_pkg
+          inst_name: alert_handler
+          width: 1
+          default: ""
+          top_type: broadcast
+          top_signame: alert_handler_crashdump
+          index: -1
+        }
+        {
           struct: tl
           package: tlul_pkg
           type: req_rsp
@@ -1683,6 +1696,18 @@
           width: 1
           default: ""
           top_signame: rstmgr_cpu
+          index: -1
+        }
+        {
+          struct: alert_crashdump
+          type: uni
+          name: alert_dump
+          act: rcv
+          package: alert_pkg
+          inst_name: rstmgr
+          width: 1
+          default: ""
+          top_signame: alert_handler_crashdump
           index: -1
         }
         {
@@ -2816,6 +2841,10 @@
       flash_ctrl.keymgr:
       [
         keymgr.flash
+      ]
+      alert_handler.crashdump:
+      [
+        rstmgr.alert_dump
       ]
       pwrmgr.wakeups:
       [
@@ -5320,6 +5349,19 @@
         index: -1
       }
       {
+        struct: alert_crashdump
+        type: uni
+        name: crashdump
+        act: req
+        package: alert_pkg
+        inst_name: alert_handler
+        width: 1
+        default: ""
+        top_type: broadcast
+        top_signame: alert_handler_crashdump
+        index: -1
+      }
+      {
         struct: tl
         package: tlul_pkg
         type: req_rsp
@@ -5495,6 +5537,18 @@
         width: 1
         default: ""
         top_signame: rstmgr_cpu
+        index: -1
+      }
+      {
+        struct: alert_crashdump
+        type: uni
+        name: alert_dump
+        act: rcv
+        package: alert_pkg
+        inst_name: rstmgr
+        width: 1
+        default: ""
+        top_signame: alert_handler_crashdump
         index: -1
       }
       {
@@ -6482,6 +6536,14 @@
         package: flash_ctrl_pkg
         struct: keymgr_flash
         signame: flash_ctrl_keymgr
+        width: 1
+        type: uni
+        default: ""
+      }
+      {
+        package: alert_pkg
+        struct: alert_crashdump
+        signame: alert_handler_crashdump
         width: 1
         type: uni
         default: ""

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -1632,8 +1632,8 @@
       alert_list: []
       wakeup_list: []
       reset_request_list: []
-      scan: "false"
-      scan_reset: "false"
+      scan: "true"
+      scan_reset: "true"
       inter_signal_list:
       [
         {

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -410,7 +410,8 @@
       'pwrmgr.pwr_flash' : ['flash_ctrl.pwrmgr'],
       'pwrmgr.pwr_rst'   : ['rstmgr.pwr'],
       'pwrmgr.pwr_clk'   : ['clkmgr.pwr'],
-      'flash_ctrl.keymgr': ['keymgr.flash']
+      'flash_ctrl.keymgr': ['keymgr.flash'],
+      'alert_handler.crashdump': ['rstmgr.alert_dump']
     }
 
     // top is to connect to top net/struct.

--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -577,8 +577,6 @@ slice = str(alert_idx+w-1) + ":" + str(alert_idx)
       .dio_attr_o,
     % endif
     % if m["type"] == "alert_handler":
-      // TODO: wire this to hardware debug circuit
-      .crashdump_o (          ),
       // TODO: wire this to TRNG
       .entropy_i   ( 1'b0     ),
       // alert signals

--- a/hw/top_earlgrey/ip/alert_handler/data/autogen/alert_handler.hjson
+++ b/hw/top_earlgrey/ip/alert_handler/data/autogen/alert_handler.hjson
@@ -93,6 +93,15 @@
       local: "true"
     },
   ],
+
+  inter_signal_list: [
+    { struct:  "alert_crashdump",
+      type:    "uni",
+      name:    "crashdump",
+      act:     "req",
+      package: "alert_pkg"
+    },
+  ]
 # interrupt registers for the classes
   interrupt_list: [
     { name: "classa",

--- a/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
+++ b/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
@@ -72,6 +72,13 @@
       package: "rstmgr_pkg", // Origin package (only needs for the req)
     },
 
+    { struct:  "alert_crashdump",
+      type:    "uni",
+      name:    "alert_dump",
+      act:     "rcv",
+      package: "alert_pkg",
+    },
+
     // Exported resets
     { struct:  "rstmgr_ast_out",
       type:    "uni",

--- a/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
+++ b/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
@@ -25,7 +25,22 @@
   ],
   bus_device: "tlul",
   regwidth: "32",
+  scan: "true",
+  scan_reset: "true",
   param_list: [
+    { name: "RdWidth",
+      desc: "Read width for crash info",
+      type: "int",
+      default: "32",
+      local: "true"
+    },
+
+    { name: "IdxWidth",
+      desc: "Index width for crash info",
+      type: "int",
+      default: "4",
+      local: "true"
+    },
   ],
 
   // Define rstmgr struct package
@@ -111,6 +126,77 @@
         },
       ]
     },
+
+    { name: "ALERT_INFO_CTRL",
+      desc: '''
+            Alert info dump controls.
+            ''',
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "0",
+          name: "EN",
+          hwaccess: "hrw",
+          desc: '''
+            Enable alert dump to capture new information.
+            This field is automatically set to 0 upon system reset (even if rstmgr is not reset).
+            '''
+          resval: "0"
+        },
+
+        { bits: "4+IdxWidth-1:4",
+          name: "INDEX",
+          desc: '''
+            Controls which 32-bit value to read.
+            '''
+          resval: "0"
+        },
+      ]
+    },
+
+    { name: "ALERT_INFO_ATTR",
+      desc: '''
+            Alert info dump attributes.
+            ''',
+      swaccess: "ro",
+      hwaccess: "hwo",
+      hwext: "true",
+      fields: [
+        { bits: "IdxWidth-1:0",
+          name: "CNT_AVAIL",
+          swaccess: "ro",
+          hwaccess: "hwo",
+          desc: '''
+            The number of 32-bit values contained in the alert info dump.
+            '''
+          resval: "0",
+          tags: [// This field only reflects the status of the design, thus the
+                 // default value is likely to change and not remain 0
+                 "excl:CsrAllTests:CsrExclCheck"]
+        },
+      ]
+    },
+
+    { name: "ALERT_INFO",
+      desc: '''
+              Alert dump information prior to last reset.
+              Which value read is controlled by the ALERT_INFO_CTRL register.
+            ''',
+      swaccess: "ro",
+      hwaccess: "hwo",
+      hwext: "true",
+      fields: [
+        { bits: "31:0",
+          name: "VALUE",
+          desc: '''
+            The current 32-bit value of alert crash dump.
+            '''
+          resval: "0",
+        },
+      ]
+    },
+
+
 
     # Templated registers for software control
 

--- a/hw/top_earlgrey/ip/rstmgr/lint/rstmgr.vlt
+++ b/hw/top_earlgrey/ip/rstmgr/lint/rstmgr.vlt
@@ -1,0 +1,5 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// waiver file for rstmgr

--- a/hw/top_earlgrey/ip/rstmgr/lint/rstmgr.waiver
+++ b/hw/top_earlgrey/ip/rstmgr/lint/rstmgr.waiver
@@ -1,0 +1,7 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for rstmgr
+
+set_reset_drivers prim_clock_mux2 prim_flop prim_flop_2sync

--- a/hw/top_earlgrey/ip/rstmgr/rstmgr.core
+++ b/hw/top_earlgrey/ip/rstmgr/rstmgr.core
@@ -14,7 +14,33 @@ filesets:
       - rtl/autogen/rstmgr.sv
     file_type: systemVerilogSource
 
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/rstmgr.waiver
+    file_type: waiver
+
+parameters:
+  SYNTHESIS:
+    datatype: bool
+    paramtype: vlogdefine
+
 targets:
-  default:
+  default: &default_target
     filesets:
+      - tool_ascentlint ? (files_ascentlint_waiver)
       - files_rtl
+    toplevel: rstmgr
+
+  lint:
+    <<: *default_target
+    default_tool: verilator
+    parameters:
+      - SYNTHESIS=true
+    tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"

--- a/hw/top_earlgrey/ip/rstmgr/rstmgr_pkg.core
+++ b/hw/top_earlgrey/ip/rstmgr/rstmgr_pkg.core
@@ -10,6 +10,8 @@ filesets:
     depend:
       - lowrisc:ip:pwrmgr_pkg
       - lowrisc:ip:rstmgr_reg
+      - lowrisc:top_earlgrey:alert_handler_reg
+      - lowrisc:ip:alert_handler_component
     files:
       - rtl/autogen/rstmgr_pkg.sv
     file_type: systemVerilogSource

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_pkg.sv
@@ -6,6 +6,10 @@
 
 package rstmgr_reg_pkg;
 
+  // Param list
+  parameter int RdWidth = 32;
+  parameter int IdxWidth = 4;
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////
@@ -14,6 +18,15 @@ package rstmgr_reg_pkg;
       logic        q;
     } hw_req;
   } rstmgr_reg2hw_reset_info_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        q;
+    } en;
+    struct packed {
+      logic [3:0]  q;
+    } index;
+  } rstmgr_reg2hw_alert_info_ctrl_reg_t;
 
   typedef struct packed {
     logic        q;
@@ -39,12 +52,28 @@ package rstmgr_reg_pkg;
     } hw_req;
   } rstmgr_hw2reg_reset_info_reg_t;
 
+  typedef struct packed {
+    struct packed {
+      logic        d;
+      logic        de;
+    } en;
+  } rstmgr_hw2reg_alert_info_ctrl_reg_t;
+
+  typedef struct packed {
+    logic [3:0]  d;
+  } rstmgr_hw2reg_alert_info_attr_reg_t;
+
+  typedef struct packed {
+    logic [31:0] d;
+  } rstmgr_hw2reg_alert_info_reg_t;
+
 
   ///////////////////////////////////////
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    rstmgr_reg2hw_reset_info_reg_t reset_info; // [2:2]
+    rstmgr_reg2hw_reset_info_reg_t reset_info; // [7:7]
+    rstmgr_reg2hw_alert_info_ctrl_reg_t alert_info_ctrl; // [6:2]
     rstmgr_reg2hw_rst_spi_device_n_reg_t rst_spi_device_n; // [1:1]
     rstmgr_reg2hw_rst_usb_n_reg_t rst_usb_n; // [0:0]
   } rstmgr_reg2hw_t;
@@ -53,20 +82,29 @@ package rstmgr_reg_pkg;
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    rstmgr_hw2reg_reset_info_reg_t reset_info; // [5:5]
+    rstmgr_hw2reg_reset_info_reg_t reset_info; // [43:43]
+    rstmgr_hw2reg_alert_info_ctrl_reg_t alert_info_ctrl; // [42:38]
+    rstmgr_hw2reg_alert_info_attr_reg_t alert_info_attr; // [37:38]
+    rstmgr_hw2reg_alert_info_reg_t alert_info; // [37:38]
   } rstmgr_hw2reg_t;
 
   // Register Address
   parameter logic [4:0] RSTMGR_RESET_INFO_OFFSET = 5'h 0;
-  parameter logic [4:0] RSTMGR_SPI_DEVICE_REGEN_OFFSET = 5'h 4;
-  parameter logic [4:0] RSTMGR_RST_SPI_DEVICE_N_OFFSET = 5'h 8;
-  parameter logic [4:0] RSTMGR_USB_REGEN_OFFSET = 5'h c;
-  parameter logic [4:0] RSTMGR_RST_USB_N_OFFSET = 5'h 10;
+  parameter logic [4:0] RSTMGR_ALERT_INFO_CTRL_OFFSET = 5'h 4;
+  parameter logic [4:0] RSTMGR_ALERT_INFO_ATTR_OFFSET = 5'h 8;
+  parameter logic [4:0] RSTMGR_ALERT_INFO_OFFSET = 5'h c;
+  parameter logic [4:0] RSTMGR_SPI_DEVICE_REGEN_OFFSET = 5'h 10;
+  parameter logic [4:0] RSTMGR_RST_SPI_DEVICE_N_OFFSET = 5'h 14;
+  parameter logic [4:0] RSTMGR_USB_REGEN_OFFSET = 5'h 18;
+  parameter logic [4:0] RSTMGR_RST_USB_N_OFFSET = 5'h 1c;
 
 
   // Register Index
   typedef enum int {
     RSTMGR_RESET_INFO,
+    RSTMGR_ALERT_INFO_CTRL,
+    RSTMGR_ALERT_INFO_ATTR,
+    RSTMGR_ALERT_INFO,
     RSTMGR_SPI_DEVICE_REGEN,
     RSTMGR_RST_SPI_DEVICE_N,
     RSTMGR_USB_REGEN,
@@ -74,12 +112,15 @@ package rstmgr_reg_pkg;
   } rstmgr_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] RSTMGR_PERMIT [5] = '{
+  parameter logic [3:0] RSTMGR_PERMIT [8] = '{
     4'b 0001, // index[0] RSTMGR_RESET_INFO
-    4'b 0001, // index[1] RSTMGR_SPI_DEVICE_REGEN
-    4'b 0001, // index[2] RSTMGR_RST_SPI_DEVICE_N
-    4'b 0001, // index[3] RSTMGR_USB_REGEN
-    4'b 0001  // index[4] RSTMGR_RST_USB_N
+    4'b 0001, // index[1] RSTMGR_ALERT_INFO_CTRL
+    4'b 0001, // index[2] RSTMGR_ALERT_INFO_ATTR
+    4'b 1111, // index[3] RSTMGR_ALERT_INFO
+    4'b 0001, // index[4] RSTMGR_SPI_DEVICE_REGEN
+    4'b 0001, // index[5] RSTMGR_RST_SPI_DEVICE_N
+    4'b 0001, // index[6] RSTMGR_USB_REGEN
+    4'b 0001  // index[7] RSTMGR_RST_USB_N
   };
 endpackage
 

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_top.sv
@@ -83,6 +83,16 @@ module rstmgr_reg_top (
   logic reset_info_hw_req_qs;
   logic reset_info_hw_req_wd;
   logic reset_info_hw_req_we;
+  logic alert_info_ctrl_en_qs;
+  logic alert_info_ctrl_en_wd;
+  logic alert_info_ctrl_en_we;
+  logic [3:0] alert_info_ctrl_index_qs;
+  logic [3:0] alert_info_ctrl_index_wd;
+  logic alert_info_ctrl_index_we;
+  logic [3:0] alert_info_attr_qs;
+  logic alert_info_attr_re;
+  logic [31:0] alert_info_qs;
+  logic alert_info_re;
   logic spi_device_regen_qs;
   logic spi_device_regen_wd;
   logic spi_device_regen_we;
@@ -203,6 +213,92 @@ module rstmgr_reg_top (
   );
 
 
+  // R[alert_info_ctrl]: V(False)
+
+  //   F[en]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_alert_info_ctrl_en (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (alert_info_ctrl_en_we),
+    .wd     (alert_info_ctrl_en_wd),
+
+    // from internal hardware
+    .de     (hw2reg.alert_info_ctrl.en.de),
+    .d      (hw2reg.alert_info_ctrl.en.d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.alert_info_ctrl.en.q ),
+
+    // to register interface (read)
+    .qs     (alert_info_ctrl_en_qs)
+  );
+
+
+  //   F[index]: 7:4
+  prim_subreg #(
+    .DW      (4),
+    .SWACCESS("RW"),
+    .RESVAL  (4'h0)
+  ) u_alert_info_ctrl_index (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (alert_info_ctrl_index_we),
+    .wd     (alert_info_ctrl_index_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.alert_info_ctrl.index.q ),
+
+    // to register interface (read)
+    .qs     (alert_info_ctrl_index_qs)
+  );
+
+
+  // R[alert_info_attr]: V(True)
+
+  prim_subreg_ext #(
+    .DW    (4)
+  ) u_alert_info_attr (
+    .re     (alert_info_attr_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.alert_info_attr.d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (alert_info_attr_qs)
+  );
+
+
+  // R[alert_info]: V(True)
+
+  prim_subreg_ext #(
+    .DW    (32)
+  ) u_alert_info (
+    .re     (alert_info_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.alert_info.d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (alert_info_qs)
+  );
+
+
   // R[spi_device_regen]: V(False)
 
   prim_subreg #(
@@ -313,14 +409,17 @@ module rstmgr_reg_top (
 
 
 
-  logic [4:0] addr_hit;
+  logic [7:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[0] = (reg_addr == RSTMGR_RESET_INFO_OFFSET);
-    addr_hit[1] = (reg_addr == RSTMGR_SPI_DEVICE_REGEN_OFFSET);
-    addr_hit[2] = (reg_addr == RSTMGR_RST_SPI_DEVICE_N_OFFSET);
-    addr_hit[3] = (reg_addr == RSTMGR_USB_REGEN_OFFSET);
-    addr_hit[4] = (reg_addr == RSTMGR_RST_USB_N_OFFSET);
+    addr_hit[1] = (reg_addr == RSTMGR_ALERT_INFO_CTRL_OFFSET);
+    addr_hit[2] = (reg_addr == RSTMGR_ALERT_INFO_ATTR_OFFSET);
+    addr_hit[3] = (reg_addr == RSTMGR_ALERT_INFO_OFFSET);
+    addr_hit[4] = (reg_addr == RSTMGR_SPI_DEVICE_REGEN_OFFSET);
+    addr_hit[5] = (reg_addr == RSTMGR_RST_SPI_DEVICE_N_OFFSET);
+    addr_hit[6] = (reg_addr == RSTMGR_USB_REGEN_OFFSET);
+    addr_hit[7] = (reg_addr == RSTMGR_RST_USB_N_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -333,6 +432,9 @@ module rstmgr_reg_top (
     if (addr_hit[2] && reg_we && (RSTMGR_PERMIT[2] != (RSTMGR_PERMIT[2] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[3] && reg_we && (RSTMGR_PERMIT[3] != (RSTMGR_PERMIT[3] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[4] && reg_we && (RSTMGR_PERMIT[4] != (RSTMGR_PERMIT[4] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[5] && reg_we && (RSTMGR_PERMIT[5] != (RSTMGR_PERMIT[5] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[6] && reg_we && (RSTMGR_PERMIT[6] != (RSTMGR_PERMIT[6] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[7] && reg_we && (RSTMGR_PERMIT[7] != (RSTMGR_PERMIT[7] & reg_be))) wr_err = 1'b1 ;
   end
 
   assign reset_info_por_we = addr_hit[0] & reg_we & ~wr_err;
@@ -347,16 +449,26 @@ module rstmgr_reg_top (
   assign reset_info_hw_req_we = addr_hit[0] & reg_we & ~wr_err;
   assign reset_info_hw_req_wd = reg_wdata[3];
 
-  assign spi_device_regen_we = addr_hit[1] & reg_we & ~wr_err;
+  assign alert_info_ctrl_en_we = addr_hit[1] & reg_we & ~wr_err;
+  assign alert_info_ctrl_en_wd = reg_wdata[0];
+
+  assign alert_info_ctrl_index_we = addr_hit[1] & reg_we & ~wr_err;
+  assign alert_info_ctrl_index_wd = reg_wdata[7:4];
+
+  assign alert_info_attr_re = addr_hit[2] && reg_re;
+
+  assign alert_info_re = addr_hit[3] && reg_re;
+
+  assign spi_device_regen_we = addr_hit[4] & reg_we & ~wr_err;
   assign spi_device_regen_wd = reg_wdata[0];
 
-  assign rst_spi_device_n_we = addr_hit[2] & reg_we & ~wr_err;
+  assign rst_spi_device_n_we = addr_hit[5] & reg_we & ~wr_err;
   assign rst_spi_device_n_wd = reg_wdata[0];
 
-  assign usb_regen_we = addr_hit[3] & reg_we & ~wr_err;
+  assign usb_regen_we = addr_hit[6] & reg_we & ~wr_err;
   assign usb_regen_wd = reg_wdata[0];
 
-  assign rst_usb_n_we = addr_hit[4] & reg_we & ~wr_err;
+  assign rst_usb_n_we = addr_hit[7] & reg_we & ~wr_err;
   assign rst_usb_n_wd = reg_wdata[0];
 
   // Read data return
@@ -371,18 +483,31 @@ module rstmgr_reg_top (
       end
 
       addr_hit[1]: begin
-        reg_rdata_next[0] = spi_device_regen_qs;
+        reg_rdata_next[0] = alert_info_ctrl_en_qs;
+        reg_rdata_next[7:4] = alert_info_ctrl_index_qs;
       end
 
       addr_hit[2]: begin
-        reg_rdata_next[0] = rst_spi_device_n_qs;
+        reg_rdata_next[3:0] = alert_info_attr_qs;
       end
 
       addr_hit[3]: begin
-        reg_rdata_next[0] = usb_regen_qs;
+        reg_rdata_next[31:0] = alert_info_qs;
       end
 
       addr_hit[4]: begin
+        reg_rdata_next[0] = spi_device_regen_qs;
+      end
+
+      addr_hit[5]: begin
+        reg_rdata_next[0] = rst_spi_device_n_qs;
+      end
+
+      addr_hit[6]: begin
+        reg_rdata_next[0] = usb_regen_qs;
+      end
+
+      addr_hit[7]: begin
         reg_rdata_next[0] = rst_usb_n_qs;
       end
 

--- a/hw/top_earlgrey/lint/top_earlgrey_lint_cfgs.hjson
+++ b/hw/top_earlgrey/lint/top_earlgrey_lint_cfgs.hjson
@@ -98,6 +98,17 @@
                     }
                   ]
              },
+             {    name: rstmgr
+                  fusesoc_core: lowrisc:systems:rstmgr
+                  import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"],
+                  rel_path: "hw/top_earlgrey/ip/rstmgr/lint/{tool}",
+                  overrides: [
+                    {
+                      name: design_level
+                      value: "top"
+                    }
+                  ]
+             },
              {    name: rv_core_ibex
                   fusesoc_core: lowrisc:ip:rv_core_ibex
                   import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -219,6 +219,7 @@ module top_earlgrey #(
   pwrmgr_pkg::pwr_clk_req_t       pwrmgr_pwr_clk_req;
   pwrmgr_pkg::pwr_clk_rsp_t       pwrmgr_pwr_clk_rsp;
   flash_ctrl_pkg::keymgr_flash_t       flash_ctrl_keymgr;
+  alert_pkg::alert_crashdump_t       alert_handler_crashdump;
   logic       pwrmgr_wakeups;
   logic       pwrmgr_rstreqs;
   tlul_pkg::tl_h2d_t       rom_tl_req;
@@ -791,10 +792,9 @@ module top_earlgrey #(
       .intr_classd_o (intr_alert_handler_classd),
 
       // Inter-module signals
+      .crashdump_o(alert_handler_crashdump),
       .tl_i(alert_handler_tl_req),
       .tl_o(alert_handler_tl_rsp),
-      // TODO: wire this to hardware debug circuit
-      .crashdump_o (          ),
       // TODO: wire this to TRNG
       .entropy_i   ( 1'b0     ),
       // alert signals
@@ -844,6 +844,7 @@ module top_earlgrey #(
       .resets_o(rstmgr_resets),
       .ast_i(rstmgr_ast_i),
       .cpu_i(rstmgr_cpu),
+      .alert_dump_i(alert_handler_crashdump),
       .resets_ast_o(rsts_ast_o),
       .tl_i(rstmgr_tl_req),
       .tl_o(rstmgr_tl_rsp),

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -847,6 +847,8 @@ module top_earlgrey #(
       .resets_ast_o(rsts_ast_o),
       .tl_i(rstmgr_tl_req),
       .tl_o(rstmgr_tl_rsp),
+      .scanmode_i   (scanmode_i),
+      .scan_rst_ni  (scan_rst_ni),
       .clk_i (clkmgr_clocks.clk_io_div4_powerup),
       .clk_aon_i (clkmgr_clocks.clk_aon_powerup),
       .clk_main_i (clkmgr_clocks.clk_main_powerup),


### PR DESCRIPTION
- Add lint directory for top level rstmgr lint
- Add bypass muxes for reset output
- Add alert_info crash dump

First commit is from #3571, it will be rebased away. 

Signed-off-by: Timothy Chen <timothytim@google.com>