### PR TITLE
[otbn] Specify flag group to update in bignum logical insns

### DIFF
--- a/hw/ip/otbn/data/bignum-insns.yml
+++ b/hw/ip/otbn/data/bignum-insns.yml
@@ -483,8 +483,9 @@
       doc: Name of the second source WDR
     - *bn-shift-type-operand
     - *bn-shift-bytes-operand
+    - *bn-flag-group-operand
   syntax: &bn-and-syntax |
-    <wrd>, <wrs1>, <wrs2>[, <shift_type> <shift_bytes>B]
+    <wrd>, <wrs1>, <wrs2>[, <shift_type> <shift_bytes>B][, FG<flag_group>]
   doc: |
     Performs a bitwise and operation.
     Takes the values stored in registers referenced by `wrs1` and `wrs2` and stores the result in the register referenced by `wrd`.
@@ -497,22 +498,23 @@
 
     sb = UInt(shift_bytes)
     st = DecodeShiftType(shift_type)
+    fg = DecodeFlagGroup(flag_group)
   operation: |
     b_shifted = ShiftReg(b, st, sb)
     result = a & b_shifted
 
     WDR[d] = result
     flags_out = FlagsForResult(result)
-    FLAGS[0] = {M: flags_out.M, L: flags_out.L, Z: flags_out.Z, C: FLAGS[0].C}
+    FLAGS[flag_group] = {M: flags_out.M, L: flags_out.L, Z: flags_out.Z, C: FLAGS[flag_group].C}
   encoding:
     scheme: bna
     mapping:
-      funct31: b0
+      fg: flag_group
       shift_type: shift_type
       shift_bytes: shift_bytes
       wrs2: wrs2
       wrs1: wrs1
-      funct3: b110
+      funct3: b010
       wrd: wrd
 
 - mnemonic: bn.or
@@ -531,16 +533,16 @@
 
     WDR[d] = result
     flags_out = FlagsForResult(result)
-    FLAGS[0] = {M: flags_out.M, L: flags_out.L, Z: flags_out.Z, C: FLAGS[0].C}
+    FLAGS[flag_group] = {M: flags_out.M, L: flags_out.L, Z: flags_out.Z, C: FLAGS[flag_group].C}
   encoding:
     scheme: bna
     mapping:
-      funct31: b1
+      fg: flag_group
       shift_type: shift_type
       shift_bytes: shift_bytes
       wrs2: wrs2
       wrs1: wrs1
-      funct3: b110
+      funct3: b100
       wrd: wrd
 
 - mnemonic: bn.not
@@ -552,8 +554,9 @@
       doc: Name of the source WDR
     - *bn-shift-type-operand
     - *bn-shift-bytes-operand
+    - *bn-flag-group-operand
   syntax: |
-    <wrd>, <wrs>[, <shift_type> <shift_bytes>B]
+    <wrd>, <wrs>[, <shift_type> <shift_bytes>B][, FG<flag_group>]
   doc: |
     Negates the value in `wrs` and stores the result in the register referenced by `wrd`.
     The source value can be shifted by an immediate before it is consumed by the operation.
@@ -564,22 +567,22 @@
 
     sb = UInt(shift_bytes)
     st = DecodeShiftType(shift_type)
+    fg = DecodeFlagGroup(flag_group)
   operation: |
     a_shifted = ShiftReg(a, st, sb)
     result = ~a_shifted
 
     WDR[d] = result
     flags_out = FlagsForResult(result)
-    FLAGS[0] = {M: flags_out.M, L: flags_out.L, Z: flags_out.Z, C: FLAGS[0].C}
+    FLAGS[flag_group] = {M: flags_out.M, L: flags_out.L, Z: flags_out.Z, C: FLAGS[flag_group].C}
   encoding:
-    scheme: bna
+    scheme: bnan
     mapping:
-      funct31: b0
+      fg: flag_group
       shift_type: shift_type
       shift_bytes: shift_bytes
-      wrs2: wrs
-      wrs1: bxxxxx
-      funct3: b111
+      wrs1: wrs
+      funct3: b101
       wrd: wrd
 
 - mnemonic: bn.xor
@@ -598,16 +601,16 @@
 
     WDR[d] = result
     flags_out = FlagsForResult(result)
-    FLAGS[0] = {M: flags_out.M, L: flags_out.L, Z: flags_out.Z, C: FLAGS[0].C}
+    FLAGS[flag_group] = {M: flags_out.M, L: flags_out.L, Z: flags_out.Z, C: FLAGS[flag_group].C}
   encoding:
-    scheme: bnaf
+    scheme: bna
     mapping:
-      fg: b1
+      fg: flag_group
       shift_type: shift_type
       shift_bytes: shift_bytes
       wrs2: wrs2
       wrs1: wrs1
-      funct3: b111
+      funct3: b110
       wrd: wrd
 
 - mnemonic: bn.rshi

--- a/hw/ip/otbn/data/enc-schemes.yml
+++ b/hw/ip/otbn/data/enc-schemes.yml
@@ -172,12 +172,6 @@ shift:
     shift_type: 30
     shift_bytes: 29-25
 
-# A partial scheme that defines a function field at bit 31 for OTBN logical
-# operations
-funct31:
-  fields:
-    funct31: 31
-
 # A partial scheme for specialized 2 bit function field, we need a reduced
 # size in the lower two bits of funct3 as RSHI spills over 1 bit from its
 # immediate
@@ -190,42 +184,40 @@ funct2:
 loop:
   parents:
     - custom3
-    - funct2(funct2=b00)
+    - funct3(funct3=b000)
   fields:
     bodysize: 31-20
     grs: 19-15
     fixed:
-      bits: 14,11-7
-      value: bxxxxxx
+      bits: 11-7
+      value: bxxxxx
 
 # A specialised encoding for the loopi instruction (which, unusually, has 2
 # immediates)
 loopi:
   parents:
     - custom3
-    - funct2(funct2=b01)
+    - funct3(funct3=b001)
   fields:
     bodysize: 31-20
     iterations: 19-15,11-7
-    fixed:
-      bits: 14
-      value: bx
 
 # Used wide logical operations (bn.and, bn.or, bn.xor).
 bna:
   parents:
-    - custom1
+    - custom3
     - wdr3
     - funct3
     - shift
-    - funct31
+    - fg
 
 # Used for bn.not (no second source reg).
 bnan:
   parents:
-    - custom1
+    - custom3
+    - funct3
     - shift
-    - funct31
+    - fg
     - wrd
   fields:
     wrs1: 24-20

--- a/hw/ip/otbn/dv/otbnsim/sim/insn.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/insn.py
@@ -572,7 +572,7 @@ class BNSUBM(OTBNInsn):
 
 
 class BNAND(OTBNInsn):
-    insn = insn_for_mnemonic('bn.and', 5)
+    insn = insn_for_mnemonic('bn.and', 6)
 
     def __init__(self, op_vals: Dict[str, int]):
         super().__init__(op_vals)
@@ -581,6 +581,7 @@ class BNAND(OTBNInsn):
         self.wrs2 = op_vals['wrs2']
         self.shift_type = op_vals['shift_type']
         self.shift_bytes = op_vals['shift_bytes']
+        self.flag_group = op_vals['flag_group']
 
     def execute(self, state: OTBNState) -> None:
         b_shifted = ShiftReg(state.wreg[self.wrs2],
@@ -588,11 +589,11 @@ class BNAND(OTBNInsn):
         a = state.wreg[self.wrs1].unsigned()
         result = a & b_shifted
         state.wreg[self.wrd] = result
-        state.update_mlz_flags(0, result)
+        state.update_mlz_flags(self.flag_group, result)
 
 
 class BNOR(OTBNInsn):
-    insn = insn_for_mnemonic('bn.or', 5)
+    insn = insn_for_mnemonic('bn.or', 6)
 
     def __init__(self, op_vals: Dict[str, int]):
         super().__init__(op_vals)
@@ -601,6 +602,7 @@ class BNOR(OTBNInsn):
         self.wrs2 = op_vals['wrs2']
         self.shift_type = op_vals['shift_type']
         self.shift_bytes = op_vals['shift_bytes']
+        self.flag_group = op_vals['flag_group']
 
     def execute(self, state: OTBNState) -> None:
         b_shifted = ShiftReg(state.wreg[self.wrs2],
@@ -608,11 +610,11 @@ class BNOR(OTBNInsn):
         a = state.wreg[self.wrs1]
         result = a | b_shifted
         state.wreg[self.wrd] = result
-        state.update_mlz_flags(0, result)
+        state.update_mlz_flags(self.flag_group, result)
 
 
 class BNNOT(OTBNInsn):
-    insn = insn_for_mnemonic('bn.not', 4)
+    insn = insn_for_mnemonic('bn.not', 5)
 
     def __init__(self, op_vals: Dict[str, int]):
         super().__init__(op_vals)
@@ -620,6 +622,7 @@ class BNNOT(OTBNInsn):
         self.wrs = op_vals['wrs']
         self.shift_type = op_vals['shift_type']
         self.shift_bytes = op_vals['shift_bytes']
+        self.flag_group = op_vals['flag_group']
 
     def execute(self, state: OTBNState) -> None:
         b_shifted = ShiftReg(state.wreg[self.wrs],
@@ -627,10 +630,11 @@ class BNNOT(OTBNInsn):
         result = ~b_shifted
         state.wreg[self.wrd] = result
         state.update_mlz_flags(0, result)
+        state.update_mlz_flags(self.flag_group, result)
 
 
 class BNXOR(OTBNInsn):
-    insn = insn_for_mnemonic('bn.xor', 5)
+    insn = insn_for_mnemonic('bn.xor', 6)
 
     def __init__(self, op_vals: Dict[str, int]):
         super().__init__(op_vals)
@@ -639,6 +643,7 @@ class BNXOR(OTBNInsn):
         self.wrs2 = op_vals['wrs2']
         self.shift_type = op_vals['shift_type']
         self.shift_bytes = op_vals['shift_bytes']
+        self.flag_group = op_vals['flag_group']
 
     def execute(self, state: OTBNState) -> None:
         b_shifted = ShiftReg(state.wreg[self.wrs2],
@@ -646,7 +651,7 @@ class BNXOR(OTBNInsn):
         a = state.wreg[self.wrs1]
         result = a ^ b_shifted
         state.wreg[self.wrd] = result
-        state.update_mlz_flags(0, result)
+        state.update_mlz_flags(self.flag_group, result)
 
 
 class BNRSHI(OTBNInsn):


### PR DESCRIPTION
Before this patch, the bignum logical instructions updated flag group
0. This patch finds some encoding space to specify the flag group for
each instruction. To do so, we switch logical operations to use the
normal "funct3" function encoding (rather than their previous special
"funct31" single-bit encoding) and rejig some other funct3 values to
make space.

The re-encoding was done by Stefan Wallentowitz; the simulator work by
me.

@GregAC: Have you done any work on decoding these instructions in the RTL yet? If so, I'm afraid this changes the encoding.