### PR TITLE
[doc] Add alias for deprecated dashboard link

### DIFF
--- a/hw/_index.md
+++ b/hw/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Hardware Dashboard"
+aliases: [/doc/project/hw_dashboard/]
 ---
 
 This page serves as the landing spot for all hardware development within the OpenTitan project.


### PR DESCRIPTION
The current docs push does not delete files and with this an old version
of the dashboard is still visible.

As the link to this page is also present use an alias to redirect to the
correct page which shows the hardware dashboard.

Fixes lowrisc/opentitan#2634

Signed-off-by: Tobias Wölfel <tobias.woelfel@mailbox.org>