### PR TITLE
[prim] remove FPV related assertions

### DIFF
--- a/hw/ip/prim/rtl/prim_packer.sv
+++ b/hw/ip/prim/rtl/prim_packer.sv
@@ -236,12 +236,6 @@ module prim_packer #(
             valid_i |-> $countones(mask_i ^ {mask_i[InW-2:0],1'b0}) <= 2)
   end
 
-  // Assume data and mask patterns to reduce FPV test time
-  if (InW + OutW > 32) begin : gen_fpv_assumption
-    `ASSUME_FPV(FpvDataWithin_M, data_i inside {'0, '1, 32'hDEAD_BEEF})
-    `ASSUME_FPV(FpvMaskWithin_M, mask_i inside {'0, '1, 32'h08FF_2E41})
-  end
-
   // Flush and Write Enable cannot be asserted same time
   `ASSUME(ExFlushValid_M, flush_i |-> !valid_i)
 


### PR DESCRIPTION
prim_packer.sv has FPV related assumptions that limits the input data.
As prim_packer uses in other modules, these assumptions should be placed
outside of the module itself but placed in _fpv testbench. Those
assumptions are removed.
