### PR TITLE
[i2c, dv] Support stress_all test

### DIFF
--- a/hw/ip/i2c/data/i2c_testplan.hjson
+++ b/hw/ip/i2c/data/i2c_testplan.hjson
@@ -50,17 +50,28 @@
       tests: ["i2c_error_intr"]
     }
     {
-      name: stress_all_with_reset
-      desc: '''
-            Pull reset at random times, ensure DUT are reset and recovered/ correctly and
-            there is no residual data left in the registers.
+      name: stress_all
+      desc: ''',
+            Support vseq (context) switching with random reset in between.
 
             Stimulus:
-              - Randomly reset DUT
-              - Restart send/receive transaction
+              - Combine above sequences in one test to run sequentially
+                except csr sequence and i2c_rx_oversample_vseq (requires zero_delays)
+              - Randomly add reset between each sequence,
 
             Checking:
-              - Ensure registers are properly reset
+              - Ensure transactions are transceivered correctly
+            '''
+      milestone: V2
+      tests: ["i2c_stress_all"]
+    }
+    {
+      name: stress_all_with_rand_reset
+      desc: '''
+            Support random reset in parallel with stress_all and tl_errors sequences.
+
+            Checking:
+              - Ensure transactions are transmitted/received correctly
             '''
       milestone: V2
       tests: ["i2c_stress_all_with_rand_reset"]
@@ -75,27 +86,12 @@
               - Issue long read/write back-to-back transactions 
               - Read rx_fifo as soon as read data valid
               - Clear interrupt quickly
+
             Checking:
               - Ensure transactions are transceivered correctly
             '''
       milestone: V2
       tests: ["i2c_perf"]
-    }
-    {
-      name: stress
-      desc: '''
-            Test multiple interrupts asserted.
-
-            Stimulus:
-              - Do combinations of multiple of above scenarios to get
-                multiple interrupts asserted at the same time
-              - Scoreboard should be robust enough to deal with all scenarios
-
-            Checking:
-              - Ensure multiple interrupts are asserted
-            '''
-      milestone: V2
-      tests: ["i2c_stress"]
     }
     {
       name: override

--- a/hw/ip/i2c/dv/env/i2c_env.core
+++ b/hw/ip/i2c/dv/env/i2c_env.core
@@ -31,6 +31,7 @@ filesets:
       - seq_lib/i2c_perf_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_stretch_timeout_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_error_intr_vseq.sv: {is_include_file: true}
+      - seq_lib/i2c_stress_all_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/i2c/dv/env/i2c_env_cfg.sv
+++ b/hw/ip/i2c/dv/env/i2c_env_cfg.sv
@@ -29,6 +29,10 @@ class i2c_env_cfg extends cip_base_env_cfg #(.RAL_T(i2c_reg_block));
   // set en_sda_interference to allow sda_interference irq is triggered
   bit en_sda_interference = 1'b0;
 
+  // bit to control dv_checks for stress_all_with_rand_reset test
+  // set to enable dv_checks inside some vseqs
+  bit en_dv_check_vseq    = 1'b1;
+
   // i2c_agent cfg
   rand i2c_agent_cfg m_i2c_agent_cfg;
 

--- a/hw/ip/i2c/dv/env/i2c_seq_cfg.sv
+++ b/hw/ip/i2c/dv/env/i2c_seq_cfg.sv
@@ -6,12 +6,13 @@
 class i2c_seq_cfg extends uvm_object;
   `uvm_object_utils(i2c_seq_cfg)
 
-  // Randomization weights in percentages, and other related settings.
-
-  // TODO: This should move to `dv_base_seq_cfg`.
-  // maximun number of times the vseq is randomized and rerun.
+  // the range of number of requests
   uint i2c_min_num_trans         = 10;
   uint i2c_max_num_trans         = 20;
+
+  // the range of number of running vseq in stress_all_vseq, error_intr_vseq
+  uint i2c_min_num_runs          = 10;
+  uint i2c_max_num_runs          = 20;
 
   // parameters configured at test level for *_vseq
   uint i2c_min_addr              = 0;
@@ -33,8 +34,6 @@ class i2c_seq_cfg extends uvm_object;
   uint i2c_prob_sda_unstable     = 10;
   uint i2c_prob_sda_interference = 10;
   uint i2c_prob_scl_interference = 50;
-  uint i2c_min_num_resets        = 30;
-  uint i2c_max_num_resets        = 50;
 
   `uvm_object_new
 

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_common_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_common_vseq.sv
@@ -16,8 +16,11 @@ class i2c_common_vseq extends i2c_base_vseq;
   virtual task body();
     // disable i2c_monitor since it can not handle this test
     `uvm_info(`gfn, $sformatf("\ndisable i2c_monitor and i2c_scoreboard"), UVM_DEBUG)
-    cfg.m_i2c_agent_cfg.en_monitor = 1'b0;
+    if (!cfg.en_scb) cfg.m_i2c_agent_cfg.en_monitor = 1'b0;
+    `uvm_info(`gfn, "\n--> start i2c_common_vseq", UVM_DEBUG)
     run_common_vseq_wrapper(num_trans); // inherit from cip_base_vseq.sv
+    reset_env_config();
+    `uvm_info(`gfn, "\n--> end i2c_common_vseq", UVM_DEBUG)
   endtask : body
 
   task post_start();

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_fifo_full_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_fifo_full_vseq.sv
@@ -7,6 +7,11 @@ class i2c_fifo_full_vseq extends i2c_sanity_vseq;
   `uvm_object_utils(i2c_fifo_full_vseq)
   `uvm_object_new
 
+  // derive this constraint from the i2c_base_vseq instead of i2c_sanity_vseq
+  constraint num_trans_c {
+    num_trans inside {[cfg.seq_cfg.i2c_min_num_trans : cfg.seq_cfg.i2c_max_num_trans]};
+  }
+
   // fast write data to fmt_fifo to quickly trigger fmt_watermark interrupt
   constraint fmt_fifo_access_dly_c { fmt_fifo_access_dly == 0;}
 
@@ -22,34 +27,13 @@ class i2c_fifo_full_vseq extends i2c_sanity_vseq;
   // read transaction length is equal to rx_fifo
   constraint num_rd_bytes_c { num_rd_bytes == I2C_RX_FIFO_DEPTH; }
 
-  bit check_fifo_full = 1'b1;
-  bit fmt_fifo_full   = 1'b0;
-  bit rx_fifo_full    = 1'b0;
-
   virtual task body();
     // hold reading rx_fifo to ensure rx_fifo gets full
     cfg.en_rx_watermark = 1'b1;
-
-    fork
-      begin
-        while (check_fifo_full) process_fifo_full_status();
-      end
-      begin
-        super.body();
-        check_fifo_full = 1'b0; // gracefully stop process_fifo_full_status
-      end
-    join
-    // verify fmt_fifo and rx_fifo has been in full status
-    `DV_CHECK_EQ({fmt_fifo_full, rx_fifo_full}, 2'b11);
+    `uvm_info(`gfn, "\n--> start i2c_fifo_full_vseq", UVM_DEBUG)
+    super.body();
+    reset_env_config();
+    `uvm_info(`gfn, "\n--> end i2c_fifo_full_vseq", UVM_DEBUG)
   endtask : body
-
-  task process_fifo_full_status();
-    bit [TL_DW-1:0] status;
-
-    csr_rd(.ptr(ral.status), .value(status), .backdoor(1'b1));
-    cfg.clk_rst_vif.wait_clks(1);
-    fmt_fifo_full |= bit'(get_field_val(ral.status.fmtfull, status));
-    rx_fifo_full  |= bit'(get_field_val(ral.status.rxfull, status));
-  endtask : process_fifo_full_status
 
 endclass : i2c_fifo_full_vseq

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_override_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_override_vseq.sv
@@ -22,13 +22,15 @@ class i2c_override_vseq extends i2c_base_vseq;
 
     device_init();
     host_init();
-
+    `uvm_info(`gfn, "\n--> start i2c_override_vseq", UVM_DEBUG)
     for (uint cur_tran = 1; cur_tran <= num_trans; cur_tran++) begin
       `uvm_info(`gfn, $sformatf("\nTransaction %0d", cur_tran), UVM_DEBUG)
       // program to enable OVRD reg
-      `DV_CHECK_MEMBER_RANDOMIZE_FATAL(sclval)
-      `DV_CHECK_MEMBER_RANDOMIZE_FATAL(sdaval)
-      `DV_CHECK_MEMBER_RANDOMIZE_FATAL(txovrden)
+      if (cfg.en_dv_check_vseq) begin
+        `DV_CHECK_MEMBER_RANDOMIZE_FATAL(sclval)
+        `DV_CHECK_MEMBER_RANDOMIZE_FATAL(sdaval)
+        `DV_CHECK_MEMBER_RANDOMIZE_FATAL(txovrden)
+      end
       ral.ovrd.txovrden.set(txovrden);
       ral.ovrd.sclval.set(sclval);
       ral.ovrd.sdaval.set(sdaval);
@@ -37,14 +39,18 @@ class i2c_override_vseq extends i2c_base_vseq;
       // checking DUT's scl and sda
       if (txovrden) begin
         cfg.m_i2c_agent_cfg.vif.wait_for_dly(1); // fast enough
-        `DV_CHECK_EQ(cfg.m_i2c_agent_cfg.vif.scl_i, sclval)
-        `DV_CHECK_EQ(cfg.m_i2c_agent_cfg.vif.sda_i, sdaval)
-        `uvm_info(`gfn, $sformatf("\n  scl_i %0b sclval %0b",
-            cfg.m_i2c_agent_cfg.vif.scl_i, sclval), UVM_DEBUG)
-        `uvm_info(`gfn, $sformatf("\n  sda_i %0b sdaval %0b",
-            cfg.m_i2c_agent_cfg.vif.sda_i, sdaval), UVM_DEBUG)
+        if (cfg.en_dv_check_vseq) begin
+          `DV_CHECK_EQ(cfg.m_i2c_agent_cfg.vif.scl_i, sclval)
+          `DV_CHECK_EQ(cfg.m_i2c_agent_cfg.vif.sda_i, sdaval)
+          `uvm_info(`gfn, $sformatf("\n  scl_i %0b sclval %0b",
+              cfg.m_i2c_agent_cfg.vif.scl_i, sclval), UVM_DEBUG)
+          `uvm_info(`gfn, $sformatf("\n  sda_i %0b sdaval %0b",
+              cfg.m_i2c_agent_cfg.vif.sda_i, sdaval), UVM_DEBUG)
+        end
       end
     end
+    reset_env_config();
+    `uvm_info(`gfn, "\n--> end i2c_override_vseq", UVM_DEBUG)
   endtask : body
 
 endclass : i2c_override_vseq

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_perf_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_perf_vseq.sv
@@ -7,6 +7,11 @@ class i2c_perf_vseq extends i2c_sanity_vseq;
   `uvm_object_utils(i2c_perf_vseq)
   `uvm_object_new
 
+  // derive this constraint from the i2c_base_vseq instead of i2c_sanity_vseq
+  constraint num_trans_c {
+    num_trans inside {[cfg.seq_cfg.i2c_min_num_trans : cfg.seq_cfg.i2c_max_num_trans]};
+  }
+
   // should have few long transactions
   constraint num_wr_bytes_c {
     num_wr_bytes dist {

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_rx_tx_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_rx_tx_vseq.sv
@@ -7,8 +7,8 @@ class i2c_rx_tx_vseq extends i2c_base_vseq;
 
   `uvm_object_new
 
-  int total_rd_bytes;
-  bit complete_program_fmt_fifo;
+  local int total_rd_bytes;
+  local bit complete_program_fmt_fifo;
 
   virtual task host_send_trans(int num_trans, tran_type_e trans_type = ReadWrite);
     bit last_tran, chained_read;
@@ -51,7 +51,7 @@ class i2c_rx_tx_vseq extends i2c_base_vseq;
           end
 
           last_tran = (cur_tran == num_trans);
-          `uvm_info(`gfn, $sformatf("\nstart sending %s transaction %0d/%0d",
+          `uvm_info(`gfn, $sformatf("\nstart sending %s transaction %0d / %0d",
               (rw_bit) ? "READ" : "WRITE", cur_tran, num_trans), UVM_DEBUG)
           if (chained_read) begin
             // keep programming chained read transaction
@@ -67,9 +67,7 @@ class i2c_rx_tx_vseq extends i2c_base_vseq;
 
           // check a completed transaction is programmed to the host/dut (stop bit must be issued)
           // and check if the host/dut is in idle before allow re-programming the timing registers
-          if (fmt_item.stop) begin
-            check_host_idle();
-          end
+          check_host_idle(fmt_item.stop);
         end
         complete_program_fmt_fifo = 1'b1;
       end

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_sanity_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_sanity_vseq.sv
@@ -11,9 +11,11 @@ class i2c_sanity_vseq extends i2c_rx_tx_vseq;
   constraint num_trans_c { num_trans inside {[50 : 100]}; }
 
   virtual task body();
+    bit do_interrupt = 1'b1;
+
     device_init();
     host_init();
-
+    `uvm_info(`gfn, "\n--> start i2c_sanity_vseq", UVM_DEBUG)
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(num_trans)
     fork
       begin
@@ -24,6 +26,8 @@ class i2c_sanity_vseq extends i2c_rx_tx_vseq;
         do_interrupt = 1'b0; // gracefully stop process_interrupts
       end
     join
+    reset_env_config();
+    `uvm_info(`gfn, "\n--> end i2c_sanity_vseq", UVM_DEBUG)
   endtask : body
 
 endclass : i2c_sanity_vseq

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_stress_all_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_stress_all_vseq.sv
@@ -1,0 +1,82 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// combine all i2c seqs (except below seqs) in one seq to run sequentially
+// 1. override_vseq requires scb to be disabled
+class i2c_stress_all_vseq extends i2c_base_vseq;
+  `uvm_object_utils(i2c_stress_all_vseq)
+
+  `uvm_object_new
+
+  rand bit random_reset;
+
+  constraint random_reset_c { random_reset dist {0 :/ 1, 1 :/ 3}; }
+
+  task body();
+    string seq_names[] = {"i2c_common_vseq",
+                          "i2c_sanity_vseq",
+                          "i2c_fifo_full_vseq",
+                          "i2c_fifo_overflow_vseq",
+                          "i2c_fifo_watermark_vseq",
+                          "i2c_fifo_full_vseq",
+                          "i2c_stretch_timeout_vseq",
+                          "i2c_override_vseq",
+                          "i2c_error_intr_vseq",
+                          "i2c_perf_vseq"};
+
+    string msg, seq_name;
+    int    seq_run_hist[string];
+
+    `uvm_info(`gfn, $sformatf("\n>>> stress_all, total stressed sequences %0d",
+        seq_names.size()), UVM_LOW)
+    `uvm_info(`gfn, $sformatf("\n>>> stress_all, en_dv_check_vseq %0d, do_dut_init %0d",
+        cfg.en_dv_check_vseq, do_dut_init), UVM_LOW)
+    for (int i = 1; i <= seq_names.size(); i++) begin
+      seq_run_hist[seq_names[i-1]] = 0;
+    end
+
+    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(num_runs)
+    for (int i = 1; i <= num_runs; i++) begin
+      uvm_sequence   seq;
+      i2c_base_vseq  i2c_vseq;
+      uint           seq_idx = $urandom_range(0, seq_names.size() - 1);
+
+      seq_name = seq_names[seq_idx];
+      `uvm_info(`gfn, $sformatf("\n>>> stress_all, run vseq %0d/%0d, start %s ",
+          i, num_runs, seq_name), UVM_LOW)
+      seq = create_seq_by_name(seq_name);
+      `downcast(i2c_vseq, seq)
+
+      // if upper seq disables do_dut_init for this seq, then can't issue reset
+      // as upper seq may drive reset
+      if (do_dut_init) begin
+        `DV_CHECK_MEMBER_RANDOMIZE_FATAL(random_reset)
+        i2c_vseq.do_dut_init = random_reset;
+        `uvm_info(`gfn, "\n  randomly issue reset", UVM_LOW)
+      end else begin
+        `uvm_info(`gfn, "\n  upper_seq may drive reset thus not issue reset", UVM_DEBUG)
+        i2c_vseq.do_dut_init = 0;
+      end
+
+      i2c_vseq.set_sequencer(p_sequencer);
+      `DV_CHECK_RANDOMIZE_FATAL(i2c_vseq)
+      if (seq_name == "i2c_common_vseq") begin
+        i2c_common_vseq common_vseq;
+        `downcast(common_vseq, i2c_vseq);
+        common_vseq.common_seq_type = "intr_test";
+      end
+      seq_run_hist[seq_name]++;
+      i2c_vseq.start(p_sequencer);
+      `uvm_info(`gfn, $sformatf("\n  stress_all, finish vseq %s", seq_name), UVM_LOW)
+    end
+    // print running histogram for vseq
+    msg = {msg, "\n\n>>> stress_all, sequence run histogram:"};
+    for (int i = 0; i < seq_names.size(); i++) begin
+      seq_name = seq_names[i];
+      msg = {msg, $sformatf("\n  %-25s  %2d/%2d", seq_name, seq_run_hist[seq_name], num_runs)};
+    end
+    `uvm_info(`gfn, $sformatf("%s\n", msg), UVM_LOW)
+  endtask : body
+
+endclass : i2c_stress_all_vseq

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
@@ -14,4 +14,5 @@
 `include "i2c_perf_vseq.sv"
 `include "i2c_stretch_timeout_vseq.sv"
 `include "i2c_error_intr_vseq.sv"
+`include "i2c_stress_all_vseq.sv"
 

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -29,7 +29,7 @@
                 // Common CIP test lists
                 "{proj_root}/hw/dv/data/tests/csr_tests.hjson",
                 "{proj_root}/hw/dv/data/tests/intr_test.hjson",
-                //TODO: enable later in V2
+                // TODO: Temporally comment out to debug stress_all_with_rand_reset
                 //"{proj_root}/hw/dv/data/tests/stress_tests.hjson",
                 "{proj_root}/hw/dv/data/tests/tl_access_tests.hjson"]
 
@@ -72,7 +72,6 @@
 
     {
       name: i2c_perf
-      reseed: 10
       uvm_test_seq: i2c_perf_vseq
     }
 
@@ -83,8 +82,14 @@
 
     {
       name: i2c_error_intr
-      reseed: 10
       uvm_test_seq: i2c_error_intr_vseq
+    }
+
+    {
+      name: i2c_stress_all
+      uvm_test_seq: i2c_stress_all_vseq
+      // 10ms
+      run_opts: ["+test_timeout_ns=10000000000"]
     }
   ]
 


### PR DESCRIPTION
This PR includes
  - Add stress_all_vseq test
  - Update required *_vseq to support stress_all_vseq
  - Update i2c_testplan.md and i2c_sim_cfg.hjson files

Signed-off-by: Tung Hoang <hoang.tung@wdc.com>