### PR TITLE
[sw, rom_exts] ROM_EXT manifest parser

### DIFF
--- a/sw/device/lib/base/mmio.h
+++ b/sw/device/lib/base/mmio.h
@@ -148,6 +148,8 @@ typedef struct mmio_region { void *mock; } mmio_region_t;
  * Stubbed-out read/write operations for overriding by a testing library.
  */
 MMIO_WARN_UNUSED_RESULT
+mmio_region_t mmio_region_from_addr(uintptr_t address);
+MMIO_WARN_UNUSED_RESULT
 uint8_t mmio_region_read8(mmio_region_t base, ptrdiff_t offset);
 MMIO_WARN_UNUSED_RESULT
 uint32_t mmio_region_read32(mmio_region_t base, ptrdiff_t offset);

--- a/sw/device/lib/testing/mock_mmio.cc
+++ b/sw/device/lib/testing/mock_mmio.cc
@@ -11,6 +11,11 @@ std::random_device MockDevice::rd;
 
 // Definitions for the MOCK_MMIO-mode declarations in |mmio.h|.
 extern "C" {
+// dummy
+mmio_region_t mmio_region_from_addr(uintptr_t address) {
+  return (mmio_region_t){};
+}
+
 uint8_t mmio_region_read8(mmio_region_t base, ptrdiff_t offset) {
   auto *dev = static_cast<MockDevice *>(base.mock);
   return dev->Read8(offset);

--- a/sw/device/rom_exts/manifest.h
+++ b/sw/device/rom_exts/manifest.h
@@ -1,0 +1,216 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_ROM_EXTS_MANIFEST_H_
+#define OPENTITAN_SW_DEVICE_ROM_EXTS_MANIFEST_H_
+
+// Header Extern Guard (so header can be used from C and C++)
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * ROM_EXT manifest field manifest_identifier offset from the base.
+ */
+#define ROM_EXT_MANIFEST_IDENTIFIER_OFFSET 0u
+
+/**
+ * ROM_EXT manifest field manifest_identifier size in bytes and words.
+ */
+#define ROM_EXT_MANIFEST_IDENTIFIER_SIZE_BYTES 4u
+#define ROM_EXT_MANIFEST_IDENTIFIER_SIZE_WORDS 1u
+
+/**
+ * ROM_EXT manifest field image_signature offset from the base.
+ */
+#define ROM_EXT_IMAGE_SIGNATURE_OFFSET 8u
+
+/**
+ * ROM_EXT manifest field image_signature size in bytes and words.
+ */
+#define ROM_EXT_IMAGE_SIGNATURE_SIZE_BYTES 384u
+#define ROM_EXT_IMAGE_SIGNATURE_SIZE_WORDS 96u
+
+/**
+ * ROM_EXT manifest field image_length offset from the base.
+ */
+#define ROM_EXT_IMAGE_LENGTH_OFFSET 392u
+
+/**
+ * ROM_EXT manifest field image_length size in bytes and words.
+ */
+#define ROM_EXT_IMAGE_LENGTH_SIZE_BYTES 4u
+#define ROM_EXT_IMAGE_LENGTH_SIZE_WORDS 1u
+
+/**
+ * ROM_EXT manifest field image_version offset from the base.
+ */
+#define ROM_EXT_IMAGE_VERSION_OFFSET 396u
+
+/**
+ * ROM_EXT manifest field image_version size in bytes and words.
+ */
+#define ROM_EXT_IMAGE_VERSION_SIZE_BYTES 4u
+#define ROM_EXT_IMAGE_VERSION_SIZE_WORDS 1u
+
+/**
+ * ROM_EXT manifest field image_timestamp offset from the base.
+ */
+#define ROM_EXT_IMAGE_TIMESTAMP_OFFSET 400u
+
+/**
+ * ROM_EXT manifest field image_timestamp size in bytes and words.
+ */
+#define ROM_EXT_IMAGE_TIMESTAMP_SIZE_BYTES 8u
+#define ROM_EXT_IMAGE_TIMESTAMP_SIZE_WORDS 2u
+
+/**
+ * ROM_EXT manifest field signature_algorithm_identifier offset from the base.
+ */
+#define ROM_EXT_SIGNATURE_ALGORITHM_IDENTIFIER_OFFSET 408u
+
+/**
+ * ROM_EXT manifest field signature_algorithm_identifier size in bytes and
+ * words.
+ */
+#define ROM_EXT_SIGNATURE_ALGORITHM_IDENTIFIER_SIZE_BYTES 4u
+#define ROM_EXT_SIGNATURE_ALGORITHM_IDENTIFIER_SIZE_WORDS 1u
+
+/**
+ * ROM_EXT manifest field exponent offset from the base.
+ */
+#define ROM_EXT_EXPONENT_OFFSET 412u
+
+/**
+ * ROM_EXT manifest field exponent size in bytes and words.
+ */
+#define ROM_EXT_EXPONENT_SIZE_BYTES 4u
+#define ROM_EXT_EXPONENT_SIZE_WORDS 1u
+
+/**
+ * ROM_EXT manifest field usage_constraints offset from the base.
+ */
+#define ROM_EXT_USAGE_CONSTRAINTS_OFFSET 416u
+
+/**
+ * ROM_EXT manifest field usage_constraints size in bytes and words.
+ */
+#define ROM_EXT_USAGE_CONSTRAINTS_SIZE_BYTES 4u
+#define ROM_EXT_USAGE_CONSTRAINTS_SIZE_WORDS 1u
+
+/**
+ * ROM_EXT manifest field peripheral_lockdown_info offset from the base.
+ */
+#define ROM_EXT_PERIPHERAL_LOCKDOWN_INFO_OFFSET 424u
+
+/**
+ * ROM_EXT manifest field peripheral_lockdown_info size in bytes and words.
+ */
+#define ROM_EXT_PERIPHERAL_LOCKDOWN_INFO_SIZE_BYTES 16u
+#define ROM_EXT_PERIPHERAL_LOCKDOWN_INFO_SIZE_WORDS 4u
+
+/**
+ * ROM_EXT manifest field signature_public_key offset from the base.
+ */
+#define ROM_EXT_SIGNATURE_PUBLIC_KEY_OFFSET 440u
+
+/**
+ * ROM_EXT manifest field signature_public_key size in bytes and words.
+ */
+#define ROM_EXT_SIGNATURE_PUBLIC_KEY_SIZE_BYTES 384u
+#define ROM_EXT_SIGNATURE_PUBLIC_KEY_SIZE_WORDS 96u
+
+/**
+ * ROM_EXT manifest field extension0_offset offset from the base.
+ */
+#define ROM_EXT_EXTENSION0_OFFSET_OFFSET 824u
+
+/**
+ * ROM_EXT manifest field extension0_offset size in bytes and words.
+ */
+#define ROM_EXT_EXTENSION0_OFFSET_SIZE_BYTES 4u
+#define ROM_EXT_EXTENSION0_OFFSET_SIZE_WORDS 1u
+
+/**
+ * ROM_EXT manifest field extension0_checksum offset from the base.
+ */
+#define ROM_EXT_EXTENSION0_CHECKSUM_OFFSET 828u
+
+/**
+ * ROM_EXT manifest field extension0_checksum size in bytes and words.
+ */
+#define ROM_EXT_EXTENSION0_CHECKSUM_SIZE_BYTES 4u
+#define ROM_EXT_EXTENSION0_CHECKSUM_SIZE_WORDS 1u
+
+/**
+ * ROM_EXT manifest field extension1_offset offset from the base.
+ */
+#define ROM_EXT_EXTENSION1_OFFSET_OFFSET 832u
+
+/**
+ * ROM_EXT manifest field extension1_offset size in bytes and words.
+ */
+#define ROM_EXT_EXTENSION1_OFFSET_SIZE_BYTES 4u
+#define ROM_EXT_EXTENSION1_OFFSET_SIZE_WORDS 1u
+
+/**
+ * ROM_EXT manifest field extension1_checksum offset from the base.
+ */
+#define ROM_EXT_EXTENSION1_CHECKSUM_OFFSET 836u
+
+/**
+ * ROM_EXT manifest field extension1_checksum size in bytes and words.
+ */
+#define ROM_EXT_EXTENSION1_CHECKSUM_SIZE_BYTES 4u
+#define ROM_EXT_EXTENSION1_CHECKSUM_SIZE_WORDS 1u
+
+/**
+ * ROM_EXT manifest field extension2_offset offset from the base.
+ */
+#define ROM_EXT_EXTENSION2_OFFSET_OFFSET 840u
+
+/**
+ * ROM_EXT manifest field extension2_offset size in bytes and words.
+ */
+#define ROM_EXT_EXTENSION2_OFFSET_SIZE_BYTES 4u
+#define ROM_EXT_EXTENSION2_OFFSET_SIZE_WORDS 1u
+
+/**
+ * ROM_EXT manifest field extension2_checksum offset from the base.
+ */
+#define ROM_EXT_EXTENSION2_CHECKSUM_OFFSET 844u
+
+/**
+ * ROM_EXT manifest field extension2_checksum size in bytes and words.
+ */
+#define ROM_EXT_EXTENSION2_CHECKSUM_SIZE_BYTES 4u
+#define ROM_EXT_EXTENSION2_CHECKSUM_SIZE_WORDS 1u
+
+/**
+ * ROM_EXT manifest field extension3_offset offset from the base.
+ */
+#define ROM_EXT_EXTENSION3_OFFSET_OFFSET 848u
+
+/**
+ * ROM_EXT manifest field extension3_offset size in bytes and words.
+ */
+#define ROM_EXT_EXTENSION3_OFFSET_SIZE_BYTES 4u
+#define ROM_EXT_EXTENSION3_OFFSET_SIZE_WORDS 1u
+
+/**
+ * ROM_EXT manifest field extension3_checksum offset from the base.
+ */
+#define ROM_EXT_EXTENSION3_CHECKSUM_OFFSET 852u
+
+/**
+ * ROM_EXT manifest field extension3_checksum size in bytes and words.
+ */
+#define ROM_EXT_EXTENSION3_CHECKSUM_SIZE_BYTES 4u
+#define ROM_EXT_EXTENSION3_CHECKSUM_SIZE_WORDS 1u
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_ROM_EXTS_MANIFEST_H_

--- a/sw/device/rom_exts/meson.build
+++ b/sw/device/rom_exts/meson.build
@@ -14,6 +14,19 @@ rom_ext_link_args = [
 ]
 rom_ext_link_deps = [rom_ext_linkfile]
 
+# ROM_EXT manifest parser.
+rom_ext_manifest_parser = declare_dependency(
+  link_with: static_library(
+    'rom_ext_manifest_parser',
+    sources: [
+      'rom_ext_manifest_parser.c',
+    ],
+    dependencies: [
+      sw_lib_mmio,
+    ],
+  )
+)
+
 foreach device_name, device_lib : sw_lib_arch_core_devices
   rom_ext_elf = executable(
     'rom_ext_' + device_name,

--- a/sw/device/rom_exts/rom_ext_manifest_parser.c
+++ b/sw/device/rom_exts/rom_ext_manifest_parser.c
@@ -1,0 +1,146 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/rom_exts/rom_ext_manifest_parser.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/rom_exts/manifest.h"
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+const rom_ext_manifest_slot_t kRomExtManifestSlotA =
+    TOP_EARLGREY_EFLASH_BASE_ADDR;
+const rom_ext_manifest_slot_t kRomExtManifestSlotB =
+    TOP_EARLGREY_EFLASH_BASE_ADDR + (TOP_EARLGREY_EFLASH_SIZE_BYTES / 2);
+
+_Static_assert((TOP_EARLGREY_EFLASH_SIZE_BYTES % 2) == 0,
+               "Flash size is not divisible by 2");
+
+rom_ext_manifest_t rom_ext_get_parameters(rom_ext_manifest_slot_t slot) {
+  if (kRomExtManifestSlotA) {
+    return (rom_ext_manifest_t){
+        .base_addr = mmio_region_from_addr(kRomExtManifestSlotA),
+        .slot = kRomExtManifestSlotA,
+    };
+  } else {
+    return (rom_ext_manifest_t){
+        .base_addr = mmio_region_from_addr(kRomExtManifestSlotB),
+        .slot = kRomExtManifestSlotB,
+    };
+  }
+}
+
+uint32_t rom_ext_get_identifier(rom_ext_manifest_t params) {
+  return mmio_region_read32(params.base_addr,
+                            ROM_EXT_MANIFEST_IDENTIFIER_OFFSET);
+}
+
+bool rom_ext_get_signature(rom_ext_manifest_t params,
+                           rom_ext_signature_t *dst) {
+  if (dst == NULL) {
+    return false;
+  }
+
+  mmio_region_memcpy_from_mmio32(params.base_addr,
+                                 ROM_EXT_IMAGE_SIGNATURE_OFFSET, &dst->data[0],
+                                 ROM_EXT_IMAGE_SIGNATURE_SIZE_BYTES);
+
+  return true;
+}
+
+uint32_t rom_ext_get_image_len(rom_ext_manifest_t params) {
+  return mmio_region_read32(params.base_addr, ROM_EXT_IMAGE_LENGTH_OFFSET);
+}
+
+uint32_t rom_ext_get_version(rom_ext_manifest_t params) {
+  return mmio_region_read32(params.base_addr, ROM_EXT_IMAGE_VERSION_OFFSET);
+}
+
+uint64_t rom_ext_get_timestamp(rom_ext_manifest_t params) {
+  uint32_t timestamp_low =
+      mmio_region_read32(params.base_addr, ROM_EXT_IMAGE_TIMESTAMP_OFFSET);
+
+  ptrdiff_t offset_high = ROM_EXT_IMAGE_TIMESTAMP_OFFSET + sizeof(uint32_t);
+  uint32_t timestamp_high = mmio_region_read32(params.base_addr, offset_high);
+
+  return ((uint64_t)timestamp_high << 32) | timestamp_low;
+}
+
+uint32_t rom_ext_get_algorithm_id(rom_ext_manifest_t params) {
+  return mmio_region_read32(params.base_addr,
+                            ROM_EXT_SIGNATURE_ALGORITHM_IDENTIFIER_OFFSET);
+}
+
+uint32_t rom_ext_get_exponent(rom_ext_manifest_t params) {
+  return mmio_region_read32(params.base_addr, ROM_EXT_EXPONENT_OFFSET);
+}
+
+uint32_t rom_ext_get_usage_constraints(rom_ext_manifest_t params) {
+  return mmio_region_read32(params.base_addr, ROM_EXT_USAGE_CONSTRAINTS_OFFSET);
+}
+
+bool rom_ext_get_peripheral_lockdown_info(rom_ext_manifest_t params,
+                                          rom_ext_lockdown_info_t *dst) {
+  if (dst == NULL) {
+    return false;
+  }
+
+  mmio_region_memcpy_from_mmio32(
+      params.base_addr, ROM_EXT_PERIPHERAL_LOCKDOWN_INFO_OFFSET, &dst->data[0],
+      ROM_EXT_PERIPHERAL_LOCKDOWN_INFO_SIZE_BYTES);
+
+  return true;
+}
+
+bool rom_ext_get_public_key(rom_ext_manifest_t params,
+                            rom_ext_public_key_t *dst) {
+  if (dst == NULL) {
+    return false;
+  }
+
+  mmio_region_memcpy_from_mmio32(
+      params.base_addr, ROM_EXT_SIGNATURE_PUBLIC_KEY_OFFSET, &dst->data[0],
+      ROM_EXT_SIGNATURE_PUBLIC_KEY_SIZE_BYTES);
+
+  return true;
+}
+
+bool rom_ext_get_extension(rom_ext_manifest_t params, rom_ext_extension_id_t id,
+                           rom_ext_extension_t *extension) {
+  if (extension == NULL) {
+    return false;
+  }
+
+  uint32_t offset = 0;
+  uint32_t checksum = 0;
+  switch (id) {
+    case kRomExtExtensionId0:
+      offset = ROM_EXT_EXTENSION0_OFFSET_OFFSET;
+      checksum = ROM_EXT_EXTENSION0_CHECKSUM_OFFSET;
+      break;
+    case kRomExtExtensionId1:
+      offset = ROM_EXT_EXTENSION1_OFFSET_OFFSET;
+      checksum = ROM_EXT_EXTENSION1_CHECKSUM_OFFSET;
+      break;
+    case kRomExtExtensionId2:
+      offset = ROM_EXT_EXTENSION2_OFFSET_OFFSET;
+      checksum = ROM_EXT_EXTENSION2_CHECKSUM_OFFSET;
+      break;
+    case kRomExtExtensionId3:
+      offset = ROM_EXT_EXTENSION3_OFFSET_OFFSET;
+      checksum = ROM_EXT_EXTENSION3_CHECKSUM_OFFSET;
+      break;
+    default:
+      return false;
+  }
+
+  uint32_t extension_offset = mmio_region_read32(params.base_addr, offset);
+
+  extension->address = (void *)(extension_offset + params.slot);
+  extension->checksum = mmio_region_read32(params.base_addr, checksum);
+
+  return true;
+}

--- a/sw/device/rom_exts/rom_ext_manifest_parser.h
+++ b/sw/device/rom_exts/rom_ext_manifest_parser.h
@@ -1,0 +1,239 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_ROM_EXTS_ROM_EXT_MANIFEST_PARSER_H_
+#define OPENTITAN_SW_DEVICE_ROM_EXTS_ROM_EXT_MANIFEST_PARSER_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/rom_exts/manifest.h"
+
+// Header Extern Guard (so header can be used from C and C++)
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * ROM Extension manifest slot type.
+ */
+typedef uintptr_t rom_ext_manifest_slot_t;
+
+/**
+ * ROM Extension manifest slots base addresses.
+ *
+ * These are intended to be used as an input parameter to
+ * `rom_ext_parameters_get`.
+ */
+extern const rom_ext_manifest_slot_t kRomExtManifestSlotA;
+extern const rom_ext_manifest_slot_t kRomExtManifestSlotB;
+
+/**
+ * ROM Extension parameters required for the manifest parsing.
+ */
+typedef struct rom_ext_manifest {
+  /**
+   * Base address of the manifest in memory.
+   */
+  mmio_region_t base_addr;
+  rom_ext_manifest_slot_t slot;
+} rom_ext_manifest_t;
+
+/**
+ * ROM Extension image signature.
+ */
+typedef struct rom_ext_signature {
+  uint32_t data[ROM_EXT_IMAGE_SIGNATURE_SIZE_WORDS];
+} rom_ext_signature_t;
+
+/**
+ * ROM Extension lockdown information.
+ *
+ * TODO - probably would eventually become an internal type, and there will
+ *        be another public type with more finely parsed information.
+ */
+typedef struct rom_ext_lockdown_info {
+  uint32_t data[ROM_EXT_PERIPHERAL_LOCKDOWN_INFO_SIZE_WORDS];
+} rom_ext_lockdown_info_t;
+
+/**
+ * ROM Extension public key.
+ */
+typedef struct rom_ext_public_key {
+  uint32_t data[ROM_EXT_SIGNATURE_PUBLIC_KEY_SIZE_WORDS];
+} rom_ext_public_key_t;
+
+/**
+ * ROM Extension image extension IDs.
+ */
+typedef enum rom_ext_extension_id {
+  /**
+   * Image extension 0.
+   */
+  kRomExtExtensionId0 = 0,
+  /**
+   * Image extension 1.
+   */
+  kRomExtExtensionId1,
+  /**
+   * Image extension 2.
+   */
+  kRomExtExtensionId2,
+  /**
+   * Image extension 3.
+   */
+  kRomExtExtensionId3,
+} rom_ext_extension_id_t;
+
+/**
+ * ROM Extension image extension.
+ */
+typedef struct rom_ext_extension {
+  /**
+   * Image extension address in memory.
+   */
+  void *address;
+  /**
+   * Image extension checksum.
+   */
+  uint32_t checksum;
+} rom_ext_extension_t;
+
+/**
+ * Creates the ROM extension manifest parameters.
+ *
+ * Required for all ROM Extension manifest parser API.
+ *
+ * @param slot ROM Extension manifest slot base address.
+ * @return `rom_ext_manifest_t`.
+ */
+rom_ext_manifest_t rom_ext_get_parameters(rom_ext_manifest_slot_t slot);
+
+/**
+ * Retrieves the ROM_EXT identifier.
+ *
+ * The memory address where ROM_EXT identifier field resides, is relative.
+ *
+ * @param params Parameters required for manifest parsing.
+ * @return ROM_EXT identifier.
+ */
+uint32_t rom_ext_get_identifier(rom_ext_manifest_t params);
+
+/**
+ * Retrieves the ROM_EXT signature.
+ *
+ * The memory address where ROM_EXT identifier field resides, is relative.
+ *
+ * @param params Parameters required for manifest parsing.
+ * @param dst The destination address where the signature is coppied to.
+ * @return `true` on success, `false` on failure.
+ */
+bool rom_ext_get_signature(rom_ext_manifest_t params, rom_ext_signature_t *dst);
+
+/**
+ * Retrieves the ROM_EXT image length.
+ *
+ * The memory address where ROM_EXT image length field resides, is relative.
+ *
+ * @param params Parameters required for manifest parsing.
+ * @return ROM_EXT image length.
+ */
+uint32_t rom_ext_get_image_len(rom_ext_manifest_t params);
+
+/**
+ * Retrieves the ROM_EXT image version.
+ *
+ * The memory address where ROM_EXT image version field resides, is relative.
+ *
+ * @param params Parameters required for manifest parsing.
+ * @return ROM_EXT image version.
+ */
+uint32_t rom_ext_get_version(rom_ext_manifest_t params);
+
+/**
+ * Retrieves the ROM_EXT image timestamp.
+ *
+ * The memory address where ROM_EXT image timestamp field resides, is relative.
+ *
+ * @param params Parameters required for manifest parsing.
+ * @return ROM_EXT image timestamp.
+ */
+uint64_t rom_ext_get_timestamp(rom_ext_manifest_t params);
+
+/**
+ * Retrieves the ROM_EXT signature algorithm identifier.
+ *
+ * The memory address where ROM_EXT signature algorithm identifier field
+ * resides, is relative.
+ *
+ * @param params Parameters required for manifest parsing.
+ * @return ROM_EXT signature algorithm identifier.
+ */
+uint32_t rom_ext_get_algorithm_id(rom_ext_manifest_t params);
+
+/**
+ * Retrieves the ROM_EXT exponent.
+ *
+ * The memory address where ROM_EXT exponent field resides, is relative.
+ *
+ * @param params Parameters required for manifest parsing.
+ * @return ROM_EXT exponent.
+ */
+uint32_t rom_ext_get_exponent(rom_ext_manifest_t params);
+
+/**
+ * Retrieves the ROM_EXT usage constraints.
+ *
+ * The memory address where ROM_EXT usage constraints field resides, is
+ * relative.
+ *
+ * @param params Parameters required for manifest parsing.
+ * @return ROM_EXT usage constraints.
+ */
+uint32_t rom_ext_get_usage_constraints(rom_ext_manifest_t params);
+
+/**
+ * Retrieves the ROM_EXT lockdown info.
+ *
+ * The memory address where ROM_EXT lockdown info field resides, is relative.
+ *
+ * @param params Parameters required for manifest parsing.
+ * @param dst The destination address where the lockdown info is coppied to.
+ * @return `true` on success, `false` on failure.
+ */
+bool rom_ext_get_peripheral_lockdown_info(rom_ext_manifest_t params,
+                                          rom_ext_lockdown_info_t *dst);
+
+/**
+ * Retrieves the ROM_EXT public key.
+ *
+ * The memory address where ROM_EXT public key field resides, is relative.
+ *
+ * @param params Parameters required for manifest parsing.
+ * @param dst The destination address where the public key is coppied to.
+ * @return `true` on success, `false` on failure.
+ */
+bool rom_ext_get_public_key(rom_ext_manifest_t params,
+                            rom_ext_public_key_t *dst);
+
+/**
+ * Retrieves the ROM_EXT image extension specified in `id`.
+ *
+ * The memory address where ROM_EXT image extension information fields reside,
+ * is relative.
+ *
+ * @param params Parameters required for manifest parsing.
+ * @param id Extension identifier.
+ * @param extension Parsed `rom_ext_extension_t` output.
+ * @return `true` on success, `false` on failure.
+ */
+bool rom_ext_get_extension(rom_ext_manifest_t params, rom_ext_extension_id_t id,
+                           rom_ext_extension_t *extension);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_ROM_EXTS_ROM_EXT_MANIFEST_PARSER_H_

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -11,6 +11,7 @@ sw_tests = {
 }
 
 subdir('dif')
+subdir('rom_ext')
 subdir('runtime')
 subdir('sim_dv')
 

--- a/sw/device/tests/rom_ext/meson.build
+++ b/sw/device/tests/rom_ext/meson.build
@@ -1,0 +1,26 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# All tests added to this dictionary will result in build targets that have
+# names starting `sw/device/tests/rom_ext/<test_name>`. They will not contain
+# the subdirectory name, because the build targets are really declared at the
+# bottom of this file, rather than in the subdirectories.
+rom_ext_tests = {
+  # 'test_name': test_lib,
+}
+
+test('rom_ext_parser_unittest', executable(
+  'rom_ext_parser_unittest',
+  sources: [
+    'rom_ext_parser_unittest.cc',
+    meson.source_root() / 'sw/device/rom_exts/rom_ext_manifest_parser.c',
+  ],
+  dependencies: [
+    sw_vendor_gtest,
+    sw_lib_testing_mock_mmio,
+  ],
+  native: true,
+  c_args: ['-DMOCK_MMIO'],
+  cpp_args: ['-DMOCK_MMIO'],
+))

--- a/sw/device/tests/rom_ext/rom_ext_parser_unittest.cc
+++ b/sw/device/tests/rom_ext/rom_ext_parser_unittest.cc
@@ -1,0 +1,230 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/rom_exts/rom_ext_manifest_parser.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/testing/mock_mmio.h"
+#include "sw/device/rom_exts/manifest.h"
+
+namespace rom_ext_parser_unittest {
+namespace {
+using mock_mmio::MmioTest;
+using mock_mmio::MockDevice;
+using testing::Each;
+using testing::ElementsAreArray;
+using testing::Eq;
+using testing::Test;
+
+class ParserTest : public Test, public MmioTest {
+ protected:
+  rom_ext_manifest_t params_ = {
+      .base_addr =
+          (mmio_region_t){
+              .mock = dev().region(),
+          },
+      .slot = kRomExtManifestSlotA,
+  };
+};
+
+class IdentifierGetTest : public ParserTest {};
+
+TEST_F(IdentifierGetTest, Success) {
+  EXPECT_READ32(ROM_EXT_MANIFEST_IDENTIFIER_OFFSET, 0xa5a5a5a5);
+  EXPECT_EQ(rom_ext_get_identifier(params_), 0xa5a5a5a5);
+}
+
+class SignatureGetTest : public ParserTest {
+ protected:
+  SignatureGetTest() {
+    for (uint32_t i = 0; i < kSizeInWords_; ++i) {
+      src_.data[i] = dev().GarbageMemory<uint32_t>();
+    }
+  }
+
+  const uint32_t kSizeInWords_ = ROM_EXT_IMAGE_SIGNATURE_SIZE_WORDS;
+  rom_ext_signature_t src_;
+};
+
+TEST_F(SignatureGetTest, NullArgs) {
+  EXPECT_FALSE(rom_ext_get_signature(params_, nullptr));
+}
+
+TEST_F(SignatureGetTest, Success) {
+  rom_ext_signature_t dst;
+
+  auto offset_word_0 = ROM_EXT_IMAGE_SIGNATURE_OFFSET;
+  for (size_t i = 0; i < kSizeInWords_; ++i) {
+    auto offset = offset_word_0 + (i * sizeof(uint32_t));
+    EXPECT_READ32(offset, src_.data[i]);
+  }
+
+  EXPECT_TRUE(rom_ext_get_signature(params_, &dst));
+  EXPECT_THAT(src_.data, ElementsAreArray(dst.data));
+}
+
+class ImageLengthGetTest : public ParserTest {};
+
+TEST_F(ImageLengthGetTest, Success) {
+  EXPECT_READ32(ROM_EXT_IMAGE_LENGTH_OFFSET, 0xa5a5a5a5);
+  EXPECT_EQ(rom_ext_get_image_len(params_), 0xa5a5a5a5);
+}
+
+class ImageVersionGetTest : public ParserTest {};
+
+TEST_F(ImageVersionGetTest, Success) {
+  EXPECT_READ32(ROM_EXT_IMAGE_VERSION_OFFSET, 0xa5a5a5a5);
+  EXPECT_EQ(rom_ext_get_version(params_), 0xa5a5a5a5);
+}
+
+class ImageTimestampGetTest : public ParserTest {};
+
+TEST_F(ImageTimestampGetTest, Success) {
+  EXPECT_READ32(ROM_EXT_IMAGE_TIMESTAMP_OFFSET, 0xcdcdcdcd);
+  EXPECT_READ32(ROM_EXT_IMAGE_TIMESTAMP_OFFSET + sizeof(uint32_t), 0xabababab);
+
+  EXPECT_EQ(rom_ext_get_timestamp(params_), 0xababababcdcdcdcd);
+}
+
+class AlgorithmIdGetTest : public ParserTest {};
+
+TEST_F(AlgorithmIdGetTest, Success) {
+  EXPECT_READ32(ROM_EXT_SIGNATURE_ALGORITHM_IDENTIFIER_OFFSET, 0xa5a5a5a5);
+  EXPECT_EQ(rom_ext_get_algorithm_id(params_), 0xa5a5a5a5);
+}
+
+class ExponentGetTest : public ParserTest {};
+
+TEST_F(ExponentGetTest, Success) {
+  EXPECT_READ32(ROM_EXT_EXPONENT_OFFSET, 0xa5a5a5a5);
+  EXPECT_EQ(rom_ext_get_exponent(params_), 0xa5a5a5a5);
+}
+
+class UsageConstraintsGetTest : public ParserTest {};
+
+TEST_F(UsageConstraintsGetTest, Success) {
+  EXPECT_READ32(ROM_EXT_USAGE_CONSTRAINTS_OFFSET, 0xa5a5a5a5);
+  EXPECT_EQ(rom_ext_get_usage_constraints(params_), 0xa5a5a5a5);
+}
+
+class PeripheralLockdownInfoGetTest : public ParserTest {
+ protected:
+  PeripheralLockdownInfoGetTest() {
+    for (uint32_t i = 0; i < kSizeInWords_; ++i) {
+      src_.data[i] = dev().GarbageMemory<uint32_t>();
+    }
+  }
+
+  const uint32_t kSizeInWords_ = ROM_EXT_PERIPHERAL_LOCKDOWN_INFO_SIZE_WORDS;
+  rom_ext_lockdown_info_t src_;
+};
+
+TEST_F(PeripheralLockdownInfoGetTest, NullArgs) {
+  EXPECT_FALSE(rom_ext_get_peripheral_lockdown_info(params_, nullptr));
+}
+
+TEST_F(PeripheralLockdownInfoGetTest, Success) {
+  rom_ext_lockdown_info_t dst;
+
+  auto offset_word_0 = ROM_EXT_PERIPHERAL_LOCKDOWN_INFO_OFFSET;
+  for (size_t i = 0; i < kSizeInWords_; ++i) {
+    auto offset = offset_word_0 + (i * sizeof(uint32_t));
+    EXPECT_READ32(offset, src_.data[i]);
+  }
+
+  EXPECT_TRUE(rom_ext_get_peripheral_lockdown_info(params_, &dst));
+  EXPECT_THAT(src_.data, ElementsAreArray(dst.data));
+}
+
+class PublicKeyGetTest : public ParserTest {
+ protected:
+  PublicKeyGetTest() {
+    for (uint32_t i = 0; i < kSizeInWords_; ++i) {
+      src_.data[i] = dev().GarbageMemory<uint32_t>();
+    }
+  }
+
+  const uint32_t kSizeInWords_ = ROM_EXT_SIGNATURE_PUBLIC_KEY_SIZE_WORDS;
+  rom_ext_public_key_t src_;
+};
+
+TEST_F(PublicKeyGetTest, NullArgs) {
+  EXPECT_FALSE(rom_ext_get_public_key(params_, nullptr));
+}
+
+TEST_F(PublicKeyGetTest, Success) {
+  rom_ext_public_key_t dst;
+
+  auto offset_word_0 = ROM_EXT_SIGNATURE_PUBLIC_KEY_OFFSET;
+  for (size_t i = 0; i < kSizeInWords_; ++i) {
+    auto offset = offset_word_0 + (i * sizeof(uint32_t));
+    EXPECT_READ32(offset, src_.data[i]);
+  }
+
+  EXPECT_TRUE(rom_ext_get_public_key(params_, &dst));
+  EXPECT_THAT(src_.data, ElementsAreArray(dst.data));
+}
+
+class ExtensionGetTest : public ParserTest {
+ protected:
+  testing::Matcher<rom_ext_extension_t> Eq(const rom_ext_extension_t &rhs) {
+    return testing::AllOf(
+        testing::Field("checksum", &rom_ext_extension_t::checksum,
+                       rhs.checksum),
+        testing::Field("address", &rom_ext_extension_t::address, rhs.address));
+  }
+};
+
+TEST_F(ExtensionGetTest, NullArgs) {
+  EXPECT_FALSE(rom_ext_get_extension(params_, kRomExtExtensionId0, nullptr));
+  EXPECT_FALSE(rom_ext_get_extension(params_, kRomExtExtensionId1, nullptr));
+  EXPECT_FALSE(rom_ext_get_extension(params_, kRomExtExtensionId2, nullptr));
+  EXPECT_FALSE(rom_ext_get_extension(params_, kRomExtExtensionId3, nullptr));
+}
+
+TEST_F(ExtensionGetTest, Success) {
+  EXPECT_READ32(ROM_EXT_EXTENSION0_OFFSET_OFFSET, 0x10);
+  EXPECT_READ32(ROM_EXT_EXTENSION0_CHECKSUM_OFFSET, 0xbbbbbbbb);
+
+  rom_ext_extension_t ext0;
+  rom_ext_extension_t ext0_expected = {
+      .address = (void *)(kRomExtManifestSlotA + 0x10), .checksum = 0xbbbbbbbb,
+  };
+  EXPECT_TRUE(rom_ext_get_extension(params_, kRomExtExtensionId0, &ext0));
+  EXPECT_THAT(ext0, Eq(ext0_expected));
+
+  EXPECT_READ32(ROM_EXT_EXTENSION1_OFFSET_OFFSET, 0x20);
+  EXPECT_READ32(ROM_EXT_EXTENSION1_CHECKSUM_OFFSET, 0xdddddddd);
+
+  rom_ext_extension_t ext1;
+  rom_ext_extension_t ext1_expected = {
+      .address = (void *)(kRomExtManifestSlotA + 0x20), .checksum = 0xdddddddd,
+  };
+  EXPECT_TRUE(rom_ext_get_extension(params_, kRomExtExtensionId1, &ext1));
+  EXPECT_THAT(ext1, Eq(ext1_expected));
+
+  EXPECT_READ32(ROM_EXT_EXTENSION2_OFFSET_OFFSET, 0x30);
+  EXPECT_READ32(ROM_EXT_EXTENSION2_CHECKSUM_OFFSET, 0xffffffff);
+
+  rom_ext_extension_t ext2;
+  rom_ext_extension_t ext2_expected = {
+      .address = (void *)(kRomExtManifestSlotA + 0x30), .checksum = 0xffffffff,
+  };
+  EXPECT_TRUE(rom_ext_get_extension(params_, kRomExtExtensionId2, &ext2));
+  EXPECT_THAT(ext2, Eq(ext2_expected));
+
+  EXPECT_READ32(ROM_EXT_EXTENSION3_OFFSET_OFFSET, 0x40);
+  EXPECT_READ32(ROM_EXT_EXTENSION3_CHECKSUM_OFFSET, 0x66666666);
+
+  rom_ext_extension_t ext3;
+  rom_ext_extension_t ext3_expected = {
+      .address = (void *)(kRomExtManifestSlotA + 0x40), .checksum = 0x66666666,
+  };
+  EXPECT_TRUE(rom_ext_get_extension(params_, kRomExtExtensionId3, &ext3));
+  EXPECT_THAT(ext3, Eq(ext3_expected));
+}
+
+}  // namespace
+}  // namespace rom_ext_parser_unittest


### PR DESCRIPTION
# ROM_EXT manifest parser

This library is intended to be used in Mask ROM, and also ROM_EXT itself. The API consists of a getter function for every ROM_EXT manifest field.

## Unittest

This PR contains a unittest for the manifest parser, which resides under `sw/test/rom_ext`, and otherwise is no different from the DIF unittests.

## manifest.h

`manifest.h` is an autogenerated file - taken from [ROM_EXT manifest generator change](https://github.com/lowRISC/opentitan/pull/3576).