### PR TITLE
[util] Instantiate DIF Checklist Too

### DIFF
--- a/sw/device/lib/dif/README.md
+++ b/sw/device/lib/dif/README.md
@@ -13,6 +13,19 @@ There is one DIF library per hardware IP, and each one contains the DIFs
 required to actuate all of the specification-required functionality of the
 hardware they are written for.
 
+## New DIFs
+
+Developers should use the `util/make_new_dif.py` script to instantiate some
+DIF-related templates which follow the guidance below. The script will create:
+
+*   A Header for the DIF, based on [`dif_template.h.tpl`](./dif_template.h.tpl).
+*   A Checklist for the DIF, based on `doc/project/sw_checklist.md.tpl`.
+
+These files will need checking and editing, but the templates serve to avoid
+most of the copy/paste required.
+
+Further documentation for the script is provided in the script's source.
+
 ## Checklists
 
 This directory also contains checklists for each DIF, in markdown format. They
@@ -67,8 +80,6 @@ Notational caveats:
   `result_t`.
 * Unless otherwise noted, all symbols mentioned below are required.
 
-[`dif_template.h.tpl`](./dif_tempalte.h.tpl) provides a starting point for
-building a DIF library that conforms to this guidance.
 
 #### Base Types
 

--- a/sw/device/lib/dif/dif_template.h.tpl
+++ b/sw/device/lib/dif/dif_template.h.tpl
@@ -9,10 +9,7 @@
 // building a DIF for a new peripheral, defining all of the declarations that
 // would be expected of a DIF library as described in the README.md.
 //
-// To instantiate this for a new IP named my_ip, run the command
-// $ util/make_new_dif.py --ip my_ip --peripheral "my peripheral"
-// where "my peripheral" is a documentation-friendly name for your peripheral.
-// Compare "pwrmgr" and "power manager".
+// This file should be instantiated with the `util/make_new_dif.py` script.
 //
 // The script also includes additional options for controlling how the tempalte
 // is instantiated. After the script runs, delete this comment, the #error


### PR DESCRIPTION
The SW Checklist was also originally created as a Mako template. This
commit ensures it will be instantated by the `make_new_dif.py` script in
addition to the header template.

Given these changes, it seemed prudent to move the docs into the script,
and document the script in `sw/lib/device/dif/README.md`.
