### PR TITLE
[dv/common] Fix response queue overflow

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_vseq__tl_errors.svh
+++ b/hw/dv/sv/cip_lib/cip_base_vseq__tl_errors.svh
@@ -27,6 +27,8 @@ virtual task tl_access_unmapped_addr();
   // randomize unmapped_addr first to improve perf
   repeat ($urandom_range(10, 100)) begin
     bit [BUS_AW-1:0] unmapped_addr;
+
+    if (cfg.under_reset) return;
     `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(unmapped_addr,
         !((unmapped_addr & csr_addr_mask) inside {normalized_csr_addrs});
         foreach (updated_mem_ranges[i]) {
@@ -41,6 +43,7 @@ endtask
 
 virtual task tl_write_csr_word_unaligned_addr();
   repeat ($urandom_range(10, 100)) begin
+    if (cfg.under_reset) return;
     `create_tl_access_error_case(
         tl_write_csr_word_unaligned_addr,
         opcode inside {tlul_pkg::PutFullData, tlul_pkg::PutPartialData};
@@ -59,6 +62,8 @@ virtual task tl_write_less_than_csr_width();
     dv_base_reg      csr;
     uint             msb_pos;
     bit [BUS_AW-1:0] addr;
+
+    if (cfg.under_reset) return;
     `DV_CHECK_FATAL($cast(csr, all_csrs[i]))
     msb_pos = csr.get_msb_pos();
     addr    = csr.get_address();
@@ -81,6 +86,7 @@ endtask
 
 virtual task tl_protocol_err();
   repeat ($urandom_range(10, 100)) begin
+    if (cfg.under_reset) return;
     `create_tl_access_error_case(
         tl_protocol_err, , tl_host_protocol_err_seq
         )
@@ -91,6 +97,7 @@ virtual task tl_write_mem_less_than_word();
   uint mem_idx;
   dv_base_mem mem;
   repeat ($urandom_range(10, 100)) begin
+    if (cfg.under_reset) return;
     // if more than one memories, randomly select one memory
     mem_idx = $urandom_range(0, cfg.mem_ranges.size - 1);
     // only test when mem doesn't support partial write
@@ -111,6 +118,7 @@ endtask
 virtual task tl_read_mem_err();
   uint mem_idx;
   repeat ($urandom_range(10, 100)) begin
+    if (cfg.under_reset) return;
     // if more than one memories, randomly select one memory
     mem_idx = $urandom_range(0, cfg.mem_ranges.size - 1);
     if (get_mem_access_by_addr(ral, cfg.mem_ranges[mem_idx].start_addr) != "WO") continue;

--- a/hw/dv/sv/tl_agent/tl_host_driver.sv
+++ b/hw/dv/sv/tl_agent/tl_host_driver.sv
@@ -92,7 +92,6 @@ class tl_host_driver extends tl_base_driver;
         cfg.vif.host_cb.h2d_int.a_source  <= req.a_source;
         cfg.vif.host_cb.h2d_int.a_valid   <= 1'b1;
       end else begin
-        seq_item_port.put_response(req); // if reset, skip data phase
         req_done = 1;
       end
       // drop valid if it lasts for a_valid_len, even there is no a_ready
@@ -105,6 +104,8 @@ class tl_host_driver extends tl_base_driver;
       invalidate_a_channel();
     end
     seq_item_port.item_done();
+    // if reset, skip data phase
+    if (reset_asserted) seq_item_port.put_response(req);
     `uvm_info(get_full_name(), $sformatf("Req sent: %0s", req.convert2string()), UVM_HIGH)
   endtask : send_a_channel_request
 


### PR DESCRIPTION
1. move put_response after item_done when reset occurs. This will fix
today's "Response queue overflow" error in regression.
2. stop sending tl error transactions when reset occurs, so that log can
be cleaner when high verbosity is enabled

Signed-off-by: Weicai Yang <weicai@google.com>