### PR TITLE
[dif] Move `dif_plic.h` to the new names.

### DIFF
--- a/sw/device/lib/dif/dif_plic.c
+++ b/sw/device/lib/dif/dif_plic.c
@@ -8,7 +8,9 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "sw/device/lib/base/bitfield.h"
 #include "sw/device/lib/base/mmio.h"
+
 #include "rv_plic_regs.h"  // Generated.
 
 // If either of these static assertions fail, then the assumptions in this DIF
@@ -147,48 +149,49 @@ static void plic_reset(const dif_plic_t *plic) {
   // Clear all of the Interrupt Enable registers.
   for (int i = 0; i < RV_PLIC_IE0_MULTIREG_COUNT; ++i) {
     ptrdiff_t offset = RV_PLIC_IE0_0_REG_OFFSET + (i * sizeof(uint32_t));
-    mmio_region_write32(plic->base_addr, offset, 0);
+    mmio_region_write32(plic->params.base_addr, offset, 0);
   }
 
   // Clear all of the Level/Edge registers.
   for (int i = 0; i < RV_PLIC_LE_MULTIREG_COUNT; ++i) {
     ptrdiff_t offset = RV_PLIC_LE_0_REG_OFFSET + (i * sizeof(uint32_t));
-    mmio_region_write32(plic->base_addr, offset, 0);
+    mmio_region_write32(plic->params.base_addr, offset, 0);
   }
 
   // Clear all of the priority registers.
   for (int i = 0; i < RV_PLIC_PARAM_NUMSRC; ++i) {
     ptrdiff_t offset = plic_priority_reg_offset(i);
-    mmio_region_write32(plic->base_addr, offset, 0);
+    mmio_region_write32(plic->params.base_addr, offset, 0);
   }
 
   // Clear all of the target threshold registers.
   for (dif_plic_target_t target = 0; target < RV_PLIC_PARAM_NUMTARGET;
        ++target) {
     ptrdiff_t offset = plic_target_reg_offsets[target].threshold;
-    mmio_region_write32(plic->base_addr, offset, 0);
+    mmio_region_write32(plic->params.base_addr, offset, 0);
   }
 
   // Clear software interrupt pending register.
-  mmio_region_write32(plic->base_addr, RV_PLIC_MSIP0_REG_OFFSET, 0);
+  mmio_region_write32(plic->params.base_addr, RV_PLIC_MSIP0_REG_OFFSET, 0);
 }
 
-dif_plic_result_t dif_plic_init(mmio_region_t base_addr, dif_plic_t *plic) {
+dif_plic_result_t dif_plic_init(dif_plic_params_t params, dif_plic_t *plic) {
   if (plic == NULL) {
     return kDifPlicBadArg;
   }
 
-  plic->base_addr = base_addr;
+  plic->params = params;
 
+  // TODO: Move this out into its own function.
   plic_reset(plic);
 
   return kDifPlicOk;
 }
 
-dif_plic_result_t dif_plic_irq_enable_set(const dif_plic_t *plic,
-                                          dif_plic_irq_id_t irq,
-                                          dif_plic_target_t target,
-                                          dif_plic_enable_t enable) {
+dif_plic_result_t dif_plic_irq_get_enabled(const dif_plic_t *plic,
+                                           dif_plic_irq_id_t irq,
+                                           dif_plic_target_t target,
+                                           dif_plic_toggle_t *state) {
   if (plic == NULL || irq >= RV_PLIC_PARAM_NUMSRC ||
       target >= RV_PLIC_PARAM_NUMTARGET) {
     return kDifPlicBadArg;
@@ -198,20 +201,45 @@ dif_plic_result_t dif_plic_irq_enable_set(const dif_plic_t *plic,
   plic_reg_info_t reg_info;
   plic_irq_enable_reg_info(irq, target, &reg_info);
 
-  if (enable == kDifPlicEnable) {
-    mmio_region_nonatomic_set_bit32(plic->base_addr, reg_info.offset,
-                                    reg_info.bit_index);
-  } else {
-    mmio_region_nonatomic_clear_bit32(plic->base_addr, reg_info.offset,
+  uint32_t reg = mmio_region_read32(plic->params.base_addr, reg_info.offset);
+  bool is_enabled = bitfield_bit32_read(reg, reg_info.bit_index);
+  *state = is_enabled ? kDifPlicToggleEnabled : kDifPlicToggleDisabled;
+
+  return kDifPlicOk;
+}
+
+dif_plic_result_t dif_plic_irq_set_enabled(const dif_plic_t *plic,
+                                           dif_plic_irq_id_t irq,
+                                           dif_plic_target_t target,
+                                           dif_plic_toggle_t state) {
+  if (plic == NULL || irq >= RV_PLIC_PARAM_NUMSRC ||
+      target >= RV_PLIC_PARAM_NUMTARGET) {
+    return kDifPlicBadArg;
+  }
+
+  // Get a target and an IRQ source specific Interrupt Enable register info.
+  plic_reg_info_t reg_info;
+  plic_irq_enable_reg_info(irq, target, &reg_info);
+
+  switch (state) {
+    case kDifPlicToggleEnabled:
+      mmio_region_nonatomic_set_bit32(plic->params.base_addr, reg_info.offset,
                                       reg_info.bit_index);
+      break;
+    case kDifPlicToggleDisabled:
+      mmio_region_nonatomic_clear_bit32(plic->params.base_addr, reg_info.offset,
+                                        reg_info.bit_index);
+      break;
+    default:
+      return kDifPlicBadArg;
   }
 
   return kDifPlicOk;
 }
 
-dif_plic_result_t dif_plic_irq_trigger_type_set(const dif_plic_t *plic,
-                                                dif_plic_irq_id_t irq,
-                                                dif_plic_enable_t enable) {
+dif_plic_result_t dif_plic_irq_set_trigger(const dif_plic_t *plic,
+                                           dif_plic_irq_id_t irq,
+                                           dif_plic_irq_trigger_t trigger) {
   if (plic == NULL || irq >= RV_PLIC_PARAM_NUMSRC) {
     return kDifPlicBadArg;
   }
@@ -220,18 +248,23 @@ dif_plic_result_t dif_plic_irq_trigger_type_set(const dif_plic_t *plic,
   plic_reg_info_t reg_info;
   plic_irq_trigger_type_reg_info(irq, &reg_info);
 
-  if (enable == kDifPlicEnable) {
-    mmio_region_nonatomic_set_bit32(plic->base_addr, reg_info.offset,
-                                    reg_info.bit_index);
-  } else {
-    mmio_region_nonatomic_clear_bit32(plic->base_addr, reg_info.offset,
+  switch (trigger) {
+    case kDifPlicIrqTriggerEdge:
+      mmio_region_nonatomic_set_bit32(plic->params.base_addr, reg_info.offset,
                                       reg_info.bit_index);
+      break;
+    case kDifPlicIrqTriggerLevel:
+      mmio_region_nonatomic_clear_bit32(plic->params.base_addr, reg_info.offset,
+                                        reg_info.bit_index);
+      break;
+    default:
+      return kDifPlicBadArg;
   }
 
   return kDifPlicOk;
 }
 
-dif_plic_result_t dif_plic_irq_priority_set(const dif_plic_t *plic,
+dif_plic_result_t dif_plic_irq_set_priority(const dif_plic_t *plic,
                                             dif_plic_irq_id_t irq,
                                             uint32_t priority) {
   if (plic == NULL || irq >= RV_PLIC_PARAM_NUMSRC ||
@@ -240,12 +273,12 @@ dif_plic_result_t dif_plic_irq_priority_set(const dif_plic_t *plic,
   }
 
   ptrdiff_t offset = plic_priority_reg_offset(irq);
-  mmio_region_write32(plic->base_addr, offset, priority);
+  mmio_region_write32(plic->params.base_addr, offset, priority);
 
   return kDifPlicOk;
 }
 
-dif_plic_result_t dif_plic_target_threshold_set(const dif_plic_t *plic,
+dif_plic_result_t dif_plic_target_set_threshold(const dif_plic_t *plic,
                                                 dif_plic_target_t target,
                                                 uint32_t threshold) {
   if (plic == NULL || target >= RV_PLIC_PARAM_NUMTARGET ||
@@ -254,27 +287,23 @@ dif_plic_result_t dif_plic_target_threshold_set(const dif_plic_t *plic,
   }
 
   ptrdiff_t threshold_offset = plic_target_reg_offsets[target].threshold;
-  mmio_region_write32(plic->base_addr, threshold_offset, threshold);
+  mmio_region_write32(plic->params.base_addr, threshold_offset, threshold);
 
   return kDifPlicOk;
 }
 
-dif_plic_result_t dif_plic_irq_pending_status_get(const dif_plic_t *plic,
-                                                  dif_plic_irq_id_t irq,
-                                                  dif_plic_flag_t *status) {
-  if (plic == NULL || irq >= RV_PLIC_PARAM_NUMSRC || status == NULL) {
+dif_plic_result_t dif_plic_irq_is_pending(const dif_plic_t *plic,
+                                          dif_plic_irq_id_t irq,
+                                          bool *is_pending) {
+  if (plic == NULL || irq >= RV_PLIC_PARAM_NUMSRC || is_pending == NULL) {
     return kDifPlicBadArg;
   }
 
   plic_reg_info_t reg_info;
   plic_irq_pending_reg_info(irq, &reg_info);
 
-  if (mmio_region_get_bit32(plic->base_addr, reg_info.offset,
-                            reg_info.bit_index)) {
-    *status = kDifPlicSet;
-  } else {
-    *status = kDifPlicUnset;
-  }
+  *is_pending = mmio_region_get_bit32(plic->params.base_addr, reg_info.offset,
+                                      reg_info.bit_index);
 
   return kDifPlicOk;
 }
@@ -288,7 +317,7 @@ dif_plic_result_t dif_plic_irq_claim(const dif_plic_t *plic,
 
   // Get an IRQ ID from the target specific CC register.
   ptrdiff_t cc_offset = plic_target_reg_offsets[target].cc;
-  uint32_t irq_id = mmio_region_read32(plic->base_addr, cc_offset);
+  uint32_t irq_id = mmio_region_read32(plic->params.base_addr, cc_offset);
 
   // Return the IRQ ID directly.
   *claim_data = irq_id;
@@ -306,7 +335,8 @@ dif_plic_result_t dif_plic_irq_complete(
   // Write back the claimed IRQ ID to the target specific CC register,
   // to notify the PLIC of the IRQ completion.
   ptrdiff_t cc_offset = plic_target_reg_offsets[target].cc;
-  mmio_region_write32(plic->base_addr, cc_offset, (uint32_t)*complete_data);
+  mmio_region_write32(plic->params.base_addr, cc_offset,
+                      (uint32_t)*complete_data);
 
   return kDifPlicOk;
 }

--- a/sw/device/lib/dif/dif_plic.c
+++ b/sw/device/lib/dif/dif_plic.c
@@ -14,7 +14,7 @@
 #include "rv_plic_regs.h"  // Generated.
 
 // If either of these static assertions fail, then the assumptions in this DIF
-// implementation should be revisited. In particular, `plic_target_reg_offsets`
+// implementation should be revisited. In particular, `kPlicTargets`
 // may need updating,
 _Static_assert(RV_PLIC_PARAM_NUMSRC == 84,
                "PLIC instantiation parameters have changed.");
@@ -31,8 +31,8 @@ const uint32_t kDifPlicMaxPriority = 0x3u;
  * and the offset of this register inside the PLIC.
  */
 typedef struct plic_reg_info {
-  ptrdiff_t offset;  /*<< Register offset. */
-  uint8_t bit_index; /*<< Bit index within the register. */
+  ptrdiff_t offset;
+  bitfield_bit32_index_t bit_index;
 } plic_reg_info_t;
 
 /**
@@ -43,9 +43,18 @@ typedef struct plic_reg_info {
  * register offsets.
  */
 typedef struct plic_target_reg_offset {
-  ptrdiff_t ie;        /*<< Interrupt Enable register offset. */
-  ptrdiff_t cc;        /*<< Claim/complete register offset. */
-  ptrdiff_t threshold; /*<< Threshold register offset. */
+  /**
+   * IRQ enable register offset for this target.
+   */
+  ptrdiff_t irq_enable;
+  /**
+   * Claim/complete register offset for this target.
+   */
+  ptrdiff_t claim_complete;
+  /**
+   * Threshold register offset for this target.
+   */
+  ptrdiff_t threshold;
 } plic_target_reg_offset_t;
 
 // This array gives a way of getting the target-specific register offsets from
@@ -58,18 +67,17 @@ typedef struct plic_target_reg_offset {
 // - `RV_PLIC_IE<i>_0_REG_OFFSET` (the first IE reg for target `i`).
 // - `RV_PLIC_CC<i>_REG_OFFSET`
 // - `RV_PLIC_THRESHOLD<i>_REG_OFFSET`
-static const plic_target_reg_offset_t plic_target_reg_offsets[] = {
-        [0] =
-            {
-                .ie = RV_PLIC_IE0_0_REG_OFFSET,
-                .cc = RV_PLIC_CC0_REG_OFFSET,
-                .threshold = RV_PLIC_THRESHOLD0_REG_OFFSET,
-            },
+static const plic_target_reg_offset_t kPlicTargets[] = {
+    [0] =
+        {
+            .irq_enable = RV_PLIC_IE0_0_REG_OFFSET,
+            .claim_complete = RV_PLIC_CC0_REG_OFFSET,
+            .threshold = RV_PLIC_THRESHOLD0_REG_OFFSET,
+        },
 };
-_Static_assert(
-    sizeof(plic_target_reg_offsets) / sizeof(*plic_target_reg_offsets) ==
-        RV_PLIC_PARAM_NUMTARGET,
-    "There should be an entry in plic_target_reg_offsets for every target");
+_Static_assert(sizeof(kPlicTargets) / sizeof(*kPlicTargets) ==
+                   RV_PLIC_PARAM_NUMTARGET,
+               "There should be an entry in kPlicTargets for every target");
 
 /**
  * Get an IE, IP or LE register offset (IE0_0, IE01, ...) from an IRQ source ID.
@@ -88,42 +96,45 @@ static ptrdiff_t plic_offset_from_reg0(dif_plic_irq_id_t irq) {
  *
  * With more than 32 IRQ sources, there is a multiple of these registers to
  * accommodate all the bits (1 bit per IRQ source). This function calculates
- * the bit position within a register for a specifci IRQ source ID (ID 32 would
+ * the bit position within a register for a specific IRQ source ID (ID 32 would
  * be bit 0).
  */
-static uint8_t plic_reg_bit_index_from_irq_id(dif_plic_irq_id_t irq) {
+static uint8_t plic_irq_bit_index(dif_plic_irq_id_t irq) {
   return irq % RV_PLIC_PARAM_REG_WIDTH;
 }
 
 /**
  * Get a target and an IRQ source specific Interrupt Enable register info.
  */
-static void plic_irq_enable_reg_info(dif_plic_irq_id_t irq,
-                                     dif_plic_target_t target,
-                                     plic_reg_info_t *reg_info) {
+static plic_reg_info_t plic_irq_enable_reg_info(dif_plic_irq_id_t irq,
+                                                dif_plic_target_t target) {
   ptrdiff_t offset = plic_offset_from_reg0(irq);
-  reg_info->offset = plic_target_reg_offsets[target].ie + offset;
-  reg_info->bit_index = plic_reg_bit_index_from_irq_id(irq);
+  return (plic_reg_info_t){
+      .offset = kPlicTargets[target].irq_enable + offset,
+      .bit_index = plic_irq_bit_index(irq),
+  };
 }
 
 /**
  * Get an IRQ source specific Level/Edge register info.
  */
-static void plic_irq_trigger_type_reg_info(dif_plic_irq_id_t irq,
-                                           plic_reg_info_t *reg_info) {
+static plic_reg_info_t plic_irq_trigger_type_reg_info(dif_plic_irq_id_t irq) {
   ptrdiff_t offset = plic_offset_from_reg0(irq);
-  reg_info->offset = RV_PLIC_LE_0_REG_OFFSET + offset;
-  reg_info->bit_index = plic_reg_bit_index_from_irq_id(irq);
+  return (plic_reg_info_t){
+      .offset = RV_PLIC_LE_0_REG_OFFSET + offset,
+      .bit_index = plic_irq_bit_index(irq),
+  };
 }
 
 /**
  * Get an IRQ source specific Interrupt Pending register info.
  */
-static void plic_irq_pending_reg_info(dif_plic_irq_id_t irq,
-                                      plic_reg_info_t *reg_info) {
+static plic_reg_info_t plic_irq_pending_reg_info(dif_plic_irq_id_t irq) {
   ptrdiff_t offset = plic_offset_from_reg0(irq);
-  reg_info->offset = RV_PLIC_IP_0_REG_OFFSET + offset;
-  reg_info->bit_index = plic_reg_bit_index_from_irq_id(irq);
+  return (plic_reg_info_t){
+      .offset = RV_PLIC_IP_0_REG_OFFSET + offset,
+      .bit_index = plic_irq_bit_index(irq),
+  };
 }
 
 /**
@@ -167,7 +178,7 @@ static void plic_reset(const dif_plic_t *plic) {
   // Clear all of the target threshold registers.
   for (dif_plic_target_t target = 0; target < RV_PLIC_PARAM_NUMTARGET;
        ++target) {
-    ptrdiff_t offset = plic_target_reg_offsets[target].threshold;
+    ptrdiff_t offset = kPlicTargets[target].threshold;
     mmio_region_write32(plic->params.base_addr, offset, 0);
   }
 
@@ -197,9 +208,7 @@ dif_plic_result_t dif_plic_irq_get_enabled(const dif_plic_t *plic,
     return kDifPlicBadArg;
   }
 
-  // Get a target and an IRQ source specific Interrupt Enable register info.
-  plic_reg_info_t reg_info;
-  plic_irq_enable_reg_info(irq, target, &reg_info);
+  plic_reg_info_t reg_info = plic_irq_enable_reg_info(irq, target);
 
   uint32_t reg = mmio_region_read32(plic->params.base_addr, reg_info.offset);
   bool is_enabled = bitfield_bit32_read(reg, reg_info.bit_index);
@@ -217,22 +226,23 @@ dif_plic_result_t dif_plic_irq_set_enabled(const dif_plic_t *plic,
     return kDifPlicBadArg;
   }
 
-  // Get a target and an IRQ source specific Interrupt Enable register info.
-  plic_reg_info_t reg_info;
-  plic_irq_enable_reg_info(irq, target, &reg_info);
-
+  bool flag;
   switch (state) {
     case kDifPlicToggleEnabled:
-      mmio_region_nonatomic_set_bit32(plic->params.base_addr, reg_info.offset,
-                                      reg_info.bit_index);
+      flag = true;
       break;
     case kDifPlicToggleDisabled:
-      mmio_region_nonatomic_clear_bit32(plic->params.base_addr, reg_info.offset,
-                                        reg_info.bit_index);
+      flag = false;
       break;
     default:
       return kDifPlicBadArg;
   }
+
+  plic_reg_info_t reg_info = plic_irq_enable_reg_info(irq, target);
+
+  uint32_t reg = mmio_region_read32(plic->params.base_addr, reg_info.offset);
+  reg = bitfield_bit32_write(reg, reg_info.bit_index, flag);
+  mmio_region_write32(plic->params.base_addr, reg_info.offset, reg);
 
   return kDifPlicOk;
 }
@@ -244,22 +254,23 @@ dif_plic_result_t dif_plic_irq_set_trigger(const dif_plic_t *plic,
     return kDifPlicBadArg;
   }
 
-  // Get an IRQ source specific Level/Edge register info.
-  plic_reg_info_t reg_info;
-  plic_irq_trigger_type_reg_info(irq, &reg_info);
-
+  bool flag;
   switch (trigger) {
     case kDifPlicIrqTriggerEdge:
-      mmio_region_nonatomic_set_bit32(plic->params.base_addr, reg_info.offset,
-                                      reg_info.bit_index);
+      flag = true;
       break;
     case kDifPlicIrqTriggerLevel:
-      mmio_region_nonatomic_clear_bit32(plic->params.base_addr, reg_info.offset,
-                                        reg_info.bit_index);
+      flag = false;
       break;
     default:
       return kDifPlicBadArg;
   }
+
+  plic_reg_info_t reg_info = plic_irq_trigger_type_reg_info(irq);
+
+  uint32_t reg = mmio_region_read32(plic->params.base_addr, reg_info.offset);
+  reg = bitfield_bit32_write(reg, reg_info.bit_index, flag);
+  mmio_region_write32(plic->params.base_addr, reg_info.offset, reg);
 
   return kDifPlicOk;
 }
@@ -286,7 +297,7 @@ dif_plic_result_t dif_plic_target_set_threshold(const dif_plic_t *plic,
     return kDifPlicBadArg;
   }
 
-  ptrdiff_t threshold_offset = plic_target_reg_offsets[target].threshold;
+  ptrdiff_t threshold_offset = kPlicTargets[target].threshold;
   mmio_region_write32(plic->params.base_addr, threshold_offset, threshold);
 
   return kDifPlicOk;
@@ -299,11 +310,9 @@ dif_plic_result_t dif_plic_irq_is_pending(const dif_plic_t *plic,
     return kDifPlicBadArg;
   }
 
-  plic_reg_info_t reg_info;
-  plic_irq_pending_reg_info(irq, &reg_info);
-
-  *is_pending = mmio_region_get_bit32(plic->params.base_addr, reg_info.offset,
-                                      reg_info.bit_index);
+  plic_reg_info_t reg_info = plic_irq_pending_reg_info(irq);
+  uint32_t reg = mmio_region_read32(plic->params.base_addr, reg_info.offset);
+  *is_pending = bitfield_bit32_read(reg, reg_info.bit_index);
 
   return kDifPlicOk;
 }
@@ -315,12 +324,9 @@ dif_plic_result_t dif_plic_irq_claim(const dif_plic_t *plic,
     return kDifPlicBadArg;
   }
 
-  // Get an IRQ ID from the target specific CC register.
-  ptrdiff_t cc_offset = plic_target_reg_offsets[target].cc;
-  uint32_t irq_id = mmio_region_read32(plic->params.base_addr, cc_offset);
+  ptrdiff_t claim_complete_reg = kPlicTargets[target].claim_complete;
+  *claim_data = mmio_region_read32(plic->params.base_addr, claim_complete_reg);
 
-  // Return the IRQ ID directly.
-  *claim_data = irq_id;
   return kDifPlicOk;
 }
 
@@ -334,9 +340,9 @@ dif_plic_result_t dif_plic_irq_complete(
 
   // Write back the claimed IRQ ID to the target specific CC register,
   // to notify the PLIC of the IRQ completion.
-  ptrdiff_t cc_offset = plic_target_reg_offsets[target].cc;
-  mmio_region_write32(plic->params.base_addr, cc_offset,
-                      (uint32_t)*complete_data);
+  ptrdiff_t claim_complete_reg = kPlicTargets[target].claim_complete;
+  mmio_region_write32(plic->params.base_addr, claim_complete_reg,
+                      *complete_data);
 
   return kDifPlicOk;
 }

--- a/sw/device/lib/dif/dif_plic.h
+++ b/sw/device/lib/dif/dif_plic.h
@@ -7,7 +7,7 @@
 
 /**
  * @file
- * @brief [PLIC](/hw/ip/rv_plic/doc/) Device Interface Functions.
+ * @brief <a href="/hw/ip/rv_plic/doc/">PLIC</a> Device Interface Functions
  *
  * The PLIC should be largely compatible with the (currently draft) [RISC-V PLIC
  * specification][plic], but tailored for the OpenTitan rv_plic register
@@ -27,27 +27,31 @@
 extern "C" {
 #endif  // __cplusplus
 
-/** The lowest interrupt priority. */
+/**
+ * The lowest interrupt priority.
+ */
 extern const uint32_t kDifPlicMinPriority;
 
-/** The highest interrupt priority. */
+/**
+ * The highest interrupt priority.
+ */
 extern const uint32_t kDifPlicMaxPriority;
 
 /**
- * PLIC interrupt source identifier.
+ * A PLIC interrupt source identifier.
  *
  * This corresponds to a specific interrupt, and not the device it originates
  * from.
  *
  * This is an unsigned 32-bit value that is at least zero and is less than the
- * `NumSrc` instantiation parameterof the `rv_plic` device.
+ * `NumSrc` instantiation parameter of the `rv_plic` device.
  *
  * The value 0 corresponds to "No Interrupt".
  */
 typedef uint32_t dif_plic_irq_id_t;
 
 /**
- * PLIC interrupt target.
+ * A PLIC interrupt target.
  *
  * This corresponds to a specific system that can service an interrupt. In
  * OpenTitan's case, that is the Ibex core. If there were multiple cores in the
@@ -59,106 +63,155 @@ typedef uint32_t dif_plic_irq_id_t;
 typedef uint32_t dif_plic_target_t;
 
 /**
- * Generic enable/disable enumeration.
- *
- * Enumeration used to enable/disable bits, flags, ...
+ * An interrupt trigger type.
  */
-typedef enum dif_plic_enable {
-  kDifPlicEnable = 0,
-  kDifPlicDisable,
-} dif_plic_enable_t;
+typedef enum dif_plic_irq_trigger {
+  /**
+   * Trigger on an edge (when the signal changes from low to high).
+   */
+  kDifPlicIrqTriggerEdge,
+  /**
+   * Trigger on a level (when the signal remains high).
+   */
+  kDifPlicIrqTriggerLevel,
+} dif_plic_irq_trigger_t;
 
 /**
- * Generic set/unset enumeration.
+ * A toggle state: enabled, or disabled.
  *
- * Enumeration used to set/unset, or get the state of bits,flags ...
+ * This enum may be used instead of a `bool` when describing an enabled/disabled
+ * state.
  */
-typedef enum dif_plic_flag {
-  kDifPlicSet = 0,
-  kDifPlicUnset,
-} dif_plic_flag_t;
+typedef enum dif_plic_toggle {
+  /*
+   * The "enabled" state.
+   */
+  kDifPlicToggleEnabled,
+  /**
+   * The "disabled" state.
+   */
+  kDifPlicToggleDisabled,
+} dif_plic_toggle_t;
 
 /**
- * PLIC instance state.
+ * Hardware instantiation parameters for PLIC.
  *
- * PLIC persistent data that is required by all the PLIC API.
+ * This struct describes information about the underlying hardware that is
+ * not determined until the hardware design is used as part of a top-level
+ * design.
+ */
+typedef struct dif_plic_params {
+  /**
+   * The base address for the PLIC hardware registers.
+   */
+  mmio_region_t base_addr;
+} dif_plic_params_t;
+
+/**
+ * A handle to PLIC.
+ *
+ * This type should be treated as opaque by users.
  */
 typedef struct dif_plic {
-  mmio_region_t base_addr; /**< PLIC instance base address. */
+  dif_plic_params_t params;
 } dif_plic_t;
 
 /**
- * PLIC generic status codes.
- *
- * These error codes can be used by any function. However if a function
- * requires additional status codes, it must define a set of status codes to
- * be used exclusicvely by such function.
+ * The result of a PLIC operation.
  */
 typedef enum dif_plic_result {
-  kDifPlicOk = 0, /**< Success. */
-  kDifPlicError,  /**< General error. */
-  kDifPlicBadArg, /**< Input parameter is not valid. */
+  /**
+   * Indicates that the operation succeeded.
+   */
+  kDifPlicOk = 0,
+  /**
+   * Indicates some unspecified failure.
+   */
+  kDifPlicError = 1,
+  /**
+   * Indicates that some parameter passed into a function failed a
+   * precondition.
+   *
+   * When this value is returned, no hardware operations occured.
+   */
+  kDifPlicBadArg = 2,
 } dif_plic_result_t;
 
 /**
- * Initialises an instance of PLIC.
+ * Creates a new handle for PLIC.
  *
- * Information that must be retained, and is required to program PLIC, shall
- * be stored in `plic`.
+ * This function does not actuate the hardware.
  *
- * @param base_addr Base address of an instance of the PLIC IP block.
- * @param[out] plic PLIC state data.
- * @return `dif_plic_result_t`.
+ * @param params Hardware instantiation parameters.
+ * @param[out] plic Out param for the initialized handle.
+ * @return The result of the operation.
  */
 DIF_WARN_UNUSED_RESULT
-dif_plic_result_t dif_plic_init(mmio_region_t base_addr, dif_plic_t *plic);
+dif_plic_result_t dif_plic_init(dif_plic_params_t params, dif_plic_t *plic);
 
 /**
- * Enables/disables handling of IRQ source in PLIC.
+ * Checks whether a particular interrupt is currently enabled or disabled.
  *
- * This operation does not affect the IRQ generation in the peripherals, which
- * must be configured in a corresponding peripheral itself.
- * @param plic PLIC state data.
- * @param irq Interrupt Source ID.
- * @param target Target to enable the IRQ for.
- * @param enable Enable/disable the IRQ handling.
- * @return `dif_plic_result_t`.
+ * @param plic A PLIC handle.
+ * @param irq An interrupt type.
+ * @param target An interrupt target.
+ * @param[out] state Out-param toggle state of the interrupt.
+ * @return The result of the operation.
  */
 DIF_WARN_UNUSED_RESULT
-dif_plic_result_t dif_plic_irq_enable_set(const dif_plic_t *plic,
-                                          dif_plic_irq_id_t irq,
-                                          dif_plic_target_t target,
-                                          dif_plic_enable_t enable);
+dif_plic_result_t dif_plic_irq_get_enabled(const dif_plic_t *plic,
+                                           dif_plic_irq_id_t irq,
+                                           dif_plic_target_t target,
+                                           dif_plic_toggle_t *state);
 
 /**
- * Sets the IRQ trigger type (edge/level).
+ * Sets whether a particular interrupt is currently enabled or disabled.
+ *
+ * This operation does not affect IRQ generation in `target`, which
+ * must be configured in the corresponding peripheral itself.
+ *
+ * @param plic A PLIC handle.
+ * @param irq An interrupt type.
+ * @param target An interrupt target.
+ * @param state The new toggle state for the interrupt.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_plic_result_t dif_plic_irq_set_enabled(const dif_plic_t *plic,
+                                           dif_plic_irq_id_t irq,
+                                           dif_plic_target_t target,
+                                           dif_plic_toggle_t state);
+
+/**
+ * Sets the IRQ trigger type.
  *
  * Sets the behaviour of the Interrupt Gateway for a particular IRQ to be edge
  * or level triggered.
- * @param plic PLIC state data.
- * @param irq Interrupt source ID.
- * @param enable Enable for the edge triggered, disable for level triggered
- * IRQs.
- * @return `dif_plic_result_t`.
+ *
+ * @param plic A PLIC handle.
+ * @param irq An interrupt type.
+ * @param trigger A trigger type.
+ * @return The result of the operation.
  */
 DIF_WARN_UNUSED_RESULT
-dif_plic_result_t dif_plic_irq_trigger_type_set(const dif_plic_t *plic,
-                                                dif_plic_irq_id_t irq,
-                                                dif_plic_enable_t enable);
+dif_plic_result_t dif_plic_irq_set_trigger(const dif_plic_t *plic,
+                                           dif_plic_irq_id_t irq,
+                                           dif_plic_irq_trigger_t trigger);
 
 /**
  * Sets IRQ source priority (0-3).
  *
- * In order for PLIC to set a CC register and assert the external interrupt line
- * to the target (Ibex, ...), the priority of an IRQ source must be higher than
- * the threshold for this source.
- * @param plic PLIC state data.
- * @param irq Interrupt source ID.
- * @param priority Priority to be set.
- * @return `dif_plic_result_t`.
+ * In order for the PLIC to set a Claim/Complete register and assert the
+ * external interrupt line to the target (Ibex, ...), the priority of the IRQ
+ * source must be higher than the threshold for this source.
+ *
+ * @param plic A PLIC handle.
+ * @param irq An interrupt type.
+ * @param priority Priority to set.
+ * @return The result of the operation.
  */
 DIF_WARN_UNUSED_RESULT
-dif_plic_result_t dif_plic_irq_priority_set(const dif_plic_t *plic,
+dif_plic_result_t dif_plic_irq_set_priority(const dif_plic_t *plic,
                                             dif_plic_irq_id_t irq,
                                             uint32_t priority);
 
@@ -168,39 +221,37 @@ dif_plic_result_t dif_plic_irq_priority_set(const dif_plic_t *plic,
  * Sets the target priority threshold. PLIC will only interrupt a target when
  * IRQ source priority is set higher than the priority threshold for the
  * corresponding target.
- * @param plic PLIC state data.
+ *
+ * @param plic A PLIC handle.
  * @param target Target to set the IRQ priority threshold for.
  * @param threshold IRQ priority threshold to be set.
- * @return `dif_plic_result_t`.
+ * @return The result of the operation.
  */
 DIF_WARN_UNUSED_RESULT
-dif_plic_result_t dif_plic_target_threshold_set(const dif_plic_t *plic,
+dif_plic_result_t dif_plic_target_set_threshold(const dif_plic_t *plic,
                                                 dif_plic_target_t target,
                                                 uint32_t threshold);
 
 /**
- * Checks the Interrupt Pending bit.
+ * Returns whether a particular interrupt is currently pending.
  *
- * Gets the status of the PLIC Interrupt Pending register bit for a specific IRQ
- * source.
- * @param plic PLIC state data.
- * @param irq Interrupt source ID.
- * @param[out] status Flag indicating whether the IRQ pending bit is set in
- * PLIC.
- * @return `dif_plic_result_t`.
+ * @param plic A PLIC handle.
+ * @param irq An interrupt type.
+ * @param[out] is_pending Out-param for whether the interrupt is pending.
+ * @return The result of the operation.
  */
 DIF_WARN_UNUSED_RESULT
-dif_plic_result_t dif_plic_irq_pending_status_get(const dif_plic_t *plic,
-                                                  dif_plic_irq_id_t irq,
-                                                  dif_plic_flag_t *status);
+dif_plic_result_t dif_plic_irq_is_pending(const dif_plic_t *plic,
+                                          dif_plic_irq_id_t irq,
+                                          bool *is_pending);
 
 /**
  * Claims an IRQ and gets the information about the source.
  *
  * Claims an IRQ and returns the IRQ related data to the caller. This function
- * reads a target specific CC register. #dif_plic_irq_complete must be called in
- * order to allow another interrupt with the same source id to be delivered.
- * This usually would be done once the interrupt has been serviced.
+ * reads a target specific Claim/Complete register. #dif_plic_irq_complete must
+ * be called in order to allow another interrupt with the same source id to be
+ * delivered. This usually would be done once the interrupt has been serviced.
  *
  * Another IRQ can be claimed before a prior IRQ is completed. In this way, this
  * functionality is compatible with nested interrupt handling. The restriction
@@ -212,10 +263,10 @@ dif_plic_result_t dif_plic_irq_pending_status_get(const dif_plic_t *plic,
  *
  * @see #dif_plic_irq_complete
  *
- * @param plic PLIC state data.
+ * @param plic A PLIC handle.
  * @param target Target that claimed the IRQ.
  * @param[out] claim_data Data that describes the origin of the IRQ.
- * @return `dif_plic_result_t`.
+ * @return The result of the operation.
  */
 DIF_WARN_UNUSED_RESULT
 dif_plic_result_t dif_plic_irq_claim(const dif_plic_t *plic,
@@ -226,7 +277,7 @@ dif_plic_result_t dif_plic_irq_claim(const dif_plic_t *plic,
  * Completes the claimed IRQ.
  *
  * Finishes servicing of the claimed IRQ by writing the IRQ source ID back to a
- * target specific CC register. This function must be called after
+ * target specific Claim/Complete register. This function must be called after
  * #dif_plic_irq_claim, when the caller is prepared to service another IRQ with
  * the same source ID. If a source ID is never Completed, then when future
  * interrupts are Claimed, they will never have the source ID of the uncompleted
@@ -234,11 +285,11 @@ dif_plic_result_t dif_plic_irq_claim(const dif_plic_t *plic,
  *
  * @see #dif_plic_irq_claim
  *
- * @param plic PLIC state data.
+ * @param plic A PLIC handle.
  * @param target Target that claimed the IRQ.
  * @param[out] complete_data Previously claimed IRQ data that is used to signal
- *                      PLIC of the IRQ servicing completion.
- * @return `dif_plic_result_t`.
+ * PLIC of the IRQ servicing completion.
+ * @return The result of the operation.
  */
 DIF_WARN_UNUSED_RESULT
 dif_plic_result_t dif_plic_irq_complete(const dif_plic_t *plic,

--- a/sw/device/lib/dif/dif_plic.h
+++ b/sw/device/lib/dif/dif_plic.h
@@ -28,55 +28,6 @@ extern "C" {
 #endif  // __cplusplus
 
 /**
- * The lowest interrupt priority.
- */
-extern const uint32_t kDifPlicMinPriority;
-
-/**
- * The highest interrupt priority.
- */
-extern const uint32_t kDifPlicMaxPriority;
-
-/**
- * A PLIC interrupt source identifier.
- *
- * This corresponds to a specific interrupt, and not the device it originates
- * from.
- *
- * This is an unsigned 32-bit value that is at least zero and is less than the
- * `NumSrc` instantiation parameter of the `rv_plic` device.
- *
- * The value 0 corresponds to "No Interrupt".
- */
-typedef uint32_t dif_plic_irq_id_t;
-
-/**
- * A PLIC interrupt target.
- *
- * This corresponds to a specific system that can service an interrupt. In
- * OpenTitan's case, that is the Ibex core. If there were multiple cores in the
- * system, each core would have its own specific interrupt target ID.
- *
- * This is an unsigned 32-bit value that is at least 0 and is less than the
- * `NumTarget` instantiation parameter of the `rv_plic` device.
- */
-typedef uint32_t dif_plic_target_t;
-
-/**
- * An interrupt trigger type.
- */
-typedef enum dif_plic_irq_trigger {
-  /**
-   * Trigger on an edge (when the signal changes from low to high).
-   */
-  kDifPlicIrqTriggerEdge,
-  /**
-   * Trigger on a level (when the signal remains high).
-   */
-  kDifPlicIrqTriggerLevel,
-} dif_plic_irq_trigger_t;
-
-/**
  * A toggle state: enabled, or disabled.
  *
  * This enum may be used instead of a `bool` when describing an enabled/disabled
@@ -138,6 +89,55 @@ typedef enum dif_plic_result {
 } dif_plic_result_t;
 
 /**
+ * The lowest interrupt priority.
+ */
+extern const uint32_t kDifPlicMinPriority;
+
+/**
+ * The highest interrupt priority.
+ */
+extern const uint32_t kDifPlicMaxPriority;
+
+/**
+ * A PLIC interrupt source identifier.
+ *
+ * This corresponds to a specific interrupt, and not the device it originates
+ * from.
+ *
+ * This is an unsigned 32-bit value that is at least zero and is less than the
+ * `NumSrc` instantiation parameter of the `rv_plic` device.
+ *
+ * The value 0 corresponds to "No Interrupt".
+ */
+typedef uint32_t dif_plic_irq_id_t;
+
+/**
+ * A PLIC interrupt target.
+ *
+ * This corresponds to a specific system that can service an interrupt. In
+ * OpenTitan's case, that is the Ibex core. If there were multiple cores in the
+ * system, each core would have its own specific interrupt target ID.
+ *
+ * This is an unsigned 32-bit value that is at least 0 and is less than the
+ * `NumTarget` instantiation parameter of the `rv_plic` device.
+ */
+typedef uint32_t dif_plic_target_t;
+
+/**
+ * An interrupt trigger type.
+ */
+typedef enum dif_plic_irq_trigger {
+  /**
+   * Trigger on an edge (when the signal changes from low to high).
+   */
+  kDifPlicIrqTriggerEdge,
+  /**
+   * Trigger on a level (when the signal remains high).
+   */
+  kDifPlicIrqTriggerLevel,
+} dif_plic_irq_trigger_t;
+
+/**
  * Creates a new handle for PLIC.
  *
  * This function does not actuate the hardware.
@@ -148,6 +148,19 @@ typedef enum dif_plic_result {
  */
 DIF_WARN_UNUSED_RESULT
 dif_plic_result_t dif_plic_init(dif_plic_params_t params, dif_plic_t *plic);
+
+/**
+ * Returns whether a particular interrupt is currently pending.
+ *
+ * @param plic A PLIC handle.
+ * @param irq An interrupt type.
+ * @param[out] is_pending Out-param for whether the interrupt is pending.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_plic_result_t dif_plic_irq_is_pending(const dif_plic_t *plic,
+                                          dif_plic_irq_id_t irq,
+                                          bool *is_pending);
 
 /**
  * Checks whether a particular interrupt is currently enabled or disabled.
@@ -231,19 +244,6 @@ DIF_WARN_UNUSED_RESULT
 dif_plic_result_t dif_plic_target_set_threshold(const dif_plic_t *plic,
                                                 dif_plic_target_t target,
                                                 uint32_t threshold);
-
-/**
- * Returns whether a particular interrupt is currently pending.
- *
- * @param plic A PLIC handle.
- * @param irq An interrupt type.
- * @param[out] is_pending Out-param for whether the interrupt is pending.
- * @return The result of the operation.
- */
-DIF_WARN_UNUSED_RESULT
-dif_plic_result_t dif_plic_irq_is_pending(const dif_plic_t *plic,
-                                          dif_plic_irq_id_t irq,
-                                          bool *is_pending);
 
 /**
  * Claims an IRQ and gets the information about the source.

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -26,6 +26,7 @@ sw_lib_dif_plic = declare_dependency(
     ],
     dependencies: [
       sw_lib_mmio,
+      sw_lib_bitfield,
     ],
   )
 )

--- a/sw/device/tests/dif/dif_plic_sanitytest.c
+++ b/sw/device/tests/dif/dif_plic_sanitytest.c
@@ -107,7 +107,9 @@ static void uart_initialise(mmio_region_t base_addr, dif_uart_t *uart) {
 }
 
 static void plic_initialise(mmio_region_t base_addr, dif_plic_t *plic) {
-  CHECK(dif_plic_init(base_addr, plic) == kDifPlicOk, "PLIC init failed!");
+  CHECK(dif_plic_init((dif_plic_params_t){.base_addr = base_addr}, plic) ==
+            kDifPlicOk,
+        "PLIC init failed!");
 }
 
 /**
@@ -127,34 +129,36 @@ static void uart_configure_irqs(dif_uart_t *uart) {
  */
 static void plic_configure_irqs(dif_plic_t *plic) {
   // Set IRQ triggers to be level triggered
-  CHECK(dif_plic_irq_trigger_type_set(plic, kTopEarlgreyPlicIrqIdUartRxOverflow,
-                                      kDifPlicDisable) == kDifPlicOk,
+  CHECK(dif_plic_irq_set_trigger(plic, kTopEarlgreyPlicIrqIdUartRxOverflow,
+                                 kDifPlicIrqTriggerLevel) == kDifPlicOk,
         "RX overflow trigger type set failed!");
-  CHECK(dif_plic_irq_trigger_type_set(plic, kTopEarlgreyPlicIrqIdUartTxEmpty,
-                                      kDifPlicDisable) == kDifPlicOk,
+  CHECK(dif_plic_irq_set_trigger(plic, kTopEarlgreyPlicIrqIdUartTxEmpty,
+                                 kDifPlicIrqTriggerLevel) == kDifPlicOk,
         "TX empty trigger type set failed!");
 
   // Set IRQ priorities to MAX
-  CHECK(dif_plic_irq_priority_set(plic, kTopEarlgreyPlicIrqIdUartRxOverflow,
+  CHECK(dif_plic_irq_set_priority(plic, kTopEarlgreyPlicIrqIdUartRxOverflow,
                                   kDifPlicMaxPriority) == kDifPlicOk,
         "priority set for RX overflow failed!");
 
-  CHECK(dif_plic_irq_priority_set(plic, kTopEarlgreyPlicIrqIdUartTxEmpty,
+  CHECK(dif_plic_irq_set_priority(plic, kTopEarlgreyPlicIrqIdUartTxEmpty,
                                   kDifPlicMaxPriority) == kDifPlicOk,
         "priority set for TX empty failed!");
 
   // Set Ibex IRQ priority threshold level
-  CHECK(dif_plic_target_threshold_set(&plic0, kPlicTarget,
+  CHECK(dif_plic_target_set_threshold(&plic0, kPlicTarget,
                                       kDifPlicMinPriority) == kDifPlicOk,
         "threshold set failed!");
 
   // Enable IRQs in PLIC
-  CHECK(dif_plic_irq_enable_set(plic, kTopEarlgreyPlicIrqIdUartRxOverflow,
-                                kPlicTarget, kDifPlicEnable) == kDifPlicOk,
+  CHECK(dif_plic_irq_set_enabled(plic, kTopEarlgreyPlicIrqIdUartRxOverflow,
+                                 kPlicTarget,
+                                 kDifPlicToggleEnabled) == kDifPlicOk,
         "interrupt Enable for RX overflow failed!");
 
-  CHECK(dif_plic_irq_enable_set(plic, kTopEarlgreyPlicIrqIdUartTxEmpty,
-                                kPlicTarget, kDifPlicEnable) == kDifPlicOk,
+  CHECK(dif_plic_irq_set_enabled(plic, kTopEarlgreyPlicIrqIdUartTxEmpty,
+                                 kPlicTarget,
+                                 kDifPlicToggleEnabled) == kDifPlicOk,
         "interrupt Enable for TX empty failed!");
 }
 

--- a/sw/device/tests/sim_dv/gpio_test.c
+++ b/sw/device/tests/sim_dv/gpio_test.c
@@ -68,31 +68,33 @@ static volatile bool expected_irq_edge;
 static void plic_init_with_irqs(mmio_region_t base_addr, dif_plic_t *plic) {
   LOG_INFO("Initializing the PLIC.");
 
-  CHECK(dif_plic_init(base_addr, plic) == kDifPlicOk, "dif_plic_init failed");
+  CHECK(dif_plic_init((dif_plic_params_t){.base_addr = base_addr}, plic) ==
+            kDifPlicOk,
+        "dif_plic_init failed");
 
   for (uint32_t i = 0; i < kNumGpios; ++i) {
     dif_plic_irq_id_t plic_irq_id = i + kTopEarlgreyPlicIrqIdGpioGpio0;
 
     // Enable GPIO interrupts at PLIC as edge triggered.
-    CHECK(dif_plic_irq_trigger_type_set(plic, plic_irq_id, kDifPlicEnable) ==
+    CHECK(dif_plic_irq_set_trigger(plic, plic_irq_id, kDifPlicIrqTriggerEdge) ==
               kDifPlicOk,
-          "dif_plic_irq_trigger_type_set failed");
+          "dif_plic_irq_set_trigger failed");
 
     // Set the priority of GPIO interrupts at PLIC to be >=1
-    CHECK(dif_plic_irq_priority_set(plic, plic_irq_id, 0x1) == kDifPlicOk,
-          "dif_plic_irq_priority_set failed");
+    CHECK(dif_plic_irq_set_priority(plic, plic_irq_id, 0x1) == kDifPlicOk,
+          "dif_plic_irq_set_priority failed");
 
     // Enable all GPIO interrupts at the PLIC.
     CHECK(
-        dif_plic_irq_enable_set(plic, plic_irq_id, kTopEarlgreyPlicTargetIbex0,
-                                kDifPlicEnable) == kDifPlicOk,
-        "dif_plic_irq_enable_set failed");
+        dif_plic_irq_set_enabled(plic, plic_irq_id, kTopEarlgreyPlicTargetIbex0,
+                                 kDifPlicToggleEnabled) == kDifPlicOk,
+        "dif_plic_irq_set_enabled failed");
   }
 
   // Set the threshold for the Ibex to 0.
-  CHECK(dif_plic_target_threshold_set(plic, kTopEarlgreyPlicTargetIbex0, 0x0) ==
+  CHECK(dif_plic_target_set_threshold(plic, kTopEarlgreyPlicTargetIbex0, 0x0) ==
             kDifPlicOk,
-        "dif_plic_target_threshold_set failed");
+        "dif_plic_target_set_threshold failed");
 }
 
 /**

--- a/sw/device/tests/sim_dv/spi_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/spi_tx_rx_test.c
@@ -196,87 +196,88 @@ static void spi_device_init_with_irqs(mmio_region_t base_addr,
 static void plic_init_with_irqs(mmio_region_t base_addr, dif_plic_t *plic) {
   LOG_INFO("Initializing the PLIC.");
 
-  CHECK(dif_plic_init(base_addr, plic) == kDifPlicOk, "dif_plic_init failed");
+  CHECK(dif_plic_init((dif_plic_params_t){.base_addr = base_addr}, plic) ==
+            kDifPlicOk,
+        "dif_plic_init failed");
 
   // Enable SPI_DEVICE interrupts at PLIC as edge triggered.
-  CHECK(dif_plic_irq_trigger_type_set(plic, kTopEarlgreyPlicIrqIdSpiDeviceRxf,
-                                      kDifPlicEnable) == kDifPlicOk,
-        "dif_plic_irq_trigger_type_set failed");
-  CHECK(dif_plic_irq_trigger_type_set(plic, kTopEarlgreyPlicIrqIdSpiDeviceRxlvl,
-                                      kDifPlicEnable) == kDifPlicOk,
-        "dif_plic_irq_trigger_type_set failed");
-  CHECK(dif_plic_irq_trigger_type_set(plic, kTopEarlgreyPlicIrqIdSpiDeviceTxlvl,
-                                      kDifPlicEnable) == kDifPlicOk,
-        "dif_plic_irq_trigger_type_set failed");
-  CHECK(dif_plic_irq_trigger_type_set(plic, kTopEarlgreyPlicIrqIdSpiDeviceRxerr,
-                                      kDifPlicEnable) == kDifPlicOk,
-        "dif_plic_irq_trigger_type_set failed");
-  CHECK(dif_plic_irq_trigger_type_set(plic,
-                                      kTopEarlgreyPlicIrqIdSpiDeviceRxoverflow,
-                                      kDifPlicEnable) == kDifPlicOk,
-        "dif_plic_irq_trigger_type_set failed");
-  CHECK(dif_plic_irq_trigger_type_set(plic,
-                                      kTopEarlgreyPlicIrqIdSpiDeviceTxunderflow,
-                                      kDifPlicEnable) == kDifPlicOk,
-        "dif_plic_irq_trigger_type_set failed");
+  CHECK(dif_plic_irq_set_trigger(plic, kTopEarlgreyPlicIrqIdSpiDeviceRxf,
+                                 kDifPlicIrqTriggerEdge) == kDifPlicOk,
+        "dif_plic_irq_set_trigger failed");
+  CHECK(dif_plic_irq_set_trigger(plic, kTopEarlgreyPlicIrqIdSpiDeviceRxlvl,
+                                 kDifPlicIrqTriggerEdge) == kDifPlicOk,
+        "dif_plic_irq_set_trigger failed");
+  CHECK(dif_plic_irq_set_trigger(plic, kTopEarlgreyPlicIrqIdSpiDeviceTxlvl,
+                                 kDifPlicIrqTriggerEdge) == kDifPlicOk,
+        "dif_plic_irq_set_trigger failed");
+  CHECK(dif_plic_irq_set_trigger(plic, kTopEarlgreyPlicIrqIdSpiDeviceRxerr,
+                                 kDifPlicIrqTriggerEdge) == kDifPlicOk,
+        "dif_plic_irq_set_trigger failed");
+  CHECK(dif_plic_irq_set_trigger(plic, kTopEarlgreyPlicIrqIdSpiDeviceRxoverflow,
+                                 kDifPlicIrqTriggerEdge) == kDifPlicOk,
+        "dif_plic_irq_set_trigger failed");
+  CHECK(
+      dif_plic_irq_set_trigger(plic, kTopEarlgreyPlicIrqIdSpiDeviceTxunderflow,
+                               kDifPlicIrqTriggerEdge) == kDifPlicOk,
+      "dif_plic_irq_set_trigger failed");
 
   // Set the priority of SPI DEVICE interrupts at PLIC to be >=1 (so ensure the
   // target does get interrupted).
-  CHECK(dif_plic_irq_priority_set(plic, kTopEarlgreyPlicIrqIdSpiDeviceRxf,
+  CHECK(dif_plic_irq_set_priority(plic, kTopEarlgreyPlicIrqIdSpiDeviceRxf,
                                   kDifPlicMaxPriority) == kDifPlicOk,
-        "dif_plic_irq_priority_set failed");
-  CHECK(dif_plic_irq_priority_set(plic, kTopEarlgreyPlicIrqIdSpiDeviceRxlvl,
+        "dif_plic_irq_set_priority failed");
+  CHECK(dif_plic_irq_set_priority(plic, kTopEarlgreyPlicIrqIdSpiDeviceRxlvl,
                                   kDifPlicMaxPriority) == kDifPlicOk,
-        "dif_plic_irq_priority_set failed");
-  CHECK(dif_plic_irq_priority_set(plic, kTopEarlgreyPlicIrqIdSpiDeviceTxlvl,
+        "dif_plic_irq_set_priority failed");
+  CHECK(dif_plic_irq_set_priority(plic, kTopEarlgreyPlicIrqIdSpiDeviceTxlvl,
                                   kDifPlicMaxPriority) == kDifPlicOk,
-        , "dif_plic_irq_priority_set failed");
-  CHECK(dif_plic_irq_priority_set(plic, kTopEarlgreyPlicIrqIdSpiDeviceRxerr,
+        , "dif_plic_irq_set_priority failed");
+  CHECK(dif_plic_irq_set_priority(plic, kTopEarlgreyPlicIrqIdSpiDeviceRxerr,
                                   kDifPlicMaxPriority) == kDifPlicOk,
-        "dif_plic_irq_priority_set failed");
+        "dif_plic_irq_set_priority failed");
   CHECK(
-      dif_plic_irq_priority_set(plic, kTopEarlgreyPlicIrqIdSpiDeviceRxoverflow,
+      dif_plic_irq_set_priority(plic, kTopEarlgreyPlicIrqIdSpiDeviceRxoverflow,
                                 kDifPlicMaxPriority) == kDifPlicOk,
-      "dif_plic_irq_priority_set failed");
+      "dif_plic_irq_set_priority failed");
   CHECK(
-      dif_plic_irq_priority_set(plic, kTopEarlgreyPlicIrqIdSpiDeviceTxunderflow,
+      dif_plic_irq_set_priority(plic, kTopEarlgreyPlicIrqIdSpiDeviceTxunderflow,
                                 kDifPlicMaxPriority) == kDifPlicOk,
-      "dif_plic_irq_priority_set failed");
+      "dif_plic_irq_set_priority failed");
 
   // Set the threshold for the Ibex to 0.
-  CHECK(dif_plic_target_threshold_set(plic, kTopEarlgreyPlicTargetIbex0, 0x0) ==
+  CHECK(dif_plic_target_set_threshold(plic, kTopEarlgreyPlicTargetIbex0, 0x0) ==
             kDifPlicOk,
-        "dif_plic_target_threshold_set failed");
+        "dif_plic_target_set_threshold failed");
 
-  CHECK(dif_plic_irq_enable_set(plic, kTopEarlgreyPlicIrqIdSpiDeviceRxf,
-                                kTopEarlgreyPlicTargetIbex0,
-                                kDifPlicEnable) == kDifPlicOk,
-        "dif_plic_irq_enable_set failed");
+  CHECK(dif_plic_irq_set_enabled(plic, kTopEarlgreyPlicIrqIdSpiDeviceRxf,
+                                 kTopEarlgreyPlicTargetIbex0,
+                                 kDifPlicToggleEnabled) == kDifPlicOk,
+        "dif_plic_irq_set_enabled failed");
 
-  CHECK(dif_plic_irq_enable_set(plic, kTopEarlgreyPlicIrqIdSpiDeviceRxlvl,
-                                kTopEarlgreyPlicTargetIbex0,
-                                kDifPlicEnable) == kDifPlicOk,
-        "dif_plic_irq_enable_set failed");
+  CHECK(dif_plic_irq_set_enabled(plic, kTopEarlgreyPlicIrqIdSpiDeviceRxlvl,
+                                 kTopEarlgreyPlicTargetIbex0,
+                                 kDifPlicToggleEnabled) == kDifPlicOk,
+        "dif_plic_irq_set_enabled failed");
 
-  CHECK(dif_plic_irq_enable_set(plic, kTopEarlgreyPlicIrqIdSpiDeviceTxlvl,
-                                kTopEarlgreyPlicTargetIbex0,
-                                kDifPlicEnable) == kDifPlicOk,
-        "dif_plic_irq_enable_set failed");
+  CHECK(dif_plic_irq_set_enabled(plic, kTopEarlgreyPlicIrqIdSpiDeviceTxlvl,
+                                 kTopEarlgreyPlicTargetIbex0,
+                                 kDifPlicToggleEnabled) == kDifPlicOk,
+        "dif_plic_irq_set_enabled failed");
 
-  CHECK(dif_plic_irq_enable_set(plic, kTopEarlgreyPlicIrqIdSpiDeviceRxerr,
-                                kTopEarlgreyPlicTargetIbex0,
-                                kDifPlicEnable) == kDifPlicOk,
-        "dif_plic_irq_enable_set failed");
+  CHECK(dif_plic_irq_set_enabled(plic, kTopEarlgreyPlicIrqIdSpiDeviceRxerr,
+                                 kTopEarlgreyPlicTargetIbex0,
+                                 kDifPlicToggleEnabled) == kDifPlicOk,
+        "dif_plic_irq_set_enabled failed");
 
-  CHECK(dif_plic_irq_enable_set(plic, kTopEarlgreyPlicIrqIdSpiDeviceRxoverflow,
-                                kTopEarlgreyPlicTargetIbex0,
-                                kDifPlicEnable) == kDifPlicOk,
-        "dif_plic_irq_enable_set failed");
+  CHECK(dif_plic_irq_set_enabled(plic, kTopEarlgreyPlicIrqIdSpiDeviceRxoverflow,
+                                 kTopEarlgreyPlicTargetIbex0,
+                                 kDifPlicToggleEnabled) == kDifPlicOk,
+        "dif_plic_irq_set_enabled failed");
 
-  CHECK(dif_plic_irq_enable_set(plic, kTopEarlgreyPlicIrqIdSpiDeviceTxunderflow,
-                                kTopEarlgreyPlicTargetIbex0,
-                                kDifPlicEnable) == kDifPlicOk,
-        "dif_plic_irq_enable_set failed");
+  CHECK(dif_plic_irq_set_enabled(
+            plic, kTopEarlgreyPlicIrqIdSpiDeviceTxunderflow,
+            kTopEarlgreyPlicTargetIbex0, kDifPlicToggleEnabled) == kDifPlicOk,
+        "dif_plic_irq_set_enabled failed");
 }
 
 static bool exp_irqs_fired() {

--- a/sw/device/tests/sim_dv/uart_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/uart_tx_rx_test.c
@@ -207,109 +207,108 @@ static void uart_init_with_irqs(mmio_region_t base_addr, dif_uart_t *uart) {
 static void plic_init_with_irqs(mmio_region_t base_addr, dif_plic_t *plic) {
   LOG_INFO("Initializing the PLIC.");
 
-  CHECK(dif_plic_init(base_addr, plic) == kDifPlicOk, "dif_plic_init failed");
+  CHECK(dif_plic_init((dif_plic_params_t){.base_addr = base_addr}, plic) ==
+            kDifPlicOk,
+        "dif_plic_init failed");
 
   // Enable UART interrupts at PLIC as edge triggered.
-  CHECK(
-      dif_plic_irq_trigger_type_set(plic, kTopEarlgreyPlicIrqIdUartTxWatermark,
-                                    kDifPlicEnable) == kDifPlicOk,
-      "dif_plic_irq_trigger_type_set failed");
-  CHECK(
-      dif_plic_irq_trigger_type_set(plic, kTopEarlgreyPlicIrqIdUartRxWatermark,
-                                    kDifPlicEnable) == kDifPlicOk,
-      "dif_plic_irq_trigger_type_set failed");
-  CHECK(dif_plic_irq_trigger_type_set(plic, kTopEarlgreyPlicIrqIdUartTxEmpty,
-                                      kDifPlicEnable) == kDifPlicOk,
-        "dif_plic_irq_trigger_type_set failed");
-  CHECK(dif_plic_irq_trigger_type_set(plic, kTopEarlgreyPlicIrqIdUartRxOverflow,
-                                      kDifPlicEnable) == kDifPlicOk,
-        "dif_plic_irq_trigger_type_set failed");
-  CHECK(dif_plic_irq_trigger_type_set(plic, kTopEarlgreyPlicIrqIdUartRxFrameErr,
-                                      kDifPlicEnable) == kDifPlicOk,
-        "dif_plic_irq_trigger_type_set failed");
-  CHECK(dif_plic_irq_trigger_type_set(plic, kTopEarlgreyPlicIrqIdUartRxBreakErr,
-                                      kDifPlicEnable) == kDifPlicOk,
-        "dif_plic_irq_trigger_type_set failed");
-  CHECK(dif_plic_irq_trigger_type_set(plic, kTopEarlgreyPlicIrqIdUartRxTimeout,
-                                      kDifPlicEnable) == kDifPlicOk,
-        "dif_plic_irq_trigger_type_set failed");
-  CHECK(
-      dif_plic_irq_trigger_type_set(plic, kTopEarlgreyPlicIrqIdUartRxParityErr,
-                                    kDifPlicEnable) == kDifPlicOk,
-      "dif_plic_irq_trigger_type_set failed");
+  CHECK(dif_plic_irq_set_trigger(plic, kTopEarlgreyPlicIrqIdUartTxWatermark,
+                                 kDifPlicIrqTriggerEdge) == kDifPlicOk,
+        "dif_plic_irq_set_trigger failed");
+  CHECK(dif_plic_irq_set_trigger(plic, kTopEarlgreyPlicIrqIdUartRxWatermark,
+                                 kDifPlicIrqTriggerEdge) == kDifPlicOk,
+        "dif_plic_irq_set_trigger failed");
+  CHECK(dif_plic_irq_set_trigger(plic, kTopEarlgreyPlicIrqIdUartTxEmpty,
+                                 kDifPlicIrqTriggerEdge) == kDifPlicOk,
+        "dif_plic_irq_set_trigger failed");
+  CHECK(dif_plic_irq_set_trigger(plic, kTopEarlgreyPlicIrqIdUartRxOverflow,
+                                 kDifPlicIrqTriggerEdge) == kDifPlicOk,
+        "dif_plic_irq_set_trigger failed");
+  CHECK(dif_plic_irq_set_trigger(plic, kTopEarlgreyPlicIrqIdUartRxFrameErr,
+                                 kDifPlicIrqTriggerEdge) == kDifPlicOk,
+        "dif_plic_irq_set_trigger failed");
+  CHECK(dif_plic_irq_set_trigger(plic, kTopEarlgreyPlicIrqIdUartRxBreakErr,
+                                 kDifPlicIrqTriggerEdge) == kDifPlicOk,
+        "dif_plic_irq_set_trigger failed");
+  CHECK(dif_plic_irq_set_trigger(plic, kTopEarlgreyPlicIrqIdUartRxTimeout,
+                                 kDifPlicIrqTriggerEdge) == kDifPlicOk,
+        "dif_plic_irq_set_trigger failed");
+  CHECK(dif_plic_irq_set_trigger(plic, kTopEarlgreyPlicIrqIdUartRxParityErr,
+                                 kDifPlicIrqTriggerEdge) == kDifPlicOk,
+        "dif_plic_irq_set_trigger failed");
 
   // Set the priority of UART interrupts at PLIC to be >=1 (so ensure the target
   // does get interrupted).
-  CHECK(dif_plic_irq_priority_set(plic, kTopEarlgreyPlicIrqIdUartTxWatermark,
+  CHECK(dif_plic_irq_set_priority(plic, kTopEarlgreyPlicIrqIdUartTxWatermark,
                                   0x1) == kDifPlicOk,
-        "dif_plic_irq_priority_set failed");
-  CHECK(dif_plic_irq_priority_set(plic, kTopEarlgreyPlicIrqIdUartRxWatermark,
+        "dif_plic_irq_set_priority failed");
+  CHECK(dif_plic_irq_set_priority(plic, kTopEarlgreyPlicIrqIdUartRxWatermark,
                                   0x2) == kDifPlicOk,
-        "dif_plic_irq_priority_set failed");
-  CHECK(dif_plic_irq_priority_set(plic, kTopEarlgreyPlicIrqIdUartTxEmpty,
+        "dif_plic_irq_set_priority failed");
+  CHECK(dif_plic_irq_set_priority(plic, kTopEarlgreyPlicIrqIdUartTxEmpty,
                                   0x3) == kDifPlicOk,
-        , "dif_plic_irq_priority_set failed");
-  CHECK(dif_plic_irq_priority_set(plic, kTopEarlgreyPlicIrqIdUartRxOverflow,
+        , "dif_plic_irq_set_priority failed");
+  CHECK(dif_plic_irq_set_priority(plic, kTopEarlgreyPlicIrqIdUartRxOverflow,
                                   0x1) == kDifPlicOk,
-        "dif_plic_irq_priority_set failed");
-  CHECK(dif_plic_irq_priority_set(plic, kTopEarlgreyPlicIrqIdUartRxFrameErr,
+        "dif_plic_irq_set_priority failed");
+  CHECK(dif_plic_irq_set_priority(plic, kTopEarlgreyPlicIrqIdUartRxFrameErr,
                                   0x2) == kDifPlicOk,
-        "dif_plic_irq_priority_set failed");
-  CHECK(dif_plic_irq_priority_set(plic, kTopEarlgreyPlicIrqIdUartRxBreakErr,
+        "dif_plic_irq_set_priority failed");
+  CHECK(dif_plic_irq_set_priority(plic, kTopEarlgreyPlicIrqIdUartRxBreakErr,
                                   0x3) == kDifPlicOk,
-        "dif_plic_irq_priority_set failed");
-  CHECK(dif_plic_irq_priority_set(plic, kTopEarlgreyPlicIrqIdUartRxTimeout,
+        "dif_plic_irq_set_priority failed");
+  CHECK(dif_plic_irq_set_priority(plic, kTopEarlgreyPlicIrqIdUartRxTimeout,
                                   0x1) == kDifPlicOk,
-        "dif_plic_irq_priority_set failed");
-  CHECK(dif_plic_irq_priority_set(plic, kTopEarlgreyPlicIrqIdUartRxParityErr,
+        "dif_plic_irq_set_priority failed");
+  CHECK(dif_plic_irq_set_priority(plic, kTopEarlgreyPlicIrqIdUartRxParityErr,
                                   0x2) == kDifPlicOk,
-        "dif_plic_irq_priority_set failed");
+        "dif_plic_irq_set_priority failed");
 
   // Set the threshold for the Ibex to 0.
-  CHECK(dif_plic_target_threshold_set(plic, kTopEarlgreyPlicTargetIbex0, 0x0) ==
+  CHECK(dif_plic_target_set_threshold(plic, kTopEarlgreyPlicTargetIbex0, 0x0) ==
             kDifPlicOk,
-        "dif_plic_target_threshold_set failed");
+        "dif_plic_target_set_threshold failed");
 
   // Enable all UART interrupts at the PLIC.
-  CHECK(dif_plic_irq_enable_set(plic, kTopEarlgreyPlicIrqIdUartTxWatermark,
-                                kTopEarlgreyPlicTargetIbex0,
-                                kDifPlicEnable) == kDifPlicOk,
-        "dif_plic_irq_enable_set failed");
+  CHECK(dif_plic_irq_set_enabled(plic, kTopEarlgreyPlicIrqIdUartTxWatermark,
+                                 kTopEarlgreyPlicTargetIbex0,
+                                 kDifPlicToggleEnabled) == kDifPlicOk,
+        "dif_plic_irq_set_enabled failed");
 
-  CHECK(dif_plic_irq_enable_set(plic, kTopEarlgreyPlicIrqIdUartRxWatermark,
-                                kTopEarlgreyPlicTargetIbex0,
-                                kDifPlicEnable) == kDifPlicOk,
-        "dif_plic_irq_enable_set failed");
+  CHECK(dif_plic_irq_set_enabled(plic, kTopEarlgreyPlicIrqIdUartRxWatermark,
+                                 kTopEarlgreyPlicTargetIbex0,
+                                 kDifPlicToggleEnabled) == kDifPlicOk,
+        "dif_plic_irq_set_enabled failed");
 
-  CHECK(dif_plic_irq_enable_set(plic, kTopEarlgreyPlicIrqIdUartTxEmpty,
-                                kTopEarlgreyPlicTargetIbex0,
-                                kDifPlicEnable) == kDifPlicOk,
-        "dif_plic_irq_enable_set failed");
+  CHECK(dif_plic_irq_set_enabled(plic, kTopEarlgreyPlicIrqIdUartTxEmpty,
+                                 kTopEarlgreyPlicTargetIbex0,
+                                 kDifPlicToggleEnabled) == kDifPlicOk,
+        "dif_plic_irq_set_enabled failed");
 
-  CHECK(dif_plic_irq_enable_set(plic, kTopEarlgreyPlicIrqIdUartRxOverflow,
-                                kTopEarlgreyPlicTargetIbex0,
-                                kDifPlicEnable) == kDifPlicOk,
-        "dif_plic_irq_enable_set failed");
+  CHECK(dif_plic_irq_set_enabled(plic, kTopEarlgreyPlicIrqIdUartRxOverflow,
+                                 kTopEarlgreyPlicTargetIbex0,
+                                 kDifPlicToggleEnabled) == kDifPlicOk,
+        "dif_plic_irq_set_enabled failed");
 
-  CHECK(dif_plic_irq_enable_set(plic, kTopEarlgreyPlicIrqIdUartRxFrameErr,
-                                kTopEarlgreyPlicTargetIbex0,
-                                kDifPlicEnable) == kDifPlicOk,
-        "dif_plic_irq_enable_set failed");
+  CHECK(dif_plic_irq_set_enabled(plic, kTopEarlgreyPlicIrqIdUartRxFrameErr,
+                                 kTopEarlgreyPlicTargetIbex0,
+                                 kDifPlicToggleEnabled) == kDifPlicOk,
+        "dif_plic_irq_set_enabled failed");
 
-  CHECK(dif_plic_irq_enable_set(plic, kTopEarlgreyPlicIrqIdUartRxBreakErr,
-                                kTopEarlgreyPlicTargetIbex0,
-                                kDifPlicEnable) == kDifPlicOk,
-        "dif_plic_irq_enable_set failed");
+  CHECK(dif_plic_irq_set_enabled(plic, kTopEarlgreyPlicIrqIdUartRxBreakErr,
+                                 kTopEarlgreyPlicTargetIbex0,
+                                 kDifPlicToggleEnabled) == kDifPlicOk,
+        "dif_plic_irq_set_enabled failed");
 
-  CHECK(dif_plic_irq_enable_set(plic, kTopEarlgreyPlicIrqIdUartRxTimeout,
-                                kTopEarlgreyPlicTargetIbex0,
-                                kDifPlicEnable) == kDifPlicOk,
-        "dif_plic_irq_enable_set failed");
+  CHECK(dif_plic_irq_set_enabled(plic, kTopEarlgreyPlicIrqIdUartRxTimeout,
+                                 kTopEarlgreyPlicTargetIbex0,
+                                 kDifPlicToggleEnabled) == kDifPlicOk,
+        "dif_plic_irq_set_enabled failed");
 
-  CHECK(dif_plic_irq_enable_set(plic, kTopEarlgreyPlicIrqIdUartRxParityErr,
-                                kTopEarlgreyPlicTargetIbex0,
-                                kDifPlicEnable) == kDifPlicOk,
-        "dif_plic_irq_enable_set failed");
+  CHECK(dif_plic_irq_set_enabled(plic, kTopEarlgreyPlicIrqIdUartRxParityErr,
+                                 kTopEarlgreyPlicTargetIbex0,
+                                 kDifPlicToggleEnabled) == kDifPlicOk,
+        "dif_plic_irq_set_enabled failed");
 }
 
 /**


### PR DESCRIPTION
Also, it seems like this DIF really wants to be parametric on the number of interrupt sources. I didn't include it in this PR since that's actually contentious, but I figured I'd mention it.