### PR TITLE
[prim_ram_1p_adv/fpv] fix assertion

### DIFF
--- a/hw/ip/prim/rtl/prim_ram_1p_adv.sv
+++ b/hw/ip/prim/rtl/prim_ram_1p_adv.sv
@@ -125,7 +125,7 @@ module prim_ram_1p_adv #(
 
     // the wmask is constantly set to 1 in this case
     `ASSERT(OnlyWordWritePossibleWithEccPortA_A, req_i |->
-          wmask_i == {TotalWidth{1'b1}})
+          wmask_i == {Width{1'b1}})
 
     assign wmask_d = {TotalWidth{1'b1}};
 

--- a/hw/ip/prim/rtl/prim_ram_2p_async_adv.sv
+++ b/hw/ip/prim/rtl/prim_ram_2p_async_adv.sv
@@ -166,9 +166,9 @@ module prim_ram_2p_async_adv #(
 
     // the wmask is constantly set to 1 in this case
     `ASSERT(OnlyWordWritePossibleWithEccPortA_A, a_req_i |->
-        a_wmask_i == {TotalWidth{1'b1}}, clk_a_i, rst_a_ni)
+        a_wmask_i == {Width{1'b1}}, clk_a_i, rst_a_ni)
     `ASSERT(OnlyWordWritePossibleWithEccPortB_A, b_req_i |->
-        b_wmask_i == {TotalWidth{1'b1}}, clk_b_i, rst_b_ni)
+        b_wmask_i == {Width{1'b1}}, clk_b_i, rst_b_ni)
 
     assign a_wmask_d = {TotalWidth{1'b1}};
     assign b_wmask_d = {TotalWidth{1'b1}};


### PR DESCRIPTION
`wmask_i` is an input with width [Width-1:0], this assertion is always
false if `TotalWidth != Width`, means if `ParWidth != 0`.

Signed-off-by: Cindy Chen <chencindy@google.com>