### PR TITLE
[otp_ctrl] Update interface signals and LFSR reseeding 

### DIFF
--- a/hw/ip/otp_ctrl/otp_ctrl.core
+++ b/hw/ip/otp_ctrl/otp_ctrl.core
@@ -8,12 +8,13 @@ description: "OTP Controller"
 filesets:
   files_rtl:
     depend:
+      - lowrisc:ip:otp_ctrl_pkg
       - lowrisc:ip:tlul
       - lowrisc:prim:all
       - lowrisc:prim:ram_1p
       - lowrisc:prim:otp
       - lowrisc:prim:lfsr
-      - lowrisc:ip:otp_ctrl_pkg
+      - lowrisc:ip:pwrmgr_pkg
     files:
       - rtl/otp_ctrl_reg_top.sv
       - rtl/otp_ctrl_parity_reg.sv

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_kdi.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_kdi.sv
@@ -30,8 +30,9 @@ module otp_ctrl_kdi
   input  logic [FlashKeySeedWidth-1:0]               flash_addr_key_seed_i,
   input  logic [SramKeySeedWidth-1:0]                sram_data_key_seed_i,
   // EDN interface for requesting entropy
-  output otp_edn_req_t                               otp_edn_req_o,
-  input  otp_edn_rsp_t                               otp_edn_rsp_i,
+  output logic                                       edn_req_o,
+  input                                              edn_ack_i,
+  input  [31:0]                                      edn_data_i,
   // Lifecycle hashing request
   input  lc_otp_token_rsp_t                          lc_otp_token_req_i,
   output lc_otp_token_rsp_t                          lc_otp_token_rsp_o,
@@ -57,7 +58,7 @@ module otp_ctrl_kdi
 
   // tie-off and unused assignments for preventing lint messages
   assign fsm_err_o = 1'b0;
-  assign otp_edn_req_o = '0;
+  assign edn_req_o = '0;
   assign lc_otp_token_rsp_o = '0;
   assign flash_otp_key_rsp_o = '0;
   assign sram_otp_key_rsp_o = '0;
@@ -75,7 +76,8 @@ module otp_ctrl_kdi
                            flash_data_key_seed_i,
                            flash_addr_key_seed_i,
                            sram_data_key_seed_i,
-                           otp_edn_rsp_i,
+                           edn_ack_i,
+                           edn_data_i,
                            lc_otp_token_req_i,
                            flash_otp_key_req_i,
                            sram_otp_key_req_i,

--- a/hw/ip/pwrmgr/data/pwrmgr.hjson
+++ b/hw/ip/pwrmgr/data/pwrmgr.hjson
@@ -1,6 +1,12 @@
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
+//
+// ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
+// PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
 { name: "PWRMGR",
   clock_primary: "clk_i",
   other_clock_list: [ "clk_slow_i" ]
@@ -49,9 +55,9 @@
     },
 
     { struct:  "pwr_flash",
-      type:    "uni",
+      type:    "req_rsp",
       name:    "pwr_flash",
-      act:     "rcv",
+      act:     "req",
       package: "pwrmgr_pkg",
     },
 
@@ -63,7 +69,7 @@
     },
 
     { struct:  "logic",
-      width:   3,
+      width:   1,
       type:    "uni",
       name:    "wakeups",
       act:     "rcv",
@@ -71,7 +77,7 @@
     },
 
     { struct:  "logic",
-      width:   2,
+      width:   1,
       type:    "uni",
       name:    "rstreqs",
       act:     "rcv",
@@ -84,7 +90,13 @@
     { name: "NumWkups",
       desc: "Number of wakeups",
       type: "int",
-      default: "16",
+      default: "1",
+      local: "true"
+    },
+    { name: "NumRstReqs",
+      desc: "Number of reset requets",
+      type: "int",
+      default: "1",
       local: "true"
     },
   ],
@@ -200,6 +212,46 @@
         },
 
         { bits: "6",
+          name: "USB_CLK_EN_LP",
+          desc: "USB clock enable during low power state",
+          resval: "0",
+          enum: [
+            { value: "0",
+              name: "Disabled",
+              desc: '''
+                USB clock disabled during low power state
+                '''
+            },
+            { value: "1",
+              name: "Enabled",
+              desc: '''
+                USB clock enabled during low power state
+                '''
+            },
+          ]
+        },
+
+        { bits: "7",
+          name: "USB_CLK_EN_ACTIVE",
+          desc: "USB clock enable during active power state",
+          resval: "1"
+          enum: [
+            { value: "0",
+              name: "Disabled",
+              desc: '''
+                USB clock disabled during active power state
+                '''
+            },
+            { value: "1",
+              name: "Enabled",
+              desc: '''
+                USB clock enabled during active power state
+                '''
+            },
+          ]
+        },
+
+        { bits: "8",
           name: "MAIN_PD_N",
           desc: "Active low, main power domain power down",
           resval: "1"
@@ -220,6 +272,8 @@
             },
           ]
         },
+
+
       ],
     },
 
@@ -294,7 +348,7 @@
       { name: "WAKE_STATUS",
         desc: "A read only register of all current wake requests post enable mask",
         swaccess: "ro",
-        hwaccess: "none",
+        hwaccess: "hwo",
         resval: "0"
         cname: "wake_status",
         count: "NumWkups",
@@ -325,36 +379,44 @@
       ]
     },
 
-    { name: "RESET_EN",
-      desc: "Bit mask for enabled resets",
-      swaccess: "rw",
-      hwaccess: "hro",
-      regwen: "RESET_EN_REGWEN",
-      resval: "0"
-      fields: [
-        { bits: "1:0",
-          name: "EN",
-          desc: '''
-            Whenever a particular bit is set to 1, that reset request is enabled.
-            Whenever a particular bit is set to 0, that reset request cannot reset the device.
-          ''',
-        },
-      ]
+    { multireg:
+      { name: "RESET_EN",
+        desc: "Bit mask for enabled reset requests",
+        swaccess: "rw",
+        hwaccess: "hro",
+        regwen: "RESET_EN_REGWEN",
+        resval: "0"
+        cname: "rstreq_en",
+        count: "NumRstReqs"
+        fields: [
+          { bits: "0",
+            name: "EN",
+            desc: '''
+              Whenever a particular bit is set to 1, that reset request is enabled.
+              Whenever a particular bit is set to 0, that reset request cannot reset the device.
+            ''',
+          },
+        ]
+      },
     },
 
-    { name: "RESET_STATUS",
-      desc: "A read only register of all current reset requests post enable mask",
-      swaccess: "ro",
-      hwaccess: "none",
-      resval: "0"
-      fields: [
-        { bits: "1:0",
-          name: "VAL",
-          desc: '''
-            Current value of reset request
-          ''',
-        },
-      ]
+    { multireg:
+      { name: "RESET_STATUS",
+        desc: "A read only register of all current reset requests post enable mask",
+        swaccess: "ro",
+        hwaccess: "hwo",
+        resval: "0"
+        cname: "reset_status",
+        count: "NumRstReqs",
+        fields: [
+          { bits: "0",
+            name: "VAL",
+            desc: '''
+              Current value of reset request
+            ''',
+          },
+        ]
+      },
     },
 
     { name: "WAKE_INFO_CAPTURE_DIS",
@@ -387,11 +449,11 @@
       hwqe: "true",
       resval: "0"
       fields: [
-        { bits: "15:0",
+        { bits: "0:0",
           name: "REASONS",
           desc: "Various peripheral wake reasons"
         },
-        { bits: "16",
+        { bits: "1",
           name: "FALL_THROUGH",
           desc: '''
             The fall through wakeup reason indicates that despite setting a WFI and providing a low power
@@ -400,7 +462,7 @@
             The power manager detects this condition, halts low power entry and reports as a wakeup reason
           ''',
         },
-        { bits: "17",
+        { bits: "2",
           name: "ABORT",
           desc: '''
             The abort wakeup reason indicates that despite setting a WFI and providing a low power
@@ -417,4 +479,3 @@
     },
   ]
 }
-

--- a/hw/ip/pwrmgr/rtl/pwrmgr_reg_pkg.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_reg_pkg.sv
@@ -7,7 +7,8 @@
 package pwrmgr_reg_pkg;
 
   // Param list
-  parameter int NumWkups = 16;
+  parameter int NumWkups = 1;
+  parameter int NumRstReqs = 1;
 
   ////////////////////////////
   // Typedefs for registers //
@@ -37,6 +38,12 @@ package pwrmgr_reg_pkg;
     } io_clk_en;
     struct packed {
       logic        q;
+    } usb_clk_en_lp;
+    struct packed {
+      logic        q;
+    } usb_clk_en_active;
+    struct packed {
+      logic        q;
     } main_pd_n;
   } pwrmgr_reg2hw_control_reg_t;
 
@@ -50,8 +57,8 @@ package pwrmgr_reg_pkg;
   } pwrmgr_reg2hw_wakeup_en_mreg_t;
 
   typedef struct packed {
-    logic [1:0]  q;
-  } pwrmgr_reg2hw_reset_en_reg_t;
+    logic        q;
+  } pwrmgr_reg2hw_reset_en_mreg_t;
 
   typedef struct packed {
     logic        q;
@@ -59,7 +66,7 @@ package pwrmgr_reg_pkg;
 
   typedef struct packed {
     struct packed {
-      logic [15:0] q;
+      logic        q;
       logic        qe;
     } reasons;
     struct packed {
@@ -95,8 +102,18 @@ package pwrmgr_reg_pkg;
   } pwrmgr_hw2reg_cfg_cdc_sync_reg_t;
 
   typedef struct packed {
+    logic        d;
+    logic        de;
+  } pwrmgr_hw2reg_wake_status_mreg_t;
+
+  typedef struct packed {
+    logic        d;
+    logic        de;
+  } pwrmgr_hw2reg_reset_status_mreg_t;
+
+  typedef struct packed {
     struct packed {
-      logic [15:0] d;
+      logic        d;
     } reasons;
     struct packed {
       logic        d;
@@ -111,26 +128,28 @@ package pwrmgr_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    pwrmgr_reg2hw_intr_state_reg_t intr_state; // [49:49]
-    pwrmgr_reg2hw_intr_enable_reg_t intr_enable; // [48:48]
-    pwrmgr_reg2hw_intr_test_reg_t intr_test; // [47:46]
-    pwrmgr_reg2hw_control_reg_t control; // [45:42]
-    pwrmgr_reg2hw_cfg_cdc_sync_reg_t cfg_cdc_sync; // [41:40]
-    pwrmgr_reg2hw_wakeup_en_mreg_t [15:0] wakeup_en; // [39:24]
-    pwrmgr_reg2hw_reset_en_reg_t reset_en; // [23:22]
-    pwrmgr_reg2hw_wake_info_capture_dis_reg_t wake_info_capture_dis; // [21:21]
-    pwrmgr_reg2hw_wake_info_reg_t wake_info; // [20:0]
+    pwrmgr_reg2hw_intr_state_reg_t intr_state; // [20:20]
+    pwrmgr_reg2hw_intr_enable_reg_t intr_enable; // [19:19]
+    pwrmgr_reg2hw_intr_test_reg_t intr_test; // [18:17]
+    pwrmgr_reg2hw_control_reg_t control; // [16:11]
+    pwrmgr_reg2hw_cfg_cdc_sync_reg_t cfg_cdc_sync; // [10:9]
+    pwrmgr_reg2hw_wakeup_en_mreg_t [0:0] wakeup_en; // [8:8]
+    pwrmgr_reg2hw_reset_en_mreg_t [0:0] reset_en; // [7:7]
+    pwrmgr_reg2hw_wake_info_capture_dis_reg_t wake_info_capture_dis; // [6:6]
+    pwrmgr_reg2hw_wake_info_reg_t wake_info; // [5:0]
   } pwrmgr_reg2hw_t;
 
   ///////////////////////////////////////
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    pwrmgr_hw2reg_intr_state_reg_t intr_state; // [24:24]
-    pwrmgr_hw2reg_ctrl_cfg_regwen_reg_t ctrl_cfg_regwen; // [23:24]
-    pwrmgr_hw2reg_control_reg_t control; // [23:20]
-    pwrmgr_hw2reg_cfg_cdc_sync_reg_t cfg_cdc_sync; // [19:18]
-    pwrmgr_hw2reg_wake_info_reg_t wake_info; // [17:-3]
+    pwrmgr_hw2reg_intr_state_reg_t intr_state; // [13:13]
+    pwrmgr_hw2reg_ctrl_cfg_regwen_reg_t ctrl_cfg_regwen; // [12:13]
+    pwrmgr_hw2reg_control_reg_t control; // [12:7]
+    pwrmgr_hw2reg_cfg_cdc_sync_reg_t cfg_cdc_sync; // [6:5]
+    pwrmgr_hw2reg_wake_status_mreg_t [0:0] wake_status; // [4:3]
+    pwrmgr_hw2reg_reset_status_mreg_t [0:0] reset_status; // [2:1]
+    pwrmgr_hw2reg_wake_info_reg_t wake_info; // [0:-5]
   } pwrmgr_hw2reg_t;
 
   // Register Address
@@ -174,16 +193,16 @@ package pwrmgr_reg_pkg;
     4'b 0001, // index[ 1] PWRMGR_INTR_ENABLE
     4'b 0001, // index[ 2] PWRMGR_INTR_TEST
     4'b 0001, // index[ 3] PWRMGR_CTRL_CFG_REGWEN
-    4'b 0001, // index[ 4] PWRMGR_CONTROL
+    4'b 0011, // index[ 4] PWRMGR_CONTROL
     4'b 0001, // index[ 5] PWRMGR_CFG_CDC_SYNC
     4'b 0001, // index[ 6] PWRMGR_WAKEUP_EN_REGWEN
-    4'b 0011, // index[ 7] PWRMGR_WAKEUP_EN
-    4'b 0011, // index[ 8] PWRMGR_WAKE_STATUS
+    4'b 0001, // index[ 7] PWRMGR_WAKEUP_EN
+    4'b 0001, // index[ 8] PWRMGR_WAKE_STATUS
     4'b 0001, // index[ 9] PWRMGR_RESET_EN_REGWEN
     4'b 0001, // index[10] PWRMGR_RESET_EN
     4'b 0001, // index[11] PWRMGR_RESET_STATUS
     4'b 0001, // index[12] PWRMGR_WAKE_INFO_CAPTURE_DIS
-    4'b 0111  // index[13] PWRMGR_WAKE_INFO
+    4'b 0001  // index[13] PWRMGR_WAKE_INFO
   };
 endpackage
 

--- a/hw/ip/pwrmgr/rtl/pwrmgr_reg_top.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_reg_top.sv
@@ -90,6 +90,12 @@ module pwrmgr_reg_top (
   logic control_io_clk_en_qs;
   logic control_io_clk_en_wd;
   logic control_io_clk_en_we;
+  logic control_usb_clk_en_lp_qs;
+  logic control_usb_clk_en_lp_wd;
+  logic control_usb_clk_en_lp_we;
+  logic control_usb_clk_en_active_qs;
+  logic control_usb_clk_en_active_wd;
+  logic control_usb_clk_en_active_we;
   logic control_main_pd_n_qs;
   logic control_main_pd_n_wd;
   logic control_main_pd_n_we;
@@ -99,82 +105,22 @@ module pwrmgr_reg_top (
   logic wakeup_en_regwen_qs;
   logic wakeup_en_regwen_wd;
   logic wakeup_en_regwen_we;
-  logic wakeup_en_en_0_qs;
-  logic wakeup_en_en_0_wd;
-  logic wakeup_en_en_0_we;
-  logic wakeup_en_en_1_qs;
-  logic wakeup_en_en_1_wd;
-  logic wakeup_en_en_1_we;
-  logic wakeup_en_en_2_qs;
-  logic wakeup_en_en_2_wd;
-  logic wakeup_en_en_2_we;
-  logic wakeup_en_en_3_qs;
-  logic wakeup_en_en_3_wd;
-  logic wakeup_en_en_3_we;
-  logic wakeup_en_en_4_qs;
-  logic wakeup_en_en_4_wd;
-  logic wakeup_en_en_4_we;
-  logic wakeup_en_en_5_qs;
-  logic wakeup_en_en_5_wd;
-  logic wakeup_en_en_5_we;
-  logic wakeup_en_en_6_qs;
-  logic wakeup_en_en_6_wd;
-  logic wakeup_en_en_6_we;
-  logic wakeup_en_en_7_qs;
-  logic wakeup_en_en_7_wd;
-  logic wakeup_en_en_7_we;
-  logic wakeup_en_en_8_qs;
-  logic wakeup_en_en_8_wd;
-  logic wakeup_en_en_8_we;
-  logic wakeup_en_en_9_qs;
-  logic wakeup_en_en_9_wd;
-  logic wakeup_en_en_9_we;
-  logic wakeup_en_en_10_qs;
-  logic wakeup_en_en_10_wd;
-  logic wakeup_en_en_10_we;
-  logic wakeup_en_en_11_qs;
-  logic wakeup_en_en_11_wd;
-  logic wakeup_en_en_11_we;
-  logic wakeup_en_en_12_qs;
-  logic wakeup_en_en_12_wd;
-  logic wakeup_en_en_12_we;
-  logic wakeup_en_en_13_qs;
-  logic wakeup_en_en_13_wd;
-  logic wakeup_en_en_13_we;
-  logic wakeup_en_en_14_qs;
-  logic wakeup_en_en_14_wd;
-  logic wakeup_en_en_14_we;
-  logic wakeup_en_en_15_qs;
-  logic wakeup_en_en_15_wd;
-  logic wakeup_en_en_15_we;
-  logic wake_status_val_0_qs;
-  logic wake_status_val_1_qs;
-  logic wake_status_val_2_qs;
-  logic wake_status_val_3_qs;
-  logic wake_status_val_4_qs;
-  logic wake_status_val_5_qs;
-  logic wake_status_val_6_qs;
-  logic wake_status_val_7_qs;
-  logic wake_status_val_8_qs;
-  logic wake_status_val_9_qs;
-  logic wake_status_val_10_qs;
-  logic wake_status_val_11_qs;
-  logic wake_status_val_12_qs;
-  logic wake_status_val_13_qs;
-  logic wake_status_val_14_qs;
-  logic wake_status_val_15_qs;
+  logic wakeup_en_qs;
+  logic wakeup_en_wd;
+  logic wakeup_en_we;
+  logic wake_status_qs;
   logic reset_en_regwen_qs;
   logic reset_en_regwen_wd;
   logic reset_en_regwen_we;
-  logic [1:0] reset_en_qs;
-  logic [1:0] reset_en_wd;
+  logic reset_en_qs;
+  logic reset_en_wd;
   logic reset_en_we;
-  logic [1:0] reset_status_qs;
+  logic reset_status_qs;
   logic wake_info_capture_dis_qs;
   logic wake_info_capture_dis_wd;
   logic wake_info_capture_dis_we;
-  logic [15:0] wake_info_reasons_qs;
-  logic [15:0] wake_info_reasons_wd;
+  logic wake_info_reasons_qs;
+  logic wake_info_reasons_wd;
   logic wake_info_reasons_we;
   logic wake_info_reasons_re;
   logic wake_info_fall_through_qs;
@@ -353,7 +299,59 @@ module pwrmgr_reg_top (
   );
 
 
-  //   F[main_pd_n]: 6:6
+  //   F[usb_clk_en_lp]: 6:6
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_control_usb_clk_en_lp (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (control_usb_clk_en_lp_we & ctrl_cfg_regwen_qs),
+    .wd     (control_usb_clk_en_lp_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.control.usb_clk_en_lp.q ),
+
+    // to register interface (read)
+    .qs     (control_usb_clk_en_lp_qs)
+  );
+
+
+  //   F[usb_clk_en_active]: 7:7
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h1)
+  ) u_control_usb_clk_en_active (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (control_usb_clk_en_active_we & ctrl_cfg_regwen_qs),
+    .wd     (control_usb_clk_en_active_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.control.usb_clk_en_active.q ),
+
+    // to register interface (read)
+    .qs     (control_usb_clk_en_active_qs)
+  );
+
+
+  //   F[main_pd_n]: 8:8
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
@@ -437,18 +435,17 @@ module pwrmgr_reg_top (
   // Subregister 0 of Multireg wakeup_en
   // R[wakeup_en]: V(False)
 
-  // F[en_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
     .RESVAL  (1'h0)
-  ) u_wakeup_en_en_0 (
+  ) u_wakeup_en (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (wakeup_en_en_0_we & wakeup_en_regwen_qs),
-    .wd     (wakeup_en_en_0_wd),
+    .we     (wakeup_en_we & wakeup_en_regwen_qs),
+    .wd     (wakeup_en_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -459,484 +456,36 @@ module pwrmgr_reg_top (
     .q      (reg2hw.wakeup_en[0].q ),
 
     // to register interface (read)
-    .qs     (wakeup_en_en_0_qs)
+    .qs     (wakeup_en_qs)
   );
-
-
-  // F[en_1]: 1:1
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_wakeup_en_en_1 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (wakeup_en_en_1_we & wakeup_en_regwen_qs),
-    .wd     (wakeup_en_en_1_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wakeup_en[1].q ),
-
-    // to register interface (read)
-    .qs     (wakeup_en_en_1_qs)
-  );
-
-
-  // F[en_2]: 2:2
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_wakeup_en_en_2 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (wakeup_en_en_2_we & wakeup_en_regwen_qs),
-    .wd     (wakeup_en_en_2_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wakeup_en[2].q ),
-
-    // to register interface (read)
-    .qs     (wakeup_en_en_2_qs)
-  );
-
-
-  // F[en_3]: 3:3
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_wakeup_en_en_3 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (wakeup_en_en_3_we & wakeup_en_regwen_qs),
-    .wd     (wakeup_en_en_3_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wakeup_en[3].q ),
-
-    // to register interface (read)
-    .qs     (wakeup_en_en_3_qs)
-  );
-
-
-  // F[en_4]: 4:4
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_wakeup_en_en_4 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (wakeup_en_en_4_we & wakeup_en_regwen_qs),
-    .wd     (wakeup_en_en_4_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wakeup_en[4].q ),
-
-    // to register interface (read)
-    .qs     (wakeup_en_en_4_qs)
-  );
-
-
-  // F[en_5]: 5:5
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_wakeup_en_en_5 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (wakeup_en_en_5_we & wakeup_en_regwen_qs),
-    .wd     (wakeup_en_en_5_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wakeup_en[5].q ),
-
-    // to register interface (read)
-    .qs     (wakeup_en_en_5_qs)
-  );
-
-
-  // F[en_6]: 6:6
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_wakeup_en_en_6 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (wakeup_en_en_6_we & wakeup_en_regwen_qs),
-    .wd     (wakeup_en_en_6_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wakeup_en[6].q ),
-
-    // to register interface (read)
-    .qs     (wakeup_en_en_6_qs)
-  );
-
-
-  // F[en_7]: 7:7
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_wakeup_en_en_7 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (wakeup_en_en_7_we & wakeup_en_regwen_qs),
-    .wd     (wakeup_en_en_7_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wakeup_en[7].q ),
-
-    // to register interface (read)
-    .qs     (wakeup_en_en_7_qs)
-  );
-
-
-  // F[en_8]: 8:8
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_wakeup_en_en_8 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (wakeup_en_en_8_we & wakeup_en_regwen_qs),
-    .wd     (wakeup_en_en_8_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wakeup_en[8].q ),
-
-    // to register interface (read)
-    .qs     (wakeup_en_en_8_qs)
-  );
-
-
-  // F[en_9]: 9:9
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_wakeup_en_en_9 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (wakeup_en_en_9_we & wakeup_en_regwen_qs),
-    .wd     (wakeup_en_en_9_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wakeup_en[9].q ),
-
-    // to register interface (read)
-    .qs     (wakeup_en_en_9_qs)
-  );
-
-
-  // F[en_10]: 10:10
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_wakeup_en_en_10 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (wakeup_en_en_10_we & wakeup_en_regwen_qs),
-    .wd     (wakeup_en_en_10_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wakeup_en[10].q ),
-
-    // to register interface (read)
-    .qs     (wakeup_en_en_10_qs)
-  );
-
-
-  // F[en_11]: 11:11
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_wakeup_en_en_11 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (wakeup_en_en_11_we & wakeup_en_regwen_qs),
-    .wd     (wakeup_en_en_11_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wakeup_en[11].q ),
-
-    // to register interface (read)
-    .qs     (wakeup_en_en_11_qs)
-  );
-
-
-  // F[en_12]: 12:12
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_wakeup_en_en_12 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (wakeup_en_en_12_we & wakeup_en_regwen_qs),
-    .wd     (wakeup_en_en_12_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wakeup_en[12].q ),
-
-    // to register interface (read)
-    .qs     (wakeup_en_en_12_qs)
-  );
-
-
-  // F[en_13]: 13:13
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_wakeup_en_en_13 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (wakeup_en_en_13_we & wakeup_en_regwen_qs),
-    .wd     (wakeup_en_en_13_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wakeup_en[13].q ),
-
-    // to register interface (read)
-    .qs     (wakeup_en_en_13_qs)
-  );
-
-
-  // F[en_14]: 14:14
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_wakeup_en_en_14 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (wakeup_en_en_14_we & wakeup_en_regwen_qs),
-    .wd     (wakeup_en_en_14_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wakeup_en[14].q ),
-
-    // to register interface (read)
-    .qs     (wakeup_en_en_14_qs)
-  );
-
-
-  // F[en_15]: 15:15
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_wakeup_en_en_15 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface (qualified with register enable)
-    .we     (wakeup_en_en_15_we & wakeup_en_regwen_qs),
-    .wd     (wakeup_en_en_15_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wakeup_en[15].q ),
-
-    // to register interface (read)
-    .qs     (wakeup_en_en_15_qs)
-  );
-
 
 
 
   // Subregister 0 of Multireg wake_status
   // R[wake_status]: V(False)
 
-  // F[val_0]: 0:0
-  // constant-only read
-  assign wake_status_val_0_qs = 1'h0;
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RO"),
+    .RESVAL  (1'h0)
+  ) u_wake_status (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
 
+    .we     (1'b0),
+    .wd     ('0  ),
 
-  // F[val_1]: 1:1
-  // constant-only read
-  assign wake_status_val_1_qs = 1'h0;
+    // from internal hardware
+    .de     (hw2reg.wake_status[0].de),
+    .d      (hw2reg.wake_status[0].d ),
 
+    // to internal hardware
+    .qe     (),
+    .q      (),
 
-  // F[val_2]: 2:2
-  // constant-only read
-  assign wake_status_val_2_qs = 1'h0;
-
-
-  // F[val_3]: 3:3
-  // constant-only read
-  assign wake_status_val_3_qs = 1'h0;
-
-
-  // F[val_4]: 4:4
-  // constant-only read
-  assign wake_status_val_4_qs = 1'h0;
-
-
-  // F[val_5]: 5:5
-  // constant-only read
-  assign wake_status_val_5_qs = 1'h0;
-
-
-  // F[val_6]: 6:6
-  // constant-only read
-  assign wake_status_val_6_qs = 1'h0;
-
-
-  // F[val_7]: 7:7
-  // constant-only read
-  assign wake_status_val_7_qs = 1'h0;
-
-
-  // F[val_8]: 8:8
-  // constant-only read
-  assign wake_status_val_8_qs = 1'h0;
-
-
-  // F[val_9]: 9:9
-  // constant-only read
-  assign wake_status_val_9_qs = 1'h0;
-
-
-  // F[val_10]: 10:10
-  // constant-only read
-  assign wake_status_val_10_qs = 1'h0;
-
-
-  // F[val_11]: 11:11
-  // constant-only read
-  assign wake_status_val_11_qs = 1'h0;
-
-
-  // F[val_12]: 12:12
-  // constant-only read
-  assign wake_status_val_12_qs = 1'h0;
-
-
-  // F[val_13]: 13:13
-  // constant-only read
-  assign wake_status_val_13_qs = 1'h0;
-
-
-  // F[val_14]: 14:14
-  // constant-only read
-  assign wake_status_val_14_qs = 1'h0;
-
-
-  // F[val_15]: 15:15
-  // constant-only read
-  assign wake_status_val_15_qs = 1'h0;
-
+    // to register interface (read)
+    .qs     (wake_status_qs)
+  );
 
 
   // R[reset_en_regwen]: V(False)
@@ -966,12 +515,14 @@ module pwrmgr_reg_top (
   );
 
 
+
+  // Subregister 0 of Multireg reset_en
   // R[reset_en]: V(False)
 
   prim_subreg #(
-    .DW      (2),
+    .DW      (1),
     .SWACCESS("RW"),
-    .RESVAL  (2'h0)
+    .RESVAL  (1'h0)
   ) u_reset_en (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -986,17 +537,39 @@ module pwrmgr_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.reset_en.q ),
+    .q      (reg2hw.reset_en[0].q ),
 
     // to register interface (read)
     .qs     (reset_en_qs)
   );
 
 
+
+  // Subregister 0 of Multireg reset_status
   // R[reset_status]: V(False)
 
-  // constant-only read
-  assign reset_status_qs = 2'h0;
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RO"),
+    .RESVAL  (1'h0)
+  ) u_reset_status (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    .we     (1'b0),
+    .wd     ('0  ),
+
+    // from internal hardware
+    .de     (hw2reg.reset_status[0].de),
+    .d      (hw2reg.reset_status[0].d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (reset_status_qs)
+  );
 
 
   // R[wake_info_capture_dis]: V(False)
@@ -1028,9 +601,9 @@ module pwrmgr_reg_top (
 
   // R[wake_info]: V(True)
 
-  //   F[reasons]: 15:0
+  //   F[reasons]: 0:0
   prim_subreg_ext #(
-    .DW    (16)
+    .DW    (1)
   ) u_wake_info_reasons (
     .re     (wake_info_reasons_re),
     .we     (wake_info_reasons_we),
@@ -1043,7 +616,7 @@ module pwrmgr_reg_top (
   );
 
 
-  //   F[fall_through]: 16:16
+  //   F[fall_through]: 1:1
   prim_subreg_ext #(
     .DW    (1)
   ) u_wake_info_fall_through (
@@ -1058,7 +631,7 @@ module pwrmgr_reg_top (
   );
 
 
-  //   F[abort]: 17:17
+  //   F[abort]: 2:2
   prim_subreg_ext #(
     .DW    (1)
   ) u_wake_info_abort (
@@ -1135,8 +708,14 @@ module pwrmgr_reg_top (
   assign control_io_clk_en_we = addr_hit[4] & reg_we & ~wr_err;
   assign control_io_clk_en_wd = reg_wdata[5];
 
+  assign control_usb_clk_en_lp_we = addr_hit[4] & reg_we & ~wr_err;
+  assign control_usb_clk_en_lp_wd = reg_wdata[6];
+
+  assign control_usb_clk_en_active_we = addr_hit[4] & reg_we & ~wr_err;
+  assign control_usb_clk_en_active_wd = reg_wdata[7];
+
   assign control_main_pd_n_we = addr_hit[4] & reg_we & ~wr_err;
-  assign control_main_pd_n_wd = reg_wdata[6];
+  assign control_main_pd_n_wd = reg_wdata[8];
 
   assign cfg_cdc_sync_we = addr_hit[5] & reg_we & ~wr_err;
   assign cfg_cdc_sync_wd = reg_wdata[0];
@@ -1144,90 +723,30 @@ module pwrmgr_reg_top (
   assign wakeup_en_regwen_we = addr_hit[6] & reg_we & ~wr_err;
   assign wakeup_en_regwen_wd = reg_wdata[0];
 
-  assign wakeup_en_en_0_we = addr_hit[7] & reg_we & ~wr_err;
-  assign wakeup_en_en_0_wd = reg_wdata[0];
-
-  assign wakeup_en_en_1_we = addr_hit[7] & reg_we & ~wr_err;
-  assign wakeup_en_en_1_wd = reg_wdata[1];
-
-  assign wakeup_en_en_2_we = addr_hit[7] & reg_we & ~wr_err;
-  assign wakeup_en_en_2_wd = reg_wdata[2];
-
-  assign wakeup_en_en_3_we = addr_hit[7] & reg_we & ~wr_err;
-  assign wakeup_en_en_3_wd = reg_wdata[3];
-
-  assign wakeup_en_en_4_we = addr_hit[7] & reg_we & ~wr_err;
-  assign wakeup_en_en_4_wd = reg_wdata[4];
-
-  assign wakeup_en_en_5_we = addr_hit[7] & reg_we & ~wr_err;
-  assign wakeup_en_en_5_wd = reg_wdata[5];
-
-  assign wakeup_en_en_6_we = addr_hit[7] & reg_we & ~wr_err;
-  assign wakeup_en_en_6_wd = reg_wdata[6];
-
-  assign wakeup_en_en_7_we = addr_hit[7] & reg_we & ~wr_err;
-  assign wakeup_en_en_7_wd = reg_wdata[7];
-
-  assign wakeup_en_en_8_we = addr_hit[7] & reg_we & ~wr_err;
-  assign wakeup_en_en_8_wd = reg_wdata[8];
-
-  assign wakeup_en_en_9_we = addr_hit[7] & reg_we & ~wr_err;
-  assign wakeup_en_en_9_wd = reg_wdata[9];
-
-  assign wakeup_en_en_10_we = addr_hit[7] & reg_we & ~wr_err;
-  assign wakeup_en_en_10_wd = reg_wdata[10];
-
-  assign wakeup_en_en_11_we = addr_hit[7] & reg_we & ~wr_err;
-  assign wakeup_en_en_11_wd = reg_wdata[11];
-
-  assign wakeup_en_en_12_we = addr_hit[7] & reg_we & ~wr_err;
-  assign wakeup_en_en_12_wd = reg_wdata[12];
-
-  assign wakeup_en_en_13_we = addr_hit[7] & reg_we & ~wr_err;
-  assign wakeup_en_en_13_wd = reg_wdata[13];
-
-  assign wakeup_en_en_14_we = addr_hit[7] & reg_we & ~wr_err;
-  assign wakeup_en_en_14_wd = reg_wdata[14];
-
-  assign wakeup_en_en_15_we = addr_hit[7] & reg_we & ~wr_err;
-  assign wakeup_en_en_15_wd = reg_wdata[15];
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  assign wakeup_en_we = addr_hit[7] & reg_we & ~wr_err;
+  assign wakeup_en_wd = reg_wdata[0];
 
 
   assign reset_en_regwen_we = addr_hit[9] & reg_we & ~wr_err;
   assign reset_en_regwen_wd = reg_wdata[0];
 
   assign reset_en_we = addr_hit[10] & reg_we & ~wr_err;
-  assign reset_en_wd = reg_wdata[1:0];
+  assign reset_en_wd = reg_wdata[0];
 
 
   assign wake_info_capture_dis_we = addr_hit[12] & reg_we & ~wr_err;
   assign wake_info_capture_dis_wd = reg_wdata[0];
 
   assign wake_info_reasons_we = addr_hit[13] & reg_we & ~wr_err;
-  assign wake_info_reasons_wd = reg_wdata[15:0];
+  assign wake_info_reasons_wd = reg_wdata[0];
   assign wake_info_reasons_re = addr_hit[13] && reg_re;
 
   assign wake_info_fall_through_we = addr_hit[13] & reg_we & ~wr_err;
-  assign wake_info_fall_through_wd = reg_wdata[16];
+  assign wake_info_fall_through_wd = reg_wdata[1];
   assign wake_info_fall_through_re = addr_hit[13] && reg_re;
 
   assign wake_info_abort_we = addr_hit[13] & reg_we & ~wr_err;
-  assign wake_info_abort_wd = reg_wdata[17];
+  assign wake_info_abort_wd = reg_wdata[2];
   assign wake_info_abort_re = addr_hit[13] && reg_re;
 
   // Read data return
@@ -1254,7 +773,9 @@ module pwrmgr_reg_top (
         reg_rdata_next[0] = control_low_power_hint_qs;
         reg_rdata_next[4] = control_core_clk_en_qs;
         reg_rdata_next[5] = control_io_clk_en_qs;
-        reg_rdata_next[6] = control_main_pd_n_qs;
+        reg_rdata_next[6] = control_usb_clk_en_lp_qs;
+        reg_rdata_next[7] = control_usb_clk_en_active_qs;
+        reg_rdata_next[8] = control_main_pd_n_qs;
       end
 
       addr_hit[5]: begin
@@ -1266,41 +787,11 @@ module pwrmgr_reg_top (
       end
 
       addr_hit[7]: begin
-        reg_rdata_next[0] = wakeup_en_en_0_qs;
-        reg_rdata_next[1] = wakeup_en_en_1_qs;
-        reg_rdata_next[2] = wakeup_en_en_2_qs;
-        reg_rdata_next[3] = wakeup_en_en_3_qs;
-        reg_rdata_next[4] = wakeup_en_en_4_qs;
-        reg_rdata_next[5] = wakeup_en_en_5_qs;
-        reg_rdata_next[6] = wakeup_en_en_6_qs;
-        reg_rdata_next[7] = wakeup_en_en_7_qs;
-        reg_rdata_next[8] = wakeup_en_en_8_qs;
-        reg_rdata_next[9] = wakeup_en_en_9_qs;
-        reg_rdata_next[10] = wakeup_en_en_10_qs;
-        reg_rdata_next[11] = wakeup_en_en_11_qs;
-        reg_rdata_next[12] = wakeup_en_en_12_qs;
-        reg_rdata_next[13] = wakeup_en_en_13_qs;
-        reg_rdata_next[14] = wakeup_en_en_14_qs;
-        reg_rdata_next[15] = wakeup_en_en_15_qs;
+        reg_rdata_next[0] = wakeup_en_qs;
       end
 
       addr_hit[8]: begin
-        reg_rdata_next[0] = wake_status_val_0_qs;
-        reg_rdata_next[1] = wake_status_val_1_qs;
-        reg_rdata_next[2] = wake_status_val_2_qs;
-        reg_rdata_next[3] = wake_status_val_3_qs;
-        reg_rdata_next[4] = wake_status_val_4_qs;
-        reg_rdata_next[5] = wake_status_val_5_qs;
-        reg_rdata_next[6] = wake_status_val_6_qs;
-        reg_rdata_next[7] = wake_status_val_7_qs;
-        reg_rdata_next[8] = wake_status_val_8_qs;
-        reg_rdata_next[9] = wake_status_val_9_qs;
-        reg_rdata_next[10] = wake_status_val_10_qs;
-        reg_rdata_next[11] = wake_status_val_11_qs;
-        reg_rdata_next[12] = wake_status_val_12_qs;
-        reg_rdata_next[13] = wake_status_val_13_qs;
-        reg_rdata_next[14] = wake_status_val_14_qs;
-        reg_rdata_next[15] = wake_status_val_15_qs;
+        reg_rdata_next[0] = wake_status_qs;
       end
 
       addr_hit[9]: begin
@@ -1308,11 +799,11 @@ module pwrmgr_reg_top (
       end
 
       addr_hit[10]: begin
-        reg_rdata_next[1:0] = reset_en_qs;
+        reg_rdata_next[0] = reset_en_qs;
       end
 
       addr_hit[11]: begin
-        reg_rdata_next[1:0] = reset_status_qs;
+        reg_rdata_next[0] = reset_status_qs;
       end
 
       addr_hit[12]: begin
@@ -1320,9 +811,9 @@ module pwrmgr_reg_top (
       end
 
       addr_hit[13]: begin
-        reg_rdata_next[15:0] = wake_info_reasons_qs;
-        reg_rdata_next[16] = wake_info_fall_through_qs;
-        reg_rdata_next[17] = wake_info_abort_qs;
+        reg_rdata_next[0] = wake_info_reasons_qs;
+        reg_rdata_next[1] = wake_info_fall_through_qs;
+        reg_rdata_next[2] = wake_info_abort_qs;
       end
 
       default: begin

--- a/hw/top_earlgrey/lint/top_earlgrey_lint_cfgs.hjson
+++ b/hw/top_earlgrey/lint/top_earlgrey_lint_cfgs.hjson
@@ -76,6 +76,12 @@
                   fusesoc_core: lowrisc:ip:otp_ctrl
                   import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
                   rel_path: "hw/ip/otp_ctrl/lint/{tool}"
+                  overrides: [
+                    {
+                      name: design_level
+                      value: "top"
+                    }
+                  ]
              },
              {    name: padctrl
                   fusesoc_core: lowrisc:ip:padctrl


### PR DESCRIPTION
This aligns the IO signals of the OTP controller, and switches the EDN update interface for LFSR reseeding to `req/ack`. A 16bit counter is added to the LFSR timer in order to periodically requests entropy for LFSR reseeding from EDN.

Ssince the power manager feedback signals are defined in the `pwrmgr_pkg`, I had to update the "example design" version for this to work standalone (second commit).