### PR TITLE
[otbn] Add support for CSRs/WSRs to ISS

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/csr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/csr.py
@@ -1,0 +1,64 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import List
+
+from riscvmodel.types import Trace  # type: ignore
+
+from .flags import FlagGroups
+from .wsr import WSRFile
+
+
+class CSRFile:
+    '''A model of the CSR file'''
+    def __init__(self) -> None:
+        self.flags = FlagGroups()
+
+    def read_unsigned(self, wsrs: WSRFile, idx: int) -> int:
+        if idx == 0x7c0:
+            # FLAGS register
+            return self.flags.read_unsigned()
+
+        if 0x7d0 <= idx <= 0x7d7:
+            # MOD0 .. MOD7. MODi is bits [32*(i+1)-1..32*i]
+            i = idx - 0x7d0
+            mod_val = wsrs.MOD.read_unsigned()
+            mask32 = (1 << 32) - 1
+            return (mod_val >> (32 * i)) & mask32
+
+        if idx == 0xfc0:
+            # RND register
+            return wsrs.RND.read_u32()
+
+        raise RuntimeError('Unknown CSR index: {:#x}'.format(idx))
+
+    def write_unsigned(self, wsrs: WSRFile, idx: int, value: int) -> None:
+        assert 0 <= value < (1 << 32)
+
+        if idx == 0x7c0:
+            # FLAGS register
+            self.flags.write_unsigned(value)
+            return
+
+        if 0x7d0 <= idx <= 0x7d7:
+            # MOD0 .. MOD7. MODi is bits [32*(i+1)-1..32*i]. read,modify,write.
+            i = idx - 0x7d0
+            old_val = wsrs.MOD.read_unsigned()
+            shifted_mask = ((1 << 32) - 1) << (32 * i)
+            cleared = old_val & ~shifted_mask
+            new_val = cleared | (value << (32 * i))
+            wsrs.MOD.write_unsigned(new_val)
+            return
+
+        if idx == 0xfc0:
+            # RND register (writes are ignored)
+            return
+
+        raise RuntimeError('Unknown CSR index: {:#x}'.format(idx))
+
+    def commit(self) -> None:
+        self.flags.commit()
+
+    def changes(self) -> List[Trace]:
+        return self.flags.changes()

--- a/hw/ip/otbn/dv/otbnsim/sim/flags.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/flags.py
@@ -1,0 +1,128 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import List, Optional, cast
+
+from riscvmodel.types import Trace  # type: ignore
+
+
+class TraceFlag(Trace):  # type: ignore
+    def __init__(self, group_name: str, flag_name: str, value: bool):
+        self.group_name = group_name
+        self.flag_name = flag_name
+        self.value = value
+
+    def __str__(self) -> str:
+        return '{}.{} = {}'.format(self.group_name, self.flag_name, int(self.value))
+
+
+class FlagReg:
+    FLAG_NAMES = ['C', 'M', 'L', 'Z']
+
+    def __init__(self, C: bool, M: bool, L: bool, Z: bool):
+        self.C = C
+        self.L = L
+        self.M = M
+        self.Z = Z
+
+        self._new_val = None  # type: Optional['FlagReg']
+
+    def set_flags(self, other: 'FlagReg') -> None:
+        self._new_val = other
+
+    def get_by_name(self, flag_name: str) -> bool:
+        assert flag_name in FlagReg.FLAG_NAMES
+        return cast(bool, getattr(self, flag_name))
+
+    def get_by_idx(self, flag_idx: int) -> bool:
+        assert 0 <= flag_idx <= 3
+        flag_name = FlagReg.FLAG_NAMES[flag_idx]
+        return self.get_by_name(flag_name)
+
+    def changes(self, group_name: str) -> List[TraceFlag]:
+        if self._new_val is None:
+            return []
+        return [TraceFlag(group_name, n, self._new_val.get_by_name(n))
+                for n in FlagReg.FLAG_NAMES]
+
+    def commit(self) -> None:
+        if self._new_val is not None:
+            for n in FlagReg.FLAG_NAMES:
+                setattr(self, n, getattr(self._new_val, n))
+        self._new_val = None
+
+    def read_unsigned(self) -> int:
+        '''Return a 4-bit number with the flags as ZMLC'''
+        return ((int(self.Z) << 3) |
+                (int(self.M) << 2) |
+                (int(self.L) << 1) |
+                (int(self.C) << 0))
+
+    def write_unsigned(self, value: int) -> None:
+        '''Set flags using bottom 4 bits of the unsigned number, value'''
+        assert 0 <= value
+        self.set_flags(FlagReg.from_bits(value))
+
+    @staticmethod
+    def mlz_for_result(C: bool, result: int) -> 'FlagReg':
+        '''Generate flags for the result of an operation.
+
+        C is the value for the C flag. result is the wide-side result value
+        that is used to generate M, L and Z.
+
+        '''
+        M = bool((result >> 255) & 1)
+        L = bool(result & 1)
+        Z = bool(result == 0)
+        return FlagReg(C=C, M=M, L=L, Z=Z)
+
+    @staticmethod
+    def from_bits(value: int) -> 'FlagReg':
+        assert 0 <= value
+        C = bool((value >> 0) & 1)
+        L = bool((value >> 1) & 1)
+        M = bool((value >> 2) & 1)
+        Z = bool((value >> 3) & 1)
+        return FlagReg(C=C, M=M, L=L, Z=Z)
+
+
+class FlagGroups:
+    def __init__(self) -> None:
+        self.groups = {0: FlagReg(False, False, False, False),
+                       1: FlagReg(False, False, False, False)}
+
+    def __getitem__(self, key: int) -> FlagReg:
+        assert 0 <= key <= 1
+        return self.groups[key]
+
+    def __setitem__(self, key: int, value: FlagReg) -> None:
+        assert 0 <= key <= 1
+        self.groups[key].set_flags(value)
+
+    def changes(self) -> List[TraceFlag]:
+        return self.groups[0].changes('FG0') + self.groups[1].changes('FG1')
+
+    def commit(self) -> None:
+        self.groups[0].commit()
+        self.groups[1].commit()
+
+    def read_unsigned(self) -> int:
+        '''Return the flag groups as an unsigned value (as seen by CSRs)
+
+        Format is defined in FlagReg, with group 0 as LSB.
+
+        '''
+        return ((self.groups[1].read_unsigned() << 4) |
+                (self.groups[0].read_unsigned() << 0))
+
+    def write_unsigned(self, value: int) -> None:
+        '''Set the flag groups with an unsigned value, ignoring unused bits
+
+        Format is defined in FlagReg, with group 0 as LSB.
+
+        '''
+        assert 0 <= value
+        mask4 = (1 << 4) - 1
+        self.groups[0].write_unsigned((value >> 0) & mask4)
+        self.groups[1].write_unsigned((value >> 4) & mask4)

--- a/hw/ip/otbn/dv/otbnsim/sim/insn.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/insn.py
@@ -258,10 +258,14 @@ class CSRRS(OTBNInsn):
         super().__init__(op_vals)
         self.grd = op_vals['grd']
         self.csr = op_vals['csr']
-        self.grs = op_vals['grs']
+        self.grs1 = op_vals['grs1']
 
     def execute(self, state: OTBNState) -> None:
-        raise NotImplementedError('csrrs.execute')
+        old_val = state.read_csr(self.csr)
+        bits_to_set = state.intreg[self.grs1].unsigned()
+
+        state.intreg[self.grd] = old_val
+        state.write_csr(self.csr, old_val | bits_to_set)
 
 
 class CSRRW(OTBNInsn):
@@ -271,10 +275,17 @@ class CSRRW(OTBNInsn):
         super().__init__(op_vals)
         self.grd = op_vals['grd']
         self.csr = op_vals['csr']
-        self.grs = op_vals['grs']
+        self.grs1 = op_vals['grs1']
 
     def execute(self, state: OTBNState) -> None:
-        raise NotImplementedError('csrrw.execute')
+        if self.grd == 0:
+            return
+
+        old_val = state.read_csr(self.csr)
+        new_val = state.intreg[self.grs1].unsigned()
+
+        state.intreg[self.grd] = old_val
+        state.write_csr(self.csr, new_val)
 
 
 class ECALL(OTBNInsn):
@@ -339,7 +350,7 @@ class BNADD(OTBNInsn):
                              self.shift_type, self.shift_bytes)
         (result, flags) = state.add_with_carry(a, b_shifted, 0)
         state.wreg[self.wrd] = result
-        state.flags[self.flag_group] = flags
+        state.set_flags(self.flag_group, flags)
 
 
 class BNADDC(OTBNInsn):
@@ -358,10 +369,10 @@ class BNADDC(OTBNInsn):
         a = int(state.wreg[self.wrs1].unsigned())
         b_shifted = ShiftReg(int(state.wreg[self.wrs2].unsigned()),
                              self.shift_type, self.shift_bytes)
-        flag_c = state.flags[self.flag_group].C
-        (result, flags) = state.add_with_carry(a, b_shifted, flag_c)
+        carry = int(state.csrs.flags[self.flag_group].C)
+        (result, flags) = state.add_with_carry(a, b_shifted, carry)
         state.wreg[self.wrd] = result
-        state.flags[self.flag_group] = flags
+        state.set_flags(self.flag_group, flags)
 
 
 class BNADDI(OTBNInsn):
@@ -379,7 +390,7 @@ class BNADDI(OTBNInsn):
         b = int(self.imm)
         (result, flags) = state.add_with_carry(a, b, 0)
         state.wreg[self.wrd] = result
-        state.flags[self.flag_group] = flags
+        state.set_flags(self.flag_group, flags)
 
 
 class BNADDM(OTBNInsn):
@@ -395,8 +406,8 @@ class BNADDM(OTBNInsn):
         a = int(state.wreg[self.wrs1].unsigned())
         b = int(state.wreg[self.wrs2].unsigned())
         (result, _) = state.add_with_carry(a, b, 0)
-        if result >= int(state.mod):
-            result -= int(state.mod)
+        if result >= state.wsrs.MOD.read_unsigned():
+            result -= state.wsrs.MOD.read_unsigned()
         state.wreg[self.wrd] = result
 
 
@@ -418,13 +429,13 @@ class BNMULQACC(OTBNInsn):
 
         mul_res = a_qw * b_qw
 
-        acc = int(state.single_regs['acc'])
+        acc = state.wsrs.ACC.read_signed()
         if self.zero_acc:
             acc = 0
 
         acc += (mul_res << self.acc_shift_imm)
 
-        state.single_regs['acc'].update(acc)
+        state.wsrs.ACC.write_signed(acc)
 
 
 class BNMULQACCWO(OTBNInsn):
@@ -446,7 +457,7 @@ class BNMULQACCWO(OTBNInsn):
 
         mul_res = a_qw * b_qw
 
-        acc = int(state.single_regs['acc'])
+        acc = state.wsrs.ACC.read_signed()
         if self.zero_acc:
             acc = 0
 
@@ -454,7 +465,7 @@ class BNMULQACCWO(OTBNInsn):
 
         state.wreg[self.wrd].set(acc)
 
-        state.single_regs['acc'].update(acc)
+        state.wsrs.ACC.write_signed(acc)
 
 
 class BNMULQACCSO(OTBNInsn):
@@ -477,7 +488,7 @@ class BNMULQACCSO(OTBNInsn):
 
         mul_res = a_qw * b_qw
 
-        acc = int(state.single_regs['acc'])
+        acc = state.wsrs.ACC.read_signed()
         if self.zero_acc:
             acc = 0
 
@@ -488,7 +499,7 @@ class BNMULQACCSO(OTBNInsn):
         state.set_wr_halfword(self.wrd, acc_lower, self.wrd_hwsel)
         acc = acc >> 128
 
-        state.single_regs['acc'].update(acc)
+        state.wsrs.ACC.write_signed(acc)
 
 
 class BNSUB(OTBNInsn):
@@ -509,7 +520,7 @@ class BNSUB(OTBNInsn):
                              self.shift_bytes)
         (result, flags) = state.subtract_with_borrow(a, b_shifted, 0)
         state.wreg[self.wrd] = result
-        state.flags[self.flag_group] = flags
+        state.set_flags(self.flag_group, flags)
 
 
 class BNSUBB(OTBNInsn):
@@ -525,16 +536,13 @@ class BNSUBB(OTBNInsn):
         self.flag_group = op_vals['flag_group']
 
     def execute(self, state: OTBNState) -> None:
-        assert (state.flags[self.flag_group].C == 0 or
-                state.flags[self.flag_group].C == 1)
-
         a = int(state.wreg[self.wrs1])
         b_shifted = ShiftReg(int(state.wreg[self.wrs2]), self.shift_type,
                              self.shift_bytes)
-        flag_c = state.flags[self.flag_group].C
-        (result, flags) = state.subtract_with_borrow(a, b_shifted, flag_c)
+        borrow = int(state.csrs.flags[self.flag_group].C)
+        (result, flags) = state.subtract_with_borrow(a, b_shifted, borrow)
         state.wreg[self.wrd] = result
-        state.flags[self.flag_group] = flags
+        state.set_flags(self.flag_group, flags)
 
 
 class BNSUBI(OTBNInsn):
@@ -552,7 +560,7 @@ class BNSUBI(OTBNInsn):
         b = int(self.imm)
         (result, flags) = state.subtract_with_borrow(a, b, 0)
         state.wreg[self.wrd] = result
-        state.flags[self.flag_group] = flags
+        state.set_flags(self.flag_group, flags)
 
 
 class BNSUBM(OTBNInsn):
@@ -569,7 +577,7 @@ class BNSUBM(OTBNInsn):
         b = int(state.wreg[self.wrs2])
         result, _ = state.subtract_with_borrow(a, b, 0)
         if result < 0:
-            result += state.mod
+            result += state.wsrs.MOD.read_unsigned()
         state.wreg[self.wrd] = result
 
 
@@ -591,7 +599,7 @@ class BNAND(OTBNInsn):
         a = state.wreg[self.wrs1].unsigned()
         result = a & b_shifted
         state.wreg[self.wrd] = result
-        state.update_mlz_flags(self.flag_group, result)
+        state.set_mlz_flags(self.flag_group, result)
 
 
 class BNOR(OTBNInsn):
@@ -612,7 +620,7 @@ class BNOR(OTBNInsn):
         a = state.wreg[self.wrs1]
         result = a | b_shifted
         state.wreg[self.wrd] = result
-        state.update_mlz_flags(self.flag_group, result)
+        state.set_mlz_flags(self.flag_group, result)
 
 
 class BNNOT(OTBNInsn):
@@ -631,8 +639,7 @@ class BNNOT(OTBNInsn):
                              self.shift_type, self.shift_bytes)
         result = ~b_shifted
         state.wreg[self.wrd] = result
-        state.update_mlz_flags(0, result)
-        state.update_mlz_flags(self.flag_group, result)
+        state.set_mlz_flags(self.flag_group, result)
 
 
 class BNXOR(OTBNInsn):
@@ -653,7 +660,7 @@ class BNXOR(OTBNInsn):
         a = state.wreg[self.wrs1]
         result = a ^ b_shifted
         state.wreg[self.wrd] = result
-        state.update_mlz_flags(self.flag_group, result)
+        state.set_mlz_flags(self.flag_group, result)
 
 
 class BNRSHI(OTBNInsn):
@@ -685,7 +692,7 @@ class BNRSEL(OTBNInsn):
         self.flag = op_vals['flag']
 
     def execute(self, state: OTBNState) -> None:
-        flag_is_set = state.flags[self.flag_group].get_by_idx(self.flag)
+        flag_is_set = state.csrs.flags[self.flag_group].get_by_idx(self.flag)
         val = state.wreg[self.wrs1 if flag_is_set else self.wrs2]
         state.wreg[self.wrd] = val
 
@@ -706,7 +713,7 @@ class BNCMP(OTBNInsn):
         b_shifted = ShiftReg(int(state.wreg[self.wrs2]), self.shift_type,
                              self.shift_bytes)
         (_, flags) = state.subtract_with_borrow(a, b_shifted, 0)
-        state.flags[self.flag_group] = flags
+        state.set_flags(self.flag_group, flags)
 
 
 class BNCMPB(OTBNInsn):
@@ -721,14 +728,12 @@ class BNCMPB(OTBNInsn):
         self.flag_group = op_vals['flag_group']
 
     def execute(self, state: OTBNState) -> None:
-        assert (state.flags[self.flag_group].C == 0 or
-                state.flags[self.flag_group].C == 1)
         a = int(state.wreg[self.wrs1])
         b_shifted = ShiftReg(int(state.wreg[self.wrs2]), self.shift_type,
                              self.shift_bytes)
-        flag_c = state.flags[self.flag_group].C
-        (_, flags) = state.subtract_with_borrow(a, b_shifted, flag_c)
-        state.flags[self.flag_group] = flags
+        borrow = int(state.csrs.flags[self.flag_group].C)
+        (_, flags) = state.subtract_with_borrow(a, b_shifted, borrow)
+        state.set_flags(self.flag_group, flags)
 
 
 class BNLID(OTBNInsn):
@@ -820,12 +825,11 @@ class BNWSRRS(OTBNInsn):
         self.wrs = op_vals['wrs']
 
     def execute(self, state: OTBNState) -> None:
-        idx = self.wsr
-        old_val = state.wcsr_read(idx)
-        new_val = old_val | state.wreg[self.wrs]
+        old_val = state.wsrs.read_at_idx(self.wsr)
+        bits_to_set = state.wreg[self.wrs].unsigned()
 
         state.wreg[self.wrd] = old_val
-        state.wcsr_write(idx, new_val)
+        state.wsrs.write_at_idx(self.wsr, old_val | bits_to_set)
 
 
 class BNWSRRW(OTBNInsn):
@@ -838,12 +842,11 @@ class BNWSRRW(OTBNInsn):
         self.wrs = op_vals['wrs']
 
     def execute(self, state: OTBNState) -> None:
-        idx = self.wsr
-        old_val = state.wcsr_read(idx)
-        new_val = state.wreg[self.wrs]
+        old_val = state.wsrs.read_at_idx(self.wsr)
+        new_val = state.wreg[self.wrs].unsigned()
 
         state.wreg[self.wrd] = old_val
-        state.wcsr_write(idx, new_val)
+        state.wsrs.write_at_idx(self.wsr, new_val)
 
 
 INSN_CLASSES = [

--- a/hw/ip/otbn/dv/otbnsim/sim/wsr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/wsr.py
@@ -1,0 +1,128 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import List, Optional
+
+from riscvmodel.types import Trace  # type: ignore
+
+
+class TraceWSR(Trace):  # type: ignore
+    def __init__(self, wsr_name: str, new_value: int):
+        self.wsr_name = wsr_name
+        self.new_value = new_value
+
+    def __str__(self) -> str:
+        return '{} = {:#x}'.format(self.wsr_name, self.new_value)
+
+
+class WSR:
+    '''Models a Wide Status Register'''
+    def __init__(self, name: str):
+        self.name = name
+
+    def read_unsigned(self) -> int:
+        '''Get the stored value as a 256-bit unsigned value'''
+        raise NotImplementedError()
+
+    def write_unsigned(self, value: int) -> None:
+        '''Set the stored value as a 256-bit unsigned value'''
+        raise NotImplementedError()
+
+    def read_signed(self) -> int:
+        '''Get the stored value as a 256-bit signed value'''
+        uval = self.read_unsigned()
+        return uval - (1 << 256 if uval >> 255 else 0)
+
+    def write_signed(self, value: int) -> None:
+        '''Set the stored value as a 256-bit signed value'''
+        assert -(1 << 255) <= value < (1 << 255)
+        uval = (1 << 256) + value if value < 0 else value
+        self.write_unsigned(uval)
+
+    def commit(self) -> None:
+        '''Commit pending changes'''
+        return
+
+    def changes(self) -> List[TraceWSR]:
+        '''Return list of pending architectural changes'''
+        return []
+
+
+class DumbWSR(WSR):
+    '''Models a WSR without special behaviour'''
+    def __init__(self, name: str):
+        super().__init__(name)
+        self._value = 0
+        self._next_value = None  # type: Optional[int]
+
+    def read_unsigned(self) -> int:
+        return self._value
+
+    def write_unsigned(self, value: int) -> None:
+        assert 0 <= value < (1 << 256)
+        self._next_value = value
+
+    def commit(self) -> None:
+        if self._next_value is not None:
+            self._value = self._next_value
+        self._next_value = None
+
+    def changes(self) -> List[TraceWSR]:
+        return ([TraceWSR(self.name, self._next_value)]
+                if self._next_value is not None
+                else [])
+
+
+class RandWSR(WSR):
+    '''The magic RND WSR'''
+    def __init__(self, name: str):
+        super().__init__(name)
+
+        # For now, the RTL doesn't have a real "random number generator".
+        # Eventually, it will have an LFSR of some sort, seeded by the
+        # CSRNG/EDN. We'll model that properly when we've specced it out. Until
+        # then, random numbers are all 0x1.
+        self._random_value = 1
+
+    def read_unsigned(self) -> int:
+        return self._random_value
+
+    def read_u32(self) -> int:
+        '''Read a 32-bit unsigned result'''
+        return self._random_value & ((1 << 32) - 1)
+
+    def write_unsigned(self, value: int) -> None:
+        return
+
+
+class WSRFile:
+    '''A model of the WSR file'''
+    def __init__(self) -> None:
+        self.MOD = DumbWSR('MOD')
+        self.RND = RandWSR('RND')
+        self.ACC = DumbWSR('ACC')
+
+    def _wsr_for_idx(self, idx: int) -> WSR:
+        assert 0 <= idx <= 2
+        return {
+            0: self.MOD,
+            1: self.RND,
+            2: self.ACC
+        }[idx]
+
+    def read_at_idx(self, idx: int) -> int:
+        '''Read the WSR at idx as an unsigned 256-bit value'''
+        return self._wsr_for_idx(idx).read_unsigned()
+
+    def write_at_idx(self, idx: int, value: int) -> None:
+        '''Write the WSR at idx as an unsigned 256-bit value'''
+        return self._wsr_for_idx(idx).write_unsigned(value)
+
+    def commit(self) -> None:
+        self.MOD.commit()
+        self.RND.commit()
+        self.ACC.commit()
+
+    def changes(self) -> List[TraceWSR]:
+        return self.MOD.changes() + self.RND.changes() + self.ACC.changes()


### PR DESCRIPTION
(EDIT: The commit message changed dramatically. This is the new one)

This gets rid of the SingleRegister dictionary that was defining MOD
and ACC and defines a new class (WSRFile) to hold the values. These
are stored internally as unsigned integers, but that's hidden: you
have to access them via functions like read_signed() or
write_unsigned().

We also move the flags inside the CSRs. I'm not completely convinced
this is the right way to do it: alternatively, you could have the
flags sitting inside the state and pass them (as well as the WSRs) to
the CSR functions. If we decide to do that, it should be reasonably
easy to change back. The flags code also gets moved into its own
file (to break a circular include dependency).

There's a certain amount of noise in insns.py from updating how we get
to the flags and how MOD/ACC work. Incidentally, I think the previous
code was probably wrong for MOD as it treated it as a signed number.
While touching this, I also got rid of some bogus assertions (which
only pass because 1 == True in Python: aargh!) and added explicit int
casts to go between bool and int objects.

Finally, this gets the CSRRS/CSRRW instructions working (and, of
course, ports the wide equivalents to the new framework).