### PR TITLE
[otbn] Fix BN.AND in ISS

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/insn.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/insn.py
@@ -588,7 +588,7 @@ class BNAND(OTBNInsn):
     def execute(self, state: OTBNState) -> None:
         b_shifted = ShiftReg(state.wreg[self.wrs2],
                              self.shift_type, self.shift_bytes)
-        a = state.wreg[self.wrs1].unsigned()
+        a = state.wreg[self.wrs1]
         result = a & b_shifted
         state.wreg[self.wrd] = result
         state.update_mlz_flags(self.flag_group, result)


### PR DESCRIPTION
I think that, combined with the CSR/WSR support in #3578, this gets the smoke test working again with Greg's ALU RTL.