### PR TITLE
[fpv/csr_assert] support all modules for CSR assert

### DIFF
--- a/hw/dv/sv/dv_lib/dv_base_vseq.sv
+++ b/hw/dv/sv/dv_lib/dv_base_vseq.sv
@@ -193,7 +193,6 @@ class dv_base_vseq #(type RAL_T               = dv_base_reg_block,
       m_csr_write_seq.set_csr_excl_item(csr_excl);
       m_csr_write_seq.external_checker = cfg.en_scb;
       m_csr_write_seq.en_rand_backdoor_write = 1;
-      set_csr_assert_en(.enable(0)); // csr assert does not support backdoor write
       if (!enable_asserts_in_hw_reset_rand_wr) $assertoff;
       m_csr_write_seq.start(null);
 

--- a/hw/ip/alert_handler/dv/sva/alert_handler_bind.sv
+++ b/hw/ip/alert_handler/dv/sva/alert_handler_bind.sv
@@ -13,15 +13,14 @@ module alert_handler_bind;
     .d2h  (tl_o)
   );
 
-  // TODO: current csr assert only support enable register sw access only
-  // import alert_handler_reg_pkg::*;
-  // bind alert_handler alert_handler_csr_assert_fpv alert_handler_csr_assert (
-  //   .clk_i,
-  //   .rst_ni,
-  //   .h2d    (tl_i),
-  //   .d2h    (tl_o),
-  //   .reg2hw (i_reg_wrap.reg2hw),
-  //   .hw2reg (i_reg_wrap.hw2reg)
-  // );
+  import alert_handler_reg_pkg::*;
+  bind alert_handler alert_handler_csr_assert_fpv alert_handler_csr_assert (
+    .clk_i,
+    .rst_ni,
+    .h2d    (tl_i),
+    .d2h    (tl_o),
+    .reg2hw (i_reg_wrap.reg2hw),
+    .hw2reg (i_reg_wrap.hw2reg)
+  );
 
 endmodule

--- a/hw/ip/flash_ctrl/dv/sva/flash_ctrl_bind.sv
+++ b/hw/ip/flash_ctrl/dv/sva/flash_ctrl_bind.sv
@@ -13,15 +13,14 @@ module flash_ctrl_bind;
     .d2h  (tl_o)
   );
 
-  // TODO: flash_ctrl's enable registers are not all RW0C, need more support on CSR FPV assertion
-  // import flash_ctrl_reg_pkg::*;
-  // bind flash_ctrl flash_ctrl_csr_assert_fpv flash_ctrl_csr_assert (
-  //   .clk_i,
-  //   .rst_ni,
-  //   .h2d    (tl_i),
-  //   .d2h    (tl_o),
-  //   .reg2hw (reg2hw),
-  //   .hw2reg (hw2reg)
-  // );
+  import flash_ctrl_reg_pkg::*;
+  bind flash_ctrl flash_ctrl_csr_assert_fpv flash_ctrl_csr_assert (
+    .clk_i,
+    .rst_ni,
+    .h2d    (tl_i),
+    .d2h    (tl_o),
+    .reg2hw (reg2hw),
+    .hw2reg (hw2reg)
+  );
 
 endmodule


### PR DESCRIPTION
This PR supports all modules to bind csr assertion in both Simulation and FPV by:
1. Add a macro to define the regwen path to see if this is a UVM
testbench or FPV testbench.
2. Remove the previous restriction for csr_hw_reset.
3. Still keep the disable signal in case some special sequence want to
disable the csr assertion check.

Signed-off-by: Cindy Chen <chencindy@google.com>