### PR TITLE
[dv/common] Change TL item content when it's not accepted

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env.sv
@@ -42,6 +42,7 @@ class cip_base_env #(type CFG_T               = cip_base_env_cfg,
     // create components
     m_tl_agent = tl_agent::type_id::create("m_tl_agent", this);
     m_tl_reg_adapter = tl_reg_adapter#()::type_id::create("m_tl_reg_adapter");
+    m_tl_reg_adapter.cfg = cfg.m_tl_agent_cfg;
 
     // create alert agents and set cfgs
     foreach(cfg.list_of_alerts[i]) begin

--- a/hw/dv/sv/csr_utils/csr_seq_lib.sv
+++ b/hw/dv/sv/csr_utils/csr_seq_lib.sv
@@ -364,14 +364,7 @@ class csr_bit_bash_seq extends csr_base_seq;
       val = rg.get();
       val[k]  = ~val[k];
       err_msg = $sformatf("Wrote %0s[%0d]: %0b", rg.get_full_name(), k, val[k]);
-      csr_wr(.csr(rg), .value(val), .blocking(1));
-
-      // if external checker is not enabled and writes are made non-blocking, then we need to
-      // pre-predict so that the mirrored value will be updated. if we dont, then csr_rd_check task
-      // might pick up stale mirrored value
-      if (!external_checker) begin
-        void'(rg.predict(.value(val), .kind(UVM_PREDICT_WRITE)));
-      end
+      csr_wr(.csr(rg), .value(val), .blocking(1), .predict(!external_checker));
 
       // TODO, outstanding access to same reg isn't supported in uvm_reg. Need to add another seq
       // uvm_reg waits until transaction is completed, before start another read/write in same reg
@@ -414,14 +407,7 @@ class csr_aliasing_seq extends csr_base_seq;
 
       `DV_CHECK_STD_RANDOMIZE_FATAL(wdata)
       wdata &= get_mask_excl_fields(test_csrs[i], CsrExclWrite, CsrAliasingTest, m_csr_excl_item);
-      csr_wr(.csr(test_csrs[i]), .value(wdata), .blocking(0));
-
-      // if external checker is not enabled and writes are made non-blocking, then we need to
-      // pre-predict so that the mirrored value will be updated. if we dont, then csr_rd_check task
-      // might pick up stale mirrored value
-      if (!external_checker) begin
-        void'(test_csrs[i].predict(.value(wdata), .kind(UVM_PREDICT_WRITE)));
-      end
+      csr_wr(.csr(test_csrs[i]), .value(wdata), .blocking(0), .predict(!external_checker));
 
       all_csrs.shuffle();
       foreach (all_csrs[j]) begin

--- a/hw/dv/sv/tl_agent/seq_lib/tl_host_seq.sv
+++ b/hw/dv/sv/tl_agent/seq_lib/tl_host_seq.sv
@@ -7,12 +7,24 @@
 class tl_host_seq extends tl_host_base_seq;
 
   rand int unsigned req_cnt;
+  // if enabled, req will be aborted if it's not accepted after given valid length
+  rand bit          req_abort_after_a_valid_len;
+  // chance to abort req
+  int               req_abort_pct = 0;
+
   tl_seq_item       pending_req[$];
   int               min_req_delay = 0;
   int               max_req_delay = 10;
 
   `uvm_object_utils(tl_host_seq)
   `uvm_object_new
+
+  constraint req_abort_after_a_valid_len_c {
+    req_abort_after_a_valid_len dist {
+      1 :/ req_abort_pct,
+      0 :/ 100 - req_abort_pct
+    };
+  }
 
   virtual task body();
     set_response_queue_depth(cfg.max_outstanding_req);
@@ -47,6 +59,7 @@ class tl_host_seq extends tl_host_base_seq;
           pre_start_item(req);
           start_item(req);
           randomize_req(req, i);
+          post_randomize_req(req, i);
           pending_req.push_back(req); // in case of device same cycle response
           finish_item(req);
           `uvm_info(`gfn, $sformatf("Sent req[%0d] : %0s",
@@ -71,6 +84,11 @@ class tl_host_seq extends tl_host_base_seq;
         a_valid_delay inside {[min_req_delay:max_req_delay]};})) begin
       `uvm_fatal(`gfn, "Cannot randomize req")
     end
+  endfunction
+
+  // callback after randomize seq, extened seq can override it to handle some non-rand variables
+  virtual function void post_randomize_req(tl_seq_item req, int idx);
+    req.req_abort_after_a_valid_len = req_abort_after_a_valid_len;
   endfunction
 
   // A reserved function that can be extended to process response packet

--- a/hw/dv/sv/tl_agent/tl_agent_cfg.sv
+++ b/hw/dv/sv/tl_agent/tl_agent_cfg.sv
@@ -119,6 +119,13 @@ class tl_agent_cfg extends dv_base_agent_cfg;
     };
   }
 
+  // TLUL allows host to switch content if the item isn't accepted. RAL doesn't provide interface
+  // to control this. Use this knob to allow tl_reg_adapter to randomize req_abort_after_a_valid_len
+  // Note: below set the chance to abort after a_valid_len in tl_reg_adapter. if > 0, csr access may
+  // return UVM_NOT_OK when the item is aborted without accepted.
+  int unsigned csr_access_abort_pct_in_adapter = 0;
+
+
   `uvm_object_utils_begin(tl_agent_cfg)
     `uvm_field_int(max_outstanding_req,   UVM_DEFAULT)
     `uvm_field_enum(tl_level_e, tl_level, UVM_DEFAULT)
@@ -126,6 +133,10 @@ class tl_agent_cfg extends dv_base_agent_cfg;
     `uvm_field_int(a_ready_delay_max,     UVM_DEFAULT)
     `uvm_field_int(d_ready_delay_min,     UVM_DEFAULT)
     `uvm_field_int(d_ready_delay_max,     UVM_DEFAULT)
+    `uvm_field_int(host_can_stall_rsp_when_a_valid_high, UVM_DEFAULT)
+    `uvm_field_int(device_can_rsp_on_same_cycle,         UVM_DEFAULT)
+    `uvm_field_int(time_a_valid_avail_after_sample_edge, UVM_DEFAULT)
+    `uvm_field_int(csr_access_abort_pct_in_adapter,      UVM_DEFAULT)
   `uvm_object_utils_end
   `uvm_object_new
 

--- a/hw/dv/sv/tl_agent/tl_seq_item.sv
+++ b/hw/dv/sv/tl_agent/tl_seq_item.sv
@@ -71,6 +71,14 @@ class tl_seq_item extends uvm_sequence_item;
   // this request, to avoid protocol violation.
   bit                             a_source_is_overridden;
 
+  // after given valid_len, end the req/rsp if it's not accepted, which allows seq to switch
+  // content and test unaccepted item shouldn't be used in design
+  bit                             req_abort_after_a_valid_len;
+  bit                             rsp_abort_after_d_valid_len;
+  // True if the item is completed, not aborted
+  bit                             req_completed;
+  bit                             rsp_completed;
+
   // param is reserved for future use, must be zero
   constraint param_c {
     a_param == 0;
@@ -129,22 +137,30 @@ class tl_seq_item extends uvm_sequence_item;
   }
 
   `uvm_object_utils_begin(tl_seq_item)
-    `uvm_field_int  (a_addr,                 UVM_DEFAULT)
-    `uvm_field_int  (a_data,                 UVM_DEFAULT)
-    `uvm_field_int  (a_mask,                 UVM_DEFAULT)
-    `uvm_field_int  (a_size,                 UVM_DEFAULT)
-    `uvm_field_int  (a_param,                UVM_DEFAULT)
-    `uvm_field_int  (a_source,               UVM_DEFAULT)
-    `uvm_field_int  (a_opcode,               UVM_DEFAULT)
-    `uvm_field_int  (d_param,                UVM_DEFAULT)
-    `uvm_field_int  (d_source,               UVM_DEFAULT)
-    `uvm_field_int  (d_data,                 UVM_DEFAULT)
-    `uvm_field_int  (d_size,                 UVM_DEFAULT)
-    `uvm_field_int  (d_opcode,               UVM_DEFAULT)
-    `uvm_field_int  (d_error,                UVM_DEFAULT)
-    `uvm_field_int  (d_sink,                 UVM_DEFAULT)
-    `uvm_field_int  (d_user,                 UVM_DEFAULT)
-    `uvm_field_int  (a_source_is_overridden, UVM_DEFAULT | UVM_NOPACK | UVM_NOPRINT)
+    `uvm_field_int  (a_addr,              UVM_DEFAULT)
+    `uvm_field_int  (a_data,              UVM_DEFAULT)
+    `uvm_field_int  (a_mask,              UVM_DEFAULT)
+    `uvm_field_int  (a_size,              UVM_DEFAULT)
+    `uvm_field_int  (a_param,             UVM_DEFAULT)
+    `uvm_field_int  (a_source,            UVM_DEFAULT)
+    `uvm_field_int  (a_opcode,            UVM_DEFAULT)
+    `uvm_field_int  (d_param,             UVM_DEFAULT)
+    `uvm_field_int  (d_source,            UVM_DEFAULT)
+    `uvm_field_int  (d_data,              UVM_DEFAULT)
+    `uvm_field_int  (d_size,              UVM_DEFAULT)
+    `uvm_field_int  (d_opcode,            UVM_DEFAULT)
+    `uvm_field_int  (d_error,             UVM_DEFAULT)
+    `uvm_field_int  (d_sink,              UVM_DEFAULT)
+    `uvm_field_int  (d_user,              UVM_DEFAULT)
+    `uvm_field_int  (a_source_is_overridden, UVM_DEFAULT | UVM_NOPACK)
+    `uvm_field_int  (a_valid_delay,       UVM_DEFAULT | UVM_NOPACK)
+    `uvm_field_int  (d_valid_delay,       UVM_DEFAULT | UVM_NOPACK)
+    `uvm_field_int  (a_valid_len,         UVM_DEFAULT | UVM_NOPACK)
+    `uvm_field_int  (d_valid_len,         UVM_DEFAULT | UVM_NOPACK)
+    `uvm_field_int  (req_abort_after_a_valid_len, UVM_DEFAULT | UVM_NOPACK)
+    `uvm_field_int  (rsp_abort_after_d_valid_len, UVM_DEFAULT | UVM_NOPACK)
+    `uvm_field_int  (req_completed,       UVM_DEFAULT | UVM_NOPACK)
+    `uvm_field_int  (rsp_completed,       UVM_DEFAULT | UVM_NOPACK)
   `uvm_object_utils_end
 
   function new (string name = "");
@@ -175,7 +191,11 @@ class tl_seq_item extends uvm_sequence_item;
            $sformatf("d_opcode = %0s ", d_opcode_name),
            $sformatf("d_error = %0b ", d_error),
            $sformatf("d_user = %0b ", d_user),
-           $sformatf("d_sink = %0b ", d_sink)};
+           $sformatf("d_sink = %0b ", d_sink),
+           $sformatf("req_abort_after_a_valid_len = %0b ", req_abort_after_a_valid_len),
+           $sformatf("rsp_abort_after_d_valid_len = %0b ", rsp_abort_after_d_valid_len),
+           $sformatf("req_completed = %0b ", req_completed),
+           $sformatf("rsp_completed = %0b ", rsp_completed)};
     return str;
   endfunction
 

--- a/hw/ip/tlul/generic_dv/env/seq_lib/xbar_base_vseq.sv
+++ b/hw/ip/tlul/generic_dv/env/seq_lib/xbar_base_vseq.sv
@@ -12,6 +12,8 @@ class xbar_base_vseq extends dv_base_vseq #(.CFG_T               (xbar_env_cfg),
   // TL host and device sub-sequences
   rand xbar_tl_host_seq  host_seq[];
   rand tl_device_seq     device_seq[];
+  rand bit               en_req_abort;
+  rand bit               en_rsp_abort;
 
   uint                   min_req_cnt = 100;
   uint                   max_req_cnt = 200;
@@ -25,6 +27,19 @@ class xbar_base_vseq extends dv_base_vseq #(.CFG_T               (xbar_env_cfg),
     }
   }
 
+  constraint en_req_abort_c {
+    en_req_abort dist {
+      1 :/ 25,
+      0 :/ 75
+    };
+  }
+
+  constraint en_rsp_abort_c {
+    en_rsp_abort dist {
+      1 :/ 25,
+      0 :/ 75
+    };
+  }
   `uvm_object_utils(xbar_base_vseq)
   `uvm_object_new
 
@@ -40,6 +55,7 @@ class xbar_base_vseq extends dv_base_vseq #(.CFG_T               (xbar_env_cfg),
     foreach (host_seq[i]) begin
       host_seq[i] = xbar_tl_host_seq::type_id::create(
                     $sformatf("%0s_seq", xbar_hosts[i].host_name));
+      if (en_req_abort) host_seq[i].req_abort_pct = $urandom_range(0, 100);
       // Default only send request to valid devices that is accessible by the host
       foreach (xbar_devices[j]) begin
         if (is_valid_path(xbar_hosts[i].host_name, xbar_devices[j].device_name)) begin
@@ -52,6 +68,7 @@ class xbar_base_vseq extends dv_base_vseq #(.CFG_T               (xbar_env_cfg),
     foreach (device_seq[i]) begin
       device_seq[i] = tl_device_seq::type_id::create(
                       $sformatf("%0s_seq", xbar_devices[i].device_name));
+      if (en_rsp_abort) device_seq[i].rsp_abort_pct = $urandom_range(0, 100);
     end
   endfunction : seq_init
 


### PR DESCRIPTION
Address #3383 item 2.

As discussed in #3410, this PR adds a option to allow driver drop this item when
valid isn't answered for given cycles. And test this feature in CSR seq. CSR seq
doesn't need csr access to be completed every time. when it's not completed,
it just doesn't update predicted value and move on to next access.
For xbar, hosts send fully random items and it's ok to drop some of them as we
have independent scb to check all the completed items.

This is wave of uart csr test. The 2nd item is dropped.
![Screen Shot 2020-09-24 at 10 29 51 AM](https://user-images.githubusercontent.com/49293026/94202422-78860f80-fe72-11ea-9dfc-96ade5eb50e9.png)

Signed-off-by: Weicai Yang <weicai@google.com>