### PR TITLE
[dv/alert] fix alert_agent cfg create function

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env.sv
@@ -43,19 +43,11 @@ class cip_base_env #(type CFG_T               = cip_base_env_cfg,
     m_tl_agent = tl_agent::type_id::create("m_tl_agent", this);
     m_tl_reg_adapter = tl_reg_adapter#()::type_id::create("m_tl_reg_adapter");
 
-    // create alert agents and cfgs
+    // create alert agents and set cfgs
     foreach(cfg.list_of_alerts[i]) begin
       string alert_name = cfg.list_of_alerts[i];
       string agent_name = {"m_alert_agent_", alert_name};
       m_alert_agent[alert_name] = alert_esc_agent::type_id::create(agent_name, this);
-      cfg.m_alert_agent_cfg[alert_name] = alert_esc_agent_cfg::type_id::create("m_alert_agent_cfg");
-      cfg.m_alert_agent_cfg[alert_name].if_mode = dv_utils_pkg::Device;
-      // seq won't send ping request because they are covered in alert_handler testbench
-      cfg.m_alert_agent_cfg[alert_name].en_ping_cov = 0;
-      if (cfg.zero_delays) begin
-        cfg.m_alert_agent_cfg[alert_name].alert_delay_min = 0;
-        cfg.m_alert_agent_cfg[alert_name].alert_delay_max = 0;
-      end
       uvm_config_db#(alert_esc_agent_cfg)::set(this, agent_name, "cfg",
           cfg.m_alert_agent_cfg[alert_name]);
     end

--- a/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
@@ -8,16 +8,19 @@ class cip_base_env_cfg #(type RAL_T = dv_base_reg_block) extends dv_base_env_cfg
   rand alert_esc_agent_cfg m_alert_agent_cfg[string];
 
   // common interfaces - intrrupts and alerts
-  intr_vif              intr_vif;
-  devmode_vif           devmode_vif;
+  intr_vif    intr_vif;
+  devmode_vif devmode_vif;
 
   // en_devmode default sets to 1 because all IPs' devmode_i is tied off internally to 1
   // TODO: enable random drive devmode once design supports
-  bit                   has_devmode = 1;
-  bit                   en_devmode = 1;
+  bit  has_devmode = 1;
+  bit  en_devmode = 1;
 
-  uint                  num_interrupts;
-  string                list_of_alerts[] = {};
+  uint num_interrupts;
+
+  // if module has alerts, this list_of_alerts needs to override in cfg before super.initialize()
+  // function is called
+  string list_of_alerts[] = {};
 
   `uvm_object_param_utils_begin(cip_base_env_cfg #(RAL_T))
     `uvm_field_object          (m_tl_agent_cfg,    UVM_DEFAULT)
@@ -34,6 +37,18 @@ class cip_base_env_cfg #(type RAL_T = dv_base_reg_block) extends dv_base_env_cfg
     m_tl_agent_cfg.if_mode = dv_utils_pkg::Host;
     // host can't support device same cycle response and host may drive d_ready=0 when a_valid=1
     m_tl_agent_cfg.host_can_stall_rsp_when_a_valid_high = $urandom_range(0, 1);
+
+    // create alert_esc_agent_cfg if the module has alerts
+    foreach(list_of_alerts[i]) begin
+      string alert_name = list_of_alerts[i];
+      m_alert_agent_cfg[alert_name] = alert_esc_agent_cfg::type_id::create("m_alert_agent_cfg");
+      m_alert_agent_cfg[alert_name].if_mode = dv_utils_pkg::Device;
+      m_alert_agent_cfg[alert_name].en_ping_cov = 0;
+      if (zero_delays) begin
+        m_alert_agent_cfg[alert_name].alert_delay_min = 0;
+        m_alert_agent_cfg[alert_name].alert_delay_max = 0;
+      end
+    end
   endfunction
 
 endclass

--- a/hw/ip/aes/dv/env/aes_env_cfg.sv
+++ b/hw/ip/aes/dv/env/aes_env_cfg.sv
@@ -109,8 +109,8 @@ class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block));
   endfunction
 
   virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);
-    super.initialize(csr_base_addr);
     list_of_alerts = aes_env_pkg::LIST_OF_ALERTS;
+    super.initialize(csr_base_addr);
   endfunction
 
 endclass

--- a/hw/ip/hmac/dv/env/hmac_env_cfg.sv
+++ b/hw/ip/hmac/dv/env/hmac_env_cfg.sv
@@ -8,8 +8,8 @@ class hmac_env_cfg extends cip_base_env_cfg #(.RAL_T(hmac_reg_block));
   `uvm_object_new
 
   virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);
+    list_of_alerts = {"msg_push_sha_disabled"};
     super.initialize(csr_base_addr);
-    list_of_alerts      = {"msg_push_sha_disabled"};
     // set num_interrupts & num_alerts which will be used to create coverage and more
     num_interrupts = ral.intr_state.get_n_used_bits();
 


### PR DESCRIPTION
Move alert_agent_cfg creation call from build_phase to initilization
function. Thanks to Sri's suggestion.
With this move, `LIST_OF_ALERTS` needs to be override before
initilization is called.

Signed-off-by: Cindy Chen <chencindy@google.com>