### PR TITLE
[otbn] Make registers much more explicit in the ISS

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/dmem.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/dmem.py
@@ -136,27 +136,22 @@ class Dmem:
             u32s += reversed(self._get_u32s(idx))
         return struct.pack('<{}I'.format(len(u32s)), *u32s)
 
-    def load_i256(self, addr: int) -> int:
-        '''Read a wide word from memory. addr should be aligned.'''
+    def load_u256(self, addr: int) -> int:
+        '''Read an unsigned wide word from memory. addr should be aligned.'''
         assert 0 == addr % 32
-        u256 = self.data[addr // 32]
-        i256 = u256 - (1 << 256) if u256 >> 255 else u256
-        assert -(1 << 255) <= i256 <= (1 << 255) - 1
-        return i256
+        return self.data[addr // 32]
 
-    def store_i256(self, addr: int, value: int) -> None:
-        '''Write a wide word to memory. addr should be aligned.'''
+    def store_u256(self, addr: int, value: int) -> None:
+        '''Write an unsigned wide word to memory. addr should be aligned.'''
         assert 0 == addr % 32
-        assert -(1 << 255) <= value <= (1 << 255) - 1
-        u256 = (1 << 256) + value if value < 0 else value
-        assert 0 <= u256 < (1 << 256)
-        self.trace.append(TraceDmemStore(addr, u256, True))
+        assert 0 <= value < (1 << 256)
+        self.trace.append(TraceDmemStore(addr, value, True))
 
-    def load_i32(self, addr: int) -> int:
+    def load_u32(self, addr: int) -> int:
         '''Read a 32-bit value from memory.
 
-        addr should be 4-byte aligned. The result is returned as a signed
-        32-bit integer (appropriate for storing in a riscvmodel Register)
+        addr should be 4-byte aligned. The result is returned as an unsigned
+        32-bit integer.
 
         '''
         assert 0 == addr % 4
@@ -166,23 +161,18 @@ class Dmem:
         idxW = idx32 // 8
         offW = idx32 % 8
 
-        u32 = self._get_u32s(idxW)[offW]
+        return self._get_u32s(idxW)[offW]
 
-        # Now convert back to signed and return
-        return u32 - (1 << 32) if u32 >> 31 else u32
-
-    def store_i32(self, addr: int, value: int) -> None:
-        '''Store a 32-bit signed value to memory.
+    def store_u32(self, addr: int, value: int) -> None:
+        '''Store a 32-bit unsigned value to memory.
 
         addr should be 4-byte aligned.
 
         '''
         assert 0 == addr % 4
         assert addr < 32 * len(self.data)
-        assert -(1 << 31) <= value <= (1 << 31) - 1
-        u32 = (1 << 32) + value if value < 0 else value
-        assert 0 <= u32 < (1 << 32)
-        self.trace.append(TraceDmemStore(addr, u32, False))
+        assert 0 <= value <= (1 << 32) - 1
+        self.trace.append(TraceDmemStore(addr, value, False))
 
     def changes(self) -> List[Trace]:
         return self.trace

--- a/hw/ip/otbn/dv/otbnsim/sim/gpr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/gpr.py
@@ -1,0 +1,65 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import List
+
+from .reg import Reg, RegFile
+
+
+class GPRs(RegFile):
+    '''The narrow OTBN register file'''
+    def __init__(self) -> None:
+        super().__init__('x', 32, 32)
+
+        # The call stack for x1 and its pending updates. self.callstack is
+        # never empty and (after commit) the tail always matches
+        # self._registers[1].read_unsigned() (pushing from the right)
+        self._callstack = [0]  # type: List[int]
+        self._callstack_pop = False
+
+    def mark_read(self, idx: int) -> None:
+        super().mark_read(idx)
+        if idx == 1:
+            self._callstack_pop = True
+
+    def get_reg(self, idx: int) -> Reg:
+        # If idx == 0, this is a zeros register that should ignore writes.
+        # Return a fresh Reg with no parent, so writes to it have no effect.
+        if idx == 0:
+            return Reg(None, 0, 32, 0)
+        return super().get_reg(idx)
+
+    def post_insn(self) -> None:
+        '''Update call stack after instruction execution but before commit
+
+        This is not idempotent: call it exactly once.
+
+        '''
+        callstack_push = 1 in self._pending_writes
+
+        # If we read from the call stack, we have popped from it. (Even if the
+        # stack is empty, we treat this as a logical pop. We need to decide
+        # what happens here: see issue #3239).
+        if self._callstack_pop:
+            if len(self._callstack) > 1:
+                self._callstack.pop()
+
+            # Write the new head of the call stack to the relevant register,
+            # unless x1 has a pending write (which means that we had an
+            # instruction like "addi x1, x1, 0", so the pop happened logically
+            # before the push)
+            if not callstack_push:
+                self._registers[1].write_unsigned(self._callstack[-1])
+
+        # If there is a pending write to x1 (which wasn't caused by the
+        # callstack pop code just above) then callstack_push will be true. In
+        # that case, we should push the new value onto the call stack.
+        if callstack_push:
+            new_x1 = self._registers[1].read_next()
+            assert new_x1 is not None
+            self._callstack.append(new_x1)
+
+    def commit(self) -> None:
+        self._callstack_pop = False
+        super().commit()

--- a/hw/ip/otbn/dv/otbnsim/sim/isa.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/isa.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-from enum import IntEnum
 import sys
 from typing import Dict
 
@@ -109,15 +108,21 @@ class RV32ImmShift(OTBNInsn):
         self.shamt = op_vals['shamt']
 
 
-class ShiftType(IntEnum):
-    LSL = 0  # logical shift left
-    LSR = 1  # logical shift right
+def logical_byte_shift(value: int, shift_type: int, shift_bytes: int) -> int:
+    '''Logical shift value by shift_bytes to the left or right.
 
+    value should be an unsigned 256-bit value. shift_type should be 0 (shift left)
+    or 1 (shift right): matching the encoding of the big number instructions.
+    shift_bytes should be a non-negative number of bytes to shift by.
 
-def ShiftReg(reg: int, shift_type: int, shift_bytes: Immediate) -> int:
-    assert 0 <= int(shift_bytes)
-    shift_bits = int(shift_bytes << 3)
+    Returns an unsigned 256-bit value, truncating on an overflowing left shift.
 
-    return (reg << shift_bits
-            if shift_type == ShiftType.LSL
-            else reg >> shift_bits)
+    '''
+    mask256 = (1 << 256) - 1
+    assert 0 <= value <= mask256
+    assert 0 <= shift_type <= 1
+    assert 0 <= shift_bytes
+
+    shift_bits = 8 * shift_bytes
+    shifted = value << shift_bits if shift_type == 0 else value >> shift_bits
+    return shifted & mask256

--- a/hw/ip/otbn/dv/otbnsim/sim/reg.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/reg.py
@@ -1,0 +1,119 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import List, Optional, Set
+
+from riscvmodel.types import Trace  # type: ignore
+
+
+class TraceRegister(Trace):  # type: ignore
+    def __init__(self, name: str, width: int, new_value: int):
+        self.name = name
+        self.width = width
+        self.new_value = new_value
+
+    def __str__(self) -> str:
+        fmt_str = '{{}} = 0x{{:0{}x}}'.format(self.width // 4)
+        return fmt_str.format(self.name, self.new_value)
+
+
+class Reg:
+    def __init__(self,
+                 parent: Optional['RegFile'],
+                 idx: int,
+                 width: int,
+                 uval: int):
+        assert 0 <= width
+        assert 0 <= uval < (1 << width)
+
+        self._parent = parent
+        self._idx = idx
+        self._width = width
+
+        self._uval = uval
+        self._next_uval = None  # type: Optional[int]
+
+    def read_unsigned(self) -> int:
+        if self._parent is not None:
+            self._parent.mark_read(self._idx)
+        return self._uval
+
+    def write_unsigned(self, uval: int) -> None:
+        assert 0 <= uval < (1 << self._width)
+        self._next_uval = uval
+        if self._parent is not None:
+            self._parent.mark_written(self._idx)
+
+    def read_next(self) -> Optional[int]:
+        return self._next_uval
+
+    def read_signed(self) -> int:
+        uval = self.read_unsigned()
+        return uval - (1 << self._width if uval >> (self._width - 1) else 0)
+
+    def read_unsigned_inverted(self) -> int:
+        '''Read value as an unsigned integer, but invert all bits'''
+        return self.read_unsigned() ^ ((1 << self._width) - 1)
+
+    def write_signed(self, ival: int) -> None:
+        assert -(1 << (self._width - 1)) <= ival < (1 << (self._width - 1))
+        uval = (1 << self._width) + ival if ival < 0 else ival
+        self.write_unsigned(uval)
+
+    def commit(self) -> None:
+        if self._next_uval is not None:
+            self._uval = self._next_uval
+        self._next_uval = None
+
+
+class RegFile:
+    '''A base class for register files (used for both GPRs and WDRs).
+
+    For GPRs, we override it (see gpr.py) to support our magic x0 and x1
+    behaviour.
+
+    '''
+    def __init__(self,
+                 name_pfx: str,
+                 width: int,
+                 depth: int):
+        assert 0 <= width
+        assert 0 <= depth
+
+        self._name_pfx = name_pfx
+        self._width = width
+        self._registers = [Reg(self, i, width, 0) for i in range(depth)]
+        self._pending_writes = set()  # type: Set[int]
+
+    def mark_read(self, idx: int) -> None:
+        '''Mark a register as having been read'''
+        # The default implementation ignores this, but the GPRs subclass
+        # overrides it to deal with reads from x1.
+        pass
+
+    def mark_written(self, idx: int) -> None:
+        '''Mark a register as having been written'''
+        assert 0 <= idx < len(self._registers)
+        self._pending_writes.add(idx)
+
+    def get_reg(self, idx: int) -> Reg:
+        assert 0 <= idx < len(self._registers)
+        return self._registers[idx]
+
+    def changes(self) -> List[TraceRegister]:
+        ret = []
+        for idx in sorted(self._pending_writes):
+            assert 0 <= idx < len(self._registers)
+            next_val = self._registers[idx].read_next()
+            assert next_val is not None
+            ret.append(TraceRegister(self._name_pfx + str(idx),
+                                     self._width,
+                                     next_val))
+        return ret
+
+    def commit(self) -> None:
+        for idx in self._pending_writes:
+            assert 0 <= idx < len(self._registers)
+            self._registers[idx].commit()
+        self._pending_writes.clear()

--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -25,7 +25,7 @@ class OTBNSim:
         Return the number of instructions executed.
 
         '''
-        self.state.pc.set(start_addr)
+        self.state.pc = start_addr
         self.state.start()
         insn_count = 0
         while self.state.running:

--- a/hw/ip/otbn/dv/otbnsim/stepped.py
+++ b/hw/ip/otbn/dv/otbnsim/stepped.py
@@ -68,7 +68,7 @@ def on_start(sim: OTBNSim, args: List[str]) -> None:
                          .format(addr))
 
     print('START {:#08x}'.format(addr))
-    sim.state.pc.set(addr)
+    sim.state.pc = addr
     sim.state.start()
 
 


### PR DESCRIPTION
This patch defines a new class for registers (called `Reg`, in reg.py).
It's a bit simpler than the riscvmodel version, but the big difference
is that it has no magic coercions. If you want to get the value as an
unsigned integer, you call `Reg.read_unsigned`. If you want set the
value as a signed integer, you call `Reg.write_signed`. It's all very
explicit, which should hopefully catch corner cases in the spec.

reg.py also defines a `RegFile` class, to hold the registers. This is
used as-is for the wide registers, but is subclassed for GPRs in
gpr.py. This allows us to give `x0` and `x1` special behaviour (a zeros
register and a call stack, respectively).

Most of the rest of this patch is porting the instruction definitions
in insn.py to use the new register interface. Because there are no
magic coercions, the definitions get rather longer, but they are
hopefully easier to understand.

One notable change from the previous Register class is that you get an
assertion error if you try to assign an integer that's out of range.
So `state.gprs.get_reg(1).write_unsigned(1 << 32)` will trigger an
error. This means that code that does arithmetic on operands generally
gains an explicit mask "`foo & ((1 << 32) - 1)`". This was an
intentional design decision, because it means the code in
insn.py (which defines what the instruction does) fully specifies the
semantics, rather than relying on magic inside the `Register` class.

Similarly, the register files no longer override `__getitem__` and
`__setitem__`. I think the result is less magical and the syntax more
accurately shows what's actually happening in the Python simulation.
The plan is that when we do automatic extraction from the ISS to the
spec examples, we'll do some sort of transformation, turning e.g.

    val1 = state.gprs.get_reg(self.grs1).read_unsigned()
    ...
    state.gprs.get_reg(self.grd).write_unsigned(result)

to something more like

    val = unsigned(state.gprs[self.grs1])
    ...
    state.gprs[self.grd] = from_unsigned(result)

So the "trace the assignments" approach to reading the documentation
works again.

When porting the instruction definitions, I made one intentional
change to behaviour (to match the intended semantics): If a big number
ALU instruction specifies a right shift of `shift_bytes`, it's now a
logical right shift, rather than an arithmetic one.

I also got rid of most updates to variable values in the instruction
definitions, so they are now in a sort of "pseudo-SSA style". This
tends to be more convenient when you're looking at pseudo-code
documentation, especially when debugging or trying to write formal
definitions, because you can say "`foo`" rather than "the value of `foo`
at line 12".

Fixes #3560.