### PR TITLE
[mask_rom] Mask ROM to ROM_EXT jump

### DIFF
--- a/sw/device/lib/base/meson.build
+++ b/sw/device/lib/base/meson.build
@@ -26,7 +26,9 @@ sw_lib_mmio = declare_dependency(
   link_with: static_library(
     'mmio_ot',
     sources: ['mmio.c'],
-    dependencies: [sw_lib_bitfield],
+    dependencies: [
+      sw_lib_bitfield,
+      sw_lib_mem,
+    ],
   )
 )
-

--- a/sw/device/lib/testing/meson.build
+++ b/sw/device/lib/testing/meson.build
@@ -63,15 +63,27 @@ sw_lib_testing_test_main = declare_dependency(
   )
 )
 
+sw_lib_testing_bitfield = declare_dependency(
+  link_with: static_library(
+    'bitfield',
+    sources: [
+      meson.source_root() / 'sw/device/lib/base/bitfield.c',
+    ],
+    native: true,
+  )
+)
+
 sw_lib_testing_mock_mmio = declare_dependency(
   link_with: static_library(
     'mock_mmio',
     sources: [
       meson.source_root() / 'sw/device/lib/base/mmio.c',
-      meson.source_root() / 'sw/device/lib/base/bitfield.c',
       'mock_mmio.cc',
     ],
-    dependencies: [sw_vendor_gtest],
+    dependencies: [
+      sw_vendor_gtest,
+      sw_lib_testing_bitfield,
+    ],
     native: true,
     c_args: ['-DMOCK_MMIO'],
     cpp_args: ['-DMOCK_MMIO'],

--- a/sw/device/mask_rom/mask_rom.c
+++ b/sw/device/mask_rom/mask_rom.c
@@ -3,13 +3,43 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sw/device/mask_rom/mask_rom.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
 #include "sw/device/lib/base/stdasm.h"
+#include "sw/device/lib/runtime/hart.h"
+#include "sw/device/rom_exts/rom_ext_manifest_parser.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+// This is the expected ROM_EXT Manifest Identifier
+static const uint32_t kRomExtIdentifierExpected = 0x4552544F;
+
+typedef void(boot_fn)(void);
 
 void mask_rom_boot(void) {
-  asm volatile("unimp");
-  __builtin_unreachable();
+  rom_ext_manifest_t rom_ext = rom_ext_get_parameters(kRomExtManifestSlotA);
+
+  // Check we have a valid ROM_EXT
+  if (rom_ext_get_identifier(rom_ext) == kRomExtIdentifierExpected) {
+    // Set mtvec for ROM_EXT.
+    uintptr_t interrupt_vector = rom_ext_get_interrupt_vector(rom_ext);
+    asm volatile("csrw mtvec, %0" ::"r"(interrupt_vector));
+
+    boot_fn *rom_ext_entry = (boot_fn *)rom_ext_get_entry(rom_ext);
+
+    // Jump to ROM_EXT entry point.
+    rom_ext_entry();
+  } else {
+    // Not yet implemented, intent is to throw simulation error.
+    asm volatile("unimp");
+  }
+  while (true) {
+    wait_for_interrupt();
+  }
 }
 
-void mask_rom_exception_handler(void) {}
+void mask_rom_exception_handler(void) { wait_for_interrupt(); }
 
-void mask_rom_nmi_handler(void) {}
+void mask_rom_nmi_handler(void) { wait_for_interrupt(); }

--- a/sw/device/mask_rom/mask_rom_start.S
+++ b/sw/device/mask_rom/mask_rom_start.S
@@ -145,9 +145,14 @@ _mask_rom_start_boot:
 
   // Set up the stack pointer.
   //
+  // In RISC-V, the stack grows downwards, so we load the address of the highest
+  // word in the stack into sp. We don't load in `_stack_end`, as that points
+  // beyond the end of RAM, and we always want it to be valid to dereference
+  // `sp`, and we need this to be 128-bit (16-byte) aligned to meet the psABI.
+  //
   // If an exception fires, the handler is conventionaly only allowed to clobber
   // memory at addresses below `sp`.
-  la   sp, _stack_end
+  la   sp, (_stack_end - 16)
 
   /**
    * Set well-defined interrupt/exception handlers

--- a/sw/device/rom_exts/manifest.md
+++ b/sw/device/rom_exts/manifest.md
@@ -267,6 +267,10 @@ Notes:
     still want a static entry address so we don't have to validate that it is in
     bounds.
 
+    **Open Q** Do we want to set `mtvec` before jumping to the ROM_EXT? This
+    could cause double fault issues if ROM_EXT is not unlocked by the comparator
+    before the jump happens.
+
 ### Data Not in the Header
 
 *   `.data` + `.bss` section sizes, for establishing PMP regions. The PMP

--- a/sw/device/rom_exts/manifest.md
+++ b/sw/device/rom_exts/manifest.md
@@ -245,7 +245,7 @@ Notes:
 1.  **Code Image** This is a sequence of bytes that make up the code and data of
     the ROM_EXT image. This data will include any data required for Extensions.
 
-    **Execution begins** at the address 128 (`0x80`) bytes beyond the first
+    Execution begins at the address 128 (`0x80`) bytes beyond the first
     256-byte (`0x100`-byte) aligned offset at the start of the ROM_EXT code
     image (measuring the offset from the start of the ROM_EXT image). This
     leaves the possibility of the Mask ROM initializing `mtvec` with the first
@@ -254,8 +254,8 @@ Notes:
 
     The total manifest length is currently `0x358` (856) bytes, so the first
     valid mtvec address is at offset `0x400` (1024) bytes from the beginning of
-    the ROM_EXT image, and the entry address is therefore `0x480`  (1152) bytes
-    from the beginning of the ROM_EXT image.
+    the ROM_EXT image, and **the entry address is therefore `0x480` (1152) bytes
+    from the beginning of the ROM_EXT image**.
 
     This does leave 168 (`0xa8`) bytes between the end of the manifest and the
     first valid mtvec. It is up to the image as to how this is used--it could be

--- a/sw/device/rom_exts/rom_ext_manifest_parser.c
+++ b/sw/device/rom_exts/rom_ext_manifest_parser.c
@@ -7,6 +7,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "sw/device/lib/base/bitfield.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/rom_exts/manifest.h"
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
@@ -143,4 +144,25 @@ bool rom_ext_get_extension(rom_ext_manifest_t params, rom_ext_extension_id_t id,
   extension->checksum = mmio_region_read32(params.base_addr, checksum);
 
   return true;
+}
+
+uintptr_t rom_ext_get_interrupt_vector(rom_ext_manifest_t params) {
+  uintptr_t vector_addr = params.slot + ROM_EXT_INTERRUPT_VECTOR_OFFSET;
+
+  // A valid value for `mtvec` contains:
+  //
+  // - The most-significant 30 bits of the value are the most-significant 30
+  //   bits of the interrupt vector address.
+  // - The least-significant 2 bits of the value must be `0b01` to encode
+  //   vectored interrupts, which we want.
+  //
+  // One additional restriction is that Ibex wants the address to be 256-byte
+  // aligned. We enforce that in the definition of
+  // ROM_EXT_INTERRUPT_VECTOR_OFFSET;
+
+  return (vector_addr & ~0x3) | 0x1;
+}
+
+uintptr_t rom_ext_get_entry(rom_ext_manifest_t params) {
+  return params.slot + ROM_EXT_ENTRY_POINT_OFFSET;
 }

--- a/sw/device/rom_exts/rom_ext_manifest_parser.h
+++ b/sw/device/rom_exts/rom_ext_manifest_parser.h
@@ -232,6 +232,29 @@ bool rom_ext_get_public_key(rom_ext_manifest_t params,
 bool rom_ext_get_extension(rom_ext_manifest_t params, rom_ext_extension_id_t id,
                            rom_ext_extension_t *extension);
 
+/**
+ * Calculates the ROM_EXT interrupt vector value.
+ *
+ * This value is based upon the absolute address of the ROM_EXT interrupt
+ * vector, for this particular ROM_EXT.
+ *
+ * The value returned does not need extra processing to be used for vectored
+ * interrupts in Ibex - the least significant two bits will have the correct
+ * value.
+ *
+ * @param param Parameters required for manifest parsing.
+ * @return The value to write to the `mtvec` RISC-V CSR.
+ */
+uintptr_t rom_ext_get_interrupt_vector(rom_ext_manifest_t params);
+
+/**
+ * Calculates the ROM_EXT image code entry point.
+ *
+ * @param params Parameters required for manifest parsing.
+ * @return The absolute address to jump to to begin execution of the ROM_EXT.
+ */
+uintptr_t rom_ext_get_entry(rom_ext_manifest_t params);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/tests/rom_ext/meson.build
+++ b/sw/device/tests/rom_ext/meson.build
@@ -20,6 +20,7 @@ test('rom_ext_parser_unittest', executable(
   dependencies: [
     sw_vendor_gtest,
     sw_lib_testing_mock_mmio,
+    sw_lib_testing_bitfield,
   ],
   native: true,
   c_args: ['-DMOCK_MMIO'],


### PR DESCRIPTION
This is a preliminary implementation of the jump from Mask ROM code into ROM_EXT. It is not hardened, verified, secure or anywhere close to complete, but it is a starting point for validating the images before we jump to them.

The code so far just checks the ROM_EXT identifier, and then jumps to the entry point.

I checked this with verilator, using `--meminit=rom,build-out/sw/device/mask_rom/mask_rom_sim_verilator.elf --meminit=flash,build-out/sw/device/rom_exts/rom_ext_sim_verilator.elf`. In this case, it successfully jumps to the ROM_EXT (the `unimp` instruction you hit is in the Flash address space, not the ROM address space).

If you leave out the `--meminit=flash,…` argument, it will stop on an `unimp` instruction inside the Mask ROM address space, because it didn't find the ROM_EXT manifest identifier in the right address.

fao @silvestrst 