### PR TITLE
[verilator] Move Verilator Stop Address out of RAM

### DIFF
--- a/hw/top_earlgrey/top_earlgrey_verilator.core
+++ b/hw/top_earlgrey/top_earlgrey_verilator.core
@@ -73,7 +73,7 @@ targets:
       - PRIM_DEFAULT_IMPL=prim_pkg::ImplGeneric
       - RVFI=true
       - VERILATOR_MEM_BASE=0x10000000
-      - VERILATOR_END_SIM_ADDR=0x10008000
+      - VERILATOR_END_SIM_ADDR=0x30000000
       - flashinit
       - rominit
       - DMIDirectTAP

--- a/sw/device/lib/arch/device_sim_verilator.c
+++ b/sw/device/lib/arch/device_sim_verilator.c
@@ -20,4 +20,4 @@ const uint64_t kClockFreqUsbHz = 500 * 1000;  // 500kHz
 const uint64_t kUartBaudrate = 7200;
 
 // Defined in `hw/top_earlgrey/top_earlgrey_verilator.core`
-const uintptr_t kDeviceStopAddress = 0x10008000;
+const uintptr_t kDeviceStopAddress = 0x30000000;


### PR DESCRIPTION
The Verilator Stop Address was at `0x10008000` - but RAM ostensibly runs
from `0x10000000` to `0x10010000`, so when Mask ROM zeroed all of RAM
before executing, it was causing the verilator simulator to finish.

This change moves the stop address out of the extents of RAM, to
`0x3000000` (which is currently unassigned in the address space).
