### PR TITLE
[sw/device] Move Device-specific Addresses

### DIFF
--- a/sw/device/lib/arch/device.h
+++ b/sw/device/lib/arch/device.h
@@ -82,4 +82,22 @@ extern const uint64_t kUartBaudrate;
  */
 extern const uintptr_t kDeviceStopAddress;
 
+/**
+ * An address to write to to report test status.
+ *
+ * If this is zero, there is no address to write to to report test status.
+ *
+ * @see #test_status_set
+ */
+extern const uintptr_t kDeviceTestStatusAddress;
+
+/**
+ * An address to write use for UART logging bypass
+ *
+ * If this is zero, there is no address to write to to bypass UART logging.
+ *
+ * @see #LOG
+ */
+extern const uintptr_t kDeviceLogBypassUartAddress;
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_ARCH_DEVICE_H_

--- a/sw/device/lib/arch/device_fpga_nexysvideo.c
+++ b/sw/device/lib/arch/device_fpga_nexysvideo.c
@@ -21,3 +21,7 @@ const uint64_t kUartBaudrate = 230400;
 
 // No Device Stop Address in our FPGA implementation.
 const uintptr_t kDeviceStopAddress = 0;
+
+const uintptr_t kDeviceTestStatusAddress = 0;
+
+const uintptr_t kDeviceLogBypassUartAddress = 0;

--- a/sw/device/lib/arch/device_sim_dv.c
+++ b/sw/device/lib/arch/device_sim_dv.c
@@ -23,3 +23,7 @@ const uint64_t kUartBaudrate = 1 * (1 << 20);  // 1Mbps
 
 // No Device Stop Address in our DV simulator.
 const uintptr_t kDeviceStopAddress = 0;
+
+const uintptr_t kDeviceTestStatusAddress = 0x1000fff8;
+
+const uintptr_t kDeviceLogBypassUartAddress = 0x1000fffc;

--- a/sw/device/lib/arch/device_sim_verilator.c
+++ b/sw/device/lib/arch/device_sim_verilator.c
@@ -21,3 +21,7 @@ const uint64_t kUartBaudrate = 7200;
 
 // Defined in `hw/top_earlgrey/top_earlgrey_verilator.core`
 const uintptr_t kDeviceStopAddress = 0x10008000;
+
+const uintptr_t kDeviceTestStatusAddress = 0;
+
+const uintptr_t kDeviceLogBypassUartAddress = 0;

--- a/sw/device/lib/base/log.c
+++ b/sw/device/lib/base/log.c
@@ -70,14 +70,8 @@ void base_log_internal_core(log_fields_t log, ...) {
 }
 
 /**
- * Indicates the fixed location in RAM for SW logging for DV.
- * TODO: Figure aout a better place to put this.
- */
-static const uintptr_t kSwDvLogAddr = 0x1000fffc;
-
-/**
  * Logs `log and the values that follow in an efficient, DV-testbench
- * specific way.
+ * specific way, which bypasses the UART.
  *
  * @param log a pointer to log data to log. Note that this pointer is likely to
  *        be invalid at runtime, since the pointed-to data will have been
@@ -86,7 +80,7 @@ static const uintptr_t kSwDvLogAddr = 0x1000fffc;
  * @param ... format parameters matching the format string.
  */
 void base_log_internal_dv(const log_fields_t *log, uint32_t nargs, ...) {
-  mmio_region_t log_device = mmio_region_from_addr(kSwDvLogAddr);
+  mmio_region_t log_device = mmio_region_from_addr(kDeviceLogBypassUartAddress);
   mmio_region_write32(log_device, 0x0, (uintptr_t)log);
 
   va_list args;

--- a/sw/device/lib/base/log.h
+++ b/sw/device/lib/base/log.h
@@ -110,7 +110,7 @@ void base_log_internal_dv(const log_fields_t *log, uint32_t nargs, ...);
  */
 #define LOG(severity, format, ...)                               \
   do {                                                           \
-    if (kDeviceType == kDeviceSimDV) {                           \
+    if (kDeviceLogBypassUartAddress != 0) {                      \
       /* clang-format off */                                     \
       /* Put DV-only log constants in .logs.* sections, which
        * the linker will dutifully discard.

--- a/sw/device/lib/testing/test_status.c
+++ b/sw/device/lib/testing/test_status.c
@@ -9,15 +9,10 @@
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/runtime/hart.h"
 
-/**
- * Address of the memory location to write the test status. For DV use only.
- */
-static const uintptr_t kSwDvTestStatusAddr = 0x1000fff8;
-
 void test_status_set(test_status_t test_status) {
-  if (kDeviceType == kDeviceSimDV) {
+  if (kDeviceTestStatusAddress != 0) {
     mmio_region_t sw_dv_test_status_addr =
-        mmio_region_from_addr(kSwDvTestStatusAddr);
+        mmio_region_from_addr(kDeviceTestStatusAddress);
     mmio_region_write32(sw_dv_test_status_addr, 0x0, (uint32_t)test_status);
   }
 


### PR DESCRIPTION
This takes a slightly more principled approach to device-specific
addresses, as used by DV (we've already done the same for verilator).

Now test status reporting just looks at the potential address to write
into, rather than the exact device kind, and the same for the DV logging
which bypasses the UART. This should allow us to replicate this
functionality in more simulation environments, without having to update
lots of different parts of the codebase.