### PR TITLE
[dv/common] Fix deadloop in reset test with Xcelium

### DIFF
--- a/hw/dv/sv/tl_agent/tl_host_driver.sv
+++ b/hw/dv/sv/tl_agent/tl_host_driver.sv
@@ -109,7 +109,7 @@ class tl_host_driver extends tl_base_driver;
     `uvm_info(get_full_name(), $sformatf("Req sent: %0s", req.convert2string()), UVM_HIGH)
   endtask : send_a_channel_request
 
-  virtual task send_a_request_body(input int a_valid_len, output bit req_done);
+  virtual task send_a_request_body(int a_valid_len, ref bit req_done);
     int unsigned a_valid_cnt;
     while(1) begin
       @(cfg.vif.host_cb);


### PR DESCRIPTION
In TL driver, when reset occurs, we set `req_done=1`, but using `output`
at task send_a_request_body will clear `req_done` even this task is
killed at the very beginning
Change `output` to `ref` to fix it

Signed-off-by: Weicai Yang <weicai@google.com>