### PR TITLE
[dv/alert_handler] fix csr test failure

### DIFF
--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_common_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_common_vseq.sv
@@ -16,6 +16,10 @@ class alert_handler_common_vseq extends alert_handler_base_vseq;
   virtual task body();
     // driven entropy to avoid assertion error in ping_timer
     cfg.entropy_vif.drive(entropy_bit);
+    // run alert/esc ping response sequences without error or timeout to prevent triggering local
+    // alert failure
+    run_alert_ping_rsp_seq_nonblocking(0);
+    run_esc_rsp_seq_nonblocking(0);
     run_common_vseq_wrapper(num_trans);
   endtask : body
 


### PR DESCRIPTION
The csr test failure in alert_handler is due to recent change in ping
timer. The ping timer now sends out ping testing much more frequently.
If during csr testing, ping test sent out without any response, it will
change the value for alert_loc_cause, and csr test cannot auto predict
that.
Instead of exclude the loc_alert_cause related registers, this PR drives
alert and esc signals to response to ping.

Signed-off-by: Cindy Chen <chencindy@google.com>