### PR TITLE
[clkmgr, top] Hook-up clkmgr idle signals

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr.hjson.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.hjson.tpl
@@ -80,11 +80,12 @@ num_grps = len(grps)
       package: "clkmgr_pkg", // This should be moved elsewhere later
     },
 
-    { struct:  "clk_hint_status",
+    { struct:  "logic",
       type:    "uni",
-      name:    "status",
+      name:    "idle",
       act:     "rcv",
-      package: "clkmgr_pkg",
+      package: "",
+      width:   "${len(hint_clks)}"
     },
   ],
 
@@ -127,7 +128,7 @@ num_grps = len(grps)
       swaccess: "rw",
       hwaccess: "hro",
       fields: [
-% for clk in hint_clks:
+% for clk in hint_clks.keys():
         {
           bits: "${loop.index}",
           name: "${clk.upper()}_HINT",
@@ -153,7 +154,7 @@ num_grps = len(grps)
       swaccess: "ro",
       hwaccess: "hwo",
       fields: [
-% for clk in hint_clks:
+% for clk in hint_clks.keys():
         {
           bits: "${loop.index}",
           name: "${clk.upper()}_VAL",

--- a/hw/ip/clkmgr/data/clkmgr.hjson.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.hjson.tpl
@@ -128,7 +128,7 @@ num_grps = len(grps)
       swaccess: "rw",
       hwaccess: "hro",
       fields: [
-% for clk in hint_clks.keys():
+% for clk in hint_clks:
         {
           bits: "${loop.index}",
           name: "${clk.upper()}_HINT",

--- a/hw/ip/clkmgr/data/clkmgr.sv.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.sv.tpl
@@ -44,7 +44,7 @@ module clkmgr import clkmgr_pkg::*; (
   input clk_dft_t dft_i,
 
   // idle hints
-  input clk_hint_status_t status_i,
+  input [${len(hint_clks)-1}:0] idle_i,
 
   // clock output interface
 % for intf in export_clks:
@@ -234,20 +234,20 @@ module clkmgr import clkmgr_pkg::*; (
 % endfor
 
 % for k,v in hint_clks.items():
-  assign ${k}_en = ${k}_hint | ~status_i.idle[${loop.index}];
+  assign ${k}_en = ${k}_hint | ~idle_i[${v["name"].capitalize()}];
 
   prim_flop_2sync #(
     .Width(1)
   ) u_${k}_hint_sync (
-    .clk_i(clk_${v}_i),
-    .rst_ni(rst_${v}_ni),
+    .clk_i(clk_${v["src"]}_i),
+    .rst_ni(rst_${v["src"]}_ni),
     .d_i(reg2hw.clk_hints.${k}_hint.q),
     .q_o(${k}_hint)
   );
 
   prim_clock_gating u_${k}_cg (
-    .clk_i(clk_${v}_i),
-    .en_i(${k}_en & clk_${v}_en),
+    .clk_i(clk_${v["src"]}_i),
+    .en_i(${k}_en & clk_${v["src"]}_en),
     .test_en_i(dft_i.test_en),
     .clk_o(clocks_o.${k})
   );

--- a/hw/ip/clkmgr/data/clkmgr_pkg.sv.tpl
+++ b/hw/ip/clkmgr/data/clkmgr_pkg.sv.tpl
@@ -12,6 +12,12 @@ num_hints = len(hint_clks)
 
 package clkmgr_pkg;
 
+  typedef enum int {
+% for hint, v in hint_clks.items():
+    ${v['name'].capitalize()} = ${loop.index}${"," if not loop.last else ""}
+% endfor
+  } hint_names_e;
+
   typedef struct packed {
     logic test_en;
   } clk_dft_t;

--- a/hw/ip/hmac/data/hmac.hjson
+++ b/hw/ip/hmac/data/hmac.hjson
@@ -16,6 +16,15 @@
       desc: "HMAC error occurred. ERR_CODE register shows which error occurred"
     }
   ],
+  inter_signal_list: [
+    { name:    "idle",
+      type:    "uni",
+      act:     "req",
+      package: "",
+      struct:  "logic",
+      width:   "1"
+    }
+  ],
   alert_list: [
     { name: "msg_push_sha_disabled",
       desc: "Dummy alert which is triggered upon writing a message when SHA is disabled",

--- a/hw/ip/hmac/rtl/hmac.sv
+++ b/hw/ip/hmac/rtl/hmac.sv
@@ -23,6 +23,8 @@ module hmac
   output logic intr_fifo_empty_o,
   output logic intr_hmac_err_o,
 
+  output logic idle_o,
+
   // alerts
   input  alert_rx_t [NumAlerts-1:0] alert_rx_i,
   output alert_tx_t [NumAlerts-1:0] alert_tx_o
@@ -522,6 +524,13 @@ module hmac
       .alert_tx_o ( alert_tx_o[j] )
     );
   end : gen_alert_tx
+
+
+  /////////////////////
+  // Idle output     //
+  /////////////////////
+  // TBD this should be connected later
+  assign idle_o = 1'b1;
 
   //////////////////////////////////////////////
   // Assertions, Assumptions, and Coverpoints //

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -999,8 +999,8 @@
           width: 1
           inst_name: aes
           default: ""
-          top_signame: aes_idle
-          index: -1
+          top_signame: clkmgr_idle
+          index: 0
         }
         {
           struct: tl
@@ -1095,6 +1095,18 @@
       scan_reset: "false"
       inter_signal_list:
       [
+        {
+          name: idle
+          type: uni
+          act: req
+          package: ""
+          struct: logic
+          width: 1
+          inst_name: hmac
+          default: ""
+          top_signame: clkmgr_idle
+          index: 1
+        }
         {
           struct: tl
           package: tlul_pkg
@@ -1875,15 +1887,16 @@
           index: -1
         }
         {
-          struct: clk_hint_status
+          struct: logic
           type: uni
-          name: status
+          name: idle
           act: rcv
-          package: clkmgr_pkg
+          package: ""
+          width: 3
           inst_name: clkmgr
-          width: 1
           default: ""
-          top_signame: clkmgr_status
+          top_type: one-to-N
+          top_signame: clkmgr_idle
           index: -1
         }
         {
@@ -2651,10 +2664,13 @@
           name: idle
           type: uni
           struct: logic
-          width: "1"
+          width: 1
           act: req
           inst_name: otbn
-          index: -1
+          default: ""
+          package: ""
+          top_signame: clkmgr_idle
+          index: 2
         }
         {
           struct: tl
@@ -2856,6 +2872,12 @@
       [
         rstmgr.alert_dump
       ]
+      clkmgr.idle:
+      [
+        aes.idle
+        hmac.idle
+        otbn.idle
+      ]
       pwrmgr.wakeups:
       [
         pinmux.aon_wkup_req
@@ -2967,8 +2989,6 @@
       rstmgr.cpu
       pwrmgr.pwr_cpu
       clkmgr.clocks
-      aes.idle
-      clkmgr.status
       main.tl_corei
       main.tl_cored
       main.tl_dm_sba
@@ -5243,8 +5263,8 @@
         width: 1
         inst_name: aes
         default: ""
-        top_signame: aes_idle
-        index: -1
+        top_signame: clkmgr_idle
+        index: 0
       }
       {
         struct: tl
@@ -5257,6 +5277,18 @@
         default: ""
         top_signame: aes_tl
         index: -1
+      }
+      {
+        name: idle
+        type: uni
+        act: req
+        package: ""
+        struct: logic
+        width: 1
+        inst_name: hmac
+        default: ""
+        top_signame: clkmgr_idle
+        index: 1
       }
       {
         struct: tl
@@ -5685,15 +5717,16 @@
         index: -1
       }
       {
-        struct: clk_hint_status
+        struct: logic
         type: uni
-        name: status
+        name: idle
         act: rcv
-        package: clkmgr_pkg
+        package: ""
+        width: 3
         inst_name: clkmgr
-        width: 1
         default: ""
-        top_signame: clkmgr_status
+        top_type: one-to-N
+        top_signame: clkmgr_idle
         index: -1
       }
       {
@@ -5890,10 +5923,13 @@
         name: idle
         type: uni
         struct: logic
-        width: "1"
+        width: 1
         act: req
         inst_name: otbn
-        index: -1
+        default: ""
+        package: ""
+        top_signame: clkmgr_idle
+        index: 2
       }
       {
         struct: tl
@@ -6561,6 +6597,14 @@
       {
         package: ""
         struct: logic
+        signame: clkmgr_idle
+        width: 3
+        type: uni
+        default: ""
+      }
+      {
+        package: ""
+        struct: logic
         signame: pwrmgr_wakeups
         width: 1
         type: uni
@@ -6986,22 +7030,6 @@
         package: clkmgr_pkg
         struct: clkmgr_out
         signame: clkmgr_clocks
-        width: 1
-        type: uni
-        default: ""
-      }
-      {
-        package: ""
-        struct: logic
-        signame: aes_idle
-        width: 1
-        type: uni
-        default: ""
-      }
-      {
-        package: clkmgr_pkg
-        struct: clk_hint_status
-        signame: clkmgr_status
         width: 1
         type: uni
         default: ""

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -411,7 +411,8 @@
       'pwrmgr.pwr_rst'   : ['rstmgr.pwr'],
       'pwrmgr.pwr_clk'   : ['clkmgr.pwr'],
       'flash_ctrl.keymgr': ['keymgr.flash'],
-      'alert_handler.crashdump': ['rstmgr.alert_dump']
+      'alert_handler.crashdump': ['rstmgr.alert_dump'],
+      'clkmgr.idle'      : [],
     }
 
     // top is to connect to top net/struct.
@@ -419,7 +420,6 @@
     // use of the signal is up to top template
     'top': [
         'rstmgr.resets', 'rstmgr.cpu', 'pwrmgr.pwr_cpu', 'clkmgr.clocks',
-        'aes.idle', 'clkmgr.status',
 
         // Xbars
         'main.tl_corei', 'main.tl_cored', 'main.tl_dm_sba', 'main.tl_debug_mem'

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -412,6 +412,9 @@
       'pwrmgr.pwr_clk'   : ['clkmgr.pwr'],
       'flash_ctrl.keymgr': ['keymgr.flash'],
       'alert_handler.crashdump': ['rstmgr.alert_dump'],
+      // The idle connection is automatically connected through topgen.
+      // The user does not need to explicitly declare anything other than
+      // an empty list.
       'clkmgr.idle'      : [],
     }
 

--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -181,11 +181,6 @@ module top_${top["name"]} #(
 % endfor
 
 ## Inter-module signal collection
-  always_comb begin
-    // TODO: So far just aes is connected
-    clkmgr_status.idle    = clkmgr_pkg::CLK_HINT_STATUS_DEFAULT;
-    clkmgr_status.idle[0] = aes_idle;
-  end
 
   // Non-debug module reset == reset for everything except for the debug module
   logic ndmreset_req;

--- a/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
+++ b/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
@@ -92,11 +92,12 @@
       package: "clkmgr_pkg", // This should be moved elsewhere later
     },
 
-    { struct:  "clk_hint_status",
+    { struct:  "logic",
       type:    "uni",
-      name:    "status",
+      name:    "idle",
       act:     "rcv",
-      package: "clkmgr_pkg",
+      package: "",
+      width:   "3"
     },
   ],
 

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
@@ -47,7 +47,7 @@ module clkmgr import clkmgr_pkg::*; (
   input clk_dft_t dft_i,
 
   // idle hints
-  input clk_hint_status_t status_i,
+  input [2:0] idle_i,
 
   // clock output interface
   output clkmgr_ast_out_t clocks_ast_o,
@@ -292,7 +292,7 @@ module clkmgr import clkmgr_pkg::*; (
   logic clk_main_otbn_hint;
   logic clk_main_otbn_en;
 
-  assign clk_main_aes_en = clk_main_aes_hint | ~status_i.idle[0];
+  assign clk_main_aes_en = clk_main_aes_hint | ~idle_i[Aes];
 
   prim_flop_2sync #(
     .Width(1)
@@ -310,7 +310,7 @@ module clkmgr import clkmgr_pkg::*; (
     .clk_o(clocks_o.clk_main_aes)
   );
 
-  assign clk_main_hmac_en = clk_main_hmac_hint | ~status_i.idle[1];
+  assign clk_main_hmac_en = clk_main_hmac_hint | ~idle_i[Hmac];
 
   prim_flop_2sync #(
     .Width(1)
@@ -328,7 +328,7 @@ module clkmgr import clkmgr_pkg::*; (
     .clk_o(clocks_o.clk_main_hmac)
   );
 
-  assign clk_main_otbn_en = clk_main_otbn_hint | ~status_i.idle[2];
+  assign clk_main_otbn_en = clk_main_otbn_hint | ~idle_i[Otbn];
 
   prim_flop_2sync #(
     .Width(1)

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_pkg.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_pkg.sv
@@ -12,6 +12,12 @@
 
 package clkmgr_pkg;
 
+  typedef enum int {
+    Aes = 0,
+    Hmac = 1,
+    Otbn = 2
+  } hint_names_e;
+
   typedef struct packed {
     logic test_en;
   } clk_dft_t;

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -221,6 +221,7 @@ module top_earlgrey #(
   pwrmgr_pkg::pwr_clk_rsp_t       pwrmgr_pwr_clk_rsp;
   flash_ctrl_pkg::keymgr_flash_t       flash_ctrl_keymgr;
   alert_pkg::alert_crashdump_t       alert_handler_crashdump;
+  logic [2:0] clkmgr_idle;
   logic       pwrmgr_wakeups;
   logic       pwrmgr_rstreqs;
   tlul_pkg::tl_h2d_t       rom_tl_req;
@@ -275,8 +276,6 @@ module top_earlgrey #(
   rstmgr_pkg::rstmgr_cpu_t       rstmgr_cpu;
   pwrmgr_pkg::pwr_cpu_t       pwrmgr_pwr_cpu;
   clkmgr_pkg::clkmgr_out_t       clkmgr_clocks;
-  logic       aes_idle;
-  clkmgr_pkg::clk_hint_status_t       clkmgr_status;
   tlul_pkg::tl_h2d_t       main_tl_corei_req;
   tlul_pkg::tl_d2h_t       main_tl_corei_rsp;
   tlul_pkg::tl_h2d_t       main_tl_cored_req;
@@ -286,11 +285,6 @@ module top_earlgrey #(
   tlul_pkg::tl_h2d_t       main_tl_debug_mem_req;
   tlul_pkg::tl_d2h_t       main_tl_debug_mem_rsp;
 
-  always_comb begin
-    // TODO: So far just aes is connected
-    clkmgr_status.idle    = clkmgr_pkg::CLK_HINT_STATUS_DEFAULT;
-    clkmgr_status.idle[0] = aes_idle;
-  end
 
   // Non-debug module reset == reset for everything except for the debug module
   logic ndmreset_req;
@@ -700,7 +694,7 @@ module top_earlgrey #(
       .alert_rx_i  ( alert_rx[1:0] ),
 
       // Inter-module signals
-      .idle_o(aes_idle),
+      .idle_o(clkmgr_idle[0]),
       .tl_i(aes_tl_req),
       .tl_o(aes_tl_rsp),
       .clk_i (clkmgr_clocks.clk_main_aes),
@@ -719,6 +713,7 @@ module top_earlgrey #(
       .alert_rx_i  ( alert_rx[2:2] ),
 
       // Inter-module signals
+      .idle_o(clkmgr_idle[1]),
       .tl_i(hmac_tl_req),
       .tl_o(hmac_tl_rsp),
       .clk_i (clkmgr_clocks.clk_main_hmac),
@@ -873,7 +868,7 @@ module top_earlgrey #(
       .pwr_i(pwrmgr_pwr_clk_req),
       .pwr_o(pwrmgr_pwr_clk_rsp),
       .dft_i(clkmgr_pkg::CLK_DFT_DEFAULT),
-      .status_i(clkmgr_status),
+      .idle_i(clkmgr_idle),
       .tl_i(clkmgr_tl_req),
       .tl_o(clkmgr_tl_rsp),
       .clk_i (clkmgr_clocks.clk_io_div4_powerup),
@@ -1020,7 +1015,7 @@ module top_earlgrey #(
       .alert_rx_i  ( alert_rx[13:11] ),
 
       // Inter-module signals
-      .idle_o(),
+      .idle_o(clkmgr_idle[2]),
       .tl_i(otbn_tl_req),
       .tl_o(otbn_tl_rsp),
       .clk_i (clkmgr_clocks.clk_main_otbn),

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -540,7 +540,7 @@ def generate_clkmgr(top, cfg_path, out_path):
 
     # hint clocks dict
     for clk, src in hints.items():
-        # the clock if constructed as clk_{src_name}_{module_name}.
+        # the clock is constructed as clk_{src_name}_{module_name}.
         # so to get the module name we split from the right and pick the last entry
         hint_clks[clk] = OrderedDict()
         hint_clks[clk]['name'] = (clk.rsplit('_', 1)[-1])

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -489,10 +489,10 @@ def generate_clkmgr(top, cfg_path, out_path):
     # clock classification
     grps = top['clocks']['groups']
 
-    src_aon_attr = OrderedDict()
     ft_clks = OrderedDict()
     rg_clks = OrderedDict()
     sw_clks = OrderedDict()
+    src_aon_attr = OrderedDict()
     hint_clks = OrderedDict()
 
     # construct a dictionary of the aon attribute for easier lookup
@@ -532,11 +532,19 @@ def generate_clkmgr(top, cfg_path, out_path):
     ])
 
     # sw hint clocks
-    hint_clks = OrderedDict([
+    hints = OrderedDict([
         (clk, src)
         for grp in grps for (clk, src) in grp['clocks'].items()
         if grp['sw_cg'] == 'hint' and not src_aon_attr[src]
     ])
+
+    # hint clocks dict
+    for clk, src in hints.items():
+        # the clock if constructed as clk_{src_name}_{module_name}.
+        # so to get the module name we split from the right and pick the last entry
+        hint_clks[clk] = OrderedDict()
+        hint_clks[clk]['name'] = (clk.rsplit('_', 1)[-1])
+        hint_clks[clk]['src'] = src
 
     for idx, tpl in enumerate(tpls):
         out = ""

--- a/util/topgen/merge.py
+++ b/util/topgen/merge.py
@@ -521,6 +521,7 @@ def amend_clocks(top: OrderedDict):
     clk_paths = clks_attr['hier_paths']
     groups_in_top = [x["name"].lower() for x in clks_attr['groups']]
     exported_clks = OrderedDict()
+    trans_eps = []
 
     # Assign default parameters to source clocks
     for src in clks_attr['srcs']:
@@ -550,6 +551,10 @@ def amend_clocks(top: OrderedDict):
         ep['clock_group'] = 'secure' if 'clock_group' not in ep else ep[
             'clock_group']
         ep_grp = ep['clock_group']
+
+        # if ep is in the transactional group, collect into list below
+        if ep['clock_group'] == 'trans':
+            trans_eps.append(ep['name'])
 
         # end point names and clocks
         ep_name = ep['name']
@@ -617,6 +622,11 @@ def amend_clocks(top: OrderedDict):
     # add entry to inter_module automatically
     for intf in top['exported_clks']:
         top['inter_module']['external']['clkmgr.clocks_{}'.format(intf)] = "clks_{}".format(intf)
+
+    # add to intermodule connections
+    for ep in trans_eps:
+        entry = ep + ".idle"
+        top['inter_module']['connect']['clkmgr.idle'].append(entry)
 
 
 def amend_resets(top):


### PR DESCRIPTION
Auto-generate connections needed for transactional clock group idle signals.
An idle for hmac is temporarily created.  Kmac will eventually fall into this group also.