### PR TITLE
[fpv/prim_packer] remove assumption

### DIFF
--- a/hw/ip/prim/rtl/prim_packer.sv
+++ b/hw/ip/prim/rtl/prim_packer.sv
@@ -248,9 +248,6 @@ module prim_packer #(
           ##1 valid_i && $past(valid_i) && !$past(ready_o)
           |-> $stable(data_i) && $stable(mask_i))
 
-  `ASSUME(ValidIPairedWithReadyO_M,
-          valid_i && !ready_o |=> valid_i)
-
   `ASSERT(FlushFollowedByDone_A,
           ##1 $rose(flush_i) && !flush_done_o |-> !flush_done_o [*0:$] ##1 flush_done_o)
 


### PR DESCRIPTION
This prim packer assumption is not accurate. Design can still drop
valid_i even when ready_o is low. Then design will just drop this
transaction. This PR removes this assumption.
The screenshot below shows this transaction. TLUL interface dropped
`a_valid` before `a_ready` is high. This triggered this assumption failure.

![image](https://user-images.githubusercontent.com/11466553/94329492-42c75080-ff70-11ea-8376-33c9c275a983.png)

Signed-off-by: Cindy Chen <chencindy@google.com>