### PR TITLE
[otbn] improve style in modexp code

### DIFF
--- a/sw/otbn/code-snippets/modexp.S
+++ b/sw/otbn/code-snippets/modexp.S
@@ -33,33 +33,13 @@ selcxSub:
   li         x8, 5
   li        x10, 3
   li        x11, 2
-  li        x12, 4
   lw        x16, 0(x0)
-  bn.wsrrs  w4, 1, w31
-  bn.add    w4, w4, w31
-  csrrs     x2, 1984, x0
-  andi      x2, x2, 2
-  bne       x2, x0, selcxSub_invsel
-  bn.addc   w3, w4, w4 << 16B, FG1
-  loop      x30, 7
+  bn.add    w31, w31, w31
+  loop      x30, 5
   bn.lid    x10, 0(x16++)
   bn.movr   x11, x8
-  bn.movr   x8, x12
   bn.subb   w4, w2, w3
-  bn.wsrrs  w3, 1, w31
-  bn.sel    w3, w4, w2, FG1.L
-  bn.movr   x8++, x10
-  ret
-
-selcxSub_invsel:
-  bn.addc   w3, w4, w4 << 16B, FG1
-  loop      x30, 7
-  bn.lid    x10, 0(x16++)
-  bn.movr   x11, x8
-  bn.movr   x8, x12
-  bn.subb   w4, w2, w3
-  bn.wsrrs  w3, 1, w31
-  bn.sel    w3, w2, w4, FG1.L
+  bn.sel    w3, w4, w2, FG1.C
   bn.movr   x8++, x10
   ret
 
@@ -146,31 +126,12 @@ dmXa:
   ret
 
 mma_sub_cx:
-  bn.wsrrs  w28, 1, w31
-  bn.add    w28, w28, w31
-  csrrs     x2, 1984, x0
-  andi      x2, x2, 2
-  bne       x2, x0, mma_invsel
-  bn.addc   w28, w28, w28 << 16B, FG1
-  loop      x30, 7
+  loop      x30, 6
   bn.lid    x13, 0(x16++)
   bn.movr   x12, x8
   bn.subb   w29, w30, w24
-  bn.wsrrs  w24, 1, w31
   bn.movr   x8, x13
-  bn.sel    w24, w29, w30, FG1.L
-  bn.movr   x8++, x13
-  ret
-
-mma_invsel:
-  bn.addc   w28, w28, w28 << 16B, FG1
-  loop      x30, 7
-  bn.lid    x13, 0(x16++)
-  bn.movr   x12, x8
-  bn.subb   w29, w30, w24
-  bn.wsrrs  w24, 1, w31
-  bn.movr   x8, x13
-  bn.sel    w24, w30, w29, FG1.L
+  bn.sel    w24, w29, w30, FG1.C
   bn.movr   x8++, x13
   ret
 
@@ -270,31 +231,12 @@ mulx:
   ret
 
 mm1_sub_cx:
-  bn.wsrrs  w3, 1, w31
-  bn.add    w3, w3, w31
-  csrrs     x2, 1984, x0
-  andi      x2, x2, 2
-  bne       x2, x0, mm1_invsel
-  bn.addc   w3, w3, w3 << 16B, FG1
-  loop      x30, 6
+  loop      x30, 5
   bn.lid    x9, 0(x16++)
   bn.movr   x11, x8++
   bn.subb   w3, w2, w3
-  bn.sel    w2, w3, w2, FG1.L
+  bn.sel    w2, w3, w2, FG1.C
   bn.sid    x11, 0(x21++)
-  nop
-  ret
-  nop
-
-mm1_invsel:
-  bn.addc   w3, w3, w3 << 16B, FG1
-  loop      x30, 6
-  bn.lid    x9, 0(x16++)
-  bn.movr   x11, x8++
-  bn.subb   w3, w2, w3
-  bn.sel    w2, w2, w3, FG1.L
-  bn.sid    x11, 0(x21++)
-  nop
   ret
 
 mul1_exp:
@@ -401,38 +343,12 @@ mulx_exp:
   ret
 
 selOutOrC:
-  bn.wsrrs  w3, 1, w31
-  bn.or     w3, w3, w3
-  csrrs     x2, 1984, x0
-  andi      x2, x2, 2
-  bne       x2, x0, selOutOrC_invsel
-  bn.addc   w3, w3, w3 << 16B
-  loop      x30, 10
-  bn.wsrrs  w3, 1, w31
-  bn.wsrrs  w2, 1, w31
+  loop      x30, 6
   bn.lid    x9, 0(x21)
   bn.sid    x11, 0(x21)
   bn.movr   x11, x8++
-  bn.wsrrs  w0, 1, w31
   bn.mov    w0, w2
-  bn.wsrrs  w2, 1, w31
-  bn.sel    w2, w0, w3, L
-  bn.sid    x11, 0(x21++)
-  ret
-  nop
-
-selOutOrC_invsel:
-  bn.addc   w3, w3, w3 << 16B
-  loop      x30, 10
-  bn.wsrrs  w3, 1, w31
-  bn.wsrrs  w2, 1, w31
-  bn.lid    x9, 0(x21)
-  bn.sid    x11, 0(x21)
-  bn.movr   x11, x8++
-  bn.wsrrs  w0, 1, w31
-  bn.mov    w0, w2
-  bn.wsrrs  w2, 1, w31
-  bn.sel    w2, w3, w0, L
+  bn.sel    w2, w0, w3, C
   bn.sid    x11, 0(x21++)
   ret
 
@@ -447,14 +363,12 @@ modexp:
   lw        x22, 120(x0)
   lw        x23, 124(x0)
   bn.sub    w2, w2, w2
-  loop      x30, 4
-  nop
+  loop      x30, 3
   bn.lid    x11, 0(x16++)
   bn.subb   w2, w31, w2
   bn.sid    x11, 0(x21++)
-  nop
   slli      x24, x22, 8
-  loop      x24, 19
+  loop      x24, 17
   jal       x1, sqrx_exp
   jal       x1, mulx_exp
   lw        x16, 96(x0)
@@ -465,10 +379,8 @@ modexp:
   lw        x21, 116(x0)
   lw        x22, 120(x0)
   lw        x23, 124(x0)
-  bn.wsrrs  w2, 1, w31
   bn.add    w2, w2, w2
-  loop      x30, 4
-  bn.wsrrs  w2, 1, w31
+  loop      x30, 3
   bn.lid    x11, 0(x20)
   bn.addc   w2, w2, w2
   bn.sid    x11, 0(x20++)

--- a/sw/otbn/code-snippets/modexp.S
+++ b/sw/otbn/code-snippets/modexp.S
@@ -27,13 +27,13 @@ d0inv:
   bn.or     w29, w29, w1
   bn.add    w0, w0, w0
   bn.sub    w29, w31, w29
-  jalr      x0, x1, 0
+  ret
 
 selcxSub:
-  addi      x8, x0, 5
-  addi      x10, x0, 3
-  addi      x11, x0, 2
-  addi      x12, x0, 4
+  li         x8, 5
+  li        x10, 3
+  li        x11, 2
+  li        x12, 4
   lw        x16, 0(x0)
   bn.wsrrs  w4, 1, w31
   bn.add    w4, w4, w31
@@ -49,7 +49,7 @@ selcxSub:
   bn.wsrrs  w3, 1, w31
   bn.sel    w3, w4, w2, FG1.L
   bn.movr   x8++, x10
-  jalr      x0, x1, 0
+  ret
 
 selcxSub_invsel:
   bn.addc   w3, w4, w4 << 16B, FG1
@@ -61,11 +61,11 @@ selcxSub_invsel:
   bn.wsrrs  w3, 1, w31
   bn.sel    w3, w2, w4, FG1.L
   bn.movr   x8++, x10
-  jalr      x0, x1, 0
+  ret
 
 computeRR:
   bn.xor    w31, w31, w31
-  addi      x3, x0, 0
+  li        x3, 0
   bn.lid    x3, 0(x0)
   lw        x16, 0(x0)
   lw        x17, 4(x0)
@@ -77,22 +77,22 @@ computeRR:
   lw        x23, 28(x0)
   bn.xor    w3, w3, w3
   slli      x24, x22, 8
-  addi      x8, x0, 5
-  addi      x10, x0, 3
+  li        x8, 5
+  li        x10, 3
   bn.xor    w3, w3, w3
   loop      x30, 1
   bn.movr   x8++, x10
   bn.sub    w3, w31, w0, FG1
   jal       x1, selcxSub
   loop      x24, 16
-  addi      x8, x0, 5
+  li        x8, 5
   bn.sub    w3, w3, w3, FG1
   loop      x30, 3
   bn.movr   x11, x8
   bn.addc   w2, w2, w2, FG1
   bn.movr   x8++, x11
   jal       x1, selcxSub
-  addi      x8, x0, 5
+  li        x8, 5
   lw        x16, 0(x0)
   bn.sub    w3, w3, w3, FG1
   loop      x30, 3
@@ -100,12 +100,12 @@ computeRR:
   bn.movr   x11, x8++
   bn.cmpb   w3, w2, FG1
   jal       x1, selcxSub
-  addi      x0, x0, 0
-  addi      x8, x0, 5
+  li        x0, 0
+  li        x8, 5
   loop      x30, 2
   bn.sid    x8, 0(x18++)
   addi      x8, x8, 1
-  jalr      x0, x1, 0
+  ret
 
 dmXd0:
   bn.mulqacc.z          w30.0, w25.0,  0
@@ -124,7 +124,7 @@ dmXd0:
   bn.mulqacc            w30.3, w25.2, 64
   bn.mulqacc.so  w26.L, w30.2, w25.3, 64
   bn.mulqacc.so  w26.U, w30.3, w25.3,  0
-  jalr      x0, x1, 0
+  ret
 
 dmXa:
   bn.mulqacc.z          w30.0, w2.0,  0
@@ -143,7 +143,7 @@ dmXa:
   bn.mulqacc            w30.3, w2.2, 64
   bn.mulqacc.so  w26.L, w30.2, w2.3, 64
   bn.mulqacc.so  w26.U, w30.3, w2.3,  0
-  jalr      x0, x1, 0
+  ret
 
 mma_sub_cx:
   bn.wsrrs  w28, 1, w31
@@ -160,7 +160,7 @@ mma_sub_cx:
   bn.movr   x8, x13
   bn.sel    w24, w29, w30, FG1.L
   bn.movr   x8++, x13
-  jalr      x0, x1, 0
+  ret
 
 mma_invsel:
   bn.addc   w28, w28, w28 << 16B, FG1
@@ -172,13 +172,13 @@ mma_invsel:
   bn.movr   x8, x13
   bn.sel    w24, w30, w29, FG1.L
   bn.movr   x8++, x13
-  jalr      x0, x1, 0
+  ret
 
 mma:
-  addi      x12, x0, 30
-  addi      x13, x0, 24
-  addi      x8, x0, 4
-  addi      x10, x0, 4
+  li        x12, 30
+  li        x13, 24
+  li         x8,  4
+  li        x10,  4
   bn.lid    x12, 0(x19++)
   jal x1,   dmXa
   bn.movr   x13, x8++
@@ -212,13 +212,13 @@ mma:
   bn.movr   x10++, x13
   lw        x16, 0(x0)
   lw        x19, 12(x0)
-  addi      x8, x0, 4
-  addi      x10, x0, 4
-  addi      x12, x0, 30
-  addi      x13, x0, 24
+  li        x8, 4
+  li        x10, 4
+  li        x12, 30
+  li        x13, 24
   jal       x1, mma_sub_cx
-  addi      x0, x0, 0
-  jalr      x0, x1, 0
+  nop
+  ret
 
 setupPtrs:
   lw        x16, 0(x0)
@@ -238,21 +238,21 @@ setupPtrs:
   lw        x30, 24(x0)
   lw        x31, 28(x0)
   bn.mov    w1, w31
-  addi      x8, x0, 4
-  addi      x9, x0, 3
-  addi      x10, x0, 4
-  addi      x11, x0, 2
-  jalr      x0, x1, 0
+  li         x8, 4
+  li         x9, 3
+  li        x10, 4
+  li        x11, 2
+  ret
 
 mulx:
-  addi      x3, x0, 0
+  li        x3, 0
   bn.lid    x3, 0(x0)
   jal       x1, setupPtrs
   bn.lid    x9, 0(x17)
   bn.mov    w2, w31
   loop      x30, 1
   bn.movr   x10++, x11
-  addi      x10, x0, 4
+  li        x10, 4
   loop      x30, 8
   bn.lid    x11, 0(x20++)
   add       x4, x16, x0
@@ -262,12 +262,12 @@ mulx:
   add       x16, x4, x0
   add       x19, x5, x0
   add       x20, x6, x0
-  addi      x8, x0, 4
+  li        x8, 4
   loop      x30, 2
   bn.sid    x8, 0(x21++)
   addi      x8, x8, 1
-  addi      x8, x0, 4
-  jalr      x0, x1, 0
+  li        x8, 4
+  ret
 
 mm1_sub_cx:
   bn.wsrrs  w3, 1, w31
@@ -282,9 +282,9 @@ mm1_sub_cx:
   bn.subb   w3, w2, w3
   bn.sel    w2, w3, w2, FG1.L
   bn.sid    x11, 0(x21++)
-  addi      x0, x0, 0
-  jalr      x0, x1, 0
-  addi      x0, x0, 0
+  nop
+  ret
+  nop
 
 mm1_invsel:
   bn.addc   w3, w3, w3 << 16B, FG1
@@ -294,8 +294,8 @@ mm1_invsel:
   bn.subb   w3, w2, w3
   bn.sel    w2, w2, w3, FG1.L
   bn.sid    x11, 0(x21++)
-  addi      x0, x0, 0
-  jalr      x0, x1, 0
+  nop
+  ret
 
 mul1_exp:
   bn.lid    x9, 0(x17)
@@ -318,17 +318,17 @@ mul1_exp:
   bn.lid    x9, 0(x16++)
   bn.movr   x11, x8++
   bn.cmpb   w3, w2, FG1
-  addi      x8, x0, 4
-  addi      x10, x0, 4
+  li         x8, 4
+  li        x10, 4
   addi      x16, x6, 0
   addi      x19, x7, 0
   jal       x1, mm1_sub_cx
   addi      x16, x6, 0
   addi      x19, x7, 0
-  jalr      x0, x1, 0
+  ret
 
 mul1:
-  addi      x3, x0, 0
+  li        x3, 0
   bn.lid    x3, 0(x0)
   jal       x1, setupPtrs
   jal       x1, mul1_exp
@@ -357,16 +357,16 @@ sqrx_exp:
   addi      x20, x5, 0
   addi      x16, x6, 0
   addi      x19, x7, 0
-  addi      x10, x0, 4
-  addi      x8, x0, 4
+  li        x10, 4
+  li         x8, 4
   loop      x30, 2
   bn.sid    x8, 0(x21++)
   addi      x8, x8, 1
-  addi      x8, x0, 4
-  addi      x10, x0, 4
+  li         x8, 4
+  li        x10, 4
   lw        x12, 16(x0)
   lw        x13, 20(x0)
-  jalr      x0, x1, 0
+  ret
 
 mulx_exp:
   lw        x16, 64(x0)
@@ -381,8 +381,8 @@ mulx_exp:
   bn.mov    w2, w31
   loop      x30, 1
   bn.movr   x10++, x11
-  addi      x8, x0, 4
-  addi      x10, x0, 4
+  li         x8, 4
+  li        x10, 4
   lw        x12, 16(x0)
   lw        x13, 20(x0)
   loop      x30, 8
@@ -394,11 +394,11 @@ mulx_exp:
   addi      x20, x5, 0
   addi      x16, x6, 0
   addi      x19, x7, 0
-  addi      x8, x0, 4
-  addi      x10, x0, 4
+  li        x8, 4
+  li        x10, 4
   lw        x12, 16(x0)
   lw        x13, 20(x0)
-  jalr      x0, x1, 0
+  ret
 
 selOutOrC:
   bn.wsrrs  w3, 1, w31
@@ -418,8 +418,8 @@ selOutOrC:
   bn.wsrrs  w2, 1, w31
   bn.sel    w2, w0, w3, L
   bn.sid    x11, 0(x21++)
-  jalr      x0, x1, 0
-  addi      x0, x0, 0
+  ret
+  nop
 
 selOutOrC_invsel:
   bn.addc   w3, w3, w3 << 16B
@@ -434,7 +434,7 @@ selOutOrC_invsel:
   bn.wsrrs  w2, 1, w31
   bn.sel    w2, w3, w0, L
   bn.sid    x11, 0(x21++)
-  jalr      x0, x1, 0
+  ret
 
 modexp:
   jal       x1, mulx
@@ -448,11 +448,11 @@ modexp:
   lw        x23, 124(x0)
   bn.sub    w2, w2, w2
   loop      x30, 4
-  addi      x0, x0, 0
+  nop
   bn.lid    x11, 0(x16++)
   bn.subb   w2, w31, w2
   bn.sid    x11, 0(x21++)
-  addi      x0, x0, 0
+  nop
   slli      x24, x22, 8
   loop      x24, 19
   jal       x1, sqrx_exp
@@ -473,8 +473,8 @@ modexp:
   bn.addc   w2, w2, w2
   bn.sid    x11, 0(x20++)
   jal       x1, selOutOrC
-  addi      x0, x0, 0
-  addi      x3, x0, 0
+  nop
+  li        x3, 0
   bn.lid    x3, 96(x0)
   lw        x16, 96(x0)
   lw        x17, 100(x0)
@@ -489,7 +489,7 @@ modexp:
 
 modload:
   bn.xor   w31, w31, w31
-  addi     x3, x0, 0
+  li       x3, 0
   bn.lid   x3, 0(x0)
   lw       x16, 0(x0)
   lw       x17, 4(x0)
@@ -507,8 +507,8 @@ modload:
   lw       x29, 20(x0)
   lw       x30, 24(x0)
   lw       x31, 28(x0)
-  addi     x8, x0, 28
-  addi     x9, x0, 29
+  li       x8, 28
+  li       x9, 29
   lw       x10, 8(x0)
   lw       x11, 12(x0)
   lw       x12, 16(x0)

--- a/sw/otbn/code-snippets/modexp.S
+++ b/sw/otbn/code-snippets/modexp.S
@@ -9,515 +9,514 @@
  *
  */
 d0inv:
-BN.XOR w0, w0, w0
-BN.ADDI w0, w0, 1
-BN.MOV w29, w0
-LOOPI 256, 13
-BN.MULQACC.Z w28.0, w29.0, 0
-BN.MULQACC w28.1, w29.0, 64
-BN.MULQACC.SO w1.L, w28.0, w29.1, 64
-BN.MULQACC w28.2, w29.0, 0
-BN.MULQACC w28.1, w29.1, 0
-BN.MULQACC w28.0, w29.2, 0
-BN.MULQACC w28.3, w29.0, 64
-BN.MULQACC w28.2, w29.1, 64
-BN.MULQACC w28.1, w29.2, 64
-BN.MULQACC.SO w1.U, w28.0, w29.3, 64
-BN.AND w1, w1, w0
-BN.OR w29, w29, w1
-BN.ADD w0, w0, w0
-BN.SUB w29, w31, w29
-JALR x0, x1, 0
+  bn.xor    w0, w0, w0
+  bn.addi   w0, w0, 1
+  bn.mov    w29, w0
+  loopi     256, 13
+  bn.mulqacc.z          w28.0, w29.0,  0
+  bn.mulqacc            w28.1, w29.0, 64
+  bn.mulqacc.so   w1.L, w28.0, w29.1, 64
+  bn.mulqacc            w28.2, w29.0,  0
+  bn.mulqacc            w28.1, w29.1,  0
+  bn.mulqacc            w28.0, w29.2,  0
+  bn.mulqacc            w28.3, w29.0, 64
+  bn.mulqacc            w28.2, w29.1, 64
+  bn.mulqacc            w28.1, w29.2, 64
+  bn.mulqacc.so   w1.U, w28.0, w29.3, 64
+  bn.and    w1, w1, w0
+  bn.or     w29, w29, w1
+  bn.add    w0, w0, w0
+  bn.sub    w29, w31, w29
+  jalr      x0, x1, 0
 
 selcxSub:
-ADDI x8, x0, 5
-ADDI x10, x0, 3
-ADDI x11, x0, 2
-ADDI x12, x0, 4
-LW x16, 0(x0)
-BN.WSRRS w4, 1, w31
-BN.ADD w4, w4, w31
-CSRRS x2, 1984, x0
-ANDI x2, x2, 2
-BNE x2, x0, selcxSub_invsel
-BN.ADDC w3, w4, w4 << 16B, FG1
-LOOP x30, 7
-BN.LID x10, 0(x16++)
-BN.MOVR x11, x8
-BN.MOVR x8, x12
-BN.SUBB w4, w2, w3
-BN.WSRRS w3, 1, w31
-BN.SEL w3, w4, w2, FG1.L
-BN.MOVR x8++, x10
-JALR x0, x1, 0
+  addi      x8, x0, 5
+  addi      x10, x0, 3
+  addi      x11, x0, 2
+  addi      x12, x0, 4
+  lw        x16, 0(x0)
+  bn.wsrrs  w4, 1, w31
+  bn.add    w4, w4, w31
+  csrrs     x2, 1984, x0
+  andi      x2, x2, 2
+  bne       x2, x0, selcxSub_invsel
+  bn.addc   w3, w4, w4 << 16B, FG1
+  loop      x30, 7
+  bn.lid    x10, 0(x16++)
+  bn.movr   x11, x8
+  bn.movr   x8, x12
+  bn.subb   w4, w2, w3
+  bn.wsrrs  w3, 1, w31
+  bn.sel    w3, w4, w2, FG1.L
+  bn.movr   x8++, x10
+  jalr      x0, x1, 0
 
 selcxSub_invsel:
-BN.ADDC w3, w4, w4 << 16B, FG1
-LOOP x30, 7
-BN.LID x10, 0(x16++)
-BN.MOVR x11, x8
-BN.MOVR x8, x12
-BN.SUBB w4, w2, w3
-BN.WSRRS w3, 1, w31
-BN.SEL w3, w2, w4, FG1.L
-BN.MOVR x8++, x10
-JALR x0, x1, 0
+  bn.addc   w3, w4, w4 << 16B, FG1
+  loop      x30, 7
+  bn.lid    x10, 0(x16++)
+  bn.movr   x11, x8
+  bn.movr   x8, x12
+  bn.subb   w4, w2, w3
+  bn.wsrrs  w3, 1, w31
+  bn.sel    w3, w2, w4, FG1.L
+  bn.movr   x8++, x10
+  jalr      x0, x1, 0
 
 computeRR:
-BN.XOR w31, w31, w31
-ADDI x3, x0, 0
-BN.LID x3, 0(x0)
-LW x16, 0(x0)
-LW x17, 4(x0)
-LW x18, 8(x0)
-LW x19, 12(x0)
-LW x20, 16(x0)
-LW x21, 20(x0)
-LW x22, 24(x0)
-LW x23, 28(x0)
-BN.XOR w3, w3, w3
-SLLI x24, x22, 8
-ADDI x8, x0, 5
-ADDI x10, x0, 3
-BN.XOR w3, w3, w3
-LOOP x30, 1
-BN.MOVR x8++, x10
-BN.SUB w3, w31, w0, FG1
-JAL x1, selcxSub
-LOOP x24, 16
-ADDI x8, x0, 5
-BN.SUB w3, w3, w3, FG1
-LOOP x30, 3
-BN.MOVR x11, x8
-BN.ADDC w2, w2, w2, FG1
-BN.MOVR x8++, x11
-JAL x1, selcxSub
-ADDI x8, x0, 5
-LW x16, 0(x0)
-BN.SUB w3, w3, w3, FG1
-LOOP x30, 3
-BN.LID x10, 0(x16++)
-BN.MOVR x11, x8++
-BN.CMPB w3, w2, FG1
-JAL x1, selcxSub
-ADDI x0, x0, 0
-ADDI x8, x0, 5
-LOOP x30, 2
-BN.SID x8, 0(x18++)
-ADDI x8, x8, 1
-JALR x0, x1, 0
+  bn.xor    w31, w31, w31
+  addi      x3, x0, 0
+  bn.lid    x3, 0(x0)
+  lw        x16, 0(x0)
+  lw        x17, 4(x0)
+  lw        x18, 8(x0)
+  lw        x19, 12(x0)
+  lw        x20, 16(x0)
+  lw        x21, 20(x0)
+  lw        x22, 24(x0)
+  lw        x23, 28(x0)
+  bn.xor    w3, w3, w3
+  slli      x24, x22, 8
+  addi      x8, x0, 5
+  addi      x10, x0, 3
+  bn.xor    w3, w3, w3
+  loop      x30, 1
+  bn.movr   x8++, x10
+  bn.sub    w3, w31, w0, FG1
+  jal       x1, selcxSub
+  loop      x24, 16
+  addi      x8, x0, 5
+  bn.sub    w3, w3, w3, FG1
+  loop      x30, 3
+  bn.movr   x11, x8
+  bn.addc   w2, w2, w2, FG1
+  bn.movr   x8++, x11
+  jal       x1, selcxSub
+  addi      x8, x0, 5
+  lw        x16, 0(x0)
+  bn.sub    w3, w3, w3, FG1
+  loop      x30, 3
+  bn.lid    x10, 0(x16++)
+  bn.movr   x11, x8++
+  bn.cmpb   w3, w2, FG1
+  jal       x1, selcxSub
+  addi      x0, x0, 0
+  addi      x8, x0, 5
+  loop      x30, 2
+  bn.sid    x8, 0(x18++)
+  addi      x8, x8, 1
+  jalr      x0, x1, 0
 
 dmXd0:
-BN.MULQACC.Z w30.0, w25.0, 0
-BN.MULQACC w30.1, w25.0, 64
-BN.MULQACC.SO w27.L, w30.0, w25.1, 64
-BN.MULQACC w30.2, w25.0, 0
-BN.MULQACC w30.1, w25.1, 0
-BN.MULQACC w30.0, w25.2, 0
-BN.MULQACC w30.3, w25.0, 64
-BN.MULQACC w30.2, w25.1, 64
-BN.MULQACC w30.1, w25.2, 64
-BN.MULQACC.SO w27.U, w30.0, w25.3, 64
-BN.MULQACC w30.3, w25.1, 0
-BN.MULQACC w30.2, w25.2, 0
-BN.MULQACC w30.1, w25.3, 0
-BN.MULQACC w30.3, w25.2, 64
-BN.MULQACC.SO w26.L, w30.2, w25.3, 64
-BN.MULQACC.SO w26.U, w30.3, w25.3, 0
-JALR x0, x1, 0
+  bn.mulqacc.z          w30.0, w25.0,  0
+  bn.mulqacc            w30.1, w25.0, 64
+  bn.mulqacc.so  w27.L, w30.0, w25.1, 64
+  bn.mulqacc            w30.2, w25.0,  0
+  bn.mulqacc            w30.1, w25.1,  0
+  bn.mulqacc            w30.0, w25.2,  0
+  bn.mulqacc            w30.3, w25.0, 64
+  bn.mulqacc            w30.2, w25.1, 64
+  bn.mulqacc            w30.1, w25.2, 64
+  bn.mulqacc.so  w27.U, w30.0, w25.3, 64
+  bn.mulqacc            w30.3, w25.1,  0
+  bn.mulqacc            w30.2, w25.2,  0
+  bn.mulqacc            w30.1, w25.3,  0
+  bn.mulqacc            w30.3, w25.2, 64
+  bn.mulqacc.so  w26.L, w30.2, w25.3, 64
+  bn.mulqacc.so  w26.U, w30.3, w25.3,  0
+  jalr      x0, x1, 0
 
 dmXa:
-BN.MULQACC.Z w30.0, w2.0, 0
-BN.MULQACC w30.1, w2.0, 64
-BN.MULQACC.SO w27.L, w30.0, w2.1, 64
-BN.MULQACC w30.2, w2.0, 0
-BN.MULQACC w30.1, w2.1, 0
-BN.MULQACC w30.0, w2.2, 0
-BN.MULQACC w30.3, w2.0, 64
-BN.MULQACC w30.2, w2.1, 64
-BN.MULQACC w30.1, w2.2, 64
-BN.MULQACC.SO w27.U, w30.0, w2.3, 64
-BN.MULQACC w30.3, w2.1, 0
-BN.MULQACC w30.2, w2.2, 0
-BN.MULQACC w30.1, w2.3, 0
-BN.MULQACC w30.3, w2.2, 64
-BN.MULQACC.SO w26.L, w30.2, w2.3, 64
-BN.MULQACC.SO w26.U, w30.3, w2.3, 0
-JALR x0, x1, 0
+  bn.mulqacc.z          w30.0, w2.0,  0
+  bn.mulqacc            w30.1, w2.0, 64
+  bn.mulqacc.so  w27.L, w30.0, w2.1, 64
+  bn.mulqacc            w30.2, w2.0,  0
+  bn.mulqacc            w30.1, w2.1,  0
+  bn.mulqacc            w30.0, w2.2,  0
+  bn.mulqacc            w30.3, w2.0, 64
+  bn.mulqacc            w30.2, w2.1, 64
+  bn.mulqacc            w30.1, w2.2, 64
+  bn.mulqacc.so  w27.U, w30.0, w2.3, 64
+  bn.mulqacc            w30.3, w2.1,  0
+  bn.mulqacc            w30.2, w2.2,  0
+  bn.mulqacc            w30.1, w2.3,  0
+  bn.mulqacc            w30.3, w2.2, 64
+  bn.mulqacc.so  w26.L, w30.2, w2.3, 64
+  bn.mulqacc.so  w26.U, w30.3, w2.3,  0
+  jalr      x0, x1, 0
 
 mma_sub_cx:
-BN.WSRRS w28, 1, w31
-BN.ADD w28, w28, w31
-CSRRS x2, 1984, x0
-ANDI x2, x2, 2
-BNE x2, x0, mma_invsel
-BN.ADDC w28, w28, w28 << 16B, FG1
-LOOP x30, 7
-BN.LID x13, 0(x16++)
-BN.MOVR x12, x8
-BN.SUBB w29, w30, w24
-BN.WSRRS w24, 1, w31
-BN.MOVR x8, x13
-BN.SEL w24, w29, w30, FG1.L
-BN.MOVR x8++, x13
-JALR x0, x1, 0
+  bn.wsrrs  w28, 1, w31
+  bn.add    w28, w28, w31
+  csrrs     x2, 1984, x0
+  andi      x2, x2, 2
+  bne       x2, x0, mma_invsel
+  bn.addc   w28, w28, w28 << 16B, FG1
+  loop      x30, 7
+  bn.lid    x13, 0(x16++)
+  bn.movr   x12, x8
+  bn.subb   w29, w30, w24
+  bn.wsrrs  w24, 1, w31
+  bn.movr   x8, x13
+  bn.sel    w24, w29, w30, FG1.L
+  bn.movr   x8++, x13
+  jalr      x0, x1, 0
 
 mma_invsel:
-BN.ADDC w28, w28, w28 << 16B, FG1
-LOOP x30, 7
-BN.LID x13, 0(x16++)
-BN.MOVR x12, x8
-BN.SUBB w29, w30, w24
-BN.WSRRS w24, 1, w31
-BN.MOVR x8, x13
-BN.SEL w24, w30, w29, FG1.L
-BN.MOVR x8++, x13
-JALR x0, x1, 0
+  bn.addc   w28, w28, w28 << 16B, FG1
+  loop      x30, 7
+  bn.lid    x13, 0(x16++)
+  bn.movr   x12, x8
+  bn.subb   w29, w30, w24
+  bn.wsrrs  w24, 1, w31
+  bn.movr   x8, x13
+  bn.sel    w24, w30, w29, FG1.L
+  bn.movr   x8++, x13
+  jalr      x0, x1, 0
 
 mma:
-ADDI x12, x0, 30
-ADDI x13, x0, 24
-ADDI x8, x0, 4
-ADDI x10, x0, 4
-BN.LID x12, 0(x19++)
-JAL x1, dmXa
-BN.MOVR x13, x8++
-BN.ADD w30, w27, w24
-BN.ADDC w29, w26, w31
-BN.MOV w25, w3
-JAL x1, dmXd0
-BN.MOV w25, w27
-BN.MOV w28, w26
-BN.MOV w24, w30
-BN.LID x12, 0(x16++)
-JAL x1, dmXd0
-BN.ADD w27, w27, w24
-BN.ADDC w28, w26, w31
-LOOP x31, 14
-BN.LID x12, 0(x19++)
-JAL x1, dmXa
-BN.MOVR x13, x8++
-BN.ADD w27, w27, w24
-BN.ADDC w26, w26, w31
-BN.ADD w24, w27, w29
-BN.ADDC w29, w26, w31
-BN.LID x12, 0(x16++)
-JAL x1, dmXd0
-BN.ADD w27, w27, w24
-BN.ADDC w26, w26, w31
-BN.ADD w24, w27, w28, FG1
-BN.MOVR x10++, x13
-BN.ADDC w28, w26, w31, FG1
-
-BN.ADDC w24, w29, w28, FG1
-BN.MOVR x10++, x13
-LW x16, 0(x0)
-LW x19, 12(x0)
-ADDI x8, x0, 4
-ADDI x10, x0, 4
-ADDI x12, x0, 30
-ADDI x13, x0, 24
-JAL x1, mma_sub_cx
-ADDI x0, x0, 0
-JALR x0, x1, 0
+  addi      x12, x0, 30
+  addi      x13, x0, 24
+  addi      x8, x0, 4
+  addi      x10, x0, 4
+  bn.lid    x12, 0(x19++)
+  jal x1,   dmXa
+  bn.movr   x13, x8++
+  bn.add    w30, w27, w24
+  bn.addc   w29, w26, w31
+  bn.mov    w25, w3
+  jal       x1, dmXd0
+  bn.mov    w25, w27
+  bn.mov    w28, w26
+  bn.mov    w24, w30
+  bn.lid    x12, 0(x16++)
+  jal x1,   dmXd0
+  bn.add    w27, w27, w24
+  bn.addc   w28, w26, w31
+  loop      x31, 14
+  bn.lid    x12, 0(x19++)
+  jal       x1, dmXa
+  bn.movr   x13, x8++
+  bn.add    w27, w27, w24
+  bn.addc   w26, w26, w31
+  bn.add    w24, w27, w29
+  bn.addc   w29, w26, w31
+  bn.lid    x12, 0(x16++)
+  jal       x1, dmXd0
+  bn.add    w27, w27, w24
+  bn.addc   w26, w26, w31
+  bn.add    w24, w27, w28, FG1
+  bn.movr   x10++, x13
+  bn.addc   w28, w26, w31, FG1
+  bn.addc   w24, w29, w28, FG1
+  bn.movr   x10++, x13
+  lw        x16, 0(x0)
+  lw        x19, 12(x0)
+  addi      x8, x0, 4
+  addi      x10, x0, 4
+  addi      x12, x0, 30
+  addi      x13, x0, 24
+  jal       x1, mma_sub_cx
+  addi      x0, x0, 0
+  jalr      x0, x1, 0
 
 setupPtrs:
-LW x16, 0(x0)
-LW x17, 4(x0)
-LW x18, 8(x0)
-LW x19, 12(x0)
-LW x20, 16(x0)
-LW x21, 20(x0)
-LW x22, 24(x0)
-LW x23, 28(x0)
-LW x24, 0(x0)
-LW x25, 4(x0)
-LW x26, 8(x0)
-LW x27, 12(x0)
-LW x28, 16(x0)
-LW x29, 20(x0)
-LW x30, 24(x0)
-LW x31, 28(x0)
-BN.MOV w1, w31
-ADDI x8, x0, 4
-ADDI x9, x0, 3
-ADDI x10, x0, 4
-ADDI x11, x0, 2
-JALR x0, x1, 0
+  lw        x16, 0(x0)
+  lw        x17, 4(x0)
+  lw        x18, 8(x0)
+  lw        x19, 12(x0)
+  lw        x20, 16(x0)
+  lw        x21, 20(x0)
+  lw        x22, 24(x0)
+  lw        x23, 28(x0)
+  lw        x24, 0(x0)
+  lw        x25, 4(x0)
+  lw        x26, 8(x0)
+  lw        x27, 12(x0)
+  lw        x28, 16(x0)
+  lw        x29, 20(x0)
+  lw        x30, 24(x0)
+  lw        x31, 28(x0)
+  bn.mov    w1, w31
+  addi      x8, x0, 4
+  addi      x9, x0, 3
+  addi      x10, x0, 4
+  addi      x11, x0, 2
+  jalr      x0, x1, 0
 
 mulx:
-ADDI x3, x0, 0
-BN.LID x3, 0(x0)
-JAL x1, setupPtrs
-BN.LID x9, 0(x17)
-BN.MOV w2, w31
-LOOP x30, 1
-BN.MOVR x10++, x11
-ADDI x10, x0, 4
-LOOP x30, 8
-BN.LID x11, 0(x20++)
-ADD x4, x16, x0
-ADD x5, x19, x0
-ADD x6, x20, x0
-JAL x1, mma
-ADD x16, x4, x0
-ADD x19, x5, x0
-ADD x20, x6, x0
-ADDI x8, x0, 4
-LOOP x30, 2
-BN.SID x8, 0(x21++)
-ADDI x8, x8, 1
-ADDI x8, x0, 4
-JALR x0, x1, 0
+  addi      x3, x0, 0
+  bn.lid    x3, 0(x0)
+  jal       x1, setupPtrs
+  bn.lid    x9, 0(x17)
+  bn.mov    w2, w31
+  loop      x30, 1
+  bn.movr   x10++, x11
+  addi      x10, x0, 4
+  loop      x30, 8
+  bn.lid    x11, 0(x20++)
+  add       x4, x16, x0
+  add       x5, x19, x0
+  add       x6, x20, x0
+  jal       x1, mma
+  add       x16, x4, x0
+  add       x19, x5, x0
+  add       x20, x6, x0
+  addi      x8, x0, 4
+  loop      x30, 2
+  bn.sid    x8, 0(x21++)
+  addi      x8, x8, 1
+  addi      x8, x0, 4
+  jalr      x0, x1, 0
 
 mm1_sub_cx:
-BN.WSRRS w3, 1, w31
-BN.ADD w3, w3, w31
-CSRRS x2, 1984, x0
-ANDI x2, x2, 2
-BNE x2, x0, mm1_invsel
-BN.ADDC w3, w3, w3 << 16B, FG1
-LOOP x30, 6
-BN.LID x9, 0(x16++)
-BN.MOVR x11, x8++
-BN.SUBB w3, w2, w3
-BN.SEL w2, w3, w2, FG1.L
-BN.SID x11, 0(x21++)
-ADDI x0, x0, 0
-JALR x0, x1, 0
-ADDI x0, x0, 0
+  bn.wsrrs  w3, 1, w31
+  bn.add    w3, w3, w31
+  csrrs     x2, 1984, x0
+  andi      x2, x2, 2
+  bne       x2, x0, mm1_invsel
+  bn.addc   w3, w3, w3 << 16B, FG1
+  loop      x30, 6
+  bn.lid    x9, 0(x16++)
+  bn.movr   x11, x8++
+  bn.subb   w3, w2, w3
+  bn.sel    w2, w3, w2, FG1.L
+  bn.sid    x11, 0(x21++)
+  addi      x0, x0, 0
+  jalr      x0, x1, 0
+  addi      x0, x0, 0
 
 mm1_invsel:
-BN.ADDC w3, w3, w3 << 16B, FG1
-LOOP x30, 6
-BN.LID x9, 0(x16++)
-BN.MOVR x11, x8++
-BN.SUBB w3, w2, w3
-BN.SEL w2, w2, w3, FG1.L
-BN.SID x11, 0(x21++)
-ADDI x0, x0, 0
-JALR x0, x1, 0
+  bn.addc   w3, w3, w3 << 16B, FG1
+  loop      x30, 6
+  bn.lid    x9, 0(x16++)
+  bn.movr   x11, x8++
+  bn.subb   w3, w2, w3
+  bn.sel    w2, w2, w3, FG1.L
+  bn.sid    x11, 0(x21++)
+  addi      x0, x0, 0
+  jalr      x0, x1, 0
 
 mul1_exp:
-BN.LID x9, 0(x17)
-BN.MOV w2, w31
-LOOP x30, 1
-BN.MOVR x10++, x11
-BN.XOR w2, w2, w2
-BN.ADDI w2, w2, 1
-ADDI x6, x16, 0
-ADDI x7, x19, 0
-LOOP x30, 4
-ADDI x16, x6, 0
-ADDI x19, x7, 0
-JAL x1, mma
-BN.MOV w2, w31
-ADDI x16, x6, 0
-ADDI x19, x7, 0
-BN.SUB w2, w2, w2, FG1
-LOOP x30, 3
-BN.LID x9, 0(x16++)
-BN.MOVR x11, x8++
-BN.CMPB w3, w2, FG1
-ADDI x8, x0, 4
-ADDI x10, x0, 4
-ADDI x16, x6, 0
-ADDI x19, x7, 0
-JAL x1, mm1_sub_cx
-ADDI x16, x6, 0
-ADDI x19, x7, 0
-JALR x0, x1, 0
+  bn.lid    x9, 0(x17)
+  bn.mov    w2, w31
+  loop      x30, 1
+  bn.movr   x10++, x11
+  bn.xor    w2, w2, w2
+  bn.addi   w2, w2, 1
+  addi      x6, x16, 0
+  addi      x7, x19, 0
+  loop      x30, 4
+  addi      x16, x6, 0
+  addi      x19, x7, 0
+  jal       x1, mma
+  bn.mov    w2, w31
+  addi      x16, x6, 0
+  addi      x19, x7, 0
+  bn.sub    w2, w2, w2, FG1
+  loop      x30, 3
+  bn.lid    x9, 0(x16++)
+  bn.movr   x11, x8++
+  bn.cmpb   w3, w2, FG1
+  addi      x8, x0, 4
+  addi      x10, x0, 4
+  addi      x16, x6, 0
+  addi      x19, x7, 0
+  jal       x1, mm1_sub_cx
+  addi      x16, x6, 0
+  addi      x19, x7, 0
+  jalr      x0, x1, 0
 
 mul1:
-ADDI x3, x0, 0
-BN.LID x3, 0(x0)
-JAL x1, setupPtrs
-JAL x1, mul1_exp
-ECALL
+  addi      x3, x0, 0
+  bn.lid    x3, 0(x0)
+  jal       x1, setupPtrs
+  jal       x1, mul1_exp
+  ecall
 
 sqrx_exp:
-LW x16, 32(x0)
-LW x17, 36(x0)
-LW x18, 40(x0)
-LW x19, 44(x0)
-LW x20, 48(x0)
-LW x21, 52(x0)
-LW x22, 56(x0)
-LW x23, 60(x0)
-BN.LID x9, 0(x17)
-BN.MOV w2, w31
-LOOP x30, 1
-BN.MOVR x10++, x11
-LW x10, 8(x0)
-LOOP x30, 8
-BN.LID x11, 0(x20++)
-ADDI x5, x20, 0
-ADDI x6, x16, 0
-ADDI x7, x19, 0
-JAL x1, mma
-ADDI x20, x5, 0
-ADDI x16, x6, 0
-ADDI x19, x7, 0
-ADDI x10, x0, 4
-ADDI x8, x0, 4
-LOOP x30, 2
-BN.SID x8, 0(x21++)
-ADDI x8, x8, 1
-ADDI x8, x0, 4
-ADDI x10, x0, 4
-LW x12, 16(x0)
-LW x13, 20(x0)
-JALR x0, x1, 0
+  lw        x16, 32(x0)
+  lw        x17, 36(x0)
+  lw        x18, 40(x0)
+  lw        x19, 44(x0)
+  lw        x20, 48(x0)
+  lw        x21, 52(x0)
+  lw        x22, 56(x0)
+  lw        x23, 60(x0)
+  bn.lid    x9, 0(x17)
+  bn.mov    w2, w31
+  loop      x30, 1
+  bn.movr   x10++, x11
+  lw        x10, 8(x0)
+  loop      x30, 8
+  bn.lid    x11, 0(x20++)
+  addi      x5, x20, 0
+  addi      x6, x16, 0
+  addi      x7, x19, 0
+  jal       x1, mma
+  addi      x20, x5, 0
+  addi      x16, x6, 0
+  addi      x19, x7, 0
+  addi      x10, x0, 4
+  addi      x8, x0, 4
+  loop      x30, 2
+  bn.sid    x8, 0(x21++)
+  addi      x8, x8, 1
+  addi      x8, x0, 4
+  addi      x10, x0, 4
+  lw        x12, 16(x0)
+  lw        x13, 20(x0)
+  jalr      x0, x1, 0
 
 mulx_exp:
-LW x16, 64(x0)
-LW x17, 68(x0)
-LW x18, 72(x0)
-LW x19, 76(x0)
-LW x20, 80(x0)
-LW x21, 84(x0)
-LW x22, 88(x0)
-LW x23, 92(x0)
-BN.LID x9, 0(x17)
-BN.MOV w2, w31
-LOOP x30, 1
-BN.MOVR x10++, x11
-ADDI x8, x0, 4
-ADDI x10, x0, 4
-LW x12, 16(x0)
-LW x13, 20(x0)
-LOOP x30, 8
-BN.LID x11, 0(x20++)
-ADDI x5, x20, 0
-ADDI x6, x16, 0
-ADDI x7, x19, 0
-JAL x1, mma
-ADDI x20, x5, 0
-ADDI x16, x6, 0
-ADDI x19, x7, 0
-ADDI x8, x0, 4
-ADDI x10, x0, 4
-LW x12, 16(x0)
-LW x13, 20(x0)
-JALR x0, x1, 0
+  lw        x16, 64(x0)
+  lw        x17, 68(x0)
+  lw        x18, 72(x0)
+  lw        x19, 76(x0)
+  lw        x20, 80(x0)
+  lw        x21, 84(x0)
+  lw        x22, 88(x0)
+  lw        x23, 92(x0)
+  bn.lid    x9, 0(x17)
+  bn.mov    w2, w31
+  loop      x30, 1
+  bn.movr   x10++, x11
+  addi      x8, x0, 4
+  addi      x10, x0, 4
+  lw        x12, 16(x0)
+  lw        x13, 20(x0)
+  loop      x30, 8
+  bn.lid    x11, 0(x20++)
+  addi      x5, x20, 0
+  addi      x6, x16, 0
+  addi      x7, x19, 0
+  jal       x1, mma
+  addi      x20, x5, 0
+  addi      x16, x6, 0
+  addi      x19, x7, 0
+  addi      x8, x0, 4
+  addi      x10, x0, 4
+  lw        x12, 16(x0)
+  lw        x13, 20(x0)
+  jalr      x0, x1, 0
 
 selOutOrC:
-BN.WSRRS w3, 1, w31
-BN.OR w3, w3, w3
-CSRRS x2, 1984, x0
-ANDI x2, x2, 2
-BNE x2, x0, selOutOrC_invsel
-BN.ADDC w3, w3, w3 << 16B
-LOOP x30, 10
-BN.WSRRS w3, 1, w31
-BN.WSRRS w2, 1, w31
-BN.LID x9, 0(x21)
-BN.SID x11, 0(x21)
-BN.MOVR x11, x8++
-BN.WSRRS w0, 1, w31
-BN.MOV w0, w2
-BN.WSRRS w2, 1, w31
-BN.SEL w2, w0, w3, L
-BN.SID x11, 0(x21++)
-JALR x0, x1, 0
-ADDI x0, x0, 0
+  bn.wsrrs  w3, 1, w31
+  bn.or     w3, w3, w3
+  csrrs     x2, 1984, x0
+  andi      x2, x2, 2
+  bne       x2, x0, selOutOrC_invsel
+  bn.addc   w3, w3, w3 << 16B
+  loop      x30, 10
+  bn.wsrrs  w3, 1, w31
+  bn.wsrrs  w2, 1, w31
+  bn.lid    x9, 0(x21)
+  bn.sid    x11, 0(x21)
+  bn.movr   x11, x8++
+  bn.wsrrs  w0, 1, w31
+  bn.mov    w0, w2
+  bn.wsrrs  w2, 1, w31
+  bn.sel    w2, w0, w3, L
+  bn.sid    x11, 0(x21++)
+  jalr      x0, x1, 0
+  addi      x0, x0, 0
 
 selOutOrC_invsel:
-BN.ADDC w3, w3, w3 << 16B
-LOOP x30, 10
-BN.WSRRS w3, 1, w31
-BN.WSRRS w2, 1, w31
-BN.LID x9, 0(x21)
-BN.SID x11, 0(x21)
-BN.MOVR x11, x8++
-BN.WSRRS w0, 1, w31
-BN.MOV w0, w2
-BN.WSRRS w2, 1, w31
-BN.SEL w2, w3, w0, L
-BN.SID x11, 0(x21++)
-JALR x0, x1, 0
+  bn.addc   w3, w3, w3 << 16B
+  loop      x30, 10
+  bn.wsrrs  w3, 1, w31
+  bn.wsrrs  w2, 1, w31
+  bn.lid    x9, 0(x21)
+  bn.sid    x11, 0(x21)
+  bn.movr   x11, x8++
+  bn.wsrrs  w0, 1, w31
+  bn.mov    w0, w2
+  bn.wsrrs  w2, 1, w31
+  bn.sel    w2, w3, w0, L
+  bn.sid    x11, 0(x21++)
+  jalr      x0, x1, 0
 
 modexp:
-JAL x1, mulx
-LW x16, 96(x0)
-LW x17, 100(x0)
-LW x18, 104(x0)
-LW x19, 108(x0)
-LW x20, 112(x0)
-LW x21, 116(x0)
-LW x22, 120(x0)
-LW x23, 124(x0)
-BN.SUB w2, w2, w2
-LOOP x30, 4
-ADDI x0, x0, 0
-BN.LID x11, 0(x16++)
-BN.SUBB w2, w31, w2
-BN.SID x11, 0(x21++)
-ADDI x0, x0, 0
-SLLI x24, x22, 8
-LOOP x24, 19
-JAL x1, sqrx_exp
-JAL x1, mulx_exp
-LW x16, 96(x0)
-LW x17, 100(x0)
-LW x18, 104(x0)
-LW x19, 108(x0)
-LW x20, 112(x0)
-LW x21, 116(x0)
-LW x22, 120(x0)
-LW x23, 124(x0)
-BN.WSRRS w2, 1, w31
-BN.ADD w2, w2, w2
-LOOP x30, 4
-BN.WSRRS w2, 1, w31
-BN.LID x11, 0(x20)
-BN.ADDC w2, w2, w2
-BN.SID x11, 0(x20++)
-JAL x1, selOutOrC
-ADDI x0, x0, 0
-ADDI x3, x0, 0
-BN.LID x3, 96(x0)
-LW x16, 96(x0)
-LW x17, 100(x0)
-LW x18, 104(x0)
-LW x19, 108(x0)
-LW x20, 112(x0)
-LW x21, 116(x0)
-LW x22, 120(x0)
-LW x23, 124(x0)
-JAL x1, mul1_exp
-ECALL
+  jal       x1, mulx
+  lw        x16, 96(x0)
+  lw        x17, 100(x0)
+  lw        x18, 104(x0)
+  lw        x19, 108(x0)
+  lw        x20, 112(x0)
+  lw        x21, 116(x0)
+  lw        x22, 120(x0)
+  lw        x23, 124(x0)
+  bn.sub    w2, w2, w2
+  loop      x30, 4
+  addi      x0, x0, 0
+  bn.lid    x11, 0(x16++)
+  bn.subb   w2, w31, w2
+  bn.sid    x11, 0(x21++)
+  addi      x0, x0, 0
+  slli      x24, x22, 8
+  loop      x24, 19
+  jal       x1, sqrx_exp
+  jal       x1, mulx_exp
+  lw        x16, 96(x0)
+  lw        x17, 100(x0)
+  lw        x18, 104(x0)
+  lw        x19, 108(x0)
+  lw        x20, 112(x0)
+  lw        x21, 116(x0)
+  lw        x22, 120(x0)
+  lw        x23, 124(x0)
+  bn.wsrrs  w2, 1, w31
+  bn.add    w2, w2, w2
+  loop      x30, 4
+  bn.wsrrs  w2, 1, w31
+  bn.lid    x11, 0(x20)
+  bn.addc   w2, w2, w2
+  bn.sid    x11, 0(x20++)
+  jal       x1, selOutOrC
+  addi      x0, x0, 0
+  addi      x3, x0, 0
+  bn.lid    x3, 96(x0)
+  lw        x16, 96(x0)
+  lw        x17, 100(x0)
+  lw        x18, 104(x0)
+  lw        x19, 108(x0)
+  lw        x20, 112(x0)
+  lw        x21, 116(x0)
+  lw        x22, 120(x0)
+  lw        x23, 124(x0)
+  jal       x1, mul1_exp
+  ecall
 
 modload:
-BN.XOR w31, w31, w31
-ADDI x3, x0, 0
-BN.LID x3, 0(x0)
-LW x16, 0(x0)
-LW x17, 4(x0)
-LW x18, 8(x0)
-LW x19, 12(x0)
-LW x20, 16(x0)
-LW x21, 20(x0)
-LW x22, 24(x0)
-LW x23, 28(x0)
-LW x24, 0(x0)
-LW x25, 4(x0)
-LW x26, 8(x0)
-LW x27, 12(x0)
-LW x28, 16(x0)
-LW x29, 20(x0)
-LW x30, 24(x0)
-LW x31, 28(x0)
-ADDI x8, x0, 28
-ADDI x9, x0, 29
-LW x10, 8(x0)
-LW x11, 12(x0)
-LW x12, 16(x0)
-LW x13, 20(x0)
-LW x14, 24(x0)
-LW x15, 28(x0)
-BN.LID x8, 0(x16)
-JAL x1, d0inv
-BN.SID x9, 0(x17)
-JAL x1, computeRR
-ECALL
+  bn.xor   w31, w31, w31
+  addi     x3, x0, 0
+  bn.lid   x3, 0(x0)
+  lw       x16, 0(x0)
+  lw       x17, 4(x0)
+  lw       x18, 8(x0)
+  lw       x19, 12(x0)
+  lw       x20, 16(x0)
+  lw       x21, 20(x0)
+  lw       x22, 24(x0)
+  lw       x23, 28(x0)
+  lw       x24, 0(x0)
+  lw       x25, 4(x0)
+  lw       x26, 8(x0)
+  lw       x27, 12(x0)
+  lw       x28, 16(x0)
+  lw       x29, 20(x0)
+  lw       x30, 24(x0)
+  lw       x31, 28(x0)
+  addi     x8, x0, 28
+  addi     x9, x0, 29
+  lw       x10, 8(x0)
+  lw       x11, 12(x0)
+  lw       x12, 16(x0)
+  lw       x13, 20(x0)
+  lw       x14, 24(x0)
+  lw       x15, 28(x0)
+  bn.lid   x8, 0(x16)
+  jal      x1, d0inv
+  bn.sid   x9, 0(x17)
+  jal      x1, computeRR
+  ecall


### PR DESCRIPTION
some style improvements to the `modexp` code snippet
- change mnemonics to lower case, as agreed
- some indentation
- use pseudo instructions (the currently available ones supported by the OTBN ISS)
- remove some unnecessary code

there is more documentation and comments to come to this file soon, but let's bring it in clean style first