### PR TITLE
[verilator simutil] Add "relative scope" support to sv_scoped.h

### DIFF
--- a/hw/dv/verilator/cpp/sv_scoped.cc
+++ b/hw/dv/verilator/cpp/sv_scoped.cc
@@ -75,11 +75,11 @@ static svScope SetRelScope(const std::string &name) {
   // If first_not_dot points inside name (so name looked like "..foo.bar"
   // rather than "..."), subtract one to point at the last dot of the initial
   // segment (we know there is one because name[0] == '.') and then append
-  // everything from there to scope_name. For example, if scope_name
+  // everything to scope_name starting from there. For example, if scope_name
   // was "TOP.foo.bar.baz" and name was "..qux", we will have just amended
   // scope_name to be "TOP.foo.bar". Now we want to add ".qux".
   if (first_not_dot < name.size()) {
-    scope_name.append(name, first_not_dot - 1);
+    scope_name.append(name, first_not_dot - 1, std::string::npos);
   }
 
   return SetAbsScope(scope_name);

--- a/hw/dv/verilator/cpp/sv_scoped.cc
+++ b/hw/dv/verilator/cpp/sv_scoped.cc
@@ -1,0 +1,95 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sv_scoped.h"
+
+#include <cassert>
+#include <sstream>
+
+// Set scope by name, returning the old scope. If the name doesn't describe a
+// valid scope, throw an SVScoped::Error.
+static svScope SetAbsScope(const std::string &name) {
+  svScope new_scope = svGetScopeFromName(name.c_str());
+  if (!new_scope)
+    throw SVScoped::Error(name);
+  return svSetScope(new_scope);
+}
+
+// Resolve name to a scope, using the rules described in the comment above the
+// class in sv_scoped.h, and then set it. Returns the old scope.
+static svScope SetRelScope(const std::string &name) {
+  // Absolute (or empty) names resolve to themselves
+  if (name[0] != '.') {
+    return SetAbsScope(name);
+  }
+
+  svScope prev_scope = svGetScope();
+
+  // Special case: If name is ".", it means to use the current scope. Rather
+  // than changing scope, we can just return where we are going to stay.
+  if (name == ".")
+    return prev_scope;
+
+  // For anything else, count how many dots appear after the first one (so
+  // ..foo gives an up_count of 1; ...bar gives an up_count of 2).
+  size_t first_not_dot = name.find_first_not_of('.', 1);
+  if (first_not_dot == std::string::npos) {
+    // name looks like "....": that's fine, it just means to go up some number
+    // of steps from the current position and not down again. Amend
+    // first_not_dot to point at the '\0'.
+    first_not_dot = name.size();
+  }
+  size_t up_count = first_not_dot - 1;
+
+  // Get the name of the current scope, so that we can perform surgery.
+  std::string scope_name = svGetNameFromScope(prev_scope);
+
+  // scope_name will look something like "TOP.foo.bar". Search up_count
+  // dots from the end, setting last_dot to point at the last dot that should
+  // appear in the resolved name.
+  //
+  // If up_count is too large, behave like "cd /; cd .." and stop at the
+  // left-most dot.
+  size_t last_dot = scope_name.size();
+  for (size_t i = 0; i < up_count; ++i) {
+    // This shouldn't ever trigger (because it would mean scope_name was
+    // either empty or started with a "."), but allowing it makes the code a
+    // bit more uniform.
+    if (last_dot == 0)
+      break;
+
+    size_t dot = scope_name.rfind('.', last_dot - 1);
+    if (dot == std::string::npos)
+      break;
+
+    last_dot = dot;
+  }
+
+  // Delete everything from last_dot onwards. If we are actually pointing at a
+  // dot, this will do something like "TOP.foo.bar" -> "TOP.foo". If up_count
+  // was zero or there were no dots, last_dot will equal the size of the string
+  // (which means, conveniently, that erase is a no-op).
+  scope_name.erase(last_dot);
+
+  // If first_not_dot points inside name (so name looked like "..foo.bar"
+  // rather than "..."), subtract one to point at the last dot of the initial
+  // segment (we know there is one because name[0] == '.') and then append
+  // everything from there to scope_name. For example, if scope_name
+  // was "TOP.foo.bar.baz" and name was "..qux", we will have just amended
+  // scope_name to be "TOP.foo.bar". Now we want to add ".qux".
+  if (first_not_dot < name.size()) {
+    scope_name.append(name, first_not_dot - 1);
+  }
+
+  return SetAbsScope(scope_name);
+}
+
+SVScoped::SVScoped(const std::string &name) : prev_scope_(SetRelScope(name)) {}
+
+SVScoped::Error::Error(const std::string &scope_name)
+    : scope_name_(scope_name) {
+  std::ostringstream oss;
+  oss << "No such SystemVerilog scope: `" << scope_name << "'.";
+  msg_ = oss.str();
+}

--- a/hw/dv/verilator/cpp/sv_scoped.h
+++ b/hw/dv/verilator/cpp/sv_scoped.h
@@ -5,26 +5,47 @@
 #ifndef OPENTITAN_HW_DV_VERILATOR_CPP_SV_SCOPED_H_
 #define OPENTITAN_HW_DV_VERILATOR_CPP_SV_SCOPED_H_
 
+#include <stdexcept>
+#include <string>
 #include <vltstd/svdpi.h>
 
 /**
- * Guard class for SV Scope
+ * Wrapper and guard class for SV Scope
  *
- * This guard ensures that all functions in the context where it is instantiated
- * are executed in an SVScope. It will restore the previous scope at destruction
- * and thereby make sure that the previous scope will be restored for all paths
- * that exit the scope.
+ * Call the constructor with a string for the scope that should be used. If
+ * this string starts with '.', it is taken to be a name relative to the
+ * current scope. Multiple periods at the start of the string move up in the
+ * tree (like Python imports).
+ *
+ * If the resolved scope cannot be found, the constructor leaves the current
+ * scope unchanged and throws an SVScoped::Error detailing the non-existent
+ * scope it tried to use.
+ *
+ * For example, if the current scope has name "TOP.foo.bar", then the string
+ * ".baz" resolves to the scope with name "TOP.foo.bar.baz". The string "..baz"
+ * resolves to the scope with name "TOP.foo.baz". The string "qux" resolves to
+ * the scope with name "qux".
+ *
+ * This guard restores the previous scope at destruction.
  */
 class SVScoped {
- private:
-  svScope prev_scope_ = 0;
-
  public:
-  SVScoped(const std::string &scopeName) : SVScoped(scopeName.c_str()) {}
-  SVScoped(const char *scopeName) : SVScoped(svGetScopeFromName(scopeName)) {}
-  SVScoped(svScope scope) { prev_scope_ = svSetScope(scope); }
-
+  SVScoped(const std::string &name);
   ~SVScoped() { svSetScope(prev_scope_); }
+
+  class Error : public std::exception {
+   public:
+    Error(const std::string &scope_name);
+    const char *what() const noexcept override { return msg_.c_str(); }
+
+    std::string scope_name_;
+
+   private:
+    std::string msg_;
+  };
+
+ private:
+  svScope prev_scope_;
 };
 
 #endif  // OPENTITAN_HW_DV_VERILATOR_CPP_SV_SCOPED_H_

--- a/hw/dv/verilator/memutil_verilator.core
+++ b/hw/dv/verilator/memutil_verilator.core
@@ -12,6 +12,7 @@ filesets:
     files:
       - cpp/verilator_memutil.cc
       - cpp/verilator_memutil.h: { is_include_file: true }
+      - cpp/sv_scoped.cc
       - cpp/sv_scoped.h: { is_include_file: true }
     file_type: cppSource
 

--- a/hw/ip/otbn/dv/model/otbn_model.cc
+++ b/hw/ip/otbn/dv/model/otbn_model.cc
@@ -162,7 +162,7 @@ extern "C" int otbn_model_start(ISSWrapper *model, const char *imem_scope,
   try {
     dump_memory_to_file(dfname, dmem_scope, dmem_words, 32);
     dump_memory_to_file(ifname, imem_scope, imem_words, 4);
-  } catch (const std::runtime_error &err) {
+  } catch (const std::exception &err) {
     std::cerr << "Error when dumping memory contents: " << err.what() << "\n";
     return -1;
   }
@@ -200,7 +200,7 @@ extern "C" int otbn_model_load_dmem(ISSWrapper *model, const char *dmem_scope,
   try {
     model->dump_d(dfname);
     load_memory_from_file(dfname, dmem_scope, dmem_words, 32);
-  } catch (const std::runtime_error &err) {
+  } catch (const std::exception &err) {
     std::cerr << "Error when loading dmem from ISS: " << err.what() << "\n";
     return -1;
   }

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -173,8 +173,8 @@ module otbn_top_sim (
   // This runs in parallel with the real core above. Eventually, we'll have strong consistency
   // checks between the two. For now, we just check that they have the same "done" signals.
 
-  localparam string ImemScope = "TOP.otbn_top_sim.u_imem.u_mem.gen_generic.u_impl_generic";
-  localparam string DmemScope = "TOP.otbn_top_sim.u_dmem.u_mem.gen_generic.u_impl_generic";
+  localparam string ImemScope = "..u_imem.u_mem.gen_generic.u_impl_generic";
+  localparam string DmemScope = "..u_dmem.u_mem.gen_generic.u_impl_generic";
 
   logic otbn_model_done;
 

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -424,8 +424,8 @@ module otbn
   assign busy_d = (busy_q | start) & ~done;
 
   if (OTBNModel) begin : gen_impl_model
-    localparam ImemScope = "TOP.top_earlgrey_verilator.top_earlgrey.u_otbn.u_imem.u_mem.gen_generic.u_impl_generic";
-    localparam DmemScope = "TOP.top_earlgrey_verilator.top_earlgrey.u_otbn.u_dmem.u_mem.gen_generic.u_impl_generic";
+    localparam ImemScope = "..u_imem.u_mem.gen_generic.u_impl_generic";
+    localparam DmemScope = "..u_dmem.u_mem.gen_generic.u_impl_generic";
 
     otbn_core_model #(
       .DmemSizeByte(DmemSizeByte),


### PR DESCRIPTION
The point of this is to avoid having to write down long dotted instantiation paths for things like the OTBN model. This PR has two patches. The first adds the support; the second uses it in OTBN. Here's the commit message for the first patch:

```
The SystemVerilog spec (1800-2017) doesn't seem to give any way to say
"start at the current scope and then follow the path ../../foo/bar".
Of course, it's not particularly difficult to implement once you've
decided on the semantics.

Here, we copy Python's import naming (they have the same dotted names,
so their solution should work quite well).

Suppose that the current scope is TOP.foo.bar.baz. Then SVScoped
should now resolve names as follows:

  TOP.qux -> TOP.qux
  qux     -> qux
  .       -> TOP.foo.bar.baz
  .a.b.c  -> TOP.foo.bar.baz.a.b.c
  .qux    -> TOP.foo.bar.baz.qux
  ..qux   -> TOP.foo.bar.qux
  ..      -> TOP.foo.bar
  ...     -> TOP.foo
  ....    -> TOP
  ......  -> TOP
```