### PR TITLE
[otbn] Add a simple testing framework for the ISS

### DIFF
--- a/hw/ip/otbn/README.md
+++ b/hw/ip/otbn/README.md
@@ -133,8 +133,14 @@ cycle count and dumps DMEM contents. This is used to implement the
 model inside of simulation, but is probably not very convenient for
 command-line use otherwise.
 
+## Test the ISS
 
-### Update the RISC-V part of the ISS
+The ISS has a simple test suite, which runs various instructions and
+makes sure they behave as expected. You can find the tests in
+`dv/otbnsim/test` and can run them with `make -C dv/otbnsim test`.
+
+
+## Update the RISC-V part of the ISS
 
 The OTBN model is an instruction set simulator written in Python. It lives
 in the `opentitan` repository in the `util/otbnsim` directory, but builds on top

--- a/hw/ip/otbn/dv/otbnsim/Makefile
+++ b/hw/ip/otbn/dv/otbnsim/Makefile
@@ -25,3 +25,7 @@ $(lint-stamps): $(build-dir)/%.stamp: % $(py-libs) | $(build-dir)
 
 .PHONY: lint
 lint: $(lint-stamps)
+
+.PHONY: test
+test:
+	pytest test

--- a/hw/ip/otbn/dv/otbnsim/sim/elf.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/elf.py
@@ -8,11 +8,10 @@ from typing import List, Tuple
 
 from elftools.elf.elffile import ELFFile  # type: ignore
 
-from riscvmodel.sim import Simulator  # type: ignore
-
 from shared.mem_layout import get_memory_layout
 
 from .decode import decode_bytes
+from .sim import OTBNSim
 
 _SegList = List[Tuple[int, bytes]]
 
@@ -117,7 +116,7 @@ def _get_elf_segments(path: str,
     return (imem_segments, dmem_segments)
 
 
-def load_elf(sim: Simulator, path: str) -> None:
+def load_elf(sim: OTBNSim, path: str) -> None:
     '''Load contents of ELF file at path'''
     mems = get_memory_layout()
     imem_desc = mems['IMEM']

--- a/hw/ip/otbn/dv/otbnsim/sim/reg.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/reg.py
@@ -34,15 +34,15 @@ class Reg:
         self._uval = uval
         self._next_uval = None  # type: Optional[int]
 
-    def read_unsigned(self) -> int:
-        if self._parent is not None:
+    def read_unsigned(self, backdoor: bool = False) -> int:
+        if not backdoor and self._parent is not None:
             self._parent.mark_read(self._idx)
         return self._uval
 
-    def write_unsigned(self, uval: int) -> None:
+    def write_unsigned(self, uval: int, backdoor: bool = False) -> None:
         assert 0 <= uval < (1 << self._width)
         self._next_uval = uval
-        if self._parent is not None:
+        if not backdoor and self._parent is not None:
             self._parent.mark_written(self._idx)
 
     def read_next(self) -> Optional[int]:
@@ -117,3 +117,7 @@ class RegFile:
             assert 0 <= idx < len(self._registers)
             self._registers[idx].commit()
         self._pending_writes.clear()
+
+    def peek_unsigned_values(self) -> List[int]:
+        '''Get a list of the (unsigned) values of the registers'''
+        return [reg.read_unsigned(backdoor=True) for reg in self._registers]

--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -19,14 +19,12 @@ class OTBNSim:
     def load_data(self, data: bytes) -> None:
         self.state.dmem.load_le_words(data)
 
-    def run(self, start_addr: int, verbose: bool) -> int:
-        '''Start a simulation at start_addr and run until ECALL.
+    def run(self, verbose: bool) -> int:
+        '''Run until ECALL.
 
-        Return the number of instructions executed.
+        Return the number of cycles taken.
 
         '''
-        self.state.pc = start_addr
-        self.state.start()
         insn_count = 0
         while self.state.running:
             self.step(verbose)

--- a/hw/ip/otbn/dv/otbnsim/standalone.py
+++ b/hw/ip/otbn/dv/otbnsim/standalone.py
@@ -21,7 +21,9 @@ def main() -> int:
     sim = OTBNSim()
     load_elf(sim, args.elf)
 
-    sim.run(start_addr=0, verbose=args.verbose)
+    sim.state.pc = 0
+    sim.state.start()
+    sim.run(verbose=args.verbose)
 
     if args.dmem_dump is not None:
         try:

--- a/hw/ip/otbn/dv/otbnsim/test/simple/add/add.s
+++ b/hw/ip/otbn/dv/otbnsim/test/simple/add/add.s
@@ -1,0 +1,20 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+  addi    x10, x0, 1
+  addi    x11, x0, -1
+
+  /* 1 + 1 = 2 (x2 = 2) */
+  add     x2, x10, x10
+
+  /* 2 + 1 = 3 (x3 = 3) */
+  add     x3, x2, x10
+
+  /* 3 + (-1) = 2 (x4 = 2) */
+  add     x4, x3, x11
+
+  /* (-1) + (-1) = -2 (x5 = -2) */
+  add     x5, x11, x11
+
+  ecall

--- a/hw/ip/otbn/dv/otbnsim/test/simple/add/expected.txt
+++ b/hw/ip/otbn/dv/otbnsim/test/simple/add/expected.txt
@@ -1,0 +1,11 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+x10 = 1
+x11 = 0xffffffff
+x2 = 2
+x3 = 3
+x4 = 2
+x5 = 0xfffffffe
+

--- a/hw/ip/otbn/dv/otbnsim/test/simple/addi/addi.s
+++ b/hw/ip/otbn/dv/otbnsim/test/simple/addi/addi.s
@@ -1,0 +1,22 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+  addi    x10, x0, 1
+
+  /* x2 = 0 + 1 = 1 */
+  addi    x2, x0, 1
+
+  /* x3 = 1 + 1 = 2 */
+  addi    x3, x2, 1
+
+  /* x4 = 0 + (-1) = 0xffffffff */
+  addi    x4, x0, -1
+
+  /* x5 = 2 + (-1) = 1 */
+  addi    x5, x3, -1
+
+  /* x6 = -1 + 10 = 9 */
+  addi    x6, x4, 10
+
+  ecall

--- a/hw/ip/otbn/dv/otbnsim/test/simple/addi/expected.txt
+++ b/hw/ip/otbn/dv/otbnsim/test/simple/addi/expected.txt
@@ -1,0 +1,10 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+x10 = 1
+x2 = 1
+x3 = 2
+x4 = 0xffffffff
+x5 = 1
+x6 = 9

--- a/hw/ip/otbn/dv/otbnsim/test/simple_test.py
+++ b/hw/ip/otbn/dv/otbnsim/test/simple_test.py
@@ -1,0 +1,147 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+'''Run tests to make sure the simulator works as expected
+
+We expect a test in each directory below ./simple. This test should comprise a
+single assembly file (called <something>.s) and a file called expected.txt,
+containing a list of expected register values.
+
+'''
+
+import os
+import re
+import subprocess
+from typing import Any, Dict, List, Tuple
+
+
+_OTBN_DIR = os.path.join(os.path.dirname(__file__), '../../..')
+_UTIL_DIR = os.path.join(_OTBN_DIR, 'util')
+_SIM_DIR = os.path.join(os.path.dirname(__file__), '..')
+
+_REG_RE = re.compile(r'\s*([xw][0-9]+)\s*=\s*((:?0x[0-9a-f]+)|([0-9]+))$')
+
+
+def find_simple_tests() -> List[Tuple[str, str]]:
+    '''Find all test directories below ./simple (relative to this file)
+
+    Returns (asm, expected) pairs, with the paths to the assembly file and
+    expected.txt.
+
+    '''
+    root = os.path.join(os.path.dirname(__file__), 'simple')
+    ret = []
+    for subdir, _, files in os.walk(root):
+        if 'expected.txt' not in files:
+            continue
+
+        dirname = os.path.join(root, subdir)
+        asm_files = [name for name in files if name.endswith('.s')]
+        if len(asm_files) != 1:
+            raise RuntimeError('In the directory {!r}, there is an '
+                               'expected.txt, but there are {} files ending '
+                               'in .s (expected exactly one).'
+                               .format(dirname, len(asm_files)))
+        ret.append((os.path.join(dirname, asm_files[0]),
+                    os.path.join(dirname, 'expected.txt')))
+    return ret
+
+
+def asm_and_link_one_file(asm_path: str, work_dir: str) -> str:
+    '''Assemble and link file at asm_path in work_dir.
+
+    Returns the path to the resulting ELF
+
+    '''
+    otbn_as = os.path.join(_UTIL_DIR, 'otbn-as')
+    otbn_ld = os.path.join(_UTIL_DIR, 'otbn-ld')
+    obj_path = os.path.join(work_dir, 'tst.o')
+    elf_path = os.path.join(work_dir, 'tst')
+
+    subprocess.run([otbn_as, '-o', obj_path, asm_path], check=True)
+    subprocess.run([otbn_ld, '-o', elf_path, obj_path], check=True)
+    return elf_path
+
+
+def get_reg_dump(stdout: str) -> Dict[str, int]:
+    '''Parse the output from a simple test ending in print_regs
+
+    Returns a dictionary keyed by register name and with value equal to the
+    value that register ended up with.
+
+    '''
+    started = False
+    done = False
+    ret = {}
+    for line in stdout.split('\n'):
+        if line == 'PRINT_REGS':
+            if started:
+                raise RuntimeError('Multiple PRINT_REGS lines seen')
+            started = True
+            continue
+        if done or not started:
+            continue
+
+        if line == '.':
+            done = True
+            continue
+
+        m = _REG_RE.match(line)
+        if not m:
+            raise RuntimeError('Failed to parse line after PRINT_REGS ({!r}).'
+                               .format(line))
+
+        ret[m.group(1)] = int(m.group(2), 0)
+
+    return ret
+
+
+def get_reg_expected(exp_path: str) -> Dict[str, int]:
+    '''Read expected.txt
+
+    Returns same format as get_reg_dump, assuming any unspecified registers
+    should be zero.
+
+    '''
+    ret = {}
+    for idx in range(32):
+        ret['x{}'.format(idx)] = 0
+        ret['w{}'.format(idx)] = 0
+
+    with open(exp_path) as exp_file:
+        for idx, line in enumerate(exp_file):
+            # Comments with '#'; ignore blank lines
+            line = line.split('#', 1)[0].strip()
+            if not line:
+                continue
+
+            m = _REG_RE.match(line)
+            if m is None:
+                raise RuntimeError('{}:{}: Bad format for line in expected.txt.'
+                                   .format(exp_path, idx + 1))
+            ret[m.group(1)] = int(m.group(2), 0)
+
+    return ret
+
+
+def test_count(tmpdir: str, asm_file: str, expected_file: str) -> None:
+    # Start by assembling and linking the input file
+    elf_file = asm_and_link_one_file(asm_file, tmpdir)
+
+    # Run the simulation. We can just pass a list of commands to stdin, and
+    # don't need to do anything clever to track what's going on.
+    stepped_py = os.path.join(_SIM_DIR, 'stepped.py')
+    commands = 'load_elf {}\nstart 0\nrun\nprint_regs\n'.format(elf_file)
+    sim_proc = subprocess.run([stepped_py], check=True, input=commands,
+                              stdout=subprocess.PIPE, universal_newlines=True)
+
+    regs_seen = get_reg_dump(sim_proc.stdout)
+    regs_expected = get_reg_expected(expected_file)
+
+    assert regs_seen == regs_expected
+
+
+def pytest_generate_tests(metafunc: Any) -> None:
+    if metafunc.function is test_count:
+        metafunc.parametrize("asm_file,expected_file", find_simple_tests())


### PR DESCRIPTION
I feel like we need some basic "input; output" tests for the ISS: I've broken things one too many times! This PR doesn't wire it into CI for now, but does define a "make test" target in the `otbnsim` directory.