### PR TITLE
[dv/alert_handler] fix ping_corner_cases with new entropy

### DIFF
--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
@@ -37,6 +37,7 @@ class alert_handler_base_vseq extends cip_base_vseq #(
   virtual task dut_init(string reset_kind = "HARD");
     super.dut_init();
     if (do_alert_handler_init) alert_handler_init();
+    config_locked = 0;
   endtask
 
   virtual task dut_shutdown();


### PR DESCRIPTION
In previous ping_corner_cases test, after a ping request is detected,
the sequence will randomly choose to insert alert or reset. Then it will
wait until the escalation phases are done. However, the new entropy
LFSR SEED changes the ping frequency - that some pings are triggered in
a short interval. So there are cases that ping triggered during
`run_ping_interrupt_seqs`. To avoid this, this PR:
1). Remove the wait for escalation phases done logic in
`run_ping_interrupt_seqs` task
2). Remove the `alert_handler_init` calls in each transaction in
ping_corner_cases, it only calls `alert_handler_init` after dut_init.
3). Fix a small logic in `alert_handler_sanity` test, the
set_config_locked logic should happen right after the `lock_config`
call. Current logic it happened after driving alert and escalation
response.

Signed-off-by: Cindy Chen <chencindy@google.com>