### PR TITLE
[alert_handler] Update core files to use the design_level switch

### DIFF
--- a/hw/ip/alert_handler/alert_handler_reg.core
+++ b/hw/ip/alert_handler/alert_handler_reg.core
@@ -8,10 +8,10 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:tlul:headers
-
+      - fileset_top ? (lowrisc:systems:alert_handler_reg)
     files:
-      - rtl/alert_handler_reg_pkg.sv
-      - rtl/alert_handler_reg_top.sv
+      - fileset_ip ? (rtl/alert_handler_reg_pkg.sv)
+      - fileset_ip ? (rtl/alert_handler_reg_top.sv)
     file_type: systemVerilogSource
 
 

--- a/hw/top_earlgrey/ip/alert_handler/alert_handler_reg.core
+++ b/hw/top_earlgrey/ip/alert_handler/alert_handler_reg.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: "lowrisc:top_earlgrey:alert_handler_reg:0.1"
+name: "lowrisc:systems:alert_handler_reg:0.1"
 description: "Auto-generated alert handler register sources for top_earlgrey chip."
 filesets:
   files_rtl:

--- a/hw/top_earlgrey/ip/alert_handler/dv/alert_handler_sim.core
+++ b/hw/top_earlgrey/ip/alert_handler/dv/alert_handler_sim.core
@@ -7,8 +7,7 @@ description: "ALERT_HANDLER DV sim target"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:top_earlgrey:alert_handler_reg
-      - lowrisc:ip:alert_handler_component
+      - lowrisc:ip:alert_handler
     file_type: systemVerilogSource
 
   files_dv:

--- a/hw/top_earlgrey/ip/alert_handler/dv/alert_handler_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip/alert_handler/dv/alert_handler_sim_cfg.hjson
@@ -11,5 +11,9 @@
       name:  fusesoc_core
       value: lowrisc:dv:alert_handler_sim:0.1
     }
+    {
+      name:  design_level
+      value: "top"
+    }
   ]
 }

--- a/hw/top_earlgrey/ip/alert_handler/dv/sva/alert_handler_sva.core
+++ b/hw/top_earlgrey/ip/alert_handler/dv/sva/alert_handler_sva.core
@@ -19,7 +19,7 @@ generate:
     generator: csr_assert_gen
     parameters:
       spec: ../../data/autogen/alert_handler.hjson
-      depend: lowrisc:top_earlgrey:alert_handler_reg
+      depend: lowrisc:ip:alert_handler_reg
 
 targets:
   default:

--- a/hw/top_earlgrey/ip/rstmgr/rstmgr_pkg.core
+++ b/hw/top_earlgrey/ip/rstmgr/rstmgr_pkg.core
@@ -10,7 +10,7 @@ filesets:
     depend:
       - lowrisc:ip:pwrmgr_pkg
       - lowrisc:ip:rstmgr_reg
-      - lowrisc:top_earlgrey:alert_handler_reg
+      - lowrisc:ip:alert_handler_reg
       - lowrisc:ip:alert_handler_component
     files:
       - rtl/autogen/rstmgr_pkg.sv

--- a/hw/top_earlgrey/lint/top_earlgrey_lint_cfgs.hjson
+++ b/hw/top_earlgrey/lint/top_earlgrey_lint_cfgs.hjson
@@ -25,6 +25,12 @@
                   fusesoc_core: lowrisc:ip:alert_handler
                   import_cfgs: ["{proj_root}/hw/lint/data/common_lint_cfg.hjson"]
                   rel_path: "hw/ip/alert_handler/lint/{tool}"
+                  overrides: [
+                    {
+                      name: design_level
+                      value: "top"
+                    }
+                  ]
              },
              {    name: entropy_src
                   fusesoc_core: lowrisc:ip:entropy_src

--- a/hw/top_earlgrey/top_earlgrey.core
+++ b/hw/top_earlgrey/top_earlgrey.core
@@ -8,9 +8,8 @@ filesets:
   files_rtl_generic:
     depend:
       - lowrisc:ip:uart:0.1
-      - lowrisc:top_earlgrey:alert_handler_reg
       - lowrisc:top_earlgrey:clkmgr
-      - lowrisc:ip:alert_handler_component
+      - lowrisc:ip:alert_handler
       - lowrisc:ip:gpio
       - lowrisc:ip:rv_core_ibex
       - lowrisc:ip:rv_dm


### PR DESCRIPTION
This replaces the old "legacy" way of switching between the regfiles for the example design and the top-level with the design_level mechanism now supported by Dvsim/Fusesoc.

The corresponding lint and DV targets are updated as well.

Signed-off-by: Michael Schaffner <msf@opentitan.org>