### PR TITLE
[mask_rom] Do Not Zero Test Area

### DIFF
--- a/sw/device/mask_rom/mask_rom_start.S
+++ b/sw/device/mask_rom/mask_rom_start.S
@@ -205,7 +205,9 @@ _mask_rom_start_boot:
   // `t0` is the address to start zeroing at.
   // `t1` is the address to stop zeroing at.
   li   t0, TOP_EARLGREY_RAM_MAIN_BASE_ADDR
-  li   t1, (TOP_EARLGREY_RAM_MAIN_BASE_ADDR + TOP_EARLGREY_RAM_MAIN_SIZE_BYTES)
+  // TODO: Ensure we do zero all of RAM, for the moment we're not zeroing the
+  // test area. https://github.com/lowRISC/opentitan/issues/3619
+  la   t1, _test_reserved_start
   bgeu t0, t1, sram_zero_end
 sram_zero_loop:
   // TODO: Unroll loop


### PR DESCRIPTION
We avoid zeroing the Test area in RAM, which is used by DV and Verilator
to report information to the simulation environment. This should avoid
spurious failures where we write data that causes the core to halt.

Later, we should revert this, once we stop using RAM signals to send data to the simulation environments.