### PR TITLE
[otp/fpv] fix a few assertion compile error

### DIFF
--- a/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
@@ -806,14 +806,13 @@ module otp_ctrl
   `ASSERT_KNOWN(IntrOtpOperationDoneKnown_A, intr_otp_operation_done_o)
   `ASSERT_KNOWN(IntrOtpErrorKnown_A,         intr_otp_error_o)
   `ASSERT_KNOWN(AlertTxKnown_A,              alert_tx_o)
-  `ASSERT_KNOWN(PwrOtpInitRspKnown_A,        pwr_otp_init_rsp_o)
-  `ASSERT_KNOWN(OtpPwrStateKnown_A,          otp_pwr_state_o)
+  `ASSERT_KNOWN(PwrOtpInitRspKnown_A,        pwr_otp_rsp_o)
   `ASSERT_KNOWN(LcOtpProgramRspKnown_A,      lc_otp_program_rsp_o)
   `ASSERT_KNOWN(OtpLcDataKnown_A,            otp_lc_data_o)
   `ASSERT_KNOWN(OtpKeymgrKeyKnown_A,         otp_keymgr_key_o)
   `ASSERT_KNOWN(OtpFlashKeyKnown_A,          flash_otp_key_rsp_o)
-  `ASSERT_KNOWN(OtpFlashKeyKnown_A,          sram_otp_key_rsp_o)
-  `ASSERT_KNOWN(OtpFlashKeyKnown_A,          otbn_otp_key_rsp_o)
+  `ASSERT_KNOWN(OtpSramKeyKnown_A,           sram_otp_key_rsp_o)
+  `ASSERT_KNOWN(OtpOtgnKeyKnown_A,           otbn_otp_key_rsp_o)
   `ASSERT_KNOWN(HwCfgKnown_A,                hw_cfg_o)
 
 endmodule : otp_ctrl

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_lfsr_timer.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_lfsr_timer.sv
@@ -307,7 +307,7 @@ module otp_ctrl_lfsr_timer import otp_ctrl_pkg::*; #(
   // Assertions //
   ////////////////
 
-  `ASSERT_KNOWN(EntropyReqKnown_A,  entropy_req_o)
+  `ASSERT_KNOWN(EdnReqKnown_A,      edn_req_o)
   `ASSERT_KNOWN(ChkPendingKnown_A,  chk_pending_o)
   `ASSERT_KNOWN(IntegChkReqKnown_A, integ_chk_req_o)
   `ASSERT_KNOWN(CnstyChkReqKnown_A, cnsty_chk_req_o)


### PR DESCRIPTION
PR #3574 update LFSR seeding and thus a few interface signal name gets
updated. This PR update the interface naming in ASSERT_KNOWN.

Signed-off-by: Cindy Chen <chencindy@google.com>