### PR TITLE
[fpga] Fix clock constraint

### DIFF
--- a/hw/top_earlgrey/data/clocks.xdc
+++ b/hw/top_earlgrey/data/clocks.xdc
@@ -13,7 +13,7 @@ set clks_48_unbuf [get_clocks -of_objects [get_pin clkgen/pll/CLKOUT1]]
 ## This is not really recommended per Vivado's guidelines, but hopefully these clocks are slow enough and their
 ## destination flops few enough.
 
-set div2_cell [get_cells top_earlgrey/u_clkmgr/u_io_div2_div/gen_div2.u_div2/gen_generic.u_impl_generic/q_o_reg[0]]
+set div2_cell [get_cells top_earlgrey/u_io_div2_div/gen_div2.u_div2/gen_generic.u_impl_generic/q_o_reg[0]]
 create_generated_clock -name clk_io_div2 -source [get_pin ${div2_cell}/C] -divide_by 2 [get_pin ${div2_cell}/Q]
 
 set div4_cell [get_cells top_earlgrey/u_clkmgr/u_io_div4_div/gen_div.clk_int_reg]


### PR DESCRIPTION
For some reason, Vivado moves one of the clock dividers inside clkmgr to the outside of clkmgr. As a result, the path used to find the relevant cell is wrong and the divided clock cannot be properly constrained. This leads to:
- a bunch of critical warnings,
- ~excessively long implementation times, and~
- ~higher negative slack.~

This PR contains a single commit to fix this path such that the clock can be constrained.

Edit: this PR does not seem to reliably fix the high negative slack and long implementation times.