### PR TITLE
[dv/common] TLUL agent function coverage

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env_cov.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env_cov.sv
@@ -60,7 +60,7 @@ class cip_base_env_cov #(type CFG_T = cip_base_env_cfg) extends dv_base_env_cov 
   // Coverage for sticky interrupt functionality described in CIP specification
   // As some interrupts are non-sticky, this covergroup should be populated on "as and when needed"
   // basis in extended <ip>_env_cov class for interrupt types that are sticky
-  dv_base_generic_cov_obj sticky_intr_cov[string];
+  bit_toggle_cg_wrap sticky_intr_cov[string];
 
   `uvm_component_new
 

--- a/hw/dv/sv/dv_lib/dv_base_env_cov.sv
+++ b/hw/dv/sv/dv_lib/dv_base_env_cov.sv
@@ -5,13 +5,15 @@
 // TODO - We are enclosing generic covergroups inside class so that we can
 // take avoid tool limitation of not allowing arrays of covergroup
 // Refer to Issue#375 for more details
-class dv_base_generic_cov_obj;
+class bit_toggle_cg_wrap;
 
   // Covergroup: bit_toggle_cg
   // Generic covergroup definition
-  covergroup bit_toggle_cg(string name, bit toggle_cov_en = 1) with function sample(bit value);
+  covergroup bit_toggle_cg(string name, string path = "", bit toggle_cov_en = 1) with function
+        sample(bit value);
     option.per_instance = 1;
-    option.name = name;
+    option.name         = (path == "") ? name : {path, "::", name};
+
     cp_value: coverpoint value;
     cp_transitions: coverpoint value {
       option.weight = toggle_cov_en;
@@ -21,8 +23,8 @@ class dv_base_generic_cov_obj;
   endgroup : bit_toggle_cg
 
   // Function: new
-  function new(string name = "dv_base_generic_cov_obj", bit toggle_cov_en = 1);
-    bit_toggle_cg = new(name, toggle_cov_en);
+  function new(string name = "bit_toggle_cg_wrap", string path = "", bit toggle_cov_en = 1);
+    bit_toggle_cg = new(name, path, toggle_cov_en);
   endfunction : new
 
   // Function: sample
@@ -30,7 +32,7 @@ class dv_base_generic_cov_obj;
     bit_toggle_cg.sample(value);
   endfunction : sample
 
-endclass : dv_base_generic_cov_obj
+endclass : bit_toggle_cg_wrap
 
 class dv_base_env_cov #(type CFG_T = dv_base_env_cfg) extends uvm_component;
   `uvm_component_param_utils(dv_base_env_cov #(CFG_T))

--- a/hw/dv/sv/tl_agent/tl_agent_cfg.sv
+++ b/hw/dv/sv/tl_agent/tl_agent_cfg.sv
@@ -125,7 +125,6 @@ class tl_agent_cfg extends dv_base_agent_cfg;
   // return UVM_NOT_OK when the item is aborted without accepted.
   int unsigned csr_access_abort_pct_in_adapter = 0;
 
-
   `uvm_object_utils_begin(tl_agent_cfg)
     `uvm_field_int(max_outstanding_req,   UVM_DEFAULT)
     `uvm_field_enum(tl_level_e, tl_level, UVM_DEFAULT)

--- a/hw/dv/sv/tl_agent/tl_agent_cov.sv
+++ b/hw/dv/sv/tl_agent/tl_agent_cov.sv
@@ -4,34 +4,127 @@
 
 // Covergroup: pending_req_on_rst_cg
 // define bins for having pending request while on reset
-covergroup pending_req_on_rst_cg(string name) with function sample(bit req_pending);
+covergroup pending_req_on_rst_cg(string name, string path) with function
+    sample(bit req_pending);
   option.per_instance = 1;
-  option.name         = name;
+  option.name         = {path, "::", name};
+
   cp_req_pending: coverpoint req_pending {
     bins values[] = {0, 1};
   }
 endgroup
 
 // coverage for sampling all the values of outstanding req, up to its max
-covergroup max_outstanding_cg(string name, int max_outstanding) with function
+covergroup max_outstanding_cg(string name, int max_outstanding, string path) with function
     sample(int num_outstanding);
   option.per_instance = 1;
-  option.name         = name;
+  option.name         = {path, "::", name};
+
   cp_num_of_outstanding: coverpoint num_outstanding {
     bins values[]  = {[1:max_outstanding]};
   }
 endgroup : max_outstanding_cg
 
+covergroup tl_a_chan_cov_cg(string name, int valid_source_width, string path) with function
+      sample(tl_seq_item item);
+  option.per_instance = 1;
+  option.name         = {path, "::", name};
+
+  cp_opcode: coverpoint item.a_opcode {
+    bins values[] = {Get, PutFullData, PutPartialData};
+  }
+  cp_mask: coverpoint item.a_mask {
+    bins all_enables  = {'1};
+    bins others       = default;
+  }
+  cp_size: coverpoint item.a_size {
+    bins biggest_size = {$clog2(DataWidth >> 3)};
+    bins others       = default;
+  }
+  cp_source: coverpoint item.a_source {
+    bins valid_sources[] = {[0 : 2 << (valid_source_width - 1) - 1]};
+  }
+  cross cp_opcode, cp_mask, cp_size;
+endgroup : tl_a_chan_cov_cg
+
+covergroup tl_d_chan_cov_cg(string name, string path) with function sample(tl_seq_item item);
+  option.per_instance = 1;
+  option.name         = {path, "::", name};
+
+  cp_opcode: coverpoint item.d_opcode {
+    bins values[] = {AccessAckData, AccessAckData};
+  }
+  cp_size: coverpoint item.a_size {
+    bins biggest_size = {$clog2(DataWidth >> 3)};
+    bins others       = default;
+  }
+  cp_error:  coverpoint item.d_error;
+  cross cp_opcode, cp_size;
+endgroup : tl_d_chan_cov_cg
+
 class tl_agent_cov extends dv_base_agent_cov #(tl_agent_cfg);
+  // sample these at proper location, for example, m_pending_req_on_rst_cg called after reset
   pending_req_on_rst_cg m_pending_req_on_rst_cg;
   max_outstanding_cg    m_max_outstanding_cg;
+  bit_toggle_cg_wrap    m_outstanding_item_w_same_addr_cov_obj;
+
+  // knob to create m_outstanding_item_w_same_addr_cov_obj, even design supports more than
+  // 1 outstanding items, but may not support they use the same address
+  // TODO: may need to disable it for spi_device and hmac even they support 2 oustanding items
+  bit en_cov_outstanding_item_w_same_addr = 1;
+
+  // item coverage, call sample(item) at the end of transaction to sample them
+  tl_a_chan_cov_cg   m_tl_a_chan_cov_cg; // host mode
+  tl_d_chan_cov_cg   m_tl_d_chan_cov_cg; // device mode
+  bit_toggle_cg_wrap m_tl_error_cov_objs[string]; // host mode
 
   `uvm_component_utils(tl_agent_cov)
   `uvm_component_new
 
   function void build_phase(uvm_phase phase);
+    string tl_error_names[] = {"invalid_a_opcode",
+                               "PutFullData_mask_not_match_size",
+                               "addr_not_align_mask",
+                               "addr_not_align_size",
+                               "mask_not_in_enabled_lanes",
+                               "size_over_max"};
     super.build_phase(phase);
-    m_pending_req_on_rst_cg = new("m_pending_req_on_rst_cg");
-    m_max_outstanding_cg    = new("m_max_outstanding_cg", cfg.max_outstanding_req);
+    m_pending_req_on_rst_cg = new("m_pending_req_on_rst_cg", `gfn);
+    m_max_outstanding_cg    = new("m_max_outstanding_cg", cfg.max_outstanding_req, `gfn);
+
+    if (cfg.max_outstanding_req > 1 && en_cov_outstanding_item_w_same_addr) begin
+      m_outstanding_item_w_same_addr_cov_obj = new(.name("m_outstanding_item_w_same_addr_cov_obj"),
+                                                   .path(`gfn));
+    end
+
+    if (cfg.if_mode == dv_utils_pkg::Host) begin
+      m_tl_a_chan_cov_cg = new("m_tl_a_chan_cov_cg", cfg.valid_a_source_width, `gfn);
+      foreach (tl_error_names[i]) begin
+        m_tl_error_cov_objs[tl_error_names[i]] = new(.name(tl_error_names[i]), .path(`gfn));
+      end
+    end else begin // device mode
+      m_tl_d_chan_cov_cg = new("m_tl_d_chan_cov_cg", `gfn);
+    end
   endfunction : build_phase
+
+  // sample info that is within the seq_item, this will be called at the end of transaction
+  virtual function void sample(tl_seq_item item);
+    if (cfg.if_mode == dv_utils_pkg::Host) begin
+      if (!item.get_exp_d_error()) begin // no error
+        m_tl_a_chan_cov_cg.sample(item);
+      end else begin // error cases
+        m_tl_error_cov_objs["invalid_a_opcode"].sample(item.get_error_a_opcode_invalid());
+        m_tl_error_cov_objs["PutFullData_mask_not_match_size"].sample(
+            item.get_error_PutFullData_mask_size_mismatched());
+        m_tl_error_cov_objs["addr_not_align_mask"].sample(item.get_error_addr_size_misaligned());
+        m_tl_error_cov_objs["addr_not_align_size"].sample(item.get_error_addr_size_misaligned());
+        m_tl_error_cov_objs["mask_not_in_enabled_lanes"].sample(
+            item.get_error_mask_not_in_enabled_lanes());
+        m_tl_error_cov_objs["size_over_max"].sample(item.get_error_size_over_max());
+      end
+    end else begin // device mode
+      m_tl_d_chan_cov_cg.sample(item);
+    end
+  endfunction : sample
+
 endclass

--- a/hw/dv/sv/tl_agent/tl_seq_item.sv
+++ b/hw/dv/sv/tl_agent/tl_seq_item.sv
@@ -19,7 +19,7 @@
 //   a_addr[1:0] == 1 -> a_mask[0]   == 0;
 //   a_addr[1:0] == 2 -> a_mask[1:0] == 0;
 //   a_addr[1:0] == 3 -> a_mask[2:0] == 0;
-`define chk_prot_mask_w_addr \
+`define chk_prot_addr_mask_align \
   MaskWidth'(a_mask << (4 - a_addr[SizeWidth-1:0])) == 0
 
 // mask must be within enabled lanes
@@ -119,8 +119,8 @@ class tl_seq_item extends uvm_sequence_item;
     `chk_prot_mask_w_PutFullData;
   }
 
-  constraint mask_w_addr_c {
-    `chk_prot_mask_w_addr;
+  constraint addr_mask_align_c {
+    `chk_prot_addr_mask_align;
   }
 
   constraint mask_in_enabled_lanes_c {
@@ -211,16 +211,40 @@ class tl_seq_item extends uvm_sequence_item;
 
   // calculate d_error based on values of a_chan
   function bit get_exp_d_error();
-    return !(`chk_prot_addr_size_align) || !(`chk_prot_max_size) ||
-           !(`chk_prot_a_opcode) || !(`chk_prot_mask_w_PutFullData) ||
-           !(`chk_prot_mask_w_addr) || !(`chk_prot_mask_in_enabled_lanes);
+    return get_error_a_opcode_invalid() || get_error_PutFullData_mask_size_mismatched() ||
+           get_error_addr_mask_misaligned() || get_error_addr_size_misaligned() ||
+           get_error_mask_not_in_enabled_lanes() || get_error_size_over_max();
+  endfunction
+
+  function bit get_error_a_opcode_invalid();
+    return !(`chk_prot_a_opcode);
+  endfunction
+
+  function bit get_error_PutFullData_mask_size_mismatched();
+    return !(`chk_prot_mask_w_PutFullData);
+  endfunction
+
+  function bit get_error_addr_mask_misaligned();
+    return !(`chk_prot_addr_mask_align);
+  endfunction
+
+  function bit get_error_addr_size_misaligned();
+    return !(`chk_prot_addr_size_align);
+  endfunction
+
+  function bit get_error_mask_not_in_enabled_lanes();
+    return !(`chk_prot_mask_in_enabled_lanes);
+  endfunction
+
+  function bit get_error_size_over_max();
+    return !(`chk_prot_max_size);
   endfunction
 
   function void disable_a_chan_protocol_constraint();
     a_opcode_c.constraint_mode(0);
     mask_contiguous_c.constraint_mode(0);
     mask_w_PutFullData_c.constraint_mode(0);
-    mask_w_addr_c.constraint_mode(0);
+    addr_mask_align_c.constraint_mode(0);
     mask_in_enabled_lanes_c.constraint_mode(0);
     addr_size_align_c.constraint_mode(0);
     max_size_c.constraint_mode(0);
@@ -230,18 +254,18 @@ class tl_seq_item extends uvm_sequence_item;
   // at least one constraint_mode needs to be disabled to make sure protocol is violated
   function void randomize_a_chan_with_protocol_error();
     bit cm_a_opcode, cm_mask_w_PutFullData;
-    bit cm_mask_w_addr, cm_mask_in_enabled_lanes, cm_addr_size_align, cm_max_size;
+    bit cm_addr_mask_align, cm_mask_in_enabled_lanes, cm_addr_size_align, cm_max_size;
     `DV_CHECK_FATAL(std::randomize(cm_a_opcode, cm_mask_w_PutFullData,
-                                   cm_mask_w_addr, cm_mask_in_enabled_lanes,
+                                   cm_addr_mask_align, cm_mask_in_enabled_lanes,
                                    cm_addr_size_align, cm_max_size) with {
                                    // at least one constraint_mode is off
                                    !(cm_a_opcode && cm_mask_w_PutFullData &&
-                                   cm_mask_w_addr && cm_mask_in_enabled_lanes &&
+                                   cm_addr_mask_align && cm_mask_in_enabled_lanes &&
                                    cm_addr_size_align && cm_max_size);
                                    })
     a_opcode_c.constraint_mode(cm_a_opcode);
     mask_w_PutFullData_c.constraint_mode(cm_mask_w_PutFullData);
-    mask_w_addr_c.constraint_mode(cm_mask_w_addr);
+    addr_mask_align_c.constraint_mode(cm_addr_mask_align);
     mask_in_enabled_lanes_c.constraint_mode(cm_mask_in_enabled_lanes);
     addr_size_align_c.constraint_mode(cm_addr_size_align);
     max_size_c.constraint_mode(cm_max_size);
@@ -249,7 +273,7 @@ class tl_seq_item extends uvm_sequence_item;
         // at least one `chk_prot_* is violated
         randomize() with {!cm_a_opcode              && !(`chk_prot_a_opcode)              ||
                           !cm_mask_w_PutFullData    && !(`chk_prot_mask_w_PutFullData)    ||
-                          !cm_mask_w_addr           && !(`chk_prot_mask_w_addr)           ||
+                          !cm_addr_mask_align       && !(`chk_prot_addr_mask_align)       ||
                           !cm_mask_in_enabled_lanes && !(`chk_prot_mask_in_enabled_lanes) ||
                           !cm_addr_size_align       && !(`chk_prot_addr_size_align)       ||
                           !cm_max_size              && !(`chk_prot_max_size);})
@@ -286,7 +310,7 @@ endclass
 
 `undef chk_prot_a_opcode
 `undef chk_prot_mask_w_PutFullData
-`undef chk_prot_mask_w_addr
+`undef chk_prot_addr_mask_align
 `undef chk_prot_mask_in_enabled_lanes
 `undef chk_prot_addr_size_align
 `undef chk_prot_max_size

--- a/hw/ip/gpio/dv/env/gpio_env_cov.sv
+++ b/hw/ip/gpio/dv/env/gpio_env_cov.sv
@@ -54,15 +54,15 @@ class gpio_env_cov extends cip_base_env_cov #(.CFG_T(gpio_env_cfg));
   `uvm_component_utils(gpio_env_cov)
 
   // Array of coverage objects for per pin coverage for gpio pin values
-  dv_base_generic_cov_obj gpio_pin_values_cov_obj[NUM_GPIOS];
+  bit_toggle_cg_wrap gpio_pin_values_cov_obj[NUM_GPIOS];
   // Interrupt State (Interrupt bit getting set and cleared)
-  dv_base_generic_cov_obj intr_state_cov_obj[NUM_GPIOS];
+  bit_toggle_cg_wrap intr_state_cov_obj[NUM_GPIOS];
   // Interrupt Control Enable registers' values
-  dv_base_generic_cov_obj intr_ctrl_en_cov_objs[NUM_GPIOS][string];
+  bit_toggle_cg_wrap intr_ctrl_en_cov_objs[NUM_GPIOS][string];
   // data_in register per bit value coverage
-  dv_base_generic_cov_obj data_in_cov_obj[NUM_GPIOS];
+  bit_toggle_cg_wrap data_in_cov_obj[NUM_GPIOS];
   // Per bit coverage on *out* and *oe* registers
-  dv_base_generic_cov_obj out_oe_cov_objs[NUM_GPIOS][string];
+  bit_toggle_cg_wrap out_oe_cov_objs[NUM_GPIOS][string];
   // Different gpio interrupt types' occurrences
   gpio_intr_type_cov_obj intr_event_type_cov_objs[NUM_GPIOS][string];
   // Coverage on data and mask fields of masked* registers

--- a/hw/ip/rv_timer/dv/env/rv_timer_env_cov.sv
+++ b/hw/ip/rv_timer/dv/env/rv_timer_env_cov.sv
@@ -58,7 +58,7 @@ class rv_timer_env_cov extends cip_base_env_cov #(.CFG_T(rv_timer_env_cfg));
 
   rv_timer_cfg_cov_obj      cfg_values_cov_obj[NUM_HARTS*NUM_TIMERS];
   rv_timer_ctrl_reg_cov_obj ctrl_reg_cov_obj[NUM_HARTS];
-  dv_base_generic_cov_obj   rv_timer_prescale_values_cov_obj[NUM_HARTS][12];
+  bit_toggle_cg_wrap        rv_timer_prescale_values_cov_obj[NUM_HARTS][12];
 
   function new(string name, uvm_component parent);
     super.new(name, parent);

--- a/hw/ip/tlul/generic_dv/env/xbar_env_cov.sv
+++ b/hw/ip/tlul/generic_dv/env/xbar_env_cov.sv
@@ -50,7 +50,7 @@ class xbar_env_cov extends dv_base_env_cov #(.CFG_T(xbar_env_cfg));
   same_device_access_cg   same_device_access_cg;
   same_source_access_cg   same_source_access_cg;
   // cover mapped/unmapped addr per host
-  dv_base_generic_cov_obj host_access_mapped_addr_cg[string];
+  bit_toggle_cg_wrap      host_access_mapped_addr_cg[string];
   // cover max_delay per host/device
   max_delay_cg_obj        max_delay_cg_obj[string];
   `uvm_component_utils(xbar_env_cov)


### PR DESCRIPTION
Added these covergroup
1. a_chan_cov_cg: cover basic req info like opcode, source, mask
2. d_chan_cov_cg: cover basic rsp info
3. same address used in more than 1 outstanding items
4. all kinds of error cases

Signed-off-by: Weicai Yang <weicai@google.com>