### PR TITLE
[prim/util/otp_ctrl] Updates the sparse FSM encoding script and all FSMs in otp_ctrl

### DIFF
--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_buf.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_buf.sv
@@ -82,7 +82,7 @@ module otp_ctrl_part_buf
   // OTP Partition FSM //
   ///////////////////////
 
-  // Encoding generated with ./sparse-fsm-encode -d 5 -m 16 -n 12
+  // Encoding generated with ./sparse-fsm-encode.py -d 5 -m 16 -n 12 -s 3370657881
   // Hamming distance histogram:
   //
   // 0:  --
@@ -90,35 +90,36 @@ module otp_ctrl_part_buf
   // 2:  --
   // 3:  --
   // 4:  --
-  // 5:  |||||||||||||||| (29.17%)
-  // 6:  |||||||||||||||||||| (35.83%)
-  // 7:  ||||||||||| (20.83%)
-  // 8:  |||| (7.50%)
-  // 9:  | (2.50%)
-  // 10: | (3.33%)
-  // 11:  (0.83%)
+  // 5:  |||||||||||||||||| (30.00%)
+  // 6:  |||||||||||||||||||| (32.50%)
+  // 7:  ||||||||||| (19.17%)
+  // 8:  ||||||| (11.67%)
+  // 9:  || (4.17%)
+  // 10: | (2.50%)
+  // 11: --
   // 12: --
   //
   // Minimum Hamming distance: 5
-  // Maximum Hamming distance: 11
+  // Maximum Hamming distance: 10
   //
-  typedef enum logic [11:0] {
-    ResetSt         = 12'b110001101001,
-    InitSt          = 12'b000100100000,
-    InitWaitSt      = 12'b011101011010,
-    InitDescrSt     = 12'b111010110000,
-    InitDescrWaitSt = 12'b110111000011,
-    IdleSt          = 12'b000000011100,
-    IntegScrSt      = 12'b001111101011,
-    IntegScrWaitSt  = 12'b000001000111,
-    IntegDigClrSt   = 12'b100110001101,
-    IntegDigSt      = 12'b101000110111,
-    IntegDigPadSt   = 12'b110101010100,
-    IntegDigFinSt   = 12'b101011001000,
-    IntegDigWaitSt  = 12'b010010101111,
-    CnstyReadSt     = 12'b001110000110,
-    CnstyReadWaitSt = 12'b011011011101,
-    ErrorSt         = 12'b000111110101
+  localparam int StateWidth = 12;
+  typedef enum logic [StateWidth-1:0] {
+    ResetSt         = 12'b001001101010,
+    InitSt          = 12'b110100100111,
+    InitWaitSt      = 12'b001110110001,
+    InitDescrSt     = 12'b110010000100,
+    InitDescrWaitSt = 12'b101000011100,
+    IdleSt          = 12'b100110101000,
+    IntegScrSt      = 12'b010101001101,
+    IntegScrWaitSt  = 12'b110101011010,
+    IntegDigClrSt   = 12'b011000011011,
+    IntegDigSt      = 12'b101001000001,
+    IntegDigPadSt   = 12'b101111010111,
+    IntegDigFinSt   = 12'b011011100101,
+    IntegDigWaitSt  = 12'b100011110010,
+    CnstyReadSt     = 12'b111111101110,
+    CnstyReadWaitSt = 12'b001100000110,
+    ErrorSt         = 12'b000011011001
   } state_e;
 
   typedef enum logic {
@@ -603,14 +604,24 @@ module otp_ctrl_part_buf
   // Registers //
   ///////////////
 
+  // This primitive is used to place a size-only constraint on the
+  // flops in order to prevent FSM state encoding optimizations.
+  prim_flop #(
+    .Width(StateWidth),
+    .ResetValue(StateWidth'(ResetSt))
+  ) u_state_regs (
+    .clk_i,
+    .rst_ni,
+    .d_i ( state_d ),
+    .q_o ( state_q )
+  );
+
   always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs
     if (!rst_ni) begin
-      state_q     <= ResetSt;
       error_q     <= NoErr;
       cnt_q       <= '0;
       dout_gate_q <= Locked;
     end else begin
-      state_q     <= state_d;
       error_q     <= error_d;
       cnt_q       <= cnt_d;
       dout_gate_q <= dout_gate_d;

--- a/hw/ip/prim_generic/rtl/prim_generic_otp.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_otp.sv
@@ -46,7 +46,7 @@ module prim_generic_otp #(
   // Control logic //
   ///////////////////
 
-  // Encoding generated with ./sparse-fsm-encode -d 5 -m 8 -n 10
+  // Encoding generated with ./sparse-fsm-encode.py -d 5 -m 8 -n 10
   // Hamming distance histogram:
   //
   // 0: --
@@ -64,7 +64,8 @@ module prim_generic_otp #(
   // Minimum Hamming distance: 5
   // Maximum Hamming distance: 8
   //
-  typedef enum logic [9:0] {
+  localparam int StateWidth = 10;
+  typedef enum logic [StateWidth-1:0] {
     ResetSt      = 10'b1100000011,
     InitSt       = 10'b1100110100,
     IdleSt       = 10'b1010111010,
@@ -249,9 +250,20 @@ module prim_generic_otp #(
   // Regs //
   //////////
 
+  // This primitive is used to place a size-only constraint on the
+  // flops in order to prevent FSM state encoding optimizations.
+  prim_flop #(
+    .Width(StateWidth),
+    .ResetValue(StateWidth'(ResetSt))
+  ) u_state_regs (
+    .clk_i,
+    .rst_ni,
+    .d_i ( state_d ),
+    .q_o ( state_q )
+  );
+
   always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs
     if (!rst_ni) begin
-      state_q <= ResetSt;
       valid_q <= '0;
       err_q   <= '0;
       addr_q  <= '0;
@@ -260,7 +272,6 @@ module prim_generic_otp #(
       cnt_q   <= '0;
       size_q  <= '0;
     end else begin
-      state_q <= state_d;
       valid_q <= valid_d;
       err_q   <= err_d;
       cnt_q   <= cnt_d;

--- a/hw/ip/prim_xilinx/prim_xilinx_flop.core
+++ b/hw/ip/prim_xilinx/prim_xilinx_flop.core
@@ -1,0 +1,40 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim_xilinx:flop"
+description: "generic flop"
+filesets:
+  files_rtl:
+    files:
+      - rtl/prim_xilinx_flop.sv
+    file_type: systemVerilogSource
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl

--- a/hw/ip/prim_xilinx/rtl/prim_xilinx_flop.sv
+++ b/hw/ip/prim_xilinx/rtl/prim_xilinx_flop.sv
@@ -1,0 +1,27 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`include "prim_assert.sv"
+
+module prim_xilinx_flop # (
+  parameter int Width      = 1,
+  localparam int WidthSubOne = Width-1,
+  parameter logic [WidthSubOne:0] ResetValue = 0
+) (
+  input clk_i,
+  input rst_ni,
+  input [Width-1:0] d_i,
+  // Prevent Vivado from optimizing this signal away.
+  (* keep = "true" *) output logic [Width-1:0] q_o
+);
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      q_o <= ResetValue;
+    end else begin
+      q_o <= d_i;
+    end
+  end
+
+endmodule // prim_xilinx_flop


### PR DESCRIPTION
With this update, the `sparse-fsm-encode` script also outputs a template for the FSM body and registers. In particular, the FSM state register is implemented using `prim_flop`, which is in turn updated to contain `KEEP` and `size_only` attributes / constraints for FPGA and ASIC synthesis, respectively. This prevents further optimization of the FSM state by the synthesis tool.