### PR TITLE
[sw/dif_pwrmgr] Power Manager DIF library implementation + unit tests

### DIFF
--- a/sw/device/lib/dif/dif_pwrmgr.c
+++ b/sw/device/lib/dif/dif_pwrmgr.c
@@ -4,7 +4,573 @@
 
 #include "sw/device/lib/dif/dif_pwrmgr.h"
 
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/mmio.h"
 
 #include "pwrmgr_regs.h"  // Generated.
 
-#error "Power Manager DIF library is not implemented yet."
+/**
+ * Following static assertions make sure that generated values match the
+ * definitions in the header, which we rely on for a simpler implementation.
+ * These constants and their usages must be revisited if there is a change in
+ * hardware.
+ */
+
+/**
+ * Relevant bits of the control register must start at
+ * `PWRMGR_CONTROL_CORE_CLK_EN` and be in the same order as
+ * `dif_pwrmgr_domain_option_t` constants.
+ */
+_Static_assert(kDifPwrmgrDomainOptionCoreClockInLowPower ==
+                   (1u << (PWRMGR_CONTROL_CORE_CLK_EN -
+                           PWRMGR_CONTROL_CORE_CLK_EN)),
+               "Layout of control register changed.");
+
+_Static_assert(kDifPwrmgrDomainOptionIoClockInLowPower ==
+                   (1u << (PWRMGR_CONTROL_IO_CLK_EN -
+                           PWRMGR_CONTROL_CORE_CLK_EN)),
+               "Layout of control register changed.");
+
+_Static_assert(kDifPwrmgrDomainOptionUsbClockInLowPower ==
+                   (1u << (PWRMGR_CONTROL_USB_CLK_EN_LP -
+                           PWRMGR_CONTROL_CORE_CLK_EN)),
+               "Layout of control register changed.");
+
+_Static_assert(kDifPwrmgrDomainOptionUsbClockInActivePower ==
+                   (1u << (PWRMGR_CONTROL_USB_CLK_EN_ACTIVE -
+                           PWRMGR_CONTROL_CORE_CLK_EN)),
+               "Layout of control register changed.");
+
+_Static_assert(kDifPwrmgrDomainOptionMainPowerInLowPower ==
+                   (1u << (PWRMGR_CONTROL_MAIN_PD_N -
+                           PWRMGR_CONTROL_CORE_CLK_EN)),
+               "Layout of control register changed.");
+
+/**
+ * Bitfield for interpreting the configuration options in the control
+ * register.
+ */
+static const bitfield_field32_t kDomainConfigBitfield = {
+    .mask = kDifPwrmgrDomainOptionCoreClockInLowPower |
+            kDifPwrmgrDomainOptionIoClockInLowPower |
+            kDifPwrmgrDomainOptionUsbClockInLowPower |
+            kDifPwrmgrDomainOptionUsbClockInActivePower |
+            kDifPwrmgrDomainOptionMainPowerInLowPower,
+    .index = PWRMGR_CONTROL_CORE_CLK_EN,
+};
+
+/**
+ * Relevant bits of the WAKEUP_EN and WAKE_INFO registers must start at `0` and
+ * be in the same order as `dif_pwrmgr_wakeup_request_source_t` constants.
+ */
+_Static_assert(kDifPwrmgrWakeupRequestSourceOne ==
+                   (1u << PWRMGR_WAKEUP_EN_EN_0),
+               "Layout of WAKEUP_EN register changed.");
+_Static_assert(kDifPwrmgrWakeupRequestSourceOne ==
+                   (1u << PWRMGR_WAKE_INFO_REASONS),
+               "Layout of WAKE_INFO register changed.");
+
+/**
+ * Relevant bits of the RESET_EN register must start at `0` and be in the same
+ * order as `dif_pwrmgr_reset_request_source_t` constants.
+ */
+_Static_assert(kDifPwrmgrResetRequestSourceOne == (1u << PWRMGR_RESET_EN_EN_0),
+               "Layout of RESET_EN register changed.");
+
+/**
+ * `dif_pwrmgr_irq_t` constants must match the corresponding generated values.
+ */
+_Static_assert(kDifPwrmgrIrqWakeup == PWRMGR_INTR_COMMON_WAKEUP,
+               "Layout of interrupt registers changed.");
+
+/**
+ * Register information for a request type.
+ */
+typedef struct request_reg_info {
+  ptrdiff_t write_enable_reg_offset;
+  bitfield_bit32_index_t write_enable_bit_index;
+  ptrdiff_t sources_enable_reg_offset;
+  ptrdiff_t cur_req_sources_reg_offset;
+  bitfield_field32_t bitfield;
+} request_reg_info_t;
+
+/**
+ * Register information for wakeup and reset requests.
+ *
+ * Wakeup and reset requests follow the same logic for configuration and
+ * monitoring but use different registers. Defining these constants here
+ * allows us to use the same code for both types of requests.
+ */
+static const request_reg_info_t request_reg_infos[2] = {
+    [kDifPwrmgrReqTypeWakeup] =
+        {
+            .write_enable_reg_offset = PWRMGR_WAKEUP_EN_REGWEN_REG_OFFSET,
+            .write_enable_bit_index = PWRMGR_WAKEUP_EN_REGWEN_EN,
+            .sources_enable_reg_offset = PWRMGR_WAKEUP_EN_REG_OFFSET,
+            .cur_req_sources_reg_offset = PWRMGR_WAKE_STATUS_REG_OFFSET,
+            .bitfield =
+                {
+                    .mask = kDifPwrmgrWakeupRequestSourceOne,
+                    .index = 0,
+                },
+        },
+    [kDifPwrmgrReqTypeReset] =
+        {
+            .write_enable_reg_offset = PWRMGR_RESET_EN_REGWEN_REG_OFFSET,
+            .write_enable_bit_index = PWRMGR_RESET_EN_REGWEN_EN,
+            .sources_enable_reg_offset = PWRMGR_RESET_EN_REG_OFFSET,
+            .cur_req_sources_reg_offset = PWRMGR_RESET_STATUS_REG_OFFSET,
+            .bitfield =
+                {
+                    .mask = kDifPwrmgrResetRequestSourceOne,
+                    .index = 0,
+                },
+        },
+};
+
+/**
+ * Checks if a value is a valid `dif_pwrmgr_toggle_t` and converts it to `bool`.
+ */
+DIF_WARN_UNUSED_RESULT
+static bool toggle_to_bool(dif_pwrmgr_toggle_t val, bool *val_bool) {
+  switch (val) {
+    case kDifPwrmgrToggleEnabled:
+      *val_bool = true;
+      break;
+    case kDifPwrmgrToggleDisabled:
+      *val_bool = false;
+      break;
+    default:
+      return false;
+  }
+  return true;
+}
+
+/**
+ * Converts a `bool` to `dif_pwrmgr_toggle_t`.
+ */
+static dif_pwrmgr_toggle_t bool_to_toggle(bool val) {
+  return val ? kDifPwrmgrToggleEnabled : kDifPwrmgrToggleDisabled;
+}
+
+/**
+ * Checks if a value is a valid `dif_pwrmgr_req_type_t`.
+ */
+DIF_WARN_UNUSED_RESULT
+static bool is_valid_req_type(dif_pwrmgr_req_type_t val) {
+  return val == kDifPwrmgrReqTypeWakeup || val == kDifPwrmgrReqTypeReset;
+}
+
+/**
+ * Checks if a value is a valid `dif_pwrmgr_irq_t`.
+ */
+DIF_WARN_UNUSED_RESULT
+static bool is_valid_irq(dif_pwrmgr_irq_t val) {
+  return val >= 0 && val <= kDifPwrmgrIrqLast;
+}
+
+/**
+ * Checks if a value is valid for, i.e. fits in the mask of, a
+ * `bitfield_field32_t`.
+ */
+DIF_WARN_UNUSED_RESULT
+static bool is_valid_for_bitfield(uint32_t val, bitfield_field32_t bitfield) {
+  return (val & bitfield.mask) == val;
+}
+
+/**
+ * Checks if the control register is locked.
+ *
+ * Control register is locked when low power is enabled and WFI occurs. It is
+ * unlocked when the chip transitions back to active power state.
+ */
+DIF_WARN_UNUSED_RESULT
+static bool control_register_is_locked(const dif_pwrmgr_t *pwrmgr) {
+  // Control register is locked when `PWRMGR_CTRL_CFG_REGWEN_EN` bit is 0.
+  return !bitfield_bit32_read(
+      mmio_region_read32(pwrmgr->params.base_addr,
+                         PWRMGR_CTRL_CFG_REGWEN_REG_OFFSET),
+      PWRMGR_CTRL_CFG_REGWEN_EN);
+}
+
+/**
+ * The configuration registers CONTROL, WAKEUP_EN, and RESET_EN are all written
+ * in the fast clock domain but used in the slow clock domain. Values of these
+ * registers are not propagated across the clock boundary until this function is
+ * called.
+ */
+static void sync_slow_clock_domain_polled(const dif_pwrmgr_t *pwrmgr) {
+  // Start sync and wait for it to finish.
+  mmio_region_write32(pwrmgr->params.base_addr, PWRMGR_CFG_CDC_SYNC_REG_OFFSET,
+                      bitfield_bit32_write(0, PWRMGR_CFG_CDC_SYNC_SYNC, true));
+  while (bitfield_bit32_read(mmio_region_read32(pwrmgr->params.base_addr,
+                                                PWRMGR_CFG_CDC_SYNC_REG_OFFSET),
+                             PWRMGR_CFG_CDC_SYNC_SYNC)) {
+  }
+}
+
+/**
+ * Checks if sources of a request type are locked.
+ */
+DIF_WARN_UNUSED_RESULT
+static bool request_sources_is_locked(const dif_pwrmgr_t *pwrmgr,
+                                      dif_pwrmgr_req_type_t req_type) {
+  request_reg_info_t reg_info = request_reg_infos[req_type];
+  uint32_t reg_val = mmio_region_read32(pwrmgr->params.base_addr,
+                                        reg_info.write_enable_reg_offset);
+  // Locked if write enable bit is set to 0.
+  return !bitfield_bit32_read(reg_val, reg_info.write_enable_bit_index);
+}
+
+dif_pwrmgr_result_t dif_pwrmgr_init(dif_pwrmgr_params_t params,
+                                    dif_pwrmgr_t *pwrmgr) {
+  if (pwrmgr == NULL) {
+    return kDifPwrmgrBadArg;
+  }
+
+  *pwrmgr = (dif_pwrmgr_t){.params = params};
+
+  return kDifPwrmgrOk;
+}
+
+dif_pwrmgr_config_result_t dif_pwrmgr_low_power_set_enabled(
+    const dif_pwrmgr_t *pwrmgr, dif_pwrmgr_toggle_t new_state) {
+  if (pwrmgr == NULL) {
+    return kDifPwrmgrConfigBadArg;
+  }
+
+  bool enable = false;
+  if (!toggle_to_bool(new_state, &enable)) {
+    return kDifPwrmgrConfigBadArg;
+  }
+
+  if (control_register_is_locked(pwrmgr)) {
+    return kDifPwrMgrConfigLocked;
+  }
+
+  uint32_t reg_val =
+      mmio_region_read32(pwrmgr->params.base_addr, PWRMGR_CONTROL_REG_OFFSET);
+  reg_val =
+      bitfield_bit32_write(reg_val, PWRMGR_CONTROL_LOW_POWER_HINT, enable);
+  mmio_region_write32(pwrmgr->params.base_addr, PWRMGR_CONTROL_REG_OFFSET,
+                      reg_val);
+
+  // Slow clock domain must be synced for changes to take effect.
+  sync_slow_clock_domain_polled(pwrmgr);
+
+  return kDifPwrmgrConfigOk;
+}
+
+dif_pwrmgr_result_t dif_pwrmgr_low_power_get_enabled(
+    const dif_pwrmgr_t *pwrmgr, dif_pwrmgr_toggle_t *cur_state) {
+  if (pwrmgr == NULL || cur_state == NULL) {
+    return kDifPwrmgrBadArg;
+  }
+
+  uint32_t reg_val =
+      mmio_region_read32(pwrmgr->params.base_addr, PWRMGR_CONTROL_REG_OFFSET);
+  *cur_state = bool_to_toggle(
+      bitfield_bit32_read(reg_val, PWRMGR_CONTROL_LOW_POWER_HINT));
+
+  return kDifPwrmgrOk;
+}
+
+dif_pwrmgr_config_result_t dif_pwrmgr_set_domain_config(
+    const dif_pwrmgr_t *pwrmgr, dif_pwrmgr_domain_config_t config) {
+  if (pwrmgr == NULL || !is_valid_for_bitfield(config, kDomainConfigBitfield)) {
+    return kDifPwrmgrConfigBadArg;
+  }
+
+  if (control_register_is_locked(pwrmgr)) {
+    return kDifPwrMgrConfigLocked;
+  }
+
+  uint32_t reg_val =
+      mmio_region_read32(pwrmgr->params.base_addr, PWRMGR_CONTROL_REG_OFFSET);
+  reg_val = bitfield_field32_write(reg_val, kDomainConfigBitfield, config);
+  mmio_region_write32(pwrmgr->params.base_addr, PWRMGR_CONTROL_REG_OFFSET,
+                      reg_val);
+
+  // Slow clock domain must be synced for changes to take effect.
+  sync_slow_clock_domain_polled(pwrmgr);
+
+  return kDifPwrmgrConfigOk;
+}
+
+dif_pwrmgr_result_t dif_pwrmgr_get_domain_config(
+    const dif_pwrmgr_t *pwrmgr, dif_pwrmgr_domain_config_t *config) {
+  if (pwrmgr == NULL || config == NULL) {
+    return kDifPwrmgrBadArg;
+  }
+
+  uint32_t reg_val =
+      mmio_region_read32(pwrmgr->params.base_addr, PWRMGR_CONTROL_REG_OFFSET);
+  *config = bitfield_field32_read(reg_val, kDomainConfigBitfield);
+
+  return kDifPwrmgrOk;
+}
+
+dif_pwrmgr_config_result_t dif_pwrmgr_set_request_sources(
+    const dif_pwrmgr_t *pwrmgr, dif_pwrmgr_req_type_t req_type,
+    dif_pwrmgr_request_sources_t sources) {
+  if (pwrmgr == NULL || !is_valid_req_type(req_type)) {
+    return kDifPwrmgrConfigBadArg;
+  }
+
+  request_reg_info_t reg_info = request_reg_infos[req_type];
+
+  if (!is_valid_for_bitfield(sources, reg_info.bitfield)) {
+    return kDifPwrmgrConfigBadArg;
+  }
+
+  // Return early if locked.
+  if (request_sources_is_locked(pwrmgr, req_type)) {
+    return kDifPwrMgrConfigLocked;
+  }
+
+  // Write new value
+  uint32_t reg_val = bitfield_field32_write(0, reg_info.bitfield, sources);
+  mmio_region_write32(pwrmgr->params.base_addr,
+                      reg_info.sources_enable_reg_offset, reg_val);
+  // Slow clock domain must be synced for changes to take effect.
+  sync_slow_clock_domain_polled(pwrmgr);
+
+  return kDifPwrmgrConfigOk;
+}
+
+dif_pwrmgr_result_t dif_pwrmgr_get_request_sources(
+    const dif_pwrmgr_t *pwrmgr, dif_pwrmgr_req_type_t req_type,
+    dif_pwrmgr_request_sources_t *sources) {
+  if (pwrmgr == NULL || !is_valid_req_type(req_type) || sources == NULL) {
+    return kDifPwrmgrBadArg;
+  }
+
+  request_reg_info_t reg_info = request_reg_infos[req_type];
+  uint32_t reg_val = mmio_region_read32(pwrmgr->params.base_addr,
+                                        reg_info.sources_enable_reg_offset);
+  *sources = bitfield_field32_read(reg_val, reg_info.bitfield);
+
+  return kDifPwrmgrOk;
+}
+
+dif_pwrmgr_result_t dif_pwrmgr_get_current_request_sources(
+    const dif_pwrmgr_t *pwrmgr, dif_pwrmgr_req_type_t req_type,
+    dif_pwrmgr_request_sources_t *sources) {
+  if (pwrmgr == NULL || !is_valid_req_type(req_type) || sources == NULL) {
+    return kDifPwrmgrBadArg;
+  }
+
+  request_reg_info_t reg_info = request_reg_infos[req_type];
+  uint32_t reg_val = mmio_region_read32(pwrmgr->params.base_addr,
+                                        reg_info.cur_req_sources_reg_offset);
+  *sources = bitfield_field32_read(reg_val, reg_info.bitfield);
+
+  return kDifPwrmgrOk;
+}
+
+dif_pwrmgr_result_t dif_pwrmgr_request_sources_lock(
+    const dif_pwrmgr_t *pwrmgr, dif_pwrmgr_req_type_t req_type) {
+  if (pwrmgr == NULL || !is_valid_req_type(req_type)) {
+    return kDifPwrmgrBadArg;
+  }
+
+  // Only a single bit of this register is significant, thus we don't perform a
+  // read-modify-write. Setting this bit to 0 locks sources.
+  mmio_region_write32(pwrmgr->params.base_addr,
+                      request_reg_infos[req_type].write_enable_reg_offset, 0);
+
+  return kDifPwrmgrOk;
+}
+
+dif_pwrmgr_result_t dif_pwrmgr_request_sources_is_locked(
+    const dif_pwrmgr_t *pwrmgr, dif_pwrmgr_req_type_t req_type,
+    bool *is_locked) {
+  if (pwrmgr == NULL || !is_valid_req_type(req_type) || is_locked == NULL) {
+    return kDifPwrmgrBadArg;
+  }
+
+  *is_locked = request_sources_is_locked(pwrmgr, req_type);
+
+  return kDifPwrmgrOk;
+}
+
+dif_pwrmgr_result_t dif_pwrmgr_wakeup_request_recording_set_enabled(
+    const dif_pwrmgr_t *pwrmgr, dif_pwrmgr_toggle_t new_state) {
+  if (pwrmgr == NULL) {
+    return kDifPwrmgrBadArg;
+  }
+
+  bool enable = false;
+  if (!toggle_to_bool(new_state, &enable)) {
+    return kDifPwrmgrBadArg;
+  }
+
+  // Only a single bit of this register is significant, thus we don't perform a
+  // read-modify-write. Setting this bit to 1 disables recording.
+  uint32_t reg_val =
+      bitfield_bit32_write(0, PWRMGR_WAKE_INFO_CAPTURE_DIS_VAL, !enable);
+
+  mmio_region_write32(pwrmgr->params.base_addr,
+                      PWRMGR_WAKE_INFO_CAPTURE_DIS_REG_OFFSET, reg_val);
+
+  return kDifPwrmgrOk;
+}
+
+dif_pwrmgr_result_t dif_pwrmgr_wakeup_request_recording_get_enabled(
+    const dif_pwrmgr_t *pwrmgr, dif_pwrmgr_toggle_t *cur_state) {
+  if (pwrmgr == NULL || cur_state == NULL) {
+    return kDifPwrmgrBadArg;
+  }
+
+  uint32_t reg_val = mmio_region_read32(
+      pwrmgr->params.base_addr, PWRMGR_WAKE_INFO_CAPTURE_DIS_REG_OFFSET);
+  // Recording is disabled if this bit is set to 1.
+  *cur_state = bool_to_toggle(
+      !bitfield_bit32_read(reg_val, PWRMGR_WAKE_INFO_CAPTURE_DIS_VAL));
+
+  return kDifPwrmgrOk;
+}
+
+dif_pwrmgr_result_t dif_pwrmgr_wakeup_reason_get(
+    const dif_pwrmgr_t *pwrmgr, dif_pwrmgr_wakeup_reason_t *reason) {
+  if (pwrmgr == NULL || reason == NULL) {
+    return kDifPwrmgrBadArg;
+  }
+
+  uint32_t reg_val =
+      mmio_region_read32(pwrmgr->params.base_addr, PWRMGR_WAKE_INFO_REG_OFFSET);
+
+  dif_pwrmgr_wakeup_types_t types = 0;
+  if (bitfield_bit32_read(reg_val, PWRMGR_WAKE_INFO_FALL_THROUGH)) {
+    types |= kDifPwrmgrWakeupTypeFallThrough;
+  }
+  if (bitfield_bit32_read(reg_val, PWRMGR_WAKE_INFO_ABORT)) {
+    types |= kDifPwrmgrWakeupTypeAbort;
+  }
+
+  uint32_t request_sources = bitfield_field32_read(
+      reg_val, request_reg_infos[kDifPwrmgrReqTypeWakeup].bitfield);
+  if (request_sources != 0) {
+    types |= kDifPwrmgrWakeupTypeRequest;
+  }
+
+  *reason = (dif_pwrmgr_wakeup_reason_t){
+      .types = types,
+      .request_sources = request_sources,
+  };
+
+  return kDifPwrmgrOk;
+}
+
+dif_pwrmgr_result_t dif_pwrmgr_wakeup_reason_clear(const dif_pwrmgr_t *pwrmgr) {
+  if (pwrmgr == NULL) {
+    return kDifPwrmgrBadArg;
+  }
+
+  mmio_region_write32(pwrmgr->params.base_addr, PWRMGR_WAKE_INFO_REG_OFFSET,
+                      UINT32_MAX);
+
+  return kDifPwrmgrOk;
+}
+
+dif_pwrmgr_result_t dif_pwrmgr_irq_is_pending(const dif_pwrmgr_t *pwrmgr,
+                                              dif_pwrmgr_irq_t irq,
+                                              bool *is_pending) {
+  if (pwrmgr == NULL || !is_valid_irq(irq) || is_pending == NULL) {
+    return kDifPwrmgrBadArg;
+  }
+
+  uint32_t reg_val = mmio_region_read32(pwrmgr->params.base_addr,
+                                        PWRMGR_INTR_STATE_REG_OFFSET);
+  *is_pending = bitfield_bit32_read(reg_val, irq);
+
+  return kDifPwrmgrOk;
+}
+
+dif_pwrmgr_result_t dif_pwrmgr_irq_acknowledge(const dif_pwrmgr_t *pwrmgr,
+                                               dif_pwrmgr_irq_t irq) {
+  if (pwrmgr == NULL || !is_valid_irq(irq)) {
+    return kDifPwrmgrBadArg;
+  }
+
+  uint32_t reg_val = bitfield_bit32_write(0, irq, true);
+  mmio_region_write32(pwrmgr->params.base_addr, PWRMGR_INTR_STATE_REG_OFFSET,
+                      reg_val);
+
+  return kDifPwrmgrOk;
+}
+
+dif_pwrmgr_result_t dif_pwrmgr_irq_get_enabled(const dif_pwrmgr_t *pwrmgr,
+                                               dif_pwrmgr_irq_t irq,
+                                               dif_pwrmgr_toggle_t *state) {
+  if (pwrmgr == NULL || !is_valid_irq(irq) || state == NULL) {
+    return kDifPwrmgrBadArg;
+  }
+
+  uint32_t reg_val = mmio_region_read32(pwrmgr->params.base_addr,
+                                        PWRMGR_INTR_ENABLE_REG_OFFSET);
+  *state = bool_to_toggle(bitfield_bit32_read(reg_val, irq));
+
+  return kDifPwrmgrOk;
+}
+
+dif_pwrmgr_result_t dif_pwrmgr_irq_set_enabled(const dif_pwrmgr_t *pwrmgr,
+                                               dif_pwrmgr_irq_t irq,
+                                               dif_pwrmgr_toggle_t state) {
+  if (pwrmgr == NULL || !is_valid_irq(irq)) {
+    return kDifPwrmgrBadArg;
+  }
+
+  bool enable = false;
+  if (!toggle_to_bool(state, &enable)) {
+    return kDifPwrmgrBadArg;
+  }
+
+  uint32_t reg_val = mmio_region_read32(pwrmgr->params.base_addr,
+                                        PWRMGR_INTR_ENABLE_REG_OFFSET);
+  reg_val = bitfield_bit32_write(reg_val, irq, enable);
+  mmio_region_write32(pwrmgr->params.base_addr, PWRMGR_INTR_ENABLE_REG_OFFSET,
+                      reg_val);
+
+  return kDifPwrmgrOk;
+}
+
+dif_pwrmgr_result_t dif_pwrmgr_irq_force(const dif_pwrmgr_t *pwrmgr,
+                                         dif_pwrmgr_irq_t irq) {
+  if (pwrmgr == NULL || !is_valid_irq(irq)) {
+    return kDifPwrmgrBadArg;
+  }
+
+  uint32_t reg_val = bitfield_bit32_write(0, irq, true);
+  mmio_region_write32(pwrmgr->params.base_addr, PWRMGR_INTR_TEST_REG_OFFSET,
+                      reg_val);
+
+  return kDifPwrmgrOk;
+}
+
+dif_pwrmgr_result_t dif_pwrmgr_irq_disable_all(
+    const dif_pwrmgr_t *pwrmgr, dif_pwrmgr_irq_snapshot_t *snapshot) {
+  if (pwrmgr == NULL) {
+    return kDifPwrmgrBadArg;
+  }
+
+  if (snapshot != NULL) {
+    *snapshot = mmio_region_read32(pwrmgr->params.base_addr,
+                                   PWRMGR_INTR_ENABLE_REG_OFFSET);
+  }
+  mmio_region_write32(pwrmgr->params.base_addr, PWRMGR_INTR_ENABLE_REG_OFFSET,
+                      0);
+
+  return kDifPwrmgrOk;
+}
+
+dif_pwrmgr_result_t dif_pwrmgr_irq_restore_all(
+    const dif_pwrmgr_t *pwrmgr, const dif_pwrmgr_irq_snapshot_t *snapshot) {
+  if (pwrmgr == NULL || snapshot == NULL) {
+    return kDifPwrmgrBadArg;
+  }
+
+  mmio_region_write32(pwrmgr->params.base_addr, PWRMGR_INTR_ENABLE_REG_OFFSET,
+                      *snapshot);
+  return kDifPwrmgrOk;
+}

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -159,16 +159,16 @@ sw_lib_dif_alert_handler = declare_dependency(
 )
 
 # Power Manager DIF library
-# sw_lib_dif_pwrmgr = declare_dependency(
-#   link_with: static_library(
-#     'sw_lib_dif_pwrmgr',
-#     sources: [
-#       hw_ip_pwrmgr_reg_h,
-#       'dif_pwrmgr.c',
-#     ],
-#     dependencies: [
-#       sw_lib_mmio,
-#       sw_lib_bitfield,
-#     ],
-#   )
-# )
+sw_lib_dif_pwrmgr = declare_dependency(
+  link_with: static_library(
+    'sw_lib_dif_pwrmgr',
+    sources: [
+      hw_ip_pwrmgr_reg_h,
+      'dif_pwrmgr.c',
+    ],
+    dependencies: [
+      sw_lib_mmio,
+      sw_lib_bitfield,
+    ],
+  )
+)

--- a/sw/device/tests/dif/dif_pwrmgr_unittest.cc
+++ b/sw/device/tests/dif/dif_pwrmgr_unittest.cc
@@ -1,0 +1,897 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/dif/dif_pwrmgr.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/testing/mock_mmio.h"
+
+#include "pwrmgr_regs.h"  // Generated
+
+namespace dif_pwrmgr_unittest {
+namespace {
+
+/**
+ * Returns a `uint32_t` with a single zero bit.
+ */
+uint32_t AllOnesExcept(uint32_t index) { return ~(1u << index); }
+
+/**
+ * Common constants used in tests.
+ */
+static constexpr std::array<dif_pwrmgr_toggle_t, 2> kAllToggles = {
+    kDifPwrmgrToggleEnabled, kDifPwrmgrToggleDisabled};
+static constexpr std::array<bool, 2> kAllBools = {true, false};
+static constexpr dif_pwrmgr_toggle_t kBadToggle =
+    static_cast<dif_pwrmgr_toggle_t>(kDifPwrmgrToggleDisabled + 1);
+static constexpr dif_pwrmgr_irq_t kBadIrq =
+    static_cast<dif_pwrmgr_irq_t>(kDifPwrmgrIrqLast + 1);
+static constexpr dif_pwrmgr_req_type_t kBadReqType =
+    static_cast<dif_pwrmgr_req_type_t>(kDifPwrmgrReqTypeReset + 1);
+static constexpr dif_pwrmgr_domain_config_t kBadConfig =
+    std::numeric_limits<uint8_t>::max();
+static constexpr dif_pwrmgr_request_sources_t kBadSources =
+    std::numeric_limits<uint32_t>::max();
+
+class DifPwrmgrTest : public testing::Test, public mock_mmio::MmioTest {
+ protected:
+  /**
+   * Parameters for initializing a `dif_pwrmgr_t`.
+   */
+  const dif_pwrmgr_params_t params_ = {.base_addr = dev().region()};
+};
+
+class InitTest : public DifPwrmgrTest {};
+
+TEST_F(InitTest, BadArgs) {
+  EXPECT_EQ(dif_pwrmgr_init(params_, nullptr), kDifPwrmgrBadArg);
+}
+
+TEST_F(InitTest, Init) {
+  dif_pwrmgr_t pwrmgr;
+  EXPECT_EQ(dif_pwrmgr_init(params_, &pwrmgr), kDifPwrmgrOk);
+}
+
+// Base class for the rest of the tests in this file, provides a
+// `dif_gpio_t` instance.
+class DifPwrmgrInitialized : public DifPwrmgrTest {
+ protected:
+  /**
+   * Expectations for functions that need to sync data to slow clock domain.
+   *
+   * Sync is triggered by writing a 1 to the CFG_CDC_SYNC register, which is
+   * reset back to 0 by the hardware when the operation is complete.
+   */
+  void ExpectSync() {
+    EXPECT_WRITE32(PWRMGR_CFG_CDC_SYNC_REG_OFFSET, 1);
+    // Insert a small random delay.
+    uint8_t rand_delay = dev().GarbageMemory<uint32_t>() & 0x7F;
+    for (uint8_t i = 0; i < rand_delay; ++i) {
+      EXPECT_READ32(PWRMGR_CFG_CDC_SYNC_REG_OFFSET, 1);
+    }
+    EXPECT_READ32(PWRMGR_CFG_CDC_SYNC_REG_OFFSET, 0);
+  }
+
+  /**
+   * Initialized `dif_pwrmgr_t` used in tests.
+   */
+  const dif_pwrmgr_t pwrmgr_ = {.params = params_};
+};
+
+class LowPowerTest : public DifPwrmgrInitialized {};
+
+TEST_F(LowPowerTest, SetBadArgs) {
+  EXPECT_EQ(dif_pwrmgr_low_power_set_enabled(nullptr, kDifPwrmgrToggleEnabled),
+            kDifPwrmgrConfigBadArg);
+  EXPECT_EQ(dif_pwrmgr_low_power_set_enabled(&pwrmgr_, kBadToggle),
+            kDifPwrmgrConfigBadArg);
+  EXPECT_EQ(dif_pwrmgr_low_power_set_enabled(nullptr, kBadToggle),
+            kDifPwrmgrConfigBadArg);
+}
+
+TEST_F(LowPowerTest, SetLocked) {
+  for (auto toggle : kAllToggles) {
+    EXPECT_READ32(PWRMGR_CTRL_CFG_REGWEN_REG_OFFSET,
+                  AllOnesExcept(PWRMGR_CTRL_CFG_REGWEN_EN));
+
+    EXPECT_EQ(dif_pwrmgr_low_power_set_enabled(&pwrmgr_, toggle),
+              kDifPwrMgrConfigLocked);
+  }
+}
+
+TEST_F(LowPowerTest, Set) {
+  for (auto toggle : kAllToggles) {
+    EXPECT_READ32(PWRMGR_CTRL_CFG_REGWEN_REG_OFFSET,
+                  {{
+                      .offset = PWRMGR_CTRL_CFG_REGWEN_EN,
+                      .value = 1,
+                  }});
+    EXPECT_MASK32(PWRMGR_CONTROL_REG_OFFSET,
+                  {{
+                      .offset = PWRMGR_CONTROL_LOW_POWER_HINT,
+                      .mask = 1,
+                      .value = (toggle == kDifPwrmgrToggleEnabled),
+                  }});
+    ExpectSync();
+
+    EXPECT_EQ(dif_pwrmgr_low_power_set_enabled(&pwrmgr_, toggle),
+              kDifPwrmgrConfigOk);
+  }
+}
+
+TEST_F(LowPowerTest, GetBadArgs) {
+  dif_pwrmgr_toggle_t state;
+
+  EXPECT_EQ(dif_pwrmgr_low_power_get_enabled(nullptr, &state),
+            kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_low_power_get_enabled(&pwrmgr_, nullptr),
+            kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_low_power_get_enabled(nullptr, nullptr),
+            kDifPwrmgrBadArg);
+}
+
+TEST_F(LowPowerTest, Get) {
+  for (auto toggle : kAllToggles) {
+    dif_pwrmgr_toggle_t state;
+
+    EXPECT_READ32(PWRMGR_CONTROL_REG_OFFSET,
+                  {{
+                      .offset = PWRMGR_CONTROL_LOW_POWER_HINT,
+                      .value = (toggle == kDifPwrmgrToggleEnabled),
+                  }});
+
+    EXPECT_EQ(dif_pwrmgr_low_power_get_enabled(&pwrmgr_, &state), kDifPwrmgrOk);
+    EXPECT_EQ(state, toggle);
+  }
+}
+
+class DomainConfig : public DifPwrmgrInitialized {
+ protected:
+  /**
+   * Constants used in set and get tests.
+   */
+  static constexpr bitfield_field32_t kConfigBitfield{
+      .mask = kDifPwrmgrDomainOptionCoreClockInLowPower |
+              kDifPwrmgrDomainOptionIoClockInLowPower |
+              kDifPwrmgrDomainOptionUsbClockInLowPower |
+              kDifPwrmgrDomainOptionUsbClockInActivePower |
+              kDifPwrmgrDomainOptionMainPowerInLowPower,
+      .index = PWRMGR_CONTROL_CORE_CLK_EN,
+  };
+  static constexpr std::array<dif_pwrmgr_domain_config_t, 4> kConfigs = {
+      // All disabled.
+      0,
+      // All enabled.
+      kDifPwrmgrDomainOptionCoreClockInLowPower |
+          kDifPwrmgrDomainOptionIoClockInLowPower |
+          kDifPwrmgrDomainOptionUsbClockInLowPower |
+          kDifPwrmgrDomainOptionUsbClockInActivePower |
+          kDifPwrmgrDomainOptionMainPowerInLowPower,
+      // Some enabled.
+      kDifPwrmgrDomainOptionCoreClockInLowPower |
+          kDifPwrmgrDomainOptionUsbClockInLowPower |
+          kDifPwrmgrDomainOptionMainPowerInLowPower,
+      // Some enabled.
+      kDifPwrmgrDomainOptionIoClockInLowPower |
+          kDifPwrmgrDomainOptionUsbClockInActivePower,
+  };
+};
+// We need this definition for the `for` loops.
+constexpr std::array<dif_pwrmgr_domain_config_t, 4> DomainConfig::kConfigs;
+
+TEST_F(DomainConfig, SetBadArgs) {
+  EXPECT_EQ(dif_pwrmgr_set_domain_config(nullptr, 0), kDifPwrmgrConfigBadArg);
+  EXPECT_EQ(dif_pwrmgr_set_domain_config(&pwrmgr_, kBadConfig),
+            kDifPwrmgrConfigBadArg);
+  EXPECT_EQ(dif_pwrmgr_set_domain_config(nullptr, kBadConfig),
+            kDifPwrmgrConfigBadArg);
+}
+
+TEST_F(DomainConfig, SetLocked) {
+  EXPECT_READ32(PWRMGR_CTRL_CFG_REGWEN_REG_OFFSET,
+                AllOnesExcept(PWRMGR_WAKEUP_EN_REGWEN_EN));
+
+  EXPECT_EQ(dif_pwrmgr_set_domain_config(&pwrmgr_, 0), kDifPwrMgrConfigLocked);
+}
+
+TEST_F(DomainConfig, Set) {
+  for (auto config : kConfigs) {
+    EXPECT_READ32(PWRMGR_CTRL_CFG_REGWEN_REG_OFFSET,
+                  {{
+                      .offset = PWRMGR_CTRL_CFG_REGWEN_EN,
+                      .value = 1,
+                  }});
+    EXPECT_MASK32(PWRMGR_CONTROL_REG_OFFSET,
+                  {{
+                      .offset = kConfigBitfield.index,
+                      .mask = kConfigBitfield.mask,
+                      .value = config,
+                  }});
+    ExpectSync();
+
+    EXPECT_EQ(dif_pwrmgr_set_domain_config(&pwrmgr_, config), kDifPwrmgrOk);
+  }
+}
+
+TEST_F(DomainConfig, GetBadArgs) {
+  dif_pwrmgr_domain_config_t config;
+  EXPECT_EQ(dif_pwrmgr_get_domain_config(nullptr, &config),
+            kDifPwrmgrConfigBadArg);
+  EXPECT_EQ(dif_pwrmgr_get_domain_config(&pwrmgr_, nullptr),
+            kDifPwrmgrConfigBadArg);
+  EXPECT_EQ(dif_pwrmgr_get_domain_config(nullptr, nullptr),
+            kDifPwrmgrConfigBadArg);
+}
+
+TEST_F(DomainConfig, Get) {
+  for (auto exp_config : kConfigs) {
+    EXPECT_READ32(PWRMGR_CONTROL_REG_OFFSET,
+                  {{
+                      .offset = kConfigBitfield.index,
+                      .value = exp_config,
+                  }});
+
+    dif_pwrmgr_domain_config_t act_config;
+    EXPECT_EQ(dif_pwrmgr_get_domain_config(&pwrmgr_, &act_config),
+              kDifPwrmgrOk);
+    EXPECT_EQ(act_config, exp_config);
+  }
+}
+
+class RequestSources : public DifPwrmgrInitialized {
+ protected:
+  /**
+   * Constants used in set and get tests.
+   */
+  static constexpr std::array<dif_pwrmgr_request_sources_t, 2> kWakeupSources =
+      {
+          // No sources.
+          0,
+          // All sources.
+          kDifPwrmgrWakeupRequestSourceOne,
+      };
+  static constexpr std::array<dif_pwrmgr_request_sources_t, 2> kResetSources = {
+      // No sources.
+      0,
+      // All sources.
+      kDifPwrmgrResetRequestSourceOne,
+  };
+};
+// We need these definitions for the `for` loops.
+constexpr std::array<dif_pwrmgr_request_sources_t, 2>
+    RequestSources::kWakeupSources;
+constexpr std::array<dif_pwrmgr_request_sources_t, 2>
+    RequestSources::kResetSources;
+
+TEST_F(RequestSources, SetBadArgs) {
+  EXPECT_EQ(dif_pwrmgr_set_request_sources(nullptr, kDifPwrmgrReqTypeWakeup,
+                                           kDifPwrmgrWakeupRequestSourceOne),
+            kDifPwrmgrConfigBadArg);
+  EXPECT_EQ(dif_pwrmgr_set_request_sources(&pwrmgr_, kBadReqType,
+                                           kDifPwrmgrWakeupRequestSourceOne),
+            kDifPwrmgrConfigBadArg);
+  EXPECT_EQ(dif_pwrmgr_set_request_sources(&pwrmgr_, kDifPwrmgrReqTypeWakeup,
+                                           kBadSources),
+            kDifPwrmgrConfigBadArg);
+  EXPECT_EQ(dif_pwrmgr_set_request_sources(nullptr, kBadReqType,
+                                           kDifPwrmgrWakeupRequestSourceOne),
+            kDifPwrmgrConfigBadArg);
+  EXPECT_EQ(dif_pwrmgr_set_request_sources(nullptr, kDifPwrmgrReqTypeWakeup,
+                                           kBadSources),
+            kDifPwrmgrConfigBadArg);
+  EXPECT_EQ(dif_pwrmgr_set_request_sources(&pwrmgr_, kBadReqType, kBadSources),
+            kDifPwrmgrConfigBadArg);
+  EXPECT_EQ(dif_pwrmgr_set_request_sources(nullptr, kBadReqType, kBadSources),
+            kDifPwrmgrConfigBadArg);
+}
+
+TEST_F(RequestSources, SetWakeupLocked) {
+  EXPECT_READ32(PWRMGR_WAKEUP_EN_REGWEN_REG_OFFSET,
+                AllOnesExcept(PWRMGR_WAKEUP_EN_REGWEN_EN));
+
+  EXPECT_EQ(dif_pwrmgr_set_request_sources(&pwrmgr_, kDifPwrmgrReqTypeWakeup,
+                                           kDifPwrmgrWakeupRequestSourceOne),
+            kDifPwrMgrConfigLocked);
+}
+
+TEST_F(RequestSources, SetResetLocked) {
+  EXPECT_READ32(PWRMGR_RESET_EN_REGWEN_REG_OFFSET,
+                AllOnesExcept(PWRMGR_RESET_EN_REGWEN_EN));
+
+  EXPECT_EQ(dif_pwrmgr_set_request_sources(&pwrmgr_, kDifPwrmgrReqTypeReset,
+                                           kDifPwrmgrResetRequestSourceOne),
+            kDifPwrMgrConfigLocked);
+}
+
+TEST_F(RequestSources, SetWakeup) {
+  EXPECT_READ32(PWRMGR_WAKEUP_EN_REGWEN_REG_OFFSET,
+                {{
+                    .offset = PWRMGR_WAKEUP_EN_REGWEN_EN,
+                    .value = 1,
+                }});
+  EXPECT_WRITE32(PWRMGR_WAKEUP_EN_REG_OFFSET, kDifPwrmgrWakeupRequestSourceOne);
+  ExpectSync();
+
+  EXPECT_EQ(dif_pwrmgr_set_request_sources(&pwrmgr_, kDifPwrmgrReqTypeWakeup,
+                                           kDifPwrmgrWakeupRequestSourceOne),
+            kDifPwrmgrConfigOk);
+}
+
+TEST_F(RequestSources, SetReset) {
+  EXPECT_READ32(PWRMGR_RESET_EN_REGWEN_REG_OFFSET,
+                {{
+                    .offset = PWRMGR_RESET_EN_REGWEN_EN,
+                    .value = 1,
+                }});
+  EXPECT_WRITE32(PWRMGR_RESET_EN_REG_OFFSET, kDifPwrmgrResetRequestSourceOne);
+  ExpectSync();
+
+  EXPECT_EQ(dif_pwrmgr_set_request_sources(&pwrmgr_, kDifPwrmgrReqTypeReset,
+                                           kDifPwrmgrResetRequestSourceOne),
+            kDifPwrmgrConfigOk);
+}
+
+TEST_F(RequestSources, GetBadArgs) {
+  dif_pwrmgr_request_sources_t sources;
+
+  EXPECT_EQ(dif_pwrmgr_get_request_sources(nullptr, kDifPwrmgrReqTypeWakeup,
+                                           &sources),
+            kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_get_request_sources(&pwrmgr_, kBadReqType, &sources),
+            kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_get_request_sources(&pwrmgr_, kDifPwrmgrReqTypeWakeup,
+                                           nullptr),
+            kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_get_request_sources(nullptr, kBadReqType, &sources),
+            kDifPwrmgrBadArg);
+  EXPECT_EQ(
+      dif_pwrmgr_get_request_sources(nullptr, kDifPwrmgrReqTypeWakeup, nullptr),
+      kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_get_request_sources(&pwrmgr_, kBadReqType, nullptr),
+            kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_get_request_sources(nullptr, kBadReqType, nullptr),
+            kDifPwrmgrBadArg);
+}
+
+TEST_F(RequestSources, GetWakeup) {
+  for (auto exp_sources : kWakeupSources) {
+    EXPECT_READ32(PWRMGR_WAKEUP_EN_REG_OFFSET, exp_sources);
+
+    dif_pwrmgr_request_sources_t act_sources = 0;
+    EXPECT_EQ(dif_pwrmgr_get_request_sources(&pwrmgr_, kDifPwrmgrReqTypeWakeup,
+                                             &act_sources),
+              kDifPwrmgrOk);
+    EXPECT_EQ(act_sources, exp_sources);
+  }
+}
+
+TEST_F(RequestSources, GetReset) {
+  for (auto exp_sources : kResetSources) {
+    EXPECT_READ32(PWRMGR_RESET_EN_REG_OFFSET, exp_sources);
+
+    dif_pwrmgr_request_sources_t act_sources = 0;
+    EXPECT_EQ(dif_pwrmgr_get_request_sources(&pwrmgr_, kDifPwrmgrReqTypeReset,
+                                             &act_sources),
+              kDifPwrmgrOk);
+    EXPECT_EQ(act_sources, exp_sources);
+  }
+}
+
+TEST_F(RequestSources, GetCurrentBadArgs) {
+  dif_pwrmgr_request_sources_t sources;
+
+  EXPECT_EQ(dif_pwrmgr_get_current_request_sources(
+                nullptr, kDifPwrmgrReqTypeWakeup, &sources),
+            kDifPwrmgrBadArg);
+  EXPECT_EQ(
+      dif_pwrmgr_get_current_request_sources(&pwrmgr_, kBadReqType, &sources),
+      kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_get_current_request_sources(
+                &pwrmgr_, kDifPwrmgrReqTypeWakeup, nullptr),
+            kDifPwrmgrBadArg);
+  EXPECT_EQ(
+      dif_pwrmgr_get_current_request_sources(nullptr, kBadReqType, &sources),
+      kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_get_current_request_sources(
+                nullptr, kDifPwrmgrReqTypeWakeup, nullptr),
+            kDifPwrmgrBadArg);
+  EXPECT_EQ(
+      dif_pwrmgr_get_current_request_sources(&pwrmgr_, kBadReqType, nullptr),
+      kDifPwrmgrBadArg);
+  EXPECT_EQ(
+      dif_pwrmgr_get_current_request_sources(nullptr, kBadReqType, nullptr),
+      kDifPwrmgrBadArg);
+}
+
+TEST_F(RequestSources, GetCurrentWakeup) {
+  for (auto exp_sources : kWakeupSources) {
+    EXPECT_READ32(PWRMGR_WAKE_STATUS_REG_OFFSET, exp_sources);
+
+    dif_pwrmgr_request_sources_t act_sources = 0;
+    EXPECT_EQ(dif_pwrmgr_get_current_request_sources(
+                  &pwrmgr_, kDifPwrmgrReqTypeWakeup, &act_sources),
+              kDifPwrmgrOk);
+    EXPECT_EQ(act_sources, exp_sources);
+  }
+}
+
+TEST_F(RequestSources, GetCurrentReset) {
+  for (auto exp_sources : kResetSources) {
+    EXPECT_READ32(PWRMGR_RESET_STATUS_REG_OFFSET, exp_sources);
+
+    dif_pwrmgr_request_sources_t act_sources = 0;
+    EXPECT_EQ(dif_pwrmgr_get_current_request_sources(
+                  &pwrmgr_, kDifPwrmgrReqTypeReset, &act_sources),
+              kDifPwrmgrOk);
+    EXPECT_EQ(act_sources, exp_sources);
+  }
+}
+
+TEST_F(RequestSources, LockBadArgs) {
+  EXPECT_EQ(dif_pwrmgr_request_sources_lock(nullptr, kDifPwrmgrReqTypeWakeup),
+            kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_request_sources_lock(&pwrmgr_, kBadReqType),
+            kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_request_sources_lock(nullptr, kBadReqType),
+            kDifPwrmgrBadArg);
+}
+
+TEST_F(RequestSources, LockWakeup) {
+  EXPECT_WRITE32(PWRMGR_WAKEUP_EN_REGWEN_REG_OFFSET, 0);
+
+  EXPECT_EQ(dif_pwrmgr_request_sources_lock(&pwrmgr_, kDifPwrmgrReqTypeWakeup),
+            kDifPwrmgrOk);
+}
+
+TEST_F(RequestSources, LockReset) {
+  EXPECT_WRITE32(PWRMGR_RESET_EN_REGWEN_REG_OFFSET, 0);
+
+  EXPECT_EQ(dif_pwrmgr_request_sources_lock(&pwrmgr_, kDifPwrmgrReqTypeReset),
+            kDifPwrmgrOk);
+}
+
+TEST_F(RequestSources, IsLockedBadArgs) {
+  bool is_locked;
+
+  EXPECT_EQ(dif_pwrmgr_request_sources_is_locked(
+                nullptr, kDifPwrmgrReqTypeWakeup, &is_locked),
+            kDifPwrmgrBadArg);
+  EXPECT_EQ(
+      dif_pwrmgr_request_sources_is_locked(&pwrmgr_, kBadReqType, &is_locked),
+      kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_request_sources_is_locked(
+                &pwrmgr_, kDifPwrmgrReqTypeWakeup, nullptr),
+            kDifPwrmgrBadArg);
+  EXPECT_EQ(
+      dif_pwrmgr_request_sources_is_locked(nullptr, kBadReqType, &is_locked),
+      kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_request_sources_is_locked(
+                nullptr, kDifPwrmgrReqTypeWakeup, nullptr),
+            kDifPwrmgrBadArg);
+  EXPECT_EQ(
+      dif_pwrmgr_request_sources_is_locked(&pwrmgr_, kBadReqType, nullptr),
+      kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_request_sources_is_locked(nullptr, kBadReqType, nullptr),
+            kDifPwrmgrBadArg);
+}
+
+TEST_F(RequestSources, IsLockedWakeup) {
+  for (auto exp_val : kAllBools) {
+    EXPECT_READ32(PWRMGR_WAKEUP_EN_REGWEN_REG_OFFSET,
+                  {{
+                      .offset = PWRMGR_WAKEUP_EN_REGWEN_EN,
+                      .value = !exp_val,
+                  }});
+
+    bool is_locked = !exp_val;
+    EXPECT_EQ(dif_pwrmgr_request_sources_is_locked(
+                  &pwrmgr_, kDifPwrmgrReqTypeWakeup, &is_locked),
+              kDifPwrmgrOk);
+    EXPECT_EQ(is_locked, exp_val);
+  }
+}
+
+TEST_F(RequestSources, IsLockedReset) {
+  for (auto exp_val : kAllBools) {
+    EXPECT_READ32(PWRMGR_RESET_EN_REGWEN_REG_OFFSET,
+                  {{
+                      .offset = PWRMGR_RESET_EN_REGWEN_EN,
+                      .value = !exp_val,
+                  }});
+
+    bool is_locked = !exp_val;
+    EXPECT_EQ(dif_pwrmgr_request_sources_is_locked(
+                  &pwrmgr_, kDifPwrmgrReqTypeReset, &is_locked),
+              kDifPwrmgrOk);
+    EXPECT_EQ(is_locked, exp_val);
+  }
+}
+
+class WakeupRecording : public DifPwrmgrInitialized {};
+
+TEST_F(WakeupRecording, SetEnabledBadArgs) {
+  EXPECT_EQ(dif_pwrmgr_wakeup_request_recording_set_enabled(
+                nullptr, kDifPwrmgrToggleEnabled),
+            kDifPwrmgrBadArg);
+  EXPECT_EQ(
+      dif_pwrmgr_wakeup_request_recording_set_enabled(&pwrmgr_, kBadToggle),
+      kDifPwrmgrBadArg);
+  EXPECT_EQ(
+      dif_pwrmgr_wakeup_request_recording_set_enabled(nullptr, kBadToggle),
+      kDifPwrmgrBadArg);
+}
+
+TEST_F(WakeupRecording, SetEnabled) {
+  for (auto new_state : kAllToggles) {
+    EXPECT_WRITE32(PWRMGR_WAKE_INFO_CAPTURE_DIS_REG_OFFSET,
+                   {{
+                       .offset = PWRMGR_WAKE_INFO_CAPTURE_DIS_VAL,
+                       .value = (new_state == kDifPwrmgrToggleDisabled),
+                   }});
+
+    EXPECT_EQ(
+        dif_pwrmgr_wakeup_request_recording_set_enabled(&pwrmgr_, new_state),
+        kDifPwrmgrOk);
+  }
+}
+
+TEST_F(WakeupRecording, GetEnabledBadArgs) {
+  dif_pwrmgr_toggle_t is_enabled;
+
+  EXPECT_EQ(
+      dif_pwrmgr_wakeup_request_recording_get_enabled(nullptr, &is_enabled),
+      kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_wakeup_request_recording_get_enabled(&pwrmgr_, nullptr),
+            kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_wakeup_request_recording_get_enabled(nullptr, nullptr),
+            kDifPwrmgrBadArg);
+}
+
+TEST_F(WakeupRecording, GetEnabled) {
+  for (auto exp_val : kAllToggles) {
+    EXPECT_READ32(PWRMGR_WAKE_INFO_CAPTURE_DIS_REG_OFFSET,
+                  {{
+                      .offset = PWRMGR_WAKE_INFO_CAPTURE_DIS_VAL,
+                      .value = (exp_val == kDifPwrmgrToggleDisabled),
+                  }});
+
+    dif_pwrmgr_toggle_t is_enabled = (exp_val == kDifPwrmgrToggleEnabled)
+                                         ? kDifPwrmgrToggleDisabled
+                                         : kDifPwrmgrToggleEnabled;
+    EXPECT_EQ(
+        dif_pwrmgr_wakeup_request_recording_get_enabled(&pwrmgr_, &is_enabled),
+        kDifPwrmgrOk);
+    EXPECT_EQ(is_enabled, exp_val);
+  }
+}
+
+TEST_F(WakeupRecording, GetReasonBadArgs) {
+  dif_pwrmgr_wakeup_reason_t wakeup_reason;
+
+  EXPECT_EQ(dif_pwrmgr_wakeup_reason_get(nullptr, &wakeup_reason),
+            kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_wakeup_reason_get(&pwrmgr_, nullptr), kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_wakeup_reason_get(nullptr, nullptr), kDifPwrmgrBadArg);
+}
+
+/**
+ * Custom equality matcher for `dif_pwrmgr_wakeup_reason_t`s.
+ */
+testing::Matcher<dif_pwrmgr_wakeup_reason_t> Eq(
+    const dif_pwrmgr_wakeup_reason_t &rhs) {
+  return testing::AllOf(
+      testing::Field("types", &dif_pwrmgr_wakeup_reason_t::types, rhs.types),
+      testing::Field("request_sources",
+                     &dif_pwrmgr_wakeup_reason_t::request_sources,
+                     rhs.request_sources));
+}
+
+TEST_F(WakeupRecording, GetReason) {
+  struct TestCase {
+    /**
+     * Value that will be read from hardware.
+     */
+    std::initializer_list<mock_mmio::BitField> read_val;
+    /**
+     * Expected output.
+     */
+    dif_pwrmgr_wakeup_reason_t exp_output;
+  };
+
+  std::array<TestCase, 5> test_cases = {{
+      // No bits set.
+      {
+          .read_val = {{
+              .offset = 0,
+              .value = 0,
+          }},
+          .exp_output =
+              {
+                  .types = 0,
+                  .request_sources = 0,
+              },
+      },
+      // All bits set.
+      {
+          .read_val = {{
+                           .offset = PWRMGR_WAKE_INFO_ABORT,
+                           .value = 1,
+                       },
+                       {
+                           .offset = PWRMGR_WAKE_INFO_FALL_THROUGH,
+                           .value = 1,
+                       },
+                       {
+                           .offset = PWRMGR_WAKE_INFO_REASONS,
+                           .value = 1,
+                       }},
+          .exp_output =
+              {
+                  .types = kDifPwrmgrWakeupTypeAbort |
+                           kDifPwrmgrWakeupTypeFallThrough |
+                           kDifPwrmgrWakeupTypeRequest,
+                  .request_sources = kDifPwrmgrWakeupRequestSourceOne,
+              },
+      },
+      // Only abort.
+      {
+          .read_val = {{
+              .offset = PWRMGR_WAKE_INFO_ABORT,
+              .value = 1,
+          }},
+          .exp_output =
+              {
+                  .types = kDifPwrmgrWakeupTypeAbort,
+                  .request_sources = 0,
+              },
+      },
+      // Only fall-through.
+      {
+          .read_val = {{
+              .offset = PWRMGR_WAKE_INFO_FALL_THROUGH,
+              .value = 1,
+          }},
+          .exp_output =
+              {
+                  .types = kDifPwrmgrWakeupTypeFallThrough,
+                  .request_sources = 0,
+              },
+      },
+      // Only requests from peripherals.
+      {
+          .read_val = {{
+              .offset = PWRMGR_WAKE_INFO_REASONS,
+              .value = 1,
+          }},
+          .exp_output =
+              {
+                  .types = kDifPwrmgrWakeupTypeRequest,
+                  .request_sources = kDifPwrmgrWakeupRequestSourceOne,
+              },
+      },
+  }};
+
+  for (const auto &test_case : test_cases) {
+    EXPECT_READ32(PWRMGR_WAKE_INFO_REG_OFFSET, test_case.read_val);
+
+    dif_pwrmgr_wakeup_reason_t wakeup_reason;
+    EXPECT_EQ(dif_pwrmgr_wakeup_reason_get(&pwrmgr_, &wakeup_reason),
+              kDifPwrmgrOk);
+    EXPECT_THAT(wakeup_reason, Eq(test_case.exp_output));
+  }
+}
+
+TEST_F(WakeupRecording, ClearReasonBadArgs) {
+  EXPECT_EQ(dif_pwrmgr_wakeup_reason_clear(nullptr), kDifPwrmgrBadArg);
+}
+
+TEST_F(WakeupRecording, ClearReason) {
+  EXPECT_WRITE32(PWRMGR_WAKE_INFO_REG_OFFSET,
+                 std::numeric_limits<uint32_t>::max());
+
+  EXPECT_EQ(dif_pwrmgr_wakeup_reason_clear(&pwrmgr_), kDifPwrmgrOk);
+}
+
+class IrqTest : public DifPwrmgrInitialized {};
+
+TEST_F(IrqTest, IsPendingBadArgs) {
+  bool is_pending;
+
+  EXPECT_EQ(
+      dif_pwrmgr_irq_is_pending(nullptr, kDifPwrmgrIrqWakeup, &is_pending),
+      kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_irq_is_pending(&pwrmgr_, kBadIrq, &is_pending),
+            kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_irq_is_pending(&pwrmgr_, kDifPwrmgrIrqWakeup, nullptr),
+            kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_irq_is_pending(nullptr, kBadIrq, &is_pending),
+            kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_irq_is_pending(nullptr, kDifPwrmgrIrqWakeup, nullptr),
+            kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_irq_is_pending(&pwrmgr_, kBadIrq, nullptr),
+            kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_irq_is_pending(nullptr, kBadIrq, nullptr),
+            kDifPwrmgrBadArg);
+}
+
+TEST_F(IrqTest, IsPending) {
+  for (std::underlying_type<dif_pwrmgr_irq_t>::type irq = 0;
+       irq <= kDifPwrmgrIrqLast; ++irq) {
+    for (auto exp_val : kAllBools) {
+      EXPECT_READ32(PWRMGR_INTR_STATE_REG_OFFSET, {{
+                                                      .offset = irq,
+                                                      .value = exp_val,
+                                                  }});
+
+      bool is_pending = !exp_val;
+      EXPECT_EQ(dif_pwrmgr_irq_is_pending(
+                    &pwrmgr_, static_cast<dif_pwrmgr_irq_t>(irq), &is_pending),
+                kDifPwrmgrOk);
+      EXPECT_EQ(is_pending, exp_val);
+    }
+  }
+}
+
+TEST_F(IrqTest, AckBadArgs) {
+  EXPECT_EQ(dif_pwrmgr_irq_acknowledge(nullptr, kDifPwrmgrIrqWakeup),
+            kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_irq_acknowledge(&pwrmgr_, kBadIrq), kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_irq_acknowledge(nullptr, kBadIrq), kDifPwrmgrBadArg);
+}
+
+TEST_F(IrqTest, Ack) {
+  for (std::underlying_type<dif_pwrmgr_irq_t>::type irq = 0;
+       irq <= kDifPwrmgrIrqLast; ++irq) {
+    EXPECT_WRITE32(PWRMGR_INTR_STATE_REG_OFFSET, (1u << irq));
+
+    EXPECT_EQ(dif_pwrmgr_irq_acknowledge(&pwrmgr_,
+                                         static_cast<dif_pwrmgr_irq_t>(irq)),
+              kDifPwrmgrOk);
+  }
+}
+
+TEST_F(IrqTest, GetEnabledBadArgs) {
+  dif_pwrmgr_toggle_t is_enabled;
+
+  EXPECT_EQ(
+      dif_pwrmgr_irq_get_enabled(nullptr, kDifPwrmgrIrqWakeup, &is_enabled),
+      kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_irq_get_enabled(&pwrmgr_, kBadIrq, &is_enabled),
+            kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_irq_get_enabled(&pwrmgr_, kDifPwrmgrIrqWakeup, nullptr),
+            kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_irq_get_enabled(nullptr, kBadIrq, &is_enabled),
+            kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_irq_get_enabled(nullptr, kDifPwrmgrIrqWakeup, nullptr),
+            kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_irq_get_enabled(&pwrmgr_, kBadIrq, nullptr),
+            kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_irq_get_enabled(nullptr, kBadIrq, nullptr),
+            kDifPwrmgrBadArg);
+}
+
+TEST_F(IrqTest, GetEnabled) {
+  for (std::underlying_type<dif_pwrmgr_irq_t>::type irq = 0;
+       irq <= kDifPwrmgrIrqLast; ++irq) {
+    for (auto exp_val : kAllToggles) {
+      EXPECT_READ32(PWRMGR_INTR_ENABLE_REG_OFFSET,
+                    {{
+                        .offset = irq,
+                        .value = (exp_val == kDifPwrmgrToggleEnabled),
+                    }});
+
+      dif_pwrmgr_toggle_t is_enabled = (exp_val == kDifPwrmgrToggleEnabled)
+                                           ? kDifPwrmgrToggleDisabled
+                                           : kDifPwrmgrToggleEnabled;
+      EXPECT_EQ(dif_pwrmgr_irq_get_enabled(
+                    &pwrmgr_, static_cast<dif_pwrmgr_irq_t>(irq), &is_enabled),
+                kDifPwrmgrOk);
+      EXPECT_EQ(is_enabled, exp_val);
+    }
+  }
+}
+
+TEST_F(IrqTest, SetEnabledBadArgs) {
+  EXPECT_EQ(dif_pwrmgr_irq_set_enabled(nullptr, kDifPwrmgrIrqWakeup,
+                                       kDifPwrmgrToggleEnabled),
+            kDifPwrmgrBadArg);
+  EXPECT_EQ(
+      dif_pwrmgr_irq_set_enabled(&pwrmgr_, kBadIrq, kDifPwrmgrToggleEnabled),
+      kDifPwrmgrBadArg);
+  EXPECT_EQ(
+      dif_pwrmgr_irq_set_enabled(&pwrmgr_, kDifPwrmgrIrqWakeup, kBadToggle),
+      kDifPwrmgrBadArg);
+  EXPECT_EQ(
+      dif_pwrmgr_irq_set_enabled(nullptr, kBadIrq, kDifPwrmgrToggleEnabled),
+      kDifPwrmgrBadArg);
+  EXPECT_EQ(
+      dif_pwrmgr_irq_set_enabled(nullptr, kDifPwrmgrIrqWakeup, kBadToggle),
+      kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_irq_set_enabled(&pwrmgr_, kBadIrq, kBadToggle),
+            kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_irq_set_enabled(nullptr, kBadIrq, kBadToggle),
+            kDifPwrmgrBadArg);
+}
+
+TEST_F(IrqTest, SetEnabled) {
+  for (std::underlying_type<dif_pwrmgr_irq_t>::type irq = 0;
+       irq <= kDifPwrmgrIrqLast; ++irq) {
+    for (auto new_state : kAllToggles) {
+      EXPECT_MASK32(PWRMGR_INTR_ENABLE_REG_OFFSET,
+                    {{
+                        .offset = irq,
+                        .mask = 1,
+                        .value = (new_state == kDifPwrmgrToggleEnabled),
+                    }});
+
+      EXPECT_EQ(dif_pwrmgr_irq_set_enabled(
+                    &pwrmgr_, static_cast<dif_pwrmgr_irq_t>(irq), new_state),
+                kDifPwrmgrOk);
+    }
+  }
+}
+
+TEST_F(IrqTest, ForceBadArgs) {
+  EXPECT_EQ(dif_pwrmgr_irq_force(nullptr, kDifPwrmgrIrqWakeup),
+            kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_irq_force(&pwrmgr_, kBadIrq), kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_irq_force(nullptr, kBadIrq), kDifPwrmgrBadArg);
+}
+
+TEST_F(IrqTest, Force) {
+  for (std::underlying_type<dif_pwrmgr_irq_t>::type irq = 0;
+       irq <= kDifPwrmgrIrqLast; ++irq) {
+    EXPECT_WRITE32(PWRMGR_INTR_TEST_REG_OFFSET, {{
+                                                    .offset = irq,
+                                                    .value = 1,
+                                                }});
+
+    EXPECT_EQ(
+        dif_pwrmgr_irq_force(&pwrmgr_, static_cast<dif_pwrmgr_irq_t>(irq)),
+        kDifPwrmgrOk);
+  }
+}
+
+TEST_F(IrqTest, DisableAllBadArgs) {
+  dif_pwrmgr_irq_snapshot_t snapshot;
+
+  // `snapshot` is optional.
+  EXPECT_EQ(dif_pwrmgr_irq_disable_all(nullptr, &snapshot), kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_irq_disable_all(nullptr, nullptr), kDifPwrmgrBadArg);
+}
+TEST_F(IrqTest, DisableAll) {
+  uint32_t exp_snapshot = 0xA5A5A5A5;
+
+  // With `snapshot`.
+  EXPECT_READ32(PWRMGR_INTR_ENABLE_REG_OFFSET, exp_snapshot);
+  EXPECT_WRITE32(PWRMGR_INTR_ENABLE_REG_OFFSET, 0);
+
+  dif_pwrmgr_irq_snapshot_t act_snapshot = 0;
+  EXPECT_EQ(dif_pwrmgr_irq_disable_all(&pwrmgr_, &act_snapshot), kDifPwrmgrOk);
+  EXPECT_EQ(act_snapshot, exp_snapshot);
+
+  // Without `snapshot`.
+  EXPECT_WRITE32(PWRMGR_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_pwrmgr_irq_disable_all(&pwrmgr_, nullptr), kDifPwrmgrOk);
+}
+
+TEST_F(IrqTest, RestoreAllBadArgs) {
+  dif_pwrmgr_irq_snapshot_t snapshot;
+
+  EXPECT_EQ(dif_pwrmgr_irq_restore_all(nullptr, &snapshot), kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_irq_restore_all(&pwrmgr_, nullptr), kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_irq_restore_all(nullptr, nullptr), kDifPwrmgrBadArg);
+}
+
+TEST_F(IrqTest, RestoreAll) {
+  dif_pwrmgr_irq_snapshot_t snapshot = 0xA5A5A5A5;
+
+  EXPECT_WRITE32(PWRMGR_INTR_ENABLE_REG_OFFSET, snapshot);
+
+  EXPECT_EQ(dif_pwrmgr_irq_restore_all(&pwrmgr_, &snapshot), kDifPwrmgrOk);
+}
+
+}  // namespace
+}  // namespace dif_pwrmgr_unittest

--- a/sw/device/tests/dif/meson.build
+++ b/sw/device/tests/dif/meson.build
@@ -114,6 +114,22 @@ test('dif_otbn_unittest', executable(
   cpp_args: ['-DMOCK_MMIO'],
 ))
 
+test('dif_pwrmgr_unittest', executable(
+  'dif_pwrmgr_unittest',
+  sources: [
+    hw_ip_pwrmgr_reg_h,
+    meson.source_root() / 'sw/device/lib/dif/dif_pwrmgr.c',
+    'dif_pwrmgr_unittest.cc',
+  ],
+  dependencies: [
+    sw_vendor_gtest,
+    sw_lib_testing_mock_mmio,
+  ],
+  native: true,
+  c_args: ['-DMOCK_MMIO'],
+  cpp_args: ['-DMOCK_MMIO'],
+))
+
 dif_plic_sanitytest_lib = declare_dependency(
   link_with: static_library(
     'dif_plic_sanitytest_lib',


### PR DESCRIPTION
This PR adds implementation of power manager DIF library along with unit tests and includes the following commits:

- [sw/dif_pwrmgr] Update Power Manager DIF library header
- [sw/dif_pwrmgr] Implement Power Manager DIF library
- [sw/dif_pwrmgr] Add unit tests for Power Manager DIF library

Please note that sources for wakeup and reset requests are not yet finalized in hardware.