### PR TITLE
[dv] fix top-level csr test failures

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/cip_base_vseq.sv
@@ -551,8 +551,10 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
                       UVM_HIGH);
             if (shadowed_csrs[index].get_shadow_storage_err()) begin
               shadow_reg_storage_err_post_write();
-              // TODO: temp wait a clk cycle, will delete once the real alert check impelemented
-              cfg.clk_rst_vif.wait_clks(1);
+              // TODO: temp wait 10 clk cycles, will delete once the real alert check impelemented
+              // use 10 clock cycles to make sure async mode it reaches at least one clock cycle
+              // for alert sender clock
+              cfg.clk_rst_vif.wait_clks(10);
             end
             csr_poke(.csr(shadowed_csrs[index]), .value(origin_val), .kind(kind), .predict(1));
           end

--- a/hw/ip/pwrmgr/data/pwrmgr.hjson
+++ b/hw/ip/pwrmgr/data/pwrmgr.hjson
@@ -352,6 +352,8 @@
         resval: "0"
         cname: "wake_status",
         count: "NumWkups",
+        tags: [// Cannot auto-predict current wake request status
+               "excl:CsrNonInitTests:CsrExclWriteCheck"],
         fields: [
           { bits: "0",
             name: "VAL",

--- a/hw/ip/pwrmgr/data/pwrmgr.hjson.tpl
+++ b/hw/ip/pwrmgr/data/pwrmgr.hjson.tpl
@@ -346,6 +346,8 @@
         resval: "0"
         cname: "wake_status",
         count: "NumWkups",
+        tags: [// Cannot auto-predict current wake request status
+               "excl:CsrNonInitTests:CsrExclWriteCheck"],
         fields: [
           { bits: "0",
             name: "VAL",

--- a/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr.hjson
+++ b/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr.hjson
@@ -352,6 +352,8 @@
         resval: "0"
         cname: "wake_status",
         count: "NumWkups",
+        tags: [// Cannot auto-predict current wake request status
+               "excl:CsrNonInitTests:CsrExclWriteCheck"],
         fields: [
           { bits: "0",
             name: "VAL",


### PR DESCRIPTION
Fix Top-level csr automation test failures due to:
1. pwrmgr register wake_status cannot be automatically predicted in csr
test. So excluded from csr read check

2. Top level shadow_reg has async alert_sender clocks. Previously to
make alert storage error, I waited for one clock cycle then backdoor
write back to original value. This will ensure only one alert is
triggered.
But in top-level async mode, one clock cycle for main_clock might be
less than one cycle alert_sender clock. Which will cause the
storage_error to be ignored.

Signed-off-by: Cindy Chen <chencindy@google.com>