### PR TITLE
[hw/dashboard] add csrng and edn to dashboard

### DIFF
--- a/hw/ip/csrng/data/csrng.prj.hjson
+++ b/hw/ip/csrng/data/csrng.prj.hjson
@@ -1,0 +1,14 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+{
+    name:               "csrng",
+    design_spec:        "hw/ip/csrng/doc",
+    dv_plan:            "hw/ip/csrng/doc/dv_plan",
+    hw_checklist:       "hw/ip/csrng/doc/checklist",
+    version:            "0.5",
+    life_stage:         "L1",
+    design_stage:       "D0",
+    verification_stage: "V0",
+}

--- a/hw/ip/edn/data/edn.prj.hjson
+++ b/hw/ip/edn/data/edn.prj.hjson
@@ -1,0 +1,14 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+{
+    name:               "edn",
+    design_spec:        "hw/ip/edn/doc",
+    dv_plan:            "hw/ip/edn/doc/dv_plan",
+    hw_checklist:       "hw/ip/edn/doc/checklist",
+    version:            "0.5",
+    life_stage:         "L1",
+    design_stage:       "D0",
+    verification_stage: "V0",
+}


### PR DESCRIPTION
Signed-off-by: Mark Branstad <mark.branstad@wdc.com>

Adding two project files for csrng and edn so that they can show up in the hw dashboard.