### PR TITLE
[otbn] Add FPGA register file and use it on FPGAs

### DIFF
--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -5,6 +5,15 @@
   clock_primary: "clk_i"
   bus_device: "tlul"
   bus_host: "none"
+  param_list: [
+    { name:    "RegFile",
+      type:    "otbn_pkg::regfile_e",
+      default: "otbn_pkg::RegFileFF",
+      desc:    "Selection of the register file implementation. See otbn_pkg.sv."
+      local:   "false",
+      expose:  "true"
+    }
+  ]
   interrupt_list: [
     { name: "done"
       desc: "OTBN has completed the operation"

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -165,13 +165,13 @@ module otbn_top_sim (
   export "DPI-C" function otbn_base_reg_get;
 
   function automatic int unsigned otbn_base_reg_get(int index);
-    return u_otbn_core.u_otbn_rf_base.rf_reg[index];
+    return u_otbn_core.gen_rf_base_ff.u_otbn_rf_base.rf_reg[index];
   endfunction
 
   export "DPI-C" function otbn_bignum_reg_get;
 
   function automatic int unsigned otbn_bignum_reg_get(int index, int word);
-    return u_otbn_core.u_otbn_rf_bignum.rf[index][word*32+:32];
+    return u_otbn_core.gen_rf_bignum_ff.u_otbn_rf_bignum.rf[index][word*32+:32];
   endfunction
 
   // The model

--- a/hw/ip/otbn/otbn.core
+++ b/hw/ip/otbn/otbn.core
@@ -21,8 +21,10 @@ filesets:
       - rtl/otbn_controller.sv
       - rtl/otbn_decoder.sv
       - rtl/otbn_instruction_fetch.sv
-      - rtl/otbn_rf_base.sv
-      - rtl/otbn_rf_bignum.sv
+      - rtl/otbn_rf_base_ff.sv
+      - rtl/otbn_rf_bignum_ff.sv
+      - rtl/otbn_rf_base_fpga.sv
+      - rtl/otbn_rf_bignum_fpga.sv
       - rtl/otbn_lsu.sv
       - rtl/otbn_alu_base.sv
       - rtl/otbn_alu_bignum.sv

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -12,6 +12,7 @@ module otbn
   import otbn_pkg::*;
   import otbn_reg_pkg::*;
 #(
+  parameter regfile_e             RegFile      = RegFileFF,
   parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}}
 ) (
   input clk_i,
@@ -444,6 +445,7 @@ module otbn
     );
   end else begin : gen_impl_rtl
     otbn_core #(
+      .RegFile(RegFile),
       .DmemSizeByte(DmemSizeByte),
       .ImemSizeByte(ImemSizeByte)
     ) u_otbn_core (

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -12,6 +12,9 @@
 module otbn_core
   import otbn_pkg::*;
 #(
+  // Register file implementation selection, see otbn_pkg.sv.
+  parameter regfile_e RegFile = RegFileFF,
+
   // Size of the instruction memory, in bytes
   parameter int ImemSizeByte = 4096,
   // Size of the data memory, in bytes
@@ -274,19 +277,35 @@ module otbn_core
   // Base Instruction Subset =======================================================================
 
   // General-Purpose Register File (GPRs): 32 32b registers
-  otbn_rf_base u_otbn_rf_base (
-    .clk_i,
-    .rst_ni,
+  if (RegFile == RegFileFF) begin : gen_rf_base_ff
+    otbn_rf_base_ff u_otbn_rf_base (
+      .clk_i,
+      .rst_ni,
 
-    .wr_addr_i (rf_base_wr_addr),
-    .wr_en_i   (rf_base_wr_en),
-    .wr_data_i (rf_base_wr_data),
+      .wr_addr_i (rf_base_wr_addr),
+      .wr_en_i   (rf_base_wr_en),
+      .wr_data_i (rf_base_wr_data),
 
-    .rd_addr_a_i (rf_base_rd_addr_a),
-    .rd_data_a_o (rf_base_rd_data_a),
-    .rd_addr_b_i (rf_base_rd_addr_b),
-    .rd_data_b_o (rf_base_rd_data_b)
-  );
+      .rd_addr_a_i (rf_base_rd_addr_a),
+      .rd_data_a_o (rf_base_rd_data_a),
+      .rd_addr_b_i (rf_base_rd_addr_b),
+      .rd_data_b_o (rf_base_rd_data_b)
+    );
+  end else if (RegFile == RegFileFPGA) begin : gen_rf_base_fpga
+    otbn_rf_base_fpga u_otbn_rf_base (
+      .clk_i,
+      .rst_ni,
+
+      .wr_addr_i (rf_base_wr_addr),
+      .wr_en_i   (rf_base_wr_en),
+      .wr_data_i (rf_base_wr_data),
+
+      .rd_addr_a_i (rf_base_rd_addr_a),
+      .rd_data_a_o (rf_base_rd_data_a),
+      .rd_addr_b_i (rf_base_rd_addr_b),
+      .rd_data_b_o (rf_base_rd_data_b)
+    );
+  end
 
   otbn_alu_base u_otbn_alu_base (
     .clk_i,
@@ -298,19 +317,35 @@ module otbn_core
     .comparison_result_o (alu_base_comparison_result)
   );
 
-  otbn_rf_bignum u_otbn_rf_bignum (
-    .clk_i,
-    .rst_ni,
+  if (RegFile == RegFileFF) begin : gen_rf_bignum_ff
+    otbn_rf_bignum_ff u_otbn_rf_bignum (
+      .clk_i,
+      .rst_ni,
 
-    .wr_addr_i (rf_bignum_wr_addr),
-    .wr_en_i   (rf_bignum_wr_en),
-    .wr_data_i (rf_bignum_wr_data),
+      .wr_addr_i (rf_bignum_wr_addr),
+      .wr_en_i   (rf_bignum_wr_en),
+      .wr_data_i (rf_bignum_wr_data),
 
-    .rd_addr_a_i (rf_bignum_rd_addr_a),
-    .rd_data_a_o (rf_bignum_rd_data_a),
-    .rd_addr_b_i (rf_bignum_rd_addr_b),
-    .rd_data_b_o (rf_bignum_rd_data_b)
-  );
+      .rd_addr_a_i (rf_bignum_rd_addr_a),
+      .rd_data_a_o (rf_bignum_rd_data_a),
+      .rd_addr_b_i (rf_bignum_rd_addr_b),
+      .rd_data_b_o (rf_bignum_rd_data_b)
+    );
+  end else if (RegFile == RegFileFPGA) begin : gen_rf_bignum_fpga
+    otbn_rf_bignum_fpga u_otbn_rf_bignum (
+      .clk_i,
+      .rst_ni,
+
+      .wr_addr_i (rf_bignum_wr_addr),
+      .wr_en_i   (rf_bignum_wr_en),
+      .wr_data_i (rf_bignum_wr_data),
+
+      .rd_addr_a_i (rf_bignum_rd_addr_a),
+      .rd_data_a_o (rf_bignum_rd_data_a),
+      .rd_addr_b_i (rf_bignum_rd_addr_b),
+      .rd_data_b_o (rf_bignum_rd_data_b)
+    );
+  end
 
   otbn_alu_bignum u_otbn_alu_bignum (
     .clk_i,

--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -36,6 +36,12 @@ package otbn_pkg;
   parameter int AlertDmemUncorrectable = 1;
   parameter int AlertRegUncorrectable = 2;
 
+  // Register file implementation selection enum.
+  typedef enum integer {
+    RegFileFF    = 0, // Generic flip-flop based implementation
+    RegFileFPGA  = 1  // FPGA implmentation, does infer RAM primitives.
+  } regfile_e;
+
   // Error codes
   typedef enum logic [31:0] {
     ErrCodeNoError     = 32'h 0000_0000,

--- a/hw/ip/otbn/rtl/otbn_rf_base_ff.sv
+++ b/hw/ip/otbn/rtl/otbn_rf_base_ff.sv
@@ -9,7 +9,7 @@
  * - 2 read ports
  * - 1 write port
  */
-module otbn_rf_base
+module otbn_rf_base_ff
   import otbn_pkg::*;
 (
   input logic          clk_i,

--- a/hw/ip/otbn/rtl/otbn_rf_base_fpga.sv
+++ b/hw/ip/otbn/rtl/otbn_rf_base_fpga.sv
@@ -1,0 +1,53 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * 32b General Purpose Register File (GPRs)
+ *
+ * Features:
+ * - 2 read ports
+ * - 1 write port
+ *
+ * Register 0 is fixed to 0.
+ *
+ * This register file is designed to make FPGA synthesis tools infer RAM primitives. For Xilinx
+ * FPGA architectures, it will produce RAM32M primitives. Other vendors have not yet been tested.
+ */
+module otbn_rf_base_fpga
+  import otbn_pkg::*;
+(
+  input logic          clk_i,
+  input logic          rst_ni,
+
+  input logic [4:0]    wr_addr_i,
+  input logic          wr_en_i,
+  input logic [31:0]   wr_data_i,
+
+  input  logic [4:0]   rd_addr_a_i,
+  output logic [31:0]  rd_data_a_o,
+
+  input  logic [4:0]   rd_addr_b_i,
+  output logic [31:0]  rd_data_b_o
+);
+  logic [31:0] rf_reg [NGpr];
+  logic        wr_en;
+
+  // The reset is not used in this register file version.
+  logic unused_rst_ni;
+  assign unused_rst_ni = rst_ni;
+
+  // No write-enable for register 0 as writes to it are ignored.
+  assign wr_en = (wr_addr_i == '0) ? 1'b0 : wr_en_i;
+
+  // Sync write
+  always_ff @(posedge clk_i) begin : g_rf_reg
+    if (wr_en == 1'b1) begin
+      rf_reg[wr_addr_i] <= wr_data_i;
+    end
+  end
+
+  // Async read
+  assign rd_data_a_o = (rd_addr_a_i == '0) ? '0 : rf_reg[rd_addr_a_i];
+  assign rd_data_b_o = (rd_addr_b_i == '0) ? '0 : rf_reg[rd_addr_b_i];
+endmodule

--- a/hw/ip/otbn/rtl/otbn_rf_bignum_ff.sv
+++ b/hw/ip/otbn/rtl/otbn_rf_bignum_ff.sv
@@ -1,0 +1,55 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * WLEN (256b) Wide Register File (WDRs)
+ *
+ * Features:
+ * - 2 read ports
+ * - 1 write port
+ * - Half (WLEN) word write enables
+ */
+module otbn_rf_bignum_ff
+  import otbn_pkg::*;
+(
+  input  logic             clk_i,
+  input  logic             rst_ni,
+
+  input  logic [WdrAw-1:0] wr_addr_i,
+  input  logic [1:0]       wr_en_i,
+  input  logic [WLEN-1:0]  wr_data_i,
+
+  input  logic [WdrAw-1:0] rd_addr_a_i,
+  output logic [WLEN-1:0]  rd_data_a_o,
+
+  input  logic [WdrAw-1:0] rd_addr_b_i,
+  output logic [WLEN-1:0]  rd_data_b_o
+);
+  logic [WLEN-1:0] rf [NWdr];
+  logic [1:0]      we_onehot [NWdr];
+
+  for (genvar i = 0;i < NWdr; i++) begin : g_rf
+    assign we_onehot[i] = wr_en_i & {2{wr_addr_i == i}};
+
+    // Split registers into halves for clear seperation for the enable terms
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni) begin
+        rf[i][0+:WLEN/2] <= '0;
+      end else if (we_onehot[i][0]) begin
+        rf[i][0+:WLEN/2] <= wr_data_i[0+:WLEN/2];
+      end
+    end
+
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni) begin
+        rf[i][WLEN/2+:WLEN/2] <= '0;
+      end else if (we_onehot[i][1]) begin
+        rf[i][WLEN/2+:WLEN/2] <= wr_data_i[WLEN/2+:WLEN/2];
+      end
+    end
+  end
+
+  assign rd_data_a_o = rf[rd_addr_a_i];
+  assign rd_data_b_o = rf[rd_addr_b_i];
+endmodule

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -2582,7 +2582,17 @@
       available_input_list: []
       available_output_list: []
       available_inout_list: []
-      param_list: []
+      param_list:
+      [
+        {
+          name: RegFile
+          type: otbn_pkg::regfile_e
+          default: otbn_pkg::RegFileFF
+          local: "false"
+          expose: "true"
+          name_top: OtbnRegFile
+        }
+      ]
       interrupt_list:
       [
         {

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -7,6 +7,7 @@ module top_earlgrey #(
   parameter bit AesMasking = 1'b0,
   parameter aes_pkg::sbox_impl_e AesSBoxImpl = aes_pkg::SBoxImplLut,
   parameter int unsigned SecAesStartTriggerDelay = 0,
+  parameter otbn_pkg::regfile_e OtbnRegFile = otbn_pkg::RegFileFF,
 
   // Manually defined parameters
   parameter ibex_pkg::regfile_e IbexRegFile = ibex_pkg::RegFileFF,
@@ -1004,7 +1005,9 @@ module top_earlgrey #(
       .rst_ni (rstmgr_resets.rst_sys_n)
   );
 
-  otbn u_otbn (
+  otbn #(
+    .RegFile(OtbnRegFile)
+  ) u_otbn (
 
       // Interrupt
       .intr_done_o (intr_otbn_done),

--- a/hw/top_earlgrey/rtl/top_earlgrey_artys7.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_artys7.sv
@@ -170,6 +170,7 @@ module top_earlgrey_artys7  #(
     .SecAesStartTriggerDelay(0),
     .IbexRegFile(ibex_pkg::RegFileFPGA),
     .IbexPipeLine(1),
+    .OtbnRegFile(otbn_pkg::RegFileFPGA),
     .BootRomInitFile(BootRomInitFile)
   ) top_earlgrey (
     // Clocks, resets

--- a/hw/top_earlgrey/rtl/top_earlgrey_cw305.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_cw305.sv
@@ -233,6 +233,7 @@ module top_earlgrey_cw305 #(
     .SecAesStartTriggerDelay(40),
     .IbexRegFile(ibex_pkg::RegFileFPGA),
     .IbexPipeLine(1),
+    .OtbnRegFile(otbn_pkg::RegFileFPGA),
     .BootRomInitFile(BootRomInitFile)
   ) top_earlgrey (
     // Clocks, resets

--- a/hw/top_earlgrey/rtl/top_earlgrey_nexysvideo.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_nexysvideo.sv
@@ -229,6 +229,7 @@ module top_earlgrey_nexysvideo #(
     .SecAesStartTriggerDelay(0),
     .IbexRegFile(ibex_pkg::RegFileFPGA),
     .IbexPipeLine(1),
+    .OtbnRegFile(otbn_pkg::RegFileFPGA),
     .BootRomInitFile(BootRomInitFile)
   ) top_earlgrey (
     // Clocks, resets


### PR DESCRIPTION
This PR adds a second implementation of the OTBN register files that will infer RAM primtives on FPGA. The reduces logic resource utilization of otbn by ~10% and gives us back around 4-5ns on the critical path.

To control the selection, a new parameter is added that is propagated to the top level. The FPGA register file is selected only on FPGA platforms. I successfully tested the new register files in simulation using the smoke test.

This is related to #3636.