### PR TITLE
[fpga] Add separate 10 MHz main system clock

### DIFF
--- a/doc/ug/getting_started_fpga.md
+++ b/doc/ug/getting_started_fpga.md
@@ -111,12 +111,12 @@ Please follow the steps shown below.
 
 * Generate the bitstream and flash it to the FPGA as described above.
 * Open a serial console (use the device file determined before) and connect.
-  Settings: 230400 baud, 8N1, no hardware or software flow control.
+  Settings: 115200 baud, 8N1, no hardware or software flow control.
   ```console
-  $ screen /dev/ttyUSB0 230400
+  $ screen /dev/ttyUSB0 115200
   ```
-  Note that the Nexsys Video demo program that comes installed on the board runs the UART at 115200 baud;
-  expect to see garbage characters if that is running.
+  Note that the Nexsys Video demo program that comes installed on the board runs the UART at 115200 baud as well;
+  expect to see different output if that is running.
   This can happen if you connect the serial console before using Vivado to program your new bitstream or you press the *PROG* button that causes the FPGA to reprogram from the code in the on-board SPI flash.
 * On the Nexys Video board, press the red button labeled *CPU_RESET*.
 * You should see the ROM code report its commit ID and build date.

--- a/doc/ug/quickstart.md
+++ b/doc/ug/quickstart.md
@@ -178,11 +178,11 @@ See [the section udev rules of the installation guide]({{< relref "install_instr
 
     It should be named `/dev/ttyUSB*` in this example it is `/dev/ttyUSB0`.
 3.  Open a serial console (use the device file determined before) and connect.
-    Settings: 230400 baud, 8N1, no hardware or software flow control.
+    Settings: 115200 baud, 8N1, no hardware or software flow control.
     `screen` needs to be installed first.
 
     ```console
-    $ screen /dev/ttyUSB0 230400
+    $ screen /dev/ttyUSB0 115200
     ```
 
 4.  On the Nexys Video board, press the red button labeled CPU_RESET.

--- a/hw/ip/prim/rtl/prim_clock_div.sv
+++ b/hw/ip/prim/rtl/prim_clock_div.sv
@@ -67,5 +67,4 @@ module prim_clock_div #(
     .clk_o
   );
 
-
-endmodule // prim_generic_clock_div2
+endmodule

--- a/hw/ip/prim_xilinx/lint/prim_xilinx_clock_buf.vlt
+++ b/hw/ip/prim_xilinx/lint/prim_xilinx_clock_buf.vlt
@@ -1,0 +1,4 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//

--- a/hw/ip/prim_xilinx/lint/prim_xilinx_clock_buf.waiver
+++ b/hw/ip/prim_xilinx/lint/prim_xilinx_clock_buf.waiver
@@ -1,0 +1,4 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#

--- a/hw/ip/prim_xilinx/prim_xilinx_clock_buf.core
+++ b/hw/ip/prim_xilinx/prim_xilinx_clock_buf.core
@@ -1,0 +1,42 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim_xilinx:clock_buf"
+description: "clock buffer"
+filesets:
+  files_rtl:
+    files:
+      - rtl/prim_xilinx_clock_buf.sv
+    file_type: systemVerilogSource
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_xilinx_clock_buf.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_xilinx_clock_buf.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl

--- a/hw/ip/prim_xilinx/rtl/prim_xilinx_clock_buf.sv
+++ b/hw/ip/prim_xilinx/rtl/prim_xilinx_clock_buf.sv
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+module prim_xilinx_clock_buf (
+  input clk_i,
+  output logic clk_o
+);
+
+  BUFG bufg_i (
+    .I (clk_i),
+    .O (clk_o)
+  );
+
+endmodule

--- a/hw/ip/spi_device/spi_device.core
+++ b/hw/ip/spi_device/spi_device.core
@@ -10,6 +10,7 @@ filesets:
     depend:
       - lowrisc:ip:tlul
       - lowrisc:prim:all
+      - lowrisc:prim:clock_buf
       - lowrisc:prim:clock_gating
       - lowrisc:prim:clock_inv
       - lowrisc:prim:ram_2p_adv

--- a/hw/top_earlgrey/data/clocks.xdc
+++ b/hw/top_earlgrey/data/clocks.xdc
@@ -6,7 +6,7 @@
 create_clock -add -name sys_clk_pin -period 10.00 -waveform {0 5} [get_ports IO_CLK]
 
 ## Clock Domain Crossings
-set clks_50_unbuf [get_clocks -of_objects [get_pin clkgen/pll/CLKOUT0]]
+set clks_10_unbuf [get_clocks -of_objects [get_pin clkgen/pll/CLKOUT0]]
 set clks_48_unbuf [get_clocks -of_objects [get_pin clkgen/pll/CLKOUT1]]
 
 ## Divided clock
@@ -19,4 +19,4 @@ create_generated_clock -name clk_io_div2 -source [get_pin ${div2_cell}/C] -divid
 set div4_cell [get_cells top_earlgrey/u_clkmgr/u_io_div4_div/gen_div.clk_int_reg]
 create_generated_clock -name clk_io_div4 -source [get_pin ${div4_cell}/C] -divide_by 4 [get_pin ${div4_cell}/Q]
 
-set_clock_groups -group ${clks_50_unbuf} -group ${clks_48_unbuf} -group clk_io_div2 -group clk_io_div4 -asynchronous
+set_clock_groups -group ${clks_10_unbuf} -group ${clks_48_unbuf} -group clk_io_div2 -group clk_io_div4 -asynchronous

--- a/hw/top_earlgrey/data/clocks.xdc
+++ b/hw/top_earlgrey/data/clocks.xdc
@@ -20,4 +20,9 @@ create_generated_clock -name clk_io_div2 -source [get_pin ${u_pll}/CLKOUT0] -div
 set u_div4 top_earlgrey/u_clkmgr/u_io_div4_div
 create_generated_clock -name clk_io_div4 -source [get_pin ${u_pll}/CLKOUT0] -divide_by 4 [get_pin ${u_div4}/u_clk_div_buf/gen_xilinx.u_impl_xilinx/bufg_i/O]
 
-set_clock_groups -group ${clks_10_unbuf} -group ${clks_48_unbuf} -group clk_io_div2 -group clk_io_div4 -asynchronous
+## JTAG and SPI clocks
+create_clock -add -name jtag_tck    -period 100.00 -waveform {0 5} [get_nets jtag_tck_buf]
+create_clock -add -name clk_spi_in  -period 100.00 -waveform {0 5} [get_pin top_earlgrey/u_spi_device/u_clk_spi_in_buf/gen_xilinx.u_impl_xilinx/bufg_i/O]
+create_clock -add -name clk_spi_out -period 100.00 -waveform {0 5} [get_pin top_earlgrey/u_spi_device/u_clk_spi_out_buf/gen_xilinx.u_impl_xilinx/bufg_i/O]
+
+set_clock_groups -group ${clks_10_unbuf} -group ${clks_48_unbuf} -group clk_io_div2 -group clk_io_div4 -group jtag_tck -group clk_spi_in -group clk_spi_out -asynchronous

--- a/hw/top_earlgrey/data/clocks.xdc
+++ b/hw/top_earlgrey/data/clocks.xdc
@@ -13,10 +13,11 @@ set clks_48_unbuf [get_clocks -of_objects [get_pin clkgen/pll/CLKOUT1]]
 ## This is not really recommended per Vivado's guidelines, but hopefully these clocks are slow enough and their
 ## destination flops few enough.
 
-set div2_cell [get_cells top_earlgrey/u_io_div2_div/gen_div2.u_div2/gen_generic.u_impl_generic/q_o_reg[0]]
-create_generated_clock -name clk_io_div2 -source [get_pin ${div2_cell}/C] -divide_by 2 [get_pin ${div2_cell}/Q]
+set u_pll clkgen/pll
+set u_div2 top_earlgrey/u_clkmgr/u_io_div2_div
+create_generated_clock -name clk_io_div2 -source [get_pin ${u_pll}/CLKOUT0] -divide_by 2 [get_pin ${u_div2}/u_clk_div_buf/gen_xilinx.u_impl_xilinx/bufg_i/O]
 
-set div4_cell [get_cells top_earlgrey/u_clkmgr/u_io_div4_div/gen_div.clk_int_reg]
-create_generated_clock -name clk_io_div4 -source [get_pin ${div4_cell}/C] -divide_by 4 [get_pin ${div4_cell}/Q]
+set u_div4 top_earlgrey/u_clkmgr/u_io_div4_div
+create_generated_clock -name clk_io_div4 -source [get_pin ${u_pll}/CLKOUT0] -divide_by 4 [get_pin ${u_div4}/u_clk_div_buf/gen_xilinx.u_impl_xilinx/bufg_i/O]
 
 set_clock_groups -group ${clks_10_unbuf} -group ${clks_48_unbuf} -group clk_io_div2 -group clk_io_div4 -asynchronous

--- a/hw/top_earlgrey/rtl/clkgen_xil7series.sv
+++ b/hw/top_earlgrey/rtl/clkgen_xil7series.sv
@@ -8,12 +8,14 @@ module clkgen_xil7series # (
 ) (
   input IO_CLK,
   input IO_RST_N,
+  input jtag_srst_n,
   output clk_main,
   output clk_48MHz,
   output rst_n
 );
   logic locked_pll;
   logic io_clk_buf;
+  logic io_rst_buf_n;
   logic clk_10_buf;
   logic clk_10_unbuf;
   logic clk_fb_buf;
@@ -21,10 +23,16 @@ module clkgen_xil7series # (
   logic clk_48_buf;
   logic clk_48_unbuf;
 
-  // input buffer
-  IBUF io_clk_ibuf (
+  // input clock buffer
+  IBUFG io_clk_ibufg (
     .I (IO_CLK),
     .O (io_clk_buf)
+  );
+
+  // input reset buffer
+  IBUF io_rst_ibuf (
+    .I (IO_RST_N),
+    .O (io_rst_buf_n)
   );
 
   PLLE2_ADV #(
@@ -97,5 +105,5 @@ module clkgen_xil7series # (
   assign clk_48MHz = clk_48_buf;
 
   // reset
-  assign rst_n = locked_pll & IO_RST_N;
+  assign rst_n = locked_pll & io_rst_buf_n & jtag_srst_n;
 endmodule

--- a/hw/top_earlgrey/rtl/clkgen_xil7series.sv
+++ b/hw/top_earlgrey/rtl/clkgen_xil7series.sv
@@ -8,14 +8,14 @@ module clkgen_xil7series # (
 ) (
   input IO_CLK,
   input IO_RST_N,
-  output clk_sys,
+  output clk_main,
   output clk_48MHz,
-  output rst_sys_n
+  output rst_n
 );
   logic locked_pll;
   logic io_clk_buf;
-  logic clk_50_buf;
-  logic clk_50_unbuf;
+  logic clk_10_buf;
+  logic clk_10_unbuf;
   logic clk_fb_buf;
   logic clk_fb_unbuf;
   logic clk_48_buf;
@@ -34,7 +34,7 @@ module clkgen_xil7series # (
     .DIVCLK_DIVIDE        (1),
     .CLKFBOUT_MULT        (12),
     .CLKFBOUT_PHASE       (0.000),
-    .CLKOUT0_DIVIDE       (24),
+    .CLKOUT0_DIVIDE       (120),
     .CLKOUT0_PHASE        (0.000),
     .CLKOUT0_DUTY_CYCLE   (0.500),
     .CLKOUT1_DIVIDE       (25),
@@ -43,7 +43,7 @@ module clkgen_xil7series # (
     .CLKIN1_PERIOD        (10.000)
   ) pll (
     .CLKFBOUT            (clk_fb_unbuf),
-    .CLKOUT0             (clk_50_unbuf),
+    .CLKOUT0             (clk_10_unbuf),
     .CLKOUT1             (clk_48_unbuf),
     .CLKOUT2             (),
     .CLKOUT3             (),
@@ -76,9 +76,9 @@ module clkgen_xil7series # (
   );
 
   if (AddClkBuf == 1) begin : gen_clk_bufs
-    BUFG clk_50_bufg (
-      .I (clk_50_unbuf),
-      .O (clk_50_buf)
+    BUFG clk_10_bufg (
+      .I (clk_10_unbuf),
+      .O (clk_10_buf)
     );
 
     BUFG clk_48_bufg (
@@ -87,15 +87,15 @@ module clkgen_xil7series # (
     );
   end else begin : gen_no_clk_bufs
     // BUFGs added by downstream modules, no need to add here
-    assign clk_50_buf = clk_50_unbuf;
+    assign clk_10_buf = clk_10_unbuf;
     assign clk_48_buf = clk_48_unbuf;
   end
 
   // outputs
   // clock
-  assign clk_sys = clk_50_buf; // TODO: choose 50 MHz clock as sysclock for now
+  assign clk_main = clk_10_buf;
   assign clk_48MHz = clk_48_buf;
 
   // reset
-  assign rst_sys_n = locked_pll & IO_RST_N;
+  assign rst_n = locked_pll & IO_RST_N;
 endmodule

--- a/hw/top_earlgrey/rtl/top_earlgrey_artys7.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_artys7.sv
@@ -133,11 +133,12 @@ module top_earlgrey_artys7  #(
   // Unlike nexysvideo, there is currently no dedicated
   // JTAG port available, hence tie off.
   logic jtag_trst_n, jtag_srst_n;
-  logic jtag_tck, jtag_tms, jtag_tdi, jtag_tdo;
+  logic jtag_tck, jtag_tck_buf, jtag_tms, jtag_tdi, jtag_tdo;
 
   assign jtag_trst_n = 1'b1;
   assign jtag_srst_n = 1'b1;
   assign jtag_tck = 1'b0;
+  assign jtag_tck_buf = 1'b0;
   assign jtag_tms = 1'b0;
   assign jtag_tdi = 1'b0;
 
@@ -212,7 +213,7 @@ module top_earlgrey_artys7  #(
     .ast_tl_rsp_i                ( '0              ),
 
     // JTAG
-    .jtag_tck_i      ( jtag_tck      ),
+    .jtag_tck_i      ( jtag_tck_buf  ),
     .jtag_tms_i      ( jtag_tms      ),
     .jtag_trst_ni    ( jtag_trst_n   ),
     .jtag_tdi_i      ( jtag_tdi      ),

--- a/hw/top_earlgrey/rtl/top_earlgrey_artys7.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_artys7.sv
@@ -8,8 +8,8 @@ module top_earlgrey_artys7  #(
   parameter BootRomInitFile = "boot_rom_fpga_artys7.32.vmem"
 ) (
   // Clock and Reset
-  inout               IO_CLK,
-  inout               IO_RST_N,
+  input               IO_CLK,
+  input               IO_RST_N,
   // JTAG interface -- not hooked up at the moment
   // inout               IO_DPS0, // IO_JTCK,    IO_SDCK
   // inout               IO_DPS3, // IO_JTMS,    IO_SDCSB
@@ -157,6 +157,7 @@ module top_earlgrey_artys7  #(
   ) clkgen (
     .IO_CLK,
     .IO_RST_N,
+    .jtag_srst_n,
     .clk_main(clk_main),
     .clk_48MHz(clk_usb_48mhz),
     .rst_n(rst_n)

--- a/hw/top_earlgrey/rtl/top_earlgrey_cw305.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_cw305.sv
@@ -144,7 +144,7 @@ module top_earlgrey_cw305 #(
   //////////////////////
 
   logic jtag_trst_n, jtag_srst_n;
-  logic jtag_tck, jtag_tms, jtag_tdi, jtag_tdo;
+  logic jtag_tck, jtag_tck_buf, jtag_tms, jtag_tdi, jtag_tdo;
 
   localparam int NumIOs = padctrl_reg_pkg::NMioPads +
                           padctrl_reg_pkg::NDioPads;
@@ -189,6 +189,15 @@ module top_earlgrey_cw305 #(
     .out_padring_o ( {dio_out_padring, mio_out_padring} ),
     .oe_padring_o  ( {dio_oe_padring , mio_oe_padring } ),
     .in_padring_i  ( {dio_in_padring , mio_in_padring } )
+  );
+
+  ////////////////////////////////
+  // JTAG clock buffer for FPGA //
+  ////////////////////////////////
+
+  BUFG jtag_buf (
+    .I (jtag_tck),
+    .O (jtag_tck_buf)
   );
 
   //////////////////
@@ -255,7 +264,7 @@ module top_earlgrey_cw305 #(
     .ast_tl_rsp_i                ( '0              ),
 
     // JTAG
-    .jtag_tck_i      ( jtag_tck      ),
+    .jtag_tck_i      ( jtag_tck_buf  ),
     .jtag_tms_i      ( jtag_tms      ),
     .jtag_trst_ni    ( jtag_trst_n   ),
     .jtag_tdi_i      ( jtag_tdi      ),

--- a/hw/top_earlgrey/rtl/top_earlgrey_cw305.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_cw305.sv
@@ -8,8 +8,8 @@ module top_earlgrey_cw305 #(
   parameter BootRomInitFile = "boot_rom_fpga_nexysvideo.32.vmem"
 ) (
   // Clock and Reset
-  inout               IO_CLK,
-  inout               IO_RST_N,
+  input               IO_CLK,
+  input               IO_RST_N,
   // JTAG interface
   inout               IO_DPS0, // IO_JTCK,    IO_SDCK
   inout               IO_DPS3, // IO_JTMS,    IO_SDCSB
@@ -199,7 +199,8 @@ module top_earlgrey_cw305 #(
     .AddClkBuf(0)
   ) clkgen (
     .IO_CLK,
-    .IO_RST_N(IO_RST_N & jtag_srst_n),
+    .IO_RST_N,
+    .jtag_srst_n,
     .clk_main(clk_main),
     .clk_48MHz(clk_usb_48mhz),
     .rst_n(rst_n)

--- a/hw/top_earlgrey/rtl/top_earlgrey_cw305.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_cw305.sv
@@ -56,7 +56,7 @@ module top_earlgrey_cw305 #(
   //////////////////////
 
 
-  logic clk, clk_usb_48mhz, rst_n;
+  logic clk_main, clk_usb_48mhz, rst_n;
   logic [padctrl_reg_pkg::NMioPads-1:0][padctrl_reg_pkg::AttrDw-1:0] mio_attr;
   logic [padctrl_reg_pkg::NDioPads-1:0][padctrl_reg_pkg::AttrDw-1:0] dio_attr;
   logic [padctrl_reg_pkg::NMioPads-1:0] mio_out_core, mio_out_padring;
@@ -198,11 +198,11 @@ module top_earlgrey_cw305 #(
   clkgen_xil7series # (
     .AddClkBuf(0)
   ) clkgen (
-      .IO_CLK,
+    .IO_CLK,
     .IO_RST_N(IO_RST_N & jtag_srst_n),
-    .clk_sys(clk),
+    .clk_main(clk_main),
     .clk_48MHz(clk_usb_48mhz),
-    .rst_sys_n(rst_n)
+    .rst_n(rst_n)
   );
 
   //////////////////////
@@ -238,10 +238,10 @@ module top_earlgrey_cw305 #(
   ) top_earlgrey (
     // Clocks, resets
     .rst_ni          ( rst_n         ),
-    .clk_main_i      ( clk           ),
-    .clk_io_i        ( clk           ),
+    .clk_main_i      ( clk_main      ),
+    .clk_io_i        ( clk_main      ),
     .clk_usb_i       ( clk_usb_48mhz ),
-    .clk_aon_i       ( clk           ),
+    .clk_aon_i       ( clk_main      ),
     .rstmgr_ast_i                ( ast_base_rst    ),
     .pwrmgr_pwr_ast_req_o        (                 ),
     .pwrmgr_pwr_ast_rsp_i        ( ast_base_pwr    ),
@@ -251,7 +251,7 @@ module top_earlgrey_cw305 #(
     .usbdev_usb_ref_val_o        (                 ),
     .usbdev_usb_ref_pulse_o      (                 ),
     .ast_tl_req_o                (                 ),
-    .ast_tl_rsp_i                ('0               ),
+    .ast_tl_rsp_i                ( '0              ),
 
     // JTAG
     .jtag_tck_i      ( jtag_tck      ),
@@ -275,6 +275,7 @@ module top_earlgrey_cw305 #(
     .dio_attr_o      ( dio_attr      ),
 
     // DFT signals
+    .scan_rst_ni     ( 1'b1          ),
     .scanmode_i      ( 1'b0          )
   );
 

--- a/hw/top_earlgrey/rtl/top_earlgrey_nexysvideo.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_nexysvideo.sv
@@ -140,7 +140,7 @@ module top_earlgrey_nexysvideo #(
   //////////////////////
 
   logic jtag_trst_n, jtag_srst_n;
-  logic jtag_tck, jtag_tms, jtag_tdi, jtag_tdo;
+  logic jtag_tck, jtag_tck_buf, jtag_tms, jtag_tdi, jtag_tdo;
 
   localparam int NumIOs = padctrl_reg_pkg::NMioPads +
                           padctrl_reg_pkg::NDioPads;
@@ -185,6 +185,15 @@ module top_earlgrey_nexysvideo #(
     .out_padring_o ( {dio_out_padring, mio_out_padring} ),
     .oe_padring_o  ( {dio_oe_padring , mio_oe_padring } ),
     .in_padring_i  ( {dio_in_padring , mio_in_padring } )
+  );
+
+  ////////////////////////////////
+  // JTAG clock buffer for FPGA //
+  ////////////////////////////////
+
+  BUFG jtag_buf (
+    .I (jtag_tck),
+    .O (jtag_tck_buf)
   );
 
   //////////////////
@@ -251,7 +260,7 @@ module top_earlgrey_nexysvideo #(
     .ast_tl_rsp_i                ( '0              ),
 
     // JTAG
-    .jtag_tck_i      ( jtag_tck      ),
+    .jtag_tck_i      ( jtag_tck_buf  ),
     .jtag_tms_i      ( jtag_tms      ),
     .jtag_trst_ni    ( jtag_trst_n   ),
     .jtag_tdi_i      ( jtag_tdi      ),

--- a/hw/top_earlgrey/rtl/top_earlgrey_nexysvideo.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_nexysvideo.sv
@@ -8,8 +8,8 @@ module top_earlgrey_nexysvideo #(
   parameter BootRomInitFile = "boot_rom_fpga_nexysvideo.32.vmem"
 ) (
   // Clock and Reset
-  inout               IO_CLK,
-  inout               IO_RST_N,
+  input               IO_CLK,
+  input               IO_RST_N,
   // JTAG interface
   inout               IO_DPS0, // IO_JTCK,    IO_SDCK
   inout               IO_DPS3, // IO_JTMS,    IO_SDCSB
@@ -195,7 +195,8 @@ module top_earlgrey_nexysvideo #(
     .AddClkBuf(0)
   ) clkgen (
     .IO_CLK,
-    .IO_RST_N(IO_RST_N & jtag_srst_n),
+    .IO_RST_N,
+    .jtag_srst_n,
     .clk_main(clk_main),
     .clk_48MHz(clk_usb_48mhz),
     .rst_n(rst_n)

--- a/hw/top_earlgrey/rtl/top_earlgrey_nexysvideo.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_nexysvideo.sv
@@ -54,7 +54,7 @@ module top_earlgrey_nexysvideo #(
   //////////////////////
 
 
-  logic clk, clk_usb_48mhz, rst_n;
+  logic clk_main, clk_usb_48mhz, rst_n;
   logic [padctrl_reg_pkg::NMioPads-1:0][padctrl_reg_pkg::AttrDw-1:0] mio_attr;
   logic [padctrl_reg_pkg::NDioPads-1:0][padctrl_reg_pkg::AttrDw-1:0] dio_attr;
   logic [padctrl_reg_pkg::NMioPads-1:0] mio_out_core, mio_out_padring;
@@ -194,11 +194,11 @@ module top_earlgrey_nexysvideo #(
   clkgen_xil7series # (
     .AddClkBuf(0)
   ) clkgen (
-      .IO_CLK,
+    .IO_CLK,
     .IO_RST_N(IO_RST_N & jtag_srst_n),
-    .clk_sys(clk),
+    .clk_main(clk_main),
     .clk_48MHz(clk_usb_48mhz),
-    .rst_sys_n(rst_n)
+    .rst_n(rst_n)
   );
 
   //////////////////////
@@ -234,10 +234,10 @@ module top_earlgrey_nexysvideo #(
   ) top_earlgrey (
     // Clocks, resets
     .rst_ni          ( rst_n         ),
-    .clk_main_i      ( clk           ),
-    .clk_io_i        ( clk           ),
+    .clk_main_i      ( clk_main      ),
+    .clk_io_i        ( clk_main      ),
     .clk_usb_i       ( clk_usb_48mhz ),
-    .clk_aon_i       ( clk           ),
+    .clk_aon_i       ( clk_main      ),
     .rstmgr_ast_i                ( ast_base_rst    ),
     .pwrmgr_pwr_ast_req_o        (                 ),
     .pwrmgr_pwr_ast_rsp_i        ( ast_base_pwr    ),

--- a/hw/top_earlgrey/util/vivado_hook_write_bitstream_pre.tcl
+++ b/hw/top_earlgrey/util/vivado_hook_write_bitstream_pre.tcl
@@ -11,7 +11,5 @@ set slack_ns [get_property SLACK [get_timing_paths -delay_type min_max]]
 send_msg "Designcheck 1-2" INFO "Slack is ${slack_ns} ns."
 
 if [expr {$slack_ns < 0}] {
-  # TODO: Make this check an ERROR again as soon as we have fixed our timing,
-  # see https://github.com/lowRISC/opentitan/issues/2508.
-  send_msg "Designcheck 1-3" WARNING "Timing failed. Slack is ${slack_ns} ns."
+  send_msg "Designcheck 1-3" ERROR "Timing failed. Slack is ${slack_ns} ns."
 }

--- a/sw/device/examples/hello_usbdev/hello_usbdev.c
+++ b/sw/device/examples/hello_usbdev/hello_usbdev.c
@@ -86,10 +86,10 @@ int main(int argc, char **argv) {
   pinmux_init();
 
   CHECK(dif_spi_device_init(
-      (dif_spi_device_params_t){
-          .base_addr = mmio_region_from_addr(0x40020000),
-      },
-      &spi));
+            (dif_spi_device_params_t){
+                .base_addr = mmio_region_from_addr(0x40020000),
+            },
+            &spi) == kDifSpiDeviceOk);
   CHECK(dif_spi_device_configure(
             &spi, (dif_spi_device_config_t){
                       .clock_polarity = kDifSpiDeviceEdgePositive,

--- a/sw/device/examples/hello_world/hello_world.c
+++ b/sw/device/examples/hello_world/hello_world.c
@@ -23,10 +23,10 @@ int main(int argc, char **argv) {
   pinmux_init();
 
   CHECK(dif_spi_device_init(
-      (dif_spi_device_params_t){
-          .base_addr = mmio_region_from_addr(0x40020000),
-      },
-      &spi));
+            (dif_spi_device_params_t){
+                .base_addr = mmio_region_from_addr(0x40020000),
+            },
+            &spi) == kDifSpiDeviceOk);
   CHECK(dif_spi_device_configure(
             &spi, (dif_spi_device_config_t){
                       .clock_polarity = kDifSpiDeviceEdgePositive,

--- a/sw/device/lib/arch/device_fpga_nexysvideo.c
+++ b/sw/device/lib/arch/device_fpga_nexysvideo.c
@@ -11,13 +11,13 @@
 
 const device_type_t kDeviceType = kDeviceFpgaNexysVideo;
 
-const uint64_t kClockFreqCpuHz = 50 * 1000 * 1000;  // 50MHz
+const uint64_t kClockFreqCpuHz = 10 * 1000 * 1000;  // 10MHz
 
-const uint64_t kClockFreqPeripheralHz = 125 * 100 * 1000;  // 12.5MHz
+const uint64_t kClockFreqPeripheralHz = 25 * 100 * 1000;  // 2.5MHz
 
 const uint64_t kClockFreqUsbHz = 48 * 1000 * 1000;  // 48MHz
 
-const uint64_t kUartBaudrate = 230400;
+const uint64_t kUartBaudrate = 115200;
 
 // No Device Stop Address in our FPGA implementation.
 const uintptr_t kDeviceStopAddress = 0;

--- a/sw/device/tock/chips/earlgrey/src/chip_config.rs
+++ b/sw/device/tock/chips/earlgrey/src/chip_config.rs
@@ -13,8 +13,8 @@ pub struct DeviceConfig<'a> {
 #[cfg(any(feature = "fpga_nexysvideo", not(feature = "device_specified")))]
 pub const DEVICE_CONFIG: DeviceConfig = DeviceConfig {
     name: &"fpga_nexysvideo",
-    chip_freq: 50_000_000,
-    uart_baudrate: 230400,
+    chip_freq: 10_000_000,
+    uart_baudrate: 115200,
 };
 
 #[cfg(feature = "sim_verilator")]

--- a/sw/host/spiflash/ftdi_spi_interface.cc
+++ b/sw/host/spiflash/ftdi_spi_interface.cc
@@ -157,8 +157,8 @@ bool FtdiSpiInterface::CheckHash(const uint8_t *tx, size_t size) {
   auto now = begin;
   while (!hash_correct &&
          std::chrono::duration_cast<std::chrono::microseconds>(now - begin)
-                 .count() < options_.hash_read_timeout_ns) {
-    usleep(options_.hash_read_delay_ns);
+                 .count() < options_.hash_read_timeout_us) {
+    usleep(options_.hash_read_delay_us);
     rx = nullptr;
     rx = ::Read(spi_->ctx, size);
     if (!rx) {
@@ -170,6 +170,7 @@ bool FtdiSpiInterface::CheckHash(const uint8_t *tx, size_t size) {
     // testing I've seen the hash appear at random locations in the message.
     // Checking for the hash at any location or even split between messages may
     // not be necessary, but it is probably safer.
+    usleep(options_.hash_check_delay_us);
     for (int i = 0; !hash_correct && i < SHA256_DIGEST_LENGTH; ++i) {
       if (rx[i] == hash[hash_index]) {
         ++hash_index;

--- a/sw/host/spiflash/ftdi_spi_interface.h
+++ b/sw/host/spiflash/ftdi_spi_interface.h
@@ -36,15 +36,20 @@ class FtdiSpiInterface : public SpiInterface {
     /** USB device serial number. */
     std::string device_serial_number;
 
-    /** Time to wait between attempts to check the hash in nanoseconds. */
-    int32_t hash_read_delay_ns = 10000;
+    /** Time to wait between attempts to check the hash in microseconds. */
+    int32_t hash_read_delay_us = 10000;
 
-    /** Time before giving up on looking for the correct hash. */
-    int32_t hash_read_timeout_ns = 1000000;
+    /** Time to wait between reading the hash over SPI and checking it in
+     *  microseconds. */
+    int32_t hash_check_delay_us = 10000;
+
+    /** Time before giving up on looking for the correct hash in
+     *  microseconds. */
+    int32_t hash_read_timeout_us = 400000;
 
     /** FTDI Configuration. This can be made configurable later on if needed.
-     * Default value is 1MHz. */
-    int32_t spi_frequency = 400000;
+     * Frequency in Hz. Default value is 1MHz. */
+    int32_t spi_frequency = 1000000;
   };
 
   explicit FtdiSpiInterface(Options options);

--- a/sw/host/spiflash/updater.cc
+++ b/sw/host/spiflash/updater.cc
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <assert.h>
+#include <unistd.h>
 
 namespace opentitan {
 namespace spiflash {
@@ -77,6 +78,12 @@ bool Updater::Run() {
                              sizeof(Frame))) {
       std::cerr << "Failed to transmit frame no: 0x" << std::setfill('0')
                 << std::setw(8) << std::hex << f.hdr.frame_num << std::endl;
+    }
+
+    // After receiving and validating the first frame, the device is erasing
+    // the Flash.
+    if (current_frame == 0) {
+      usleep(options_.flash_erase_delay_us);
     }
 
     // When we send each frame we wait for the correct hash before continuing.

--- a/sw/host/spiflash/updater.h
+++ b/sw/host/spiflash/updater.h
@@ -55,6 +55,8 @@ class Updater {
   struct Options {
     /** Firmware image in binary format. */
     std::string code;
+    /** Flash erase delay in microseconds. */
+    int32_t flash_erase_delay_us = 100000;
   };
 
   /**

--- a/sw/vendor/patches/riscv_compliance/0002-Add-OpenTitan-target.patch
+++ b/sw/vendor/patches/riscv_compliance/0002-Add-OpenTitan-target.patch
@@ -1,4 +1,4 @@
-From 1b37cf8ea5468c9bdf17e8633507fc595a8858b2 Mon Sep 17 00:00:00 2001
+From 12485c998481c4414e157a7b6d475c2c118fce77 Mon Sep 17 00:00:00 2001
 From: Greg Chadwick <gac@lowrisc.org>
 Date: Wed, 15 Apr 2020 15:44:54 +0100
 Subject: [PATCH 2/3] Add OpenTitan target
@@ -254,7 +254,7 @@ index 0000000..6a889cf
 +#endif
 diff --git a/riscv-target/opentitan/device/rv32imc/Makefile.include b/riscv-target/opentitan/device/rv32imc/Makefile.include
 new file mode 100644
-index 0000000..a44e0c3
+index 0000000..b71105c
 --- /dev/null
 +++ b/riscv-target/opentitan/device/rv32imc/Makefile.include
 @@ -0,0 +1,75 @@
@@ -298,7 +298,7 @@ index 0000000..a44e0c3
 +        ( test -e "$(OT_FPGA_UART)" || ( echo "UART device '$(OT_FPGA_UART)' not available. Set OT_FPGA_UART." >&2 && exit 1 ) ) \
 +        && echo "Writing '$(<).bin' to device." \
 +        && $(OT_BIN)/sw/host/spiflash/spiflash --input="$(<).bin" \
-+        && stty -F "$(OT_FPGA_UART)" speed 230400 cs8 -cstopb -parenb \
++        && stty -F "$(OT_FPGA_UART)" speed 115200 cs8 -cstopb -parenb \
 +        && grep -o 'SIG: [a-zA-Z0-9_]*' "$(OT_FPGA_UART)" \
 +            | sed 's/SIG: //' > $(*).signature.output
 +else

--- a/sw/vendor/patches/riscv_compliance/0003-Remove-tests-that-do-not-pass-on-OpenTitan.patch
+++ b/sw/vendor/patches/riscv_compliance/0003-Remove-tests-that-do-not-pass-on-OpenTitan.patch
@@ -1,4 +1,4 @@
-From f36a2c5d29559193c8a976bff2870539169f4893 Mon Sep 17 00:00:00 2001
+From 238c8583aa41156429c890e9761979007fae8be0 Mon Sep 17 00:00:00 2001
 From: Greg Chadwick <gac@lowrisc.org>
 Date: Wed, 15 Apr 2020 18:39:08 +0100
 Subject: [PATCH 3/3] Remove tests that do not pass on OpenTitan

--- a/sw/vendor/riscv_compliance/riscv-target/opentitan/device/rv32imc/Makefile.include
+++ b/sw/vendor/riscv_compliance/riscv-target/opentitan/device/rv32imc/Makefile.include
@@ -38,7 +38,7 @@ else ifeq ($(OT_TARGET),fpga_nexysvideo)
         ( test -e "$(OT_FPGA_UART)" || ( echo "UART device '$(OT_FPGA_UART)' not available. Set OT_FPGA_UART." >&2 && exit 1 ) ) \
         && echo "Writing '$(<).bin' to device." \
         && $(OT_BIN)/sw/host/spiflash/spiflash --input="$(<).bin" \
-        && stty -F "$(OT_FPGA_UART)" speed 230400 cs8 -cstopb -parenb \
+        && stty -F "$(OT_FPGA_UART)" speed 115200 cs8 -cstopb -parenb \
         && grep -o 'SIG: [a-zA-Z0-9_]*' "$(OT_FPGA_UART)" \
             | sed 's/SIG: //' > $(*).signature.output
 else


### PR DESCRIPTION
This PR lets the Xilinx clocking primitive generate a separate 10 MHz clock that is connected to the main clock input. Peripherals and IOs keep using the 12.5 MHz clock that is internally derived from the 50 MHz clock input.

There are multiple reasons for reducing the clock frequency from previously 50 MHz to 10 MHz:
- The FPGA build didn't meet timing previously, and at some point we decided to even disable the timing checks in CI.
- With the implementation of the otbn wide ALU (#3471 ), the critical paths got even longer.
- We are currently over-constraining the main clock on FPGA quite a bit which leads to high FPGA build times and CI timeouts & failures.
- As further (otbn) features get implemented, this will only get worse.
- For SCA analysis, we need some oversampling and the capture board can only run at 100 MHz. So we anyway have to reduce the clock frequency there.

This PR does not change the clocks of the peripherals to not touch the clkmgr. This can be reworked in a follow-up PR if necessary.

This is related to #3636 .

Note: I couldn't test this on the FPGA yet. But will do this and report back.