### PR TITLE
[kmac] Add shared secret key

### DIFF
--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -251,12 +251,12 @@
       ]
     } // R: STATUS
     { multireg: {
-        name: "KEY"
+        name: "KEY_SHARE0"
         desc: '''KMAC Secret Key
 
               KMAC secret key can be up to 512 bit.
               Order of the secret key is:
-              key[512:0] = {KEY0, KEY1, KEY2, ... , KEY15};
+              key[512:0] = {KEY15, KEY14, ... , KEY0};
 
               The registers are allowed to be updated when the engine is in Idle state.
               If the engine computes the hash, it discards any attempts to update the secret keys
@@ -277,20 +277,72 @@
             desc: "32-bit chunk of up-to 512-bit Secret Key"
           }
         ]
-      } // R: KEY
-    } // multireg: KEY
+      } // R: KEY_SHARE0
+    } // multireg: KEY_SHARE0
+    { multireg: {
+        name: "KEY_SHARE1"
+        desc: '''KMAC Secret Key, 2nd share.
+
+              KMAC secret key can be up to 512 bit.
+              Order of the secret key is:
+              key[512:0] = {KEY15, KEY14, ... , KEY0};
+
+              The registers are allowed to be updated when the engine is in Idle state.
+              If the engine computes the hash, it discards any attempts to update the secret keys
+              and report an error.
+
+              Current KMAC supports up to 512 bit secret key. It is the sw
+              responsibility to keep upper bits of the secret key to 0.
+              '''
+        count: "NumWordsKey"
+        cname: "KMAC"
+        hwext: "true"
+        hwqe : "true"
+        swaccess: "wo"
+        hwaccess: "hro"
+        fields: [
+          { bits: "31:0"
+            name: "key"
+            desc: "32-bit chunk of up-to 512-bit Secret Key"
+          }
+        ]
+      } // R: KEY_SHARE1
+    } // multireg: KEY_SHARE1
     { name: "KEY_LEN"
       desc: '''Secret Key length in bit.
 
             This value is used to make encoded secret key in KMAC.
             '''
+      regwen: "CFG_REGWEN"
       swaccess: "wo"
       hwaccess: "hro"
       hwext: "false"
       fields: [
-        { bits: "9:0"
+        { bits: "2:0"
           name: "len"
           desc: "Length in bits"
+          enum: [
+            { value: "0"
+              name:  "Key128"
+              desc: "Key length is 128 bit."
+            }
+            { value: "1"
+              name:  "Key192"
+              desc: "Key length is 192 bit."
+            }
+            { value: "2"
+              name:  "Key256"
+              desc: "Key length is 256 bit."
+            }
+            { value: "3"
+              name:  "Key384"
+              desc: "Key length is 384 bit."
+            }
+            { value: "4"
+              name:  "Key512"
+              desc: "Key length is 512 bit."
+            }
+          ]
         } // f : len
       ]
     } // R : KEY_LEN

--- a/hw/ip/kmac/rtl/kmac_reg_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_pkg.sv
@@ -92,10 +92,15 @@ package kmac_reg_pkg;
   typedef struct packed {
     logic [31:0] q;
     logic        qe;
-  } kmac_reg2hw_key_mreg_t;
+  } kmac_reg2hw_key_share0_mreg_t;
 
   typedef struct packed {
-    logic [9:0] q;
+    logic [31:0] q;
+    logic        qe;
+  } kmac_reg2hw_key_share1_mreg_t;
+
+  typedef struct packed {
+    logic [2:0]  q;
   } kmac_reg2hw_key_len_reg_t;
 
   typedef struct packed {
@@ -177,13 +182,14 @@ package kmac_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    kmac_reg2hw_intr_state_reg_t intr_state; // [928:926]
-    kmac_reg2hw_intr_enable_reg_t intr_enable; // [925:923]
-    kmac_reg2hw_intr_test_reg_t intr_test; // [922:917]
-    kmac_reg2hw_cfg_reg_t cfg; // [916:909]
-    kmac_reg2hw_cmd_reg_t cmd; // [908:901]
-    kmac_reg2hw_key_mreg_t [15:0] key; // [900:373]
-    kmac_reg2hw_key_len_reg_t key_len; // [372:363]
+    kmac_reg2hw_intr_state_reg_t intr_state; // [1449:1447]
+    kmac_reg2hw_intr_enable_reg_t intr_enable; // [1446:1444]
+    kmac_reg2hw_intr_test_reg_t intr_test; // [1443:1438]
+    kmac_reg2hw_cfg_reg_t cfg; // [1437:1430]
+    kmac_reg2hw_cmd_reg_t cmd; // [1429:1422]
+    kmac_reg2hw_key_share0_mreg_t [15:0] key_share0; // [1421:894]
+    kmac_reg2hw_key_share1_mreg_t [15:0] key_share1; // [893:366]
+    kmac_reg2hw_key_len_reg_t key_len; // [365:363]
     kmac_reg2hw_prefix_mreg_t [10:0] prefix; // [362:0]
   } kmac_reg2hw_t;
 
@@ -205,36 +211,52 @@ package kmac_reg_pkg;
   parameter logic [11:0] KMAC_CFG_OFFSET = 12'h c;
   parameter logic [11:0] KMAC_CMD_OFFSET = 12'h 10;
   parameter logic [11:0] KMAC_STATUS_OFFSET = 12'h 14;
-  parameter logic [11:0] KMAC_KEY_0_OFFSET = 12'h 18;
-  parameter logic [11:0] KMAC_KEY_1_OFFSET = 12'h 1c;
-  parameter logic [11:0] KMAC_KEY_2_OFFSET = 12'h 20;
-  parameter logic [11:0] KMAC_KEY_3_OFFSET = 12'h 24;
-  parameter logic [11:0] KMAC_KEY_4_OFFSET = 12'h 28;
-  parameter logic [11:0] KMAC_KEY_5_OFFSET = 12'h 2c;
-  parameter logic [11:0] KMAC_KEY_6_OFFSET = 12'h 30;
-  parameter logic [11:0] KMAC_KEY_7_OFFSET = 12'h 34;
-  parameter logic [11:0] KMAC_KEY_8_OFFSET = 12'h 38;
-  parameter logic [11:0] KMAC_KEY_9_OFFSET = 12'h 3c;
-  parameter logic [11:0] KMAC_KEY_10_OFFSET = 12'h 40;
-  parameter logic [11:0] KMAC_KEY_11_OFFSET = 12'h 44;
-  parameter logic [11:0] KMAC_KEY_12_OFFSET = 12'h 48;
-  parameter logic [11:0] KMAC_KEY_13_OFFSET = 12'h 4c;
-  parameter logic [11:0] KMAC_KEY_14_OFFSET = 12'h 50;
-  parameter logic [11:0] KMAC_KEY_15_OFFSET = 12'h 54;
-  parameter logic [11:0] KMAC_KEY_LEN_OFFSET = 12'h 58;
-  parameter logic [11:0] KMAC_PREFIX_0_OFFSET = 12'h 5c;
-  parameter logic [11:0] KMAC_PREFIX_1_OFFSET = 12'h 60;
-  parameter logic [11:0] KMAC_PREFIX_2_OFFSET = 12'h 64;
-  parameter logic [11:0] KMAC_PREFIX_3_OFFSET = 12'h 68;
-  parameter logic [11:0] KMAC_PREFIX_4_OFFSET = 12'h 6c;
-  parameter logic [11:0] KMAC_PREFIX_5_OFFSET = 12'h 70;
-  parameter logic [11:0] KMAC_PREFIX_6_OFFSET = 12'h 74;
-  parameter logic [11:0] KMAC_PREFIX_7_OFFSET = 12'h 78;
-  parameter logic [11:0] KMAC_PREFIX_8_OFFSET = 12'h 7c;
-  parameter logic [11:0] KMAC_PREFIX_9_OFFSET = 12'h 80;
-  parameter logic [11:0] KMAC_PREFIX_10_OFFSET = 12'h 84;
-  parameter logic [11:0] KMAC_ERR_CODE_OFFSET = 12'h 88;
-  parameter logic [11:0] KMAC_CFG_REGWEN_OFFSET = 12'h 8c;
+  parameter logic [11:0] KMAC_KEY_SHARE0_0_OFFSET = 12'h 18;
+  parameter logic [11:0] KMAC_KEY_SHARE0_1_OFFSET = 12'h 1c;
+  parameter logic [11:0] KMAC_KEY_SHARE0_2_OFFSET = 12'h 20;
+  parameter logic [11:0] KMAC_KEY_SHARE0_3_OFFSET = 12'h 24;
+  parameter logic [11:0] KMAC_KEY_SHARE0_4_OFFSET = 12'h 28;
+  parameter logic [11:0] KMAC_KEY_SHARE0_5_OFFSET = 12'h 2c;
+  parameter logic [11:0] KMAC_KEY_SHARE0_6_OFFSET = 12'h 30;
+  parameter logic [11:0] KMAC_KEY_SHARE0_7_OFFSET = 12'h 34;
+  parameter logic [11:0] KMAC_KEY_SHARE0_8_OFFSET = 12'h 38;
+  parameter logic [11:0] KMAC_KEY_SHARE0_9_OFFSET = 12'h 3c;
+  parameter logic [11:0] KMAC_KEY_SHARE0_10_OFFSET = 12'h 40;
+  parameter logic [11:0] KMAC_KEY_SHARE0_11_OFFSET = 12'h 44;
+  parameter logic [11:0] KMAC_KEY_SHARE0_12_OFFSET = 12'h 48;
+  parameter logic [11:0] KMAC_KEY_SHARE0_13_OFFSET = 12'h 4c;
+  parameter logic [11:0] KMAC_KEY_SHARE0_14_OFFSET = 12'h 50;
+  parameter logic [11:0] KMAC_KEY_SHARE0_15_OFFSET = 12'h 54;
+  parameter logic [11:0] KMAC_KEY_SHARE1_0_OFFSET = 12'h 58;
+  parameter logic [11:0] KMAC_KEY_SHARE1_1_OFFSET = 12'h 5c;
+  parameter logic [11:0] KMAC_KEY_SHARE1_2_OFFSET = 12'h 60;
+  parameter logic [11:0] KMAC_KEY_SHARE1_3_OFFSET = 12'h 64;
+  parameter logic [11:0] KMAC_KEY_SHARE1_4_OFFSET = 12'h 68;
+  parameter logic [11:0] KMAC_KEY_SHARE1_5_OFFSET = 12'h 6c;
+  parameter logic [11:0] KMAC_KEY_SHARE1_6_OFFSET = 12'h 70;
+  parameter logic [11:0] KMAC_KEY_SHARE1_7_OFFSET = 12'h 74;
+  parameter logic [11:0] KMAC_KEY_SHARE1_8_OFFSET = 12'h 78;
+  parameter logic [11:0] KMAC_KEY_SHARE1_9_OFFSET = 12'h 7c;
+  parameter logic [11:0] KMAC_KEY_SHARE1_10_OFFSET = 12'h 80;
+  parameter logic [11:0] KMAC_KEY_SHARE1_11_OFFSET = 12'h 84;
+  parameter logic [11:0] KMAC_KEY_SHARE1_12_OFFSET = 12'h 88;
+  parameter logic [11:0] KMAC_KEY_SHARE1_13_OFFSET = 12'h 8c;
+  parameter logic [11:0] KMAC_KEY_SHARE1_14_OFFSET = 12'h 90;
+  parameter logic [11:0] KMAC_KEY_SHARE1_15_OFFSET = 12'h 94;
+  parameter logic [11:0] KMAC_KEY_LEN_OFFSET = 12'h 98;
+  parameter logic [11:0] KMAC_PREFIX_0_OFFSET = 12'h 9c;
+  parameter logic [11:0] KMAC_PREFIX_1_OFFSET = 12'h a0;
+  parameter logic [11:0] KMAC_PREFIX_2_OFFSET = 12'h a4;
+  parameter logic [11:0] KMAC_PREFIX_3_OFFSET = 12'h a8;
+  parameter logic [11:0] KMAC_PREFIX_4_OFFSET = 12'h ac;
+  parameter logic [11:0] KMAC_PREFIX_5_OFFSET = 12'h b0;
+  parameter logic [11:0] KMAC_PREFIX_6_OFFSET = 12'h b4;
+  parameter logic [11:0] KMAC_PREFIX_7_OFFSET = 12'h b8;
+  parameter logic [11:0] KMAC_PREFIX_8_OFFSET = 12'h bc;
+  parameter logic [11:0] KMAC_PREFIX_9_OFFSET = 12'h c0;
+  parameter logic [11:0] KMAC_PREFIX_10_OFFSET = 12'h c4;
+  parameter logic [11:0] KMAC_ERR_CODE_OFFSET = 12'h c8;
+  parameter logic [11:0] KMAC_CFG_REGWEN_OFFSET = 12'h cc;
 
   // Window parameter
   parameter logic [11:0] KMAC_STATE_OFFSET = 12'h 400;
@@ -250,22 +272,38 @@ package kmac_reg_pkg;
     KMAC_CFG,
     KMAC_CMD,
     KMAC_STATUS,
-    KMAC_KEY_0,
-    KMAC_KEY_1,
-    KMAC_KEY_2,
-    KMAC_KEY_3,
-    KMAC_KEY_4,
-    KMAC_KEY_5,
-    KMAC_KEY_6,
-    KMAC_KEY_7,
-    KMAC_KEY_8,
-    KMAC_KEY_9,
-    KMAC_KEY_10,
-    KMAC_KEY_11,
-    KMAC_KEY_12,
-    KMAC_KEY_13,
-    KMAC_KEY_14,
-    KMAC_KEY_15,
+    KMAC_KEY_SHARE0_0,
+    KMAC_KEY_SHARE0_1,
+    KMAC_KEY_SHARE0_2,
+    KMAC_KEY_SHARE0_3,
+    KMAC_KEY_SHARE0_4,
+    KMAC_KEY_SHARE0_5,
+    KMAC_KEY_SHARE0_6,
+    KMAC_KEY_SHARE0_7,
+    KMAC_KEY_SHARE0_8,
+    KMAC_KEY_SHARE0_9,
+    KMAC_KEY_SHARE0_10,
+    KMAC_KEY_SHARE0_11,
+    KMAC_KEY_SHARE0_12,
+    KMAC_KEY_SHARE0_13,
+    KMAC_KEY_SHARE0_14,
+    KMAC_KEY_SHARE0_15,
+    KMAC_KEY_SHARE1_0,
+    KMAC_KEY_SHARE1_1,
+    KMAC_KEY_SHARE1_2,
+    KMAC_KEY_SHARE1_3,
+    KMAC_KEY_SHARE1_4,
+    KMAC_KEY_SHARE1_5,
+    KMAC_KEY_SHARE1_6,
+    KMAC_KEY_SHARE1_7,
+    KMAC_KEY_SHARE1_8,
+    KMAC_KEY_SHARE1_9,
+    KMAC_KEY_SHARE1_10,
+    KMAC_KEY_SHARE1_11,
+    KMAC_KEY_SHARE1_12,
+    KMAC_KEY_SHARE1_13,
+    KMAC_KEY_SHARE1_14,
+    KMAC_KEY_SHARE1_15,
     KMAC_KEY_LEN,
     KMAC_PREFIX_0,
     KMAC_PREFIX_1,
@@ -283,43 +321,59 @@ package kmac_reg_pkg;
   } kmac_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] KMAC_PERMIT [36] = '{
+  parameter logic [3:0] KMAC_PERMIT [52] = '{
     4'b 0001, // index[ 0] KMAC_INTR_STATE
     4'b 0001, // index[ 1] KMAC_INTR_ENABLE
     4'b 0001, // index[ 2] KMAC_INTR_TEST
     4'b 0011, // index[ 3] KMAC_CFG
     4'b 0001, // index[ 4] KMAC_CMD
     4'b 0011, // index[ 5] KMAC_STATUS
-    4'b 1111, // index[ 6] KMAC_KEY_0
-    4'b 1111, // index[ 7] KMAC_KEY_1
-    4'b 1111, // index[ 8] KMAC_KEY_2
-    4'b 1111, // index[ 9] KMAC_KEY_3
-    4'b 1111, // index[10] KMAC_KEY_4
-    4'b 1111, // index[11] KMAC_KEY_5
-    4'b 1111, // index[12] KMAC_KEY_6
-    4'b 1111, // index[13] KMAC_KEY_7
-    4'b 1111, // index[14] KMAC_KEY_8
-    4'b 1111, // index[15] KMAC_KEY_9
-    4'b 1111, // index[16] KMAC_KEY_10
-    4'b 1111, // index[17] KMAC_KEY_11
-    4'b 1111, // index[18] KMAC_KEY_12
-    4'b 1111, // index[19] KMAC_KEY_13
-    4'b 1111, // index[20] KMAC_KEY_14
-    4'b 1111, // index[21] KMAC_KEY_15
-    4'b 0011, // index[22] KMAC_KEY_LEN
-    4'b 1111, // index[23] KMAC_PREFIX_0
-    4'b 1111, // index[24] KMAC_PREFIX_1
-    4'b 1111, // index[25] KMAC_PREFIX_2
-    4'b 1111, // index[26] KMAC_PREFIX_3
-    4'b 1111, // index[27] KMAC_PREFIX_4
-    4'b 1111, // index[28] KMAC_PREFIX_5
-    4'b 1111, // index[29] KMAC_PREFIX_6
-    4'b 1111, // index[30] KMAC_PREFIX_7
-    4'b 1111, // index[31] KMAC_PREFIX_8
-    4'b 1111, // index[32] KMAC_PREFIX_9
-    4'b 1111, // index[33] KMAC_PREFIX_10
-    4'b 1111, // index[34] KMAC_ERR_CODE
-    4'b 0001  // index[35] KMAC_CFG_REGWEN
+    4'b 1111, // index[ 6] KMAC_KEY_SHARE0_0
+    4'b 1111, // index[ 7] KMAC_KEY_SHARE0_1
+    4'b 1111, // index[ 8] KMAC_KEY_SHARE0_2
+    4'b 1111, // index[ 9] KMAC_KEY_SHARE0_3
+    4'b 1111, // index[10] KMAC_KEY_SHARE0_4
+    4'b 1111, // index[11] KMAC_KEY_SHARE0_5
+    4'b 1111, // index[12] KMAC_KEY_SHARE0_6
+    4'b 1111, // index[13] KMAC_KEY_SHARE0_7
+    4'b 1111, // index[14] KMAC_KEY_SHARE0_8
+    4'b 1111, // index[15] KMAC_KEY_SHARE0_9
+    4'b 1111, // index[16] KMAC_KEY_SHARE0_10
+    4'b 1111, // index[17] KMAC_KEY_SHARE0_11
+    4'b 1111, // index[18] KMAC_KEY_SHARE0_12
+    4'b 1111, // index[19] KMAC_KEY_SHARE0_13
+    4'b 1111, // index[20] KMAC_KEY_SHARE0_14
+    4'b 1111, // index[21] KMAC_KEY_SHARE0_15
+    4'b 1111, // index[22] KMAC_KEY_SHARE1_0
+    4'b 1111, // index[23] KMAC_KEY_SHARE1_1
+    4'b 1111, // index[24] KMAC_KEY_SHARE1_2
+    4'b 1111, // index[25] KMAC_KEY_SHARE1_3
+    4'b 1111, // index[26] KMAC_KEY_SHARE1_4
+    4'b 1111, // index[27] KMAC_KEY_SHARE1_5
+    4'b 1111, // index[28] KMAC_KEY_SHARE1_6
+    4'b 1111, // index[29] KMAC_KEY_SHARE1_7
+    4'b 1111, // index[30] KMAC_KEY_SHARE1_8
+    4'b 1111, // index[31] KMAC_KEY_SHARE1_9
+    4'b 1111, // index[32] KMAC_KEY_SHARE1_10
+    4'b 1111, // index[33] KMAC_KEY_SHARE1_11
+    4'b 1111, // index[34] KMAC_KEY_SHARE1_12
+    4'b 1111, // index[35] KMAC_KEY_SHARE1_13
+    4'b 1111, // index[36] KMAC_KEY_SHARE1_14
+    4'b 1111, // index[37] KMAC_KEY_SHARE1_15
+    4'b 0001, // index[38] KMAC_KEY_LEN
+    4'b 1111, // index[39] KMAC_PREFIX_0
+    4'b 1111, // index[40] KMAC_PREFIX_1
+    4'b 1111, // index[41] KMAC_PREFIX_2
+    4'b 1111, // index[42] KMAC_PREFIX_3
+    4'b 1111, // index[43] KMAC_PREFIX_4
+    4'b 1111, // index[44] KMAC_PREFIX_5
+    4'b 1111, // index[45] KMAC_PREFIX_6
+    4'b 1111, // index[46] KMAC_PREFIX_7
+    4'b 1111, // index[47] KMAC_PREFIX_8
+    4'b 1111, // index[48] KMAC_PREFIX_9
+    4'b 1111, // index[49] KMAC_PREFIX_10
+    4'b 1111, // index[50] KMAC_ERR_CODE
+    4'b 0001  // index[51] KMAC_CFG_REGWEN
   };
 endpackage
 

--- a/hw/ip/kmac/rtl/kmac_reg_top.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_top.sv
@@ -181,39 +181,71 @@ module kmac_reg_top (
   logic status_fifo_empty_re;
   logic status_fifo_full_qs;
   logic status_fifo_full_re;
-  logic [31:0] key_0_wd;
-  logic key_0_we;
-  logic [31:0] key_1_wd;
-  logic key_1_we;
-  logic [31:0] key_2_wd;
-  logic key_2_we;
-  logic [31:0] key_3_wd;
-  logic key_3_we;
-  logic [31:0] key_4_wd;
-  logic key_4_we;
-  logic [31:0] key_5_wd;
-  logic key_5_we;
-  logic [31:0] key_6_wd;
-  logic key_6_we;
-  logic [31:0] key_7_wd;
-  logic key_7_we;
-  logic [31:0] key_8_wd;
-  logic key_8_we;
-  logic [31:0] key_9_wd;
-  logic key_9_we;
-  logic [31:0] key_10_wd;
-  logic key_10_we;
-  logic [31:0] key_11_wd;
-  logic key_11_we;
-  logic [31:0] key_12_wd;
-  logic key_12_we;
-  logic [31:0] key_13_wd;
-  logic key_13_we;
-  logic [31:0] key_14_wd;
-  logic key_14_we;
-  logic [31:0] key_15_wd;
-  logic key_15_we;
-  logic [9:0] key_len_wd;
+  logic [31:0] key_share0_0_wd;
+  logic key_share0_0_we;
+  logic [31:0] key_share0_1_wd;
+  logic key_share0_1_we;
+  logic [31:0] key_share0_2_wd;
+  logic key_share0_2_we;
+  logic [31:0] key_share0_3_wd;
+  logic key_share0_3_we;
+  logic [31:0] key_share0_4_wd;
+  logic key_share0_4_we;
+  logic [31:0] key_share0_5_wd;
+  logic key_share0_5_we;
+  logic [31:0] key_share0_6_wd;
+  logic key_share0_6_we;
+  logic [31:0] key_share0_7_wd;
+  logic key_share0_7_we;
+  logic [31:0] key_share0_8_wd;
+  logic key_share0_8_we;
+  logic [31:0] key_share0_9_wd;
+  logic key_share0_9_we;
+  logic [31:0] key_share0_10_wd;
+  logic key_share0_10_we;
+  logic [31:0] key_share0_11_wd;
+  logic key_share0_11_we;
+  logic [31:0] key_share0_12_wd;
+  logic key_share0_12_we;
+  logic [31:0] key_share0_13_wd;
+  logic key_share0_13_we;
+  logic [31:0] key_share0_14_wd;
+  logic key_share0_14_we;
+  logic [31:0] key_share0_15_wd;
+  logic key_share0_15_we;
+  logic [31:0] key_share1_0_wd;
+  logic key_share1_0_we;
+  logic [31:0] key_share1_1_wd;
+  logic key_share1_1_we;
+  logic [31:0] key_share1_2_wd;
+  logic key_share1_2_we;
+  logic [31:0] key_share1_3_wd;
+  logic key_share1_3_we;
+  logic [31:0] key_share1_4_wd;
+  logic key_share1_4_we;
+  logic [31:0] key_share1_5_wd;
+  logic key_share1_5_we;
+  logic [31:0] key_share1_6_wd;
+  logic key_share1_6_we;
+  logic [31:0] key_share1_7_wd;
+  logic key_share1_7_we;
+  logic [31:0] key_share1_8_wd;
+  logic key_share1_8_we;
+  logic [31:0] key_share1_9_wd;
+  logic key_share1_9_we;
+  logic [31:0] key_share1_10_wd;
+  logic key_share1_10_we;
+  logic [31:0] key_share1_11_wd;
+  logic key_share1_11_we;
+  logic [31:0] key_share1_12_wd;
+  logic key_share1_12_we;
+  logic [31:0] key_share1_13_wd;
+  logic key_share1_13_we;
+  logic [31:0] key_share1_14_wd;
+  logic key_share1_14_we;
+  logic [31:0] key_share1_15_wd;
+  logic key_share1_15_we;
+  logic [2:0] key_len_wd;
   logic key_len_we;
   logic [31:0] prefix_0_qs;
   logic [31:0] prefix_0_wd;
@@ -747,259 +779,517 @@ module kmac_reg_top (
 
 
 
-  // Subregister 0 of Multireg key
-  // R[key_0]: V(True)
+  // Subregister 0 of Multireg key_share0
+  // R[key_share0_0]: V(True)
 
   prim_subreg_ext #(
     .DW    (32)
-  ) u_key_0 (
+  ) u_key_share0_0 (
     .re     (1'b0),
-    .we     (key_0_we),
-    .wd     (key_0_wd),
+    .we     (key_share0_0_we),
+    .wd     (key_share0_0_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key[0].qe),
-    .q      (reg2hw.key[0].q ),
+    .qe     (reg2hw.key_share0[0].qe),
+    .q      (reg2hw.key_share0[0].q ),
     .qs     ()
   );
 
-  // Subregister 1 of Multireg key
-  // R[key_1]: V(True)
+  // Subregister 1 of Multireg key_share0
+  // R[key_share0_1]: V(True)
 
   prim_subreg_ext #(
     .DW    (32)
-  ) u_key_1 (
+  ) u_key_share0_1 (
     .re     (1'b0),
-    .we     (key_1_we),
-    .wd     (key_1_wd),
+    .we     (key_share0_1_we),
+    .wd     (key_share0_1_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key[1].qe),
-    .q      (reg2hw.key[1].q ),
+    .qe     (reg2hw.key_share0[1].qe),
+    .q      (reg2hw.key_share0[1].q ),
     .qs     ()
   );
 
-  // Subregister 2 of Multireg key
-  // R[key_2]: V(True)
+  // Subregister 2 of Multireg key_share0
+  // R[key_share0_2]: V(True)
 
   prim_subreg_ext #(
     .DW    (32)
-  ) u_key_2 (
+  ) u_key_share0_2 (
     .re     (1'b0),
-    .we     (key_2_we),
-    .wd     (key_2_wd),
+    .we     (key_share0_2_we),
+    .wd     (key_share0_2_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key[2].qe),
-    .q      (reg2hw.key[2].q ),
+    .qe     (reg2hw.key_share0[2].qe),
+    .q      (reg2hw.key_share0[2].q ),
     .qs     ()
   );
 
-  // Subregister 3 of Multireg key
-  // R[key_3]: V(True)
+  // Subregister 3 of Multireg key_share0
+  // R[key_share0_3]: V(True)
 
   prim_subreg_ext #(
     .DW    (32)
-  ) u_key_3 (
+  ) u_key_share0_3 (
     .re     (1'b0),
-    .we     (key_3_we),
-    .wd     (key_3_wd),
+    .we     (key_share0_3_we),
+    .wd     (key_share0_3_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key[3].qe),
-    .q      (reg2hw.key[3].q ),
+    .qe     (reg2hw.key_share0[3].qe),
+    .q      (reg2hw.key_share0[3].q ),
     .qs     ()
   );
 
-  // Subregister 4 of Multireg key
-  // R[key_4]: V(True)
+  // Subregister 4 of Multireg key_share0
+  // R[key_share0_4]: V(True)
 
   prim_subreg_ext #(
     .DW    (32)
-  ) u_key_4 (
+  ) u_key_share0_4 (
     .re     (1'b0),
-    .we     (key_4_we),
-    .wd     (key_4_wd),
+    .we     (key_share0_4_we),
+    .wd     (key_share0_4_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key[4].qe),
-    .q      (reg2hw.key[4].q ),
+    .qe     (reg2hw.key_share0[4].qe),
+    .q      (reg2hw.key_share0[4].q ),
     .qs     ()
   );
 
-  // Subregister 5 of Multireg key
-  // R[key_5]: V(True)
+  // Subregister 5 of Multireg key_share0
+  // R[key_share0_5]: V(True)
 
   prim_subreg_ext #(
     .DW    (32)
-  ) u_key_5 (
+  ) u_key_share0_5 (
     .re     (1'b0),
-    .we     (key_5_we),
-    .wd     (key_5_wd),
+    .we     (key_share0_5_we),
+    .wd     (key_share0_5_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key[5].qe),
-    .q      (reg2hw.key[5].q ),
+    .qe     (reg2hw.key_share0[5].qe),
+    .q      (reg2hw.key_share0[5].q ),
     .qs     ()
   );
 
-  // Subregister 6 of Multireg key
-  // R[key_6]: V(True)
+  // Subregister 6 of Multireg key_share0
+  // R[key_share0_6]: V(True)
 
   prim_subreg_ext #(
     .DW    (32)
-  ) u_key_6 (
+  ) u_key_share0_6 (
     .re     (1'b0),
-    .we     (key_6_we),
-    .wd     (key_6_wd),
+    .we     (key_share0_6_we),
+    .wd     (key_share0_6_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key[6].qe),
-    .q      (reg2hw.key[6].q ),
+    .qe     (reg2hw.key_share0[6].qe),
+    .q      (reg2hw.key_share0[6].q ),
     .qs     ()
   );
 
-  // Subregister 7 of Multireg key
-  // R[key_7]: V(True)
+  // Subregister 7 of Multireg key_share0
+  // R[key_share0_7]: V(True)
 
   prim_subreg_ext #(
     .DW    (32)
-  ) u_key_7 (
+  ) u_key_share0_7 (
     .re     (1'b0),
-    .we     (key_7_we),
-    .wd     (key_7_wd),
+    .we     (key_share0_7_we),
+    .wd     (key_share0_7_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key[7].qe),
-    .q      (reg2hw.key[7].q ),
+    .qe     (reg2hw.key_share0[7].qe),
+    .q      (reg2hw.key_share0[7].q ),
     .qs     ()
   );
 
-  // Subregister 8 of Multireg key
-  // R[key_8]: V(True)
+  // Subregister 8 of Multireg key_share0
+  // R[key_share0_8]: V(True)
 
   prim_subreg_ext #(
     .DW    (32)
-  ) u_key_8 (
+  ) u_key_share0_8 (
     .re     (1'b0),
-    .we     (key_8_we),
-    .wd     (key_8_wd),
+    .we     (key_share0_8_we),
+    .wd     (key_share0_8_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key[8].qe),
-    .q      (reg2hw.key[8].q ),
+    .qe     (reg2hw.key_share0[8].qe),
+    .q      (reg2hw.key_share0[8].q ),
     .qs     ()
   );
 
-  // Subregister 9 of Multireg key
-  // R[key_9]: V(True)
+  // Subregister 9 of Multireg key_share0
+  // R[key_share0_9]: V(True)
 
   prim_subreg_ext #(
     .DW    (32)
-  ) u_key_9 (
+  ) u_key_share0_9 (
     .re     (1'b0),
-    .we     (key_9_we),
-    .wd     (key_9_wd),
+    .we     (key_share0_9_we),
+    .wd     (key_share0_9_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key[9].qe),
-    .q      (reg2hw.key[9].q ),
+    .qe     (reg2hw.key_share0[9].qe),
+    .q      (reg2hw.key_share0[9].q ),
     .qs     ()
   );
 
-  // Subregister 10 of Multireg key
-  // R[key_10]: V(True)
+  // Subregister 10 of Multireg key_share0
+  // R[key_share0_10]: V(True)
 
   prim_subreg_ext #(
     .DW    (32)
-  ) u_key_10 (
+  ) u_key_share0_10 (
     .re     (1'b0),
-    .we     (key_10_we),
-    .wd     (key_10_wd),
+    .we     (key_share0_10_we),
+    .wd     (key_share0_10_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key[10].qe),
-    .q      (reg2hw.key[10].q ),
+    .qe     (reg2hw.key_share0[10].qe),
+    .q      (reg2hw.key_share0[10].q ),
     .qs     ()
   );
 
-  // Subregister 11 of Multireg key
-  // R[key_11]: V(True)
+  // Subregister 11 of Multireg key_share0
+  // R[key_share0_11]: V(True)
 
   prim_subreg_ext #(
     .DW    (32)
-  ) u_key_11 (
+  ) u_key_share0_11 (
     .re     (1'b0),
-    .we     (key_11_we),
-    .wd     (key_11_wd),
+    .we     (key_share0_11_we),
+    .wd     (key_share0_11_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key[11].qe),
-    .q      (reg2hw.key[11].q ),
+    .qe     (reg2hw.key_share0[11].qe),
+    .q      (reg2hw.key_share0[11].q ),
     .qs     ()
   );
 
-  // Subregister 12 of Multireg key
-  // R[key_12]: V(True)
+  // Subregister 12 of Multireg key_share0
+  // R[key_share0_12]: V(True)
 
   prim_subreg_ext #(
     .DW    (32)
-  ) u_key_12 (
+  ) u_key_share0_12 (
     .re     (1'b0),
-    .we     (key_12_we),
-    .wd     (key_12_wd),
+    .we     (key_share0_12_we),
+    .wd     (key_share0_12_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key[12].qe),
-    .q      (reg2hw.key[12].q ),
+    .qe     (reg2hw.key_share0[12].qe),
+    .q      (reg2hw.key_share0[12].q ),
     .qs     ()
   );
 
-  // Subregister 13 of Multireg key
-  // R[key_13]: V(True)
+  // Subregister 13 of Multireg key_share0
+  // R[key_share0_13]: V(True)
 
   prim_subreg_ext #(
     .DW    (32)
-  ) u_key_13 (
+  ) u_key_share0_13 (
     .re     (1'b0),
-    .we     (key_13_we),
-    .wd     (key_13_wd),
+    .we     (key_share0_13_we),
+    .wd     (key_share0_13_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key[13].qe),
-    .q      (reg2hw.key[13].q ),
+    .qe     (reg2hw.key_share0[13].qe),
+    .q      (reg2hw.key_share0[13].q ),
     .qs     ()
   );
 
-  // Subregister 14 of Multireg key
-  // R[key_14]: V(True)
+  // Subregister 14 of Multireg key_share0
+  // R[key_share0_14]: V(True)
 
   prim_subreg_ext #(
     .DW    (32)
-  ) u_key_14 (
+  ) u_key_share0_14 (
     .re     (1'b0),
-    .we     (key_14_we),
-    .wd     (key_14_wd),
+    .we     (key_share0_14_we),
+    .wd     (key_share0_14_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key[14].qe),
-    .q      (reg2hw.key[14].q ),
+    .qe     (reg2hw.key_share0[14].qe),
+    .q      (reg2hw.key_share0[14].q ),
     .qs     ()
   );
 
-  // Subregister 15 of Multireg key
-  // R[key_15]: V(True)
+  // Subregister 15 of Multireg key_share0
+  // R[key_share0_15]: V(True)
 
   prim_subreg_ext #(
     .DW    (32)
-  ) u_key_15 (
+  ) u_key_share0_15 (
     .re     (1'b0),
-    .we     (key_15_we),
-    .wd     (key_15_wd),
+    .we     (key_share0_15_we),
+    .wd     (key_share0_15_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key[15].qe),
-    .q      (reg2hw.key[15].q ),
+    .qe     (reg2hw.key_share0[15].qe),
+    .q      (reg2hw.key_share0[15].q ),
+    .qs     ()
+  );
+
+
+
+  // Subregister 0 of Multireg key_share1
+  // R[key_share1_0]: V(True)
+
+  prim_subreg_ext #(
+    .DW    (32)
+  ) u_key_share1_0 (
+    .re     (1'b0),
+    .we     (key_share1_0_we),
+    .wd     (key_share1_0_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (reg2hw.key_share1[0].qe),
+    .q      (reg2hw.key_share1[0].q ),
+    .qs     ()
+  );
+
+  // Subregister 1 of Multireg key_share1
+  // R[key_share1_1]: V(True)
+
+  prim_subreg_ext #(
+    .DW    (32)
+  ) u_key_share1_1 (
+    .re     (1'b0),
+    .we     (key_share1_1_we),
+    .wd     (key_share1_1_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (reg2hw.key_share1[1].qe),
+    .q      (reg2hw.key_share1[1].q ),
+    .qs     ()
+  );
+
+  // Subregister 2 of Multireg key_share1
+  // R[key_share1_2]: V(True)
+
+  prim_subreg_ext #(
+    .DW    (32)
+  ) u_key_share1_2 (
+    .re     (1'b0),
+    .we     (key_share1_2_we),
+    .wd     (key_share1_2_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (reg2hw.key_share1[2].qe),
+    .q      (reg2hw.key_share1[2].q ),
+    .qs     ()
+  );
+
+  // Subregister 3 of Multireg key_share1
+  // R[key_share1_3]: V(True)
+
+  prim_subreg_ext #(
+    .DW    (32)
+  ) u_key_share1_3 (
+    .re     (1'b0),
+    .we     (key_share1_3_we),
+    .wd     (key_share1_3_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (reg2hw.key_share1[3].qe),
+    .q      (reg2hw.key_share1[3].q ),
+    .qs     ()
+  );
+
+  // Subregister 4 of Multireg key_share1
+  // R[key_share1_4]: V(True)
+
+  prim_subreg_ext #(
+    .DW    (32)
+  ) u_key_share1_4 (
+    .re     (1'b0),
+    .we     (key_share1_4_we),
+    .wd     (key_share1_4_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (reg2hw.key_share1[4].qe),
+    .q      (reg2hw.key_share1[4].q ),
+    .qs     ()
+  );
+
+  // Subregister 5 of Multireg key_share1
+  // R[key_share1_5]: V(True)
+
+  prim_subreg_ext #(
+    .DW    (32)
+  ) u_key_share1_5 (
+    .re     (1'b0),
+    .we     (key_share1_5_we),
+    .wd     (key_share1_5_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (reg2hw.key_share1[5].qe),
+    .q      (reg2hw.key_share1[5].q ),
+    .qs     ()
+  );
+
+  // Subregister 6 of Multireg key_share1
+  // R[key_share1_6]: V(True)
+
+  prim_subreg_ext #(
+    .DW    (32)
+  ) u_key_share1_6 (
+    .re     (1'b0),
+    .we     (key_share1_6_we),
+    .wd     (key_share1_6_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (reg2hw.key_share1[6].qe),
+    .q      (reg2hw.key_share1[6].q ),
+    .qs     ()
+  );
+
+  // Subregister 7 of Multireg key_share1
+  // R[key_share1_7]: V(True)
+
+  prim_subreg_ext #(
+    .DW    (32)
+  ) u_key_share1_7 (
+    .re     (1'b0),
+    .we     (key_share1_7_we),
+    .wd     (key_share1_7_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (reg2hw.key_share1[7].qe),
+    .q      (reg2hw.key_share1[7].q ),
+    .qs     ()
+  );
+
+  // Subregister 8 of Multireg key_share1
+  // R[key_share1_8]: V(True)
+
+  prim_subreg_ext #(
+    .DW    (32)
+  ) u_key_share1_8 (
+    .re     (1'b0),
+    .we     (key_share1_8_we),
+    .wd     (key_share1_8_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (reg2hw.key_share1[8].qe),
+    .q      (reg2hw.key_share1[8].q ),
+    .qs     ()
+  );
+
+  // Subregister 9 of Multireg key_share1
+  // R[key_share1_9]: V(True)
+
+  prim_subreg_ext #(
+    .DW    (32)
+  ) u_key_share1_9 (
+    .re     (1'b0),
+    .we     (key_share1_9_we),
+    .wd     (key_share1_9_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (reg2hw.key_share1[9].qe),
+    .q      (reg2hw.key_share1[9].q ),
+    .qs     ()
+  );
+
+  // Subregister 10 of Multireg key_share1
+  // R[key_share1_10]: V(True)
+
+  prim_subreg_ext #(
+    .DW    (32)
+  ) u_key_share1_10 (
+    .re     (1'b0),
+    .we     (key_share1_10_we),
+    .wd     (key_share1_10_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (reg2hw.key_share1[10].qe),
+    .q      (reg2hw.key_share1[10].q ),
+    .qs     ()
+  );
+
+  // Subregister 11 of Multireg key_share1
+  // R[key_share1_11]: V(True)
+
+  prim_subreg_ext #(
+    .DW    (32)
+  ) u_key_share1_11 (
+    .re     (1'b0),
+    .we     (key_share1_11_we),
+    .wd     (key_share1_11_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (reg2hw.key_share1[11].qe),
+    .q      (reg2hw.key_share1[11].q ),
+    .qs     ()
+  );
+
+  // Subregister 12 of Multireg key_share1
+  // R[key_share1_12]: V(True)
+
+  prim_subreg_ext #(
+    .DW    (32)
+  ) u_key_share1_12 (
+    .re     (1'b0),
+    .we     (key_share1_12_we),
+    .wd     (key_share1_12_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (reg2hw.key_share1[12].qe),
+    .q      (reg2hw.key_share1[12].q ),
+    .qs     ()
+  );
+
+  // Subregister 13 of Multireg key_share1
+  // R[key_share1_13]: V(True)
+
+  prim_subreg_ext #(
+    .DW    (32)
+  ) u_key_share1_13 (
+    .re     (1'b0),
+    .we     (key_share1_13_we),
+    .wd     (key_share1_13_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (reg2hw.key_share1[13].qe),
+    .q      (reg2hw.key_share1[13].q ),
+    .qs     ()
+  );
+
+  // Subregister 14 of Multireg key_share1
+  // R[key_share1_14]: V(True)
+
+  prim_subreg_ext #(
+    .DW    (32)
+  ) u_key_share1_14 (
+    .re     (1'b0),
+    .we     (key_share1_14_we),
+    .wd     (key_share1_14_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (reg2hw.key_share1[14].qe),
+    .q      (reg2hw.key_share1[14].q ),
+    .qs     ()
+  );
+
+  // Subregister 15 of Multireg key_share1
+  // R[key_share1_15]: V(True)
+
+  prim_subreg_ext #(
+    .DW    (32)
+  ) u_key_share1_15 (
+    .re     (1'b0),
+    .we     (key_share1_15_we),
+    .wd     (key_share1_15_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (reg2hw.key_share1[15].qe),
+    .q      (reg2hw.key_share1[15].q ),
     .qs     ()
   );
 
@@ -1007,15 +1297,15 @@ module kmac_reg_top (
   // R[key_len]: V(False)
 
   prim_subreg #(
-    .DW      (10),
+    .DW      (3),
     .SWACCESS("WO"),
-    .RESVAL  (10'h0)
+    .RESVAL  (3'h0)
   ) u_key_len (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
-    // from register interface
-    .we     (key_len_we),
+    // from register interface (qualified with register enable)
+    .we     (key_len_we & cfg_regwen_qs),
     .wd     (key_len_wd),
 
     // from internal hardware
@@ -1373,7 +1663,7 @@ module kmac_reg_top (
 
 
 
-  logic [35:0] addr_hit;
+  logic [51:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == KMAC_INTR_STATE_OFFSET);
@@ -1382,36 +1672,52 @@ module kmac_reg_top (
     addr_hit[ 3] = (reg_addr == KMAC_CFG_OFFSET);
     addr_hit[ 4] = (reg_addr == KMAC_CMD_OFFSET);
     addr_hit[ 5] = (reg_addr == KMAC_STATUS_OFFSET);
-    addr_hit[ 6] = (reg_addr == KMAC_KEY_0_OFFSET);
-    addr_hit[ 7] = (reg_addr == KMAC_KEY_1_OFFSET);
-    addr_hit[ 8] = (reg_addr == KMAC_KEY_2_OFFSET);
-    addr_hit[ 9] = (reg_addr == KMAC_KEY_3_OFFSET);
-    addr_hit[10] = (reg_addr == KMAC_KEY_4_OFFSET);
-    addr_hit[11] = (reg_addr == KMAC_KEY_5_OFFSET);
-    addr_hit[12] = (reg_addr == KMAC_KEY_6_OFFSET);
-    addr_hit[13] = (reg_addr == KMAC_KEY_7_OFFSET);
-    addr_hit[14] = (reg_addr == KMAC_KEY_8_OFFSET);
-    addr_hit[15] = (reg_addr == KMAC_KEY_9_OFFSET);
-    addr_hit[16] = (reg_addr == KMAC_KEY_10_OFFSET);
-    addr_hit[17] = (reg_addr == KMAC_KEY_11_OFFSET);
-    addr_hit[18] = (reg_addr == KMAC_KEY_12_OFFSET);
-    addr_hit[19] = (reg_addr == KMAC_KEY_13_OFFSET);
-    addr_hit[20] = (reg_addr == KMAC_KEY_14_OFFSET);
-    addr_hit[21] = (reg_addr == KMAC_KEY_15_OFFSET);
-    addr_hit[22] = (reg_addr == KMAC_KEY_LEN_OFFSET);
-    addr_hit[23] = (reg_addr == KMAC_PREFIX_0_OFFSET);
-    addr_hit[24] = (reg_addr == KMAC_PREFIX_1_OFFSET);
-    addr_hit[25] = (reg_addr == KMAC_PREFIX_2_OFFSET);
-    addr_hit[26] = (reg_addr == KMAC_PREFIX_3_OFFSET);
-    addr_hit[27] = (reg_addr == KMAC_PREFIX_4_OFFSET);
-    addr_hit[28] = (reg_addr == KMAC_PREFIX_5_OFFSET);
-    addr_hit[29] = (reg_addr == KMAC_PREFIX_6_OFFSET);
-    addr_hit[30] = (reg_addr == KMAC_PREFIX_7_OFFSET);
-    addr_hit[31] = (reg_addr == KMAC_PREFIX_8_OFFSET);
-    addr_hit[32] = (reg_addr == KMAC_PREFIX_9_OFFSET);
-    addr_hit[33] = (reg_addr == KMAC_PREFIX_10_OFFSET);
-    addr_hit[34] = (reg_addr == KMAC_ERR_CODE_OFFSET);
-    addr_hit[35] = (reg_addr == KMAC_CFG_REGWEN_OFFSET);
+    addr_hit[ 6] = (reg_addr == KMAC_KEY_SHARE0_0_OFFSET);
+    addr_hit[ 7] = (reg_addr == KMAC_KEY_SHARE0_1_OFFSET);
+    addr_hit[ 8] = (reg_addr == KMAC_KEY_SHARE0_2_OFFSET);
+    addr_hit[ 9] = (reg_addr == KMAC_KEY_SHARE0_3_OFFSET);
+    addr_hit[10] = (reg_addr == KMAC_KEY_SHARE0_4_OFFSET);
+    addr_hit[11] = (reg_addr == KMAC_KEY_SHARE0_5_OFFSET);
+    addr_hit[12] = (reg_addr == KMAC_KEY_SHARE0_6_OFFSET);
+    addr_hit[13] = (reg_addr == KMAC_KEY_SHARE0_7_OFFSET);
+    addr_hit[14] = (reg_addr == KMAC_KEY_SHARE0_8_OFFSET);
+    addr_hit[15] = (reg_addr == KMAC_KEY_SHARE0_9_OFFSET);
+    addr_hit[16] = (reg_addr == KMAC_KEY_SHARE0_10_OFFSET);
+    addr_hit[17] = (reg_addr == KMAC_KEY_SHARE0_11_OFFSET);
+    addr_hit[18] = (reg_addr == KMAC_KEY_SHARE0_12_OFFSET);
+    addr_hit[19] = (reg_addr == KMAC_KEY_SHARE0_13_OFFSET);
+    addr_hit[20] = (reg_addr == KMAC_KEY_SHARE0_14_OFFSET);
+    addr_hit[21] = (reg_addr == KMAC_KEY_SHARE0_15_OFFSET);
+    addr_hit[22] = (reg_addr == KMAC_KEY_SHARE1_0_OFFSET);
+    addr_hit[23] = (reg_addr == KMAC_KEY_SHARE1_1_OFFSET);
+    addr_hit[24] = (reg_addr == KMAC_KEY_SHARE1_2_OFFSET);
+    addr_hit[25] = (reg_addr == KMAC_KEY_SHARE1_3_OFFSET);
+    addr_hit[26] = (reg_addr == KMAC_KEY_SHARE1_4_OFFSET);
+    addr_hit[27] = (reg_addr == KMAC_KEY_SHARE1_5_OFFSET);
+    addr_hit[28] = (reg_addr == KMAC_KEY_SHARE1_6_OFFSET);
+    addr_hit[29] = (reg_addr == KMAC_KEY_SHARE1_7_OFFSET);
+    addr_hit[30] = (reg_addr == KMAC_KEY_SHARE1_8_OFFSET);
+    addr_hit[31] = (reg_addr == KMAC_KEY_SHARE1_9_OFFSET);
+    addr_hit[32] = (reg_addr == KMAC_KEY_SHARE1_10_OFFSET);
+    addr_hit[33] = (reg_addr == KMAC_KEY_SHARE1_11_OFFSET);
+    addr_hit[34] = (reg_addr == KMAC_KEY_SHARE1_12_OFFSET);
+    addr_hit[35] = (reg_addr == KMAC_KEY_SHARE1_13_OFFSET);
+    addr_hit[36] = (reg_addr == KMAC_KEY_SHARE1_14_OFFSET);
+    addr_hit[37] = (reg_addr == KMAC_KEY_SHARE1_15_OFFSET);
+    addr_hit[38] = (reg_addr == KMAC_KEY_LEN_OFFSET);
+    addr_hit[39] = (reg_addr == KMAC_PREFIX_0_OFFSET);
+    addr_hit[40] = (reg_addr == KMAC_PREFIX_1_OFFSET);
+    addr_hit[41] = (reg_addr == KMAC_PREFIX_2_OFFSET);
+    addr_hit[42] = (reg_addr == KMAC_PREFIX_3_OFFSET);
+    addr_hit[43] = (reg_addr == KMAC_PREFIX_4_OFFSET);
+    addr_hit[44] = (reg_addr == KMAC_PREFIX_5_OFFSET);
+    addr_hit[45] = (reg_addr == KMAC_PREFIX_6_OFFSET);
+    addr_hit[46] = (reg_addr == KMAC_PREFIX_7_OFFSET);
+    addr_hit[47] = (reg_addr == KMAC_PREFIX_8_OFFSET);
+    addr_hit[48] = (reg_addr == KMAC_PREFIX_9_OFFSET);
+    addr_hit[49] = (reg_addr == KMAC_PREFIX_10_OFFSET);
+    addr_hit[50] = (reg_addr == KMAC_ERR_CODE_OFFSET);
+    addr_hit[51] = (reg_addr == KMAC_CFG_REGWEN_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -1455,6 +1761,22 @@ module kmac_reg_top (
     if (addr_hit[33] && reg_we && (KMAC_PERMIT[33] != (KMAC_PERMIT[33] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[34] && reg_we && (KMAC_PERMIT[34] != (KMAC_PERMIT[34] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[35] && reg_we && (KMAC_PERMIT[35] != (KMAC_PERMIT[35] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[36] && reg_we && (KMAC_PERMIT[36] != (KMAC_PERMIT[36] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[37] && reg_we && (KMAC_PERMIT[37] != (KMAC_PERMIT[37] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[38] && reg_we && (KMAC_PERMIT[38] != (KMAC_PERMIT[38] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[39] && reg_we && (KMAC_PERMIT[39] != (KMAC_PERMIT[39] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[40] && reg_we && (KMAC_PERMIT[40] != (KMAC_PERMIT[40] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[41] && reg_we && (KMAC_PERMIT[41] != (KMAC_PERMIT[41] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[42] && reg_we && (KMAC_PERMIT[42] != (KMAC_PERMIT[42] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[43] && reg_we && (KMAC_PERMIT[43] != (KMAC_PERMIT[43] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[44] && reg_we && (KMAC_PERMIT[44] != (KMAC_PERMIT[44] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[45] && reg_we && (KMAC_PERMIT[45] != (KMAC_PERMIT[45] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[46] && reg_we && (KMAC_PERMIT[46] != (KMAC_PERMIT[46] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[47] && reg_we && (KMAC_PERMIT[47] != (KMAC_PERMIT[47] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[48] && reg_we && (KMAC_PERMIT[48] != (KMAC_PERMIT[48] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[49] && reg_we && (KMAC_PERMIT[49] != (KMAC_PERMIT[49] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[50] && reg_we && (KMAC_PERMIT[50] != (KMAC_PERMIT[50] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[51] && reg_we && (KMAC_PERMIT[51] != (KMAC_PERMIT[51] & reg_be))) wr_err = 1'b1 ;
   end
 
   assign intr_state_kmac_done_we = addr_hit[0] & reg_we & ~wr_err;
@@ -1523,92 +1845,140 @@ module kmac_reg_top (
 
   assign status_fifo_full_re = addr_hit[5] && reg_re;
 
-  assign key_0_we = addr_hit[6] & reg_we & ~wr_err;
-  assign key_0_wd = reg_wdata[31:0];
+  assign key_share0_0_we = addr_hit[6] & reg_we & ~wr_err;
+  assign key_share0_0_wd = reg_wdata[31:0];
 
-  assign key_1_we = addr_hit[7] & reg_we & ~wr_err;
-  assign key_1_wd = reg_wdata[31:0];
+  assign key_share0_1_we = addr_hit[7] & reg_we & ~wr_err;
+  assign key_share0_1_wd = reg_wdata[31:0];
 
-  assign key_2_we = addr_hit[8] & reg_we & ~wr_err;
-  assign key_2_wd = reg_wdata[31:0];
+  assign key_share0_2_we = addr_hit[8] & reg_we & ~wr_err;
+  assign key_share0_2_wd = reg_wdata[31:0];
 
-  assign key_3_we = addr_hit[9] & reg_we & ~wr_err;
-  assign key_3_wd = reg_wdata[31:0];
+  assign key_share0_3_we = addr_hit[9] & reg_we & ~wr_err;
+  assign key_share0_3_wd = reg_wdata[31:0];
 
-  assign key_4_we = addr_hit[10] & reg_we & ~wr_err;
-  assign key_4_wd = reg_wdata[31:0];
+  assign key_share0_4_we = addr_hit[10] & reg_we & ~wr_err;
+  assign key_share0_4_wd = reg_wdata[31:0];
 
-  assign key_5_we = addr_hit[11] & reg_we & ~wr_err;
-  assign key_5_wd = reg_wdata[31:0];
+  assign key_share0_5_we = addr_hit[11] & reg_we & ~wr_err;
+  assign key_share0_5_wd = reg_wdata[31:0];
 
-  assign key_6_we = addr_hit[12] & reg_we & ~wr_err;
-  assign key_6_wd = reg_wdata[31:0];
+  assign key_share0_6_we = addr_hit[12] & reg_we & ~wr_err;
+  assign key_share0_6_wd = reg_wdata[31:0];
 
-  assign key_7_we = addr_hit[13] & reg_we & ~wr_err;
-  assign key_7_wd = reg_wdata[31:0];
+  assign key_share0_7_we = addr_hit[13] & reg_we & ~wr_err;
+  assign key_share0_7_wd = reg_wdata[31:0];
 
-  assign key_8_we = addr_hit[14] & reg_we & ~wr_err;
-  assign key_8_wd = reg_wdata[31:0];
+  assign key_share0_8_we = addr_hit[14] & reg_we & ~wr_err;
+  assign key_share0_8_wd = reg_wdata[31:0];
 
-  assign key_9_we = addr_hit[15] & reg_we & ~wr_err;
-  assign key_9_wd = reg_wdata[31:0];
+  assign key_share0_9_we = addr_hit[15] & reg_we & ~wr_err;
+  assign key_share0_9_wd = reg_wdata[31:0];
 
-  assign key_10_we = addr_hit[16] & reg_we & ~wr_err;
-  assign key_10_wd = reg_wdata[31:0];
+  assign key_share0_10_we = addr_hit[16] & reg_we & ~wr_err;
+  assign key_share0_10_wd = reg_wdata[31:0];
 
-  assign key_11_we = addr_hit[17] & reg_we & ~wr_err;
-  assign key_11_wd = reg_wdata[31:0];
+  assign key_share0_11_we = addr_hit[17] & reg_we & ~wr_err;
+  assign key_share0_11_wd = reg_wdata[31:0];
 
-  assign key_12_we = addr_hit[18] & reg_we & ~wr_err;
-  assign key_12_wd = reg_wdata[31:0];
+  assign key_share0_12_we = addr_hit[18] & reg_we & ~wr_err;
+  assign key_share0_12_wd = reg_wdata[31:0];
 
-  assign key_13_we = addr_hit[19] & reg_we & ~wr_err;
-  assign key_13_wd = reg_wdata[31:0];
+  assign key_share0_13_we = addr_hit[19] & reg_we & ~wr_err;
+  assign key_share0_13_wd = reg_wdata[31:0];
 
-  assign key_14_we = addr_hit[20] & reg_we & ~wr_err;
-  assign key_14_wd = reg_wdata[31:0];
+  assign key_share0_14_we = addr_hit[20] & reg_we & ~wr_err;
+  assign key_share0_14_wd = reg_wdata[31:0];
 
-  assign key_15_we = addr_hit[21] & reg_we & ~wr_err;
-  assign key_15_wd = reg_wdata[31:0];
+  assign key_share0_15_we = addr_hit[21] & reg_we & ~wr_err;
+  assign key_share0_15_wd = reg_wdata[31:0];
 
-  assign key_len_we = addr_hit[22] & reg_we & ~wr_err;
-  assign key_len_wd = reg_wdata[9:0];
+  assign key_share1_0_we = addr_hit[22] & reg_we & ~wr_err;
+  assign key_share1_0_wd = reg_wdata[31:0];
 
-  assign prefix_0_we = addr_hit[23] & reg_we & ~wr_err;
+  assign key_share1_1_we = addr_hit[23] & reg_we & ~wr_err;
+  assign key_share1_1_wd = reg_wdata[31:0];
+
+  assign key_share1_2_we = addr_hit[24] & reg_we & ~wr_err;
+  assign key_share1_2_wd = reg_wdata[31:0];
+
+  assign key_share1_3_we = addr_hit[25] & reg_we & ~wr_err;
+  assign key_share1_3_wd = reg_wdata[31:0];
+
+  assign key_share1_4_we = addr_hit[26] & reg_we & ~wr_err;
+  assign key_share1_4_wd = reg_wdata[31:0];
+
+  assign key_share1_5_we = addr_hit[27] & reg_we & ~wr_err;
+  assign key_share1_5_wd = reg_wdata[31:0];
+
+  assign key_share1_6_we = addr_hit[28] & reg_we & ~wr_err;
+  assign key_share1_6_wd = reg_wdata[31:0];
+
+  assign key_share1_7_we = addr_hit[29] & reg_we & ~wr_err;
+  assign key_share1_7_wd = reg_wdata[31:0];
+
+  assign key_share1_8_we = addr_hit[30] & reg_we & ~wr_err;
+  assign key_share1_8_wd = reg_wdata[31:0];
+
+  assign key_share1_9_we = addr_hit[31] & reg_we & ~wr_err;
+  assign key_share1_9_wd = reg_wdata[31:0];
+
+  assign key_share1_10_we = addr_hit[32] & reg_we & ~wr_err;
+  assign key_share1_10_wd = reg_wdata[31:0];
+
+  assign key_share1_11_we = addr_hit[33] & reg_we & ~wr_err;
+  assign key_share1_11_wd = reg_wdata[31:0];
+
+  assign key_share1_12_we = addr_hit[34] & reg_we & ~wr_err;
+  assign key_share1_12_wd = reg_wdata[31:0];
+
+  assign key_share1_13_we = addr_hit[35] & reg_we & ~wr_err;
+  assign key_share1_13_wd = reg_wdata[31:0];
+
+  assign key_share1_14_we = addr_hit[36] & reg_we & ~wr_err;
+  assign key_share1_14_wd = reg_wdata[31:0];
+
+  assign key_share1_15_we = addr_hit[37] & reg_we & ~wr_err;
+  assign key_share1_15_wd = reg_wdata[31:0];
+
+  assign key_len_we = addr_hit[38] & reg_we & ~wr_err;
+  assign key_len_wd = reg_wdata[2:0];
+
+  assign prefix_0_we = addr_hit[39] & reg_we & ~wr_err;
   assign prefix_0_wd = reg_wdata[31:0];
 
-  assign prefix_1_we = addr_hit[24] & reg_we & ~wr_err;
+  assign prefix_1_we = addr_hit[40] & reg_we & ~wr_err;
   assign prefix_1_wd = reg_wdata[31:0];
 
-  assign prefix_2_we = addr_hit[25] & reg_we & ~wr_err;
+  assign prefix_2_we = addr_hit[41] & reg_we & ~wr_err;
   assign prefix_2_wd = reg_wdata[31:0];
 
-  assign prefix_3_we = addr_hit[26] & reg_we & ~wr_err;
+  assign prefix_3_we = addr_hit[42] & reg_we & ~wr_err;
   assign prefix_3_wd = reg_wdata[31:0];
 
-  assign prefix_4_we = addr_hit[27] & reg_we & ~wr_err;
+  assign prefix_4_we = addr_hit[43] & reg_we & ~wr_err;
   assign prefix_4_wd = reg_wdata[31:0];
 
-  assign prefix_5_we = addr_hit[28] & reg_we & ~wr_err;
+  assign prefix_5_we = addr_hit[44] & reg_we & ~wr_err;
   assign prefix_5_wd = reg_wdata[31:0];
 
-  assign prefix_6_we = addr_hit[29] & reg_we & ~wr_err;
+  assign prefix_6_we = addr_hit[45] & reg_we & ~wr_err;
   assign prefix_6_wd = reg_wdata[31:0];
 
-  assign prefix_7_we = addr_hit[30] & reg_we & ~wr_err;
+  assign prefix_7_we = addr_hit[46] & reg_we & ~wr_err;
   assign prefix_7_wd = reg_wdata[31:0];
 
-  assign prefix_8_we = addr_hit[31] & reg_we & ~wr_err;
+  assign prefix_8_we = addr_hit[47] & reg_we & ~wr_err;
   assign prefix_8_wd = reg_wdata[31:0];
 
-  assign prefix_9_we = addr_hit[32] & reg_we & ~wr_err;
+  assign prefix_9_we = addr_hit[48] & reg_we & ~wr_err;
   assign prefix_9_wd = reg_wdata[31:0];
 
-  assign prefix_10_we = addr_hit[33] & reg_we & ~wr_err;
+  assign prefix_10_we = addr_hit[49] & reg_we & ~wr_err;
   assign prefix_10_wd = reg_wdata[31:0];
 
 
-  assign cfg_regwen_re = addr_hit[35] && reg_re;
+  assign cfg_regwen_re = addr_hit[51] && reg_re;
 
   // Read data return
   always_comb begin
@@ -1721,58 +2091,122 @@ module kmac_reg_top (
       end
 
       addr_hit[22]: begin
-        reg_rdata_next[9:0] = '0;
+        reg_rdata_next[31:0] = '0;
       end
 
       addr_hit[23]: begin
-        reg_rdata_next[31:0] = prefix_0_qs;
+        reg_rdata_next[31:0] = '0;
       end
 
       addr_hit[24]: begin
-        reg_rdata_next[31:0] = prefix_1_qs;
+        reg_rdata_next[31:0] = '0;
       end
 
       addr_hit[25]: begin
-        reg_rdata_next[31:0] = prefix_2_qs;
+        reg_rdata_next[31:0] = '0;
       end
 
       addr_hit[26]: begin
-        reg_rdata_next[31:0] = prefix_3_qs;
+        reg_rdata_next[31:0] = '0;
       end
 
       addr_hit[27]: begin
-        reg_rdata_next[31:0] = prefix_4_qs;
+        reg_rdata_next[31:0] = '0;
       end
 
       addr_hit[28]: begin
-        reg_rdata_next[31:0] = prefix_5_qs;
+        reg_rdata_next[31:0] = '0;
       end
 
       addr_hit[29]: begin
-        reg_rdata_next[31:0] = prefix_6_qs;
+        reg_rdata_next[31:0] = '0;
       end
 
       addr_hit[30]: begin
-        reg_rdata_next[31:0] = prefix_7_qs;
+        reg_rdata_next[31:0] = '0;
       end
 
       addr_hit[31]: begin
-        reg_rdata_next[31:0] = prefix_8_qs;
+        reg_rdata_next[31:0] = '0;
       end
 
       addr_hit[32]: begin
-        reg_rdata_next[31:0] = prefix_9_qs;
+        reg_rdata_next[31:0] = '0;
       end
 
       addr_hit[33]: begin
-        reg_rdata_next[31:0] = prefix_10_qs;
+        reg_rdata_next[31:0] = '0;
       end
 
       addr_hit[34]: begin
-        reg_rdata_next[31:0] = err_code_qs;
+        reg_rdata_next[31:0] = '0;
       end
 
       addr_hit[35]: begin
+        reg_rdata_next[31:0] = '0;
+      end
+
+      addr_hit[36]: begin
+        reg_rdata_next[31:0] = '0;
+      end
+
+      addr_hit[37]: begin
+        reg_rdata_next[31:0] = '0;
+      end
+
+      addr_hit[38]: begin
+        reg_rdata_next[2:0] = '0;
+      end
+
+      addr_hit[39]: begin
+        reg_rdata_next[31:0] = prefix_0_qs;
+      end
+
+      addr_hit[40]: begin
+        reg_rdata_next[31:0] = prefix_1_qs;
+      end
+
+      addr_hit[41]: begin
+        reg_rdata_next[31:0] = prefix_2_qs;
+      end
+
+      addr_hit[42]: begin
+        reg_rdata_next[31:0] = prefix_3_qs;
+      end
+
+      addr_hit[43]: begin
+        reg_rdata_next[31:0] = prefix_4_qs;
+      end
+
+      addr_hit[44]: begin
+        reg_rdata_next[31:0] = prefix_5_qs;
+      end
+
+      addr_hit[45]: begin
+        reg_rdata_next[31:0] = prefix_6_qs;
+      end
+
+      addr_hit[46]: begin
+        reg_rdata_next[31:0] = prefix_7_qs;
+      end
+
+      addr_hit[47]: begin
+        reg_rdata_next[31:0] = prefix_8_qs;
+      end
+
+      addr_hit[48]: begin
+        reg_rdata_next[31:0] = prefix_9_qs;
+      end
+
+      addr_hit[49]: begin
+        reg_rdata_next[31:0] = prefix_10_qs;
+      end
+
+      addr_hit[50]: begin
+        reg_rdata_next[31:0] = err_code_qs;
+      end
+
+      addr_hit[51]: begin
         reg_rdata_next[0] = cfg_regwen_qs;
       end
 


### PR DESCRIPTION
Revise the register description to have two share secret key in the
Memory mapped registers. It means, the software shall prepare masked
secret key and write into `KEY_SHARE0` and `KEY_SHARE1`.

This PR has two commits. Second commit is only for generating the register RTL. 