### PR TITLE
[otbn] Add register checking at end of run to OTBN model

### DIFF
--- a/hw/ip/otbn/dv/model/iss_wrapper.h
+++ b/hw/ip/otbn/dv/model/iss_wrapper.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <array>
 #include <cstdint>
 #include <cstdio>
 #include <memory>
@@ -16,6 +17,12 @@ struct TmpDir;
 
 // An object wrapping the ISS subprocess.
 struct ISSWrapper {
+  // A 256-bit unsigned integer value, stored in "LSB order". Thus, words[0]
+  // contains the LSB and words[7] contains the MSB.
+  struct u256_t {
+    uint32_t words[256 / 32];
+  };
+
   ISSWrapper();
   ~ISSWrapper();
 
@@ -32,6 +39,9 @@ struct ISSWrapper {
   // Run simulation for a single cycle. Return true if it is now
   // finished (ECALL or error).
   bool step();
+
+  // Read contents of the register file
+  void get_regs(std::array<uint32_t, 32> *gprs, std::array<u256_t, 32> *wdrs);
 
   // Resolve a path relative to the convenience temporary directory.
   // relative should be a relative path (it is just appended to the

--- a/hw/ip/otbn/dv/model/otbn_core_model.sv
+++ b/hw/ip/otbn/dv/model/otbn_core_model.sv
@@ -21,11 +21,10 @@ module otbn_core_model
   parameter string ImemScope = "",
   // Scope of the data memory (for DPI)
   parameter string DmemScope = "",
-
-  // True if this is a "standalone" model, which should write DMEM on completion. If false, we
-  // assume there's a real implementation running alongside and we check that the DMEM contents
-  // match on completion.
-  parameter bit StandaloneModel = 1'b0,
+  // Scope of an RTL OTBN implementation (for DPI). If empty, this is a "standalone" model, which
+  // should update DMEM on completion. If not empty, we assume it's the scope for the top-level of a
+  // real implementation running alongside and we check DMEM contents on completion.
+  parameter string DesignScope = "",
 
   localparam int ImemAddrWidth = prim_util_pkg::vbits(ImemSizeByte),
   localparam int DmemAddrWidth = prim_util_pkg::vbits(DmemSizeByte)
@@ -107,11 +106,11 @@ module otbn_core_model
     unique case (retcode)
       0: new_run = 1'b1;
       1: begin
-        // The model has just finished running. If this is a standalone model, write the ISS's DMEM
-        // contents back to the simulation. Otherwise, check the ISS and simulation agree (TODO: We
-        // don't do error handling properly at the moment; for now, the C++ code just prints error
-        // messages to stderr).
-        if (StandaloneModel) begin
+        // The model has just finished running. If this is a standalone model (which we can tell
+        // because DesignScope is empty), write the ISS's DMEM contents back to the simulation.
+        // Otherwise, check the ISS and simulation agree (TODO: We don't do error handling properly
+        // at the moment; for now, the C++ code just prints error messages to stderr).
+        if (DesignScope.len() == 0) begin
           void'(otbn_model_load_dmem(model_handle, DmemScope, DmemSizeWords));
         end else begin
           void'(otbn_model_check_dmem(model_handle, DmemScope, DmemSizeWords));

--- a/hw/ip/otbn/dv/model/otbn_model.cc
+++ b/hw/ip/otbn/dv/model/otbn_model.cc
@@ -15,8 +15,9 @@
 #include "iss_wrapper.h"
 #include "sv_scoped.h"
 
-extern "C" int simutil_verilator_get_mem(int index, const svBitVecVal *val);
+extern "C" int simutil_verilator_get_mem(int index, svBitVecVal *val);
 extern "C" int simutil_verilator_set_mem(int index, const svBitVecVal *val);
+extern "C" int otbn_rf_peek(int index, svBitVecVal *val);
 
 // Use simutil_verilator_get_mem to read data one word at a time from the given
 // scope and collect the results up in a vector of uint8_t values.
@@ -207,52 +208,158 @@ extern "C" int otbn_model_load_dmem(ISSWrapper *model, const char *dmem_scope,
   return 0;
 }
 
-// Grab contents of dmem from the model and compare it with the RTL. Prints
-// messages to stderr on failure or mismatch. Returns 1 for a match, 0 for a
-// mismatch, -1 for some other failure.
-extern "C" int otbn_model_check_dmem(ISSWrapper *model, const char *dmem_scope,
-                                     int dmem_words) {
+// Grab contents of dmem from the model and compare it with the RTL.
+// Prints messages to stderr on failure or mismatch. Returns true on
+// success; false on mismatch. Throws a std::runtime_error on failure.
+static bool otbn_model_check_dmem(ISSWrapper *model, const char *dmem_scope,
+                                  int dmem_words) {
   assert(model);
   assert(dmem_words >= 0);
 
   size_t dmem_bytes = dmem_words * 32;
   std::string dfname(model->make_tmp_path("dmem_out"));
-  try {
-    model->dump_d(dfname);
-    std::vector<uint8_t> iss_data = read_vector_from_file(dfname, dmem_bytes);
-    assert(iss_data.size() == dmem_bytes);
 
-    std::vector<uint8_t> rtl_data = get_sim_memory(dmem_scope, dmem_words, 32);
-    assert(rtl_data.size() == dmem_bytes);
+  model->dump_d(dfname);
+  std::vector<uint8_t> iss_data = read_vector_from_file(dfname, dmem_bytes);
+  assert(iss_data.size() == dmem_bytes);
 
-    // If the arrays match, we're done.
-    if (0 == memcmp(&iss_data[0], &rtl_data[0], dmem_bytes))
-      return 1;
+  std::vector<uint8_t> rtl_data = get_sim_memory(dmem_scope, dmem_words, 32);
+  assert(rtl_data.size() == dmem_bytes);
 
-    // If not, print out the first 10 mismatches
-    std::ios old_state(nullptr);
-    old_state.copyfmt(std::cerr);
-    std::cerr << "ERROR: Mismatches in dmem data:\n"
-              << std::hex << std::setfill('0');
-    int bad_count = 0;
-    for (size_t i = 0; i < dmem_bytes; ++i) {
-      if (iss_data[i] != rtl_data[i]) {
-        std::cerr << " @offset 0x" << std::setw(3) << i << ": rtl has 0x"
-                  << std::setw(2) << (int)rtl_data[i] << "; iss has 0x"
-                  << std::setw(2) << (int)iss_data[i] << "\n";
-        ++bad_count;
+  // If the arrays match, we're done.
+  if (0 == memcmp(&iss_data[0], &rtl_data[0], dmem_bytes))
+    return true;
 
-        if (bad_count == 10) {
-          std::cerr << " (skipping further errors...)\n";
-          break;
-        }
+  // If not, print out the first 10 mismatches
+  std::ios old_state(nullptr);
+  old_state.copyfmt(std::cerr);
+  std::cerr << "ERROR: Mismatches in dmem data:\n"
+            << std::hex << std::setfill('0');
+  int bad_count = 0;
+  for (size_t i = 0; i < dmem_bytes; ++i) {
+    if (iss_data[i] != rtl_data[i]) {
+      std::cerr << " @offset 0x" << std::setw(3) << i << ": rtl has 0x"
+                << std::setw(2) << (int)rtl_data[i] << "; iss has 0x"
+                << std::setw(2) << (int)iss_data[i] << "\n";
+      ++bad_count;
+
+      if (bad_count == 10) {
+        std::cerr << " (skipping further errors...)\n";
+        break;
       }
     }
-    std::cerr.copyfmt(old_state);
-    return 0;
+  }
+  std::cerr.copyfmt(old_state);
+  return false;
+}
 
-  } catch (const std::runtime_error &err) {
-    std::cerr << "Error when loading dmem from ISS: " << err.what() << "\n";
+template <typename T>
+static std::array<T, 32> get_rtl_regs(const std::string &reg_scope) {
+  std::array<T, 32> ret;
+  static_assert(sizeof(T) <= 256 / 8, "Can only copy 256 bits");
+
+  SVScoped scoped(reg_scope);
+
+  // otbn_rf_peek passes data as a packed array of svBitVecVal words (for a
+  // "bit [255:0]" argument). Allocate 256 bits (= 32 bytes) as
+  // 32/sizeof(svBitVecVal) words on the stack.
+  svBitVecVal buf[256 / 8 / sizeof(svBitVecVal)];
+
+  for (int i = 0; i < 32; ++i) {
+    if (!otbn_rf_peek(i, buf)) {
+      std::ostringstream oss;
+      oss << "Failed to peek into RTL to get value of register " << i
+          << " at scope `" << reg_scope << "'.";
+      throw std::runtime_error(oss.str());
+    }
+    memcpy(&ret[i], buf, sizeof(T));
+  }
+
+  return ret;
+}
+
+// Compare contents of ISS registers with those from the design. Prints
+// messages to stderr on failure or mismatch. Returns true on success; false on
+// mismatch. Throws a std::runtime_error on failure.
+static bool otbn_model_check_regs(ISSWrapper *model,
+                                  const std::string &design_scope) {
+  assert(model);
+
+  std::string base_scope =
+      design_scope + ".gen_rf_base_ff.u_otbn_rf_base.u_snooper";
+  std::string wide_scope =
+      design_scope + ".gen_rf_bignum_ff.u_otbn_rf_bignum.u_snooper";
+
+  auto rtl_gprs = get_rtl_regs<uint32_t>(base_scope);
+  auto rtl_wdrs = get_rtl_regs<ISSWrapper::u256_t>(wide_scope);
+
+  std::array<uint32_t, 32> iss_gprs;
+  std::array<ISSWrapper::u256_t, 32> iss_wdrs;
+  model->get_regs(&iss_gprs, &iss_wdrs);
+
+  bool good = true;
+
+  for (int i = 0; i < 32; ++i) {
+    if (rtl_gprs[i] != iss_gprs[i]) {
+      std::ios old_state(nullptr);
+      old_state.copyfmt(std::cerr);
+      std::cerr << std::setfill('0') << "RTL computed x" << i << " as 0x"
+                << std::hex << rtl_gprs[i] << ", but ISS got 0x" << iss_gprs[i]
+                << ".\n";
+      std::cerr.copyfmt(old_state);
+      good = false;
+    }
+  }
+  for (int i = 0; i < 32; ++i) {
+    if (0 != memcmp(rtl_wdrs[i].words, iss_wdrs[i].words,
+                    sizeof(rtl_wdrs[i].words))) {
+      std::ios old_state(nullptr);
+      old_state.copyfmt(std::cerr);
+      std::cerr << "RTL computed w" << i << " as 0x" << std::hex
+                << std::setfill('0');
+      for (int j = 0; j < 8; ++j) {
+        if (j)
+          std::cerr << "_";
+        std::cerr << std::setw(8) << rtl_wdrs[i].words[7 - j];
+      }
+      std::cerr << ", but ISS got 0x";
+      for (int j = 0; j < 8; ++j) {
+        if (j)
+          std::cerr << "_";
+        std::cerr << std::setw(8) << iss_wdrs[i].words[7 - j];
+      }
+      std::cerr << ".\n";
+      std::cerr.copyfmt(old_state);
+      good = false;
+    }
+  }
+
+  return good;
+}
+
+// Check model against RTL when a run has finished. Prints messages to
+// stderr on failure or mismatch. Returns 1 for a match, 0 for a
+// mismatch, -1 for some other failure.
+extern "C" int otbn_model_check(ISSWrapper *model, const char *dmem_scope,
+                                int dmem_words, const char *design_scope) {
+  assert(model);
+  assert(dmem_words >= 0);
+  assert(design_scope);
+
+  bool good = true;
+  try {
+    good &= otbn_model_check_dmem(model, dmem_scope, dmem_words);
+  } catch (const std::exception &err) {
+    std::cerr << "Failed to check DMEM: " << err.what() << "\n";
     return -1;
   }
+
+  try {
+    good &= otbn_model_check_regs(model, design_scope);
+  } catch (const std::exception &err) {
+    std::cerr << "Failed to check registers: " << err.what() << "\n";
+    return -1;
+  }
+
+  return good ? 1 : 0;
 }

--- a/hw/ip/otbn/dv/model/otbn_rf_snooper.sv
+++ b/hw/ip/otbn/dv/model/otbn_rf_snooper.sv
@@ -1,0 +1,32 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Backdoor interface that can be bound into an OTBN register file and exports a function to peek at
+// the memory contents.
+
+interface otbn_rf_snooper #(
+  parameter int Width = 32,    // Memory width in bits
+  parameter int Depth = 32     // Number of registers
+) (
+   input logic [Width-1:0] rf [Depth]
+);
+
+  export "DPI-C" function otbn_rf_peek;
+
+  function automatic int otbn_rf_peek(input int index, output bit [255:0] val);
+    // Function only works for register files <= 256 bits wide
+    if (Width > 256) begin
+      return 0;
+    end
+
+    if (index > Depth) begin
+      return 0;
+    end
+
+    val = '0;
+    val[Width-1:0] = rf[index];
+    return 1;
+  endfunction
+
+endinterface

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -181,6 +181,7 @@ module otbn_top_sim (
 
   localparam string ImemScope = "..u_imem.u_mem.gen_generic.u_impl_generic";
   localparam string DmemScope = "..u_dmem.u_mem.gen_generic.u_impl_generic";
+  localparam string DesignScope = "..u_otbn_core";
 
   logic otbn_model_done;
 
@@ -189,7 +190,7 @@ module otbn_top_sim (
     .ImemSizeByte    ( ImemSizeByte ),
     .DmemScope       ( DmemScope ),
     .ImemScope       ( ImemScope ),
-    .StandaloneModel ( 1'b0 )
+    .DesignScope     ( DesignScope )
   ) u_otbn_core_model (
     .clk_i        ( IO_CLK ),
     .rst_ni       ( IO_RST_N ),

--- a/hw/ip/otbn/otbn.core
+++ b/hw/ip/otbn/otbn.core
@@ -52,6 +52,7 @@ filesets:
       - dv/model/iss_wrapper.cc
       - dv/model/iss_wrapper.h: { is_include_file: true }
       - dv/model/otbn_core_model.sv: { file_type: systemVerilogSource }
+      - dv/model/otbn_rf_snooper.sv: { file_type: systemVerilogSource }
     file_type: cppSource
 
   files_verilator_waiver:

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -433,7 +433,7 @@ module otbn
       .ImemSizeByte(ImemSizeByte),
       .DmemScope(DmemScope),
       .ImemScope(ImemScope),
-      .StandaloneModel(1'b1)
+      .DesignScope("")
     ) u_otbn_core_model (
       .clk_i,
       .rst_ni,


### PR DESCRIPTION
This is the last of the "simple: check when we're done" checks. The interesting patch is the second.

Once this is merged, the last part of this work is wiring an "oh no, something went wrong" signal out of the model. That's now mostly working (but needed rather painful changes to the control flow in otbn_core_model.sv, yuck).