### PR TITLE
[otbn] Fail OTBN tests on DMEM or register mismatch

### DIFF
--- a/hw/ip/otbn/dv/model/otbn_core_model.sv
+++ b/hw/ip/otbn/dv/model/otbn_core_model.sv
@@ -35,30 +35,32 @@ module otbn_core_model
   input  logic  start_i, // start the operation
   output logic  done_o,  // operation done
 
-  input  logic [ImemAddrWidth-1:0] start_addr_i // start byte address in IMEM
-);
+  input  logic [ImemAddrWidth-1:0] start_addr_i, // start byte address in IMEM
 
+  output bit err_o        // something went wrong
+);
 
   import "DPI-C" function chandle otbn_model_init();
   import "DPI-C" function void otbn_model_destroy(chandle handle);
   import "DPI-C" context function
-    int otbn_model_start(chandle model,
-                         string  imem_scope,
-                         int     imem_size,
-                         string  dmem_scope,
-                         int     dmem_size,
-                         int     start_addr);
-  import "DPI-C" function int otbn_model_step(chandle model);
-  import "DPI-C" context function
-    int otbn_model_load_dmem(chandle model,
-                             string  dmem_scope,
-                             int     dmem_size);
-  import "DPI-C" context function
-    int otbn_model_check(chandle model,
-                         string dmem_scope,
-                         int    dmem_size,
-                         string design_scope);
+    int unsigned otbn_model_step(chandle      model,
+                                 string       imem_scope,
+                                 int unsigned imem_size,
+                                 string       dmem_scope,
+                                 int unsigned dmem_size,
+                                 string       design_scope,
+                                 logic        start_i,
+                                 int unsigned start_addr,
+                                 int unsigned status);
 
+  localparam ImemSizeWords = ImemSizeByte / 4;
+  localparam DmemSizeWords = DmemSizeByte / (WLEN / 8);
+
+  `ASSERT_INIT(StartAddr32_A, ImemAddrWidth <= 32);
+  logic [31:0] start_addr_32;
+  assign start_addr_32 = {{32 - ImemAddrWidth{1'b0}}, start_addr_i};
+
+  // Create and destroy an object through which we can talk to the ISS
   chandle model_handle;
   initial begin
     model_handle = otbn_model_init();
@@ -69,73 +71,47 @@ module otbn_core_model
     model_handle = 0;
   end
 
+  // A packed "status" value. This gets assigned by DPI function calls that need to update both
+  // whether we're running and also error flags at the same time. The contents are magic simulation
+  // values, so get initialized before reset (to avoid stopping the simulation before it even
+  // starts).
+  int unsigned status = 0;
 
-  localparam ImemSizeWords = ImemSizeByte / 4;
-  localparam DmemSizeWords = DmemSizeByte / (WLEN / 8);
+  // Extract particular bits of the status value.
+  //
+  //   running: The ISS is currently running
+  //   failed_step: Something went wrong when trying to start or step the ISS.
+  //   failed_cmp:  The consistency check at the end of run failed.
+  bit failed_cmp, failed_step, running;
+  assign {failed_cmp, failed_step, running} = status[2:0];
 
-  `ASSERT_INIT(StartAddr32_A, ImemAddrWidth <= 32);
-  logic [31:0] start_addr_32;
-  assign start_addr_32 = {{32 - ImemAddrWidth{1'b0}}, start_addr_i};
-
-  // The control loop for the model. We track whether we're currently running in the running
-  // variable. The step_iss function is run every cycle when not in reset. It steps the ISS if
-  // necessary and returns the new value for running.
-  function automatic bit step_iss(bit running);
-    int retcode;
-    bit new_run = running;
-
-    // If start_i is asserted, start again (regardless of whether we're currently running).
-    if (start_i) begin
-      retcode = otbn_model_start(model_handle,
-                                 ImemScope, ImemSizeWords,
-                                 DmemScope, DmemSizeWords,
-                                 start_addr_32);
-      unique case (retcode)
-        0:       new_run = 1'b1;
-        // Something went wrong. Assume we didn't manage to start.
-        default: new_run = 1'b0;
-      endcase
-    end
-
-    // Otherwise, if we aren't currently running then there's nothing more to do.
-    if (!new_run) begin
-      return 1'b0;
-    end
-
-    // We are running. Step by one instruction.
-    retcode = otbn_model_step(model_handle);
-    unique case (retcode)
-      0: new_run = 1'b1;
-      1: begin
-        // The model has just finished running. If this is a standalone model (which we can tell
-        // because DesignScope is empty), write the ISS's DMEM contents back to the simulation.
-        // Otherwise, check the ISS and simulation agree (TODO: We don't do error handling properly
-        // at the moment; for now, the C++ code just prints error messages to stderr).
-        if (DesignScope.len() == 0) begin
-          void'(otbn_model_load_dmem(model_handle, DmemScope, DmemSizeWords));
-        end else begin
-          void'(otbn_model_check(model_handle, DmemScope, DmemSizeWords, DesignScope));
-        end
-        new_run = 1'b0;
-      end
-      // Something went wrong. Assume we've stopped.
-      default: new_run = 1'b0;
-    endcase
-    return new_run;
-  endfunction
-
-  bit running, running_r;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      running   <= 1'b0;
-      running_r <= 1'b0;
+      // Clear status (stop running, and forget any errors)
+      status <= 0;
     end else begin
-      running   <= step_iss(running);
-      running_r <= running;
+      if (start_i | running) begin
+        status <= otbn_model_step(model_handle,
+                                  ImemScope, ImemSizeWords,
+                                  DmemScope, DmemSizeWords,
+                                  DesignScope,
+                                  start_i, start_addr_32,
+                                  status);
+      end else begin
+        // If we're not running and we're not being told to start, there's nothing to do.
+      end
     end
   end
 
-  // Track negedges of running and expose that as a "done" output.
+  // Track negedges of running_q and expose that as a "done" output.
+  bit running_r = 1'b0;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      running_r <= 1'b0;
+    end else begin
+      running_r <= running;
+    end
+  end
   assign done_o = running_r & ~running;
 
   // If DesignScope is not empty, we have a design to check. Bind a copy of otbn_rf_snooper into
@@ -147,5 +123,7 @@ module otbn_core_model
     bind otbn_rf_base_ff otbn_rf_snooper #(.Width (32), .Depth (32)) u_snooper (.rf (rf_reg));
     bind otbn_rf_bignum_ff otbn_rf_snooper #(.Width (256), .Depth (32)) u_snooper (.rf (rf));
   end endgenerate
+
+  assign err_o = failed_step | failed_cmp;
 
 endmodule

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.cc
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.cc
@@ -51,6 +51,12 @@ int main(int argc, char **argv) {
   }
 
   svSetScope(svGetScopeFromName("TOP.otbn_top_sim"));
+
+  svBit model_err = otbn_err_get();
+  if (model_err) {
+    return 1;
+  }
+
   std::cout << "Final Base Register Values:" << std::endl;
   std::cout << "Reg | Value" << std::endl;
   std::cout << "----------------" << std::endl;

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -198,7 +198,9 @@ module otbn_top_sim (
     .start_i      ( otbn_start ),
     .done_o       ( otbn_model_done ),
 
-    .start_addr_i ( ImemStartAddr )
+    .start_addr_i ( ImemStartAddr ),
+
+    .err_o ()
   );
 
   always_ff @(posedge IO_CLK or negedge IO_RST_N) begin

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -441,7 +441,9 @@ module otbn
       .start_i (start),
       .done_o  (done),
 
-      .start_addr_i  (start_addr)
+      .start_addr_i  (start_addr),
+
+      .err_o ()
     );
   end else begin : gen_impl_rtl
     otbn_core #(


### PR DESCRIPTION
This adds an `err_o` output to `otbn_core_model`, latches it on error, and fails the block-level simulation if it's set.

The patch is big because of difficulties controlling when DPI functions get evaluated (if you do things like `case (call_my_dpi_function(...)) ...` then you end up calling it multiple times per cycle). Eventually, I gave up and did the main state tracking in C++, which is far easier (and probably also easier to understand). Since all the status bits are still passed through the verilog, it should still be easy to figure out what's going on from the trace.

This PR depends on #3665 and #3648, which will need merging first and this rebasing.

Fixes #3520.