### PR TITLE
[otp] disable prim_arbiter_tree stable assertion

### DIFF
--- a/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
@@ -469,7 +469,8 @@ module otp_ctrl
   // Hence, the idx_o signal is guaranteed to remain stable until ack'ed.
   prim_arbiter_tree #(
     .N(NumAgents),
-    .DW($bits(scrmbl_bundle_t))
+    .DW($bits(scrmbl_bundle_t)),
+    .EnReqStabA(0)
   ) u_scrmbl_mtx (
     .clk_i,
     .rst_ni,


### PR DESCRIPTION
Because in otp_ctrl's `u_scrmbl_mtx` the `ready_i` is tied to 0,
the assertions under `EnReqStabA` will fire when `req_i` reset to 0.
This PR disabled the assertions by setting `EnReqStabA` to 0.

Signed-off-by: Cindy Chen <chencindy@google.com>