### PR TITLE
Revert "[dif] Make SPI use new-style DIF names"

### DIFF
--- a/sw/device/boot_rom/bootstrap.c
+++ b/sw/device/boot_rom/bootstrap.c
@@ -88,13 +88,15 @@ static int bootstrap_flash(dif_spi_device_t *spi) {
   uint32_t expected_frame_num = 0;
   while (true) {
     size_t bytes_available;
-    CHECK(dif_spi_device_rx_pending(spi, &bytes_available) == kDifSpiDeviceOk,
+    CHECK(dif_spi_device_rx_pending(spi, &bytes_available) ==
+              kDifSpiDeviceResultOk,
           "Failed to check pending bytes.");
     if (bytes_available >= sizeof(spiflash_frame_t)) {
       spiflash_frame_t frame;
-      CHECK(dif_spi_device_recv(spi, &frame, sizeof(spiflash_frame_t),
-                                /*bytes_received=*/NULL) == kDifSpiDeviceOk,
-            "Failed to recieve bytes from SPI.");
+      CHECK(
+          dif_spi_device_recv(spi, &frame, sizeof(spiflash_frame_t),
+                              /*bytes_received=*/NULL) == kDifSpiDeviceResultOk,
+          "Failed to recieve bytes from SPI.");
 
       uint32_t frame_num = SPIFLASH_FRAME_NUM(frame.header.frame_num);
       LOG_INFO("Processing frame #%d, expecting #%d", frame_num,
@@ -104,14 +106,16 @@ static int bootstrap_flash(dif_spi_device_t *spi) {
         if (!check_frame_hash(&frame)) {
           LOG_ERROR("Detected hash mismatch on frame #%d", frame_num);
           CHECK(dif_spi_device_send(spi, ack, sizeof(ack),
-                                    /*bytes_received=*/NULL) == kDifSpiDeviceOk,
+                                    /*bytes_received=*/NULL) ==
+                    kDifSpiDeviceResultOk,
                 "Failed to send bytes to SPI.");
           continue;
         }
 
         hw_SHA256_hash(&frame, sizeof(spiflash_frame_t), ack);
         CHECK(dif_spi_device_send(spi, ack, sizeof(ack),
-                                  /*bytes_received=*/NULL) == kDifSpiDeviceOk,
+                                  /*bytes_received=*/NULL) ==
+                  kDifSpiDeviceResultOk,
               "Failed to send bytes to SPI.");
 
         if (expected_frame_num == 0) {
@@ -137,7 +141,8 @@ static int bootstrap_flash(dif_spi_device_t *spi) {
       } else {
         // Send previous ack if unable to verify current frame.
         CHECK(dif_spi_device_send(spi, ack, sizeof(ack),
-                                  /*bytes_received=*/NULL) == kDifSpiDeviceOk,
+                                  /*bytes_received=*/NULL) ==
+                  kDifSpiDeviceResultOk,
               "Failed to send bytes to SPI.");
       }
     }
@@ -153,25 +158,19 @@ int bootstrap(void) {
   LOG_INFO("Bootstrap requested, initialising HW...");
   flash_init_block();
 
+  mmio_region_t spi_reg = mmio_region_from_addr(0x40020000);
+  dif_spi_device_config_t config = {
+      .clock_polarity = kDifSpiDeviceEdgePositive,
+      .data_phase = kDifSpiDeviceEdgeNegative,
+      .tx_order = kDifSpiDeviceBitOrderMsbToLsb,
+      .rx_order = kDifSpiDeviceBitOrderMsbToLsb,
+      .rx_fifo_timeout = 63,
+      .rx_fifo_len = kDifSpiDeviceBufferLen / 2,
+      .tx_fifo_len = kDifSpiDeviceBufferLen / 2,
+  };
   dif_spi_device_t spi;
-  CHECK(dif_spi_device_init(
-            (dif_spi_device_params_t){
-                .base_addr = mmio_region_from_addr(0x40020000),
-            },
-            &spi),
+  CHECK(dif_spi_device_init(spi_reg, &config, &spi) == kDifSpiDeviceResultOk,
         "Failed to initialize SPI.");
-  CHECK(
-      dif_spi_device_configure(&spi,
-                               (dif_spi_device_config_t){
-                                   .clock_polarity = kDifSpiDeviceEdgePositive,
-                                   .data_phase = kDifSpiDeviceEdgeNegative,
-                                   .tx_order = kDifSpiDeviceBitOrderMsbToLsb,
-                                   .rx_order = kDifSpiDeviceBitOrderMsbToLsb,
-                                   .rx_fifo_timeout = 63,
-                                   .rx_fifo_len = kDifSpiDeviceBufferLen / 2,
-                                   .tx_fifo_len = kDifSpiDeviceBufferLen / 2,
-                               }) == kDifSpiDeviceOk,
-      "Failed to configure SPI.");
 
   LOG_INFO("HW initialisation completed, waiting for SPI input...");
   int error = bootstrap_flash(&spi);

--- a/sw/device/examples/demos.c
+++ b/sw/device/examples/demos.c
@@ -66,11 +66,11 @@ void demo_spi_to_log_echo(const dif_spi_device_t *spi) {
   uint32_t spi_buf[8];
   size_t spi_len;
   CHECK(dif_spi_device_recv(spi, spi_buf, sizeof(spi_buf), &spi_len) ==
-        kDifSpiDeviceOk);
+        kDifSpiDeviceResultOk);
   if (spi_len > 0) {
     uint32_t echo_word = spi_buf[0] ^ 0x01010101;
     CHECK(dif_spi_device_send(spi, &echo_word, sizeof(uint32_t),
-                              /*bytes_sent=*/NULL) == kDifSpiDeviceOk);
+                              /*bytes_sent=*/NULL) == kDifSpiDeviceResultOk);
     LOG_INFO("SPI: %z", spi_len, spi_buf);
   }
 }

--- a/sw/device/examples/hello_usbdev/hello_usbdev.c
+++ b/sw/device/examples/hello_usbdev/hello_usbdev.c
@@ -85,21 +85,18 @@ int main(int argc, char **argv) {
 
   pinmux_init();
 
-  CHECK(dif_spi_device_init(
-      (dif_spi_device_params_t){
-          .base_addr = mmio_region_from_addr(0x40020000),
-      },
-      &spi));
-  CHECK(dif_spi_device_configure(
-            &spi, (dif_spi_device_config_t){
-                      .clock_polarity = kDifSpiDeviceEdgePositive,
-                      .data_phase = kDifSpiDeviceEdgeNegative,
-                      .tx_order = kDifSpiDeviceBitOrderMsbToLsb,
-                      .rx_order = kDifSpiDeviceBitOrderMsbToLsb,
-                      .rx_fifo_timeout = 63,
-                      .rx_fifo_len = kDifSpiDeviceBufferLen / 2,
-                      .tx_fifo_len = kDifSpiDeviceBufferLen / 2,
-                  }) == kDifSpiDeviceOk);
+  mmio_region_t spi_reg = mmio_region_from_addr(0x40020000);
+  dif_spi_device_config_t spi_config = {
+      .clock_polarity = kDifSpiDeviceEdgePositive,
+      .data_phase = kDifSpiDeviceEdgeNegative,
+      .tx_order = kDifSpiDeviceBitOrderMsbToLsb,
+      .rx_order = kDifSpiDeviceBitOrderMsbToLsb,
+      .rx_fifo_timeout = 63,
+      .rx_fifo_len = kDifSpiDeviceBufferLen / 2,
+      .tx_fifo_len = kDifSpiDeviceBufferLen / 2,
+  };
+  CHECK(dif_spi_device_init(spi_reg, &spi_config, &spi) ==
+        kDifSpiDeviceResultOk);
 
   dif_gpio_params_t gpio_params = {
       .base_addr = mmio_region_from_addr(0x40010000),
@@ -123,7 +120,7 @@ int main(int argc, char **argv) {
   usb_simpleserial_init(&simple_serial1, &usbdev, 2, usb_receipt_callback_1);
 
   CHECK(dif_spi_device_send(&spi, "SPI!", 4, /*bytes_sent=*/NULL) ==
-        kDifSpiDeviceOk);
+        kDifSpiDeviceResultOk);
 
   uint32_t gpio_state = 0;
   bool pass_signaled = false;

--- a/sw/device/examples/hello_world/hello_world.c
+++ b/sw/device/examples/hello_world/hello_world.c
@@ -22,21 +22,18 @@ int main(int argc, char **argv) {
 
   pinmux_init();
 
-  CHECK(dif_spi_device_init(
-      (dif_spi_device_params_t){
-          .base_addr = mmio_region_from_addr(0x40020000),
-      },
-      &spi));
-  CHECK(dif_spi_device_configure(
-            &spi, (dif_spi_device_config_t){
-                      .clock_polarity = kDifSpiDeviceEdgePositive,
-                      .data_phase = kDifSpiDeviceEdgeNegative,
-                      .tx_order = kDifSpiDeviceBitOrderMsbToLsb,
-                      .rx_order = kDifSpiDeviceBitOrderMsbToLsb,
-                      .rx_fifo_timeout = 63,
-                      .rx_fifo_len = kDifSpiDeviceBufferLen / 2,
-                      .tx_fifo_len = kDifSpiDeviceBufferLen / 2,
-                  }) == kDifSpiDeviceOk);
+  mmio_region_t spi_reg = mmio_region_from_addr(0x40020000);
+  dif_spi_device_config_t spi_config = {
+      .clock_polarity = kDifSpiDeviceEdgePositive,
+      .data_phase = kDifSpiDeviceEdgeNegative,
+      .tx_order = kDifSpiDeviceBitOrderMsbToLsb,
+      .rx_order = kDifSpiDeviceBitOrderMsbToLsb,
+      .rx_fifo_timeout = 63,
+      .rx_fifo_len = kDifSpiDeviceBufferLen / 2,
+      .tx_fifo_len = kDifSpiDeviceBufferLen / 2,
+  };
+  CHECK(dif_spi_device_init(spi_reg, &spi_config, &spi) ==
+        kDifSpiDeviceResultOk);
 
   dif_gpio_params_t gpio_params = {
       .base_addr = mmio_region_from_addr(0x40010000),
@@ -59,7 +56,7 @@ int main(int argc, char **argv) {
   LOG_INFO("The LEDs show the ASCII code of the last character.");
 
   CHECK(dif_spi_device_send(&spi, "SPI!", 4, /*bytes_sent=*/NULL) ==
-        kDifSpiDeviceOk);
+        kDifSpiDeviceResultOk);
 
   uint32_t gpio_state = 0;
   while (true) {

--- a/sw/device/lib/dif/dif_spi_device.c
+++ b/sw/device/lib/dif/dif_spi_device.c
@@ -10,44 +10,32 @@
 
 const uint16_t kDifSpiDeviceBufferLen = SPI_DEVICE_BUFFER_SIZE_BYTES;
 
-dif_spi_device_result_t dif_spi_device_init(dif_spi_device_params_t params,
-                                            dif_spi_device_t *spi) {
-  if (spi == NULL) {
-    return kDifSpiDeviceBadArg;
-  }
-
-  // This ensures all other fields are zeroed.
-  *spi = (dif_spi_device_t){.params = params};
-
-  return kDifSpiDeviceOk;
-}
-
 /**
  * Computes the required value of the control register from a given
  * configuration.
  */
 DIF_WARN_UNUSED_RESULT
 static dif_spi_device_result_t build_control_word(
-    dif_spi_device_config_t config, uint32_t *control_word) {
+    const dif_spi_device_config_t *config, uint32_t *control_word) {
   *control_word = 0;
 
   // Default polarity is positive.
-  if (config.clock_polarity == kDifSpiDeviceEdgeNegative) {
+  if (config->clock_polarity == kDifSpiDeviceEdgeNegative) {
     *control_word |= 0x1 << SPI_DEVICE_CFG_CPOL;
   }
 
   // Default phase is negative.
-  if (config.data_phase == kDifSpiDeviceEdgePositive) {
+  if (config->data_phase == kDifSpiDeviceEdgePositive) {
     *control_word |= 0x1 << SPI_DEVICE_CFG_CPHA;
   }
 
   // Default order is msb to lsb.
-  if (config.tx_order == kDifSpiDeviceBitOrderLsbToMsb) {
+  if (config->tx_order == kDifSpiDeviceBitOrderLsbToMsb) {
     *control_word |= 0x1 << SPI_DEVICE_CFG_TX_ORDER;
   }
 
   // Default order is msb to lsb.
-  if (config.rx_order == kDifSpiDeviceBitOrderLsbToMsb) {
+  if (config->rx_order == kDifSpiDeviceBitOrderLsbToMsb) {
     *control_word |= 0x1 << SPI_DEVICE_CFG_RX_ORDER;
   }
 
@@ -57,16 +45,18 @@ static dif_spi_device_result_t build_control_word(
                                  .mask = SPI_DEVICE_CFG_TIMER_V_MASK,
                                  .index = SPI_DEVICE_CFG_TIMER_V_OFFSET,
                              },
-                             config.rx_fifo_timeout);
+                             config->rx_fifo_timeout);
 
-  return kDifSpiDeviceOk;
+  return kDifSpiDeviceResultOk;
 }
 
-dif_spi_device_result_t dif_spi_device_configure(
-    dif_spi_device_t *spi, dif_spi_device_config_t config) {
-  if (spi == NULL) {
-    return kDifSpiDeviceBadArg;
+dif_spi_device_result_t dif_spi_device_init(
+    mmio_region_t base_addr, const dif_spi_device_config_t *config,
+    dif_spi_device_t *spi) {
+  if (config == NULL || spi == NULL) {
+    return kDifSpiDeviceResultBadArg;
   }
+  spi->base_addr = base_addr;
 
   // NOTE: we do not write to any registers until performing all
   // function argument checks, to avoid a halfway-configured SPI.
@@ -74,17 +64,17 @@ dif_spi_device_result_t dif_spi_device_configure(
   uint32_t device_config;
   dif_spi_device_result_t control_error =
       build_control_word(config, &device_config);
-  if (control_error != kDifSpiDeviceOk) {
+  if (control_error != kDifSpiDeviceResultOk) {
     return control_error;
   }
 
   uint16_t rx_fifo_start = 0x0;
-  uint16_t rx_fifo_end = config.rx_fifo_len - 1;
+  uint16_t rx_fifo_end = config->rx_fifo_len - 1;
   uint16_t tx_fifo_start = rx_fifo_end + 1;
-  uint16_t tx_fifo_end = tx_fifo_start + config.tx_fifo_len - 1;
+  uint16_t tx_fifo_end = tx_fifo_start + config->tx_fifo_len - 1;
   if (tx_fifo_end >= kDifSpiDeviceBufferLen) {
     // We've overflown the SRAM region...
-    return kDifSpiDeviceBadArg;
+    return kDifSpiDeviceResultBadArg;
   }
 
   uint32_t rx_fifo_bounds = 0;
@@ -119,251 +109,198 @@ dif_spi_device_result_t dif_spi_device_configure(
                              },
                              tx_fifo_end);
 
-  spi->rx_fifo_len = config.rx_fifo_len;
-  spi->tx_fifo_len = config.tx_fifo_len;
+  spi->rx_fifo_base = rx_fifo_start;
+  spi->rx_fifo_len = config->rx_fifo_len;
+  spi->tx_fifo_base = tx_fifo_start;
+  spi->tx_fifo_len = config->tx_fifo_len;
 
-  mmio_region_write32(spi->params.base_addr, SPI_DEVICE_CFG_REG_OFFSET,
-                      device_config);
-  mmio_region_write32(spi->params.base_addr, SPI_DEVICE_RXF_ADDR_REG_OFFSET,
+  // Now that we know that all function arguments are valid, we can abort
+  // all current transactions and begin reconfiguring the device.
+  dif_spi_device_result_t err;
+  err = dif_spi_device_abort(spi);
+  if (err != kDifSpiDeviceResultOk) {
+    return err;
+  }
+  err = dif_spi_device_irq_reset(spi);
+  if (err != kDifSpiDeviceResultOk) {
+    return err;
+  }
+
+  mmio_region_write32(spi->base_addr, SPI_DEVICE_CFG_REG_OFFSET, device_config);
+  mmio_region_write32(spi->base_addr, SPI_DEVICE_RXF_ADDR_REG_OFFSET,
                       rx_fifo_bounds);
-  mmio_region_write32(spi->params.base_addr, SPI_DEVICE_TXF_ADDR_REG_OFFSET,
+  mmio_region_write32(spi->base_addr, SPI_DEVICE_TXF_ADDR_REG_OFFSET,
                       tx_fifo_bounds);
 
-  return kDifSpiDeviceOk;
+  return kDifSpiDeviceResultOk;
 }
 
 dif_spi_device_result_t dif_spi_device_abort(const dif_spi_device_t *spi) {
   if (spi == NULL) {
-    return kDifSpiDeviceBadArg;
+    return kDifSpiDeviceResultBadArg;
   }
 
   // Set the `abort` bit, and then spin until `abort_done` is asserted.
-  mmio_region_nonatomic_set_bit32(spi->params.base_addr,
-                                  SPI_DEVICE_CONTROL_REG_OFFSET,
+  mmio_region_nonatomic_set_bit32(spi->base_addr, SPI_DEVICE_CONTROL_REG_OFFSET,
                                   SPI_DEVICE_CONTROL_ABORT);
-  while (!mmio_region_get_bit32(spi->params.base_addr,
-                                SPI_DEVICE_STATUS_REG_OFFSET,
+  while (!mmio_region_get_bit32(spi->base_addr, SPI_DEVICE_STATUS_REG_OFFSET,
                                 SPI_DEVICE_STATUS_ABORT_DONE)) {
   }
 
-  return kDifSpiDeviceOk;
+  return kDifSpiDeviceResultOk;
 }
 
-dif_spi_device_result_t dif_spi_device_irq_is_pending(
-    const dif_spi_device_t *spi, dif_spi_device_irq_t irq, bool *is_pending) {
-  if (spi == NULL || is_pending == NULL) {
-    return kDifSpiDeviceBadArg;
+dif_spi_device_result_t dif_spi_device_irq_reset(const dif_spi_device_t *spi) {
+  if (spi == NULL) {
+    return kDifSpiDeviceResultBadArg;
+  }
+
+  dif_spi_device_result_t err;
+
+  err = dif_spi_device_irq_clear_all(spi);
+  if (err != kDifSpiDeviceResultOk) {
+    return err;
+  }
+  err = dif_spi_device_set_irq_levels(spi, 0x80, 0x00);
+  if (err != kDifSpiDeviceResultOk) {
+    return err;
+  }
+
+  // Disable interrupts manually, since the relevant DIF only allows for single
+  // bit flips.
+  mmio_region_write32(spi->base_addr, SPI_DEVICE_INTR_ENABLE_REG_OFFSET, 0);
+
+  return kDifSpiDeviceResultOk;
+}
+
+dif_spi_device_result_t dif_spi_device_irq_get(const dif_spi_device_t *spi,
+                                               dif_spi_device_irq_type_t type,
+                                               bool *flag_out) {
+  if (spi == NULL || flag_out == NULL) {
+    return kDifSpiDeviceResultBadArg;
   }
 
   uint32_t bit_index = 0;
-  switch (irq) {
-    case kDifSpiDeviceIrqRxFull:
+  switch (type) {
+    case kDifSpiDeviceIrqTypeRxFull:
       bit_index = SPI_DEVICE_INTR_STATE_RXF;
       break;
-    case kDifSpiDeviceIrqRxAboveLevel:
+    case kDifSpiDeviceIrqTypeRxAboveLevel:
       bit_index = SPI_DEVICE_INTR_STATE_RXLVL;
       break;
-    case kDifSpiDeviceIrqTxBelowLevel:
+    case kDifSpiDeviceIrqTypeTxBelowLevel:
       bit_index = SPI_DEVICE_INTR_STATE_TXLVL;
       break;
-    case kDifSpiDeviceIrqRxError:
+    case kDifSpiDeviceIrqTypeRxError:
       bit_index = SPI_DEVICE_INTR_STATE_RXERR;
       break;
-    case kDifSpiDeviceIrqRxOverflow:
+    case kDifSpiDeviceIrqTypeRxOverflow:
       bit_index = SPI_DEVICE_INTR_STATE_RXOVERFLOW;
       break;
-    case kDifSpiDeviceIrqTxUnderflow:
+    case kDifSpiDeviceIrqTypeTxUnderflow:
       bit_index = SPI_DEVICE_INTR_STATE_TXUNDERFLOW;
       break;
   }
 
-  *is_pending = mmio_region_get_bit32(
-      spi->params.base_addr, SPI_DEVICE_INTR_STATE_REG_OFFSET, bit_index);
-  return kDifSpiDeviceOk;
+  *flag_out = mmio_region_get_bit32(
+      spi->base_addr, SPI_DEVICE_INTR_STATE_REG_OFFSET, bit_index);
+  return kDifSpiDeviceResultOk;
 }
 
-dif_spi_device_result_t dif_spi_device_irq_acknowledge(
-    const dif_spi_device_t *spi, dif_spi_device_irq_t irq) {
+dif_spi_device_result_t dif_spi_device_irq_clear_all(
+    const dif_spi_device_t *spi) {
   if (spi == NULL) {
-    return kDifSpiDeviceBadArg;
+    return kDifSpiDeviceResultBadArg;
   }
 
-  uint32_t bit_index = 0;
-  switch (irq) {
-    case kDifSpiDeviceIrqRxFull:
-      bit_index = SPI_DEVICE_INTR_STATE_RXF;
-      break;
-    case kDifSpiDeviceIrqRxAboveLevel:
-      bit_index = SPI_DEVICE_INTR_STATE_RXLVL;
-      break;
-    case kDifSpiDeviceIrqTxBelowLevel:
-      bit_index = SPI_DEVICE_INTR_STATE_TXLVL;
-      break;
-    case kDifSpiDeviceIrqRxError:
-      bit_index = SPI_DEVICE_INTR_STATE_RXERR;
-      break;
-    case kDifSpiDeviceIrqRxOverflow:
-      bit_index = SPI_DEVICE_INTR_STATE_RXOVERFLOW;
-      break;
-    case kDifSpiDeviceIrqTxUnderflow:
-      bit_index = SPI_DEVICE_INTR_STATE_TXUNDERFLOW;
-      break;
-  }
+  // The state register is a write-one-clear register.
+  mmio_region_write32(spi->base_addr, SPI_DEVICE_INTR_STATE_REG_OFFSET,
+                      UINT32_MAX);
 
-  mmio_region_write32(spi->params.base_addr, SPI_DEVICE_INTR_STATE_REG_OFFSET,
-                      1 << bit_index);
-  return kDifSpiDeviceOk;
+  return kDifSpiDeviceResultOk;
 }
 
-dif_spi_device_result_t dif_spi_device_irq_get_enabled(
-    const dif_spi_device_t *spi, dif_spi_device_irq_t irq,
-    dif_spi_device_toggle_t *state) {
-  if (spi == NULL || state == NULL) {
-    return kDifSpiDeviceBadArg;
+dif_spi_device_result_t dif_spi_device_irq_enable(
+    const dif_spi_device_t *spi, dif_spi_device_irq_type_t type,
+    dif_spi_device_irq_state_t state) {
+  if (spi == NULL) {
+    return kDifSpiDeviceResultBadArg;
   }
 
   uint32_t bit_index = 0;
-  switch (irq) {
-    case kDifSpiDeviceIrqRxFull:
+  switch (type) {
+    case kDifSpiDeviceIrqTypeRxFull:
       bit_index = SPI_DEVICE_INTR_ENABLE_RXF;
       break;
-    case kDifSpiDeviceIrqRxAboveLevel:
+    case kDifSpiDeviceIrqTypeRxAboveLevel:
       bit_index = SPI_DEVICE_INTR_ENABLE_RXLVL;
       break;
-    case kDifSpiDeviceIrqTxBelowLevel:
+    case kDifSpiDeviceIrqTypeTxBelowLevel:
       bit_index = SPI_DEVICE_INTR_ENABLE_TXLVL;
       break;
-    case kDifSpiDeviceIrqRxError:
+    case kDifSpiDeviceIrqTypeRxError:
       bit_index = SPI_DEVICE_INTR_ENABLE_RXERR;
       break;
-    case kDifSpiDeviceIrqRxOverflow:
+    case kDifSpiDeviceIrqTypeRxOverflow:
       bit_index = SPI_DEVICE_INTR_ENABLE_RXOVERFLOW;
       break;
-    case kDifSpiDeviceIrqTxUnderflow:
-      bit_index = SPI_DEVICE_INTR_ENABLE_TXUNDERFLOW;
-      break;
-  }
-
-  bool is_enabled = mmio_region_get_bit32(
-      spi->params.base_addr, SPI_DEVICE_INTR_ENABLE_REG_OFFSET, bit_index);
-  *state =
-      is_enabled ? kDifSpiDeviceToggleEnabled : kDifSpiDeviceToggleDisabled;
-
-  return kDifSpiDeviceOk;
-}
-
-dif_spi_device_result_t dif_spi_device_irq_set_enabled(
-    const dif_spi_device_t *spi, dif_spi_device_irq_t irq,
-    dif_spi_device_toggle_t state) {
-  if (spi == NULL) {
-    return kDifSpiDeviceBadArg;
-  }
-
-  uint32_t bit_index = 0;
-  switch (irq) {
-    case kDifSpiDeviceIrqRxFull:
-      bit_index = SPI_DEVICE_INTR_ENABLE_RXF;
-      break;
-    case kDifSpiDeviceIrqRxAboveLevel:
-      bit_index = SPI_DEVICE_INTR_ENABLE_RXLVL;
-      break;
-    case kDifSpiDeviceIrqTxBelowLevel:
-      bit_index = SPI_DEVICE_INTR_ENABLE_TXLVL;
-      break;
-    case kDifSpiDeviceIrqRxError:
-      bit_index = SPI_DEVICE_INTR_ENABLE_RXERR;
-      break;
-    case kDifSpiDeviceIrqRxOverflow:
-      bit_index = SPI_DEVICE_INTR_ENABLE_RXOVERFLOW;
-      break;
-    case kDifSpiDeviceIrqTxUnderflow:
+    case kDifSpiDeviceIrqTypeTxUnderflow:
       bit_index = SPI_DEVICE_INTR_ENABLE_TXUNDERFLOW;
       break;
   }
 
   switch (state) {
-    case kDifSpiDeviceToggleEnabled:
+    case kDifSpiDeviceIrqStateEnabled:
       mmio_region_nonatomic_set_bit32(
-          spi->params.base_addr, SPI_DEVICE_INTR_ENABLE_REG_OFFSET, bit_index);
+          spi->base_addr, SPI_DEVICE_INTR_ENABLE_REG_OFFSET, bit_index);
       break;
-    case kDifSpiDeviceToggleDisabled:
+    case kDifSpiDeviceIrqStateDisabled:
       mmio_region_nonatomic_clear_bit32(
-          spi->params.base_addr, SPI_DEVICE_INTR_ENABLE_REG_OFFSET, bit_index);
+          spi->base_addr, SPI_DEVICE_INTR_ENABLE_REG_OFFSET, bit_index);
       break;
   }
 
-  return kDifSpiDeviceOk;
+  return kDifSpiDeviceResultOk;
 }
 
-dif_spi_device_result_t dif_spi_device_irq_force(const dif_spi_device_t *spi,
-                                                 dif_spi_device_irq_t irq) {
+dif_spi_device_result_t dif_spi_device_irq_force(
+    const dif_spi_device_t *spi, dif_spi_device_irq_type_t type) {
   if (spi == NULL) {
-    return kDifSpiDeviceBadArg;
+    return kDifSpiDeviceResultBadArg;
   }
 
   uint32_t bit_index = 0;
-  switch (irq) {
-    case kDifSpiDeviceIrqRxFull:
+  switch (type) {
+    case kDifSpiDeviceIrqTypeRxFull:
       bit_index = SPI_DEVICE_INTR_TEST_RXF;
       break;
-    case kDifSpiDeviceIrqRxAboveLevel:
+    case kDifSpiDeviceIrqTypeRxAboveLevel:
       bit_index = SPI_DEVICE_INTR_TEST_RXLVL;
       break;
-    case kDifSpiDeviceIrqTxBelowLevel:
+    case kDifSpiDeviceIrqTypeTxBelowLevel:
       bit_index = SPI_DEVICE_INTR_TEST_TXLVL;
       break;
-    case kDifSpiDeviceIrqRxError:
+    case kDifSpiDeviceIrqTypeRxError:
       bit_index = SPI_DEVICE_INTR_TEST_RXERR;
       break;
-    case kDifSpiDeviceIrqRxOverflow:
+    case kDifSpiDeviceIrqTypeRxOverflow:
       bit_index = SPI_DEVICE_INTR_TEST_RXOVERFLOW;
       break;
-    case kDifSpiDeviceIrqTxUnderflow:
+    case kDifSpiDeviceIrqTypeTxUnderflow:
       bit_index = SPI_DEVICE_INTR_TEST_TXUNDERFLOW;
       break;
   }
 
   uint32_t mask = 1 << bit_index;
-  mmio_region_write32(spi->params.base_addr, SPI_DEVICE_INTR_TEST_REG_OFFSET,
-                      mask);
+  mmio_region_write32(spi->base_addr, SPI_DEVICE_INTR_TEST_REG_OFFSET, mask);
 
-  return kDifSpiDeviceOk;
-}
-
-dif_spi_device_result_t dif_spi_device_irq_disable_all(
-    const dif_spi_device_t *spi, dif_spi_device_irq_snapshot_t *snapshot) {
-  if (spi == NULL) {
-    return kDifSpiDeviceBadArg;
-  }
-
-  if (snapshot != NULL) {
-    *snapshot = mmio_region_read32(spi->params.base_addr,
-                                   SPI_DEVICE_INTR_ENABLE_REG_OFFSET);
-  }
-
-  mmio_region_write32(spi->params.base_addr, SPI_DEVICE_INTR_ENABLE_REG_OFFSET,
-                      0);
-
-  return kDifSpiDeviceOk;
-}
-
-dif_spi_device_result_t dif_spi_device_irq_restore_all(
-    const dif_spi_device_t *spi,
-    const dif_spi_device_irq_snapshot_t *snapshot) {
-  if (spi == NULL || snapshot == NULL) {
-    return kDifSpiDeviceBadArg;
-  }
-
-  mmio_region_write32(spi->params.base_addr, SPI_DEVICE_INTR_ENABLE_REG_OFFSET,
-                      *snapshot);
-
-  return kDifSpiDeviceOk;
+  return kDifSpiDeviceResultOk;
 }
 
 dif_spi_device_result_t dif_spi_device_set_irq_levels(
     const dif_spi_device_t *spi, uint16_t rx_level, uint16_t tx_level) {
   if (spi == NULL) {
-    return kDifSpiDeviceBadArg;
+    return kDifSpiDeviceResultBadArg;
   }
 
   uint32_t compressed_limit = 0;
@@ -381,10 +318,10 @@ dif_spi_device_result_t dif_spi_device_set_irq_levels(
                                  .index = SPI_DEVICE_FIFO_LEVEL_TXLVL_OFFSET,
                              },
                              tx_level);
-  mmio_region_write32(spi->params.base_addr, SPI_DEVICE_FIFO_LEVEL_REG_OFFSET,
+  mmio_region_write32(spi->base_addr, SPI_DEVICE_FIFO_LEVEL_REG_OFFSET,
                       compressed_limit);
 
-  return kDifSpiDeviceOk;
+  return kDifSpiDeviceResultOk;
 }
 
 /**
@@ -481,7 +418,7 @@ typedef struct fifo_ptrs {
  */
 static fifo_ptrs_t decompress_ptrs(const dif_spi_device_t *spi,
                                    fifo_ptr_params_t params) {
-  uint32_t ptr = mmio_region_read32(spi->params.base_addr, params.reg_offset);
+  uint32_t ptr = mmio_region_read32(spi->base_addr, params.reg_offset);
   uint16_t write_val =
       (uint16_t)((ptr >> params.write_offset) & params.write_mask);
   uint16_t read_val =
@@ -532,7 +469,7 @@ static void compress_ptrs(const dif_spi_device_t *spi, fifo_ptr_params_t params,
           .mask = params.read_mask, .index = params.read_offset,
       },
       read_val);
-  mmio_region_write32(spi->params.base_addr, params.reg_offset, ptr);
+  mmio_region_write32(spi->base_addr, params.reg_offset, ptr);
 }
 
 /**
@@ -568,25 +505,25 @@ static uint16_t fifo_bytes_in_use(fifo_ptrs_t ptrs, uint16_t fifo_len) {
 dif_spi_device_result_t dif_spi_device_rx_pending(const dif_spi_device_t *spi,
                                                   size_t *bytes_pending) {
   if (spi == NULL || bytes_pending == NULL) {
-    return kDifSpiDeviceBadArg;
+    return kDifSpiDeviceResultBadArg;
   }
 
   fifo_ptrs_t ptrs = decompress_ptrs(spi, kRxFifoParams);
   *bytes_pending = fifo_bytes_in_use(ptrs, spi->rx_fifo_len);
 
-  return kDifSpiDeviceOk;
+  return kDifSpiDeviceResultOk;
 }
 
 dif_spi_device_result_t dif_spi_device_tx_pending(const dif_spi_device_t *spi,
                                                   size_t *bytes_pending) {
   if (spi == NULL || bytes_pending == NULL) {
-    return kDifSpiDeviceBadArg;
+    return kDifSpiDeviceResultBadArg;
   }
 
   fifo_ptrs_t ptrs = decompress_ptrs(spi, kTxFifoParams);
   *bytes_pending = fifo_bytes_in_use(ptrs, spi->tx_fifo_len);
 
-  return kDifSpiDeviceOk;
+  return kDifSpiDeviceResultOk;
 }
 
 /**
@@ -645,11 +582,11 @@ static size_t spi_memcpy(const dif_spi_device_t *spi, fifo_ptrs_t *fifo,
     }
     if (is_recv) {
       // SPI device buffer -> `byte_buf`
-      mmio_region_memcpy_from_mmio32(spi->params.base_addr, mmio_offset,
-                                     byte_buf, bytes_to_copy);
+      mmio_region_memcpy_from_mmio32(spi->base_addr, mmio_offset, byte_buf,
+                                     bytes_to_copy);
     } else {
       // `byte_buf` -> SPI device buffer
-      mmio_region_memcpy_to_mmio32(spi->params.base_addr, mmio_offset, byte_buf,
+      mmio_region_memcpy_to_mmio32(spi->base_addr, mmio_offset, byte_buf,
                                    bytes_to_copy);
     }
     fifo_ptr_increment(ptr, bytes_to_copy, fifo_len);
@@ -664,10 +601,10 @@ dif_spi_device_result_t dif_spi_device_recv(const dif_spi_device_t *spi,
                                             void *buf, size_t buf_len,
                                             size_t *bytes_received) {
   if (spi == NULL || buf == NULL) {
-    return kDifSpiDeviceBadArg;
+    return kDifSpiDeviceResultBadArg;
   }
 
-  uint16_t fifo_base = 0;
+  uint16_t fifo_base = spi->rx_fifo_base;
   uint16_t fifo_len = spi->rx_fifo_len;
   fifo_ptrs_t fifo = decompress_ptrs(spi, kRxFifoParams);
 
@@ -680,18 +617,17 @@ dif_spi_device_result_t dif_spi_device_recv(const dif_spi_device_t *spi,
     // Commit the new RX FIFO pointers.
     compress_ptrs(spi, kRxFifoParams, fifo);
   }
-  return kDifSpiDeviceOk;
+  return kDifSpiDeviceResultOk;
 }
 
 dif_spi_device_result_t dif_spi_device_send(const dif_spi_device_t *spi,
                                             const void *buf, size_t buf_len,
                                             size_t *bytes_sent) {
   if (spi == NULL || buf == NULL) {
-    return kDifSpiDeviceBadArg;
+    return kDifSpiDeviceResultBadArg;
   }
 
-  // Start of the TX FIFO is the end of the RX FIFO.
-  uint16_t fifo_base = spi->rx_fifo_len;
+  uint16_t fifo_base = spi->tx_fifo_base;
   uint16_t fifo_len = spi->tx_fifo_len;
   fifo_ptrs_t fifo = decompress_ptrs(spi, kTxFifoParams);
 
@@ -704,5 +640,5 @@ dif_spi_device_result_t dif_spi_device_send(const dif_spi_device_t *spi,
     // Commit the new TX FIFO pointers.
     compress_ptrs(spi, kTxFifoParams, fifo);
   }
-  return kDifSpiDeviceOk;
+  return kDifSpiDeviceResultOk;
 }

--- a/sw/device/lib/dif/dif_spi_device.c
+++ b/sw/device/lib/dif/dif_spi_device.c
@@ -26,26 +26,40 @@ dif_spi_device_result_t dif_spi_device_init(dif_spi_device_params_t params,
  * Computes the required value of the control register from a given
  * configuration.
  */
-static uint32_t build_control_word(dif_spi_device_config_t config) {
-  uint32_t val = 0;
+DIF_WARN_UNUSED_RESULT
+static dif_spi_device_result_t build_control_word(
+    dif_spi_device_config_t config, uint32_t *control_word) {
+  *control_word = 0;
 
-  val =
-      bitfield_bit32_write(val, SPI_DEVICE_CFG_CPOL,
-                           config.clock_polarity == kDifSpiDeviceEdgeNegative);
-  val = bitfield_bit32_write(val, SPI_DEVICE_CFG_CPHA,
-                             config.data_phase == kDifSpiDeviceEdgePositive);
-  val = bitfield_bit32_write(val, SPI_DEVICE_CFG_TX_ORDER,
-                             config.tx_order == kDifSpiDeviceBitOrderLsbToMsb);
-  val = bitfield_bit32_write(val, SPI_DEVICE_CFG_RX_ORDER,
-                             config.rx_order == kDifSpiDeviceBitOrderLsbToMsb);
-  val = bitfield_field32_write(val,
-                               (bitfield_field32_t){
-                                   .mask = SPI_DEVICE_CFG_TIMER_V_MASK,
-                                   .index = SPI_DEVICE_CFG_TIMER_V_OFFSET,
-                               },
-                               config.rx_fifo_timeout);
+  // Default polarity is positive.
+  if (config.clock_polarity == kDifSpiDeviceEdgeNegative) {
+    *control_word |= 0x1 << SPI_DEVICE_CFG_CPOL;
+  }
 
-  return val;
+  // Default phase is negative.
+  if (config.data_phase == kDifSpiDeviceEdgePositive) {
+    *control_word |= 0x1 << SPI_DEVICE_CFG_CPHA;
+  }
+
+  // Default order is msb to lsb.
+  if (config.tx_order == kDifSpiDeviceBitOrderLsbToMsb) {
+    *control_word |= 0x1 << SPI_DEVICE_CFG_TX_ORDER;
+  }
+
+  // Default order is msb to lsb.
+  if (config.rx_order == kDifSpiDeviceBitOrderLsbToMsb) {
+    *control_word |= 0x1 << SPI_DEVICE_CFG_RX_ORDER;
+  }
+
+  *control_word =
+      bitfield_field32_write(*control_word,
+                             (bitfield_field32_t){
+                                 .mask = SPI_DEVICE_CFG_TIMER_V_MASK,
+                                 .index = SPI_DEVICE_CFG_TIMER_V_OFFSET,
+                             },
+                             config.rx_fifo_timeout);
+
+  return kDifSpiDeviceOk;
 }
 
 dif_spi_device_result_t dif_spi_device_configure(
@@ -57,7 +71,12 @@ dif_spi_device_result_t dif_spi_device_configure(
   // NOTE: we do not write to any registers until performing all
   // function argument checks, to avoid a halfway-configured SPI.
 
-  uint32_t device_config = build_control_word(config);
+  uint32_t device_config;
+  dif_spi_device_result_t control_error =
+      build_control_word(config, &device_config);
+  if (control_error != kDifSpiDeviceOk) {
+    return control_error;
+  }
 
   uint16_t rx_fifo_start = 0x0;
   uint16_t rx_fifo_end = config.rx_fifo_len - 1;
@@ -119,46 +138,15 @@ dif_spi_device_result_t dif_spi_device_abort(const dif_spi_device_t *spi) {
   }
 
   // Set the `abort` bit, and then spin until `abort_done` is asserted.
-  uint32_t reg =
-      mmio_region_read32(spi->params.base_addr, SPI_DEVICE_CONTROL_REG_OFFSET);
-  reg = bitfield_bit32_write(reg, SPI_DEVICE_CONTROL_ABORT, true);
-  mmio_region_write32(spi->params.base_addr, SPI_DEVICE_CONTROL_REG_OFFSET,
-                      reg);
-
-  while (true) {
-    uint32_t reg =
-        mmio_region_read32(spi->params.base_addr, SPI_DEVICE_STATUS_REG_OFFSET);
-    if (bitfield_bit32_read(reg, SPI_DEVICE_STATUS_ABORT_DONE)) {
-      return kDifSpiDeviceOk;
-    }
+  mmio_region_nonatomic_set_bit32(spi->params.base_addr,
+                                  SPI_DEVICE_CONTROL_REG_OFFSET,
+                                  SPI_DEVICE_CONTROL_ABORT);
+  while (!mmio_region_get_bit32(spi->params.base_addr,
+                                SPI_DEVICE_STATUS_REG_OFFSET,
+                                SPI_DEVICE_STATUS_ABORT_DONE)) {
   }
-}
 
-DIF_WARN_UNUSED_RESULT
-static bool irq_index(dif_spi_device_irq_t irq, bitfield_bit32_index_t *index) {
-  switch (irq) {
-    case kDifSpiDeviceIrqRxFull:
-      *index = SPI_DEVICE_INTR_COMMON_RXF;
-      break;
-    case kDifSpiDeviceIrqRxAboveLevel:
-      *index = SPI_DEVICE_INTR_COMMON_RXLVL;
-      break;
-    case kDifSpiDeviceIrqTxBelowLevel:
-      *index = SPI_DEVICE_INTR_COMMON_TXLVL;
-      break;
-    case kDifSpiDeviceIrqRxError:
-      *index = SPI_DEVICE_INTR_COMMON_RXERR;
-      break;
-    case kDifSpiDeviceIrqRxOverflow:
-      *index = SPI_DEVICE_INTR_COMMON_RXOVERFLOW;
-      break;
-    case kDifSpiDeviceIrqTxUnderflow:
-      *index = SPI_DEVICE_INTR_COMMON_TXUNDERFLOW;
-      break;
-    default:
-      return false;
-  }
-  return true;
+  return kDifSpiDeviceOk;
 }
 
 dif_spi_device_result_t dif_spi_device_irq_is_pending(
@@ -167,15 +155,30 @@ dif_spi_device_result_t dif_spi_device_irq_is_pending(
     return kDifSpiDeviceBadArg;
   }
 
-  bitfield_bit32_index_t index;
-  if (!irq_index(irq, &index)) {
-    return kDifSpiDeviceBadArg;
+  uint32_t bit_index = 0;
+  switch (irq) {
+    case kDifSpiDeviceIrqRxFull:
+      bit_index = SPI_DEVICE_INTR_STATE_RXF;
+      break;
+    case kDifSpiDeviceIrqRxAboveLevel:
+      bit_index = SPI_DEVICE_INTR_STATE_RXLVL;
+      break;
+    case kDifSpiDeviceIrqTxBelowLevel:
+      bit_index = SPI_DEVICE_INTR_STATE_TXLVL;
+      break;
+    case kDifSpiDeviceIrqRxError:
+      bit_index = SPI_DEVICE_INTR_STATE_RXERR;
+      break;
+    case kDifSpiDeviceIrqRxOverflow:
+      bit_index = SPI_DEVICE_INTR_STATE_RXOVERFLOW;
+      break;
+    case kDifSpiDeviceIrqTxUnderflow:
+      bit_index = SPI_DEVICE_INTR_STATE_TXUNDERFLOW;
+      break;
   }
 
-  uint32_t reg = mmio_region_read32(spi->params.base_addr,
-                                    SPI_DEVICE_INTR_STATE_REG_OFFSET);
-  *is_pending = bitfield_bit32_read(reg, index);
-
+  *is_pending = mmio_region_get_bit32(
+      spi->params.base_addr, SPI_DEVICE_INTR_STATE_REG_OFFSET, bit_index);
   return kDifSpiDeviceOk;
 }
 
@@ -185,15 +188,30 @@ dif_spi_device_result_t dif_spi_device_irq_acknowledge(
     return kDifSpiDeviceBadArg;
   }
 
-  bitfield_bit32_index_t index;
-  if (!irq_index(irq, &index)) {
-    return kDifSpiDeviceBadArg;
+  uint32_t bit_index = 0;
+  switch (irq) {
+    case kDifSpiDeviceIrqRxFull:
+      bit_index = SPI_DEVICE_INTR_STATE_RXF;
+      break;
+    case kDifSpiDeviceIrqRxAboveLevel:
+      bit_index = SPI_DEVICE_INTR_STATE_RXLVL;
+      break;
+    case kDifSpiDeviceIrqTxBelowLevel:
+      bit_index = SPI_DEVICE_INTR_STATE_TXLVL;
+      break;
+    case kDifSpiDeviceIrqRxError:
+      bit_index = SPI_DEVICE_INTR_STATE_RXERR;
+      break;
+    case kDifSpiDeviceIrqRxOverflow:
+      bit_index = SPI_DEVICE_INTR_STATE_RXOVERFLOW;
+      break;
+    case kDifSpiDeviceIrqTxUnderflow:
+      bit_index = SPI_DEVICE_INTR_STATE_TXUNDERFLOW;
+      break;
   }
 
-  uint32_t reg = bitfield_bit32_write(0, index, true);
   mmio_region_write32(spi->params.base_addr, SPI_DEVICE_INTR_STATE_REG_OFFSET,
-                      reg);
-
+                      1 << bit_index);
   return kDifSpiDeviceOk;
 }
 
@@ -204,15 +222,32 @@ dif_spi_device_result_t dif_spi_device_irq_get_enabled(
     return kDifSpiDeviceBadArg;
   }
 
-  bitfield_bit32_index_t index;
-  if (!irq_index(irq, &index)) {
-    return kDifSpiDeviceBadArg;
+  uint32_t bit_index = 0;
+  switch (irq) {
+    case kDifSpiDeviceIrqRxFull:
+      bit_index = SPI_DEVICE_INTR_ENABLE_RXF;
+      break;
+    case kDifSpiDeviceIrqRxAboveLevel:
+      bit_index = SPI_DEVICE_INTR_ENABLE_RXLVL;
+      break;
+    case kDifSpiDeviceIrqTxBelowLevel:
+      bit_index = SPI_DEVICE_INTR_ENABLE_TXLVL;
+      break;
+    case kDifSpiDeviceIrqRxError:
+      bit_index = SPI_DEVICE_INTR_ENABLE_RXERR;
+      break;
+    case kDifSpiDeviceIrqRxOverflow:
+      bit_index = SPI_DEVICE_INTR_ENABLE_RXOVERFLOW;
+      break;
+    case kDifSpiDeviceIrqTxUnderflow:
+      bit_index = SPI_DEVICE_INTR_ENABLE_TXUNDERFLOW;
+      break;
   }
 
-  uint32_t reg = mmio_region_read32(spi->params.base_addr,
-                                    SPI_DEVICE_INTR_ENABLE_REG_OFFSET);
-  *state = bitfield_bit32_read(reg, index) ? kDifSpiDeviceToggleEnabled
-                                           : kDifSpiDeviceToggleDisabled;
+  bool is_enabled = mmio_region_get_bit32(
+      spi->params.base_addr, SPI_DEVICE_INTR_ENABLE_REG_OFFSET, bit_index);
+  *state =
+      is_enabled ? kDifSpiDeviceToggleEnabled : kDifSpiDeviceToggleDisabled;
 
   return kDifSpiDeviceOk;
 }
@@ -224,28 +259,38 @@ dif_spi_device_result_t dif_spi_device_irq_set_enabled(
     return kDifSpiDeviceBadArg;
   }
 
-  bitfield_bit32_index_t index;
-  if (!irq_index(irq, &index)) {
-    return kDifSpiDeviceBadArg;
+  uint32_t bit_index = 0;
+  switch (irq) {
+    case kDifSpiDeviceIrqRxFull:
+      bit_index = SPI_DEVICE_INTR_ENABLE_RXF;
+      break;
+    case kDifSpiDeviceIrqRxAboveLevel:
+      bit_index = SPI_DEVICE_INTR_ENABLE_RXLVL;
+      break;
+    case kDifSpiDeviceIrqTxBelowLevel:
+      bit_index = SPI_DEVICE_INTR_ENABLE_TXLVL;
+      break;
+    case kDifSpiDeviceIrqRxError:
+      bit_index = SPI_DEVICE_INTR_ENABLE_RXERR;
+      break;
+    case kDifSpiDeviceIrqRxOverflow:
+      bit_index = SPI_DEVICE_INTR_ENABLE_RXOVERFLOW;
+      break;
+    case kDifSpiDeviceIrqTxUnderflow:
+      bit_index = SPI_DEVICE_INTR_ENABLE_TXUNDERFLOW;
+      break;
   }
 
-  bool flag;
   switch (state) {
     case kDifSpiDeviceToggleEnabled:
-      flag = true;
+      mmio_region_nonatomic_set_bit32(
+          spi->params.base_addr, SPI_DEVICE_INTR_ENABLE_REG_OFFSET, bit_index);
       break;
     case kDifSpiDeviceToggleDisabled:
-      flag = false;
+      mmio_region_nonatomic_clear_bit32(
+          spi->params.base_addr, SPI_DEVICE_INTR_ENABLE_REG_OFFSET, bit_index);
       break;
-    default:
-      return kDifSpiDeviceBadArg;
   }
-
-  uint32_t reg = mmio_region_read32(spi->params.base_addr,
-                                    SPI_DEVICE_INTR_ENABLE_REG_OFFSET);
-  reg = bitfield_bit32_write(reg, index, flag);
-  mmio_region_write32(spi->params.base_addr, SPI_DEVICE_INTR_ENABLE_REG_OFFSET,
-                      reg);
 
   return kDifSpiDeviceOk;
 }
@@ -256,14 +301,31 @@ dif_spi_device_result_t dif_spi_device_irq_force(const dif_spi_device_t *spi,
     return kDifSpiDeviceBadArg;
   }
 
-  bitfield_bit32_index_t index;
-  if (!irq_index(irq, &index)) {
-    return kDifSpiDeviceBadArg;
+  uint32_t bit_index = 0;
+  switch (irq) {
+    case kDifSpiDeviceIrqRxFull:
+      bit_index = SPI_DEVICE_INTR_TEST_RXF;
+      break;
+    case kDifSpiDeviceIrqRxAboveLevel:
+      bit_index = SPI_DEVICE_INTR_TEST_RXLVL;
+      break;
+    case kDifSpiDeviceIrqTxBelowLevel:
+      bit_index = SPI_DEVICE_INTR_TEST_TXLVL;
+      break;
+    case kDifSpiDeviceIrqRxError:
+      bit_index = SPI_DEVICE_INTR_TEST_RXERR;
+      break;
+    case kDifSpiDeviceIrqRxOverflow:
+      bit_index = SPI_DEVICE_INTR_TEST_RXOVERFLOW;
+      break;
+    case kDifSpiDeviceIrqTxUnderflow:
+      bit_index = SPI_DEVICE_INTR_TEST_TXUNDERFLOW;
+      break;
   }
 
-  uint32_t reg = bitfield_bit32_write(0, index, true);
+  uint32_t mask = 1 << bit_index;
   mmio_region_write32(spi->params.base_addr, SPI_DEVICE_INTR_TEST_REG_OFFSET,
-                      reg);
+                      mask);
 
   return kDifSpiDeviceOk;
 }

--- a/sw/device/lib/dif/dif_spi_device.h
+++ b/sw/device/lib/dif/dif_spi_device.h
@@ -23,108 +23,54 @@ extern "C" {
 #endif  // __cplusplus
 
 /**
- * A signal edge type: positive or negative.
+ * Represents a signal edge type.
  */
 typedef enum dif_spi_device_edge {
-  /**
-   * Represents a positive edge (i.e., from low to high).
-   */
   kDifSpiDeviceEdgePositive,
-  /**
-   * Represents a negative edge (i.e., from high to low).
-   */
   kDifSpiDeviceEdgeNegative,
 } dif_spi_device_edge_t;
 
 /**
- * A bit ordering within a byte.
+ * Represents a bit ordering.
  */
 typedef enum dif_spi_device_bit_order {
-  /**
-   * Represents the most-significant-bit to least-significant-bit order.
-   */
   kDifSpiDeviceBitOrderMsbToLsb,
-  /**
-   * Represents the least-significant-bit to most-significant-bit order.
-   */
   kDifSpiDeviceBitOrderLsbToMsb,
 } dif_spi_device_bit_order_t;
 
 /**
- * A toggle state: enabled, or disabled.
- *
- * This enum may be used instead of a `bool` when describing an enabled/disabled
- * state.
+ * Represents the enablement state of a particular SPI IRQ.
  */
-typedef enum dif_spi_device_toggle {
-  /*
-   * The "enabled" state.
-   */
-  kDifSpiDeviceToggleEnabled,
-  /**
-   * The "disabled" state.
-   */
-  kDifSpiDeviceToggleDisabled,
-} dif_spi_device_toggle_t;
+typedef enum dif_spi_device_irq_state {
+  kDifSpiDeviceIrqStateEnabled = true,
+  kDifSpiDeviceIrqStateDisabled = false,
+} dif_spi_device_irq_state_t;
 
 /**
- * A SPI interrupt request type.
+ * Represents the types of interrupts that the SPI device will
+ * fire to signal state.
  */
-typedef enum dif_spi_device_irq {
-  /**
-   * Indicates that the RX FIFO is full.
-   */
-  kDifSpiDeviceIrqRxFull,
-  /**
-   * Indicates that the RX FIFO is above the configured level.
-   */
-  kDifSpiDeviceIrqRxAboveLevel,
-  /**
-   * Indicates that the TX FIFO is below the configured level.
-   */
-  kDifSpiDeviceIrqTxBelowLevel,
-  /**
-   * Indicates an error in the RX FIFO.
-   */
-  kDifSpiDeviceIrqRxError,
-  /**
-   * Indicates that overflow has occured in the RX FIFO.
-   */
-  kDifSpiDeviceIrqRxOverflow,
-  /**
-   * Indicates that underflow has occured in the RX FIFO.
-   */
-  kDifSpiDeviceIrqTxUnderflow,
-} dif_spi_device_irq_t;
+typedef enum dif_spi_device_irq_type {
+  kDifSpiDeviceIrqTypeRxFull,
+  kDifSpiDeviceIrqTypeRxAboveLevel,
+  kDifSpiDeviceIrqTypeTxBelowLevel,
+  kDifSpiDeviceIrqTypeRxError,
+  kDifSpiDeviceIrqTypeRxOverflow,
+  kDifSpiDeviceIrqTypeTxUnderflow,
+} dif_spi_device_irq_type_t;
 
 /**
- * A snapshot of the enablement state of the interrupts for SPI.
- *
- * This is an opaque type, to be used with the
- * `dif_spi_device_irq_disable_all()` and
- * `dif_spi_device_irq_restore_all()` functions.
- */
-typedef uint32_t dif_spi_device_irq_snapshot_t;
-
-/**
- * The result of a SPI operation.
+ * Errors returned by SPI DIF functions.
  */
 typedef enum dif_spi_device_result {
   /**
-   * Indicates that the operation succeeded.
+   * Indicates a successful operation.
    */
-  kDifSpiDeviceOk = 0,
+  kDifSpiDeviceResultOk = 0,
   /**
-   * Indicates some unspecified failure.
+   * Indicates a failed precondition on the function arguments.
    */
-  kDifSpiDeviceError = 1,
-  /**
-   * Indicates that some parameter passed into a function failed a
-   * precondition.
-   *
-   * When this value is returned, no hardware operations occured.
-   */
-  kDifSpiDeviceBadArg = 2,
+  kDifSpiDeviceResultBadArg,
 } dif_spi_device_result_t;
 
 /**
@@ -136,24 +82,7 @@ typedef enum dif_spi_device_result {
 extern const uint16_t kDifSpiDeviceBufferLen;
 
 /**
- * Hardware instantiation parameters for SPI.
- *
- * This struct describes information about the underlying hardware that is
- * not determined until the hardware design is used as part of a top-level
- * design.
- */
-typedef struct dif_spi_device_params {
-  /**
-   * The base address for the SPI hardware registers.
-   */
-  mmio_region_t base_addr;
-} dif_spi_device_params_t;
-
-/**
- * Runtime configuration for SPI.
- *
- * This struct describes runtime information for one-time configuration of the
- * hardware.
+ * Configuration for initializing a SPI device.
  */
 typedef struct dif_spi_device_config {
   dif_spi_device_edge_t clock_polarity;
@@ -161,155 +90,103 @@ typedef struct dif_spi_device_config {
   dif_spi_device_bit_order_t tx_order;
   dif_spi_device_bit_order_t rx_order;
   uint8_t rx_fifo_timeout;
-  /**
-   * The length, in bytes, that should be reserved for the RX FIFO.
-   *
-   * `kDifSpiDeviceBufferLen / 2` is a good default for this value.
-   */
   uint16_t rx_fifo_len;
-  /**
-   * The length, in bytes, that should be reserved for the TX FIFO.
-   *
-   * `kDifSpiDeviceBufferLen / 2` is a good default for this value.
-   */
   uint16_t tx_fifo_len;
 } dif_spi_device_config_t;
 
 /**
- * A handle to a SPI device.
+ * State for a particular SPI device.
  *
- * This type should be treated as opaque by users.
+ * Its member variables should be considered private, and are only provided so
+ * that callers can allocate it.
  */
 typedef struct dif_spi_device {
-  dif_spi_device_params_t params;
+  mmio_region_t base_addr;
+  uint16_t rx_fifo_base;
   uint16_t rx_fifo_len;
+  uint16_t tx_fifo_base;
   uint16_t tx_fifo_len;
 } dif_spi_device_t;
 
 /**
- * Creates a new handle for SPI.
+ * Initializes a SPI device with the given configuration.
  *
- * This function does not actuate the hardware.
- *
- * @param params Hardware instantiation parameters.
- * @param[out] spi Out param for the initialized handle.
+ * @param base_addr The start of the SPI device register.
+ * @param config The configuration to initialize with.
+ * @param[out] spi The initialized device.
  * @return The result of the operation.
  */
 DIF_WARN_UNUSED_RESULT
-dif_spi_device_result_t dif_spi_device_init(dif_spi_device_params_t params,
-                                            dif_spi_device_t *spi);
-
-/**
- * Configures SPI with runtime information.
- *
- * This function should need to be called once for the lifetime of `handle`.
- *
- * @param spi A SPI handle.
- * @param config Runtime configuration parameters.
- * @return The result of the operation.
- */
-DIF_WARN_UNUSED_RESULT
-dif_spi_device_result_t dif_spi_device_configure(
-    dif_spi_device_t *spi, dif_spi_device_config_t config);
+dif_spi_device_result_t dif_spi_device_init(
+    mmio_region_t base_addr, const dif_spi_device_config_t *config,
+    dif_spi_device_t *spi);
 
 /**
  * Issues an "abort" to the given SPI device, causing all in-progress IO to
  * halt.
  *
- * @param spi A SPI handle.
+ * @param spi An SPI device.
  * @return The result of the operation.
  */
 DIF_WARN_UNUSED_RESULT
 dif_spi_device_result_t dif_spi_device_abort(const dif_spi_device_t *spi);
 
 /**
- * Returns whether a particular interrupt is currently pending.
+ * Resets all interrupt-related state on the given SPI device, such as enabled
+ * interrupts and set RX/TX levels.
  *
- * @param spi A SPI handle.
- * @param irq An interrupt type.
- * @param[out] is_pending Out-param for whether the interrupt is pending.
+ * @param spi An SPI device.
  * @return The result of the operation.
  */
 DIF_WARN_UNUSED_RESULT
-dif_spi_device_result_t dif_spi_device_irq_is_pending(
-    const dif_spi_device_t *spi, dif_spi_device_irq_t irq, bool *is_pending);
+dif_spi_device_result_t dif_spi_device_irq_reset(const dif_spi_device_t *spi);
 
 /**
- * Acknowledges a particular interrupt, indicating to the hardware that it has
- * been successfully serviced.
+ * Returns whether the given IRQ is currently being serviced.
  *
- * @param spi A SPI handle.
- * @param irq An interrupt type.
+ * @param spi An SPI device.
+ * @param type Which IRQ type to check.
+ * @param[out] flag Whether the IRQ is active.
  * @return The result of the operation.
  */
 DIF_WARN_UNUSED_RESULT
-dif_spi_device_result_t dif_spi_device_irq_acknowledge(
-    const dif_spi_device_t *spi, dif_spi_device_irq_t irq);
+dif_spi_device_result_t dif_spi_device_irq_get(const dif_spi_device_t *spi,
+                                               dif_spi_device_irq_type_t type,
+                                               bool *flag_out);
 
 /**
- * Checks whether a particular interrupt is currently enabled or disabled.
+ * Clears all active interrupt bits.
  *
- * @param spi A SPI handle.
- * @param irq An interrupt type.
- * @param[out] state Out-param toggle state of the interrupt.
+ * @param spi An SPI device.
  * @return The result of the operation.
  */
 DIF_WARN_UNUSED_RESULT
-dif_spi_device_result_t dif_spi_device_irq_get_enabled(
-    const dif_spi_device_t *spi, dif_spi_device_irq_t irq,
-    dif_spi_device_toggle_t *state);
+dif_spi_device_result_t dif_spi_device_irq_clear_all(
+    const dif_spi_device_t *spi);
 
 /**
- * Sets whether a particular interrupt is currently enabled or disabled.
+ * Enable or disable a particular interrupt.
  *
- * @param spi A SPI handle.
- * @param irq An interrupt type.
- * @param state The new toggle state for the interrupt.
+ * @param spi An SPI device.
+ * @param type Which IRQ type to toggle.
+ * @param state The state to update the bit to.
  * @return The result of the operation.
  */
 DIF_WARN_UNUSED_RESULT
-dif_spi_device_result_t dif_spi_device_irq_set_enabled(
-    const dif_spi_device_t *spi, dif_spi_device_irq_t irq,
-    dif_spi_device_toggle_t state);
+dif_spi_device_result_t dif_spi_device_irq_enable(
+    const dif_spi_device_t *spi, dif_spi_device_irq_type_t type,
+    dif_spi_device_irq_state_t state);
 
 /**
- * Forces a particular interrupt, causing it to be serviced as if hardware had
- * asserted it.
+ * Forces a particular IRQ type to fire.
  *
- * @param spi A SPI handle.
- * @param irq An interrupt type.
+ * @param spi An SPI device.
+ * @param type Which IRQ type to fire.
  * @return The result of the operation.
  */
 DIF_WARN_UNUSED_RESULT
-dif_spi_device_result_t dif_spi_device_irq_force(const dif_spi_device_t *spi,
-                                                 dif_spi_device_irq_t irq);
-
-/**
- * Disables all interrupts, optionally snapshotting all toggle state for later
- * restoration.
- *
- * @param spi A SPI handle.
- * @param[out] snapshot Out-param for the snapshot; may be `NULL`.
- * @return The result of the operation.
- */
-DIF_WARN_UNUSED_RESULT
-dif_spi_device_result_t dif_spi_device_irq_disable_all(
-    const dif_spi_device_t *spi, dif_spi_device_irq_snapshot_t *snapshot);
-
-/**
- * Restores interrupts from the given snapshot.
- *
- * This function can be used with `dif_spi_device_irq_disable_all()` to
- * temporary
- * interrupt save-and-restore.
- *
- * @param spi A SPI handle.
- * @param snapshot A snapshot to restore from.
- * @return The result of the operation.
- */
-DIF_WARN_UNUSED_RESULT
-dif_spi_device_result_t dif_spi_device_irq_restore_all(
-    const dif_spi_device_t *spi, const dif_spi_device_irq_snapshot_t *snapshot);
+dif_spi_device_result_t dif_spi_device_irq_force(
+    const dif_spi_device_t *spi, dif_spi_device_irq_type_t type);
 
 /**
  * Sets up the "FIFO level" (that is, number of bytes present in a particular
@@ -325,7 +202,7 @@ dif_spi_device_result_t dif_spi_device_irq_restore_all(
  * to detect that there is free space to write more data to the TX FIFO.
  * This is the `Main Memory -> Spi Buffer` case.
  *
- * @param spi A SPI handle.
+ * @param spi An SPI device.
  * @param rx_level The new RX level, as described above.
  * @param tx_level The new TX level, as described above.
  * @return The result of the operation.
@@ -337,7 +214,7 @@ dif_spi_device_result_t dif_spi_device_set_irq_levels(
 /**
  * Returns the number of bytes still pending receipt by software in the RX FIFO.
  *
- * @param spi A SPI handle.
+ * @param spi An SPI device.
  * @param[out] bytes_pending The number of bytes pending
  * @return The result of the operation.
  */
@@ -349,7 +226,7 @@ dif_spi_device_result_t dif_spi_device_rx_pending(const dif_spi_device_t *spi,
  * Returns the number of bytes still pending transmission by hardware in the TX
  * FIFO.
  *
- * @param spi A SPI handle.
+ * @param spi An SPI device.
  * @param[out] bytes_pending The number of bytes pending
  * @return The result of the operation.
  */

--- a/sw/device/lib/dif/dif_spi_device.h
+++ b/sw/device/lib/dif/dif_spi_device.h
@@ -68,6 +68,74 @@ typedef enum dif_spi_device_toggle {
 } dif_spi_device_toggle_t;
 
 /**
+ * A SPI interrupt request type.
+ */
+typedef enum dif_spi_device_irq {
+  /**
+   * Indicates that the RX FIFO is full.
+   */
+  kDifSpiDeviceIrqRxFull,
+  /**
+   * Indicates that the RX FIFO is above the configured level.
+   */
+  kDifSpiDeviceIrqRxAboveLevel,
+  /**
+   * Indicates that the TX FIFO is below the configured level.
+   */
+  kDifSpiDeviceIrqTxBelowLevel,
+  /**
+   * Indicates an error in the RX FIFO.
+   */
+  kDifSpiDeviceIrqRxError,
+  /**
+   * Indicates that overflow has occured in the RX FIFO.
+   */
+  kDifSpiDeviceIrqRxOverflow,
+  /**
+   * Indicates that underflow has occured in the RX FIFO.
+   */
+  kDifSpiDeviceIrqTxUnderflow,
+} dif_spi_device_irq_t;
+
+/**
+ * A snapshot of the enablement state of the interrupts for SPI.
+ *
+ * This is an opaque type, to be used with the
+ * `dif_spi_device_irq_disable_all()` and
+ * `dif_spi_device_irq_restore_all()` functions.
+ */
+typedef uint32_t dif_spi_device_irq_snapshot_t;
+
+/**
+ * The result of a SPI operation.
+ */
+typedef enum dif_spi_device_result {
+  /**
+   * Indicates that the operation succeeded.
+   */
+  kDifSpiDeviceOk = 0,
+  /**
+   * Indicates some unspecified failure.
+   */
+  kDifSpiDeviceError = 1,
+  /**
+   * Indicates that some parameter passed into a function failed a
+   * precondition.
+   *
+   * When this value is returned, no hardware operations occured.
+   */
+  kDifSpiDeviceBadArg = 2,
+} dif_spi_device_result_t;
+
+/**
+ * The length of the SPI device FIFO buffer, in bytes.
+ *
+ * Useful for initializing FIFO lengths: for example, for equally-sized FIFOs,
+ * `rx_fifo_len` and `tx_fifo_len` would be set to `kDifSpiDeviceBufferLen / 2`.
+ */
+extern const uint16_t kDifSpiDeviceBufferLen;
+
+/**
  * Hardware instantiation parameters for SPI.
  *
  * This struct describes information about the underlying hardware that is
@@ -117,74 +185,6 @@ typedef struct dif_spi_device {
   uint16_t rx_fifo_len;
   uint16_t tx_fifo_len;
 } dif_spi_device_t;
-
-/**
- * The result of a SPI operation.
- */
-typedef enum dif_spi_device_result {
-  /**
-   * Indicates that the operation succeeded.
-   */
-  kDifSpiDeviceOk = 0,
-  /**
-   * Indicates some unspecified failure.
-   */
-  kDifSpiDeviceError = 1,
-  /**
-   * Indicates that some parameter passed into a function failed a
-   * precondition.
-   *
-   * When this value is returned, no hardware operations occured.
-   */
-  kDifSpiDeviceBadArg = 2,
-} dif_spi_device_result_t;
-
-/**
- * A SPI interrupt request type.
- */
-typedef enum dif_spi_device_irq {
-  /**
-   * Indicates that the RX FIFO is full.
-   */
-  kDifSpiDeviceIrqRxFull,
-  /**
-   * Indicates that the RX FIFO is above the configured level.
-   */
-  kDifSpiDeviceIrqRxAboveLevel,
-  /**
-   * Indicates that the TX FIFO is below the configured level.
-   */
-  kDifSpiDeviceIrqTxBelowLevel,
-  /**
-   * Indicates an error in the RX FIFO.
-   */
-  kDifSpiDeviceIrqRxError,
-  /**
-   * Indicates that overflow has occured in the RX FIFO.
-   */
-  kDifSpiDeviceIrqRxOverflow,
-  /**
-   * Indicates that underflow has occured in the RX FIFO.
-   */
-  kDifSpiDeviceIrqTxUnderflow,
-} dif_spi_device_irq_t;
-
-/**
- * A snapshot of the enablement state of the interrupts for SPI.
- *
- * This is an opaque type, to be used with the
- * `dif_spi_device_irq_disable_all()` and
- * `dif_spi_device_irq_restore_all()` functions.
- */
-typedef uint32_t dif_spi_device_irq_snapshot_t;
-
-/**
- * The length of the SPI device FIFO buffer, in bytes.
- *
- * Useful for initializing FIFO lengths: for example, for equally-sized FIFOs,
- * `rx_fifo_len` and `tx_fifo_len` would be set to `kDifSpiDeviceBufferLen / 2`.
- */
-extern const uint16_t kDifSpiDeviceBufferLen;
 
 /**
  * Creates a new handle for SPI.

--- a/sw/device/tests/dif/dif_spi_device_unittest.cc
+++ b/sw/device/tests/dif/dif_spi_device_unittest.cc
@@ -40,9 +40,11 @@ class SpiTest : public testing::Test, public MmioTest {
   static const uint16_t kFifoLen = 0x400;
 
   dif_spi_device_t spi_ = {
-      .params = {.base_addr = dev().region()},
-      .rx_fifo_len = kFifoLen,
-      .tx_fifo_len = kFifoLen,
+      /*base_addr=*/dev().region(),
+      /*rx_fifo_base=*/0x0000,
+      /*rx_fifo_len=*/kFifoLen,
+      /*tx_fifo_base=*/kFifoLen,
+      /*tx_fifo_len=*/kFifoLen,
   };
 
   dif_spi_device_config_t config_ = {
@@ -64,7 +66,7 @@ TEST_F(AbortTest, Immediate) {
   EXPECT_READ32(SPI_DEVICE_STATUS_REG_OFFSET,
                 {{SPI_DEVICE_STATUS_ABORT_DONE, 0x1}});
 
-  EXPECT_EQ(dif_spi_device_abort(&spi_), kDifSpiDeviceOk);
+  EXPECT_EQ(dif_spi_device_abort(&spi_), kDifSpiDeviceResultOk);
 }
 
 TEST_F(AbortTest, Delayed) {
@@ -79,16 +81,30 @@ TEST_F(AbortTest, Delayed) {
   EXPECT_READ32(SPI_DEVICE_STATUS_REG_OFFSET,
                 {{SPI_DEVICE_STATUS_ABORT_DONE, 0x1}});
 
-  EXPECT_EQ(dif_spi_device_abort(&spi_), kDifSpiDeviceOk);
+  EXPECT_EQ(dif_spi_device_abort(&spi_), kDifSpiDeviceResultOk);
 }
 
 TEST_F(AbortTest, NullArgs) {
-  EXPECT_EQ(dif_spi_device_abort(nullptr), kDifSpiDeviceBadArg);
+  EXPECT_EQ(dif_spi_device_abort(nullptr), kDifSpiDeviceResultBadArg);
 }
 
-class ConfigTest : public SpiTest {};
+class InitTest : public SpiTest {};
 
-TEST_F(ConfigTest, BasicInit) {
+TEST_F(InitTest, BasicInit) {
+  EXPECT_MASK32(SPI_DEVICE_CONTROL_REG_OFFSET,
+                {{SPI_DEVICE_CONTROL_ABORT, 0x1, 0x1}});
+  EXPECT_READ32(SPI_DEVICE_STATUS_REG_OFFSET,
+                {{SPI_DEVICE_STATUS_ABORT_DONE, 0x1}});
+
+  EXPECT_WRITE32(SPI_DEVICE_INTR_STATE_REG_OFFSET,
+                 std::numeric_limits<uint32_t>::max());
+
+  EXPECT_WRITE32(SPI_DEVICE_FIFO_LEVEL_REG_OFFSET,
+                 {{SPI_DEVICE_FIFO_LEVEL_RXLVL_OFFSET, 0x80},
+                  {SPI_DEVICE_FIFO_LEVEL_TXLVL_OFFSET, 0x00}});
+
+  EXPECT_WRITE32(SPI_DEVICE_INTR_ENABLE_REG_OFFSET, 0x0);
+
   EXPECT_WRITE32(SPI_DEVICE_CFG_REG_OFFSET,
                  {
                      {SPI_DEVICE_CFG_CPOL, 0},
@@ -108,15 +124,30 @@ TEST_F(ConfigTest, BasicInit) {
                      {SPI_DEVICE_TXF_ADDR_LIMIT_OFFSET, 0x800 - 1},
                  });
 
-  EXPECT_EQ(dif_spi_device_configure(&spi_, config_), kDifSpiDeviceOk);
+  EXPECT_EQ(dif_spi_device_init(dev().region(), &config_, &spi_),
+            kDifSpiDeviceResultOk);
 }
 
-TEST_F(ConfigTest, ComplexInit) {
+TEST_F(InitTest, ComplexInit) {
   config_.clock_polarity = kDifSpiDeviceEdgeNegative;
   config_.data_phase = kDifSpiDeviceEdgePositive;
   config_.tx_order = kDifSpiDeviceBitOrderLsbToMsb;
   config_.rx_fifo_timeout = 42;
   config_.rx_fifo_len = 0x24;
+
+  EXPECT_MASK32(SPI_DEVICE_CONTROL_REG_OFFSET,
+                {{SPI_DEVICE_CONTROL_ABORT, 0x1, 0x1}});
+  EXPECT_READ32(SPI_DEVICE_STATUS_REG_OFFSET,
+                {{SPI_DEVICE_STATUS_ABORT_DONE, 0x1}});
+
+  EXPECT_WRITE32(SPI_DEVICE_INTR_STATE_REG_OFFSET,
+                 std::numeric_limits<uint32_t>::max());
+
+  EXPECT_WRITE32(SPI_DEVICE_FIFO_LEVEL_REG_OFFSET,
+                 {{SPI_DEVICE_FIFO_LEVEL_RXLVL_OFFSET, 0x80},
+                  {SPI_DEVICE_FIFO_LEVEL_TXLVL_OFFSET, 0x00}});
+
+  EXPECT_WRITE32(SPI_DEVICE_INTR_ENABLE_REG_OFFSET, 0x0);
 
   EXPECT_WRITE32(SPI_DEVICE_CFG_REG_OFFSET,
                  {
@@ -137,16 +168,21 @@ TEST_F(ConfigTest, ComplexInit) {
                      {SPI_DEVICE_TXF_ADDR_LIMIT_OFFSET, 0x423},
                  });
 
-  EXPECT_EQ(dif_spi_device_configure(&spi_, config_), kDifSpiDeviceOk);
+  EXPECT_EQ(dif_spi_device_init(dev().region(), &config_, &spi_),
+            kDifSpiDeviceResultOk);
 }
 
-TEST_F(ConfigTest, NullArgs) {
-  EXPECT_EQ(dif_spi_device_configure(nullptr, config_), kDifSpiDeviceBadArg);
+TEST_F(InitTest, NullArgs) {
+  EXPECT_EQ(dif_spi_device_init(dev().region(), &config_, nullptr),
+            kDifSpiDeviceResultBadArg);
+  EXPECT_EQ(dif_spi_device_init(dev().region(), nullptr, &spi_),
+            kDifSpiDeviceResultBadArg);
 }
 
-TEST_F(ConfigTest, InitSramOverflow) {
+TEST_F(InitTest, InitSramOverflow) {
   config_.rx_fifo_len = 0x1000;
-  EXPECT_EQ(dif_spi_device_configure(&spi_, config_), kDifSpiDeviceBadArg);
+  EXPECT_EQ(dif_spi_device_init(dev().region(), &config_, &spi_),
+            kDifSpiDeviceResultBadArg);
 }
 
 class IrqTest : public SpiTest {};
@@ -156,111 +192,110 @@ TEST_F(IrqTest, Get) {
 
   EXPECT_READ32(SPI_DEVICE_INTR_STATE_REG_OFFSET,
                 {{SPI_DEVICE_INTR_STATE_RXF, 1}});
-  EXPECT_EQ(dif_spi_device_irq_is_pending(&spi_, kDifSpiDeviceIrqRxFull, &out),
-            kDifSpiDeviceOk);
+  EXPECT_EQ(dif_spi_device_irq_get(&spi_, kDifSpiDeviceIrqTypeRxFull, &out),
+            kDifSpiDeviceResultOk);
   EXPECT_TRUE(out);
 
   EXPECT_READ32(
       SPI_DEVICE_INTR_STATE_REG_OFFSET,
       {{SPI_DEVICE_INTR_STATE_RXERR, 0}, {SPI_DEVICE_INTR_STATE_RXF, 1}});
-  EXPECT_EQ(dif_spi_device_irq_is_pending(&spi_, kDifSpiDeviceIrqRxError, &out),
-            kDifSpiDeviceOk);
+  EXPECT_EQ(dif_spi_device_irq_get(&spi_, kDifSpiDeviceIrqTypeRxError, &out),
+            kDifSpiDeviceResultOk);
   EXPECT_FALSE(out);
 
   EXPECT_READ32(SPI_DEVICE_INTR_STATE_REG_OFFSET,
                 {{SPI_DEVICE_INTR_STATE_TXUNDERFLOW, 1}});
   EXPECT_EQ(
-      dif_spi_device_irq_is_pending(&spi_, kDifSpiDeviceIrqTxUnderflow, &out),
-      kDifSpiDeviceOk);
+      dif_spi_device_irq_get(&spi_, kDifSpiDeviceIrqTypeTxUnderflow, &out),
+      kDifSpiDeviceResultOk);
   EXPECT_TRUE(out);
 
   EXPECT_READ32(SPI_DEVICE_INTR_STATE_REG_OFFSET,
                 {{SPI_DEVICE_INTR_STATE_TXLVL, 0}});
   EXPECT_EQ(
-      dif_spi_device_irq_is_pending(&spi_, kDifSpiDeviceIrqTxBelowLevel, &out),
-      kDifSpiDeviceOk);
+      dif_spi_device_irq_get(&spi_, kDifSpiDeviceIrqTypeTxBelowLevel, &out),
+      kDifSpiDeviceResultOk);
   EXPECT_FALSE(out);
 }
 
 TEST_F(IrqTest, GetNull) {
   bool out;
-  EXPECT_EQ(
-      dif_spi_device_irq_is_pending(nullptr, kDifSpiDeviceIrqRxFull, &out),
-      kDifSpiDeviceBadArg);
-  EXPECT_EQ(
-      dif_spi_device_irq_is_pending(&spi_, kDifSpiDeviceIrqRxFull, nullptr),
-      kDifSpiDeviceBadArg);
+  EXPECT_EQ(dif_spi_device_irq_get(nullptr, kDifSpiDeviceIrqTypeRxFull, &out),
+            kDifSpiDeviceResultBadArg);
+  EXPECT_EQ(dif_spi_device_irq_get(&spi_, kDifSpiDeviceIrqTypeRxFull, nullptr),
+            kDifSpiDeviceResultBadArg);
 }
 
 TEST_F(IrqTest, Enable) {
   EXPECT_MASK32(SPI_DEVICE_INTR_ENABLE_REG_OFFSET,
                 {{SPI_DEVICE_INTR_ENABLE_RXF, 0x1, 1}});
-  EXPECT_EQ(dif_spi_device_irq_set_enabled(&spi_, kDifSpiDeviceIrqRxFull,
-                                           kDifSpiDeviceToggleEnabled),
-            kDifSpiDeviceOk);
+  EXPECT_EQ(dif_spi_device_irq_enable(&spi_, kDifSpiDeviceIrqTypeRxFull,
+                                      kDifSpiDeviceIrqStateEnabled),
+            kDifSpiDeviceResultOk);
 
   EXPECT_MASK32(SPI_DEVICE_INTR_ENABLE_REG_OFFSET,
                 {{SPI_DEVICE_INTR_ENABLE_RXERR, 0x1, 0}});
-  EXPECT_EQ(dif_spi_device_irq_set_enabled(&spi_, kDifSpiDeviceIrqRxError,
-                                           kDifSpiDeviceToggleDisabled),
-            kDifSpiDeviceOk);
+  EXPECT_EQ(dif_spi_device_irq_enable(&spi_, kDifSpiDeviceIrqTypeRxError,
+                                      kDifSpiDeviceIrqStateDisabled),
+            kDifSpiDeviceResultOk);
 
   EXPECT_MASK32(SPI_DEVICE_INTR_ENABLE_REG_OFFSET,
                 {{SPI_DEVICE_INTR_ENABLE_TXUNDERFLOW, 0x1, 1}});
-  EXPECT_EQ(dif_spi_device_irq_set_enabled(&spi_, kDifSpiDeviceIrqTxUnderflow,
-                                           kDifSpiDeviceToggleEnabled),
-            kDifSpiDeviceOk);
+  EXPECT_EQ(dif_spi_device_irq_enable(&spi_, kDifSpiDeviceIrqTypeTxUnderflow,
+                                      kDifSpiDeviceIrqStateEnabled),
+            kDifSpiDeviceResultOk);
 
   EXPECT_MASK32(SPI_DEVICE_INTR_ENABLE_REG_OFFSET,
                 {{SPI_DEVICE_INTR_ENABLE_TXLVL, 0x1, 0}});
-  EXPECT_EQ(dif_spi_device_irq_set_enabled(&spi_, kDifSpiDeviceIrqTxBelowLevel,
-                                           kDifSpiDeviceToggleDisabled),
-            kDifSpiDeviceOk);
+  EXPECT_EQ(dif_spi_device_irq_enable(&spi_, kDifSpiDeviceIrqTypeTxBelowLevel,
+                                      kDifSpiDeviceIrqStateDisabled),
+            kDifSpiDeviceResultOk);
 }
 
 TEST_F(IrqTest, EnableNull) {
-  EXPECT_EQ(dif_spi_device_irq_set_enabled(nullptr, kDifSpiDeviceIrqRxFull,
-                                           kDifSpiDeviceToggleEnabled),
-            kDifSpiDeviceBadArg);
+  EXPECT_EQ(dif_spi_device_irq_enable(nullptr, kDifSpiDeviceIrqTypeRxFull,
+                                      kDifSpiDeviceIrqStateEnabled),
+            kDifSpiDeviceResultBadArg);
 }
 
 TEST_F(IrqTest, Force) {
   EXPECT_WRITE32(SPI_DEVICE_INTR_TEST_REG_OFFSET,
                  {{SPI_DEVICE_INTR_TEST_RXF, 1}});
-  EXPECT_EQ(dif_spi_device_irq_force(&spi_, kDifSpiDeviceIrqRxFull),
-            kDifSpiDeviceOk);
+  EXPECT_EQ(dif_spi_device_irq_force(&spi_, kDifSpiDeviceIrqTypeRxFull),
+            kDifSpiDeviceResultOk);
 
   EXPECT_WRITE32(SPI_DEVICE_INTR_TEST_REG_OFFSET,
                  {{SPI_DEVICE_INTR_TEST_RXERR, 1}});
-  EXPECT_EQ(dif_spi_device_irq_force(&spi_, kDifSpiDeviceIrqRxError),
-            kDifSpiDeviceOk);
+  EXPECT_EQ(dif_spi_device_irq_force(&spi_, kDifSpiDeviceIrqTypeRxError),
+            kDifSpiDeviceResultOk);
 
   EXPECT_WRITE32(SPI_DEVICE_INTR_TEST_REG_OFFSET,
                  {{SPI_DEVICE_INTR_TEST_TXUNDERFLOW, 1}});
-  EXPECT_EQ(dif_spi_device_irq_force(&spi_, kDifSpiDeviceIrqTxUnderflow),
-            kDifSpiDeviceOk);
+  EXPECT_EQ(dif_spi_device_irq_force(&spi_, kDifSpiDeviceIrqTypeTxUnderflow),
+            kDifSpiDeviceResultOk);
 
   EXPECT_WRITE32(SPI_DEVICE_INTR_TEST_REG_OFFSET,
                  {{SPI_DEVICE_INTR_TEST_TXLVL, 1}});
-  EXPECT_EQ(dif_spi_device_irq_force(&spi_, kDifSpiDeviceIrqTxBelowLevel),
-            kDifSpiDeviceOk);
+  EXPECT_EQ(dif_spi_device_irq_force(&spi_, kDifSpiDeviceIrqTypeTxBelowLevel),
+            kDifSpiDeviceResultOk);
 }
 
 TEST_F(IrqTest, ForceNull) {
-  EXPECT_EQ(dif_spi_device_irq_force(nullptr, kDifSpiDeviceIrqRxFull),
-            kDifSpiDeviceBadArg);
+  EXPECT_EQ(dif_spi_device_irq_force(nullptr, kDifSpiDeviceIrqTypeRxFull),
+            kDifSpiDeviceResultBadArg);
 }
 
 TEST_F(IrqTest, Levels) {
   EXPECT_WRITE32(SPI_DEVICE_FIFO_LEVEL_REG_OFFSET,
                  {{SPI_DEVICE_FIFO_LEVEL_RXLVL_OFFSET, 42},
                   {SPI_DEVICE_FIFO_LEVEL_TXLVL_OFFSET, 123}});
-  EXPECT_EQ(dif_spi_device_set_irq_levels(&spi_, 42, 123), kDifSpiDeviceOk);
+  EXPECT_EQ(dif_spi_device_set_irq_levels(&spi_, 42, 123),
+            kDifSpiDeviceResultOk);
 }
 
 TEST_F(IrqTest, LevelsNull) {
   EXPECT_EQ(dif_spi_device_set_irq_levels(nullptr, 123, 456),
-            kDifSpiDeviceBadArg);
+            kDifSpiDeviceResultBadArg);
 }
 
 class RxPendingTest : public SpiTest {};
@@ -271,7 +306,7 @@ TEST_F(RxPendingTest, BothZero) {
                  {SPI_DEVICE_RXF_PTR_RPTR_OFFSET, 0x0}});
   size_t bytes_remaining;
   EXPECT_EQ(dif_spi_device_rx_pending(&spi_, &bytes_remaining),
-            kDifSpiDeviceOk);
+            kDifSpiDeviceResultOk);
   EXPECT_EQ(bytes_remaining, 0);
 }
 
@@ -281,7 +316,7 @@ TEST_F(RxPendingTest, InPhaseEmpty) {
                  {SPI_DEVICE_RXF_PTR_RPTR_OFFSET, FifoPtr(0x42, true)}});
   size_t bytes_remaining;
   EXPECT_EQ(dif_spi_device_rx_pending(&spi_, &bytes_remaining),
-            kDifSpiDeviceOk);
+            kDifSpiDeviceResultOk);
   EXPECT_EQ(bytes_remaining, 0);
 }
 
@@ -291,7 +326,7 @@ TEST_F(RxPendingTest, InPhase) {
                  {SPI_DEVICE_RXF_PTR_RPTR_OFFSET, FifoPtr(0x42, true)}});
   size_t bytes_remaining;
   EXPECT_EQ(dif_spi_device_rx_pending(&spi_, &bytes_remaining),
-            kDifSpiDeviceOk);
+            kDifSpiDeviceResultOk);
   EXPECT_EQ(bytes_remaining, 0x15);
 }
 
@@ -301,7 +336,7 @@ TEST_F(RxPendingTest, OutOfPhaseFull) {
                  {SPI_DEVICE_RXF_PTR_RPTR_OFFSET, FifoPtr(0x42, true)}});
   size_t bytes_remaining;
   EXPECT_EQ(dif_spi_device_rx_pending(&spi_, &bytes_remaining),
-            kDifSpiDeviceOk);
+            kDifSpiDeviceResultOk);
   EXPECT_EQ(bytes_remaining, 0x400);
 }
 
@@ -311,15 +346,16 @@ TEST_F(RxPendingTest, OutOfPhase) {
                  {SPI_DEVICE_RXF_PTR_RPTR_OFFSET, FifoPtr(0x57, true)}});
   size_t bytes_remaining;
   EXPECT_EQ(dif_spi_device_rx_pending(&spi_, &bytes_remaining),
-            kDifSpiDeviceOk);
+            kDifSpiDeviceResultOk);
   EXPECT_EQ(bytes_remaining, 0x3eb);
 }
 
 TEST_F(RxPendingTest, NullArgs) {
   size_t bytes_remaining;
   EXPECT_EQ(dif_spi_device_rx_pending(nullptr, &bytes_remaining),
-            kDifSpiDeviceBadArg);
-  EXPECT_EQ(dif_spi_device_rx_pending(&spi_, nullptr), kDifSpiDeviceBadArg);
+            kDifSpiDeviceResultBadArg);
+  EXPECT_EQ(dif_spi_device_rx_pending(&spi_, nullptr),
+            kDifSpiDeviceResultBadArg);
 }
 
 class TxPendingTest : public SpiTest {};
@@ -330,7 +366,7 @@ TEST_F(TxPendingTest, BothZero) {
                  {SPI_DEVICE_TXF_PTR_RPTR_OFFSET, 0x0}});
   size_t bytes_remaining;
   EXPECT_EQ(dif_spi_device_tx_pending(&spi_, &bytes_remaining),
-            kDifSpiDeviceOk);
+            kDifSpiDeviceResultOk);
   EXPECT_EQ(bytes_remaining, 0);
 }
 
@@ -340,7 +376,7 @@ TEST_F(TxPendingTest, InPhaseEmpty) {
                  {SPI_DEVICE_TXF_PTR_RPTR_OFFSET, FifoPtr(0x42, true)}});
   size_t bytes_remaining;
   EXPECT_EQ(dif_spi_device_tx_pending(&spi_, &bytes_remaining),
-            kDifSpiDeviceOk);
+            kDifSpiDeviceResultOk);
   EXPECT_EQ(bytes_remaining, 0);
 }
 
@@ -350,7 +386,7 @@ TEST_F(TxPendingTest, InPhase) {
                  {SPI_DEVICE_TXF_PTR_RPTR_OFFSET, FifoPtr(0x42, true)}});
   size_t bytes_remaining;
   EXPECT_EQ(dif_spi_device_tx_pending(&spi_, &bytes_remaining),
-            kDifSpiDeviceOk);
+            kDifSpiDeviceResultOk);
   EXPECT_EQ(bytes_remaining, 0x15);
 }
 
@@ -360,7 +396,7 @@ TEST_F(TxPendingTest, OutOfPhaseFull) {
                  {SPI_DEVICE_TXF_PTR_RPTR_OFFSET, FifoPtr(0x42, true)}});
   size_t bytes_remaining;
   EXPECT_EQ(dif_spi_device_tx_pending(&spi_, &bytes_remaining),
-            kDifSpiDeviceOk);
+            kDifSpiDeviceResultOk);
   EXPECT_EQ(bytes_remaining, 0x400);
 }
 
@@ -370,15 +406,16 @@ TEST_F(TxPendingTest, OutOfPhase) {
                  {SPI_DEVICE_TXF_PTR_RPTR_OFFSET, FifoPtr(0x57, true)}});
   size_t bytes_remaining;
   EXPECT_EQ(dif_spi_device_tx_pending(&spi_, &bytes_remaining),
-            kDifSpiDeviceOk);
+            kDifSpiDeviceResultOk);
   EXPECT_EQ(bytes_remaining, 0x3eb);
 }
 
 TEST_F(TxPendingTest, NullArgs) {
   size_t bytes_remaining;
   EXPECT_EQ(dif_spi_device_tx_pending(nullptr, &bytes_remaining),
-            kDifSpiDeviceBadArg);
-  EXPECT_EQ(dif_spi_device_tx_pending(&spi_, nullptr), kDifSpiDeviceBadArg);
+            kDifSpiDeviceResultBadArg);
+  EXPECT_EQ(dif_spi_device_tx_pending(&spi_, nullptr),
+            kDifSpiDeviceResultBadArg);
 }
 
 class RecvTest : public SpiTest {};
@@ -392,7 +429,7 @@ TEST_F(RecvTest, EmptyFifo) {
   size_t recv_len = 0;
   EXPECT_EQ(dif_spi_device_recv(&spi_, const_cast<char *>(buf.data()),
                                 buf.size(), &recv_len),
-            kDifSpiDeviceOk);
+            kDifSpiDeviceResultOk);
   EXPECT_EQ(recv_len, 0);
   buf.resize(recv_len);
   EXPECT_EQ(buf, "");
@@ -404,7 +441,7 @@ TEST_F(RecvTest, FullFifoAligned) {
                  {SPI_DEVICE_RXF_PTR_RPTR_OFFSET, FifoPtr(0x50, false)}});
 
   auto message = MakeBlob(kFifoLen);
-  auto fifo_base = SPI_DEVICE_BUFFER_REG_OFFSET;
+  auto fifo_base = SPI_DEVICE_BUFFER_REG_OFFSET + spi_.rx_fifo_base;
   for (int i = 0; i < kFifoLen; i += 4) {
     auto idx = fifo_base + (i + 0x50) % kFifoLen;
     EXPECT_READ32(idx, LeInt(&message[i]));
@@ -418,7 +455,7 @@ TEST_F(RecvTest, FullFifoAligned) {
   buf.resize(message.size() * 2);
   size_t recv_len = 0;
   EXPECT_EQ(dif_spi_device_recv(&spi_, buf.data(), buf.size(), &recv_len),
-            kDifSpiDeviceOk);
+            kDifSpiDeviceResultOk);
   EXPECT_EQ(recv_len, message.size());
   buf.resize(recv_len);
   EXPECT_EQ(buf, message);
@@ -432,7 +469,7 @@ TEST_F(RecvTest, FullFifoSmallBuf) {
                  {SPI_DEVICE_RXF_PTR_RPTR_OFFSET, FifoPtr(0x50, false)}});
 
   auto message = MakeBlob(kFifoLen);
-  auto fifo_base = SPI_DEVICE_BUFFER_REG_OFFSET;
+  auto fifo_base = SPI_DEVICE_BUFFER_REG_OFFSET + spi_.rx_fifo_base;
   for (size_t i = 0; i < buf_len; i += 4) {
     auto idx = fifo_base + (i + 0x50) % kFifoLen;
     EXPECT_READ32(idx, LeInt(&message[i]));
@@ -447,7 +484,7 @@ TEST_F(RecvTest, FullFifoSmallBuf) {
   buf.resize(buf_len);
   size_t recv_len = 0;
   EXPECT_EQ(dif_spi_device_recv(&spi_, buf.data(), buf.size(), &recv_len),
-            kDifSpiDeviceOk);
+            kDifSpiDeviceResultOk);
   EXPECT_EQ(recv_len, buf_len);
   buf.resize(recv_len);
   message.resize(recv_len);
@@ -463,7 +500,7 @@ TEST_F(RecvTest, FullyAligned) {
       {{SPI_DEVICE_RXF_PTR_WPTR_OFFSET, FifoPtr(message.size(), false)},
        {SPI_DEVICE_RXF_PTR_RPTR_OFFSET, FifoPtr(0x00, false)}});
 
-  auto fifo_base = SPI_DEVICE_BUFFER_REG_OFFSET;
+  auto fifo_base = SPI_DEVICE_BUFFER_REG_OFFSET + spi_.rx_fifo_base;
   EXPECT_READ32(fifo_base + 0x0, LeInt(&message[0x0]));
   EXPECT_READ32(fifo_base + 0x4, LeInt(&message[0x4]));
   EXPECT_READ32(fifo_base + 0x8, LeInt(&message[0x8]));
@@ -477,7 +514,7 @@ TEST_F(RecvTest, FullyAligned) {
   size_t recv_len = 0;
   EXPECT_EQ(dif_spi_device_recv(&spi_, const_cast<char *>(buf.data()),
                                 buf.size(), &recv_len),
-            kDifSpiDeviceOk);
+            kDifSpiDeviceResultOk);
   EXPECT_EQ(recv_len, message.size());
   buf.resize(recv_len);
   EXPECT_EQ(buf, message);
@@ -492,7 +529,7 @@ TEST_F(RecvTest, UnalignedMessage) {
                 {{SPI_DEVICE_RXF_PTR_WPTR_OFFSET, FifoPtr(cropped_len, false)},
                  {SPI_DEVICE_RXF_PTR_RPTR_OFFSET, FifoPtr(0x00, false)}});
 
-  auto fifo_base = SPI_DEVICE_BUFFER_REG_OFFSET;
+  auto fifo_base = SPI_DEVICE_BUFFER_REG_OFFSET + spi_.rx_fifo_base;
   EXPECT_READ32(fifo_base + 0x0, LeInt(&message[0x0]));
   EXPECT_READ32(fifo_base + 0x4, LeInt(&message[0x4]));
   EXPECT_READ32(fifo_base + 0x8, LeInt(&message[0x8]));
@@ -506,7 +543,7 @@ TEST_F(RecvTest, UnalignedMessage) {
   size_t recv_len = 0;
   EXPECT_EQ(dif_spi_device_recv(&spi_, const_cast<char *>(buf.data()),
                                 buf.size(), &recv_len),
-            kDifSpiDeviceOk);
+            kDifSpiDeviceResultOk);
   EXPECT_EQ(recv_len, cropped_len);
 
   buf.resize(message.size());
@@ -527,7 +564,7 @@ TEST_F(RecvTest, UnalignedStart) {
       {{SPI_DEVICE_RXF_PTR_WPTR_OFFSET, FifoPtr(cropped_len, false)},
        {SPI_DEVICE_RXF_PTR_RPTR_OFFSET, FifoPtr(cropped_start, false)}});
 
-  auto fifo_base = SPI_DEVICE_BUFFER_REG_OFFSET;
+  auto fifo_base = SPI_DEVICE_BUFFER_REG_OFFSET + spi_.rx_fifo_base;
   EXPECT_READ32(fifo_base + 0x0, LeInt(&message[0x0]));
   EXPECT_READ32(fifo_base + 0x4, LeInt(&message[0x4]));
   EXPECT_READ32(fifo_base + 0x8, LeInt(&message[0x8]));
@@ -541,7 +578,7 @@ TEST_F(RecvTest, UnalignedStart) {
   size_t recv_len = 0;
   EXPECT_EQ(dif_spi_device_recv(&spi_, const_cast<char *>(buf.data()),
                                 buf.size(), &recv_len),
-            kDifSpiDeviceOk);
+            kDifSpiDeviceResultOk);
   EXPECT_EQ(recv_len, cropped_len - cropped_start);
 
   buf.resize(message.size());
@@ -562,7 +599,7 @@ TEST_F(RecvTest, UnalignedSmall) {
       {{SPI_DEVICE_RXF_PTR_WPTR_OFFSET, FifoPtr(cropped_len, false)},
        {SPI_DEVICE_RXF_PTR_RPTR_OFFSET, FifoPtr(cropped_start, false)}});
 
-  auto fifo_base = SPI_DEVICE_BUFFER_REG_OFFSET;
+  auto fifo_base = SPI_DEVICE_BUFFER_REG_OFFSET + spi_.rx_fifo_base;
   EXPECT_READ32(fifo_base + 0x0, LeInt(&message[0x0]));
 
   EXPECT_WRITE32(
@@ -574,7 +611,7 @@ TEST_F(RecvTest, UnalignedSmall) {
   size_t recv_len = 0;
   EXPECT_EQ(dif_spi_device_recv(&spi_, const_cast<char *>(buf.data()),
                                 buf.size(), &recv_len),
-            kDifSpiDeviceOk);
+            kDifSpiDeviceResultOk);
   EXPECT_EQ(recv_len, cropped_len - cropped_start);
 
   buf.resize(message.size());
@@ -590,16 +627,16 @@ TEST_F(RecvTest, NullArgs) {
 
   EXPECT_EQ(dif_spi_device_recv(nullptr, const_cast<char *>(buf.data()),
                                 buf.size(), &recv_len),
-            kDifSpiDeviceBadArg);
+            kDifSpiDeviceResultBadArg);
   EXPECT_EQ(dif_spi_device_recv(&spi_, nullptr, buf.size(), &recv_len),
-            kDifSpiDeviceBadArg);
+            kDifSpiDeviceResultBadArg);
 
   EXPECT_READ32(SPI_DEVICE_RXF_PTR_REG_OFFSET,
                 {{SPI_DEVICE_RXF_PTR_WPTR_OFFSET, FifoPtr(0x5a, false)},
                  {SPI_DEVICE_RXF_PTR_RPTR_OFFSET, FifoPtr(0x5a, false)}});
   EXPECT_EQ(dif_spi_device_recv(&spi_, const_cast<char *>(buf.data()),
                                 buf.size(), nullptr),
-            kDifSpiDeviceOk);
+            kDifSpiDeviceResultOk);
 }
 
 class SendTest : public SpiTest {};
@@ -613,7 +650,7 @@ TEST_F(SendTest, FullFifo) {
   size_t send_len = 0;
   EXPECT_EQ(
       dif_spi_device_send(&spi_, message.data(), message.size(), &send_len),
-      kDifSpiDeviceOk);
+      kDifSpiDeviceResultOk);
   EXPECT_EQ(send_len, 0);
 }
 
@@ -623,7 +660,7 @@ TEST_F(SendTest, EmptyToFull) {
                  {SPI_DEVICE_TXF_PTR_RPTR_OFFSET, FifoPtr(0x50, true)}});
 
   auto message = MakeBlob(kFifoLen);
-  auto fifo_base = SPI_DEVICE_BUFFER_REG_OFFSET + spi_.rx_fifo_len;
+  auto fifo_base = SPI_DEVICE_BUFFER_REG_OFFSET + spi_.tx_fifo_base;
   for (int i = 0; i < kFifoLen; i += 4) {
     auto idx = fifo_base + (i + 0x50) % kFifoLen;
     EXPECT_WRITE32(idx, LeInt(&message[i]));
@@ -636,7 +673,7 @@ TEST_F(SendTest, EmptyToFull) {
   size_t sent_len = 0;
   EXPECT_EQ(
       dif_spi_device_send(&spi_, message.data(), message.size(), &sent_len),
-      kDifSpiDeviceOk);
+      kDifSpiDeviceResultOk);
   EXPECT_EQ(sent_len, message.size());
 }
 
@@ -649,7 +686,7 @@ TEST_F(SendTest, AlmostFull) {
   uintptr_t value = 0;
   memcpy(&value, message.data(), 2);
 
-  auto fifo_base = SPI_DEVICE_BUFFER_REG_OFFSET + spi_.rx_fifo_len;
+  auto fifo_base = SPI_DEVICE_BUFFER_REG_OFFSET + spi_.tx_fifo_base;
   EXPECT_MASK32(fifo_base + 0x4c, {{0x10, 0xffff, value}});
 
   EXPECT_WRITE32(SPI_DEVICE_TXF_PTR_REG_OFFSET,
@@ -659,7 +696,7 @@ TEST_F(SendTest, AlmostFull) {
   size_t sent_len = 0;
   EXPECT_EQ(
       dif_spi_device_send(&spi_, message.data(), message.size(), &sent_len),
-      kDifSpiDeviceOk);
+      kDifSpiDeviceResultOk);
   EXPECT_EQ(sent_len, 2);
 }
 
@@ -671,7 +708,7 @@ TEST_F(SendTest, FullyAligned) {
                 {{SPI_DEVICE_TXF_PTR_WPTR_OFFSET, FifoPtr(0x00, false)},
                  {SPI_DEVICE_TXF_PTR_RPTR_OFFSET, FifoPtr(0x00, false)}});
 
-  auto fifo_base = SPI_DEVICE_BUFFER_REG_OFFSET + spi_.rx_fifo_len;
+  auto fifo_base = SPI_DEVICE_BUFFER_REG_OFFSET + spi_.tx_fifo_base;
   EXPECT_WRITE32(fifo_base + 0x0, LeInt(&message[0x0]));
   EXPECT_WRITE32(fifo_base + 0x4, LeInt(&message[0x4]));
   EXPECT_WRITE32(fifo_base + 0x8, LeInt(&message[0x8]));
@@ -684,7 +721,7 @@ TEST_F(SendTest, FullyAligned) {
   size_t send_len = 0;
   EXPECT_EQ(
       dif_spi_device_send(&spi_, message.data(), message.size(), &send_len),
-      kDifSpiDeviceOk);
+      kDifSpiDeviceResultOk);
   EXPECT_EQ(send_len, message.size());
 }
 
@@ -697,7 +734,7 @@ TEST_F(SendTest, UnalignedMessage) {
                 {{SPI_DEVICE_TXF_PTR_WPTR_OFFSET, FifoPtr(0x00, false)},
                  {SPI_DEVICE_TXF_PTR_RPTR_OFFSET, FifoPtr(0x00, false)}});
 
-  auto fifo_base = SPI_DEVICE_BUFFER_REG_OFFSET + spi_.rx_fifo_len;
+  auto fifo_base = SPI_DEVICE_BUFFER_REG_OFFSET + spi_.tx_fifo_base;
   EXPECT_WRITE32(fifo_base + 0x0, LeInt(&message[0x0]));
   EXPECT_WRITE32(fifo_base + 0x4, LeInt(&message[0x4]));
 
@@ -711,7 +748,7 @@ TEST_F(SendTest, UnalignedMessage) {
 
   size_t send_len = 0;
   EXPECT_EQ(dif_spi_device_send(&spi_, message.data(), cropped_len, &send_len),
-            kDifSpiDeviceOk);
+            kDifSpiDeviceResultOk);
   EXPECT_EQ(send_len, cropped_len);
 }
 
@@ -726,7 +763,7 @@ TEST_F(SendTest, UnalignedStart) {
       {{SPI_DEVICE_TXF_PTR_WPTR_OFFSET, FifoPtr(cropped_start, false)},
        {SPI_DEVICE_TXF_PTR_RPTR_OFFSET, FifoPtr(cropped_start, false)}});
 
-  auto fifo_base = SPI_DEVICE_BUFFER_REG_OFFSET + spi_.rx_fifo_len;
+  auto fifo_base = SPI_DEVICE_BUFFER_REG_OFFSET + spi_.tx_fifo_base;
 
   uintptr_t start_value = 0;
   memcpy(&start_value, &message[0x0], 3);
@@ -745,7 +782,7 @@ TEST_F(SendTest, UnalignedStart) {
 
   size_t send_len = 0;
   EXPECT_EQ(dif_spi_device_send(&spi_, message.data(), cropped_len, &send_len),
-            kDifSpiDeviceOk);
+            kDifSpiDeviceResultOk);
   EXPECT_EQ(send_len, cropped_len);
 }
 
@@ -760,7 +797,7 @@ TEST_F(SendTest, UnalignedSmall) {
       {{SPI_DEVICE_TXF_PTR_WPTR_OFFSET, FifoPtr(cropped_start, false)},
        {SPI_DEVICE_TXF_PTR_RPTR_OFFSET, FifoPtr(cropped_start, false)}});
 
-  auto fifo_base = SPI_DEVICE_BUFFER_REG_OFFSET + spi_.rx_fifo_len;
+  auto fifo_base = SPI_DEVICE_BUFFER_REG_OFFSET + spi_.tx_fifo_base;
 
   uintptr_t start_value = 0;
   memcpy(&start_value, &message[0x0], 2);
@@ -774,7 +811,7 @@ TEST_F(SendTest, UnalignedSmall) {
 
   size_t send_len = 0;
   EXPECT_EQ(dif_spi_device_send(&spi_, message.data(), cropped_len, &send_len),
-            kDifSpiDeviceOk);
+            kDifSpiDeviceResultOk);
   EXPECT_EQ(send_len, cropped_len);
 }
 
@@ -783,15 +820,15 @@ TEST_F(SendTest, NullArgs) {
   size_t recv_len;
 
   EXPECT_EQ(dif_spi_device_send(nullptr, buf.data(), buf.size(), &recv_len),
-            kDifSpiDeviceBadArg);
+            kDifSpiDeviceResultBadArg);
   EXPECT_EQ(dif_spi_device_send(&spi_, nullptr, buf.size(), &recv_len),
-            kDifSpiDeviceBadArg);
+            kDifSpiDeviceResultBadArg);
 
   EXPECT_READ32(SPI_DEVICE_TXF_PTR_REG_OFFSET,
                 {{SPI_DEVICE_TXF_PTR_WPTR_OFFSET, FifoPtr(0x5a, true)},
                  {SPI_DEVICE_TXF_PTR_RPTR_OFFSET, FifoPtr(0x5a, false)}});
   EXPECT_EQ(dif_spi_device_send(&spi_, buf.data(), buf.size(), nullptr),
-            kDifSpiDeviceOk);
+            kDifSpiDeviceResultOk);
 }
 }  // namespace
 }  // namespace dif_spi_device_unittest

--- a/sw/device/tests/dif/dif_spi_device_unittest.cc
+++ b/sw/device/tests/dif/dif_spi_device_unittest.cc
@@ -46,13 +46,13 @@ class SpiTest : public testing::Test, public MmioTest {
   };
 
   dif_spi_device_config_t config_ = {
-      .clock_polarity = kDifSpiDeviceEdgePositive,
-      .data_phase = kDifSpiDeviceEdgeNegative,
-      .tx_order = kDifSpiDeviceBitOrderMsbToLsb,
-      .rx_order = kDifSpiDeviceBitOrderMsbToLsb,
-      .rx_fifo_timeout = 63,
-      .rx_fifo_len = kFifoLen,
-      .tx_fifo_len = kFifoLen,
+      /*clock_polarity=*/kDifSpiDeviceEdgePositive,
+      /*data_phase=*/kDifSpiDeviceEdgeNegative,
+      /*tx_order=*/kDifSpiDeviceBitOrderMsbToLsb,
+      /*rx_order=*/kDifSpiDeviceBitOrderMsbToLsb,
+      /*rx_fifo_timeout=*/63,
+      /*rx_fifo_len=*/kFifoLen,
+      /*tx_fifo_len=*/kFifoLen,
   };
 };
 
@@ -112,15 +112,11 @@ TEST_F(ConfigTest, BasicInit) {
 }
 
 TEST_F(ConfigTest, ComplexInit) {
-  config_ = {
-      .clock_polarity = kDifSpiDeviceEdgeNegative,
-      .data_phase = kDifSpiDeviceEdgePositive,
-      .tx_order = kDifSpiDeviceBitOrderLsbToMsb,
-      .rx_order = kDifSpiDeviceBitOrderMsbToLsb,
-      .rx_fifo_timeout = 42,
-      .rx_fifo_len = 0x24,
-      .tx_fifo_len = kFifoLen,
-  };
+  config_.clock_polarity = kDifSpiDeviceEdgeNegative;
+  config_.data_phase = kDifSpiDeviceEdgePositive;
+  config_.tx_order = kDifSpiDeviceBitOrderLsbToMsb;
+  config_.rx_fifo_timeout = 42;
+  config_.rx_fifo_len = 0x24;
 
   EXPECT_WRITE32(SPI_DEVICE_CFG_REG_OFFSET,
                  {


### PR DESCRIPTION
Reverts lowRISC/opentitan#3496.

That PR seems to be causing issues with SPI, as described in https://github.com/lowRISC/opentitan/pull/3647#issuecomment-702821595 - as #3496 is a cleanup change, it's cheap to revert and re-apply later once the correct fix is diagnosed.