### PR TITLE
[bootstrap] Fix Missing Conditional in CHECK

### DIFF
--- a/sw/device/boot_rom/bootstrap.c
+++ b/sw/device/boot_rom/bootstrap.c
@@ -158,7 +158,7 @@ int bootstrap(void) {
             (dif_spi_device_params_t){
                 .base_addr = mmio_region_from_addr(0x40020000),
             },
-            &spi),
+            &spi) == kDifSpiDeviceOk,
         "Failed to initialize SPI.");
   CHECK(
       dif_spi_device_configure(&spi,


### PR DESCRIPTION
This issue was found by @alphan when investigating what part of #3496 caused SPI bootstrap to fail.