### PR TITLE
[otbn] Use ast/astor to extract implementations for docs

### DIFF
--- a/hw/ip/otbn/data/base-insns.yml
+++ b/hw/ip/otbn/data/base-insns.yml
@@ -374,14 +374,6 @@
   lsu:
     type: csr
     target: [csr]
-  decode: |
-    csr_num = UInt(csr)
-    d = UInt(grd)
-    s = UInt(grs1)
-  operation: |
-    gpr_s_val = GPR[s]
-    GPR[d] = CSR[csr_num]
-    CSR[csr_num] |= gpr_s_val
 
 - mnemonic: csrrw
   rv32i: true
@@ -403,17 +395,6 @@
   lsu:
     type: csr
     target: [csr]
-  decode: |
-    csr_num = UInt(csr)
-    d = UInt(grd)
-    s = UInt(grs1)
-  operation: |
-    gpr_s_val = GPR[s]
-
-    if d != 0:
-      GPR[d] = CSR[csr_num]
-
-    CSR[csr_num] = gpr_s_val
 
 - mnemonic: ecall
   rv32i: true

--- a/hw/ip/otbn/data/bignum-insns.yml
+++ b/hw/ip/otbn/data/bignum-insns.yml
@@ -34,20 +34,6 @@
     Adds two WDR values, writes the result to the destination WDR and updates
     flags. The content of the second source WDR can be shifted by an unsigned
     immediate before it is consumed by the operation.
-  decode: |
-    d = UInt(wrd)
-    a = UInt(wrs1)
-    b = UInt(wrs2)
-
-    fg = DecodeFlagGroup(flag_group)
-    sb = UInt(shift_bytes)
-    st = DecodeShiftType(shift_type)
-  operation: |
-    b_shifted = ShiftReg(b, st, sb)
-    (result, flags_out) = AddWithCarry(a, b_shifted, "0")
-
-    WDR[d] = result
-    FLAGS[flag_group] = flags_out
   encoding:
     scheme: bnaf
     mapping:
@@ -68,20 +54,6 @@
     destination WDR, and updates the flags. The content of the second source
     WDR can be shifted by an unsigned immediate before it is consumed by the
     operation.
-  decode: |
-    d = UInt(wrd)
-    a = UInt(wrs1)
-    b = UInt(wrs2)
-
-    fg = DecodeFlagGroup(flag_group)
-    sb = UInt(shift_bytes)
-    st = DecodeShiftType(shift_type)
-  operation: |
-    b_shifted = ShiftReg(b, st, sb)
-    (result, flags_out) = AddWithCarry(a, b_shifted, FLAGS[flag_group].C)
-
-    WDR[d] = result
-    FLAGS[flag_group] = flags_out
   encoding:
     scheme: bnaf
     mapping:
@@ -109,17 +81,6 @@
   doc: |
     Adds a zero-extended unsigned immediate to the value of a WDR, writes the
     result to the destination WDR, and updates the flags.
-  decode: |
-    d = UInt(wrd)
-    a = UInt(wrs1)
-
-    fg = DecodeFlagGroup(flag_group)
-    i = ZeroExtend(imm, WLEN)
-  operation: |
-    (result, flags_out) = AddWithCarry(a, i, "0")
-
-    WDR[d] = result
-    FLAGS[flag_group] = flags_out
   encoding:
     scheme: bnai
     mapping:
@@ -144,17 +105,6 @@
     The intermediate result is small enough if both inputs are less than `MOD`.
 
     Flags are not used or saved.
-  decode: |
-    d = UInt(wrd)
-    a = UInt(wrs1)
-    b = UInt(wrs2)
-  operation: |
-    result = a + b
-
-    if result >= MOD:
-      result = result - MOD
-
-    WDR[d] = result & ((1 << 256) - 1)
   encoding:
     scheme: bnam
     mapping:
@@ -211,37 +161,6 @@
     Multiplies two `WLEN/4` WDR values, shifts the product by `acc_shift_imm` bit, and adds the result to the accumulator.
 
     For versions of the instruction with writeback, see `BN.MULQACC.WO` and `BN.MULQACC.SO`.
-  decode: |
-    writeback_variant = None
-    zero_accumulator = DecodeMulqaccZeroacc(zero_acc)
-
-    d = None
-    a = UInt(wrs1)
-    b = UInt(wrs2)
-
-    d_hwsel = None
-    a_qwsel = DecodeQuarterWordSelect(wrs1_qwsel)
-    b_qwsel = DecodeQuarterWordSelect(wrs2_qwsel)
-  operation: &mulqacc-operation |
-    a_qw = GetQuarterWord(a, a_qwsel)
-    b_qw = GetQuarterWord(b, b_qwsel)
-
-    mul_res = a_qw * b_qw
-
-    if zero_accumulator:
-      ACC = 0
-
-    ACC = ACC + (mul_res << acc_shift_imm)
-
-    if writeback_variant == 'shiftout':
-      if d_hwsel == 'L':
-        WDR[d][WLEN/2-1:0] = ACC[WLEN/2-1:0]
-      elif d_hwsel == 'U':
-        WDR[d][WLEN-1:WLEN/2] = ACC[WLEN/2-1:0]
-      ACC = ACC >> (WLEN/2)
-
-    elif writeback_variant == 'writeout':
-      WDR[d] = ACC
   encoding:
     scheme: bnaq
     mapping:
@@ -273,18 +192,6 @@
   doc: |
     Multiplies two `WLEN/4` WDR values, shifts the product by `acc_shift_imm` bit, and adds the result to the accumulator.
     Writes the resulting accumulator to `wrd`.
-  decode: |
-    writeback_variant = 'writeout'
-    zero_accumulator = DecodeMulqaccZeroacc(zero_acc)
-
-    d = UInt(wrd)
-    a = UInt(wrs1)
-    b = UInt(wrs2)
-
-    d_hwsel = None
-    a_qwsel = DecodeQuarterWordSelect(wrs1_qwsel)
-    b_qwsel = DecodeQuarterWordSelect(wrs2_qwsel)
-  operation: *mulqacc-operation
   encoding:
     scheme: bnaq
     mapping:
@@ -322,18 +229,6 @@
     Next, shifts the resulting accumulator right by half a word.
     The bits that are shifted out are written to a half-word of `<wrd>`, selected with `<wrd_hwsel>`.
 
-  decode: |
-    writeback_variant = 'shiftout'
-    zero_accumulator = DecodeMulqaccZeroacc(zero_acc)
-
-    d = UInt(wrd)
-    a = UInt(wrs1)
-    b = UInt(wrs2)
-
-    d_hwsel = DecodeHalfWordSelect(wrd_hwsel)
-    a_qwsel = DecodeQuarterWordSelect(wrs1_qwsel)
-    b_qwsel = DecodeQuarterWordSelect(wrs2_qwsel)
-  operation: *mulqacc-operation
   encoding:
     scheme: bnaq
     mapping:
@@ -363,20 +258,6 @@
   doc: |
     Subtracts the second WDR value from the first one, writes the result to the destination WDR and updates flags.
     The content of the second source WDR can be shifted by an unsigned immediate before it is consumed by the operation.
-  decode: &bn-sub-decode |
-    d = UInt(wrd)
-    a = UInt(wrs1)
-    b = UInt(wrs2)
-
-    fg = DecodeFlagGroup(flag_group)
-    sb = UInt(shift_bytes)
-    st = DecodeShiftType(shift_type)
-  operation: |
-    b_shifted = ShiftReg(b, st, sb)
-    (result, flags_out) = SubtractWithBorrow(a, b_shifted, 0)
-
-    WDR[d] = result
-    FLAGS[flag_group] = flags_out
   encoding:
     scheme: bnaf
     mapping:
@@ -395,13 +276,6 @@
   doc: |
     Subtracts the second WDR value and the Carry from the first one, writes the result to the destination WDR, and updates the flags.
     The content of the second source WDR can be shifted by an unsigned immediate before it is consumed by the operation.
-  decode: *bn-sub-decode
-  operation: |
-    b_shifted = ShiftReg(b, st, sb)
-    (result, flags_out) = SubtractWithBorrow(a, b_shifted, FLAGS[flag_group].C)
-
-    WDR[d] = result
-    FLAGS[flag_group] = flags_out
   encoding:
     scheme: bnaf
     mapping:
@@ -428,17 +302,6 @@
   doc: |
     Subtracts a zero-extended unsigned immediate from the value of a WDR,
     writes the result to the destination WDR, and updates the flags.
-  decode: |
-    d = UInt(wrd)
-    a = UInt(wrs1)
-
-    fg = DecodeFlagGroup(flag_group)
-    i = ZeroExtend(imm, WLEN)
-  operation: |
-    (result, flags_out) = SubtractWithBorrow(a, i, 0)
-
-    WDR[d] = result
-    FLAGS[flag_group] = flags_out
   encoding:
     scheme: bnai
     mapping:
@@ -463,17 +326,6 @@
     This is guaranteed if both inputs are less than `MOD`.
 
     Flags are not used or saved.
-  decode: |
-    d = UInt(wrd)
-    a = UInt(wrs1)
-    b = UInt(wrs2)
-  operation: |
-    result = a - b
-
-    if result < 0:
-      result = MOD + result
-
-    WDR[d] = result & ((1 << 256) - 1)
   encoding:
     scheme: bnam
     mapping:
@@ -502,21 +354,6 @@
     Takes the values stored in registers referenced by `wrs1` and `wrs2` and stores the result in the register referenced by `wrd`.
     The content of the second source register can be shifted by an immediate before it is consumed by the operation.
     The M, L and Z flags in flag group 0 are updated with the result of the operation.
-  decode: &bn-and-decode |
-    d = UInt(wrd)
-    a = UInt(wrs1)
-    b = UInt(wrs2)
-
-    sb = UInt(shift_bytes)
-    st = DecodeShiftType(shift_type)
-    fg = DecodeFlagGroup(flag_group)
-  operation: |
-    b_shifted = ShiftReg(b, st, sb)
-    result = a & b_shifted
-
-    WDR[d] = result
-    flags_out = FlagsForResult(result)
-    FLAGS[flag_group] = {M: flags_out.M, L: flags_out.L, Z: flags_out.Z, C: FLAGS[flag_group].C}
   encoding:
     scheme: bna
     mapping:
@@ -537,14 +374,6 @@
     Takes the values stored in WDRs referenced by `wrs1` and `wrs2` and stores the result in the WDR referenced by `wrd`.
     The content of the second source WDR can be shifted by an immediate before it is consumed by the operation.
     The M, L and Z flags in flag group 0 are updated with the result of the operation.
-  decode: *bn-and-decode
-  operation: |
-    b_shifted = ShiftReg(b, st, sb)
-    result = a | b_shifted
-
-    WDR[d] = result
-    flags_out = FlagsForResult(result)
-    FLAGS[flag_group] = {M: flags_out.M, L: flags_out.L, Z: flags_out.Z, C: FLAGS[flag_group].C}
   encoding:
     scheme: bna
     mapping:
@@ -572,20 +401,6 @@
     Negates the value in `wrs` and stores the result in the register referenced by `wrd`.
     The source value can be shifted by an immediate before it is consumed by the operation.
     The M, L and Z flags in flag group 0 are updated with the result of the operation.
-  decode: |
-    d = UInt(wrd)
-    a = UInt(wrs1)
-
-    sb = UInt(shift_bytes)
-    st = DecodeShiftType(shift_type)
-    fg = DecodeFlagGroup(flag_group)
-  operation: |
-    a_shifted = ShiftReg(a, st, sb)
-    result = ~a_shifted
-
-    WDR[d] = result
-    flags_out = FlagsForResult(result)
-    FLAGS[flag_group] = {M: flags_out.M, L: flags_out.L, Z: flags_out.Z, C: FLAGS[flag_group].C}
   encoding:
     scheme: bnan
     mapping:
@@ -605,14 +420,6 @@
     Takes the values stored in WDRs referenced by `wrs1` and `wrs2` and stores the result in the WDR referenced by `wrd`.
     The content of the second source WDR can be shifted by an immediate before it is consumed by the operation.
     The M, L and Z flags in flag group 0 are updated with the result of the operation.
-  decode: *bn-and-decode
-  operation: |
-    b_shifted = ShiftReg(b, st, sb)
-    result = a ^ b_shifted
-
-    WDR[d] = result
-    flags_out = FlagsForResult(result)
-    FLAGS[flag_group] = {M: flags_out.M, L: flags_out.L, Z: flags_out.Z, C: FLAGS[flag_group].C}
   encoding:
     scheme: bna
     mapping:
@@ -642,13 +449,6 @@
   doc: |
     Concatenates the content of WDRs referenced by `wrs1` and `wrs2` (`wrs1` forms the upper part), shifts it right by an immediate value and truncates to WLEN bit.
     The result is stored in the WDR referenced by `wrd`.
-  decode: |
-    d = UInt(wrd)
-    a = UInt(wrs1)
-    b = UInt(wrs2)
-    shift_bit = Uint(imm)
-  operation: |
-    WDR[d] = (((a << WLEN) | b) >> shift_bit)[WLEN-1:0]
   encoding:
     scheme: bnr
     mapping:
@@ -680,16 +480,6 @@
     <wrd>, <wrs1>, <wrs2>, [FG<flag_group>.]<flag>
   doc: |
     Returns in the destination WDR the value of the first source WDR if the flag in the chosen flag group is set, otherwise returns the value of the second source WDR.
-  decode: |
-    d = UInt(wrd)
-    a = UInt(wrs1)
-    b = UInt(wrs2)
-    fg = DecodeFlagGroup(flag_group)
-    flag = DecodeFlag(flag)
-  operation: |
-    flag_is_set = FLAGS[fg].get(flag)
-
-    WDR[d] = wrs1 if flag_is_set else wrs2
   encoding:
     scheme: bns
     mapping:
@@ -714,18 +504,6 @@
   doc: |
     Subtracts the second WDR value from the first one and updates flags.
     This instruction is identical to BN.SUB, except that no result register is written.
-  decode: &bn-cmp-decode |
-    a = UInt(wrs1)
-    b = UInt(wrs2)
-
-    fg = DecodeFlagGroup(flag_group)
-    sb = UInt(shift_bytes)
-    st = DecodeShiftType(shift_type)
-  operation: |
-    b_shifted = ShiftReg(b, st, sb)
-    (, flags_out) = SubtractWithBorrow(a, b_shifted, 0)
-
-    FLAGS[flag_group] = flags_out
   encoding:
     scheme: bnc
     mapping:
@@ -743,11 +521,6 @@
   doc: |
     Subtracts the second WDR value from the first one and updates flags.
     This instruction is identical to BN.SUBB, except that no result register is written.
-  decode: *bn-cmp-decode
-  operation: |
-    (, flags_out) = SubtractWithBorrow(a, b, FLAGS[flag_group].C)
-
-    FLAGS[flag_group] = flags_out
   encoding:
     scheme: bnc
     mapping:
@@ -798,26 +571,6 @@
     The memory address must be aligned to WLEN bits.
     Any address that is unaligned or is above the top of memory will result in an error (with error code `ErrCodeBadDataAddr`).
   cycles: 2
-  decode: |
-    rd = UInt(grd)
-    rs1 = UInt(grs1)
-    offset = UInt(offset)
-  operation: |
-    mem_addr = GPR[rs1] + offset
-    wdr_dest = GPR[rd]
-
-    assert not (grs1_inc and grd_inc)  # prevented in encoding
-    if mem_addr % (WLEN / 8) or mem_addr + WLEN > DMEM_SIZE:
-        raise BadDataAddr()
-
-    mem_index = mem_addr // (WLEN / 8)
-
-    WDR[wdr_dest] = LoadWlenWordFromMemory(mem_index)
-
-    if grs1_inc:
-        GPR[rs1] = GPR[rs1] + (WLEN / 8)
-    if grd_inc:
-        GPR[rd] = (GPR[rd] + 1) & 0x1f
   lsu:
     type: mem-load
     target: [offset, grs1]
@@ -871,26 +624,6 @@
 
     The memory address must be aligned to WLEN bits.
     Any address that is unaligned or is above the top of memory will result in an error (with error code `ErrCodeBadDataAddr`).
-  decode: |
-    rs1 = UInt(grs1)
-    rs2 = UInt(grs2)
-    offset = UInt(offset)
-  operation: |
-    mem_addr = GPR[rs1] + offset
-    wdr_src = GPR[rs2]
-
-    assert not (grs1_inc and grd_inc)  # prevented in encoding
-    if mem_addr % (WLEN / 8) or mem_addr + WLEN > DMEM_SIZE:
-        raise BadDataAddr()
-
-    mem_index = mem_addr // (WLEN / 8)
-
-    StoreWlenWordToMemory(mem_index, WDR[wdr_src])
-
-    if grs1_inc:
-        GPR[rs1] = GPR[rs1] + (WLEN / 8)
-    if grs2_inc:
-        GPR[rs2] = (GPR[rs2] + 1) & 0x1f
   lsu:
     type: mem-store
     target: [offset, grs1]
@@ -908,10 +641,6 @@
 - mnemonic: bn.mov
   synopsis: Copy content between WDRs (direct addressing)
   operands: [wrd, wrs]
-  decode: |
-    s = UInt(wrs)
-    d = UInt(wrd)
-  operation: WDR[d] = WDR[s]
   encoding:
     scheme: bnmov
     mapping:
@@ -943,16 +672,6 @@
   doc: |
     Copies WDR contents between registers with indirect addressing.
     Optionally, either the source or the destination register address can be incremented by 1.
-  decode: |
-    s = UInt(grs)
-    d = UInt(grd)
-  operation: |
-    WDR[GPR[d]] = WDR[GPR[s]]
-
-    if grs_inc:
-      GPR[s] = GPR[s] + 1
-    if grd_inc:
-      GPR[d] = GPR[d] + 1
   encoding:
     scheme: bnmov
     mapping:

--- a/hw/ip/otbn/util/shared/insn_yaml.py
+++ b/hw/ip/otbn/util/shared/insn_yaml.py
@@ -27,7 +27,7 @@ class Insn:
                         ['mnemonic', 'operands'],
                         ['group', 'rv32i', 'synopsis',
                          'syntax', 'doc', 'note', 'trailing-doc',
-                         'decode', 'operation', 'encoding', 'glued-ops',
+                         'encoding', 'glued-ops',
                          'literal-pseudo-op', 'python-pseudo-op', 'lsu',
                          'straight-line', 'cycles'])
 
@@ -73,8 +73,6 @@ class Insn:
         self.doc = get_optional_str(yd, 'doc', what)
         self.note = get_optional_str(yd, 'note', what)
         self.trailing_doc = get_optional_str(yd, 'trailing-doc', what)
-        self.decode = get_optional_str(yd, 'decode', what)
-        self.operation = get_optional_str(yd, 'operation', what)
 
         raw_syntax = get_optional_str(yd, 'syntax', what)
         if raw_syntax is not None:

--- a/hw/ip/otbn/util/shared/yaml_parse_helpers.py
+++ b/hw/ip/otbn/util/shared/yaml_parse_helpers.py
@@ -10,7 +10,7 @@ import yaml
 try:
     from yaml import CSafeLoader as YamlLoader
 except ImportError:
-    from yaml import SafeLoader as YamlLoader
+    from yaml import SafeLoader as YamlLoader  # type: ignore
 
 
 T = TypeVar('T')

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Keep sorted.
+astor
 flake8
 gitpython
 hjson

--- a/util/build_docs.py
+++ b/util/build_docs.py
@@ -311,9 +311,11 @@ def generate_otbn_isa():
     otbn_dir = SRCTREE_TOP / 'hw/ip/otbn'
     script = otbn_dir / 'util/yaml_to_doc.py'
     yaml_file = otbn_dir / 'data/insns.yml'
+    impl_file = otbn_dir / 'dv/otbnsim/sim/insn.py'
 
     out_dir = config['outdir-generated'].joinpath('otbn-isa')
-    subprocess.run([str(script), str(yaml_file), str(out_dir)], check=True)
+    subprocess.run([str(script), str(yaml_file), str(impl_file), str(out_dir)],
+                   check=True)
 
 
 def hugo_match_version(hugo_bin_path, version):


### PR DESCRIPTION
This isn't the full solution: we are going to want to do some
prettifying to make this more "pseudo-codeish". For example, we
currently have lines like

    val1 = state.gprs.get_reg(self.grs1).read_unsigned()
    state.gprs.get_reg(self.grd).write_unsigned(result)

which should probably be something more like

    val1 <- gprs[self.grs1]
    gprs[self.grd] <- val1

or similar. However, it does get rid of the duplicated definitions
from the YAML files and, if ugly, the definitions in the spec are now
at least clear.