### PR TITLE
[otbn] Adjust BN.LID/BN.SID/BN.MOVR encoding

### DIFF
--- a/hw/ip/otbn/data/bignum-insns.yml
+++ b/hw/ip/otbn/data/bignum-insns.yml
@@ -826,11 +826,11 @@
     scheme: bnxid
     mapping:
       imm: offset
+      rs2: grd
+      rs1: grs1
       spp: grs1_inc
       dpp: grd_inc
-      rs: grs1
       funct3: b100
-      rd: grd
 
 - mnemonic: bn.sid
   synopsis: Store Word (indirect source, indirect destination)
@@ -899,11 +899,11 @@
     scheme: bnxid
     mapping:
       imm: offset
+      rs2: grs2
+      rs1: grs1
       spp: grs1_inc
       dpp: grs2_inc
-      rs: grs1
       funct3: b101
-      rd: grs2
 
 - mnemonic: bn.mov
   synopsis: Copy content between WDRs (direct addressing)
@@ -915,9 +915,6 @@
   encoding:
     scheme: bnmov
     mapping:
-      indirect: b0
-      spp: bx
-      dpp: bx
       src: wrs
       dst: wrd
 
@@ -954,13 +951,12 @@
     if grd_inc:
       GPR[d] = GPR[d] + 1
   encoding:
-    scheme: bnmov
+    scheme: bnmovr
     mapping:
-      indirect: b1
+      dst: grd
+      src: grs
       spp: grs_inc
       dpp: grd_inc
-      src: grs
-      dst: grd
 
 - mnemonic: bn.wsrrs
   synopsis: Atomic Read and Set Bits in WSR

--- a/hw/ip/otbn/data/enc-schemes.yml
+++ b/hw/ip/otbn/data/enc-schemes.yml
@@ -179,6 +179,12 @@ funct2:
   fields:
     funct2: 13-12
 
+# A partial scheme for the bn.mov/bn.movr instructions. Specifies if register
+# indirect lookup is used (bn.mov vs bn.movr)
+indirect:
+  fields:
+    indirect: 31
+
 # A specialised encoding for the loop instruction (only one source, no
 # destination)
 loop:
@@ -309,26 +315,42 @@ bnxid:
     - custom0
     - funct3
   fields:
-    imm: 24-22,31-25
-    spp: 21
-    dpp: 20
-    rs: 19-15
-    rd: 11-7
+    imm: 11-9,31-25
+    rs2: 24-20
+    rs1: 19-15
+    spp: 8
+    dpp: 7
 
-# Used by bn.mov and bn.movr
+# Used by bn.mov
 bnmov:
   parents:
     - custom0
     - funct3(funct3=b110)
+    - indirect(indirect=b0)
   fields:
-    indirect: 31
     fixed_top:
-      bits: 30-22
-      value: bxxxxxxxxx
-    spp: 21
-    dpp: 20
+      bits: 30-20
+      value: bxxxxxxxxxxx
     src: 19-15
     dst: 11-7
+
+# Used by bn.movr
+bnmovr:
+  parents:
+    - custom0
+    - funct3(funct3=b110)
+    - indirect(indirect=b1)
+  fields:
+    fixed_top:
+      bits: 30-25
+      value: bxxxxxx
+    dst: 24-20
+    src: 19-15
+    spp: 9
+    dpp: 7
+    unused:
+      bits: 11-10,8
+      value: bxxx
 
 # Used by bn.wsrrs and bn.wsrrw
 wcsr:


### PR DESCRIPTION
This is a draft PR because I want to finish the LID/SID/MOVR implementation in the RTL before merging in case I come across anything else I'd like to adjust about the encoding.

As these use indirect addressing grd register field is moved to the
field used for grs2 in all other instructions as the given grd value
becomes a base side register to read to generate a bignum side register
index for the destination register.

BN.SID has no destination but the grs2 register field is moved to match
with all other instructions (and so the offset and inc fields match up
with BN.LID/BN.MOVR).

Fixes #3666

Signed-off-by: Greg Chadwick <gac@lowrisc.org>