### PR TITLE
[flash_ctrl] Minor clean-up of the req/ack interface

### DIFF
--- a/hw/ip/flash_ctrl/rtl/flash_phy_core.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_core.sv
@@ -198,8 +198,6 @@ module flash_phy_core import flash_phy_pkg::*; #(
 
       // other controller operations directly interface with flash
       StCtrl: begin
-        reqs[PhyPgErase] = pg_erase_i;
-        reqs[PhyBkErase] = bk_erase_i;
         if (ack) begin
           ctrl_rsp_vld = 1'b1;
           state_d = StIdle;


### PR DESCRIPTION
Now all requests are single cycle pulse.
This is in preparation for a consistent interface as flash wrapper construction begins.

Signed-off-by: Timothy Chen <timothytim@google.com>