### PR TITLE
[otbn] Allow hex constants for big number operands

### DIFF
--- a/hw/ip/otbn/util/shared/operand.py
+++ b/hw/ip/otbn/util/shared/operand.py
@@ -302,7 +302,7 @@ class ImmOperandType(OperandType):
         # decipher the immediate here. It might be a label which binutils' as
         # can deal with for us.
         try:
-            return int(as_str)
+            return int(as_str, 0)
         except ValueError:
             return None
 


### PR DESCRIPTION
This part of the code is in charge of converting a string to a number.
If the string doesn't look like a number (we have something like
"`bn.addi w1, w2, cabbage`") then it punts and hopes that we can use the
binutils assembler to resolve the argument as a symbol.

However, we don't want to punt on "`bn.addi w1, w2, 0x123`" and Python's
`int()` function needs a base argument of `0` to do auto-detection of hex
constants.

Fixes #3706.