### PR TITLE
Use GitHub upstream git for Verilator

### DIFF
--- a/doc/ug/install_instructions/index.md
+++ b/doc/ug/install_instructions/index.md
@@ -172,7 +172,7 @@ Then you can fetch, build and install Verilator itself (this should be done outs
 ```console
 $ export VERILATOR_VERSION={{< tool_version "verilator" >}}
 
-$ git clone http://git.veripool.org/git/verilator
+$ git clone https://github.com/verilator/verilator.git
 $ cd verilator
 $ git checkout v$VERILATOR_VERSION
 

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update && apt-get install -y \
     flex \
     git
 RUN git clone --depth=1 -b  v${VERILATOR_VERSION} \
-    http://git.veripool.org/git/verilator /usr/local/src/verilator
+    https://github.com/verilator/verilator.git /usr/local/src/verilator
 RUN cd /usr/local/src/verilator && \
     autoconf && ./configure --prefix=/tools/verilator/${VERILATOR_VERSION} && \
     make -j$(nproc) && make install


### PR DESCRIPTION
Verilator has moved to GitHub, use the new upstream for a more reliable
git clone experience.