### PR TITLE
[ci] Move Vendor Directory Check into Slow Lint Job

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ pr:
 
 jobs:
 - job: lint
-  displayName: Run code quality checks (lint)
+  displayName: Run code quality checks (quick lint)
   pool:
     vmImage: ubuntu-16.04
   steps:
@@ -177,25 +177,6 @@ jobs:
     condition: eq(variables['Build.Reason'], 'PullRequest')
     displayName: Check commit metadata
   - bash: |
-      # Here we look for all *.vendor.hjson files in the repo to re-vendor them.
-      # We exclude the following:
-      # - Any in 'hw/vendor/lowrisc_ibex', because that directory is vendored.
-      # - `./sw/vendor/riscv_compliance.vendor.hjson`, because it has whitespace
-      #   issues in the repository that we cannot easily solve.
-      find . \
-        -not \( -path './hw/vendor/lowrisc_ibex' -prune \) \
-        -not \( -name 'riscv_compliance.vendor.hjson' \) \
-        -name '*.vendor.hjson' \
-        | xargs -n1 util/vendor.py --verbose \
-        && git diff --exit-code
-      if [[ $? != 0 ]]; then
-        echo -n "##vso[task.logissue type=error]"
-        echo "Vendored repositories not up-to-date. Run util/vendor.py to fix."
-        exit 1
-      fi
-    condition: always()
-    displayName: Check vendored directories are up-to-date
-  - bash: |
       set -e
       only_doc_changes=0
       has_otbn_changes=0
@@ -246,6 +227,30 @@ jobs:
       fi
     condition: eq(variables['Build.Reason'], 'PullRequest')
     displayName: Check Licence Headers
+
+- job: slow_lints
+  displayName: Run code quality checks (in-depth lint)
+  dependsOn: lint
+  pool:
+    vmImage: ubuntu-16.04
+  steps:
+  - template: ci/install-package-dependencies.yml
+  - bash: |
+      # Here we look for all *.vendor.hjson files in the repo to re-vendor them.
+      # We exclude the following:
+      # - Any in 'hw/vendor/lowrisc_ibex', because that directory is vendored.
+      find . \
+        -not \( -path './hw/vendor/lowrisc_ibex' -prune \) \
+        -name '*.vendor.hjson' \
+        | xargs -n1 util/vendor.py --verbose \
+        && git diff --exit-code
+      if [[ $? != 0 ]]; then
+        echo -n "##vso[task.logissue type=error]"
+        echo "Vendored repositories not up-to-date. Run util/vendor.py to fix."
+        exit 1
+      fi
+    condition: always()
+    displayName: Check vendored directories are up-to-date
 
 - job: sw_build
   displayName: Build Software


### PR DESCRIPTION
I noticed that "Checking vendored directories" takes about 5 minutes,
whereas most other lint tasks take about 1-30s each.

Lint tasks are run on every single commit, and block all other jobs
until they are complete. The idea here is to move this task to a
separate job that can be performed in parallel with any other build
steps. This should speed up CI, as long as we have enough parallel jobs
available.

As the whitespace issues in the riscv-compliance repo have been solved,
I have re-enabled checking the vendoring of that directory.