### PR TITLE
[dv/uvmgen] update has_alerts

### DIFF
--- a/util/uvmdvgen/env_cfg.sv.tpl
+++ b/util/uvmdvgen/env_cfg.sv.tpl
@@ -24,6 +24,9 @@ class ${name}_env_cfg extends dv_base_env_cfg;
   `uvm_object_new
 
   virtual function void initialize(bit [31:0] csr_base_addr = '1);
+% if has_alerts:
+    list_of_alerts = ${name}_env_pkg::LIST_OF_ALERTS;
+% endif
 % if has_ral:
     super.initialize(csr_base_addr);
 % endif

--- a/util/uvmdvgen/env_pkg.sv.tpl
+++ b/util/uvmdvgen/env_pkg.sv.tpl
@@ -25,6 +25,11 @@ package ${name}_env_pkg;
   `include "dv_macros.svh"
 
   // parameters
+% if has_alerts:
+  // TODO: add the names of alerts in order
+  parameter string LIST_OF_ALERTS[] = {};
+  parameter uint   NUM_ALERTS = ;
+% endif
 
   // types
 % if not has_ral:


### PR DESCRIPTION
This PR updates alert creation and connection in uvmdvgen.
If an IP has alerts, this can be automatically generated by using switch
`-ha`.

Signed-off-by: Cindy Chen <chencindy@google.com>