### PR TITLE
[dv/alert_handler] fix three alert issues

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_sender_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_sender_driver.sv
@@ -20,10 +20,10 @@ class alert_sender_driver extends alert_esc_base_driver;
     forever begin
       @(negedge cfg.vif.rst_n);
       under_reset = 1;
-      void'(alert_atomic.try_get(1));
-      alert_atomic.put(1);
       do_reset();
       @(posedge cfg.vif.rst_n);
+      void'(alert_atomic.try_get(1));
+      alert_atomic.put(1);
       under_reset = 0;
     end
   endtask

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_entropy_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_entropy_vseq.sv
@@ -17,7 +17,7 @@ class alert_handler_entropy_vseq extends alert_handler_sanity_vseq;
   // increase the possibility to enable more alerts, because alert_handler only sends ping on
   // enabled alerts
   constraint enable_one_alert_c {
-    alert_en dist {'b1111 :/ 9, [0:'b1110] :/ 1};
+    alert_en dist {'1 :/ 9, [0:('1-1)] :/ 1};
   }
 
   constraint sig_int_c {

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_sanity_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_sanity_vseq.sv
@@ -129,10 +129,6 @@ class alert_handler_sanity_vseq extends alert_handler_base_vseq;
       // when all configuration registers are set, write lock register
       lock_config(do_lock_config);
 
-      if (esc_standalone_int_err) drive_esc_rsp(esc_standalone_int_err);
-      // drive alert
-      drive_alert(alert_trigger, alert_int_err);
-
       // if config is not locked, update max_intr_timeout and max_wait_phases cycles
       if (!config_locked) begin
         bit [TL_DW-1:0] max_intr_timeout_cyc;
@@ -141,6 +137,10 @@ class alert_handler_sanity_vseq extends alert_handler_base_vseq;
         max_wait_phases_cyc = max2(max_wait_phases_cyc, max_phase_cyc * NUM_ESC_PHASES);
         if (do_lock_config) config_locked = 1;
       end
+
+      // drive alerts and escalations
+      if (esc_standalone_int_err) drive_esc_rsp(esc_standalone_int_err);
+      drive_alert(alert_trigger, alert_int_err);
 
       if (do_esc_intr_timeout) begin
         cfg.clk_rst_vif.wait_clks(max_intr_timeout_cyc);


### PR DESCRIPTION
This PR consists of two commits that trying to fix these issues:
1). constrains for `alert_en`. In current coding, this is hard-coded, but in top-level alert_handler test, the number of alerts are more than 4 (default number), can could be increased in the future. This commit removes the hard-coded number.

2). fix a potential race condition during reset. When `under_reset` is triggered, there could potentially have a race condition when: a). trying to disable fork (that fork could potentially trying to get/put semaphore) b). trying to release semaphore in `reset_thread`. This PR moves the release semaphore after `posedge rst_n` to avoid the race condition.

3). move the `config_lock` logic right after `do_lock_config`. In current code, `config_lock` logic won't be called until drive alerts/escalation. There is no need to drive alert/escalation. We should predict `config_lock` right after task `do_lock_config`. 