### PR TITLE
[kmac] Revise CFG to be read-only in HW

### DIFF
--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -69,7 +69,7 @@
             '''
       regwen: "CFG_REGWEN"
       swaccess: "rw"
-      hwaccess: "hrw"
+      hwaccess: "hro"
       fields: [
         { bits: "0"
           name: "kmac_en"

--- a/hw/ip/kmac/rtl/kmac_reg_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_pkg.sv
@@ -127,29 +127,6 @@ package kmac_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        d;
-      logic        de;
-    } kmac_en;
-    struct packed {
-      logic [2:0]  d;
-      logic        de;
-    } strength;
-    struct packed {
-      logic [1:0]  d;
-      logic        de;
-    } mode;
-    struct packed {
-      logic        d;
-      logic        de;
-    } msg_endianness;
-    struct packed {
-      logic        d;
-      logic        de;
-    } state_endianness;
-  } kmac_hw2reg_cfg_reg_t;
-
-  typedef struct packed {
-    struct packed {
-      logic        d;
     } sha3_idle;
     struct packed {
       logic        d;
@@ -197,11 +174,10 @@ package kmac_reg_pkg;
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    kmac_hw2reg_intr_state_reg_t intr_state; // [62:60]
-    kmac_hw2reg_cfg_reg_t cfg; // [59:52]
-    kmac_hw2reg_status_reg_t status; // [51:52]
-    kmac_hw2reg_err_code_reg_t err_code; // [51:52]
-    kmac_hw2reg_cfg_regwen_reg_t cfg_regwen; // [51:52]
+    kmac_hw2reg_intr_state_reg_t intr_state; // [49:47]
+    kmac_hw2reg_status_reg_t status; // [46:47]
+    kmac_hw2reg_err_code_reg_t err_code; // [46:47]
+    kmac_hw2reg_cfg_regwen_reg_t cfg_regwen; // [46:47]
   } kmac_hw2reg_t;
 
   // Register Address

--- a/hw/ip/kmac/rtl/kmac_reg_top.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_top.sv
@@ -508,8 +508,8 @@ module kmac_reg_top (
     .wd     (cfg_kmac_en_wd),
 
     // from internal hardware
-    .de     (hw2reg.cfg.kmac_en.de),
-    .d      (hw2reg.cfg.kmac_en.d ),
+    .de     (1'b0),
+    .d      ('0  ),
 
     // to internal hardware
     .qe     (),
@@ -534,8 +534,8 @@ module kmac_reg_top (
     .wd     (cfg_strength_wd),
 
     // from internal hardware
-    .de     (hw2reg.cfg.strength.de),
-    .d      (hw2reg.cfg.strength.d ),
+    .de     (1'b0),
+    .d      ('0  ),
 
     // to internal hardware
     .qe     (),
@@ -560,8 +560,8 @@ module kmac_reg_top (
     .wd     (cfg_mode_wd),
 
     // from internal hardware
-    .de     (hw2reg.cfg.mode.de),
-    .d      (hw2reg.cfg.mode.d ),
+    .de     (1'b0),
+    .d      ('0  ),
 
     // to internal hardware
     .qe     (),
@@ -586,8 +586,8 @@ module kmac_reg_top (
     .wd     (cfg_msg_endianness_wd),
 
     // from internal hardware
-    .de     (hw2reg.cfg.msg_endianness.de),
-    .d      (hw2reg.cfg.msg_endianness.d ),
+    .de     (1'b0),
+    .d      ('0  ),
 
     // to internal hardware
     .qe     (),
@@ -612,8 +612,8 @@ module kmac_reg_top (
     .wd     (cfg_state_endianness_wd),
 
     // from internal hardware
-    .de     (hw2reg.cfg.state_endianness.de),
-    .d      (hw2reg.cfg.state_endianness.d ),
+    .de     (1'b0),
+    .d      ('0  ),
 
     // to internal hardware
     .qe     (),


### PR DESCRIPTION
This commit is to fix the CFG register behavior. It was external and
`hrw` type for HW to direct control the write permission.  After
utilizing REGWEN feature, it doesn't have to be write-able from HW view.
The permission was remained and caused the unknown value to kmac_en and
rest of the values, which creates an error on FPV.