### PR TITLE
[dv/otp_ctrl] Add exclusions to csr automation tests

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson
@@ -448,6 +448,9 @@
       swaccess: "ro",
       hwaccess: "hwo",
       hwext:    "true",
+      tags: [ // DAI interface will set it to 0 during initialization,
+              // so even after reset, the value might not be the reset value
+              "excl:CsrAllTests:CsrExclCheck"],
       fields: [
         {
             bits:   "0",
@@ -467,6 +470,9 @@
       hwqe:     "true",
       hwext:    "true",
       regwen:   "DIRECT_ACCESS_REGWEN",
+      tags: [ // The enable register "DIRECT_ACCESS_REGWEN" is HW controlled,
+              // so not able to predict this register value automatically
+              "excl:CsrNonInitTests:CsrExclCheck"],
       fields: [
         { bits: "0",
           name: "READ",
@@ -499,6 +505,9 @@
       hwaccess: "hro",
       hwqe:     "false",
       regwen:   "DIRECT_ACCESS_REGWEN",
+      tags: [ // The enable register "DIRECT_ACCESS_REGWEN" is HW controlled,
+              // so not able to predict this register value automatically
+              "excl:CsrNonInitTests:CsrExclCheck"],
       fields: [
         { bits: "OtpByteAddrWidth-1:0",
           desc: '''
@@ -524,6 +533,9 @@
         hwqe:     "false",
         regwen:   "DIRECT_ACCESS_REGWEN",
         cname:    "WORD",
+        tags: [ // The value of this register is written from "DIRECT_ACCESS_RDATA",
+                // so could not predict this register value automatically
+                "excl:CsrAllTests:CsrExclCheck"],
         fields: [
           { bits: "31:0"
           }

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -27,7 +27,9 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
 
   // setup basic otp_ctrl features
   virtual task otp_ctrl_init();
-    //`uvm_error(`gfn, "FIXME")
+    cfg.pwr_otp_vif.drive_pin(0, 0);
+    // reset memory to avoid readout X
+    cfg.mem_bkdr_vif.clear_mem();
   endtask
 
 endclass : otp_ctrl_base_vseq

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_wake_up_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_wake_up_vseq.sv
@@ -12,8 +12,6 @@ class otp_ctrl_wake_up_vseq extends otp_ctrl_base_vseq;
     super.otp_ctrl_init();
     // drive pwr_otp_req pin
     cfg.pwr_otp_vif.drive_pin(0, 1);
-    // reset memory to avoid readout X
-    cfg.mem_bkdr_vif.clear_mem();
   endtask
 
   virtual task pre_start();

--- a/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -29,7 +29,8 @@
                 "{proj_root}/hw/dv/data/common_sim_cfg.hjson",
                 // Common CIP test lists
                 "{proj_root}/hw/dv/data/tests/csr_tests.hjson",
-                "{proj_root}/hw/dv/data/tests/mem_tests.hjson",
+                // TODO: SW CFG memory can only be read after OTP initialization
+                // "{proj_root}/hw/dv/data/tests/mem_tests.hjson",
                 "{proj_root}/hw/dv/data/tests/intr_test.hjson",
                 "{proj_root}/hw/dv/data/tests/tl_access_tests.hjson",
                 "{proj_root}/hw/dv/data/tests/stress_tests.hjson"]

--- a/hw/ip/otp_ctrl/dv/tb.sv
+++ b/hw/ip/otp_ctrl/dv/tb.sv
@@ -47,7 +47,7 @@ module tb;
     .lc_otp_token_req_i        ('0),
     .lc_escalate_en_i          ('0),
     .lc_provision_en_i         ('0),
-    .lc_test_en_i              ('0),
+    .lc_dft_en_i               ('0),
     .flash_otp_key_req_i       ('0),
     .sram_otp_key_req_i        ('0),
     .otbn_otp_key_req_i        ('0)


### PR DESCRIPTION
1. Add exclusions to CSR automation test
2. Fix port naming from tb
3. Add clear mem and drive pwr input

Signed-off-by: Cindy Chen <chencindy@google.com>