### PR TITLE
[docs] Silence Hugo warning about empty File.Dir

### DIFF
--- a/site/docs/layouts/partials/menu.html
+++ b/site/docs/layouts/partials/menu.html
@@ -18,7 +18,11 @@
                 {{- if .LinkTitle }}
                     {{- .LinkTitle }}
                 {{- else }}
-                    {{- replace .File.Dir .Parent.File.Dir "" | replaceRE "/" "-" }}{{- .File.TranslationBaseName }}
+                    {{- $noparent := .File.Dir }}
+                    {{- if .Parent.File }}
+                        {{- $noparent = replace .File.Dir .Parent.File.Dir "" }}
+                    {{- end }}
+                    {{- replaceRE "/" "-" $noparent }}{{- .File.TranslationBaseName }}
                 {{- end }}
             </a>
             {{- if and (ne $numberOfPages 0) (or (.IsDescendant $displayedNode) (.IsAncestor $displayedNode) (.InSection $displayedNode)) }}


### PR DESCRIPTION
I don't think this matters for a clean checkout, but if you have
random .md files lying around, Hugo picks them up and then complains
about a zero `.Parent.File` when generating the menu.
