### PR TITLE
[fpga] Route UART Tx to second pin on ChipWhisperer board for debugging

### DIFF
--- a/hw/top_earlgrey/data/pins_cw305.xdc
+++ b/hw/top_earlgrey/data/pins_cw305.xdc
@@ -47,6 +47,10 @@ set_property -dict { PACKAGE_PIN H16 IOSTANDARD LVCMOS33 } [get_ports { IO_USB_D
 set_property -dict { PACKAGE_PIN D16 IOSTANDARD LVCMOS33 } [get_ports { IO_USB_SENSE0 }]; #JP3.D16
 set_property -dict { PACKAGE_PIN E16 IOSTANDARD LVCMOS33 } [get_ports { IO_USB_DNPULLUP0 }]; #JP3.E16
 
+set_property -dict { PACKAGE_PIN G16 IOSTANDARD LVCMOS33 } [get_ports { IO_UTX_DEBUG }]; #JP3.G16 (UART) for debugging
+
+## Unused pins of JP3: A12, B12, F12
+
 ## 20-Pin Connector (JP1)
 
 set_property -dict { PACKAGE_PIN R16 IOSTANDARD LVCMOS33 } [get_ports { IO_UTX }];     #JP1 PIN 10 (UART)

--- a/hw/top_earlgrey/rtl/top_earlgrey_cw305.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_cw305.sv
@@ -45,8 +45,9 @@ module top_earlgrey_cw305 #(
   inout               IO_GP13,
   inout               IO_GP14,
   inout               IO_GP15,
-  // chipwhisperer IO
-  output              TIO_CLKOUT
+  // ChipWhisperer IO
+  output              TIO_CLKOUT,
+  output              IO_UTX_DEBUG
 );
 
   import top_earlgrey_pkg::*;
@@ -65,8 +66,6 @@ module top_earlgrey_cw305 #(
   logic [padctrl_reg_pkg::NDioPads-1:0] dio_out_core, dio_out_padring;
   logic [padctrl_reg_pkg::NDioPads-1:0] dio_oe_core, dio_oe_padring;
   logic [padctrl_reg_pkg::NDioPads-1:0] dio_in_core, dio_in_padring;
-
-  assign TIO_CLKOUT = IO_CLK;
 
   padring #(
     // MIOs 31:20 are currently not
@@ -308,5 +307,15 @@ module top_earlgrey_cw305 #(
       assign mio_out[i] = mio_out_core[i];
     end
   end
+
+  //////////////////////
+  // ChipWhisperer IO //
+  //////////////////////
+
+  // Clock ouput to capture board.
+  assign TIO_CLKOUT = IO_CLK;
+
+  // UART Tx for debugging. The UART itself is connected to the capture board.
+  assign IO_UTX_DEBUG = top_earlgrey.cio_uart_tx_d2p;
 
 endmodule : top_earlgrey_cw305


### PR DESCRIPTION
On the ChipWhisperer FPGA board, the UART is connected to the capture board and used for transfering input and output data. This PR adds a second UART Tx pin to allow debugging before capturing traces.