### PR TITLE
[sw/sca/aes_serial] Make sure to actually receive characters over UART

### DIFF
--- a/sw/device/sca/aes_serial/aes_serial.c
+++ b/sw/device/sca/aes_serial/aes_serial.c
@@ -312,9 +312,10 @@ int main(int argc, char **argv) {
   char text[128] = {0};
   size_t pos = 0;
   while (true) {
-    size_t chars_available;
-    if (dif_uart_rx_bytes_available(&uart, &chars_available) != kDifUartOk ||
-        chars_available == 0) {
+    size_t chars_read;
+    if (dif_uart_bytes_receive(&uart, 1, (uint8_t *)&text[pos], &chars_read) !=
+            kDifUartOk ||
+        chars_read == 0) {
       usleep(50);
       continue;
     }


### PR DESCRIPTION
In lowRISC/OpenTitan#3526, a function call to inside the `aes_serial` app to receive UART characters was accidentally replaced with a call to check for available characters only. The characters were never read from the UART Receive FIFO. As a result, the aes_serial application was not working at all.
