### PR TITLE
[rom_ext] Document Usage Constraint Value and Signing Scheme

### DIFF
--- a/sw/device/rom_exts/manifest.hjson
+++ b/sw/device/rom_exts/manifest.hjson
@@ -78,16 +78,12 @@
     },
     {
       name: "usage_constraints",
-      desc: '''ROM_EXT Manifest usage constraints (TBC).
+      desc: '''ROM_EXT Manifest usage constraints.
 
             TODO
             ''',
       type: "field",
-      size: 32,
-    },
-    {
-      type: "reserved",
-      size: 32,
+      size: 256,
     },
     {
       name: "peripheral_lockdown_info",

--- a/sw/device/rom_exts/rom_ext_manifest.protocol.sh
+++ b/sw/device/rom_exts/rom_ext_manifest.protocol.sh
@@ -27,8 +27,8 @@ Image Timestamp:64,
 
 Signature Algorithm Identifier:32,
 Signature Exponent:32,
-Usage Constraints (TBC):32,
-Reserved:32,
+
+Usage Constraints (256 bits):${BROKEN_LENGTH},
 
 Peripheral Lockdown Info (TBC):128,
 


### PR DESCRIPTION
This is the scheme as agreed in the SW/Security Sync on 2020-10-07.

Signed-off-by: Sam Elliott <selliott@lowrisc.org>