### PR TITLE
Add a dependency for lsb_release

### DIFF
--- a/apt-requirements.txt
+++ b/apt-requirements.txt
@@ -18,6 +18,7 @@ libftdi1-2
 libftdi1-dev
 libssl-dev
 libusb-1.0-0
+lsb-release
 make
 ninja-build
 pkgconf


### PR DESCRIPTION
We use lsb_release currently in pipeline scripts to determine the Ubuntu
version. Add it as dependency to ensure it's installed everywhere; it's
likely we'll rely on its functionality in more scripts going forward.