### PR TITLE
[ci] Switch over Vivado builds to scalable cloud builder

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -427,7 +427,7 @@ jobs:
     # The bootrom is built into the FPGA image at synthesis time.
     - sw_build
   condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'))
-  pool: Default
+  pool: ci-public
   timeoutInMinutes: 120 # 2 hours
   steps:
   - template: ci/install-package-dependencies.yml
@@ -435,13 +435,15 @@ jobs:
   - bash: |
       set -e
       . util/build_consts.sh
+
+      module load "xilinx/vivado/$(VIVADO_VERSION)"
+
       mkdir -p "$OBJ_DIR/hw"
       mkdir -p "$BIN_DIR/hw/top_earlgrey"
 
       BOOTROM_VMEM="$BIN_DIR/sw/device/boot_rom/boot_rom_fpga_nexysvideo.32.vmem"
       test -f "$BOOTROM_VMEM"
 
-      . /opt/xilinx/Vivado/2018.3/settings64.sh
       fusesoc --cores-root=. \
         run --flag=fileset_top --target=synth --setup --build \
         --build-root="$OBJ_DIR/hw" \

--- a/doc/ug/getting_started_fpga.md
+++ b/doc/ug/getting_started_fpga.md
@@ -36,10 +36,10 @@ $ ./meson_init.sh
 $ ninja -C build-out sw/device/boot_rom/boot_rom_export_fpga_nexysvideo
 ```
 
-In the following example we synthesize the Earl Grey design for the Nexys Video board using Xilinx Vivado 2018.3.
+In the following example we synthesize the Earl Grey design for the Nexys Video board using Xilinx Vivado 2020.1.
 
 ```console
-$ . /tools/xilinx/Vivado/2018.3/settings64.sh
+$ . /tools/xilinx/Vivado/2020.1/settings64.sh
 $ cd $REPO_TOP
 $ ./meson_init.sh
 $ ninja -C build-out sw/device/boot_rom/boot_rom_export_fpga_nexysvideo
@@ -66,7 +66,7 @@ To flash the bitstream onto the FPGA you need to use either the Vivado GUI or th
 Use the following command to program the FPGA with fusesoc.
 
 ```console
-$ . /tools/xilinx/Vivado/2018.3/settings64.sh
+$ . /tools/xilinx/Vivado/2020.1/settings64.sh
 $ cd $REPO_TOP
 $ fusesoc --cores-root . pgm lowrisc:systems:top_earlgrey_nexysvideo:0.1
 ```
@@ -87,7 +87,7 @@ If you have having trouble with programming using the command line, try the GUI.
 ### Using the Vivado GUI
 
 ```console
-$ . /tools/xilinx/Vivado/2018.3/settings64.sh
+$ . /tools/xilinx/Vivado/2020.1/settings64.sh
 $ cd $REPO_TOP
 $ make -C build/lowrisc_systems_top_earlgrey_nexysvideo_0.1/synth-vivado build-gui
 ```
@@ -96,7 +96,7 @@ Now the Vivado GUI opens and loads the project.
 
 * Connect the FPGA board to the PC and turn it on.
 * In the navigation on the left, click on *PROGRAM AND DEBUG* > *Open Hardware Manager* > *Open Target* > *Auto Connect*.
-* Vivado now enumerates all boards and connects to it. (Note on Vivado 2018.1 you may get an error the first time and have to do auto connect twice.)
+* Vivado now enumerates all boards and connects to it.
 * Click on *Program Device* in the menu on the left (or at the top of the screen).
 * A dialog titled *Program Device* pops up. Select the file `lowrisc_systems_top_earlgrey_nexysvideo_0.1.bit` as *Bitstream file*, and leave the *Debug probes file* empty.
 * Click on *Program* to flash the FPGA with the bitstream.

--- a/doc/ug/install_instructions/index.md
+++ b/doc/ug/install_instructions/index.md
@@ -284,8 +284,7 @@ Most lowRISC designs support at least one FPGA board which works with a free Web
 
 ### Install Xilinx Vivado
 
-_**Vivado Version:** Vivado 2019.1 and all its updates are not compatible with this project.
-A discussion on this problem can be found in the [Github issue](https://github.com/lowRISC/opentitan/issues/89)._
+_**Vivado Version:** Vivado 2019.1 and all its minor updates are not compatible with this project._
 
 Vivado can be installed in two ways: either through an "All OS installer Single-File Download", or via the "Linux Self Extracting Web Installer".
 Neither option is great:
@@ -295,9 +294,9 @@ But unfortunately it doesn't support the batch mode for unattended installations
 
 To get started faster we use the web installer in the following.
 
-1. Go to the [Xilinx download page](https://www.xilinx.com/support/download/index.html/content/xilinx/en/downloadNav/vivado-design-tools/2018-3.html) and download two files for Vivado 2018.3.
-   (The version can be chosen on the left side if version 2018.3 is not already selected.)
-   1. The file "Vivado HLx 2018.3: WebPACK and Editions - Linux Self Extracting Web Installer".
+1. Go to the [Xilinx download page](https://www.xilinx.com/support/download/index.html/content/xilinx/en/downloadNav/vivado-design-tools/2020-1.html) and download two files for Vivado 2020.1.
+   (The version can be chosen on the left side if version 2020.1 is not already selected.)
+   1. The file "Xilinx Unified Installer 2020.1: Linux Self Extracting Web Installer".
    2. The "Digests" file below the download.
 
    ![Vivado download site](img/install_vivado/vivado_download.png)
@@ -308,8 +307,8 @@ To get started faster we use the web installer in the following.
 2. Before you proceed ensure that the download didn't get corrupted by verifying the checksum.
 
     ```console
-    $ sha512sum --check Xilinx_Vivado_SDK_Web_2018.3_1207_2324_Lin64.bin.digests
-    Xilinx_Vivado_SDK_Web_2018.3_1207_2324_Lin64.bin: OK
+    $ sha512sum --check Xilinx_Unified_2020.1_0602_1208_Lin64.bin.digests
+   Xilinx_Unified_2020.1_0602_1208_Lin64.bin: OK
     sha512sum: WARNING: 22 lines are improperly formatted
     ```
 
@@ -317,7 +316,7 @@ To get started faster we use the web installer in the following.
 3. Run the graphical installer.
 
     ```console
-    $ sh Xilinx_Vivado_SDK_Web_2018.3_1207_2324_Lin64.bin
+    $ sh Xilinx_Unified_2020.1_0602_1208_Lin64.bin
     ```
 
 4. Now you need to click through the installer.


### PR DESCRIPTION
Currently, the FPGA builds are done on legacy lowRISC infrastructure.
This PR moves it over to the same cloud-based infrastructure we use for
private CI. This infrastructure is based on containers in a Kubernetes
cluster, and provides better isolation and scaling properties than
before.