### PR TITLE
[kmac] Change !!CMD register to enum type

### DIFF
--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -177,41 +177,49 @@
              // design assertion : process can be set only after start is set
              "excl:CsrAllTests:CsrExclWrite"]
       fields: [
-        { bits: "0"
-          name: "start"
-          desc: '''If writes 1 into this field when KMAC/SHA3 is in idle,
-                KMAC/SHA3 begins its operation.
+        { bits: "3:0"
+          name: "cmd"
+          desc: '''Issue a command to the KMAC/SHA3 IP. To prevent sw from
+                writing multiple bits at once, the field is defined as enum.
+                '''
+          enum: [
+            { value: "1"
+              name: "start"
+              desc: '''If writes 1 into this field when KMAC/SHA3 is in idle,
+                    KMAC/SHA3 begins its operation.
 
-                If the mode is cSHAKE, before receiving the message, the
-                hashing logic processes Function name string N and
-                customization input string S first. If KMAC mode is enabled,
-                additionally it processes secret key block.
-                '''
-        } // f: start
-        { bits: "1"
-          name: "process"
-          desc: '''If writes 1 into this field when KMAC/SHA3 began its
-                operation and received the entire message, it computes the
-                digest or signing.
-                '''
-        } // f: process
-        { bits: "2"
-          name: "run"
-          desc: '''The `run` field is used in the sponge squeezing stage.
-                It triggers the keccak round logic to run full 24 rounds.
-                This is optional and used when software needs more digest bits
-                than the keccak rate.
+                    If the mode is cSHAKE, before receiving the message, the
+                    hashing logic processes Function name string N and
+                    customization input string S first. If KMAC mode is enabled,
+                    additionally it processes secret key block.
+                    '''
+            } // e: start
+            { value: "2"
+              name: "process"
+              desc: '''If writes 1 into this field when KMAC/SHA3 began its
+                    operation and received the entire message, it computes the
+                    digest or signing.
+                    '''
+            } // e: process
+            { value: "4"
+              name: "run"
+              desc: '''The `run` field is used in the sponge squeezing stage.
+                    It triggers the keccak round logic to run full 24 rounds.
+                    This is optional and used when software needs more digest
+                    bits than the keccak rate.
 
-                It only affects when the kmac/sha3 operation is completed.
-                '''
-        } // f: run
-        { bits: "3"
-          name: "done"
-          desc: '''If writes 1 into this field when KMAC/SHA3 squeezing is
-                completed. KMAC/SHA3 hashing engine clears internal varaibles
-                and goes back to Idle state for next command.
-                '''
-        } // f: done
+                    It only affects when the kmac/sha3 operation is completed.
+                    '''
+            } // e: run
+            { value: "8"
+              name: "done"
+              desc: '''If writes 1 into this field when KMAC/SHA3 squeezing is
+                    completed. KMAC/SHA3 hashing engine clears internal
+                    variables and goes back to Idle state for next command.
+                    '''
+            } // e: done
+          ] // enum
+        } // f: cmd
       ]
     } // R: CMD
     { name: "STATUS"

--- a/hw/ip/kmac/rtl/kmac_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_pkg.sv
@@ -190,6 +190,15 @@ package kmac_pkg;
     StFlush
   } sha3_st_e;
 
+  // kmac_cmd_e defines the possible command sets that software issues via
+  // !!CMD register. This is mainly to limit the error scenario that SW writes
+  // multiple commands at once.
+  typedef enum logic [3:0] {
+    CmdStart     = 4'b 0001,
+    CmdProcess   = 4'b 0010,
+    CmdManualRun = 4'b 0100,
+    CmdDone      = 4'b 1000
+  } kmac_cmd_e;
 
   //////////////////
   // Error Report //

--- a/hw/ip/kmac/rtl/kmac_reg_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_pkg.sv
@@ -71,22 +71,8 @@ package kmac_reg_pkg;
   } kmac_reg2hw_cfg_reg_t;
 
   typedef struct packed {
-    struct packed {
-      logic        q;
-      logic        qe;
-    } start;
-    struct packed {
-      logic        q;
-      logic        qe;
-    } process;
-    struct packed {
-      logic        q;
-      logic        qe;
-    } run;
-    struct packed {
-      logic        q;
-      logic        qe;
-    } done;
+    logic [3:0]  q;
+    logic        qe;
   } kmac_reg2hw_cmd_reg_t;
 
   typedef struct packed {
@@ -159,11 +145,11 @@ package kmac_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    kmac_reg2hw_intr_state_reg_t intr_state; // [1449:1447]
-    kmac_reg2hw_intr_enable_reg_t intr_enable; // [1446:1444]
-    kmac_reg2hw_intr_test_reg_t intr_test; // [1443:1438]
-    kmac_reg2hw_cfg_reg_t cfg; // [1437:1430]
-    kmac_reg2hw_cmd_reg_t cmd; // [1429:1422]
+    kmac_reg2hw_intr_state_reg_t intr_state; // [1446:1444]
+    kmac_reg2hw_intr_enable_reg_t intr_enable; // [1443:1441]
+    kmac_reg2hw_intr_test_reg_t intr_test; // [1440:1435]
+    kmac_reg2hw_cfg_reg_t cfg; // [1434:1427]
+    kmac_reg2hw_cmd_reg_t cmd; // [1426:1422]
     kmac_reg2hw_key_share0_mreg_t [15:0] key_share0; // [1421:894]
     kmac_reg2hw_key_share1_mreg_t [15:0] key_share1; // [893:366]
     kmac_reg2hw_key_len_reg_t key_len; // [365:363]

--- a/hw/ip/kmac/rtl/kmac_reg_top.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_top.sv
@@ -161,14 +161,8 @@ module kmac_reg_top (
   logic cfg_state_endianness_qs;
   logic cfg_state_endianness_wd;
   logic cfg_state_endianness_we;
-  logic cmd_start_wd;
-  logic cmd_start_we;
-  logic cmd_process_wd;
-  logic cmd_process_we;
-  logic cmd_run_wd;
-  logic cmd_run_we;
-  logic cmd_done_wd;
-  logic cmd_done_we;
+  logic [3:0] cmd_wd;
+  logic cmd_we;
   logic status_sha3_idle_qs;
   logic status_sha3_idle_re;
   logic status_sha3_absorb_qs;
@@ -626,62 +620,16 @@ module kmac_reg_top (
 
   // R[cmd]: V(True)
 
-  //   F[start]: 0:0
   prim_subreg_ext #(
-    .DW    (1)
-  ) u_cmd_start (
+    .DW    (4)
+  ) u_cmd (
     .re     (1'b0),
-    .we     (cmd_start_we),
-    .wd     (cmd_start_wd),
+    .we     (cmd_we),
+    .wd     (cmd_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.cmd.start.qe),
-    .q      (reg2hw.cmd.start.q ),
-    .qs     ()
-  );
-
-
-  //   F[process]: 1:1
-  prim_subreg_ext #(
-    .DW    (1)
-  ) u_cmd_process (
-    .re     (1'b0),
-    .we     (cmd_process_we),
-    .wd     (cmd_process_wd),
-    .d      ('0),
-    .qre    (),
-    .qe     (reg2hw.cmd.process.qe),
-    .q      (reg2hw.cmd.process.q ),
-    .qs     ()
-  );
-
-
-  //   F[run]: 2:2
-  prim_subreg_ext #(
-    .DW    (1)
-  ) u_cmd_run (
-    .re     (1'b0),
-    .we     (cmd_run_we),
-    .wd     (cmd_run_wd),
-    .d      ('0),
-    .qre    (),
-    .qe     (reg2hw.cmd.run.qe),
-    .q      (reg2hw.cmd.run.q ),
-    .qs     ()
-  );
-
-
-  //   F[done]: 3:3
-  prim_subreg_ext #(
-    .DW    (1)
-  ) u_cmd_done (
-    .re     (1'b0),
-    .we     (cmd_done_we),
-    .wd     (cmd_done_wd),
-    .d      ('0),
-    .qre    (),
-    .qe     (reg2hw.cmd.done.qe),
-    .q      (reg2hw.cmd.done.q ),
+    .qe     (reg2hw.cmd.qe),
+    .q      (reg2hw.cmd.q ),
     .qs     ()
   );
 
@@ -1821,17 +1769,8 @@ module kmac_reg_top (
   assign cfg_state_endianness_we = addr_hit[3] & reg_we & ~wr_err;
   assign cfg_state_endianness_wd = reg_wdata[9];
 
-  assign cmd_start_we = addr_hit[4] & reg_we & ~wr_err;
-  assign cmd_start_wd = reg_wdata[0];
-
-  assign cmd_process_we = addr_hit[4] & reg_we & ~wr_err;
-  assign cmd_process_wd = reg_wdata[1];
-
-  assign cmd_run_we = addr_hit[4] & reg_we & ~wr_err;
-  assign cmd_run_wd = reg_wdata[2];
-
-  assign cmd_done_we = addr_hit[4] & reg_we & ~wr_err;
-  assign cmd_done_wd = reg_wdata[3];
+  assign cmd_we = addr_hit[4] & reg_we & ~wr_err;
+  assign cmd_wd = reg_wdata[3:0];
 
   assign status_sha3_idle_re = addr_hit[5] && reg_re;
 
@@ -2011,10 +1950,7 @@ module kmac_reg_top (
       end
 
       addr_hit[4]: begin
-        reg_rdata_next[0] = '0;
-        reg_rdata_next[1] = '0;
-        reg_rdata_next[2] = '0;
-        reg_rdata_next[3] = '0;
+        reg_rdata_next[3:0] = '0;
       end
 
       addr_hit[5]: begin


### PR DESCRIPTION
This PR revises the KMAC CMD register. It previously has four fields. Each field represents the command controlling the SHA3 engine.
    
Now, it is revised to have one enum field which still has four bits. By changing to enum type, the logic guarantees that only one command can be issued to the design.