### PR TITLE
[kmac] Add KeyMgr sideload/ data interfaces

### DIFF
--- a/hw/ip/keymgr/rtl/keymgr_kmac_if.sv
+++ b/hw/ip/keymgr/rtl/keymgr_kmac_if.sv
@@ -174,6 +174,8 @@ module keymgr_kmac_if import keymgr_pkg::*;(
       StTxLast: begin
         valid = 1'b1;
 
+        // TODO: kmac_data_o.last set here
+
         if (adv_en_i) begin
           strb = AdvByteMask;
         end else if (id_en_i) begin
@@ -189,6 +191,7 @@ module keymgr_kmac_if import keymgr_pkg::*;(
 
       StOpWait: begin
         if (kmac_data_i.done) begin
+          // TODO: kmac_data_i.error check here.
           done_o = 1'b1;
           state_d = StClean;
         end

--- a/hw/ip/keymgr/rtl/keymgr_pkg.sv
+++ b/hw/ip/keymgr/rtl/keymgr_pkg.sv
@@ -113,6 +113,9 @@ package keymgr_pkg;
     logic valid;
     logic [KmacDataIfWidth-1:0] data;
     logic [KmacDataIfWidth/8-1:0] strb;
+    // last indicates the last beat of the data. strb can be partial only with
+    // last.
+    logic last;
   } kmac_data_req_t;
 
   typedef struct packed {
@@ -120,13 +123,24 @@ package keymgr_pkg;
     logic done;
     logic [KeyWidth-1:0] digest_share0;
     logic [KeyWidth-1:0] digest_share1;
+    // Error is valid when done is high. If any error occurs during KDF, KMAC
+    // returns the garbage digest data with error. The KeyMgr discards the
+    // digest and may re-initiate the process.
+    logic error;
   } kmac_data_rsp_t;
 
+  parameter kmac_data_req_t KMAC_DATA_REQ_DEFAULT = '{
+    valid: 1'b 0,
+    data: '0,
+    strb: '0,
+    last: 1'b 0
+  };
   parameter kmac_data_rsp_t KMAC_DATA_RSP_DEFAULT = '{
     ready: 1'b1,
     done:  1'b1,
     digest_share0: KeyWidth'(32'hDEADBEEF),
-    digest_share1: KeyWidth'(32'hFACEBEEF)
+    digest_share1: KeyWidth'(32'hFACEBEEF),
+    error: 1'b1
   };
 
   // The following structs should be sourced from other modules

--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -58,6 +58,20 @@
       local:   "true"
     }
   ]
+  inter_signal_list: [
+    { struct:  "hw_key_req"
+      type:    "uni"
+      name:    "keymgr_key"
+      act:     "rcv"
+      package: "keymgr_pkg"
+    }
+    { struct:  "kmac_data"
+      type:    "req_rsp"
+      name:    "keymgr_kdf"
+      act:     "rsp"
+      package: "keymgr_pkg"
+    }
+  ]
   regwidth: "32"
   registers: [
     { name: "CFG"

--- a/hw/ip/kmac/kmac.core
+++ b/hw/ip/kmac/kmac.core
@@ -11,6 +11,7 @@ filesets:
       - lowrisc:prim:prim_dom_and_2share
       - lowrisc:prim:assert
       - lowrisc:ip:tlul
+      - lowrisc:ip:keymgr_pkg
     files:
       - rtl/kmac_pkg.sv
       - rtl/keccak_round.sv

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -25,9 +25,12 @@ module kmac
   input  tlul_pkg::tl_h2d_t tl_i,
   output tlul_pkg::tl_d2h_t tl_o,
 
-  // TODO: KeyMgr sideload (secret key) interface
+  // KeyMgr sideload (secret key) interface
+  input keymgr_pkg::hw_key_req_t keymgr_key_i,
 
-  // TODO: KeyMgr KDF data path
+  // KeyMgr KDF data path
+  input  keymgr_pkg::kmac_data_req_t keymgr_kdf_i,
+  output keymgr_pkg::kmac_data_rsp_t keymgr_kdf_o,
 
   // TODO: CSRNG (EDN) interface
 
@@ -238,6 +241,14 @@ module kmac
   end
 
   assign key_len = key_len_e'(reg2hw.key_len.q);
+
+  // TODO: Implement KeyMgr interface module. As of now, tying them to default value
+  assign keymgr_kdf_o = '{
+    ready: 1'b 0,
+    digest_share0: '0,
+    digest_share1: '0,
+    done: 1'b 0
+  };
 
   ///////////////
   // Interrupt //


### PR DESCRIPTION
KMAC has a feature that KeyMgr can initiates the KDF operation. To achieve this, KeyMgr and KMAC have defined the `kmac_data_req/rsp_t` interface (`typedef struct packed`) as an inter module signal form.

This PR is to add the KeyMgr interfaces including the sideloaded secret keys in KMAC/SHA3 HWIP.

This PR has the content of PR #3676 . Please take a look at the last commit only.