### PR TITLE
Add hier_path to list of optional keys in validate.py

### DIFF
--- a/util/reggen/gen_selfdoc.py
+++ b/util/reggen/gen_selfdoc.py
@@ -208,11 +208,20 @@ def doc_tbl_head(outfile, use):
 
 def doc_tbl_line(outfile, key, use, desc):
     if use is not None:
-        genout(
-            outfile, key + " | " + validate.key_use[use] + " | " +
-            validate.val_types[desc[0]][0] + " | " + desc[1] + "\n")
+        desc_key, desc_txt = desc
+        val_type = (validate.val_types[desc_key][0]
+                    if desc_key is not None else None)
     else:
-        genout(outfile, key + " | " + desc + "\n")
+        assert isinstance(desc, str)
+        val_type = None
+        desc_txt = desc
+
+    if val_type is not None:
+        genout(outfile,
+               '{} | {} | {} | {}\n'
+               .format(key, validate.key_use[use], val_type, desc_txt))
+    else:
+        genout(outfile, key + " | " + desc_txt + "\n")
 
 
 def document(outfile):

--- a/util/reggen/validate.py
+++ b/util/reggen/validate.py
@@ -206,17 +206,18 @@ def check_keys(obj, required_keys, optional_keys, added_keys, err_prefix):
             error += 1
             log.error(err_prefix + " missing required key " + x)
     for x in obj:
-        type = ''
+        type = None
         if x in required_keys:
             type = required_keys[x][0]
         elif x in optional_keys:
             type = optional_keys[x][0]
         elif x not in added_keys:
             log.warning(err_prefix + " contains extra key " + x)
-        if type[:2] == 'ln':
-            error += check_ln(obj, x, type == 'lnw', err_prefix)
-        if type == 'lp':
-            error += check_lp(obj, x, err_prefix)
+        if type is not None:
+            if type[:2] == 'ln':
+                error += check_ln(obj, x, type == 'lnw', err_prefix)
+            if type == 'lp':
+                error += check_lp(obj, x, err_prefix)
 
     return error
 
@@ -343,7 +344,9 @@ top_optional = {
         "Only use this if unable to put this "
         "information in a comment at the top of the "
         "file."
-    ]
+    ],
+    'hier_path': [None,
+                  'additional hierarchy path before the reg block instance']
 }
 top_added = {
     'genrnames': ['pl', "list of register names"],


### PR DESCRIPTION
This adds hier_path as an optional key in validate.py, silencing a
reggen warning. Since we probably don't want to include it in
documentation, this teaches various bits of doc generation to cope
with a "None" index.

Fixes #3732.