### PR TITLE
[otbn, dv] Add an initial DV plan for OTBN

### DIFF
--- a/hw/ip/otbn/data/otbn_testplan.hjson
+++ b/hw/ip/otbn/data/otbn_testplan.hjson
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  name: "otbn"
+  // TODO: remove the common testplans if not applicable
+  import_testplans: ["hw/dv/tools/testplans/csr_testplan.hjson",
+                     "hw/dv/tools/testplans/mem_testplan.hjson",
+                     "hw/dv/tools/testplans/intr_test_testplan.hjson",
+                     "hw/dv/tools/testplans/tl_device_access_types_testplan.hjson"]
+  entries: [
+    {
+      name: sanity
+      desc: '''
+            Basic sanity test acessing a major datapath within the otbn.
+
+            **Stimulus**:
+            - TBD
+
+            **Checks**:
+            - TBD
+            '''
+      milestone: V1
+      tests: ["otbn_sanity"]
+    }
+    {
+      name: feature1
+      desc: '''Add more test entries here like above.'''
+      milestone: V1
+      tests: []
+    }
+  ]
+}

--- a/hw/ip/otbn/doc/dv_plan/index.md
+++ b/hw/ip/otbn/doc/dv_plan/index.md
@@ -1,0 +1,108 @@
+---
+title: "OTBN DV Plan"
+---
+
+<!-- Copy this file to hw/ip/otbn/doc/otbn_dv_plan.md and make changes as needed.
+For convenience 'otbn' in the document can be searched and replaced easily with the
+desired IP (with case sensitivity!). Also, use the testbench block diagram
+located at OpenTitan team drive / 'design verification'
+as a starting point and modify it to reflect your otbn testbench and save it
+to hw/ip/otbn/doc/tb.svg. It should get linked and rendered under the block
+diagram section below. Please update / modify / remove sections below as
+applicable. Once done, remove this comment before making a PR. -->
+
+## Goals
+* **DV**
+  * Verify all OTBN IP features by running dynamic simulations with a SV/UVM based testbench
+  * Develop and run all tests based on the [testplan](#testplan) below towards closing code and functional coverage on the IP and all of its sub-modules
+* **FPV**
+  * Verify TileLink device protocol compliance with an SVA based testbench
+
+## Current status
+* [Design & verification stage]({{< relref "hw" >}})
+  * [HW development stages]({{< relref "doc/project/development_stages" >}})
+* [Simulation results](https://reports.opentitan.org/hw/ip/otbn/dv/latest/results.html)
+
+## Design features
+For detailed information on OTBN design features, please see the [OTBN HWIP technical specification]({{< relref "hw/ip/otbn/doc" >}}).
+
+## Testbench architecture
+OTBN testbench has been constructed based on the [CIP testbench architecture]({{< relref "hw/dv/sv/cip_lib/doc" >}}).
+
+### Block diagram
+![Block diagram](tb.svg)
+
+### Top level testbench
+Top level testbench is located at `hw/ip/otbn/dv/uvm/tb.sv`. It instantiates the OTBN DUT module `hw/ip/otbn/rtl/otbn.sv`.
+In addition, it instantiates the following interfaces, connects them to the DUT and sets their handle into `uvm_config_db`:
+* [Clock and reset interface]({{< relref "hw/dv/sv/common_ifs" >}})
+* [TileLink host interface]({{< relref "hw/dv/sv/tl_agent/README.md" >}})
+* OTBN IOs
+* Interrupts ([`pins_if`]({{< relref "hw/dv/sv/common_ifs" >}})
+* Alerts ([`pins_if`]({{< relref "hw/dv/sv/common_ifs" >}})
+* Devmode ([`pins_if`]({{< relref "hw/dv/sv/common_ifs" >}})
+
+### Common DV utility components
+The following utilities provide generic helper tasks and functions to perform activities that are common across the project:
+* [dv_utils_pkg]({{< relref "hw/dv/sv/dv_utils/README.md" >}})
+* [csr_utils_pkg]({{< relref "hw/dv/sv/csr_utils/README.md" >}})
+
+### Compile-time configurations
+[list compile time configurations, if any and what are they used for]
+
+### Global types & methods
+All common types and methods defined at the package level can be found in
+`otbn_env_pkg`. Some of them in use are:
+```systemverilog
+[list a few parameters, types & methods; no need to mention all]
+```
+### UVC/agent 1
+[Describe here or add link to its README]
+
+### UVC/agent 2
+[Describe here or add link to its README]
+
+### Reference models
+[Describe reference models in use if applicable, example: SHA256/HMAC]
+
+### Stimulus strategy
+#### Test sequences
+All test sequences reside in `hw/ip/otbn/dv/uvm/env/seq_lib`.
+The `otbn_base_vseq` virtual sequence is extended from `cip_base_vseq` and serves as a starting point.
+All test sequences are extended from `otbn_base_vseq`.
+It provides commonly used handles, variables, functions and tasks that the test sequences can simple use / call.
+Some of the most commonly used tasks / functions are as follows:
+* task 1:
+* task 2:
+
+#### Functional coverage
+To ensure high quality constrained random stimulus, it is necessary to develop a functional coverage model.
+The following covergroups have been developed to prove that the test intent has been adequately met:
+* cg1:
+* cg2:
+
+### Self-checking strategy
+#### Scoreboard
+The `otbn_scoreboard` is primarily used for end to end checking.
+It creates the following analysis ports to retrieve the data monitored by corresponding interface agents:
+* analysis port1:
+* analysis port2:
+<!-- explain inputs monitored, flow of data and outputs checked -->
+
+#### Assertions
+* TLUL assertions: The `tb/otbn_bind.sv` binds the `tlul_assert` [assertions]({{< relref "hw/ip/tlul/doc/TlulProtocolChecker.md" >}}) to the IP to ensure TileLink interface protocol compliance.
+* Unknown checks on DUT outputs: The RTL has assertions to ensure all outputs are initialized to known values after coming out of reset.
+* assert prop 1:
+* assert prop 2:
+
+## Building and running tests
+We are using our in-house developed [regression tool]({{< relref "hw/dv/tools/README.md" >}}) for building and running our tests and regressions.
+Please take a look at the link for detailed information on the usage, capabilities, features and known issues.
+Here's how to run a basic sanity test:
+```console
+$ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson -i otbn_sanity
+```
+
+## Testplan
+<!-- TODO: uncomment the line below after adding the testplan -->
+{{</* testplan "hw/ip/otbn/data/otbn_testplan.hjson" */>}}

--- a/hw/ip/otbn/doc/dv_plan/index.md
+++ b/hw/ip/otbn/doc/dv_plan/index.md
@@ -2,19 +2,11 @@
 title: "OTBN DV Plan"
 ---
 
-<!-- Copy this file to hw/ip/otbn/doc/otbn_dv_plan.md and make changes as needed.
-For convenience 'otbn' in the document can be searched and replaced easily with the
-desired IP (with case sensitivity!). Also, use the testbench block diagram
-located at OpenTitan team drive / 'design verification'
-as a starting point and modify it to reflect your otbn testbench and save it
-to hw/ip/otbn/doc/tb.svg. It should get linked and rendered under the block
-diagram section below. Please update / modify / remove sections below as
-applicable. Once done, remove this comment before making a PR. -->
-
 ## Goals
 * **DV**
-  * Verify all OTBN IP features by running dynamic simulations with a SV/UVM based testbench
-  * Develop and run all tests based on the [testplan](#testplan) below towards closing code and functional coverage on the IP and all of its sub-modules
+  * Verify the OTBN processor by running dynamic simulations with a SV/UVM based testbench
+  * These simulations are grouped in tests listed in the [testplan](#testplan) below.
+  * Close code and functional coverage on the IP and all of its sub-modules
 * **FPV**
   * Verify TileLink device protocol compliance with an SVA based testbench
 
@@ -24,83 +16,123 @@ applicable. Once done, remove this comment before making a PR. -->
 * [Simulation results](https://reports.opentitan.org/hw/ip/otbn/dv/latest/results.html)
 
 ## Design features
-For detailed information on OTBN design features, please see the [OTBN HWIP technical specification]({{< relref "hw/ip/otbn/doc" >}}).
+
+OTBN, the OpenTitan Big Number accelerator, is a cryptographic accelerator.
+For detailed information on OTBN design features, see the [OTBN HWIP technical specification]({{< relref "hw/ip/otbn/doc" >}}).
 
 ## Testbench architecture
-OTBN testbench has been constructed based on the [CIP testbench architecture]({{< relref "hw/dv/sv/cip_lib/doc" >}}).
+
+The OTBN testbench is based on the [CIP testbench architecture]({{< relref "hw/dv/sv/cip_lib/doc" >}}).
+It builds on the [dv_utils]({{< relref "hw/dv/sv/dv_utils/README.md" >}}) and [csr_utils]({{< relref "hw/dv/sv/csr_utils/README.md" >}}) packages.
 
 ### Block diagram
+
+OTBN testing makes use of a DPI-based model called `otbn_core_model`.
+This is shown in the block diagram.
+The dotted interfaces in the `otbn` block are bound in by the model to access internal signals (register file and memory contents).
+
 ![Block diagram](tb.svg)
 
 ### Top level testbench
-Top level testbench is located at `hw/ip/otbn/dv/uvm/tb.sv`. It instantiates the OTBN DUT module `hw/ip/otbn/rtl/otbn.sv`.
-In addition, it instantiates the following interfaces, connects them to the DUT and sets their handle into `uvm_config_db`:
-* [Clock and reset interface]({{< relref "hw/dv/sv/common_ifs" >}})
-* [TileLink host interface]({{< relref "hw/dv/sv/tl_agent/README.md" >}})
-* OTBN IOs
-* Interrupts ([`pins_if`]({{< relref "hw/dv/sv/common_ifs" >}})
-* Alerts ([`pins_if`]({{< relref "hw/dv/sv/common_ifs" >}})
-* Devmode ([`pins_if`]({{< relref "hw/dv/sv/common_ifs" >}})
 
-### Common DV utility components
-The following utilities provide generic helper tasks and functions to perform activities that are common across the project:
-* [dv_utils_pkg]({{< relref "hw/dv/sv/dv_utils/README.md" >}})
-* [csr_utils_pkg]({{< relref "hw/dv/sv/csr_utils/README.md" >}})
+The top-level testbench is located at `hw/ip/otbn/dv/uvm/tb.sv`.
+This instantiates the OTBN DUT module `hw/ip/otbn/rtl/otbn.sv`.
 
-### Compile-time configurations
-[list compile time configurations, if any and what are they used for]
+OTBN has the following interfaces:
+- A [Clock and reset interface]({{< relref "hw/dv/sv/common_ifs#clk_rst_if" >}})
+- A [TileLink interface]({{< relref "hw/dv/sv/tl_agent/README.md" >}}).
+  OTBN is a TL device, which expects to communicate with a TL host.
+  In the OpenTitan SoC, this will be the Ibex core.
+- An idle signal, `idle_o`
+- Two interrupts
+- An [alert interface]({{< relref "hw/dv/sv/alert_esc_agent/README" >}})
 
-### Global types & methods
-All common types and methods defined at the package level can be found in
-`otbn_env_pkg`. Some of them in use are:
-```systemverilog
-[list a few parameters, types & methods; no need to mention all]
-```
-### UVC/agent 1
-[Describe here or add link to its README]
+The idle and interrupt signals are modelled with the basic
+[`pins_if`]({{< relref "hw/dv/sv/common_ifs#pins_if" >}}) interface.
 
-### UVC/agent 2
-[Describe here or add link to its README]
+As well as instantiating OTBN, the testbench also instantiates an `otbn_core_model`.
+This module wraps an ISS (instruction set simulator) subprocess and performs checks to make sure that OTBN behaves the same as the ISS.
+It has a single output signal that goes high when there's a mismatch with the model.
+Since this should never go high, the testbench contains an assertion saying it is always low.
+
+### otbn_agent
+
+There is a single agent, called `otbn_agent`.
+This is in charge of driving `tl_if`, the TileLink interface to start and stop OTBN.
+It also monitors `alert_if`, `int_if` and `idle_if` for changes in state.
 
 ### Reference models
-[Describe reference models in use if applicable, example: SHA256/HMAC]
+
+The main reference model for OTBN is the instruction set simulator (ISS), which is run as a subprocess by DPI code inside `otbn_core_model`.
+This Python-based simulator can be found at `hw/ip/otbn/dv/otbnsim`.
 
 ### Stimulus strategy
+
+When testing OTBN, we are careful to distinguish between
+
+- behaviour that can be triggered by particular instruction streams
+- behaviour that is triggered by particular external stimuli (register writes; surprise resets etc.)
+
+Testing lots of different instruction streams doesn't really use the UVM machinery, so we have a "pre-DV" phase of testing that generates constrained-random instruction streams (as ELF binaries) and runs a simple block-level simulation on each to check that the RTL matches the model.
+The idea is that this is much quicker for designers to use to sanity-test proposed changes, and can be run with Verilator, so it doesn't require an EDA tool licence.
+This pre-DV phase cannot drive sign-off, but it does use much of the same tooling.
+
+Once we are running full DV tests, we re-use this work, by using the same collection of randomised instruction streams and randomly picking from them for most of the sequences.
+The ELF binaries are all placed in a single directory and named sequentially (`0.elf`, `1.elf`, ..., `1234.elf` or similar).
+This directory and the maximum index are passed to the simulation with plusargs.
+
+<div class="bd-callout bd-callout-warning">
+
+**TODO:** There's a bit of infrastructure work to do here to teach `dvsim.py` to run the instruction generator. Also, maybe it would be better to pass a list of ELF files (which would let us filter the initial generation for things that hit coverage points in pre-DV). This design might change slightly.
+
+</div>
+
+The pre-DV testing doesn't address external stimuli like resets or TileLink-based register accesses.
+These are driven by specialised test sequences, described below.
+
 #### Test sequences
-All test sequences reside in `hw/ip/otbn/dv/uvm/env/seq_lib`.
-The `otbn_base_vseq` virtual sequence is extended from `cip_base_vseq` and serves as a starting point.
-All test sequences are extended from `otbn_base_vseq`.
-It provides commonly used handles, variables, functions and tasks that the test sequences can simple use / call.
-Some of the most commonly used tasks / functions are as follows:
-* task 1:
-* task 2:
+
+The test sequences can be found in `hw/ip/otbn/dv/uvm/env/seq_lib`.
+The basic test sequence (`otbn_base_vseq`) loads the instruction stream from a randomly chosen binary (see above), configures OTBN and then lets it run to completion.
+
+More specialized sequences include things like multiple runs, register accesses during operation (which should fail) and memory corruption.
+We also check things like the correct operation of the interrupt registers.
 
 #### Functional coverage
-To ensure high quality constrained random stimulus, it is necessary to develop a functional coverage model.
-The following covergroups have been developed to prove that the test intent has been adequately met:
-* cg1:
-* cg2:
+
+<div class="bd-callout bd-callout-warning">
+
+**TODO**: Functional coverage points are not yet defined.
+
+</div>
+
 
 ### Self-checking strategy
 #### Scoreboard
-The `otbn_scoreboard` is primarily used for end to end checking.
-It creates the following analysis ports to retrieve the data monitored by corresponding interface agents:
-* analysis port1:
-* analysis port2:
-<!-- explain inputs monitored, flow of data and outputs checked -->
+
+Much of the checking for these tests is actually performed in `otbn_core_model`, which ensures that the RTL and ISS have the same behaviour.
+However, the scoreboard does have some checks, to ensure that interrupt and idle signals are high at the expected times.
 
 #### Assertions
-* TLUL assertions: The `tb/otbn_bind.sv` binds the `tlul_assert` [assertions]({{< relref "hw/ip/tlul/doc/TlulProtocolChecker.md" >}}) to the IP to ensure TileLink interface protocol compliance.
-* Unknown checks on DUT outputs: The RTL has assertions to ensure all outputs are initialized to known values after coming out of reset.
-* assert prop 1:
-* assert prop 2:
+
+Core TLUL protocol assertions are checked by binding the [TL-UL protocol checker]({{< relref "hw/ip/tlul/doc/TlulProtocolChecker.md" >}}) into the design.
+
+Outputs are also checked for `'X` values by assertions in the design RTL.
+The design RTL contains other assertions defined by the designers, which will be checked in simulation (and won't have been checked by the pre-DV Verilator simulations).
+
+<div class="bd-callout bd-callout-warning">
+
+**TODO**: Define other SVA checks. A protocol check for the alert interface? Are there any properties that should hold relating interrupt and idle signals?
+
+</div>
 
 ## Building and running tests
-We are using our in-house developed [regression tool]({{< relref "hw/dv/tools/README.md" >}}) for building and running our tests and regressions.
-Please take a look at the link for detailed information on the usage, capabilities, features and known issues.
-Here's how to run a basic sanity test:
+
+Tests can be run with [`dvsim.py`]({{< relref "hw/dv/tools/README.md" >}}).
+The link gives details of the tool's features and command line arguments.
+To run a basic sanity test, go to the top of the repository and run:
 ```console
-$ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson -i otbn_sanity
+$ util/dvsim/dvsim.py hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson -i otbn_sanity
 ```
 
 ## Testplan

--- a/hw/ip/otbn/doc/dv_plan/tb.svg
+++ b/hw/ip/otbn/doc/dv_plan/tb.svg
@@ -1,0 +1,1580 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="1029.02"
+   height="973.72717"
+   fill="none"
+   stroke-linecap="square"
+   stroke-miterlimit="10"
+   version="1.1"
+   viewBox="0 0 1029.02 973.72715"
+   id="svg1209"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs835">
+    <rect
+       x="-297.9502"
+       y="658.20032"
+       width="290.82916"
+       height="55.29501"
+       id="rect1331" />
+    <rect
+       x="-230.9109"
+       y="542.1825"
+       width="519.57452"
+       height="330.1489"
+       id="rect1240" />
+    <marker
+       id="marker1910"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         fill="#000000"
+         fill-rule="evenodd"
+         stroke="#000000"
+         stroke-width="1pt"
+         id="path823" />
+    </marker>
+    <marker
+       id="marker1078"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         fill="#000000"
+         fill-rule="evenodd"
+         stroke="#000000"
+         stroke-width="1pt"
+         id="path826" />
+    </marker>
+    <marker
+       id="marker1029"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         fill="#000000"
+         fill-rule="evenodd"
+         stroke="#000000"
+         stroke-width="1pt"
+         id="path829" />
+    </marker>
+    <marker
+       id="Arrow1Lend"
+       overflow="visible"
+       orient="auto">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         fill="#000000"
+         fill-rule="evenodd"
+         stroke="#000000"
+         stroke-width="1pt"
+         id="path832" />
+    </marker>
+  </defs>
+  <clipPath
+     id="clipPath839">
+    <path
+       d="M 0,0 H 1086 V 817 H 0 Z"
+       id="path837" />
+  </clipPath>
+  <rect
+     x="563.52002"
+     y="186.67685"
+     width="465"
+     height="630"
+     rx="0"
+     ry="0"
+     color="#000000"
+     color-rendering="auto"
+     fill="#dad2ea"
+     fill-rule="evenodd"
+     image-rendering="auto"
+     shape-rendering="auto"
+     solid-color="#000000"
+     stroke="#000000"
+     stroke-linecap="butt"
+     stroke-miterlimit="10"
+     style="isolation:auto;mix-blend-mode:normal"
+     id="rect841" />
+  <g
+     fill-opacity="0"
+     id="g855"
+     transform="translate(0,186.17684)">
+    <path
+       d="m 389.76,497.24 c 0,12.499 -57.798,51.23 -103.76,24.998 -45.962,-26.232 -80.086,-117.42 -103.76,-208.62 -23.674,-91.192 -36.897,-182.38 -61.956,-208.62 -25.06,-26.232 -61.956,12.495 -61.956,24.991"
+       id="path843" />
+    <path
+       d="m 231.69,278.45 c 12.518,0 12.829,64.179 25.036,121.9 12.208,57.719 36.312,108.98 66.521,121.9 30.209,12.921 66.521,-12.496 66.521,-24.992"
+       id="path845" />
+    <path
+       d="m 231.69,210.06 c 12.518,0 12.829,82.416 25.036,156.09 12.207,73.674 36.312,138.61 66.521,156.09 30.209,17.478 66.521,-12.502 66.521,-25.005"
+       id="path847" />
+    <path
+       d="m 557.73,2.0176 h 454.08 v 244.03 H 557.73 Z"
+       id="path849" />
+    <path
+       d="m 555.27,250.1 h 458.99 V 487.39 H 555.27 Z"
+       id="path851" />
+    <path
+       d="m 389.76,497.24 c 0,12.501 -36.311,47.041 -66.519,25.002 -30.207,-22.039 -54.311,-100.66 -66.519,-190.3 -12.208,-89.638 -12.521,-190.3 -25.041,-190.3"
+       id="path853" />
+  </g>
+  <g
+     stroke-linecap="butt"
+     id="g871"
+     transform="translate(0,186.17684)">
+    <rect
+       x="0.5"
+       y="0.5"
+       width="530"
+       height="631.28998"
+       rx="40"
+       ry="40"
+       color="#000000"
+       color-rendering="auto"
+       fill="#fff8e3"
+       fill-rule="evenodd"
+       image-rendering="auto"
+       shape-rendering="auto"
+       solid-color="#000000"
+       stroke="#000000"
+       stroke-miterlimit="10"
+       style="isolation:auto;mix-blend-mode:normal"
+       id="rect857" />
+    <rect
+       x="10.5"
+       y="73.699997"
+       width="240"
+       height="300.17001"
+       rx="25"
+       ry="25"
+       color="#000000"
+       color-rendering="auto"
+       fill="#fff2cc"
+       fill-rule="evenodd"
+       image-rendering="auto"
+       shape-rendering="auto"
+       solid-color="#000000"
+       stroke="#000000"
+       stroke-miterlimit="10"
+       style="isolation:auto;mix-blend-mode:normal"
+       id="rect859" />
+    <text
+       x="264.93945"
+       y="32.595211"
+       fill="#f18080"
+       font-family="'Liberation Sans'"
+       font-size="18.667px"
+       letter-spacing="0px"
+       stroke-width="1px"
+       text-align="center"
+       text-anchor="middle"
+       word-spacing="0px"
+       style="line-height:20px"
+       xml:space="preserve"
+       id="text863"><tspan
+         x="264.93945"
+         y="32.595211"
+         fill="#000000"
+         id="tspan861">otbn_base_test</tspan></text>
+    <rect
+       x="280.5"
+       y="73.699997"
+       width="240"
+       height="300.17001"
+       rx="25"
+       ry="25"
+       color="#000000"
+       color-rendering="auto"
+       fill="#ffe599"
+       fill-rule="evenodd"
+       image-rendering="auto"
+       shape-rendering="auto"
+       solid-color="#000000"
+       stroke="#000000"
+       stroke-miterlimit="10"
+       style="isolation:auto;mix-blend-mode:normal"
+       id="rect865" />
+    <text
+       x="400.48169"
+       y="107.04469"
+       fill="#f18080"
+       font-family="'Liberation Sans'"
+       font-size="18.667px"
+       letter-spacing="0px"
+       stroke-width="1px"
+       text-align="center"
+       text-anchor="middle"
+       word-spacing="0px"
+       style="line-height:20px"
+       xml:space="preserve"
+       id="text869"><tspan
+         x="400.48169"
+         y="107.04469"
+         fill="#000000"
+         id="tspan867">otbn_env_cfg</tspan></text>
+  </g>
+  <g
+     transform="translate(205.5,112.87684)"
+     stroke-linecap="butt"
+     id="g879">
+    <rect
+       x="80"
+       y="205.67999"
+       width="230"
+       height="36.323002"
+       rx="10"
+       ry="10"
+       color="#000000"
+       color-rendering="auto"
+       fill="#f4cccc"
+       fill-rule="evenodd"
+       image-rendering="auto"
+       shape-rendering="auto"
+       solid-color="#000000"
+       stroke="#000000"
+       stroke-miterlimit="10"
+       style="isolation:auto;mix-blend-mode:normal"
+       id="rect873" />
+    <text
+       x="194.49219"
+       y="228.39612"
+       fill="#000000"
+       font-family="'Liberation Sans'"
+       font-size="16px"
+       letter-spacing="0px"
+       stroke-width="1px"
+       text-align="center"
+       text-anchor="middle"
+       word-spacing="0px"
+       style="line-height:20px"
+       xml:space="preserve"
+       id="text877"><tspan
+         x="194.49219"
+         y="228.39612"
+         id="tspan875">otbn_core_if</tspan></text>
+  </g>
+  <g
+     transform="translate(210.5,146.17984)"
+     stroke-linecap="butt"
+     id="g887">
+    <rect
+       x="75"
+       y="355.67999"
+       width="230"
+       height="36.323002"
+       rx="10"
+       ry="10"
+       color="#000000"
+       color-rendering="auto"
+       fill="#d9ead3"
+       fill-rule="evenodd"
+       image-rendering="auto"
+       shape-rendering="auto"
+       solid-color="#000000"
+       stroke="#000000"
+       stroke-miterlimit="10"
+       style="isolation:auto;mix-blend-mode:normal"
+       id="rect881" />
+    <text
+       x="189.98438"
+       y="378.39615"
+       fill="#000000"
+       font-family="'Liberation Sans'"
+       font-size="16px"
+       letter-spacing="0px"
+       stroke-width="1px"
+       text-align="center"
+       text-anchor="middle"
+       word-spacing="0px"
+       style="line-height:20px"
+       xml:space="preserve"
+       id="text885"><tspan
+         x="189.98438"
+         y="378.39615"
+         id="tspan883">otbn_agent_cfg</tspan></text>
+  </g>
+  <g
+     id="g1133"
+     transform="translate(0,186.17684)">
+    <rect
+       x="285.5"
+       y="177.37999"
+       width="230"
+       height="36.323002"
+       rx="10"
+       ry="10"
+       color="#000000"
+       color-rendering="auto"
+       fill="#f4cccc"
+       fill-rule="evenodd"
+       image-rendering="auto"
+       shape-rendering="auto"
+       solid-color="#000000"
+       stroke="#000000"
+       stroke-miterlimit="10"
+       style="isolation:auto;mix-blend-mode:normal;stroke-linecap:butt"
+       id="rect889" />
+    <text
+       x="399.99219"
+       y="200.09612"
+       fill="#000000"
+       font-family="'Liberation Sans'"
+       font-size="16px"
+       letter-spacing="0px"
+       stroke-width="1px"
+       text-align="center"
+       text-anchor="middle"
+       word-spacing="0px"
+       style="line-height:20px;stroke-linecap:butt"
+       xml:space="preserve"
+       id="text893"><tspan
+         x="399.99219"
+         y="200.09612"
+         id="tspan891">otbn_mem_if</tspan></text>
+  </g>
+  <g
+     transform="translate(205.5,202.87684)"
+     stroke-linecap="butt"
+     id="g903">
+    <rect
+       x="80"
+       y="205.67999"
+       width="230"
+       height="36.323002"
+       rx="10"
+       ry="10"
+       color="#000000"
+       color-rendering="auto"
+       fill="#f4cccc"
+       fill-rule="evenodd"
+       image-rendering="auto"
+       shape-rendering="auto"
+       solid-color="#000000"
+       stroke="#000000"
+       stroke-miterlimit="10"
+       style="isolation:auto;mix-blend-mode:normal"
+       id="rect897" />
+    <text
+       x="194.49219"
+       y="228.39612"
+       fill="#000000"
+       font-family="'Liberation Sans'"
+       font-size="16px"
+       letter-spacing="0px"
+       stroke-width="1px"
+       text-align="center"
+       text-anchor="middle"
+       word-spacing="0px"
+       style="line-height:20px"
+       xml:space="preserve"
+       id="text901"><tspan
+         x="194.49219"
+         y="228.39612"
+         id="tspan899">clk_reset_if</tspan></text>
+  </g>
+  <text
+     x="43.516396"
+     y="686.67682"
+     fill="#000000"
+     font-family="'Liberation Sans'"
+     font-size="17.333px"
+     letter-spacing="0px"
+     stroke-linecap="butt"
+     stroke-width="1px"
+     text-align="center"
+     text-anchor="middle"
+     word-spacing="0px"
+     style="line-height:20px"
+     xml:space="preserve"
+     id="text907"><tspan
+       x="43.516396"
+       y="686.67682"
+       id="tspan905" /></text>
+  <flowRoot
+     transform="translate(-36.484,139.67684)"
+     fill="#000000"
+     font-family="'Liberation Sans'"
+     font-size="14.667px"
+     letter-spacing="0px"
+     stroke-linecap="butt"
+     stroke-width="1px"
+     word-spacing="0px"
+     style="line-height:20px"
+     xml:space="preserve"
+     id="flowRoot915"><flowRegion
+       id="flowRegion911"><rect
+         x="80"
+         y="537"
+         width="440"
+         height="120"
+         id="rect909" /></flowRegion><flowPara
+       id="flowPara913" /></flowRoot>
+  <g
+     transform="translate(-59.5,158.08084)"
+     id="g947">
+    <path
+       d="m 70,447 h 470 l 40,50 V 617 H 70 Z"
+       fill="#cfe2f3"
+       fill-rule="evenodd"
+       stroke="#000000"
+       id="path917" />
+    <g
+       fill="#000000"
+       font-family="'Liberation Sans'"
+       letter-spacing="0px"
+       stroke-linecap="butt"
+       stroke-width="1px"
+       word-spacing="0px"
+       id="g937">
+      <text
+         x="90"
+         y="471.74084"
+         font-size="17.333px"
+         style="line-height:20px"
+         xml:space="preserve"
+         id="text921"><tspan
+           x="90"
+           y="471.74084"
+           id="tspan919">run_phase:</tspan></text>
+      <text
+         x="90"
+         y="497.8609"
+         font-size="14.667px"
+         style="line-height:20px"
+         xml:space="preserve"
+         id="text935"><tspan
+           x="90"
+           y="497.8609"
+           id="tspan925"><tspan
+             x="90"
+             y="497.8609"
+             id="tspan923">In the UVM run phase, the dv_base_test class (from which the </tspan></tspan><tspan
+           x="90"
+           y="517.8609"
+           id="tspan929"><tspan
+             x="90"
+             y="517.8609"
+             id="tspan927">otbn_base_test class derives) creates and runs the sequence </tspan></tspan><tspan
+           x="90"
+           y="537.8609"
+           id="tspan933"><tspan
+             x="90"
+             y="537.8609"
+             id="tspan931">named by the +UVM_TEST_SEQ plusarg.</tspan></tspan></text>
+    </g>
+    <g
+       stroke-linecap="butt"
+       id="g945">
+      <rect
+         x="90"
+         y="557"
+         width="470"
+         height="39.939999"
+         rx="20"
+         ry="15.181"
+         color="#000000"
+         color-rendering="auto"
+         fill="#fff3cd"
+         fill-rule="evenodd"
+         image-rendering="auto"
+         shape-rendering="auto"
+         solid-color="#000000"
+         stroke="#000000"
+         stroke-miterlimit="10"
+         style="isolation:auto;mix-blend-mode:normal"
+         id="rect939" />
+      <text
+         x="324.9772"
+         y="581.76636"
+         fill="#000000"
+         font-family="'Liberation Sans'"
+         font-size="18.667px"
+         letter-spacing="0px"
+         stroke-width="1px"
+         text-align="center"
+         text-anchor="middle"
+         word-spacing="0px"
+         style="line-height:20px"
+         xml:space="preserve"
+         id="text943"><tspan
+           x="324.9772"
+           y="581.76636"
+           id="tspan941">otbn_base_vseq</tspan></text>
+    </g>
+  </g>
+  <text
+     x="8.2500267"
+     y="15.458092"
+     fill="#000000"
+     font-family="'Liberation Sans'"
+     font-size="18.667px"
+     letter-spacing="0px"
+     stroke-linecap="butt"
+     stroke-width="1px"
+     text-align="center"
+     text-anchor="middle"
+     word-spacing="0px"
+     style="line-height:20px"
+     xml:space="preserve"
+     id="text951"><tspan
+       x="8.2500267"
+       y="15.458092"
+       font-size="21.333px"
+       text-align="start"
+       text-anchor="start"
+       id="tspan949">Legend:</tspan></text>
+  <g
+     fill="none"
+     stroke="#000000"
+     stroke-dasharray="1, 2"
+     stroke-linecap="butt"
+     stroke-miterlimit="10"
+     id="g961"
+     transform="translate(0,186.17684)">
+    <path
+       d="m 280.5,108.7 c -15,0 -35,30 -35,30"
+       id="path953" />
+    <path
+       d="m 280.5,108.7 c -15,0 -35,75 -35,75"
+       id="path955" />
+    <path
+       d="m 280.5,108.7 c -15,0 -35,120 -35,120"
+       id="path957" />
+    <path
+       d="m 280.5,108.7 c -15,0 -30,10 -30,10"
+       id="path959" />
+  </g>
+  <g
+     transform="translate(-10,188.90884)"
+     stroke-linecap="butt"
+     id="g969">
+    <rect
+       x="590.5"
+       y="107.79"
+       width="136.17"
+       height="35"
+       color="#000000"
+       color-rendering="auto"
+       fill="#fce6ce"
+       fill-rule="evenodd"
+       image-rendering="auto"
+       shape-rendering="auto"
+       solid-color="#000000"
+       stroke="#000000"
+       stroke-miterlimit="10"
+       style="isolation:auto;mix-blend-mode:normal"
+       id="rect963" />
+    <text
+       x="658.44318"
+       y="129.84575"
+       fill="#000000"
+       font-family="'Liberation Sans'"
+       font-size="17.333px"
+       letter-spacing="0px"
+       stroke-width="1px"
+       text-align="center"
+       text-anchor="middle"
+       word-spacing="0px"
+       style="line-height:20px"
+       xml:space="preserve"
+       id="text967"><tspan
+         x="658.44318"
+         y="129.84575"
+         id="tspan965">tl_if</tspan></text>
+  </g>
+  <g
+     transform="translate(-10,188.90884)"
+     stroke-linecap="butt"
+     id="g977">
+    <rect
+       x="590.5"
+       y="60.5"
+       width="136.17"
+       height="35"
+       color="#000000"
+       color-rendering="auto"
+       fill="#fce6ce"
+       fill-rule="evenodd"
+       image-rendering="auto"
+       shape-rendering="auto"
+       solid-color="#000000"
+       stroke="#000000"
+       stroke-miterlimit="10"
+       style="isolation:auto;mix-blend-mode:normal"
+       id="rect971" />
+    <text
+       x="658.20618"
+       y="82.557625"
+       fill="#000000"
+       font-family="'Liberation Sans'"
+       font-size="17.333px"
+       letter-spacing="0px"
+       stroke-width="1px"
+       text-align="center"
+       text-anchor="middle"
+       word-spacing="0px"
+       style="line-height:20px"
+       xml:space="preserve"
+       id="text975"><tspan
+         x="658.20618"
+         y="82.557625"
+         id="tspan973">clk_rst_if</tspan></text>
+  </g>
+  <text
+     x="795.39844"
+     y="218.77205"
+     fill="#000000"
+     font-family="'Liberation Sans'"
+     font-size="17.333px"
+     letter-spacing="0px"
+     stroke-linecap="butt"
+     stroke-width="1px"
+     text-align="center"
+     text-anchor="middle"
+     word-spacing="0px"
+     style="line-height:20px"
+     xml:space="preserve"
+     id="text981"><tspan
+       x="795.39844"
+       y="218.77205"
+       id="tspan979">tb.sv</tspan></text>
+  <text
+     transform="scale(1.0069088,0.99313864)"
+     x="130.15814"
+     y="294.70496"
+     fill="#f18080"
+     font-family="'Liberation Sans'"
+     font-size="18.6668px"
+     letter-spacing="0px"
+     stroke-linecap="butt"
+     stroke-width="0.999991px"
+     text-align="center"
+     text-anchor="middle"
+     word-spacing="0px"
+     style="line-height:19.8623px"
+     xml:space="preserve"
+     id="text985"><tspan
+       x="130.15814"
+       y="294.70496"
+       fill="#000000"
+       stroke-width="0.999991px"
+       id="tspan983">otbn_env</tspan></text>
+  <g
+     transform="translate(-64.5,112.87684)"
+     stroke-linecap="butt"
+     id="g993">
+    <rect
+       x="80"
+       y="205.67999"
+       width="230"
+       height="36.323002"
+       rx="10"
+       ry="10"
+       color="#000000"
+       color-rendering="auto"
+       fill="#ffe599"
+       fill-rule="evenodd"
+       image-rendering="auto"
+       shape-rendering="auto"
+       solid-color="#000000"
+       stroke="#000000"
+       stroke-miterlimit="10"
+       style="isolation:auto;mix-blend-mode:normal"
+       id="rect987" />
+    <text
+       x="194.49219"
+       y="228.39612"
+       fill="#000000"
+       font-family="'Liberation Sans'"
+       font-size="16px"
+       letter-spacing="0px"
+       stroke-width="1px"
+       text-align="center"
+       text-anchor="middle"
+       word-spacing="0px"
+       style="line-height:20px"
+       xml:space="preserve"
+       id="text991"><tspan
+         x="194.49219"
+         y="228.39612"
+         id="tspan989">otbn_env_cov</tspan></text>
+  </g>
+  <g
+     transform="translate(-64.5,116.55384)"
+     stroke-linecap="butt"
+     id="g1001">
+    <rect
+       x="80"
+       y="247"
+       width="230"
+       height="36.323002"
+       rx="10"
+       ry="10"
+       color="#000000"
+       color-rendering="auto"
+       fill="#ffe599"
+       fill-rule="evenodd"
+       image-rendering="auto"
+       shape-rendering="auto"
+       solid-color="#000000"
+       stroke="#000000"
+       stroke-miterlimit="10"
+       style="isolation:auto;mix-blend-mode:normal"
+       id="rect995" />
+    <text
+       x="194.98438"
+       y="269.71912"
+       fill="#000000"
+       font-family="'Liberation Sans'"
+       font-size="16px"
+       letter-spacing="0px"
+       stroke-width="1px"
+       text-align="center"
+       text-anchor="middle"
+       word-spacing="0px"
+       style="line-height:20px"
+       xml:space="preserve"
+       id="text999"><tspan
+         x="194.98438"
+         y="269.71912"
+         id="tspan997">otbn_scoreboard</tspan></text>
+  </g>
+  <g
+     transform="translate(-64.5,121.55384)"
+     stroke-linecap="butt"
+     id="g1009">
+    <rect
+       x="80"
+       y="287"
+       width="230"
+       height="36.323002"
+       rx="10"
+       ry="10"
+       color="#000000"
+       color-rendering="auto"
+       fill="#ffe599"
+       fill-rule="evenodd"
+       image-rendering="auto"
+       shape-rendering="auto"
+       solid-color="#000000"
+       stroke="#000000"
+       stroke-miterlimit="10"
+       style="isolation:auto;mix-blend-mode:normal"
+       id="rect1003" />
+    <text
+       x="194.98438"
+       y="309.71912"
+       fill="#000000"
+       font-family="'Liberation Sans'"
+       font-size="16px"
+       letter-spacing="0px"
+       stroke-width="1px"
+       text-align="center"
+       text-anchor="middle"
+       word-spacing="0px"
+       style="line-height:20px"
+       xml:space="preserve"
+       id="text1007"><tspan
+         x="194.98438"
+         y="309.71912"
+         id="tspan1005">otbn_virtual_sequencer</tspan></text>
+  </g>
+  <g
+     transform="translate(-59.5,144.85684)"
+     stroke-linecap="butt"
+     id="g1017">
+    <rect
+       x="75"
+       y="355.67999"
+       width="230"
+       height="36.323002"
+       rx="10"
+       ry="10"
+       color="#000000"
+       color-rendering="auto"
+       fill="#d9ead3"
+       fill-rule="evenodd"
+       image-rendering="auto"
+       shape-rendering="auto"
+       solid-color="#000000"
+       stroke="#000000"
+       stroke-miterlimit="10"
+       style="isolation:auto;mix-blend-mode:normal"
+       id="rect1011" />
+    <text
+       x="189.98438"
+       y="378.39615"
+       fill="#000000"
+       font-family="'Liberation Sans'"
+       font-size="16px"
+       letter-spacing="0px"
+       stroke-width="1px"
+       text-align="center"
+       text-anchor="middle"
+       word-spacing="0px"
+       style="line-height:20px"
+       xml:space="preserve"
+       id="text1015"><tspan
+         x="189.98438"
+         y="378.39615"
+         id="tspan1013">otbn_agent</tspan></text>
+  </g>
+  <g
+     transform="translate(-10,188.90884)"
+     stroke-linecap="butt"
+     id="g1063">
+    <rect
+       x="590.5"
+       y="155.08"
+       width="136.17"
+       height="35"
+       color="#000000"
+       color-rendering="auto"
+       fill="#fce6ce"
+       fill-rule="evenodd"
+       image-rendering="auto"
+       shape-rendering="auto"
+       solid-color="#000000"
+       stroke="#000000"
+       stroke-miterlimit="10"
+       style="isolation:auto;mix-blend-mode:normal"
+       id="rect1057" />
+    <text
+       x="658.20618"
+       y="177.13387"
+       fill="#000000"
+       font-family="'Liberation Sans'"
+       font-size="17.333px"
+       letter-spacing="0px"
+       stroke-width="1px"
+       text-align="center"
+       text-anchor="middle"
+       word-spacing="0px"
+       style="line-height:20px"
+       xml:space="preserve"
+       id="text1061"><tspan
+         x="658.20618"
+         y="177.13387"
+         id="tspan1059">alert_if</tspan></text>
+  </g>
+  <g
+     transform="translate(-10,188.90884)"
+     stroke-linecap="butt"
+     id="g1071">
+    <rect
+       x="590.5"
+       y="249.64999"
+       width="136.17"
+       height="35"
+       color="#000000"
+       color-rendering="auto"
+       fill="#fce6ce"
+       fill-rule="evenodd"
+       image-rendering="auto"
+       shape-rendering="auto"
+       solid-color="#000000"
+       stroke="#000000"
+       stroke-miterlimit="10"
+       style="isolation:auto;mix-blend-mode:normal"
+       id="rect1065" />
+    <text
+       x="657.99457"
+       y="271.71008"
+       fill="#000000"
+       font-family="'Liberation Sans'"
+       font-size="17.333px"
+       letter-spacing="0px"
+       stroke-width="1px"
+       text-align="center"
+       text-anchor="middle"
+       word-spacing="0px"
+       style="line-height:20px"
+       xml:space="preserve"
+       id="text1069"><tspan
+         x="657.99457"
+         y="271.71008"
+         id="tspan1067">idle_if</tspan></text>
+  </g>
+  <g
+     transform="translate(-10,188.90884)"
+     stroke-linecap="butt"
+     id="g1079">
+    <rect
+       x="590.5"
+       y="202.36"
+       width="136.17"
+       height="35"
+       color="#000000"
+       color-rendering="auto"
+       fill="#fce6ce"
+       fill-rule="evenodd"
+       image-rendering="auto"
+       shape-rendering="auto"
+       solid-color="#000000"
+       stroke="#000000"
+       stroke-miterlimit="10"
+       style="isolation:auto;mix-blend-mode:normal"
+       id="rect1073" />
+    <text
+       x="657.99457"
+       y="224.42198"
+       fill="#000000"
+       font-family="'Liberation Sans'"
+       font-size="17.333px"
+       letter-spacing="0px"
+       stroke-width="1px"
+       text-align="center"
+       text-anchor="middle"
+       word-spacing="0px"
+       style="line-height:20px"
+       xml:space="preserve"
+       id="text1077"><tspan
+         x="657.99457"
+         y="224.42198"
+         id="tspan1075">int_if</tspan></text>
+  </g>
+  <g
+     fill-rule="evenodd"
+     stroke="#000000"
+     stroke-linecap="butt"
+     stroke-width="1px"
+     id="g1091"
+     transform="translate(0,186.17684)">
+    <path
+       d="m 723.16,128.02 10,-15 v 10 h 24.605 v -10 l 10,15 -10,15 v -10 H 733.16 v 10 z"
+       fill="#ffffff"
+       id="path1081" />
+    <path
+       d="m 723.16,80.732 h 42.738"
+       fill="#000000"
+       marker-end="url(#marker1029)"
+       id="path1083" />
+    <path
+       d="m 723.16,175.31 10,-15 v 10 h 24.605 v -10 l 10,15 -10,15 v -10 H 733.16 v 10 z"
+       fill="#ffffff"
+       id="path1085" />
+    <path
+       d="M 767.77,269.88 H 725.107"
+       fill="#000000"
+       marker-end="url(#Arrow1Lend)"
+       id="path1087" />
+    <path
+       d="M 767.77,222.6 H 725.107"
+       fill="#000000"
+       marker-end="url(#marker1078)"
+       id="path1089" />
+  </g>
+  <g
+     stroke-linecap="butt"
+     id="g1159"
+     transform="translate(0,186.17684)">
+    <rect
+       x="774.26001"
+       y="61.200001"
+       width="239.25999"
+       height="439.29999"
+       color="#000000"
+       color-rendering="auto"
+       fill="#ffffff"
+       fill-rule="evenodd"
+       image-rendering="auto"
+       shape-rendering="auto"
+       solid-color="#000000"
+       stroke="#000000"
+       stroke-miterlimit="10"
+       style="isolation:auto;mix-blend-mode:normal"
+       id="rect1093" />
+    <text
+       x="892.6748"
+       y="104.98247"
+       fill="#000000"
+       font-family="'Liberation Sans'"
+       font-size="17.333px"
+       letter-spacing="0px"
+       stroke-width="1px"
+       text-align="center"
+       text-anchor="middle"
+       word-spacing="0px"
+       style="line-height:20px"
+       xml:space="preserve"
+       id="text1097"><tspan
+         x="892.6748"
+         y="104.98247"
+         id="tspan1095">otbn</tspan></text>
+    <g
+       stroke-miterlimit="10"
+       id="g1125">
+      <rect
+         x="828.52002"
+         y="145.5"
+         width="170"
+         height="150"
+         color="#000000"
+         fill="#ffe8fe"
+         fill-rule="evenodd"
+         stop-color="#000000"
+         stroke="#000000"
+         style="font-variation-settings:normal"
+         id="rect1099" />
+      <g
+         stroke-width="1.0016"
+         id="g1109">
+        <rect
+           x="838.52002"
+           y="185.5"
+           width="150"
+           height="45"
+           color="#000000"
+           fill="#cee8fc"
+           fill-rule="evenodd"
+           stop-color="#000000"
+           stroke="#000000"
+           stroke-dasharray="1.00157, 2.00314"
+           style="font-variation-settings:normal"
+           id="rect1101" />
+        <text
+           transform="translate(27.265,24.119)"
+           x="886.3244"
+           y="176.75005"
+           dominant-baseline="auto"
+           fill="#000000"
+           font-family="'Liberation Sans'"
+           font-size="17.333px"
+           letter-spacing="0px"
+           stop-color="#000000"
+           text-align="center"
+           text-anchor="middle"
+           word-spacing="0px"
+           style="line-height:20px;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0"
+           xml:space="preserve"
+           id="text1107"><tspan
+             x="886.3244"
+             y="176.75005"
+             id="tspan1103">u_snooper</tspan><tspan
+             x="886.3244"
+             y="196.75005"
+             id="tspan1105">(GPR file)</tspan></text>
+      </g>
+      <g
+         stroke-width="1.0016"
+         id="g1119">
+        <rect
+           x="838.52002"
+           y="240.5"
+           width="150"
+           height="45"
+           color="#000000"
+           fill="#cee8fc"
+           fill-rule="evenodd"
+           stop-color="#000000"
+           stroke="#000000"
+           stroke-dasharray="1.00157, 2.00314"
+           style="font-variation-settings:normal"
+           id="rect1111" />
+        <text
+           transform="translate(27.265,79.119)"
+           x="886.3244"
+           y="176.75005"
+           dominant-baseline="auto"
+           fill="#000000"
+           font-family="'Liberation Sans'"
+           font-size="17.333px"
+           letter-spacing="0px"
+           stop-color="#000000"
+           text-align="center"
+           text-anchor="middle"
+           word-spacing="0px"
+           style="line-height:20px;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0"
+           xml:space="preserve"
+           id="text1117"><tspan
+             x="886.3244"
+             y="176.75005"
+             id="tspan1113">u_snooper</tspan><tspan
+             x="886.3244"
+             y="196.75005"
+             id="tspan1115">(WDR file)</tspan></text>
+      </g>
+      <text
+         transform="translate(30.452,44.604)"
+         x="882.41827"
+         y="120.72346"
+         dominant-baseline="auto"
+         fill="#000000"
+         font-family="'Liberation Sans'"
+         font-size="17.333px"
+         letter-spacing="0px"
+         stop-color="#000000"
+         stroke-width="1px"
+         text-align="center"
+         text-anchor="middle"
+         word-spacing="0px"
+         style="line-height:20px;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0"
+         xml:space="preserve"
+         id="text1123"><tspan
+           x="882.41827"
+           y="120.72346"
+           id="tspan1121">u_otbn_core</tspan></text>
+    </g>
+    <g
+       stroke-miterlimit="10"
+       id="g1141">
+      <rect
+         x="828.52002"
+         y="310.5"
+         width="170"
+         height="80.620003"
+         color="#000000"
+         fill="#ffe8fe"
+         fill-rule="evenodd"
+         stop-color="#000000"
+         stroke="#000000"
+         style="font-variation-settings:normal"
+         id="rect1127" />
+      <text
+         transform="translate(30.452,209.11)"
+         x="882.41827"
+         y="120.72346"
+         dominant-baseline="auto"
+         fill="#000000"
+         font-family="'Liberation Sans'"
+         font-size="17.333px"
+         letter-spacing="0px"
+         stop-color="#000000"
+         stroke-width="1px"
+         text-align="center"
+         text-anchor="middle"
+         word-spacing="0px"
+         style="line-height:20px;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0"
+         xml:space="preserve"
+         id="text1131"><tspan
+           x="882.41827"
+           y="120.72346"
+           id="tspan1129">u_imem</tspan></text>
+      <g
+         transform="matrix(1.019,0,0,1,-29.298,49.244)"
+         id="g1139">
+        <rect
+           x="851.63"
+           y="296.26001"
+           width="147.2"
+           height="35"
+           color="#000000"
+           fill="#cee8fc"
+           fill-rule="evenodd"
+           stop-color="#000000"
+           stroke="#000000"
+           stroke-dasharray="0.992184, 1.98437"
+           stroke-width="0.99218"
+           style="font-variation-settings:normal"
+           id="rect1133" />
+        <text
+           transform="translate(38.902,141.49)"
+           x="886.3244"
+           y="176.75005"
+           dominant-baseline="auto"
+           fill="#000000"
+           font-family="'Liberation Sans'"
+           font-size="17.333px"
+           letter-spacing="0px"
+           stop-color="#000000"
+           stroke-width="0.99063px"
+           text-align="center"
+           text-anchor="middle"
+           word-spacing="0px"
+           style="line-height:20px;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0"
+           xml:space="preserve"
+           id="text1137"><tspan
+             x="886.3244"
+             y="176.75005"
+             stroke-width="0.99063px"
+             id="tspan1135">(DPI access)</tspan></text>
+      </g>
+    </g>
+    <g
+       stroke-miterlimit="10"
+       id="g1157">
+      <rect
+         x="828.52002"
+         y="405.5"
+         width="170"
+         height="80"
+         color="#000000"
+         fill="#ffe8fe"
+         fill-rule="evenodd"
+         stop-color="#000000"
+         stroke="#000000"
+         style="font-variation-settings:normal"
+         id="rect1143" />
+      <text
+         transform="translate(30.452,303.49)"
+         x="882.41827"
+         y="120.72346"
+         dominant-baseline="auto"
+         fill="#000000"
+         font-family="'Liberation Sans'"
+         font-size="17.333px"
+         letter-spacing="0px"
+         stop-color="#000000"
+         stroke-width="1px"
+         text-align="center"
+         text-anchor="middle"
+         word-spacing="0px"
+         style="line-height:20px;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0"
+         xml:space="preserve"
+         id="text1147"><tspan
+           x="882.41827"
+           y="120.72346"
+           id="tspan1145">u_dmem</tspan></text>
+      <g
+         transform="matrix(1.019,0,0,1,-29.298,49.53)"
+         id="g1155">
+        <rect
+           x="851.63"
+           y="390.97"
+           width="147.2"
+           height="35"
+           color="#000000"
+           fill="#cee8fc"
+           fill-rule="evenodd"
+           stop-color="#000000"
+           stroke="#000000"
+           stroke-dasharray="0.992184, 1.98437"
+           stroke-width="0.99218"
+           style="font-variation-settings:normal"
+           id="rect1149" />
+        <text
+           transform="translate(38.902,236.21)"
+           x="886.3244"
+           y="176.75005"
+           dominant-baseline="auto"
+           fill="#000000"
+           font-family="'Liberation Sans'"
+           font-size="17.333px"
+           letter-spacing="0px"
+           stop-color="#000000"
+           stroke-width="0.99063px"
+           text-align="center"
+           text-anchor="middle"
+           word-spacing="0px"
+           style="line-height:20px;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0"
+           xml:space="preserve"
+           id="text1153"><tspan
+             x="886.3244"
+             y="176.75005"
+             stroke-width="0.99063px"
+             id="tspan1151">(DPI access)</tspan></text>
+      </g>
+    </g>
+  </g>
+  <rect
+     x="773.52002"
+     y="701.67682"
+     width="240"
+     height="90"
+     color="#000000"
+     color-rendering="auto"
+     fill="#ffffff"
+     fill-rule="evenodd"
+     image-rendering="auto"
+     shape-rendering="auto"
+     solid-color="#000000"
+     stroke="#000000"
+     stroke-linecap="butt"
+     stroke-miterlimit="10"
+     style="isolation:auto;mix-blend-mode:normal"
+     id="rect1161" />
+  <text
+     transform="translate(27.151,189.63414)"
+     x="865.44354"
+     y="559.55121"
+     dominant-baseline="auto"
+     fill="#000000"
+     font-family="'Liberation Sans'"
+     font-size="17.333px"
+     letter-spacing="0px"
+     stop-color="#000000"
+     stroke-linecap="butt"
+     stroke-miterlimit="10"
+     stroke-width="1px"
+     text-align="center"
+     text-anchor="middle"
+     word-spacing="0px"
+     style="line-height:20px;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0"
+     xml:space="preserve"
+     id="text1165"><tspan
+       x="865.44354"
+       y="559.55121"
+       id="tspan1163">otbn_core_model</tspan></text>
+  <text
+     transform="translate(19.640625,859.6457)"
+     x="-12.809546"
+     fill="#000000"
+     font-family="'Liberation Sans'"
+     font-size="16px"
+     letter-spacing="0px"
+     stroke-linecap="butt"
+     stroke-width="1px"
+     word-spacing="0px"
+     style="line-height:18.4615px;white-space:pre;shape-inside:url(#rect2085)"
+     xml:space="preserve"
+     id="text1207"><tspan
+       x="0"
+       y="0"><tspan
+         style="shape-inside:url(#rect1653)">Many classes have handles (always called cfg) to the test's 
+</tspan></tspan><tspan
+       x="0"
+       y="18.4615"><tspan
+         style="shape-inside:url(#rect1653)">otbn_env_cfg object. To denote this, those classes are </tspan><tspan
+         style="shape-inside:url(#rect1653)">connected by a
+</tspan></tspan><tspan
+       x="0"
+       y="36.923"><tspan
+         style="shape-inside:url(#rect1653)">dotted line to the otbn_env_cfg class.
+</tspan></tspan><tspan
+       x="0"
+       y="55.384501"><tspan
+         style="shape-inside:url(#rect1653)">
+</tspan></tspan><tspan
+       x="0"
+       y="73.846001"><tspan
+         style="shape-inside:url(#rect1653)">The virtual sequence object created in the run phase has a 
+</tspan></tspan><tspan
+       x="0"
+       y="92.307501"><tspan
+         style="shape-inside:url(#rect1653)">p_sequencer handle to the otbn_virtual_sequencer inside </tspan><tspan
+         style="shape-inside:url(#rect1653)">the environment
+</tspan></tspan><tspan
+       x="0"
+       y="110.769"><tspan
+         style="shape-inside:url(#rect1653)">(not shown).
+</tspan></tspan></text>
+  <text
+     xml:space="preserve"
+     id="text1329"
+     style="font-size:26.6667px;line-height:20px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:center;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect1331);fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     transform="translate(0,186.17684)" />
+  <text
+     xml:space="preserve"
+     style="font-size:14.6667px;line-height:15px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="381.45059"
+     y="72.469238"
+     id="text1070"><tspan
+       x="381.45059"
+       y="72.469238"
+       id="tspan1082"
+       style="font-size:14.6667px">Nesting shows fields in classes, so there is an object of type</tspan><tspan
+       x="381.45059"
+       y="87.469238"
+       id="tspan1084"
+       style="font-size:14.6667px">otbn_env inside the object of type otbn_base_test.</tspan><tspan
+       x="381.45059"
+       y="102.46924"
+       style="font-size:14.6667px"
+       id="tspan1364" /><tspan
+       x="381.45059"
+       y="117.46924"
+       style="font-size:14.6667px"
+       id="tspan1366">The color of the box for a class shows the base class. For </tspan><tspan
+       x="381.45059"
+       y="132.46924"
+       id="tspan1086"
+       style="font-size:14.6667px">example, interfaces are pink; agents are green.</tspan></text>
+  <g
+     id="g1376"
+     transform="translate(360,-48.823158)">
+    <g
+       id="g1318">
+      <rect
+         x="-330"
+         y="95"
+         width="35"
+         height="25"
+         rx="6.9096456"
+         ry="6.8383126"
+         color="#000000"
+         color-rendering="auto"
+         fill="#ffe599"
+         fill-rule="evenodd"
+         image-rendering="auto"
+         shape-rendering="auto"
+         solid-color="#000000"
+         stroke="#000000"
+         stroke-miterlimit="10"
+         style="font-variation-settings:normal;opacity:1;isolation:auto;mix-blend-mode:normal;vector-effect:none;fill:#d9ead3;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect1197" />
+      <rect
+         x="-335"
+         y="90"
+         width="35"
+         height="25"
+         rx="6.9096456"
+         ry="6.8383126"
+         color="#000000"
+         color-rendering="auto"
+         fill="#ffe599"
+         fill-rule="evenodd"
+         image-rendering="auto"
+         shape-rendering="auto"
+         solid-color="#000000"
+         stroke="#000000"
+         stroke-miterlimit="10"
+         style="font-variation-settings:normal;opacity:1;isolation:auto;mix-blend-mode:normal;vector-effect:none;fill:#f4cccc;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect1184" />
+      <rect
+         x="-340"
+         y="85"
+         width="35"
+         height="25"
+         rx="6.9096456"
+         ry="6.8383126"
+         color="#000000"
+         color-rendering="auto"
+         fill="#ffe599"
+         fill-rule="evenodd"
+         image-rendering="auto"
+         shape-rendering="auto"
+         solid-color="#000000"
+         stroke="#000000"
+         stroke-miterlimit="10"
+         style="isolation:auto;mix-blend-mode:normal;stroke-width:1.00001;stroke-linecap:butt"
+         id="rect1094" />
+      <text
+         x="-322.5"
+         y="98.355469"
+         fill="#000000"
+         font-family="'Liberation Sans'"
+         font-size="16px"
+         letter-spacing="0px"
+         stroke-width="1px"
+         text-align="center"
+         text-anchor="middle"
+         word-spacing="0px"
+         style="line-height:20px;stroke-linecap:butt"
+         xml:space="preserve"
+         id="text1098"><tspan
+           x="-322.5"
+           y="98.355469"
+           id="tspan1096">...</tspan></text>
+    </g>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.6667px;line-height:15px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       x="-270"
+       y="200"
+       id="text1278"
+       transform="translate(-10.461954,-93.708002)"><tspan
+         id="tspan1276"
+         x="-270"
+         y="200">SV classes (UVM; dynamically created)</tspan></text>
+  </g>
+  <g
+     id="g1387"
+     transform="translate(360,-48.823158)">
+    <g
+       id="g1325">
+      <rect
+         x="-330"
+         y="140"
+         width="35"
+         height="25"
+         color="#000000"
+         color-rendering="auto"
+         fill="#fce6ce"
+         fill-rule="evenodd"
+         image-rendering="auto"
+         shape-rendering="auto"
+         solid-color="#000000"
+         stroke="#000000"
+         stroke-miterlimit="10"
+         style="font-variation-settings:normal;opacity:1;isolation:auto;mix-blend-mode:normal;vector-effect:none;fill:#cee8fc;fill-opacity:1;stroke:#000000;stroke-width:1.00156;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:1.00157, 2.00313;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect1251" />
+      <rect
+         x="-335"
+         y="135"
+         width="35"
+         height="25"
+         color="#000000"
+         color-rendering="auto"
+         fill="#fce6ce"
+         fill-rule="evenodd"
+         image-rendering="auto"
+         shape-rendering="auto"
+         solid-color="#000000"
+         stroke="#000000"
+         stroke-miterlimit="10"
+         style="font-variation-settings:normal;opacity:1;isolation:auto;mix-blend-mode:normal;vector-effect:none;fill:#ffe8fe;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+         id="rect1221" />
+      <rect
+         x="-340"
+         y="130"
+         width="35"
+         height="25"
+         color="#000000"
+         color-rendering="auto"
+         fill="#fce6ce"
+         fill-rule="evenodd"
+         image-rendering="auto"
+         shape-rendering="auto"
+         solid-color="#000000"
+         stroke="#000000"
+         stroke-miterlimit="10"
+         style="isolation:auto;mix-blend-mode:normal;stroke-width:0.999996;stroke-linecap:butt"
+         id="rect1159" />
+      <text
+         x="-322.5"
+         y="143.35547"
+         fill="#000000"
+         font-family="'Liberation Sans'"
+         font-size="16px"
+         letter-spacing="0px"
+         stroke-width="1px"
+         text-align="center"
+         text-anchor="middle"
+         word-spacing="0px"
+         style="line-height:20px;stroke-linecap:butt"
+         xml:space="preserve"
+         id="text1212"><tspan
+           x="-322.5"
+           y="143.35547"
+           id="tspan1210">...</tspan></text>
+    </g>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.6667px;line-height:15px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       x="-270"
+       y="200"
+       id="text1309"
+       transform="translate(-10.461954,-54.757409)"><tspan
+         id="tspan1307"
+         x="-270"
+         y="200">SV modules / interfaces (static)</tspan><tspan
+         x="-270"
+         y="215"
+         id="tspan1311">Dotted boxes are bound-in interfaces.</tspan></text>
+  </g>
+  <g
+     id="g1392"
+     transform="translate(360,-48.823158)">
+    <path
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:#cfe2f3;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       d="m -335,180 h 25 l 10,10 v 15 h -35 z"
+       id="path1327" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14.6667px;line-height:15px;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+       x="-270"
+       y="200"
+       id="text1342"
+       transform="translate(-10.461954,-3.7079991)"><tspan
+         id="tspan1340"
+         x="-270"
+         y="200">Code block (a UVM phase)</tspan></text>
+  </g>
+</svg>

--- a/hw/ip/otbn/dv/uvm/env/otbn_env.core
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env.core
@@ -1,0 +1,28 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:otbn_env:0.1"
+description: "OTBN DV UVM environment"
+filesets:
+  files_dv:
+    depend:
+      - lowrisc:dv:dv_lib
+    files:
+      - otbn_env_pkg.sv
+      - otbn_env_cfg.sv: {is_include_file: true}
+      - otbn_env_cov.sv: {is_include_file: true}
+      - otbn_virtual_sequencer.sv: {is_include_file: true}
+      - otbn_scoreboard.sv: {is_include_file: true}
+      - otbn_env.sv: {is_include_file: true}
+      - seq_lib/otbn_vseq_list.sv: {is_include_file: true}
+      - seq_lib/otbn_base_vseq.sv: {is_include_file: true}
+      - seq_lib/otbn_common_vseq.sv: {is_include_file: true}
+      - seq_lib/otbn_sanity_vseq.sv: {is_include_file: true}
+    file_type: systemVerilogSource
+
+
+targets:
+  default:
+    filesets:
+      - files_dv

--- a/hw/ip/otbn/dv/uvm/env/otbn_env.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env.sv
@@ -1,0 +1,23 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class otbn_env extends dv_base_env #(
+    .CFG_T              (otbn_env_cfg),
+    .COV_T              (otbn_env_cov),
+    .VIRTUAL_SEQUENCER_T(otbn_virtual_sequencer),
+    .SCOREBOARD_T       (otbn_scoreboard)
+  );
+  `uvm_component_utils(otbn_env)
+
+  `uvm_component_new
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+  endfunction
+
+  function void connect_phase(uvm_phase phase);
+    super.connect_phase(phase);
+  endfunction
+
+endclass

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cfg.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cfg.sv
@@ -1,0 +1,18 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class otbn_env_cfg extends dv_base_env_cfg;
+
+  // ext component cfgs
+
+  `uvm_object_utils_begin(otbn_env_cfg)
+  `uvm_object_utils_end
+
+  `uvm_object_new
+
+
+  virtual function void initialize(bit [31:0] csr_base_addr = '1);
+  endfunction
+
+endclass

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
@@ -1,0 +1,30 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Covergoups that are dependent on run-time parameters that may be available
+ * only in build_phase can be defined here
+ * Covergroups may also be wrapped inside helper classes if needed.
+ */
+
+class otbn_env_cov extends dv_base_env_cov #(.CFG_T(otbn_env_cfg));
+  `uvm_component_utils(otbn_env_cov)
+
+  // the base class provides the following handles for use:
+  // otbn_env_cfg: cfg
+
+  // covergroups
+  // [add covergroups here]
+
+  function new(string name, uvm_component parent);
+    super.new(name, parent);
+    // [instantiate covergroups here]
+  endfunction : new
+
+  virtual function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    // [or instantiate covergroups here]
+  endfunction
+
+endclass

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_pkg.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_pkg.sv
@@ -1,0 +1,31 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package otbn_env_pkg;
+  // dep packages
+  import uvm_pkg::*;
+  import top_pkg::*;
+  import dv_utils_pkg::*;
+  import dv_lib_pkg::*;
+
+  // macro includes
+  `include "uvm_macros.svh"
+  `include "dv_macros.svh"
+
+  // parameters
+
+  // types
+  typedef dv_base_reg_block otbn_reg_block;
+
+  // functions
+
+  // package sources
+  `include "otbn_env_cfg.sv"
+  `include "otbn_env_cov.sv"
+  `include "otbn_virtual_sequencer.sv"
+  `include "otbn_scoreboard.sv"
+  `include "otbn_env.sv"
+  `include "otbn_vseq_list.sv"
+
+endpackage

--- a/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
@@ -1,0 +1,43 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class otbn_scoreboard extends dv_base_scoreboard #(
+    .CFG_T(otbn_env_cfg),
+    .COV_T(otbn_env_cov)
+  );
+  `uvm_component_utils(otbn_scoreboard)
+
+  // local variables
+
+  // TLM agent fifos
+
+  // local queues to hold incoming packets pending comparison
+
+  `uvm_component_new
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+  endfunction
+
+  function void connect_phase(uvm_phase phase);
+    super.connect_phase(phase);
+  endfunction
+
+  task run_phase(uvm_phase phase);
+    super.run_phase(phase);
+    fork
+    join_none
+  endtask
+
+  virtual function void reset(string kind = "HARD");
+    super.reset(kind);
+    // reset local fifos queues and variables
+  endfunction
+
+  function void check_phase(uvm_phase phase);
+    super.check_phase(phase);
+    // post test checks - ensure that all local fifos and queues are empty
+  endfunction
+
+endclass

--- a/hw/ip/otbn/dv/uvm/env/otbn_virtual_sequencer.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_virtual_sequencer.sv
@@ -1,0 +1,14 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class otbn_virtual_sequencer extends dv_base_virtual_sequencer #(
+    .CFG_T(otbn_env_cfg),
+    .COV_T(otbn_env_cov)
+  );
+  `uvm_component_utils(otbn_virtual_sequencer)
+
+
+  `uvm_component_new
+
+endclass

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
@@ -1,0 +1,32 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class otbn_base_vseq extends dv_base_vseq #(
+    .CFG_T               (otbn_env_cfg),
+    .COV_T               (otbn_env_cov),
+    .VIRTUAL_SEQUENCER_T (otbn_virtual_sequencer)
+  );
+  `uvm_object_utils(otbn_base_vseq)
+
+  // various knobs to enable certain routines
+  bit do_otbn_init = 1'b1;
+
+  `uvm_object_new
+
+  virtual task dut_init(string reset_kind = "HARD");
+    super.dut_init();
+    if (do_otbn_init) otbn_init();
+  endtask
+
+  virtual task dut_shutdown();
+    // check for pending otbn operations and wait for them to complete
+    // TODO
+  endtask
+
+  // setup basic otbn features
+  virtual task otbn_init();
+    `uvm_error(`gfn, "FIXME")
+  endtask
+
+endclass : otbn_base_vseq

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_common_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_common_vseq.sv
@@ -1,0 +1,16 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class otbn_common_vseq extends otbn_base_vseq;
+  `uvm_object_utils(otbn_common_vseq)
+
+  constraint num_trans_c {
+    num_trans inside {[1:2]};
+  }
+  `uvm_object_new
+
+  virtual task body();
+  endtask : body
+
+endclass

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_sanity_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_sanity_vseq.sv
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// basic sanity test vseq
+class otbn_sanity_vseq extends otbn_base_vseq;
+  `uvm_object_utils(otbn_sanity_vseq)
+
+  `uvm_object_new
+
+  task body();
+    `uvm_error(`gfn, "FIXME")
+  endtask : body
+
+endclass : otbn_sanity_vseq

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_vseq_list.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_vseq_list.sv
@@ -1,0 +1,7 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`include "otbn_base_vseq.sv"
+`include "otbn_sanity_vseq.sv"
+`include "otbn_common_vseq.sv"

--- a/hw/ip/otbn/dv/uvm/otbn_sim.core
+++ b/hw/ip/otbn/dv/uvm/otbn_sim.core
@@ -1,0 +1,26 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:otbn_sim:0.1"
+description: "OTBN DV sim target"
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:ip:otbn
+
+  files_dv:
+    depend:
+      - lowrisc:dv:otbn_test
+      - lowrisc:dv:otbn_sva
+    files:
+      - tb.sv
+    file_type: systemVerilogSource
+
+targets:
+  sim:
+    toplevel: tb
+    filesets:
+      - files_rtl
+      - files_dv
+    default_tool: vcs

--- a/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
+++ b/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
@@ -1,0 +1,56 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  // Name of the sim cfg - typically same as the name of the DUT.
+  name: otbn
+
+  // Top level dut name (sv module).
+  dut: otbn
+
+  // Top level testbench name (sv module).
+  tb: tb
+
+  // Simulator used to sign off this block
+  tool: vcs
+
+  // Fusesoc core file used for building the file list.
+  fusesoc_core: lowrisc:dv:otbn_sim:0.1
+
+  // Testplan hjson file.
+  testplan: "{proj_root}/hw/ip/otbn/data/otbn_testplan.hjson"
+
+
+  // Import additional common sim cfg files.
+  // TODO: remove imported cfgs that do not apply.
+  import_cfgs: [// Project wide common sim cfg file
+                "{proj_root}/hw/dv/data/common_sim_cfg.hjson",
+
+  // Add additional tops for simulation.
+  sim_tops: ["-top {name}_bind"]
+
+  // Default iterations for all tests - each test entry can override this.
+  reseed: 50
+
+  // Default UVM test and seq class name.
+  uvm_test: otbn_base_test
+  uvm_test_seq: otbn_base_vseq
+
+  // List of test specifications.
+  tests: [
+    {
+      name: otbn_sanity
+      uvm_test_seq: otbn_sanity_vseq
+    }
+
+    // TODO: add more tests here
+  ]
+
+  // List of regressions.
+  regressions: [
+    {
+      name: sanity
+      tests: ["otbn_sanity"]
+    }
+  ]
+}

--- a/hw/ip/otbn/dv/uvm/sva/otbn_bind.sv
+++ b/hw/ip/otbn/dv/uvm/sva/otbn_bind.sv
@@ -1,0 +1,7 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+module otbn_bind;
+
+endmodule

--- a/hw/ip/otbn/dv/uvm/sva/otbn_sva.core
+++ b/hw/ip/otbn/dv/uvm/sva/otbn_sva.core
@@ -1,0 +1,19 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:otbn_sva:0.1"
+description: "OTBN assertion modules and bind file."
+filesets:
+  files_dv:
+    depend:
+      - lowrisc:tlul:headers
+    files:
+      - otbn_bind.sv
+    file_type: systemVerilogSource
+
+
+targets:
+  default:
+    filesets:
+      - files_dv

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -1,0 +1,38 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+module tb;
+  // dep packages
+  import uvm_pkg::*;
+  import dv_utils_pkg::*;
+  import otbn_env_pkg::*;
+  import otbn_test_pkg::*;
+
+  // macro includes
+  `include "uvm_macros.svh"
+  `include "dv_macros.svh"
+
+  wire clk, rst_n;
+  wire devmode;
+
+  // interfaces
+  clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
+
+  // dut
+  otbn dut (
+    .clk_i                (clk        ),
+    .rst_ni               (rst_n      )
+
+    // TODO: add remaining IOs and hook them
+  );
+
+  initial begin
+    // drive clk and rst_n from clk_if
+    clk_rst_if.set_active();
+    uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
+    $timeformat(-12, 0, " ps", 12);
+    run_test();
+  end
+
+endmodule

--- a/hw/ip/otbn/dv/uvm/tests/otbn_base_test.sv
+++ b/hw/ip/otbn/dv/uvm/tests/otbn_base_test.sv
@@ -1,0 +1,25 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class otbn_base_test extends dv_base_test #(
+    .CFG_T(otbn_env_cfg),
+    .ENV_T(otbn_env)
+  );
+
+  `uvm_component_utils(otbn_base_test)
+  `uvm_component_new
+
+  // the base class dv_base_test creates the following instances:
+  // otbn_env_cfg: cfg
+  // otbn_env:     env
+
+  virtual function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    cfg.has_ral = 1'b0;
+  endfunction
+
+  // the base class also looks up UVM_TEST_SEQ plusarg to create and run that seq in
+  // the run_phase; as such, nothing more needs to be done
+
+endclass : otbn_base_test

--- a/hw/ip/otbn/dv/uvm/tests/otbn_test.core
+++ b/hw/ip/otbn/dv/uvm/tests/otbn_test.core
@@ -1,0 +1,19 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:otbn_test:0.1"
+description: "OTBN DV UVM test"
+filesets:
+  files_dv:
+    depend:
+      - lowrisc:dv:otbn_env
+    files:
+      - otbn_test_pkg.sv
+      - otbn_base_test.sv: {is_include_file: true}
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_dv

--- a/hw/ip/otbn/dv/uvm/tests/otbn_test_pkg.sv
+++ b/hw/ip/otbn/dv/uvm/tests/otbn_test_pkg.sv
@@ -1,0 +1,22 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package otbn_test_pkg;
+  // dep packages
+  import uvm_pkg::*;
+  import dv_lib_pkg::*;
+  import otbn_env_pkg::*;
+
+  // macro includes
+  `include "uvm_macros.svh"
+  `include "dv_macros.svh"
+
+  // local types
+
+  // functions
+
+  // package sources
+  `include "otbn_base_test.sv"
+
+endpackage


### PR DESCRIPTION
This PR consists of two commits. The first runs `uvmdvgen` to generate UVM boilerplate. There's a little bit of tweaking to get paths right, but this is essentially unchanged afterwards: obviously we will need to add actual code to the testbench in future!

The second commit contains an initial DV plan. This is also slightly provisional, as you'd expect for a document describing a testbench that doesn't yet exist(!), but it describes the rough shape of how things will work.

Fixes #3171.