### PR TITLE
[dv/common] Fix a few regression failures

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/cip_base_vseq.sv
@@ -452,7 +452,11 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
   virtual task read_and_check_all_csrs_after_reset();
     csr_excl_item csr_excl = add_and_return_csr_excl("hw_reset");
     `uvm_info(`gfn, "running csr hw_reset vseq", UVM_HIGH)
+
     run_csr_vseq(.csr_test_type("hw_reset"), .csr_excl(csr_excl), .do_rand_wr_and_reset(0));
+    // abort should not occur after this, as the following is normal seq
+    cfg.m_tl_agent_cfg.csr_access_abort_pct_in_adapter = 0;
+    csr_utils_pkg::default_csr_check = UVM_CHECK;
   endtask
 
   virtual task run_same_csr_outstanding_vseq(int num_times);

--- a/hw/dv/sv/tl_agent/tl_host_driver.sv
+++ b/hw/dv/sv/tl_agent/tl_host_driver.sv
@@ -180,10 +180,11 @@ class tl_host_driver extends tl_base_driver;
             rsp.d_opcode = cfg.vif.host_cb.d2h.d_opcode;
             rsp.d_data   = cfg.vif.host_cb.d2h.d_data;
             rsp.d_param  = cfg.vif.host_cb.d2h.d_param;
-            rsp.d_error  = cfg.vif.host_cb.d2h.d_error;
             rsp.d_sink   = cfg.vif.host_cb.d2h.d_sink;
             rsp.d_size   = cfg.vif.host_cb.d2h.d_size;
             rsp.d_user   = cfg.vif.host_cb.d2h.d_user;
+            // set d_error = 0 and rsp_completed = 0 when reset occurs
+            rsp.d_error  = reset_asserted ? 0 : cfg.vif.host_cb.d2h.d_error;
             // make sure every req has a rsp with same source even during reset
             if (reset_asserted) rsp.d_source = rsp.a_source;
             else                rsp.d_source = cfg.vif.host_cb.d2h.d_source;
@@ -192,7 +193,7 @@ class tl_host_driver extends tl_base_driver;
             `uvm_info(get_full_name(), $sformatf("Got response %0s, pending req:%0d",
                                        rsp.convert2string(), pending_a_req.size()), UVM_HIGH)
             req_found         = 1;
-            rsp.rsp_completed = 1;
+            rsp.rsp_completed = !reset_asserted;
             break;
           end
         end

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
@@ -221,6 +221,7 @@ class i2c_base_vseq extends cip_base_vseq #(
     bit fmtempty, hostidle;
     bit [TL_DW-1:0] reg_val;
     do begin
+      if (cfg.under_reset) break;
       csr_rd(.ptr(ral.status), .value(reg_val));
       fmtempty = bit'(get_field_val(ral.status.fmtempty, reg_val));
       hostidle = bit'(get_field_val(ral.status.hostidle, reg_val));

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_rx_tx_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_rx_tx_vseq.sv
@@ -147,6 +147,7 @@ class i2c_rx_tx_vseq extends i2c_base_vseq;
     rx_overflow  = 1'b0;
     rx_watermark = 1'b0;
     while (!complete_program_fmt_fifo || total_rd_bytes > 0) begin
+      if (cfg.under_reset) break;
       rx_sanity      = !cfg.en_rx_watermark & !cfg.en_rx_overflow;
       rx_overflow   |= (cfg.en_rx_overflow  & cfg.intr_vif.pins[RxOverflow]);
       if (cfg.en_rx_watermark) begin

--- a/hw/ip/uart/dv/env/seq_lib/uart_base_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_base_vseq.sv
@@ -211,6 +211,7 @@ class uart_base_vseq extends cip_base_vseq #(.CFG_T               (uart_env_cfg)
 
     if (ral.ctrl.tx.get_mirrored_value()) begin
       do begin
+        if (cfg.under_reset) break;
         `DV_CHECK_MEMBER_RANDOMIZE_FATAL(dly_to_access_fifo)
         cfg.clk_rst_vif.wait_clks(dly_to_access_fifo);
         csr_rd(.ptr(ral.fifo_status), .value(fifo_status));


### PR DESCRIPTION
1. TL driver returns d_error = 0 and req_complete = 0 when reset occurs
2. Fix driving TL abort in stress all with reset test
3. Fix infinite loop
  in below loop, when reset occurs, we no longer update ral predict
  value. `status` will be a fixed value and this may create a deadloop

```
do begin
 csr_rd(.ptr(ral.fifo_status), .value(fifo_status));
end while (get_field_val(ral.status.txidle, status) == 0);
```

  In previous TL driver, we updated predicted value no matter if reset
  occurs or not. so, this kind of issue doesn't show up. But it makes
  more sense to not update when it's in reset

Signed-off-by: Weicai Yang <weicai@google.com>