### PR TITLE
[dv/alert_handler] add async logic in alert interface

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent_pkg.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent_pkg.sv
@@ -20,6 +20,7 @@ package alert_esc_agent_pkg;
   } alert_esc_trans_type_e;
 
   typedef enum {
+    AlertPingReceived,
     AlertReceived,
     AlertAckReceived,
     AlertComplete,


### PR DESCRIPTION
Since it might take a little bit time until standard CDC is implemented,
this PR propose a temp 2 cycle delay model in alert_esc_if:
1. Add two flops to get two cycle delayed values in interface
2. Remove the patched two cycle delay in alert_monitor
3. In wait_ping tasks, add reset considerations. (alert ping is edge
triggered, and reset will flip the ping to 0. This might cause a
unexpected reset in scb)

Signed-off-by: Cindy Chen <chencindy@google.com>