### PR TITLE
[otbn] Use a single digit in a 1-bit constant

### DIFF
--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -155,7 +155,7 @@ module otbn_controller
         if (start_i) begin
           state_d = OtbnStateRun;
           insn_fetch_req_addr_o  = start_addr_i;
-          insn_fetch_req_valid_o = 1'b01;
+          insn_fetch_req_valid_o = 1'b1;
         end
       end
       OtbnStateRun: begin


### PR DESCRIPTION
For some bizarre reason, VCS complains about 1'b01:

    Warning-[TMBIN] Too many bits in Based Number
    ../src/lowrisc_ip_otbn_0.1/rtl/otbn_controller.sv, 158
      The specified width is '1' bit, actually got '2' bits.
      The offending number is : '01'.
