### PR TITLE
[flash_ctrl] Switch to new keyschedule in PRINCE

### DIFF
--- a/hw/ip/flash_ctrl/rtl/flash_phy_scramble.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_scramble.sv
@@ -54,13 +54,15 @@ module flash_phy_scramble import flash_phy_pkg::*; (
 
   assign dec = op_type_i == DeScrambleOp;
 
-  // Previous discussion settled on PRESENT, using PRINCE here for now
-  // just to get some area idea
   prim_prince # (
     .DataWidth(DataWidth),
     .KeyWidth(KeySize),
-    .UseOldKeySched(1'b1),
-    .HalfwayDataReg(1'b1)
+    // Use improved key schedule proposed by https://eprint.iacr.org/2014/656.pdf (see appendix).
+    .UseOldKeySched(1'b0),
+    .HalfwayDataReg(1'b1),
+    // No key register is needed half way, since the data_key_i and operation op_type_i inputs
+    // remain constant until one data block has been processed.
+    .HalfwayKeyReg (1'b0)
   ) u_cipher (
     .clk_i,
     .rst_ni,

--- a/hw/ip/prim/rtl/prim_prince.sv
+++ b/hw/ip/prim/rtl/prim_prince.sv
@@ -65,10 +65,18 @@ module prim_prince #(
   end
 
   if (UseOldKeySched) begin : gen_legacy_keyschedule
+    // In this case we constantly use k1.
     assign k0_new_d = k1_d;
   end else begin : gen_new_keyschedule
-    // improved keyschedule proposed by https://eprint.iacr.org/2014/656.pdf
-    assign k0_new_d = k0;
+    // Imroved keyschedule proposed by https://eprint.iacr.org/2014/656.pdf
+    // In this case we alternate between k1 and k0.
+    always_comb begin : p_new_keyschedule_k0_alpha
+      k0_new_d = key_i[DataWidth-1:0];
+      // We need to apply the alpha constant here as well, just as for k1 in decryption mode.
+      if (dec_i) begin
+        k0_new_d ^= prim_cipher_pkg::PRINCE_ALPHA_CONST[DataWidth-1:0];
+      end
+    end
   end
 
   if (HalfwayKeyReg) begin : gen_key_reg
@@ -130,8 +138,11 @@ module prim_prince #(
     assign data_state_xor = data_state_round ^
                             prim_cipher_pkg::PRINCE_ROUND_CONST[k][DataWidth-1:0];
     // improved keyschedule proposed by https://eprint.iacr.org/2014/656.pdf
-    if (k % 2 == 1) assign data_state[k]  = data_state_xor ^ k0_new_d;
-    else            assign data_state[k]  = data_state_xor ^ k1_d;
+    if (k % 2 == 1) begin : gen_fwd_key_odd
+      assign data_state[k]  = data_state_xor ^ k0_new_d;
+    end else begin : gen_fwd_key_even
+      assign data_state[k]  = data_state_xor ^ k1_d;
+    end
   end
 
   // middle part
@@ -180,8 +191,11 @@ module prim_prince #(
   for (genvar k = 1; k <= NumRoundsHalf; k++) begin : gen_bwd_pass
     logic [DataWidth-1:0] data_state_xor0, data_state_xor1;
     // improved keyschedule proposed by https://eprint.iacr.org/2014/656.pdf
-    if (k % 2 == 1) assign data_state_xor0 = data_state[NumRoundsHalf+k] ^ k0_new_q;
-    else            assign data_state_xor0 = data_state[NumRoundsHalf+k] ^ k1_q;
+    if ((NumRoundsHalf + k + 1) % 2 == 1) begin : gen_bkwd_key_odd
+      assign data_state_xor0 = data_state[NumRoundsHalf+k] ^ k0_new_q;
+    end else begin : gen_bkwd_key_even
+      assign data_state_xor0 = data_state[NumRoundsHalf+k] ^ k1_q;
+    end
     // the construction is reflective, hence the subtraction with NumRoundsHalf
     assign data_state_xor1 = data_state_xor0 ^
                              prim_cipher_pkg::PRINCE_ROUND_CONST[10-NumRoundsHalf+k][DataWidth-1:0];


### PR DESCRIPTION
This initially did not work correctly due to a bug in the PRINCE primitive that has in the meantime been fixed.

The comment was outdated, as we have decided to go with PRINCE due to the lower latency and area with respect to PRESENT.

Signed-off-by: Michael Schaffner <msf@opentitan.org>