### PR TITLE
[edn/doc] remove references to broadcast mode

### DIFF
--- a/hw/ip/edn/data/edn.hjson
+++ b/hw/ip/edn/data/edn.hjson
@@ -141,9 +141,13 @@
           desc: '''
                 This bit indicates that the EDN state machine has started the instantiation
                 process. If this bit is asserted it means the state machine has started in
-                boot-time request mode and that the the CSRNG has confirmed that this
+                boot-time request mode and that the CSRNG has confirmed that this
                 EDN will be the next application to receive a seed from the entropy_src IP.
                 '''
+        }
+        { bits: "31",
+          name: "INTERNAL_USE",
+          desc: "This bit is for internal use only."
         }
       ]
     },

--- a/hw/ip/edn/doc/_index.md
+++ b/hw/ip/edn/doc/_index.md
@@ -198,15 +198,16 @@ See the [CSRNG IP]({{< relref "hw/ip/csrng/doc" >}}) waveform section for the CS
 
 ##### Peripheral Hardware Interface - Req/Ack
 The following waveform shows an example of how the peripheral hardware interface works.
+This example shows the case where the boot-time mode in the ENTROPY_SRC block is enabled.
 
 {{< wavejson >}}
 {signal: [
    {name: 'clk'           , wave: 'p...|.........|.......'},
    {name: 'edn_enable'    , wave: '01..|.........|.......'},
-   {name: 'edn_req'       , wave: '0..1|......0.1|.....0.'},
-   {name: 'edn_ack'       , wave: '0...|.1.01.0..|101....'},
-   {name: 'edn_bus[31:0]' , wave: 'x...|.33.33...|3.3333.', data: ['gb0','gb1','gb2','gb3','es4','es5','es6','es7','es8']},
-   {name: 'edn_fips'      , wave: '2.....................', data: ['Typically "1", unless in boot-time request mode']},
+   {name: 'edn_req'       , wave: '0..1|..01.0..1|.....0.'},
+   {name: 'edn_ack'       , wave: '0...|.10.10...|....10.'},
+   {name: 'edn_bus[31:0]' , wave: '0...|.30.30...|....30.', data: ['es0','es1','es2']},
+   {name: 'edn_fips'      , wave: '0...|....10...|....10.'},
  {},
 ]}
 {{< /wavejson >}}

--- a/hw/ip/edn/doc/edn_blk_diag.svg
+++ b/hw/ip/edn/doc/edn_blk_diag.svg
@@ -20,9 +20,9 @@
 		.st5 {marker-end:url(#mrkr13-21);marker-start:url(#mrkr13-19);stroke:#000000;stroke-linecap:round;stroke-linejoin:round;stroke-width:2.25}
 		.st6 {fill:#000000;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:0.47169811320755}
 		.st7 {fill:none;stroke:none;stroke-width:0.25}
-		.st8 {marker-end:url(#mrkr5-60);stroke:#000000;stroke-linecap:round;stroke-linejoin:round;stroke-width:0.75}
+		.st8 {marker-end:url(#mrkr5-59);stroke:#000000;stroke-linecap:round;stroke-linejoin:round;stroke-width:0.75}
 		.st9 {fill:#000000;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:0.22935779816514}
-		.st10 {marker-end:url(#mrkr5-60);stroke:#000000;stroke-width:0.75}
+		.st10 {marker-end:url(#mrkr5-59);stroke:#000000;stroke-width:0.75}
 		.st11 {stroke:#000000;stroke-linecap:round;stroke-linejoin:round;stroke-width:0.75}
 		.st12 {fill:none;fill-rule:evenodd;font-size:12px;overflow:visible;stroke-linecap:square;stroke-miterlimit:3}
 	]]>
@@ -43,7 +43,7 @@
 		<g id="lend5">
 			<path d="M 2 1 L 0 0 L 1.98117 -0.993387 C 1.67173 -0.364515 1.67301 0.372641 1.98465 1.00043 " style="stroke:none"/>
 		</g>
-		<marker id="mrkr5-60" class="st9" v:arrowType="5" v:arrowSize="2" v:setback="7.63" refX="-7.63" orient="auto"
+		<marker id="mrkr5-59" class="st9" v:arrowType="5" v:arrowSize="2" v:setback="7.63" refX="-7.63" orient="auto"
 				markerUnits="strokeWidth" overflow="visible">
 			<use xlink:href="#lend5" transform="scale(-4.36,-4.36) "/>
 		</marker>
@@ -75,8 +75,8 @@
 			<v:textRect cx="59.2127" cy="558.407" width="118.43" height="107.186"/>
 			<rect x="0" y="504.814" width="118.425" height="107.186" class="st4"/>
 			<text x="68.28" y="543.41" class="st2" v:langID="1033"><v:paragraph v:horizAlign="2"/><v:tabList/>edn_cntl.q<v:newlineChar/><tspan
-						x="28.81" dy="1.2em" class="st3">edn</tspan>_reseed_cmd.q<v:newlineChar/><tspan x="42.7" dy="1.2em"
-						class="st3">edn</tspan>_gen_cmd.q<v:newlineChar/><tspan x="24.37" dy="1.2em" class="st3"> </tspan>edn_sw_cmd_req.q</text>		</g>
+						x="28.81" dy="1.2em" class="st3">edn_reseed_cmd.q<v:newlineChar/></tspan><tspan x="42.7" dy="1.2em"
+						class="st3">edn_gen_cmd.q<v:newlineChar/></tspan><tspan x="24.37" dy="1.2em" class="st3"> </tspan>edn_sw_cmd_req.q</text>		</g>
 		<g id="shape491-13" v:mID="491" v:groupContext="shape" transform="translate(18,-463.205)">
 			<title>Sheet.491</title>
 			<path d="M13.95 612 L14.31 612 L41.52 612" class="st5"/>
@@ -90,27 +90,26 @@
 			<text x="6.78" y="564.55" class="st2" v:langID="1033"><v:paragraph/><v:tabList/>TL-UL Interface<v:newlineChar/></text>		</g>
 		<g id="shape589-25" v:mID="589" v:groupContext="shape" transform="translate(78.0373,-363.375)">
 			<title>Sheet.589</title>
-			<desc>edn_broadcast_req_timer.q edn_sw_cmd_sts.d</desc>
+			<desc>edn_sw_cmd_sts.d</desc>
 			<v:textBlock v:margins="rect(4,4,4,4)" v:verticalAlign="0"/>
 			<v:textRect cx="68.2127" cy="587.25" width="136.43" height="49.5"/>
 			<rect x="0" y="562.5" width="136.425" height="49.5" class="st4"/>
-			<text x="10.12" y="575.5" class="st2" v:langID="1033"><v:paragraph v:horizAlign="2"/><v:tabList/>edn_broadcast_req_timer.q<v:newlineChar/><tspan
-						x="44.05" dy="1.2em" class="st3"> </tspan>edn_sw_cmd_sts.d  </text>		</g>
-		<g id="shape591-29" v:mID="591" v:groupContext="shape" transform="translate(230.625,-511.373)">
+			<text x="46.82" y="587.5" class="st2" v:langID="1033"><v:paragraph v:horizAlign="2"/><v:tabList/><v:space/><v:space/><v:newlineChar/>edn_sw_cmd_sts.d  </text>		</g>
+		<g id="shape591-28" v:mID="591" v:groupContext="shape" transform="translate(230.625,-511.373)">
 			<title>Sheet.591</title>
 		</g>
-		<g id="shape769-30" v:mID="769" v:groupContext="shape" transform="translate(90.3555,-284.18)">
+		<g id="shape769-29" v:mID="769" v:groupContext="shape" transform="translate(90.3555,-284.18)">
 			<title>Sheet.769</title>
 			<desc>Peripheral Port 0</desc>
 			<v:textBlock v:margins="rect(4,4,4,4)" v:verticalAlign="0"/>
 			<v:textRect cx="58.4452" cy="599.18" width="116.9" height="25.6401"/>
 			<rect x="0" y="586.36" width="116.89" height="25.6401" class="st7"/>
 			<text x="37.85" y="599.36" class="st2" v:langID="1033"><v:paragraph v:horizAlign="2"/><v:tabList/>Peripheral Port 0</text>		</g>
-		<g id="shape957-33" v:mID="957" v:groupContext="shape" transform="translate(391.668,-279)">
+		<g id="shape957-32" v:mID="957" v:groupContext="shape" transform="translate(391.668,-279)">
 			<title>Sheet.957</title>
 			<rect x="0" y="562.5" width="13.2734" height="49.5" class="st1"/>
 		</g>
-		<g id="shape958-35" v:mID="958" v:groupContext="shape" transform="translate(374.094,-330.617)">
+		<g id="shape958-34" v:mID="958" v:groupContext="shape" transform="translate(374.094,-330.617)">
 			<title>Sheet.958</title>
 			<desc>128 to N unpacker</desc>
 			<v:textBlock v:margins="rect(4,4,4,4)"/>
@@ -118,11 +117,11 @@
 			<rect x="0" y="586.36" width="54.7817" height="25.6401" class="st4"/>
 			<text x="8.49" y="596.18" class="st2" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>128 to N <v:newlineChar/><tspan
 						x="6.82" dy="1.2em" class="st3">unpacker</tspan></text>		</g>
-		<g id="shape1019-39" v:mID="1019" v:groupContext="shape" transform="translate(306.956,-347.478)">
+		<g id="shape1019-38" v:mID="1019" v:groupContext="shape" transform="translate(306.956,-347.478)">
 			<title>Sheet.1019</title>
 			<rect x="0" y="562.5" width="28.3995" height="49.5" class="st1"/>
 		</g>
-		<g id="shape1020-41" v:mID="1020" v:groupContext="shape" transform="translate(297,-400.882)">
+		<g id="shape1020-40" v:mID="1020" v:groupContext="shape" transform="translate(297,-400.882)">
 			<title>Sheet.1020</title>
 			<desc>Req Arb</desc>
 			<v:textBlock v:margins="rect(4,4,4,4)"/>
@@ -130,7 +129,7 @@
 			<rect x="0" y="586.36" width="48.3116" height="25.6401" class="st4"/>
 			<text x="14.98" y="596.18" class="st2" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>Req <v:newlineChar/><tspan
 						x="16.38" dy="1.2em" class="st3">Arb</tspan></text>		</g>
-		<g id="shape1023-45" v:mID="1023" v:groupContext="shape" transform="translate(583.145,-397.244)">
+		<g id="shape1023-44" v:mID="1023" v:groupContext="shape" transform="translate(583.145,-397.244)">
 			<title>Sheet.1023</title>
 			<desc>EDN Main SM</desc>
 			<v:textBlock v:margins="rect(4,4,4,4)"/>
@@ -138,7 +137,7 @@
 			<rect x="0" y="560.489" width="60.665" height="51.5114" class="st1"/>
 			<text x="7.55" y="577.24" class="st2" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>EDN Main <tspan
 						x="22.83" dy="1.2em" class="st3">SM</tspan><v:newlineChar/></text>		</g>
-		<g id="shape1027-49" v:mID="1027" v:groupContext="shape" transform="translate(370.287,-533.623)">
+		<g id="shape1027-48" v:mID="1027" v:groupContext="shape" transform="translate(370.287,-533.623)">
 			<title>Sheet.1027</title>
 			<desc>Reseed Cmd FIFO</desc>
 			<v:textBlock v:margins="rect(4,4,4,4)"/>
@@ -146,55 +145,55 @@
 			<rect x="0" y="582.75" width="72" height="29.25" class="st1"/>
 			<text x="6.82" y="594.38" class="st2" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>Reseed Cmd <tspan
 						x="24.61" dy="1.2em" class="st3">FIFO</tspan></text>		</g>
-		<g id="shape1109-53" v:mID="1109" v:groupContext="shape" transform="translate(475.448,-49.5)">
+		<g id="shape1109-52" v:mID="1109" v:groupContext="shape" transform="translate(475.448,-49.5)">
 			<title>Sheet.1109</title>
 			<path d="M0 579.92 L0 612 L17.01 579.92 L17.01 365.08 L0 333 L0 365.08 L0 579.92 Z" class="st1"/>
 		</g>
-		<g id="shape1112-55" v:mID="1112" v:groupContext="shape" transform="translate(216,-320.258)">
+		<g id="shape1112-54" v:mID="1112" v:groupContext="shape" transform="translate(216,-320.258)">
 			<title>Sheet.1112</title>
 			<path d="M0 612 L169.95 612" class="st8"/>
 		</g>
-		<g id="shape1113-61" v:mID="1113" v:groupContext="shape" transform="translate(391.668,921.742) rotate(180)">
+		<g id="shape1113-60" v:mID="1113" v:groupContext="shape" transform="translate(391.668,921.742) rotate(180)">
 			<title>Sheet.1113</title>
 			<path d="M0 612 L169.95 612" class="st8"/>
 		</g>
-		<g id="shape1114-66" v:mID="1114" v:groupContext="shape" transform="translate(390.48,939.742) rotate(180)">
+		<g id="shape1114-65" v:mID="1114" v:groupContext="shape" transform="translate(390.48,939.742) rotate(180)">
 			<title>Sheet.1114</title>
 			<path d="M0 612 L168.76 612" class="st8"/>
 		</g>
-		<g id="shape1115-71" v:mID="1115" v:groupContext="shape" transform="translate(341.195,-320.488)">
+		<g id="shape1115-70" v:mID="1115" v:groupContext="shape" transform="translate(341.195,-320.488)">
 			<title>Sheet.1115</title>
 			<desc>req</desc>
 			<v:textBlock v:margins="rect(4,4,4,4)"/>
 			<v:textRect cx="14.1997" cy="605.365" width="28.4" height="13.27"/>
 			<rect x="0" y="598.73" width="28.3995" height="13.27" class="st4"/>
 			<text x="6.97" y="608.36" class="st2" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>req</text>		</g>
-		<g id="shape1116-74" v:mID="1116" v:groupContext="shape" transform="translate(341.144,-301.373)">
+		<g id="shape1116-73" v:mID="1116" v:groupContext="shape" transform="translate(341.144,-301.373)">
 			<title>Sheet.1116</title>
 			<desc>ack</desc>
 			<v:textBlock v:margins="rect(4,4,4,4)"/>
 			<v:textRect cx="14.1997" cy="605.365" width="28.4" height="13.27"/>
 			<rect x="0" y="598.73" width="28.3995" height="13.27" class="st4"/>
 			<text x="6.42" y="608.36" class="st2" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>ack</text>		</g>
-		<g id="shape1117-77" v:mID="1117" v:groupContext="shape" transform="translate(341.394,-283.873)">
+		<g id="shape1117-76" v:mID="1117" v:groupContext="shape" transform="translate(341.394,-283.873)">
 			<title>Sheet.1117</title>
 			<desc>bits</desc>
 			<v:textBlock v:margins="rect(4,4,4,4)"/>
 			<v:textRect cx="14.1997" cy="605.365" width="28.4" height="13.27"/>
 			<rect x="0" y="598.73" width="28.3995" height="13.27" class="st4"/>
 			<text x="6.42" y="608.36" class="st2" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>bits</text>		</g>
-		<g id="shape1118-80" v:mID="1118" v:groupContext="shape" transform="translate(102.182,-203.18)">
+		<g id="shape1118-79" v:mID="1118" v:groupContext="shape" transform="translate(102.182,-203.18)">
 			<title>Sheet.1118</title>
 			<desc>Peripheral Port 1</desc>
 			<v:textBlock v:margins="rect(4,4,4,4)" v:verticalAlign="0"/>
 			<v:textRect cx="52.5317" cy="599.18" width="105.07" height="25.6401"/>
 			<rect x="0" y="586.36" width="105.063" height="25.6401" class="st7"/>
 			<text x="26.02" y="599.36" class="st2" v:langID="1033"><v:paragraph v:horizAlign="2"/><v:tabList/>Peripheral Port 1</text>		</g>
-		<g id="shape1119-83" v:mID="1119" v:groupContext="shape" transform="translate(391.668,-198)">
+		<g id="shape1119-82" v:mID="1119" v:groupContext="shape" transform="translate(391.668,-198)">
 			<title>Sheet.1119</title>
 			<rect x="0" y="562.5" width="13.2734" height="49.5" class="st1"/>
 		</g>
-		<g id="shape1120-85" v:mID="1120" v:groupContext="shape" transform="translate(374.094,-249.617)">
+		<g id="shape1120-84" v:mID="1120" v:groupContext="shape" transform="translate(374.094,-249.617)">
 			<title>Sheet.1120</title>
 			<desc>128 to N unpacker</desc>
 			<v:textBlock v:margins="rect(4,4,4,4)"/>
@@ -202,39 +201,39 @@
 			<rect x="0" y="586.36" width="54.7817" height="25.6401" class="st4"/>
 			<text x="8.49" y="596.18" class="st2" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>128 to N <v:newlineChar/><tspan
 						x="6.82" dy="1.2em" class="st3">unpacker</tspan></text>		</g>
-		<g id="shape1124-89" v:mID="1124" v:groupContext="shape" transform="translate(341.195,-239.488)">
+		<g id="shape1124-88" v:mID="1124" v:groupContext="shape" transform="translate(341.195,-239.488)">
 			<title>Sheet.1124</title>
 			<desc>req</desc>
 			<v:textBlock v:margins="rect(4,4,4,4)"/>
 			<v:textRect cx="14.1997" cy="605.365" width="28.4" height="13.27"/>
 			<rect x="0" y="598.73" width="28.3995" height="13.27" class="st4"/>
 			<text x="6.97" y="608.36" class="st2" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>req</text>		</g>
-		<g id="shape1125-92" v:mID="1125" v:groupContext="shape" transform="translate(341.144,-220.373)">
+		<g id="shape1125-91" v:mID="1125" v:groupContext="shape" transform="translate(341.144,-220.373)">
 			<title>Sheet.1125</title>
 			<desc>ack</desc>
 			<v:textBlock v:margins="rect(4,4,4,4)"/>
 			<v:textRect cx="14.1997" cy="605.365" width="28.4" height="13.27"/>
 			<rect x="0" y="598.73" width="28.3995" height="13.27" class="st4"/>
 			<text x="6.42" y="608.36" class="st2" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>ack</text>		</g>
-		<g id="shape1126-95" v:mID="1126" v:groupContext="shape" transform="translate(341.394,-202.873)">
+		<g id="shape1126-94" v:mID="1126" v:groupContext="shape" transform="translate(341.394,-202.873)">
 			<title>Sheet.1126</title>
 			<desc>bits</desc>
 			<v:textBlock v:margins="rect(4,4,4,4)"/>
 			<v:textRect cx="14.1997" cy="605.365" width="28.4" height="13.27"/>
 			<rect x="0" y="598.73" width="28.3995" height="13.27" class="st4"/>
 			<text x="6.42" y="608.36" class="st2" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>bits</text>		</g>
-		<g id="shape1127-98" v:mID="1127" v:groupContext="shape" transform="translate(102.777,-125.922)">
+		<g id="shape1127-97" v:mID="1127" v:groupContext="shape" transform="translate(102.777,-125.922)">
 			<title>Sheet.1127</title>
 			<desc>Peripheral Port 2</desc>
 			<v:textBlock v:margins="rect(4,4,4,4)" v:verticalAlign="0"/>
 			<v:textRect cx="52.5317" cy="599.18" width="105.07" height="25.6401"/>
 			<rect x="0" y="586.36" width="105.063" height="25.6401" class="st7"/>
 			<text x="26.02" y="599.36" class="st2" v:langID="1033"><v:paragraph v:horizAlign="2"/><v:tabList/>Peripheral Port 2</text>		</g>
-		<g id="shape1128-101" v:mID="1128" v:groupContext="shape" transform="translate(392.262,-120.742)">
+		<g id="shape1128-100" v:mID="1128" v:groupContext="shape" transform="translate(392.262,-120.742)">
 			<title>Sheet.1128</title>
 			<rect x="0" y="562.5" width="13.2734" height="49.5" class="st1"/>
 		</g>
-		<g id="shape1129-103" v:mID="1129" v:groupContext="shape" transform="translate(374.688,-172.36)">
+		<g id="shape1129-102" v:mID="1129" v:groupContext="shape" transform="translate(374.688,-172.36)">
 			<title>Sheet.1129</title>
 			<desc>128 to N unpacker</desc>
 			<v:textBlock v:margins="rect(4,4,4,4)"/>
@@ -242,39 +241,39 @@
 			<rect x="0" y="586.36" width="54.7817" height="25.6401" class="st4"/>
 			<text x="8.49" y="596.18" class="st2" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>128 to N <v:newlineChar/><tspan
 						x="6.82" dy="1.2em" class="st3">unpacker</tspan></text>		</g>
-		<g id="shape1133-107" v:mID="1133" v:groupContext="shape" transform="translate(341.789,-162.23)">
+		<g id="shape1133-106" v:mID="1133" v:groupContext="shape" transform="translate(341.789,-162.23)">
 			<title>Sheet.1133</title>
 			<desc>req</desc>
 			<v:textBlock v:margins="rect(4,4,4,4)"/>
 			<v:textRect cx="14.1997" cy="605.365" width="28.4" height="13.27"/>
 			<rect x="0" y="598.73" width="28.3995" height="13.27" class="st4"/>
 			<text x="6.97" y="608.36" class="st2" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>req</text>		</g>
-		<g id="shape1134-110" v:mID="1134" v:groupContext="shape" transform="translate(341.739,-143.115)">
+		<g id="shape1134-109" v:mID="1134" v:groupContext="shape" transform="translate(341.739,-143.115)">
 			<title>Sheet.1134</title>
 			<desc>ack</desc>
 			<v:textBlock v:margins="rect(4,4,4,4)"/>
 			<v:textRect cx="14.1997" cy="605.365" width="28.4" height="13.27"/>
 			<rect x="0" y="598.73" width="28.3995" height="13.27" class="st4"/>
 			<text x="6.42" y="608.36" class="st2" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>ack</text>		</g>
-		<g id="shape1135-113" v:mID="1135" v:groupContext="shape" transform="translate(341.989,-125.615)">
+		<g id="shape1135-112" v:mID="1135" v:groupContext="shape" transform="translate(341.989,-125.615)">
 			<title>Sheet.1135</title>
 			<desc>bits</desc>
 			<v:textBlock v:margins="rect(4,4,4,4)"/>
 			<v:textRect cx="14.1997" cy="605.365" width="28.4" height="13.27"/>
 			<rect x="0" y="598.73" width="28.3995" height="13.27" class="st4"/>
 			<text x="6.42" y="608.36" class="st2" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>bits</text>		</g>
-		<g id="shape1136-116" v:mID="1136" v:groupContext="shape" transform="translate(90.9497,-44.9224)">
+		<g id="shape1136-115" v:mID="1136" v:groupContext="shape" transform="translate(90.9497,-44.9224)">
 			<title>Sheet.1136</title>
 			<desc>Peripheral Port 3</desc>
 			<v:textBlock v:margins="rect(4,4,4,4)" v:verticalAlign="0"/>
 			<v:textRect cx="58.4452" cy="599.18" width="116.9" height="25.6401"/>
 			<rect x="0" y="586.36" width="116.89" height="25.6401" class="st7"/>
 			<text x="37.85" y="599.36" class="st2" v:langID="1033"><v:paragraph v:horizAlign="2"/><v:tabList/>Peripheral Port 3</text>		</g>
-		<g id="shape1137-119" v:mID="1137" v:groupContext="shape" transform="translate(392.262,-39.7424)">
+		<g id="shape1137-118" v:mID="1137" v:groupContext="shape" transform="translate(392.262,-39.7424)">
 			<title>Sheet.1137</title>
 			<rect x="0" y="562.5" width="13.2734" height="49.5" class="st1"/>
 		</g>
-		<g id="shape1138-121" v:mID="1138" v:groupContext="shape" transform="translate(374.688,-91.3599)">
+		<g id="shape1138-120" v:mID="1138" v:groupContext="shape" transform="translate(374.688,-91.3599)">
 			<title>Sheet.1138</title>
 			<desc>128 to N unpacker</desc>
 			<v:textBlock v:margins="rect(4,4,4,4)"/>
@@ -282,80 +281,80 @@
 			<rect x="0" y="586.36" width="54.7817" height="25.6401" class="st4"/>
 			<text x="8.49" y="596.18" class="st2" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>128 to N <v:newlineChar/><tspan
 						x="6.82" dy="1.2em" class="st3">unpacker</tspan></text>		</g>
-		<g id="shape1142-125" v:mID="1142" v:groupContext="shape" transform="translate(341.789,-81.23)">
+		<g id="shape1142-124" v:mID="1142" v:groupContext="shape" transform="translate(341.789,-81.23)">
 			<title>Sheet.1142</title>
 			<desc>req</desc>
 			<v:textBlock v:margins="rect(4,4,4,4)"/>
 			<v:textRect cx="14.1997" cy="605.365" width="28.4" height="13.27"/>
 			<rect x="0" y="598.73" width="28.3995" height="13.27" class="st4"/>
 			<text x="6.97" y="608.36" class="st2" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>req</text>		</g>
-		<g id="shape1143-128" v:mID="1143" v:groupContext="shape" transform="translate(341.739,-62.115)">
+		<g id="shape1143-127" v:mID="1143" v:groupContext="shape" transform="translate(341.739,-62.115)">
 			<title>Sheet.1143</title>
 			<desc>ack</desc>
 			<v:textBlock v:margins="rect(4,4,4,4)"/>
 			<v:textRect cx="14.1997" cy="605.365" width="28.4" height="13.27"/>
 			<rect x="0" y="598.73" width="28.3995" height="13.27" class="st4"/>
 			<text x="6.42" y="608.36" class="st2" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>ack</text>		</g>
-		<g id="shape1144-131" v:mID="1144" v:groupContext="shape" transform="translate(341.989,-44.615)">
+		<g id="shape1144-130" v:mID="1144" v:groupContext="shape" transform="translate(341.989,-44.615)">
 			<title>Sheet.1144</title>
 			<desc>bits</desc>
 			<v:textBlock v:margins="rect(4,4,4,4)"/>
 			<v:textRect cx="14.1997" cy="605.365" width="28.4" height="13.27"/>
 			<rect x="0" y="598.73" width="28.3995" height="13.27" class="st4"/>
 			<text x="6.42" y="608.36" class="st2" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>bits</text>		</g>
-		<g id="shape1145-134" v:mID="1145" v:groupContext="shape" transform="translate(216,-238.5)">
+		<g id="shape1145-133" v:mID="1145" v:groupContext="shape" transform="translate(216,-238.5)">
 			<title>Sheet.1145</title>
 			<path d="M0 612 L169.95 612" class="st8"/>
 		</g>
-		<g id="shape1146-139" v:mID="1146" v:groupContext="shape" transform="translate(216.594,-162)">
+		<g id="shape1146-138" v:mID="1146" v:groupContext="shape" transform="translate(216.594,-162)">
 			<title>Sheet.1146</title>
 			<path d="M0 612 L169.95 612" class="st8"/>
 		</g>
-		<g id="shape1147-144" v:mID="1147" v:groupContext="shape" transform="translate(216.594,-81)">
+		<g id="shape1147-143" v:mID="1147" v:groupContext="shape" transform="translate(216.594,-81)">
 			<title>Sheet.1147</title>
 			<path d="M0 612 L169.95 612" class="st8"/>
 		</g>
-		<g id="shape1148-149" v:mID="1148" v:groupContext="shape" transform="translate(391.668,1003.5) rotate(180)">
+		<g id="shape1148-148" v:mID="1148" v:groupContext="shape" transform="translate(391.668,1003.5) rotate(180)">
 			<title>Sheet.1148</title>
 			<path d="M0 612 L168.76 612" class="st8"/>
 		</g>
-		<g id="shape1149-154" v:mID="1149" v:groupContext="shape" transform="translate(391.668,1021.5) rotate(180)">
+		<g id="shape1149-153" v:mID="1149" v:groupContext="shape" transform="translate(391.668,1021.5) rotate(180)">
 			<title>Sheet.1149</title>
 			<path d="M0 612 L168.76 612" class="st8"/>
 		</g>
-		<g id="shape1150-159" v:mID="1150" v:groupContext="shape" transform="translate(392.262,1080) rotate(180)">
+		<g id="shape1150-158" v:mID="1150" v:groupContext="shape" transform="translate(392.262,1080) rotate(180)">
 			<title>Sheet.1150</title>
 			<path d="M0 612 L168.76 612" class="st8"/>
 		</g>
-		<g id="shape1151-164" v:mID="1151" v:groupContext="shape" transform="translate(390.99,1097.55) rotate(180)">
+		<g id="shape1151-163" v:mID="1151" v:groupContext="shape" transform="translate(390.99,1097.55) rotate(180)">
 			<title>Sheet.1151</title>
 			<path d="M0 612 L168.76 612" class="st8"/>
 		</g>
-		<g id="shape1152-169" v:mID="1152" v:groupContext="shape" transform="translate(392.262,1161) rotate(180)">
+		<g id="shape1152-168" v:mID="1152" v:groupContext="shape" transform="translate(392.262,1161) rotate(180)">
 			<title>Sheet.1152</title>
 			<path d="M0 612 L168.76 612" class="st8"/>
 		</g>
-		<g id="shape1153-174" v:mID="1153" v:groupContext="shape" transform="translate(392.262,1179) rotate(180)">
+		<g id="shape1153-173" v:mID="1153" v:groupContext="shape" transform="translate(392.262,1179) rotate(180)">
 			<title>Sheet.1153</title>
 			<path d="M0 612 L168.76 612" class="st8"/>
 		</g>
-		<g id="shape1155-179" v:mID="1155" v:groupContext="shape" transform="translate(261,-238.5)">
+		<g id="shape1155-178" v:mID="1155" v:groupContext="shape" transform="translate(261,-238.5)">
 			<title>Sheet.1155</title>
 			<path d="M0 612 L0 472.5 L40.23 472.5" class="st10"/>
 		</g>
-		<g id="shape1156-184" v:mID="1156" v:groupContext="shape" transform="translate(270,-162)">
+		<g id="shape1156-183" v:mID="1156" v:groupContext="shape" transform="translate(270,-162)">
 			<title>Sheet.1156</title>
 			<path d="M0 612 L0 405 L31.23 405" class="st10"/>
 		</g>
-		<g id="shape1157-189" v:mID="1157" v:groupContext="shape" transform="translate(279,-81)">
+		<g id="shape1157-188" v:mID="1157" v:groupContext="shape" transform="translate(279,-81)">
 			<title>Sheet.1157</title>
 			<path d="M0 612 L0 333 L22.23 333" class="st10"/>
 		</g>
-		<g id="shape1158-194" v:mID="1158" v:groupContext="shape" transform="translate(596.418,-177.371)">
+		<g id="shape1158-193" v:mID="1158" v:groupContext="shape" transform="translate(596.418,-177.371)">
 			<title>Sheet.1158</title>
 			<rect x="0" y="562.5" width="13.2734" height="49.5" class="st1"/>
 		</g>
-		<g id="shape1159-196" v:mID="1159" v:groupContext="shape" transform="translate(578.844,-228.989)">
+		<g id="shape1159-195" v:mID="1159" v:groupContext="shape" transform="translate(578.844,-228.989)">
 			<title>Sheet.1159</title>
 			<desc>128 FIFO</desc>
 			<v:textBlock v:margins="rect(4,4,4,4)"/>
@@ -363,65 +362,65 @@
 			<rect x="0" y="586.36" width="48.3116" height="25.6401" class="st4"/>
 			<text x="15.81" y="596.18" class="st2" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>128 <tspan x="12.77"
 						dy="1.2em" class="st3">FIFO</tspan></text>		</g>
-		<g id="shape1160-200" v:mID="1160" v:groupContext="shape" transform="translate(475.448,918) rotate(180)">
+		<g id="shape1160-199" v:mID="1160" v:groupContext="shape" transform="translate(475.448,918) rotate(180)">
 			<title>Sheet.1160</title>
 			<path d="M0 612 L64.78 612" class="st8"/>
 		</g>
-		<g id="shape1161-205" v:mID="1161" v:groupContext="shape" transform="translate(475.448,999) rotate(180)">
+		<g id="shape1161-204" v:mID="1161" v:groupContext="shape" transform="translate(475.448,999) rotate(180)">
 			<title>Sheet.1161</title>
 			<path d="M0 612 L64.78 612" class="st8"/>
 		</g>
-		<g id="shape1162-210" v:mID="1162" v:groupContext="shape" transform="translate(475.448,1071) rotate(180)">
+		<g id="shape1162-209" v:mID="1162" v:groupContext="shape" transform="translate(475.448,1071) rotate(180)">
 			<title>Sheet.1162</title>
 			<path d="M0 612 L64.19 612" class="st8"/>
 		</g>
-		<g id="shape1163-215" v:mID="1163" v:groupContext="shape" transform="translate(475.448,1152) rotate(180)">
+		<g id="shape1163-214" v:mID="1163" v:groupContext="shape" transform="translate(475.448,1152) rotate(180)">
 			<title>Sheet.1163</title>
 			<path d="M0 612 L64.19 612" class="st8"/>
 		</g>
-		<g id="shape1164-220" v:mID="1164" v:groupContext="shape" transform="translate(596.418,1017) rotate(180)">
+		<g id="shape1164-219" v:mID="1164" v:groupContext="shape" transform="translate(596.418,1017) rotate(180)">
 			<title>Sheet.1164</title>
 			<path d="M0 612 L98.24 612" class="st8"/>
 		</g>
-		<g id="shape1165-225" v:mID="1165" v:groupContext="shape" transform="translate(666,1017) rotate(180)">
+		<g id="shape1165-224" v:mID="1165" v:groupContext="shape" transform="translate(666,1017) rotate(180)">
 			<title>Sheet.1165</title>
 			<path d="M0 612 L50.59 612" class="st8"/>
 		</g>
-		<g id="shape1169-230" v:mID="1169" v:groupContext="shape" transform="translate(335.356,-317.489)">
+		<g id="shape1169-229" v:mID="1169" v:groupContext="shape" transform="translate(335.356,-317.489)">
 			<title>Sheet.1169</title>
 			<path d="M0 560.49 L146.14 560.49 L145.95 606.28" class="st10"/>
 		</g>
-		<g id="shape1170-235" v:mID="1170" v:groupContext="shape" transform="translate(335.356,-220.5)">
+		<g id="shape1170-234" v:mID="1170" v:groupContext="shape" transform="translate(335.356,-220.5)">
 			<title>Sheet.1170</title>
 			<path d="M0 445.5 L204.64 445.5 L204.64 612 L255.34 612" class="st10"/>
 		</g>
-		<g id="shape1171-240" v:mID="1171" v:groupContext="shape" transform="translate(486,-387)">
+		<g id="shape1171-239" v:mID="1171" v:groupContext="shape" transform="translate(486,-387)">
 			<title>Sheet.1171</title>
 			<desc>pop</desc>
 			<v:textBlock v:margins="rect(4,4,4,4)"/>
 			<v:textRect cx="14.1997" cy="605.365" width="28.4" height="13.27"/>
 			<rect x="0" y="598.73" width="28.3995" height="13.27" class="st4"/>
 			<text x="5.86" y="608.36" class="st2" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>pop</text>		</g>
-		<g id="shape1172-243" v:mID="1172" v:groupContext="shape" transform="translate(1048.51,714.846) rotate(120.964)">
+		<g id="shape1172-242" v:mID="1172" v:groupContext="shape" transform="translate(1048.51,714.846) rotate(120.964)">
 			<title>Sheet.1172</title>
 			<path d="M0 612 L13.12 612" class="st11"/>
 		</g>
-		<g id="shape1173-246" v:mID="1173" v:groupContext="shape" transform="translate(500.688,-182.365)">
+		<g id="shape1173-245" v:mID="1173" v:groupContext="shape" transform="translate(500.688,-182.365)">
 			<title>Sheet.1173</title>
 			<desc>128 bits</desc>
 			<v:textBlock v:margins="rect(4,4,4,4)"/>
 			<v:textRect cx="24.1558" cy="605.365" width="48.32" height="13.27"/>
 			<rect x="0" y="598.73" width="48.3116" height="13.27" class="st4"/>
 			<text x="6.64" y="608.36" class="st2" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>128 bits</text>		</g>
-		<g id="shape1174-249" v:mID="1174" v:groupContext="shape" transform="translate(335.851,-524.25)">
+		<g id="shape1174-248" v:mID="1174" v:groupContext="shape" transform="translate(335.851,-524.25)">
 			<title>Sheet.1174</title>
 			<path d="M0 606.48 L0 612 L10.65 606.48 L10.65 569.52 L0 564 L0 569.52 L0 606.48 Z" class="st1"/>
 		</g>
-		<g id="shape1177-251" v:mID="1177" v:groupContext="shape" transform="translate(346.5,-549)">
+		<g id="shape1177-250" v:mID="1177" v:groupContext="shape" transform="translate(346.5,-549)">
 			<title>Sheet.1177</title>
 			<path d="M0 612 L18.06 612" class="st8"/>
 		</g>
-		<g id="shape1178-256" v:mID="1178" v:groupContext="shape" transform="translate(411.156,-471.375)">
+		<g id="shape1178-255" v:mID="1178" v:groupContext="shape" transform="translate(411.156,-471.375)">
 			<title>Sheet.1178</title>
 			<desc>Generate Cmd FIFO</desc>
 			<v:textBlock v:margins="rect(4,4,4,4)"/>
@@ -429,146 +428,130 @@
 			<rect x="0" y="582.75" width="72" height="29.25" class="st1"/>
 			<text x="15.15" y="594.38" class="st2" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>Generate <tspan
 						x="12.67" dy="1.2em" class="st3">Cmd FIFO</tspan></text>		</g>
-		<g id="shape1179-260" v:mID="1179" v:groupContext="shape" transform="translate(369.782,-462.002)">
+		<g id="shape1179-259" v:mID="1179" v:groupContext="shape" transform="translate(369.782,-462.002)">
 			<title>Sheet.1179</title>
 			<path d="M0 606.48 L0 612 L10.65 606.48 L10.65 569.52 L0 564 L0 569.52 L0 606.48 Z" class="st1"/>
 		</g>
-		<g id="shape1181-262" v:mID="1181" v:groupContext="shape" transform="translate(547.351,-485.627)">
+		<g id="shape1181-261" v:mID="1181" v:groupContext="shape" transform="translate(547.351,-485.627)">
 			<title>Sheet.1181</title>
 			<path d="M0 606.48 L0 612 L10.65 606.48 L10.65 569.52 L0 564 L0 569.52 L0 606.48 Z" class="st1"/>
 		</g>
-		<g id="shape1182-264" v:mID="1182" v:groupContext="shape" transform="translate(583.145,-484.123)">
+		<g id="shape1182-263" v:mID="1182" v:groupContext="shape" transform="translate(583.145,-484.123)">
 			<title>Sheet.1182</title>
 			<rect x="0" y="562.5" width="13.2734" height="49.5" class="st1"/>
 		</g>
-		<g id="shape1183-266" v:mID="1183" v:groupContext="shape" transform="translate(621.563,-484.123)">
+		<g id="shape1183-265" v:mID="1183" v:groupContext="shape" transform="translate(621.563,-484.123)">
 			<title>Sheet.1183</title>
 			<rect x="0" y="562.5" width="13.2734" height="49.5" class="st1"/>
 		</g>
-		<g id="shape1184-268" v:mID="1184" v:groupContext="shape" transform="translate(429.014,-418.5)">
+		<g id="shape1184-267" v:mID="1184" v:groupContext="shape" transform="translate(429.014,-418.5)">
 			<title>Sheet.1184</title>
 			<rect x="0" y="582.75" width="13.2734" height="29.25" class="st1"/>
 		</g>
-		<g id="shape1186-270" v:mID="1186" v:groupContext="shape" transform="translate(575.803,-535.5)">
+		<g id="shape1186-269" v:mID="1186" v:groupContext="shape" transform="translate(575.803,-535.5)">
 			<title>Sheet.1186</title>
 			<desc>flops</desc>
 			<v:textBlock v:margins="rect(4,4,4,4)"/>
 			<v:textRect cx="15.8483" cy="603" width="31.7" height="18"/>
 			<rect x="0" y="594" width="31.6966" height="18" class="st4"/>
 			<text x="5.29" y="606" class="st2" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>flops</text>		</g>
-		<g id="shape1187-273" v:mID="1187" v:groupContext="shape" transform="translate(614.222,-535.5)">
+		<g id="shape1187-272" v:mID="1187" v:groupContext="shape" transform="translate(614.222,-535.5)">
 			<title>Sheet.1187</title>
 			<desc>flops</desc>
 			<v:textBlock v:margins="rect(4,4,4,4)"/>
 			<v:textRect cx="14.8224" cy="603" width="29.65" height="18"/>
 			<rect x="0" y="594" width="29.6448" height="18" class="st4"/>
 			<text x="4.26" y="606" class="st2" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>flops</text>		</g>
-		<g id="shape1188-276" v:mID="1188" v:groupContext="shape" transform="translate(420.272,-448.312)">
+		<g id="shape1188-275" v:mID="1188" v:groupContext="shape" transform="translate(420.272,-448.312)">
 			<title>Sheet.1188</title>
 			<desc>flops</desc>
 			<v:textBlock v:margins="rect(4,4,4,4)"/>
 			<v:textRect cx="15.9276" cy="603" width="31.86" height="18"/>
 			<rect x="0" y="594" width="31.8553" height="18" class="st4"/>
 			<text x="5.37" y="606" class="st2" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>flops</text>		</g>
-		<g id="shape1189-279" v:mID="1189" v:groupContext="shape" transform="translate(483.156,-486)">
+		<g id="shape1189-278" v:mID="1189" v:groupContext="shape" transform="translate(483.156,-486)">
 			<title>Sheet.1189</title>
 			<path d="M0 612 L20.84 612 L20.84 585 L58.47 585" class="st10"/>
 		</g>
-		<g id="shape1190-284" v:mID="1190" v:groupContext="shape" transform="translate(558,-513)">
+		<g id="shape1190-283" v:mID="1190" v:groupContext="shape" transform="translate(558,-513)">
 			<title>Sheet.1190</title>
 			<path d="M0 612 L19.42 612" class="st8"/>
 		</g>
-		<g id="shape1191-289" v:mID="1191" v:groupContext="shape" transform="translate(596.418,-513)">
+		<g id="shape1191-288" v:mID="1191" v:groupContext="shape" transform="translate(596.418,-513)">
 			<title>Sheet.1191</title>
 			<path d="M0 612 L19.42 612" class="st8"/>
 		</g>
-		<g id="shape1192-294" v:mID="1192" v:groupContext="shape" transform="translate(634.836,-513)">
+		<g id="shape1192-293" v:mID="1192" v:groupContext="shape" transform="translate(634.836,-513)">
 			<title>Sheet.1192</title>
 			<path d="M0 612 L25.44 612" class="st8"/>
 		</g>
-		<g id="shape1193-299" v:mID="1193" v:groupContext="shape" transform="translate(217.425,-515.25)">
+		<g id="shape1193-298" v:mID="1193" v:groupContext="shape" transform="translate(217.425,-515.25)">
 			<title>Sheet.1193</title>
 			<path d="M0 612 L34.57 612 L34.57 587.25 L112.7 587.25" class="st10"/>
 		</g>
-		<g id="shape1194-304" v:mID="1194" v:groupContext="shape" transform="translate(315,-513)">
+		<g id="shape1194-303" v:mID="1194" v:groupContext="shape" transform="translate(315,-513)">
 			<title>Sheet.1194</title>
 			<path d="M292.5 612 L292.5 537.75 L0 537.75 L0 567 L15.13 567" class="st10"/>
 		</g>
-		<g id="shape1195-309" v:mID="1195" v:groupContext="shape" transform="translate(217.425,-477)">
+		<g id="shape1195-308" v:mID="1195" v:groupContext="shape" transform="translate(217.425,-477)">
 			<title>Sheet.1195</title>
 			<path d="M0 585 L34.57 585 L34.57 612 L146.63 612" class="st10"/>
 		</g>
-		<g id="shape1196-314" v:mID="1196" v:groupContext="shape" transform="translate(315,-499.5)">
+		<g id="shape1196-313" v:mID="1196" v:groupContext="shape" transform="translate(315,-499.5)">
 			<title>Sheet.1196</title>
 			<path d="M0 553.5 L0 612 L49.06 612" class="st10"/>
 		</g>
-		<g id="shape1197-319" v:mID="1197" v:groupContext="shape" transform="translate(217.425,-438.989)">
+		<g id="shape1197-318" v:mID="1197" v:groupContext="shape" transform="translate(217.425,-438.989)">
 			<title>Sheet.1197</title>
 			<path d="M0 560.49 L16.57 560.49 L16.57 612 L205.87 612" class="st10"/>
 		</g>
-		<g id="shape1198-324" v:mID="1198" v:groupContext="shape" transform="translate(442.287,-439.045)">
+		<g id="shape1198-323" v:mID="1198" v:groupContext="shape" transform="translate(442.287,-439.045)">
 			<title>Sheet.1198</title>
 			<path d="M0 612 L84.21 612 L84.21 551.54 L99.34 551.54" class="st10"/>
 		</g>
-		<g id="shape1201-329" v:mID="1201" v:groupContext="shape" transform="translate(442.287,-526.5)">
+		<g id="shape1201-328" v:mID="1201" v:groupContext="shape" transform="translate(442.287,-526.5)">
 			<title>Sheet.1201</title>
 			<path d="M0 589.5 L84.21 589.5 L84.21 612 L99.34 612" class="st10"/>
 		</g>
-		<g id="shape1203-334" v:mID="1203" v:groupContext="shape" transform="translate(380.431,-486)">
+		<g id="shape1203-333" v:mID="1203" v:groupContext="shape" transform="translate(380.431,-486)">
 			<title>Sheet.1203</title>
 			<path d="M0 612 L25 612" class="st8"/>
 		</g>
-		<g id="shape1205-339" v:mID="1205" v:groupContext="shape" transform="translate(553.5,-441)">
+		<g id="shape1205-338" v:mID="1205" v:groupContext="shape" transform="translate(553.5,-441)">
 			<title>Sheet.1205</title>
 			<path d="M29.64 612 L0 612 L0.06 569.87" class="st10"/>
 		</g>
-		<g id="shape1206-344" v:mID="1206" v:groupContext="shape" transform="translate(373.427,-409.5)">
+		<g id="shape1206-343" v:mID="1206" v:groupContext="shape" transform="translate(373.427,-409.5)">
 			<title>Sheet.1206</title>
 			<path d="M209.72 612 L139.57 612 L139.57 495 L0.07 495 L0.02 507.67" class="st10"/>
 		</g>
-		<g id="shape1208-349" v:mID="1208" v:groupContext="shape" transform="translate(341.645,-512.585)">
+		<g id="shape1208-348" v:mID="1208" v:groupContext="shape" transform="translate(341.645,-512.585)">
 			<title>Sheet.1208</title>
 			<path d="M31.86 598.09 L13.86 598.09 L13.86 612 L0 612 L0.02 603.04" class="st10"/>
 		</g>
-		<g id="shape1209-354" v:mID="1209" v:groupContext="shape" transform="translate(672.504,-501.983)">
+		<g id="shape1209-353" v:mID="1209" v:groupContext="shape" transform="translate(672.504,-501.983)">
 			<title>Sheet.1209</title>
 			<desc>CSRNG Application Interface: Cmd Req</desc>
 			<v:textBlock v:margins="rect(4,4,4,4)" v:verticalAlign="0"/>
 			<v:textRect cx="49.6229" cy="599.18" width="99.25" height="25.6401"/>
 			<rect x="0" y="586.36" width="99.2459" height="25.6401" class="st7"/>
 			<text x="4" y="599.36" class="st2" v:langID="1033"><v:paragraph/><v:tabList/>CSRNG Application<v:newlineChar/><tspan
-						x="4" dy="1.2em" class="st3">Interface</tspan>: Cmd Req</text>		</g>
-		<g id="shape1210-358" v:mID="1210" v:groupContext="shape" transform="translate(672.504,-196.43)">
+						x="4" dy="1.2em" class="st3">Interface: Cmd Req</tspan></text>		</g>
+		<g id="shape1210-357" v:mID="1210" v:groupContext="shape" transform="translate(672.504,-196.43)">
 			<title>Sheet.1210</title>
 			<desc>CSRNG Application Interface: Genbits Bus</desc>
 			<v:textBlock v:margins="rect(4,4,4,4)" v:verticalAlign="0"/>
 			<v:textRect cx="58.4452" cy="599.18" width="116.9" height="25.6401"/>
 			<rect x="0" y="586.36" width="116.89" height="25.6401" class="st7"/>
 			<text x="4" y="599.36" class="st2" v:langID="1033"><v:paragraph/><v:tabList/>CSRNG Application<v:newlineChar/><tspan
-						x="4" dy="1.2em" class="st3">Interface</tspan>: Genbits Bus</text>		</g>
-		<g id="shape1212-362" v:mID="1212" v:groupContext="shape" transform="translate(234,-367.875)">
-			<title>Sheet.1212</title>
-			<rect x="0" y="569.25" width="13.2734" height="42.75" class="st1"/>
-		</g>
-		<g id="shape1213-364" v:mID="1213" v:groupContext="shape" transform="translate(217.859,-412.5)">
-			<title>Sheet.1213</title>
-			<desc>Broadcast Req Timer</desc>
-			<v:textBlock v:margins="rect(4,4,4,4)"/>
-			<v:textRect cx="27.3909" cy="603" width="54.79" height="18"/>
-			<rect x="0" y="594" width="54.7817" height="18" class="st4"/>
-			<text x="4.88" y="600" class="st2" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>Broadcast<v:lf/><tspan
-						x="4.05" dy="1.2em" class="st3">Req Timer</tspan></text>		</g>
-		<g id="shape1214-368" v:mID="1214" v:groupContext="shape" transform="translate(217.425,-405)">
-			<title>Sheet.1214</title>
-			<path d="M0 612 L10.85 612" class="st8"/>
-		</g>
-		<g id="shape1215-373" v:mID="1215" v:groupContext="shape" transform="translate(-371.25,291.742) rotate(-90)">
-			<title>Sheet.1215</title>
-			<path d="M0 612 L41.89 612" class="st8"/>
-		</g>
-		<g id="shape1217-378" v:mID="1217" v:groupContext="shape" transform="translate(247.273,-387)">
+						x="4" dy="1.2em" class="st3">Interface: Genbits Bus</tspan></text>		</g>
+		<g id="shape1217-361" v:mID="1217" v:groupContext="shape" transform="translate(252,-387)">
 			<title>Sheet.1217</title>
-			<path d="M0 612 L53.96 612" class="st8"/>
+			<path d="M0 612 L49.23 612" class="st8"/>
+		</g>
+		<g id="shape1218-366" v:mID="1218" v:groupContext="shape" transform="translate(-360,291.742) rotate(-90)">
+			<title>Sheet.1218</title>
+			<path d="M0 612 L66.74 612" class="st11"/>
 		</g>
 	</g>
 </svg>

--- a/hw/ip/edn/doc/edn_top_diag.svg
+++ b/hw/ip/edn/doc/edn_top_diag.svg
@@ -415,7 +415,7 @@
 			<v:textRect cx="11.5" cy="581.727" width="23.01" height="60.5461"/>
 			<rect x="0" y="551.454" width="23" height="60.5461" class="st8"/>
 			<text x="19.15" y="555.45" writing-mode="tb-rl" class="st3" v:langID="1033"><v:paragraph/><v:tabList/>peripheral<v:lf/><tspan
-						dx="-1.2em" y="50.496em 51.052em 51.608em 51.941em 52.219em" class="st13">port </tspan>0</text>		</g>
+						dx="-1.2em" y="50.496em 51.052em 51.608em 51.941em 52.219em 52.497em" class="st13">port 0</tspan></text>		</g>
 		<g id="shape189-236" v:mID="189" v:groupContext="shape" transform="translate(-218.454,563) rotate(-90)">
 			<title>Sheet.189</title>
 			<desc>peripheral port 2</desc>
@@ -423,7 +423,7 @@
 			<v:textRect cx="11.5" cy="581.727" width="23.01" height="60.5461"/>
 			<rect x="0" y="551.454" width="23" height="60.5461" class="st8"/>
 			<text x="19.15" y="555.45" writing-mode="tb-rl" class="st3" v:langID="1033"><v:paragraph/><v:tabList/>peripheral<v:lf/><tspan
-						dx="-1.2em" y="50.496em 51.052em 51.608em 51.941em 52.219em" class="st13">port </tspan>2</text>		</g>
+						dx="-1.2em" y="50.496em 51.052em 51.608em 51.941em 52.219em 52.497em" class="st13">port 2</tspan></text>		</g>
 		<g id="shape190-240" v:mID="190" v:groupContext="shape" transform="translate(-218.454,101.5) rotate(-90)">
 			<title>Sheet.190</title>
 			<desc>peripheral port 0</desc>
@@ -431,7 +431,7 @@
 			<v:textRect cx="11.5" cy="581.727" width="23.01" height="60.5461"/>
 			<rect x="0" y="551.454" width="23" height="60.5461" class="st8"/>
 			<text x="19.15" y="555.45" writing-mode="tb-rl" class="st3" v:langID="1033"><v:paragraph/><v:tabList/>peripheral<v:lf/><tspan
-						dx="-1.2em" y="50.496em 51.052em 51.608em 51.941em 52.219em" class="st13">port </tspan>0</text>		</g>
+						dx="-1.2em" y="50.496em 51.052em 51.608em 51.941em 52.219em 52.497em" class="st13">port 0</tspan></text>		</g>
 		<g id="shape191-244" v:mID="191" v:groupContext="shape" transform="translate(-218.454,270) rotate(-90)">
 			<title>Sheet.191</title>
 			<desc>peripheral port N</desc>
@@ -447,7 +447,7 @@
 			<v:textRect cx="11.5" cy="581.727" width="23.01" height="60.5461"/>
 			<rect x="0" y="551.454" width="23" height="60.5461" class="st8"/>
 			<text x="19.15" y="555.45" writing-mode="tb-rl" class="st3" v:langID="1033"><v:paragraph/><v:tabList/>peripheral<v:lf/><tspan
-						dx="-1.2em" y="50.496em 51.052em 51.608em 51.941em 52.219em" class="st13">port </tspan>1</text>		</g>
+						dx="-1.2em" y="50.496em 51.052em 51.608em 51.941em 52.219em 52.497em" class="st13">port 1</tspan></text>		</g>
 		<g id="shape194-252" v:mID="194" v:groupContext="shape" transform="translate(148.375,-251)">
 			<title>Sheet.194</title>
 			<desc>req</desc>
@@ -509,7 +509,7 @@
 			<v:textRect cx="11.5" cy="581.727" width="23.01" height="60.5461"/>
 			<rect x="0" y="551.454" width="23" height="60.5461" class="st8"/>
 			<text x="19.15" y="555.45" writing-mode="tb-rl" class="st3" v:langID="1033"><v:paragraph/><v:tabList/>peripheral<v:lf/><tspan
-						dx="-1.2em" y="50.496em 51.052em 51.608em 51.941em 52.219em" class="st13">port </tspan>1</text>		</g>
+						dx="-1.2em" y="50.496em 51.052em 51.608em 51.941em 52.219em 52.497em" class="st13">port 1</tspan></text>		</g>
 		<g id="shape204-289" v:mID="204" v:groupContext="shape" transform="translate(-24.5041,133) rotate(-90)">
 			<title>Sheet.204</title>
 			<desc>Application Interface Port 0</desc>
@@ -518,8 +518,8 @@
 			<rect x="0" y="544.254" width="23" height="67.7459" class="st8"/>
 			<text x="25.75" y="548.25" writing-mode="tb-rl" class="st3" v:langID="1033"><v:paragraph/><v:tabList/>Application <tspan
 						dx="-1.2em" y="49.841em 50.119em 50.675em 50.953em 51.509em 51.842em 52.12em 52.676em 53.176em 53.732em"
-						class="st13">Interface </tspan><tspan dx="-1.2em" y="49.841em 50.508em 51.064em 51.397em 51.675em"
-						class="st13">Port </tspan>0</text>		</g>
+						class="st13">Interface </tspan><tspan dx="-1.2em" y="49.841em 50.508em 51.064em 51.397em 51.675em 51.953em"
+						class="st13">Port 0</tspan></text>		</g>
 		<g id="shape205-294" v:mID="205" v:groupContext="shape" transform="translate(-24.5041,369) rotate(-90)">
 			<title>Sheet.205</title>
 			<desc>Application Interface Port 1</desc>
@@ -528,8 +528,8 @@
 			<rect x="0" y="544.254" width="23" height="67.7459" class="st8"/>
 			<text x="25.75" y="548.25" writing-mode="tb-rl" class="st3" v:langID="1033"><v:paragraph/><v:tabList/>Application <tspan
 						dx="-1.2em" y="49.841em 50.119em 50.675em 50.953em 51.509em 51.842em 52.12em 52.676em 53.176em 53.732em"
-						class="st13">Interface </tspan><tspan dx="-1.2em" y="49.841em 50.508em 51.064em 51.397em 51.675em"
-						class="st13">Port </tspan>1</text>		</g>
+						class="st13">Interface </tspan><tspan dx="-1.2em" y="49.841em 50.508em 51.064em 51.397em 51.675em 51.953em"
+						class="st13">Port 1</tspan></text>		</g>
 		<g id="shape206-299" v:mID="206" v:groupContext="shape" transform="translate(686.125,-299.25)">
 			<title>Sheet.206</title>
 			<desc>entropy_src</desc>
@@ -548,7 +548,7 @@
 			<v:textRect cx="23.75" cy="602" width="47.5" height="20"/>
 			<rect x="0" y="592" width="47.5" height="20" class="st8"/>
 			<text x="4" y="605.3" class="st3" v:langID="1033"><v:paragraph/><v:tabList/>req</text>		</g>
-		<g id="shape216-310" v:mID="216" v:groupContext="shape" transform="translate(607.5,-439) rotate(6.99858E-007)">
+		<g id="shape216-310" v:mID="216" v:groupContext="shape" transform="translate(607.5,-439) rotate(6.99858E-07)">
 			<title>Sheet.216</title>
 			<path d="M5.8 612 L6.16 612 L78.08 612" class="st14"/>
 		</g>


### PR DESCRIPTION
As part of the review process, broadcast mode was dropped.

The broadcast timer shows up in the graphic.

The request/ack waveform was updated.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>