### PR TITLE
[otp_ctrl/fpv] update error code assertion

### DIFF
--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_dai.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_dai.sv
@@ -685,7 +685,7 @@ module otp_ctrl_dai
   // OTP error response
   `ASSERT(OtpErrorState_A,
       state_q inside {InitOtpSt, ReadWaitSt, WriteWaitSt, DigReadWaitSt} && otp_rvalid_i &&
-      !(otp_err_i inside {NoErr, OtpReadCorrErr})
+      !(otp_err_i inside {NoErr, OtpReadCorrErr, OtpWriteBlankErr})
       |=>
       state_q == ErrorSt && error_o == $past(otp_err_i))
 


### PR DESCRIPTION
This `OtpErrorState_A` ensures OTP unrecoverable errors go to terminal
state. But the unrecoverable errors seem to be out-of-dated.
This PR added all recoverable errors from the spec.

Signed-off-by: Cindy Chen <chencindy@google.com>