### PR TITLE
[dv] Fix 2 regression failures

### DIFF
--- a/hw/dv/sv/dv_base_reg/dv_base_reg.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg.sv
@@ -127,6 +127,10 @@ class dv_base_reg extends uvm_reg;
   virtual task post_write(uvm_reg_item rw);
     dv_base_reg_field fields[$];
     string field_access;
+
+    // no need to update shadow value or access type if access is not OK, as access is aborted
+    if (rw.status != UVM_IS_OK) return;
+
     if (is_shadowed) begin
       // first write
       if (!shadow_wr_staged) begin

--- a/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
@@ -85,6 +85,7 @@ class dv_base_reg_block extends uvm_reg_block;
   // when reset issued - the locked registers' access will be reset to original access
   virtual function void reset(string kind = "HARD");
     dv_base_reg enable_regs[$];
+    `uvm_info(`gfn, "Resetting RAL reg block", UVM_MEDIUM)
     super.reset(kind);
     get_enable_regs(enable_regs);
     foreach (enable_regs[i]) enable_regs[i].set_locked_regs_access();

--- a/hw/ip/uart/dv/env/uart_scoreboard.sv
+++ b/hw/ip/uart/dv/env/uart_scoreboard.sv
@@ -224,6 +224,8 @@ class uart_scoreboard extends cip_base_scoreboard #(.CFG_T(uart_env_cfg),
           end
           fork begin
             int loc_tx_q_size = tx_q.size();
+            // remove 1 when it's abort to be popped for transfer
+            if (tx_enabled && tx_processing_item_q.size == 0 && tx_q.size > 0) loc_tx_q_size--;
             // use negedge to avoid race condition
             cfg.clk_rst_vif.wait_n_clks(NUM_CLK_DLY_TO_UPDATE_TX_WATERMARK);
             if (ral.ctrl.slpbk.get_mirrored_value()) begin


### PR DESCRIPTION
1. uart tx watermark calculation needs to remove one for the processing item
2. Shouldn't update predicted reg value in post_write when the item is
aborted (rw.state == UVM_NOT_OK)

Signed-off-by: Weicai Yang <weicai@google.com>