### PR TITLE
[verilator] Move Stop Address into Test Area

### DIFF
--- a/hw/top_earlgrey/top_earlgrey_verilator.core
+++ b/hw/top_earlgrey/top_earlgrey_verilator.core
@@ -78,7 +78,7 @@ targets:
       - PRIM_DEFAULT_IMPL=prim_pkg::ImplGeneric
       - RVFI=true
       - VERILATOR_MEM_BASE=0x10000000
-      - VERILATOR_END_SIM_ADDR=0x10008000
+      - VERILATOR_END_SIM_ADDR=0x1000fff4
       - flashinit
       - rominit
       - DMIDirectTAP

--- a/sw/device/lib/arch/device_sim_verilator.c
+++ b/sw/device/lib/arch/device_sim_verilator.c
@@ -20,7 +20,7 @@ const uint64_t kClockFreqUsbHz = 500 * 1000;  // 500kHz
 const uint64_t kUartBaudrate = 7200;
 
 // Defined in `hw/top_earlgrey/top_earlgrey_verilator.core`
-const uintptr_t kDeviceStopAddress = 0x10008000;
+const uintptr_t kDeviceStopAddress = 0x1000fff4;
 
 const uintptr_t kDeviceTestStatusAddress = 0;
 


### PR DESCRIPTION
This is an interim change while we wait for:
- DV to move the log address and the sw test status address into the sim sram area
- Verilator to start using the sw_test_status system, and match DV's sw test status address (I have a provisional PR in #3598).

I realised we could do this as we had spare space in the test_reserved_area which is going unused at the moment (I believe).