### PR TITLE
Improvements to how dvsim.py runs jobs

### DIFF
--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -734,9 +734,11 @@ class CovMerge(Deploy):
     # Register all builds with the class
     items = []
 
-    def __init__(self, sim_cfg):
+    def __init__(self, run_items, sim_cfg):
         # Initialize common vars.
         super().__init__(sim_cfg)
+
+        self.dependencies += run_items
 
         self.target = "cov_merge"
         self.pass_patterns = []

--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -26,9 +26,6 @@ class Deploy():
     Abstraction for deploying builds and runs.
     """
 
-    # Maintain a list of dispatched items.
-    dispatch_counter = 0
-
     # Misc common deploy settings.
     max_odirs = 5
 
@@ -272,7 +269,6 @@ class Deploy():
                                             stderr=f,
                                             env=exports)
             self.log_fd = f
-            Deploy.dispatch_counter += 1
         except IOError:
             if self.log_fd:
                 self.log_fd.close()
@@ -415,7 +411,6 @@ class Deploy():
         status = 'P' if self._test_passed() else 'F'
 
         log.debug("Item %s has completed execution: %s", self.name, status)
-        Deploy.dispatch_counter -= 1
         self._on_finish(status)
 
         del self.process

--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -56,9 +56,6 @@ class Deploy():
     def __str__(self):
         return self.__self_str__()
 
-    def __repr__(self):
-        return self.__self_str__()
-
     def __init__(self, sim_cfg):
         '''Initialize common class members.'''
 

--- a/util/dvsim/FlowCfg.py
+++ b/util/dvsim/FlowCfg.py
@@ -380,24 +380,34 @@ class FlowCfg():
             self._create_deploy_objects()
 
     def deploy_objects(self):
-        '''Public facing API for deploying all available objects.'''
-        Scheduler.run(self.deploy)
+        '''Public facing API for deploying all available objects.
 
-    def _gen_results(self, fmt="md"):
+        Runs each job and returns a map from item to status.
+
+        '''
+        return Scheduler.run(self.deploy)
+
+    def _gen_results(self, results):
         '''
         The function is called after the regression has completed. It collates the
         status of all run targets and generates a dict. It parses the testplan and
         maps the generated result to the testplan entries to generate a final table
         (list). It also prints the full list of failures for debug / triage. The
         final result is in markdown format.
+
+        results should be a dictionary mapping deployed item to result.
+
         '''
         return
 
-    def gen_results(self):
+    def gen_results(self, results):
         '''Public facing API for _gen_results().
+
+        results should be a dictionary mapping deployed item to result.
+
         '''
         for item in self.cfgs:
-            result = item._gen_results()
+            result = item._gen_results(results)
             log.info("[results]: [%s]:\n%s\n", item.name, result)
             log.info("[scratch_path]: [%s] [%s]", item.name, item.scratch_path)
             self.errors_seen |= item.errors_seen

--- a/util/dvsim/FlowCfg.py
+++ b/util/dvsim/FlowCfg.py
@@ -13,7 +13,7 @@ import sys
 import hjson
 
 from CfgJson import set_target_attribute
-from Deploy import Deploy
+import Scheduler
 from utils import (VERBOSE, md_results_to_html,
                    subst_wildcards, find_and_substitute_wildcards)
 
@@ -381,7 +381,7 @@ class FlowCfg():
 
     def deploy_objects(self):
         '''Public facing API for deploying all available objects.'''
-        Deploy.deploy(self.deploy)
+        Scheduler.run(self.deploy)
 
     def _gen_results(self, fmt="md"):
         '''

--- a/util/dvsim/FpvCfg.py
+++ b/util/dvsim/FpvCfg.py
@@ -183,7 +183,7 @@ class FpvCfg(OneShotCfg):
 
         return self.results_summary_md
 
-    def _gen_results(self):
+    def _gen_results(self, results):
         # This function is called after the regression and looks for
         # results.hjson file with aggregated results from the FPV run.
         # The hjson file is required to follow this format:

--- a/util/dvsim/LintCfg.py
+++ b/util/dvsim/LintCfg.py
@@ -87,7 +87,7 @@ class LintCfg(OneShotCfg):
         # Return only the tables
         return self.results_summary_md
 
-    def _gen_results(self):
+    def _gen_results(self, results):
         # '''
         # The function is called after the regression has completed. It looks
         # for a regr_results.hjson file with aggregated results from the lint run.

--- a/util/dvsim/Scheduler.py
+++ b/util/dvsim/Scheduler.py
@@ -243,7 +243,6 @@ class TargetScheduler:
 
 class Scheduler:
     '''An object to run one or more Deploy items'''
-    print_legend = True
 
     # Max jobs running at one time
     max_parallel = 16
@@ -274,12 +273,8 @@ class Scheduler:
         '''
         timer = Timer()
 
-        # Print the legend just once (at the start of the first run)
-        if Scheduler.print_legend:
-            log.info("[legend]: [Q: queued, D: dispatched, "
-                     "P: passed, F: failed, K: killed, T: total]")
-            Scheduler.print_legend = False
-
+        log.info("[legend]: [Q: queued, D: dispatched, "
+                 "P: passed, F: failed, K: killed, T: total]")
         results = {}
         for scheduler in self.schedulers.values():
             results.update(scheduler.run(timer, results))

--- a/util/dvsim/Scheduler.py
+++ b/util/dvsim/Scheduler.py
@@ -5,50 +5,137 @@
 
 from collections import OrderedDict
 import logging as log
-import time
+from signal import SIGINT, signal
+import threading
 
 from utils import VERBOSE
-from Deploy import Deploy
+from Deploy import Deploy, DeployError
 from Timer import Timer
 
 
-class TargetStatus:
-    '''An object to track the status of a run for a given target'''
+class TargetScheduler:
+    '''A scheduler for the jobs of a given target'''
     def __init__(self):
-        self.counters = OrderedDict()
-        self.counters['Q'] = 0
-        self.counters['D'] = 0
-        self.counters['P'] = 0
-        self.counters['F'] = 0
-        self.counters['K'] = 0
-        self.counters['T'] = 0
+        # Sets of items, split up by their current state. The sets are disjoint
+        # and their union equals the keys of self.item_to_status.
+        self._queued = set()
+        self._running = set()
+        self._passed = set()
+        self._failed = set()
+        self._killed = set()
 
-        self.done = True
+        # A map from the Deploy objects tracked by this class to their current
+        # status. This status is 'Q', 'D', 'P', 'F' or 'K', corresponding to
+        # membership in the dicts above.
+        self.item_to_status = {}
 
-        self.by_item = OrderedDict()
+        # A flag set by check_if_done if all jobs are done.
+        self._done = True
+
+    def check_status(self):
+        '''Return (was_done, is_done, has_started)'''
+        was_done = self._done
+        self._done = not (self._queued or self._running)
+        return (was_done,
+                self._done,
+                (self._running or self._passed or
+                 self._failed or self._killed))
+
+    def print_counters(self, tgt_name, hms):
+        total_cnt = len(self.item_to_status)
+        width = len(str(total_cnt))
+
+        field_fmt = '{{:0{}d}}'.format(width)
+        msg_fmt = ('[Q: {0}, D: {0}, P: {0}, F: {0}, K: {0}, T: {0}]'
+                   .format(field_fmt))
+        msg = msg_fmt.format(len(self._queued),
+                             len(self._running),
+                             len(self._passed),
+                             len(self._failed),
+                             len(self._killed),
+                             total_cnt)
+        log.info("[%s]: [%s]: %s", hms, tgt_name, msg)
 
     def add_item(self, item):
-        self.by_item[item] = 'Q'
-        self.counters['T'] += 1
-        self.counters['Q'] += 1
-        self.done = False
+        assert item not in self.item_to_status
+        self.item_to_status[item] = 'Q'
+        self._queued.add(item)
+        self._done = False
 
-    def update_item(self, item):
-        '''Update the tracked status of the item. Return true on change.'''
-        old_status = self.by_item[item]
-        if item.status == old_status:
-            return False
+    def _kill_item(self, item):
+        '''Kill a running item'''
+        self._running.remove(item)
+        item.kill()
+        self._killed.add(item)
+        self.item_to_status[item] = 'K'
 
-        self.by_item[item] = item.status
+    def dispatch(self, items):
+        '''Start (dispatch) each item in the list'''
+        for item in items:
+            assert item in self._queued
+            self._queued.remove(item)
+            self._running.add(item)
+            self.item_to_status[item] = 'D'
+            try:
+                item.dispatch_cmd()
+            except DeployError as err:
+                log.error('{}'.format(err))
+                self._kill_item(item)
 
-        self.counters[old_status] -= 1
-        self.counters[item.status] += 1
-        return True
+    def kill(self):
+        '''Kill any running items and cancel any that are waiting'''
 
-    def check_if_done(self):
-        '''Update done flag to match counters. Returns done flag.'''
-        self.done = (self.counters['Q'] == 0) and (self.counters['D'] == 0)
-        return self.done
+        # Cancel any waiting items. We take a copy of self._queued to avoid
+        # iterating over the set as we modify it.
+        for item in [item for item in self._queued]:
+            self.cancel(item)
+
+        # Kill any running items. Again, take a copy of the set to avoid
+        # modifying it while iterating over it.
+        for item in [item for item in self._running]:
+            self._kill_item(item)
+
+    def poll(self, hms):
+        '''Check for running items that have finished
+
+        Returns True if something changed.
+
+        '''
+        to_pass = []
+        to_fail = []
+
+        for item in self._running:
+            status = item.poll()
+            assert status in ['D', 'P', 'F']
+            if status == 'D':
+                # Still running
+                continue
+            elif status == 'P':
+                log.log(VERBOSE, "[%s]: [%s]: [status] [%s: P]",
+                        hms, item.target, item.identifier)
+                to_pass.append(item)
+            else:
+                log.error("[%s]: [%s]: [status] [%s: F]",
+                          hms, item.target, item.identifier)
+                to_fail.append(item)
+
+        for item in to_pass:
+            self._running.remove(item)
+            self._passed.add(item)
+            self.item_to_status[item] = 'P'
+        for item in to_fail:
+            self._running.remove(item)
+            self._failed.add(item)
+            self.item_to_status[item] = 'F'
+
+        return to_pass or to_fail
+
+    def cancel(self, item):
+        '''Cancel an item that is currently queued'''
+        assert item in self._queued
+        self._queued.remove(item)
+        self._killed.add(item)
+        self.item_to_status[item] = 'K'
 
 
 class Scheduler:
@@ -67,8 +154,8 @@ class Scheduler:
         self.dispatched_items = []
 
         # An ordered dictionary keyed by target ('build', 'run' or similar).
-        # The value for each target is a TargetStatus object.
-        self.status = OrderedDict()
+        # The value for each target is a TargetScheduler object.
+        self.schedulers = OrderedDict()
 
         for item in items:
             self.add_item(item)
@@ -77,39 +164,27 @@ class Scheduler:
         '''Add a queued item'''
         self.queued_items.append(item)
 
-        # Like setdefault, but doesn't construct a TargetStatus object
+        # Like setdefault, but doesn't construct a TargetScheduler object
         # unnecessarily.
-        tgt_status = self.status.get(item.target)
-        if tgt_status is None:
-            tgt_status = TargetStatus()
-            self.status[item.target] = tgt_status
+        tgt_scheduler = self.schedulers.get(item.target)
+        if tgt_scheduler is None:
+            tgt_scheduler = TargetScheduler()
+            self.schedulers[item.target] = tgt_scheduler
 
-        tgt_status.add_item(item)
+        tgt_scheduler.add_item(item)
 
-    def update_status(self):
-        '''Update status of dispatched items. Returns true on a change'''
+    def kill(self):
+        '''Kill any running items and cancel any that are waiting'''
+        for scheduler in self.schedulers.values():
+            scheduler.kill()
+
+    def poll(self):
+        '''Update status of running items. Returns true on a change'''
         status_changed = False
         hms = self.timer.hms()
-
-        # Get status of dispatched items
-        for item in self.dispatched_items:
-            if item.status == 'D':
-                item.get_status()
-
-            tgt_status = self.status[item.target]
-            if not tgt_status.update_item(item):
-                continue
-
-            status_changed = True
-            if item.status == "D":
-                continue
-
-            if item.status != "P":
-                log.error("[%s]: [%s]: [status] [%s: %s]",
-                          hms, item.target, item.identifier, item.status)
-            else:
-                log.log(VERBOSE, "[%s]: [%s]: [status] [%s: %s]",
-                        hms, item.target, item.identifier, item.status)
+        for scheduler in self.schedulers.values():
+            if scheduler.poll(hms):
+                status_changed = True
 
         return status_changed
 
@@ -124,11 +199,12 @@ class Scheduler:
         # We only dispatch things for one target at once.
         cur_tgt = None
         for item in self.dispatched_items:
-            if item.status == 'D':
+            if item.process is not None:
                 cur_tgt = item.target
                 break
 
         to_dispatch = []
+
         while len(to_dispatch) < num_slots and self.queued_items:
             next_item = self.queued_items[0]
 
@@ -146,34 +222,34 @@ class Scheduler:
             # earlier in the list than we do.
             has_failed_dep = False
             for dep in next_item.dependencies:
-                assert dep.status in ['P', 'F', 'K']
-                if dep.status in ['F', 'K']:
+                dep_status = self.schedulers[dep.target].item_to_status[dep]
+                assert dep_status in ['P', 'F', 'K']
+                if dep_status in ['F', 'K']:
                     has_failed_dep = True
                     break
 
             # If has_failed_dep then at least one of the dependencies has been
             # cancelled or has run and failed. Give up on this item too.
             if has_failed_dep:
-                next_item.status = 'K'
+                self.schedulers[cur_tgt].cancel(next_item)
                 continue
 
             to_dispatch.append(next_item)
 
+        if not to_dispatch:
+            return
+
+        assert cur_tgt is not None
+
         self.dispatched_items.extend(to_dispatch)
+        self.schedulers[cur_tgt].dispatch(to_dispatch)
 
-        tgt_names = OrderedDict()
-        for item in to_dispatch:
-            if item.status is None:
-                tgt_names.setdefault(item.target, []).append(item.identifier)
-                item.dispatch_cmd()
-
-        hms = self.timer.hms()
-        for target, names in tgt_names.items():
-            log.log(VERBOSE, "[%s]: [%s]: [dispatch]:\n%s",
-                    hms, target, ", ".join(names))
+        log.log(VERBOSE, "[%s]: [%s]: [dispatch]:\n%s",
+                self.timer.hms(), cur_tgt,
+                ", ".join(item.identifier for item in to_dispatch))
 
     def check_if_done(self, print_status):
-        '''Update the "done" flag for each TargetStatus object
+        '''Check whether we are finished.
 
         If print_status or we've reached a time interval then print current
         status for those that weren't known to be finished already.
@@ -186,30 +262,25 @@ class Scheduler:
 
         all_done = True
         printed_something = False
-        for target, tgt_status in self.status.items():
-            was_done = tgt_status.done
-            tgt_status.check_if_done()
-            is_done = tgt_status.done
-            all_queued = tgt_status.counters['Q'] == tgt_status.counters['T']
-
+        for target, scheduler in self.schedulers.items():
+            was_done, is_done, has_started = scheduler.check_status()
             all_done &= is_done
 
             should_print = (print_status and
                             not (was_done and is_done) and
-                            not (printed_something and all_queued))
+                            (has_started or not printed_something))
             if should_print:
-                stats = tgt_status.counters
-                width = "0{}d".format(len(str(stats["T"])))
-                msg = "["
-                for s in stats.keys():
-                    msg += s + ": {:{}}, ".format(stats[s], width)
-                msg = msg[:-2] + "]"
+                scheduler.print_counters(target, hms)
                 printed_something = True
-                log.info("[%s]: [%s]: %s", hms, target, msg)
+
         return all_done
 
     def run(self):
-        '''Run all items'''
+        '''Run all items
+
+        Returns a map from item to status.
+
+        '''
 
         # Print the legend just once (at the start of the first run)
         if Scheduler.print_legend:
@@ -217,16 +288,58 @@ class Scheduler:
                      "P: passed, F: failed, K: killed, T: total]")
             Scheduler.print_legend = False
 
-        first_time = True
-        while True:
-            changed = self.update_status()
-            self.dispatch()
-            if self.check_if_done(changed or first_time):
-                break
-            first_time = False
-            time.sleep(1)
+        # Catch one SIGINT and tell the scheduler to quit. On a second, die.
+        stop_now = threading.Event()
+        old_handler = None
+
+        def on_sigint(signal_received, frame):
+            log.info('Received SIGINT. Exiting gracefully. '
+                     'Send another to force immediate quit '
+                     '(but you may need to manually kill child processes)')
+
+            # Restore old handler to catch any second signal
+            assert old_handler is not None
+            signal(SIGINT, old_handler)
+
+            stop_now.set()
+
+        old_handler = signal(SIGINT, on_sigint)
+
+        try:
+            first_time = True
+            while True:
+                if stop_now.is_set():
+                    # We've had an interrupt. Kill any jobs that are running,
+                    # then exit.
+                    self.kill()
+                    exit(1)
+
+                changed = self.poll()
+                self.dispatch()
+                if self.check_if_done(changed or first_time):
+                    break
+                first_time = False
+
+                # This is essentially sleep(1) to wait a second between each
+                # polling loop. But we do it with a bounded wait on stop_now so
+                # that we jump back to the polling loop immediately on a
+                # signal.
+                stop_now.wait(timeout=1)
+        finally:
+            signal(SIGINT, old_handler)
+
+        # We got to the end without anything exploding. Extract and return
+        # results from the schedulers.
+        results = {}
+        for scheduler in self.schedulers.values():
+            results.update(scheduler.item_to_status)
+        return results
 
 
 def run(items):
-    '''Run the given items'''
-    Scheduler(items).run()
+    '''Run the given items.
+
+    Returns a map from item to status.
+
+    '''
+    return Scheduler(items).run()

--- a/util/dvsim/Scheduler.py
+++ b/util/dvsim/Scheduler.py
@@ -9,7 +9,7 @@ from signal import SIGINT, signal
 import threading
 
 from utils import VERBOSE
-from Deploy import Deploy, DeployError
+from Deploy import DeployError
 from Timer import Timer
 
 
@@ -89,10 +89,9 @@ class TargetScheduler:
 
         '''
         num_slots = min(Scheduler.slot_limit,
-                        Scheduler.max_parallel - Deploy.dispatch_counter,
+                        Scheduler.max_parallel - len(self._running),
                         len(self._queued))
-
-        if not num_slots:
+        if num_slots <= 0:
             return
 
         to_dispatch = []

--- a/util/dvsim/Scheduler.py
+++ b/util/dvsim/Scheduler.py
@@ -1,0 +1,196 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+
+from collections import OrderedDict
+import logging as log
+import time
+
+from utils import VERBOSE
+from Deploy import Deploy
+from Timer import Timer
+
+
+class TargetStatus:
+    '''An object to track the status of a run for a given target'''
+    def __init__(self):
+        self.counters = OrderedDict()
+        self.counters['Q'] = 0
+        self.counters['D'] = 0
+        self.counters['P'] = 0
+        self.counters['F'] = 0
+        self.counters['K'] = 0
+        self.counters['T'] = 0
+
+        self.done = True
+
+        self.by_item = OrderedDict()
+
+    def add_item(self, item):
+        self.by_item[item] = 'Q'
+        self.counters['T'] += 1
+        self.counters['Q'] += 1
+        self.done = False
+
+    def update_item(self, item):
+        '''Update the tracked status of the item. Return true on change.'''
+        old_status = self.by_item[item]
+        if item.status == old_status:
+            return False
+
+        self.by_item[item] = item.status
+
+        self.counters[old_status] -= 1
+        self.counters[item.status] += 1
+        return True
+
+    def check_if_done(self):
+        '''Update done flag to match counters. Returns done flag.'''
+        self.done = (self.counters['Q'] == 0) and (self.counters['D'] == 0)
+        return self.done
+
+
+class Scheduler:
+    '''An object to run one or more Deploy items'''
+    print_legend = True
+
+    # Max jobs running at one time
+    max_parallel = 16
+
+    # Max jobs dispatched in one go.
+    slot_limit = 20
+
+    def __init__(self, items):
+        self.timer = Timer()
+        self.queued_items = []
+        self.dispatched_items = []
+
+        # An ordered dictionary keyed by target ('build', 'run' or similar).
+        # The value for each target is a TargetStatus object.
+        self.status = OrderedDict()
+
+        for item in items:
+            self.add_item(item)
+
+    def add_item(self, item):
+        '''Add a queued item'''
+        self.queued_items.append(item)
+
+        # Like setdefault, but doesn't construct a TargetStatus object
+        # unnecessarily.
+        tgt_status = self.status.get(item.target)
+        if tgt_status is None:
+            tgt_status = TargetStatus()
+            self.status[item.target] = tgt_status
+
+        tgt_status.add_item(item)
+
+    def update_status(self):
+        '''Update status of dispatched items. Returns true on a change'''
+        status_changed = False
+        hms = self.timer.hms()
+
+        # Get status of dispatched items
+        for item in self.dispatched_items:
+            if item.status == 'D':
+                item.get_status()
+
+            tgt_status = self.status[item.target]
+            if not tgt_status.update_item(item):
+                continue
+
+            status_changed = True
+            if item.status == "D":
+                continue
+
+            if item.status != "P":
+                # Kill its sub items if item did not pass.
+                item.set_sub_status("K")
+                log.error("[%s]: [%s]: [status] [%s: %s]",
+                          hms, item.target, item.identifier, item.status)
+            else:
+                log.log(VERBOSE, "[%s]: [%s]: [status] [%s: %s]",
+                        hms, item.target, item.identifier, item.status)
+
+            # Queue items' sub-items if it is done.
+            for sub_item in item.sub:
+                self.add_item(sub_item)
+
+        return status_changed
+
+    def dispatch(self):
+        '''Dispatch some queued items if possible'''
+        num_slots = min(Scheduler.slot_limit,
+                        Scheduler.max_parallel - Deploy.dispatch_counter,
+                        len(self.queued_items))
+        if not num_slots:
+            return
+
+        items = self.queued_items[0:num_slots]
+        self.queued_items = self.queued_items[num_slots:]
+        self.dispatched_items.extend(items)
+
+        tgt_names = OrderedDict()
+        for item in items:
+            if item.status is None:
+                tgt_names.setdefault(item.target, []).append(item.identifier)
+                item.dispatch_cmd()
+
+        hms = self.timer.hms()
+        for target, names in tgt_names.items():
+            log.log(VERBOSE, "[%s]: [%s]: [dispatch]:\n%s",
+                    hms, target, ", ".join(names))
+
+    def check_if_done(self, print_status):
+        '''Update the "done" flag for each TargetStatus object
+
+        If print_status or we've reached a time interval then print current
+        status for those that weren't known to be finished already.
+
+        '''
+        if self.timer.check_time():
+            print_status = True
+
+        hms = self.timer.hms()
+
+        all_done = True
+        for target, tgt_status in self.status.items():
+            was_done = tgt_status.done
+            tgt_status.check_if_done()
+            is_done = tgt_status.done
+
+            all_done &= is_done
+
+            if print_status and not (was_done and is_done):
+                stats = tgt_status.counters
+                width = "0{}d".format(len(str(stats["T"])))
+                msg = "["
+                for s in stats.keys():
+                    msg += s + ": {:{}}, ".format(stats[s], width)
+                msg = msg[:-2] + "]"
+                log.info("[%s]: [%s]: %s", hms, target, msg)
+        return all_done
+
+    def run(self):
+        '''Run all items'''
+
+        # Print the legend just once (at the start of the first run)
+        if Scheduler.print_legend:
+            log.info("[legend]: [Q: queued, D: dispatched, "
+                     "P: passed, F: failed, K: killed, T: total]")
+            Scheduler.print_legend = False
+
+        first_time = True
+        while True:
+            changed = self.update_status()
+            self.dispatch()
+            if self.check_if_done(changed or first_time):
+                break
+            first_time = False
+            time.sleep(1)
+
+
+def run(items):
+    '''Run the given items'''
+    Scheduler(items).run()

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -12,8 +12,8 @@ import subprocess
 import sys
 from collections import OrderedDict
 
-from Deploy import (CompileSim, CovAnalyze, CovMerge, CovReport, CovUnr,
-                    Deploy, RunTest)
+from Deploy import CompileSim, CovAnalyze, CovMerge, CovReport, CovUnr, RunTest
+import Scheduler
 from FlowCfg import FlowCfg
 from Modes import BuildModes, Modes, Regressions, RunModes, Tests
 from tabulate import tabulate
@@ -533,7 +533,7 @@ class SimCfg(FlowCfg):
 
         # If coverage is enabled, then deploy the coverage tasks.
         if self.cov:
-            Deploy.deploy(self.cov_deploys)
+            Scheduler.run(self.cov_deploys)
 
     def _cov_analyze(self):
         '''Use the last regression coverage data to open up the GUI tool to

--- a/util/dvsim/Timer.py
+++ b/util/dvsim/Timer.py
@@ -1,0 +1,50 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import time
+
+
+class Timer:
+    '''A timer to keep track of how long jobs have been running
+
+    This has a notion of start time (the time when the object was constructed),
+    together with a time when the results should next be printed.
+
+    '''
+
+    print_interval = 5
+
+    def __init__(self):
+        self.start = time.monotonic()
+        self.next_print = self.start + Timer.print_interval
+
+    def period(self):
+        '''Return the float time in seconds since start'''
+        return time.monotonic() - self.start
+
+    def hms(self):
+        '''Get the time since start in hh:mm:ss'''
+        period = self.period()
+        secs = int(period + 0.5)
+        mins = secs // 60
+        hours = mins // 60
+        return '{:02}:{:02}:{:02}'.format(hours, mins % 60, secs % 60)
+
+    def check_time(self):
+        '''Return true if we have passed next_print.
+
+        If so, increment next_print by print_interval unless the result would
+        be in the past, in which case set it to the current time plus
+        print_interval.
+
+        '''
+        now = time.monotonic()
+        if now < self.next_print:
+            return False
+
+        self.next_print += Timer.print_interval
+        if self.next_print <= now:
+            self.next_print = now + Timer.print_interval
+
+        return True

--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -31,6 +31,7 @@ import textwrap
 from signal import SIGINT, signal
 
 import Deploy
+import Timer
 import utils
 from CfgFactory import make_cfg
 
@@ -636,7 +637,7 @@ def main():
     Deploy.RunTest.fixed_seed = args.fixed_seed
 
     # Register the common deploy settings.
-    Deploy.Deploy.print_interval = args.print_interval
+    Timer.Timer.print_interval = args.print_interval
     Deploy.Deploy.max_parallel = args.max_parallel
     Deploy.Deploy.max_odirs = args.max_odirs
 

--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -31,7 +31,8 @@ import textwrap
 from signal import SIGINT, signal
 
 import Deploy
-import Timer
+from Scheduler import Scheduler
+from Timer import Timer
 import utils
 from CfgFactory import make_cfg
 
@@ -637,8 +638,8 @@ def main():
     Deploy.RunTest.fixed_seed = args.fixed_seed
 
     # Register the common deploy settings.
-    Timer.Timer.print_interval = args.print_interval
-    Deploy.Deploy.max_parallel = args.max_parallel
+    Timer.print_interval = args.print_interval
+    Scheduler.max_parallel = args.max_parallel
     Deploy.Deploy.max_odirs = args.max_odirs
 
     # Build infrastructure from hjson file and create the list of items to

--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -28,7 +28,6 @@ import shlex
 import subprocess
 import sys
 import textwrap
-from signal import SIGINT, signal
 
 import Deploy
 from Scheduler import Scheduler
@@ -184,14 +183,6 @@ def resolve_proj_root(args):
         proj_root_dest = proj_root_src
 
     return proj_root_src, proj_root_dest
-
-
-def sigint_handler(signal_received, frame):
-    # Kill processes and background jobs.
-    log.debug('SIGINT or CTRL-C detected. Exiting gracefully')
-    cfg.kill()
-    log.info('Exit due to SIGINT or CTRL-C ')
-    exit(1)
 
 
 def copy_repo(src, dest, dry_run):
@@ -647,9 +638,6 @@ def main():
     global cfg
     cfg = make_cfg(args.cfg, args, proj_root)
 
-    # Handle Ctrl-C exit.
-    signal(SIGINT, sigint_handler)
-
     # List items available for run if --list switch is passed, and exit.
     if args.list is not None:
         cfg.print_list()
@@ -677,10 +665,10 @@ def main():
     if args.items != []:
         # Create deploy objects.
         cfg.create_deploy_objects()
-        cfg.deploy_objects()
+        results = cfg.deploy_objects()
 
         # Generate results.
-        cfg.gen_results()
+        cfg.gen_results(results)
 
         # Publish results
         if args.publish:

--- a/util/dvsim/testplanner/class_defs.py
+++ b/util/dvsim/testplanner/class_defs.py
@@ -12,6 +12,14 @@ import mistletoe
 from tabulate import tabulate
 
 
+class TestResult:
+    '''The results for a single test'''
+    def __init__(self, name):
+        self.name = name
+        self.passing = 0
+        self.total = 0
+
+
 class TestplanEntry():
     """An entry in the testplan
 
@@ -312,10 +320,19 @@ class Testplan():
         result = result.replace("&gt;", ">")
         return result
 
-    def results_table(self, regr_results, map_full_testplan=True, fmt="pipe"):
+    def results_table(self, test_results, map_full_testplan=True, fmt="pipe"):
         '''Print the mapped regression results into a table in the format
         specified by the 'fmt' arg.
+
+        test_results should be a list of TestResult objects, one for each named
+        test.
+
         '''
+        # Generate a list of dictionaries as expected by map_regr_results. In
+        # future, that code could be tightened up to use proper classes too,
+        # but let's put a shim here for now.
+        regr_results = [{"name": tr.name, "passing": tr.passing, "total": tr.total}
+                        for tr in test_results]
         self.map_regr_results(regr_results, map_full_testplan)
         table = [[
             "Milestone", "Name", "Tests", "Passing", "Total", "Pass Rate"


### PR DESCRIPTION
This patch queue tries to unpick some of the logic in `Deploy.py` which has got a little tangled. There are quite a few commits (9), because I wanted to merge incremental, bisectable changes rather than a giant "rewrite the world" commit.

The main thrust of the set of patches is to move the scheduling logic into a new file (`Runner.py`) and untangle all the "scheduley" bits from the code in the `Deploy` class. There are a few main changes:

1. Job tracking is now done in a scheduler class, rather than in the `Deploy` class, which also represents jobs to be run.
1. Jobs now have a notion of dependencies, rather than the ability to spawn new jobs. This matches other build systems much more closely, and also simplifies how we do coverage runs.
1. Signal handling (intercepting SIGINT) is now done by the scheduler rather than `dvsim.py`.

There are a few user-visible changes (and hopefully no bugs!):

1. If you have 100 tests that depend on 1 build and the build fails, you don't have to wait `100 / parallelism` seconds for dvsim to crank through the tests it can't run.
1. The timer doesn't reset to zero when starting coverage collection.

This refactoring also makes it possible to make other improvements in the future. For example, it would now be much simpler to add LSF job array support: we could essentially just dump the commands for a given target into shell scripts and then fire them all off at once. In the code, this would be represented by an `LSFTargetRunner` class (subclassing `TargetRunner`) with a specialized (and simplified!) `run` method.

Another possible future improvement (which is slightly at odds with LSF magic) is to allow different "targets" (the phases of the run) to run at once, which would allow you to fire off some runs as soon as their build was ready. This would make no difference on my laptop (with few cores and fewer EDA licences), but might make a significant difference on a big compute cluster, where you can get started on the big list of tests as soon as some can be run. Of course, this is getting to look awfully like a Make replacement: if we move further in that direction, I suggest dumping commands into shell scripts and writing out the dependency DAG to a Makefile.

@cindychip, @msfschaffner: As usual, I can't try out some of the linter commands or the FPV commands locally. If you have a minute, I'd be really grateful if you could try out this PR to make sure I haven't broken anything with a silly typo. I think that most of the cleverness is on the simulation side (which I could test), so I'm hopeful this will work.
