### PR TITLE
[dv/hmac] increase FSM reset coverage

### DIFF
--- a/hw/ip/hmac/dv/hmac_sim_cfg.hjson
+++ b/hw/ip/hmac/dv/hmac_sim_cfg.hjson
@@ -107,6 +107,7 @@
       // Append the common stress_tests.hjson entry for more run_opts.
       name: hmac_stress_all_with_rand_reset
       run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0"]
+      reseed: 200
     }
   ]
 


### PR DESCRIPTION
Increase nightly hmac reset related FSM coverage by increasing the seed
for hmac_stress_all_with_rand_reset seq.

Signed-off-by: Cindy Chen <chencindy@google.com>