### PR TITLE
[dv/shadow_reg] top-level shadow reg sequence

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -32,8 +32,6 @@
                 "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",
                 // Common CIP test lists
                 "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
-                // TODO: temp commented out to avoid regression errors, will support soon
-                // "{proj_root}/hw/dv/tools/dvsim/tests/shadow_reg_errors_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/mem_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
                 // xbar tests
@@ -200,7 +198,12 @@
                  "+sw_test_is_external=1",
                  "+sw_test_timeout_ns=50000000"]
     }
-
+    {
+      name: chip_shadow_reg_errors
+      uvm_test_seq: chip_shadow_reg_errors_vseq
+      en_run_modes: ["stub_cpu"]
+      run_opts: ["+en_scb=0"]
+    }
     // The test below is added in the included tl_access_tests.hjson.
     // We just need to append the stub_cpu run mode to it.
     {

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -28,6 +28,7 @@ filesets:
       - seq_lib/chip_vseq_list.sv: {is_include_file: true}
       - seq_lib/chip_base_vseq.sv: {is_include_file: true}
       - seq_lib/chip_common_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_shadow_reg_errors_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_base_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_uart_tx_rx_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_gpio_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -7,6 +7,7 @@ package chip_env_pkg;
   import uvm_pkg::*;
   import top_pkg::*;
   import dv_utils_pkg::*;
+  import dv_base_reg_pkg::*;
   import csr_utils_pkg::*;
   import tl_agent_pkg::*;
   import uart_agent_pkg::*;

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_shadow_reg_errors_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_shadow_reg_errors_vseq.sv
@@ -1,0 +1,67 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This sequence tests shadow_registers' update error and storage error
+// The sequence will loop thorugh all shadow_regs from each IP
+// It will create update error by first write value 'h5555_5555 to shadow_reg, then write value
+// 'haaaa_aaaa as second write, and check the corresponding alert handshake
+// It will create storage error by randomly backdoor write to shadow register's committed_val or
+// shadow_val, and check the corresponding alert handshake
+class chip_shadow_reg_errors_vseq extends chip_common_vseq;
+  `uvm_object_utils(chip_shadow_reg_errors_vseq)
+  `uvm_object_new
+
+  // Most of the shadow_reg related tasks are from `dv/sv/cip_lib/cip_base_vseq.sv`
+  virtual task body();
+    dv_base_reg shadowed_csrs[$], non_shadowed_csrs[$];
+
+    // Get all shadowed_regs from each IP
+    split_all_csrs_by_shadowed(shadowed_csrs, non_shadowed_csrs);
+    shadowed_csrs.shuffle();
+
+    foreach (shadowed_csrs[i]) begin
+      bit             alert_triggered;
+      string          alert_name;
+      bit [TL_DW-1:0] origin_val, poke_val;
+      bkdr_reg_path_e kind;
+
+      // Create update error
+      wr_shadowed_reg_update_err(shadowed_csrs[i], alert_triggered);
+
+      // Check update error alerts
+      alert_name = get_alert_agent_name(err_update, shadowed_csrs[i]);
+      `DV_SPINWAIT(while (!alert_triggered && !cfg.m_alert_agent_cfg[alert_name].vif.get_alert())
+                   cfg.clk_rst_vif.wait_clks(1);,
+                   $sformatf("%0s update_err alert not detected", shadowed_csrs[i].get_name()));
+      `DV_SPINWAIT(cfg.m_alert_agent_cfg[alert_name].vif.wait_ack_complete();,
+                   $sformatf("timeout for alert:%0s", alert_name))
+
+      // Create storage error, randomly choose to poke committed or shadow value
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(kind, kind inside
+                                         {BkdrRegPathRtlCommitted, BkdrRegPathRtlShadow};)
+      csr_peek(.ptr(shadowed_csrs[i]), .value(origin_val), .kind(kind));
+      poke_val = gen_storage_err_val(shadowed_csrs[i], origin_val, 0);
+      csr_poke(.csr(shadowed_csrs[i]), .value(poke_val), .kind(kind), .predict(1));
+
+      // Check storage error alerts
+      alert_name = get_alert_agent_name(err_storage, shadowed_csrs[i]);
+      `DV_SPINWAIT(while (!cfg.m_alert_agent_cfg[alert_name].vif.get_alert())
+                   cfg.clk_rst_vif.wait_clks(1);,
+                   $sformatf("%0s storage_err alert not detected", shadowed_csrs[i].get_name()));
+      csr_poke(.csr(shadowed_csrs[i]), .value(origin_val), .kind(kind), .predict(1));
+      `DV_SPINWAIT(cfg.m_alert_agent_cfg[alert_name].vif.wait_ack_complete();,
+                   $sformatf("timeout for alert:%0s", alert_name))
+    end
+
+  endtask : body
+
+  // Generally we should get update error if first write of the register is 'h5555_5555,
+  // and the second write is 'haaaa_aaaa
+  // If any shadow reg does not follow this, can add additional requirements to this task
+  virtual task wr_shadowed_reg_update_err(dv_base_reg csr, output bit alert_triggered);
+    csr_wr(.csr(csr), .value('h5555_5555), .en_shadow_wr(0), .predict(1));
+    shadow_reg_wr(.csr(csr), .wdata('haaaa_aaaa), .alert_triggered(alert_triggered));
+  endtask : wr_shadowed_reg_update_err
+
+endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -4,6 +4,7 @@
 
 `include "chip_base_vseq.sv"
 `include "chip_common_vseq.sv"
+`include "chip_shadow_reg_errors_vseq.sv"
 `include "chip_sw_base_vseq.sv"
 `include "chip_sw_uart_tx_rx_vseq.sv"
 `include "chip_sw_gpio_vseq.sv"


### PR DESCRIPTION
In top-level, plan to use a simpler shadow_reg sequence
This sequence will loop through all shadow_regs within the chip, then
1. Do an update error by first writing 'h5555_5555 to shadow_reg,
   then write h'aaaa_aaaa as second write.
2. Do a storage error by poking either the shadow_reg or committed_reg.
3. Check alert handshakes.

Signed-off-by: Cindy Chen <chencindy@google.com>