### PR TITLE
[keymgr/dv] Update testbench

### DIFF
--- a/hw/dv/sv/dv_utils/dv_macros.svh
+++ b/hw/dv/sv/dv_utils/dv_macros.svh
@@ -474,4 +474,22 @@
 
 `endif // UVM
 
+// Declare array of alert interface, using parameter NUM_ALERTS and LIST_OF_ALERTS, and connect to
+// arrays of wires (alert_tx and alert_rx). User need to manually connect these wires to DUT
+// Also set each alert_if to uvm_config_db to use in env
+`ifndef DV_ALERT_IF_CONNECT
+`define DV_ALERT_IF_CONNECT \
+  alert_esc_if alert_if[NUM_ALERTS](.clk(clk), .rst_n(rst_n)); \
+  prim_alert_pkg::alert_rx_t [NUM_ALERTS-1:0] alert_rx; \
+  prim_alert_pkg::alert_tx_t [NUM_ALERTS-1:0] alert_tx; \
+  for (genvar k = 0; k < NUM_ALERTS; k++) begin : connect_alerts_pins \
+    assign alert_rx[k] = alert_if[k].alert_rx; \
+    assign alert_if[k].alert_tx = alert_tx[k]; \
+    initial begin \
+      uvm_config_db#(virtual alert_esc_if)::set(null, $sformatf("*.env.m_alert_agent_%0s", \
+          LIST_OF_ALERTS[k]), "vif", alert_if[k]); \
+    end \
+  end
+`endif
+
 `endif // __DV_MACROS_SVH__

--- a/hw/ip/aes/dv/tb/tb.sv
+++ b/hw/ip/aes/dv/tb/tb.sv
@@ -16,9 +16,6 @@ module tb;
   wire clk, rst_n;
   wire devmode;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
-  alert_esc_if alert_if[NUM_ALERTS](.clk(clk), .rst_n(rst_n));
-  prim_alert_pkg::alert_rx_t [NUM_ALERTS-1:0] alert_rx;
-  prim_alert_pkg::alert_tx_t [NUM_ALERTS-1:0] alert_tx;
 
   // interfaces
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
@@ -27,14 +24,7 @@ module tb;
   pins_if #(1) devmode_if(devmode);
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
 
-  for (genvar k = 0; k < NUM_ALERTS; k++) begin : connect_alerts_pins
-    assign alert_rx[k] = alert_if[k].alert_rx;
-    assign alert_if[k].alert_tx = alert_tx[k];
-    initial begin
-      uvm_config_db#(virtual alert_esc_if)::set(null, $sformatf("*.env.m_alert_agent_%0s",
-          LIST_OF_ALERTS[k]), "vif", alert_if[k]);
-    end
-  end
+  `DV_ALERT_IF_CONNECT
 
   // dut
   aes dut (

--- a/hw/ip/keymgr/dv/env/keymgr_env.core
+++ b/hw/ip/keymgr/dv/env/keymgr_env.core
@@ -10,6 +10,7 @@ filesets:
       - lowrisc:dv:ralgen
       - lowrisc:dv:cip_lib
     files:
+      - keymgr_input_data_if.sv
       - keymgr_env_pkg.sv
       - keymgr_env_cfg.sv: {is_include_file: true}
       - keymgr_env_cov.sv: {is_include_file: true}
@@ -20,6 +21,7 @@ filesets:
       - seq_lib/keymgr_base_vseq.sv: {is_include_file: true}
       - seq_lib/keymgr_common_vseq.sv: {is_include_file: true}
       - seq_lib/keymgr_sanity_vseq.sv: {is_include_file: true}
+      - seq_lib/keymgr_op_at_wipe_state_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/keymgr/dv/env/keymgr_env.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_env.sv
@@ -14,6 +14,10 @@ class keymgr_env extends cip_base_env #(
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
+    if (!uvm_config_db#(keymgr_input_data_vif)::get(this, "", "keymgr_input_data_vif",
+        cfg.keymgr_input_data_vif)) begin
+      `uvm_fatal(`gfn, "failed to get keymgr_input_data_vif from uvm_config_db")
+    end
   endfunction
 
   function void connect_phase(uvm_phase phase);

--- a/hw/ip/keymgr/dv/env/keymgr_env_cfg.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_env_cfg.sv
@@ -4,7 +4,8 @@
 
 class keymgr_env_cfg extends cip_base_env_cfg #(.RAL_T(keymgr_reg_block));
 
-  // ext component cfgs
+  // interface for input data from LC, OTP and flash
+  keymgr_input_data_vif keymgr_input_data_vif;
 
   `uvm_object_utils_begin(keymgr_env_cfg)
   `uvm_object_utils_end
@@ -12,6 +13,7 @@ class keymgr_env_cfg extends cip_base_env_cfg #(.RAL_T(keymgr_reg_block));
   `uvm_object_new
 
   virtual function void initialize(bit [31:0] csr_base_addr = '1);
+    list_of_alerts = keymgr_env_pkg::LIST_OF_ALERTS;
     super.initialize(csr_base_addr);
 
     // set num_interrupts & num_alerts

--- a/hw/ip/keymgr/dv/env/keymgr_env_pkg.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_env_pkg.sv
@@ -17,13 +17,33 @@ package keymgr_env_pkg;
   `include "uvm_macros.svh"
   `include "dv_macros.svh"
 
-  // parameters
-  // TODO update below, or compile error occurs
-  parameter uint KEYMGR_ADDR_MAP_SIZE = 256;
+  // parameters and types
+  parameter string LIST_OF_ALERTS[] = {"keymgr_err"};
+  parameter uint NUM_ALERTS = 1;
+  parameter keymgr_pkg::keymgr_working_state_e LIST_OF_NORMAL_STATES[] = {
+      keymgr_pkg::StInit,
+      keymgr_pkg::StCreatorRootKey,
+      keymgr_pkg::StOwnerIntKey,
+      keymgr_pkg::StOwnerKey};
 
-  // types
+  typedef virtual keymgr_input_data_if keymgr_input_data_vif;
+  typedef enum {
+    IntrOpDone,
+    IntrErr,
+    NumKeyMgrIntr
+  } keymgr_intr_e;
 
   // functions
+  function automatic keymgr_pkg::keymgr_working_state_e get_next_state(
+      keymgr_pkg::keymgr_working_state_e current_state);
+    case (current_state)
+      keymgr_pkg::StInit:           return keymgr_pkg::StCreatorRootKey;
+      keymgr_pkg::StCreatorRootKey: return keymgr_pkg::StOwnerIntKey;
+      keymgr_pkg::StOwnerIntKey:    return keymgr_pkg::StOwnerKey;
+      keymgr_pkg::StOwnerKey:       return keymgr_pkg::StDisabled;
+      default: return current_state;
+    endcase
+  endfunction
 
   // package sources
   `include "keymgr_env_cfg.sv"

--- a/hw/ip/keymgr/dv/env/keymgr_input_data_if.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_input_data_if.sv
@@ -1,0 +1,14 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// interface for input data from LC, OTP and flash
+interface keymgr_input_data_if();
+
+  import keymgr_pkg::*;
+
+  lc_data_t lc                         = keymgr_pkg::LC_DATA_DEFAULT;
+  otp_data_t otp                       = keymgr_pkg::OTP_DATA_DEFAULT;
+  flash_ctrl_pkg::keymgr_flash_t flash = keymgr_pkg::FLASH_KEY_DEFAULT;
+
+endinterface

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_op_at_wipe_state_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_op_at_wipe_state_vseq.sv
@@ -1,0 +1,36 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Test advance state and generate output at StWipe state
+// also test both start and init setting to 1, which triggers error
+class keymgr_op_at_wipe_state_vseq extends keymgr_sanity_vseq;
+  `uvm_object_utils(keymgr_op_at_wipe_state_vseq)
+  `uvm_object_new
+
+  virtual task keymgr_init();
+    `uvm_info(`gfn, "Initializating key manager with both start and init setting to 1", UVM_MEDIUM)
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(ral.control,
+                                   init.value == 1;
+                                   start.value == 1;)
+    csr_update(.csr(ral.control));
+    wait_op_done(.is_gen_output(0));
+
+    `uvm_info(`gfn, "Initializating key manager", UVM_MEDIUM)
+    ral.control.set(0); // clear random value
+    ral.control.init.set(1'b1);
+    csr_update(.csr(ral.control));
+    ral.control.init.set(1'b0); // don't program init again
+
+    current_state = keymgr_pkg::StWipe;
+    // it's StWipe now, but only last for several cycles, during this period, any OP will be
+    // ignored
+    randcase
+      1: keymgr_operations(.advance_state(1), .num_gen_op(0), .wait_done(0), .clr_output(0));
+      1: keymgr_operations(.advance_state(0), .num_gen_op(1), .wait_done(0), .clr_output(0));
+    endcase
+    csr_spinwait(.ptr(ral.working_state), .exp_data(keymgr_pkg::StInit));
+    current_state = keymgr_pkg::StInit;
+  endtask : keymgr_init
+
+endclass : keymgr_op_at_wipe_state_vseq

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_sanity_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_sanity_vseq.sv
@@ -7,14 +7,20 @@ class keymgr_sanity_vseq extends keymgr_base_vseq;
   `uvm_object_utils(keymgr_sanity_vseq)
   `uvm_object_new
 
+  // test op at StReset
+  constraint do_op_before_init_c {
+    do_op_before_init == 1;
+  }
+
   task body();
     `uvm_info(`gfn, "Key manager sanity check", UVM_HIGH)
+    // check operation at StInit state
+    keymgr_operations(.advance_state(0), .num_gen_op(1), .clr_output(1));
     // Advance state until StDisabled. In each state check SW output and clear output
-    keymgr_operations(.exp_next_state(keymgr_pkg::StCreatorRootKey), .gen_output(1), .clr_output(1));
-    keymgr_operations(.exp_next_state(keymgr_pkg::StOwnerIntKey), .gen_output(1), .clr_output(1));
-    keymgr_operations(.exp_next_state(keymgr_pkg::StOwnerKey), .gen_output(1), .clr_output(1));
-    keymgr_operations(.exp_next_state(keymgr_pkg::StDisabled), .gen_output(1), .clr_output(1));
-    keymgr_operations(.exp_next_state(keymgr_pkg::StDisabled), .gen_output(1), .clr_output(1));
+    repeat (5) begin
+      keymgr_operations(.advance_state(1), .num_gen_op(1), .clr_output(1));
+    end
+
   endtask : body
 
 endclass : keymgr_sanity_vseq

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_vseq_list.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_vseq_list.sv
@@ -5,3 +5,4 @@
 `include "keymgr_base_vseq.sv"
 `include "keymgr_sanity_vseq.sv"
 `include "keymgr_common_vseq.sv"
+`include "keymgr_op_at_wipe_state_vseq.sv"

--- a/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson
+++ b/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson
@@ -51,7 +51,12 @@
       uvm_test_seq: keymgr_sanity_vseq
     }
 
-    // TODO: add more tests here
+    {
+      name: keymgr_op_at_wipe_state
+      uvm_test_seq: keymgr_op_at_wipe_state_vseq
+      // StWipe only lasts for several cycles, don't add delay during CSR access
+      run_opts: ["+zero_delays=1"]
+    }
   ]
 
   // List of regressions.

--- a/util/uvmdvgen/tb.sv.tpl
+++ b/util/uvmdvgen/tb.sv.tpl
@@ -19,10 +19,6 @@ module tb;
 % if has_interrupts:
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
 % endif
-% if has_alerts:
-  prim_alert_pkg::alert_rx_t [NUM_ALERTS-1:0] alert_rx;
-  prim_alert_pkg::alert_tx_t [NUM_ALERTS-1:0] alert_tx;
-% endif
 % endif
 
   // interfaces
@@ -31,15 +27,16 @@ module tb;
 % if has_interrupts:
   pins_if #(NUM_MAX_INTERRUPTS) intr_if(interrupts);
 % endif
-% if has_alerts:
-  alert_esc_if alert_if[NUM_ALERTS](.clk(clk), .rst_n(rst_n));
-% endif
   pins_if #(1) devmode_if(devmode);
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
 % endif
 % for agent in env_agents:
   ${agent}_if ${agent}_if();
 % endfor
+
+% if has_alerts:
+  `DV_ALERT_IF_CONNECT
+% endif
 
   // dut
   ${name} dut (

--- a/util/uvmdvgen/tb.sv.tpl
+++ b/util/uvmdvgen/tb.sv.tpl
@@ -59,19 +59,6 @@ module tb;
     // TODO: add remaining IOs and hook them
   );
 
-% if is_cip:
-% if has_alerts:
-  for (genvar k = 0; k < NUM_ALERTS; k++) begin : connect_alerts_pins
-    assign alert_rx[k] = alert_if[k].alert_rx;
-    assign alert_if[k].alert_tx = alert_tx[k];
-    initial begin
-      uvm_config_db#(virtual alert_esc_if)::set(null, $sformatf("*.env.m_alert_agent_%0s",
-          LIST_OF_ALERTS[k]), "vif", alert_if[k]);
-    end
-  end
-% endif
-% endif
-
   initial begin
     // drive clk and rst_n from clk_if
     clk_rst_if.set_active();


### PR DESCRIPTION
1. Add keymgr_input_data_if to connect to lc/otp/flash data
2. Connect alerts and interrupts, check them after OP
3. Add keymgr_op_at_wipe_state_vseq to test OP in StWipe

Also create a macro to quickly connect alert in TB

This PR depends on the fixes #3742. CI is failing now

Signed-off-by: Weicai Yang <weicai@google.com>