### PR TITLE
[rom_ext] Add support for Alignment and Offsets to Generator

### DIFF
--- a/sw/device/rom_exts/manifest.h.tpl
+++ b/sw/device/rom_exts/manifest.h.tpl
@@ -10,7 +10,7 @@
 extern "C" {
 #endif  // __cplusplus
 
-% for name, region in items:
+% for name, region in regions:
 /**
  * Manifest field ${name} offset from the base.
  */
@@ -23,6 +23,15 @@ extern "C" {
 #define ${region.size_words_name().as_c_define()} ${region.size_words}u
 
 % endfor
+
+% for name, offset in offsets:
+/**
+ * Manifest offset ${name} from the base.
+ */
+#define ${offset.offset_name().as_c_define()} ${offset.offset}u
+
+%endfor
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/rom_exts/manifest.hjson
+++ b/sw/device/rom_exts/manifest.hjson
@@ -13,7 +13,7 @@
     },
     { type: "reserved",
       size: 32,
-    }
+    },
     { name: "image_signature",
       desc: '''ROM_EXT Manifest image signature.
 
@@ -21,6 +21,14 @@
             ''',
       type: "field",
       size: 3072,
+    },
+    {
+      name: 'signed_area_start',
+      desc: '''ROM_EXT Manifest image start of signed area.
+
+            TODO
+            ''',
+      type: "offset",
     },
     {
       name: "image_length",
@@ -48,6 +56,7 @@
             ''',
       type: "field",
       size: 64,
+      alignment: 64,
     },
     {
       name: "signature_algorithm_identifier",
@@ -169,6 +178,35 @@
             ''',
       type: "field",
       size: 32,
+    },
+    {
+      // This is modelled as an offset, as we don't want this to have a size,
+      // and if we generate assembly like `rom_ext_manifest.S`, we don't want to
+      // allocate this area using `.byte` instructions.
+      name: "interrupt_vector",
+      desc: '''ROM_EXT Manifest interrupt vector.
+
+            TODO
+            ''',
+      type: "offset",
+      // Ibex requires this to be 256-byte aligned. In this file, all alignments
+      // and sizes are in bits.
+      alignment: 2048,
+    },
+    {
+      // This reserved area covers the interrupt vector then, to ensure the
+      // `entry_point` field is 128 bytes later.
+      type: "reserved",
+      // A RISC-V interrupt vector is 32*32bit entries.
+      size: 1024,
+    },
+    {
+      name: "entry_point",
+      desc: '''ROM_EXT Manifest entry point.
+
+            TODO
+            ''',
+      type: "offset",
     },
   ],
 }

--- a/util/rom-ext-manifest-generator.py
+++ b/util/rom-ext-manifest-generator.py
@@ -18,7 +18,7 @@ USAGE = """
     Directory where manifest.hjson and manifest.h.tpl reside.
 
   rom-ext-manifest-generator --output-dir:
-    Directory where manifest.hjson and manifest.h.tpl reside.
+    Directory where manifest.h will be created.
 """
 
 
@@ -26,7 +26,7 @@ def generate_cheader(fields, input_dir, output_dir):
     """ Generates C header file from the `template_file`.
 
     It produces a list of tuples with a field name and the `MemoryRegion`
-    object, whic is used in the `template_path`. The resulting header file is
+    object, which is used in the `template_path`. The resulting header file is
     placed into `output_path`.
     """
 

--- a/util/rom-ext-manifest-generator.py
+++ b/util/rom-ext-manifest-generator.py
@@ -2,6 +2,38 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+"""
+This script generates various descriptions of the ROM_EXT manifest format based
+on the `sw/device/rom_exts/manifest.hjson` machine-readable description of that
+format.
+
+The main part of `mainfest.hjson` is a list of fields described using a list of
+dicts. These features are given in sequential order.
+
+Each dict can describe one of the following kinds of data format features:
+- `type: reserved` which is a reserved area of a certain size. These definitions
+  are not named, and definitions are not produced for them.
+- `type: field` which is a readable field of a certain size. We generate
+  definitions for the start offset of the field, and for the field size (in both
+  bytes and words). These must have a name.
+- `type: offset` which is a named offset into the ROM_EXT image. This implicitly
+  has a size of zero, but no size definitions are given for these fields.
+  Offsets with an alignment can move any features that follow them. These must
+  have a name.
+
+All data format features have a default alignment of 32-bits. This alignment can
+be reduced or expanded with the `alignment` key.
+
+All sizes and alignments are given in *bits*, not bytes.
+
+All fields and offsets must have a name, and optionally a description in the
+`desc` key.
+
+The generator currently produces the following files (into the given output
+directory):
+- `template.h`, from `sw/device/rom_exts/manifest.h.tpl` which provides field
+  size and offset preprocessor definitions for use from C.
+"""
 
 import argparse
 from pathlib import Path
@@ -21,6 +53,14 @@ USAGE = """
     Directory where manifest.h will be created.
 """
 
+class MemoryOffset(object):
+    def __init__(self, name, offset):
+        self.name = name
+        self.offset = offset
+
+    def offset_name(self):
+        return self.name + Name(["offset"])
+
 
 def generate_cheader(fields, input_dir, output_dir):
     """ Generates C header file from the `template_file`.
@@ -35,21 +75,38 @@ def generate_cheader(fields, input_dir, output_dir):
 
     base_name = Name.from_snake_case("ROM_EXT")
 
-    items = []
-    offset = 0
+    regions = []
+    offsets = []
+    current_offset_bytes = 0
     for field in fields:
-        assert field['size'] % 8 == 0
-        size_bytes = field['size'] // 8
-        if field['type'] == "field":
-            region_name = base_name + Name.from_snake_case(field['name'])
-            region = MemoryRegion(region_name, offset, size_bytes)
-            items.append((field['name'], region))
-        offset += size_bytes
+        required_alignment_bits = field.get("alignment", 32)
+        assert required_alignment_bits % 8 == 0
+        required_alignment_bytes = required_alignment_bits // 8
+
+        # The 8-byte two-step https://zinascii.com/2014/the-8-byte-two-step.html
+        # This ends up aligning `current_offset_bytes` to `required_alignment_bytes`
+        # that is greater than or equal to `current_offset_bytes`.
+        current_offset_bytes = (current_offset_bytes + required_alignment_bytes - 1) \
+                             & ~(required_alignment_bytes - 1)
+
+        if field['type'] == "offset":
+            offset_name = base_name + Name.from_snake_case(field['name'])
+            offset = MemoryOffset(offset_name, current_offset_bytes)
+            offsets.append((field['name'], offset))
+
+        else:
+            assert field['size'] % 8 == 0
+            size_bytes = field['size'] // 8
+            if field['type'] == "field":
+                region_name = base_name + Name.from_snake_case(field['name'])
+                region = MemoryRegion(region_name, current_offset_bytes, size_bytes)
+                regions.append((field['name'], region))
+            current_offset_bytes += size_bytes
 
     with template_path.open('r') as f:
         template = Template(f.read())
 
-    header = template.render(items=items)
+    header = template.render(regions=regions, offsets=offsets)
 
     with output_path.open('w') as f:
         f.write(header)


### PR DESCRIPTION
This adds support for "offsets" to the rom ext manifest generator - these are areas which have only an `OFFSET` but no size, and don't move the offset of future fields forward.

This will make it easier to see the difference if we ever generate `rom_ext_manifest.S`, where the offsets have no `.word …` data.

Layout of existing fields in the generator is not changed.

I also fixed two typos noted in #3576.
