### PR TITLE
Update to device toolchain 20200904-1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ variables:
   VERIBLE_VERSION: v0.0-520-g650c6cc
   # Release tag from https://github.com/lowRISC/lowrisc-toolchains/releases
   # if you update this, update the definition in util/container/Dockerfile
-  TOOLCHAIN_VERSION: 20200626-1
+  TOOLCHAIN_VERSION: 20200904-1
   # This controls where builds happen, and gets picked up by build_consts.sh.
   BUILD_ROOT: $(Build.ArtifactStagingDirectory)
   VIVADO_VERSION: "2020.1"

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -9,7 +9,7 @@
 ARG VERILATOR_VERSION=4.040
 
 # The RISCV toolchain version should match the release tag used in GitHub.
-ARG RISCV_TOOLCHAIN_TAR_VERSION=20200626-1
+ARG RISCV_TOOLCHAIN_TAR_VERSION=20200904-1
 
 # Build OpenOCD
 # OpenOCD is a tool to connect with the target chip over JTAG and similar


### PR DESCRIPTION
To compile OTBN source code we need a RV32 toolchain which provides the
`as` binary, and an appropriate meson configuration to find it. This was
added in https://github.com/lowRISC/lowrisc-toolchains/pull/33, and is
part of the 20200904-1 release. Require this release to make use of this
functionality in CI.

The in-tree documentation at
https://docs.opentitan.org/doc/ug/install_instructions/#compiler-toolchain
was already updated to describe the required meson configuration.