### PR TITLE
[memutil] Split out the non-verilator part of verilator_memutil

### DIFF
--- a/hw/dv/verilator/cpp/dpi_memutil.cc
+++ b/hw/dv/verilator/cpp/dpi_memutil.cc
@@ -1,0 +1,603 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dpi_memutil.h"
+
+#include <cassert>
+#include <cstring>
+#include <fcntl.h>
+#include <iostream>
+#include <libelf.h>
+#include <sstream>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <vector>
+
+#include "sv_scoped.h"
+
+// DPI Exports
+extern "C" {
+
+/**
+ * Write |file| to a memory
+ *
+ * @param file path to a SystemVerilog $readmemh()-compatible file (VMEM file)
+ */
+extern void simutil_memload(const char *file);
+
+/**
+ * Write a 32 bit word |val| to memory at index |index|
+ *
+ * @return 1 if successful, 0 otherwise
+ */
+extern int simutil_set_mem(int index, const svBitVecVal *val);
+}
+
+namespace {
+// Convenience class for runtime errors when loading an ELF file
+class ElfError : public std::exception {
+ public:
+  ElfError(const std::string &path, const std::string &msg) {
+    std::ostringstream oss;
+    oss << "Failed to load ELF file at `" << path << "': " << msg;
+    msg_ = oss.str();
+  }
+
+  const char *what() const noexcept override { return msg_.c_str(); }
+
+ private:
+  std::string msg_;
+};
+
+// Class wrapping an open ELF file
+class ElfFile {
+ public:
+  ElfFile(const std::string &path) : path_(path) {
+    fd_ = open(path.c_str(), O_RDONLY, 0);
+    if (fd_ < 0) {
+      throw ElfError(path, "could not open file.");
+    }
+
+    ptr_ = elf_begin(fd_, ELF_C_READ, NULL);
+    if (!ptr_) {
+      close(fd_);
+      throw ElfError(path, elf_errmsg(-1));
+    }
+
+    if (elf_kind(ptr_) != ELF_K_ELF) {
+      elf_end(ptr_);
+      close(fd_);
+      throw ElfError(path, "not an ELF file.");
+    }
+  }
+
+  ~ElfFile() {
+    elf_end(ptr_);
+    close(fd_);
+  }
+
+  size_t GetPhdrNum() {
+    size_t phnum;
+    if (elf_getphdrnum(ptr_, &phnum) != 0) {
+      throw ElfError(path_, elf_errmsg(-1));
+    }
+    return phnum;
+  }
+
+  const Elf32_Phdr *GetPhdrs() {
+    const Elf32_Phdr *phdrs = elf32_getphdr(ptr_);
+    if (!phdrs)
+      throw ElfError(path_, elf_errmsg(-1));
+    return phdrs;
+  }
+
+  std::string path_;
+  int fd_;
+  Elf *ptr_;
+};
+}  // namespace
+
+// Convert a string to a MemImageType, throwing a std::runtime_error
+// if it's not a known name.
+static MemImageType GetMemImageTypeByName(const std::string &name) {
+  if (name == "elf")
+    return kMemImageElf;
+  if (name == "vmem")
+    return kMemImageVmem;
+
+  std::ostringstream oss;
+  oss << "Unknown image type: `" << name << "'.";
+  throw std::runtime_error(oss.str());
+}
+
+// Return a MemImageType for the file at filepath or throw a std::runtime_error.
+// Never returns kMemImageUnknown.
+static MemImageType DetectMemImageType(const std::string &filepath) {
+  size_t ext_pos = filepath.find_last_of(".");
+  if (ext_pos == std::string::npos) {
+    // Assume ELF files if no file extension is given.
+    // TODO: Make this more robust by actually checking the file contents.
+    return kMemImageElf;
+  }
+
+  std::string ext = filepath.substr(ext_pos + 1);
+  MemImageType image_type = GetMemImageTypeByName(ext);
+  if (image_type == kMemImageUnknown) {
+    std::ostringstream oss;
+    oss << "Cannot auto-detect file type for `" << filepath << "'.";
+    throw std::runtime_error(oss.str());
+  }
+
+  return image_type;
+}
+
+// Generate a single array of bytes representing the contents of PT_LOAD
+// segments of the ELF file. Like objcopy, this generates a single "giant
+// segment" whose first byte corresponds to the first byte of the lowest
+// addressed segment and whose last byte corresponds to the last byte of the
+// highest address.
+//
+// The data for any intermediate addresses that don't appear in a segment are
+// set to zero.
+static std::vector<uint8_t> FlattenElfFile(const std::string &filepath) {
+  (void)elf_errno();
+  if (elf_version(EV_CURRENT) == EV_NONE) {
+    throw std::runtime_error(elf_errmsg(-1));
+  }
+
+  ElfFile elf(filepath);
+
+  size_t phnum = elf.GetPhdrNum();
+  const Elf32_Phdr *phdrs = elf.GetPhdrs();
+
+  // To mimic what objcopy does (that is, the binary target of BFD), we need to
+  // iterate over all loadable program headers, find the lowest address, and
+  // then copy in our loadable data based on their offset with respect to the
+  // found base address.
+
+  bool any = false;
+  Elf32_Addr low = 0, high = 0;
+  for (size_t i = 0; i < phnum; i++) {
+    const Elf32_Phdr &phdr = phdrs[i];
+
+    if (phdr.p_type != PT_LOAD) {
+      std::cout << "Program header number " << i << " in `" << filepath
+                << "' is not of type PT_LOAD; ignoring." << std::endl;
+      continue;
+    }
+
+    if (phdr.p_memsz == 0) {
+      continue;
+    }
+
+    if (!any || phdr.p_paddr < low) {
+      low = phdr.p_paddr;
+    }
+
+    if (!any || phdr.p_paddr + phdr.p_memsz > high) {
+      high = phdr.p_paddr + phdr.p_memsz;
+    }
+
+    any = true;
+  }
+
+  assert(low <= high);
+  size_t len_bytes = high - low;
+
+  size_t file_size;
+  const char *file_data = elf_rawfile(elf.ptr_, &file_size);
+  assert(file_data);
+
+  std::vector<uint8_t> buf(len_bytes);
+  for (size_t i = 0; i < phnum; i++) {
+    const Elf32_Phdr &phdr = phdrs[i];
+
+    if (phdr.p_type != PT_LOAD || phdr.p_filesz == 0) {
+      continue;
+    }
+
+    // Check the segment actually fits in the file
+    if (file_size < phdr.p_offset + phdr.p_filesz) {
+      std::ostringstream oss;
+      oss << "phdr for segment " << i << " claims to end at offset 0x"
+          << std::hex << phdr.p_offset + phdr.p_filesz
+          << ", but the file only has size 0x" << file_size << ".";
+      throw ElfError(filepath, oss.str());
+    }
+
+    // Actually copy the data across. We have just checked that there are
+    // p_filesz bytes of data available, and the loop that picked low/high
+    // above ensured that we have space to store for p_memsz bytes: use the
+    // smaller of the two numbers.
+    memcpy(&buf[phdr.p_paddr - low], file_data + phdr.p_offset,
+           std::min(phdr.p_filesz, phdr.p_memsz));
+  }
+
+  return buf;
+}
+
+// Write a "segment" of data to the given memory area. Reads file_sz bytes from
+// data. If mem_sz > file_sz, appends mem_sz - file_sz bytes of zeros to the
+// end.
+static void WriteSegment(const MemArea &m, uint32_t offset, uint32_t file_sz,
+                         uint32_t mem_sz, const uint8_t *data) {
+  assert(m.width_byte <= 32);
+  assert(m.addr_loc.size == 0 || mem_sz + offset <= m.addr_loc.size);
+  assert((offset % m.width_byte) == 0);
+
+  // Valid ELF files probably have file_sz <= mem_sz, but it sort of makes sense
+  // even if not: we are just reading the initial portion of some data stored in
+  // the file.
+  file_sz = std::min(file_sz, mem_sz);
+
+  // If this fails to set scope, it will throw an error which should
+  // be caught at this function's callsite.
+  SVScoped scoped(m.location.data());
+
+  // This "mini buffer" is used to transfer each write to SystemVerilog. It's
+  // not massively efficient, but doing so ensures that we pass 256 bits (32
+  // bytes) of initialised data each time. This is for simutil_set_mem (defined
+  // in prim_util_memload.svh), whose "val" argument has SystemVerilog type bit
+  // [255:0].
+  uint8_t minibuf[32];
+  memset(minibuf, 0, sizeof minibuf);
+  assert(m.width_byte <= sizeof minibuf);
+
+  uint32_t all_words = (mem_sz + m.width_byte - 1) / m.width_byte;
+  uint32_t full_data_words = file_sz / m.width_byte;
+  uint32_t part_data_word_len = file_sz % m.width_byte;
+  bool has_part_data_word = part_data_word_len != 0;
+  uint32_t all_data_words = full_data_words + (has_part_data_word ? 1 : 0);
+
+  assert(all_data_words <= all_words);
+  uint32_t zero_words = all_words - all_data_words;
+
+  uint32_t word_offset = offset / m.width_byte;
+
+  // Copy the full data words
+  for (uint32_t i = 0; i < full_data_words; ++i) {
+    uint32_t dst_word = word_offset + i;
+    uint32_t src_byte = i * m.width_byte;
+    memcpy(minibuf, &data[src_byte], m.width_byte);
+    if (!simutil_set_mem(dst_word, (svBitVecVal *)minibuf)) {
+      std::ostringstream oss;
+      oss << "Could not set `" << m.name << "' memory at byte offset 0x"
+          << std::hex << dst_word * m.width_byte << ".";
+      throw std::runtime_error(oss.str());
+    }
+  }
+
+  // Copy any partial data, zeroing minibuf first to ensure that the latter
+  // bytes in the word are zero.
+  if (has_part_data_word) {
+    memset(minibuf, 0, sizeof minibuf);
+    uint32_t dst_word = word_offset + full_data_words;
+    uint32_t src_byte = full_data_words * m.width_byte;
+    memcpy(minibuf, &data[src_byte], part_data_word_len);
+    if (!simutil_set_mem(dst_word, (svBitVecVal *)minibuf)) {
+      std::ostringstream oss;
+      oss << "Could not set `" << m.name << "' memory at byte offset 0x"
+          << std::hex << dst_word * m.width_byte << " (partial data word).";
+      throw std::runtime_error(oss.str());
+    }
+  }
+
+  // Zero minibuf again and splat any remaining words.
+  if (zero_words > 0) {
+    memset(minibuf, 0, sizeof minibuf);
+    for (uint32_t i = 0; i < zero_words; ++i) {
+      uint32_t dst_word = word_offset + full_data_words + i;
+      if (!simutil_set_mem(dst_word, (svBitVecVal *)minibuf)) {
+        std::ostringstream oss;
+        oss << "Could not set `" << m.name << "' memory at byte offset 0x"
+            << std::hex << dst_word * m.width_byte << " (zero word).";
+        throw std::runtime_error(oss.str());
+      }
+    }
+  }
+}
+
+static void WriteElfToMem(const MemArea &m, const std::string &filepath) {
+  std::vector<uint8_t> elf_data = FlattenElfFile(filepath);
+  WriteSegment(m, 0, elf_data.size(), elf_data.size(), &elf_data[0]);
+}
+
+static void WriteVmemToMem(const MemArea &m, const std::string &filepath) {
+  SVScoped scoped(m.location.data());
+  // TODO: Add error handling.
+  simutil_memload(filepath.data());
+}
+
+bool DpiMemUtil::RegisterMemoryArea(const std::string name,
+                                    const std::string location) {
+  // Default to 32bit width and no address
+  return RegisterMemoryArea(name, location, 32, nullptr);
+}
+
+bool DpiMemUtil::RegisterMemoryArea(const std::string name,
+                                    const std::string location,
+                                    size_t width_bit,
+                                    const MemAreaLoc *addr_loc) {
+  assert((width_bit <= 256) &&
+         "TODO: Memory loading only supported up to 256 bits.");
+  assert(width_bit % 8 == 0);
+
+  // First, create and register the memory by name
+  MemArea mem = {.name = name,
+                 .location = location,
+                 .width_byte = (uint32_t)width_bit / 8,
+                 .addr_loc = {.base = 0, .size = 0}};
+  auto ret = name_to_mem_.emplace(name, mem);
+  if (ret.second == false) {
+    std::cerr << "ERROR: Can not register \"" << name << "\" at: \"" << location
+              << "\" (Previously defined at: \"" << ret.first->second.location
+              << "\")" << std::endl;
+    return false;
+  }
+
+  MemArea *stored_mem_area = &ret.first->second;
+
+  // If we have no address information, there's nothing more to do. However, if
+  // we do have address information, we should add an entry to addr_to_mem_.
+  if (!addr_loc) {
+    return true;
+  }
+
+  // Check that the size of the new area is positive, and that we don't overflow
+  // the address space.
+  if (addr_loc->size == 0) {
+    std::cerr << "ERROR: Can not register '" << name
+              << "' because it has zero size.\n";
+    return false;
+  }
+  uint32_t addr_top = addr_loc->base + (addr_loc->size - 1);
+  if (addr_top < addr_loc->base) {
+    std::cerr << "ERROR: Can not register '" << name
+              << "' because it overflows the top of the address space.\n";
+    return false;
+  }
+
+  // If the existing map is non-empty, we must check for overlaps
+  if (!addr_to_mem_.empty()) {
+    // We start by checking for an overlap "from the right". This would be a
+    // region that starts strictly above addr_loc->base, but where it's low
+    // address is still less than addr_top. We can use std::map::upper_bound to
+    // find the first region strictly above addr_loc->base (which returns the
+    // end iterator if there isn't one).
+    auto right_it = addr_to_mem_.upper_bound(addr_loc->base);
+    if (right_it != addr_to_mem_.end()) {
+      const MemAreaLoc &ub_loc = right_it->second->addr_loc;
+      assert(ub_loc.size != 0);
+      if (ub_loc.base <= addr_top) {
+        std::cerr << "ERROR: Can not register '" << name
+                  << "' because its address range overlaps to left of '"
+                  << right_it->second->name << "'.\n";
+        return false;
+      }
+    }
+
+    // We also need to check from the other side. This would be a region that
+    // starts at or before addr_loc->base and extends past it. If right_it is
+    // addr_to_mem_.begin(), there is no such region (because the lowest
+    // addressed region already starts above addr_loc->base). Otherwise,
+    // decrement right_it to get the highest addressed region that starts at or
+    // before addr_loc->base. Note this still works if right_it is the end
+    // iterator: we just pick up the last region, which we know exists because
+    // addr_to_mem_ is not empty.
+    if (right_it != addr_to_mem_.begin()) {
+      auto left_it = std::prev(right_it);
+      const MemAreaLoc &lb_loc = left_it->second->addr_loc;
+      assert(lb_loc.size != 0);
+      uint32_t lb_max = lb_loc.base + lb_loc.size;
+      if (addr_loc->base <= lb_max) {
+        std::cerr << "ERROR: Can not register '" << name
+                  << "' because its address range overlaps to right of '"
+                  << left_it->second->name << "'.\n";
+        return false;
+      }
+    }
+  }
+
+  // Phew, no overlap!
+  addr_to_mem_.insert(std::make_pair(addr_loc->base, stored_mem_area));
+  stored_mem_area->addr_loc = *addr_loc;
+  return true;
+}
+
+MemImageType DpiMemUtil::GetMemImageType(const std::string &path,
+                                         const char *type) {
+  return type ? GetMemImageTypeByName(type) : DetectMemImageType(path);
+}
+
+void DpiMemUtil::PrintMemRegions() const {
+  std::cout << "Registered memory regions:" << std::endl;
+  for (const auto &pr : name_to_mem_) {
+    const MemArea &m = pr.second;
+    std::cout << "\t'" << m.name << "' (" << m.width_byte * 8
+              << "bits) at location: '" << m.location << "'";
+    if (m.addr_loc.size) {
+      uint32_t low = m.addr_loc.base;
+      uint32_t high = m.addr_loc.base + m.addr_loc.size - 1;
+      std::cout << " (LMA range [0x" << std::hex << low << ", 0x" << high
+                << "])" << std::dec;
+    }
+    std::cout << std::endl;
+  }
+}
+
+void DpiMemUtil::LoadFileToNamedMem(bool verbose, const std::string &name,
+                                    const std::string &filepath,
+                                    MemImageType type) {
+  // If the image type isn't specified, try to figure it out from the file name
+  if (type == kMemImageUnknown) {
+    type = DetectMemImageType(filepath);
+  }
+  assert(type != kMemImageUnknown);
+
+  // Search for corresponding registered memory based on the name
+  auto it = name_to_mem_.find(name);
+  if (it == name_to_mem_.end()) {
+    std::ostringstream oss;
+    oss << "`" << name
+        << ("' is not the name of a known memory region. "
+            "Run with --meminit=list to get a list.");
+    throw std::runtime_error(oss.str());
+  }
+
+  if (verbose) {
+    std::cout << "Loading data from file `" << filepath << "' into memory `"
+              << name << "'." << std::endl;
+  }
+
+  const MemArea &m = it->second;
+
+  try {
+    switch (type) {
+      case kMemImageElf:
+        WriteElfToMem(m, filepath);
+        break;
+      case kMemImageVmem:
+        WriteVmemToMem(m, filepath);
+        break;
+      default:
+        assert(0);
+    }
+  } catch (const SVScoped::Error &err) {
+    std::ostringstream oss;
+    oss << "No memory found at `" << err.scope_name_
+        << "' (the scope associated with region `" << m.name << "').";
+    throw std::runtime_error(oss.str());
+  }
+}
+
+void DpiMemUtil::LoadElfToMemories(bool verbose, const std::string &filepath) {
+  (void)elf_errno();
+  if (elf_version(EV_CURRENT) == EV_NONE) {
+    throw std::runtime_error(elf_errmsg(-1));
+  }
+
+  ElfFile elf(filepath);
+
+  size_t file_size;
+  const char *file_data = elf_rawfile(elf.ptr_, &file_size);
+  assert(file_data);
+
+  size_t phnum = elf.GetPhdrNum();
+  const Elf32_Phdr *phdrs = elf.GetPhdrs();
+
+  for (size_t i = 0; i < phnum; ++i) {
+    const Elf32_Phdr &phdr = phdrs[i];
+    if (phdr.p_type != PT_LOAD)
+      continue;
+
+    if (phdr.p_memsz == 0)
+      continue;
+
+    const MemArea *mem_area = FindRegionForAddr(phdr.p_paddr);
+    if (!mem_area) {
+      std::ostringstream oss;
+      oss << "No memory region is registered that contains the address 0x"
+          << std::hex << phdr.p_paddr << " (the base address of segment " << i
+          << ").";
+      throw ElfError(filepath, oss.str());
+    }
+    assert(mem_area->addr_loc.base <= phdr.p_paddr);
+
+    uint32_t lma_top = phdr.p_paddr + (phdr.p_memsz - 1);
+    uint32_t off_end = phdr.p_offset + phdr.p_filesz;
+
+    // Overflow checks
+    if (lma_top < phdr.p_paddr) {
+      std::ostringstream oss;
+      oss << "Integer overflow for top address of segment " << i << ".";
+      throw ElfError(filepath, oss.str());
+    }
+    if (off_end < phdr.p_offset) {
+      std::ostringstream oss;
+      oss << "Integer overflow for top file offset of segment " << i << ".";
+      throw ElfError(filepath, oss.str());
+    }
+
+    uint32_t local_base = phdr.p_paddr - mem_area->addr_loc.base;
+    uint32_t local_top = lma_top - mem_area->addr_loc.base;
+
+    if (mem_area->addr_loc.size <= local_top) {
+      std::ostringstream oss;
+      oss << "Segment " << i << " has size 0x" << std::hex << phdr.p_memsz
+          << " bytes. Its LMA of 0x" << phdr.p_paddr << " is at offset 0x"
+          << local_base << " in the memory region `" << mem_area->name
+          << "', so the segment finishes at offset 0x" << local_top
+          << ", but the memory region is only 0x" << mem_area->addr_loc.size
+          << " bytes long.";
+      throw ElfError(filepath, oss.str());
+    }
+
+    // Check that the segment is aligned correctly for the memory
+    if (local_base % mem_area->width_byte) {
+      std::ostringstream oss;
+      oss << "Segment " << i << " has LMA 0x" << std::hex << phdr.p_paddr
+          << ", which starts at offset 0x" << local_base
+          << " in the memory region `" << mem_area->name
+          << "'. This offset is not aligned to the region's word width of "
+          << std::dec << 8 * mem_area->width_byte << " bits.";
+      throw ElfError(filepath, oss.str());
+    }
+
+    // Check the segment actually fits in the file
+    if (file_size < off_end) {
+      std::ostringstream oss;
+      oss << "phdr for segment " << i << " claims to end at offset 0x"
+          << std::hex << off_end - 1 << ", but the file only has size 0x"
+          << file_size << ".";
+      throw ElfError(filepath, oss.str());
+    }
+
+    if (verbose) {
+      std::cout << "Loading segment " << i << " from ELF file `" << filepath
+                << "' into memory `" << mem_area->name << "'." << std::endl;
+    }
+
+    const char *seg_data = file_data + phdr.p_offset;
+    try {
+      WriteSegment(*mem_area, local_base, phdr.p_filesz, phdr.p_memsz,
+                   (const uint8_t *)seg_data);
+    } catch (const SVScoped::Error &err) {
+      std::ostringstream oss;
+      oss << "No memory found at `" << err.scope_name_
+          << "' (the scope associated with region `" << mem_area->name
+          << "', used by segment " << i << ", which starts at LMA 0x"
+          << std::hex << phdr.p_paddr << ").";
+      throw std::runtime_error(oss.str());
+    }
+  }
+}
+
+const MemArea *DpiMemUtil::FindRegionForAddr(uint32_t lma) const {
+  // To find the memory area containing lma, use upper_bound to find the first
+  // region strictly after it, and then std::prev to step backwards. This fails
+  // if either the map is empty (obviously!) or if ub_it is already the
+  // beginning of the map.
+  if (addr_to_mem_.empty())
+    return nullptr;
+
+  auto ub_it = addr_to_mem_.upper_bound(lma);
+  if (ub_it == addr_to_mem_.begin())
+    return nullptr;
+
+  const MemArea *m = std::prev(ub_it)->second;
+
+  // Every entry in addr_to_mem_ should have a valid pointer to a MemArea with a
+  // valid location.
+  assert(m != nullptr);
+  assert(m->addr_loc.size != 0);
+
+  // What's more, the base of the location should be less than equal to lma
+  // (because it's strictly less than the smallest entry strictly greater).
+  assert(m->addr_loc.base <= lma);
+
+  // This means that we've found the right region iff the top of the region
+  // includes lma.
+  uint32_t addr_top = m->addr_loc.base + (m->addr_loc.size - 1);
+  return (lma <= addr_top) ? m : nullptr;
+}

--- a/hw/dv/verilator/cpp/dpi_memutil.h
+++ b/hw/dv/verilator/cpp/dpi_memutil.h
@@ -1,0 +1,106 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <map>
+#include <string>
+#include <svdpi.h>
+
+enum MemImageType {
+  kMemImageUnknown = 0,
+  kMemImageElf,
+  kMemImageVmem,
+};
+
+// The "load" location of a memory area. base is the lowest address in
+// the area, and should correspond to an ELF file's LMA. size is the
+// length of the area in bytes.
+struct MemAreaLoc {
+  uint32_t base;
+  uint32_t size;
+};
+
+struct MemArea {
+  std::string name;      // Unique identifier
+  std::string location;  // Design scope location
+  uint32_t width_byte;   // Memory width in bytes
+  MemAreaLoc addr_loc;   // Address location. If !size, location is unknown.
+};
+
+/**
+ * Provide various memory loading utilities for verilog simulations
+ *
+ * These utilities require the corresponding DPI functions:
+ * simutil_memload()
+ * simutil_set_mem()
+ * to be defined somewhere as SystemVerilog functions.
+ */
+class DpiMemUtil {
+ public:
+  /**
+   * Register a memory as instantiated by generic ram
+   *
+   * The |name| must be a unique identifier. The function will return false if
+   * |name| is already used. |location| is the path to the scope of the
+   * instantiated memory, which needs to support the DPI-C interfaces
+   * 'simutil_memload' and 'simutil_set_mem' used for 'vmem' and 'elf' files,
+   * respectively.
+   *
+   * The |width_bit| argument specifies the with in bits of the target memory
+   * instance (used for packing data). This must be a multiple of 8. If
+   * |addr_loc| is not null, it gives the base and size of the memory for
+   * loading in the address space (corresponding to LMAs in an ELF file).
+   *
+   * Memories must be registered before command arguments are parsed by
+   * ParseCommandArgs() in order for them to be known.
+   */
+  bool RegisterMemoryArea(const std::string name, const std::string location,
+                          size_t width_bit, const MemAreaLoc *addr_loc);
+
+  /**
+   * Register a memory with default width (32bits)
+   */
+  bool RegisterMemoryArea(const std::string name, const std::string location);
+
+  /**
+   * Guess the type of the file at |path|.
+   *
+   * If |type| is non-null, it is the name of an image type and will be used.
+   * Otherwise, the check is based on |path|. If |type| is not a valid name or
+   * if the function can't guess from the path, throws a std::runtime_error
+   * with a message about what went wrong.
+   *
+   * Never returns kMemImageUnknown.
+   */
+  static MemImageType GetMemImageType(const std::string &path,
+                                      const char *type);
+
+  /**
+   * Print a list of all registered memory regions
+   *
+   * @see RegisterMemoryArea()
+   */
+  void PrintMemRegions() const;
+
+  /**
+   * Load the file at filepath into the named memory. If type is
+   * kMemImageUnknown, the file type is determined from the path.
+   */
+  void LoadFileToNamedMem(bool verbose, const std::string &name,
+                          const std::string &filepath, MemImageType type);
+  /**
+   * Load an ELF file, placing segments in memories by LMA
+   */
+  void LoadElfToMemories(bool verbose, const std::string &filepath);
+
+ private:
+  std::map<std::string, MemArea> name_to_mem_;
+  std::map<uint32_t, const MemArea *> addr_to_mem_;
+
+  /**
+   * Try to find a region for the given LMA. Returns nullptr if none is found.
+   */
+  const MemArea *FindRegionForAddr(uint32_t lma) const;
+};

--- a/hw/dv/verilator/cpp/sv_scoped.h
+++ b/hw/dv/verilator/cpp/sv_scoped.h
@@ -7,7 +7,7 @@
 
 #include <stdexcept>
 #include <string>
-#include <vltstd/svdpi.h>
+#include <svdpi.h>
 
 /**
  * Wrapper and guard class for SV Scope

--- a/hw/dv/verilator/cpp/verilator_memutil.cc
+++ b/hw/dv/verilator/cpp/verilator_memutil.cc
@@ -4,153 +4,14 @@
 
 #include "verilator_memutil.h"
 
+#include <array>
 #include <cassert>
 #include <cstring>
-#include <fcntl.h>
 #include <getopt.h>
 #include <iostream>
-#include <libelf.h>
 #include <sstream>
-#include <sys/stat.h>
-#include <unistd.h>
+#include <string>
 #include <vector>
-
-#include "sv_scoped.h"
-
-// DPI Exports
-extern "C" {
-
-/**
- * Write |file| to a memory
- *
- * @param file path to a SystemVerilog $readmemh()-compatible file (VMEM file)
- */
-extern void simutil_verilator_memload(const char *file);
-
-/**
- * Write a 32 bit word |val| to memory at index |index|
- *
- * @return 1 if successful, 0 otherwise
- */
-extern int simutil_verilator_set_mem(int index, const svBitVecVal *val);
-}
-
-namespace {
-// Convenience class for runtime errors when loading an ELF file
-class ElfError : public std::exception {
- public:
-  ElfError(const std::string &path, const std::string &msg) {
-    std::ostringstream oss;
-    oss << "Failed to load ELF file at `" << path << "': " << msg;
-    msg_ = oss.str();
-  }
-
-  const char *what() const noexcept override { return msg_.c_str(); }
-
- private:
-  std::string msg_;
-};
-
-// Class wrapping an open ELF file
-class ElfFile {
- public:
-  ElfFile(const std::string &path) : path_(path) {
-    fd_ = open(path.c_str(), O_RDONLY, 0);
-    if (fd_ < 0) {
-      throw ElfError(path, "could not open file.");
-    }
-
-    ptr_ = elf_begin(fd_, ELF_C_READ, NULL);
-    if (!ptr_) {
-      close(fd_);
-      throw ElfError(path, elf_errmsg(-1));
-    }
-
-    if (elf_kind(ptr_) != ELF_K_ELF) {
-      elf_end(ptr_);
-      close(fd_);
-      throw ElfError(path, "not an ELF file.");
-    }
-  }
-
-  ~ElfFile() {
-    elf_end(ptr_);
-    close(fd_);
-  }
-
-  size_t GetPhdrNum() {
-    size_t phnum;
-    if (elf_getphdrnum(ptr_, &phnum) != 0) {
-      throw ElfError(path_, elf_errmsg(-1));
-    }
-    return phnum;
-  }
-
-  const Elf32_Phdr *GetPhdrs() {
-    const Elf32_Phdr *phdrs = elf32_getphdr(ptr_);
-    if (!phdrs)
-      throw ElfError(path_, elf_errmsg(-1));
-    return phdrs;
-  }
-
-  std::string path_;
-  int fd_;
-  Elf *ptr_;
-};
-}  // namespace
-
-// Print a usage message to stdout
-static void PrintHelp() {
-  std::cout << "Simulation memory utilities:\n\n"
-               "-r|--rominit=FILE\n"
-               "  Initialize the ROM with FILE (elf/vmem)\n\n"
-               "-m|--raminit=FILE\n"
-               "  Initialize the RAM with FILE (elf/vmem)\n\n"
-               "-f|--flashinit=FILE\n"
-               "  Initialize the FLASH with FILE (elf/vmem)\n\n"
-               "-l|--meminit=NAME,FILE[,TYPE]\n"
-               "  Initialize memory region NAME with FILE [of TYPE]\n"
-               "  TYPE is either 'elf' or 'vmem'\n\n"
-               "-E|--load-elf=FILE\n"
-               "  Load ELF file, using segment LMAs to pick memory regions\n\n"
-               "-l list|--meminit=list\n"
-               "  Print registered memory regions\n\n"
-               "--verbose-mem-load\n"
-               "  Print a message for each memory load\n\n"
-               "-h|--help\n"
-               "  Show help\n\n";
-}
-
-// Convert a string to a MemImageType, returning kMemImageUnknown if it's not a
-// known name.
-static MemImageType GetMemImageTypeByName(const std::string &name) {
-  if (name == "elf")
-    return kMemImageElf;
-  if (name == "vmem")
-    return kMemImageVmem;
-  return kMemImageUnknown;
-}
-
-// Return a MemImageType for the file at filepath or throw a std::runtime_error.
-// Never returns kMemImageUnknown.
-static MemImageType DetectMemImageType(const std::string &filepath) {
-  size_t ext_pos = filepath.find_last_of(".");
-  if (ext_pos == std::string::npos) {
-    // Assume ELF files if no file extension is given.
-    // TODO: Make this more robust by actually checking the file contents.
-    return kMemImageElf;
-  }
-
-  std::string ext = filepath.substr(ext_pos + 1);
-  MemImageType image_type = GetMemImageTypeByName(ext);
-  if (image_type == kMemImageUnknown) {
-    std::ostringstream oss;
-    oss << "Cannot auto-detect file type for `" << filepath << "'.";
-    throw std::runtime_error(oss.str());
-  }
-
-  return image_type;
-}
 
 namespace {
 // An instruction to load the file at filepath to the memory called name. If
@@ -195,288 +56,40 @@ static LoadArg ParseMemArg(std::string mem_argument) {
     throw std::runtime_error(oss.str());
   }
 
-  MemImageType type;
-  if (i == 1) {
-    // Type not set explicitly
-    type = DetectMemImageType(args[1]);
-  } else {
-    type = GetMemImageTypeByName(args[2]);
-  }
+  const char *str_type = (2 <= i) ? args[2].c_str() : nullptr;
+  MemImageType type = DpiMemUtil::GetMemImageType(args[1], str_type);
 
   return {.name = args[0], .filepath = args[1], .type = type};
 }
 
-// Generate a single array of bytes representing the contents of PT_LOAD
-// segments of the ELF file. Like objcopy, this generates a single "giant
-// segment" whose first byte corresponds to the first byte of the lowest
-// addressed segment and whose last byte corresponds to the last byte of the
-// highest address.
-//
-// The data for any intermediate addresses that don't appear in a segment are
-// set to zero.
-static std::vector<uint8_t> FlattenElfFile(const std::string &filepath) {
-  (void)elf_errno();
-  if (elf_version(EV_CURRENT) == EV_NONE) {
-    throw std::runtime_error(elf_errmsg(-1));
-  }
-
-  ElfFile elf(filepath);
-
-  size_t phnum = elf.GetPhdrNum();
-  const Elf32_Phdr *phdrs = elf.GetPhdrs();
-
-  // To mimic what objcopy does (that is, the binary target of BFD), we need to
-  // iterate over all loadable program headers, find the lowest address, and
-  // then copy in our loadable data based on their offset with respect to the
-  // found base address.
-
-  bool any = false;
-  Elf32_Addr low = 0, high = 0;
-  for (size_t i = 0; i < phnum; i++) {
-    const Elf32_Phdr &phdr = phdrs[i];
-
-    if (phdr.p_type != PT_LOAD) {
-      std::cout << "Program header number " << i << " in `" << filepath
-                << "' is not of type PT_LOAD; ignoring." << std::endl;
-      continue;
-    }
-
-    if (phdr.p_memsz == 0) {
-      continue;
-    }
-
-    if (!any || phdr.p_paddr < low) {
-      low = phdr.p_paddr;
-    }
-
-    if (!any || phdr.p_paddr + phdr.p_memsz > high) {
-      high = phdr.p_paddr + phdr.p_memsz;
-    }
-
-    any = true;
-  }
-
-  assert(low <= high);
-  size_t len_bytes = high - low;
-
-  size_t file_size;
-  const char *file_data = elf_rawfile(elf.ptr_, &file_size);
-  assert(file_data);
-
-  std::vector<uint8_t> buf(len_bytes);
-  for (size_t i = 0; i < phnum; i++) {
-    const Elf32_Phdr &phdr = phdrs[i];
-
-    if (phdr.p_type != PT_LOAD || phdr.p_filesz == 0) {
-      continue;
-    }
-
-    // Check the segment actually fits in the file
-    if (file_size < phdr.p_offset + phdr.p_filesz) {
-      std::ostringstream oss;
-      oss << "phdr for segment " << i << " claims to end at offset 0x"
-          << std::hex << phdr.p_offset + phdr.p_filesz
-          << ", but the file only has size 0x" << file_size << ".";
-      throw ElfError(filepath, oss.str());
-    }
-
-    // Actually copy the data across. We have just checked that there are
-    // p_filesz bytes of data available, and the loop that picked low/high
-    // above ensured that we have space to store for p_memsz bytes: use the
-    // smaller of the two numbers.
-    memcpy(&buf[phdr.p_paddr - low], file_data + phdr.p_offset,
-           std::min(phdr.p_filesz, phdr.p_memsz));
-  }
-
-  return buf;
+// Print a usage message to stdout
+static void PrintHelp() {
+  std::cout << "Simulation memory utilities:\n\n"
+               "-r|--rominit=FILE\n"
+               "  Initialize the ROM with FILE (elf/vmem)\n\n"
+               "-m|--raminit=FILE\n"
+               "  Initialize the RAM with FILE (elf/vmem)\n\n"
+               "-f|--flashinit=FILE\n"
+               "  Initialize the FLASH with FILE (elf/vmem)\n\n"
+               "-l|--meminit=NAME,FILE[,TYPE]\n"
+               "  Initialize memory region NAME with FILE [of TYPE]\n"
+               "  TYPE is either 'elf' or 'vmem'\n\n"
+               "-E|--load-elf=FILE\n"
+               "  Load ELF file, using segment LMAs to pick memory regions\n\n"
+               "-l list|--meminit=list\n"
+               "  Print registered memory regions\n\n"
+               "--verbose-mem-load\n"
+               "  Print a message for each memory load\n\n"
+               "-h|--help\n"
+               "  Show help\n\n";
 }
 
-// Write a "segment" of data to the given memory area. Reads file_sz bytes from
-// data. If mem_sz > file_sz, appends mem_sz - file_sz bytes of zeros to the
-// end.
-static void WriteSegment(const MemArea &m, uint32_t offset, uint32_t file_sz,
-                         uint32_t mem_sz, const uint8_t *data) {
-  assert(m.width_byte <= 32);
-  assert(m.addr_loc.size == 0 || mem_sz + offset <= m.addr_loc.size);
-  assert((offset % m.width_byte) == 0);
-
-  // Valid ELF files probably have file_sz <= mem_sz, but it sort of makes sense
-  // even if not: we are just reading the initial portion of some data stored in
-  // the file.
-  file_sz = std::min(file_sz, mem_sz);
-
-  // If this fails to set scope, it will throw an error which should
-  // be caught at this function's callsite.
-  SVScoped scoped(m.location.data());
-
-  // This "mini buffer" is used to transfer each write to SystemVerilog. It's
-  // not massively efficient, but doing so ensures that we pass 256 bits (32
-  // bytes) of initialised data each time. This is for simutil_verilator_set_mem
-  // (defined in prim_util_memload.svh), whose "val" argument has SystemVerilog
-  // type bit [255:0].
-  uint8_t minibuf[32];
-  memset(minibuf, 0, sizeof minibuf);
-  assert(m.width_byte <= sizeof minibuf);
-
-  uint32_t all_words = (mem_sz + m.width_byte - 1) / m.width_byte;
-  uint32_t full_data_words = file_sz / m.width_byte;
-  uint32_t part_data_word_len = file_sz % m.width_byte;
-  bool has_part_data_word = part_data_word_len != 0;
-  uint32_t all_data_words = full_data_words + (has_part_data_word ? 1 : 0);
-
-  assert(all_data_words <= all_words);
-  uint32_t zero_words = all_words - all_data_words;
-
-  uint32_t word_offset = offset / m.width_byte;
-
-  // Copy the full data words
-  for (uint32_t i = 0; i < full_data_words; ++i) {
-    uint32_t dst_word = word_offset + i;
-    uint32_t src_byte = i * m.width_byte;
-    memcpy(minibuf, &data[src_byte], m.width_byte);
-    if (!simutil_verilator_set_mem(dst_word, (svBitVecVal *)minibuf)) {
-      std::ostringstream oss;
-      oss << "Could not set `" << m.name << "' memory at byte offset 0x"
-          << std::hex << dst_word * m.width_byte << ".";
-      throw std::runtime_error(oss.str());
-    }
-  }
-
-  // Copy any partial data, zeroing minibuf first to ensure that the latter
-  // bytes in the word are zero.
-  if (has_part_data_word) {
-    memset(minibuf, 0, sizeof minibuf);
-    uint32_t dst_word = word_offset + full_data_words;
-    uint32_t src_byte = full_data_words * m.width_byte;
-    memcpy(minibuf, &data[src_byte], part_data_word_len);
-    if (!simutil_verilator_set_mem(dst_word, (svBitVecVal *)minibuf)) {
-      std::ostringstream oss;
-      oss << "Could not set `" << m.name << "' memory at byte offset 0x"
-          << std::hex << dst_word * m.width_byte << " (partial data word).";
-      throw std::runtime_error(oss.str());
-    }
-  }
-
-  // Zero minibuf again and splat any remaining words.
-  if (zero_words > 0) {
-    memset(minibuf, 0, sizeof minibuf);
-    for (uint32_t i = 0; i < zero_words; ++i) {
-      uint32_t dst_word = word_offset + full_data_words + i;
-      if (!simutil_verilator_set_mem(dst_word, (svBitVecVal *)minibuf)) {
-        std::ostringstream oss;
-        oss << "Could not set `" << m.name << "' memory at byte offset 0x"
-            << std::hex << dst_word * m.width_byte << " (zero word).";
-        throw std::runtime_error(oss.str());
-      }
-    }
-  }
+VerilatorMemUtil::VerilatorMemUtil() : allocation_(new DpiMemUtil()) {
+  mem_util_ = allocation_.get();
 }
 
-static void WriteElfToMem(const MemArea &m, const std::string &filepath) {
-  std::vector<uint8_t> elf_data = FlattenElfFile(filepath);
-  WriteSegment(m, 0, elf_data.size(), elf_data.size(), &elf_data[0]);
-}
-
-static void WriteVmemToMem(const MemArea &m, const std::string &filepath) {
-  SVScoped scoped(m.location.data());
-  // TODO: Add error handling.
-  simutil_verilator_memload(filepath.data());
-}
-
-bool VerilatorMemUtil::RegisterMemoryArea(const std::string name,
-                                          const std::string location) {
-  // Default to 32bit width and no address
-  return RegisterMemoryArea(name, location, 32, nullptr);
-}
-
-bool VerilatorMemUtil::RegisterMemoryArea(const std::string name,
-                                          const std::string location,
-                                          size_t width_bit,
-                                          const MemAreaLoc *addr_loc) {
-  assert((width_bit <= 256) &&
-         "TODO: Memory loading only supported up to 256 bits.");
-  assert(width_bit % 8 == 0);
-
-  // First, create and register the memory by name
-  MemArea mem = {.name = name,
-                 .location = location,
-                 .width_byte = (uint32_t)width_bit / 8,
-                 .addr_loc = {.base = 0, .size = 0}};
-  auto ret = name_to_mem_.emplace(name, mem);
-  if (ret.second == false) {
-    std::cerr << "ERROR: Can not register \"" << name << "\" at: \"" << location
-              << "\" (Previously defined at: \"" << ret.first->second.location
-              << "\")" << std::endl;
-    return false;
-  }
-
-  MemArea *stored_mem_area = &ret.first->second;
-
-  // If we have no address information, there's nothing more to do. However, if
-  // we do have address information, we should add an entry to addr_to_mem_.
-  if (!addr_loc) {
-    return true;
-  }
-
-  // Check that the size of the new area is positive, and that we don't overflow
-  // the address space.
-  if (addr_loc->size == 0) {
-    std::cerr << "ERROR: Can not register '" << name
-              << "' because it has zero size.\n";
-    return false;
-  }
-  uint32_t addr_top = addr_loc->base + (addr_loc->size - 1);
-  if (addr_top < addr_loc->base) {
-    std::cerr << "ERROR: Can not register '" << name
-              << "' because it overflows the top of the address space.\n";
-    return false;
-  }
-
-  // If the existing map is non-empty, we must check for overlaps
-  if (!addr_to_mem_.empty()) {
-    // We start by checking for an overlap "from the right". This would be a
-    // region that starts strictly above addr_loc->base, but where it's low
-    // address is still less than addr_top. We can use std::map::upper_bound to
-    // find the first region strictly above addr_loc->base (which returns the
-    // end iterator if there isn't one).
-    auto right_it = addr_to_mem_.upper_bound(addr_loc->base);
-    if (right_it != addr_to_mem_.end()) {
-      const MemAreaLoc &ub_loc = right_it->second->addr_loc;
-      assert(ub_loc.size != 0);
-      if (ub_loc.base <= addr_top) {
-        std::cerr << "ERROR: Can not register '" << name
-                  << "' because its address range overlaps to left of '"
-                  << right_it->second->name << "'.\n";
-        return false;
-      }
-    }
-
-    // We also need to check from the other side. This would be a region that
-    // starts at or before addr_loc->base and extends past it. If right_it is
-    // addr_to_mem_.begin(), there is no such region (because the lowest
-    // addressed region already starts above addr_loc->base). Otherwise,
-    // decrement right_it to get the highest addressed region that starts at or
-    // before addr_loc->base. Note this still works if right_it is the end
-    // iterator: we just pick up the last region, which we know exists because
-    // addr_to_mem_ is not empty.
-    if (right_it != addr_to_mem_.begin()) {
-      auto left_it = std::prev(right_it);
-      const MemAreaLoc &lb_loc = left_it->second->addr_loc;
-      assert(lb_loc.size != 0);
-      uint32_t lb_max = lb_loc.base + lb_loc.size;
-      if (addr_loc->base <= lb_max) {
-        std::cerr << "ERROR: Can not register '" << name
-                  << "' because its address range overlaps to right of '"
-                  << left_it->second->name << "'.\n";
-        return false;
-      }
-    }
-  }
-
-  // Phew, no overlap!
-  addr_to_mem_.insert(std::make_pair(addr_loc->base, stored_mem_area));
-  stored_mem_area->addr_loc = *addr_loc;
-  return true;
+VerilatorMemUtil::VerilatorMemUtil(DpiMemUtil *mem_util) : mem_util_(mem_util) {
+  assert(mem_util);
 }
 
 bool VerilatorMemUtil::ParseCLIArguments(int argc, char **argv,
@@ -523,7 +136,7 @@ bool VerilatorMemUtil::ParseCLIArguments(int argc, char **argv,
         break;
       case 'l':
         if (strcasecmp(optarg, "list") == 0) {
-          PrintMemRegions();
+          mem_util_->PrintMemRegions();
           exit_app = true;
           return true;
         }
@@ -559,10 +172,11 @@ bool VerilatorMemUtil::ParseCLIArguments(int argc, char **argv,
   for (const LoadArg &arg : load_args) {
     try {
       if (!arg.name.empty()) {
-        LoadFileToNamedMem(verbose, arg.name, arg.filepath, arg.type);
+        mem_util_->LoadFileToNamedMem(verbose, arg.name, arg.filepath,
+                                      arg.type);
       } else {
         assert(arg.type == kMemImageElf);
-        LoadElfToMemories(verbose, arg.filepath);
+        mem_util_->LoadElfToMemories(verbose, arg.filepath);
       }
     } catch (const std::exception &err) {
       std::cerr << "ERROR: " << err.what() << std::endl;
@@ -571,196 +185,4 @@ bool VerilatorMemUtil::ParseCLIArguments(int argc, char **argv,
   }
 
   return true;
-}
-
-void VerilatorMemUtil::PrintMemRegions() const {
-  std::cout << "Registered memory regions:" << std::endl;
-  for (const auto &pr : name_to_mem_) {
-    const MemArea &m = pr.second;
-    std::cout << "\t'" << m.name << "' (" << m.width_byte * 8
-              << "bits) at location: '" << m.location << "'";
-    if (m.addr_loc.size) {
-      uint32_t low = m.addr_loc.base;
-      uint32_t high = m.addr_loc.base + m.addr_loc.size - 1;
-      std::cout << " (LMA range [0x" << std::hex << low << ", 0x" << high
-                << "])" << std::dec;
-    }
-    std::cout << std::endl;
-  }
-}
-
-void VerilatorMemUtil::LoadFileToNamedMem(bool verbose, const std::string &name,
-                                          const std::string &filepath,
-                                          MemImageType type) {
-  // If the image type isn't specified, try to figure it out from the file name
-  if (type == kMemImageUnknown) {
-    type = DetectMemImageType(filepath);
-  }
-  assert(type != kMemImageUnknown);
-
-  // Search for corresponding registered memory based on the name
-  auto it = name_to_mem_.find(name);
-  if (it == name_to_mem_.end()) {
-    std::ostringstream oss;
-    oss << "`" << name << ("' is not the name of a known memory region. "
-                           "Run with --meminit=list to get a list.");
-    throw std::runtime_error(oss.str());
-  }
-
-  if (verbose) {
-    std::cout << "Loading data from file `" << filepath << "' into memory `"
-              << name << "'." << std::endl;
-  }
-
-  const MemArea &m = it->second;
-
-  try {
-    switch (type) {
-      case kMemImageElf:
-        WriteElfToMem(m, filepath);
-        break;
-      case kMemImageVmem:
-        WriteVmemToMem(m, filepath);
-        break;
-      default:
-        assert(0);
-    }
-  } catch (const SVScoped::Error &err) {
-    std::ostringstream oss;
-    oss << "No memory found at `" << err.scope_name_
-        << "' (the scope associated with region `" << m.name << "').";
-    throw std::runtime_error(oss.str());
-  }
-}
-
-void VerilatorMemUtil::LoadElfToMemories(bool verbose,
-                                         const std::string &filepath) {
-  (void)elf_errno();
-  if (elf_version(EV_CURRENT) == EV_NONE) {
-    throw std::runtime_error(elf_errmsg(-1));
-  }
-
-  ElfFile elf(filepath);
-
-  size_t file_size;
-  const char *file_data = elf_rawfile(elf.ptr_, &file_size);
-  assert(file_data);
-
-  size_t phnum = elf.GetPhdrNum();
-  const Elf32_Phdr *phdrs = elf.GetPhdrs();
-
-  for (size_t i = 0; i < phnum; ++i) {
-    const Elf32_Phdr &phdr = phdrs[i];
-    if (phdr.p_type != PT_LOAD)
-      continue;
-
-    if (phdr.p_memsz == 0)
-      continue;
-
-    const MemArea *mem_area = FindRegionForAddr(phdr.p_paddr);
-    if (!mem_area) {
-      std::ostringstream oss;
-      oss << "No memory region is registered that contains the address 0x"
-          << std::hex << phdr.p_paddr << " (the base address of segment " << i
-          << ").";
-      throw ElfError(filepath, oss.str());
-    }
-    assert(mem_area->addr_loc.base <= phdr.p_paddr);
-
-    uint32_t lma_top = phdr.p_paddr + (phdr.p_memsz - 1);
-    uint32_t off_end = phdr.p_offset + phdr.p_filesz;
-
-    // Overflow checks
-    if (lma_top < phdr.p_paddr) {
-      std::ostringstream oss;
-      oss << "Integer overflow for top address of segment " << i << ".";
-      throw ElfError(filepath, oss.str());
-    }
-    if (off_end < phdr.p_offset) {
-      std::ostringstream oss;
-      oss << "Integer overflow for top file offset of segment " << i << ".";
-      throw ElfError(filepath, oss.str());
-    }
-
-    uint32_t local_base = phdr.p_paddr - mem_area->addr_loc.base;
-    uint32_t local_top = lma_top - mem_area->addr_loc.base;
-
-    if (mem_area->addr_loc.size <= local_top) {
-      std::ostringstream oss;
-      oss << "Segment " << i << " has size 0x" << std::hex << phdr.p_memsz
-          << " bytes. Its LMA of 0x" << phdr.p_paddr << " is at offset 0x"
-          << local_base << " in the memory region `" << mem_area->name
-          << "', so the segment finishes at offset 0x" << local_top
-          << ", but the memory region is only 0x" << mem_area->addr_loc.size
-          << " bytes long.";
-      throw ElfError(filepath, oss.str());
-    }
-
-    // Check that the segment is aligned correctly for the memory
-    if (local_base % mem_area->width_byte) {
-      std::ostringstream oss;
-      oss << "Segment " << i << " has LMA 0x" << std::hex << phdr.p_paddr
-          << ", which starts at offset 0x" << local_base
-          << " in the memory region `" << mem_area->name
-          << "'. This offset is not aligned to the region's word width of "
-          << std::dec << 8 * mem_area->width_byte << " bits.";
-      throw ElfError(filepath, oss.str());
-    }
-
-    // Check the segment actually fits in the file
-    if (file_size < off_end) {
-      std::ostringstream oss;
-      oss << "phdr for segment " << i << " claims to end at offset 0x"
-          << std::hex << off_end - 1 << ", but the file only has size 0x"
-          << file_size << ".";
-      throw ElfError(filepath, oss.str());
-    }
-
-    if (verbose) {
-      std::cout << "Loading segment " << i << " from ELF file `" << filepath
-                << "' into memory `" << mem_area->name << "'." << std::endl;
-    }
-
-    const char *seg_data = file_data + phdr.p_offset;
-    try {
-      WriteSegment(*mem_area, local_base, phdr.p_filesz, phdr.p_memsz,
-                   (const uint8_t *)seg_data);
-    } catch (const SVScoped::Error &err) {
-      std::ostringstream oss;
-      oss << "No memory found at `" << err.scope_name_
-          << "' (the scope associated with region `" << mem_area->name
-          << "', used by segment " << i << ", which starts at LMA 0x"
-          << std::hex << phdr.p_paddr << ").";
-      throw std::runtime_error(oss.str());
-    }
-  }
-}
-
-const MemArea *VerilatorMemUtil::FindRegionForAddr(uint32_t lma) const {
-  // To find the memory area containing lma, use upper_bound to find the first
-  // region strictly after it, and then std::prev to step backwards. This fails
-  // if either the map is empty (obviously!) or if ub_it is already the
-  // beginning of the map.
-  if (addr_to_mem_.empty())
-    return nullptr;
-
-  auto ub_it = addr_to_mem_.upper_bound(lma);
-  if (ub_it == addr_to_mem_.begin())
-    return nullptr;
-
-  const MemArea *m = std::prev(ub_it)->second;
-
-  // Every entry in addr_to_mem_ should have a valid pointer to a MemArea with a
-  // valid location.
-  assert(m != nullptr);
-  assert(m->addr_loc.size != 0);
-
-  // What's more, the base of the location should be less than equal to lma
-  // (because it's strictly less than the smallest entry strictly greater).
-  assert(m->addr_loc.base <= lma);
-
-  // This means that we've found the right region iff the top of the region
-  // includes lma.
-  uint32_t addr_top = m->addr_loc.base + (m->addr_loc.size - 1);
-  return (lma <= addr_top) ? m : nullptr;
 }

--- a/hw/dv/verilator/cpp/verilator_memutil.h
+++ b/hw/dv/verilator/cpp/verilator_memutil.h
@@ -2,108 +2,41 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef OPENTITAN_HW_DV_VERILATOR_CPP_VERILATOR_MEMUTIL_H_
-#define OPENTITAN_HW_DV_VERILATOR_CPP_VERILATOR_MEMUTIL_H_
+#pragma once
 
-#include <map>
-#include <string>
-#include <vltstd/svdpi.h>
+//
+// A wrapper class that converts a VerilatorMemutil into a SimCtrlExtension
+//
 
+#include <memory>
+
+#include "dpi_memutil.h"
 #include "sim_ctrl_extension.h"
 
-enum MemImageType {
-  kMemImageUnknown = 0,
-  kMemImageElf,
-  kMemImageVmem,
-};
-
-// The "load" location of a memory area. base is the lowest address in
-// the area, and should correspond to an ELF file's LMA. size is the
-// length of the area in bytes.
-struct MemAreaLoc {
-  uint32_t base;
-  uint32_t size;
-};
-
-struct MemArea {
-  std::string name;      // Unique identifier
-  std::string location;  // Design scope location
-  uint32_t width_byte;   // Memory width in bytes
-  MemAreaLoc addr_loc;   // Address location. If !size, location is unknown.
-};
-
-/**
- * Provide various memory loading utilities for Verilator simulations
- *
- * These utilities require the corresponding DPI functions:
- * simutil_verilator_memload()
- * simutil_verilator_set_mem()
- * to be defined somewhere as SystemVerilog functions.
- */
 class VerilatorMemUtil : public SimCtrlExtension {
  public:
-  /**
-   * Register a memory as instantiated by generic ram
-   *
-   * The |name| must be a unique identifier. The function will return false
-   * if |name| is already used. |location| is the path to the scope of the
-   * instantiated memory, which needs to support the DPI-C interfaces
-   * 'simutil_verilator_memload' and 'simutil_verilator_set_mem' used for
-   * 'vmem' and 'elf' files, respectively.
-   * The |width_bit| argument specifies the with in bits of the target memory
-   * instance (used for packing data). This must be a multiple of 8.
-   * If |addr_loc| is not null, it gives the base and size of the
-   * memory for loading in the address space (corresponding to LMAs in
-   * an ELF file).
-   *
-   * Memories must be registered before command arguments are parsed by
-   * ParseCommandArgs() in order for them to be known.
-   */
-  bool RegisterMemoryArea(const std::string name, const std::string location,
-                          size_t width_bit, const MemAreaLoc *addr_loc);
+  // No-argument constructor makes a VerilatorMemUtil. Single-argument
+  // constructor wraps its mem_util argument (but does not take ownership).
+  VerilatorMemUtil();
+  explicit VerilatorMemUtil(DpiMemUtil *mem_util);
 
-  /**
-   * Register a memory with default width (32bits)
-   */
-  bool RegisterMemoryArea(const std::string name, const std::string location);
-
-  /**
-   * Parse command line arguments
-   *
-   * Process all recognized command-line arguments from argc/argv.
-   *
-   * @param argc, argv Standard C command line arguments
-   * @param exit_app Indicate that program should terminate
-   * @return Return code, true == success
-   */
+  // Declared in SimCtrlExtension
   bool ParseCLIArguments(int argc, char **argv, bool &exit_app) override;
 
+  // Get underlying DpiMemUtil object
+  DpiMemUtil *GetUnderlying() { return mem_util_; }
+
+  // Pass-thru functions to underlying object
+  bool RegisterMemoryArea(const std::string name, const std::string location,
+                          size_t width_bit, const MemAreaLoc *addr_loc) {
+    return mem_util_->RegisterMemoryArea(name, location, width_bit, addr_loc);
+  }
+
+  bool RegisterMemoryArea(const std::string name, const std::string location) {
+    return mem_util_->RegisterMemoryArea(name, location);
+  }
+
  private:
-  std::map<std::string, MemArea> name_to_mem_;
-  std::map<uint32_t, const MemArea *> addr_to_mem_;
-
-  /**
-   * Print a list of all registered memory regions
-   *
-   * @see RegisterMemoryArea()
-   */
-  void PrintMemRegions() const;
-
-  /**
-   * Load the file at filepath into the named memory. If type is
-   * kMemImageUnknown, the file type is determined from the path.
-   */
-  void LoadFileToNamedMem(bool verbose, const std::string &name,
-                          const std::string &filepath, MemImageType type);
-  /**
-   * Load an ELF file, placing segments in memories by LMA
-   */
-  void LoadElfToMemories(bool verbose, const std::string &filepath);
-
-  /**
-   * Try to find a region for the given LMA. Returns nullptr if none is found.
-   */
-  const MemArea *FindRegionForAddr(uint32_t lma) const;
+  DpiMemUtil *mem_util_;
+  std::unique_ptr<DpiMemUtil> allocation_;
 };
-
-#endif  // OPENTITAN_HW_DV_VERILATOR_CPP_VERILATOR_MEMUTIL_H_

--- a/hw/dv/verilator/memutil_dpi.core
+++ b/hw/dv/verilator/memutil_dpi.core
@@ -1,0 +1,20 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:dv_verilator:memutil_dpi"
+description: "DPI memory utilities"
+filesets:
+  files_cpp:
+    files:
+      - cpp/dpi_memutil.cc
+      - cpp/dpi_memutil.h: { is_include_file: true }
+      - cpp/sv_scoped.cc
+      - cpp/sv_scoped.h: { is_include_file: true }
+    file_type: cppSource
+
+targets:
+  default:
+    filesets:
+      - files_cpp

--- a/hw/dv/verilator/memutil_verilator.core
+++ b/hw/dv/verilator/memutil_verilator.core
@@ -9,11 +9,10 @@ filesets:
   files_cpp:
     depend:
       - lowrisc:dv_verilator:simutil_verilator
+      - lowrisc:dv_verilator:memutil_dpi
     files:
       - cpp/verilator_memutil.cc
       - cpp/verilator_memutil.h: { is_include_file: true }
-      - cpp/sv_scoped.cc
-      - cpp/sv_scoped.h: { is_include_file: true }
     file_type: cppSource
 
 targets:

--- a/hw/ip/prim/rtl/prim_util_memload.svh
+++ b/hw/ip/prim/rtl/prim_util_memload.svh
@@ -16,21 +16,20 @@
 *    the memory if not empty.
  */
 
-`ifdef VERILATOR
+`ifndef SYNTHESIS
   // Task for loading 'mem' with SystemVerilog system task $readmemh()
-  export "DPI-C" task simutil_verilator_memload;
+  export "DPI-C" task simutil_memload;
 
-  task simutil_verilator_memload;
+  task simutil_memload;
     input string file;
     $readmemh(file, mem);
   endtask
 
   // Function for setting a specific element in |mem|
   // Returns 1 (true) for success, 0 (false) for errors.
-  export "DPI-C" function simutil_verilator_set_mem;
+  export "DPI-C" function simutil_set_mem;
 
-  function int simutil_verilator_set_mem(input int         index,
-                                         input bit [255:0] val);
+  function int simutil_set_mem(input int index, input bit [255:0] val);
 
     // Function will only work for memories <= 256 bits
     if (Width > 256) begin
@@ -46,10 +45,9 @@
   endfunction
 
   // Function for getting a specific element in |mem|
-  export "DPI-C" function simutil_verilator_get_mem;
+  export "DPI-C" function simutil_get_mem;
 
-  function int simutil_verilator_get_mem(input int          index,
-                                         output bit [255:0] val);
+  function int simutil_get_mem(input int index, output bit [255:0] val);
 
     // Function will only work for memories <= 256 bits
     if (Width > 256) begin


### PR DESCRIPTION
The point of this patch is to define `DpiMemutil`, a DPI-based interface
to backdoor load memories with the contents of VMem or ELF files, in a
way that can be used by non-Verilator simulations.

To do this, we split out everything but command line parsing and
`SimCtrlExtension` bits into a `DpiMemutil` class. The `VerilatorMemutil`
class is now a wrapper around a `DpiMemutil`, providing the
`SimCtrlExtension` interface.

This wrapping is done with a member (rather than multiple inheritance)
to allow users to subclass `DpiMemutil` and then wrap that. Doing that
with multiple inheritance, you end up with the usual diamond diagram
and bad things happen...

The split is cunningly designed to stay API compatible for C++ code
that uses `VerilatorMemutil`, but we don't keep API compatibility for
SystemVerilog code because we rename

```
   simutil_verilator_memload -> simutil_memload
   simutil_verilator_set_mem -> simutil_set_mem
   simutil_verilator_get_mem -> simutil_get_mem
```

One slight wart on the `VerilatorMemutil` class is the
`RegisterMemoryArea` forwarding functions. These are needed for API
compatibility, but we could get rid of them in future by changing the
callsites to use the `GetUnderlying()` accessor.
