### PR TITLE
[otbn] Small improvements to the DIF

### DIFF
--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -153,8 +153,10 @@
         desc: '''
           Instruction Memory.
 
-          Not accessible during the operation of the engine.
-          TODO: Discuss and document behavior in that case. Alert? Ignore?
+          This register should only be accesed while OTBN is not busy, as indicated by the !!STATUS.busy flag.
+          Accesses while OTBN is busy are blocking.
+
+          TODO: The exact behavior is yet to be determined, see https://github.com/lowRISC/opentitan/issues/2696 for details.
         '''
       }
     }
@@ -169,8 +171,10 @@
         desc: '''
           Data Memory.
 
-          Not accessible during the operation of the engine.
-          TODO: Discuss and document behavior in that case. Alert? Ignore?
+          This register should only be accesed while OTBN is not busy, as indicated by the !!STATUS.busy flag.
+          Accesses while OTBN is busy are blocking.
+
+          TODO: The exact behavior is yet to be determined, see https://github.com/lowRISC/opentitan/issues/2696 for details.
         '''
       }
     }

--- a/hw/ip/otbn/doc/_index.md
+++ b/hw/ip/otbn/doc/_index.md
@@ -516,6 +516,9 @@ The data memory (DMEM) is 256b wide and read-write accessible from the base and 
 When accessed from the base instruction subset through the `LW` or `SW` instructions, accesses must read or write 32b-aligned 32b words.
 When accessed from the big number instruction subset through the `BN.LID` or `BN.SID` instructions, accesses must read or write 256b-aligned 256b words.
 
+Both memories can be accessed through OTBN's register interface ({{< regref "DMEM" >}} and {{< regref "IMEM" >}}) only when OTBN is idle, as indicated by the {{< regref "STATUS.busy">}} flag.
+All memory accesses through the register interface must be word-aligned 32b word accesses.
+
 ## Operation
 
 <div class="bd-callout bd-callout-warning">

--- a/sw/device/lib/dif/dif_otbn.c
+++ b/sw/device/lib/dif/dif_otbn.c
@@ -261,9 +261,9 @@ dif_otbn_result_t dif_otbn_imem_read(const dif_otbn_t *otbn,
 dif_otbn_result_t dif_otbn_dmem_write(const dif_otbn_t *otbn,
                                       uint32_t offset_bytes,
                                       const uint32_t *src, size_t len_bytes) {
-  // Only 256b-aligned 256b word accesses are allowed.
-  if (otbn == NULL || src == NULL || len_bytes % kDifOtbnWlenBytes != 0 ||
-      (offset_bytes % kDifOtbnWlenBytes != 0) ||
+  // Only 32b-aligned 32b word accesses are allowed.
+  if (otbn == NULL || src == NULL || len_bytes % 4 != 0 ||
+      offset_bytes % 4 != 0 ||
       offset_bytes + len_bytes > OTBN_DMEM_SIZE_BYTES) {
     return kDifOtbnBadArg;
   }
@@ -277,9 +277,9 @@ dif_otbn_result_t dif_otbn_dmem_write(const dif_otbn_t *otbn,
 dif_otbn_result_t dif_otbn_dmem_read(const dif_otbn_t *otbn,
                                      uint32_t offset_bytes, uint32_t *dest,
                                      size_t len_bytes) {
-  // Only 256b-aligned 256b word accesses are allowed.
-  if (otbn == NULL || dest == NULL || len_bytes % kDifOtbnWlenBytes != 0 ||
-      (offset_bytes % kDifOtbnWlenBytes != 0) ||
+  // Only 32b-aligned 32b word accesses are allowed.
+  if (otbn == NULL || dest == NULL || len_bytes % 4 != 0 ||
+      offset_bytes % 4 != 0 ||
       offset_bytes + len_bytes > OTBN_DMEM_SIZE_BYTES) {
     return kDifOtbnBadArg;
   }

--- a/sw/device/lib/dif/dif_otbn.c
+++ b/sw/device/lib/dif/dif_otbn.c
@@ -289,3 +289,11 @@ dif_otbn_result_t dif_otbn_dmem_read(const dif_otbn_t *otbn,
 
   return kDifOtbnOk;
 }
+
+size_t dif_otbn_get_dmem_size_bytes(const dif_otbn_t *otbn) {
+  return OTBN_DMEM_SIZE_BYTES;
+}
+
+size_t dif_otbn_get_imem_size_bytes(const dif_otbn_t *otbn) {
+  return OTBN_IMEM_SIZE_BYTES;
+}

--- a/sw/device/lib/dif/dif_otbn.h
+++ b/sw/device/lib/dif/dif_otbn.h
@@ -259,6 +259,8 @@ dif_otbn_result_t dif_otbn_get_err_code(const dif_otbn_t *otbn,
 /**
  * Write an OTBN application into its instruction memory (IMEM)
  *
+ * Only 32b-aligned 32b word accesses are allowed.
+ *
  * @param otbn OTBN instance
  * @param offset_bytes the byte offset in IMEM the first word is written to
  * @param src the main memory location to start reading from.
@@ -272,6 +274,8 @@ dif_otbn_result_t dif_otbn_imem_write(const dif_otbn_t *otbn,
 
 /**
  * Read from OTBN's instruction memory (IMEM)
+ *
+ * Only 32b-aligned 32b word accesses are allowed.
  *
  * @param otbn OTBN instance
  * @param offset_bytes the byte offset in IMEM the first word is read from
@@ -287,6 +291,8 @@ dif_otbn_result_t dif_otbn_imem_read(const dif_otbn_t *otbn,
 /**
  * Write to OTBN's data memory (DMEM)
  *
+ * Only 32b-aligned 32b word accesses are allowed.
+ *
  * @param otbn OTBN instance
  * @param offset_bytes the byte offset in DMEM the first word is written to
  * @param src the main memory location to start reading from.
@@ -300,6 +306,8 @@ dif_otbn_result_t dif_otbn_dmem_write(const dif_otbn_t *otbn,
 
 /**
  * Read from OTBN's data memory (DMEM)
+ *
+ * Only 32b-aligned 32b word accesses are allowed.
  *
  * @param otbn OTBN instance
  * @param offset_bytes the byte offset in DMEM the first word is read from

--- a/sw/device/lib/dif/dif_otbn.h
+++ b/sw/device/lib/dif/dif_otbn.h
@@ -320,6 +320,22 @@ dif_otbn_result_t dif_otbn_dmem_read(const dif_otbn_t *otbn,
                                      uint32_t offset_bytes, uint32_t *dest,
                                      size_t len_bytes);
 
+/**
+ * Get the size of OTBN's data memory in bytes.
+ *
+ * @param otbn OTBN instance
+ * @return data memory size in bytes
+ */
+size_t dif_otbn_get_dmem_size_bytes(const dif_otbn_t *otbn);
+
+/**
+ * Get the size of OTBN's instruction memory in bytes.
+ *
+ * @param otbn OTBN instance
+ * @return instruction memory size in bytes
+ */
+size_t dif_otbn_get_imem_size_bytes(const dif_otbn_t *otbn);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus


### PR DESCRIPTION
Improve the OTBN DIF slightly to prepare it for the sanity test.

See the individual commit messages for details:
﻿- [otbn] Document how IMEM and DMEM are accesses from bus (@rswarbrick please have a look)
- [dif/otbn] Allow 32b access to DMEM
- [dif/otbn] Add getters and setters for memory sizes
