### PR TITLE
[reggen] Enum Value Definition Fixes

### DIFF
--- a/sw/device/lib/dif/dif_i2c.c
+++ b/sw/device/lib/dif/dif_i2c.c
@@ -255,19 +255,19 @@ dif_i2c_result_t dif_i2c_set_watermarks(const dif_i2c_t *i2c,
   ptrdiff_t rx_level_value;
   switch (rx_level) {
     case kDifI2cLevel1Byte:
-      rx_level_value = I2C_FIFO_CTRL_RXILVL_RXLVL1;
+      rx_level_value = I2C_FIFO_CTRL_RXILVL_VALUE_RXLVL1;
       break;
     case kDifI2cLevel4Byte:
-      rx_level_value = I2C_FIFO_CTRL_RXILVL_RXLVL4;
+      rx_level_value = I2C_FIFO_CTRL_RXILVL_VALUE_RXLVL4;
       break;
     case kDifI2cLevel8Byte:
-      rx_level_value = I2C_FIFO_CTRL_RXILVL_RXLVL8;
+      rx_level_value = I2C_FIFO_CTRL_RXILVL_VALUE_RXLVL8;
       break;
     case kDifI2cLevel16Byte:
-      rx_level_value = I2C_FIFO_CTRL_RXILVL_RXLVL16;
+      rx_level_value = I2C_FIFO_CTRL_RXILVL_VALUE_RXLVL16;
       break;
     case kDifI2cLevel30Byte:
-      rx_level_value = I2C_FIFO_CTRL_RXILVL_RXLVL30;
+      rx_level_value = I2C_FIFO_CTRL_RXILVL_VALUE_RXLVL30;
       break;
     default:
       return kDifI2cBadArg;
@@ -276,16 +276,16 @@ dif_i2c_result_t dif_i2c_set_watermarks(const dif_i2c_t *i2c,
   ptrdiff_t fmt_level_value;
   switch (fmt_level) {
     case kDifI2cLevel1Byte:
-      fmt_level_value = I2C_FIFO_CTRL_FMTILVL_FMTLVL1;
+      fmt_level_value = I2C_FIFO_CTRL_FMTILVL_VALUE_FMTLVL1;
       break;
     case kDifI2cLevel4Byte:
-      fmt_level_value = I2C_FIFO_CTRL_FMTILVL_FMTLVL4;
+      fmt_level_value = I2C_FIFO_CTRL_FMTILVL_VALUE_FMTLVL4;
       break;
     case kDifI2cLevel8Byte:
-      fmt_level_value = I2C_FIFO_CTRL_FMTILVL_FMTLVL8;
+      fmt_level_value = I2C_FIFO_CTRL_FMTILVL_VALUE_FMTLVL8;
       break;
     case kDifI2cLevel16Byte:
-      fmt_level_value = I2C_FIFO_CTRL_FMTILVL_FMTLVL16;
+      fmt_level_value = I2C_FIFO_CTRL_FMTILVL_VALUE_FMTLVL16;
       break;
     default:
       return kDifI2cBadArg;

--- a/sw/device/lib/dif/dif_uart.c
+++ b/sw/device/lib/dif/dif_uart.c
@@ -332,19 +332,19 @@ dif_uart_result_t dif_uart_watermark_rx_set(const dif_uart_t *uart,
   uint32_t value;
   switch (watermark) {
     case kDifUartWatermarkByte1:
-      value = UART_FIFO_CTRL_RXILVL_RXLVL1;
+      value = UART_FIFO_CTRL_RXILVL_VALUE_RXLVL1;
       break;
     case kDifUartWatermarkByte4:
-      value = UART_FIFO_CTRL_RXILVL_RXLVL4;
+      value = UART_FIFO_CTRL_RXILVL_VALUE_RXLVL4;
       break;
     case kDifUartWatermarkByte8:
-      value = UART_FIFO_CTRL_RXILVL_RXLVL8;
+      value = UART_FIFO_CTRL_RXILVL_VALUE_RXLVL8;
       break;
     case kDifUartWatermarkByte16:
-      value = UART_FIFO_CTRL_RXILVL_RXLVL16;
+      value = UART_FIFO_CTRL_RXILVL_VALUE_RXLVL16;
       break;
     case kDifUartWatermarkByte30:
-      value = UART_FIFO_CTRL_RXILVL_RXLVL30;
+      value = UART_FIFO_CTRL_RXILVL_VALUE_RXLVL30;
       break;
     default:
       return kDifUartError;
@@ -371,16 +371,16 @@ dif_uart_result_t dif_uart_watermark_tx_set(const dif_uart_t *uart,
   uint32_t value;
   switch (watermark) {
     case kDifUartWatermarkByte1:
-      value = UART_FIFO_CTRL_TXILVL_TXLVL1;
+      value = UART_FIFO_CTRL_TXILVL_VALUE_TXLVL1;
       break;
     case kDifUartWatermarkByte4:
-      value = UART_FIFO_CTRL_TXILVL_TXLVL4;
+      value = UART_FIFO_CTRL_TXILVL_VALUE_TXLVL4;
       break;
     case kDifUartWatermarkByte8:
-      value = UART_FIFO_CTRL_TXILVL_TXLVL8;
+      value = UART_FIFO_CTRL_TXILVL_VALUE_TXLVL8;
       break;
     case kDifUartWatermarkByte16:
-      value = UART_FIFO_CTRL_TXILVL_TXLVL16;
+      value = UART_FIFO_CTRL_TXILVL_VALUE_TXLVL16;
       break;
     default:
       // The minimal TX watermark is 1 byte, maximal 16 bytes.

--- a/sw/device/lib/dif/dif_usbdev.c
+++ b/sw/device/lib/dif/dif_usbdev.c
@@ -781,19 +781,19 @@ dif_usbdev_result_t dif_usbdev_status_get_link_state(
       USBDEV_USBSTAT_LINK_STATE_MASK, USBDEV_USBSTAT_LINK_STATE_OFFSET);
 
   switch (val) {
-    case USBDEV_USBSTAT_LINK_STATE_DISCONNECT:
+    case USBDEV_USBSTAT_LINK_STATE_VALUE_DISCONNECT:
       *link_state = kDifUsbdevLinkStateDisconnected;
       break;
-    case USBDEV_USBSTAT_LINK_STATE_POWERED:
+    case USBDEV_USBSTAT_LINK_STATE_VALUE_POWERED:
       *link_state = kDifUsbdevLinkStatePowered;
       break;
-    case USBDEV_USBSTAT_LINK_STATE_POWERED_SUSPEND:
+    case USBDEV_USBSTAT_LINK_STATE_VALUE_POWERED_SUSPEND:
       *link_state = kDifUsbdevLinkStatePoweredSuspend;
       break;
-    case USBDEV_USBSTAT_LINK_STATE_ACTIVE:
+    case USBDEV_USBSTAT_LINK_STATE_VALUE_ACTIVE:
       *link_state = kDifUsbdevLinkStateActive;
       break;
-    case USBDEV_USBSTAT_LINK_STATE_SUSPEND:
+    case USBDEV_USBSTAT_LINK_STATE_VALUE_SUSPEND:
       *link_state = kDifUsbdevLinkStateSuspend;
       break;
     default:

--- a/sw/device/tests/dif/dif_i2c_unittest.cc
+++ b/sw/device/tests/dif/dif_i2c_unittest.cc
@@ -304,49 +304,52 @@ TEST_F(FifoCtrlTest, FmtNullArgs) {
 }
 
 TEST_F(FifoCtrlTest, SetLevels) {
-  EXPECT_MASK32(
-      I2C_FIFO_CTRL_REG_OFFSET,
-      {
-          {
-              I2C_FIFO_CTRL_RXILVL_OFFSET, I2C_FIFO_CTRL_RXILVL_MASK,
-              I2C_FIFO_CTRL_RXILVL_RXLVL1,
-          },
-          {
-              I2C_FIFO_CTRL_FMTILVL_OFFSET, I2C_FIFO_CTRL_FMTILVL_MASK,
-              I2C_FIFO_CTRL_FMTILVL_FMTLVL1,
-          },
-      });
+  EXPECT_MASK32(I2C_FIFO_CTRL_REG_OFFSET,
+                {
+                    {
+                        I2C_FIFO_CTRL_RXILVL_OFFSET,
+                        I2C_FIFO_CTRL_RXILVL_MASK,
+                        I2C_FIFO_CTRL_RXILVL_VALUE_RXLVL1,
+                    },
+                    {
+                        I2C_FIFO_CTRL_FMTILVL_OFFSET,
+                        I2C_FIFO_CTRL_FMTILVL_MASK,
+                        I2C_FIFO_CTRL_FMTILVL_VALUE_FMTLVL1,
+                    },
+                });
   EXPECT_EQ(dif_i2c_set_watermarks(&i2c_, kDifI2cLevel1Byte, kDifI2cLevel1Byte),
             kDifI2cOk);
 
-  EXPECT_MASK32(
-      I2C_FIFO_CTRL_REG_OFFSET,
-      {
-          {
-              I2C_FIFO_CTRL_RXILVL_OFFSET, I2C_FIFO_CTRL_RXILVL_MASK,
-              I2C_FIFO_CTRL_RXILVL_RXLVL4,
-          },
-          {
-              I2C_FIFO_CTRL_FMTILVL_OFFSET, I2C_FIFO_CTRL_FMTILVL_MASK,
-              I2C_FIFO_CTRL_FMTILVL_FMTLVL16,
-          },
-      });
+  EXPECT_MASK32(I2C_FIFO_CTRL_REG_OFFSET,
+                {
+                    {
+                        I2C_FIFO_CTRL_RXILVL_OFFSET,
+                        I2C_FIFO_CTRL_RXILVL_MASK,
+                        I2C_FIFO_CTRL_RXILVL_VALUE_RXLVL4,
+                    },
+                    {
+                        I2C_FIFO_CTRL_FMTILVL_OFFSET,
+                        I2C_FIFO_CTRL_FMTILVL_MASK,
+                        I2C_FIFO_CTRL_FMTILVL_VALUE_FMTLVL16,
+                    },
+                });
   EXPECT_EQ(
       dif_i2c_set_watermarks(&i2c_, kDifI2cLevel4Byte, kDifI2cLevel16Byte),
       kDifI2cOk);
 
-  EXPECT_MASK32(
-      I2C_FIFO_CTRL_REG_OFFSET,
-      {
-          {
-              I2C_FIFO_CTRL_RXILVL_OFFSET, I2C_FIFO_CTRL_RXILVL_MASK,
-              I2C_FIFO_CTRL_RXILVL_RXLVL30,
-          },
-          {
-              I2C_FIFO_CTRL_FMTILVL_OFFSET, I2C_FIFO_CTRL_FMTILVL_MASK,
-              I2C_FIFO_CTRL_FMTILVL_FMTLVL8,
-          },
-      });
+  EXPECT_MASK32(I2C_FIFO_CTRL_REG_OFFSET,
+                {
+                    {
+                        I2C_FIFO_CTRL_RXILVL_OFFSET,
+                        I2C_FIFO_CTRL_RXILVL_MASK,
+                        I2C_FIFO_CTRL_RXILVL_VALUE_RXLVL30,
+                    },
+                    {
+                        I2C_FIFO_CTRL_FMTILVL_OFFSET,
+                        I2C_FIFO_CTRL_FMTILVL_MASK,
+                        I2C_FIFO_CTRL_FMTILVL_VALUE_FMTLVL8,
+                    },
+                });
   EXPECT_EQ(
       dif_i2c_set_watermarks(&i2c_, kDifI2cLevel30Byte, kDifI2cLevel8Byte),
       kDifI2cOk);

--- a/sw/device/tests/dif/dif_uart_unittest.cc
+++ b/sw/device/tests/dif/dif_uart_unittest.cc
@@ -148,7 +148,7 @@ TEST_F(WatermarkRxSetTest, Success) {
   EXPECT_MASK32(UART_FIFO_CTRL_REG_OFFSET,
                 {
                     {UART_FIFO_CTRL_RXILVL_OFFSET, UART_FIFO_CTRL_RXILVL_MASK,
-                     UART_FIFO_CTRL_RXILVL_RXLVL1},
+                     UART_FIFO_CTRL_RXILVL_VALUE_RXLVL1},
                 });
   EXPECT_EQ(dif_uart_watermark_rx_set(&uart_, kDifUartWatermarkByte1),
             kDifUartOk);
@@ -156,7 +156,7 @@ TEST_F(WatermarkRxSetTest, Success) {
   EXPECT_MASK32(UART_FIFO_CTRL_REG_OFFSET,
                 {
                     {UART_FIFO_CTRL_RXILVL_OFFSET, UART_FIFO_CTRL_RXILVL_MASK,
-                     UART_FIFO_CTRL_RXILVL_RXLVL30},
+                     UART_FIFO_CTRL_RXILVL_VALUE_RXLVL30},
                 });
   EXPECT_EQ(dif_uart_watermark_rx_set(&uart_, kDifUartWatermarkByte30),
             kDifUartOk);
@@ -181,7 +181,7 @@ TEST_F(WatermarkTxSetTest, Success) {
   EXPECT_MASK32(UART_FIFO_CTRL_REG_OFFSET,
                 {
                     {UART_FIFO_CTRL_TXILVL_OFFSET, UART_FIFO_CTRL_TXILVL_MASK,
-                     UART_FIFO_CTRL_TXILVL_TXLVL1},
+                     UART_FIFO_CTRL_TXILVL_VALUE_TXLVL1},
                 });
   EXPECT_EQ(dif_uart_watermark_tx_set(&uart_, kDifUartWatermarkByte1),
             kDifUartOk);
@@ -189,7 +189,7 @@ TEST_F(WatermarkTxSetTest, Success) {
   EXPECT_MASK32(UART_FIFO_CTRL_REG_OFFSET,
                 {
                     {UART_FIFO_CTRL_TXILVL_OFFSET, UART_FIFO_CTRL_TXILVL_MASK,
-                     UART_FIFO_CTRL_TXILVL_TXLVL16},
+                     UART_FIFO_CTRL_TXILVL_VALUE_TXLVL16},
                 });
   EXPECT_EQ(dif_uart_watermark_tx_set(&uart_, kDifUartWatermarkByte16),
             kDifUartOk);

--- a/util/reggen/gen_cheader.py
+++ b/util/reggen/gen_cheader.py
@@ -127,11 +127,12 @@ def gen_cdefine_register(outstr, reg, comp, width, rnames, existing_defines):
             if 'enum' in field:
                 for enum in field['enum']:
                     ename = as_define(enum['name'])
+                    value = hex(int(enum['value'], 0))
                     genout(
                         outstr,
                         gen_define(
-                            defname + '_' + as_define(field['name']) + '_' +
-                            ename, [], enum['value'], existing_defines))
+                            defname + '_' + as_define(field['name']) +
+                            '_VALUE_' + ename, [], value, existing_defines))
     genout(outstr, '\n')
     return
 


### PR DESCRIPTION
Reggen has been generating enum values already, directly using the
definitions from the hjson. This causes issues when binary literals are
included in the string, as we don't allow those in C/C++ code, so this
change moves to emitting all values as hexadecimal values.

The other change this makes is to add '_VALUE_` between the register
field name and the enum name, so that there are no collisions between
the offset/mask definitions and the enum values.

Closes #3804. 