### PR TITLE
[util/container] Fix container build

### DIFF
--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -88,7 +88,8 @@ ENV LANGUAGE en_US:en
 
 # Copy repository into tmp directory to execute additional install steps.
 COPY python-requirements.txt /tmp/python-requirements.txt
-RUN pip3 install -r /tmp/python-requirements.txt
+RUN pip3 install -U pip six setuptools \
+  && pip3 install -r /tmp/python-requirements.txt
 
 COPY util/get-toolchain.py /tmp/get-toolchain.py
 RUN /tmp/get-toolchain.py -r ${RISCV_TOOLCHAIN_TAR_VERSION}


### PR DESCRIPTION
The container build fails with the following message, which could
indicate an outdated pip/setuptools version.

```
Collecting fusesoc>=1.11.0 from git+https://github.com/lowRISC/fusesoc.git@ot#egg=fusesoc >= 1.11.0 (from -r /tmp/python-requirements.txt (line 34))
  Cloning https://github.com/lowRISC/fusesoc.git (to ot) to /tmp/pip-build-psww_tt_/fusesoc
    Complete output from command python setup.py egg_info:
    Download error on https://pypi.python.org/simple/setuptools_scm/: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:645) -- Some packages may not be found!
    Download error on https://pypi.python.org/simple/setuptools-scm/: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:645) -- Some packages may not be found!
    Couldn't find index page for 'setuptools_scm' (maybe misspelled?)
    Download error on https://pypi.python.org/simple/: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:645) -- Some packages may not be found!
    No local packages or download links found for setuptools_scm
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-psww_tt_/fusesoc/setup.py", line 52, in <module>
        python_requires=">=3.5, <4",
      File "/usr/lib/python3.5/distutils/core.py", line 108, in setup
        _setup_distribution = dist = klass(attrs)
      File "/usr/lib/python3/dist-packages/setuptools/dist.py", line 269, in __init__
        self.fetch_build_eggs(attrs['setup_requires'])
      File "/usr/lib/python3/dist-packages/setuptools/dist.py", line 313, in fetch_build_eggs
        replace_conflicting=True,
      File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 826, in resolve
        dist = best[req.key] = env.best_match(req, ws, installer)
      File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 1092, in best_match
        return self.obtain(req, installer)
      File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 1104, in obtain
        return installer(requirement)
      File "/usr/lib/python3/dist-packages/setuptools/dist.py", line 380, in fetch_build_egg
        return cmd.easy_install(req)
      File "/usr/lib/python3/dist-packages/setuptools/command/easy_install.py", line 657, in easy_install
        raise DistutilsError(msg)
    distutils.errors.DistutilsError: Could not find suitable distribution for Requirement.parse('setuptools_scm')
```