### PR TITLE
[dv/common] Update source id constraint

### DIFF
--- a/hw/dv/sv/tl_agent/tl_agent_cfg.sv
+++ b/hw/dv/sv/tl_agent/tl_agent_cfg.sv
@@ -160,7 +160,8 @@ class tl_agent_cfg extends dv_base_agent_cfg;
   protected function void randomize_a_source_in_item(tl_seq_item item,
                                                      bit use_last_a_source_released);
     `DV_CHECK_MEMBER_RANDOMIZE_WITH_FATAL(a_source,
-        (!reset_asserted) -> !(a_source inside {a_source_pend_q});
+        // use soft constraint as seq may still send req when all the valid a_source are used
+        (!reset_asserted) -> soft !(a_source inside {a_source_pend_q});
         // Set the upper a_source bits that are unused to 0.
         (a_source >> valid_a_source_width) == 0;
         // We cannot guarantee that last_a_source_released is not in a_source_pend_q,

--- a/hw/dv/sv/tl_agent/tl_host_driver.sv
+++ b/hw/dv/sv/tl_agent/tl_host_driver.sv
@@ -59,14 +59,15 @@ class tl_host_driver extends tl_base_driver;
     int unsigned a_valid_delay, a_valid_len;
     bit req_done, req_abort;
 
-    // Seq may override the a_source, in which case it is possible that it might not have factored
+    // Seq may override the a_source or all valid sources are used but still send req, in which case
+    // it is possible that it might not have factored
+    // This wait is only needed in xbar test as xbar can use all valid sources and xbar_stress runs
+    // all seq in parallel, which needs driver to stall when the source is currently being used
     // in the a_source values from pending requests that have not yet completed. If that is true, we
     // need to insert additional delays to ensure we do not end up sending the new request whose
     // a_source matches one of the pending requests.
-    if (req.a_source_is_overridden) begin
-      `DV_SPINWAIT_EXIT(while (is_source_in_pending_req(req.a_source)) @(cfg.vif.host_cb);,
-                        wait(reset_asserted);)
-    end
+    `DV_SPINWAIT_EXIT(while (is_source_in_pending_req(req.a_source)) @(cfg.vif.host_cb);,
+                      wait(reset_asserted);)
 
     while (!req_done && !req_abort) begin
       if (cfg.use_seq_item_a_valid_delay) begin


### PR DESCRIPTION
Fix regression failure in chip xbar

xbar stress_all test runs all seq in parallel, seq could still send req
even all valid sources are used. Change source constraint to soft and
let driver stall if the source is used in pending items

Signed-off-by: Weicai Yang <weicai@google.com>