### PR TITLE
[prim] Fix AscentLint waiver that made the tool crash

### DIFF
--- a/hw/ip/prim/lint/prim.waiver
+++ b/hw/ip/prim/lint/prim.waiver
@@ -64,6 +64,6 @@ waive -rules {HIER_BRANCH_NOT_READ} -location {tlul_fifo_sync.sv} -regexp {Conne
 waive -rules {HIER_BRANCH_NOT_READ INPUT_NOT_READ} -location {prim_arbiter_fixed.sv} -regexp {.*'(clk_i|rst_ni)' is not read from in module 'prim_arbiter_fixed'.*} \
       -comment "clk_ and rst_ni are only used for assertions in this module."
 
-waive -rules {INTEGER} -location{prim_cipher_pkg.sv} -msg {'k' of type int used as a non-constant} \
+waive -rules {INTEGER} -location {prim_cipher_pkg.sv} -msg {'k' of type int used as a non-constant} \
       -comment "We need to use the iterator value in the keyschedule function, hence this is ok."
 


### PR DESCRIPTION
This error has been reported to RealIntent, as the tool did not output a meaningful error message.

Signed-off-by: Michael Schaffner <msf@google.com>