### PR TITLE
[kmac] Fix Critical Lint Error

### DIFF
--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -82,7 +82,7 @@
                  "excl:CsrNonInitTests:CsrExclWrite"]
         } // f: kmac_en
         { bits: "3:1"
-          name: "strength"
+          name: "kstrength"
           desc: '''Hashing Strength
 
                 3 bit field to select the security strength of SHA3 hashing

--- a/hw/ip/kmac/rtl/keccak_2share.sv
+++ b/hw/ip/kmac/rtl/keccak_2share.sv
@@ -57,6 +57,16 @@ module keccak_2share #(
   box_t phase2_in  [Share];
   box_t phase2_out [Share];
 
+  /////////////////
+  // Unused nets //
+  /////////////////
+  // clk_i, rst_ni, rand_valid_i are not used when EnMasking is 0. Tying them.
+  if (EnMasking == 0) begin : gen_tie_unused
+    logic unused_clk, unused_rst_n, unused_rand_valid;
+    assign unused_clk = clk_i;
+    assign unused_rst_n = rst_ni;
+    assign unused_rand_valid = rand_valid_i;
+  end
 
   ///////////////////////
   // Input/ Output Mux //

--- a/hw/ip/kmac/rtl/kmac_core.sv
+++ b/hw/ip/kmac/rtl/kmac_core.sv
@@ -197,7 +197,7 @@ module kmac_core
   // When Key write happens, hold the FIFO request. so fifo_ready_o is tied to 0
   assign msg_valid_o  = (kmac_en_i && en_kmac_datapath) ? kmac_valid : fifo_valid_i;
   assign msg_data_o   = (kmac_en_i && en_kmac_datapath) ? kmac_data  : fifo_data_i ;
-  assign msg_strb_i   = (kmac_en_i && en_kmac_datapath) ? kmac_strb  : fifo_strb_i ;
+  assign msg_strb_o   = (kmac_en_i && en_kmac_datapath) ? kmac_strb  : fifo_strb_i ;
   assign fifo_ready_o = (kmac_en_i && en_kmac_datapath) ? 1'b 0      : msg_ready_i ;
 
   // secret key write request to SHA3 hashing engine is always full width write.
@@ -300,7 +300,7 @@ module kmac_core
 
   assign encoded_key_block[0] = {encoded_key[0], encode_bytepad};
 
-  if (EnMasking) begin : encoded_key_block_masked
+  if (EnMasking) begin : gen_encoded_key_block_masked
     assign encoded_key_block[1] = {encoded_key[1], 16'h 0};
   end
 
@@ -334,11 +334,11 @@ module kmac_core
   // but below is easier to understand
   always_comb begin
     unique case (strength_i)
-      L128: block_addr_limit = KeccakRate[L128];
-      L224: block_addr_limit = KeccakRate[L224];
-      L256: block_addr_limit = KeccakRate[L256];
-      L384: block_addr_limit = KeccakRate[L384];
-      L512: block_addr_limit = KeccakRate[L512];
+      L128: block_addr_limit = KeccakCountW'(KeccakRate[L128]);
+      L224: block_addr_limit = KeccakCountW'(KeccakRate[L224]);
+      L256: block_addr_limit = KeccakCountW'(KeccakRate[L256]);
+      L384: block_addr_limit = KeccakCountW'(KeccakRate[L384]);
+      L512: block_addr_limit = KeccakCountW'(KeccakRate[L512]);
 
       default: block_addr_limit = '0;
     endcase

--- a/hw/ip/kmac/rtl/kmac_msgfifo.sv
+++ b/hw/ip/kmac/rtl/kmac_msgfifo.sv
@@ -203,6 +203,9 @@ module kmac_msgfifo
     .rdata_o  (fifo_rdata)
   );
 
+  assign fifo_wvalid = packer_wvalid;
+  assign packer_wready = fifo_wready;
+
   assign msg_valid_o = fifo_rvalid;
   assign fifo_rready = msg_ready_i;
   assign msg_data_o  = fifo_rdata.data;

--- a/hw/ip/kmac/rtl/kmac_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_pkg.sv
@@ -111,7 +111,7 @@ package kmac_pkg;
     L512 = 3'b 100  // rate:  576 bit / capacity: 1024 bit Keccak[1024](, 512)
   } keccak_strength_e;
 
-  parameter int KeccakRate [5] = '{
+  parameter int unsigned KeccakRate [5] = '{
     1344/MsgWidth,  // 21 depth := (1600 - 128*2)
     1152/MsgWidth,  // 18 depth := (1600 - 224*2)
     1088/MsgWidth,  // 17 depth := (1600 - 256*2)
@@ -119,12 +119,12 @@ package kmac_pkg;
      576/MsgWidth   //  9 depth := (1600 - 512*2)
   };
 
-  parameter int MaxBlockSize = KeccakRate[0];
+  parameter int unsigned MaxBlockSize = KeccakRate[0];
 
-  parameter int KeccakEntries = 1600/MsgWidth;
-  parameter int KeccakMsgAddrW = $clog2(KeccakEntries);
+  parameter int unsigned KeccakEntries = 1600/MsgWidth;
+  parameter int unsigned KeccakMsgAddrW = $clog2(KeccakEntries);
 
-  parameter int KeccakCountW = $clog2(KeccakEntries+1);
+  parameter int unsigned KeccakCountW = $clog2(KeccakEntries+1);
 
   // Key related definitions
   // If this value is changed, please modify the logic inside kmac_core
@@ -241,9 +241,9 @@ package kmac_pkg;
   // It depends on the block size. We can reuse KeccakRate
   // 10000000 || 00010101 // 168
   // 10000000 || 00010001 // 136
-  function automatic logic [15:0] encode_bytepad_len(keccak_strength_e strength);
+  function automatic logic [15:0] encode_bytepad_len(keccak_strength_e kstrength);
     logic [15:0] result;
-    unique case (strength)
+    unique case (kstrength)
       L128: result = 16'h A801; // cSHAKE128
       L224: result = 16'h 9001; // not used
       L256: result = 16'h 8801; // cSHAKE256
@@ -252,6 +252,7 @@ package kmac_pkg;
 
       default: result = 16'h 0000;
     endcase
+    return result;
   endfunction : encode_bytepad_len
 
 endpackage : kmac_pkg

--- a/hw/ip/kmac/rtl/kmac_reg_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_pkg.sv
@@ -58,7 +58,7 @@ package kmac_reg_pkg;
     } kmac_en;
     struct packed {
       logic [2:0]  q;
-    } strength;
+    } kstrength;
     struct packed {
       logic [1:0]  q;
     } mode;

--- a/hw/ip/kmac/rtl/kmac_reg_top.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_top.sv
@@ -149,9 +149,9 @@ module kmac_reg_top (
   logic cfg_kmac_en_qs;
   logic cfg_kmac_en_wd;
   logic cfg_kmac_en_we;
-  logic [2:0] cfg_strength_qs;
-  logic [2:0] cfg_strength_wd;
-  logic cfg_strength_we;
+  logic [2:0] cfg_kstrength_qs;
+  logic [2:0] cfg_kstrength_wd;
+  logic cfg_kstrength_we;
   logic [1:0] cfg_mode_qs;
   logic [1:0] cfg_mode_wd;
   logic cfg_mode_we;
@@ -514,18 +514,18 @@ module kmac_reg_top (
   );
 
 
-  //   F[strength]: 3:1
+  //   F[kstrength]: 3:1
   prim_subreg #(
     .DW      (3),
     .SWACCESS("RW"),
     .RESVAL  (3'h0)
-  ) u_cfg_strength (
+  ) u_cfg_kstrength (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface (qualified with register enable)
-    .we     (cfg_strength_we & cfg_regwen_qs),
-    .wd     (cfg_strength_wd),
+    .we     (cfg_kstrength_we & cfg_regwen_qs),
+    .wd     (cfg_kstrength_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -533,10 +533,10 @@ module kmac_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.cfg.strength.q ),
+    .q      (reg2hw.cfg.kstrength.q ),
 
     // to register interface (read)
-    .qs     (cfg_strength_qs)
+    .qs     (cfg_kstrength_qs)
   );
 
 
@@ -1757,8 +1757,8 @@ module kmac_reg_top (
   assign cfg_kmac_en_we = addr_hit[3] & reg_we & ~wr_err;
   assign cfg_kmac_en_wd = reg_wdata[0];
 
-  assign cfg_strength_we = addr_hit[3] & reg_we & ~wr_err;
-  assign cfg_strength_wd = reg_wdata[3:1];
+  assign cfg_kstrength_we = addr_hit[3] & reg_we & ~wr_err;
+  assign cfg_kstrength_wd = reg_wdata[3:1];
 
   assign cfg_mode_we = addr_hit[3] & reg_we & ~wr_err;
   assign cfg_mode_wd = reg_wdata[5:4];
@@ -1943,7 +1943,7 @@ module kmac_reg_top (
 
       addr_hit[3]: begin
         reg_rdata_next[0] = cfg_kmac_en_qs;
-        reg_rdata_next[3:1] = cfg_strength_qs;
+        reg_rdata_next[3:1] = cfg_kstrength_qs;
         reg_rdata_next[5:4] = cfg_mode_qs;
         reg_rdata_next[8] = cfg_msg_endianness_qs;
         reg_rdata_next[9] = cfg_state_endianness_qs;

--- a/hw/ip/kmac/rtl/kmac_staterd.sv
+++ b/hw/ip/kmac/rtl/kmac_staterd.sv
@@ -54,7 +54,7 @@ module kmac_staterd
   // TL Adapter
   tlul_adapter_sram #(
     .SramAw (AddrW-2),
-    .SramDw (323),
+    .SramDw (32),
     .Outstanding (1),
     .ByteAccess  (1),
     .ErrOnWrite  (1),

--- a/hw/ip/kmac/rtl/sha3core.sv
+++ b/hw/ip/kmac/rtl/sha3core.sv
@@ -254,7 +254,7 @@ module sha3core
           error_o = '{
             valid: 1'b 1,
             code: ErrSha3SwControl,
-            info: {done_i, run_i, process_i, start_i}
+            info: 24'({done_i, run_i, process_i, start_i})
           };
         end
       end
@@ -264,7 +264,7 @@ module sha3core
           error_o = '{
             valid: 1'b 1,
             code: ErrSha3SwControl,
-            info: {done_i, run_i, process_i, start_i}
+            info: 24'({done_i, run_i, process_i, start_i})
           };
         end
       end
@@ -274,7 +274,7 @@ module sha3core
           error_o = '{
             valid: 1'b 1,
             code: ErrSha3SwControl,
-            info: {done_i, run_i, process_i, start_i}
+            info: 24'({done_i, run_i, process_i, start_i})
           };
         end
       end
@@ -284,7 +284,7 @@ module sha3core
           error_o = '{
             valid: 1'b 1,
             code: ErrSha3SwControl,
-            info: {done_i, run_i, process_i, start_i}
+            info: 24'({done_i, run_i, process_i, start_i})
           };
         end
       end
@@ -294,7 +294,7 @@ module sha3core
           error_o = '{
             valid: 1'b 1,
             code: ErrSha3SwControl,
-            info: {done_i, run_i, process_i, start_i}
+            info: 24'({done_i, run_i, process_i, start_i})
           };
         end
       end

--- a/hw/ip/prim/prim.core
+++ b/hw/ip/prim/prim.core
@@ -24,7 +24,6 @@ filesets:
       - rtl/prim_alert_sender.sv
       - rtl/prim_arbiter_ppc.sv
       - rtl/prim_arbiter_tree.sv
-      - rtl/prim_dom_and_2share.sv
       - rtl/prim_arbiter_fixed.sv
       - rtl/prim_esc_pkg.sv
       - rtl/prim_esc_receiver.sv


### PR DESCRIPTION
This commit is to fix a few critical errors preventing the design from
compiling in the simulator. Mainly the KMAC has been checked in FPV not
in the simulator until now. So some parts of the design assumed `FPV_ON`
is set always.