### PR TITLE
[alert_handler] update alert hander ports

### DIFF
--- a/hw/ip/aes/rtl/aes.sv
+++ b/hw/ip/aes/rtl/aes.sv
@@ -103,11 +103,12 @@ module aes
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i])
     ) u_alert_sender_i (
-      .clk_i      ( clk_i         ),
-      .rst_ni     ( rst_ni        ),
-      .alert_i    ( alert[i]      ),
-      .alert_rx_i ( alert_rx_i[i] ),
-      .alert_tx_o ( alert_tx_o[i] )
+      .clk_i       ( clk_i         ),
+      .rst_ni      ( rst_ni        ),
+      .alert_req_i ( alert[i]      ),
+      .alert_ack_o (               ),
+      .alert_rx_i  ( alert_rx_i[i] ),
+      .alert_tx_o  ( alert_tx_o[i] )
     );
   end
 

--- a/hw/ip/keymgr/rtl/keymgr.sv
+++ b/hw/ip/keymgr/rtl/keymgr.sv
@@ -380,7 +380,8 @@ module keymgr import keymgr_pkg::*; #(
   ) u_err_alert (
     .clk_i,
     .rst_ni,
-    .alert_i(|reg2hw.err_code),
+    .alert_req_i(|reg2hw.err_code),
+    .alert_ack_o(),
     .alert_rx_i(alert_rx_i),
     .alert_tx_o(alert_tx_o)
   );

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -406,9 +406,10 @@ module otbn
     ) i_prim_alert_sender (
       .clk_i,
       .rst_ni,
-      .alert_i    (alerts[i]    ),
-      .alert_rx_i (alert_rx_i[i]),
-      .alert_tx_o (alert_tx_o[i])
+      .alert_req_i (alerts[i]    ),
+      .alert_ack_o (             ),
+      .alert_rx_i  (alert_rx_i[i]),
+      .alert_tx_o  (alert_tx_o[i])
     );
   end
 

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
@@ -363,9 +363,10 @@ module otp_ctrl
   ) u_prim_alert_sender0 (
     .clk_i,
     .rst_ni,
-    .alert_i    ( otp_macro_failure_q ),
-    .alert_rx_i ( alert_rx_i[0] ),
-    .alert_tx_o ( alert_tx_o[0] )
+    .alert_req_i ( otp_macro_failure_q ),
+    .alert_ack_o (                 ),
+    .alert_rx_i  ( alert_rx_i[0]   ),
+    .alert_tx_o  ( alert_tx_o[0]   )
   );
 
   prim_alert_sender #(
@@ -373,9 +374,10 @@ module otp_ctrl
   ) u_prim_alert_sender1 (
     .clk_i,
     .rst_ni,
-    .alert_i    ( otp_check_failure_q ),
-    .alert_rx_i ( alert_rx_i[1] ),
-    .alert_tx_o ( alert_tx_o[1] )
+    .alert_req_i ( otp_check_failure_q ),
+    .alert_ack_o (                  ),
+    .alert_rx_i  ( alert_rx_i[1]    ),
+    .alert_tx_o  ( alert_tx_o[1]    )
   );
 
   ////////////////////////////////

--- a/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl.sv
+++ b/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl.sv
@@ -88,7 +88,8 @@ module sensor_ctrl import sensor_ctrl_pkg::*; #(
     ) i_prim_alert_sender (
       .clk_i,
       .rst_ni,
-      .alert_i(sw_ack_mode[i] ? reg2hw.alert_state[i].q : valid_alert),
+      .alert_req_i(sw_ack_mode[i] ? reg2hw.alert_state[i].q : valid_alert),
+      .alert_ack_o(),
       .alert_rx_i(alert_rx_i[i]),
       .alert_tx_o(alert_tx_o[i])
     );


### PR DESCRIPTION
- alert_i becomes alert_req_i
- add alert_ack_o which can be used to inform the module when to
  clear a level assert.  The outside module 'does not' have to use
  this.

Signed-off-by: Timothy Chen <timothytim@google.com>