### PR TITLE
[lint] Add option to bail out on first invalid Tcl cmd

### DIFF
--- a/hw/ip/aes/aes.core
+++ b/hw/ip/aes/aes.core
@@ -96,6 +96,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/aes/dv/aes_sim.core
+++ b/hw/ip/aes/dv/aes_sim.core
@@ -32,6 +32,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/alert_handler/alert_handler.core
+++ b/hw/ip/alert_handler/alert_handler.core
@@ -44,6 +44,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/alert_handler/dv/alert_handler_generic_sim.core
+++ b/hw/ip/alert_handler/dv/alert_handler_generic_sim.core
@@ -42,6 +42,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/clkmgr/clkmgr.core
+++ b/hw/ip/clkmgr/clkmgr.core
@@ -58,6 +58,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/entropy_src/dv/entropy_src_sim.core
+++ b/hw/ip/entropy_src/dv/entropy_src_sim.core
@@ -32,6 +32,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/entropy_src/entropy_src.core
+++ b/hw/ip/entropy_src/entropy_src.core
@@ -68,6 +68,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/flash_ctrl/dv/flash_ctrl_sim.core
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_sim.core
@@ -38,6 +38,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/flash_ctrl/flash_ctrl.core
+++ b/hw/ip/flash_ctrl/flash_ctrl.core
@@ -95,6 +95,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/gpio/dv/gpio_sim.core
+++ b/hw/ip/gpio/dv/gpio_sim.core
@@ -32,6 +32,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/gpio/gpio.core
+++ b/hw/ip/gpio/gpio.core
@@ -75,6 +75,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/hmac/dv/hmac_sim.core
+++ b/hw/ip/hmac/dv/hmac_sim.core
@@ -32,6 +32,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/hmac/hmac.core
+++ b/hw/ip/hmac/hmac.core
@@ -79,6 +79,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/i2c/dv/i2c_sim.core
+++ b/hw/ip/i2c/dv/i2c_sim.core
@@ -32,6 +32,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/i2c/i2c.core
+++ b/hw/ip/i2c/i2c.core
@@ -78,6 +78,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/kmac/kmac.core
+++ b/hw/ip/kmac/kmac.core
@@ -76,6 +76,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/nmi_gen/nmi_gen.core
+++ b/hw/ip/nmi_gen/nmi_gen.core
@@ -65,6 +65,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/otbn/otbn.core
+++ b/hw/ip/otbn/otbn.core
@@ -88,6 +88,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:
@@ -105,6 +106,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/otp_ctrl/lint/otp_ctrl.waiver
+++ b/hw/ip/otp_ctrl/lint/otp_ctrl.waiver
@@ -15,3 +15,6 @@ waive -rules {TERMINAL_STATE} -location {otp_ctrl_dai.sv \
 
 waive -rules {INVALID_COMPARE} -location {otp_ctrl_dai.sv} -regexp {.*dai_addr_i >= PartInfo\[0\]\.offset.*} \
       -comment "This invalid compare is due to the first partition offset being zero."
+
+waive -rules {LOOP_VAR_OP FOR_LOOP_BOUNDS} -location {prim_cipher_pkg.sv} -regexp {Loop.*round_cnt.*constant.*} \
+      -comment "This function needs to iterate over the key schedule function in order to derive the decryption key."

--- a/hw/ip/otp_ctrl/otp_ctrl.core
+++ b/hw/ip/otp_ctrl/otp_ctrl.core
@@ -81,6 +81,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_scrmbl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_scrmbl.sv
@@ -166,9 +166,10 @@ module otp_ctrl_scrmbl import otp_ctrl_pkg::*; (
                                                                   {data_i, data_shadow_q};
 
   // Initialize the round index state with 1 in all cases, except for the decrypt operation.
-  assign idx_state_d     = (key_state_sel == SelDecKeyOut)      ? dec_idx_out          :
-                           (key_state_sel == SelEncKeyOut)      ? enc_idx_out          :
-                           (key_state_sel == SelDecKeyInit)     ? 5'(NumPresentRounds) : 5'd1;
+  assign idx_state_d     = (key_state_sel == SelDecKeyOut)      ? dec_idx_out                     :
+                           (key_state_sel == SelEncKeyOut)      ? enc_idx_out                     :
+                           (key_state_sel == SelDecKeyInit)     ? unsigned'(5'(NumPresentRounds)) :
+                                                                  5'd1;
 
   assign digest_state_d  = enc_data_out;
 

--- a/hw/ip/padctrl/padctrl.core
+++ b/hw/ip/padctrl/padctrl.core
@@ -32,6 +32,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/pwrmgr/pwrmgr.core
+++ b/hw/ip/pwrmgr/pwrmgr.core
@@ -78,6 +78,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/rstmgr/rstmgr.core
+++ b/hw/ip/rstmgr/rstmgr.core
@@ -55,6 +55,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/rv_core_ibex/rv_core_ibex.core
+++ b/hw/ip/rv_core_ibex/rv_core_ibex.core
@@ -76,6 +76,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/rv_dm/rv_dm.core
+++ b/hw/ip/rv_dm/rv_dm.core
@@ -81,6 +81,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/rv_plic/rv_plic.core
+++ b/hw/ip/rv_plic/rv_plic.core
@@ -37,6 +37,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/rv_timer/dv/rv_timer_sim.core
+++ b/hw/ip/rv_timer/dv/rv_timer_sim.core
@@ -32,6 +32,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/rv_timer/rv_timer.core
+++ b/hw/ip/rv_timer/rv_timer.core
@@ -76,6 +76,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/spi_device/dv/spi_device_sim.core
+++ b/hw/ip/spi_device/dv/spi_device_sim.core
@@ -32,6 +32,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/spi_device/spi_device.core
+++ b/hw/ip/spi_device/spi_device.core
@@ -84,6 +84,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/tlul/adapter_host.core
+++ b/hw/ip/tlul/adapter_host.core
@@ -61,6 +61,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/tlul/adapter_reg.core
+++ b/hw/ip/tlul/adapter_reg.core
@@ -60,6 +60,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/tlul/adapter_sram.core
+++ b/hw/ip/tlul/adapter_sram.core
@@ -61,6 +61,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/tlul/socket_1n.core
+++ b/hw/ip/tlul/socket_1n.core
@@ -62,6 +62,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/tlul/socket_m1.core
+++ b/hw/ip/tlul/socket_m1.core
@@ -61,6 +61,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/tlul/sram2tlul.core
+++ b/hw/ip/tlul/sram2tlul.core
@@ -60,6 +60,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/trial1/dv/trial1_sim.core
+++ b/hw/ip/trial1/dv/trial1_sim.core
@@ -37,6 +37,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/uart/dv/uart_sim.core
+++ b/hw/ip/uart/dv/uart_sim.core
@@ -32,6 +32,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/uart/uart.core
+++ b/hw/ip/uart/uart.core
@@ -79,6 +79,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/usb_fs_nb_pe/usbfs_nb_pe.core
+++ b/hw/ip/usb_fs_nb_pe/usbfs_nb_pe.core
@@ -66,6 +66,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/usbdev/dv/usbdev_sim.core
+++ b/hw/ip/usbdev/dv/usbdev_sim.core
@@ -32,6 +32,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/usbdev/usbdev.core
+++ b/hw/ip/usbdev/usbdev.core
@@ -81,6 +81,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/usbuart/usbuart.core
+++ b/hw/ip/usbuart/usbuart.core
@@ -82,6 +82,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/lint/doc/README.md
+++ b/hw/lint/doc/README.md
@@ -63,6 +63,10 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/top_earlgrey/dv/chip_sim.core
+++ b/hw/top_earlgrey/dv/chip_sim.core
@@ -43,6 +43,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/top_earlgrey/ip/alert_handler/dv/alert_handler_sim.core
+++ b/hw/top_earlgrey/ip/alert_handler/dv/alert_handler_sim.core
@@ -42,6 +42,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/top_earlgrey/ip/rstmgr/rstmgr.core
+++ b/hw/top_earlgrey/ip/rstmgr/rstmgr.core
@@ -44,3 +44,4 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"

--- a/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_main_sim.core
+++ b/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_main_sim.core
@@ -33,6 +33,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_peri_sim.core
+++ b/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_peri_sim.core
@@ -33,6 +33,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/top_earlgrey/top_earlgrey.core
+++ b/hw/top_earlgrey/top_earlgrey.core
@@ -111,6 +111,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/util/tlgen/xbar.sim.core.tpl
+++ b/util/tlgen/xbar.sim.core.tpl
@@ -33,6 +33,7 @@ targets:
       ascentlint:
         ascentlint_options:
           - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:


### PR DESCRIPTION
This adds an AscentLint-specific switch such that the tool bails out if a Tcl command does not complete successfully.

The second commit fixes two otp_ctrl-related lint errors.