### PR TITLE
[dv] Use platform-agnostic logs everywhere applicable

### DIFF
--- a/hw/dv/sv/dv_utils/dv_macros.core
+++ b/hw/dv/sv/dv_utils/dv_macros.core
@@ -3,15 +3,15 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 name: "lowrisc:dv:dv_macros"
-description: "DV macros"
+description: "A collection of macros used in DV."
 
 filesets:
   files_dv:
     files:
-      - dv_macros.svh
+      - dv_macros.svh: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:
-  default:
+  default: &default_target
     filesets:
       - files_dv

--- a/hw/dv/sv/dv_utils/dv_macros.svh
+++ b/hw/dv/sv/dv_utils/dv_macros.svh
@@ -2,6 +2,13 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+`ifndef __DV_MACROS_SVH__
+`define __DV_MACROS_SVH__
+
+`ifdef UVM
+  `include "uvm_macros.svh"
+`endif
+
 // UVM speficic macros
 `ifndef gfn
   // verilog_lint: waive macro-name-style
@@ -394,66 +401,53 @@
   end
 `endif
 
-// Logs an info message.
+// Macros for logging (info, warning, error and fatal severities).
 //
-// This is meant to be invoked in modules and interfaces that are shared between DV and Verilator
+// These are meant to be invoked in modules and interfaces that are shared between DV and Verilator
 // testbenches.
 `ifdef UVM
 `ifndef DV_INFO
-  `define DV_INFO(_msg, _id = $sformatf("%m"), _verbosity = UVM_LOW) \
-    `uvm_info(_id, _msg, _verbosity)
+  `define DV_INFO(MSG_,  VERBOSITY_ = UVM_LOW, ID_ = $sformatf("%m")) \
+    `uvm_info(ID_, MSG_, VERBOSITY_)
 `endif
-`else
+
+`ifndef DV_WARNING
+  `define DV_WARNING(MSG_, ID_ = $sformatf("%m")) \
+    `uvm_warning(ID_, MSG_)
+`endif
+
+`ifndef DV_ERROR
+  `define DV_ERROR(MSG_, ID_ = $sformatf("%m")) \
+    `uvm_error(ID_, MSG_)
+`endif
+
+`ifndef DV_FATAL
+  `define DV_FATAL(MSG_, ID_ = $sformatf("%m")) \
+    `uvm_fatal(ID_, MSG_)
+`endif
+
+`else // UVM
+
 `ifndef DV_INFO
-  `define DV_INFO(_msg, _id = $sformatf("%m")) \
-    $display("[%0t] %0s(%0d): [%0s] %0s", $time, `__FILE__, `__LINE__, _id, _msg);
-`endif
+  `define DV_INFO(MSG_, VERBOSITY = DUMMY_, ID_ = $sformatf("%m")) \
+    $display("%0t: (%0s:%0d) [%0s] %0s", $time, `__FILE__, `__LINE__, ID_, MSG_);
 `endif
 
-// Logs a warning message.
-//
-// This is meant to be invoked in modules and interfaces that are shared between DV and Verilator
-// testbenches.
-`ifdef UVM
 `ifndef DV_WARNING
-  `define DV_WARNING(_msg, _id = $sformatf("%m")) \
-    `uvm_warning(_id, _msg)
-`endif
-`else
-`ifndef DV_WARNING
-  `define DV_WARNING(_msg, _id = $sformatf("%m")) \
-    $warning("[%0t] %0s(%0d): [%0s] %0s", $time, `__FILE__, `__LINE__, _id, _msg);
-`endif
+  `define DV_WARNING(MSG_, ID_ = $sformatf("%m")) \
+    $warning("%0t: (%0s:%0d) [%0s] %0s", $time, `__FILE__, `__LINE__, ID_, MSG_);
 `endif
 
-// Logs an error message.
-//
-// This is meant to be invoked in modules and interfaces that are shared between DV and Verilator
-// testbenches.
-`ifdef UVM
 `ifndef DV_ERROR
-  `define DV_ERROR(_msg, _id = $sformatf("%m")) \
-    `uvm_error(_id, _msg)
-`endif
-`else
-`ifndef DV_ERROR
-  `define DV_ERROR(_msg, _id = $sformatf("%m")) \
-    $error("[%0t] %0s(%0d): [%0s] %0s", $time, `__FILE__, `__LINE__, _id, _msg);
-`endif
+  `define DV_ERROR(MSG_, ID_ = $sformatf("%m")) \
+    $error("%0t: (%0s:%0d) [%0s] %0s", $time, `__FILE__, `__LINE__, ID_, MSG_);
 `endif
 
-// Logs a fatal message.
-//
-// This is meant to be invoked in modules and interfaces that are shared between DV and Verilator
-// testbenches.
-`ifdef UVM
 `ifndef DV_FATAL
-  `define DV_FATAL(_msg, _id = $sformatf("%m")) \
-    `uvm_fatal(_id, _msg)
+  `define DV_FATAL(MSG_, ID_ = $sformatf("%m")) \
+    $fatal("%0t: (%0s:%0d) [%0s] %0s", $time, `__FILE__, `__LINE__, ID_, MSG_);
 `endif
-`else
-`ifndef DV_FATAL
-  `define DV_FATAL(_msg, _id = $sformatf("%m")) \
-    $fatal("[%0t] %0s(%0d): [%0s] %0s", $time, `__FILE__, `__LINE__, _id, _msg);
-`endif
-`endif
+
+`endif // UVM
+
+`endif // __DV_MACROS_SVH__

--- a/hw/dv/sv/dv_utils/dv_utils.core
+++ b/hw/dv/sv/dv_utils/dv_utils.core
@@ -8,12 +8,12 @@ description: "DV utilities"
 filesets:
   files_dv:
     depend:
+      - lowrisc:dv:dv_macros
       - lowrisc:dv:common_ifs
       - lowrisc:prim:assert:0.1
       - lowrisc:opentitan:bus_params_pkg
     files:
       - dv_utils_pkg.sv
-      - dv_macros.svh: {is_include_file: true}
       - dv_report_server.sv: {is_include_file: true}
     file_type: systemVerilogSource
 

--- a/hw/dv/sv/dv_utils/dv_utils_pkg.sv
+++ b/hw/dv/sv/dv_utils/dv_utils_pkg.sv
@@ -85,6 +85,17 @@ package dv_utils_pkg;
     return (a > b) ? a : b;
   endfunction
 
+  // get absolute value of the input. Usage: absolute(val) or absolute(a - b)
+  function automatic uint absolute(int val);
+    return val >= 0 ? val : -val;
+  endfunction
+
+  // endian swap
+  function automatic logic [31:0] endian_swap(logic [31:0] data);
+    return {<<8{data}};
+  endfunction
+
+`ifdef UVM
   // Simple function to set max errors before quitting sim
   function automatic void set_max_quit_count(int n);
     uvm_report_server report_server = uvm_report_server::get_server();
@@ -121,16 +132,6 @@ package dv_utils_pkg;
     end
   endfunction
 
-  // get absolute value of the input. Usage: absolute(val) or absolute(a - b)
-  function automatic uint absolute(int val);
-    return val >= 0 ? val : -val;
-  endfunction
-
-  // endian swap
-  function automatic logic [31:0] endian_swap(logic [31:0] data);
-    return {<<8{data}};
-  endfunction
-
   // create a sequence by name and return the handle of uvm_sequence
   function automatic uvm_sequence create_seq_by_name(string seq_name);
     uvm_object      obj;
@@ -149,8 +150,11 @@ package dv_utils_pkg;
     end
     return seq;
   endfunction
+`endif
 
   // sources
+`ifdef UVM
   `include "dv_report_server.sv"
+`endif
 
 endpackage

--- a/hw/dv/sv/sw_logger_if/sw_logger_if.core
+++ b/hw/dv/sv/sw_logger_if/sw_logger_if.core
@@ -7,6 +7,8 @@ description: "SW msg monitor interface (convert SW msg prints into SV)"
 
 filesets:
   files_dv:
+    depend:
+      - lowrisc:dv:dv_macros
     files:
       - sw_logger_if.sv
     file_type: systemVerilogSource

--- a/hw/dv/sv/sw_logger_if/sw_logger_if.sv
+++ b/hw/dv/sv/sw_logger_if/sw_logger_if.sv
@@ -53,6 +53,9 @@ interface sw_logger_if #(
   import uvm_pkg::*;
 `endif
 
+  // macro includes
+  `include "dv_macros.svh"
+
   // Address to which the SW logs are written to. This is set by the testbench.
   logic [AddrDataWidth-1:0] sw_log_addr;
 
@@ -125,7 +128,7 @@ interface sw_logger_if #(
   // <sw_name>_logs.txt: contains logs split as fields of `sw_log_t`
   // <sw_name>_rodata.txt: contains constants from the read-only sections.
   function automatic void set_sw_name(string sw_name);
-    if (_ready) log_fatal(.log("this function cannot be called after calling ready()"));
+    if (_ready) `DV_FATAL("This function cannot be called after calling ready()")
     sw_log_db_files[sw_name] = {sw_name, "_logs.txt"};
     sw_rodata_db_files[sw_name] = {sw_name, "_rodata.txt"};
   endfunction
@@ -204,8 +207,8 @@ interface sw_logger_if #(
         end
 
         if (sw_logs.exists(sw) && sw_logs[sw].exists(addr)) begin
-          log_warning($sformatf("Log entry for addr %0x already exists:\nOld: %p\nNew: %p",
-                                addr, sw_logs[sw][addr], sw_log));
+          `DV_WARNING($sformatf("Log entry for addr %0x already exists:\nOld: %p\nNew: %p",
+                                addr, sw_logs[sw][addr], sw_log))
         end
         sw_logs[sw][addr] = sw_log;
       end
@@ -219,8 +222,7 @@ interface sw_logger_if #(
 
     // print parsed logs
     foreach (sw_logs[sw, addr]) begin
-      log_info(.verbosity(LogVerbosityHigh),
-               .log($sformatf("sw_logs[%0s][%0h] = %p", sw, addr, sw_logs[sw][addr])));
+      `DV_INFO($sformatf("sw_logs[%0s][%0h] = %p", sw, addr, sw_logs[sw][addr]), UVM_HIGH)
     end
 
     return result;
@@ -243,8 +245,8 @@ interface sw_logger_if #(
       void'(get_sw_log_field(fd, "string", field));
 
       if (sw_rodata.exists(sw) && sw_rodata[sw].exists(addr)) begin
-        log_warning($sformatf("Rodata entry for addr %0x already exists:\nOld: %s\nNew: %s",
-                              addr, sw_rodata[sw][addr], field));
+        `DV_WARNING($sformatf("Rodata entry for addr %0x already exists:\nOld: %s\nNew: %s",
+                              addr, sw_rodata[sw][addr], field))
       end
       // Replace CRs in the middle of the string with NLs.
       sw_rodata[sw][addr] = replace_cr_with_nl(field);
@@ -253,8 +255,7 @@ interface sw_logger_if #(
 
     // print parsed rodata
     foreach (sw_rodata[sw, addr]) begin
-      log_info(.verbosity(LogVerbosityHigh),
-               .log($sformatf("sw_rodata[%0s][%0h] = %p", sw, addr, sw_rodata[sw][addr])));
+      `DV_INFO($sformatf("sw_rodata[%0s][%0h] = %p", sw, addr, sw_rodata[sw][addr]), UVM_HIGH)
     end
 
     return (sw_rodata[sw].size() > 0);
@@ -383,10 +384,8 @@ interface sw_logger_if #(
                   if (sw_logs[sw][addr].str_arg.exists(i)) begin
                     // The arg[i] received is the addr in rodata where the string resides.
                     sw_logs[sw][addr].str_arg[i] = get_str_at_addr(sw, sw_logs[sw][addr].arg[i]);
-                    log_info(.verbosity(LogVerbosityDebug),
-                             .log($sformatf("String arg at addr %0h: %0s",
-                                            sw_logs[sw][addr].arg[i],
-                                            sw_logs[sw][addr].str_arg[i])));
+                    `DV_INFO($sformatf("String arg at addr %0h: %0s", sw_logs[sw][addr].arg[i],
+                                       sw_logs[sw][addr].str_arg[i]), UVM_DEBUG)
                   end
                 end
                 begin
@@ -407,6 +406,13 @@ interface sw_logger_if #(
 
   // print the log captured from the SW.
   function automatic void print_sw_log(sw_log_t sw_log);
+    string log_header = sw_log.name;
+    if (sw_log.file != "") begin
+      // Append the SW file and line to the header.
+      log_header = {log_header, "(", sw_log.file, ":",
+                    $sformatf("%0d", sw_log.line), ")"};
+    end
+
     // construct formatted string based on args
     case (sw_log.nargs)
        0: ;
@@ -442,55 +448,11 @@ interface sw_logger_if #(
       30: sw_log.format = $sformatf(sw_log.format, `_ADD_ARGS(30));
       31: sw_log.format = $sformatf(sw_log.format, `_ADD_ARGS(31));
       32: sw_log.format = $sformatf(sw_log.format, `_ADD_ARGS(32));
-    default: log_fatal($sformatf("UNSUPPORTED: nargs = %0d (only 0:32 allowed)", sw_log.nargs));
+      default: `DV_FATAL($sformatf("UNSUPPORTED: nargs = %0d (only 0:32 allowed)", sw_log.nargs))
     endcase
-    print_log(.sw_log(sw_log), .is_sw_log(1'b1));
-    printed_log = sw_log.format;
-    ->printed_log_event;
-  endfunction
 
-  // print logs from this file.
-  function automatic void print_self_log(log_severity_e severity,
-                                         log_verbosity_e verbosity = LogVerbosityLow,
-                                         string log);
-    sw_log_t self_log;
-    self_log.name = "sw_logger_if";
-    self_log.severity = severity;
-    self_log.verbosity = verbosity;
-    self_log.file = "";
-    self_log.format = log;
-    print_log(.sw_log(self_log));
-  endfunction
-
-  // print an info message from this file
-  function automatic void log_info(log_verbosity_e verbosity = LogVerbosityLow, string log);
-    print_self_log(.severity(LogSeverityInfo), .verbosity(verbosity), .log(log));
-  endfunction
-
-  // print a warning message from this file
-  function automatic void log_warning(string log);
-    print_self_log(.severity(LogSeverityWarning), .log(log));
-  endfunction
-
-  // print an error message from this file
-  function automatic void log_error(string log);
-    print_self_log(.severity(LogSeverityError), .log(log));
-  endfunction
-
-  // print a fatal message from this file
-  function automatic void log_fatal(string log);
-    print_self_log(.severity(LogSeverityFatal), .log(log));
-  endfunction
-
-  // UVM-agnostic print_log api that switches between system call and UVM call
-  function automatic void print_log(sw_log_t sw_log, bit is_sw_log = 1'b0);
-    string log_header = sw_log.name;
-    if (sw_log.file != "") begin
-      log_header = {log_header, "(", sw_log.file, ":",
-                    $sformatf("%0d", sw_log.line), ")"};
-    end
-`ifdef UVM
     begin
+`ifdef UVM
       uvm_verbosity level;
       case (sw_log.verbosity)
         LogVerbosityNone:   level = UVM_NONE;
@@ -501,28 +463,23 @@ interface sw_logger_if #(
         LogVerbosityDebug:  level = UVM_DEBUG;
         default:            level = UVM_LOW;
       endcase
-
+`endif
       case (sw_log.severity)
-        LogSeverityInfo:    `uvm_info(log_header, sw_log.format, level)
-        LogSeverityWarning: `uvm_error(log_header, sw_log.format)
-        LogSeverityError:   `uvm_error(log_header, sw_log.format)
-        LogSeverityFatal:   `uvm_fatal(log_header, sw_log.format)
-        default:            `uvm_info(log_header, sw_log.format, level)
+        LogSeverityInfo:    `DV_INFO(sw_log.format, level, log_header)
+        LogSeverityWarning: `DV_WARNING(sw_log.format, log_header)
+        LogSeverityError:   `DV_ERROR(sw_log.format, log_header)
+        LogSeverityFatal:   `DV_FATAL(sw_log.format, log_header)
+        default:            `DV_INFO(sw_log.format, level, log_header)
       endcase
     end
-`else
-    case (sw_log.severity)
-      LogSeverityInfo:    $info("[%15t]: [%0s] %0s", $time, log_header, sw_log.format);
-      LogSeverityWarning: $warning("[%15t]: [%0s] %0s", $time, log_header, sw_log.format);
-      LogSeverityError:   $error("[%15t]: [%0s] %0s", $time, log_header, sw_log.format);
-      LogSeverityFatal:   $fatal("[%15t]: [%0s] %0s", $time, log_header, sw_log.format);
-      default:            $info("[%15t]: [%0s] %0s", $time, log_header, sw_log.format);
-    endcase
-`endif
+
     // write sw log to file if enabled
-    if (is_sw_log && sw_logs_output_fd) begin
+    if (sw_logs_output_fd) begin
       $fwrite(sw_logs_output_fd, "[%15t]: [%0s] %0s\n", $time, log_header, sw_log.format);
     end
+
+    printed_log = sw_log.format;
+    ->printed_log_event;
   endfunction
 
 endinterface

--- a/hw/dv/sv/sw_test_status/sw_test_status_if.sv
+++ b/hw/dv/sv/sw_test_status/sw_test_status_if.sv
@@ -16,6 +16,9 @@ interface sw_test_status_if #(
 `endif
   import sw_test_status_pkg::*;
 
+  // macro includes
+  `include "dv_macros.svh"
+
   // Address to which the test status is written to. This is set by the testbench.
   logic [AddrWidth-1:0] sw_test_status_addr;
 

--- a/hw/ip/prim/rtl/prim_assert.sv
+++ b/hw/ip/prim/rtl/prim_assert.sv
@@ -9,17 +9,6 @@
 `ifndef PRIM_ASSERT_SV
 `define PRIM_ASSERT_SV
 
-`ifdef UVM
-  // report assertion error with UVM if compiled
-  package assert_rpt_pkg;
-    import uvm_pkg::*;
-    `include "uvm_macros.svh"
-    function void assert_rpt(string msg);
-      `uvm_error("ASSERT FAILED", msg)
-    endfunction
-  endpackage
-`endif
-
 ///////////////////
 // Helper macros //
 ///////////////////
@@ -30,6 +19,18 @@
 
 // Converts an arbitrary block of code into a Verilog string
 `define PRIM_STRINGIFY(__x) `"__x`"
+
+// ASSERT_ERROR logs an error message with either `uvm_error or with $error.
+//
+// This somewhat duplicates `DV_ERROR macro defined in hw/dv/sv/dv_utils/dv_macros.svh. The reason
+// for redefining it here is to avoid creating a dependency.
+`define ASSERT_ERROR(__name)                                                             \
+`ifdef UVM                                                                               \
+  uvm_pkg::uvm_report_error("ASSERT FAILED", `PRIM_STRINGIFY(__name), uvm_pkg::UVM_NONE, \
+                            `__FILE__, `__LINE__, "", 1);                                \
+`else                                                                                    \
+  $error("%0t: (%0s:%0d) [%m] [ASSERT FAILED] %0s", $time, `__FILE__, `__LINE__, MSG_);  \
+`endif
 
 // The basic helper macros are actually defined in "implementation headers". The macros should do
 // the same thing in each case (except for the dummy flavour), but in a way that the respective

--- a/hw/ip/prim/rtl/prim_assert_standard_macros.svh
+++ b/hw/ip/prim/rtl/prim_assert_standard_macros.svh
@@ -5,47 +5,38 @@
 // Macro bodies included by prim_assert.sv for tools that support full SystemVerilog and SVA syntax.
 // See prim_assert.sv for documentation for each of the macros.
 
-// ASSERT_RPT is available to change the reporting mechanism when an assert fails
-`define ASSERT_RPT(__name)                                                  \
-`ifdef UVM                                                                  \
-  assert_rpt_pkg::assert_rpt($sformatf("[%m] %s (%s:%0d)",                  \
-                             __name, `__FILE__, `__LINE__));                \
-`else                                                                       \
-  $error("[ASSERT FAILED] [%m] %s (%s:%0d)", __name, `__FILE__, `__LINE__); \
-`endif
-
-`define ASSERT_I(__name, __prop)           \
-  __name: assert (__prop)                  \
-    else begin                             \
-      `ASSERT_RPT(`PRIM_STRINGIFY(__name)) \
+`define ASSERT_I(__name, __prop) \
+  __name: assert (__prop)        \
+    else begin                   \
+      `ASSERT_ERROR(__name)      \
     end
 
-`define ASSERT_INIT(__name, __prop)          \
-  initial begin                              \
-    __name: assert (__prop)                  \
-      else begin                             \
-        `ASSERT_RPT(`PRIM_STRINGIFY(__name)) \
-      end                                    \
+`define ASSERT_INIT(__name, __prop) \
+  initial begin                     \
+    __name: assert (__prop)         \
+      else begin                    \
+        `ASSERT_ERROR(__name)       \
+      end                           \
   end
 
 `define ASSERT_FINAL(__name, __prop)                                         \
   final begin                                                                \
     __name: assert (__prop || $test$plusargs("disable_assert_final_checks")) \
       else begin                                                             \
-        `ASSERT_RPT(`PRIM_STRINGIFY(__name))                                 \
+        `ASSERT_ERROR(__name)                                                \
       end                                                                    \
   end
 
 `define ASSERT(__name, __prop, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST) \
   __name: assert property (@(posedge __clk) disable iff ((__rst) !== '0) (__prop))       \
     else begin                                                                           \
-      `ASSERT_RPT(`PRIM_STRINGIFY(__name))                                               \
+      `ASSERT_ERROR(__name)                                                              \
     end
 
 `define ASSERT_NEVER(__name, __prop, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST) \
   __name: assert property (@(posedge __clk) disable iff ((__rst) !== '0) not (__prop))         \
     else begin                                                                                 \
-      `ASSERT_RPT(`PRIM_STRINGIFY(__name))                                                     \
+      `ASSERT_ERROR(__name)                                                                    \
     end
 
 `define ASSERT_KNOWN(__name, __sig, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST) \
@@ -57,11 +48,11 @@
 `define ASSUME(__name, __prop, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST) \
   __name: assume property (@(posedge __clk) disable iff ((__rst) !== '0) (__prop))       \
     else begin                                                                           \
-      `ASSERT_RPT(`PRIM_STRINGIFY(__name))                                               \
+      `ASSERT_ERROR(__name)                                                              \
     end
 
-`define ASSUME_I(__name, __prop)           \
-  __name: assume (__prop)                  \
-    else begin                             \
-      `ASSERT_RPT(`PRIM_STRINGIFY(__name)) \
+`define ASSUME_I(__name, __prop) \
+  __name: assume (__prop)        \
+    else begin                   \
+      `ASSERT_ERROR(__name)      \
     end


### PR DESCRIPTION
- Added `` `DV_INFO|WARNING|ERROR|FATAL`` that handles the switch between UVM logging and standard SV logging. 
- Updated all existing modules to use these macros instead of adding `` `ifdef VERILATOR|UVM`` everywhere
  - `prim_assert`, `sw_test_status`, `sw_logger_if`