### PR TITLE
[spiflash] Avoid libftdi Deprecated Errors

### DIFF
--- a/sw/host/vendor/meson.build
+++ b/sw/host/vendor/meson.build
@@ -13,7 +13,10 @@ libmpsse = declare_dependency(
     # requirements. This -I argument allows libmpsse to use its existing
     # includes.
     c_args: [
-      '-I' + meson.source_root() + '/sw/host/vendor/mpsse'
+      '-I' + meson.source_root() + '/sw/host/vendor/mpsse',
+      # TODO: Remove this once https://github.com/lowRISC/opentitan/issues/3182
+      # is resolved.
+      '-Wno-error=deprecated-declarations',
     ],
     dependencies: [
       dependency('libftdi1', native: true),


### PR DESCRIPTION
---

This is a temporary fix for #3182 and #3821 - it downgrades the "deprecated decaration" errors to warnings (we use `-Werror` which upgraded the warning to an error, thus undoes that).

The real solution is to update mpsse so it doesn't use the deprecated functions.