### PR TITLE
[dif/hmac] Clarify Transaction Semantics

### DIFF
--- a/sw/device/lib/dif/dif_hmac.h
+++ b/sw/device/lib/dif/dif_hmac.h
@@ -19,7 +19,7 @@ extern "C" {
 #endif  // __cplusplus
 
 /**
- * HMAC interrupt configuration.
+ * HMAC interrupt  configuration.
  *
  * Enumeration used to enable, disable, test and query the HMAC interrupts.
  * Please see the comportability specification for more information:
@@ -277,9 +277,9 @@ dif_hmac_result_t dif_hmac_irq_force(const dif_hmac_t *hmac,
  * @param config The per-transaction configuration.
  * @return `kDifHmacBadArg` if `hmac` or `key` is null, `kDifHmacOk` otherwise.
  */
-dif_hmac_result_t dif_hmac_mode_hmac_start(
-    const dif_hmac_t *hmac, const uint8_t *key,
-    const dif_hmac_transaction_t config);
+dif_hmac_result_t dif_hmac_mode_hmac_start(const dif_hmac_t *hmac,
+                                           const uint8_t *key,
+                                           const dif_hmac_transaction_t config);
 
 /**
  * Resets the HMAC engine and readies it to receive a new message to process a

--- a/sw/device/tests/dif/dif_hmac_smoketest.c
+++ b/sw/device/tests/dif/dif_hmac_smoketest.c
@@ -24,7 +24,7 @@ const test_config_t kTestConfig;
 _Static_assert(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__,
                "This test assumes the target platform is little endian.");
 
-static const dif_hmac_transaction_config_t kHmacTransactionConfig = {
+static const dif_hmac_transaction_t kHmacTransactionConfig = {
     .digest_endianness = kDifHmacEndiannessLittle,
     .message_endianness = kDifHmacEndiannessLittle,
 };


### PR DESCRIPTION
This solves a "two wrongs make a right" issue with the endianness configuration, and moves the endianness configuration to be per-transaction.

It also changes `dif_hmac_digest_read` to be `dif_hmac_finish`, to clarify the transactional semantics of this DIF, as suggested in #2920. 

Signed-off-by: Sam Elliott <selliott@lowrisc.org>