### PR TITLE
[i2c, dv] Add stress_all test

### DIFF
--- a/hw/ip/i2c/data/i2c_testplan.hjson
+++ b/hw/ip/i2c/data/i2c_testplan.hjson
@@ -82,7 +82,7 @@
               - Ensure transactions are transmitted/received correctly
               - Ensure reset is handled correctly
             '''
-      milestone: V3
+      milestone: V2
       tests: ["i2c_stress_all_with_rand_reset"]
     }
     {

--- a/hw/ip/i2c/dv/env/i2c_env.core
+++ b/hw/ip/i2c/dv/env/i2c_env.core
@@ -31,6 +31,7 @@ filesets:
       - seq_lib/i2c_perf_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_stretch_timeout_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_error_intr_vseq.sv: {is_include_file: true}
+      - seq_lib/i2c_stress_all_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/i2c/dv/env/i2c_env_cfg.sv
+++ b/hw/ip/i2c/dv/env/i2c_env_cfg.sv
@@ -13,22 +13,6 @@ class i2c_env_cfg extends cip_base_env_cfg #(.RAL_T(i2c_reg_block));
   // set start_dev_seq at the first time m_dev_seq is started
   bit start_dev_seq       = 1'b0;
 
-  // bits to control fifos access
-  // set en_fmt_overflow to ensure fmt_overflow irq is triggered
-  bit en_fmt_overflow     = 1'b0;
-  // set en_rx_overflow to ensure ensure rx_overflow irq is triggered
-  bit en_rx_overflow      = 1'b0;
-  // set en_rx_watermark to ensure rx_watermark irq is triggered
-  bit en_rx_watermark     = 1'b0;
-
-  // bits to control interference and unstable interrupts
-  // set en_sda_unstable to allow sda_unstable irq is triggered
-  bit en_sda_unstable     = 1'b0;
-  // set en_scl_interference to allow scl_interference irq is triggered
-  bit en_scl_interference = 1'b0;
-  // set en_sda_interference to allow sda_interference irq is triggered
-  bit en_sda_interference = 1'b0;
-
   // i2c_agent cfg
   rand i2c_agent_cfg m_i2c_agent_cfg;
 
@@ -58,5 +42,15 @@ class i2c_env_cfg extends cip_base_env_cfg #(.RAL_T(i2c_reg_block));
       end
     end
   endfunction
+
+  // this function is called after reset or end of vseq run
+  virtual function void reset_seq_cfg();
+    seq_cfg.en_fmt_overflow     = 1'b0;
+    seq_cfg.en_rx_overflow      = 1'b0;
+    seq_cfg.en_rx_watermark     = 1'b0;
+    seq_cfg.en_sda_unstable     = 1'b0;
+    seq_cfg.en_scl_interference = 1'b0;
+    seq_cfg.en_sda_interference = 1'b0;
+  endfunction : reset_seq_cfg
 
 endclass : i2c_env_cfg

--- a/hw/ip/i2c/dv/env/i2c_seq_cfg.sv
+++ b/hw/ip/i2c/dv/env/i2c_seq_cfg.sv
@@ -12,8 +12,8 @@ class i2c_seq_cfg extends uvm_object;
 
   // knobs for number of retry after reset
   // for stress_all, error_intr, stress_all_with_rand_reset
-  uint i2c_min_num_runs         = 10;
-  uint i2c_max_num_runs         = 20;
+  uint i2c_min_num_runs          = 5;
+  uint i2c_max_num_runs          = 10;
 
   // knobs for dut's registers
   uint i2c_min_addr              = 0;
@@ -33,9 +33,25 @@ class i2c_seq_cfg extends uvm_object;
   // knobs for error_intr test
   // assertion probability of sda_interference, scl_interference, and
   // sda_unstable interrupts (in percentage)
-  uint i2c_prob_sda_unstable     = 10;
-  uint i2c_prob_sda_interference = 10;
-  uint i2c_prob_scl_interference = 50;
+  uint i2c_prob_sda_unstable     = 30;
+  uint i2c_prob_sda_interference = 30;
+  uint i2c_prob_scl_interference = 70;
+
+  // bits to control fifos access
+  // set en_fmt_overflow to ensure fmt_overflow irq is triggered
+  bit en_fmt_overflow            = 1'b0;
+  // set en_rx_overflow to ensure ensure rx_overflow irq is triggered
+  bit en_rx_overflow             = 1'b0;
+  // set en_rx_watermark to ensure rx_watermark irq is triggered
+  bit en_rx_watermark            = 1'b0;
+
+  // bits to control interference and unstable interrupts
+  // set en_sda_unstable to allow sda_unstable irq is triggered
+  bit en_sda_unstable            = 1'b0;
+  // set en_scl_interference to allow scl_interference irq is triggered
+  bit en_scl_interference        = 1'b0;
+  // set en_sda_interference to allow sda_interference irq is triggered
+  bit en_sda_interference        = 1'b0;
 
   `uvm_object_new
 

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_common_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_common_vseq.sv
@@ -8,15 +8,8 @@ class i2c_common_vseq extends i2c_base_vseq;
 
   constraint num_trans_c { num_trans inside {[1:2]}; }
 
-  virtual task pre_start();
-    super.pre_start();
-    // for this vseq, $value$plusargs "+en_scb=0" is defined in i2c_sim_cfg.hjson
-    // disable i2c_monitor and i2c_scoreboard since they can not handle this test
-    if (!cfg.en_scb) begin
-      cfg.m_i2c_agent_cfg.en_monitor = 1'b0;
-      `uvm_info(`gfn, $sformatf("\n  disable i2c_monitor and i2c_scoreboard"), UVM_DEBUG)
-    end
-  endtask : pre_start
+  // for this vseq, $value$plusargs "+en_scb=0" is defined in i2c_sim_cfg.hjson
+  // disable i2c_monitor and i2c_scoreboard since they can not handle this test
 
   virtual task body();
     `uvm_info(`gfn, "\n--> start of i2c_common_vseq", UVM_DEBUG)

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_error_intr_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_error_intr_vseq.sv
@@ -14,15 +14,15 @@ class i2c_error_intr_vseq extends i2c_rx_tx_vseq;
   local bit do_reset = 1'b0;
 
   // increase num_trans to cover error interrupts
-  constraint num_trans_c { num_trans inside {[50 : 100]}; }
+  constraint num_trans_c { num_trans inside {[40 : 50]}; }
 
   virtual task pre_start();
-    super.pre_start();
     // allow agent/target creating interference and unstable signals so
     // sda_interference, scl_interference, sda_unstable are asserted
-    cfg.en_sda_unstable     = 1'b1;
-    cfg.en_sda_interference = 1'b1;
-    cfg.en_scl_interference = 1'b1;
+    cfg.seq_cfg.en_sda_unstable     = 1'b1;
+    cfg.seq_cfg.en_sda_interference = 1'b1;
+    cfg.seq_cfg.en_scl_interference = 1'b1;
+    super.pre_start();
   endtask : pre_start
 
   virtual task body();
@@ -63,7 +63,6 @@ class i2c_error_intr_vseq extends i2c_rx_tx_vseq;
   endtask : body
 
   virtual task process_error_interrupts();
-
     forever begin
       @(posedge cfg.clk_rst_vif.clk) begin
         if (cfg.intr_vif.pins[SclInference] ||

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_fifo_full_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_fifo_full_vseq.sv
@@ -13,7 +13,7 @@ class i2c_fifo_full_vseq extends i2c_rx_tx_vseq;
   // fast write data to fmt_fifo to quickly trigger fmt_watermark interrupt
   constraint fmt_fifo_access_dly_c { fmt_fifo_access_dly == 0;}
 
-  // fast read data from rd_fifo to quickly finish simulation (increasing sim. performance)
+  // fast read data from rd_fifo after it is full in order to quickly finish simulation
   constraint rx_fifo_access_dly_c { rx_fifo_access_dly == 0;}
 
   // write transaction length is more than fmt_fifo depth to fill up fmt_fifo
@@ -30,9 +30,9 @@ class i2c_fifo_full_vseq extends i2c_rx_tx_vseq;
   local bit rx_fifo_full    = 1'b0;
 
   virtual task pre_start();
-    super.pre_start();
     // hold reading rx_fifo to ensure rx_fifo gets full
-    cfg.en_rx_watermark = 1'b1;
+    cfg.seq_cfg.en_rx_watermark = 1'b1;
+    super.pre_start();
   endtask : pre_start
 
   virtual task body();
@@ -40,15 +40,15 @@ class i2c_fifo_full_vseq extends i2c_rx_tx_vseq;
     `uvm_info(`gfn, "\n--> start of i2c_fifo_full_vseq", UVM_DEBUG)
     fork
       begin
-        while (check_fifo_full) process_fifo_full_status();
+        while (!cfg.under_reset && check_fifo_full) process_fifo_full_status();
       end
       begin
         host_send_trans(num_trans);
         check_fifo_full = 1'b0; // gracefully stop process_fifo_full_status
       end
     join
-    // verify fmt_fifo and rx_fifo has been in full status
-    `DV_CHECK_EQ({fmt_fifo_full, rx_fifo_full}, 2'b11);
+    // verify either fmt_fifo or rx_fifo has been in full status
+    `DV_CHECK_EQ((fmt_fifo_full | rx_fifo_full), 1'b1);
     `uvm_info(`gfn, "\n--> end of i2c_fifo_full_vseq", UVM_DEBUG)
   endtask : body
 

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_fifo_overflow_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_fifo_overflow_vseq.sv
@@ -27,10 +27,10 @@ class i2c_fifo_overflow_vseq extends i2c_rx_tx_vseq;
   local uint cnt_rx_overflow;
 
   virtual task pre_start();
-    super.pre_start();
     // config fmt_overflow and rx_overflow tests
-    cfg.en_fmt_overflow = 1'b1;
-    cfg.en_rx_overflow  = 1'b1;
+    cfg.seq_cfg.en_fmt_overflow = 1'b1;
+    cfg.seq_cfg.en_rx_overflow  = 1'b1;
+    super.pre_start();
   endtask : pre_start
 
   virtual task body();
@@ -39,7 +39,6 @@ class i2c_fifo_overflow_vseq extends i2c_rx_tx_vseq;
     bit rxempty = 1'b0;
 
     initialization();
-
     `uvm_info(`gfn, "\n--> start of i2c_fifo_overflow_vseq", UVM_DEBUG)
     for (int i = 1; i <= num_trans; i++) begin
       check_fmt_overflow = 1'b1; // set to gracefully stop process_fmt_overflow_intr
@@ -56,8 +55,7 @@ class i2c_fifo_overflow_vseq extends i2c_rx_tx_vseq;
           // -> verify the number of received fmt_watermark interrupt
           // -> verify fmt_data dropped is performed scoreboard
           if (check_fmt_overflow) begin
-            host_send_trans(.num_trans(1), .trans_type(WriteOnly));
-            csr_spinwait(.ptr(ral.status.fmtempty), .exp_data(1'b1));
+            host_send_trans(1, WriteOnly);
             check_fmt_overflow = 1'b0;
             // number of fmt_overflow received is at most num_data_ovf
             // since fmt_fifo can be drained thus decreasing cnt_fmt_overflow counter
@@ -74,8 +72,7 @@ class i2c_fifo_overflow_vseq extends i2c_rx_tx_vseq;
           // -> verify the number of received rx_overflow interrupt
           // -> verify the rx_data dropped is performed in scoreboard
           if (check_rx_overflow) begin
-            host_send_trans(.num_trans(1), .trans_type(ReadOnly));
-            csr_spinwait(.ptr(ral.status.rxempty), .exp_data(1'b1));
+            host_send_trans(1, ReadOnly);
             check_rx_overflow = 1'b0;
             if (!cfg.under_reset) begin
               `DV_CHECK_EQ(cnt_rx_overflow, 1)

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_override_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_override_vseq.sv
@@ -10,22 +10,20 @@ class i2c_override_vseq extends i2c_base_vseq;
   local rand bit sdaval;
   local rand bit txovrden;
 
-  virtual task pre_start();
-    super.pre_start();
+  constraint txovrden_c { txovrden dist {1 :/ 3, 0 :/ 1}; };
+
+  task pre_start();
     // for this vseq, $value$plusargs "+en_scb=0" is defined in i2c_sim_cfg.hjson
     // disable i2c_monitor and i2c_scoreboard since they can not handle this test
-    if (!cfg.en_scb) begin
-      cfg.m_i2c_agent_cfg.en_monitor = 1'b0;
-      `uvm_info(`gfn, $sformatf("\n  disable i2c_monitor and i2c_scoreboard"), UVM_DEBUG)
-    end
+
     // disable clear_all_interrupts task due to abnormal assertion of interrupts
     do_clear_all_interrupts = 1'b0;
+    super.pre_start();
   endtask : pre_start
 
-  virtual task body();
+  task body();
+    initialization();
     `uvm_info(`gfn, "\n--> start of i2c_override_vseq", UVM_DEBUG)
-    device_init();
-    host_init();
     for (uint i = 1; i <= num_trans; i++) begin
       `uvm_info(`gfn, $sformatf("\n  run simulation %0d/%0d", i, num_trans), UVM_DEBUG)
       // program to enable OVRD reg

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_stress_all_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_stress_all_vseq.sv
@@ -1,0 +1,102 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// combine all i2c seqs (except below vseqs) in one seq to run sequentially
+// 1. override_vseq requires scb and monitor to be disabled
+// 1. csr seq, which requires scb to be disabled
+class i2c_stress_all_vseq extends i2c_base_vseq;
+  `uvm_object_utils(i2c_stress_all_vseq)
+
+  `uvm_object_new
+
+  local string str, seq_name;
+  local int    seq_run_hist[string];
+
+  string seq_names[] = {
+    "i2c_common_vseq",      // for intr_test
+    "i2c_sanity_vseq",
+    "i2c_fifo_full_vseq",
+    "i2c_fifo_overflow_vseq",
+    "i2c_fifo_watermark_vseq",
+    "i2c_fifo_full_vseq",
+    "i2c_stretch_timeout_vseq",
+    "i2c_error_intr_vseq",
+    "i2c_perf_vseq"
+  };
+
+  virtual task body();
+
+    `uvm_info(`gfn, "\n=> start i2c_stress_all_vseq", UVM_LOW)
+    print_seq_names(seq_names);
+    for (int i = 1; i <= seq_names.size(); i++) begin
+      seq_run_hist[seq_names[i-1]] = 0;
+    end
+
+    for (int i = 1; i <= num_runs; i++) begin
+      uvm_sequence   seq;
+      i2c_base_vseq  i2c_vseq;
+      uint           seq_idx = $urandom_range(0, seq_names.size() - 1);
+
+      seq_name = seq_names[seq_idx];
+      `uvm_info(`gfn, $sformatf("\n\n=> start stressing vseq %s (%0d/%0d)",
+          seq_name, i, num_runs), UVM_LOW)
+      seq = create_seq_by_name(seq_name);
+      `downcast(i2c_vseq, seq)
+
+      // if upper seq disables do_dut_init for this seq, then can't issue reset
+      // as upper seq may drive reset
+      if (do_dut_init) begin
+        i2c_vseq.do_dut_init = $urandom_range(0, 1);
+        if (i2c_vseq.do_dut_init) begin
+          `uvm_info(`gfn, "\n  *reset is randomly issued with stress_test", UVM_LOW)
+        end
+      end else begin
+        i2c_vseq.do_dut_init = 0;
+        `uvm_info(`gfn, "\n  *upper_seq may drive reset thus not issue reset", UVM_DEBUG)
+      end
+
+      i2c_vseq.set_sequencer(p_sequencer);
+      `DV_CHECK_RANDOMIZE_FATAL(i2c_vseq)
+      case (seq_name)
+        "i2c_common_vseq": begin
+          i2c_common_vseq common_vseq;
+          `downcast(common_vseq, i2c_vseq);
+          common_vseq.common_seq_type = "intr_test";
+          cfg.en_scb = 1'b0;
+        end
+        "i2c_override_vseq": begin
+          cfg.en_scb = 1'b0;
+        end
+        default: begin
+          cfg.en_scb = 1'b1;
+        end
+      endcase
+      // run vseq
+      i2c_vseq.start(p_sequencer);
+      seq_run_hist[seq_name]++;
+      `uvm_info(`gfn, $sformatf("\n  end stressing vseq %s", seq_name), UVM_LOW)
+    end
+    wait_host_for_idle();
+    `uvm_info(`gfn, "\n=> end of i2c_stress_all_vseq", UVM_LOW)
+
+    // get the histogram of vseq running
+    str = {str, "\n\n=> vseq run histogram:"};
+    for (int i = 0; i < seq_names.size(); i++) begin
+      seq_name = seq_names[i];
+      str = {str, $sformatf("\n  %-25s  %2d / %2d", seq_name, seq_run_hist[seq_name], num_runs)};
+    end
+    `uvm_info(`gfn, $sformatf("%s\n", str), UVM_LOW)
+  endtask : body
+
+  virtual function print_seq_names(string seq_names[]);
+    string str;
+
+    `uvm_info(`gfn, $sformatf("\n  list of %0d vseqs are stressed", seq_names.size()), UVM_LOW)
+    for (int i = 1; i <= seq_names.size(); i++) begin
+      str = {str, $sformatf("\n    %s", seq_names[i-1])};
+    end
+    `uvm_info(`gfn, $sformatf("%s", str), UVM_LOW)
+  endfunction : print_seq_names
+
+endclass : i2c_stress_all_vseq

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_stretch_timeout_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_stretch_timeout_vseq.sv
@@ -14,66 +14,67 @@ class i2c_stretch_timeout_vseq extends i2c_rx_tx_vseq;
   // timeout is always enabled so stretch_timeout irq is aggressively asserted
   constraint e_timeout_c { e_timeout == 1; }
 
-  local uint num_wr_st;
-  local uint num_rd_st;
-  local bit  check_wr_st;
-  local bit  check_rd_st;
+  local uint cnt_wr_stretch;
+  local uint cnt_rd_stretch;
+  local bit  check_wr_stretch;
+  local bit  check_rd_stretch;
 
   virtual task body();
 
     `uvm_info(`gfn, "\n--> start of i2c_stretch_timeout_vseq", UVM_DEBUG)
     initialization();
     for (int i = 1; i <= num_trans; i++) begin
-      num_wr_st = 0;
-      num_rd_st = 0;
-      check_wr_st = 1'b0;
-      check_rd_st = 1'b0;
+      cnt_wr_stretch = 0;
+      cnt_rd_stretch = 0;
+      check_wr_stretch = 1'b0;
+      check_rd_stretch = 1'b0;
 
+      `uvm_info(`gfn, $sformatf("\n  run simulation %0d/%0d", i, num_trans), UVM_DEBUG)
       fork
         begin
-          check_wr_st = 1'b1;
-          host_send_trans(.num_trans(1), .trans_type(WriteOnly));
-          csr_spinwait(.ptr(ral.status.fmtempty), .exp_data(1'b1));
-          check_wr_st = 1'b0;
-          `uvm_info(`gfn, $sformatf("\n  check_wr_st %0d", check_wr_st), UVM_DEBUG)
-          // host clock is stretched for every target's ACK thus
-          // num_wr_st must be equal to (num_wr_bytes + 1)
-          // adding 1 is for the target's ACK to the response address byte sent by host
-          if (!cfg.under_reset) `DV_CHECK_EQ(num_wr_st, (num_wr_bytes + 1))
+          check_wr_stretch = 1'b1;
+          host_send_trans(1, WriteOnly);
+          check_wr_stretch = 1'b0;
+          if (!cfg.under_reset) begin
+            // host clock is stretched for every target's ACK thus
+            // cnt_wr_stretch must be equal to (num_wr_bytes + 1)
+            // adding 1 is for the target's ACK to the response address byte sent by host
+            `DV_CHECK_EQ(cnt_wr_stretch, (num_wr_bytes + 1))
+          end
 
-          check_rd_st = 1'b1;
-          host_send_trans(.num_trans(1), .trans_type(ReadOnly));
-          csr_spinwait(.ptr(ral.status.rxempty), .exp_data(1'b1));
-          check_rd_st = 1'b0;
-          `uvm_info(`gfn, $sformatf("\n  check_rd_st %0d", check_rd_st), UVM_DEBUG)
-          // check_rd_stretch_timeout must be equal to 1
-          // that is the target's ACK to response the address byte sent by host
-          if (!cfg.under_reset) `DV_CHECK_EQ(num_rd_st, 1)
+          check_rd_stretch = 1'b1;
+          host_send_trans(1, ReadOnly);
+          check_rd_stretch = 1'b0;
+          if (!cfg.under_reset) begin
+            // check_rd_stretchretch_timeout must be equal to 1
+            // that is the target's ACK to response the address byte sent by host
+            `DV_CHECK_EQ(cnt_rd_stretch, 1)
+          end
         end
         begin
-          while (check_wr_st || check_rd_st) check_wr_st_intr();
+          while (check_wr_stretch || check_rd_stretch) process_stretch_timeout_intr();
         end
       join
     end
     `uvm_info(`gfn, "\n--> end of i2c_stretch_timeout_vseq", UVM_DEBUG)
   endtask : body
 
-  task check_wr_st_intr();
+  task process_stretch_timeout_intr();
     bit stretch_timeout;
 
     csr_rd(.ptr(ral.intr_state.stretch_timeout), .value(stretch_timeout));
     if (stretch_timeout) begin
-      if (check_wr_st) num_wr_st++;
-      if (check_rd_st) num_rd_st++;
+      if (check_wr_stretch) cnt_wr_stretch++;
+      if (check_rd_stretch) cnt_rd_stretch++;
 
       // must wait stretch_timeout event passes (scl_i is deasserted)
       // before clearing irq otherwise stretch_timeout irq can be re-triggered
       // within clock pulses that interferes the counters
       wait(!cfg.m_i2c_agent_cfg.vif.scl_i);
       clear_interrupt(StretchTimeout);
-      `uvm_info(`gfn, $sformatf("\n  check_wr_st %0d, check_rd_st %0d",
-          num_wr_st, num_rd_st), UVM_DEBUG)
+      `uvm_info(`gfn, $sformatf("\n  check_wr_st %b cnt_wr_st %0d, check_rd_st %b, cnt_rd_st %0d",
+          check_wr_stretch, cnt_wr_stretch, check_rd_stretch, cnt_rd_stretch), UVM_DEBUG)
     end
-  endtask : check_wr_st_intr
+  endtask : process_stretch_timeout_intr
 
 endclass : i2c_stretch_timeout_vseq

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
@@ -14,4 +14,4 @@
 `include "i2c_perf_vseq.sv"
 `include "i2c_stretch_timeout_vseq.sv"
 `include "i2c_error_intr_vseq.sv"
-
+`include "i2c_stress_all_vseq.sv"

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -85,6 +85,15 @@
       name: i2c_error_intr
       uvm_test_seq: i2c_error_intr_vseq
     }
+
+    {
+      // TODO: remove later when i2c_stress_all_with_rand_reset is added
+      // (then stress_tests.hjson would be included)
+      name: i2c_stress_all
+      uvm_test_seq: i2c_stress_all_vseq
+      // 10ms
+      run_opts: ["+test_timeout_ns=10000000000"]
+    }
   ]
 
   // List of regressions.


### PR DESCRIPTION
This PR includes

  - Use pre_start and post_start to configure vseq
  - Add i2c_stress_all_vseq
  - Remove redundant csr_spinwait in *_vseq
  - Move cfg variables from i2c_env_seq into i2c_seq_cfg 

Signed-off-by: Tung Hoang <hoang.tung@wdc.com>