### PR TITLE
[otp_ctrl] Simplify and consolidate OTP error codes

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson
@@ -15,15 +15,15 @@
       desc: "A direct access command or digest calculation operation has completed."
     }
     { name: "otp_error",
-      desc: "An error has occurred in the OTP controller. Check the ERR_CODE register to get more information."
+      desc: "An error has occurred in the OTP controller. Check the !!ERR_CODE register to get more information."
     }
   ],
 
   alert_list: [
-    { name: "otp_fatal_error",
+    { name: "otp_macro_failure",
       desc: "This alert triggers if hardware detects a parity bit or digest error in the buffered partitions.",
     }
-    { name: "otp_check_failed",
+    { name: "otp_check_failure",
       desc: "This alert triggers if the digest over the buffered registers does not match with the digest stored in OTP.",
     }
   ],
@@ -284,28 +284,28 @@
           name: "TIMEOUT_ERROR"
           desc: '''
                 Set to 1 if an integrity or consistency check times out.
-                This raises an otp_check_failed alert and is an unrecoverable error condition.
+                This raises an otp_check_failure alert and is an unrecoverable error condition.
                 '''
         }
         { bits: "10"
           name: "LFSR_FSM_ERROR"
           desc: '''
                 Set to 1 if the LFSR timer FSM has reached an invalid state.
-                This raises an otp_check_failed alert and is an unrecoverable error condition.
+                This raises an otp_check_failure alert and is an unrecoverable error condition.
                 '''
         }
         { bits: "11"
           name: "SCRAMBLING_FSM_ERROR"
           desc: '''
                 Set to 1 if the scrambling datapath FSM has reached an invalid state.
-                This raises an otp_check_failed alert and is an unrecoverable error condition.
+                This raises an otp_check_failure alert and is an unrecoverable error condition.
                 '''
         }
         { bits: "12"
           name: "KEY_DERIV_FSM_ERROR"
           desc: '''
                 Set to 1 if the key derivation FSM has reached an invalid state.
-                This raises an otp_check_failed alert and is an unrecoverable error condition.
+                This raises an otp_check_failure alert and is an unrecoverable error condition.
                 '''
         }
         { bits: "13"
@@ -321,145 +321,85 @@
     { multireg: {
         name:     "ERR_CODE",
         desc:     '''
-                  This register holds information on error conditions and should be
-                  checked when any of the partitions or the DAI flags an error in the
-                  !!STATUS registers, or when an !!INTR_STATE.otp_error has been triggered.
-                  Note that all errors trigger an otp_error interrupt, and in addition some
-                  errors may trigger either an otp_fatal_error or an otp_check_failed alert.
+                  This register holds information about error conditions that occurred in the agents
+                  interacting with the OTP macro via the internal bus. The error codes should be checked
+                  if the partitions, DAI or LCI flag an error in the !!STATUS register, or when an
+                  !!INTR_STATE.otp_error has been triggered. Note that all errors trigger an otp_error
+                  interrupt, and in addition some errors may trigger either an otp_macro_failure or an
+                  otp_check_failure alert.
                   ''',
         count:     "NumErrorEntries",
         swaccess:  "ro",
         hwaccess:  "hwo",
         hwext:     "true",
-        cname:     "MODULE",
+        cname:     "AGENT",
         fields: [
           {
-            bits: "3:0"
+            bits: "2:0"
             enum: [
               { value: "0",
-                name: "NO_ERR",
+                name: "NO_ERROR",
                 desc: '''
                 No error condition has occurred.
                 '''
               },
               { value: "1",
-                name: "OTP_CMD_INV_ERR",
+                name: "MACRO_ERROR",
                 desc: '''
-                An invalid command has been written to the OTP macro.
+                Returned if the OTP macro command was invalid or did not complete successfully
+                due to a macro malfunction.
                 This error should never occur during normal operation and is not recoverable.
-                If this error is present this may be a sign that the device is malfunctioning.
-                This error triggers an otp_fatal_error alert.
+                This error triggers an otp_macro_failure alert.
                 '''
               },
               { value: "2",
-                name: "OTP_INIT_ERR",
+                name: "MACRO_ECC_CORR_ERROR",
                 desc: '''
-                The OTP macro initialization sequence has failed.
-                This error should never occur during normal operation and is not recoverable.
-                If this error is present this may be a sign that the device is malfunctioning.
-                This error triggers an otp_fatal_error alert.
+                A correctable ECC error has occured during an OTP read operation.
+                The corresponding controller automatically recovers from this error when
+                issuing a new command.
                 '''
               },
               { value: "3",
-                name: "OTP_READ_CORR_ERR",
+                name: "MACRO_ECC_UNCORR_ERROR",
                 desc: '''
-                A correctable error has occured during an OTP read operation.
-                The corresponding controller automatically recovers from this error when
-                issuing a new command.
+                An uncorrectable ECC error has occurred during an OTP read operation.
+                This error should never occur during normal operation and is not recoverable.
+                If this error is present this may be a sign that the device is malfunctioning.
+                This error triggers an otp_macro_failure alert.
                 '''
               },
               { value: "4",
-                name: "OTP_READ_UNCORR_ERR",
+                name: "MACRO_WRITE_BLANK_ERROR",
                 desc: '''
-                An uncorrectable error has occurred during an OTP read operation.
-                This error should never occur during normal operation and is not recoverable.
-                If this error is present this may be a sign that the device is malfunctioning.
-                This error triggers an otp_fatal_error alert.
+                A blank write check has failed during an OTP write operation. This effectively
+                aborts the write operation such that no harm is done to the OTP. The corresponding
+                controller automatically recovers from this error when issuing a new command.
                 '''
               },
               { value: "5",
-                name: "OTP_READ_ERR",
+                name: "ACCESS_ERROR",
                 desc: '''
-                A unspecified error has occurred during an OTP read operation.
-                This error should never occur during normal operation and is not recoverable.
-                If this error is present this may be a sign that the device is malfunctioning.
-                This error triggers an otp_fatal_error alert.
+                This error indicates that a locked memory region has been accessed.
+                The corresponding controller automatically recovers from this error when issuing a new command.
                 '''
               },
               { value: "6",
-                name: "OTP_WRITE_BLANK_ERR",
+                name: "CHECK_FAIL_ERROR",
                 desc: '''
-                A blank write check has failed during an OTP write operation.
-                This effectively aborts the write operation such that no harm is done to the OTP.
-                The corresponding controller automatically recovers from this error when issuing
-                a new command.
+                A parity, integrity or consistency mismatch has been detected in the buffer registers.
+                This error should never occur during normal operation and is not recoverable.
+                This error triggers an otp_check_failure alert.
                 '''
               },
               { value: "7",
-                name: "OTP_WRITE_ERR",
+                name: "FSM_STATE_ERROR",
                 desc: '''
-                A unspecified error has occurred during an OTP write operation.
-                This error should never occur during normal operation and is not recoverable.
-                If this error is present this may be a sign that the device is malfunctioning.
-                This error triggers an otp_fatal_error alert.
-                '''
-              },
-              { value: "8",
-                name: "CMD_INV_ERR",
-                desc: '''
-                This error indicates that an invalid command has been written to the DAI.
-                The DAI controller automatically recovers from this error when issuing
-                a new command.
-                '''
-              },
-              { value: "9",
-                name: "ACCESS_ERR",
-                desc: '''
-                This error indicates that a locked memory region has been accessed.
-                The corresponding controller automatically recovers from this error when
-                issuing a new command.
-                '''
-              },
-              { value: "10",
-                name: "PARITY_ERROR",
-                desc: '''
-                A parity mismatch has been detected in the buffer registers.
-                This error should never occur during normal operation and is not recoverable.
-                This error triggers an otp_check_failed alert.
-                '''
-              },
-              { value: "11",
-                name: "INTEG_ERR",
-                desc: '''
-                An integrity check mismatch has been detected in the buffer registers.
-                This error should never occur during normal operation and is not recoverable.
-                This error triggers an otp_check_failed alert.
-                '''
-              },
-              { value: "12",
-                name: "CNSTY_ERR",
-                desc: '''
-                A consistency check mismatch has been detected in the buffer registers.
-                This error should never occur during normal operation and is not recoverable.
-                This error triggers an otp_check_failed alert.
-                '''
-              },
-              { value: "13",
-                name: "FSM_ERR",
-                desc: '''
-                The FSM of the corresponding controller has reached a parasitic state.
+                The FSM of the corresponding controller has reached an invalid state, or the FSM has
+                been moved into a terminal error state due to an escalation action via lc_escalate_en_i.
                 This error should never occur during normal operation and is not recoverable.
                 If this error is present, this is a sign that the device has fallen victim to
-                a glitch attack.
-                This error triggers an otp_check_failed alert.
-                '''
-              },
-              { value: "14",
-                name: "ESC_ERR",
-                desc: '''
-                This error is the result of an escalation action in the alert subsystem, and
-                indicates that the corresponding controller FSM has been moved into a terminal
-                state due to escalation via the alert subsystem.
+                an invasive attack. This error triggers an otp_check_failure alert.
                 '''
               },
             ]
@@ -659,7 +599,7 @@
           desc: '''
           Timeout value in cycles for the for the integrity and consistency checks. If an integrity or consistency
           check does not complete within the timeout window, an error will be flagged in the !!STATUS register,
-          an otp_error interrupt will be raised, and an otp_check_failed alert will be sent out. The timeout should
+          an otp_error interrupt will be raised, and an otp_check_failure alert will be sent out. The timeout should
           be set to a large value to stay on the safe side. The maximum check time can be upper bounded by the
           number of cycles it takes to readout, scramble and digest the entire OTP array. Since this amounts to
           roughly 25k cycles, it is recommended to set this value to at least 100'000 cycles in order to stay on the

--- a/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
@@ -74,7 +74,7 @@
       desc: '''
             This test will cover two methods of locking read and write: digest calculation and CSR
             write. After locking the partitions, issue read or program sequences and check if the
-            operations are locked correctly, and check if the `access_error` is set.
+            operations are locked correctly, and check if the `AccessError` is set.
             '''
       milestone: V2
       tests: []
@@ -106,13 +106,10 @@
     { name: otp_macro_errors
       desc: '''
             This test will randomly run the following OTP errors:
-            - OtpCmdInvErr
-            - OtpInitErr
-            - OtpReadCorrErr
-            - OtpReadUncorrErr
-            - OtpReadErr
-            - OtpWriteBlankErr
-            - OtpWriteErr
+            - MacroError
+            - MacroEccCorrError
+            - MacroEccUncorrError
+            - MacroWriteBlankError
 
             The test will check:
             - The value of err_code and status registers
@@ -124,9 +121,8 @@
     { name: otp_ctrl_errors
       desc: '''
             This test will randomly run the following OTP errors:
-            - CmdInvErr
-            - FsmErr
-            - EscErr
+            - CheckFailError
+            - FsmStateError
 
             The test will check:
             - The value of err_code and status registers

--- a/hw/ip/otp_ctrl/doc/_index.md
+++ b/hw/ip/otp_ctrl/doc/_index.md
@@ -694,7 +694,7 @@ Parameter      | Default | Top Earlgrey  | Description
 `Width`        | 16      | 16            | Native OTP word width.
 `Depth`        | 1024    | 1024          | Depth of OTP macro.
 `CmdWidth`     | 2       | 2             | Width of the OTP command.
-`ErrWidth`     | 4       | 4             | Width of error code output signal.
+`ErrWidth`     | 3       | 3             | Width of error code output signal.
 `PwrSeqWidth`  | 2       | 2             | Width of power sequencing signals to/from AST.
 `SizeWidth`    | 2       | 2             | Width of the size field.
 `IfWidth`      | 2^`SizeWidth` * `Width` | 2^`SizeWidth` * `Width` | Data interface width.
@@ -729,7 +729,7 @@ Signal                  | Direction        | Type                        | Descr
 `rdata_o`               | `output`         | `logic [IfWidth-1:0]`       | Read data from read commands.
 `err_o`                 | `output`         | `logic [ErrWidth-1:0]`      | Error code.
 
-The `prim_otp` wrappers implements the error codes 0x0 - 0x7 defined in the [OTP error handling]({{< relref "#error-handling" >}}).
+The `prim_otp` wrappers implements the `Macro*` error codes (0x0 - 0x4) defined in the [OTP error handling]({{< relref "#error-handling" >}}).
 
 The timing diagram below illustrates the timing of a command.
 Note that both read and write commands return a response, and each command is independent of the previously issued commands.
@@ -881,29 +881,21 @@ The table also lists which error codes are supported by which agent.
 Errors that are not "recoverable" are severe errors that move the corresponding partition or DAI/LCI FSM into a terminal error state, where no more commands can be accepted (a system reset is required to restore functionality in that case).
 Errors that are "recoverable" are less severe and do not cause the FSM to jump into a terminal error state.
 
-Note that error codes that originate in the physical OTP macro are prefixed with `Otp*`.
+Note that error codes that originate in the physical OTP macro are prefixed with `Macro*`.
 
-Error Code | Enum Name        | Recoverable | DAI | LCI | Unbuf | Buf   | Description
------------|------------------|-------------|-----|-----|-------|-------|-------------
-0x0        | NoErr            | -           |  x  |  x  |   x   |  x    | Command completed successfully.
-0x1        | OtpCmdInvErr     | no          |  x  |  x  |   x   |  x    | Invalid OTP macro command. This error is returned if the command encoding is incorrect, or if a read or write command is issued to an uninitialized OTP wrapper.
-0x2        | OtpInitErr       | no          |  x  |  x  |   x   |  x    | Failure during OTP macro initialization. Asserted in case OTP initialization does not complete successfully.
-0x3        | OtpReadCorrErr   | yes         |  x  |  -  |   x   |  x    | Correctable ECC error occurred during a read in the OTP macro.
-0x4        | OtpReadUncorrErr | no          |  x  |  -  |   x   |  x    | Uncorrectable ECC error occurred during a read in the OTP macro.
-0x5        | OtpReadErr       | no          |  x  |  -  |   x   |  x    | An unrecoverable error occurred during a read operation in the OTP macro.
-0x6        | OtpWriteBlankErr | yes         |  x  |  x  |   -   |  -    | OTP macro blank check failed. The location to be programmed is not all-zero.
-0x7        | OtpWriteErr      | no          |  x  |  x  |   -   |  -    | An unrecoverable error occurred during a program operation in the OTP macro.
-0x8        | CmdInvErr        | yes         |  x  |  -  |   -   |  -    | An invalid command has been issued.
-0x9        | AccessErr        | yes         |  x  |  -  |   x   |  -    | An access error has occurred (e.g. write to write-locked region, or read to a read-locked region).
-0xA        | ParityErr        | no          |  -  |  -  |   x   |  x    | A parity error has been detected.
-0xB        | IntegErr         | no          |  -  |  -  |   -   |  x    | An integrity error has been detected.
-0xC        | CnstyErr         | no          |  -  |  -  |   -   |  x    | A consistency error has been detected.
-0xD        | FsmErr           | no          |  x  |  x  |   x   |  x    | The FSM has been glitched into a parasitic state.
-0xE        | EscErr           | no          |  x  |  x  |   x   |  x    | Escalation has been triggered and the FSM has been moved into a terminal error state.
-0xF        | -                | -           |  -  |  -  |   -   |  -    | Reserved.
+Error Code | Enum Name            | Recoverable | DAI | LCI | Unbuf | Buf   | Description
+-----------|----------------------|-------------|-----|-----|-------|-------|-------------
+0x0        | NoError              | -           |  x  |  x  |   x   |  x    | No error has occurred.
+0x1        | MacroError           | no          |  x  |  x  |   x   |  x    | Returned if the OTP macro command was invalid or did not complete successfully due to a macro malfunction.
+0x2        | MacroEccCorrError    | yes         |  x  |  -  |   x   |  x    | A correctable ECC error has occurred during a read operation in the OTP macro.
+0x3        | MacroEccUncorrError  | no          |  x  |  -  |   x   |  x    | An uncorrectable ECC error has occurred during a read operation in the OTP macro.
+0x4        | MacroWriteBlankError | yes         |  x  |  x  |   x   |  x    | This error is returned if a write operation attempted to overwrite an already programmed location.
+0x5        | AccessError          | yes         |  x  |  -  |   x   |  -    | An access error has occurred (e.g. write to write-locked region, or read to a read-locked region).
+0x6        | CheckFailError       | no          |  -  |  -  |   x   |  x    | An unrecoverable parity, integrity or consistency error has been detected.
+0x7        | FsmStateError        | no          |  x  |  x  |   x   |  x    | The FSM has been glitched into an invalid state, or escalation has been triggered and the FSM has been moved into a terminal error state.
 
 All non-zero error codes listed above trigger an `otp_error` interrupt.
-In addition, all unrecoverable OTP macro errors (codes <= 0x7) trigger an `otp_fatal_error` alert, while all remaining unrecoverable errors trigger an `otp_check_failed` alert.
+In addition, all unrecoverable OTP `Macro*` errors (codes 0x1, 0x3) trigger an `otp_macro_failure` alert, while all remaining unrecoverable errors trigger an `otp_check_failure` alert.
 
 ## Direct Access Memory Map
 

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv
@@ -54,7 +54,7 @@ package otp_ctrl_pkg;
   parameter int OtpDepth         = 2**OtpAddrWidth;
   parameter int OtpCmdWidth      = 2;
   parameter int OtpSizeWidth     = 2; // Allows to transfer up to 4 native OTP words at once.
-  parameter int OtpErrWidth      = 4;
+  parameter int OtpErrWidth      = 3;
   parameter int OtpPwrSeqWidth   = 2;
   parameter int OtpIfWidth       = 2**OtpSizeWidth*OtpWidth;
   // Number of Byte address bits to cut off in order to get the native OTP word address.
@@ -67,21 +67,14 @@ package otp_ctrl_pkg;
   } prim_otp_cmd_e;
 
   typedef enum logic [OtpErrWidth-1:0] {
-    NoErr            = 4'h0,
-    OtpCmdInvErr     = 4'h1,
-    OtpInitErr       = 4'h2,
-    OtpReadCorrErr   = 4'h3,
-    OtpReadUncorrErr = 4'h4,
-    OtpReadErr       = 4'h5,
-    OtpWriteBlankErr = 4'h6,
-    OtpWriteErr      = 4'h7,
-    CmdInvErr        = 4'h8,
-    AccessErr        = 4'h9,
-    ParityErr        = 4'hA,
-    IntegErr         = 4'hB,
-    CnstyErr         = 4'hC,
-    FsmErr           = 4'hD,
-    EscErr           = 4'hE
+    NoError              = 3'h0,
+    MacroError           = 3'h1,
+    MacroEccCorrError    = 3'h2,
+    MacroEccUncorrError  = 3'h3,
+    MacroWriteBlankError = 3'h4,
+    AccessError          = 3'h5,
+    CheckFailError       = 3'h6,
+    FsmStateError        = 3'h7
   } otp_err_e;
 
   /////////////////////////////////

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
@@ -163,7 +163,7 @@ package otp_ctrl_reg_pkg;
   } otp_ctrl_hw2reg_status_reg_t;
 
   typedef struct packed {
-    logic [3:0]  d;
+    logic [2:0]  d;
   } otp_ctrl_hw2reg_err_code_mreg_t;
 
   typedef struct packed {
@@ -221,9 +221,9 @@ package otp_ctrl_reg_pkg;
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    otp_ctrl_hw2reg_intr_state_reg_t intr_state; // [503:502]
-    otp_ctrl_hw2reg_status_reg_t status; // [501:502]
-    otp_ctrl_hw2reg_err_code_mreg_t [8:0] err_code; // [501:466]
+    otp_ctrl_hw2reg_intr_state_reg_t intr_state; // [494:493]
+    otp_ctrl_hw2reg_status_reg_t status; // [492:493]
+    otp_ctrl_hw2reg_err_code_mreg_t [8:0] err_code; // [492:466]
     otp_ctrl_hw2reg_direct_access_regwen_reg_t direct_access_regwen; // [465:466]
     otp_ctrl_hw2reg_direct_access_rdata_mreg_t [1:0] direct_access_rdata; // [465:402]
     otp_ctrl_hw2reg_creator_sw_cfg_digest_mreg_t [1:0] creator_sw_cfg_digest; // [401:338]
@@ -239,35 +239,34 @@ package otp_ctrl_reg_pkg;
   parameter logic [13:0] OTP_CTRL_INTR_ENABLE_OFFSET = 14'h 4;
   parameter logic [13:0] OTP_CTRL_INTR_TEST_OFFSET = 14'h 8;
   parameter logic [13:0] OTP_CTRL_STATUS_OFFSET = 14'h c;
-  parameter logic [13:0] OTP_CTRL_ERR_CODE_0_OFFSET = 14'h 10;
-  parameter logic [13:0] OTP_CTRL_ERR_CODE_1_OFFSET = 14'h 14;
-  parameter logic [13:0] OTP_CTRL_DIRECT_ACCESS_REGWEN_OFFSET = 14'h 18;
-  parameter logic [13:0] OTP_CTRL_DIRECT_ACCESS_CMD_OFFSET = 14'h 1c;
-  parameter logic [13:0] OTP_CTRL_DIRECT_ACCESS_ADDRESS_OFFSET = 14'h 20;
-  parameter logic [13:0] OTP_CTRL_DIRECT_ACCESS_WDATA_0_OFFSET = 14'h 24;
-  parameter logic [13:0] OTP_CTRL_DIRECT_ACCESS_WDATA_1_OFFSET = 14'h 28;
-  parameter logic [13:0] OTP_CTRL_DIRECT_ACCESS_RDATA_0_OFFSET = 14'h 2c;
-  parameter logic [13:0] OTP_CTRL_DIRECT_ACCESS_RDATA_1_OFFSET = 14'h 30;
-  parameter logic [13:0] OTP_CTRL_CHECK_TRIGGER_REGWEN_OFFSET = 14'h 34;
-  parameter logic [13:0] OTP_CTRL_CHECK_TRIGGER_OFFSET = 14'h 38;
-  parameter logic [13:0] OTP_CTRL_CHECK_REGWEN_OFFSET = 14'h 3c;
-  parameter logic [13:0] OTP_CTRL_CHECK_TIMEOUT_OFFSET = 14'h 40;
-  parameter logic [13:0] OTP_CTRL_INTEGRITY_CHECK_PERIOD_OFFSET = 14'h 44;
-  parameter logic [13:0] OTP_CTRL_CONSISTENCY_CHECK_PERIOD_OFFSET = 14'h 48;
-  parameter logic [13:0] OTP_CTRL_CREATOR_SW_CFG_READ_LOCK_OFFSET = 14'h 4c;
-  parameter logic [13:0] OTP_CTRL_OWNER_SW_CFG_READ_LOCK_OFFSET = 14'h 50;
-  parameter logic [13:0] OTP_CTRL_CREATOR_SW_CFG_DIGEST_0_OFFSET = 14'h 54;
-  parameter logic [13:0] OTP_CTRL_CREATOR_SW_CFG_DIGEST_1_OFFSET = 14'h 58;
-  parameter logic [13:0] OTP_CTRL_OWNER_SW_CFG_DIGEST_0_OFFSET = 14'h 5c;
-  parameter logic [13:0] OTP_CTRL_OWNER_SW_CFG_DIGEST_1_OFFSET = 14'h 60;
-  parameter logic [13:0] OTP_CTRL_HW_CFG_DIGEST_0_OFFSET = 14'h 64;
-  parameter logic [13:0] OTP_CTRL_HW_CFG_DIGEST_1_OFFSET = 14'h 68;
-  parameter logic [13:0] OTP_CTRL_SECRET0_DIGEST_0_OFFSET = 14'h 6c;
-  parameter logic [13:0] OTP_CTRL_SECRET0_DIGEST_1_OFFSET = 14'h 70;
-  parameter logic [13:0] OTP_CTRL_SECRET1_DIGEST_0_OFFSET = 14'h 74;
-  parameter logic [13:0] OTP_CTRL_SECRET1_DIGEST_1_OFFSET = 14'h 78;
-  parameter logic [13:0] OTP_CTRL_SECRET2_DIGEST_0_OFFSET = 14'h 7c;
-  parameter logic [13:0] OTP_CTRL_SECRET2_DIGEST_1_OFFSET = 14'h 80;
+  parameter logic [13:0] OTP_CTRL_ERR_CODE_OFFSET = 14'h 10;
+  parameter logic [13:0] OTP_CTRL_DIRECT_ACCESS_REGWEN_OFFSET = 14'h 14;
+  parameter logic [13:0] OTP_CTRL_DIRECT_ACCESS_CMD_OFFSET = 14'h 18;
+  parameter logic [13:0] OTP_CTRL_DIRECT_ACCESS_ADDRESS_OFFSET = 14'h 1c;
+  parameter logic [13:0] OTP_CTRL_DIRECT_ACCESS_WDATA_0_OFFSET = 14'h 20;
+  parameter logic [13:0] OTP_CTRL_DIRECT_ACCESS_WDATA_1_OFFSET = 14'h 24;
+  parameter logic [13:0] OTP_CTRL_DIRECT_ACCESS_RDATA_0_OFFSET = 14'h 28;
+  parameter logic [13:0] OTP_CTRL_DIRECT_ACCESS_RDATA_1_OFFSET = 14'h 2c;
+  parameter logic [13:0] OTP_CTRL_CHECK_TRIGGER_REGWEN_OFFSET = 14'h 30;
+  parameter logic [13:0] OTP_CTRL_CHECK_TRIGGER_OFFSET = 14'h 34;
+  parameter logic [13:0] OTP_CTRL_CHECK_REGWEN_OFFSET = 14'h 38;
+  parameter logic [13:0] OTP_CTRL_CHECK_TIMEOUT_OFFSET = 14'h 3c;
+  parameter logic [13:0] OTP_CTRL_INTEGRITY_CHECK_PERIOD_OFFSET = 14'h 40;
+  parameter logic [13:0] OTP_CTRL_CONSISTENCY_CHECK_PERIOD_OFFSET = 14'h 44;
+  parameter logic [13:0] OTP_CTRL_CREATOR_SW_CFG_READ_LOCK_OFFSET = 14'h 48;
+  parameter logic [13:0] OTP_CTRL_OWNER_SW_CFG_READ_LOCK_OFFSET = 14'h 4c;
+  parameter logic [13:0] OTP_CTRL_CREATOR_SW_CFG_DIGEST_0_OFFSET = 14'h 50;
+  parameter logic [13:0] OTP_CTRL_CREATOR_SW_CFG_DIGEST_1_OFFSET = 14'h 54;
+  parameter logic [13:0] OTP_CTRL_OWNER_SW_CFG_DIGEST_0_OFFSET = 14'h 58;
+  parameter logic [13:0] OTP_CTRL_OWNER_SW_CFG_DIGEST_1_OFFSET = 14'h 5c;
+  parameter logic [13:0] OTP_CTRL_HW_CFG_DIGEST_0_OFFSET = 14'h 60;
+  parameter logic [13:0] OTP_CTRL_HW_CFG_DIGEST_1_OFFSET = 14'h 64;
+  parameter logic [13:0] OTP_CTRL_SECRET0_DIGEST_0_OFFSET = 14'h 68;
+  parameter logic [13:0] OTP_CTRL_SECRET0_DIGEST_1_OFFSET = 14'h 6c;
+  parameter logic [13:0] OTP_CTRL_SECRET1_DIGEST_0_OFFSET = 14'h 70;
+  parameter logic [13:0] OTP_CTRL_SECRET1_DIGEST_1_OFFSET = 14'h 74;
+  parameter logic [13:0] OTP_CTRL_SECRET2_DIGEST_0_OFFSET = 14'h 78;
+  parameter logic [13:0] OTP_CTRL_SECRET2_DIGEST_1_OFFSET = 14'h 7c;
 
   // Window parameter
   parameter logic [13:0] OTP_CTRL_SW_CFG_WINDOW_OFFSET = 14'h 1000;
@@ -281,8 +280,7 @@ package otp_ctrl_reg_pkg;
     OTP_CTRL_INTR_ENABLE,
     OTP_CTRL_INTR_TEST,
     OTP_CTRL_STATUS,
-    OTP_CTRL_ERR_CODE_0,
-    OTP_CTRL_ERR_CODE_1,
+    OTP_CTRL_ERR_CODE,
     OTP_CTRL_DIRECT_ACCESS_REGWEN,
     OTP_CTRL_DIRECT_ACCESS_CMD,
     OTP_CTRL_DIRECT_ACCESS_ADDRESS,
@@ -313,40 +311,39 @@ package otp_ctrl_reg_pkg;
   } otp_ctrl_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] OTP_CTRL_PERMIT [33] = '{
+  parameter logic [3:0] OTP_CTRL_PERMIT [32] = '{
     4'b 0001, // index[ 0] OTP_CTRL_INTR_STATE
     4'b 0001, // index[ 1] OTP_CTRL_INTR_ENABLE
     4'b 0001, // index[ 2] OTP_CTRL_INTR_TEST
     4'b 0011, // index[ 3] OTP_CTRL_STATUS
-    4'b 1111, // index[ 4] OTP_CTRL_ERR_CODE_0
-    4'b 0001, // index[ 5] OTP_CTRL_ERR_CODE_1
-    4'b 0001, // index[ 6] OTP_CTRL_DIRECT_ACCESS_REGWEN
-    4'b 0001, // index[ 7] OTP_CTRL_DIRECT_ACCESS_CMD
-    4'b 0011, // index[ 8] OTP_CTRL_DIRECT_ACCESS_ADDRESS
-    4'b 1111, // index[ 9] OTP_CTRL_DIRECT_ACCESS_WDATA_0
-    4'b 1111, // index[10] OTP_CTRL_DIRECT_ACCESS_WDATA_1
-    4'b 1111, // index[11] OTP_CTRL_DIRECT_ACCESS_RDATA_0
-    4'b 1111, // index[12] OTP_CTRL_DIRECT_ACCESS_RDATA_1
-    4'b 0001, // index[13] OTP_CTRL_CHECK_TRIGGER_REGWEN
-    4'b 0001, // index[14] OTP_CTRL_CHECK_TRIGGER
-    4'b 0001, // index[15] OTP_CTRL_CHECK_REGWEN
-    4'b 1111, // index[16] OTP_CTRL_CHECK_TIMEOUT
-    4'b 1111, // index[17] OTP_CTRL_INTEGRITY_CHECK_PERIOD
-    4'b 1111, // index[18] OTP_CTRL_CONSISTENCY_CHECK_PERIOD
-    4'b 0001, // index[19] OTP_CTRL_CREATOR_SW_CFG_READ_LOCK
-    4'b 0001, // index[20] OTP_CTRL_OWNER_SW_CFG_READ_LOCK
-    4'b 1111, // index[21] OTP_CTRL_CREATOR_SW_CFG_DIGEST_0
-    4'b 1111, // index[22] OTP_CTRL_CREATOR_SW_CFG_DIGEST_1
-    4'b 1111, // index[23] OTP_CTRL_OWNER_SW_CFG_DIGEST_0
-    4'b 1111, // index[24] OTP_CTRL_OWNER_SW_CFG_DIGEST_1
-    4'b 1111, // index[25] OTP_CTRL_HW_CFG_DIGEST_0
-    4'b 1111, // index[26] OTP_CTRL_HW_CFG_DIGEST_1
-    4'b 1111, // index[27] OTP_CTRL_SECRET0_DIGEST_0
-    4'b 1111, // index[28] OTP_CTRL_SECRET0_DIGEST_1
-    4'b 1111, // index[29] OTP_CTRL_SECRET1_DIGEST_0
-    4'b 1111, // index[30] OTP_CTRL_SECRET1_DIGEST_1
-    4'b 1111, // index[31] OTP_CTRL_SECRET2_DIGEST_0
-    4'b 1111  // index[32] OTP_CTRL_SECRET2_DIGEST_1
+    4'b 1111, // index[ 4] OTP_CTRL_ERR_CODE
+    4'b 0001, // index[ 5] OTP_CTRL_DIRECT_ACCESS_REGWEN
+    4'b 0001, // index[ 6] OTP_CTRL_DIRECT_ACCESS_CMD
+    4'b 0011, // index[ 7] OTP_CTRL_DIRECT_ACCESS_ADDRESS
+    4'b 1111, // index[ 8] OTP_CTRL_DIRECT_ACCESS_WDATA_0
+    4'b 1111, // index[ 9] OTP_CTRL_DIRECT_ACCESS_WDATA_1
+    4'b 1111, // index[10] OTP_CTRL_DIRECT_ACCESS_RDATA_0
+    4'b 1111, // index[11] OTP_CTRL_DIRECT_ACCESS_RDATA_1
+    4'b 0001, // index[12] OTP_CTRL_CHECK_TRIGGER_REGWEN
+    4'b 0001, // index[13] OTP_CTRL_CHECK_TRIGGER
+    4'b 0001, // index[14] OTP_CTRL_CHECK_REGWEN
+    4'b 1111, // index[15] OTP_CTRL_CHECK_TIMEOUT
+    4'b 1111, // index[16] OTP_CTRL_INTEGRITY_CHECK_PERIOD
+    4'b 1111, // index[17] OTP_CTRL_CONSISTENCY_CHECK_PERIOD
+    4'b 0001, // index[18] OTP_CTRL_CREATOR_SW_CFG_READ_LOCK
+    4'b 0001, // index[19] OTP_CTRL_OWNER_SW_CFG_READ_LOCK
+    4'b 1111, // index[20] OTP_CTRL_CREATOR_SW_CFG_DIGEST_0
+    4'b 1111, // index[21] OTP_CTRL_CREATOR_SW_CFG_DIGEST_1
+    4'b 1111, // index[22] OTP_CTRL_OWNER_SW_CFG_DIGEST_0
+    4'b 1111, // index[23] OTP_CTRL_OWNER_SW_CFG_DIGEST_1
+    4'b 1111, // index[24] OTP_CTRL_HW_CFG_DIGEST_0
+    4'b 1111, // index[25] OTP_CTRL_HW_CFG_DIGEST_1
+    4'b 1111, // index[26] OTP_CTRL_SECRET0_DIGEST_0
+    4'b 1111, // index[27] OTP_CTRL_SECRET0_DIGEST_1
+    4'b 1111, // index[28] OTP_CTRL_SECRET1_DIGEST_0
+    4'b 1111, // index[29] OTP_CTRL_SECRET1_DIGEST_1
+    4'b 1111, // index[30] OTP_CTRL_SECRET2_DIGEST_0
+    4'b 1111  // index[31] OTP_CTRL_SECRET2_DIGEST_1
   };
 endpackage
 

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_top.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_top.sv
@@ -167,24 +167,24 @@ module otp_ctrl_reg_top (
   logic status_dai_idle_re;
   logic status_check_pending_qs;
   logic status_check_pending_re;
-  logic [3:0] err_code_0_err_code_0_qs;
-  logic err_code_0_err_code_0_re;
-  logic [3:0] err_code_0_err_code_1_qs;
-  logic err_code_0_err_code_1_re;
-  logic [3:0] err_code_0_err_code_2_qs;
-  logic err_code_0_err_code_2_re;
-  logic [3:0] err_code_0_err_code_3_qs;
-  logic err_code_0_err_code_3_re;
-  logic [3:0] err_code_0_err_code_4_qs;
-  logic err_code_0_err_code_4_re;
-  logic [3:0] err_code_0_err_code_5_qs;
-  logic err_code_0_err_code_5_re;
-  logic [3:0] err_code_0_err_code_6_qs;
-  logic err_code_0_err_code_6_re;
-  logic [3:0] err_code_0_err_code_7_qs;
-  logic err_code_0_err_code_7_re;
-  logic [3:0] err_code_1_qs;
-  logic err_code_1_re;
+  logic [2:0] err_code_err_code_0_qs;
+  logic err_code_err_code_0_re;
+  logic [2:0] err_code_err_code_1_qs;
+  logic err_code_err_code_1_re;
+  logic [2:0] err_code_err_code_2_qs;
+  logic err_code_err_code_2_re;
+  logic [2:0] err_code_err_code_3_qs;
+  logic err_code_err_code_3_re;
+  logic [2:0] err_code_err_code_4_qs;
+  logic err_code_err_code_4_re;
+  logic [2:0] err_code_err_code_5_qs;
+  logic err_code_err_code_5_re;
+  logic [2:0] err_code_err_code_6_qs;
+  logic err_code_err_code_6_re;
+  logic [2:0] err_code_err_code_7_qs;
+  logic err_code_err_code_7_re;
+  logic [2:0] err_code_err_code_8_qs;
+  logic err_code_err_code_8_re;
   logic direct_access_regwen_qs;
   logic direct_access_regwen_re;
   logic direct_access_cmd_read_wd;
@@ -626,143 +626,142 @@ module otp_ctrl_reg_top (
 
 
   // Subregister 0 of Multireg err_code
-  // R[err_code_0]: V(True)
+  // R[err_code]: V(True)
 
-  // F[err_code_0]: 3:0
+  // F[err_code_0]: 2:0
   prim_subreg_ext #(
-    .DW    (4)
-  ) u_err_code_0_err_code_0 (
-    .re     (err_code_0_err_code_0_re),
+    .DW    (3)
+  ) u_err_code_err_code_0 (
+    .re     (err_code_err_code_0_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.err_code[0].d),
     .qre    (),
     .qe     (),
     .q      (),
-    .qs     (err_code_0_err_code_0_qs)
+    .qs     (err_code_err_code_0_qs)
   );
 
 
-  // F[err_code_1]: 7:4
+  // F[err_code_1]: 5:3
   prim_subreg_ext #(
-    .DW    (4)
-  ) u_err_code_0_err_code_1 (
-    .re     (err_code_0_err_code_1_re),
+    .DW    (3)
+  ) u_err_code_err_code_1 (
+    .re     (err_code_err_code_1_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.err_code[1].d),
     .qre    (),
     .qe     (),
     .q      (),
-    .qs     (err_code_0_err_code_1_qs)
+    .qs     (err_code_err_code_1_qs)
   );
 
 
-  // F[err_code_2]: 11:8
+  // F[err_code_2]: 8:6
   prim_subreg_ext #(
-    .DW    (4)
-  ) u_err_code_0_err_code_2 (
-    .re     (err_code_0_err_code_2_re),
+    .DW    (3)
+  ) u_err_code_err_code_2 (
+    .re     (err_code_err_code_2_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.err_code[2].d),
     .qre    (),
     .qe     (),
     .q      (),
-    .qs     (err_code_0_err_code_2_qs)
+    .qs     (err_code_err_code_2_qs)
   );
 
 
-  // F[err_code_3]: 15:12
+  // F[err_code_3]: 11:9
   prim_subreg_ext #(
-    .DW    (4)
-  ) u_err_code_0_err_code_3 (
-    .re     (err_code_0_err_code_3_re),
+    .DW    (3)
+  ) u_err_code_err_code_3 (
+    .re     (err_code_err_code_3_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.err_code[3].d),
     .qre    (),
     .qe     (),
     .q      (),
-    .qs     (err_code_0_err_code_3_qs)
+    .qs     (err_code_err_code_3_qs)
   );
 
 
-  // F[err_code_4]: 19:16
+  // F[err_code_4]: 14:12
   prim_subreg_ext #(
-    .DW    (4)
-  ) u_err_code_0_err_code_4 (
-    .re     (err_code_0_err_code_4_re),
+    .DW    (3)
+  ) u_err_code_err_code_4 (
+    .re     (err_code_err_code_4_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.err_code[4].d),
     .qre    (),
     .qe     (),
     .q      (),
-    .qs     (err_code_0_err_code_4_qs)
+    .qs     (err_code_err_code_4_qs)
   );
 
 
-  // F[err_code_5]: 23:20
+  // F[err_code_5]: 17:15
   prim_subreg_ext #(
-    .DW    (4)
-  ) u_err_code_0_err_code_5 (
-    .re     (err_code_0_err_code_5_re),
+    .DW    (3)
+  ) u_err_code_err_code_5 (
+    .re     (err_code_err_code_5_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.err_code[5].d),
     .qre    (),
     .qe     (),
     .q      (),
-    .qs     (err_code_0_err_code_5_qs)
+    .qs     (err_code_err_code_5_qs)
   );
 
 
-  // F[err_code_6]: 27:24
+  // F[err_code_6]: 20:18
   prim_subreg_ext #(
-    .DW    (4)
-  ) u_err_code_0_err_code_6 (
-    .re     (err_code_0_err_code_6_re),
+    .DW    (3)
+  ) u_err_code_err_code_6 (
+    .re     (err_code_err_code_6_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.err_code[6].d),
     .qre    (),
     .qe     (),
     .q      (),
-    .qs     (err_code_0_err_code_6_qs)
+    .qs     (err_code_err_code_6_qs)
   );
 
 
-  // F[err_code_7]: 31:28
+  // F[err_code_7]: 23:21
   prim_subreg_ext #(
-    .DW    (4)
-  ) u_err_code_0_err_code_7 (
-    .re     (err_code_0_err_code_7_re),
+    .DW    (3)
+  ) u_err_code_err_code_7 (
+    .re     (err_code_err_code_7_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.err_code[7].d),
     .qre    (),
     .qe     (),
     .q      (),
-    .qs     (err_code_0_err_code_7_qs)
+    .qs     (err_code_err_code_7_qs)
   );
 
 
-  // Subregister 8 of Multireg err_code
-  // R[err_code_1]: V(True)
-
+  // F[err_code_8]: 26:24
   prim_subreg_ext #(
-    .DW    (4)
-  ) u_err_code_1 (
-    .re     (err_code_1_re),
+    .DW    (3)
+  ) u_err_code_err_code_8 (
+    .re     (err_code_err_code_8_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.err_code[8].d),
     .qre    (),
     .qe     (),
     .q      (),
-    .qs     (err_code_1_qs)
+    .qs     (err_code_err_code_8_qs)
   );
+
 
 
   // R[direct_access_regwen]: V(True)
@@ -1377,42 +1376,41 @@ module otp_ctrl_reg_top (
 
 
 
-  logic [32:0] addr_hit;
+  logic [31:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == OTP_CTRL_INTR_STATE_OFFSET);
     addr_hit[ 1] = (reg_addr == OTP_CTRL_INTR_ENABLE_OFFSET);
     addr_hit[ 2] = (reg_addr == OTP_CTRL_INTR_TEST_OFFSET);
     addr_hit[ 3] = (reg_addr == OTP_CTRL_STATUS_OFFSET);
-    addr_hit[ 4] = (reg_addr == OTP_CTRL_ERR_CODE_0_OFFSET);
-    addr_hit[ 5] = (reg_addr == OTP_CTRL_ERR_CODE_1_OFFSET);
-    addr_hit[ 6] = (reg_addr == OTP_CTRL_DIRECT_ACCESS_REGWEN_OFFSET);
-    addr_hit[ 7] = (reg_addr == OTP_CTRL_DIRECT_ACCESS_CMD_OFFSET);
-    addr_hit[ 8] = (reg_addr == OTP_CTRL_DIRECT_ACCESS_ADDRESS_OFFSET);
-    addr_hit[ 9] = (reg_addr == OTP_CTRL_DIRECT_ACCESS_WDATA_0_OFFSET);
-    addr_hit[10] = (reg_addr == OTP_CTRL_DIRECT_ACCESS_WDATA_1_OFFSET);
-    addr_hit[11] = (reg_addr == OTP_CTRL_DIRECT_ACCESS_RDATA_0_OFFSET);
-    addr_hit[12] = (reg_addr == OTP_CTRL_DIRECT_ACCESS_RDATA_1_OFFSET);
-    addr_hit[13] = (reg_addr == OTP_CTRL_CHECK_TRIGGER_REGWEN_OFFSET);
-    addr_hit[14] = (reg_addr == OTP_CTRL_CHECK_TRIGGER_OFFSET);
-    addr_hit[15] = (reg_addr == OTP_CTRL_CHECK_REGWEN_OFFSET);
-    addr_hit[16] = (reg_addr == OTP_CTRL_CHECK_TIMEOUT_OFFSET);
-    addr_hit[17] = (reg_addr == OTP_CTRL_INTEGRITY_CHECK_PERIOD_OFFSET);
-    addr_hit[18] = (reg_addr == OTP_CTRL_CONSISTENCY_CHECK_PERIOD_OFFSET);
-    addr_hit[19] = (reg_addr == OTP_CTRL_CREATOR_SW_CFG_READ_LOCK_OFFSET);
-    addr_hit[20] = (reg_addr == OTP_CTRL_OWNER_SW_CFG_READ_LOCK_OFFSET);
-    addr_hit[21] = (reg_addr == OTP_CTRL_CREATOR_SW_CFG_DIGEST_0_OFFSET);
-    addr_hit[22] = (reg_addr == OTP_CTRL_CREATOR_SW_CFG_DIGEST_1_OFFSET);
-    addr_hit[23] = (reg_addr == OTP_CTRL_OWNER_SW_CFG_DIGEST_0_OFFSET);
-    addr_hit[24] = (reg_addr == OTP_CTRL_OWNER_SW_CFG_DIGEST_1_OFFSET);
-    addr_hit[25] = (reg_addr == OTP_CTRL_HW_CFG_DIGEST_0_OFFSET);
-    addr_hit[26] = (reg_addr == OTP_CTRL_HW_CFG_DIGEST_1_OFFSET);
-    addr_hit[27] = (reg_addr == OTP_CTRL_SECRET0_DIGEST_0_OFFSET);
-    addr_hit[28] = (reg_addr == OTP_CTRL_SECRET0_DIGEST_1_OFFSET);
-    addr_hit[29] = (reg_addr == OTP_CTRL_SECRET1_DIGEST_0_OFFSET);
-    addr_hit[30] = (reg_addr == OTP_CTRL_SECRET1_DIGEST_1_OFFSET);
-    addr_hit[31] = (reg_addr == OTP_CTRL_SECRET2_DIGEST_0_OFFSET);
-    addr_hit[32] = (reg_addr == OTP_CTRL_SECRET2_DIGEST_1_OFFSET);
+    addr_hit[ 4] = (reg_addr == OTP_CTRL_ERR_CODE_OFFSET);
+    addr_hit[ 5] = (reg_addr == OTP_CTRL_DIRECT_ACCESS_REGWEN_OFFSET);
+    addr_hit[ 6] = (reg_addr == OTP_CTRL_DIRECT_ACCESS_CMD_OFFSET);
+    addr_hit[ 7] = (reg_addr == OTP_CTRL_DIRECT_ACCESS_ADDRESS_OFFSET);
+    addr_hit[ 8] = (reg_addr == OTP_CTRL_DIRECT_ACCESS_WDATA_0_OFFSET);
+    addr_hit[ 9] = (reg_addr == OTP_CTRL_DIRECT_ACCESS_WDATA_1_OFFSET);
+    addr_hit[10] = (reg_addr == OTP_CTRL_DIRECT_ACCESS_RDATA_0_OFFSET);
+    addr_hit[11] = (reg_addr == OTP_CTRL_DIRECT_ACCESS_RDATA_1_OFFSET);
+    addr_hit[12] = (reg_addr == OTP_CTRL_CHECK_TRIGGER_REGWEN_OFFSET);
+    addr_hit[13] = (reg_addr == OTP_CTRL_CHECK_TRIGGER_OFFSET);
+    addr_hit[14] = (reg_addr == OTP_CTRL_CHECK_REGWEN_OFFSET);
+    addr_hit[15] = (reg_addr == OTP_CTRL_CHECK_TIMEOUT_OFFSET);
+    addr_hit[16] = (reg_addr == OTP_CTRL_INTEGRITY_CHECK_PERIOD_OFFSET);
+    addr_hit[17] = (reg_addr == OTP_CTRL_CONSISTENCY_CHECK_PERIOD_OFFSET);
+    addr_hit[18] = (reg_addr == OTP_CTRL_CREATOR_SW_CFG_READ_LOCK_OFFSET);
+    addr_hit[19] = (reg_addr == OTP_CTRL_OWNER_SW_CFG_READ_LOCK_OFFSET);
+    addr_hit[20] = (reg_addr == OTP_CTRL_CREATOR_SW_CFG_DIGEST_0_OFFSET);
+    addr_hit[21] = (reg_addr == OTP_CTRL_CREATOR_SW_CFG_DIGEST_1_OFFSET);
+    addr_hit[22] = (reg_addr == OTP_CTRL_OWNER_SW_CFG_DIGEST_0_OFFSET);
+    addr_hit[23] = (reg_addr == OTP_CTRL_OWNER_SW_CFG_DIGEST_1_OFFSET);
+    addr_hit[24] = (reg_addr == OTP_CTRL_HW_CFG_DIGEST_0_OFFSET);
+    addr_hit[25] = (reg_addr == OTP_CTRL_HW_CFG_DIGEST_1_OFFSET);
+    addr_hit[26] = (reg_addr == OTP_CTRL_SECRET0_DIGEST_0_OFFSET);
+    addr_hit[27] = (reg_addr == OTP_CTRL_SECRET0_DIGEST_1_OFFSET);
+    addr_hit[28] = (reg_addr == OTP_CTRL_SECRET1_DIGEST_0_OFFSET);
+    addr_hit[29] = (reg_addr == OTP_CTRL_SECRET1_DIGEST_1_OFFSET);
+    addr_hit[30] = (reg_addr == OTP_CTRL_SECRET2_DIGEST_0_OFFSET);
+    addr_hit[31] = (reg_addr == OTP_CTRL_SECRET2_DIGEST_1_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -1452,7 +1450,6 @@ module otp_ctrl_reg_top (
     if (addr_hit[29] && reg_we && (OTP_CTRL_PERMIT[29] != (OTP_CTRL_PERMIT[29] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[30] && reg_we && (OTP_CTRL_PERMIT[30] != (OTP_CTRL_PERMIT[30] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[31] && reg_we && (OTP_CTRL_PERMIT[31] != (OTP_CTRL_PERMIT[31] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[32] && reg_we && (OTP_CTRL_PERMIT[32] != (OTP_CTRL_PERMIT[32] & reg_be))) wr_err = 1'b1 ;
   end
 
   assign intr_state_otp_operation_done_we = addr_hit[0] & reg_we & ~wr_err;
@@ -1503,98 +1500,98 @@ module otp_ctrl_reg_top (
 
   assign status_check_pending_re = addr_hit[3] && reg_re;
 
-  assign err_code_0_err_code_0_re = addr_hit[4] && reg_re;
+  assign err_code_err_code_0_re = addr_hit[4] && reg_re;
 
-  assign err_code_0_err_code_1_re = addr_hit[4] && reg_re;
+  assign err_code_err_code_1_re = addr_hit[4] && reg_re;
 
-  assign err_code_0_err_code_2_re = addr_hit[4] && reg_re;
+  assign err_code_err_code_2_re = addr_hit[4] && reg_re;
 
-  assign err_code_0_err_code_3_re = addr_hit[4] && reg_re;
+  assign err_code_err_code_3_re = addr_hit[4] && reg_re;
 
-  assign err_code_0_err_code_4_re = addr_hit[4] && reg_re;
+  assign err_code_err_code_4_re = addr_hit[4] && reg_re;
 
-  assign err_code_0_err_code_5_re = addr_hit[4] && reg_re;
+  assign err_code_err_code_5_re = addr_hit[4] && reg_re;
 
-  assign err_code_0_err_code_6_re = addr_hit[4] && reg_re;
+  assign err_code_err_code_6_re = addr_hit[4] && reg_re;
 
-  assign err_code_0_err_code_7_re = addr_hit[4] && reg_re;
+  assign err_code_err_code_7_re = addr_hit[4] && reg_re;
 
-  assign err_code_1_re = addr_hit[5] && reg_re;
+  assign err_code_err_code_8_re = addr_hit[4] && reg_re;
 
-  assign direct_access_regwen_re = addr_hit[6] && reg_re;
+  assign direct_access_regwen_re = addr_hit[5] && reg_re;
 
-  assign direct_access_cmd_read_we = addr_hit[7] & reg_we & ~wr_err;
+  assign direct_access_cmd_read_we = addr_hit[6] & reg_we & ~wr_err;
   assign direct_access_cmd_read_wd = reg_wdata[0];
 
-  assign direct_access_cmd_write_we = addr_hit[7] & reg_we & ~wr_err;
+  assign direct_access_cmd_write_we = addr_hit[6] & reg_we & ~wr_err;
   assign direct_access_cmd_write_wd = reg_wdata[1];
 
-  assign direct_access_cmd_digest_we = addr_hit[7] & reg_we & ~wr_err;
+  assign direct_access_cmd_digest_we = addr_hit[6] & reg_we & ~wr_err;
   assign direct_access_cmd_digest_wd = reg_wdata[2];
 
-  assign direct_access_address_we = addr_hit[8] & reg_we & ~wr_err;
+  assign direct_access_address_we = addr_hit[7] & reg_we & ~wr_err;
   assign direct_access_address_wd = reg_wdata[10:0];
 
-  assign direct_access_wdata_0_we = addr_hit[9] & reg_we & ~wr_err;
+  assign direct_access_wdata_0_we = addr_hit[8] & reg_we & ~wr_err;
   assign direct_access_wdata_0_wd = reg_wdata[31:0];
 
-  assign direct_access_wdata_1_we = addr_hit[10] & reg_we & ~wr_err;
+  assign direct_access_wdata_1_we = addr_hit[9] & reg_we & ~wr_err;
   assign direct_access_wdata_1_wd = reg_wdata[31:0];
 
-  assign direct_access_rdata_0_re = addr_hit[11] && reg_re;
+  assign direct_access_rdata_0_re = addr_hit[10] && reg_re;
 
-  assign direct_access_rdata_1_re = addr_hit[12] && reg_re;
+  assign direct_access_rdata_1_re = addr_hit[11] && reg_re;
 
-  assign check_trigger_regwen_we = addr_hit[13] & reg_we & ~wr_err;
+  assign check_trigger_regwen_we = addr_hit[12] & reg_we & ~wr_err;
   assign check_trigger_regwen_wd = reg_wdata[0];
 
-  assign check_trigger_integrity_we = addr_hit[14] & reg_we & ~wr_err;
+  assign check_trigger_integrity_we = addr_hit[13] & reg_we & ~wr_err;
   assign check_trigger_integrity_wd = reg_wdata[0];
 
-  assign check_trigger_consistency_we = addr_hit[14] & reg_we & ~wr_err;
+  assign check_trigger_consistency_we = addr_hit[13] & reg_we & ~wr_err;
   assign check_trigger_consistency_wd = reg_wdata[1];
 
-  assign check_regwen_we = addr_hit[15] & reg_we & ~wr_err;
+  assign check_regwen_we = addr_hit[14] & reg_we & ~wr_err;
   assign check_regwen_wd = reg_wdata[0];
 
-  assign check_timeout_we = addr_hit[16] & reg_we & ~wr_err;
+  assign check_timeout_we = addr_hit[15] & reg_we & ~wr_err;
   assign check_timeout_wd = reg_wdata[31:0];
 
-  assign integrity_check_period_we = addr_hit[17] & reg_we & ~wr_err;
+  assign integrity_check_period_we = addr_hit[16] & reg_we & ~wr_err;
   assign integrity_check_period_wd = reg_wdata[31:0];
 
-  assign consistency_check_period_we = addr_hit[18] & reg_we & ~wr_err;
+  assign consistency_check_period_we = addr_hit[17] & reg_we & ~wr_err;
   assign consistency_check_period_wd = reg_wdata[31:0];
 
-  assign creator_sw_cfg_read_lock_we = addr_hit[19] & reg_we & ~wr_err;
+  assign creator_sw_cfg_read_lock_we = addr_hit[18] & reg_we & ~wr_err;
   assign creator_sw_cfg_read_lock_wd = reg_wdata[0];
 
-  assign owner_sw_cfg_read_lock_we = addr_hit[20] & reg_we & ~wr_err;
+  assign owner_sw_cfg_read_lock_we = addr_hit[19] & reg_we & ~wr_err;
   assign owner_sw_cfg_read_lock_wd = reg_wdata[0];
 
-  assign creator_sw_cfg_digest_0_re = addr_hit[21] && reg_re;
+  assign creator_sw_cfg_digest_0_re = addr_hit[20] && reg_re;
 
-  assign creator_sw_cfg_digest_1_re = addr_hit[22] && reg_re;
+  assign creator_sw_cfg_digest_1_re = addr_hit[21] && reg_re;
 
-  assign owner_sw_cfg_digest_0_re = addr_hit[23] && reg_re;
+  assign owner_sw_cfg_digest_0_re = addr_hit[22] && reg_re;
 
-  assign owner_sw_cfg_digest_1_re = addr_hit[24] && reg_re;
+  assign owner_sw_cfg_digest_1_re = addr_hit[23] && reg_re;
 
-  assign hw_cfg_digest_0_re = addr_hit[25] && reg_re;
+  assign hw_cfg_digest_0_re = addr_hit[24] && reg_re;
 
-  assign hw_cfg_digest_1_re = addr_hit[26] && reg_re;
+  assign hw_cfg_digest_1_re = addr_hit[25] && reg_re;
 
-  assign secret0_digest_0_re = addr_hit[27] && reg_re;
+  assign secret0_digest_0_re = addr_hit[26] && reg_re;
 
-  assign secret0_digest_1_re = addr_hit[28] && reg_re;
+  assign secret0_digest_1_re = addr_hit[27] && reg_re;
 
-  assign secret1_digest_0_re = addr_hit[29] && reg_re;
+  assign secret1_digest_0_re = addr_hit[28] && reg_re;
 
-  assign secret1_digest_1_re = addr_hit[30] && reg_re;
+  assign secret1_digest_1_re = addr_hit[29] && reg_re;
 
-  assign secret2_digest_0_re = addr_hit[31] && reg_re;
+  assign secret2_digest_0_re = addr_hit[30] && reg_re;
 
-  assign secret2_digest_1_re = addr_hit[32] && reg_re;
+  assign secret2_digest_1_re = addr_hit[31] && reg_re;
 
   // Read data return
   always_comb begin
@@ -1634,128 +1631,125 @@ module otp_ctrl_reg_top (
       end
 
       addr_hit[4]: begin
-        reg_rdata_next[3:0] = err_code_0_err_code_0_qs;
-        reg_rdata_next[7:4] = err_code_0_err_code_1_qs;
-        reg_rdata_next[11:8] = err_code_0_err_code_2_qs;
-        reg_rdata_next[15:12] = err_code_0_err_code_3_qs;
-        reg_rdata_next[19:16] = err_code_0_err_code_4_qs;
-        reg_rdata_next[23:20] = err_code_0_err_code_5_qs;
-        reg_rdata_next[27:24] = err_code_0_err_code_6_qs;
-        reg_rdata_next[31:28] = err_code_0_err_code_7_qs;
+        reg_rdata_next[2:0] = err_code_err_code_0_qs;
+        reg_rdata_next[5:3] = err_code_err_code_1_qs;
+        reg_rdata_next[8:6] = err_code_err_code_2_qs;
+        reg_rdata_next[11:9] = err_code_err_code_3_qs;
+        reg_rdata_next[14:12] = err_code_err_code_4_qs;
+        reg_rdata_next[17:15] = err_code_err_code_5_qs;
+        reg_rdata_next[20:18] = err_code_err_code_6_qs;
+        reg_rdata_next[23:21] = err_code_err_code_7_qs;
+        reg_rdata_next[26:24] = err_code_err_code_8_qs;
       end
 
       addr_hit[5]: begin
-        reg_rdata_next[3:0] = err_code_1_qs;
-      end
-
-      addr_hit[6]: begin
         reg_rdata_next[0] = direct_access_regwen_qs;
       end
 
-      addr_hit[7]: begin
+      addr_hit[6]: begin
         reg_rdata_next[0] = '0;
         reg_rdata_next[1] = '0;
         reg_rdata_next[2] = '0;
       end
 
-      addr_hit[8]: begin
+      addr_hit[7]: begin
         reg_rdata_next[10:0] = direct_access_address_qs;
       end
 
-      addr_hit[9]: begin
+      addr_hit[8]: begin
         reg_rdata_next[31:0] = direct_access_wdata_0_qs;
       end
 
-      addr_hit[10]: begin
+      addr_hit[9]: begin
         reg_rdata_next[31:0] = direct_access_wdata_1_qs;
       end
 
-      addr_hit[11]: begin
+      addr_hit[10]: begin
         reg_rdata_next[31:0] = direct_access_rdata_0_qs;
       end
 
-      addr_hit[12]: begin
+      addr_hit[11]: begin
         reg_rdata_next[31:0] = direct_access_rdata_1_qs;
       end
 
-      addr_hit[13]: begin
+      addr_hit[12]: begin
         reg_rdata_next[0] = check_trigger_regwen_qs;
       end
 
-      addr_hit[14]: begin
+      addr_hit[13]: begin
         reg_rdata_next[0] = '0;
         reg_rdata_next[1] = '0;
       end
 
-      addr_hit[15]: begin
+      addr_hit[14]: begin
         reg_rdata_next[0] = check_regwen_qs;
       end
 
-      addr_hit[16]: begin
+      addr_hit[15]: begin
         reg_rdata_next[31:0] = check_timeout_qs;
       end
 
-      addr_hit[17]: begin
+      addr_hit[16]: begin
         reg_rdata_next[31:0] = integrity_check_period_qs;
       end
 
-      addr_hit[18]: begin
+      addr_hit[17]: begin
         reg_rdata_next[31:0] = consistency_check_period_qs;
       end
 
-      addr_hit[19]: begin
+      addr_hit[18]: begin
         reg_rdata_next[0] = creator_sw_cfg_read_lock_qs;
       end
 
-      addr_hit[20]: begin
+      addr_hit[19]: begin
         reg_rdata_next[0] = owner_sw_cfg_read_lock_qs;
       end
 
-      addr_hit[21]: begin
+      addr_hit[20]: begin
         reg_rdata_next[31:0] = creator_sw_cfg_digest_0_qs;
       end
 
-      addr_hit[22]: begin
+      addr_hit[21]: begin
         reg_rdata_next[31:0] = creator_sw_cfg_digest_1_qs;
       end
 
-      addr_hit[23]: begin
+      addr_hit[22]: begin
         reg_rdata_next[31:0] = owner_sw_cfg_digest_0_qs;
       end
 
-      addr_hit[24]: begin
+      addr_hit[23]: begin
         reg_rdata_next[31:0] = owner_sw_cfg_digest_1_qs;
       end
 
-      addr_hit[25]: begin
+      addr_hit[24]: begin
         reg_rdata_next[31:0] = hw_cfg_digest_0_qs;
       end
 
-      addr_hit[26]: begin
+      addr_hit[25]: begin
         reg_rdata_next[31:0] = hw_cfg_digest_1_qs;
       end
 
-      addr_hit[27]: begin
+      addr_hit[26]: begin
         reg_rdata_next[31:0] = secret0_digest_0_qs;
       end
 
-      addr_hit[28]: begin
+      addr_hit[27]: begin
         reg_rdata_next[31:0] = secret0_digest_1_qs;
       end
 
-      addr_hit[29]: begin
+      addr_hit[28]: begin
         reg_rdata_next[31:0] = secret1_digest_0_qs;
       end
 
-      addr_hit[30]: begin
+      addr_hit[29]: begin
         reg_rdata_next[31:0] = secret1_digest_1_qs;
       end
 
-      addr_hit[31]: begin
+      addr_hit[30]: begin
         reg_rdata_next[31:0] = secret2_digest_0_qs;
       end
 
-      addr_hit[32]: begin
+      addr_hit[31]: begin
         reg_rdata_next[31:0] = secret2_digest_1_qs;
       end
 

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -2642,13 +2642,13 @@
       alert_list:
       [
         {
-          name: otp_fatal_error
+          name: otp_macro_failure
           width: 1
           type: alert
           async: 1
         }
         {
-          name: otp_check_failed
+          name: otp_check_failure
           width: 1
           type: alert
           async: 1
@@ -5073,14 +5073,14 @@
       module_name: keymgr
     }
     {
-      name: otp_ctrl_otp_fatal_error
+      name: otp_ctrl_otp_macro_failure
       width: 1
       type: alert
       async: 1
       module_name: otp_ctrl
     }
     {
-      name: otp_ctrl_otp_check_failed
+      name: otp_ctrl_otp_check_failure
       width: 1
       type: alert
       async: 1

--- a/hw/top_earlgrey/dv/env/autogen/alert_handler_env_pkg__params.sv
+++ b/hw/top_earlgrey/dv/env/autogen/alert_handler_env_pkg__params.sv
@@ -12,8 +12,8 @@ parameter string LIST_OF_ALERTS[] = {
   "otbn_reg_uncorrectable",
   "sensor_ctrl_ast_alerts",
   "keymgr_err",
-  "otp_ctrl_otp_fatal_error",
-  "otp_ctrl_otp_check_failed"
+  "otp_ctrl_otp_macro_failure",
+  "otp_ctrl_otp_check_failure"
 };
 
 parameter uint NUM_ALERTS = 9;

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -1013,8 +1013,8 @@ module top_earlgrey #(
       .intr_otp_operation_done_o (intr_otp_ctrl_otp_operation_done),
       .intr_otp_error_o          (intr_otp_ctrl_otp_error),
 
-      // [10]: otp_fatal_error
-      // [11]: otp_check_failed
+      // [10]: otp_macro_failure
+      // [11]: otp_check_failure
       .alert_tx_o  ( alert_tx[11:10] ),
       .alert_rx_i  ( alert_rx[11:10] ),
 

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.c
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.c
@@ -120,7 +120,7 @@ const top_earlgrey_alert_peripheral_t
   [kTopEarlgreyAlertIdSensorCtrlAstAlerts5] = kTopEarlgreyAlertPeripheralSensorCtrl,
   [kTopEarlgreyAlertIdSensorCtrlAstAlerts6] = kTopEarlgreyAlertPeripheralSensorCtrl,
   [kTopEarlgreyAlertIdKeymgrErr] = kTopEarlgreyAlertPeripheralKeymgr,
-  [kTopEarlgreyAlertIdOtpCtrlOtpFatalError] = kTopEarlgreyAlertPeripheralOtpCtrl,
-  [kTopEarlgreyAlertIdOtpCtrlOtpCheckFailed] = kTopEarlgreyAlertPeripheralOtpCtrl,
+  [kTopEarlgreyAlertIdOtpCtrlOtpMacroFailure] = kTopEarlgreyAlertPeripheralOtpCtrl,
+  [kTopEarlgreyAlertIdOtpCtrlOtpCheckFailure] = kTopEarlgreyAlertPeripheralOtpCtrl,
 };
 

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -599,8 +599,8 @@ typedef enum top_earlgrey_alert_id {
   kTopEarlgreyAlertIdSensorCtrlAstAlerts5 = 10, /**< sensor_ctrl_ast_alerts 5 */
   kTopEarlgreyAlertIdSensorCtrlAstAlerts6 = 11, /**< sensor_ctrl_ast_alerts 6 */
   kTopEarlgreyAlertIdKeymgrErr = 12, /**< keymgr_err */
-  kTopEarlgreyAlertIdOtpCtrlOtpFatalError = 13, /**< otp_ctrl_otp_fatal_error */
-  kTopEarlgreyAlertIdOtpCtrlOtpCheckFailed = 14, /**< otp_ctrl_otp_check_failed */
+  kTopEarlgreyAlertIdOtpCtrlOtpMacroFailure = 13, /**< otp_ctrl_otp_macro_failure */
+  kTopEarlgreyAlertIdOtpCtrlOtpCheckFailure = 14, /**< otp_ctrl_otp_check_failure */
   kTopEarlgreyAlertIdLast = 14, /**< \internal The Last Valid Alert ID. */
 } top_earlgrey_alert_id_t;
 

--- a/sw/device/lib/dif/dif_otp_ctrl.h
+++ b/sw/device/lib/dif/dif_otp_ctrl.h
@@ -281,7 +281,7 @@ typedef uint32_t dif_otp_ctrl_irq_snapshot_t;
  */
 typedef enum dif_otp_ctrl_status_code {
   // NOTE: This enum's API *requires* that all "error"-like codes (that is,
-  // those which have associated cause registrers) be a prefix of the enum
+  // those which have associated cause registers) be a prefix of the enum
   // values.
   //
   // Note furthermore that these enum variants are intended as bit indices, so
@@ -378,76 +378,47 @@ typedef enum dif_otp_ctrl_error {
    */
   kDifOtpCtrlErrorOk,
   /**
-   * Indicates an invalid command was issued by hardware.
+   * Indicates that an OTP macro command was invalid or did not
+   * complete successfully.
    *
    * This error indicates non-recoverable hardware malfunction.
    */
-  kDifOtpCtrlErrorInvalidHwCommand,
-  /**
-   * Indicates that the hardware initialization sequence failed.
-   *
-   * This error indicates non-recoverable hardware malfunction.
-   */
-  kDifOtpCtrlErrorFailedInit,
+  kDifOtpCtrlErrorMacroUnspecified,
   /**
    * Indicates a recoverable error during a read operation.
    *
    * A followup read should work as expected.
    */
-  kDifOtpCtrlErrorRecoverableRead,
+  kDifOtpCtrlErrorMacroRecoverableRead,
   /**
    * Indicates an unrecoverable error during a read operation.
    *
    * This error indicates non-recoverable hardware malfunction.
    */
-  kDifOtpCtrlErrorUnrecoverableRead,
-  /**
-   * Indicates an unspecified error during a read operation.
-   *
-   * This error indicates non-recoverable hardware malfunction.
-   */
-  kDifOtpCtrlErrorUnspecifiedRead,
+  kDifOtpCtrlErrorMacroUnrecoverableRead,
   /**
    * Indicates that the blank write check failed during a write operation.
    */
-  kDifOtpCtrlErrorBlankCheckFailed,
-  /**
-   * Indicates an unspecified error during a write operation.
-   *
-   * This error indicates non-recoverable hardware malfunction.
-   */
-  kDifOtpCtrlErrorUnspecifiedWrite,
-  /**
-   * Indicates an invalid command was issued to the DAI.
-   */
-  kDifOtpCtrlErrorInvalidDaiCommand,
+  kDifOtpCtrlErrorMacroBlankCheckFailed,
   /**
    * Indicates a locked memory region was accessed.
    */
   kDifOtpCtrlErrorLockedAccess,
   /**
-   * Indicates an integrity check failed in the buffer registers.
+   * Indicates a parity, integrity or consistency check failed in the buffer
+   * registers.
    *
    * This error indicates non-recoverable hardware malfunction.
    */
-  kDifOtpCtrlErrorIntegrityLoss,
+  kDifOtpCtrlErrorBackgroundCheckFailed,
   /**
-   * Indicates a consistency check failed in the buffer registers.
-   *
-   * This error indicates non-recoverable hardware malfunction.
-   */
-  kDifOtpCtrlErrorConsistencyLoss,
-  /**
-   * Indicates that the FSM of the controller is in a bad state.
+   * Indicates that the FSM of the controller is in a bad state or that the
+   * controller's FSM has been moved into its terminal state due to escalation
+   * via the alert subsystem.
    *
    * This error indicates that the device has been glitched by an attacker.
    */
   kDifOtpCtrlErrorFsmBadState,
-  /**
-   * Indicates that an escalation occured in the alert subsystem, and the
-   * controller's FSM is in its terminal state.
-   */
-  kDifOtpCtrlErrorFsmTerminalState,
 } dif_otp_ctrl_error_t;
 
 /**


### PR DESCRIPTION
This is an attempt to consolidate the OTP error codes and simplify the OTP error reporting.
In particular, the number of codes has been reduced from 15 to 8. This should lessen the burden on DV somewhat, and it streamlines the error codes CSR, since all partition/DAI/LCI error codes now fit into a single 32bit word.

@cindychip @mcy sorry for yet another CSR change. Let me know if this works for you.

Note that this also fixes the TL-UL window sizes (as reported in https://github.com/lowRISC/opentitan/issues/3797).