### PR TITLE
[otbn] Fix otbn-as for input files that don't end with a newline

### DIFF
--- a/hw/ip/otbn/util/otbn-as
+++ b/hw/ip/otbn/util/otbn-as
@@ -1040,6 +1040,11 @@ class Transformer:
         pos = 0
         self.line_number += 1
 
+        # Append a newline if the line doesn't have one. In practice, this just
+        # happens with the last line of a file that doesn't end with a newline.
+        if line and line[-1] != '\n':
+            line = line + '\n'
+
         # Finish up any block comment
         if self.in_comment:
             # Strings can't contain nested comments


### PR DESCRIPTION
Obviously, such files are evil and should be banned :-) But we
probably shouldn't explode when reading them.

Triggered by code in PR #3823.