### PR TITLE
[rom_ext] ROM_EXT Parser: Image Extents

### DIFF
--- a/sw/device/rom_exts/rom_ext_manifest_parser.c
+++ b/sw/device/rom_exts/rom_ext_manifest_parser.c
@@ -52,8 +52,17 @@ bool rom_ext_get_signature(rom_ext_manifest_t params,
   return true;
 }
 
-uint32_t rom_ext_get_image_len(rom_ext_manifest_t params) {
-  return mmio_region_read32(params.base_addr, ROM_EXT_IMAGE_LENGTH_OFFSET);
+rom_ext_ranges_t rom_ext_get_ranges(rom_ext_manifest_t params) {
+  uintptr_t image_length =
+      mmio_region_read32(params.base_addr, ROM_EXT_IMAGE_LENGTH_OFFSET);
+
+  rom_ext_ranges_t ranges = {
+      .image_start = params.slot,
+      .signed_area_start = params.slot + ROM_EXT_SIGNED_AREA_START_OFFSET,
+      .image_end = params.slot + image_length,
+  };
+
+  return ranges;
 }
 
 uint32_t rom_ext_get_version(rom_ext_manifest_t params) {

--- a/sw/device/tests/rom_ext/rom_ext_parser_unittest.cc
+++ b/sw/device/tests/rom_ext/rom_ext_parser_unittest.cc
@@ -66,11 +66,31 @@ TEST_F(SignatureGetTest, Success) {
   EXPECT_THAT(src_.data, ElementsAreArray(dst.data));
 }
 
-class ImageLengthGetTest : public ParserTest {};
+class RangesGetTest : public ParserTest {
+ protected:
+  testing::Matcher<rom_ext_ranges_t> EqualsRanges(const rom_ext_ranges_t &rhs) {
+    return testing::AllOf(
+        testing::Field("image_start", &rom_ext_ranges_t::image_start,
+                       rhs.image_start),
+        testing::Field("signed_area_start",
+                       &rom_ext_ranges_t::signed_area_start,
+                       rhs.signed_area_start),
+        testing::Field("image_end", &rom_ext_ranges_t::image_end,
+                       rhs.image_end));
+  }
+};
 
-TEST_F(ImageLengthGetTest, Success) {
+TEST_F(RangesGetTest, Success) {
   EXPECT_READ32(ROM_EXT_IMAGE_LENGTH_OFFSET, 0xa5a5a5a5);
-  EXPECT_EQ(rom_ext_get_image_len(params_), 0xa5a5a5a5);
+
+  rom_ext_ranges_t expected = {
+      .image_start = kRomExtManifestSlotA,
+      .signed_area_start =
+          kRomExtManifestSlotA + ROM_EXT_SIGNED_AREA_START_OFFSET,
+      .image_end = kRomExtManifestSlotA + 0xa5a5a5a5,
+  };
+
+  EXPECT_THAT(rom_ext_get_ranges(params_), EqualsRanges(expected));
 }
 
 class ImageVersionGetTest : public ParserTest {};


### PR DESCRIPTION
This change adds an accessor for the image extents, which computes useful offsets within the image:
- The Image Start
- The Start of the Signed Area
- The End of the Image (which is the End of the Signed Area)

The latter one of these is the complex issue, because it is calculated from the image length, which is stored in the image and user-provided. This code does no checking of the calculated value, a caller must check this value has not overflowed, and is within the expected extents of the slot.

This is FAO @alphan and @jon-flatley who need this information when calculating the digest of the ROM_EXT image.