### PR TITLE
[clkmgr] Initial Clock Manager DIF

### DIFF
--- a/hw/top_earlgrey/data/top_earlgrey.h.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.h.tpl
@@ -159,6 +159,20 @@ ${helper.rstmgr_sw_rsts.render()}
  */
 ${helper.pwrmgr_reset_requests.render()}
 
+/**
+ * Clock Manager Software-Controlled ("Gated") Clocks.
+ *
+ * The Software has full control over these clocks.
+ */
+${helper.clkmgr_gateable_clocks.render()}
+
+/**
+ * Clock Manager Software-Hinted Clocks.
+ *
+ * The Software has partial control over these clocks. It can ask them to stop,
+ * but the clock manager is in control of whether the clock actually is stopped.
+ */
+${helper.clkmgr_hintable_clocks.render()}
 
 // Header Extern Guard
 #ifdef __cplusplus

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -830,6 +830,30 @@ typedef enum top_earlgrey_power_manager_reset_requests {
   kTopEarlgreyPowerManagerResetRequestsLast = 0, /**< \internal Last valid pwrmgr reset_request signal */
 } top_earlgrey_power_manager_reset_requests_t;
 
+/**
+ * Clock Manager Software-Controlled ("Gated") Clocks.
+ *
+ * The Software has full control over these clocks.
+ */
+typedef enum top_earlgrey_gateable_clocks {
+  kTopEarlgreyGateableClocksIoDiv4Peri = 0, /**< Clock clk_io_div4_peri in group peri */
+  kTopEarlgreyGateableClocksUsbPeri = 1, /**< Clock clk_usb_peri in group peri */
+  kTopEarlgreyGateableClocksLast = 1, /**< \internal Last Valid Gateable Clock */
+} top_earlgrey_gateable_clocks_t;
+
+/**
+ * Clock Manager Software-Hinted Clocks.
+ *
+ * The Software has partial control over these clocks. It can ask them to stop,
+ * but the clock manager is in control of whether the clock actually is stopped.
+ */
+typedef enum top_earlgrey_hintable_clocks {
+  kTopEarlgreyHintableClocksMainAes = 0, /**< Clock clk_main_aes in group trans */
+  kTopEarlgreyHintableClocksMainHmac = 1, /**< Clock clk_main_hmac in group trans */
+  kTopEarlgreyHintableClocksMainKmac = 2, /**< Clock clk_main_kmac in group trans */
+  kTopEarlgreyHintableClocksMainOtbn = 3, /**< Clock clk_main_otbn in group trans */
+  kTopEarlgreyHintableClocksLast = 3, /**< \internal Last Valid Hintable Clock */
+} top_earlgrey_hintable_clocks_t;
 
 // Header Extern Guard
 #ifdef __cplusplus

--- a/meson.build
+++ b/meson.build
@@ -168,6 +168,7 @@ gen_hw_hdr = generator(
 # TODO: Considering moving these into hw/ip directories.
 hw_ip_aes_reg_h = gen_hw_hdr.process('hw/ip/aes/data/aes.hjson')
 hw_ip_alert_handler_reg_h = gen_hw_hdr.process('hw/ip/alert_handler/data/alert_handler.hjson')
+hw_ip_clkgmr_reg_h = gen_hw_hdr.process('hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson')
 hw_ip_flash_ctrl_reg_h = gen_hw_hdr.process('hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson')
 hw_ip_gpio_reg_h = gen_hw_hdr.process('hw/ip/gpio/data/gpio.hjson')
 hw_ip_hmac_reg_h = gen_hw_hdr.process('hw/ip/hmac/data/hmac.hjson')

--- a/sw/device/lib/dif/dif_clkmgr.c
+++ b/sw/device/lib/dif/dif_clkmgr.c
@@ -1,0 +1,9 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/dif/dif_clkmgr.h"
+
+#include "clkmgr_regs.h"  // Generated
+
+#error "Clock Manager DIF Implementation Incomplete"

--- a/sw/device/lib/dif/dif_clkmgr.c
+++ b/sw/device/lib/dif/dif_clkmgr.c
@@ -3,7 +3,145 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sw/device/lib/dif/dif_clkmgr.h"
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/mmio.h"
 
 #include "clkmgr_regs.h"  // Generated
 
-#error "Clock Manager DIF Implementation Incomplete"
+static bool clkmgr_valid_gateable_clock(dif_clkmgr_params_t params,
+                                        dif_clkmgr_gateable_clock_t clock) {
+  // TODO For the moment, last_gateable_clocks has to be less than 32, as we
+  // only support one enable register for gateable clocks.
+  // https://github.com/lowRISC/opentitan/issues/4201
+  return (clock <= params.last_gateable_clock) &&
+         (params.last_gateable_clock < CLKMGR_PARAM_REG_WIDTH);
+}
+
+static bool clkmgr_valid_hintable_clock(dif_clkmgr_params_t params,
+                                        dif_clkmgr_hintable_clock_t clock) {
+  // TODO: For the moment, last_hintable_clocks has to be less than 32, as we
+  // only support one enable/hint_status register for hintable clocks.
+  // https://github.com/lowRISC/opentitan/issues/4201
+  return (clock <= params.last_hintable_clock) &&
+         (params.last_hintable_clock < CLKMGR_PARAM_REG_WIDTH);
+}
+
+dif_clkmgr_result_t dif_clkmgr_init(dif_clkmgr_params_t params,
+                                    dif_clkmgr_t *handle) {
+  if (handle == NULL) {
+    return kDifClkmgrBadArg;
+  }
+
+  // TODO: For the moment, `last_hintable_clock` and `last_gateable_clock` has
+  // to be less than 32, as we only support one register of bits for each.
+  // https://github.com/lowRISC/opentitan/issues/4201
+  if (params.last_gateable_clock >= CLKMGR_PARAM_REG_WIDTH ||
+      params.last_hintable_clock >= CLKMGR_PARAM_REG_WIDTH) {
+    return kDifClkmgrBadArg;
+  }
+
+  handle->params = params;
+  return kDifClkmgrOk;
+}
+
+dif_clkmgr_result_t dif_clkmgr_gateable_clock_get_enabled(
+    const dif_clkmgr_t *handle, dif_clkmgr_gateable_clock_t clock,
+    bool *is_enabled) {
+  if (handle == NULL || is_enabled == NULL ||
+      !clkmgr_valid_gateable_clock(handle->params, clock)) {
+    return kDifClkmgrBadArg;
+  }
+
+  uint32_t clk_enables_val = mmio_region_read32(handle->params.base_addr,
+                                                CLKMGR_CLK_ENABLES_REG_OFFSET);
+  *is_enabled = bitfield_bit32_read(clk_enables_val, clock);
+
+  return kDifClkmgrOk;
+}
+
+dif_clkmgr_result_t dif_clkmgr_gateable_clock_set_enabled(
+    const dif_clkmgr_t *handle, dif_clkmgr_gateable_clock_t clock,
+    dif_clkmgr_toggle_t new_state) {
+  if (handle == NULL || !clkmgr_valid_gateable_clock(handle->params, clock)) {
+    return kDifClkmgrBadArg;
+  }
+
+  bool new_clk_enables_bit;
+  switch (new_state) {
+    case kDifClkmgrToggleEnabled:
+      new_clk_enables_bit = true;
+      break;
+    case kDifClkmgrToggleDisabled:
+      new_clk_enables_bit = false;
+      break;
+    default:
+      return kDifClkmgrBadArg;
+  }
+
+  uint32_t clk_enables_val = mmio_region_read32(handle->params.base_addr,
+                                                CLKMGR_CLK_ENABLES_REG_OFFSET);
+  clk_enables_val =
+      bitfield_bit32_write(clk_enables_val, clock, new_clk_enables_bit);
+  mmio_region_write32(handle->params.base_addr, CLKMGR_CLK_ENABLES_REG_OFFSET,
+                      clk_enables_val);
+
+  return kDifClkmgrOk;
+}
+
+dif_clkmgr_result_t dif_clkmgr_hintable_clock_get_enabled(
+    const dif_clkmgr_t *handle, dif_clkmgr_hintable_clock_t clock,
+    bool *is_enabled) {
+  if (handle == NULL || is_enabled == NULL ||
+      !clkmgr_valid_hintable_clock(handle->params, clock)) {
+    return kDifClkmgrBadArg;
+  }
+
+  uint32_t clk_hints_val = mmio_region_read32(
+      handle->params.base_addr, CLKMGR_CLK_HINTS_STATUS_REG_OFFSET);
+  *is_enabled = bitfield_bit32_read(clk_hints_val, clock);
+
+  return kDifClkmgrOk;
+}
+
+dif_clkmgr_result_t dif_clkmgr_hintable_clock_set_hint(
+    const dif_clkmgr_t *handle, dif_clkmgr_hintable_clock_t clock,
+    dif_clkmgr_toggle_t new_state) {
+  if (handle == NULL || !clkmgr_valid_hintable_clock(handle->params, clock)) {
+    return kDifClkmgrBadArg;
+  }
+
+  bool new_clk_hints_bit;
+  switch (new_state) {
+    case kDifClkmgrToggleEnabled:
+      new_clk_hints_bit = true;
+      break;
+    case kDifClkmgrToggleDisabled:
+      new_clk_hints_bit = false;
+      break;
+    default:
+      return kDifClkmgrBadArg;
+  }
+
+  uint32_t clk_hints_val =
+      mmio_region_read32(handle->params.base_addr, CLKMGR_CLK_HINTS_REG_OFFSET);
+  clk_hints_val = bitfield_bit32_write(clk_hints_val, clock, new_clk_hints_bit);
+  mmio_region_write32(handle->params.base_addr, CLKMGR_CLK_HINTS_REG_OFFSET,
+                      clk_hints_val);
+
+  return kDifClkmgrOk;
+}
+
+dif_clkmgr_result_t dif_clkmgr_hintable_clock_get_hint(
+    const dif_clkmgr_t *handle, dif_clkmgr_hintable_clock_t clock,
+    bool *hinted_is_enabled) {
+  if (handle == NULL || hinted_is_enabled == NULL ||
+      !clkmgr_valid_hintable_clock(handle->params, clock)) {
+    return kDifClkmgrBadArg;
+  }
+
+  uint32_t clk_hints_val =
+      mmio_region_read32(handle->params.base_addr, CLKMGR_CLK_HINTS_REG_OFFSET);
+  *hinted_is_enabled = bitfield_bit32_read(clk_hints_val, clock);
+
+  return kDifClkmgrOk;
+}

--- a/sw/device/lib/dif/dif_clkmgr.h
+++ b/sw/device/lib/dif/dif_clkmgr.h
@@ -1,0 +1,205 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_DIF_CLKMGR_H_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_DIF_CLKMGR_H_
+
+/**
+ * @file
+ * @brief <a href="/hw/ip/clkmgr/doc/">Clock manager</a> Device Interface
+ * Functions
+ */
+
+#include <stdint.h>
+
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_warn_unused_result.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * A toggle state: enabled, or disabled.
+ *
+ * This enum may be used instead of a `bool` when describing an enabled/disabled
+ * state.
+ */
+typedef enum dif_clkmgr_toggle {
+  /*
+   * The "enabled" state.
+   */
+  kDifClkmgrToggleEnabled,
+  /**
+   * The "disabled" state.
+   */
+  kDifClkmgrToggleDisabled,
+} dif_clkmgr_toggle_t;
+
+/**
+ * Hardware instantiation parameters for a clock manager.
+ *
+ * This struct describes information about the underlying hardware instance that
+ * is not determined until the hardware design is used as part of a top-level
+ * design.
+ */
+typedef struct dif_clkmgr_params {
+  /**
+   * The base address for the clock manager hardware registers.
+   */
+  mmio_region_t base_addr;
+} dif_clkmgr_params_t;
+
+/**
+ * A handle to a clock manager.
+ *
+ * This type should be treated as opaque by users.
+ */
+typedef struct dif_clkmgr {
+  dif_clkmgr_params_t params;
+} dif_clkmgr_t;
+
+/**
+ * The result of a clock manager operation.
+ */
+typedef enum dif_clkmgr_result {
+  /**
+   * Indicates that the operation succeeded.
+   */
+  kDifClkmgrOk = 0,
+  /**
+   * Indicates some unspecified failure.
+   */
+  kDifClkmgrError = 1,
+  /**
+   * Indicates that some parameter passed into a function failed a
+   * precondition.
+   *
+   * When this value is returned, no hardware operations occured.
+   */
+  kDifClkmgrBadArg = 2,
+} dif_clkmgr_result_t;
+
+/**
+ * An Index of a "Gateable" Clock.
+ *
+ * "Gateable" clocks are under full software control: they can be enabled and
+ * disabled by software, which directly starts and stops the identified clock.
+ */
+typedef uint32_t dif_clkmgr_gateable_clock_t;
+
+/**
+ * An Index of a "Hintable" Clock.
+ *
+ * "Hintable" clocks are under partial software control: software can suggest
+ * they are stopped, but the clock manager may delay stopping the peripheral, or
+ * may ignore the request altogether.
+ */
+typedef uint32_t dif_clkmgr_hintable_clock_t;
+
+/**
+ * Creates a new handle for a clock manager.
+ *
+ * This function does not actuate the hardware.
+ *
+ * @param params Hardware instance parameters.
+ * @param[out] handle Out param for the initialized handle.
+ * @return The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_clkmgr_result_t dif_clkmgr_init(dif_clkmgr_params_t params,
+                                    dif_clkmgr_t *handle);
+
+/**
+ * Check if a Gateable Clock is Enabled or Disabled.
+ *
+ * @param handle Clock Manager Handle.
+ * @param clock Gateable Clock ID.
+ * @param[out] is_enabled whether the clock is enabled or not.
+ * @returns The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_clkmgr_result_t dif_clkmgr_gateable_clock_get_enabled(
+    const dif_clkmgr_t *handle, dif_clkmgr_gateable_clock_t clock,
+    bool *is_enabled);
+
+/**
+ * Enable or Disable a Gateable Clock.
+ *
+ * @param handle Clock Manager Handle.
+ * @param clock Gateable Clock ID.
+ * @param new_state whether to enable or disable the clock.
+ * @returns The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_clkmgr_result_t dif_clkmgr_gateable_clock_set_enabled(
+    const dif_clkmgr_t *handle, dif_clkmgr_gateable_clock_t clock,
+    dif_clkmgr_toggle_t new_state);
+
+/**
+ * Check if a Hintable Clock is Enabled or Disabled.
+ *
+ * Hintable clocks are not under full software control, but this operation
+ * accurately reflects the state of the current clock, regardless of any hint
+ * requests made by software.
+ *
+ * To read what hint the software has given the hardware, use
+ * #dif_clkmgr_hintable_clock_get_hint.
+ *
+ * @param handle Clock Manager Handle.
+ * @param clock Hintable Clock ID.
+ * @param[out] is_enabled whether the clock is enabled or not.
+ * @returns The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_clkmgr_result_t dif_clkmgr_hintable_clock_get_enabled(
+    const dif_clkmgr_t *handle, dif_clkmgr_hintable_clock_t clock,
+    bool *is_enabled);
+
+/**
+ * Enable or Disable a Hintable Clock.
+ *
+ * This only sets a hint that the clock should be enabled or disabled. The clock
+ * manager is in control of whether the clock should actually be enabled or
+ * disabled.
+ *
+ * To read what hint the software has given the hardware, use
+ * #dif_clkmgr_hintable_clock_get_hint. To read whether the clock is currently
+ * enabled or disabled, use #dif_clkmgr_hintable_clock_get_enabled.
+ *
+ * @param handle Clock Manager Handle.
+ * @param clock Hintable Clock ID.
+ * @param new_state whether to enable or disable the clock.
+ * @returns The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_clkmgr_result_t dif_clkmgr_hintable_clock_set_hint(
+    const dif_clkmgr_t *handle, dif_clkmgr_hintable_clock_t clock,
+    dif_clkmgr_toggle_t new_state);
+
+/**
+ * Read the current Hint for a Hintable Clock.
+ *
+ * Hintable clocks are not under full software control; this operation
+ * accurately reflects the current software hint, not the current state of the
+ * clock.
+ *
+ * To read whether the clock is currently enabled or disabled, use
+ * #dif_clkmgr_hintable_clock_get_enabled.
+ *
+ * @param handle Clock Manager Handle.
+ * @param clock Hintable Clock ID.
+ * @param[out] is_enabled the current software request (hint) for this clock.
+ * @returns The result of the operation.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_clkmgr_result_t dif_clkmgr_hintable_clock_get_hint(
+    const dif_clkmgr_t *handle, dif_clkmgr_hintable_clock_t clock,
+    bool *hinted_is_enabled);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_DIF_CLKMGR_H_

--- a/sw/device/lib/dif/dif_clkmgr.h
+++ b/sw/device/lib/dif/dif_clkmgr.h
@@ -21,6 +21,23 @@ extern "C" {
 #endif  // __cplusplus
 
 /**
+ * An Index of a "Gateable" Clock.
+ *
+ * "Gateable" clocks are under full software control: they can be enabled and
+ * disabled by software, which directly starts and stops the identified clock.
+ */
+typedef uint32_t dif_clkmgr_gateable_clock_t;
+
+/**
+ * An Index of a "Hintable" Clock.
+ *
+ * "Hintable" clocks are under partial software control: software can suggest
+ * they are stopped, but the clock manager may delay stopping the peripheral, or
+ * may ignore the request altogether.
+ */
+typedef uint32_t dif_clkmgr_hintable_clock_t;
+
+/**
  * A toggle state: enabled, or disabled.
  *
  * This enum may be used instead of a `bool` when describing an enabled/disabled
@@ -49,6 +66,14 @@ typedef struct dif_clkmgr_params {
    * The base address for the clock manager hardware registers.
    */
   mmio_region_t base_addr;
+  /**
+   * The last index of gateable clocks being managed by this clock manager.
+   */
+  dif_clkmgr_gateable_clock_t last_gateable_clock;
+  /**
+   * The last index of of hintable clocks being managed by this clock manager.
+   */
+  dif_clkmgr_hintable_clock_t last_hintable_clock;
 } dif_clkmgr_params_t;
 
 /**
@@ -80,23 +105,6 @@ typedef enum dif_clkmgr_result {
    */
   kDifClkmgrBadArg = 2,
 } dif_clkmgr_result_t;
-
-/**
- * An Index of a "Gateable" Clock.
- *
- * "Gateable" clocks are under full software control: they can be enabled and
- * disabled by software, which directly starts and stops the identified clock.
- */
-typedef uint32_t dif_clkmgr_gateable_clock_t;
-
-/**
- * An Index of a "Hintable" Clock.
- *
- * "Hintable" clocks are under partial software control: software can suggest
- * they are stopped, but the clock manager may delay stopping the peripheral, or
- * may ignore the request altogether.
- */
-typedef uint32_t dif_clkmgr_hintable_clock_t;
 
 /**
  * Creates a new handle for a clock manager.

--- a/sw/device/lib/dif/dif_clkmgr.md
+++ b/sw/device/lib/dif/dif_clkmgr.md
@@ -9,7 +9,7 @@ All checklist items refer to the content in the [Checklist]({{< relref "/doc/pro
 
 Type           | Item                 | Resolution  | Note/Collaterals
 ---------------|----------------------|-------------|------------------
-Implementation | [DIF_EXISTS][]       | Not Started |
+Implementation | [DIF_EXISTS][]       | Done        |
 Implementation | [DIF_USED_IN_TREE][] | Not Started |
 Tests          | [DIF_TEST_UNIT][]    | Not Started |
 Tests          | [DIF_TEST_SANITY][]  | Not Started |

--- a/sw/device/lib/dif/dif_clkmgr.md
+++ b/sw/device/lib/dif/dif_clkmgr.md
@@ -1,0 +1,63 @@
+---
+title: "Clock manager DIF Checklist"
+---
+
+This checklist is for [Development Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the Clock manager DIF.
+All checklist items refer to the content in the [Checklist]({{< relref "/doc/project/checklist.md" >}}).
+
+
+
+Type           | Item                 | Resolution  | Note/Collaterals
+---------------|----------------------|-------------|------------------
+Implementation | [DIF_EXISTS][]       | Not Started |
+Implementation | [DIF_USED_IN_TREE][] | Not Started |
+Tests          | [DIF_TEST_UNIT][]    | Not Started |
+Tests          | [DIF_TEST_SANITY][]  | Not Started |
+
+[DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif_exists" >}}
+[DIF_USED_IN_TREE]: {{< relref "/doc/project/checklist.md#dif_used_in_tree" >}}
+[DIF_TEST_UNIT]:    {{< relref "/doc/project/checklist.md#dif_test_unit" >}}
+[DIF_TEST_SANITY]:  {{< relref "/doc/project/checklist.md#dif_test_sanity" >}}
+
+
+Type           | Item                        | Resolution  | Note/Collaterals
+---------------|-----------------------------|-------------|------------------
+Implementation | [DIF_FEATURES][]            | Not Started |
+Coordination   | [DIF_HW_USAGE_REVIEWED][]   | Not Started |
+Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Not Started | [HW Dashboard]({{< relref "hw" >}})
+Implementation | [DIF_HW_PARAMS][]           | Not Started |
+Documentation  | [DIF_DOC_HW][]              | Not Started |
+Documentation  | [DIF_DOC_API][]             | Not Started |
+Code Quality   | [DIF_CODE_STYLE][]          | Not Started |
+Coordination   | [DIF_DV_TESTS][]            | Not Started |
+Implementation | [DIF_USED_TOCK][]           | Not Started |
+Review         | HW IP Usage Reviewer(s)     | Not Started |
+
+[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
+[DIF_HW_USAGE_REVIEWED]:   {{< relref "/doc/project/checklist.md#dif_hw_usage_reviewed" >}}
+[DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_feature_complete" >}}
+[DIF_HW_PARAMS]:           {{< relref "/doc/project/checklist.md#dif_hw_params" >}}
+[DIF_DOC_HW]:              {{< relref "/doc/project/checklist.md#dif_doc_hw" >}}
+[DIF_DOC_API]:             {{< relref "/doc/project/checklist.md#dif_doc_api" >}}
+[DIF_CODE_STYLE]:          {{< relref "/doc/project/checklist.md#dif_code_style" >}}
+[DIF_DV_TESTS]:            {{< relref "/doc/project/checklist.md#dif_dv_tests" >}}
+[DIF_USED_TOCK]:           {{< relref "/doc/project/checklist.md#dif_used_tock" >}}
+
+
+Type           | Item                             | Resolution  | Note/Collaterals
+---------------|----------------------------------|-------------|------------------
+Coordination   | [DIF_HW_DESIGN_COMPLETE][]       | Not Started |
+Coordination   | [DIF_HW_VERIFICATION_COMPLETE][] | Not Started |
+Review         | [DIF_REVIEW_C_STABLE][]          | Not Started |
+Tests          | [DIF_TEST_UNIT_COMPLETE][]       | Not Started |
+Review         | [DIF_TODO_COMPLETE][]            | Not Started |
+Review         | [DIF_REVIEW_TOCK_STABLE][]       | Not Started |
+Review         | Reviewer(s)                      | Not Started |
+Review         | Signoff date                     | Not Started |
+
+[DIF_HW_DESIGN_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif_hw_design_complete" >}}
+[DIF_HW_VERIFICATION_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_verification_complete" >}}
+[DIF_REVIEW_C_STABLE]:          {{< relref "/doc/project/checklist.md#dif_review_c_stable" >}}
+[DIF_TEST_UNIT_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif_test_unit_complete" >}}
+[DIF_TODO_COMPLETE]:            {{< relref "/doc/project/checklist.md#dif_todo_complete" >}}
+[DIF_REVIEW_TOCK_STABLE]:       {{< relref "/doc/project/checklist.md#dif_review_tock_stable" >}}

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -2,6 +2,20 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+# Clock Manager DIF Library (dif_clkmgr)
+sw_lib_dif_clkmgr = declare_dependency(
+  link_with: static_library(
+    'clkmgr_ot',
+    sources: [
+      hw_ip_clkgmr_reg_h,
+      'dif_clkmgr.c',
+    ],
+    dependencies: [
+      sw_lib_mmio,
+    ],
+  )
+)
+
 # UART DIF library (dif_uart)
 sw_lib_dif_uart = declare_dependency(
   link_with: static_library(


### PR DESCRIPTION
This PR adds an initial Clock Manager DIF.

The clock manager is as yet undocumented, beyond the register file in `hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson` (note this is topgen'd, ignore other `clkmgr.hjson` files in the repo). Not all clocks are software-accessible, so not all can be controlled via the register interface in the clock manager.

The intention is to use the values of `top_earlgrey_gateable_clocks_t` in params of type `dif_clkmgr_gateable_clock_t`, and likewise for hintable clocks.