### PR TITLE
[otp_ctrl] Fix scrmbl assertion failure

### DIFF
--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_scrmbl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_scrmbl.sv
@@ -146,9 +146,8 @@ module otp_ctrl_scrmbl import otp_ctrl_pkg::*; (
                                 OtpDigestIV[sel_d[vbits(NumDigestSets)-1:0]]     : '0;
 
   // Make sure we always select a valid key / digest constant.
-  `ASSERT(CheckNumEncKeys_A, data_state_sel == SelEncKeyInit  |-> sel_d < NumScrmblKeys)
-  `ASSERT(CheckNumDecKeys_A, data_state_sel == SelDecKeyInit  |-> sel_d < NumScrmblKeys)
-  `ASSERT(CheckNumDigest0_A, data_state_sel == SelDigestIV    |-> sel_d < NumDigestSets)
+  `ASSERT(CheckNumEncKeys_A, key_state_sel  == SelEncKeyInit  |-> sel_d < NumScrmblKeys)
+  `ASSERT(CheckNumDecKeys_A, key_state_sel  == SelDecKeyInit  |-> sel_d < NumScrmblKeys)
   `ASSERT(CheckNumDigest1_A, data_state_sel == SelDigestConst |-> sel_d < NumDigestSets)
 
   assign data_state_d    = (data_state_sel == SelEncDataOut)  ? enc_data_out      :


### PR DESCRIPTION
Fix a small enum typo in otp_ctrl assertion.
Delete IV check because it is tied to constant.

Signed-off-by: Cindy Chen <chencindy@google.com>