### PR TITLE
[sw] Remove Header Extern Comments

### DIFF
--- a/hw/top_earlgrey/data/top_earlgrey.h.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.h.tpl
@@ -21,7 +21,6 @@
  * - Power Manager Wakeups
  */
 
-// Header Extern Guard  (so header can be used from C and C++)
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -21,7 +21,6 @@
  * - Power Manager Wakeups
  */
 
-// Header Extern Guard  (so header can be used from C and C++)
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/sw/device/lib/base/bitfield.h
+++ b/sw/device/lib/base/bitfield.h
@@ -8,7 +8,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-// Header Extern Guard  (so header can be used from C and C++)
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus

--- a/sw/device/lib/base/memory.h
+++ b/sw/device/lib/base/memory.h
@@ -17,7 +17,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-// Header Extern Guard  (so header can be used from C and C++)
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus

--- a/sw/device/lib/base/mmio.h
+++ b/sw/device/lib/base/mmio.h
@@ -11,7 +11,6 @@
 
 #include "sw/device/lib/base/bitfield.h"
 
-// Header Extern Guard  (so header can be used from C and C++)
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus

--- a/sw/device/lib/dif/dif_alert_handler.h
+++ b/sw/device/lib/dif/dif_alert_handler.h
@@ -16,7 +16,6 @@
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_warn_unused_result.h"
 
-// Header Extern Guard (so header can be used from C and C++)
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus

--- a/sw/device/lib/dif/dif_gpio.h
+++ b/sw/device/lib/dif/dif_gpio.h
@@ -16,7 +16,6 @@
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_warn_unused_result.h"
 
-// Header Extern Guard (so header can be used from C and C++)
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus

--- a/sw/device/lib/dif/dif_i2c.h
+++ b/sw/device/lib/dif/dif_i2c.h
@@ -16,7 +16,6 @@
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_warn_unused_result.h"
 
-// Header Extern Guard (so header can be used from C and C++)
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus

--- a/sw/device/lib/dif/dif_plic.h
+++ b/sw/device/lib/dif/dif_plic.h
@@ -23,7 +23,6 @@
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_warn_unused_result.h"
 
-// Header Extern Guard (so header can be used from C and C++)
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus

--- a/sw/device/lib/dif/dif_pwrmgr.h
+++ b/sw/device/lib/dif/dif_pwrmgr.h
@@ -16,7 +16,6 @@
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_warn_unused_result.h"
 
-// Header Extern Guard (so header can be used from C and C++)
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus

--- a/sw/device/lib/dif/dif_rstmgr.h
+++ b/sw/device/lib/dif/dif_rstmgr.h
@@ -17,7 +17,6 @@
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_warn_unused_result.h"
 
-// Header Extern Guard (so header can be used from C and C++)
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus

--- a/sw/device/lib/dif/dif_spi_device.h
+++ b/sw/device/lib/dif/dif_spi_device.h
@@ -17,7 +17,6 @@
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_warn_unused_result.h"
 
-// Header Extern Guard (so header can be used from C and C++)
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus

--- a/sw/device/lib/dif/dif_template.h.tpl
+++ b/sw/device/lib/dif/dif_template.h.tpl
@@ -29,7 +29,6 @@
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_warn_unused_result.h"
 
-// Header Extern Guard (so header can be used from C and C++)
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus

--- a/sw/device/lib/dif/dif_uart.h
+++ b/sw/device/lib/dif/dif_uart.h
@@ -15,7 +15,6 @@
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_warn_unused_result.h"
 
-// Header Extern Guard (so header can be used from C and C++)
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus

--- a/sw/device/lib/dif/dif_warn_unused_result.h
+++ b/sw/device/lib/dif/dif_warn_unused_result.h
@@ -10,7 +10,6 @@
  * @brief Unused Result Warning Macro for DIFs.
  */
 
-// Header Extern Guard (so header can be used from C and C++)
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus

--- a/sw/device/mask_rom/mask_rom.h
+++ b/sw/device/mask_rom/mask_rom.h
@@ -7,7 +7,6 @@
 
 #include <stdnoreturn.h>
 
-// Header Extern Guard (so header can be used from C and C++)
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus

--- a/sw/device/rom_exts/manifest.h.tpl
+++ b/sw/device/rom_exts/manifest.h.tpl
@@ -5,7 +5,6 @@
 #ifndef OPENTITAN_SW_DEVICE_ROM_EXTS_MANIFEST_H_
 #define OPENTITAN_SW_DEVICE_ROM_EXTS_MANIFEST_H_
 
-// Header Extern Guard (so header can be used from C and C++)
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus

--- a/sw/device/rom_exts/rom_ext_manifest_parser.h
+++ b/sw/device/rom_exts/rom_ext_manifest_parser.h
@@ -11,7 +11,6 @@
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/rom_exts/manifest.h"
 
-// Header Extern Guard (so header can be used from C and C++)
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus


### PR DESCRIPTION
These are a common C/C++ pattern, and the comments are getting more and more useless with each file they're included in.

These patterns are documented in the [C/C++ Coding Style Guide](https://docs.opentitan.org/doc/rm/c_cpp_coding_style/).