### PR TITLE
[dv/common] Fix testplan path

### DIFF
--- a/hw/ip/otbn/data/otbn_testplan.hjson
+++ b/hw/ip/otbn/data/otbn_testplan.hjson
@@ -4,10 +4,10 @@
 {
   name: "otbn"
   // TODO: remove the common testplans if not applicable
-  import_testplans: ["hw/dv/tools/testplans/csr_testplan.hjson",
-                     "hw/dv/tools/testplans/mem_testplan.hjson",
-                     "hw/dv/tools/testplans/intr_test_testplan.hjson",
-                     "hw/dv/tools/testplans/tl_device_access_types_testplan.hjson"]
+  import_testplans: ["hw/dv/tools/dvsim/testplans/csr_testplan.hjson",
+                     "hw/dv/tools/dvsim/testplans/mem_testplan.hjson",
+                     "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
+                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson"]
   entries: [
     {
       name: sanity

--- a/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
@@ -3,10 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   name: "otp_ctrl"
-  import_testplans: ["hw/dv/tools/testplans/csr_testplan.hjson",
-                     "hw/dv/tools/testplans/mem_testplan.hjson",
-                     "hw/dv/tools/testplans/intr_test_testplan.hjson",
-                     "hw/dv/tools/testplans/tl_device_access_types_testplan.hjson"]
+  import_testplans: ["hw/dv/tools/dvsim/testplans/csr_testplan.hjson",
+                     "hw/dv/tools/dvsim/testplans/mem_testplan.hjson",
+                     "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
+                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson"]
   entries: [
     {
       name: wake_up

--- a/util/dvsim/testplanner/README.md
+++ b/util/dvsim/testplanner/README.md
@@ -172,7 +172,7 @@ In addition, see the [UART DV Plan]({{< relref "hw/ip/uart/doc/dv_plan" >}}) for
 real 'production' example of inline expansion of an imported testplan as a table
 within the DV Plan document.
 The [UART testplan](https://github.com/lowRISC/opentitan/blob/master/hw/ip/uart/data/uart_testplan.hjson)
-imports the shared testplans located at `hw/dv/tools/testplans` area.
+imports the shared testplans located at `hw/dv/tools/dvsim/testplans` area.
 
 ### Limitations
 

--- a/util/uvmdvgen/testplan.hjson.tpl
+++ b/util/uvmdvgen/testplan.hjson.tpl
@@ -4,10 +4,10 @@
 {
   name: "${name}"
   // TODO: remove the common testplans if not applicable
-  import_testplans: ["hw/dv/tools/testplans/csr_testplan.hjson",
-                     "hw/dv/tools/testplans/mem_testplan.hjson",
-                     "hw/dv/tools/testplans/intr_test_testplan.hjson",
-                     "hw/dv/tools/testplans/tl_device_access_types_testplan.hjson"]
+  import_testplans: ["hw/dv/tools/dvsim/testplans/csr_testplan.hjson",
+                     "hw/dv/tools/dvsim/testplans/mem_testplan.hjson",
+                     "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
+                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson"]
   entries: [
     {
       name: sanity


### PR DESCRIPTION
Fixed that PR #3656 didn't apply the directory changes to some recent commits
Also update uvmdvgen

Thanks @cindychip for pointing this out.
Signed-off-by: Weicai Yang <weicai@google.com>