### PR TITLE
[dv/otp] add push_pull agent to sram_otp if

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.core
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.core
@@ -10,6 +10,7 @@ filesets:
       - lowrisc:dv:ralgen
       - lowrisc:dv:cip_lib
       - lowrisc:dv:mem_bkdr_if
+      - lowrisc:dv:push_pull_agent
     files:
       - otp_ctrl_env_pkg.sv
       - otp_ctrl_env_cfg.sv: {is_include_file: true}

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
@@ -5,6 +5,9 @@
 class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_reg_block));
 
   // ext component cfgs
+  rand push_pull_agent_cfg#(SRAM_DATA_SIZE) m_sram_pull_agent_cfg[NumSramKeyReqSlots];
+
+  // ext interfaces
   pwr_otp_vif         pwr_otp_vif;
   lc_provision_en_vif lc_provision_en_vif;
   mem_bkdr_vif        mem_bkdr_vif;
@@ -16,6 +19,13 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_reg_block));
 
   virtual function void initialize(bit [31:0] csr_base_addr = '1);
     super.initialize(csr_base_addr);
+
+    // create push_pull agent config obj
+    for (int i = 0; i < NumSramKeyReqSlots; i++) begin
+      string cfg_name = $sformatf("sram_pull_agent_cfg[%0d]", i);
+      m_sram_pull_agent_cfg[i] = push_pull_agent_cfg#(SRAM_DATA_SIZE)::type_id::create(cfg_name);
+      m_sram_pull_agent_cfg[i].agent_type = PullAgent;
+    end
 
     // set num_interrupts & num_alerts
     begin

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -11,8 +11,10 @@ package otp_ctrl_env_pkg;
   import tl_agent_pkg::*;
   import cip_base_pkg::*;
   import csr_utils_pkg::*;
+  import push_pull_agent_pkg::*;
   import otp_ctrl_ral_pkg::*;
   import otp_ctrl_pkg::*;
+  import otp_ctrl_reg_pkg::*;
   import lc_ctrl_pkg::*;
 
   // macro includes
@@ -20,11 +22,13 @@ package otp_ctrl_env_pkg;
   `include "dv_macros.svh"
 
   // parameters
-  parameter uint DIGEST_SIZE              = 8;
-  parameter uint CREATOR_WINDOW_BASE_ADDR = 'h1000;
-  parameter uint OWNER_WINDOW_BASE_ADDR   = 'h1300;
-  parameter uint TEST_ACCESS_BASE_ADDR    = 'h2000;
-  parameter uint WINDOW_SIZE              = 512 * 4;
+  parameter uint DIGEST_SIZE           = 8;
+  parameter uint SW_WINDOW_BASE_ADDR   = 'h1000;
+  parameter uint TEST_ACCESS_BASE_ADDR = 'h2000;
+  parameter uint WINDOW_SIZE           = 512 * 4;
+  // sram rsp data has 1 bit for seed_valid, the rest are for key and nonce
+  parameter uint SRAM_DATA_SIZE        = 1 + otp_ctrl_pkg::SramKeyWidth +
+                                             otp_ctrl_pkg::SramNonceWidth;
 
   // lc does not have digest
   parameter bit[10:0] DIGESTS_ADDR [NumPart-1] = {
@@ -76,7 +80,7 @@ package otp_ctrl_env_pkg;
   endfunction
 
   function automatic bit [TL_AW-1:0] get_sw_window_addr(bit [TL_AW-1:0] dai_addr);
-    get_sw_window_addr = dai_addr + CREATOR_WINDOW_BASE_ADDR;
+    get_sw_window_addr = dai_addr + SW_WINDOW_BASE_ADDR;
   endfunction
 
   // package sources

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -12,6 +12,7 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
   // local variables
 
   // TLM agent fifos
+  uvm_tlm_analysis_fifo #(push_pull_item#(SRAM_DATA_SIZE)) sram_fifo[NumSramKeyReqSlots];
 
   // local queues to hold incoming packets pending comparison
 
@@ -19,6 +20,9 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
+    for (int i = 0; i < NumSramKeyReqSlots; i++) begin
+      sram_fifo[i] = new($sformatf("sram_fifo[%0d]", i), this);
+    end
   endfunction
 
   function void connect_phase(uvm_phase phase);
@@ -37,7 +41,7 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
     bit     write             = item.is_write();
     uvm_reg_addr_t csr_addr   = get_normalized_addr(item.a_addr);
     bit [TL_AW-1:0] addr_mask = cfg.csr_addr_map_size - 1;
- 
+
     bit addr_phase_read   = (!write && channel == AddrChannel);
     bit addr_phase_write  = (write && channel == AddrChannel);
     bit data_phase_read   = (!write && channel == DataChannel);
@@ -50,7 +54,7 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
     // memories
     // TODO: memory read check, change hardcoded to parameters once design finalized
     end else if ((csr_addr & addr_mask) inside
-        {[CREATOR_WINDOW_BASE_ADDR : CREATOR_WINDOW_BASE_ADDR + WINDOW_SIZE],
+        {[SW_WINDOW_BASE_ADDR : SW_WINDOW_BASE_ADDR + WINDOW_SIZE],
          [TEST_ACCESS_BASE_ADDR : TEST_ACCESS_BASE_ADDR + WINDOW_SIZE]}) begin
       return;
     end else begin

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_virtual_sequencer.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_virtual_sequencer.sv
@@ -8,7 +8,7 @@ class otp_ctrl_virtual_sequencer extends cip_base_virtual_sequencer #(
   );
   `uvm_component_utils(otp_ctrl_virtual_sequencer)
 
-
   `uvm_component_new
 
+  push_pull_sequencer#(SRAM_DATA_SIZE) sram_pull_sequencer_h[NumSramKeyReqSlots];
 endclass

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -78,4 +78,15 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     end
   endtask
 
+  virtual task req_sram_key(int index);
+    push_pull_host_seq#(SRAM_DATA_SIZE) sram_pull_seq;
+    `uvm_create_on(sram_pull_seq, p_sequencer.sram_pull_sequencer_h[index]);
+    `DV_CHECK_RANDOMIZE_FATAL(sram_pull_seq)
+    `uvm_send(sram_pull_seq)
+  endtask
+
+  virtual task req_all_sram_keys();
+    for (int i = 0; i < NumSramKeyReqSlots; i++) req_sram_key(i);
+  endtask
+
 endclass : otp_ctrl_base_vseq

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_sanity_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_sanity_vseq.sv
@@ -62,6 +62,9 @@ class otp_ctrl_sanity_vseq extends otp_ctrl_base_vseq;
       cfg.clk_rst_vif.wait_clks(1);
       csr_rd_check(.ptr(ral.status), .compare_value(OtpIdle));
 
+      // get sram keys
+      req_all_sram_keys();
+
       for (int i = 0; i < num_dai_wr; i++) begin
         bit [TL_DW-1:0] rdata0, rdata1;
         `DV_CHECK_RANDOMIZE_FATAL(this)


### PR DESCRIPTION
This PR adds two push pull agents to support key request from sram to
otp. The push pull agent number is configurable based on design
parameters from the hjson config.

Signed-off-by: Cindy Chen <chencindy@google.com>