### PR TITLE
[otp] Fix xcelium compile error

### DIFF
--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_lci.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_lci.sv
@@ -12,7 +12,7 @@ module otp_ctrl_lci
   import otp_ctrl_reg_pkg::*;
 #(
   // Lifecycle partition information
-  parameter part_info_t Info
+  parameter part_info_t Info = part_info_t'(0)
 ) (
   input                                    clk_i,
   input                                    rst_ni,

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_buf.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_buf.sv
@@ -12,8 +12,8 @@ module otp_ctrl_part_buf
   import otp_ctrl_reg_pkg::*;
 #(
   // Partition information.
-  parameter part_info_t             Info,
-  parameter logic [Info.size*8-1:0] DataDefault
+  parameter part_info_t             Info = part_info_t'(0),
+  parameter logic [Info.size*8-1:0] DataDefault = '0
 ) (
   input                               clk_i,
   input                               rst_ni,

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
@@ -12,7 +12,7 @@ module otp_ctrl_part_unbuf
   import otp_ctrl_reg_pkg::*;
 #(
   // Partition information.
-  parameter part_info_t Info
+  parameter part_info_t Info = part_info_t'(0)
 ) (
   input                               clk_i,
   input                               rst_ni,


### PR DESCRIPTION
Fix xcelium compile error by adding parameters a default value in
module.

Signed-off-by: Cindy Chen <chencindy@google.com>