### PR TITLE
[dv/otp_ctrl] Add otp_ctrl DV to nightly regression and update CSR sequences

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson
@@ -216,6 +216,8 @@
       swaccess: "ro",
       hwaccess: "hwo",
       hwext:    "true",
+      tags: [ // OTP internal HW can modify status register
+              "excl:CsrAllTests:CsrExclCheck"],
       fields: [
         { bits: "0"
           name: "CREATOR_SW_CFG_ERROR"
@@ -414,8 +416,10 @@
       swaccess: "ro",
       hwaccess: "hwo",
       hwext:    "true",
-      tags: [ // DAI interface will set it to 0 during initialization,
-              // so even after reset, the value might not be the reset value
+      tags: [ // OTP internal HW will set this enable register to 0 when OTP is not under IDLE
+              // state, so could not auto-predict its value
+              // TODO: change the exclusion to CsrNonInitTests once top-level triggers otp_init
+              // after reset
               "excl:CsrAllTests:CsrExclCheck"],
       fields: [
         {
@@ -436,9 +440,8 @@
       hwqe:     "true",
       hwext:    "true",
       regwen:   "DIRECT_ACCESS_REGWEN",
-      tags: [ // The enable register "DIRECT_ACCESS_REGWEN" is HW controlled,
-              // so not able to predict this register value automatically
-              "excl:CsrNonInitTests:CsrExclCheck"],
+      tags: [ // Write to DIRECT_ACCESS_CMD randomly might cause OTP_ERRORs and illegal sequences
+              "excl:CsrNonInitTests:CsrExclWrite"],
       fields: [
         { bits: "0",
           name: "READ",

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -34,7 +34,6 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
   virtual task otp_ctrl_init();
     // reset memory to avoid readout X
     cfg.mem_bkdr_vif.clear_mem();
-    csr_wr(ral.intr_enable, en_intr);
   endtask
 
   // this task triggers an OTP write sequence via the DAI interface

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_common_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_common_vseq.sv
@@ -10,6 +10,13 @@ class otp_ctrl_common_vseq extends otp_ctrl_base_vseq;
   }
   `uvm_object_new
 
+  virtual task dut_init(string reset_kind = "HARD");
+    super.dut_init(reset_kind);
+    // drive pwr_otp_req pin
+    cfg.pwr_otp_vif.drive_pin(0, 1);
+    wait(cfg.pwr_otp_vif.pins[2] == 1);
+  endtask
+
   virtual task body();
     run_common_vseq_wrapper(num_trans);
   endtask : body

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_sanity_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_sanity_vseq.sv
@@ -42,6 +42,7 @@ class otp_ctrl_sanity_vseq extends otp_ctrl_base_vseq;
     cfg.pwr_otp_vif.drive_pin(0, 1);
     wait(cfg.pwr_otp_vif.pins[2] == 1);
     cfg.lc_provision_en_vif.drive(lc_ctrl_pkg::On);
+    csr_wr(ral.intr_enable, en_intr);
   endtask
 
   virtual task pre_start();

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_wake_up_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_wake_up_vseq.sv
@@ -10,6 +10,7 @@ class otp_ctrl_wake_up_vseq extends otp_ctrl_base_vseq;
 
   virtual task otp_ctrl_init();
     super.otp_ctrl_init();
+    csr_wr(ral.intr_enable, en_intr);
     // drive pwr_otp_req pin
     cfg.pwr_otp_vif.drive_pin(0, 1);
   endtask

--- a/hw/top_earlgrey/dv/top_earlgrey_sim_cfgs.hjson
+++ b/hw/top_earlgrey/dv/top_earlgrey_sim_cfgs.hjson
@@ -17,6 +17,7 @@
              "{proj_root}/hw/ip/hmac/dv/hmac_sim_cfg.hjson",
              "{proj_root}/hw/ip/i2c/dv/i2c_sim_cfg.hjson",
              "{proj_root}/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson",
+             "{proj_root}/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson",
              "{proj_root}/hw/ip/rv_timer/dv/rv_timer_sim_cfg.hjson",
              "{proj_root}/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson",
              "{proj_root}/hw/ip/uart/dv/uart_sim_cfg.hjson",


### PR DESCRIPTION
The two commits in this PR are:
1. Add otp_ctrl dv to nightly regression and CI check
2. Update CSR sequences: exclusions and sequences.
   Previous CSR sequences will trigger right after rst is deasserted. This won't work for OTP memory sequences. The OTP memories are accessible only after OTP_init. So this commit update exclusions accordingly.