### PR TITLE
[push_pull_agent] Update push_pull_if to allow use of 'assign' in testbench

### DIFF
--- a/hw/dv/sv/push_pull_agent/push_pull_agent.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_agent.sv
@@ -22,6 +22,7 @@ class push_pull_agent #(parameter int DataWidth = 32) extends dv_base_agent #(
     if (!uvm_config_db#(virtual push_pull_if#(DataWidth))::get(this, "", "vif", cfg.vif)) begin
       `uvm_fatal(`gfn, "failed to get push_pull_if handle from uvm_config_db")
     end
+    cfg.vif.if_mode = cfg.if_mode;
     cfg.vif.is_push_agent = (cfg.agent_type == PushAgent);
   endfunction
 

--- a/hw/dv/sv/push_pull_agent/push_pull_device_driver.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_device_driver.sv
@@ -16,10 +16,10 @@ class push_pull_device_driver #(parameter int DataWidth = 32) extends push_pull_
 
   virtual task do_reset();
     if (cfg.agent_type == PushAgent) begin
-      cfg.vif.ready <= '0;
+      cfg.vif.ready_int <= '0;
     end else begin
-      cfg.vif.ack   <= '0;
-      cfg.vif.data  <= 'x;
+      cfg.vif.ack_int   <= '0;
+      cfg.vif.data      <= 'x;
     end
   endtask
 
@@ -49,11 +49,11 @@ class push_pull_device_driver #(parameter int DataWidth = 32) extends push_pull_
       @(`PUSH_DRIVER);
     end
     if (!in_reset) begin
-      `PUSH_DRIVER.ready <= 1'b1;
+      `PUSH_DRIVER.ready_int <= 1'b1;
     end
     @(`PUSH_DRIVER);
     if (!in_reset) begin
-      `PUSH_DRIVER.ready <= 1'b0;
+      `PUSH_DRIVER.ready_int <= 1'b0;
     end
   endtask
 
@@ -66,13 +66,13 @@ class push_pull_device_driver #(parameter int DataWidth = 32) extends push_pull_
       @(`PULL_DRIVER);
     end
     if (!in_reset) begin
-      `PULL_DRIVER.ack  <= 1'b1;
-      `PULL_DRIVER.data <= req.data;
+      `PULL_DRIVER.ack_int  <= 1'b1;
+      `PULL_DRIVER.data     <= req.data;
     end
     @(`PULL_DRIVER);
     if (!in_reset) begin
-      `PULL_DRIVER.ack  <= 1'b0;
-      `PULL_DRIVER.data <= 'x;
+      `PULL_DRIVER.ack_int  <= 1'b0;
+      `PULL_DRIVER.data     <= 'x;
     end
   endtask
 

--- a/hw/dv/sv/push_pull_agent/push_pull_host_driver.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_host_driver.sv
@@ -16,10 +16,10 @@ class push_pull_host_driver #(parameter int DataWidth = 32) extends push_pull_dr
 
   virtual task do_reset();
     if (cfg.agent_type == PushAgent) begin
-      cfg.vif.valid <= '0;
-      cfg.vif.data  <= 'x;
+      cfg.vif.valid_int <= '0;
+      cfg.vif.data      <= 'x;
     end else begin
-      cfg.vif.req <= '0;
+      cfg.vif.req_int   <= '0;
     end
   endtask
 
@@ -54,15 +54,15 @@ class push_pull_host_driver #(parameter int DataWidth = 32) extends push_pull_dr
       @(`PUSH_DRIVER);
     end
     if (!in_reset) begin
-      `PUSH_DRIVER.valid <= 1'b1;
-      `PUSH_DRIVER.data  <= req.data;
+      `PUSH_DRIVER.valid_int <= 1'b1;
+      `PUSH_DRIVER.data      <= req.data;
     end
     do begin
       @(`PUSH_DRIVER);
     end while (!`PUSH_DRIVER.ready && !in_reset);
     if (!in_reset) begin
-      `PUSH_DRIVER.valid <= 1'b0;
-      `PUSH_DRIVER.data  <= 'x;
+      `PUSH_DRIVER.valid_int <= 1'b0;
+      `PUSH_DRIVER.data      <= 'x;
     end
   endtask
 
@@ -73,13 +73,13 @@ class push_pull_host_driver #(parameter int DataWidth = 32) extends push_pull_dr
       @(`PULL_DRIVER);
     end
     if (!in_reset) begin
-      `PULL_DRIVER.req <= 1'b1;
+      `PULL_DRIVER.req_int <= 1'b1;
     end
     do begin
       @(`PULL_DRIVER);
     end while (!`PULL_DRIVER.ack && !in_reset);
     if (!in_reset) begin
-      `PULL_DRIVER.req <= 1'b0;
+      `PULL_DRIVER.req_int <= 1'b0;
     end
   endtask
 


### PR DESCRIPTION
This PR addresses an issue reported by @cindychip from #3868 , where manually assigning interface connections using `assign` to the `push_pull_if` would trigger some compile errors.
To fix this, an approach similar to `tl_if` is taken where some internal signals are declared in the interface and conditionally assigned as outputs (depending on the agent's configuration).

Signed-off-by: Udi Jonnalagadda <udij@google.com>