### PR TITLE
[otbn] Generate separate segments in rig programs

### DIFF
--- a/hw/ip/otbn/util/rig/program.py
+++ b/hw/ip/otbn/util/rig/program.py
@@ -276,6 +276,14 @@ class Program:
 
         '''
         self.close_section()
+        out_file.write('PHDRS\n'
+                       '{\n')
+        for idx, (addr, insns) in enumerate(sorted(self._sections.items())):
+            lma = addr + self.imem_lma
+            out_file.write('    seg{:04} PT_LOAD AT ( {:#x} );\n'
+                           .format(idx, lma))
+        out_file.write('}\n\n')
+
         out_file.write('SECTIONS\n'
                        '{\n')
         for idx, (addr, insns) in enumerate(sorted(self._sections.items())):
@@ -286,8 +294,8 @@ class Program:
             out_file.write('    {} {:#x} : AT({:#x})\n'
                            '    {{\n'
                            '        *({})\n'
-                           '    }}\n'
-                           .format(sec_name, addr, lma, sec_name))
+                           '    }} : seg{:04}\n'
+                           .format(sec_name, addr, lma, sec_name, idx))
         out_file.write('}\n')
 
     def pick_branch_targets(self,


### PR DESCRIPTION
We want to load these programs up by PHDR, so want to avoid ld merging
them all together into one segment. This patch modifies the generated
linker script to look like this:

    PHDRS
    {
        seg0000 PT_LOAD AT ( 0x100000 );
        seg0001 PT_LOAD AT ( 0x1002d4 );
        seg0002 PT_LOAD AT ( 0x100cfc );
    }

    SECTIONS
    {
        /* Section 0 (addresses [0x0000..0x0007]) */
        .text.sec0000 0x0 : AT(0x100000)
        {
            *(.text.sec0000)
        } : seg0000

        /* Section 1 (addresses [0x02d4..0x02d7]) */
        .text.sec0001 0x2d4 : AT(0x1002d4)
        {
            *(.text.sec0001)
        } : seg0001

        /* Section 2 (addresses [0x0cfc..0x0d03]) */
        .text.sec0002 0xcfc : AT(0x100cfc)
        {
            *(.text.sec0002)
        } : seg0002
    }
