### PR TITLE
[sw, dif_plic] Add `RV_PLIC.MSIP0` control and query API

### DIFF
--- a/sw/device/lib/dif/dif_plic.h
+++ b/sw/device/lib/dif/dif_plic.h
@@ -296,6 +296,55 @@ dif_plic_result_t dif_plic_irq_complete(const dif_plic_t *plic,
                                         dif_plic_target_t target,
                                         const dif_plic_irq_id_t *complete_data);
 
+/**
+ * Forces the software interrupt for a particular target.
+ *
+ * This function causes an interrupt to the `target` HART to be serviced as if
+ * hardware had asserted it.
+ *
+ * This function allows to synchronise between the HARTs, which otherwise
+ * would not be possible due to HART being only able to access own CSRs.
+ * NOTE: this is not an issue on Ibex, as it has only one HART.
+ *
+ * An interrupt handler is expected to call `dif_plic_software_irq_acknowledge`
+ * when the interrupt has been handled.
+ *
+ * @param plic PLIC state data.
+ * @param target Target HART.
+ * @return `dif_plic_result_t`.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_plic_result_t dif_plic_software_irq_force(const dif_plic_t *plic,
+                                              dif_plic_target_t target);
+
+/**
+ * Acknowledges the software interrupt for a particular target.
+ *
+ * This function indicates to the hardware that the software interrupt has been
+ * successfully serviced. It is expected to be called from a software interrupt
+ * handler.
+ *
+ * @param plic PLIC state data.
+ * @param target Target HART.
+ * @return `dif_plic_result_t`.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_plic_result_t dif_plic_software_irq_acknowledge(const dif_plic_t *plic,
+                                                    dif_plic_target_t target);
+
+/**
+ * Returns software interrupt pending state for a particular target.
+ *
+ * @param plic PLIC state data.
+ * @param target Target HART.
+ * @param is_pending[out] Flag indicating whether the interrupt is pending.
+ * @return `dif_plic_result_t`.
+ */
+DIF_WARN_UNUSED_RESULT
+dif_plic_result_t dif_plic_software_irq_is_pending(const dif_plic_t *plic,
+                                                   dif_plic_target_t target,
+                                                   bool *is_pending);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/tests/dif/dif_plic_unittest.cc
+++ b/sw/device/tests/dif/dif_plic_unittest.cc
@@ -207,7 +207,7 @@ TEST_F(IrqPrioritySetTest, Success) {
 
 class TargetThresholdSetTest : public PlicTest {};
 
-TEST_F(TargetThresholdSetTest, Target0NullArgs) {
+TEST_F(TargetThresholdSetTest, NullArgs) {
   EXPECT_EQ(
       dif_plic_target_set_threshold(nullptr, kTarget0, kDifPlicMaxPriority),
       kDifPlicBadArg);
@@ -270,7 +270,7 @@ class IrqClaimTest : public PlicTest {
   static_assert(RV_PLIC_PARAM_NUMTARGET == 1, "");
 };
 
-TEST_F(IrqClaimTest, Target0NullArgs) {
+TEST_F(IrqClaimTest, NullArgs) {
   dif_plic_irq_id_t data;
   EXPECT_EQ(dif_plic_irq_claim(nullptr, kTarget0, &data), kDifPlicBadArg);
 
@@ -297,7 +297,7 @@ class IrqCompleteTest : public PlicTest {
   static_assert(RV_PLIC_PARAM_NUMTARGET == 1, "");
 };
 
-TEST_F(IrqCompleteTest, Target0NullArgs) {
+TEST_F(IrqCompleteTest, NullArgs) {
   dif_plic_irq_id_t data;
   EXPECT_EQ(dif_plic_irq_complete(nullptr, kTarget0, &data), kDifPlicBadArg);
 
@@ -317,6 +317,83 @@ TEST_F(IrqCompleteTest, Target0Success) {
     dif_plic_irq_id_t data = i;
     EXPECT_EQ(dif_plic_irq_complete(&plic_, kTarget0, &data), kDifPlicOk);
   }
+}
+
+class SoftwareIrqForceTest : public PlicTest {
+  static_assert(RV_PLIC_PARAM_NUMTARGET == 1, "");
+};
+
+TEST_F(SoftwareIrqForceTest, NullArgs) {
+  EXPECT_EQ(dif_plic_software_irq_force(nullptr, kTarget0), kDifPlicBadArg);
+}
+
+TEST_F(SoftwareIrqForceTest, BadTarget) {
+  EXPECT_EQ(dif_plic_software_irq_force(&plic_, RV_PLIC_PARAM_NUMTARGET),
+            kDifPlicBadArg);
+}
+
+TEST_F(SoftwareIrqForceTest, Target0Success) {
+  EXPECT_WRITE32(RV_PLIC_MSIP0_REG_OFFSET, 1);
+  EXPECT_EQ(dif_plic_software_irq_force(&plic_, kTarget0), kDifPlicOk);
+}
+
+class SoftwareIrqAcknowledgeTest : public PlicTest {
+  static_assert(RV_PLIC_PARAM_NUMTARGET == 1, "");
+};
+
+TEST_F(SoftwareIrqAcknowledgeTest, NullArgs) {
+  EXPECT_EQ(dif_plic_software_irq_acknowledge(nullptr, kTarget0),
+            kDifPlicBadArg);
+}
+
+TEST_F(SoftwareIrqAcknowledgeTest, BadTarget) {
+  EXPECT_EQ(dif_plic_software_irq_acknowledge(&plic_, RV_PLIC_PARAM_NUMTARGET),
+            kDifPlicBadArg);
+}
+
+TEST_F(SoftwareIrqAcknowledgeTest, Target0Success) {
+  EXPECT_WRITE32(RV_PLIC_MSIP0_REG_OFFSET, 0);
+  EXPECT_EQ(dif_plic_software_irq_acknowledge(&plic_, kTarget0), kDifPlicOk);
+}
+
+class SoftwareIrqIsPendingTest : public PlicTest {
+  static_assert(RV_PLIC_PARAM_NUMTARGET == 1, "");
+};
+
+TEST_F(SoftwareIrqIsPendingTest, NullArgs) {
+  EXPECT_EQ(dif_plic_software_irq_is_pending(nullptr, kTarget0, nullptr),
+            kDifPlicBadArg);
+
+  EXPECT_EQ(dif_plic_software_irq_is_pending(&plic_, kTarget0, nullptr),
+            kDifPlicBadArg);
+
+  bool is_pending;
+  EXPECT_EQ(dif_plic_software_irq_is_pending(nullptr, kTarget0, &is_pending),
+            kDifPlicBadArg);
+}
+
+TEST_F(SoftwareIrqIsPendingTest, BadTarget) {
+  bool is_pending;
+  EXPECT_EQ(dif_plic_software_irq_is_pending(&plic_, RV_PLIC_PARAM_NUMTARGET,
+                                             &is_pending),
+            kDifPlicBadArg);
+}
+
+TEST_F(SoftwareIrqIsPendingTest, Target0Success) {
+  bool is_pending = false;
+  EXPECT_READ32(RV_PLIC_MSIP0_REG_OFFSET, 1);
+
+  EXPECT_EQ(dif_plic_software_irq_is_pending(&plic_, kTarget0, &is_pending),
+            kDifPlicOk);
+  EXPECT_TRUE(is_pending);
+
+  // Cleared
+  is_pending = true;
+  EXPECT_READ32(RV_PLIC_MSIP0_REG_OFFSET, 0);
+
+  EXPECT_EQ(dif_plic_software_irq_is_pending(&plic_, kTarget0, &is_pending),
+            kDifPlicOk);
+  EXPECT_FALSE(is_pending);
 }
 
 }  // namespace


### PR DESCRIPTION
API to access the `RV_PLIC.MSIP0` was discussed in the `DIF_HW_USAGE_REVIEWED`, and was deemed necessary for the DIF PLIC completeness.

Closes #3663