### PR TITLE
[memutil] Expose the loaded ELF file to SystemVerilog

### DIFF
--- a/hw/dv/verilator/cpp/dpi_memutil.cc
+++ b/hw/dv/verilator/cpp/dpi_memutil.cc
@@ -358,49 +358,15 @@ bool DpiMemUtil::RegisterMemoryArea(const std::string name,
     return false;
   }
 
-  // If the existing map is non-empty, we must check for overlaps
-  if (!addr_to_mem_.empty()) {
-    // We start by checking for an overlap "from the right". This would be a
-    // region that starts strictly above addr_loc->base, but where it's low
-    // address is still less than addr_top. We can use std::map::upper_bound to
-    // find the first region strictly above addr_loc->base (which returns the
-    // end iterator if there isn't one).
-    auto right_it = addr_to_mem_.upper_bound(addr_loc->base);
-    if (right_it != addr_to_mem_.end()) {
-      const MemAreaLoc &ub_loc = right_it->second->addr_loc;
-      assert(ub_loc.size != 0);
-      if (ub_loc.base <= addr_top) {
-        std::cerr << "ERROR: Can not register '" << name
-                  << "' because its address range overlaps to left of '"
-                  << right_it->second->name << "'.\n";
-        return false;
-      }
-    }
-
-    // We also need to check from the other side. This would be a region that
-    // starts at or before addr_loc->base and extends past it. If right_it is
-    // addr_to_mem_.begin(), there is no such region (because the lowest
-    // addressed region already starts above addr_loc->base). Otherwise,
-    // decrement right_it to get the highest addressed region that starts at or
-    // before addr_loc->base. Note this still works if right_it is the end
-    // iterator: we just pick up the last region, which we know exists because
-    // addr_to_mem_ is not empty.
-    if (right_it != addr_to_mem_.begin()) {
-      auto left_it = std::prev(right_it);
-      const MemAreaLoc &lb_loc = left_it->second->addr_loc;
-      assert(lb_loc.size != 0);
-      uint32_t lb_max = lb_loc.base + lb_loc.size;
-      if (addr_loc->base <= lb_max) {
-        std::cerr << "ERROR: Can not register '" << name
-                  << "' because its address range overlaps to right of '"
-                  << left_it->second->name << "'.\n";
-        return false;
-      }
-    }
+  auto clash = addr_to_mem_.EmplaceDisjoint(addr_loc->base, addr_top,
+                                            std::move(stored_mem_area));
+  if (clash) {
+    assert(*clash);
+    std::cerr << "ERROR: Can not register '" << name
+              << "' because its address range overlaps the existing area `"
+              << (*clash)->name << "'.\n";
+    return false;
   }
-
-  // Phew, no overlap!
-  addr_to_mem_.insert(std::make_pair(addr_loc->base, stored_mem_area));
   stored_mem_area->addr_loc = *addr_loc;
   return true;
 }
@@ -494,14 +460,16 @@ void DpiMemUtil::LoadElfToMemories(bool verbose, const std::string &filepath) {
     if (phdr.p_memsz == 0)
       continue;
 
-    const MemArea *mem_area = FindRegionForAddr(phdr.p_paddr);
-    if (!mem_area) {
+    auto mem_area_p = addr_to_mem_.Find(phdr.p_paddr);
+    if (!mem_area_p) {
       std::ostringstream oss;
       oss << "No memory region is registered that contains the address 0x"
           << std::hex << phdr.p_paddr << " (the base address of segment " << i
           << ").";
       throw ElfError(filepath, oss.str());
     }
+    assert(*mem_area_p);
+    const MemArea *mem_area = *mem_area_p;
     assert(mem_area->addr_loc.base <= phdr.p_paddr);
 
     uint32_t lma_top = phdr.p_paddr + (phdr.p_memsz - 1);
@@ -571,33 +539,4 @@ void DpiMemUtil::LoadElfToMemories(bool verbose, const std::string &filepath) {
       throw std::runtime_error(oss.str());
     }
   }
-}
-
-const MemArea *DpiMemUtil::FindRegionForAddr(uint32_t lma) const {
-  // To find the memory area containing lma, use upper_bound to find the first
-  // region strictly after it, and then std::prev to step backwards. This fails
-  // if either the map is empty (obviously!) or if ub_it is already the
-  // beginning of the map.
-  if (addr_to_mem_.empty())
-    return nullptr;
-
-  auto ub_it = addr_to_mem_.upper_bound(lma);
-  if (ub_it == addr_to_mem_.begin())
-    return nullptr;
-
-  const MemArea *m = std::prev(ub_it)->second;
-
-  // Every entry in addr_to_mem_ should have a valid pointer to a MemArea with a
-  // valid location.
-  assert(m != nullptr);
-  assert(m->addr_loc.size != 0);
-
-  // What's more, the base of the location should be less than equal to lma
-  // (because it's strictly less than the smallest entry strictly greater).
-  assert(m->addr_loc.base <= lma);
-
-  // This means that we've found the right region iff the top of the region
-  // includes lma.
-  uint32_t addr_top = m->addr_loc.base + (m->addr_loc.size - 1);
-  return (lma <= addr_top) ? m : nullptr;
 }

--- a/hw/dv/verilator/cpp/dpi_memutil.h
+++ b/hw/dv/verilator/cpp/dpi_memutil.h
@@ -8,6 +8,8 @@
 #include <string>
 #include <svdpi.h>
 
+#include "ranged_map.h"
+
 enum MemImageType {
   kMemImageUnknown = 0,
   kMemImageElf,
@@ -97,10 +99,5 @@ class DpiMemUtil {
 
  private:
   std::map<std::string, MemArea> name_to_mem_;
-  std::map<uint32_t, const MemArea *> addr_to_mem_;
-
-  /**
-   * Try to find a region for the given LMA. Returns nullptr if none is found.
-   */
-  const MemArea *FindRegionForAddr(uint32_t lma) const;
+  RangedMap<uint32_t, MemArea *> addr_to_mem_;
 };

--- a/hw/dv/verilator/cpp/dpi_memutil.h
+++ b/hw/dv/verilator/cpp/dpi_memutil.h
@@ -7,6 +7,7 @@
 #include <map>
 #include <string>
 #include <svdpi.h>
+#include <vector>
 
 #include "ranged_map.h"
 
@@ -29,6 +30,36 @@ struct MemArea {
   std::string location;  // Design scope location
   uint32_t width_byte;   // Memory width in bytes
   MemAreaLoc addr_loc;   // Address location. If !size, location is unknown.
+};
+
+// Staged data for a given memory area.
+//
+// This is represented as an ordered list of disjoint segments (as loaded from
+// an ELF file).
+//
+// Once it is nonempty, the class maintains the invariant that min_addr_ /
+// max_addr_ is the smallest / largest byte offset with valid data.
+class StagedMem {
+ public:
+  StagedMem() : min_addr_(~(uint32_t)0), max_addr_(0) {}
+
+  // Add a segment to the tracked memory
+  void AddSegment(uint32_t offset, std::vector<uint8_t> &&seg);
+
+  // Glob together the tracked segments, interspersing them with
+  // zeros, and return as a single flat array.
+  std::vector<uint8_t> GetFlat() const;
+
+  typedef RangedMap<uint32_t, std::vector<uint8_t>> SegMap;
+
+  std::pair<uint32_t, uint32_t> GetBounds() const {
+    return std::make_pair(min_addr_, max_addr_);
+  }
+  const SegMap &GetSegs() const { return segs_; }
+
+ private:
+  uint32_t min_addr_, max_addr_;
+  SegMap segs_;
 };
 
 /**
@@ -92,12 +123,44 @@ class DpiMemUtil {
    */
   void LoadFileToNamedMem(bool verbose, const std::string &name,
                           const std::string &filepath, MemImageType type);
+
   /**
-   * Load an ELF file, placing segments in memories by LMA
+   * Load an ELF file, placing segments in memories by LMA.
+   *
+   * Replaces any data currently in the staging area.
    */
   void LoadElfToMemories(bool verbose, const std::string &filepath);
 
+  /**
+   * Load an ELF file into a staging area in this object, which can then be
+   * accessed with GetMemoryData().
+   *
+   * If the load fails, raises a std::exception with information about what
+   * happened.
+   */
+  void StageElf(bool verbose, const std::string &path);
+
+  /**
+   * Get the contents of the staging area by memory name
+   */
+  const StagedMem &GetMemoryData(const std::string &mem_name) const;
+
  private:
+  // Memory area registry
   std::map<std::string, MemArea> name_to_mem_;
   RangedMap<uint32_t, MemArea *> addr_to_mem_;
+
+  // Staging area, loaded by StageElf. The map is keyed by names of memories
+  // stored in name_to_mem_. We also ensure that every segment in a StagedMem
+  // for a memory starts at an address that's aligned for the word width of
+  // that memory. Note: we don't also check segments' lengths are aligned.
+  std::map<std::string, StagedMem> staging_area_;
+  const StagedMem empty_;
+
+  /**
+   * Find a region containing for the given segment's addresses.
+   * Raises a std::exception if none is found.
+   */
+  const MemArea &GetRegionForSegment(const std::string &path, int seg_idx,
+                                     uint32_t lma, uint32_t mem_sz) const;
 };

--- a/hw/dv/verilator/cpp/ranged_map.h
+++ b/hw/dv/verilator/cpp/ranged_map.h
@@ -1,0 +1,100 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Utility class representing disjoint segments of memory
+
+#include <cassert>
+#include <map>
+
+// The type used to represent address ranges. This is essentially a std::pair,
+// but we need a operator< custom for the internal map.
+template <typename addr_t>
+struct AddrRange {
+  addr_t lo, hi;
+};
+
+template <typename addr_t>
+bool operator<(const AddrRange<addr_t> &a, const AddrRange<addr_t> &b) {
+  return a.lo < b.lo;
+}
+
+template <typename addr_t, typename val_t>
+class RangedMap {
+ public:
+  using rng_t = AddrRange<addr_t>;
+
+  // Try to insert an entry that covers the address range [min_addr, max_addr]
+  // (inclusive) with value val.
+  //
+  // If there is an existing entry that overlaps with the range on either side,
+  // the map and val are unchanged and a pointer to the existing entry is
+  // returned. Otherwise, returns nullptr.
+  const val_t *EmplaceDisjoint(addr_t min_addr, addr_t max_addr, val_t &&val) {
+    assert(min_addr <= max_addr);
+    rng_t rng = {.lo = min_addr, .hi = max_addr};
+
+    if (!map_.empty()) {
+      // We start by checking for an overlap "from the right". This would be a
+      // region that starts strictly above min_addr, but where it's low address
+      // is still <= max_addr. We can use std::map::upper_bound to find the
+      // first region strictly above min_addr (which returns the end iterator
+      // if there isn't one).
+      auto right_it = map_.upper_bound(rng);
+      if (right_it != map_.end()) {
+        addr_t right_min = right_it->first.lo;
+        if (right_min <= max_addr) {
+          return &right_it->second;
+        }
+      }
+
+      // We also need to check from the left side. This would be a region that
+      // starts at or before min_addr and extends past it. If right_it is
+      // mem_.begin(), there is no such region (because the lowest addressed
+      // region already starts above min_addr). Otherwise, decrement right_it
+      // to get the highest addressed region that starts at or before min_addr.
+      // Note this still works if right_it is the end iterator: we just pick up
+      // the last region, which we know exists because map_ is not empty.
+      if (right_it != map_.begin()) {
+        auto left_it = std::prev(right_it);
+        addr_t left_max = left_it->first.hi;
+
+        if (min_addr <= left_max) {
+          return &left_it->second;
+        }
+      }
+    }
+
+    // Phew, no overlap!
+    map_.insert(std::make_pair(rng, std::move(val)));
+    return nullptr;
+  }
+
+  // Try to find an entry hitting the given address. Returns nullptr if there
+  // is none.
+  const val_t *Find(addr_t addr) const {
+    // To find the entry containing addr, use upper_bound to find the first
+    // region strictly after it, and then std::prev to step backwards. This
+    // fails if either the map is empty (obviously!) or if ub_it is already the
+    // beginning of the map.
+    if (map_.empty())
+      return nullptr;
+
+    rng_t diag = {.lo = addr, .hi = addr};
+    auto it = map_.upper_bound(diag);
+    if (it == map_.begin())
+      return nullptr;
+
+    --it;
+
+    // At this point, it will point at the right region if there is one. We
+    // know that it->first.lo <= addr (because of how upper_bound works). We
+    // now just need to check that addr <= it->first.hi.
+    return (addr <= it->first.hi) ? &it->second : nullptr;
+  }
+
+ private:
+  std::map<rng_t, val_t> map_;
+};

--- a/hw/dv/verilator/cpp/ranged_map.h
+++ b/hw/dv/verilator/cpp/ranged_map.h
@@ -26,6 +26,79 @@ class RangedMap {
  public:
   using rng_t = AddrRange<addr_t>;
 
+  // A function used to merge overlapping segments. When called by
+  // Emplace(), val1 will be the newer value and val0 will be the
+  // older.
+  typedef val_t (*MergeFun)(const rng_t &rng0, val_t &&val0, const rng_t &rng1,
+                            val_t &&val1);
+
+  // Insert an entry that covers the address range [min_addr, max_addr]
+  // (inclusive) with value val.
+  void Emplace(addr_t min_addr, addr_t max_addr, val_t &&new_val,
+               MergeFun merge) {
+    assert(min_addr <= max_addr);
+
+    // Construct hit_lo / hit_hi, a pair of iterators that bound the
+    // segments that touch the new value.
+    auto hit_lo = map_.end();
+    auto hit_hi = map_.end();
+
+    rng_t rng = {.lo = min_addr, .hi = max_addr};
+
+    if (!map_.empty()) {
+      // Start by finding the first region that starts strictly above min_addr.
+      auto right_it = map_.upper_bound(rng);
+      hit_hi = right_it;
+
+      // If hit_hi is map_.end(), every region starts at or below min_addr. If
+      // not, the region it points to overlaps with the range if hit_hi->first
+      // <= max_addr. Increment hit_hi until we get to the end or are no longer
+      // overlapping. The result is the end iterator for our range.
+      while (hit_hi != map_.end() && hit_hi->first.lo <= max_addr) {
+        ++hit_hi;
+      }
+
+      // Now we need to find the low end of the range. Start at right_it and
+      // decrement while we've not got to the beginning and while the previous
+      // iterator has a top >= min_addr.
+      hit_lo = right_it;
+      while (hit_lo != map_.begin() &&
+             min_addr <= std::prev(hit_lo)->first.hi) {
+        --hit_lo;
+      }
+    }
+
+    // The entry is disjoint from all others iff hit_lo == hit_hi. In which
+    // case, we can just insert it.
+    if (hit_lo == hit_hi) {
+      map_.insert(std::make_pair(rng, std::move(new_val)));
+      return;
+    }
+
+    // Otherwise, we use the merge function to merge everything together.
+    // Accumulate into a new val_t and update min_addr / max_addr as we go.
+    // Peel off the 1st iteration of the loop to avoid an unnecessary move/copy
+    // of new_val.
+    val_t acc = merge(hit_lo->first, std::move(hit_lo->second), rng,
+                      std::move(new_val));
+    min_addr = std::min(min_addr, hit_lo->first.lo);
+    max_addr = std::max(max_addr, hit_lo->first.hi);
+
+    for (auto it = std::next(hit_lo); it != hit_hi; ++it) {
+      rng_t rng1 = {.lo = min_addr, .hi = max_addr};
+      acc = merge(it->first, std::move(it->second), rng1, std::move(acc));
+      min_addr = std::min(min_addr, it->first.lo);
+      max_addr = std::max(max_addr, it->first.hi);
+    }
+
+    // We've merged everything, and have possibly trashed the values pointed to
+    // by all the iterators in the range. Throw that lot away and finally
+    // insert the merged result.
+    map_.erase(hit_lo, hit_hi);
+    rng_t rng1 = {.lo = min_addr, .hi = max_addr};
+    map_.insert(std::make_pair(rng1, std::move(acc)));
+  }
+
   // Try to insert an entry that covers the address range [min_addr, max_addr]
   // (inclusive) with value val.
   //
@@ -72,27 +145,35 @@ class RangedMap {
     return nullptr;
   }
 
-  // Try to find an entry hitting the given address. Returns nullptr if there
-  // is none.
-  const val_t *Find(addr_t addr) const {
+  // Iteration interface
+  using map_t = std::map<rng_t, val_t>;
+  using const_iterator = typename map_t::const_iterator;
+
+  const_iterator begin() const { return const_iterator(map_.begin()); }
+  const_iterator end() const { return const_iterator(map_.end()); }
+  size_t size() const { return map_.size(); }
+
+  // Try to find an entry hitting the given address. Returns end() if there is
+  // none.
+  const_iterator find(addr_t addr) const {
     // To find the entry containing addr, use upper_bound to find the first
     // region strictly after it, and then std::prev to step backwards. This
     // fails if either the map is empty (obviously!) or if ub_it is already the
     // beginning of the map.
     if (map_.empty())
-      return nullptr;
+      return end();
 
     rng_t diag = {.lo = addr, .hi = addr};
     auto it = map_.upper_bound(diag);
     if (it == map_.begin())
-      return nullptr;
+      return end();
 
     --it;
 
     // At this point, it will point at the right region if there is one. We
     // know that it->first.lo <= addr (because of how upper_bound works). We
     // now just need to check that addr <= it->first.hi.
-    return (addr <= it->first.hi) ? &it->second : nullptr;
+    return (addr <= it->first.hi) ? const_iterator(it) : end();
   }
 
  private:

--- a/hw/dv/verilator/memutil_dpi.core
+++ b/hw/dv/verilator/memutil_dpi.core
@@ -8,6 +8,7 @@ description: "DPI memory utilities"
 filesets:
   files_cpp:
     files:
+      - cpp/ranged_map.h: { is_include_file: true }
       - cpp/dpi_memutil.cc
       - cpp/dpi_memutil.h: { is_include_file: true }
       - cpp/sv_scoped.cc

--- a/hw/ip/otbn/dv/memutil/README.md
+++ b/hw/ip/otbn/dv/memutil/README.md
@@ -1,0 +1,9 @@
+# OTBN memutil wrapper
+
+This code is a wrapper around `VerilatorMemUtil` (defined in
+`hw/dv/verilator/cpp`).
+
+To use it, depend on the core file. If you're using dvsim, you'll also
+need to include `otbn_memutil_sim_opts.hjson` in your simulator
+configuration and add `"{tool}_otbn_memutil_build_opts"` to the
+`en_build_modes` variable.

--- a/hw/ip/otbn/dv/memutil/otbn_memutil.cc
+++ b/hw/ip/otbn/dv/memutil/otbn_memutil.cc
@@ -1,0 +1,181 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "otbn_memutil.h"
+
+#include <cassert>
+#include <cstring>
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+
+OtbnMemUtil::OtbnMemUtil(const std::string &top_scope) {
+  MemAreaLoc imem_loc = {.base = 0x100000, .size = 4096};
+  std::string imem_scope =
+      top_scope + ".u_imem.u_mem.gen_generic.u_impl_generic";
+  if (!RegisterMemoryArea("imem", imem_scope, 32, &imem_loc)) {
+    throw std::runtime_error("Failed to register IMEM OTBN memory area.");
+  }
+
+  MemAreaLoc dmem_loc = {.base = 0x200000, .size = 4096};
+  std::string dmem_scope =
+      top_scope + ".u_dmem.u_mem.gen_generic.u_impl_generic";
+  if (!RegisterMemoryArea("dmem", dmem_scope, 256, &dmem_loc)) {
+    throw std::runtime_error("Failed to register DMEM OTBN memory area.");
+  }
+}
+
+void OtbnMemUtil::LoadElf(const std::string &elf_path) {
+  LoadElfToMemories(false, elf_path);
+}
+
+const StagedMem::SegMap &OtbnMemUtil::GetSegs(bool is_imem) const {
+  return GetMemoryData(is_imem ? "imem" : "dmem").GetSegs();
+}
+
+extern "C" OtbnMemUtil *OtbnMemUtilMake(const char *top_scope) {
+  try {
+    return new OtbnMemUtil(top_scope);
+  } catch (const std::exception &err) {
+    std::cerr << "Failed to create OtbnMemUtil: " << err.what() << "\n";
+    return nullptr;
+  }
+}
+
+extern "C" void OtbnMemUtilFree(OtbnMemUtil *mem_util) { delete mem_util; }
+
+extern "C" svBit OtbnMemUtilLoadElf(OtbnMemUtil *mem_util,
+                                    const char *elf_path) {
+  assert(mem_util);
+  assert(elf_path);
+  try {
+    mem_util->LoadElf(elf_path);
+    return sv_1;
+  } catch (const std::exception &err) {
+    std::cerr << "Failed to load ELF file from `" << elf_path
+              << "': " << err.what() << "\n";
+    return sv_0;
+  }
+}
+
+extern "C" svBit OtbnMemUtilStageElf(OtbnMemUtil *mem_util,
+                                     const char *elf_path) {
+  assert(mem_util);
+  assert(elf_path);
+  try {
+    mem_util->StageElf(false, elf_path);
+    return sv_1;
+  } catch (const std::exception &err) {
+    std::cerr << "Failed to load ELF file from `" << elf_path
+              << "': " << err.what() << "\n";
+    return sv_0;
+  }
+}
+
+extern "C" int OtbnMemUtilGetSegCount(OtbnMemUtil *mem_util, svBit is_imem) {
+  assert(mem_util);
+  const StagedMem::SegMap &segs = mem_util->GetSegs(is_imem);
+  size_t num_segs = segs.size();
+
+  // Since the segments are disjoint and 32-bit aligned, there are at most 2^30
+  // of them (this, admittedly, would mean an ELF file with a billion segments,
+  // but it's theoretically possible). Fortunately, that number is still
+  // representable with a signed 32-bit integer, so this assertion shouldn't
+  // ever fire.
+  assert(num_segs < std::numeric_limits<int>::max());
+
+  return num_segs;
+}
+
+extern "C" svBit OtbnMemUtilGetSegInfo(OtbnMemUtil *mem_util, svBit is_imem,
+                                       int seg_idx, svBitVecVal *seg_off,
+                                       svBitVecVal *seg_size) {
+  assert(mem_util);
+  assert(seg_off);
+  assert(seg_size);
+
+  const StagedMem::SegMap &segs = mem_util->GetSegs(is_imem);
+
+  // Make sure there is such an index.
+  if ((seg_idx < 0) || ((unsigned)seg_idx > segs.size())) {
+    std::cerr << "Invalid segment index: " << seg_idx << ". "
+              << (is_imem ? 'I' : 'D') << "MEM has " << segs.size()
+              << " segments.\n";
+    return sv_0;
+  }
+
+  // Walk to the desired segment (which we know is safe because we just checked
+  // the index was valid).
+  auto it = std::next(segs.begin(), seg_idx);
+
+  uint32_t seg_addr = it->first.lo;
+
+  // We know that seg_addr must be 32 bit aligned because DpiMemUtil checks its
+  // segments are aligned to the memory word size (which is 32 or 256 bits for
+  // imem/dmem, respectively).
+  assert(seg_addr % 4 == 0);
+
+  uint32_t word_seg_addr = seg_addr / 4;
+
+  size_t size_bytes = it->second.size();
+
+  // We know the size can't be too enormous, because the segment fits in a
+  // 32-bit address space.
+  assert(size_bytes < std::numeric_limits<uint32_t>::max());
+
+  // Divide by 4 to get the number of 32 bit words. Round up: we'll pad out the
+  // data with zeros if there's a ragged edge. (We know this is valid because
+  // any next range is also 32 bit aligned).
+  uint32_t size_words = ((uint64_t)size_bytes + 3) / 4;
+
+  memcpy(seg_off, &word_seg_addr, sizeof(uint32_t));
+  memcpy(seg_size, &size_words, sizeof(uint32_t));
+
+  return sv_1;
+}
+
+extern "C" svBit OtbnMemUtilGetSegData(
+    OtbnMemUtil *mem_util, svBit is_imem, int word_off,
+    /* output bit[31:0] */ svBitVecVal *data_value) {
+  assert(mem_util);
+  assert(data_value);
+
+  if ((word_off < 0) ||
+      ((unsigned)word_off > std::numeric_limits<uint32_t>::max() / 4)) {
+    std::cerr << "Invalid word offset: " << word_off << ".\n";
+    return sv_0;
+  }
+
+  uint32_t byte_addr = (unsigned)word_off * 4;
+
+  const StagedMem::SegMap &segs = mem_util->GetSegs(is_imem);
+
+  auto it = segs.find(byte_addr);
+  if (it == segs.end()) {
+    return sv_0;
+  }
+
+  uint32_t seg_addr = it->first.lo;
+  assert(seg_addr <= byte_addr);
+
+  // The offset within the segment
+  uint32_t seg_off = byte_addr - seg_addr;
+  assert(seg_off < it->second.size());
+
+  // How many bytes are available in the segment, starting at seg_off? We know
+  // this will be positive (because RangeMap::find finds us a range that
+  // includes seg_addr and then DpiMemUtil makes sure that the value at that
+  // range is the right length).
+  size_t avail = it->second.size() - seg_off;
+  size_t to_copy = std::min(avail, (size_t)4);
+
+  // Copy data from the segment into a uint32_t. Zero-initialize it, in case
+  // to_copy < 4.
+  uint32_t data = 0;
+  memcpy(&data, &it->second[seg_off], to_copy);
+
+  // Now copy that uint32_t into data_value and return success.
+  memcpy(data_value, &data, 4);
+  return sv_1;
+}

--- a/hw/ip/otbn/dv/memutil/otbn_memutil.core
+++ b/hw/ip/otbn/dv/memutil/otbn_memutil.core
@@ -1,0 +1,22 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:dv:otbn_memutil"
+description: "A wrapper around memutil_verilator for OTBN"
+
+filesets:
+  files_cpp:
+    depend:
+      - lowrisc:dv_verilator:memutil_dpi
+    files:
+      - otbn_memutil.cc
+      - otbn_memutil.h: { is_include_file: true }
+      - otbn_memutil.svh: { file_type: systemVerilogSource, is_include_file: true }
+    file_type: cppSource
+
+targets:
+  default:
+    filesets:
+      - files_cpp

--- a/hw/ip/otbn/dv/memutil/otbn_memutil.h
+++ b/hw/ip/otbn/dv/memutil/otbn_memutil.h
@@ -1,0 +1,60 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <svdpi.h>
+
+#include "dpi_memutil.h"
+
+class OtbnMemUtil : public DpiMemUtil {
+ public:
+  // Constructor. top_scope is the SV scope that contains IMEM and
+  // DMEM memories as u_imem and u_dmem, respectively.
+  OtbnMemUtil(const std::string &top_scope);
+
+  // Load an ELF file at the given path and backdoor load it into the
+  // attached memories.
+  //
+  // If something goes wrong, throws a std::exception.
+  void LoadElf(const std::string &elf_path);
+
+  // Get access to the segments currently staged for imem/dmem
+  const StagedMem::SegMap &GetSegs(bool is_imem) const;
+};
+
+// DPI-accessible wrappers
+extern "C" {
+OtbnMemUtil *OtbnMemUtilMake(const char *top_scope);
+void OtbnMemUtilFree(OtbnMemUtil *mem_util);
+
+// Loads an ELF file into memory via the backdoor. Returns 1'b1 on success.
+// Prints a message to stderr and returns 1'b0 on failure.
+svBit OtbnMemUtilLoadElf(OtbnMemUtil *mem_util, const char *elf_path);
+
+// Loads an ELF file into the OtbnMemUtil object, but doesn't touch the
+// simulated memory. Returns 1'b1 on success. Prints a message to stderr and
+// returns 1'b0 on failure.
+svBit OtbnMemUtilStageElf(OtbnMemUtil *mem_util, const char *elf_path);
+
+// Returns the number of segments currently staged in imem/dmem.
+int OtbnMemUtilGetSegCount(OtbnMemUtil *mem_util, svBit is_imem);
+
+// Gets offset and size (both in 32-bit words) for a segment currently staged
+// in imem/dmem. Both are returned with output arguments. Returns 1'b1 on
+// success. Prints a message to stderr and returns 1'b0 on failure.
+svBit OtbnMemUtilGetSegInfo(OtbnMemUtil *mem_util, svBit is_imem, int seg_idx,
+                            /* output bit[31:0] */ svBitVecVal *seg_off,
+                            /* output bit[31:0] */ svBitVecVal *seg_size);
+
+// Gets a word of data from segments currently staged in imem/dmem. If there
+// is a word at that address, the function writes its value to the output
+// argument and then returns 1'b1. If there is no word at that address, the
+// output argument is untouched and the function returns 1'b0.
+//
+// If word_off is invalid (negative or enormous), the function writes a
+// message to stderr and returns 1'b0.
+svBit OtbnMemUtilGetSegData(OtbnMemUtil *mem_util, svBit is_imem, int word_off,
+                            /* output bit[31:0] */ svBitVecVal *data_value);
+}

--- a/hw/ip/otbn/dv/memutil/otbn_memutil.svh
+++ b/hw/ip/otbn/dv/memutil/otbn_memutil.svh
@@ -1,0 +1,29 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`ifndef __OTBN_MEMUTIL_SVH__
+`define __OTBN_MEMUTIL_SVH__
+
+// Imports for the functions defined in otbn_memutil.h. There are documentation comments explaining
+// what the functions do there.
+
+import "DPI-C" function chandle OtbnMemUtilMake(string top_scope);
+
+import "DPI-C" function void OtbnMemUtilFree(chandle mem_util);
+
+import "DPI-C" function bit OtbnMemUtilLoadElf(chandle mem_util, string elf_path);
+
+import "DPI-C" function bit OtbnMemUtilStageElf(chandle mem_util, string elf_path);
+
+import "DPI-C" function int OtbnMemUtilGetSegCount(chandle mem_util, bit is_imem);
+
+import "DPI-C" function bit OtbnMemUtilGetSegInfo(chandle mem_util, bit is_imem, int seg_idx,
+                                                  output bit [31:0] seg_off,
+                                                  output bit [31:0] seg_size);
+
+import "DPI-C" function bit OtbnMemUtilGetSegData(chandle mem_util, bit is_imem, int word_off,
+                                                  output bit[31:0] data_value);
+
+
+`endif // __OTBN_MEMUTIL_SVH__

--- a/hw/ip/otbn/dv/memutil/otbn_memutil_sim_opts.hjson
+++ b/hw/ip/otbn/dv/memutil/otbn_memutil_sim_opts.hjson
@@ -1,0 +1,24 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  // Additional build-time options needed to compile C++ sources in
+  // simulators such as VCS and Xcelium for anything that uses
+  // otbn_memutil.
+  memutil_dpi_core: "lowrisc:dv_verilator:memutil_dpi:0"
+  memutil_dpi_src_dir: "{eval_cmd} echo \"{memutil_dpi_core}\" | tr ':' '_'"
+
+  build_modes: [
+    {
+      name: vcs_otbn_memutil_build_opts
+      build_opts: ["-CFLAGS -I{build_dir}/src/{memutil_dpi_src_dir}/cpp",
+                   "-lelf"]
+    }
+
+    {
+      name: xcelium_otbn_memutil_build_opts
+      build_opts: ["-I{build_dir}/src/{memutil_dpi_src_dir}/cpp",
+                   "-lelf"]
+    }
+  ]
+}

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.cc
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.cc
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <svdpi.h>
 
+#include "otbn_memutil.h"
 #include "verilated_toplevel.h"
 #include "verilator_memutil.h"
 #include "verilator_sim_ctrl.h"
@@ -18,20 +19,11 @@ extern unsigned int otbn_bignum_reg_get(int index, int quarter);
 
 int main(int argc, char **argv) {
   otbn_top_sim top;
-  VerilatorMemUtil memutil;
+  VerilatorMemUtil memutil(new OtbnMemUtil("TOP.otbn_top_sim"));
+
   VerilatorSimCtrl &simctrl = VerilatorSimCtrl::GetInstance();
   simctrl.SetTop(&top, &top.IO_CLK, &top.IO_RST_N,
                  VerilatorSimCtrlFlags::ResetPolarityNegative);
-
-  MemAreaLoc imem_loc = {.base = 0x100000, .size = 4096};
-  MemAreaLoc dmem_loc = {.base = 0x200000, .size = 4096};
-
-  memutil.RegisterMemoryArea(
-      "dmem", "TOP.otbn_top_sim.u_dmem.u_mem.gen_generic.u_impl_generic", 256,
-      &dmem_loc);
-  memutil.RegisterMemoryArea(
-      "imem", "TOP.otbn_top_sim.u_imem.u_mem.gen_generic.u_impl_generic", 32,
-      &imem_loc);
   simctrl.RegisterExtension(&memutil);
 
   bool exit_app = false;

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.core
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.core
@@ -11,7 +11,7 @@ filesets:
       - lowrisc:ip:otbn:0.1
   files_verilator:
     depend:
-      - lowrisc:dv_verilator:memutil_verilator
+      - lowrisc:dv:otbn_memutil
       - lowrisc:dv_verilator:simutil_verilator
     files:
       - otbn_top_sim.cc: { file_type: cppSource }

--- a/hw/top_earlgrey/top_earlgrey_verilator.cc
+++ b/hw/top_earlgrey/top_earlgrey_verilator.cc
@@ -5,12 +5,12 @@
 #include <iostream>
 
 #include "verilated_toplevel.h"
-#include "verilator_memutil.h"
+#include "verilator_memutil_extension.h"
 #include "verilator_sim_ctrl.h"
 
 int main(int argc, char **argv) {
   top_earlgrey_verilator top;
-  VerilatorMemUtil memutil;
+  VerilatorMemUtilExtension memutil;
   VerilatorSimCtrl &simctrl = VerilatorSimCtrl::GetInstance();
   simctrl.SetTop(&top, &top.clk_i, &top.rst_ni,
                  VerilatorSimCtrlFlags::ResetPolarityNegative);


### PR DESCRIPTION
The first three patches in this series define a "staging area". The idea is that `DpiMemutil` loads up an ELF file, divvying up its segments by destination memory. If you do the normal backdoor load, it then iterates over these segments, loading them into the memory using DPI. However, you can now stop after staging and then allow SystemVerilog code to request the data one word at a time.

The final patch shows how this can work for OTBN. It defines a specialised version of `DpiMemutil` (called `OtbnMemutil`), together with a set of functions that can be called over DPI to actually get the data. Note that this allows "sparse" loads, where you might have some bytes at the bottom of a memory and some bytes at the top, but the middle of the memory is still `'X` (not splatted with zeros).

It's not part of this patch, but I've locally got some code that uses `OtbnMemutil` to load up an ELF, places the writes in a queue, randomises their order, and finally sends them over the TL interface to the DUT (and it works!).

Note that this patch doesn't contain any tests for the logic in `RangedMap`, mainly because I couldn't think of a good way to package them up and run them. Locally I ran some sanity checks, loading up a random sequences of segments and comparing against a "dense" memory model. This found a couple of bugs in the iterator gymnastics, but now everything seems to work.