### PR TITLE
[dv/otp_ctrl] temp remove mem related tests in nightly regression

### DIFF
--- a/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -29,10 +29,11 @@
                 "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",
                 // Common CIP test lists
                 "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
-                // TODO: SW CFG memory can only be read after OTP initialization
+                // TODO: TEST_ACCESS memory only maps to one reg
                 // "{proj_root}/hw/dv/tools/dvsim/tests/mem_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
+                //TODO: TEST_ACCESS memory only maps to one reg
+                //"{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
 
   // Add additional tops for simulation.


### PR DESCRIPTION
Due to TEST_ACCESS mem is only mapped to one internal address, this PR
remove memory access auto test until working with design and find a
solution

Signed-off-by: Cindy Chen <chencindy@google.com>