### PR TITLE
[dv] Remove dead code (initialize_csr_addr_map_size)

### DIFF
--- a/hw/ip/keymgr/dv/env/keymgr_env_cfg.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_env_cfg.sv
@@ -11,10 +11,6 @@ class keymgr_env_cfg extends cip_base_env_cfg #(.RAL_T(keymgr_reg_block));
 
   `uvm_object_new
 
-  virtual function void initialize_csr_addr_map_size();
-    this.csr_addr_map_size = KEYMGR_ADDR_MAP_SIZE;
-  endfunction : initialize_csr_addr_map_size
-
   virtual function void initialize(bit [31:0] csr_base_addr = '1);
     super.initialize(csr_base_addr);
 

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -59,10 +59,6 @@ class chip_env_cfg extends cip_base_env_cfg #(.RAL_T(chip_reg_block));
 
   `uvm_object_new
 
-  virtual function void initialize_csr_addr_map_size();
-    this.csr_addr_map_size = 1 << TL_AW;
-  endfunction : initialize_csr_addr_map_size
-
   virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);
     chip_mem_e mems[] = {Rom,
                          RamMain,


### PR DESCRIPTION
This was orphaned by commit 7e9b524, which taught `dv_base_reg_block` to
calculate the size of its address map.
