### PR TITLE
 [aes_dv] Updated AES to test DUT with back 2 back transactions

### DIFF
--- a/hw/ip/aes/data/aes_testplan.hjson
+++ b/hw/ip/aes/data/aes_testplan.hjson
@@ -48,7 +48,7 @@
            Randomly select the spacing between consecutive messages and blocks from 0 - n clock cycles.
            The distribution will be weighted toward no and small gaps (0-10 cycles) but will also cover larger gaps.'''
       milestone: V2
-      tests: []
+      tests: ["aes_b2b", "aes_stress"]
     }
     {
       name: backpressure

--- a/hw/ip/aes/dv/aes_sim_cfg.hjson
+++ b/hw/ip/aes/dv/aes_sim_cfg.hjson
@@ -67,6 +67,11 @@
       uvm_test: aes_stress_test
       uvm_test_seq: aes_stress_vseq
     }
+    {
+      name: aes_b2b
+      uvm_test: aes_b2b_test
+      uvm_test_seq: aes_stress_vseq
+    }
   ]
 
   // List of regressions.
@@ -77,7 +82,7 @@
     }
      {
       name: stress
-      tests: ["aes_stress"]
+      tests: ["aes_stress","aes_b2b"]
     }
   ]
 }

--- a/hw/ip/aes/dv/env/aes_env.sv
+++ b/hw/ip/aes/dv/env/aes_env.sv
@@ -14,6 +14,7 @@ class aes_env extends cip_base_env #(
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
+
   endfunction
 
   function void connect_phase(uvm_phase phase);

--- a/hw/ip/aes/dv/env/aes_message_item.sv
+++ b/hw/ip/aes/dv/env/aes_message_item.sv
@@ -55,6 +55,7 @@ class aes_message_item extends uvm_sequence_item;
   int    cfb_weight           = 10;
   int    ofb_weight           = 10;
   int    ctr_weight           = 10;
+
   // KEYLEN weights
   int    key_128b_weight      = 10;
   int    key_192b_weight      = 10;

--- a/hw/ip/aes/dv/env/aes_scoreboard.sv
+++ b/hw/ip/aes/dv/env/aes_scoreboard.sv
@@ -456,22 +456,21 @@ class aes_scoreboard extends cip_base_scoreboard #(
                 , UVM_MEDIUM)
       txt = "";
       foreach(msg.input_msg[i]) begin
-        txt = { txt, $sformatf("\n\t  %h \t %h \t %h",
-                               msg.input_msg[i],msg.output_msg[i], msg.predicted_msg[i])};
+        txt = { txt, $sformatf("\n\t %d %h \t %h \t %h",
+                              i, msg.input_msg[i], msg.output_msg[i], msg.predicted_msg[i])};
       end
-
 
       for( int n =0 ; n < msg.input_msg.size(); n++) begin
         if( msg.output_msg[n] != msg.predicted_msg[n]) begin
-          txt = "\t TEST FAILED MESSAGES DID NOT MATCH";
+          txt = {"\t TEST FAILED MESSAGES DID NOT MATCH \n ", txt};
 
-          txt = {txt,  $sformatf("\n\t ----| ACTUAL OUTPUT DID NOT MATCH PREDICTED OUTPUT |----")};
-          txt = {txt, $sformatf("\n\t ----| FAILED AT BLOCK #%d \t ACTUAL: %h \t PREDICTED: %h, ",
+          txt = {txt,  $sformatf("\n\n\t ----| ACTUAL OUTPUT DID NOT MATCH PREDICTED OUTPUT |----")};
+          txt = {txt, $sformatf("\n\t ----| FAILED AT BYTE #%0d \t ACTUAL: 0x%h \t PREDICTED: 0x%h, ",
                                 n, msg.output_msg[n], msg.predicted_msg[n] )};
-          `uvm_fatal(`gfn, $sformatf(" # %d  \n\t %s \n",message_cnt, txt))
+          `uvm_fatal(`gfn, $sformatf(" # %0d  \n\t %s \n", message_cnt, txt))
         end
       end
-      `uvm_info(`gfn, $sformatf("\n\t ----|   MESSAGE #%0d MATCHED    |-----",message_cnt), UVM_MEDIUM)
+      `uvm_info(`gfn, $sformatf("\n\t ----|   MESSAGE #%0d MATCHED    |-----",message_cnt), UVM_LOW)
       message_cnt++;
     end
   endtask

--- a/hw/ip/aes/dv/env/aes_seq_item.sv
+++ b/hw/ip/aes/dv/env/aes_seq_item.sv
@@ -36,6 +36,8 @@ class aes_seq_item extends uvm_sequence_item;
   bit [3:0]       iv_vld;
   aes_mode_e      mode;
 
+  bit             en_b2b_transactions = 1;
+
 
   ///////////////////////////////////////
   // Fixed variables                   //
@@ -52,7 +54,7 @@ class aes_seq_item extends uvm_sequence_item;
   // set if data should be fixed and not randomized
   bit             fixed_data          = 0;
   // if set unused key bytes will be forced to 0 - controlled from test
-  bit             key_mask            = 0;
+  bit             key_mask            = 1;
 
 
   ///////////////////////////////////////
@@ -61,6 +63,9 @@ class aes_seq_item extends uvm_sequence_item;
 
   // used by the checker
   rand  bit [3:0][31:0] data_in;
+
+  // back to back
+  rand bit              do_b2b;
 
 
   function new( string name="aes_sequence_item");
@@ -82,7 +87,9 @@ class aes_seq_item extends uvm_sequence_item;
         end
         default: begin
         end
-      endcase
+      endcase // case (key_len)
+
+      if (!en_b2b_transactions) do_b2b = 0;
     end
 
     // mask unused data bits

--- a/hw/ip/aes/dv/env/seq_lib/aes_wake_up_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_wake_up_vseq.sv
@@ -19,6 +19,7 @@ class aes_wake_up_vseq extends aes_base_vseq;
   bit [3:0] [31:0]    decrypted_text;
   logic [3:0] [31:0]  read_text;
   string              str="";
+  bit                 do_b2b = 0;
 
 
   task body();
@@ -33,12 +34,12 @@ class aes_wake_up_vseq extends aes_base_vseq;
     set_operation(ENCRYPT);
 
     `uvm_info(`gfn, $sformatf(" \n\t ---| WRITING INIT KEY \n\t ----| SHARE0 %02h \n\t ---| SHARE1 %02h ", init_key[0], init_key[1]), UVM_HIGH)
-    write_key(init_key);
+    write_key(init_key, do_b2b);
     cfg.clk_rst_vif.wait_clks(20);
 
     `uvm_info(`gfn, $sformatf(" \n\t ---| ADDING PLAIN TEXT"), UVM_HIGH)
 
-    add_data(plain_text);
+    add_data(plain_text, do_b2b);
 
     cfg.clk_rst_vif.wait_clks(20);
     // poll status register
@@ -47,7 +48,7 @@ class aes_wake_up_vseq extends aes_base_vseq;
                               ral.status.convert2string()), UVM_DEBUG)
 
     csr_spinwait(.ptr(ral.status.output_valid) , .exp_data(1'b1));
-    read_data(cypher_text);
+    read_data(cypher_text, do_b2b);
     // read output
     `uvm_info(`gfn, $sformatf("\n\t ------|WAIT 0 |-------"), UVM_HIGH)
     cfg.clk_rst_vif.wait_clks(20);
@@ -56,10 +57,10 @@ class aes_wake_up_vseq extends aes_base_vseq;
     set_operation(DECRYPT);
     cfg.clk_rst_vif.wait_clks(20);
     `uvm_info(`gfn, $sformatf("\n\t ---| WRITING INIT KEY \n\t ----| SHARE0 %02h \n\t ---| SHARE1 %02h ", init_key[0], init_key[1]), UVM_HIGH)
-    write_key(init_key);
+    write_key(init_key, do_b2b);
     cfg.clk_rst_vif.wait_clks(20);
     `uvm_info(`gfn, $sformatf("\n\t ---| WRITING CYPHER TEXT"), UVM_HIGH)
-    add_data(cypher_text);
+    add_data(cypher_text, do_b2b);
 
 
     `uvm_info(`gfn, $sformatf("\n\t ---| Polling for data %s", ral.status.convert2string()),
@@ -67,7 +68,7 @@ class aes_wake_up_vseq extends aes_base_vseq;
 
     cfg.clk_rst_vif.wait_clks(20);
     csr_spinwait(.ptr(ral.status.output_valid) , .exp_data(1'b1));
-    read_data(decrypted_text);
+    read_data(decrypted_text, do_b2b);
     //need scoreboard disable
     foreach(plain_text[i]) begin
       if(plain_text[i] != decrypted_text[i]) begin

--- a/hw/ip/aes/dv/tests/aes_b2b_test.sv
+++ b/hw/ip/aes/dv/tests/aes_b2b_test.sv
@@ -2,24 +2,25 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class aes_stress_test extends aes_base_test;
-  `uvm_component_utils(aes_stress_test)
+
+class aes_b2b_test extends aes_base_test;
+  `uvm_component_utils(aes_b2b_test)
   `uvm_component_new
 
    virtual function void build_phase(uvm_phase phase);
      super.build_phase(phase);
      configure_env();
-     // TODO fix manual mode so we can randomize speeds
-     `DV_CHECK_RANDOMIZE_WITH_FATAL(cfg, cfg.host_resp_speed  == VeryFast;)
+     `DV_CHECK_RANDOMIZE_FATAL(cfg)
   endfunction
 
   virtual function void configure_env();
     //   cfg.ref_model          = OpenSSL;
     // env related knobs
 
+    // TODO fix manual mode so we can randomize speeds
     cfg.errors_en                = 0;
     cfg.num_messages_min         = 1;
-    cfg.num_messages_max         = 50;
+    cfg.num_messages_max         = 5;
     // message related knobs
     cfg.ecb_weight               = 10;
     cfg.cbc_weight               = 10;
@@ -43,6 +44,6 @@ class aes_stress_test extends aes_base_test;
 
     cfg.random_data_key_iv_order = 1;
 
-    cfg.manual_operation_pct     = 30;
+    cfg.manual_operation_pct     = 0;
   endfunction // configure_env
-endclass : aes_stress_test
+endclass : aes_b2b_test

--- a/hw/ip/aes/dv/tests/aes_base_test.sv
+++ b/hw/ip/aes/dv/tests/aes_base_test.sv
@@ -73,6 +73,5 @@ class aes_base_test extends cip_base_test #(
     cfg.error_types                 = 3'b111;
 
     cfg.config_error_pct            = 0;           // percentage of configuration errors
- `DV_CHECK_RANDOMIZE_FATAL(cfg)
   endfunction
 endclass : aes_base_test

--- a/hw/ip/aes/dv/tests/aes_sanity_test.sv
+++ b/hw/ip/aes/dv/tests/aes_sanity_test.sv
@@ -7,13 +7,18 @@ class aes_sanity_test extends aes_base_test;
   `uvm_component_utils(aes_sanity_test)
   `uvm_component_new
 
-   virtual function void build_phase(uvm_phase phase);
-     super.build_phase(phase);
-     configure_env();
+
+  virtual function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    configure_env();
   endfunction
 
   function void configure_env();
     super.configure_env();
+
+//    the feature below is waiting in anther PR
+//    cfg.zero_delay_pct           = 100;
+
     cfg.errors_en                = 0;     // no errors in sanity test
     cfg.num_messages_min         = 2;
     cfg.num_messages_max         = 2;

--- a/hw/ip/aes/dv/tests/aes_test.core
+++ b/hw/ip/aes/dv/tests/aes_test.core
@@ -14,6 +14,7 @@ filesets:
       - aes_wake_up_test.sv: {is_include_file: true}
       - aes_sanity_test.sv: {is_include_file: true}
       - aes_stress_test.sv: {is_include_file: true}
+      - aes_b2b_test.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:

--- a/hw/ip/aes/dv/tests/aes_test_pkg.sv
+++ b/hw/ip/aes/dv/tests/aes_test_pkg.sv
@@ -21,5 +21,6 @@ package aes_test_pkg;
   `include "aes_wake_up_test.sv"
   `include "aes_sanity_test.sv"
   `include "aes_stress_test.sv"
+  `include "aes_b2b_test.sv"
 
 endpackage

--- a/hw/ip/aes/dv/tests/aes_wake_up_test.sv
+++ b/hw/ip/aes/dv/tests/aes_wake_up_test.sv
@@ -13,6 +13,7 @@ class aes_wake_up_test extends aes_base_test;
   endfunction
 
   virtual function void configure_env();
+     cfg.en_scb             = 0;
      cfg.ecb_weight         = 100;
      cfg.cbc_weight         = 0;
      cfg.ctr_weight         = 0;


### PR DESCRIPTION
This PR is the first in a series of PRs that will update AES DV behavior and functionality as we progress towards V2.
in this PR I added random b2b variable to set blocking in csr sequence 
The back to back behavior is randomized during environment configuration and not changed during simulation.

this PR also instantiates the TL config item to make TL-UL delays configurable
this is randomized in configuration as host resposiveness
A problem exists in manual mode when responsiveness is very slow- which is fixed in a PR that will follow this.



