### PR TITLE
[dv/alert_handler] separate esc ping_timeout and resp sig_int_fail

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_seq_item.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_seq_item.sv
@@ -16,7 +16,7 @@ class alert_esc_seq_item extends uvm_sequence_item;
   rand bit r_esc_rsp;
   rand bit int_err;
   rand bit standalone_int_err;
-  rand bit timeout;
+  rand bit ping_timeout;
   rand alert_sig_int_err_e alert_int_err_type;
 
   // for monitor only
@@ -60,7 +60,7 @@ class alert_esc_seq_item extends uvm_sequence_item;
     `uvm_field_int (r_esc_rsp,         UVM_DEFAULT)
     `uvm_field_int (int_err,           UVM_DEFAULT)
     `uvm_field_int (standalone_int_err,UVM_DEFAULT)
-    `uvm_field_int (timeout,           UVM_DEFAULT)
+    `uvm_field_int (ping_timeout,      UVM_DEFAULT)
     `uvm_field_int (ping_delay,        UVM_DEFAULT)
     `uvm_field_int (ack_delay,         UVM_DEFAULT)
     `uvm_field_int (ack_stable,        UVM_DEFAULT)

--- a/hw/dv/sv/alert_esc_agent/alert_monitor.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_monitor.sv
@@ -44,7 +44,7 @@ class alert_monitor extends alert_esc_base_monitor;
             fork
               begin : wait_ping_timeout
                 repeat (cfg.ping_timeout_cycle - 1) @(cfg.vif.monitor_cb);
-                req.timeout = 1'b1;
+                req.ping_timeout = 1'b1;
               end
               begin : wait_ping_handshake
                 // in case there is an alert happened before ping
@@ -74,7 +74,7 @@ class alert_monitor extends alert_esc_base_monitor;
 
           // spurious alert error, can only happen one clock after timeout. Detail please see
           // discussion on Issue #2321
-          if (req.timeout && req.alert_handshake_sta == AlertReceived) begin
+          if (req.ping_timeout && req.alert_handshake_sta == AlertReceived) begin
             @(cfg.vif.monitor_cb);
             if (cfg.vif.alert_rx.ack_p == 1'b1) alert_esc_port.write(req);
           end
@@ -106,7 +106,7 @@ class alert_monitor extends alert_esc_base_monitor;
             fork
               begin : alert_timeout
                 repeat (cfg.handshake_timeout_cycle) @(cfg.vif.monitor_cb);
-                req.timeout = 1'b1;
+                req.ping_timeout = 1'b1;
               end
               begin : wait_alert_handshake
                 wait_ack();

--- a/hw/dv/sv/alert_esc_agent/alert_sender_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_sender_driver.sv
@@ -89,7 +89,7 @@ class alert_sender_driver extends alert_esc_base_driver;
             begin
               wait_ping();
               alert_atomic.get(1);
-              if (!req.timeout) begin
+              if (!req.ping_timeout) begin
                 drive_alert_pins(req);
               end else begin
                 repeat (cfg.ping_timeout_cycle) wait_sender_clk();

--- a/hw/dv/sv/alert_esc_agent/esc_monitor.sv
+++ b/hw/dv/sv/alert_esc_agent/esc_monitor.sv
@@ -56,7 +56,7 @@ class esc_monitor extends alert_esc_base_monitor;
           if (ping_cnter >= cfg.ping_timeout_cycle) begin
             alert_esc_seq_item req_clone;
             `downcast(req_clone, req.clone());
-            req_clone.timeout = 1;
+            req_clone.ping_timeout = 1;
             alert_esc_port.write(req_clone);
             // alignment for prim_esc_sender design. Design does not know ping timeout cycles, only
             // way to exit FSM is when state is IDLE or PingComplete.
@@ -97,7 +97,7 @@ class esc_monitor extends alert_esc_base_monitor;
         end
 
         `uvm_info("esc_monitor", $sformatf("[%s]: handshake status is %s, timeout=%0b",
-            req.alert_esc_type.name(), req.esc_handshake_sta.name(), req.timeout), UVM_HIGH)
+            req.alert_esc_type.name(), req.esc_handshake_sta.name(), req.ping_timeout), UVM_HIGH)
          if (cfg.en_cov) begin
            cov.m_esc_handshake_complete_cg.sample(req.alert_esc_type, req.esc_handshake_sta);
            if (cfg.en_ping_cov) cov.m_alert_esc_trans_cg.sample(req.alert_esc_type);

--- a/hw/dv/sv/alert_esc_agent/seq_lib/alert_sender_base_seq.sv
+++ b/hw/dv/sv/alert_esc_agent/seq_lib/alert_sender_base_seq.sv
@@ -15,7 +15,7 @@ class alert_sender_base_seq extends dv_base_seq #(
   rand bit s_alert_send;
   rand bit s_alert_ping_rsp;
   rand bit int_err;
-  rand bit timeout;
+  rand bit ping_timeout;
 
   virtual task body();
     `uvm_info(`gfn, $sformatf("starting alert sender transfer"), UVM_HIGH)
@@ -25,7 +25,7 @@ class alert_sender_base_seq extends dv_base_seq #(
         s_alert_send     == local::s_alert_send;
         s_alert_ping_rsp == local::s_alert_ping_rsp;
         int_err          == local::int_err;
-        timeout          == local::timeout;
+        ping_timeout     == local::ping_timeout;
     )
     `uvm_info(`gfn, $sformatf("seq_item: send_alert=%0b, ping_rsp=%0b, int_err=%0b",
         req.s_alert_send, req.s_alert_ping_rsp, req.int_err), UVM_MEDIUM)

--- a/hw/dv/sv/alert_esc_agent/seq_lib/alert_sender_seq.sv
+++ b/hw/dv/sv/alert_esc_agent/seq_lib/alert_sender_seq.sv
@@ -11,7 +11,7 @@ class alert_sender_seq extends alert_sender_base_seq;
   constraint alert_sender_seq_c {
     s_alert_send     == 1;
     s_alert_ping_rsp == 0;
-    timeout          == 0;
+    ping_timeout     == 0;
   }
 
 endclass : alert_sender_seq

--- a/hw/dv/sv/alert_esc_agent/seq_lib/esc_receiver_base_seq.sv
+++ b/hw/dv/sv/alert_esc_agent/seq_lib/esc_receiver_base_seq.sv
@@ -15,6 +15,7 @@ class esc_receiver_base_seq extends dv_base_seq #(
   rand bit int_err;
   rand bit r_esc_rsp;
   rand bit standalone_int_err;
+  rand bit ping_timeout;
 
   virtual task body();
     `uvm_info(`gfn, $sformatf("starting escalator receiver transfer"), UVM_HIGH)
@@ -24,9 +25,10 @@ class esc_receiver_base_seq extends dv_base_seq #(
         r_esc_rsp          == local::r_esc_rsp;
         int_err            == local::int_err;
         standalone_int_err == local::standalone_int_err;
+        ping_timeout       == local::ping_timeout;
     )
-    `uvm_info(`gfn, $sformatf("seq_item: esc_rsp=%0b, int_err=%0b",
-        req.r_esc_rsp, req.int_err), UVM_MEDIUM)
+    `uvm_info(`gfn, $sformatf("seq_item: esc_rsp=%0b, int_err=%0b, ping_timeout=%0b",
+        req.r_esc_rsp, req.int_err, req.ping_timeout), UVM_MEDIUM)
     finish_item(req);
     get_response(rsp);
     `uvm_info(`gfn, "escalator receiver transfer done", UVM_HIGH)

--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -80,13 +80,13 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
           alert_esc_seq_item item;
           alert_fifos[alert_name].get(item);
           if (!cfg.en_scb) continue;
-          if (item.alert_esc_type == AlertEscSigTrans && !item.timeout &&
+          if (item.alert_esc_type == AlertEscSigTrans && !item.ping_timeout &&
               item.alert_handshake_sta inside {AlertReceived, AlertAckComplete}) begin
             process_alert(alert_name, item);
           // IP level alert protocol does not drive any sig_int_err or ping response
           end else if (item.alert_esc_type == AlertEscIntFail) begin
             `uvm_error(`gfn, $sformatf("alert %s has unexpected signal int error", alert_name))
-          end else if (item.timeout) begin
+          end else if (item.ping_timeout) begin
             `uvm_error(`gfn, $sformatf("alert %s has unexpected timeout error", alert_name))
           end else if (item.alert_esc_type == AlertEscPingTrans) begin
             `uvm_error(`gfn, $sformatf("alert %s has unexpected alert ping response", alert_name))

--- a/hw/ip/alert_handler/dv/env/alert_handler_scoreboard.sv
+++ b/hw/ip/alert_handler/dv/env/alert_handler_scoreboard.sv
@@ -89,14 +89,15 @@ class alert_handler_scoreboard extends cip_base_scoreboard #(
           alert_en = ral.alert_en.get_mirrored_value();
           if (alert_en[index]) begin
             // alert detected
-            if (act_item.alert_esc_type == AlertEscSigTrans && !act_item.timeout &&
+            if (act_item.alert_esc_type == AlertEscSigTrans && !act_item.ping_timeout &&
                 act_item.alert_handshake_sta == AlertReceived) begin
               process_alert_sig(index, 0);
             // alert integrity fail
             end else if (act_item.alert_esc_type == AlertEscIntFail) begin
               bit [TL_DW-1:0] loc_alert_en = ral.loc_alert_en.get_mirrored_value();
               if (loc_alert_en[LocalAlertIntFail]) process_alert_sig(index, 1, LocalAlertIntFail);
-            end else if (act_item.alert_esc_type == AlertEscPingTrans && act_item.timeout) begin
+            end else if (act_item.alert_esc_type == AlertEscPingTrans &&
+                         act_item.ping_timeout) begin
               bit [TL_DW-1:0] loc_alert_en = ral.loc_alert_en.get_mirrored_value();
               if (loc_alert_en[LocalAlertPingFail]) begin
                 process_alert_sig(index, 1, LocalAlertPingFail);
@@ -123,11 +124,11 @@ class alert_handler_scoreboard extends cip_base_scoreboard #(
             check_esc_signal(act_item.sig_cycle_cnt, index);
           // escalation integrity fail
           end else if (act_item.alert_esc_type == AlertEscIntFail ||
-               (act_item.esc_handshake_sta == EscIntFail && !act_item.timeout)) begin
+               (act_item.esc_handshake_sta == EscIntFail && !act_item.ping_timeout)) begin
             bit [TL_DW-1:0] loc_alert_en = ral.loc_alert_en.get_mirrored_value();
             if (loc_alert_en[LocalEscIntFail]) process_alert_sig(index, 1, LocalEscIntFail);
           // escalation ping timeout
-          end else if (act_item.alert_esc_type == AlertEscPingTrans && act_item.timeout) begin
+          end else if (act_item.alert_esc_type == AlertEscPingTrans && act_item.ping_timeout) begin
             bit [TL_DW-1:0] loc_alert_en = ral.loc_alert_en.get_mirrored_value();
             if (loc_alert_en[LocalEscPingFail]) begin
               process_alert_sig(index, 1, LocalEscPingFail);

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
@@ -111,7 +111,8 @@ class alert_handler_base_vseq extends cip_base_vseq #(
               begin
                 esc_receiver_esc_rsp_seq esc_seq =
                     esc_receiver_esc_rsp_seq::type_id::create("esc_seq");
-                `DV_CHECK_RANDOMIZE_WITH_FATAL(esc_seq, int_err == 1; standalone_int_err == 1;)
+                `DV_CHECK_RANDOMIZE_WITH_FATAL(esc_seq, int_err == 1; standalone_int_err == 1;
+                                               ping_timeout == 0;)
                 esc_seq.start(p_sequencer.esc_device_seqr_h[index]);
               end
             join_none
@@ -251,15 +252,18 @@ class alert_handler_base_vseq extends cip_base_vseq #(
   endtask
 
   // This sequence will automatically response to all escalation ping and esc responses
-  virtual task run_esc_rsp_seq_nonblocking(bit [NUM_ESCS-1:0] esc_int_errs = '0);
+  virtual task run_esc_rsp_seq_nonblocking(bit [NUM_ESCS-1:0] esc_int_errs = '0,
+                                           bit [NUM_ESCS-1:0] ping_timeout_errs = '0);
     foreach (cfg.esc_device_cfg[i]) begin
       automatic int index = i;
       fork
         forever begin
-          bit esc_int_err = esc_int_errs[index] ? $urandom_range(0, 1) : 0;
+          bit esc_int_err      = esc_int_errs[index]      ? $urandom_range(0, 1) : 0;
+          bit ping_timeout_err = ping_timeout_errs[index] ? $urandom_range(0, 1) : 0;
           esc_receiver_esc_rsp_seq esc_seq =
               esc_receiver_esc_rsp_seq::type_id::create("esc_seq");
-          `DV_CHECK_RANDOMIZE_WITH_FATAL(esc_seq, int_err == esc_int_err; standalone_int_err == 0;)
+          `DV_CHECK_RANDOMIZE_WITH_FATAL(esc_seq, int_err == esc_int_err; standalone_int_err == 0;
+                                         ping_timeout == ping_timeout_err;)
           esc_seq.start(p_sequencer.esc_device_seqr_h[index]);
         end
       join_none

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
@@ -275,7 +275,7 @@ class alert_handler_base_vseq extends cip_base_vseq #(
           bit alert_timeout = alert_int_err[index] ? $urandom_range(0, 1) : 0;
           alert_sender_ping_rsp_seq ping_seq =
               alert_sender_ping_rsp_seq::type_id::create("ping_seq");
-          `DV_CHECK_RANDOMIZE_WITH_FATAL(ping_seq, int_err == 0; timeout == alert_timeout;)
+          `DV_CHECK_RANDOMIZE_WITH_FATAL(ping_seq, int_err == 0; ping_timeout == alert_timeout;)
           ping_seq.start(p_sequencer.alert_host_seqr_h[index]);
         end
       join_none

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_ping_corner_cases_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_ping_corner_cases_vseq.sv
@@ -31,8 +31,12 @@ class alert_handler_ping_corner_cases_vseq extends alert_handler_entropy_vseq;
 
   constraint sig_int_c {
     esc_int_err == '1;
-    esc_standalone_int_err dist {0 :/ 9, [1:'b1111] :/ 1};
+    esc_standalone_int_err dist {0 :/ 9, [1:'1] :/ 1};
+  }
+
+  constraint ping_fail_c {
     alert_ping_timeout == '1;
+    esc_ping_timeout   == '1;
   }
 
   constraint ping_timeout_cyc_c {

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_sanity_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_sanity_vseq.sv
@@ -20,6 +20,7 @@ class alert_handler_sanity_vseq extends alert_handler_base_vseq;
   rand bit [NUM_LOCAL_ALERT*2-1:0]         local_alert_class_map;
   rand bit [NUM_ESCS-1:0]                  esc_int_err;
   rand bit [NUM_ESCS-1:0]                  esc_standalone_int_err;
+  rand bit [NUM_ESCS-1:0]                  esc_ping_timeout;
 
   rand bit do_clr_esc;
   rand bit do_wr_phases_cyc;
@@ -79,6 +80,11 @@ class alert_handler_sanity_vseq extends alert_handler_base_vseq;
     esc_standalone_int_err == 0;
   }
 
+  constraint ping_fail_c {
+    alert_ping_timeout == 0;
+    esc_ping_timeout   == 0;
+  }
+
   task body();
     fork
       begin : isolation_fork
@@ -91,7 +97,9 @@ class alert_handler_sanity_vseq extends alert_handler_base_vseq;
 
   virtual task trigger_non_blocking_seqs();
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(esc_int_err)
-    run_esc_rsp_seq_nonblocking(esc_int_err);
+    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(alert_ping_timeout)
+    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(esc_ping_timeout)
+    run_esc_rsp_seq_nonblocking(esc_int_err, esc_ping_timeout);
     run_alert_ping_rsp_seq_nonblocking(alert_ping_timeout);
   endtask
 


### PR DESCRIPTION
There are two commits within this PR:
1. Rename `alert_esc_seq_item` bit `timeout` to `ping_timeout`. Because alert/esc normal handshake does not have timeout. The only timeout counters are coming from alert/esc pings. So I update the naming to be more clear.
2. Separate esc ping_timeout and esc_int_fail.
In current code, these two items are used in by the same bit `int_fail` because for esc_ping_timeoue, each cycle that the response does not match expected behavior, it will trigger a `int_fail`. But alert has a ping_timeout, I think it would be good to separate out one for escalation as well.
There is no functional change in alert_handler TB, just clean up and separation. 