### PR TITLE
[dv/otp_ctrl] enable memory auto test

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.sv
@@ -45,13 +45,21 @@ class otp_ctrl_env extends cip_base_env #(
     uvm_config_db#(push_pull_agent_cfg#(FLASH_DATA_SIZE))::set(this, "m_flash_data_pull_agent",
         "cfg", cfg.m_flash_data_pull_agent_cfg);
 
+    // config power manager pin
     if (!uvm_config_db#(pwr_otp_vif)::get(this, "", "pwr_otp_vif", cfg.pwr_otp_vif)) begin
       `uvm_fatal(get_full_name(), "failed to get pwr_otp_vif from uvm_config_db")
     end
+
+    // config lc pins
     if (!uvm_config_db#(lc_provision_en_vif)::get(this, "", "lc_provision_en_vif",
                                                   cfg.lc_provision_en_vif)) begin
       `uvm_fatal(get_full_name(), "failed to get lc_provision_en_vif from uvm_config_db")
     end
+    if (!uvm_config_db#(lc_dft_en_vif)::get(this, "", "lc_dft_en_vif", cfg.lc_dft_en_vif)) begin
+      `uvm_fatal(get_full_name(), "failed to get lc_dft_en_vif from uvm_config_db")
+    end
+
+    // config mem virtual interface
     if (!uvm_config_db#(mem_bkdr_vif)::get(this, "", "mem_bkdr_vif", cfg.mem_bkdr_vif)) begin
       `uvm_fatal(`gfn, "failed to get mem_bkdr_vif from uvm_config_db")
     end

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
@@ -13,6 +13,7 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_reg_block));
   // ext interfaces
   pwr_otp_vif         pwr_otp_vif;
   lc_provision_en_vif lc_provision_en_vif;
+  lc_dft_en_vif       lc_dft_en_vif;
   mem_bkdr_vif        mem_bkdr_vif;
 
   `uvm_object_utils_begin(otp_ctrl_env_cfg)

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -22,18 +22,18 @@ package otp_ctrl_env_pkg;
   `include "dv_macros.svh"
 
   // parameters
-  parameter uint DIGEST_SIZE           = 8;
-  parameter uint SW_WINDOW_BASE_ADDR   = 'h1000;
-  parameter uint TEST_ACCESS_BASE_ADDR = 'h2000;
-  parameter uint WINDOW_SIZE           = 512 * 4;
+  parameter uint DIGEST_SIZE             = 8;
+  parameter uint SW_WINDOW_BASE_ADDR     = 'h1000;
+  parameter uint TEST_ACCESS_BASE_ADDR   = 'h2000;
+  parameter uint SW_WINDOW_SIZE          = 512 * 4;
+  parameter uint TEST_ACCESS_WINDOW_SIZE = 16 * 4;
+
   // sram rsp data has 1 bit for seed_valid, the rest are for key and nonce
-  parameter uint SRAM_DATA_SIZE        = 1 + otp_ctrl_pkg::SramKeyWidth +
-                                             otp_ctrl_pkg::SramNonceWidth;
+  parameter uint SRAM_DATA_SIZE  = 1 + otp_ctrl_pkg::SramKeyWidth + otp_ctrl_pkg::SramNonceWidth;
   // otbn rsp data has 1 bit for seed_valid, the rest are for key and nonce
-  parameter uint OTBN_DATA_SIZE        = 1 + otp_ctrl_pkg::OtbnKeyWidth +
-                                             otp_ctrl_pkg::OtbnNonceWidth;
+  parameter uint OTBN_DATA_SIZE  = 1 + otp_ctrl_pkg::OtbnKeyWidth + otp_ctrl_pkg::OtbnNonceWidth;
   // flash rsp data has 1 bit for seed_valid, the rest are for key
-  parameter uint FLASH_DATA_SIZE       = 1 + otp_ctrl_pkg::FlashKeyWidth;
+  parameter uint FLASH_DATA_SIZE = 1 + otp_ctrl_pkg::FlashKeyWidth;
 
   // lc does not have digest
   parameter bit[10:0] DIGESTS_ADDR [NumPart-1] = {
@@ -47,6 +47,7 @@ package otp_ctrl_env_pkg;
   // types
   typedef virtual pins_if #(3) pwr_otp_vif;
   typedef virtual pins_if #(4) lc_provision_en_vif;
+  typedef virtual pins_if #(4) lc_dft_en_vif;
   typedef virtual mem_bkdr_if mem_bkdr_vif;
 
   typedef enum bit [1:0] {

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -60,8 +60,8 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
     // memories
     // TODO: memory read check, change hardcoded to parameters once design finalized
     end else if ((csr_addr & addr_mask) inside
-        {[SW_WINDOW_BASE_ADDR : SW_WINDOW_BASE_ADDR + WINDOW_SIZE],
-         [TEST_ACCESS_BASE_ADDR : TEST_ACCESS_BASE_ADDR + WINDOW_SIZE]}) begin
+        {[SW_WINDOW_BASE_ADDR : SW_WINDOW_BASE_ADDR + SW_WINDOW_SIZE],
+         [TEST_ACCESS_BASE_ADDR : TEST_ACCESS_BASE_ADDR + TEST_ACCESS_WINDOW_SIZE]}) begin
       return;
     end else begin
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -19,9 +19,10 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
 
   virtual task dut_init(string reset_kind = "HARD");
     super.dut_init(reset_kind);
+    // reset power init pin and lc pins
     cfg.pwr_otp_vif.drive_pin(0, 0);
     cfg.lc_provision_en_vif.drive(lc_ctrl_pkg::Off);
-    // reset power init pin and lc_provision_en pin
+    cfg.lc_dft_en_vif.drive(lc_ctrl_pkg::Off);
     if (do_otp_ctrl_init) otp_ctrl_init();
   endtask
 

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_common_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_common_vseq.sv
@@ -14,6 +14,8 @@ class otp_ctrl_common_vseq extends otp_ctrl_base_vseq;
     super.dut_init(reset_kind);
     // drive pwr_otp_req pin
     cfg.pwr_otp_vif.drive_pin(0, 1);
+    // drive dft_en pins to access the test_access memory
+    cfg.lc_dft_en_vif.drive(lc_ctrl_pkg::On);
     wait(cfg.pwr_otp_vif.pins[2] == 1);
   endtask
 

--- a/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -29,11 +29,9 @@
                 "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",
                 // Common CIP test lists
                 "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
-                // TODO: TEST_ACCESS memory only maps to one reg
-                // "{proj_root}/hw/dv/tools/dvsim/tests/mem_tests.hjson",
+                "{proj_root}/hw/dv/tools/dvsim/tests/mem_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
-                //TODO: TEST_ACCESS memory only maps to one reg
-                //"{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
+                "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
 
   // Add additional tops for simulation.

--- a/hw/ip/otp_ctrl/dv/tb.sv
+++ b/hw/ip/otp_ctrl/dv/tb.sv
@@ -17,9 +17,8 @@ module tb;
 
   wire clk, rst_n;
   wire devmode;
-  wire [3:0] lc_provision_en;
+  wire [3:0] lc_provision_en, lc_dft_en;
 
-  // TODO: use standard req/rsp agent
   wire [2:0] pwr_otp;
   wire otp_ctrl_pkg::flash_otp_key_req_t flash_req;
   wire otp_ctrl_pkg::flash_otp_key_rsp_t flash_rsp;
@@ -42,6 +41,7 @@ module tb;
   // TODO: use standard req/rsp agent
   pins_if #(3) pwr_otp_if(pwr_otp);
   pins_if #(4) lc_provision_en_if(lc_provision_en);
+  pins_if #(4) lc_dft_en_if(lc_dft_en);
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
 
   // dut
@@ -73,7 +73,7 @@ module tb;
     .lc_otp_token_o            (  ),
     .lc_escalate_en_i          (lc_ctrl_pkg::Off),
     .lc_provision_en_i         (lc_provision_en),
-    .lc_dft_en_i               ('0),
+    .lc_dft_en_i               (lc_dft_en),
     .otp_lc_data_o             (  ),
     // keymgr
     .otp_keymgr_key_o          (  ),
@@ -135,6 +135,7 @@ module tb;
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
     uvm_config_db#(lc_provision_en_vif)::set(null, "*.env", "lc_provision_en_vif",
                                              lc_provision_en_if);
+    uvm_config_db#(lc_dft_en_vif)::set(null, "*.env", "lc_dft_en_vif", lc_dft_en_if);
     uvm_config_db#(mem_bkdr_vif)::set(null, "*.env", "mem_bkdr_vif", `OTP_CTRL_MEM_HIER.mem_bkdr_if);
     $timeformat(-12, 0, " ps", 12);
     run_test();


### PR DESCRIPTION
enable memory automation test for otp_ctrl. The test_access memory can
only be accessed when lc_dft_en is on. So this PR added a pin interface
for this port to be turned on while running automation tests.

Signed-off-by: Cindy Chen <chencindy@google.com>