### PR TITLE
[dv/top-earlgrey] Support otp_mem auto-tests

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -66,7 +66,8 @@ class chip_env_cfg extends cip_base_env_cfg #(.RAL_T(chip_reg_block));
                          FlashBank0,
                          FlashBank1,
                          FlashBank0Info,
-                         FlashBank1Info};
+                         FlashBank1Info,
+                         Otp};
 
     has_devmode = 0;
     list_of_alerts = chip_env_pkg::LIST_OF_ALERTS;

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -49,6 +49,7 @@ package chip_env_pkg;
     FlashBank1,
     FlashBank0Info,
     FlashBank1Info,
+    Otp,
     SpiMem
   } chip_mem_e;
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
@@ -19,6 +19,7 @@ class chip_common_vseq extends chip_base_vseq;
 
   virtual task apply_reset(string kind = "HARD");
     super.apply_reset(kind);
+    cfg.mem_bkdr_vifs[Otp].clear_mem();
     wait (cfg.rst_n_mon_vif.pins[0] === 1);
     cfg.clk_rst_vif.wait_clks(100);
   endtask
@@ -29,10 +30,6 @@ class chip_common_vseq extends chip_base_vseq;
     super.dut_init(reset_kind);
     cfg.jtag_spi_n_vif.drive(1'b0);
   endtask
-
-  virtual function void shadow_reg_storage_err_post_write();
-    ral.aes.status.ctrl_err_storage.predict(1);
-  endfunction
 
   virtual task body();
     run_common_vseq_wrapper(num_trans);

--- a/hw/top_earlgrey/dv/tb/chip_hier_macros.svh
+++ b/hw/top_earlgrey/dv/tb/chip_hier_macros.svh
@@ -22,3 +22,5 @@
 `define FLASH1_MEM_HIER    `FLASH_BANK1.u_mem
 `define FLASH0_INFO_HIER   `FLASH_BANK0.u_info_mem
 `define FLASH1_INFO_HIER   `FLASH_BANK1.u_info_mem
+`define OTP_MEM_HIER       `CHIP_HIER.u_otp_ctrl.u_otp.gen_generic.u_impl_generic.i_prim_ram_1p_adv.\
+                           u_mem.gen_generic.u_impl_generic


### PR DESCRIPTION
To support top-level OTP mem test, this PR added the following:
1. Add a backdoor mem to initialize OTP_mem to avoid X assertion errors.
2. Add options to run OTP mem tests after OTP init.
3. Temp force pwr_req_i signal to 1 to trigger OTP init. Once the OTP is
connected to pwrmgr, we can replace it with real sequence.

Signed-off-by: Cindy Chen <chencindy@google.com>