### PR TITLE
[top/otp_ctrl] Connect init request to pwrmgr

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson
@@ -882,6 +882,9 @@
       hwqe:     "true",
       hwext:    "true",
       regwen:   "CHECK_TRIGGER_REGWEN",
+      tags:     [ // Triggering any of these checks may lead to unintended alerts
+                  // if the CHECK_TIMEOUT is not configured properly.
+                  "excl:CsrAllTests:CsrExclWrite"],
       fields: [
         { bits: "0",
           name: "INTEGRITY",
@@ -947,6 +950,9 @@
       swaccess: "rw",
       hwaccess: "hro",
       regwen:   "CHECK_REGWEN",
+      tags:     [ // Triggering any of these checks may lead to unintended alerts
+                  // if the CHECK_TIMEOUT is not configured properly.
+                  "excl:CsrAllTests:CsrExclWrite"],
       fields: [
         { bits: "31:0",
           desc: '''
@@ -969,6 +975,9 @@
       swaccess: "rw",
       hwaccess: "hro",
       regwen:   "CHECK_REGWEN",
+      tags:     [ // Triggering any of these checks may lead to unintended alerts
+                  // if the CHECK_TIMEOUT is not configured properly.
+                  "excl:CsrAllTests:CsrExclWrite"],
       fields: [
         { bits: "31:0",
           desc: '''
@@ -994,6 +1003,9 @@
       swaccess: "rw1c",
       hwaccess: "hro",
       regwen:   "DIRECT_ACCESS_REGWEN",
+      tags:     [ // The enable register "DIRECT_ACCESS_REGWEN" is HW controlled,
+                  // so not able to predict this register value automatically
+                  "excl:CsrNonInitTests:CsrExclCheck"],
       fields: [
         { bits:   "0",
           desc: '''
@@ -1011,6 +1023,9 @@
       swaccess: "rw1c",
       hwaccess: "hro",
       regwen:   "DIRECT_ACCESS_REGWEN",
+      tags:     [ // The enable register "DIRECT_ACCESS_REGWEN" is HW controlled,
+                  // so not able to predict this register value automatically
+                  "excl:CsrNonInitTests:CsrExclCheck"],
       fields: [
         { bits:   "0",
           desc: '''

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
@@ -571,6 +571,9 @@
       hwqe:     "true",
       hwext:    "true",
       regwen:   "CHECK_TRIGGER_REGWEN",
+      tags:     [ // Triggering any of these checks may lead to unintended alerts
+                  // if the CHECK_TIMEOUT is not configured properly.
+                  "excl:CsrAllTests:CsrExclWrite"],
       fields: [
         { bits: "0",
           name: "INTEGRITY",
@@ -636,6 +639,9 @@
       swaccess: "rw",
       hwaccess: "hro",
       regwen:   "CHECK_REGWEN",
+      tags:     [ // Triggering any of these checks may lead to unintended alerts
+                  // if the CHECK_TIMEOUT is not configured properly.
+                  "excl:CsrAllTests:CsrExclWrite"],
       fields: [
         { bits: "31:0",
           desc: '''
@@ -658,6 +664,9 @@
       swaccess: "rw",
       hwaccess: "hro",
       regwen:   "CHECK_REGWEN",
+      tags:     [ // Triggering any of these checks may lead to unintended alerts
+                  // if the CHECK_TIMEOUT is not configured properly.
+                  "excl:CsrAllTests:CsrExclWrite"],
       fields: [
         { bits: "31:0",
           desc: '''
@@ -684,6 +693,10 @@
             ''',
       swaccess: "rw1c",
       hwaccess: "hro",
+      regwen:   "DIRECT_ACCESS_REGWEN",
+      tags:     [ // The enable register "DIRECT_ACCESS_REGWEN" is HW controlled,
+                  // so not able to predict this register value automatically
+                  "excl:CsrNonInitTests:CsrExclCheck"],
       fields: [
         { bits:   "0",
           desc: '''

--- a/hw/ip/pwrmgr/rtl/pwrmgr.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr.sv
@@ -81,6 +81,7 @@ module pwrmgr import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;
   logic low_power_abort;
 
   pwr_flash_rsp_t flash_rsp;
+  pwr_otp_rsp_t otp_rsp;
 
   ////////////////////////////
   ///  clk_slow_i domain declarations
@@ -195,7 +196,12 @@ module pwrmgr import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;
 
     // flash handshake
     .flash_i(pwr_flash_i),
-    .flash_o(flash_rsp)
+    .flash_o(flash_rsp),
+
+    // OTP signals
+    .otp_i(pwr_otp_i),
+    .otp_o(otp_rsp)
+
   );
 
   assign hw2reg.cfg_cdc_sync.d = 1'b0;
@@ -306,8 +312,8 @@ module pwrmgr import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;
 
     // otp
     .otp_init_o        (pwr_otp_o.otp_init),
-    .otp_done_i        (pwr_otp_i.otp_done),
-    .otp_idle_i        (pwr_otp_i.otp_idle),
+    .otp_done_i        (otp_rsp.otp_done),
+    .otp_idle_i        (otp_rsp.otp_idle),
 
     // lc
     .lc_init_o         (pwr_lc_o.lc_init),

--- a/hw/ip/pwrmgr/rtl/pwrmgr_cdc.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_cdc.sv
@@ -55,6 +55,10 @@ module pwrmgr_cdc import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;
   input pwr_flash_rsp_t flash_i,
   output pwr_flash_rsp_t flash_o,
 
+  // otp interface
+  input  pwr_otp_rsp_t otp_i,
+  output pwr_otp_rsp_t otp_o,
+
   // AST inputs, unknown domain
   input pwr_ast_rsp_t ast_i
 
@@ -244,6 +248,7 @@ module pwrmgr_cdc import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;
 
   prim_flop_2sync #(
     .Width(1),
+    // TODO: Is a value of 1 correct here?
     .ResetValue(1'b1)
   ) u_sync_flash_idle (
     .clk_i,
@@ -252,6 +257,15 @@ module pwrmgr_cdc import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;
     .q_o(flash_o.flash_idle)
   );
 
+  prim_flop_2sync #(
+    .Width($bits(pwr_otp_rsp_t)),
+    .ResetValue('0)
+  ) u_sync_otp (
+    .clk_i,
+    .rst_ni,
+    .d_i(otp_i),
+    .q_o(otp_o)
+  );
 
 endmodule
 

--- a/hw/ip/pwrmgr/rtl/pwrmgr_fsm.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_fsm.sv
@@ -330,18 +330,37 @@ module pwrmgr_fsm import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;(
   assign pwr_rst_o.reset_cause = reset_cause_q;
   assign pwr_rst_o.rstreqs = reset_reqs_i;
 
-  assign otp_init_o = otp_init;
-  assign lc_init_o = lc_init;
   assign ips_clk_en_o = ip_clk_en_q;
 
   prim_flop #(
     .Width(1),
+    // TODO: Is a value of 1 correct here?
     .ResetValue(1'b1)
-  ) u_reg_idle (
+  ) u_reg_flash_init (
     .clk_i,
     .rst_ni,
     .d_i(flash_init_d),
     .q_o(flash_init_o)
+  );
+
+  prim_flop #(
+    .Width(1),
+    .ResetValue(1'b0)
+  ) u_reg_otp_init (
+    .clk_i,
+    .rst_ni,
+    .d_i(otp_init),
+    .q_o(otp_init_o)
+  );
+
+  prim_flop #(
+    .Width(1),
+    .ResetValue(1'b0)
+  ) u_reg_lc_init (
+    .clk_i,
+    .rst_ni,
+    .d_i(lc_init),
+    .q_o(lc_init_o)
   );
 
 

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -1556,6 +1556,9 @@
           act: req
           package: pwrmgr_pkg
           inst_name: pwrmgr
+          width: 1
+          default: ""
+          top_signame: pwrmgr_pwr_otp
           index: -1
         }
         {
@@ -2597,7 +2600,7 @@
       clock_group: timers
       reset_connections:
       {
-        rst_ni: sys_io_div4
+        rst_ni: lc_io
       }
       base_addr: 0x401b0000
       clock_reset_export: []
@@ -2704,6 +2707,8 @@
           default: "'0"
           package: pwrmgr_pkg
           inst_name: otp_ctrl
+          width: 1
+          top_signame: pwrmgr_pwr_otp
           index: -1
         }
         {
@@ -3123,6 +3128,10 @@
       pwrmgr.pwr_clk:
       [
         clkmgr.pwr
+      ]
+      pwrmgr.pwr_otp:
+      [
+        otp_ctrl.pwr_otp
       ]
       flash_ctrl.keymgr:
       [
@@ -5767,6 +5776,9 @@
         act: req
         package: pwrmgr_pkg
         inst_name: pwrmgr
+        width: 1
+        default: ""
+        top_signame: pwrmgr_pwr_otp
         index: -1
       }
       {
@@ -6271,6 +6283,8 @@
         default: "'0"
         package: pwrmgr_pkg
         inst_name: otp_ctrl
+        width: 1
+        top_signame: pwrmgr_pwr_otp
         index: -1
       }
       {
@@ -7081,6 +7095,22 @@
         package: pwrmgr_pkg
         struct: pwr_clk_rsp
         signame: pwrmgr_pwr_clk_rsp
+        width: 1
+        type: req_rsp
+        default: ""
+      }
+      {
+        package: pwrmgr_pkg
+        struct: pwr_otp_req
+        signame: pwrmgr_pwr_otp_req
+        width: 1
+        type: req_rsp
+        default: ""
+      }
+      {
+        package: pwrmgr_pkg
+        struct: pwr_otp_rsp
+        signame: pwrmgr_pwr_otp_rsp
         width: 1
         type: req_rsp
         default: ""

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -317,7 +317,7 @@
       type: "otp_ctrl",
       clock_srcs: {clk_i: "io_div4"},
       clock_group: "timers",
-      reset_connections: {rst_ni: "sys_io_div4"},
+      reset_connections: {rst_ni: "lc_io"},
       base_addr: "0x401b0000",
     },
     { name: "otbn",
@@ -417,7 +417,7 @@
       'pwrmgr.pwr_flash' : ['flash_ctrl.pwrmgr'],
       'pwrmgr.pwr_rst'   : ['rstmgr.pwr'],
       'pwrmgr.pwr_clk'   : ['clkmgr.pwr'],
-      // TODO: connect this once OTP has passed initial sanity tests: 'pwrmgr.pwr_otp'   : ['otp_ctrl.pwr_otp'],
+      'pwrmgr.pwr_otp'   : ['otp_ctrl.pwr_otp'],
       'flash_ctrl.keymgr': ['keymgr.flash'],
       'alert_handler.crashdump': ['rstmgr.alert_dump'],
       // The idle connection is automatically connected through topgen.

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -51,6 +51,7 @@ class chip_base_vseq extends cip_base_vseq #(
     cfg.mem_bkdr_vifs[FlashBank0Info].set_mem();
     cfg.mem_bkdr_vifs[FlashBank1Info].set_mem();
     // Bring the chip out of reset.
+    cfg.mem_bkdr_vifs[Otp].clear_mem();
     super.dut_init(reset_kind);
   endtask
 

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -225,6 +225,8 @@ module top_earlgrey #(
   pwrmgr_pkg::pwr_rst_rsp_t       pwrmgr_pwr_rst_rsp;
   pwrmgr_pkg::pwr_clk_req_t       pwrmgr_pwr_clk_req;
   pwrmgr_pkg::pwr_clk_rsp_t       pwrmgr_pwr_clk_rsp;
+  pwrmgr_pkg::pwr_otp_req_t       pwrmgr_pwr_otp_req;
+  pwrmgr_pkg::pwr_otp_rsp_t       pwrmgr_pwr_otp_rsp;
   flash_ctrl_pkg::keymgr_flash_t       flash_ctrl_keymgr;
   alert_pkg::alert_crashdump_t       alert_handler_crashdump;
   logic [2:0] clkmgr_idle;
@@ -822,8 +824,8 @@ module top_earlgrey #(
       .pwr_rst_i(pwrmgr_pwr_rst_rsp),
       .pwr_clk_o(pwrmgr_pwr_clk_req),
       .pwr_clk_i(pwrmgr_pwr_clk_rsp),
-      .pwr_otp_o(),
-      .pwr_otp_i(pwrmgr_pkg::PWR_OTP_RSP_DEFAULT),
+      .pwr_otp_o(pwrmgr_pwr_otp_req),
+      .pwr_otp_i(pwrmgr_pwr_otp_rsp),
       .pwr_lc_o(),
       .pwr_lc_i(pwrmgr_pkg::PWR_LC_RSP_DEFAULT),
       .pwr_flash_o(pwrmgr_pwr_flash_req),
@@ -1023,8 +1025,8 @@ module top_earlgrey #(
       .otp_ast_pwr_seq_h_i(otp_ctrl_otp_ast_pwr_seq_h_i),
       .otp_edn_o(),
       .otp_edn_i('0),
-      .pwr_otp_i('0),
-      .pwr_otp_o(),
+      .pwr_otp_i(pwrmgr_pwr_otp_req),
+      .pwr_otp_o(pwrmgr_pwr_otp_rsp),
       .lc_otp_program_i('0),
       .lc_otp_program_o(),
       .lc_otp_token_i('0),
@@ -1044,7 +1046,7 @@ module top_earlgrey #(
       .tl_i(otp_ctrl_tl_req),
       .tl_o(otp_ctrl_tl_rsp),
       .clk_i (clkmgr_clocks.clk_io_div4_timers),
-      .rst_ni (rstmgr_resets.rst_sys_io_div4_n)
+      .rst_ni (rstmgr_resets.rst_lc_io_n)
   );
 
   otbn #(


### PR DESCRIPTION
This is needed to properly initialize OTP at boot.

Signed-off-by: Michael Schaffner <msf@opentitan.org>