### PR TITLE
[fpv] update regression items

### DIFF
--- a/hw/top_earlgrey/fpv/top_earlgrey_fpv_cfgs.hjson
+++ b/hw/top_earlgrey/fpv/top_earlgrey_fpv_cfgs.hjson
@@ -25,6 +25,11 @@
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
              }
              {
+               name: prim_arbiter_fixed_fpv
+               fusesoc_core: lowrisc:fpv:prim_arbiter_fixed_fpv
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+             }
+             {
                name: prim_lfsr_fpv
                fusesoc_core: lowrisc:fpv:prim_lfsr_fpv
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
@@ -75,78 +80,8 @@
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
              }
              {
-               name: aes
-               fusesoc_core: lowrisc:ip:aes
-               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
-             }
-             {
-               name: alert_handler
-               fusesoc_core: lowrisc:ip:alert_handler
-               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
-             }
-             {
-               name: flash_ctrl
-               fusesoc_core: lowrisc:ip:flash_ctrl
-               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
-             }
-             {
-               name: gpio
-               fusesoc_core: lowrisc:ip:gpio
-               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
-             }
-             {
-               name: hmac
-               fusesoc_core: lowrisc:ip:hmac
-               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
-             }
-             {
-               name: i2c
-               fusesoc_core: lowrisc:ip:i2c
-               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
-             }
-             {
-               name: otp_ctrl
-               fusesoc_core: lowrisc:ip:otp_ctrl
-               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
-             }
-             {
-               name: pwrmgr
-               fusesoc_core: lowrisc:ip:pwrmgr
-               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
-             }
-             {
-               name: rv_core_ibex
-               fusesoc_core: lowrisc:ip:rv_core_ibex
-               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
-             }
-             {
-               name: rv_dm
-               fusesoc_core: lowrisc:ip:rv_dm
-               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
-             }
-             {
-               name: rv_timer
-               fusesoc_core: lowrisc:ip:rv_timer
-               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
-             }
-             {
-               name: spi_device
-               fusesoc_core: lowrisc:ip:spi_device
-               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
-             }
-             {
-               name: uart
-               fusesoc_core: lowrisc:ip:uart
-               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
-             }
-             {
-               name: usbdev
-               fusesoc_core: lowrisc:ip:usbdev
-               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
-             }
-             {
-               name: usbuart
-               fusesoc_core: lowrisc:ip:usbuart
+               name: sha3pad_fpv
+               fusesoc_core: lowrisc:fpv:sha3pad_fpv
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
              }
             ]


### PR DESCRIPTION
Update FPV regression items:
1. Remove the ones that already had a DV testbench (The generated FPV
csr assertions does not work for FPV fusesoc)
2. Add sha3pad_fpv and prim_arbiter_fixed_fpv to regression

Signed-off-by: Cindy Chen <chencindy@google.com>