### PR TITLE
[tlul] Increase Max Outstanding

### DIFF
--- a/hw/ip/tlul/rtl/tlul_socket_1n.sv
+++ b/hw/ip/tlul/rtl/tlul_socket_1n.sv
@@ -92,11 +92,12 @@ module tlul_socket_1n #(
   // We need to keep track of how many requests are outstanding,
   // and to which device. New requests are compared to this and
   // stall until that number is zero.
-
-  logic [7:0]     num_req_outstanding;
-  logic [NWD-1:0] dev_select_outstanding;
-  logic           hold_all_requests;
-  logic           accept_t_req, accept_t_rsp;
+  localparam int MaxOutstanding = 2**top_pkg::TL_AIW; // Up to 256 ounstanding
+  localparam int OutstandingW = $clog2(MaxOutstanding+1);
+  logic [OutstandingW-1:0] num_req_outstanding;
+  logic [NWD-1:0]          dev_select_outstanding;
+  logic                    hold_all_requests;
+  logic                    accept_t_req, accept_t_rsp;
 
   assign  accept_t_req = tl_t_o.a_valid & tl_t_i.a_ready;
   assign  accept_t_rsp = tl_t_i.d_valid & tl_t_o.d_ready;
@@ -107,7 +108,7 @@ module tlul_socket_1n #(
       dev_select_outstanding <= '0;
     end else if (accept_t_req) begin
       if (!accept_t_rsp) begin
-        `ASSERT_I(NotOverflowed_A, num_req_outstanding != '1)
+        `ASSERT_I(NotOverflowed_A, num_req_outstanding < MaxOutstanding)
         num_req_outstanding <= num_req_outstanding + 8'h1;
       end
       dev_select_outstanding <= dev_select_t;


### PR DESCRIPTION
Reported by Weicai in #3910

tlul socket 1n has internal variable that tracks the current outstanding
requests. It is 8 bit signal. It can have up to 255 outstandings. The
`a_source` can have up to 256 unique source IDs. When the host issues
more than 255, the internal variable overflows then the logic assumes no
outstanding.

It may not cause an issue as this issue only occurs with 1:1 connection
between the host and the device. So that the overflow still forwards the
request to the only device.