### PR TITLE
Pattgen lint enable

### DIFF
--- a/hw/top_earlgrey/lint/top_earlgrey_lint_cfgs.hjson
+++ b/hw/top_earlgrey/lint/top_earlgrey_lint_cfgs.hjson
@@ -68,6 +68,11 @@
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
                   rel_path: "hw/ip/i2c/lint/{tool}"
              },
+             {    name: pattgen
+                  fusesoc_core: lowrisc:ip:pattgen
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/pattgen/lint/{tool}"
+             },
              {    name: keymgr
                   fusesoc_core: lowrisc:ip:keymgr
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]


### PR DESCRIPTION
This commit is to be built on top of #3844.  The goal is to enable the linting subsystem for pattgen CI.
This initial pair of commits includes a number of RTL files, but those will vanish once #3844 is merged.