### PR TITLE
[kmac] Fix KeyMgr default value

### DIFF
--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -247,7 +247,8 @@ module kmac
     ready: 1'b 0,
     digest_share0: '0,
     digest_share1: '0,
-    done: 1'b 0
+    done: 1'b 0,
+    error: 1'b 0
   };
 
   ///////////////


### PR DESCRIPTION
After revised the KeyMgr Interface at @66e2618a , the kmac.sv didn't
revise the default assignment of keymgr_kdf output. It missed `error`
signal. This commit fixed that.