### PR TITLE
[RTL] Update num_req_outstanding check

### DIFF
--- a/hw/ip/tlul/rtl/tlul_socket_1n.sv
+++ b/hw/ip/tlul/rtl/tlul_socket_1n.sv
@@ -108,7 +108,7 @@ module tlul_socket_1n #(
       dev_select_outstanding <= '0;
     end else if (accept_t_req) begin
       if (!accept_t_rsp) begin
-        `ASSERT_I(NotOverflowed_A, num_req_outstanding < MaxOutstanding)
+        `ASSERT_I(NotOverflowed_A, num_req_outstanding <= MaxOutstanding)
         num_req_outstanding <= num_req_outstanding + 1'b1;
       end
       dev_select_outstanding <= dev_select_t;


### PR DESCRIPTION
as discussed at #3911, num_req_outstanding can be equal to MaxOutstanding
Signed-off-by: Weicai Yang <weicai@google.com>