### PR TITLE
[reggen] Automatically generate alert test register

### DIFF
--- a/hw/ip/aes/rtl/aes.sv
+++ b/hw/ip/aes/rtl/aes.sv
@@ -99,16 +99,24 @@ module aes
 
   assign idle_o = hw2reg.status.idle.d;
 
+  logic [NumAlerts-1:0] alert_test;
+  assign alert_test = {
+    reg2hw.alert_test.ctrl_err_update.q &
+    reg2hw.alert_test.ctrl_err_update.qe,
+    reg2hw.alert_test.ctrl_err_storage.q &
+    reg2hw.alert_test.ctrl_err_storage.qe
+  };
+
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i])
     ) u_alert_sender_i (
-      .clk_i       ( clk_i         ),
-      .rst_ni      ( rst_ni        ),
-      .alert_req_i ( alert[i]      ),
-      .alert_ack_o (               ),
-      .alert_rx_i  ( alert_rx_i[i] ),
-      .alert_tx_o  ( alert_tx_o[i] )
+      .clk_i       ( clk_i                    ),
+      .rst_ni      ( rst_ni                   ),
+      .alert_req_i ( alert[i] | alert_test[i] ),
+      .alert_ack_o (                          ),
+      .alert_rx_i  ( alert_rx_i[i]            ),
+      .alert_tx_o  ( alert_tx_o[i]            )
     );
   end
 

--- a/hw/ip/aes/rtl/aes_core.sv
+++ b/hw/ip/aes/rtl/aes_core.sv
@@ -458,6 +458,10 @@ module aes_core
   assign manual_operation_q = ctrl_q.manual_operation;
   assign force_zero_masks_q = ctrl_q.force_zero_masks;
 
+  // Unused alert signals
+  logic unused_alert_signals;
+  assign unused_alert_signals = ^reg2hw.alert_test;
+
   /////////////
   // Control //
   /////////////

--- a/hw/ip/aes/rtl/aes_reg_pkg.sv
+++ b/hw/ip/aes/rtl/aes_reg_pkg.sv
@@ -16,6 +16,17 @@ package aes_reg_pkg;
   // Typedefs for registers //
   ////////////////////////////
   typedef struct packed {
+    struct packed {
+      logic        q;
+      logic        qe;
+    } ctrl_err_update;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } ctrl_err_storage;
+  } aes_reg2hw_alert_test_reg_t;
+
+  typedef struct packed {
     logic [31:0] q;
     logic        qe;
   } aes_reg2hw_key_share0_mreg_t;
@@ -184,6 +195,7 @@ package aes_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
+    aes_reg2hw_alert_test_reg_t alert_test; // [950:947]
     aes_reg2hw_key_share0_mreg_t [7:0] key_share0; // [946:683]
     aes_reg2hw_key_share1_mreg_t [7:0] key_share1; // [682:419]
     aes_reg2hw_iv_mreg_t [3:0] iv; // [418:287]
@@ -208,41 +220,43 @@ package aes_reg_pkg;
   } aes_hw2reg_t;
 
   // Register Address
-  parameter logic [6:0] AES_KEY_SHARE0_0_OFFSET = 7'h 0;
-  parameter logic [6:0] AES_KEY_SHARE0_1_OFFSET = 7'h 4;
-  parameter logic [6:0] AES_KEY_SHARE0_2_OFFSET = 7'h 8;
-  parameter logic [6:0] AES_KEY_SHARE0_3_OFFSET = 7'h c;
-  parameter logic [6:0] AES_KEY_SHARE0_4_OFFSET = 7'h 10;
-  parameter logic [6:0] AES_KEY_SHARE0_5_OFFSET = 7'h 14;
-  parameter logic [6:0] AES_KEY_SHARE0_6_OFFSET = 7'h 18;
-  parameter logic [6:0] AES_KEY_SHARE0_7_OFFSET = 7'h 1c;
-  parameter logic [6:0] AES_KEY_SHARE1_0_OFFSET = 7'h 20;
-  parameter logic [6:0] AES_KEY_SHARE1_1_OFFSET = 7'h 24;
-  parameter logic [6:0] AES_KEY_SHARE1_2_OFFSET = 7'h 28;
-  parameter logic [6:0] AES_KEY_SHARE1_3_OFFSET = 7'h 2c;
-  parameter logic [6:0] AES_KEY_SHARE1_4_OFFSET = 7'h 30;
-  parameter logic [6:0] AES_KEY_SHARE1_5_OFFSET = 7'h 34;
-  parameter logic [6:0] AES_KEY_SHARE1_6_OFFSET = 7'h 38;
-  parameter logic [6:0] AES_KEY_SHARE1_7_OFFSET = 7'h 3c;
-  parameter logic [6:0] AES_IV_0_OFFSET = 7'h 40;
-  parameter logic [6:0] AES_IV_1_OFFSET = 7'h 44;
-  parameter logic [6:0] AES_IV_2_OFFSET = 7'h 48;
-  parameter logic [6:0] AES_IV_3_OFFSET = 7'h 4c;
-  parameter logic [6:0] AES_DATA_IN_0_OFFSET = 7'h 50;
-  parameter logic [6:0] AES_DATA_IN_1_OFFSET = 7'h 54;
-  parameter logic [6:0] AES_DATA_IN_2_OFFSET = 7'h 58;
-  parameter logic [6:0] AES_DATA_IN_3_OFFSET = 7'h 5c;
-  parameter logic [6:0] AES_DATA_OUT_0_OFFSET = 7'h 60;
-  parameter logic [6:0] AES_DATA_OUT_1_OFFSET = 7'h 64;
-  parameter logic [6:0] AES_DATA_OUT_2_OFFSET = 7'h 68;
-  parameter logic [6:0] AES_DATA_OUT_3_OFFSET = 7'h 6c;
-  parameter logic [6:0] AES_CTRL_SHADOWED_OFFSET = 7'h 70;
-  parameter logic [6:0] AES_TRIGGER_OFFSET = 7'h 74;
-  parameter logic [6:0] AES_STATUS_OFFSET = 7'h 78;
+  parameter logic [6:0] AES_ALERT_TEST_OFFSET = 7'h 0;
+  parameter logic [6:0] AES_KEY_SHARE0_0_OFFSET = 7'h 4;
+  parameter logic [6:0] AES_KEY_SHARE0_1_OFFSET = 7'h 8;
+  parameter logic [6:0] AES_KEY_SHARE0_2_OFFSET = 7'h c;
+  parameter logic [6:0] AES_KEY_SHARE0_3_OFFSET = 7'h 10;
+  parameter logic [6:0] AES_KEY_SHARE0_4_OFFSET = 7'h 14;
+  parameter logic [6:0] AES_KEY_SHARE0_5_OFFSET = 7'h 18;
+  parameter logic [6:0] AES_KEY_SHARE0_6_OFFSET = 7'h 1c;
+  parameter logic [6:0] AES_KEY_SHARE0_7_OFFSET = 7'h 20;
+  parameter logic [6:0] AES_KEY_SHARE1_0_OFFSET = 7'h 24;
+  parameter logic [6:0] AES_KEY_SHARE1_1_OFFSET = 7'h 28;
+  parameter logic [6:0] AES_KEY_SHARE1_2_OFFSET = 7'h 2c;
+  parameter logic [6:0] AES_KEY_SHARE1_3_OFFSET = 7'h 30;
+  parameter logic [6:0] AES_KEY_SHARE1_4_OFFSET = 7'h 34;
+  parameter logic [6:0] AES_KEY_SHARE1_5_OFFSET = 7'h 38;
+  parameter logic [6:0] AES_KEY_SHARE1_6_OFFSET = 7'h 3c;
+  parameter logic [6:0] AES_KEY_SHARE1_7_OFFSET = 7'h 40;
+  parameter logic [6:0] AES_IV_0_OFFSET = 7'h 44;
+  parameter logic [6:0] AES_IV_1_OFFSET = 7'h 48;
+  parameter logic [6:0] AES_IV_2_OFFSET = 7'h 4c;
+  parameter logic [6:0] AES_IV_3_OFFSET = 7'h 50;
+  parameter logic [6:0] AES_DATA_IN_0_OFFSET = 7'h 54;
+  parameter logic [6:0] AES_DATA_IN_1_OFFSET = 7'h 58;
+  parameter logic [6:0] AES_DATA_IN_2_OFFSET = 7'h 5c;
+  parameter logic [6:0] AES_DATA_IN_3_OFFSET = 7'h 60;
+  parameter logic [6:0] AES_DATA_OUT_0_OFFSET = 7'h 64;
+  parameter logic [6:0] AES_DATA_OUT_1_OFFSET = 7'h 68;
+  parameter logic [6:0] AES_DATA_OUT_2_OFFSET = 7'h 6c;
+  parameter logic [6:0] AES_DATA_OUT_3_OFFSET = 7'h 70;
+  parameter logic [6:0] AES_CTRL_SHADOWED_OFFSET = 7'h 74;
+  parameter logic [6:0] AES_TRIGGER_OFFSET = 7'h 78;
+  parameter logic [6:0] AES_STATUS_OFFSET = 7'h 7c;
 
 
   // Register Index
   typedef enum int {
+    AES_ALERT_TEST,
     AES_KEY_SHARE0_0,
     AES_KEY_SHARE0_1,
     AES_KEY_SHARE0_2,
@@ -277,38 +291,39 @@ package aes_reg_pkg;
   } aes_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] AES_PERMIT [31] = '{
-    4'b 1111, // index[ 0] AES_KEY_SHARE0_0
-    4'b 1111, // index[ 1] AES_KEY_SHARE0_1
-    4'b 1111, // index[ 2] AES_KEY_SHARE0_2
-    4'b 1111, // index[ 3] AES_KEY_SHARE0_3
-    4'b 1111, // index[ 4] AES_KEY_SHARE0_4
-    4'b 1111, // index[ 5] AES_KEY_SHARE0_5
-    4'b 1111, // index[ 6] AES_KEY_SHARE0_6
-    4'b 1111, // index[ 7] AES_KEY_SHARE0_7
-    4'b 1111, // index[ 8] AES_KEY_SHARE1_0
-    4'b 1111, // index[ 9] AES_KEY_SHARE1_1
-    4'b 1111, // index[10] AES_KEY_SHARE1_2
-    4'b 1111, // index[11] AES_KEY_SHARE1_3
-    4'b 1111, // index[12] AES_KEY_SHARE1_4
-    4'b 1111, // index[13] AES_KEY_SHARE1_5
-    4'b 1111, // index[14] AES_KEY_SHARE1_6
-    4'b 1111, // index[15] AES_KEY_SHARE1_7
-    4'b 1111, // index[16] AES_IV_0
-    4'b 1111, // index[17] AES_IV_1
-    4'b 1111, // index[18] AES_IV_2
-    4'b 1111, // index[19] AES_IV_3
-    4'b 1111, // index[20] AES_DATA_IN_0
-    4'b 1111, // index[21] AES_DATA_IN_1
-    4'b 1111, // index[22] AES_DATA_IN_2
-    4'b 1111, // index[23] AES_DATA_IN_3
-    4'b 1111, // index[24] AES_DATA_OUT_0
-    4'b 1111, // index[25] AES_DATA_OUT_1
-    4'b 1111, // index[26] AES_DATA_OUT_2
-    4'b 1111, // index[27] AES_DATA_OUT_3
-    4'b 0011, // index[28] AES_CTRL_SHADOWED
-    4'b 0001, // index[29] AES_TRIGGER
-    4'b 0001  // index[30] AES_STATUS
+  parameter logic [3:0] AES_PERMIT [32] = '{
+    4'b 0001, // index[ 0] AES_ALERT_TEST
+    4'b 1111, // index[ 1] AES_KEY_SHARE0_0
+    4'b 1111, // index[ 2] AES_KEY_SHARE0_1
+    4'b 1111, // index[ 3] AES_KEY_SHARE0_2
+    4'b 1111, // index[ 4] AES_KEY_SHARE0_3
+    4'b 1111, // index[ 5] AES_KEY_SHARE0_4
+    4'b 1111, // index[ 6] AES_KEY_SHARE0_5
+    4'b 1111, // index[ 7] AES_KEY_SHARE0_6
+    4'b 1111, // index[ 8] AES_KEY_SHARE0_7
+    4'b 1111, // index[ 9] AES_KEY_SHARE1_0
+    4'b 1111, // index[10] AES_KEY_SHARE1_1
+    4'b 1111, // index[11] AES_KEY_SHARE1_2
+    4'b 1111, // index[12] AES_KEY_SHARE1_3
+    4'b 1111, // index[13] AES_KEY_SHARE1_4
+    4'b 1111, // index[14] AES_KEY_SHARE1_5
+    4'b 1111, // index[15] AES_KEY_SHARE1_6
+    4'b 1111, // index[16] AES_KEY_SHARE1_7
+    4'b 1111, // index[17] AES_IV_0
+    4'b 1111, // index[18] AES_IV_1
+    4'b 1111, // index[19] AES_IV_2
+    4'b 1111, // index[20] AES_IV_3
+    4'b 1111, // index[21] AES_DATA_IN_0
+    4'b 1111, // index[22] AES_DATA_IN_1
+    4'b 1111, // index[23] AES_DATA_IN_2
+    4'b 1111, // index[24] AES_DATA_IN_3
+    4'b 1111, // index[25] AES_DATA_OUT_0
+    4'b 1111, // index[26] AES_DATA_OUT_1
+    4'b 1111, // index[27] AES_DATA_OUT_2
+    4'b 1111, // index[28] AES_DATA_OUT_3
+    4'b 0011, // index[29] AES_CTRL_SHADOWED
+    4'b 0001, // index[30] AES_TRIGGER
+    4'b 0001  // index[31] AES_STATUS
   };
 endpackage
 

--- a/hw/ip/aes/rtl/aes_reg_top.sv
+++ b/hw/ip/aes/rtl/aes_reg_top.sv
@@ -71,6 +71,10 @@ module aes_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
+  logic alert_test_ctrl_err_update_wd;
+  logic alert_test_ctrl_err_update_we;
+  logic alert_test_ctrl_err_storage_wd;
+  logic alert_test_ctrl_err_storage_we;
   logic [31:0] key_share0_0_wd;
   logic key_share0_0_we;
   logic [31:0] key_share0_1_wd;
@@ -166,6 +170,38 @@ module aes_reg_top (
   logic status_ctrl_err_storage_qs;
 
   // Register instances
+  // R[alert_test]: V(True)
+
+  //   F[ctrl_err_update]: 0:0
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_alert_test_ctrl_err_update (
+    .re     (1'b0),
+    .we     (alert_test_ctrl_err_update_we),
+    .wd     (alert_test_ctrl_err_update_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (reg2hw.alert_test.ctrl_err_update.qe),
+    .q      (reg2hw.alert_test.ctrl_err_update.q ),
+    .qs     ()
+  );
+
+
+  //   F[ctrl_err_storage]: 1:1
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_alert_test_ctrl_err_storage (
+    .re     (1'b0),
+    .we     (alert_test_ctrl_err_storage_we),
+    .wd     (alert_test_ctrl_err_storage_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (reg2hw.alert_test.ctrl_err_storage.qe),
+    .q      (reg2hw.alert_test.ctrl_err_storage.q ),
+    .qs     ()
+  );
+
+
 
   // Subregister 0 of Multireg key_share0
   // R[key_share0_0]: V(True)
@@ -1022,40 +1058,41 @@ module aes_reg_top (
 
 
 
-  logic [30:0] addr_hit;
+  logic [31:0] addr_hit;
   always_comb begin
     addr_hit = '0;
-    addr_hit[ 0] = (reg_addr == AES_KEY_SHARE0_0_OFFSET);
-    addr_hit[ 1] = (reg_addr == AES_KEY_SHARE0_1_OFFSET);
-    addr_hit[ 2] = (reg_addr == AES_KEY_SHARE0_2_OFFSET);
-    addr_hit[ 3] = (reg_addr == AES_KEY_SHARE0_3_OFFSET);
-    addr_hit[ 4] = (reg_addr == AES_KEY_SHARE0_4_OFFSET);
-    addr_hit[ 5] = (reg_addr == AES_KEY_SHARE0_5_OFFSET);
-    addr_hit[ 6] = (reg_addr == AES_KEY_SHARE0_6_OFFSET);
-    addr_hit[ 7] = (reg_addr == AES_KEY_SHARE0_7_OFFSET);
-    addr_hit[ 8] = (reg_addr == AES_KEY_SHARE1_0_OFFSET);
-    addr_hit[ 9] = (reg_addr == AES_KEY_SHARE1_1_OFFSET);
-    addr_hit[10] = (reg_addr == AES_KEY_SHARE1_2_OFFSET);
-    addr_hit[11] = (reg_addr == AES_KEY_SHARE1_3_OFFSET);
-    addr_hit[12] = (reg_addr == AES_KEY_SHARE1_4_OFFSET);
-    addr_hit[13] = (reg_addr == AES_KEY_SHARE1_5_OFFSET);
-    addr_hit[14] = (reg_addr == AES_KEY_SHARE1_6_OFFSET);
-    addr_hit[15] = (reg_addr == AES_KEY_SHARE1_7_OFFSET);
-    addr_hit[16] = (reg_addr == AES_IV_0_OFFSET);
-    addr_hit[17] = (reg_addr == AES_IV_1_OFFSET);
-    addr_hit[18] = (reg_addr == AES_IV_2_OFFSET);
-    addr_hit[19] = (reg_addr == AES_IV_3_OFFSET);
-    addr_hit[20] = (reg_addr == AES_DATA_IN_0_OFFSET);
-    addr_hit[21] = (reg_addr == AES_DATA_IN_1_OFFSET);
-    addr_hit[22] = (reg_addr == AES_DATA_IN_2_OFFSET);
-    addr_hit[23] = (reg_addr == AES_DATA_IN_3_OFFSET);
-    addr_hit[24] = (reg_addr == AES_DATA_OUT_0_OFFSET);
-    addr_hit[25] = (reg_addr == AES_DATA_OUT_1_OFFSET);
-    addr_hit[26] = (reg_addr == AES_DATA_OUT_2_OFFSET);
-    addr_hit[27] = (reg_addr == AES_DATA_OUT_3_OFFSET);
-    addr_hit[28] = (reg_addr == AES_CTRL_SHADOWED_OFFSET);
-    addr_hit[29] = (reg_addr == AES_TRIGGER_OFFSET);
-    addr_hit[30] = (reg_addr == AES_STATUS_OFFSET);
+    addr_hit[ 0] = (reg_addr == AES_ALERT_TEST_OFFSET);
+    addr_hit[ 1] = (reg_addr == AES_KEY_SHARE0_0_OFFSET);
+    addr_hit[ 2] = (reg_addr == AES_KEY_SHARE0_1_OFFSET);
+    addr_hit[ 3] = (reg_addr == AES_KEY_SHARE0_2_OFFSET);
+    addr_hit[ 4] = (reg_addr == AES_KEY_SHARE0_3_OFFSET);
+    addr_hit[ 5] = (reg_addr == AES_KEY_SHARE0_4_OFFSET);
+    addr_hit[ 6] = (reg_addr == AES_KEY_SHARE0_5_OFFSET);
+    addr_hit[ 7] = (reg_addr == AES_KEY_SHARE0_6_OFFSET);
+    addr_hit[ 8] = (reg_addr == AES_KEY_SHARE0_7_OFFSET);
+    addr_hit[ 9] = (reg_addr == AES_KEY_SHARE1_0_OFFSET);
+    addr_hit[10] = (reg_addr == AES_KEY_SHARE1_1_OFFSET);
+    addr_hit[11] = (reg_addr == AES_KEY_SHARE1_2_OFFSET);
+    addr_hit[12] = (reg_addr == AES_KEY_SHARE1_3_OFFSET);
+    addr_hit[13] = (reg_addr == AES_KEY_SHARE1_4_OFFSET);
+    addr_hit[14] = (reg_addr == AES_KEY_SHARE1_5_OFFSET);
+    addr_hit[15] = (reg_addr == AES_KEY_SHARE1_6_OFFSET);
+    addr_hit[16] = (reg_addr == AES_KEY_SHARE1_7_OFFSET);
+    addr_hit[17] = (reg_addr == AES_IV_0_OFFSET);
+    addr_hit[18] = (reg_addr == AES_IV_1_OFFSET);
+    addr_hit[19] = (reg_addr == AES_IV_2_OFFSET);
+    addr_hit[20] = (reg_addr == AES_IV_3_OFFSET);
+    addr_hit[21] = (reg_addr == AES_DATA_IN_0_OFFSET);
+    addr_hit[22] = (reg_addr == AES_DATA_IN_1_OFFSET);
+    addr_hit[23] = (reg_addr == AES_DATA_IN_2_OFFSET);
+    addr_hit[24] = (reg_addr == AES_DATA_IN_3_OFFSET);
+    addr_hit[25] = (reg_addr == AES_DATA_OUT_0_OFFSET);
+    addr_hit[26] = (reg_addr == AES_DATA_OUT_1_OFFSET);
+    addr_hit[27] = (reg_addr == AES_DATA_OUT_2_OFFSET);
+    addr_hit[28] = (reg_addr == AES_DATA_OUT_3_OFFSET);
+    addr_hit[29] = (reg_addr == AES_CTRL_SHADOWED_OFFSET);
+    addr_hit[30] = (reg_addr == AES_TRIGGER_OFFSET);
+    addr_hit[31] = (reg_addr == AES_STATUS_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -1094,124 +1131,131 @@ module aes_reg_top (
     if (addr_hit[28] && reg_we && (AES_PERMIT[28] != (AES_PERMIT[28] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[29] && reg_we && (AES_PERMIT[29] != (AES_PERMIT[29] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[30] && reg_we && (AES_PERMIT[30] != (AES_PERMIT[30] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[31] && reg_we && (AES_PERMIT[31] != (AES_PERMIT[31] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign key_share0_0_we = addr_hit[0] & reg_we & ~wr_err;
+  assign alert_test_ctrl_err_update_we = addr_hit[0] & reg_we & ~wr_err;
+  assign alert_test_ctrl_err_update_wd = reg_wdata[0];
+
+  assign alert_test_ctrl_err_storage_we = addr_hit[0] & reg_we & ~wr_err;
+  assign alert_test_ctrl_err_storage_wd = reg_wdata[1];
+
+  assign key_share0_0_we = addr_hit[1] & reg_we & ~wr_err;
   assign key_share0_0_wd = reg_wdata[31:0];
 
-  assign key_share0_1_we = addr_hit[1] & reg_we & ~wr_err;
+  assign key_share0_1_we = addr_hit[2] & reg_we & ~wr_err;
   assign key_share0_1_wd = reg_wdata[31:0];
 
-  assign key_share0_2_we = addr_hit[2] & reg_we & ~wr_err;
+  assign key_share0_2_we = addr_hit[3] & reg_we & ~wr_err;
   assign key_share0_2_wd = reg_wdata[31:0];
 
-  assign key_share0_3_we = addr_hit[3] & reg_we & ~wr_err;
+  assign key_share0_3_we = addr_hit[4] & reg_we & ~wr_err;
   assign key_share0_3_wd = reg_wdata[31:0];
 
-  assign key_share0_4_we = addr_hit[4] & reg_we & ~wr_err;
+  assign key_share0_4_we = addr_hit[5] & reg_we & ~wr_err;
   assign key_share0_4_wd = reg_wdata[31:0];
 
-  assign key_share0_5_we = addr_hit[5] & reg_we & ~wr_err;
+  assign key_share0_5_we = addr_hit[6] & reg_we & ~wr_err;
   assign key_share0_5_wd = reg_wdata[31:0];
 
-  assign key_share0_6_we = addr_hit[6] & reg_we & ~wr_err;
+  assign key_share0_6_we = addr_hit[7] & reg_we & ~wr_err;
   assign key_share0_6_wd = reg_wdata[31:0];
 
-  assign key_share0_7_we = addr_hit[7] & reg_we & ~wr_err;
+  assign key_share0_7_we = addr_hit[8] & reg_we & ~wr_err;
   assign key_share0_7_wd = reg_wdata[31:0];
 
-  assign key_share1_0_we = addr_hit[8] & reg_we & ~wr_err;
+  assign key_share1_0_we = addr_hit[9] & reg_we & ~wr_err;
   assign key_share1_0_wd = reg_wdata[31:0];
 
-  assign key_share1_1_we = addr_hit[9] & reg_we & ~wr_err;
+  assign key_share1_1_we = addr_hit[10] & reg_we & ~wr_err;
   assign key_share1_1_wd = reg_wdata[31:0];
 
-  assign key_share1_2_we = addr_hit[10] & reg_we & ~wr_err;
+  assign key_share1_2_we = addr_hit[11] & reg_we & ~wr_err;
   assign key_share1_2_wd = reg_wdata[31:0];
 
-  assign key_share1_3_we = addr_hit[11] & reg_we & ~wr_err;
+  assign key_share1_3_we = addr_hit[12] & reg_we & ~wr_err;
   assign key_share1_3_wd = reg_wdata[31:0];
 
-  assign key_share1_4_we = addr_hit[12] & reg_we & ~wr_err;
+  assign key_share1_4_we = addr_hit[13] & reg_we & ~wr_err;
   assign key_share1_4_wd = reg_wdata[31:0];
 
-  assign key_share1_5_we = addr_hit[13] & reg_we & ~wr_err;
+  assign key_share1_5_we = addr_hit[14] & reg_we & ~wr_err;
   assign key_share1_5_wd = reg_wdata[31:0];
 
-  assign key_share1_6_we = addr_hit[14] & reg_we & ~wr_err;
+  assign key_share1_6_we = addr_hit[15] & reg_we & ~wr_err;
   assign key_share1_6_wd = reg_wdata[31:0];
 
-  assign key_share1_7_we = addr_hit[15] & reg_we & ~wr_err;
+  assign key_share1_7_we = addr_hit[16] & reg_we & ~wr_err;
   assign key_share1_7_wd = reg_wdata[31:0];
 
-  assign iv_0_we = addr_hit[16] & reg_we & ~wr_err;
+  assign iv_0_we = addr_hit[17] & reg_we & ~wr_err;
   assign iv_0_wd = reg_wdata[31:0];
 
-  assign iv_1_we = addr_hit[17] & reg_we & ~wr_err;
+  assign iv_1_we = addr_hit[18] & reg_we & ~wr_err;
   assign iv_1_wd = reg_wdata[31:0];
 
-  assign iv_2_we = addr_hit[18] & reg_we & ~wr_err;
+  assign iv_2_we = addr_hit[19] & reg_we & ~wr_err;
   assign iv_2_wd = reg_wdata[31:0];
 
-  assign iv_3_we = addr_hit[19] & reg_we & ~wr_err;
+  assign iv_3_we = addr_hit[20] & reg_we & ~wr_err;
   assign iv_3_wd = reg_wdata[31:0];
 
-  assign data_in_0_we = addr_hit[20] & reg_we & ~wr_err;
+  assign data_in_0_we = addr_hit[21] & reg_we & ~wr_err;
   assign data_in_0_wd = reg_wdata[31:0];
 
-  assign data_in_1_we = addr_hit[21] & reg_we & ~wr_err;
+  assign data_in_1_we = addr_hit[22] & reg_we & ~wr_err;
   assign data_in_1_wd = reg_wdata[31:0];
 
-  assign data_in_2_we = addr_hit[22] & reg_we & ~wr_err;
+  assign data_in_2_we = addr_hit[23] & reg_we & ~wr_err;
   assign data_in_2_wd = reg_wdata[31:0];
 
-  assign data_in_3_we = addr_hit[23] & reg_we & ~wr_err;
+  assign data_in_3_we = addr_hit[24] & reg_we & ~wr_err;
   assign data_in_3_wd = reg_wdata[31:0];
 
-  assign data_out_0_re = addr_hit[24] && reg_re;
+  assign data_out_0_re = addr_hit[25] && reg_re;
 
-  assign data_out_1_re = addr_hit[25] && reg_re;
+  assign data_out_1_re = addr_hit[26] && reg_re;
 
-  assign data_out_2_re = addr_hit[26] && reg_re;
+  assign data_out_2_re = addr_hit[27] && reg_re;
 
-  assign data_out_3_re = addr_hit[27] && reg_re;
+  assign data_out_3_re = addr_hit[28] && reg_re;
 
-  assign ctrl_shadowed_operation_we = addr_hit[28] & reg_we & ~wr_err;
+  assign ctrl_shadowed_operation_we = addr_hit[29] & reg_we & ~wr_err;
   assign ctrl_shadowed_operation_wd = reg_wdata[0];
-  assign ctrl_shadowed_operation_re = addr_hit[28] && reg_re;
+  assign ctrl_shadowed_operation_re = addr_hit[29] && reg_re;
 
-  assign ctrl_shadowed_mode_we = addr_hit[28] & reg_we & ~wr_err;
+  assign ctrl_shadowed_mode_we = addr_hit[29] & reg_we & ~wr_err;
   assign ctrl_shadowed_mode_wd = reg_wdata[6:1];
-  assign ctrl_shadowed_mode_re = addr_hit[28] && reg_re;
+  assign ctrl_shadowed_mode_re = addr_hit[29] && reg_re;
 
-  assign ctrl_shadowed_key_len_we = addr_hit[28] & reg_we & ~wr_err;
+  assign ctrl_shadowed_key_len_we = addr_hit[29] & reg_we & ~wr_err;
   assign ctrl_shadowed_key_len_wd = reg_wdata[9:7];
-  assign ctrl_shadowed_key_len_re = addr_hit[28] && reg_re;
+  assign ctrl_shadowed_key_len_re = addr_hit[29] && reg_re;
 
-  assign ctrl_shadowed_manual_operation_we = addr_hit[28] & reg_we & ~wr_err;
+  assign ctrl_shadowed_manual_operation_we = addr_hit[29] & reg_we & ~wr_err;
   assign ctrl_shadowed_manual_operation_wd = reg_wdata[10];
-  assign ctrl_shadowed_manual_operation_re = addr_hit[28] && reg_re;
+  assign ctrl_shadowed_manual_operation_re = addr_hit[29] && reg_re;
 
-  assign ctrl_shadowed_force_zero_masks_we = addr_hit[28] & reg_we & ~wr_err;
+  assign ctrl_shadowed_force_zero_masks_we = addr_hit[29] & reg_we & ~wr_err;
   assign ctrl_shadowed_force_zero_masks_wd = reg_wdata[11];
-  assign ctrl_shadowed_force_zero_masks_re = addr_hit[28] && reg_re;
+  assign ctrl_shadowed_force_zero_masks_re = addr_hit[29] && reg_re;
 
-  assign trigger_start_we = addr_hit[29] & reg_we & ~wr_err;
+  assign trigger_start_we = addr_hit[30] & reg_we & ~wr_err;
   assign trigger_start_wd = reg_wdata[0];
 
-  assign trigger_key_clear_we = addr_hit[29] & reg_we & ~wr_err;
+  assign trigger_key_clear_we = addr_hit[30] & reg_we & ~wr_err;
   assign trigger_key_clear_wd = reg_wdata[1];
 
-  assign trigger_iv_clear_we = addr_hit[29] & reg_we & ~wr_err;
+  assign trigger_iv_clear_we = addr_hit[30] & reg_we & ~wr_err;
   assign trigger_iv_clear_wd = reg_wdata[2];
 
-  assign trigger_data_in_clear_we = addr_hit[29] & reg_we & ~wr_err;
+  assign trigger_data_in_clear_we = addr_hit[30] & reg_we & ~wr_err;
   assign trigger_data_in_clear_wd = reg_wdata[3];
 
-  assign trigger_data_out_clear_we = addr_hit[29] & reg_we & ~wr_err;
+  assign trigger_data_out_clear_we = addr_hit[30] & reg_we & ~wr_err;
   assign trigger_data_out_clear_wd = reg_wdata[4];
 
-  assign trigger_prng_reseed_we = addr_hit[29] & reg_we & ~wr_err;
+  assign trigger_prng_reseed_we = addr_hit[30] & reg_we & ~wr_err;
   assign trigger_prng_reseed_wd = reg_wdata[5];
 
 
@@ -1224,7 +1268,8 @@ module aes_reg_top (
     reg_rdata_next = '0;
     unique case (1'b1)
       addr_hit[0]: begin
-        reg_rdata_next[31:0] = '0;
+        reg_rdata_next[0] = '0;
+        reg_rdata_next[1] = '0;
       end
 
       addr_hit[1]: begin
@@ -1320,22 +1365,26 @@ module aes_reg_top (
       end
 
       addr_hit[24]: begin
-        reg_rdata_next[31:0] = data_out_0_qs;
+        reg_rdata_next[31:0] = '0;
       end
 
       addr_hit[25]: begin
-        reg_rdata_next[31:0] = data_out_1_qs;
+        reg_rdata_next[31:0] = data_out_0_qs;
       end
 
       addr_hit[26]: begin
-        reg_rdata_next[31:0] = data_out_2_qs;
+        reg_rdata_next[31:0] = data_out_1_qs;
       end
 
       addr_hit[27]: begin
-        reg_rdata_next[31:0] = data_out_3_qs;
+        reg_rdata_next[31:0] = data_out_2_qs;
       end
 
       addr_hit[28]: begin
+        reg_rdata_next[31:0] = data_out_3_qs;
+      end
+
+      addr_hit[29]: begin
         reg_rdata_next[0] = ctrl_shadowed_operation_qs;
         reg_rdata_next[6:1] = ctrl_shadowed_mode_qs;
         reg_rdata_next[9:7] = ctrl_shadowed_key_len_qs;
@@ -1343,7 +1392,7 @@ module aes_reg_top (
         reg_rdata_next[11] = ctrl_shadowed_force_zero_masks_qs;
       end
 
-      addr_hit[29]: begin
+      addr_hit[30]: begin
         reg_rdata_next[0] = '0;
         reg_rdata_next[1] = '0;
         reg_rdata_next[2] = '0;
@@ -1352,7 +1401,7 @@ module aes_reg_top (
         reg_rdata_next[5] = '0;
       end
 
-      addr_hit[30]: begin
+      addr_hit[31]: begin
         reg_rdata_next[0] = status_idle_qs;
         reg_rdata_next[1] = status_stall_qs;
         reg_rdata_next[2] = status_output_valid_qs;

--- a/hw/ip/keymgr/rtl/keymgr.sv
+++ b/hw/ip/keymgr/rtl/keymgr.sv
@@ -380,7 +380,7 @@ module keymgr import keymgr_pkg::*; #(
   ) u_err_alert (
     .clk_i,
     .rst_ni,
-    .alert_req_i(|reg2hw.err_code),
+    .alert_req_i(|reg2hw.err_code | (reg2hw.alert_test.q & reg2hw.alert_test.qe)),
     .alert_ack_o(),
     .alert_rx_i(alert_rx_i),
     .alert_tx_o(alert_tx_o)

--- a/hw/ip/keymgr/rtl/keymgr_reg_pkg.sv
+++ b/hw/ip/keymgr/rtl/keymgr_reg_pkg.sv
@@ -46,6 +46,11 @@ package keymgr_reg_pkg;
   } keymgr_reg2hw_intr_test_reg_t;
 
   typedef struct packed {
+    logic        q;
+    logic        qe;
+  } keymgr_reg2hw_alert_test_reg_t;
+
+  typedef struct packed {
     struct packed {
       logic        q;
     } init;
@@ -174,9 +179,10 @@ package keymgr_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    keymgr_reg2hw_intr_state_reg_t intr_state; // [530:529]
-    keymgr_reg2hw_intr_enable_reg_t intr_enable; // [528:527]
-    keymgr_reg2hw_intr_test_reg_t intr_test; // [526:523]
+    keymgr_reg2hw_intr_state_reg_t intr_state; // [532:531]
+    keymgr_reg2hw_intr_enable_reg_t intr_enable; // [530:529]
+    keymgr_reg2hw_intr_test_reg_t intr_test; // [528:525]
+    keymgr_reg2hw_alert_test_reg_t alert_test; // [524:523]
     keymgr_reg2hw_control_reg_t control; // [522:516]
     keymgr_reg2hw_rom_ext_desc_mreg_t [3:0] rom_ext_desc; // [515:388]
     keymgr_reg2hw_software_binding_mreg_t [3:0] software_binding; // [387:260]
@@ -206,47 +212,48 @@ package keymgr_reg_pkg;
   parameter logic [7:0] KEYMGR_INTR_STATE_OFFSET = 8'h 0;
   parameter logic [7:0] KEYMGR_INTR_ENABLE_OFFSET = 8'h 4;
   parameter logic [7:0] KEYMGR_INTR_TEST_OFFSET = 8'h 8;
-  parameter logic [7:0] KEYMGR_CFGEN_OFFSET = 8'h c;
-  parameter logic [7:0] KEYMGR_CONTROL_OFFSET = 8'h 10;
-  parameter logic [7:0] KEYMGR_ROM_EXT_DESC_EN_OFFSET = 8'h 14;
-  parameter logic [7:0] KEYMGR_ROM_EXT_DESC_0_OFFSET = 8'h 18;
-  parameter logic [7:0] KEYMGR_ROM_EXT_DESC_1_OFFSET = 8'h 1c;
-  parameter logic [7:0] KEYMGR_ROM_EXT_DESC_2_OFFSET = 8'h 20;
-  parameter logic [7:0] KEYMGR_ROM_EXT_DESC_3_OFFSET = 8'h 24;
-  parameter logic [7:0] KEYMGR_SOFTWARE_BINDING_0_OFFSET = 8'h 28;
-  parameter logic [7:0] KEYMGR_SOFTWARE_BINDING_1_OFFSET = 8'h 2c;
-  parameter logic [7:0] KEYMGR_SOFTWARE_BINDING_2_OFFSET = 8'h 30;
-  parameter logic [7:0] KEYMGR_SOFTWARE_BINDING_3_OFFSET = 8'h 34;
-  parameter logic [7:0] KEYMGR_SALT_0_OFFSET = 8'h 38;
-  parameter logic [7:0] KEYMGR_SALT_1_OFFSET = 8'h 3c;
-  parameter logic [7:0] KEYMGR_SALT_2_OFFSET = 8'h 40;
-  parameter logic [7:0] KEYMGR_SALT_3_OFFSET = 8'h 44;
-  parameter logic [7:0] KEYMGR_KEY_VERSION_OFFSET = 8'h 48;
-  parameter logic [7:0] KEYMGR_MAX_CREATOR_KEY_VER_EN_OFFSET = 8'h 4c;
-  parameter logic [7:0] KEYMGR_MAX_CREATOR_KEY_VER_OFFSET = 8'h 50;
-  parameter logic [7:0] KEYMGR_MAX_OWNER_INT_KEY_VER_EN_OFFSET = 8'h 54;
-  parameter logic [7:0] KEYMGR_MAX_OWNER_INT_KEY_VER_OFFSET = 8'h 58;
-  parameter logic [7:0] KEYMGR_MAX_OWNER_KEY_VER_EN_OFFSET = 8'h 5c;
-  parameter logic [7:0] KEYMGR_MAX_OWNER_KEY_VER_OFFSET = 8'h 60;
-  parameter logic [7:0] KEYMGR_SW_SHARE0_OUTPUT_0_OFFSET = 8'h 64;
-  parameter logic [7:0] KEYMGR_SW_SHARE0_OUTPUT_1_OFFSET = 8'h 68;
-  parameter logic [7:0] KEYMGR_SW_SHARE0_OUTPUT_2_OFFSET = 8'h 6c;
-  parameter logic [7:0] KEYMGR_SW_SHARE0_OUTPUT_3_OFFSET = 8'h 70;
-  parameter logic [7:0] KEYMGR_SW_SHARE0_OUTPUT_4_OFFSET = 8'h 74;
-  parameter logic [7:0] KEYMGR_SW_SHARE0_OUTPUT_5_OFFSET = 8'h 78;
-  parameter logic [7:0] KEYMGR_SW_SHARE0_OUTPUT_6_OFFSET = 8'h 7c;
-  parameter logic [7:0] KEYMGR_SW_SHARE0_OUTPUT_7_OFFSET = 8'h 80;
-  parameter logic [7:0] KEYMGR_SW_SHARE1_OUTPUT_0_OFFSET = 8'h 84;
-  parameter logic [7:0] KEYMGR_SW_SHARE1_OUTPUT_1_OFFSET = 8'h 88;
-  parameter logic [7:0] KEYMGR_SW_SHARE1_OUTPUT_2_OFFSET = 8'h 8c;
-  parameter logic [7:0] KEYMGR_SW_SHARE1_OUTPUT_3_OFFSET = 8'h 90;
-  parameter logic [7:0] KEYMGR_SW_SHARE1_OUTPUT_4_OFFSET = 8'h 94;
-  parameter logic [7:0] KEYMGR_SW_SHARE1_OUTPUT_5_OFFSET = 8'h 98;
-  parameter logic [7:0] KEYMGR_SW_SHARE1_OUTPUT_6_OFFSET = 8'h 9c;
-  parameter logic [7:0] KEYMGR_SW_SHARE1_OUTPUT_7_OFFSET = 8'h a0;
-  parameter logic [7:0] KEYMGR_WORKING_STATE_OFFSET = 8'h a4;
-  parameter logic [7:0] KEYMGR_OP_STATUS_OFFSET = 8'h a8;
-  parameter logic [7:0] KEYMGR_ERR_CODE_OFFSET = 8'h ac;
+  parameter logic [7:0] KEYMGR_ALERT_TEST_OFFSET = 8'h c;
+  parameter logic [7:0] KEYMGR_CFGEN_OFFSET = 8'h 10;
+  parameter logic [7:0] KEYMGR_CONTROL_OFFSET = 8'h 14;
+  parameter logic [7:0] KEYMGR_ROM_EXT_DESC_EN_OFFSET = 8'h 18;
+  parameter logic [7:0] KEYMGR_ROM_EXT_DESC_0_OFFSET = 8'h 1c;
+  parameter logic [7:0] KEYMGR_ROM_EXT_DESC_1_OFFSET = 8'h 20;
+  parameter logic [7:0] KEYMGR_ROM_EXT_DESC_2_OFFSET = 8'h 24;
+  parameter logic [7:0] KEYMGR_ROM_EXT_DESC_3_OFFSET = 8'h 28;
+  parameter logic [7:0] KEYMGR_SOFTWARE_BINDING_0_OFFSET = 8'h 2c;
+  parameter logic [7:0] KEYMGR_SOFTWARE_BINDING_1_OFFSET = 8'h 30;
+  parameter logic [7:0] KEYMGR_SOFTWARE_BINDING_2_OFFSET = 8'h 34;
+  parameter logic [7:0] KEYMGR_SOFTWARE_BINDING_3_OFFSET = 8'h 38;
+  parameter logic [7:0] KEYMGR_SALT_0_OFFSET = 8'h 3c;
+  parameter logic [7:0] KEYMGR_SALT_1_OFFSET = 8'h 40;
+  parameter logic [7:0] KEYMGR_SALT_2_OFFSET = 8'h 44;
+  parameter logic [7:0] KEYMGR_SALT_3_OFFSET = 8'h 48;
+  parameter logic [7:0] KEYMGR_KEY_VERSION_OFFSET = 8'h 4c;
+  parameter logic [7:0] KEYMGR_MAX_CREATOR_KEY_VER_EN_OFFSET = 8'h 50;
+  parameter logic [7:0] KEYMGR_MAX_CREATOR_KEY_VER_OFFSET = 8'h 54;
+  parameter logic [7:0] KEYMGR_MAX_OWNER_INT_KEY_VER_EN_OFFSET = 8'h 58;
+  parameter logic [7:0] KEYMGR_MAX_OWNER_INT_KEY_VER_OFFSET = 8'h 5c;
+  parameter logic [7:0] KEYMGR_MAX_OWNER_KEY_VER_EN_OFFSET = 8'h 60;
+  parameter logic [7:0] KEYMGR_MAX_OWNER_KEY_VER_OFFSET = 8'h 64;
+  parameter logic [7:0] KEYMGR_SW_SHARE0_OUTPUT_0_OFFSET = 8'h 68;
+  parameter logic [7:0] KEYMGR_SW_SHARE0_OUTPUT_1_OFFSET = 8'h 6c;
+  parameter logic [7:0] KEYMGR_SW_SHARE0_OUTPUT_2_OFFSET = 8'h 70;
+  parameter logic [7:0] KEYMGR_SW_SHARE0_OUTPUT_3_OFFSET = 8'h 74;
+  parameter logic [7:0] KEYMGR_SW_SHARE0_OUTPUT_4_OFFSET = 8'h 78;
+  parameter logic [7:0] KEYMGR_SW_SHARE0_OUTPUT_5_OFFSET = 8'h 7c;
+  parameter logic [7:0] KEYMGR_SW_SHARE0_OUTPUT_6_OFFSET = 8'h 80;
+  parameter logic [7:0] KEYMGR_SW_SHARE0_OUTPUT_7_OFFSET = 8'h 84;
+  parameter logic [7:0] KEYMGR_SW_SHARE1_OUTPUT_0_OFFSET = 8'h 88;
+  parameter logic [7:0] KEYMGR_SW_SHARE1_OUTPUT_1_OFFSET = 8'h 8c;
+  parameter logic [7:0] KEYMGR_SW_SHARE1_OUTPUT_2_OFFSET = 8'h 90;
+  parameter logic [7:0] KEYMGR_SW_SHARE1_OUTPUT_3_OFFSET = 8'h 94;
+  parameter logic [7:0] KEYMGR_SW_SHARE1_OUTPUT_4_OFFSET = 8'h 98;
+  parameter logic [7:0] KEYMGR_SW_SHARE1_OUTPUT_5_OFFSET = 8'h 9c;
+  parameter logic [7:0] KEYMGR_SW_SHARE1_OUTPUT_6_OFFSET = 8'h a0;
+  parameter logic [7:0] KEYMGR_SW_SHARE1_OUTPUT_7_OFFSET = 8'h a4;
+  parameter logic [7:0] KEYMGR_WORKING_STATE_OFFSET = 8'h a8;
+  parameter logic [7:0] KEYMGR_OP_STATUS_OFFSET = 8'h ac;
+  parameter logic [7:0] KEYMGR_ERR_CODE_OFFSET = 8'h b0;
 
 
   // Register Index
@@ -254,6 +261,7 @@ package keymgr_reg_pkg;
     KEYMGR_INTR_STATE,
     KEYMGR_INTR_ENABLE,
     KEYMGR_INTR_TEST,
+    KEYMGR_ALERT_TEST,
     KEYMGR_CFGEN,
     KEYMGR_CONTROL,
     KEYMGR_ROM_EXT_DESC_EN,
@@ -298,51 +306,52 @@ package keymgr_reg_pkg;
   } keymgr_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] KEYMGR_PERMIT [44] = '{
+  parameter logic [3:0] KEYMGR_PERMIT [45] = '{
     4'b 0001, // index[ 0] KEYMGR_INTR_STATE
     4'b 0001, // index[ 1] KEYMGR_INTR_ENABLE
     4'b 0001, // index[ 2] KEYMGR_INTR_TEST
-    4'b 0001, // index[ 3] KEYMGR_CFGEN
-    4'b 0011, // index[ 4] KEYMGR_CONTROL
-    4'b 0001, // index[ 5] KEYMGR_ROM_EXT_DESC_EN
-    4'b 1111, // index[ 6] KEYMGR_ROM_EXT_DESC_0
-    4'b 1111, // index[ 7] KEYMGR_ROM_EXT_DESC_1
-    4'b 1111, // index[ 8] KEYMGR_ROM_EXT_DESC_2
-    4'b 1111, // index[ 9] KEYMGR_ROM_EXT_DESC_3
-    4'b 1111, // index[10] KEYMGR_SOFTWARE_BINDING_0
-    4'b 1111, // index[11] KEYMGR_SOFTWARE_BINDING_1
-    4'b 1111, // index[12] KEYMGR_SOFTWARE_BINDING_2
-    4'b 1111, // index[13] KEYMGR_SOFTWARE_BINDING_3
-    4'b 1111, // index[14] KEYMGR_SALT_0
-    4'b 1111, // index[15] KEYMGR_SALT_1
-    4'b 1111, // index[16] KEYMGR_SALT_2
-    4'b 1111, // index[17] KEYMGR_SALT_3
-    4'b 1111, // index[18] KEYMGR_KEY_VERSION
-    4'b 0001, // index[19] KEYMGR_MAX_CREATOR_KEY_VER_EN
-    4'b 1111, // index[20] KEYMGR_MAX_CREATOR_KEY_VER
-    4'b 0001, // index[21] KEYMGR_MAX_OWNER_INT_KEY_VER_EN
-    4'b 1111, // index[22] KEYMGR_MAX_OWNER_INT_KEY_VER
-    4'b 0001, // index[23] KEYMGR_MAX_OWNER_KEY_VER_EN
-    4'b 1111, // index[24] KEYMGR_MAX_OWNER_KEY_VER
-    4'b 1111, // index[25] KEYMGR_SW_SHARE0_OUTPUT_0
-    4'b 1111, // index[26] KEYMGR_SW_SHARE0_OUTPUT_1
-    4'b 1111, // index[27] KEYMGR_SW_SHARE0_OUTPUT_2
-    4'b 1111, // index[28] KEYMGR_SW_SHARE0_OUTPUT_3
-    4'b 1111, // index[29] KEYMGR_SW_SHARE0_OUTPUT_4
-    4'b 1111, // index[30] KEYMGR_SW_SHARE0_OUTPUT_5
-    4'b 1111, // index[31] KEYMGR_SW_SHARE0_OUTPUT_6
-    4'b 1111, // index[32] KEYMGR_SW_SHARE0_OUTPUT_7
-    4'b 1111, // index[33] KEYMGR_SW_SHARE1_OUTPUT_0
-    4'b 1111, // index[34] KEYMGR_SW_SHARE1_OUTPUT_1
-    4'b 1111, // index[35] KEYMGR_SW_SHARE1_OUTPUT_2
-    4'b 1111, // index[36] KEYMGR_SW_SHARE1_OUTPUT_3
-    4'b 1111, // index[37] KEYMGR_SW_SHARE1_OUTPUT_4
-    4'b 1111, // index[38] KEYMGR_SW_SHARE1_OUTPUT_5
-    4'b 1111, // index[39] KEYMGR_SW_SHARE1_OUTPUT_6
-    4'b 1111, // index[40] KEYMGR_SW_SHARE1_OUTPUT_7
-    4'b 0001, // index[41] KEYMGR_WORKING_STATE
-    4'b 0001, // index[42] KEYMGR_OP_STATUS
-    4'b 0001  // index[43] KEYMGR_ERR_CODE
+    4'b 0001, // index[ 3] KEYMGR_ALERT_TEST
+    4'b 0001, // index[ 4] KEYMGR_CFGEN
+    4'b 0011, // index[ 5] KEYMGR_CONTROL
+    4'b 0001, // index[ 6] KEYMGR_ROM_EXT_DESC_EN
+    4'b 1111, // index[ 7] KEYMGR_ROM_EXT_DESC_0
+    4'b 1111, // index[ 8] KEYMGR_ROM_EXT_DESC_1
+    4'b 1111, // index[ 9] KEYMGR_ROM_EXT_DESC_2
+    4'b 1111, // index[10] KEYMGR_ROM_EXT_DESC_3
+    4'b 1111, // index[11] KEYMGR_SOFTWARE_BINDING_0
+    4'b 1111, // index[12] KEYMGR_SOFTWARE_BINDING_1
+    4'b 1111, // index[13] KEYMGR_SOFTWARE_BINDING_2
+    4'b 1111, // index[14] KEYMGR_SOFTWARE_BINDING_3
+    4'b 1111, // index[15] KEYMGR_SALT_0
+    4'b 1111, // index[16] KEYMGR_SALT_1
+    4'b 1111, // index[17] KEYMGR_SALT_2
+    4'b 1111, // index[18] KEYMGR_SALT_3
+    4'b 1111, // index[19] KEYMGR_KEY_VERSION
+    4'b 0001, // index[20] KEYMGR_MAX_CREATOR_KEY_VER_EN
+    4'b 1111, // index[21] KEYMGR_MAX_CREATOR_KEY_VER
+    4'b 0001, // index[22] KEYMGR_MAX_OWNER_INT_KEY_VER_EN
+    4'b 1111, // index[23] KEYMGR_MAX_OWNER_INT_KEY_VER
+    4'b 0001, // index[24] KEYMGR_MAX_OWNER_KEY_VER_EN
+    4'b 1111, // index[25] KEYMGR_MAX_OWNER_KEY_VER
+    4'b 1111, // index[26] KEYMGR_SW_SHARE0_OUTPUT_0
+    4'b 1111, // index[27] KEYMGR_SW_SHARE0_OUTPUT_1
+    4'b 1111, // index[28] KEYMGR_SW_SHARE0_OUTPUT_2
+    4'b 1111, // index[29] KEYMGR_SW_SHARE0_OUTPUT_3
+    4'b 1111, // index[30] KEYMGR_SW_SHARE0_OUTPUT_4
+    4'b 1111, // index[31] KEYMGR_SW_SHARE0_OUTPUT_5
+    4'b 1111, // index[32] KEYMGR_SW_SHARE0_OUTPUT_6
+    4'b 1111, // index[33] KEYMGR_SW_SHARE0_OUTPUT_7
+    4'b 1111, // index[34] KEYMGR_SW_SHARE1_OUTPUT_0
+    4'b 1111, // index[35] KEYMGR_SW_SHARE1_OUTPUT_1
+    4'b 1111, // index[36] KEYMGR_SW_SHARE1_OUTPUT_2
+    4'b 1111, // index[37] KEYMGR_SW_SHARE1_OUTPUT_3
+    4'b 1111, // index[38] KEYMGR_SW_SHARE1_OUTPUT_4
+    4'b 1111, // index[39] KEYMGR_SW_SHARE1_OUTPUT_5
+    4'b 1111, // index[40] KEYMGR_SW_SHARE1_OUTPUT_6
+    4'b 1111, // index[41] KEYMGR_SW_SHARE1_OUTPUT_7
+    4'b 0001, // index[42] KEYMGR_WORKING_STATE
+    4'b 0001, // index[43] KEYMGR_OP_STATUS
+    4'b 0001  // index[44] KEYMGR_ERR_CODE
   };
 endpackage
 

--- a/hw/ip/keymgr/rtl/keymgr_reg_top.sv
+++ b/hw/ip/keymgr/rtl/keymgr_reg_top.sv
@@ -87,6 +87,8 @@ module keymgr_reg_top (
   logic intr_test_op_done_we;
   logic intr_test_err_wd;
   logic intr_test_err_we;
+  logic alert_test_wd;
+  logic alert_test_we;
   logic cfgen_qs;
   logic cfgen_re;
   logic control_init_qs;
@@ -363,6 +365,22 @@ module keymgr_reg_top (
     .qre    (),
     .qe     (reg2hw.intr_test.err.qe),
     .q      (reg2hw.intr_test.err.q ),
+    .qs     ()
+  );
+
+
+  // R[alert_test]: V(True)
+
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_alert_test (
+    .re     (1'b0),
+    .we     (alert_test_we),
+    .wd     (alert_test_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (reg2hw.alert_test.qe),
+    .q      (reg2hw.alert_test.q ),
     .qs     ()
   );
 
@@ -1634,53 +1652,54 @@ module keymgr_reg_top (
 
 
 
-  logic [43:0] addr_hit;
+  logic [44:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == KEYMGR_INTR_STATE_OFFSET);
     addr_hit[ 1] = (reg_addr == KEYMGR_INTR_ENABLE_OFFSET);
     addr_hit[ 2] = (reg_addr == KEYMGR_INTR_TEST_OFFSET);
-    addr_hit[ 3] = (reg_addr == KEYMGR_CFGEN_OFFSET);
-    addr_hit[ 4] = (reg_addr == KEYMGR_CONTROL_OFFSET);
-    addr_hit[ 5] = (reg_addr == KEYMGR_ROM_EXT_DESC_EN_OFFSET);
-    addr_hit[ 6] = (reg_addr == KEYMGR_ROM_EXT_DESC_0_OFFSET);
-    addr_hit[ 7] = (reg_addr == KEYMGR_ROM_EXT_DESC_1_OFFSET);
-    addr_hit[ 8] = (reg_addr == KEYMGR_ROM_EXT_DESC_2_OFFSET);
-    addr_hit[ 9] = (reg_addr == KEYMGR_ROM_EXT_DESC_3_OFFSET);
-    addr_hit[10] = (reg_addr == KEYMGR_SOFTWARE_BINDING_0_OFFSET);
-    addr_hit[11] = (reg_addr == KEYMGR_SOFTWARE_BINDING_1_OFFSET);
-    addr_hit[12] = (reg_addr == KEYMGR_SOFTWARE_BINDING_2_OFFSET);
-    addr_hit[13] = (reg_addr == KEYMGR_SOFTWARE_BINDING_3_OFFSET);
-    addr_hit[14] = (reg_addr == KEYMGR_SALT_0_OFFSET);
-    addr_hit[15] = (reg_addr == KEYMGR_SALT_1_OFFSET);
-    addr_hit[16] = (reg_addr == KEYMGR_SALT_2_OFFSET);
-    addr_hit[17] = (reg_addr == KEYMGR_SALT_3_OFFSET);
-    addr_hit[18] = (reg_addr == KEYMGR_KEY_VERSION_OFFSET);
-    addr_hit[19] = (reg_addr == KEYMGR_MAX_CREATOR_KEY_VER_EN_OFFSET);
-    addr_hit[20] = (reg_addr == KEYMGR_MAX_CREATOR_KEY_VER_OFFSET);
-    addr_hit[21] = (reg_addr == KEYMGR_MAX_OWNER_INT_KEY_VER_EN_OFFSET);
-    addr_hit[22] = (reg_addr == KEYMGR_MAX_OWNER_INT_KEY_VER_OFFSET);
-    addr_hit[23] = (reg_addr == KEYMGR_MAX_OWNER_KEY_VER_EN_OFFSET);
-    addr_hit[24] = (reg_addr == KEYMGR_MAX_OWNER_KEY_VER_OFFSET);
-    addr_hit[25] = (reg_addr == KEYMGR_SW_SHARE0_OUTPUT_0_OFFSET);
-    addr_hit[26] = (reg_addr == KEYMGR_SW_SHARE0_OUTPUT_1_OFFSET);
-    addr_hit[27] = (reg_addr == KEYMGR_SW_SHARE0_OUTPUT_2_OFFSET);
-    addr_hit[28] = (reg_addr == KEYMGR_SW_SHARE0_OUTPUT_3_OFFSET);
-    addr_hit[29] = (reg_addr == KEYMGR_SW_SHARE0_OUTPUT_4_OFFSET);
-    addr_hit[30] = (reg_addr == KEYMGR_SW_SHARE0_OUTPUT_5_OFFSET);
-    addr_hit[31] = (reg_addr == KEYMGR_SW_SHARE0_OUTPUT_6_OFFSET);
-    addr_hit[32] = (reg_addr == KEYMGR_SW_SHARE0_OUTPUT_7_OFFSET);
-    addr_hit[33] = (reg_addr == KEYMGR_SW_SHARE1_OUTPUT_0_OFFSET);
-    addr_hit[34] = (reg_addr == KEYMGR_SW_SHARE1_OUTPUT_1_OFFSET);
-    addr_hit[35] = (reg_addr == KEYMGR_SW_SHARE1_OUTPUT_2_OFFSET);
-    addr_hit[36] = (reg_addr == KEYMGR_SW_SHARE1_OUTPUT_3_OFFSET);
-    addr_hit[37] = (reg_addr == KEYMGR_SW_SHARE1_OUTPUT_4_OFFSET);
-    addr_hit[38] = (reg_addr == KEYMGR_SW_SHARE1_OUTPUT_5_OFFSET);
-    addr_hit[39] = (reg_addr == KEYMGR_SW_SHARE1_OUTPUT_6_OFFSET);
-    addr_hit[40] = (reg_addr == KEYMGR_SW_SHARE1_OUTPUT_7_OFFSET);
-    addr_hit[41] = (reg_addr == KEYMGR_WORKING_STATE_OFFSET);
-    addr_hit[42] = (reg_addr == KEYMGR_OP_STATUS_OFFSET);
-    addr_hit[43] = (reg_addr == KEYMGR_ERR_CODE_OFFSET);
+    addr_hit[ 3] = (reg_addr == KEYMGR_ALERT_TEST_OFFSET);
+    addr_hit[ 4] = (reg_addr == KEYMGR_CFGEN_OFFSET);
+    addr_hit[ 5] = (reg_addr == KEYMGR_CONTROL_OFFSET);
+    addr_hit[ 6] = (reg_addr == KEYMGR_ROM_EXT_DESC_EN_OFFSET);
+    addr_hit[ 7] = (reg_addr == KEYMGR_ROM_EXT_DESC_0_OFFSET);
+    addr_hit[ 8] = (reg_addr == KEYMGR_ROM_EXT_DESC_1_OFFSET);
+    addr_hit[ 9] = (reg_addr == KEYMGR_ROM_EXT_DESC_2_OFFSET);
+    addr_hit[10] = (reg_addr == KEYMGR_ROM_EXT_DESC_3_OFFSET);
+    addr_hit[11] = (reg_addr == KEYMGR_SOFTWARE_BINDING_0_OFFSET);
+    addr_hit[12] = (reg_addr == KEYMGR_SOFTWARE_BINDING_1_OFFSET);
+    addr_hit[13] = (reg_addr == KEYMGR_SOFTWARE_BINDING_2_OFFSET);
+    addr_hit[14] = (reg_addr == KEYMGR_SOFTWARE_BINDING_3_OFFSET);
+    addr_hit[15] = (reg_addr == KEYMGR_SALT_0_OFFSET);
+    addr_hit[16] = (reg_addr == KEYMGR_SALT_1_OFFSET);
+    addr_hit[17] = (reg_addr == KEYMGR_SALT_2_OFFSET);
+    addr_hit[18] = (reg_addr == KEYMGR_SALT_3_OFFSET);
+    addr_hit[19] = (reg_addr == KEYMGR_KEY_VERSION_OFFSET);
+    addr_hit[20] = (reg_addr == KEYMGR_MAX_CREATOR_KEY_VER_EN_OFFSET);
+    addr_hit[21] = (reg_addr == KEYMGR_MAX_CREATOR_KEY_VER_OFFSET);
+    addr_hit[22] = (reg_addr == KEYMGR_MAX_OWNER_INT_KEY_VER_EN_OFFSET);
+    addr_hit[23] = (reg_addr == KEYMGR_MAX_OWNER_INT_KEY_VER_OFFSET);
+    addr_hit[24] = (reg_addr == KEYMGR_MAX_OWNER_KEY_VER_EN_OFFSET);
+    addr_hit[25] = (reg_addr == KEYMGR_MAX_OWNER_KEY_VER_OFFSET);
+    addr_hit[26] = (reg_addr == KEYMGR_SW_SHARE0_OUTPUT_0_OFFSET);
+    addr_hit[27] = (reg_addr == KEYMGR_SW_SHARE0_OUTPUT_1_OFFSET);
+    addr_hit[28] = (reg_addr == KEYMGR_SW_SHARE0_OUTPUT_2_OFFSET);
+    addr_hit[29] = (reg_addr == KEYMGR_SW_SHARE0_OUTPUT_3_OFFSET);
+    addr_hit[30] = (reg_addr == KEYMGR_SW_SHARE0_OUTPUT_4_OFFSET);
+    addr_hit[31] = (reg_addr == KEYMGR_SW_SHARE0_OUTPUT_5_OFFSET);
+    addr_hit[32] = (reg_addr == KEYMGR_SW_SHARE0_OUTPUT_6_OFFSET);
+    addr_hit[33] = (reg_addr == KEYMGR_SW_SHARE0_OUTPUT_7_OFFSET);
+    addr_hit[34] = (reg_addr == KEYMGR_SW_SHARE1_OUTPUT_0_OFFSET);
+    addr_hit[35] = (reg_addr == KEYMGR_SW_SHARE1_OUTPUT_1_OFFSET);
+    addr_hit[36] = (reg_addr == KEYMGR_SW_SHARE1_OUTPUT_2_OFFSET);
+    addr_hit[37] = (reg_addr == KEYMGR_SW_SHARE1_OUTPUT_3_OFFSET);
+    addr_hit[38] = (reg_addr == KEYMGR_SW_SHARE1_OUTPUT_4_OFFSET);
+    addr_hit[39] = (reg_addr == KEYMGR_SW_SHARE1_OUTPUT_5_OFFSET);
+    addr_hit[40] = (reg_addr == KEYMGR_SW_SHARE1_OUTPUT_6_OFFSET);
+    addr_hit[41] = (reg_addr == KEYMGR_SW_SHARE1_OUTPUT_7_OFFSET);
+    addr_hit[42] = (reg_addr == KEYMGR_WORKING_STATE_OFFSET);
+    addr_hit[43] = (reg_addr == KEYMGR_OP_STATUS_OFFSET);
+    addr_hit[44] = (reg_addr == KEYMGR_ERR_CODE_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -1732,6 +1751,7 @@ module keymgr_reg_top (
     if (addr_hit[41] && reg_we && (KEYMGR_PERMIT[41] != (KEYMGR_PERMIT[41] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[42] && reg_we && (KEYMGR_PERMIT[42] != (KEYMGR_PERMIT[42] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[43] && reg_we && (KEYMGR_PERMIT[43] != (KEYMGR_PERMIT[43] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[44] && reg_we && (KEYMGR_PERMIT[44] != (KEYMGR_PERMIT[44] & reg_be))) wr_err = 1'b1 ;
   end
 
   assign intr_state_op_done_we = addr_hit[0] & reg_we & ~wr_err;
@@ -1752,142 +1772,145 @@ module keymgr_reg_top (
   assign intr_test_err_we = addr_hit[2] & reg_we & ~wr_err;
   assign intr_test_err_wd = reg_wdata[1];
 
-  assign cfgen_re = addr_hit[3] && reg_re;
+  assign alert_test_we = addr_hit[3] & reg_we & ~wr_err;
+  assign alert_test_wd = reg_wdata[0];
 
-  assign control_init_we = addr_hit[4] & reg_we & ~wr_err;
+  assign cfgen_re = addr_hit[4] && reg_re;
+
+  assign control_init_we = addr_hit[5] & reg_we & ~wr_err;
   assign control_init_wd = reg_wdata[0];
 
-  assign control_start_we = addr_hit[4] & reg_we & ~wr_err;
+  assign control_start_we = addr_hit[5] & reg_we & ~wr_err;
   assign control_start_wd = reg_wdata[4];
 
-  assign control_operation_we = addr_hit[4] & reg_we & ~wr_err;
+  assign control_operation_we = addr_hit[5] & reg_we & ~wr_err;
   assign control_operation_wd = reg_wdata[10:8];
 
-  assign control_dest_sel_we = addr_hit[4] & reg_we & ~wr_err;
+  assign control_dest_sel_we = addr_hit[5] & reg_we & ~wr_err;
   assign control_dest_sel_wd = reg_wdata[13:12];
 
-  assign rom_ext_desc_en_we = addr_hit[5] & reg_we & ~wr_err;
+  assign rom_ext_desc_en_we = addr_hit[6] & reg_we & ~wr_err;
   assign rom_ext_desc_en_wd = reg_wdata[1:0];
 
-  assign rom_ext_desc_0_we = addr_hit[6] & reg_we & ~wr_err;
+  assign rom_ext_desc_0_we = addr_hit[7] & reg_we & ~wr_err;
   assign rom_ext_desc_0_wd = reg_wdata[31:0];
 
-  assign rom_ext_desc_1_we = addr_hit[7] & reg_we & ~wr_err;
+  assign rom_ext_desc_1_we = addr_hit[8] & reg_we & ~wr_err;
   assign rom_ext_desc_1_wd = reg_wdata[31:0];
 
-  assign rom_ext_desc_2_we = addr_hit[8] & reg_we & ~wr_err;
+  assign rom_ext_desc_2_we = addr_hit[9] & reg_we & ~wr_err;
   assign rom_ext_desc_2_wd = reg_wdata[31:0];
 
-  assign rom_ext_desc_3_we = addr_hit[9] & reg_we & ~wr_err;
+  assign rom_ext_desc_3_we = addr_hit[10] & reg_we & ~wr_err;
   assign rom_ext_desc_3_wd = reg_wdata[31:0];
 
-  assign software_binding_0_we = addr_hit[10] & reg_we & ~wr_err;
+  assign software_binding_0_we = addr_hit[11] & reg_we & ~wr_err;
   assign software_binding_0_wd = reg_wdata[31:0];
 
-  assign software_binding_1_we = addr_hit[11] & reg_we & ~wr_err;
+  assign software_binding_1_we = addr_hit[12] & reg_we & ~wr_err;
   assign software_binding_1_wd = reg_wdata[31:0];
 
-  assign software_binding_2_we = addr_hit[12] & reg_we & ~wr_err;
+  assign software_binding_2_we = addr_hit[13] & reg_we & ~wr_err;
   assign software_binding_2_wd = reg_wdata[31:0];
 
-  assign software_binding_3_we = addr_hit[13] & reg_we & ~wr_err;
+  assign software_binding_3_we = addr_hit[14] & reg_we & ~wr_err;
   assign software_binding_3_wd = reg_wdata[31:0];
 
-  assign salt_0_we = addr_hit[14] & reg_we & ~wr_err;
+  assign salt_0_we = addr_hit[15] & reg_we & ~wr_err;
   assign salt_0_wd = reg_wdata[31:0];
 
-  assign salt_1_we = addr_hit[15] & reg_we & ~wr_err;
+  assign salt_1_we = addr_hit[16] & reg_we & ~wr_err;
   assign salt_1_wd = reg_wdata[31:0];
 
-  assign salt_2_we = addr_hit[16] & reg_we & ~wr_err;
+  assign salt_2_we = addr_hit[17] & reg_we & ~wr_err;
   assign salt_2_wd = reg_wdata[31:0];
 
-  assign salt_3_we = addr_hit[17] & reg_we & ~wr_err;
+  assign salt_3_we = addr_hit[18] & reg_we & ~wr_err;
   assign salt_3_wd = reg_wdata[31:0];
 
-  assign key_version_we = addr_hit[18] & reg_we & ~wr_err;
+  assign key_version_we = addr_hit[19] & reg_we & ~wr_err;
   assign key_version_wd = reg_wdata[31:0];
 
-  assign max_creator_key_ver_en_we = addr_hit[19] & reg_we & ~wr_err;
+  assign max_creator_key_ver_en_we = addr_hit[20] & reg_we & ~wr_err;
   assign max_creator_key_ver_en_wd = reg_wdata[0];
 
-  assign max_creator_key_ver_we = addr_hit[20] & reg_we & ~wr_err;
+  assign max_creator_key_ver_we = addr_hit[21] & reg_we & ~wr_err;
   assign max_creator_key_ver_wd = reg_wdata[31:0];
 
-  assign max_owner_int_key_ver_en_we = addr_hit[21] & reg_we & ~wr_err;
+  assign max_owner_int_key_ver_en_we = addr_hit[22] & reg_we & ~wr_err;
   assign max_owner_int_key_ver_en_wd = reg_wdata[0];
 
-  assign max_owner_int_key_ver_we = addr_hit[22] & reg_we & ~wr_err;
+  assign max_owner_int_key_ver_we = addr_hit[23] & reg_we & ~wr_err;
   assign max_owner_int_key_ver_wd = reg_wdata[31:0];
 
-  assign max_owner_key_ver_en_we = addr_hit[23] & reg_we & ~wr_err;
+  assign max_owner_key_ver_en_we = addr_hit[24] & reg_we & ~wr_err;
   assign max_owner_key_ver_en_wd = reg_wdata[0];
 
-  assign max_owner_key_ver_we = addr_hit[24] & reg_we & ~wr_err;
+  assign max_owner_key_ver_we = addr_hit[25] & reg_we & ~wr_err;
   assign max_owner_key_ver_wd = reg_wdata[31:0];
 
-  assign sw_share0_output_0_we = addr_hit[25] & reg_re;
+  assign sw_share0_output_0_we = addr_hit[26] & reg_re;
   assign sw_share0_output_0_wd = '1;
 
-  assign sw_share0_output_1_we = addr_hit[26] & reg_re;
+  assign sw_share0_output_1_we = addr_hit[27] & reg_re;
   assign sw_share0_output_1_wd = '1;
 
-  assign sw_share0_output_2_we = addr_hit[27] & reg_re;
+  assign sw_share0_output_2_we = addr_hit[28] & reg_re;
   assign sw_share0_output_2_wd = '1;
 
-  assign sw_share0_output_3_we = addr_hit[28] & reg_re;
+  assign sw_share0_output_3_we = addr_hit[29] & reg_re;
   assign sw_share0_output_3_wd = '1;
 
-  assign sw_share0_output_4_we = addr_hit[29] & reg_re;
+  assign sw_share0_output_4_we = addr_hit[30] & reg_re;
   assign sw_share0_output_4_wd = '1;
 
-  assign sw_share0_output_5_we = addr_hit[30] & reg_re;
+  assign sw_share0_output_5_we = addr_hit[31] & reg_re;
   assign sw_share0_output_5_wd = '1;
 
-  assign sw_share0_output_6_we = addr_hit[31] & reg_re;
+  assign sw_share0_output_6_we = addr_hit[32] & reg_re;
   assign sw_share0_output_6_wd = '1;
 
-  assign sw_share0_output_7_we = addr_hit[32] & reg_re;
+  assign sw_share0_output_7_we = addr_hit[33] & reg_re;
   assign sw_share0_output_7_wd = '1;
 
-  assign sw_share1_output_0_we = addr_hit[33] & reg_re;
+  assign sw_share1_output_0_we = addr_hit[34] & reg_re;
   assign sw_share1_output_0_wd = '1;
 
-  assign sw_share1_output_1_we = addr_hit[34] & reg_re;
+  assign sw_share1_output_1_we = addr_hit[35] & reg_re;
   assign sw_share1_output_1_wd = '1;
 
-  assign sw_share1_output_2_we = addr_hit[35] & reg_re;
+  assign sw_share1_output_2_we = addr_hit[36] & reg_re;
   assign sw_share1_output_2_wd = '1;
 
-  assign sw_share1_output_3_we = addr_hit[36] & reg_re;
+  assign sw_share1_output_3_we = addr_hit[37] & reg_re;
   assign sw_share1_output_3_wd = '1;
 
-  assign sw_share1_output_4_we = addr_hit[37] & reg_re;
+  assign sw_share1_output_4_we = addr_hit[38] & reg_re;
   assign sw_share1_output_4_wd = '1;
 
-  assign sw_share1_output_5_we = addr_hit[38] & reg_re;
+  assign sw_share1_output_5_we = addr_hit[39] & reg_re;
   assign sw_share1_output_5_wd = '1;
 
-  assign sw_share1_output_6_we = addr_hit[39] & reg_re;
+  assign sw_share1_output_6_we = addr_hit[40] & reg_re;
   assign sw_share1_output_6_wd = '1;
 
-  assign sw_share1_output_7_we = addr_hit[40] & reg_re;
+  assign sw_share1_output_7_we = addr_hit[41] & reg_re;
   assign sw_share1_output_7_wd = '1;
 
 
-  assign op_status_we = addr_hit[42] & reg_we & ~wr_err;
+  assign op_status_we = addr_hit[43] & reg_we & ~wr_err;
   assign op_status_wd = reg_wdata[1:0];
 
-  assign err_code_invalid_op_we = addr_hit[43] & reg_we & ~wr_err;
+  assign err_code_invalid_op_we = addr_hit[44] & reg_we & ~wr_err;
   assign err_code_invalid_op_wd = reg_wdata[0];
 
-  assign err_code_invalid_cmd_we = addr_hit[43] & reg_we & ~wr_err;
+  assign err_code_invalid_cmd_we = addr_hit[44] & reg_we & ~wr_err;
   assign err_code_invalid_cmd_wd = reg_wdata[1];
 
-  assign err_code_invalid_kmac_input_we = addr_hit[43] & reg_we & ~wr_err;
+  assign err_code_invalid_kmac_input_we = addr_hit[44] & reg_we & ~wr_err;
   assign err_code_invalid_kmac_input_wd = reg_wdata[2];
 
-  assign err_code_invalid_kmac_data_we = addr_hit[43] & reg_we & ~wr_err;
+  assign err_code_invalid_kmac_data_we = addr_hit[44] & reg_we & ~wr_err;
   assign err_code_invalid_kmac_data_wd = reg_wdata[3];
 
   // Read data return
@@ -1910,169 +1933,173 @@ module keymgr_reg_top (
       end
 
       addr_hit[3]: begin
-        reg_rdata_next[0] = cfgen_qs;
+        reg_rdata_next[0] = '0;
       end
 
       addr_hit[4]: begin
+        reg_rdata_next[0] = cfgen_qs;
+      end
+
+      addr_hit[5]: begin
         reg_rdata_next[0] = control_init_qs;
         reg_rdata_next[4] = control_start_qs;
         reg_rdata_next[10:8] = control_operation_qs;
         reg_rdata_next[13:12] = control_dest_sel_qs;
       end
 
-      addr_hit[5]: begin
+      addr_hit[6]: begin
         reg_rdata_next[1:0] = rom_ext_desc_en_qs;
       end
 
-      addr_hit[6]: begin
+      addr_hit[7]: begin
         reg_rdata_next[31:0] = rom_ext_desc_0_qs;
       end
 
-      addr_hit[7]: begin
+      addr_hit[8]: begin
         reg_rdata_next[31:0] = rom_ext_desc_1_qs;
       end
 
-      addr_hit[8]: begin
+      addr_hit[9]: begin
         reg_rdata_next[31:0] = rom_ext_desc_2_qs;
       end
 
-      addr_hit[9]: begin
+      addr_hit[10]: begin
         reg_rdata_next[31:0] = rom_ext_desc_3_qs;
       end
 
-      addr_hit[10]: begin
+      addr_hit[11]: begin
         reg_rdata_next[31:0] = software_binding_0_qs;
       end
 
-      addr_hit[11]: begin
+      addr_hit[12]: begin
         reg_rdata_next[31:0] = software_binding_1_qs;
       end
 
-      addr_hit[12]: begin
+      addr_hit[13]: begin
         reg_rdata_next[31:0] = software_binding_2_qs;
       end
 
-      addr_hit[13]: begin
+      addr_hit[14]: begin
         reg_rdata_next[31:0] = software_binding_3_qs;
       end
 
-      addr_hit[14]: begin
+      addr_hit[15]: begin
         reg_rdata_next[31:0] = salt_0_qs;
       end
 
-      addr_hit[15]: begin
+      addr_hit[16]: begin
         reg_rdata_next[31:0] = salt_1_qs;
       end
 
-      addr_hit[16]: begin
+      addr_hit[17]: begin
         reg_rdata_next[31:0] = salt_2_qs;
       end
 
-      addr_hit[17]: begin
+      addr_hit[18]: begin
         reg_rdata_next[31:0] = salt_3_qs;
       end
 
-      addr_hit[18]: begin
+      addr_hit[19]: begin
         reg_rdata_next[31:0] = key_version_qs;
       end
 
-      addr_hit[19]: begin
+      addr_hit[20]: begin
         reg_rdata_next[0] = max_creator_key_ver_en_qs;
       end
 
-      addr_hit[20]: begin
+      addr_hit[21]: begin
         reg_rdata_next[31:0] = max_creator_key_ver_qs;
       end
 
-      addr_hit[21]: begin
+      addr_hit[22]: begin
         reg_rdata_next[0] = max_owner_int_key_ver_en_qs;
       end
 
-      addr_hit[22]: begin
+      addr_hit[23]: begin
         reg_rdata_next[31:0] = max_owner_int_key_ver_qs;
       end
 
-      addr_hit[23]: begin
+      addr_hit[24]: begin
         reg_rdata_next[0] = max_owner_key_ver_en_qs;
       end
 
-      addr_hit[24]: begin
+      addr_hit[25]: begin
         reg_rdata_next[31:0] = max_owner_key_ver_qs;
       end
 
-      addr_hit[25]: begin
+      addr_hit[26]: begin
         reg_rdata_next[31:0] = sw_share0_output_0_qs;
       end
 
-      addr_hit[26]: begin
+      addr_hit[27]: begin
         reg_rdata_next[31:0] = sw_share0_output_1_qs;
       end
 
-      addr_hit[27]: begin
+      addr_hit[28]: begin
         reg_rdata_next[31:0] = sw_share0_output_2_qs;
       end
 
-      addr_hit[28]: begin
+      addr_hit[29]: begin
         reg_rdata_next[31:0] = sw_share0_output_3_qs;
       end
 
-      addr_hit[29]: begin
+      addr_hit[30]: begin
         reg_rdata_next[31:0] = sw_share0_output_4_qs;
       end
 
-      addr_hit[30]: begin
+      addr_hit[31]: begin
         reg_rdata_next[31:0] = sw_share0_output_5_qs;
       end
 
-      addr_hit[31]: begin
+      addr_hit[32]: begin
         reg_rdata_next[31:0] = sw_share0_output_6_qs;
       end
 
-      addr_hit[32]: begin
+      addr_hit[33]: begin
         reg_rdata_next[31:0] = sw_share0_output_7_qs;
       end
 
-      addr_hit[33]: begin
+      addr_hit[34]: begin
         reg_rdata_next[31:0] = sw_share1_output_0_qs;
       end
 
-      addr_hit[34]: begin
+      addr_hit[35]: begin
         reg_rdata_next[31:0] = sw_share1_output_1_qs;
       end
 
-      addr_hit[35]: begin
+      addr_hit[36]: begin
         reg_rdata_next[31:0] = sw_share1_output_2_qs;
       end
 
-      addr_hit[36]: begin
+      addr_hit[37]: begin
         reg_rdata_next[31:0] = sw_share1_output_3_qs;
       end
 
-      addr_hit[37]: begin
+      addr_hit[38]: begin
         reg_rdata_next[31:0] = sw_share1_output_4_qs;
       end
 
-      addr_hit[38]: begin
+      addr_hit[39]: begin
         reg_rdata_next[31:0] = sw_share1_output_5_qs;
       end
 
-      addr_hit[39]: begin
+      addr_hit[40]: begin
         reg_rdata_next[31:0] = sw_share1_output_6_qs;
       end
 
-      addr_hit[40]: begin
+      addr_hit[41]: begin
         reg_rdata_next[31:0] = sw_share1_output_7_qs;
       end
 
-      addr_hit[41]: begin
+      addr_hit[42]: begin
         reg_rdata_next[2:0] = working_state_qs;
       end
 
-      addr_hit[42]: begin
+      addr_hit[43]: begin
         reg_rdata_next[1:0] = op_status_qs;
       end
 
-      addr_hit[43]: begin
+      addr_hit[44]: begin
         reg_rdata_next[0] = err_code_invalid_op_qs;
         reg_rdata_next[1] = err_code_invalid_cmd_qs;
         reg_rdata_next[2] = err_code_invalid_kmac_input_qs;

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -396,6 +396,16 @@ module otbn
 
   // Alerts ====================================================================
 
+  logic [NumAlerts-1:0] alert_test;
+  assign alert_test = {
+    reg2hw.alert_test.imem_uncorrectable.q &
+    reg2hw.alert_test.imem_uncorrectable.qe,
+    reg2hw.alert_test.dmem_uncorrectable.q &
+    reg2hw.alert_test.dmem_uncorrectable.qe,
+    reg2hw.alert_test.reg_uncorrectable.q &
+    reg2hw.alert_test.reg_uncorrectable.qe
+  };
+
   logic [NumAlerts-1:0] alerts;
   assign alerts[AlertImemUncorrectable] = imem_rerror[1];
   assign alerts[AlertDmemUncorrectable] = dmem_rerror[1];
@@ -406,7 +416,7 @@ module otbn
     ) i_prim_alert_sender (
       .clk_i,
       .rst_ni,
-      .alert_req_i (alerts[i]    ),
+      .alert_req_i (alerts[i] | alert_test[i]),
       .alert_ack_o (             ),
       .alert_rx_i  (alert_rx_i[i]),
       .alert_tx_o  (alert_tx_o[i])

--- a/hw/ip/otbn/rtl/otbn_reg_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_pkg.sv
@@ -45,6 +45,21 @@ package otbn_reg_pkg;
     struct packed {
       logic        q;
       logic        qe;
+    } imem_uncorrectable;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } dmem_uncorrectable;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } reg_uncorrectable;
+  } otbn_reg2hw_alert_test_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        q;
+      logic        qe;
     } start;
     struct packed {
       logic        q;
@@ -87,9 +102,10 @@ package otbn_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    otbn_reg2hw_intr_state_reg_t intr_state; // [43:42]
-    otbn_reg2hw_intr_enable_reg_t intr_enable; // [41:40]
-    otbn_reg2hw_intr_test_reg_t intr_test; // [39:36]
+    otbn_reg2hw_intr_state_reg_t intr_state; // [49:48]
+    otbn_reg2hw_intr_enable_reg_t intr_enable; // [47:46]
+    otbn_reg2hw_intr_test_reg_t intr_test; // [45:42]
+    otbn_reg2hw_alert_test_reg_t alert_test; // [41:36]
     otbn_reg2hw_cmd_reg_t cmd; // [35:32]
     otbn_reg2hw_start_addr_reg_t start_addr; // [31:0]
   } otbn_reg2hw_t;
@@ -107,10 +123,11 @@ package otbn_reg_pkg;
   parameter logic [21:0] OTBN_INTR_STATE_OFFSET = 22'h 0;
   parameter logic [21:0] OTBN_INTR_ENABLE_OFFSET = 22'h 4;
   parameter logic [21:0] OTBN_INTR_TEST_OFFSET = 22'h 8;
-  parameter logic [21:0] OTBN_CMD_OFFSET = 22'h c;
-  parameter logic [21:0] OTBN_STATUS_OFFSET = 22'h 10;
-  parameter logic [21:0] OTBN_ERR_CODE_OFFSET = 22'h 14;
-  parameter logic [21:0] OTBN_START_ADDR_OFFSET = 22'h 18;
+  parameter logic [21:0] OTBN_ALERT_TEST_OFFSET = 22'h c;
+  parameter logic [21:0] OTBN_CMD_OFFSET = 22'h 10;
+  parameter logic [21:0] OTBN_STATUS_OFFSET = 22'h 14;
+  parameter logic [21:0] OTBN_ERR_CODE_OFFSET = 22'h 18;
+  parameter logic [21:0] OTBN_START_ADDR_OFFSET = 22'h 1c;
 
   // Window parameter
   parameter logic [21:0] OTBN_IMEM_OFFSET = 22'h 100000;
@@ -123,6 +140,7 @@ package otbn_reg_pkg;
     OTBN_INTR_STATE,
     OTBN_INTR_ENABLE,
     OTBN_INTR_TEST,
+    OTBN_ALERT_TEST,
     OTBN_CMD,
     OTBN_STATUS,
     OTBN_ERR_CODE,
@@ -130,14 +148,15 @@ package otbn_reg_pkg;
   } otbn_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] OTBN_PERMIT [7] = '{
+  parameter logic [3:0] OTBN_PERMIT [8] = '{
     4'b 0001, // index[0] OTBN_INTR_STATE
     4'b 0001, // index[1] OTBN_INTR_ENABLE
     4'b 0001, // index[2] OTBN_INTR_TEST
-    4'b 0001, // index[3] OTBN_CMD
-    4'b 0001, // index[4] OTBN_STATUS
-    4'b 1111, // index[5] OTBN_ERR_CODE
-    4'b 1111  // index[6] OTBN_START_ADDR
+    4'b 0001, // index[3] OTBN_ALERT_TEST
+    4'b 0001, // index[4] OTBN_CMD
+    4'b 0001, // index[5] OTBN_STATUS
+    4'b 1111, // index[6] OTBN_ERR_CODE
+    4'b 1111  // index[7] OTBN_START_ADDR
   };
 endpackage
 

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson
@@ -882,6 +882,9 @@
       hwqe:     "true",
       hwext:    "true",
       regwen:   "CHECK_TRIGGER_REGWEN",
+      tags:     [ // Triggering any of these checks may lead to unintended alerts
+                  // if the CHECK_TIMEOUT is not configured properly.
+                  "excl:CsrAllTests:CsrExclWrite"],
       fields: [
         { bits: "0",
           name: "INTEGRITY",
@@ -947,6 +950,9 @@
       swaccess: "rw",
       hwaccess: "hro",
       regwen:   "CHECK_REGWEN",
+      tags:     [ // Triggering any of these checks may lead to unintended alerts
+                  // if the CHECK_TIMEOUT is not configured properly.
+                  "excl:CsrAllTests:CsrExclWrite"],
       fields: [
         { bits: "31:0",
           desc: '''
@@ -969,6 +975,9 @@
       swaccess: "rw",
       hwaccess: "hro",
       regwen:   "CHECK_REGWEN",
+      tags:     [ // Triggering any of these checks may lead to unintended alerts
+                  // if the CHECK_TIMEOUT is not configured properly.
+                  "excl:CsrAllTests:CsrExclWrite"],
       fields: [
         { bits: "31:0",
           desc: '''
@@ -994,6 +1003,9 @@
       swaccess: "rw1c",
       hwaccess: "hro",
       regwen:   "DIRECT_ACCESS_REGWEN",
+      tags:     [ // The enable register "DIRECT_ACCESS_REGWEN" is HW controlled,
+                  // so not able to predict this register value automatically
+                  "excl:CsrNonInitTests:CsrExclCheck"],
       fields: [
         { bits:   "0",
           desc: '''
@@ -1011,6 +1023,9 @@
       swaccess: "rw1c",
       hwaccess: "hro",
       regwen:   "DIRECT_ACCESS_REGWEN",
+      tags:     [ // The enable register "DIRECT_ACCESS_REGWEN" is HW controlled,
+                  // so not able to predict this register value automatically
+                  "excl:CsrNonInitTests:CsrExclCheck"],
       fields: [
         { bits:   "0",
           desc: '''

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
@@ -571,6 +571,9 @@
       hwqe:     "true",
       hwext:    "true",
       regwen:   "CHECK_TRIGGER_REGWEN",
+      tags:     [ // Triggering any of these checks may lead to unintended alerts
+                  // if the CHECK_TIMEOUT is not configured properly.
+                  "excl:CsrAllTests:CsrExclWrite"],
       fields: [
         { bits: "0",
           name: "INTEGRITY",
@@ -636,6 +639,9 @@
       swaccess: "rw",
       hwaccess: "hro",
       regwen:   "CHECK_REGWEN",
+      tags:     [ // Triggering any of these checks may lead to unintended alerts
+                  // if the CHECK_TIMEOUT is not configured properly.
+                  "excl:CsrAllTests:CsrExclWrite"],
       fields: [
         { bits: "31:0",
           desc: '''
@@ -658,6 +664,9 @@
       swaccess: "rw",
       hwaccess: "hro",
       regwen:   "CHECK_REGWEN",
+      tags:     [ // Triggering any of these checks may lead to unintended alerts
+                  // if the CHECK_TIMEOUT is not configured properly.
+                  "excl:CsrAllTests:CsrExclWrite"],
       fields: [
         { bits: "31:0",
           desc: '''
@@ -684,6 +693,10 @@
             ''',
       swaccess: "rw1c",
       hwaccess: "hro",
+      regwen:   "DIRECT_ACCESS_REGWEN",
+      tags:     [ // The enable register "DIRECT_ACCESS_REGWEN" is HW controlled,
+                  // so not able to predict this register value automatically
+                  "excl:CsrNonInitTests:CsrExclCheck"],
       fields: [
         { bits:   "0",
           desc: '''

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
@@ -105,6 +105,17 @@ package otp_ctrl_reg_pkg;
     struct packed {
       logic        q;
       logic        qe;
+    } otp_macro_failure;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } otp_check_failure;
+  } otp_ctrl_reg2hw_alert_test_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        q;
+      logic        qe;
     } read;
     struct packed {
       logic        q;
@@ -256,9 +267,10 @@ package otp_ctrl_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    otp_ctrl_reg2hw_intr_state_reg_t intr_state; // [190:189]
-    otp_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [188:187]
-    otp_ctrl_reg2hw_intr_test_reg_t intr_test; // [186:183]
+    otp_ctrl_reg2hw_intr_state_reg_t intr_state; // [194:193]
+    otp_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [192:191]
+    otp_ctrl_reg2hw_intr_test_reg_t intr_test; // [190:187]
+    otp_ctrl_reg2hw_alert_test_reg_t alert_test; // [186:183]
     otp_ctrl_reg2hw_direct_access_cmd_reg_t direct_access_cmd; // [182:177]
     otp_ctrl_reg2hw_direct_access_address_reg_t direct_access_address; // [176:166]
     otp_ctrl_reg2hw_direct_access_wdata_mreg_t [1:0] direct_access_wdata; // [165:102]
@@ -291,35 +303,36 @@ package otp_ctrl_reg_pkg;
   parameter logic [13:0] OTP_CTRL_INTR_STATE_OFFSET = 14'h 0;
   parameter logic [13:0] OTP_CTRL_INTR_ENABLE_OFFSET = 14'h 4;
   parameter logic [13:0] OTP_CTRL_INTR_TEST_OFFSET = 14'h 8;
-  parameter logic [13:0] OTP_CTRL_STATUS_OFFSET = 14'h c;
-  parameter logic [13:0] OTP_CTRL_ERR_CODE_OFFSET = 14'h 10;
-  parameter logic [13:0] OTP_CTRL_DIRECT_ACCESS_REGWEN_OFFSET = 14'h 14;
-  parameter logic [13:0] OTP_CTRL_DIRECT_ACCESS_CMD_OFFSET = 14'h 18;
-  parameter logic [13:0] OTP_CTRL_DIRECT_ACCESS_ADDRESS_OFFSET = 14'h 1c;
-  parameter logic [13:0] OTP_CTRL_DIRECT_ACCESS_WDATA_0_OFFSET = 14'h 20;
-  parameter logic [13:0] OTP_CTRL_DIRECT_ACCESS_WDATA_1_OFFSET = 14'h 24;
-  parameter logic [13:0] OTP_CTRL_DIRECT_ACCESS_RDATA_0_OFFSET = 14'h 28;
-  parameter logic [13:0] OTP_CTRL_DIRECT_ACCESS_RDATA_1_OFFSET = 14'h 2c;
-  parameter logic [13:0] OTP_CTRL_CHECK_TRIGGER_REGWEN_OFFSET = 14'h 30;
-  parameter logic [13:0] OTP_CTRL_CHECK_TRIGGER_OFFSET = 14'h 34;
-  parameter logic [13:0] OTP_CTRL_CHECK_REGWEN_OFFSET = 14'h 38;
-  parameter logic [13:0] OTP_CTRL_CHECK_TIMEOUT_OFFSET = 14'h 3c;
-  parameter logic [13:0] OTP_CTRL_INTEGRITY_CHECK_PERIOD_OFFSET = 14'h 40;
-  parameter logic [13:0] OTP_CTRL_CONSISTENCY_CHECK_PERIOD_OFFSET = 14'h 44;
-  parameter logic [13:0] OTP_CTRL_CREATOR_SW_CFG_READ_LOCK_OFFSET = 14'h 48;
-  parameter logic [13:0] OTP_CTRL_OWNER_SW_CFG_READ_LOCK_OFFSET = 14'h 4c;
-  parameter logic [13:0] OTP_CTRL_CREATOR_SW_CFG_DIGEST_0_OFFSET = 14'h 50;
-  parameter logic [13:0] OTP_CTRL_CREATOR_SW_CFG_DIGEST_1_OFFSET = 14'h 54;
-  parameter logic [13:0] OTP_CTRL_OWNER_SW_CFG_DIGEST_0_OFFSET = 14'h 58;
-  parameter logic [13:0] OTP_CTRL_OWNER_SW_CFG_DIGEST_1_OFFSET = 14'h 5c;
-  parameter logic [13:0] OTP_CTRL_HW_CFG_DIGEST_0_OFFSET = 14'h 60;
-  parameter logic [13:0] OTP_CTRL_HW_CFG_DIGEST_1_OFFSET = 14'h 64;
-  parameter logic [13:0] OTP_CTRL_SECRET0_DIGEST_0_OFFSET = 14'h 68;
-  parameter logic [13:0] OTP_CTRL_SECRET0_DIGEST_1_OFFSET = 14'h 6c;
-  parameter logic [13:0] OTP_CTRL_SECRET1_DIGEST_0_OFFSET = 14'h 70;
-  parameter logic [13:0] OTP_CTRL_SECRET1_DIGEST_1_OFFSET = 14'h 74;
-  parameter logic [13:0] OTP_CTRL_SECRET2_DIGEST_0_OFFSET = 14'h 78;
-  parameter logic [13:0] OTP_CTRL_SECRET2_DIGEST_1_OFFSET = 14'h 7c;
+  parameter logic [13:0] OTP_CTRL_ALERT_TEST_OFFSET = 14'h c;
+  parameter logic [13:0] OTP_CTRL_STATUS_OFFSET = 14'h 10;
+  parameter logic [13:0] OTP_CTRL_ERR_CODE_OFFSET = 14'h 14;
+  parameter logic [13:0] OTP_CTRL_DIRECT_ACCESS_REGWEN_OFFSET = 14'h 18;
+  parameter logic [13:0] OTP_CTRL_DIRECT_ACCESS_CMD_OFFSET = 14'h 1c;
+  parameter logic [13:0] OTP_CTRL_DIRECT_ACCESS_ADDRESS_OFFSET = 14'h 20;
+  parameter logic [13:0] OTP_CTRL_DIRECT_ACCESS_WDATA_0_OFFSET = 14'h 24;
+  parameter logic [13:0] OTP_CTRL_DIRECT_ACCESS_WDATA_1_OFFSET = 14'h 28;
+  parameter logic [13:0] OTP_CTRL_DIRECT_ACCESS_RDATA_0_OFFSET = 14'h 2c;
+  parameter logic [13:0] OTP_CTRL_DIRECT_ACCESS_RDATA_1_OFFSET = 14'h 30;
+  parameter logic [13:0] OTP_CTRL_CHECK_TRIGGER_REGWEN_OFFSET = 14'h 34;
+  parameter logic [13:0] OTP_CTRL_CHECK_TRIGGER_OFFSET = 14'h 38;
+  parameter logic [13:0] OTP_CTRL_CHECK_REGWEN_OFFSET = 14'h 3c;
+  parameter logic [13:0] OTP_CTRL_CHECK_TIMEOUT_OFFSET = 14'h 40;
+  parameter logic [13:0] OTP_CTRL_INTEGRITY_CHECK_PERIOD_OFFSET = 14'h 44;
+  parameter logic [13:0] OTP_CTRL_CONSISTENCY_CHECK_PERIOD_OFFSET = 14'h 48;
+  parameter logic [13:0] OTP_CTRL_CREATOR_SW_CFG_READ_LOCK_OFFSET = 14'h 4c;
+  parameter logic [13:0] OTP_CTRL_OWNER_SW_CFG_READ_LOCK_OFFSET = 14'h 50;
+  parameter logic [13:0] OTP_CTRL_CREATOR_SW_CFG_DIGEST_0_OFFSET = 14'h 54;
+  parameter logic [13:0] OTP_CTRL_CREATOR_SW_CFG_DIGEST_1_OFFSET = 14'h 58;
+  parameter logic [13:0] OTP_CTRL_OWNER_SW_CFG_DIGEST_0_OFFSET = 14'h 5c;
+  parameter logic [13:0] OTP_CTRL_OWNER_SW_CFG_DIGEST_1_OFFSET = 14'h 60;
+  parameter logic [13:0] OTP_CTRL_HW_CFG_DIGEST_0_OFFSET = 14'h 64;
+  parameter logic [13:0] OTP_CTRL_HW_CFG_DIGEST_1_OFFSET = 14'h 68;
+  parameter logic [13:0] OTP_CTRL_SECRET0_DIGEST_0_OFFSET = 14'h 6c;
+  parameter logic [13:0] OTP_CTRL_SECRET0_DIGEST_1_OFFSET = 14'h 70;
+  parameter logic [13:0] OTP_CTRL_SECRET1_DIGEST_0_OFFSET = 14'h 74;
+  parameter logic [13:0] OTP_CTRL_SECRET1_DIGEST_1_OFFSET = 14'h 78;
+  parameter logic [13:0] OTP_CTRL_SECRET2_DIGEST_0_OFFSET = 14'h 7c;
+  parameter logic [13:0] OTP_CTRL_SECRET2_DIGEST_1_OFFSET = 14'h 80;
 
   // Window parameter
   parameter logic [13:0] OTP_CTRL_SW_CFG_WINDOW_OFFSET = 14'h 1000;
@@ -332,6 +345,7 @@ package otp_ctrl_reg_pkg;
     OTP_CTRL_INTR_STATE,
     OTP_CTRL_INTR_ENABLE,
     OTP_CTRL_INTR_TEST,
+    OTP_CTRL_ALERT_TEST,
     OTP_CTRL_STATUS,
     OTP_CTRL_ERR_CODE,
     OTP_CTRL_DIRECT_ACCESS_REGWEN,
@@ -364,39 +378,40 @@ package otp_ctrl_reg_pkg;
   } otp_ctrl_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] OTP_CTRL_PERMIT [32] = '{
+  parameter logic [3:0] OTP_CTRL_PERMIT [33] = '{
     4'b 0001, // index[ 0] OTP_CTRL_INTR_STATE
     4'b 0001, // index[ 1] OTP_CTRL_INTR_ENABLE
     4'b 0001, // index[ 2] OTP_CTRL_INTR_TEST
-    4'b 0011, // index[ 3] OTP_CTRL_STATUS
-    4'b 1111, // index[ 4] OTP_CTRL_ERR_CODE
-    4'b 0001, // index[ 5] OTP_CTRL_DIRECT_ACCESS_REGWEN
-    4'b 0001, // index[ 6] OTP_CTRL_DIRECT_ACCESS_CMD
-    4'b 0011, // index[ 7] OTP_CTRL_DIRECT_ACCESS_ADDRESS
-    4'b 1111, // index[ 8] OTP_CTRL_DIRECT_ACCESS_WDATA_0
-    4'b 1111, // index[ 9] OTP_CTRL_DIRECT_ACCESS_WDATA_1
-    4'b 1111, // index[10] OTP_CTRL_DIRECT_ACCESS_RDATA_0
-    4'b 1111, // index[11] OTP_CTRL_DIRECT_ACCESS_RDATA_1
-    4'b 0001, // index[12] OTP_CTRL_CHECK_TRIGGER_REGWEN
-    4'b 0001, // index[13] OTP_CTRL_CHECK_TRIGGER
-    4'b 0001, // index[14] OTP_CTRL_CHECK_REGWEN
-    4'b 1111, // index[15] OTP_CTRL_CHECK_TIMEOUT
-    4'b 1111, // index[16] OTP_CTRL_INTEGRITY_CHECK_PERIOD
-    4'b 1111, // index[17] OTP_CTRL_CONSISTENCY_CHECK_PERIOD
-    4'b 0001, // index[18] OTP_CTRL_CREATOR_SW_CFG_READ_LOCK
-    4'b 0001, // index[19] OTP_CTRL_OWNER_SW_CFG_READ_LOCK
-    4'b 1111, // index[20] OTP_CTRL_CREATOR_SW_CFG_DIGEST_0
-    4'b 1111, // index[21] OTP_CTRL_CREATOR_SW_CFG_DIGEST_1
-    4'b 1111, // index[22] OTP_CTRL_OWNER_SW_CFG_DIGEST_0
-    4'b 1111, // index[23] OTP_CTRL_OWNER_SW_CFG_DIGEST_1
-    4'b 1111, // index[24] OTP_CTRL_HW_CFG_DIGEST_0
-    4'b 1111, // index[25] OTP_CTRL_HW_CFG_DIGEST_1
-    4'b 1111, // index[26] OTP_CTRL_SECRET0_DIGEST_0
-    4'b 1111, // index[27] OTP_CTRL_SECRET0_DIGEST_1
-    4'b 1111, // index[28] OTP_CTRL_SECRET1_DIGEST_0
-    4'b 1111, // index[29] OTP_CTRL_SECRET1_DIGEST_1
-    4'b 1111, // index[30] OTP_CTRL_SECRET2_DIGEST_0
-    4'b 1111  // index[31] OTP_CTRL_SECRET2_DIGEST_1
+    4'b 0001, // index[ 3] OTP_CTRL_ALERT_TEST
+    4'b 0011, // index[ 4] OTP_CTRL_STATUS
+    4'b 1111, // index[ 5] OTP_CTRL_ERR_CODE
+    4'b 0001, // index[ 6] OTP_CTRL_DIRECT_ACCESS_REGWEN
+    4'b 0001, // index[ 7] OTP_CTRL_DIRECT_ACCESS_CMD
+    4'b 0011, // index[ 8] OTP_CTRL_DIRECT_ACCESS_ADDRESS
+    4'b 1111, // index[ 9] OTP_CTRL_DIRECT_ACCESS_WDATA_0
+    4'b 1111, // index[10] OTP_CTRL_DIRECT_ACCESS_WDATA_1
+    4'b 1111, // index[11] OTP_CTRL_DIRECT_ACCESS_RDATA_0
+    4'b 1111, // index[12] OTP_CTRL_DIRECT_ACCESS_RDATA_1
+    4'b 0001, // index[13] OTP_CTRL_CHECK_TRIGGER_REGWEN
+    4'b 0001, // index[14] OTP_CTRL_CHECK_TRIGGER
+    4'b 0001, // index[15] OTP_CTRL_CHECK_REGWEN
+    4'b 1111, // index[16] OTP_CTRL_CHECK_TIMEOUT
+    4'b 1111, // index[17] OTP_CTRL_INTEGRITY_CHECK_PERIOD
+    4'b 1111, // index[18] OTP_CTRL_CONSISTENCY_CHECK_PERIOD
+    4'b 0001, // index[19] OTP_CTRL_CREATOR_SW_CFG_READ_LOCK
+    4'b 0001, // index[20] OTP_CTRL_OWNER_SW_CFG_READ_LOCK
+    4'b 1111, // index[21] OTP_CTRL_CREATOR_SW_CFG_DIGEST_0
+    4'b 1111, // index[22] OTP_CTRL_CREATOR_SW_CFG_DIGEST_1
+    4'b 1111, // index[23] OTP_CTRL_OWNER_SW_CFG_DIGEST_0
+    4'b 1111, // index[24] OTP_CTRL_OWNER_SW_CFG_DIGEST_1
+    4'b 1111, // index[25] OTP_CTRL_HW_CFG_DIGEST_0
+    4'b 1111, // index[26] OTP_CTRL_HW_CFG_DIGEST_1
+    4'b 1111, // index[27] OTP_CTRL_SECRET0_DIGEST_0
+    4'b 1111, // index[28] OTP_CTRL_SECRET0_DIGEST_1
+    4'b 1111, // index[29] OTP_CTRL_SECRET1_DIGEST_0
+    4'b 1111, // index[30] OTP_CTRL_SECRET1_DIGEST_1
+    4'b 1111, // index[31] OTP_CTRL_SECRET2_DIGEST_0
+    4'b 1111  // index[32] OTP_CTRL_SECRET2_DIGEST_1
   };
 endpackage
 

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_top.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_top.sv
@@ -137,6 +137,10 @@ module otp_ctrl_reg_top (
   logic intr_test_otp_operation_done_we;
   logic intr_test_otp_error_wd;
   logic intr_test_otp_error_we;
+  logic alert_test_otp_macro_failure_wd;
+  logic alert_test_otp_macro_failure_we;
+  logic alert_test_otp_check_failure_wd;
+  logic alert_test_otp_check_failure_we;
   logic status_creator_sw_cfg_error_qs;
   logic status_creator_sw_cfg_error_re;
   logic status_owner_sw_cfg_error_qs;
@@ -393,6 +397,38 @@ module otp_ctrl_reg_top (
     .qre    (),
     .qe     (reg2hw.intr_test.otp_error.qe),
     .q      (reg2hw.intr_test.otp_error.q ),
+    .qs     ()
+  );
+
+
+  // R[alert_test]: V(True)
+
+  //   F[otp_macro_failure]: 0:0
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_alert_test_otp_macro_failure (
+    .re     (1'b0),
+    .we     (alert_test_otp_macro_failure_we),
+    .wd     (alert_test_otp_macro_failure_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (reg2hw.alert_test.otp_macro_failure.qe),
+    .q      (reg2hw.alert_test.otp_macro_failure.q ),
+    .qs     ()
+  );
+
+
+  //   F[otp_check_failure]: 1:1
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_alert_test_otp_check_failure (
+    .re     (1'b0),
+    .we     (alert_test_otp_check_failure_we),
+    .wd     (alert_test_otp_check_failure_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (reg2hw.alert_test.otp_check_failure.qe),
+    .q      (reg2hw.alert_test.otp_check_failure.q ),
     .qs     ()
   );
 
@@ -1376,41 +1412,42 @@ module otp_ctrl_reg_top (
 
 
 
-  logic [31:0] addr_hit;
+  logic [32:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == OTP_CTRL_INTR_STATE_OFFSET);
     addr_hit[ 1] = (reg_addr == OTP_CTRL_INTR_ENABLE_OFFSET);
     addr_hit[ 2] = (reg_addr == OTP_CTRL_INTR_TEST_OFFSET);
-    addr_hit[ 3] = (reg_addr == OTP_CTRL_STATUS_OFFSET);
-    addr_hit[ 4] = (reg_addr == OTP_CTRL_ERR_CODE_OFFSET);
-    addr_hit[ 5] = (reg_addr == OTP_CTRL_DIRECT_ACCESS_REGWEN_OFFSET);
-    addr_hit[ 6] = (reg_addr == OTP_CTRL_DIRECT_ACCESS_CMD_OFFSET);
-    addr_hit[ 7] = (reg_addr == OTP_CTRL_DIRECT_ACCESS_ADDRESS_OFFSET);
-    addr_hit[ 8] = (reg_addr == OTP_CTRL_DIRECT_ACCESS_WDATA_0_OFFSET);
-    addr_hit[ 9] = (reg_addr == OTP_CTRL_DIRECT_ACCESS_WDATA_1_OFFSET);
-    addr_hit[10] = (reg_addr == OTP_CTRL_DIRECT_ACCESS_RDATA_0_OFFSET);
-    addr_hit[11] = (reg_addr == OTP_CTRL_DIRECT_ACCESS_RDATA_1_OFFSET);
-    addr_hit[12] = (reg_addr == OTP_CTRL_CHECK_TRIGGER_REGWEN_OFFSET);
-    addr_hit[13] = (reg_addr == OTP_CTRL_CHECK_TRIGGER_OFFSET);
-    addr_hit[14] = (reg_addr == OTP_CTRL_CHECK_REGWEN_OFFSET);
-    addr_hit[15] = (reg_addr == OTP_CTRL_CHECK_TIMEOUT_OFFSET);
-    addr_hit[16] = (reg_addr == OTP_CTRL_INTEGRITY_CHECK_PERIOD_OFFSET);
-    addr_hit[17] = (reg_addr == OTP_CTRL_CONSISTENCY_CHECK_PERIOD_OFFSET);
-    addr_hit[18] = (reg_addr == OTP_CTRL_CREATOR_SW_CFG_READ_LOCK_OFFSET);
-    addr_hit[19] = (reg_addr == OTP_CTRL_OWNER_SW_CFG_READ_LOCK_OFFSET);
-    addr_hit[20] = (reg_addr == OTP_CTRL_CREATOR_SW_CFG_DIGEST_0_OFFSET);
-    addr_hit[21] = (reg_addr == OTP_CTRL_CREATOR_SW_CFG_DIGEST_1_OFFSET);
-    addr_hit[22] = (reg_addr == OTP_CTRL_OWNER_SW_CFG_DIGEST_0_OFFSET);
-    addr_hit[23] = (reg_addr == OTP_CTRL_OWNER_SW_CFG_DIGEST_1_OFFSET);
-    addr_hit[24] = (reg_addr == OTP_CTRL_HW_CFG_DIGEST_0_OFFSET);
-    addr_hit[25] = (reg_addr == OTP_CTRL_HW_CFG_DIGEST_1_OFFSET);
-    addr_hit[26] = (reg_addr == OTP_CTRL_SECRET0_DIGEST_0_OFFSET);
-    addr_hit[27] = (reg_addr == OTP_CTRL_SECRET0_DIGEST_1_OFFSET);
-    addr_hit[28] = (reg_addr == OTP_CTRL_SECRET1_DIGEST_0_OFFSET);
-    addr_hit[29] = (reg_addr == OTP_CTRL_SECRET1_DIGEST_1_OFFSET);
-    addr_hit[30] = (reg_addr == OTP_CTRL_SECRET2_DIGEST_0_OFFSET);
-    addr_hit[31] = (reg_addr == OTP_CTRL_SECRET2_DIGEST_1_OFFSET);
+    addr_hit[ 3] = (reg_addr == OTP_CTRL_ALERT_TEST_OFFSET);
+    addr_hit[ 4] = (reg_addr == OTP_CTRL_STATUS_OFFSET);
+    addr_hit[ 5] = (reg_addr == OTP_CTRL_ERR_CODE_OFFSET);
+    addr_hit[ 6] = (reg_addr == OTP_CTRL_DIRECT_ACCESS_REGWEN_OFFSET);
+    addr_hit[ 7] = (reg_addr == OTP_CTRL_DIRECT_ACCESS_CMD_OFFSET);
+    addr_hit[ 8] = (reg_addr == OTP_CTRL_DIRECT_ACCESS_ADDRESS_OFFSET);
+    addr_hit[ 9] = (reg_addr == OTP_CTRL_DIRECT_ACCESS_WDATA_0_OFFSET);
+    addr_hit[10] = (reg_addr == OTP_CTRL_DIRECT_ACCESS_WDATA_1_OFFSET);
+    addr_hit[11] = (reg_addr == OTP_CTRL_DIRECT_ACCESS_RDATA_0_OFFSET);
+    addr_hit[12] = (reg_addr == OTP_CTRL_DIRECT_ACCESS_RDATA_1_OFFSET);
+    addr_hit[13] = (reg_addr == OTP_CTRL_CHECK_TRIGGER_REGWEN_OFFSET);
+    addr_hit[14] = (reg_addr == OTP_CTRL_CHECK_TRIGGER_OFFSET);
+    addr_hit[15] = (reg_addr == OTP_CTRL_CHECK_REGWEN_OFFSET);
+    addr_hit[16] = (reg_addr == OTP_CTRL_CHECK_TIMEOUT_OFFSET);
+    addr_hit[17] = (reg_addr == OTP_CTRL_INTEGRITY_CHECK_PERIOD_OFFSET);
+    addr_hit[18] = (reg_addr == OTP_CTRL_CONSISTENCY_CHECK_PERIOD_OFFSET);
+    addr_hit[19] = (reg_addr == OTP_CTRL_CREATOR_SW_CFG_READ_LOCK_OFFSET);
+    addr_hit[20] = (reg_addr == OTP_CTRL_OWNER_SW_CFG_READ_LOCK_OFFSET);
+    addr_hit[21] = (reg_addr == OTP_CTRL_CREATOR_SW_CFG_DIGEST_0_OFFSET);
+    addr_hit[22] = (reg_addr == OTP_CTRL_CREATOR_SW_CFG_DIGEST_1_OFFSET);
+    addr_hit[23] = (reg_addr == OTP_CTRL_OWNER_SW_CFG_DIGEST_0_OFFSET);
+    addr_hit[24] = (reg_addr == OTP_CTRL_OWNER_SW_CFG_DIGEST_1_OFFSET);
+    addr_hit[25] = (reg_addr == OTP_CTRL_HW_CFG_DIGEST_0_OFFSET);
+    addr_hit[26] = (reg_addr == OTP_CTRL_HW_CFG_DIGEST_1_OFFSET);
+    addr_hit[27] = (reg_addr == OTP_CTRL_SECRET0_DIGEST_0_OFFSET);
+    addr_hit[28] = (reg_addr == OTP_CTRL_SECRET0_DIGEST_1_OFFSET);
+    addr_hit[29] = (reg_addr == OTP_CTRL_SECRET1_DIGEST_0_OFFSET);
+    addr_hit[30] = (reg_addr == OTP_CTRL_SECRET1_DIGEST_1_OFFSET);
+    addr_hit[31] = (reg_addr == OTP_CTRL_SECRET2_DIGEST_0_OFFSET);
+    addr_hit[32] = (reg_addr == OTP_CTRL_SECRET2_DIGEST_1_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -1450,6 +1487,7 @@ module otp_ctrl_reg_top (
     if (addr_hit[29] && reg_we && (OTP_CTRL_PERMIT[29] != (OTP_CTRL_PERMIT[29] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[30] && reg_we && (OTP_CTRL_PERMIT[30] != (OTP_CTRL_PERMIT[30] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[31] && reg_we && (OTP_CTRL_PERMIT[31] != (OTP_CTRL_PERMIT[31] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[32] && reg_we && (OTP_CTRL_PERMIT[32] != (OTP_CTRL_PERMIT[32] & reg_be))) wr_err = 1'b1 ;
   end
 
   assign intr_state_otp_operation_done_we = addr_hit[0] & reg_we & ~wr_err;
@@ -1470,128 +1508,134 @@ module otp_ctrl_reg_top (
   assign intr_test_otp_error_we = addr_hit[2] & reg_we & ~wr_err;
   assign intr_test_otp_error_wd = reg_wdata[1];
 
-  assign status_creator_sw_cfg_error_re = addr_hit[3] && reg_re;
+  assign alert_test_otp_macro_failure_we = addr_hit[3] & reg_we & ~wr_err;
+  assign alert_test_otp_macro_failure_wd = reg_wdata[0];
 
-  assign status_owner_sw_cfg_error_re = addr_hit[3] && reg_re;
+  assign alert_test_otp_check_failure_we = addr_hit[3] & reg_we & ~wr_err;
+  assign alert_test_otp_check_failure_wd = reg_wdata[1];
 
-  assign status_hw_cfg_error_re = addr_hit[3] && reg_re;
+  assign status_creator_sw_cfg_error_re = addr_hit[4] && reg_re;
 
-  assign status_secret0_error_re = addr_hit[3] && reg_re;
+  assign status_owner_sw_cfg_error_re = addr_hit[4] && reg_re;
 
-  assign status_secret1_error_re = addr_hit[3] && reg_re;
+  assign status_hw_cfg_error_re = addr_hit[4] && reg_re;
 
-  assign status_secret2_error_re = addr_hit[3] && reg_re;
+  assign status_secret0_error_re = addr_hit[4] && reg_re;
 
-  assign status_life_cycle_error_re = addr_hit[3] && reg_re;
+  assign status_secret1_error_re = addr_hit[4] && reg_re;
 
-  assign status_dai_error_re = addr_hit[3] && reg_re;
+  assign status_secret2_error_re = addr_hit[4] && reg_re;
 
-  assign status_lci_error_re = addr_hit[3] && reg_re;
+  assign status_life_cycle_error_re = addr_hit[4] && reg_re;
 
-  assign status_timeout_error_re = addr_hit[3] && reg_re;
+  assign status_dai_error_re = addr_hit[4] && reg_re;
 
-  assign status_lfsr_fsm_error_re = addr_hit[3] && reg_re;
+  assign status_lci_error_re = addr_hit[4] && reg_re;
 
-  assign status_scrambling_fsm_error_re = addr_hit[3] && reg_re;
+  assign status_timeout_error_re = addr_hit[4] && reg_re;
 
-  assign status_key_deriv_fsm_error_re = addr_hit[3] && reg_re;
+  assign status_lfsr_fsm_error_re = addr_hit[4] && reg_re;
 
-  assign status_dai_idle_re = addr_hit[3] && reg_re;
+  assign status_scrambling_fsm_error_re = addr_hit[4] && reg_re;
 
-  assign status_check_pending_re = addr_hit[3] && reg_re;
+  assign status_key_deriv_fsm_error_re = addr_hit[4] && reg_re;
 
-  assign err_code_err_code_0_re = addr_hit[4] && reg_re;
+  assign status_dai_idle_re = addr_hit[4] && reg_re;
 
-  assign err_code_err_code_1_re = addr_hit[4] && reg_re;
+  assign status_check_pending_re = addr_hit[4] && reg_re;
 
-  assign err_code_err_code_2_re = addr_hit[4] && reg_re;
+  assign err_code_err_code_0_re = addr_hit[5] && reg_re;
 
-  assign err_code_err_code_3_re = addr_hit[4] && reg_re;
+  assign err_code_err_code_1_re = addr_hit[5] && reg_re;
 
-  assign err_code_err_code_4_re = addr_hit[4] && reg_re;
+  assign err_code_err_code_2_re = addr_hit[5] && reg_re;
 
-  assign err_code_err_code_5_re = addr_hit[4] && reg_re;
+  assign err_code_err_code_3_re = addr_hit[5] && reg_re;
 
-  assign err_code_err_code_6_re = addr_hit[4] && reg_re;
+  assign err_code_err_code_4_re = addr_hit[5] && reg_re;
 
-  assign err_code_err_code_7_re = addr_hit[4] && reg_re;
+  assign err_code_err_code_5_re = addr_hit[5] && reg_re;
 
-  assign err_code_err_code_8_re = addr_hit[4] && reg_re;
+  assign err_code_err_code_6_re = addr_hit[5] && reg_re;
 
-  assign direct_access_regwen_re = addr_hit[5] && reg_re;
+  assign err_code_err_code_7_re = addr_hit[5] && reg_re;
 
-  assign direct_access_cmd_read_we = addr_hit[6] & reg_we & ~wr_err;
+  assign err_code_err_code_8_re = addr_hit[5] && reg_re;
+
+  assign direct_access_regwen_re = addr_hit[6] && reg_re;
+
+  assign direct_access_cmd_read_we = addr_hit[7] & reg_we & ~wr_err;
   assign direct_access_cmd_read_wd = reg_wdata[0];
 
-  assign direct_access_cmd_write_we = addr_hit[6] & reg_we & ~wr_err;
+  assign direct_access_cmd_write_we = addr_hit[7] & reg_we & ~wr_err;
   assign direct_access_cmd_write_wd = reg_wdata[1];
 
-  assign direct_access_cmd_digest_we = addr_hit[6] & reg_we & ~wr_err;
+  assign direct_access_cmd_digest_we = addr_hit[7] & reg_we & ~wr_err;
   assign direct_access_cmd_digest_wd = reg_wdata[2];
 
-  assign direct_access_address_we = addr_hit[7] & reg_we & ~wr_err;
+  assign direct_access_address_we = addr_hit[8] & reg_we & ~wr_err;
   assign direct_access_address_wd = reg_wdata[10:0];
 
-  assign direct_access_wdata_0_we = addr_hit[8] & reg_we & ~wr_err;
+  assign direct_access_wdata_0_we = addr_hit[9] & reg_we & ~wr_err;
   assign direct_access_wdata_0_wd = reg_wdata[31:0];
 
-  assign direct_access_wdata_1_we = addr_hit[9] & reg_we & ~wr_err;
+  assign direct_access_wdata_1_we = addr_hit[10] & reg_we & ~wr_err;
   assign direct_access_wdata_1_wd = reg_wdata[31:0];
 
-  assign direct_access_rdata_0_re = addr_hit[10] && reg_re;
+  assign direct_access_rdata_0_re = addr_hit[11] && reg_re;
 
-  assign direct_access_rdata_1_re = addr_hit[11] && reg_re;
+  assign direct_access_rdata_1_re = addr_hit[12] && reg_re;
 
-  assign check_trigger_regwen_we = addr_hit[12] & reg_we & ~wr_err;
+  assign check_trigger_regwen_we = addr_hit[13] & reg_we & ~wr_err;
   assign check_trigger_regwen_wd = reg_wdata[0];
 
-  assign check_trigger_integrity_we = addr_hit[13] & reg_we & ~wr_err;
+  assign check_trigger_integrity_we = addr_hit[14] & reg_we & ~wr_err;
   assign check_trigger_integrity_wd = reg_wdata[0];
 
-  assign check_trigger_consistency_we = addr_hit[13] & reg_we & ~wr_err;
+  assign check_trigger_consistency_we = addr_hit[14] & reg_we & ~wr_err;
   assign check_trigger_consistency_wd = reg_wdata[1];
 
-  assign check_regwen_we = addr_hit[14] & reg_we & ~wr_err;
+  assign check_regwen_we = addr_hit[15] & reg_we & ~wr_err;
   assign check_regwen_wd = reg_wdata[0];
 
-  assign check_timeout_we = addr_hit[15] & reg_we & ~wr_err;
+  assign check_timeout_we = addr_hit[16] & reg_we & ~wr_err;
   assign check_timeout_wd = reg_wdata[31:0];
 
-  assign integrity_check_period_we = addr_hit[16] & reg_we & ~wr_err;
+  assign integrity_check_period_we = addr_hit[17] & reg_we & ~wr_err;
   assign integrity_check_period_wd = reg_wdata[31:0];
 
-  assign consistency_check_period_we = addr_hit[17] & reg_we & ~wr_err;
+  assign consistency_check_period_we = addr_hit[18] & reg_we & ~wr_err;
   assign consistency_check_period_wd = reg_wdata[31:0];
 
-  assign creator_sw_cfg_read_lock_we = addr_hit[18] & reg_we & ~wr_err;
+  assign creator_sw_cfg_read_lock_we = addr_hit[19] & reg_we & ~wr_err;
   assign creator_sw_cfg_read_lock_wd = reg_wdata[0];
 
-  assign owner_sw_cfg_read_lock_we = addr_hit[19] & reg_we & ~wr_err;
+  assign owner_sw_cfg_read_lock_we = addr_hit[20] & reg_we & ~wr_err;
   assign owner_sw_cfg_read_lock_wd = reg_wdata[0];
 
-  assign creator_sw_cfg_digest_0_re = addr_hit[20] && reg_re;
+  assign creator_sw_cfg_digest_0_re = addr_hit[21] && reg_re;
 
-  assign creator_sw_cfg_digest_1_re = addr_hit[21] && reg_re;
+  assign creator_sw_cfg_digest_1_re = addr_hit[22] && reg_re;
 
-  assign owner_sw_cfg_digest_0_re = addr_hit[22] && reg_re;
+  assign owner_sw_cfg_digest_0_re = addr_hit[23] && reg_re;
 
-  assign owner_sw_cfg_digest_1_re = addr_hit[23] && reg_re;
+  assign owner_sw_cfg_digest_1_re = addr_hit[24] && reg_re;
 
-  assign hw_cfg_digest_0_re = addr_hit[24] && reg_re;
+  assign hw_cfg_digest_0_re = addr_hit[25] && reg_re;
 
-  assign hw_cfg_digest_1_re = addr_hit[25] && reg_re;
+  assign hw_cfg_digest_1_re = addr_hit[26] && reg_re;
 
-  assign secret0_digest_0_re = addr_hit[26] && reg_re;
+  assign secret0_digest_0_re = addr_hit[27] && reg_re;
 
-  assign secret0_digest_1_re = addr_hit[27] && reg_re;
+  assign secret0_digest_1_re = addr_hit[28] && reg_re;
 
-  assign secret1_digest_0_re = addr_hit[28] && reg_re;
+  assign secret1_digest_0_re = addr_hit[29] && reg_re;
 
-  assign secret1_digest_1_re = addr_hit[29] && reg_re;
+  assign secret1_digest_1_re = addr_hit[30] && reg_re;
 
-  assign secret2_digest_0_re = addr_hit[30] && reg_re;
+  assign secret2_digest_0_re = addr_hit[31] && reg_re;
 
-  assign secret2_digest_1_re = addr_hit[31] && reg_re;
+  assign secret2_digest_1_re = addr_hit[32] && reg_re;
 
   // Read data return
   always_comb begin
@@ -1613,6 +1657,11 @@ module otp_ctrl_reg_top (
       end
 
       addr_hit[3]: begin
+        reg_rdata_next[0] = '0;
+        reg_rdata_next[1] = '0;
+      end
+
+      addr_hit[4]: begin
         reg_rdata_next[0] = status_creator_sw_cfg_error_qs;
         reg_rdata_next[1] = status_owner_sw_cfg_error_qs;
         reg_rdata_next[2] = status_hw_cfg_error_qs;
@@ -1630,7 +1679,7 @@ module otp_ctrl_reg_top (
         reg_rdata_next[14] = status_check_pending_qs;
       end
 
-      addr_hit[4]: begin
+      addr_hit[5]: begin
         reg_rdata_next[2:0] = err_code_err_code_0_qs;
         reg_rdata_next[5:3] = err_code_err_code_1_qs;
         reg_rdata_next[8:6] = err_code_err_code_2_qs;
@@ -1642,114 +1691,114 @@ module otp_ctrl_reg_top (
         reg_rdata_next[26:24] = err_code_err_code_8_qs;
       end
 
-      addr_hit[5]: begin
+      addr_hit[6]: begin
         reg_rdata_next[0] = direct_access_regwen_qs;
       end
 
-      addr_hit[6]: begin
+      addr_hit[7]: begin
         reg_rdata_next[0] = '0;
         reg_rdata_next[1] = '0;
         reg_rdata_next[2] = '0;
       end
 
-      addr_hit[7]: begin
+      addr_hit[8]: begin
         reg_rdata_next[10:0] = direct_access_address_qs;
       end
 
-      addr_hit[8]: begin
+      addr_hit[9]: begin
         reg_rdata_next[31:0] = direct_access_wdata_0_qs;
       end
 
-      addr_hit[9]: begin
+      addr_hit[10]: begin
         reg_rdata_next[31:0] = direct_access_wdata_1_qs;
       end
 
-      addr_hit[10]: begin
+      addr_hit[11]: begin
         reg_rdata_next[31:0] = direct_access_rdata_0_qs;
       end
 
-      addr_hit[11]: begin
+      addr_hit[12]: begin
         reg_rdata_next[31:0] = direct_access_rdata_1_qs;
       end
 
-      addr_hit[12]: begin
+      addr_hit[13]: begin
         reg_rdata_next[0] = check_trigger_regwen_qs;
       end
 
-      addr_hit[13]: begin
+      addr_hit[14]: begin
         reg_rdata_next[0] = '0;
         reg_rdata_next[1] = '0;
       end
 
-      addr_hit[14]: begin
+      addr_hit[15]: begin
         reg_rdata_next[0] = check_regwen_qs;
       end
 
-      addr_hit[15]: begin
+      addr_hit[16]: begin
         reg_rdata_next[31:0] = check_timeout_qs;
       end
 
-      addr_hit[16]: begin
+      addr_hit[17]: begin
         reg_rdata_next[31:0] = integrity_check_period_qs;
       end
 
-      addr_hit[17]: begin
+      addr_hit[18]: begin
         reg_rdata_next[31:0] = consistency_check_period_qs;
       end
 
-      addr_hit[18]: begin
+      addr_hit[19]: begin
         reg_rdata_next[0] = creator_sw_cfg_read_lock_qs;
       end
 
-      addr_hit[19]: begin
+      addr_hit[20]: begin
         reg_rdata_next[0] = owner_sw_cfg_read_lock_qs;
       end
 
-      addr_hit[20]: begin
+      addr_hit[21]: begin
         reg_rdata_next[31:0] = creator_sw_cfg_digest_0_qs;
       end
 
-      addr_hit[21]: begin
+      addr_hit[22]: begin
         reg_rdata_next[31:0] = creator_sw_cfg_digest_1_qs;
       end
 
-      addr_hit[22]: begin
+      addr_hit[23]: begin
         reg_rdata_next[31:0] = owner_sw_cfg_digest_0_qs;
       end
 
-      addr_hit[23]: begin
+      addr_hit[24]: begin
         reg_rdata_next[31:0] = owner_sw_cfg_digest_1_qs;
       end
 
-      addr_hit[24]: begin
+      addr_hit[25]: begin
         reg_rdata_next[31:0] = hw_cfg_digest_0_qs;
       end
 
-      addr_hit[25]: begin
+      addr_hit[26]: begin
         reg_rdata_next[31:0] = hw_cfg_digest_1_qs;
       end
 
-      addr_hit[26]: begin
+      addr_hit[27]: begin
         reg_rdata_next[31:0] = secret0_digest_0_qs;
       end
 
-      addr_hit[27]: begin
+      addr_hit[28]: begin
         reg_rdata_next[31:0] = secret0_digest_1_qs;
       end
 
-      addr_hit[28]: begin
+      addr_hit[29]: begin
         reg_rdata_next[31:0] = secret1_digest_0_qs;
       end
 
-      addr_hit[29]: begin
+      addr_hit[30]: begin
         reg_rdata_next[31:0] = secret1_digest_1_qs;
       end
 
-      addr_hit[30]: begin
+      addr_hit[31]: begin
         reg_rdata_next[31:0] = secret2_digest_0_qs;
       end
 
-      addr_hit[31]: begin
+      addr_hit[32]: begin
         reg_rdata_next[31:0] = secret2_digest_1_qs;
       end
 

--- a/hw/ip/pwrmgr/rtl/pwrmgr.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr.sv
@@ -81,6 +81,7 @@ module pwrmgr import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;
   logic low_power_abort;
 
   pwr_flash_rsp_t flash_rsp;
+  pwr_otp_rsp_t otp_rsp;
 
   ////////////////////////////
   ///  clk_slow_i domain declarations
@@ -195,7 +196,12 @@ module pwrmgr import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;
 
     // flash handshake
     .flash_i(pwr_flash_i),
-    .flash_o(flash_rsp)
+    .flash_o(flash_rsp),
+
+    // OTP signals
+    .otp_i(pwr_otp_i),
+    .otp_o(otp_rsp)
+
   );
 
   assign hw2reg.cfg_cdc_sync.d = 1'b0;
@@ -306,8 +312,8 @@ module pwrmgr import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;
 
     // otp
     .otp_init_o        (pwr_otp_o.otp_init),
-    .otp_done_i        (pwr_otp_i.otp_done),
-    .otp_idle_i        (pwr_otp_i.otp_idle),
+    .otp_done_i        (otp_rsp.otp_done),
+    .otp_idle_i        (otp_rsp.otp_idle),
 
     // lc
     .lc_init_o         (pwr_lc_o.lc_init),

--- a/hw/ip/pwrmgr/rtl/pwrmgr_cdc.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_cdc.sv
@@ -55,6 +55,10 @@ module pwrmgr_cdc import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;
   input pwr_flash_rsp_t flash_i,
   output pwr_flash_rsp_t flash_o,
 
+  // otp interface
+  input  pwr_otp_rsp_t otp_i,
+  output pwr_otp_rsp_t otp_o,
+
   // AST inputs, unknown domain
   input pwr_ast_rsp_t ast_i
 
@@ -244,6 +248,7 @@ module pwrmgr_cdc import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;
 
   prim_flop_2sync #(
     .Width(1),
+    // TODO: Is a value of 1 correct here?
     .ResetValue(1'b1)
   ) u_sync_flash_idle (
     .clk_i,
@@ -252,6 +257,15 @@ module pwrmgr_cdc import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;
     .q_o(flash_o.flash_idle)
   );
 
+  prim_flop_2sync #(
+    .Width($bits(pwr_otp_rsp_t)),
+    .ResetValue('0)
+  ) u_sync_otp (
+    .clk_i,
+    .rst_ni,
+    .d_i(otp_i),
+    .q_o(otp_o)
+  );
 
 endmodule
 

--- a/hw/ip/pwrmgr/rtl/pwrmgr_fsm.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_fsm.sv
@@ -330,18 +330,37 @@ module pwrmgr_fsm import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;(
   assign pwr_rst_o.reset_cause = reset_cause_q;
   assign pwr_rst_o.rstreqs = reset_reqs_i;
 
-  assign otp_init_o = otp_init;
-  assign lc_init_o = lc_init;
   assign ips_clk_en_o = ip_clk_en_q;
 
   prim_flop #(
     .Width(1),
+    // TODO: Is a value of 1 correct here?
     .ResetValue(1'b1)
-  ) u_reg_idle (
+  ) u_reg_flash_init (
     .clk_i,
     .rst_ni,
     .d_i(flash_init_d),
     .q_o(flash_init_o)
+  );
+
+  prim_flop #(
+    .Width(1),
+    .ResetValue(1'b0)
+  ) u_reg_otp_init (
+    .clk_i,
+    .rst_ni,
+    .d_i(otp_init),
+    .q_o(otp_init_o)
+  );
+
+  prim_flop #(
+    .Width(1),
+    .ResetValue(1'b0)
+  ) u_reg_lc_init (
+    .clk_i,
+    .rst_ni,
+    .d_i(lc_init),
+    .q_o(lc_init_o)
   );
 
 

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -1556,6 +1556,9 @@
           act: req
           package: pwrmgr_pkg
           inst_name: pwrmgr
+          width: 1
+          default: ""
+          top_signame: pwrmgr_pwr_otp
           index: -1
         }
         {
@@ -2597,7 +2600,7 @@
       clock_group: timers
       reset_connections:
       {
-        rst_ni: sys_io_div4
+        rst_ni: lc_io
       }
       base_addr: 0x401b0000
       clock_reset_export: []
@@ -2704,6 +2707,8 @@
           default: "'0"
           package: pwrmgr_pkg
           inst_name: otp_ctrl
+          width: 1
+          top_signame: pwrmgr_pwr_otp
           index: -1
         }
         {
@@ -3123,6 +3128,10 @@
       pwrmgr.pwr_clk:
       [
         clkmgr.pwr
+      ]
+      pwrmgr.pwr_otp:
+      [
+        otp_ctrl.pwr_otp
       ]
       flash_ctrl.keymgr:
       [
@@ -5767,6 +5776,9 @@
         act: req
         package: pwrmgr_pkg
         inst_name: pwrmgr
+        width: 1
+        default: ""
+        top_signame: pwrmgr_pwr_otp
         index: -1
       }
       {
@@ -6271,6 +6283,8 @@
         default: "'0"
         package: pwrmgr_pkg
         inst_name: otp_ctrl
+        width: 1
+        top_signame: pwrmgr_pwr_otp
         index: -1
       }
       {
@@ -7081,6 +7095,22 @@
         package: pwrmgr_pkg
         struct: pwr_clk_rsp
         signame: pwrmgr_pwr_clk_rsp
+        width: 1
+        type: req_rsp
+        default: ""
+      }
+      {
+        package: pwrmgr_pkg
+        struct: pwr_otp_req
+        signame: pwrmgr_pwr_otp_req
+        width: 1
+        type: req_rsp
+        default: ""
+      }
+      {
+        package: pwrmgr_pkg
+        struct: pwr_otp_rsp
+        signame: pwrmgr_pwr_otp_rsp
         width: 1
         type: req_rsp
         default: ""

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -998,12 +998,26 @@
         {
           name: ctrl_err_update
           width: 1
+          bits: "0"
+          bitinfo:
+          [
+            1
+            1
+            0
+          ]
           type: alert
           async: 0
         }
         {
           name: ctrl_err_storage
           width: 1
+          bits: "1"
+          bitinfo:
+          [
+            2
+            1
+            1
+          ]
           type: alert
           async: 0
         }
@@ -2393,6 +2407,13 @@
         {
           name: ast_alerts
           width: 7
+          bits: 6:0
+          bitinfo:
+          [
+            127
+            7
+            0
+          ]
           type: alert
           async: 1
         }
@@ -2500,6 +2521,13 @@
         {
           name: err
           width: 1
+          bits: "0"
+          bitinfo:
+          [
+            1
+            1
+            0
+          ]
           type: alert
           async: 0
         }
@@ -2647,12 +2675,26 @@
         {
           name: otp_macro_failure
           width: 1
+          bits: "0"
+          bitinfo:
+          [
+            1
+            1
+            0
+          ]
           type: alert
           async: 1
         }
         {
           name: otp_check_failure
           width: 1
+          bits: "1"
+          bitinfo:
+          [
+            2
+            1
+            1
+          ]
           type: alert
           async: 1
         }
@@ -2903,18 +2945,39 @@
         {
           name: imem_uncorrectable
           width: 1
+          bits: "0"
+          bitinfo:
+          [
+            1
+            1
+            0
+          ]
           type: alert
           async: 0
         }
         {
           name: dmem_uncorrectable
           width: 1
+          bits: "1"
+          bitinfo:
+          [
+            2
+            1
+            1
+          ]
           type: alert
           async: 0
         }
         {
           name: reg_uncorrectable
           width: 1
+          bits: "2"
+          bitinfo:
+          [
+            4
+            1
+            2
+          ]
           type: alert
           async: 0
         }
@@ -5035,6 +5098,13 @@
     {
       name: aes_ctrl_err_update
       width: 1
+      bits: "0"
+      bitinfo:
+      [
+        1
+        1
+        0
+      ]
       type: alert
       async: 0
       module_name: aes
@@ -5042,6 +5112,13 @@
     {
       name: aes_ctrl_err_storage
       width: 1
+      bits: "1"
+      bitinfo:
+      [
+        2
+        1
+        1
+      ]
       type: alert
       async: 0
       module_name: aes
@@ -5049,6 +5126,13 @@
     {
       name: otbn_imem_uncorrectable
       width: 1
+      bits: "0"
+      bitinfo:
+      [
+        1
+        1
+        0
+      ]
       type: alert
       async: 0
       module_name: otbn
@@ -5056,6 +5140,13 @@
     {
       name: otbn_dmem_uncorrectable
       width: 1
+      bits: "1"
+      bitinfo:
+      [
+        2
+        1
+        1
+      ]
       type: alert
       async: 0
       module_name: otbn
@@ -5063,6 +5154,13 @@
     {
       name: otbn_reg_uncorrectable
       width: 1
+      bits: "2"
+      bitinfo:
+      [
+        4
+        1
+        2
+      ]
       type: alert
       async: 0
       module_name: otbn
@@ -5070,6 +5168,13 @@
     {
       name: sensor_ctrl_ast_alerts
       width: 7
+      bits: 6:0
+      bitinfo:
+      [
+        127
+        7
+        0
+      ]
       type: alert
       async: 1
       module_name: sensor_ctrl
@@ -5077,6 +5182,13 @@
     {
       name: keymgr_err
       width: 1
+      bits: "0"
+      bitinfo:
+      [
+        1
+        1
+        0
+      ]
       type: alert
       async: 0
       module_name: keymgr
@@ -5084,6 +5196,13 @@
     {
       name: otp_ctrl_otp_macro_failure
       width: 1
+      bits: "0"
+      bitinfo:
+      [
+        1
+        1
+        0
+      ]
       type: alert
       async: 1
       module_name: otp_ctrl
@@ -5091,6 +5210,13 @@
     {
       name: otp_ctrl_otp_check_failure
       width: 1
+      bits: "1"
+      bitinfo:
+      [
+        2
+        1
+        1
+      ]
       type: alert
       async: 1
       module_name: otp_ctrl

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -317,7 +317,7 @@
       type: "otp_ctrl",
       clock_srcs: {clk_i: "io_div4"},
       clock_group: "timers",
-      reset_connections: {rst_ni: "sys_io_div4"},
+      reset_connections: {rst_ni: "lc_io"},
       base_addr: "0x401b0000",
     },
     { name: "otbn",
@@ -417,7 +417,7 @@
       'pwrmgr.pwr_flash' : ['flash_ctrl.pwrmgr'],
       'pwrmgr.pwr_rst'   : ['rstmgr.pwr'],
       'pwrmgr.pwr_clk'   : ['clkmgr.pwr'],
-      // TODO: connect this once OTP has passed initial sanity tests: 'pwrmgr.pwr_otp'   : ['otp_ctrl.pwr_otp'],
+      'pwrmgr.pwr_otp'   : ['otp_ctrl.pwr_otp'],
       'flash_ctrl.keymgr': ['keymgr.flash'],
       'alert_handler.crashdump': ['rstmgr.alert_dump'],
       // The idle connection is automatically connected through topgen.

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -51,6 +51,7 @@ class chip_base_vseq extends cip_base_vseq #(
     cfg.mem_bkdr_vifs[FlashBank0Info].set_mem();
     cfg.mem_bkdr_vifs[FlashBank1Info].set_mem();
     // Bring the chip out of reset.
+    cfg.mem_bkdr_vifs[Otp].clear_mem();
     super.dut_init(reset_kind);
   endtask
 

--- a/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_pkg.sv
@@ -14,6 +14,11 @@ package sensor_ctrl_reg_pkg;
   // Typedefs for registers //
   ////////////////////////////
   typedef struct packed {
+    logic [6:0]  q;
+    logic        qe;
+  } sensor_ctrl_reg2hw_alert_test_reg_t;
+
+  typedef struct packed {
     logic        q;
   } sensor_ctrl_reg2hw_ack_mode_mreg_t;
 
@@ -42,6 +47,7 @@ package sensor_ctrl_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
+    sensor_ctrl_reg2hw_alert_test_reg_t alert_test; // [35:28]
     sensor_ctrl_reg2hw_ack_mode_mreg_t [6:0] ack_mode; // [27:21]
     sensor_ctrl_reg2hw_alert_trig_mreg_t [6:0] alert_trig; // [20:14]
     sensor_ctrl_reg2hw_alert_state_mreg_t [6:0] alert_state; // [13:0]
@@ -56,15 +62,17 @@ package sensor_ctrl_reg_pkg;
   } sensor_ctrl_hw2reg_t;
 
   // Register Address
-  parameter logic [4:0] SENSOR_CTRL_CFG_REGWEN_OFFSET = 5'h 0;
-  parameter logic [4:0] SENSOR_CTRL_ACK_MODE_OFFSET = 5'h 4;
-  parameter logic [4:0] SENSOR_CTRL_ALERT_TRIG_OFFSET = 5'h 8;
-  parameter logic [4:0] SENSOR_CTRL_ALERT_STATE_OFFSET = 5'h c;
-  parameter logic [4:0] SENSOR_CTRL_STATUS_OFFSET = 5'h 10;
+  parameter logic [4:0] SENSOR_CTRL_ALERT_TEST_OFFSET = 5'h 0;
+  parameter logic [4:0] SENSOR_CTRL_CFG_REGWEN_OFFSET = 5'h 4;
+  parameter logic [4:0] SENSOR_CTRL_ACK_MODE_OFFSET = 5'h 8;
+  parameter logic [4:0] SENSOR_CTRL_ALERT_TRIG_OFFSET = 5'h c;
+  parameter logic [4:0] SENSOR_CTRL_ALERT_STATE_OFFSET = 5'h 10;
+  parameter logic [4:0] SENSOR_CTRL_STATUS_OFFSET = 5'h 14;
 
 
   // Register Index
   typedef enum int {
+    SENSOR_CTRL_ALERT_TEST,
     SENSOR_CTRL_CFG_REGWEN,
     SENSOR_CTRL_ACK_MODE,
     SENSOR_CTRL_ALERT_TRIG,
@@ -73,12 +81,13 @@ package sensor_ctrl_reg_pkg;
   } sensor_ctrl_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] SENSOR_CTRL_PERMIT [5] = '{
-    4'b 0001, // index[0] SENSOR_CTRL_CFG_REGWEN
-    4'b 0001, // index[1] SENSOR_CTRL_ACK_MODE
-    4'b 0001, // index[2] SENSOR_CTRL_ALERT_TRIG
-    4'b 0001, // index[3] SENSOR_CTRL_ALERT_STATE
-    4'b 0001  // index[4] SENSOR_CTRL_STATUS
+  parameter logic [3:0] SENSOR_CTRL_PERMIT [6] = '{
+    4'b 0001, // index[0] SENSOR_CTRL_ALERT_TEST
+    4'b 0001, // index[1] SENSOR_CTRL_CFG_REGWEN
+    4'b 0001, // index[2] SENSOR_CTRL_ACK_MODE
+    4'b 0001, // index[3] SENSOR_CTRL_ALERT_TRIG
+    4'b 0001, // index[4] SENSOR_CTRL_ALERT_STATE
+    4'b 0001  // index[5] SENSOR_CTRL_STATUS
   };
 endpackage
 

--- a/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_top.sv
+++ b/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_top.sv
@@ -71,6 +71,8 @@ module sensor_ctrl_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
+  logic [6:0] alert_test_wd;
+  logic alert_test_we;
   logic cfg_regwen_qs;
   logic cfg_regwen_wd;
   logic cfg_regwen_we;
@@ -140,6 +142,22 @@ module sensor_ctrl_reg_top (
   logic [1:0] status_qs;
 
   // Register instances
+  // R[alert_test]: V(True)
+
+  prim_subreg_ext #(
+    .DW    (7)
+  ) u_alert_test (
+    .re     (1'b0),
+    .we     (alert_test_we),
+    .wd     (alert_test_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (reg2hw.alert_test.qe),
+    .q      (reg2hw.alert_test.q ),
+    .qs     ()
+  );
+
+
   // R[cfg_regwen]: V(False)
 
   prim_subreg #(
@@ -756,14 +774,15 @@ module sensor_ctrl_reg_top (
 
 
 
-  logic [4:0] addr_hit;
+  logic [5:0] addr_hit;
   always_comb begin
     addr_hit = '0;
-    addr_hit[0] = (reg_addr == SENSOR_CTRL_CFG_REGWEN_OFFSET);
-    addr_hit[1] = (reg_addr == SENSOR_CTRL_ACK_MODE_OFFSET);
-    addr_hit[2] = (reg_addr == SENSOR_CTRL_ALERT_TRIG_OFFSET);
-    addr_hit[3] = (reg_addr == SENSOR_CTRL_ALERT_STATE_OFFSET);
-    addr_hit[4] = (reg_addr == SENSOR_CTRL_STATUS_OFFSET);
+    addr_hit[0] = (reg_addr == SENSOR_CTRL_ALERT_TEST_OFFSET);
+    addr_hit[1] = (reg_addr == SENSOR_CTRL_CFG_REGWEN_OFFSET);
+    addr_hit[2] = (reg_addr == SENSOR_CTRL_ACK_MODE_OFFSET);
+    addr_hit[3] = (reg_addr == SENSOR_CTRL_ALERT_TRIG_OFFSET);
+    addr_hit[4] = (reg_addr == SENSOR_CTRL_ALERT_STATE_OFFSET);
+    addr_hit[5] = (reg_addr == SENSOR_CTRL_STATUS_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -776,72 +795,76 @@ module sensor_ctrl_reg_top (
     if (addr_hit[2] && reg_we && (SENSOR_CTRL_PERMIT[2] != (SENSOR_CTRL_PERMIT[2] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[3] && reg_we && (SENSOR_CTRL_PERMIT[3] != (SENSOR_CTRL_PERMIT[3] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[4] && reg_we && (SENSOR_CTRL_PERMIT[4] != (SENSOR_CTRL_PERMIT[4] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[5] && reg_we && (SENSOR_CTRL_PERMIT[5] != (SENSOR_CTRL_PERMIT[5] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign cfg_regwen_we = addr_hit[0] & reg_we & ~wr_err;
+  assign alert_test_we = addr_hit[0] & reg_we & ~wr_err;
+  assign alert_test_wd = reg_wdata[6:0];
+
+  assign cfg_regwen_we = addr_hit[1] & reg_we & ~wr_err;
   assign cfg_regwen_wd = reg_wdata[0];
 
-  assign ack_mode_val_0_we = addr_hit[1] & reg_we & ~wr_err;
+  assign ack_mode_val_0_we = addr_hit[2] & reg_we & ~wr_err;
   assign ack_mode_val_0_wd = reg_wdata[0];
 
-  assign ack_mode_val_1_we = addr_hit[1] & reg_we & ~wr_err;
+  assign ack_mode_val_1_we = addr_hit[2] & reg_we & ~wr_err;
   assign ack_mode_val_1_wd = reg_wdata[1];
 
-  assign ack_mode_val_2_we = addr_hit[1] & reg_we & ~wr_err;
+  assign ack_mode_val_2_we = addr_hit[2] & reg_we & ~wr_err;
   assign ack_mode_val_2_wd = reg_wdata[2];
 
-  assign ack_mode_val_3_we = addr_hit[1] & reg_we & ~wr_err;
+  assign ack_mode_val_3_we = addr_hit[2] & reg_we & ~wr_err;
   assign ack_mode_val_3_wd = reg_wdata[3];
 
-  assign ack_mode_val_4_we = addr_hit[1] & reg_we & ~wr_err;
+  assign ack_mode_val_4_we = addr_hit[2] & reg_we & ~wr_err;
   assign ack_mode_val_4_wd = reg_wdata[4];
 
-  assign ack_mode_val_5_we = addr_hit[1] & reg_we & ~wr_err;
+  assign ack_mode_val_5_we = addr_hit[2] & reg_we & ~wr_err;
   assign ack_mode_val_5_wd = reg_wdata[5];
 
-  assign ack_mode_val_6_we = addr_hit[1] & reg_we & ~wr_err;
+  assign ack_mode_val_6_we = addr_hit[2] & reg_we & ~wr_err;
   assign ack_mode_val_6_wd = reg_wdata[6];
 
-  assign alert_trig_val_0_we = addr_hit[2] & reg_we & ~wr_err;
+  assign alert_trig_val_0_we = addr_hit[3] & reg_we & ~wr_err;
   assign alert_trig_val_0_wd = reg_wdata[0];
 
-  assign alert_trig_val_1_we = addr_hit[2] & reg_we & ~wr_err;
+  assign alert_trig_val_1_we = addr_hit[3] & reg_we & ~wr_err;
   assign alert_trig_val_1_wd = reg_wdata[1];
 
-  assign alert_trig_val_2_we = addr_hit[2] & reg_we & ~wr_err;
+  assign alert_trig_val_2_we = addr_hit[3] & reg_we & ~wr_err;
   assign alert_trig_val_2_wd = reg_wdata[2];
 
-  assign alert_trig_val_3_we = addr_hit[2] & reg_we & ~wr_err;
+  assign alert_trig_val_3_we = addr_hit[3] & reg_we & ~wr_err;
   assign alert_trig_val_3_wd = reg_wdata[3];
 
-  assign alert_trig_val_4_we = addr_hit[2] & reg_we & ~wr_err;
+  assign alert_trig_val_4_we = addr_hit[3] & reg_we & ~wr_err;
   assign alert_trig_val_4_wd = reg_wdata[4];
 
-  assign alert_trig_val_5_we = addr_hit[2] & reg_we & ~wr_err;
+  assign alert_trig_val_5_we = addr_hit[3] & reg_we & ~wr_err;
   assign alert_trig_val_5_wd = reg_wdata[5];
 
-  assign alert_trig_val_6_we = addr_hit[2] & reg_we & ~wr_err;
+  assign alert_trig_val_6_we = addr_hit[3] & reg_we & ~wr_err;
   assign alert_trig_val_6_wd = reg_wdata[6];
 
-  assign alert_state_val_0_we = addr_hit[3] & reg_we & ~wr_err;
+  assign alert_state_val_0_we = addr_hit[4] & reg_we & ~wr_err;
   assign alert_state_val_0_wd = reg_wdata[0];
 
-  assign alert_state_val_1_we = addr_hit[3] & reg_we & ~wr_err;
+  assign alert_state_val_1_we = addr_hit[4] & reg_we & ~wr_err;
   assign alert_state_val_1_wd = reg_wdata[1];
 
-  assign alert_state_val_2_we = addr_hit[3] & reg_we & ~wr_err;
+  assign alert_state_val_2_we = addr_hit[4] & reg_we & ~wr_err;
   assign alert_state_val_2_wd = reg_wdata[2];
 
-  assign alert_state_val_3_we = addr_hit[3] & reg_we & ~wr_err;
+  assign alert_state_val_3_we = addr_hit[4] & reg_we & ~wr_err;
   assign alert_state_val_3_wd = reg_wdata[3];
 
-  assign alert_state_val_4_we = addr_hit[3] & reg_we & ~wr_err;
+  assign alert_state_val_4_we = addr_hit[4] & reg_we & ~wr_err;
   assign alert_state_val_4_wd = reg_wdata[4];
 
-  assign alert_state_val_5_we = addr_hit[3] & reg_we & ~wr_err;
+  assign alert_state_val_5_we = addr_hit[4] & reg_we & ~wr_err;
   assign alert_state_val_5_wd = reg_wdata[5];
 
-  assign alert_state_val_6_we = addr_hit[3] & reg_we & ~wr_err;
+  assign alert_state_val_6_we = addr_hit[4] & reg_we & ~wr_err;
   assign alert_state_val_6_wd = reg_wdata[6];
 
 
@@ -850,10 +873,14 @@ module sensor_ctrl_reg_top (
     reg_rdata_next = '0;
     unique case (1'b1)
       addr_hit[0]: begin
-        reg_rdata_next[0] = cfg_regwen_qs;
+        reg_rdata_next[6:0] = '0;
       end
 
       addr_hit[1]: begin
+        reg_rdata_next[0] = cfg_regwen_qs;
+      end
+
+      addr_hit[2]: begin
         reg_rdata_next[0] = ack_mode_val_0_qs;
         reg_rdata_next[1] = ack_mode_val_1_qs;
         reg_rdata_next[2] = ack_mode_val_2_qs;
@@ -863,7 +890,7 @@ module sensor_ctrl_reg_top (
         reg_rdata_next[6] = ack_mode_val_6_qs;
       end
 
-      addr_hit[2]: begin
+      addr_hit[3]: begin
         reg_rdata_next[0] = alert_trig_val_0_qs;
         reg_rdata_next[1] = alert_trig_val_1_qs;
         reg_rdata_next[2] = alert_trig_val_2_qs;
@@ -873,7 +900,7 @@ module sensor_ctrl_reg_top (
         reg_rdata_next[6] = alert_trig_val_6_qs;
       end
 
-      addr_hit[3]: begin
+      addr_hit[4]: begin
         reg_rdata_next[0] = alert_state_val_0_qs;
         reg_rdata_next[1] = alert_state_val_1_qs;
         reg_rdata_next[2] = alert_state_val_2_qs;
@@ -883,7 +910,7 @@ module sensor_ctrl_reg_top (
         reg_rdata_next[6] = alert_state_val_6_qs;
       end
 
-      addr_hit[4]: begin
+      addr_hit[5]: begin
         reg_rdata_next[1:0] = status_qs;
       end
 

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -225,6 +225,8 @@ module top_earlgrey #(
   pwrmgr_pkg::pwr_rst_rsp_t       pwrmgr_pwr_rst_rsp;
   pwrmgr_pkg::pwr_clk_req_t       pwrmgr_pwr_clk_req;
   pwrmgr_pkg::pwr_clk_rsp_t       pwrmgr_pwr_clk_rsp;
+  pwrmgr_pkg::pwr_otp_req_t       pwrmgr_pwr_otp_req;
+  pwrmgr_pkg::pwr_otp_rsp_t       pwrmgr_pwr_otp_rsp;
   flash_ctrl_pkg::keymgr_flash_t       flash_ctrl_keymgr;
   alert_pkg::alert_crashdump_t       alert_handler_crashdump;
   logic [2:0] clkmgr_idle;
@@ -822,8 +824,8 @@ module top_earlgrey #(
       .pwr_rst_i(pwrmgr_pwr_rst_rsp),
       .pwr_clk_o(pwrmgr_pwr_clk_req),
       .pwr_clk_i(pwrmgr_pwr_clk_rsp),
-      .pwr_otp_o(),
-      .pwr_otp_i(pwrmgr_pkg::PWR_OTP_RSP_DEFAULT),
+      .pwr_otp_o(pwrmgr_pwr_otp_req),
+      .pwr_otp_i(pwrmgr_pwr_otp_rsp),
       .pwr_lc_o(),
       .pwr_lc_i(pwrmgr_pkg::PWR_LC_RSP_DEFAULT),
       .pwr_flash_o(pwrmgr_pwr_flash_req),
@@ -1023,8 +1025,8 @@ module top_earlgrey #(
       .otp_ast_pwr_seq_h_i(otp_ctrl_otp_ast_pwr_seq_h_i),
       .otp_edn_o(),
       .otp_edn_i('0),
-      .pwr_otp_i('0),
-      .pwr_otp_o(),
+      .pwr_otp_i(pwrmgr_pwr_otp_req),
+      .pwr_otp_o(pwrmgr_pwr_otp_rsp),
       .lc_otp_program_i('0),
       .lc_otp_program_o(),
       .lc_otp_token_i('0),
@@ -1044,7 +1046,7 @@ module top_earlgrey #(
       .tl_i(otp_ctrl_tl_req),
       .tl_o(otp_ctrl_tl_rsp),
       .clk_i (clkmgr_clocks.clk_io_div4_timers),
-      .rst_ni (rstmgr_resets.rst_sys_io_div4_n)
+      .rst_ni (rstmgr_resets.rst_lc_io_n)
   );
 
   otbn #(


### PR DESCRIPTION
This reuses the automatic interrupt register generation mechanism in `reggen` to generate alert test registers that allow the SW to test specific alerts in the system in the same way as it would test interrupts.

I regenerated the CSRs, and wired these alert test signals up in all affected modules (`aes`, `keymgr`, `otbn` and `otp_ctrl` so far).

Note that the alert test registers cannot be locked down at the moment. I am not entirely sure whether that will be needed, though... WDYT?

