### PR TITLE
[otp] fix FPV compile error

### DIFF
--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_dai.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_dai.sv
@@ -132,7 +132,8 @@ module otp_ctrl_dai
     DaiOffset = 1'b1
   } addr_sel_e;
 
-  state_e state_d, state_q;
+  state_e state_d;
+  logic [StateWidth-1:0] state_q;
   logic [CntWidth-1:0] cnt_d, cnt_q;
   logic cnt_en, cnt_clr;
   otp_err_e error_d, error_q;
@@ -151,7 +152,7 @@ module otp_ctrl_dai
   assign scrmbl_data_o = data_q;
 
   always_comb begin : p_fsm
-    state_d = state_q;
+    state_d = state_e'(state_q);
 
     // Init signals
     init_done_o = 1'b1;

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_kdi.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_kdi.sv
@@ -279,10 +279,11 @@ module otp_ctrl_kdi
     ErrorSt      = 10'b1111011100
   } state_e;
 
-  state_e state_d, state_q;
+  state_e state_d;
+  logic [StateWidth-1:0] state_q;
 
   always_comb begin : p_fsm
-    state_d = state_q;
+    state_d = state_e'(state_q);
 
     // FSM Error output
     fsm_err_o = 1'b0;

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_lci.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_lci.sv
@@ -92,13 +92,14 @@ module otp_ctrl_lci
   logic [CntWidth-1:0] cnt_d, cnt_q;
   otp_err_e error_d, error_q;
   logic delta_data_is_set;
-  state_e state_d, state_q;
+  state_e state_d;
+  logic [StateWidth-1:0] state_q;
 
   // Output LCI errors
   assign error_o = error_q;
 
   always_comb begin : p_fsm
-    state_d = state_q;
+    state_d = state_e'(state_q);
 
     // Counter
     cnt_en   = 1'b0;

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_lfsr_timer.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_lfsr_timer.sv
@@ -181,13 +181,14 @@ module otp_ctrl_lfsr_timer
     ErrorSt     = 9'b100101111
   } state_e;
 
-  state_e state_d, state_q;
+  state_e state_d;
+  bit [StateWidth-1:0] state_q;
   logic chk_timeout_d, chk_timeout_q;
 
   assign chk_timeout_o = chk_timeout_q;
 
   always_comb begin : p_fsm
-    state_d = state_q;
+    state_d = state_e'(state_q);
 
     // LFSR and counter signals
     lfsr_en = 1'b0;

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_buf.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_buf.sv
@@ -133,11 +133,12 @@ module otp_ctrl_part_buf
     DigOffset
   } base_sel_e;
 
-  state_e state_d, state_q;
+  state_e state_d;
   otp_err_e error_d, error_q;
   data_sel_e data_sel;
   base_sel_e base_sel;
   access_e dout_gate_d, dout_gate_q;
+  logic [StateWidth-1:0] state_q;
   logic [CntWidth-1:0] cnt_d, cnt_q;
   logic cnt_en, cnt_clr;
   logic parity_err;
@@ -153,7 +154,7 @@ module otp_ctrl_part_buf
   assign otp_cmd_o   = OtpRead;
 
   always_comb begin : p_fsm
-    state_d = state_q;
+    state_d = state_e'(state_q);
 
     // Redundantly encoded lock signal for buffer regs.
     dout_gate_d = dout_gate_q;

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
@@ -102,7 +102,7 @@ module otp_ctrl_part_unbuf
     DataAddr = 1'b1
   } addr_sel_e;
 
-  state_e state_d, state_q;
+  state_e state_d;
   addr_sel_e otp_addr_sel;
   otp_err_e error_d, error_q;
 
@@ -110,6 +110,7 @@ module otp_ctrl_part_unbuf
   logic parity_err;
 
   logic [SwWindowAddrWidth-1:0] tlul_addr_d, tlul_addr_q;
+  logic [StateWidth-1:0] state_q;
 
   // Output partition error state.
   assign error_o = error_q;
@@ -122,7 +123,7 @@ module otp_ctrl_part_unbuf
   `ASSERT_KNOWN(FsmStateKnown_A, state_q)
   always_comb begin : p_fsm
     // Default assignments
-    state_d = state_q;
+    state_d = state_e'(state_q);
 
     // Response to init request
     init_done_o = 1'b0;

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_scrmbl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_scrmbl.sv
@@ -205,7 +205,8 @@ module otp_ctrl_scrmbl import otp_ctrl_pkg::*; (
   } state_e;
 
   localparam int CntWidth = $clog2(NumPresentRounds+1);
-  state_e state_d, state_q;
+  state_e state_d;
+  logic [StateWidth-1:0] state_q;
   logic [CntWidth-1:0] cnt_d, cnt_q;
   logic cnt_clr, cnt_en;
   logic valid_d, valid_q;
@@ -218,7 +219,7 @@ module otp_ctrl_scrmbl import otp_ctrl_pkg::*; (
                              cnt_q;
 
   always_comb begin : p_fsm
-    state_d          = state_q;
+    state_d          = state_e'(state_q);
     is_first_d       = is_first_q;
     sel_d            = sel_q;
     digest_mode_d    = digest_mode_q;

--- a/hw/ip/prim_generic/rtl/prim_generic_otp.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_otp.sv
@@ -39,7 +39,7 @@ module prim_generic_otp #(
   // Response channel
   output logic                   valid_o,
   output logic [IfWidth-1:0]     rdata_o,
-  output logic [ErrWidth-1:0]    err_o
+  output otp_ctrl_pkg::otp_err_e err_o
 );
 
   // Not supported in open-source emulation model.
@@ -132,8 +132,9 @@ module prim_generic_otp #(
   } state_e;
 
   state_e state_d, state_q;
-  logic  valid_d, valid_q;
-  logic [ErrWidth-1:0] err_d, err_q;
+  otp_ctrl_pkg::otp_err_e err_d, err_q;
+  logic [StateWidth-1:0] state_o;
+  logic valid_d, valid_q;
   logic req, wren, rvalid;
   logic [1:0] rerror;
   logic [Width-1:0] rdata_d;
@@ -143,6 +144,7 @@ module prim_generic_otp #(
   logic [SizeWidth-1:0] cnt_d, cnt_q;
   logic cnt_clr, cnt_en;
 
+  assign state_q = state_e'(state_o);
   assign cnt_d = (cnt_clr) ? '0           :
                  (cnt_en)  ? cnt_q + 1'b1 : cnt_q;
 
@@ -310,13 +312,13 @@ module prim_generic_otp #(
     .clk_i,
     .rst_ni,
     .d_i ( state_d ),
-    .q_o ( state_q )
+    .q_o ( state_o )
   );
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs
     if (!rst_ni) begin
       valid_q <= '0;
-      err_q   <= '0;
+      err_q   <= otp_ctrl_pkg::NoError;
       addr_q  <= '0;
       wdata_q <= '0;
       rdata_q <= '0;


### PR DESCRIPTION
This is a compile error for JG formal but warnings for Xcelium and VCS.
The simulators are complaining that assigning an enum to a non-enum
port.

Signed-off-by: Cindy Chen <chencindy@google.com>