### PR TITLE
[fpv] fix pattgen fusesoc formal compile error

### DIFF
--- a/hw/ip/pattgen/pattgen.core
+++ b/hw/ip/pattgen/pattgen.core
@@ -61,7 +61,8 @@ targets:
       - tool_verilator   ? (files_verilator_waiver)
       - tool_ascentlint  ? (files_ascentlint_waiver)
       - tool_veriblelint ? (files_veriblelint_waiver)
-      - target_formal    ? (files_formal)
+#     files_formal yet undefined
+#     - target_formal    ? (files_formal)
       - files_rtl
     toplevel: pattgen
 


### PR DESCRIPTION
This target_formal picks formal_files that is undefined. This causes a
fusesoc error while compile formal.
Comment it out until formal is defined.

Signed-off-by: Cindy Chen <chencindy@google.com>