### PR TITLE
[dvsim] Kill subprocesses more gracefully

### DIFF
--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -385,7 +385,15 @@ class Deploy():
         '''
         if self.status == "D" and self.process.poll() is None:
             self.kill_remote_job()
-            self.process.kill()
+
+            # Try to kill the running process. Send SIGTERM first, wait a bit,
+            # and then send SIGKILL if it didn't work.
+            self.process.terminate()
+            try:
+                self.process.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                self.process.kill()
+
             if self.log_fd:
                 self.log_fd.close()
             self.status = "K"


### PR DESCRIPTION
Before this patch, we just used subprocess.Popen.kill(), which sends a
SIGKILL signal. This doesn't work well if the process has some child
processes, because it doesn't have a chance to clean up. This patch
sends a SIGTERM first, waits up to half a second for the process to
terminate, and then sends a SIGKILL if necessary. Hopefully, this will
leave fewer simv processes lying around.

Fixes #3947 (I think). I'm doing lots of UVM simulations at the moment, some of which hang. So I'll be trying this out locally a bit today - I'll leave a note to say whether it works.