### PR TITLE
[sw, rom_exts] Add slot B linker file, and factor out common bits

### DIFF
--- a/sw/device/rom_exts/meson.build
+++ b/sw/device/rom_exts/meson.build
@@ -6,13 +6,38 @@
 #
 # See sw/device/exts/common/flash_link.ld for additional info about these
 # parameters.
-rom_ext_linkfile = files(['rom_ext_slot_a.ld'])
-rom_ext_link_args = [
-  '-Wl,-L,@0@'.format(meson.source_root()),
-  '-Wl,-T,@0@/@1@'.format(meson.source_root(), rom_ext_linkfile[0]),
-  '-Wl,--build-id=none',
-]
-rom_ext_link_deps = [rom_ext_linkfile]
+
+rom_ext_linkfile_slot_a = files(['rom_ext_slot_a.ld'])
+rom_ext_linkfile_slot_b = files(['rom_ext_slot_b.ld'])
+
+rom_ext_link_info = {
+  'rom_ext_slot_a' :
+  [
+    # Link arguments for slot A.
+    [
+      '-Wl,-L,@0@'.format(meson.source_root()),
+      '-Wl,-T,@0@/@1@'.format(meson.source_root(), rom_ext_linkfile_slot_a[0]),
+      '-Wl,--build-id=none',
+    ],
+    # Link dependency file for slot A.
+    [
+      rom_ext_linkfile_slot_a,
+    ],
+  ],
+  'rom_ext_slot_b' :
+  [
+    # Link arguments for slot B.
+    [
+      '-Wl,-L,@0@'.format(meson.source_root()),
+      '-Wl,-T,@0@/@1@'.format(meson.source_root(), rom_ext_linkfile_slot_b[0]),
+      '-Wl,--build-id=none',
+    ],
+    # Link dependency file for slot B.
+    [
+      rom_ext_linkfile_slot_b,
+    ],
+  ],
+}
 
 # ROM_EXT manifest generator.
 rom_exts_manifest_offsets_header = custom_target(
@@ -45,38 +70,40 @@ rom_ext_manifest_parser = declare_dependency(
 )
 
 foreach device_name, device_lib : sw_lib_arch_core_devices
-  rom_ext_elf = executable(
-    'rom_ext_' + device_name,
-    sources: [
-      'rom_ext_manifest.S',
-      'rom_ext_start.S',
-      'rom_ext.c',
-    ],
-    name_suffix: 'elf',
-    link_args: rom_ext_link_args,
-    link_depends: rom_ext_link_deps,
-    dependencies: [
-      device_lib,
-      sw_lib_dif_uart,
-      sw_lib_runtime_hart,
-      sw_lib_runtime_print,
-    ],
-  )
+  foreach slot, slot_link_args : rom_ext_link_info
+    rom_ext_elf = executable(
+      slot + '_' + device_name,
+      sources: [
+        'rom_ext_manifest.S',
+        'rom_ext_start.S',
+        'rom_ext.c',
+      ],
+      name_suffix: 'elf',
+      link_args: slot_link_args[0],
+      link_depends: slot_link_args[1],
+      dependencies: [
+        device_lib,
+        sw_lib_dif_uart,
+        sw_lib_runtime_hart,
+        sw_lib_runtime_print,
+      ],
+    )
 
-  rom_ext_embedded = custom_target(
-    'rom_ext_' + device_name,
-    command: make_embedded_target,
-    input: rom_ext_elf,
-    output: make_embedded_target_outputs,
-    build_by_default: true,
-  )
+    rom_ext_embedded = custom_target(
+      slot + '_' + device_name,
+      command: make_embedded_target,
+      input: rom_ext_elf,
+      output: make_embedded_target_outputs,
+      build_by_default: true,
+    )
 
-  custom_target(
-    'rom_ext_export_' + device_name,
-    command: export_embedded_target,
-    input: [rom_ext_elf, rom_ext_embedded],
-    output: 'rom_ext_export_' + device_name,
-    build_always_stale: true,
-    build_by_default: true,
-  )
+    custom_target(
+      slot + '_export_' + device_name,
+      command: export_embedded_target,
+      input: [rom_ext_elf, rom_ext_embedded],
+      output: slot + '_export_' + device_name,
+      build_always_stale: true,
+      build_by_default: true,
+    )
+  endforeach
 endforeach

--- a/sw/device/rom_exts/meson.build
+++ b/sw/device/rom_exts/meson.build
@@ -6,7 +6,7 @@
 #
 # See sw/device/exts/common/flash_link.ld for additional info about these
 # parameters.
-rom_ext_linkfile = files(['rom_ext.ld'])
+rom_ext_linkfile = files(['rom_ext_slot_a.ld'])
 rom_ext_link_args = [
   '-Wl,-L,@0@'.format(meson.source_root()),
   '-Wl,-T,@0@/@1@'.format(meson.source_root(), rom_ext_linkfile[0]),

--- a/sw/device/rom_exts/rom_ext_common.ld
+++ b/sw/device/rom_exts/rom_ext_common.ld
@@ -3,16 +3,10 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 /**
- * Linker script for an OpenTitan ROM_EXT.
- *
- * Portions of this file are Ibex-specific.
- *
- * The ROM_EXT is actually kept in flash, rather than ROM. While a ROM_EXT can
- * be loaded into either Slot A (the start of flash), or Slot B (the start of
- * the upper half of flash), this linker script only targets Slot A, and we hope
- * not to need to re-link our images for Slot B.
- *
- * TODO: Slot B Support, if needed.
+ * NOTE:
+ * This is an incomplete common portion of ROM_EXT linker file, and should not
+ * be used directly. Instead it should be included by a top level ROM_EXT slot
+ * linker file.
  */
 
 OUTPUT_ARCH(riscv)
@@ -22,13 +16,6 @@ GROUP(-lgcc)
  * Indicate that there are no dynamic libraries, whatsoever.
  */
 __DYNAMIC = 0;
-
-INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
-
-/* Reserving space at the top of the RAM for the stack. */
-_stack_size = 0x2000;
-_stack_end = ORIGIN(ram_main) + LENGTH(ram_main);
-_stack_start = _stack_end - _stack_size;
 
 /**
  * Marking the entrypoint correctly for the ELF file. In reality, we will end up
@@ -43,7 +30,7 @@ ENTRY(_rom_ext_start_boot)
  * s19->slm conversion scripts are not able to handle non-word aligned sections.
  */
 SECTIONS {
-  .rom_ext_manifest ORIGIN(eflash) : {
+  .rom_ext_manifest _slot_start_address : {
     KEEP(*(.rom_ext_manifest))
   } > eflash
 

--- a/sw/device/rom_exts/rom_ext_slot_a.ld
+++ b/sw/device/rom_exts/rom_ext_slot_a.ld
@@ -1,0 +1,25 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * Linker script for an OpenTitan ROM_EXT.
+ *
+ * Portions of this file are Ibex-specific.
+ *
+ * The ROM_EXT is actually kept in flash, rather than ROM. While a ROM_EXT can
+ * be loaded into either Slot A (the start of flash), or Slot B (the start of
+ * the upper half of flash), this linker script only targets Slot A.
+ */
+
+INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+
+/* Reserving space at the top of the RAM for the stack. */
+_stack_size = 0x2000;
+_stack_end = ORIGIN(ram_main) + LENGTH(ram_main);
+_stack_start = _stack_end - _stack_size;
+
+/* Slot A starts at the start of the eFlash. */
+_slot_start_address = ORIGIN(eflash);
+
+INCLUDE sw/device/rom_exts/rom_ext_common.ld

--- a/sw/device/rom_exts/rom_ext_slot_b.ld
+++ b/sw/device/rom_exts/rom_ext_slot_b.ld
@@ -1,0 +1,25 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * Linker script for an OpenTitan ROM_EXT.
+ *
+ * Portions of this file are Ibex-specific.
+ *
+ * The ROM_EXT is actually kept in flash, rather than ROM. While a ROM_EXT can
+ * be loaded into either Slot A (the start of flash), or Slot B (the start of
+ * the upper half of flash), this linker script only targets Slot B.
+ */
+
+INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+
+/* Reserving space at the top of the RAM for the stack. */
+_stack_size = 0x2000;
+_stack_end = ORIGIN(ram_main) + LENGTH(ram_main);
+_stack_start = _stack_end - _stack_size;
+
+/* Slot B starts at the half-size mark of the eFlash. */
+_slot_start_address = ORIGIN(eflash) + (LENGTH(eflash) / 2);
+
+INCLUDE sw/device/rom_exts/rom_ext_common.ld


### PR DESCRIPTION
# Description

LLVM RISC-V at this point does not have support for position-independent code (PIC), which means that to produce slot A and slot B images with the different offset from the flash start, we must produce two executables with different absolute addresses. To do that, we must maintain two separate linker files.
 
The linker script body is almost entirely the same, so most of the functionality has been split out into the `rom_ext_common.ld`, which is included by `rom_ext_slot_a.ld` and `rom_ext_slot_b.ld`. The main idea is that the common body has a `.phony` section at the beginning of flash to create an offset. The offset is defined in a corresponding slot linker file - is 0 for slot A and half the flash size for slot B.

# Testing

Has been run on the verilator, and produces the expected "Hello World!" output:

- Slot A

- Slot B (untested at this moment)