### PR TITLE
[kmac] Split SHA3 related RTLs to new core

### DIFF
--- a/hw/ip/kmac/fpv/keccak_2share_fpv.core
+++ b/hw/ip/kmac/fpv/keccak_2share_fpv.core
@@ -8,7 +8,7 @@ filesets:
   files_formal:
     depend:
       - lowrisc:prim:all
-      - lowrisc:ip:kmac
+      - lowrisc:ip:sha3
     files:
       - tb/keccak_2share_fpv.sv
     file_type: systemVerilogSource

--- a/hw/ip/kmac/fpv/keccak_round_fpv.core
+++ b/hw/ip/kmac/fpv/keccak_round_fpv.core
@@ -8,7 +8,7 @@ filesets:
   files_formal:
     depend:
       - lowrisc:prim:all
-      - lowrisc:ip:kmac
+      - lowrisc:ip:sha3
     files:
       - tb/keccak_round_fpv.sv
     file_type: systemVerilogSource

--- a/hw/ip/kmac/fpv/sha3_fpv.core
+++ b/hw/ip/kmac/fpv/sha3_fpv.core
@@ -2,15 +2,15 @@ CAPI=2:
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: "lowrisc:fpv:sha3core_fpv:0.1"
+name: "lowrisc:fpv:sha3_fpv:0.1"
 description: "SHA3 Core FPV target"
 filesets:
   files_formal:
     depend:
       - lowrisc:prim:all
-      - lowrisc:ip:kmac
+      - lowrisc:ip:sha3
     files:
-      - tb/sha3core_fpv.sv
+      - tb/sha3_fpv.sv
     file_type: systemVerilogSource
 
 targets:
@@ -21,7 +21,7 @@ targets:
     filesets:
       - files_formal
     toplevel:
-      - sha3core_fpv
+      - sha3_fpv
 
   formal:
     <<: *default_target

--- a/hw/ip/kmac/fpv/sha3pad_fpv.core
+++ b/hw/ip/kmac/fpv/sha3pad_fpv.core
@@ -8,7 +8,7 @@ filesets:
   files_formal:
     depend:
       - lowrisc:prim:all
-      - lowrisc:ip:kmac
+      - lowrisc:ip:sha3
     files:
       - tb/sha3pad_fpv.sv
     file_type: systemVerilogSource

--- a/hw/ip/kmac/fpv/tb/sha3_fpv.sv
+++ b/hw/ip/kmac/fpv/tb/sha3_fpv.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-module sha3core_fpv
+module sha3_fpv
   import kmac_pkg::*;
 #(
   // Enable Masked Keccak if 1
@@ -48,10 +48,10 @@ module sha3core_fpv
   output err_t error_o
 );
 
-  sha3core #(
+  sha3 #(
     .EnMasking(EnMasking),
     .ReuseShare (0)
-  ) u_core (
+  ) u_sha3 (
     .*
   );
 

--- a/hw/ip/kmac/kmac.core
+++ b/hw/ip/kmac/kmac.core
@@ -12,12 +12,9 @@ filesets:
       - lowrisc:prim:assert
       - lowrisc:ip:tlul
       - lowrisc:ip:keymgr_pkg
+      - lowrisc:ip:sha3
     files:
       - rtl/kmac_pkg.sv
-      - rtl/keccak_round.sv
-      - rtl/keccak_2share.sv
-      - rtl/sha3pad.sv
-      - rtl/sha3core.sv
       - rtl/kmac_core.sv
       - rtl/kmac_msgfifo.sv
       - rtl/kmac_staterd.sv

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -79,14 +79,14 @@ module kmac
   // It is active only if SW initiates the hashing engine.
   logic event_absorbed;
 
-  kmac_pkg::sha3_st_e sha3_fsm;
+  sha3_pkg::sha3_st_e sha3_fsm;
 
   // Prefix: kmac_pkg defines Prefix based on N size and S size.
   // Then computes left_encode(len(N)) size and left_encode(len(S))
   // For given default value 32, 256 bits, the max
   // encode_string(N) || encode_string(S) is 328. So 11 Prefix registers are
   // created.
-  logic [kmac_pkg::NSRegisterSize*8-1:0] ns_prefix;
+  logic [sha3_pkg::NSRegisterSize*8-1:0] ns_prefix;
 
   // NumWordsPrefix from kmac_reg_pkg
   `ASSERT_INIT(PrefixRegSameToPrefixPkg_A,
@@ -95,16 +95,16 @@ module kmac
   // Output state: this is used to redirect the digest to KeyMgr or Software
   // depends on the configuration.
   logic state_valid;
-  logic [kmac_pkg::StateW-1:0] state [Share];
+  logic [sha3_pkg::StateW-1:0] state [Share];
 
   // state is de-muxed in keymgr interface logic.
   // the output from keymgr logic goes into staterd module to be visible to SW
   logic reg_state_valid;
-  logic [kmac_pkg::StateW-1:0] reg_state [Share];
+  logic [sha3_pkg::StateW-1:0] reg_state [Share];
 
   // SHA3 Entropy interface
   logic sha3_rand_valid, sha3_rand_consumed;
-  logic [kmac_pkg::StateW-1:0] sha3_rand_data;
+  logic [sha3_pkg::StateW-1:0] sha3_rand_data;
   // TODO: Connect to entropy when ready
   assign sha3_rand_valid = 1'b 1;
   assign sha3_rand_data = '0;
@@ -177,7 +177,7 @@ module kmac
   kmac_cmd_e sw_cmd, kmac_cmd;
 
   // SHA3 Error response
-  err_t sha3_err;
+  sha3_pkg::err_t sha3_err;
 
   //////////////////////////////////////
   // Connecting Register IF to logics //
@@ -231,9 +231,9 @@ module kmac
   // status.squeeze is valid only when SHA3 engine completes the Absorb and not
   // running the manual keccak rounds. This status is for SW to determine when
   // to read the STATE values.
-  assign hw2reg.status.sha3_idle.d     = sha3_fsm == kmac_pkg::StIdle;
-  assign hw2reg.status.sha3_absorb.d   = sha3_fsm == kmac_pkg::StAbsorb;
-  assign hw2reg.status.sha3_squeeze.d  = sha3_fsm == kmac_pkg::StSqueeze;
+  assign hw2reg.status.sha3_idle.d     = sha3_fsm == sha3_pkg::StIdle;
+  assign hw2reg.status.sha3_absorb.d   = sha3_fsm == sha3_pkg::StAbsorb;
+  assign hw2reg.status.sha3_squeeze.d  = sha3_fsm == sha3_pkg::StSqueeze;
 
   // FIFO related status
   // TODO: handle if register width of `depth` is not same to MsgFifoDepthW
@@ -246,7 +246,7 @@ module kmac
 
   // Configuration Register
   logic engine_stable;
-  assign engine_stable = sha3_fsm == kmac_pkg::StIdle;
+  assign engine_stable = sha3_fsm == sha3_pkg::StIdle;
 
   assign hw2reg.cfg_regwen.d = engine_stable;
 
@@ -374,8 +374,8 @@ module kmac
 
     // Configurations
     .kmac_en_i  (reg2hw.cfg.kmac_en.q),
-    .mode_i     (sha3_mode_e'(reg2hw.cfg.mode.q)),
-    .strength_i (keccak_strength_e'(reg2hw.cfg.kstrength.q)),
+    .mode_i     (sha3_pkg::sha3_mode_e'(reg2hw.cfg.mode.q)),
+    .strength_i (sha3_pkg::keccak_strength_e'(reg2hw.cfg.kstrength.q)),
 
     // Secret key interface
     .key_data_i (key_data),
@@ -411,8 +411,8 @@ module kmac
     .ns_data_i       (ns_prefix),
 
     // Configurations
-    .mode_i     (sha3_mode_e'(reg2hw.cfg.mode.q)),
-    .strength_i (keccak_strength_e'(reg2hw.cfg.kstrength.q)),
+    .mode_i     (sha3_pkg::sha3_mode_e'(reg2hw.cfg.mode.q)),
+    .strength_i (sha3_pkg::keccak_strength_e'(reg2hw.cfg.kstrength.q)),
 
     // Controls (CMD register)
     .start_i    (sha3_start       ),

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -389,7 +389,7 @@ module kmac
   );
 
   // SHA3 hashing engine
-  sha3core #(
+  sha3 #(
     .EnMasking (EnMasking),
     .ReuseShare (ReuseShare)
   ) u_sha3 (

--- a/hw/ip/kmac/rtl/kmac_core.sv
+++ b/hw/ip/kmac/rtl/kmac_core.sv
@@ -33,9 +33,9 @@ module kmac_core
 
   // If kmac_en is cleared, Core logic doesn't function but forward incoming
   // mesage to SHA3 core
-  input                   kmac_en_i,
-  input sha3_mode_e       mode_i,
-  input keccak_strength_e strength_i,
+  input                             kmac_en_i,
+  input sha3_pkg::sha3_mode_e       mode_i,
+  input sha3_pkg::keccak_strength_e strength_i,
 
   // Key input from CSR
   input [MaxKeyLen-1:0] key_data_i [Share],
@@ -50,7 +50,7 @@ module kmac_core
   output logic process_o
 );
 
-  import kmac_pkg::*;
+  import sha3_pkg::*;
 
   /////////////////
   // Definitions //
@@ -83,12 +83,12 @@ module kmac_core
 
   // Key slice address
   // This signal controls the 64 bit output of the sliced secret_key.
-  logic [KeccakMsgAddrW-1:0] key_index;
+  logic [sha3_pkg::KeccakMsgAddrW-1:0] key_index;
   logic inc_keyidx, clr_keyidx;
 
   // `sent_blocksize` indicates that the encoded key is sent to sha3 hashing
   // engine. If this hits at StKey stage, the state moves to message state.
-  logic [KeccakCountW-1:0] block_addr_limit;
+  logic [sha3_pkg::KeccakCountW-1:0] block_addr_limit;
   logic sent_blocksize;
 
   // Internal message signals

--- a/hw/ip/kmac/rtl/kmac_keymgr.sv
+++ b/hw/ip/kmac/rtl/kmac_keymgr.sv
@@ -43,15 +43,15 @@ module kmac_keymgr
   input                       kmac_ready_i,
 
   // STATE from SHA3 Core
-  input              keccak_state_valid_i,
-  input [StateW-1:0] keccak_state_i [Share],
+  input                        keccak_state_valid_i,
+  input [sha3_pkg::StateW-1:0] keccak_state_i [Share],
 
   // to STATE TL-window
   // if KeyMgr KDF is not enabled, the incoming state goes to register
   // if kdf_en is set, the state value goes to KeyMgr and the output to the
   // register is all zero.
-  output logic              reg_state_valid_o,
-  output logic [StateW-1:0] reg_state_o [Share],
+  output logic                        reg_state_valid_o,
+  output logic [sha3_pkg::StateW-1:0] reg_state_o [Share],
 
   // Configurations
   // If key_en is set, the logic uses KeyMgr's sideloaded key as a secret key

--- a/hw/ip/kmac/rtl/kmac_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_pkg.sv
@@ -6,51 +6,10 @@
 
 package kmac_pkg;
 
-  // StateW represents the width of Keccak state variable.
-  // As Sha3 assume the state value as 1600, this shouldn't be modified.
-  // Note that keccak_round is flexible. It can have any values defined in SHA3
-  // specification. But sha3pad logic assumes the value as 1600.
-  parameter int StateW = 1600;
-
-  // Function Name (N) and Customzation String (S) shall be
-  // smaller than 2**256 bits and integer divisiable by 8.
-  parameter int FnWidth = 32;  // up to 32bit Function Name
-  parameter int CsWidth = 256; // up to 256bit Customization Input
-
-  // Calculate left_encode(len( X )) bit size.
-  // Assume the enc_8(n) is always 1 (up to 255 byte of len(S) size)
-  // e.g) 248bit --> two bytes , 256bit --> three bytes
-  //  round8bit(clog2(X+1))/8
-
-  parameter int MaxFnEncodeSize = ($clog2(FnWidth+1) + 8 - 1) / 8 + 1;
-  parameter int MaxCsEncodeSize = ($clog2(CsWidth+1) + 8 - 1) / 8 + 1;
-
-  parameter int NSRegisterSizePre = FnWidth/8       + CsWidth/8
-                                  + MaxFnEncodeSize + MaxCsEncodeSize;
-  // Round up to 32bit word base
-  parameter int NSRegisterSize = ((NSRegisterSizePre + 4 - 1 ) / 4) * 4;
-
-  // Prefix represents bytepad(encode_string(N) || encode_string(S), 168 or 136)
-  // +2 represents left_encoding(168 or 136) which could be either:
-  // 10000000 || 00010101 // 168
-  // 10000000 || 00010001 // 136
-  parameter int PrefixSize = NSRegisterSize + 2;
-
-  // index width for `N` and `S`
-  parameter int PrefixIndexW = $clog2(PrefixSize/64);
-
-  // Datapath width in KMAC, this also affects the output of MSG_FIFO
-  // This is assumed as 64 in KMAC design. If this value is changed, some parts
-  // of the KMAC design need to be changed.
-  //
-  // 1. keccak_round logic datapath. Keccak round logic assumes MsgWidth
-  //    divides 1600 keccak state `Width`. Choose the value accordingly.
-  // 2. sha3pad module has fixed width mux for funcpad logic. If MsgWidth is
-  //    changed, the logic also need to be revised.
-  // 3. kmac core logic also has fixed size mux for appeding output length.
-  //    Revise the case statement to fit into revised MsgWidth value.
-  parameter int MsgWidth = 64;
-  parameter int MsgStrbW = MsgWidth / 8;
+  // import necessary functions from sha3_pkg
+  import sha3_pkg::*;
+  export sha3_pkg::MsgWidth;
+  export sha3_pkg::MsgStrbW;
 
   // Message FIFO depth
   //
@@ -84,51 +43,6 @@ package kmac_pkg;
   parameter int MsgWindowWidth = 32; // Register width
   parameter int MsgWindowDepth = 512; // 2kB space
 
-  // Keccak module supports SHA3, SHAKE, cSHAKE function.
-  // This mode determines if the module uses encoded N and S or not.
-  // Also it chooses the padding value.
-  //
-  //    mode   |  little-endian
-  //    -------|----------------
-  //    Sha3   |  2'b   10
-  //    Shake  |  4'b 1111
-  //    CShake |  2'b   00
-  //
-  // Please remind that if input strings N and S are empty, SW shall
-  // choose SHAKE even for cSHAKE operation.
-  typedef enum logic[1:0] {
-    Sha3   = 2'b 00,
-    Shake  = 2'b 10,
-    CShake = 2'b 11
-  } sha3_mode_e;
-
-  // keccak_strength_e determines the security strength against collision attack
-  // This value decides the _rate_ and _capacity_ of the keccak states.
-  // It affects the sha3pad module too. the padding module implements
-  // `bytepad(X,168)` for L128, `bytepad(X,136)` for L256 in cSHAKE
-  typedef enum logic [2:0] {
-    L128 = 3'b 000, // rate: 1344 bit / capacity:  256 bit Keccak[ 256](, 128)
-    L224 = 3'b 001, // rate: 1152 bit / capacity:  448 bit Keccak[ 448](, 224)
-    L256 = 3'b 010, // rate: 1088 bit / capacity:  512 bit Keccak[ 512](, 256)
-    L384 = 3'b 011, // rate:  832 bit / capacity:  768 bit Keccak[ 768](, 384)
-    L512 = 3'b 100  // rate:  576 bit / capacity: 1024 bit Keccak[1024](, 512)
-  } keccak_strength_e;
-
-  parameter int unsigned KeccakRate [5] = '{
-    1344/MsgWidth,  // 21 depth := (1600 - 128*2)
-    1152/MsgWidth,  // 18 depth := (1600 - 224*2)
-    1088/MsgWidth,  // 17 depth := (1600 - 256*2)
-     832/MsgWidth,  // 13 depth := (1600 - 384*2)
-     576/MsgWidth   //  9 depth := (1600 - 512*2)
-  };
-
-  parameter int unsigned MaxBlockSize = KeccakRate[0];
-
-  parameter int unsigned KeccakEntries = 1600/MsgWidth;
-  parameter int unsigned KeccakMsgAddrW = $clog2(KeccakEntries);
-
-  parameter int unsigned KeccakCountW = $clog2(KeccakEntries+1);
-
   // Key related definitions
   // If this value is changed, please modify the logic inside kmac_core
   // that assigns the value into `encoded_key`
@@ -157,44 +71,6 @@ package kmac_pkg;
   } key_len_e;
 
 
-  // SHA3 core state. This state value is used in sha3core module
-  // and also in KMAC top module and the register interface for sw to track the
-  // sha3 status.
-  typedef enum logic [2:0] {
-    StIdle,
-
-    // Absorb stage receives the message bitstream and computes the keccak
-    // rounds. This internal operation is mainly done inside sha3pad module
-    // not sha3core. The core module and this state machine observe the status
-    // of the process and mainly waits until all the sponge absorbing is
-    // completed. The main indicator is `absorbed` signal.
-    StAbsorb,
-
-    // TODO: Implement StAbort later after context-switching discussion.
-    // Abort stage can be moved from StAbsorb stage. It basically holds the
-    // keccak round operation and opens up the internal state variable to the
-    // software. This stage is for the software to pause current operation and
-    // store the internal state elsewhere then initiates new KMAC/SHA3 process.
-    // StAbort only can be moved to _StFlush_.
-    //StAbort,
-
-    // Squeeze stage allows the software to read the internal state.
-    // If `EnMasking`, it opens the read permission of two share of the state.
-    // The squeezing in SHA3 specification describes the software to read up to
-    // the rate of SHA3 algorithm but this logic opens up the entire 1600 bits
-    // of the state (3200bits if `EnMasking`).
-    StSqueeze,
-
-    // ManualRun stage initiaties the keccak round and waits the completion.
-    // This state is moved from Squeeze state by writing 1 to manual_run CSR.
-    // When keccak round is completed, it goes back to Squeeze state.
-    StManualRun,
-
-    // Flush stage, the core clears out the internal variables and also
-    // submodules' variables too. Then moves back to Idle state.
-    StFlush
-  } sha3_st_e;
-
   // kmac_cmd_e defines the possible command sets that software issues via
   // !!CMD register. This is mainly to limit the error scenario that SW writes
   // multiple commands at once.
@@ -205,25 +81,6 @@ package kmac_pkg;
     CmdManualRun = 4'b 0100,
     CmdDone      = 4'b 1000
   } kmac_cmd_e;
-
-  //////////////////
-  // Error Report //
-  //////////////////
-  typedef enum logic [7:0] {
-    ErrNone = 8'h 00,
-
-    // ErrSha3SwControl occurs when software sent wrong flow signal.
-    // e.g) Sw set `process_i` without `start_i`. The state machine ignores
-    //      the signal and report through the error FIFO.
-    ErrSha3SwControl = 8'h 80
-  } err_code_e;
-
-  typedef struct packed {
-    logic        valid;
-    err_code_e   code; // Type of error
-    logic [23:0] info; // Additional Debug info
-  } err_t;
-
 
   ///////////////////////
   // Library Functions //
@@ -239,24 +96,5 @@ package kmac_pkg;
     logic [63:0] conv_data = {<<8{v}};
     conv_endian64 = (swap) ? conv_data : v ;
   endfunction : conv_endian64
-
-  // Bytepading function
-  // `encode_bytepad_len` represents the first two bytes of bytepad()
-  // It depends on the block size. We can reuse KeccakRate
-  // 10000000 || 00010101 // 168
-  // 10000000 || 00010001 // 136
-  function automatic logic [15:0] encode_bytepad_len(keccak_strength_e kstrength);
-    logic [15:0] result;
-    unique case (kstrength)
-      L128: result = 16'h A801; // cSHAKE128
-      L224: result = 16'h 9001; // not used
-      L256: result = 16'h 8801; // cSHAKE256
-      L384: result = 16'h 6801; // not used
-      L512: result = 16'h 4801; // not used
-
-      default: result = 16'h 0000;
-    endcase
-    return result;
-  endfunction : encode_bytepad_len
 
 endpackage : kmac_pkg

--- a/hw/ip/kmac/rtl/kmac_staterd.sv
+++ b/hw/ip/kmac/rtl/kmac_staterd.sv
@@ -26,13 +26,13 @@ module kmac_staterd
 
   // State in
   input valid_i,
-  input [StateW-1:0] state_i [Share],
+  input [sha3_pkg::StateW-1:0] state_i [Share],
 
   // Config
   input endian_swap_i
 );
 
-  localparam int StateAddrW = $clog2(kmac_pkg::StateW/32);
+  localparam int StateAddrW = $clog2(sha3_pkg::StateW/32);
   localparam int SelAddrW   = AddrW-2-StateAddrW;
 
   /////////////
@@ -95,7 +95,7 @@ module kmac_staterd
 
   for (genvar i = 0 ; i < Share ; i++) begin : gen_slicer
     prim_slicer #(
-      .InW (kmac_pkg::StateW),
+      .InW (sha3_pkg::StateW),
       .OutW (32),
       .IndexW (StateAddrW)
     ) u_state_slice (

--- a/hw/ip/kmac/rtl/sha3.sv
+++ b/hw/ip/kmac/rtl/sha3.sv
@@ -9,7 +9,7 @@
 `include "prim_assert.sv"
 
 module sha3
-  import kmac_pkg::*;
+  import sha3_pkg::*;
 #(
   // Enable Masked Keccak if 1
   parameter  int EnMasking = 0,
@@ -36,7 +36,7 @@ module sha3
   output logic              rand_consumed_o,
 
   // N, S: Used in cSHAKE mode only
-  input [NSRegisterSize*8-1:0] ns_data_i, // See kmac_pkg for details
+  input [NSRegisterSize*8-1:0] ns_data_i, // See sha3_pkg for details
 
   // configurations
   input sha3_mode_e       mode_i,     // see sha3pad for details
@@ -100,7 +100,7 @@ module sha3
   logic squeezing;
 
   // FSM variable
-  kmac_pkg::sha3_st_e st, st_d;
+  sha3_pkg::sha3_st_e st, st_d;
 
   // Keccak control signal (filtered by State Machine)
   logic keccak_start, keccak_process, keccak_done;
@@ -347,8 +347,8 @@ module sha3
 
   // Keccak round logic
   keccak_round #(
-    .Width    (kmac_pkg::StateW),
-    .DInWidth (kmac_pkg::MsgWidth),
+    .Width    (sha3_pkg::StateW),
+    .DInWidth (sha3_pkg::MsgWidth),
 
     .EnMasking  (EnMasking),
     .ReuseShare (ReuseShare)

--- a/hw/ip/kmac/rtl/sha3.sv
+++ b/hw/ip/kmac/rtl/sha3.sv
@@ -8,7 +8,7 @@
 
 `include "prim_assert.sv"
 
-module sha3core
+module sha3
   import kmac_pkg::*;
 #(
   // Enable Masked Keccak if 1

--- a/hw/ip/kmac/rtl/sha3_pkg.sv
+++ b/hw/ip/kmac/rtl/sha3_pkg.sv
@@ -1,0 +1,181 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// sha3_pkg
+
+package sha3_pkg;
+
+  // StateW represents the width of Keccak state variable.
+  // As Sha3 assume the state value as 1600, this shouldn't be modified.
+  // Note that keccak_round is flexible. It can have any values defined in SHA3
+  // specification. But sha3pad logic assumes the value as 1600.
+  parameter int StateW = 1600;
+
+  // Function Name (N) and Customzation String (S) shall be
+  // smaller than 2**256 bits and integer divisiable by 8.
+  parameter int FnWidth = 32;  // up to 32bit Function Name
+  parameter int CsWidth = 256; // up to 256bit Customization Input
+
+  // Calculate left_encode(len( X )) bit size.
+  // Assume the enc_8(n) is always 1 (up to 255 byte of len(S) size)
+  // e.g) 248bit --> two bytes , 256bit --> three bytes
+  //  round8bit(clog2(X+1))/8
+
+  parameter int MaxFnEncodeSize = ($clog2(FnWidth+1) + 8 - 1) / 8 + 1;
+  parameter int MaxCsEncodeSize = ($clog2(CsWidth+1) + 8 - 1) / 8 + 1;
+
+  parameter int NSRegisterSizePre = FnWidth/8       + CsWidth/8
+                                  + MaxFnEncodeSize + MaxCsEncodeSize;
+  // Round up to 32bit word base
+  parameter int NSRegisterSize = ((NSRegisterSizePre + 4 - 1 ) / 4) * 4;
+
+  // Prefix represents bytepad(encode_string(N) || encode_string(S), 168 or 136)
+  // +2 represents left_encoding(168 or 136) which could be either:
+  // 10000000 || 00010101 // 168
+  // 10000000 || 00010001 // 136
+  parameter int PrefixSize = NSRegisterSize + 2;
+
+  // index width for `N` and `S`
+  parameter int PrefixIndexW = $clog2(PrefixSize/64);
+
+  // Datapath width in KMAC, this also affects the output of MSG_FIFO
+  // This is assumed as 64 in KMAC design. If this value is changed, some parts
+  // of the KMAC design need to be changed.
+  //
+  // 1. keccak_round logic datapath. Keccak round logic assumes MsgWidth
+  //    divides 1600 keccak state `Width`. Choose the value accordingly.
+  // 2. sha3pad module has fixed width mux for funcpad logic. If MsgWidth is
+  //    changed, the logic also need to be revised.
+  // 3. kmac core logic also has fixed size mux for appeding output length.
+  //    Revise the case statement to fit into revised MsgWidth value.
+  parameter int MsgWidth = 64;
+  parameter int MsgStrbW = MsgWidth / 8;
+
+  // Keccak module supports SHA3, SHAKE, cSHAKE function.
+  // This mode determines if the module uses encoded N and S or not.
+  // Also it chooses the padding value.
+  //
+  //    mode   |  little-endian
+  //    -------|----------------
+  //    Sha3   |  2'b   10
+  //    Shake  |  4'b 1111
+  //    CShake |  2'b   00
+  //
+  // Please remind that if input strings N and S are empty, SW shall
+  // choose SHAKE even for cSHAKE operation.
+  typedef enum logic[1:0] {
+    Sha3   = 2'b 00,
+    Shake  = 2'b 10,
+    CShake = 2'b 11
+  } sha3_mode_e;
+
+  // keccak_strength_e determines the security strength against collision attack
+  // This value decides the _rate_ and _capacity_ of the keccak states.
+  // It affects the sha3pad module too. the padding module implements
+  // `bytepad(X,168)` for L128, `bytepad(X,136)` for L256 in cSHAKE
+  typedef enum logic [2:0] {
+    L128 = 3'b 000, // rate: 1344 bit / capacity:  256 bit Keccak[ 256](, 128)
+    L224 = 3'b 001, // rate: 1152 bit / capacity:  448 bit Keccak[ 448](, 224)
+    L256 = 3'b 010, // rate: 1088 bit / capacity:  512 bit Keccak[ 512](, 256)
+    L384 = 3'b 011, // rate:  832 bit / capacity:  768 bit Keccak[ 768](, 384)
+    L512 = 3'b 100  // rate:  576 bit / capacity: 1024 bit Keccak[1024](, 512)
+  } keccak_strength_e;
+
+  parameter int unsigned KeccakRate [5] = '{
+    1344/MsgWidth,  // 21 depth := (1600 - 128*2)
+    1152/MsgWidth,  // 18 depth := (1600 - 224*2)
+    1088/MsgWidth,  // 17 depth := (1600 - 256*2)
+     832/MsgWidth,  // 13 depth := (1600 - 384*2)
+     576/MsgWidth   //  9 depth := (1600 - 512*2)
+  };
+
+  parameter int unsigned MaxBlockSize = KeccakRate[0];
+
+  parameter int unsigned KeccakEntries = 1600/MsgWidth;
+  parameter int unsigned KeccakMsgAddrW = $clog2(KeccakEntries);
+
+  parameter int unsigned KeccakCountW = $clog2(KeccakEntries+1);
+
+  // SHA3 core state. This state value is used in sha3core module
+  // and also in KMAC top module and the register interface for sw to track the
+  // sha3 status.
+  typedef enum logic [2:0] {
+    StIdle,
+
+    // Absorb stage receives the message bitstream and computes the keccak
+    // rounds. This internal operation is mainly done inside sha3pad module
+    // not sha3core. The core module and this state machine observe the status
+    // of the process and mainly waits until all the sponge absorbing is
+    // completed. The main indicator is `absorbed` signal.
+    StAbsorb,
+
+    // TODO: Implement StAbort later after context-switching discussion.
+    // Abort stage can be moved from StAbsorb stage. It basically holds the
+    // keccak round operation and opens up the internal state variable to the
+    // software. This stage is for the software to pause current operation and
+    // store the internal state elsewhere then initiates new KMAC/SHA3 process.
+    // StAbort only can be moved to _StFlush_.
+    //StAbort,
+
+    // Squeeze stage allows the software to read the internal state.
+    // If `EnMasking`, it opens the read permission of two share of the state.
+    // The squeezing in SHA3 specification describes the software to read up to
+    // the rate of SHA3 algorithm but this logic opens up the entire 1600 bits
+    // of the state (3200bits if `EnMasking`).
+    StSqueeze,
+
+    // ManualRun stage initiaties the keccak round and waits the completion.
+    // This state is moved from Squeeze state by writing 1 to manual_run CSR.
+    // When keccak round is completed, it goes back to Squeeze state.
+    StManualRun,
+
+    // Flush stage, the core clears out the internal variables and also
+    // submodules' variables too. Then moves back to Idle state.
+    StFlush
+  } sha3_st_e;
+
+  //////////////////
+  // Error Report //
+  //////////////////
+  typedef enum logic [7:0] {
+    ErrNone = 8'h 00,
+
+    // ErrSha3SwControl occurs when software sent wrong flow signal.
+    // e.g) Sw set `process_i` without `start_i`. The state machine ignores
+    //      the signal and report through the error FIFO.
+    ErrSha3SwControl = 8'h 80
+  } err_code_e;
+
+  typedef struct packed {
+    logic        valid;
+    err_code_e   code; // Type of error
+    logic [23:0] info; // Additional Debug info
+  } err_t;
+
+
+  ///////////////
+  // Functions //
+  ///////////////
+
+  // Bytepading function
+  // `encode_bytepad_len` represents the first two bytes of bytepad()
+  // It depends on the block size. We can reuse KeccakRate
+  // 10000000 || 00010101 // 168
+  // 10000000 || 00010001 // 136
+  function automatic logic [15:0] encode_bytepad_len(keccak_strength_e kstrength);
+    logic [15:0] result;
+    unique case (kstrength)
+      L128: result = 16'h A801; // cSHAKE128
+      L224: result = 16'h 9001; // not used
+      L256: result = 16'h 8801; // cSHAKE256
+      L384: result = 16'h 6801; // not used
+      L512: result = 16'h 4801; // not used
+
+      default: result = 16'h 0000;
+    endcase
+    return result;
+  endfunction : encode_bytepad_len
+
+
+endpackage : sha3_pkg

--- a/hw/ip/kmac/rtl/sha3pad.sv
+++ b/hw/ip/kmac/rtl/sha3pad.sv
@@ -7,7 +7,7 @@
 `include "prim_assert.sv"
 
 module sha3pad
-  import kmac_pkg::*;
+  import sha3_pkg::*;
 #(
   parameter int EnMasking = 0,
   localparam int Share = (EnMasking) ? 2 : 1
@@ -22,7 +22,7 @@ module sha3pad
   output logic                msg_ready_o,
 
   // N, S: Used in cSHAKE mode only
-  input [NSRegisterSize*8-1:0] ns_data_i, // See kmac_pkg for details
+  input [NSRegisterSize*8-1:0] ns_data_i, // See sha3_pkg for details
 
   // output to keccak_round: message path
   output logic                       keccak_valid_o,
@@ -147,7 +147,7 @@ module sha3pad
 
   // `sent_message` indicates the number of entries sent to keccak round per
   // block. The value shall be enough to cover Maximum entry of the Keccak
-  // storage as defined in kmac_pkg, `$clog2(KeccakEntries+1)`. Logically,
+  // storage as defined in sha3_pkg, `$clog2(KeccakEntries+1)`. Logically,
   // it is not needed to have more than KeccakEntries but for safety in case of
   // SHA3 context switch resuming the SHA3 from the middle of sponge
   // construction. If needed, the software should be able to write whole 1600

--- a/hw/ip/kmac/sha3.core
+++ b/hw/ip/kmac/sha3.core
@@ -12,7 +12,7 @@ filesets:
       - lowrisc:prim:assert
       - lowrisc:ip:tlul
     files:
-      - rtl/kmac_pkg.sv
+      - rtl/sha3_pkg.sv
       - rtl/keccak_round.sv
       - rtl/keccak_2share.sv
       - rtl/sha3pad.sv

--- a/hw/ip/kmac/sha3.core
+++ b/hw/ip/kmac/sha3.core
@@ -1,0 +1,39 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:ip:sha3:0.1"
+description: "SHA3 core"
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:prim:all
+      - lowrisc:prim:prim_dom_and_2share
+      - lowrisc:prim:assert
+      - lowrisc:ip:tlul
+    files:
+      - rtl/kmac_pkg.sv
+      - rtl/keccak_round.sv
+      - rtl/keccak_2share.sv
+      - rtl/sha3pad.sv
+      - rtl/sha3.sv
+    file_type: systemVerilogSource
+
+
+parameters:
+  SYNTHESIS:
+    datatype: bool
+    paramtype: vlogdefine
+
+
+targets:
+  default: &default_target
+    filesets:
+      - files_rtl
+    toplevel: sha3
+
+  formal:
+    filesets:
+      - files_rtl
+    toplevel: sha3
+


### PR DESCRIPTION
Creating new sha3.core file to re-use SHA3 core in other IPs.
The `kmac_pkg.sv` splits into two packages `sha3_pkg.sv` and `kmac_pkg.sv`. `sha3_pkg` has the definitions, parameters for SHA3 use.