### PR TITLE
[dv/top] Fix top level regression timeout

### DIFF
--- a/hw/ip/alert_handler/data/alert_handler.hjson
+++ b/hw/ip/alert_handler/data/alert_handler.hjson
@@ -255,6 +255,11 @@
       cname: "LOC_ALERT",
       swaccess: "rw1c",
       hwaccess: "hrw",
+      tags: [// Top level CSR automation test, CPU clock is disabled, so escalation response will
+             // not send back to alert handler. This will set loc_alert_cause and could not predict
+             // automatically.
+             // TODO: remove the exclusion after set up top-level esc_receiver_driver
+             "excl:CsrNonInitTests:CsrExclCheck"],
       fields: [
         { bits: "0", name: "LA", desc: "Cause bit " }
       ]

--- a/hw/ip/alert_handler/data/alert_handler.hjson.tpl
+++ b/hw/ip/alert_handler/data/alert_handler.hjson.tpl
@@ -257,6 +257,11 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
       cname: "LOC_ALERT",
       swaccess: "rw1c",
       hwaccess: "hrw",
+      tags: [// Top level CSR automation test, CPU clock is disabled, so escalation response will
+             // not send back to alert handler. This will set loc_alert_cause and could not predict
+             // automatically.
+             // TODO: remove the exclusion after set up top-level esc_receiver_driver
+             "excl:CsrNonInitTests:CsrExclCheck"],
       fields: [
         { bits: "0", name: "LA", desc: "Cause bit " }
       ]

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson
@@ -747,9 +747,7 @@
       hwext:    "true",
       tags: [ // OTP internal HW will set this enable register to 0 when OTP is not under IDLE
               // state, so could not auto-predict its value
-              // TODO: change the exclusion to CsrNonInitTests once top-level triggers otp_init
-              // after reset
-              "excl:CsrAllTests:CsrExclCheck"],
+              "excl:CsrNonInitTests:CsrExclCheck"],
       fields: [
         {
             bits:   "0",

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
@@ -436,9 +436,7 @@
       hwext:    "true",
       tags: [ // OTP internal HW will set this enable register to 0 when OTP is not under IDLE
               // state, so could not auto-predict its value
-              // TODO: change the exclusion to CsrNonInitTests once top-level triggers otp_init
-              // after reset
-              "excl:CsrAllTests:CsrExclCheck"],
+              "excl:CsrNonInitTests:CsrExclCheck"],
       fields: [
         {
             bits:   "0",

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
@@ -17,6 +17,13 @@ class chip_common_vseq extends chip_base_vseq;
     enable_asserts_in_hw_reset_rand_wr = 0;
   endtask
 
+  task post_start();
+    super.post_start();
+    // Random CSR rw might trigger alert. Some alerts will conintuously be triggered until reset
+    // applied, which will cause alert_monitor phase_ready_to_end timeout.
+    apply_reset();
+  endtask
+
   virtual task apply_reset(string kind = "HARD");
     super.apply_reset(kind);
     cfg.mem_bkdr_vifs[Otp].clear_mem();

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -282,7 +282,6 @@ module tb;
     void'($value$plusargs("csr_%0s", csr_seq_type));
     if (common_seq_type inside {"mem_partial_access", "tl_errors"} ||
         csr_seq_type == "mem_walk") begin
-      force tb.dut.top_earlgrey.u_otp_ctrl.pwr_otp_i   = 1'b1;
       force tb.dut.top_earlgrey.u_otp_ctrl.lc_dft_en_i = 4'b1010;
     end
   end

--- a/hw/top_earlgrey/ip/alert_handler/data/autogen/alert_handler.hjson
+++ b/hw/top_earlgrey/ip/alert_handler/data/autogen/alert_handler.hjson
@@ -272,6 +272,11 @@
       cname: "LOC_ALERT",
       swaccess: "rw1c",
       hwaccess: "hrw",
+      tags: [// Top level CSR automation test, CPU clock is disabled, so escalation response will
+             // not send back to alert handler. This will set loc_alert_cause and could not predict
+             // automatically.
+             // TODO: remove the exclusion after set up top-level esc_receiver_driver
+             "excl:CsrNonInitTests:CsrExclCheck"],
       fields: [
         { bits: "0", name: "LA", desc: "Cause bit " }
       ]


### PR DESCRIPTION
This PR contains three commits to fix top-level regression failures:
1. Add a `apply_reset` in `post_start()` to avoid alert phase_ok_to_end timeout. (Because in OTP, some alert will keep asserting and never drops until reset), thanks Weicai for the suggestion!
2. Clean up top-level testbench after otp and pwrmgr connects.
3. Temp exclude alert_loc_cause until we added an escalation receiver driver.