### PR TITLE
[sparse-fsm-encode] Update template to prevent JG compile error

### DIFF
--- a/hw/ip/prim/util/sparse-fsm-encode.py
+++ b/hw/ip/prim/util/sparse-fsm-encode.py
@@ -54,7 +54,8 @@ RUST_INSTRUCTIONS = """
 ------------------------------------------------
 """
 
-def wrapped_docstring():
+
+def _wrapped_docstring():
     '''Return a text-wrapped version of the module docstring'''
     paras = []
     para = []
@@ -71,7 +72,9 @@ def wrapped_docstring():
 
     return '\n\n'.join(textwrap.fill(p) for p in paras)
 
-def hist_to_bars(hist, m):
+
+def _hist_to_bars(hist, m):
+    '''Convert histogramm list into ASCII bar plot'''
     bars = []
     for i, j in enumerate(hist):
         bar_prefix = "{:2}: ".format(i)
@@ -91,7 +94,7 @@ def main():
 
     parser = argparse.ArgumentParser(
         prog="sparse-fsm-encode",
-        description=wrapped_docstring(),
+        description=_wrapped_docstring(),
         formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument('-d',
                         type=int,
@@ -120,7 +123,7 @@ def main():
     args = parser.parse_args()
 
     if args.language in ['c', 'rust']:
-        if args.n not in [8,16,32]:
+        if args.n not in [8, 16, 32]:
             logging.error("When using C or Rust, widths must be a power-of-two "
                           "at least a byte (8 bits) wide. You chose %d." % (args.n,))
             sys.exit(1)
@@ -210,8 +213,7 @@ def main():
                 minimum = min(dist, minimum)
                 maximum = max(dist, maximum)
 
-    bars = hist_to_bars(hist, args.m)
-
+    bars = _hist_to_bars(hist, args.m)
 
     if args.language == "sv":
         print(SV_INSTRUCTIONS)
@@ -222,14 +224,14 @@ def main():
             "//\n"
             "// Hamming distance histogram:\n"
             "//".format(args.d, args.m, args.n, args.s))
-        for bar in hist_to_bars(hist, args.m):
+        for bar in _hist_to_bars(hist, args.m):
             print('// ' + bar)
         print("//\n"
-            "// Minimum Hamming distance: {}\n"
-            "// Maximum Hamming distance: {}\n"
-            "//\n"
-            "localparam int StateWidth = {};\n"
-            "typedef enum logic [StateWidth-1:0] {{".format(minimum, maximum, args.n))
+              "// Minimum Hamming distance: {}\n"
+              "// Maximum Hamming distance: {}\n"
+              "//\n"
+              "localparam int StateWidth = {};\n"
+              "typedef enum logic [StateWidth-1:0] {{".format(minimum, maximum, args.n))
         fmt_str = "  State{0:} {1:}= {2:}'b{3:0" + str(args.n) + "b}"
         state_str = ""
         for j, k in enumerate(encodings):
@@ -243,10 +245,12 @@ def main():
         # print FSM template
         print('''}} state_e;
 
-state_e state_d, state_q;
+state_e state_d;
+logic [StateWidth-1:0] state_q;
+
 always_comb begin : p_fsm
   // Default assignments
-  state_d = state_q;
+  state_d = state_e'(state_q);
 
   unique case (state_q)
 {}    default: ; // Consider triggering an error or alert in this case.
@@ -269,19 +273,19 @@ prim_flop #(
     elif args.language == "c":
         print(C_INSTRUCTIONS)
         print("/*\n"
-            " * Encoding generated with\n"
-            " * $ ./sparse-fsm-encode.py -d {} -m {} -n {} \\\n"
-            " *     -s {} --language=c\n"
-            " *\n"
-            " * Hamming distance histogram:\n"
-            " *".format(args.d, args.m, args.n, args.s))
+              " * Encoding generated with\n"
+              " * $ ./sparse-fsm-encode.py -d {} -m {} -n {} \\\n"
+              " *     -s {} --language=c\n"
+              " *\n"
+              " * Hamming distance histogram:\n"
+              " *".format(args.d, args.m, args.n, args.s))
         for hist_bar in bars:
             print(" * " + hist_bar)
         print(" *\n"
-            " * Minimum Hamming distance: {}\n"
-            " * Maximum Hamming distance: {}\n"
-            " */\n"
-            "typedef enum my_state {{".format(minimum, maximum))
+              " * Minimum Hamming distance: {}\n"
+              " * Maximum Hamming distance: {}\n"
+              " */\n"
+              "typedef enum my_state {{".format(minimum, maximum))
         fmt_str = "  kMyState{0:} {1:}= 0x{3:0" + str(math.ceil(args.n / 4)) + "x}"
         for j, k in enumerate(encodings):
             pad = ""
@@ -290,31 +294,31 @@ prim_flop #(
             print(fmt_str.format(j, pad, args.n, k) + ",")
 
         # print FSM template
-        print("} my_state_t;");
+        print("} my_state_t;")
     elif args.language == 'rust':
         print(RUST_INSTRUCTIONS)
         print("//\n"
-            "// Encoding generated with\n"
-            "// $ ./sparse-fsm-encode.py -d {} -m {} -n {} \\\n"
-            "//     -s {} --language=rust\n"
-            "//\n"
-            "// Hamming distance histogram:\n"
-            "//".format(args.d, args.m, args.n, args.s))
+              "// Encoding generated with\n"
+              "// $ ./sparse-fsm-encode.py -d {} -m {} -n {} \\\n"
+              "//     -s {} --language=rust\n"
+              "//\n"
+              "// Hamming distance histogram:\n"
+              "//".format(args.d, args.m, args.n, args.s))
         for hist_bar in bars:
             print("// " + hist_bar)
         print("//\n"
-            "// Minimum Hamming distance: {}\n"
-            "// Maximum Hamming distance: {}\n"
-            "//\n"
-            "#[repr(u{})]\n"
-            "enum MyState {{".format(minimum, maximum, args.n))
+              "// Minimum Hamming distance: {}\n"
+              "// Maximum Hamming distance: {}\n"
+              "//\n"
+              "#[repr(u{})]\n"
+              "enum MyState {{".format(minimum, maximum, args.n))
         fmt_str = "  MyState{0:} {1:}= 0x{3:0" + str(math.ceil(args.n / 4)) + "x}"
         for j, k in enumerate(encodings):
             pad = ""
             for i in range(len(str(args.m)) - len(str(j))):
                 pad += " "
             print(fmt_str.format(j, pad, args.n, k) + ",")
-        print("}");
+        print("}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This updates the SV template to prevent users from running into a JG compile error (basically the assignment of the `state_q` output needs to be an assingment to a logic vector instead of an enum type).

I've also cleaned up a bunch of `flake8` lint errors.

Signed-off-by: Michael Schaffner <msf@opentitan.org>