### PR TITLE
[otbn] Make model easier to use in Earl Grey simulation

### DIFF
--- a/hw/ip/otbn/README.md
+++ b/hw/ip/otbn/README.md
@@ -99,16 +99,26 @@ and check the results are as expected.
 
 ### Run OT earlgrey simulation with the OTBN model, rather than the RTL design
 
-The default behaviour is that the OTBN block contains the RTL design.
-If you wish to run system-level testing against the Python-based
-instruction set simulator instead of the RTL (hereafter called the
-ISS), you need to pass the `OTBN_MODEL` flag. For example, to compile
-the Verilator simulation, use:
+For simulation targets, the OTBN block can be built with both the RTL
+implementation and the Python-based instruction set simulator (hereafter called
+the ISS) compiled in. When running the simulation the plusarg `OTBN_USE_MODEL`
+can be used to switch between the RTL implementation and the model, without
+recompiling the simulation.
+
+The Verilator simulation of Earl Grey (`lowrisc:systems:top_earlgrey_verilator`)
+builds the model by default when compiling the simulation and nothing else needs
+to be done. For other simulation targets, set the `OTBN_BUILD_MODEL` define,
+e.g. by passing `--OTBN_BUILD_MODEL` to fusesoc.
+
+To run the simulation against the OTBN ISS pass `+OTBN_USE_MODEL=1` to the
+simulation run, e.g.
 
 ```sh
-fusesoc --cores-root=. run \
-  --flag=fileset_top --target=sim --setup --build \
-  lowrisc:systems:top_earlgrey_verilator --OTBN_MODEL
+build/lowrisc_systems_top_earlgrey_verilator_0.1/sim-verilator/Vtop_earlgrey_verilator \
+  --meminit=rom,build-bin/sw/device/boot_rom/boot_rom_sim_verilator.elf  \
+  --meminit=flash,build-bin/sw/device/tests/dif_otbn_sanitytest_sim_verilator.elf \
+  +UARTDPI_LOG_uart0=- \
+  +OTBN_USE_MODEL=1
 ```
 
 The simulation communicates with the model by creating a directory in
@@ -116,7 +126,6 @@ the temporary directory (/tmp or TMPDIR) and filling it with files.
 Normally, it cleans up after itself. If something goes wrong and you'd
 like to look at these files, set the `OTBN_MODEL_KEEP_TMP` environment
 variable to `1`.
-
 
 ### Run the ISS on its own
 

--- a/hw/ip/otbn/dv/model/otbn_core_model.sv
+++ b/hw/ip/otbn/dv/model/otbn_core_model.sv
@@ -136,13 +136,13 @@ module otbn_core_model
 
   // If DesignScope is not empty, we have a design to check. Bind a copy of otbn_rf_snooper into
   // each register file. The otbn_model_check() function will use these to extract memory contents.
-  generate if (DesignScope != "") begin
+  if (DesignScope != "") begin: g_check_design
     // TODO: This bind is by module, rather than by instance, because I couldn't get the by-instance
     // syntax plus upwards name referencing to work with Verilator. Obviously, this won't work with
     // multiple OTBN instances, so it would be nice to get it right.
     bind otbn_rf_base_ff otbn_rf_snooper #(.Width (32), .Depth (32)) u_snooper (.rf (rf_reg));
     bind otbn_rf_bignum_ff otbn_rf_snooper #(.Width (256), .Depth (32)) u_snooper (.rf (rf));
-  end endgenerate
+  end
 
   assign err_o = failed_step | failed_cmp;
 

--- a/hw/ip/otbn/dv/model/otbn_core_model.sv
+++ b/hw/ip/otbn/dv/model/otbn_core_model.sv
@@ -32,6 +32,10 @@ module otbn_core_model
   input  logic  clk_i,
   input  logic  rst_ni,
 
+  // Enable the model. This signal is a "runtime parameter", it is only honored if set in an initial
+  // block.
+  input logic   enable_i,
+
   input  logic  start_i, // start the operation
   output logic  done_o,  // operation done
 
@@ -69,15 +73,22 @@ module otbn_core_model
   chandle chandle_null = null;
 `endif
 
-  // Create and destroy an object through which we can talk to the ISS
-  chandle model_handle;
+  // Create and destroy an object through which we can talk to the ISS.
+  // If enable_i is not set, do not initialize the ISS (and, by consequence, do not start the Python
+  // process).
+  chandle model_handle = chandle_null;
   initial begin
-    model_handle = otbn_model_init();
-    assert(model_handle != chandle_null);
+    if (enable_i) begin
+      model_handle = otbn_model_init();
+      assert(model_handle != chandle_null);
+      $display("OTBN: Model enabled.");
+    end
   end
   final begin
-    otbn_model_destroy(model_handle);
-    model_handle = chandle_null;
+    if (model_handle != chandle_null) begin
+      otbn_model_destroy(model_handle);
+      model_handle = chandle_null;
+    end
   end
 
   // A packed "status" value. This gets assigned by DPI function calls that need to update both
@@ -95,7 +106,7 @@ module otbn_core_model
   assign {failed_cmp, failed_step, running} = status[2:0];
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
+    if (!rst_ni || !enable_i) begin
       // Clear status (stop running, and forget any errors)
       status <= 0;
     end else begin

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -184,6 +184,8 @@ module otbn_top_sim (
     .clk_i        ( IO_CLK ),
     .rst_ni       ( IO_RST_N ),
 
+    .enable_i     ( 1'b1 ),
+
     .start_i      ( otbn_start ),
     .done_o       ( otbn_model_done ),
 

--- a/hw/ip/otbn/otbn.core
+++ b/hw/ip/otbn/otbn.core
@@ -68,6 +68,17 @@ parameters:
   SYNTHESIS:
     datatype: bool
     paramtype: vlogdefine
+  OTBN_BUILD_MODEL:
+    datatype: bool
+    paramtype: vlogdefine
+    description: |
+      Build the simulation with the ISS as well as with the RTL implementation
+      (development only). Use the OTBN_USE_MODEL plusarg to switch at runtime.
+  OTBN_USE_MODEL:
+    datatype: bool
+    description: Use the OTBN model instead of the RTL implementation (development only)
+    paramtype: plusarg
+    default: false
 
 targets:
   default: &default_target
@@ -78,6 +89,9 @@ targets:
       - files_rtl_top
       - tool_verilator ? (files_model)
     toplevel: otbn
+    parameters:
+      - OTBN_USE_MODEL
+      - OTBN_BUILD_MODEL
 
   lint:
     <<: *default_target

--- a/hw/top_earlgrey/top_earlgrey_verilator.core
+++ b/hw/top_earlgrey/top_earlgrey_verilator.core
@@ -56,10 +56,6 @@ parameters:
     paramtype: vlogdefine
     default: true
     description: Replace JTAG TAP with an OpenOCD direct connection
-  OTBN_MODEL:
-    datatype: bool
-    paramtype: vlogdefine
-    description: Use the OTBN model instead of the RTL implementation (development only)
   UART_LOG_uart0:
     datatype: string
     paramtype: plusarg
@@ -84,7 +80,9 @@ targets:
       - flashinit
       - rominit
       - DMIDirectTAP
-      - OTBN_MODEL
+      # Always build OTBN with model and RTL. Switch between the two at runtime
+      # by passing "+OTBN_USE_MODEL=1" to the simulation.
+      - OTBN_BUILD_MODEL=true
       - RV_CORE_IBEX_SIM_SRAM=true
     default_tool: verilator
     filesets:


### PR DESCRIPTION
In OTBN, we have both a RTL implementation and a model (an instruction set
simulator). Before this change, either the model or the RTL implementation
had to be selected at simulation compile time (the only supported simulator
currently is Verilator, even though there's no blocking issue in supporting
other simulators as well). After this change the simulation can be built
with both RTL and model enabled at compile time, and then a runtime switch,
a plusarg, can be used to select between the two. It is still not possible
to run both model and RTL in parallel.

The main motivator for this change are CI runs: we can now use the same 
Verilator-based simulation of Earl Grey to run software against both the 
RTL and the model.

This PR also contains two related commits:
* A compile fix around `otbn_rf_peek()`. The solution isn't beautiful, but should do the trick.
* One small style fix with no functional change.