### PR TITLE
Gracefully shut down Verilator when software test fails

### DIFF
--- a/hw/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.cc
+++ b/hw/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.cc
@@ -22,6 +22,18 @@
  */
 double sc_time_stamp() { return VerilatorSimCtrl::GetInstance().GetTime(); }
 
+#ifdef VL_USER_STOP
+/**
+ * A simulation stop was requested, e.g. through $stop() or $error()
+ *
+ * This function overrides Verilator's default implementation to more gracefully
+ * shut down the simulation.
+ */
+void vl_stop(const char *filename, int linenum, const char *hier) VL_MT_UNSAFE {
+  VerilatorSimCtrl::GetInstance().RequestStop(false);
+}
+#endif
+
 VerilatorSimCtrl &VerilatorSimCtrl::GetInstance() {
   static VerilatorSimCtrl instance;
   return instance;

--- a/hw/top_earlgrey/top_earlgrey_verilator.core
+++ b/hw/top_earlgrey/top_earlgrey_verilator.core
@@ -102,7 +102,7 @@ targets:
           - '--trace-structs'
           - '--trace-params'
           - '--trace-max-array 1024'
-          - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=top_earlgrey_verilator -g"'
+          - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DVL_USER_STOP -DTOPLEVEL_NAME=top_earlgrey_verilator -g"'
           - '-LDFLAGS "-pthread -lutil -lelf"'
           - '-Wall'
           # Execute simulation with four threads by default, which works best


### PR DESCRIPTION
When a software test fails (i.e. an "potentially expected error", e.g.
through the `CHECK()` functionality), we call `DV_ERROR()`, which in
turn calls `$error()`, which calls `$stop()`. By default, Verilator
terminates the simulation immediately and writes a crash dump. This is
not necessarily what we want for such "expected errors"; instead, we
want a clean exit with a non-zero exit code.

Before:

```
E00008 dif_otbn_sanitytest.c:125] CHECK-fail: Unexpected result c at byte 0: 0xc8 (actual) != 0xc9 (expected)
I00009 test_status.c:34] FAIL!
[1988778] %Error: sw_test_status_if.sv:42: Assertion failed in TOP.top_earlgrey_verilator.u_sw_test_status_if: 1988778: (../src/lowrisc_dv_sw_test_status_0/sw_test_status_if.sv:42) [TOP.top_earlgrey_verilator.u_sw_test_status_if] ==== SW TEST FAILED ====
%Error: ../src/lowrisc_dv_sw_test_status_0/sw_test_status_if.sv:42: Verilog $stop
Aborting...
Abgebrochen (Speicherabzug geschrieben)
```

("Aborted (core dumped)" in German)

After:

```
E00008 dif_otbn_sanitytest.c:125] CHECK-fail: Unexpected result c at byte 0: 0xc8 (actual) != 0xc9 (expected)
I00009 test_status.c:34] FAIL!
[1988778] %Error: sw_test_status_if.sv:42: Assertion failed in TOP.top_earlgrey_verilator.u_sw_test_status_if: 1988778: (../src/lowrisc_dv_sw_test_status_0/sw_test_status_if.sv:42) [TOP.top_earlgrey_verilator.u_sw_test_status_if] ==== SW TEST FAILED ====
Received stop request, shutting down simulation.

Simulation statistics
=====================
Executed cycles:  994389
Wallclock time:   44.676 s
Simulation speed: 22257.8 cycles/s (22.2578 kHz)
$ echo $?
1
```