### PR TITLE
[otbn] Use the correct PC when disassembling in ISS

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -44,6 +44,7 @@ class OTBNSim:
             return (None, [])
 
         was_stalled = self.state.stalled
+        pc_before = self.state.pc
 
         if was_stalled:
             insn = None
@@ -73,7 +74,7 @@ class OTBNSim:
 
         if verbose:
             disasm = ('(stall)' if was_stalled
-                      else insn.disassemble(self.state.pc))
+                      else insn.disassemble(pc_before))
             self._print_trace(disasm, changes)
 
         return (insn, changes)


### PR DESCRIPTION
After a jump, self.state.pc gets updated by the call to
self.state.commit(). This was actually always wrong (we were
disassembling with PC + 4 for straight-line code), but it triggers an
assertion on a conditional jump or loop (because we see two different
"new" addresses for an instruction).
