### PR TITLE
[dv] Move get_normalized_addr into dv_base_reg_block

### DIFF
--- a/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
@@ -8,6 +8,15 @@ class dv_base_reg_block extends uvm_reg_block;
 
   csr_excl_item csr_excl;
 
+  // The address mask for the register block. This will be (1 << K) - 1 for some K. All relative
+  // offsets in the register block have addresses less than (1 << K), so an address decoder that
+  // starts by discarding all higher bits will work correctly so long as the chosen base address of
+  // the register block has no bits in common with this mask.
+  //
+  // This is initialized to zero (which means "unset") and then set by compute_mask(), which must
+  // run after locking the model.
+  protected uvm_reg_addr_t addr_mask = 0;
+
   function new (string name = "", int has_coverage = UVM_NO_COVERAGE);
     super.new(name, has_coverage);
   endfunction
@@ -18,40 +27,15 @@ class dv_base_reg_block extends uvm_reg_block;
     `uvm_fatal(`gfn, "this method is not supposed to be called directly!")
   endfunction
 
-  // use below to get the addr map size #3317
-  // max2(biggest_reg_offset+reg_size, biggest_mem_offset+mem_size) and then round up to 2**N
-  virtual function bit[`UVM_REG_ADDR_WIDTH:0] get_addr_map_size();
-    uvm_reg_addr_t mem_biggest_offset;
-    uvm_reg_addr_t reg_biggest_offset;
-    uvm_reg_addr_t biggest_offset;
-    uvm_reg_block  blocks[$];
-    uvm_reg        regs[$];
-    uvm_mem        mems[$];
-
-    // TODO: assume IP only contains 1 reg block, find a better way to handle chip-level and IP
-    // with multiple reg blocks
-    this.get_blocks(blocks);
-    if (blocks.size > 0) return 1 << `UVM_REG_ADDR_WIDTH;
-
-    this.get_registers(regs);
-    this.get_memories(mems);
-    `DV_CHECK_GT_FATAL(regs.size + mems.size, 0)
-
-    foreach (regs[i]) begin
-      biggest_offset = max2(regs[i].get_offset() + regs[i].get_n_bytes() - 1, biggest_offset);
+  // Get the address mask. This should only be called after locking the model (because it depends on
+  // the layout of registers and memories in the block).
+  function uvm_reg_addr_t get_addr_mask();
+    `DV_CHECK_FATAL(is_locked())
+    if (this.addr_mask == 0) begin
+      this.compute_mask();
+      `DV_CHECK_FATAL(this.addr_mask != 0)
     end
-
-    foreach (mems[i]) begin
-      biggest_offset = max2(mems[i].get_offset() + mems[i].get_size() * mems[i].get_n_bytes() - 1,
-                            biggest_offset);
-    end
-
-    get_addr_map_size = 1;
-    while (biggest_offset > 0) begin
-      biggest_offset = biggest_offset >> 1;
-      get_addr_map_size = get_addr_map_size << 1;
-    end
-    return get_addr_map_size;
+    return addr_mask;
   endfunction
 
   function void get_dv_base_reg_blocks(ref dv_base_reg_block blks[$]);
@@ -89,6 +73,99 @@ class dv_base_reg_block extends uvm_reg_block;
     super.reset(kind);
     get_enable_regs(enable_regs);
     foreach (enable_regs[i]) enable_regs[i].set_locked_regs_access();
+  endfunction
+
+  // Internal function, used to compute the address mask for this register block.
+  //
+  // This is quite an expensive computation, so we memoize the results in addr_mask
+  //
+  // use below to get the addr map size #3317
+  // max2(biggest_reg_offset+reg_size, biggest_mem_offset+mem_size) and then round up to 2**N
+  protected function void compute_mask();
+    uvm_reg_addr_t max_addr, max_offset;
+    uvm_reg_block  blocks[$];
+    uvm_reg        regs[$];
+    uvm_mem        mems[$];
+    int unsigned   alignment;
+
+    // TODO: assume IP only contains 1 reg block, find a better way to handle chip-level and IP
+    // with multiple reg blocks
+    this.get_blocks(blocks);
+    if (blocks.size > 0) begin
+      this.addr_mask = '1;
+      return;
+    end
+
+    this.get_registers(regs);
+    this.get_memories(mems);
+    `DV_CHECK_GT_FATAL(regs.size + mems.size, 0)
+
+    // Walk the known registers and memories, calculating the largest byte address visible. Note
+    // that the get_offset() calls will return absolute addresses, including any base address in the
+    // default register map.
+    max_addr = 0;
+    foreach (regs[i]) begin
+      max_addr = max2(regs[i].get_offset() + regs[i].get_n_bytes() - 1, max_addr);
+    end
+
+    foreach (mems[i]) begin
+      max_addr = max2(mems[i].get_offset() + mems[i].get_size() * mems[i].get_n_bytes() - 1,
+                      max_addr);
+    end
+
+    // Subtract the base address in the default register map to get the maximum relative offset.
+    max_offset = max_addr - this.default_map.get_base_addr();
+
+    // Set alignment to be ceil(log2(biggest_offset))
+    alignment = 0;
+    while (max_offset > 0) begin
+      alignment++;
+      max_offset = max_offset >> 1;
+    end
+
+    // Note that we know alignment > 0 (because we've already checked that we have at least one
+    // register or memory).
+    `DV_CHECK_GT_FATAL(alignment, 0)
+
+    // Finally, extract a mask corresponding to the alignment
+    this.addr_mask = (1 << alignment) - 1;
+
+  endfunction
+
+  // Pick or check a base address for the given register map
+  //
+  // Check that base_addr is aligned as required by the register block and return it again. If
+  // base_addr is the "magic" address '1, randomly pick an appropriately aligned base address and
+  // return it.
+  function uvm_reg_addr_t pick_base_addr(uvm_reg_addr_t base_addr);
+    uvm_reg_addr_t mask = this.get_addr_mask();
+
+    // If base_addr is '1, randomly pick an aligned base address
+    if (base_addr == '1) begin
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(base_addr, (base_addr & mask) == '0;)
+    end
+
+    // Check base addr alignment (which should be guaranteed if we just picked it, but needs
+    // checking if not).
+    `DV_CHECK_FATAL((base_addr & mask) == '0)
+
+    return base_addr;
+  endfunction
+
+  // Round the given address down to the start of the containing word. For example, if the address
+  // is 'h123, it will be rounded down to 'h120.
+  //
+  // This is useful if you have a possibly misaligned address and you want to know whether it hits a
+  // register (since get_reg_by_offset needs the aligned address for the start of the register).
+  function uvm_reg_addr_t align_to_word_addr(uvm_reg_addr_t byte_addr);
+    return (byte_addr >> 2) << 2;
+  endfunction
+
+  // Get the absolute address (in the default register map) for the given offset. For example, if
+  // the base address is 'h100 and offset is 'h13, this will return 'h113.
+  function uvm_reg_addr_t offset_to_addr(uvm_reg_addr_t byte_offset);
+    uvm_reg_addr_t word_offset = byte_offset >> 2;
+    return (word_offset << 2) + this.default_map.get_base_addr();
   endfunction
 
 endclass

--- a/hw/ip/aes/dv/env/aes_scoreboard.sv
+++ b/hw/ip/aes/dv/env/aes_scoreboard.sv
@@ -69,7 +69,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
     aes_seq_item   complete_clone;
     bit            do_read_check = 1'b0;
     bit            write         = item.is_write();
-    uvm_reg_addr_t csr_addr      = get_normalized_addr(item.a_addr);
+    uvm_reg_addr_t csr_addr      = ral.align_to_word_addr(item.a_addr);
 
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.csr_addrs}) begin

--- a/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
@@ -36,7 +36,7 @@ class entropy_src_scoreboard extends cip_base_scoreboard #(
     // TODO Turned off do_read_check for polling, add prediction
     bit     do_read_check   = 1'b1;
     bit     write           = item.is_write();
-    uvm_reg_addr_t csr_addr = get_normalized_addr(item.a_addr);
+    uvm_reg_addr_t csr_addr = ral.align_to_word_addr(item.a_addr);
 
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.csr_addrs}) begin

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
@@ -60,7 +60,7 @@ class flash_ctrl_scoreboard extends cip_base_scoreboard #(
     uvm_reg csr;
     bit     do_read_check   = 1'b1;
     bit     write           = item.is_write();
-    uvm_reg_addr_t csr_addr = get_normalized_addr(item.a_addr);
+    uvm_reg_addr_t csr_addr = ral.align_to_word_addr(item.a_addr);
 
     bit addr_phase_read   = (!write && channel == AddrChannel);
     bit addr_phase_write  = (write && channel == AddrChannel);

--- a/hw/ip/gpio/dv/env/gpio_scoreboard.sv
+++ b/hw/ip/gpio/dv/env/gpio_scoreboard.sv
@@ -60,7 +60,7 @@ class gpio_scoreboard extends cip_base_scoreboard #(.CFG_T (gpio_env_cfg),
     uvm_reg csr;
     bit do_read_check       = 1'b1;
     bit write               = item.is_write();
-    uvm_reg_addr_t csr_addr = get_normalized_addr(item.a_addr);
+    uvm_reg_addr_t csr_addr = ral.align_to_word_addr(item.a_addr);
 
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.csr_addrs}) begin

--- a/hw/ip/hmac/dv/env/hmac_env.sv
+++ b/hw/ip/hmac/dv/env/hmac_env.sv
@@ -17,7 +17,7 @@ class hmac_env extends cip_base_env #(.CFG_T               (hmac_env_cfg),
     dv_base_mem mem;
     super.end_of_elaboration_phase(phase);
     // hmac mem supports partial write, set it after ral model is locked
-    `downcast(mem, get_mem_by_addr(cfg.ral, cfg.csr_base_addr + HMAC_MSG_FIFO_BASE))
+    `downcast(mem, get_mem_by_addr(cfg.ral, cfg.ral.offset_to_addr(HMAC_MSG_FIFO_BASE)))
     mem.set_mem_partial_write_support(1);
   endfunction
 

--- a/hw/ip/hmac/dv/env/hmac_scoreboard.sv
+++ b/hw/ip/hmac/dv/env/hmac_scoreboard.sv
@@ -34,8 +34,8 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
     bit     do_cycle_accurate_check = 1'b1;
     bit     write                   = item.is_write();
     string  csr_name;
-    bit [TL_AW-1:0] addr_mask       = cfg.csr_addr_map_size - 1;
-    uvm_reg_addr_t  csr_addr        = get_normalized_addr(item.a_addr);
+    bit [TL_AW-1:0] addr_mask       = ral.get_addr_mask();
+    uvm_reg_addr_t  csr_addr        = ral.align_to_word_addr(item.a_addr);
 
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.csr_addrs}) begin

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
@@ -171,8 +171,8 @@ class hmac_base_vseq extends cip_base_vseq #(.CFG_T               (hmac_env_cfg)
       word = {>>byte{word_unpack}};
       `uvm_info(`gfn, $sformatf("wr_addr = %0h, wr_mask = %0h, words = 0x%0h",
                                 wr_addr, wr_mask, word), UVM_HIGH)
-      tl_access(.addr(wr_addr + cfg.csr_base_addr), .write(1'b1), .data(word), .mask(wr_mask),
-                .blocking(non_blocking));
+      tl_access(.addr(cfg.ral.offset_to_addr(wr_addr)),
+                .write(1'b1), .data(word), .mask(wr_mask), .blocking(non_blocking));
 
       if (ral.cfg.sha_en.get_mirrored_value()) begin
         if (!do_back_pressure) begin
@@ -207,8 +207,8 @@ class hmac_base_vseq extends cip_base_vseq #(.CFG_T               (hmac_env_cfg)
           `uvm_info(`gfn, $sformatf("wr_addr = %0h, wr_mask = %0h, words = 0x%0h",
                                     wr_addr, wr_mask, word), UVM_HIGH)
           `DV_CHECK_FATAL(randomize(wr_addr, wr_mask) with {wr_mask == '1;})
-          tl_access(.addr(wr_addr + cfg.csr_base_addr), .write(1'b1), .data(word), .mask(wr_mask),
-                    .blocking($urandom_range(0, 1)));
+          tl_access(.addr(cfg.ral.offset_to_addr(wr_addr)),
+                    .write(1'b1), .data(word), .mask(wr_mask), .blocking($urandom_range(0, 1)));
         end
         if (ral.cfg.sha_en.get_mirrored_value()) begin
           //clear_intr_fifo_full();

--- a/hw/ip/i2c/dv/env/i2c_scoreboard.sv
+++ b/hw/ip/i2c/dv/env/i2c_scoreboard.sv
@@ -61,7 +61,7 @@ class i2c_scoreboard extends cip_base_scoreboard #(
     bit       do_read_check = 1'b0;    // TODO: Enable this bit later
     bit       write = item.is_write();
 
-    uvm_reg_addr_t csr_addr = get_normalized_addr(item.a_addr);
+    uvm_reg_addr_t csr_addr = ral.align_to_word_addr(item.a_addr);
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.csr_addrs}) begin
       csr = ral.default_map.get_reg_by_offset(csr_addr);

--- a/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
@@ -35,7 +35,7 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
     uvm_reg csr;
     bit     do_read_check   = 1'b1;
     bit     write           = item.is_write();
-    uvm_reg_addr_t csr_addr = get_normalized_addr(item.a_addr);
+    uvm_reg_addr_t csr_addr = ral.align_to_word_addr(item.a_addr);
 
     bit addr_phase_read   = (!write && channel == AddrChannel);
     bit addr_phase_write  = (write && channel == AddrChannel);

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -87,8 +87,9 @@ package otp_ctrl_env_pkg;
     else return 1;
   endfunction
 
-  function automatic bit [TL_AW-1:0] get_sw_window_addr(bit [TL_AW-1:0] dai_addr);
-    get_sw_window_addr = dai_addr + SW_WINDOW_BASE_ADDR;
+  // Resolve an offset within the software window as an offset within the whole otp_ctrl block.
+  function automatic bit [TL_AW-1:0] get_sw_window_offset(bit [TL_AW-1:0] dai_addr);
+    return dai_addr + SW_WINDOW_BASE_ADDR;
   endfunction
 
   // package sources

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -45,8 +45,8 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
     uvm_reg csr;
     bit     do_read_check     = 1'b0;
     bit     write             = item.is_write();
-    uvm_reg_addr_t csr_addr   = get_normalized_addr(item.a_addr);
-    bit [TL_AW-1:0] addr_mask = cfg.csr_addr_map_size - 1;
+    uvm_reg_addr_t csr_addr   = ral.align_to_word_addr(item.a_addr);
+    bit [TL_AW-1:0] addr_mask = ral.get_addr_mask();
 
     bit addr_phase_read   = (!write && channel == AddrChannel);
     bit addr_phase_write  = (write && channel == AddrChannel);

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_sanity_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_sanity_vseq.sv
@@ -90,7 +90,7 @@ class otp_ctrl_sanity_vseq extends otp_ctrl_base_vseq;
 
         // if write sw partitions, check tlul window
         if (part_idx inside {CreatorSwCfgIdx, OwnerSwCfgIdx}) begin
-          bit [TL_AW-1:0] tlul_addr = get_sw_window_addr(dai_addr);
+          uvm_reg_addr_t tlul_addr = cfg.ral.offset_to_addr(get_sw_window_offset(dai_addr));
 
           // random issue reset, OTP content should not be cleared
           if ($urandom_range(0, 1)) dut_init();

--- a/hw/ip/rv_timer/dv/env/rv_timer_scoreboard.sv
+++ b/hw/ip/rv_timer/dv/env/rv_timer_scoreboard.sv
@@ -39,7 +39,7 @@ class rv_timer_scoreboard extends cip_base_scoreboard #(.CFG_T (rv_timer_env_cfg
     string  csr_name;
     bit     do_read_check   = 1'b1;
     bit     write           = item.is_write();
-    uvm_reg_addr_t csr_addr = get_normalized_addr(item.a_addr);
+    uvm_reg_addr_t csr_addr = ral.align_to_word_addr(item.a_addr);
 
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.csr_addrs}) begin

--- a/hw/ip/spi_device/dv/env/spi_device_env_cfg.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env_cfg.sv
@@ -20,7 +20,7 @@ class spi_device_env_cfg extends cip_base_env_cfg #(.RAL_T(spi_device_reg_block)
     // set num_interrupts & num_alerts which will be used to create coverage and more
     num_interrupts = ral.intr_state.get_n_used_bits();
 
-    sram_start_addr = SRAM_OFFSET + this.csr_base_addr;
+    sram_start_addr = ral.offset_to_addr(SRAM_OFFSET);
     sram_end_addr   = sram_start_addr + SRAM_SIZE - 1;
   endfunction
 

--- a/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
@@ -68,7 +68,7 @@ class spi_device_scoreboard extends cip_base_scoreboard #(.CFG_T (spi_device_env
     uvm_reg csr;
     bit     do_read_check   = 1'b0; // TODO: fixme
     bit     write           = item.is_write();
-    uvm_reg_addr_t csr_addr = get_normalized_addr(item.a_addr);
+    uvm_reg_addr_t csr_addr = ral.align_to_word_addr(item.a_addr);
 
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.csr_addrs}) begin

--- a/hw/ip/uart/dv/env/uart_scoreboard.sv
+++ b/hw/ip/uart/dv/env/uart_scoreboard.sv
@@ -163,7 +163,7 @@ class uart_scoreboard extends cip_base_scoreboard #(.CFG_T(uart_env_cfg),
     uvm_reg csr;
     bit     do_read_check   = 1'b1;
     bit     write           = item.is_write();
-    uvm_reg_addr_t csr_addr = get_normalized_addr(item.a_addr);
+    uvm_reg_addr_t csr_addr = ral.align_to_word_addr(item.a_addr);
 
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.csr_addrs}) begin

--- a/hw/ip/usbdev/dv/env/usbdev_scoreboard.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_scoreboard.sv
@@ -51,7 +51,7 @@ class usbdev_scoreboard extends cip_base_scoreboard #(
     uvm_reg csr;
     bit     do_read_check   = 1'b1;
     bit     write           = item.is_write();
-    uvm_reg_addr_t csr_addr = get_normalized_addr(item.a_addr);
+    uvm_reg_addr_t csr_addr = ral.align_to_word_addr(item.a_addr);
 
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.csr_addrs}) begin

--- a/util/uvmdvgen/scoreboard.sv.tpl
+++ b/util/uvmdvgen/scoreboard.sv.tpl
@@ -64,7 +64,7 @@ class ${name}_scoreboard extends dv_base_scoreboard #(
     uvm_reg csr;
     bit     do_read_check   = 1'b1;
     bit     write           = item.is_write();
-    uvm_reg_addr_t csr_addr = get_normalized_addr(item.a_addr);
+    uvm_reg_addr_t csr_addr = ral.align_to_word_addr(item.a_addr);
 
     bit addr_phase_read   = (!write && channel == AddrChannel);
     bit addr_phase_write  = (write && channel == AddrChannel);


### PR DESCRIPTION
EDIT: The latest version of this patch has quite a different commit message from the original. Reproduced below:

The `get_normalized_addr` function is defined in `cip_base_scoreboard` and
is used to round down word addresses and (seemingly) to convert byte
offsets (as reported by the TL agent) into absolute addresses matching
the RAL model.

However, it turns out that this isn't actually how we were using
it (which has had me *very* confused!). In fact, most of the addresses
floating around are absolute addresses (with occasional exceptions in
code like `spi_device_env_cfg` and some of the hmac code). The
definition of `get_normalized_addr` threw away the upper bits of the
address (converting to an offset), rounded down to a multiple of 4,
and then added the base address back on again.

This patch splits up that function into two functions:

  - `align_to_word_addr`  (rounds down to a multiple of 4)
  - `offset_to_addr`      (adds default map's base address to an offset)

and updates the code to use the right one in each situation.

Now (I think) everything called an "address" is an absolute address,
including the base address. Things relative to the start of the
register block are now called "offset"s.

The other part of this patch moves these two functions from
`cip_base_scoreboard` into `dv_base_reg_block`, which is probably a more
appropriate place for them to live. This was the original motivation
because I thought I needed the "offset_to_addr" functionality in
reactive sequences. It turns out this is wrong (we actually just need
to round addresses down!), but it can't hurt to put things somewhere
more sensible.

Finally, the patch tidies up how the base address for the register
block gets set (since I had to touch the code anyway). This includes
fixes for some integer overflows to do with sizes that are the whole
of the address space.

Note that it's a bit odd to put these functions in the register block
rather than the register map (since one register block can have
multiple register maps). However, we don't seem to actually
instantiate `dv_base_reg_map` when building our register blocks (indeed,
I'm not sure whether you can do so with UVM), so putting the functions
there doesn't work! Assuming this is right, I'll follow up with a
patch to get rid of that class later.
