### PR TITLE
[otbn] Tweaks to otbn_core_model

### DIFF
--- a/hw/ip/otbn/dv/model/otbn_core_model.sv
+++ b/hw/ip/otbn/dv/model/otbn_core_model.sv
@@ -37,7 +37,7 @@ module otbn_core_model
   input logic   enable_i,
 
   input  logic  start_i, // start the operation
-  output logic  done_o,  // operation done
+  output bit    done_o,  // operation done
 
   input  logic [ImemAddrWidth-1:0] start_addr_i, // start byte address in IMEM
 

--- a/hw/ip/otbn/dv/model/otbn_core_model.sv
+++ b/hw/ip/otbn/dv/model/otbn_core_model.sv
@@ -134,17 +134,19 @@ module otbn_core_model
   end
   assign done_o = running_r & ~running;
 
-  // If DesignScope is not empty, we have a design to check. Bind a copy of otbn_rf_snooper into
+  // If DesignScope is not empty, we have a design to check. Bind a copy of otbn_rf_snooper_if into
   // each register file. The otbn_model_check() function will use these to extract memory contents.
   if (DesignScope != "") begin: g_check_design
     // TODO: This bind is by module, rather than by instance, because I couldn't get the by-instance
     // syntax plus upwards name referencing to work with Verilator. Obviously, this won't work with
     // multiple OTBN instances, so it would be nice to get it right.
-    bind otbn_rf_base_ff otbn_rf_snooper #(.Width (32), .Depth (32)) u_snooper (.rf (rf_reg));
-    bind otbn_rf_bignum_ff otbn_rf_snooper #(.Width (256), .Depth (32)) u_snooper (.rf (rf));
-    bind otbn_rf_base otbn_stack_snooper #(.StackWidth (32), .StackDepth(8)) u_call_stack_snooper (
-      .stack_storage(u_call_stack.stack_storage),
-      .stack_wr_ptr_q(u_call_stack.stack_wr_ptr_q));
+    bind otbn_rf_base_ff otbn_rf_snooper_if #(.Width (32), .Depth (32)) u_snooper (.rf (rf_reg));
+    bind otbn_rf_bignum_ff otbn_rf_snooper_if #(.Width (256), .Depth (32)) u_snooper (.rf (rf));
+    bind otbn_rf_base otbn_stack_snooper_if #(.StackWidth (32), .StackDepth(8))
+      u_call_stack_snooper (
+        .stack_storage(u_call_stack.stack_storage),
+        .stack_wr_ptr_q(u_call_stack.stack_wr_ptr_q)
+      );
   end
 
   assign err_o = failed_step | failed_cmp;

--- a/hw/ip/otbn/dv/model/otbn_core_model.sv
+++ b/hw/ip/otbn/dv/model/otbn_core_model.sv
@@ -57,8 +57,8 @@ module otbn_core_model
                                  int unsigned start_addr,
                                  int unsigned status);
 
-  localparam ImemSizeWords = ImemSizeByte / 4;
-  localparam DmemSizeWords = DmemSizeByte / (WLEN / 8);
+  localparam int ImemSizeWords = ImemSizeByte / 4;
+  localparam int DmemSizeWords = DmemSizeByte / (WLEN / 8);
 
   `ASSERT_INIT(StartAddr32_A, ImemAddrWidth <= 32);
   logic [31:0] start_addr_32;

--- a/hw/ip/otbn/dv/model/otbn_model.core
+++ b/hw/ip/otbn/dv/model/otbn_model.core
@@ -1,0 +1,26 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:otbn_model:0.1"
+description: "OpenTitan Big Number Accelerator (OTBN)"
+
+filesets:
+  files_model:
+    depend:
+      - lowrisc:ip:otbn_pkg
+      - lowrisc:dv_verilator:memutil_dpi
+    files:
+      - otbn_model.cc: { file_type: cppSource }
+      - iss_wrapper.cc: { file_type: cppSource }
+      - iss_wrapper.h: { file_type: cppSource, is_include_file: true }
+      - otbn_core_model.sv
+      - otbn_rf_snooper_if.sv
+      - otbn_stack_snooper_if.sv
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_model
+    toplevel: otbn_core_model

--- a/hw/ip/otbn/dv/model/otbn_rf_snooper_if.sv
+++ b/hw/ip/otbn/dv/model/otbn_rf_snooper_if.sv
@@ -5,7 +5,7 @@
 // Backdoor interface that can be bound into an OTBN register file and exports a function to peek at
 // the memory contents.
 
-interface otbn_rf_snooper #(
+interface otbn_rf_snooper_if #(
   parameter int Width = 32,    // Memory width in bits
   parameter int Depth = 32     // Number of registers
 ) (

--- a/hw/ip/otbn/dv/model/otbn_stack_snooper_if.sv
+++ b/hw/ip/otbn/dv/model/otbn_stack_snooper_if.sv
@@ -5,7 +5,7 @@
 // Backdoor interface that can be bound into an OTBN stack and exports a function to peek at
 // the stack contents.
 
-interface otbn_stack_snooper #(
+interface otbn_stack_snooper_if #(
   parameter int StackWidth = 32,
   parameter int StackDepth = 4,
   localparam int StackDepthW = prim_util_pkg::vbits(StackDepth)

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.core
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.core
@@ -8,10 +8,12 @@ description: "Standalone OpenTitan Big Number Accelerator (OTBN) simulation"
 filesets:
   files_otbn:
     depend:
-      - lowrisc:ip:otbn:0.1
+      - lowrisc:ip:otbn
+      - lowrisc:dv:otbn_model
   files_verilator:
     depend:
       - lowrisc:dv:otbn_memutil
+      - lowrisc:dv_verilator:memutil_verilator
       - lowrisc:dv_verilator:simutil_verilator
     files:
       - otbn_top_sim.cc: { file_type: cppSource }

--- a/hw/ip/otbn/otbn.core
+++ b/hw/ip/otbn/otbn.core
@@ -55,8 +55,8 @@ filesets:
       - dv/model/iss_wrapper.cc
       - dv/model/iss_wrapper.h: { is_include_file: true }
       - dv/model/otbn_core_model.sv: { file_type: systemVerilogSource }
-      - dv/model/otbn_rf_snooper.sv: { file_type: systemVerilogSource }
-      - dv/model/otbn_stack_snooper.sv: { file_type: systemVerilogSource }
+      - dv/model/otbn_rf_snooper_if.sv: { file_type: systemVerilogSource }
+      - dv/model/otbn_stack_snooper_if.sv: { file_type: systemVerilogSource }
     file_type: cppSource
 
   files_verilator_waiver:

--- a/hw/ip/otbn/otbn.core
+++ b/hw/ip/otbn/otbn.core
@@ -6,17 +6,11 @@ name: "lowrisc:ip:otbn:0.1"
 description: "OpenTitan Big Number Accelerator (OTBN)"
 
 filesets:
-  files_rtl_pkg:
-    depend:
-      - lowrisc:prim:assert
-    files:
-      - rtl/otbn_pkg.sv
-    file_type: systemVerilogSource
-
   files_rtl_core:
     depend:
       - lowrisc:prim:assert
       - lowrisc:prim:util
+      - lowrisc:ip:otbn_pkg
     files:
       - rtl/otbn_controller.sv
       - rtl/otbn_decoder.sv
@@ -41,23 +35,13 @@ filesets:
       - lowrisc:prim:assert
       - lowrisc:prim:util
       - lowrisc:prim:ram_1p_adv
+      - lowrisc:ip:otbn_pkg
+      - lowrisc:dv:otbn_model
     files:
       - rtl/otbn_reg_pkg.sv
       - rtl/otbn_reg_top.sv
       - rtl/otbn.sv
     file_type: systemVerilogSource
-
-  files_model:
-    depend:
-      - lowrisc:dv_verilator:memutil_verilator
-    files:
-      - dv/model/otbn_model.cc
-      - dv/model/iss_wrapper.cc
-      - dv/model/iss_wrapper.h: { is_include_file: true }
-      - dv/model/otbn_core_model.sv: { file_type: systemVerilogSource }
-      - dv/model/otbn_rf_snooper_if.sv: { file_type: systemVerilogSource }
-      - dv/model/otbn_stack_snooper_if.sv: { file_type: systemVerilogSource }
-    file_type: cppSource
 
   files_verilator_waiver:
     depend:
@@ -88,10 +72,8 @@ targets:
   default: &default_target
     filesets:
       - tool_verilator ? (files_verilator_waiver)
-      - files_rtl_pkg
       - files_rtl_core
       - files_rtl_top
-      - tool_verilator ? (files_model)
     toplevel: otbn
     parameters:
       - OTBN_USE_MODEL
@@ -114,7 +96,6 @@ targets:
 
   lint-core:
     filesets:
-      - files_rtl_pkg
       - files_rtl_core
     toplevel: otbn_core
     default_tool: verilator

--- a/hw/ip/otbn/otbn_pkg.core
+++ b/hw/ip/otbn/otbn_pkg.core
@@ -1,0 +1,19 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:ip:otbn_pkg:0.1"
+description: "Constants used by OTBN"
+
+filesets:
+  files_pkg:
+    depend:
+      - lowrisc:prim:assert
+    files:
+      - rtl/otbn_pkg.sv
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_pkg


### PR DESCRIPTION
Split out the core file (so that we can build it with simulators other than Verilator) and simplify a type from `logic` to `bit`.