### PR TITLE
[kmac] Split the tl_adapter from msg_fifo

### DIFF
--- a/hw/ip/kmac/rtl/kmac_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_pkg.sv
@@ -81,6 +81,9 @@ package kmac_pkg;
   parameter int MsgFifoDepth   = 2 + ((BufferSizeBits + MsgWidth - 1)/MsgWidth);
   parameter int MsgFifoDepthW  = $clog2(MsgFifoDepth+1);
 
+  parameter int MsgWindowWidth = 32; // Register width
+  parameter int MsgWindowDepth = 512; // 2kB space
+
   // Keccak module supports SHA3, SHAKE, cSHAKE function.
   // This mode determines if the module uses encoded N and S or not.
   // Also it chooses the padding value.
@@ -196,6 +199,7 @@ package kmac_pkg;
   // !!CMD register. This is mainly to limit the error scenario that SW writes
   // multiple commands at once.
   typedef enum logic [3:0] {
+    CmdNone      = 4'b 0000,
     CmdStart     = 4'b 0001,
     CmdProcess   = 4'b 0010,
     CmdManualRun = 4'b 0100,


### PR DESCRIPTION
In following commits, I will introduce KeyMgr interface module. It
hijacks the data between the software MSG_FIFO interface and the
prim_packer in MSG_FIFO. It switches to KeyMgr data interface when
KeyMgr KDF request is received.

To support it in a modular way, tl adapter module is moved outside of
the kmac_msgfifo module. The MSG_FIFO module now accepts generic FIFO
interface that has same 64bit Width as internal datapath. The software
will still write in 32bit. Upper 32bit will be zero.