### PR TITLE
[dv/kmac] Create barebones KMAC testbench

### DIFF
--- a/hw/ip/kmac/data/kmac_testplan.hjson
+++ b/hw/ip/kmac/data/kmac_testplan.hjson
@@ -1,0 +1,32 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  name: "kmac"
+  // TODO: remove the common testplans if not applicable
+  import_testplans: ["hw/dv/tools/dvsim/testplans/csr_testplan.hjson",
+                     "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
+                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson"]
+  entries: [
+    {
+      name: sanity
+      desc: '''
+            Basic sanity test acessing a major datapath within the kmac.
+
+            **Stimulus**:
+            - TBD
+
+            **Checks**:
+            - TBD
+            '''
+      milestone: V1
+      tests: ["kmac_sanity"]
+    }
+    {
+      name: feature1
+      desc: '''Add more test entries here like above.'''
+      milestone: V1
+      tests: []
+    }
+  ]
+}

--- a/hw/ip/kmac/doc/dv_plan/index.md
+++ b/hw/ip/kmac/doc/dv_plan/index.md
@@ -1,0 +1,117 @@
+---
+title: "KMAC DV Plan"
+---
+
+<!-- Copy this file to hw/ip/kmac/doc/kmac_dv_plan.md and make changes as needed.
+For convenience 'kmac' in the document can be searched and replaced easily with the
+desired IP (with case sensitivity!). Also, use the testbench block diagram
+located at OpenTitan team drive / 'design verification'
+as a starting point and modify it to reflect your kmac testbench and save it
+to hw/ip/kmac/doc/tb.svg. It should get linked and rendered under the block
+diagram section below. Please update / modify / remove sections below as
+applicable. Once done, remove this comment before making a PR. -->
+
+## Goals
+* **DV**
+  * Verify all KMAC IP features by running dynamic simulations with a SV/UVM based testbench
+  * Develop and run all tests based on the [testplan](#testplan) below towards closing code and functional coverage on the IP and all of its sub-modules
+* **FPV**
+  * Verify TileLink device protocol compliance with an SVA based testbench
+
+## Current status
+* [Design & verification stage]({{< relref "hw" >}})
+  * [HW development stages]({{< relref "doc/project/development_stages" >}})
+* [Simulation results](https://reports.opentitan.org/hw/ip/kmac/dv/latest/results.html)
+
+## Design features
+For detailed information on KMAC design features, please see the [KMAC HWIP technical specification]({{< relref "hw/ip/kmac/doc" >}}).
+
+## Testbench architecture
+KMAC testbench has been constructed based on the [CIP testbench architecture]({{< relref "hw/dv/sv/cip_lib/doc" >}}).
+
+### Block diagram
+![Block diagram](tb.svg)
+
+### Top level testbench
+Top level testbench is located at `hw/ip/kmac/dv/tb/tb.sv`. It instantiates the KMAC DUT module `hw/ip/kmac/rtl/kmac.sv`.
+In addition, it instantiates the following interfaces, connects them to the DUT and sets their handle into `uvm_config_db`:
+* [Clock and reset interface]({{< relref "hw/dv/sv/common_ifs" >}})
+* [TileLink host interface]({{< relref "hw/dv/sv/tl_agent/README.md" >}})
+* KMAC IOs
+* Interrupts ([`pins_if`]({{< relref "hw/dv/sv/common_ifs" >}})
+* Devmode ([`pins_if`]({{< relref "hw/dv/sv/common_ifs" >}})
+
+### Common DV utility components
+The following utilities provide generic helper tasks and functions to perform activities that are common across the project:
+* [dv_utils_pkg]({{< relref "hw/dv/sv/dv_utils/README.md" >}})
+* [csr_utils_pkg]({{< relref "hw/dv/sv/csr_utils/README.md" >}})
+
+### Compile-time configurations
+[list compile time configurations, if any and what are they used for]
+
+### Global types & methods
+All common types and methods defined at the package level can be found in
+`kmac_env_pkg`. Some of them in use are:
+```systemverilog
+[list a few parameters, types & methods; no need to mention all]
+```
+### TL_agent
+KMAC testbench instantiates (already handled in CIP base env) [tl_agent]({{< relref "hw/dv/sv/tl_agent/README.md" >}})
+which provides the ability to drive and independently monitor random traffic via
+TL host interface into KMAC device.
+
+### UVC/agent 1
+[Describe here or add link to its README]
+
+### UVC/agent 2
+[Describe here or add link to its README]
+
+### UVM RAL Model
+The KMAC RAL model is created with the [`ralgen`]({{< relref "hw/dv/tools/ralgen/README.md" >}}) FuseSoC generator script automatically when the simulation is at the build stage.
+
+It can be created manually by invoking [`regtool`]({{< relref "util/reggen/README.md" >}}):
+
+### Reference models
+[Describe reference models in use if applicable, example: SHA256/HMAC]
+
+### Stimulus strategy
+#### Test sequences
+All test sequences reside in `hw/ip/kmac/dv/env/seq_lib`.
+The `kmac_base_vseq` virtual sequence is extended from `cip_base_vseq` and serves as a starting point.
+All test sequences are extended from `kmac_base_vseq`.
+It provides commonly used handles, variables, functions and tasks that the test sequences can simple use / call.
+Some of the most commonly used tasks / functions are as follows:
+* task 1:
+* task 2:
+
+#### Functional coverage
+To ensure high quality constrained random stimulus, it is necessary to develop a functional coverage model.
+The following covergroups have been developed to prove that the test intent has been adequately met:
+* cg1:
+* cg2:
+
+### Self-checking strategy
+#### Scoreboard
+The `kmac_scoreboard` is primarily used for end to end checking.
+It creates the following analysis ports to retrieve the data monitored by corresponding interface agents:
+* analysis port1:
+* analysis port2:
+<!-- explain inputs monitored, flow of data and outputs checked -->
+
+#### Assertions
+* TLUL assertions: The `tb/kmac_bind.sv` binds the `tlul_assert` [assertions]({{< relref "hw/ip/tlul/doc/TlulProtocolChecker.md" >}}) to the IP to ensure TileLink interface protocol compliance.
+* Unknown checks on DUT outputs: The RTL has assertions to ensure all outputs are initialized to known values after coming out of reset.
+* assert prop 1:
+* assert prop 2:
+
+## Building and running tests
+We are using our in-house developed [regression tool]({{< relref "hw/dv/tools/README.md" >}}) for building and running our tests and regressions.
+Please take a look at the link for detailed information on the usage, capabilities, features and known issues.
+Here's how to run a basic sanity test:
+```console
+$ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/kmac/dv/kmac_sim_cfg.hjson -i kmac_sanity
+```
+
+## Testplan
+<!-- TODO: uncomment the line below after adding the testplan -->
+{{</* testplan "hw/ip/kmac/data/kmac_testplan.hjson" */>}}

--- a/hw/ip/kmac/dv/env/kmac_env.core
+++ b/hw/ip/kmac/dv/env/kmac_env.core
@@ -1,0 +1,37 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:kmac_env:0.1"
+description: "KMAC DV UVM environment"
+filesets:
+  files_dv:
+    depend:
+      - lowrisc:dv:ralgen
+      - lowrisc:dv:cip_lib
+    files:
+      - kmac_env_pkg.sv
+      - kmac_env_cfg.sv: {is_include_file: true}
+      - kmac_env_cov.sv: {is_include_file: true}
+      - kmac_virtual_sequencer.sv: {is_include_file: true}
+      - kmac_scoreboard.sv: {is_include_file: true}
+      - kmac_env.sv: {is_include_file: true}
+      - seq_lib/kmac_vseq_list.sv: {is_include_file: true}
+      - seq_lib/kmac_base_vseq.sv: {is_include_file: true}
+      - seq_lib/kmac_common_vseq.sv: {is_include_file: true}
+      - seq_lib/kmac_sanity_vseq.sv: {is_include_file: true}
+    file_type: systemVerilogSource
+
+generate:
+  ral:
+    generator: ralgen
+    parameters:
+      name: kmac
+      ip_hjson: ../../data/kmac.hjson
+
+targets:
+  default:
+    filesets:
+      - files_dv
+    generate:
+      - ral

--- a/hw/ip/kmac/dv/env/kmac_env.sv
+++ b/hw/ip/kmac/dv/env/kmac_env.sv
@@ -1,0 +1,23 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class kmac_env extends cip_base_env #(
+    .CFG_T              (kmac_env_cfg),
+    .COV_T              (kmac_env_cov),
+    .VIRTUAL_SEQUENCER_T(kmac_virtual_sequencer),
+    .SCOREBOARD_T       (kmac_scoreboard)
+  );
+  `uvm_component_utils(kmac_env)
+
+  `uvm_component_new
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+  endfunction
+
+  function void connect_phase(uvm_phase phase);
+    super.connect_phase(phase);
+  endfunction
+
+endclass

--- a/hw/ip/kmac/dv/env/kmac_env_cfg.sv
+++ b/hw/ip/kmac/dv/env/kmac_env_cfg.sv
@@ -1,0 +1,26 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class kmac_env_cfg extends cip_base_env_cfg #(.RAL_T(kmac_reg_block));
+
+  // ext component cfgs
+
+  `uvm_object_utils_begin(kmac_env_cfg)
+  `uvm_object_utils_end
+
+  `uvm_object_new
+
+  virtual function void initialize(bit [31:0] csr_base_addr = '1);
+    super.initialize(csr_base_addr);
+
+    // set num_interrupts & num_alerts
+    begin
+      uvm_reg rg = ral.get_reg_by_name("intr_state");
+      if (rg != null) begin
+        num_interrupts = ral.intr_state.get_n_used_bits();
+      end
+    end
+  endfunction
+
+endclass

--- a/hw/ip/kmac/dv/env/kmac_env_cov.sv
+++ b/hw/ip/kmac/dv/env/kmac_env_cov.sv
@@ -1,0 +1,32 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Covergoups that are dependent on run-time parameters that may be available
+ * only in build_phase can be defined here
+ * Covergroups may also be wrapped inside helper classes if needed.
+ */
+
+class kmac_env_cov extends cip_base_env_cov #(.CFG_T(kmac_env_cfg));
+  `uvm_component_utils(kmac_env_cov)
+
+  // the base class provides the following handles for use:
+  // kmac_env_cfg: cfg
+
+  // covergroups
+  // [add covergroups here]
+
+  function new(string name, uvm_component parent);
+    super.new(name, parent);
+    // [instantiate covergroups here]
+  endfunction : new
+
+  virtual function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    // [or instantiate covergroups here]
+    // Please instantiate sticky_intr_cov array of objects for all interrupts that are sticky
+    // See cip_base_env_cov for details
+  endfunction
+
+endclass

--- a/hw/ip/kmac/dv/env/kmac_env_pkg.sv
+++ b/hw/ip/kmac/dv/env/kmac_env_pkg.sv
@@ -1,0 +1,39 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package kmac_env_pkg;
+  // dep packages
+  import uvm_pkg::*;
+  import top_pkg::*;
+  import dv_utils_pkg::*;
+  import dv_lib_pkg::*;
+  import tl_agent_pkg::*;
+  import cip_base_pkg::*;
+  import csr_utils_pkg::*;
+  import kmac_ral_pkg::*;
+
+  // macro includes
+  `include "uvm_macros.svh"
+  `include "dv_macros.svh"
+
+  // parameters
+
+  // types
+  typedef enum {
+    KmacDone,
+    KmacFifoEmpty,
+    KmacErr
+  } kmac_intr_e;
+
+  // functions
+
+  // package sources
+  `include "kmac_env_cfg.sv"
+  `include "kmac_env_cov.sv"
+  `include "kmac_virtual_sequencer.sv"
+  `include "kmac_scoreboard.sv"
+  `include "kmac_env.sv"
+  `include "kmac_vseq_list.sv"
+
+endpackage

--- a/hw/ip/kmac/dv/env/kmac_scoreboard.sv
+++ b/hw/ip/kmac/dv/env/kmac_scoreboard.sv
@@ -1,0 +1,99 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class kmac_scoreboard extends cip_base_scoreboard #(
+    .CFG_T(kmac_env_cfg),
+    .RAL_T(kmac_reg_block),
+    .COV_T(kmac_env_cov)
+  );
+  `uvm_component_utils(kmac_scoreboard)
+
+  // local variables
+
+  // TLM agent fifos
+
+  // local queues to hold incoming packets pending comparison
+
+  `uvm_component_new
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+  endfunction
+
+  function void connect_phase(uvm_phase phase);
+    super.connect_phase(phase);
+  endfunction
+
+  task run_phase(uvm_phase phase);
+    super.run_phase(phase);
+    fork
+    join_none
+  endtask
+
+  virtual task process_tl_access(tl_seq_item item, tl_channels_e channel = DataChannel);
+    uvm_reg csr;
+    bit     do_read_check   = 1'b1;
+    bit     write           = item.is_write();
+    uvm_reg_addr_t csr_addr = ral.align_to_word_addr(item.a_addr);
+
+    bit addr_phase_read   = (!write && channel == AddrChannel);
+    bit addr_phase_write  = (write && channel == AddrChannel);
+    bit data_phase_read   = (!write && channel == DataChannel);
+    bit data_phase_write  = (write && channel == DataChannel);
+
+    // if access was to a valid csr, get the csr handle
+    if (csr_addr inside {cfg.csr_addrs}) begin
+      csr = ral.default_map.get_reg_by_offset(csr_addr);
+      `DV_CHECK_NE_FATAL(csr, null)
+    end
+    else begin
+      `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
+    end
+
+    // if incoming access is a write to a valid csr, then make updates right away
+    if (addr_phase_write) begin
+      void'(csr.predict(.value(item.a_data), .kind(UVM_PREDICT_WRITE), .be(item.a_mask)));
+    end
+
+    // process the csr req
+    // for write, update local variable and fifo at address phase
+    // for read, update predication at address phase and compare at data phase
+    case (csr.get_name())
+      // add individual case item for each csr
+      "intr_state": begin
+        // FIXME
+        do_read_check = 1'b0;
+      end
+      "intr_enable": begin
+        // FIXME
+      end
+      "intr_test": begin
+        // FIXME
+      end
+      default: begin
+        `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
+      end
+    endcase
+
+    // On reads, if do_read_check, is set, then check mirrored_value against item.d_data
+    if (data_phase_read) begin
+      if (do_read_check) begin
+        `DV_CHECK_EQ(csr.get_mirrored_value(), item.d_data,
+                     $sformatf("reg name: %0s", csr.get_full_name()))
+      end
+      void'(csr.predict(.value(item.d_data), .kind(UVM_PREDICT_READ)));
+    end
+  endtask
+
+  virtual function void reset(string kind = "HARD");
+    super.reset(kind);
+    // reset local fifos queues and variables
+  endfunction
+
+  function void check_phase(uvm_phase phase);
+    super.check_phase(phase);
+    // post test checks - ensure that all local fifos and queues are empty
+  endfunction
+
+endclass

--- a/hw/ip/kmac/dv/env/kmac_virtual_sequencer.sv
+++ b/hw/ip/kmac/dv/env/kmac_virtual_sequencer.sv
@@ -1,0 +1,13 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class kmac_virtual_sequencer extends cip_base_virtual_sequencer #(
+    .CFG_T(kmac_env_cfg),
+    .COV_T(kmac_env_cov)
+  );
+  `uvm_component_utils(kmac_virtual_sequencer)
+
+  `uvm_component_new
+
+endclass

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_base_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_base_vseq.sv
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class kmac_base_vseq extends cip_base_vseq #(
+    .RAL_T               (kmac_reg_block),
+    .CFG_T               (kmac_env_cfg),
+    .COV_T               (kmac_env_cov),
+    .VIRTUAL_SEQUENCER_T (kmac_virtual_sequencer)
+  );
+  `uvm_object_utils(kmac_base_vseq)
+
+  // various knobs to enable certain routines
+  bit do_kmac_init = 1'b1;
+
+  `uvm_object_new
+
+  virtual task dut_init(string reset_kind = "HARD");
+    super.dut_init();
+    if (do_kmac_init) kmac_init();
+  endtask
+
+  virtual task dut_shutdown();
+    // check for pending kmac operations and wait for them to complete
+    // TODO
+  endtask
+
+  // setup basic kmac features
+  virtual task kmac_init();
+    `uvm_error(`gfn, "FIXME")
+  endtask
+
+endclass : kmac_base_vseq

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_common_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_common_vseq.sv
@@ -1,0 +1,17 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class kmac_common_vseq extends kmac_base_vseq;
+  `uvm_object_utils(kmac_common_vseq)
+
+  constraint num_trans_c {
+    num_trans inside {[1:2]};
+  }
+  `uvm_object_new
+
+  virtual task body();
+    run_common_vseq_wrapper(num_trans);
+  endtask : body
+
+endclass

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_sanity_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_sanity_vseq.sv
@@ -1,0 +1,14 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// basic sanity test vseq
+class kmac_sanity_vseq extends kmac_base_vseq;
+  `uvm_object_utils(kmac_sanity_vseq)
+
+  `uvm_object_new
+
+  task body();
+  endtask : body
+
+endclass : kmac_sanity_vseq

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_vseq_list.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_vseq_list.sv
@@ -1,0 +1,7 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`include "kmac_base_vseq.sv"
+`include "kmac_sanity_vseq.sv"
+`include "kmac_common_vseq.sv"

--- a/hw/ip/kmac/dv/kmac_sim.core
+++ b/hw/ip/kmac/dv/kmac_sim.core
@@ -1,0 +1,29 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:kmac_sim:0.1"
+description: "KMAC DV sim target"
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:ip:kmac
+
+  files_dv:
+    depend:
+      - lowrisc:dv:kmac_test
+      - lowrisc:dv:kmac_sva
+    files:
+      - tb.sv
+    file_type: systemVerilogSource
+
+targets:
+  sim: &sim_target
+    toplevel: tb
+    filesets:
+      - files_rtl
+      - files_dv
+    default_tool: vcs
+
+  lint:
+    <<: *sim_target

--- a/hw/ip/kmac/dv/kmac_sim_cfg.hjson
+++ b/hw/ip/kmac/dv/kmac_sim_cfg.hjson
@@ -1,0 +1,63 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  // Name of the sim cfg - typically same as the name of the DUT.
+  name: kmac
+
+  // Top level dut name (sv module).
+  dut: kmac
+
+  // Top level testbench name (sv module).
+  tb: tb
+
+  // Simulator used to sign off this block
+  tool: vcs
+
+  // Fusesoc core file used for building the file list.
+  fusesoc_core: lowrisc:dv:kmac_sim:0.1
+
+  // Testplan hjson file.
+  testplan: "{proj_root}/hw/ip/kmac/data/kmac_testplan.hjson"
+
+  // RAL spec - used to generate the RAL model.
+  ral_spec: "{proj_root}/hw/ip/kmac/data/kmac.hjson"
+
+  // Import additional common sim cfg files.
+  // TODO: remove imported cfgs that do not apply.
+  import_cfgs: [// Project wide common sim cfg file
+                "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",
+                // Common CIP test lists
+                "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
+                "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
+                "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
+                "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
+
+  // Add additional tops for simulation.
+  sim_tops: ["-top kmac_bind"]
+
+  // Default iterations for all tests - each test entry can override this.
+  reseed: 50
+
+  // Default UVM test and seq class name.
+  uvm_test: kmac_base_test
+  uvm_test_seq: kmac_base_vseq
+
+  // List of test specifications.
+  tests: [
+    {
+      name: kmac_sanity
+      uvm_test_seq: kmac_sanity_vseq
+    }
+
+    // TODO: add more tests here
+  ]
+
+  // List of regressions.
+  regressions: [
+    {
+      name: sanity
+      tests: ["kmac_sanity"]
+    }
+  ]
+}

--- a/hw/ip/kmac/dv/sva/kmac_bind.sv
+++ b/hw/ip/kmac/dv/sva/kmac_bind.sv
@@ -1,0 +1,26 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+module kmac_bind;
+
+  bind kmac tlul_assert #(
+    .EndpointType("Device")
+  ) tlul_assert_device (
+    .clk_i,
+    .rst_ni,
+    .h2d  (tl_i),
+    .d2h  (tl_o)
+  );
+
+  import kmac_reg_pkg::*;
+  bind kmac kmac_csr_assert_fpv kmac_csr_assert (
+    .clk_i,
+    .rst_ni,
+    .h2d    (tl_i),
+    .d2h    (tl_o),
+    .reg2hw (reg2hw),
+    .hw2reg (hw2reg)
+  );
+
+endmodule

--- a/hw/ip/kmac/dv/sva/kmac_sva.core
+++ b/hw/ip/kmac/dv/sva/kmac_sva.core
@@ -1,0 +1,28 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:kmac_sva:0.1"
+description: "KMAC assertion modules and bind file."
+filesets:
+  files_dv:
+    depend:
+      - lowrisc:tlul:headers
+      - lowrisc:fpv:csr_assert_gen
+    files:
+      - kmac_bind.sv
+    file_type: systemVerilogSource
+
+generate:
+  csr_assert_gen:
+    generator: csr_assert_gen
+    parameters:
+      spec: ../../data/kmac.hjson
+      depend: lowrisc:ip:kmac
+
+targets:
+  default:
+    filesets:
+      - files_dv
+    generate:
+      - csr_assert_gen

--- a/hw/ip/kmac/dv/tb.sv
+++ b/hw/ip/kmac/dv/tb.sv
@@ -1,0 +1,65 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+module tb;
+  // dep packages
+  import uvm_pkg::*;
+  import dv_utils_pkg::*;
+  import kmac_env_pkg::*;
+  import kmac_test_pkg::*;
+
+  // macro includes
+  `include "uvm_macros.svh"
+  `include "dv_macros.svh"
+
+  wire clk, rst_n;
+  wire devmode;
+  wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
+  // Interrupt wires
+  wire intr_kmac_done, intr_kmac_fifo_empty, intr_kmac_err;
+
+  // interfaces
+  clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
+  pins_if #(NUM_MAX_INTERRUPTS) intr_if(interrupts);
+  pins_if #(1) devmode_if(devmode);
+  tl_if tl_if(.clk(clk), .rst_n(rst_n));
+
+  // dut
+  kmac dut (
+    .clk_i                (clk                  ),
+    .rst_ni               (rst_n                ),
+
+    // TLUL interface
+    .tl_i                 (tl_if.h2d            ),
+    .tl_o                 (tl_if.d2h            ),
+
+    // Interrupts
+    .intr_kmac_done_o     (intr_kmac_done       ),
+    .intr_fifo_empty_o    (intr_kmac_fifo_empty ),
+    .intr_kmac_err_o      (intr_kmac_err        )
+
+    // TODO: hook up interfaces for:
+    //
+    // 1) keymgr sideload
+    // 2) keymgr KDF
+    // 3) csrng/edn
+  );
+
+  // Bind interrupt wires to interrupt interface
+  assign interrupts[KmacDone]       = intr_kmac_done;
+  assign interrupts[KmacFifoEmpty]  = intr_kmac_fifo_empty;
+  assign interrupts[KmacErr]        = intr_kmac_done;
+
+  initial begin
+    // drive clk and rst_n from clk_if
+    clk_rst_if.set_active();
+    uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
+    uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
+    uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
+    uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
+    $timeformat(-12, 0, " ps", 12);
+    run_test();
+  end
+
+endmodule

--- a/hw/ip/kmac/dv/tests/kmac_base_test.sv
+++ b/hw/ip/kmac/dv/tests/kmac_base_test.sv
@@ -1,0 +1,20 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class kmac_base_test extends cip_base_test #(
+    .CFG_T(kmac_env_cfg),
+    .ENV_T(kmac_env)
+  );
+
+  `uvm_component_utils(kmac_base_test)
+  `uvm_component_new
+
+  // the base class dv_base_test creates the following instances:
+  // kmac_env_cfg: cfg
+  // kmac_env:     env
+
+  // the base class also looks up UVM_TEST_SEQ plusarg to create and run that seq in
+  // the run_phase; as such, nothing more needs to be done
+
+endclass : kmac_base_test

--- a/hw/ip/kmac/dv/tests/kmac_test.core
+++ b/hw/ip/kmac/dv/tests/kmac_test.core
@@ -1,0 +1,19 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:kmac_test:0.1"
+description: "KMAC DV UVM test"
+filesets:
+  files_dv:
+    depend:
+      - lowrisc:dv:kmac_env
+    files:
+      - kmac_test_pkg.sv
+      - kmac_base_test.sv: {is_include_file: true}
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_dv

--- a/hw/ip/kmac/dv/tests/kmac_test_pkg.sv
+++ b/hw/ip/kmac/dv/tests/kmac_test_pkg.sv
@@ -1,0 +1,22 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package kmac_test_pkg;
+  // dep packages
+  import uvm_pkg::*;
+  import cip_base_pkg::*;
+  import kmac_env_pkg::*;
+
+  // macro includes
+  `include "uvm_macros.svh"
+  `include "dv_macros.svh"
+
+  // local types
+
+  // functions
+
+  // package sources
+  `include "kmac_base_test.sv"
+
+endpackage

--- a/hw/top_earlgrey/lint/top_earlgrey_dv_lint_cfgs.hjson
+++ b/hw/top_earlgrey/lint/top_earlgrey_dv_lint_cfgs.hjson
@@ -61,6 +61,12 @@
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
                   rel_path: "hw/ip/keymgr/dv/lint/{tool}"
              },
+             {
+                  name: kmac
+                  fusesoc_core: lowrisc:dv:kmac_sim
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/kmac/dv/lint/{tool}"
+             },
              {    name: otp_ctrl
                   fusesoc_core: lowrisc:dv:otp_ctrl_sim
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]


### PR DESCRIPTION
This PR creates the barebones KMAC testbench extended from cip_lib, and
as such mostly just consists of the skeleton code generated by uvmdvgen
tool.

With this PR, the testbench can compile successfully - no tests exist as
of now but will be added later.

The DV documentation will be filled out later as well.

Signed-off-by: Udi Jonnalagadda <udij@google.com>