### PR TITLE
[dvsim] HJSon fixes, rewrite exports as a list of dicts

### DIFF
--- a/hw/dv/tools/dvsim/common_sim_cfg.hjson
+++ b/hw/dv/tools/dvsim/common_sim_cfg.hjson
@@ -75,12 +75,12 @@
 
   // Default list of things to export to shell
   exports: [
-    TOOL_SRCS_DIR: {tool_srcs_dir}
-    EN_WAVES: {waves}
-    DUMP_FMT: {dump_fmt}
-    DUT_TOP: {dut}
-    TB_TOP: {tb}
-    dut_instance: {dut_instance}
+    { TOOL_SRCS_DIR: "{tool_srcs_dir}" },
+    { EN_WAVES: "{waves}" },
+    { DUMP_FMT: "{dump_fmt}" },
+    { DUT_TOP: "{dut}" },
+    { TB_TOP: "{tb}" },
+    { dut_instance: "{dut_instance}" }
   ]
 
   // Build modes are collection of build_opts and run_opts

--- a/hw/dv/tools/dvsim/dsim.hjson
+++ b/hw/dv/tools/dvsim/dsim.hjson
@@ -72,7 +72,9 @@
                      "-elfile {vcs_cov_excl_files}"]
 
   // Vars that need to exported to the env.
-  exports: []
+  exports: [
+    { LD_LIBRARY_PATH: "{DSIM_HOME}/lib:{LD_LIBRARY_PATH}" }
+  ]
 
   // Defaults for DSim
   // TODO: there is currently no equivalent of "all" coverage metrics in DSim

--- a/hw/dv/tools/dvsim/dsim.hjson
+++ b/hw/dv/tools/dvsim/dsim.hjson
@@ -5,8 +5,7 @@
   build_cmd:  "{job_prefix} dsim"
   run_cmd:    "{job_prefix} dsim"
 
-  build_opts: [
-               "-work {build_dir}/dsim_out",
+  build_opts: ["-work {build_dir}/dsim_out",
                "-genimage image",
                "-sv",
                // Set parallel compilation jobs limit
@@ -21,16 +20,14 @@
                "+incdir+{build_dir}",
                // Suppress following DSim errors and warnings:
                //   EnumMustBePositive - UVM 1.2 violates this
-               "-suppress EnumMustBePositive"
-              ]
+               "-suppress EnumMustBePositive"]
 
-  run_opts:   [
-               "-work {build_dir}/dsim_out",
+  run_opts:   ["-work {build_dir}/dsim_out",
                "-image image",
                // UVM DPI
                "-sv_lib {DSIM_HOME}/lib/libuvm_dpi.so",
                "-sv_seed {seed}",
-               // tell DSim to write line-buffered std output (lines will be written in proper order)
+               // tell DSim to write line-buffered stdout (lines will be written in proper order)
                "-linebuf",
                "+UVM_TESTNAME={uvm_test}",
                "+UVM_TEST_SEQ={uvm_test_seq}"]
@@ -38,7 +35,7 @@
   // Indicate the tool specific helper sources - these are copied over to the
   // {tool_srcs_dir} before running the simulation.
   // TODO, there is no dsim tool file, point to vcs for now to avoid error from script
-  tool_srcs:  ["{dv_root}/tools/vcs/*"]
+  tool_srcs: ["{dv_root}/tools/vcs/*"]
 
   // TODO: refactor coverage configuration for DSim.
 
@@ -56,13 +53,12 @@
   cov_merge_dir:    "{scratch_base_path}/cov_merge"
   cov_merge_db_dir: "{cov_merge_dir}/merged.vdb"
   cov_merge_cmd:    "{job_prefix} urg"
-  cov_merge_opts:   [
-                    ]
+  cov_merge_opts:   []
+
   // Generate coverage reports in text as well as html.
   cov_report_dir:   "{scratch_base_path}/cov_report"
   cov_report_cmd:   "{job_prefix} urg"
-  cov_report_opts:  [
-                    ]
+  cov_report_opts:  []
   cov_report_txt:   "{cov_report_dir}/dashboard.txt"
   cov_report_page:  "dashboard.html"
 
@@ -72,40 +68,35 @@
   cov_analyze_cmd:  "{job_prefix} verdi"
   cov_analyze_opts: ["-cov",
                      "-covdir {cov_merge_db_dir}",
-                     "-line nocasedef"
+                     "-line nocasedef",
                      "-elfile {vcs_cov_excl_files}"]
 
   // Vars that need to exported to the env.
-  exports: [
-  ]
+  exports: []
 
   // Defaults for DSim
   // TODO: there is currently no equivalent of "all" coverage metrics in DSim
-  cov_metrics:         ""
+  cov_metrics: ""
 
   // pass and fail patterns
   build_fail_patterns: ["^Error-.*$"]
   run_fail_patterns:   ["^Error-.*$"] // Null pointer error
 
   // waveform
-  wave_type:           "vcd"
-  wave_file:           "dsim_wave.{wave_type}"
-  probe_file:          "dsim.probe"
+  wave_type:  "vcd"
+  wave_file:  "dsim_wave.{wave_type}"
+  probe_file: "dsim.probe"
 
   build_modes: [
     {
       name: dsim_waves
       is_sim_mode: 1
-      build_opts: [
-                    "+acc+b"
-                  ]
-      run_opts:   [
-                    "-waves {wave_file}",
-                    // dsim.probe is currently undefined
-                    //"-wave-scope-specs {probe_file}",
-                    // Dump unpacked structs and arrays.
-                    "-dump-agg"
-                  ]
+      build_opts: ["+acc+b"]
+      run_opts:   ["-waves {wave_file}",
+                   // dsim.probe is currently undefined
+                   //"-wave-scope-specs {probe_file}",
+                   // Dump unpacked structs and arrays.
+                   "-dump-agg"]
     }
     // TODO: support coverage mode
     // Note: no specific build or run options are required for dsim to produce functional

--- a/hw/dv/tools/dvsim/vcs.hjson
+++ b/hw/dv/tools/dvsim/vcs.hjson
@@ -149,8 +149,8 @@
 
   // Vars that need to exported to the env.
   exports: [
-    VCS_ARCH_OVERRIDE: linux
-    VCS_LIC_EXPIRE_WARNING: 1
+    { VCS_ARCH_OVERRIDE: "linux" },
+    { VCS_LIC_EXPIRE_WARNING: 1 }
   ]
 
   // Defaults for VCS

--- a/hw/dv/tools/dvsim/xcelium.hjson
+++ b/hw/dv/tools/dvsim/xcelium.hjson
@@ -33,18 +33,19 @@
   // Vars that need to exported to the env.
   exports: [
     // Poll for an available license in all servers.
-    CDS_LIC_QUEUE_POLL: 1
+    { CDS_LIC_QUEUE_POLL: 1 },
+
     // Poll for an available license every 1 min.
-    CDS_LIC_QUEUE_POLL_INT: 60
+    { CDS_LIC_QUEUE_POLL_INT: 60 },
 
     // X-prop related: these were suggested by Xcelium as warnings during the build time.
     // These enable array corruption when the index is out of range or invalid.
-    VL_ENABLE_INVALID_IDX_XPROP: 1
-    VL_ENABLE_OUTOFRANGE_IDX_XPROP: 1
+    { VL_ENABLE_INVALID_IDX_XPROP: 1 },
+    { VL_ENABLE_OUTOFRANGE_IDX_XPROP: 1 },
 
     // Export the cov_report path so that the tcl file can read these as env vars.
-    cov_merge_db_dir: "{cov_merge_db_dir}"
-    cov_report_dir:   "{cov_report_dir}"
+    { cov_merge_db_dir: "{cov_merge_db_dir}" },
+    { cov_report_dir: "{cov_report_dir}" }
   ]
 
   // Coverage related.
@@ -57,7 +58,7 @@
 
   // Supply the cov refinement files.
   // Note that this needs to be set as -load_refinement <file>.
-  xcelium_cov_refine_files: [""]
+  xcelium_cov_refine_files: []
 
   // Set the coverage directories.
   cov_work_dir: "{scratch_path}/coverage"

--- a/hw/formal/tools/dvsim/common_fpv_cfg.hjson
+++ b/hw/formal/tools/dvsim/common_fpv_cfg.hjson
@@ -32,9 +32,10 @@
 
   // Vars that need to exported to the env
   exports: [
-    FPV_TOP: {dut}
-    COV:     {cov}
+    { FPV_TOP: "{dut}" },
+    { COV: "{cov}" }
   ]
+
   report_cmd:  "python3 {proj_root}/hw/formal/tools/{tool}/parse-fpv-report.py"
   report_opts: ["--logpath={build_dir}/fpv.log",
                 "--reppath={build_dir}/results.hjson",

--- a/hw/syn/tools/dvsim/dc.hjson
+++ b/hw/syn/tools/dvsim/dc.hjson
@@ -12,10 +12,12 @@
               "{foundry_sdc_path}/{foundry_sdc_file}"]
 
   // Environment variables that are needed in the synthesis script
-  exports: [{"DUT"       : "{dut}"},
-            {"CONSTRAINT": "{sdc_file}"},
-            {"BUILD_DIR" : "{build_dir}"},
-            {"SV_FLIST"  : "{sv_flist}"}]
+  exports: [
+    { DUT:        "{dut}" },
+    { CONSTRAINT: "{sdc_file}" },
+    { BUILD_DIR:  "{build_dir}" },
+    { SV_FLIST:   "{sv_flist}" }
+  ]
 
   // Tool invocation
   build_cmd:  "{job_prefix} dc_shell-xg-t "
@@ -25,7 +27,7 @@
   report_cmd: "{proj_root}/hw/syn/tools/{tool}/parse-syn-report.py --depth {area_depth}"
   report_opts: ["--dut {dut}",
                 "--logpath {build_dir} ",
-                "--reppath {build_dir}/REPORTS/ ",
+                "--reppath {build_dir}/REPORTS",
                 "--outdir {build_dir}"]
 
   // Restrict the maximum message count in each category

--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -75,7 +75,7 @@ class Deploy():
         self.renew_odir = False
 
         # List of vars required to be exported to sub-shell
-        self.exports = {}
+        self.exports = None
 
         # Deploy sub commands
         self.sub = []
@@ -157,8 +157,35 @@ class Deploy():
         self.odir_ln = os.path.basename(os.path.normpath(self.odir))
         self.log = self.odir + "/" + self.target + ".log"
 
+        # Make exports more easily mergeable with the current process' env.
+        self._process_exports()
+
         # If using LSF, redirect stdout and err to the log file
         self.cmd = self.construct_cmd()
+
+    def _process_exports(self):
+        '''Convert 'exports' as a list of dicts in the HJson to a dict.
+
+        Exports is a list of key-value pairs that are to be exported to the
+        subprocess' environment so that the tools can lookup those options.
+        DVSim limits how the data is presented in the HJson (the value of a
+        HJson member cannot be an object). This method converts a list of dicts
+        into a dict variable, which makes it easy to merge the list of exports
+        with the subprocess' env where the ASIC tool is invoked.
+        '''
+        exports_dict = {}
+        if self.exports:
+            try:
+                exports_dict = {
+                    k: str(v)
+                    for item in self.exports for k, v in item.items()
+                }
+            except ValueError as e:
+                log.error(
+                    "%s: exports: \'%s\' Exports key must be a list of dicts!",
+                    e, str(self.exports))
+                sys.exit(1)
+        self.exports = exports_dict
 
     def construct_cmd(self):
         cmd = "make -f " + self.flow_makefile + " " + self.target
@@ -216,7 +243,11 @@ class Deploy():
         return True
 
     def dispatch_cmd(self):
-        self.exports.update(os.environ)
+        # Update the shell's env vars with self.exports. Values in exports must
+        # replace the values in the shell's env vars if the keys match.
+        exports = os.environ.copy()
+        exports.update(self.exports)
+
         args = shlex.split(self.cmd)
         try:
             # If renew_odir flag is True - then move it.
@@ -228,8 +259,8 @@ class Deploy():
                       "w",
                       encoding="UTF-8",
                       errors="surrogateescape") as f:
-                for var in sorted(self.exports.keys()):
-                    f.write("{}={}\n".format(var, self.exports[var]))
+                for var in sorted(exports.keys()):
+                    f.write("{}={}\n".format(var, exports[var]))
                 f.close()
             os.system("ln -s " + self.odir + " " + self.sim_cfg.links['D'] +
                       '/' + self.odir_ln)
@@ -241,7 +272,7 @@ class Deploy():
                                             universal_newlines=True,
                                             stdout=f,
                                             stderr=f,
-                                            env=self.exports)
+                                            env=exports)
             self.log_fd = f
             self.status = "D"
             Deploy.dispatch_counter += 1

--- a/util/dvsim/FlowCfg.py
+++ b/util/dvsim/FlowCfg.py
@@ -379,25 +379,6 @@ class FlowCfg():
             log.error("Override key \"%s\" not found in the cfg!", ov_name)
             sys.exit(1)
 
-    def _process_exports(self):
-        # Convert 'exports' to dict
-        exports_dict = {}
-        if self.exports != []:
-            for item in self.exports:
-                if type(item) is dict:
-                    exports_dict.update(item)
-                elif type(item) is str:
-                    [key, value] = item.split(':', 1)
-                    if type(key) is not str:
-                        key = str(key)
-                    if type(value) is not str:
-                        value = str(value)
-                    exports_dict.update({key.strip(): value.strip()})
-                else:
-                    log.error("Type error in \"exports\": %s", str(item))
-                    sys.exit(1)
-        self.exports = exports_dict
-
     def _purge(self):
         '''Purge the existing scratch areas in preperation for the new run.'''
         return

--- a/util/dvsim/OneShotCfg.py
+++ b/util/dvsim/OneShotCfg.py
@@ -109,8 +109,6 @@ class OneShotCfg(FlowCfg):
             if not hasattr(self, "build_mode"):
                 setattr(self, "build_mode", "default")
 
-            self._process_exports()
-
             # Create objects from raw dicts - build_modes, sim_modes, run_modes,
             # tests and regressions, only if not a primary cfg obj
             self._create_objects()

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -172,7 +172,7 @@ class SimCfg(FlowCfg):
         # the configuration format because our choice might depend on the
         # chosen tool.
         self.dump_fmt = (resolve_dump_format(self.tool, args.dump)
-                         if self.waves else 'none')
+                         if self.waves and not self.is_primary_cfg else 'none')
 
         # If build_unique is set, then add current timestamp to uniquify it
         if self.build_unique:
@@ -224,8 +224,6 @@ class SimCfg(FlowCfg):
             # Use the default build mode for tests that do not specify it
             if not hasattr(self, "build_mode"):
                 self.build_mode = 'default'
-
-            self._process_exports()
 
             # Create objects from raw dicts - build_modes, sim_modes, run_modes,
             # tests and regressions, only if not a primary cfg obj


### PR DESCRIPTION
The first commit contains fixes and cleaups in the HJSon files, including updating the exports key to be a list of dicts instead of a list of strings. 

The second commit moves the `process_exports` to the `Deploy` class since it is not necessary to look it up in `FlowCfg` or it's extensions. It also simplifies the method a bit now that it is already a list of dicts. 