### PR TITLE
[dv/push_pull_agent]

### DIFF
--- a/hw/dv/sv/push_pull_agent/push_pull_device_driver.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_device_driver.sv
@@ -67,12 +67,12 @@ class push_pull_device_driver #(parameter int DataWidth = 32) extends push_pull_
     end
     if (!in_reset) begin
       `PULL_DRIVER.ack_int  <= 1'b1;
-      `PULL_DRIVER.data     <= req.data;
+      `PULL_DRIVER.data_int <= req.data;
     end
     @(`PULL_DRIVER);
     if (!in_reset) begin
       `PULL_DRIVER.ack_int  <= 1'b0;
-      `PULL_DRIVER.data     <= 'x;
+      `PULL_DRIVER.data_int <= 'x;
     end
   endtask
 

--- a/hw/dv/sv/push_pull_agent/push_pull_host_driver.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_host_driver.sv
@@ -55,14 +55,14 @@ class push_pull_host_driver #(parameter int DataWidth = 32) extends push_pull_dr
     end
     if (!in_reset) begin
       `PUSH_DRIVER.valid_int <= 1'b1;
-      `PUSH_DRIVER.data      <= req.data;
+      `PUSH_DRIVER.data_int  <= req.data;
     end
     do begin
       @(`PUSH_DRIVER);
     end while (!`PUSH_DRIVER.ready && !in_reset);
     if (!in_reset) begin
       `PUSH_DRIVER.valid_int <= 1'b0;
-      `PUSH_DRIVER.data      <= 'x;
+      `PUSH_DRIVER.data_int  <= 'x;
     end
   endtask
 

--- a/hw/dv/sv/push_pull_agent/push_pull_if.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_if.sv
@@ -40,7 +40,7 @@ interface push_pull_if #(parameter int DataWidth = 32) (input wire clk, input wi
   clocking host_push_cb @(posedge clk);
     input   ready;
     output  valid_int;
-    output  data;
+    output  data_int;
   endclocking
 
   clocking device_push_cb @(posedge clk);
@@ -58,7 +58,7 @@ interface push_pull_if #(parameter int DataWidth = 32) (input wire clk, input wi
   clocking device_pull_cb @(posedge clk);
     input   req;
     output  ack_int;
-    output  data;
+    output  data_int;
   endclocking
 
   clocking mon_cb @(posedge clk);


### PR DESCRIPTION
When pull agent is config to Device mode, data has X and this PR fix it
by assigning the driver data to data_int rather than data directly.

Signed-off-by: Cindy Chen <chencindy@google.com>