### PR TITLE
[dv/otp] connect remaining interfaces

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.core
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.core
@@ -13,6 +13,7 @@ filesets:
       - lowrisc:dv:push_pull_agent
     files:
       - otp_ctrl_env_pkg.sv
+      - otp_ctrl_output_data_if.sv
       - otp_ctrl_env_cfg.sv: {is_include_file: true}
       - otp_ctrl_env_cov.sv: {is_include_file: true}
       - otp_ctrl_virtual_sequencer.sv: {is_include_file: true}

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
@@ -9,12 +9,14 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_reg_block));
   rand push_pull_agent_cfg#(OTBN_DATA_SIZE)  m_otbn_pull_agent_cfg;
   rand push_pull_agent_cfg#(FLASH_DATA_SIZE) m_flash_data_pull_agent_cfg;
   rand push_pull_agent_cfg#(FLASH_DATA_SIZE) m_flash_addr_pull_agent_cfg;
+  rand push_pull_agent_cfg#(EDN_DATA_SIZE)   m_edn_pull_agent_cfg;
 
   // ext interfaces
-  pwr_otp_vif         pwr_otp_vif;
-  lc_provision_en_vif lc_provision_en_vif;
-  lc_dft_en_vif       lc_dft_en_vif;
-  mem_bkdr_vif        mem_bkdr_vif;
+  pwr_otp_vif              pwr_otp_vif;
+  lc_provision_en_vif      lc_provision_en_vif;
+  lc_dft_en_vif            lc_dft_en_vif;
+  mem_bkdr_vif             mem_bkdr_vif;
+  otp_ctrl_output_data_vif otp_ctrl_output_data_vif;
 
   `uvm_object_utils_begin(otp_ctrl_env_cfg)
   `uvm_object_utils_end
@@ -22,6 +24,7 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_reg_block));
   `uvm_object_new
 
   virtual function void initialize(bit [31:0] csr_base_addr = '1);
+    list_of_alerts = otp_ctrl_env_pkg::LIST_OF_ALERTS;
     super.initialize(csr_base_addr);
 
     // create push_pull agent config obj
@@ -41,6 +44,12 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_reg_block));
     m_flash_addr_pull_agent_cfg = push_pull_agent_cfg#(FLASH_DATA_SIZE)::type_id::create
                                   ("m_flash_addr_pull_agent_cfg");
     m_flash_addr_pull_agent_cfg.agent_type = PullAgent;
+
+    m_edn_pull_agent_cfg = push_pull_agent_cfg#(EDN_DATA_SIZE)::type_id::create
+                           ("m_edn_pull_agent_cfg");
+    m_edn_pull_agent_cfg.agent_type = PullAgent;
+    m_edn_pull_agent_cfg.if_mode    = Device;
+
 
     // set num_interrupts & num_alerts
     begin

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -23,6 +23,9 @@ package otp_ctrl_env_pkg;
   `include "dv_macros.svh"
 
   // parameters
+  parameter string LIST_OF_ALERTS[]      = {"otp_macro_failure", "otp_check_failure"};
+  parameter uint NUM_ALERTS              = 2;
+
   parameter uint DIGEST_SIZE             = 8;
   parameter uint SW_WINDOW_BASE_ADDR     = 'h1000;
   parameter uint TEST_ACCESS_BASE_ADDR   = 'h2000;
@@ -35,6 +38,8 @@ package otp_ctrl_env_pkg;
   parameter uint OTBN_DATA_SIZE  = 1 + OtbnKeyWidth + OtbnNonceWidth;
   // flash rsp data has 1 bit for seed_valid, the rest are for key
   parameter uint FLASH_DATA_SIZE = 1 + FlashKeyWidth;
+  // edn rsp data are key width
+  parameter uint EDN_DATA_SIZE   = EdnDataWidth;
 
   // lc does not have digest
   parameter bit[10:0] DIGESTS_ADDR [NumPart-1] = {
@@ -47,10 +52,11 @@ package otp_ctrl_env_pkg;
   };
 
   // types
-  typedef virtual pins_if #(3) pwr_otp_vif;
-  typedef virtual pins_if #(4) lc_provision_en_vif;
-  typedef virtual pins_if #(4) lc_dft_en_vif;
-  typedef virtual mem_bkdr_if mem_bkdr_vif;
+  typedef virtual pins_if #(3)            pwr_otp_vif;
+  typedef virtual pins_if #(4)            lc_provision_en_vif;
+  typedef virtual pins_if #(4)            lc_dft_en_vif;
+  typedef virtual mem_bkdr_if             mem_bkdr_vif;
+  typedef virtual otp_ctrl_output_data_if otp_ctrl_output_data_vif;
 
   typedef enum bit [1:0] {
     OtpOperationDone,

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_output_data_if.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_output_data_if.sv
@@ -1,0 +1,14 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This interface collect the broadcast output data from OTP
+interface otp_ctrl_output_data_if();
+  import otp_ctrl_pkg::*;
+  import otp_ctrl_reg_pkg::*;
+
+  wire [HwCfgContentSize * 8-1:0] hw_cfg;
+  otp_keymgr_key_t                keymgr_key;
+  otp_lc_data_t                   lc_data;
+
+endinterface

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -16,6 +16,7 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
   uvm_tlm_analysis_fifo #(push_pull_item#(OTBN_DATA_SIZE))  otbn_fifo;
   uvm_tlm_analysis_fifo #(push_pull_item#(FLASH_DATA_SIZE)) flash_addr_fifo;
   uvm_tlm_analysis_fifo #(push_pull_item#(FLASH_DATA_SIZE)) flash_data_fifo;
+  uvm_tlm_analysis_fifo #(push_pull_item#(EDN_DATA_SIZE))   edn_fifo;
 
   // local queues to hold incoming packets pending comparison
 
@@ -29,6 +30,7 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
     otbn_fifo       = new("otbn_fifo", this);
     flash_addr_fifo = new("flash_addr_fifo", this);
     flash_data_fifo = new("flash_data_fifo", this);
+    edn_fifo        = new("edn_fifo", this);
   endfunction
 
   function void connect_phase(uvm_phase phase);

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_virtual_sequencer.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_virtual_sequencer.sv
@@ -14,4 +14,5 @@ class otp_ctrl_virtual_sequencer extends cip_base_virtual_sequencer #(
   push_pull_sequencer#(OTBN_DATA_SIZE)  otbn_pull_sequencer_h;
   push_pull_sequencer#(FLASH_DATA_SIZE) flash_data_pull_sequencer_h;
   push_pull_sequencer#(FLASH_DATA_SIZE) flash_addr_pull_sequencer_h;
+  push_pull_sequencer#(EDN_DATA_SIZE)   edn_pull_sequencer_h;
 endclass

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -110,4 +110,5 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     `DV_CHECK_RANDOMIZE_FATAL(flash_data_pull_seq)
     `uvm_send(flash_data_pull_seq)
   endtask
+
 endclass : otp_ctrl_base_vseq

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_common_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_common_vseq.sv
@@ -19,6 +19,13 @@ class otp_ctrl_common_vseq extends otp_ctrl_base_vseq;
     wait(cfg.pwr_otp_vif.pins[2] == 1);
   endtask
 
+  task post_start();
+    super.post_start();
+    // Random CSR rw might trigger alert. Some alerts will conintuously be triggered until reset
+    // applied, which will cause alert_monitor phase_ready_to_end timeout.
+    apply_reset();
+  endtask
+
   virtual task body();
     run_common_vseq_wrapper(num_trans);
   endtask : body

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_lfsr_timer.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_lfsr_timer.sv
@@ -307,7 +307,7 @@ module otp_ctrl_lfsr_timer
       integ_chk_req_q <= '0;
       cnsty_chk_req_q <= '0;
       chk_timeout_q   <= 1'b0;
-      reseed_timer_q  <= '0;
+      reseed_timer_q  <= {ReseedTimerWidth{1'b1}};
     end else begin
       integ_cnt_q <= integ_cnt_d;
       cnsty_cnt_q <= cnsty_cnt_d;


### PR DESCRIPTION
This PR has two commits:
1. Connects all reminding interfaces within OTP_CTRL testbench:
   this includes:
   1). alert agent,
   2). edn pull device agent,
   3). temp connect LC, once push pull agent supports bi-direct data, will update to push-pull agent
   4). a virtual interface to collect broadcast data from OTP

2. An RTL enhancement to initialize lfsr_counter to all-ones to avoid `edn_req` fired at negedge reset.