### PR TITLE
[fpga] Add Vivado pre-synthesis hook, also setup hooks for CW305 board

### DIFF
--- a/hw/top_earlgrey/top_earlgrey_cw305.core
+++ b/hw/top_earlgrey/top_earlgrey_cw305.core
@@ -22,7 +22,22 @@ filesets:
       - data/clocks.xdc
     file_type: xdc
 
+  files_tcl:
+    files:
+      - util/vivado_setup_hooks.tcl: { file_type: tclSource }
+      # File copied by fusesoc into the workroot (the file containing the
+      # .eda.yml file), and referenced from vivado_setup_hooks.tcl
+      - util/vivado_hook_synth_design_pre.tcl: { file_type: user, copyto: vivado_hook_synth_design_pre.tcl }
+      - util/vivado_hook_write_bitstream_pre.tcl: { file_type: user, copyto: vivado_hook_write_bitstream_pre.tcl }
+      - util/vivado_hook_opt_design_post.tcl: { file_type: user, copyto: vivado_hook_opt_design_post.tcl }
+
 parameters:
+  # XXX: This parameter needs to be absolute, or relative to the *.runs/synth_1
+  # directory. It's best to pass it as absolute path when invoking fusesoc, e.g.
+  # --BootRomInitFile=$PWD/build-bin/sw/device/boot_rom/boot_rom_fpga_nexysvideo.32.vmem
+  # XXX: The VMEM file should be added to the sources of the Vivado project to
+  # make the Vivado dependency tracking work. However this requires changes to
+  # fusesoc first.
   BootRomInitFile:
     datatype: str
     description: Boot ROM initialization file in 32 bit vmem hex format
@@ -45,6 +60,7 @@ targets:
     filesets:
       - files_rtl_cw305
       - files_constraints
+      - files_tcl
     toplevel: top_earlgrey_cw305
     parameters:
       - BootRomInitFile

--- a/hw/top_earlgrey/top_earlgrey_nexysvideo.core
+++ b/hw/top_earlgrey/top_earlgrey_nexysvideo.core
@@ -26,6 +26,7 @@ filesets:
       - util/vivado_setup_hooks.tcl: { file_type: tclSource }
       # File copied by fusesoc into the workroot (the file containing the
       # .eda.yml file), and referenced from vivado_setup_hooks.tcl
+      - util/vivado_hook_synth_design_pre.tcl: { file_type: user, copyto: vivado_hook_synth_design_pre.tcl }
       - util/vivado_hook_write_bitstream_pre.tcl: { file_type: user, copyto: vivado_hook_write_bitstream_pre.tcl }
       - util/vivado_hook_opt_design_post.tcl: { file_type: user, copyto: vivado_hook_opt_design_post.tcl }
 

--- a/hw/top_earlgrey/util/vivado_hook_opt_design_post.tcl
+++ b/hw/top_earlgrey/util/vivado_hook_opt_design_post.tcl
@@ -2,15 +2,18 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-# Any change in ROM instances path should be updated in following two files
-# 1. hw/top_earlgrey/data/placement.xdc and
-# 2. hw/top_earlgrey/util/vivado_hook_opt_design_post.tcl
+# Hook to check BRAM implementation for ROM memory - Only used on the NexysVideo board.
+if {[string first nexysvideo [get_property TOP [current_design]]] != -1} {
+  # Any change in ROM instances path should be updated in following two files
+  # 1. hw/top_earlgrey/data/placement.xdc and
+  # 2. hw/top_earlgrey/util/vivado_hook_opt_design_post.tcl
 
-send_msg "Designcheck 2-1" INFO "Checking if ROM memory is mapped to BRAM memory."
+  send_msg "Designcheck 2-1" INFO "Checking if ROM memory is mapped to BRAM memory."
 
-if {[catch [get_cells -hierarchical -filter { NAME =~  "*rom_rom*rdata_o_reg_0" && PRIMITIVE_TYPE =~ BMEM.*.* }]]\
-&& [catch [get_cells -hierarchical -filter { NAME =~  "*rom_rom*rdata_o_reg_1" && PRIMITIVE_TYPE =~ BMEM.*.* }]] } {
-  send_msg "Designcheck 2-2" INFO "BRAM implementation found for ROM memory."
-} else {
-  send_msg "Designcheck 2-3" ERROR "BRAM implementation not found for ROM memory."
+  if {[catch [get_cells -hierarchical -filter { NAME =~  "*rom_rom*rdata_o_reg_0" && PRIMITIVE_TYPE =~ BMEM.*.* }]]\
+  && [catch [get_cells -hierarchical -filter { NAME =~  "*rom_rom*rdata_o_reg_1" && PRIMITIVE_TYPE =~ BMEM.*.* }]] } {
+    send_msg "Designcheck 2-2" INFO "BRAM implementation found for ROM memory."
+  } else {
+    send_msg "Designcheck 2-3" ERROR "BRAM implementation not found for ROM memory."
+  }
 }

--- a/hw/top_earlgrey/util/vivado_hook_synth_design_pre.tcl
+++ b/hw/top_earlgrey/util/vivado_hook_synth_design_pre.tcl
@@ -1,0 +1,13 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Change the severity of some messages.
+
+# Abort if the boot ROM init file cannot be found. This is normally just a critical warning
+# which is easily overlooked. The bitstream can still be generated but is not functional.
+set_msg_config -id {[Synth 8-4445]} -new_severity ERROR
+
+# Abort upon inferring latches. This is normally just a warning. We want to avoid that
+# code inferring latches ends up in the repo in the first place.
+set_msg_config -id {[Synth 8-327]} -new_severity ERROR

--- a/hw/top_earlgrey/util/vivado_setup_hooks.tcl
+++ b/hw/top_earlgrey/util/vivado_setup_hooks.tcl
@@ -8,7 +8,10 @@
 # fusesoc-generated workroot containing the Vivado project file
 set workroot [pwd]
 
-# Hook to check BRAM implementation for ROM memory
+# Pre synthesize design hook
+set_property STEPS.SYNTH_DESIGN.TCL.PRE "${workroot}/vivado_hook_synth_design_pre.tcl" [get_runs synth_1]
+
+# Post opt design hook
 set_property STEPS.OPT_DESIGN.TCL.POST "${workroot}/vivado_hook_opt_design_post.tcl" [get_runs impl_1]
 
 # TODO: This hook is not getting called by Vivado when running through our


### PR DESCRIPTION
This PR adds a new pre-synthesis to hook to change the severity of messages. Also, two warnings are changed to errors:
- If the boot ROM init file cannot be found, the tool should not proceed and generate a non-functional bitstream.
- If latches are automatically inferred during synthesis, the tool should abort. This helps to prevent that such code ends up in the repo. Currently there is again a latch inferred inside OTBN (See #3773). For this reason CI for this PR should fail at the moment.

Existing hooks are also enabled on the ChipWhisperer CW305 FPGA board except for the placement check of the boot ROM (specific to the NexysVideo, required to use the boot ROM splicing script).