### PR TITLE
[sw] Refactor exporting to only use BIN_DIR

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -24,10 +24,9 @@ if ot_version == 'undef'
   error('ot_version option not set. Please run meson with a valid OpenTitan version option.')
 endif
 
-dev_bin_dir = get_option('dev_bin_dir')
-host_bin_dir = get_option('host_bin_dir')
-if dev_bin_dir == 'undef' or host_bin_dir == 'undef'
-  error('dev_bin_dir option not set. Please run meson with a valid binary directory option.')
+bin_dir = get_option('bin_dir')
+if bin_dir == 'undef'
+  error('bin_dir option not set. Please run meson with a valid binary directory option.')
 endif
 tock_local = get_option('tock_local')
 

--- a/meson_init.sh
+++ b/meson_init.sh
@@ -157,12 +157,11 @@ else
   fi
 fi
 
-mkdir -p "$DEV_BIN_DIR"
+mkdir -p "$BIN_DIR"
 set -x
 meson $reconf \
   -Dot_version="$OT_VERSION" \
-  -Ddev_bin_dir="$DEV_BIN_DIR" \
-  -Dhost_bin_dir="$HOST_BIN_DIR" \
+  -Dbin_dir="$BIN_DIR" \
   -Dtock_local="$TOCK_LOCAL" \
   -Dkeep_includes="$FLAGS_keep_includes" \
   -Dcoverage="$FLAGS_coverage" \

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -3,13 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 option(
-  'dev_bin_dir',
-  type: 'string',
-  value: 'undef',
-)
-
-option(
-  'host_bin_dir',
+  'bin_dir',
   type: 'string',
   value: 'undef',
 )

--- a/sw/device/benchmarks/coremark/meson.build
+++ b/sw/device/benchmarks/coremark/meson.build
@@ -45,7 +45,7 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
 
   custom_target(
     'coremark_top_earlgrey_export_' + device_name,
-    command: export_embedded_target,
+    command: export_target_command,
     input: [
       coremark_top_earlgrey_elf,
       coremark_top_earlgrey_embedded,

--- a/sw/device/boot_rom/meson.build
+++ b/sw/device/boot_rom/meson.build
@@ -68,7 +68,7 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
 
   custom_target(
     'boot_rom_export_' + device_name,
-    command: export_embedded_target,
+    command: export_target_command,
     input: [boot_rom_elf, boot_rom_embedded],
     output: 'boot_rom_export_' + device_name,
     build_always_stale: true,

--- a/sw/device/examples/hello_usbdev/meson.build
+++ b/sw/device/examples/hello_usbdev/meson.build
@@ -37,7 +37,7 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
 
   custom_target(
     'hello_usbdev_export_' + device_name,
-    command: export_embedded_target,
+    command: export_target_command,
     input: [hello_usbdev_elf, hello_usbdev_embedded],
     output: 'hello_usbdev_export_' + device_name,
     build_always_stale: true,

--- a/sw/device/examples/hello_world/meson.build
+++ b/sw/device/examples/hello_world/meson.build
@@ -34,7 +34,7 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
 
   custom_target(
     'hello_world_export_' + device_name,
-    command: export_embedded_target,
+    command: export_target_command,
     input: [hello_world_elf, hello_world_embedded],
     output: 'hello_world_export_' + device_name,
     build_always_stale: true,

--- a/sw/device/mask_rom/meson.build
+++ b/sw/device/mask_rom/meson.build
@@ -41,7 +41,7 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
 
   custom_target(
     'mask_rom_export_' + device_name,
-    command: export_embedded_target,
+    command: export_target_command,
     input: [mask_rom_elf, mask_rom_embedded],
     output: 'mask_rom_export_' + device_name,
     build_always_stale: true,

--- a/sw/device/meson.build
+++ b/sw/device/meson.build
@@ -20,16 +20,6 @@ make_embedded_target = [
   '--outdir', '@OUTDIR@',
 ]
 
-# Arguments for custom_target, for copying a completed |make_embedded_target| into
-# the appropriate location under $BIN_DIR.
-export_embedded_target = [
-  meson.source_root() / 'util/export_target.sh',
-  dev_bin_dir,
-  'sw/device',
-  '@OUTDIR@',
-  '@INPUT@',
-]
-
 embedded_target_extra_link_args = [
   '-Wl,--build-id=none',
 ]

--- a/sw/device/riscv_compliance_support/meson.build
+++ b/sw/device/riscv_compliance_support/meson.build
@@ -28,7 +28,7 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
 
   custom_target(
     'riscv_compliance_support_export_' + device_name,
-    command: export_embedded_target,
+    command: export_target_command,
     input: [riscv_compliance_support],
     output: 'riscv_compliance_support_export_' + device_name,
     build_always_stale: true,

--- a/sw/device/rom_exts/meson.build
+++ b/sw/device/rom_exts/meson.build
@@ -99,7 +99,7 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
 
     custom_target(
       slot + '_export_' + device_name,
-      command: export_embedded_target,
+      command: export_target_command,
       input: [rom_ext_elf, rom_ext_embedded],
       output: slot + '_export_' + device_name,
       build_always_stale: true,

--- a/sw/device/sca/aes_serial/meson.build
+++ b/sw/device/sca/aes_serial/meson.build
@@ -33,7 +33,7 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
 
   custom_target(
     'aes_serial_export_' + device_name,
-    command: export_embedded_target,
+    command: export_target_command,
     input: [aes_serial_elf, aes_serial_embedded],
     output: 'aes_serial_export_' + device_name,
     build_always_stale: true,

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -134,7 +134,7 @@ foreach sw_test_name, sw_test_lib : sw_tests
 
     custom_target(
       sw_test_name + '_export_' + device_name,
-      command: export_embedded_target,
+      command: export_target_command,
       input: [sw_test_elf, sw_test_embedded],
       output: sw_test_name + '_export_' + device_name,
       build_always_stale: true,
@@ -172,7 +172,7 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
 
   custom_target(
     'crt_test_export_' + device_name,
-    command: export_embedded_target,
+    command: export_target_command,
     input: [crt_test_elf, crt_test_embedded],
     output: 'crt_test_export_' + device_name,
     build_always_stale: true,

--- a/sw/device/tock/meson.build
+++ b/sw/device/tock/meson.build
@@ -77,11 +77,10 @@ tock_bin = custom_target(
 
 custom_target(
   'tock_export',
-  command: export_embedded_target,
+  command: export_target_command,
   input: [tock_elf, tock_bin],
   depends: [tock_elf, tock_bin],
   output: 'tock',
   build_always_stale: true,
   build_by_default: false,
 )
-

--- a/sw/host/meson.build
+++ b/sw/host/meson.build
@@ -2,15 +2,5 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-# Arguments for custom_target, for copying a completed host binary into
-# the appropriate location under $BIN_DIR.
-export_host_target = [
-  meson.source_root() / 'util/export_target.sh',
-  host_bin_dir,
-  'sw/host',
-  '@OUTDIR@',
-  '@INPUT@',
-]
-
 subdir('vendor')
 subdir('spiflash')

--- a/sw/host/spiflash/meson.build
+++ b/sw/host/spiflash/meson.build
@@ -21,9 +21,8 @@ spiflash_bin = executable(
 custom_target(
   'spiflash_export',
   output: 'spiflash_export',
-  command: export_host_target,
+  command: export_target_command,
   input: spiflash_bin,
   build_always_stale: true,
   build_by_default: true,
 )
-

--- a/sw/meson.build
+++ b/sw/meson.build
@@ -2,6 +2,15 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+# A command, for use in custom_target(), to build artifacts into $BIN_DIR.
+export_target_command = [
+  meson.source_root() / 'util/export_target.sh',
+  bin_dir / 'sw',
+  'sw',
+  '@OUTDIR@',
+  '@INPUT@',
+]
+
 subdir('vendor')
 subdir('device')
 subdir('host')

--- a/util/build_consts.sh
+++ b/util/build_consts.sh
@@ -45,15 +45,6 @@ export OBJ_DIR
 readonly BIN_DIR="$BUILD_ROOT/build-bin"
 export BIN_DIR
 
-# $DEV_BIN_DIR is a subdirectory of $BIN_DIR where device build outputs (i.e.,
-# compiled programs that should run on the OpenTitan SoC) should be written.
-export DEV_BIN_DIR="$BIN_DIR/sw/device"
-
-# $HOST_BIN_DIR is a subdirectory of $BIN_DIR where host build outputs (i.e.,
-# compiled programs that should run on a host workstation or server) should be
-# written.
-export HOST_BIN_DIR="$BIN_DIR/sw/host"
-
 # $TOCK_SYMLINK is the symlink used when referencing a local checkout of tock to
 # build from.
 export TOCK_SYMLINK="$REPO_TOP/sw/device/tock/tock_local"

--- a/util/fpga/splice_nexysvideo.sh
+++ b/util/fpga/splice_nexysvideo.sh
@@ -17,12 +17,12 @@ set -e
 . util/build_consts.sh
 
 TARGET_PREFIX="sw/device/boot_rom/boot_rom_fpga_nexysvideo"
-TARGET="${DEV_BIN_DIR}/${TARGET_PREFIX}"
+TARGET="${BIN_DIR}/${TARGET_PREFIX}"
 FPGA_BUILD_DIR=build/lowrisc_systems_top_earlgrey_nexysvideo_0.1/synth-vivado/
 FPGA_BIT_NAME=lowrisc_systems_top_earlgrey_nexysvideo_0.1
 
 ./meson_init.sh
-ninja -C "$DEV_BIN_DIR" "${TARGET_PREFIX}.bin"
+ninja -C "$BIN_DIR" "${TARGET_PREFIX}.bin"
 
 srec_cat "${TARGET}.bin" -binary -offset 0x0 -o "${TARGET}.brammem" \
   -vmem -Output_Block_Size 4;


### PR DESCRIPTION
We build code in the object directory (build-out, $OBJ_DIR), and then export it
into the bin directory (build-bin, $BIN_DIR). Within BIN_DIR, we
conventionally follow/mirror the directory structure in the source tree.

Before this patch we constructed the sub-directories $BIN_DIR/sw/host
and $BIN_DIR/sw/device in build_consts.sh, and passed them individually
to meson. After this patch, we only pass $BIN_DIR to meson, and let its
build logic figure out the rest.

This allows for a simplification in the meson logic without changing the
directory structure we produce.

The motivation for this change is the pending addition of the sw/otbn
directory, which would duplicate the same functionality for a third
time.