### PR TITLE
[sw, tests] Add DIF Rstmgr sanity test + minor follow-up

### DIFF
--- a/hw/ip/rstmgr/data/rstmgr.prj.hjson
+++ b/hw/ip/rstmgr/data/rstmgr.prj.hjson
@@ -14,7 +14,7 @@
         life_stage:         "L1",
         design_stage:       "D1",
         verification_stage: "V0", // this module is not verified at the block level
-        dif_stage:          "S0",
+        dif_stage:          "S1",
       }
     ]
 }

--- a/sw/device/lib/dif/dif_rstmgr.md
+++ b/sw/device/lib/dif/dif_rstmgr.md
@@ -11,10 +11,10 @@ All checklist items refer to the content in the [Checklist]({{< relref "/doc/pro
 
 Type           | Item                 | Resolution  | Note/Collaterals
 ---------------|----------------------|-------------|------------------
-Implementation | [DIF_EXISTS][]       | Not Started |
-Implementation | [DIF_USED_IN_TREE][] | Not Started |
-Tests          | [DIF_TEST_UNIT][]    | Not Started |
-Tests          | [DIF_TEST_SANITY][]  | Not Started |
+Implementation | [DIF_EXISTS][]       | Done        |
+Implementation | [DIF_USED_IN_TREE][] | Done        |
+Tests          | [DIF_TEST_UNIT][]    | Done        |
+Tests          | [DIF_TEST_SANITY][]  | Done        |
 
 [DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif_exists" >}}
 [DIF_USED_IN_TREE]: {{< relref "/doc/project/checklist.md#dif_used_in_tree" >}}

--- a/sw/device/tests/dif/dif_rstmgr_sanitytest.c
+++ b/sw/device/tests/dif/dif_rstmgr_sanitytest.c
@@ -1,0 +1,29 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_rstmgr.h"
+#include "sw/device/lib/testing/check.h"
+#include "sw/device/lib/testing/test_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
+
+static dif_rstmgr_t rstmgr;
+
+const test_config_t kTestConfig;
+
+bool test_main(void) {
+  dif_rstmgr_params_t params = {
+      .base_addr = mmio_region_from_addr(TOP_EARLGREY_RSTMGR_BASE_ADDR),
+  };
+  CHECK(dif_rstmgr_init(params, &rstmgr) == kDifRstmgrOk);
+
+  dif_rstmgr_reset_info_bitfield_t info;
+  CHECK(dif_rstmgr_reset_info_get(&rstmgr, &info) == kDifRstmgrOk);
+
+  // Only POR reset cause should be set (assuming normal power-up).
+  CHECK((info & kDifRstmgrResetInfoPor) == info);
+
+  return true;
+}

--- a/sw/device/tests/dif/dif_rstmgr_unittest.cc
+++ b/sw/device/tests/dif/dif_rstmgr_unittest.cc
@@ -167,6 +167,9 @@ TEST_F(ResetCausesGetTest, Success) {
 
   dif_rstmgr_reset_info_bitfield_t info;
   EXPECT_EQ(dif_rstmgr_reset_info_get(&rstmgr_, &info), kDifRstmgrOk);
+
+  // Make sure that `kDifRstmgrResetInfoPor` and `kDifRstmgrResetInfoLast`
+  // reset causes are set.
   EXPECT_EQ(info & (kDifRstmgrResetInfoPor | kDifRstmgrResetInfoLast), info);
 }
 

--- a/sw/device/tests/dif/meson.build
+++ b/sw/device/tests/dif/meson.build
@@ -221,3 +221,16 @@ dif_hmac_sanitytest_lib = declare_dependency(
 )
 
 sw_tests += { 'dif_hmac_sanitytest': dif_hmac_sanitytest_lib }
+
+dif_rstmgr_sanitytest_lib = declare_dependency(
+  link_with: static_library(
+    'dif_rstmgr_sanitytest_lib',
+    sources: ['dif_rstmgr_sanitytest.c'],
+    dependencies: [
+      sw_lib_dif_rstmgr,
+      sw_lib_mmio,
+    ],
+  ),
+)
+
+sw_tests += { 'dif_rstmgr_sanitytest': dif_rstmgr_sanitytest_lib }

--- a/test/systemtest/config.py
+++ b/test/systemtest/config.py
@@ -8,6 +8,7 @@ TEST_APPS_SELFCHECKING = [
     "aes_test",
     "crt_test",
     "dif_plic_sanitytest",
+    "dif_rstmgr_sanitytest",
     "dif_rv_timer_sanitytest",
     "dif_uart_sanitytest",
     "flash_ctrl_test",


### PR DESCRIPTION
This PR adds DIF Reset Manager sanity test, hooks it up to the CI, and it also addresses one of the previous clarification requests from @mcy .

I think this change makes DIF Reset Manager S1 worthy.

This is a part of #3454