### PR TITLE
Aes cfg errors

### DIFF
--- a/hw/ip/aes/data/aes_testplan.hjson
+++ b/hw/ip/aes/data/aes_testplan.hjson
@@ -33,14 +33,14 @@
       desc: '''
            Compare cypher text from DUT with the output of a C model using same key and data.'''
            milestone: V2
-      tests: ["aes_sanity"]
+      tests: ["aes_sanity", "aes_config_error"]
     }
     {
       name: key_length
       desc: '''
            Randomly select key length to verify all supported key lengths are working.'''
            milestone: V2
-      tests: []
+      tests: ["aes_stress", "aes_sanity", "aes_config_error"]
     }
     {
       name: back2back
@@ -55,7 +55,7 @@
       desc: '''
         Try to write data to registers without offloading the DUT output to verify Stall functionality.'''
         milestone: V2
-      tests: []
+      tests: ["aes_stress"]
     }
     {
       name: multi_message
@@ -63,7 +63,7 @@
         Run multiple messages in a random mix of encryption / decryption.
         Each message should select its mode randomly.'''
       milestone: V2
-      tests: []
+      tests: ["aes_stress", "aes_sanity", "aes_config_error"]
     }
     {
       name: failure_test
@@ -76,7 +76,7 @@
               Will result match plain text and vice.
             - Write unsupported configurations (Key length and mode are 1 hot, what happens if more than one bit is set.)'''
       milestone: V2
-      tests: []
+      tests: ["aes_config_error"]
     }
     {
       name: trigger_clear_test
@@ -113,7 +113,7 @@
       desc: '''
             This will combine the other individual testpoints to ensure we stress test everything across the board.'''
       milestone: V2
-      tests: []
+      tests: ["aes_stress"]
     }
     {
       name: deinitialization

--- a/hw/ip/aes/dv/aes_sim_cfg.hjson
+++ b/hw/ip/aes/dv/aes_sim_cfg.hjson
@@ -63,6 +63,11 @@
       uvm_test_seq: aes_stress_vseq
     }
     {
+      name: aes_config_error
+      uvm_test: aes_config_error_test
+      uvm_test_seq: aes_stress_vseq
+    }
+    {
       name: aes_stress
       uvm_test: aes_stress_test
       uvm_test_seq: aes_stress_vseq
@@ -80,7 +85,7 @@
       name: sanity
       tests: ["aes_sanity"]
     }
-     {
+    {
       name: stress
       tests: ["aes_stress","aes_b2b"]
     }

--- a/hw/ip/aes/dv/aes_sim_cfg.hjson
+++ b/hw/ip/aes/dv/aes_sim_cfg.hjson
@@ -86,6 +86,10 @@
       tests: ["aes_sanity"]
     }
     {
+      name: failure
+      tests: ["aes_config_error"]
+    }
+    {
       name: stress
       tests: ["aes_stress","aes_b2b"]
     }

--- a/hw/ip/aes/dv/env/aes_env_cfg.sv
+++ b/hw/ip/aes/dv/env/aes_env_cfg.sv
@@ -115,10 +115,9 @@ class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block));
         m_tl_agent_cfg.d_ready_delay_min = 0;
         m_tl_agent_cfg.d_ready_delay_max = 0;
       end
-    endcase // case (host_resp_speed)
+    endcase // case (host_resp_speed
 
     if (config_error_type[0] == 1'b1) num_corrupt_messages += 1;
-
   endfunction
 
 

--- a/hw/ip/aes/dv/env/aes_env_cfg.sv
+++ b/hw/ip/aes/dv/env/aes_env_cfg.sv
@@ -22,7 +22,7 @@ class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block));
   int            message_len_max             = 128;
   bit            use_key_mask                = 0;
   bit            use_c_model_pct             = 0;
-  bit            errors_en                   = 0;
+
   // clear registers with 0's or rand
   bit            clear_reg_w_rand            = 1;
   // if set the order of which key iv and data is written will be randomized and interleaved
@@ -66,8 +66,16 @@ class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block));
   //   010: malicous injection
   //   100: random resets
   bit [2:0]      error_types                = 3'b111;
+  bit [1:0]      config_error_type          = 2'b00;
+  // number of messages that was selected to be corrupt
+  // these should be excluded from the num_messages count
+  // when checking that all messages was processed
+  int            num_corrupt_messages       = 0;
   // percentage of configuration errors
   int            config_error_pct           = 10;
+  int            mal_error_pct              = 5;
+  int            random_reset_pct           = 10;
+
 
   // rand variables
   // 0: C model 1: OPEN_SSL/BORING_SSL
@@ -88,7 +96,7 @@ class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block));
 
 
   function void post_randomize();
-    if(use_key_mask) key_mask = 1;
+    if (use_key_mask) key_mask = 1;
 
     case(host_resp_speed)
       VerySlow: begin
@@ -108,6 +116,9 @@ class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block));
         m_tl_agent_cfg.d_ready_delay_max = 0;
       end
     endcase // case (host_resp_speed)
+
+    if (config_error_type[0] == 1'b1) num_corrupt_messages += 1;
+
   endfunction
 
 

--- a/hw/ip/aes/dv/env/aes_env_cfg.sv
+++ b/hw/ip/aes/dv/env/aes_env_cfg.sv
@@ -115,7 +115,7 @@ class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block));
         m_tl_agent_cfg.d_ready_delay_min = 0;
         m_tl_agent_cfg.d_ready_delay_max = 0;
       end
-    endcase // case (host_resp_speed
+    endcase
 
     if (config_error_type[0] == 1'b1) num_corrupt_messages += 1;
   endfunction

--- a/hw/ip/aes/dv/env/aes_message_item.sv
+++ b/hw/ip/aes/dv/env/aes_message_item.sv
@@ -18,7 +18,10 @@ class aes_message_item extends uvm_sequence_item;
   int    message_len_min      = 1;
   // percentage of configuration errors
   int    config_error_pct     = 20;
-  // errors enabled
+  // errors enabled mask
+  // 001: configuration errors
+  // 010: malicous injection
+  // 100: random resets
   bit [2:0]   error_types     = 3'b000;
   // configuraiton errors enabled
   bit    config_err           = 0;
@@ -153,8 +156,6 @@ class aes_message_item extends uvm_sequence_item;
      }
    }
 
-
-
   constraint c_has_config_error {
     if (error_types[0])
       {
@@ -177,7 +178,6 @@ class aes_message_item extends uvm_sequence_item;
                   manual_operation dist { 0:/ (100 - manual_operation_pct),
                                           1:/ manual_operation_pct };
    };
-
 
 
   function void add_data_item(aes_seq_item item);
@@ -296,7 +296,6 @@ class aes_message_item extends uvm_sequence_item;
     fixed_data_en    = rhs_.fixed_data_en;
     fixed_data       = rhs_.fixed_data;
     fixed_iv_en      = rhs_.fixed_iv_en;
-
 
   endfunction // copy
 endclass

--- a/hw/ip/aes/dv/env/aes_scoreboard.sv
+++ b/hw/ip/aes/dv/env/aes_scoreboard.sv
@@ -53,8 +53,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
 
   task run_phase(uvm_phase phase);
     super.run_phase(phase);
-//    `uvm_info(`gfn, $sformatf("%s", cfg.convert2string()), UVM_MEDIUM)
-    if(cfg.en_scb) begin
+    if (cfg.en_scb) begin
       fork
         compare();
         rebuild_message();
@@ -155,7 +154,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
         end
         // clear key
         if (item.a_data[1]) begin
-          if(cfg.clear_reg_w_rand) begin
+          if (cfg.clear_reg_w_rand) begin
             input_item.key = '{default: {8{$urandom()}}};
           end else begin
             input_item.key = '{default: '0};
@@ -163,7 +162,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
         end
         // clear IV
         if (item.a_data[2]) begin
-          if(cfg.clear_reg_w_rand) begin
+          if (cfg.clear_reg_w_rand) begin
             input_item.iv = {4{$urandom()}};
           end else begin
             input_item.iv = '0;
@@ -171,7 +170,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
         end
         // clear data_in
         if (item.a_data[3]) begin
-          if(cfg.clear_reg_w_rand) begin
+          if (cfg.clear_reg_w_rand) begin
             input_item.data_in = {4{$urandom()}};
           end else begin
             input_item.data_in = '0;
@@ -179,7 +178,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
         end
         // clear data out
         if (item.a_data[4]) begin
-          if(cfg.clear_reg_w_rand) begin
+          if (cfg.clear_reg_w_rand) begin
             input_item.data_out = {4{$urandom()}};
           end else begin
             input_item.data_out = '0;
@@ -206,13 +205,13 @@ class aes_scoreboard extends cip_base_scoreboard #(
       ///////////////////////////////////////
 
       // check that the item is valid - all registers clean base on mode //
-      if(input_item.valid && !input_item.manual_op) begin
+      if (input_item.valid && !input_item.manual_op) begin
         case (input_item.mode)
           AES_ECB: begin
             `uvm_info(`gfn, $sformatf("\n\t ----| ECB mode"), UVM_MEDIUM)
-            if(aes_from_rst) begin
+            if (aes_from_rst) begin
               // verify that all 4 data_in and all 8 key have been updated
-              if(input_item.data_in_valid() && input_item.key_clean(0)) begin
+              if (input_item.data_in_valid() && input_item.key_clean(0)) begin
                 //clone and add to ref and rec data fifo
                 ok_to_fwd    = 1;
                 aes_from_rst = 0;
@@ -222,7 +221,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
               `uvm_info(`gfn, $sformatf("\n\t ----|data_inv_vld?  %b, key clean ? %b",
                         input_item.data_in_valid(), input_item.key_clean(1) ), UVM_MEDIUM)
 
-              if(input_item.data_in_valid() && input_item.key_clean(1)) begin
+              if (input_item.data_in_valid() && input_item.key_clean(1)) begin
                 //clone and add to ref and rec data fifo
                 ok_to_fwd = 1;
               end
@@ -231,9 +230,9 @@ class aes_scoreboard extends cip_base_scoreboard #(
 
           AES_CBC: begin
             `uvm_info(`gfn, $sformatf("\n\t ----| CBC mode"), UVM_MEDIUM)
-            if(aes_from_rst) begin
+            if (aes_from_rst) begin
               // verify that all 4 data_in and all 8 key and all 4 IV have been updated
-              if(input_item.data_in_valid() && input_item.key_clean(0) && input_item.iv_clean(0)) begin
+              if (input_item.data_in_valid() && input_item.key_clean(0) && input_item.iv_clean(0)) begin
                 //clone and add to ref and rec data fifo
                 ok_to_fwd    = 1;
                 aes_from_rst = 0;
@@ -243,7 +242,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
               `uvm_info(`gfn, $sformatf("\n\t ----|data_inv_vld?  %b, key clean ? %b",
                                 input_item.data_in_valid(), input_item.key_clean(1) ), UVM_MEDIUM)
 
-              if(input_item.data_in_valid() && input_item.key_clean(1) && input_item.iv_clean(1)) begin
+              if (input_item.data_in_valid() && input_item.key_clean(1) && input_item.iv_clean(1)) begin
                 //clone and add to ref and rec data fifo
                 ok_to_fwd = 1;
               end
@@ -251,9 +250,9 @@ class aes_scoreboard extends cip_base_scoreboard #(
           end
 
           AES_CFB: begin
-            if(aes_from_rst) begin
+            if (aes_from_rst) begin
               // verify that all 4 data_in and all 8 key and all 4 IV have been updated
-              if(input_item.data_in_valid() && input_item.key_clean(0) && input_item.iv_clean(0)) begin
+              if (input_item.data_in_valid() && input_item.key_clean(0) && input_item.iv_clean(0)) begin
                 //clone and add to ref and rec data fifo
                 ok_to_fwd    = 1;
                 aes_from_rst = 0;
@@ -263,7 +262,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
               `uvm_info(`gfn, $sformatf("\n\t ----|data_inv_vld?  %b, key clean ? %b",
                                 input_item.data_in_valid(), input_item.key_clean(1) ), UVM_HIGH)
 
-              if(input_item.data_in_valid() && input_item.key_clean(1) && input_item.iv_clean(1)) begin
+              if (input_item.data_in_valid() && input_item.key_clean(1) && input_item.iv_clean(1)) begin
                 //clone and add to ref and rec data fifo
                 ok_to_fwd = 1;
               end
@@ -271,9 +270,9 @@ class aes_scoreboard extends cip_base_scoreboard #(
           end
 
           AES_OFB: begin
-            if(aes_from_rst) begin
+            if (aes_from_rst) begin
               // verify that all 4 data_in and all 8 key and all 4 IV have been updated
-              if(input_item.data_in_valid() && input_item.key_clean(0) && input_item.iv_clean(0)) begin
+              if (input_item.data_in_valid() && input_item.key_clean(0) && input_item.iv_clean(0)) begin
                 //clone and add to ref and rec data fifo
                 ok_to_fwd    = 1;
                 aes_from_rst = 0;
@@ -283,7 +282,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
               `uvm_info(`gfn, $sformatf("\n\t ----|data_inv_vld?  %b, key clean ? %b",
                                 input_item.data_in_valid(), input_item.key_clean(1) ), UVM_HIGH)
 
-              if(input_item.data_in_valid() && input_item.key_clean(1) && input_item.iv_clean(1)) begin
+              if (input_item.data_in_valid() && input_item.key_clean(1) && input_item.iv_clean(1)) begin
                 //clone and add to ref and rec data fifo
                 ok_to_fwd = 1;
               end
@@ -292,34 +291,37 @@ class aes_scoreboard extends cip_base_scoreboard #(
 
           AES_CTR: begin
             `uvm_info(`gfn, $sformatf("\n\t ----| CTR mode"), UVM_MEDIUM)
-            if(aes_from_rst) begin
+            if (aes_from_rst) begin
               // verify that all 4 data_in and all 8 key and all 4 IV have been updated
-              if(input_item.data_in_valid() && input_item.key_clean(0) && input_item.iv_clean(0)) begin
+              if (input_item.data_in_valid() && input_item.key_clean(0) && input_item.iv_clean(0)) begin
                 //clone and add to ref and rec data fifo
                 ok_to_fwd    = 1;
                 aes_from_rst = 0;
               end
             end else begin
               // verify that all 4 data_in and all 8 and all 4 IV  key are clean
-              `uvm_info(`gfn, $sformatf("\n\t ----|data_inv_vld?  %b, key clean ? %b",input_item.data_in_valid(), input_item.key_clean(1) ), UVM_MEDIUM)
-              if(input_item.data_in_valid() && input_item.key_clean(1) && input_item.iv_clean(1)) begin
+              `uvm_info(`gfn, $sformatf("\n\t ----|data_inv_vld?  %b, key clean ? %b",input_item.data_in_valid(), input_item.key_clean(1) ),
+                                       UVM_MEDIUM)
+              if (input_item.data_in_valid() && input_item.key_clean(1) && input_item.iv_clean(1)) begin
                 //clone and add to ref and rec data fifo
                 ok_to_fwd = 1;
               end
             end
           end
           default: begin
-            `uvm_info(`gfn, $sformatf("\n\t ----| Received illegal AES_MODE setting reverting to AES_NONE "), UVM_HIGH)
+            `uvm_info(`gfn, $sformatf("\n\t ----| Received illegal AES_MODE setting reverting to AES_NONE "),
+                                      UVM_HIGH)
 
           end
         endcase // case (input_item.mode)
       end // if (input_item.valid)
 
       // forward item to receive side
-      if(ok_to_fwd ) begin
+      if (ok_to_fwd ) begin
         ok_to_fwd = 0;
         `downcast(input_clone, input_item.clone());
-        `uvm_info(`gfn, $sformatf("\n\t AES INPUT ITEM RECEIVED - \n %s", input_clone.convert2string()), UVM_MEDIUM)
+        `uvm_info(`gfn, $sformatf("\n\t AES INPUT ITEM RECEIVED - \n %s", input_clone.convert2string()),
+                                  UVM_MEDIUM)
         rcv_item_q.push_front(input_clone);
         input_item.clean();
       end
@@ -360,7 +362,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
       endcase // case (csr.get_name())
 
       if (output_item.data_out_valid()) begin
-        if( rcv_item_q.size() == 0) begin
+        if ( rcv_item_q.size() == 0) begin
           `uvm_fatal(`gfn, $sformatf("\n\t ----| TRIED TO READ EMPTY RECEIVE QUEUE |----"))
         end
 
@@ -380,7 +382,8 @@ class aes_scoreboard extends cip_base_scoreboard #(
   endtask // process_tl_access
 
 
-  // takes items from the item queue and builds full aes_messages with both input data and output data.
+  // takes items from the item queue and builds full
+  // aes_messages with both input data and output data.
   task rebuild_message();
     typedef enum { MSG_START,MSG_RUN } aes_message_stat_t;
 
@@ -398,7 +401,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
               full_item = new();
               item_fifo.get(full_item);
               `uvm_info(`gfn, $sformatf("\n\t ----| got item from item fifo"), UVM_FULL)
-              if(!full_item.message_start()) begin
+              if (!full_item.message_start()) begin
                 `uvm_fatal(`gfn,
                  $sformatf("\n\t ----| FIRST ITEM DID NOT HAVE MESSAGE START/CONFIG SETTINGS"))
               end
@@ -410,7 +413,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
               full_item = new();
               item_fifo.get(full_item);
               `uvm_info(`gfn, $sformatf("\n\t ----| got item from item fifo"), UVM_FULL)
-              if(full_item.message_start() ) begin
+              if (full_item.message_start() ) begin
                 `uvm_info(`gfn, $sformatf("\n\t ----| adding message item to mg_fifo"), UVM_FULL)
                 `downcast(msg_clone, message.clone());
                 msg_fifo.put(msg_clone);
@@ -426,8 +429,8 @@ class aes_scoreboard extends cip_base_scoreboard #(
 
       begin
         wait( finish_message )
-        `uvm_info(`gfn, $sformatf("\n\t ----| Finish test received adding message item to mg_fifo")
-         , UVM_MEDIUM)
+        `uvm_info(`gfn, $sformatf("\n\t ----| Finish test received adding message item to mg_fifo"),
+                                  UVM_MEDIUM)
 
         `downcast(msg_clone, message.clone());
         msg_fifo.put(msg_clone);
@@ -447,8 +450,8 @@ class aes_scoreboard extends cip_base_scoreboard #(
       msg_fifo.get(msg);
       `uvm_info(`gfn, $sformatf("model %b, operation: %b, mode %06b, IV %h, key_len %03b, key share0 %h, key share1 %h ",
                                 cfg.ref_model, msg.aes_operation, msg.aes_mode, msg.aes_iv, msg.aes_keylen,
-                                msg.aes_key[0], msg.aes_key[1])
-                , UVM_MEDIUM)
+                                msg.aes_key[0], msg.aes_key[1]),
+                                UVM_MEDIUM)
 
       if (msg.aes_mode != AES_NONE) begin
         msg.alloc_predicted_msg();
@@ -458,16 +461,16 @@ class aes_scoreboard extends cip_base_scoreboard #(
                                 msg.aes_keylen, msg.aes_key[0] ^ msg.aes_key[1],
                                 msg.input_msg, msg.predicted_msg);
 
-        `uvm_info(`gfn, $sformatf("\n\t ----| printing MESSAGE %s", msg.convert2string() )
-                  , UVM_MEDIUM)
+        `uvm_info(`gfn, $sformatf("\n\t ----| printing MESSAGE %s", msg.convert2string()),
+                  UVM_MEDIUM)
         txt = "";
-        foreach(msg.input_msg[i]) begin
+        foreach (msg.input_msg[i]) begin
           txt = { txt, $sformatf("\n\t %d %h \t %h \t %h",
                                 i, msg.input_msg[i], msg.output_msg[i], msg.predicted_msg[i])};
         end
 
-        for( int n =0 ; n < msg.input_msg.size(); n++) begin
-          if( msg.output_msg[n] != msg.predicted_msg[n]) begin
+        for (int n =0 ; n < msg.input_msg.size(); n++) begin
+          if (msg.output_msg[n] != msg.predicted_msg[n]) begin
             txt = {"\t TEST FAILED MESSAGES DID NOT MATCH \n ", txt};
 
             txt = {txt,  $sformatf("\n\n\t ----| ACTUAL OUTPUT DID NOT MATCH PREDICTED OUTPUT |----")};
@@ -552,7 +555,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
     txt = {   txt, $sformatf("\n\t SAW %d Good messages ", message_cnt)};
     txt = {   txt, $sformatf("\n\t Expected %d messages ", cfg.num_messages)};
     rpt_srvr = uvm_report_server::get_server();
-    if(rpt_srvr.get_severity_count(UVM_FATAL)+rpt_srvr.get_severity_count(UVM_ERROR)>0) begin
+    if (rpt_srvr.get_severity_count(UVM_FATAL)+rpt_srvr.get_severity_count(UVM_ERROR)>0) begin
       `uvm_info(`gfn, $sformatf("%s", cfg.convert2string()), UVM_LOW)
       txt = { txt,"\n\t---------------------------------------"};
       txt = { txt,"\n\t----            TEST FAILED        ----"};

--- a/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
@@ -202,7 +202,7 @@ class aes_base_vseq extends cip_base_vseq #(
         `DV_CHECK_RANDOMIZE_FATAL(aes_item)
       end
 
-      `uvm_info(`gfn, $sformatf("\n ----| DATA AES ITEM %s", aes_item.convert2string()), UVM_MEDIUM)
+      `uvm_info(`gfn, $sformatf("\n ----| DATA AES ITEM %s", aes_item.convert2string()), UVM_HIGH)
       `downcast(item_clone, aes_item.clone());
       aes_item_queue.push_front(item_clone);
       `uvm_info(`gfn, $sformatf("\n ----| generating data item %d", n), UVM_MEDIUM)
@@ -401,7 +401,7 @@ class aes_base_vseq extends cip_base_vseq #(
     aes_item.item_type = AES_CFG;
 
     `DV_CHECK_RANDOMIZE_FATAL(aes_item)
-    `uvm_info(`gfn, $sformatf("----| CONFIG  AES ITEM %s", aes_item.convert2string()), UVM_MEDIUM)
+    `uvm_info(`gfn, $sformatf("\n\t ----| CONFIG  AES ITEM %s", aes_item.convert2string()), UVM_FULL)
 
     `downcast(item_clone, aes_item.clone());
     aes_item_queue.push_front(item_clone);
@@ -439,11 +439,13 @@ class aes_base_vseq extends cip_base_vseq #(
     aes_message_item cloned_message;
     for(int i=0; i < cfg.num_messages; i++) begin
       `DV_CHECK_RANDOMIZE_FATAL(aes_message)
+      if(aes_message.cfg_error_type[0] == 1'b1) cfg.num_corrupt_messages += 1;
+
       `downcast(cloned_message, aes_message.clone());
       //`assert($cast(cloned_message, aes_message.clone());
       message_queue.push_front(cloned_message);
-      `uvm_info(`gfn, $sformatf("\n message # %d \n %s",i, cloned_message.convert2string()),
-                UVM_MEDIUM)
+      `uvm_info(`gfn, $sformatf("\n\t ----| MESSAGE # %d \n %s",i, cloned_message.convert2string())
+               , UVM_MEDIUM)
     end
 
   endfunction
@@ -451,7 +453,7 @@ class aes_base_vseq extends cip_base_vseq #(
 
   function void aes_print_item_queue(ref aes_seq_item item_queue[$]);
     aes_seq_item print_item;
-    `uvm_info(`gfn, $sformatf("----| Item queue size: %d", item_queue.size()), UVM_MEDIUM)
+    `uvm_info(`gfn, $sformatf("----| Item queue size: %d", item_queue.size()), UVM_HIGH)
     for(int n = 0; n < item_queue.size(); n++) begin
       print_item = item_queue[n];
       `uvm_info(`gfn, $sformatf("----|  ITEM #%d", n ), UVM_MEDIUM)

--- a/hw/ip/aes/dv/env/seq_lib/aes_stress_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_stress_vseq.sv
@@ -15,7 +15,7 @@ class aes_stress_vseq extends aes_base_vseq;
     // generate list of messages //
     generate_message_queue();
     // process all messages //
-    while( message_queue.size() > 0) begin
+    while (message_queue.size() > 0) begin
       // get next message from queue
       my_message = new();
       my_message = message_queue.pop_back();
@@ -24,8 +24,8 @@ class aes_stress_vseq extends aes_base_vseq;
       // and data items (split message into blocks)
       generate_aes_item_queue(my_message);
       // setup and transmit based on settings
-      if(my_message.manual_operation) begin
-        transmit_message_manual_op();
+      if (my_message.manual_operation) begin
+        transmit_message_manual_op_w_rd_back();
       end else begin
         transmit_message_with_rd_back();
       end

--- a/hw/ip/aes/dv/env/seq_lib/aes_stress_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_stress_vseq.sv
@@ -10,8 +10,7 @@ class aes_stress_vseq extends aes_base_vseq;
   aes_message_item my_message;
 
   task body();
-    `uvm_info(`gfn, $sformatf("\n\t ----| STARTING AES MAIN SEQUENCE |----\n"), UVM_LOW);
-    `uvm_info(`gfn, $sformatf("\n\t cfg item \n %s", cfg.convert2string()), UVM_LOW)
+    `uvm_info(`gfn, $sformatf("\n\n\t ----| STARTING AES MAIN SEQUENCE |----\n %s", cfg.convert2string()), UVM_LOW)
 
     // generate list of messages //
     generate_message_queue();

--- a/hw/ip/aes/dv/tests/aes_b2b_test.sv
+++ b/hw/ip/aes/dv/tests/aes_b2b_test.sv
@@ -18,7 +18,7 @@ class aes_b2b_test extends aes_base_test;
     // env related knobs
 
     // TODO fix manual mode so we can randomize speeds
-    cfg.errors_en                = 0;
+
     cfg.num_messages_min         = 1;
     cfg.num_messages_max         = 5;
     // message related knobs

--- a/hw/ip/aes/dv/tests/aes_base_test.sv
+++ b/hw/ip/aes/dv/tests/aes_base_test.sv
@@ -27,7 +27,7 @@ class aes_base_test extends cip_base_test #(
     cfg.message_len_max             = 599;
     cfg.use_key_mask                = 0;
     cfg.use_c_model_pct             = 0;
-    cfg.errors_en                   = 0;
+    cfg.error_types                 = '0;
   // clear registers with 0's or rand
     cfg.clear_reg_w_rand            = 1;
   // if set the order of which key iv and data is written will be randomized and interleaved

--- a/hw/ip/aes/dv/tests/aes_config_error_test.sv
+++ b/hw/ip/aes/dv/tests/aes_config_error_test.sv
@@ -1,0 +1,54 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class aes_config_error_test extends aes_base_test;
+
+  `uvm_component_utils(aes_config_error_test)
+  `uvm_component_new
+
+
+  virtual function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    configure_env();
+  endfunction
+
+  function void configure_env();
+    super.configure_env();
+
+//    the feature below is waiting in anther PR
+//    cfg.zero_delay_pct           = 100;
+
+
+    cfg.error_types              = 3'b001;
+    cfg.config_error_pct         = 75;
+    cfg.num_messages_min         = 3;
+    cfg.num_messages_max         = 10;
+    // message related knobs
+    cfg.ecb_weight               = 10;
+    cfg.cbc_weight               = 10;
+    cfg.ctr_weight               = 10;
+    cfg.ofb_weight               = 10;
+    cfg.cfb_weight               = 10;
+
+    cfg.message_len_min          = 16;    // one block (16bytes=128bits)
+    cfg.message_len_max          = 32;    //
+    cfg.manual_operation_pct     = 0;
+    cfg.use_key_mask             = 0;
+
+    cfg.fixed_data_en            = 0;
+    cfg.fixed_key_en             = 0;
+
+    cfg.fixed_operation_en       = 0;
+    cfg.fixed_operation          = 0;
+
+    cfg.fixed_keylen_en          = 0;
+    cfg.fixed_keylen             = 3'b001;
+
+    cfg.fixed_iv_en              = 0;
+
+    cfg.random_data_key_iv_order = 0;
+
+    `DV_CHECK_RANDOMIZE_FATAL(cfg)
+  endfunction
+endclass : aes_config_error_test

--- a/hw/ip/aes/dv/tests/aes_config_error_test.sv
+++ b/hw/ip/aes/dv/tests/aes_config_error_test.sv
@@ -18,8 +18,6 @@ class aes_config_error_test extends aes_base_test;
 
 //    the feature below is waiting in anther PR
 //    cfg.zero_delay_pct           = 100;
-
-
     cfg.error_types              = 3'b001;
     cfg.config_error_pct         = 75;
     cfg.num_messages_min         = 3;

--- a/hw/ip/aes/dv/tests/aes_sanity_test.sv
+++ b/hw/ip/aes/dv/tests/aes_sanity_test.sv
@@ -19,7 +19,7 @@ class aes_sanity_test extends aes_base_test;
 //    the feature below is waiting in anther PR
 //    cfg.zero_delay_pct           = 100;
 
-    cfg.errors_en                = 0;     // no errors in sanity test
+    cfg.error_types              = 0;     // no errors in sanity test
     cfg.num_messages_min         = 2;
     cfg.num_messages_max         = 2;
     // message related knobs

--- a/hw/ip/aes/dv/tests/aes_stress_test.sv
+++ b/hw/ip/aes/dv/tests/aes_stress_test.sv
@@ -17,7 +17,7 @@ class aes_stress_test extends aes_base_test;
     //   cfg.ref_model          = OpenSSL;
     // env related knobs
 
-    cfg.errors_en                = 0;
+    cfg.error_types              = 0;
     cfg.num_messages_min         = 1;
     cfg.num_messages_max         = 50;
     // message related knobs

--- a/hw/ip/aes/dv/tests/aes_test.core
+++ b/hw/ip/aes/dv/tests/aes_test.core
@@ -15,6 +15,7 @@ filesets:
       - aes_sanity_test.sv: {is_include_file: true}
       - aes_stress_test.sv: {is_include_file: true}
       - aes_b2b_test.sv: {is_include_file: true}
+      - aes_config_error_test.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:

--- a/hw/ip/aes/dv/tests/aes_test_pkg.sv
+++ b/hw/ip/aes/dv/tests/aes_test_pkg.sv
@@ -22,5 +22,6 @@ package aes_test_pkg;
   `include "aes_sanity_test.sv"
   `include "aes_stress_test.sv"
   `include "aes_b2b_test.sv"
+  `include "aes_config_error_test.sv"
 
 endpackage

--- a/hw/ip/aes/dv/tests/aes_wake_up_test.sv
+++ b/hw/ip/aes/dv/tests/aes_wake_up_test.sv
@@ -19,7 +19,6 @@ class aes_wake_up_test extends aes_base_test;
      cfg.ctr_weight         = 0;
      cfg.num_messages_min   = 2;
      cfg.num_messages_max   = 2;
-     cfg.errors_en          = 0;
     `DV_CHECK_RANDOMIZE_FATAL(cfg)
   endfunction
 endclass : aes_wake_up_test


### PR DESCRIPTION
This PR contains 3 commits.
The first commit adds configuration errors into the environment. configuration errors will be inserted into message items at random. For key_len errors the scoreboard will revert to default mode and verify that the DUT does the same. For Mode errors the scoreboard will go into AES_NONE mode and wait for a correct configuration to be applied.
Items with illegal modes will be flagged as corrupt and counted.

The second commit adds a directed test that enables configuration errors - but disables much of the other features.

the third commit added a new manual mode that will only add new data once the result of the previous operation has been read.
only this mode is used for manual as the environment has no way of detecting if output data has been overwritten.
the original manual mode will be re-activated once a new bit indicating if data has been overwritten will be added to the dut. 