### PR TITLE
[csrng/rtl] lifecycle input to support aes mode

### DIFF
--- a/hw/ip/csrng/csrng.core
+++ b/hw/ip/csrng/csrng.core
@@ -11,10 +11,8 @@ filesets:
       - lowrisc:prim:all
       - lowrisc:ip:tlul
       - lowrisc:ip:aes
-      - lowrisc:ip:entropy_src_pkg
+      - lowrisc:ip:csrng_pkg
     files:
-      - rtl/csrng_pkg.sv
-      - rtl/csrng_reg_pkg.sv
       - rtl/csrng_reg_top.sv
       - rtl/csrng_main_sm.sv
       - rtl/csrng_state_db.sv
@@ -66,6 +64,10 @@ targets:
     parameters:
       - SYNTHESIS=true
     tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
+          - "-stop_on_error"
       verilator:
         mode: lint-only
         verilator_options:

--- a/hw/ip/csrng/csrng_pkg.core
+++ b/hw/ip/csrng/csrng_pkg.core
@@ -1,0 +1,23 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:ip:csrng_pkg:0.1"
+description: "csrng package"
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:tlul:headers
+      - lowrisc:ip:lc_ctrl_pkg
+      - lowrisc:ip:entropy_src_pkg
+
+    files:
+      - rtl/csrng_reg_pkg.sv
+      - rtl/csrng_pkg.sv
+    file_type: systemVerilogSource
+
+
+targets:
+  default: &default_target
+    filesets:
+      - files_rtl

--- a/hw/ip/csrng/data/csrng.hjson
+++ b/hw/ip/csrng/data/csrng.hjson
@@ -227,137 +227,172 @@
         { bits: "0",
           name: "SFIFO_CMD_ERR",
           desc: '''
-                This is set when a command stage command fifo error is set.
-                Writing a zero to this bit will reset it.
+                This bit will be set to one when an error has been detected for the
+                command stage command FIFO. The type of error is reflected in the type status
+                bits (bits 28 through 30 of this register).
+                This bit will stay set until firmware clears it.
                 '''
         }
         { bits: "1",
           name: "SFIFO_GENBITS_ERR",
           desc: '''
-                This is set when a command stage genbits fifo error is set.
-                Writing a zero to this bit will reset it.
+                This bit will be set to one when an error has been detected for the
+                command stage genbits FIFO. The type of error is reflected in the type status
+                bits (bits 28 through 30 of this register).
+                This bit will stay set until firmware clears it.
                 '''
         }
         { bits: "2",
           name: "SFIFO_CMDREQ_ERR",
           desc: '''
-                This is set when a command stage cmdreq fifo error is set.
-                Writing a zero to this bit will reset it.
+                This bit will be set to one when an error has been detected for the
+                cmdreq FIFO. The type of error is reflected in the type status
+                bits (bits 28 through 30 of this register).
+                This bit will stay set until firmware clears it.
                 '''
         }
         { bits: "3",
           name: "SFIFO_RCSTAGE_ERR",
           desc: '''
-                This is set when a command stage rcstage fifo error is set.
-                Writing a zero to this bit will reset it.
+                This bit will be set to one when an error has been detected for the
+                rcstage FIFO. The type of error is reflected in the type status
+                bits (bits 28 through 30 of this register).
+                This bit will stay set until firmware clears it.
                 '''
         }
         { bits: "4",
           name: "SFIFO_KEYVRC_ERR",
           desc: '''
-                This is set when a command stage keyvrc fifo error is set.
-                Writing a zero to this bit will reset it.
+                This bit will be set to one when an error has been detected for the
+                keyvrc FIFO. The type of error is reflected in the type status
+                bits (bits 28 through 30 of this register).
+                This bit will stay set until firmware clears it.
                 '''
         }
         { bits: "5",
           name: "SFIFO_UPDREQ_ERR",
           desc: '''
-                This is set when a command stage updreq fifo error is set.
-                Writing a zero to this bit will reset it.
+                This bit will be set to one when an error has been detected for the
+                updreq FIFO. The type of error is reflected in the type status
+                bits (bits 28 through 30 of this register).
+                This bit will stay set until firmware clears it.
                 '''
         }
         { bits: "6",
           name: "SFIFO_BENCREQ_ERR",
           desc: '''
-                This is set when a command stage bencreq fifo error is set.
-                Writing a zero to this bit will reset it.
+                This bit will be set to one when an error has been detected for the
+                bencreq FIFO. The type of error is reflected in the type status
+                bits (bits 28 through 30 of this register).
+                This bit will stay set until firmware clears it.
                 '''
         }
         { bits: "7",
           name: "SFIFO_BENCACK_ERR",
           desc: '''
-                This is set when a command stage bencack fifo error is set.
-                Writing a zero to this bit will reset it.
+                This bit will be set to one when an error has been detected for the
+                bencack FIFO. The type of error is reflected in the type status
+                bits (bits 28 through 30 of this register).
+                This bit will stay set until firmware clears it.
                 '''
         }
         { bits: "8",
           name: "SFIFO_PDATA_ERR",
           desc: '''
-                This is set when a command stage pdata fifo error is set.
-                Writing a zero to this bit will reset it.
+                This bit will be set to one when an error has been detected for the
+                pdata FIFO. The type of error is reflected in the type status
+                bits (bits 28 through 30 of this register).
+                This bit will stay set until firmware clears it.
                 '''
         }
         { bits: "9",
           name: "SFIFO_FINAL_ERR",
           desc: '''
-                This is set when a command stage final fifo error is set.
-                Writing a zero to this bit will reset it.
+                This bit will be set to one when an error has been detected for the
+                final FIFO. The type of error is reflected in the type status
+                bits (bits 28 through 30 of this register).
+                This bit will stay set until firmware clears it.
                 '''
         }
         { bits: "10",
           name: "SFIFO_GBENCACK_ERR",
           desc: '''
-                This is set when a command stage gbencack fifo error is set.
-                Writing a zero to this bit will reset it.
+                This bit will be set to one when an error has been detected for the
+                gbencack FIFO. The type of error is reflected in the type status
+                bits (bits 28 through 30 of this register).
+                This bit will stay set until firmware clears it.
                 '''
         }
         { bits: "11",
           name: "SFIFO_GRCSTAGE_ERR",
           desc: '''
-                This is set when a command stage grcstage fifo error is set.
-                Writing a zero to this bit will reset it.
+                This bit will be set to one when an error has been detected for the
+                grcstage FIFO. The type of error is reflected in the type status
+                bits (bits 28 through 30 of this register).
+                This bit will stay set until firmware clears it.
                 '''
         }
         { bits: "12",
           name: "SFIFO_GGENREQ_ERR",
           desc: '''
-                This is set when a command stage ggenreq fifo error is set.
-                Writing a zero to this bit will reset it.
+                This bit will be set to one when an error has been detected for the
+                ggenreq FIFO. The type of error is reflected in the type status
+                bits (bits 28 through 30 of this register).
+                This bit will stay set until firmware clears it.
                 '''
         }
         { bits: "13",
           name: "SFIFO_GADSTAGE_ERR",
           desc: '''
-                This is set when a command stage gadstage fifo error is set.
-                Writing a zero to this bit will reset it.
+                This bit will be set to one when an error has been detected for the
+                gadstage FIFO. The type of error is reflected in the type status
+                bits (bits 28 through 30 of this register).
+                This bit will stay set until firmware clears it.
                 '''
         }
         { bits: "14",
           name: "SFIFO_GGENBITS_ERR",
           desc: '''
-                This is set when a command stage ggenbits fifo error is set.
-                Writing a zero to this bit will reset it.
+                This bit will be set to one when an error has been detected for the
+                ggenbits FIFO. The type of error is reflected in the type status
+                bits (bits 28 through 30 of this register).
+                This bit will stay set until firmware clears it.
                 '''
         }
         { bits: "15",
           name: "SFIFO_BLKENC_ERR",
           desc: '''
-                This is set when a command stage blkenc fifo error is set.
-                Writing a zero to this bit will reset it.
+                This bit will be set to one when an error has been detected for the
+                blkenc FIFO. The type of error is reflected in the type status
+                bits (bits 28 through 30 of this register).
+                This bit will stay set until firmware clears it.
                 '''
         }
         { bits: "28",
           name: "FIFO_WRITE_ERR",
           desc: '''
-                This is type of error when other source bits are set in this register.
-                This is the case where a full FIFO has been written.
-                Writing a zero to this bit will reset it.
+                This bit will be set to one when any of the source bits (bits 0 through 15 of this
+                this register) are asserted as a result of an error pulse generated from
+                any full FIFO that has been recieved a write pulse.
+                This bit will stay set until firmware clears it.
                 '''
         }
         { bits: "29",
           name: "FIFO_READ_ERR",
           desc: '''
-                This is type of error when other source bits are set in this register.
-                This is the case where an empty FIFO has been read.
-                Writing a zero to this bit will reset it.
+                This bit will be set to one when any of the source bits (bits 0 through 15 of this
+                this register) are asserted as a result of an error pulse generated from
+                any empty FIFO that has recieved a read pulse.
+                This bit will stay set until firmware clears it.
                 '''
         }
         { bits: "30",
           name: "FIFO_STATE_ERR",
           desc: '''
-                This is type of error when other source bits are set in this register.
-                This is the case where a FIFO has both the empty and full indications asserted.
-                Writing a zero to this bit will reset it.
+                This bit will be set to one when any of the source bits (bits 0 through 15 of this
+                this register) are asserted as a result of an error pulse generated from
+                any FIFO where both the empty and full status bits are set.
+                This bit will stay set until firmware clears it.
                 '''
         }
       ]

--- a/hw/ip/csrng/rtl/csrng.sv
+++ b/hw/ip/csrng/rtl/csrng.sv
@@ -18,6 +18,9 @@ module csrng import csrng_pkg::*; #(
   // Efuse Interface
   input logic efuse_sw_app_enable_i,
 
+  // Lifecycle broadcast inputs
+  input  lc_ctrl_pkg::lc_tx_t  lc_dft_en_i,
+
   // Entropy Interface
   output entropy_src_pkg::entropy_src_hw_if_req_t entropy_src_hw_if_o,
   input  entropy_src_pkg::entropy_src_hw_if_rsp_t entropy_src_hw_if_i,
@@ -59,7 +62,10 @@ module csrng import csrng_pkg::*; #(
     .reg2hw,
     .hw2reg,
 
+    // misc inputs
     .efuse_sw_app_enable_i,
+    .lc_dft_en_i,
+
     // Entropy Interface
     .entropy_src_hw_if_o,
     .entropy_src_hw_if_i,

--- a/hw/ip/csrng/rtl/csrng_block_encrypt.sv
+++ b/hw/ip/csrng/rtl/csrng_block_encrypt.sv
@@ -18,6 +18,7 @@ module csrng_block_encrypt #(
    // update interface
   input logic                block_encrypt_bypass_i,
   input logic                block_encrypt_enable_i,
+  input lc_ctrl_pkg::lc_tx_t block_encrypt_lc_dft_en_i,
   input logic                block_encrypt_req_i,
   output logic               block_encrypt_rdy_o,
   input logic [KeyLen-1:0]   block_encrypt_key_i,
@@ -54,6 +55,7 @@ module csrng_block_encrypt #(
   logic                 cipher_out_valid;
   logic                 cipher_out_ready;
   logic [BlkLen-1:0]    cipher_data_out;
+  logic                 aes_cipher_core_enable;
 
   logic [3:0][3:0][7:0] state_init[NumShares];
 
@@ -69,9 +71,28 @@ module csrng_block_encrypt #(
 
 
   //--------------------------------------------
+  // aes cipher core lifecycle enable
+  //--------------------------------------------
+
+  lc_ctrl_pkg::lc_tx_t lc_dft_en;
+
+  prim_multibit_sync #(
+    .Width(lc_ctrl_pkg::TxWidth),
+    .NumChecks (2),
+    .ResetValue(lc_ctrl_pkg::TxWidth'(lc_ctrl_pkg::Off))
+  ) u_prim_multibit_sync (
+    .clk_i,
+    .rst_ni,
+    .data_i (block_encrypt_lc_dft_en_i),
+    .data_o (lc_dft_en)
+  );
+
+  assign aes_cipher_core_enable = (!block_encrypt_bypass_i) || (lc_dft_en != lc_ctrl_pkg::On);
+
+  //--------------------------------------------
   // aes cipher core
   //--------------------------------------------
-  assign cipher_in_valid = (!block_encrypt_bypass_i && block_encrypt_req_i);
+  assign cipher_in_valid = (aes_cipher_core_enable && block_encrypt_req_i);
 
   // Cipher core
   aes_cipher_core #(
@@ -89,7 +110,7 @@ module csrng_block_encrypt #(
     .out_ready_i        ( cipher_out_ready           ),
     .op_i               ( aes_pkg::CIPH_FWD          ),
     .key_len_i          ( aes_pkg::AES_256           ),
-    .crypt_i            ( !block_encrypt_bypass_i    ),
+    .crypt_i            ( aes_cipher_core_enable     ),
     .crypt_o            (                            ),
     .dec_key_gen_i      ( 1'b0                       ), // Disable
     .dec_key_gen_o      (                            ),
@@ -134,17 +155,17 @@ module csrng_block_encrypt #(
   assign sfifo_blkenc_push = block_encrypt_req_i && sfifo_blkenc_not_full;
   assign sfifo_blkenc_wdata = {block_encrypt_v_i,block_encrypt_id_i,block_encrypt_cmd_i};
 
-  assign block_encrypt_rdy_o = block_encrypt_bypass_i ? sfifo_blkenc_not_full : cipher_in_ready;
+  assign block_encrypt_rdy_o = aes_cipher_core_enable ? sfifo_blkenc_not_full : cipher_in_ready;
 
   assign sfifo_blkenc_pop = block_encrypt_ack_o;
   assign {sfifo_blkenc_v,sfifo_blkenc_id,sfifo_blkenc_cmd} = sfifo_blkenc_rdata;
 
   assign block_encrypt_ack_o = block_encrypt_rdy_i &&
-         (block_encrypt_bypass_i ? sfifo_blkenc_not_empty : cipher_out_valid);
+         (!aes_cipher_core_enable ? sfifo_blkenc_not_empty : cipher_out_valid);
 
   assign block_encrypt_cmd_o = sfifo_blkenc_cmd;
   assign block_encrypt_id_o = sfifo_blkenc_id;
-  assign block_encrypt_v_o = block_encrypt_bypass_i ? sfifo_blkenc_v : cipher_data_out;
+  assign block_encrypt_v_o = !aes_cipher_core_enable ? sfifo_blkenc_v : cipher_data_out;
   assign cipher_out_ready = block_encrypt_rdy_i;
 
   assign block_encrypt_sfifo_blkenc_err_o =

--- a/hw/ip/csrng/rtl/csrng_core.sv
+++ b/hw/ip/csrng/rtl/csrng_core.sv
@@ -19,6 +19,9 @@ module csrng_core import csrng_pkg::*; #(
   // Efuse Interface
   input efuse_sw_app_enable_i,
 
+  // Lifecycle broadcast inputs
+  input  lc_ctrl_pkg::lc_tx_t  lc_dft_en_i,
+
   // Entropy Interface
   output entropy_src_pkg::entropy_src_hw_if_req_t entropy_src_hw_if_o,
   input  entropy_src_pkg::entropy_src_hw_if_rsp_t entropy_src_hw_if_i,
@@ -417,20 +420,20 @@ module csrng_core import csrng_pkg::*; #(
  // set the err code type bits
   assign hw2reg.err_code.fifo_write_err.d = 1'b1;
   assign hw2reg.err_code.fifo_write_err.de =
-         block_encrypt_sfifo_blkenc_err[0] ||
-         ctr_drbg_gen_sfifo_ggenbits_err[0] ||
-         ctr_drbg_gen_sfifo_gadstage_err[0] ||
-         ctr_drbg_gen_sfifo_ggenreq_err[0] ||
-         ctr_drbg_gen_sfifo_grcstage_err[0] ||
-         ctr_drbg_gen_sfifo_gbencack_err[0] ||
-         ctr_drbg_upd_sfifo_final_err[0] ||
-         ctr_drbg_upd_sfifo_pdata_err[0] ||
-         ctr_drbg_upd_sfifo_bencack_err[0] ||
-         ctr_drbg_upd_sfifo_bencreq_err[0] ||
-         ctr_drbg_upd_sfifo_updreq_err[0] ||
-         ctr_drbg_cmd_sfifo_keyvrc_err[0] ||
-         ctr_drbg_cmd_sfifo_rcstage_err[0] ||
-         ctr_drbg_cmd_sfifo_cmdreq_err[0] ||
+         block_encrypt_sfifo_blkenc_err[2] ||
+         ctr_drbg_gen_sfifo_ggenbits_err[2] ||
+         ctr_drbg_gen_sfifo_gadstage_err[2] ||
+         ctr_drbg_gen_sfifo_ggenreq_err[2] ||
+         ctr_drbg_gen_sfifo_grcstage_err[2] ||
+         ctr_drbg_gen_sfifo_gbencack_err[2] ||
+         ctr_drbg_upd_sfifo_final_err[2] ||
+         ctr_drbg_upd_sfifo_pdata_err[2] ||
+         ctr_drbg_upd_sfifo_bencack_err[2] ||
+         ctr_drbg_upd_sfifo_bencreq_err[2] ||
+         ctr_drbg_upd_sfifo_updreq_err[2] ||
+         ctr_drbg_cmd_sfifo_keyvrc_err[2] ||
+         ctr_drbg_cmd_sfifo_rcstage_err[2] ||
+         ctr_drbg_cmd_sfifo_cmdreq_err[2] ||
          (|cmd_stage_sfifo_genbits_err_wr) ||
          (|cmd_stage_sfifo_cmd_err_wr);
 
@@ -455,20 +458,20 @@ module csrng_core import csrng_pkg::*; #(
 
   assign hw2reg.err_code.fifo_state_err.d = 1'b1;
   assign hw2reg.err_code.fifo_state_err.de =
-         block_encrypt_sfifo_blkenc_err[2] ||
-         ctr_drbg_gen_sfifo_ggenbits_err[2] ||
-         ctr_drbg_gen_sfifo_gadstage_err[2] ||
-         ctr_drbg_gen_sfifo_ggenreq_err[2] ||
-         ctr_drbg_gen_sfifo_grcstage_err[2] ||
-         ctr_drbg_gen_sfifo_gbencack_err[2] ||
-         ctr_drbg_upd_sfifo_final_err[2] ||
-         ctr_drbg_upd_sfifo_pdata_err[2] ||
-         ctr_drbg_upd_sfifo_bencack_err[2] ||
-         ctr_drbg_upd_sfifo_bencreq_err[2] ||
-         ctr_drbg_upd_sfifo_updreq_err[2] ||
-         ctr_drbg_cmd_sfifo_keyvrc_err[2] ||
-         ctr_drbg_cmd_sfifo_rcstage_err[2] ||
-         ctr_drbg_cmd_sfifo_cmdreq_err[2] ||
+         block_encrypt_sfifo_blkenc_err[0] ||
+         ctr_drbg_gen_sfifo_ggenbits_err[0] ||
+         ctr_drbg_gen_sfifo_gadstage_err[0] ||
+         ctr_drbg_gen_sfifo_ggenreq_err[0] ||
+         ctr_drbg_gen_sfifo_grcstage_err[0] ||
+         ctr_drbg_gen_sfifo_gbencack_err[0] ||
+         ctr_drbg_upd_sfifo_final_err[0] ||
+         ctr_drbg_upd_sfifo_pdata_err[0] ||
+         ctr_drbg_upd_sfifo_bencack_err[0] ||
+         ctr_drbg_upd_sfifo_bencreq_err[0] ||
+         ctr_drbg_upd_sfifo_updreq_err[0] ||
+         ctr_drbg_cmd_sfifo_keyvrc_err[0] ||
+         ctr_drbg_cmd_sfifo_rcstage_err[0] ||
+         ctr_drbg_cmd_sfifo_cmdreq_err[0] ||
          (|cmd_stage_sfifo_genbits_err_st) ||
          (|cmd_stage_sfifo_cmd_err_st);
 
@@ -986,6 +989,7 @@ module csrng_core import csrng_pkg::*; #(
     .rst_ni(rst_ni),
     .block_encrypt_bypass_i(!aes_cipher_enable),
     .block_encrypt_enable_i(cs_enable),
+    .block_encrypt_lc_dft_en_i(lc_dft_en_i),
     .block_encrypt_req_i(benblk_arb_vld),
     .block_encrypt_rdy_o(benblk_arb_rdy),
     .block_encrypt_key_i(benblk_arb_key),


### PR DESCRIPTION
The lifecycle input will make sure that aes bypass will only occur in certain modes.
This is related to issue #3894
Also, some minor text corrects are made to the hjson file.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>