### PR TITLE
[sw] Cleanup Device Image Linker Scripts

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -90,6 +90,8 @@ c_cpp_cross_args = [
   '-nostdinc',
   # Use OpenTitan's freestanding headers instead
   '-isystem' + meson.source_root() / 'sw/device/lib/base/freestanding',
+  # Don't emit unwinding information
+  '-fno-asynchronous-unwind-tables',
 ]
 
 # Add extra warning flags for cross builds, if they are supported.
@@ -112,6 +114,12 @@ c_cpp_cross_link_args = [
   '-nostdlib',
    # Only link static files
   '-static',
+  # Warn if we use COMMON
+  '-Wl,--warn-common',
+  # Warn if we include orphan sections
+  '-Wl,--orphan-handling=warn',
+  # Turn Linker Warnings into Errors
+  '-Wl,--fatal-warnings',
 ]
 add_project_link_arguments(
   c_cpp_cross_link_args,

--- a/sw/device/boot_rom/rom_link.ld
+++ b/sw/device/boot_rom/rom_link.ld
@@ -42,6 +42,16 @@ _flash_header = _flash_start;
 _chip_info_size = 128;
 _chip_info_start = ORIGIN(rom) + LENGTH(rom) - _chip_info_size;
 
+/* DV Log offset (has to be different to other boot stages). */
+_dv_log_offset = 0x0;
+
+/**
+ * We define an entry point only for documentation purposes (and to stop LLD
+ * erroring). In reality, we don't use this information within the ROM image, as
+ * we start at a fixed offset.
+ */
+ENTRY(_reset_start);
+
 /**
  * NOTE: We have to align each section to word boundaries as our current
  * s19->slm conversion scripts are not able to handle non-word aligned sections.
@@ -134,42 +144,9 @@ SECTIONS {
     *(.sbss.*)
     *(.bss)
     *(.bss.*)
-    *(COMMON)
     . = ALIGN(4);
     _bss_end = .;
   } > ram_main
 
-  /**
-   * STAB debug table.
-   */
-  .stab 0x0 (NOLOAD): {
-    [.stab]
-  }
-
-  /**
-   * STAB debug strings.
-   */
-  .stabstr 0x0 (NOLOAD): {
-    [.stabstr]
-  }
-
-  /**
-   * The following sections are used by DV to implement logging in an
-   * alternate way, which enables simulation speed up by completely avoiding
-   * any string format processing or even the actual transmission of log data
-   * to a real peripheral.
-   *
-   * These sections are marked as dummy so that they can still be extracted
-   * using readelf or similar utilities. As such, the content in these sections
-   * is not relevant for the actual SW code and can be safely discarded.
-   */
-
-  /**
-   * The following section contains log fields constructed from the logs using
-   * the log_fields_t struct defined in sw/device/lib/runtime/log.h. The size of
-   * each log field is fixed - 20 bytes, which is used as the delimiter.
-   */
-  .logs.fields 0x0 (DSECT): {
-    *(.logs.fields)
-  }
+  INCLUDE sw/device/info_sections.ld
 }

--- a/sw/device/exts/common/flash_link.ld
+++ b/sw/device/exts/common/flash_link.ld
@@ -29,6 +29,17 @@ _stack_size = 0x2000;
 _stack_end = ORIGIN(ram_main) + LENGTH(ram_main);
 _stack_start = _stack_end - _stack_size;
 
+/* DV Log offset (has to be different to other boot stages). */
+_dv_log_offset = 0x10000;
+
+/**
+ * The entry point in `flash_crt.S` is called `_start`. This information in the
+ * ELF file is not used - instead we use the information in the `.flash_header`
+ * section to understand where to start execution of a flash image. We need this
+ * declaration so LLD does not error.
+ */
+ENTRY(_start);
+
 SECTIONS {
   /**
    * The flash header. This will eventually contain other stuff, like a
@@ -41,8 +52,8 @@ SECTIONS {
   /**
    * C runtime (CRT) section, containing program initialization code.
    *
-   * We don't use ENTRY, so the start of |flash| acts as the entrypoint. Since
-   * the CRT is the first thing that needs to run, it goes at the top.
+   * The flash header contains the address of the entry point, _start, which is
+   * inside this section. We keep them together in the linked elf files too.
    */
   .crt : ALIGN(4) {
     KEEP(*(.crt))
@@ -143,42 +154,9 @@ SECTIONS {
     *(.sbss.*)
     *(.bss)
     *(.bss.*)
-    *(COMMON)
     . = ALIGN(4);
     _bss_end = .;
   } > ram_main
 
-  /**
-   * STAB debug table.
-   */
-  .stab 0x0 (NOLOAD): {
-    *(.stab)
-  }
-
-  /**
-   * STAB debug strings.
-   */
-  .stabstr 0x0 (NOLOAD): {
-    *(.stabstr)
-  }
-
-  /**
-   * The following sections are used by DV to implement logging in an
-   * alternate way, which enables simulation speed up by completely avoiding
-   * any string format processing or even the actual transmission of log data
-   * to a real peripheral.
-   *
-   * These sections are marked as dummy so that they can still be extracted
-   * using readelf or similar utilities. As such, the content in these sections
-   * is not relevant for the actual SW code and can be safely discarded.
-   */
-
-  /**
-   * The following section contains log fields constructed from the logs using
-   * the log_fields_t struct defined in sw/device/lib/runtime/log.h. The size of
-   * each log field is fixed - 20 bytes, which is used as the delimiter.
-   */
-  .logs.fields 0x10000 (DSECT): {
-    *(.logs.fields)
-  }
+  INCLUDE sw/device/info_sections.ld
 }

--- a/sw/device/info_sections.ld
+++ b/sw/device/info_sections.ld
@@ -1,0 +1,91 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * Partial Linker Script for OpenTitan Device Executables
+ *
+ * This Linker Script controls all the sections that we need in the ELF file for
+ * a device executable, but which are not mapped into memory or otherwise
+ * allocated on the device itself.
+ *
+ * These contain amongst other things:
+ * - debugging information needed by DV logging,
+ * - DWARF Sections
+ * - RISC-V Attributes sections
+ *
+ * This is also where we specify the sections to discard, because it is a common
+ * file between all our other linker scripts.
+ *
+ * This partial linker script requires the main linker script to define the
+ * following symbols:
+ * - _dv_log_offset
+ */
+
+/*
+ * Start DV Sections.
+ *
+ * The following sections are used by DV to implement logging in an
+ * alternate way, which enables simulation speed up by completely avoiding
+ * any string format processing or even the actual transmission of log data
+ * to a real peripheral.
+ *
+ * These sections are marked as dummy so that they can still be extracted
+ * using readelf or similar utilities. As such, the content in these sections
+ * is not relevant for the actual SW code and can be safely discarded.
+ */
+
+/**
+ * The following section contains log fields constructed from the logs using
+ * the log_fields_t struct defined in sw/device/lib/runtime/log.h. The size of
+ * each log field is fixed - 20 bytes.
+ */
+.logs.fields _dv_log_offset (INFO): {
+  *(.logs.fields)
+}
+
+/*
+ * End DV Sections
+ */
+
+/* ELF-internal Sections. */
+.symtab 0x0 : { *(.symtab) }
+.strtab 0x0 : { *(.strtab) }
+.shstrtab 0x0 : { *(.shstrtab) }
+
+/* Preserve RISC-V Attributes */
+.riscv.attributes 0x0 : { *(.riscv.attributes) }
+
+/* Preserve Debug Info in ELF Files */
+.debug_info 0x0 : { *(.debug_info) }
+.debug_abbrev 0x0 : { *(.debug_abbrev) }
+.debug_aranges 0x0 : { *(.debug_aranges) }
+.debug_line 0x0 : { *(.debug_line) }
+.debug_loc 0x0 : { *(.debug_loc) }
+.debug_ranges 0x0 : { *(.debug_ranges) }
+.debug_str 0x0 : { *(.debug_str) }
+.debug_frame 0x0 : { *(.debug_frame) }
+
+/* Discarded Sections (Not needed in device images). */
+/DISCARD/ : {
+  /* We don't keep unwind information */
+  *(.eh_frame)
+  *(.eh_frame_hdr)
+
+  /* Compiler Information */
+  *(.comment)
+  *(.comment.*)
+
+  /* Other Notes */
+  *(.note)
+  *(.note.*)
+
+  /* Relocations */
+  *(.rela.*)
+  *(.rela.dyn)
+
+  /* STAB Debugging Info - We Use DWARF */
+  *(.stab)
+  *(.stab.*)
+  *(.stabstr)
+}

--- a/sw/device/mask_rom/mask_rom.ld
+++ b/sw/device/mask_rom/mask_rom.ld
@@ -34,6 +34,12 @@ _chip_info_size  = 0x80;
 _chip_info_end   = ORIGIN(rom) + LENGTH(rom);
 _chip_info_start = _chip_info_end - _chip_info_size;
 
+/* DV Log offset (has to be different to other boot stages). */
+_dv_log_offset = 0x0;
+
+
+ENTRY(_mask_rom_start_boot);
+
 /**
  * NOTE: We have to align each section to word boundaries as our current
  * s19->slm conversion scripts are not able to handle non-word aligned sections.
@@ -137,9 +143,6 @@ SECTIONS {
     *(.bss)
     *(.bss.*)
 
-    /* Any other uninitialized data. */
-    *(COMMON)
-
     /* Ensure section end is word-aligned. */
     . = ALIGN(4);
     _bss_end = .;
@@ -154,37 +157,5 @@ SECTIONS {
     KEEP(*(.chip_info))
   } > rom
 
-  /**
-   * STAB debug table.
-   */
-  .stab 0x0 (NOLOAD): {
-    [.stab]
-  }
-
-  /**
-   * STAB debug strings.
-   */
-  .stabstr 0x0 (NOLOAD): {
-    [.stabstr]
-  }
-
-  /**
-   * The following sections are used by DV to implement logging in an
-   * alternate way, which enables simulation speed up by completely avoiding
-   * any string format processing or even the actual transmission of log data
-   * to a real peripheral.
-   *
-   * These sections are marked as dummy so that they can still be extracted
-   * using readelf or similar utilities. As such, the content in these sections
-   * is not relevant for the actual SW code and can be safely discarded.
-   */
-
-  /**
-   * The following section contains log fields constructed from the logs using
-   * the log_fields_t struct defined in sw/device/lib/runtime/log.h. The size of
-   * each log field is fixed - 20 bytes, which is used as the delimiter.
-   */
-  .logs.fields 0x0 (DSECT): {
-    *(.logs.fields)
-  }
+  INCLUDE sw/device/info_sections.ld
 }

--- a/sw/device/mask_rom/meson.build
+++ b/sw/device/mask_rom/meson.build
@@ -10,7 +10,7 @@ rom_linkfile = files(['mask_rom.ld'])
 rom_link_args = [
   '-Wl,-L,@0@'.format(meson.source_root()),
   '-Wl,-T,@0@/@1@'.format(meson.source_root(), rom_linkfile[0]),
-  '-Wl,--build-id=none',
+  embedded_target_extra_link_args
 ]
 rom_link_deps = [rom_linkfile]
 

--- a/sw/device/meson.build
+++ b/sw/device/meson.build
@@ -30,6 +30,10 @@ export_embedded_target = [
   '@INPUT@',
 ]
 
+embedded_target_extra_link_args = [
+  '-Wl,--build-id=none',
+]
+
 subdir('boot_rom')
 subdir('rom_exts')
 subdir('mask_rom')

--- a/sw/device/rom_exts/meson.build
+++ b/sw/device/rom_exts/meson.build
@@ -17,7 +17,7 @@ rom_ext_link_info = {
     [
       '-Wl,-L,@0@'.format(meson.source_root()),
       '-Wl,-T,@0@/@1@'.format(meson.source_root(), rom_ext_linkfile_slot_a[0]),
-      '-Wl,--build-id=none',
+      embedded_target_extra_link_args,
     ],
     # Link dependency file for slot A.
     [
@@ -30,7 +30,7 @@ rom_ext_link_info = {
     [
       '-Wl,-L,@0@'.format(meson.source_root()),
       '-Wl,-T,@0@/@1@'.format(meson.source_root(), rom_ext_linkfile_slot_b[0]),
-      '-Wl,--build-id=none',
+      embedded_target_extra_link_args,
     ],
     # Link dependency file for slot B.
     [

--- a/sw/device/rom_exts/rom_ext_common.ld
+++ b/sw/device/rom_exts/rom_ext_common.ld
@@ -17,6 +17,9 @@ GROUP(-lgcc)
  */
 __DYNAMIC = 0;
 
+/* DV Log offset (has to be different to other boot stages). */
+_dv_log_offset = 0x10000;
+
 /**
  * Marking the entrypoint correctly for the ELF file. In reality, we will end up
  * using a hard-coded offset from the slot start, as we don't have the ELF info
@@ -132,9 +135,6 @@ SECTIONS {
     *(.bss)
     *(.bss.*)
 
-    /* Any other uninitialized data. */
-    *(COMMON)
-
     /* Ensure section end is word-aligned. */
     . = ALIGN(4);
     _bss_end = .;
@@ -155,37 +155,5 @@ SECTIONS {
     KEEP(*(.rom_ext_end))
   } > eflash
 
-  /**
-   * STAB debug table.
-   */
-  .stab 0x0 (NOLOAD): {
-    [.stab]
-  }
-
-  /**
-   * STAB debug strings.
-   */
-  .stabstr 0x0 (NOLOAD): {
-    [.stabstr]
-  }
-
-  /**
-   * The following sections are used by DV to implement logging in an
-   * alternate way, which enables simulation speed up by completely avoiding
-   * any string format processing or even the actual transmission of log data
-   * to a real peripheral.
-   *
-   * These sections are marked as dummy so that they can still be extracted
-   * using readelf or similar utilities. As such, the content in these sections
-   * is not relevant for the actual SW code and can be safely discarded.
-   */
-
-  /**
-   * The following section contains log fields constructed from the logs using
-   * the log_fields_t struct defined in sw/device/lib/runtime/log.h. The size of
-   * each log field is fixed - 20 bytes, which is used as the delimiter.
-   */
-  .logs.fields 0x0 (DSECT): {
-    *(.logs.fields)
-  }
+  INCLUDE sw/device/info_sections.ld
 }


### PR DESCRIPTION
This change is intended to cleanup how we use our linker scripts and our
linker flags so that we end up with a more controlled set of device ELF
files.

The main way this is done is by extracting out all the informational
sections into a separate linker script fragment, that the other scripts
include.

This change also:
- Disables emitting unwind information.
- Adds some linker arguments to emit warnings if problematic sections
  are emitted (COMMON, and orphan sections).
- Defines entry points for all linker scripts (not that we ever use this
  information, but the ELF format requires it).
- Extracts some common device link arguments that are duplicated in the
  device tree.
- Lays some groundwork for investigating how we can use LLD for
  OpenTitan Device Builds.

Signed-off-by: Sam Elliott <selliott@lowrisc.org>