### PR TITLE
[otbn] Fix idle logic

### DIFF
--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -72,7 +72,7 @@ module otbn
 
   // TODO: Better define what "idle" means -- only the core, or also the
   // register interface?
-  assign idle_o = ~busy_q | ~start;
+  assign idle_o = ~busy_q & ~start;
 
 
   // Interrupts ================================================================


### PR DESCRIPTION
We are idle if we aren't running (`~ busy_q`) and also aren't being told
to start (`~ start`).
