### PR TITLE
[gen_cheader] Only generate module params that are defined in SV package

### DIFF
--- a/util/reggen/gen_cheader.py
+++ b/util/reggen/gen_cheader.py
@@ -159,6 +159,11 @@ def gen_cdefine_window(outstr, win, comp, regwidth, rnames, existing_defines):
 def gen_cdefines_module_param(outstr, param, module_name, existing_defines):
     param_type = param['type']
 
+    # Do not generate C defines for parameters that are not localparams defined
+    # in the corresponding SystemVerilog package.
+    if param["local"].lower() == "false":
+        return
+
     # Presently there is only one type (int), however if the new types are
     # added, they potentially need to be handled differently.
     known_types = ["int"]


### PR DESCRIPTION
We should only convert local parameters that are defined in SV packages.

For instance, if a parameter is exposed to the top-level, there is no guarantee that the parameter will have the value specified here since it can be overridden when instantiating the top.

Further, the random constants are netlist secrets, and should not make their way into SW headers.
In fact, since these have custom SV types, the random constants just produce a bunch of conversion warnings in this script.

Signed-off-by: Michael Schaffner <msf@opentitan.org>