### PR TITLE
[otp] Fix CI private compile error

### DIFF
--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_lfsr_timer.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_lfsr_timer.sv
@@ -304,7 +304,7 @@ module otp_ctrl_lfsr_timer
       integ_chk_req_q <= '0;
       cnsty_chk_req_q <= '0;
       chk_timeout_q   <= 1'b0;
-      reseed_timer_q  <= {ReseedTimerWidth{1'b1}};
+      reseed_timer_q  <= {ReseedLfsrWidth{1'b1}};
     end else begin
       integ_cnt_q <= integ_cnt_d;
       cnsty_cnt_q <= cnsty_cnt_d;


### PR DESCRIPTION
Due to two PRs committed at similar time, PR #3946 and PR #3987, some
paramter names are changed while the other pr still uses the old name.
This PR aligns the naming and solve the compile error.

Signed-off-by: Cindy Chen <chencindy@google.com>