### PR TITLE
[kmac] Integrate to TOP Earlgrey

### DIFF
--- a/hw/ip/kmac/rtl/kmac_core.sv
+++ b/hw/ip/kmac/rtl/kmac_core.sv
@@ -380,11 +380,11 @@ module kmac_core
           st == StKmacMsg && process_latched |=> !process_latched)
 
   // Assume configuration is stable during the operation
-  `ASSUME(KmacEnStable_M, $changed(kmac_en_i) |-> st == StIdle)
-  `ASSUME(ModeStable_M, $changed(mode_i) |-> st == StIdle)
-  `ASSUME(StrengthStable_M, $changed(strength_i) |-> st == StIdle)
-  `ASSUME(KeyLengthStable_M, $changed(key_len_i) |-> st == StIdle)
-  `ASSUME(KeyDataStable_M, $changed(key_data_i) |-> st == StIdle)
+  `ASSUME(KmacEnStable_M, $changed(kmac_en_i) |-> st == StKmacIdle)
+  `ASSUME(ModeStable_M, $changed(mode_i) |-> st == StKmacIdle)
+  `ASSUME(StrengthStable_M, $changed(strength_i) |-> st == StKmacIdle)
+  `ASSUME(KeyLengthStable_M, $changed(key_len_i) |-> st == StKmacIdle)
+  `ASSUME(KeyDataStable_M, $changed(key_data_i) |-> st == StKmacIdle)
 
   // no acked to MsgFIFO in StKmacMsg
   `ASSERT(AckOnlyInMessageState_A,

--- a/hw/ip/tlul/rtl/tlul_socket_1n.sv
+++ b/hw/ip/tlul/rtl/tlul_socket_1n.sv
@@ -57,7 +57,7 @@ module tlul_socket_1n #(
   input  [NWD-1:0]          dev_select_i
 );
 
-  `ASSERT_INIT(maxN, N < 16)
+  `ASSERT_INIT(maxN, N < 32)
 
   // Since our steering is done after potential FIFOing, we need to
   // shove our device select bits into spare bits of reqfifo

--- a/hw/syn/tools/dc/run-syn.tcl
+++ b/hw/syn/tools/dc/run-syn.tcl
@@ -66,7 +66,7 @@ set_app_var hdlin_enable_hier_map true
 set DEFINE "PRIM_DEFAULT_IMPL=${PRIM_DEFAULT_IMPL}+${PRIM_STD_CELL_VARIANT}"
 
 # additional parameters
-set PARAMS ""
+set PARAMS "KmacEnMasking=1"
 
 ###########################
 ##   ELABORATE DESIGN    ##

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -95,6 +95,7 @@
         {
           clk_main_aes: main
           clk_main_hmac: main
+          clk_main_kmac: main
           clk_main_otbn: main
         }
       }
@@ -1195,6 +1196,164 @@
       ]
     }
     {
+      name: kmac
+      type: kmac
+      clock_srcs:
+      {
+        clk_i: main
+      }
+      clock_group: trans
+      reset_connections:
+      {
+        rst_ni: sys
+      }
+      base_addr: 0x41120000
+      clock_reset_export: []
+      clock_connections:
+      {
+        clk_i: clkmgr_clocks.clk_main_kmac
+      }
+      size: 0x1000
+      bus_device: tlul
+      bus_host: none
+      available_input_list: []
+      available_output_list: []
+      available_inout_list: []
+      param_list:
+      [
+        {
+          name: EnMasking
+          type: int
+          default: "0"
+          desc:
+            '''
+            Disable(0) or enable(1) first-order masking of Keccak round.
+
+            If masking is enabled, ReuseShare parameter will impact the design.
+            '''
+          local: "false"
+          expose: "true"
+          randcount: "0"
+          randtype: none
+          name_top: KmacEnMasking
+        }
+        {
+          name: ReuseShare
+          type: int
+          default: "0"
+          desc:
+            '''
+            If enabled (1), the internal Keccak round logic will re-use the
+            adjacent shares as entropy in Domain-Oriented Masking AND logic.
+            It improves the throughput of Keccak, as it only requires small
+            amount of entropy rather than 1600 bit per round.
+
+            This feature is not implemented yet.
+            '''
+          local: "false"
+          expose: "true"
+          randcount: "0"
+          randtype: none
+          name_top: KmacReuseShare
+        }
+      ]
+      interrupt_list:
+      [
+        {
+          name: kmac_done
+          width: 1
+          bits: "0"
+          bitinfo:
+          [
+            1
+            1
+            0
+          ]
+          type: interrupt
+        }
+        {
+          name: fifo_empty
+          width: 1
+          bits: "1"
+          bitinfo:
+          [
+            2
+            1
+            1
+          ]
+          type: interrupt
+        }
+        {
+          name: kmac_err
+          width: 1
+          bits: "2"
+          bitinfo:
+          [
+            4
+            1
+            2
+          ]
+          type: interrupt
+        }
+      ]
+      alert_list: []
+      wakeup_list: []
+      reset_request_list: []
+      scan: "false"
+      scan_reset: "false"
+      inter_signal_list:
+      [
+        {
+          struct: hw_key_req
+          type: uni
+          name: keymgr_key
+          act: rcv
+          package: keymgr_pkg
+          inst_name: kmac
+          width: 1
+          default: ""
+          top_signame: keymgr_kmac_key
+          index: -1
+        }
+        {
+          struct: kmac_data
+          type: req_rsp
+          name: keymgr_kdf
+          act: rsp
+          package: keymgr_pkg
+          inst_name: kmac
+          width: 1
+          default: ""
+          top_signame: keymgr_kmac_data
+          index: -1
+        }
+        {
+          name: idle
+          type: uni
+          act: req
+          package: ""
+          struct: logic
+          width: 1
+          inst_name: kmac
+          default: ""
+          top_signame: clkmgr_idle
+          index: 2
+        }
+        {
+          struct: tl
+          package: tlul_pkg
+          type: req_rsp
+          act: rsp
+          name: tl
+          inst_name: kmac
+          width: 1
+          default: ""
+          top_signame: kmac_tl
+          index: -1
+        }
+      ]
+    }
+    {
       name: rv_plic
       type: rv_plic
       clock_srcs:
@@ -1994,7 +2153,7 @@
           name: idle
           act: rcv
           package: ""
-          width: 3
+          width: 4
           inst_name: clkmgr
           default: ""
           top_type: one-to-N
@@ -2645,6 +2804,10 @@
           act: req
           package: keymgr_pkg
           inst_name: keymgr
+          width: 1
+          default: ""
+          top_type: broadcast
+          top_signame: keymgr_kmac_key
           index: -1
         }
         {
@@ -2654,6 +2817,9 @@
           act: req
           package: keymgr_pkg
           inst_name: keymgr
+          width: 1
+          default: ""
+          top_signame: keymgr_kmac_data
           index: -1
         }
         {
@@ -3145,7 +3311,7 @@
           default: ""
           package: ""
           top_signame: clkmgr_idle
-          index: 2
+          index: 3
         }
         {
           struct: tl
@@ -3362,10 +3528,19 @@
       [
         rstmgr.alert_dump
       ]
+      keymgr.kmac_key:
+      [
+        kmac.keymgr_key
+      ]
+      keymgr.kmac_data:
+      [
+        kmac.keymgr_kdf
+      ]
       clkmgr.idle:
       [
         aes.idle
         hmac.idle
+        kmac.idle
         otbn.idle
       ]
       pwrmgr.wakeups:
@@ -3399,6 +3574,10 @@
       hmac.tl:
       [
         main.tl_hmac
+      ]
+      kmac.tl:
+      [
+        main.tl_kmac
       ]
       aes.tl:
       [
@@ -3555,6 +3734,7 @@
           nmi_gen
           otbn
           keymgr
+          kmac
         ]
         dm_sba:
         [
@@ -3571,6 +3751,7 @@
           alert_handler
           nmi_gen
           otbn
+          kmac
         ]
       }
       nodes:
@@ -3750,6 +3931,24 @@
           [
             {
               base_addr: 0x40120000
+              size_byte: 0x1000
+            }
+          ]
+          xbar: false
+          stub: false
+          pipeline: "true"
+        }
+        {
+          name: kmac
+          type: device
+          clock: clk_main_i
+          rset: rst_main_ni
+          pipeline_byp: "false"
+          inst_type: kmac
+          addr_range:
+          [
+            {
+              base_addr: 0x41120000
               size_byte: 0x1000
             }
           ]
@@ -4022,6 +4221,18 @@
           width: 1
           default: ""
           top_signame: hmac_tl
+          index: -1
+        }
+        {
+          struct: tl
+          type: req_rsp
+          name: tl_kmac
+          act: req
+          package: tlul_pkg
+          inst_name: main
+          width: 1
+          default: ""
+          top_signame: kmac_tl
           index: -1
         }
         {
@@ -4563,6 +4774,7 @@
     pwrmgr
     otbn
     keymgr
+    kmac
   ]
   interrupt:
   [
@@ -5242,6 +5454,45 @@
       type: interrupt
       module_name: keymgr
     }
+    {
+      name: kmac_kmac_done
+      width: 1
+      bits: "0"
+      bitinfo:
+      [
+        1
+        1
+        0
+      ]
+      type: interrupt
+      module_name: kmac
+    }
+    {
+      name: kmac_fifo_empty
+      width: 1
+      bits: "1"
+      bitinfo:
+      [
+        2
+        1
+        1
+      ]
+      type: interrupt
+      module_name: kmac
+    }
+    {
+      name: kmac_kmac_err
+      width: 1
+      bits: "2"
+      bitinfo:
+      [
+        4
+        1
+        2
+      ]
+      type: interrupt
+      module_name: kmac
+    }
   ]
   alert_module:
   [
@@ -5918,6 +6169,54 @@
         index: -1
       }
       {
+        struct: hw_key_req
+        type: uni
+        name: keymgr_key
+        act: rcv
+        package: keymgr_pkg
+        inst_name: kmac
+        width: 1
+        default: ""
+        top_signame: keymgr_kmac_key
+        index: -1
+      }
+      {
+        struct: kmac_data
+        type: req_rsp
+        name: keymgr_kdf
+        act: rsp
+        package: keymgr_pkg
+        inst_name: kmac
+        width: 1
+        default: ""
+        top_signame: keymgr_kmac_data
+        index: -1
+      }
+      {
+        name: idle
+        type: uni
+        act: req
+        package: ""
+        struct: logic
+        width: 1
+        inst_name: kmac
+        default: ""
+        top_signame: clkmgr_idle
+        index: 2
+      }
+      {
+        struct: tl
+        package: tlul_pkg
+        type: req_rsp
+        act: rsp
+        name: tl
+        inst_name: kmac
+        width: 1
+        default: ""
+        top_signame: kmac_tl
+        index: -1
+      }
+      {
         struct: tl
         package: tlul_pkg
         type: req_rsp
@@ -6340,7 +6639,7 @@
         name: idle
         act: rcv
         package: ""
-        width: 3
+        width: 4
         inst_name: clkmgr
         default: ""
         top_type: one-to-N
@@ -6484,6 +6783,10 @@
         act: req
         package: keymgr_pkg
         inst_name: keymgr
+        width: 1
+        default: ""
+        top_type: broadcast
+        top_signame: keymgr_kmac_key
         index: -1
       }
       {
@@ -6493,6 +6796,9 @@
         act: req
         package: keymgr_pkg
         inst_name: keymgr
+        width: 1
+        default: ""
+        top_signame: keymgr_kmac_data
         index: -1
       }
       {
@@ -6718,7 +7024,7 @@
         default: ""
         package: ""
         top_signame: clkmgr_idle
-        index: 2
+        index: 3
       }
       {
         struct: tl
@@ -6910,6 +7216,18 @@
         width: 1
         default: ""
         top_signame: hmac_tl
+        index: -1
+      }
+      {
+        struct: tl
+        type: req_rsp
+        name: tl_kmac
+        act: req
+        package: tlul_pkg
+        inst_name: main
+        width: 1
+        default: ""
+        top_signame: kmac_tl
         index: -1
       }
       {
@@ -7430,10 +7748,34 @@
         default: ""
       }
       {
+        package: keymgr_pkg
+        struct: hw_key_req
+        signame: keymgr_kmac_key
+        width: 1
+        type: uni
+        default: ""
+      }
+      {
+        package: keymgr_pkg
+        struct: kmac_data_req
+        signame: keymgr_kmac_data_req
+        width: 1
+        type: req_rsp
+        default: ""
+      }
+      {
+        package: keymgr_pkg
+        struct: kmac_data_rsp
+        signame: keymgr_kmac_data_rsp
+        width: 1
+        type: req_rsp
+        default: ""
+      }
+      {
         package: ""
         struct: logic
         signame: clkmgr_idle
-        width: 3
+        width: 4
         type: uni
         default: ""
       }
@@ -7545,6 +7887,22 @@
         package: tlul_pkg
         struct: tl_d2h
         signame: hmac_tl_rsp
+        width: 1
+        type: req_rsp
+        default: ""
+      }
+      {
+        package: tlul_pkg
+        struct: tl_h2d
+        signame: kmac_tl_req
+        width: 1
+        type: req_rsp
+        default: ""
+      }
+      {
+        package: tlul_pkg
+        struct: tl_d2h
+        signame: kmac_tl_rsp
         width: 1
         type: req_rsp
         default: ""

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -218,6 +218,13 @@
       reset_connections: {rst_ni: "sys"},
       base_addr: "0x40120000",
     },
+    { name: "kmac"
+      type: "kmac"
+      clock_srcs: {clk_i: "main"}
+      clock_group: "trans"
+      reset_connections: {rst_ni: "sys"}
+      base_addr: "0x41120000"
+    }
     { name: "rv_plic",
       type: "rv_plic",
       clock_srcs: {clk_i: "main"},
@@ -428,6 +435,10 @@
       'pwrmgr.pwr_otp'   : ['otp_ctrl.pwr_otp'],
       'flash_ctrl.keymgr': ['keymgr.flash'],
       'alert_handler.crashdump': ['rstmgr.alert_dump'],
+
+      // KeyMgr Sideload & KDF function
+      'keymgr.kmac_key' : ['kmac.keymgr_key']
+      'keymgr.kmac_data': ['kmac.keymgr_kdf']
       // The idle connection is automatically connected through topgen.
       // The user does not need to explicitly declare anything other than
       // an empty list.
@@ -490,7 +501,7 @@
   // first item goes to LSB of the interrupt source
   interrupt_module: ["gpio", "uart", "spi_device", "flash_ctrl",
                      "hmac", "alert_handler", "nmi_gen", "usbdev", "pwrmgr",
-                     "otbn", "keymgr" ]
+                     "otbn", "keymgr", "kmac" ]
 
   // RV_PLIC has two searching algorithm internally to pick the most highest priority interrupt
   // source. "sequential" is smaller but slower, "matrix" is larger but faster.

--- a/hw/top_earlgrey/data/xbar_main.hjson
+++ b/hw/top_earlgrey/data/xbar_main.hjson
@@ -72,6 +72,12 @@
       reset:     "rst_main_ni",
       pipeline_byp: "false"
     },
+    { name:         "kmac"
+      type:         "device"
+      clock:        "clk_main_i"
+      rset:         "rst_main_ni"
+      pipeline_byp: "false"
+    }
     { name:      "aes",
       type:      "device",
       clock:     "clk_main_i"
@@ -141,8 +147,8 @@
   connections: {
     corei:  ["rom", "debug_mem", "ram_main", "eflash"],
     cored:  ["rom", "debug_mem", "ram_main", "eflash", "peri", "flash_ctrl",
-    "aes", "hmac", "rv_plic", "pinmux", "padctrl", "alert_handler", "nmi_gen", "otbn", "keymgr"],
+    "aes", "hmac", "rv_plic", "pinmux", "padctrl", "alert_handler", "nmi_gen", "otbn", "keymgr", "kmac"],
     dm_sba: ["rom",              "ram_main", "eflash", "peri", "flash_ctrl",
-    "aes", "hmac", "rv_plic", "pinmux", "padctrl", "alert_handler", "nmi_gen", "otbn"],
+    "aes", "hmac", "rv_plic", "pinmux", "padctrl", "alert_handler", "nmi_gen", "otbn", "kmac"],
   },
 }

--- a/hw/top_earlgrey/dv/autogen/tb__xbar_connect.sv
+++ b/hw/top_earlgrey/dv/autogen/tb__xbar_connect.sv
@@ -39,6 +39,7 @@ tl_if ram_main_tl_if(clk_main, rst_n);
 tl_if eflash_tl_if(clk_main, rst_n);
 tl_if flash_ctrl_tl_if(clk_main, rst_n);
 tl_if hmac_tl_if(clk_main, rst_n);
+tl_if kmac_tl_if(clk_main, rst_n);
 tl_if aes_tl_if(clk_main, rst_n);
 tl_if rv_plic_tl_if(clk_main, rst_n);
 tl_if pinmux_tl_if(clk_main, rst_n);
@@ -93,6 +94,7 @@ initial begin
     `DRIVE_CHIP_TL_DEVICE_IF(eflash, tl_adapter_eflash, tl)
     `DRIVE_CHIP_TL_DEVICE_IF(flash_ctrl, flash_ctrl, tl)
     `DRIVE_CHIP_TL_DEVICE_IF(hmac, hmac, tl)
+    `DRIVE_CHIP_TL_DEVICE_IF(kmac, kmac, tl)
     `DRIVE_CHIP_TL_DEVICE_IF(aes, aes, tl)
     `DRIVE_CHIP_TL_DEVICE_IF(rv_plic, rv_plic, tl)
     `DRIVE_CHIP_TL_DEVICE_IF(pinmux, pinmux, tl)

--- a/hw/top_earlgrey/dv/autogen/xbar_env_pkg__params.sv
+++ b/hw/top_earlgrey/dv/autogen/xbar_env_pkg__params.sv
@@ -25,6 +25,9 @@ tl_device_t xbar_devices[$] = '{
     '{"hmac", '{
         '{32'h40120000, 32'h40120fff}
     }},
+    '{"kmac", '{
+        '{32'h41120000, 32'h41120fff}
+    }},
     '{"aes", '{
         '{32'h40110000, 32'h40110fff}
     }},
@@ -120,7 +123,8 @@ tl_host_t xbar_hosts[$] = '{
         "alert_handler",
         "nmi_gen",
         "otbn",
-        "keymgr"}}
+        "keymgr",
+        "kmac"}}
     ,
     '{"dm_sba", 2, '{
         "rom",
@@ -146,5 +150,6 @@ tl_host_t xbar_hosts[$] = '{
         "padctrl",
         "alert_handler",
         "nmi_gen",
-        "otbn"}}
+        "otbn",
+        "kmac"}}
 };

--- a/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
+++ b/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
@@ -97,7 +97,7 @@
       name:    "idle",
       act:     "rcv",
       package: "",
-      width:   "3"
+      width:   "4"
     },
   ],
 
@@ -167,6 +167,15 @@
         }
         {
           bits: "2",
+          name: "CLK_MAIN_KMAC_HINT",
+          resval: 1,
+          desc: '''
+            0 CLK_MAIN_KMAC can be disabled.
+            1 CLK_MAIN_KMAC is enabled.
+          '''
+        }
+        {
+          bits: "3",
           name: "CLK_MAIN_OTBN_HINT",
           resval: 1,
           desc: '''
@@ -209,6 +218,15 @@
         }
         {
           bits: "2",
+          name: "CLK_MAIN_KMAC_VAL",
+          resval: 1,
+          desc: '''
+            0 CLK_MAIN_KMAC is disabled.
+            1 CLK_MAIN_KMAC is enabled.
+          '''
+        }
+        {
+          bits: "3",
           name: "CLK_MAIN_OTBN_VAL",
           resval: 1,
           desc: '''

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
@@ -47,7 +47,7 @@ module clkmgr import clkmgr_pkg::*; (
   input clk_dft_t dft_i,
 
   // idle hints
-  input [2:0] idle_i,
+  input [3:0] idle_i,
 
   // clock output interface
   output clkmgr_ast_out_t clocks_ast_o,
@@ -289,6 +289,8 @@ module clkmgr import clkmgr_pkg::*; (
   logic clk_main_aes_en;
   logic clk_main_hmac_hint;
   logic clk_main_hmac_en;
+  logic clk_main_kmac_hint;
+  logic clk_main_kmac_en;
   logic clk_main_otbn_hint;
   logic clk_main_otbn_en;
 
@@ -328,6 +330,24 @@ module clkmgr import clkmgr_pkg::*; (
     .clk_o(clocks_o.clk_main_hmac)
   );
 
+  assign clk_main_kmac_en = clk_main_kmac_hint | ~idle_i[Kmac];
+
+  prim_flop_2sync #(
+    .Width(1)
+  ) u_clk_main_kmac_hint_sync (
+    .clk_i(clk_main_i),
+    .rst_ni(rst_main_ni),
+    .d_i(reg2hw.clk_hints.clk_main_kmac_hint.q),
+    .q_o(clk_main_kmac_hint)
+  );
+
+  prim_clock_gating u_clk_main_kmac_cg (
+    .clk_i(clk_main_i),
+    .en_i(clk_main_kmac_en & clk_main_en),
+    .test_en_i(dft_i.test_en),
+    .clk_o(clocks_o.clk_main_kmac)
+  );
+
   assign clk_main_otbn_en = clk_main_otbn_hint | ~idle_i[Otbn];
 
   prim_flop_2sync #(
@@ -352,6 +372,8 @@ module clkmgr import clkmgr_pkg::*; (
   assign hw2reg.clk_hints_status.clk_main_aes_val.d = clk_main_aes_en;
   assign hw2reg.clk_hints_status.clk_main_hmac_val.de = 1'b1;
   assign hw2reg.clk_hints_status.clk_main_hmac_val.d = clk_main_hmac_en;
+  assign hw2reg.clk_hints_status.clk_main_kmac_val.de = 1'b1;
+  assign hw2reg.clk_hints_status.clk_main_kmac_val.d = clk_main_kmac_en;
   assign hw2reg.clk_hints_status.clk_main_otbn_val.de = 1'b1;
   assign hw2reg.clk_hints_status.clk_main_otbn_val.d = clk_main_otbn_en;
 

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_pkg.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_pkg.sv
@@ -15,7 +15,8 @@ package clkmgr_pkg;
   typedef enum int {
     Aes = 0,
     Hmac = 1,
-    Otbn = 2
+    Kmac = 2,
+    Otbn = 3
   } hint_names_e;
 
   typedef struct packed {
@@ -36,6 +37,7 @@ package clkmgr_pkg;
   logic clk_aon_secure;
   logic clk_main_aes;
   logic clk_main_hmac;
+  logic clk_main_kmac;
   logic clk_main_otbn;
   logic clk_main_infra;
   logic clk_io_div4_infra;
@@ -55,11 +57,11 @@ package clkmgr_pkg;
   } clkmgr_ast_out_t;
 
   typedef struct packed {
-    logic [3-1:0] idle;
+    logic [4-1:0] idle;
   } clk_hint_status_t;
 
   parameter clk_hint_status_t CLK_HINT_STATUS_DEFAULT = '{
-    idle: {3{1'b1}}
+    idle: {4{1'b1}}
   };
 
 

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_pkg.sv
@@ -30,6 +30,9 @@ package clkmgr_reg_pkg;
     } clk_main_hmac_hint;
     struct packed {
       logic        q;
+    } clk_main_kmac_hint;
+    struct packed {
+      logic        q;
     } clk_main_otbn_hint;
   } clkmgr_reg2hw_clk_hints_reg_t;
 
@@ -46,6 +49,10 @@ package clkmgr_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
+    } clk_main_kmac_val;
+    struct packed {
+      logic        d;
+      logic        de;
     } clk_main_otbn_val;
   } clkmgr_hw2reg_clk_hints_status_reg_t;
 
@@ -54,15 +61,15 @@ package clkmgr_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    clkmgr_reg2hw_clk_enables_reg_t clk_enables; // [4:3]
-    clkmgr_reg2hw_clk_hints_reg_t clk_hints; // [2:0]
+    clkmgr_reg2hw_clk_enables_reg_t clk_enables; // [5:4]
+    clkmgr_reg2hw_clk_hints_reg_t clk_hints; // [3:0]
   } clkmgr_reg2hw_t;
 
   ///////////////////////////////////////
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    clkmgr_hw2reg_clk_hints_status_reg_t clk_hints_status; // [5:6]
+    clkmgr_hw2reg_clk_hints_status_reg_t clk_hints_status; // [7:8]
   } clkmgr_hw2reg_t;
 
   // Register Address

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
@@ -83,11 +83,15 @@ module clkmgr_reg_top (
   logic clk_hints_clk_main_hmac_hint_qs;
   logic clk_hints_clk_main_hmac_hint_wd;
   logic clk_hints_clk_main_hmac_hint_we;
+  logic clk_hints_clk_main_kmac_hint_qs;
+  logic clk_hints_clk_main_kmac_hint_wd;
+  logic clk_hints_clk_main_kmac_hint_we;
   logic clk_hints_clk_main_otbn_hint_qs;
   logic clk_hints_clk_main_otbn_hint_wd;
   logic clk_hints_clk_main_otbn_hint_we;
   logic clk_hints_status_clk_main_aes_val_qs;
   logic clk_hints_status_clk_main_hmac_val_qs;
+  logic clk_hints_status_clk_main_kmac_val_qs;
   logic clk_hints_status_clk_main_otbn_val_qs;
 
   // Register instances
@@ -199,7 +203,33 @@ module clkmgr_reg_top (
   );
 
 
-  //   F[clk_main_otbn_hint]: 2:2
+  //   F[clk_main_kmac_hint]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h1)
+  ) u_clk_hints_clk_main_kmac_hint (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (clk_hints_clk_main_kmac_hint_we),
+    .wd     (clk_hints_clk_main_kmac_hint_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.clk_hints.clk_main_kmac_hint.q ),
+
+    // to register interface (read)
+    .qs     (clk_hints_clk_main_kmac_hint_qs)
+  );
+
+
+  //   F[clk_main_otbn_hint]: 3:3
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
@@ -277,7 +307,32 @@ module clkmgr_reg_top (
   );
 
 
-  //   F[clk_main_otbn_val]: 2:2
+  //   F[clk_main_kmac_val]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RO"),
+    .RESVAL  (1'h1)
+  ) u_clk_hints_status_clk_main_kmac_val (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    .we     (1'b0),
+    .wd     ('0  ),
+
+    // from internal hardware
+    .de     (hw2reg.clk_hints_status.clk_main_kmac_val.de),
+    .d      (hw2reg.clk_hints_status.clk_main_kmac_val.d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (clk_hints_status_clk_main_kmac_val_qs)
+  );
+
+
+  //   F[clk_main_otbn_val]: 3:3
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RO"),
@@ -334,8 +389,12 @@ module clkmgr_reg_top (
   assign clk_hints_clk_main_hmac_hint_we = addr_hit[1] & reg_we & ~wr_err;
   assign clk_hints_clk_main_hmac_hint_wd = reg_wdata[1];
 
+  assign clk_hints_clk_main_kmac_hint_we = addr_hit[1] & reg_we & ~wr_err;
+  assign clk_hints_clk_main_kmac_hint_wd = reg_wdata[2];
+
   assign clk_hints_clk_main_otbn_hint_we = addr_hit[1] & reg_we & ~wr_err;
-  assign clk_hints_clk_main_otbn_hint_wd = reg_wdata[2];
+  assign clk_hints_clk_main_otbn_hint_wd = reg_wdata[3];
+
 
 
 
@@ -352,13 +411,15 @@ module clkmgr_reg_top (
       addr_hit[1]: begin
         reg_rdata_next[0] = clk_hints_clk_main_aes_hint_qs;
         reg_rdata_next[1] = clk_hints_clk_main_hmac_hint_qs;
-        reg_rdata_next[2] = clk_hints_clk_main_otbn_hint_qs;
+        reg_rdata_next[2] = clk_hints_clk_main_kmac_hint_qs;
+        reg_rdata_next[3] = clk_hints_clk_main_otbn_hint_qs;
       end
 
       addr_hit[2]: begin
         reg_rdata_next[0] = clk_hints_status_clk_main_aes_val_qs;
         reg_rdata_next[1] = clk_hints_status_clk_main_hmac_val_qs;
-        reg_rdata_next[2] = clk_hints_status_clk_main_otbn_val_qs;
+        reg_rdata_next[2] = clk_hints_status_clk_main_kmac_val_qs;
+        reg_rdata_next[3] = clk_hints_status_clk_main_otbn_val_qs;
       end
 
       default: begin

--- a/hw/top_earlgrey/ip/rv_plic/data/autogen/rv_plic.hjson
+++ b/hw/top_earlgrey/ip/rv_plic/data/autogen/rv_plic.hjson
@@ -25,7 +25,7 @@
     { name: "NumSrc",
       desc: "Number of interrupt sources",
       type: "int",
-      default: "84",
+      default: "87",
       local: "true"
     },
     { name: "NumTarget",
@@ -735,6 +735,30 @@
     }
     { name: "PRIO83",
       desc: "Interrupt Source 83 Priority",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "1:0" }
+      ],
+    }
+    { name: "PRIO84",
+      desc: "Interrupt Source 84 Priority",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "1:0" }
+      ],
+    }
+    { name: "PRIO85",
+      desc: "Interrupt Source 85 Priority",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "1:0" }
+      ],
+    }
+    { name: "PRIO86",
+      desc: "Interrupt Source 86 Priority",
       swaccess: "rw",
       hwaccess: "hro",
       fields: [

--- a/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic.sv
+++ b/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic.sv
@@ -178,11 +178,14 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   assign prio[81] = reg2hw.prio81.q;
   assign prio[82] = reg2hw.prio82.q;
   assign prio[83] = reg2hw.prio83.q;
+  assign prio[84] = reg2hw.prio84.q;
+  assign prio[85] = reg2hw.prio85.q;
+  assign prio[86] = reg2hw.prio86.q;
 
   //////////////////////
   // Interrupt Enable //
   //////////////////////
-  for (genvar s = 0; s < 84; s++) begin : gen_ie0
+  for (genvar s = 0; s < 87; s++) begin : gen_ie0
     assign ie[0][s] = reg2hw.ie0[s].q;
   end
 
@@ -208,7 +211,7 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   ////////
   // IP //
   ////////
-  for (genvar s = 0; s < 84; s++) begin : gen_ip
+  for (genvar s = 0; s < 87; s++) begin : gen_ip
     assign hw2reg.ip[s].de = 1'b1; // Always write
     assign hw2reg.ip[s].d  = ip[s];
   end
@@ -216,7 +219,7 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   ///////////////////////////////////
   // Detection:: 0: Level, 1: Edge //
   ///////////////////////////////////
-  for (genvar s = 0; s < 84; s++) begin : gen_le
+  for (genvar s = 0; s < 87; s++) begin : gen_le
     assign le[s] = reg2hw.le[s].q;
   end
 

--- a/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_pkg.sv
@@ -7,7 +7,7 @@
 package rv_plic_reg_pkg;
 
   // Param list
-  parameter int NumSrc = 84;
+  parameter int NumSrc = 87;
   parameter int NumTarget = 1;
   parameter int PrioWidth = 2;
 
@@ -355,6 +355,18 @@ package rv_plic_reg_pkg;
   } rv_plic_reg2hw_prio83_reg_t;
 
   typedef struct packed {
+    logic [1:0]  q;
+  } rv_plic_reg2hw_prio84_reg_t;
+
+  typedef struct packed {
+    logic [1:0]  q;
+  } rv_plic_reg2hw_prio85_reg_t;
+
+  typedef struct packed {
+    logic [1:0]  q;
+  } rv_plic_reg2hw_prio86_reg_t;
+
+  typedef struct packed {
     logic        q;
   } rv_plic_reg2hw_ie0_mreg_t;
 
@@ -387,92 +399,95 @@ package rv_plic_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    rv_plic_reg2hw_le_mreg_t [83:0] le; // [347:264]
-    rv_plic_reg2hw_prio0_reg_t prio0; // [263:262]
-    rv_plic_reg2hw_prio1_reg_t prio1; // [261:260]
-    rv_plic_reg2hw_prio2_reg_t prio2; // [259:258]
-    rv_plic_reg2hw_prio3_reg_t prio3; // [257:256]
-    rv_plic_reg2hw_prio4_reg_t prio4; // [255:254]
-    rv_plic_reg2hw_prio5_reg_t prio5; // [253:252]
-    rv_plic_reg2hw_prio6_reg_t prio6; // [251:250]
-    rv_plic_reg2hw_prio7_reg_t prio7; // [249:248]
-    rv_plic_reg2hw_prio8_reg_t prio8; // [247:246]
-    rv_plic_reg2hw_prio9_reg_t prio9; // [245:244]
-    rv_plic_reg2hw_prio10_reg_t prio10; // [243:242]
-    rv_plic_reg2hw_prio11_reg_t prio11; // [241:240]
-    rv_plic_reg2hw_prio12_reg_t prio12; // [239:238]
-    rv_plic_reg2hw_prio13_reg_t prio13; // [237:236]
-    rv_plic_reg2hw_prio14_reg_t prio14; // [235:234]
-    rv_plic_reg2hw_prio15_reg_t prio15; // [233:232]
-    rv_plic_reg2hw_prio16_reg_t prio16; // [231:230]
-    rv_plic_reg2hw_prio17_reg_t prio17; // [229:228]
-    rv_plic_reg2hw_prio18_reg_t prio18; // [227:226]
-    rv_plic_reg2hw_prio19_reg_t prio19; // [225:224]
-    rv_plic_reg2hw_prio20_reg_t prio20; // [223:222]
-    rv_plic_reg2hw_prio21_reg_t prio21; // [221:220]
-    rv_plic_reg2hw_prio22_reg_t prio22; // [219:218]
-    rv_plic_reg2hw_prio23_reg_t prio23; // [217:216]
-    rv_plic_reg2hw_prio24_reg_t prio24; // [215:214]
-    rv_plic_reg2hw_prio25_reg_t prio25; // [213:212]
-    rv_plic_reg2hw_prio26_reg_t prio26; // [211:210]
-    rv_plic_reg2hw_prio27_reg_t prio27; // [209:208]
-    rv_plic_reg2hw_prio28_reg_t prio28; // [207:206]
-    rv_plic_reg2hw_prio29_reg_t prio29; // [205:204]
-    rv_plic_reg2hw_prio30_reg_t prio30; // [203:202]
-    rv_plic_reg2hw_prio31_reg_t prio31; // [201:200]
-    rv_plic_reg2hw_prio32_reg_t prio32; // [199:198]
-    rv_plic_reg2hw_prio33_reg_t prio33; // [197:196]
-    rv_plic_reg2hw_prio34_reg_t prio34; // [195:194]
-    rv_plic_reg2hw_prio35_reg_t prio35; // [193:192]
-    rv_plic_reg2hw_prio36_reg_t prio36; // [191:190]
-    rv_plic_reg2hw_prio37_reg_t prio37; // [189:188]
-    rv_plic_reg2hw_prio38_reg_t prio38; // [187:186]
-    rv_plic_reg2hw_prio39_reg_t prio39; // [185:184]
-    rv_plic_reg2hw_prio40_reg_t prio40; // [183:182]
-    rv_plic_reg2hw_prio41_reg_t prio41; // [181:180]
-    rv_plic_reg2hw_prio42_reg_t prio42; // [179:178]
-    rv_plic_reg2hw_prio43_reg_t prio43; // [177:176]
-    rv_plic_reg2hw_prio44_reg_t prio44; // [175:174]
-    rv_plic_reg2hw_prio45_reg_t prio45; // [173:172]
-    rv_plic_reg2hw_prio46_reg_t prio46; // [171:170]
-    rv_plic_reg2hw_prio47_reg_t prio47; // [169:168]
-    rv_plic_reg2hw_prio48_reg_t prio48; // [167:166]
-    rv_plic_reg2hw_prio49_reg_t prio49; // [165:164]
-    rv_plic_reg2hw_prio50_reg_t prio50; // [163:162]
-    rv_plic_reg2hw_prio51_reg_t prio51; // [161:160]
-    rv_plic_reg2hw_prio52_reg_t prio52; // [159:158]
-    rv_plic_reg2hw_prio53_reg_t prio53; // [157:156]
-    rv_plic_reg2hw_prio54_reg_t prio54; // [155:154]
-    rv_plic_reg2hw_prio55_reg_t prio55; // [153:152]
-    rv_plic_reg2hw_prio56_reg_t prio56; // [151:150]
-    rv_plic_reg2hw_prio57_reg_t prio57; // [149:148]
-    rv_plic_reg2hw_prio58_reg_t prio58; // [147:146]
-    rv_plic_reg2hw_prio59_reg_t prio59; // [145:144]
-    rv_plic_reg2hw_prio60_reg_t prio60; // [143:142]
-    rv_plic_reg2hw_prio61_reg_t prio61; // [141:140]
-    rv_plic_reg2hw_prio62_reg_t prio62; // [139:138]
-    rv_plic_reg2hw_prio63_reg_t prio63; // [137:136]
-    rv_plic_reg2hw_prio64_reg_t prio64; // [135:134]
-    rv_plic_reg2hw_prio65_reg_t prio65; // [133:132]
-    rv_plic_reg2hw_prio66_reg_t prio66; // [131:130]
-    rv_plic_reg2hw_prio67_reg_t prio67; // [129:128]
-    rv_plic_reg2hw_prio68_reg_t prio68; // [127:126]
-    rv_plic_reg2hw_prio69_reg_t prio69; // [125:124]
-    rv_plic_reg2hw_prio70_reg_t prio70; // [123:122]
-    rv_plic_reg2hw_prio71_reg_t prio71; // [121:120]
-    rv_plic_reg2hw_prio72_reg_t prio72; // [119:118]
-    rv_plic_reg2hw_prio73_reg_t prio73; // [117:116]
-    rv_plic_reg2hw_prio74_reg_t prio74; // [115:114]
-    rv_plic_reg2hw_prio75_reg_t prio75; // [113:112]
-    rv_plic_reg2hw_prio76_reg_t prio76; // [111:110]
-    rv_plic_reg2hw_prio77_reg_t prio77; // [109:108]
-    rv_plic_reg2hw_prio78_reg_t prio78; // [107:106]
-    rv_plic_reg2hw_prio79_reg_t prio79; // [105:104]
-    rv_plic_reg2hw_prio80_reg_t prio80; // [103:102]
-    rv_plic_reg2hw_prio81_reg_t prio81; // [101:100]
-    rv_plic_reg2hw_prio82_reg_t prio82; // [99:98]
-    rv_plic_reg2hw_prio83_reg_t prio83; // [97:96]
-    rv_plic_reg2hw_ie0_mreg_t [83:0] ie0; // [95:12]
+    rv_plic_reg2hw_le_mreg_t [86:0] le; // [359:273]
+    rv_plic_reg2hw_prio0_reg_t prio0; // [272:271]
+    rv_plic_reg2hw_prio1_reg_t prio1; // [270:269]
+    rv_plic_reg2hw_prio2_reg_t prio2; // [268:267]
+    rv_plic_reg2hw_prio3_reg_t prio3; // [266:265]
+    rv_plic_reg2hw_prio4_reg_t prio4; // [264:263]
+    rv_plic_reg2hw_prio5_reg_t prio5; // [262:261]
+    rv_plic_reg2hw_prio6_reg_t prio6; // [260:259]
+    rv_plic_reg2hw_prio7_reg_t prio7; // [258:257]
+    rv_plic_reg2hw_prio8_reg_t prio8; // [256:255]
+    rv_plic_reg2hw_prio9_reg_t prio9; // [254:253]
+    rv_plic_reg2hw_prio10_reg_t prio10; // [252:251]
+    rv_plic_reg2hw_prio11_reg_t prio11; // [250:249]
+    rv_plic_reg2hw_prio12_reg_t prio12; // [248:247]
+    rv_plic_reg2hw_prio13_reg_t prio13; // [246:245]
+    rv_plic_reg2hw_prio14_reg_t prio14; // [244:243]
+    rv_plic_reg2hw_prio15_reg_t prio15; // [242:241]
+    rv_plic_reg2hw_prio16_reg_t prio16; // [240:239]
+    rv_plic_reg2hw_prio17_reg_t prio17; // [238:237]
+    rv_plic_reg2hw_prio18_reg_t prio18; // [236:235]
+    rv_plic_reg2hw_prio19_reg_t prio19; // [234:233]
+    rv_plic_reg2hw_prio20_reg_t prio20; // [232:231]
+    rv_plic_reg2hw_prio21_reg_t prio21; // [230:229]
+    rv_plic_reg2hw_prio22_reg_t prio22; // [228:227]
+    rv_plic_reg2hw_prio23_reg_t prio23; // [226:225]
+    rv_plic_reg2hw_prio24_reg_t prio24; // [224:223]
+    rv_plic_reg2hw_prio25_reg_t prio25; // [222:221]
+    rv_plic_reg2hw_prio26_reg_t prio26; // [220:219]
+    rv_plic_reg2hw_prio27_reg_t prio27; // [218:217]
+    rv_plic_reg2hw_prio28_reg_t prio28; // [216:215]
+    rv_plic_reg2hw_prio29_reg_t prio29; // [214:213]
+    rv_plic_reg2hw_prio30_reg_t prio30; // [212:211]
+    rv_plic_reg2hw_prio31_reg_t prio31; // [210:209]
+    rv_plic_reg2hw_prio32_reg_t prio32; // [208:207]
+    rv_plic_reg2hw_prio33_reg_t prio33; // [206:205]
+    rv_plic_reg2hw_prio34_reg_t prio34; // [204:203]
+    rv_plic_reg2hw_prio35_reg_t prio35; // [202:201]
+    rv_plic_reg2hw_prio36_reg_t prio36; // [200:199]
+    rv_plic_reg2hw_prio37_reg_t prio37; // [198:197]
+    rv_plic_reg2hw_prio38_reg_t prio38; // [196:195]
+    rv_plic_reg2hw_prio39_reg_t prio39; // [194:193]
+    rv_plic_reg2hw_prio40_reg_t prio40; // [192:191]
+    rv_plic_reg2hw_prio41_reg_t prio41; // [190:189]
+    rv_plic_reg2hw_prio42_reg_t prio42; // [188:187]
+    rv_plic_reg2hw_prio43_reg_t prio43; // [186:185]
+    rv_plic_reg2hw_prio44_reg_t prio44; // [184:183]
+    rv_plic_reg2hw_prio45_reg_t prio45; // [182:181]
+    rv_plic_reg2hw_prio46_reg_t prio46; // [180:179]
+    rv_plic_reg2hw_prio47_reg_t prio47; // [178:177]
+    rv_plic_reg2hw_prio48_reg_t prio48; // [176:175]
+    rv_plic_reg2hw_prio49_reg_t prio49; // [174:173]
+    rv_plic_reg2hw_prio50_reg_t prio50; // [172:171]
+    rv_plic_reg2hw_prio51_reg_t prio51; // [170:169]
+    rv_plic_reg2hw_prio52_reg_t prio52; // [168:167]
+    rv_plic_reg2hw_prio53_reg_t prio53; // [166:165]
+    rv_plic_reg2hw_prio54_reg_t prio54; // [164:163]
+    rv_plic_reg2hw_prio55_reg_t prio55; // [162:161]
+    rv_plic_reg2hw_prio56_reg_t prio56; // [160:159]
+    rv_plic_reg2hw_prio57_reg_t prio57; // [158:157]
+    rv_plic_reg2hw_prio58_reg_t prio58; // [156:155]
+    rv_plic_reg2hw_prio59_reg_t prio59; // [154:153]
+    rv_plic_reg2hw_prio60_reg_t prio60; // [152:151]
+    rv_plic_reg2hw_prio61_reg_t prio61; // [150:149]
+    rv_plic_reg2hw_prio62_reg_t prio62; // [148:147]
+    rv_plic_reg2hw_prio63_reg_t prio63; // [146:145]
+    rv_plic_reg2hw_prio64_reg_t prio64; // [144:143]
+    rv_plic_reg2hw_prio65_reg_t prio65; // [142:141]
+    rv_plic_reg2hw_prio66_reg_t prio66; // [140:139]
+    rv_plic_reg2hw_prio67_reg_t prio67; // [138:137]
+    rv_plic_reg2hw_prio68_reg_t prio68; // [136:135]
+    rv_plic_reg2hw_prio69_reg_t prio69; // [134:133]
+    rv_plic_reg2hw_prio70_reg_t prio70; // [132:131]
+    rv_plic_reg2hw_prio71_reg_t prio71; // [130:129]
+    rv_plic_reg2hw_prio72_reg_t prio72; // [128:127]
+    rv_plic_reg2hw_prio73_reg_t prio73; // [126:125]
+    rv_plic_reg2hw_prio74_reg_t prio74; // [124:123]
+    rv_plic_reg2hw_prio75_reg_t prio75; // [122:121]
+    rv_plic_reg2hw_prio76_reg_t prio76; // [120:119]
+    rv_plic_reg2hw_prio77_reg_t prio77; // [118:117]
+    rv_plic_reg2hw_prio78_reg_t prio78; // [116:115]
+    rv_plic_reg2hw_prio79_reg_t prio79; // [114:113]
+    rv_plic_reg2hw_prio80_reg_t prio80; // [112:111]
+    rv_plic_reg2hw_prio81_reg_t prio81; // [110:109]
+    rv_plic_reg2hw_prio82_reg_t prio82; // [108:107]
+    rv_plic_reg2hw_prio83_reg_t prio83; // [106:105]
+    rv_plic_reg2hw_prio84_reg_t prio84; // [104:103]
+    rv_plic_reg2hw_prio85_reg_t prio85; // [102:101]
+    rv_plic_reg2hw_prio86_reg_t prio86; // [100:99]
+    rv_plic_reg2hw_ie0_mreg_t [86:0] ie0; // [98:12]
     rv_plic_reg2hw_threshold0_reg_t threshold0; // [11:10]
     rv_plic_reg2hw_cc0_reg_t cc0; // [9:1]
     rv_plic_reg2hw_msip0_reg_t msip0; // [0:0]
@@ -482,7 +497,7 @@ package rv_plic_reg_pkg;
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    rv_plic_hw2reg_ip_mreg_t [83:0] ip; // [174:7]
+    rv_plic_hw2reg_ip_mreg_t [86:0] ip; // [180:7]
     rv_plic_hw2reg_cc0_reg_t cc0; // [6:-2]
   } rv_plic_hw2reg_t;
 
@@ -577,6 +592,9 @@ package rv_plic_reg_pkg;
   parameter logic [9:0] RV_PLIC_PRIO81_OFFSET = 10'h 15c;
   parameter logic [9:0] RV_PLIC_PRIO82_OFFSET = 10'h 160;
   parameter logic [9:0] RV_PLIC_PRIO83_OFFSET = 10'h 164;
+  parameter logic [9:0] RV_PLIC_PRIO84_OFFSET = 10'h 168;
+  parameter logic [9:0] RV_PLIC_PRIO85_OFFSET = 10'h 16c;
+  parameter logic [9:0] RV_PLIC_PRIO86_OFFSET = 10'h 170;
   parameter logic [9:0] RV_PLIC_IE0_0_OFFSET = 10'h 200;
   parameter logic [9:0] RV_PLIC_IE0_1_OFFSET = 10'h 204;
   parameter logic [9:0] RV_PLIC_IE0_2_OFFSET = 10'h 208;
@@ -677,6 +695,9 @@ package rv_plic_reg_pkg;
     RV_PLIC_PRIO81,
     RV_PLIC_PRIO82,
     RV_PLIC_PRIO83,
+    RV_PLIC_PRIO84,
+    RV_PLIC_PRIO85,
+    RV_PLIC_PRIO86,
     RV_PLIC_IE0_0,
     RV_PLIC_IE0_1,
     RV_PLIC_IE0_2,
@@ -686,7 +707,7 @@ package rv_plic_reg_pkg;
   } rv_plic_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] RV_PLIC_PERMIT [96] = '{
+  parameter logic [3:0] RV_PLIC_PERMIT [99] = '{
     4'b 1111, // index[ 0] RV_PLIC_IP_0
     4'b 1111, // index[ 1] RV_PLIC_IP_1
     4'b 0111, // index[ 2] RV_PLIC_IP_2
@@ -777,12 +798,15 @@ package rv_plic_reg_pkg;
     4'b 0001, // index[87] RV_PLIC_PRIO81
     4'b 0001, // index[88] RV_PLIC_PRIO82
     4'b 0001, // index[89] RV_PLIC_PRIO83
-    4'b 1111, // index[90] RV_PLIC_IE0_0
-    4'b 1111, // index[91] RV_PLIC_IE0_1
-    4'b 0111, // index[92] RV_PLIC_IE0_2
-    4'b 0001, // index[93] RV_PLIC_THRESHOLD0
-    4'b 0001, // index[94] RV_PLIC_CC0
-    4'b 0001  // index[95] RV_PLIC_MSIP0
+    4'b 0001, // index[90] RV_PLIC_PRIO84
+    4'b 0001, // index[91] RV_PLIC_PRIO85
+    4'b 0001, // index[92] RV_PLIC_PRIO86
+    4'b 1111, // index[93] RV_PLIC_IE0_0
+    4'b 1111, // index[94] RV_PLIC_IE0_1
+    4'b 0111, // index[95] RV_PLIC_IE0_2
+    4'b 0001, // index[96] RV_PLIC_THRESHOLD0
+    4'b 0001, // index[97] RV_PLIC_CC0
+    4'b 0001  // index[98] RV_PLIC_MSIP0
   };
 endpackage
 

--- a/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_top.sv
+++ b/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_top.sv
@@ -155,6 +155,9 @@ module rv_plic_reg_top (
   logic ip_2_p_81_qs;
   logic ip_2_p_82_qs;
   logic ip_2_p_83_qs;
+  logic ip_2_p_84_qs;
+  logic ip_2_p_85_qs;
+  logic ip_2_p_86_qs;
   logic le_0_le_0_qs;
   logic le_0_le_0_wd;
   logic le_0_le_0_we;
@@ -407,6 +410,15 @@ module rv_plic_reg_top (
   logic le_2_le_83_qs;
   logic le_2_le_83_wd;
   logic le_2_le_83_we;
+  logic le_2_le_84_qs;
+  logic le_2_le_84_wd;
+  logic le_2_le_84_we;
+  logic le_2_le_85_qs;
+  logic le_2_le_85_wd;
+  logic le_2_le_85_we;
+  logic le_2_le_86_qs;
+  logic le_2_le_86_wd;
+  logic le_2_le_86_we;
   logic [1:0] prio0_qs;
   logic [1:0] prio0_wd;
   logic prio0_we;
@@ -659,6 +671,15 @@ module rv_plic_reg_top (
   logic [1:0] prio83_qs;
   logic [1:0] prio83_wd;
   logic prio83_we;
+  logic [1:0] prio84_qs;
+  logic [1:0] prio84_wd;
+  logic prio84_we;
+  logic [1:0] prio85_qs;
+  logic [1:0] prio85_wd;
+  logic prio85_we;
+  logic [1:0] prio86_qs;
+  logic [1:0] prio86_wd;
+  logic prio86_we;
   logic ie0_0_e_0_qs;
   logic ie0_0_e_0_wd;
   logic ie0_0_e_0_we;
@@ -911,6 +932,15 @@ module rv_plic_reg_top (
   logic ie0_2_e_83_qs;
   logic ie0_2_e_83_wd;
   logic ie0_2_e_83_we;
+  logic ie0_2_e_84_qs;
+  logic ie0_2_e_84_wd;
+  logic ie0_2_e_84_we;
+  logic ie0_2_e_85_qs;
+  logic ie0_2_e_85_wd;
+  logic ie0_2_e_85_we;
+  logic ie0_2_e_86_qs;
+  logic ie0_2_e_86_wd;
+  logic ie0_2_e_86_we;
   logic [1:0] threshold0_qs;
   logic [1:0] threshold0_wd;
   logic threshold0_we;
@@ -3030,6 +3060,81 @@ module rv_plic_reg_top (
 
     // to register interface (read)
     .qs     (ip_2_p_83_qs)
+  );
+
+
+  // F[p_84]: 20:20
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RO"),
+    .RESVAL  (1'h0)
+  ) u_ip_2_p_84 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    .we     (1'b0),
+    .wd     ('0  ),
+
+    // from internal hardware
+    .de     (hw2reg.ip[84].de),
+    .d      (hw2reg.ip[84].d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (ip_2_p_84_qs)
+  );
+
+
+  // F[p_85]: 21:21
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RO"),
+    .RESVAL  (1'h0)
+  ) u_ip_2_p_85 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    .we     (1'b0),
+    .wd     ('0  ),
+
+    // from internal hardware
+    .de     (hw2reg.ip[85].de),
+    .d      (hw2reg.ip[85].d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (ip_2_p_85_qs)
+  );
+
+
+  // F[p_86]: 22:22
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RO"),
+    .RESVAL  (1'h0)
+  ) u_ip_2_p_86 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    .we     (1'b0),
+    .wd     ('0  ),
+
+    // from internal hardware
+    .de     (hw2reg.ip[86].de),
+    .d      (hw2reg.ip[86].d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (ip_2_p_86_qs)
   );
 
 
@@ -5225,6 +5330,84 @@ module rv_plic_reg_top (
 
     // to register interface (read)
     .qs     (le_2_le_83_qs)
+  );
+
+
+  // F[le_84]: 20:20
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_le_2_le_84 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (le_2_le_84_we),
+    .wd     (le_2_le_84_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.le[84].q ),
+
+    // to register interface (read)
+    .qs     (le_2_le_84_qs)
+  );
+
+
+  // F[le_85]: 21:21
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_le_2_le_85 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (le_2_le_85_we),
+    .wd     (le_2_le_85_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.le[85].q ),
+
+    // to register interface (read)
+    .qs     (le_2_le_85_qs)
+  );
+
+
+  // F[le_86]: 22:22
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_le_2_le_86 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (le_2_le_86_we),
+    .wd     (le_2_le_86_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.le[86].q ),
+
+    // to register interface (read)
+    .qs     (le_2_le_86_qs)
   );
 
 
@@ -7497,6 +7680,87 @@ module rv_plic_reg_top (
   );
 
 
+  // R[prio84]: V(False)
+
+  prim_subreg #(
+    .DW      (2),
+    .SWACCESS("RW"),
+    .RESVAL  (2'h0)
+  ) u_prio84 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (prio84_we),
+    .wd     (prio84_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.prio84.q ),
+
+    // to register interface (read)
+    .qs     (prio84_qs)
+  );
+
+
+  // R[prio85]: V(False)
+
+  prim_subreg #(
+    .DW      (2),
+    .SWACCESS("RW"),
+    .RESVAL  (2'h0)
+  ) u_prio85 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (prio85_we),
+    .wd     (prio85_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.prio85.q ),
+
+    // to register interface (read)
+    .qs     (prio85_qs)
+  );
+
+
+  // R[prio86]: V(False)
+
+  prim_subreg #(
+    .DW      (2),
+    .SWACCESS("RW"),
+    .RESVAL  (2'h0)
+  ) u_prio86 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (prio86_we),
+    .wd     (prio86_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.prio86.q ),
+
+    // to register interface (read)
+    .qs     (prio86_qs)
+  );
+
+
 
   // Subregister 0 of Multireg ie0
   // R[ie0_0]: V(False)
@@ -9691,6 +9955,84 @@ module rv_plic_reg_top (
   );
 
 
+  // F[e_84]: 20:20
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_ie0_2_e_84 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ie0_2_e_84_we),
+    .wd     (ie0_2_e_84_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ie0[84].q ),
+
+    // to register interface (read)
+    .qs     (ie0_2_e_84_qs)
+  );
+
+
+  // F[e_85]: 21:21
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_ie0_2_e_85 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ie0_2_e_85_we),
+    .wd     (ie0_2_e_85_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ie0[85].q ),
+
+    // to register interface (read)
+    .qs     (ie0_2_e_85_qs)
+  );
+
+
+  // F[e_86]: 22:22
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_ie0_2_e_86 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ie0_2_e_86_we),
+    .wd     (ie0_2_e_86_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ie0[86].q ),
+
+    // to register interface (read)
+    .qs     (ie0_2_e_86_qs)
+  );
+
+
 
   // R[threshold0]: V(False)
 
@@ -9764,7 +10106,7 @@ module rv_plic_reg_top (
 
 
 
-  logic [95:0] addr_hit;
+  logic [98:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == RV_PLIC_IP_0_OFFSET);
@@ -9857,12 +10199,15 @@ module rv_plic_reg_top (
     addr_hit[87] = (reg_addr == RV_PLIC_PRIO81_OFFSET);
     addr_hit[88] = (reg_addr == RV_PLIC_PRIO82_OFFSET);
     addr_hit[89] = (reg_addr == RV_PLIC_PRIO83_OFFSET);
-    addr_hit[90] = (reg_addr == RV_PLIC_IE0_0_OFFSET);
-    addr_hit[91] = (reg_addr == RV_PLIC_IE0_1_OFFSET);
-    addr_hit[92] = (reg_addr == RV_PLIC_IE0_2_OFFSET);
-    addr_hit[93] = (reg_addr == RV_PLIC_THRESHOLD0_OFFSET);
-    addr_hit[94] = (reg_addr == RV_PLIC_CC0_OFFSET);
-    addr_hit[95] = (reg_addr == RV_PLIC_MSIP0_OFFSET);
+    addr_hit[90] = (reg_addr == RV_PLIC_PRIO84_OFFSET);
+    addr_hit[91] = (reg_addr == RV_PLIC_PRIO85_OFFSET);
+    addr_hit[92] = (reg_addr == RV_PLIC_PRIO86_OFFSET);
+    addr_hit[93] = (reg_addr == RV_PLIC_IE0_0_OFFSET);
+    addr_hit[94] = (reg_addr == RV_PLIC_IE0_1_OFFSET);
+    addr_hit[95] = (reg_addr == RV_PLIC_IE0_2_OFFSET);
+    addr_hit[96] = (reg_addr == RV_PLIC_THRESHOLD0_OFFSET);
+    addr_hit[97] = (reg_addr == RV_PLIC_CC0_OFFSET);
+    addr_hit[98] = (reg_addr == RV_PLIC_MSIP0_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -9966,7 +10311,13 @@ module rv_plic_reg_top (
     if (addr_hit[93] && reg_we && (RV_PLIC_PERMIT[93] != (RV_PLIC_PERMIT[93] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[94] && reg_we && (RV_PLIC_PERMIT[94] != (RV_PLIC_PERMIT[94] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[95] && reg_we && (RV_PLIC_PERMIT[95] != (RV_PLIC_PERMIT[95] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[96] && reg_we && (RV_PLIC_PERMIT[96] != (RV_PLIC_PERMIT[96] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[97] && reg_we && (RV_PLIC_PERMIT[97] != (RV_PLIC_PERMIT[97] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[98] && reg_we && (RV_PLIC_PERMIT[98] != (RV_PLIC_PERMIT[98] & reg_be))) wr_err = 1'b1 ;
   end
+
+
+
 
 
 
@@ -10304,6 +10655,15 @@ module rv_plic_reg_top (
   assign le_2_le_83_we = addr_hit[5] & reg_we & ~wr_err;
   assign le_2_le_83_wd = reg_wdata[19];
 
+  assign le_2_le_84_we = addr_hit[5] & reg_we & ~wr_err;
+  assign le_2_le_84_wd = reg_wdata[20];
+
+  assign le_2_le_85_we = addr_hit[5] & reg_we & ~wr_err;
+  assign le_2_le_85_wd = reg_wdata[21];
+
+  assign le_2_le_86_we = addr_hit[5] & reg_we & ~wr_err;
+  assign le_2_le_86_wd = reg_wdata[22];
+
   assign prio0_we = addr_hit[6] & reg_we & ~wr_err;
   assign prio0_wd = reg_wdata[1:0];
 
@@ -10556,266 +10916,284 @@ module rv_plic_reg_top (
   assign prio83_we = addr_hit[89] & reg_we & ~wr_err;
   assign prio83_wd = reg_wdata[1:0];
 
-  assign ie0_0_e_0_we = addr_hit[90] & reg_we & ~wr_err;
+  assign prio84_we = addr_hit[90] & reg_we & ~wr_err;
+  assign prio84_wd = reg_wdata[1:0];
+
+  assign prio85_we = addr_hit[91] & reg_we & ~wr_err;
+  assign prio85_wd = reg_wdata[1:0];
+
+  assign prio86_we = addr_hit[92] & reg_we & ~wr_err;
+  assign prio86_wd = reg_wdata[1:0];
+
+  assign ie0_0_e_0_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_0_wd = reg_wdata[0];
 
-  assign ie0_0_e_1_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_0_e_1_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_1_wd = reg_wdata[1];
 
-  assign ie0_0_e_2_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_0_e_2_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_2_wd = reg_wdata[2];
 
-  assign ie0_0_e_3_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_0_e_3_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_3_wd = reg_wdata[3];
 
-  assign ie0_0_e_4_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_0_e_4_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_4_wd = reg_wdata[4];
 
-  assign ie0_0_e_5_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_0_e_5_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_5_wd = reg_wdata[5];
 
-  assign ie0_0_e_6_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_0_e_6_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_6_wd = reg_wdata[6];
 
-  assign ie0_0_e_7_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_0_e_7_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_7_wd = reg_wdata[7];
 
-  assign ie0_0_e_8_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_0_e_8_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_8_wd = reg_wdata[8];
 
-  assign ie0_0_e_9_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_0_e_9_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_9_wd = reg_wdata[9];
 
-  assign ie0_0_e_10_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_0_e_10_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_10_wd = reg_wdata[10];
 
-  assign ie0_0_e_11_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_0_e_11_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_11_wd = reg_wdata[11];
 
-  assign ie0_0_e_12_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_0_e_12_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_12_wd = reg_wdata[12];
 
-  assign ie0_0_e_13_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_0_e_13_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_13_wd = reg_wdata[13];
 
-  assign ie0_0_e_14_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_0_e_14_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_14_wd = reg_wdata[14];
 
-  assign ie0_0_e_15_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_0_e_15_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_15_wd = reg_wdata[15];
 
-  assign ie0_0_e_16_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_0_e_16_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_16_wd = reg_wdata[16];
 
-  assign ie0_0_e_17_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_0_e_17_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_17_wd = reg_wdata[17];
 
-  assign ie0_0_e_18_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_0_e_18_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_18_wd = reg_wdata[18];
 
-  assign ie0_0_e_19_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_0_e_19_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_19_wd = reg_wdata[19];
 
-  assign ie0_0_e_20_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_0_e_20_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_20_wd = reg_wdata[20];
 
-  assign ie0_0_e_21_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_0_e_21_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_21_wd = reg_wdata[21];
 
-  assign ie0_0_e_22_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_0_e_22_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_22_wd = reg_wdata[22];
 
-  assign ie0_0_e_23_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_0_e_23_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_23_wd = reg_wdata[23];
 
-  assign ie0_0_e_24_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_0_e_24_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_24_wd = reg_wdata[24];
 
-  assign ie0_0_e_25_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_0_e_25_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_25_wd = reg_wdata[25];
 
-  assign ie0_0_e_26_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_0_e_26_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_26_wd = reg_wdata[26];
 
-  assign ie0_0_e_27_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_0_e_27_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_27_wd = reg_wdata[27];
 
-  assign ie0_0_e_28_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_0_e_28_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_28_wd = reg_wdata[28];
 
-  assign ie0_0_e_29_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_0_e_29_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_29_wd = reg_wdata[29];
 
-  assign ie0_0_e_30_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_0_e_30_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_30_wd = reg_wdata[30];
 
-  assign ie0_0_e_31_we = addr_hit[90] & reg_we & ~wr_err;
+  assign ie0_0_e_31_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_31_wd = reg_wdata[31];
 
-  assign ie0_1_e_32_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_1_e_32_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_32_wd = reg_wdata[0];
 
-  assign ie0_1_e_33_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_1_e_33_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_33_wd = reg_wdata[1];
 
-  assign ie0_1_e_34_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_1_e_34_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_34_wd = reg_wdata[2];
 
-  assign ie0_1_e_35_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_1_e_35_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_35_wd = reg_wdata[3];
 
-  assign ie0_1_e_36_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_1_e_36_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_36_wd = reg_wdata[4];
 
-  assign ie0_1_e_37_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_1_e_37_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_37_wd = reg_wdata[5];
 
-  assign ie0_1_e_38_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_1_e_38_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_38_wd = reg_wdata[6];
 
-  assign ie0_1_e_39_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_1_e_39_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_39_wd = reg_wdata[7];
 
-  assign ie0_1_e_40_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_1_e_40_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_40_wd = reg_wdata[8];
 
-  assign ie0_1_e_41_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_1_e_41_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_41_wd = reg_wdata[9];
 
-  assign ie0_1_e_42_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_1_e_42_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_42_wd = reg_wdata[10];
 
-  assign ie0_1_e_43_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_1_e_43_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_43_wd = reg_wdata[11];
 
-  assign ie0_1_e_44_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_1_e_44_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_44_wd = reg_wdata[12];
 
-  assign ie0_1_e_45_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_1_e_45_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_45_wd = reg_wdata[13];
 
-  assign ie0_1_e_46_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_1_e_46_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_46_wd = reg_wdata[14];
 
-  assign ie0_1_e_47_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_1_e_47_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_47_wd = reg_wdata[15];
 
-  assign ie0_1_e_48_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_1_e_48_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_48_wd = reg_wdata[16];
 
-  assign ie0_1_e_49_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_1_e_49_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_49_wd = reg_wdata[17];
 
-  assign ie0_1_e_50_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_1_e_50_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_50_wd = reg_wdata[18];
 
-  assign ie0_1_e_51_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_1_e_51_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_51_wd = reg_wdata[19];
 
-  assign ie0_1_e_52_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_1_e_52_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_52_wd = reg_wdata[20];
 
-  assign ie0_1_e_53_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_1_e_53_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_53_wd = reg_wdata[21];
 
-  assign ie0_1_e_54_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_1_e_54_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_54_wd = reg_wdata[22];
 
-  assign ie0_1_e_55_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_1_e_55_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_55_wd = reg_wdata[23];
 
-  assign ie0_1_e_56_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_1_e_56_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_56_wd = reg_wdata[24];
 
-  assign ie0_1_e_57_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_1_e_57_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_57_wd = reg_wdata[25];
 
-  assign ie0_1_e_58_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_1_e_58_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_58_wd = reg_wdata[26];
 
-  assign ie0_1_e_59_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_1_e_59_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_59_wd = reg_wdata[27];
 
-  assign ie0_1_e_60_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_1_e_60_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_60_wd = reg_wdata[28];
 
-  assign ie0_1_e_61_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_1_e_61_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_61_wd = reg_wdata[29];
 
-  assign ie0_1_e_62_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_1_e_62_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_62_wd = reg_wdata[30];
 
-  assign ie0_1_e_63_we = addr_hit[91] & reg_we & ~wr_err;
+  assign ie0_1_e_63_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_63_wd = reg_wdata[31];
 
-  assign ie0_2_e_64_we = addr_hit[92] & reg_we & ~wr_err;
+  assign ie0_2_e_64_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_64_wd = reg_wdata[0];
 
-  assign ie0_2_e_65_we = addr_hit[92] & reg_we & ~wr_err;
+  assign ie0_2_e_65_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_65_wd = reg_wdata[1];
 
-  assign ie0_2_e_66_we = addr_hit[92] & reg_we & ~wr_err;
+  assign ie0_2_e_66_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_66_wd = reg_wdata[2];
 
-  assign ie0_2_e_67_we = addr_hit[92] & reg_we & ~wr_err;
+  assign ie0_2_e_67_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_67_wd = reg_wdata[3];
 
-  assign ie0_2_e_68_we = addr_hit[92] & reg_we & ~wr_err;
+  assign ie0_2_e_68_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_68_wd = reg_wdata[4];
 
-  assign ie0_2_e_69_we = addr_hit[92] & reg_we & ~wr_err;
+  assign ie0_2_e_69_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_69_wd = reg_wdata[5];
 
-  assign ie0_2_e_70_we = addr_hit[92] & reg_we & ~wr_err;
+  assign ie0_2_e_70_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_70_wd = reg_wdata[6];
 
-  assign ie0_2_e_71_we = addr_hit[92] & reg_we & ~wr_err;
+  assign ie0_2_e_71_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_71_wd = reg_wdata[7];
 
-  assign ie0_2_e_72_we = addr_hit[92] & reg_we & ~wr_err;
+  assign ie0_2_e_72_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_72_wd = reg_wdata[8];
 
-  assign ie0_2_e_73_we = addr_hit[92] & reg_we & ~wr_err;
+  assign ie0_2_e_73_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_73_wd = reg_wdata[9];
 
-  assign ie0_2_e_74_we = addr_hit[92] & reg_we & ~wr_err;
+  assign ie0_2_e_74_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_74_wd = reg_wdata[10];
 
-  assign ie0_2_e_75_we = addr_hit[92] & reg_we & ~wr_err;
+  assign ie0_2_e_75_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_75_wd = reg_wdata[11];
 
-  assign ie0_2_e_76_we = addr_hit[92] & reg_we & ~wr_err;
+  assign ie0_2_e_76_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_76_wd = reg_wdata[12];
 
-  assign ie0_2_e_77_we = addr_hit[92] & reg_we & ~wr_err;
+  assign ie0_2_e_77_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_77_wd = reg_wdata[13];
 
-  assign ie0_2_e_78_we = addr_hit[92] & reg_we & ~wr_err;
+  assign ie0_2_e_78_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_78_wd = reg_wdata[14];
 
-  assign ie0_2_e_79_we = addr_hit[92] & reg_we & ~wr_err;
+  assign ie0_2_e_79_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_79_wd = reg_wdata[15];
 
-  assign ie0_2_e_80_we = addr_hit[92] & reg_we & ~wr_err;
+  assign ie0_2_e_80_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_80_wd = reg_wdata[16];
 
-  assign ie0_2_e_81_we = addr_hit[92] & reg_we & ~wr_err;
+  assign ie0_2_e_81_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_81_wd = reg_wdata[17];
 
-  assign ie0_2_e_82_we = addr_hit[92] & reg_we & ~wr_err;
+  assign ie0_2_e_82_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_82_wd = reg_wdata[18];
 
-  assign ie0_2_e_83_we = addr_hit[92] & reg_we & ~wr_err;
+  assign ie0_2_e_83_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_83_wd = reg_wdata[19];
 
-  assign threshold0_we = addr_hit[93] & reg_we & ~wr_err;
+  assign ie0_2_e_84_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_2_e_84_wd = reg_wdata[20];
+
+  assign ie0_2_e_85_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_2_e_85_wd = reg_wdata[21];
+
+  assign ie0_2_e_86_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_2_e_86_wd = reg_wdata[22];
+
+  assign threshold0_we = addr_hit[96] & reg_we & ~wr_err;
   assign threshold0_wd = reg_wdata[1:0];
 
-  assign cc0_we = addr_hit[94] & reg_we & ~wr_err;
+  assign cc0_we = addr_hit[97] & reg_we & ~wr_err;
   assign cc0_wd = reg_wdata[6:0];
-  assign cc0_re = addr_hit[94] && reg_re;
+  assign cc0_re = addr_hit[97] && reg_re;
 
-  assign msip0_we = addr_hit[95] & reg_we & ~wr_err;
+  assign msip0_we = addr_hit[98] & reg_we & ~wr_err;
   assign msip0_wd = reg_wdata[0];
 
   // Read data return
@@ -10913,6 +11291,9 @@ module rv_plic_reg_top (
         reg_rdata_next[17] = ip_2_p_81_qs;
         reg_rdata_next[18] = ip_2_p_82_qs;
         reg_rdata_next[19] = ip_2_p_83_qs;
+        reg_rdata_next[20] = ip_2_p_84_qs;
+        reg_rdata_next[21] = ip_2_p_85_qs;
+        reg_rdata_next[22] = ip_2_p_86_qs;
       end
 
       addr_hit[3]: begin
@@ -11006,6 +11387,9 @@ module rv_plic_reg_top (
         reg_rdata_next[17] = le_2_le_81_qs;
         reg_rdata_next[18] = le_2_le_82_qs;
         reg_rdata_next[19] = le_2_le_83_qs;
+        reg_rdata_next[20] = le_2_le_84_qs;
+        reg_rdata_next[21] = le_2_le_85_qs;
+        reg_rdata_next[22] = le_2_le_86_qs;
       end
 
       addr_hit[6]: begin
@@ -11345,6 +11729,18 @@ module rv_plic_reg_top (
       end
 
       addr_hit[90]: begin
+        reg_rdata_next[1:0] = prio84_qs;
+      end
+
+      addr_hit[91]: begin
+        reg_rdata_next[1:0] = prio85_qs;
+      end
+
+      addr_hit[92]: begin
+        reg_rdata_next[1:0] = prio86_qs;
+      end
+
+      addr_hit[93]: begin
         reg_rdata_next[0] = ie0_0_e_0_qs;
         reg_rdata_next[1] = ie0_0_e_1_qs;
         reg_rdata_next[2] = ie0_0_e_2_qs;
@@ -11379,7 +11775,7 @@ module rv_plic_reg_top (
         reg_rdata_next[31] = ie0_0_e_31_qs;
       end
 
-      addr_hit[91]: begin
+      addr_hit[94]: begin
         reg_rdata_next[0] = ie0_1_e_32_qs;
         reg_rdata_next[1] = ie0_1_e_33_qs;
         reg_rdata_next[2] = ie0_1_e_34_qs;
@@ -11414,7 +11810,7 @@ module rv_plic_reg_top (
         reg_rdata_next[31] = ie0_1_e_63_qs;
       end
 
-      addr_hit[92]: begin
+      addr_hit[95]: begin
         reg_rdata_next[0] = ie0_2_e_64_qs;
         reg_rdata_next[1] = ie0_2_e_65_qs;
         reg_rdata_next[2] = ie0_2_e_66_qs;
@@ -11435,17 +11831,20 @@ module rv_plic_reg_top (
         reg_rdata_next[17] = ie0_2_e_81_qs;
         reg_rdata_next[18] = ie0_2_e_82_qs;
         reg_rdata_next[19] = ie0_2_e_83_qs;
+        reg_rdata_next[20] = ie0_2_e_84_qs;
+        reg_rdata_next[21] = ie0_2_e_85_qs;
+        reg_rdata_next[22] = ie0_2_e_86_qs;
       end
 
-      addr_hit[93]: begin
+      addr_hit[96]: begin
         reg_rdata_next[1:0] = threshold0_qs;
       end
 
-      addr_hit[94]: begin
+      addr_hit[97]: begin
         reg_rdata_next[6:0] = cc0_qs;
       end
 
-      addr_hit[95]: begin
+      addr_hit[98]: begin
         reg_rdata_next[0] = msip0_qs;
       end
 

--- a/hw/top_earlgrey/ip/xbar_main/data/autogen/xbar_main.gen.hjson
+++ b/hw/top_earlgrey/ip/xbar_main/data/autogen/xbar_main.gen.hjson
@@ -52,6 +52,7 @@
       nmi_gen
       otbn
       keymgr
+      kmac
     ]
     dm_sba:
     [
@@ -68,6 +69,7 @@
       alert_handler
       nmi_gen
       otbn
+      kmac
     ]
   }
   nodes:
@@ -247,6 +249,24 @@
       [
         {
           base_addr: 0x40120000
+          size_byte: 0x1000
+        }
+      ]
+      xbar: false
+      stub: false
+      pipeline: "true"
+    }
+    {
+      name: kmac
+      type: device
+      clock: clk_main_i
+      rset: rst_main_ni
+      pipeline_byp: "false"
+      inst_type: kmac
+      addr_range:
+      [
+        {
+          base_addr: 0x41120000
           size_byte: 0x1000
         }
       ]

--- a/hw/top_earlgrey/ip/xbar_main/data/autogen/xbar_main.hjson
+++ b/hw/top_earlgrey/ip/xbar_main/data/autogen/xbar_main.hjson
@@ -75,6 +75,12 @@
     }
     { struct: "tl"
       type:   "req_rsp"
+      name:   "tl_kmac"
+      act:    "req"
+      package: "tlul_pkg"
+    }
+    { struct: "tl"
+      type:   "req_rsp"
       name:   "tl_aes"
       act:    "req"
       package: "tlul_pkg"

--- a/hw/top_earlgrey/ip/xbar_main/dv/autogen/tb__xbar_connect.sv
+++ b/hw/top_earlgrey/ip/xbar_main/dv/autogen/tb__xbar_connect.sv
@@ -29,6 +29,7 @@ initial force dut.rst_fixed_ni = rst_n;
 `CONNECT_TL_DEVICE_IF(peri, dut, clk_fixed_i, rst_n)
 `CONNECT_TL_DEVICE_IF(flash_ctrl, dut, clk_main_i, rst_n)
 `CONNECT_TL_DEVICE_IF(hmac, dut, clk_main_i, rst_n)
+`CONNECT_TL_DEVICE_IF(kmac, dut, clk_main_i, rst_n)
 `CONNECT_TL_DEVICE_IF(aes, dut, clk_main_i, rst_n)
 `CONNECT_TL_DEVICE_IF(rv_plic, dut, clk_main_i, rst_n)
 `CONNECT_TL_DEVICE_IF(pinmux, dut, clk_main_i, rst_n)

--- a/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_env_pkg__params.sv
+++ b/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_env_pkg__params.sv
@@ -34,6 +34,9 @@ tl_device_t xbar_devices[$] = '{
     '{"hmac", '{
         '{32'h40120000, 32'h40120fff}
     }},
+    '{"kmac", '{
+        '{32'h41120000, 32'h41120fff}
+    }},
     '{"aes", '{
         '{32'h40110000, 32'h40110fff}
     }},
@@ -82,7 +85,8 @@ tl_host_t xbar_hosts[$] = '{
         "alert_handler",
         "nmi_gen",
         "otbn",
-        "keymgr"}}
+        "keymgr",
+        "kmac"}}
     ,
     '{"dm_sba", 2, '{
         "rom",
@@ -97,5 +101,6 @@ tl_host_t xbar_hosts[$] = '{
         "padctrl",
         "alert_handler",
         "nmi_gen",
-        "otbn"}}
+        "otbn",
+        "kmac"}}
 };

--- a/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_main_bind.sv
+++ b/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_main_bind.sv
@@ -68,6 +68,12 @@ module xbar_main_bind;
     .h2d    (tl_hmac_o),
     .d2h    (tl_hmac_i)
   );
+  bind xbar_main tlul_assert #(.EndpointType("Host")) tlul_assert_device_kmac (
+    .clk_i  (clk_main_i),
+    .rst_ni (rst_main_ni),
+    .h2d    (tl_kmac_o),
+    .d2h    (tl_kmac_i)
+  );
   bind xbar_main tlul_assert #(.EndpointType("Host")) tlul_assert_device_aes (
     .clk_i  (clk_main_i),
     .rst_ni (rst_main_ni),

--- a/hw/top_earlgrey/ip/xbar_main/rtl/autogen/tl_main_pkg.sv
+++ b/hw/top_earlgrey/ip/xbar_main/rtl/autogen/tl_main_pkg.sv
@@ -21,6 +21,7 @@ package tl_main_pkg;
   };
   localparam logic [31:0] ADDR_SPACE_FLASH_CTRL    = 32'h 40030000;
   localparam logic [31:0] ADDR_SPACE_HMAC          = 32'h 40120000;
+  localparam logic [31:0] ADDR_SPACE_KMAC          = 32'h 41120000;
   localparam logic [31:0] ADDR_SPACE_AES           = 32'h 40110000;
   localparam logic [31:0] ADDR_SPACE_RV_PLIC       = 32'h 40090000;
   localparam logic [31:0] ADDR_SPACE_PINMUX        = 32'h 40070000;
@@ -45,6 +46,7 @@ package tl_main_pkg;
   };
   localparam logic [31:0] ADDR_MASK_FLASH_CTRL    = 32'h 00000fff;
   localparam logic [31:0] ADDR_MASK_HMAC          = 32'h 00000fff;
+  localparam logic [31:0] ADDR_MASK_KMAC          = 32'h 00000fff;
   localparam logic [31:0] ADDR_MASK_AES           = 32'h 00000fff;
   localparam logic [31:0] ADDR_MASK_RV_PLIC       = 32'h 00000fff;
   localparam logic [31:0] ADDR_MASK_PINMUX        = 32'h 00000fff;
@@ -55,7 +57,7 @@ package tl_main_pkg;
   localparam logic [31:0] ADDR_MASK_KEYMGR        = 32'h 00000fff;
 
   localparam int N_HOST   = 3;
-  localparam int N_DEVICE = 15;
+  localparam int N_DEVICE = 16;
 
   typedef enum int {
     TlRom = 0,
@@ -65,14 +67,15 @@ package tl_main_pkg;
     TlPeri = 4,
     TlFlashCtrl = 5,
     TlHmac = 6,
-    TlAes = 7,
-    TlRvPlic = 8,
-    TlPinmux = 9,
-    TlPadctrl = 10,
-    TlAlertHandler = 11,
-    TlNmiGen = 12,
-    TlOtbn = 13,
-    TlKeymgr = 14
+    TlKmac = 7,
+    TlAes = 8,
+    TlRvPlic = 9,
+    TlPinmux = 10,
+    TlPadctrl = 11,
+    TlAlertHandler = 12,
+    TlNmiGen = 13,
+    TlOtbn = 14,
+    TlKeymgr = 15
   } tl_device_e;
 
   typedef enum int {

--- a/hw/top_earlgrey/ip/xbar_main/rtl/autogen/xbar_main.sv
+++ b/hw/top_earlgrey/ip/xbar_main/rtl/autogen/xbar_main.sv
@@ -7,76 +7,80 @@
 //
 // Interconnect
 // corei
-//   -> s1n_18
-//     -> sm1_19
-//       -> rom
+//   -> s1n_19
 //     -> sm1_20
-//       -> debug_mem
+//       -> rom
 //     -> sm1_21
-//       -> ram_main
+//       -> debug_mem
 //     -> sm1_22
+//       -> ram_main
+//     -> sm1_23
 //       -> eflash
 // cored
-//   -> s1n_23
-//     -> sm1_19
-//       -> rom
+//   -> s1n_24
 //     -> sm1_20
-//       -> debug_mem
+//       -> rom
 //     -> sm1_21
-//       -> ram_main
+//       -> debug_mem
 //     -> sm1_22
+//       -> ram_main
+//     -> sm1_23
 //       -> eflash
-//     -> sm1_25
-//       -> asf_24
-//         -> peri
 //     -> sm1_26
-//       -> flash_ctrl
+//       -> asf_25
+//         -> peri
 //     -> sm1_27
-//       -> aes
+//       -> flash_ctrl
 //     -> sm1_28
-//       -> hmac
+//       -> aes
 //     -> sm1_29
-//       -> rv_plic
+//       -> hmac
 //     -> sm1_30
-//       -> pinmux
+//       -> rv_plic
 //     -> sm1_31
-//       -> padctrl
+//       -> pinmux
 //     -> sm1_32
-//       -> alert_handler
+//       -> padctrl
 //     -> sm1_33
-//       -> nmi_gen
+//       -> alert_handler
 //     -> sm1_34
+//       -> nmi_gen
+//     -> sm1_35
 //       -> otbn
 //     -> keymgr
+//     -> sm1_36
+//       -> kmac
 // dm_sba
-//   -> s1n_35
-//     -> sm1_19
+//   -> s1n_37
+//     -> sm1_20
 //       -> rom
-//     -> sm1_21
-//       -> ram_main
 //     -> sm1_22
+//       -> ram_main
+//     -> sm1_23
 //       -> eflash
-//     -> sm1_25
-//       -> asf_24
-//         -> peri
 //     -> sm1_26
-//       -> flash_ctrl
+//       -> asf_25
+//         -> peri
 //     -> sm1_27
-//       -> aes
+//       -> flash_ctrl
 //     -> sm1_28
-//       -> hmac
+//       -> aes
 //     -> sm1_29
-//       -> rv_plic
+//       -> hmac
 //     -> sm1_30
-//       -> pinmux
+//       -> rv_plic
 //     -> sm1_31
-//       -> padctrl
+//       -> pinmux
 //     -> sm1_32
-//       -> alert_handler
+//       -> padctrl
 //     -> sm1_33
-//       -> nmi_gen
+//       -> alert_handler
 //     -> sm1_34
+//       -> nmi_gen
+//     -> sm1_35
 //       -> otbn
+//     -> sm1_36
+//       -> kmac
 
 module xbar_main (
   input clk_main_i,
@@ -107,6 +111,8 @@ module xbar_main (
   input  tlul_pkg::tl_d2h_t tl_flash_ctrl_i,
   output tlul_pkg::tl_h2d_t tl_hmac_o,
   input  tlul_pkg::tl_d2h_t tl_hmac_i,
+  output tlul_pkg::tl_h2d_t tl_kmac_o,
+  input  tlul_pkg::tl_d2h_t tl_kmac_i,
   output tlul_pkg::tl_h2d_t tl_aes_o,
   input  tlul_pkg::tl_d2h_t tl_aes_i,
   output tlul_pkg::tl_h2d_t tl_rv_plic_o,
@@ -135,33 +141,26 @@ module xbar_main (
   logic unused_scanmode;
   assign unused_scanmode = scanmode_i;
 
-  tl_h2d_t tl_s1n_18_us_h2d ;
-  tl_d2h_t tl_s1n_18_us_d2h ;
+  tl_h2d_t tl_s1n_19_us_h2d ;
+  tl_d2h_t tl_s1n_19_us_d2h ;
 
 
-  tl_h2d_t tl_s1n_18_ds_h2d [4];
-  tl_d2h_t tl_s1n_18_ds_d2h [4];
+  tl_h2d_t tl_s1n_19_ds_h2d [4];
+  tl_d2h_t tl_s1n_19_ds_d2h [4];
 
   // Create steering signal
-  logic [2:0] dev_sel_s1n_18;
+  logic [2:0] dev_sel_s1n_19;
 
 
-  tl_h2d_t tl_sm1_19_us_h2d [3];
-  tl_d2h_t tl_sm1_19_us_d2h [3];
-
-  tl_h2d_t tl_sm1_19_ds_h2d ;
-  tl_d2h_t tl_sm1_19_ds_d2h ;
-
-
-  tl_h2d_t tl_sm1_20_us_h2d [2];
-  tl_d2h_t tl_sm1_20_us_d2h [2];
+  tl_h2d_t tl_sm1_20_us_h2d [3];
+  tl_d2h_t tl_sm1_20_us_d2h [3];
 
   tl_h2d_t tl_sm1_20_ds_h2d ;
   tl_d2h_t tl_sm1_20_ds_d2h ;
 
 
-  tl_h2d_t tl_sm1_21_us_h2d [3];
-  tl_d2h_t tl_sm1_21_us_d2h [3];
+  tl_h2d_t tl_sm1_21_us_h2d [2];
+  tl_d2h_t tl_sm1_21_us_d2h [2];
 
   tl_h2d_t tl_sm1_21_ds_h2d ;
   tl_d2h_t tl_sm1_21_ds_d2h ;
@@ -173,27 +172,27 @@ module xbar_main (
   tl_h2d_t tl_sm1_22_ds_h2d ;
   tl_d2h_t tl_sm1_22_ds_d2h ;
 
-  tl_h2d_t tl_s1n_23_us_h2d ;
-  tl_d2h_t tl_s1n_23_us_d2h ;
+
+  tl_h2d_t tl_sm1_23_us_h2d [3];
+  tl_d2h_t tl_sm1_23_us_d2h [3];
+
+  tl_h2d_t tl_sm1_23_ds_h2d ;
+  tl_d2h_t tl_sm1_23_ds_d2h ;
+
+  tl_h2d_t tl_s1n_24_us_h2d ;
+  tl_d2h_t tl_s1n_24_us_d2h ;
 
 
-  tl_h2d_t tl_s1n_23_ds_h2d [15];
-  tl_d2h_t tl_s1n_23_ds_d2h [15];
+  tl_h2d_t tl_s1n_24_ds_h2d [16];
+  tl_d2h_t tl_s1n_24_ds_d2h [16];
 
   // Create steering signal
-  logic [3:0] dev_sel_s1n_23;
+  logic [4:0] dev_sel_s1n_24;
 
-  tl_h2d_t tl_asf_24_us_h2d ;
-  tl_d2h_t tl_asf_24_us_d2h ;
-  tl_h2d_t tl_asf_24_ds_h2d ;
-  tl_d2h_t tl_asf_24_ds_d2h ;
-
-
-  tl_h2d_t tl_sm1_25_us_h2d [2];
-  tl_d2h_t tl_sm1_25_us_d2h [2];
-
-  tl_h2d_t tl_sm1_25_ds_h2d ;
-  tl_d2h_t tl_sm1_25_ds_d2h ;
+  tl_h2d_t tl_asf_25_us_h2d ;
+  tl_d2h_t tl_asf_25_us_d2h ;
+  tl_h2d_t tl_asf_25_ds_h2d ;
+  tl_d2h_t tl_asf_25_ds_d2h ;
 
 
   tl_h2d_t tl_sm1_26_us_h2d [2];
@@ -258,304 +257,333 @@ module xbar_main (
   tl_h2d_t tl_sm1_34_ds_h2d ;
   tl_d2h_t tl_sm1_34_ds_d2h ;
 
-  tl_h2d_t tl_s1n_35_us_h2d ;
-  tl_d2h_t tl_s1n_35_us_d2h ;
+
+  tl_h2d_t tl_sm1_35_us_h2d [2];
+  tl_d2h_t tl_sm1_35_us_d2h [2];
+
+  tl_h2d_t tl_sm1_35_ds_h2d ;
+  tl_d2h_t tl_sm1_35_ds_d2h ;
 
 
-  tl_h2d_t tl_s1n_35_ds_h2d [13];
-  tl_d2h_t tl_s1n_35_ds_d2h [13];
+  tl_h2d_t tl_sm1_36_us_h2d [2];
+  tl_d2h_t tl_sm1_36_us_d2h [2];
+
+  tl_h2d_t tl_sm1_36_ds_h2d ;
+  tl_d2h_t tl_sm1_36_ds_d2h ;
+
+  tl_h2d_t tl_s1n_37_us_h2d ;
+  tl_d2h_t tl_s1n_37_us_d2h ;
+
+
+  tl_h2d_t tl_s1n_37_ds_h2d [14];
+  tl_d2h_t tl_s1n_37_ds_d2h [14];
 
   // Create steering signal
-  logic [3:0] dev_sel_s1n_35;
+  logic [3:0] dev_sel_s1n_37;
 
 
 
-  assign tl_sm1_19_us_h2d[0] = tl_s1n_18_ds_h2d[0];
-  assign tl_s1n_18_ds_d2h[0] = tl_sm1_19_us_d2h[0];
+  assign tl_sm1_20_us_h2d[0] = tl_s1n_19_ds_h2d[0];
+  assign tl_s1n_19_ds_d2h[0] = tl_sm1_20_us_d2h[0];
 
-  assign tl_sm1_20_us_h2d[0] = tl_s1n_18_ds_h2d[1];
-  assign tl_s1n_18_ds_d2h[1] = tl_sm1_20_us_d2h[0];
+  assign tl_sm1_21_us_h2d[0] = tl_s1n_19_ds_h2d[1];
+  assign tl_s1n_19_ds_d2h[1] = tl_sm1_21_us_d2h[0];
 
-  assign tl_sm1_21_us_h2d[0] = tl_s1n_18_ds_h2d[2];
-  assign tl_s1n_18_ds_d2h[2] = tl_sm1_21_us_d2h[0];
+  assign tl_sm1_22_us_h2d[0] = tl_s1n_19_ds_h2d[2];
+  assign tl_s1n_19_ds_d2h[2] = tl_sm1_22_us_d2h[0];
 
-  assign tl_sm1_22_us_h2d[0] = tl_s1n_18_ds_h2d[3];
-  assign tl_s1n_18_ds_d2h[3] = tl_sm1_22_us_d2h[0];
+  assign tl_sm1_23_us_h2d[0] = tl_s1n_19_ds_h2d[3];
+  assign tl_s1n_19_ds_d2h[3] = tl_sm1_23_us_d2h[0];
 
-  assign tl_sm1_19_us_h2d[1] = tl_s1n_23_ds_h2d[0];
-  assign tl_s1n_23_ds_d2h[0] = tl_sm1_19_us_d2h[1];
+  assign tl_sm1_20_us_h2d[1] = tl_s1n_24_ds_h2d[0];
+  assign tl_s1n_24_ds_d2h[0] = tl_sm1_20_us_d2h[1];
 
-  assign tl_sm1_20_us_h2d[1] = tl_s1n_23_ds_h2d[1];
-  assign tl_s1n_23_ds_d2h[1] = tl_sm1_20_us_d2h[1];
+  assign tl_sm1_21_us_h2d[1] = tl_s1n_24_ds_h2d[1];
+  assign tl_s1n_24_ds_d2h[1] = tl_sm1_21_us_d2h[1];
 
-  assign tl_sm1_21_us_h2d[1] = tl_s1n_23_ds_h2d[2];
-  assign tl_s1n_23_ds_d2h[2] = tl_sm1_21_us_d2h[1];
+  assign tl_sm1_22_us_h2d[1] = tl_s1n_24_ds_h2d[2];
+  assign tl_s1n_24_ds_d2h[2] = tl_sm1_22_us_d2h[1];
 
-  assign tl_sm1_22_us_h2d[1] = tl_s1n_23_ds_h2d[3];
-  assign tl_s1n_23_ds_d2h[3] = tl_sm1_22_us_d2h[1];
+  assign tl_sm1_23_us_h2d[1] = tl_s1n_24_ds_h2d[3];
+  assign tl_s1n_24_ds_d2h[3] = tl_sm1_23_us_d2h[1];
 
-  assign tl_sm1_25_us_h2d[0] = tl_s1n_23_ds_h2d[4];
-  assign tl_s1n_23_ds_d2h[4] = tl_sm1_25_us_d2h[0];
+  assign tl_sm1_26_us_h2d[0] = tl_s1n_24_ds_h2d[4];
+  assign tl_s1n_24_ds_d2h[4] = tl_sm1_26_us_d2h[0];
 
-  assign tl_sm1_26_us_h2d[0] = tl_s1n_23_ds_h2d[5];
-  assign tl_s1n_23_ds_d2h[5] = tl_sm1_26_us_d2h[0];
+  assign tl_sm1_27_us_h2d[0] = tl_s1n_24_ds_h2d[5];
+  assign tl_s1n_24_ds_d2h[5] = tl_sm1_27_us_d2h[0];
 
-  assign tl_sm1_27_us_h2d[0] = tl_s1n_23_ds_h2d[6];
-  assign tl_s1n_23_ds_d2h[6] = tl_sm1_27_us_d2h[0];
+  assign tl_sm1_28_us_h2d[0] = tl_s1n_24_ds_h2d[6];
+  assign tl_s1n_24_ds_d2h[6] = tl_sm1_28_us_d2h[0];
 
-  assign tl_sm1_28_us_h2d[0] = tl_s1n_23_ds_h2d[7];
-  assign tl_s1n_23_ds_d2h[7] = tl_sm1_28_us_d2h[0];
+  assign tl_sm1_29_us_h2d[0] = tl_s1n_24_ds_h2d[7];
+  assign tl_s1n_24_ds_d2h[7] = tl_sm1_29_us_d2h[0];
 
-  assign tl_sm1_29_us_h2d[0] = tl_s1n_23_ds_h2d[8];
-  assign tl_s1n_23_ds_d2h[8] = tl_sm1_29_us_d2h[0];
+  assign tl_sm1_30_us_h2d[0] = tl_s1n_24_ds_h2d[8];
+  assign tl_s1n_24_ds_d2h[8] = tl_sm1_30_us_d2h[0];
 
-  assign tl_sm1_30_us_h2d[0] = tl_s1n_23_ds_h2d[9];
-  assign tl_s1n_23_ds_d2h[9] = tl_sm1_30_us_d2h[0];
+  assign tl_sm1_31_us_h2d[0] = tl_s1n_24_ds_h2d[9];
+  assign tl_s1n_24_ds_d2h[9] = tl_sm1_31_us_d2h[0];
 
-  assign tl_sm1_31_us_h2d[0] = tl_s1n_23_ds_h2d[10];
-  assign tl_s1n_23_ds_d2h[10] = tl_sm1_31_us_d2h[0];
+  assign tl_sm1_32_us_h2d[0] = tl_s1n_24_ds_h2d[10];
+  assign tl_s1n_24_ds_d2h[10] = tl_sm1_32_us_d2h[0];
 
-  assign tl_sm1_32_us_h2d[0] = tl_s1n_23_ds_h2d[11];
-  assign tl_s1n_23_ds_d2h[11] = tl_sm1_32_us_d2h[0];
+  assign tl_sm1_33_us_h2d[0] = tl_s1n_24_ds_h2d[11];
+  assign tl_s1n_24_ds_d2h[11] = tl_sm1_33_us_d2h[0];
 
-  assign tl_sm1_33_us_h2d[0] = tl_s1n_23_ds_h2d[12];
-  assign tl_s1n_23_ds_d2h[12] = tl_sm1_33_us_d2h[0];
+  assign tl_sm1_34_us_h2d[0] = tl_s1n_24_ds_h2d[12];
+  assign tl_s1n_24_ds_d2h[12] = tl_sm1_34_us_d2h[0];
 
-  assign tl_sm1_34_us_h2d[0] = tl_s1n_23_ds_h2d[13];
-  assign tl_s1n_23_ds_d2h[13] = tl_sm1_34_us_d2h[0];
+  assign tl_sm1_35_us_h2d[0] = tl_s1n_24_ds_h2d[13];
+  assign tl_s1n_24_ds_d2h[13] = tl_sm1_35_us_d2h[0];
 
-  assign tl_keymgr_o = tl_s1n_23_ds_h2d[14];
-  assign tl_s1n_23_ds_d2h[14] = tl_keymgr_i;
+  assign tl_keymgr_o = tl_s1n_24_ds_h2d[14];
+  assign tl_s1n_24_ds_d2h[14] = tl_keymgr_i;
 
-  assign tl_sm1_19_us_h2d[2] = tl_s1n_35_ds_h2d[0];
-  assign tl_s1n_35_ds_d2h[0] = tl_sm1_19_us_d2h[2];
+  assign tl_sm1_36_us_h2d[0] = tl_s1n_24_ds_h2d[15];
+  assign tl_s1n_24_ds_d2h[15] = tl_sm1_36_us_d2h[0];
 
-  assign tl_sm1_21_us_h2d[2] = tl_s1n_35_ds_h2d[1];
-  assign tl_s1n_35_ds_d2h[1] = tl_sm1_21_us_d2h[2];
+  assign tl_sm1_20_us_h2d[2] = tl_s1n_37_ds_h2d[0];
+  assign tl_s1n_37_ds_d2h[0] = tl_sm1_20_us_d2h[2];
 
-  assign tl_sm1_22_us_h2d[2] = tl_s1n_35_ds_h2d[2];
-  assign tl_s1n_35_ds_d2h[2] = tl_sm1_22_us_d2h[2];
+  assign tl_sm1_22_us_h2d[2] = tl_s1n_37_ds_h2d[1];
+  assign tl_s1n_37_ds_d2h[1] = tl_sm1_22_us_d2h[2];
 
-  assign tl_sm1_25_us_h2d[1] = tl_s1n_35_ds_h2d[3];
-  assign tl_s1n_35_ds_d2h[3] = tl_sm1_25_us_d2h[1];
+  assign tl_sm1_23_us_h2d[2] = tl_s1n_37_ds_h2d[2];
+  assign tl_s1n_37_ds_d2h[2] = tl_sm1_23_us_d2h[2];
 
-  assign tl_sm1_26_us_h2d[1] = tl_s1n_35_ds_h2d[4];
-  assign tl_s1n_35_ds_d2h[4] = tl_sm1_26_us_d2h[1];
+  assign tl_sm1_26_us_h2d[1] = tl_s1n_37_ds_h2d[3];
+  assign tl_s1n_37_ds_d2h[3] = tl_sm1_26_us_d2h[1];
 
-  assign tl_sm1_27_us_h2d[1] = tl_s1n_35_ds_h2d[5];
-  assign tl_s1n_35_ds_d2h[5] = tl_sm1_27_us_d2h[1];
+  assign tl_sm1_27_us_h2d[1] = tl_s1n_37_ds_h2d[4];
+  assign tl_s1n_37_ds_d2h[4] = tl_sm1_27_us_d2h[1];
 
-  assign tl_sm1_28_us_h2d[1] = tl_s1n_35_ds_h2d[6];
-  assign tl_s1n_35_ds_d2h[6] = tl_sm1_28_us_d2h[1];
+  assign tl_sm1_28_us_h2d[1] = tl_s1n_37_ds_h2d[5];
+  assign tl_s1n_37_ds_d2h[5] = tl_sm1_28_us_d2h[1];
 
-  assign tl_sm1_29_us_h2d[1] = tl_s1n_35_ds_h2d[7];
-  assign tl_s1n_35_ds_d2h[7] = tl_sm1_29_us_d2h[1];
+  assign tl_sm1_29_us_h2d[1] = tl_s1n_37_ds_h2d[6];
+  assign tl_s1n_37_ds_d2h[6] = tl_sm1_29_us_d2h[1];
 
-  assign tl_sm1_30_us_h2d[1] = tl_s1n_35_ds_h2d[8];
-  assign tl_s1n_35_ds_d2h[8] = tl_sm1_30_us_d2h[1];
+  assign tl_sm1_30_us_h2d[1] = tl_s1n_37_ds_h2d[7];
+  assign tl_s1n_37_ds_d2h[7] = tl_sm1_30_us_d2h[1];
 
-  assign tl_sm1_31_us_h2d[1] = tl_s1n_35_ds_h2d[9];
-  assign tl_s1n_35_ds_d2h[9] = tl_sm1_31_us_d2h[1];
+  assign tl_sm1_31_us_h2d[1] = tl_s1n_37_ds_h2d[8];
+  assign tl_s1n_37_ds_d2h[8] = tl_sm1_31_us_d2h[1];
 
-  assign tl_sm1_32_us_h2d[1] = tl_s1n_35_ds_h2d[10];
-  assign tl_s1n_35_ds_d2h[10] = tl_sm1_32_us_d2h[1];
+  assign tl_sm1_32_us_h2d[1] = tl_s1n_37_ds_h2d[9];
+  assign tl_s1n_37_ds_d2h[9] = tl_sm1_32_us_d2h[1];
 
-  assign tl_sm1_33_us_h2d[1] = tl_s1n_35_ds_h2d[11];
-  assign tl_s1n_35_ds_d2h[11] = tl_sm1_33_us_d2h[1];
+  assign tl_sm1_33_us_h2d[1] = tl_s1n_37_ds_h2d[10];
+  assign tl_s1n_37_ds_d2h[10] = tl_sm1_33_us_d2h[1];
 
-  assign tl_sm1_34_us_h2d[1] = tl_s1n_35_ds_h2d[12];
-  assign tl_s1n_35_ds_d2h[12] = tl_sm1_34_us_d2h[1];
+  assign tl_sm1_34_us_h2d[1] = tl_s1n_37_ds_h2d[11];
+  assign tl_s1n_37_ds_d2h[11] = tl_sm1_34_us_d2h[1];
 
-  assign tl_s1n_18_us_h2d = tl_corei_i;
-  assign tl_corei_o = tl_s1n_18_us_d2h;
+  assign tl_sm1_35_us_h2d[1] = tl_s1n_37_ds_h2d[12];
+  assign tl_s1n_37_ds_d2h[12] = tl_sm1_35_us_d2h[1];
 
-  assign tl_rom_o = tl_sm1_19_ds_h2d;
-  assign tl_sm1_19_ds_d2h = tl_rom_i;
+  assign tl_sm1_36_us_h2d[1] = tl_s1n_37_ds_h2d[13];
+  assign tl_s1n_37_ds_d2h[13] = tl_sm1_36_us_d2h[1];
 
-  assign tl_debug_mem_o = tl_sm1_20_ds_h2d;
-  assign tl_sm1_20_ds_d2h = tl_debug_mem_i;
+  assign tl_s1n_19_us_h2d = tl_corei_i;
+  assign tl_corei_o = tl_s1n_19_us_d2h;
 
-  assign tl_ram_main_o = tl_sm1_21_ds_h2d;
-  assign tl_sm1_21_ds_d2h = tl_ram_main_i;
+  assign tl_rom_o = tl_sm1_20_ds_h2d;
+  assign tl_sm1_20_ds_d2h = tl_rom_i;
 
-  assign tl_eflash_o = tl_sm1_22_ds_h2d;
-  assign tl_sm1_22_ds_d2h = tl_eflash_i;
+  assign tl_debug_mem_o = tl_sm1_21_ds_h2d;
+  assign tl_sm1_21_ds_d2h = tl_debug_mem_i;
 
-  assign tl_s1n_23_us_h2d = tl_cored_i;
-  assign tl_cored_o = tl_s1n_23_us_d2h;
+  assign tl_ram_main_o = tl_sm1_22_ds_h2d;
+  assign tl_sm1_22_ds_d2h = tl_ram_main_i;
 
-  assign tl_peri_o = tl_asf_24_ds_h2d;
-  assign tl_asf_24_ds_d2h = tl_peri_i;
+  assign tl_eflash_o = tl_sm1_23_ds_h2d;
+  assign tl_sm1_23_ds_d2h = tl_eflash_i;
 
-  assign tl_asf_24_us_h2d = tl_sm1_25_ds_h2d;
-  assign tl_sm1_25_ds_d2h = tl_asf_24_us_d2h;
+  assign tl_s1n_24_us_h2d = tl_cored_i;
+  assign tl_cored_o = tl_s1n_24_us_d2h;
 
-  assign tl_flash_ctrl_o = tl_sm1_26_ds_h2d;
-  assign tl_sm1_26_ds_d2h = tl_flash_ctrl_i;
+  assign tl_peri_o = tl_asf_25_ds_h2d;
+  assign tl_asf_25_ds_d2h = tl_peri_i;
 
-  assign tl_aes_o = tl_sm1_27_ds_h2d;
-  assign tl_sm1_27_ds_d2h = tl_aes_i;
+  assign tl_asf_25_us_h2d = tl_sm1_26_ds_h2d;
+  assign tl_sm1_26_ds_d2h = tl_asf_25_us_d2h;
 
-  assign tl_hmac_o = tl_sm1_28_ds_h2d;
-  assign tl_sm1_28_ds_d2h = tl_hmac_i;
+  assign tl_flash_ctrl_o = tl_sm1_27_ds_h2d;
+  assign tl_sm1_27_ds_d2h = tl_flash_ctrl_i;
 
-  assign tl_rv_plic_o = tl_sm1_29_ds_h2d;
-  assign tl_sm1_29_ds_d2h = tl_rv_plic_i;
+  assign tl_aes_o = tl_sm1_28_ds_h2d;
+  assign tl_sm1_28_ds_d2h = tl_aes_i;
 
-  assign tl_pinmux_o = tl_sm1_30_ds_h2d;
-  assign tl_sm1_30_ds_d2h = tl_pinmux_i;
+  assign tl_hmac_o = tl_sm1_29_ds_h2d;
+  assign tl_sm1_29_ds_d2h = tl_hmac_i;
 
-  assign tl_padctrl_o = tl_sm1_31_ds_h2d;
-  assign tl_sm1_31_ds_d2h = tl_padctrl_i;
+  assign tl_rv_plic_o = tl_sm1_30_ds_h2d;
+  assign tl_sm1_30_ds_d2h = tl_rv_plic_i;
 
-  assign tl_alert_handler_o = tl_sm1_32_ds_h2d;
-  assign tl_sm1_32_ds_d2h = tl_alert_handler_i;
+  assign tl_pinmux_o = tl_sm1_31_ds_h2d;
+  assign tl_sm1_31_ds_d2h = tl_pinmux_i;
 
-  assign tl_nmi_gen_o = tl_sm1_33_ds_h2d;
-  assign tl_sm1_33_ds_d2h = tl_nmi_gen_i;
+  assign tl_padctrl_o = tl_sm1_32_ds_h2d;
+  assign tl_sm1_32_ds_d2h = tl_padctrl_i;
 
-  assign tl_otbn_o = tl_sm1_34_ds_h2d;
-  assign tl_sm1_34_ds_d2h = tl_otbn_i;
+  assign tl_alert_handler_o = tl_sm1_33_ds_h2d;
+  assign tl_sm1_33_ds_d2h = tl_alert_handler_i;
 
-  assign tl_s1n_35_us_h2d = tl_dm_sba_i;
-  assign tl_dm_sba_o = tl_s1n_35_us_d2h;
+  assign tl_nmi_gen_o = tl_sm1_34_ds_h2d;
+  assign tl_sm1_34_ds_d2h = tl_nmi_gen_i;
+
+  assign tl_otbn_o = tl_sm1_35_ds_h2d;
+  assign tl_sm1_35_ds_d2h = tl_otbn_i;
+
+  assign tl_kmac_o = tl_sm1_36_ds_h2d;
+  assign tl_sm1_36_ds_d2h = tl_kmac_i;
+
+  assign tl_s1n_37_us_h2d = tl_dm_sba_i;
+  assign tl_dm_sba_o = tl_s1n_37_us_d2h;
 
   always_comb begin
     // default steering to generate error response if address is not within the range
-    dev_sel_s1n_18 = 3'd4;
-    if ((tl_s1n_18_us_h2d.a_address & ~(ADDR_MASK_ROM)) == ADDR_SPACE_ROM) begin
-      dev_sel_s1n_18 = 3'd0;
+    dev_sel_s1n_19 = 3'd4;
+    if ((tl_s1n_19_us_h2d.a_address & ~(ADDR_MASK_ROM)) == ADDR_SPACE_ROM) begin
+      dev_sel_s1n_19 = 3'd0;
 
-    end else if ((tl_s1n_18_us_h2d.a_address & ~(ADDR_MASK_DEBUG_MEM)) == ADDR_SPACE_DEBUG_MEM) begin
-      dev_sel_s1n_18 = 3'd1;
+    end else if ((tl_s1n_19_us_h2d.a_address & ~(ADDR_MASK_DEBUG_MEM)) == ADDR_SPACE_DEBUG_MEM) begin
+      dev_sel_s1n_19 = 3'd1;
 
-    end else if ((tl_s1n_18_us_h2d.a_address & ~(ADDR_MASK_RAM_MAIN)) == ADDR_SPACE_RAM_MAIN) begin
-      dev_sel_s1n_18 = 3'd2;
+    end else if ((tl_s1n_19_us_h2d.a_address & ~(ADDR_MASK_RAM_MAIN)) == ADDR_SPACE_RAM_MAIN) begin
+      dev_sel_s1n_19 = 3'd2;
 
-    end else if ((tl_s1n_18_us_h2d.a_address & ~(ADDR_MASK_EFLASH)) == ADDR_SPACE_EFLASH) begin
-      dev_sel_s1n_18 = 3'd3;
+    end else if ((tl_s1n_19_us_h2d.a_address & ~(ADDR_MASK_EFLASH)) == ADDR_SPACE_EFLASH) begin
+      dev_sel_s1n_19 = 3'd3;
 end
   end
 
   always_comb begin
     // default steering to generate error response if address is not within the range
-    dev_sel_s1n_23 = 4'd15;
-    if ((tl_s1n_23_us_h2d.a_address & ~(ADDR_MASK_ROM)) == ADDR_SPACE_ROM) begin
-      dev_sel_s1n_23 = 4'd0;
+    dev_sel_s1n_24 = 5'd16;
+    if ((tl_s1n_24_us_h2d.a_address & ~(ADDR_MASK_ROM)) == ADDR_SPACE_ROM) begin
+      dev_sel_s1n_24 = 5'd0;
 
-    end else if ((tl_s1n_23_us_h2d.a_address & ~(ADDR_MASK_DEBUG_MEM)) == ADDR_SPACE_DEBUG_MEM) begin
-      dev_sel_s1n_23 = 4'd1;
+    end else if ((tl_s1n_24_us_h2d.a_address & ~(ADDR_MASK_DEBUG_MEM)) == ADDR_SPACE_DEBUG_MEM) begin
+      dev_sel_s1n_24 = 5'd1;
 
-    end else if ((tl_s1n_23_us_h2d.a_address & ~(ADDR_MASK_RAM_MAIN)) == ADDR_SPACE_RAM_MAIN) begin
-      dev_sel_s1n_23 = 4'd2;
+    end else if ((tl_s1n_24_us_h2d.a_address & ~(ADDR_MASK_RAM_MAIN)) == ADDR_SPACE_RAM_MAIN) begin
+      dev_sel_s1n_24 = 5'd2;
 
-    end else if ((tl_s1n_23_us_h2d.a_address & ~(ADDR_MASK_EFLASH)) == ADDR_SPACE_EFLASH) begin
-      dev_sel_s1n_23 = 4'd3;
+    end else if ((tl_s1n_24_us_h2d.a_address & ~(ADDR_MASK_EFLASH)) == ADDR_SPACE_EFLASH) begin
+      dev_sel_s1n_24 = 5'd3;
 
     end else if (
-      ((tl_s1n_23_us_h2d.a_address & ~(ADDR_MASK_PERI[0])) == ADDR_SPACE_PERI[0]) ||
-      ((tl_s1n_23_us_h2d.a_address <= (ADDR_MASK_PERI[1] + ADDR_SPACE_PERI[1])) &&
-       (tl_s1n_23_us_h2d.a_address >= ADDR_SPACE_PERI[1])) ||
-      ((tl_s1n_23_us_h2d.a_address <= (ADDR_MASK_PERI[2] + ADDR_SPACE_PERI[2])) &&
-       (tl_s1n_23_us_h2d.a_address >= ADDR_SPACE_PERI[2])) ||
-      ((tl_s1n_23_us_h2d.a_address <= (ADDR_MASK_PERI[3] + ADDR_SPACE_PERI[3])) &&
-       (tl_s1n_23_us_h2d.a_address >= ADDR_SPACE_PERI[3])) ||
-      ((tl_s1n_23_us_h2d.a_address <= (ADDR_MASK_PERI[4] + ADDR_SPACE_PERI[4])) &&
-       (tl_s1n_23_us_h2d.a_address >= ADDR_SPACE_PERI[4])) ||
-      ((tl_s1n_23_us_h2d.a_address <= (ADDR_MASK_PERI[5] + ADDR_SPACE_PERI[5])) &&
-       (tl_s1n_23_us_h2d.a_address >= ADDR_SPACE_PERI[5])) ||
-      ((tl_s1n_23_us_h2d.a_address <= (ADDR_MASK_PERI[6] + ADDR_SPACE_PERI[6])) &&
-       (tl_s1n_23_us_h2d.a_address >= ADDR_SPACE_PERI[6]))
+      ((tl_s1n_24_us_h2d.a_address & ~(ADDR_MASK_PERI[0])) == ADDR_SPACE_PERI[0]) ||
+      ((tl_s1n_24_us_h2d.a_address <= (ADDR_MASK_PERI[1] + ADDR_SPACE_PERI[1])) &&
+       (tl_s1n_24_us_h2d.a_address >= ADDR_SPACE_PERI[1])) ||
+      ((tl_s1n_24_us_h2d.a_address <= (ADDR_MASK_PERI[2] + ADDR_SPACE_PERI[2])) &&
+       (tl_s1n_24_us_h2d.a_address >= ADDR_SPACE_PERI[2])) ||
+      ((tl_s1n_24_us_h2d.a_address <= (ADDR_MASK_PERI[3] + ADDR_SPACE_PERI[3])) &&
+       (tl_s1n_24_us_h2d.a_address >= ADDR_SPACE_PERI[3])) ||
+      ((tl_s1n_24_us_h2d.a_address <= (ADDR_MASK_PERI[4] + ADDR_SPACE_PERI[4])) &&
+       (tl_s1n_24_us_h2d.a_address >= ADDR_SPACE_PERI[4])) ||
+      ((tl_s1n_24_us_h2d.a_address <= (ADDR_MASK_PERI[5] + ADDR_SPACE_PERI[5])) &&
+       (tl_s1n_24_us_h2d.a_address >= ADDR_SPACE_PERI[5])) ||
+      ((tl_s1n_24_us_h2d.a_address <= (ADDR_MASK_PERI[6] + ADDR_SPACE_PERI[6])) &&
+       (tl_s1n_24_us_h2d.a_address >= ADDR_SPACE_PERI[6]))
     ) begin
-      dev_sel_s1n_23 = 4'd4;
+      dev_sel_s1n_24 = 5'd4;
 
-    end else if ((tl_s1n_23_us_h2d.a_address & ~(ADDR_MASK_FLASH_CTRL)) == ADDR_SPACE_FLASH_CTRL) begin
-      dev_sel_s1n_23 = 4'd5;
+    end else if ((tl_s1n_24_us_h2d.a_address & ~(ADDR_MASK_FLASH_CTRL)) == ADDR_SPACE_FLASH_CTRL) begin
+      dev_sel_s1n_24 = 5'd5;
 
-    end else if ((tl_s1n_23_us_h2d.a_address & ~(ADDR_MASK_AES)) == ADDR_SPACE_AES) begin
-      dev_sel_s1n_23 = 4'd6;
+    end else if ((tl_s1n_24_us_h2d.a_address & ~(ADDR_MASK_AES)) == ADDR_SPACE_AES) begin
+      dev_sel_s1n_24 = 5'd6;
 
-    end else if ((tl_s1n_23_us_h2d.a_address & ~(ADDR_MASK_HMAC)) == ADDR_SPACE_HMAC) begin
-      dev_sel_s1n_23 = 4'd7;
+    end else if ((tl_s1n_24_us_h2d.a_address & ~(ADDR_MASK_HMAC)) == ADDR_SPACE_HMAC) begin
+      dev_sel_s1n_24 = 5'd7;
 
-    end else if ((tl_s1n_23_us_h2d.a_address & ~(ADDR_MASK_RV_PLIC)) == ADDR_SPACE_RV_PLIC) begin
-      dev_sel_s1n_23 = 4'd8;
+    end else if ((tl_s1n_24_us_h2d.a_address & ~(ADDR_MASK_RV_PLIC)) == ADDR_SPACE_RV_PLIC) begin
+      dev_sel_s1n_24 = 5'd8;
 
-    end else if ((tl_s1n_23_us_h2d.a_address & ~(ADDR_MASK_PINMUX)) == ADDR_SPACE_PINMUX) begin
-      dev_sel_s1n_23 = 4'd9;
+    end else if ((tl_s1n_24_us_h2d.a_address & ~(ADDR_MASK_PINMUX)) == ADDR_SPACE_PINMUX) begin
+      dev_sel_s1n_24 = 5'd9;
 
-    end else if ((tl_s1n_23_us_h2d.a_address & ~(ADDR_MASK_PADCTRL)) == ADDR_SPACE_PADCTRL) begin
-      dev_sel_s1n_23 = 4'd10;
+    end else if ((tl_s1n_24_us_h2d.a_address & ~(ADDR_MASK_PADCTRL)) == ADDR_SPACE_PADCTRL) begin
+      dev_sel_s1n_24 = 5'd10;
 
-    end else if ((tl_s1n_23_us_h2d.a_address & ~(ADDR_MASK_ALERT_HANDLER)) == ADDR_SPACE_ALERT_HANDLER) begin
-      dev_sel_s1n_23 = 4'd11;
+    end else if ((tl_s1n_24_us_h2d.a_address & ~(ADDR_MASK_ALERT_HANDLER)) == ADDR_SPACE_ALERT_HANDLER) begin
+      dev_sel_s1n_24 = 5'd11;
 
-    end else if ((tl_s1n_23_us_h2d.a_address & ~(ADDR_MASK_NMI_GEN)) == ADDR_SPACE_NMI_GEN) begin
-      dev_sel_s1n_23 = 4'd12;
+    end else if ((tl_s1n_24_us_h2d.a_address & ~(ADDR_MASK_NMI_GEN)) == ADDR_SPACE_NMI_GEN) begin
+      dev_sel_s1n_24 = 5'd12;
 
-    end else if ((tl_s1n_23_us_h2d.a_address & ~(ADDR_MASK_OTBN)) == ADDR_SPACE_OTBN) begin
-      dev_sel_s1n_23 = 4'd13;
+    end else if ((tl_s1n_24_us_h2d.a_address & ~(ADDR_MASK_OTBN)) == ADDR_SPACE_OTBN) begin
+      dev_sel_s1n_24 = 5'd13;
 
-    end else if ((tl_s1n_23_us_h2d.a_address & ~(ADDR_MASK_KEYMGR)) == ADDR_SPACE_KEYMGR) begin
-      dev_sel_s1n_23 = 4'd14;
+    end else if ((tl_s1n_24_us_h2d.a_address & ~(ADDR_MASK_KEYMGR)) == ADDR_SPACE_KEYMGR) begin
+      dev_sel_s1n_24 = 5'd14;
+
+    end else if ((tl_s1n_24_us_h2d.a_address & ~(ADDR_MASK_KMAC)) == ADDR_SPACE_KMAC) begin
+      dev_sel_s1n_24 = 5'd15;
 end
   end
 
   always_comb begin
     // default steering to generate error response if address is not within the range
-    dev_sel_s1n_35 = 4'd13;
-    if ((tl_s1n_35_us_h2d.a_address & ~(ADDR_MASK_ROM)) == ADDR_SPACE_ROM) begin
-      dev_sel_s1n_35 = 4'd0;
+    dev_sel_s1n_37 = 4'd14;
+    if ((tl_s1n_37_us_h2d.a_address & ~(ADDR_MASK_ROM)) == ADDR_SPACE_ROM) begin
+      dev_sel_s1n_37 = 4'd0;
 
-    end else if ((tl_s1n_35_us_h2d.a_address & ~(ADDR_MASK_RAM_MAIN)) == ADDR_SPACE_RAM_MAIN) begin
-      dev_sel_s1n_35 = 4'd1;
+    end else if ((tl_s1n_37_us_h2d.a_address & ~(ADDR_MASK_RAM_MAIN)) == ADDR_SPACE_RAM_MAIN) begin
+      dev_sel_s1n_37 = 4'd1;
 
-    end else if ((tl_s1n_35_us_h2d.a_address & ~(ADDR_MASK_EFLASH)) == ADDR_SPACE_EFLASH) begin
-      dev_sel_s1n_35 = 4'd2;
+    end else if ((tl_s1n_37_us_h2d.a_address & ~(ADDR_MASK_EFLASH)) == ADDR_SPACE_EFLASH) begin
+      dev_sel_s1n_37 = 4'd2;
 
     end else if (
-      ((tl_s1n_35_us_h2d.a_address & ~(ADDR_MASK_PERI[0])) == ADDR_SPACE_PERI[0]) ||
-      ((tl_s1n_35_us_h2d.a_address <= (ADDR_MASK_PERI[1] + ADDR_SPACE_PERI[1])) &&
-       (tl_s1n_35_us_h2d.a_address >= ADDR_SPACE_PERI[1])) ||
-      ((tl_s1n_35_us_h2d.a_address <= (ADDR_MASK_PERI[2] + ADDR_SPACE_PERI[2])) &&
-       (tl_s1n_35_us_h2d.a_address >= ADDR_SPACE_PERI[2])) ||
-      ((tl_s1n_35_us_h2d.a_address <= (ADDR_MASK_PERI[3] + ADDR_SPACE_PERI[3])) &&
-       (tl_s1n_35_us_h2d.a_address >= ADDR_SPACE_PERI[3])) ||
-      ((tl_s1n_35_us_h2d.a_address <= (ADDR_MASK_PERI[4] + ADDR_SPACE_PERI[4])) &&
-       (tl_s1n_35_us_h2d.a_address >= ADDR_SPACE_PERI[4])) ||
-      ((tl_s1n_35_us_h2d.a_address <= (ADDR_MASK_PERI[5] + ADDR_SPACE_PERI[5])) &&
-       (tl_s1n_35_us_h2d.a_address >= ADDR_SPACE_PERI[5])) ||
-      ((tl_s1n_35_us_h2d.a_address <= (ADDR_MASK_PERI[6] + ADDR_SPACE_PERI[6])) &&
-       (tl_s1n_35_us_h2d.a_address >= ADDR_SPACE_PERI[6]))
+      ((tl_s1n_37_us_h2d.a_address & ~(ADDR_MASK_PERI[0])) == ADDR_SPACE_PERI[0]) ||
+      ((tl_s1n_37_us_h2d.a_address <= (ADDR_MASK_PERI[1] + ADDR_SPACE_PERI[1])) &&
+       (tl_s1n_37_us_h2d.a_address >= ADDR_SPACE_PERI[1])) ||
+      ((tl_s1n_37_us_h2d.a_address <= (ADDR_MASK_PERI[2] + ADDR_SPACE_PERI[2])) &&
+       (tl_s1n_37_us_h2d.a_address >= ADDR_SPACE_PERI[2])) ||
+      ((tl_s1n_37_us_h2d.a_address <= (ADDR_MASK_PERI[3] + ADDR_SPACE_PERI[3])) &&
+       (tl_s1n_37_us_h2d.a_address >= ADDR_SPACE_PERI[3])) ||
+      ((tl_s1n_37_us_h2d.a_address <= (ADDR_MASK_PERI[4] + ADDR_SPACE_PERI[4])) &&
+       (tl_s1n_37_us_h2d.a_address >= ADDR_SPACE_PERI[4])) ||
+      ((tl_s1n_37_us_h2d.a_address <= (ADDR_MASK_PERI[5] + ADDR_SPACE_PERI[5])) &&
+       (tl_s1n_37_us_h2d.a_address >= ADDR_SPACE_PERI[5])) ||
+      ((tl_s1n_37_us_h2d.a_address <= (ADDR_MASK_PERI[6] + ADDR_SPACE_PERI[6])) &&
+       (tl_s1n_37_us_h2d.a_address >= ADDR_SPACE_PERI[6]))
     ) begin
-      dev_sel_s1n_35 = 4'd3;
+      dev_sel_s1n_37 = 4'd3;
 
-    end else if ((tl_s1n_35_us_h2d.a_address & ~(ADDR_MASK_FLASH_CTRL)) == ADDR_SPACE_FLASH_CTRL) begin
-      dev_sel_s1n_35 = 4'd4;
+    end else if ((tl_s1n_37_us_h2d.a_address & ~(ADDR_MASK_FLASH_CTRL)) == ADDR_SPACE_FLASH_CTRL) begin
+      dev_sel_s1n_37 = 4'd4;
 
-    end else if ((tl_s1n_35_us_h2d.a_address & ~(ADDR_MASK_AES)) == ADDR_SPACE_AES) begin
-      dev_sel_s1n_35 = 4'd5;
+    end else if ((tl_s1n_37_us_h2d.a_address & ~(ADDR_MASK_AES)) == ADDR_SPACE_AES) begin
+      dev_sel_s1n_37 = 4'd5;
 
-    end else if ((tl_s1n_35_us_h2d.a_address & ~(ADDR_MASK_HMAC)) == ADDR_SPACE_HMAC) begin
-      dev_sel_s1n_35 = 4'd6;
+    end else if ((tl_s1n_37_us_h2d.a_address & ~(ADDR_MASK_HMAC)) == ADDR_SPACE_HMAC) begin
+      dev_sel_s1n_37 = 4'd6;
 
-    end else if ((tl_s1n_35_us_h2d.a_address & ~(ADDR_MASK_RV_PLIC)) == ADDR_SPACE_RV_PLIC) begin
-      dev_sel_s1n_35 = 4'd7;
+    end else if ((tl_s1n_37_us_h2d.a_address & ~(ADDR_MASK_RV_PLIC)) == ADDR_SPACE_RV_PLIC) begin
+      dev_sel_s1n_37 = 4'd7;
 
-    end else if ((tl_s1n_35_us_h2d.a_address & ~(ADDR_MASK_PINMUX)) == ADDR_SPACE_PINMUX) begin
-      dev_sel_s1n_35 = 4'd8;
+    end else if ((tl_s1n_37_us_h2d.a_address & ~(ADDR_MASK_PINMUX)) == ADDR_SPACE_PINMUX) begin
+      dev_sel_s1n_37 = 4'd8;
 
-    end else if ((tl_s1n_35_us_h2d.a_address & ~(ADDR_MASK_PADCTRL)) == ADDR_SPACE_PADCTRL) begin
-      dev_sel_s1n_35 = 4'd9;
+    end else if ((tl_s1n_37_us_h2d.a_address & ~(ADDR_MASK_PADCTRL)) == ADDR_SPACE_PADCTRL) begin
+      dev_sel_s1n_37 = 4'd9;
 
-    end else if ((tl_s1n_35_us_h2d.a_address & ~(ADDR_MASK_ALERT_HANDLER)) == ADDR_SPACE_ALERT_HANDLER) begin
-      dev_sel_s1n_35 = 4'd10;
+    end else if ((tl_s1n_37_us_h2d.a_address & ~(ADDR_MASK_ALERT_HANDLER)) == ADDR_SPACE_ALERT_HANDLER) begin
+      dev_sel_s1n_37 = 4'd10;
 
-    end else if ((tl_s1n_35_us_h2d.a_address & ~(ADDR_MASK_NMI_GEN)) == ADDR_SPACE_NMI_GEN) begin
-      dev_sel_s1n_35 = 4'd11;
+    end else if ((tl_s1n_37_us_h2d.a_address & ~(ADDR_MASK_NMI_GEN)) == ADDR_SPACE_NMI_GEN) begin
+      dev_sel_s1n_37 = 4'd11;
 
-    end else if ((tl_s1n_35_us_h2d.a_address & ~(ADDR_MASK_OTBN)) == ADDR_SPACE_OTBN) begin
-      dev_sel_s1n_35 = 4'd12;
+    end else if ((tl_s1n_37_us_h2d.a_address & ~(ADDR_MASK_OTBN)) == ADDR_SPACE_OTBN) begin
+      dev_sel_s1n_37 = 4'd12;
+
+    end else if ((tl_s1n_37_us_h2d.a_address & ~(ADDR_MASK_KMAC)) == ADDR_SPACE_KMAC) begin
+      dev_sel_s1n_37 = 4'd13;
 end
   end
 
@@ -567,14 +595,14 @@ end
     .DReqDepth (16'h0),
     .DRspDepth (16'h0),
     .N         (4)
-  ) u_s1n_18 (
+  ) u_s1n_19 (
     .clk_i        (clk_main_i),
     .rst_ni       (rst_main_ni),
-    .tl_h_i       (tl_s1n_18_us_h2d),
-    .tl_h_o       (tl_s1n_18_us_d2h),
-    .tl_d_o       (tl_s1n_18_ds_h2d),
-    .tl_d_i       (tl_s1n_18_ds_d2h),
-    .dev_select_i (dev_sel_s1n_18)
+    .tl_h_i       (tl_s1n_19_us_h2d),
+    .tl_h_o       (tl_s1n_19_us_d2h),
+    .tl_d_o       (tl_s1n_19_ds_h2d),
+    .tl_d_i       (tl_s1n_19_ds_d2h),
+    .dev_select_i (dev_sel_s1n_19)
   );
   tlul_socket_m1 #(
     .HReqDepth (12'h0),
@@ -582,20 +610,6 @@ end
     .DReqDepth (4'h0),
     .DRspDepth (4'h0),
     .M         (3)
-  ) u_sm1_19 (
-    .clk_i        (clk_main_i),
-    .rst_ni       (rst_main_ni),
-    .tl_h_i       (tl_sm1_19_us_h2d),
-    .tl_h_o       (tl_sm1_19_us_d2h),
-    .tl_d_o       (tl_sm1_19_ds_h2d),
-    .tl_d_i       (tl_sm1_19_ds_d2h)
-  );
-  tlul_socket_m1 #(
-    .HReqDepth (8'h0),
-    .HRspDepth (8'h0),
-    .DReqPass  (1'b0),
-    .DRspPass  (1'b0),
-    .M         (2)
   ) u_sm1_20 (
     .clk_i        (clk_main_i),
     .rst_ni       (rst_main_ni),
@@ -605,11 +619,11 @@ end
     .tl_d_i       (tl_sm1_20_ds_d2h)
   );
   tlul_socket_m1 #(
-    .HReqDepth (12'h0),
-    .HRspDepth (12'h0),
-    .DReqDepth (4'h0),
-    .DRspDepth (4'h0),
-    .M         (3)
+    .HReqDepth (8'h0),
+    .HRspDepth (8'h0),
+    .DReqPass  (1'b0),
+    .DRspPass  (1'b0),
+    .M         (2)
   ) u_sm1_21 (
     .clk_i        (clk_main_i),
     .rst_ni       (rst_main_ni),
@@ -632,55 +646,55 @@ end
     .tl_d_o       (tl_sm1_22_ds_h2d),
     .tl_d_i       (tl_sm1_22_ds_d2h)
   );
+  tlul_socket_m1 #(
+    .HReqDepth (12'h0),
+    .HRspDepth (12'h0),
+    .DReqDepth (4'h0),
+    .DRspDepth (4'h0),
+    .M         (3)
+  ) u_sm1_23 (
+    .clk_i        (clk_main_i),
+    .rst_ni       (rst_main_ni),
+    .tl_h_i       (tl_sm1_23_us_h2d),
+    .tl_h_o       (tl_sm1_23_us_d2h),
+    .tl_d_o       (tl_sm1_23_ds_h2d),
+    .tl_d_i       (tl_sm1_23_ds_d2h)
+  );
   tlul_socket_1n #(
     .HReqDepth (4'h0),
     .HRspDepth (4'h0),
-    .DReqPass  (15'h3fff),
-    .DRspPass  (15'h3fff),
-    .DReqDepth (60'h200000000000000),
-    .DRspDepth (60'h200000000000000),
-    .N         (15)
-  ) u_s1n_23 (
+    .DReqPass  (16'hbfff),
+    .DRspPass  (16'hbfff),
+    .DReqDepth (64'h200000000000000),
+    .DRspDepth (64'h200000000000000),
+    .N         (16)
+  ) u_s1n_24 (
     .clk_i        (clk_main_i),
     .rst_ni       (rst_main_ni),
-    .tl_h_i       (tl_s1n_23_us_h2d),
-    .tl_h_o       (tl_s1n_23_us_d2h),
-    .tl_d_o       (tl_s1n_23_ds_h2d),
-    .tl_d_i       (tl_s1n_23_ds_d2h),
-    .dev_select_i (dev_sel_s1n_23)
+    .tl_h_i       (tl_s1n_24_us_h2d),
+    .tl_h_o       (tl_s1n_24_us_d2h),
+    .tl_d_o       (tl_s1n_24_ds_h2d),
+    .tl_d_i       (tl_s1n_24_ds_d2h),
+    .dev_select_i (dev_sel_s1n_24)
   );
   tlul_fifo_async #(
     .ReqDepth        (3),// At least 3 to make async work
     .RspDepth        (3) // At least 3 to make async work
-  ) u_asf_24 (
+  ) u_asf_25 (
     .clk_h_i      (clk_main_i),
     .rst_h_ni     (rst_main_ni),
     .clk_d_i      (clk_fixed_i),
     .rst_d_ni     (rst_fixed_ni),
-    .tl_h_i       (tl_asf_24_us_h2d),
-    .tl_h_o       (tl_asf_24_us_d2h),
-    .tl_d_o       (tl_asf_24_ds_h2d),
-    .tl_d_i       (tl_asf_24_ds_d2h)
+    .tl_h_i       (tl_asf_25_us_h2d),
+    .tl_h_o       (tl_asf_25_us_d2h),
+    .tl_d_o       (tl_asf_25_ds_h2d),
+    .tl_d_i       (tl_asf_25_ds_d2h)
   );
   tlul_socket_m1 #(
     .HReqDepth (8'h0),
     .HRspDepth (8'h0),
     .DReqDepth (4'h0),
     .DRspDepth (4'h0),
-    .M         (2)
-  ) u_sm1_25 (
-    .clk_i        (clk_main_i),
-    .rst_ni       (rst_main_ni),
-    .tl_h_i       (tl_sm1_25_us_h2d),
-    .tl_h_o       (tl_sm1_25_us_d2h),
-    .tl_d_o       (tl_sm1_25_ds_h2d),
-    .tl_d_i       (tl_sm1_25_ds_d2h)
-  );
-  tlul_socket_m1 #(
-    .HReqDepth (8'h0),
-    .HRspDepth (8'h0),
-    .DReqPass  (1'b0),
-    .DRspPass  (1'b0),
     .M         (2)
   ) u_sm1_26 (
     .clk_i        (clk_main_i),
@@ -802,20 +816,48 @@ end
     .tl_d_o       (tl_sm1_34_ds_h2d),
     .tl_d_i       (tl_sm1_34_ds_d2h)
   );
+  tlul_socket_m1 #(
+    .HReqDepth (8'h0),
+    .HRspDepth (8'h0),
+    .DReqPass  (1'b0),
+    .DRspPass  (1'b0),
+    .M         (2)
+  ) u_sm1_35 (
+    .clk_i        (clk_main_i),
+    .rst_ni       (rst_main_ni),
+    .tl_h_i       (tl_sm1_35_us_h2d),
+    .tl_h_o       (tl_sm1_35_us_d2h),
+    .tl_d_o       (tl_sm1_35_ds_h2d),
+    .tl_d_i       (tl_sm1_35_ds_d2h)
+  );
+  tlul_socket_m1 #(
+    .HReqDepth (8'h0),
+    .HRspDepth (8'h0),
+    .DReqPass  (1'b0),
+    .DRspPass  (1'b0),
+    .M         (2)
+  ) u_sm1_36 (
+    .clk_i        (clk_main_i),
+    .rst_ni       (rst_main_ni),
+    .tl_h_i       (tl_sm1_36_us_h2d),
+    .tl_h_o       (tl_sm1_36_us_d2h),
+    .tl_d_o       (tl_sm1_36_ds_h2d),
+    .tl_d_i       (tl_sm1_36_ds_d2h)
+  );
   tlul_socket_1n #(
     .HReqPass  (1'b0),
     .HRspPass  (1'b0),
-    .DReqDepth (52'h0),
-    .DRspDepth (52'h0),
-    .N         (13)
-  ) u_s1n_35 (
+    .DReqDepth (56'h0),
+    .DRspDepth (56'h0),
+    .N         (14)
+  ) u_s1n_37 (
     .clk_i        (clk_main_i),
     .rst_ni       (rst_main_ni),
-    .tl_h_i       (tl_s1n_35_us_h2d),
-    .tl_h_o       (tl_s1n_35_us_d2h),
-    .tl_d_o       (tl_s1n_35_ds_h2d),
-    .tl_d_i       (tl_s1n_35_ds_d2h),
-    .dev_select_i (dev_sel_s1n_35)
+    .tl_h_i       (tl_s1n_37_us_h2d),
+    .tl_h_o       (tl_s1n_37_us_d2h),
+    .tl_d_o       (tl_s1n_37_ds_h2d),
+    .tl_d_i       (tl_s1n_37_ds_d2h),
+    .dev_select_i (dev_sel_s1n_37)
   );
 
 endmodule

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey_pkg.sv
@@ -82,6 +82,16 @@ package top_earlgrey_pkg;
   parameter int unsigned TOP_EARLGREY_HMAC_SIZE_BYTES = 32'h1000;
 
   /**
+   * Peripheral base address for kmac in top earlgrey.
+   */
+  parameter int unsigned TOP_EARLGREY_KMAC_BASE_ADDR = 32'h41120000;
+
+  /**
+   * Peripheral size in bytes for kmac in top earlgrey.
+   */
+  parameter int unsigned TOP_EARLGREY_KMAC_SIZE_BYTES = 32'h1000;
+
+  /**
    * Peripheral base address for rv_plic in top earlgrey.
    */
   parameter int unsigned TOP_EARLGREY_RV_PLIC_BASE_ADDR = 32'h40090000;

--- a/hw/top_earlgrey/rtl/top_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_asic.sv
@@ -252,7 +252,9 @@ module top_earlgrey_asic (
     .AesMasking(1'b1),
     .AesSBoxImpl(aes_pkg::SBoxImplCanrightMasked),
     .SecAesStartTriggerDelay(0),
-    .SecAesAllowForcingMasks(1'b0)
+    .SecAesAllowForcingMasks(1'b0),
+    .KmacEnMasking(1),  // DOM AND + Masking scheme
+    .KmacReuseShare(0)
   ) top_earlgrey (
     .rst_ni          ( rst_n         ),
     // ast connections

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.c
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.c
@@ -11,7 +11,7 @@
  * `top_earlgrey_plic_peripheral_t`.
  */
 const top_earlgrey_plic_peripheral_t
-    top_earlgrey_plic_interrupt_for_peripheral[84] = {
+    top_earlgrey_plic_interrupt_for_peripheral[87] = {
   [kTopEarlgreyPlicIrqIdNone] = kTopEarlgreyPlicPeripheralUnknown,
   [kTopEarlgreyPlicIrqIdGpioGpio0] = kTopEarlgreyPlicPeripheralGpio,
   [kTopEarlgreyPlicIrqIdGpioGpio1] = kTopEarlgreyPlicPeripheralGpio,
@@ -96,6 +96,9 @@ const top_earlgrey_plic_peripheral_t
   [kTopEarlgreyPlicIrqIdOtbnErr] = kTopEarlgreyPlicPeripheralOtbn,
   [kTopEarlgreyPlicIrqIdKeymgrOpDone] = kTopEarlgreyPlicPeripheralKeymgr,
   [kTopEarlgreyPlicIrqIdKeymgrErr] = kTopEarlgreyPlicPeripheralKeymgr,
+  [kTopEarlgreyPlicIrqIdKmacKmacDone] = kTopEarlgreyPlicPeripheralKmac,
+  [kTopEarlgreyPlicIrqIdKmacFifoEmpty] = kTopEarlgreyPlicPeripheralKmac,
+  [kTopEarlgreyPlicIrqIdKmacKmacErr] = kTopEarlgreyPlicPeripheralKmac,
 };
 
 

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -152,6 +152,24 @@ extern "C" {
 #define TOP_EARLGREY_HMAC_SIZE_BYTES 0x1000u
 
 /**
+ * Peripheral base address for kmac in top earlgrey.
+ *
+ * This should be used with #mmio_region_from_addr to access the memory-mapped
+ * registers associated with the peripheral (usually via a DIF).
+ */
+#define TOP_EARLGREY_KMAC_BASE_ADDR 0x41120000u
+
+/**
+ * Peripheral size for kmac in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_KMAC_BASE_ADDR and
+ * `TOP_EARLGREY_KMAC_BASE_ADDR + TOP_EARLGREY_KMAC_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_KMAC_SIZE_BYTES 0x1000u
+
+/**
  * Peripheral base address for rv_plic in top earlgrey.
  *
  * This should be used with #mmio_region_from_addr to access the memory-mapped
@@ -446,7 +464,8 @@ typedef enum top_earlgrey_plic_peripheral {
   kTopEarlgreyPlicPeripheralPwrmgr = 9, /**< pwrmgr */
   kTopEarlgreyPlicPeripheralOtbn = 10, /**< otbn */
   kTopEarlgreyPlicPeripheralKeymgr = 11, /**< keymgr */
-  kTopEarlgreyPlicPeripheralLast = 11, /**< \internal Final PLIC peripheral */
+  kTopEarlgreyPlicPeripheralKmac = 12, /**< kmac */
+  kTopEarlgreyPlicPeripheralLast = 12, /**< \internal Final PLIC peripheral */
 } top_earlgrey_plic_peripheral_t;
 
 /**
@@ -540,7 +559,10 @@ typedef enum top_earlgrey_plic_irq_id {
   kTopEarlgreyPlicIrqIdOtbnErr = 81, /**< otbn_err */
   kTopEarlgreyPlicIrqIdKeymgrOpDone = 82, /**< keymgr_op_done */
   kTopEarlgreyPlicIrqIdKeymgrErr = 83, /**< keymgr_err */
-  kTopEarlgreyPlicIrqIdLast = 83, /**< \internal The Last Valid Interrupt ID. */
+  kTopEarlgreyPlicIrqIdKmacKmacDone = 84, /**< kmac_kmac_done */
+  kTopEarlgreyPlicIrqIdKmacFifoEmpty = 85, /**< kmac_fifo_empty */
+  kTopEarlgreyPlicIrqIdKmacKmacErr = 86, /**< kmac_kmac_err */
+  kTopEarlgreyPlicIrqIdLast = 86, /**< \internal The Last Valid Interrupt ID. */
 } top_earlgrey_plic_irq_id_t;
 
 /**
@@ -550,7 +572,7 @@ typedef enum top_earlgrey_plic_irq_id {
  * `top_earlgrey_plic_peripheral_t`.
  */
 extern const top_earlgrey_plic_peripheral_t
-    top_earlgrey_plic_interrupt_for_peripheral[84];
+    top_earlgrey_plic_interrupt_for_peripheral[87];
 
 /**
  * PLIC Interrupt Target.

--- a/hw/top_earlgrey/top_earlgrey.core
+++ b/hw/top_earlgrey/top_earlgrey.core
@@ -23,6 +23,7 @@ filesets:
       - lowrisc:ip:spi_device
       - lowrisc:ip:aes
       - lowrisc:ip:hmac
+      - lowrisc:ip:kmac
       - lowrisc:ip:otbn
       - lowrisc:prim:ram_1p_adv
       - lowrisc:prim:rom_adv

--- a/sw/device/lib/dif/dif_plic.c
+++ b/sw/device/lib/dif/dif_plic.c
@@ -16,7 +16,7 @@
 // If either of these static assertions fail, then the assumptions in this DIF
 // implementation should be revisited. In particular, `kPlicTargets`
 // may need updating,
-_Static_assert(RV_PLIC_PARAM_NUMSRC == 84,
+_Static_assert(RV_PLIC_PARAM_NUMSRC == 87,
                "PLIC instantiation parameters have changed.");
 _Static_assert(RV_PLIC_PARAM_NUMTARGET == 1,
                "PLIC instantiation parameters have changed.");

--- a/sw/device/tests/dif/dif_plic_unittest.cc
+++ b/sw/device/tests/dif/dif_plic_unittest.cc
@@ -78,19 +78,19 @@ class IrqTest : public PlicTest {
       kEnableRegisters{{
           {RV_PLIC_IE0_0_REG_OFFSET, RV_PLIC_IE0_0_E_31_BIT},
           {RV_PLIC_IE0_1_REG_OFFSET, RV_PLIC_IE0_1_E_63_BIT},
-          {RV_PLIC_IE0_2_REG_OFFSET, RV_PLIC_IE0_2_E_83_BIT},
+          {RV_PLIC_IE0_2_REG_OFFSET, RV_PLIC_IE0_2_E_86_BIT},
       }};
   static constexpr std::array<Register, RV_PLIC_LE_MULTIREG_COUNT>
       kTriggerRegisters{{
           {RV_PLIC_LE_0_REG_OFFSET, RV_PLIC_LE_0_LE_31_BIT},
           {RV_PLIC_LE_1_REG_OFFSET, RV_PLIC_LE_1_LE_63_BIT},
-          {RV_PLIC_LE_2_REG_OFFSET, RV_PLIC_LE_2_LE_83_BIT},
+          {RV_PLIC_LE_2_REG_OFFSET, RV_PLIC_LE_2_LE_86_BIT},
       }};
   static constexpr std::array<Register, RV_PLIC_IP_MULTIREG_COUNT>
       kPendingRegisters{{
           {RV_PLIC_IP_0_REG_OFFSET, RV_PLIC_IP_0_P_31_BIT},
           {RV_PLIC_IP_1_REG_OFFSET, RV_PLIC_IP_1_P_63_BIT},
-          {RV_PLIC_IP_2_REG_OFFSET, RV_PLIC_IP_2_P_83_BIT},
+          {RV_PLIC_IP_2_REG_OFFSET, RV_PLIC_IP_2_P_86_BIT},
       }};
 
   // Set enable/disable multireg expectations, one bit per call.


### PR DESCRIPTION
As KMAC reached to D1 stage, this PR adds KMAC HWIP into the top Earlgrey.

Changes:

- PLIC DIF changes the number of interrupts (Need the confirmation from SW ppl if this is enough)
- Adding KMAC to top_earlgrey and Xbar