### PR TITLE
[top] Turn on aes masking

### DIFF
--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -19,7 +19,7 @@
     },
     { name:    "Masking",
       type:    "bit",
-      default: "1'b0",
+      default: "1'b1",
       desc:    '''
         Disable (0) or enable (1) first-order masking of the AES cipher core.
         Masking requires the use of a masked S-Box, see SBoxImpl parameter.
@@ -29,7 +29,7 @@
     },
     { name:    "SBoxImpl",
       type:    "aes_pkg::sbox_impl_e",
-      default: "aes_pkg::SBoxImplLut",
+      default: "aes_pkg::SBoxImplCanrightMasked",
       desc:    '''
         Selection of the S-Box implementation. See aes_pkg.sv.
       '''

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -947,7 +947,7 @@
         {
           name: Masking
           type: bit
-          default: 1'b0
+          default: 1'b1
           desc:
             '''
             Disable (0) or enable (1) first-order masking of the AES cipher core.
@@ -962,7 +962,7 @@
         {
           name: SBoxImpl
           type: aes_pkg::sbox_impl_e
-          default: aes_pkg::SBoxImplLut
+          default: aes_pkg::SBoxImplCanrightMasked
           desc: Selection of the S-Box implementation. See aes_pkg.sv.
           local: "false"
           expose: "true"

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -12,8 +12,8 @@
 
 module top_earlgrey #(
   // Auto-inferred parameters
-  parameter bit AesMasking = 1'b0,
-  parameter aes_pkg::sbox_impl_e AesSBoxImpl = aes_pkg::SBoxImplLut,
+  parameter bit AesMasking = 1'b1,
+  parameter aes_pkg::sbox_impl_e AesSBoxImpl = aes_pkg::SBoxImplCanrightMasked,
   parameter int unsigned SecAesStartTriggerDelay = 0,
   parameter bit SecAesAllowForcingMasks = 1'b0,
   parameter otbn_pkg::regfile_e OtbnRegFile = otbn_pkg::RegFileFF,

--- a/hw/top_earlgrey/rtl/top_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_asic.sv
@@ -249,8 +249,8 @@ module top_earlgrey_asic (
   //////////////////////
 
   top_earlgrey #(
-    .AesMasking(1'b0),
-    .AesSBoxImpl(aes_pkg::SBoxImplCanright),
+    .AesMasking(1'b1),
+    .AesSBoxImpl(aes_pkg::SBoxImplCanrightMasked),
     .SecAesStartTriggerDelay(0),
     .SecAesAllowForcingMasks(1'b0)
   ) top_earlgrey (


### PR DESCRIPTION
- update aes defaults to enable masking (this ensures nightly synth results are more accurate)
- all fpga variants already have masking 'off'.
- turn on masking for `asic` variant. 