### PR TITLE
[sw] Minor fix for crt code

### DIFF
--- a/sw/device/exts/common/flash_crt.S
+++ b/sw/device/exts/common/flash_crt.S
@@ -56,7 +56,7 @@ _start:
 bss_zero_loop:
   sw    zero, 0(t0)
   addi  t0, t0, 0x4
-  bltu  t0, t1, bss_zero_loop
+  bleu  t0, t1, bss_zero_loop
 bss_zero_loop_end:
 
   // Zero out the stack


### PR DESCRIPTION
Without this fix, the bss zero code gets to 0x1000_0010 (kTestConfig)
and just skips zero-ing the last entry.

This causes the test to fail later when the processor reads back the
config and gets unknown data.  This is not likely to be an issue
on verilator, as unknowns will probably come back as 0s.

It is not clear at the moment why this escaped DV CI private.

The main change from before seems to be `COMMON` code that is now removed from the end of bss.
I guess when there used to be more "stuff" kTestConfig got 0'd anyways. 

Signed-off-by: Timothy Chen <timothytim@google.com>