### PR TITLE
[usbdev] Fixes and testability additions

### DIFF
--- a/hw/dv/dpi/usbdpi/usbdpi.sv
+++ b/hw/dv/dpi/usbdpi/usbdpi.sv
@@ -82,6 +82,7 @@ module usbdpi #(
       d_int <= 0;
       dp_int <= 0;
       dn_int <= 0;
+      sense_p2d <= 0;
     end
   end
 

--- a/hw/ip/usb_fs_nb_pe/rtl/usb_fs_nb_in_pe.sv
+++ b/hw/ip/usb_fs_nb_pe/rtl/usb_fs_nb_in_pe.sv
@@ -29,7 +29,7 @@ module usb_fs_nb_in_pe #(
   ////////////////////
   output logic [3:0]            in_ep_current_o, // Other signals addressed to this ep
   output logic                  in_ep_rollback_o, // Bad termination, rollback transaction
-  output logic                  in_ep_acked_o, // good termination, transaction complete
+  output logic                  in_ep_xfr_end_o, // good termination, transaction complete
   output logic [PktW - 1:0]     in_ep_get_addr_o, // Offset requested (0..pktlen)
   output logic                  in_ep_data_get_o, // Accept data (get_addr advances too)
   output logic                  in_ep_newpkt_o, // New IN packet starting (updates in_ep_current_o)
@@ -93,7 +93,7 @@ module usb_fs_nb_in_pe #(
 
   logic in_xfr_end;
 
-  assign in_ep_acked_o = in_xfr_end;
+  assign in_ep_xfr_end_o = in_xfr_end;
 
   // data toggle state
   logic [NumInEps-1:0] data_toggle_q, data_toggle_d;
@@ -199,6 +199,7 @@ module usb_fs_nb_in_pe #(
         if ((!more_data_to_send) || ((&in_ep_get_addr_o) && tx_data_get_i)) begin
           if (in_ep_iso_i[in_ep_index]) begin
             in_xfr_state_next = StIdle; // no ACK for ISO EPs
+            in_xfr_end = 1'b1;
           end else begin
             in_xfr_state_next = StWaitAck;
           end

--- a/hw/ip/usb_fs_nb_pe/rtl/usb_fs_nb_out_pe.sv
+++ b/hw/ip/usb_fs_nb_pe/rtl/usb_fs_nb_out_pe.sv
@@ -224,7 +224,8 @@ module usb_fs_nb_out_pe #(
           // ISO EP: Don't send a handshake, ignore toggle. Note an unimplemented EP cannot be an
           // ISO EP.
           out_xfr_state_next = StRcvdIsoDataEnd;
-        end else if (ep_impl_q && bad_data_toggle) begin
+        end else if (ep_impl_q && bad_data_toggle && !out_ep_stall_i[out_ep_index]) begin
+          // The DATA toggle was wrong (skipped when this EP is stalled)
           // Note: bad_data_toggle is meaningless for unimplemented EPs.
           out_xfr_state_next = StIdle;
           rollback_data = 1'b1;

--- a/hw/ip/usb_fs_nb_pe/rtl/usb_fs_nb_pe.sv
+++ b/hw/ip/usb_fs_nb_pe/rtl/usb_fs_nb_pe.sv
@@ -53,7 +53,7 @@ module usb_fs_nb_pe #(
   // in endpoint interfaces
   output logic [3:0]             in_ep_current_o, // Other signals addressed to this ep
   output logic                   in_ep_rollback_o, // Bad termination, rollback transaction
-  output logic                   in_ep_acked_o, // good termination, transaction complete
+  output logic                   in_ep_xfr_end_o, // good termination, transaction complete
   output logic [PktW - 1:0]      in_ep_get_addr_o, // Offset requested (0..pktlen)
   output logic                   in_ep_data_get_o, // Accept data (get_addr advances too)
   output logic                   in_ep_newpkt_o, // New IN pkt start (with in_ep_current_o update)
@@ -137,7 +137,7 @@ module usb_fs_nb_pe #(
     // endpoint interface
     .in_ep_current_o       (in_ep_current_o),
     .in_ep_rollback_o      (in_ep_rollback_o),
-    .in_ep_acked_o         (in_ep_acked_o),
+    .in_ep_xfr_end_o       (in_ep_xfr_end_o),
     .in_ep_get_addr_o      (in_ep_get_addr_o),
     .in_ep_data_get_o      (in_ep_data_get_o),
     .in_ep_newpkt_o        (in_ep_newpkt_o),

--- a/hw/ip/usb_fs_nb_pe/rtl/usb_fs_nb_pe.sv
+++ b/hw/ip/usb_fs_nb_pe/rtl/usb_fs_nb_pe.sv
@@ -68,7 +68,6 @@ module usb_fs_nb_pe #(
   output logic [10:0]            frame_index_o,
 
   // RX line status
-  output logic                   rx_se0_det_o,
   output logic                   rx_jjj_det_o,
 
   // RX errors
@@ -227,7 +226,6 @@ module usb_fs_nb_pe #(
     .rx_data_put_o          (rx_data_put),
     .rx_data_o              (rx_data),
     .valid_packet_o         (rx_pkt_valid),
-    .rx_se0_det_o           (rx_se0_det_o),
     .rx_jjj_det_o           (rx_jjj_det_o),
     .crc_error_o            (rx_crc_err_o),
     .pid_error_o            (rx_pid_err_o),

--- a/hw/ip/usb_fs_nb_pe/rtl/usb_fs_rx.sv
+++ b/hw/ip/usb_fs_nb_pe/rtl/usb_fs_rx.sv
@@ -45,7 +45,6 @@ module usb_fs_rx (
   output logic valid_packet_o,
 
   // line status for the status detection (actual rx bits after clock recovery)
-  output logic rx_se0_det_o,
   output logic rx_jjj_det_o,
 
   // Error detection
@@ -301,7 +300,6 @@ module usb_fs_rx (
   end
 
   // mask out jjj detection when transmitting (because rx is forced to J)
-  assign rx_se0_det_o = line_history_q[5:0] == 6'b000000; // three SE0s
   assign rx_jjj_det_o = ~tx_en_i & (line_history_q[5:0] == 6'b101010); // three Js
 
   /////////////////

--- a/hw/ip/usbdev/data/usbdev.hjson
+++ b/hw/ip/usbdev/data/usbdev.hjson
@@ -132,10 +132,8 @@
     }
     { name: "link_out_err",
       desc: '''
-            Raised if a packet to an OUT endpoint started to be received but was
-            then dropped due to an error. This error is raised if either the 
-            data toggle, token, packet or CRC is invalid or if there is no 
-            buffer available in the rxfifo.
+            Raised if a packet to an OUT endpoint started to be received but was then dropped due to an error.
+            This error is raised if either the data toggle, token, packet or CRC is invalid or if there is no buffer available in the Received Buffer FIFO.
             '''
     }
   ]
@@ -501,6 +499,135 @@
           }
         ]
       }
+    }
+    { name: "phy_pins_sense",
+      desc: '''
+            USB PHY pins sense. 
+            This register can be used to read out the state of the USB device inputs and outputs from software.
+            This is designed to be used for debugging purposes or during chip testing.
+            '''
+      swaccess: "ro",
+      hwaccess: "hwo",
+      hwext: "true",
+      fields: [
+        {
+          bits: "0",
+          name: "rx_dp_i",
+          desc: "USB D+ input."
+        }
+        {
+          bits: "1",
+          name: "rx_dn_i",
+          desc: "USB D- input."
+        }
+        {
+          bits: "2",
+          name: "rx_d_i",
+          desc: "USB differential input."
+        }
+        {
+          bits: "8",
+          name: "tx_dp_o",
+          desc: "USB D+ output (readback)."
+        }
+        {
+          bits: "9",
+          name: "tx_dn_o",
+          desc: "USB D- output (readback)."
+        }
+        {
+          bits: "10",
+          name: "tx_d_o",
+          desc: "USB differential output (readback)."
+        }
+        {
+          bits: "11",
+          name: "tx_se0_o",
+          desc: "USB SE0 output (readback)."
+        }
+        {
+          bits: "12",
+          name: "tx_oe_o",
+          desc: "USB OE output (readback)."
+        }
+        {
+          bits: "13",
+          name: "suspend_o",
+          desc: "USB suspend output (readback)."
+        }
+        {
+          bits: "16",
+          name: "pwr_sense",
+          desc: "USB power sense signal."
+        }
+      ]
+      tags: [// Updated by HW based on observed USB PHY signals, comprises also readbacks.
+             // Exclude all read checks in all tests including reset tests.
+             "excl:CsrAllTests:CsrExclCheck"]
+    }
+    { name: "phy_pins_drive",
+      desc: '''
+            USB PHY pins drive.
+            This register can be used to control the USB device inputs and outputs from software.
+            This is designed to be used for debugging purposes or during chip testing.
+            '''
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        {
+          bits: "0",
+          name: "dp_o",
+          desc: "USB D+ output."
+        }
+        {
+          bits: "1",
+          name: "dn_o",
+          desc: "USB D- output."
+        }
+        {
+          bits: "2",
+          name: "d_o",
+          desc: "USB differential output."
+        }
+        {
+          bits: "3",
+          name: "se0_o",
+          desc: "USB SE0 output."
+        }
+        {
+          bits: "4",
+          name: "oe_o",
+          desc: "USB OE output."
+        }
+        {
+          bits: "5",
+          name: "tx_mode_se_o",
+          desc: "USB TX mode. 0: Differential, 1: Single-ended."
+        }
+        {
+          bits: "6",
+          name: "dp_pullup_en_o",
+          desc: "USB D+ pullup enable output."
+        }
+        {
+          bits: "7",
+          name: "dn_pullup_en_o",
+          desc: "USB D- pullup enable output."
+        }
+        {
+          bits: "8",
+          name: "suspend_o",
+          desc: "USB suspend output."
+        }
+        {
+          bits: "16",
+          name: "en",
+          desc: '''
+                0: Outputs are controlled by the hardware block.
+                1: Outputs are controlled with this register.
+                '''
+        }
+      ]
     }
     { name: "phy_config",
       desc: "USB PHY Configuration",

--- a/hw/ip/usbdev/data/usbdev.hjson
+++ b/hw/ip/usbdev/data/usbdev.hjson
@@ -130,6 +130,14 @@
     { name: "connected",
       desc: "Raised if VBUS is applied."
     }
+    { name: "link_out_err",
+      desc: '''
+            Raised if a packet to an OUT endpoint started to be received but was
+            then dropped due to an error. This error is raised if either the 
+            data toggle, token, packet or CRC is invalid or if there is no 
+            buffer available in the rxfifo.
+            '''
+    }
   ]
   regwidth: "32",
   registers: [

--- a/hw/ip/usbdev/rtl/usbdev.sv
+++ b/hw/ip/usbdev/rtl/usbdev.sv
@@ -60,6 +60,7 @@ module usbdev (
   output logic       intr_rx_full_o,
   output logic       intr_av_overflow_o,
   output logic       intr_link_in_err_o,
+  output logic       intr_link_out_err_o,
   output logic       intr_rx_crc_err_o,
   output logic       intr_rx_pid_err_o,
   output logic       intr_rx_bitstuff_err_o,
@@ -116,6 +117,7 @@ module usbdev (
   logic              usb_event_rx_crc_err, usb_event_rx_pid_err;
   logic              usb_event_rx_bitstuff_err;
   logic              usb_event_in_err;
+  logic              usb_event_out_err;
   logic              usb_event_frame;
   logic              usb_link_active;
 
@@ -124,6 +126,7 @@ module usbdev (
   logic              event_rx_crc_err, event_rx_pid_err;
   logic              event_rx_bitstuff_err;
   logic              event_in_err;
+  logic              event_out_err;
   logic              event_frame;
 
   // CDC signals
@@ -364,6 +367,15 @@ module usbdev (
     .dst_pulse_o (event_in_err)
   );
 
+  prim_pulse_sync usbdev_sync_out_err (
+    .clk_src_i   (clk_usb_48mhz_i),
+    .clk_dst_i   (clk_i),
+    .rst_src_ni  (rst_usb_48mhz_ni),
+    .rst_dst_ni  (rst_ni),
+    .src_pulse_i (usb_event_out_err),
+    .dst_pulse_o (event_out_err)
+  );
+
   prim_pulse_sync usbdev_outrdyclr (
     .clk_src_i   (clk_usb_48mhz_i),
     .clk_dst_i   (clk_i),
@@ -538,6 +550,7 @@ module usbdev (
     .link_resume_o        (usb_event_link_resume),
     .host_lost_o          (usb_event_host_lost),
     .link_in_err_o        (usb_event_in_err),
+    .link_out_err_o       (usb_event_out_err),
     .rx_crc_err_o         (usb_event_rx_crc_err),
     .rx_pid_err_o         (usb_event_rx_pid_err),
     .rx_bitstuff_err_o    (usb_event_rx_bitstuff_err)
@@ -864,6 +877,19 @@ module usbdev (
     .hw2reg_intr_state_de_o (hw2reg.intr_state.link_in_err.de),
     .hw2reg_intr_state_d_o  (hw2reg.intr_state.link_in_err.d),
     .intr_o                 (intr_link_in_err_o)
+  );
+
+  prim_intr_hw #(.Width(1)) intr_link_out_err (
+    .clk_i,
+    .rst_ni,
+    .event_intr_i           (event_out_err),
+    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.link_out_err.q),
+    .reg2hw_intr_test_q_i   (reg2hw.intr_test.link_out_err.q),
+    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.link_out_err.qe),
+    .reg2hw_intr_state_q_i  (reg2hw.intr_state.link_out_err.q),
+    .hw2reg_intr_state_de_o (hw2reg.intr_state.link_out_err.de),
+    .hw2reg_intr_state_d_o  (hw2reg.intr_state.link_out_err.d),
+    .intr_o                 (intr_link_out_err_o)
   );
 
   prim_intr_hw #(.Width(1)) intr_rx_crc_err (

--- a/hw/ip/usbdev/rtl/usbdev.sv
+++ b/hw/ip/usbdev/rtl/usbdev.sv
@@ -956,6 +956,8 @@ module usbdev (
     .rst_usb_48mhz_ni       (rst_usb_48mhz_ni),
 
     // Register interface
+    .sys_hw2reg_sense_o     (hw2reg.phy_pins_sense),
+    .sys_reg2hw_drive_i     (reg2hw.phy_pins_drive),
     .sys_reg2hw_config_i    (reg2hw.phy_config),
     .sys_usb_sense_o        (hw2reg.usbstat.sense.d),
 

--- a/hw/ip/usbdev/rtl/usbdev_iomux.sv
+++ b/hw/ip/usbdev/rtl/usbdev_iomux.sv
@@ -17,9 +17,11 @@ module usbdev_iomux
   input  logic                          clk_usb_48mhz_i, // use usb_ prefix for signals in this clk
   input  logic                          rst_usb_48mhz_ni,
 
-  // Register interface (system clk, quasi-static)
-  input  usbdev_reg2hw_phy_config_reg_t sys_reg2hw_config_i,
-  output logic                          sys_usb_sense_o,
+  // Register interface (system clk)
+  output usbdev_hw2reg_phy_pins_sense_reg_t sys_hw2reg_sense_o,
+  input  usbdev_reg2hw_phy_pins_drive_reg_t sys_reg2hw_drive_i,
+  input  usbdev_reg2hw_phy_config_reg_t     sys_reg2hw_config_i,
+  output logic                              sys_usb_sense_o,
 
   // External USB Interface(s) (async)
   input  logic                          cio_usb_d_i,
@@ -50,6 +52,9 @@ module usbdev_iomux
   input  logic                          usb_suspend_i
 );
 
+  logic cio_usb_d_flipped;
+  logic cio_usb_dp_pullup_en, cio_usb_dn_pullup_en;
+
   logic async_pwr_sense, sys_usb_sense;
   logic cio_usb_dp, cio_usb_dn, cio_usb_d;
   logic pinflip;
@@ -67,17 +72,36 @@ module usbdev_iomux
   // CDCs //
   //////////
 
-  // USB sense pin (to sysclk)
+  // USB pins sense (to sysclk)
   prim_flop_2sync #(
-    .Width (1)
+    .Width (10)
   ) cdc_io_to_sys (
     .clk_i  (clk_i),
     .rst_ni (rst_ni),
-    .d_i    ({cio_usb_sense_i}),
-    .q_o    ({sys_usb_sense})
+    .d_i    ({cio_usb_dp_i,
+              cio_usb_dn_i,
+              cio_usb_d_i,
+              cio_usb_dp_o,
+              cio_usb_dn_o,
+              usb_tx_d_i,
+              usb_tx_se0_i,
+              usb_tx_oe_i,
+              usb_suspend_i,
+              cio_usb_sense_i}),
+    .q_o   ({sys_hw2reg_sense_o.rx_dp_i.d,
+              sys_hw2reg_sense_o.rx_dn_i.d,
+              sys_hw2reg_sense_o.rx_d_i.d,
+              sys_hw2reg_sense_o.tx_dp_o.d,
+              sys_hw2reg_sense_o.tx_dn_o.d,
+              sys_hw2reg_sense_o.tx_d_o.d,
+              sys_hw2reg_sense_o.tx_se0_o.d,
+              sys_hw2reg_sense_o.tx_oe_o.d,
+              sys_hw2reg_sense_o.suspend_o.d,
+              sys_usb_sense})
   );
 
-  assign sys_usb_sense_o = sys_usb_sense;
+  assign sys_usb_sense_o                = sys_usb_sense;
+  assign sys_hw2reg_sense_o.pwr_sense.d = sys_usb_sense;
 
   // USB input pins (to usbclk)
   prim_flop_2sync #(
@@ -102,39 +126,99 @@ module usbdev_iomux
   // D+/D- can be swapped based on a config register.
   assign pinflip = sys_reg2hw_config_i.pinflip.q;
 
-  assign cio_usb_d_o            = pinflip ? ~usb_tx_d_i     : usb_tx_d_i;
-  assign cio_usb_dp_pullup_en_o = pinflip ? 1'b0            : usb_pullup_en_i;
-  assign cio_usb_dn_pullup_en_o = pinflip ? usb_pullup_en_i : 1'b0;
+  prim_generic_clock_mux2 #(
+    .NoFpgaBufG(1)
+  ) i_mux_tx_d_flip (
+    .clk0_i (usb_tx_d_i),
+    .clk1_i (~usb_tx_d_i),
+    .sel_i  (pinflip),
+    .clk_o  (cio_usb_d_flipped)
+  );
+  prim_generic_clock_mux2 #(
+    .NoFpgaBufG(1)
+  ) i_mux_dp_pull_flip (
+    .clk0_i (usb_pullup_en_i),
+    .clk1_i (1'b0),
+    .sel_i  (pinflip),
+    .clk_o  (cio_usb_dp_pullup_en)
+  );
+  prim_generic_clock_mux2 #(
+    .NoFpgaBufG(1)
+  ) i_mux_dn_pull_flip (
+    .clk0_i (1'b0),
+    .clk1_i (usb_pullup_en_i),
+    .sel_i  (pinflip),
+    .clk_o  (cio_usb_dn_pullup_en)
+  );
 
-  always_comb begin : proc_diff_se_mux_out
+  always_comb begin : proc_drive_out
     // Defaults
     cio_usb_dn_o           = 1'b0;
     cio_usb_dp_o           = 1'b0;
 
-    // The single-ended signals are only driven in single-ended mode.
-    if (sys_reg2hw_config_i.tx_differential_mode.q) begin
-      // Differential TX mode (physical IO takes d and se0)
-      // i.e. expect the "else" logic to be in the physical interface
-      cio_usb_tx_mode_se_o   = 1'b0;
+    if (sys_reg2hw_drive_i.en.q) begin
+      // Override from registers
+      cio_usb_dp_o           = sys_reg2hw_drive_i.dp_o.q;
+      cio_usb_dn_o           = sys_reg2hw_drive_i.dn_o.q;
+      cio_usb_dp_pullup_en_o = sys_reg2hw_drive_i.dp_pullup_en_o.q;
+      cio_usb_dn_pullup_en_o = sys_reg2hw_drive_i.dn_pullup_en_o.q;
+      cio_usb_tx_mode_se_o   = sys_reg2hw_drive_i.tx_mode_se_o.q;
+      cio_usb_suspend_o      = sys_reg2hw_drive_i.suspend_o.q;
 
     end else begin
-      // Single-ended TX mode (physical IO takes dp and dn)
-      cio_usb_tx_mode_se_o   = 1'b1;
-      if (usb_tx_se0_i) begin
-        cio_usb_dp_o = 1'b0;
-        cio_usb_dn_o = 1'b0;
+      // Signals from the peripheral core
+      cio_usb_dp_pullup_en_o = cio_usb_dp_pullup_en;
+      cio_usb_dn_pullup_en_o = cio_usb_dn_pullup_en;
+      cio_usb_suspend_o      = usb_suspend_i;
+
+      if(sys_reg2hw_config_i.tx_differential_mode.q) begin
+        // Differential TX mode (physical IO takes d and se0)
+        // i.e. expect the "else" logic to be in the physical interface
+        cio_usb_tx_mode_se_o   = 1'b0;
+
       end else begin
-        cio_usb_dp_o = pinflip ? ~usb_tx_d_i :  usb_tx_d_i;
-        cio_usb_dn_o = pinflip ?  usb_tx_d_i : ~usb_tx_d_i;
+        // Single-ended mode (physical IO takes dp and dn)
+        cio_usb_tx_mode_se_o   = 1'b1;
+        if (usb_tx_se0_i) begin
+          cio_usb_dp_o = 1'b0;
+          cio_usb_dn_o = 1'b0;
+        end else begin
+          cio_usb_dp_o = usb_tx_d_i;
+          cio_usb_dn_o = !usb_tx_d_i;
+        end
       end
     end
   end
 
-  // It would be possible to insert explicit controllability muxes here.
-  // For now, we just pass the signal through
-  assign cio_usb_oe_o      = usb_tx_oe_i;
-  assign cio_usb_se0_o     = usb_tx_se0_i;
-  assign cio_usb_suspend_o = usb_suspend_i;
+  // Use explicit muxes for the critical output signals, we do this
+  // to avoid glitches from synthesized logic on these signals.
+  // Clock muxes should be used here to achieve the best match between
+  // rising and falling edges on an ASIC. This mismatch on the data line
+  // degrades performance in the JK-KJ jitter test.
+  prim_generic_clock_mux2 #(
+    .NoFpgaBufG(1)
+  ) i_mux_tx_d (
+    .clk0_i (cio_usb_d_flipped),
+    .clk1_i (sys_reg2hw_drive_i.d_o.q),
+    .sel_i  (sys_reg2hw_drive_i.en.q),
+    .clk_o  (cio_usb_d_o)
+  );
+  prim_generic_clock_mux2 #(
+    .NoFpgaBufG(1)
+  ) i_mux_tx_se0 (
+    .clk0_i (usb_tx_se0_i),
+    .clk1_i (sys_reg2hw_drive_i.se0_o.q),
+    .sel_i  (sys_reg2hw_drive_i.en.q),
+    .clk_o  (cio_usb_se0_o)
+  );
+  prim_generic_clock_mux2 #(
+    .NoFpgaBufG(1)
+  ) i_mux_tx_oe (
+    .clk0_i (usb_tx_oe_i),
+    .clk1_i (sys_reg2hw_drive_i.oe_o.q),
+    .sel_i  (sys_reg2hw_drive_i.en.q),
+    .clk_o  (cio_usb_oe_o)
+  );
 
   ///////////////////////
   // USB input pin mux //

--- a/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
@@ -61,6 +61,9 @@ package usbdev_reg_pkg;
     struct packed {
       logic        q;
     } connected;
+    struct packed {
+      logic        q;
+    } link_out_err;
   } usbdev_reg2hw_intr_state_reg_t;
 
   typedef struct packed {
@@ -112,6 +115,9 @@ package usbdev_reg_pkg;
     struct packed {
       logic        q;
     } connected;
+    struct packed {
+      logic        q;
+    } link_out_err;
   } usbdev_reg2hw_intr_enable_reg_t;
 
   typedef struct packed {
@@ -179,6 +185,10 @@ package usbdev_reg_pkg;
       logic        q;
       logic        qe;
     } connected;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } link_out_err;
   } usbdev_reg2hw_intr_test_reg_t;
 
   typedef struct packed {
@@ -343,6 +353,10 @@ package usbdev_reg_pkg;
       logic        d;
       logic        de;
     } connected;
+    struct packed {
+      logic        d;
+      logic        de;
+    } link_out_err;
   } usbdev_hw2reg_intr_state_reg_t;
 
   typedef struct packed {
@@ -420,9 +434,9 @@ package usbdev_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    usbdev_reg2hw_intr_state_reg_t intr_state; // [346:331]
-    usbdev_reg2hw_intr_enable_reg_t intr_enable; // [330:315]
-    usbdev_reg2hw_intr_test_reg_t intr_test; // [314:283]
+    usbdev_reg2hw_intr_state_reg_t intr_state; // [350:334]
+    usbdev_reg2hw_intr_enable_reg_t intr_enable; // [333:317]
+    usbdev_reg2hw_intr_test_reg_t intr_test; // [316:283]
     usbdev_reg2hw_usbctrl_reg_t usbctrl; // [282:275]
     usbdev_reg2hw_avbuffer_reg_t avbuffer; // [274:269]
     usbdev_reg2hw_rxfifo_reg_t rxfifo; // [268:248]
@@ -439,13 +453,13 @@ package usbdev_reg_pkg;
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    usbdev_hw2reg_intr_state_reg_t intr_state; // [176:161]
-    usbdev_hw2reg_usbctrl_reg_t usbctrl; // [160:153]
-    usbdev_hw2reg_usbstat_reg_t usbstat; // [152:153]
-    usbdev_hw2reg_rxfifo_reg_t rxfifo; // [152:132]
-    usbdev_hw2reg_in_sent_mreg_t [11:0] in_sent; // [131:108]
-    usbdev_hw2reg_stall_mreg_t [11:0] stall; // [107:84]
-    usbdev_hw2reg_configin_mreg_t [11:0] configin; // [83:36]
+    usbdev_hw2reg_intr_state_reg_t intr_state; // [178:162]
+    usbdev_hw2reg_usbctrl_reg_t usbctrl; // [161:154]
+    usbdev_hw2reg_usbstat_reg_t usbstat; // [153:154]
+    usbdev_hw2reg_rxfifo_reg_t rxfifo; // [153:133]
+    usbdev_hw2reg_in_sent_mreg_t [11:0] in_sent; // [132:109]
+    usbdev_hw2reg_stall_mreg_t [11:0] stall; // [108:85]
+    usbdev_hw2reg_configin_mreg_t [11:0] configin; // [84:37]
   } usbdev_hw2reg_t;
 
   // Register Address
@@ -512,9 +526,9 @@ package usbdev_reg_pkg;
 
   // Register width information to check illegal writes
   parameter logic [3:0] USBDEV_PERMIT [26] = '{
-    4'b 0011, // index[ 0] USBDEV_INTR_STATE
-    4'b 0011, // index[ 1] USBDEV_INTR_ENABLE
-    4'b 0011, // index[ 2] USBDEV_INTR_TEST
+    4'b 0111, // index[ 0] USBDEV_INTR_STATE
+    4'b 0111, // index[ 1] USBDEV_INTR_ENABLE
+    4'b 0111, // index[ 2] USBDEV_INTR_TEST
     4'b 0111, // index[ 3] USBDEV_USBCTRL
     4'b 1111, // index[ 4] USBDEV_USBSTAT
     4'b 0001, // index[ 5] USBDEV_AVBUFFER

--- a/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
@@ -263,6 +263,39 @@ package usbdev_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        q;
+    } dp_o;
+    struct packed {
+      logic        q;
+    } dn_o;
+    struct packed {
+      logic        q;
+    } d_o;
+    struct packed {
+      logic        q;
+    } se0_o;
+    struct packed {
+      logic        q;
+    } oe_o;
+    struct packed {
+      logic        q;
+    } tx_mode_se_o;
+    struct packed {
+      logic        q;
+    } dp_pullup_en_o;
+    struct packed {
+      logic        q;
+    } dn_pullup_en_o;
+    struct packed {
+      logic        q;
+    } suspend_o;
+    struct packed {
+      logic        q;
+    } en;
+  } usbdev_reg2hw_phy_pins_drive_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        q;
     } rx_differential_mode;
     struct packed {
       logic        q;
@@ -429,23 +462,57 @@ package usbdev_reg_pkg;
     } rdy;
   } usbdev_hw2reg_configin_mreg_t;
 
+  typedef struct packed {
+    struct packed {
+      logic        d;
+    } rx_dp_i;
+    struct packed {
+      logic        d;
+    } rx_dn_i;
+    struct packed {
+      logic        d;
+    } rx_d_i;
+    struct packed {
+      logic        d;
+    } tx_dp_o;
+    struct packed {
+      logic        d;
+    } tx_dn_o;
+    struct packed {
+      logic        d;
+    } tx_d_o;
+    struct packed {
+      logic        d;
+    } tx_se0_o;
+    struct packed {
+      logic        d;
+    } tx_oe_o;
+    struct packed {
+      logic        d;
+    } suspend_o;
+    struct packed {
+      logic        d;
+    } pwr_sense;
+  } usbdev_hw2reg_phy_pins_sense_reg_t;
+
 
   ///////////////////////////////////////
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    usbdev_reg2hw_intr_state_reg_t intr_state; // [350:334]
-    usbdev_reg2hw_intr_enable_reg_t intr_enable; // [333:317]
-    usbdev_reg2hw_intr_test_reg_t intr_test; // [316:283]
-    usbdev_reg2hw_usbctrl_reg_t usbctrl; // [282:275]
-    usbdev_reg2hw_avbuffer_reg_t avbuffer; // [274:269]
-    usbdev_reg2hw_rxfifo_reg_t rxfifo; // [268:248]
-    usbdev_reg2hw_rxenable_setup_mreg_t [11:0] rxenable_setup; // [247:236]
-    usbdev_reg2hw_rxenable_out_mreg_t [11:0] rxenable_out; // [235:224]
-    usbdev_reg2hw_stall_mreg_t [11:0] stall; // [223:212]
-    usbdev_reg2hw_configin_mreg_t [11:0] configin; // [211:44]
-    usbdev_reg2hw_iso_mreg_t [11:0] iso; // [43:32]
-    usbdev_reg2hw_data_toggle_clear_mreg_t [11:0] data_toggle_clear; // [31:8]
+    usbdev_reg2hw_intr_state_reg_t intr_state; // [360:344]
+    usbdev_reg2hw_intr_enable_reg_t intr_enable; // [343:327]
+    usbdev_reg2hw_intr_test_reg_t intr_test; // [326:293]
+    usbdev_reg2hw_usbctrl_reg_t usbctrl; // [292:285]
+    usbdev_reg2hw_avbuffer_reg_t avbuffer; // [284:279]
+    usbdev_reg2hw_rxfifo_reg_t rxfifo; // [278:258]
+    usbdev_reg2hw_rxenable_setup_mreg_t [11:0] rxenable_setup; // [257:246]
+    usbdev_reg2hw_rxenable_out_mreg_t [11:0] rxenable_out; // [245:234]
+    usbdev_reg2hw_stall_mreg_t [11:0] stall; // [233:222]
+    usbdev_reg2hw_configin_mreg_t [11:0] configin; // [221:54]
+    usbdev_reg2hw_iso_mreg_t [11:0] iso; // [53:42]
+    usbdev_reg2hw_data_toggle_clear_mreg_t [11:0] data_toggle_clear; // [41:18]
+    usbdev_reg2hw_phy_pins_drive_reg_t phy_pins_drive; // [17:8]
     usbdev_reg2hw_phy_config_reg_t phy_config; // [7:0]
   } usbdev_reg2hw_t;
 
@@ -453,13 +520,14 @@ package usbdev_reg_pkg;
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    usbdev_hw2reg_intr_state_reg_t intr_state; // [178:162]
-    usbdev_hw2reg_usbctrl_reg_t usbctrl; // [161:154]
-    usbdev_hw2reg_usbstat_reg_t usbstat; // [153:154]
-    usbdev_hw2reg_rxfifo_reg_t rxfifo; // [153:133]
-    usbdev_hw2reg_in_sent_mreg_t [11:0] in_sent; // [132:109]
-    usbdev_hw2reg_stall_mreg_t [11:0] stall; // [108:85]
-    usbdev_hw2reg_configin_mreg_t [11:0] configin; // [84:37]
+    usbdev_hw2reg_intr_state_reg_t intr_state; // [188:172]
+    usbdev_hw2reg_usbctrl_reg_t usbctrl; // [171:164]
+    usbdev_hw2reg_usbstat_reg_t usbstat; // [163:164]
+    usbdev_hw2reg_rxfifo_reg_t rxfifo; // [163:143]
+    usbdev_hw2reg_in_sent_mreg_t [11:0] in_sent; // [142:119]
+    usbdev_hw2reg_stall_mreg_t [11:0] stall; // [118:95]
+    usbdev_hw2reg_configin_mreg_t [11:0] configin; // [94:47]
+    usbdev_hw2reg_phy_pins_sense_reg_t phy_pins_sense; // [46:47]
   } usbdev_hw2reg_t;
 
   // Register Address
@@ -488,7 +556,9 @@ package usbdev_reg_pkg;
   parameter logic [11:0] USBDEV_CONFIGIN_11_OFFSET = 12'h 58;
   parameter logic [11:0] USBDEV_ISO_OFFSET = 12'h 5c;
   parameter logic [11:0] USBDEV_DATA_TOGGLE_CLEAR_OFFSET = 12'h 60;
-  parameter logic [11:0] USBDEV_PHY_CONFIG_OFFSET = 12'h 64;
+  parameter logic [11:0] USBDEV_PHY_PINS_SENSE_OFFSET = 12'h 64;
+  parameter logic [11:0] USBDEV_PHY_PINS_DRIVE_OFFSET = 12'h 68;
+  parameter logic [11:0] USBDEV_PHY_CONFIG_OFFSET = 12'h 6c;
 
   // Window parameter
   parameter logic [11:0] USBDEV_BUFFER_OFFSET = 12'h 800;
@@ -521,11 +591,13 @@ package usbdev_reg_pkg;
     USBDEV_CONFIGIN_11,
     USBDEV_ISO,
     USBDEV_DATA_TOGGLE_CLEAR,
+    USBDEV_PHY_PINS_SENSE,
+    USBDEV_PHY_PINS_DRIVE,
     USBDEV_PHY_CONFIG
   } usbdev_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] USBDEV_PERMIT [26] = '{
+  parameter logic [3:0] USBDEV_PERMIT [28] = '{
     4'b 0111, // index[ 0] USBDEV_INTR_STATE
     4'b 0111, // index[ 1] USBDEV_INTR_ENABLE
     4'b 0111, // index[ 2] USBDEV_INTR_TEST
@@ -551,7 +623,9 @@ package usbdev_reg_pkg;
     4'b 1111, // index[22] USBDEV_CONFIGIN_11
     4'b 0011, // index[23] USBDEV_ISO
     4'b 0011, // index[24] USBDEV_DATA_TOGGLE_CLEAR
-    4'b 0001  // index[25] USBDEV_PHY_CONFIG
+    4'b 0111, // index[25] USBDEV_PHY_PINS_SENSE
+    4'b 0111, // index[26] USBDEV_PHY_PINS_DRIVE
+    4'b 0001  // index[27] USBDEV_PHY_CONFIG
   };
 endpackage
 

--- a/hw/ip/usbdev/rtl/usbdev_reg_top.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_top.sv
@@ -633,6 +633,56 @@ module usbdev_reg_top (
   logic data_toggle_clear_clear_10_we;
   logic data_toggle_clear_clear_11_wd;
   logic data_toggle_clear_clear_11_we;
+  logic phy_pins_sense_rx_dp_i_qs;
+  logic phy_pins_sense_rx_dp_i_re;
+  logic phy_pins_sense_rx_dn_i_qs;
+  logic phy_pins_sense_rx_dn_i_re;
+  logic phy_pins_sense_rx_d_i_qs;
+  logic phy_pins_sense_rx_d_i_re;
+  logic phy_pins_sense_tx_dp_o_qs;
+  logic phy_pins_sense_tx_dp_o_re;
+  logic phy_pins_sense_tx_dn_o_qs;
+  logic phy_pins_sense_tx_dn_o_re;
+  logic phy_pins_sense_tx_d_o_qs;
+  logic phy_pins_sense_tx_d_o_re;
+  logic phy_pins_sense_tx_se0_o_qs;
+  logic phy_pins_sense_tx_se0_o_re;
+  logic phy_pins_sense_tx_oe_o_qs;
+  logic phy_pins_sense_tx_oe_o_re;
+  logic phy_pins_sense_suspend_o_qs;
+  logic phy_pins_sense_suspend_o_re;
+  logic phy_pins_sense_pwr_sense_qs;
+  logic phy_pins_sense_pwr_sense_re;
+  logic phy_pins_drive_dp_o_qs;
+  logic phy_pins_drive_dp_o_wd;
+  logic phy_pins_drive_dp_o_we;
+  logic phy_pins_drive_dn_o_qs;
+  logic phy_pins_drive_dn_o_wd;
+  logic phy_pins_drive_dn_o_we;
+  logic phy_pins_drive_d_o_qs;
+  logic phy_pins_drive_d_o_wd;
+  logic phy_pins_drive_d_o_we;
+  logic phy_pins_drive_se0_o_qs;
+  logic phy_pins_drive_se0_o_wd;
+  logic phy_pins_drive_se0_o_we;
+  logic phy_pins_drive_oe_o_qs;
+  logic phy_pins_drive_oe_o_wd;
+  logic phy_pins_drive_oe_o_we;
+  logic phy_pins_drive_tx_mode_se_o_qs;
+  logic phy_pins_drive_tx_mode_se_o_wd;
+  logic phy_pins_drive_tx_mode_se_o_we;
+  logic phy_pins_drive_dp_pullup_en_o_qs;
+  logic phy_pins_drive_dp_pullup_en_o_wd;
+  logic phy_pins_drive_dp_pullup_en_o_we;
+  logic phy_pins_drive_dn_pullup_en_o_qs;
+  logic phy_pins_drive_dn_pullup_en_o_wd;
+  logic phy_pins_drive_dn_pullup_en_o_we;
+  logic phy_pins_drive_suspend_o_qs;
+  logic phy_pins_drive_suspend_o_wd;
+  logic phy_pins_drive_suspend_o_we;
+  logic phy_pins_drive_en_qs;
+  logic phy_pins_drive_en_wd;
+  logic phy_pins_drive_en_we;
   logic phy_config_rx_differential_mode_qs;
   logic phy_config_rx_differential_mode_wd;
   logic phy_config_rx_differential_mode_we;
@@ -5244,6 +5294,420 @@ module usbdev_reg_top (
 
 
 
+  // R[phy_pins_sense]: V(True)
+
+  //   F[rx_dp_i]: 0:0
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_phy_pins_sense_rx_dp_i (
+    .re     (phy_pins_sense_rx_dp_i_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.phy_pins_sense.rx_dp_i.d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (phy_pins_sense_rx_dp_i_qs)
+  );
+
+
+  //   F[rx_dn_i]: 1:1
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_phy_pins_sense_rx_dn_i (
+    .re     (phy_pins_sense_rx_dn_i_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.phy_pins_sense.rx_dn_i.d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (phy_pins_sense_rx_dn_i_qs)
+  );
+
+
+  //   F[rx_d_i]: 2:2
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_phy_pins_sense_rx_d_i (
+    .re     (phy_pins_sense_rx_d_i_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.phy_pins_sense.rx_d_i.d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (phy_pins_sense_rx_d_i_qs)
+  );
+
+
+  //   F[tx_dp_o]: 8:8
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_phy_pins_sense_tx_dp_o (
+    .re     (phy_pins_sense_tx_dp_o_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.phy_pins_sense.tx_dp_o.d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (phy_pins_sense_tx_dp_o_qs)
+  );
+
+
+  //   F[tx_dn_o]: 9:9
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_phy_pins_sense_tx_dn_o (
+    .re     (phy_pins_sense_tx_dn_o_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.phy_pins_sense.tx_dn_o.d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (phy_pins_sense_tx_dn_o_qs)
+  );
+
+
+  //   F[tx_d_o]: 10:10
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_phy_pins_sense_tx_d_o (
+    .re     (phy_pins_sense_tx_d_o_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.phy_pins_sense.tx_d_o.d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (phy_pins_sense_tx_d_o_qs)
+  );
+
+
+  //   F[tx_se0_o]: 11:11
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_phy_pins_sense_tx_se0_o (
+    .re     (phy_pins_sense_tx_se0_o_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.phy_pins_sense.tx_se0_o.d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (phy_pins_sense_tx_se0_o_qs)
+  );
+
+
+  //   F[tx_oe_o]: 12:12
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_phy_pins_sense_tx_oe_o (
+    .re     (phy_pins_sense_tx_oe_o_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.phy_pins_sense.tx_oe_o.d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (phy_pins_sense_tx_oe_o_qs)
+  );
+
+
+  //   F[suspend_o]: 13:13
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_phy_pins_sense_suspend_o (
+    .re     (phy_pins_sense_suspend_o_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.phy_pins_sense.suspend_o.d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (phy_pins_sense_suspend_o_qs)
+  );
+
+
+  //   F[pwr_sense]: 16:16
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_phy_pins_sense_pwr_sense (
+    .re     (phy_pins_sense_pwr_sense_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.phy_pins_sense.pwr_sense.d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (phy_pins_sense_pwr_sense_qs)
+  );
+
+
+  // R[phy_pins_drive]: V(False)
+
+  //   F[dp_o]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_phy_pins_drive_dp_o (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (phy_pins_drive_dp_o_we),
+    .wd     (phy_pins_drive_dp_o_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.phy_pins_drive.dp_o.q ),
+
+    // to register interface (read)
+    .qs     (phy_pins_drive_dp_o_qs)
+  );
+
+
+  //   F[dn_o]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_phy_pins_drive_dn_o (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (phy_pins_drive_dn_o_we),
+    .wd     (phy_pins_drive_dn_o_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.phy_pins_drive.dn_o.q ),
+
+    // to register interface (read)
+    .qs     (phy_pins_drive_dn_o_qs)
+  );
+
+
+  //   F[d_o]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_phy_pins_drive_d_o (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (phy_pins_drive_d_o_we),
+    .wd     (phy_pins_drive_d_o_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.phy_pins_drive.d_o.q ),
+
+    // to register interface (read)
+    .qs     (phy_pins_drive_d_o_qs)
+  );
+
+
+  //   F[se0_o]: 3:3
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_phy_pins_drive_se0_o (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (phy_pins_drive_se0_o_we),
+    .wd     (phy_pins_drive_se0_o_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.phy_pins_drive.se0_o.q ),
+
+    // to register interface (read)
+    .qs     (phy_pins_drive_se0_o_qs)
+  );
+
+
+  //   F[oe_o]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_phy_pins_drive_oe_o (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (phy_pins_drive_oe_o_we),
+    .wd     (phy_pins_drive_oe_o_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.phy_pins_drive.oe_o.q ),
+
+    // to register interface (read)
+    .qs     (phy_pins_drive_oe_o_qs)
+  );
+
+
+  //   F[tx_mode_se_o]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_phy_pins_drive_tx_mode_se_o (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (phy_pins_drive_tx_mode_se_o_we),
+    .wd     (phy_pins_drive_tx_mode_se_o_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.phy_pins_drive.tx_mode_se_o.q ),
+
+    // to register interface (read)
+    .qs     (phy_pins_drive_tx_mode_se_o_qs)
+  );
+
+
+  //   F[dp_pullup_en_o]: 6:6
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_phy_pins_drive_dp_pullup_en_o (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (phy_pins_drive_dp_pullup_en_o_we),
+    .wd     (phy_pins_drive_dp_pullup_en_o_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.phy_pins_drive.dp_pullup_en_o.q ),
+
+    // to register interface (read)
+    .qs     (phy_pins_drive_dp_pullup_en_o_qs)
+  );
+
+
+  //   F[dn_pullup_en_o]: 7:7
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_phy_pins_drive_dn_pullup_en_o (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (phy_pins_drive_dn_pullup_en_o_we),
+    .wd     (phy_pins_drive_dn_pullup_en_o_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.phy_pins_drive.dn_pullup_en_o.q ),
+
+    // to register interface (read)
+    .qs     (phy_pins_drive_dn_pullup_en_o_qs)
+  );
+
+
+  //   F[suspend_o]: 8:8
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_phy_pins_drive_suspend_o (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (phy_pins_drive_suspend_o_we),
+    .wd     (phy_pins_drive_suspend_o_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.phy_pins_drive.suspend_o.q ),
+
+    // to register interface (read)
+    .qs     (phy_pins_drive_suspend_o_qs)
+  );
+
+
+  //   F[en]: 16:16
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_phy_pins_drive_en (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (phy_pins_drive_en_we),
+    .wd     (phy_pins_drive_en_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.phy_pins_drive.en.q ),
+
+    // to register interface (read)
+    .qs     (phy_pins_drive_en_qs)
+  );
+
+
   // R[phy_config]: V(False)
 
   //   F[rx_differential_mode]: 0:0
@@ -5456,7 +5920,7 @@ module usbdev_reg_top (
 
 
 
-  logic [25:0] addr_hit;
+  logic [27:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == USBDEV_INTR_STATE_OFFSET);
@@ -5484,7 +5948,9 @@ module usbdev_reg_top (
     addr_hit[22] = (reg_addr == USBDEV_CONFIGIN_11_OFFSET);
     addr_hit[23] = (reg_addr == USBDEV_ISO_OFFSET);
     addr_hit[24] = (reg_addr == USBDEV_DATA_TOGGLE_CLEAR_OFFSET);
-    addr_hit[25] = (reg_addr == USBDEV_PHY_CONFIG_OFFSET);
+    addr_hit[25] = (reg_addr == USBDEV_PHY_PINS_SENSE_OFFSET);
+    addr_hit[26] = (reg_addr == USBDEV_PHY_PINS_DRIVE_OFFSET);
+    addr_hit[27] = (reg_addr == USBDEV_PHY_CONFIG_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -5518,6 +5984,8 @@ module usbdev_reg_top (
     if (addr_hit[23] && reg_we && (USBDEV_PERMIT[23] != (USBDEV_PERMIT[23] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[24] && reg_we && (USBDEV_PERMIT[24] != (USBDEV_PERMIT[24] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[25] && reg_we && (USBDEV_PERMIT[25] != (USBDEV_PERMIT[25] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[26] && reg_we && (USBDEV_PERMIT[26] != (USBDEV_PERMIT[26] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[27] && reg_we && (USBDEV_PERMIT[27] != (USBDEV_PERMIT[27] & reg_be))) wr_err = 1'b1 ;
   end
 
   assign intr_state_pkt_received_we = addr_hit[0] & reg_we & ~wr_err;
@@ -6066,28 +6534,78 @@ module usbdev_reg_top (
   assign data_toggle_clear_clear_11_we = addr_hit[24] & reg_we & ~wr_err;
   assign data_toggle_clear_clear_11_wd = reg_wdata[11];
 
-  assign phy_config_rx_differential_mode_we = addr_hit[25] & reg_we & ~wr_err;
+  assign phy_pins_sense_rx_dp_i_re = addr_hit[25] && reg_re;
+
+  assign phy_pins_sense_rx_dn_i_re = addr_hit[25] && reg_re;
+
+  assign phy_pins_sense_rx_d_i_re = addr_hit[25] && reg_re;
+
+  assign phy_pins_sense_tx_dp_o_re = addr_hit[25] && reg_re;
+
+  assign phy_pins_sense_tx_dn_o_re = addr_hit[25] && reg_re;
+
+  assign phy_pins_sense_tx_d_o_re = addr_hit[25] && reg_re;
+
+  assign phy_pins_sense_tx_se0_o_re = addr_hit[25] && reg_re;
+
+  assign phy_pins_sense_tx_oe_o_re = addr_hit[25] && reg_re;
+
+  assign phy_pins_sense_suspend_o_re = addr_hit[25] && reg_re;
+
+  assign phy_pins_sense_pwr_sense_re = addr_hit[25] && reg_re;
+
+  assign phy_pins_drive_dp_o_we = addr_hit[26] & reg_we & ~wr_err;
+  assign phy_pins_drive_dp_o_wd = reg_wdata[0];
+
+  assign phy_pins_drive_dn_o_we = addr_hit[26] & reg_we & ~wr_err;
+  assign phy_pins_drive_dn_o_wd = reg_wdata[1];
+
+  assign phy_pins_drive_d_o_we = addr_hit[26] & reg_we & ~wr_err;
+  assign phy_pins_drive_d_o_wd = reg_wdata[2];
+
+  assign phy_pins_drive_se0_o_we = addr_hit[26] & reg_we & ~wr_err;
+  assign phy_pins_drive_se0_o_wd = reg_wdata[3];
+
+  assign phy_pins_drive_oe_o_we = addr_hit[26] & reg_we & ~wr_err;
+  assign phy_pins_drive_oe_o_wd = reg_wdata[4];
+
+  assign phy_pins_drive_tx_mode_se_o_we = addr_hit[26] & reg_we & ~wr_err;
+  assign phy_pins_drive_tx_mode_se_o_wd = reg_wdata[5];
+
+  assign phy_pins_drive_dp_pullup_en_o_we = addr_hit[26] & reg_we & ~wr_err;
+  assign phy_pins_drive_dp_pullup_en_o_wd = reg_wdata[6];
+
+  assign phy_pins_drive_dn_pullup_en_o_we = addr_hit[26] & reg_we & ~wr_err;
+  assign phy_pins_drive_dn_pullup_en_o_wd = reg_wdata[7];
+
+  assign phy_pins_drive_suspend_o_we = addr_hit[26] & reg_we & ~wr_err;
+  assign phy_pins_drive_suspend_o_wd = reg_wdata[8];
+
+  assign phy_pins_drive_en_we = addr_hit[26] & reg_we & ~wr_err;
+  assign phy_pins_drive_en_wd = reg_wdata[16];
+
+  assign phy_config_rx_differential_mode_we = addr_hit[27] & reg_we & ~wr_err;
   assign phy_config_rx_differential_mode_wd = reg_wdata[0];
 
-  assign phy_config_tx_differential_mode_we = addr_hit[25] & reg_we & ~wr_err;
+  assign phy_config_tx_differential_mode_we = addr_hit[27] & reg_we & ~wr_err;
   assign phy_config_tx_differential_mode_wd = reg_wdata[1];
 
-  assign phy_config_eop_single_bit_we = addr_hit[25] & reg_we & ~wr_err;
+  assign phy_config_eop_single_bit_we = addr_hit[27] & reg_we & ~wr_err;
   assign phy_config_eop_single_bit_wd = reg_wdata[2];
 
-  assign phy_config_override_pwr_sense_en_we = addr_hit[25] & reg_we & ~wr_err;
+  assign phy_config_override_pwr_sense_en_we = addr_hit[27] & reg_we & ~wr_err;
   assign phy_config_override_pwr_sense_en_wd = reg_wdata[3];
 
-  assign phy_config_override_pwr_sense_val_we = addr_hit[25] & reg_we & ~wr_err;
+  assign phy_config_override_pwr_sense_val_we = addr_hit[27] & reg_we & ~wr_err;
   assign phy_config_override_pwr_sense_val_wd = reg_wdata[4];
 
-  assign phy_config_pinflip_we = addr_hit[25] & reg_we & ~wr_err;
+  assign phy_config_pinflip_we = addr_hit[27] & reg_we & ~wr_err;
   assign phy_config_pinflip_wd = reg_wdata[5];
 
-  assign phy_config_usb_ref_disable_we = addr_hit[25] & reg_we & ~wr_err;
+  assign phy_config_usb_ref_disable_we = addr_hit[27] & reg_we & ~wr_err;
   assign phy_config_usb_ref_disable_wd = reg_wdata[6];
 
-  assign phy_config_tx_osc_test_mode_we = addr_hit[25] & reg_we & ~wr_err;
+  assign phy_config_tx_osc_test_mode_we = addr_hit[27] & reg_we & ~wr_err;
   assign phy_config_tx_osc_test_mode_wd = reg_wdata[7];
 
   // Read data return
@@ -6356,6 +6874,32 @@ module usbdev_reg_top (
       end
 
       addr_hit[25]: begin
+        reg_rdata_next[0] = phy_pins_sense_rx_dp_i_qs;
+        reg_rdata_next[1] = phy_pins_sense_rx_dn_i_qs;
+        reg_rdata_next[2] = phy_pins_sense_rx_d_i_qs;
+        reg_rdata_next[8] = phy_pins_sense_tx_dp_o_qs;
+        reg_rdata_next[9] = phy_pins_sense_tx_dn_o_qs;
+        reg_rdata_next[10] = phy_pins_sense_tx_d_o_qs;
+        reg_rdata_next[11] = phy_pins_sense_tx_se0_o_qs;
+        reg_rdata_next[12] = phy_pins_sense_tx_oe_o_qs;
+        reg_rdata_next[13] = phy_pins_sense_suspend_o_qs;
+        reg_rdata_next[16] = phy_pins_sense_pwr_sense_qs;
+      end
+
+      addr_hit[26]: begin
+        reg_rdata_next[0] = phy_pins_drive_dp_o_qs;
+        reg_rdata_next[1] = phy_pins_drive_dn_o_qs;
+        reg_rdata_next[2] = phy_pins_drive_d_o_qs;
+        reg_rdata_next[3] = phy_pins_drive_se0_o_qs;
+        reg_rdata_next[4] = phy_pins_drive_oe_o_qs;
+        reg_rdata_next[5] = phy_pins_drive_tx_mode_se_o_qs;
+        reg_rdata_next[6] = phy_pins_drive_dp_pullup_en_o_qs;
+        reg_rdata_next[7] = phy_pins_drive_dn_pullup_en_o_qs;
+        reg_rdata_next[8] = phy_pins_drive_suspend_o_qs;
+        reg_rdata_next[16] = phy_pins_drive_en_qs;
+      end
+
+      addr_hit[27]: begin
         reg_rdata_next[0] = phy_config_rx_differential_mode_qs;
         reg_rdata_next[1] = phy_config_tx_differential_mode_qs;
         reg_rdata_next[2] = phy_config_eop_single_bit_qs;

--- a/hw/ip/usbdev/rtl/usbdev_reg_top.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_top.sv
@@ -165,6 +165,9 @@ module usbdev_reg_top (
   logic intr_state_connected_qs;
   logic intr_state_connected_wd;
   logic intr_state_connected_we;
+  logic intr_state_link_out_err_qs;
+  logic intr_state_link_out_err_wd;
+  logic intr_state_link_out_err_we;
   logic intr_enable_pkt_received_qs;
   logic intr_enable_pkt_received_wd;
   logic intr_enable_pkt_received_we;
@@ -213,6 +216,9 @@ module usbdev_reg_top (
   logic intr_enable_connected_qs;
   logic intr_enable_connected_wd;
   logic intr_enable_connected_we;
+  logic intr_enable_link_out_err_qs;
+  logic intr_enable_link_out_err_wd;
+  logic intr_enable_link_out_err_we;
   logic intr_test_pkt_received_wd;
   logic intr_test_pkt_received_we;
   logic intr_test_pkt_sent_wd;
@@ -245,6 +251,8 @@ module usbdev_reg_top (
   logic intr_test_frame_we;
   logic intr_test_connected_wd;
   logic intr_test_connected_we;
+  logic intr_test_link_out_err_wd;
+  logic intr_test_link_out_err_we;
   logic usbctrl_enable_qs;
   logic usbctrl_enable_wd;
   logic usbctrl_enable_we;
@@ -1069,6 +1077,32 @@ module usbdev_reg_top (
   );
 
 
+  //   F[link_out_err]: 16:16
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("W1C"),
+    .RESVAL  (1'h0)
+  ) u_intr_state_link_out_err (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (intr_state_link_out_err_we),
+    .wd     (intr_state_link_out_err_wd),
+
+    // from internal hardware
+    .de     (hw2reg.intr_state.link_out_err.de),
+    .d      (hw2reg.intr_state.link_out_err.d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.intr_state.link_out_err.q ),
+
+    // to register interface (read)
+    .qs     (intr_state_link_out_err_qs)
+  );
+
+
   // R[intr_enable]: V(False)
 
   //   F[pkt_received]: 0:0
@@ -1487,6 +1521,32 @@ module usbdev_reg_top (
   );
 
 
+  //   F[link_out_err]: 16:16
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_intr_enable_link_out_err (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (intr_enable_link_out_err_we),
+    .wd     (intr_enable_link_out_err_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.intr_enable.link_out_err.q ),
+
+    // to register interface (read)
+    .qs     (intr_enable_link_out_err_qs)
+  );
+
+
   // R[intr_test]: V(True)
 
   //   F[pkt_received]: 0:0
@@ -1725,6 +1785,21 @@ module usbdev_reg_top (
     .qre    (),
     .qe     (reg2hw.intr_test.connected.qe),
     .q      (reg2hw.intr_test.connected.q ),
+    .qs     ()
+  );
+
+
+  //   F[link_out_err]: 16:16
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_intr_test_link_out_err (
+    .re     (1'b0),
+    .we     (intr_test_link_out_err_we),
+    .wd     (intr_test_link_out_err_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (reg2hw.intr_test.link_out_err.qe),
+    .q      (reg2hw.intr_test.link_out_err.q ),
     .qs     ()
   );
 
@@ -5493,6 +5568,9 @@ module usbdev_reg_top (
   assign intr_state_connected_we = addr_hit[0] & reg_we & ~wr_err;
   assign intr_state_connected_wd = reg_wdata[15];
 
+  assign intr_state_link_out_err_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_link_out_err_wd = reg_wdata[16];
+
   assign intr_enable_pkt_received_we = addr_hit[1] & reg_we & ~wr_err;
   assign intr_enable_pkt_received_wd = reg_wdata[0];
 
@@ -5541,6 +5619,9 @@ module usbdev_reg_top (
   assign intr_enable_connected_we = addr_hit[1] & reg_we & ~wr_err;
   assign intr_enable_connected_wd = reg_wdata[15];
 
+  assign intr_enable_link_out_err_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_link_out_err_wd = reg_wdata[16];
+
   assign intr_test_pkt_received_we = addr_hit[2] & reg_we & ~wr_err;
   assign intr_test_pkt_received_wd = reg_wdata[0];
 
@@ -5588,6 +5669,9 @@ module usbdev_reg_top (
 
   assign intr_test_connected_we = addr_hit[2] & reg_we & ~wr_err;
   assign intr_test_connected_wd = reg_wdata[15];
+
+  assign intr_test_link_out_err_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_link_out_err_wd = reg_wdata[16];
 
   assign usbctrl_enable_we = addr_hit[3] & reg_we & ~wr_err;
   assign usbctrl_enable_wd = reg_wdata[0];
@@ -6027,6 +6111,7 @@ module usbdev_reg_top (
         reg_rdata_next[13] = intr_state_rx_bitstuff_err_qs;
         reg_rdata_next[14] = intr_state_frame_qs;
         reg_rdata_next[15] = intr_state_connected_qs;
+        reg_rdata_next[16] = intr_state_link_out_err_qs;
       end
 
       addr_hit[1]: begin
@@ -6046,6 +6131,7 @@ module usbdev_reg_top (
         reg_rdata_next[13] = intr_enable_rx_bitstuff_err_qs;
         reg_rdata_next[14] = intr_enable_frame_qs;
         reg_rdata_next[15] = intr_enable_connected_qs;
+        reg_rdata_next[16] = intr_enable_link_out_err_qs;
       end
 
       addr_hit[2]: begin
@@ -6065,6 +6151,7 @@ module usbdev_reg_top (
         reg_rdata_next[13] = '0;
         reg_rdata_next[14] = '0;
         reg_rdata_next[15] = '0;
+        reg_rdata_next[16] = '0;
       end
 
       addr_hit[3]: begin

--- a/hw/ip/usbdev/rtl/usbdev_usbif.sv
+++ b/hw/ip/usbdev/rtl/usbdev_usbif.sv
@@ -260,7 +260,7 @@ module usbdev_usbif  #(
   assign set_sent_o = in_ep_acked;
 
   logic [10:0]     frame_index_raw;
-  logic            rx_se0_det, rx_jjj_det;
+  logic            rx_jjj_det;
 
   usb_fs_nb_pe #(
     .NumOutEps      (NEndpoints),
@@ -312,7 +312,6 @@ module usbdev_usbif  #(
     .in_ep_iso_i           (ep_iso_i),
 
     // rx status
-    .rx_se0_det_o          (rx_se0_det),
     .rx_jjj_det_o          (rx_jjj_det),
 
     // error signals
@@ -358,7 +357,8 @@ module usbdev_usbif  #(
     .rst_ni            (rst_ni),
     .us_tick_i         (us_tick),
     .usb_sense_i       (usb_sense_i),
-    .rx_se0_det_i      (rx_se0_det),
+    .usb_dp_i          (usb_dp_i),
+    .usb_dn_i          (usb_dn_i),
     .rx_jjj_det_i      (rx_jjj_det),
     .sof_valid_i       (sof_valid),
     .link_disconnect_o (link_disconnect_o),

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -2543,6 +2543,18 @@
           ]
           type: interrupt
         }
+        {
+          name: link_out_err
+          width: 1
+          bits: "16"
+          bitinfo:
+          [
+            65536
+            1
+            16
+          ]
+          type: interrupt
+        }
       ]
       alert_list: []
       wakeup_list: []
@@ -5376,6 +5388,19 @@
         32768
         1
         15
+      ]
+      type: interrupt
+      module_name: usbdev
+    }
+    {
+      name: usbdev_link_out_err
+      width: 1
+      bits: "16"
+      bitinfo:
+      [
+        65536
+        1
+        16
       ]
       type: interrupt
       module_name: usbdev

--- a/hw/top_earlgrey/ip/rv_plic/data/autogen/rv_plic.hjson
+++ b/hw/top_earlgrey/ip/rv_plic/data/autogen/rv_plic.hjson
@@ -25,7 +25,7 @@
     { name: "NumSrc",
       desc: "Number of interrupt sources",
       type: "int",
-      default: "87",
+      default: "88",
       local: "true"
     },
     { name: "NumTarget",
@@ -759,6 +759,14 @@
     }
     { name: "PRIO86",
       desc: "Interrupt Source 86 Priority",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "1:0" }
+      ],
+    }
+    { name: "PRIO87",
+      desc: "Interrupt Source 87 Priority",
       swaccess: "rw",
       hwaccess: "hro",
       fields: [

--- a/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic.sv
+++ b/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic.sv
@@ -181,11 +181,12 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   assign prio[84] = reg2hw.prio84.q;
   assign prio[85] = reg2hw.prio85.q;
   assign prio[86] = reg2hw.prio86.q;
+  assign prio[87] = reg2hw.prio87.q;
 
   //////////////////////
   // Interrupt Enable //
   //////////////////////
-  for (genvar s = 0; s < 87; s++) begin : gen_ie0
+  for (genvar s = 0; s < 88; s++) begin : gen_ie0
     assign ie[0][s] = reg2hw.ie0[s].q;
   end
 
@@ -211,7 +212,7 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   ////////
   // IP //
   ////////
-  for (genvar s = 0; s < 87; s++) begin : gen_ip
+  for (genvar s = 0; s < 88; s++) begin : gen_ip
     assign hw2reg.ip[s].de = 1'b1; // Always write
     assign hw2reg.ip[s].d  = ip[s];
   end
@@ -219,7 +220,7 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   ///////////////////////////////////
   // Detection:: 0: Level, 1: Edge //
   ///////////////////////////////////
-  for (genvar s = 0; s < 87; s++) begin : gen_le
+  for (genvar s = 0; s < 88; s++) begin : gen_le
     assign le[s] = reg2hw.le[s].q;
   end
 

--- a/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_pkg.sv
@@ -7,7 +7,7 @@
 package rv_plic_reg_pkg;
 
   // Param list
-  parameter int NumSrc = 87;
+  parameter int NumSrc = 88;
   parameter int NumTarget = 1;
   parameter int PrioWidth = 2;
 
@@ -367,6 +367,10 @@ package rv_plic_reg_pkg;
   } rv_plic_reg2hw_prio86_reg_t;
 
   typedef struct packed {
+    logic [1:0]  q;
+  } rv_plic_reg2hw_prio87_reg_t;
+
+  typedef struct packed {
     logic        q;
   } rv_plic_reg2hw_ie0_mreg_t;
 
@@ -399,95 +403,96 @@ package rv_plic_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    rv_plic_reg2hw_le_mreg_t [86:0] le; // [359:273]
-    rv_plic_reg2hw_prio0_reg_t prio0; // [272:271]
-    rv_plic_reg2hw_prio1_reg_t prio1; // [270:269]
-    rv_plic_reg2hw_prio2_reg_t prio2; // [268:267]
-    rv_plic_reg2hw_prio3_reg_t prio3; // [266:265]
-    rv_plic_reg2hw_prio4_reg_t prio4; // [264:263]
-    rv_plic_reg2hw_prio5_reg_t prio5; // [262:261]
-    rv_plic_reg2hw_prio6_reg_t prio6; // [260:259]
-    rv_plic_reg2hw_prio7_reg_t prio7; // [258:257]
-    rv_plic_reg2hw_prio8_reg_t prio8; // [256:255]
-    rv_plic_reg2hw_prio9_reg_t prio9; // [254:253]
-    rv_plic_reg2hw_prio10_reg_t prio10; // [252:251]
-    rv_plic_reg2hw_prio11_reg_t prio11; // [250:249]
-    rv_plic_reg2hw_prio12_reg_t prio12; // [248:247]
-    rv_plic_reg2hw_prio13_reg_t prio13; // [246:245]
-    rv_plic_reg2hw_prio14_reg_t prio14; // [244:243]
-    rv_plic_reg2hw_prio15_reg_t prio15; // [242:241]
-    rv_plic_reg2hw_prio16_reg_t prio16; // [240:239]
-    rv_plic_reg2hw_prio17_reg_t prio17; // [238:237]
-    rv_plic_reg2hw_prio18_reg_t prio18; // [236:235]
-    rv_plic_reg2hw_prio19_reg_t prio19; // [234:233]
-    rv_plic_reg2hw_prio20_reg_t prio20; // [232:231]
-    rv_plic_reg2hw_prio21_reg_t prio21; // [230:229]
-    rv_plic_reg2hw_prio22_reg_t prio22; // [228:227]
-    rv_plic_reg2hw_prio23_reg_t prio23; // [226:225]
-    rv_plic_reg2hw_prio24_reg_t prio24; // [224:223]
-    rv_plic_reg2hw_prio25_reg_t prio25; // [222:221]
-    rv_plic_reg2hw_prio26_reg_t prio26; // [220:219]
-    rv_plic_reg2hw_prio27_reg_t prio27; // [218:217]
-    rv_plic_reg2hw_prio28_reg_t prio28; // [216:215]
-    rv_plic_reg2hw_prio29_reg_t prio29; // [214:213]
-    rv_plic_reg2hw_prio30_reg_t prio30; // [212:211]
-    rv_plic_reg2hw_prio31_reg_t prio31; // [210:209]
-    rv_plic_reg2hw_prio32_reg_t prio32; // [208:207]
-    rv_plic_reg2hw_prio33_reg_t prio33; // [206:205]
-    rv_plic_reg2hw_prio34_reg_t prio34; // [204:203]
-    rv_plic_reg2hw_prio35_reg_t prio35; // [202:201]
-    rv_plic_reg2hw_prio36_reg_t prio36; // [200:199]
-    rv_plic_reg2hw_prio37_reg_t prio37; // [198:197]
-    rv_plic_reg2hw_prio38_reg_t prio38; // [196:195]
-    rv_plic_reg2hw_prio39_reg_t prio39; // [194:193]
-    rv_plic_reg2hw_prio40_reg_t prio40; // [192:191]
-    rv_plic_reg2hw_prio41_reg_t prio41; // [190:189]
-    rv_plic_reg2hw_prio42_reg_t prio42; // [188:187]
-    rv_plic_reg2hw_prio43_reg_t prio43; // [186:185]
-    rv_plic_reg2hw_prio44_reg_t prio44; // [184:183]
-    rv_plic_reg2hw_prio45_reg_t prio45; // [182:181]
-    rv_plic_reg2hw_prio46_reg_t prio46; // [180:179]
-    rv_plic_reg2hw_prio47_reg_t prio47; // [178:177]
-    rv_plic_reg2hw_prio48_reg_t prio48; // [176:175]
-    rv_plic_reg2hw_prio49_reg_t prio49; // [174:173]
-    rv_plic_reg2hw_prio50_reg_t prio50; // [172:171]
-    rv_plic_reg2hw_prio51_reg_t prio51; // [170:169]
-    rv_plic_reg2hw_prio52_reg_t prio52; // [168:167]
-    rv_plic_reg2hw_prio53_reg_t prio53; // [166:165]
-    rv_plic_reg2hw_prio54_reg_t prio54; // [164:163]
-    rv_plic_reg2hw_prio55_reg_t prio55; // [162:161]
-    rv_plic_reg2hw_prio56_reg_t prio56; // [160:159]
-    rv_plic_reg2hw_prio57_reg_t prio57; // [158:157]
-    rv_plic_reg2hw_prio58_reg_t prio58; // [156:155]
-    rv_plic_reg2hw_prio59_reg_t prio59; // [154:153]
-    rv_plic_reg2hw_prio60_reg_t prio60; // [152:151]
-    rv_plic_reg2hw_prio61_reg_t prio61; // [150:149]
-    rv_plic_reg2hw_prio62_reg_t prio62; // [148:147]
-    rv_plic_reg2hw_prio63_reg_t prio63; // [146:145]
-    rv_plic_reg2hw_prio64_reg_t prio64; // [144:143]
-    rv_plic_reg2hw_prio65_reg_t prio65; // [142:141]
-    rv_plic_reg2hw_prio66_reg_t prio66; // [140:139]
-    rv_plic_reg2hw_prio67_reg_t prio67; // [138:137]
-    rv_plic_reg2hw_prio68_reg_t prio68; // [136:135]
-    rv_plic_reg2hw_prio69_reg_t prio69; // [134:133]
-    rv_plic_reg2hw_prio70_reg_t prio70; // [132:131]
-    rv_plic_reg2hw_prio71_reg_t prio71; // [130:129]
-    rv_plic_reg2hw_prio72_reg_t prio72; // [128:127]
-    rv_plic_reg2hw_prio73_reg_t prio73; // [126:125]
-    rv_plic_reg2hw_prio74_reg_t prio74; // [124:123]
-    rv_plic_reg2hw_prio75_reg_t prio75; // [122:121]
-    rv_plic_reg2hw_prio76_reg_t prio76; // [120:119]
-    rv_plic_reg2hw_prio77_reg_t prio77; // [118:117]
-    rv_plic_reg2hw_prio78_reg_t prio78; // [116:115]
-    rv_plic_reg2hw_prio79_reg_t prio79; // [114:113]
-    rv_plic_reg2hw_prio80_reg_t prio80; // [112:111]
-    rv_plic_reg2hw_prio81_reg_t prio81; // [110:109]
-    rv_plic_reg2hw_prio82_reg_t prio82; // [108:107]
-    rv_plic_reg2hw_prio83_reg_t prio83; // [106:105]
-    rv_plic_reg2hw_prio84_reg_t prio84; // [104:103]
-    rv_plic_reg2hw_prio85_reg_t prio85; // [102:101]
-    rv_plic_reg2hw_prio86_reg_t prio86; // [100:99]
-    rv_plic_reg2hw_ie0_mreg_t [86:0] ie0; // [98:12]
+    rv_plic_reg2hw_le_mreg_t [87:0] le; // [363:276]
+    rv_plic_reg2hw_prio0_reg_t prio0; // [275:274]
+    rv_plic_reg2hw_prio1_reg_t prio1; // [273:272]
+    rv_plic_reg2hw_prio2_reg_t prio2; // [271:270]
+    rv_plic_reg2hw_prio3_reg_t prio3; // [269:268]
+    rv_plic_reg2hw_prio4_reg_t prio4; // [267:266]
+    rv_plic_reg2hw_prio5_reg_t prio5; // [265:264]
+    rv_plic_reg2hw_prio6_reg_t prio6; // [263:262]
+    rv_plic_reg2hw_prio7_reg_t prio7; // [261:260]
+    rv_plic_reg2hw_prio8_reg_t prio8; // [259:258]
+    rv_plic_reg2hw_prio9_reg_t prio9; // [257:256]
+    rv_plic_reg2hw_prio10_reg_t prio10; // [255:254]
+    rv_plic_reg2hw_prio11_reg_t prio11; // [253:252]
+    rv_plic_reg2hw_prio12_reg_t prio12; // [251:250]
+    rv_plic_reg2hw_prio13_reg_t prio13; // [249:248]
+    rv_plic_reg2hw_prio14_reg_t prio14; // [247:246]
+    rv_plic_reg2hw_prio15_reg_t prio15; // [245:244]
+    rv_plic_reg2hw_prio16_reg_t prio16; // [243:242]
+    rv_plic_reg2hw_prio17_reg_t prio17; // [241:240]
+    rv_plic_reg2hw_prio18_reg_t prio18; // [239:238]
+    rv_plic_reg2hw_prio19_reg_t prio19; // [237:236]
+    rv_plic_reg2hw_prio20_reg_t prio20; // [235:234]
+    rv_plic_reg2hw_prio21_reg_t prio21; // [233:232]
+    rv_plic_reg2hw_prio22_reg_t prio22; // [231:230]
+    rv_plic_reg2hw_prio23_reg_t prio23; // [229:228]
+    rv_plic_reg2hw_prio24_reg_t prio24; // [227:226]
+    rv_plic_reg2hw_prio25_reg_t prio25; // [225:224]
+    rv_plic_reg2hw_prio26_reg_t prio26; // [223:222]
+    rv_plic_reg2hw_prio27_reg_t prio27; // [221:220]
+    rv_plic_reg2hw_prio28_reg_t prio28; // [219:218]
+    rv_plic_reg2hw_prio29_reg_t prio29; // [217:216]
+    rv_plic_reg2hw_prio30_reg_t prio30; // [215:214]
+    rv_plic_reg2hw_prio31_reg_t prio31; // [213:212]
+    rv_plic_reg2hw_prio32_reg_t prio32; // [211:210]
+    rv_plic_reg2hw_prio33_reg_t prio33; // [209:208]
+    rv_plic_reg2hw_prio34_reg_t prio34; // [207:206]
+    rv_plic_reg2hw_prio35_reg_t prio35; // [205:204]
+    rv_plic_reg2hw_prio36_reg_t prio36; // [203:202]
+    rv_plic_reg2hw_prio37_reg_t prio37; // [201:200]
+    rv_plic_reg2hw_prio38_reg_t prio38; // [199:198]
+    rv_plic_reg2hw_prio39_reg_t prio39; // [197:196]
+    rv_plic_reg2hw_prio40_reg_t prio40; // [195:194]
+    rv_plic_reg2hw_prio41_reg_t prio41; // [193:192]
+    rv_plic_reg2hw_prio42_reg_t prio42; // [191:190]
+    rv_plic_reg2hw_prio43_reg_t prio43; // [189:188]
+    rv_plic_reg2hw_prio44_reg_t prio44; // [187:186]
+    rv_plic_reg2hw_prio45_reg_t prio45; // [185:184]
+    rv_plic_reg2hw_prio46_reg_t prio46; // [183:182]
+    rv_plic_reg2hw_prio47_reg_t prio47; // [181:180]
+    rv_plic_reg2hw_prio48_reg_t prio48; // [179:178]
+    rv_plic_reg2hw_prio49_reg_t prio49; // [177:176]
+    rv_plic_reg2hw_prio50_reg_t prio50; // [175:174]
+    rv_plic_reg2hw_prio51_reg_t prio51; // [173:172]
+    rv_plic_reg2hw_prio52_reg_t prio52; // [171:170]
+    rv_plic_reg2hw_prio53_reg_t prio53; // [169:168]
+    rv_plic_reg2hw_prio54_reg_t prio54; // [167:166]
+    rv_plic_reg2hw_prio55_reg_t prio55; // [165:164]
+    rv_plic_reg2hw_prio56_reg_t prio56; // [163:162]
+    rv_plic_reg2hw_prio57_reg_t prio57; // [161:160]
+    rv_plic_reg2hw_prio58_reg_t prio58; // [159:158]
+    rv_plic_reg2hw_prio59_reg_t prio59; // [157:156]
+    rv_plic_reg2hw_prio60_reg_t prio60; // [155:154]
+    rv_plic_reg2hw_prio61_reg_t prio61; // [153:152]
+    rv_plic_reg2hw_prio62_reg_t prio62; // [151:150]
+    rv_plic_reg2hw_prio63_reg_t prio63; // [149:148]
+    rv_plic_reg2hw_prio64_reg_t prio64; // [147:146]
+    rv_plic_reg2hw_prio65_reg_t prio65; // [145:144]
+    rv_plic_reg2hw_prio66_reg_t prio66; // [143:142]
+    rv_plic_reg2hw_prio67_reg_t prio67; // [141:140]
+    rv_plic_reg2hw_prio68_reg_t prio68; // [139:138]
+    rv_plic_reg2hw_prio69_reg_t prio69; // [137:136]
+    rv_plic_reg2hw_prio70_reg_t prio70; // [135:134]
+    rv_plic_reg2hw_prio71_reg_t prio71; // [133:132]
+    rv_plic_reg2hw_prio72_reg_t prio72; // [131:130]
+    rv_plic_reg2hw_prio73_reg_t prio73; // [129:128]
+    rv_plic_reg2hw_prio74_reg_t prio74; // [127:126]
+    rv_plic_reg2hw_prio75_reg_t prio75; // [125:124]
+    rv_plic_reg2hw_prio76_reg_t prio76; // [123:122]
+    rv_plic_reg2hw_prio77_reg_t prio77; // [121:120]
+    rv_plic_reg2hw_prio78_reg_t prio78; // [119:118]
+    rv_plic_reg2hw_prio79_reg_t prio79; // [117:116]
+    rv_plic_reg2hw_prio80_reg_t prio80; // [115:114]
+    rv_plic_reg2hw_prio81_reg_t prio81; // [113:112]
+    rv_plic_reg2hw_prio82_reg_t prio82; // [111:110]
+    rv_plic_reg2hw_prio83_reg_t prio83; // [109:108]
+    rv_plic_reg2hw_prio84_reg_t prio84; // [107:106]
+    rv_plic_reg2hw_prio85_reg_t prio85; // [105:104]
+    rv_plic_reg2hw_prio86_reg_t prio86; // [103:102]
+    rv_plic_reg2hw_prio87_reg_t prio87; // [101:100]
+    rv_plic_reg2hw_ie0_mreg_t [87:0] ie0; // [99:12]
     rv_plic_reg2hw_threshold0_reg_t threshold0; // [11:10]
     rv_plic_reg2hw_cc0_reg_t cc0; // [9:1]
     rv_plic_reg2hw_msip0_reg_t msip0; // [0:0]
@@ -497,7 +502,7 @@ package rv_plic_reg_pkg;
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    rv_plic_hw2reg_ip_mreg_t [86:0] ip; // [180:7]
+    rv_plic_hw2reg_ip_mreg_t [87:0] ip; // [182:7]
     rv_plic_hw2reg_cc0_reg_t cc0; // [6:-2]
   } rv_plic_hw2reg_t;
 
@@ -595,6 +600,7 @@ package rv_plic_reg_pkg;
   parameter logic [9:0] RV_PLIC_PRIO84_OFFSET = 10'h 168;
   parameter logic [9:0] RV_PLIC_PRIO85_OFFSET = 10'h 16c;
   parameter logic [9:0] RV_PLIC_PRIO86_OFFSET = 10'h 170;
+  parameter logic [9:0] RV_PLIC_PRIO87_OFFSET = 10'h 174;
   parameter logic [9:0] RV_PLIC_IE0_0_OFFSET = 10'h 200;
   parameter logic [9:0] RV_PLIC_IE0_1_OFFSET = 10'h 204;
   parameter logic [9:0] RV_PLIC_IE0_2_OFFSET = 10'h 208;
@@ -698,6 +704,7 @@ package rv_plic_reg_pkg;
     RV_PLIC_PRIO84,
     RV_PLIC_PRIO85,
     RV_PLIC_PRIO86,
+    RV_PLIC_PRIO87,
     RV_PLIC_IE0_0,
     RV_PLIC_IE0_1,
     RV_PLIC_IE0_2,
@@ -707,7 +714,7 @@ package rv_plic_reg_pkg;
   } rv_plic_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] RV_PLIC_PERMIT [99] = '{
+  parameter logic [3:0] RV_PLIC_PERMIT [100] = '{
     4'b 1111, // index[ 0] RV_PLIC_IP_0
     4'b 1111, // index[ 1] RV_PLIC_IP_1
     4'b 0111, // index[ 2] RV_PLIC_IP_2
@@ -801,12 +808,13 @@ package rv_plic_reg_pkg;
     4'b 0001, // index[90] RV_PLIC_PRIO84
     4'b 0001, // index[91] RV_PLIC_PRIO85
     4'b 0001, // index[92] RV_PLIC_PRIO86
-    4'b 1111, // index[93] RV_PLIC_IE0_0
-    4'b 1111, // index[94] RV_PLIC_IE0_1
-    4'b 0111, // index[95] RV_PLIC_IE0_2
-    4'b 0001, // index[96] RV_PLIC_THRESHOLD0
-    4'b 0001, // index[97] RV_PLIC_CC0
-    4'b 0001  // index[98] RV_PLIC_MSIP0
+    4'b 0001, // index[93] RV_PLIC_PRIO87
+    4'b 1111, // index[94] RV_PLIC_IE0_0
+    4'b 1111, // index[95] RV_PLIC_IE0_1
+    4'b 0111, // index[96] RV_PLIC_IE0_2
+    4'b 0001, // index[97] RV_PLIC_THRESHOLD0
+    4'b 0001, // index[98] RV_PLIC_CC0
+    4'b 0001  // index[99] RV_PLIC_MSIP0
   };
 endpackage
 

--- a/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_top.sv
+++ b/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_top.sv
@@ -158,6 +158,7 @@ module rv_plic_reg_top (
   logic ip_2_p_84_qs;
   logic ip_2_p_85_qs;
   logic ip_2_p_86_qs;
+  logic ip_2_p_87_qs;
   logic le_0_le_0_qs;
   logic le_0_le_0_wd;
   logic le_0_le_0_we;
@@ -419,6 +420,9 @@ module rv_plic_reg_top (
   logic le_2_le_86_qs;
   logic le_2_le_86_wd;
   logic le_2_le_86_we;
+  logic le_2_le_87_qs;
+  logic le_2_le_87_wd;
+  logic le_2_le_87_we;
   logic [1:0] prio0_qs;
   logic [1:0] prio0_wd;
   logic prio0_we;
@@ -680,6 +684,9 @@ module rv_plic_reg_top (
   logic [1:0] prio86_qs;
   logic [1:0] prio86_wd;
   logic prio86_we;
+  logic [1:0] prio87_qs;
+  logic [1:0] prio87_wd;
+  logic prio87_we;
   logic ie0_0_e_0_qs;
   logic ie0_0_e_0_wd;
   logic ie0_0_e_0_we;
@@ -941,6 +948,9 @@ module rv_plic_reg_top (
   logic ie0_2_e_86_qs;
   logic ie0_2_e_86_wd;
   logic ie0_2_e_86_we;
+  logic ie0_2_e_87_qs;
+  logic ie0_2_e_87_wd;
+  logic ie0_2_e_87_we;
   logic [1:0] threshold0_qs;
   logic [1:0] threshold0_wd;
   logic threshold0_we;
@@ -3135,6 +3145,31 @@ module rv_plic_reg_top (
 
     // to register interface (read)
     .qs     (ip_2_p_86_qs)
+  );
+
+
+  // F[p_87]: 23:23
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RO"),
+    .RESVAL  (1'h0)
+  ) u_ip_2_p_87 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    .we     (1'b0),
+    .wd     ('0  ),
+
+    // from internal hardware
+    .de     (hw2reg.ip[87].de),
+    .d      (hw2reg.ip[87].d ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (ip_2_p_87_qs)
   );
 
 
@@ -5408,6 +5443,32 @@ module rv_plic_reg_top (
 
     // to register interface (read)
     .qs     (le_2_le_86_qs)
+  );
+
+
+  // F[le_87]: 23:23
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_le_2_le_87 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (le_2_le_87_we),
+    .wd     (le_2_le_87_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.le[87].q ),
+
+    // to register interface (read)
+    .qs     (le_2_le_87_qs)
   );
 
 
@@ -7761,6 +7822,33 @@ module rv_plic_reg_top (
   );
 
 
+  // R[prio87]: V(False)
+
+  prim_subreg #(
+    .DW      (2),
+    .SWACCESS("RW"),
+    .RESVAL  (2'h0)
+  ) u_prio87 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (prio87_we),
+    .wd     (prio87_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.prio87.q ),
+
+    // to register interface (read)
+    .qs     (prio87_qs)
+  );
+
+
 
   // Subregister 0 of Multireg ie0
   // R[ie0_0]: V(False)
@@ -10033,6 +10121,32 @@ module rv_plic_reg_top (
   );
 
 
+  // F[e_87]: 23:23
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_ie0_2_e_87 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (ie0_2_e_87_we),
+    .wd     (ie0_2_e_87_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ie0[87].q ),
+
+    // to register interface (read)
+    .qs     (ie0_2_e_87_qs)
+  );
+
+
 
   // R[threshold0]: V(False)
 
@@ -10106,7 +10220,7 @@ module rv_plic_reg_top (
 
 
 
-  logic [98:0] addr_hit;
+  logic [99:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == RV_PLIC_IP_0_OFFSET);
@@ -10202,12 +10316,13 @@ module rv_plic_reg_top (
     addr_hit[90] = (reg_addr == RV_PLIC_PRIO84_OFFSET);
     addr_hit[91] = (reg_addr == RV_PLIC_PRIO85_OFFSET);
     addr_hit[92] = (reg_addr == RV_PLIC_PRIO86_OFFSET);
-    addr_hit[93] = (reg_addr == RV_PLIC_IE0_0_OFFSET);
-    addr_hit[94] = (reg_addr == RV_PLIC_IE0_1_OFFSET);
-    addr_hit[95] = (reg_addr == RV_PLIC_IE0_2_OFFSET);
-    addr_hit[96] = (reg_addr == RV_PLIC_THRESHOLD0_OFFSET);
-    addr_hit[97] = (reg_addr == RV_PLIC_CC0_OFFSET);
-    addr_hit[98] = (reg_addr == RV_PLIC_MSIP0_OFFSET);
+    addr_hit[93] = (reg_addr == RV_PLIC_PRIO87_OFFSET);
+    addr_hit[94] = (reg_addr == RV_PLIC_IE0_0_OFFSET);
+    addr_hit[95] = (reg_addr == RV_PLIC_IE0_1_OFFSET);
+    addr_hit[96] = (reg_addr == RV_PLIC_IE0_2_OFFSET);
+    addr_hit[97] = (reg_addr == RV_PLIC_THRESHOLD0_OFFSET);
+    addr_hit[98] = (reg_addr == RV_PLIC_CC0_OFFSET);
+    addr_hit[99] = (reg_addr == RV_PLIC_MSIP0_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -10314,7 +10429,9 @@ module rv_plic_reg_top (
     if (addr_hit[96] && reg_we && (RV_PLIC_PERMIT[96] != (RV_PLIC_PERMIT[96] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[97] && reg_we && (RV_PLIC_PERMIT[97] != (RV_PLIC_PERMIT[97] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[98] && reg_we && (RV_PLIC_PERMIT[98] != (RV_PLIC_PERMIT[98] & reg_be))) wr_err = 1'b1 ;
+    if (addr_hit[99] && reg_we && (RV_PLIC_PERMIT[99] != (RV_PLIC_PERMIT[99] & reg_be))) wr_err = 1'b1 ;
   end
+
 
 
 
@@ -10664,6 +10781,9 @@ module rv_plic_reg_top (
   assign le_2_le_86_we = addr_hit[5] & reg_we & ~wr_err;
   assign le_2_le_86_wd = reg_wdata[22];
 
+  assign le_2_le_87_we = addr_hit[5] & reg_we & ~wr_err;
+  assign le_2_le_87_wd = reg_wdata[23];
+
   assign prio0_we = addr_hit[6] & reg_we & ~wr_err;
   assign prio0_wd = reg_wdata[1:0];
 
@@ -10925,275 +11045,281 @@ module rv_plic_reg_top (
   assign prio86_we = addr_hit[92] & reg_we & ~wr_err;
   assign prio86_wd = reg_wdata[1:0];
 
-  assign ie0_0_e_0_we = addr_hit[93] & reg_we & ~wr_err;
+  assign prio87_we = addr_hit[93] & reg_we & ~wr_err;
+  assign prio87_wd = reg_wdata[1:0];
+
+  assign ie0_0_e_0_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_0_e_0_wd = reg_wdata[0];
 
-  assign ie0_0_e_1_we = addr_hit[93] & reg_we & ~wr_err;
+  assign ie0_0_e_1_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_0_e_1_wd = reg_wdata[1];
 
-  assign ie0_0_e_2_we = addr_hit[93] & reg_we & ~wr_err;
+  assign ie0_0_e_2_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_0_e_2_wd = reg_wdata[2];
 
-  assign ie0_0_e_3_we = addr_hit[93] & reg_we & ~wr_err;
+  assign ie0_0_e_3_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_0_e_3_wd = reg_wdata[3];
 
-  assign ie0_0_e_4_we = addr_hit[93] & reg_we & ~wr_err;
+  assign ie0_0_e_4_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_0_e_4_wd = reg_wdata[4];
 
-  assign ie0_0_e_5_we = addr_hit[93] & reg_we & ~wr_err;
+  assign ie0_0_e_5_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_0_e_5_wd = reg_wdata[5];
 
-  assign ie0_0_e_6_we = addr_hit[93] & reg_we & ~wr_err;
+  assign ie0_0_e_6_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_0_e_6_wd = reg_wdata[6];
 
-  assign ie0_0_e_7_we = addr_hit[93] & reg_we & ~wr_err;
+  assign ie0_0_e_7_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_0_e_7_wd = reg_wdata[7];
 
-  assign ie0_0_e_8_we = addr_hit[93] & reg_we & ~wr_err;
+  assign ie0_0_e_8_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_0_e_8_wd = reg_wdata[8];
 
-  assign ie0_0_e_9_we = addr_hit[93] & reg_we & ~wr_err;
+  assign ie0_0_e_9_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_0_e_9_wd = reg_wdata[9];
 
-  assign ie0_0_e_10_we = addr_hit[93] & reg_we & ~wr_err;
+  assign ie0_0_e_10_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_0_e_10_wd = reg_wdata[10];
 
-  assign ie0_0_e_11_we = addr_hit[93] & reg_we & ~wr_err;
+  assign ie0_0_e_11_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_0_e_11_wd = reg_wdata[11];
 
-  assign ie0_0_e_12_we = addr_hit[93] & reg_we & ~wr_err;
+  assign ie0_0_e_12_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_0_e_12_wd = reg_wdata[12];
 
-  assign ie0_0_e_13_we = addr_hit[93] & reg_we & ~wr_err;
+  assign ie0_0_e_13_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_0_e_13_wd = reg_wdata[13];
 
-  assign ie0_0_e_14_we = addr_hit[93] & reg_we & ~wr_err;
+  assign ie0_0_e_14_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_0_e_14_wd = reg_wdata[14];
 
-  assign ie0_0_e_15_we = addr_hit[93] & reg_we & ~wr_err;
+  assign ie0_0_e_15_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_0_e_15_wd = reg_wdata[15];
 
-  assign ie0_0_e_16_we = addr_hit[93] & reg_we & ~wr_err;
+  assign ie0_0_e_16_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_0_e_16_wd = reg_wdata[16];
 
-  assign ie0_0_e_17_we = addr_hit[93] & reg_we & ~wr_err;
+  assign ie0_0_e_17_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_0_e_17_wd = reg_wdata[17];
 
-  assign ie0_0_e_18_we = addr_hit[93] & reg_we & ~wr_err;
+  assign ie0_0_e_18_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_0_e_18_wd = reg_wdata[18];
 
-  assign ie0_0_e_19_we = addr_hit[93] & reg_we & ~wr_err;
+  assign ie0_0_e_19_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_0_e_19_wd = reg_wdata[19];
 
-  assign ie0_0_e_20_we = addr_hit[93] & reg_we & ~wr_err;
+  assign ie0_0_e_20_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_0_e_20_wd = reg_wdata[20];
 
-  assign ie0_0_e_21_we = addr_hit[93] & reg_we & ~wr_err;
+  assign ie0_0_e_21_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_0_e_21_wd = reg_wdata[21];
 
-  assign ie0_0_e_22_we = addr_hit[93] & reg_we & ~wr_err;
+  assign ie0_0_e_22_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_0_e_22_wd = reg_wdata[22];
 
-  assign ie0_0_e_23_we = addr_hit[93] & reg_we & ~wr_err;
+  assign ie0_0_e_23_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_0_e_23_wd = reg_wdata[23];
 
-  assign ie0_0_e_24_we = addr_hit[93] & reg_we & ~wr_err;
+  assign ie0_0_e_24_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_0_e_24_wd = reg_wdata[24];
 
-  assign ie0_0_e_25_we = addr_hit[93] & reg_we & ~wr_err;
+  assign ie0_0_e_25_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_0_e_25_wd = reg_wdata[25];
 
-  assign ie0_0_e_26_we = addr_hit[93] & reg_we & ~wr_err;
+  assign ie0_0_e_26_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_0_e_26_wd = reg_wdata[26];
 
-  assign ie0_0_e_27_we = addr_hit[93] & reg_we & ~wr_err;
+  assign ie0_0_e_27_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_0_e_27_wd = reg_wdata[27];
 
-  assign ie0_0_e_28_we = addr_hit[93] & reg_we & ~wr_err;
+  assign ie0_0_e_28_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_0_e_28_wd = reg_wdata[28];
 
-  assign ie0_0_e_29_we = addr_hit[93] & reg_we & ~wr_err;
+  assign ie0_0_e_29_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_0_e_29_wd = reg_wdata[29];
 
-  assign ie0_0_e_30_we = addr_hit[93] & reg_we & ~wr_err;
+  assign ie0_0_e_30_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_0_e_30_wd = reg_wdata[30];
 
-  assign ie0_0_e_31_we = addr_hit[93] & reg_we & ~wr_err;
+  assign ie0_0_e_31_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_0_e_31_wd = reg_wdata[31];
 
-  assign ie0_1_e_32_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_1_e_32_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_1_e_32_wd = reg_wdata[0];
 
-  assign ie0_1_e_33_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_1_e_33_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_1_e_33_wd = reg_wdata[1];
 
-  assign ie0_1_e_34_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_1_e_34_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_1_e_34_wd = reg_wdata[2];
 
-  assign ie0_1_e_35_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_1_e_35_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_1_e_35_wd = reg_wdata[3];
 
-  assign ie0_1_e_36_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_1_e_36_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_1_e_36_wd = reg_wdata[4];
 
-  assign ie0_1_e_37_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_1_e_37_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_1_e_37_wd = reg_wdata[5];
 
-  assign ie0_1_e_38_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_1_e_38_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_1_e_38_wd = reg_wdata[6];
 
-  assign ie0_1_e_39_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_1_e_39_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_1_e_39_wd = reg_wdata[7];
 
-  assign ie0_1_e_40_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_1_e_40_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_1_e_40_wd = reg_wdata[8];
 
-  assign ie0_1_e_41_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_1_e_41_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_1_e_41_wd = reg_wdata[9];
 
-  assign ie0_1_e_42_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_1_e_42_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_1_e_42_wd = reg_wdata[10];
 
-  assign ie0_1_e_43_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_1_e_43_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_1_e_43_wd = reg_wdata[11];
 
-  assign ie0_1_e_44_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_1_e_44_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_1_e_44_wd = reg_wdata[12];
 
-  assign ie0_1_e_45_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_1_e_45_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_1_e_45_wd = reg_wdata[13];
 
-  assign ie0_1_e_46_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_1_e_46_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_1_e_46_wd = reg_wdata[14];
 
-  assign ie0_1_e_47_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_1_e_47_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_1_e_47_wd = reg_wdata[15];
 
-  assign ie0_1_e_48_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_1_e_48_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_1_e_48_wd = reg_wdata[16];
 
-  assign ie0_1_e_49_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_1_e_49_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_1_e_49_wd = reg_wdata[17];
 
-  assign ie0_1_e_50_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_1_e_50_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_1_e_50_wd = reg_wdata[18];
 
-  assign ie0_1_e_51_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_1_e_51_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_1_e_51_wd = reg_wdata[19];
 
-  assign ie0_1_e_52_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_1_e_52_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_1_e_52_wd = reg_wdata[20];
 
-  assign ie0_1_e_53_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_1_e_53_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_1_e_53_wd = reg_wdata[21];
 
-  assign ie0_1_e_54_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_1_e_54_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_1_e_54_wd = reg_wdata[22];
 
-  assign ie0_1_e_55_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_1_e_55_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_1_e_55_wd = reg_wdata[23];
 
-  assign ie0_1_e_56_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_1_e_56_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_1_e_56_wd = reg_wdata[24];
 
-  assign ie0_1_e_57_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_1_e_57_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_1_e_57_wd = reg_wdata[25];
 
-  assign ie0_1_e_58_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_1_e_58_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_1_e_58_wd = reg_wdata[26];
 
-  assign ie0_1_e_59_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_1_e_59_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_1_e_59_wd = reg_wdata[27];
 
-  assign ie0_1_e_60_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_1_e_60_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_1_e_60_wd = reg_wdata[28];
 
-  assign ie0_1_e_61_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_1_e_61_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_1_e_61_wd = reg_wdata[29];
 
-  assign ie0_1_e_62_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_1_e_62_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_1_e_62_wd = reg_wdata[30];
 
-  assign ie0_1_e_63_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_1_e_63_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_1_e_63_wd = reg_wdata[31];
 
-  assign ie0_2_e_64_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_2_e_64_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_2_e_64_wd = reg_wdata[0];
 
-  assign ie0_2_e_65_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_2_e_65_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_2_e_65_wd = reg_wdata[1];
 
-  assign ie0_2_e_66_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_2_e_66_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_2_e_66_wd = reg_wdata[2];
 
-  assign ie0_2_e_67_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_2_e_67_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_2_e_67_wd = reg_wdata[3];
 
-  assign ie0_2_e_68_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_2_e_68_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_2_e_68_wd = reg_wdata[4];
 
-  assign ie0_2_e_69_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_2_e_69_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_2_e_69_wd = reg_wdata[5];
 
-  assign ie0_2_e_70_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_2_e_70_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_2_e_70_wd = reg_wdata[6];
 
-  assign ie0_2_e_71_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_2_e_71_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_2_e_71_wd = reg_wdata[7];
 
-  assign ie0_2_e_72_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_2_e_72_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_2_e_72_wd = reg_wdata[8];
 
-  assign ie0_2_e_73_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_2_e_73_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_2_e_73_wd = reg_wdata[9];
 
-  assign ie0_2_e_74_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_2_e_74_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_2_e_74_wd = reg_wdata[10];
 
-  assign ie0_2_e_75_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_2_e_75_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_2_e_75_wd = reg_wdata[11];
 
-  assign ie0_2_e_76_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_2_e_76_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_2_e_76_wd = reg_wdata[12];
 
-  assign ie0_2_e_77_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_2_e_77_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_2_e_77_wd = reg_wdata[13];
 
-  assign ie0_2_e_78_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_2_e_78_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_2_e_78_wd = reg_wdata[14];
 
-  assign ie0_2_e_79_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_2_e_79_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_2_e_79_wd = reg_wdata[15];
 
-  assign ie0_2_e_80_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_2_e_80_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_2_e_80_wd = reg_wdata[16];
 
-  assign ie0_2_e_81_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_2_e_81_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_2_e_81_wd = reg_wdata[17];
 
-  assign ie0_2_e_82_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_2_e_82_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_2_e_82_wd = reg_wdata[18];
 
-  assign ie0_2_e_83_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_2_e_83_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_2_e_83_wd = reg_wdata[19];
 
-  assign ie0_2_e_84_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_2_e_84_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_2_e_84_wd = reg_wdata[20];
 
-  assign ie0_2_e_85_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_2_e_85_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_2_e_85_wd = reg_wdata[21];
 
-  assign ie0_2_e_86_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_2_e_86_we = addr_hit[96] & reg_we & ~wr_err;
   assign ie0_2_e_86_wd = reg_wdata[22];
 
-  assign threshold0_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_2_e_87_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_2_e_87_wd = reg_wdata[23];
+
+  assign threshold0_we = addr_hit[97] & reg_we & ~wr_err;
   assign threshold0_wd = reg_wdata[1:0];
 
-  assign cc0_we = addr_hit[97] & reg_we & ~wr_err;
+  assign cc0_we = addr_hit[98] & reg_we & ~wr_err;
   assign cc0_wd = reg_wdata[6:0];
-  assign cc0_re = addr_hit[97] && reg_re;
+  assign cc0_re = addr_hit[98] && reg_re;
 
-  assign msip0_we = addr_hit[98] & reg_we & ~wr_err;
+  assign msip0_we = addr_hit[99] & reg_we & ~wr_err;
   assign msip0_wd = reg_wdata[0];
 
   // Read data return
@@ -11294,6 +11420,7 @@ module rv_plic_reg_top (
         reg_rdata_next[20] = ip_2_p_84_qs;
         reg_rdata_next[21] = ip_2_p_85_qs;
         reg_rdata_next[22] = ip_2_p_86_qs;
+        reg_rdata_next[23] = ip_2_p_87_qs;
       end
 
       addr_hit[3]: begin
@@ -11390,6 +11517,7 @@ module rv_plic_reg_top (
         reg_rdata_next[20] = le_2_le_84_qs;
         reg_rdata_next[21] = le_2_le_85_qs;
         reg_rdata_next[22] = le_2_le_86_qs;
+        reg_rdata_next[23] = le_2_le_87_qs;
       end
 
       addr_hit[6]: begin
@@ -11741,6 +11869,10 @@ module rv_plic_reg_top (
       end
 
       addr_hit[93]: begin
+        reg_rdata_next[1:0] = prio87_qs;
+      end
+
+      addr_hit[94]: begin
         reg_rdata_next[0] = ie0_0_e_0_qs;
         reg_rdata_next[1] = ie0_0_e_1_qs;
         reg_rdata_next[2] = ie0_0_e_2_qs;
@@ -11775,7 +11907,7 @@ module rv_plic_reg_top (
         reg_rdata_next[31] = ie0_0_e_31_qs;
       end
 
-      addr_hit[94]: begin
+      addr_hit[95]: begin
         reg_rdata_next[0] = ie0_1_e_32_qs;
         reg_rdata_next[1] = ie0_1_e_33_qs;
         reg_rdata_next[2] = ie0_1_e_34_qs;
@@ -11810,7 +11942,7 @@ module rv_plic_reg_top (
         reg_rdata_next[31] = ie0_1_e_63_qs;
       end
 
-      addr_hit[95]: begin
+      addr_hit[96]: begin
         reg_rdata_next[0] = ie0_2_e_64_qs;
         reg_rdata_next[1] = ie0_2_e_65_qs;
         reg_rdata_next[2] = ie0_2_e_66_qs;
@@ -11834,17 +11966,18 @@ module rv_plic_reg_top (
         reg_rdata_next[20] = ie0_2_e_84_qs;
         reg_rdata_next[21] = ie0_2_e_85_qs;
         reg_rdata_next[22] = ie0_2_e_86_qs;
-      end
-
-      addr_hit[96]: begin
-        reg_rdata_next[1:0] = threshold0_qs;
+        reg_rdata_next[23] = ie0_2_e_87_qs;
       end
 
       addr_hit[97]: begin
-        reg_rdata_next[6:0] = cc0_qs;
+        reg_rdata_next[1:0] = threshold0_qs;
       end
 
       addr_hit[98]: begin
+        reg_rdata_next[6:0] = cc0_qs;
+      end
+
+      addr_hit[99]: begin
         reg_rdata_next[0] = msip0_qs;
       end
 

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -154,7 +154,7 @@ module top_earlgrey #(
   // otbn
 
 
-  logic [86:0]  intr_vector;
+  logic [87:0]  intr_vector;
   // Interrupt source list
   logic intr_uart_tx_watermark;
   logic intr_uart_rx_watermark;
@@ -208,6 +208,7 @@ module top_earlgrey #(
   logic intr_usbdev_rx_bitstuff_err;
   logic intr_usbdev_frame;
   logic intr_usbdev_connected;
+  logic intr_usbdev_link_out_err;
   logic intr_keymgr_op_done;
   logic intr_keymgr_err;
   logic intr_otp_ctrl_otp_operation_done;
@@ -996,6 +997,7 @@ module top_earlgrey #(
       .intr_rx_bitstuff_err_o (intr_usbdev_rx_bitstuff_err),
       .intr_frame_o           (intr_usbdev_frame),
       .intr_connected_o       (intr_usbdev_connected),
+      .intr_link_out_err_o    (intr_usbdev_link_out_err),
 
       // Inter-module signals
       .usb_ref_val_o(usbdev_usb_ref_val_o),
@@ -1134,6 +1136,7 @@ module top_earlgrey #(
       intr_otbn_err,
       intr_otbn_done,
       intr_pwrmgr_wakeup,
+      intr_usbdev_link_out_err,
       intr_usbdev_connected,
       intr_usbdev_frame,
       intr_usbdev_rx_bitstuff_err,

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.c
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.c
@@ -11,7 +11,7 @@
  * `top_earlgrey_plic_peripheral_t`.
  */
 const top_earlgrey_plic_peripheral_t
-    top_earlgrey_plic_interrupt_for_peripheral[87] = {
+    top_earlgrey_plic_interrupt_for_peripheral[88] = {
   [kTopEarlgreyPlicIrqIdNone] = kTopEarlgreyPlicPeripheralUnknown,
   [kTopEarlgreyPlicIrqIdGpioGpio0] = kTopEarlgreyPlicPeripheralGpio,
   [kTopEarlgreyPlicIrqIdGpioGpio1] = kTopEarlgreyPlicPeripheralGpio,
@@ -91,6 +91,7 @@ const top_earlgrey_plic_peripheral_t
   [kTopEarlgreyPlicIrqIdUsbdevRxBitstuffErr] = kTopEarlgreyPlicPeripheralUsbdev,
   [kTopEarlgreyPlicIrqIdUsbdevFrame] = kTopEarlgreyPlicPeripheralUsbdev,
   [kTopEarlgreyPlicIrqIdUsbdevConnected] = kTopEarlgreyPlicPeripheralUsbdev,
+  [kTopEarlgreyPlicIrqIdUsbdevLinkOutErr] = kTopEarlgreyPlicPeripheralUsbdev,
   [kTopEarlgreyPlicIrqIdPwrmgrWakeup] = kTopEarlgreyPlicPeripheralPwrmgr,
   [kTopEarlgreyPlicIrqIdOtbnDone] = kTopEarlgreyPlicPeripheralOtbn,
   [kTopEarlgreyPlicIrqIdOtbnErr] = kTopEarlgreyPlicPeripheralOtbn,

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -554,15 +554,16 @@ typedef enum top_earlgrey_plic_irq_id {
   kTopEarlgreyPlicIrqIdUsbdevRxBitstuffErr = 76, /**< usbdev_rx_bitstuff_err */
   kTopEarlgreyPlicIrqIdUsbdevFrame = 77, /**< usbdev_frame */
   kTopEarlgreyPlicIrqIdUsbdevConnected = 78, /**< usbdev_connected */
-  kTopEarlgreyPlicIrqIdPwrmgrWakeup = 79, /**< pwrmgr_wakeup */
-  kTopEarlgreyPlicIrqIdOtbnDone = 80, /**< otbn_done */
-  kTopEarlgreyPlicIrqIdOtbnErr = 81, /**< otbn_err */
-  kTopEarlgreyPlicIrqIdKeymgrOpDone = 82, /**< keymgr_op_done */
-  kTopEarlgreyPlicIrqIdKeymgrErr = 83, /**< keymgr_err */
-  kTopEarlgreyPlicIrqIdKmacKmacDone = 84, /**< kmac_kmac_done */
-  kTopEarlgreyPlicIrqIdKmacFifoEmpty = 85, /**< kmac_fifo_empty */
-  kTopEarlgreyPlicIrqIdKmacKmacErr = 86, /**< kmac_kmac_err */
-  kTopEarlgreyPlicIrqIdLast = 86, /**< \internal The Last Valid Interrupt ID. */
+  kTopEarlgreyPlicIrqIdUsbdevLinkOutErr = 79, /**< usbdev_link_out_err */
+  kTopEarlgreyPlicIrqIdPwrmgrWakeup = 80, /**< pwrmgr_wakeup */
+  kTopEarlgreyPlicIrqIdOtbnDone = 81, /**< otbn_done */
+  kTopEarlgreyPlicIrqIdOtbnErr = 82, /**< otbn_err */
+  kTopEarlgreyPlicIrqIdKeymgrOpDone = 83, /**< keymgr_op_done */
+  kTopEarlgreyPlicIrqIdKeymgrErr = 84, /**< keymgr_err */
+  kTopEarlgreyPlicIrqIdKmacKmacDone = 85, /**< kmac_kmac_done */
+  kTopEarlgreyPlicIrqIdKmacFifoEmpty = 86, /**< kmac_fifo_empty */
+  kTopEarlgreyPlicIrqIdKmacKmacErr = 87, /**< kmac_kmac_err */
+  kTopEarlgreyPlicIrqIdLast = 87, /**< \internal The Last Valid Interrupt ID. */
 } top_earlgrey_plic_irq_id_t;
 
 /**
@@ -572,7 +573,7 @@ typedef enum top_earlgrey_plic_irq_id {
  * `top_earlgrey_plic_peripheral_t`.
  */
 extern const top_earlgrey_plic_peripheral_t
-    top_earlgrey_plic_interrupt_for_peripheral[87];
+    top_earlgrey_plic_interrupt_for_peripheral[88];
 
 /**
  * PLIC Interrupt Target.

--- a/sw/device/lib/dif/dif_plic.c
+++ b/sw/device/lib/dif/dif_plic.c
@@ -16,7 +16,7 @@
 // If either of these static assertions fail, then the assumptions in this DIF
 // implementation should be revisited. In particular, `kPlicTargets`
 // may need updating,
-_Static_assert(RV_PLIC_PARAM_NUMSRC == 87,
+_Static_assert(RV_PLIC_PARAM_NUMSRC == 88,
                "PLIC instantiation parameters have changed.");
 _Static_assert(RV_PLIC_PARAM_NUMTARGET == 1,
                "PLIC instantiation parameters have changed.");

--- a/sw/device/tests/dif/dif_plic_unittest.cc
+++ b/sw/device/tests/dif/dif_plic_unittest.cc
@@ -78,19 +78,19 @@ class IrqTest : public PlicTest {
       kEnableRegisters{{
           {RV_PLIC_IE0_0_REG_OFFSET, RV_PLIC_IE0_0_E_31_BIT},
           {RV_PLIC_IE0_1_REG_OFFSET, RV_PLIC_IE0_1_E_63_BIT},
-          {RV_PLIC_IE0_2_REG_OFFSET, RV_PLIC_IE0_2_E_86_BIT},
+          {RV_PLIC_IE0_2_REG_OFFSET, RV_PLIC_IE0_2_E_87_BIT},
       }};
   static constexpr std::array<Register, RV_PLIC_LE_MULTIREG_COUNT>
       kTriggerRegisters{{
           {RV_PLIC_LE_0_REG_OFFSET, RV_PLIC_LE_0_LE_31_BIT},
           {RV_PLIC_LE_1_REG_OFFSET, RV_PLIC_LE_1_LE_63_BIT},
-          {RV_PLIC_LE_2_REG_OFFSET, RV_PLIC_LE_2_LE_86_BIT},
+          {RV_PLIC_LE_2_REG_OFFSET, RV_PLIC_LE_2_LE_87_BIT},
       }};
   static constexpr std::array<Register, RV_PLIC_IP_MULTIREG_COUNT>
       kPendingRegisters{{
           {RV_PLIC_IP_0_REG_OFFSET, RV_PLIC_IP_0_P_31_BIT},
           {RV_PLIC_IP_1_REG_OFFSET, RV_PLIC_IP_1_P_63_BIT},
-          {RV_PLIC_IP_2_REG_OFFSET, RV_PLIC_IP_2_P_86_BIT},
+          {RV_PLIC_IP_2_REG_OFFSET, RV_PLIC_IP_2_P_87_BIT},
       }};
 
   // Set enable/disable multireg expectations, one bit per call.


### PR DESCRIPTION
Hi all

This pull request includes the following:
- Moves the link_reset SE0 detection back to usbdev_linkstate. This reverts some changes from #3359 and solves #4031.
- Fixes for a bug where ISO IN transfers did not generate an interrupt on completion.
- Fixes for an issue where stalled endpoints sent ACK when the data toggle is invalid (sending a STALL seems to make more sense in this situation).
- Addition of observability and controllability registers as discussed in #2703.

After this PR the ETH and OpenTitan version of the peripheral are mostly aligned. The simulation results look fine (`PASS!` in uart0.log), but it would probably make sense if someone tested the changes on one of your FPGA testbeds.

I have split out the auto-generated changes into a separate commit to ease review.