### PR TITLE
[reggen] Add bitfield.h-style constants to reggen's output

### DIFF
--- a/sw/device/lib/dif/dif_alert_handler.c
+++ b/sw/device/lib/dif/dif_alert_handler.c
@@ -143,23 +143,19 @@ static bool classify_local_alerts(
     switch (class->local_alerts[i]) {
       case kDifAlertHandlerLocalAlertAlertPingFail:
         enable_bit = ALERT_HANDLER_LOC_ALERT_EN_EN_LA_0_BIT;
-        field.mask = ALERT_HANDLER_LOC_ALERT_CLASS_CLASS_LA_0_MASK;
-        field.index = ALERT_HANDLER_LOC_ALERT_CLASS_CLASS_LA_0_OFFSET;
+        field = ALERT_HANDLER_LOC_ALERT_CLASS_CLASS_LA_0_FIELD;
         break;
       case kDifAlertHandlerLocalAlertEscalationPingFail:
         enable_bit = ALERT_HANDLER_LOC_ALERT_EN_EN_LA_1_BIT;
-        field.mask = ALERT_HANDLER_LOC_ALERT_CLASS_CLASS_LA_1_MASK;
-        field.index = ALERT_HANDLER_LOC_ALERT_CLASS_CLASS_LA_1_OFFSET;
+        field = ALERT_HANDLER_LOC_ALERT_CLASS_CLASS_LA_1_FIELD;
         break;
       case kDifAlertHandlerLocalAlertAlertIntegrityFail:
         enable_bit = ALERT_HANDLER_LOC_ALERT_EN_EN_LA_2_BIT;
-        field.mask = ALERT_HANDLER_LOC_ALERT_CLASS_CLASS_LA_2_MASK;
-        field.index = ALERT_HANDLER_LOC_ALERT_CLASS_CLASS_LA_2_OFFSET;
+        field = ALERT_HANDLER_LOC_ALERT_CLASS_CLASS_LA_2_FIELD;
         break;
       case kDifAlertHandlerLocalAlertEscalationIntegrityFail:
         enable_bit = ALERT_HANDLER_LOC_ALERT_EN_EN_LA_3_BIT;
-        field.mask = ALERT_HANDLER_LOC_ALERT_CLASS_CLASS_LA_3_MASK;
-        field.index = ALERT_HANDLER_LOC_ALERT_CLASS_CLASS_LA_3_OFFSET;
+        field = ALERT_HANDLER_LOC_ALERT_CLASS_CLASS_LA_3_FIELD;
         break;
       default:
         return false;
@@ -261,23 +257,19 @@ static bool configure_class(const dif_alert_handler_t *handler,
     switch (class->phase_signals[i].phase) {
       case kDifAlertHandlerClassStatePhase0:
         enable_bit = ALERT_HANDLER_CLASSA_CTRL_EN_E0_BIT;
-        map_field.mask = ALERT_HANDLER_CLASSA_CTRL_MAP_E0_MASK;
-        map_field.index = ALERT_HANDLER_CLASSA_CTRL_MAP_E0_OFFSET;
+        map_field = ALERT_HANDLER_CLASSA_CTRL_MAP_E0_FIELD;
         break;
       case kDifAlertHandlerClassStatePhase1:
         enable_bit = ALERT_HANDLER_CLASSA_CTRL_EN_E1_BIT;
-        map_field.mask = ALERT_HANDLER_CLASSA_CTRL_MAP_E1_MASK;
-        map_field.index = ALERT_HANDLER_CLASSA_CTRL_MAP_E1_OFFSET;
+        map_field = ALERT_HANDLER_CLASSA_CTRL_MAP_E1_FIELD;
         break;
       case kDifAlertHandlerClassStatePhase2:
         enable_bit = ALERT_HANDLER_CLASSA_CTRL_EN_E2_BIT;
-        map_field.mask = ALERT_HANDLER_CLASSA_CTRL_MAP_E2_MASK;
-        map_field.index = ALERT_HANDLER_CLASSA_CTRL_MAP_E2_OFFSET;
+        map_field = ALERT_HANDLER_CLASSA_CTRL_MAP_E2_FIELD;
         break;
       case kDifAlertHandlerClassStatePhase3:
         enable_bit = ALERT_HANDLER_CLASSA_CTRL_EN_E3_BIT;
-        map_field.mask = ALERT_HANDLER_CLASSA_CTRL_MAP_E3_MASK;
-        map_field.index = ALERT_HANDLER_CLASSA_CTRL_MAP_E3_OFFSET;
+        map_field = ALERT_HANDLER_CLASSA_CTRL_MAP_E3_FIELD;
         break;
       default:
         return false;
@@ -444,11 +436,7 @@ dif_alert_handler_config_result_t dif_alert_handler_configure(
   }
 
   uint32_t ping_timeout_reg = bitfield_field32_write(
-      0,
-      (bitfield_field32_t){
-          .mask = ALERT_HANDLER_PING_TIMEOUT_CYC_PING_TIMEOUT_CYC_MASK,
-          .index = ALERT_HANDLER_PING_TIMEOUT_CYC_PING_TIMEOUT_CYC_OFFSET,
-      },
+      0, ALERT_HANDLER_PING_TIMEOUT_CYC_PING_TIMEOUT_CYC_FIELD,
       config.ping_timeout);
   mmio_region_write32(handler->params.base_addr,
                       ALERT_HANDLER_PING_TIMEOUT_CYC_REG_OFFSET,
@@ -829,23 +817,19 @@ dif_alert_handler_result_t dif_alert_handler_get_accumulator(
   switch (alert_class) {
     case kDifAlertHandlerClassA:
       reg_offset = ALERT_HANDLER_CLASSA_ACCUM_CNT_REG_OFFSET;
-      field.mask = ALERT_HANDLER_CLASSA_ACCUM_CNT_CLASSA_ACCUM_CNT_MASK;
-      field.index = ALERT_HANDLER_CLASSA_ACCUM_CNT_CLASSA_ACCUM_CNT_OFFSET;
+      field = ALERT_HANDLER_CLASSA_ACCUM_CNT_CLASSA_ACCUM_CNT_FIELD;
       break;
     case kDifAlertHandlerClassB:
       reg_offset = ALERT_HANDLER_CLASSB_ACCUM_CNT_REG_OFFSET;
-      field.mask = ALERT_HANDLER_CLASSB_ACCUM_CNT_CLASSB_ACCUM_CNT_MASK;
-      field.index = ALERT_HANDLER_CLASSB_ACCUM_CNT_CLASSB_ACCUM_CNT_OFFSET;
+      field = ALERT_HANDLER_CLASSB_ACCUM_CNT_CLASSB_ACCUM_CNT_FIELD;
       break;
     case kDifAlertHandlerClassC:
       reg_offset = ALERT_HANDLER_CLASSC_ACCUM_CNT_REG_OFFSET;
-      field.mask = ALERT_HANDLER_CLASSC_ACCUM_CNT_CLASSC_ACCUM_CNT_MASK;
-      field.index = ALERT_HANDLER_CLASSC_ACCUM_CNT_CLASSC_ACCUM_CNT_OFFSET;
+      field = ALERT_HANDLER_CLASSC_ACCUM_CNT_CLASSC_ACCUM_CNT_FIELD;
       break;
     case kDifAlertHandlerClassD:
       reg_offset = ALERT_HANDLER_CLASSD_ACCUM_CNT_REG_OFFSET;
-      field.mask = ALERT_HANDLER_CLASSD_ACCUM_CNT_CLASSD_ACCUM_CNT_MASK;
-      field.index = ALERT_HANDLER_CLASSD_ACCUM_CNT_CLASSD_ACCUM_CNT_OFFSET;
+      field = ALERT_HANDLER_CLASSD_ACCUM_CNT_CLASSD_ACCUM_CNT_FIELD;
       break;
     default:
       return kDifAlertHandlerBadArg;
@@ -899,23 +883,19 @@ dif_alert_handler_result_t dif_alert_handler_get_class_state(
   switch (alert_class) {
     case kDifAlertHandlerClassA:
       reg_offset = ALERT_HANDLER_CLASSA_STATE_REG_OFFSET;
-      field.mask = ALERT_HANDLER_CLASSA_STATE_CLASSA_STATE_MASK;
-      field.index = ALERT_HANDLER_CLASSA_STATE_CLASSA_STATE_OFFSET;
+      field = ALERT_HANDLER_CLASSA_STATE_CLASSA_STATE_FIELD;
       break;
     case kDifAlertHandlerClassB:
       reg_offset = ALERT_HANDLER_CLASSB_STATE_REG_OFFSET;
-      field.mask = ALERT_HANDLER_CLASSB_STATE_CLASSB_STATE_MASK;
-      field.index = ALERT_HANDLER_CLASSB_STATE_CLASSB_STATE_OFFSET;
+      field = ALERT_HANDLER_CLASSB_STATE_CLASSB_STATE_FIELD;
       break;
     case kDifAlertHandlerClassC:
       reg_offset = ALERT_HANDLER_CLASSC_STATE_REG_OFFSET;
-      field.mask = ALERT_HANDLER_CLASSC_STATE_CLASSC_STATE_MASK;
-      field.index = ALERT_HANDLER_CLASSC_STATE_CLASSC_STATE_OFFSET;
+      field = ALERT_HANDLER_CLASSC_STATE_CLASSC_STATE_FIELD;
       break;
     case kDifAlertHandlerClassD:
       reg_offset = ALERT_HANDLER_CLASSD_STATE_REG_OFFSET;
-      field.mask = ALERT_HANDLER_CLASSD_STATE_CLASSD_STATE_MASK;
-      field.index = ALERT_HANDLER_CLASSD_STATE_CLASSD_STATE_OFFSET;
+      field = ALERT_HANDLER_CLASSD_STATE_CLASSD_STATE_FIELD;
       break;
     default:
       return kDifAlertHandlerBadArg;

--- a/sw/device/lib/dif/dif_hmac.c
+++ b/sw/device/lib/dif/dif_hmac.c
@@ -29,11 +29,7 @@ static uint32_t get_status(const dif_hmac_t *hmac) {
  * @return The number of entries in the HMAC FIFO.
  */
 static uint32_t get_fifo_entry_count(const dif_hmac_t *hmac) {
-  return bitfield_field32_read(get_status(hmac),
-                               (bitfield_field32_t){
-                                   .mask = HMAC_STATUS_FIFO_DEPTH_MASK,
-                                   .index = HMAC_STATUS_FIFO_DEPTH_OFFSET,
-                               });
+  return bitfield_field32_read(get_status(hmac), HMAC_STATUS_FIFO_DEPTH_FIELD);
 }
 
 /**

--- a/sw/device/lib/dif/dif_i2c.c
+++ b/sw/device/lib/dif/dif_i2c.c
@@ -142,78 +142,38 @@ dif_i2c_result_t dif_i2c_configure(const dif_i2c_t *i2c,
   }
 
   uint32_t timing0 = 0;
-  timing0 = bitfield_field32_write(
-      timing0,
-      (bitfield_field32_t){
-          .mask = I2C_TIMING0_THIGH_MASK, .index = I2C_TIMING0_THIGH_OFFSET,
-      },
-      config.scl_time_high_cycles);
-  timing0 = bitfield_field32_write(
-      timing0,
-      (bitfield_field32_t){
-          .mask = I2C_TIMING0_TLOW_MASK, .index = I2C_TIMING0_TLOW_OFFSET,
-      },
-      config.scl_time_low_cycles);
+  timing0 = bitfield_field32_write(timing0, I2C_TIMING0_THIGH_FIELD,
+                                   config.scl_time_high_cycles);
+  timing0 = bitfield_field32_write(timing0, I2C_TIMING0_TLOW_FIELD,
+                                   config.scl_time_low_cycles);
   mmio_region_write32(i2c->params.base_addr, I2C_TIMING0_REG_OFFSET, timing0);
 
   uint32_t timing1 = 0;
-  timing1 = bitfield_field32_write(
-      timing1,
-      (bitfield_field32_t){
-          .mask = I2C_TIMING1_T_R_MASK, .index = I2C_TIMING1_T_R_OFFSET,
-      },
-      config.rise_cycles);
-  timing1 = bitfield_field32_write(
-      timing1,
-      (bitfield_field32_t){
-          .mask = I2C_TIMING1_T_F_MASK, .index = I2C_TIMING1_T_F_OFFSET,
-      },
-      config.fall_cycles);
+  timing1 = bitfield_field32_write(timing1, I2C_TIMING1_T_R_FIELD,
+                                   config.rise_cycles);
+  timing1 = bitfield_field32_write(timing1, I2C_TIMING1_T_F_FIELD,
+                                   config.fall_cycles);
   mmio_region_write32(i2c->params.base_addr, I2C_TIMING1_REG_OFFSET, timing1);
 
   uint32_t timing2 = 0;
-  timing2 = bitfield_field32_write(
-      timing2,
-      (bitfield_field32_t){
-          .mask = I2C_TIMING2_TSU_STA_MASK, .index = I2C_TIMING2_TSU_STA_OFFSET,
-      },
-      config.start_signal_setup_cycles);
-  timing2 = bitfield_field32_write(
-      timing2,
-      (bitfield_field32_t){
-          .mask = I2C_TIMING2_THD_STA_MASK, .index = I2C_TIMING2_THD_STA_OFFSET,
-      },
-      config.start_signal_hold_cycles);
+  timing2 = bitfield_field32_write(timing2, I2C_TIMING2_TSU_STA_FIELD,
+                                   config.start_signal_setup_cycles);
+  timing2 = bitfield_field32_write(timing2, I2C_TIMING2_THD_STA_FIELD,
+                                   config.start_signal_hold_cycles);
   mmio_region_write32(i2c->params.base_addr, I2C_TIMING2_REG_OFFSET, timing2);
 
   uint32_t timing3 = 0;
-  timing3 = bitfield_field32_write(
-      timing3,
-      (bitfield_field32_t){
-          .mask = I2C_TIMING3_TSU_DAT_MASK, .index = I2C_TIMING3_TSU_DAT_OFFSET,
-      },
-      config.data_signal_setup_cycles);
-  timing3 = bitfield_field32_write(
-      timing3,
-      (bitfield_field32_t){
-          .mask = I2C_TIMING3_THD_DAT_MASK, .index = I2C_TIMING3_THD_DAT_OFFSET,
-      },
-      config.data_signal_hold_cycles);
+  timing3 = bitfield_field32_write(timing3, I2C_TIMING3_TSU_DAT_FIELD,
+                                   config.data_signal_setup_cycles);
+  timing3 = bitfield_field32_write(timing3, I2C_TIMING3_THD_DAT_FIELD,
+                                   config.data_signal_hold_cycles);
   mmio_region_write32(i2c->params.base_addr, I2C_TIMING3_REG_OFFSET, timing3);
 
   uint32_t timing4 = 0;
-  timing4 = bitfield_field32_write(
-      timing4,
-      (bitfield_field32_t){
-          .mask = I2C_TIMING4_TSU_STO_MASK, .index = I2C_TIMING4_TSU_STO_OFFSET,
-      },
-      config.stop_signal_setup_cycles);
-  timing4 = bitfield_field32_write(
-      timing4,
-      (bitfield_field32_t){
-          .mask = I2C_TIMING4_T_BUF_MASK, .index = I2C_TIMING4_T_BUF_OFFSET,
-      },
-      config.stop_signal_hold_cycles);
+  timing4 = bitfield_field32_write(timing4, I2C_TIMING4_TSU_STO_FIELD,
+                                   config.stop_signal_setup_cycles);
+  timing4 = bitfield_field32_write(timing4, I2C_TIMING4_T_BUF_FIELD,
+                                   config.stop_signal_hold_cycles);
   mmio_region_write32(i2c->params.base_addr, I2C_TIMING4_REG_OFFSET, timing4);
 
   return kDifI2cOk;
@@ -293,17 +253,9 @@ dif_i2c_result_t dif_i2c_set_watermarks(const dif_i2c_t *i2c,
 
   uint32_t ctrl_value =
       mmio_region_read32(i2c->params.base_addr, I2C_FIFO_CTRL_REG_OFFSET);
-  ctrl_value = bitfield_field32_write(ctrl_value,
-                                      (bitfield_field32_t){
-                                          .mask = I2C_FIFO_CTRL_RXILVL_MASK,
-                                          .index = I2C_FIFO_CTRL_RXILVL_OFFSET,
-                                      },
+  ctrl_value = bitfield_field32_write(ctrl_value, I2C_FIFO_CTRL_RXILVL_FIELD,
                                       rx_level_value);
-  ctrl_value = bitfield_field32_write(ctrl_value,
-                                      (bitfield_field32_t){
-                                          .mask = I2C_FIFO_CTRL_FMTILVL_MASK,
-                                          .index = I2C_FIFO_CTRL_FMTILVL_OFFSET,
-                                      },
+  ctrl_value = bitfield_field32_write(ctrl_value, I2C_FIFO_CTRL_FMTILVL_FIELD,
                                       fmt_level_value);
   mmio_region_write32(i2c->params.base_addr, I2C_FIFO_CTRL_REG_OFFSET,
                       ctrl_value);
@@ -553,19 +505,11 @@ dif_i2c_result_t dif_i2c_override_sample_pins(const dif_i2c_t *i2c,
   uint32_t samples =
       mmio_region_read32(i2c->params.base_addr, I2C_VAL_REG_OFFSET);
   if (scl_samples != NULL) {
-    *scl_samples = bitfield_field32_read(
-        samples,
-        (bitfield_field32_t){
-            .mask = I2C_VAL_SCL_RX_MASK, .index = I2C_VAL_SCL_RX_OFFSET,
-        });
+    *scl_samples = bitfield_field32_read(samples, I2C_VAL_SCL_RX_FIELD);
   }
 
   if (sda_samples != NULL) {
-    *sda_samples = bitfield_field32_read(
-        samples,
-        (bitfield_field32_t){
-            .mask = I2C_VAL_SDA_RX_MASK, .index = I2C_VAL_SDA_RX_OFFSET,
-        });
+    *sda_samples = bitfield_field32_read(samples, I2C_VAL_SDA_RX_FIELD);
   }
 
   return kDifI2cOk;
@@ -581,18 +525,11 @@ dif_i2c_result_t dif_i2c_get_fifo_levels(const dif_i2c_t *i2c,
   uint32_t values =
       mmio_region_read32(i2c->params.base_addr, I2C_FIFO_STATUS_REG_OFFSET);
   if (fmt_fifo_level != NULL) {
-    *fmt_fifo_level = bitfield_field32_read(
-        values, (bitfield_field32_t){
-                    .mask = I2C_FIFO_STATUS_FMTLVL_MASK,
-                    .index = I2C_FIFO_STATUS_FMTLVL_OFFSET,
-                });
+    *fmt_fifo_level =
+        bitfield_field32_read(values, I2C_FIFO_STATUS_FMTLVL_FIELD);
   }
   if (rx_fifo_level != NULL) {
-    *rx_fifo_level =
-        bitfield_field32_read(values, (bitfield_field32_t){
-                                          .mask = I2C_FIFO_STATUS_RXLVL_MASK,
-                                          .index = I2C_FIFO_STATUS_RXLVL_OFFSET,
-                                      });
+    *rx_fifo_level = bitfield_field32_read(values, I2C_FIFO_STATUS_RXLVL_FIELD);
   }
 
   return kDifI2cOk;
@@ -606,10 +543,7 @@ dif_i2c_result_t dif_i2c_read_byte(const dif_i2c_t *i2c, uint8_t *byte) {
   uint32_t values =
       mmio_region_read32(i2c->params.base_addr, I2C_RDATA_REG_OFFSET);
   if (byte != NULL) {
-    *byte = bitfield_field32_read(values, (bitfield_field32_t){
-                                              .mask = I2C_RDATA_RDATA_MASK,
-                                              .index = I2C_RDATA_RDATA_OFFSET,
-                                          });
+    *byte = bitfield_field32_read(values, I2C_RDATA_RDATA_FIELD);
   }
 
   return kDifI2cOk;
@@ -633,12 +567,7 @@ dif_i2c_result_t dif_i2c_write_byte_raw(const dif_i2c_t *i2c, uint8_t byte,
   }
 
   uint32_t fmt_byte = 0;
-  fmt_byte = bitfield_field32_write(
-      fmt_byte,
-      (bitfield_field32_t){
-          .mask = I2C_FDATA_FBYTE_MASK, .index = I2C_FDATA_FBYTE_OFFSET,
-      },
-      byte);
+  fmt_byte = bitfield_field32_write(fmt_byte, I2C_FDATA_FBYTE_FIELD, byte);
   fmt_byte = bitfield_bit32_write(fmt_byte, I2C_FDATA_START_BIT, flags.start);
   fmt_byte = bitfield_bit32_write(fmt_byte, I2C_FDATA_STOP_BIT, flags.stop);
   fmt_byte = bitfield_bit32_write(fmt_byte, I2C_FDATA_READ_BIT, flags.read);

--- a/sw/device/lib/dif/dif_rstmgr.c
+++ b/sw/device/lib/dif/dif_rstmgr.c
@@ -218,17 +218,13 @@ dif_rstmgr_result_t dif_rstmgr_alert_info_dump_read(
     return kDifRstmgrError;
   }
 
-  bitfield_field32_t index_field = {
-      .mask = RSTMGR_ALERT_INFO_CTRL_INDEX_MASK,
-      .index = RSTMGR_ALERT_INFO_CTRL_INDEX_OFFSET,
-  };
-
   uint32_t control_reg =
       mmio_region_read32(base_addr, RSTMGR_ALERT_INFO_CTRL_REG_OFFSET);
 
   // Read the entire alert info crash dump, one 32bit data segment at the time.
   for (int i = 0; i < dump_size_actual; ++i) {
-    control_reg = bitfield_field32_write(control_reg, index_field, i);
+    control_reg = bitfield_field32_write(control_reg,
+                                         RSTMGR_ALERT_INFO_CTRL_INDEX_FIELD, i);
 
     // Set the index of the 32bit data segment to be read at `i`.
     mmio_region_write32(base_addr, RSTMGR_ALERT_INFO_CTRL_REG_OFFSET,

--- a/sw/device/lib/dif/dif_rv_timer.c
+++ b/sw/device/lib/dif/dif_rv_timer.c
@@ -94,19 +94,10 @@ dif_rv_timer_result_t dif_rv_timer_set_tick_params(
   }
 
   uint32_t config_value = 0;
-  config_value =
-      bitfield_field32_write(config_value,
-                             (bitfield_field32_t){
-                                 .mask = RV_TIMER_CFG0_PRESCALE_MASK,
-                                 .index = RV_TIMER_CFG0_PRESCALE_OFFSET,
-                             },
-                             params.prescale);
   config_value = bitfield_field32_write(
-      config_value,
-      (bitfield_field32_t){
-          .mask = RV_TIMER_CFG0_STEP_MASK, .index = RV_TIMER_CFG0_STEP_OFFSET,
-      },
-      params.tick_step);
+      config_value, RV_TIMER_CFG0_PRESCALE_FIELD, params.prescale);
+  config_value = bitfield_field32_write(config_value, RV_TIMER_CFG0_STEP_FIELD,
+                                        params.tick_step);
   mmio_region_write32(timer->base_addr,
                       reg_for_hart(hart_id, RV_TIMER_CFG0_REG_OFFSET),
                       config_value);

--- a/sw/device/lib/dif/dif_spi_device.c
+++ b/sw/device/lib/dif/dif_spi_device.c
@@ -38,11 +38,7 @@ static uint32_t build_control_word(dif_spi_device_config_t config) {
                              config.tx_order == kDifSpiDeviceBitOrderLsbToMsb);
   val = bitfield_bit32_write(val, SPI_DEVICE_CFG_RX_ORDER_BIT,
                              config.rx_order == kDifSpiDeviceBitOrderLsbToMsb);
-  val = bitfield_field32_write(val,
-                               (bitfield_field32_t){
-                                   .mask = SPI_DEVICE_CFG_TIMER_V_MASK,
-                                   .index = SPI_DEVICE_CFG_TIMER_V_OFFSET,
-                               },
+  val = bitfield_field32_write(val, SPI_DEVICE_CFG_TIMER_V_FIELD,
                                config.rx_fifo_timeout);
 
   return val;
@@ -69,36 +65,16 @@ dif_spi_device_result_t dif_spi_device_configure(
   }
 
   uint32_t rx_fifo_bounds = 0;
-  rx_fifo_bounds =
-      bitfield_field32_write(rx_fifo_bounds,
-                             (bitfield_field32_t){
-                                 .mask = SPI_DEVICE_RXF_ADDR_BASE_MASK,
-                                 .index = SPI_DEVICE_RXF_ADDR_BASE_OFFSET,
-                             },
-                             rx_fifo_start);
-  rx_fifo_bounds =
-      bitfield_field32_write(rx_fifo_bounds,
-                             (bitfield_field32_t){
-                                 .mask = SPI_DEVICE_RXF_ADDR_LIMIT_MASK,
-                                 .index = SPI_DEVICE_RXF_ADDR_LIMIT_OFFSET,
-                             },
-                             rx_fifo_end);
+  rx_fifo_bounds = bitfield_field32_write(
+      rx_fifo_bounds, SPI_DEVICE_RXF_ADDR_BASE_FIELD, rx_fifo_start);
+  rx_fifo_bounds = bitfield_field32_write(
+      rx_fifo_bounds, SPI_DEVICE_RXF_ADDR_LIMIT_FIELD, rx_fifo_end);
 
   uint32_t tx_fifo_bounds = 0;
-  tx_fifo_bounds =
-      bitfield_field32_write(tx_fifo_bounds,
-                             (bitfield_field32_t){
-                                 .mask = SPI_DEVICE_TXF_ADDR_BASE_MASK,
-                                 .index = SPI_DEVICE_TXF_ADDR_BASE_OFFSET,
-                             },
-                             tx_fifo_start);
-  tx_fifo_bounds =
-      bitfield_field32_write(tx_fifo_bounds,
-                             (bitfield_field32_t){
-                                 .mask = SPI_DEVICE_TXF_ADDR_LIMIT_MASK,
-                                 .index = SPI_DEVICE_TXF_ADDR_LIMIT_OFFSET,
-                             },
-                             tx_fifo_end);
+  tx_fifo_bounds = bitfield_field32_write(
+      tx_fifo_bounds, SPI_DEVICE_TXF_ADDR_BASE_FIELD, tx_fifo_start);
+  tx_fifo_bounds = bitfield_field32_write(
+      tx_fifo_bounds, SPI_DEVICE_TXF_ADDR_LIMIT_FIELD, tx_fifo_end);
 
   spi->rx_fifo_len = config.rx_fifo_len;
   spi->tx_fifo_len = config.tx_fifo_len;
@@ -305,20 +281,10 @@ dif_spi_device_result_t dif_spi_device_set_irq_levels(
   }
 
   uint32_t compressed_limit = 0;
-  compressed_limit =
-      bitfield_field32_write(compressed_limit,
-                             (bitfield_field32_t){
-                                 .mask = SPI_DEVICE_FIFO_LEVEL_RXLVL_MASK,
-                                 .index = SPI_DEVICE_FIFO_LEVEL_RXLVL_OFFSET,
-                             },
-                             rx_level);
-  compressed_limit =
-      bitfield_field32_write(compressed_limit,
-                             (bitfield_field32_t){
-                                 .mask = SPI_DEVICE_FIFO_LEVEL_TXLVL_MASK,
-                                 .index = SPI_DEVICE_FIFO_LEVEL_TXLVL_OFFSET,
-                             },
-                             tx_level);
+  compressed_limit = bitfield_field32_write(
+      compressed_limit, SPI_DEVICE_FIFO_LEVEL_RXLVL_FIELD, rx_level);
+  compressed_limit = bitfield_field32_write(
+      compressed_limit, SPI_DEVICE_FIFO_LEVEL_TXLVL_FIELD, tx_level);
   mmio_region_write32(spi->params.base_addr, SPI_DEVICE_FIFO_LEVEL_REG_OFFSET,
                       compressed_limit);
 

--- a/sw/device/lib/dif/dif_uart.c
+++ b/sw/device/lib/dif/dif_uart.c
@@ -326,9 +326,6 @@ dif_uart_result_t dif_uart_watermark_rx_set(const dif_uart_t *uart,
 
   // Check if the requested watermark is valid, and get a corresponding
   // register definition to be written.
-  bitfield_field32_t field = {
-      .mask = UART_FIFO_CTRL_RXILVL_MASK, .index = UART_FIFO_CTRL_RXILVL_OFFSET,
-  };
   uint32_t value;
   switch (watermark) {
     case kDifUartWatermarkByte1:
@@ -352,7 +349,8 @@ dif_uart_result_t dif_uart_watermark_rx_set(const dif_uart_t *uart,
 
   // Set watermark level.
   mmio_region_nonatomic_set_field32(uart->params.base_addr,
-                                    UART_FIFO_CTRL_REG_OFFSET, field, value);
+                                    UART_FIFO_CTRL_REG_OFFSET,
+                                    UART_FIFO_CTRL_RXILVL_FIELD, value);
 
   return kDifUartOk;
 }
@@ -365,9 +363,6 @@ dif_uart_result_t dif_uart_watermark_tx_set(const dif_uart_t *uart,
 
   // Check if the requested watermark is valid, and get a corresponding
   // register definition to be written.
-  bitfield_field32_t field = {
-      .mask = UART_FIFO_CTRL_TXILVL_MASK, .index = UART_FIFO_CTRL_TXILVL_OFFSET,
-  };
   uint32_t value;
   switch (watermark) {
     case kDifUartWatermarkByte1:
@@ -389,7 +384,8 @@ dif_uart_result_t dif_uart_watermark_tx_set(const dif_uart_t *uart,
 
   // Set watermark level.
   mmio_region_nonatomic_set_field32(uart->params.base_addr,
-                                    UART_FIFO_CTRL_REG_OFFSET, field, value);
+                                    UART_FIFO_CTRL_REG_OFFSET,
+                                    UART_FIFO_CTRL_TXILVL_FIELD, value);
 
   return kDifUartOk;
 }

--- a/util/reggen/gen_cheader.py
+++ b/util/reggen/gen_cheader.py
@@ -118,6 +118,12 @@ def gen_cdefine_register(outstr, reg, comp, width, rnames, existing_defines):
                     outstr,
                     gen_define(dname + '_OFFSET', [], str(fieldlsb),
                                existing_defines))
+                genout(
+                    outstr,
+                    gen_define(
+                        dname + '_FIELD', [],
+                        '((bitfield_field32_t) {{ .mask = {dname}_MASK, .index = {dname}_OFFSET }})'
+                        .format(dname=dname), existing_defines))
             if 'enum' in field:
                 for enum in field['enum']:
                     ename = as_define(enum['name'])
@@ -260,6 +266,12 @@ def gen_cdefines_interrupt_field(outstr, interrupt, component, regwidth,
                 outstr,
                 gen_define(defname + '_OFFSET', [], str(fieldlsb),
                            existing_defines))
+            genout(
+                outstr,
+                gen_define(
+                    defname + '_FIELD', [],
+                    '((bitfield_field32_t) {{ .mask = {dname}_MASK, .index = {dname}_OFFSET }})'
+                    .format(dname=defname), existing_defines))
 
 
 def gen_cdefines_interrupts(outstr, regs, component, regwidth,


### PR DESCRIPTION
This PR adds new constants to reggen's output. For a non-bit-sized register field, in addition to FIELD_MASK and FIELD_OFFSET, we now generate
```c
#define FIELD_FIELD ((bitfield_field32_t) { .mask = FIELD_MASK, .index = FIELD_OFFSET })
```
Here's what it looks like in a concrete example:
```c
// I2C Format Data
#define I2C_FDATA_REG_OFFSET 0x18
#define I2C_FDATA_FBYTE_MASK 0xff
#define I2C_FDATA_FBYTE_OFFSET 0
#define I2C_FDATA_FBYTE_FIELD \
  ((bitfield_field32_t) { .mask = I2C_FDATA_FBYTE_MASK, .index = I2C_FDATA_FBYTE_OFFSET })
#define I2C_FDATA_START 8
#define I2C_FDATA_STOP 9
#define I2C_FDATA_READ 10
#define I2C_FDATA_RCONT 11
#define I2C_FDATA_NAKOK 12
```

These defines can be used to make quite a bit of C code more concise; migrating existing code is a trivial ctrl-replace, ~~though I kind of want to do them in batches to minimize merge conflicts. This PR includes a change to I2C as a PoC.~~ I went ahead and did all the easy ones in this PR; some others will come as we remove the `nonatomic` MMIO functions.

They are currently not (easily) usable in tests, and that will require a somewhat more invasive approach to mock_mmio.h, but it shouldn't be an onerous change.