### PR TITLE
[keymgr] Fix inter-module signal

### DIFF
--- a/hw/ip/keymgr/data/keymgr.hjson
+++ b/hw/ip/keymgr/data/keymgr.hjson
@@ -21,19 +21,19 @@
 
   // Define keymgr <-> kmac / aes / hmac struct packages
   inter_signal_list: [
-    { struct:  "hw_key",      // aes_key_req_t
+    { struct:  "hw_key_req",  // aes_key_req_t
       type:    "uni",
       name:    "aes_key",     // aes_key_o (req)
       act:     "req",
       package: "keymgr_pkg",  // Origin package (only needs for the requester)
     },
-    { struct:  "hw_key",      // hmac_key_req_t
+    { struct:  "hw_key_req",  // hmac_key_req_t
       type:    "uni",
       name:    "hmac_key",    // hmac_key_o (req)
       act:     "req",
       package: "keymgr_pkg",  // Origin package (only needs for the requester)
     },
-    { struct:  "hw_key",      // kmac_key_req_t
+    { struct:  "hw_key_req",  // kmac_key_req_t
       type:    "uni",
       name:    "kmac_key",    // kmac_key_o (req)
       act:     "req",

--- a/hw/ip/keymgr/rtl/keymgr_pkg.sv
+++ b/hw/ip/keymgr/rtl/keymgr_pkg.sv
@@ -108,6 +108,12 @@ package keymgr_pkg;
     logic [KeyWidth-1:0] key_share1;
   } hw_key_req_t;
 
+  parameter hw_key_req_t HW_KEY_REQ_DEFAULT = '{
+    valid: 1'b0,
+    key_share0: KeyWidth'(32'hDEADBEEF),
+    key_share1: KeyWidth'(32'hFACEBEEF)
+  };
+
   typedef struct packed {
     logic valid;
     logic [KmacDataIfWidth-1:0] data;

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -2621,7 +2621,7 @@
       inter_signal_list:
       [
         {
-          struct: hw_key
+          struct: hw_key_req
           type: uni
           name: aes_key
           act: req
@@ -2630,7 +2630,7 @@
           index: -1
         }
         {
-          struct: hw_key
+          struct: hw_key_req
           type: uni
           name: hmac_key
           act: req
@@ -2639,7 +2639,7 @@
           index: -1
         }
         {
-          struct: hw_key
+          struct: hw_key_req
           type: uni
           name: kmac_key
           act: req
@@ -6460,7 +6460,7 @@
         index: -1
       }
       {
-        struct: hw_key
+        struct: hw_key_req
         type: uni
         name: aes_key
         act: req
@@ -6469,7 +6469,7 @@
         index: -1
       }
       {
-        struct: hw_key
+        struct: hw_key_req
         type: uni
         name: hmac_key
         act: req
@@ -6478,7 +6478,7 @@
         index: -1
       }
       {
-        struct: hw_key
+        struct: hw_key_req
         type: uni
         name: kmac_key
         act: req


### PR DESCRIPTION
`hw_key_req_t` is a uni-directional im signal. The keymgr.hjson defines
the struct as `hw_key`. It should be `hw_key_req`.

Also added the default signal of `hw_key_req_t`.