### PR TITLE
[kmac] Add `idle_o` signal

### DIFF
--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -70,6 +70,13 @@
       act:     "rsp"
       package: "keymgr_pkg"
     }
+    { name:    "idle",
+      type:    "uni",
+      act:     "req",
+      package: "",
+      struct:  "logic",
+      width:   "1"
+    }
   ]
   regwidth: "32"
   registers: [


### PR DESCRIPTION
clkmgr IP uses `idle_o` to check if the IP is in idle state in order to
turn off the clock safely. KMAC IP missed the mandated signal.