### PR TITLE
[kmac] Re-order CFG_REGWEN register

### DIFF
--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -80,6 +80,26 @@
   ]
   regwidth: "32"
   registers: [
+    { name: "CFG_REGWEN"
+      desc: '''Controls the configurability of !!CFG register.
+
+            This register ensures the contents of !!CFG register cannot be
+            changed by the software while the KMAC/SHA3 is in operation mode.
+            '''
+      swaccess: "ro"
+      hwaccess: "hwo"
+      hwext: "true"
+      fields: [
+        { bits: "0"
+          name: "en"
+          desc: "Configuration enable."
+          resval: "1"
+        } // f : en 
+      ]
+      tags: [// This regwen is completely under HW management and thus cannot be manipulated
+             // by software.
+             "excl:CsrNonInitTests:CsrExclCheck"]
+    } // R : CFG_REGWEN
     { name: "CFG"
       desc: '''KMAC Configuration register.
 
@@ -436,27 +456,6 @@
         }
       ]
     } // R: ERR_CODE
-    { name: "CFG_REGWEN"
-      desc: '''Controls the configurability of !!CFG register.
-
-            This register ensures the contents of !!CFG register cannot be
-            changed by the software while the KMAC/SHA3 is in operation mode.
-            '''
-      swaccess: "ro"
-      hwaccess: "hwo"
-      hwext: "true"
-      fields: [
-        { bits: "0"
-          name: "en"
-          desc: "Configuration enable."
-          resval: "1"
-        } // f : en 
-      ]
-      tags: [// This regwen is completely under HW management and thus cannot be manipulated
-             // by software.
-             "excl:CsrNonInitTests:CsrExclCheck"]
-    } // R : CFG_REGWEN
-
     { skipto: "0x400"}
     { window: {
         name: "STATE"

--- a/hw/ip/kmac/rtl/kmac_reg_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_pkg.sv
@@ -113,6 +113,10 @@ package kmac_reg_pkg;
   } kmac_hw2reg_intr_state_reg_t;
 
   typedef struct packed {
+    logic        d;
+  } kmac_hw2reg_cfg_regwen_reg_t;
+
+  typedef struct packed {
     struct packed {
       logic        d;
     } sha3_idle;
@@ -138,10 +142,6 @@ package kmac_reg_pkg;
     logic        de;
   } kmac_hw2reg_err_code_reg_t;
 
-  typedef struct packed {
-    logic        d;
-  } kmac_hw2reg_cfg_regwen_reg_t;
-
 
   ///////////////////////////////////////
   // Register to internal design logic //
@@ -163,64 +163,64 @@ package kmac_reg_pkg;
   ///////////////////////////////////////
   typedef struct packed {
     kmac_hw2reg_intr_state_reg_t intr_state; // [49:47]
+    kmac_hw2reg_cfg_regwen_reg_t cfg_regwen; // [46:47]
     kmac_hw2reg_status_reg_t status; // [46:47]
     kmac_hw2reg_err_code_reg_t err_code; // [46:47]
-    kmac_hw2reg_cfg_regwen_reg_t cfg_regwen; // [46:47]
   } kmac_hw2reg_t;
 
   // Register Address
   parameter logic [11:0] KMAC_INTR_STATE_OFFSET = 12'h 0;
   parameter logic [11:0] KMAC_INTR_ENABLE_OFFSET = 12'h 4;
   parameter logic [11:0] KMAC_INTR_TEST_OFFSET = 12'h 8;
-  parameter logic [11:0] KMAC_CFG_OFFSET = 12'h c;
-  parameter logic [11:0] KMAC_CMD_OFFSET = 12'h 10;
-  parameter logic [11:0] KMAC_STATUS_OFFSET = 12'h 14;
-  parameter logic [11:0] KMAC_KEY_SHARE0_0_OFFSET = 12'h 18;
-  parameter logic [11:0] KMAC_KEY_SHARE0_1_OFFSET = 12'h 1c;
-  parameter logic [11:0] KMAC_KEY_SHARE0_2_OFFSET = 12'h 20;
-  parameter logic [11:0] KMAC_KEY_SHARE0_3_OFFSET = 12'h 24;
-  parameter logic [11:0] KMAC_KEY_SHARE0_4_OFFSET = 12'h 28;
-  parameter logic [11:0] KMAC_KEY_SHARE0_5_OFFSET = 12'h 2c;
-  parameter logic [11:0] KMAC_KEY_SHARE0_6_OFFSET = 12'h 30;
-  parameter logic [11:0] KMAC_KEY_SHARE0_7_OFFSET = 12'h 34;
-  parameter logic [11:0] KMAC_KEY_SHARE0_8_OFFSET = 12'h 38;
-  parameter logic [11:0] KMAC_KEY_SHARE0_9_OFFSET = 12'h 3c;
-  parameter logic [11:0] KMAC_KEY_SHARE0_10_OFFSET = 12'h 40;
-  parameter logic [11:0] KMAC_KEY_SHARE0_11_OFFSET = 12'h 44;
-  parameter logic [11:0] KMAC_KEY_SHARE0_12_OFFSET = 12'h 48;
-  parameter logic [11:0] KMAC_KEY_SHARE0_13_OFFSET = 12'h 4c;
-  parameter logic [11:0] KMAC_KEY_SHARE0_14_OFFSET = 12'h 50;
-  parameter logic [11:0] KMAC_KEY_SHARE0_15_OFFSET = 12'h 54;
-  parameter logic [11:0] KMAC_KEY_SHARE1_0_OFFSET = 12'h 58;
-  parameter logic [11:0] KMAC_KEY_SHARE1_1_OFFSET = 12'h 5c;
-  parameter logic [11:0] KMAC_KEY_SHARE1_2_OFFSET = 12'h 60;
-  parameter logic [11:0] KMAC_KEY_SHARE1_3_OFFSET = 12'h 64;
-  parameter logic [11:0] KMAC_KEY_SHARE1_4_OFFSET = 12'h 68;
-  parameter logic [11:0] KMAC_KEY_SHARE1_5_OFFSET = 12'h 6c;
-  parameter logic [11:0] KMAC_KEY_SHARE1_6_OFFSET = 12'h 70;
-  parameter logic [11:0] KMAC_KEY_SHARE1_7_OFFSET = 12'h 74;
-  parameter logic [11:0] KMAC_KEY_SHARE1_8_OFFSET = 12'h 78;
-  parameter logic [11:0] KMAC_KEY_SHARE1_9_OFFSET = 12'h 7c;
-  parameter logic [11:0] KMAC_KEY_SHARE1_10_OFFSET = 12'h 80;
-  parameter logic [11:0] KMAC_KEY_SHARE1_11_OFFSET = 12'h 84;
-  parameter logic [11:0] KMAC_KEY_SHARE1_12_OFFSET = 12'h 88;
-  parameter logic [11:0] KMAC_KEY_SHARE1_13_OFFSET = 12'h 8c;
-  parameter logic [11:0] KMAC_KEY_SHARE1_14_OFFSET = 12'h 90;
-  parameter logic [11:0] KMAC_KEY_SHARE1_15_OFFSET = 12'h 94;
-  parameter logic [11:0] KMAC_KEY_LEN_OFFSET = 12'h 98;
-  parameter logic [11:0] KMAC_PREFIX_0_OFFSET = 12'h 9c;
-  parameter logic [11:0] KMAC_PREFIX_1_OFFSET = 12'h a0;
-  parameter logic [11:0] KMAC_PREFIX_2_OFFSET = 12'h a4;
-  parameter logic [11:0] KMAC_PREFIX_3_OFFSET = 12'h a8;
-  parameter logic [11:0] KMAC_PREFIX_4_OFFSET = 12'h ac;
-  parameter logic [11:0] KMAC_PREFIX_5_OFFSET = 12'h b0;
-  parameter logic [11:0] KMAC_PREFIX_6_OFFSET = 12'h b4;
-  parameter logic [11:0] KMAC_PREFIX_7_OFFSET = 12'h b8;
-  parameter logic [11:0] KMAC_PREFIX_8_OFFSET = 12'h bc;
-  parameter logic [11:0] KMAC_PREFIX_9_OFFSET = 12'h c0;
-  parameter logic [11:0] KMAC_PREFIX_10_OFFSET = 12'h c4;
-  parameter logic [11:0] KMAC_ERR_CODE_OFFSET = 12'h c8;
-  parameter logic [11:0] KMAC_CFG_REGWEN_OFFSET = 12'h cc;
+  parameter logic [11:0] KMAC_CFG_REGWEN_OFFSET = 12'h c;
+  parameter logic [11:0] KMAC_CFG_OFFSET = 12'h 10;
+  parameter logic [11:0] KMAC_CMD_OFFSET = 12'h 14;
+  parameter logic [11:0] KMAC_STATUS_OFFSET = 12'h 18;
+  parameter logic [11:0] KMAC_KEY_SHARE0_0_OFFSET = 12'h 1c;
+  parameter logic [11:0] KMAC_KEY_SHARE0_1_OFFSET = 12'h 20;
+  parameter logic [11:0] KMAC_KEY_SHARE0_2_OFFSET = 12'h 24;
+  parameter logic [11:0] KMAC_KEY_SHARE0_3_OFFSET = 12'h 28;
+  parameter logic [11:0] KMAC_KEY_SHARE0_4_OFFSET = 12'h 2c;
+  parameter logic [11:0] KMAC_KEY_SHARE0_5_OFFSET = 12'h 30;
+  parameter logic [11:0] KMAC_KEY_SHARE0_6_OFFSET = 12'h 34;
+  parameter logic [11:0] KMAC_KEY_SHARE0_7_OFFSET = 12'h 38;
+  parameter logic [11:0] KMAC_KEY_SHARE0_8_OFFSET = 12'h 3c;
+  parameter logic [11:0] KMAC_KEY_SHARE0_9_OFFSET = 12'h 40;
+  parameter logic [11:0] KMAC_KEY_SHARE0_10_OFFSET = 12'h 44;
+  parameter logic [11:0] KMAC_KEY_SHARE0_11_OFFSET = 12'h 48;
+  parameter logic [11:0] KMAC_KEY_SHARE0_12_OFFSET = 12'h 4c;
+  parameter logic [11:0] KMAC_KEY_SHARE0_13_OFFSET = 12'h 50;
+  parameter logic [11:0] KMAC_KEY_SHARE0_14_OFFSET = 12'h 54;
+  parameter logic [11:0] KMAC_KEY_SHARE0_15_OFFSET = 12'h 58;
+  parameter logic [11:0] KMAC_KEY_SHARE1_0_OFFSET = 12'h 5c;
+  parameter logic [11:0] KMAC_KEY_SHARE1_1_OFFSET = 12'h 60;
+  parameter logic [11:0] KMAC_KEY_SHARE1_2_OFFSET = 12'h 64;
+  parameter logic [11:0] KMAC_KEY_SHARE1_3_OFFSET = 12'h 68;
+  parameter logic [11:0] KMAC_KEY_SHARE1_4_OFFSET = 12'h 6c;
+  parameter logic [11:0] KMAC_KEY_SHARE1_5_OFFSET = 12'h 70;
+  parameter logic [11:0] KMAC_KEY_SHARE1_6_OFFSET = 12'h 74;
+  parameter logic [11:0] KMAC_KEY_SHARE1_7_OFFSET = 12'h 78;
+  parameter logic [11:0] KMAC_KEY_SHARE1_8_OFFSET = 12'h 7c;
+  parameter logic [11:0] KMAC_KEY_SHARE1_9_OFFSET = 12'h 80;
+  parameter logic [11:0] KMAC_KEY_SHARE1_10_OFFSET = 12'h 84;
+  parameter logic [11:0] KMAC_KEY_SHARE1_11_OFFSET = 12'h 88;
+  parameter logic [11:0] KMAC_KEY_SHARE1_12_OFFSET = 12'h 8c;
+  parameter logic [11:0] KMAC_KEY_SHARE1_13_OFFSET = 12'h 90;
+  parameter logic [11:0] KMAC_KEY_SHARE1_14_OFFSET = 12'h 94;
+  parameter logic [11:0] KMAC_KEY_SHARE1_15_OFFSET = 12'h 98;
+  parameter logic [11:0] KMAC_KEY_LEN_OFFSET = 12'h 9c;
+  parameter logic [11:0] KMAC_PREFIX_0_OFFSET = 12'h a0;
+  parameter logic [11:0] KMAC_PREFIX_1_OFFSET = 12'h a4;
+  parameter logic [11:0] KMAC_PREFIX_2_OFFSET = 12'h a8;
+  parameter logic [11:0] KMAC_PREFIX_3_OFFSET = 12'h ac;
+  parameter logic [11:0] KMAC_PREFIX_4_OFFSET = 12'h b0;
+  parameter logic [11:0] KMAC_PREFIX_5_OFFSET = 12'h b4;
+  parameter logic [11:0] KMAC_PREFIX_6_OFFSET = 12'h b8;
+  parameter logic [11:0] KMAC_PREFIX_7_OFFSET = 12'h bc;
+  parameter logic [11:0] KMAC_PREFIX_8_OFFSET = 12'h c0;
+  parameter logic [11:0] KMAC_PREFIX_9_OFFSET = 12'h c4;
+  parameter logic [11:0] KMAC_PREFIX_10_OFFSET = 12'h c8;
+  parameter logic [11:0] KMAC_ERR_CODE_OFFSET = 12'h cc;
 
   // Window parameter
   parameter logic [11:0] KMAC_STATE_OFFSET = 12'h 400;
@@ -233,6 +233,7 @@ package kmac_reg_pkg;
     KMAC_INTR_STATE,
     KMAC_INTR_ENABLE,
     KMAC_INTR_TEST,
+    KMAC_CFG_REGWEN,
     KMAC_CFG,
     KMAC_CMD,
     KMAC_STATUS,
@@ -280,8 +281,7 @@ package kmac_reg_pkg;
     KMAC_PREFIX_8,
     KMAC_PREFIX_9,
     KMAC_PREFIX_10,
-    KMAC_ERR_CODE,
-    KMAC_CFG_REGWEN
+    KMAC_ERR_CODE
   } kmac_id_e;
 
   // Register width information to check illegal writes
@@ -289,55 +289,55 @@ package kmac_reg_pkg;
     4'b 0001, // index[ 0] KMAC_INTR_STATE
     4'b 0001, // index[ 1] KMAC_INTR_ENABLE
     4'b 0001, // index[ 2] KMAC_INTR_TEST
-    4'b 0011, // index[ 3] KMAC_CFG
-    4'b 0001, // index[ 4] KMAC_CMD
-    4'b 0011, // index[ 5] KMAC_STATUS
-    4'b 1111, // index[ 6] KMAC_KEY_SHARE0_0
-    4'b 1111, // index[ 7] KMAC_KEY_SHARE0_1
-    4'b 1111, // index[ 8] KMAC_KEY_SHARE0_2
-    4'b 1111, // index[ 9] KMAC_KEY_SHARE0_3
-    4'b 1111, // index[10] KMAC_KEY_SHARE0_4
-    4'b 1111, // index[11] KMAC_KEY_SHARE0_5
-    4'b 1111, // index[12] KMAC_KEY_SHARE0_6
-    4'b 1111, // index[13] KMAC_KEY_SHARE0_7
-    4'b 1111, // index[14] KMAC_KEY_SHARE0_8
-    4'b 1111, // index[15] KMAC_KEY_SHARE0_9
-    4'b 1111, // index[16] KMAC_KEY_SHARE0_10
-    4'b 1111, // index[17] KMAC_KEY_SHARE0_11
-    4'b 1111, // index[18] KMAC_KEY_SHARE0_12
-    4'b 1111, // index[19] KMAC_KEY_SHARE0_13
-    4'b 1111, // index[20] KMAC_KEY_SHARE0_14
-    4'b 1111, // index[21] KMAC_KEY_SHARE0_15
-    4'b 1111, // index[22] KMAC_KEY_SHARE1_0
-    4'b 1111, // index[23] KMAC_KEY_SHARE1_1
-    4'b 1111, // index[24] KMAC_KEY_SHARE1_2
-    4'b 1111, // index[25] KMAC_KEY_SHARE1_3
-    4'b 1111, // index[26] KMAC_KEY_SHARE1_4
-    4'b 1111, // index[27] KMAC_KEY_SHARE1_5
-    4'b 1111, // index[28] KMAC_KEY_SHARE1_6
-    4'b 1111, // index[29] KMAC_KEY_SHARE1_7
-    4'b 1111, // index[30] KMAC_KEY_SHARE1_8
-    4'b 1111, // index[31] KMAC_KEY_SHARE1_9
-    4'b 1111, // index[32] KMAC_KEY_SHARE1_10
-    4'b 1111, // index[33] KMAC_KEY_SHARE1_11
-    4'b 1111, // index[34] KMAC_KEY_SHARE1_12
-    4'b 1111, // index[35] KMAC_KEY_SHARE1_13
-    4'b 1111, // index[36] KMAC_KEY_SHARE1_14
-    4'b 1111, // index[37] KMAC_KEY_SHARE1_15
-    4'b 0001, // index[38] KMAC_KEY_LEN
-    4'b 1111, // index[39] KMAC_PREFIX_0
-    4'b 1111, // index[40] KMAC_PREFIX_1
-    4'b 1111, // index[41] KMAC_PREFIX_2
-    4'b 1111, // index[42] KMAC_PREFIX_3
-    4'b 1111, // index[43] KMAC_PREFIX_4
-    4'b 1111, // index[44] KMAC_PREFIX_5
-    4'b 1111, // index[45] KMAC_PREFIX_6
-    4'b 1111, // index[46] KMAC_PREFIX_7
-    4'b 1111, // index[47] KMAC_PREFIX_8
-    4'b 1111, // index[48] KMAC_PREFIX_9
-    4'b 1111, // index[49] KMAC_PREFIX_10
-    4'b 1111, // index[50] KMAC_ERR_CODE
-    4'b 0001  // index[51] KMAC_CFG_REGWEN
+    4'b 0001, // index[ 3] KMAC_CFG_REGWEN
+    4'b 0011, // index[ 4] KMAC_CFG
+    4'b 0001, // index[ 5] KMAC_CMD
+    4'b 0011, // index[ 6] KMAC_STATUS
+    4'b 1111, // index[ 7] KMAC_KEY_SHARE0_0
+    4'b 1111, // index[ 8] KMAC_KEY_SHARE0_1
+    4'b 1111, // index[ 9] KMAC_KEY_SHARE0_2
+    4'b 1111, // index[10] KMAC_KEY_SHARE0_3
+    4'b 1111, // index[11] KMAC_KEY_SHARE0_4
+    4'b 1111, // index[12] KMAC_KEY_SHARE0_5
+    4'b 1111, // index[13] KMAC_KEY_SHARE0_6
+    4'b 1111, // index[14] KMAC_KEY_SHARE0_7
+    4'b 1111, // index[15] KMAC_KEY_SHARE0_8
+    4'b 1111, // index[16] KMAC_KEY_SHARE0_9
+    4'b 1111, // index[17] KMAC_KEY_SHARE0_10
+    4'b 1111, // index[18] KMAC_KEY_SHARE0_11
+    4'b 1111, // index[19] KMAC_KEY_SHARE0_12
+    4'b 1111, // index[20] KMAC_KEY_SHARE0_13
+    4'b 1111, // index[21] KMAC_KEY_SHARE0_14
+    4'b 1111, // index[22] KMAC_KEY_SHARE0_15
+    4'b 1111, // index[23] KMAC_KEY_SHARE1_0
+    4'b 1111, // index[24] KMAC_KEY_SHARE1_1
+    4'b 1111, // index[25] KMAC_KEY_SHARE1_2
+    4'b 1111, // index[26] KMAC_KEY_SHARE1_3
+    4'b 1111, // index[27] KMAC_KEY_SHARE1_4
+    4'b 1111, // index[28] KMAC_KEY_SHARE1_5
+    4'b 1111, // index[29] KMAC_KEY_SHARE1_6
+    4'b 1111, // index[30] KMAC_KEY_SHARE1_7
+    4'b 1111, // index[31] KMAC_KEY_SHARE1_8
+    4'b 1111, // index[32] KMAC_KEY_SHARE1_9
+    4'b 1111, // index[33] KMAC_KEY_SHARE1_10
+    4'b 1111, // index[34] KMAC_KEY_SHARE1_11
+    4'b 1111, // index[35] KMAC_KEY_SHARE1_12
+    4'b 1111, // index[36] KMAC_KEY_SHARE1_13
+    4'b 1111, // index[37] KMAC_KEY_SHARE1_14
+    4'b 1111, // index[38] KMAC_KEY_SHARE1_15
+    4'b 0001, // index[39] KMAC_KEY_LEN
+    4'b 1111, // index[40] KMAC_PREFIX_0
+    4'b 1111, // index[41] KMAC_PREFIX_1
+    4'b 1111, // index[42] KMAC_PREFIX_2
+    4'b 1111, // index[43] KMAC_PREFIX_3
+    4'b 1111, // index[44] KMAC_PREFIX_4
+    4'b 1111, // index[45] KMAC_PREFIX_5
+    4'b 1111, // index[46] KMAC_PREFIX_6
+    4'b 1111, // index[47] KMAC_PREFIX_7
+    4'b 1111, // index[48] KMAC_PREFIX_8
+    4'b 1111, // index[49] KMAC_PREFIX_9
+    4'b 1111, // index[50] KMAC_PREFIX_10
+    4'b 1111  // index[51] KMAC_ERR_CODE
   };
 endpackage
 

--- a/hw/ip/kmac/rtl/kmac_reg_top.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_top.sv
@@ -146,6 +146,8 @@ module kmac_reg_top (
   logic intr_test_fifo_empty_we;
   logic intr_test_kmac_err_wd;
   logic intr_test_kmac_err_we;
+  logic cfg_regwen_qs;
+  logic cfg_regwen_re;
   logic cfg_kmac_en_qs;
   logic cfg_kmac_en_wd;
   logic cfg_kmac_en_we;
@@ -278,8 +280,6 @@ module kmac_reg_top (
   logic [31:0] prefix_10_wd;
   logic prefix_10_we;
   logic [31:0] err_code_qs;
-  logic cfg_regwen_qs;
-  logic cfg_regwen_re;
 
   // Register instances
   // R[intr_state]: V(False)
@@ -486,6 +486,22 @@ module kmac_reg_top (
     .qe     (reg2hw.intr_test.kmac_err.qe),
     .q      (reg2hw.intr_test.kmac_err.q ),
     .qs     ()
+  );
+
+
+  // R[cfg_regwen]: V(True)
+
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_cfg_regwen (
+    .re     (cfg_regwen_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.cfg_regwen.d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (cfg_regwen_qs)
   );
 
 
@@ -1622,22 +1638,6 @@ module kmac_reg_top (
   );
 
 
-  // R[cfg_regwen]: V(True)
-
-  prim_subreg_ext #(
-    .DW    (1)
-  ) u_cfg_regwen (
-    .re     (cfg_regwen_re),
-    .we     (1'b0),
-    .wd     ('0),
-    .d      (hw2reg.cfg_regwen.d),
-    .qre    (),
-    .qe     (),
-    .q      (),
-    .qs     (cfg_regwen_qs)
-  );
-
-
 
 
   logic [51:0] addr_hit;
@@ -1646,55 +1646,55 @@ module kmac_reg_top (
     addr_hit[ 0] = (reg_addr == KMAC_INTR_STATE_OFFSET);
     addr_hit[ 1] = (reg_addr == KMAC_INTR_ENABLE_OFFSET);
     addr_hit[ 2] = (reg_addr == KMAC_INTR_TEST_OFFSET);
-    addr_hit[ 3] = (reg_addr == KMAC_CFG_OFFSET);
-    addr_hit[ 4] = (reg_addr == KMAC_CMD_OFFSET);
-    addr_hit[ 5] = (reg_addr == KMAC_STATUS_OFFSET);
-    addr_hit[ 6] = (reg_addr == KMAC_KEY_SHARE0_0_OFFSET);
-    addr_hit[ 7] = (reg_addr == KMAC_KEY_SHARE0_1_OFFSET);
-    addr_hit[ 8] = (reg_addr == KMAC_KEY_SHARE0_2_OFFSET);
-    addr_hit[ 9] = (reg_addr == KMAC_KEY_SHARE0_3_OFFSET);
-    addr_hit[10] = (reg_addr == KMAC_KEY_SHARE0_4_OFFSET);
-    addr_hit[11] = (reg_addr == KMAC_KEY_SHARE0_5_OFFSET);
-    addr_hit[12] = (reg_addr == KMAC_KEY_SHARE0_6_OFFSET);
-    addr_hit[13] = (reg_addr == KMAC_KEY_SHARE0_7_OFFSET);
-    addr_hit[14] = (reg_addr == KMAC_KEY_SHARE0_8_OFFSET);
-    addr_hit[15] = (reg_addr == KMAC_KEY_SHARE0_9_OFFSET);
-    addr_hit[16] = (reg_addr == KMAC_KEY_SHARE0_10_OFFSET);
-    addr_hit[17] = (reg_addr == KMAC_KEY_SHARE0_11_OFFSET);
-    addr_hit[18] = (reg_addr == KMAC_KEY_SHARE0_12_OFFSET);
-    addr_hit[19] = (reg_addr == KMAC_KEY_SHARE0_13_OFFSET);
-    addr_hit[20] = (reg_addr == KMAC_KEY_SHARE0_14_OFFSET);
-    addr_hit[21] = (reg_addr == KMAC_KEY_SHARE0_15_OFFSET);
-    addr_hit[22] = (reg_addr == KMAC_KEY_SHARE1_0_OFFSET);
-    addr_hit[23] = (reg_addr == KMAC_KEY_SHARE1_1_OFFSET);
-    addr_hit[24] = (reg_addr == KMAC_KEY_SHARE1_2_OFFSET);
-    addr_hit[25] = (reg_addr == KMAC_KEY_SHARE1_3_OFFSET);
-    addr_hit[26] = (reg_addr == KMAC_KEY_SHARE1_4_OFFSET);
-    addr_hit[27] = (reg_addr == KMAC_KEY_SHARE1_5_OFFSET);
-    addr_hit[28] = (reg_addr == KMAC_KEY_SHARE1_6_OFFSET);
-    addr_hit[29] = (reg_addr == KMAC_KEY_SHARE1_7_OFFSET);
-    addr_hit[30] = (reg_addr == KMAC_KEY_SHARE1_8_OFFSET);
-    addr_hit[31] = (reg_addr == KMAC_KEY_SHARE1_9_OFFSET);
-    addr_hit[32] = (reg_addr == KMAC_KEY_SHARE1_10_OFFSET);
-    addr_hit[33] = (reg_addr == KMAC_KEY_SHARE1_11_OFFSET);
-    addr_hit[34] = (reg_addr == KMAC_KEY_SHARE1_12_OFFSET);
-    addr_hit[35] = (reg_addr == KMAC_KEY_SHARE1_13_OFFSET);
-    addr_hit[36] = (reg_addr == KMAC_KEY_SHARE1_14_OFFSET);
-    addr_hit[37] = (reg_addr == KMAC_KEY_SHARE1_15_OFFSET);
-    addr_hit[38] = (reg_addr == KMAC_KEY_LEN_OFFSET);
-    addr_hit[39] = (reg_addr == KMAC_PREFIX_0_OFFSET);
-    addr_hit[40] = (reg_addr == KMAC_PREFIX_1_OFFSET);
-    addr_hit[41] = (reg_addr == KMAC_PREFIX_2_OFFSET);
-    addr_hit[42] = (reg_addr == KMAC_PREFIX_3_OFFSET);
-    addr_hit[43] = (reg_addr == KMAC_PREFIX_4_OFFSET);
-    addr_hit[44] = (reg_addr == KMAC_PREFIX_5_OFFSET);
-    addr_hit[45] = (reg_addr == KMAC_PREFIX_6_OFFSET);
-    addr_hit[46] = (reg_addr == KMAC_PREFIX_7_OFFSET);
-    addr_hit[47] = (reg_addr == KMAC_PREFIX_8_OFFSET);
-    addr_hit[48] = (reg_addr == KMAC_PREFIX_9_OFFSET);
-    addr_hit[49] = (reg_addr == KMAC_PREFIX_10_OFFSET);
-    addr_hit[50] = (reg_addr == KMAC_ERR_CODE_OFFSET);
-    addr_hit[51] = (reg_addr == KMAC_CFG_REGWEN_OFFSET);
+    addr_hit[ 3] = (reg_addr == KMAC_CFG_REGWEN_OFFSET);
+    addr_hit[ 4] = (reg_addr == KMAC_CFG_OFFSET);
+    addr_hit[ 5] = (reg_addr == KMAC_CMD_OFFSET);
+    addr_hit[ 6] = (reg_addr == KMAC_STATUS_OFFSET);
+    addr_hit[ 7] = (reg_addr == KMAC_KEY_SHARE0_0_OFFSET);
+    addr_hit[ 8] = (reg_addr == KMAC_KEY_SHARE0_1_OFFSET);
+    addr_hit[ 9] = (reg_addr == KMAC_KEY_SHARE0_2_OFFSET);
+    addr_hit[10] = (reg_addr == KMAC_KEY_SHARE0_3_OFFSET);
+    addr_hit[11] = (reg_addr == KMAC_KEY_SHARE0_4_OFFSET);
+    addr_hit[12] = (reg_addr == KMAC_KEY_SHARE0_5_OFFSET);
+    addr_hit[13] = (reg_addr == KMAC_KEY_SHARE0_6_OFFSET);
+    addr_hit[14] = (reg_addr == KMAC_KEY_SHARE0_7_OFFSET);
+    addr_hit[15] = (reg_addr == KMAC_KEY_SHARE0_8_OFFSET);
+    addr_hit[16] = (reg_addr == KMAC_KEY_SHARE0_9_OFFSET);
+    addr_hit[17] = (reg_addr == KMAC_KEY_SHARE0_10_OFFSET);
+    addr_hit[18] = (reg_addr == KMAC_KEY_SHARE0_11_OFFSET);
+    addr_hit[19] = (reg_addr == KMAC_KEY_SHARE0_12_OFFSET);
+    addr_hit[20] = (reg_addr == KMAC_KEY_SHARE0_13_OFFSET);
+    addr_hit[21] = (reg_addr == KMAC_KEY_SHARE0_14_OFFSET);
+    addr_hit[22] = (reg_addr == KMAC_KEY_SHARE0_15_OFFSET);
+    addr_hit[23] = (reg_addr == KMAC_KEY_SHARE1_0_OFFSET);
+    addr_hit[24] = (reg_addr == KMAC_KEY_SHARE1_1_OFFSET);
+    addr_hit[25] = (reg_addr == KMAC_KEY_SHARE1_2_OFFSET);
+    addr_hit[26] = (reg_addr == KMAC_KEY_SHARE1_3_OFFSET);
+    addr_hit[27] = (reg_addr == KMAC_KEY_SHARE1_4_OFFSET);
+    addr_hit[28] = (reg_addr == KMAC_KEY_SHARE1_5_OFFSET);
+    addr_hit[29] = (reg_addr == KMAC_KEY_SHARE1_6_OFFSET);
+    addr_hit[30] = (reg_addr == KMAC_KEY_SHARE1_7_OFFSET);
+    addr_hit[31] = (reg_addr == KMAC_KEY_SHARE1_8_OFFSET);
+    addr_hit[32] = (reg_addr == KMAC_KEY_SHARE1_9_OFFSET);
+    addr_hit[33] = (reg_addr == KMAC_KEY_SHARE1_10_OFFSET);
+    addr_hit[34] = (reg_addr == KMAC_KEY_SHARE1_11_OFFSET);
+    addr_hit[35] = (reg_addr == KMAC_KEY_SHARE1_12_OFFSET);
+    addr_hit[36] = (reg_addr == KMAC_KEY_SHARE1_13_OFFSET);
+    addr_hit[37] = (reg_addr == KMAC_KEY_SHARE1_14_OFFSET);
+    addr_hit[38] = (reg_addr == KMAC_KEY_SHARE1_15_OFFSET);
+    addr_hit[39] = (reg_addr == KMAC_KEY_LEN_OFFSET);
+    addr_hit[40] = (reg_addr == KMAC_PREFIX_0_OFFSET);
+    addr_hit[41] = (reg_addr == KMAC_PREFIX_1_OFFSET);
+    addr_hit[42] = (reg_addr == KMAC_PREFIX_2_OFFSET);
+    addr_hit[43] = (reg_addr == KMAC_PREFIX_3_OFFSET);
+    addr_hit[44] = (reg_addr == KMAC_PREFIX_4_OFFSET);
+    addr_hit[45] = (reg_addr == KMAC_PREFIX_5_OFFSET);
+    addr_hit[46] = (reg_addr == KMAC_PREFIX_6_OFFSET);
+    addr_hit[47] = (reg_addr == KMAC_PREFIX_7_OFFSET);
+    addr_hit[48] = (reg_addr == KMAC_PREFIX_8_OFFSET);
+    addr_hit[49] = (reg_addr == KMAC_PREFIX_9_OFFSET);
+    addr_hit[50] = (reg_addr == KMAC_PREFIX_10_OFFSET);
+    addr_hit[51] = (reg_addr == KMAC_ERR_CODE_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -1783,173 +1783,173 @@ module kmac_reg_top (
   assign intr_test_kmac_err_we = addr_hit[2] & reg_we & ~wr_err;
   assign intr_test_kmac_err_wd = reg_wdata[2];
 
-  assign cfg_kmac_en_we = addr_hit[3] & reg_we & ~wr_err;
+  assign cfg_regwen_re = addr_hit[3] && reg_re;
+
+  assign cfg_kmac_en_we = addr_hit[4] & reg_we & ~wr_err;
   assign cfg_kmac_en_wd = reg_wdata[0];
 
-  assign cfg_kstrength_we = addr_hit[3] & reg_we & ~wr_err;
+  assign cfg_kstrength_we = addr_hit[4] & reg_we & ~wr_err;
   assign cfg_kstrength_wd = reg_wdata[3:1];
 
-  assign cfg_mode_we = addr_hit[3] & reg_we & ~wr_err;
+  assign cfg_mode_we = addr_hit[4] & reg_we & ~wr_err;
   assign cfg_mode_wd = reg_wdata[5:4];
 
-  assign cfg_msg_endianness_we = addr_hit[3] & reg_we & ~wr_err;
+  assign cfg_msg_endianness_we = addr_hit[4] & reg_we & ~wr_err;
   assign cfg_msg_endianness_wd = reg_wdata[8];
 
-  assign cfg_state_endianness_we = addr_hit[3] & reg_we & ~wr_err;
+  assign cfg_state_endianness_we = addr_hit[4] & reg_we & ~wr_err;
   assign cfg_state_endianness_wd = reg_wdata[9];
 
-  assign cfg_sideload_we = addr_hit[3] & reg_we & ~wr_err;
+  assign cfg_sideload_we = addr_hit[4] & reg_we & ~wr_err;
   assign cfg_sideload_wd = reg_wdata[12];
 
-  assign cmd_we = addr_hit[4] & reg_we & ~wr_err;
+  assign cmd_we = addr_hit[5] & reg_we & ~wr_err;
   assign cmd_wd = reg_wdata[3:0];
 
-  assign status_sha3_idle_re = addr_hit[5] && reg_re;
+  assign status_sha3_idle_re = addr_hit[6] && reg_re;
 
-  assign status_sha3_absorb_re = addr_hit[5] && reg_re;
+  assign status_sha3_absorb_re = addr_hit[6] && reg_re;
 
-  assign status_sha3_squeeze_re = addr_hit[5] && reg_re;
+  assign status_sha3_squeeze_re = addr_hit[6] && reg_re;
 
-  assign status_fifo_depth_re = addr_hit[5] && reg_re;
+  assign status_fifo_depth_re = addr_hit[6] && reg_re;
 
-  assign status_fifo_empty_re = addr_hit[5] && reg_re;
+  assign status_fifo_empty_re = addr_hit[6] && reg_re;
 
-  assign status_fifo_full_re = addr_hit[5] && reg_re;
+  assign status_fifo_full_re = addr_hit[6] && reg_re;
 
-  assign key_share0_0_we = addr_hit[6] & reg_we & ~wr_err;
+  assign key_share0_0_we = addr_hit[7] & reg_we & ~wr_err;
   assign key_share0_0_wd = reg_wdata[31:0];
 
-  assign key_share0_1_we = addr_hit[7] & reg_we & ~wr_err;
+  assign key_share0_1_we = addr_hit[8] & reg_we & ~wr_err;
   assign key_share0_1_wd = reg_wdata[31:0];
 
-  assign key_share0_2_we = addr_hit[8] & reg_we & ~wr_err;
+  assign key_share0_2_we = addr_hit[9] & reg_we & ~wr_err;
   assign key_share0_2_wd = reg_wdata[31:0];
 
-  assign key_share0_3_we = addr_hit[9] & reg_we & ~wr_err;
+  assign key_share0_3_we = addr_hit[10] & reg_we & ~wr_err;
   assign key_share0_3_wd = reg_wdata[31:0];
 
-  assign key_share0_4_we = addr_hit[10] & reg_we & ~wr_err;
+  assign key_share0_4_we = addr_hit[11] & reg_we & ~wr_err;
   assign key_share0_4_wd = reg_wdata[31:0];
 
-  assign key_share0_5_we = addr_hit[11] & reg_we & ~wr_err;
+  assign key_share0_5_we = addr_hit[12] & reg_we & ~wr_err;
   assign key_share0_5_wd = reg_wdata[31:0];
 
-  assign key_share0_6_we = addr_hit[12] & reg_we & ~wr_err;
+  assign key_share0_6_we = addr_hit[13] & reg_we & ~wr_err;
   assign key_share0_6_wd = reg_wdata[31:0];
 
-  assign key_share0_7_we = addr_hit[13] & reg_we & ~wr_err;
+  assign key_share0_7_we = addr_hit[14] & reg_we & ~wr_err;
   assign key_share0_7_wd = reg_wdata[31:0];
 
-  assign key_share0_8_we = addr_hit[14] & reg_we & ~wr_err;
+  assign key_share0_8_we = addr_hit[15] & reg_we & ~wr_err;
   assign key_share0_8_wd = reg_wdata[31:0];
 
-  assign key_share0_9_we = addr_hit[15] & reg_we & ~wr_err;
+  assign key_share0_9_we = addr_hit[16] & reg_we & ~wr_err;
   assign key_share0_9_wd = reg_wdata[31:0];
 
-  assign key_share0_10_we = addr_hit[16] & reg_we & ~wr_err;
+  assign key_share0_10_we = addr_hit[17] & reg_we & ~wr_err;
   assign key_share0_10_wd = reg_wdata[31:0];
 
-  assign key_share0_11_we = addr_hit[17] & reg_we & ~wr_err;
+  assign key_share0_11_we = addr_hit[18] & reg_we & ~wr_err;
   assign key_share0_11_wd = reg_wdata[31:0];
 
-  assign key_share0_12_we = addr_hit[18] & reg_we & ~wr_err;
+  assign key_share0_12_we = addr_hit[19] & reg_we & ~wr_err;
   assign key_share0_12_wd = reg_wdata[31:0];
 
-  assign key_share0_13_we = addr_hit[19] & reg_we & ~wr_err;
+  assign key_share0_13_we = addr_hit[20] & reg_we & ~wr_err;
   assign key_share0_13_wd = reg_wdata[31:0];
 
-  assign key_share0_14_we = addr_hit[20] & reg_we & ~wr_err;
+  assign key_share0_14_we = addr_hit[21] & reg_we & ~wr_err;
   assign key_share0_14_wd = reg_wdata[31:0];
 
-  assign key_share0_15_we = addr_hit[21] & reg_we & ~wr_err;
+  assign key_share0_15_we = addr_hit[22] & reg_we & ~wr_err;
   assign key_share0_15_wd = reg_wdata[31:0];
 
-  assign key_share1_0_we = addr_hit[22] & reg_we & ~wr_err;
+  assign key_share1_0_we = addr_hit[23] & reg_we & ~wr_err;
   assign key_share1_0_wd = reg_wdata[31:0];
 
-  assign key_share1_1_we = addr_hit[23] & reg_we & ~wr_err;
+  assign key_share1_1_we = addr_hit[24] & reg_we & ~wr_err;
   assign key_share1_1_wd = reg_wdata[31:0];
 
-  assign key_share1_2_we = addr_hit[24] & reg_we & ~wr_err;
+  assign key_share1_2_we = addr_hit[25] & reg_we & ~wr_err;
   assign key_share1_2_wd = reg_wdata[31:0];
 
-  assign key_share1_3_we = addr_hit[25] & reg_we & ~wr_err;
+  assign key_share1_3_we = addr_hit[26] & reg_we & ~wr_err;
   assign key_share1_3_wd = reg_wdata[31:0];
 
-  assign key_share1_4_we = addr_hit[26] & reg_we & ~wr_err;
+  assign key_share1_4_we = addr_hit[27] & reg_we & ~wr_err;
   assign key_share1_4_wd = reg_wdata[31:0];
 
-  assign key_share1_5_we = addr_hit[27] & reg_we & ~wr_err;
+  assign key_share1_5_we = addr_hit[28] & reg_we & ~wr_err;
   assign key_share1_5_wd = reg_wdata[31:0];
 
-  assign key_share1_6_we = addr_hit[28] & reg_we & ~wr_err;
+  assign key_share1_6_we = addr_hit[29] & reg_we & ~wr_err;
   assign key_share1_6_wd = reg_wdata[31:0];
 
-  assign key_share1_7_we = addr_hit[29] & reg_we & ~wr_err;
+  assign key_share1_7_we = addr_hit[30] & reg_we & ~wr_err;
   assign key_share1_7_wd = reg_wdata[31:0];
 
-  assign key_share1_8_we = addr_hit[30] & reg_we & ~wr_err;
+  assign key_share1_8_we = addr_hit[31] & reg_we & ~wr_err;
   assign key_share1_8_wd = reg_wdata[31:0];
 
-  assign key_share1_9_we = addr_hit[31] & reg_we & ~wr_err;
+  assign key_share1_9_we = addr_hit[32] & reg_we & ~wr_err;
   assign key_share1_9_wd = reg_wdata[31:0];
 
-  assign key_share1_10_we = addr_hit[32] & reg_we & ~wr_err;
+  assign key_share1_10_we = addr_hit[33] & reg_we & ~wr_err;
   assign key_share1_10_wd = reg_wdata[31:0];
 
-  assign key_share1_11_we = addr_hit[33] & reg_we & ~wr_err;
+  assign key_share1_11_we = addr_hit[34] & reg_we & ~wr_err;
   assign key_share1_11_wd = reg_wdata[31:0];
 
-  assign key_share1_12_we = addr_hit[34] & reg_we & ~wr_err;
+  assign key_share1_12_we = addr_hit[35] & reg_we & ~wr_err;
   assign key_share1_12_wd = reg_wdata[31:0];
 
-  assign key_share1_13_we = addr_hit[35] & reg_we & ~wr_err;
+  assign key_share1_13_we = addr_hit[36] & reg_we & ~wr_err;
   assign key_share1_13_wd = reg_wdata[31:0];
 
-  assign key_share1_14_we = addr_hit[36] & reg_we & ~wr_err;
+  assign key_share1_14_we = addr_hit[37] & reg_we & ~wr_err;
   assign key_share1_14_wd = reg_wdata[31:0];
 
-  assign key_share1_15_we = addr_hit[37] & reg_we & ~wr_err;
+  assign key_share1_15_we = addr_hit[38] & reg_we & ~wr_err;
   assign key_share1_15_wd = reg_wdata[31:0];
 
-  assign key_len_we = addr_hit[38] & reg_we & ~wr_err;
+  assign key_len_we = addr_hit[39] & reg_we & ~wr_err;
   assign key_len_wd = reg_wdata[2:0];
 
-  assign prefix_0_we = addr_hit[39] & reg_we & ~wr_err;
+  assign prefix_0_we = addr_hit[40] & reg_we & ~wr_err;
   assign prefix_0_wd = reg_wdata[31:0];
 
-  assign prefix_1_we = addr_hit[40] & reg_we & ~wr_err;
+  assign prefix_1_we = addr_hit[41] & reg_we & ~wr_err;
   assign prefix_1_wd = reg_wdata[31:0];
 
-  assign prefix_2_we = addr_hit[41] & reg_we & ~wr_err;
+  assign prefix_2_we = addr_hit[42] & reg_we & ~wr_err;
   assign prefix_2_wd = reg_wdata[31:0];
 
-  assign prefix_3_we = addr_hit[42] & reg_we & ~wr_err;
+  assign prefix_3_we = addr_hit[43] & reg_we & ~wr_err;
   assign prefix_3_wd = reg_wdata[31:0];
 
-  assign prefix_4_we = addr_hit[43] & reg_we & ~wr_err;
+  assign prefix_4_we = addr_hit[44] & reg_we & ~wr_err;
   assign prefix_4_wd = reg_wdata[31:0];
 
-  assign prefix_5_we = addr_hit[44] & reg_we & ~wr_err;
+  assign prefix_5_we = addr_hit[45] & reg_we & ~wr_err;
   assign prefix_5_wd = reg_wdata[31:0];
 
-  assign prefix_6_we = addr_hit[45] & reg_we & ~wr_err;
+  assign prefix_6_we = addr_hit[46] & reg_we & ~wr_err;
   assign prefix_6_wd = reg_wdata[31:0];
 
-  assign prefix_7_we = addr_hit[46] & reg_we & ~wr_err;
+  assign prefix_7_we = addr_hit[47] & reg_we & ~wr_err;
   assign prefix_7_wd = reg_wdata[31:0];
 
-  assign prefix_8_we = addr_hit[47] & reg_we & ~wr_err;
+  assign prefix_8_we = addr_hit[48] & reg_we & ~wr_err;
   assign prefix_8_wd = reg_wdata[31:0];
 
-  assign prefix_9_we = addr_hit[48] & reg_we & ~wr_err;
+  assign prefix_9_we = addr_hit[49] & reg_we & ~wr_err;
   assign prefix_9_wd = reg_wdata[31:0];
 
-  assign prefix_10_we = addr_hit[49] & reg_we & ~wr_err;
+  assign prefix_10_we = addr_hit[50] & reg_we & ~wr_err;
   assign prefix_10_wd = reg_wdata[31:0];
 
-
-  assign cfg_regwen_re = addr_hit[51] && reg_re;
 
   // Read data return
   always_comb begin
@@ -1974,6 +1974,10 @@ module kmac_reg_top (
       end
 
       addr_hit[3]: begin
+        reg_rdata_next[0] = cfg_regwen_qs;
+      end
+
+      addr_hit[4]: begin
         reg_rdata_next[0] = cfg_kmac_en_qs;
         reg_rdata_next[3:1] = cfg_kstrength_qs;
         reg_rdata_next[5:4] = cfg_mode_qs;
@@ -1982,21 +1986,17 @@ module kmac_reg_top (
         reg_rdata_next[12] = cfg_sideload_qs;
       end
 
-      addr_hit[4]: begin
+      addr_hit[5]: begin
         reg_rdata_next[3:0] = '0;
       end
 
-      addr_hit[5]: begin
+      addr_hit[6]: begin
         reg_rdata_next[0] = status_sha3_idle_qs;
         reg_rdata_next[1] = status_sha3_absorb_qs;
         reg_rdata_next[2] = status_sha3_squeeze_qs;
         reg_rdata_next[12:8] = status_fifo_depth_qs;
         reg_rdata_next[14] = status_fifo_empty_qs;
         reg_rdata_next[15] = status_fifo_full_qs;
-      end
-
-      addr_hit[6]: begin
-        reg_rdata_next[31:0] = '0;
       end
 
       addr_hit[7]: begin
@@ -2124,59 +2124,59 @@ module kmac_reg_top (
       end
 
       addr_hit[38]: begin
-        reg_rdata_next[2:0] = '0;
+        reg_rdata_next[31:0] = '0;
       end
 
       addr_hit[39]: begin
-        reg_rdata_next[31:0] = prefix_0_qs;
+        reg_rdata_next[2:0] = '0;
       end
 
       addr_hit[40]: begin
-        reg_rdata_next[31:0] = prefix_1_qs;
+        reg_rdata_next[31:0] = prefix_0_qs;
       end
 
       addr_hit[41]: begin
-        reg_rdata_next[31:0] = prefix_2_qs;
+        reg_rdata_next[31:0] = prefix_1_qs;
       end
 
       addr_hit[42]: begin
-        reg_rdata_next[31:0] = prefix_3_qs;
+        reg_rdata_next[31:0] = prefix_2_qs;
       end
 
       addr_hit[43]: begin
-        reg_rdata_next[31:0] = prefix_4_qs;
+        reg_rdata_next[31:0] = prefix_3_qs;
       end
 
       addr_hit[44]: begin
-        reg_rdata_next[31:0] = prefix_5_qs;
+        reg_rdata_next[31:0] = prefix_4_qs;
       end
 
       addr_hit[45]: begin
-        reg_rdata_next[31:0] = prefix_6_qs;
+        reg_rdata_next[31:0] = prefix_5_qs;
       end
 
       addr_hit[46]: begin
-        reg_rdata_next[31:0] = prefix_7_qs;
+        reg_rdata_next[31:0] = prefix_6_qs;
       end
 
       addr_hit[47]: begin
-        reg_rdata_next[31:0] = prefix_8_qs;
+        reg_rdata_next[31:0] = prefix_7_qs;
       end
 
       addr_hit[48]: begin
-        reg_rdata_next[31:0] = prefix_9_qs;
+        reg_rdata_next[31:0] = prefix_8_qs;
       end
 
       addr_hit[49]: begin
-        reg_rdata_next[31:0] = prefix_10_qs;
+        reg_rdata_next[31:0] = prefix_9_qs;
       end
 
       addr_hit[50]: begin
-        reg_rdata_next[31:0] = err_code_qs;
+        reg_rdata_next[31:0] = prefix_10_qs;
       end
 
       addr_hit[51]: begin
-        reg_rdata_next[0] = cfg_regwen_qs;
+        reg_rdata_next[31:0] = err_code_qs;
       end
 
       default: begin


### PR DESCRIPTION
As filed in the issue #4058 , if REGWEN is defined after the registers to guard, the DV RAL package raises an error in simulation. Until the issue is resolved, shifting the CFG_REGWEN to the first register.