### PR TITLE
[sw] Prevent use of COMMON Sections

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -92,6 +92,8 @@ c_cpp_cross_args = [
   '-isystem' + meson.source_root() / 'sw/device/lib/base/freestanding',
   # Don't emit unwinding information
   '-fno-asynchronous-unwind-tables',
+  # Don't use COMMON sections for uninitialized globals
+  '-fno-common',
 ]
 
 # Add extra warning flags for cross builds, if they are supported.

--- a/sw/device/info_sections.ld
+++ b/sw/device/info_sections.ld
@@ -88,4 +88,7 @@
   *(.stab)
   *(.stab.*)
   *(.stabstr)
+
+  /* COMMON Sections */
+  *(COMMON)
 }


### PR DESCRIPTION
Old versions of GCC default to using `-fcommon`, but this changed in
GCC version 10.0 to default to `-fno-common`, which Clang matches.

The DV environment was using an old GCC version with the wrong default,
which was causing issues when exposed to the changes in
lowrisc/opentitan#4014. This ensures we avoid using COMMON at all costs,
instead favouring using real, defined sections for our C code.

--

Closes #4048. 