### PR TITLE
[otp_ctrl/otbn/aes] Fix alert test register enumeration order

### DIFF
--- a/hw/ip/aes/rtl/aes.sv
+++ b/hw/ip/aes/rtl/aes.sv
@@ -101,10 +101,10 @@ module aes
 
   logic [NumAlerts-1:0] alert_test;
   assign alert_test = {
-    reg2hw.alert_test.ctrl_err_update.q &
-    reg2hw.alert_test.ctrl_err_update.qe,
     reg2hw.alert_test.ctrl_err_storage.q &
-    reg2hw.alert_test.ctrl_err_storage.qe
+    reg2hw.alert_test.ctrl_err_storage.qe,
+    reg2hw.alert_test.ctrl_err_update.q &
+    reg2hw.alert_test.ctrl_err_update.qe
   };
 
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -391,14 +391,12 @@ module otbn
   // Alerts ====================================================================
 
   logic [NumAlerts-1:0] alert_test;
-  assign alert_test = {
-    reg2hw.alert_test.imem_uncorrectable.q &
-    reg2hw.alert_test.imem_uncorrectable.qe,
-    reg2hw.alert_test.dmem_uncorrectable.q &
-    reg2hw.alert_test.dmem_uncorrectable.qe,
-    reg2hw.alert_test.reg_uncorrectable.q &
-    reg2hw.alert_test.reg_uncorrectable.qe
-  };
+  assign alert_test[AlertImemUncorrectable] = reg2hw.alert_test.imem_uncorrectable.q &
+                                              reg2hw.alert_test.imem_uncorrectable.qe;
+  assign alert_test[AlertDmemUncorrectable] = reg2hw.alert_test.dmem_uncorrectable.q &
+                                              reg2hw.alert_test.dmem_uncorrectable.qe;
+  assign alert_test[AlertRegUncorrectable]  = reg2hw.alert_test.reg_uncorrectable.q &
+                                              reg2hw.alert_test.reg_uncorrectable.qe;
 
   logic [NumAlerts-1:0] alerts;
   assign alerts[AlertImemUncorrectable] = imem_rerror[1];

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
@@ -360,15 +360,15 @@ module otp_ctrl
   logic [NumAlerts-1:0] alert_test;
 
   assign alerts = {
-    otp_macro_failure_q,
-    otp_check_failure_q
+    otp_check_failure_q,
+    otp_macro_failure_q
   };
 
   assign alert_test = {
-    reg2hw.alert_test.otp_macro_failure.q &
-    reg2hw.alert_test.otp_macro_failure.qe,
     reg2hw.alert_test.otp_check_failure.q &
-    reg2hw.alert_test.otp_check_failure.qe
+    reg2hw.alert_test.otp_check_failure.qe,
+    reg2hw.alert_test.otp_macro_failure.q &
+    reg2hw.alert_test.otp_macro_failure.qe
   };
 
   for (genvar k = 0; k < NumAlerts; k++) begin : gen_alert_tx


### PR DESCRIPTION
This fixes #4049

Signed-off-by: Michael Schaffner <msf@opentitan.org>