### PR TITLE
[sw] Degrade unused functions to warnings

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -48,6 +48,7 @@ extra_warning_args = [
   '-Wswitch-default', # Ensure all switches have default statements
   '-Wno-covered-switch-default', # We require `default:` always.
   '-Wgnu', # We aim to be standards compliant, and avoid gnu extensions.
+  '-Wno-error=unused-function', # Don't error out on unused functions, only warn.
   # Issues we intend to fix in the future but are currently ignored as there are
   # many places they are triggered.
   '-Wno-unused-parameter',


### PR DESCRIPTION
Currently we abort the build if a function (in C) is unused. This is
quite inconvenient during development when one tries to comment out code
or return early to iteratively develop or debug a feature. To increase
developer productivity, this commit reduces the compiler message from an
error to a warning.

As we get closer to finalizing the software we can think about
re-enabling it, or using a different build configuration in CI that
overrides this setting.