### PR TITLE
[kmac] moving up to L1 stage.

### DIFF
--- a/hw/ip/kmac/data/kmac.prj.hjson
+++ b/hw/ip/kmac/data/kmac.prj.hjson
@@ -11,7 +11,7 @@
     revisions: [
       {
         version:            "1.0",
-        life_stage:         "L0",
+        life_stage:         "L1",
         design_stage:       "D1",
         verification_stage: "V0",
         commit_id:          "40979092",


### PR DESCRIPTION
Fixing typo in kmac.prj.hjson. If an IP reaches D1, the life stage
should be L1 too.