### PR TITLE
[kmac] Fix FPV testbenches

### DIFF
--- a/hw/ip/kmac/fpv/tb/sha3_fpv.sv
+++ b/hw/ip/kmac/fpv/tb/sha3_fpv.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 module sha3_fpv
-  import kmac_pkg::*;
+  import sha3_pkg::*;
 #(
   // Enable Masked Keccak if 1
   parameter  int EnMasking = 0,

--- a/hw/ip/kmac/fpv/tb/sha3pad_fpv.sv
+++ b/hw/ip/kmac/fpv/tb/sha3pad_fpv.sv
@@ -4,7 +4,7 @@
 //
 
 module sha3pad_fpv
-  import kmac_pkg::*;
+  import sha3_pkg::*;
 #(
   parameter int EnMasking = 0,
   localparam int Share = (EnMasking) ? 2 : 1


### PR DESCRIPTION
SHA3 related parameters, functions are relocated into `sha3_pkg.sv` in
40979092 . But some of sha3 fpv testbenches still include `kmac_pkg`.
This commit is to fix the issue so that FPV test can run.