### PR TITLE
[dv/otp] Pwr_otp interface cleanup

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -52,12 +52,6 @@ package otp_ctrl_env_pkg;
   };
 
   // types
-  typedef virtual pins_if #(3)            pwr_otp_vif;
-  typedef virtual pins_if #(4)            lc_provision_en_vif;
-  typedef virtual pins_if #(4)            lc_dft_en_vif;
-  typedef virtual mem_bkdr_if             mem_bkdr_vif;
-  typedef virtual otp_ctrl_output_data_if otp_ctrl_output_data_vif;
-
   typedef enum bit [1:0] {
     OtpOperationDone,
     OtpErr,
@@ -81,6 +75,19 @@ package otp_ctrl_env_pkg;
     OtpOwnerSwCfgErr    = 15'b000_0000_0000_0010,
     OtpCreatorSwCfgErr  = 15'b000_0000_0000_0001
   } otp_status_e;
+
+  typedef enum bit [1:0] {
+    OtpPwrInitReq,
+    OtpPwrIdleRsp,
+    OtpPwrDoneRsp,
+    OtpPwrIfWidth
+  } otp_pwr_if_e;
+
+  typedef virtual pins_if #(OtpPwrIfWidth) pwr_otp_vif;
+  typedef virtual pins_if #(4)             lc_provision_en_vif;
+  typedef virtual pins_if #(4)             lc_dft_en_vif;
+  typedef virtual mem_bkdr_if              mem_bkdr_vif;
+  typedef virtual otp_ctrl_output_data_if  otp_ctrl_output_data_vif;
 
   // functions
   function automatic int get_part_index(bit [TL_DW-1:0] addr);

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_common_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_common_vseq.sv
@@ -12,11 +12,8 @@ class otp_ctrl_common_vseq extends otp_ctrl_base_vseq;
 
   virtual task dut_init(string reset_kind = "HARD");
     super.dut_init(reset_kind);
-    // drive pwr_otp_req pin
-    cfg.pwr_otp_vif.drive_pin(0, 1);
     // drive dft_en pins to access the test_access memory
     cfg.lc_dft_en_vif.drive(lc_ctrl_pkg::On);
-    wait(cfg.pwr_otp_vif.pins[2] == 1);
   endtask
 
   task post_start();

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_sanity_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_sanity_vseq.sv
@@ -38,9 +38,6 @@ class otp_ctrl_sanity_vseq extends otp_ctrl_base_vseq;
 
   virtual task dut_init(string reset_kind = "HARD");
     super.dut_init(reset_kind);
-    // drive pwr_otp_req pin
-    cfg.pwr_otp_vif.drive_pin(0, 1);
-    wait(cfg.pwr_otp_vif.pins[2] == 1);
     cfg.lc_provision_en_vif.drive(lc_ctrl_pkg::On);
     csr_wr(ral.intr_enable, en_intr);
   endtask

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_wake_up_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_wake_up_vseq.sv
@@ -11,8 +11,6 @@ class otp_ctrl_wake_up_vseq extends otp_ctrl_base_vseq;
   virtual task otp_ctrl_init();
     super.otp_ctrl_init();
     csr_wr(ral.intr_enable, en_intr);
-    // drive pwr_otp_req pin
-    cfg.pwr_otp_vif.drive_pin(0, 1);
   endtask
 
   virtual task pre_start();
@@ -23,9 +21,7 @@ class otp_ctrl_wake_up_vseq extends otp_ctrl_base_vseq;
     bit [TL_DW-1:0] rand_addr = $urandom_range(0, 768);
     dut_init();
 
-    // wait until otp-init done, check status
-    wait(cfg.pwr_otp_vif.pins[2] == 1);
-    cfg.pwr_otp_vif.drive_pin(0, 0);
+    // check status
     cfg.clk_rst_vif.wait_clks(1);
     csr_wr(ral.intr_enable, 2'b11);
     csr_rd_check(.ptr(ral.status), .compare_value(2));

--- a/hw/ip/otp_ctrl/dv/tb.sv
+++ b/hw/ip/otp_ctrl/dv/tb.sv
@@ -19,7 +19,7 @@ module tb;
   wire devmode;
   wire [3:0] lc_provision_en, lc_dft_en;
 
-  wire [2:0] pwr_otp;
+  wire [OtpPwrIfWidth-1:0] pwr_otp;
   wire otp_ctrl_pkg::flash_otp_key_req_t flash_req;
   wire otp_ctrl_pkg::flash_otp_key_rsp_t flash_rsp;
   wire otp_ctrl_pkg::otbn_otp_key_req_t  otbn_req;
@@ -51,8 +51,8 @@ module tb;
   push_pull_if #(FLASH_DATA_SIZE) flash_data_if(.clk(clk), .rst_n(rst_n));
   push_pull_if #(EDN_DATA_SIZE)   edn_if(.clk(clk), .rst_n(rst_n));
 
+  pins_if #(OtpPwrIfWidth) pwr_otp_if(pwr_otp);
   // TODO: use standard req/rsp agent
-  pins_if #(3) pwr_otp_if(pwr_otp);
   pins_if #(4) lc_provision_en_if(lc_provision_en);
   pins_if #(4) lc_dft_en_if(lc_dft_en);
 
@@ -89,8 +89,8 @@ module tb;
     .otp_edn_o                 (edn_if.req),
     .otp_edn_i                 ({edn_if.ack, edn_if.data}),
     // pwrmgr
-    .pwr_otp_i                 (pwr_otp[0]),
-    .pwr_otp_o                 (pwr_otp[2:1]),
+    .pwr_otp_i                 (pwr_otp[OtpPwrInitReq]),
+    .pwr_otp_o                 (pwr_otp[OtpPwrDoneRsp:OtpPwrIdleRsp]),
     // lc
     .lc_otp_program_i          ('0),
     .lc_otp_program_o          (otp_prog),


### PR DESCRIPTION
From PR #3990, weicai recommended to change pwr_otp_if index naming to
more meaningful ones.
This PR uses an enum to replace the hard-coded numbers. It also unifies
all the tests to do otp_pwr_init. This option can be turned off by a
flag `do_otp_pwr_init`.

Signed-off-by: Cindy Chen <chencindy@google.com>