### PR TITLE
[fpv] Fix dv-verified IPs' fusesoc dependency issue and add them back to nightly regression

### DIFF
--- a/hw/formal/fpv
+++ b/hw/formal/fpv
@@ -31,6 +31,7 @@ export FPV_TOP=$1
 shift
 gui=0
 tool="jg"
+flag="fileset_top"
 export COV=0
 export CHECK=0
 
@@ -57,6 +58,11 @@ while [ "$1" != "" ]; do
       tool=$1
       echo "running in tool: $tool"
       ;;
+    "-flag")
+      shift
+      flag=$1
+      echo "flag is set to: $flag"
+      ;;
   esac
   shift
 done
@@ -74,12 +80,12 @@ if [ "${CORE_PATH}" == "" ]; then
   if [[ $FPV_TOP == *"_fpv" ]]; then
     CORE_PATH="fpv:${FPV_TOP}"
   else
-    CORE_PATH="ip:${FPV_TOP}"
+    CORE_PATH="dv:${FPV_TOP}_sva"
   fi
 fi
 echo "core_file path: lowrisc:${CORE_PATH}"
 
-fusesoc --cores-root ../.. run --tool=icarus --target=formal --setup "lowrisc:${CORE_PATH}"
+fusesoc --cores-root ../.. run --tool=icarus --target=formal --flag=${flag} --setup "lowrisc:${CORE_PATH}"
 
 echo "-------------------------------------------------------------------------"
 echo "-- Run JasperGold"

--- a/hw/ip/aes/aes.core
+++ b/hw/ip/aes/aes.core
@@ -60,11 +60,6 @@ filesets:
       - lowrisc:lint:common
       - lowrisc:lint:comportable
 
-  files_formal:
-    files:
-      - dv/tb/aes_bind.sv
-    file_type: systemVerilogSource
-
 parameters:
   SYNTHESIS:
     datatype: bool
@@ -77,13 +72,6 @@ targets:
       - tool_verilator   ? (files_verilator_waiver)
       - tool_ascentlint  ? (files_ascentlint_waiver)
       - tool_veriblelint ? (files_veriblelint_waiver)
-      - target_formal    ? (files_formal)
-      - files_rtl
-    toplevel: aes
-
-  formal:
-    filesets:
-      - files_formal
       - files_rtl
     toplevel: aes
 

--- a/hw/ip/aes/dv/sva/aes_sva.core
+++ b/hw/ip/aes/dv/sva/aes_sva.core
@@ -13,6 +13,10 @@ filesets:
       - aes_bind.sv
     file_type: systemVerilogSource
 
+  files_formal:
+    depend:
+      - lowrisc:ip:aes
+
 generate:
   csr_assert_gen:
     generator: csr_assert_gen
@@ -21,8 +25,15 @@ generate:
       depend: lowrisc:ip:aes
 
 targets:
-  default:
+  default: &default_target
     filesets:
       - files_dv
     generate:
       - csr_assert_gen
+
+  formal:
+    <<: *default_target
+    filesets:
+      - files_formal
+      - files_dv
+    toplevel: aes

--- a/hw/ip/alert_handler/alert_handler.core
+++ b/hw/ip/alert_handler/alert_handler.core
@@ -11,11 +11,6 @@ filesets:
       - lowrisc:ip:alert_handler_reg
       - lowrisc:ip:alert_handler_component
 
-  files_formal:
-    files:
-      - dv/tb/alert_handler_bind.sv
-    file_type: systemVerilogSource
-
 parameters:
   SYNTHESIS:
     datatype: bool
@@ -25,14 +20,7 @@ parameters:
 targets:
   default: &default_target
     filesets:
-      - target_formal    ? (files_formal)
       - files_rtl
-    toplevel: alert_handler
-
-  formal:
-    filesets:
-      - files_rtl
-      - files_formal
     toplevel: alert_handler
 
   lint:

--- a/hw/ip/alert_handler/dv/sva/alert_handler_sva.core
+++ b/hw/ip/alert_handler/dv/sva/alert_handler_sva.core
@@ -13,6 +13,10 @@ filesets:
       - alert_handler_bind.sv
     file_type: systemVerilogSource
 
+  files_formal:
+    depend:
+      - lowrisc:ip:alert_handler
+
 generate:
   csr_assert_gen:
     generator: csr_assert_gen
@@ -21,8 +25,15 @@ generate:
       depend: lowrisc:ip:alert_handler_reg
 
 targets:
-  default:
+  default: &default_target
     filesets:
       - files_dv
     generate:
       - csr_assert_gen
+
+  formal:
+    <<: *default_target
+    filesets:
+      - files_formal
+      - files_dv
+    toplevel: alert_handler

--- a/hw/ip/entropy_src/dv/sva/entropy_src_sva.core
+++ b/hw/ip/entropy_src/dv/sva/entropy_src_sva.core
@@ -13,6 +13,10 @@ filesets:
       - entropy_src_bind.sv
     file_type: systemVerilogSource
 
+  files_formal:
+    depend:
+      - lowrisc:ip:entropy_src
+
 generate:
   csr_assert_gen:
     generator: csr_assert_gen
@@ -21,8 +25,15 @@ generate:
       depend: lowrisc:ip:entropy_src
 
 targets:
-  default:
+  default: &default_target
     filesets:
       - files_dv
     generate:
       - csr_assert_gen
+
+  formal:
+    <<: *default_target
+    filesets:
+      - files_formal
+      - files_dv
+    toplevel: entropy_src

--- a/hw/ip/flash_ctrl/dv/sva/flash_ctrl_sva.core
+++ b/hw/ip/flash_ctrl/dv/sva/flash_ctrl_sva.core
@@ -13,6 +13,10 @@ filesets:
       - flash_ctrl_bind.sv
     file_type: systemVerilogSource
 
+  files_formal:
+    depend:
+      - lowrisc:ip:flash_ctrl
+
 generate:
   csr_assert_gen:
     generator: csr_assert_gen
@@ -21,8 +25,15 @@ generate:
       depend: lowrisc:ip:flash_ctrl
 
 targets:
-  default:
+  default: &default_target
     filesets:
       - files_dv
     generate:
       - csr_assert_gen
+
+  formal:
+    <<: *default_target
+    filesets:
+      - files_formal
+      - files_dv
+    toplevel: flash_ctrl

--- a/hw/ip/flash_ctrl/flash_ctrl.core
+++ b/hw/ip/flash_ctrl/flash_ctrl.core
@@ -59,11 +59,6 @@ filesets:
       - lowrisc:lint:common
       - lowrisc:lint:comportable
 
-  files_formal:
-    files:
-      - dv/tb/flash_ctrl_bind.sv
-    file_type: systemVerilogSource
-
 parameters:
   SYNTHESIS:
     datatype: bool
@@ -76,14 +71,7 @@ targets:
       - tool_verilator   ? (files_verilator_waiver)
       - tool_ascentlint  ? (files_ascentlint_waiver)
       - tool_veriblelint ? (files_veriblelint_waiver)
-      - target_formal    ? (files_formal)
       - files_rtl
-    toplevel: flash_ctrl
-
-  formal:
-    filesets:
-      - files_rtl
-      - files_formal
     toplevel: flash_ctrl
 
   lint:

--- a/hw/ip/gpio/dv/sva/gpio_sva.core
+++ b/hw/ip/gpio/dv/sva/gpio_sva.core
@@ -13,6 +13,10 @@ filesets:
       - gpio_bind.sv
     file_type: systemVerilogSource
 
+  files_formal:
+    depend:
+      - lowrisc:ip:gpio
+
 generate:
   csr_assert_gen:
     generator: csr_assert_gen
@@ -21,8 +25,15 @@ generate:
       depend: lowrisc:ip:gpio
 
 targets:
-  default:
+  default: &default_target
     filesets:
       - files_dv
     generate:
       - csr_assert_gen
+
+  formal:
+    <<: *default_target
+    filesets:
+      - files_formal
+      - files_dv
+    toplevel: gpio

--- a/hw/ip/gpio/gpio.core
+++ b/hw/ip/gpio/gpio.core
@@ -39,11 +39,6 @@ filesets:
       - lowrisc:lint:common
       - lowrisc:lint:comportable
 
-  files_formal:
-    files:
-      - dv/tb/gpio_bind.sv
-    file_type: systemVerilogSource
-
 parameters:
   SYNTHESIS:
     datatype: bool
@@ -56,14 +51,7 @@ targets:
       - tool_verilator   ? (files_verilator_waiver)
       - tool_ascentlint  ? (files_ascentlint_waiver)
       - tool_veriblelint ? (files_veriblelint_waiver)
-      - target_formal    ? (files_formal)
       - files_rtl
-    toplevel: gpio
-
-  formal:
-    filesets:
-      - files_rtl
-      - files_formal
     toplevel: gpio
 
   lint:
@@ -80,5 +68,3 @@ targets:
         mode: lint-only
         verilator_options:
           - "-Wall"
-
-

--- a/hw/ip/hmac/dv/sva/hmac_sva.core
+++ b/hw/ip/hmac/dv/sva/hmac_sva.core
@@ -13,6 +13,10 @@ filesets:
       - hmac_bind.sv
     file_type: systemVerilogSource
 
+  files_formal:
+    depend:
+      - lowrisc:ip:hmac
+
 generate:
   csr_assert_gen:
     generator: csr_assert_gen
@@ -21,8 +25,15 @@ generate:
       depend: lowrisc:ip:hmac
 
 targets:
-  default:
+  default: &default_target
     filesets:
       - files_dv
     generate:
       - csr_assert_gen
+
+  formal:
+    <<: *default_target
+    filesets:
+      - files_formal
+      - files_dv
+    toplevel: hmac

--- a/hw/ip/hmac/hmac.core
+++ b/hw/ip/hmac/hmac.core
@@ -43,11 +43,6 @@ filesets:
       - lowrisc:lint:common
       - lowrisc:lint:comportable
 
-  files_formal:
-    files:
-      - dv/tb/hmac_bind.sv
-    file_type: systemVerilogSource
-
 parameters:
   SYNTHESIS:
     datatype: bool
@@ -60,14 +55,7 @@ targets:
       - tool_verilator   ? (files_verilator_waiver)
       - tool_ascentlint  ? (files_ascentlint_waiver)
       - tool_veriblelint ? (files_veriblelint_waiver)
-      - target_formal    ? (files_formal)
       - files_rtl
-    toplevel: hmac
-
-  formal:
-    filesets:
-      - files_rtl
-      - files_formal
     toplevel: hmac
 
   lint:
@@ -84,5 +72,3 @@ targets:
         mode: lint-only
         verilator_options:
           - "-Wall"
-
-

--- a/hw/ip/i2c/dv/sva/i2c_sva.core
+++ b/hw/ip/i2c/dv/sva/i2c_sva.core
@@ -13,6 +13,10 @@ filesets:
       - i2c_bind.sv
     file_type: systemVerilogSource
 
+  files_formal:
+    depend:
+      - lowrisc:ip:i2c
+
 generate:
   csr_assert_gen:
     generator: csr_assert_gen
@@ -21,8 +25,15 @@ generate:
       depend: lowrisc:ip:i2c
 
 targets:
-  default:
+  default: &default_target
     filesets:
       - files_dv
     generate:
       - csr_assert_gen
+
+  formal:
+    <<: *default_target
+    filesets:
+      - files_formal
+      - files_dv
+    toplevel: i2c

--- a/hw/ip/i2c/i2c.core
+++ b/hw/ip/i2c/i2c.core
@@ -42,11 +42,6 @@ filesets:
       - lowrisc:lint:common
       - lowrisc:lint:comportable
 
-  files_formal:
-    files:
-      - dv/tb/i2c_bind.sv
-    file_type: systemVerilogSource
-
 parameters:
   SYNTHESIS:
     datatype: bool
@@ -59,14 +54,7 @@ targets:
       - tool_verilator   ? (files_verilator_waiver)
       - tool_ascentlint  ? (files_ascentlint_waiver)
       - tool_veriblelint ? (files_veriblelint_waiver)
-      - target_formal    ? (files_formal)
       - files_rtl
-    toplevel: i2c
-
-  formal:
-    filesets:
-      - files_rtl
-      - files_formal
     toplevel: i2c
 
   lint:
@@ -83,5 +71,3 @@ targets:
         mode: lint-only
         verilator_options:
           - "-Wall"
-
-

--- a/hw/ip/keymgr/dv/sva/keymgr_sva.core
+++ b/hw/ip/keymgr/dv/sva/keymgr_sva.core
@@ -13,6 +13,10 @@ filesets:
       - keymgr_bind.sv
     file_type: systemVerilogSource
 
+  files_formal:
+    depend:
+      - lowrisc:ip:keymgr
+
 generate:
   csr_assert_gen:
     generator: csr_assert_gen
@@ -21,8 +25,15 @@ generate:
       depend: lowrisc:ip:keymgr
 
 targets:
-  default:
+  default: &default_target
     filesets:
       - files_dv
     generate:
       - csr_assert_gen
+
+  formal:
+    <<: *default_target
+    filesets:
+      - files_formal
+      - files_dv
+    toplevel: keymgr

--- a/hw/ip/keymgr/keymgr.core
+++ b/hw/ip/keymgr/keymgr.core
@@ -41,11 +41,6 @@ filesets:
       - lint/keymgr.waiver
     file_type: waiver
 
-  files_formal:
-    files:
-      - dv/tb/keymgr_bind.sv
-    file_type: systemVerilogSource
-
 parameters:
   SYNTHESIS:
     datatype: bool
@@ -57,14 +52,7 @@ targets:
     filesets:
       - tool_verilator  ? (files_verilator_waiver)
       - tool_ascentlint ? (files_ascentlint_waiver)
-      - target_formal   ? (files_formal)
       - files_rtl
-    toplevel: keymgr
-
-  formal:
-    filesets:
-      - files_rtl
-      - files_formal
     toplevel: keymgr
 
   lint:

--- a/hw/ip/otp_ctrl/dv/sva/otp_ctrl_sva.core
+++ b/hw/ip/otp_ctrl/dv/sva/otp_ctrl_sva.core
@@ -13,6 +13,10 @@ filesets:
       - otp_ctrl_bind.sv
     file_type: systemVerilogSource
 
+  files_formal:
+    depend:
+      - lowrisc:ip:otp_ctrl
+
 generate:
   csr_assert_gen:
     generator: csr_assert_gen
@@ -21,8 +25,15 @@ generate:
       depend: lowrisc:ip:otp_ctrl_pkg
 
 targets:
-  default:
+  default: &default_target
     filesets:
       - files_dv
     generate:
       - csr_assert_gen
+
+  formal:
+    <<: *default_target
+    filesets:
+      - files_formal
+      - files_dv
+    toplevel: otp_ctrl

--- a/hw/ip/otp_ctrl/otp_ctrl.core
+++ b/hw/ip/otp_ctrl/otp_ctrl.core
@@ -47,11 +47,6 @@ filesets:
       - lint/otp_ctrl.waiver
     file_type: waiver
 
-  files_formal:
-    files:
-      - dv/tb/otp_ctrl_bind.sv
-    file_type: systemVerilogSource
-
 parameters:
   SYNTHESIS:
     datatype: bool
@@ -63,14 +58,7 @@ targets:
     filesets:
       - tool_verilator  ? (files_verilator_waiver)
       - tool_ascentlint ? (files_ascentlint_waiver)
-      - target_formal   ? (files_formal)
       - files_rtl
-    toplevel: otp_ctrl
-
-  formal:
-    filesets:
-      - files_rtl
-      - files_formal
     toplevel: otp_ctrl
 
   lint:

--- a/hw/ip/rv_timer/dv/sva/rv_timer_sva.core
+++ b/hw/ip/rv_timer/dv/sva/rv_timer_sva.core
@@ -13,6 +13,10 @@ filesets:
       - rv_timer_bind.sv
     file_type: systemVerilogSource
 
+  files_formal:
+    depend:
+      - lowrisc:ip:rv_timer
+
 generate:
   csr_assert_gen:
     generator: csr_assert_gen
@@ -21,8 +25,15 @@ generate:
       depend: lowrisc:ip:rv_timer
 
 targets:
-  default:
+  default: &default_target
     filesets:
       - files_dv
     generate:
       - csr_assert_gen
+
+  formal:
+    <<: *default_target
+    filesets:
+      - files_formal
+      - files_dv
+    toplevel: rv_timer

--- a/hw/ip/rv_timer/rv_timer.core
+++ b/hw/ip/rv_timer/rv_timer.core
@@ -40,16 +40,10 @@ filesets:
       - lowrisc:lint:common
       - lowrisc:lint:comportable
 
-  files_formal:
-    files:
-      - dv/tb/rv_timer_bind.sv
-    file_type: systemVerilogSource
-
 parameters:
   SYNTHESIS:
     datatype: bool
     paramtype: vlogdefine
-
 
 targets:
   default: &default_target
@@ -57,14 +51,7 @@ targets:
       - tool_verilator   ? (files_verilator_waiver)
       - tool_ascentlint  ? (files_ascentlint_waiver)
       - tool_veriblelint ? (files_veriblelint_waiver)
-      - target_formal    ? (files_formal)
       - files_rtl
-    toplevel: rv_timer
-
-  formal:
-    filesets:
-      - files_rtl
-      - files_formal
     toplevel: rv_timer
 
   lint:
@@ -81,5 +68,3 @@ targets:
         mode: lint-only
         verilator_options:
           - "-Wall"
-
-

--- a/hw/ip/spi_device/dv/sva/spi_device_sva.core
+++ b/hw/ip/spi_device/dv/sva/spi_device_sva.core
@@ -13,6 +13,10 @@ filesets:
       - spi_device_bind.sv
     file_type: systemVerilogSource
 
+  files_formal:
+    depend:
+      - lowrisc:ip:spi_device
+
 generate:
   csr_assert_gen:
     generator: csr_assert_gen
@@ -21,8 +25,15 @@ generate:
       depend: lowrisc:ip:spi_device
 
 targets:
-  default:
+  default: &default_target
     filesets:
       - files_dv
     generate:
       - csr_assert_gen
+
+  formal:
+    <<: *default_target
+    filesets:
+      - files_formal
+      - files_dv
+    toplevel: spi_device

--- a/hw/ip/spi_device/spi_device.core
+++ b/hw/ip/spi_device/spi_device.core
@@ -48,11 +48,6 @@ filesets:
       - lowrisc:lint:common
       - lowrisc:lint:comportable
 
-  files_formal:
-    files:
-      - dv/tb/spi_device_bind.sv
-    file_type: systemVerilogSource
-
 parameters:
   SYNTHESIS:
     datatype: bool
@@ -65,14 +60,7 @@ targets:
       - tool_verilator   ? (files_verilator_waiver)
       - tool_ascentlint  ? (files_ascentlint_waiver)
       - tool_veriblelint ? (files_veriblelint_waiver)
-      - target_formal    ? (files_formal)
       - files_rtl
-    toplevel: spi_device
-
-  formal:
-    filesets:
-      - files_rtl
-      - files_formal
     toplevel: spi_device
 
   lint:
@@ -89,5 +77,3 @@ targets:
         mode: lint-only
         verilator_options:
           - "-Wall"
-
-

--- a/hw/ip/uart/dv/sva/uart_sva.core
+++ b/hw/ip/uart/dv/sva/uart_sva.core
@@ -13,6 +13,10 @@ filesets:
       - uart_bind.sv
     file_type: systemVerilogSource
 
+  files_formal:
+    depend:
+      - lowrisc:ip:uart
+
 generate:
   csr_assert_gen:
     generator: csr_assert_gen
@@ -21,8 +25,15 @@ generate:
       depend: lowrisc:ip:uart
 
 targets:
-  default:
+  default: &default_target
     filesets:
       - files_dv
     generate:
       - csr_assert_gen
+
+  formal:
+    <<: *default_target
+    filesets:
+      - files_formal
+      - files_dv
+    toplevel: uart

--- a/hw/ip/uart/uart.core
+++ b/hw/ip/uart/uart.core
@@ -43,11 +43,6 @@ filesets:
       - lowrisc:lint:common
       - lowrisc:lint:comportable
 
-  files_formal:
-    files:
-      - dv/tb/uart_bind.sv
-    file_type: systemVerilogSource
-
 parameters:
   SYNTHESIS:
     datatype: bool
@@ -60,14 +55,7 @@ targets:
       - tool_verilator   ? (files_verilator_waiver)
       - tool_ascentlint  ? (files_ascentlint_waiver)
       - tool_veriblelint ? (files_veriblelint_waiver)
-      - target_formal    ? (files_formal)
       - files_rtl
-    toplevel: uart
-
-  formal:
-    filesets:
-      - files_rtl
-      - files_formal
     toplevel: uart
 
   lint:

--- a/hw/top_earlgrey/fpv/top_earlgrey_fpv_cfgs.hjson
+++ b/hw/top_earlgrey/fpv/top_earlgrey_fpv_cfgs.hjson
@@ -18,71 +18,160 @@
                name: prim_arbiter_ppc_fpv
                fusesoc_core: lowrisc:fpv:prim_arbiter_ppc_fpv
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               cov: true
              }
              {
                name: prim_arbiter_tree_fpv
                fusesoc_core: lowrisc:fpv:prim_arbiter_tree_fpv
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               cov: true
              }
              {
                name: prim_arbiter_fixed_fpv
                fusesoc_core: lowrisc:fpv:prim_arbiter_fixed_fpv
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               cov: true
              }
              {
                name: prim_lfsr_fpv
                fusesoc_core: lowrisc:fpv:prim_lfsr_fpv
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               cov: true
              }
              {
                name: prim_fifo_sync_fpv
                fusesoc_core: lowrisc:fpv:prim_fifo_sync_fpv
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               cov: true
              }
              {
                name: prim_alert_rxtx_fpv
                fusesoc_core: lowrisc:fpv:prim_alert_rxtx_fpv
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               cov: true
              }
              {
                name: prim_alert_rxtx_async_fpv
                fusesoc_core: lowrisc:fpv:prim_alert_rxtx_async_fpv
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               cov: true
              }
              {
                name: prim_esc_rxtx_fpv
                fusesoc_core: lowrisc:fpv:prim_esc_rxtx_fpv
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               cov: true
              }
              {
                name: prim_packer_fpv
                fusesoc_core: lowrisc:fpv:prim_packer_fpv
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               cov: true
              }
              {
                name: padctrl_fpv
                fusesoc_core: lowrisc:fpv:padctrl_fpv
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               cov: true
              }
              {
                name: pinmux_fpv
                fusesoc_core: lowrisc:fpv:pinmux_fpv
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               cov: true
              }
              {
                name: rv_plic_fpv
                fusesoc_core: lowrisc:fpv:rv_plic_fpv
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               cov: true
              }
              {
                name: rv_plic_generic_fpv
                fusesoc_core: lowrisc:fpv:rv_plic_generic_fpv
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               cov: true
              }
              {
                name: sha3pad_fpv
                fusesoc_core: lowrisc:fpv:sha3pad_fpv
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               cov: true
+             }
+             // Below are IPs that already has a DV testbench,
+             // FPV only verifies TLUL interface and build-in assertions,
+             // so will not collect FPV coverage.
+             {
+               name: aes
+               fusesoc_core: lowrisc:dv:aes_sva
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               cov: false
+             }
+             {
+               name: alert_handler
+               fusesoc_core: lowrisc:dv:alert_handler_sva
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               cov: false
+             }
+             {
+               name: entropy_src
+               fusesoc_core: lowrisc:dv:entropy_src_sva
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               cov: false
+             }
+             {
+               name: flash_ctrl
+               fusesoc_core: lowrisc:dv:flash_ctrl_sva
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               cov: false
+             }
+             {
+               name: gpio
+               fusesoc_core: lowrisc:dv:gpio_sva
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               cov: false
+             }
+             {
+               name: hmac
+               fusesoc_core: lowrisc:dv:hmac_sva
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               cov: false
+             }
+             {
+               name: i2c
+               fusesoc_core: lowrisc:dv:i2c_sva
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               cov: false
+             }
+             {
+               name: keymgr
+               fusesoc_core: lowrisc:dv:keymgr_sva
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               cov: false
+             }
+             {
+               name: otp_ctrl
+               fusesoc_core: lowrisc:dv:otp_ctrl_sva
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               cov: false
+             }
+             {
+               name: rv_timer
+               fusesoc_core: lowrisc:dv:rv_timer_sva
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               cov: false
+             }
+             {
+               name: spi_device
+               fusesoc_core: lowrisc:dv:spi_device_sva
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               cov: false
+             }
+             {
+               name: uart
+               fusesoc_core: lowrisc:dv:uart_sva
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               cov: false
              }
             ]
 }

--- a/util/uvmdvgen/sva.core.tpl
+++ b/util/uvmdvgen/sva.core.tpl
@@ -15,6 +15,10 @@ filesets:
       - ${name}_bind.sv
     file_type: systemVerilogSource
 
+  files_formal:
+    depend:
+      - lowrisc:ip:${name}
+
 % if has_ral:
 generate:
   csr_assert_gen:
@@ -25,10 +29,16 @@ generate:
 % endif
 
 targets:
-  default:
+  default: &default_target
     filesets:
       - files_dv
 % if has_ral:
     generate:
       - csr_assert_gen
+  formal:
+    <<: *default_target
+    filesets:
+      - files_formal
+      - files_dv
+    toplevel: ${name}
 % endif


### PR DESCRIPTION
This PR spilts into two commits:

1. Fix fusesoc dependency issue for IPs that has DV testbench.
  Current FPV "formal" target is located in the main core file under `ip/hw/${name}/${name}.core`.
  The dependency issue comes from the auto-generated csr assertion core file, we name it ${name}_sva.core. This core file depends on ${name}_reg_pkg to generate assertions. As most of IPs do not have a separate core file for reg_pkg, this  directly uses ${ip}.core.
  This creates a dependency loop when running formal target. In short:
   Formal targets sits in `${ip}.core`, and imports `${name}_sva.core`, which (in some IPs) depends on `${ip}.core`.

  So the solution in this commit is to move the `formal_target` to `${ip}_sva.core` file instead.

  This commit also update `dvsim` and adds back the DV-verified IPs.

2. This commit fix the `fpv` run file to support this change, and also support ` --flag` option.