### PR TITLE
[reggen] Add a _BIT suffix to bit index constants

### DIFF
--- a/sw/device/lib/aes.c
+++ b/sw/device/lib/aes.c
@@ -16,12 +16,12 @@
 
 void aes_init(aes_cfg_t aes_cfg) {
   uint32_t cfg_val =
-      (aes_cfg.operation << AES_CTRL_SHADOWED_OPERATION) |
+      (aes_cfg.operation << AES_CTRL_SHADOWED_OPERATION_BIT) |
       ((aes_cfg.mode & AES_CTRL_SHADOWED_MODE_MASK)
        << AES_CTRL_SHADOWED_MODE_OFFSET) |
       ((aes_cfg.key_len & AES_CTRL_SHADOWED_KEY_LEN_MASK)
        << AES_CTRL_SHADOWED_KEY_LEN_OFFSET) |
-      (aes_cfg.manual_operation << AES_CTRL_SHADOWED_MANUAL_OPERATION);
+      (aes_cfg.manual_operation << AES_CTRL_SHADOWED_MANUAL_OPERATION_BIT);
   REG32(AES0_BASE_ADDR + AES_CTRL_SHADOWED_REG_OFFSET) = cfg_val;
   REG32(AES0_BASE_ADDR + AES_CTRL_SHADOWED_REG_OFFSET) = cfg_val;
 };
@@ -99,21 +99,22 @@ void aes_data_get(void *data) {
 
 bool aes_data_ready(void) {
   return (REG32(AES0_BASE_ADDR + AES_STATUS_REG_OFFSET) &
-          (0x1u << AES_STATUS_INPUT_READY));
+          (0x1u << AES_STATUS_INPUT_READY_BIT));
 }
 
 bool aes_data_valid(void) {
   return (REG32(AES0_BASE_ADDR + AES_STATUS_REG_OFFSET) &
-          (0x1u << AES_STATUS_OUTPUT_VALID));
+          (0x1u << AES_STATUS_OUTPUT_VALID_BIT));
 }
 
 bool aes_idle(void) {
   return (REG32(AES0_BASE_ADDR + AES_STATUS_REG_OFFSET) &
-          (0x1u << AES_STATUS_IDLE));
+          (0x1u << AES_STATUS_IDLE_BIT));
 }
 
 void aes_manual_trigger(void) {
-  REG32(AES0_BASE_ADDR + AES_TRIGGER_REG_OFFSET) = 0x1u << AES_TRIGGER_START;
+  REG32(AES0_BASE_ADDR + AES_TRIGGER_REG_OFFSET) = 0x1u
+                                                   << AES_TRIGGER_START_BIT;
 }
 
 void aes_clear(void) {
@@ -122,15 +123,15 @@ void aes_clear(void) {
   }
 
   // Disable autostart
-  uint32_t cfg_val = 0x1u << AES_CTRL_SHADOWED_MANUAL_OPERATION;
+  uint32_t cfg_val = 0x1u << AES_CTRL_SHADOWED_MANUAL_OPERATION_BIT;
   REG32(AES0_BASE_ADDR + AES_CTRL_SHADOWED_REG_OFFSET) = cfg_val;
   REG32(AES0_BASE_ADDR + AES_CTRL_SHADOWED_REG_OFFSET) = cfg_val;
 
   // Clear internal key and output registers
   REG32(AES0_BASE_ADDR + AES_TRIGGER_REG_OFFSET) =
-      (0x1u << AES_TRIGGER_KEY_CLEAR) | (0x1u << AES_TRIGGER_IV_CLEAR) |
-      (0x1u << AES_TRIGGER_DATA_IN_CLEAR) |
-      (0x1u << AES_TRIGGER_DATA_OUT_CLEAR);
+      (0x1u << AES_TRIGGER_KEY_CLEAR_BIT) | (0x1u << AES_TRIGGER_IV_CLEAR_BIT) |
+      (0x1u << AES_TRIGGER_DATA_IN_CLEAR_BIT) |
+      (0x1u << AES_TRIGGER_DATA_OUT_CLEAR_BIT);
 
   // Wait for output not valid, and input ready
   while (!(!aes_data_valid() && aes_data_ready())) {

--- a/sw/device/lib/dif/dif_alert_handler.c
+++ b/sw/device/lib/dif/dif_alert_handler.c
@@ -142,22 +142,22 @@ static bool classify_local_alerts(
     bitfield_field32_t field;
     switch (class->local_alerts[i]) {
       case kDifAlertHandlerLocalAlertAlertPingFail:
-        enable_bit = ALERT_HANDLER_LOC_ALERT_EN_EN_LA_0;
+        enable_bit = ALERT_HANDLER_LOC_ALERT_EN_EN_LA_0_BIT;
         field.mask = ALERT_HANDLER_LOC_ALERT_CLASS_CLASS_LA_0_MASK;
         field.index = ALERT_HANDLER_LOC_ALERT_CLASS_CLASS_LA_0_OFFSET;
         break;
       case kDifAlertHandlerLocalAlertEscalationPingFail:
-        enable_bit = ALERT_HANDLER_LOC_ALERT_EN_EN_LA_1;
+        enable_bit = ALERT_HANDLER_LOC_ALERT_EN_EN_LA_1_BIT;
         field.mask = ALERT_HANDLER_LOC_ALERT_CLASS_CLASS_LA_1_MASK;
         field.index = ALERT_HANDLER_LOC_ALERT_CLASS_CLASS_LA_1_OFFSET;
         break;
       case kDifAlertHandlerLocalAlertAlertIntegrityFail:
-        enable_bit = ALERT_HANDLER_LOC_ALERT_EN_EN_LA_2;
+        enable_bit = ALERT_HANDLER_LOC_ALERT_EN_EN_LA_2_BIT;
         field.mask = ALERT_HANDLER_LOC_ALERT_CLASS_CLASS_LA_2_MASK;
         field.index = ALERT_HANDLER_LOC_ALERT_CLASS_CLASS_LA_2_OFFSET;
         break;
       case kDifAlertHandlerLocalAlertEscalationIntegrityFail:
-        enable_bit = ALERT_HANDLER_LOC_ALERT_EN_EN_LA_3;
+        enable_bit = ALERT_HANDLER_LOC_ALERT_EN_EN_LA_3_BIT;
         field.mask = ALERT_HANDLER_LOC_ALERT_CLASS_CLASS_LA_3_MASK;
         field.index = ALERT_HANDLER_LOC_ALERT_CLASS_CLASS_LA_3_OFFSET;
         break;
@@ -234,7 +234,7 @@ static bool configure_class(const dif_alert_handler_t *handler,
                       &use_escalation_protocol)) {
     return false;
   }
-  ctrl_reg = bitfield_bit32_write(ctrl_reg, ALERT_HANDLER_CLASSA_CTRL_EN,
+  ctrl_reg = bitfield_bit32_write(ctrl_reg, ALERT_HANDLER_CLASSA_CTRL_EN_BIT,
                                   use_escalation_protocol);
 
   // Configure the escalation protocol auto-lock flag.
@@ -242,7 +242,7 @@ static bool configure_class(const dif_alert_handler_t *handler,
   if (!toggle_to_bool(class->automatic_locking, &automatic_locking)) {
     return false;
   }
-  ctrl_reg = bitfield_bit32_write(ctrl_reg, ALERT_HANDLER_CLASSA_CTRL_LOCK,
+  ctrl_reg = bitfield_bit32_write(ctrl_reg, ALERT_HANDLER_CLASSA_CTRL_LOCK_BIT,
                                   automatic_locking);
 
   if (class->phase_signals == NULL && class->phase_signals_len != 0) {
@@ -260,22 +260,22 @@ static bool configure_class(const dif_alert_handler_t *handler,
     bitfield_field32_t map_field;
     switch (class->phase_signals[i].phase) {
       case kDifAlertHandlerClassStatePhase0:
-        enable_bit = ALERT_HANDLER_CLASSA_CTRL_EN_E0;
+        enable_bit = ALERT_HANDLER_CLASSA_CTRL_EN_E0_BIT;
         map_field.mask = ALERT_HANDLER_CLASSA_CTRL_MAP_E0_MASK;
         map_field.index = ALERT_HANDLER_CLASSA_CTRL_MAP_E0_OFFSET;
         break;
       case kDifAlertHandlerClassStatePhase1:
-        enable_bit = ALERT_HANDLER_CLASSA_CTRL_EN_E1;
+        enable_bit = ALERT_HANDLER_CLASSA_CTRL_EN_E1_BIT;
         map_field.mask = ALERT_HANDLER_CLASSA_CTRL_MAP_E1_MASK;
         map_field.index = ALERT_HANDLER_CLASSA_CTRL_MAP_E1_OFFSET;
         break;
       case kDifAlertHandlerClassStatePhase2:
-        enable_bit = ALERT_HANDLER_CLASSA_CTRL_EN_E2;
+        enable_bit = ALERT_HANDLER_CLASSA_CTRL_EN_E2_BIT;
         map_field.mask = ALERT_HANDLER_CLASSA_CTRL_MAP_E2_MASK;
         map_field.index = ALERT_HANDLER_CLASSA_CTRL_MAP_E2_OFFSET;
         break;
       case kDifAlertHandlerClassStatePhase3:
-        enable_bit = ALERT_HANDLER_CLASSA_CTRL_EN_E3;
+        enable_bit = ALERT_HANDLER_CLASSA_CTRL_EN_E3_BIT;
         map_field.mask = ALERT_HANDLER_CLASSA_CTRL_MAP_E3_MASK;
         map_field.index = ALERT_HANDLER_CLASSA_CTRL_MAP_E3_OFFSET;
         break;
@@ -463,7 +463,7 @@ dif_alert_handler_result_t dif_alert_handler_lock(
     return kDifAlertHandlerBadArg;
   }
 
-  uint32_t reg = bitfield_bit32_write(0, ALERT_HANDLER_REGEN_REGEN, true);
+  uint32_t reg = bitfield_bit32_write(0, ALERT_HANDLER_REGEN_REGEN_BIT, true);
   mmio_region_write32(handler->params.base_addr, ALERT_HANDLER_REGEN_REG_OFFSET,
                       reg);
 
@@ -479,7 +479,7 @@ dif_alert_handler_result_t dif_alert_handler_is_locked(
   uint32_t reg = mmio_region_read32(handler->params.base_addr,
                                     ALERT_HANDLER_REGEN_REG_OFFSET);
   // Note that "true" indicates "enabled", so we negated to get "locked".
-  *is_locked = !bitfield_bit32_read(reg, ALERT_HANDLER_REGEN_REGEN);
+  *is_locked = !bitfield_bit32_read(reg, ALERT_HANDLER_REGEN_REGEN_BIT);
 
   return kDifAlertHandlerOk;
 }
@@ -489,16 +489,16 @@ static bool irq_index(dif_alert_handler_class_t class,
                       bitfield_bit32_index_t *index) {
   switch (class) {
     case kDifAlertHandlerClassA:
-      *index = ALERT_HANDLER_INTR_COMMON_CLASSA;
+      *index = ALERT_HANDLER_INTR_COMMON_CLASSA_BIT;
       break;
     case kDifAlertHandlerClassB:
-      *index = ALERT_HANDLER_INTR_COMMON_CLASSB;
+      *index = ALERT_HANDLER_INTR_COMMON_CLASSB_BIT;
       break;
     case kDifAlertHandlerClassC:
-      *index = ALERT_HANDLER_INTR_COMMON_CLASSC;
+      *index = ALERT_HANDLER_INTR_COMMON_CLASSC_BIT;
       break;
     case kDifAlertHandlerClassD:
-      *index = ALERT_HANDLER_INTR_COMMON_CLASSD;
+      *index = ALERT_HANDLER_INTR_COMMON_CLASSD_BIT;
       break;
     default:
       return false;
@@ -673,16 +673,16 @@ static bool loc_alert_index(dif_alert_handler_local_alert_t alert,
                             bitfield_bit32_index_t *index) {
   switch (alert) {
     case kDifAlertHandlerLocalAlertAlertPingFail:
-      *index = ALERT_HANDLER_LOC_ALERT_CAUSE_LA_0;
+      *index = ALERT_HANDLER_LOC_ALERT_CAUSE_LA_0_BIT;
       break;
     case kDifAlertHandlerLocalAlertEscalationPingFail:
-      *index = ALERT_HANDLER_LOC_ALERT_CAUSE_LA_1;
+      *index = ALERT_HANDLER_LOC_ALERT_CAUSE_LA_1_BIT;
       break;
     case kDifAlertHandlerLocalAlertAlertIntegrityFail:
-      *index = ALERT_HANDLER_LOC_ALERT_CAUSE_LA_2;
+      *index = ALERT_HANDLER_LOC_ALERT_CAUSE_LA_2_BIT;
       break;
     case kDifAlertHandlerLocalAlertEscalationIntegrityFail:
-      *index = ALERT_HANDLER_LOC_ALERT_CAUSE_LA_3;
+      *index = ALERT_HANDLER_LOC_ALERT_CAUSE_LA_3_BIT;
       break;
     default:
       return false;
@@ -763,7 +763,7 @@ dif_alert_handler_result_t dif_alert_handler_escalation_can_clear(
 
   uint32_t reg = mmio_region_read32(handler->params.base_addr, reg_offset);
   *can_clear =
-      bitfield_bit32_read(reg, ALERT_HANDLER_CLASSA_CLREN_CLASSA_CLREN);
+      bitfield_bit32_read(reg, ALERT_HANDLER_CLASSA_CLREN_CLASSA_CLREN_BIT);
 
   return kDifAlertHandlerOk;
 }
@@ -779,8 +779,8 @@ dif_alert_handler_result_t dif_alert_handler_escalation_disable_clearing(
     return kDifAlertHandlerBadArg;
   }
 
-  uint32_t reg =
-      bitfield_bit32_write(0, ALERT_HANDLER_CLASSA_CLREN_CLASSA_CLREN, true);
+  uint32_t reg = bitfield_bit32_write(
+      0, ALERT_HANDLER_CLASSA_CLREN_CLASSA_CLREN_BIT, true);
   mmio_region_write32(handler->params.base_addr, reg_offset, reg);
 
   return kDifAlertHandlerOk;
@@ -811,7 +811,7 @@ dif_alert_handler_result_t dif_alert_handler_escalation_clear(
   }
 
   uint32_t reg =
-      bitfield_bit32_write(0, ALERT_HANDLER_CLASSA_CLR_CLASSA_CLR, true);
+      bitfield_bit32_write(0, ALERT_HANDLER_CLASSA_CLR_CLASSA_CLR_BIT, true);
   mmio_region_write32(handler->params.base_addr, reg_offset, reg);
 
   return kDifAlertHandlerOk;

--- a/sw/device/lib/dif/dif_i2c.c
+++ b/sw/device/lib/dif/dif_i2c.c
@@ -226,7 +226,7 @@ dif_i2c_result_t dif_i2c_reset_rx_fifo(const dif_i2c_t *i2c) {
 
   uint32_t reg =
       mmio_region_read32(i2c->params.base_addr, I2C_FIFO_CTRL_REG_OFFSET);
-  reg = bitfield_bit32_write(reg, I2C_FIFO_CTRL_RXRST, true);
+  reg = bitfield_bit32_write(reg, I2C_FIFO_CTRL_RXRST_BIT, true);
   mmio_region_write32(i2c->params.base_addr, I2C_FIFO_CTRL_REG_OFFSET, reg);
 
   return kDifI2cOk;
@@ -239,7 +239,7 @@ dif_i2c_result_t dif_i2c_reset_fmt_fifo(const dif_i2c_t *i2c) {
 
   uint32_t reg =
       mmio_region_read32(i2c->params.base_addr, I2C_FIFO_CTRL_REG_OFFSET);
-  reg = bitfield_bit32_write(reg, I2C_FIFO_CTRL_FMTRST, true);
+  reg = bitfield_bit32_write(reg, I2C_FIFO_CTRL_FMTRST_BIT, true);
   mmio_region_write32(i2c->params.base_addr, I2C_FIFO_CTRL_REG_OFFSET, reg);
 
   return kDifI2cOk;
@@ -315,31 +315,31 @@ DIF_WARN_UNUSED_RESULT
 static bool irq_index(dif_i2c_irq_t irq, bitfield_bit32_index_t *bit_index) {
   switch (irq) {
     case kDifI2cIrqFmtWatermarkUnderflow:
-      *bit_index = I2C_INTR_COMMON_FMT_WATERMARK;
+      *bit_index = I2C_INTR_COMMON_FMT_WATERMARK_BIT;
       break;
     case kDifI2cIrqRxWatermarkOverflow:
-      *bit_index = I2C_INTR_COMMON_RX_WATERMARK;
+      *bit_index = I2C_INTR_COMMON_RX_WATERMARK_BIT;
       break;
     case kDifI2cIrqFmtFifoOverflow:
-      *bit_index = I2C_INTR_COMMON_FMT_OVERFLOW;
+      *bit_index = I2C_INTR_COMMON_FMT_OVERFLOW_BIT;
       break;
     case kDifI2cIrqRxFifoOverflow:
-      *bit_index = I2C_INTR_COMMON_RX_OVERFLOW;
+      *bit_index = I2C_INTR_COMMON_RX_OVERFLOW_BIT;
       break;
     case kDifI2cIrqNak:
-      *bit_index = I2C_INTR_COMMON_NAK;
+      *bit_index = I2C_INTR_COMMON_NAK_BIT;
       break;
     case kDifI2cIrqSclInterference:
-      *bit_index = I2C_INTR_COMMON_SCL_INTERFERENCE;
+      *bit_index = I2C_INTR_COMMON_SCL_INTERFERENCE_BIT;
       break;
     case kDifI2cIrqSdaInterference:
-      *bit_index = I2C_INTR_COMMON_SDA_INTERFERENCE;
+      *bit_index = I2C_INTR_COMMON_SDA_INTERFERENCE_BIT;
       break;
     case kDifI2cIrqClockStretchTimeout:
-      *bit_index = I2C_INTR_COMMON_STRETCH_TIMEOUT;
+      *bit_index = I2C_INTR_COMMON_STRETCH_TIMEOUT_BIT;
       break;
     case kDifI2cIrqSdaUnstable:
-      *bit_index = I2C_INTR_COMMON_SDA_UNSTABLE;
+      *bit_index = I2C_INTR_COMMON_SDA_UNSTABLE_BIT;
       break;
     default:
       return false;
@@ -497,7 +497,7 @@ dif_i2c_result_t dif_i2c_host_set_enabled(const dif_i2c_t *i2c,
   }
 
   uint32_t reg = mmio_region_read32(i2c->params.base_addr, I2C_CTRL_REG_OFFSET);
-  reg = bitfield_bit32_write(reg, I2C_CTRL_ENABLEHOST, flag);
+  reg = bitfield_bit32_write(reg, I2C_CTRL_ENABLEHOST_BIT, flag);
   mmio_region_write32(i2c->params.base_addr, I2C_CTRL_REG_OFFSET, reg);
 
   return kDifI2cOk;
@@ -522,7 +522,7 @@ dif_i2c_result_t dif_i2c_override_set_enabled(const dif_i2c_t *i2c,
   }
 
   uint32_t reg = mmio_region_read32(i2c->params.base_addr, I2C_OVRD_REG_OFFSET);
-  reg = bitfield_bit32_write(reg, I2C_OVRD_TXOVRDEN, flag);
+  reg = bitfield_bit32_write(reg, I2C_OVRD_TXOVRDEN_BIT, flag);
   mmio_region_write32(i2c->params.base_addr, I2C_OVRD_REG_OFFSET, reg);
 
   return kDifI2cOk;
@@ -536,8 +536,8 @@ dif_i2c_result_t dif_i2c_override_drive_pins(const dif_i2c_t *i2c, bool scl,
 
   uint32_t override_val =
       mmio_region_read32(i2c->params.base_addr, I2C_OVRD_REG_OFFSET);
-  override_val = bitfield_bit32_write(override_val, I2C_OVRD_SCLVAL, scl);
-  override_val = bitfield_bit32_write(override_val, I2C_OVRD_SDAVAL, sda);
+  override_val = bitfield_bit32_write(override_val, I2C_OVRD_SCLVAL_BIT, scl);
+  override_val = bitfield_bit32_write(override_val, I2C_OVRD_SDAVAL_BIT, sda);
   mmio_region_write32(i2c->params.base_addr, I2C_OVRD_REG_OFFSET, override_val);
 
   return kDifI2cOk;
@@ -639,12 +639,13 @@ dif_i2c_result_t dif_i2c_write_byte_raw(const dif_i2c_t *i2c, uint8_t byte,
           .mask = I2C_FDATA_FBYTE_MASK, .index = I2C_FDATA_FBYTE_OFFSET,
       },
       byte);
-  fmt_byte = bitfield_bit32_write(fmt_byte, I2C_FDATA_START, flags.start);
-  fmt_byte = bitfield_bit32_write(fmt_byte, I2C_FDATA_STOP, flags.stop);
-  fmt_byte = bitfield_bit32_write(fmt_byte, I2C_FDATA_READ, flags.read);
-  fmt_byte = bitfield_bit32_write(fmt_byte, I2C_FDATA_RCONT, flags.read_cont);
+  fmt_byte = bitfield_bit32_write(fmt_byte, I2C_FDATA_START_BIT, flags.start);
+  fmt_byte = bitfield_bit32_write(fmt_byte, I2C_FDATA_STOP_BIT, flags.stop);
+  fmt_byte = bitfield_bit32_write(fmt_byte, I2C_FDATA_READ_BIT, flags.read);
   fmt_byte =
-      bitfield_bit32_write(fmt_byte, I2C_FDATA_NAKOK, flags.suppress_nak_irq);
+      bitfield_bit32_write(fmt_byte, I2C_FDATA_RCONT_BIT, flags.read_cont);
+  fmt_byte = bitfield_bit32_write(fmt_byte, I2C_FDATA_NAKOK_BIT,
+                                  flags.suppress_nak_irq);
   mmio_region_write32(i2c->params.base_addr, I2C_FDATA_REG_OFFSET, fmt_byte);
 
   return kDifI2cOk;

--- a/sw/device/lib/dif/dif_otbn.c
+++ b/sw/device/lib/dif/dif_otbn.c
@@ -23,10 +23,10 @@ static bool irq_bit_index_get(dif_otbn_interrupt_t irq_type,
   ptrdiff_t offset;
   switch (irq_type) {
     case kDifOtbnInterruptDone:
-      offset = OTBN_INTR_COMMON_DONE;
+      offset = OTBN_INTR_COMMON_DONE_BIT;
       break;
     case kDifOtbnInterruptErr:
-      offset = OTBN_INTR_COMMON_ERR;
+      offset = OTBN_INTR_COMMON_ERR_BIT;
       break;
     default:
       return false;
@@ -184,7 +184,7 @@ dif_otbn_result_t dif_otbn_start(const dif_otbn_t *otbn,
   mmio_region_write32(otbn->base_addr, OTBN_START_ADDR_REG_OFFSET, start_addr);
 
   uint32_t cmd_reg_val = 0x0u;
-  cmd_reg_val = bitfield_bit32_write(cmd_reg_val, OTBN_CMD_START, true);
+  cmd_reg_val = bitfield_bit32_write(cmd_reg_val, OTBN_CMD_START_BIT, true);
   mmio_region_write32(otbn->base_addr, OTBN_CMD_REG_OFFSET, cmd_reg_val);
 
   return kDifOtbnOk;
@@ -196,10 +196,10 @@ dif_otbn_result_t dif_otbn_is_busy(const dif_otbn_t *otbn, bool *busy) {
   }
 
   uint32_t status = mmio_region_read32(otbn->base_addr, OTBN_STATUS_REG_OFFSET);
-  *busy =
-      bitfield_field32_read(status, (bitfield_field32_t){
-                                        .mask = 1, .index = OTBN_STATUS_BUSY,
-                                    });
+  *busy = bitfield_field32_read(status, (bitfield_field32_t){
+                                            .mask = 1,
+                                            .index = OTBN_STATUS_BUSY_BIT,
+                                        });
 
   return kDifOtbnOk;
 }

--- a/sw/device/lib/dif/dif_otp_ctrl.c
+++ b/sw/device/lib/dif/dif_otp_ctrl.c
@@ -30,7 +30,7 @@ dif_otp_ctrl_result_t dif_otp_ctrl_init(dif_otp_ctrl_params_t params,
 static bool checks_are_locked(const dif_otp_ctrl_t *otp) {
   uint32_t locked = mmio_region_read32(otp->params.base_addr,
                                        OTP_CTRL_CHECK_REGWEN_REG_OFFSET);
-  return !bitfield_bit32_read(locked, OTP_CTRL_CHECK_REGWEN_CHECK_REGWEN);
+  return !bitfield_bit32_read(locked, OTP_CTRL_CHECK_REGWEN_CHECK_REGWEN_BIT);
 }
 
 dif_otp_ctrl_lockable_result_t dif_otp_ctrl_configure(
@@ -64,7 +64,7 @@ dif_otp_ctrl_lockable_result_t dif_otp_ctrl_check_integrity(
   }
 
   uint32_t reg =
-      bitfield_bit32_write(0, OTP_CTRL_CHECK_TRIGGER_INTEGRITY, true);
+      bitfield_bit32_write(0, OTP_CTRL_CHECK_TRIGGER_INTEGRITY_BIT, true);
   mmio_region_write32(otp->params.base_addr, OTP_CTRL_CHECK_TRIGGER_REG_OFFSET,
                       reg);
 
@@ -81,7 +81,7 @@ dif_otp_ctrl_lockable_result_t dif_otp_ctrl_check_consistency(
   }
 
   uint32_t reg =
-      bitfield_bit32_write(0, OTP_CTRL_CHECK_TRIGGER_CONSISTENCY, true);
+      bitfield_bit32_write(0, OTP_CTRL_CHECK_TRIGGER_CONSISTENCY_BIT, true);
   mmio_region_write32(otp->params.base_addr, OTP_CTRL_CHECK_TRIGGER_REG_OFFSET,
                       reg);
 
@@ -94,7 +94,7 @@ dif_otp_ctrl_result_t dif_otp_ctrl_lock_config(const dif_otp_ctrl_t *otp) {
   }
 
   uint32_t reg =
-      bitfield_bit32_write(0, OTP_CTRL_CHECK_REGWEN_CHECK_REGWEN, true);
+      bitfield_bit32_write(0, OTP_CTRL_CHECK_REGWEN_CHECK_REGWEN_BIT, true);
   mmio_region_write32(otp->params.base_addr, OTP_CTRL_CHECK_REGWEN_REG_OFFSET,
                       reg);
 
@@ -117,11 +117,11 @@ static bool sw_read_lock_reg_offset(dif_otp_ctrl_partition_t partition,
   switch (partition) {
     case kDifOtpCtrlPartitionCreatorSwCfg:
       *reg_offset = OTP_CTRL_CREATOR_SW_CFG_READ_LOCK_REG_OFFSET;
-      *index = OTP_CTRL_CREATOR_SW_CFG_READ_LOCK_CREATOR_SW_CFG_READ_LOCK;
+      *index = OTP_CTRL_CREATOR_SW_CFG_READ_LOCK_CREATOR_SW_CFG_READ_LOCK_BIT;
       break;
     case kDifOtpCtrlPartitionOwnerSwCfg:
       *reg_offset = OTP_CTRL_OWNER_SW_CFG_READ_LOCK_REG_OFFSET;
-      *index = OTP_CTRL_OWNER_SW_CFG_READ_LOCK_OWNER_SW_CFG_READ_LOCK;
+      *index = OTP_CTRL_OWNER_SW_CFG_READ_LOCK_OWNER_SW_CFG_READ_LOCK_BIT;
       break;
     default:
       return false;
@@ -168,10 +168,10 @@ dif_otp_ctrl_result_t dif_otp_ctrl_reading_is_locked(
 static bool irq_index(dif_otp_ctrl_irq_t irq, bitfield_bit32_index_t *index) {
   switch (irq) {
     case kDifOtpCtrlIrqDone:
-      *index = OTP_CTRL_INTR_COMMON_OTP_OPERATION_DONE;
+      *index = OTP_CTRL_INTR_COMMON_OTP_OPERATION_DONE_BIT;
       break;
     case kDifOtpCtrlIrqError:
-      *index = OTP_CTRL_INTR_COMMON_OTP_ERROR;
+      *index = OTP_CTRL_INTR_COMMON_OTP_ERROR_BIT;
       break;
     default:
       return false;
@@ -322,23 +322,24 @@ dif_otp_ctrl_result_t dif_otp_ctrl_get_status(const dif_otp_ctrl_t *otp,
 
   static const bitfield_bit32_index_t kIndices[] = {
       [kDifOtpCtrlStatusCodeCreatorSwCfgError] =
-          OTP_CTRL_STATUS_CREATOR_SW_CFG_ERROR,
+          OTP_CTRL_STATUS_CREATOR_SW_CFG_ERROR_BIT,
       [kDifOtpCtrlStatusCodeOwnerSwCfgError] =
-          OTP_CTRL_STATUS_OWNER_SW_CFG_ERROR,
-      [kDifOtpCtrlStatusCodeHwCfgError] = OTP_CTRL_STATUS_HW_CFG_ERROR,
-      [kDifOtpCtrlStatusCodeLifeCycleError] = OTP_CTRL_STATUS_LIFE_CYCLE_ERROR,
-      [kDifOtpCtrlStatusCodeSecret0Error] = OTP_CTRL_STATUS_SECRET0_ERROR,
-      [kDifOtpCtrlStatusCodeSecret1Error] = OTP_CTRL_STATUS_SECRET1_ERROR,
-      [kDifOtpCtrlStatusCodeSecret2Error] = OTP_CTRL_STATUS_SECRET2_ERROR,
-      [kDifOtpCtrlStatusCodeDaiError] = OTP_CTRL_STATUS_DAI_ERROR,
-      [kDifOtpCtrlStatusCodeLciError] = OTP_CTRL_STATUS_LCI_ERROR,
-      [kDifOtpCtrlStatusCodeTimeoutError] = OTP_CTRL_STATUS_TIMEOUT_ERROR,
-      [kDifOtpCtrlStatusCodeLfsrError] = OTP_CTRL_STATUS_LFSR_FSM_ERROR,
+          OTP_CTRL_STATUS_OWNER_SW_CFG_ERROR_BIT,
+      [kDifOtpCtrlStatusCodeHwCfgError] = OTP_CTRL_STATUS_HW_CFG_ERROR_BIT,
+      [kDifOtpCtrlStatusCodeLifeCycleError] =
+          OTP_CTRL_STATUS_LIFE_CYCLE_ERROR_BIT,
+      [kDifOtpCtrlStatusCodeSecret0Error] = OTP_CTRL_STATUS_SECRET0_ERROR_BIT,
+      [kDifOtpCtrlStatusCodeSecret1Error] = OTP_CTRL_STATUS_SECRET1_ERROR_BIT,
+      [kDifOtpCtrlStatusCodeSecret2Error] = OTP_CTRL_STATUS_SECRET2_ERROR_BIT,
+      [kDifOtpCtrlStatusCodeDaiError] = OTP_CTRL_STATUS_DAI_ERROR_BIT,
+      [kDifOtpCtrlStatusCodeLciError] = OTP_CTRL_STATUS_LCI_ERROR_BIT,
+      [kDifOtpCtrlStatusCodeTimeoutError] = OTP_CTRL_STATUS_TIMEOUT_ERROR_BIT,
+      [kDifOtpCtrlStatusCodeLfsrError] = OTP_CTRL_STATUS_LFSR_FSM_ERROR_BIT,
       [kDifOtpCtrlStatusCodeScramblingError] =
-          OTP_CTRL_STATUS_SCRAMBLING_FSM_ERROR,
-      [kDifOtpCtrlStatusCodeKdfError] = OTP_CTRL_STATUS_KEY_DERIV_FSM_ERROR,
-      [kDifOtpCtrlStatusCodeDaiIdle] = OTP_CTRL_STATUS_DAI_IDLE,
-      [kDifOtpCtrlStatusCodeCheckPending] = OTP_CTRL_STATUS_CHECK_PENDING,
+          OTP_CTRL_STATUS_SCRAMBLING_FSM_ERROR_BIT,
+      [kDifOtpCtrlStatusCodeKdfError] = OTP_CTRL_STATUS_KEY_DERIV_FSM_ERROR_BIT,
+      [kDifOtpCtrlStatusCodeDaiIdle] = OTP_CTRL_STATUS_DAI_IDLE_BIT,
+      [kDifOtpCtrlStatusCodeCheckPending] = OTP_CTRL_STATUS_CHECK_PENDING_BIT,
   };
 
   status->codes = 0;
@@ -548,7 +549,7 @@ dif_otp_ctrl_dai_result_t dif_otp_ctrl_dai_read_start(
   uint32_t busy = mmio_region_read32(otp->params.base_addr,
                                      OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET);
   if (!bitfield_bit32_read(
-          busy, OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN)) {
+          busy, OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN_BIT)) {
     return kDifOtpCtrlDaiBusy;
   }
 
@@ -556,7 +557,8 @@ dif_otp_ctrl_dai_result_t dif_otp_ctrl_dai_read_start(
   mmio_region_write32(otp->params.base_addr,
                       OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET, address);
 
-  uint32_t cmd = bitfield_bit32_write(0, OTP_CTRL_DIRECT_ACCESS_CMD_READ, true);
+  uint32_t cmd =
+      bitfield_bit32_write(0, OTP_CTRL_DIRECT_ACCESS_CMD_READ_BIT, true);
   mmio_region_write32(otp->params.base_addr,
                       OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET, cmd);
 
@@ -572,7 +574,7 @@ dif_otp_ctrl_dai_result_t dif_otp_ctrl_dai_read32_end(const dif_otp_ctrl_t *otp,
   uint32_t busy = mmio_region_read32(otp->params.base_addr,
                                      OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET);
   if (!bitfield_bit32_read(
-          busy, OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN)) {
+          busy, OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN_BIT)) {
     return kDifOtpCtrlDaiBusy;
   }
 
@@ -590,7 +592,7 @@ dif_otp_ctrl_dai_result_t dif_otp_ctrl_dai_read64_end(const dif_otp_ctrl_t *otp,
   uint32_t busy = mmio_region_read32(otp->params.base_addr,
                                      OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET);
   if (!bitfield_bit32_read(
-          busy, OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN)) {
+          busy, OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN_BIT)) {
     return kDifOtpCtrlDaiBusy;
   }
 
@@ -633,7 +635,7 @@ dif_otp_ctrl_dai_result_t dif_otp_ctrl_dai_program32(
   uint32_t busy = mmio_region_read32(otp->params.base_addr,
                                      OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET);
   if (!bitfield_bit32_read(
-          busy, OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN)) {
+          busy, OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN_BIT)) {
     return kDifOtpCtrlDaiBusy;
   }
 
@@ -645,7 +647,7 @@ dif_otp_ctrl_dai_result_t dif_otp_ctrl_dai_program32(
                       OTP_CTRL_DIRECT_ACCESS_WDATA_0_REG_OFFSET, value);
 
   uint32_t cmd =
-      bitfield_bit32_write(0, OTP_CTRL_DIRECT_ACCESS_CMD_WRITE, true);
+      bitfield_bit32_write(0, OTP_CTRL_DIRECT_ACCESS_CMD_WRITE_BIT, true);
   mmio_region_write32(otp->params.base_addr,
                       OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET, cmd);
 
@@ -679,7 +681,7 @@ dif_otp_ctrl_dai_result_t dif_otp_ctrl_dai_program64(
   uint32_t busy = mmio_region_read32(otp->params.base_addr,
                                      OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET);
   if (!bitfield_bit32_read(
-          busy, OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN)) {
+          busy, OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN_BIT)) {
     return kDifOtpCtrlDaiBusy;
   }
 
@@ -694,7 +696,7 @@ dif_otp_ctrl_dai_result_t dif_otp_ctrl_dai_program64(
                       OTP_CTRL_DIRECT_ACCESS_WDATA_1_REG_OFFSET, value >> 32);
 
   uint32_t cmd =
-      bitfield_bit32_write(0, OTP_CTRL_DIRECT_ACCESS_CMD_WRITE, true);
+      bitfield_bit32_write(0, OTP_CTRL_DIRECT_ACCESS_CMD_WRITE_BIT, true);
   mmio_region_write32(otp->params.base_addr,
                       OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET, cmd);
 
@@ -723,7 +725,7 @@ dif_otp_ctrl_dai_result_t dif_otp_ctrl_dai_digest(
   uint32_t busy = mmio_region_read32(otp->params.base_addr,
                                      OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET);
   if (!bitfield_bit32_read(
-          busy, OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN)) {
+          busy, OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN_BIT)) {
     return kDifOtpCtrlDaiBusy;
   }
 
@@ -743,8 +745,9 @@ dif_otp_ctrl_dai_result_t dif_otp_ctrl_dai_digest(
                         digest >> 32);
   }
 
-  bitfield_bit32_index_t cmd_bit = is_sw ? OTP_CTRL_DIRECT_ACCESS_CMD_WRITE
-                                         : OTP_CTRL_DIRECT_ACCESS_CMD_DIGEST;
+  bitfield_bit32_index_t cmd_bit = is_sw
+                                       ? OTP_CTRL_DIRECT_ACCESS_CMD_WRITE_BIT
+                                       : OTP_CTRL_DIRECT_ACCESS_CMD_DIGEST_BIT;
   uint32_t cmd = bitfield_bit32_write(0, cmd_bit, true);
   mmio_region_write32(otp->params.base_addr,
                       OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET, cmd);

--- a/sw/device/lib/dif/dif_pwrmgr.c
+++ b/sw/device/lib/dif/dif_pwrmgr.c
@@ -18,32 +18,32 @@
 
 /**
  * Relevant bits of the control register must start at
- * `PWRMGR_CONTROL_CORE_CLK_EN` and be in the same order as
+ * `PWRMGR_CONTROL_CORE_CLK_EN_BIT` and be in the same order as
  * `dif_pwrmgr_domain_option_t` constants.
  */
 _Static_assert(kDifPwrmgrDomainOptionCoreClockInLowPower ==
-                   (1u << (PWRMGR_CONTROL_CORE_CLK_EN -
-                           PWRMGR_CONTROL_CORE_CLK_EN)),
+                   (1u << (PWRMGR_CONTROL_CORE_CLK_EN_BIT -
+                           PWRMGR_CONTROL_CORE_CLK_EN_BIT)),
                "Layout of control register changed.");
 
 _Static_assert(kDifPwrmgrDomainOptionIoClockInLowPower ==
-                   (1u << (PWRMGR_CONTROL_IO_CLK_EN -
-                           PWRMGR_CONTROL_CORE_CLK_EN)),
+                   (1u << (PWRMGR_CONTROL_IO_CLK_EN_BIT -
+                           PWRMGR_CONTROL_CORE_CLK_EN_BIT)),
                "Layout of control register changed.");
 
 _Static_assert(kDifPwrmgrDomainOptionUsbClockInLowPower ==
-                   (1u << (PWRMGR_CONTROL_USB_CLK_EN_LP -
-                           PWRMGR_CONTROL_CORE_CLK_EN)),
+                   (1u << (PWRMGR_CONTROL_USB_CLK_EN_LP_BIT -
+                           PWRMGR_CONTROL_CORE_CLK_EN_BIT)),
                "Layout of control register changed.");
 
 _Static_assert(kDifPwrmgrDomainOptionUsbClockInActivePower ==
-                   (1u << (PWRMGR_CONTROL_USB_CLK_EN_ACTIVE -
-                           PWRMGR_CONTROL_CORE_CLK_EN)),
+                   (1u << (PWRMGR_CONTROL_USB_CLK_EN_ACTIVE_BIT -
+                           PWRMGR_CONTROL_CORE_CLK_EN_BIT)),
                "Layout of control register changed.");
 
 _Static_assert(kDifPwrmgrDomainOptionMainPowerInLowPower ==
-                   (1u << (PWRMGR_CONTROL_MAIN_PD_N -
-                           PWRMGR_CONTROL_CORE_CLK_EN)),
+                   (1u << (PWRMGR_CONTROL_MAIN_PD_N_BIT -
+                           PWRMGR_CONTROL_CORE_CLK_EN_BIT)),
                "Layout of control register changed.");
 
 /**
@@ -56,7 +56,7 @@ static const bitfield_field32_t kDomainConfigBitfield = {
             kDifPwrmgrDomainOptionUsbClockInLowPower |
             kDifPwrmgrDomainOptionUsbClockInActivePower |
             kDifPwrmgrDomainOptionMainPowerInLowPower,
-    .index = PWRMGR_CONTROL_CORE_CLK_EN,
+    .index = PWRMGR_CONTROL_CORE_CLK_EN_BIT,
 };
 
 /**
@@ -64,23 +64,24 @@ static const bitfield_field32_t kDomainConfigBitfield = {
  * be in the same order as `dif_pwrmgr_wakeup_request_source_t` constants.
  */
 _Static_assert(kDifPwrmgrWakeupRequestSourceOne ==
-                   (1u << PWRMGR_WAKEUP_EN_EN_0),
+                   (1u << PWRMGR_WAKEUP_EN_EN_0_BIT),
                "Layout of WAKEUP_EN register changed.");
 _Static_assert(kDifPwrmgrWakeupRequestSourceOne ==
-                   (1u << PWRMGR_WAKE_INFO_REASONS),
+                   (1u << PWRMGR_WAKE_INFO_REASONS_BIT),
                "Layout of WAKE_INFO register changed.");
 
 /**
  * Relevant bits of the RESET_EN register must start at `0` and be in the same
  * order as `dif_pwrmgr_reset_request_source_t` constants.
  */
-_Static_assert(kDifPwrmgrResetRequestSourceOne == (1u << PWRMGR_RESET_EN_EN_0),
+_Static_assert(kDifPwrmgrResetRequestSourceOne ==
+                   (1u << PWRMGR_RESET_EN_EN_0_BIT),
                "Layout of RESET_EN register changed.");
 
 /**
  * `dif_pwrmgr_irq_t` constants must match the corresponding generated values.
  */
-_Static_assert(kDifPwrmgrIrqWakeup == PWRMGR_INTR_COMMON_WAKEUP,
+_Static_assert(kDifPwrmgrIrqWakeup == PWRMGR_INTR_COMMON_WAKEUP_BIT,
                "Layout of interrupt registers changed.");
 
 /**
@@ -105,7 +106,7 @@ static const request_reg_info_t request_reg_infos[2] = {
     [kDifPwrmgrReqTypeWakeup] =
         {
             .write_enable_reg_offset = PWRMGR_WAKEUP_EN_REGWEN_REG_OFFSET,
-            .write_enable_bit_index = PWRMGR_WAKEUP_EN_REGWEN_EN,
+            .write_enable_bit_index = PWRMGR_WAKEUP_EN_REGWEN_EN_BIT,
             .sources_enable_reg_offset = PWRMGR_WAKEUP_EN_REG_OFFSET,
             .cur_req_sources_reg_offset = PWRMGR_WAKE_STATUS_REG_OFFSET,
             .bitfield =
@@ -117,7 +118,7 @@ static const request_reg_info_t request_reg_infos[2] = {
     [kDifPwrmgrReqTypeReset] =
         {
             .write_enable_reg_offset = PWRMGR_RESET_EN_REGWEN_REG_OFFSET,
-            .write_enable_bit_index = PWRMGR_RESET_EN_REGWEN_EN,
+            .write_enable_bit_index = PWRMGR_RESET_EN_REGWEN_EN_BIT,
             .sources_enable_reg_offset = PWRMGR_RESET_EN_REG_OFFSET,
             .cur_req_sources_reg_offset = PWRMGR_RESET_STATUS_REG_OFFSET,
             .bitfield =
@@ -186,11 +187,11 @@ static bool is_valid_for_bitfield(uint32_t val, bitfield_field32_t bitfield) {
  */
 DIF_WARN_UNUSED_RESULT
 static bool control_register_is_locked(const dif_pwrmgr_t *pwrmgr) {
-  // Control register is locked when `PWRMGR_CTRL_CFG_REGWEN_EN` bit is 0.
+  // Control register is locked when `PWRMGR_CTRL_CFG_REGWEN_EN_BIT` bit is 0.
   return !bitfield_bit32_read(
       mmio_region_read32(pwrmgr->params.base_addr,
                          PWRMGR_CTRL_CFG_REGWEN_REG_OFFSET),
-      PWRMGR_CTRL_CFG_REGWEN_EN);
+      PWRMGR_CTRL_CFG_REGWEN_EN_BIT);
 }
 
 /**
@@ -201,11 +202,12 @@ static bool control_register_is_locked(const dif_pwrmgr_t *pwrmgr) {
  */
 static void sync_slow_clock_domain_polled(const dif_pwrmgr_t *pwrmgr) {
   // Start sync and wait for it to finish.
-  mmio_region_write32(pwrmgr->params.base_addr, PWRMGR_CFG_CDC_SYNC_REG_OFFSET,
-                      bitfield_bit32_write(0, PWRMGR_CFG_CDC_SYNC_SYNC, true));
+  mmio_region_write32(
+      pwrmgr->params.base_addr, PWRMGR_CFG_CDC_SYNC_REG_OFFSET,
+      bitfield_bit32_write(0, PWRMGR_CFG_CDC_SYNC_SYNC_BIT, true));
   while (bitfield_bit32_read(mmio_region_read32(pwrmgr->params.base_addr,
                                                 PWRMGR_CFG_CDC_SYNC_REG_OFFSET),
-                             PWRMGR_CFG_CDC_SYNC_SYNC)) {
+                             PWRMGR_CFG_CDC_SYNC_SYNC_BIT)) {
   }
 }
 
@@ -251,7 +253,7 @@ dif_pwrmgr_config_result_t dif_pwrmgr_low_power_set_enabled(
   uint32_t reg_val =
       mmio_region_read32(pwrmgr->params.base_addr, PWRMGR_CONTROL_REG_OFFSET);
   reg_val =
-      bitfield_bit32_write(reg_val, PWRMGR_CONTROL_LOW_POWER_HINT, enable);
+      bitfield_bit32_write(reg_val, PWRMGR_CONTROL_LOW_POWER_HINT_BIT, enable);
   mmio_region_write32(pwrmgr->params.base_addr, PWRMGR_CONTROL_REG_OFFSET,
                       reg_val);
 
@@ -270,7 +272,7 @@ dif_pwrmgr_result_t dif_pwrmgr_low_power_get_enabled(
   uint32_t reg_val =
       mmio_region_read32(pwrmgr->params.base_addr, PWRMGR_CONTROL_REG_OFFSET);
   *cur_state = bool_to_toggle(
-      bitfield_bit32_read(reg_val, PWRMGR_CONTROL_LOW_POWER_HINT));
+      bitfield_bit32_read(reg_val, PWRMGR_CONTROL_LOW_POWER_HINT_BIT));
 
   return kDifPwrmgrOk;
 }
@@ -408,7 +410,7 @@ dif_pwrmgr_result_t dif_pwrmgr_wakeup_request_recording_set_enabled(
   // Only a single bit of this register is significant, thus we don't perform a
   // read-modify-write. Setting this bit to 1 disables recording.
   uint32_t reg_val =
-      bitfield_bit32_write(0, PWRMGR_WAKE_INFO_CAPTURE_DIS_VAL, !enable);
+      bitfield_bit32_write(0, PWRMGR_WAKE_INFO_CAPTURE_DIS_VAL_BIT, !enable);
 
   mmio_region_write32(pwrmgr->params.base_addr,
                       PWRMGR_WAKE_INFO_CAPTURE_DIS_REG_OFFSET, reg_val);
@@ -426,7 +428,7 @@ dif_pwrmgr_result_t dif_pwrmgr_wakeup_request_recording_get_enabled(
       pwrmgr->params.base_addr, PWRMGR_WAKE_INFO_CAPTURE_DIS_REG_OFFSET);
   // Recording is disabled if this bit is set to 1.
   *cur_state = bool_to_toggle(
-      !bitfield_bit32_read(reg_val, PWRMGR_WAKE_INFO_CAPTURE_DIS_VAL));
+      !bitfield_bit32_read(reg_val, PWRMGR_WAKE_INFO_CAPTURE_DIS_VAL_BIT));
 
   return kDifPwrmgrOk;
 }
@@ -441,10 +443,10 @@ dif_pwrmgr_result_t dif_pwrmgr_wakeup_reason_get(
       mmio_region_read32(pwrmgr->params.base_addr, PWRMGR_WAKE_INFO_REG_OFFSET);
 
   dif_pwrmgr_wakeup_types_t types = 0;
-  if (bitfield_bit32_read(reg_val, PWRMGR_WAKE_INFO_FALL_THROUGH)) {
+  if (bitfield_bit32_read(reg_val, PWRMGR_WAKE_INFO_FALL_THROUGH_BIT)) {
     types |= kDifPwrmgrWakeupTypeFallThrough;
   }
-  if (bitfield_bit32_read(reg_val, PWRMGR_WAKE_INFO_ABORT)) {
+  if (bitfield_bit32_read(reg_val, PWRMGR_WAKE_INFO_ABORT_BIT)) {
     types |= kDifPwrmgrWakeupTypeAbort;
   }
 

--- a/sw/device/lib/dif/dif_rstmgr.c
+++ b/sw/device/lib/dif/dif_rstmgr.c
@@ -12,10 +12,11 @@
 
 // This macro simplifies the `_Static_assert` check to make sure that the
 // public reset info register bitfield matches register bits.
-#define RSTMGR_RESET_INFO_CHECK(pub_name, priv_name)                      \
-  _Static_assert(                                                         \
-      kDifRstmgrResetInfo##pub_name == (0x1 << RSTMGR_RESET_##priv_name), \
-      "kDifRstmgrResetInfo" #pub_name " must match the register definition!")
+#define RSTMGR_RESET_INFO_CHECK(pub_name, priv_name)          \
+  _Static_assert(kDifRstmgrResetInfo##pub_name ==             \
+                     (0x1 << RSTMGR_RESET_##priv_name##_BIT), \
+                 "kDifRstmgrResetInfo" #pub_name              \
+                 " must match the register definition!")
 
 RSTMGR_RESET_INFO_CHECK(Por, INFO_POR);
 RSTMGR_RESET_INFO_CHECK(LowPowerExit, INFO_LOW_POWER_EXIT);
@@ -192,7 +193,7 @@ dif_rstmgr_result_t dif_rstmgr_alert_info_get_enabled(
 
   uint32_t reg =
       mmio_region_read32(base_addr, RSTMGR_ALERT_INFO_CTRL_REG_OFFSET);
-  bool enabled = bitfield_bit32_read(reg, RSTMGR_ALERT_INFO_CTRL_EN);
+  bool enabled = bitfield_bit32_read(reg, RSTMGR_ALERT_INFO_CTRL_EN_BIT);
 
   *state = enabled ? kDifRstmgrToggleEnabled : kDifRstmgrToggleDisabled;
 

--- a/sw/device/lib/dif/dif_spi_device.c
+++ b/sw/device/lib/dif/dif_spi_device.c
@@ -30,13 +30,13 @@ static uint32_t build_control_word(dif_spi_device_config_t config) {
   uint32_t val = 0;
 
   val =
-      bitfield_bit32_write(val, SPI_DEVICE_CFG_CPOL,
+      bitfield_bit32_write(val, SPI_DEVICE_CFG_CPOL_BIT,
                            config.clock_polarity == kDifSpiDeviceEdgeNegative);
-  val = bitfield_bit32_write(val, SPI_DEVICE_CFG_CPHA,
+  val = bitfield_bit32_write(val, SPI_DEVICE_CFG_CPHA_BIT,
                              config.data_phase == kDifSpiDeviceEdgePositive);
-  val = bitfield_bit32_write(val, SPI_DEVICE_CFG_TX_ORDER,
+  val = bitfield_bit32_write(val, SPI_DEVICE_CFG_TX_ORDER_BIT,
                              config.tx_order == kDifSpiDeviceBitOrderLsbToMsb);
-  val = bitfield_bit32_write(val, SPI_DEVICE_CFG_RX_ORDER,
+  val = bitfield_bit32_write(val, SPI_DEVICE_CFG_RX_ORDER_BIT,
                              config.rx_order == kDifSpiDeviceBitOrderLsbToMsb);
   val = bitfield_field32_write(val,
                                (bitfield_field32_t){
@@ -121,14 +121,14 @@ dif_spi_device_result_t dif_spi_device_abort(const dif_spi_device_t *spi) {
   // Set the `abort` bit, and then spin until `abort_done` is asserted.
   uint32_t reg =
       mmio_region_read32(spi->params.base_addr, SPI_DEVICE_CONTROL_REG_OFFSET);
-  reg = bitfield_bit32_write(reg, SPI_DEVICE_CONTROL_ABORT, true);
+  reg = bitfield_bit32_write(reg, SPI_DEVICE_CONTROL_ABORT_BIT, true);
   mmio_region_write32(spi->params.base_addr, SPI_DEVICE_CONTROL_REG_OFFSET,
                       reg);
 
   while (true) {
     uint32_t reg =
         mmio_region_read32(spi->params.base_addr, SPI_DEVICE_STATUS_REG_OFFSET);
-    if (bitfield_bit32_read(reg, SPI_DEVICE_STATUS_ABORT_DONE)) {
+    if (bitfield_bit32_read(reg, SPI_DEVICE_STATUS_ABORT_DONE_BIT)) {
       return kDifSpiDeviceOk;
     }
   }
@@ -138,22 +138,22 @@ DIF_WARN_UNUSED_RESULT
 static bool irq_index(dif_spi_device_irq_t irq, bitfield_bit32_index_t *index) {
   switch (irq) {
     case kDifSpiDeviceIrqRxFull:
-      *index = SPI_DEVICE_INTR_COMMON_RXF;
+      *index = SPI_DEVICE_INTR_COMMON_RXF_BIT;
       break;
     case kDifSpiDeviceIrqRxAboveLevel:
-      *index = SPI_DEVICE_INTR_COMMON_RXLVL;
+      *index = SPI_DEVICE_INTR_COMMON_RXLVL_BIT;
       break;
     case kDifSpiDeviceIrqTxBelowLevel:
-      *index = SPI_DEVICE_INTR_COMMON_TXLVL;
+      *index = SPI_DEVICE_INTR_COMMON_TXLVL_BIT;
       break;
     case kDifSpiDeviceIrqRxError:
-      *index = SPI_DEVICE_INTR_COMMON_RXERR;
+      *index = SPI_DEVICE_INTR_COMMON_RXERR_BIT;
       break;
     case kDifSpiDeviceIrqRxOverflow:
-      *index = SPI_DEVICE_INTR_COMMON_RXOVERFLOW;
+      *index = SPI_DEVICE_INTR_COMMON_RXOVERFLOW_BIT;
       break;
     case kDifSpiDeviceIrqTxUnderflow:
-      *index = SPI_DEVICE_INTR_COMMON_TXUNDERFLOW;
+      *index = SPI_DEVICE_INTR_COMMON_TXUNDERFLOW_BIT;
       break;
     default:
       return false;

--- a/sw/device/lib/dif/dif_usbdev.c
+++ b/sw/device/lib/dif/dif_usbdev.c
@@ -42,7 +42,7 @@ typedef struct endpoint_hw_info {
  */
 #define ENDPOINT_HW_INFO_ENTRY(N)                                  \
   [N] = {.config_in_reg_offset = USBDEV_CONFIGIN_##N##_REG_OFFSET, \
-         .bit_index = USBDEV_IN_SENT_SENT_##N}
+         .bit_index = USBDEV_IN_SENT_SENT_##N##_BIT}
 
 static const endpoint_hw_info_t kEndpointHwInfos[USBDEV_NUM_ENDPOINTS] = {
     ENDPOINT_HW_INFO_ENTRY(0),  ENDPOINT_HW_INFO_ENTRY(1),
@@ -59,22 +59,22 @@ static const endpoint_hw_info_t kEndpointHwInfos[USBDEV_NUM_ENDPOINTS] = {
  * Mapping from `dif_usbdev_irq_t` to bit indices in interrupt registers.
  */
 static const uint8_t kIrqEnumToBitIndex[] = {
-        [kDifUsbdevIrqPktReceived] = USBDEV_INTR_COMMON_PKT_RECEIVED,
-        [kDifUsbdevIrqPktSent] = USBDEV_INTR_COMMON_PKT_SENT,
-        [kDifUsbdevIrqDisconnected] = USBDEV_INTR_COMMON_DISCONNECTED,
-        [kDifUsbdevIrqHostLost] = USBDEV_INTR_COMMON_HOST_LOST,
-        [kDifUsbdevIrqLinkReset] = USBDEV_INTR_COMMON_LINK_RESET,
-        [kDifUsbdevIrqLinkSuspend] = USBDEV_INTR_COMMON_LINK_SUSPEND,
-        [kDifUsbdevIrqLinkResume] = USBDEV_INTR_COMMON_LINK_RESUME,
-        [kDifUsbdevIrqAvEmpty] = USBDEV_INTR_COMMON_AV_EMPTY,
-        [kDifUsbdevIrqRxFull] = USBDEV_INTR_COMMON_RX_FULL,
-        [kDifUsbdevIrqAvOverflow] = USBDEV_INTR_COMMON_AV_OVERFLOW,
-        [kDifUsbdevIrqLinkInError] = USBDEV_INTR_COMMON_LINK_IN_ERR,
-        [kDifUsbdevIrqRxCrcError] = USBDEV_INTR_COMMON_RX_CRC_ERR,
-        [kDifUsbdevIrqRxPidError] = USBDEV_INTR_COMMON_RX_PID_ERR,
-        [kDifUsbdevIrqRxBitstuffError] = USBDEV_INTR_COMMON_RX_BITSTUFF_ERR,
-        [kDifUsbdevIrqFrame] = USBDEV_INTR_COMMON_FRAME,
-        [kDifUsbdevIrqConnected] = USBDEV_INTR_COMMON_CONNECTED,
+    [kDifUsbdevIrqPktReceived] = USBDEV_INTR_COMMON_PKT_RECEIVED_BIT,
+    [kDifUsbdevIrqPktSent] = USBDEV_INTR_COMMON_PKT_SENT_BIT,
+    [kDifUsbdevIrqDisconnected] = USBDEV_INTR_COMMON_DISCONNECTED_BIT,
+    [kDifUsbdevIrqHostLost] = USBDEV_INTR_COMMON_HOST_LOST_BIT,
+    [kDifUsbdevIrqLinkReset] = USBDEV_INTR_COMMON_LINK_RESET_BIT,
+    [kDifUsbdevIrqLinkSuspend] = USBDEV_INTR_COMMON_LINK_SUSPEND_BIT,
+    [kDifUsbdevIrqLinkResume] = USBDEV_INTR_COMMON_LINK_RESUME_BIT,
+    [kDifUsbdevIrqAvEmpty] = USBDEV_INTR_COMMON_AV_EMPTY_BIT,
+    [kDifUsbdevIrqRxFull] = USBDEV_INTR_COMMON_RX_FULL_BIT,
+    [kDifUsbdevIrqAvOverflow] = USBDEV_INTR_COMMON_AV_OVERFLOW_BIT,
+    [kDifUsbdevIrqLinkInError] = USBDEV_INTR_COMMON_LINK_IN_ERR_BIT,
+    [kDifUsbdevIrqRxCrcError] = USBDEV_INTR_COMMON_RX_CRC_ERR_BIT,
+    [kDifUsbdevIrqRxPidError] = USBDEV_INTR_COMMON_RX_PID_ERR_BIT,
+    [kDifUsbdevIrqRxBitstuffError] = USBDEV_INTR_COMMON_RX_BITSTUFF_ERR_BIT,
+    [kDifUsbdevIrqFrame] = USBDEV_INTR_COMMON_FRAME_BIT,
+    [kDifUsbdevIrqConnected] = USBDEV_INTR_COMMON_CONNECTED_BIT,
 };
 
 /**
@@ -290,7 +290,8 @@ dif_usbdev_result_t dif_usbdev_init(dif_usbdev_config_t *config,
     phy_config_val = bitfield_field32_write(
         phy_config_val,
         (bitfield_field32_t){
-            .mask = 1, .index = USBDEV_PHY_CONFIG_RX_DIFFERENTIAL_MODE,
+            .mask = 1,
+            .index = USBDEV_PHY_CONFIG_RX_DIFFERENTIAL_MODE_BIT,
         },
         1);
   }
@@ -299,7 +300,8 @@ dif_usbdev_result_t dif_usbdev_init(dif_usbdev_config_t *config,
     phy_config_val = bitfield_field32_write(
         phy_config_val,
         (bitfield_field32_t){
-            .mask = 1, .index = USBDEV_PHY_CONFIG_TX_DIFFERENTIAL_MODE,
+            .mask = 1,
+            .index = USBDEV_PHY_CONFIG_TX_DIFFERENTIAL_MODE_BIT,
         },
         1);
   }
@@ -308,7 +310,8 @@ dif_usbdev_result_t dif_usbdev_init(dif_usbdev_config_t *config,
     phy_config_val = bitfield_field32_write(
         phy_config_val,
         (bitfield_field32_t){
-            .mask = 1, .index = USBDEV_PHY_CONFIG_EOP_SINGLE_BIT,
+            .mask = 1,
+            .index = USBDEV_PHY_CONFIG_EOP_SINGLE_BIT_BIT,
         },
         1);
   }
@@ -317,13 +320,15 @@ dif_usbdev_result_t dif_usbdev_init(dif_usbdev_config_t *config,
     phy_config_val = bitfield_field32_write(
         phy_config_val,
         (bitfield_field32_t){
-            .mask = 1, .index = USBDEV_PHY_CONFIG_OVERRIDE_PWR_SENSE_EN,
+            .mask = 1,
+            .index = USBDEV_PHY_CONFIG_OVERRIDE_PWR_SENSE_EN_BIT,
         },
         1);
     phy_config_val = bitfield_field32_write(
         phy_config_val,
         (bitfield_field32_t){
-            .mask = 1, .index = USBDEV_PHY_CONFIG_OVERRIDE_PWR_SENSE_VAL,
+            .mask = 1,
+            .index = USBDEV_PHY_CONFIG_OVERRIDE_PWR_SENSE_VAL_BIT,
         },
         1);
   } else if (config->power_sense_override ==
@@ -331,25 +336,28 @@ dif_usbdev_result_t dif_usbdev_init(dif_usbdev_config_t *config,
     phy_config_val = bitfield_field32_write(
         phy_config_val,
         (bitfield_field32_t){
-            .mask = 1, .index = USBDEV_PHY_CONFIG_OVERRIDE_PWR_SENSE_EN,
+            .mask = 1,
+            .index = USBDEV_PHY_CONFIG_OVERRIDE_PWR_SENSE_EN_BIT,
         },
         1);
   }
 
   if (config->pin_flip == kDifUsbdevToggleEnable) {
-    phy_config_val = bitfield_field32_write(
-        phy_config_val,
-        (bitfield_field32_t){
-            .mask = 1, .index = USBDEV_PHY_CONFIG_PINFLIP,
-        },
-        1);
+    phy_config_val =
+        bitfield_field32_write(phy_config_val,
+                               (bitfield_field32_t){
+                                   .mask = 1,
+                                   .index = USBDEV_PHY_CONFIG_PINFLIP_BIT,
+                               },
+                               1);
   }
 
   if (config->clock_sync_signals == kDifUsbdevToggleDisable) {
     phy_config_val = bitfield_field32_write(
         phy_config_val,
         (bitfield_field32_t){
-            .mask = 1, .index = USBDEV_PHY_CONFIG_USB_REF_DISABLE,
+            .mask = 1,
+            .index = USBDEV_PHY_CONFIG_USB_REF_DISABLE_BIT,
         },
         1);
   }
@@ -368,7 +376,7 @@ dif_usbdev_result_t dif_usbdev_fill_available_fifo(dif_usbdev_t *usbdev) {
 
   // Remove buffers from the pool and write them to the AV FIFO until it is full
   while (!mmio_region_get_bit32(usbdev->base_addr, USBDEV_USBSTAT_REG_OFFSET,
-                                USBDEV_USBSTAT_AV_FULL) &&
+                                USBDEV_USBSTAT_AV_FULL_BIT) &&
          !buffer_pool_is_empty(&usbdev->buffer_pool)) {
     uint8_t buffer_id;
     if (!buffer_pool_remove(&usbdev->buffer_pool, &buffer_id)) {
@@ -430,11 +438,13 @@ dif_usbdev_result_t dif_usbdev_interface_enable(dif_usbdev_t *usbdev,
   }
 
   if (new_state == kDifUsbdevToggleEnable) {
-    mmio_region_nonatomic_set_bit32(
-        usbdev->base_addr, USBDEV_USBCTRL_REG_OFFSET, USBDEV_USBCTRL_ENABLE);
+    mmio_region_nonatomic_set_bit32(usbdev->base_addr,
+                                    USBDEV_USBCTRL_REG_OFFSET,
+                                    USBDEV_USBCTRL_ENABLE_BIT);
   } else {
-    mmio_region_nonatomic_clear_bit32(
-        usbdev->base_addr, USBDEV_USBCTRL_REG_OFFSET, USBDEV_USBCTRL_ENABLE);
+    mmio_region_nonatomic_clear_bit32(usbdev->base_addr,
+                                      USBDEV_USBCTRL_REG_OFFSET,
+                                      USBDEV_USBCTRL_ENABLE_BIT);
   }
 
   return kDifUsbdevOK;
@@ -449,7 +459,7 @@ dif_usbdev_recv_result_t dif_usbdev_recv(dif_usbdev_t *usbdev,
 
   // Check if the RX FIFO is empty
   if (mmio_region_get_bit32(usbdev->base_addr, USBDEV_USBSTAT_REG_OFFSET,
-                            USBDEV_USBSTAT_RX_EMPTY)) {
+                            USBDEV_USBSTAT_RX_EMPTY_BIT)) {
     return kDifUsbdevRecvResultNoNewPacket;
   }
 
@@ -458,16 +468,16 @@ dif_usbdev_recv_result_t dif_usbdev_recv(dif_usbdev_t *usbdev,
       mmio_region_read32(usbdev->base_addr, USBDEV_RXFIFO_REG_OFFSET);
   // Init packet info
   *info = (dif_usbdev_rx_packet_info_t){
-      .endpoint = bitfield_field32_read(
-          fifo_entry,
-          (bitfield_field32_t){
-              .mask = USBDEV_RXFIFO_EP_MASK, .index = USBDEV_RXFIFO_EP_OFFSET,
-          }),
-      .is_setup =
-          bitfield_field32_read(fifo_entry,
-                                (bitfield_field32_t){
-                                    .mask = 1, .index = USBDEV_RXFIFO_SETUP,
-                                }),
+      .endpoint = bitfield_field32_read(fifo_entry,
+                                        (bitfield_field32_t){
+                                            .mask = USBDEV_RXFIFO_EP_MASK,
+                                            .index = USBDEV_RXFIFO_EP_OFFSET,
+                                        }),
+      .is_setup = bitfield_field32_read(fifo_entry,
+                                        (bitfield_field32_t){
+                                            .mask = 1,
+                                            .index = USBDEV_RXFIFO_SETUP_BIT,
+                                        }),
       .length = bitfield_field32_read(fifo_entry,
                                       (bitfield_field32_t){
                                           .mask = USBDEV_RXFIFO_SIZE_MASK,
@@ -642,7 +652,7 @@ dif_usbdev_result_t dif_usbdev_send(dif_usbdev_t *usbdev, uint8_t endpoint,
 
   // Mark the packet as ready for transmission
   mmio_region_nonatomic_set_bit32(usbdev->base_addr, config_in_reg_offset,
-                                  USBDEV_CONFIGIN_0_RDY_0);
+                                  USBDEV_CONFIGIN_0_RDY_0_BIT);
 
   // Mark the buffer as stale. It will be returned to the free buffer pool
   // in dif_usbdev_get_tx_status once transmission is complete.
@@ -677,7 +687,8 @@ dif_usbdev_result_t dif_usbdev_get_tx_status(dif_usbdev_t *usbdev,
   // Check the status of the packet
   if (bitfield_field32_read(config_in_val,
                             (bitfield_field32_t){
-                                .mask = 1, .index = USBDEV_CONFIGIN_0_RDY_0,
+                                .mask = 1,
+                                .index = USBDEV_CONFIGIN_0_RDY_0_BIT,
                             })) {
     // Packet is marked as ready to be sent and pending transmission
     *status = kDifUsbdevTxStatusPending;
@@ -692,15 +703,15 @@ dif_usbdev_result_t dif_usbdev_get_tx_status(dif_usbdev_t *usbdev,
       return kDifUsbdevError;
     }
     *status = kDifUsbdevTxStatusSent;
-  } else if (bitfield_field32_read(
-                 config_in_val,
-                 (bitfield_field32_t){
-                     .mask = 1, .index = USBDEV_CONFIGIN_0_PEND_0,
-                 })) {
+  } else if (bitfield_field32_read(config_in_val,
+                                   (bitfield_field32_t){
+                                       .mask = 1,
+                                       .index = USBDEV_CONFIGIN_0_PEND_0_BIT,
+                                   })) {
     // Canceled due to an IN SETUP packet or link reset
     // Clear pending bit (rw1c)
     mmio_region_write_only_set_bit32(usbdev->base_addr, config_in_reg_offset,
-                                     USBDEV_CONFIGIN_0_PEND_0);
+                                     USBDEV_CONFIGIN_0_PEND_0_BIT);
     // Return the buffer back to the free buffer pool
     if (!buffer_pool_add(&usbdev->buffer_pool, buffer)) {
       return kDifUsbdevError;
@@ -764,8 +775,9 @@ dif_usbdev_result_t dif_usbdev_status_get_host_lost(dif_usbdev_t *usbdev,
     return kDifUsbdevBadArg;
   }
 
-  *host_lost = mmio_region_get_bit32(
-      usbdev->base_addr, USBDEV_USBSTAT_REG_OFFSET, USBDEV_USBSTAT_HOST_LOST);
+  *host_lost =
+      mmio_region_get_bit32(usbdev->base_addr, USBDEV_USBSTAT_REG_OFFSET,
+                            USBDEV_USBSTAT_HOST_LOST_BIT);
 
   return kDifUsbdevOK;
 }
@@ -810,7 +822,7 @@ dif_usbdev_result_t dif_usbdev_status_get_sense(dif_usbdev_t *usbdev,
   }
 
   *sense = mmio_region_get_bit32(usbdev->base_addr, USBDEV_USBSTAT_REG_OFFSET,
-                                 USBDEV_USBSTAT_SENSE);
+                                 USBDEV_USBSTAT_SENSE_BIT);
 
   return kDifUsbdevOK;
 }
@@ -836,7 +848,7 @@ dif_usbdev_result_t dif_usbdev_status_get_available_fifo_full(
   }
 
   *is_full = mmio_region_get_bit32(usbdev->base_addr, USBDEV_USBSTAT_REG_OFFSET,
-                                   USBDEV_USBSTAT_AV_FULL);
+                                   USBDEV_USBSTAT_AV_FULL_BIT);
 
   return kDifUsbdevOK;
 }
@@ -862,7 +874,7 @@ dif_usbdev_result_t dif_usbdev_status_get_rx_fifo_empty(dif_usbdev_t *usbdev,
   }
 
   *is_full = mmio_region_get_bit32(usbdev->base_addr, USBDEV_USBSTAT_REG_OFFSET,
-                                   USBDEV_USBSTAT_RX_EMPTY);
+                                   USBDEV_USBSTAT_RX_EMPTY_BIT);
 
   return kDifUsbdevOK;
 }

--- a/sw/device/lib/hmac.c
+++ b/sw/device/lib/hmac.c
@@ -15,13 +15,14 @@
 
 void hmac_init(hmac_cfg_t hmac_cfg) {
   REG32(HMAC0_BASE_ADDR + HMAC_CFG_REG_OFFSET) =
-      hmac_cfg.input_endian_swap << HMAC_CFG_ENDIAN_SWAP | 1 << hmac_cfg.mode |
-      hmac_cfg.digest_endian_swap << HMAC_CFG_DIGEST_SWAP;
+      hmac_cfg.input_endian_swap << HMAC_CFG_ENDIAN_SWAP_BIT |
+      1 << hmac_cfg.mode |
+      hmac_cfg.digest_endian_swap << HMAC_CFG_DIGEST_SWAP_BIT;
   for (int i = 0; i < 8; i++) {
     REG32(HMAC0_BASE_ADDR + HMAC_KEY_0_REG_OFFSET + i * sizeof(uint32_t)) =
         hmac_cfg.keys[i];
   }
-  REG32(HMAC0_BASE_ADDR + HMAC_CMD_REG_OFFSET) = 1 << HMAC_CMD_HASH_START;
+  REG32(HMAC0_BASE_ADDR + HMAC_CMD_REG_OFFSET) = 1 << HMAC_CMD_HASH_START_BIT;
 };
 
 static int hmac_fifo_depth(void) {
@@ -68,13 +69,13 @@ void hmac_update(const void *data, size_t size_in_bytes) {
 }
 
 void hmac_done(uint32_t *digest) {
-  REG32(HMAC0_BASE_ADDR + HMAC_CMD_REG_OFFSET) = 1 << HMAC_CMD_HASH_PROCESS;
+  REG32(HMAC0_BASE_ADDR + HMAC_CMD_REG_OFFSET) = 1 << HMAC_CMD_HASH_PROCESS_BIT;
   while (!((REG32(HMAC0_BASE_ADDR + HMAC_INTR_STATE_REG_OFFSET) >>
-            HMAC_INTR_STATE_HMAC_DONE) &
+            HMAC_INTR_STATE_HMAC_DONE_BIT) &
            0x1)) {
   }
   REG32(HMAC0_BASE_ADDR + HMAC_INTR_STATE_REG_OFFSET) =
-      1 << HMAC_INTR_STATE_HMAC_DONE;
+      1 << HMAC_INTR_STATE_HMAC_DONE_BIT;
 
   for (uint32_t i = 0; i < 8; i++) {
     *digest++ = REG32(HMAC0_BASE_ADDR + HMAC_DIGEST_0_REG_OFFSET +

--- a/sw/device/tests/dif/dif_alert_handler_unittest.cc
+++ b/sw/device/tests/dif/dif_alert_handler_unittest.cc
@@ -110,7 +110,7 @@ TEST_F(ConfigTest, NoClassInit) {
   };
 
   EXPECT_READ32(ALERT_HANDLER_REGEN_REG_OFFSET,
-                {{ALERT_HANDLER_REGEN_REGEN, true}});
+                {{ALERT_HANDLER_REGEN_REGEN_BIT, true}});
 
   EXPECT_WRITE32(
       ALERT_HANDLER_PING_TIMEOUT_CYC_REG_OFFSET,
@@ -208,7 +208,7 @@ TEST_F(ConfigTest, ClassInit) {
   };
 
   EXPECT_READ32(ALERT_HANDLER_REGEN_REG_OFFSET,
-                {{ALERT_HANDLER_REGEN_REGEN, true}});
+                {{ALERT_HANDLER_REGEN_REGEN_BIT, true}});
 
   // Unfortunately, we can't use EXPECT_MASK for these reads and writes,
   // since there are not sequenced exactly.
@@ -232,7 +232,7 @@ TEST_F(ConfigTest, ClassInit) {
 
   EXPECT_WRITE32(ALERT_HANDLER_LOC_ALERT_EN_REG_OFFSET,
                  {
-                     {ALERT_HANDLER_LOC_ALERT_EN_EN_LA_1, true},
+                     {ALERT_HANDLER_LOC_ALERT_EN_EN_LA_1_BIT, true},
                  });
   uint32_t loc_reg_a = kAllOnes;
   loc_reg_a = bitfield_field32_write(
@@ -246,11 +246,11 @@ TEST_F(ConfigTest, ClassInit) {
 
   EXPECT_WRITE32(ALERT_HANDLER_CLASSA_CTRL_REG_OFFSET,
                  {
-                     {ALERT_HANDLER_CLASSA_CTRL_EN, false},
-                     {ALERT_HANDLER_CLASSA_CTRL_LOCK, true},
-                     {ALERT_HANDLER_CLASSA_CTRL_EN_E0, true},
+                     {ALERT_HANDLER_CLASSA_CTRL_EN_BIT, false},
+                     {ALERT_HANDLER_CLASSA_CTRL_LOCK_BIT, true},
+                     {ALERT_HANDLER_CLASSA_CTRL_EN_E0_BIT, true},
                      {ALERT_HANDLER_CLASSA_CTRL_MAP_E0_OFFSET, 3},
-                     {ALERT_HANDLER_CLASSA_CTRL_EN_E2, true},
+                     {ALERT_HANDLER_CLASSA_CTRL_EN_E2_BIT, true},
                      {ALERT_HANDLER_CLASSA_CTRL_MAP_E2_OFFSET, 1},
                  });
 
@@ -280,8 +280,8 @@ TEST_F(ConfigTest, ClassInit) {
 
   EXPECT_WRITE32(ALERT_HANDLER_LOC_ALERT_EN_REG_OFFSET,
                  {
-                     {ALERT_HANDLER_LOC_ALERT_EN_EN_LA_0, true},
-                     {ALERT_HANDLER_LOC_ALERT_EN_EN_LA_2, true},
+                     {ALERT_HANDLER_LOC_ALERT_EN_EN_LA_0_BIT, true},
+                     {ALERT_HANDLER_LOC_ALERT_EN_EN_LA_2_BIT, true},
                  });
   uint32_t loc_reg_b = kAllOnes;
   loc_reg_b = bitfield_field32_write(
@@ -302,9 +302,9 @@ TEST_F(ConfigTest, ClassInit) {
 
   EXPECT_WRITE32(ALERT_HANDLER_CLASSB_CTRL_REG_OFFSET,
                  {
-                     {ALERT_HANDLER_CLASSB_CTRL_EN, true},
-                     {ALERT_HANDLER_CLASSB_CTRL_LOCK, false},
-                     {ALERT_HANDLER_CLASSB_CTRL_EN_E1, true},
+                     {ALERT_HANDLER_CLASSB_CTRL_EN_BIT, true},
+                     {ALERT_HANDLER_CLASSB_CTRL_LOCK_BIT, false},
+                     {ALERT_HANDLER_CLASSB_CTRL_EN_E1_BIT, true},
                      {ALERT_HANDLER_CLASSB_CTRL_MAP_E1_OFFSET, 0},
                  });
 
@@ -570,19 +570,19 @@ TEST_F(LockTest, IsLocked) {
   bool flag;
 
   EXPECT_READ32(ALERT_HANDLER_REGEN_REG_OFFSET,
-                {{ALERT_HANDLER_REGEN_REGEN, true}});
+                {{ALERT_HANDLER_REGEN_REGEN_BIT, true}});
   EXPECT_EQ(dif_alert_handler_is_locked(&handler_, &flag), kDifAlertHandlerOk);
   EXPECT_FALSE(flag);
 
   EXPECT_READ32(ALERT_HANDLER_REGEN_REG_OFFSET,
-                {{ALERT_HANDLER_REGEN_REGEN, false}});
+                {{ALERT_HANDLER_REGEN_REGEN_BIT, false}});
   EXPECT_EQ(dif_alert_handler_is_locked(&handler_, &flag), kDifAlertHandlerOk);
   EXPECT_TRUE(flag);
 }
 
 TEST_F(LockTest, Lock) {
   EXPECT_WRITE32(ALERT_HANDLER_REGEN_REG_OFFSET,
-                 {{ALERT_HANDLER_REGEN_REGEN, true}});
+                 {{ALERT_HANDLER_REGEN_REGEN_BIT, true}});
   EXPECT_EQ(dif_alert_handler_lock(&handler_), kDifAlertHandlerOk);
 }
 
@@ -603,8 +603,8 @@ TEST_F(IrqTest, IsPending) {
 
   EXPECT_READ32(ALERT_HANDLER_INTR_STATE_REG_OFFSET,
                 {
-                    {ALERT_HANDLER_INTR_COMMON_CLASSB, true},
-                    {ALERT_HANDLER_INTR_COMMON_CLASSD, true},
+                    {ALERT_HANDLER_INTR_COMMON_CLASSB_BIT, true},
+                    {ALERT_HANDLER_INTR_COMMON_CLASSD_BIT, true},
                 });
   EXPECT_EQ(dif_alert_handler_irq_is_pending(&handler_, kDifAlertHandlerClassA,
                                              &flag),
@@ -613,8 +613,8 @@ TEST_F(IrqTest, IsPending) {
 
   EXPECT_READ32(ALERT_HANDLER_INTR_STATE_REG_OFFSET,
                 {
-                    {ALERT_HANDLER_INTR_COMMON_CLASSB, true},
-                    {ALERT_HANDLER_INTR_COMMON_CLASSD, true},
+                    {ALERT_HANDLER_INTR_COMMON_CLASSB_BIT, true},
+                    {ALERT_HANDLER_INTR_COMMON_CLASSD_BIT, true},
                 });
   EXPECT_EQ(dif_alert_handler_irq_is_pending(&handler_, kDifAlertHandlerClassB,
                                              &flag),
@@ -624,7 +624,7 @@ TEST_F(IrqTest, IsPending) {
 
 TEST_F(IrqTest, Ack) {
   EXPECT_MASK32(ALERT_HANDLER_INTR_STATE_REG_OFFSET,
-                {{ALERT_HANDLER_INTR_COMMON_CLASSC, 1, true}});
+                {{ALERT_HANDLER_INTR_COMMON_CLASSC_BIT, 1, true}});
   EXPECT_EQ(
       dif_alert_handler_irq_acknowledge(&handler_, kDifAlertHandlerClassC),
       kDifAlertHandlerOk);
@@ -635,8 +635,8 @@ TEST_F(IrqTest, GetEnabled) {
 
   EXPECT_READ32(ALERT_HANDLER_INTR_ENABLE_REG_OFFSET,
                 {
-                    {ALERT_HANDLER_INTR_COMMON_CLASSB, true},
-                    {ALERT_HANDLER_INTR_COMMON_CLASSD, true},
+                    {ALERT_HANDLER_INTR_COMMON_CLASSB_BIT, true},
+                    {ALERT_HANDLER_INTR_COMMON_CLASSD_BIT, true},
                 });
   EXPECT_EQ(dif_alert_handler_irq_get_enabled(&handler_, kDifAlertHandlerClassA,
                                               &flag),
@@ -645,8 +645,8 @@ TEST_F(IrqTest, GetEnabled) {
 
   EXPECT_READ32(ALERT_HANDLER_INTR_ENABLE_REG_OFFSET,
                 {
-                    {ALERT_HANDLER_INTR_COMMON_CLASSB, true},
-                    {ALERT_HANDLER_INTR_COMMON_CLASSD, true},
+                    {ALERT_HANDLER_INTR_COMMON_CLASSB_BIT, true},
+                    {ALERT_HANDLER_INTR_COMMON_CLASSD_BIT, true},
                 });
   EXPECT_EQ(dif_alert_handler_irq_get_enabled(&handler_, kDifAlertHandlerClassB,
                                               &flag),
@@ -656,7 +656,7 @@ TEST_F(IrqTest, GetEnabled) {
 
 TEST_F(IrqTest, SetEnabled) {
   EXPECT_MASK32(ALERT_HANDLER_INTR_ENABLE_REG_OFFSET,
-                {{ALERT_HANDLER_INTR_COMMON_CLASSC, 1, true}});
+                {{ALERT_HANDLER_INTR_COMMON_CLASSC_BIT, 1, true}});
   EXPECT_EQ(dif_alert_handler_irq_set_enabled(&handler_, kDifAlertHandlerClassC,
                                               kDifAlertHandlerToggleEnabled),
             kDifAlertHandlerOk);
@@ -664,7 +664,7 @@ TEST_F(IrqTest, SetEnabled) {
 
 TEST_F(IrqTest, SetDisabled) {
   EXPECT_MASK32(ALERT_HANDLER_INTR_ENABLE_REG_OFFSET,
-                {{ALERT_HANDLER_INTR_COMMON_CLASSD, 1, false}});
+                {{ALERT_HANDLER_INTR_COMMON_CLASSD_BIT, 1, false}});
   EXPECT_EQ(dif_alert_handler_irq_set_enabled(&handler_, kDifAlertHandlerClassD,
                                               kDifAlertHandlerToggleDisabled),
             kDifAlertHandlerOk);
@@ -672,7 +672,7 @@ TEST_F(IrqTest, SetDisabled) {
 
 TEST_F(IrqTest, Force) {
   EXPECT_WRITE32(ALERT_HANDLER_INTR_TEST_REG_OFFSET,
-                 {{ALERT_HANDLER_INTR_COMMON_CLASSC, true}});
+                 {{ALERT_HANDLER_INTR_COMMON_CLASSC_BIT, true}});
   EXPECT_EQ(dif_alert_handler_irq_force(&handler_, kDifAlertHandlerClassC),
             kDifAlertHandlerOk);
 }
@@ -762,16 +762,16 @@ TEST_F(CauseTest, IsCauseLocal) {
   bool flag;
 
   EXPECT_READ32(ALERT_HANDLER_LOC_ALERT_CAUSE_REG_OFFSET,
-                {{ALERT_HANDLER_LOC_ALERT_CAUSE_LA_0, true},
-                 {ALERT_HANDLER_LOC_ALERT_CAUSE_LA_1, true}});
+                {{ALERT_HANDLER_LOC_ALERT_CAUSE_LA_0_BIT, true},
+                 {ALERT_HANDLER_LOC_ALERT_CAUSE_LA_1_BIT, true}});
   EXPECT_EQ(dif_alert_handler_local_alert_is_cause(
                 &handler_, kDifAlertHandlerLocalAlertEscalationPingFail, &flag),
             kDifAlertHandlerOk);
   EXPECT_TRUE(flag);
 
   EXPECT_READ32(ALERT_HANDLER_LOC_ALERT_CAUSE_REG_OFFSET,
-                {{ALERT_HANDLER_LOC_ALERT_CAUSE_LA_0, true},
-                 {ALERT_HANDLER_LOC_ALERT_CAUSE_LA_1, true}});
+                {{ALERT_HANDLER_LOC_ALERT_CAUSE_LA_0_BIT, true},
+                 {ALERT_HANDLER_LOC_ALERT_CAUSE_LA_1_BIT, true}});
   EXPECT_EQ(dif_alert_handler_local_alert_is_cause(
                 &handler_, kDifAlertHandlerLocalAlertAlertIntegrityFail, &flag),
             kDifAlertHandlerOk);
@@ -780,7 +780,7 @@ TEST_F(CauseTest, IsCauseLocal) {
 
 TEST_F(CauseTest, AckLocal) {
   EXPECT_WRITE32(ALERT_HANDLER_LOC_ALERT_CAUSE_REG_OFFSET,
-                 {{ALERT_HANDLER_LOC_ALERT_CAUSE_LA_3, true}});
+                 {{ALERT_HANDLER_LOC_ALERT_CAUSE_LA_3_BIT, true}});
   EXPECT_EQ(dif_alert_handler_local_alert_acknowledge(
                 &handler_, kDifAlertHandlerLocalAlertEscalationIntegrityFail),
             kDifAlertHandlerOk);

--- a/sw/device/tests/dif/dif_i2c_unittest.cc
+++ b/sw/device/tests/dif/dif_i2c_unittest.cc
@@ -286,7 +286,8 @@ TEST_F(ConfigTest, NullArgs) {
 class FifoCtrlTest : public I2cTest {};
 
 TEST_F(FifoCtrlTest, RxReset) {
-  EXPECT_MASK32(I2C_FIFO_CTRL_REG_OFFSET, {{I2C_FIFO_CTRL_RXRST, 0x1, 0x1}});
+  EXPECT_MASK32(I2C_FIFO_CTRL_REG_OFFSET,
+                {{I2C_FIFO_CTRL_RXRST_BIT, 0x1, 0x1}});
   EXPECT_EQ(dif_i2c_reset_rx_fifo(&i2c_), kDifI2cOk);
 }
 
@@ -295,7 +296,8 @@ TEST_F(FifoCtrlTest, RxNullArgs) {
 }
 
 TEST_F(FifoCtrlTest, FmtReset) {
-  EXPECT_MASK32(I2C_FIFO_CTRL_REG_OFFSET, {{I2C_FIFO_CTRL_FMTRST, 0x1, 0x1}});
+  EXPECT_MASK32(I2C_FIFO_CTRL_REG_OFFSET,
+                {{I2C_FIFO_CTRL_FMTRST_BIT, 0x1, 0x1}});
   EXPECT_EQ(dif_i2c_reset_fmt_fifo(&i2c_), kDifI2cOk);
 }
 
@@ -371,24 +373,24 @@ TEST_F(IrqTest, Get) {
   bool flag;
 
   EXPECT_READ32(I2C_INTR_STATE_REG_OFFSET,
-                {{I2C_INTR_STATE_FMT_WATERMARK, 0x1}});
+                {{I2C_INTR_STATE_FMT_WATERMARK_BIT, 0x1}});
   EXPECT_EQ(
       dif_i2c_irq_is_pending(&i2c_, kDifI2cIrqFmtWatermarkUnderflow, &flag),
       kDifI2cOk);
   EXPECT_TRUE(flag);
 
   EXPECT_READ32(I2C_INTR_STATE_REG_OFFSET,
-                {{I2C_INTR_STATE_FMT_WATERMARK, 0x0}});
+                {{I2C_INTR_STATE_FMT_WATERMARK_BIT, 0x0}});
   EXPECT_EQ(
       dif_i2c_irq_is_pending(&i2c_, kDifI2cIrqFmtWatermarkUnderflow, &flag),
       kDifI2cOk);
   EXPECT_FALSE(flag);
 
-  EXPECT_READ32(I2C_INTR_STATE_REG_OFFSET, {{I2C_INTR_STATE_NAK, 0x1}});
+  EXPECT_READ32(I2C_INTR_STATE_REG_OFFSET, {{I2C_INTR_STATE_NAK_BIT, 0x1}});
   EXPECT_EQ(dif_i2c_irq_is_pending(&i2c_, kDifI2cIrqNak, &flag), kDifI2cOk);
   EXPECT_TRUE(flag);
 
-  EXPECT_READ32(I2C_INTR_STATE_REG_OFFSET, {{I2C_INTR_STATE_NAK, 0x0}});
+  EXPECT_READ32(I2C_INTR_STATE_REG_OFFSET, {{I2C_INTR_STATE_NAK_BIT, 0x0}});
   EXPECT_EQ(dif_i2c_irq_is_pending(&i2c_, kDifI2cIrqNak, &flag), kDifI2cOk);
   EXPECT_FALSE(flag);
 }
@@ -404,11 +406,11 @@ TEST_F(IrqTest, GetNullArgs) {
 
 TEST_F(IrqTest, Clear) {
   EXPECT_WRITE32(I2C_INTR_STATE_REG_OFFSET,
-                 {{I2C_INTR_STATE_FMT_WATERMARK, 0x1}});
+                 {{I2C_INTR_STATE_FMT_WATERMARK_BIT, 0x1}});
   EXPECT_EQ(dif_i2c_irq_acknowledge(&i2c_, kDifI2cIrqFmtWatermarkUnderflow),
             kDifI2cOk);
 
-  EXPECT_WRITE32(I2C_INTR_STATE_REG_OFFSET, {{I2C_INTR_STATE_NAK, 0x1}});
+  EXPECT_WRITE32(I2C_INTR_STATE_REG_OFFSET, {{I2C_INTR_STATE_NAK_BIT, 0x1}});
   EXPECT_EQ(dif_i2c_irq_acknowledge(&i2c_, kDifI2cIrqNak), kDifI2cOk);
 }
 
@@ -418,22 +420,24 @@ TEST_F(IrqTest, ClearNullArgs) {
 
 TEST_F(IrqTest, Enable) {
   EXPECT_MASK32(I2C_INTR_ENABLE_REG_OFFSET,
-                {{I2C_INTR_STATE_FMT_WATERMARK, 0x1, 0x1}});
+                {{I2C_INTR_STATE_FMT_WATERMARK_BIT, 0x1, 0x1}});
   EXPECT_EQ(dif_i2c_irq_set_enabled(&i2c_, kDifI2cIrqFmtWatermarkUnderflow,
                                     kDifI2cToggleEnabled),
             kDifI2cOk);
 
   EXPECT_MASK32(I2C_INTR_ENABLE_REG_OFFSET,
-                {{I2C_INTR_STATE_FMT_WATERMARK, 0x1, 0x0}});
+                {{I2C_INTR_STATE_FMT_WATERMARK_BIT, 0x1, 0x0}});
   EXPECT_EQ(dif_i2c_irq_set_enabled(&i2c_, kDifI2cIrqFmtWatermarkUnderflow,
                                     kDifI2cToggleDisabled),
             kDifI2cOk);
 
-  EXPECT_MASK32(I2C_INTR_ENABLE_REG_OFFSET, {{I2C_INTR_STATE_NAK, 0x1, 0x1}});
+  EXPECT_MASK32(I2C_INTR_ENABLE_REG_OFFSET,
+                {{I2C_INTR_STATE_NAK_BIT, 0x1, 0x1}});
   EXPECT_EQ(dif_i2c_irq_set_enabled(&i2c_, kDifI2cIrqNak, kDifI2cToggleEnabled),
             kDifI2cOk);
 
-  EXPECT_MASK32(I2C_INTR_ENABLE_REG_OFFSET, {{I2C_INTR_STATE_NAK, 0x1, 0x0}});
+  EXPECT_MASK32(I2C_INTR_ENABLE_REG_OFFSET,
+                {{I2C_INTR_STATE_NAK_BIT, 0x1, 0x0}});
   EXPECT_EQ(
       dif_i2c_irq_set_enabled(&i2c_, kDifI2cIrqNak, kDifI2cToggleDisabled),
       kDifI2cOk);
@@ -447,11 +451,11 @@ TEST_F(IrqTest, EnableNullArgs) {
 
 TEST_F(IrqTest, Force) {
   EXPECT_WRITE32(I2C_INTR_TEST_REG_OFFSET,
-                 {{I2C_INTR_TEST_FMT_WATERMARK, 0x1}});
+                 {{I2C_INTR_TEST_FMT_WATERMARK_BIT, 0x1}});
   EXPECT_EQ(dif_i2c_irq_force(&i2c_, kDifI2cIrqFmtWatermarkUnderflow),
             kDifI2cOk);
 
-  EXPECT_WRITE32(I2C_INTR_TEST_REG_OFFSET, {{I2C_INTR_TEST_NAK, 0x1}});
+  EXPECT_WRITE32(I2C_INTR_TEST_REG_OFFSET, {{I2C_INTR_TEST_NAK_BIT, 0x1}});
   EXPECT_EQ(dif_i2c_irq_force(&i2c_, kDifI2cIrqNak), kDifI2cOk);
 }
 
@@ -462,10 +466,10 @@ TEST_F(IrqTest, ForceNullArgs) {
 class ControlTest : public I2cTest {};
 
 TEST_F(ControlTest, HostEnable) {
-  EXPECT_MASK32(I2C_CTRL_REG_OFFSET, {{I2C_CTRL_ENABLEHOST, 0x1, 0x1}});
+  EXPECT_MASK32(I2C_CTRL_REG_OFFSET, {{I2C_CTRL_ENABLEHOST_BIT, 0x1, 0x1}});
   EXPECT_EQ(dif_i2c_host_set_enabled(&i2c_, kDifI2cToggleEnabled), kDifI2cOk);
 
-  EXPECT_MASK32(I2C_CTRL_REG_OFFSET, {{I2C_CTRL_ENABLEHOST, 0x1, 0x0}});
+  EXPECT_MASK32(I2C_CTRL_REG_OFFSET, {{I2C_CTRL_ENABLEHOST_BIT, 0x1, 0x0}});
   EXPECT_EQ(dif_i2c_host_set_enabled(&i2c_, kDifI2cToggleDisabled), kDifI2cOk);
 }
 
@@ -477,11 +481,11 @@ TEST_F(ControlTest, HostEnableNullArgs) {
 class OverrideTest : public I2cTest {};
 
 TEST_F(OverrideTest, Enable) {
-  EXPECT_MASK32(I2C_OVRD_REG_OFFSET, {{I2C_OVRD_TXOVRDEN, 0x1, 0x1}});
+  EXPECT_MASK32(I2C_OVRD_REG_OFFSET, {{I2C_OVRD_TXOVRDEN_BIT, 0x1, 0x1}});
   EXPECT_EQ(dif_i2c_override_set_enabled(&i2c_, kDifI2cToggleEnabled),
             kDifI2cOk);
 
-  EXPECT_MASK32(I2C_OVRD_REG_OFFSET, {{I2C_OVRD_TXOVRDEN, 0x1, 0x0}});
+  EXPECT_MASK32(I2C_OVRD_REG_OFFSET, {{I2C_OVRD_TXOVRDEN_BIT, 0x1, 0x0}});
   EXPECT_EQ(dif_i2c_override_set_enabled(&i2c_, kDifI2cToggleDisabled),
             kDifI2cOk);
 }
@@ -492,22 +496,22 @@ TEST_F(OverrideTest, EnableNullArgs) {
 }
 
 TEST_F(OverrideTest, Drive) {
-  EXPECT_MASK32(I2C_OVRD_REG_OFFSET,
-                {
-                    {I2C_OVRD_SCLVAL, 0x1, 0x0}, {I2C_OVRD_SDAVAL, 0x1, 0x0},
-                });
+  EXPECT_MASK32(I2C_OVRD_REG_OFFSET, {
+                                         {I2C_OVRD_SCLVAL_BIT, 0x1, 0x0},
+                                         {I2C_OVRD_SDAVAL_BIT, 0x1, 0x0},
+                                     });
   EXPECT_EQ(dif_i2c_override_drive_pins(&i2c_, false, false), kDifI2cOk);
 
-  EXPECT_MASK32(I2C_OVRD_REG_OFFSET,
-                {
-                    {I2C_OVRD_SCLVAL, 0x1, 0x0}, {I2C_OVRD_SDAVAL, 0x1, 0x1},
-                });
+  EXPECT_MASK32(I2C_OVRD_REG_OFFSET, {
+                                         {I2C_OVRD_SCLVAL_BIT, 0x1, 0x0},
+                                         {I2C_OVRD_SDAVAL_BIT, 0x1, 0x1},
+                                     });
   EXPECT_EQ(dif_i2c_override_drive_pins(&i2c_, false, true), kDifI2cOk);
 
-  EXPECT_MASK32(I2C_OVRD_REG_OFFSET,
-                {
-                    {I2C_OVRD_SCLVAL, 0x1, 0x1}, {I2C_OVRD_SDAVAL, 0x1, 0x1},
-                });
+  EXPECT_MASK32(I2C_OVRD_REG_OFFSET, {
+                                         {I2C_OVRD_SCLVAL_BIT, 0x1, 0x1},
+                                         {I2C_OVRD_SDAVAL_BIT, 0x1, 0x1},
+                                     });
   EXPECT_EQ(dif_i2c_override_drive_pins(&i2c_, true, true), kDifI2cOk);
 }
 
@@ -592,10 +596,10 @@ TEST_F(FifoTest, ReadNullArgs) {
 // upgraded.
 
 TEST_F(FifoTest, WriteRaw) {
-  EXPECT_WRITE32(I2C_FDATA_REG_OFFSET,
-                 {
-                     {I2C_FDATA_FBYTE_OFFSET, 0x44}, {I2C_FDATA_START, 0x1},
-                 });
+  EXPECT_WRITE32(I2C_FDATA_REG_OFFSET, {
+                                           {I2C_FDATA_FBYTE_OFFSET, 0x44},
+                                           {I2C_FDATA_START_BIT, 0x1},
+                                       });
   EXPECT_EQ(dif_i2c_write_byte_raw(&i2c_, 0x44,
                                    {
                                        .start = true,
@@ -609,8 +613,8 @@ TEST_F(FifoTest, WriteRaw) {
 
   EXPECT_WRITE32(I2C_FDATA_REG_OFFSET, {
                                            {I2C_FDATA_FBYTE_OFFSET, 0x66},
-                                           {I2C_FDATA_STOP, 0x1},
-                                           {I2C_FDATA_NAKOK, 0x1},
+                                           {I2C_FDATA_STOP_BIT, 0x1},
+                                           {I2C_FDATA_NAKOK_BIT, 0x1},
                                        });
   EXPECT_EQ(dif_i2c_write_byte_raw(&i2c_, 0x66,
                                    {
@@ -624,8 +628,8 @@ TEST_F(FifoTest, WriteRaw) {
 
   EXPECT_WRITE32(I2C_FDATA_REG_OFFSET, {
                                            {I2C_FDATA_FBYTE_OFFSET, 0x00},
-                                           {I2C_FDATA_READ, 0x1},
-                                           {I2C_FDATA_RCONT, 0x1},
+                                           {I2C_FDATA_READ_BIT, 0x1},
+                                           {I2C_FDATA_RCONT_BIT, 0x1},
                                        });
   EXPECT_EQ(
       dif_i2c_write_byte_raw(
@@ -635,10 +639,10 @@ TEST_F(FifoTest, WriteRaw) {
           }),
       kDifI2cOk);
 
-  EXPECT_WRITE32(I2C_FDATA_REG_OFFSET,
-                 {
-                     {I2C_FDATA_FBYTE_OFFSET, 0x77}, {I2C_FDATA_READ, 0x1},
-                 });
+  EXPECT_WRITE32(I2C_FDATA_REG_OFFSET, {
+                                           {I2C_FDATA_FBYTE_OFFSET, 0x77},
+                                           {I2C_FDATA_READ_BIT, 0x1},
+                                       });
   EXPECT_EQ(
       dif_i2c_write_byte_raw(&i2c_, 0x77,
                              {

--- a/sw/device/tests/dif/dif_otbn_unittest.cc
+++ b/sw/device/tests/dif/dif_otbn_unittest.cc
@@ -93,7 +93,7 @@ TEST_F(IrqStateGetTest, NullArgs) {
 
 TEST_F(IrqStateGetTest, Success) {
   // Get the first IRQ state.
-  EXPECT_READ32(OTBN_INTR_STATE_REG_OFFSET, {{OTBN_INTR_STATE_DONE, true}});
+  EXPECT_READ32(OTBN_INTR_STATE_REG_OFFSET, {{OTBN_INTR_STATE_DONE_BIT, true}});
 
   dif_otbn_enable_t done_state = kDifOtbnDisable;
   dif_otbn_result_t result =
@@ -102,7 +102,7 @@ TEST_F(IrqStateGetTest, Success) {
   EXPECT_EQ(done_state, kDifOtbnEnable);
 
   // Get the last IRQ state.
-  EXPECT_READ32(OTBN_INTR_STATE_REG_OFFSET, {{OTBN_INTR_STATE_ERR, false}});
+  EXPECT_READ32(OTBN_INTR_STATE_REG_OFFSET, {{OTBN_INTR_STATE_ERR_BIT, false}});
 
   dif_otbn_enable_t err_state = kDifOtbnEnable;
   result = dif_otbn_irq_state_get(&dif_otbn_, kDifOtbnInterruptErr, &err_state);
@@ -120,14 +120,14 @@ TEST_F(IrqStateClearTest, NullArgs) {
 
 TEST_F(IrqStateClearTest, Success) {
   // Clear the first IRQ state.
-  EXPECT_WRITE32(OTBN_INTR_STATE_REG_OFFSET, {{OTBN_INTR_STATE_DONE, 1}});
+  EXPECT_WRITE32(OTBN_INTR_STATE_REG_OFFSET, {{OTBN_INTR_STATE_DONE_BIT, 1}});
 
   dif_otbn_result_t result =
       dif_otbn_irq_state_clear(&dif_otbn_, kDifOtbnInterruptDone);
   EXPECT_EQ(result, kDifOtbnOk);
 
   // Clear the last IRQ state.
-  EXPECT_WRITE32(OTBN_INTR_STATE_REG_OFFSET, {{OTBN_INTR_STATE_ERR, 1}});
+  EXPECT_WRITE32(OTBN_INTR_STATE_REG_OFFSET, {{OTBN_INTR_STATE_ERR_BIT, 1}});
 
   result = dif_otbn_irq_state_clear(&dif_otbn_, kDifOtbnInterruptErr);
   EXPECT_EQ(result, kDifOtbnOk);
@@ -211,7 +211,7 @@ TEST_F(IrqControlTest, NullArgs) {
 TEST_F(IrqControlTest, Success) {
   // Enable first IRQ.
   EXPECT_MASK32(OTBN_INTR_ENABLE_REG_OFFSET,
-                {{OTBN_INTR_ENABLE_DONE, 0x1, true}});
+                {{OTBN_INTR_ENABLE_DONE_BIT, 0x1, true}});
 
   dif_otbn_result_t result =
       dif_otbn_irq_control(&dif_otbn_, kDifOtbnInterruptDone, kDifOtbnEnable);
@@ -219,7 +219,7 @@ TEST_F(IrqControlTest, Success) {
 
   // Disable last IRQ.
   EXPECT_MASK32(OTBN_INTR_ENABLE_REG_OFFSET,
-                {{OTBN_INTR_ENABLE_ERR, 0x1, false}});
+                {{OTBN_INTR_ENABLE_ERR_BIT, 0x1, false}});
 
   result =
       dif_otbn_irq_control(&dif_otbn_, kDifOtbnInterruptErr, kDifOtbnDisable);
@@ -235,14 +235,16 @@ TEST_F(IrqForceTest, NullArgs) {
 
 TEST_F(IrqForceTest, Success) {
   // Force first IRQ.
-  EXPECT_MASK32(OTBN_INTR_TEST_REG_OFFSET, {{OTBN_INTR_TEST_DONE, 0x1, true}});
+  EXPECT_MASK32(OTBN_INTR_TEST_REG_OFFSET,
+                {{OTBN_INTR_TEST_DONE_BIT, 0x1, true}});
 
   dif_otbn_result_t result =
       dif_otbn_irq_force(&dif_otbn_, kDifOtbnInterruptDone);
   EXPECT_EQ(result, kDifOtbnOk);
 
   // Force last IRQ.
-  EXPECT_MASK32(OTBN_INTR_TEST_REG_OFFSET, {{OTBN_INTR_TEST_ERR, 0x1, true}});
+  EXPECT_MASK32(OTBN_INTR_TEST_REG_OFFSET,
+                {{OTBN_INTR_TEST_ERR_BIT, 0x1, true}});
 
   result = dif_otbn_irq_force(&dif_otbn_, kDifOtbnInterruptErr);
   EXPECT_EQ(result, kDifOtbnOk);
@@ -281,7 +283,7 @@ TEST_F(StartTest, Success) {
   EXPECT_WRITE32(OTBN_START_ADDR_REG_OFFSET, 4);
 
   // Set start command bit.
-  EXPECT_WRITE32(OTBN_CMD_REG_OFFSET, {{OTBN_CMD_START, 1}});
+  EXPECT_WRITE32(OTBN_CMD_REG_OFFSET, {{OTBN_CMD_START_BIT, 1}});
 
   dif_otbn_result_t result = dif_otbn_start(&dif_otbn_, 4);
   EXPECT_EQ(result, kDifOtbnOk);
@@ -312,7 +314,7 @@ TEST_F(IsBusyTest, NullArgs) {
 }
 
 TEST_F(IsBusyTest, Success) {
-  EXPECT_READ32(OTBN_STATUS_REG_OFFSET, {{OTBN_STATUS_BUSY, true}});
+  EXPECT_READ32(OTBN_STATUS_REG_OFFSET, {{OTBN_STATUS_BUSY_BIT, true}});
 
   bool busy = false;
   dif_otbn_result_t result = dif_otbn_is_busy(&dif_otbn_, &busy);

--- a/sw/device/tests/dif/dif_otp_ctrl_unittest.cc
+++ b/sw/device/tests/dif/dif_otp_ctrl_unittest.cc
@@ -56,7 +56,7 @@ TEST_F(ConfigTest, Basic) {
   };
 
   EXPECT_READ32(OTP_CTRL_CHECK_REGWEN_REG_OFFSET,
-                {{OTP_CTRL_CHECK_REGWEN_CHECK_REGWEN, true}});
+                {{OTP_CTRL_CHECK_REGWEN_CHECK_REGWEN_BIT, true}});
 
   EXPECT_WRITE32(OTP_CTRL_CHECK_TIMEOUT_REG_OFFSET, config.check_timeout);
   EXPECT_WRITE32(OTP_CTRL_INTEGRITY_CHECK_PERIOD_REG_OFFSET,
@@ -69,7 +69,7 @@ TEST_F(ConfigTest, Basic) {
 
 TEST_F(ConfigTest, Locked) {
   EXPECT_READ32(OTP_CTRL_CHECK_REGWEN_REG_OFFSET,
-                {{OTP_CTRL_CHECK_REGWEN_CHECK_REGWEN, false}});
+                {{OTP_CTRL_CHECK_REGWEN_CHECK_REGWEN_BIT, false}});
 
   EXPECT_EQ(dif_otp_ctrl_configure(&otp_, {}), kDifOtpCtrlLockableLocked);
 }
@@ -78,19 +78,19 @@ TEST_F(ConfigTest, IsConfigLocked) {
   bool flag;
 
   EXPECT_READ32(OTP_CTRL_CHECK_REGWEN_REG_OFFSET,
-                {{OTP_CTRL_CHECK_REGWEN_CHECK_REGWEN, true}});
+                {{OTP_CTRL_CHECK_REGWEN_CHECK_REGWEN_BIT, true}});
   EXPECT_EQ(dif_otp_ctrl_config_is_locked(&otp_, &flag), kDifOtpCtrlOk);
   EXPECT_FALSE(flag);
 
   EXPECT_READ32(OTP_CTRL_CHECK_REGWEN_REG_OFFSET,
-                {{OTP_CTRL_CHECK_REGWEN_CHECK_REGWEN, false}});
+                {{OTP_CTRL_CHECK_REGWEN_CHECK_REGWEN_BIT, false}});
   EXPECT_EQ(dif_otp_ctrl_config_is_locked(&otp_, &flag), kDifOtpCtrlOk);
   EXPECT_TRUE(flag);
 }
 
 TEST_F(ConfigTest, LockConfig) {
   EXPECT_WRITE32(OTP_CTRL_CHECK_REGWEN_REG_OFFSET,
-                 {{OTP_CTRL_CHECK_REGWEN_CHECK_REGWEN, true}});
+                 {{OTP_CTRL_CHECK_REGWEN_CHECK_REGWEN_BIT, true}});
   EXPECT_EQ(dif_otp_ctrl_lock_config(&otp_), kDifOtpCtrlOk);
 }
 
@@ -108,29 +108,29 @@ class CheckTest : public OtpTest {};
 
 TEST_F(CheckTest, Integrity) {
   EXPECT_READ32(OTP_CTRL_CHECK_REGWEN_REG_OFFSET,
-                {{OTP_CTRL_CHECK_REGWEN_CHECK_REGWEN, true}});
+                {{OTP_CTRL_CHECK_REGWEN_CHECK_REGWEN_BIT, true}});
   EXPECT_WRITE32(OTP_CTRL_CHECK_TRIGGER_REG_OFFSET,
-                 {{OTP_CTRL_CHECK_TRIGGER_INTEGRITY, true}});
+                 {{OTP_CTRL_CHECK_TRIGGER_INTEGRITY_BIT, true}});
 
   EXPECT_EQ(dif_otp_ctrl_check_integrity(&otp_), kDifOtpCtrlLockableOk);
 }
 
 TEST_F(CheckTest, Consistency) {
   EXPECT_READ32(OTP_CTRL_CHECK_REGWEN_REG_OFFSET,
-                {{OTP_CTRL_CHECK_REGWEN_CHECK_REGWEN, true}});
+                {{OTP_CTRL_CHECK_REGWEN_CHECK_REGWEN_BIT, true}});
   EXPECT_WRITE32(OTP_CTRL_CHECK_TRIGGER_REG_OFFSET,
-                 {{OTP_CTRL_CHECK_TRIGGER_CONSISTENCY, true}});
+                 {{OTP_CTRL_CHECK_TRIGGER_CONSISTENCY_BIT, true}});
 
   EXPECT_EQ(dif_otp_ctrl_check_consistency(&otp_), kDifOtpCtrlLockableOk);
 }
 
 TEST_F(CheckTest, Locked) {
   EXPECT_READ32(OTP_CTRL_CHECK_REGWEN_REG_OFFSET,
-                {{OTP_CTRL_CHECK_REGWEN_CHECK_REGWEN, false}});
+                {{OTP_CTRL_CHECK_REGWEN_CHECK_REGWEN_BIT, false}});
   EXPECT_EQ(dif_otp_ctrl_check_integrity(&otp_), kDifOtpCtrlLockableLocked);
 
   EXPECT_READ32(OTP_CTRL_CHECK_REGWEN_REG_OFFSET,
-                {{OTP_CTRL_CHECK_REGWEN_CHECK_REGWEN, false}});
+                {{OTP_CTRL_CHECK_REGWEN_CHECK_REGWEN_BIT, false}});
   EXPECT_EQ(dif_otp_ctrl_check_consistency(&otp_), kDifOtpCtrlLockableLocked);
 }
 
@@ -146,7 +146,7 @@ TEST_F(ReadLockTest, IsLocked) {
 
   EXPECT_READ32(
       OTP_CTRL_CREATOR_SW_CFG_READ_LOCK_REG_OFFSET,
-      {{OTP_CTRL_CREATOR_SW_CFG_READ_LOCK_CREATOR_SW_CFG_READ_LOCK, true}});
+      {{OTP_CTRL_CREATOR_SW_CFG_READ_LOCK_CREATOR_SW_CFG_READ_LOCK_BIT, true}});
   EXPECT_EQ(dif_otp_ctrl_reading_is_locked(
                 &otp_, kDifOtpCtrlPartitionCreatorSwCfg, &flag),
             kDifOtpCtrlOk);
@@ -154,7 +154,8 @@ TEST_F(ReadLockTest, IsLocked) {
 
   EXPECT_READ32(
       OTP_CTRL_CREATOR_SW_CFG_READ_LOCK_REG_OFFSET,
-      {{OTP_CTRL_CREATOR_SW_CFG_READ_LOCK_CREATOR_SW_CFG_READ_LOCK, false}});
+      {{OTP_CTRL_CREATOR_SW_CFG_READ_LOCK_CREATOR_SW_CFG_READ_LOCK_BIT,
+        false}});
   EXPECT_EQ(dif_otp_ctrl_reading_is_locked(
                 &otp_, kDifOtpCtrlPartitionCreatorSwCfg, &flag),
             kDifOtpCtrlOk);
@@ -162,7 +163,7 @@ TEST_F(ReadLockTest, IsLocked) {
 
   EXPECT_READ32(
       OTP_CTRL_OWNER_SW_CFG_READ_LOCK_REG_OFFSET,
-      {{OTP_CTRL_CREATOR_SW_CFG_READ_LOCK_CREATOR_SW_CFG_READ_LOCK, true}});
+      {{OTP_CTRL_CREATOR_SW_CFG_READ_LOCK_CREATOR_SW_CFG_READ_LOCK_BIT, true}});
   EXPECT_EQ(dif_otp_ctrl_reading_is_locked(
                 &otp_, kDifOtpCtrlPartitionOwnerSwCfg, &flag),
             kDifOtpCtrlOk);
@@ -170,7 +171,8 @@ TEST_F(ReadLockTest, IsLocked) {
 
   EXPECT_READ32(
       OTP_CTRL_OWNER_SW_CFG_READ_LOCK_REG_OFFSET,
-      {{OTP_CTRL_CREATOR_SW_CFG_READ_LOCK_CREATOR_SW_CFG_READ_LOCK, false}});
+      {{OTP_CTRL_CREATOR_SW_CFG_READ_LOCK_CREATOR_SW_CFG_READ_LOCK_BIT,
+        false}});
   EXPECT_EQ(dif_otp_ctrl_reading_is_locked(
                 &otp_, kDifOtpCtrlPartitionOwnerSwCfg, &flag),
             kDifOtpCtrlOk);
@@ -180,13 +182,13 @@ TEST_F(ReadLockTest, IsLocked) {
 TEST_F(ReadLockTest, Lock) {
   EXPECT_WRITE32(
       OTP_CTRL_CREATOR_SW_CFG_READ_LOCK_REG_OFFSET,
-      {{OTP_CTRL_CREATOR_SW_CFG_READ_LOCK_CREATOR_SW_CFG_READ_LOCK, true}});
+      {{OTP_CTRL_CREATOR_SW_CFG_READ_LOCK_CREATOR_SW_CFG_READ_LOCK_BIT, true}});
   EXPECT_EQ(dif_otp_ctrl_lock_reading(&otp_, kDifOtpCtrlPartitionCreatorSwCfg),
             kDifOtpCtrlOk);
 
   EXPECT_WRITE32(
       OTP_CTRL_OWNER_SW_CFG_READ_LOCK_REG_OFFSET,
-      {{OTP_CTRL_CREATOR_SW_CFG_READ_LOCK_CREATOR_SW_CFG_READ_LOCK, true}});
+      {{OTP_CTRL_CREATOR_SW_CFG_READ_LOCK_CREATOR_SW_CFG_READ_LOCK_BIT, true}});
   EXPECT_EQ(dif_otp_ctrl_lock_reading(&otp_, kDifOtpCtrlPartitionOwnerSwCfg),
             kDifOtpCtrlOk);
 }
@@ -220,7 +222,7 @@ TEST_F(IrqTest, IsPending) {
 
   EXPECT_READ32(OTP_CTRL_INTR_STATE_REG_OFFSET,
                 {
-                    {OTP_CTRL_INTR_COMMON_OTP_ERROR, true},
+                    {OTP_CTRL_INTR_COMMON_OTP_ERROR_BIT, true},
                 });
   EXPECT_EQ(dif_otp_ctrl_irq_is_pending(&otp_, kDifOtpCtrlIrqDone, &flag),
             kDifOtpCtrlOk);
@@ -228,7 +230,7 @@ TEST_F(IrqTest, IsPending) {
 
   EXPECT_READ32(OTP_CTRL_INTR_STATE_REG_OFFSET,
                 {
-                    {OTP_CTRL_INTR_COMMON_OTP_ERROR, true},
+                    {OTP_CTRL_INTR_COMMON_OTP_ERROR_BIT, true},
                 });
   EXPECT_EQ(dif_otp_ctrl_irq_is_pending(&otp_, kDifOtpCtrlIrqError, &flag),
             kDifOtpCtrlOk);
@@ -237,7 +239,7 @@ TEST_F(IrqTest, IsPending) {
 
 TEST_F(IrqTest, Ack) {
   EXPECT_WRITE32(OTP_CTRL_INTR_STATE_REG_OFFSET,
-                 {{OTP_CTRL_INTR_COMMON_OTP_OPERATION_DONE, true}});
+                 {{OTP_CTRL_INTR_COMMON_OTP_OPERATION_DONE_BIT, true}});
   EXPECT_EQ(dif_otp_ctrl_irq_acknowledge(&otp_, kDifOtpCtrlIrqDone),
             kDifOtpCtrlOk);
 }
@@ -247,7 +249,7 @@ TEST_F(IrqTest, GetEnabled) {
 
   EXPECT_READ32(OTP_CTRL_INTR_ENABLE_REG_OFFSET,
                 {
-                    {OTP_CTRL_INTR_COMMON_OTP_ERROR, true},
+                    {OTP_CTRL_INTR_COMMON_OTP_ERROR_BIT, true},
                 });
   EXPECT_EQ(dif_otp_ctrl_irq_get_enabled(&otp_, kDifOtpCtrlIrqDone, &flag),
             kDifOtpCtrlOk);
@@ -255,7 +257,7 @@ TEST_F(IrqTest, GetEnabled) {
 
   EXPECT_READ32(OTP_CTRL_INTR_ENABLE_REG_OFFSET,
                 {
-                    {OTP_CTRL_INTR_COMMON_OTP_ERROR, true},
+                    {OTP_CTRL_INTR_COMMON_OTP_ERROR_BIT, true},
                 });
   EXPECT_EQ(dif_otp_ctrl_irq_get_enabled(&otp_, kDifOtpCtrlIrqError, &flag),
             kDifOtpCtrlOk);
@@ -264,7 +266,7 @@ TEST_F(IrqTest, GetEnabled) {
 
 TEST_F(IrqTest, SetEnabled) {
   EXPECT_MASK32(OTP_CTRL_INTR_ENABLE_REG_OFFSET,
-                {{OTP_CTRL_INTR_COMMON_OTP_OPERATION_DONE, 1, true}});
+                {{OTP_CTRL_INTR_COMMON_OTP_OPERATION_DONE_BIT, 1, true}});
   EXPECT_EQ(dif_otp_ctrl_irq_set_enabled(&otp_, kDifOtpCtrlIrqDone,
                                          kDifOtpCtrlToggleEnabled),
             kDifOtpCtrlOk);
@@ -272,7 +274,7 @@ TEST_F(IrqTest, SetEnabled) {
 
 TEST_F(IrqTest, SetDisabled) {
   EXPECT_MASK32(OTP_CTRL_INTR_ENABLE_REG_OFFSET,
-                {{OTP_CTRL_INTR_COMMON_OTP_ERROR, 1, false}});
+                {{OTP_CTRL_INTR_COMMON_OTP_ERROR_BIT, 1, false}});
   EXPECT_EQ(dif_otp_ctrl_irq_set_enabled(&otp_, kDifOtpCtrlIrqError,
                                          kDifOtpCtrlToggleDisabled),
             kDifOtpCtrlOk);
@@ -280,7 +282,7 @@ TEST_F(IrqTest, SetDisabled) {
 
 TEST_F(IrqTest, Force) {
   EXPECT_WRITE32(OTP_CTRL_INTR_TEST_REG_OFFSET,
-                 {{OTP_CTRL_INTR_COMMON_OTP_OPERATION_DONE, true}});
+                 {{OTP_CTRL_INTR_COMMON_OTP_OPERATION_DONE_BIT, true}});
   EXPECT_EQ(dif_otp_ctrl_irq_force(&otp_, kDifOtpCtrlIrqDone), kDifOtpCtrlOk);
 }
 
@@ -330,7 +332,8 @@ class StatusTest : public OtpTest {};
 TEST_F(StatusTest, Idle) {
   dif_otp_ctrl_status_t status;
 
-  EXPECT_READ32(OTP_CTRL_STATUS_REG_OFFSET, {{OTP_CTRL_STATUS_DAI_IDLE, true}});
+  EXPECT_READ32(OTP_CTRL_STATUS_REG_OFFSET,
+                {{OTP_CTRL_STATUS_DAI_IDLE_BIT, true}});
   EXPECT_READ32(OTP_CTRL_ERR_CODE_REG_OFFSET, 0);
   EXPECT_EQ(dif_otp_ctrl_get_status(&otp_, &status), kDifOtpCtrlOk);
 
@@ -343,9 +346,9 @@ TEST_F(StatusTest, Errors) {
 
   EXPECT_READ32(OTP_CTRL_STATUS_REG_OFFSET,
                 {
-                    {OTP_CTRL_STATUS_DAI_IDLE, true},
-                    {OTP_CTRL_STATUS_HW_CFG_ERROR, true},
-                    {OTP_CTRL_STATUS_LCI_ERROR, true},
+                    {OTP_CTRL_STATUS_DAI_IDLE_BIT, true},
+                    {OTP_CTRL_STATUS_HW_CFG_ERROR_BIT, true},
+                    {OTP_CTRL_STATUS_LCI_ERROR_BIT, true},
                 });
 
   EXPECT_READ32(OTP_CTRL_ERR_CODE_REG_OFFSET,
@@ -374,18 +377,20 @@ TEST_F(StatusTest, NullArgs) {
 class DaiReadTest : public OtpTest {};
 
 TEST_F(DaiReadTest, Read32) {
-  EXPECT_READ32(OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET,
-                {{OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN, true}});
+  EXPECT_READ32(
+      OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET,
+      {{OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN_BIT, true}});
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET, 0x620);
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET,
-                 {{OTP_CTRL_DIRECT_ACCESS_CMD_READ, true}});
+                 {{OTP_CTRL_DIRECT_ACCESS_CMD_READ_BIT, true}});
 
   EXPECT_EQ(dif_otp_ctrl_dai_read_start(&otp_, kDifOtpCtrlPartitionHwCfg,
                                         /*address=*/0x20),
             kDifOtpCtrlDaiOk);
 
-  EXPECT_READ32(OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET,
-                {{OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN, true}});
+  EXPECT_READ32(
+      OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET,
+      {{OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN_BIT, true}});
   EXPECT_READ32(OTP_CTRL_DIRECT_ACCESS_RDATA_0_REG_OFFSET, 0x12345678);
 
   uint32_t val;
@@ -394,18 +399,20 @@ TEST_F(DaiReadTest, Read32) {
 }
 
 TEST_F(DaiReadTest, Read64) {
-  EXPECT_READ32(OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET,
-                {{OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN, true}});
+  EXPECT_READ32(
+      OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET,
+      {{OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN_BIT, true}});
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET, 0x738);
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET,
-                 {{OTP_CTRL_DIRECT_ACCESS_CMD_READ, true}});
+                 {{OTP_CTRL_DIRECT_ACCESS_CMD_READ_BIT, true}});
 
   EXPECT_EQ(dif_otp_ctrl_dai_read_start(&otp_, kDifOtpCtrlPartitionSecret2,
                                         /*address=*/0x8),
             kDifOtpCtrlDaiOk);
 
-  EXPECT_READ32(OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET,
-                {{OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN, true}});
+  EXPECT_READ32(
+      OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET,
+      {{OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN_BIT, true}});
   EXPECT_READ32(OTP_CTRL_DIRECT_ACCESS_RDATA_1_REG_OFFSET, 0x12345678);
   EXPECT_READ32(OTP_CTRL_DIRECT_ACCESS_RDATA_0_REG_OFFSET, 0x90abcdef);
 
@@ -430,19 +437,22 @@ TEST_F(DaiReadTest, OutOfRange) {
 }
 
 TEST_F(DaiReadTest, Busy) {
-  EXPECT_READ32(OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET,
-                {{OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN, false}});
+  EXPECT_READ32(
+      OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET,
+      {{OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN_BIT, false}});
   EXPECT_EQ(dif_otp_ctrl_dai_read_start(&otp_, kDifOtpCtrlPartitionHwCfg,
                                         /*address=*/0x0),
             kDifOtpCtrlDaiBusy);
 
-  EXPECT_READ32(OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET,
-                {{OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN, false}});
+  EXPECT_READ32(
+      OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET,
+      {{OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN_BIT, false}});
   uint32_t val32;
   EXPECT_EQ(dif_otp_ctrl_dai_read32_end(&otp_, &val32), kDifOtpCtrlDaiBusy);
 
-  EXPECT_READ32(OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET,
-                {{OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN, false}});
+  EXPECT_READ32(
+      OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET,
+      {{OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN_BIT, false}});
   uint64_t val64;
   EXPECT_EQ(dif_otp_ctrl_dai_read64_end(&otp_, &val64), kDifOtpCtrlDaiBusy);
 }
@@ -464,12 +474,13 @@ TEST_F(DaiReadTest, NullArgs) {
 class DaiProgramTest : public OtpTest {};
 
 TEST_F(DaiProgramTest, Program32) {
-  EXPECT_READ32(OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET,
-                {{OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN, true}});
+  EXPECT_READ32(
+      OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET,
+      {{OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN_BIT, true}});
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET, 0x620);
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_WDATA_0_REG_OFFSET, 0x12345678);
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET,
-                 {{OTP_CTRL_DIRECT_ACCESS_CMD_WRITE, true}});
+                 {{OTP_CTRL_DIRECT_ACCESS_CMD_WRITE_BIT, true}});
 
   EXPECT_EQ(dif_otp_ctrl_dai_program32(&otp_, kDifOtpCtrlPartitionHwCfg,
                                        /*address=*/0x20, /*value=*/0x12345678),
@@ -477,13 +488,14 @@ TEST_F(DaiProgramTest, Program32) {
 }
 
 TEST_F(DaiProgramTest, Program64) {
-  EXPECT_READ32(OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET,
-                {{OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN, true}});
+  EXPECT_READ32(
+      OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET,
+      {{OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN_BIT, true}});
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET, 0x738);
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_WDATA_0_REG_OFFSET, 0x90abcdef);
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_WDATA_1_REG_OFFSET, 0x12345678);
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET,
-                 {{OTP_CTRL_DIRECT_ACCESS_CMD_WRITE, true}});
+                 {{OTP_CTRL_DIRECT_ACCESS_CMD_WRITE_BIT, true}});
 
   EXPECT_EQ(
       dif_otp_ctrl_dai_program64(&otp_, kDifOtpCtrlPartitionSecret2,
@@ -527,14 +539,16 @@ TEST_F(DaiProgramTest, OutOfRange) {
 }
 
 TEST_F(DaiProgramTest, Busy) {
-  EXPECT_READ32(OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET,
-                {{OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN, false}});
+  EXPECT_READ32(
+      OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET,
+      {{OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN_BIT, false}});
   EXPECT_EQ(dif_otp_ctrl_dai_program32(&otp_, kDifOtpCtrlPartitionHwCfg,
                                        /*address=*/0x0, /*value=*/42),
             kDifOtpCtrlDaiBusy);
 
-  EXPECT_READ32(OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET,
-                {{OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN, false}});
+  EXPECT_READ32(
+      OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET,
+      {{OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN_BIT, false}});
   EXPECT_EQ(dif_otp_ctrl_dai_program64(&otp_, kDifOtpCtrlPartitionSecret0,
                                        /*address=*/0x0, /*value=*/42),
             kDifOtpCtrlDaiBusy);
@@ -552,13 +566,14 @@ TEST_F(DaiProgramTest, NullArgs) {
 class DaiDigestTest : public OtpTest {};
 
 TEST_F(DaiDigestTest, DigestSw) {
-  EXPECT_READ32(OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET,
-                {{OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN, true}});
+  EXPECT_READ32(
+      OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET,
+      {{OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN_BIT, true}});
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET, 0x2f8);
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_WDATA_0_REG_OFFSET, 0x00abcdef);
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_WDATA_1_REG_OFFSET, 0xabcdef00);
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET,
-                 {{OTP_CTRL_DIRECT_ACCESS_CMD_WRITE, true}});
+                 {{OTP_CTRL_DIRECT_ACCESS_CMD_WRITE_BIT, true}});
 
   EXPECT_EQ(dif_otp_ctrl_dai_digest(&otp_, kDifOtpCtrlPartitionCreatorSwCfg,
                                     /*digest=*/0xabcdef0000abcdef),
@@ -566,11 +581,12 @@ TEST_F(DaiDigestTest, DigestSw) {
 }
 
 TEST_F(DaiDigestTest, DigestHw) {
-  EXPECT_READ32(OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET,
-                {{OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN, true}});
+  EXPECT_READ32(
+      OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET,
+      {{OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN_BIT, true}});
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET, 0x600);
   EXPECT_WRITE32(OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET,
-                 {{OTP_CTRL_DIRECT_ACCESS_CMD_DIGEST, true}});
+                 {{OTP_CTRL_DIRECT_ACCESS_CMD_DIGEST_BIT, true}});
 
   EXPECT_EQ(
       dif_otp_ctrl_dai_digest(&otp_, kDifOtpCtrlPartitionHwCfg, /*digest=*/0),
@@ -584,8 +600,9 @@ TEST_F(DaiDigestTest, BadPartition) {
 }
 
 TEST_F(DaiDigestTest, Busy) {
-  EXPECT_READ32(OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET,
-                {{OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN, false}});
+  EXPECT_READ32(
+      OTP_CTRL_DIRECT_ACCESS_REGWEN_REG_OFFSET,
+      {{OTP_CTRL_DIRECT_ACCESS_REGWEN_DIRECT_ACCESS_REGWEN_BIT, false}});
 
   EXPECT_EQ(
       dif_otp_ctrl_dai_digest(&otp_, kDifOtpCtrlPartitionHwCfg, /*digest=*/0),

--- a/sw/device/tests/dif/dif_plic_unittest.cc
+++ b/sw/device/tests/dif/dif_plic_unittest.cc
@@ -76,21 +76,21 @@ class IrqTest : public PlicTest {
   };
   static constexpr std::array<Register, RV_PLIC_IE0_MULTIREG_COUNT>
       kEnableRegisters{{
-          {RV_PLIC_IE0_0_REG_OFFSET, RV_PLIC_IE0_0_E_31},
-          {RV_PLIC_IE0_1_REG_OFFSET, RV_PLIC_IE0_1_E_63},
-          {RV_PLIC_IE0_2_REG_OFFSET, RV_PLIC_IE0_2_E_83},
+          {RV_PLIC_IE0_0_REG_OFFSET, RV_PLIC_IE0_0_E_31_BIT},
+          {RV_PLIC_IE0_1_REG_OFFSET, RV_PLIC_IE0_1_E_63_BIT},
+          {RV_PLIC_IE0_2_REG_OFFSET, RV_PLIC_IE0_2_E_83_BIT},
       }};
   static constexpr std::array<Register, RV_PLIC_LE_MULTIREG_COUNT>
       kTriggerRegisters{{
-          {RV_PLIC_LE_0_REG_OFFSET, RV_PLIC_LE_0_LE_31},
-          {RV_PLIC_LE_1_REG_OFFSET, RV_PLIC_LE_1_LE_63},
-          {RV_PLIC_LE_2_REG_OFFSET, RV_PLIC_LE_2_LE_83},
+          {RV_PLIC_LE_0_REG_OFFSET, RV_PLIC_LE_0_LE_31_BIT},
+          {RV_PLIC_LE_1_REG_OFFSET, RV_PLIC_LE_1_LE_63_BIT},
+          {RV_PLIC_LE_2_REG_OFFSET, RV_PLIC_LE_2_LE_83_BIT},
       }};
   static constexpr std::array<Register, RV_PLIC_IP_MULTIREG_COUNT>
       kPendingRegisters{{
-          {RV_PLIC_IP_0_REG_OFFSET, RV_PLIC_IP_0_P_31},
-          {RV_PLIC_IP_1_REG_OFFSET, RV_PLIC_IP_1_P_63},
-          {RV_PLIC_IP_2_REG_OFFSET, RV_PLIC_IP_2_P_83},
+          {RV_PLIC_IP_0_REG_OFFSET, RV_PLIC_IP_0_P_31_BIT},
+          {RV_PLIC_IP_1_REG_OFFSET, RV_PLIC_IP_1_P_63_BIT},
+          {RV_PLIC_IP_2_REG_OFFSET, RV_PLIC_IP_2_P_83_BIT},
       }};
 
   // Set enable/disable multireg expectations, one bit per call.

--- a/sw/device/tests/dif/dif_pwrmgr_unittest.cc
+++ b/sw/device/tests/dif/dif_pwrmgr_unittest.cc
@@ -94,7 +94,7 @@ TEST_F(LowPowerTest, SetBadArgs) {
 TEST_F(LowPowerTest, SetLocked) {
   for (auto toggle : kAllToggles) {
     EXPECT_READ32(PWRMGR_CTRL_CFG_REGWEN_REG_OFFSET,
-                  AllOnesExcept(PWRMGR_CTRL_CFG_REGWEN_EN));
+                  AllOnesExcept(PWRMGR_CTRL_CFG_REGWEN_EN_BIT));
 
     EXPECT_EQ(dif_pwrmgr_low_power_set_enabled(&pwrmgr_, toggle),
               kDifPwrMgrConfigLocked);
@@ -105,12 +105,12 @@ TEST_F(LowPowerTest, Set) {
   for (auto toggle : kAllToggles) {
     EXPECT_READ32(PWRMGR_CTRL_CFG_REGWEN_REG_OFFSET,
                   {{
-                      .offset = PWRMGR_CTRL_CFG_REGWEN_EN,
+                      .offset = PWRMGR_CTRL_CFG_REGWEN_EN_BIT,
                       .value = 1,
                   }});
     EXPECT_MASK32(PWRMGR_CONTROL_REG_OFFSET,
                   {{
-                      .offset = PWRMGR_CONTROL_LOW_POWER_HINT,
+                      .offset = PWRMGR_CONTROL_LOW_POWER_HINT_BIT,
                       .mask = 1,
                       .value = (toggle == kDifPwrmgrToggleEnabled),
                   }});
@@ -138,7 +138,7 @@ TEST_F(LowPowerTest, Get) {
 
     EXPECT_READ32(PWRMGR_CONTROL_REG_OFFSET,
                   {{
-                      .offset = PWRMGR_CONTROL_LOW_POWER_HINT,
+                      .offset = PWRMGR_CONTROL_LOW_POWER_HINT_BIT,
                       .value = (toggle == kDifPwrmgrToggleEnabled),
                   }});
 
@@ -158,7 +158,7 @@ class DomainConfig : public DifPwrmgrInitialized {
               kDifPwrmgrDomainOptionUsbClockInLowPower |
               kDifPwrmgrDomainOptionUsbClockInActivePower |
               kDifPwrmgrDomainOptionMainPowerInLowPower,
-      .index = PWRMGR_CONTROL_CORE_CLK_EN,
+      .index = PWRMGR_CONTROL_CORE_CLK_EN_BIT,
   };
   static constexpr std::array<dif_pwrmgr_domain_config_t, 4> kConfigs = {
       // All disabled.
@@ -191,7 +191,7 @@ TEST_F(DomainConfig, SetBadArgs) {
 
 TEST_F(DomainConfig, SetLocked) {
   EXPECT_READ32(PWRMGR_CTRL_CFG_REGWEN_REG_OFFSET,
-                AllOnesExcept(PWRMGR_WAKEUP_EN_REGWEN_EN));
+                AllOnesExcept(PWRMGR_WAKEUP_EN_REGWEN_EN_BIT));
 
   EXPECT_EQ(dif_pwrmgr_set_domain_config(&pwrmgr_, 0), kDifPwrMgrConfigLocked);
 }
@@ -200,7 +200,7 @@ TEST_F(DomainConfig, Set) {
   for (auto config : kConfigs) {
     EXPECT_READ32(PWRMGR_CTRL_CFG_REGWEN_REG_OFFSET,
                   {{
-                      .offset = PWRMGR_CTRL_CFG_REGWEN_EN,
+                      .offset = PWRMGR_CTRL_CFG_REGWEN_EN_BIT,
                       .value = 1,
                   }});
     EXPECT_MASK32(PWRMGR_CONTROL_REG_OFFSET,
@@ -289,7 +289,7 @@ TEST_F(RequestSources, SetBadArgs) {
 
 TEST_F(RequestSources, SetWakeupLocked) {
   EXPECT_READ32(PWRMGR_WAKEUP_EN_REGWEN_REG_OFFSET,
-                AllOnesExcept(PWRMGR_WAKEUP_EN_REGWEN_EN));
+                AllOnesExcept(PWRMGR_WAKEUP_EN_REGWEN_EN_BIT));
 
   EXPECT_EQ(dif_pwrmgr_set_request_sources(&pwrmgr_, kDifPwrmgrReqTypeWakeup,
                                            kDifPwrmgrWakeupRequestSourceOne),
@@ -298,7 +298,7 @@ TEST_F(RequestSources, SetWakeupLocked) {
 
 TEST_F(RequestSources, SetResetLocked) {
   EXPECT_READ32(PWRMGR_RESET_EN_REGWEN_REG_OFFSET,
-                AllOnesExcept(PWRMGR_RESET_EN_REGWEN_EN));
+                AllOnesExcept(PWRMGR_RESET_EN_REGWEN_EN_BIT));
 
   EXPECT_EQ(dif_pwrmgr_set_request_sources(&pwrmgr_, kDifPwrmgrReqTypeReset,
                                            kDifPwrmgrResetRequestSourceOne),
@@ -308,7 +308,7 @@ TEST_F(RequestSources, SetResetLocked) {
 TEST_F(RequestSources, SetWakeup) {
   EXPECT_READ32(PWRMGR_WAKEUP_EN_REGWEN_REG_OFFSET,
                 {{
-                    .offset = PWRMGR_WAKEUP_EN_REGWEN_EN,
+                    .offset = PWRMGR_WAKEUP_EN_REGWEN_EN_BIT,
                     .value = 1,
                 }});
   EXPECT_WRITE32(PWRMGR_WAKEUP_EN_REG_OFFSET, kDifPwrmgrWakeupRequestSourceOne);
@@ -322,7 +322,7 @@ TEST_F(RequestSources, SetWakeup) {
 TEST_F(RequestSources, SetReset) {
   EXPECT_READ32(PWRMGR_RESET_EN_REGWEN_REG_OFFSET,
                 {{
-                    .offset = PWRMGR_RESET_EN_REGWEN_EN,
+                    .offset = PWRMGR_RESET_EN_REGWEN_EN_BIT,
                     .value = 1,
                 }});
   EXPECT_WRITE32(PWRMGR_RESET_EN_REG_OFFSET, kDifPwrmgrResetRequestSourceOne);
@@ -481,7 +481,7 @@ TEST_F(RequestSources, IsLockedWakeup) {
   for (auto exp_val : kAllBools) {
     EXPECT_READ32(PWRMGR_WAKEUP_EN_REGWEN_REG_OFFSET,
                   {{
-                      .offset = PWRMGR_WAKEUP_EN_REGWEN_EN,
+                      .offset = PWRMGR_WAKEUP_EN_REGWEN_EN_BIT,
                       .value = !exp_val,
                   }});
 
@@ -497,7 +497,7 @@ TEST_F(RequestSources, IsLockedReset) {
   for (auto exp_val : kAllBools) {
     EXPECT_READ32(PWRMGR_RESET_EN_REGWEN_REG_OFFSET,
                   {{
-                      .offset = PWRMGR_RESET_EN_REGWEN_EN,
+                      .offset = PWRMGR_RESET_EN_REGWEN_EN_BIT,
                       .value = !exp_val,
                   }});
 
@@ -527,7 +527,7 @@ TEST_F(WakeupRecording, SetEnabled) {
   for (auto new_state : kAllToggles) {
     EXPECT_WRITE32(PWRMGR_WAKE_INFO_CAPTURE_DIS_REG_OFFSET,
                    {{
-                       .offset = PWRMGR_WAKE_INFO_CAPTURE_DIS_VAL,
+                       .offset = PWRMGR_WAKE_INFO_CAPTURE_DIS_VAL_BIT,
                        .value = (new_state == kDifPwrmgrToggleDisabled),
                    }});
 
@@ -553,7 +553,7 @@ TEST_F(WakeupRecording, GetEnabled) {
   for (auto exp_val : kAllToggles) {
     EXPECT_READ32(PWRMGR_WAKE_INFO_CAPTURE_DIS_REG_OFFSET,
                   {{
-                      .offset = PWRMGR_WAKE_INFO_CAPTURE_DIS_VAL,
+                      .offset = PWRMGR_WAKE_INFO_CAPTURE_DIS_VAL_BIT,
                       .value = (exp_val == kDifPwrmgrToggleDisabled),
                   }});
 
@@ -616,15 +616,15 @@ TEST_F(WakeupRecording, GetReason) {
       // All bits set.
       {
           .read_val = {{
-                           .offset = PWRMGR_WAKE_INFO_ABORT,
+                           .offset = PWRMGR_WAKE_INFO_ABORT_BIT,
                            .value = 1,
                        },
                        {
-                           .offset = PWRMGR_WAKE_INFO_FALL_THROUGH,
+                           .offset = PWRMGR_WAKE_INFO_FALL_THROUGH_BIT,
                            .value = 1,
                        },
                        {
-                           .offset = PWRMGR_WAKE_INFO_REASONS,
+                           .offset = PWRMGR_WAKE_INFO_REASONS_BIT,
                            .value = 1,
                        }},
           .exp_output =
@@ -638,7 +638,7 @@ TEST_F(WakeupRecording, GetReason) {
       // Only abort.
       {
           .read_val = {{
-              .offset = PWRMGR_WAKE_INFO_ABORT,
+              .offset = PWRMGR_WAKE_INFO_ABORT_BIT,
               .value = 1,
           }},
           .exp_output =
@@ -650,7 +650,7 @@ TEST_F(WakeupRecording, GetReason) {
       // Only fall-through.
       {
           .read_val = {{
-              .offset = PWRMGR_WAKE_INFO_FALL_THROUGH,
+              .offset = PWRMGR_WAKE_INFO_FALL_THROUGH_BIT,
               .value = 1,
           }},
           .exp_output =
@@ -662,7 +662,7 @@ TEST_F(WakeupRecording, GetReason) {
       // Only requests from peripherals.
       {
           .read_val = {{
-              .offset = PWRMGR_WAKE_INFO_REASONS,
+              .offset = PWRMGR_WAKE_INFO_REASONS_BIT,
               .value = 1,
           }},
           .exp_output =

--- a/sw/device/tests/dif/dif_rstmgr_unittest.cc
+++ b/sw/device/tests/dif/dif_rstmgr_unittest.cc
@@ -133,10 +133,10 @@ class ResetCausesGetTest : public RstmgrTest {
   }
 
   const std::vector<uint32_t> reset_info_reasons_{
-      RSTMGR_RESET_INFO_POR,
-      RSTMGR_RESET_INFO_LOW_POWER_EXIT,
-      RSTMGR_RESET_INFO_NDM_RESET,
-      RSTMGR_RESET_INFO_HW_REQ,
+      RSTMGR_RESET_INFO_POR_BIT,
+      RSTMGR_RESET_INFO_LOW_POWER_EXIT_BIT,
+      RSTMGR_RESET_INFO_NDM_RESET_BIT,
+      RSTMGR_RESET_INFO_HW_REQ_BIT,
   };
 };
 
@@ -197,7 +197,7 @@ TEST_F(AlertInfoSetTest, Success) {
   // Enable.
   EXPECT_WRITE32(RSTMGR_ALERT_INFO_CTRL_REG_OFFSET,
                  {
-                     {RSTMGR_ALERT_INFO_CTRL_EN, true},
+                     {RSTMGR_ALERT_INFO_CTRL_EN_BIT, true},
                  });
   EXPECT_EQ(
       dif_rstmgr_alert_info_set_enabled(&rstmgr_, kDifRstmgrToggleEnabled),
@@ -206,7 +206,7 @@ TEST_F(AlertInfoSetTest, Success) {
   // Disable.
   EXPECT_WRITE32(RSTMGR_ALERT_INFO_CTRL_REG_OFFSET,
                  {
-                     {RSTMGR_ALERT_INFO_CTRL_EN, false},
+                     {RSTMGR_ALERT_INFO_CTRL_EN_BIT, false},
                  });
   EXPECT_EQ(
       dif_rstmgr_alert_info_set_enabled(&rstmgr_, kDifRstmgrToggleDisabled),
@@ -229,7 +229,7 @@ TEST_F(AlertInfoGetTest, Success) {
   // Enabled.
   EXPECT_READ32(RSTMGR_ALERT_INFO_CTRL_REG_OFFSET,
                 {
-                    {RSTMGR_ALERT_INFO_CTRL_EN, true},
+                    {RSTMGR_ALERT_INFO_CTRL_EN_BIT, true},
                 });
 
   dif_rstmgr_toggle_t state = kDifRstmgrToggleDisabled;
@@ -240,8 +240,9 @@ TEST_F(AlertInfoGetTest, Success) {
   //
   // Make sure that the only relevant `enabled` bit is read - set all bits
   // high apart from the `enabled` bit.
-  uint32_t register_value = bitfield_bit32_write(
-      std::numeric_limits<uint32_t>::max(), RSTMGR_ALERT_INFO_CTRL_EN, false);
+  uint32_t register_value =
+      bitfield_bit32_write(std::numeric_limits<uint32_t>::max(),
+                           RSTMGR_ALERT_INFO_CTRL_EN_BIT, false);
   EXPECT_READ32(RSTMGR_ALERT_INFO_CTRL_REG_OFFSET, register_value);
 
   state = kDifRstmgrToggleEnabled;
@@ -313,7 +314,7 @@ TEST_F(AlertInfoDumpReadTest, SuccessFullBuffer) {
     EXPECT_WRITE32(RSTMGR_ALERT_INFO_CTRL_REG_OFFSET,
                    {
                        {
-                           RSTMGR_ALERT_INFO_CTRL_EN,
+                           RSTMGR_ALERT_INFO_CTRL_EN_BIT,
                            true,
                        },
                        {
@@ -345,7 +346,7 @@ TEST_F(AlertInfoDumpReadTest, SuccessDumpSmaller) {
     EXPECT_WRITE32(RSTMGR_ALERT_INFO_CTRL_REG_OFFSET,
                    {
                        {
-                           RSTMGR_ALERT_INFO_CTRL_EN,
+                           RSTMGR_ALERT_INFO_CTRL_EN_BIT,
                            true,
                        },
                        {

--- a/sw/device/tests/dif/dif_spi_device_unittest.cc
+++ b/sw/device/tests/dif/dif_spi_device_unittest.cc
@@ -60,16 +60,16 @@ class AbortTest : public SpiTest {};
 
 TEST_F(AbortTest, Immediate) {
   EXPECT_MASK32(SPI_DEVICE_CONTROL_REG_OFFSET,
-                {{SPI_DEVICE_CONTROL_ABORT, 0x1, 0x1}});
+                {{SPI_DEVICE_CONTROL_ABORT_BIT, 0x1, 0x1}});
   EXPECT_READ32(SPI_DEVICE_STATUS_REG_OFFSET,
-                {{SPI_DEVICE_STATUS_ABORT_DONE, 0x1}});
+                {{SPI_DEVICE_STATUS_ABORT_DONE_BIT, 0x1}});
 
   EXPECT_EQ(dif_spi_device_abort(&spi_), kDifSpiDeviceOk);
 }
 
 TEST_F(AbortTest, Delayed) {
   EXPECT_MASK32(SPI_DEVICE_CONTROL_REG_OFFSET,
-                {{SPI_DEVICE_CONTROL_ABORT, 0x1, 0x1}});
+                {{SPI_DEVICE_CONTROL_ABORT_BIT, 0x1, 0x1}});
   EXPECT_READ32(SPI_DEVICE_STATUS_REG_OFFSET, 0);
   EXPECT_READ32(SPI_DEVICE_STATUS_REG_OFFSET, 0);
   EXPECT_READ32(SPI_DEVICE_STATUS_REG_OFFSET, 0);
@@ -77,7 +77,7 @@ TEST_F(AbortTest, Delayed) {
   EXPECT_READ32(SPI_DEVICE_STATUS_REG_OFFSET, 0);
   EXPECT_READ32(SPI_DEVICE_STATUS_REG_OFFSET, 0);
   EXPECT_READ32(SPI_DEVICE_STATUS_REG_OFFSET,
-                {{SPI_DEVICE_STATUS_ABORT_DONE, 0x1}});
+                {{SPI_DEVICE_STATUS_ABORT_DONE_BIT, 0x1}});
 
   EXPECT_EQ(dif_spi_device_abort(&spi_), kDifSpiDeviceOk);
 }
@@ -91,10 +91,10 @@ class ConfigTest : public SpiTest {};
 TEST_F(ConfigTest, BasicInit) {
   EXPECT_WRITE32(SPI_DEVICE_CFG_REG_OFFSET,
                  {
-                     {SPI_DEVICE_CFG_CPOL, 0},
-                     {SPI_DEVICE_CFG_CPHA, 0},
-                     {SPI_DEVICE_CFG_TX_ORDER, 0},
-                     {SPI_DEVICE_CFG_RX_ORDER, 0},
+                     {SPI_DEVICE_CFG_CPOL_BIT, 0},
+                     {SPI_DEVICE_CFG_CPHA_BIT, 0},
+                     {SPI_DEVICE_CFG_TX_ORDER_BIT, 0},
+                     {SPI_DEVICE_CFG_RX_ORDER_BIT, 0},
                      {SPI_DEVICE_CFG_TIMER_V_OFFSET, config_.rx_fifo_timeout},
                  });
   EXPECT_WRITE32(SPI_DEVICE_RXF_ADDR_REG_OFFSET,
@@ -124,10 +124,10 @@ TEST_F(ConfigTest, ComplexInit) {
 
   EXPECT_WRITE32(SPI_DEVICE_CFG_REG_OFFSET,
                  {
-                     {SPI_DEVICE_CFG_CPOL, 1},
-                     {SPI_DEVICE_CFG_CPHA, 1},
-                     {SPI_DEVICE_CFG_TX_ORDER, 1},
-                     {SPI_DEVICE_CFG_RX_ORDER, 0},
+                     {SPI_DEVICE_CFG_CPOL_BIT, 1},
+                     {SPI_DEVICE_CFG_CPHA_BIT, 1},
+                     {SPI_DEVICE_CFG_TX_ORDER_BIT, 1},
+                     {SPI_DEVICE_CFG_RX_ORDER_BIT, 0},
                      {SPI_DEVICE_CFG_TIMER_V_OFFSET, config_.rx_fifo_timeout},
                  });
   EXPECT_WRITE32(SPI_DEVICE_RXF_ADDR_REG_OFFSET,
@@ -159,27 +159,27 @@ TEST_F(IrqTest, Get) {
   bool out;
 
   EXPECT_READ32(SPI_DEVICE_INTR_STATE_REG_OFFSET,
-                {{SPI_DEVICE_INTR_STATE_RXF, 1}});
+                {{SPI_DEVICE_INTR_STATE_RXF_BIT, 1}});
   EXPECT_EQ(dif_spi_device_irq_is_pending(&spi_, kDifSpiDeviceIrqRxFull, &out),
             kDifSpiDeviceOk);
   EXPECT_TRUE(out);
 
-  EXPECT_READ32(
-      SPI_DEVICE_INTR_STATE_REG_OFFSET,
-      {{SPI_DEVICE_INTR_STATE_RXERR, 0}, {SPI_DEVICE_INTR_STATE_RXF, 1}});
+  EXPECT_READ32(SPI_DEVICE_INTR_STATE_REG_OFFSET,
+                {{SPI_DEVICE_INTR_STATE_RXERR_BIT, 0},
+                 {SPI_DEVICE_INTR_STATE_RXF_BIT, 1}});
   EXPECT_EQ(dif_spi_device_irq_is_pending(&spi_, kDifSpiDeviceIrqRxError, &out),
             kDifSpiDeviceOk);
   EXPECT_FALSE(out);
 
   EXPECT_READ32(SPI_DEVICE_INTR_STATE_REG_OFFSET,
-                {{SPI_DEVICE_INTR_STATE_TXUNDERFLOW, 1}});
+                {{SPI_DEVICE_INTR_STATE_TXUNDERFLOW_BIT, 1}});
   EXPECT_EQ(
       dif_spi_device_irq_is_pending(&spi_, kDifSpiDeviceIrqTxUnderflow, &out),
       kDifSpiDeviceOk);
   EXPECT_TRUE(out);
 
   EXPECT_READ32(SPI_DEVICE_INTR_STATE_REG_OFFSET,
-                {{SPI_DEVICE_INTR_STATE_TXLVL, 0}});
+                {{SPI_DEVICE_INTR_STATE_TXLVL_BIT, 0}});
   EXPECT_EQ(
       dif_spi_device_irq_is_pending(&spi_, kDifSpiDeviceIrqTxBelowLevel, &out),
       kDifSpiDeviceOk);
@@ -198,25 +198,25 @@ TEST_F(IrqTest, GetNull) {
 
 TEST_F(IrqTest, Enable) {
   EXPECT_MASK32(SPI_DEVICE_INTR_ENABLE_REG_OFFSET,
-                {{SPI_DEVICE_INTR_ENABLE_RXF, 0x1, 1}});
+                {{SPI_DEVICE_INTR_ENABLE_RXF_BIT, 0x1, 1}});
   EXPECT_EQ(dif_spi_device_irq_set_enabled(&spi_, kDifSpiDeviceIrqRxFull,
                                            kDifSpiDeviceToggleEnabled),
             kDifSpiDeviceOk);
 
   EXPECT_MASK32(SPI_DEVICE_INTR_ENABLE_REG_OFFSET,
-                {{SPI_DEVICE_INTR_ENABLE_RXERR, 0x1, 0}});
+                {{SPI_DEVICE_INTR_ENABLE_RXERR_BIT, 0x1, 0}});
   EXPECT_EQ(dif_spi_device_irq_set_enabled(&spi_, kDifSpiDeviceIrqRxError,
                                            kDifSpiDeviceToggleDisabled),
             kDifSpiDeviceOk);
 
   EXPECT_MASK32(SPI_DEVICE_INTR_ENABLE_REG_OFFSET,
-                {{SPI_DEVICE_INTR_ENABLE_TXUNDERFLOW, 0x1, 1}});
+                {{SPI_DEVICE_INTR_ENABLE_TXUNDERFLOW_BIT, 0x1, 1}});
   EXPECT_EQ(dif_spi_device_irq_set_enabled(&spi_, kDifSpiDeviceIrqTxUnderflow,
                                            kDifSpiDeviceToggleEnabled),
             kDifSpiDeviceOk);
 
   EXPECT_MASK32(SPI_DEVICE_INTR_ENABLE_REG_OFFSET,
-                {{SPI_DEVICE_INTR_ENABLE_TXLVL, 0x1, 0}});
+                {{SPI_DEVICE_INTR_ENABLE_TXLVL_BIT, 0x1, 0}});
   EXPECT_EQ(dif_spi_device_irq_set_enabled(&spi_, kDifSpiDeviceIrqTxBelowLevel,
                                            kDifSpiDeviceToggleDisabled),
             kDifSpiDeviceOk);
@@ -230,22 +230,22 @@ TEST_F(IrqTest, EnableNull) {
 
 TEST_F(IrqTest, Force) {
   EXPECT_WRITE32(SPI_DEVICE_INTR_TEST_REG_OFFSET,
-                 {{SPI_DEVICE_INTR_TEST_RXF, 1}});
+                 {{SPI_DEVICE_INTR_TEST_RXF_BIT, 1}});
   EXPECT_EQ(dif_spi_device_irq_force(&spi_, kDifSpiDeviceIrqRxFull),
             kDifSpiDeviceOk);
 
   EXPECT_WRITE32(SPI_DEVICE_INTR_TEST_REG_OFFSET,
-                 {{SPI_DEVICE_INTR_TEST_RXERR, 1}});
+                 {{SPI_DEVICE_INTR_TEST_RXERR_BIT, 1}});
   EXPECT_EQ(dif_spi_device_irq_force(&spi_, kDifSpiDeviceIrqRxError),
             kDifSpiDeviceOk);
 
   EXPECT_WRITE32(SPI_DEVICE_INTR_TEST_REG_OFFSET,
-                 {{SPI_DEVICE_INTR_TEST_TXUNDERFLOW, 1}});
+                 {{SPI_DEVICE_INTR_TEST_TXUNDERFLOW_BIT, 1}});
   EXPECT_EQ(dif_spi_device_irq_force(&spi_, kDifSpiDeviceIrqTxUnderflow),
             kDifSpiDeviceOk);
 
   EXPECT_WRITE32(SPI_DEVICE_INTR_TEST_REG_OFFSET,
-                 {{SPI_DEVICE_INTR_TEST_TXLVL, 1}});
+                 {{SPI_DEVICE_INTR_TEST_TXLVL_BIT, 1}});
   EXPECT_EQ(dif_spi_device_irq_force(&spi_, kDifSpiDeviceIrqTxBelowLevel),
             kDifSpiDeviceOk);
 }

--- a/sw/device/tests/dif/dif_uart_unittest.cc
+++ b/sw/device/tests/dif/dif_uart_unittest.cc
@@ -28,10 +28,11 @@ class UartTest : public Test, public MmioTest {
  protected:
   void ExpectDeviceReset() {
     EXPECT_WRITE32(UART_CTRL_REG_OFFSET, 0);
-    EXPECT_WRITE32(UART_FIFO_CTRL_REG_OFFSET, {
-                                                  {UART_FIFO_CTRL_RXRST, true},
-                                                  {UART_FIFO_CTRL_TXRST, true},
-                                              });
+    EXPECT_WRITE32(UART_FIFO_CTRL_REG_OFFSET,
+                   {
+                       {UART_FIFO_CTRL_RXRST_BIT, true},
+                       {UART_FIFO_CTRL_TXRST_BIT, true},
+                   });
     EXPECT_WRITE32(UART_OVRD_REG_OFFSET, 0);
     EXPECT_WRITE32(UART_TIMEOUT_CTRL_REG_OFFSET, 0);
     EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET, 0);
@@ -70,15 +71,16 @@ TEST_F(ConfigTest, NullArgs) {
 TEST_F(ConfigTest, Default) {
   ExpectDeviceReset();
 
-  EXPECT_WRITE32(
-      UART_CTRL_REG_OFFSET,
-      {
-          {UART_CTRL_TX, true}, {UART_CTRL_RX, true}, {UART_CTRL_NCO_OFFSET, 1},
-      });
+  EXPECT_WRITE32(UART_CTRL_REG_OFFSET, {
+                                           {UART_CTRL_TX_BIT, true},
+                                           {UART_CTRL_RX_BIT, true},
+                                           {UART_CTRL_NCO_OFFSET, 1},
+                                       });
 
   EXPECT_WRITE32(UART_FIFO_CTRL_REG_OFFSET,
                  {
-                     {UART_FIFO_CTRL_RXRST, true}, {UART_FIFO_CTRL_TXRST, true},
+                     {UART_FIFO_CTRL_RXRST_BIT, true},
+                     {UART_FIFO_CTRL_TXRST_BIT, true},
                  });
 
   EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET, 0);
@@ -93,15 +95,16 @@ TEST_F(ConfigTest, ParityEven) {
   ExpectDeviceReset();
 
   EXPECT_WRITE32(UART_CTRL_REG_OFFSET, {
-                                           {UART_CTRL_TX, true},
-                                           {UART_CTRL_RX, true},
-                                           {UART_CTRL_PARITY_EN, true},
+                                           {UART_CTRL_TX_BIT, true},
+                                           {UART_CTRL_RX_BIT, true},
+                                           {UART_CTRL_PARITY_EN_BIT, true},
                                            {UART_CTRL_NCO_OFFSET, 1},
                                        });
 
   EXPECT_WRITE32(UART_FIFO_CTRL_REG_OFFSET,
                  {
-                     {UART_FIFO_CTRL_RXRST, true}, {UART_FIFO_CTRL_TXRST, true},
+                     {UART_FIFO_CTRL_RXRST_BIT, true},
+                     {UART_FIFO_CTRL_TXRST_BIT, true},
                  });
 
   EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET, 0);
@@ -116,16 +119,17 @@ TEST_F(ConfigTest, ParityOdd) {
   ExpectDeviceReset();
 
   EXPECT_WRITE32(UART_CTRL_REG_OFFSET, {
-                                           {UART_CTRL_TX, true},
-                                           {UART_CTRL_RX, true},
-                                           {UART_CTRL_PARITY_EN, true},
-                                           {UART_CTRL_PARITY_ODD, true},
+                                           {UART_CTRL_TX_BIT, true},
+                                           {UART_CTRL_RX_BIT, true},
+                                           {UART_CTRL_PARITY_EN_BIT, true},
+                                           {UART_CTRL_PARITY_ODD_BIT, true},
                                            {UART_CTRL_NCO_OFFSET, 1},
                                        });
 
   EXPECT_WRITE32(UART_FIFO_CTRL_REG_OFFSET,
                  {
-                     {UART_FIFO_CTRL_RXRST, true}, {UART_FIFO_CTRL_TXRST, true},
+                     {UART_FIFO_CTRL_RXRST_BIT, true},
+                     {UART_FIFO_CTRL_TXRST_BIT, true},
                  });
 
   EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET, 0);
@@ -240,7 +244,7 @@ TEST_F(BytesSendTest, TxFifoEmpty) {
 }
 
 TEST_F(BytesSendTest, TxFifoFull) {
-  EXPECT_READ32(UART_STATUS_REG_OFFSET, {{UART_STATUS_TXFULL, true}});
+  EXPECT_READ32(UART_STATUS_REG_OFFSET, {{UART_STATUS_TXFULL_BIT, true}});
 
   size_t bytes_written;
   EXPECT_EQ(dif_uart_bytes_send(&uart_, kBytesArray.data(), kBytesArray.size(),
@@ -305,7 +309,7 @@ TEST_F(BytesReceiveTest, RxFifoFull) {
 }
 
 TEST_F(BytesReceiveTest, RxFifoEmpty) {
-  EXPECT_READ32(UART_STATUS_REG_OFFSET, {{UART_STATUS_RXEMPTY, true}});
+  EXPECT_READ32(UART_STATUS_REG_OFFSET, {{UART_STATUS_RXEMPTY_BIT, true}});
 
   uint8_t num_bytes = kBytesArray.size();
 
@@ -327,16 +331,16 @@ TEST_F(BytesSendPolledTest, NullArgs) {
 
 TEST_F(BytesSendPolledTest, Success) {
   // Busy loop 1 iteration (waiting for TX FIFO to free up)
-  EXPECT_READ32(UART_STATUS_REG_OFFSET, {{UART_STATUS_TXFULL, true}});
-  EXPECT_READ32(UART_STATUS_REG_OFFSET, {{UART_STATUS_TXFULL, false}});
+  EXPECT_READ32(UART_STATUS_REG_OFFSET, {{UART_STATUS_TXFULL_BIT, true}});
+  EXPECT_READ32(UART_STATUS_REG_OFFSET, {{UART_STATUS_TXFULL_BIT, false}});
 
   // Set expectations for the byte to be set
-  EXPECT_READ32(UART_STATUS_REG_OFFSET, {{UART_STATUS_TXFULL, false}});
+  EXPECT_READ32(UART_STATUS_REG_OFFSET, {{UART_STATUS_TXFULL_BIT, false}});
   EXPECT_WRITE32(UART_WDATA_REG_OFFSET, 'X');
 
   // Busy loop 1 iteration (waiting for the byte to be sent out by the HW)
-  EXPECT_READ32(UART_STATUS_REG_OFFSET, {{UART_STATUS_TXIDLE, false}});
-  EXPECT_READ32(UART_STATUS_REG_OFFSET, {{UART_STATUS_TXIDLE, true}});
+  EXPECT_READ32(UART_STATUS_REG_OFFSET, {{UART_STATUS_TXIDLE_BIT, false}});
+  EXPECT_READ32(UART_STATUS_REG_OFFSET, {{UART_STATUS_TXIDLE_BIT, true}});
 
   EXPECT_EQ(dif_uart_byte_send_polled(&uart_, 'X'), kDifUartOk);
 }
@@ -354,11 +358,11 @@ TEST_F(BytesReceivePolledTest, NullArgs) {
 
 TEST_F(BytesReceivePolledTest, Success) {
   // Busy loop 1 iteration (waiting for RX FIFO to fill up)
-  EXPECT_READ32(UART_STATUS_REG_OFFSET, {{UART_STATUS_RXEMPTY, true}});
-  EXPECT_READ32(UART_STATUS_REG_OFFSET, {{UART_STATUS_RXEMPTY, false}});
+  EXPECT_READ32(UART_STATUS_REG_OFFSET, {{UART_STATUS_RXEMPTY_BIT, true}});
+  EXPECT_READ32(UART_STATUS_REG_OFFSET, {{UART_STATUS_RXEMPTY_BIT, false}});
 
   // Set expectations for the byte to be read
-  EXPECT_READ32(UART_STATUS_REG_OFFSET, {{UART_STATUS_RXEMPTY, false}});
+  EXPECT_READ32(UART_STATUS_REG_OFFSET, {{UART_STATUS_RXEMPTY_BIT, false}});
   EXPECT_READ32(UART_RDATA_REG_OFFSET, 'X');
 
   uint8_t byte = 'Y';
@@ -383,7 +387,7 @@ TEST_F(IrqStateGetTest, NullArgs) {
 TEST_F(IrqStateGetTest, Success) {
   // Get the first IRQ state.
   EXPECT_READ32(UART_INTR_STATE_REG_OFFSET,
-                {{UART_INTR_STATE_TX_WATERMARK, true}});
+                {{UART_INTR_STATE_TX_WATERMARK_BIT, true}});
 
   bool tx_watermark_state;
   EXPECT_EQ(dif_uart_irq_is_pending(&uart_, kDifUartIrqTxWatermark,
@@ -393,7 +397,7 @@ TEST_F(IrqStateGetTest, Success) {
 
   // Get the last IRQ state.
   EXPECT_READ32(UART_INTR_STATE_REG_OFFSET,
-                {{UART_INTR_STATE_RX_PARITY_ERR, false}});
+                {{UART_INTR_STATE_RX_PARITY_ERR_BIT, false}});
 
   bool rx_parity_error_state;
   EXPECT_EQ(dif_uart_irq_is_pending(&uart_, kDifUartIrqRxParityErr,
@@ -412,14 +416,14 @@ TEST_F(IrqStateClearTest, NullArgs) {
 TEST_F(IrqStateClearTest, Success) {
   // Clear the first IRQ state.
   EXPECT_WRITE32(UART_INTR_STATE_REG_OFFSET,
-                 {{UART_INTR_STATE_TX_WATERMARK, 1}});
+                 {{UART_INTR_STATE_TX_WATERMARK_BIT, 1}});
 
   EXPECT_EQ(dif_uart_irq_acknowledge(&uart_, kDifUartIrqTxWatermark),
             kDifUartOk);
 
   // Clear the last IRQ state.
   EXPECT_WRITE32(UART_INTR_STATE_REG_OFFSET,
-                 {{UART_INTR_STATE_RX_PARITY_ERR, 1}});
+                 {{UART_INTR_STATE_RX_PARITY_ERR_BIT, 1}});
 
   EXPECT_EQ(dif_uart_irq_acknowledge(&uart_, kDifUartIrqRxParityErr),
             kDifUartOk);
@@ -497,7 +501,7 @@ TEST_F(IrqEnableTest, NullArgs) {
 TEST_F(IrqEnableTest, Success) {
   // Enable first IRQ.
   EXPECT_MASK32(UART_INTR_ENABLE_REG_OFFSET,
-                {{UART_INTR_ENABLE_TX_WATERMARK, 0x1, true}});
+                {{UART_INTR_ENABLE_TX_WATERMARK_BIT, 0x1, true}});
 
   EXPECT_EQ(dif_uart_irq_set_enabled(&uart_, kDifUartIrqTxWatermark,
                                      kDifUartToggleEnabled),
@@ -505,7 +509,7 @@ TEST_F(IrqEnableTest, Success) {
 
   // Disable last IRQ.
   EXPECT_MASK32(UART_INTR_ENABLE_REG_OFFSET,
-                {{UART_INTR_ENABLE_RX_PARITY_ERR, 0x1, false}});
+                {{UART_INTR_ENABLE_RX_PARITY_ERR_BIT, 0x1, false}});
 
   EXPECT_EQ(dif_uart_irq_set_enabled(&uart_, kDifUartIrqRxParityErr,
                                      kDifUartToggleDisabled),
@@ -522,13 +526,13 @@ TEST_F(IrqForceTest, NullArgs) {
 TEST_F(IrqForceTest, Success) {
   // Force first IRQ.
   EXPECT_MASK32(UART_INTR_TEST_REG_OFFSET,
-                {{UART_INTR_TEST_TX_WATERMARK, 0x1, true}});
+                {{UART_INTR_TEST_TX_WATERMARK_BIT, 0x1, true}});
 
   EXPECT_EQ(dif_uart_irq_force(&uart_, kDifUartIrqTxWatermark), kDifUartOk);
 
   // Force last IRQ.
   EXPECT_MASK32(UART_INTR_TEST_REG_OFFSET,
-                {{UART_INTR_TEST_RX_PARITY_ERR, 0x1, true}});
+                {{UART_INTR_TEST_RX_PARITY_ERR_BIT, 0x1, true}});
 
   EXPECT_EQ(dif_uart_irq_force(&uart_, kDifUartIrqRxParityErr), kDifUartOk);
 }
@@ -603,17 +607,19 @@ TEST_F(FifoResetTest, NullArgs) {
 }
 
 TEST_F(FifoResetTest, Success) {
-  EXPECT_MASK32(UART_FIFO_CTRL_REG_OFFSET, {{UART_FIFO_CTRL_RXRST, 0x1, true}});
+  EXPECT_MASK32(UART_FIFO_CTRL_REG_OFFSET,
+                {{UART_FIFO_CTRL_RXRST_BIT, 0x1, true}});
   EXPECT_EQ(dif_uart_fifo_reset(&uart_, kDifUartFifoResetRx), kDifUartOk);
 
-  EXPECT_MASK32(UART_FIFO_CTRL_REG_OFFSET, {{UART_FIFO_CTRL_TXRST, 0x1, true}});
+  EXPECT_MASK32(UART_FIFO_CTRL_REG_OFFSET,
+                {{UART_FIFO_CTRL_TXRST_BIT, 0x1, true}});
   EXPECT_EQ(dif_uart_fifo_reset(&uart_, kDifUartFifoResetTx), kDifUartOk);
 
-  EXPECT_MASK32(
-      UART_FIFO_CTRL_REG_OFFSET,
-      {
-          {UART_FIFO_CTRL_RXRST, 0x1, true}, {UART_FIFO_CTRL_TXRST, 0x1, true},
-      });
+  EXPECT_MASK32(UART_FIFO_CTRL_REG_OFFSET,
+                {
+                    {UART_FIFO_CTRL_RXRST_BIT, 0x1, true},
+                    {UART_FIFO_CTRL_TXRST_BIT, 0x1, true},
+                });
   EXPECT_EQ(dif_uart_fifo_reset(&uart_, kDifUartFifoResetAll), kDifUartOk);
 }
 
@@ -626,22 +632,22 @@ TEST_F(LoopbackSetTest, NullArgs) {
 }
 
 TEST_F(LoopbackSetTest, Success) {
-  EXPECT_MASK32(UART_CTRL_REG_OFFSET, {{UART_CTRL_SLPBK, 0x1, true}});
+  EXPECT_MASK32(UART_CTRL_REG_OFFSET, {{UART_CTRL_SLPBK_BIT, 0x1, true}});
   EXPECT_EQ(dif_uart_loopback_set(&uart_, kDifUartLoopbackSystem,
                                   kDifUartToggleEnabled),
             kDifUartOk);
 
-  EXPECT_MASK32(UART_CTRL_REG_OFFSET, {{UART_CTRL_SLPBK, 0x1, false}});
+  EXPECT_MASK32(UART_CTRL_REG_OFFSET, {{UART_CTRL_SLPBK_BIT, 0x1, false}});
   EXPECT_EQ(dif_uart_loopback_set(&uart_, kDifUartLoopbackSystem,
                                   kDifUartToggleDisabled),
             kDifUartOk);
 
-  EXPECT_MASK32(UART_CTRL_REG_OFFSET, {{UART_CTRL_LLPBK, 0x1, true}});
+  EXPECT_MASK32(UART_CTRL_REG_OFFSET, {{UART_CTRL_LLPBK_BIT, 0x1, true}});
   EXPECT_EQ(dif_uart_loopback_set(&uart_, kDifUartLoopbackLine,
                                   kDifUartToggleEnabled),
             kDifUartOk);
 
-  EXPECT_MASK32(UART_CTRL_REG_OFFSET, {{UART_CTRL_LLPBK, 0x1, false}});
+  EXPECT_MASK32(UART_CTRL_REG_OFFSET, {{UART_CTRL_LLPBK_BIT, 0x1, false}});
   EXPECT_EQ(dif_uart_loopback_set(&uart_, kDifUartLoopbackLine,
                                   kDifUartToggleDisabled),
             kDifUartOk);

--- a/util/reggen/gen_cheader.py
+++ b/util/reggen/gen_cheader.py
@@ -105,7 +105,7 @@ def gen_cdefine_register(outstr, reg, comp, width, rnames, existing_defines):
         if field['bitinfo'][1] == 1:
             # single bit
             genout(outstr,
-                   gen_define(dname, [], str(fieldlsb), existing_defines))
+                   gen_define(dname + '_BIT', [], str(fieldlsb), existing_defines))
         else:
             # multiple bits (unless it is the whole register)
             if field['bitinfo'][1] != width:
@@ -247,7 +247,7 @@ def gen_cdefines_interrupt_field(outstr, interrupt, component, regwidth,
 
     if interrupt['bitinfo'][1] == 1:
         # single bit
-        genout(outstr, gen_define(defname, [], str(fieldlsb),
+        genout(outstr, gen_define(defname + '_BIT', [], str(fieldlsb),
                                   existing_defines))
     else:
         # multiple bits (unless it is the whole register)


### PR DESCRIPTION
Also includes a global refactor to use the new names, which unfortunately need to come in the same commit.

The following arcane incantation was used to generate the script that generated this PR.
```sh
grep -ohP '\w+_BIT' build-out/sw/device/lib/**/*.h > bit_names
perl -pi -e 's/(\w+)_BIT/perl -pi -e '"'"'s#\\b$1\\b#$1_BIT#g'"'"' \$1/g' bit_names
for f in ...; do echo $f; ./bit_names $f; done
```