### PR TITLE
[dv/dvsim] Fix -c option compile error

### DIFF
--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -894,6 +894,9 @@ class CovMerge(Deploy):
             ignored_wildcards=["cov_db_dirs"],
             ignore_error=False)
 
+        # Call base class __post_init__ to do checks and substitutions
+        super().__post_init__()
+
         # Prune previous merged cov directories.
         prev_cov_db_dirs = self.odir_limiter(odir=self.cov_merge_db_dir)
 
@@ -905,9 +908,6 @@ class CovMerge(Deploy):
 
         # Append cov_db_dirs to the list of exports.
         self.exports["cov_db_dirs"] = "\"{}\"".format(self.cov_db_dirs)
-
-        # Call base class __post_init__ to do checks and substitutions
-        super().__post_init__()
 
 
 class CovReport(Deploy):


### PR DESCRIPTION
Current self.exports uses `_process_exports` to convert it from a list
of dict to dict. But when enable coverage collection, in its `post_init`
function, current code tries to add `cov_db_dirs` to `self.exports`
before it converts to `dict`. So there is a compile error.

This fix calls the super._post_init first and avoid this error.

Signed-off-by: Cindy Chen <chencindy@google.com>