### PR TITLE
[otp_ctrl] Change state_q assignment to ease debugging

### DIFF
--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_dai.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_dai.sv
@@ -132,8 +132,7 @@ module otp_ctrl_dai
     DaiOffset = 1'b1
   } addr_sel_e;
 
-  state_e state_d;
-  logic [StateWidth-1:0] state_q;
+  state_e state_d, state_q;
   logic [CntWidth-1:0] cnt_d, cnt_q;
   logic cnt_en, cnt_clr;
   otp_err_e error_d, error_q;
@@ -152,7 +151,7 @@ module otp_ctrl_dai
   assign scrmbl_data_o = data_q;
 
   always_comb begin : p_fsm
-    state_d = state_e'(state_q);
+    state_d = state_q;
 
     // Init signals
     init_done_o = 1'b1;
@@ -637,14 +636,16 @@ module otp_ctrl_dai
 
   // This primitive is used to place a size-only constraint on the
   // flops in order to prevent FSM state encoding optimizations.
+  logic [StateWidth-1:0] state_raw_q;
+  assign state_q = state_e'(state_raw_q);
   prim_flop #(
     .Width(StateWidth),
     .ResetValue(StateWidth'(ResetSt))
   ) u_state_regs (
     .clk_i,
     .rst_ni,
-    .d_i ( state_d ),
-    .q_o ( state_q )
+    .d_i ( state_d     ),
+    .q_o ( state_raw_q )
   );
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_kdi.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_kdi.sv
@@ -279,11 +279,10 @@ module otp_ctrl_kdi
     ErrorSt      = 10'b1111011100
   } state_e;
 
-  state_e state_d;
-  logic [StateWidth-1:0] state_q;
+  state_e state_d, state_q;
 
   always_comb begin : p_fsm
-    state_d = state_e'(state_q);
+    state_d = state_q;
 
     // FSM Error output
     fsm_err_o = 1'b0;
@@ -475,14 +474,16 @@ module otp_ctrl_kdi
 
   // This primitive is used to place a size-only constraint on the
   // flops in order to prevent FSM state encoding optimizations.
+  logic [StateWidth-1:0] state_raw_q;
+  assign state_q = state_e'(state_raw_q);
   prim_flop #(
     .Width(StateWidth),
     .ResetValue(StateWidth'(ResetSt))
   ) u_state_regs (
     .clk_i,
     .rst_ni,
-    .d_i ( state_d ),
-    .q_o ( state_q )
+    .d_i ( state_d     ),
+    .q_o ( state_raw_q )
   );
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_lci.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_lci.sv
@@ -92,14 +92,13 @@ module otp_ctrl_lci
   logic [CntWidth-1:0] cnt_d, cnt_q;
   otp_err_e error_d, error_q;
   logic delta_data_is_set;
-  state_e state_d;
-  logic [StateWidth-1:0] state_q;
+  state_e state_d, state_q;
 
   // Output LCI errors
   assign error_o = error_q;
 
   always_comb begin : p_fsm
-    state_d = state_e'(state_q);
+    state_d = state_q;
 
     // Counter
     cnt_en   = 1'b0;
@@ -243,14 +242,16 @@ module otp_ctrl_lci
 
   // This primitive is used to place a size-only constraint on the
   // flops in order to prevent FSM state encoding optimizations.
+  logic [StateWidth-1:0] state_raw_q;
+  assign state_q = state_e'(state_raw_q);
   prim_flop #(
     .Width(StateWidth),
     .ResetValue(StateWidth'(ResetSt))
   ) u_state_regs (
     .clk_i,
     .rst_ni,
-    .d_i ( state_d ),
-    .q_o ( state_q )
+    .d_i ( state_d     ),
+    .q_o ( state_raw_q )
   );
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_lfsr_timer.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_lfsr_timer.sv
@@ -178,8 +178,7 @@ module otp_ctrl_lfsr_timer
     ErrorSt     = 9'b100101111
   } state_e;
 
-  state_e state_d;
-  bit [StateWidth-1:0] state_q;
+  state_e state_d, state_q;
   logic chk_timeout_d, chk_timeout_q;
 
   assign chk_timeout_o = chk_timeout_q;
@@ -287,14 +286,16 @@ module otp_ctrl_lfsr_timer
 
   // This primitive is used to place a size-only constraint on the
   // flops in order to prevent FSM state encoding optimizations.
+  logic [StateWidth-1:0] state_raw_q;
+  assign state_q = state_e'(state_raw_q);
   prim_flop #(
     .Width(StateWidth),
     .ResetValue(StateWidth'(ResetSt))
   ) u_state_regs (
     .clk_i,
     .rst_ni,
-    .d_i ( state_d ),
-    .q_o ( state_q )
+    .d_i ( state_d     ),
+    .q_o ( state_raw_q )
   );
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_buf.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_buf.sv
@@ -133,12 +133,11 @@ module otp_ctrl_part_buf
     DigOffset
   } base_sel_e;
 
-  state_e state_d;
+  state_e state_d, state_q;
   otp_err_e error_d, error_q;
   data_sel_e data_sel;
   base_sel_e base_sel;
   access_e dout_gate_d, dout_gate_q;
-  logic [StateWidth-1:0] state_q;
   logic [CntWidth-1:0] cnt_d, cnt_q;
   logic cnt_en, cnt_clr;
   logic ecc_err;
@@ -154,7 +153,7 @@ module otp_ctrl_part_buf
   assign otp_cmd_o   = OtpRead;
 
   always_comb begin : p_fsm
-    state_d = state_e'(state_q);
+    state_d = state_q;
 
     // Redundantly encoded lock signal for buffer regs.
     dout_gate_d = dout_gate_q;
@@ -609,14 +608,16 @@ module otp_ctrl_part_buf
 
   // This primitive is used to place a size-only constraint on the
   // flops in order to prevent FSM state encoding optimizations.
+  logic [StateWidth-1:0] state_raw_q;
+  assign state_q = state_e'(state_raw_q);
   prim_flop #(
     .Width(StateWidth),
     .ResetValue(StateWidth'(ResetSt))
   ) u_state_regs (
     .clk_i,
     .rst_ni,
-    .d_i ( state_d ),
-    .q_o ( state_q )
+    .d_i ( state_d     ),
+    .q_o ( state_raw_q )
   );
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
@@ -102,7 +102,7 @@ module otp_ctrl_part_unbuf
     DataAddr = 1'b1
   } addr_sel_e;
 
-  state_e state_d;
+  state_e state_d, state_q;
   addr_sel_e otp_addr_sel;
   otp_err_e error_d, error_q;
 
@@ -110,7 +110,6 @@ module otp_ctrl_part_unbuf
   logic ecc_err;
 
   logic [SwWindowAddrWidth-1:0] tlul_addr_d, tlul_addr_q;
-  logic [StateWidth-1:0] state_q;
 
   // Output partition error state.
   assign error_o = error_q;
@@ -123,7 +122,7 @@ module otp_ctrl_part_unbuf
   `ASSERT_KNOWN(FsmStateKnown_A, state_q)
   always_comb begin : p_fsm
     // Default assignments
-    state_d = state_e'(state_q);
+    state_d = state_q;
 
     // Response to init request
     init_done_o = 1'b0;
@@ -343,14 +342,16 @@ module otp_ctrl_part_unbuf
 
   // This primitive is used to place a size-only constraint on the
   // flops in order to prevent FSM state encoding optimizations.
+  logic [StateWidth-1:0] state_raw_q;
+  assign state_q = state_e'(state_raw_q);
   prim_flop #(
     .Width(StateWidth),
     .ResetValue(StateWidth'(ResetSt))
   ) u_state_regs (
     .clk_i,
     .rst_ni,
-    .d_i ( state_d ),
-    .q_o ( state_q )
+    .d_i ( state_d     ),
+    .q_o ( state_raw_q )
   );
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_scrmbl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_scrmbl.sv
@@ -210,8 +210,7 @@ module otp_ctrl_scrmbl import otp_ctrl_pkg::*; #(
   } state_e;
 
   localparam int CntWidth = $clog2(NumPresentRounds+1);
-  state_e state_d;
-  logic [StateWidth-1:0] state_q;
+  state_e state_d, state_q;
   logic [CntWidth-1:0] cnt_d, cnt_q;
   logic cnt_clr, cnt_en;
   logic valid_d, valid_q;
@@ -224,7 +223,7 @@ module otp_ctrl_scrmbl import otp_ctrl_pkg::*; #(
                              cnt_q;
 
   always_comb begin : p_fsm
-    state_d          = state_e'(state_q);
+    state_d          = state_q;
     is_first_d       = is_first_q;
     sel_d            = sel_q;
     digest_mode_d    = digest_mode_q;
@@ -399,14 +398,16 @@ module otp_ctrl_scrmbl import otp_ctrl_pkg::*; #(
 
   // This primitive is used to place a size-only constraint on the
   // flops in order to prevent FSM state encoding optimizations.
+  logic [StateWidth-1:0] state_raw_q;
+  assign state_q = state_e'(state_raw_q);
   prim_flop #(
     .Width(StateWidth),
     .ResetValue(StateWidth'(IdleSt))
   ) u_state_regs (
     .clk_i,
     .rst_ni,
-    .d_i ( state_d ),
-    .q_o ( state_q )
+    .d_i ( state_d     ),
+    .q_o ( state_raw_q )
   );
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs

--- a/hw/ip/prim/util/sparse-fsm-encode.py
+++ b/hw/ip/prim/util/sparse-fsm-encode.py
@@ -245,12 +245,11 @@ def main():
         # print FSM template
         print('''}} state_e;
 
-state_e state_d;
-logic [StateWidth-1:0] state_q;
+state_e state_d, state_q;
 
 always_comb begin : p_fsm
   // Default assignments
-  state_d = state_e'(state_q);
+  state_d = state_q;
 
   unique case (state_q)
 {}    default: ; // Consider triggering an error or alert in this case.
@@ -259,14 +258,16 @@ end
 
 // This primitive is used to place a size-only constraint on the
 // flops in order to prevent FSM state encoding optimizations.
+logic [StateWidth-1:0] state_raw_q;
+assign state_q = state_e'(state_raw_q);
 prim_flop #(
   .Width(StateWidth),
   .ResetValue(StateWidth'(State0))
 ) u_state_regs (
   .clk_i,
   .rst_ni,
-  .d_i ( state_d ),
-  .q_o ( state_q )
+  .d_i ( state_d     ),
+  .q_o ( state_raw_q )
 );
 '''.format(state_str))
 

--- a/hw/ip/prim_generic/rtl/prim_generic_otp.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_otp.sv
@@ -133,7 +133,6 @@ module prim_generic_otp #(
 
   state_e state_d, state_q;
   otp_ctrl_pkg::otp_err_e err_d, err_q;
-  logic [StateWidth-1:0] state_o;
   logic valid_d, valid_q;
   logic req, wren, rvalid;
   logic [1:0] rerror;
@@ -144,7 +143,6 @@ module prim_generic_otp #(
   logic [SizeWidth-1:0] cnt_d, cnt_q;
   logic cnt_clr, cnt_en;
 
-  assign state_q = state_e'(state_o);
   assign cnt_d = (cnt_clr) ? '0           :
                  (cnt_en)  ? cnt_q + 1'b1 : cnt_q;
 
@@ -305,14 +303,16 @@ module prim_generic_otp #(
 
   // This primitive is used to place a size-only constraint on the
   // flops in order to prevent FSM state encoding optimizations.
+  logic [StateWidth-1:0] state_raw_q;
+  assign state_q = state_e'(state_raw_q);
   prim_flop #(
     .Width(StateWidth),
     .ResetValue(StateWidth'(ResetSt))
   ) u_state_regs (
     .clk_i,
     .rst_ni,
-    .d_i ( state_d ),
-    .q_o ( state_o )
+    .d_i ( state_d     ),
+    .q_o ( state_raw_q )
   );
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs


### PR DESCRIPTION
Introduce a temporary signal such that we can make `state_q` of type `state_e`, which greatly eases debugging.

Signed-off-by: Michael Schaffner <msf@opentitan.org>