### PR TITLE
[dv/alert] Support async mode in device mode

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_if.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_if.sv
@@ -10,18 +10,26 @@ interface alert_esc_if(input clk, input rst_n);
   wire prim_alert_pkg::alert_rx_t alert_rx;
   wire prim_esc_pkg::esc_tx_t     esc_tx;
   wire prim_esc_pkg::esc_rx_t     esc_rx;
-  prim_alert_pkg::alert_tx_t      alert_tx_sync_dly2; // sync alert_tx 2 clk cycle delay flop
-  prim_alert_pkg::alert_tx_t      alert_tx_sync_dly1; // sync alert_tx 1 clk cycle delay flop
-  prim_alert_pkg::alert_tx_t      alert_tx_final;     // final alert_tx value depends if on async_mode
-  prim_alert_pkg::alert_tx_t      alert_tx_int; // internal alert_tx
-  prim_alert_pkg::alert_rx_t      alert_rx_int; // internal alert_rx
-  prim_esc_pkg::esc_tx_t          esc_tx_int;   // internal esc_tx
-  prim_esc_pkg::esc_rx_t          esc_rx_int;   // internal esc_rx
 
-  wire                     sender_clk;
-  bit                      is_async, is_alert;
-  dv_utils_pkg::if_mode_e  if_mode;
-  clk_rst_if               clk_rst_async_if(.clk(sender_clk), .rst_n(rst_n));
+  prim_alert_pkg::alert_tx_t alert_tx_sync_dly2; // sync alert_tx 2 clk cycle delay flop
+  prim_alert_pkg::alert_tx_t alert_tx_sync_dly1; // sync alert_tx 1 clk cycle delay flop
+  // final alert_tx value depends if on async and host mode
+  prim_alert_pkg::alert_tx_t alert_tx_final;
+
+  prim_alert_pkg::alert_rx_t alert_rx_sync_dly2; // sync alert_rx 2 clk cycle delay flop
+  prim_alert_pkg::alert_rx_t alert_rx_sync_dly1; // sync alert_rx 1 clk cycle delay flop
+  // final alert_rx value depends if on async and device mode
+  prim_alert_pkg::alert_rx_t alert_rx_final;
+
+  prim_alert_pkg::alert_tx_t alert_tx_int; // internal alert_tx
+  prim_alert_pkg::alert_rx_t alert_rx_int; // internal alert_rx
+  prim_esc_pkg::esc_tx_t     esc_tx_int;   // internal esc_tx
+  prim_esc_pkg::esc_rx_t     esc_rx_int;   // internal esc_rx
+
+  wire                    sender_clk;
+  bit                     is_async, is_alert;
+  dv_utils_pkg::if_mode_e if_mode;
+  clk_rst_if              clk_rst_async_if(.clk(sender_clk), .rst_n(rst_n));
 
   // if alert sender is async mode, the clock will be drived in alert_esc_agent,
   // if it is sync mode, will assign to dut clk here
@@ -33,12 +41,19 @@ interface alert_esc_if(input clk, input rst_n);
     if (!rst_n) begin
       alert_tx_sync_dly2 <= {2'b01};
       alert_tx_sync_dly1 <= {2'b01};
+      alert_rx_sync_dly2 <= {4'b0101};
+      alert_rx_sync_dly1 <= {4'b0101};
     end else begin
       alert_tx_sync_dly2 <= alert_tx_sync_dly1;
       alert_tx_sync_dly1 <= alert_tx;
+      alert_rx_sync_dly2 <= alert_rx_sync_dly1;
+      alert_rx_sync_dly1 <= alert_rx;
     end
   end
-  assign alert_tx_final = (is_async) ? alert_tx_sync_dly2 : alert_tx;
+  assign alert_tx_final = (is_async && (if_mode == dv_utils_pkg::Host)) ?
+                          alert_tx_sync_dly2 : alert_tx;
+  assign alert_rx_final = (is_async && (if_mode == dv_utils_pkg::Device)) ?
+                          alert_rx_sync_dly2 : alert_rx;
 
   clocking sender_cb @(posedge sender_clk);
     input  rst_n;
@@ -59,14 +74,14 @@ interface alert_esc_if(input clk, input rst_n);
   clocking monitor_cb @(posedge clk);
     input rst_n;
     input alert_tx_final;
-    input alert_rx;
+    input alert_rx_final;
     input esc_tx;
     input esc_rx;
   endclocking
 
   task automatic wait_ack_complete();
-    while (alert_tx.alert_p === 1'b1) @(monitor_cb);
-    while (alert_rx.ack_p === 1'b1) @(monitor_cb);
+    while (alert_tx_final.alert_p === 1'b1) @(monitor_cb);
+    while (alert_rx_final.ack_p === 1'b1)   @(monitor_cb);
   endtask : wait_ack_complete
 
   task automatic wait_esc_complete();
@@ -74,7 +89,7 @@ interface alert_esc_if(input clk, input rst_n);
   endtask : wait_esc_complete
 
   function automatic bit get_alert();
-    get_alert = (alert_tx.alert_p === 1'b1 && alert_tx.alert_n === 1'b0);
+    get_alert = (alert_tx_final.alert_p === 1'b1 && alert_tx_final.alert_n === 1'b0);
   endfunction : get_alert
 
   assign alert_tx = (if_mode == dv_utils_pkg::Host && is_alert)    ? alert_tx_int : 'z;
@@ -89,8 +104,8 @@ interface alert_esc_if(input clk, input rst_n);
     do begin
       logic ping_p;
       wait(rst_n === 1'b1);
-      ping_p = alert_rx.ping_p;
-      wait(alert_rx.ping_p !== ping_p && alert_rx.ping_p === !alert_rx.ping_n);
+      ping_p = alert_rx_final.ping_p;
+      wait(alert_rx_final.ping_p !== ping_p && alert_rx_final.ping_p === !alert_rx_final.ping_n);
     end while (rst_n != 1'b1);
   endtask : wait_alert_ping
 

--- a/hw/dv/sv/alert_esc_agent/alert_monitor.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_monitor.sv
@@ -34,7 +34,7 @@ class alert_monitor extends alert_esc_base_monitor;
     alert_esc_seq_item req;
     bit                ping_p, alert_p;
     forever @(cfg.vif.monitor_cb) begin
-      if (ping_p != cfg.vif.monitor_cb.alert_rx.ping_p) begin
+      if (ping_p != cfg.vif.monitor_cb.alert_rx_final.ping_p) begin
         under_ping_rsp = 1;
         req = alert_esc_seq_item::type_id::create("req");
         req.alert_esc_type = AlertEscPingTrans;
@@ -76,12 +76,12 @@ class alert_monitor extends alert_esc_base_monitor;
           // discussion on Issue #2321
           if (req.ping_timeout && req.alert_handshake_sta == AlertReceived) begin
             @(cfg.vif.monitor_cb);
-            if (cfg.vif.alert_rx.ack_p == 1'b1) alert_esc_port.write(req);
+            if (cfg.vif.alert_rx_final.ack_p == 1'b1) alert_esc_port.write(req);
           end
         end
         under_ping_rsp = 0;
       end
-      ping_p = cfg.vif.monitor_cb.alert_rx.ping_p;
+      ping_p = cfg.vif.monitor_cb.alert_rx_final.ping_p;
       alert_p = cfg.vif.monitor_cb.alert_tx_final.alert_p;
     end
   endtask : ping_thread
@@ -163,11 +163,11 @@ class alert_monitor extends alert_esc_base_monitor;
   endtask : wait_alert_complete
 
   virtual task wait_ack();
-    while (cfg.vif.alert_rx.ack_p !== 1'b1) @(cfg.vif.monitor_cb);
+    while (cfg.vif.alert_rx_final.ack_p !== 1'b1) @(cfg.vif.monitor_cb);
   endtask : wait_ack
 
   virtual task wait_ack_complete();
-    while (cfg.vif.alert_rx.ack_p !== 1'b0) @(cfg.vif.monitor_cb);
+    while (cfg.vif.alert_rx_final.ack_p !== 1'b0) @(cfg.vif.monitor_cb);
   endtask : wait_ack_complete
 
   virtual function bit is_sig_int_err();

--- a/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
@@ -43,6 +43,7 @@ class cip_base_env_cfg #(type RAL_T = dv_base_reg_block) extends dv_base_env_cfg
       string alert_name = list_of_alerts[i];
       m_alert_agent_cfg[alert_name] = alert_esc_agent_cfg::type_id::create("m_alert_agent_cfg");
       m_alert_agent_cfg[alert_name].if_mode = dv_utils_pkg::Device;
+      m_alert_agent_cfg[alert_name].is_async = 1; // default async_on, can override this
       m_alert_agent_cfg[alert_name].en_ping_cov = 0;
       if (zero_delays) begin
         m_alert_agent_cfg[alert_name].alert_delay_min = 0;


### PR DESCRIPTION
This PR adds support for async mode in Device mode.
In device mode, IPs are connected with `alert_sender`, so in async_mode,
the `alert_sender` will delay received signals `alert_rx` in two clock
cycle. This PR support that and adds a default async mode to all IPs.
This can be override in inidividual IPs if needed.

Signed-off-by: Cindy Chen <chencindy@google.com>