### PR TITLE
[sw][PROTOTYPE] Change _regs.h Generation

### DIFF
--- a/hw/ip/aes/meson.build
+++ b/hw/ip/aes/meson.build
@@ -1,0 +1,10 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+hw_ip_aes_reg_h = custom_target(
+  'hw_ip_aes_reg_h',
+  input: 'data/aes.hjson',
+  command: gen_hw_hdr_command,
+  output: gen_hw_hdr_output,
+)

--- a/hw/ip/meson.build
+++ b/hw/ip/meson.build
@@ -1,0 +1,5 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+subdir('aes')

--- a/hw/meson.build
+++ b/hw/meson.build
@@ -1,0 +1,20 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Reggen invocation for generating the register headers we use in the software
+# to ensure register offsets continue to match the hardware.
+gen_hw_hdr_output = '@BASENAME@_regs.h'
+gen_hw_hdr_command = [
+  prog_python,
+  meson.source_root() / 'util/regtool.py',
+  '--cdefines',
+  '-o', '@OUTPUT@',
+  '@INPUT@'
+]
+
+# Most IPs are in `hw/ip`
+subdir('ip')
+# Some IPs are parameterized by `top_earlgrey`, so are in `hw/top_earlgrey/ip`.
+# This directory will also contain any topgen-generated libraries.
+subdir('top_earlgrey')

--- a/hw/top_earlgrey/ip/meson.build
+++ b/hw/top_earlgrey/ip/meson.build
@@ -1,0 +1,5 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+subdir('rv_plic')

--- a/hw/top_earlgrey/ip/rv_plic/meson.build
+++ b/hw/top_earlgrey/ip/rv_plic/meson.build
@@ -1,0 +1,10 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+hw_top_earlgrey_ip_rv_plic_reg_h = custom_target(
+  'hw_top_earlgrey_ip_rv_plic_reg_h',
+  input: 'data/autogen/rv_plic.hjson',
+  command: gen_hw_hdr_command,
+  output: gen_hw_hdr_output,
+)

--- a/hw/top_earlgrey/meson.build
+++ b/hw/top_earlgrey/meson.build
@@ -1,0 +1,6 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+subdir('ip')
+subdir('sw')

--- a/hw/top_earlgrey/sw/meson.build
+++ b/hw/top_earlgrey/sw/meson.build
@@ -1,0 +1,13 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Top Earlgrey library (top_earlgrey)
+top_earlgrey = declare_dependency(
+  link_with: static_library(
+    'top_earlgrey_ot',
+    sources: [
+      'autogen/top_earlgrey.c',
+    ],
+  )
+)

--- a/meson.build
+++ b/meson.build
@@ -154,6 +154,7 @@ prog_objcopy = find_program('objcopy')
 prog_srec_cat = find_program('srec_cat')
 prog_git = find_program('git')
 
+
 # Hardware register headers. These are generated from HJSON files, and accesible
 # in C via |#include "{IP_NAME}_regs.h"|.
 gen_hw_hdr = generator(
@@ -165,8 +166,7 @@ gen_hw_hdr = generator(
   ],
 )
 
-# TODO: Considering moving these into hw/ip directories.
-hw_ip_aes_reg_h = gen_hw_hdr.process('hw/ip/aes/data/aes.hjson')
+# hw_ip_aes_reg_h = gen_hw_hdr.process('hw/ip/aes/data/aes.hjson')
 hw_ip_alert_handler_reg_h = gen_hw_hdr.process('hw/ip/alert_handler/data/alert_handler.hjson')
 hw_ip_flash_ctrl_reg_h = gen_hw_hdr.process('hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson')
 hw_ip_gpio_reg_h = gen_hw_hdr.process('hw/ip/gpio/data/gpio.hjson')
@@ -181,17 +181,12 @@ hw_ip_usbdev_reg_h = gen_hw_hdr.process('hw/ip/usbdev/data/usbdev.hjson')
 hw_ip_pwrmgr_reg_h = gen_hw_hdr.process('hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr.hjson')
 hw_ip_rstmgr_reg_h = gen_hw_hdr.process('hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson')
 hw_top_earlgrey_pinmux_reg_h = gen_hw_hdr.process('hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson')
-hw_top_earlgrey_rv_plic_reg_h = gen_hw_hdr.process('hw/top_earlgrey/ip/rv_plic/data/autogen/rv_plic.hjson')
+# hw_top_earlgrey_rv_plic_reg_h = gen_hw_hdr.process('hw/top_earlgrey/ip/rv_plic/data/autogen/rv_plic.hjson')
 
-# Top Earlgrey library (top_earlgrey)
-# The sources for this are generated into the hw hierarchy.
-top_earlgrey = declare_dependency(
-  link_with: static_library(
-    'top_earlgrey_ot',
-    sources: [
-      'hw/top_earlgrey/sw/autogen/top_earlgrey.c',
-    ],
-  )
-)
+# Meson in `hw` includes targets for auto-generated headers and libraries based
+# on reggen and topgen information. This is depended on by the device targets in
+# `sw`.
+subdir('hw')
 
+# This contains the majority of the software configuration.
 subdir('sw')

--- a/sw/device/lib/aes.c
+++ b/sw/device/lib/aes.c
@@ -4,7 +4,7 @@
 
 #include "sw/device/lib/aes.h"
 
-#include "aes_regs.h"  // Generated.
+#include "hw/ip/aes/aes_regs.h"  // Generated.
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 #define AES0_BASE_ADDR TOP_EARLGREY_AES_BASE_ADDR

--- a/sw/device/lib/dif/dif_plic.c
+++ b/sw/device/lib/dif/dif_plic.c
@@ -11,7 +11,7 @@
 #include "sw/device/lib/base/bitfield.h"
 #include "sw/device/lib/base/mmio.h"
 
-#include "rv_plic_regs.h"  // Generated.
+#include "hw/top_earlgrey/ip/rv_plic/rv_plic_regs.h"  // Generated.
 
 // If either of these static assertions fail, then the assumptions in this DIF
 // implementation should be revisited. In particular, `kPlicTargets`

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -21,7 +21,7 @@ sw_lib_dif_plic = declare_dependency(
   link_with: static_library(
     'dif_plic_ot',
     sources: [
-      hw_top_earlgrey_rv_plic_reg_h,
+      hw_top_earlgrey_ip_rv_plic_reg_h,
       'dif_plic.c',
     ],
     dependencies: [

--- a/sw/device/tests/dif/dif_plic_unittest.cc
+++ b/sw/device/tests/dif/dif_plic_unittest.cc
@@ -10,7 +10,7 @@
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/testing/mock_mmio.h"
 
-#include "rv_plic_regs.h"  // Generated.
+#include "hw/top_earlgrey/ip/rv_plic/rv_plic_regs.h"  // Generated.
 
 namespace dif_plic_unittest {
 namespace {

--- a/sw/device/tests/dif/meson.build
+++ b/sw/device/tests/dif/meson.build
@@ -37,7 +37,7 @@ test('dif_uart_unittest', executable(
 test('dif_plic_unittest', executable(
   'dif_plic_unittest',
   sources: [
-    hw_top_earlgrey_rv_plic_reg_h,
+    hw_top_earlgrey_ip_rv_plic_reg_h,
     meson.source_root() / 'sw/device/lib/dif/dif_plic.c',
     'dif_plic_unittest.cc',
   ],


### PR DESCRIPTION
This change does two related things with the generation of the
`<ip>_regs.h` headers:
- The first is to move away from `generator`, which will re-run the
  header generator for every target that depends on the header.
- The second is to move the meson targets for files in the `hw`
  directories closer to the files they target. This could be
  controversial as this introduces meson to the hw tree, and results in
  needing to change/add a lot of new meson configuration.