### PR TITLE
[otbn] Enable sanity test in CI and Chip DV

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -173,6 +173,11 @@
       sw_test: sw/device/tests/flash_ctrl_test
     }
     {
+      name: chip_dif_otbn_sanitytest
+      uvm_test_seq: chip_sw_base_vseq
+      sw_test: sw/device/tests/dif_otbn_sanitytest
+    }
+    {
       name: chip_hmac_sha256_encr
       uvm_test_seq: chip_sw_base_vseq
       sw_test: sw/device/tests/sha256_test

--- a/test/systemtest/config.py
+++ b/test/systemtest/config.py
@@ -25,6 +25,17 @@ TEST_APPS_SELFCHECKING = [
         "name": "crt_test",
     },
     {
+        "name": "dif_otbn_sanitytest_rtl",
+        "binary_name": "dif_otbn_sanitytest",
+        "verilator_extra_args": ['+OTBN_USE_MODEL=0'],
+    },
+    {
+        "name": "dif_otbn_sanitytest_model",
+        "binary_name": "dif_otbn_sanitytest",
+        "verilator_extra_args": ['+OTBN_USE_MODEL=1'],
+        "targets": ["sim_verilator"],
+    },
+    {
         "name": "dif_plic_sanitytest",
     },
     {

--- a/test/systemtest/config.py
+++ b/test/systemtest/config.py
@@ -29,12 +29,13 @@ TEST_APPS_SELFCHECKING = [
         "binary_name": "dif_otbn_sanitytest",
         "verilator_extra_args": ['+OTBN_USE_MODEL=0'],
     },
-    {
-        "name": "dif_otbn_sanitytest_model",
-        "binary_name": "dif_otbn_sanitytest",
-        "verilator_extra_args": ['+OTBN_USE_MODEL=1'],
-        "targets": ["sim_verilator"],
-    },
+# Using the model in CI isn't possible until #4097 is resolved.
+#    {
+#        "name": "dif_otbn_sanitytest_model",
+#        "binary_name": "dif_otbn_sanitytest",
+#        "verilator_extra_args": ['+OTBN_USE_MODEL=1'],
+#        "targets": ["sim_verilator"],
+#    },
     {
         "name": "dif_plic_sanitytest",
     },

--- a/test/systemtest/config.py
+++ b/test/systemtest/config.py
@@ -2,22 +2,54 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-# Self-checking test applications, which return PASS or FAIL after completion,
-# usable on all targets.
+# List of self-checking test applications, which return PASS or FAIL after
+# completion.
+#
+# Each list entry is a dict with the following keys:
+#
+# name:
+#   Name of the test (required)
+# binary_name:
+#   Basename of the test binary. Default: name (optional)
+# verilator_extra_args:
+#   A list of additional command-line arguments passed to the Verilator
+#   simulation (optional).
+# targets:
+#   List of targets for which the test is executed. The test will be executed
+#   on all targets if not given (optional).
 TEST_APPS_SELFCHECKING = [
-    "aes_test",
-    "crt_test",
-    "dif_plic_sanitytest",
-    "dif_rstmgr_sanitytest",
-    "dif_rv_timer_sanitytest",
-    "dif_uart_sanitytest",
-    "flash_ctrl_test",
-    "pmp_sanitytest_napot",
-    "pmp_sanitytest_tor",
-    "sha256_test",
-]
-
-# Self-checking applications running on the Verilator simulation
-TEST_APPS_SELFCHECKING_SIM_VERILATOR = TEST_APPS_SELFCHECKING + [
-    "usbdev_test",
+    {
+        "name": "aes_test",
+    },
+    {
+        "name": "crt_test",
+    },
+    {
+        "name": "dif_plic_sanitytest",
+    },
+    {
+        "name": "dif_rstmgr_sanitytest",
+    },
+    {
+        "name": "dif_rv_timer_sanitytest",
+    },
+    {
+        "name": "dif_uart_sanitytest",
+    },
+    {
+        "name": "flash_ctrl_test",
+    },
+    {
+        "name": "pmp_sanitytest_napot",
+    },
+    {
+        "name": "pmp_sanitytest_tor",
+    },
+    {
+        "name": "sha256_test",
+    },
+    {
+        "name": "usbdev_test",
+        "targets": ["sim_verilator"],
+    },
 ]

--- a/test/systemtest/earlgrey/test_fpga_nexysvideo.py
+++ b/test/systemtest/earlgrey/test_fpga_nexysvideo.py
@@ -67,7 +67,8 @@ def uart(uart_persistent, request):
 
 
 @pytest.fixture(scope="module")
-def nexysvideo_earlgrey(tmp_path_factory, topsrcdir, bin_dir, localconf_nexysvideo):
+def nexysvideo_earlgrey(tmp_path_factory, topsrcdir, bin_dir,
+                        localconf_nexysvideo):
     """ A Nexys Video board flashed with an Earl Grey bitstream """
 
     bitstream = bin_dir / "hw/top_earlgrey/lowrisc_systems_top_earlgrey_nexysvideo_0.1.bit"

--- a/test/systemtest/earlgrey/test_fpga_nexysvideo.py
+++ b/test/systemtest/earlgrey/test_fpga_nexysvideo.py
@@ -95,9 +95,24 @@ def nexysvideo_earlgrey(tmp_path_factory, topsrcdir, bin_dir, localconf_nexysvid
     assert p_pgm.proc.returncode == 0
 
 
-@pytest.fixture(params=config.TEST_APPS_SELFCHECKING)
+@pytest.fixture(params=config.TEST_APPS_SELFCHECKING,
+                ids=lambda param: param['name'])
 def app_selfchecking_bin(request, bin_dir):
-    test_filename = request.param + '_fpga_nexysvideo.bin'
+    app_config = request.param
+
+    if 'name' not in app_config:
+        raise RuntimeError("Key 'name' not found in TEST_APPS_SELFCHECKING")
+
+    if 'targets' in app_config and 'fpga_nexysvideo' not in app_config[
+            'targets']:
+        pytest.skip("Test %s skipped on NexysVideo FPGA." % app_config['name'])
+
+    if 'binary_name' in app_config:
+        binary_name = app_config['binary_name']
+    else:
+        binary_name = app_config['name']
+
+    test_filename = binary_name + '_fpga_nexysvideo.bin'
     bin_path = bin_dir / 'sw/device/tests' / test_filename
     assert bin_path.is_file()
     return bin_path

--- a/test/systemtest/earlgrey/test_sim_verilator.py
+++ b/test/systemtest/earlgrey/test_sim_verilator.py
@@ -4,6 +4,7 @@
 
 import logging
 import re
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -144,11 +145,14 @@ class VerilatorSimEarlgrey:
             # The default filter function for all device software in OpenTitan.
             filter_func = utils.filter_remove_device_sw_log_prefix
 
-        return utils.find_in_files([self._uart0_log],
-                                   pattern,
-                                   timeout,
-                                   filter_func=filter_func,
-                                   from_start=from_start)
+        try:
+            return utils.find_in_files([self._uart0_log],
+                                       pattern,
+                                       timeout,
+                                       filter_func=filter_func,
+                                       from_start=from_start)
+        except subprocess.TimeoutExpired:
+            return None
 
 
 @pytest.fixture(params=config.TEST_APPS_SELFCHECKING,

--- a/test/systemtest/earlgrey/test_sim_verilator.py
+++ b/test/systemtest/earlgrey/test_sim_verilator.py
@@ -228,7 +228,8 @@ def test_apps_selfchecking(tmp_path, bin_dir, app_selfchecking):
     sim.terminate()
 
 
-@pytest.mark.skip(reason="Spiflash on Verilator isn't reliable currently. See issue #3708.")
+@pytest.mark.skip(
+    reason="Spiflash on Verilator isn't reliable currently. See issue #3708.")
 def test_spiflash(tmp_path, bin_dir):
     """ Load a single application to the Verilator simulation using spiflash """
 

--- a/test/systemtest/utils.py
+++ b/test/systemtest/utils.py
@@ -426,19 +426,13 @@ def find_in_files(file_objects,
             file_object.seek(0)
 
     while True:
-        i = 0
         for file_object in file_objects:
-            i = 0
             for line in file_object:
-                i += 1
-
                 m = match_line(line.rstrip(), pattern, filter_func)
                 if m is not None:
                     return m
 
-        # Check if we exceed the timeout. Do so only every 100 lines to reduce
-        # the performance impact.
-        if timeout is not None and i % 100 == 99 and time.time() >= t_end:
+        if timeout is not None and time.time() >= t_end:
             raise subprocess.TimeoutExpired(None, timeout)
 
         end_loop = wait_func()


### PR DESCRIPTION
Enable the OTBN DIF sanity test in all testing environments:

* ~Verilator with the OTBN model~ (not until #4097 is resolved)
* Verilator with the OTBN RTL implementation
* UVM DV (chip DV) with the RTL implementation
* On FPGA (with the RTL implementation, unsurprisingly)

To be able to do so I had to make small modifications to the system test harness, which are also included in this PR. As usual, reviewing patch-by-patch will make your life easier.