### PR TITLE
[otbn] Fix nested loops in modexp.S

### DIFF
--- a/sw/otbn/code-snippets/modexp.s
+++ b/sw/otbn/code-snippets/modexp.s
@@ -1054,7 +1054,7 @@ modexp_65537:
 
   /* 65537 = 0b10000000000000001
                 ^<< 16 x sqr >>^   */
-  loopi      16, 7
+  loopi      16, 8
     /* square: out = montmul(out, out) */
     lw        x19, 28(x0)
     lw        x20, 28(x0)
@@ -1064,6 +1064,7 @@ modexp_65537:
     loop      x30, 2
       bn.sid    x8, 0(x21++)
       addi      x8, x8, 1
+    nop
 
   /* 65537 = 0b10000000000000001
                           mult ^


### PR DESCRIPTION
Currently (as implemented in RTL) nested loops cannot end on the same
instruction. There was one example of this in modexp.S. This fixes that
(by adding a nop to the outer loop).

Signed-off-by: Greg Chadwick <gac@lowrisc.org>

With this fix RTL can successfully execute rsa_1204_enc_test (at least it gets the final expected values correct and matches ISS for final RF contents).