### PR TITLE
[top] Add partial SRAM scrambling device to top-level

### DIFF
--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv
@@ -201,16 +201,17 @@ package otp_ctrl_pkg;
 
   parameter int FlashKeySeedWidth = 256;
   parameter int SramKeySeedWidth  = 128;
-
   parameter int KeyMgrKeyWidth   = 256;
-
   parameter int FlashKeyWidth    = 128;
-
   parameter int SramKeyWidth     = 128;
   parameter int SramNonceWidth   = 64;
-
   parameter int OtbnKeyWidth     = 128;
   parameter int OtbnNonceWidth   = 256;
+
+  typedef logic [SramKeyWidth-1:0]   sram_key_t;
+  typedef logic [SramNonceWidth-1:0] sram_nonce_t;
+  typedef logic [OtbnKeyWidth-1:0]   otbn_key_t;
+  typedef logic [OtbnNonceWidth-1:0] otbn_nonce_t;
 
   typedef struct packed {
     logic valid;
@@ -253,17 +254,17 @@ package otp_ctrl_pkg;
   };
 
   typedef struct packed {
-    logic                      ack;   // Ack for key.
-    logic [SramKeyWidth-1:0]   key;   // 128bit ephemeral scrambling key.
-    logic [SramNonceWidth-1:0] nonce; // 64bit nonce.
-    logic seed_valid;                 // Set to 1 if the key seed has been provisioned and is valid.
+    logic        ack;         // Ack for key.
+    sram_key_t   key;        // 128bit ephemeral scrambling key.
+    sram_nonce_t nonce;      // 64bit nonce.
+    logic        seed_valid; // Set to 1 if the key seed has been provisioned and is valid.
   } sram_otp_key_rsp_t;
 
   typedef struct packed {
-    logic ack;                        // Ack for key.
-    logic [OtbnKeyWidth-1:0]   key;   // 128bit ephemeral scrambling key.
-    logic [OtbnNonceWidth-1:0] nonce; // 256bit nonce.
-    logic seed_valid;                 // Set to 1 if the key seed has been provisioned and is valid.
+    logic        ack;        // Ack for key.
+    otbn_key_t   key;        // 128bit ephemeral scrambling key.
+    otbn_nonce_t nonce;      // 256bit nonce.
+    logic        seed_valid; // Set to 1 if the key seed has been provisioned and is valid.
   } otbn_otp_key_rsp_t;
 
   ////////////////////////////////

--- a/hw/ip/prim/rtl/prim_ram_1p_scr.sv
+++ b/hw/ip/prim/rtl/prim_ram_1p_scr.sv
@@ -10,9 +10,9 @@
 //
 // The currently implemented architecture uses a reduced-round PRINCE cipher primitive in CTR mode
 // in order to (weakly) scramble the data written to the memory macro. Plain CTR mode does not
-// diffuse the data since the keystream is just XOR'ed onto it, hence we also we perform Byte-wise
+// diffuse the data since the keystream is just XOR'ed onto it, hence we also we perform byte-wise
 // diffusion using a (shallow) substitution/permutation network layers in order to provide a limited
-// avalanche effect within a Byte.
+// avalanche effect within a byte.
 //
 // In order to break the linear addressing space, the address is passed through a bijective
 // scrambling function constructed using a (shallow) substitution/permutation and a nonce. Due to
@@ -25,7 +25,7 @@
 
 module prim_ram_1p_scr #(
   parameter  int Depth                = 512, // Needs to be a power of 2 if NumAddrScrRounds > 0.
-  parameter  int Width                = 256, // Needs to be Byte aligned for parity
+  parameter  int Width                = 256, // Needs to be byte aligned for parity
   parameter  int DataBitsPerMask      = 8,   // Currently only 8 is supported
   parameter  int CfgWidth             = 8,   // WTC, RTC, etc
 
@@ -33,7 +33,7 @@ module prim_ram_1p_scr #(
   // amount of cipher rounds low. PRINCE has 5 half rounds in its original form, which corresponds
   // to 2*5 + 1 effective rounds. Setting this to 2 halves this to approximately 5 effective rounds.
   parameter  int NumPrinceRoundsHalf  = 2,   // Number of PRINCE half rounds, can be [1..5]
-  // Number of extra intra-Byte diffusion rounds. Setting this to 0 disables intra-Byte diffusion.
+  // Number of extra intra-byte diffusion rounds. Setting this to 0 disables intra-byte diffusion.
   parameter  int NumByteScrRounds     = 2,
   // Number of address scrambling rounds. Setting this to 0 disables address scrambling.
   parameter  int NumAddrScrRounds     = 2,
@@ -65,7 +65,7 @@ module prim_ram_1p_scr #(
   input                             write_i,
   input        [AddrWidth-1:0]      addr_i,
   input        [Width-1:0]          wdata_i,
-  input        [Width-1:0]          wmask_i,  // Needs to be Byte-aligned for parity
+  input        [Width-1:0]          wmask_i,  // Needs to be byte-aligned for parity
   output logic [Width-1:0]          rdata_o,
   output logic                      rvalid_o, // Read response (rdata_o) is valid
   output logic [1:0]                rerror_o, // Bit1: Uncorrectable, Bit0: Correctable
@@ -86,40 +86,37 @@ module prim_ram_1p_scr #(
   // Pending Write and Address Registers //
   /////////////////////////////////////////
 
-  // Read / write strobes
-  logic read_en, write_en;
-  assign read_en = req_i & ~write_i;
-  assign write_en = req_i & write_i;
-
   // Writes are delayed by one cycle, such the same keystream generation primitive (prim_prince) can
   // be reused among reads and writes. Note however that with this arrangement, we have to introduce
   // a mechanism to hold a pending write transaction in cases where that transaction is immediately
   // followed by a read. The pending write transaction is written to memory as soon as there is no
-  // new read transaction incoming. The latter is a special case, and if that happens, we return the
-  // data from the write holding register.
-  logic macro_write;
-  logic write_pending_d, write_pending_q;
-  assign write_pending_d =
-      (write_en)                ? 1'b1            : // Set new write request
-      (macro_write)             ? 1'b0            : // Clear pending request when writing to memory
-                                  write_pending_q;  // Keep pending write request alive
+  // new read transaction incoming. The latter can be a special case if the incoming read goes to
+  // the same address as the pending write. To that end, we detect the address collision and return
+  // the data from the write holding register.
 
-  logic collision_d, collision_q;
+  // Read / write strobes
+  logic read_en, write_en_d, write_en_q;
+  assign read_en = req_i & ~write_i;
+  assign write_en_d = req_i & write_i;
+
+  logic write_pending_q;
+  logic addr_collision_d, addr_collision_q;
   logic [AddrWidth-1:0] waddr_q;
-  assign collision_d = read_en & write_pending_q & (addr_i == waddr_q);
+  assign addr_collision_d = read_en & (write_en_q | write_pending_q) & (addr_i == waddr_q);
 
   // Macro requests and write strobe
   logic macro_req;
-  assign macro_req   = read_en | write_pending_q;
+  assign macro_req   = read_en | write_en_q | write_pending_q;
   // We are allowed to write a pending write transaction to the memory if there is no incoming read
-  assign macro_write = write_pending_q & ~read_en;
+  logic macro_write;
+  assign macro_write = (write_en_q | write_pending_q) & ~read_en;
+  // New read write collision
+  logic rw_collision;
+  assign rw_collision = write_en_q & read_en;
 
   ////////////////////////
   // Address Scrambling //
   ////////////////////////
-
-  // TODO: check whether this is good enough for our purposes, or whether we should go for something
-  // else. Also, we may want to input some secret key material into this function as well.
 
   // We only select the pending write address in case there is no incoming read transaction.
   logic [AddrWidth-1:0] addr_mux;
@@ -132,7 +129,7 @@ module prim_ram_1p_scr #(
       .DataWidth ( AddrWidth        ),
       .NumRounds ( NumAddrScrRounds ),
       .Decrypt   ( 0                )
-    ) i_prim_subst_perm (
+    ) u_prim_subst_perm (
       .data_i ( addr_mux ),
       // Since the counter mode concatenates {nonce_i[NonceWidth-1-AddrWidth:0], addr_i} to form
       // the IV, the upper AddrWidth bits of the nonce are not used and can be used for address
@@ -146,8 +143,7 @@ module prim_ram_1p_scr #(
   end
 
   // We latch the non-scrambled address for error reporting.
-  logic [AddrWidth-1:0] raddr_d, raddr_q;
-  assign raddr_d = addr_mux;
+  logic [AddrWidth-1:0] raddr_q;
   assign raddr_o = raddr_q;
 
   //////////////////////////////////////////////
@@ -198,13 +194,13 @@ module prim_ram_1p_scr #(
   /////////////////////
 
   // Data scrambling is a two step process. First, we XOR the write data with the keystream obtained
-  // by operating a reduced-round PRINCE cipher in CTR-mode. Then, we diffuse data within each Byte
-  // in order to get a limited "avalanche" behavior in case parts of the Bytes are flipped as a
+  // by operating a reduced-round PRINCE cipher in CTR-mode. Then, we diffuse data within each byte
+  // in order to get a limited "avalanche" behavior in case parts of the bytes are flipped as a
   // result of a malicious attempt to tamper with the data in memory. We perform the diffusion only
-  // within Bytes in order to maintain the ability to write individual Bytes. Note that the
+  // within bytes in order to maintain the ability to write individual bytes. Note that the
   // keystream XOR is performed first for the write path such that it can be performed last for the
   // read path. This allows us to hide a part of the combinational delay of the PRINCE primitive
-  // behind the propagation delay of the SRAM macro and the per-Byte diffusion step.
+  // behind the propagation delay of the SRAM macro and the per-byte diffusion step.
 
   // Write path. Note that since this does not fan out into the interconnect, the write path is not
   // as critical as the read path below in terms of timing.
@@ -214,12 +210,12 @@ module prim_ram_1p_scr #(
     logic [7:0] wdata_xor;
     assign wdata_xor = wdata_q[k*8 +: 8] ^ keystream_repl[k*8 +: 8];
 
-    // Byte aligned diffusion using a substitution / permutation network
+    // byte aligned diffusion using a substitution / permutation network
     prim_subst_perm #(
       .DataWidth ( 8                ),
       .NumRounds ( NumByteScrRounds ),
       .Decrypt   ( 0                )
-    ) i_prim_subst_perm (
+    ) u_prim_subst_perm (
       .data_i ( wdata_xor             ),
       .key_i  ( '0                    ),
       .data_o ( wdata_scr_d[k*8 +: 8] )
@@ -228,7 +224,7 @@ module prim_ram_1p_scr #(
 
   // Read path. This is timing critical. The keystream XOR operation is performed last in order to
   // hide the combinational delay of the PRINCE primitive behind the propagation delay of the
-  // SRAM and the Byte diffusion.
+  // SRAM and the byte diffusion.
   logic [Width-1:0] rdata_scr, rdata;
   for (genvar k = 0; k < Width/8; k++) begin : gen_undiffuse_rdata
     // Reverse diffusion first
@@ -237,7 +233,7 @@ module prim_ram_1p_scr #(
       .DataWidth ( 8                ),
       .NumRounds ( NumByteScrRounds ),
       .Decrypt   ( 1                )
-    ) i_prim_subst_perm (
+    ) u_prim_subst_perm (
       .data_i ( rdata_scr[k*8 +: 8]  ),
       .key_i  ( '0                   ),
       .data_o ( rdata_xor            )
@@ -265,24 +261,28 @@ module prim_ram_1p_scr #(
   // need an additional holding register that can buffer the scrambled data of the first write in
   // cycle 1.
 
-  // Clear this if we can write the memory in this cycle, otherwise set if there is a pending write
-  logic write_scr_pending_d, write_scr_pending_q;
-  assign write_scr_pending_d = (macro_write) ? 1'b0 : write_pending_q;
+  // Clear this if we can write the memory in this cycle. Set only if the current write cannot
+  // proceed due to an incoming read operation.
+  logic write_scr_pending_d;
+  assign write_scr_pending_d = (macro_write)  ? 1'b0 :
+                               (rw_collision) ? 1'b1 :
+                                                write_pending_q;
+
   // Select the correct scrambled word to be written, based on whether the word in the scrambled
   // data holding register is valid or not. Note that the write_scr_q register could in theory be
   // combined with the wdata_q register. We don't do that here for timing reasons, since that would
   // require another read data mux to inject the scrambled data into the read descrambling path.
   logic [Width-1:0] wdata_scr;
-  assign wdata_scr = (write_scr_pending_q) ? wdata_scr_q : wdata_scr_d;
+  assign wdata_scr = (write_pending_q) ? wdata_scr_q : wdata_scr_d;
 
   // Output read valid strobe
   logic rvalid_q;
   assign rvalid_o = rvalid_q;
 
   // In case of a collision, we forward the write data from the unscrambled holding register
-  assign rdata_o = (collision_q) ? wdata_q   : // forward pending (unscrambled) write data
-                   (rvalid_q)    ? rdata     : // regular reads
-                                   '0;         // tie to zero otherwise
+  assign rdata_o = (addr_collision_q) ? wdata_q   : // forward pending (unscrambled) write data
+                   (rvalid_q)         ? rdata     : // regular reads
+                                        '0;         // tie to zero otherwise
 
   ///////////////
   // Registers //
@@ -292,8 +292,7 @@ module prim_ram_1p_scr #(
   always_ff @(posedge clk_i or negedge rst_ni) begin : p_wdata_buf
     if (!rst_ni) begin
       write_pending_q     <= 1'b0;
-      write_scr_pending_q <= 1'b0;
-      collision_q         <= 1'b0;
+      addr_collision_q    <= 1'b0;
       rvalid_q            <= 1'b0;
       waddr_q             <= '0;
       wdata_q             <= '0;
@@ -301,17 +300,19 @@ module prim_ram_1p_scr #(
       wmask_q             <= '0;
       raddr_q             <= '0;
     end else begin
-      write_scr_pending_q <= write_scr_pending_d;
-      write_pending_q     <= write_pending_d;
-      collision_q         <= collision_d;
+      write_pending_q     <= write_scr_pending_d;
+      addr_collision_q    <= addr_collision_d;
       rvalid_q            <= read_en;
-      raddr_q             <= raddr_d;
-      if (write_en) begin
+      write_en_q          <= write_en_d;
+      if (read_en) begin
+        raddr_q           <= addr_i;
+      end
+      if (write_en_d) begin
         waddr_q <= addr_i;
         wmask_q <= wmask_i;
         wdata_q <= wdata_i;
       end
-      if (write_scr_pending_d) begin
+      if (rw_collision) begin
         wdata_scr_q <= wdata_scr_d;
       end
     end
@@ -327,7 +328,7 @@ module prim_ram_1p_scr #(
     .DataBitsPerMask(DataBitsPerMask),
     .CfgW(CfgWidth),
     .EnableECC(1'b0),
-    .EnableParity(1'b1), // We are using Byte parity
+    .EnableParity(1'b1), // We are using byte parity
     .EnableInputPipeline(1'b0),
     .EnableOutputPipeline(1'b0)
   ) u_prim_ram_1p_adv (

--- a/hw/ip/prim/rtl/prim_subst_perm.sv
+++ b/hw/ip/prim/rtl/prim_subst_perm.sv
@@ -36,6 +36,7 @@ module prim_subst_perm #(
       always_comb begin : p_dec
         data_state_sbox = data_state[r] ^ key_i;
         // Reverse odd/even grouping
+        data_state_flipped = data_state_sbox;
         for (int k = 0; k < DataWidth/2; k++) begin
           data_state_flipped[k * 2]     = data_state_sbox[k];
           data_state_flipped[k * 2 + 1] = data_state_sbox[k + DataWidth/2];
@@ -68,6 +69,7 @@ module prim_subst_perm #(
         // Regroup bits such that all even indices are stacked up first, followed by all odd
         // indices. Note that if the Width is odd, this is still ok, since
         // the uppermost bit just stays in place in that case.
+        data_state_sbox = data_state_flipped;
         for (int k = 0; k < DataWidth/2; k++) begin
           data_state_sbox[k]               = data_state_flipped[k * 2];
           data_state_sbox[k + DataWidth/2] = data_state_flipped[k * 2 + 1];

--- a/hw/ip/sram_ctrl/data/sram_ctrl.hjson
+++ b/hw/ip/sram_ctrl/data/sram_ctrl.hjson
@@ -28,7 +28,18 @@
   // Parameters //
   ////////////////
   param_list: [
-
+    { name:      "RndCnstSramKey",
+      desc:      "Compile-time random reset value for SRAM scrambling key.",
+      type:      "otp_ctrl_pkg::sram_key_t"
+      randcount: "128",
+      randtype:  "data", // randomize randcount databits
+    }
+    { name:      "RndCnstSramNonce",
+      desc:      "Compile-time random reset value for SRAM scrambling nonce.",
+      type:      "otp_ctrl_pkg::sram_nonce_t"
+      randcount: "64",
+      randtype:  "data", // randomize randcount databits
+    }
   ]
 
   /////////////////////////////

--- a/hw/ip/sram_ctrl/lint/sram_ctrl.waiver
+++ b/hw/ip/sram_ctrl/lint/sram_ctrl.waiver
@@ -4,3 +4,5 @@
 #
 # waiver file for SRAM controller
 
+waive -rules {HIER_NET_NOT_READ NOT_READ} -location {sram_ctrl_reg_top.sv} -regexp {.* 'reg_wdata\[31:8\]' is not read from in module 'sram_ctrl_reg_top'} \
+      -comment {Not all bits are wdata bits are used}

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
@@ -8,10 +8,10 @@
 `include "prim_assert.sv"
 
 module sram_ctrl
+  import sram_ctrl_pkg::*;
   import sram_ctrl_reg_pkg::*;
 #(
   parameter  int Depth                = 512, // Needs to be a power of 2 if NumAddrScrRounds > 0.
-  parameter  int Width                = 32,  // Needs to be Byte aligned for parity
   parameter  int CfgWidth             = 8,   // WTC, RTC, etc
   // Scrambling parameters. Note that this needs to be low-latency, hence we have to keep the
   // amount of cipher rounds low. PRINCE has 5 half rounds in its original form, which corresponds
@@ -21,8 +21,11 @@ module sram_ctrl
   parameter  int NumByteScrRounds     = 2,
   // Number of address scrambling rounds. Setting this to 0 disables address scrambling.
   parameter  int NumAddrScrRounds     = 2,
+  // Random netlist constants
+  parameter otp_ctrl_pkg::sram_key_t   RndCnstSramKey   = RndCnstSramKeyDefault,
+  parameter otp_ctrl_pkg::sram_nonce_t RndCnstSramNonce = RndCnstSramNonceDefault,
   // Derived parameters
-  localparam int AddrWidth            = prim_util_pkg::vbits(Depth)
+  localparam int AddrWidth = prim_util_pkg::vbits(Depth)
 ) (
   // SRAM Clock
   input                                   clk_i,
@@ -155,8 +158,8 @@ module sram_ctrl
       key_req_pending_q <= 1'b0;
       key_valid_q       <= 1'b0;
       key_seed_valid_q  <= 1'b0;
-      key_q             <= '0;
-      nonce_q           <= '0;
+      key_q             <= RndCnstSramKey;
+      nonce_q           <= RndCnstSramNonce;
     end else begin
       key_req_pending_q <= key_req_pending_d;
       key_valid_q       <= key_valid_d;
@@ -168,8 +171,8 @@ module sram_ctrl
       // This scraps the keys
       if (escalate_en != lc_ctrl_pkg::Off) begin
         key_seed_valid_q <= '0;
-        key_q            <= '0;
-        nonce_q          <= '0;
+        key_q            <= RndCnstSramKey;
+        nonce_q          <= RndCnstSramNonce;
       end
     end
   end

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl_pkg.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl_pkg.sv
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package sram_ctrl_pkg;
+
+  // The width of this RAM is currently restricted to 32.
+  parameter int Width = 32;
+  parameter otp_ctrl_pkg::sram_key_t RndCnstSramKeyDefault =
+      128'hbecda03b34bc0418a30a33861a610f71;
+  parameter otp_ctrl_pkg::sram_nonce_t RndCnstSramNonceDefault =
+      64'he73363ee4fedb75c;
+
+endpackage : sram_ctrl_pkg

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl_reg_pkg.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl_reg_pkg.sv
@@ -6,6 +6,8 @@
 
 package sram_ctrl_reg_pkg;
 
+  // Param list
+
   ////////////////////////////
   // Typedefs for registers //
   ////////////////////////////

--- a/hw/ip/sram_ctrl/sram_ctrl_pkg.core
+++ b/hw/ip/sram_ctrl/sram_ctrl_pkg.core
@@ -12,6 +12,7 @@ filesets:
 
     files:
       - rtl/sram_ctrl_reg_pkg.sv
+      - rtl/sram_ctrl_pkg.sv
     file_type: systemVerilogSource
 
 

--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -342,13 +342,11 @@ module top_${top["name"]} #(
     .rerror_i (${m["name"]}_rerror)
   );
 
-  prim_ram_1p_adv #(
+  prim_ram_1p_scr #(
     .Width(${data_width}),
     .Depth(${sram_depth}),
     .DataBitsPerMask(8),
-    .CfgW(8),
-    // TODO: enable parity once supported by the simulation infrastructure
-    .EnableParity(0)
+    .CfgWidth(8)
   ) u_ram1p_${m["name"]} (
     % for key in clocks:
     .${key}   (${clocks[key]}),
@@ -356,6 +354,9 @@ module top_${top["name"]} #(
     % for key, value in resets.items():
     .${key}   (${value}),
     % endfor
+
+    .key_i    ( '0 ),
+    .nonce_i  ( '0 ),
 
     .req_i    (${m["name"]}_req),
     .write_i  (${m["name"]}_we),
@@ -365,8 +366,10 @@ module top_${top["name"]} #(
     .rdata_o  (${m["name"]}_rdata),
     .rvalid_o (${m["name"]}_rvalid),
     .rerror_o (${m["name"]}_rerror),
+    .raddr_o  (  ),
     .cfg_i    ('0)
   );
+
   % elif m["type"] == "rom":
 <%
      data_width = int(top["datawidth"])

--- a/hw/top_earlgrey/dv/tb/chip_hier_macros.svh
+++ b/hw/top_earlgrey/dv/tb/chip_hier_macros.svh
@@ -9,8 +9,8 @@
 `define SPI_DEVICE_HIER    `CHIP_HIER.u_spi_device
 `define ALERT_HANDLER_HIER `CHIP_HIER.u_alert_handler
 `define CPU_HIER           `CHIP_HIER.u_rv_core_ibex
-`define RAM_MAIN_HIER      `CHIP_HIER.u_ram1p_ram_main.u_mem
-`define RAM_RET_HIER       `CHIP_HIER.u_ram1p_ram_ret.u_mem
+`define RAM_MAIN_HIER      `CHIP_HIER.u_ram1p_ram_main.u_prim_ram_1p_adv.u_mem
+`define RAM_RET_HIER       `CHIP_HIER.u_ram1p_ram_ret.u_prim_ram_1p_adv.u_mem
 `define ROM_HIER           `CHIP_HIER.u_rom_rom.u_prim_rom
 `define FLASH_HIER         `CHIP_HIER.u_flash_eflash.u_flash
 `define RSTMGR_HIER        `CHIP_HIER.u_rstmgr

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -573,16 +573,17 @@ module top_earlgrey #(
     .rerror_i (ram_main_rerror)
   );
 
-  prim_ram_1p_adv #(
+  prim_ram_1p_scr #(
     .Width(32),
     .Depth(16384),
     .DataBitsPerMask(8),
-    .CfgW(8),
-    // TODO: enable parity once supported by the simulation infrastructure
-    .EnableParity(0)
+    .CfgWidth(8)
   ) u_ram1p_ram_main (
     .clk_i   (clkmgr_clocks.clk_main_infra),
     .rst_ni   (rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]),
+
+    .key_i    ( '0 ),
+    .nonce_i  ( '0 ),
 
     .req_i    (ram_main_req),
     .write_i  (ram_main_we),
@@ -592,8 +593,10 @@ module top_earlgrey #(
     .rdata_o  (ram_main_rdata),
     .rvalid_o (ram_main_rvalid),
     .rerror_o (ram_main_rerror),
+    .raddr_o  (  ),
     .cfg_i    ('0)
   );
+
   // sram device
   logic        ram_ret_req;
   logic        ram_ret_we;
@@ -625,16 +628,17 @@ module top_earlgrey #(
     .rerror_i (ram_ret_rerror)
   );
 
-  prim_ram_1p_adv #(
+  prim_ram_1p_scr #(
     .Width(32),
     .Depth(1024),
     .DataBitsPerMask(8),
-    .CfgW(8),
-    // TODO: enable parity once supported by the simulation infrastructure
-    .EnableParity(0)
+    .CfgWidth(8)
   ) u_ram1p_ram_ret (
     .clk_i   (clkmgr_clocks.clk_io_div4_infra),
     .rst_ni   (rstmgr_resets.rst_sys_io_div4_n[rstmgr_pkg::DomainAonSel]),
+
+    .key_i    ( '0 ),
+    .nonce_i  ( '0 ),
 
     .req_i    (ram_ret_req),
     .write_i  (ram_ret_we),
@@ -644,8 +648,10 @@ module top_earlgrey #(
     .rdata_o  (ram_ret_rdata),
     .rvalid_o (ram_ret_rvalid),
     .rerror_o (ram_ret_rerror),
+    .raddr_o  (  ),
     .cfg_i    ('0)
   );
+
 
   // host to flash communication
   logic flash_host_req;

--- a/hw/top_earlgrey/top_earlgrey.core
+++ b/hw/top_earlgrey/top_earlgrey.core
@@ -28,7 +28,7 @@ filesets:
       - lowrisc:ip:hmac
       - lowrisc:ip:kmac
       - lowrisc:ip:otbn
-      - lowrisc:prim:ram_1p_adv
+      - lowrisc:prim:ram_1p_scr
       - lowrisc:prim:rom_adv
       - lowrisc:prim:flash
       - lowrisc:ip:flash_ctrl

--- a/hw/top_earlgrey/top_earlgrey_verilator.cc
+++ b/hw/top_earlgrey/top_earlgrey_verilator.cc
@@ -21,8 +21,8 @@ int main(int argc, char **argv) {
       "gen_generic.u_impl_generic");
   memutil.RegisterMemoryArea(
       "ram",
-      "TOP.top_earlgrey_verilator.top_earlgrey.u_ram1p_ram_main.u_mem."
-      "gen_generic.u_impl_generic");
+      "TOP.top_earlgrey_verilator.top_earlgrey.u_ram1p_ram_main."
+      "u_prim_ram_1p_adv.u_mem.gen_generic.u_impl_generic");
   memutil.RegisterMemoryArea(
       "flash",
       ("TOP.top_earlgrey_verilator.top_earlgrey.u_flash_eflash.u_flash."


### PR DESCRIPTION
This is in preparation to for instantiating the `sram_ctrl` module, and instantiates the scrambling device in the top level (without CSRs and support for key request). The main goal here is to get this up and running with the default all-zero key such that we have this block covered in our regressions.

Signed-off-by: Michael Schaffner <msf@opentitan.org>