### PR TITLE
[csrng/rtl] Split cmd_sts into two registers

### DIFF
--- a/hw/ip/csrng/csrng.core
+++ b/hw/ip/csrng/csrng.core
@@ -9,6 +9,7 @@ filesets:
     depend:
       - lowrisc:constants:top_pkg
       - lowrisc:prim:all
+      - lowrisc:prim:multibit_sync
       - lowrisc:ip:tlul
       - lowrisc:ip:aes
       - lowrisc:ip:csrng_pkg

--- a/hw/ip/csrng/data/csrng.hjson
+++ b/hw/ip/csrng/data/csrng.hjson
@@ -136,9 +136,9 @@
       ]
     },
     {
-      name: "CMD_STS",
-      desc: "Command status register",
-      swaccess: "rw",
+      name: "SW_CMD_STS",
+      desc: "Application interface command status register",
+      swaccess: "ro",
       hwaccess: "hwo",
       fields: [
         { bits: "0",
@@ -147,15 +147,11 @@
                 '''
         }
         { bits: "1",
-          name: "CMD_ACK",
-          desc: '''This bit is set when the command request has completed. This bit must
-                   be cleared before a new request is made.
-                '''
-        }
-        { bits: "4",
           name: "CMD_STS",
           desc: '''
                 This one bit field is the status code returned with the application command ack.
+                It is updated each time a command ack is asserted on the internal application
+                interface for software use.
                 0b0: Request completed successfully
                 0b1: Request completed with an error
                 '''

--- a/hw/ip/csrng/doc/_index.md
+++ b/hw/ip/csrng/doc/_index.md
@@ -305,7 +305,7 @@ The actions performed by each command, as well as which flags are supported, are
     <td>Instantiate</td>
     <td>0x1</td>
     <td> Initializes an instance in CSRNG.
-         When seeding, if <tt>flag0</tt> is not set and <tt>clen</tt> is zero, then a seed of of only the entropy source seed will be used.
+         When seeding, if <tt>flag0</tt> is not set and <tt>clen</tt> is zero, then a seed of only the entropy source seed will be used.
          If <tt>flag0</tt> is not set and <tt>clen</tt> is non-zero, then the seed will xor'ed with the provided additional data.
          If <tt>flag0</tt> is set and <tt>clen</tt> is zero, then a seed of zero with no entropy source seed material will be used.
          If <tt>flag0</tt> is set and <tt>clen</tt> is non-zero, then only the provided additional data will be used as the seed.

--- a/hw/ip/csrng/rtl/csrng.sv
+++ b/hw/ip/csrng/rtl/csrng.sv
@@ -6,7 +6,7 @@
 
 module csrng import csrng_pkg::*; #(
   parameter aes_pkg::sbox_impl_e SBoxImpl = aes_pkg::SBoxImplLut,
-  parameter int unsigned NHwApps = 2
+  parameter int NHwApps = 2
 ) (
   input logic         clk_i,
   input logic         rst_ni,

--- a/hw/ip/csrng/rtl/csrng_block_encrypt.sv
+++ b/hw/ip/csrng/rtl/csrng_block_encrypt.sv
@@ -7,10 +7,10 @@
 
 module csrng_block_encrypt #(
   parameter aes_pkg::sbox_impl_e SBoxImpl = aes_pkg::SBoxImplLut,
-  parameter int unsigned Cmd = 3,
-  parameter int unsigned StateId = 4,
-  parameter int unsigned BlkLen = 128,
-  parameter int unsigned KeyLen = 256
+  parameter int Cmd = 3,
+  parameter int StateId = 4,
+  parameter int BlkLen = 128,
+  parameter int KeyLen = 256
 ) (
   input logic                clk_i,
   input logic                rst_ni,
@@ -33,9 +33,9 @@ module csrng_block_encrypt #(
   output logic [2:0]         block_encrypt_sfifo_blkenc_err_o
 );
 
-  localparam int unsigned BlkEncFifoDepth = 1;
-  localparam int unsigned BlkEncFifoWidth = BlkLen+StateId+Cmd;
-  localparam int unsigned NumShares = 1;
+  localparam int BlkEncFifoDepth = 1;
+  localparam int BlkEncFifoWidth = BlkLen+StateId+Cmd;
+  localparam int NumShares = 1;
 
   // signals
   // blk_encrypt_in fifo
@@ -155,7 +155,7 @@ module csrng_block_encrypt #(
   assign sfifo_blkenc_push = block_encrypt_req_i && sfifo_blkenc_not_full;
   assign sfifo_blkenc_wdata = {block_encrypt_v_i,block_encrypt_id_i,block_encrypt_cmd_i};
 
-  assign block_encrypt_rdy_o = aes_cipher_core_enable ? sfifo_blkenc_not_full : cipher_in_ready;
+  assign block_encrypt_rdy_o = !aes_cipher_core_enable ? sfifo_blkenc_not_full : cipher_in_ready;
 
   assign sfifo_blkenc_pop = block_encrypt_ack_o;
   assign {sfifo_blkenc_v,sfifo_blkenc_id,sfifo_blkenc_cmd} = sfifo_blkenc_rdata;

--- a/hw/ip/csrng/rtl/csrng_cmd_stage.sv
+++ b/hw/ip/csrng/rtl/csrng_cmd_stage.sv
@@ -6,9 +6,9 @@
 //
 
 module csrng_cmd_stage import csrng_pkg::*; #(
-  parameter int unsigned CmdFifoWidth = 32,
-  parameter int unsigned CmdFifoDepth = 16,
-  parameter int unsigned StateId = 4
+  parameter int CmdFifoWidth = 32,
+  parameter int CmdFifoDepth = 16,
+  parameter int StateId = 4
 ) (
   input logic                        clk_i,
   input logic                        rst_ni,
@@ -45,8 +45,8 @@ module csrng_cmd_stage import csrng_pkg::*; #(
   output logic [2:0]                 cmd_stage_sfifo_genbits_err_o
 );
 
-  localparam int unsigned GenBitsFifoWidth = 1+128;
-  localparam int unsigned GenBitsFifoDepth = 1;
+  localparam int GenBitsFifoWidth = 1+128;
+  localparam int GenBitsFifoDepth = 1;
 
   // signals
   // command fifo
@@ -196,9 +196,9 @@ module csrng_cmd_stage import csrng_pkg::*; #(
     GenReq    = 6'b111000  // process gen requests
   } state_e;
 
-  state_e state_d;
+  state_e state_d, state_q;
 
-  logic [StateWidth-1:0] state_q;
+  logic [StateWidth-1:0] state_raw_q;
 
   // This primitive is used to place a size-only constraint on the
   // flops in order to prevent FSM state encoding optimizations.
@@ -209,11 +209,13 @@ module csrng_cmd_stage import csrng_pkg::*; #(
     .clk_i,
     .rst_ni,
     .d_i ( state_d ),
-    .q_o ( state_q )
+    .q_o ( state_raw_q )
   );
 
+  assign state_q = state_e'(state_raw_q);
+
   always_comb begin
-    state_d = state_e'(state_q);
+    state_d = state_q;
     cmd_fifo_pop = 1'b0;
     cmd_len_dec = 1'b0;
     cmd_gen_cnt_dec= 1'b0;

--- a/hw/ip/csrng/rtl/csrng_core.sv
+++ b/hw/ip/csrng/rtl/csrng_core.sv
@@ -8,7 +8,7 @@
 
 module csrng_core import csrng_pkg::*; #(
   parameter aes_pkg::sbox_impl_e SBoxImpl = aes_pkg::SBoxImplLut,
-  parameter int unsigned NHwApps = 2
+  parameter int NHwApps = 2
 ) (
   input logic        clk_i,
   input logic        rst_ni,
@@ -39,20 +39,20 @@ module csrng_core import csrng_pkg::*; #(
 
   import csrng_reg_pkg::*;
 
-  localparam int unsigned NApps = NHwApps + 1;
-  localparam int unsigned AppCmdWidth = 32;
-  localparam int unsigned AppCmdFifoDepth = 2;
-  localparam int unsigned GenBitsWidth = 128;
-  localparam int unsigned Cmd = 3;
-  localparam int unsigned StateId = 4;
-  localparam int unsigned KeyLen = 256;
-  localparam int unsigned BlkLen = 128;
-  localparam int unsigned SeedLen = 384;
-  localparam int unsigned CtrLen = 32;
-  localparam int unsigned NBlkEncArbReqs = 2;
-  localparam int unsigned BlkEncArbWidth = KeyLen+BlkLen+StateId+Cmd;
-  localparam int unsigned NUpdateArbReqs = 2;
-  localparam int unsigned UpdateArbWidth = KeyLen+BlkLen+SeedLen+StateId+Cmd;
+  localparam int NApps = NHwApps + 1;
+  localparam int AppCmdWidth = 32;
+  localparam int AppCmdFifoDepth = 2;
+  localparam int GenBitsWidth = 128;
+  localparam int Cmd = 3;
+  localparam int StateId = 4;
+  localparam int KeyLen = 256;
+  localparam int BlkLen = 128;
+  localparam int SeedLen = 384;
+  localparam int CtrLen = 32;
+  localparam int NBlkEncArbReqs = 2;
+  localparam int BlkEncArbWidth = KeyLen+BlkLen+StateId+Cmd;
+  localparam int NUpdateArbReqs = 2;
+  localparam int UpdateArbWidth = KeyLen+BlkLen+SeedLen+StateId+Cmd;
 
   // signals
   // interrupt signals
@@ -87,7 +87,6 @@ module csrng_core import csrng_pkg::*; #(
   logic                   cmd_entropy_req;
   logic                   cmd_entropy_avail;
   logic                   cmd_entropy_fips;
-  logic                   cmd_adata_avail;
   logic [SeedLen-1:0]     cmd_entropy;
 
   logic                   cmd_result_wr_req;
@@ -534,13 +533,11 @@ module csrng_core import csrng_pkg::*; #(
   assign cmd_stage_vld[NApps-1] = reg2hw.cmd_req.qe;
   assign cmd_stage_shid[NApps-1] = (NApps-1);
   assign cmd_stage_bus[NApps-1] = reg2hw.cmd_req.q;
-  assign hw2reg.cmd_sts.cmd_rdy.de = 1'b1;
-  assign hw2reg.cmd_sts.cmd_rdy.d = cmd_stage_rdy[NApps-1];
-  // cmd ack
-  assign hw2reg.cmd_sts.cmd_ack.de = cmd_stage_ack[NApps-1];
-  assign hw2reg.cmd_sts.cmd_ack.d = 1'b1;
-  assign hw2reg.cmd_sts.cmd_sts.de = cmd_stage_ack[NApps-1];
-  assign hw2reg.cmd_sts.cmd_sts.d = cmd_stage_ack_sts[NApps-1];
+  assign hw2reg.sw_cmd_sts.cmd_rdy.de = 1'b1;
+  assign hw2reg.sw_cmd_sts.cmd_rdy.d = cmd_stage_rdy[NApps-1];
+  // cmd ack sts
+  assign hw2reg.sw_cmd_sts.cmd_sts.de = cmd_stage_ack[NApps-1];
+  assign hw2reg.sw_cmd_sts.cmd_sts.d = cmd_stage_ack_sts[NApps-1];
   // genbits
   assign hw2reg.genbits_vld.genbits_vld.d = genbits_stage_vldo_sw;
   assign hw2reg.genbits_vld.genbits_fips.d = genbits_stage_fips_sw;
@@ -662,7 +659,6 @@ module csrng_core import csrng_pkg::*; #(
     .flag0_i(flag0_q),
     .cmd_entropy_req_o(cmd_entropy_req),
     .cmd_entropy_avail_i(cmd_entropy_avail),
-    .cmd_adata_avail_i(cmd_adata_avail),
     .instant_req_o(instant_req),
     .reseed_req_o(reseed_req),
     .generate_req_o(generate_req),
@@ -672,7 +668,7 @@ module csrng_core import csrng_pkg::*; #(
 
 
   // interrupt for sw app interface only
-  assign event_cs_cmd_req_done = cmd_core_ack[NApps-1];
+  assign event_cs_cmd_req_done = cmd_stage_ack[NApps-1];
 
   // interrupt for entropy request
   assign event_cs_entropy_req = entropy_src_hw_if_o.es_req;
@@ -702,7 +698,7 @@ module csrng_core import csrng_pkg::*; #(
     .wvalid_i   (acmd_mop),
     .wdata_i    (acmd_bus),
     .wready_o   (),
-    .rvalid_o   (cmd_adata_avail),
+    .rvalid_o   (),
     .rdata_o    (packer_adata),
     .rready_i   (packer_adata_rrdy),
     .depth_o    ()
@@ -1127,7 +1123,7 @@ module csrng_core import csrng_pkg::*; #(
          24'b0;
 
 
-  assign hw2reg.sum_sts.diag.de = ~cs_enable;
+  assign hw2reg.sum_sts.diag.de = !cs_enable;
   assign hw2reg.sum_sts.diag.d  =
          (reg2hw.regen)          || // not used
          (|reg2hw.genbits.q);       // not used

--- a/hw/ip/csrng/rtl/csrng_ctr_drbg_cmd.sv
+++ b/hw/ip/csrng/rtl/csrng_ctr_drbg_cmd.sv
@@ -7,12 +7,12 @@
 // Accepts all csrng commands
 
 module csrng_ctr_drbg_cmd import csrng_pkg::*; #(
-  parameter int unsigned Cmd = 3,
-  parameter int unsigned StateId = 4,
-  parameter int unsigned BlkLen = 128,
-  parameter int unsigned KeyLen = 256,
-  parameter int unsigned SeedLen = 384,
-  parameter int unsigned CtrLen  = 32
+  parameter int Cmd = 3,
+  parameter int StateId = 4,
+  parameter int BlkLen = 128,
+  parameter int KeyLen = 256,
+  parameter int SeedLen = 384,
+  parameter int CtrLen  = 32
 ) (
   input logic                clk_i,
   input logic                rst_ni,
@@ -63,12 +63,12 @@ module csrng_ctr_drbg_cmd import csrng_pkg::*; #(
   output logic [2:0]         ctr_drbg_cmd_sfifo_keyvrc_err_o
 );
 
-  localparam int unsigned CmdreqFifoDepth = 1;
-  localparam int unsigned CmdreqFifoWidth = KeyLen+BlkLen+CtrLen+1+2*SeedLen+StateId+Cmd;
-  localparam int unsigned RCStageFifoDepth = 1;
-  localparam int unsigned RCStageFifoWidth = CtrLen+1+SeedLen+Cmd;
-  localparam int unsigned KeyVRCFifoDepth = 1;
-  localparam int unsigned KeyVRCFifoWidth = KeyLen+BlkLen+CtrLen+1+SeedLen+StateId+Cmd;
+  localparam int CmdreqFifoDepth = 1;
+  localparam int CmdreqFifoWidth = KeyLen+BlkLen+CtrLen+1+2*SeedLen+StateId+Cmd;
+  localparam int RCStageFifoDepth = 1;
+  localparam int RCStageFifoWidth = CtrLen+1+SeedLen+Cmd;
+  localparam int KeyVRCFifoDepth = 1;
+  localparam int KeyVRCFifoWidth = KeyLen+BlkLen+CtrLen+1+SeedLen+StateId+Cmd;
 
 
   // signals
@@ -94,7 +94,7 @@ module csrng_ctr_drbg_cmd import csrng_pkg::*; #(
   // cmdreq fifo
   logic [CmdreqFifoWidth-1:0] sfifo_cmdreq_rdata;
   logic                       sfifo_cmdreq_push;
-  logic [CmdreqFifoWidth-1:0]  sfifo_cmdreq_wdata;
+  logic [CmdreqFifoWidth-1:0] sfifo_cmdreq_wdata;
   logic                       sfifo_cmdreq_pop;
   logic                       sfifo_cmdreq_not_full;
   logic                       sfifo_cmdreq_not_empty;

--- a/hw/ip/csrng/rtl/csrng_ctr_drbg_gen.sv
+++ b/hw/ip/csrng/rtl/csrng_ctr_drbg_gen.sv
@@ -9,12 +9,12 @@
 // ctr_drbg cmd module.
 
 module csrng_ctr_drbg_gen import csrng_pkg::*; #(
-  parameter int unsigned Cmd = 3,
-  parameter int unsigned StateId = 4,
-  parameter int unsigned BlkLen = 128,
-  parameter int unsigned KeyLen = 256,
-  parameter int unsigned SeedLen = 384,
-  parameter int unsigned CtrLen  = 32
+  parameter int Cmd = 3,
+  parameter int StateId = 4,
+  parameter int BlkLen = 128,
+  parameter int KeyLen = 256,
+  parameter int SeedLen = 384,
+  parameter int CtrLen  = 32
 ) (
   input logic                clk_i,
   input logic                rst_ni,
@@ -76,16 +76,16 @@ module csrng_ctr_drbg_gen import csrng_pkg::*; #(
   output logic [2:0]         ctr_drbg_gen_sfifo_ggenbits_err_o
 );
 
-  localparam int unsigned GenreqFifoDepth = 1;
-  localparam int unsigned GenreqFifoWidth = KeyLen+BlkLen+CtrLen+1+SeedLen+StateId+Cmd;
-  localparam int unsigned BlkEncAckFifoDepth = 1;
-  localparam int unsigned BlkEncAckFifoWidth = BlkLen+StateId+Cmd;
-  localparam int unsigned AdstageFifoDepth = 1;
-  localparam int unsigned AdstageFifoWidth = KeyLen+BlkLen+CtrLen+1+SeedLen;
-  localparam int unsigned RCStageFifoDepth = 1;
-  localparam int unsigned RCStageFifoWidth = BlkLen+CtrLen+1;
-  localparam int unsigned GenbitsFifoDepth = 1;
-  localparam int unsigned GenbitsFifoWidth = 1+BlkLen+KeyLen+BlkLen+CtrLen+StateId+Cmd;
+  localparam int GenreqFifoDepth = 1;
+  localparam int GenreqFifoWidth = KeyLen+BlkLen+CtrLen+1+SeedLen+StateId+Cmd;
+  localparam int BlkEncAckFifoDepth = 1;
+  localparam int BlkEncAckFifoWidth = BlkLen+StateId+Cmd;
+  localparam int AdstageFifoDepth = 1;
+  localparam int AdstageFifoWidth = KeyLen+BlkLen+CtrLen+1+SeedLen;
+  localparam int RCStageFifoDepth = 1;
+  localparam int RCStageFifoWidth = BlkLen+CtrLen+1;
+  localparam int GenbitsFifoDepth = 1;
+  localparam int GenbitsFifoWidth = 1+BlkLen+KeyLen+BlkLen+CtrLen+StateId+Cmd;
 
   // signals
   logic [Cmd-1:0]     genreq_ccmd;
@@ -184,10 +184,9 @@ module csrng_ctr_drbg_gen import csrng_pkg::*; #(
     ReqSend = 4'b0101
 } state_e;
 
+  state_e state_d, state_q;
 
-  state_e state_d;
-
-  logic [StateWidth-1:0] state_q;
+  logic [StateWidth-1:0] state_raw_q;
 
   // This primitive is used to place a size-only constraint on the
   // flops in order to prevent FSM state encoding optimizations.
@@ -198,8 +197,10 @@ module csrng_ctr_drbg_gen import csrng_pkg::*; #(
     .clk_i,
     .rst_ni,
     .d_i ( state_d ),
-    .q_o ( state_q )
+    .q_o ( state_raw_q )
   );
+
+  assign state_q = state_e'(state_raw_q);
 
   always_ff @(posedge clk_i or negedge rst_ni)
     if (!rst_ni) begin
@@ -291,7 +292,7 @@ module csrng_ctr_drbg_gen import csrng_pkg::*; #(
   assign block_encrypt_v_o = v_sized;
 
   always_comb begin
-    state_d = state_e'(state_q);
+    state_d = state_q;
     v_ctr_load = 1'b0;
     v_ctr_inc  = 1'b0;
     interate_ctr_inc  = 1'b0;

--- a/hw/ip/csrng/rtl/csrng_ctr_drbg_upd.sv
+++ b/hw/ip/csrng/rtl/csrng_ctr_drbg_upd.sv
@@ -7,12 +7,12 @@
 // implementation using security_strength = 256
 
 module csrng_ctr_drbg_upd #(
-  parameter int unsigned Cmd = 3,
-  parameter int unsigned StateId = 4,
-  parameter int unsigned BlkLen = 128,
-  parameter int unsigned KeyLen = 256,
-  parameter int unsigned SeedLen = 384,
-  parameter int unsigned CtrLen  = 32
+  parameter int Cmd = 3,
+  parameter int StateId = 4,
+  parameter int BlkLen = 128,
+  parameter int KeyLen = 256,
+  parameter int SeedLen = 384,
+  parameter int CtrLen  = 32
 ) (
   input logic                clk_i,
   input logic                rst_ni,
@@ -51,16 +51,16 @@ module csrng_ctr_drbg_upd #(
   output logic [2:0]         ctr_drbg_upd_sfifo_final_err_o
 );
 
-  localparam int unsigned UpdReqFifoDepth = 1;
-  localparam int unsigned UpdReqFifoWidth = KeyLen+BlkLen+SeedLen+StateId+Cmd;
-  localparam int unsigned BlkEncReqFifoDepth = 1;
-  localparam int unsigned BlkEncReqFifoWidth = KeyLen+BlkLen+StateId+Cmd;
-  localparam int unsigned BlkEncAckFifoDepth = 1;
-  localparam int unsigned BlkEncAckFifoWidth = BlkLen+StateId+Cmd;
-  localparam int unsigned PDataFifoDepth = 1;
-  localparam int unsigned PDataFifoWidth = SeedLen;
-  localparam int unsigned FinalFifoDepth = 1;
-  localparam int unsigned FinalFifoWidth = KeyLen+BlkLen+StateId+Cmd;
+  localparam int UpdReqFifoDepth = 1;
+  localparam int UpdReqFifoWidth = KeyLen+BlkLen+SeedLen+StateId+Cmd;
+  localparam int BlkEncReqFifoDepth = 1;
+  localparam int BlkEncReqFifoWidth = KeyLen+BlkLen+StateId+Cmd;
+  localparam int BlkEncAckFifoDepth = 1;
+  localparam int BlkEncAckFifoWidth = BlkLen+StateId+Cmd;
+  localparam int PDataFifoDepth = 1;
+  localparam int PDataFifoWidth = SeedLen;
+  localparam int FinalFifoDepth = 1;
+  localparam int FinalFifoWidth = KeyLen+BlkLen+StateId+Cmd;
 
   // signals
   logic [SeedLen-1:0] updated_key_and_v;
@@ -166,9 +166,9 @@ module csrng_ctr_drbg_upd #(
     ReqSend = 4'b0110
   } blk_enc_state_e;
 
-  blk_enc_state_e blk_enc_state_d;
+  blk_enc_state_e blk_enc_state_d, blk_enc_state_q;
 
-  logic [BlkEncStateWidth-1:0] blk_enc_state_q;
+  logic [BlkEncStateWidth-1:0] blk_enc_state_raw_q;
 
   // This primitive is used to place a size-only constraint on the
   // flops in order to prevent FSM state encoding optimizations.
@@ -179,8 +179,10 @@ module csrng_ctr_drbg_upd #(
     .clk_i,
     .rst_ni,
     .d_i ( blk_enc_state_d ),
-    .q_o ( blk_enc_state_q )
+    .q_o ( blk_enc_state_raw_q )
   );
+
+  assign blk_enc_state_q = blk_enc_state_e'(blk_enc_state_raw_q);
 
   // Encoding generated with ./sparse-fsm-encode.py -d 3 -m 3 -n 6 -s 4062121537
   // Hamming distance histogram:
@@ -204,9 +206,9 @@ module csrng_ctr_drbg_upd #(
     Shift   = 6'b110010
   } outblk_state_e;
 
-  outblk_state_e outblk_state_d;
+  outblk_state_e outblk_state_d, outblk_state_q;
 
-  logic [OutBlkStateWidth-1:0] outblk_state_q;
+  logic [OutBlkStateWidth-1:0] outblk_state_raw_q;
 
   // This primitive is used to place a size-only constraint on the
   // flops in order to prevent FSM state encoding optimizations.
@@ -217,8 +219,10 @@ module csrng_ctr_drbg_upd #(
     .clk_i,
     .rst_ni,
     .d_i ( outblk_state_d ),
-    .q_o ( outblk_state_q )
+    .q_o ( outblk_state_raw_q )
   );
+
+  assign outblk_state_q = outblk_state_e'(outblk_state_raw_q);
 
   always_ff @(posedge clk_i or negedge rst_ni)
     if (!rst_ni) begin
@@ -303,7 +307,7 @@ module csrng_ctr_drbg_upd #(
   //--------------------------------------------
 
   always_comb begin
-    blk_enc_state_d = blk_enc_state_e'(blk_enc_state_q);
+    blk_enc_state_d = blk_enc_state_q;
     v_ctr_load = 1'b0;
     v_ctr_inc  = 1'b0;
     interate_ctr_inc  = 1'b0;
@@ -462,7 +466,7 @@ module csrng_ctr_drbg_upd #(
   //--------------------------------------------
 
   always_comb begin
-    outblk_state_d = outblk_state_e'(outblk_state_q);
+    outblk_state_d = outblk_state_q;
     concat_ctr_inc  = 1'b0;
     concat_outblk_shift = 1'b0;
     sfifo_pdata_pop = 1'b0;

--- a/hw/ip/csrng/rtl/csrng_main_sm.sv
+++ b/hw/ip/csrng/rtl/csrng_main_sm.sv
@@ -19,7 +19,6 @@ module csrng_main_sm import csrng_pkg::*; (
   input logic                flag0_i,
   output logic               cmd_entropy_req_o,
   input logic                cmd_entropy_avail_i,
-  input logic                cmd_adata_avail_i,
   output logic               instant_req_o,
   output logic               reseed_req_o,
   output logic               generate_req_o,
@@ -57,9 +56,9 @@ module csrng_main_sm import csrng_pkg::*; (
     UninstantReq = 8'b00101000  // uninstantiate request (no input)
   } state_e;
 
- state_e state_d;
+  state_e state_d, state_q;
 
-  logic [StateWidth-1:0] state_q;
+  logic [StateWidth-1:0] state_raw_q;
 
   // This primitive is used to place a size-only constraint on the
   // flops in order to prevent FSM state encoding optimizations.
@@ -70,11 +69,13 @@ module csrng_main_sm import csrng_pkg::*; (
     .clk_i,
     .rst_ni,
     .d_i ( state_d ),
-    .q_o ( state_q )
+    .q_o ( state_raw_q )
   );
 
+  assign state_q = state_e'(state_raw_q);
+
   always_comb begin
-    state_d = state_e'(state_q);
+    state_d = state_q;
     acmd_accept_o = 1'b0;
     cmd_entropy_req_o = 1'b0;
     instant_req_o = 1'b0;
@@ -109,10 +110,8 @@ module csrng_main_sm import csrng_pkg::*; (
       end
       InstantPrep: begin
         if (flag0_i) begin
-          acmd_accept_o = 1'b1;
-          if (cmd_adata_avail_i) begin
-            state_d = InstantReq;
-          end
+          // assumes all adata is present now
+          state_d = InstantReq;
         end else begin
           // delay one clock to fix timing issue
           cmd_entropy_req_o = 1'b1;
@@ -128,7 +127,8 @@ module csrng_main_sm import csrng_pkg::*; (
       ReseedPrep: begin
         acmd_accept_o = 1'b1;
         cmd_entropy_req_o = 1'b1;
-        if (cmd_adata_avail_i && cmd_entropy_avail_i) begin
+        // assumes all adata is present now
+        if (cmd_entropy_avail_i) begin
           state_d = ReseedReq;
         end
       end
@@ -142,10 +142,9 @@ module csrng_main_sm import csrng_pkg::*; (
         state_d = Idle;
       end
       UpdatePrep: begin
+        // assumes all adata is present now
         acmd_accept_o = 1'b1;
-        if (cmd_adata_avail_i) begin
-          state_d = UpdateReq;
-        end
+        state_d = UpdateReq;
       end
       UpdateReq: begin
         update_req_o = 1'b1;

--- a/hw/ip/csrng/rtl/csrng_reg_pkg.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_pkg.sv
@@ -126,12 +126,8 @@ package csrng_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } cmd_ack;
-    struct packed {
-      logic        d;
-      logic        de;
     } cmd_sts;
-  } csrng_hw2reg_cmd_sts_reg_t;
+  } csrng_hw2reg_sw_cmd_sts_reg_t;
 
   typedef struct packed {
     struct packed {
@@ -248,13 +244,13 @@ package csrng_reg_pkg;
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    csrng_hw2reg_intr_state_reg_t intr_state; // [128:125]
-    csrng_hw2reg_sum_sts_reg_t sum_sts; // [124:125]
-    csrng_hw2reg_cmd_sts_reg_t cmd_sts; // [124:125]
-    csrng_hw2reg_genbits_vld_reg_t genbits_vld; // [124:125]
-    csrng_hw2reg_genbits_reg_t genbits; // [124:92]
-    csrng_hw2reg_hw_exc_sts_reg_t hw_exc_sts; // [91:92]
-    csrng_hw2reg_err_code_reg_t err_code; // [91:92]
+    csrng_hw2reg_intr_state_reg_t intr_state; // [126:123]
+    csrng_hw2reg_sum_sts_reg_t sum_sts; // [122:123]
+    csrng_hw2reg_sw_cmd_sts_reg_t sw_cmd_sts; // [122:123]
+    csrng_hw2reg_genbits_vld_reg_t genbits_vld; // [122:123]
+    csrng_hw2reg_genbits_reg_t genbits; // [122:90]
+    csrng_hw2reg_hw_exc_sts_reg_t hw_exc_sts; // [89:90]
+    csrng_hw2reg_err_code_reg_t err_code; // [89:90]
   } csrng_hw2reg_t;
 
   // Register Address
@@ -265,7 +261,7 @@ package csrng_reg_pkg;
   parameter logic [5:0] CSRNG_CTRL_OFFSET = 6'h 10;
   parameter logic [5:0] CSRNG_SUM_STS_OFFSET = 6'h 14;
   parameter logic [5:0] CSRNG_CMD_REQ_OFFSET = 6'h 18;
-  parameter logic [5:0] CSRNG_CMD_STS_OFFSET = 6'h 1c;
+  parameter logic [5:0] CSRNG_SW_CMD_STS_OFFSET = 6'h 1c;
   parameter logic [5:0] CSRNG_GENBITS_VLD_OFFSET = 6'h 20;
   parameter logic [5:0] CSRNG_GENBITS_OFFSET = 6'h 24;
   parameter logic [5:0] CSRNG_HW_EXC_STS_OFFSET = 6'h 28;
@@ -281,7 +277,7 @@ package csrng_reg_pkg;
     CSRNG_CTRL,
     CSRNG_SUM_STS,
     CSRNG_CMD_REQ,
-    CSRNG_CMD_STS,
+    CSRNG_SW_CMD_STS,
     CSRNG_GENBITS_VLD,
     CSRNG_GENBITS,
     CSRNG_HW_EXC_STS,
@@ -297,7 +293,7 @@ package csrng_reg_pkg;
     4'b 0111, // index[ 4] CSRNG_CTRL
     4'b 1111, // index[ 5] CSRNG_SUM_STS
     4'b 1111, // index[ 6] CSRNG_CMD_REQ
-    4'b 0001, // index[ 7] CSRNG_CMD_STS
+    4'b 0001, // index[ 7] CSRNG_SW_CMD_STS
     4'b 0001, // index[ 8] CSRNG_GENBITS_VLD
     4'b 1111, // index[ 9] CSRNG_GENBITS
     4'b 0011, // index[10] CSRNG_HW_EXC_STS

--- a/hw/ip/csrng/rtl/csrng_state_db.sv
+++ b/hw/ip/csrng/rtl/csrng_state_db.sv
@@ -8,12 +8,12 @@
 //    working state for a given drbg instance.
 
 module csrng_state_db import csrng_pkg::*; #(
-  parameter int unsigned NApps = 4,
-  parameter int unsigned StateId = 4,
-  parameter int unsigned BlkLen = 128,
-  parameter int unsigned KeyLen = 256,
-  parameter int unsigned CtrLen  = 32,
-  parameter int unsigned Cmd     = 3
+  parameter int NApps = 4,
+  parameter int StateId = 4,
+  parameter int BlkLen = 128,
+  parameter int KeyLen = 256,
+  parameter int CtrLen  = 32,
+  parameter int Cmd     = 3
 ) (
   input logic                clk_i,
   input logic                rst_ni,
@@ -43,7 +43,7 @@ module csrng_state_db import csrng_pkg::*; #(
   output logic [StateId-1:0] state_db_sts_id_o
 );
 
-  localparam int unsigned InternalStateWidth = 2+KeyLen+BlkLen+CtrLen;
+  localparam int InternalStateWidth = 2+KeyLen+BlkLen+CtrLen;
 
   logic [StateId-1:0]              state_db_id;
   logic [KeyLen-1:0]               state_db_key;


### PR DESCRIPTION
Fixed general style issues.
Fixed type in doc.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>