### PR TITLE
[dv] Expand top level bind-file name in dvsim cfg

### DIFF
--- a/hw/ip/entropy_src/dv/entropy_src_sim_cfg.hjson
+++ b/hw/ip/entropy_src/dv/entropy_src_sim_cfg.hjson
@@ -34,7 +34,7 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
 
   // Add additional tops for simulation.
-  sim_tops: ["-top {name}_bind"]
+  sim_tops: ["-top entropy_src_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50

--- a/hw/ip/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson
@@ -39,7 +39,7 @@
   ]
 
   // Add additional tops for simulation.
-  sim_tops: ["-top {name}_bind"]
+  sim_tops: ["-top flash_ctrl_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50

--- a/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson
+++ b/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson
@@ -35,7 +35,7 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
 
   // Add additional tops for simulation.
-  sim_tops: ["-top {name}_bind"]
+  sim_tops: ["-top keymgr_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50

--- a/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
+++ b/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
@@ -35,7 +35,7 @@ name:
   en_build_modes: ["{tool}_otbn_memutil_build_opts"]
 
   // Add additional tops for simulation.
-  sim_tops: ["-top {name}_bind"]
+  sim_tops: ["-top otbn_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   //

--- a/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -35,7 +35,7 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
 
   // Add additional tops for simulation.
-  sim_tops: ["-top {name}_bind"]
+  sim_tops: ["-top otp_ctrl_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50


### PR DESCRIPTION
- A very small bug in the auto-testbench generator resulted in `{name}`
variable creeping into the generated sim cfg HJson. It should have
really been expanded to the DUT name instead (which was recently fixed
in the uvmdvgen template.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>