### PR TITLE
[otbn] Enable automated CSR tests

### DIFF
--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -70,8 +70,13 @@
 
             The completion is signalled by the done interrupt.
           '''
-          tags: [// Do not randomly start big num operations
-                 "excl:CsrNonInitTests:CsrExclWrite"],
+          tags: [
+            // Don't write this field in the automated CSR tests. Doing so will
+            // start OTBN, but we won't have initialised its memory with any
+            // code, so we'll get Xs on its interfaces and everything will be
+            // a bit of a mess!
+            "excl:CsrAllTests:CsrExclWrite"
+          ]
         }
         { bits: "1",
           name: "dummy",

--- a/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
+++ b/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
@@ -28,7 +28,12 @@ name:
       // Project wide common sim cfg file
       "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",
       // Config file to pull in the correct flags for otbn_memutil
-      "{proj_root}/hw/ip/otbn/dv/memutil/otbn_memutil_sim_opts.hjson"
+      "{proj_root}/hw/ip/otbn/dv/memutil/otbn_memutil_sim_opts.hjson",
+      // Common CIP test lists
+      "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
+      "{proj_root}/hw/dv/tools/dvsim/tests/mem_tests.hjson",
+      "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
+      "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson"
   ]
 
   // Add options needed to compile against otbn_memutil
@@ -55,13 +60,13 @@ name:
   //       that stress my new feature; please run the test suite with them")
   otbn_elf_dir: "{sw_build_dir}"
 
+  run_opts: ["+otbn_elf_dir={otbn_elf_dir}"]
+
   // List of test specifications.
   tests: [
     {
       name: "otbn_sanity"
       uvm_test_seq: "otbn_sanity_vseq"
-
-      run_opts: ["+otbn_elf_dir={otbn_elf_dir}"]
     }
 
     // TODO: add more tests here

--- a/hw/ip/otbn/dv/uvm/tests/otbn_base_test.sv
+++ b/hw/ip/otbn/dv/uvm/tests/otbn_base_test.sv
@@ -16,8 +16,6 @@ class otbn_base_test extends dv_base_test #(
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
-    cfg.has_ral = 1'b0;
-
     if (!$value$plusargs("otbn_elf_dir=%0s", cfg.otbn_elf_dir)) begin
       `uvm_fatal(`gfn, "Missing required plusarg: otbn_elf_dir.")
     end


### PR DESCRIPTION
This imports the standard CSR / memory tests into the OTBN testbench, which are now all passing happily.