### PR TITLE
[sw] Deny K&R Declarations in C

### DIFF
--- a/doc/rm/c_cpp_coding_style.md
+++ b/doc/rm/c_cpp_coding_style.md
@@ -371,6 +371,18 @@ This may change if we find cases where this initialization improves readability.
 When initializing an array, initializers *may* be designated when that makes the array more readable (e.g., lookup tables that are mostly zeroed). Mixing designated and undesignated initializers, or using nested initializers, is still
 forbidden.
 
+### Function Declarations
+
+***All function declarations in C must include a list of the function's parameters, with their types.***
+
+C functions declared as `return_t my_function()` are called "K&R declarations", and are type compatible with any list of arguments, with any types.
+Declarations of this type allow type confusion, especially if the function definition is not available.
+
+The correct way to denote that a function takes no arguments is using the parameter type `void`.
+For example `return_t my_function(void)` is the correct way to declare that `my_function` takes no arguments.
+
+The parameter names in every declaration should match the parameter names in the function definition.
+
 ### Inline Functions
 
 Functions that we strongly wish to be inlined, and which are part of a public interface, should be declared as an inline function.

--- a/doc/rm/c_cpp_coding_style.md
+++ b/doc/rm/c_cpp_coding_style.md
@@ -368,8 +368,8 @@ When initializing a struct or union, initializers within *must* be designated; a
 Furthermore, the nested forms of designated initialization are forbidden (e.g., `.x.y = foo` and `.x[0] = bar`), to discourage initialization of deeply nested structures with flat syntax.
 This may change if we find cases where this initialization improves readability.
 
-When initializing an array, initializers *may* be designated when that makes the array more readable (e.g., lookup tables that are mostly zeroed). Mixing designated and undesignated initializers, or using nested initializers, is still
-forbidden.
+When initializing an array, initializers *may* be designated when that makes the array more readable (e.g., lookup tables that are mostly zeroed).
+Mixing designated and undesignated initializers, or using nested initializers, is still forbidden.
 
 ### Function Declarations
 

--- a/meson.build
+++ b/meson.build
@@ -108,6 +108,10 @@ add_project_arguments(
   c_cpp_cross_args,
   optimize_size_args,
   language: ['c', 'cpp'], native: false)
+# Add a C-only flag for cross builds.
+add_project_arguments(
+  '-Wstrict-prototypes', # Ban K&R Declarations/Definitions.
+  language: ['c'], native: false)
 
 # The following flags are applied only to cross builds
 c_cpp_cross_link_args = [
@@ -144,6 +148,10 @@ endforeach
 add_project_arguments(
   c_cpp_native_args,
   language: ['c', 'cpp'], native: true)
+# Add a C-only flag for native builds.
+add_project_arguments(
+  '-Wstrict-prototypes', # Ban K&R Declarations/Definitions.
+  language: ['c'], native: true)
 
 # Common program references.
 prog_python = import('python').find_installation('python3')

--- a/sw/device/benchmarks/coremark/meson.build
+++ b/sw/device/benchmarks/coremark/meson.build
@@ -28,6 +28,7 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
     # Set up coremark-specific defines.
     c_args: [
       '-Wno-implicit-fallthrough',
+      '-Wno-strict-prototypes',
       '-DITERATIONS=@0@'.format(coremark_iterations),
       '-DPERFORMANCE_RUN=1',
       '-DTOTAL_DATA_SIZE=2000',

--- a/sw/device/lib/flash_ctrl.c
+++ b/sw/device/lib/flash_ctrl.c
@@ -193,17 +193,21 @@ void flash_cfg_region(const mp_region_t *region_cfg) {
   }
 }
 
-uint32_t flash_get_banks() { return FLASH_CTRL_PARAM_REGNUMBANKS; }
+uint32_t flash_get_banks(void) { return FLASH_CTRL_PARAM_REGNUMBANKS; }
 
-uint32_t flash_get_pages_per_bank() { return FLASH_CTRL_PARAM_REGPAGESPERBANK; }
+uint32_t flash_get_pages_per_bank(void) {
+  return FLASH_CTRL_PARAM_REGPAGESPERBANK;
+}
 
-uint32_t flash_get_words_per_page() { return FLASH_CTRL_PARAM_WORDSPERPAGE; }
+uint32_t flash_get_words_per_page(void) {
+  return FLASH_CTRL_PARAM_WORDSPERPAGE;
+}
 
-uint32_t flash_get_bank_size() { return FLASH_CTRL_PARAM_BYTESPERBANK; }
+uint32_t flash_get_bank_size(void) { return FLASH_CTRL_PARAM_BYTESPERBANK; }
 
-uint32_t flash_get_page_size() { return FLASH_CTRL_PARAM_BYTESPERPAGE; }
+uint32_t flash_get_page_size(void) { return FLASH_CTRL_PARAM_BYTESPERPAGE; }
 
-uint32_t flash_get_word_size() { return FLASH_CTRL_PARAM_BYTESPERWORD; }
+uint32_t flash_get_word_size(void) { return FLASH_CTRL_PARAM_BYTESPERWORD; }
 
 void flash_write_scratch_reg(uint32_t value) {
   REG32(FLASH_CTRL0_BASE_ADDR + FLASH_CTRL_SCRATCH_REG_OFFSET) = value;

--- a/sw/device/lib/flash_ctrl.h
+++ b/sw/device/lib/flash_ctrl.h
@@ -113,22 +113,22 @@ void flash_default_region_access(bool rd_en, bool prog_en, bool erase_en);
 void flash_cfg_region(const mp_region_t *region_cfg);
 
 /** Get number of flash banks */
-uint32_t flash_get_banks();
+uint32_t flash_get_banks(void);
 
 /** Get number of pages per bank */
-uint32_t flash_get_pages_per_bank();
+uint32_t flash_get_pages_per_bank(void);
 
 /** Get number of words per page */
-uint32_t flash_get_words_per_page();
+uint32_t flash_get_words_per_page(void);
 
 /** Get size of each bank in bytes */
-uint32_t flash_get_bank_size();
+uint32_t flash_get_bank_size(void);
 
 /** Get size of each page in bytes */
-uint32_t flash_get_page_size();
+uint32_t flash_get_page_size(void);
 
 /** Get size of each flash word in bytes */
-uint32_t flash_get_word_size();
+uint32_t flash_get_word_size(void);
 
 /** Write value to flash scratch register */
 void flash_write_scratch_reg(uint32_t value);

--- a/sw/device/lib/hw_sha256.c
+++ b/sw/device/lib/hw_sha256.c
@@ -12,7 +12,7 @@ static const HASH_VTAB HW_SHA256_VTAB = {.init = &hw_SHA256_init,
                                          .hash = &hw_SHA256_hash,
                                          .size = SHA256_DIGEST_SIZE};
 
-static void sha256_init() {
+static void sha256_init(void) {
   hmac_cfg_t config = {.mode = HMAC_OP_SHA256,
                        .input_endian_swap = 1,
                        .digest_endian_swap = 1,

--- a/sw/device/lib/runtime/ibex.c
+++ b/sw/device/lib/runtime/ibex.c
@@ -4,4 +4,4 @@
 
 #include "sw/device/lib/runtime/ibex.h"
 
-extern uint64_t ibex_mcycle_read();
+extern uint64_t ibex_mcycle_read(void);

--- a/sw/device/lib/runtime/ibex.h
+++ b/sw/device/lib/runtime/ibex.h
@@ -25,7 +25,7 @@
  * Adapted from: The RISC-V Instruction Set Manual, Volume I: Unprivileged ISA
  * V20191213, pp. 61.
  */
-inline uint64_t ibex_mcycle_read() {
+inline uint64_t ibex_mcycle_read(void) {
   uint32_t cycle_low = 0;
   uint32_t cycle_high = 0;
   uint32_t cycle_high_2 = 0;

--- a/sw/device/tests/dif/dif_otbn_sanitytest.c
+++ b/sw/device/tests/dif/dif_otbn_sanitytest.c
@@ -153,7 +153,7 @@ static void call_function(const otbn_func_t *func) {
 /**
  * Busy wait for OTBN to be done with its operation.
  */
-static void otbn_wait_for_done() {
+static void otbn_wait_for_done(void) {
   bool busy = true;
   while (busy) {
     CHECK(dif_otbn_is_busy(&otbn, &busy) == kDifOtbnOk,
@@ -164,7 +164,7 @@ static void otbn_wait_for_done() {
 /**
  * Initialize OTBN's data memory with zeros
  */
-static void zero_dmem() {
+static void zero_dmem(void) {
   int dmem_size_words = dif_otbn_get_dmem_size_bytes(&otbn) / sizeof(uint32_t);
   for (int i = 0; i < dmem_size_words; ++i) {
     const uint32_t zero = 0;
@@ -185,7 +185,7 @@ static void zero_dmem() {
  * The entry point wrap_barrett384() is called according to the calling
  * convention described in the OTBN assembly code file.
  */
-static void test_barrett384() {
+static void test_barrett384(void) {
   enum { kDataSizeBytes = 48 };
 
   zero_dmem();

--- a/sw/device/tests/sim_dv/spi_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/spi_tx_rx_test.c
@@ -280,7 +280,7 @@ static void plic_init_with_irqs(mmio_region_t base_addr, dif_plic_t *plic) {
         "dif_plic_irq_set_enabled failed");
 }
 
-static bool exp_irqs_fired() {
+static bool exp_irqs_fired(void) {
   return fired_irqs[kDifSpiDeviceIrqRxAboveLevel] &&
          fired_irqs[kDifSpiDeviceIrqTxBelowLevel] &&
          fired_irqs[kDifSpiDeviceIrqRxOverflow] &&


### PR DESCRIPTION
C functions that take no arguments have to specify `void` between the
parentheses in the function declaration. If this is omitted, then the
compiler assumes it is a K&R style declaration, which are not type safe.

---

Noticed when touching some other code. I thought we denied K&R declarations in our style guide, but apparently not. This is an improvement nonetheless.