### PR TITLE
[otbn] Allow core to fetch IMEM on start cycle

### DIFF
--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -246,7 +246,7 @@ module otbn
   );
 
   // Mux core and bus access into IMEM
-  assign imem_access_core = busy_q;
+  assign imem_access_core = busy_q | start;
 
   assign imem_req   = imem_access_core ? imem_req_core   : imem_req_bus;
   assign imem_write = imem_access_core ? imem_write_core : imem_write_bus;


### PR DESCRIPTION
The fetch unit issues its first request on the same cycle as the start
signal goes high (so there's a combinatorial path from the TL
interface to `imem_req_core`) but `imem_access_core` was only turning on
at the following cycle.

The result is that the first instruction was silently getting
discarded.
