### PR TITLE
[sw, testing] Add Inverted() function in mock_mmio.h

### DIFF
--- a/sw/device/lib/testing/mock_mmio.h
+++ b/sw/device/lib/testing/mock_mmio.h
@@ -128,6 +128,22 @@ Int ToInt(std::initializer_list<BitField> fields) {
   }
   return val;
 }
+
+/**
+ * Returns an integer with the bit at index set to 1 and all other bits to 0.
+ */
+template <typename Int>
+Int Bit(Int index) {
+  return (1 << index);
+}
+
+/**
+ * Bitwise invert received value.
+ */
+template <typename Int>
+Int Inverted(Int integer) {
+  return ~integer;
+}
 }  // namespace internal
 
 /**

--- a/sw/device/lib/testing/mock_mmio_test.cc
+++ b/sw/device/lib/testing/mock_mmio_test.cc
@@ -10,6 +10,8 @@
 namespace {
 using ::mock_mmio::LeInt;
 using ::mock_mmio::MmioTest;
+using ::mock_mmio::internal::Bit;
+using ::mock_mmio::internal::Inverted;
 using ::testing::Test;
 
 /**
@@ -76,5 +78,13 @@ TEST_F(MockMmioTest, ExpectMask) {
   // Clear the 16th bit.
   value &= ~(1 << 0x10);
   mmio_region_write32(dev().region(), 0x8, value);
+}
+
+TEST_F(MockMmioTest, ExpectReadBit) {
+  EXPECT_READ32(0x0, Bit(0x5));
+  EXPECT_EQ(mmio_region_read32(dev().region(), 0x0), 0x1 << 5);
+
+  EXPECT_READ32(0x1, Inverted(Bit(0x3)));
+  EXPECT_EQ(mmio_region_read32(dev().region(), 0x1), ~(0x1 << 3));
 }
 }  // namespace


### PR DESCRIPTION
Closes https://github.com/lowRISC/opentitan/issues/3847

Hello, newcomer here interested in contributing :) 

The new function should be used in `dif_rstmgr_unittest.cc` instead of `bitfield_bit32_write()` right ? Should that be included in this PR ?  