### PR TITLE
[otbn] Fix otbnsim bitwise operations with signed immediates

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/insn.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/insn.py
@@ -123,7 +123,7 @@ class ANDI(RV32RegImm):
 
     def execute(self, state: OTBNState) -> None:
         val1 = state.gprs.get_reg(self.grs1).read_unsigned()
-        val2 = self.imm
+        val2 = self.as_u32(self.imm)
         result = val1 & val2
         state.gprs.get_reg(self.grd).write_unsigned(result)
 
@@ -143,7 +143,7 @@ class ORI(RV32RegImm):
 
     def execute(self, state: OTBNState) -> None:
         val1 = state.gprs.get_reg(self.grs1).read_unsigned()
-        val2 = self.imm
+        val2 = self.as_u32(self.imm)
         result = val1 | val2
         state.gprs.get_reg(self.grd).write_unsigned(result)
 
@@ -163,7 +163,7 @@ class XORI(RV32RegImm):
 
     def execute(self, state: OTBNState) -> None:
         val1 = state.gprs.get_reg(self.grs1).read_unsigned()
-        val2 = self.imm
+        val2 = self.as_u32(self.imm)
         result = val1 ^ val2
         state.gprs.get_reg(self.grd).write_unsigned(result)
 

--- a/hw/ip/otbn/dv/otbnsim/sim/isa.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/isa.py
@@ -90,6 +90,12 @@ class OTBNInsn:
         self._disasm = (pc, disasm)
         return disasm
 
+    @staticmethod
+    def as_u32(value: int) -> int:
+        '''Interpret the signed value as a 2's complement u32'''
+        assert -(1 << 31) <= value < (1 << 31)
+        return (1 << 32) + value if value < 0 else value
+
 
 class RV32RegReg(OTBNInsn):
     '''A general class for register-register insns from the RV32I ISA'''


### PR DESCRIPTION
In Python, XOR'ing a signed number gives a signed number (inheriting
semantics from C). We store unsigned values in our registers in
otbnsim, so we need to convert the signed immediate into a `u32` before
doing the bitwise operation.

Before this change, we hit assertions when performing bitwise
operations with negative immediates. After the change, we'll see trace
lines like this:

    xori         x10, x0, -728          | [x10 = 0xfffffd28]

(incidentally, this is the right interpretation - the RISC-V ISA
specifies that these signed immediates are sign-extended).
