### PR TITLE
[dv/alert_esc_agent] Corner case timing alignment

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_sender_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_sender_driver.sv
@@ -170,12 +170,12 @@ class alert_sender_driver extends alert_esc_base_driver;
 
   virtual task random_drive_int_fail(int int_err_cyc);
     repeat (req.int_err_cyc) begin
+      wait_sender_clk();
       if (under_reset) break;
       randcase
         1: drive_alerts_low();
         1: drive_alerts_high();
       endcase
-      wait_sender_clk();
     end
   endtask : random_drive_int_fail
 

--- a/hw/dv/sv/alert_esc_agent/esc_receiver_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/esc_receiver_driver.sv
@@ -91,6 +91,7 @@ class esc_receiver_driver extends alert_esc_base_driver;
   virtual task drive_esc_resp(alert_esc_seq_item req);
     if (req.standalone_int_err) begin
       wait_esc_complete();
+      @(cfg.vif.receiver_cb); // wait one clock cycle to ensure is_ping is set
       if (!is_ping) begin
         repeat (req.int_err_cyc) begin
           if (cfg.vif.esc_tx.esc_p === 1'b0 && !is_ping) begin


### PR DESCRIPTION
This PR fixes corner case related to alert_esc_agent timing:
1. If alert_p/n and ping_p/n triggers at the same clock cycle, the
alert_p/n is considered ping response rather than independent alerts.
2. In esc_driver, is_ping is determined one clock cycle after esc_p/n is
being reset (because ping response is only one clock cycle long). So the
code has to wait one clock cycle to ensure is_ping is set.
3. Move the wait clcok before drive int_err to avoid reset confilict.

Signed-off-by: Cindy Chen <chencindy@google.com>