### PR TITLE
[otbn] Bring design to S1 and L1

### DIFF
--- a/hw/ip/otbn/otbn.prj.hjson
+++ b/hw/ip/otbn/otbn.prj.hjson
@@ -12,5 +12,5 @@
     life_stage:         "L1",
     design_stage:       "D1",
     verification_stage: "V0",
-    dif_stage:          "S0",
+    dif_stage:          "S1",
 }

--- a/hw/ip/otbn/otbn.prj.hjson
+++ b/hw/ip/otbn/otbn.prj.hjson
@@ -9,7 +9,7 @@
     hw_checklist:       "hw/ip/otbn/doc/checklist",
     sw_checklist:       "sw/device/lib/dif/dif_otbn"
     version:            "0.1",
-    life_stage:         "L0",
+    life_stage:         "L1",
     design_stage:       "D1",
     verification_stage: "V0",
     dif_stage:          "S0",

--- a/sw/device/lib/dif/dif_otbn.md
+++ b/sw/device/lib/dif/dif_otbn.md
@@ -11,10 +11,10 @@ All checklist items refer to the content in the [Checklist]({{< relref "/doc/pro
 
 Type           | Item                 | Resolution  | Note/Collaterals
 ---------------|----------------------|-------------|------------------
-Implementation | [DIF_EXISTS][]       | Not Started |
-Implementation | [DIF_USED_IN_TREE][] | Not Started |
-Tests          | [DIF_TEST_UNIT][]    | Not Started |
-Tests          | [DIF_TEST_SANITY][]  | Not Started |
+Implementation | [DIF_EXISTS][]       | Done        |
+Implementation | [DIF_USED_IN_TREE][] | Done        |
+Tests          | [DIF_TEST_UNIT][]    | Done        |
+Tests          | [DIF_TEST_SANITY][]  | Done        |
 
 [DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif_exists" >}}
 [DIF_USED_IN_TREE]: {{< relref "/doc/project/checklist.md#dif_used_in_tree" >}}


### PR DESCRIPTION
Update the checklists to indicate that all work necessary for the S1 software stage (development) has been completed.

Also indicate that we're actually in the development lifecycle state, L1.