### PR TITLE
[kmac/dv] Add keymgr and idle interfaces to TB

### DIFF
--- a/hw/ip/kmac/dv/env/kmac_env.core
+++ b/hw/ip/kmac/dv/env/kmac_env.core
@@ -9,8 +9,10 @@ filesets:
     depend:
       - lowrisc:dv:ralgen
       - lowrisc:dv:cip_lib
+      - lowrisc:dv:push_pull_agent
     files:
       - kmac_env_pkg.sv
+      - kmac_sideload_if.sv
       - kmac_env_cfg.sv: {is_include_file: true}
       - kmac_env_cov.sv: {is_include_file: true}
       - kmac_virtual_sequencer.sv: {is_include_file: true}

--- a/hw/ip/kmac/dv/env/kmac_env.sv
+++ b/hw/ip/kmac/dv/env/kmac_env.sv
@@ -14,6 +14,14 @@ class kmac_env extends cip_base_env #(
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
+
+    // get ext interfaces
+    if (!uvm_config_db#(idle_vif)::get(this, "", "idle_vif", cfg.idle_vif)) begin
+      `uvm_fatal(`gfn, "failed to get idle_vif handle from uvm_config_db")
+    end
+    if (!uvm_config_db#(sideload_vif)::get(this, "", "sideload_vif", cfg.sideload_vif)) begin
+      `uvm_fatal(`gfn, "failed to get sideload_vif handle from uvm_config_db")
+    end
   endfunction
 
   function void connect_phase(uvm_phase phase);

--- a/hw/ip/kmac/dv/env/kmac_env_cfg.sv
+++ b/hw/ip/kmac/dv/env/kmac_env_cfg.sv
@@ -4,7 +4,9 @@
 
 class kmac_env_cfg extends cip_base_env_cfg #(.RAL_T(kmac_reg_block));
 
-  // ext component cfgs
+  // ext interfaces
+  idle_vif        idle_vif;
+  sideload_vif    sideload_vif;
 
   `uvm_object_utils_begin(kmac_env_cfg)
   `uvm_object_utils_end

--- a/hw/ip/kmac/dv/env/kmac_env_pkg.sv
+++ b/hw/ip/kmac/dv/env/kmac_env_pkg.sv
@@ -11,7 +11,9 @@ package kmac_env_pkg;
   import tl_agent_pkg::*;
   import cip_base_pkg::*;
   import csr_utils_pkg::*;
+  import push_pull_agent_pkg::*;
   import kmac_ral_pkg::*;
+  import keymgr_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"
@@ -19,12 +21,24 @@ package kmac_env_pkg;
 
   // parameters
 
+  // Sideload data has 2*KeyWidth bits of key shares and 1 bit valid.
+  parameter int SIDELOAD_KEY_SIZE = $bits(hw_key_req_t);
+  // KDF request data has 1 bit for last, and the rest are for data/strb.
+  // We subtract 1 from the width of the struct as it includes the valid handshake signal.
+  parameter int KDF_DATA_SIZE = $bits(kmac_data_req_t) - 1;
+  // KDF response data has 2 bits for done/error signals and the rest are for digest shares.
+  // We subtract 1 from the struct width as it includes the ready handshake signal.
+  parameter int KDF_DIGEST_SIZE = $bits(kmac_data_rsp_t) - 1;
+
   // types
   typedef enum {
     KmacDone,
     KmacFifoEmpty,
     KmacErr
   } kmac_intr_e;
+
+  typedef virtual pins_if#(1)       idle_vif;
+  typedef virtual kmac_sideload_if  sideload_vif;
 
   // functions
 

--- a/hw/ip/kmac/dv/env/kmac_scoreboard.sv
+++ b/hw/ip/kmac/dv/env/kmac_scoreboard.sv
@@ -11,8 +11,6 @@ class kmac_scoreboard extends cip_base_scoreboard #(
 
   // local variables
 
-  // TLM agent fifos
-
   // local queues to hold incoming packets pending comparison
 
   `uvm_component_new

--- a/hw/ip/kmac/dv/env/kmac_sideload_if.sv
+++ b/hw/ip/kmac/dv/env/kmac_sideload_if.sv
@@ -1,0 +1,12 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+interface kmac_sideload_if;
+  // This struct contains three fields:
+  // - valid
+  // - key_share0
+  // - key_share1
+  keymgr_pkg::hw_key_req_t sideload_key;
+
+endinterface

--- a/hw/ip/kmac/dv/tb.sv
+++ b/hw/ip/kmac/dv/tb.sv
@@ -1,13 +1,14 @@
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-//
+
 module tb;
   // dep packages
   import uvm_pkg::*;
   import dv_utils_pkg::*;
   import kmac_env_pkg::*;
   import kmac_test_pkg::*;
+  import kmac_reg_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"
@@ -15,38 +16,61 @@ module tb;
 
   wire clk, rst_n;
   wire devmode;
+  wire idle;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
   // Interrupt wires
   wire intr_kmac_done, intr_kmac_fifo_empty, intr_kmac_err;
+  // keymgr/kmac sideload wires
+  keymgr_pkg::hw_key_req_t kmac_sideload_key;
+  // keymgr kdf interface wires
+  wire [KDF_DIGEST_SIZE-1:0] kdf_digest;
 
   // interfaces
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
-  pins_if #(NUM_MAX_INTERRUPTS) intr_if(interrupts);
-  pins_if #(1) devmode_if(devmode);
+
+  pins_if #(1)                   devmode_if(devmode);
+  pins_if #(1)                   idle_if(idle);
+  pins_if #(NUM_MAX_INTERRUPTS)  intr_if(interrupts);
+
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
+
+  kmac_sideload_if sideload_if();
 
   // dut
   kmac dut (
-    .clk_i                (clk                  ),
-    .rst_ni               (rst_n                ),
+    .clk_i                (clk                      ),
+    .rst_ni               (rst_n                    ),
 
     // TLUL interface
-    .tl_i                 (tl_if.h2d            ),
-    .tl_o                 (tl_if.d2h            ),
+    .tl_i                 (tl_if.h2d                ),
+    .tl_o                 (tl_if.d2h                ),
+
+    // KeyMgr sideload key interface
+    .keymgr_key_i         (sideload_if.sideload_key ),
+
+    // KeyMgr KDF datapath
+    //
+    // TODO: this is set to 0 for the time being to get the csr tests passing.
+    //       this will eventually be hooked up to the kmac<->keymgr agent.
+    .keymgr_kdf_i         ('0                       ),
 
     // Interrupts
-    .intr_kmac_done_o     (intr_kmac_done       ),
-    .intr_fifo_empty_o    (intr_kmac_fifo_empty ),
-    .intr_kmac_err_o      (intr_kmac_err        )
+    .intr_kmac_done_o     (intr_kmac_done           ),
+    .intr_fifo_empty_o    (intr_kmac_fifo_empty     ),
+    .intr_kmac_err_o      (intr_kmac_err            ),
+
+    // Idle interface
+    .idle_o               (idle                     )
 
     // TODO: hook up interfaces for:
     //
-    // 1) keymgr sideload
-    // 2) keymgr KDF
-    // 3) csrng/edn
+    // 1) KDF
+    // 2) csrng/edn
   );
 
-  // Bind interrupt wires to interrupt interface
+  // Interface assignments
+
+  // Interrupt interface
   assign interrupts[KmacDone]       = intr_kmac_done;
   assign interrupts[KmacFifoEmpty]  = intr_kmac_fifo_empty;
   assign interrupts[KmacErr]        = intr_kmac_done;
@@ -58,6 +82,8 @@ module tb;
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
+    uvm_config_db#(virtual pins_if#(1))::set(null, "*.env", "idle_vif", idle_if);
+    uvm_config_db#(virtual kmac_sideload_if)::set(null, "*.env", "sideload_vif", sideload_if);
     $timeformat(-12, 0, " ps", 12);
     run_test();
   end


### PR DESCRIPTION
This PR creates an `idle_if` and a `sideload_if` for the kmac idle signal and sideload input, respectively.

The keymgr KDF interface is stubbed to `'0` for the time being to get the basic csr tests passing and to allow development of smoke test (in follow up PRs).
This will be replaced by a connection to the `kmac<->keymgr` agent once it is completed.

Signed-off-by: Udi Jonnalagadda <udij@google.com>