### PR TITLE
Avoid "sanity" terminology in OTBN UVM code

### DIFF
--- a/hw/ip/otbn/data/otbn_testplan.hjson
+++ b/hw/ip/otbn/data/otbn_testplan.hjson
@@ -38,7 +38,7 @@
 
             '''
       milestone: V1
-      tests: ["otbn_sanity"]
+      tests: ["otbn_single"]
     }
 
     {

--- a/hw/ip/otbn/doc/checklist.md
+++ b/hw/ip/otbn/doc/checklist.md
@@ -41,7 +41,7 @@ Documentation | [DOC_INTERFACE][]       | Not Started |
 Documentation | [MISSING_FUNC][]        | Not Started |
 Documentation | [FEATURE_FROZEN][]      | Not Started |
 RTL           | [FEATURE_COMPLETE][]    | Not Started |
-RTL           | [AREA_SANITY_CHECK][]   | Not Started |
+RTL           | [AREA_CROSS_CHECK][]    | Not Started |
 RTL           | [PORT_FROZEN][]         | Not Started |
 RTL           | [ARCHITECTURE_FROZEN][] | Not Started |
 RTL           | [REVIEW_TODO][]         | Not Started |
@@ -61,7 +61,7 @@ Security      | [SEC_RND_CNST][]        | Not Started |
 [MISSING_FUNC]:        {{<relref "/doc/project/checklist.md#missing_func" >}}
 [FEATURE_FROZEN]:      {{<relref "/doc/project/checklist.md#feature_frozen" >}}
 [FEATURE_COMPLETE]:    {{<relref "/doc/project/checklist.md#feature_complete" >}}
-[AREA_SANITY_CHECK]:   {{<relref "/doc/project/checklist.md#area_sanity_check" >}}
+[AREA_CROSS_CHECK]:    {{<relref "/doc/project/checklist.md#area_cross_check" >}}
 [PORT_FROZEN]:         {{<relref "/doc/project/checklist.md#port_frozen" >}}
 [ARCHITECTURE_FROZEN]: {{<relref "/doc/project/checklist.md#architecture_frozen" >}}
 [REVIEW_TODO]:         {{<relref "/doc/project/checklist.md#review_todo" >}}
@@ -118,11 +118,11 @@ Testbench     | [SIM_TB_ENV_CREATED][]                | Not Started |
 Testbench     | [SIM_RAL_MODEL_GEN_AUTOMATED][]       | Not Started |
 Testbench     | [CSR_CHECK_GEN_AUTOMATED][]           | Not Started |
 Testbench     | [TB_GEN_AUTOMATED][]                  | Not Started |
-Tests         | [SIM_SANITY_TEST_PASSING][]           | Not Started |
+Tests         | [SIM_SMOKE_TEST_PASSING][]            | Not Started |
 Tests         | [SIM_CSR_MEM_TEST_SUITE_PASSING][]    | Not Started |
 Tests         | [FPV_MAIN_ASSERTIONS_PROVEN][]        | Not Started |
 Tool Setup    | [SIM_ALT_TOOL_SETUP][]                | Not Started |
-Regression    | [SIM_SANITY_REGRESSION_SETUP][]       | Not Started |
+Regression    | [SIM_SMOKE_REGRESSION_SETUP][]        | Not Started |
 Regression    | [SIM_NIGHTLY_REGRESSION_SETUP][]      | Not Started |
 Regression    | [FPV_REGRESSION_SETUP][]              | Not Started |
 Coverage      | [SIM_COVERAGE_MODEL_ADDED][]          | Not Started |
@@ -140,11 +140,11 @@ Review        | [V2_CHECKLIST_SCOPED][]               | Not Started |
 [SIM_RAL_MODEL_GEN_AUTOMATED]:        {{<relref "/doc/project/checklist.md#sim_ral_model_gen_automated" >}}
 [CSR_CHECK_GEN_AUTOMATED]:            {{<relref "/doc/project/checklist.md#csr_check_gen_automated" >}}
 [TB_GEN_AUTOMATED]:                   {{<relref "/doc/project/checklist.md#tb_gen_automated" >}}
-[SIM_SANITY_TEST_PASSING]:            {{<relref "/doc/project/checklist.md#sim_sanity_test_passing" >}}
+[SIM_SMOKE_TEST_PASSING]:             {{<relref "/doc/project/checklist.md#sim_smoke_test_passing" >}}
 [SIM_CSR_MEM_TEST_SUITE_PASSING]:     {{<relref "/doc/project/checklist.md#sim_csr_mem_test_suite_passing" >}}
 [FPV_MAIN_ASSERTIONS_PROVEN]:         {{<relref "/doc/project/checklist.md#fpv_main_assertions_proven" >}}
 [SIM_ALT_TOOL_SETUP]:                 {{<relref "/doc/project/checklist.md#sim_alt_tool_setup" >}}
-[SIM_SANITY_REGRESSION_SETUP]:        {{<relref "/doc/project/checklist.md#sim_sanity_regression_setup" >}}
+[SIM_SMOKE_REGRESSION_SETUP]:         {{<relref "/doc/project/checklist.md#sim_smoke_regression_setup" >}}
 [SIM_NIGHTLY_REGRESSION_SETUP]:       {{<relref "/doc/project/checklist.md#sim_nightly_regression_setup" >}}
 [FPV_REGRESSION_SETUP]:               {{<relref "/doc/project/checklist.md#fpv_regression_setup" >}}
 [SIM_COVERAGE_MODEL_ADDED]:           {{<relref "/doc/project/checklist.md#sim_coverage_model_added" >}}

--- a/hw/ip/otbn/doc/dv_plan/index.md
+++ b/hw/ip/otbn/doc/dv_plan/index.md
@@ -134,7 +134,7 @@ Tests can be run with [`dvsim.py`]({{< relref "hw/dv/tools/README.md" >}}).
 The link gives details of the tool's features and command line arguments.
 To run a basic sanity test, go to the top of the repository and run:
 ```console
-$ util/dvsim/dvsim.py hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson -i otbn_sanity
+$ util/dvsim/dvsim.py hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson -i otbn_single
 ```
 
 ## Testplan

--- a/hw/ip/otbn/doc/dv_plan/index.md
+++ b/hw/ip/otbn/doc/dv_plan/index.md
@@ -76,7 +76,7 @@ When testing OTBN, we are careful to distinguish between
 - behaviour that is triggered by particular external stimuli (register writes; surprise resets etc.)
 
 Testing lots of different instruction streams doesn't really use the UVM machinery, so we have a "pre-DV" phase of testing that generates constrained-random instruction streams (as ELF binaries) and runs a simple block-level simulation on each to check that the RTL matches the model.
-The idea is that this is much quicker for designers to use to sanity-test proposed changes, and can be run with Verilator, so it doesn't require an EDA tool licence.
+The idea is that this is much quicker for designers to use to smoke-test proposed changes, and can be run with Verilator, so it doesn't require an EDA tool licence.
 This pre-DV phase cannot drive sign-off, but it does use much of the same tooling.
 
 Once we are running full DV tests, we re-use this work, by using the same collection of randomised instruction streams and randomly picking from them for most of the sequences.
@@ -132,7 +132,7 @@ The design RTL contains other assertions defined by the designers, which will be
 
 Tests can be run with [`dvsim.py`]({{< relref "hw/dv/tools/README.md" >}}).
 The link gives details of the tool's features and command line arguments.
-To run a basic sanity test, go to the top of the repository and run:
+To run a basic smoke test, go to the top of the repository and run:
 ```console
 $ util/dvsim/dvsim.py hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson -i otbn_single
 ```

--- a/hw/ip/otbn/dv/uvm/env/otbn_env.core
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env.core
@@ -25,7 +25,7 @@ filesets:
       - seq_lib/otbn_vseq_list.sv: {is_include_file: true}
       - seq_lib/otbn_base_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_common_vseq.sv: {is_include_file: true}
-      - seq_lib/otbn_sanity_vseq.sv: {is_include_file: true}
+      - seq_lib/otbn_single_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
@@ -59,7 +59,7 @@ class otbn_base_vseq extends cip_base_vseq #(
 
   protected function automatic void
   get_queue_entries(bit for_imem, ref otbn_loaded_word entries[$]);
-    // Get the size of this memory (for a sanity check on the loaded words)
+    // Get the size of this memory (to make sure the number of loaded words makes sense)
     logic [21:0] mem_size = for_imem ? OTBN_IMEM_SIZE   : OTBN_DMEM_SIZE;
 
     // Iterate over the segments for this memory

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_single_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_single_vseq.sv
@@ -2,12 +2,10 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// A basic sanity test
-//
-// This loads up an ELF file, lets it run to completion, and then finishes.
+// A basic sequence that loads up an ELF file, lets it run to completion, and then finishes.
 
-class otbn_sanity_vseq extends otbn_base_vseq;
-  `uvm_object_utils(otbn_sanity_vseq)
+class otbn_single_vseq extends otbn_base_vseq;
+  `uvm_object_utils(otbn_single_vseq)
   `uvm_object_new
 
   // Should the ELF file be loaded with a backdoor DPI method, or should we actually generate the
@@ -57,4 +55,4 @@ class otbn_sanity_vseq extends otbn_base_vseq;
     run_otbn();
   endtask : body
 
-endclass : otbn_sanity_vseq
+endclass : otbn_single_vseq

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_vseq_list.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_vseq_list.sv
@@ -4,4 +4,4 @@
 
 `include "otbn_base_vseq.sv"
 `include "otbn_common_vseq.sv"
-`include "otbn_sanity_vseq.sv"
+`include "otbn_single_vseq.sv"

--- a/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
+++ b/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
@@ -65,8 +65,8 @@ name:
   // List of test specifications.
   tests: [
     {
-      name: "otbn_sanity"
-      uvm_test_seq: "otbn_sanity_vseq"
+      name: "otbn_single"
+      uvm_test_seq: "otbn_single_vseq"
     }
 
     // TODO: add more tests here
@@ -75,8 +75,8 @@ name:
   // List of regressions.
   regressions: [
     {
-      name: sanity
-      tests: ["otbn_sanity"]
+      name: smoke
+      tests: []
     }
   ]
 }


### PR DESCRIPTION
This relates to Cindy's PR #4143. Since things are moving around quite a bit in the OTBN tree, it seemed to make sense to apply the proposed changes just here. I also wanted to rename the "sanity" sequence to "single" anyway, so thought the history might look less confusing if I did that first.