### PR TITLE
[util, rom_ext] Add rust "header" generation

### DIFF
--- a/sw/device/rom_exts/manifest.rs.tpl
+++ b/sw/device/rom_exts/manifest.rs.tpl
@@ -1,0 +1,21 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+% for name, region in regions:
+/// Manifest field ${name} offset from the base.
+pub const ${region.offset_name().as_c_define()}:u32 = ${region.base_addr};
+
+/// Manifest field ${name} size in bytes.
+pub const ${region.size_bytes_name().as_c_define()}:u32 = ${region.size_bytes};
+
+/// Manifest field ${name} size in words.
+pub const ${region.size_words_name().as_c_define()}:u32 = ${region.size_words};
+
+% endfor
+
+% for name, offset in offsets:
+/// Manifest offset ${name} from the base.
+pub const ${offset.offset_name().as_c_define()}:u32 = ${offset.offset};
+
+%endfor

--- a/sw/device/rom_exts/meson.build
+++ b/sw/device/rom_exts/meson.build
@@ -53,6 +53,7 @@ rom_exts_manifest_offsets_header = custom_target(
     meson.source_root() / 'util/rom-ext-manifest-generator.py',
     '--input-dir', meson.current_source_dir(),
     '--output-dir', meson.current_build_dir(),
+    '--output-headers', 'c',
   ],
 )
 


### PR DESCRIPTION
This change allows to generate the set of ROM_EXT manifest offset and size values required by the ROM_EXT image signer tool.

This feature is intended to be used, and is a part of future ROM_EXT image signer tool, however is sufficiently independent to be a standalone PR.