### PR TITLE
[reggen] Minor cleanups

### DIFF
--- a/util/regtool.py
+++ b/util/regtool.py
@@ -27,7 +27,6 @@ USAGE = '''
 
 
 def main():
-    format = 'hjson'
     verbose = 0
 
     parser = argparse.ArgumentParser(
@@ -106,24 +105,28 @@ def main():
 
     verbose = args.verbose
 
-    if args.j:
-        format = 'json'
-    elif args.c:
-        format = 'compact'
-    elif args.d:
-        format = 'html'
-    elif args.doc:
-        format = 'doc'
-    elif args.r:
-        format = 'rtl'
-    elif args.s:
-        format = 'dv'
-    elif args.f:
-        format = 'fpv'
-    elif args.cdefines:
-        format = 'cdh'
-    elif args.ctdefines:
-        format = 'cth'
+    arg_to_format = [
+        ('j', 'json'),
+        ('c', 'compact'),
+        ('d', 'html'),
+        ('doc', 'doc'),
+        ('r', 'rtl'),
+        ('s', 'dv'),
+        ('f', 'fpv'),
+        ('cdefines', 'cdh'),
+        ('ctdefines', 'cth')
+    ]
+    format = None
+    for arg_name, fmt in arg_to_format:
+        if getattr(args, arg_name):
+            if format is not None:
+                log.error('Multiple output formats specified on '
+                          'command line ({} and {}).'
+                          .format(format, fmt))
+                sys.exit(1)
+            format = fmt
+    if format is None:
+        format = 'hjson'
 
     if (verbose):
         log.basicConfig(format="%(levelname)s: %(message)s", level=log.DEBUG)

--- a/util/regtool.py
+++ b/util/regtool.py
@@ -178,14 +178,13 @@ def main():
             gen_selfdoc.document(outfile)
         exit(0)
 
-    with infile:
-        try:
-            srcfull = infile.read()
-            obj = hjson.loads(srcfull,
-                              use_decimal=True,
-                              object_pairs_hook=validate.checking_dict)
-        except ValueError:
-            raise SystemExit(sys.exc_info()[1])
+    try:
+        srcfull = infile.read()
+        obj = hjson.loads(srcfull,
+                          use_decimal=True,
+                          object_pairs_hook=validate.checking_dict)
+    except ValueError:
+        raise SystemExit(sys.exc_info()[1])
 
     if args.novalidate:
         with outfile:


### PR DESCRIPTION
This is a grab-bag of simple cleanups in `reggen` and `regtool`. I was looking at the code because I was considering automating some DV code for OTBN. I'm not now convinced that's the right thing to do, but I made some clean-ups as I went past, so thought it made sense to share them!

There should be no functional change, except the argument parsing will now complain in a couple of cases if we call it in a silly way (hopefully, we don't have any code doing that!)