### PR TITLE
Otbn trace

### DIFF
--- a/hw/ip/otbn/dv/tracer/README.md
+++ b/hw/ip/otbn/dv/tracer/README.md
@@ -1,0 +1,141 @@
+# OTBN Tracer
+
+The tracer consists of a module (`otbn_tracer.sv`) and an interface
+(`otbn_trace_intf.sv`). The interface is responsible for directly probing the
+design and implementing any basic tracking logic that is required. The module
+takes an instance of this interface and uses it to produce trace data.
+
+Trace output is provided to the simulation environment by calling the
+`accept_otbn_trace_string` function which is imported via DPI (the simulator
+environment provides its implementation). Each call to
+`accept_otbn_trace_string` provides a trace record and a cycle count. There is
+at most one call per cycle. Further details are below.
+
+A typical setup would bind an instantiation of `otbn_trace_intf` and
+`otbn_tracer` into `otbn_core` passing the `otbn_trace_intf` instance into the
+`otbn_tracer` instance. However this is no need for `otbn_tracer` to be bound
+into `otbn_core` provided it is given a `otbn_trace_intf` instance.
+
+## Trace Format
+
+Trace output is generated as a series of records. Each record consists of a
+number of lines that begin with a single character that identifies the category
+of the line and relate to activity occurring in the cycle the record is
+associated with.  The format following that within the line depends upon the
+category (see the XPrefix parameters below for the possible categories).
+
+A record may start with an 'E' or 'S' (instruction execute or stall) line, then
+has other lines.  Ordering for the other lines is not guaranteed. A record will
+never be empty. It is expected that all records begin with an 'E' or 'S' line. A
+record without an 'E' or 'S' line indicates a bug in OTBN. It is not the
+tracer's responsibility to detect bugs; the simulation environment should flag
+these as errors in a suitable way.
+
+Whilst the tracer does not aim to detect bugs there may be instances where the
+signals it traces do something unexpected that requires special behaviour. Where
+this happens 'ERR' will be placed somewhere in the line that contains
+information about the unexpected signals. See information on Memory Write (`W`)
+lines below for an example. 'ERR' will not be present in trace output for any
+other reason.
+
+### Record examples
+(The first line of each example illustrates the instruction being traced to aid the example and
+is not part of the record)
+
+Executing `BN.SID x26++, 0(x25)` at PC 0x00000158:
+```
+E PC: 0x00000158, insn: 0x01acd08b
+< w20: 0x78fccc06_2228e9d6_89c9b54f_887cf14e_c79af825_69be57d4_fecd21a1_b9dd0141
+< x25: 0x00000020
+< x26: 0x00000014
+> x26: 0x00000015
+W [0x00000020]: 0x78fccc06_2228e9d6_89c9b54f_887cf14e_c79af825_69be57d4_fecd21a1_b9dd0141
+```
+
+Executing `BN.ADD w3, w1, w2` at PC 0x000000e8:
+```
+E PC: 0x000000e8, insn: 0x002081ab
+< w01: 0x78fccc06_2228e9d6_89c9b54f_887cf14e_c79af825_69be586e_9866bb3b_53769ada
+< w02: 0x99999999_99999999_99999999_99999999_99999999_99999999_99999999_99999999
+> w03: 0x1296659f_bbc28370_23634ee9_22168ae8_613491bf_0357f208_320054d4_ed103473
+> FLAGS0: {C: 1, M: 0, L: 1, Z: 0}
+```
+
+## Line formats
+
+### Instruction Execute (`E`) and Stall (`S`) lines
+
+Indicates an instruction is executing or stalling. An 'E' line indicates the
+instruction completed in the trace record's cycle. An instruction that is
+stalled will first produce a record containing an 'S' line and will producing a
+matching 'E' line in a future record the cycle it unstalls and finishes. The
+line provides the PC and raw instruction bits. 
+
+Instruction at 0x0000014c is 0x01800d13 and stalling (a future record will
+contain a matching 'E' line):
+```
+S PC: 0x0000014c, insn: 0x01800d13
+```
+
+Instruction at 0x00000150 is 0x01acc10b is executing and will complete:
+```
+E PC: 0x00000150, insn: 0x01acc10b
+```
+
+### Register Read (`<`) and Write (`>`) lines
+
+Indicates data that has been read or written to either register files or special
+purpose registers (such as ACC or the bignum side flags).  The line provides the
+register name and the data read/written
+
+Register x26 was read and contained value 0x00000018:
+```
+< x26: 0x00000018
+```
+
+Register w24 had value
+`0xcccccccc_bbbbbbbb_aaaaaaaa_facefeed_deadbeef_cafed00d_d0beb533_1234abcd` 
+written to it:
+```
+> w24: 0xcccccccc_bbbbbbbb_aaaaaaaa_facefeed_deadbeef_cafed00d_d0beb533_1234abcd
+```
+
+Accumulator had value
+`0x00000000_00000000_00311bcb_5e157313_a2fd5453_c7eb58ce_1a1d070d_673963ce`
+written to it:
+```
+> ACC: 0x00000000_00000000_00311bcb_5e157313_a2fd5453_c7eb58ce_1a1d070d_673963ce
+```
+
+Flag group 0 had value `{C: 1, M: 1, L: 1, Z: 0}` written to it:
+```
+> FLAGS0: {C: 1, M: 1, L: 1, Z: 0}
+```
+
+### Memory Read (`R`) and Write (`W`) lines
+
+Indicates activity on the Dmem bus. The line provides the address and data
+written/read. For a read the data is always WLEN bits and the address is WLEN
+aligned (for an execution of LW only a 32-bit chunk of that data is required).
+For a write the write mask is examined. Where the mask indicates a bignum side
+write (BN.SID) full WLEN bit data is provided and the address is WLEN aligned.
+Where the mask indicates a base side write (SW) only 32-bit data is provided and
+the address is 32-bit aligned (giving the full address of the written chunk).
+
+Address `0x00000040` was read and contained value
+`0xcccccccc_bbbbbbbb_aaaaaaaa_facefeed_deadbeef_cafed00d_baadf00d_1234abcd`:
+```
+R [0x00000040]: 0xcccccccc_bbbbbbbb_aaaaaaaa_facefeed_deadbeef_cafed00d_baadf00d_1234abcd
+```
+
+Address `0x00000004` had value `0xd0beb533` written to it:
+```
+W [0x00000004]: 0xd0beb533
+```
+
+In the event of an OTBN bug that produces bad memory masks on writes (where the
+write is neither to a full 256 bits nor a aligned 32-bit chunk), an error line
+is produced giving the full mask and data
+```
+W [0x00000080]: Mask ERR Mask: 0xfffff800_0000ffff_ffffffff_00000000_00000000_00000000_00000000_00000000 Data: 0xcccccccc_bbbbbbbb_aaaaaaaa_facefeed_deadbeef_cafed00d_baadf00d_1234abcd
+```

--- a/hw/ip/otbn/dv/tracer/cpp/log_trace_listener.cc
+++ b/hw/ip/otbn/dv/tracer/cpp/log_trace_listener.cc
@@ -1,0 +1,66 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cassert>
+#include <iomanip>
+#include <ios>
+#include <sstream>
+#include <string>
+
+#include "log_trace_listener.h"
+
+LogTraceListener::LogTraceListener(const std::string &log_filename)
+    : trace_log(log_filename, std::fstream::out) {
+  if (!trace_log.is_open()) {
+    std::ostringstream oss;
+    oss << "Could not open log file: " << log_filename;
+    throw std::runtime_error(oss.str());
+  }
+}
+
+void LogTraceListener::AcceptTraceString(const std::string &trace,
+                                         unsigned int cycle_count) {
+  assert(trace_log.is_open());
+
+  // Split the trace up into a vector of strings, one per line
+  auto trace_lines = SplitTraceLines(trace);
+
+  // Write out the lines from the trace
+  bool first_line = true;
+  for (auto &line : trace_lines) {
+    if (first_line) {
+      if (line.size() > 1) {
+        // It is expected the first line of any trace output is an 'E' or 'S'
+        // line (instruction execute or instruction stall)
+        bool is_e_or_s_line = line[0] == 'E' || line[0] == 'S';
+
+        // Output the beginning of the first line adding a cycle count. A
+        // special '!' line, only giving the cycle count, is output if the first
+        // line isn't an 'E' or 'S' line.
+        std::ios old_state(nullptr);
+        old_state.copyfmt(trace_log);
+        trace_log << (is_e_or_s_line ? line[0] : '!') << " " << std::setw(9)
+                  << std::setfill('0') << cycle_count;
+        trace_log.copyfmt(old_state);
+
+        if (is_e_or_s_line) {
+          // If this is an expected 'E' or 'S' line write the rest of it out
+          trace_log << line.substr(1) << "\n";
+        } else {
+          // Otherwise leave the '!' line on it's own and dump this line out
+          // indented.
+          trace_log << "\n    " << line << "\n";
+        }
+      } else {
+        trace_log << "ERR: Bad line at " << cycle_count
+                  << " line should be more than 1 character: " << line << "\n";
+      }
+
+      first_line = false;
+    } else {
+      // All lines other than the first are indented.
+      trace_log << "    " << line << "\n";
+    }
+  }
+}

--- a/hw/ip/otbn/dv/tracer/cpp/log_trace_listener.h
+++ b/hw/ip/otbn/dv/tracer/cpp/log_trace_listener.h
@@ -1,0 +1,39 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_HW_IP_OTBN_DV_TRACER_CPP_LOG_TRACE_LISTENER_H_
+#define OPENTITAN_HW_IP_OTBN_DV_TRACER_CPP_LOG_TRACE_LISTENER_H_
+
+#include <fstream>
+#include <string>
+#include "otbn_trace_listener.h"
+
+/**
+ * An OTBNTraceListener that dumps the trace to a log file, with some minimal
+ * pretty printing.
+ *
+ * It examines the first line of any trace output, expecting it to be an 'E' or
+ * 'S' (execute or stall) line. If this is the case it adds a cycle count
+ * following the 'E' or 'S' and then dumps the trace. Lines that follow in the
+ * 'E' or 'S' line in the same clock cycle are indented by four spaces.
+ *
+ * If an 'E' or 'S' line isn't seen as the first line it prints a special '!'
+ * line that gives the cycle count and dumps the rest of the trace indented by
+ * four spaces.
+ */
+class LogTraceListener : public OTBNTraceListener {
+ private:
+  std::ofstream trace_log;
+
+ public:
+  /**
+   * Constructor that takes a log filename to write trace output to. It throws
+   * std::runtime_error if the file cannot be opened.
+   */
+  LogTraceListener(const std::string &log_filename);
+  void AcceptTraceString(const std::string &trace,
+                         unsigned int cycle_count) override;
+};
+
+#endif  // OPENTITAN_HW_IP_OTBN_DV_TRACER_CPP_LOG_TRACE_LISTENER_H_

--- a/hw/ip/otbn/dv/tracer/cpp/otbn_trace_listener.h
+++ b/hw/ip/otbn/dv/tracer/cpp/otbn_trace_listener.h
@@ -1,0 +1,49 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_HW_IP_OTBN_DV_TRACER_CPP_OTBN_TRACE_LISTENER_H_
+#define OPENTITAN_HW_IP_OTBN_DV_TRACER_CPP_OTBN_TRACE_LISTENER_H_
+
+#include <sstream>
+#include <string>
+#include <vector>
+
+/**
+ * Base class for anything that wants to examine trace output from OTBN. The
+ * simulation that hosts the tracer is responsible for setting up listeners and
+ * routing the DPI `accept_otbn_trace_string` calls to them.
+ */
+class OTBNTraceListener {
+ public:
+  /**
+   * Helper function to split an OTBN trace output up into individual lines.
+   *
+   * @param trace Trace output from OTBN
+   * @return A vector of lines from the trace
+   */
+  static std::vector<std::string> SplitTraceLines(const std::string &trace) {
+    std::stringstream trace_ss(trace);
+    std::string trace_line;
+
+    std::vector<std::string> trace_lines;
+
+    while (std::getline(trace_ss, trace_line, '\n')) {
+      trace_lines.push_back(trace_line);
+    }
+
+    return trace_lines;
+  }
+
+  /**
+   * Called to process an OTBN trace output, called a maximum of once per cycle
+   *
+   * @param trace Trace output from OTBN
+   * @param cycle_count The cycle count associated with the trace output
+   */
+  virtual void AcceptTraceString(const std::string &trace,
+                                 unsigned int cycle_count) = 0;
+  virtual ~OTBNTraceListener() {}
+};
+
+#endif  // OPENTITAN_HW_IP_OTBN_DV_TRACER_CPP_OTBN_TRACE_LISTENER_H_

--- a/hw/ip/otbn/dv/tracer/lint/otbn_tracer_waivers.vlt
+++ b/hw/ip/otbn/dv/tracer/lint/otbn_tracer_waivers.vlt
@@ -1,0 +1,14 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`verilator_config
+
+lint_off -rule BLKSEQ -file "*/otbn_tracer.sv" -match "*Blocking assignments (=) in sequential (flop or latch) block*"
+
+// Flag ISPR (3) has its own trace signals due to special handling
+lint_off -rule UNDRIVEN -file "*/otbn_trace_intf.sv" -match "*Bits of signal are not driven: 'ispr_*'[3]*"
+
+lint_off -rule UNUSED -file "*/otbn_trace_intf.sv" -match "*Bits of signal are not used: 'dmem_addr_o'*"
+lint_off -rule UNUSED -file "*/otbn_trace_intf.sv" -match "*Bits of signal are not used: 'insn_dec_shared'*"
+lint_off -rule UNUSED -file "*/otbn_trace_intf.sv" -match "*Bits of signal are not used: 'alu_bignum_operation'*"

--- a/hw/ip/otbn/dv/tracer/otbn_tracer.core
+++ b/hw/ip/otbn/dv/tracer/otbn_tracer.core
@@ -1,0 +1,27 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:ip:otbn_tracer"
+description: "Tracer for OTBN"
+
+filesets:
+  files_tracer:
+    depend:
+      - lowrisc:ip:otbn_pkg
+    files:
+      - cpp/otbn_trace_listener.h: { is_include_file: true, file_type: cppSource }
+      - cpp/log_trace_listener.h: { is_include_file: true, file_type: cppSource }
+      - cpp/log_trace_listener.cc: { file_type: cppSource }
+      - rtl/otbn_tracer.sv: { file_type: systemVerilogSource }
+      - rtl/otbn_trace_intf.sv: { file_type: systemVerilogSource }
+  files_verilator_waiver:
+    files:
+      - lint/otbn_tracer_waivers.vlt
+    file_type: vlt
+
+targets:
+  default:
+    filesets:
+      - files_tracer
+      - tool_verilator ? (files_verilator_waiver)

--- a/hw/ip/otbn/dv/tracer/rtl/otbn_trace_intf.sv
+++ b/hw/ip/otbn/dv/tracer/rtl/otbn_trace_intf.sv
@@ -1,0 +1,210 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Interface designed to be bound into otbn_core and extract out signals useful for the tracer.
+ *
+ * The tracer takes an instance of this interface as one of its module ports. The tracer will
+ * examine both inputs to this interface as well as signals created within it. This interface is
+ * quite messy, it is built following the principles below that lead to its current design:
+ *
+ * 1. Producing suitable signals for a tracer from internal design signals can be a messy/fiddly
+ *    process. Anything that is messy/fiddly should be confined to this file if at all possible so
+ *    the tracer itself can be cleanly written.
+ * 2. Aim to provide signals from interface to the tracer with clear consistent naming, this may
+ *    result in situations where this interface simply renames an existing otbn_core signal (by
+ *    bringing it in via an input and then assigning it to an internal signal).
+ * 3. Hierarchical references can only refer to modules inside otbn_core, not otbn_core itself as
+ *    this requires assuming the instance name of otbn_core (which could vary from environment to
+ *    environment).
+ * 4. To use a signal from the otbn_core module, name it as an input with the name used in
+ *    otbn_core.  Whatever binds the interface into otbn_core is responsible for connecting these
+ *    up, e.g. using a wildcard '.*'.
+ */
+interface otbn_trace_intf #(
+  parameter int ImemAddrWidth,
+  parameter int DmemAddrWidth,
+  parameter otbn_pkg::regfile_e RegFile = otbn_pkg::RegFileFF
+)(
+  input logic clk_i,
+  input logic rst_ni,
+
+  input logic [4:0] rf_base_rd_addr_a,
+  input logic [4:0] rf_base_rd_addr_b,
+  input logic [4:0] rf_base_wr_addr,
+
+  input logic rf_base_rd_en_a,
+  input logic rf_base_rd_en_b,
+  input logic rf_base_wr_en,
+
+  input logic [31:0] rf_base_rd_data_a,
+  input logic [31:0] rf_base_rd_data_b,
+  input logic [31:0] rf_base_wr_data,
+
+  input logic [WdrAw-1:0] rf_bignum_rd_addr_a,
+  input logic [WdrAw-1:0] rf_bignum_rd_addr_b,
+  input logic [WdrAw-1:0] rf_bignum_wr_addr,
+
+  input logic [otbn_pkg::WLEN-1:0] rf_bignum_rd_data_a,
+  input logic [otbn_pkg::WLEN-1:0] rf_bignum_rd_data_b,
+
+  input logic [31:0]              insn_fetch_resp_data,
+  input logic [ImemAddrWidth-1:0] insn_fetch_resp_addr,
+  input logic                     insn_fetch_resp_valid,
+
+  input logic                      dmem_req_o,
+  input logic                      dmem_write_o,
+  input logic [DmemAddrWidth-1:0]  dmem_addr_o,
+  input logic [otbn_pkg::WLEN-1:0] dmem_wdata_o,
+  input logic [otbn_pkg::WLEN-1:0] dmem_wmask_o,
+  input logic [otbn_pkg::WLEN-1:0] dmem_rdata_i,
+
+  input otbn_pkg::ispr_e                 ispr_addr,
+  input otbn_pkg::insn_dec_shared_t      insn_dec_shared,
+  input otbn_pkg::alu_bignum_operation_t alu_bignum_operation,
+  input logic                            mac_bignum_en,
+
+  input logic [otbn_pkg::WLEN-1:0] rnd
+);
+  import otbn_pkg::*;
+
+  localparam int DmemSubWordAddrWidth = prim_util_pkg::vbits(WLEN/8);
+
+  logic rf_ren_a_bignum;
+  logic rf_ren_b_bignum;
+
+  // Read enables for bignum are only inside the decoder with the current design, so bring them out
+  // here for access by the tracer.
+  assign rf_ren_a_bignum = u_otbn_decoder.rf_ren_a_bignum;
+  assign rf_ren_b_bignum = u_otbn_decoder.rf_ren_b_bignum;
+
+  // The bignum register file is capable of half register writes. To avoid the tracer having to deal
+  // with this, slightly modified rf_bignum_wr_en and rf_bignum_wr_data signals are provided here.
+  // If there is a half-word write the other half of the register is taken directly from the
+  // register file and both halves are presented as the write data to the tracer. `rf_bignum_wr_en`
+  // becomes a single bit signal because of this.
+  logic            rf_bignum_wr_en;
+  logic [WLEN-1:0] rf_bignum_wr_data;
+
+  assign rf_bignum_wr_en = |u_otbn_controller.rf_bignum_wr_en_o;
+
+  logic [WLEN-1:0] rf_bignum_wr_old_data;
+
+  if (RegFile == RegFileFF) begin : g_rf_ff_bignum_wr_old_data
+    assign rf_bignum_wr_old_data = gen_rf_bignum_ff.u_otbn_rf_bignum.rf[rf_bignum_wr_addr];
+  end else if (RegFile == RegFileFPGA) begin : g_rf_fpga_bignum_wr_old_data
+    assign rf_bignum_wr_old_data = gen_rf_bignum_fpga.u_otbn_rf_bignum.rf[rf_bignum_wr_addr];
+  end
+
+  for (genvar i = 0; i < 2; i++) begin : g_rf_bignum_wr_data
+    assign rf_bignum_wr_data[(WLEN/2)*i +: WLEN/2] = u_otbn_controller.rf_bignum_wr_en_o[i] ?
+      u_otbn_controller.rf_bignum_wr_data_o[(WLEN/2)*i +: WLEN/2] :
+      rf_bignum_wr_old_data[(WLEN/2)*i +: WLEN/2];
+  end
+
+  // `insn_stall` isn't a signal that exists in the design so needs creating here. To keep things
+  // consistent `insn_X` signals are provided here that are simply assigned to `otbn_core` signals.
+  // To prevent the tracer needing to deal with differing Imem sizes the address is padded out to
+  // 32-bits.
+  logic        insn_valid;
+  logic [31:0] insn_addr;
+  logic [31:0] insn_data;
+  logic        insn_stall;
+
+  assign insn_valid = insn_fetch_resp_valid;
+  assign insn_addr  = {{(32-ImemAddrWidth){1'b0}}, insn_fetch_resp_addr};
+  assign insn_data  = insn_fetch_resp_data;
+  assign insn_stall = u_otbn_core.u_otbn_controller.state_d == OtbnStateStall;
+
+  // Take Dmem interface and present it as two seperate read and write sets of signals. To ease
+  // tracer implementation a small tracker tracks reads so the whole transaction (address + data
+  // together) is presented in a single cycle.
+  logic [31:0]     dmem_wlen_aligned_addr;
+
+  logic            dmem_write;
+  logic [31:0]     dmem_write_addr;
+  logic [WLEN-1:0] dmem_write_data;
+  logic [WLEN-1:0] dmem_write_mask;
+
+  logic            dmem_read;
+  logic [31:0]     dmem_read_addr;
+  logic [WLEN-1:0] dmem_read_data;
+
+  assign dmem_wlen_aligned_addr = {{(32-DmemAddrWidth){1'b0}},
+                                   dmem_addr_o[DmemAddrWidth-1:DmemSubWordAddrWidth],
+                                   {DmemSubWordAddrWidth{1'b0}}};
+  assign dmem_write      = dmem_req_o & dmem_write_o;
+  assign dmem_write_addr = dmem_wlen_aligned_addr;
+
+  assign dmem_write_data = dmem_wdata_o;
+  assign dmem_write_mask = dmem_wmask_o;
+
+  // TODO: Tracing for read errors
+  assign dmem_read_data  = dmem_rdata_i;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      dmem_read      <= 1'b0;
+      dmem_read_addr <= '0;
+    end else begin
+      dmem_read      <= dmem_req_o & ~dmem_write_o;
+      dmem_read_addr <= dmem_wlen_aligned_addr;
+    end
+  end
+
+  // ISPRs all have slightly different implementations and each have their own specific read/write
+  // sources. This presents a uniform interface for all ispr reads/writes, excluding flags, as it's
+  // useful to present those differently so seperate signals are provided for the tracing of them.
+  logic [NIspr-1:0] ispr_write;
+  logic [WLEN-1:0]  ispr_write_data [NIspr];
+  logic [NIspr-1:0] ispr_read;
+  logic [WLEN-1:0]  ispr_read_data [NIspr];
+
+  logic any_ispr_read;
+
+  assign any_ispr_read = (insn_dec_shared.ispr_rw_insn | insn_dec_shared.ispr_rs_insn) & insn_fetch_resp_valid;
+
+  assign ispr_write[IsprMod] = |u_otbn_alu_bignum.mod_wr_en;
+
+  for (genvar i_word = 0; i_word < BaseWordsPerWLEN; i_word++) begin : g_mod_words
+    assign ispr_write_data[IsprMod][i_word*32+:32] =
+      u_otbn_alu_bignum.mod_wr_en[i_word] ? u_otbn_alu_bignum.mod_d[i_word*32+:32] :
+                                            u_otbn_alu_bignum.mod_q[i_word*32+:32];
+  end
+
+  assign ispr_read[IsprMod] = (any_ispr_read & (ispr_addr == IsprMod)) |
+    (alu_bignum_operation.op inside {AluOpBignumAddm, AluOpBignumSubm});
+
+  assign ispr_read_data[IsprMod] = u_otbn_alu_bignum.mod_q;
+
+  assign ispr_write[IsprAcc] = u_otbn_mac_bignum.acc_en;
+  assign ispr_write_data[IsprAcc] = u_otbn_mac_bignum.acc_d;
+
+  assign ispr_read[IsprAcc] = (any_ispr_read & (ispr_addr == IsprAcc)) | mac_bignum_en;
+  assign ispr_read_data[IsprAcc] = u_otbn_mac_bignum.acc;
+
+  assign ispr_write[IsprRnd] = 1'b0;
+  assign ispr_write_data[IsprRnd] = '0;
+
+  assign ispr_read[IsprRnd] = any_ispr_read & (ispr_addr == IsprRnd);
+  assign ispr_read_data[IsprRnd] = rnd;
+
+  // Seperate per flag group tracking using the flags_t struct so tracer can cleanly present flag
+  // accesses.
+  logic [NFlagGroups-1:0] flags_write;
+  flags_t                 flags_write_data [NFlagGroups];
+  logic [NFlagGroups-1:0] flags_read;
+  flags_t                 flags_read_data [NFlagGroups];
+
+  for (genvar i_fg = 0; i_fg < NFlagGroups; i_fg++) begin : g_flag_group_acceses
+    assign flags_write[i_fg] = u_otbn_alu_bignum.flags_en[i_fg];
+    assign flags_write_data[i_fg] = u_otbn_alu_bignum.flags_d[i_fg];
+
+    assign flags_read[i_fg] = (any_ispr_read & (ispr_addr == IsprFlags)) |
+        ((alu_bignum_operation.op inside {AluOpBignumAddc, AluOpBignumSubb, AluOpBignumSel}) &
+         (alu_bignum_operation.flag_group == i_fg) & insn_fetch_resp_valid);
+
+    assign flags_read_data[i_fg] = u_otbn_alu_bignum.flags_q[i_fg];
+  end
+endinterface

--- a/hw/ip/otbn/dv/tracer/rtl/otbn_tracer.sv
+++ b/hw/ip/otbn/dv/tracer/rtl/otbn_tracer.sv
@@ -1,0 +1,219 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tracer module for OTBN. This produces a multi-line string as trace output at most once every
+ * cycle and provides it to the simulation environment via a DPI call. It uses `otbn_trace_intf` to
+ * get the information it needs. For further information see `hw/ip/otbn/dv/tracer/README.md`.
+ */
+module otbn_tracer
+(
+  input  logic  clk_i,
+  input  logic  rst_ni,
+
+  otbn_trace_intf otbn_trace
+);
+  import otbn_pkg::*;
+
+  // Prefixes used in trace lines. Formats are documented in `hw/ip/otbn/dv/tracer/README.md`
+  parameter string InsnExecutePrefix = "E";
+  parameter string InsnStallPrefix = "S";
+  parameter string RegReadPrefix = "<";
+  parameter string RegWritePrefix = ">";
+  parameter string MemWritePrefix = "W";
+  parameter string MemReadPrefix = "R";
+
+  string trace_output_buffer;
+
+  logic [31:0] cycle_count;
+
+  // Given a WLEN size word output a hex string with the data split into 32-bit chunks separated
+  // with '_'. WLEN must be a multiple of 32.
+  function automatic string otbn_wlen_data_str(logic [WLEN-1:0] data);
+    string data_str;
+
+    assert ((WLEN % 32) == 0) else $error("WLEN must be a multiple of 32 in otbn_wlen_data_str");
+
+    for (int i = WLEN; i > 0; i-= 32) begin
+      if (i != WLEN) begin
+        data_str = $sformatf("%s_", data_str);
+      end else begin
+        data_str = "0x";
+      end
+
+      data_str = $sformatf("%s%08x", data_str, data[i-1 -: 32]);
+    end
+
+    return data_str;
+  endfunction
+
+  // Produce trace output string for dmem writes. For a 256-bit write, the address and full data is
+  // output. For 32-bit writes (determined by looking at the mask) only the relevant 32-bit chunk is
+  // output along with the address modified so it refers to that chunk.
+  function automatic string otbn_dmem_write_str(logic [31:0] addr,
+                                                logic [WLEN-1:0] data,
+                                                logic [WLEN-1:0] wmask);
+
+    logic [WLEN-1:0] cur_base_mask;
+
+    // For a full WLEN write output all of the data.
+    if (wmask == '1) begin
+      return $sformatf("[0x%08x]: %s", addr, otbn_wlen_data_str(data));
+    end
+
+    // Iterate through the possible 32-bit chunks
+    cur_base_mask = {{(WLEN-32){1'b0}}, 32'hFFFF_FFFF};
+
+    for (int i = 0; i < WLEN; i += 32) begin
+      // If mask matches current chunk alone output trace indicating a single 32-bit write.
+      if (wmask == cur_base_mask) begin
+        return $sformatf("[0x%08x]: 0x%08x", addr + (i / 8), data[i*32 +: 32]);
+      end
+
+      cur_base_mask = cur_base_mask << 32;
+    end
+
+    // Fallback where mask isn't as expected, indicate ERR in the trace and provide both full mask
+    // and data.
+    return $sformatf("[0x%08x]: Mask ERR Mask: %s Data: %s", addr, otbn_wlen_data_str(wmask),
+      otbn_wlen_data_str(data));
+  endfunction
+
+  // Determine name for an ISPR
+  function automatic string otbn_ispr_name_str(ispr_e ispr);
+    unique case (ispr)
+      IsprMod: return "MOD";
+      IsprAcc: return "ACC";
+      IsprRnd: return "RND";
+      IsprFlags: return "FLAGS";
+    endcase
+
+    return "UNKNOWN_ISPR";
+  endfunction
+
+  // Format flag information into a string
+  function automatic string otbn_flags_str(flags_t f);
+    return $sformatf("{C: %d, M: %d, L: %d, Z: %d}", f.C, f.M, f.L, f.Z);
+  endfunction
+
+  // Called by other trace functions to append their trace lines to the output buffer
+  function automatic void output_trace(string prefix, string trace_line);
+    trace_output_buffer = $sformatf("%s%s %s\n", trace_output_buffer, prefix, trace_line);
+  endfunction
+
+  function automatic void trace_base_rf();
+    if (otbn_trace.rf_base_rd_en_a) begin
+      output_trace(RegReadPrefix, $sformatf("x%02d: 0x%08x", otbn_trace.rf_base_rd_addr_a,
+                                            otbn_trace.rf_base_rd_data_a));
+    end
+
+    if (otbn_trace.rf_base_rd_en_b) begin
+      output_trace(RegReadPrefix, $sformatf("x%02d: 0x%08x", otbn_trace.rf_base_rd_addr_b,
+                                            otbn_trace.rf_base_rd_data_b));
+    end
+
+    if (otbn_trace.rf_base_wr_en) begin
+      output_trace(RegWritePrefix, $sformatf("x%02d: 0x%08x", otbn_trace.rf_base_wr_addr,
+                                             otbn_trace.rf_base_wr_data));
+    end
+  endfunction
+
+  function automatic void trace_bignum_rf();
+    if (otbn_trace.rf_ren_a_bignum) begin
+      output_trace(RegReadPrefix, $sformatf("w%02d: %s", otbn_trace.rf_bignum_rd_addr_a,
+                                            otbn_wlen_data_str(otbn_trace.rf_bignum_rd_data_a)));
+    end
+
+    if (otbn_trace.rf_ren_b_bignum) begin
+      output_trace(RegReadPrefix, $sformatf("w%02d: %s", otbn_trace.rf_bignum_rd_addr_b,
+                                            otbn_wlen_data_str(otbn_trace.rf_bignum_rd_data_b)));
+    end
+
+    if (otbn_trace.rf_bignum_wr_en) begin
+      output_trace(RegWritePrefix, $sformatf("w%02d: %s", otbn_trace.rf_bignum_wr_addr,
+                                             otbn_wlen_data_str(otbn_trace.rf_bignum_wr_data)));
+    end
+  endfunction
+
+  function automatic void trace_bignum_mem();
+    if (otbn_trace.dmem_write) begin
+      output_trace(MemWritePrefix, otbn_dmem_write_str(otbn_trace.dmem_write_addr,
+                                                       otbn_trace.dmem_write_data,
+                                                       otbn_trace.dmem_write_mask));
+    end
+
+    if (otbn_trace.dmem_read) begin
+      output_trace(MemReadPrefix, $sformatf("[0x%08x]: %s", otbn_trace.dmem_read_addr,
+                                            otbn_wlen_data_str(otbn_trace.dmem_read_data)));
+    end
+  endfunction
+
+  function automatic void trace_ispr_accesses();
+    // Iterate through all ISPRs outputting reg reads and writes where ISPR accesses have occurred
+    for (int i_ispr = 0; i_ispr < NIspr; i_ispr++) begin
+      if (ispr_e'(i_ispr) == IsprFlags) begin
+        // Special handling for flags ISPR to provide per flag field output
+        for (int i_fg = 0; i_fg < NFlagGroups; i_fg++) begin
+          if (otbn_trace.flags_read[i_fg]) begin
+            output_trace(RegReadPrefix,
+                         $sformatf("%s%1d: %s", otbn_ispr_name_str(ispr_e'(i_ispr)), i_fg,
+                                   otbn_flags_str(otbn_trace.flags_read_data[i_fg])));
+          end
+
+          if (otbn_trace.flags_write[i_fg]) begin
+            output_trace(RegWritePrefix,
+                         $sformatf("%s%1d: %s", otbn_ispr_name_str(ispr_e'(i_ispr)), i_fg,
+                                   otbn_flags_str(otbn_trace.flags_write_data[i_fg])));
+          end
+        end
+      end else begin
+        // For all other ISPRs just dump out the full 256-bits of data being read/written
+        if (otbn_trace.ispr_read[i_ispr]) begin
+          output_trace(RegReadPrefix,
+                       $sformatf("%s: %s", otbn_ispr_name_str(ispr_e'(i_ispr)),
+                                 otbn_wlen_data_str(otbn_trace.ispr_read_data[i_ispr])));
+        end
+
+        if (otbn_trace.ispr_write[i_ispr]) begin
+          output_trace(RegWritePrefix,
+                       $sformatf("%s: %s", otbn_ispr_name_str(ispr_e'(i_ispr)),
+                                 otbn_wlen_data_str(otbn_trace.ispr_write_data[i_ispr])));
+        end
+      end
+    end
+  endfunction
+
+  function automatic void trace_insn();
+    if (otbn_trace.insn_valid) begin
+      output_trace(otbn_trace.insn_stall ? InsnStallPrefix : InsnExecutePrefix,
+                   $sformatf("PC: 0x%08x, insn: 0x%08x", otbn_trace.insn_addr,
+                             otbn_trace.insn_data));
+    end
+  endfunction
+
+  import "DPI-C" function void accept_otbn_trace_string(string trace, int unsigned cycle_count);
+
+  function automatic void do_trace();
+    trace_output_buffer = "";
+
+    trace_insn();
+    trace_bignum_rf();
+    trace_base_rf();
+    trace_bignum_mem();
+    trace_ispr_accesses();
+
+    if (trace_output_buffer != "") begin
+      accept_otbn_trace_string(trace_output_buffer, cycle_count);
+    end
+  endfunction
+
+  always @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      cycle_count <= '0;
+    end else begin
+      cycle_count <= cycle_count + 1'b1;
+      do_trace();
+    end
+  end
+endmodule

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.cc
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.cc
@@ -127,20 +127,14 @@ int main(int argc, char **argv) {
   simctrl.RegisterExtension(&memutil);
   simctrl.RegisterExtension(&traceutil);
 
-  bool exit_app = false;
-  int ret_code = simctrl.ParseCommandArgs(argc, argv, exit_app);
-  if (exit_app) {
-    return ret_code;
-  }
-
   std::cout << "Simulation of OTBN" << std::endl
             << "==================" << std::endl
             << std::endl;
 
-  simctrl.RunSimulation();
+  int ret_code = simctrl.Exec(argc, argv);
 
-  if (!simctrl.WasSimulationSuccessful()) {
-    return 1;
+  if (ret_code != 0) {
+    return ret_code;
   }
 
   svSetScope(svGetScopeFromName("TOP.otbn_top_sim"));

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.core
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.core
@@ -10,6 +10,7 @@ filesets:
     depend:
       - lowrisc:ip:otbn
       - lowrisc:dv:otbn_model
+      - lowrisc:ip:otbn_tracer
   files_verilator:
     depend:
       - lowrisc:dv:otbn_memutil

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -69,6 +69,9 @@ module otbn_top_sim (
     .dmem_rerror_i ( dmem_rerror   )
   );
 
+  bind otbn_core otbn_trace_intf #(.ImemAddrWidth, .DmemAddrWidth) i_otbn_trace_intf (.*);
+  bind otbn_core otbn_tracer u_otbn_tracer(.*, .otbn_trace(i_otbn_trace_intf));
+
   // Pulse otbn_start for 1 cycle immediately out of reset
   always @(posedge IO_CLK or negedge IO_RST_N) begin
     if(!IO_RST_N) begin

--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -103,12 +103,6 @@ module otbn_controller
 
   logic done_d, done_q;
 
-  typedef enum logic [1:0] {
-    OtbnStateHalt,
-    OtbnStateRun,
-    OtbnStateStall
-  } otbn_state_e;
-
   otbn_state_e state_q, state_d;
 
   logic stall;

--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -329,5 +329,11 @@ package otbn_pkg;
     logic            shift_acc;
   } mac_bignum_operation_t;
 
+  // States for controller state machine
+  typedef enum logic [1:0] {
+    OtbnStateHalt,
+    OtbnStateRun,
+    OtbnStateStall
+  } otbn_state_e;
 
 endpackage


### PR DESCRIPTION
Here's a sample of the trace log output from the smoke test:

```
E 000000075 PC: 0x0000012c, insn: 0x7c002c73
    < x00: 0x00000000
    > x24: 0x00000055
    < FLAGS0: {C: 1, M: 0, L: 1, Z: 0}
    > FLAGS0: {C: 0, M: 0, L: 0, Z: 1}
    < FLAGS1: {C: 1, M: 0, L: 1, Z: 0}
    > FLAGS1: {C: 0, M: 0, L: 0, Z: 1}
E 000000076 PC: 0x00000130, insn: 0x2220892b
    < w01: 0x78fccc06_2228e9d6_89c9b54f_887cf14e_c79af825_69be586e_9866bb3b_53769ada
    < w02: 0x99999999_99999999_99999999_99999999_99999999_99999999_99999999_99999999
    > w18: 0x1296659f_bbc28370_23634ee9_22168a4e_c79af825_69be586e_9866bb3b_53769ada
    > FLAGS0: {C: 1, M: 0, L: 0, Z: 0}
E 000000077 PC: 0x00000134, insn: 0x1220a9fb
    < w01: 0x78fccc06_2228e9d6_89c9b54f_887cf14e_c79af825_69be586e_9866bb3b_53769ada
    < w02: 0x99999999_99999999_99999999_99999999_99999999_99999999_99999999_99999999
    > w19: 0x18988800_00088990_89899109_88189108_81989801_09981800_00000000_00000000
    > FLAGS0: {C: 1, M: 0, L: 0, Z: 0}
E 000000078 PC: 0x00000138, insn: 0x6e209a2b
    < w01: 0x78fccc06_2228e9d6_89c9b54f_887cf14e_c79af825_69be586e_9866bb3b_53769ada
    < w02: 0x99999999_99999999_99999999_99999999_99999999_99999999_99999999_99999999
    > w20: 0x78fccc06_2228e9d6_89c9b54f_887cf14e_c79af825_69be57d4_fecd21a1_b9dd0141
    > FLAGS0: {C: 0, M: 0, L: 1, Z: 0}
E 000000079 PC: 0x0000013c, insn: 0x5e20cafb
    < w01: 0x78fccc06_2228e9d6_89c9b54f_887cf14e_c79af825_69be586e_9866bb3b_53769ada
    < w02: 0x99999999_99999999_99999999_99999999_99999999_99999999_99999999_99999999
    > w21: 0x78fccc06_2228e9d6_89c9b54f_887cf1df_df9bf9bd_f9bfd9ff_99ffbbbb_dbff9bdb
    > FLAGS0: {C: 0, M: 0, L: 1, Z: 0}
E 000000080 PC: 0x00000140, insn: 0x1bdacb2b
    < w21: 0x78fccc06_2228e9d6_89c9b54f_887cf1df_df9bf9bd_f9bfd9ff_99ffbbbb_dbff9bdb
    > w22: 0x78fccc06_2228e9d6_89c9b54f_887cf1df_df9bf9bd_f9bfd9ff_99ffbbbb_dbff9d98
    > FLAGS0: {C: 0, M: 0, L: 0, Z: 0}
E 000000081 PC: 0x00000144, insn: 0x607acbab
    < w21: 0x78fccc06_2228e9d6_89c9b54f_887cf1df_df9bf9bd_f9bfd9ff_99ffbbbb_dbff9bdb
    > w23: 0x78fccc06_2228e9d6_89c9b54f_887cf1df_df9bf9bd_f9bfd9ff_99ffbbbb_dbff99d4
    > FLAGS0: {C: 0, M: 0, L: 0, Z: 0}
E 000000082 PC: 0x00000148, insn: 0x00000c93
    < x00: 0x00000000
    > x25: 0x00000000
E 000000083 PC: 0x0000014c, insn: 0x01800d13
    < x00: 0x00000000
    > x26: 0x00000018
E 000000084 PC: 0x00000150, insn: 0x01acc10b
    < x25: 0x00000000
    < x26: 0x00000018
S 000000085 PC: 0x00000150, insn: 0x01acc10b
    > w24: 0xcccccccc_bbbbbbbb_aaaaaaaa_facefeed_deadbeef_cafed00d_d0beb533_1234abcd
    < x25: 0x00000000
    < x26: 0x00000018
    > x25: 0x00000020
    R [0x00000000]: 0xcccccccc_bbbbbbbb_aaaaaaaa_facefeed_deadbeef_cafed00d_d0beb533_1234abcd
E 000000086 PC: 0x00000154, insn: 0x01400d13
    < x00: 0x00000000
    > x26: 0x00000014
E 000000087 PC: 0x00000158, insn: 0x01acd08b
    < w20: 0x78fccc06_2228e9d6_89c9b54f_887cf14e_c79af825_69be57d4_fecd21a1_b9dd0141
    < x25: 0x00000020
    < x26: 0x00000014
    > x26: 0x00000015
    W 0x[00000020]: 0x78fccc06_2228e9d6_89c9b54f_887cf14e_c79af825_69be57d4_fecd21a1_b9dd0141
```

Note the log file output has a small amount of formatting applied by the log file listener so the raw output that's received via the DPI call looks like this:

```
E PC: 0x0000012c, insn: 0x7c002c73
< x00: 0x00000000
> x24: 0x00000055
< FLAGS0: {C: 1, M: 0, L: 1, Z: 0}
> FLAGS0: {C: 0, M: 0, L: 0, Z: 1}
< FLAGS1: {C: 1, M: 0, L: 1, Z: 0}
> FLAGS1: {C: 0, M: 0, L: 0, Z: 1}
E PC: 0x00000130, insn: 0x2220892b
< w01: 0x78fccc06_2228e9d6_89c9b54f_887cf14e_c79af825_69be586e_9866bb3b_53769ada
< w02: 0x99999999_99999999_99999999_99999999_99999999_99999999_99999999_99999999
> w18: 0x1296659f_bbc28370_23634ee9_22168a4e_c79af825_69be586e_9866bb3b_53769ada
> FLAGS0: {C: 1, M: 0, L: 0, Z: 0}
...
```

No indentation and the 'E' and 'S' lines don't have cycle counts with them (they're passed as a separate parameter to the DPI call)

The formatting of each trace line is in part derived from @imphil's suggestion it would be useful to be able to produce json log files. Currently you'd need some minor regex search/replace to get things into a format you could easily dump to json.