### PR TITLE
[otbn] Core file update

### DIFF
--- a/hw/ip/otbn/otbn.core
+++ b/hw/ip/otbn/otbn.core
@@ -37,7 +37,7 @@ filesets:
       - lowrisc:prim:util
       - lowrisc:prim:ram_1p_adv
       - lowrisc:ip:otbn_pkg
-      - lowrisc:dv:otbn_model
+      - "!tool_ascentlint ? (lowrisc:dv:otbn_model)"
     files:
       - rtl/otbn_reg_pkg.sv
       - rtl/otbn_reg_top.sv


### PR DESCRIPTION
- do not depend on otbn model when running lint.

Signed-off-by: Timothy Chen <timothytim@google.com>