### PR TITLE
[top] Support power domains

### DIFF
--- a/hw/ip/rstmgr/data/rstmgr.hjson
+++ b/hw/ip/rstmgr/data/rstmgr.hjson
@@ -11,10 +11,10 @@
   clock_primary: "clk_i",
   other_clock_list: [
     "clk_aon_i"
-    "clk_io_div2_i"
+    "clk_io_div4_i"
     "clk_main_i"
     "clk_io_i"
-    "clk_io_div4_i"
+    "clk_io_div2_i"
     "clk_usb_i"
   ],
   bus_device: "tlul",

--- a/hw/ip/rstmgr/data/rstmgr_pkg.sv.tpl
+++ b/hw/ip/rstmgr/data/rstmgr_pkg.sv.tpl
@@ -8,14 +8,13 @@
 
 package rstmgr_pkg;
 
-  // global constants
-  parameter int ALWAYS_ON_SEL   = pwrmgr_pkg::ALWAYS_ON_DOMAIN;
+  // Power domain parameters
+  parameter int PowerDomains = ${len(power_domains)};
+  % for power_domain in power_domains:
+  parameter int Domain${power_domain}Sel = ${loop.index};
+  % endfor
 
-  // params that reference pwrmgr, should be replaced once pwrmgr is merged
-  parameter int PowerDomains  = pwrmgr_pkg::PowerDomains;
-  //parameter int HwResetReqs   = pwrmgr_pkg::NumRstReqs;
-
-  // calculated domains
+  // Number of non-always-on domains
   parameter int OffDomains = PowerDomains-1;
 
   // positions of software controllable reset bits
@@ -37,7 +36,7 @@ package rstmgr_pkg;
   // This should be templatized and generated
   typedef struct packed {
 % for rst in output_rsts:
-    logic rst_${rst['name']}_n;
+    logic [PowerDomains-1:0] rst_${rst['name']}_n;
 % endfor
   } rstmgr_out_t;
 
@@ -52,7 +51,7 @@ package rstmgr_pkg;
   typedef struct packed {
   % for ep, rsts in eps.items():
     % for rst in rsts:
-    logic rst_${intf}_${ep}_${rst}_n;
+    logic [PowerDomains-1:0] rst_${intf}_${ep}_${rst}_n;
     % endfor
   % endfor
   } rstmgr_${intf}_out_t;

--- a/hw/ip/rstmgr/rtl/rstmgr_ctrl.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr_ctrl.sv
@@ -18,12 +18,6 @@ module rstmgr_ctrl import rstmgr_pkg::*; #(
   output logic [PowerDomains-1:0] rst_no
 );
 
-  // The code below always assumes the always on domain is index 0
-  `ASSERT_INIT(AlwaysOnIndex_A, ALWAYS_ON_SEL == 0)
-
-  // when there are multiple on domains, the latter 1 should become another parameter
-  localparam int OffDomainSelStart = ALWAYS_ON_SEL + 1;
-
   // the always on root reset
   logic rst_aon_nq;
 
@@ -47,16 +41,15 @@ module rstmgr_ctrl import rstmgr_pkg::*; #(
   prim_flop u_aon_rst (
     .clk_i,
     .rst_ni,
-    .d_i(~rst_req_i[ALWAYS_ON_SEL] & rst_parent_synced[ALWAYS_ON_SEL]),
+    .d_i(~rst_req_i[DomainAonSel] & rst_parent_synced[DomainAonSel]),
     .q_o(rst_aon_nq)
   );
-
 
   // the non-always-on domains
   // These reset whenever the always on domain reset, to ensure power definition consistency.
   // By extension, they also reset whenever the root (rst_ni) resets
-  assign rst_pd_nd = ~rst_req_i[OffDomainSelStart +: OffDomains] &
-                     rst_parent_synced[OffDomainSelStart +: OffDomains];
+  assign rst_pd_nd = ~rst_req_i[Domain0Sel +: OffDomains] &
+                     rst_parent_synced[Domain0Sel +: OffDomains];
 
   prim_flop u_pd_rst (
     .clk_i,

--- a/hw/ip/rstmgr/rtl/rstmgr_pkg.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr_pkg.sv
@@ -8,14 +8,12 @@
 
 package rstmgr_pkg;
 
-  // global constants
-  parameter int ALWAYS_ON_SEL   = pwrmgr_pkg::ALWAYS_ON_DOMAIN;
+  // Power domain parameters
+  parameter int PowerDomains = 2;
+  parameter int DomainAonSel = 0;
+  parameter int Domain0Sel = 1;
 
-  // params that reference pwrmgr, should be replaced once pwrmgr is merged
-  parameter int PowerDomains  = pwrmgr_pkg::PowerDomains;
-  //parameter int HwResetReqs   = pwrmgr_pkg::NumRstReqs;
-
-  // calculated domains
+  // Number of non-always-on domains
   parameter int OffDomains = PowerDomains-1;
 
   // positions of software controllable reset bits
@@ -35,20 +33,20 @@ package rstmgr_pkg;
   // resets generated and broadcast
   // This should be templatized and generated
   typedef struct packed {
-    logic rst_por_aon_n;
-    logic rst_por_n;
-    logic rst_por_io_n;
-    logic rst_por_io_div2_n;
-    logic rst_por_io_div4_n;
-    logic rst_por_usb_n;
-    logic rst_lc_n;
-    logic rst_lc_io_n;
-    logic rst_sys_n;
-    logic rst_sys_io_n;
-    logic rst_sys_io_div4_n;
-    logic rst_sys_aon_n;
-    logic rst_spi_device_n;
-    logic rst_usb_n;
+    logic [PowerDomains-1:0] rst_por_aon_n;
+    logic [PowerDomains-1:0] rst_por_n;
+    logic [PowerDomains-1:0] rst_por_io_n;
+    logic [PowerDomains-1:0] rst_por_io_div2_n;
+    logic [PowerDomains-1:0] rst_por_io_div4_n;
+    logic [PowerDomains-1:0] rst_por_usb_n;
+    logic [PowerDomains-1:0] rst_lc_n;
+    logic [PowerDomains-1:0] rst_lc_io_div4_n;
+    logic [PowerDomains-1:0] rst_sys_n;
+    logic [PowerDomains-1:0] rst_sys_io_n;
+    logic [PowerDomains-1:0] rst_sys_io_div4_n;
+    logic [PowerDomains-1:0] rst_sys_aon_n;
+    logic [PowerDomains-1:0] rst_spi_device_n;
+    logic [PowerDomains-1:0] rst_usb_n;
   } rstmgr_out_t;
 
   // cpu reset requests and status
@@ -59,9 +57,9 @@ package rstmgr_pkg;
 
   // exported resets
   typedef struct packed {
-    logic rst_ast_usbdev_sys_io_div4_n;
-    logic rst_ast_usbdev_usb_n;
-    logic rst_ast_sensor_ctrl_sys_io_div4_n;
+    logic [PowerDomains-1:0] rst_ast_usbdev_sys_io_div4_n;
+    logic [PowerDomains-1:0] rst_ast_usbdev_usb_n;
+    logic [PowerDomains-1:0] rst_ast_sensor_ctrl_sys_io_div4_n;
   } rstmgr_ast_out_t;
 
   // default value for rstmgr_ast_rsp_t (for dangling ports)

--- a/hw/ip/rstmgr/util/rstmgr_gen.py
+++ b/hw/ip/rstmgr/util/rstmgr_gen.py
@@ -2,7 +2,7 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-r"""Clock Manager Generator
+r"""Reset Manager Generator
 """
 
 import argparse
@@ -66,25 +66,10 @@ def main():
     # Number of reset requests
     n_rstreqs = len(topcfg["reset_requests"])
 
-#    # unique clocks
-#    for rst in topcfg["resets"]:
-#        if rst['type'] != "ext" and rst['clk'] not in clks:
-#            clks.append(rst['clk'])
-#
-#    # resets sent to reset struct
-#    output_rsts = [rst for rst in topcfg["resets"] if rst['type'] == "top"]
-#
-#    # por_rsts = [rst for rst in topcfg["resets"] if 'inst' in rst and rst['inst'] == "por"]
-#
-#    # sw controlled resets
-#    sw_rsts = [rst for rst in topcfg["resets"] if 'sw' in rst and rst['sw'] == 1]
-#
-#    # leaf resets
-#    leaf_rsts = [rst for rst in topcfg["resets"] if rst['gen'] == 1]
-
     # generate hjson
     hjson_out.write_text(
          hjson_tpl.render(clks=clks,
+                          power_domains=topcfg['power']['domains'],
                           num_rstreqs=n_rstreqs,
                           sw_rsts=sw_rsts,
                           output_rsts=output_rsts,
@@ -94,6 +79,7 @@ def main():
     # generate rtl package
     pkg_out.write_text(
         pkg_tpl.render(clks=clks,
+                       power_domains=topcfg['power']['domains'],
                        num_rstreqs=n_rstreqs,
                        sw_rsts=sw_rsts,
                        output_rsts=output_rsts,
@@ -103,6 +89,7 @@ def main():
     # generate top level
     rtl_out.write_text(
          rtl_tpl.render(clks=clks,
+                        power_domains=topcfg['power']['domains'],
                         num_rstreqs=n_rstreqs,
                         sw_rsts=sw_rsts,
                         output_rsts=output_rsts,

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -14,6 +14,15 @@
   type: top
   rnd_cnst_seed: 4881560218908238235
   datawidth: "32"
+  power:
+  {
+    domains:
+    [
+      Aon
+      "0"
+    ]
+    default: "0"
+  }
   clocks:
   {
     hier_paths:
@@ -173,27 +182,42 @@
         name: por_aon
         gen: false
         type: top
-        parent: rst_ni
+        domains:
+        [
+          Aon
+        ]
         clk: aon
       }
       {
         name: lc_src
         gen: false
         type: int
-        parent: por
-        clk: io_div2
+        domains:
+        [
+          Aon
+          "0"
+        ]
+        clk: io_div4
       }
       {
         name: sys_src
         gen: false
         type: int
-        parent: por
-        clk: io_div2
+        domains:
+        [
+          Aon
+          "0"
+        ]
+        clk: io_div4
       }
       {
         name: por
         gen: true
         type: top
+        domains:
+        [
+          Aon
+        ]
         parent: por_aon
         clk: main
       }
@@ -201,6 +225,10 @@
         name: por_io
         gen: true
         type: top
+        domains:
+        [
+          Aon
+        ]
         parent: por_aon
         clk: io
       }
@@ -208,6 +236,10 @@
         name: por_io_div2
         gen: true
         type: top
+        domains:
+        [
+          Aon
+        ]
         parent: por_aon
         clk: io_div2
       }
@@ -215,6 +247,10 @@
         name: por_io_div4
         gen: true
         type: top
+        domains:
+        [
+          Aon
+        ]
         parent: por_aon
         clk: io_div4
       }
@@ -222,6 +258,10 @@
         name: por_usb
         gen: true
         type: top
+        domains:
+        [
+          Aon
+        ]
         parent: por_aon
         clk: usb
       }
@@ -229,15 +269,21 @@
         name: lc
         gen: true
         type: top
-        domain: "0"
+        domains:
+        [
+          "0"
+        ]
         parent: lc_src
         clk: main
       }
       {
-        name: lc_io
+        name: lc_io_div4
         gen: true
         type: top
-        domain: "0"
+        domains:
+        [
+          "0"
+        ]
         parent: lc_src
         clk: io_div4
       }
@@ -245,23 +291,23 @@
         name: sys
         gen: true
         type: top
-        domain: "0"
+        domains:
+        [
+          Aon
+          "0"
+        ]
         parent: sys_src
         clk: main
-      }
-      {
-        name: sys_io
-        gen: true
-        type: top
-        domain: "0"
-        parent: sys_src
-        clk: io_div2
       }
       {
         name: sys_io_div4
         gen: true
         type: top
-        domain: "0"
+        domains:
+        [
+          Aon
+          "0"
+        ]
         parent: sys_src
         clk: io_div4
       }
@@ -269,7 +315,10 @@
         name: sys_aon
         gen: true
         type: top
-        domain: "0"
+        domains:
+        [
+          Aon
+        ]
         parent: sys_src
         clk: aon
       }
@@ -277,7 +326,10 @@
         name: spi_device
         gen: true
         type: top
-        domain: "0"
+        domains:
+        [
+          "0"
+        ]
         parent: sys_src
         clk: io_div2
         sw: 1
@@ -286,7 +338,10 @@
         name: usb
         gen: true
         type: top
-        domain: "0"
+        domains:
+        [
+          Aon
+        ]
         parent: sys_src
         clk: usb
         sw: 1
@@ -305,7 +360,7 @@
       }
       reset_connections:
       {
-        rst_ni: sys_io_div4
+        rst_ni: rstmgr_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]
       }
       base_addr: 0x40000000
       clock_reset_export: []
@@ -314,6 +369,7 @@
       {
         clk_i: clkmgr_clocks.clk_io_div4_secure
       }
+      domain: "0"
       size: 0x1000
       bus_device: tlul
       bus_host: none
@@ -465,7 +521,7 @@
       clock_group: peri
       reset_connections:
       {
-        rst_ni: sys_io_div4
+        rst_ni: rstmgr_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]
       }
       base_addr: 0x40010000
       clock_reset_export: []
@@ -473,6 +529,7 @@
       {
         clk_i: clkmgr_clocks.clk_io_div4_peri
       }
+      domain: "0"
       size: 0x1000
       bus_device: tlul
       bus_host: none
@@ -533,7 +590,7 @@
       clock_group: peri
       reset_connections:
       {
-        rst_ni: spi_device
+        rst_ni: rstmgr_resets.rst_spi_device_n[rstmgr_pkg::Domain0Sel]
       }
       base_addr: 0x40020000
       clock_reset_export: []
@@ -541,6 +598,7 @@
       {
         clk_i: clkmgr_clocks.clk_io_div4_peri
       }
+      domain: "0"
       size: 0x1000
       bus_device: tlul
       bus_host: none
@@ -678,7 +736,7 @@
       clock_group: infra
       reset_connections:
       {
-        rst_ni: lc
+        rst_ni: rstmgr_resets.rst_lc_n[rstmgr_pkg::Domain0Sel]
       }
       base_addr: 0x40030000
       generated: "true"
@@ -687,6 +745,7 @@
       {
         clk_i: clkmgr_clocks.clk_main_infra
       }
+      domain: "0"
       size: 0x1000
       bus_device: tlul
       bus_host: none
@@ -864,7 +923,7 @@
       clock_group: timers
       reset_connections:
       {
-        rst_ni: sys_io_div4
+        rst_ni: rstmgr_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]
       }
       base_addr: 0x40080000
       clock_reset_export: []
@@ -872,6 +931,7 @@
       {
         clk_i: clkmgr_clocks.clk_io_div4_timers
       }
+      domain: "0"
       size: 0x1000
       bus_device: tlul
       bus_host: none
@@ -918,7 +978,7 @@
       clock_group: trans
       reset_connections:
       {
-        rst_ni: sys
+        rst_ni: rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
       }
       base_addr: 0x40110000
       clock_reset_export: []
@@ -926,6 +986,7 @@
       {
         clk_i: clkmgr_clocks.clk_main_aes
       }
+      domain: "0"
       size: 0x1000
       bus_device: tlul
       bus_host: none
@@ -1108,7 +1169,7 @@
       clock_group: trans
       reset_connections:
       {
-        rst_ni: sys
+        rst_ni: rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
       }
       base_addr: 0x40120000
       clock_reset_export: []
@@ -1116,6 +1177,7 @@
       {
         clk_i: clkmgr_clocks.clk_main_hmac
       }
+      domain: "0"
       size: 0x1000
       bus_device: tlul
       bus_host: none
@@ -1205,7 +1267,7 @@
       clock_group: trans
       reset_connections:
       {
-        rst_ni: sys
+        rst_ni: rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
       }
       base_addr: 0x41120000
       clock_reset_export: []
@@ -1213,6 +1275,7 @@
       {
         clk_i: clkmgr_clocks.clk_main_kmac
       }
+      domain: "0"
       size: 0x1000
       bus_device: tlul
       bus_host: none
@@ -1363,7 +1426,7 @@
       clock_group: secure
       reset_connections:
       {
-        rst_ni: sys
+        rst_ni: rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
       }
       base_addr: 0x40090000
       generated: "true"
@@ -1372,6 +1435,7 @@
       {
         clk_i: clkmgr_clocks.clk_main_secure
       }
+      domain: "0"
       size: 0x1000
       bus_device: tlul
       bus_host: none
@@ -1413,9 +1477,10 @@
       clock_group: secure
       reset_connections:
       {
-        rst_ni: sys
-        rst_aon_ni: sys_aon
+        rst_ni: rstmgr_resets.rst_sys_n[rstmgr_pkg::DomainAonSel]
+        rst_aon_ni: rstmgr_resets.rst_sys_aon_n[rstmgr_pkg::DomainAonSel]
       }
+      domain: Aon
       base_addr: 0x40070000
       generated: "true"
       clock_reset_export: []
@@ -1522,8 +1587,9 @@
       clock_group: secure
       reset_connections:
       {
-        rst_ni: sys
+        rst_ni: rstmgr_resets.rst_sys_n[rstmgr_pkg::DomainAonSel]
       }
+      domain: Aon
       base_addr: 0x40160000
       generated: "true"
       clock_reset_export: []
@@ -1570,7 +1636,7 @@
       clock_group: secure
       reset_connections:
       {
-        rst_ni: sys
+        rst_ni: rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
       }
       base_addr: 0x40130000
       generated: "true"
@@ -1585,6 +1651,7 @@
       {
         clk_i: clkmgr_clocks.clk_main_secure
       }
+      domain: "0"
       size: 0x1000
       bus_device: tlul
       bus_host: none
@@ -1714,9 +1781,10 @@
       clock_group: powerup
       reset_connections:
       {
-        rst_ni: por
-        rst_slow_ni: por_aon
+        rst_ni: rstmgr_resets.rst_por_n[rstmgr_pkg::DomainAonSel]
+        rst_slow_ni: rstmgr_resets.rst_por_aon_n[rstmgr_pkg::DomainAonSel]
       }
+      domain: Aon
       base_addr: 0x400A0000
       generated: "true"
       clock_reset_export: []
@@ -1894,6 +1962,7 @@
       {
         rst_ni: rst_ni
       }
+      domain: Aon
       base_addr: 0x400B0000
       generated: "true"
       clock_reset_export: []
@@ -2020,13 +2089,14 @@
       clock_group: powerup
       reset_connections:
       {
-        rst_ni: por_io
-        rst_main_ni: por
-        rst_io_ni: por_io
-        rst_usb_ni: por_usb
-        rst_io_div2_ni: por_io_div2
-        rst_io_div4_ni: por_io_div4
+        rst_ni: rstmgr_resets.rst_por_io_div4_n[rstmgr_pkg::DomainAonSel]
+        rst_main_ni: rstmgr_resets.rst_por_n[rstmgr_pkg::DomainAonSel]
+        rst_io_ni: rstmgr_resets.rst_por_io_n[rstmgr_pkg::DomainAonSel]
+        rst_usb_ni: rstmgr_resets.rst_por_usb_n[rstmgr_pkg::DomainAonSel]
+        rst_io_div2_ni: rstmgr_resets.rst_por_io_div2_n[rstmgr_pkg::DomainAonSel]
+        rst_io_div4_ni: rstmgr_resets.rst_por_io_div4_n[rstmgr_pkg::DomainAonSel]
       }
+      domain: Aon
       base_addr: 0x400C0000
       generated: "true"
       clock_reset_export: []
@@ -2175,7 +2245,7 @@
       clock_group: secure
       reset_connections:
       {
-        rst_ni: sys
+        rst_ni: rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
       }
       base_addr: 0x40140000
       clock_reset_export: []
@@ -2183,6 +2253,7 @@
       {
         clk_i: clkmgr_clocks.clk_main_secure
       }
+      domain: "0"
       size: 0x1000
       bus_device: tlul
       bus_host: none
@@ -2282,9 +2353,10 @@
       ]
       reset_connections:
       {
-        rst_ni: sys_io_div4
-        rst_usb_48mhz_ni: usb
+        rst_ni: rstmgr_resets.rst_sys_io_div4_n[rstmgr_pkg::DomainAonSel]
+        rst_usb_48mhz_ni: rstmgr_resets.rst_usb_n[rstmgr_pkg::DomainAonSel]
       }
+      domain: Aon
       base_addr: 0x40150000
       clock_connections:
       {
@@ -2617,8 +2689,9 @@
       ]
       reset_connections:
       {
-        rst_ni: sys_io_div4
+        rst_ni: rstmgr_resets.rst_sys_io_div4_n[rstmgr_pkg::DomainAonSel]
       }
+      domain: Aon
       base_addr: 0x40170000
       top_only: "true"
       clock_connections:
@@ -2705,7 +2778,7 @@
       clock_group: secure
       reset_connections:
       {
-        rst_ni: sys
+        rst_ni: rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
       }
       base_addr: 0x401a0000
       clock_reset_export: []
@@ -2713,6 +2786,7 @@
       {
         clk_i: clkmgr_clocks.clk_main_secure
       }
+      domain: "0"
       size: 0x1000
       bus_device: tlul
       bus_host: none
@@ -2879,7 +2953,7 @@
       clock_group: timers
       reset_connections:
       {
-        rst_ni: lc_io
+        rst_ni: rstmgr_resets.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel]
       }
       base_addr: 0x401b0000
       clock_reset_export: []
@@ -2887,6 +2961,7 @@
       {
         clk_i: clkmgr_clocks.clk_io_div4_timers
       }
+      domain: "0"
       size: 0x4000
       bus_device: tlul
       bus_host: none
@@ -3201,7 +3276,7 @@
       clock_group: trans
       reset_connections:
       {
-        rst_ni: sys
+        rst_ni: rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
       }
       base_addr: 0x50000000
       clock_reset_export: []
@@ -3209,6 +3284,7 @@
       {
         clk_i: clkmgr_clocks.clk_main_otbn
       }
+      domain: "0"
       size: 0x400000
       bus_device: tlul
       bus_host: none
@@ -3342,7 +3418,7 @@
       clock_group: infra
       reset_connections:
       {
-        rst_ni: sys
+        rst_ni: rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
       }
       type: rom
       base_addr: 0x00008000
@@ -3368,6 +3444,7 @@
       {
         clk_i: clkmgr_clocks.clk_main_infra
       }
+      domain: "0"
     }
     {
       name: ram_main
@@ -3378,7 +3455,7 @@
       clock_group: infra
       reset_connections:
       {
-        rst_ni: sys
+        rst_ni: rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
       }
       type: ram_1p
       base_addr: 0x10000000
@@ -3403,6 +3480,7 @@
       {
         clk_i: clkmgr_clocks.clk_main_infra
       }
+      domain: "0"
     }
     {
       name: ram_ret
@@ -3413,8 +3491,9 @@
       clock_group: infra
       reset_connections:
       {
-        rst_ni: sys_io_div4
+        rst_ni: rstmgr_resets.rst_sys_io_div4_n[rstmgr_pkg::DomainAonSel]
       }
+      domain: Aon
       type: ram_1p
       base_addr: 0x18000000
       size: 0x1000
@@ -3448,7 +3527,7 @@
       clock_group: infra
       reset_connections:
       {
-        rst_ni: lc
+        rst_ni: rstmgr_resets.rst_lc_n[rstmgr_pkg::Domain0Sel]
       }
       type: eflash
       base_addr: 0x20000000
@@ -3499,6 +3578,7 @@
       ]
       size: 0x80000
       pgm_resolution_bytes: 1024
+      domain: "0"
     }
   ]
   inter_module:
@@ -3704,8 +3784,8 @@
       reset: rst_main_ni
       reset_connections:
       {
-        rst_main_ni: sys
-        rst_fixed_ni: sys_io_div4
+        rst_main_ni: rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
+        rst_fixed_ni: rstmgr_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]
       }
       clock_reset_export: []
       clock_connections:
@@ -3713,6 +3793,7 @@
         clk_main_i: clkmgr_clocks.clk_main_infra
         clk_fixed_i: clkmgr_clocks.clk_io_div4_infra
       }
+      domain: "0"
       connections:
       {
         corei:
@@ -4348,13 +4429,14 @@
       reset: rst_peri_ni
       reset_connections:
       {
-        rst_peri_ni: sys_io_div4
+        rst_peri_ni: rstmgr_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]
       }
       clock_reset_export: []
       clock_connections:
       {
         clk_peri_i: clkmgr_clocks.clk_io_div4_infra
       }
+      domain: "0"
       connections:
       {
         main:
@@ -5962,39 +6044,6 @@
       ]
     }
   }
-  reset_paths:
-  {
-    rst_ni: rst_ni
-    por_aon: rstmgr_resets.rst_por_aon_n
-    por: rstmgr_resets.rst_por_n
-    por_io: rstmgr_resets.rst_por_io_n
-    por_io_div2: rstmgr_resets.rst_por_io_div2_n
-    por_io_div4: rstmgr_resets.rst_por_io_div4_n
-    por_usb: rstmgr_resets.rst_por_usb_n
-    lc: rstmgr_resets.rst_lc_n
-    lc_io: rstmgr_resets.rst_lc_io_n
-    sys: rstmgr_resets.rst_sys_n
-    sys_io: rstmgr_resets.rst_sys_io_n
-    sys_io_div4: rstmgr_resets.rst_sys_io_div4_n
-    sys_aon: rstmgr_resets.rst_sys_aon_n
-    spi_device: rstmgr_resets.rst_spi_device_n
-    usb: rstmgr_resets.rst_usb_n
-  }
-  exported_rsts:
-  {
-    ast:
-    {
-      usbdev:
-      [
-        sys_io_div4
-        usb
-      ]
-      sensor_ctrl:
-      [
-        sys_io_div4
-      ]
-    }
-  }
   wakeups:
   [
     {
@@ -6010,6 +6059,38 @@
       module: nmi_gen
     }
   ]
+  exported_rsts:
+  {
+    ast:
+    {
+      usbdev:
+      [
+        sys_io_div4
+        usb
+      ]
+      sensor_ctrl:
+      [
+        sys_io_div4
+      ]
+    }
+  }
+  reset_paths:
+  {
+    rst_ni: rst_ni
+    por_aon: rstmgr_resets.rst_por_aon_n
+    por: rstmgr_resets.rst_por_n
+    por_io: rstmgr_resets.rst_por_io_n
+    por_io_div2: rstmgr_resets.rst_por_io_div2_n
+    por_io_div4: rstmgr_resets.rst_por_io_div4_n
+    por_usb: rstmgr_resets.rst_por_usb_n
+    lc: rstmgr_resets.rst_lc_n
+    lc_io_div4: rstmgr_resets.rst_lc_io_div4_n
+    sys: rstmgr_resets.rst_sys_n
+    sys_io_div4: rstmgr_resets.rst_sys_io_div4_n
+    sys_aon: rstmgr_resets.rst_sys_aon_n
+    spi_device: rstmgr_resets.rst_spi_device_n
+    usb: rstmgr_resets.rst_usb_n
+  }
   inter_signal:
   {
     signals:

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -15,6 +15,17 @@
   // 32-bit datawidth
   datawidth: "32",
 
+  // Power information for the design
+  power: {
+    // Power domains supported by the design
+    // Aon represents domain aon
+    // 0 represents domain 0
+    domains: ["Aon", "0"],
+
+    // Default power domain used for the design
+    default: "0"
+  },
+
   // This is the clock data structure of the design.
   // The hier path refers to the clock reference path (struct / port)
   //   - The top/ext desgination follows the same scheme as inter-module
@@ -109,6 +120,7 @@
     // gen: whether the reset is generated
     // true: it is a generated reset inside rstmgr
     // false: it is a hardwired design reset inside rstmgr (roots and por)
+    // For non-generated resets, the parent / domain definitions have no meaning.
     //
     // type: the reset type [ext, top]
     // ext: the reset is coming in from the ports, external to earlgrey
@@ -118,34 +130,32 @@
     // parent: The parent reset
     // If type is "ext", there is no root, since it is external
     //
-    // domain: The power domain
-    // If no domain, it means there is no choice, just inherits from root.
-    // Otherwise, selects the domain to which it is related
-    // 0 is defaulted for always on.
-    // TBD: This should eventually be changed to a name->index project wide lookup
+    // domains: The power domains of a particular reset
+    // This is a list of of the supported power domains.
+    // Valid values are Aon and (power domain)0 ~ (power domain)1.
+    // If no value is supplied, the default is only the Aon version.
     //
     // clk:  related clock domain for synchronous release
     // If type is "por", there is not related clock, since it is
     // likely external or generated from a voltage comparator
     //
     nodes: [
-      { name: "rst_ni",      gen: false, type: "ext"                                                    }
-      { name: "por_aon",     gen: false, type: "top",              parent: "rst_ni",  clk: "aon"        }
-      { name: "lc_src",      gen: false, type: "int",              parent: "por",     clk: "io_div2"    }
-      { name: "sys_src",     gen: false, type: "int",              parent: "por",     clk: "io_div2"    }
-      { name: "por",         gen: true,  type: "top",              parent: "por_aon", clk: "main"       }
-      { name: "por_io",      gen: true,  type: "top",              parent: "por_aon", clk: "io"         }
-      { name: "por_io_div2", gen: true,  type: "top",              parent: "por_aon", clk: "io_div2"    }
-      { name: "por_io_div4", gen: true , type: "top",              parent: "por_aon", clk: "io_div4"    }
-      { name: "por_usb",     gen: true,  type: "top",              parent: "por_aon", clk: "usb"        }
-      { name: "lc",          gen: true,  type: "top", domain: "0", parent: "lc_src",  clk: "main"       }
-      { name: "lc_io",       gen: true,  type: "top", domain: "0", parent: "lc_src",  clk: "io_div4"    }
-      { name: "sys",         gen: true,  type: "top", domain: "0", parent: "sys_src", clk: "main"       }
-      { name: "sys_io",      gen: true,  type: "top", domain: "0", parent: "sys_src", clk: "io_div2"    }
-      { name: "sys_io_div4", gen: true,  type: "top", domain: "0", parent: "sys_src", clk: "io_div4"    }
-      { name: "sys_aon",     gen: true,  type: "top", domain: "0", parent: "sys_src", clk: "aon"        }
-      { name: "spi_device",  gen: true,  type: "top", domain: "0", parent: "sys_src", clk: "io_div2", sw: 1 }
-      { name: "usb",         gen: true,  type: "top", domain: "0", parent: "sys_src", clk: "usb",     sw: 1 }
+      { name: "rst_ni",      gen: false, type: "ext",                                                          }
+      { name: "por_aon",     gen: false, type: "top", domains: ["Aon"     ],                    clk: "aon"     }
+      { name: "lc_src",      gen: false, type: "int", domains: ["Aon", "0"],                    clk: "io_div4" }
+      { name: "sys_src",     gen: false, type: "int", domains: ["Aon", "0"],                    clk: "io_div4" }
+      { name: "por",         gen: true,  type: "top", domains: ["Aon"     ], parent: "por_aon", clk: "main"    }
+      { name: "por_io",      gen: true,  type: "top", domains: ["Aon",    ], parent: "por_aon", clk: "io"      }
+      { name: "por_io_div2", gen: true,  type: "top", domains: ["Aon",    ], parent: "por_aon", clk: "io_div2" }
+      { name: "por_io_div4", gen: true , type: "top", domains: ["Aon",    ], parent: "por_aon", clk: "io_div4" }
+      { name: "por_usb",     gen: true,  type: "top", domains: ["Aon",    ], parent: "por_aon", clk: "usb"     }
+      { name: "lc",          gen: true,  type: "top", domains: [       "0"], parent: "lc_src",  clk: "main"    }
+      { name: "lc_io_div4",  gen: true,  type: "top", domains: [       "0"], parent: "lc_src",  clk: "io_div4" }
+      { name: "sys",         gen: true,  type: "top", domains: ["Aon", "0"], parent: "sys_src", clk: "main"    }
+      { name: "sys_io_div4", gen: true,  type: "top", domains: ["Aon", "0"], parent: "sys_src", clk: "io_div4" }
+      { name: "sys_aon",     gen: true,  type: "top", domains: ["Aon",    ], parent: "sys_src", clk: "aon"     }
+      { name: "spi_device",  gen: true,  type: "top", domains: [       "0"], parent: "sys_src", clk: "io_div2", sw: 1 }
+      { name: "usb",         gen: true,  type: "top", domains: ["Aon",    ], parent: "sys_src", clk: "usb",     sw: 1 }
     ]
   }
 
@@ -241,6 +251,7 @@
       clock_srcs: {clk_i: "main", clk_aon_i: "aon"},
       clock_group: "secure",
       reset_connections: {rst_ni: "sys", rst_aon_ni: "sys_aon"},
+      domain: "Aon",
       base_addr: "0x40070000",
       generated: "true"
     },
@@ -251,6 +262,7 @@
       clock_srcs: {clk_i: "main"},
       clock_group: "secure",
       reset_connections: {rst_ni: "sys"},
+      domain: "Aon",
       base_addr: "0x40160000",
       generated: "true"
     },
@@ -272,6 +284,7 @@
       clock_srcs: {clk_i: "io_div4", clk_slow_i: "aon"},
       clock_group: "powerup",
       reset_connections: {rst_ni: "por", rst_slow_ni: "por_aon"},
+      domain: "Aon",
       base_addr: "0x400A0000",
       generated: "true"         // Indicate this module is generated in the topgen
 
@@ -282,6 +295,7 @@
                    clk_io_div2_i: "io_div2", clk_io_div4_i: "io_div4"},
       clock_group: "powerup",
       reset_connections: {rst_ni: "rst_ni"},
+      domain: "Aon",
       base_addr: "0x400B0000",
       generated: "true"         // Indicate this module is generated in the topgen
     },
@@ -289,8 +303,9 @@
       type: "clkmgr",
       clock_srcs: {clk_i: "io_div4"},
       clock_group: "powerup",
-      reset_connections: {rst_ni: "por_io", rst_main_ni: "por", rst_io_ni: "por_io", rst_usb_ni: "por_usb"
+      reset_connections: {rst_ni: "por_io_div4", rst_main_ni: "por", rst_io_ni: "por_io", rst_usb_ni: "por_usb"
                           rst_io_div2_ni: "por_io_div2", rst_io_div4_ni: "por_io_div4"},
+      domain: "Aon",
       base_addr: "0x400C0000",
       generated: "true"
     },
@@ -309,6 +324,7 @@
       clock_group: "peri",
       clock_reset_export: ["ast"],
       reset_connections: {rst_ni: "sys_io_div4", rst_usb_48mhz_ni: "usb"},
+      domain: "Aon",
       base_addr: "0x40150000",
     },
     { name: "sensor_ctrl",
@@ -317,6 +333,7 @@
       clock_group: "secure",
       clock_reset_export: ["ast"],
       reset_connections: {rst_ni: "sys_io_div4"},
+      domain: "Aon",
       base_addr: "0x40170000",
       top_only: "true"
     },
@@ -331,7 +348,7 @@
       type: "otp_ctrl",
       clock_srcs: {clk_i: "io_div4"},
       clock_group: "timers",
-      reset_connections: {rst_ni: "lc_io"},
+      reset_connections: {rst_ni: "lc_io_div4"},
       base_addr: "0x401b0000",
     },
     { name: "otbn",
@@ -383,9 +400,10 @@
       clock_srcs: {clk_i: "io_div4"},
       clock_group: "infra",
       reset_connections: {rst_ni: "sys_io_div4"},
+      domain: "Aon",
       type: "ram_1p",
       base_addr: "0x18000000",
-      size: "0x1000"
+      size: "0x1000",
       inter_signal_list: [
         { struct: "tl"
           package: "tlul_pkg"

--- a/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
+++ b/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
@@ -17,10 +17,10 @@
   clock_primary: "clk_i",
   other_clock_list: [
     "clk_aon_i"
-    "clk_io_div2_i"
+    "clk_io_div4_i"
     "clk_main_i"
     "clk_io_i"
-    "clk_io_div4_i"
+    "clk_io_div2_i"
     "clk_usb_i"
   ],
   bus_device: "tlul",

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
@@ -20,10 +20,10 @@ module rstmgr import rstmgr_pkg::*; (
   input clk_i,
   input rst_ni, // this is currently connected to top level reset, but will change once ast is in
   input clk_aon_i,
-  input clk_io_div2_i,
+  input clk_io_div4_i,
   input clk_main_i,
   input clk_io_i,
-  input clk_io_div4_i,
+  input clk_io_div2_i,
   input clk_usb_i,
 
   // Bus Interface
@@ -58,23 +58,32 @@ module rstmgr import rstmgr_pkg::*; (
   // receive POR and stretch
   // The por is at first stretched and synced on clk_aon
   // The rst_ni and pok_i input will be changed once AST is integrated
-  logic rst_por_aon_n;
-  rstmgr_por u_rst_por_aon (
-    .clk_i(clk_aon_i),
-    .rst_ni(ast_i.aon_pok),
-    .scan_rst_ni,
-    .scanmode_i,
-    .rst_no(rst_por_aon_n)
-  );
+  logic [PowerDomains-1:0] rst_por_aon_n;
 
-  prim_clock_mux2 #(
-    .NoFpgaBufG(1'b1)
-  ) u_rst_por_aon_n_mux (
-    .clk0_i(rst_por_aon_n),
-    .clk1_i(scan_rst_ni),
-    .sel_i(scanmode_i),
-    .clk_o(resets_o.rst_por_aon_n)
-  );
+  for (genvar i = 0; i < PowerDomains; i++) begin : gen_rst_por_aon
+    if (i == DomainAonSel) begin : gen_rst_por_aon_normal
+      rstmgr_por u_rst_por_aon (
+        .clk_i(clk_aon_i),
+        .rst_ni(ast_i.aon_pok),
+        .scan_rst_ni,
+        .scanmode_i,
+        .rst_no(rst_por_aon_n[i])
+      );
+
+      prim_clock_mux2 #(
+        .NoFpgaBufG(1'b1)
+      ) u_rst_por_aon_n_mux (
+        .clk0_i(rst_por_aon_n[i]),
+        .clk1_i(scan_rst_ni),
+        .sel_i(scanmode_i),
+        .clk_o(resets_o.rst_por_aon_n[i])
+      );
+    end else begin : gen_rst_por_aon_tieoff
+      assign rst_por_aon_n[i] = 1'b0;
+      assign resets_o.rst_por_aon_n[i] = rst_por_aon_n[i];
+    end
+  end
+
 
   ////////////////////////////////////////////////////
   // Register Interface                             //
@@ -82,7 +91,7 @@ module rstmgr import rstmgr_pkg::*; (
 
   // local_rst_n is the reset used by the rstmgr for its internal logic
   logic local_rst_n;
-  assign local_rst_n = resets_o.rst_por_io_div2_n;
+  assign local_rst_n = resets_o.rst_por_io_div2_n[DomainAonSel];
 
   rstmgr_reg_pkg::rstmgr_reg2hw_t reg2hw;
   rstmgr_reg_pkg::rstmgr_hw2reg_t hw2reg;
@@ -183,279 +192,326 @@ module rstmgr import rstmgr_pkg::*; (
   // leaf reset in the system                       //
   // These should all be generated                  //
   ////////////////////////////////////////////////////
+  // To simplify generation, each reset generates all associated power domain outputs.
+  // If a reset does not support a particular power domain, that reset is always hard-wired to 0.
 
-  logic rst_por_n;
-
+  logic [PowerDomains-1:0] rst_por_n;
   prim_flop_2sync #(
     .Width(1),
     .ResetValue('0)
-  ) u_por (
+  ) u_aon_por (
     .clk_i(clk_main_i),
-    .rst_ni(rst_por_aon_n),
+    .rst_ni(rst_por_aon_n[DomainAonSel]),
     .d_i(1'b1),
-    .q_o(rst_por_n)
+    .q_o(rst_por_n[DomainAonSel])
   );
 
   prim_clock_mux2 #(
     .NoFpgaBufG(1'b1)
-  ) u_por_mux (
-    .clk0_i(rst_por_n),
+  ) u_aon_por_mux (
+    .clk0_i(rst_por_n[DomainAonSel]),
     .clk1_i(scan_rst_ni),
     .sel_i(scanmode_i),
-    .clk_o(resets_o.rst_por_n)
+    .clk_o(resets_o.rst_por_n[DomainAonSel])
   );
 
-  logic rst_por_io_n;
+  assign rst_por_n[Domain0Sel] = 1'b0;
+  assign resets_o.rst_por_n[Domain0Sel] = rst_por_n[Domain0Sel];
 
+
+  logic [PowerDomains-1:0] rst_por_io_n;
   prim_flop_2sync #(
     .Width(1),
     .ResetValue('0)
-  ) u_por_io (
+  ) u_aon_por_io (
     .clk_i(clk_io_i),
-    .rst_ni(rst_por_aon_n),
+    .rst_ni(rst_por_aon_n[DomainAonSel]),
     .d_i(1'b1),
-    .q_o(rst_por_io_n)
+    .q_o(rst_por_io_n[DomainAonSel])
   );
 
   prim_clock_mux2 #(
     .NoFpgaBufG(1'b1)
-  ) u_por_io_mux (
-    .clk0_i(rst_por_io_n),
+  ) u_aon_por_io_mux (
+    .clk0_i(rst_por_io_n[DomainAonSel]),
     .clk1_i(scan_rst_ni),
     .sel_i(scanmode_i),
-    .clk_o(resets_o.rst_por_io_n)
+    .clk_o(resets_o.rst_por_io_n[DomainAonSel])
   );
 
-  logic rst_por_io_div2_n;
+  assign rst_por_io_n[Domain0Sel] = 1'b0;
+  assign resets_o.rst_por_io_n[Domain0Sel] = rst_por_io_n[Domain0Sel];
 
+
+  logic [PowerDomains-1:0] rst_por_io_div2_n;
   prim_flop_2sync #(
     .Width(1),
     .ResetValue('0)
-  ) u_por_io_div2 (
+  ) u_aon_por_io_div2 (
     .clk_i(clk_io_div2_i),
-    .rst_ni(rst_por_aon_n),
+    .rst_ni(rst_por_aon_n[DomainAonSel]),
     .d_i(1'b1),
-    .q_o(rst_por_io_div2_n)
+    .q_o(rst_por_io_div2_n[DomainAonSel])
   );
 
   prim_clock_mux2 #(
     .NoFpgaBufG(1'b1)
-  ) u_por_io_div2_mux (
-    .clk0_i(rst_por_io_div2_n),
+  ) u_aon_por_io_div2_mux (
+    .clk0_i(rst_por_io_div2_n[DomainAonSel]),
     .clk1_i(scan_rst_ni),
     .sel_i(scanmode_i),
-    .clk_o(resets_o.rst_por_io_div2_n)
+    .clk_o(resets_o.rst_por_io_div2_n[DomainAonSel])
   );
 
-  logic rst_por_io_div4_n;
+  assign rst_por_io_div2_n[Domain0Sel] = 1'b0;
+  assign resets_o.rst_por_io_div2_n[Domain0Sel] = rst_por_io_div2_n[Domain0Sel];
 
+
+  logic [PowerDomains-1:0] rst_por_io_div4_n;
   prim_flop_2sync #(
     .Width(1),
     .ResetValue('0)
-  ) u_por_io_div4 (
+  ) u_aon_por_io_div4 (
     .clk_i(clk_io_div4_i),
-    .rst_ni(rst_por_aon_n),
+    .rst_ni(rst_por_aon_n[DomainAonSel]),
     .d_i(1'b1),
-    .q_o(rst_por_io_div4_n)
+    .q_o(rst_por_io_div4_n[DomainAonSel])
   );
 
   prim_clock_mux2 #(
     .NoFpgaBufG(1'b1)
-  ) u_por_io_div4_mux (
-    .clk0_i(rst_por_io_div4_n),
+  ) u_aon_por_io_div4_mux (
+    .clk0_i(rst_por_io_div4_n[DomainAonSel]),
     .clk1_i(scan_rst_ni),
     .sel_i(scanmode_i),
-    .clk_o(resets_o.rst_por_io_div4_n)
+    .clk_o(resets_o.rst_por_io_div4_n[DomainAonSel])
   );
 
-  logic rst_por_usb_n;
+  assign rst_por_io_div4_n[Domain0Sel] = 1'b0;
+  assign resets_o.rst_por_io_div4_n[Domain0Sel] = rst_por_io_div4_n[Domain0Sel];
 
+
+  logic [PowerDomains-1:0] rst_por_usb_n;
   prim_flop_2sync #(
     .Width(1),
     .ResetValue('0)
-  ) u_por_usb (
+  ) u_aon_por_usb (
     .clk_i(clk_usb_i),
-    .rst_ni(rst_por_aon_n),
+    .rst_ni(rst_por_aon_n[DomainAonSel]),
     .d_i(1'b1),
-    .q_o(rst_por_usb_n)
+    .q_o(rst_por_usb_n[DomainAonSel])
   );
 
   prim_clock_mux2 #(
     .NoFpgaBufG(1'b1)
-  ) u_por_usb_mux (
-    .clk0_i(rst_por_usb_n),
+  ) u_aon_por_usb_mux (
+    .clk0_i(rst_por_usb_n[DomainAonSel]),
     .clk1_i(scan_rst_ni),
     .sel_i(scanmode_i),
-    .clk_o(resets_o.rst_por_usb_n)
+    .clk_o(resets_o.rst_por_usb_n[DomainAonSel])
   );
 
-  logic rst_lc_n;
+  assign rst_por_usb_n[Domain0Sel] = 1'b0;
+  assign resets_o.rst_por_usb_n[Domain0Sel] = rst_por_usb_n[Domain0Sel];
+
+
+  logic [PowerDomains-1:0] rst_lc_n;
+  assign rst_lc_n[DomainAonSel] = 1'b0;
+  assign resets_o.rst_lc_n[DomainAonSel] = rst_lc_n[DomainAonSel];
+
 
   prim_flop_2sync #(
     .Width(1),
     .ResetValue('0)
-  ) u_lc (
+  ) u_0_lc (
     .clk_i(clk_main_i),
-    .rst_ni(rst_lc_src_n[0]),
+    .rst_ni(rst_lc_src_n[Domain0Sel]),
     .d_i(1'b1),
-    .q_o(rst_lc_n)
+    .q_o(rst_lc_n[Domain0Sel])
   );
 
   prim_clock_mux2 #(
     .NoFpgaBufG(1'b1)
-  ) u_lc_mux (
-    .clk0_i(rst_lc_n),
+  ) u_0_lc_mux (
+    .clk0_i(rst_lc_n[Domain0Sel]),
     .clk1_i(scan_rst_ni),
     .sel_i(scanmode_i),
-    .clk_o(resets_o.rst_lc_n)
+    .clk_o(resets_o.rst_lc_n[Domain0Sel])
   );
 
-  logic rst_lc_io_n;
+  logic [PowerDomains-1:0] rst_lc_io_div4_n;
+  assign rst_lc_io_div4_n[DomainAonSel] = 1'b0;
+  assign resets_o.rst_lc_io_div4_n[DomainAonSel] = rst_lc_io_div4_n[DomainAonSel];
+
 
   prim_flop_2sync #(
     .Width(1),
     .ResetValue('0)
-  ) u_lc_io (
+  ) u_0_lc_io_div4 (
     .clk_i(clk_io_div4_i),
-    .rst_ni(rst_lc_src_n[0]),
+    .rst_ni(rst_lc_src_n[Domain0Sel]),
     .d_i(1'b1),
-    .q_o(rst_lc_io_n)
+    .q_o(rst_lc_io_div4_n[Domain0Sel])
   );
 
   prim_clock_mux2 #(
     .NoFpgaBufG(1'b1)
-  ) u_lc_io_mux (
-    .clk0_i(rst_lc_io_n),
+  ) u_0_lc_io_div4_mux (
+    .clk0_i(rst_lc_io_div4_n[Domain0Sel]),
     .clk1_i(scan_rst_ni),
     .sel_i(scanmode_i),
-    .clk_o(resets_o.rst_lc_io_n)
+    .clk_o(resets_o.rst_lc_io_div4_n[Domain0Sel])
   );
 
-  logic rst_sys_n;
-
+  logic [PowerDomains-1:0] rst_sys_n;
   prim_flop_2sync #(
     .Width(1),
     .ResetValue('0)
-  ) u_sys (
+  ) u_aon_sys (
     .clk_i(clk_main_i),
-    .rst_ni(rst_sys_src_n[0]),
+    .rst_ni(rst_sys_src_n[DomainAonSel]),
     .d_i(1'b1),
-    .q_o(rst_sys_n)
+    .q_o(rst_sys_n[DomainAonSel])
   );
 
   prim_clock_mux2 #(
     .NoFpgaBufG(1'b1)
-  ) u_sys_mux (
-    .clk0_i(rst_sys_n),
+  ) u_aon_sys_mux (
+    .clk0_i(rst_sys_n[DomainAonSel]),
     .clk1_i(scan_rst_ni),
     .sel_i(scanmode_i),
-    .clk_o(resets_o.rst_sys_n)
+    .clk_o(resets_o.rst_sys_n[DomainAonSel])
   );
-
-  logic rst_sys_io_n;
 
   prim_flop_2sync #(
     .Width(1),
     .ResetValue('0)
-  ) u_sys_io (
-    .clk_i(clk_io_div2_i),
-    .rst_ni(rst_sys_src_n[0]),
+  ) u_0_sys (
+    .clk_i(clk_main_i),
+    .rst_ni(rst_sys_src_n[Domain0Sel]),
     .d_i(1'b1),
-    .q_o(rst_sys_io_n)
+    .q_o(rst_sys_n[Domain0Sel])
   );
 
   prim_clock_mux2 #(
     .NoFpgaBufG(1'b1)
-  ) u_sys_io_mux (
-    .clk0_i(rst_sys_io_n),
+  ) u_0_sys_mux (
+    .clk0_i(rst_sys_n[Domain0Sel]),
     .clk1_i(scan_rst_ni),
     .sel_i(scanmode_i),
-    .clk_o(resets_o.rst_sys_io_n)
+    .clk_o(resets_o.rst_sys_n[Domain0Sel])
   );
 
-  logic rst_sys_io_div4_n;
-
+  logic [PowerDomains-1:0] rst_sys_io_div4_n;
   prim_flop_2sync #(
     .Width(1),
     .ResetValue('0)
-  ) u_sys_io_div4 (
+  ) u_aon_sys_io_div4 (
     .clk_i(clk_io_div4_i),
-    .rst_ni(rst_sys_src_n[0]),
+    .rst_ni(rst_sys_src_n[DomainAonSel]),
     .d_i(1'b1),
-    .q_o(rst_sys_io_div4_n)
+    .q_o(rst_sys_io_div4_n[DomainAonSel])
   );
 
   prim_clock_mux2 #(
     .NoFpgaBufG(1'b1)
-  ) u_sys_io_div4_mux (
-    .clk0_i(rst_sys_io_div4_n),
+  ) u_aon_sys_io_div4_mux (
+    .clk0_i(rst_sys_io_div4_n[DomainAonSel]),
     .clk1_i(scan_rst_ni),
     .sel_i(scanmode_i),
-    .clk_o(resets_o.rst_sys_io_div4_n)
+    .clk_o(resets_o.rst_sys_io_div4_n[DomainAonSel])
   );
-
-  logic rst_sys_aon_n;
 
   prim_flop_2sync #(
     .Width(1),
     .ResetValue('0)
-  ) u_sys_aon (
+  ) u_0_sys_io_div4 (
+    .clk_i(clk_io_div4_i),
+    .rst_ni(rst_sys_src_n[Domain0Sel]),
+    .d_i(1'b1),
+    .q_o(rst_sys_io_div4_n[Domain0Sel])
+  );
+
+  prim_clock_mux2 #(
+    .NoFpgaBufG(1'b1)
+  ) u_0_sys_io_div4_mux (
+    .clk0_i(rst_sys_io_div4_n[Domain0Sel]),
+    .clk1_i(scan_rst_ni),
+    .sel_i(scanmode_i),
+    .clk_o(resets_o.rst_sys_io_div4_n[Domain0Sel])
+  );
+
+  logic [PowerDomains-1:0] rst_sys_aon_n;
+  prim_flop_2sync #(
+    .Width(1),
+    .ResetValue('0)
+  ) u_aon_sys_aon (
     .clk_i(clk_aon_i),
-    .rst_ni(rst_sys_src_n[0]),
+    .rst_ni(rst_sys_src_n[DomainAonSel]),
     .d_i(1'b1),
-    .q_o(rst_sys_aon_n)
+    .q_o(rst_sys_aon_n[DomainAonSel])
   );
 
   prim_clock_mux2 #(
     .NoFpgaBufG(1'b1)
-  ) u_sys_aon_mux (
-    .clk0_i(rst_sys_aon_n),
+  ) u_aon_sys_aon_mux (
+    .clk0_i(rst_sys_aon_n[DomainAonSel]),
     .clk1_i(scan_rst_ni),
     .sel_i(scanmode_i),
-    .clk_o(resets_o.rst_sys_aon_n)
+    .clk_o(resets_o.rst_sys_aon_n[DomainAonSel])
   );
 
-  logic rst_spi_device_n;
+  assign rst_sys_aon_n[Domain0Sel] = 1'b0;
+  assign resets_o.rst_sys_aon_n[Domain0Sel] = rst_sys_aon_n[Domain0Sel];
+
+
+  logic [PowerDomains-1:0] rst_spi_device_n;
+  assign rst_spi_device_n[DomainAonSel] = 1'b0;
+  assign resets_o.rst_spi_device_n[DomainAonSel] = rst_spi_device_n[DomainAonSel];
+
 
   prim_flop_2sync #(
     .Width(1),
     .ResetValue('0)
-  ) u_spi_device (
+  ) u_0_spi_device (
     .clk_i(clk_io_div2_i),
-    .rst_ni(rst_sys_src_n[0]),
+    .rst_ni(rst_sys_src_n[Domain0Sel]),
     .d_i(sw_rst_ctrl_n[SPI_DEVICE]),
-    .q_o(rst_spi_device_n)
+    .q_o(rst_spi_device_n[Domain0Sel])
   );
 
   prim_clock_mux2 #(
     .NoFpgaBufG(1'b1)
-  ) u_spi_device_mux (
-    .clk0_i(rst_spi_device_n),
+  ) u_0_spi_device_mux (
+    .clk0_i(rst_spi_device_n[Domain0Sel]),
     .clk1_i(scan_rst_ni),
     .sel_i(scanmode_i),
-    .clk_o(resets_o.rst_spi_device_n)
+    .clk_o(resets_o.rst_spi_device_n[Domain0Sel])
   );
 
-  logic rst_usb_n;
-
+  logic [PowerDomains-1:0] rst_usb_n;
   prim_flop_2sync #(
     .Width(1),
     .ResetValue('0)
-  ) u_usb (
+  ) u_aon_usb (
     .clk_i(clk_usb_i),
-    .rst_ni(rst_sys_src_n[0]),
+    .rst_ni(rst_sys_src_n[DomainAonSel]),
     .d_i(sw_rst_ctrl_n[USB]),
-    .q_o(rst_usb_n)
+    .q_o(rst_usb_n[DomainAonSel])
   );
 
   prim_clock_mux2 #(
     .NoFpgaBufG(1'b1)
-  ) u_usb_mux (
-    .clk0_i(rst_usb_n),
+  ) u_aon_usb_mux (
+    .clk0_i(rst_usb_n[DomainAonSel]),
     .clk1_i(scan_rst_ni),
     .sel_i(scanmode_i),
-    .clk_o(resets_o.rst_usb_n)
+    .clk_o(resets_o.rst_usb_n[DomainAonSel])
   );
+
+  assign rst_usb_n[Domain0Sel] = 1'b0;
+  assign resets_o.rst_usb_n[Domain0Sel] = rst_usb_n[Domain0Sel];
+
 
 
   ////////////////////////////////////////////////////

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_pkg.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_pkg.sv
@@ -14,14 +14,12 @@
 
 package rstmgr_pkg;
 
-  // global constants
-  parameter int ALWAYS_ON_SEL   = pwrmgr_pkg::ALWAYS_ON_DOMAIN;
+  // Power domain parameters
+  parameter int PowerDomains = 2;
+  parameter int DomainAonSel = 0;
+  parameter int Domain0Sel = 1;
 
-  // params that reference pwrmgr, should be replaced once pwrmgr is merged
-  parameter int PowerDomains  = pwrmgr_pkg::PowerDomains;
-  //parameter int HwResetReqs   = pwrmgr_pkg::NumRstReqs;
-
-  // calculated domains
+  // Number of non-always-on domains
   parameter int OffDomains = PowerDomains-1;
 
   // positions of software controllable reset bits
@@ -41,20 +39,19 @@ package rstmgr_pkg;
   // resets generated and broadcast
   // This should be templatized and generated
   typedef struct packed {
-    logic rst_por_aon_n;
-    logic rst_por_n;
-    logic rst_por_io_n;
-    logic rst_por_io_div2_n;
-    logic rst_por_io_div4_n;
-    logic rst_por_usb_n;
-    logic rst_lc_n;
-    logic rst_lc_io_n;
-    logic rst_sys_n;
-    logic rst_sys_io_n;
-    logic rst_sys_io_div4_n;
-    logic rst_sys_aon_n;
-    logic rst_spi_device_n;
-    logic rst_usb_n;
+    logic [PowerDomains-1:0] rst_por_aon_n;
+    logic [PowerDomains-1:0] rst_por_n;
+    logic [PowerDomains-1:0] rst_por_io_n;
+    logic [PowerDomains-1:0] rst_por_io_div2_n;
+    logic [PowerDomains-1:0] rst_por_io_div4_n;
+    logic [PowerDomains-1:0] rst_por_usb_n;
+    logic [PowerDomains-1:0] rst_lc_n;
+    logic [PowerDomains-1:0] rst_lc_io_div4_n;
+    logic [PowerDomains-1:0] rst_sys_n;
+    logic [PowerDomains-1:0] rst_sys_io_div4_n;
+    logic [PowerDomains-1:0] rst_sys_aon_n;
+    logic [PowerDomains-1:0] rst_spi_device_n;
+    logic [PowerDomains-1:0] rst_usb_n;
   } rstmgr_out_t;
 
   // cpu reset requests and status
@@ -65,9 +62,9 @@ package rstmgr_pkg;
 
   // exported resets
   typedef struct packed {
-    logic rst_ast_usbdev_sys_io_div4_n;
-    logic rst_ast_usbdev_usb_n;
-    logic rst_ast_sensor_ctrl_sys_io_div4_n;
+    logic [PowerDomains-1:0] rst_ast_usbdev_sys_io_div4_n;
+    logic [PowerDomains-1:0] rst_ast_usbdev_usb_n;
+    logic [PowerDomains-1:0] rst_ast_sensor_ctrl_sys_io_div4_n;
   } rstmgr_ast_out_t;
 
   // default value for rstmgr_ast_rsp_t (for dangling ports)

--- a/hw/top_earlgrey/ip/xbar_main/data/autogen/xbar_main.gen.hjson
+++ b/hw/top_earlgrey/ip/xbar_main/data/autogen/xbar_main.gen.hjson
@@ -17,8 +17,8 @@
   reset: rst_main_ni
   reset_connections:
   {
-    rst_main_ni: sys
-    rst_fixed_ni: sys_io_div4
+    rst_main_ni: rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
+    rst_fixed_ni: rstmgr_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]
   }
   clock_reset_export: []
   clock_connections:
@@ -26,6 +26,7 @@
     clk_main_i: clkmgr_clocks.clk_main_infra
     clk_fixed_i: clkmgr_clocks.clk_io_div4_infra
   }
+  domain: "0"
   connections:
   {
     corei:

--- a/hw/top_earlgrey/ip/xbar_peri/data/autogen/xbar_peri.gen.hjson
+++ b/hw/top_earlgrey/ip/xbar_peri/data/autogen/xbar_peri.gen.hjson
@@ -16,13 +16,14 @@
   reset: rst_peri_ni
   reset_connections:
   {
-    rst_peri_ni: sys_io_div4
+    rst_peri_ni: rstmgr_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]
   }
   clock_reset_export: []
   clock_connections:
   {
     clk_peri_i: clkmgr_clocks.clk_io_div4_infra
   }
+  domain: "0"
   connections:
   {
     main:

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -319,6 +319,30 @@ module top_earlgrey #(
   tlul_pkg::tl_d2h_t       main_tl_debug_mem_rsp;
 
 
+  // Unused reset signals
+  logic unused_d0_rst_por_aon;
+  logic unused_d0_rst_por;
+  logic unused_d0_rst_por_io;
+  logic unused_d0_rst_por_io_div2;
+  logic unused_d0_rst_por_io_div4;
+  logic unused_d0_rst_por_usb;
+  logic unused_daon_rst_lc;
+  logic unused_daon_rst_lc_io_div4;
+  logic unused_d0_rst_sys_aon;
+  logic unused_daon_rst_spi_device;
+  logic unused_d0_rst_usb;
+  assign unused_d0_rst_por_aon = rstmgr_resets.rst_por_aon_n[rstmgr_pkg::Domain0Sel];
+  assign unused_d0_rst_por = rstmgr_resets.rst_por_n[rstmgr_pkg::Domain0Sel];
+  assign unused_d0_rst_por_io = rstmgr_resets.rst_por_io_n[rstmgr_pkg::Domain0Sel];
+  assign unused_d0_rst_por_io_div2 = rstmgr_resets.rst_por_io_div2_n[rstmgr_pkg::Domain0Sel];
+  assign unused_d0_rst_por_io_div4 = rstmgr_resets.rst_por_io_div4_n[rstmgr_pkg::Domain0Sel];
+  assign unused_d0_rst_por_usb = rstmgr_resets.rst_por_usb_n[rstmgr_pkg::Domain0Sel];
+  assign unused_daon_rst_lc = rstmgr_resets.rst_lc_n[rstmgr_pkg::DomainAonSel];
+  assign unused_daon_rst_lc_io_div4 = rstmgr_resets.rst_lc_io_div4_n[rstmgr_pkg::DomainAonSel];
+  assign unused_d0_rst_sys_aon = rstmgr_resets.rst_sys_aon_n[rstmgr_pkg::Domain0Sel];
+  assign unused_daon_rst_spi_device = rstmgr_resets.rst_spi_device_n[rstmgr_pkg::DomainAonSel];
+  assign unused_d0_rst_usb = rstmgr_resets.rst_usb_n[rstmgr_pkg::Domain0Sel];
+
   // Non-debug module reset == reset for everything except for the debug module
   logic ndmreset_req;
 
@@ -349,7 +373,7 @@ module top_earlgrey #(
   ) u_rv_core_ibex (
     // clock and reset
     .clk_i                (clkmgr_clocks.clk_proc_main),
-    .rst_ni               (rstmgr_resets.rst_sys_n),
+    .rst_ni               (rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]),
     .test_en_i            (1'b0),
     // static pinning
     .hart_id_i            (32'b0),
@@ -381,7 +405,7 @@ module top_earlgrey #(
     .IdcodeValue (JTAG_IDCODE)
   ) u_dm_top (
     .clk_i         (clkmgr_clocks.clk_proc_main),
-    .rst_ni        (rstmgr_resets.rst_lc_n),
+    .rst_ni        (rstmgr_resets.rst_lc_n[rstmgr_pkg::Domain0Sel]),
     .testmode_i    (1'b0),
     .ndmreset_o    (ndmreset_req),
     .dmactive_o    (),
@@ -406,7 +430,7 @@ module top_earlgrey #(
   );
 
   assign rstmgr_cpu.ndmreset_req = ndmreset_req;
-  assign rstmgr_cpu.rst_cpu_n = rstmgr_resets.rst_sys_n;
+  assign rstmgr_cpu.rst_cpu_n = rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel];
 
   // ROM device
   logic        rom_req;
@@ -421,7 +445,7 @@ module top_earlgrey #(
     .ErrOnWrite(1)
   ) u_tl_adapter_rom (
     .clk_i   (clkmgr_clocks.clk_main_infra),
-    .rst_ni   (rstmgr_resets.rst_sys_n),
+    .rst_ni   (rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]),
 
     .tl_i     (rom_tl_req),
     .tl_o     (rom_tl_rsp),
@@ -443,7 +467,7 @@ module top_earlgrey #(
     .MemInitFile(BootRomInitFile)
   ) u_rom_rom (
     .clk_i   (clkmgr_clocks.clk_main_infra),
-    .rst_ni   (rstmgr_resets.rst_sys_n),
+    .rst_ni   (rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]),
     .req_i    (rom_req),
     .addr_i   (rom_addr),
     .rdata_o  (rom_rdata),
@@ -467,7 +491,7 @@ module top_earlgrey #(
     .Outstanding(2)
   ) u_tl_adapter_ram_main (
     .clk_i   (clkmgr_clocks.clk_main_infra),
-    .rst_ni   (rstmgr_resets.rst_sys_n),
+    .rst_ni   (rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]),
     .tl_i     (ram_main_tl_req),
     .tl_o     (ram_main_tl_rsp),
 
@@ -491,7 +515,7 @@ module top_earlgrey #(
     .EnableParity(0)
   ) u_ram1p_ram_main (
     .clk_i   (clkmgr_clocks.clk_main_infra),
-    .rst_ni   (rstmgr_resets.rst_sys_n),
+    .rst_ni   (rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]),
 
     .req_i    (ram_main_req),
     .write_i  (ram_main_we),
@@ -519,7 +543,7 @@ module top_earlgrey #(
     .Outstanding(2)
   ) u_tl_adapter_ram_ret (
     .clk_i   (clkmgr_clocks.clk_io_div4_infra),
-    .rst_ni   (rstmgr_resets.rst_sys_io_div4_n),
+    .rst_ni   (rstmgr_resets.rst_sys_io_div4_n[rstmgr_pkg::DomainAonSel]),
     .tl_i     (ram_ret_tl_req),
     .tl_o     (ram_ret_tl_rsp),
 
@@ -543,7 +567,7 @@ module top_earlgrey #(
     .EnableParity(0)
   ) u_ram1p_ram_ret (
     .clk_i   (clkmgr_clocks.clk_io_div4_infra),
-    .rst_ni   (rstmgr_resets.rst_sys_io_div4_n),
+    .rst_ni   (rstmgr_resets.rst_sys_io_div4_n[rstmgr_pkg::DomainAonSel]),
 
     .req_i    (ram_ret_req),
     .write_i  (ram_ret_we),
@@ -572,7 +596,7 @@ module top_earlgrey #(
     .ErrOnWrite(1)
   ) u_tl_adapter_eflash (
     .clk_i   (clkmgr_clocks.clk_main_infra),
-    .rst_ni   (rstmgr_resets.rst_lc_n),
+    .rst_ni   (rstmgr_resets.rst_lc_n[rstmgr_pkg::Domain0Sel]),
 
     .tl_i     (eflash_tl_req),
     .tl_o     (eflash_tl_rsp),
@@ -590,7 +614,7 @@ module top_earlgrey #(
 
   flash_phy u_flash_eflash (
     .clk_i   (clkmgr_clocks.clk_main_infra),
-    .rst_ni   (rstmgr_resets.rst_lc_n),
+    .rst_ni   (rstmgr_resets.rst_lc_n[rstmgr_pkg::Domain0Sel]),
     .host_req_i      (flash_host_req),
     .host_addr_i     (flash_host_addr),
     .host_req_rdy_o  (flash_host_req_rdy),
@@ -626,7 +650,7 @@ module top_earlgrey #(
       .tl_i(uart_tl_req),
       .tl_o(uart_tl_rsp),
       .clk_i (clkmgr_clocks.clk_io_div4_secure),
-      .rst_ni (rstmgr_resets.rst_sys_io_div4_n)
+      .rst_ni (rstmgr_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel])
   );
 
   gpio u_gpio (
@@ -645,7 +669,7 @@ module top_earlgrey #(
       .tl_i(gpio_tl_req),
       .tl_o(gpio_tl_rsp),
       .clk_i (clkmgr_clocks.clk_io_div4_peri),
-      .rst_ni (rstmgr_resets.rst_sys_io_div4_n)
+      .rst_ni (rstmgr_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel])
   );
 
   spi_device u_spi_device (
@@ -672,7 +696,7 @@ module top_earlgrey #(
       .tl_o(spi_device_tl_rsp),
       .scanmode_i   (scanmode_i),
       .clk_i (clkmgr_clocks.clk_io_div4_peri),
-      .rst_ni (rstmgr_resets.rst_spi_device_n)
+      .rst_ni (rstmgr_resets.rst_spi_device_n[rstmgr_pkg::Domain0Sel])
   );
 
   flash_ctrl u_flash_ctrl (
@@ -698,7 +722,7 @@ module top_earlgrey #(
       .tl_i(flash_ctrl_tl_req),
       .tl_o(flash_ctrl_tl_rsp),
       .clk_i (clkmgr_clocks.clk_main_infra),
-      .rst_ni (rstmgr_resets.rst_lc_n)
+      .rst_ni (rstmgr_resets.rst_lc_n[rstmgr_pkg::Domain0Sel])
   );
 
   rv_timer u_rv_timer (
@@ -710,7 +734,7 @@ module top_earlgrey #(
       .tl_i(rv_timer_tl_req),
       .tl_o(rv_timer_tl_rsp),
       .clk_i (clkmgr_clocks.clk_io_div4_timers),
-      .rst_ni (rstmgr_resets.rst_sys_io_div4_n)
+      .rst_ni (rstmgr_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel])
   );
 
   aes #(
@@ -734,7 +758,7 @@ module top_earlgrey #(
       .tl_i(aes_tl_req),
       .tl_o(aes_tl_rsp),
       .clk_i (clkmgr_clocks.clk_main_aes),
-      .rst_ni (rstmgr_resets.rst_sys_n)
+      .rst_ni (rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel])
   );
 
   hmac u_hmac (
@@ -749,7 +773,7 @@ module top_earlgrey #(
       .tl_i(hmac_tl_req),
       .tl_o(hmac_tl_rsp),
       .clk_i (clkmgr_clocks.clk_main_hmac),
-      .rst_ni (rstmgr_resets.rst_sys_n)
+      .rst_ni (rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel])
   );
 
   kmac #(
@@ -770,7 +794,7 @@ module top_earlgrey #(
       .tl_i(kmac_tl_req),
       .tl_o(kmac_tl_rsp),
       .clk_i (clkmgr_clocks.clk_main_kmac),
-      .rst_ni (rstmgr_resets.rst_sys_n)
+      .rst_ni (rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel])
   );
 
   rv_plic u_rv_plic (
@@ -784,7 +808,7 @@ module top_earlgrey #(
       .irq_id_o   (irq_id),
       .msip_o     (msip),
       .clk_i (clkmgr_clocks.clk_main_secure),
-      .rst_ni (rstmgr_resets.rst_sys_n)
+      .rst_ni (rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel])
   );
 
   pinmux u_pinmux (
@@ -816,8 +840,8 @@ module top_earlgrey #(
       .dio_in_i,
       .clk_i (clkmgr_clocks.clk_main_secure),
       .clk_aon_i (clkmgr_clocks.clk_aon_secure),
-      .rst_ni (rstmgr_resets.rst_sys_n),
-      .rst_aon_ni (rstmgr_resets.rst_sys_aon_n)
+      .rst_ni (rstmgr_resets.rst_sys_n[rstmgr_pkg::DomainAonSel]),
+      .rst_aon_ni (rstmgr_resets.rst_sys_aon_n[rstmgr_pkg::DomainAonSel])
   );
 
   padctrl u_padctrl (
@@ -829,7 +853,7 @@ module top_earlgrey #(
       .mio_attr_o,
       .dio_attr_o,
       .clk_i (clkmgr_clocks.clk_main_secure),
-      .rst_ni (rstmgr_resets.rst_sys_n)
+      .rst_ni (rstmgr_resets.rst_sys_n[rstmgr_pkg::DomainAonSel])
   );
 
   alert_handler #(
@@ -856,7 +880,7 @@ module top_earlgrey #(
       .esc_rx_i    ( esc_rx   ),
       .esc_tx_o    ( esc_tx   ),
       .clk_i (clkmgr_clocks.clk_main_secure),
-      .rst_ni (rstmgr_resets.rst_sys_n)
+      .rst_ni (rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel])
   );
 
   pwrmgr u_pwrmgr (
@@ -884,8 +908,8 @@ module top_earlgrey #(
       .tl_o(pwrmgr_tl_rsp),
       .clk_i (clkmgr_clocks.clk_io_div4_powerup),
       .clk_slow_i (clkmgr_clocks.clk_aon_powerup),
-      .rst_ni (rstmgr_resets.rst_por_n),
-      .rst_slow_ni (rstmgr_resets.rst_por_aon_n)
+      .rst_ni (rstmgr_resets.rst_por_n[rstmgr_pkg::DomainAonSel]),
+      .rst_slow_ni (rstmgr_resets.rst_por_aon_n[rstmgr_pkg::DomainAonSel])
   );
 
   rstmgr u_rstmgr (
@@ -928,12 +952,12 @@ module top_earlgrey #(
       .tl_o(clkmgr_tl_rsp),
       .scanmode_i   (scanmode_i),
       .clk_i (clkmgr_clocks.clk_io_div4_powerup),
-      .rst_ni (rstmgr_resets.rst_por_io_n),
-      .rst_main_ni (rstmgr_resets.rst_por_n),
-      .rst_io_ni (rstmgr_resets.rst_por_io_n),
-      .rst_usb_ni (rstmgr_resets.rst_por_usb_n),
-      .rst_io_div2_ni (rstmgr_resets.rst_por_io_div2_n),
-      .rst_io_div4_ni (rstmgr_resets.rst_por_io_div4_n)
+      .rst_ni (rstmgr_resets.rst_por_io_div4_n[rstmgr_pkg::DomainAonSel]),
+      .rst_main_ni (rstmgr_resets.rst_por_n[rstmgr_pkg::DomainAonSel]),
+      .rst_io_ni (rstmgr_resets.rst_por_io_n[rstmgr_pkg::DomainAonSel]),
+      .rst_usb_ni (rstmgr_resets.rst_por_usb_n[rstmgr_pkg::DomainAonSel]),
+      .rst_io_div2_ni (rstmgr_resets.rst_por_io_div2_n[rstmgr_pkg::DomainAonSel]),
+      .rst_io_div4_ni (rstmgr_resets.rst_por_io_div4_n[rstmgr_pkg::DomainAonSel])
   );
 
   nmi_gen u_nmi_gen (
@@ -951,7 +975,7 @@ module top_earlgrey #(
       .esc_rx_o    ( esc_rx[3:1] ),
       .esc_tx_i    ( esc_tx[3:1] ),
       .clk_i (clkmgr_clocks.clk_main_secure),
-      .rst_ni (rstmgr_resets.rst_sys_n)
+      .rst_ni (rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel])
   );
 
   usbdev u_usbdev (
@@ -1006,8 +1030,8 @@ module top_earlgrey #(
       .tl_o(usbdev_tl_rsp),
       .clk_i (clkmgr_clocks.clk_io_div4_peri),
       .clk_usb_48mhz_i (clkmgr_clocks.clk_usb_peri),
-      .rst_ni (rstmgr_resets.rst_sys_io_div4_n),
-      .rst_usb_48mhz_ni (rstmgr_resets.rst_usb_n)
+      .rst_ni (rstmgr_resets.rst_sys_io_div4_n[rstmgr_pkg::DomainAonSel]),
+      .rst_usb_48mhz_ni (rstmgr_resets.rst_usb_n[rstmgr_pkg::DomainAonSel])
   );
 
   sensor_ctrl u_sensor_ctrl (
@@ -1029,7 +1053,7 @@ module top_earlgrey #(
       .tl_i(sensor_ctrl_tl_req),
       .tl_o(sensor_ctrl_tl_rsp),
       .clk_i (clkmgr_clocks.clk_io_div4_secure),
-      .rst_ni (rstmgr_resets.rst_sys_io_div4_n)
+      .rst_ni (rstmgr_resets.rst_sys_io_div4_n[rstmgr_pkg::DomainAonSel])
   );
 
   keymgr u_keymgr (
@@ -1055,7 +1079,7 @@ module top_earlgrey #(
       .tl_i(keymgr_tl_req),
       .tl_o(keymgr_tl_rsp),
       .clk_i (clkmgr_clocks.clk_main_secure),
-      .rst_ni (rstmgr_resets.rst_sys_n)
+      .rst_ni (rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel])
   );
 
   otp_ctrl #(
@@ -1101,7 +1125,7 @@ module top_earlgrey #(
       .tl_i(otp_ctrl_tl_req),
       .tl_o(otp_ctrl_tl_rsp),
       .clk_i (clkmgr_clocks.clk_io_div4_timers),
-      .rst_ni (rstmgr_resets.rst_lc_io_n)
+      .rst_ni (rstmgr_resets.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel])
   );
 
   otbn #(
@@ -1123,7 +1147,7 @@ module top_earlgrey #(
       .tl_i(otbn_tl_req),
       .tl_o(otbn_tl_rsp),
       .clk_i (clkmgr_clocks.clk_main_otbn),
-      .rst_ni (rstmgr_resets.rst_sys_n)
+      .rst_ni (rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel])
   );
 
   // interrupt assignments
@@ -1191,8 +1215,8 @@ module top_earlgrey #(
   xbar_main u_xbar_main (
     .clk_main_i (clkmgr_clocks.clk_main_infra),
     .clk_fixed_i (clkmgr_clocks.clk_io_div4_infra),
-    .rst_main_ni (rstmgr_resets.rst_sys_n),
-    .rst_fixed_ni (rstmgr_resets.rst_sys_io_div4_n),
+    .rst_main_ni (rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]),
+    .rst_fixed_ni (rstmgr_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]),
 
     // port: tl_corei
     .tl_corei_i(main_tl_corei_req),
@@ -1275,7 +1299,7 @@ module top_earlgrey #(
   );
   xbar_peri u_xbar_peri (
     .clk_peri_i (clkmgr_clocks.clk_io_div4_infra),
-    .rst_peri_ni (rstmgr_resets.rst_sys_io_div4_n),
+    .rst_peri_ni (rstmgr_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]),
 
     // port: tl_main
     .tl_main_i(main_tl_peri_req),

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -693,6 +693,7 @@ def generate_rstmgr(topcfg, out_path):
             tpl = Template(fin.read())
             try:
                 out = tpl.render(clks=clks,
+                                 power_domains=topcfg['power']['domains'],
                                  num_rstreqs=n_rstreqs,
                                  sw_rsts=sw_rsts,
                                  output_rsts=output_rsts,

--- a/util/topgen/lib.py
+++ b/util/topgen/lib.py
@@ -231,11 +231,43 @@ def get_clk_name(clk):
         return "clk_{}_i".format(clk)
 
 
-def get_reset_path(resets, name):
+def get_reset_path(reset, domain, reset_cfg):
     """Return the appropriate reset path given name
     """
-    for reset in resets:
-        if reset['name'] == name:
-            return reset['path']
+    # find matching node for reset
+    node_match = [node for node in reset_cfg['nodes'] if node['name'] == reset]
+    assert len(node_match) == 1
+    reset_type = node_match[0]['type']
 
-    return "none"
+    # find matching path
+    hier_path = ""
+    if reset_type == "int":
+        log.debug("{} used as internal reset".format(reset["name"]))
+    else:
+        hier_path = reset_cfg['hier_paths'][reset_type]
+
+    # find domain selection
+    domain_sel = ''
+    if reset_type not in ["ext", "int"]:
+        domain_sel = "[rstmgr_pkg::Domain{}Sel]".format(domain)
+
+    reset_path = ""
+    if reset_type == "ext":
+        reset_path = reset
+    else:
+        reset_path = "{}rst_{}_n{}".format(hier_path, reset, domain_sel)
+
+    return reset_path
+
+
+def get_unused_resets(top):
+    """Return dict of unused resets and associated domain
+    """
+    unused_resets = OrderedDict()
+    unused_resets = {reset['name']: domain
+                     for reset in top['resets']['nodes']
+                     for domain in top['power']['domains']
+                     if reset['type'] == 'top' and domain not in reset['domains']}
+
+    log.debug("Unused resets are {}".format(unused_resets))
+    return unused_resets


### PR DESCRIPTION
Add power domain support to the design. 

- Each module, memory and xbar now has a notion of what power domain it belongs to.
- The resets generated now also have always-on and non-always-on versions.  These should be correctly routed to all the consuming modules. 