### PR TITLE
[dv] add two-way data to push_pull_agent

### DIFF
--- a/hw/dv/sv/push_pull_agent/push_pull_agent.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_agent.sv
@@ -2,28 +2,32 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class push_pull_agent #(parameter int DataWidth = 32) extends dv_base_agent #(
-  .CFG_T          (push_pull_agent_cfg#(DataWidth)),
-  .DRIVER_T       (push_pull_driver#(DataWidth)),
-  .HOST_DRIVER_T  (push_pull_host_driver#(DataWidth)),
-  .DEVICE_DRIVER_T(push_pull_device_driver#(DataWidth)),
-  .SEQUENCER_T    (push_pull_sequencer#(DataWidth)),
-  .MONITOR_T      (push_pull_monitor#(DataWidth)),
-  .COV_T          (push_pull_agent_cov#(DataWidth))
+class push_pull_agent #(parameter int HostDataWidth = 32,
+                        parameter int DeviceDataWidth = HostDataWidth)
+  extends dv_base_agent #(
+  .CFG_T          (push_pull_agent_cfg#(HostDataWidth, DeviceDataWidth)),
+  .DRIVER_T       (push_pull_driver#(HostDataWidth, DeviceDataWidth)),
+  .HOST_DRIVER_T  (push_pull_host_driver#(HostDataWidth, DeviceDataWidth)),
+  .DEVICE_DRIVER_T(push_pull_device_driver#(HostDataWidth, DeviceDataWidth)),
+  .SEQUENCER_T    (push_pull_sequencer#(HostDataWidth, DeviceDataWidth)),
+  .MONITOR_T      (push_pull_monitor#(HostDataWidth, DeviceDataWidth)),
+  .COV_T          (push_pull_agent_cov#(HostDataWidth, DeviceDataWidth))
 );
 
-  `uvm_component_param_utils(push_pull_agent#(DataWidth))
+  `uvm_component_param_utils(push_pull_agent#(HostDataWidth, DeviceDataWidth))
 
   `uvm_component_new
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
     // get push_pull_if handle
-    if (!uvm_config_db#(virtual push_pull_if#(DataWidth))::get(this, "", "vif", cfg.vif)) begin
+    if (!uvm_config_db#(virtual push_pull_if#(HostDataWidth, DeviceDataWidth))::get(this, "", "vif",
+                                                                                    cfg.vif)) begin
       `uvm_fatal(`gfn, "failed to get push_pull_if handle from uvm_config_db")
     end
-    cfg.vif.if_mode = cfg.if_mode;
-    cfg.vif.is_push_agent = (cfg.agent_type == PushAgent);
+    cfg.vif.if_mode               = cfg.if_mode;
+    cfg.vif.is_push_agent         = (cfg.agent_type == PushAgent);
+    cfg.vif.in_bidirectional_mode = cfg.in_bidirectional_mode;
   endfunction
 
   function void connect_phase(uvm_phase phase);
@@ -34,8 +38,8 @@ class push_pull_agent #(parameter int DataWidth = 32) extends dv_base_agent #(
   endfunction
 
   virtual task run_phase(uvm_phase phase);
-    push_pull_device_seq#(DataWidth) m_seq =
-      push_pull_device_seq#(DataWidth)::type_id::create("m_seq", this);
+    push_pull_device_seq#(HostDataWidth, DeviceDataWidth) m_seq =
+      push_pull_device_seq#(HostDataWidth, DeviceDataWidth)::type_id::create("m_seq", this);
     if (cfg.if_mode == dv_utils_pkg::Device && cfg.start_default_device_seq) begin
       uvm_config_db#(uvm_object_wrapper)::set(null,
                                              {sequencer.get_full_name(), ".run_phase"},

--- a/hw/dv/sv/push_pull_agent/push_pull_agent_cfg.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_agent_cfg.sv
@@ -2,14 +2,20 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class push_pull_agent_cfg #(parameter int DataWidth = 32) extends dv_base_agent_cfg;
+class push_pull_agent_cfg #(parameter int HostDataWidth = 32,
+                            parameter int DeviceDataWidth = HostDataWidth)
+  extends dv_base_agent_cfg;
 
   // interface handle used by driver, monitor & the sequencer, via cfg handle
-  virtual push_pull_if#(DataWidth) vif;
+  virtual push_pull_if#(HostDataWidth, DeviceDataWidth) vif;
 
   // Determines whether this agent is configured as push or pull.
   // Should be set from the IP level environment.
   push_pull_agent_e agent_type;
+
+  // Configures the agent to act in bidirectional mode,
+  // transferring data on both sides of the handshake.
+  bit in_bidirectional_mode = 1'b0;
 
   // Device-side delay range for both Push/Pull protocols.
   int unsigned device_delay_min = 0;
@@ -31,8 +37,9 @@ class push_pull_agent_cfg #(parameter int DataWidth = 32) extends dv_base_agent_
                        1 := 3 };
   }
 
-  `uvm_object_param_utils_begin(push_pull_agent_cfg#(DataWidth))
+  `uvm_object_param_utils_begin(push_pull_agent_cfg#(HostDataWidth, DeviceDataWidth))
     `uvm_field_enum(push_pull_agent_e, agent_type, UVM_DEFAULT)
+    `uvm_field_int(in_bidirectional_mode,          UVM_DEFAULT)
     `uvm_field_int(device_delay_min,               UVM_DEFAULT)
     `uvm_field_int(device_delay_max,               UVM_DEFAULT)
     `uvm_field_int(host_delay_min,                 UVM_DEFAULT)

--- a/hw/dv/sv/push_pull_agent/push_pull_agent_cov.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_agent_cov.sv
@@ -2,11 +2,13 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class push_pull_agent_cov #(parameter int DataWidth = 32) extends dv_base_agent_cov #(
-    push_pull_agent_cfg#(DataWidth)
+class push_pull_agent_cov #(parameter int HostDataWidth = 32,
+                            parameter int DeviceDataWidth = HostDataWidth)
+  extends dv_base_agent_cov #(
+    push_pull_agent_cfg#(HostDataWidth, DeviceDataWidth)
 );
 
-  `uvm_component_param_utils(push_pull_agent_cov#(DataWidth))
+  `uvm_component_param_utils(push_pull_agent_cov#(HostDataWidth, DeviceDataWidth))
 
   // the base class provides the following handles for use:
   // push_pull_agent_cfg: cfg

--- a/hw/dv/sv/push_pull_agent/push_pull_device_driver.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_device_driver.sv
@@ -5,9 +5,11 @@
 `define PUSH_DRIVER cfg.vif.device_push_cb
 `define PULL_DRIVER cfg.vif.device_pull_cb
 
-class push_pull_device_driver #(parameter int DataWidth = 32) extends push_pull_driver #(DataWidth);
+class push_pull_device_driver #(parameter int HostDataWidth = 32,
+                                parameter int DeviceDataWidth = HostDataWidth)
+  extends push_pull_driver #(HostDataWidth, DeviceDataWidth);
 
-  `uvm_component_param_utils(push_pull_device_driver#(DataWidth))
+  `uvm_component_param_utils(push_pull_device_driver#(HostDataWidth, DeviceDataWidth))
 
   // the base class provides the following handles for use:
   // push_pull_agent_cfg: cfg
@@ -19,8 +21,8 @@ class push_pull_device_driver #(parameter int DataWidth = 32) extends push_pull_
       cfg.vif.ready_int <= '0;
     end else begin
       cfg.vif.ack_int   <= '0;
-      cfg.vif.data_int  <= 'x;
     end
+    cfg.vif.d_data_int <= 'x;
   endtask
 
   virtual task get_and_drive();
@@ -49,11 +51,13 @@ class push_pull_device_driver #(parameter int DataWidth = 32) extends push_pull_
       @(`PUSH_DRIVER);
     end
     if (!in_reset) begin
-      `PUSH_DRIVER.ready_int <= 1'b1;
+      `PUSH_DRIVER.ready_int  <= 1'b1;
+      `PUSH_DRIVER.d_data_int <= req.d_data;
     end
     @(`PUSH_DRIVER);
     if (!in_reset) begin
-      `PUSH_DRIVER.ready_int <= 1'b0;
+      `PUSH_DRIVER.ready_int  <= 1'b0;
+      `PUSH_DRIVER.d_data_int <= 'x;
     end
   endtask
 
@@ -66,13 +70,13 @@ class push_pull_device_driver #(parameter int DataWidth = 32) extends push_pull_
       @(`PULL_DRIVER);
     end
     if (!in_reset) begin
-      `PULL_DRIVER.ack_int  <= 1'b1;
-      `PULL_DRIVER.data_int <= req.data;
+      `PULL_DRIVER.ack_int    <= 1'b1;
+      `PULL_DRIVER.d_data_int <= req.d_data;
     end
     @(`PULL_DRIVER);
     if (!in_reset) begin
-      `PULL_DRIVER.ack_int  <= 1'b0;
-      `PULL_DRIVER.data_int <= 'x;
+      `PULL_DRIVER.ack_int    <= 1'b0;
+      `PULL_DRIVER.d_data_int <= 'x;
     end
   endtask
 

--- a/hw/dv/sv/push_pull_agent/push_pull_driver.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_driver.sv
@@ -2,14 +2,16 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class push_pull_driver #(parameter int DataWidth = 32) extends dv_base_driver #(
-    .ITEM_T(push_pull_item#(DataWidth)),
-    .CFG_T(push_pull_agent_cfg#(DataWidth))
+class push_pull_driver #(parameter int HostDataWidth = 32,
+                         parameter int DeviceDataWidth = HostDataWidth)
+  extends dv_base_driver #(
+    .ITEM_T(push_pull_item#(HostDataWidth, DeviceDataWidth)),
+    .CFG_T(push_pull_agent_cfg#(HostDataWidth, DeviceDataWidth))
 );
 
   bit in_reset = 1'b0;
 
-  `uvm_component_param_utils(push_pull_driver#(DataWidth))
+  `uvm_component_param_utils(push_pull_driver#(HostDataWidth, DeviceDataWidth))
   `uvm_component_new
 
   virtual task reset_signals();

--- a/hw/dv/sv/push_pull_agent/push_pull_if.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_if.sv
@@ -4,7 +4,10 @@
 
 `include "prim_assert.sv"
 
-interface push_pull_if #(parameter int DataWidth = 32) (input wire clk, input wire rst_n);
+interface push_pull_if #(parameter int HostDataWidth = 32,
+                         parameter int DeviceDataWidth = HostDataWidth) (
+  input wire clk, input wire rst_n
+);
 
   // Pins for the push handshake (ready/valid)
   wire  ready;
@@ -14,6 +17,12 @@ interface push_pull_if #(parameter int DataWidth = 32) (input wire clk, input wi
   wire  req;
   wire  ack;
 
+  // Parameterized width data payloads in both directions of the handshake.
+  // Data sent from host to device
+  wire [HostDataWidth-1:0] h_data;
+  // Data sent from device to host
+  wire [DeviceDataWidth-1:0] d_data;
+
   // Internal versions of the interface output signals.
   // These signals are assigned as outputs depending on
   // how the agent is configured.
@@ -21,10 +30,8 @@ interface push_pull_if #(parameter int DataWidth = 32) (input wire clk, input wi
   logic valid_int;
   logic req_int;
   logic ack_int;
-  logic [DataWidth-1:0] data_int;
-
-  // Parameterized width data payload
-  wire  [DataWidth-1:0] data;
+  logic [HostDataWidth-1:0]   h_data_int;
+  logic [DeviceDataWidth-1:0]   d_data_int;
 
   // Interface mode - Host or Device
   dv_utils_pkg::if_mode_e if_mode;
@@ -36,29 +43,37 @@ interface push_pull_if #(parameter int DataWidth = 32) (input wire clk, input wi
   // This bit is set to the appropriate value in push_pull_agent::build_phase().
   bit is_push_agent;
 
+  // This bit controls whether the agent is in bidirectional mode,
+  // transferring data on both sides of the handshake.
+  bit in_bidirectional_mode;
+
   // clocking blocks
   clocking host_push_cb @(posedge clk);
     input   ready;
+    input   d_data;
     output  valid_int;
-    output  data_int;
+    output  h_data_int;
   endclocking
 
   clocking device_push_cb @(posedge clk);
     output  ready_int;
+    output  d_data_int;
     input   valid;
-    input   data;
+    input   h_data;
   endclocking
 
   clocking host_pull_cb @(posedge clk);
     output  req_int;
+    output  h_data_int;
     input   ack;
-    input   data;
+    input   d_data;
   endclocking
 
   clocking device_pull_cb @(posedge clk);
     input   req;
+    input   h_data;
     output  ack_int;
-    output  data_int;
+    output  d_data_int;
   endclocking
 
   clocking mon_cb @(posedge clk);
@@ -66,18 +81,21 @@ interface push_pull_if #(parameter int DataWidth = 32) (input wire clk, input wi
     input valid;
     input req;
     input ack;
-    input data;
+    input d_data;
+    input h_data;
   endclocking
 
   // Push output assignments
-  assign ready = (is_push_agent && if_mode == dv_utils_pkg::Device) ? ready_int : 'z;
-  assign valid = (is_push_agent && if_mode == dv_utils_pkg::Host)   ? valid_int : 'z;
-  assign data  = (is_push_agent && if_mode == dv_utils_pkg::Host)   ? data_int : 'z;
+  assign ready =    (is_push_agent && if_mode == dv_utils_pkg::Device) ? ready_int : 'z;
+  assign valid =    (is_push_agent && if_mode == dv_utils_pkg::Host)   ? valid_int : 'z;
 
   // Pull output assignments
-  assign req  = (!is_push_agent && if_mode == dv_utils_pkg::Host)   ? req_int : 'z;
-  assign ack  = (!is_push_agent && if_mode == dv_utils_pkg::Device) ? ack_int : 'z;
-  assign data = (!is_push_agent && if_mode == dv_utils_pkg::Device) ? data_int : 'z;
+  assign req  =     (!is_push_agent && if_mode == dv_utils_pkg::Host)   ? req_int : 'z;
+  assign ack  =     (!is_push_agent && if_mode == dv_utils_pkg::Device) ? ack_int : 'z;
+
+  // Data signal assignments
+  assign h_data = (if_mode == dv_utils_pkg::Host) ? h_data_int : 'z;
+  assign d_data = (if_mode == dv_utils_pkg::Device) ? d_data_int : 'z;
 
   // utility tasks
   task automatic wait_clks(input int num);
@@ -88,31 +106,50 @@ interface push_pull_if #(parameter int DataWidth = 32) (input wire clk, input wi
     repeat (num) @(negedge clk);
   endtask : wait_n_clks
 
-  // Assertions for ready/valid protocol.
+  /////////////////////////////////////////
+  // Assertions for ready/valid protocol //
+  /////////////////////////////////////////
 
   // The ready and valid signals should always have known values.
   `ASSERT_KNOWN_IF(ReadyIsKnown_A, ready, is_push_agent, clk, !rst_n)
   `ASSERT_KNOWN_IF(ValidIsKnown_A, valid, is_push_agent, clk, !rst_n)
 
-  // Whenever valid is asserted, the data must have a known value.
-  `ASSERT_KNOWN_IF(DataKnownWhenValid_A, data, valid && is_push_agent, clk, !rst_n)
+  // Whenever valid is asserted, h_data must have a known value.
+  `ASSERT_KNOWN_IF(H_DataKnownWhenValid_A, h_data, valid && is_push_agent, clk, !rst_n)
 
-  // When valid is asserted but ready is low the data must stay stable.
-  `ASSERT_IF(DataStableWhenValidAndNotReady_A, (valid && !ready) |=> $stable(data),
+  // Whenver ready is asserted and the agent is in bidirectional mode,
+  // d_data must have a known value.
+  `ASSERT_KNOWN_IF(D_DataKnownWhenReady_A, d_data,
+                   ready && is_push_agent && in_bidirectional_mode, clk, !rst_n)
+
+  // When valid is asserted but ready is low the h_data must stay stable.
+  `ASSERT_IF(H_DataStableWhenValidAndNotReady_A, (valid && !ready) |=> $stable(h_data),
              is_push_agent, clk, !rst_n)
 
   // When valid is asserted, it must stay high until seeing ready be asserted.
   `ASSERT_IF(ValidHighUntilReady_A, $rose(valid) |-> (valid throughout ready [->1]),
              is_push_agent, clk, !rst_n)
 
-  // Assertions for req/ack protocol.
+  /////////////////////////////////////
+  // Assertions for req/ack protocol //
+  /////////////////////////////////////
 
   // The req and ack signals should always have known values.
   `ASSERT_KNOWN_IF(ReqIsKnown_A, req, !is_push_agent, clk, !rst_n)
   `ASSERT_KNOWN_IF(AckIsKnown_A, ack, !is_push_agent, clk, !rst_n)
 
-  // When ack is asserted, the data must have a known value.
-  `ASSERT_KNOWN_IF(DataKnownWhenAck_A, data, ack && !is_push_agent, clk, !rst_n)
+  // When ack is asserted, d_data must have a known value.
+  `ASSERT_KNOWN_IF(D_DataKnownWhenAck_A, d_data, ack && !is_push_agent, clk, !rst_n)
+
+  // When req is asserted and the agent is in bidirectional mode,
+  // h_data must have a known value.
+  `ASSERT_KNOWN_IF(H_DataKnownWhenReq_A, h_data,
+                   req && !is_push_agent && in_bidirectional_mode, clk, !rst_n)
+
+  // When req is asserted but ack is low, and the agent is in bidirectional mode,
+  // h_data must remain stable.
+  `ASSERT_IF(H_DataStableWhenBidirectionalAndReq_A, (req && !ack) |=> $stable(h_data),
+             in_bidirectional_mode, clk, !rst_n)
 
   // TODO: The following two assertions make a rather important assumption about the req/ack
   //       protocol that will be used for the key/csrng interfaces, which is that no requests

--- a/hw/dv/sv/push_pull_agent/push_pull_item.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_item.sv
@@ -2,9 +2,12 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class push_pull_item #(parameter int DataWidth = 32) extends uvm_sequence_item;
+class push_pull_item #(parameter int HostDataWidth = 32,
+                       parameter int DeviceDataWidth = HostDataWidth)
+  extends uvm_sequence_item;
 
-  rand bit [DataWidth-1:0] data;
+  rand bit [HostDataWidth-1:0]      h_data;
+  rand bit [DeviceDataWidth-1:0]    d_data;
 
   // Host-side delay for both Push/Pull protocols.
   rand int unsigned host_delay;
@@ -12,8 +15,9 @@ class push_pull_item #(parameter int DataWidth = 32) extends uvm_sequence_item;
   // Device-side delay for both Push/Pull protocols.
   rand int unsigned device_delay;
 
-  `uvm_object_param_utils_begin(push_pull_item#(DataWidth))
-    `uvm_field_int(data,         UVM_DEFAULT)
+  `uvm_object_param_utils_begin(push_pull_item#(HostDataWidth, DeviceDataWidth))
+    `uvm_field_int(h_data,     UVM_DEFAULT)
+    `uvm_field_int(d_data,     UVM_DEFAULT)
     `uvm_field_int(host_delay,   UVM_DEFAULT)
     `uvm_field_int(device_delay, UVM_DEFAULT)
   `uvm_object_utils_end
@@ -21,7 +25,8 @@ class push_pull_item #(parameter int DataWidth = 32) extends uvm_sequence_item;
   `uvm_object_new
 
   virtual function string convert2string();
-    return {$sformatf("data = 0x%0x ", data),
+    return {$sformatf("h_data = 0x%0x ", h_data),
+            $sformatf("d_data = 0x%0x ", d_data),
             $sformatf("host_delay = 0x%0x ", host_delay),
             $sformatf("device_delay = 0x%0x ", device_delay)};
   endfunction

--- a/hw/dv/sv/push_pull_agent/push_pull_sequencer.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_sequencer.sv
@@ -2,15 +2,17 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class push_pull_sequencer #(parameter int DataWidth = 32) extends dv_base_sequencer #(
-    .ITEM_T (push_pull_item#(DataWidth)),
-    .CFG_T  (push_pull_agent_cfg#(DataWidth))
+class push_pull_sequencer #(parameter int HostDataWidth = 32,
+                            parameter int DeviceDataWidth = HostDataWidth)
+  extends dv_base_sequencer #(
+    .ITEM_T (push_pull_item#(HostDataWidth, DeviceDataWidth)),
+    .CFG_T  (push_pull_agent_cfg#(HostDataWidth, DeviceDataWidth))
 );
-  `uvm_component_param_utils(push_pull_sequencer#(DataWidth))
+  `uvm_component_param_utils(push_pull_sequencer#(HostDataWidth, DeviceDataWidth))
 
   // Analysis port through which device monitors can send transactions
   // to the sequencer.
-  uvm_tlm_analysis_fifo #(push_pull_item#(DataWidth)) req_fifo;
+  uvm_tlm_analysis_fifo #(push_pull_item#(HostDataWidth, DeviceDataWidth)) req_fifo;
 
   `uvm_component_new
 

--- a/hw/dv/sv/push_pull_agent/seq_lib/push_pull_base_seq.sv
+++ b/hw/dv/sv/push_pull_agent/seq_lib/push_pull_base_seq.sv
@@ -2,12 +2,14 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class push_pull_base_seq #(parameter int DataWidth = 32) extends dv_base_seq #(
-    .REQ         (push_pull_item#(DataWidth)),
-    .CFG_T       (push_pull_agent_cfg#(DataWidth)),
-    .SEQUENCER_T (push_pull_sequencer#(DataWidth))
+class push_pull_base_seq #(parameter int HostDataWidth = 32,
+                           parameter int DeviceDataWidth = HostDataWidth)
+  extends dv_base_seq #(
+    .REQ         (push_pull_item#(HostDataWidth, DeviceDataWidth)),
+    .CFG_T       (push_pull_agent_cfg#(HostDataWidth, DeviceDataWidth)),
+    .SEQUENCER_T (push_pull_sequencer#(HostDataWidth, DeviceDataWidth))
   );
-  `uvm_object_param_utils(push_pull_base_seq#(DataWidth))
+  `uvm_object_param_utils(push_pull_base_seq#(HostDataWidth, DeviceDataWidth))
 
   `uvm_object_new
 

--- a/hw/ip/entropy_src/dv/env/entropy_src_env.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env.sv
@@ -10,21 +10,21 @@ class entropy_src_env extends cip_base_env #(
   );
   `uvm_component_utils(entropy_src_env)
 
-   push_pull_agent#(.DataWidth(RNG_DATA_WIDTH))     m_rng_agent;
-   push_pull_agent#(.DataWidth(CSRNG_DATA_WIDTH))   m_csrng_agent;
+   push_pull_agent#(.HostDataWidth(RNG_DATA_WIDTH))     m_rng_agent;
+   push_pull_agent#(.DeviceDataWidth(CSRNG_DATA_WIDTH)) m_csrng_agent;
 
   `uvm_component_new
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
 
-    m_rng_agent = push_pull_agent#(.DataWidth(RNG_DATA_WIDTH))::type_id::create("m_rng_agent", this);
-    uvm_config_db#(push_pull_agent_cfg#(.DataWidth(RNG_DATA_WIDTH)))::set(this, "m_rng_agent*", "cfg", cfg.m_rng_agent_cfg);
+    m_rng_agent = push_pull_agent#(.HostDataWidth(RNG_DATA_WIDTH))::type_id::create("m_rng_agent", this);
+    uvm_config_db#(push_pull_agent_cfg#(.HostDataWidth(RNG_DATA_WIDTH)))::set(this, "m_rng_agent*", "cfg", cfg.m_rng_agent_cfg);
     cfg.m_rng_agent_cfg.agent_type = push_pull_agent_pkg::PushAgent;
     cfg.m_rng_agent_cfg.if_mode    = dv_utils_pkg::Host;
 
-    m_csrng_agent = push_pull_agent#(.DataWidth(CSRNG_DATA_WIDTH))::type_id::create("m_csrng_agent", this);
-    uvm_config_db#(push_pull_agent_cfg#(.DataWidth(CSRNG_DATA_WIDTH)))::set(this, "m_csrng_agent*", "cfg", cfg.m_csrng_agent_cfg);
+    m_csrng_agent = push_pull_agent#(.DeviceDataWidth(CSRNG_DATA_WIDTH))::type_id::create("m_csrng_agent", this);
+    uvm_config_db#(push_pull_agent_cfg#(.DeviceDataWidth(CSRNG_DATA_WIDTH)))::set(this, "m_csrng_agent*", "cfg", cfg.m_csrng_agent_cfg);
     cfg.m_csrng_agent_cfg.agent_type = push_pull_agent_pkg::PullAgent;
     cfg.m_csrng_agent_cfg.if_mode    = dv_utils_pkg::Host;
 

--- a/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
@@ -8,9 +8,9 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
   `uvm_object_utils_end
 
   // ext component cfgs
-  rand push_pull_agent_cfg#(RNG_DATA_WIDTH)     m_rng_agent_cfg;
-  rand push_pull_agent_cfg#(CSRNG_DATA_WIDTH)   m_csrng_agent_cfg;
-  
+  rand push_pull_agent_cfg#(.HostDataWidth(RNG_DATA_WIDTH))     m_rng_agent_cfg;
+  rand push_pull_agent_cfg#(.DeviceDataWidth(CSRNG_DATA_WIDTH)) m_csrng_agent_cfg;
+
   virtual pins_if                  efuse_es_sw_reg_en_vif;
 
   `uvm_object_new
@@ -20,8 +20,8 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
     super.initialize(csr_base_addr);
 
     // create agent config objs
-    m_rng_agent_cfg   = push_pull_agent_cfg#(RNG_DATA_WIDTH)::type_id::create("m_rng_agent_cfg");
-    m_csrng_agent_cfg = push_pull_agent_cfg#(CSRNG_DATA_WIDTH)::type_id::create("m_csrng_agent_cfg");
+    m_rng_agent_cfg   = push_pull_agent_cfg#(.HostDataWidth(RNG_DATA_WIDTH))::type_id::create("m_rng_agent_cfg");
+    m_csrng_agent_cfg = push_pull_agent_cfg#(.DeviceDataWidth(CSRNG_DATA_WIDTH))::type_id::create("m_csrng_agent_cfg");
 
     // set num_interrupts & num_alerts
     begin

--- a/hw/ip/entropy_src/dv/tb/tb.sv
+++ b/hw/ip/entropy_src/dv/tb/tb.sv
@@ -28,8 +28,8 @@ module tb;
   pins_if#(1) fips_if(fips);
   pins_if#(1) efuse_es_sw_reg_en_if(efuse_es_sw_reg_en);
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
-  push_pull_if#(.DataWidth(RNG_DATA_WIDTH)) rng_if(.clk(clk), .rst_n(rst_n));
-  push_pull_if#(.DataWidth(CSRNG_DATA_WIDTH)) csrng_if(.clk(clk), .rst_n(rst_n));
+  push_pull_if#(.HostDataWidth(RNG_DATA_WIDTH)) rng_if(.clk(clk), .rst_n(rst_n));
+  push_pull_if#(.DeviceDataWidth(CSRNG_DATA_WIDTH)) csrng_if(.clk(clk), .rst_n(rst_n));
 
   `DV_ALERT_IF_CONNECT
 
@@ -43,14 +43,14 @@ module tb;
 
     .efuse_es_sw_reg_en_i      (efuse_es_sw_reg_en),
 
-    .entropy_src_hw_if_o       ({csrng_if.ack, csrng_if.data, fips}),
+    .entropy_src_hw_if_o       ({csrng_if.ack, csrng_if.d_data, fips}),
     .entropy_src_hw_if_i       (csrng_if.req),
 
     .entropy_src_xht_o         (),
     .entropy_src_xht_i         ('0),
 
     .entropy_src_rng_o         (rng_if.ready),
-    .entropy_src_rng_i         ({rng_if.valid, rng_if.data}),
+    .entropy_src_rng_i         ({rng_if.valid, rng_if.h_data}),
 
     .alert_rx_i                (alert_rx),
     .alert_tx_o                (alert_tx),
@@ -74,8 +74,8 @@ module tb;
     uvm_config_db#(virtual pins_if)::set(null, "*.env", "efuse_es_sw_reg_en_vif", efuse_es_sw_reg_en_if);
     uvm_config_db#(virtual pins_if)::set(null, "*.env", "fips_vif", fips_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
-    uvm_config_db#(virtual push_pull_if#(.DataWidth(RNG_DATA_WIDTH)))::set(null, "*.env.m_rng_agent*", "vif", rng_if);
-    uvm_config_db#(virtual push_pull_if#(.DataWidth(CSRNG_DATA_WIDTH)))::set(null, "*.env.m_csrng_agent*", "vif", csrng_if);
+    uvm_config_db#(virtual push_pull_if#(.HostDataWidth(RNG_DATA_WIDTH)))::set(null, "*.env.m_rng_agent*", "vif", rng_if);
+    uvm_config_db#(virtual push_pull_if#(.DeviceDataWidth(CSRNG_DATA_WIDTH)))::set(null, "*.env.m_csrng_agent*", "vif", csrng_if);
     $timeformat(-12, 0, " ps", 12);
     run_test();
   end

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.sv
@@ -12,11 +12,11 @@ class otp_ctrl_env extends cip_base_env #(
 
   `uvm_component_new
 
-  push_pull_agent#(SRAM_DATA_SIZE)  m_sram_pull_agent[NumSramKeyReqSlots];
-  push_pull_agent#(OTBN_DATA_SIZE)  m_otbn_pull_agent;
-  push_pull_agent#(FLASH_DATA_SIZE) m_flash_addr_pull_agent;
-  push_pull_agent#(FLASH_DATA_SIZE) m_flash_data_pull_agent;
-  push_pull_agent#(EDN_DATA_SIZE)   m_edn_pull_agent;
+  push_pull_agent#(.DeviceDataWidth(SRAM_DATA_SIZE))  m_sram_pull_agent[NumSramKeyReqSlots];
+  push_pull_agent#(.DeviceDataWidth(OTBN_DATA_SIZE))  m_otbn_pull_agent;
+  push_pull_agent#(.DeviceDataWidth(FLASH_DATA_SIZE)) m_flash_addr_pull_agent;
+  push_pull_agent#(.DeviceDataWidth(FLASH_DATA_SIZE)) m_flash_data_pull_agent;
+  push_pull_agent#(.DeviceDataWidth(EDN_DATA_SIZE))   m_edn_pull_agent;
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
@@ -24,33 +24,33 @@ class otp_ctrl_env extends cip_base_env #(
     // build sram-otp pull agent
     for (int i = 0; i < NumSramKeyReqSlots; i++) begin
       string sram_agent_name = $sformatf("m_sram_pull_agent[%0d]", i);
-      m_sram_pull_agent[i] = push_pull_agent#(SRAM_DATA_SIZE)::type_id::create(sram_agent_name,
-                                                                               this);
-      uvm_config_db#(push_pull_agent_cfg#(SRAM_DATA_SIZE))::set(this,
+      m_sram_pull_agent[i] = push_pull_agent#(.DeviceDataWidth(SRAM_DATA_SIZE))::type_id::create(
+        sram_agent_name, this);
+      uvm_config_db#(push_pull_agent_cfg#(.DeviceDataWidth(SRAM_DATA_SIZE)))::set(this,
                      $sformatf("%0s*", sram_agent_name), "cfg", cfg.m_sram_pull_agent_cfg[i]);
     end
 
     // build otbn-otp pull agent
-    m_otbn_pull_agent = push_pull_agent#(OTBN_DATA_SIZE)::type_id::create("m_otbn_pull_agent",
-                                                                          this);
-    uvm_config_db#(push_pull_agent_cfg#(OTBN_DATA_SIZE))::set(this, "m_otbn_pull_agent", "cfg",
-                                                              cfg.m_otbn_pull_agent_cfg);
+    m_otbn_pull_agent = push_pull_agent#(.DeviceDataWidth(OTBN_DATA_SIZE))::type_id::create(
+      "m_otbn_pull_agent", this);
+    uvm_config_db#(push_pull_agent_cfg#(.DeviceDataWidth(OTBN_DATA_SIZE)))::set(
+      this, "m_otbn_pull_agent", "cfg", cfg.m_otbn_pull_agent_cfg);
 
     // build flash-otp pull agent
-    m_flash_addr_pull_agent = push_pull_agent#(FLASH_DATA_SIZE)::type_id::create(
+    m_flash_addr_pull_agent = push_pull_agent#(.DeviceDataWidth(FLASH_DATA_SIZE))::type_id::create(
         "m_flash_addr_pull_agent", this);
-    uvm_config_db#(push_pull_agent_cfg#(FLASH_DATA_SIZE))::set(this, "m_flash_addr_pull_agent",
-        "cfg", cfg.m_flash_addr_pull_agent_cfg);
-    m_flash_data_pull_agent = push_pull_agent#(FLASH_DATA_SIZE)::type_id::create(
+    uvm_config_db#(push_pull_agent_cfg#(.DeviceDataWidth(FLASH_DATA_SIZE)))::set(
+      this, "m_flash_addr_pull_agent", "cfg", cfg.m_flash_addr_pull_agent_cfg);
+    m_flash_data_pull_agent = push_pull_agent#(.DeviceDataWidth(FLASH_DATA_SIZE))::type_id::create(
         "m_flash_data_pull_agent", this);
-    uvm_config_db#(push_pull_agent_cfg#(FLASH_DATA_SIZE))::set(this, "m_flash_data_pull_agent",
+    uvm_config_db#(push_pull_agent_cfg#(.DeviceDataWidth(FLASH_DATA_SIZE)))::set(this, "m_flash_data_pull_agent",
         "cfg", cfg.m_flash_data_pull_agent_cfg);
 
     // build edn-otp push agent
-    m_edn_pull_agent = push_pull_agent#(EDN_DATA_SIZE)::type_id::create("m_edn_pull_agent",
+    m_edn_pull_agent = push_pull_agent#(.DeviceDataWidth(EDN_DATA_SIZE))::type_id::create("m_edn_pull_agent",
                                                                           this);
-    uvm_config_db#(push_pull_agent_cfg#(EDN_DATA_SIZE))::set(this, "m_edn_pull_agent", "cfg",
-                                                              cfg.m_edn_pull_agent_cfg);
+    uvm_config_db#(push_pull_agent_cfg#(.DeviceDataWidth(EDN_DATA_SIZE)))::set(
+      this, "m_edn_pull_agent", "cfg", cfg.m_edn_pull_agent_cfg);
 
     // config power manager pin
     if (!uvm_config_db#(pwr_otp_vif)::get(this, "", "pwr_otp_vif", cfg.pwr_otp_vif)) begin

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
@@ -5,11 +5,11 @@
 class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_reg_block));
 
   // ext component cfgs
-  rand push_pull_agent_cfg#(SRAM_DATA_SIZE)  m_sram_pull_agent_cfg[NumSramKeyReqSlots];
-  rand push_pull_agent_cfg#(OTBN_DATA_SIZE)  m_otbn_pull_agent_cfg;
-  rand push_pull_agent_cfg#(FLASH_DATA_SIZE) m_flash_data_pull_agent_cfg;
-  rand push_pull_agent_cfg#(FLASH_DATA_SIZE) m_flash_addr_pull_agent_cfg;
-  rand push_pull_agent_cfg#(EDN_DATA_SIZE)   m_edn_pull_agent_cfg;
+  rand push_pull_agent_cfg#(.DeviceDataWidth(SRAM_DATA_SIZE))  m_sram_pull_agent_cfg[NumSramKeyReqSlots];
+  rand push_pull_agent_cfg#(.DeviceDataWidth(OTBN_DATA_SIZE))  m_otbn_pull_agent_cfg;
+  rand push_pull_agent_cfg#(.DeviceDataWidth(FLASH_DATA_SIZE)) m_flash_data_pull_agent_cfg;
+  rand push_pull_agent_cfg#(.DeviceDataWidth(FLASH_DATA_SIZE)) m_flash_addr_pull_agent_cfg;
+  rand push_pull_agent_cfg#(.DeviceDataWidth(EDN_DATA_SIZE))   m_edn_pull_agent_cfg;
 
   // ext interfaces
   pwr_otp_vif              pwr_otp_vif;
@@ -30,22 +30,22 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_reg_block));
     // create push_pull agent config obj
     for (int i = 0; i < NumSramKeyReqSlots; i++) begin
       string cfg_name = $sformatf("sram_pull_agent_cfg[%0d]", i);
-      m_sram_pull_agent_cfg[i] = push_pull_agent_cfg#(SRAM_DATA_SIZE)::type_id::create(cfg_name);
+      m_sram_pull_agent_cfg[i] = push_pull_agent_cfg#(.DeviceDataWidth(SRAM_DATA_SIZE))::type_id::create(cfg_name);
       m_sram_pull_agent_cfg[i].agent_type = PullAgent;
     end
 
-    m_otbn_pull_agent_cfg = push_pull_agent_cfg#(OTBN_DATA_SIZE)::type_id::create
+    m_otbn_pull_agent_cfg = push_pull_agent_cfg#(.DeviceDataWidth(OTBN_DATA_SIZE))::type_id::create
                             ("m_otbn_pull_agent_cfg");
     m_otbn_pull_agent_cfg.agent_type = PullAgent;
 
-    m_flash_data_pull_agent_cfg = push_pull_agent_cfg#(FLASH_DATA_SIZE)::type_id::create
+    m_flash_data_pull_agent_cfg = push_pull_agent_cfg#(.DeviceDataWidth(FLASH_DATA_SIZE))::type_id::create
                                   ("m_flash_data_pull_agent_cfg");
     m_flash_data_pull_agent_cfg.agent_type = PullAgent;
-    m_flash_addr_pull_agent_cfg = push_pull_agent_cfg#(FLASH_DATA_SIZE)::type_id::create
+    m_flash_addr_pull_agent_cfg = push_pull_agent_cfg#(.DeviceDataWidth(FLASH_DATA_SIZE))::type_id::create
                                   ("m_flash_addr_pull_agent_cfg");
     m_flash_addr_pull_agent_cfg.agent_type = PullAgent;
 
-    m_edn_pull_agent_cfg = push_pull_agent_cfg#(EDN_DATA_SIZE)::type_id::create
+    m_edn_pull_agent_cfg = push_pull_agent_cfg#(.DeviceDataWidth(EDN_DATA_SIZE))::type_id::create
                            ("m_edn_pull_agent_cfg");
     m_edn_pull_agent_cfg.agent_type = PullAgent;
     m_edn_pull_agent_cfg.if_mode    = Device;

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -12,11 +12,11 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
   // local variables
 
   // TLM agent fifos
-  uvm_tlm_analysis_fifo #(push_pull_item#(SRAM_DATA_SIZE))  sram_fifo[NumSramKeyReqSlots];
-  uvm_tlm_analysis_fifo #(push_pull_item#(OTBN_DATA_SIZE))  otbn_fifo;
-  uvm_tlm_analysis_fifo #(push_pull_item#(FLASH_DATA_SIZE)) flash_addr_fifo;
-  uvm_tlm_analysis_fifo #(push_pull_item#(FLASH_DATA_SIZE)) flash_data_fifo;
-  uvm_tlm_analysis_fifo #(push_pull_item#(EDN_DATA_SIZE))   edn_fifo;
+  uvm_tlm_analysis_fifo #(push_pull_item#(.DeviceDataWidth(SRAM_DATA_SIZE)))  sram_fifo[NumSramKeyReqSlots];
+  uvm_tlm_analysis_fifo #(push_pull_item#(.DeviceDataWidth(OTBN_DATA_SIZE)))  otbn_fifo;
+  uvm_tlm_analysis_fifo #(push_pull_item#(.DeviceDataWidth(FLASH_DATA_SIZE))) flash_addr_fifo;
+  uvm_tlm_analysis_fifo #(push_pull_item#(.DeviceDataWidth(FLASH_DATA_SIZE))) flash_data_fifo;
+  uvm_tlm_analysis_fifo #(push_pull_item#(.DeviceDataWidth(EDN_DATA_SIZE)))   edn_fifo;
 
   // local queues to hold incoming packets pending comparison
 

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_virtual_sequencer.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_virtual_sequencer.sv
@@ -10,9 +10,9 @@ class otp_ctrl_virtual_sequencer extends cip_base_virtual_sequencer #(
 
   `uvm_component_new
 
-  push_pull_sequencer#(SRAM_DATA_SIZE)  sram_pull_sequencer_h[NumSramKeyReqSlots];
-  push_pull_sequencer#(OTBN_DATA_SIZE)  otbn_pull_sequencer_h;
-  push_pull_sequencer#(FLASH_DATA_SIZE) flash_data_pull_sequencer_h;
-  push_pull_sequencer#(FLASH_DATA_SIZE) flash_addr_pull_sequencer_h;
-  push_pull_sequencer#(EDN_DATA_SIZE)   edn_pull_sequencer_h;
+  push_pull_sequencer#(.DeviceDataWidth(SRAM_DATA_SIZE))  sram_pull_sequencer_h[NumSramKeyReqSlots];
+  push_pull_sequencer#(.DeviceDataWidth(OTBN_DATA_SIZE))  otbn_pull_sequencer_h;
+  push_pull_sequencer#(.DeviceDataWidth(FLASH_DATA_SIZE)) flash_data_pull_sequencer_h;
+  push_pull_sequencer#(.DeviceDataWidth(FLASH_DATA_SIZE)) flash_addr_pull_sequencer_h;
+  push_pull_sequencer#(.DeviceDataWidth(EDN_DATA_SIZE))   edn_pull_sequencer_h;
 endclass

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -96,7 +96,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
   endtask
 
   virtual task req_sram_key(int index);
-    push_pull_host_seq#(SRAM_DATA_SIZE) sram_pull_seq;
+    push_pull_host_seq#(.DeviceDataWidth(SRAM_DATA_SIZE)) sram_pull_seq;
     `uvm_create_on(sram_pull_seq, p_sequencer.sram_pull_sequencer_h[index]);
     `DV_CHECK_RANDOMIZE_FATAL(sram_pull_seq)
     `uvm_send(sram_pull_seq)
@@ -107,21 +107,21 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
   endtask
 
   virtual task req_otbn_key();
-    push_pull_host_seq#(OTBN_DATA_SIZE) otbn_pull_seq;
+    push_pull_host_seq#(.DeviceDataWidth(OTBN_DATA_SIZE)) otbn_pull_seq;
     `uvm_create_on(otbn_pull_seq, p_sequencer.otbn_pull_sequencer_h);
     `DV_CHECK_RANDOMIZE_FATAL(otbn_pull_seq)
     `uvm_send(otbn_pull_seq)
   endtask
 
   virtual task req_flash_addr();
-    push_pull_host_seq#(FLASH_DATA_SIZE) flash_addr_pull_seq;
+    push_pull_host_seq#(.DeviceDataWidth(FLASH_DATA_SIZE)) flash_addr_pull_seq;
     `uvm_create_on(flash_addr_pull_seq, p_sequencer.flash_addr_pull_sequencer_h);
     `DV_CHECK_RANDOMIZE_FATAL(flash_addr_pull_seq)
     `uvm_send(flash_addr_pull_seq)
   endtask
 
   virtual task req_flash_data();
-    push_pull_host_seq#(FLASH_DATA_SIZE) flash_data_pull_seq;
+    push_pull_host_seq#(.DeviceDataWidth(FLASH_DATA_SIZE)) flash_data_pull_seq;
     `uvm_create_on(flash_data_pull_seq, p_sequencer.flash_data_pull_sequencer_h);
     `DV_CHECK_RANDOMIZE_FATAL(flash_data_pull_seq)
     `uvm_send(flash_data_pull_seq)


### PR DESCRIPTION
This PR adds bidirectional data transfer to the push_pull_agent, controlled by the `cfg.in_bidirectional_mode` knob.

Minor modifications are also made to the `otp_ctrl` and `entropy_src`
testbench modules to update the interface connection names.

Note that #4146 (kmac tb) will have to be updated as well to get the right signal naming,
this will be done once this PR goes in.

Signed-off-by: Udi Jonnalagadda <udij@google.com>