### PR TITLE
[otbn] Define a "smoke test" UVM sequence

### DIFF
--- a/hw/ip/otbn/data/otbn_testplan.hjson
+++ b/hw/ip/otbn/data/otbn_testplan.hjson
@@ -20,7 +20,7 @@
 
             '''
       milestone: V1
-      tests: []
+      tests: ["otbn_smoke"]
     }
     {
       name: single_binary

--- a/hw/ip/otbn/dv/uvm/env/otbn_env.core
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env.core
@@ -26,6 +26,7 @@ filesets:
       - seq_lib/otbn_base_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_common_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_single_vseq.sv: {is_include_file: true}
+      - seq_lib/otbn_smoke_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_smoke_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_smoke_vseq.sv
@@ -1,0 +1,22 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A smoke test sequence. This loads up the fixed "smoke.elf" binary and forces everything to be in
+// "simple" mode.
+
+class otbn_smoke_vseq extends otbn_single_vseq;
+  `uvm_object_utils(otbn_smoke_vseq)
+  `uvm_object_new
+
+  constraint do_backdoor_load_c { do_backdoor_load == 1'b0; }
+
+  // Override pick_elf_path to always choose "smoke.elf"
+  protected function string pick_elf_path();
+    // Check that cfg.otbn_elf_dir was set by the test
+    `DV_CHECK_FATAL(cfg.otbn_elf_dir.len() > 0);
+
+    return $sformatf("%0s/smoke.elf", cfg.otbn_elf_dir);
+  endfunction
+
+endclass

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_vseq_list.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_vseq_list.sv
@@ -5,3 +5,4 @@
 `include "otbn_base_vseq.sv"
 `include "otbn_common_vseq.sv"
 `include "otbn_single_vseq.sv"
+`include "otbn_smoke_vseq.sv"

--- a/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
+++ b/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
@@ -65,6 +65,10 @@ name:
   // List of test specifications.
   tests: [
     {
+      name: "otbn_smoke"
+      uvm_test_seq: "otbn_smoke_vseq"
+    }
+    {
       name: "otbn_single"
       uvm_test_seq: "otbn_single_vseq"
     }
@@ -76,7 +80,7 @@ name:
   regressions: [
     {
       name: smoke
-      tests: []
+      tests: ["otbn_smoke"]
     }
   ]
 }


### PR DESCRIPTION
This currently fails because of a onehot assertion failure (tracked as
issue #4168), but everything seems to load properly.

Note that it assumes the directory of ELF files contains a
"smoke.elf" (which we will ensure with the "make me some binaries"
scripts).
