### PR TITLE
Update to Verilator 4.102 (and potentially 4.104)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@
 # Documentation at https://aka.ms/yaml
 
 variables:
-  VERILATOR_VERSION: 4.040
+  VERILATOR_VERSION: 4.102
   TOOLCHAIN_PATH: /opt/buildcache/riscv
   VERIBLE_VERSION: v0.0-520-g650c6cc
   # Release tag from https://github.com/lowRISC/lowrisc-toolchains/releases

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@
 # Documentation at https://aka.ms/yaml
 
 variables:
-  VERILATOR_VERSION: 4.102
+  VERILATOR_VERSION: 4.104
   TOOLCHAIN_PATH: /opt/buildcache/riscv
   VERIBLE_VERSION: v0.0-520-g650c6cc
   # Release tag from https://github.com/lowRISC/lowrisc-toolchains/releases

--- a/tool_requirements.py
+++ b/tool_requirements.py
@@ -9,5 +9,5 @@ __TOOL_REQUIREMENTS__ = {
     'hugo_extended': '0.71.0',
     'ninja-build': '1.8.2',
     'verible': '0.0-520-g650c6cc',
-    'verilator': '4.040',
+    'verilator': '4.102',
 }

--- a/tool_requirements.py
+++ b/tool_requirements.py
@@ -9,5 +9,5 @@ __TOOL_REQUIREMENTS__ = {
     'hugo_extended': '0.71.0',
     'ninja-build': '1.8.2',
     'verible': '0.0-520-g650c6cc',
-    'verilator': '4.102',
+    'verilator': '4.104',
 }

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -6,7 +6,7 @@
 # for OpenTitan.
 
 # Global configuration options.
-ARG VERILATOR_VERSION=4.102
+ARG VERILATOR_VERSION=4.104
 
 # The RISCV toolchain version should match the release tag used in GitHub.
 ARG RISCV_TOOLCHAIN_TAR_VERSION=20200904-1

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -6,7 +6,7 @@
 # for OpenTitan.
 
 # Global configuration options.
-ARG VERILATOR_VERSION=4.040
+ARG VERILATOR_VERSION=4.102
 
 # The RISCV toolchain version should match the release tag used in GitHub.
 ARG RISCV_TOOLCHAIN_TAR_VERSION=20200904-1


### PR DESCRIPTION
Require Verilator 4.102 (over 4.040) to fix a bug we encounter in OTBN
tracing code.

Besides the typical set of bug fixes and improvements we don't expect
any visible change to existing testbenches.

Note that this version of Verilator now requires a C++11-capable
compiler on the host; this is not a new requirement for OpenTitan users,
as we had such a host compiler requirement for a while now and building,
e.g. spiflash, requires even newer C++ features.

Fixes #4170