### PR TITLE
[sw, dif_plic] Add diagnostic message to one of the test cases

### DIFF
--- a/sw/device/tests/dif/dif_plic_unittest.cc
+++ b/sw/device/tests/dif/dif_plic_unittest.cc
@@ -82,7 +82,8 @@ class IrqTest : public PlicTest {
     for (const auto &reg : kEnableRegisters) {
       number_of_sources += (reg.last_bit + 1);
     }
-    EXPECT_EQ(RV_PLIC_PARAM_NUMSRC, number_of_sources);
+    EXPECT_EQ(RV_PLIC_PARAM_NUMSRC, number_of_sources)
+        << "make sure to update the IrqTest register arrays!";
 
     EXPECT_EQ(RV_PLIC_PARAM_NUMTARGET, 1);
   }


### PR DESCRIPTION
The mismatch of in-test register array values with the RV_PLIC_PARAM_NUMSRC, costed two engineers some debug time.

This change should help to identify the fault quicker.