### PR TITLE
[nexysvideo] Map 8 GPIOs to PMOD JA header

### DIFF
--- a/hw/top_earlgrey/data/pins_nexysvideo.xdc
+++ b/hw/top_earlgrey/data/pins_nexysvideo.xdc
@@ -115,14 +115,14 @@ set_property -dict { PACKAGE_PIN M17  IOSTANDARD LVCMOS12 } [get_ports { IO_GP7 
 
 
 ## Pmod header JA
-#set_property -dict { PACKAGE_PIN AB22  IOSTANDARD LVCMOS33 } [get_ports { IO_DP }]; #IO_L10N_T1_D15_14 Sch=ja[1]
-#set_property -dict { PACKAGE_PIN AB21  IOSTANDARD LVCMOS33 } [get_ports { IO_DN }]; #IO_L10P_T1_D14_14 Sch=ja[2]
-#set_property -dict { PACKAGE_PIN AB20  IOSTANDARD LVCMOS33 } [get_ports { IO_PULLUP }]; #IO_L15N_T2_DQS_DOUT_CSO_B_14 Sch=ja[3]
-#set_property -dict { PACKAGE_PIN AB18  IOSTANDARD LVCMOS33 } [get_ports { IO_SENSE }]; #IO_L17N_T2_A13_D29_14 Sch=ja[4]
-#set_property -dict { PACKAGE_PIN Y21   IOSTANDARD LVCMOS33 } [get_ports { IO_GP4 }]; #IO_L9P_T1_DQS_14 Sch=ja[7]
-#set_property -dict { PACKAGE_PIN AA21  IOSTANDARD LVCMOS33 } [get_ports { IO_GP5 }]; #IO_L8N_T1_D12_14 Sch=ja[8]
-#set_property -dict { PACKAGE_PIN AA20  IOSTANDARD LVCMOS33 } [get_ports { IO_GP6 }]; #IO_L8P_T1_D11_14 Sch=ja[9]
-#set_property -dict { PACKAGE_PIN AA18  IOSTANDARD LVCMOS33 } [get_ports { IO_GP7 }]; #IO_L17P_T2_A14_D30_14 Sch=ja[10]
+set_property -dict { PACKAGE_PIN AB22  IOSTANDARD LVCMOS33 } [get_ports { IO_GP24 }]; #IO_L10N_T1_D15_14 Sch=ja[1]
+set_property -dict { PACKAGE_PIN AB21  IOSTANDARD LVCMOS33 } [get_ports { IO_GP25 }]; #IO_L10P_T1_D14_14 Sch=ja[2]
+set_property -dict { PACKAGE_PIN AB20  IOSTANDARD LVCMOS33 } [get_ports { IO_GP26 }]; #IO_L15N_T2_DQS_DOUT_CSO_B_14 Sch=ja[3]
+set_property -dict { PACKAGE_PIN AB18  IOSTANDARD LVCMOS33 } [get_ports { IO_GP27 }]; #IO_L17N_T2_A13_D29_14 Sch=ja[4]
+set_property -dict { PACKAGE_PIN Y21   IOSTANDARD LVCMOS33 } [get_ports { IO_GP28 }]; #IO_L9P_T1_DQS_14 Sch=ja[7]
+set_property -dict { PACKAGE_PIN AA21  IOSTANDARD LVCMOS33 } [get_ports { IO_GP29 }]; #IO_L8N_T1_D12_14 Sch=ja[8]
+set_property -dict { PACKAGE_PIN AA20  IOSTANDARD LVCMOS33 } [get_ports { IO_GP30 }]; #IO_L8P_T1_D11_14 Sch=ja[9]
+set_property -dict { PACKAGE_PIN AA18  IOSTANDARD LVCMOS33 } [get_ports { IO_GP31 }]; #IO_L17P_T2_A14_D30_14 Sch=ja[10]
 
 
 ## Pmod header JB

--- a/hw/top_earlgrey/rtl/top_earlgrey_nexysvideo.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_nexysvideo.sv
@@ -44,7 +44,16 @@ module top_earlgrey_nexysvideo #(
   inout               IO_GP12,
   inout               IO_GP13,
   inout               IO_GP14,
-  inout               IO_GP15
+  inout               IO_GP15,
+  // GPIOs going to PMOD JA
+  inout               IO_GP24,
+  inout               IO_GP25,
+  inout               IO_GP26,
+  inout               IO_GP27,
+  inout               IO_GP28,
+  inout               IO_GP29,
+  inout               IO_GP30,
+  inout               IO_GP31
 );
 
   import top_earlgrey_pkg::*;
@@ -65,10 +74,10 @@ module top_earlgrey_nexysvideo #(
   logic [padctrl_reg_pkg::NDioPads-1:0] dio_in_core, dio_in_umux, dio_in_padring;
 
   padring #(
-    // MIOs 31:20 are currently not
+    // MIOs 23:20 are currently not
     // connected to pads and hence tied off
-    .ConnectMioIn  ( 32'h000FFFFF ),
-    .ConnectMioOut ( 32'h000FFFFF ),
+    .ConnectMioIn  ( 32'hFF0FFFFF ),
+    .ConnectMioOut ( 32'hFF0FFFFF ),
     // Tied off DIOs:
     // 2: usbdev_d
     // 3: usbdev_suspend
@@ -85,7 +94,15 @@ module top_earlgrey_nexysvideo #(
     .clk_usb_48mhz_o     (      ),
     .rst_no              (      ),
     // MIO Pads
-    .mio_pad_io          ( { 12'bz,   // Note that 31:20 are currently not mapped
+    .mio_pad_io          ( { IO_GP31,
+                             IO_GP30,
+                             IO_GP29,
+                             IO_GP28,
+                             IO_GP27,
+                             IO_GP26,
+                             IO_GP25,
+                             IO_GP24,
+                             4'bz,    // Note that 23:20 are currently not mapped
                              IO_DPS5, // Use GPIO19 to pass JTAG_SRST
                              IO_DPS4, // Use GPIO18 to pass JTAG_TRST
                              IO_DPS7, // Use GPIO17 to pass rom boot_strap indication


### PR DESCRIPTION
This maps 8 of the currently unconnected GPIOs to the PMOD JA header to enable certain lab experiments.

Signed-off-by: Michael Schaffner <msf@opentitan.org>