### PR TITLE
[design checklist] avoid using word sanity

### DIFF
--- a/doc/project/checklist.md
+++ b/doc/project/checklist.md
@@ -82,9 +82,9 @@ Feature requests for this IP version are frozen at this time.
 
 All features specified have been completed.
 
-### AREA_SANITY_CHECK
+### AREA_CHECK
 
-Area sanity check completed either on FPGA or on Design Compiler.
+Area check completed either on FPGA or on Design Compiler.
 
 ### PORT_FROZEN
 

--- a/hw/ip/aes/doc/checklist.md
+++ b/hw/ip/aes/doc/checklist.md
@@ -41,7 +41,7 @@ Documentation | [DOC_INTERFACE][]       | Not Started |
 Documentation | [MISSING_FUNC][]        | Not Started |
 Documentation | [FEATURE_FROZEN][]      | Not Started |
 RTL           | [FEATURE_COMPLETE][]    | Not Started |
-RTL           | [AREA_SANITY_CHECK][]   | Not Started |
+RTL           | [AREA_CHECK][]          | Not Started |
 RTL           | [PORT_FROZEN][]         | Not Started |
 RTL           | [ARCHITECTURE_FROZEN][] | Not Started |
 RTL           | [REVIEW_TODO][]         | Not Started |
@@ -61,7 +61,7 @@ Security      | [SEC_RND_CNST][]        | Not Started |
 [MISSING_FUNC]:        {{<relref "/doc/project/checklist.md#missing_func" >}}
 [FEATURE_FROZEN]:      {{<relref "/doc/project/checklist.md#feature_frozen" >}}
 [FEATURE_COMPLETE]:    {{<relref "/doc/project/checklist.md#feature_complete" >}}
-[AREA_SANITY_CHECK]:   {{<relref "/doc/project/checklist.md#area_sanity_check" >}}
+[AREA_CHECK]:          {{<relref "/doc/project/checklist.md#area_check" >}}
 [PORT_FROZEN]:         {{<relref "/doc/project/checklist.md#port_frozen" >}}
 [ARCHITECTURE_FROZEN]: {{<relref "/doc/project/checklist.md#architecture_frozen" >}}
 [REVIEW_TODO]:         {{<relref "/doc/project/checklist.md#review_todo" >}}

--- a/hw/ip/alert_handler/doc/checklist.md
+++ b/hw/ip/alert_handler/doc/checklist.md
@@ -41,7 +41,7 @@ Documentation | [DOC_INTERFACE][]       | Done        |
 Documentation | [MISSING_FUNC][]        | Not Started |
 Documentation | [FEATURE_FROZEN][]      | Not Started |
 RTL           | [FEATURE_COMPLETE][]    | Not Started |
-RTL           | [AREA_SANITY_CHECK][]   | Not Started |
+RTL           | [AREA_CHECK][]          | Not Started |
 RTL           | [PORT_FROZEN][]         | Not Started |
 RTL           | [ARCHITECTURE_FROZEN][] | Not Started |
 RTL           | [REVIEW_TODO][]         | Not Started |
@@ -61,7 +61,7 @@ Security      | [SEC_RND_CNST][]        | Not Started |
 [MISSING_FUNC]:        {{<relref "/doc/project/checklist.md#missing_func" >}}
 [FEATURE_FROZEN]:      {{<relref "/doc/project/checklist.md#feature_frozen" >}}
 [FEATURE_COMPLETE]:    {{<relref "/doc/project/checklist.md#feature_complete" >}}
-[AREA_SANITY_CHECK]:   {{<relref "/doc/project/checklist.md#area_sanity_check" >}}
+[AREA_CHECK]:          {{<relref "/doc/project/checklist.md#area_check" >}}
 [PORT_FROZEN]:         {{<relref "/doc/project/checklist.md#port_frozen" >}}
 [ARCHITECTURE_FROZEN]: {{<relref "/doc/project/checklist.md#architecture_frozen" >}}
 [REVIEW_TODO]:         {{<relref "/doc/project/checklist.md#review_todo" >}}

--- a/hw/ip/csrng/doc/checklist.md
+++ b/hw/ip/csrng/doc/checklist.md
@@ -46,7 +46,7 @@ Documentation | [DOC_INTERFACE][]       | Not Started |
 Documentation | [MISSING_FUNC][]        | Not Started |
 Documentation | [FEATURE_FROZEN][]      | Not Started |
 RTL           | [FEATURE_COMPLETE][]    | Not Started |
-RTL           | [AREA_SANITY_CHECK][]   | Not Started |
+RTL           | [AREA_CHECK][]          | Not Started |
 RTL           | [PORT_FROZEN][]         | Not Started |
 RTL           | [ARCHITECTURE_FROZEN][] | Not Started |
 RTL           | [REVIEW_TODO][]         | Not Started |
@@ -66,7 +66,7 @@ Security      | [SEC_RND_CNST][]        | Not Started |
 [MISSING_FUNC]:        {{<relref "/doc/project/checklist.md#missing_func" >}}
 [FEATURE_FROZEN]:      {{<relref "/doc/project/checklist.md#feature_frozen" >}}
 [FEATURE_COMPLETE]:    {{<relref "/doc/project/checklist.md#feature_complete" >}}
-[AREA_SANITY_CHECK]:   {{<relref "/doc/project/checklist.md#area_sanity_check" >}}
+[AREA_CHECK]:          {{<relref "/doc/project/checklist.md#area_check" >}}
 [PORT_FROZEN]:         {{<relref "/doc/project/checklist.md#port_frozen" >}}
 [ARCHITECTURE_FROZEN]: {{<relref "/doc/project/checklist.md#architecture_frozen" >}}
 [REVIEW_TODO]:         {{<relref "/doc/project/checklist.md#review_todo" >}}

--- a/hw/ip/entropy_src/doc/checklist.md
+++ b/hw/ip/entropy_src/doc/checklist.md
@@ -41,7 +41,7 @@ Documentation | [DOC_INTERFACE][]       | Not Started |
 Documentation | [MISSING_FUNC][]        | Not Started |
 Documentation | [FEATURE_FROZEN][]      | Not Started |
 RTL           | [FEATURE_COMPLETE][]    | Not Started |
-RTL           | [AREA_SANITY_CHECK][]   | Not Started |
+RTL           | [AREA_CHECK][]          | Not Started |
 RTL           | [PORT_FROZEN][]         | Not Started |
 RTL           | [ARCHITECTURE_FROZEN][] | Not Started |
 RTL           | [REVIEW_TODO][]         | Not Started |
@@ -61,7 +61,7 @@ Security      | [SEC_RND_CNST][]        | Not Started |
 [MISSING_FUNC]:        {{<relref "/doc/project/checklist.md#missing_func" >}}
 [FEATURE_FROZEN]:      {{<relref "/doc/project/checklist.md#feature_frozen" >}}
 [FEATURE_COMPLETE]:    {{<relref "/doc/project/checklist.md#feature_complete" >}}
-[AREA_SANITY_CHECK]:   {{<relref "/doc/project/checklist.md#area_sanity_check" >}}
+[AREA_CHECK]:          {{<relref "/doc/project/checklist.md#area_check" >}}
 [PORT_FROZEN]:         {{<relref "/doc/project/checklist.md#port_frozen" >}}
 [ARCHITECTURE_FROZEN]: {{<relref "/doc/project/checklist.md#architecture_frozen" >}}
 [REVIEW_TODO]:         {{<relref "/doc/project/checklist.md#review_todo" >}}

--- a/hw/ip/flash_ctrl/doc/checklist.md
+++ b/hw/ip/flash_ctrl/doc/checklist.md
@@ -42,7 +42,7 @@ Documentation | [DOC_INTERFACE][]       | Done        |
 Documentation | [MISSING_FUNC][]        | N/A         |
 Documentation | [FEATURE_FROZEN][]      | Done        |
 RTL           | [FEATURE_COMPLETE][]    | Done        |
-RTL           | [AREA_SANITY_CHECK][]   | In Progress |
+RTL           | [AREA_CHECK][]          | In Progress |
 RTL           | [PORT_FROZEN][]         | Done        |
 RTL           | [ARCHITECTURE_FROZEN][] | Done        |
 RTL           | [REVIEW_TODO][]         | Done        |
@@ -62,7 +62,7 @@ Code Quality  | [CDC_SYNCMACRO][]       | Not Started |
 [MISSING_FUNC]:        {{<relref "/doc/project/checklist.md#missing_func" >}}
 [FEATURE_FROZEN]:      {{<relref "/doc/project/checklist.md#feature_frozen" >}}
 [FEATURE_COMPLETE]:    {{<relref "/doc/project/checklist.md#feature_complete" >}}
-[AREA_SANITY_CHECK]:   {{<relref "/doc/project/checklist.md#area_sanity_check" >}}
+[AREA_CHECK]:          {{<relref "/doc/project/checklist.md#area_check" >}}
 [PORT_FROZEN]:         {{<relref "/doc/project/checklist.md#port_frozen" >}}
 [ARCHITECTURE_FROZEN]: {{<relref "/doc/project/checklist.md#architecture_frozen" >}}
 [REVIEW_TODO]:         {{<relref "/doc/project/checklist.md#review_todo" >}}

--- a/hw/ip/gpio/doc/checklist.md
+++ b/hw/ip/gpio/doc/checklist.md
@@ -45,7 +45,7 @@ Documentation | [DOC_INTERFACE][]       | Done        |
 Documentation | [MISSING_FUNC][]        | N/A         |
 Documentation | [FEATURE_FROZEN][]      | Done        |
 RTL           | [FEATURE_COMPLETE][]    | Done        |
-RTL           | [AREA_SANITY_CHECK][]   | Done        |
+RTL           | [AREA_CHECK][]          | Done        |
 RTL           | [PORT_FROZEN][]         | Done        |
 RTL           | [ARCHITECTURE_FROZEN][] | Done        |
 RTL           | [REVIEW_TODO][]         | Done        |
@@ -65,7 +65,7 @@ Security      | [SEC_RND_CNST][]        | N/A         |
 [MISSING_FUNC]:        {{<relref "/doc/project/checklist.md#missing_func" >}}
 [FEATURE_FROZEN]:      {{<relref "/doc/project/checklist.md#feature_frozen" >}}
 [FEATURE_COMPLETE]:    {{<relref "/doc/project/checklist.md#feature_complete" >}}
-[AREA_SANITY_CHECK]:   {{<relref "/doc/project/checklist.md#area_sanity_check" >}}
+[AREA_CHECK]:          {{<relref "/doc/project/checklist.md#area_check" >}}
 [PORT_FROZEN]:         {{<relref "/doc/project/checklist.md#port_frozen" >}}
 [ARCHITECTURE_FROZEN]: {{<relref "/doc/project/checklist.md#architecture_frozen" >}}
 [REVIEW_TODO]:         {{<relref "/doc/project/checklist.md#review_todo" >}}

--- a/hw/ip/hmac/doc/checklist.md
+++ b/hw/ip/hmac/doc/checklist.md
@@ -43,7 +43,7 @@ Documentation | [DOC_INTERFACE][]       | Done        |
 Documentation | [MISSING_FUNC][]        | N/A         |
 Documentation | [FEATURE_FROZEN][]      | Done        |
 RTL           | [FEATURE_COMPLETE][]    | Done        |
-RTL           | [AREA_SANITY_CHECK][]   | Done        |
+RTL           | [AREA_CHECK][]          | Done        |
 RTL           | [PORT_FROZEN][]         | Done        | Interrupt port was revised.
 RTL           | [ARCHITECTURE_FROZEN][] | Done        | Livestream was added
 RTL           | [REVIEW_TODO][]         | Done        | Removed irrelevant TODOs and create [#761][]
@@ -65,7 +65,7 @@ Security      | [SEC_RND_CNST][]        | Not Started |
 [MISSING_FUNC]:        {{<relref "/doc/project/checklist.md#missing_func" >}}
 [FEATURE_FROZEN]:      {{<relref "/doc/project/checklist.md#feature_frozen" >}}
 [FEATURE_COMPLETE]:    {{<relref "/doc/project/checklist.md#feature_complete" >}}
-[AREA_SANITY_CHECK]:   {{<relref "/doc/project/checklist.md#area_sanity_check" >}}
+[AREA_CHECK]:          {{<relref "/doc/project/checklist.md#area_check" >}}
 [PORT_FROZEN]:         {{<relref "/doc/project/checklist.md#port_frozen" >}}
 [ARCHITECTURE_FROZEN]: {{<relref "/doc/project/checklist.md#architecture_frozen" >}}
 [REVIEW_TODO]:         {{<relref "/doc/project/checklist.md#review_todo" >}}

--- a/hw/ip/i2c/doc/checklist.md
+++ b/hw/ip/i2c/doc/checklist.md
@@ -43,7 +43,7 @@ Documentation | [DOC_INTERFACE][]       | Not Started |
 Documentation | [MISSING_FUNC][]        | Not Started |
 Documentation | [FEATURE_FROZEN][]      | Not Started |
 RTL           | [FEATURE_COMPLETE][]    | Not Started | Consider to add loopback test
-RTL           | [AREA_SANITY_CHECK][]   | Not Started | Think about FIFO size, there will be multiple I2C in top_earlgrey
+RTL           | [AREA_CHECK][]          | Not Started | Think about FIFO size, there will be multiple I2C in top_earlgrey
 RTL           | [PORT_FROZEN][]         | Not Started |
 RTL           | [ARCHITECTURE_FROZEN][] | Not Started |
 RTL           | [REVIEW_TODO][]         | Not Started |
@@ -63,7 +63,7 @@ Security      | [SEC_RND_CNST][]        | Not Started |
 [MISSING_FUNC]:        {{<relref "/doc/project/checklist.md#missing_func" >}}
 [FEATURE_FROZEN]:      {{<relref "/doc/project/checklist.md#feature_frozen" >}}
 [FEATURE_COMPLETE]:    {{<relref "/doc/project/checklist.md#feature_complete" >}}
-[AREA_SANITY_CHECK]:   {{<relref "/doc/project/checklist.md#area_sanity_check" >}}
+[AREA_CHECK]:          {{<relref "/doc/project/checklist.md#area_check" >}}
 [PORT_FROZEN]:         {{<relref "/doc/project/checklist.md#port_frozen" >}}
 [ARCHITECTURE_FROZEN]: {{<relref "/doc/project/checklist.md#architecture_frozen" >}}
 [REVIEW_TODO]:         {{<relref "/doc/project/checklist.md#review_todo" >}}

--- a/hw/ip/keymgr/doc/checklist.md
+++ b/hw/ip/keymgr/doc/checklist.md
@@ -46,7 +46,7 @@ Documentation | [DOC_INTERFACE][]       | Not Started |
 Documentation | [MISSING_FUNC][]        | Not Started |
 Documentation | [FEATURE_FROZEN][]      | Not Started |
 RTL           | [FEATURE_COMPLETE][]    | Not Started |
-RTL           | [AREA_SANITY_CHECK][]   | Not Started |
+RTL           | [AREA_CHECK][]          | Not Started |
 RTL           | [PORT_FROZEN][]         | Not Started |
 RTL           | [ARCHITECTURE_FROZEN][] | Not Started |
 RTL           | [REVIEW_TODO][]         | Not Started |
@@ -66,7 +66,7 @@ Security      | [SEC_RND_CNST][]        | Not Started |
 [MISSING_FUNC]:        {{<relref "/doc/project/checklist.md#missing_func" >}}
 [FEATURE_FROZEN]:      {{<relref "/doc/project/checklist.md#feature_frozen" >}}
 [FEATURE_COMPLETE]:    {{<relref "/doc/project/checklist.md#feature_complete" >}}
-[AREA_SANITY_CHECK]:   {{<relref "/doc/project/checklist.md#area_sanity_check" >}}
+[AREA_CHECK]:          {{<relref "/doc/project/checklist.md#area_check" >}}
 [PORT_FROZEN]:         {{<relref "/doc/project/checklist.md#port_frozen" >}}
 [ARCHITECTURE_FROZEN]: {{<relref "/doc/project/checklist.md#architecture_frozen" >}}
 [REVIEW_TODO]:         {{<relref "/doc/project/checklist.md#review_todo" >}}

--- a/hw/ip/kmac/doc/checklist.md
+++ b/hw/ip/kmac/doc/checklist.md
@@ -41,7 +41,7 @@ Documentation | [DOC_INTERFACE][]       | Not Started |
 Documentation | [MISSING_FUNC][]        | Not Started |
 Documentation | [FEATURE_FROZEN][]      | Not Started |
 RTL           | [FEATURE_COMPLETE][]    | Not Started |
-RTL           | [AREA_SANITY_CHECK][]   | Not Started |
+RTL           | [AREA_CHECK][]          | Not Started |
 RTL           | [PORT_FROZEN][]         | Not Started |
 RTL           | [ARCHITECTURE_FROZEN][] | Not Started |
 RTL           | [REVIEW_TODO][]         | Not Started |
@@ -61,7 +61,7 @@ Security      | [SEC_RND_CNST][]        | Not Started |
 [MISSING_FUNC]:        {{<relref "/doc/project/checklist.md#missing_func" >}}
 [FEATURE_FROZEN]:      {{<relref "/doc/project/checklist.md#feature_frozen" >}}
 [FEATURE_COMPLETE]:    {{<relref "/doc/project/checklist.md#feature_complete" >}}
-[AREA_SANITY_CHECK]:   {{<relref "/doc/project/checklist.md#area_sanity_check" >}}
+[AREA_CHECK]:          {{<relref "/doc/project/checklist.md#area_check" >}}
 [PORT_FROZEN]:         {{<relref "/doc/project/checklist.md#port_frozen" >}}
 [ARCHITECTURE_FROZEN]: {{<relref "/doc/project/checklist.md#architecture_frozen" >}}
 [REVIEW_TODO]:         {{<relref "/doc/project/checklist.md#review_todo" >}}

--- a/hw/ip/otp_ctrl/doc/checklist.md
+++ b/hw/ip/otp_ctrl/doc/checklist.md
@@ -46,7 +46,7 @@ Documentation | [DOC_INTERFACE][]       | Not Started |
 Documentation | [MISSING_FUNC][]        | Not Started |
 Documentation | [FEATURE_FROZEN][]      | Not Started |
 RTL           | [FEATURE_COMPLETE][]    | Not Started |
-RTL           | [AREA_SANITY_CHECK][]   | Not Started |
+RTL           | [AREA_CHECK][]          | Not Started |
 RTL           | [PORT_FROZEN][]         | Not Started |
 RTL           | [ARCHITECTURE_FROZEN][] | Not Started |
 RTL           | [REVIEW_TODO][]         | Not Started |
@@ -66,7 +66,7 @@ Security      | [SEC_RND_CNST][]        | Not Started |
 [MISSING_FUNC]:        {{<relref "/doc/project/checklist.md#missing_func" >}}
 [FEATURE_FROZEN]:      {{<relref "/doc/project/checklist.md#feature_frozen" >}}
 [FEATURE_COMPLETE]:    {{<relref "/doc/project/checklist.md#feature_complete" >}}
-[AREA_SANITY_CHECK]:   {{<relref "/doc/project/checklist.md#area_sanity_check" >}}
+[AREA_CHECK]:          {{<relref "/doc/project/checklist.md#area_check" >}}
 [PORT_FROZEN]:         {{<relref "/doc/project/checklist.md#port_frozen" >}}
 [ARCHITECTURE_FROZEN]: {{<relref "/doc/project/checklist.md#architecture_frozen" >}}
 [REVIEW_TODO]:         {{<relref "/doc/project/checklist.md#review_todo" >}}

--- a/hw/ip/padctrl/doc/checklist.md
+++ b/hw/ip/padctrl/doc/checklist.md
@@ -42,7 +42,7 @@ Documentation | [DOC_INTERFACE][]       | Done        |
 Documentation | [MISSING_FUNC][]        | Not Started |
 Documentation | [FEATURE_FROZEN][]      | Not Started |
 RTL           | [FEATURE_COMPLETE][]    | Not Started |
-RTL           | [AREA_SANITY_CHECK][]   | Not Started |
+RTL           | [AREA_CHECK][]          | Not Started |
 RTL           | [PORT_FROZEN][]         | Not Started |
 RTL           | [ARCHITECTURE_FROZEN][] | Not Started |
 RTL           | [REVIEW_TODO][]         | Not Started |
@@ -62,7 +62,7 @@ Security      | [SEC_RND_CNST][]        | Not Started |
 [MISSING_FUNC]:        {{<relref "/doc/project/checklist.md#missing_func" >}}
 [FEATURE_FROZEN]:      {{<relref "/doc/project/checklist.md#feature_frozen" >}}
 [FEATURE_COMPLETE]:    {{<relref "/doc/project/checklist.md#feature_complete" >}}
-[AREA_SANITY_CHECK]:   {{<relref "/doc/project/checklist.md#area_sanity_check" >}}
+[AREA_CHECK]:          {{<relref "/doc/project/checklist.md#area_check" >}}
 [PORT_FROZEN]:         {{<relref "/doc/project/checklist.md#port_frozen" >}}
 [ARCHITECTURE_FROZEN]: {{<relref "/doc/project/checklist.md#architecture_frozen" >}}
 [REVIEW_TODO]:         {{<relref "/doc/project/checklist.md#review_todo" >}}

--- a/hw/ip/pattgen/doc/checklist.md
+++ b/hw/ip/pattgen/doc/checklist.md
@@ -41,7 +41,7 @@ Documentation | [DOC_INTERFACE][]       | Not Started |
 Documentation | [MISSING_FUNC][]        | Not Started |
 Documentation | [FEATURE_FROZEN][]      | Not Started |
 RTL           | [FEATURE_COMPLETE][]    | Not Started |
-RTL           | [AREA_SANITY_CHECK][]   | Not Started |
+RTL           | [AREA_CHECK][]          | Not Started |
 RTL           | [PORT_FROZEN][]         | Not Started |
 RTL           | [ARCHITECTURE_FROZEN][] | Not Started |
 RTL           | [REVIEW_TODO][]         | Not Started |
@@ -61,7 +61,7 @@ Security      | [SEC_RND_CNST][]        | Not Started |
 [MISSING_FUNC]:        {{<relref "/doc/project/checklist.md#missing_func" >}}
 [FEATURE_FROZEN]:      {{<relref "/doc/project/checklist.md#feature_frozen" >}}
 [FEATURE_COMPLETE]:    {{<relref "/doc/project/checklist.md#feature_complete" >}}
-[AREA_SANITY_CHECK]:   {{<relref "/doc/project/checklist.md#area_sanity_check" >}}
+[AREA_CHECK]:          {{<relref "/doc/project/checklist.md#area_check" >}}
 [PORT_FROZEN]:         {{<relref "/doc/project/checklist.md#port_frozen" >}}
 [ARCHITECTURE_FROZEN]: {{<relref "/doc/project/checklist.md#architecture_frozen" >}}
 [REVIEW_TODO]:         {{<relref "/doc/project/checklist.md#review_todo" >}}

--- a/hw/ip/pinmux/doc/checklist.md
+++ b/hw/ip/pinmux/doc/checklist.md
@@ -42,7 +42,7 @@ Documentation | [DOC_INTERFACE][]       | Done        |
 Documentation | [MISSING_FUNC][]        | Not Started |
 Documentation | [FEATURE_FROZEN][]      | Not Started |
 RTL           | [FEATURE_COMPLETE][]    | Not Started |
-RTL           | [AREA_SANITY_CHECK][]   | Not Started |
+RTL           | [AREA_CHECK][]          | Not Started |
 RTL           | [PORT_FROZEN][]         | Not Started |
 RTL           | [ARCHITECTURE_FROZEN][] | Not Started |
 RTL           | [REVIEW_TODO][]         | Not Started |
@@ -62,7 +62,7 @@ Security      | [SEC_RND_CNST][]        | Not Started |
 [MISSING_FUNC]:        {{<relref "/doc/project/checklist.md#missing_func" >}}
 [FEATURE_FROZEN]:      {{<relref "/doc/project/checklist.md#feature_frozen" >}}
 [FEATURE_COMPLETE]:    {{<relref "/doc/project/checklist.md#feature_complete" >}}
-[AREA_SANITY_CHECK]:   {{<relref "/doc/project/checklist.md#area_sanity_check" >}}
+[AREA_CHECK]:          {{<relref "/doc/project/checklist.md#area_check" >}}
 [PORT_FROZEN]:         {{<relref "/doc/project/checklist.md#port_frozen" >}}
 [ARCHITECTURE_FROZEN]: {{<relref "/doc/project/checklist.md#architecture_frozen" >}}
 [REVIEW_TODO]:         {{<relref "/doc/project/checklist.md#review_todo" >}}

--- a/hw/ip/pwrmgr/doc/checklist.md
+++ b/hw/ip/pwrmgr/doc/checklist.md
@@ -41,7 +41,7 @@ Documentation | [DOC_INTERFACE][]       | Not Started |
 Documentation | [MISSING_FUNC][]        | Not Started |
 Documentation | [FEATURE_FROZEN][]      | Not Started |
 RTL           | [FEATURE_COMPLETE][]    | Not Started |
-RTL           | [AREA_SANITY_CHECK][]   | Not Started |
+RTL           | [AREA_CHECK][]          | Not Started |
 RTL           | [PORT_FROZEN][]         | Not Started |
 RTL           | [ARCHITECTURE_FROZEN][] | Not Started |
 RTL           | [REVIEW_TODO][]         | Not Started |
@@ -61,7 +61,7 @@ Security      | [SEC_RND_CNST][]        | Not Started |
 [MISSING_FUNC]:        {{<relref "/doc/project/checklist.md#missing_func" >}}
 [FEATURE_FROZEN]:      {{<relref "/doc/project/checklist.md#feature_frozen" >}}
 [FEATURE_COMPLETE]:    {{<relref "/doc/project/checklist.md#feature_complete" >}}
-[AREA_SANITY_CHECK]:   {{<relref "/doc/project/checklist.md#area_sanity_check" >}}
+[AREA_CHECK]:          {{<relref "/doc/project/checklist.md#area_check" >}}
 [PORT_FROZEN]:         {{<relref "/doc/project/checklist.md#port_frozen" >}}
 [ARCHITECTURE_FROZEN]: {{<relref "/doc/project/checklist.md#architecture_frozen" >}}
 [REVIEW_TODO]:         {{<relref "/doc/project/checklist.md#review_todo" >}}

--- a/hw/ip/rstmgr/doc/checklist.md
+++ b/hw/ip/rstmgr/doc/checklist.md
@@ -41,7 +41,7 @@ Documentation | [DOC_INTERFACE][]       | Not Started |
 Documentation | [MISSING_FUNC][]        | Not Started |
 Documentation | [FEATURE_FROZEN][]      | Not Started |
 RTL           | [FEATURE_COMPLETE][]    | Not Started |
-RTL           | [AREA_SANITY_CHECK][]   | Not Started |
+RTL           | [AREA_CHECK][]          | Not Started |
 RTL           | [PORT_FROZEN][]         | Not Started |
 RTL           | [ARCHITECTURE_FROZEN][] | Not Started |
 RTL           | [REVIEW_TODO][]         | Not Started |
@@ -61,7 +61,7 @@ Security      | [SEC_RND_CNST][]        | Not Started |
 [MISSING_FUNC]:        {{<relref "/doc/project/checklist.md#missing_func" >}}
 [FEATURE_FROZEN]:      {{<relref "/doc/project/checklist.md#feature_frozen" >}}
 [FEATURE_COMPLETE]:    {{<relref "/doc/project/checklist.md#feature_complete" >}}
-[AREA_SANITY_CHECK]:   {{<relref "/doc/project/checklist.md#area_sanity_check" >}}
+[AREA_CHECK]:          {{<relref "/doc/project/checklist.md#area_check" >}}
 [PORT_FROZEN]:         {{<relref "/doc/project/checklist.md#port_frozen" >}}
 [ARCHITECTURE_FROZEN]: {{<relref "/doc/project/checklist.md#architecture_frozen" >}}
 [REVIEW_TODO]:         {{<relref "/doc/project/checklist.md#review_todo" >}}

--- a/hw/ip/rv_core_ibex/doc/checklist.md
+++ b/hw/ip/rv_core_ibex/doc/checklist.md
@@ -49,7 +49,7 @@ Documentation | [DOC_INTERFACE][]       | Done        |
 Documentation | [MISSING_FUNC][]        | N/A         |
 Documentation | [FEATURE_FROZEN][]      | Done        |
 RTL           | [FEATURE_COMPLETE][]    | Done        |
-RTL           | [AREA_SANITY_CHECK][]   | Done        | Area Sanity Check Done (on FPGA)
+RTL           | [AREA_CHECK][]          | Done        | Area Sanity Check Done (on FPGA)
 RTL           | [PORT_FROZEN][]         | Done        |
 RTL           | [ARCHITECTURE_FROZEN][] | Done        |
 RTL           | [REVIEW_TODO][]         | Done        | Minor TODOs remain, waived
@@ -69,7 +69,7 @@ Security      | [SEC_RND_CNST][]        | Not Started |
 [MISSING_FUNC]:        {{<relref "/doc/project/checklist.md#missing_func" >}}
 [FEATURE_FROZEN]:      {{<relref "/doc/project/checklist.md#feature_frozen" >}}
 [FEATURE_COMPLETE]:    {{<relref "/doc/project/checklist.md#feature_complete" >}}
-[AREA_SANITY_CHECK]:   {{<relref "/doc/project/checklist.md#area_sanity_check" >}}
+[AREA_CHECK]:          {{<relref "/doc/project/checklist.md#area_check" >}}
 [PORT_FROZEN]:         {{<relref "/doc/project/checklist.md#port_frozen" >}}
 [ARCHITECTURE_FROZEN]: {{<relref "/doc/project/checklist.md#architecture_frozen" >}}
 [REVIEW_TODO]:         {{<relref "/doc/project/checklist.md#review_todo" >}}

--- a/hw/ip/rv_plic/doc/checklist.md
+++ b/hw/ip/rv_plic/doc/checklist.md
@@ -43,7 +43,7 @@ Documentation | [DOC_INTERFACE][]       | Done        |
 Documentation | [MISSING_FUNC][]        | N/A         |
 Documentation | [FEATURE_FROZEN][]      | Done        |
 RTL           | [FEATURE_COMPLETE][]    | Done        |
-RTL           | [AREA_SANITY_CHECK][]   | Done        |
+RTL           | [AREA_CHECK][]          | Done        |
 RTL           | [PORT_FROZEN][]         | Done        |
 RTL           | [ARCHITECTURE_FROZEN][] | Done        |
 RTL           | [REVIEW_TODO][]         | Done        | One TODO about Vivado Issue
@@ -63,7 +63,7 @@ Security      | [SEC_RND_CNST][]        | N/A         |
 [MISSING_FUNC]:        {{<relref "/doc/project/checklist.md#missing_func" >}}
 [FEATURE_FROZEN]:      {{<relref "/doc/project/checklist.md#feature_frozen" >}}
 [FEATURE_COMPLETE]:    {{<relref "/doc/project/checklist.md#feature_complete" >}}
-[AREA_SANITY_CHECK]:   {{<relref "/doc/project/checklist.md#area_sanity_check" >}}
+[AREA_CHECK]:          {{<relref "/doc/project/checklist.md#area_check" >}}
 [PORT_FROZEN]:         {{<relref "/doc/project/checklist.md#port_frozen" >}}
 [ARCHITECTURE_FROZEN]: {{<relref "/doc/project/checklist.md#architecture_frozen" >}}
 [REVIEW_TODO]:         {{<relref "/doc/project/checklist.md#review_todo" >}}

--- a/hw/ip/rv_timer/doc/checklist.md
+++ b/hw/ip/rv_timer/doc/checklist.md
@@ -44,7 +44,7 @@ Documentation | [DOC_INTERFACE][]       | Done           |
 Documentation | [MISSING_FUNC][]        | N/A            |
 Documentation | [FEATURE_FROZEN][]      | Done           |
 RTL           | [FEATURE_COMPLETE][]    | Done           |
-RTL           | [AREA_SANITY_CHECK][]   | Done           |
+RTL           | [AREA_CHECK][]          | Done           |
 RTL           | [PORT_FROZEN][]         | Done w/ waiver | Change intr port name
 RTL           | [ARCHITECTURE_FROZEN][] | Done           |
 RTL           | [REVIEW_TODO][]         | Done           | [#68][]
@@ -65,7 +65,7 @@ Security      | [SEC_SHADOW_REGS][]     | N/A            |
 [MISSING_FUNC]:        {{<relref "/doc/project/checklist.md#missing_func" >}}
 [FEATURE_FROZEN]:      {{<relref "/doc/project/checklist.md#feature_frozen" >}}
 [FEATURE_COMPLETE]:    {{<relref "/doc/project/checklist.md#feature_complete" >}}
-[AREA_SANITY_CHECK]:   {{<relref "/doc/project/checklist.md#area_sanity_check" >}}
+[AREA_CHECK]:          {{<relref "/doc/project/checklist.md#area_check" >}}
 [PORT_FROZEN]:         {{<relref "/doc/project/checklist.md#port_frozen" >}}
 [ARCHITECTURE_FROZEN]: {{<relref "/doc/project/checklist.md#architecture_frozen" >}}
 [REVIEW_TODO]:         {{<relref "/doc/project/checklist.md#review_todo" >}}

--- a/hw/ip/spi_device/doc/checklist.md
+++ b/hw/ip/spi_device/doc/checklist.md
@@ -43,7 +43,7 @@ Documentation | [DOC_INTERFACE][]       | Not Started |
 Documentation | [MISSING_FUNC][]        | Not Started |
 Documentation | [FEATURE_FROZEN][]      | Not Started |
 RTL           | [FEATURE_COMPLETE][]    | Not Started |
-RTL           | [AREA_SANITY_CHECK][]   | Not Started |
+RTL           | [AREA_CHECK][]          | Not Started |
 RTL           | [PORT_FROZEN][]         | Not Started |
 RTL           | [ARCHITECTURE_FROZEN][] | Not Started |
 RTL           | [REVIEW_TODO][]         | Not Started |
@@ -63,7 +63,7 @@ Security      | [SEC_RND_CNST][]        | Not Started |
 [MISSING_FUNC]:        {{<relref "/doc/project/checklist.md#missing_func" >}}
 [FEATURE_FROZEN]:      {{<relref "/doc/project/checklist.md#feature_frozen" >}}
 [FEATURE_COMPLETE]:    {{<relref "/doc/project/checklist.md#feature_complete" >}}
-[AREA_SANITY_CHECK]:   {{<relref "/doc/project/checklist.md#area_sanity_check" >}}
+[AREA_CHECK]:          {{<relref "/doc/project/checklist.md#area_check" >}}
 [PORT_FROZEN]:         {{<relref "/doc/project/checklist.md#port_frozen" >}}
 [ARCHITECTURE_FROZEN]: {{<relref "/doc/project/checklist.md#architecture_frozen" >}}
 [REVIEW_TODO]:         {{<relref "/doc/project/checklist.md#review_todo" >}}

--- a/hw/ip/sram_ctrl/doc/checklist.md
+++ b/hw/ip/sram_ctrl/doc/checklist.md
@@ -41,7 +41,7 @@ Documentation | [DOC_INTERFACE][]       | Not Started |
 Documentation | [MISSING_FUNC][]        | Not Started |
 Documentation | [FEATURE_FROZEN][]      | Not Started |
 RTL           | [FEATURE_COMPLETE][]    | Not Started |
-RTL           | [AREA_SANITY_CHECK][]   | Not Started |
+RTL           | [AREA_CHECK][]          | Not Started |
 RTL           | [PORT_FROZEN][]         | Not Started |
 RTL           | [ARCHITECTURE_FROZEN][] | Not Started |
 RTL           | [REVIEW_TODO][]         | Not Started |
@@ -61,7 +61,7 @@ Security      | [SEC_RND_CNST][]        | Not Started |
 [MISSING_FUNC]:        {{<relref "/doc/project/checklist.md#missing_func" >}}
 [FEATURE_FROZEN]:      {{<relref "/doc/project/checklist.md#feature_frozen" >}}
 [FEATURE_COMPLETE]:    {{<relref "/doc/project/checklist.md#feature_complete" >}}
-[AREA_SANITY_CHECK]:   {{<relref "/doc/project/checklist.md#area_sanity_check" >}}
+[AREA_CHECK]:          {{<relref "/doc/project/checklist.md#area_check" >}}
 [PORT_FROZEN]:         {{<relref "/doc/project/checklist.md#port_frozen" >}}
 [ARCHITECTURE_FROZEN]: {{<relref "/doc/project/checklist.md#architecture_frozen" >}}
 [REVIEW_TODO]:         {{<relref "/doc/project/checklist.md#review_todo" >}}

--- a/hw/ip/uart/doc/checklist.md
+++ b/hw/ip/uart/doc/checklist.md
@@ -49,7 +49,7 @@ Documentation | [DOC_INTERFACE][]       | Done        |
 Documentation | [MISSING_FUNC][]        | N/A         |
 Documentation | [FEATURE_FROZEN][]      | Done        |
 RTL           | [FEATURE_COMPLETE][]    | Done        |
-RTL           | [AREA_SANITY_CHECK][]   | Done        | Area Sanity Check Done (on FPGA)
+RTL           | [AREA_CHECK][]          | Done        | Area Sanity Check Done (on FPGA)
 RTL           | [PORT_FROZEN][]         | Done        |
 RTL           | [ARCHITECTURE_FROZEN][] | Done        |
 RTL           | [REVIEW_TODO][]         | Done        |
@@ -69,7 +69,7 @@ Security      | [SEC_RND_CNST][]        | N/A         |
 [MISSING_FUNC]:        {{<relref "/doc/project/checklist.md#missing_func" >}}
 [FEATURE_FROZEN]:      {{<relref "/doc/project/checklist.md#feature_frozen" >}}
 [FEATURE_COMPLETE]:    {{<relref "/doc/project/checklist.md#feature_complete" >}}
-[AREA_SANITY_CHECK]:   {{<relref "/doc/project/checklist.md#area_sanity_check" >}}
+[AREA_CHECK]:          {{<relref "/doc/project/checklist.md#area_check" >}}
 [PORT_FROZEN]:         {{<relref "/doc/project/checklist.md#port_frozen" >}}
 [ARCHITECTURE_FROZEN]: {{<relref "/doc/project/checklist.md#architecture_frozen" >}}
 [REVIEW_TODO]:         {{<relref "/doc/project/checklist.md#review_todo" >}}

--- a/hw/ip/usbdev/doc/checklist.md
+++ b/hw/ip/usbdev/doc/checklist.md
@@ -41,7 +41,7 @@ Documentation | [DOC_INTERFACE][]       | Not Started |
 Documentation | [MISSING_FUNC][]        | Not Started |
 Documentation | [FEATURE_FROZEN][]      | Not Started |
 RTL           | [FEATURE_COMPLETE][]    | Not Started |
-RTL           | [AREA_SANITY_CHECK][]   | Not Started |
+RTL           | [AREA_CHECK][]          | Not Started |
 RTL           | [PORT_FROZEN][]         | Not Started |
 RTL           | [ARCHITECTURE_FROZEN][] | Not Started |
 RTL           | [REVIEW_TODO][]         | Not Started |
@@ -61,7 +61,7 @@ Security      | [SEC_RND_CNST][]        | Not Started |
 [MISSING_FUNC]:        {{<relref "/doc/project/checklist.md#missing_func" >}}
 [FEATURE_FROZEN]:      {{<relref "/doc/project/checklist.md#feature_frozen" >}}
 [FEATURE_COMPLETE]:    {{<relref "/doc/project/checklist.md#feature_complete" >}}
-[AREA_SANITY_CHECK]:   {{<relref "/doc/project/checklist.md#area_sanity_check" >}}
+[AREA_CHECK]:          {{<relref "/doc/project/checklist.md#area_check" >}}
 [PORT_FROZEN]:         {{<relref "/doc/project/checklist.md#port_frozen" >}}
 [ARCHITECTURE_FROZEN]: {{<relref "/doc/project/checklist.md#architecture_frozen" >}}
 [REVIEW_TODO]:         {{<relref "/doc/project/checklist.md#review_todo" >}}

--- a/hw/top_earlgrey/ip/xbar/doc/checklist.md
+++ b/hw/top_earlgrey/ip/xbar/doc/checklist.md
@@ -46,7 +46,7 @@ Documentation | [DOC_INTERFACE][]       | N/A         |
 Documentation | [MISSING_FUNC][]        | N/A         |
 Documentation | [FEATURE_FROZEN][]      | Done        |
 RTL           | [FEATURE_COMPLETE][]    | Done        |
-RTL           | [AREA_SANITY_CHECK][]   | Done        |
+RTL           | [AREA_CHECK][]          | Done        |
 RTL           | [PORT_FROZEN][]         | Done        | Targetting for current top_earlgrey( Port can be changed later based on top_earlgrey config)
 RTL           | [ARCHITECTURE_FROZEN][] | Done        |
 RTL           | [REVIEW_TODO][]         | Done        | PR [#837][] is pending
@@ -69,7 +69,7 @@ Review        | Signoff date            | Done        | 2019-11-04
 [MISSING_FUNC]:        {{<relref "/doc/project/checklist.md#missing-func" >}}
 [FEATURE_FROZEN]:      {{<relref "/doc/project/checklist.md#feature-frozen" >}}
 [FEATURE_COMPLETE]:    {{<relref "/doc/project/checklist.md#feature-complete" >}}
-[AREA_SANITY_CHECK]:   {{<relref "/doc/project/checklist.md#area-sanity-check" >}}
+[AREA_CHECK]:          {{<relref "/doc/project/checklist.md#area-sanity-check" >}}
 [PORT_FROZEN]:         {{<relref "/doc/project/checklist.md#port-frozen" >}}
 [ARCHITECTURE_FROZEN]: {{<relref "/doc/project/checklist.md#architecture-frozen" >}}
 [REVIEW_TODO]:         {{<relref "/doc/project/checklist.md#review-todo" >}}

--- a/util/uvmdvgen/checklist.md.tpl
+++ b/util/uvmdvgen/checklist.md.tpl
@@ -46,7 +46,7 @@ Documentation | [DOC_INTERFACE][]       | Not Started |
 Documentation | [MISSING_FUNC][]        | Not Started |
 Documentation | [FEATURE_FROZEN][]      | Not Started |
 RTL           | [FEATURE_COMPLETE][]    | Not Started |
-RTL           | [AREA_SANITY_CHECK][]   | Not Started |
+RTL           | [AREA_CHECK][]          | Not Started |
 RTL           | [PORT_FROZEN][]         | Not Started |
 RTL           | [ARCHITECTURE_FROZEN][] | Not Started |
 RTL           | [REVIEW_TODO][]         | Not Started |
@@ -66,7 +66,7 @@ Security      | [SEC_RND_CNST][]        | Not Started |
 [MISSING_FUNC]:        {{<relref "/doc/project/checklist.md#missing_func" >}}
 [FEATURE_FROZEN]:      {{<relref "/doc/project/checklist.md#feature_frozen" >}}
 [FEATURE_COMPLETE]:    {{<relref "/doc/project/checklist.md#feature_complete" >}}
-[AREA_SANITY_CHECK]:   {{<relref "/doc/project/checklist.md#area_sanity_check" >}}
+[AREA_CHECK]:          {{<relref "/doc/project/checklist.md#area_check" >}}
 [PORT_FROZEN]:         {{<relref "/doc/project/checklist.md#port_frozen" >}}
 [ARCHITECTURE_FROZEN]: {{<relref "/doc/project/checklist.md#architecture_frozen" >}}
 [REVIEW_TODO]:         {{<relref "/doc/project/checklist.md#review_todo" >}}


### PR DESCRIPTION
In D2 checklist, we are using `area_sanity_check`. After discussed with
designers, we decided to update this to `area_check`.

Signed-off-by: Cindy Chen <chencindy@google.com>