### PR TITLE
[prim_lc_sync] Add two stage sync for life cycle control signals 

### DIFF
--- a/hw/ip/prim/prim_lc_sync.core
+++ b/hw/ip/prim/prim_lc_sync.core
@@ -1,0 +1,61 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:lc_sync:0.1"
+description: "Two-stage synchronizer for life cycle control signals."
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:prim:assert
+      - lowrisc:prim:flop_2sync
+      - lowrisc:prim:clock_buf
+      - lowrisc:ip:lc_ctrl_pkg
+    files:
+      - rtl/prim_lc_sync.sv
+    file_type: systemVerilogSource
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      # - lint/prim_lc_sync.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+
+targets:
+  default: &default_target
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl
+
+  lint:
+    <<: *default_target
+    default_tool: verilator
+    parameters:
+      - SYNTHESIS=true
+    tools:
+      ascentlint:
+        ascentlint_options:
+          - "-wait_license"
+          - "-stop_on_error"
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"

--- a/hw/ip/prim/rtl/prim_lc_sync.sv
+++ b/hw/ip/prim/rtl/prim_lc_sync.sv
@@ -1,0 +1,55 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Double-synchronizer flop for life cycle control signals with additional
+// output buffers and life-cycle specific assertions.
+//
+// Should be used exactly as recommended in the life cycle controller spec:
+// https://docs.opentitan.org/hw/ip/lc_ctrl/doc/index.html#control-signal-propagation
+
+`include "prim_assert.sv"
+
+module prim_lc_sync #(
+  // Number of separately buffered output signals.
+  // The buffer cells have a don't touch constraint
+  // on them such that synthesis tools won't collapse
+  // all copies into one signal.
+  parameter int NumCopies = 1
+) (
+  input                                       clk_i,
+  input                                       rst_ni,
+  input  lc_ctrl_pkg::lc_tx_t                 lc_en_i,
+  output lc_ctrl_pkg::lc_tx_t [NumCopies-1:0] lc_en_o
+);
+
+  `ASSERT_INIT(NumCopiesMustBeGreaterZero_A, NumCopies > 0)
+
+  lc_ctrl_pkg::lc_tx_t lc_en;
+  prim_flop_2sync #(
+    .Width(lc_ctrl_pkg::TxWidth),
+    .ResetValue(lc_ctrl_pkg::Off)
+  ) u_prim_flop_2sync (
+    .clk_i,
+    .rst_ni,
+    .d_i(lc_en_i),
+    .q_o(lc_en)
+  );
+
+  for (genvar j = 0; j < NumCopies; j++) begin : gen_buffs
+    for (genvar k = 0; k < lc_ctrl_pkg::TxWidth; k++) begin : gen_bits
+      // TODO: replace this with a normal buffer primitive, once available.
+      prim_clock_buf u_prim_clock_buf (
+        .clk_i(lc_en[k]),
+        .clk_o(lc_en_o[j][k])
+      );
+    end
+  end
+
+  ////////////////
+  // Assertions //
+  ////////////////
+
+  // TODO: add more assertions
+
+endmodule : prim_lc_sync

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
@@ -116,20 +116,18 @@ module sram_ctrl
     .intr_o                 ( sram_integ_error_o   )
   );
 
-  ///////////////////////////////////
-  // Lifecycle Escalation Receiver //
-  ///////////////////////////////////
+  //////////////////////////////////////////
+  // Lifecycle Escalation Synchronization //
+  //////////////////////////////////////////
 
   lc_ctrl_pkg::lc_tx_t escalate_en;
-  prim_multibit_sync #(
-    .Width(lc_ctrl_pkg::TxWidth),
-    .NumChecks (2),
-    .ResetValue(lc_ctrl_pkg::TxWidth'(lc_ctrl_pkg::Off))
-  ) u_prim_multibit_sync (
+  prim_lc_sync #(
+    .NumCopies (1)
+  ) u_prim_lc_sync (
     .clk_i,
     .rst_ni,
-    .data_i (lc_escalate_en_i),
-    .data_o (escalate_en)
+    .lc_en_i (lc_escalate_en_i),
+    .lc_en_o (escalate_en)
   );
 
   ////////////////////////////

--- a/hw/ip/sram_ctrl/sram_ctrl.core
+++ b/hw/ip/sram_ctrl/sram_ctrl.core
@@ -10,7 +10,7 @@ filesets:
     depend:
       - lowrisc:prim:all
       - lowrisc:prim:util
-      - lowrisc:prim:multibit_sync
+      - lowrisc:prim:lc_sync
       - lowrisc:prim:ram_1p_scr
       - lowrisc:tlul:adapter_sram
       - lowrisc:ip:tlul


### PR DESCRIPTION
This adds a synchronization primitive for life cycle control signals and updates the use of `lc_escalate_en` in the SRAM controller IP.

Note that I will add more assertions as the LC controller is fleshed out more. 
The important part is that we have a functional module in the tree that designers can reference.

The corresponding documentation can be found [here](https://docs.opentitan.org/hw/ip/lc_ctrl/doc/index.html#control-signal-propagation), as soon as as #4108 has been merged.