### PR TITLE
[aes] Use fresh, random intermediate masks in "noreuse" Canright S-Box

### DIFF
--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -29,7 +29,7 @@
     },
     { name:    "SBoxImpl",
       type:    "aes_pkg::sbox_impl_e",
-      default: "aes_pkg::SBoxImplCanrightMasked",
+      default: "aes_pkg::SBoxImplCanrightMaskedNoreuse",
       desc:    '''
         Selection of the S-Box implementation. See aes_pkg.sv.
       '''

--- a/hw/ip/aes/pre_dv/aes_sbox_lec/aes_sbox_masked_wrapper.sv
+++ b/hw/ip/aes/pre_dv/aes_sbox_lec/aes_sbox_masked_wrapper.sv
@@ -12,20 +12,23 @@ module aes_sbox_masked_wrapper (
 
   logic [7:0] in_data_m, out_data_m;
   logic [7:0] in_mask, out_mask;
+  logic [9:0] prd_masking;
 
   // The mask inputs are tied to constant values.
-  assign in_mask  = 8'hAA;
-  assign out_mask = 8'h55;
+  assign in_mask     = 8'hAA;
+  assign out_mask    = 8'h55;
+  assign prd_masking = 10'h2AA;
 
   // Mask input data
   assign in_data_m = data_i ^ in_mask;
 
   aes_sbox_masked aes_sbox_masked (
-    .op_i       ( op_i       ),
-    .data_i     ( in_data_m  ),
-    .in_mask_i  ( in_mask    ),
-    .out_mask_i ( out_mask   ),
-    .data_o     ( out_data_m )
+    .op_i          ( op_i        ),
+    .data_i        ( in_data_m   ),
+    .in_mask_i     ( in_mask     ),
+    .out_mask_i    ( out_mask    ),
+    .prd_masking_i ( prd_masking ),
+    .data_o        ( out_data_m  )
   );
 
   // Unmask output data

--- a/hw/ip/aes/pre_dv/aes_sbox_tb/rtl/aes_sbox_tb.sv
+++ b/hw/ip/aes/pre_dv/aes_sbox_tb/rtl/aes_sbox_tb.sv
@@ -51,12 +51,13 @@ module aes_sbox_tb #(
   );
 
   // Mask Generation
-  logic [7:0] masked_stimulus;
-  logic [7:0] in_mask;
-  logic [7:0] out_mask;
-  logic [7:0] masked_response [NUM_SBOX_IMPLS_MASKED];
-  logic [31:0] tmp;
-  logic [15:0] unused_tmp;
+  logic              [7:0] masked_stimulus;
+  logic              [7:0] in_mask;
+  logic              [7:0] out_mask;
+  logic [WidthPRDSBox-1:0] prd_masking;
+  logic              [7:0] masked_response [NUM_SBOX_IMPLS_MASKED];
+  logic             [31:0] tmp;
+  logic              [5:0] unused_tmp;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : reg_tmp
     if (!rst_ni) begin
@@ -65,19 +66,21 @@ module aes_sbox_tb #(
       tmp <= $random;
     end
   end
-  assign unused_tmp = tmp[31:16];
-  assign in_mask  = tmp[7:0];
-  assign out_mask = tmp[15:8];
+  assign in_mask     = tmp[7:0];
+  assign out_mask    = tmp[15:8];
+  assign prd_masking = tmp[WidthPRDSBox-1+16:16];
+  assign unused_tmp  = tmp[31:WidthPRDSBox+16];
 
   assign masked_stimulus = stimulus ^ in_mask;
 
   // Instantiate Masked SBox Implementations
   aes_sbox_canright_masked_noreuse aes_sbox_canright_masked_noreuse (
-    .op_i       ( op                 ),
-    .data_i     ( masked_stimulus    ),
-    .in_mask_i  ( in_mask            ),
-    .out_mask_i ( out_mask           ),
-    .data_o     ( masked_response[0] )
+    .op_i          ( op                 ),
+    .data_i        ( masked_stimulus    ),
+    .in_mask_i     ( in_mask            ),
+    .out_mask_i    ( out_mask           ),
+    .prd_masking_i ( prd_masking        ),
+    .data_o        ( masked_response[0] )
   );
 
   aes_sbox_canright_masked aes_sbox_canright_masked (

--- a/hw/ip/aes/rtl/aes_pkg.sv
+++ b/hw/ip/aes/rtl/aes_pkg.sv
@@ -8,13 +8,25 @@ package aes_pkg;
 
 // Widths of signals carrying pseudo-random data for clearing and masking and purposes
 parameter int unsigned WidthPRDClearing = 64;
-parameter int unsigned WidthPRDData     = 128;
-parameter int unsigned WidthPRDKey      = 32;
+parameter int unsigned WidthPRDSBox     = 10; // Number PRD bits per S-Box, not incl. the 8 bits
+                                              // for the output mask
+parameter int unsigned WidthPRDData     = 16*(8+WidthPRDSBox); // 16 S-Boxes for the data path
+parameter int unsigned WidthPRDKey      = 4*(8+WidthPRDSBox);  // 4 S-Boxes for the key expand
 parameter int unsigned WidthPRDMasking  = WidthPRDData + WidthPRDKey;
+
+parameter int unsigned ChunkSizePRDMasking = WidthPRDMasking/10;
 
 // Default seeds for pseudo-random number generators
 parameter logic [WidthPRDClearing-1:0] DefaultSeedClearing = 64'hFEDCBA9876543210;
-parameter logic  [WidthPRDMasking-1:0] DefaultSeedMasking  = {32'h5, 32'h4, 32'h3, 32'h2, 32'h1};
+parameter logic  [WidthPRDMasking-1:0] DefaultSeedMasking  = {36'ha, 36'h9, 36'h8, 36'h7, 36'h6,
+                                                              36'h5, 36'h4, 36'h3, 36'h2, 36'h1};
+
+// These LFSR parameters have been generated with
+// $ hw/ip/prim/util/gen-lfsr-seed.py --width 36 --seed 31468618 --prefix "MskgChunk"
+parameter int MskgChunkLfsrWidth = 36;
+typedef logic [MskgChunkLfsrWidth-1:0][$clog2(MskgChunkLfsrWidth)-1:0] mskg_chunk_lfsr_perm_t;
+parameter mskg_chunk_lfsr_perm_t RndCnstMskgChunkLfsrPermDefault =
+    216'h6587da04c59c02125750f35e7634e08951122874022ce19b143211;
 
 typedef enum integer {
   SBoxImplLut,                  // Unmasked LUT-based S-Box
@@ -219,6 +231,25 @@ function automatic logic [7:0] aes_mvm(
     end
   end
   return vec_c;
+endfunction
+
+// Extract one row of output masks for SubBytes from PRNG output. The output mask is in the LSBs of
+// each segment.
+function automatic logic [3:0][7:0] aes_sb_out_mask_get(logic [4*(8+WidthPRDSBox)-1:0] in);
+  logic [3:0][7:0] sb_out_mask;
+  for (int i=0; i<4; i++) begin
+    sb_out_mask[i] = in[i*(8+WidthPRDSBox) +: 8];
+  end
+  return sb_out_mask;
+endfunction
+
+// Extract one row of PRD for SubBytes from PRNG output. The PRD part ins the MSBs of each segment.
+function automatic logic [3:0][WidthPRDSBox-1:0] aes_sb_prd_get(logic [4*(8+WidthPRDSBox)-1:0] in);
+  logic [3:0][WidthPRDSBox-1:0] sb_prd;
+  for (int i=0; i<4; i++) begin
+    sb_prd[i] = in[i*(8+WidthPRDSBox)+8 +: WidthPRDSBox];
+  end
+  return sb_prd;
 endfunction
 
 endpackage

--- a/hw/ip/aes/rtl/aes_sbox.sv
+++ b/hw/ip/aes/rtl/aes_sbox.sv
@@ -8,11 +8,12 @@ module aes_sbox import aes_pkg::*;
 #(
   parameter sbox_impl_e SBoxImpl = SBoxImplLut
 ) (
-  input  ciph_op_e   op_i,
-  input  logic [7:0] data_i,
-  input  logic [7:0] in_mask_i,
-  input  logic [7:0] out_mask_i,
-  output logic [7:0] data_o
+  input  ciph_op_e                op_i,
+  input  logic              [7:0] data_i,
+  input  logic              [7:0] in_mask_i,
+  input  logic              [7:0] out_mask_i,
+  input  logic [WidthPRDSBox-1:0] prd_masking_i,
+  output logic              [7:0] data_o
 );
 
   import aes_pkg::*;
@@ -20,9 +21,11 @@ module aes_sbox import aes_pkg::*;
                                SBoxImpl == SBoxImplCanrightMaskedNoreuse) ? 1'b1 : 1'b0;
 
   if (!SBoxMasked) begin : gen_sbox_unmasked
-    // Tie off unused mask inputs.
-    logic [15:0] unused_masks;
+    // Tie off unused mask and PRD inputs.
+    logic             [15:0] unused_masks;
+    logic [WidthPRDSBox-1:0] unused_prd;
     assign unused_masks = {in_mask_i, out_mask_i};
+    assign unused_prd   = prd_masking_i;
 
     if (SBoxImpl == SBoxImplCanright) begin : gen_sbox_canright
       aes_sbox_canright u_aes_sbox (
@@ -45,9 +48,14 @@ module aes_sbox import aes_pkg::*;
         .data_i,
         .in_mask_i,
         .out_mask_i,
+        .prd_masking_i,
         .data_o
       );
     end else begin : gen_sbox_canright_masked // SBoxImpl == SBoxImplCanrightMasked
+      // Tie of unused PRD inputs.
+      logic [WidthPRDSBox-1:0] unused_prd;
+      assign unused_prd = prd_masking_i;
+
       aes_sbox_canright_masked u_aes_sbox (
         .op_i,
         .data_i,

--- a/hw/ip/aes/rtl/aes_sbox_canright_masked.sv
+++ b/hw/ip/aes/rtl/aes_sbox_canright_masked.sv
@@ -12,6 +12,13 @@
 // For details, see Section 2.3 of the paper. Re-using masks may make the implementation more
 // vulnerable to higher-order differential side-channel analysis, but it remains secure against
 // first-order attacks. This implementation is commonly referred to as THE Canright Masked SBox.
+//
+// A formal analysis using REBECCA (static mode) shows that this implementation is not secure.
+// It is thus recommended to use the "noreuse" variant of the masked Canright S-Box.
+//
+// For details on the REBECCA tool, see the following paper:
+// Bloem, "Formal verification of masked hardware implementations in the presence of glitches"
+// available at https://eprint.iacr.org/2017/897.pdf
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // IMPORTANT NOTE:                                                                               //

--- a/hw/ip/aes/rtl/aes_sbox_canright_masked_noreuse.sv
+++ b/hw/ip/aes/rtl/aes_sbox_canright_masked_noreuse.sv
@@ -9,7 +9,13 @@
 // available at https://eprint.iacr.org/2009/011.pdf
 //
 // Note: This module implements the original masked inversion algorithm without re-using masks.
-// For details, see Section 2.2 of the paper.
+// For details, see Section 2.2 of the paper. In addition, a formal analysis using REBECCA (static
+// mode) shows that the intermediate masks cannot be created by re-using bits from the input and
+// output masks. Instead, fresh random bits need to be used for this intermediate masks.
+//
+// For details on the REBECCA tool, see the following paper:
+// Bloem, "Formal verification of masked hardware implementations in the presence of glitches"
+// available at https://eprint.iacr.org/2017/897.pdf
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // IMPORTANT NOTE:                                                                               //
@@ -111,10 +117,11 @@ endmodule
 // Masked inverse in GF(2^8), using normal basis [y^16, y]
 // (see Formulas 3, 12, 18 and 19 in the paper)
 module aes_masked_inverse_gf2p8_noreuse (
-  input  logic [7:0] a,
-  input  logic [7:0] m,
-  input  logic [7:0] n,
-  output logic [7:0] a_inv
+  input  logic [7:0] a,    // input data masked by m
+  input  logic [7:0] m,    // input mask
+  input  logic [7:0] n,    // output mask
+  input  logic [9:0] prd,  // pseudo-random data, e.g. for intermediate masks
+  output logic [7:0] a_inv // output data masked by n
 );
 
   import aes_pkg::*;
@@ -133,8 +140,37 @@ module aes_masked_inverse_gf2p8_noreuse (
   assign m1 = m[7:4];
   assign m0 = m[3:0];
 
-  // q must be independent of m.
-  assign q = n[7:4];
+  ////////////////////
+  // Notes on masks //
+  ////////////////////
+  // The paper states the following.
+  // r:
+  // - must be indpendent of q, and
+  // - it is suggested to re-use bits of m.
+  //
+  // q:
+  // - must be independent of m.
+  //
+  // t:
+  // - must be independent of r,
+  // - must be independent of m (for the final steps involving s),
+  // - t1 must be independent of q0, t0 must be independent of q1,
+  // - it is suggested to use t = q.
+  //
+  // s:
+  // - must be independent of t,
+  // - s1 must be independent of m0, s0 must be independent of m1,
+  // - it is suggested to use s = m.
+  //
+  // Formally analyzing the implementation with REBECCA reveals that:
+  // 1. Fresh random bits are required for r, q and t. Any re-use of other mask bits from m or n
+  //    causes the static check to fail.
+  // 2. s can be the specified output mask n.
+  assign r  = prd[1:0];
+  assign q  = prd[5:2];
+  assign t  = prd[9:6];
+  assign s1 = n[7:4];
+  assign s0 = n[3:0];
 
   // Formula 12
   // IMPORTANT: The following ops must be executed in order (left to right):
@@ -159,20 +195,6 @@ module aes_masked_inverse_gf2p8_noreuse (
   assign b_4 = b_3 ^ mul_a0_m1;
   assign b   = b_4 ^ mul_m0_m1;
 
-  // r must be independent of q.
-  assign r = m1[3:2];
-
-  // Note that the paper states the following requirements on t:
-  // - t must be independent of r.
-  // - t1 must be independent of q0, t0 must be independent of q1.
-  // - t must be independent of m (for the final steps involving s)
-  // The paper suggests to use t = q. To select s = n for the output mask (s must be independent
-  // of t = q = n[7:4]), we would need t = m0 or similar (not r, m1[3:2] though), but this would
-  // break the random product distribution of aes_mul_gf2p4(m0, t), or aes_mul_gf2p4(m1, t) below
-  // (see Lemma 2 in the paper). For this reason, we select t = q here and apply a final mask
-  // switch from s = m to n after the inversion.
-  assign t = q;
-
   // b is masked by q, b_inv is masked by t.
   aes_masked_inverse_gf2p4_noreuse aes_masked_inverse_gf2p4 (
     .b     ( b     ),
@@ -181,14 +203,6 @@ module aes_masked_inverse_gf2p8_noreuse (
     .t     ( t     ),
     .b_inv ( b_inv )
   );
-
-  // Note that the paper states the following requirements on s:
-  // - s must be independent of t
-  // - s1 must be independent of m0, s0 must be independent of m1.
-  // The paper suggests to use s = m (the input mask). To still end up with the specified output
-  // mask n, we will apply a final mask switch after the inversion.
-  assign s1 = m1;
-  assign s0 = m0;
 
   // Formulas 18 and 19
   // IMPORTANT: The following ops must be executed in order (left to right):
@@ -222,27 +236,18 @@ module aes_masked_inverse_gf2p8_noreuse (
   assign a0_inv_2 = a0_inv_1 ^ mul_m1_b_inv;
   assign a0_inv   = a0_inv_2 ^ mul_m1_t;
 
-  // Note: a_inv is now masked by s = m, a was masked by m.
-  (* keep = "true" *) logic [7:0] a_inv_0;
-  assign a_inv_0 = {a1_inv, a0_inv};
-
-  // To have a_inv masked by n (the specified output mask), we perform a final mask switch.
-  // IMPORTANT: The following ops must be executed in order (left to right):
-  // a_inv = a_inv ^ n ^ m;
-  //
-  // Generate a_inv step by step.
-  (* keep = "true" *) logic [7:0] a_inv_1;
-  assign a_inv_1 = a_inv_0 ^ n;
-  assign a_inv   = a_inv_1 ^ m;
+  // Note: a_inv is now masked by s = n, a was masked by m.
+  assign a_inv = {a1_inv, a0_inv};
 
 endmodule
 
 module aes_sbox_canright_masked_noreuse (
   input  aes_pkg::ciph_op_e op_i,
-  input  logic [7:0]        data_i,     // masked, the actual input data is data_i ^ in_mask_i
-  input  logic [7:0]        in_mask_i,  // input mask, independent from actual input data
-  input  logic [7:0]        out_mask_i, // output mask, independent from input mask
-  output logic [7:0]        data_o      // masked, the actual output data is data_o ^ out_mask_i
+  input  logic [7:0]        data_i,        // masked, the actual input data is data_i ^ in_mask_i
+  input  logic [7:0]        in_mask_i,     // input mask, independent from actual input data
+  input  logic [7:0]        out_mask_i,    // output mask, independent from input mask
+  input  logic [9:0]        prd_masking_i, // pseudo-random data, e.g. for intermediate masks
+  output logic [7:0]        data_o         // masked, the actual output data is data_o ^ out_mask_i
 );
 
   import aes_pkg::*;
@@ -273,6 +278,7 @@ module aes_sbox_canright_masked_noreuse (
     .a     ( in_data_basis_x  ), // input
     .m     ( in_mask_basis_x  ), // input
     .n     ( out_mask_basis_x ), // input
+    .prd   ( prd_masking_i    ), // input
     .a_inv ( out_data_basis_x )  // output
   );
 

--- a/hw/ip/aes/rtl/aes_sub_bytes.sv
+++ b/hw/ip/aes/rtl/aes_sub_bytes.sv
@@ -8,11 +8,12 @@ module aes_sub_bytes import aes_pkg::*;
 #(
   parameter sbox_impl_e SBoxImpl = SBoxImplLut
 ) (
-  input  ciph_op_e             op_i,
-  input  logic [3:0][3:0][7:0] data_i,
-  input  logic [3:0][3:0][7:0] in_mask_i,
-  input  logic [3:0][3:0][7:0] out_mask_i,
-  output logic [3:0][3:0][7:0] data_o
+  input  ciph_op_e                          op_i,
+  input  logic              [3:0][3:0][7:0] data_i,
+  input  logic              [3:0][3:0][7:0] in_mask_i,
+  input  logic              [3:0][3:0][7:0] out_mask_i,
+  input  logic [3:0][3:0][WidthPRDSBox-1:0] prd_masking_i,
+  output logic              [3:0][3:0][7:0] data_o
 );
 
   // Individually substitute bytes
@@ -21,11 +22,12 @@ module aes_sub_bytes import aes_pkg::*;
       aes_sbox #(
         .SBoxImpl ( SBoxImpl )
       ) u_aes_sbox_ij (
-        .op_i       ( op_i             ),
-        .data_i     ( data_i[i][j]     ),
-        .in_mask_i  ( in_mask_i[i][j]  ),
-        .out_mask_i ( out_mask_i[i][j] ),
-        .data_o     ( data_o[i][j]     )
+        .op_i          ( op_i                ),
+        .data_i        ( data_i[i][j]        ),
+        .in_mask_i     ( in_mask_i[i][j]     ),
+        .out_mask_i    ( out_mask_i[i][j]    ),
+        .prd_masking_i ( prd_masking_i[i][j] ),
+        .data_o        ( data_o[i][j]        )
       );
     end
   end

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -2539,7 +2539,7 @@
         {
           name: SBoxImpl
           type: aes_pkg::sbox_impl_e
-          default: aes_pkg::SBoxImplCanrightMasked
+          default: aes_pkg::SBoxImplCanrightMaskedNoreuse
           desc: Selection of the S-Box implementation. See aes_pkg.sv.
           local: "false"
           expose: "true"

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -13,7 +13,7 @@
 module top_earlgrey #(
   // Auto-inferred parameters
   parameter bit AesMasking = 1'b1,
-  parameter aes_pkg::sbox_impl_e AesSBoxImpl = aes_pkg::SBoxImplCanrightMasked,
+  parameter aes_pkg::sbox_impl_e AesSBoxImpl = aes_pkg::SBoxImplCanrightMaskedNoreuse,
   parameter int unsigned SecAesStartTriggerDelay = 0,
   parameter bit SecAesAllowForcingMasks = 1'b0,
   parameter int KmacEnMasking = 0,

--- a/hw/top_earlgrey/rtl/top_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_asic.sv
@@ -250,7 +250,7 @@ module top_earlgrey_asic (
 
   top_earlgrey #(
     .AesMasking(1'b1),
-    .AesSBoxImpl(aes_pkg::SBoxImplCanrightMasked),
+    .AesSBoxImpl(aes_pkg::SBoxImplCanrightMaskedNoreuse),
     .SecAesStartTriggerDelay(0),
     .SecAesAllowForcingMasks(1'b0),
     .KmacEnMasking(1),  // DOM AND + Masking scheme


### PR DESCRIPTION
Formal analysis using the REBECCA tool revealed that it is not secure to re-use bits of the input and output masks for these intermediate masks. Using fresh randomness instead allows the "noreuse" version to pass static verification.

This also requires changes in the masking PRNG and the distribution of the randomness inside the cipher core. To simplify future changes to the masking scheme, the PRNG output now consists of a fixed-width part (8 bits output mask per S-Box) and a parameterized part per S-Box, used e.g. for intermediate masks.

Notes:
- ~~This PR depends on #3851 . Please just review the second commit.~~
- I will enable the setting of LFSR seeds and permutations via topgen into AES in a separate PR as it touches many files. I didn't want to further complicate this PR.