### PR TITLE
[aes/doc] Clarify that SW must poll Status Reg after sending a trigger

### DIFF
--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -387,7 +387,10 @@
     desc: '''
       Trigger Register.
       Each bit is individually cleared to zero when executing the corresponding trigger.
-
+      While executing any of the triggered operations, the AES unit will set the IDLE bit in the Status Register to zero.
+      The processor must check the Status Register before triggering further actions.
+      For example, writes to Initial Key and IV Registers are ignored while the AES unit is busy.
+      Writes to the Input Data Registers are not ignored but the data will be cleared if a DATA_IN_CLEAR operation is pending.
     '''
     swaccess: "wo",
     hwaccess: "hrw",


### PR DESCRIPTION
When executing a trigger, the AES module will indicate this by driving the IDLE bit in the Status Register to zero. While busy, writes to Initial Key and IV registers are ignored.

This is related to lowRISC/OpenTitan#4118.