### PR TITLE
[otbn] Remove "sanity" from tree

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -417,7 +417,7 @@ jobs:
       ./hw/ip/otbn/dv/smoke/run_smoke.sh
     displayName: OTBN Smoke Test
   - bash: |
-      make -C hw/ip/otbn/util asm-sanity
+      make -C hw/ip/otbn/util asm-check
     displayName: Assemble and link code snippets
 
 - job: top_earlgrey_nexysvideo

--- a/hw/ip/otbn/README.md
+++ b/hw/ip/otbn/README.md
@@ -40,7 +40,7 @@ Will assemble and link `prog.s` and produce various outputs using
 
 The instruction set is described in machine readable form in
 `data/insns.yml`. This is parsed by Python code in
-`util/insn_yaml.py`, which runs various sanity checks on the data. The
+`util/insn_yaml.py`, which runs various basic checks on the data. The
 binutils-based toolchain described above uses this information. Other
 users include:
 

--- a/hw/ip/otbn/dv/otbnsim/sim/dmem.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/dmem.py
@@ -35,8 +35,8 @@ class Dmem:
     def __init__(self) -> None:
         _, dmem_size = get_memory_layout()['DMEM']
 
-        # Sanity check to avoid allocating massive chunks of memory. We know we
-        # won't have more than 1 MiB of DMEM.
+        # Check the arguments look sensible, to avoid allocating massive chunks
+        # of memory. We know we won't have more than 1 MiB of DMEM.
         if dmem_size > 1024 * 1024:
             raise RuntimeError('Implausibly large DMEM size: {}'
                                .format(dmem_size))

--- a/hw/ip/otbn/dv/otbnsim/sim/isa.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/isa.py
@@ -37,10 +37,11 @@ class DummyInsn(Insn):
 def insn_for_mnemonic(mnemonic: str, num_operands: int) -> Insn:
     '''Look up the named instruction in the loaded YAML data.
 
-    As a sanity check, make sure it has the expected number of operands. If we
-    fail to find the right instruction, print a message to stderr and exit
-    (rather than raising a RuntimeError: this happens on module load time, so
-    it's a lot clearer to the user what's going on this way).
+    To make sure nothing's gone really wrong, make sure it has the expected
+    number of operands. If we fail to find the right instruction, print a
+    message to stderr and exit (rather than raising a RuntimeError: this
+    happens on module load time, so it's a lot clearer to the user what's going
+    on this way).
 
     '''
     insn = _INSNS_FILE.mnemonic_to_insn.get(mnemonic)

--- a/hw/ip/otbn/util/Makefile
+++ b/hw/ip/otbn/util/Makefile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 .PHONY: all
-all: lint asm-sanity
+all: lint asm-check
 
 # We need a directory to build stuff and use the "otbn/util" namespace
 # in the top-level build-bin directory.
@@ -33,8 +33,8 @@ lint: $(lint-stamps)
 $(lint-targets): lint-%:
 	mypy --strict $* $(pylibs)
 
-# Sanity check target that assembles and links each of the code
-# snippets.
+# Target that assembles and links each of the code snippets to make
+# sure the toolchain is in a reasonable shape.
 
 otbn-code-snippets-obj-dir := $(cs-build-dir)
 otbn-code-snippets-bin-dir := $(cs-build-dir)
@@ -42,8 +42,8 @@ otbn-code-snippets-util-dir  := .
 
 include $(repo-top)/sw/otbn/code-snippets/rules.mk
 
-.PHONY: asm-sanity
-asm-sanity: $(otbn-code-snippets-elfs)
+.PHONY: asm-check
+asm-check: $(otbn-code-snippets-elfs)
 
 .PHONY: clean
 clean:

--- a/hw/ip/otbn/util/otbn-as
+++ b/hw/ip/otbn/util/otbn-as
@@ -730,8 +730,9 @@ class Transformer:
         for rv_name, rv_num in rv_nums.items():
             rv_op_fmt, _, _ = rve.rvfmt.op_data[rv_name]
             if rv_num != 0:
-                # We've got some fixed or partial data. As a sanity check, make
-                # sure we don't have a match in rv_field_to_op.
+                # We've got some fixed or partial data. We shouldn't have a
+                # match in rv_to_full_op (because the code in find_rv_encoding
+                # will put an operand in that or rv_masks, but not both)
                 assert rv_name not in rve.rv_to_full_op
                 rv_strings[rv_name] = rv_render(rv_op_fmt, rv_num)
                 continue

--- a/hw/ip/otbn/util/rig/gens/straight_line_insn.py
+++ b/hw/ip/otbn/util/rig/gens/straight_line_insn.py
@@ -59,7 +59,10 @@ class StraightLineInsn(SnippetGen):
         prog_insn = None
         while prog_insn is None:
             idx = random.choices(range(len(self.insns)), weights=weights)[0]
-            # Sanity check to make sure some weight was positive
+            # At least one weight should be positive. This is guaranteed so
+            # long as fill_insn doesn't fail for absolutely everything. We know
+            # that doesn't happen, because we have some instructions (such as
+            # addi) where it will not fail.
             assert weights[idx] > 0
 
             # Try to fill out the instruction. On failure, clear the weight for
@@ -85,6 +88,10 @@ class StraightLineInsn(SnippetGen):
 
         This might fail if, for example, the model doesn't have enough
         registers with architectural values. In that case, return None.
+
+        Note that there are some instructions that will never return None. For
+        example, addi, which can always expand to "addi x0, x0, 0" (also known
+        as nop).
 
         '''
 

--- a/hw/ip/otbn/util/rig/program.py
+++ b/hw/ip/otbn/util/rig/program.py
@@ -231,9 +231,9 @@ class Program:
         sec_addr, open_section = self._cur_section
 
         # The "insns_left" tracking in OpenSection should ensure that this
-        # section doesn't collide with anything else in self._sections. As a
-        # quick sanity check, we make sure the base address isn't duplicated
-        # (of course, that's not a full check, but it can't hurt).
+        # section doesn't collide with anything else in self._sections. To
+        # catch really silly errors, we make sure the base address isn't
+        # duplicated (of course, that's not a full check, but it can't hurt).
         assert sec_addr not in self._sections
         self._sections[sec_addr] = open_section.insns
 

--- a/hw/ip/otbn/util/rig/snippet_gens.py
+++ b/hw/ip/otbn/util/rig/snippet_gens.py
@@ -58,8 +58,8 @@ class SnippetGens:
             # Note that there should always be at least one non-zero weight in
             # real_weights. random.choices doesn't check that: if you pass all
             # weights equal to zero, it always picks the last element. Since
-            # that would cause an infinite loop, add a sanity check here to
-            # make sure that the choice we made had positive weight.
+            # that would cause an infinite loop, add a check here to make sure
+            # that the choice we made had positive weight.
             assert real_weights[idx] > 0
 
             # Run the generator to generate a snippet

--- a/hw/ip/otbn/util/shared/operand.py
+++ b/hw/ip/otbn/util/shared/operand.py
@@ -189,8 +189,6 @@ class RegOperandType(OperandType):
              is_dest: bool,
              what: str,
              scheme_field: Optional[EncSchemeField]) -> 'RegOperandType':
-        '''Sanity-checking smart constructor'''
-
         if scheme_field is not None:
             fmt = RegOperandType.TYPE_FMTS.get(reg_type)
             assert fmt is not None
@@ -265,8 +263,6 @@ class ImmOperandType(OperandType):
              pc_rel: bool,
              what: str,
              scheme_field: Optional[EncSchemeField]) -> 'ImmOperandType':
-        '''Sanity-checking smart constructor'''
-
         if scheme_field is not None:
             # If there is an encoding scheme, check its width is compatible
             # with the operand type. If the operand type doesn't specify a

--- a/hw/ip/otbn/util/yaml_to_doc.py
+++ b/hw/ip/otbn/util/yaml_to_doc.py
@@ -129,7 +129,8 @@ def render_encoding(mnemonic: str,
     # Now run down the ranges in descending order of msb to get the table cells
     next_bit = 31
     for msb in sorted(by_msb.keys(), reverse=True):
-        # Sanity check to make sure we have a dense table
+        # Check to make sure we have a dense table (this should be guaranteed
+        # because encoding objects ensure they hit every bit).
         assert msb == next_bit
 
         width, desc = by_msb[msb]


### PR DESCRIPTION
Rewrite comments using this term, sometimes expanding them a bit.
There's one remaining use, in README.md: this seems tied in with the
OTBN DIF work, which is slightly in flux, so I've left it for now.

This was a bigger change than I expected: apparently I have been using this terminology a lot! :-/

@imphil: I don't know much about the chip-level integration stuff. Is the flash path in the readme correct?