### PR TITLE
Fix Synthesis Errors

### DIFF
--- a/hw/ip/keymgr/rtl/keymgr_sideload_key_ctrl.sv
+++ b/hw/ip/keymgr/rtl/keymgr_sideload_key_ctrl.sv
@@ -26,10 +26,10 @@ module keymgr_sideload_key_ctrl import keymgr_pkg::*;(
 
   // Enumeration for working state
   typedef enum logic [1:0] {
-    StReset,
-    StIdle,
-    StWipe,
-    StStop
+    StSideloadReset,
+    StSideloadIdle,
+    StSideloadWipe,
+    StSideloadStop
   } keymgr_sideload_e;
 
   keymgr_sideload_e state_q, state_d;
@@ -41,7 +41,7 @@ module keymgr_sideload_key_ctrl import keymgr_pkg::*;(
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      state_q <= StReset;
+      state_q <= StSideloadReset;
       cnt_q <= '0;
     end else begin
       state_q <= state_d;
@@ -60,28 +60,28 @@ module keymgr_sideload_key_ctrl import keymgr_pkg::*;(
     state_d = state_q;
 
     unique case (state_q)
-      StReset: begin
+      StSideloadReset: begin
         if (init_i && en_i) begin
-          state_d = StIdle;
+          state_d = StSideloadIdle;
         end
       end
 
-      StIdle: begin
+      StSideloadIdle: begin
         keys_en = 1'b1;
         if (!en_i) begin
           keys_en = 1'b0;
-          state_d = StWipe;
+          state_d = StSideloadWipe;
         end
       end
 
-      StWipe: begin
+      StSideloadWipe: begin
         keys_en = 1'b0;
         clr = 1'b1;
-        state_d = StStop;
+        state_d = StSideloadStop;
       end
 
       // intentional terminal state
-      StStop: begin
+      StSideloadStop: begin
         keys_en = 1'b0;
       end
 

--- a/hw/ip/otbn/dv/model/otbn_core_model.sv
+++ b/hw/ip/otbn/dv/model/otbn_core_model.sv
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+`ifndef SYNTHESIS
 `include "prim_assert.sv"
 
 /**
@@ -9,6 +10,7 @@
  *
  * This module is the top-level of the OTBN processing core.
  */
+
 module otbn_core_model
   import otbn_pkg::*;
 #(
@@ -152,3 +154,5 @@ module otbn_core_model
   assign err_o = failed_step | failed_cmp;
 
 endmodule
+`endif // SYNTHESIS
+

--- a/hw/ip/otbn/dv/model/otbn_rf_snooper_if.sv
+++ b/hw/ip/otbn/dv/model/otbn_rf_snooper_if.sv
@@ -5,6 +5,7 @@
 // Backdoor interface that can be bound into an OTBN register file and exports a function to peek at
 // the memory contents.
 
+`ifndef SYNTHESIS
 interface otbn_rf_snooper_if #(
   parameter int Width = 32,    // Memory width in bits
   parameter int Depth = 32     // Number of registers
@@ -30,3 +31,4 @@ interface otbn_rf_snooper_if #(
   endfunction
 
 endinterface
+`endif // SYNTHESIS

--- a/hw/ip/otbn/dv/model/otbn_stack_snooper_if.sv
+++ b/hw/ip/otbn/dv/model/otbn_stack_snooper_if.sv
@@ -5,6 +5,7 @@
 // Backdoor interface that can be bound into an OTBN stack and exports a function to peek at
 // the stack contents.
 
+`ifndef SYNTHESIS
 interface otbn_stack_snooper_if #(
   parameter int StackWidth = 32,
   parameter int StackDepth = 4,
@@ -36,3 +37,4 @@ interface otbn_stack_snooper_if #(
   endfunction
 
 endinterface
+`endif // SYNTHESIS

--- a/hw/ip/otbn/otbn.core
+++ b/hw/ip/otbn/otbn.core
@@ -37,7 +37,7 @@ filesets:
       - lowrisc:prim:util
       - lowrisc:prim:ram_1p_adv
       - lowrisc:ip:otbn_pkg
-      - "!tool_ascentlint ? (lowrisc:dv:otbn_model)"
+      - lowrisc:dv:otbn_model
     files:
       - rtl/otbn_reg_pkg.sv
       - rtl/otbn_reg_top.sv


### PR DESCRIPTION
This PR has two fixes. One for OTBN, other for KeyMgr.

**OTBN**:

otbn_core_model is included in the synthesis filelist. Issue discussed in #4144 

**KeyMgr**:

sideload state enums conflict to keymgr_pkg state enums. Added `Sideload` identifier to the state enums.