### PR TITLE
[keymgr] en_i updates

### DIFF
--- a/hw/ip/keymgr/doc/_index.md
+++ b/hw/ip/keymgr/doc/_index.md
@@ -128,7 +128,12 @@ When entering Disabled random values are used to compute a new random value.
 The function of the key manager is directly tied to the life cycle controller.
 During specific life cycle states, the key manager is explicitly disabled.
 
-When disabled, key manager will not advance or generate and if currently in an operational state, will automatically transition to `Disabled`.
+When disabled, the following key manager behavior applies:
+-  If the key manager has not been initialized, it cannot be initialized until life cycle enables key manager.
+-  If the key manager has been initialized and is currently in a valid state, it immediately wipes its key contents (working state, sideload keys and software keys) and transitions to `Disabled`.
+   -  Note, unlike a normal software requested disable, this path does not gracefully interact with KMAC, instead the secret contents are forcibly wiped.
+   -  If there is an ongoing transaction with KMAC, the handshake with KMAC is still completed as usual, however the results are discarded and the value sent to KMAC are also not real.
+-  Once the system settles to `Disabled` state, the behavior is consistent with normal behavior.
 
 
 ## Commands in Each State
@@ -224,7 +229,7 @@ Key manager is primarily composed of two components:
 ### Key Manager Control
 
 The key manager control block manages the working state, sideload key updates, as well as what commands are valid in each state.
-It also handles the life cycle keymgr_en input, which helps disable the entire key manager function in the event of an escalation.
+It also handles the life cycle `keymgr_en` input, which helps disable the entire key manager function in the event of an escalation.
 
 ![Key Manager Control Block Diagram](keymgr_control_diagram.svg)
 

--- a/hw/ip/keymgr/lint/keymgr.waiver
+++ b/hw/ip/keymgr/lint/keymgr.waiver
@@ -7,5 +7,5 @@
 waive -rules {MISSING_STATE} -location {keymgr_ctrl.sv} -regexp {.*StDisabled.*} \
       -comment "Disabled state absorbed into default."
 
-waive -rules {TERMINAL_STATE} -location {keymgr_sideload_key_ctrl.sv} -regexp {.*StStop.*} \
+waive -rules {TERMINAL_STATE} -location {keymgr_sideload_key_ctrl.sv} -regexp {.*StSideloadStop.*} \
       -comment "Intentional terminal state."

--- a/hw/ip/keymgr/rtl/keymgr_cfg_en.sv
+++ b/hw/ip/keymgr/rtl/keymgr_cfg_en.sv
@@ -10,7 +10,7 @@
 module keymgr_cfg_en (
   input clk_i,
   input rst_ni,
-  input keymgr_en_i,
+  input en_i,
   input set_i,
   input clr_i,
   output logic out_o
@@ -20,13 +20,13 @@ module keymgr_cfg_en (
 
   // the same cycle where clear is asserted should already block future
   // configuration
-  assign out_o = ~clr_i & out_q & keymgr_en_i;
+  assign out_o = ~clr_i & out_q & en_i;
 
   // clearing the configure enable always has higher priority than setting
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       out_q <= 1'b1;
-    end else if (!keymgr_en_i) begin
+    end else if (!en_i) begin
       out_q <= 1'b0;
     end else if (set_i) begin
       out_q <= 1'b1;

--- a/hw/ip/keymgr/rtl/keymgr_kmac_if.sv
+++ b/hw/ip/keymgr/rtl/keymgr_kmac_if.sv
@@ -202,9 +202,12 @@ module keymgr_kmac_if import keymgr_pkg::*;(
       end
 
       StClean: begin
-        // make sure there's a cycle of random data to keymgr_ctrl/kmac before transitioning
-        // back to idle
-        state_d = StIdle;
+        done_o = 1'b1;
+
+        // wait for control side to ack done by waiting start de-assertion
+        if (!start) begin
+          state_d = StIdle;
+        end
       end
 
       // trigger error

--- a/hw/ip/keymgr/rtl/keymgr_pkg.sv
+++ b/hw/ip/keymgr/rtl/keymgr_pkg.sv
@@ -75,12 +75,13 @@ package keymgr_pkg;
   // Enumeration for working state
   typedef enum logic [2:0] {
     StReset = 0,
-    StWipe = 1,
+    StRandom = 1,
     StInit = 2,
     StCreatorRootKey = 3,
     StOwnerIntKey = 4,
     StOwnerKey = 5,
-    StDisabled = 6
+    StWipe = 6,
+    StDisabled = 7
   } keymgr_working_state_e;
 
   // Enumeration for operation status

--- a/hw/ip/keymgr/rtl/keymgr_sideload_key_ctrl.sv
+++ b/hw/ip/keymgr/rtl/keymgr_sideload_key_ctrl.sv
@@ -9,8 +9,8 @@
 module keymgr_sideload_key_ctrl import keymgr_pkg::*;(
   input clk_i,
   input rst_ni,
-  input en_i,
   input init_i,
+  input wipe_key_i,
   input [31:0] entropy_i,
   input keymgr_key_dest_e dest_sel_i,
   input keymgr_gen_out_e key_sel_i,
@@ -61,14 +61,14 @@ module keymgr_sideload_key_ctrl import keymgr_pkg::*;(
 
     unique case (state_q)
       StSideloadReset: begin
-        if (init_i && en_i) begin
+        if (init_i) begin
           state_d = StSideloadIdle;
         end
       end
 
       StSideloadIdle: begin
         keys_en = 1'b1;
-        if (!en_i) begin
+        if (wipe_key_i) begin
           keys_en = 1'b0;
           state_d = StSideloadWipe;
         end
@@ -77,7 +77,9 @@ module keymgr_sideload_key_ctrl import keymgr_pkg::*;(
       StSideloadWipe: begin
         keys_en = 1'b0;
         clr = 1'b1;
-        state_d = StSideloadStop;
+        if (!wipe_key_i) begin
+          state_d = StSideloadStop;
+        end
       end
 
       // intentional terminal state


### PR DESCRIPTION
- immediately clear key states when enable drops
- still transition to disable state gracefully

