### PR TITLE
[flash_ctrl] rd buffer enable controls

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
@@ -307,6 +307,9 @@ module flash_ctrl import flash_ctrl_pkg::*; (
     // phase indication
     .phase_o(hw_phase),
 
+    // phy read buffer enable
+    .rd_buf_en_o(flash_o.rd_buf_en),
+
     // init ongoing
     .init_busy_o(ctrl_init_busy)
   );

--- a/hw/ip/flash_ctrl/data/flash_ctrl_pkg.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_pkg.sv.tpl
@@ -247,6 +247,7 @@ package flash_ctrl_pkg;
     mp_region_cfg_t [MpRegions:0] region_cfgs;
     logic [127:0]         addr_key;
     logic [127:0]         data_key;
+    logic                 rd_buf_en;
   } flash_req_t;
 
   // default value of flash_req_t (for dangling ports)
@@ -264,7 +265,8 @@ package flash_ctrl_pkg;
     prog_type:   FlashProgNormal,
     region_cfgs: '0,
     addr_key:    128'hDEADBEEFBEEFFACEDEADBEEF5A5AA5A5,
-    data_key:    128'hDEADBEEF5A5AA5A5DEADBEEFBEEFFACE
+    data_key:    128'hDEADBEEF5A5AA5A5DEADBEEFBEEFFACE,
+    rd_buf_en:   1'b0
   };
 
   // memory to flash controller

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -307,6 +307,9 @@ module flash_ctrl import flash_ctrl_pkg::*; (
     // phase indication
     .phase_o(hw_phase),
 
+    // phy read buffer enable
+    .rd_buf_en_o(flash_o.rd_buf_en),
+
     // init ongoing
     .init_busy_o(ctrl_init_busy)
   );

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_lcmgr.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_lcmgr.sv
@@ -49,6 +49,9 @@ module flash_ctrl_lcmgr import flash_ctrl_pkg::*; (
   // error status to registers
   output logic seed_err_o,
 
+  // enable read buffer in flash_phy
+  output logic rd_buf_en_o,
+
   // init ongoing
   output logic init_busy_o
 );
@@ -230,6 +233,9 @@ module flash_ctrl_lcmgr import flash_ctrl_pkg::*; (
     state_d = state_q;
     validate_d = validate_q;
 
+    // read buffer enable
+    rd_buf_en_o = 1'b0;
+
     // init status
     // flash_ctrl handles its own arbitration between hardware and software.
     // So once the init kicks off it is safe to ack.  The done signal is still
@@ -291,6 +297,7 @@ module flash_ctrl_lcmgr import flash_ctrl_pkg::*; (
 
       // Waiting for an rma entry command
       StWait: begin
+        rd_buf_en_o = 1'b1;
         if (rma_i) begin
           state_d = StWipeOwner;
         end

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
@@ -245,6 +245,7 @@ package flash_ctrl_pkg;
     mp_region_cfg_t [MpRegions:0] region_cfgs;
     logic [127:0]         addr_key;
     logic [127:0]         data_key;
+    logic                 rd_buf_en;
   } flash_req_t;
 
   // default value of flash_req_t (for dangling ports)
@@ -262,7 +263,8 @@ package flash_ctrl_pkg;
     prog_type:   FlashProgNormal,
     region_cfgs: '0,
     addr_key:    128'hDEADBEEFBEEFFACEDEADBEEF5A5AA5A5,
-    data_key:    128'hDEADBEEF5A5AA5A5DEADBEEFBEEFFACE
+    data_key:    128'hDEADBEEF5A5AA5A5DEADBEEFBEEFFACE,
+    rd_buf_en:   1'b0
   };
 
   // memory to flash controller

--- a/hw/ip/flash_ctrl/rtl/flash_phy.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy.sv
@@ -179,6 +179,7 @@ module flash_phy import flash_ctrl_pkg::*; (
       .prog_type_i(flash_ctrl_i.prog_type),
       .addr_key_i(flash_ctrl_i.addr_key),
       .data_key_i(flash_ctrl_i.data_key),
+      .rd_buf_en_i(flash_ctrl_i.rd_buf_en),
       .prog_type_avail_o(prog_type_avail[bank]),
       .host_req_rdy_o(host_req_rdy[bank]),
       .host_req_done_o(host_req_done[bank]),

--- a/hw/ip/flash_ctrl/rtl/flash_phy_core.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_core.sv
@@ -31,6 +31,7 @@ module flash_phy_core import flash_phy_pkg::*; #(
   input flash_ctrl_pkg::flash_prog_e prog_type_i,
   input [KeySize-1:0]                addr_key_i,
   input [KeySize-1:0]                data_key_i,
+  input                              rd_buf_en_i,
   output logic [ProgTypes-1:0]       prog_type_avail_o,
   output logic                       host_req_rdy_o,
   output logic                       host_req_done_o,
@@ -235,6 +236,7 @@ module flash_phy_core import flash_phy_pkg::*; #(
   flash_phy_rd u_rd (
     .clk_i,
     .rst_ni,
+    .buf_en_i(rd_buf_en_i),
     .req_i(reqs[PhyRead]),
     .descramble_i(muxed_scramble_en),
     .prog_i(reqs[PhyProg]),

--- a/hw/ip/flash_ctrl/rtl/flash_phy_rd.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_rd.sv
@@ -17,7 +17,7 @@
 // The allocate and descramble indication received at read stage are saved.
 // When the read completes, depending on the 'descramble' indication saved, the
 // data is either stored into FIFO (reg + skid) between read and descramble stage,
-// or forwarded directly to the buffers (no de-scramble)
+// or forwarded directly to the buffer (no de-scramble)
 //
 // If the storage element between read and de-scramble stages are completely full
 // for any reason, then the read stage cannot start.
@@ -29,6 +29,9 @@
 module flash_phy_rd import flash_phy_pkg::*; (
   input clk_i,
   input rst_ni,
+
+  // configuration interface from flash controller
+  input buf_en_i,
 
   // interface with arbitration unit
   input req_i,
@@ -64,6 +67,9 @@ module flash_phy_rd import flash_phy_pkg::*; (
   /////////////////////////////////
   // Read buffers
   /////////////////////////////////
+
+  // internal buffer enable
+  logic buf_en_q;
 
   // muxed de-scrambled and plain-data
   logic [DataWidth-1:0] muxed_data;
@@ -146,6 +152,7 @@ module flash_phy_rd import flash_phy_pkg::*; (
   // do not attempt to generate match unless the transaction is relevant
   for (genvar i = 0; i < NumBuf; i++) begin: gen_buf_match
     assign buf_match[i] = req_i &
+                          buf_en_q &
                           (buf_valid[i] | buf_wip[i]) &
                           (read_buf[i].addr == flash_word_addr) &
                           (read_buf[i].part == part_i);
@@ -179,7 +186,7 @@ module flash_phy_rd import flash_phy_pkg::*; (
   assign no_match = ~|buf_match;
 
   // if new request does not match anything, allocate
-  assign alloc = no_match ? {NumBuf{req_i}} &  buf_alloc : '0;
+  assign alloc = no_match ? {NumBuf{req_i & buf_en_q}} &  buf_alloc : '0;
 
   // read buffers
   // allocate sets state to Wip
@@ -189,6 +196,7 @@ module flash_phy_rd import flash_phy_pkg::*; (
     flash_phy_rd_buffers u_rd_buf (
       .clk_i,
       .rst_ni,
+      .en_i(buf_en_q),
       .alloc_i(rdy_o & alloc[i]),
       .update_i(update[i] & ~muxed_err),
       .wipe_i(data_hazard[i]),
@@ -197,6 +205,15 @@ module flash_phy_rd import flash_phy_pkg::*; (
       .data_i(muxed_data),
       .out_o(read_buf[i])
     );
+  end
+
+  // buffer enable cannot be changed unless the entire read pipeline is idle
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      buf_en_q <= 1'b0;
+    end else if (idle_o) begin
+      buf_en_q <= buf_en_i;
+    end
   end
 
   /////////////////////////////////
@@ -475,11 +492,14 @@ module flash_phy_rd import flash_phy_pkg::*; (
                   fifo_data_ready ? alloc_q2 : '0;
 
   // match in flash response when allocated buffer is the same as top of response fifo
-  assign flash_rsp_match = rsp_fifo_vld & data_valid & (rsp_fifo_rdata.buf_sel == update);
+  // if read buffers are not enabled, do not check buffer selection
+  assign flash_rsp_match = rsp_fifo_vld & data_valid &
+                           (~buf_en_q | rsp_fifo_rdata.buf_sel == update);
 
   // match in buf response when there is a valid buffer that is the same as top of response fifo
   for (genvar i = 0; i < NumBuf; i++) begin: gen_buf_rsp_match
-    assign buf_rsp_match[i] = rsp_fifo_vld & (rsp_fifo_rdata.buf_sel[i] & buf_valid[i]);
+    assign buf_rsp_match[i] = buf_en_q & rsp_fifo_vld &
+                              (rsp_fifo_rdata.buf_sel[i] & buf_valid[i]);
   end
 
   // select among the buffers

--- a/hw/ip/flash_ctrl/rtl/flash_phy_rd_buffers.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_rd_buffers.sv
@@ -22,6 +22,7 @@
 module flash_phy_rd_buffers import flash_phy_pkg::*; (
   input clk_i,
   input rst_ni,
+  input en_i,
   input alloc_i,
   input update_i,
   input wipe_i,
@@ -37,13 +38,15 @@ module flash_phy_rd_buffers import flash_phy_pkg::*; (
       out_o.addr <= '0;
       out_o.part <= flash_ctrl_pkg::FlashPartData;
       out_o.attr <= Invalid;
-    end else if (wipe_i) begin
+    end else if (!en_i && out_o.attr != Invalid) begin
       out_o.attr <= Invalid;
-    end else if (alloc_i) begin
+    end else if (wipe_i && en_i) begin
+      out_o.attr <= Invalid;
+    end else if (alloc_i && en_i) begin
       out_o.addr <= addr_i;
       out_o.part <= part_i;
       out_o.attr <= Wip;
-    end else if (update_i) begin
+    end else if (update_i && en_i) begin
       out_o.data <= data_i;
       out_o.attr <= Valid;
     end

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
@@ -313,6 +313,9 @@ module flash_ctrl import flash_ctrl_pkg::*; (
     // phase indication
     .phase_o(hw_phase),
 
+    // phy read buffer enable
+    .rd_buf_en_o(flash_o.rd_buf_en),
+
     // init ongoing
     .init_busy_o(ctrl_init_busy)
   );

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_pkg.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_pkg.sv
@@ -251,6 +251,7 @@ package flash_ctrl_pkg;
     mp_region_cfg_t [MpRegions:0] region_cfgs;
     logic [127:0]         addr_key;
     logic [127:0]         data_key;
+    logic                 rd_buf_en;
   } flash_req_t;
 
   // default value of flash_req_t (for dangling ports)
@@ -268,7 +269,8 @@ package flash_ctrl_pkg;
     prog_type:   FlashProgNormal,
     region_cfgs: '0,
     addr_key:    128'hDEADBEEFBEEFFACEDEADBEEF5A5AA5A5,
-    data_key:    128'hDEADBEEF5A5AA5A5DEADBEEFBEEFFACE
+    data_key:    128'hDEADBEEF5A5AA5A5DEADBEEFBEEFFACE,
+    rd_buf_en:   1'b0
   };
 
   // memory to flash controller


### PR DESCRIPTION
- disable read buffers during intial seed read and verification phases.
- the read buffers are automatically enabled during other periods.
- there is currently no software ability to control buffer enable/disable,
  but that's something that should be discussed as to whether there is a need.

