### PR TITLE
[flash_ctrl] Split scramble and ECC controls

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson
@@ -392,7 +392,14 @@
             { bits: "4",
               name: "SCRAMBLE_EN",
               desc: '''
-                Region is scramble and ECC enabled.
+                Region is scramble enabled.
+              ''',
+              resval: "0"
+            }
+            { bits: "5",
+              name: "ECC_EN",
+              desc: '''
+                Region is ECC enabled.
               ''',
               resval: "0"
             }
@@ -445,7 +452,14 @@
         { bits: "3",
           name: "SCRAMBLE_EN",
           desc: '''
-            Region is scramble and ECC enabled
+            Region is scrambleenabled
+          ''',
+          resval: "0"
+        }
+        { bits: "4",
+          name: "ECC_EN",
+          desc: '''
+            Region is ECC enabled
           ''',
           resval: "0"
         }
@@ -529,7 +543,14 @@
             { bits: "4",
               name: "SCRAMBLE_EN",
               desc: '''
-                Region is scramble and ECC enabled.
+                Region is scramble enabled.
+              ''',
+              resval: "0"
+            }
+            { bits: "5",
+              name: "ECC_EN",
+              desc: '''
+                Region is ECC enabled.
               ''',
               resval: "0"
             }
@@ -612,7 +633,14 @@
             { bits: "4",
               name: "SCRAMBLE_EN",
               desc: '''
-                Region is scramble and ECC enabled.
+                Region is scramble enabled.
+              ''',
+              resval: "0"
+            }
+            { bits: "5",
+              name: "ECC_EN",
+              desc: '''
+                Region is ECC enabled.
               ''',
               resval: "0"
             }
@@ -695,7 +723,14 @@
             { bits: "4",
               name: "SCRAMBLE_EN",
               desc: '''
-                Region is scramble and ECC enabled.
+                Region is scramble enabled.
+              ''',
+              resval: "0"
+            }
+            { bits: "5",
+              name: "ECC_EN",
+              desc: '''
+                Region is ECC enabled.
               ''',
               resval: "0"
             }
@@ -778,7 +813,14 @@
             { bits: "4",
               name: "SCRAMBLE_EN",
               desc: '''
-                Region is scramble and ECC enabled.
+                Region is scramble enabled.
+              ''',
+              resval: "0"
+            }
+            { bits: "5",
+              name: "ECC_EN",
+              desc: '''
+                Region is ECC enabled.
               ''',
               resval: "0"
             }

--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
@@ -388,7 +388,14 @@
             { bits: "4",
               name: "SCRAMBLE_EN",
               desc: '''
-                Region is scramble and ECC enabled.
+                Region is scramble enabled.
+              ''',
+              resval: "0"
+            }
+            { bits: "5",
+              name: "ECC_EN",
+              desc: '''
+                Region is ECC enabled.
               ''',
               resval: "0"
             }
@@ -441,7 +448,14 @@
         { bits: "3",
           name: "SCRAMBLE_EN",
           desc: '''
-            Region is scramble and ECC enabled
+            Region is scrambleenabled
+          ''',
+          resval: "0"
+        }
+        { bits: "4",
+          name: "ECC_EN",
+          desc: '''
+            Region is ECC enabled
           ''',
           resval: "0"
         }
@@ -527,7 +541,14 @@
             { bits: "4",
               name: "SCRAMBLE_EN",
               desc: '''
-                Region is scramble and ECC enabled.
+                Region is scramble enabled.
+              ''',
+              resval: "0"
+            }
+            { bits: "5",
+              name: "ECC_EN",
+              desc: '''
+                Region is ECC enabled.
               ''',
               resval: "0"
             }

--- a/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
@@ -516,6 +516,7 @@ module flash_ctrl import flash_ctrl_pkg::*; (
   assign region_cfgs[MpRegions].prog_en.q = reg2hw.default_region.prog_en.q;
   assign region_cfgs[MpRegions].erase_en.q = reg2hw.default_region.erase_en.q;
   assign region_cfgs[MpRegions].scramble_en.q = reg2hw.default_region.scramble_en.q;
+  assign region_cfgs[MpRegions].ecc_en.q = reg2hw.default_region.ecc_en.q;
 
   //////////////////////////////////////
   // Info partition protection configuration
@@ -591,6 +592,7 @@ module flash_ctrl import flash_ctrl_pkg::*; (
     // flash phy interface
     .req_o(flash_o.req),
     .scramble_en_o(flash_o.scramble_en),
+    .ecc_en_o(flash_o.ecc_en),
     .rd_o(flash_o.rd),
     .prog_o(flash_o.prog),
     .pg_erase_o(flash_o.pg_erase),

--- a/hw/ip/flash_ctrl/data/flash_ctrl_pkg.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_pkg.sv.tpl
@@ -140,7 +140,8 @@ package flash_ctrl_pkg;
     rd_en:       1'b1,
     prog_en:     1'b0,
     erase_en:    1'b0,
-    scramble_en: 1'b0  // TBD, update to 1 once tb supports ECC
+    scramble_en: 1'b0,
+    ecc_en:      1'b0  // TBD, update to 1 once tb supports ECC
   };
 
   parameter info_page_cfg_t CfgAllowReadErase = '{
@@ -148,7 +149,8 @@ package flash_ctrl_pkg;
     rd_en:       1'b1,
     prog_en:     1'b0,
     erase_en:    1'b1,
-    scramble_en: 1'b0  // TBD, update to 1 once tb supports ECC
+    scramble_en: 1'b0,
+    ecc_en:      1'b0  // TBD, update to 1 once tb supports ECC
   };
 
   parameter info_page_attr_t HwInfoPageAttr[HwInfoRules] = '{
@@ -180,6 +182,7 @@ package flash_ctrl_pkg;
                  prog_en:     1'b0,
                  erase_en:    1'b1,
                  scramble_en: 1'b0,
+                 ecc_en:      1'b0,
                  base:        '0,
                  size:        '{default:'1}
                 }
@@ -235,6 +238,7 @@ package flash_ctrl_pkg;
   typedef struct packed {
     logic                 req;
     logic                 scramble_en;
+    logic                 ecc_en;
     logic                 rd;
     logic                 prog;
     logic                 pg_erase;
@@ -253,6 +257,7 @@ package flash_ctrl_pkg;
   parameter flash_req_t FLASH_REQ_DEFAULT = '{
     req:         1'b0,
     scramble_en: 1'b0,
+    ecc_en:      1'b0,
     rd:          1'b0,
     prog:        1'b0,
     pg_erase:    1'b0,

--- a/hw/ip/flash_ctrl/doc/_index.md
+++ b/hw/ip/flash_ctrl/doc/_index.md
@@ -222,10 +222,25 @@ When a read transaction is sent to flash, the following steps are taken:
 *  If the data content is not scrambled, the prince and XOR steps are skipped and data provided directly back to the requestor.
 
 When a program transaction is sent to flash, the same steps are taken if the address in question has scrambling enabled.
-During a program, the text is encrypted through the prince block cipher.
+During a program, the text is scrambled through the prince block cipher.
 
-Note, at the moment scrambling is enabled on the entire 2nd bank of flash, but in the future will be a page boundary attribute.
+Scramble enablement is done differently depending on the type of partitions.
+*  For data partitions, the scramble enablement is done on contiugous page boundaries.
+   *  Software has the ability to configure these regions and whether scramble is enabled.
+*  For information partitions,the scramble enablement is done on a per page basis.
+   *  Software can configure for each page whether scramble is enabled.
 
+### Flash ECC
+
+Similar to scrambling, flash ECC is enabled based on an address decode.
+The ECC for flash is chosen such that a fully erased flash word has valid ECC.
+Likewise a flash word that is completely 0 is also valid ECC.
+
+ECC enablement is done differently depending on the type of partitions.
+*  For data partitions, the ECC enablement is done on contiugous page boundaries.
+   *  Software has the ability to configure these regions and whether ECC is enabled.
+*  For information partitions,the ECC enablement is done on a per page basis.
+   *  Software can configure for each page whether ECC is enabled.
 
 #### Scrambling Consistency
 

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -516,6 +516,7 @@ module flash_ctrl import flash_ctrl_pkg::*; (
   assign region_cfgs[MpRegions].prog_en.q = reg2hw.default_region.prog_en.q;
   assign region_cfgs[MpRegions].erase_en.q = reg2hw.default_region.erase_en.q;
   assign region_cfgs[MpRegions].scramble_en.q = reg2hw.default_region.scramble_en.q;
+  assign region_cfgs[MpRegions].ecc_en.q = reg2hw.default_region.ecc_en.q;
 
   //////////////////////////////////////
   // Info partition protection configuration
@@ -590,6 +591,7 @@ module flash_ctrl import flash_ctrl_pkg::*; (
     // flash phy interface
     .req_o(flash_o.req),
     .scramble_en_o(flash_o.scramble_en),
+    .ecc_en_o(flash_o.ecc_en),
     .rd_o(flash_o.rd),
     .prog_o(flash_o.prog),
     .pg_erase_o(flash_o.pg_erase),

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
@@ -138,7 +138,8 @@ package flash_ctrl_pkg;
     rd_en:       1'b1,
     prog_en:     1'b0,
     erase_en:    1'b0,
-    scramble_en: 1'b0  // TBD, update to 1 once tb supports ECC
+    scramble_en: 1'b0,
+    ecc_en:      1'b0  // TBD, update to 1 once tb supports ECC
   };
 
   parameter info_page_cfg_t CfgAllowReadErase = '{
@@ -146,7 +147,8 @@ package flash_ctrl_pkg;
     rd_en:       1'b1,
     prog_en:     1'b0,
     erase_en:    1'b1,
-    scramble_en: 1'b0  // TBD, update to 1 once tb supports ECC
+    scramble_en: 1'b0,
+    ecc_en:      1'b0  // TBD, update to 1 once tb supports ECC
   };
 
   parameter info_page_attr_t HwInfoPageAttr[HwInfoRules] = '{
@@ -178,6 +180,7 @@ package flash_ctrl_pkg;
                  prog_en:     1'b0,
                  erase_en:    1'b1,
                  scramble_en: 1'b0,
+                 ecc_en:      1'b0,
                  base:        '0,
                  size:        '{default:'1}
                 }
@@ -233,6 +236,7 @@ package flash_ctrl_pkg;
   typedef struct packed {
     logic                 req;
     logic                 scramble_en;
+    logic                 ecc_en;
     logic                 rd;
     logic                 prog;
     logic                 pg_erase;
@@ -251,6 +255,7 @@ package flash_ctrl_pkg;
   parameter flash_req_t FLASH_REQ_DEFAULT = '{
     req:         1'b0,
     scramble_en: 1'b0,
+    ecc_en:      1'b0,
     rd:          1'b0,
     prog:        1'b0,
     pg_erase:    1'b0,

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
@@ -135,6 +135,9 @@ package flash_ctrl_reg_pkg;
       logic        q;
     } scramble_en;
     struct packed {
+      logic        q;
+    } ecc_en;
+    struct packed {
       logic [8:0]  q;
     } base;
     struct packed {
@@ -155,6 +158,9 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        q;
     } scramble_en;
+    struct packed {
+      logic        q;
+    } ecc_en;
   } flash_ctrl_reg2hw_default_region_reg_t;
 
   typedef struct packed {
@@ -173,6 +179,9 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        q;
     } scramble_en;
+    struct packed {
+      logic        q;
+    } ecc_en;
   } flash_ctrl_reg2hw_bank0_info0_page_cfg_mreg_t;
 
   typedef struct packed {
@@ -191,6 +200,9 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        q;
     } scramble_en;
+    struct packed {
+      logic        q;
+    } ecc_en;
   } flash_ctrl_reg2hw_bank0_info1_page_cfg_mreg_t;
 
   typedef struct packed {
@@ -209,6 +221,9 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        q;
     } scramble_en;
+    struct packed {
+      logic        q;
+    } ecc_en;
   } flash_ctrl_reg2hw_bank1_info0_page_cfg_mreg_t;
 
   typedef struct packed {
@@ -227,6 +242,9 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        q;
     } scramble_en;
+    struct packed {
+      logic        q;
+    } ecc_en;
   } flash_ctrl_reg2hw_bank1_info1_page_cfg_mreg_t;
 
   typedef struct packed {
@@ -347,17 +365,17 @@ package flash_ctrl_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    flash_ctrl_reg2hw_intr_state_reg_t intr_state; // [395:390]
-    flash_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [389:384]
-    flash_ctrl_reg2hw_intr_test_reg_t intr_test; // [383:372]
-    flash_ctrl_reg2hw_control_reg_t control; // [371:353]
-    flash_ctrl_reg2hw_addr_reg_t addr; // [352:321]
-    flash_ctrl_reg2hw_mp_region_cfg_mreg_t [7:0] mp_region_cfg; // [320:129]
-    flash_ctrl_reg2hw_default_region_reg_t default_region; // [128:125]
-    flash_ctrl_reg2hw_bank0_info0_page_cfg_mreg_t [3:0] bank0_info0_page_cfg; // [124:105]
-    flash_ctrl_reg2hw_bank0_info1_page_cfg_mreg_t [3:0] bank0_info1_page_cfg; // [104:85]
-    flash_ctrl_reg2hw_bank1_info0_page_cfg_mreg_t [3:0] bank1_info0_page_cfg; // [84:65]
-    flash_ctrl_reg2hw_bank1_info1_page_cfg_mreg_t [3:0] bank1_info1_page_cfg; // [64:45]
+    flash_ctrl_reg2hw_intr_state_reg_t intr_state; // [420:415]
+    flash_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [414:409]
+    flash_ctrl_reg2hw_intr_test_reg_t intr_test; // [408:397]
+    flash_ctrl_reg2hw_control_reg_t control; // [396:378]
+    flash_ctrl_reg2hw_addr_reg_t addr; // [377:346]
+    flash_ctrl_reg2hw_mp_region_cfg_mreg_t [7:0] mp_region_cfg; // [345:146]
+    flash_ctrl_reg2hw_default_region_reg_t default_region; // [145:141]
+    flash_ctrl_reg2hw_bank0_info0_page_cfg_mreg_t [3:0] bank0_info0_page_cfg; // [140:117]
+    flash_ctrl_reg2hw_bank0_info1_page_cfg_mreg_t [3:0] bank0_info1_page_cfg; // [116:93]
+    flash_ctrl_reg2hw_bank1_info0_page_cfg_mreg_t [3:0] bank1_info0_page_cfg; // [92:69]
+    flash_ctrl_reg2hw_bank1_info1_page_cfg_mreg_t [3:0] bank1_info1_page_cfg; // [68:45]
     flash_ctrl_reg2hw_mp_bank_cfg_mreg_t [1:0] mp_bank_cfg; // [44:43]
     flash_ctrl_reg2hw_scratch_reg_t scratch; // [42:11]
     flash_ctrl_reg2hw_fifo_lvl_reg_t fifo_lvl; // [10:1]

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_top.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_top.sv
@@ -234,6 +234,9 @@ module flash_ctrl_reg_top (
   logic mp_region_cfg_0_scramble_en_0_qs;
   logic mp_region_cfg_0_scramble_en_0_wd;
   logic mp_region_cfg_0_scramble_en_0_we;
+  logic mp_region_cfg_0_ecc_en_0_qs;
+  logic mp_region_cfg_0_ecc_en_0_wd;
+  logic mp_region_cfg_0_ecc_en_0_we;
   logic [8:0] mp_region_cfg_0_base_0_qs;
   logic [8:0] mp_region_cfg_0_base_0_wd;
   logic mp_region_cfg_0_base_0_we;
@@ -255,6 +258,9 @@ module flash_ctrl_reg_top (
   logic mp_region_cfg_1_scramble_en_1_qs;
   logic mp_region_cfg_1_scramble_en_1_wd;
   logic mp_region_cfg_1_scramble_en_1_we;
+  logic mp_region_cfg_1_ecc_en_1_qs;
+  logic mp_region_cfg_1_ecc_en_1_wd;
+  logic mp_region_cfg_1_ecc_en_1_we;
   logic [8:0] mp_region_cfg_1_base_1_qs;
   logic [8:0] mp_region_cfg_1_base_1_wd;
   logic mp_region_cfg_1_base_1_we;
@@ -276,6 +282,9 @@ module flash_ctrl_reg_top (
   logic mp_region_cfg_2_scramble_en_2_qs;
   logic mp_region_cfg_2_scramble_en_2_wd;
   logic mp_region_cfg_2_scramble_en_2_we;
+  logic mp_region_cfg_2_ecc_en_2_qs;
+  logic mp_region_cfg_2_ecc_en_2_wd;
+  logic mp_region_cfg_2_ecc_en_2_we;
   logic [8:0] mp_region_cfg_2_base_2_qs;
   logic [8:0] mp_region_cfg_2_base_2_wd;
   logic mp_region_cfg_2_base_2_we;
@@ -297,6 +306,9 @@ module flash_ctrl_reg_top (
   logic mp_region_cfg_3_scramble_en_3_qs;
   logic mp_region_cfg_3_scramble_en_3_wd;
   logic mp_region_cfg_3_scramble_en_3_we;
+  logic mp_region_cfg_3_ecc_en_3_qs;
+  logic mp_region_cfg_3_ecc_en_3_wd;
+  logic mp_region_cfg_3_ecc_en_3_we;
   logic [8:0] mp_region_cfg_3_base_3_qs;
   logic [8:0] mp_region_cfg_3_base_3_wd;
   logic mp_region_cfg_3_base_3_we;
@@ -318,6 +330,9 @@ module flash_ctrl_reg_top (
   logic mp_region_cfg_4_scramble_en_4_qs;
   logic mp_region_cfg_4_scramble_en_4_wd;
   logic mp_region_cfg_4_scramble_en_4_we;
+  logic mp_region_cfg_4_ecc_en_4_qs;
+  logic mp_region_cfg_4_ecc_en_4_wd;
+  logic mp_region_cfg_4_ecc_en_4_we;
   logic [8:0] mp_region_cfg_4_base_4_qs;
   logic [8:0] mp_region_cfg_4_base_4_wd;
   logic mp_region_cfg_4_base_4_we;
@@ -339,6 +354,9 @@ module flash_ctrl_reg_top (
   logic mp_region_cfg_5_scramble_en_5_qs;
   logic mp_region_cfg_5_scramble_en_5_wd;
   logic mp_region_cfg_5_scramble_en_5_we;
+  logic mp_region_cfg_5_ecc_en_5_qs;
+  logic mp_region_cfg_5_ecc_en_5_wd;
+  logic mp_region_cfg_5_ecc_en_5_we;
   logic [8:0] mp_region_cfg_5_base_5_qs;
   logic [8:0] mp_region_cfg_5_base_5_wd;
   logic mp_region_cfg_5_base_5_we;
@@ -360,6 +378,9 @@ module flash_ctrl_reg_top (
   logic mp_region_cfg_6_scramble_en_6_qs;
   logic mp_region_cfg_6_scramble_en_6_wd;
   logic mp_region_cfg_6_scramble_en_6_we;
+  logic mp_region_cfg_6_ecc_en_6_qs;
+  logic mp_region_cfg_6_ecc_en_6_wd;
+  logic mp_region_cfg_6_ecc_en_6_we;
   logic [8:0] mp_region_cfg_6_base_6_qs;
   logic [8:0] mp_region_cfg_6_base_6_wd;
   logic mp_region_cfg_6_base_6_we;
@@ -381,6 +402,9 @@ module flash_ctrl_reg_top (
   logic mp_region_cfg_7_scramble_en_7_qs;
   logic mp_region_cfg_7_scramble_en_7_wd;
   logic mp_region_cfg_7_scramble_en_7_we;
+  logic mp_region_cfg_7_ecc_en_7_qs;
+  logic mp_region_cfg_7_ecc_en_7_wd;
+  logic mp_region_cfg_7_ecc_en_7_we;
   logic [8:0] mp_region_cfg_7_base_7_qs;
   logic [8:0] mp_region_cfg_7_base_7_wd;
   logic mp_region_cfg_7_base_7_we;
@@ -399,6 +423,9 @@ module flash_ctrl_reg_top (
   logic default_region_scramble_en_qs;
   logic default_region_scramble_en_wd;
   logic default_region_scramble_en_we;
+  logic default_region_ecc_en_qs;
+  logic default_region_ecc_en_wd;
+  logic default_region_ecc_en_we;
   logic bank0_info0_regwen_0_qs;
   logic bank0_info0_regwen_0_wd;
   logic bank0_info0_regwen_0_we;
@@ -426,6 +453,9 @@ module flash_ctrl_reg_top (
   logic bank0_info0_page_cfg_0_scramble_en_0_qs;
   logic bank0_info0_page_cfg_0_scramble_en_0_wd;
   logic bank0_info0_page_cfg_0_scramble_en_0_we;
+  logic bank0_info0_page_cfg_0_ecc_en_0_qs;
+  logic bank0_info0_page_cfg_0_ecc_en_0_wd;
+  logic bank0_info0_page_cfg_0_ecc_en_0_we;
   logic bank0_info0_page_cfg_1_en_1_qs;
   logic bank0_info0_page_cfg_1_en_1_wd;
   logic bank0_info0_page_cfg_1_en_1_we;
@@ -441,6 +471,9 @@ module flash_ctrl_reg_top (
   logic bank0_info0_page_cfg_1_scramble_en_1_qs;
   logic bank0_info0_page_cfg_1_scramble_en_1_wd;
   logic bank0_info0_page_cfg_1_scramble_en_1_we;
+  logic bank0_info0_page_cfg_1_ecc_en_1_qs;
+  logic bank0_info0_page_cfg_1_ecc_en_1_wd;
+  logic bank0_info0_page_cfg_1_ecc_en_1_we;
   logic bank0_info0_page_cfg_2_en_2_qs;
   logic bank0_info0_page_cfg_2_en_2_wd;
   logic bank0_info0_page_cfg_2_en_2_we;
@@ -456,6 +489,9 @@ module flash_ctrl_reg_top (
   logic bank0_info0_page_cfg_2_scramble_en_2_qs;
   logic bank0_info0_page_cfg_2_scramble_en_2_wd;
   logic bank0_info0_page_cfg_2_scramble_en_2_we;
+  logic bank0_info0_page_cfg_2_ecc_en_2_qs;
+  logic bank0_info0_page_cfg_2_ecc_en_2_wd;
+  logic bank0_info0_page_cfg_2_ecc_en_2_we;
   logic bank0_info0_page_cfg_3_en_3_qs;
   logic bank0_info0_page_cfg_3_en_3_wd;
   logic bank0_info0_page_cfg_3_en_3_we;
@@ -471,6 +507,9 @@ module flash_ctrl_reg_top (
   logic bank0_info0_page_cfg_3_scramble_en_3_qs;
   logic bank0_info0_page_cfg_3_scramble_en_3_wd;
   logic bank0_info0_page_cfg_3_scramble_en_3_we;
+  logic bank0_info0_page_cfg_3_ecc_en_3_qs;
+  logic bank0_info0_page_cfg_3_ecc_en_3_wd;
+  logic bank0_info0_page_cfg_3_ecc_en_3_we;
   logic bank0_info1_regwen_0_qs;
   logic bank0_info1_regwen_0_wd;
   logic bank0_info1_regwen_0_we;
@@ -498,6 +537,9 @@ module flash_ctrl_reg_top (
   logic bank0_info1_page_cfg_0_scramble_en_0_qs;
   logic bank0_info1_page_cfg_0_scramble_en_0_wd;
   logic bank0_info1_page_cfg_0_scramble_en_0_we;
+  logic bank0_info1_page_cfg_0_ecc_en_0_qs;
+  logic bank0_info1_page_cfg_0_ecc_en_0_wd;
+  logic bank0_info1_page_cfg_0_ecc_en_0_we;
   logic bank0_info1_page_cfg_1_en_1_qs;
   logic bank0_info1_page_cfg_1_en_1_wd;
   logic bank0_info1_page_cfg_1_en_1_we;
@@ -513,6 +555,9 @@ module flash_ctrl_reg_top (
   logic bank0_info1_page_cfg_1_scramble_en_1_qs;
   logic bank0_info1_page_cfg_1_scramble_en_1_wd;
   logic bank0_info1_page_cfg_1_scramble_en_1_we;
+  logic bank0_info1_page_cfg_1_ecc_en_1_qs;
+  logic bank0_info1_page_cfg_1_ecc_en_1_wd;
+  logic bank0_info1_page_cfg_1_ecc_en_1_we;
   logic bank0_info1_page_cfg_2_en_2_qs;
   logic bank0_info1_page_cfg_2_en_2_wd;
   logic bank0_info1_page_cfg_2_en_2_we;
@@ -528,6 +573,9 @@ module flash_ctrl_reg_top (
   logic bank0_info1_page_cfg_2_scramble_en_2_qs;
   logic bank0_info1_page_cfg_2_scramble_en_2_wd;
   logic bank0_info1_page_cfg_2_scramble_en_2_we;
+  logic bank0_info1_page_cfg_2_ecc_en_2_qs;
+  logic bank0_info1_page_cfg_2_ecc_en_2_wd;
+  logic bank0_info1_page_cfg_2_ecc_en_2_we;
   logic bank0_info1_page_cfg_3_en_3_qs;
   logic bank0_info1_page_cfg_3_en_3_wd;
   logic bank0_info1_page_cfg_3_en_3_we;
@@ -543,6 +591,9 @@ module flash_ctrl_reg_top (
   logic bank0_info1_page_cfg_3_scramble_en_3_qs;
   logic bank0_info1_page_cfg_3_scramble_en_3_wd;
   logic bank0_info1_page_cfg_3_scramble_en_3_we;
+  logic bank0_info1_page_cfg_3_ecc_en_3_qs;
+  logic bank0_info1_page_cfg_3_ecc_en_3_wd;
+  logic bank0_info1_page_cfg_3_ecc_en_3_we;
   logic bank1_info0_regwen_0_qs;
   logic bank1_info0_regwen_0_wd;
   logic bank1_info0_regwen_0_we;
@@ -570,6 +621,9 @@ module flash_ctrl_reg_top (
   logic bank1_info0_page_cfg_0_scramble_en_0_qs;
   logic bank1_info0_page_cfg_0_scramble_en_0_wd;
   logic bank1_info0_page_cfg_0_scramble_en_0_we;
+  logic bank1_info0_page_cfg_0_ecc_en_0_qs;
+  logic bank1_info0_page_cfg_0_ecc_en_0_wd;
+  logic bank1_info0_page_cfg_0_ecc_en_0_we;
   logic bank1_info0_page_cfg_1_en_1_qs;
   logic bank1_info0_page_cfg_1_en_1_wd;
   logic bank1_info0_page_cfg_1_en_1_we;
@@ -585,6 +639,9 @@ module flash_ctrl_reg_top (
   logic bank1_info0_page_cfg_1_scramble_en_1_qs;
   logic bank1_info0_page_cfg_1_scramble_en_1_wd;
   logic bank1_info0_page_cfg_1_scramble_en_1_we;
+  logic bank1_info0_page_cfg_1_ecc_en_1_qs;
+  logic bank1_info0_page_cfg_1_ecc_en_1_wd;
+  logic bank1_info0_page_cfg_1_ecc_en_1_we;
   logic bank1_info0_page_cfg_2_en_2_qs;
   logic bank1_info0_page_cfg_2_en_2_wd;
   logic bank1_info0_page_cfg_2_en_2_we;
@@ -600,6 +657,9 @@ module flash_ctrl_reg_top (
   logic bank1_info0_page_cfg_2_scramble_en_2_qs;
   logic bank1_info0_page_cfg_2_scramble_en_2_wd;
   logic bank1_info0_page_cfg_2_scramble_en_2_we;
+  logic bank1_info0_page_cfg_2_ecc_en_2_qs;
+  logic bank1_info0_page_cfg_2_ecc_en_2_wd;
+  logic bank1_info0_page_cfg_2_ecc_en_2_we;
   logic bank1_info0_page_cfg_3_en_3_qs;
   logic bank1_info0_page_cfg_3_en_3_wd;
   logic bank1_info0_page_cfg_3_en_3_we;
@@ -615,6 +675,9 @@ module flash_ctrl_reg_top (
   logic bank1_info0_page_cfg_3_scramble_en_3_qs;
   logic bank1_info0_page_cfg_3_scramble_en_3_wd;
   logic bank1_info0_page_cfg_3_scramble_en_3_we;
+  logic bank1_info0_page_cfg_3_ecc_en_3_qs;
+  logic bank1_info0_page_cfg_3_ecc_en_3_wd;
+  logic bank1_info0_page_cfg_3_ecc_en_3_we;
   logic bank1_info1_regwen_0_qs;
   logic bank1_info1_regwen_0_wd;
   logic bank1_info1_regwen_0_we;
@@ -642,6 +705,9 @@ module flash_ctrl_reg_top (
   logic bank1_info1_page_cfg_0_scramble_en_0_qs;
   logic bank1_info1_page_cfg_0_scramble_en_0_wd;
   logic bank1_info1_page_cfg_0_scramble_en_0_we;
+  logic bank1_info1_page_cfg_0_ecc_en_0_qs;
+  logic bank1_info1_page_cfg_0_ecc_en_0_wd;
+  logic bank1_info1_page_cfg_0_ecc_en_0_we;
   logic bank1_info1_page_cfg_1_en_1_qs;
   logic bank1_info1_page_cfg_1_en_1_wd;
   logic bank1_info1_page_cfg_1_en_1_we;
@@ -657,6 +723,9 @@ module flash_ctrl_reg_top (
   logic bank1_info1_page_cfg_1_scramble_en_1_qs;
   logic bank1_info1_page_cfg_1_scramble_en_1_wd;
   logic bank1_info1_page_cfg_1_scramble_en_1_we;
+  logic bank1_info1_page_cfg_1_ecc_en_1_qs;
+  logic bank1_info1_page_cfg_1_ecc_en_1_wd;
+  logic bank1_info1_page_cfg_1_ecc_en_1_we;
   logic bank1_info1_page_cfg_2_en_2_qs;
   logic bank1_info1_page_cfg_2_en_2_wd;
   logic bank1_info1_page_cfg_2_en_2_we;
@@ -672,6 +741,9 @@ module flash_ctrl_reg_top (
   logic bank1_info1_page_cfg_2_scramble_en_2_qs;
   logic bank1_info1_page_cfg_2_scramble_en_2_wd;
   logic bank1_info1_page_cfg_2_scramble_en_2_we;
+  logic bank1_info1_page_cfg_2_ecc_en_2_qs;
+  logic bank1_info1_page_cfg_2_ecc_en_2_wd;
+  logic bank1_info1_page_cfg_2_ecc_en_2_we;
   logic bank1_info1_page_cfg_3_en_3_qs;
   logic bank1_info1_page_cfg_3_en_3_wd;
   logic bank1_info1_page_cfg_3_en_3_we;
@@ -687,6 +759,9 @@ module flash_ctrl_reg_top (
   logic bank1_info1_page_cfg_3_scramble_en_3_qs;
   logic bank1_info1_page_cfg_3_scramble_en_3_wd;
   logic bank1_info1_page_cfg_3_scramble_en_3_we;
+  logic bank1_info1_page_cfg_3_ecc_en_3_qs;
+  logic bank1_info1_page_cfg_3_ecc_en_3_wd;
+  logic bank1_info1_page_cfg_3_ecc_en_3_we;
   logic bank_cfg_regwen_qs;
   logic bank_cfg_regwen_wd;
   logic bank_cfg_regwen_we;
@@ -1712,6 +1787,32 @@ module flash_ctrl_reg_top (
   );
 
 
+  // F[ecc_en_0]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_mp_region_cfg_0_ecc_en_0 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (mp_region_cfg_0_ecc_en_0_we & region_cfg_regwen_0_qs),
+    .wd     (mp_region_cfg_0_ecc_en_0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.mp_region_cfg[0].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (mp_region_cfg_0_ecc_en_0_qs)
+  );
+
+
   // F[base_0]: 16:8
   prim_subreg #(
     .DW      (9),
@@ -1894,6 +1995,32 @@ module flash_ctrl_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_1_scramble_en_1_qs)
+  );
+
+
+  // F[ecc_en_1]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_mp_region_cfg_1_ecc_en_1 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (mp_region_cfg_1_ecc_en_1_we & region_cfg_regwen_1_qs),
+    .wd     (mp_region_cfg_1_ecc_en_1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.mp_region_cfg[1].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (mp_region_cfg_1_ecc_en_1_qs)
   );
 
 
@@ -2082,6 +2209,32 @@ module flash_ctrl_reg_top (
   );
 
 
+  // F[ecc_en_2]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_mp_region_cfg_2_ecc_en_2 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (mp_region_cfg_2_ecc_en_2_we & region_cfg_regwen_2_qs),
+    .wd     (mp_region_cfg_2_ecc_en_2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.mp_region_cfg[2].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (mp_region_cfg_2_ecc_en_2_qs)
+  );
+
+
   // F[base_2]: 16:8
   prim_subreg #(
     .DW      (9),
@@ -2264,6 +2417,32 @@ module flash_ctrl_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_3_scramble_en_3_qs)
+  );
+
+
+  // F[ecc_en_3]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_mp_region_cfg_3_ecc_en_3 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (mp_region_cfg_3_ecc_en_3_we & region_cfg_regwen_3_qs),
+    .wd     (mp_region_cfg_3_ecc_en_3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.mp_region_cfg[3].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (mp_region_cfg_3_ecc_en_3_qs)
   );
 
 
@@ -2452,6 +2631,32 @@ module flash_ctrl_reg_top (
   );
 
 
+  // F[ecc_en_4]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_mp_region_cfg_4_ecc_en_4 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (mp_region_cfg_4_ecc_en_4_we & region_cfg_regwen_4_qs),
+    .wd     (mp_region_cfg_4_ecc_en_4_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.mp_region_cfg[4].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (mp_region_cfg_4_ecc_en_4_qs)
+  );
+
+
   // F[base_4]: 16:8
   prim_subreg #(
     .DW      (9),
@@ -2634,6 +2839,32 @@ module flash_ctrl_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_5_scramble_en_5_qs)
+  );
+
+
+  // F[ecc_en_5]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_mp_region_cfg_5_ecc_en_5 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (mp_region_cfg_5_ecc_en_5_we & region_cfg_regwen_5_qs),
+    .wd     (mp_region_cfg_5_ecc_en_5_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.mp_region_cfg[5].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (mp_region_cfg_5_ecc_en_5_qs)
   );
 
 
@@ -2822,6 +3053,32 @@ module flash_ctrl_reg_top (
   );
 
 
+  // F[ecc_en_6]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_mp_region_cfg_6_ecc_en_6 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (mp_region_cfg_6_ecc_en_6_we & region_cfg_regwen_6_qs),
+    .wd     (mp_region_cfg_6_ecc_en_6_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.mp_region_cfg[6].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (mp_region_cfg_6_ecc_en_6_qs)
+  );
+
+
   // F[base_6]: 16:8
   prim_subreg #(
     .DW      (9),
@@ -3007,6 +3264,32 @@ module flash_ctrl_reg_top (
   );
 
 
+  // F[ecc_en_7]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_mp_region_cfg_7_ecc_en_7 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (mp_region_cfg_7_ecc_en_7_we & region_cfg_regwen_7_qs),
+    .wd     (mp_region_cfg_7_ecc_en_7_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.mp_region_cfg[7].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (mp_region_cfg_7_ecc_en_7_qs)
+  );
+
+
   // F[base_7]: 16:8
   prim_subreg #(
     .DW      (9),
@@ -3163,6 +3446,32 @@ module flash_ctrl_reg_top (
 
     // to register interface (read)
     .qs     (default_region_scramble_en_qs)
+  );
+
+
+  //   F[ecc_en]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_default_region_ecc_en (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (default_region_ecc_en_we),
+    .wd     (default_region_ecc_en_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.default_region.ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (default_region_ecc_en_qs)
   );
 
 
@@ -3410,6 +3719,32 @@ module flash_ctrl_reg_top (
   );
 
 
+  // F[ecc_en_0]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank0_info0_page_cfg_0_ecc_en_0 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank0_info0_page_cfg_0_ecc_en_0_we & bank0_info0_regwen_0_qs),
+    .wd     (bank0_info0_page_cfg_0_ecc_en_0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank0_info0_page_cfg[0].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (bank0_info0_page_cfg_0_ecc_en_0_qs)
+  );
+
+
   // Subregister 1 of Multireg bank0_info0_page_cfg
   // R[bank0_info0_page_cfg_1]: V(False)
 
@@ -3540,6 +3875,32 @@ module flash_ctrl_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_1_scramble_en_1_qs)
+  );
+
+
+  // F[ecc_en_1]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank0_info0_page_cfg_1_ecc_en_1 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank0_info0_page_cfg_1_ecc_en_1_we & bank0_info0_regwen_1_qs),
+    .wd     (bank0_info0_page_cfg_1_ecc_en_1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank0_info0_page_cfg[1].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (bank0_info0_page_cfg_1_ecc_en_1_qs)
   );
 
 
@@ -3676,6 +4037,32 @@ module flash_ctrl_reg_top (
   );
 
 
+  // F[ecc_en_2]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank0_info0_page_cfg_2_ecc_en_2 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank0_info0_page_cfg_2_ecc_en_2_we & bank0_info0_regwen_2_qs),
+    .wd     (bank0_info0_page_cfg_2_ecc_en_2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank0_info0_page_cfg[2].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (bank0_info0_page_cfg_2_ecc_en_2_qs)
+  );
+
+
   // Subregister 3 of Multireg bank0_info0_page_cfg
   // R[bank0_info0_page_cfg_3]: V(False)
 
@@ -3806,6 +4193,32 @@ module flash_ctrl_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_3_scramble_en_3_qs)
+  );
+
+
+  // F[ecc_en_3]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank0_info0_page_cfg_3_ecc_en_3 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank0_info0_page_cfg_3_ecc_en_3_we & bank0_info0_regwen_3_qs),
+    .wd     (bank0_info0_page_cfg_3_ecc_en_3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank0_info0_page_cfg[3].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (bank0_info0_page_cfg_3_ecc_en_3_qs)
   );
 
 
@@ -4054,6 +4467,32 @@ module flash_ctrl_reg_top (
   );
 
 
+  // F[ecc_en_0]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank0_info1_page_cfg_0_ecc_en_0 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank0_info1_page_cfg_0_ecc_en_0_we & bank0_info1_regwen_0_qs),
+    .wd     (bank0_info1_page_cfg_0_ecc_en_0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank0_info1_page_cfg[0].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (bank0_info1_page_cfg_0_ecc_en_0_qs)
+  );
+
+
   // Subregister 1 of Multireg bank0_info1_page_cfg
   // R[bank0_info1_page_cfg_1]: V(False)
 
@@ -4184,6 +4623,32 @@ module flash_ctrl_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info1_page_cfg_1_scramble_en_1_qs)
+  );
+
+
+  // F[ecc_en_1]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank0_info1_page_cfg_1_ecc_en_1 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank0_info1_page_cfg_1_ecc_en_1_we & bank0_info1_regwen_1_qs),
+    .wd     (bank0_info1_page_cfg_1_ecc_en_1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank0_info1_page_cfg[1].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (bank0_info1_page_cfg_1_ecc_en_1_qs)
   );
 
 
@@ -4320,6 +4785,32 @@ module flash_ctrl_reg_top (
   );
 
 
+  // F[ecc_en_2]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank0_info1_page_cfg_2_ecc_en_2 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank0_info1_page_cfg_2_ecc_en_2_we & bank0_info1_regwen_2_qs),
+    .wd     (bank0_info1_page_cfg_2_ecc_en_2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank0_info1_page_cfg[2].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (bank0_info1_page_cfg_2_ecc_en_2_qs)
+  );
+
+
   // Subregister 3 of Multireg bank0_info1_page_cfg
   // R[bank0_info1_page_cfg_3]: V(False)
 
@@ -4450,6 +4941,32 @@ module flash_ctrl_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info1_page_cfg_3_scramble_en_3_qs)
+  );
+
+
+  // F[ecc_en_3]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank0_info1_page_cfg_3_ecc_en_3 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank0_info1_page_cfg_3_ecc_en_3_we & bank0_info1_regwen_3_qs),
+    .wd     (bank0_info1_page_cfg_3_ecc_en_3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank0_info1_page_cfg[3].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (bank0_info1_page_cfg_3_ecc_en_3_qs)
   );
 
 
@@ -4698,6 +5215,32 @@ module flash_ctrl_reg_top (
   );
 
 
+  // F[ecc_en_0]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank1_info0_page_cfg_0_ecc_en_0 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank1_info0_page_cfg_0_ecc_en_0_we & bank1_info0_regwen_0_qs),
+    .wd     (bank1_info0_page_cfg_0_ecc_en_0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank1_info0_page_cfg[0].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (bank1_info0_page_cfg_0_ecc_en_0_qs)
+  );
+
+
   // Subregister 1 of Multireg bank1_info0_page_cfg
   // R[bank1_info0_page_cfg_1]: V(False)
 
@@ -4828,6 +5371,32 @@ module flash_ctrl_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_1_scramble_en_1_qs)
+  );
+
+
+  // F[ecc_en_1]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank1_info0_page_cfg_1_ecc_en_1 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank1_info0_page_cfg_1_ecc_en_1_we & bank1_info0_regwen_1_qs),
+    .wd     (bank1_info0_page_cfg_1_ecc_en_1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank1_info0_page_cfg[1].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (bank1_info0_page_cfg_1_ecc_en_1_qs)
   );
 
 
@@ -4964,6 +5533,32 @@ module flash_ctrl_reg_top (
   );
 
 
+  // F[ecc_en_2]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank1_info0_page_cfg_2_ecc_en_2 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank1_info0_page_cfg_2_ecc_en_2_we & bank1_info0_regwen_2_qs),
+    .wd     (bank1_info0_page_cfg_2_ecc_en_2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank1_info0_page_cfg[2].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (bank1_info0_page_cfg_2_ecc_en_2_qs)
+  );
+
+
   // Subregister 3 of Multireg bank1_info0_page_cfg
   // R[bank1_info0_page_cfg_3]: V(False)
 
@@ -5094,6 +5689,32 @@ module flash_ctrl_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_3_scramble_en_3_qs)
+  );
+
+
+  // F[ecc_en_3]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank1_info0_page_cfg_3_ecc_en_3 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank1_info0_page_cfg_3_ecc_en_3_we & bank1_info0_regwen_3_qs),
+    .wd     (bank1_info0_page_cfg_3_ecc_en_3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank1_info0_page_cfg[3].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (bank1_info0_page_cfg_3_ecc_en_3_qs)
   );
 
 
@@ -5342,6 +5963,32 @@ module flash_ctrl_reg_top (
   );
 
 
+  // F[ecc_en_0]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank1_info1_page_cfg_0_ecc_en_0 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank1_info1_page_cfg_0_ecc_en_0_we & bank1_info1_regwen_0_qs),
+    .wd     (bank1_info1_page_cfg_0_ecc_en_0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank1_info1_page_cfg[0].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (bank1_info1_page_cfg_0_ecc_en_0_qs)
+  );
+
+
   // Subregister 1 of Multireg bank1_info1_page_cfg
   // R[bank1_info1_page_cfg_1]: V(False)
 
@@ -5472,6 +6119,32 @@ module flash_ctrl_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info1_page_cfg_1_scramble_en_1_qs)
+  );
+
+
+  // F[ecc_en_1]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank1_info1_page_cfg_1_ecc_en_1 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank1_info1_page_cfg_1_ecc_en_1_we & bank1_info1_regwen_1_qs),
+    .wd     (bank1_info1_page_cfg_1_ecc_en_1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank1_info1_page_cfg[1].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (bank1_info1_page_cfg_1_ecc_en_1_qs)
   );
 
 
@@ -5608,6 +6281,32 @@ module flash_ctrl_reg_top (
   );
 
 
+  // F[ecc_en_2]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank1_info1_page_cfg_2_ecc_en_2 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank1_info1_page_cfg_2_ecc_en_2_we & bank1_info1_regwen_2_qs),
+    .wd     (bank1_info1_page_cfg_2_ecc_en_2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank1_info1_page_cfg[2].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (bank1_info1_page_cfg_2_ecc_en_2_qs)
+  );
+
+
   // Subregister 3 of Multireg bank1_info1_page_cfg
   // R[bank1_info1_page_cfg_3]: V(False)
 
@@ -5738,6 +6437,32 @@ module flash_ctrl_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info1_page_cfg_3_scramble_en_3_qs)
+  );
+
+
+  // F[ecc_en_3]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank1_info1_page_cfg_3_ecc_en_3 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank1_info1_page_cfg_3_ecc_en_3_we & bank1_info1_regwen_3_qs),
+    .wd     (bank1_info1_page_cfg_3_ecc_en_3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank1_info1_page_cfg[3].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (bank1_info1_page_cfg_3_ecc_en_3_qs)
   );
 
 
@@ -6476,6 +7201,9 @@ module flash_ctrl_reg_top (
   assign mp_region_cfg_0_scramble_en_0_we = addr_hit[14] & reg_we & ~wr_err;
   assign mp_region_cfg_0_scramble_en_0_wd = reg_wdata[4];
 
+  assign mp_region_cfg_0_ecc_en_0_we = addr_hit[14] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_ecc_en_0_wd = reg_wdata[5];
+
   assign mp_region_cfg_0_base_0_we = addr_hit[14] & reg_we & ~wr_err;
   assign mp_region_cfg_0_base_0_wd = reg_wdata[16:8];
 
@@ -6496,6 +7224,9 @@ module flash_ctrl_reg_top (
 
   assign mp_region_cfg_1_scramble_en_1_we = addr_hit[15] & reg_we & ~wr_err;
   assign mp_region_cfg_1_scramble_en_1_wd = reg_wdata[4];
+
+  assign mp_region_cfg_1_ecc_en_1_we = addr_hit[15] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_ecc_en_1_wd = reg_wdata[5];
 
   assign mp_region_cfg_1_base_1_we = addr_hit[15] & reg_we & ~wr_err;
   assign mp_region_cfg_1_base_1_wd = reg_wdata[16:8];
@@ -6518,6 +7249,9 @@ module flash_ctrl_reg_top (
   assign mp_region_cfg_2_scramble_en_2_we = addr_hit[16] & reg_we & ~wr_err;
   assign mp_region_cfg_2_scramble_en_2_wd = reg_wdata[4];
 
+  assign mp_region_cfg_2_ecc_en_2_we = addr_hit[16] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_ecc_en_2_wd = reg_wdata[5];
+
   assign mp_region_cfg_2_base_2_we = addr_hit[16] & reg_we & ~wr_err;
   assign mp_region_cfg_2_base_2_wd = reg_wdata[16:8];
 
@@ -6538,6 +7272,9 @@ module flash_ctrl_reg_top (
 
   assign mp_region_cfg_3_scramble_en_3_we = addr_hit[17] & reg_we & ~wr_err;
   assign mp_region_cfg_3_scramble_en_3_wd = reg_wdata[4];
+
+  assign mp_region_cfg_3_ecc_en_3_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_ecc_en_3_wd = reg_wdata[5];
 
   assign mp_region_cfg_3_base_3_we = addr_hit[17] & reg_we & ~wr_err;
   assign mp_region_cfg_3_base_3_wd = reg_wdata[16:8];
@@ -6560,6 +7297,9 @@ module flash_ctrl_reg_top (
   assign mp_region_cfg_4_scramble_en_4_we = addr_hit[18] & reg_we & ~wr_err;
   assign mp_region_cfg_4_scramble_en_4_wd = reg_wdata[4];
 
+  assign mp_region_cfg_4_ecc_en_4_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_ecc_en_4_wd = reg_wdata[5];
+
   assign mp_region_cfg_4_base_4_we = addr_hit[18] & reg_we & ~wr_err;
   assign mp_region_cfg_4_base_4_wd = reg_wdata[16:8];
 
@@ -6580,6 +7320,9 @@ module flash_ctrl_reg_top (
 
   assign mp_region_cfg_5_scramble_en_5_we = addr_hit[19] & reg_we & ~wr_err;
   assign mp_region_cfg_5_scramble_en_5_wd = reg_wdata[4];
+
+  assign mp_region_cfg_5_ecc_en_5_we = addr_hit[19] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_ecc_en_5_wd = reg_wdata[5];
 
   assign mp_region_cfg_5_base_5_we = addr_hit[19] & reg_we & ~wr_err;
   assign mp_region_cfg_5_base_5_wd = reg_wdata[16:8];
@@ -6602,6 +7345,9 @@ module flash_ctrl_reg_top (
   assign mp_region_cfg_6_scramble_en_6_we = addr_hit[20] & reg_we & ~wr_err;
   assign mp_region_cfg_6_scramble_en_6_wd = reg_wdata[4];
 
+  assign mp_region_cfg_6_ecc_en_6_we = addr_hit[20] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_ecc_en_6_wd = reg_wdata[5];
+
   assign mp_region_cfg_6_base_6_we = addr_hit[20] & reg_we & ~wr_err;
   assign mp_region_cfg_6_base_6_wd = reg_wdata[16:8];
 
@@ -6623,6 +7369,9 @@ module flash_ctrl_reg_top (
   assign mp_region_cfg_7_scramble_en_7_we = addr_hit[21] & reg_we & ~wr_err;
   assign mp_region_cfg_7_scramble_en_7_wd = reg_wdata[4];
 
+  assign mp_region_cfg_7_ecc_en_7_we = addr_hit[21] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_ecc_en_7_wd = reg_wdata[5];
+
   assign mp_region_cfg_7_base_7_we = addr_hit[21] & reg_we & ~wr_err;
   assign mp_region_cfg_7_base_7_wd = reg_wdata[16:8];
 
@@ -6640,6 +7389,9 @@ module flash_ctrl_reg_top (
 
   assign default_region_scramble_en_we = addr_hit[22] & reg_we & ~wr_err;
   assign default_region_scramble_en_wd = reg_wdata[3];
+
+  assign default_region_ecc_en_we = addr_hit[22] & reg_we & ~wr_err;
+  assign default_region_ecc_en_wd = reg_wdata[4];
 
   assign bank0_info0_regwen_0_we = addr_hit[23] & reg_we & ~wr_err;
   assign bank0_info0_regwen_0_wd = reg_wdata[0];
@@ -6668,6 +7420,9 @@ module flash_ctrl_reg_top (
   assign bank0_info0_page_cfg_0_scramble_en_0_we = addr_hit[27] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
 
+  assign bank0_info0_page_cfg_0_ecc_en_0_we = addr_hit[27] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_0_ecc_en_0_wd = reg_wdata[5];
+
   assign bank0_info0_page_cfg_1_en_1_we = addr_hit[28] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_1_en_1_wd = reg_wdata[0];
 
@@ -6682,6 +7437,9 @@ module flash_ctrl_reg_top (
 
   assign bank0_info0_page_cfg_1_scramble_en_1_we = addr_hit[28] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
+
+  assign bank0_info0_page_cfg_1_ecc_en_1_we = addr_hit[28] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_1_ecc_en_1_wd = reg_wdata[5];
 
   assign bank0_info0_page_cfg_2_en_2_we = addr_hit[29] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_2_en_2_wd = reg_wdata[0];
@@ -6698,6 +7456,9 @@ module flash_ctrl_reg_top (
   assign bank0_info0_page_cfg_2_scramble_en_2_we = addr_hit[29] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_2_scramble_en_2_wd = reg_wdata[4];
 
+  assign bank0_info0_page_cfg_2_ecc_en_2_we = addr_hit[29] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_2_ecc_en_2_wd = reg_wdata[5];
+
   assign bank0_info0_page_cfg_3_en_3_we = addr_hit[30] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_3_en_3_wd = reg_wdata[0];
 
@@ -6712,6 +7473,9 @@ module flash_ctrl_reg_top (
 
   assign bank0_info0_page_cfg_3_scramble_en_3_we = addr_hit[30] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_3_scramble_en_3_wd = reg_wdata[4];
+
+  assign bank0_info0_page_cfg_3_ecc_en_3_we = addr_hit[30] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_3_ecc_en_3_wd = reg_wdata[5];
 
   assign bank0_info1_regwen_0_we = addr_hit[31] & reg_we & ~wr_err;
   assign bank0_info1_regwen_0_wd = reg_wdata[0];
@@ -6740,6 +7504,9 @@ module flash_ctrl_reg_top (
   assign bank0_info1_page_cfg_0_scramble_en_0_we = addr_hit[35] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
 
+  assign bank0_info1_page_cfg_0_ecc_en_0_we = addr_hit[35] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_0_ecc_en_0_wd = reg_wdata[5];
+
   assign bank0_info1_page_cfg_1_en_1_we = addr_hit[36] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_1_en_1_wd = reg_wdata[0];
 
@@ -6754,6 +7521,9 @@ module flash_ctrl_reg_top (
 
   assign bank0_info1_page_cfg_1_scramble_en_1_we = addr_hit[36] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
+
+  assign bank0_info1_page_cfg_1_ecc_en_1_we = addr_hit[36] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_1_ecc_en_1_wd = reg_wdata[5];
 
   assign bank0_info1_page_cfg_2_en_2_we = addr_hit[37] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_2_en_2_wd = reg_wdata[0];
@@ -6770,6 +7540,9 @@ module flash_ctrl_reg_top (
   assign bank0_info1_page_cfg_2_scramble_en_2_we = addr_hit[37] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_2_scramble_en_2_wd = reg_wdata[4];
 
+  assign bank0_info1_page_cfg_2_ecc_en_2_we = addr_hit[37] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_2_ecc_en_2_wd = reg_wdata[5];
+
   assign bank0_info1_page_cfg_3_en_3_we = addr_hit[38] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_3_en_3_wd = reg_wdata[0];
 
@@ -6784,6 +7557,9 @@ module flash_ctrl_reg_top (
 
   assign bank0_info1_page_cfg_3_scramble_en_3_we = addr_hit[38] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_3_scramble_en_3_wd = reg_wdata[4];
+
+  assign bank0_info1_page_cfg_3_ecc_en_3_we = addr_hit[38] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_3_ecc_en_3_wd = reg_wdata[5];
 
   assign bank1_info0_regwen_0_we = addr_hit[39] & reg_we & ~wr_err;
   assign bank1_info0_regwen_0_wd = reg_wdata[0];
@@ -6812,6 +7588,9 @@ module flash_ctrl_reg_top (
   assign bank1_info0_page_cfg_0_scramble_en_0_we = addr_hit[43] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
 
+  assign bank1_info0_page_cfg_0_ecc_en_0_we = addr_hit[43] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_0_ecc_en_0_wd = reg_wdata[5];
+
   assign bank1_info0_page_cfg_1_en_1_we = addr_hit[44] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_1_en_1_wd = reg_wdata[0];
 
@@ -6826,6 +7605,9 @@ module flash_ctrl_reg_top (
 
   assign bank1_info0_page_cfg_1_scramble_en_1_we = addr_hit[44] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
+
+  assign bank1_info0_page_cfg_1_ecc_en_1_we = addr_hit[44] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_1_ecc_en_1_wd = reg_wdata[5];
 
   assign bank1_info0_page_cfg_2_en_2_we = addr_hit[45] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_2_en_2_wd = reg_wdata[0];
@@ -6842,6 +7624,9 @@ module flash_ctrl_reg_top (
   assign bank1_info0_page_cfg_2_scramble_en_2_we = addr_hit[45] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_2_scramble_en_2_wd = reg_wdata[4];
 
+  assign bank1_info0_page_cfg_2_ecc_en_2_we = addr_hit[45] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_2_ecc_en_2_wd = reg_wdata[5];
+
   assign bank1_info0_page_cfg_3_en_3_we = addr_hit[46] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_3_en_3_wd = reg_wdata[0];
 
@@ -6856,6 +7641,9 @@ module flash_ctrl_reg_top (
 
   assign bank1_info0_page_cfg_3_scramble_en_3_we = addr_hit[46] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_3_scramble_en_3_wd = reg_wdata[4];
+
+  assign bank1_info0_page_cfg_3_ecc_en_3_we = addr_hit[46] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_3_ecc_en_3_wd = reg_wdata[5];
 
   assign bank1_info1_regwen_0_we = addr_hit[47] & reg_we & ~wr_err;
   assign bank1_info1_regwen_0_wd = reg_wdata[0];
@@ -6884,6 +7672,9 @@ module flash_ctrl_reg_top (
   assign bank1_info1_page_cfg_0_scramble_en_0_we = addr_hit[51] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
 
+  assign bank1_info1_page_cfg_0_ecc_en_0_we = addr_hit[51] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_0_ecc_en_0_wd = reg_wdata[5];
+
   assign bank1_info1_page_cfg_1_en_1_we = addr_hit[52] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_1_en_1_wd = reg_wdata[0];
 
@@ -6898,6 +7689,9 @@ module flash_ctrl_reg_top (
 
   assign bank1_info1_page_cfg_1_scramble_en_1_we = addr_hit[52] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
+
+  assign bank1_info1_page_cfg_1_ecc_en_1_we = addr_hit[52] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_1_ecc_en_1_wd = reg_wdata[5];
 
   assign bank1_info1_page_cfg_2_en_2_we = addr_hit[53] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_2_en_2_wd = reg_wdata[0];
@@ -6914,6 +7708,9 @@ module flash_ctrl_reg_top (
   assign bank1_info1_page_cfg_2_scramble_en_2_we = addr_hit[53] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_2_scramble_en_2_wd = reg_wdata[4];
 
+  assign bank1_info1_page_cfg_2_ecc_en_2_we = addr_hit[53] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_2_ecc_en_2_wd = reg_wdata[5];
+
   assign bank1_info1_page_cfg_3_en_3_we = addr_hit[54] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_3_en_3_wd = reg_wdata[0];
 
@@ -6928,6 +7725,9 @@ module flash_ctrl_reg_top (
 
   assign bank1_info1_page_cfg_3_scramble_en_3_we = addr_hit[54] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_3_scramble_en_3_wd = reg_wdata[4];
+
+  assign bank1_info1_page_cfg_3_ecc_en_3_we = addr_hit[54] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_3_ecc_en_3_wd = reg_wdata[5];
 
   assign bank_cfg_regwen_we = addr_hit[55] & reg_we & ~wr_err;
   assign bank_cfg_regwen_wd = reg_wdata[0];
@@ -7052,6 +7852,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = mp_region_cfg_0_prog_en_0_qs;
         reg_rdata_next[3] = mp_region_cfg_0_erase_en_0_qs;
         reg_rdata_next[4] = mp_region_cfg_0_scramble_en_0_qs;
+        reg_rdata_next[5] = mp_region_cfg_0_ecc_en_0_qs;
         reg_rdata_next[16:8] = mp_region_cfg_0_base_0_qs;
         reg_rdata_next[29:20] = mp_region_cfg_0_size_0_qs;
       end
@@ -7062,6 +7863,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = mp_region_cfg_1_prog_en_1_qs;
         reg_rdata_next[3] = mp_region_cfg_1_erase_en_1_qs;
         reg_rdata_next[4] = mp_region_cfg_1_scramble_en_1_qs;
+        reg_rdata_next[5] = mp_region_cfg_1_ecc_en_1_qs;
         reg_rdata_next[16:8] = mp_region_cfg_1_base_1_qs;
         reg_rdata_next[29:20] = mp_region_cfg_1_size_1_qs;
       end
@@ -7072,6 +7874,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = mp_region_cfg_2_prog_en_2_qs;
         reg_rdata_next[3] = mp_region_cfg_2_erase_en_2_qs;
         reg_rdata_next[4] = mp_region_cfg_2_scramble_en_2_qs;
+        reg_rdata_next[5] = mp_region_cfg_2_ecc_en_2_qs;
         reg_rdata_next[16:8] = mp_region_cfg_2_base_2_qs;
         reg_rdata_next[29:20] = mp_region_cfg_2_size_2_qs;
       end
@@ -7082,6 +7885,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = mp_region_cfg_3_prog_en_3_qs;
         reg_rdata_next[3] = mp_region_cfg_3_erase_en_3_qs;
         reg_rdata_next[4] = mp_region_cfg_3_scramble_en_3_qs;
+        reg_rdata_next[5] = mp_region_cfg_3_ecc_en_3_qs;
         reg_rdata_next[16:8] = mp_region_cfg_3_base_3_qs;
         reg_rdata_next[29:20] = mp_region_cfg_3_size_3_qs;
       end
@@ -7092,6 +7896,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = mp_region_cfg_4_prog_en_4_qs;
         reg_rdata_next[3] = mp_region_cfg_4_erase_en_4_qs;
         reg_rdata_next[4] = mp_region_cfg_4_scramble_en_4_qs;
+        reg_rdata_next[5] = mp_region_cfg_4_ecc_en_4_qs;
         reg_rdata_next[16:8] = mp_region_cfg_4_base_4_qs;
         reg_rdata_next[29:20] = mp_region_cfg_4_size_4_qs;
       end
@@ -7102,6 +7907,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = mp_region_cfg_5_prog_en_5_qs;
         reg_rdata_next[3] = mp_region_cfg_5_erase_en_5_qs;
         reg_rdata_next[4] = mp_region_cfg_5_scramble_en_5_qs;
+        reg_rdata_next[5] = mp_region_cfg_5_ecc_en_5_qs;
         reg_rdata_next[16:8] = mp_region_cfg_5_base_5_qs;
         reg_rdata_next[29:20] = mp_region_cfg_5_size_5_qs;
       end
@@ -7112,6 +7918,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = mp_region_cfg_6_prog_en_6_qs;
         reg_rdata_next[3] = mp_region_cfg_6_erase_en_6_qs;
         reg_rdata_next[4] = mp_region_cfg_6_scramble_en_6_qs;
+        reg_rdata_next[5] = mp_region_cfg_6_ecc_en_6_qs;
         reg_rdata_next[16:8] = mp_region_cfg_6_base_6_qs;
         reg_rdata_next[29:20] = mp_region_cfg_6_size_6_qs;
       end
@@ -7122,6 +7929,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = mp_region_cfg_7_prog_en_7_qs;
         reg_rdata_next[3] = mp_region_cfg_7_erase_en_7_qs;
         reg_rdata_next[4] = mp_region_cfg_7_scramble_en_7_qs;
+        reg_rdata_next[5] = mp_region_cfg_7_ecc_en_7_qs;
         reg_rdata_next[16:8] = mp_region_cfg_7_base_7_qs;
         reg_rdata_next[29:20] = mp_region_cfg_7_size_7_qs;
       end
@@ -7131,6 +7939,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[1] = default_region_prog_en_qs;
         reg_rdata_next[2] = default_region_erase_en_qs;
         reg_rdata_next[3] = default_region_scramble_en_qs;
+        reg_rdata_next[4] = default_region_ecc_en_qs;
       end
 
       addr_hit[23]: begin
@@ -7155,6 +7964,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = bank0_info0_page_cfg_0_prog_en_0_qs;
         reg_rdata_next[3] = bank0_info0_page_cfg_0_erase_en_0_qs;
         reg_rdata_next[4] = bank0_info0_page_cfg_0_scramble_en_0_qs;
+        reg_rdata_next[5] = bank0_info0_page_cfg_0_ecc_en_0_qs;
       end
 
       addr_hit[28]: begin
@@ -7163,6 +7973,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = bank0_info0_page_cfg_1_prog_en_1_qs;
         reg_rdata_next[3] = bank0_info0_page_cfg_1_erase_en_1_qs;
         reg_rdata_next[4] = bank0_info0_page_cfg_1_scramble_en_1_qs;
+        reg_rdata_next[5] = bank0_info0_page_cfg_1_ecc_en_1_qs;
       end
 
       addr_hit[29]: begin
@@ -7171,6 +7982,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = bank0_info0_page_cfg_2_prog_en_2_qs;
         reg_rdata_next[3] = bank0_info0_page_cfg_2_erase_en_2_qs;
         reg_rdata_next[4] = bank0_info0_page_cfg_2_scramble_en_2_qs;
+        reg_rdata_next[5] = bank0_info0_page_cfg_2_ecc_en_2_qs;
       end
 
       addr_hit[30]: begin
@@ -7179,6 +7991,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = bank0_info0_page_cfg_3_prog_en_3_qs;
         reg_rdata_next[3] = bank0_info0_page_cfg_3_erase_en_3_qs;
         reg_rdata_next[4] = bank0_info0_page_cfg_3_scramble_en_3_qs;
+        reg_rdata_next[5] = bank0_info0_page_cfg_3_ecc_en_3_qs;
       end
 
       addr_hit[31]: begin
@@ -7203,6 +8016,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = bank0_info1_page_cfg_0_prog_en_0_qs;
         reg_rdata_next[3] = bank0_info1_page_cfg_0_erase_en_0_qs;
         reg_rdata_next[4] = bank0_info1_page_cfg_0_scramble_en_0_qs;
+        reg_rdata_next[5] = bank0_info1_page_cfg_0_ecc_en_0_qs;
       end
 
       addr_hit[36]: begin
@@ -7211,6 +8025,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = bank0_info1_page_cfg_1_prog_en_1_qs;
         reg_rdata_next[3] = bank0_info1_page_cfg_1_erase_en_1_qs;
         reg_rdata_next[4] = bank0_info1_page_cfg_1_scramble_en_1_qs;
+        reg_rdata_next[5] = bank0_info1_page_cfg_1_ecc_en_1_qs;
       end
 
       addr_hit[37]: begin
@@ -7219,6 +8034,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = bank0_info1_page_cfg_2_prog_en_2_qs;
         reg_rdata_next[3] = bank0_info1_page_cfg_2_erase_en_2_qs;
         reg_rdata_next[4] = bank0_info1_page_cfg_2_scramble_en_2_qs;
+        reg_rdata_next[5] = bank0_info1_page_cfg_2_ecc_en_2_qs;
       end
 
       addr_hit[38]: begin
@@ -7227,6 +8043,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = bank0_info1_page_cfg_3_prog_en_3_qs;
         reg_rdata_next[3] = bank0_info1_page_cfg_3_erase_en_3_qs;
         reg_rdata_next[4] = bank0_info1_page_cfg_3_scramble_en_3_qs;
+        reg_rdata_next[5] = bank0_info1_page_cfg_3_ecc_en_3_qs;
       end
 
       addr_hit[39]: begin
@@ -7251,6 +8068,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = bank1_info0_page_cfg_0_prog_en_0_qs;
         reg_rdata_next[3] = bank1_info0_page_cfg_0_erase_en_0_qs;
         reg_rdata_next[4] = bank1_info0_page_cfg_0_scramble_en_0_qs;
+        reg_rdata_next[5] = bank1_info0_page_cfg_0_ecc_en_0_qs;
       end
 
       addr_hit[44]: begin
@@ -7259,6 +8077,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = bank1_info0_page_cfg_1_prog_en_1_qs;
         reg_rdata_next[3] = bank1_info0_page_cfg_1_erase_en_1_qs;
         reg_rdata_next[4] = bank1_info0_page_cfg_1_scramble_en_1_qs;
+        reg_rdata_next[5] = bank1_info0_page_cfg_1_ecc_en_1_qs;
       end
 
       addr_hit[45]: begin
@@ -7267,6 +8086,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = bank1_info0_page_cfg_2_prog_en_2_qs;
         reg_rdata_next[3] = bank1_info0_page_cfg_2_erase_en_2_qs;
         reg_rdata_next[4] = bank1_info0_page_cfg_2_scramble_en_2_qs;
+        reg_rdata_next[5] = bank1_info0_page_cfg_2_ecc_en_2_qs;
       end
 
       addr_hit[46]: begin
@@ -7275,6 +8095,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = bank1_info0_page_cfg_3_prog_en_3_qs;
         reg_rdata_next[3] = bank1_info0_page_cfg_3_erase_en_3_qs;
         reg_rdata_next[4] = bank1_info0_page_cfg_3_scramble_en_3_qs;
+        reg_rdata_next[5] = bank1_info0_page_cfg_3_ecc_en_3_qs;
       end
 
       addr_hit[47]: begin
@@ -7299,6 +8120,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = bank1_info1_page_cfg_0_prog_en_0_qs;
         reg_rdata_next[3] = bank1_info1_page_cfg_0_erase_en_0_qs;
         reg_rdata_next[4] = bank1_info1_page_cfg_0_scramble_en_0_qs;
+        reg_rdata_next[5] = bank1_info1_page_cfg_0_ecc_en_0_qs;
       end
 
       addr_hit[52]: begin
@@ -7307,6 +8129,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = bank1_info1_page_cfg_1_prog_en_1_qs;
         reg_rdata_next[3] = bank1_info1_page_cfg_1_erase_en_1_qs;
         reg_rdata_next[4] = bank1_info1_page_cfg_1_scramble_en_1_qs;
+        reg_rdata_next[5] = bank1_info1_page_cfg_1_ecc_en_1_qs;
       end
 
       addr_hit[53]: begin
@@ -7315,6 +8138,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = bank1_info1_page_cfg_2_prog_en_2_qs;
         reg_rdata_next[3] = bank1_info1_page_cfg_2_erase_en_2_qs;
         reg_rdata_next[4] = bank1_info1_page_cfg_2_scramble_en_2_qs;
+        reg_rdata_next[5] = bank1_info1_page_cfg_2_ecc_en_2_qs;
       end
 
       addr_hit[54]: begin
@@ -7323,6 +8147,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = bank1_info1_page_cfg_3_prog_en_3_qs;
         reg_rdata_next[3] = bank1_info1_page_cfg_3_erase_en_3_qs;
         reg_rdata_next[4] = bank1_info1_page_cfg_3_scramble_en_3_qs;
+        reg_rdata_next[5] = bank1_info1_page_cfg_3_ecc_en_3_qs;
       end
 
       addr_hit[55]: begin

--- a/hw/ip/flash_ctrl/rtl/flash_mp.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_mp.sv
@@ -41,6 +41,7 @@ module flash_mp import flash_ctrl_pkg::*; import flash_ctrl_reg_pkg::*; (
   output logic rd_o,
   output logic prog_o,
   output logic scramble_en_o,
+  output logic ecc_en_o,
   output logic pg_erase_o,
   output logic bk_erase_o,
   input rd_done_i,
@@ -71,10 +72,12 @@ module flash_mp import flash_ctrl_pkg::*; import flash_ctrl_reg_pkg::*; (
   logic data_pg_erase_en;
   logic data_bk_erase_en;
   logic data_scramble_en;
+  logic data_ecc_en;
   logic info_rd_en;
   logic info_prog_en;
   logic info_erase_en;
   logic info_scramble_en;
+  logic info_ecc_en;
 
   // Memory protection handling for hardware interface
   logic hw_sel;
@@ -175,6 +178,7 @@ module flash_mp import flash_ctrl_pkg::*; import flash_ctrl_reg_pkg::*; (
   assign data_pg_erase_en = data_en & pg_erase_i      & data_region_cfg.erase_en.q;
   assign data_bk_erase_en = data_en & bk_erase_i      & |bk_erase_en;
   assign data_scramble_en = data_en & (rd_i | prog_i) & data_region_cfg.scramble_en.q;
+  assign data_ecc_en      = data_en & (rd_i | prog_i) & data_region_cfg.ecc_en.q;
 
 
   assign invalid_data_txn = req_i & data_part_sel &
@@ -227,6 +231,7 @@ module flash_mp import flash_ctrl_pkg::*; import flash_ctrl_reg_pkg::*; (
   assign info_prog_en     = info_en & prog_i          & page_cfg.prog_en.q;
   assign info_erase_en    = info_en & pg_erase_i      & page_cfg.erase_en.q;
   assign info_scramble_en = info_en & (rd_i | prog_i) & page_cfg.scramble_en.q;
+  assign info_ecc_en      = info_en & (rd_i | prog_i) & page_cfg.ecc_en.q;
 
   // check for invalid transactions
   assign invalid_info_txn = req_i & info_part_sel &
@@ -241,6 +246,7 @@ module flash_mp import flash_ctrl_pkg::*; import flash_ctrl_reg_pkg::*; (
   assign pg_erase_o    = req_i & (data_pg_erase_en | info_erase_en);
   assign bk_erase_o    = req_i & data_bk_erase_en;
   assign scramble_en_o = req_i & (data_scramble_en | info_scramble_en);
+  assign ecc_en_o      = req_i & (data_ecc_en | info_ecc_en);
   assign req_o         = rd_o | prog_o | pg_erase_o | bk_erase_o;
 
   logic txn_err;

--- a/hw/ip/flash_ctrl/rtl/flash_phy.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy.sv
@@ -105,7 +105,7 @@ module flash_phy import flash_ctrl_pkg::*; (
 
   // Generate host scramble_en indication, broadcasted to all banks
   localparam int TotalRegions = MpRegions + 1;
-  logic host_scramble_en;
+  logic host_scramble_en, host_ecc_en;
   data_region_attr_t region_attrs [TotalRegions];
   mp_region_cfg_t region_cfg, unused_cfg;
 
@@ -128,8 +128,9 @@ module flash_phy import flash_ctrl_pkg::*; (
   // most attributes are unused
   assign unused_cfg = region_cfg;
 
-  // only scramble attributes are looked at
+  // only scramble/ecc attributes are looked at
   assign host_scramble_en = region_cfg.scramble_en.q;
+  assign host_ecc_en = region_cfg.ecc_en.q;
 
   for (genvar bank = 0; bank < NumBanks; bank++) begin : gen_flash_banks
 
@@ -163,10 +164,12 @@ module flash_phy import flash_ctrl_pkg::*; (
       .rst_ni,
       .req_i(ctrl_req),
       .scramble_en_i(flash_ctrl_i.scramble_en),
+      .ecc_en_i(flash_ctrl_i.ecc_en),
       // host request must be suppressed if response fifo cannot hold more
       // otherwise the flash_phy_core and flash_phy will get out of sync
       .host_req_i(host_req),
       .host_scramble_en_i(host_scramble_en),
+      .host_ecc_en_i(host_ecc_en),
       .host_addr_i(host_addr_i[0 +: BusBankAddrW]),
       .rd_i(flash_ctrl_i.rd),
       .prog_i(flash_ctrl_i.prog),

--- a/hw/ip/flash_ctrl/rtl/flash_phy_core.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_core.sv
@@ -17,9 +17,11 @@ module flash_phy_core import flash_phy_pkg::*; #(
   input                              rst_ni,
   input                              host_req_i,   // host request - read only
   input                              host_scramble_en_i,
+  input                              host_ecc_en_i,
   input [BusBankAddrW-1:0]           host_addr_i,
   input                              req_i,        // controller request
   input                              scramble_en_i,
+  input                              ecc_en_i,
   input                              rd_i,
   input                              prog_i,
   input                              pg_erase_i,
@@ -80,6 +82,7 @@ module flash_phy_core import flash_phy_pkg::*; #(
   logic [BusBankAddrW-1:0] muxed_addr;
   flash_ctrl_pkg::flash_part_e muxed_part;
   logic muxed_scramble_en;
+  logic muxed_ecc_en;
 
   // entire read stage is idle, inclusive of all stages
   logic rd_stage_idle;
@@ -216,6 +219,7 @@ module flash_phy_core import flash_phy_pkg::*; #(
   assign muxed_addr = host_sel ? host_addr_i : addr_i;
   assign muxed_part = host_sel ? flash_ctrl_pkg::FlashPartData : part_i;
   assign muxed_scramble_en = host_sel ? host_scramble_en_i : scramble_en_i;
+  assign muxed_ecc_en = host_sel ? host_ecc_en_i : ecc_en_i;
   assign rd_done_o = ctrl_rsp_vld & rd_i;
   assign prog_done_o = ctrl_rsp_vld & prog_i;
   assign erase_done_o = ctrl_rsp_vld & (pg_erase_i | bk_erase_i);
@@ -237,6 +241,7 @@ module flash_phy_core import flash_phy_pkg::*; #(
     .rst_ni,
     .req_i(reqs[PhyRead]),
     .descramble_i(muxed_scramble_en),
+    .ecc_i(muxed_ecc_en),
     .prog_i(reqs[PhyProg]),
     .pg_erase_i(reqs[PhyPgErase]),
     .bk_erase_i(reqs[PhyBkErase]),
@@ -284,6 +289,7 @@ module flash_phy_core import flash_phy_pkg::*; #(
       .rst_ni,
       .req_i(reqs[PhyProg]),
       .scramble_i(muxed_scramble_en),
+      .ecc_i(muxed_ecc_en),
       .sel_i(addr_i[0 +: WordSelW]),
       .data_i(prog_data_i),
       .last_i(prog_last_i),

--- a/hw/ip/flash_ctrl/rtl/flash_phy_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_pkg.sv
@@ -72,6 +72,7 @@ package flash_phy_pkg;
   typedef struct packed {
     logic [BankAddrW-1:0] addr;
     logic descramble;
+    logic ecc;
   } rd_attr_t;
 
   // Flash Operations Supported

--- a/hw/ip/flash_ctrl/rtl/flash_phy_prog.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_prog.sv
@@ -27,6 +27,7 @@ module flash_phy_prog import flash_phy_pkg::*; (
   input rst_ni,
   input req_i,
   input scramble_i,
+  input ecc_i,
   input [WordSelW-1:0] sel_i,
   input [BusWidth-1:0] data_i,
   input last_i,
@@ -239,7 +240,7 @@ module flash_phy_prog import flash_phy_pkg::*; (
   );
 
   // pad the remaining bits to '0', this effectively "programs" them.
-  assign data_o = scramble_i ? FullDataWidth'(ecc_data) : FullDataWidth'(packed_data);
+  assign data_o = ecc_i ? FullDataWidth'(ecc_data) : FullDataWidth'(packed_data);
 
   /////////////////////////////////
   // Assertions

--- a/hw/ip/flash_ctrl/rtl/flash_phy_rd.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_rd.sv
@@ -33,6 +33,7 @@ module flash_phy_rd import flash_phy_pkg::*; (
   // interface with arbitration unit
   input req_i,
   input descramble_i,
+  input ecc_i,
   input prog_i,
   input pg_erase_i,
   input bk_erase_i,
@@ -274,6 +275,7 @@ module flash_phy_rd import flash_phy_pkg::*; (
       alloc_q <= alloc;
       rd_attrs.addr <= addr_i[BusBankAddrW-1:LsbAddrBit];
       rd_attrs.descramble <= descramble_i;
+      rd_attrs.ecc <= ecc_i;
     end else if (rd_done) begin
       rd_busy <= 1'b0;
     end
@@ -320,6 +322,7 @@ module flash_phy_rd import flash_phy_pkg::*; (
     .syndrome_o(),
     .err_o({ecc_err, ecc_single_err})
   );
+
   assign unused_err = ecc_single_err;
 
   // If data needs to be de-scrambled and has not been erased, pass through ecc decoder.
@@ -327,9 +330,9 @@ module flash_phy_rd import flash_phy_pkg::*; (
   // Likewise, ecc error is only observed if the data needs to be de-scrambled and has not been
   // erased.
   // rd_done signal below is duplicated (already in data_erased) to show clear intent of the code.
-  assign data_int = (rd_done && rd_attrs.descramble && !data_erased) ? data_ecc_chk :
-                                                                       data_i[DataWidth-1:0];
-  assign data_err = (rd_done && rd_attrs.descramble && !data_erased) ? ecc_err : 1'b0;
+  assign data_int = (rd_done && rd_attrs.ecc && !data_erased) ? data_ecc_chk :
+                                                                data_i[DataWidth-1:0];
+  assign data_err = (rd_done && rd_attrs.ecc && !data_erased) ? ecc_err : 1'b0;
 
   /////////////////////////////////
   // De-scrambling stage

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
@@ -398,7 +398,14 @@
             { bits: "4",
               name: "SCRAMBLE_EN",
               desc: '''
-                Region is scramble and ECC enabled.
+                Region is scramble enabled.
+              ''',
+              resval: "0"
+            }
+            { bits: "5",
+              name: "ECC_EN",
+              desc: '''
+                Region is ECC enabled.
               ''',
               resval: "0"
             }
@@ -451,7 +458,14 @@
         { bits: "3",
           name: "SCRAMBLE_EN",
           desc: '''
-            Region is scramble and ECC enabled
+            Region is scrambleenabled
+          ''',
+          resval: "0"
+        }
+        { bits: "4",
+          name: "ECC_EN",
+          desc: '''
+            Region is ECC enabled
           ''',
           resval: "0"
         }
@@ -535,7 +549,14 @@
             { bits: "4",
               name: "SCRAMBLE_EN",
               desc: '''
-                Region is scramble and ECC enabled.
+                Region is scramble enabled.
+              ''',
+              resval: "0"
+            }
+            { bits: "5",
+              name: "ECC_EN",
+              desc: '''
+                Region is ECC enabled.
               ''',
               resval: "0"
             }
@@ -618,7 +639,14 @@
             { bits: "4",
               name: "SCRAMBLE_EN",
               desc: '''
-                Region is scramble and ECC enabled.
+                Region is scramble enabled.
+              ''',
+              resval: "0"
+            }
+            { bits: "5",
+              name: "ECC_EN",
+              desc: '''
+                Region is ECC enabled.
               ''',
               resval: "0"
             }
@@ -701,7 +729,14 @@
             { bits: "4",
               name: "SCRAMBLE_EN",
               desc: '''
-                Region is scramble and ECC enabled.
+                Region is scramble enabled.
+              ''',
+              resval: "0"
+            }
+            { bits: "5",
+              name: "ECC_EN",
+              desc: '''
+                Region is ECC enabled.
               ''',
               resval: "0"
             }
@@ -784,7 +819,14 @@
             { bits: "4",
               name: "SCRAMBLE_EN",
               desc: '''
-                Region is scramble and ECC enabled.
+                Region is scramble enabled.
+              ''',
+              resval: "0"
+            }
+            { bits: "5",
+              name: "ECC_EN",
+              desc: '''
+                Region is ECC enabled.
               ''',
               resval: "0"
             }

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
@@ -522,6 +522,7 @@ module flash_ctrl import flash_ctrl_pkg::*; (
   assign region_cfgs[MpRegions].prog_en.q = reg2hw.default_region.prog_en.q;
   assign region_cfgs[MpRegions].erase_en.q = reg2hw.default_region.erase_en.q;
   assign region_cfgs[MpRegions].scramble_en.q = reg2hw.default_region.scramble_en.q;
+  assign region_cfgs[MpRegions].ecc_en.q = reg2hw.default_region.ecc_en.q;
 
   //////////////////////////////////////
   // Info partition protection configuration
@@ -596,6 +597,7 @@ module flash_ctrl import flash_ctrl_pkg::*; (
     // flash phy interface
     .req_o(flash_o.req),
     .scramble_en_o(flash_o.scramble_en),
+    .ecc_en_o(flash_o.ecc_en),
     .rd_o(flash_o.rd),
     .prog_o(flash_o.prog),
     .pg_erase_o(flash_o.pg_erase),

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_pkg.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_pkg.sv
@@ -144,7 +144,8 @@ package flash_ctrl_pkg;
     rd_en:       1'b1,
     prog_en:     1'b0,
     erase_en:    1'b0,
-    scramble_en: 1'b0  // TBD, update to 1 once tb supports ECC
+    scramble_en: 1'b0,
+    ecc_en:      1'b0  // TBD, update to 1 once tb supports ECC
   };
 
   parameter info_page_cfg_t CfgAllowReadErase = '{
@@ -152,7 +153,8 @@ package flash_ctrl_pkg;
     rd_en:       1'b1,
     prog_en:     1'b0,
     erase_en:    1'b1,
-    scramble_en: 1'b0  // TBD, update to 1 once tb supports ECC
+    scramble_en: 1'b0,
+    ecc_en:      1'b0  // TBD, update to 1 once tb supports ECC
   };
 
   parameter info_page_attr_t HwInfoPageAttr[HwInfoRules] = '{
@@ -184,6 +186,7 @@ package flash_ctrl_pkg;
                  prog_en:     1'b0,
                  erase_en:    1'b1,
                  scramble_en: 1'b0,
+                 ecc_en:      1'b0,
                  base:        '0,
                  size:        '{default:'1}
                 }
@@ -239,6 +242,7 @@ package flash_ctrl_pkg;
   typedef struct packed {
     logic                 req;
     logic                 scramble_en;
+    logic                 ecc_en;
     logic                 rd;
     logic                 prog;
     logic                 pg_erase;
@@ -257,6 +261,7 @@ package flash_ctrl_pkg;
   parameter flash_req_t FLASH_REQ_DEFAULT = '{
     req:         1'b0,
     scramble_en: 1'b0,
+    ecc_en:      1'b0,
     rd:          1'b0,
     prog:        1'b0,
     pg_erase:    1'b0,

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_pkg.sv
@@ -135,6 +135,9 @@ package flash_ctrl_reg_pkg;
       logic        q;
     } scramble_en;
     struct packed {
+      logic        q;
+    } ecc_en;
+    struct packed {
       logic [8:0]  q;
     } base;
     struct packed {
@@ -155,6 +158,9 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        q;
     } scramble_en;
+    struct packed {
+      logic        q;
+    } ecc_en;
   } flash_ctrl_reg2hw_default_region_reg_t;
 
   typedef struct packed {
@@ -173,6 +179,9 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        q;
     } scramble_en;
+    struct packed {
+      logic        q;
+    } ecc_en;
   } flash_ctrl_reg2hw_bank0_info0_page_cfg_mreg_t;
 
   typedef struct packed {
@@ -191,6 +200,9 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        q;
     } scramble_en;
+    struct packed {
+      logic        q;
+    } ecc_en;
   } flash_ctrl_reg2hw_bank0_info1_page_cfg_mreg_t;
 
   typedef struct packed {
@@ -209,6 +221,9 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        q;
     } scramble_en;
+    struct packed {
+      logic        q;
+    } ecc_en;
   } flash_ctrl_reg2hw_bank1_info0_page_cfg_mreg_t;
 
   typedef struct packed {
@@ -227,6 +242,9 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        q;
     } scramble_en;
+    struct packed {
+      logic        q;
+    } ecc_en;
   } flash_ctrl_reg2hw_bank1_info1_page_cfg_mreg_t;
 
   typedef struct packed {
@@ -347,17 +365,17 @@ package flash_ctrl_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    flash_ctrl_reg2hw_intr_state_reg_t intr_state; // [395:390]
-    flash_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [389:384]
-    flash_ctrl_reg2hw_intr_test_reg_t intr_test; // [383:372]
-    flash_ctrl_reg2hw_control_reg_t control; // [371:353]
-    flash_ctrl_reg2hw_addr_reg_t addr; // [352:321]
-    flash_ctrl_reg2hw_mp_region_cfg_mreg_t [7:0] mp_region_cfg; // [320:129]
-    flash_ctrl_reg2hw_default_region_reg_t default_region; // [128:125]
-    flash_ctrl_reg2hw_bank0_info0_page_cfg_mreg_t [3:0] bank0_info0_page_cfg; // [124:105]
-    flash_ctrl_reg2hw_bank0_info1_page_cfg_mreg_t [3:0] bank0_info1_page_cfg; // [104:85]
-    flash_ctrl_reg2hw_bank1_info0_page_cfg_mreg_t [3:0] bank1_info0_page_cfg; // [84:65]
-    flash_ctrl_reg2hw_bank1_info1_page_cfg_mreg_t [3:0] bank1_info1_page_cfg; // [64:45]
+    flash_ctrl_reg2hw_intr_state_reg_t intr_state; // [420:415]
+    flash_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [414:409]
+    flash_ctrl_reg2hw_intr_test_reg_t intr_test; // [408:397]
+    flash_ctrl_reg2hw_control_reg_t control; // [396:378]
+    flash_ctrl_reg2hw_addr_reg_t addr; // [377:346]
+    flash_ctrl_reg2hw_mp_region_cfg_mreg_t [7:0] mp_region_cfg; // [345:146]
+    flash_ctrl_reg2hw_default_region_reg_t default_region; // [145:141]
+    flash_ctrl_reg2hw_bank0_info0_page_cfg_mreg_t [3:0] bank0_info0_page_cfg; // [140:117]
+    flash_ctrl_reg2hw_bank0_info1_page_cfg_mreg_t [3:0] bank0_info1_page_cfg; // [116:93]
+    flash_ctrl_reg2hw_bank1_info0_page_cfg_mreg_t [3:0] bank1_info0_page_cfg; // [92:69]
+    flash_ctrl_reg2hw_bank1_info1_page_cfg_mreg_t [3:0] bank1_info1_page_cfg; // [68:45]
     flash_ctrl_reg2hw_mp_bank_cfg_mreg_t [1:0] mp_bank_cfg; // [44:43]
     flash_ctrl_reg2hw_scratch_reg_t scratch; // [42:11]
     flash_ctrl_reg2hw_fifo_lvl_reg_t fifo_lvl; // [10:1]

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_top.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_top.sv
@@ -234,6 +234,9 @@ module flash_ctrl_reg_top (
   logic mp_region_cfg_0_scramble_en_0_qs;
   logic mp_region_cfg_0_scramble_en_0_wd;
   logic mp_region_cfg_0_scramble_en_0_we;
+  logic mp_region_cfg_0_ecc_en_0_qs;
+  logic mp_region_cfg_0_ecc_en_0_wd;
+  logic mp_region_cfg_0_ecc_en_0_we;
   logic [8:0] mp_region_cfg_0_base_0_qs;
   logic [8:0] mp_region_cfg_0_base_0_wd;
   logic mp_region_cfg_0_base_0_we;
@@ -255,6 +258,9 @@ module flash_ctrl_reg_top (
   logic mp_region_cfg_1_scramble_en_1_qs;
   logic mp_region_cfg_1_scramble_en_1_wd;
   logic mp_region_cfg_1_scramble_en_1_we;
+  logic mp_region_cfg_1_ecc_en_1_qs;
+  logic mp_region_cfg_1_ecc_en_1_wd;
+  logic mp_region_cfg_1_ecc_en_1_we;
   logic [8:0] mp_region_cfg_1_base_1_qs;
   logic [8:0] mp_region_cfg_1_base_1_wd;
   logic mp_region_cfg_1_base_1_we;
@@ -276,6 +282,9 @@ module flash_ctrl_reg_top (
   logic mp_region_cfg_2_scramble_en_2_qs;
   logic mp_region_cfg_2_scramble_en_2_wd;
   logic mp_region_cfg_2_scramble_en_2_we;
+  logic mp_region_cfg_2_ecc_en_2_qs;
+  logic mp_region_cfg_2_ecc_en_2_wd;
+  logic mp_region_cfg_2_ecc_en_2_we;
   logic [8:0] mp_region_cfg_2_base_2_qs;
   logic [8:0] mp_region_cfg_2_base_2_wd;
   logic mp_region_cfg_2_base_2_we;
@@ -297,6 +306,9 @@ module flash_ctrl_reg_top (
   logic mp_region_cfg_3_scramble_en_3_qs;
   logic mp_region_cfg_3_scramble_en_3_wd;
   logic mp_region_cfg_3_scramble_en_3_we;
+  logic mp_region_cfg_3_ecc_en_3_qs;
+  logic mp_region_cfg_3_ecc_en_3_wd;
+  logic mp_region_cfg_3_ecc_en_3_we;
   logic [8:0] mp_region_cfg_3_base_3_qs;
   logic [8:0] mp_region_cfg_3_base_3_wd;
   logic mp_region_cfg_3_base_3_we;
@@ -318,6 +330,9 @@ module flash_ctrl_reg_top (
   logic mp_region_cfg_4_scramble_en_4_qs;
   logic mp_region_cfg_4_scramble_en_4_wd;
   logic mp_region_cfg_4_scramble_en_4_we;
+  logic mp_region_cfg_4_ecc_en_4_qs;
+  logic mp_region_cfg_4_ecc_en_4_wd;
+  logic mp_region_cfg_4_ecc_en_4_we;
   logic [8:0] mp_region_cfg_4_base_4_qs;
   logic [8:0] mp_region_cfg_4_base_4_wd;
   logic mp_region_cfg_4_base_4_we;
@@ -339,6 +354,9 @@ module flash_ctrl_reg_top (
   logic mp_region_cfg_5_scramble_en_5_qs;
   logic mp_region_cfg_5_scramble_en_5_wd;
   logic mp_region_cfg_5_scramble_en_5_we;
+  logic mp_region_cfg_5_ecc_en_5_qs;
+  logic mp_region_cfg_5_ecc_en_5_wd;
+  logic mp_region_cfg_5_ecc_en_5_we;
   logic [8:0] mp_region_cfg_5_base_5_qs;
   logic [8:0] mp_region_cfg_5_base_5_wd;
   logic mp_region_cfg_5_base_5_we;
@@ -360,6 +378,9 @@ module flash_ctrl_reg_top (
   logic mp_region_cfg_6_scramble_en_6_qs;
   logic mp_region_cfg_6_scramble_en_6_wd;
   logic mp_region_cfg_6_scramble_en_6_we;
+  logic mp_region_cfg_6_ecc_en_6_qs;
+  logic mp_region_cfg_6_ecc_en_6_wd;
+  logic mp_region_cfg_6_ecc_en_6_we;
   logic [8:0] mp_region_cfg_6_base_6_qs;
   logic [8:0] mp_region_cfg_6_base_6_wd;
   logic mp_region_cfg_6_base_6_we;
@@ -381,6 +402,9 @@ module flash_ctrl_reg_top (
   logic mp_region_cfg_7_scramble_en_7_qs;
   logic mp_region_cfg_7_scramble_en_7_wd;
   logic mp_region_cfg_7_scramble_en_7_we;
+  logic mp_region_cfg_7_ecc_en_7_qs;
+  logic mp_region_cfg_7_ecc_en_7_wd;
+  logic mp_region_cfg_7_ecc_en_7_we;
   logic [8:0] mp_region_cfg_7_base_7_qs;
   logic [8:0] mp_region_cfg_7_base_7_wd;
   logic mp_region_cfg_7_base_7_we;
@@ -399,6 +423,9 @@ module flash_ctrl_reg_top (
   logic default_region_scramble_en_qs;
   logic default_region_scramble_en_wd;
   logic default_region_scramble_en_we;
+  logic default_region_ecc_en_qs;
+  logic default_region_ecc_en_wd;
+  logic default_region_ecc_en_we;
   logic bank0_info0_regwen_0_qs;
   logic bank0_info0_regwen_0_wd;
   logic bank0_info0_regwen_0_we;
@@ -426,6 +453,9 @@ module flash_ctrl_reg_top (
   logic bank0_info0_page_cfg_0_scramble_en_0_qs;
   logic bank0_info0_page_cfg_0_scramble_en_0_wd;
   logic bank0_info0_page_cfg_0_scramble_en_0_we;
+  logic bank0_info0_page_cfg_0_ecc_en_0_qs;
+  logic bank0_info0_page_cfg_0_ecc_en_0_wd;
+  logic bank0_info0_page_cfg_0_ecc_en_0_we;
   logic bank0_info0_page_cfg_1_en_1_qs;
   logic bank0_info0_page_cfg_1_en_1_wd;
   logic bank0_info0_page_cfg_1_en_1_we;
@@ -441,6 +471,9 @@ module flash_ctrl_reg_top (
   logic bank0_info0_page_cfg_1_scramble_en_1_qs;
   logic bank0_info0_page_cfg_1_scramble_en_1_wd;
   logic bank0_info0_page_cfg_1_scramble_en_1_we;
+  logic bank0_info0_page_cfg_1_ecc_en_1_qs;
+  logic bank0_info0_page_cfg_1_ecc_en_1_wd;
+  logic bank0_info0_page_cfg_1_ecc_en_1_we;
   logic bank0_info0_page_cfg_2_en_2_qs;
   logic bank0_info0_page_cfg_2_en_2_wd;
   logic bank0_info0_page_cfg_2_en_2_we;
@@ -456,6 +489,9 @@ module flash_ctrl_reg_top (
   logic bank0_info0_page_cfg_2_scramble_en_2_qs;
   logic bank0_info0_page_cfg_2_scramble_en_2_wd;
   logic bank0_info0_page_cfg_2_scramble_en_2_we;
+  logic bank0_info0_page_cfg_2_ecc_en_2_qs;
+  logic bank0_info0_page_cfg_2_ecc_en_2_wd;
+  logic bank0_info0_page_cfg_2_ecc_en_2_we;
   logic bank0_info0_page_cfg_3_en_3_qs;
   logic bank0_info0_page_cfg_3_en_3_wd;
   logic bank0_info0_page_cfg_3_en_3_we;
@@ -471,6 +507,9 @@ module flash_ctrl_reg_top (
   logic bank0_info0_page_cfg_3_scramble_en_3_qs;
   logic bank0_info0_page_cfg_3_scramble_en_3_wd;
   logic bank0_info0_page_cfg_3_scramble_en_3_we;
+  logic bank0_info0_page_cfg_3_ecc_en_3_qs;
+  logic bank0_info0_page_cfg_3_ecc_en_3_wd;
+  logic bank0_info0_page_cfg_3_ecc_en_3_we;
   logic bank0_info1_regwen_0_qs;
   logic bank0_info1_regwen_0_wd;
   logic bank0_info1_regwen_0_we;
@@ -498,6 +537,9 @@ module flash_ctrl_reg_top (
   logic bank0_info1_page_cfg_0_scramble_en_0_qs;
   logic bank0_info1_page_cfg_0_scramble_en_0_wd;
   logic bank0_info1_page_cfg_0_scramble_en_0_we;
+  logic bank0_info1_page_cfg_0_ecc_en_0_qs;
+  logic bank0_info1_page_cfg_0_ecc_en_0_wd;
+  logic bank0_info1_page_cfg_0_ecc_en_0_we;
   logic bank0_info1_page_cfg_1_en_1_qs;
   logic bank0_info1_page_cfg_1_en_1_wd;
   logic bank0_info1_page_cfg_1_en_1_we;
@@ -513,6 +555,9 @@ module flash_ctrl_reg_top (
   logic bank0_info1_page_cfg_1_scramble_en_1_qs;
   logic bank0_info1_page_cfg_1_scramble_en_1_wd;
   logic bank0_info1_page_cfg_1_scramble_en_1_we;
+  logic bank0_info1_page_cfg_1_ecc_en_1_qs;
+  logic bank0_info1_page_cfg_1_ecc_en_1_wd;
+  logic bank0_info1_page_cfg_1_ecc_en_1_we;
   logic bank0_info1_page_cfg_2_en_2_qs;
   logic bank0_info1_page_cfg_2_en_2_wd;
   logic bank0_info1_page_cfg_2_en_2_we;
@@ -528,6 +573,9 @@ module flash_ctrl_reg_top (
   logic bank0_info1_page_cfg_2_scramble_en_2_qs;
   logic bank0_info1_page_cfg_2_scramble_en_2_wd;
   logic bank0_info1_page_cfg_2_scramble_en_2_we;
+  logic bank0_info1_page_cfg_2_ecc_en_2_qs;
+  logic bank0_info1_page_cfg_2_ecc_en_2_wd;
+  logic bank0_info1_page_cfg_2_ecc_en_2_we;
   logic bank0_info1_page_cfg_3_en_3_qs;
   logic bank0_info1_page_cfg_3_en_3_wd;
   logic bank0_info1_page_cfg_3_en_3_we;
@@ -543,6 +591,9 @@ module flash_ctrl_reg_top (
   logic bank0_info1_page_cfg_3_scramble_en_3_qs;
   logic bank0_info1_page_cfg_3_scramble_en_3_wd;
   logic bank0_info1_page_cfg_3_scramble_en_3_we;
+  logic bank0_info1_page_cfg_3_ecc_en_3_qs;
+  logic bank0_info1_page_cfg_3_ecc_en_3_wd;
+  logic bank0_info1_page_cfg_3_ecc_en_3_we;
   logic bank1_info0_regwen_0_qs;
   logic bank1_info0_regwen_0_wd;
   logic bank1_info0_regwen_0_we;
@@ -570,6 +621,9 @@ module flash_ctrl_reg_top (
   logic bank1_info0_page_cfg_0_scramble_en_0_qs;
   logic bank1_info0_page_cfg_0_scramble_en_0_wd;
   logic bank1_info0_page_cfg_0_scramble_en_0_we;
+  logic bank1_info0_page_cfg_0_ecc_en_0_qs;
+  logic bank1_info0_page_cfg_0_ecc_en_0_wd;
+  logic bank1_info0_page_cfg_0_ecc_en_0_we;
   logic bank1_info0_page_cfg_1_en_1_qs;
   logic bank1_info0_page_cfg_1_en_1_wd;
   logic bank1_info0_page_cfg_1_en_1_we;
@@ -585,6 +639,9 @@ module flash_ctrl_reg_top (
   logic bank1_info0_page_cfg_1_scramble_en_1_qs;
   logic bank1_info0_page_cfg_1_scramble_en_1_wd;
   logic bank1_info0_page_cfg_1_scramble_en_1_we;
+  logic bank1_info0_page_cfg_1_ecc_en_1_qs;
+  logic bank1_info0_page_cfg_1_ecc_en_1_wd;
+  logic bank1_info0_page_cfg_1_ecc_en_1_we;
   logic bank1_info0_page_cfg_2_en_2_qs;
   logic bank1_info0_page_cfg_2_en_2_wd;
   logic bank1_info0_page_cfg_2_en_2_we;
@@ -600,6 +657,9 @@ module flash_ctrl_reg_top (
   logic bank1_info0_page_cfg_2_scramble_en_2_qs;
   logic bank1_info0_page_cfg_2_scramble_en_2_wd;
   logic bank1_info0_page_cfg_2_scramble_en_2_we;
+  logic bank1_info0_page_cfg_2_ecc_en_2_qs;
+  logic bank1_info0_page_cfg_2_ecc_en_2_wd;
+  logic bank1_info0_page_cfg_2_ecc_en_2_we;
   logic bank1_info0_page_cfg_3_en_3_qs;
   logic bank1_info0_page_cfg_3_en_3_wd;
   logic bank1_info0_page_cfg_3_en_3_we;
@@ -615,6 +675,9 @@ module flash_ctrl_reg_top (
   logic bank1_info0_page_cfg_3_scramble_en_3_qs;
   logic bank1_info0_page_cfg_3_scramble_en_3_wd;
   logic bank1_info0_page_cfg_3_scramble_en_3_we;
+  logic bank1_info0_page_cfg_3_ecc_en_3_qs;
+  logic bank1_info0_page_cfg_3_ecc_en_3_wd;
+  logic bank1_info0_page_cfg_3_ecc_en_3_we;
   logic bank1_info1_regwen_0_qs;
   logic bank1_info1_regwen_0_wd;
   logic bank1_info1_regwen_0_we;
@@ -642,6 +705,9 @@ module flash_ctrl_reg_top (
   logic bank1_info1_page_cfg_0_scramble_en_0_qs;
   logic bank1_info1_page_cfg_0_scramble_en_0_wd;
   logic bank1_info1_page_cfg_0_scramble_en_0_we;
+  logic bank1_info1_page_cfg_0_ecc_en_0_qs;
+  logic bank1_info1_page_cfg_0_ecc_en_0_wd;
+  logic bank1_info1_page_cfg_0_ecc_en_0_we;
   logic bank1_info1_page_cfg_1_en_1_qs;
   logic bank1_info1_page_cfg_1_en_1_wd;
   logic bank1_info1_page_cfg_1_en_1_we;
@@ -657,6 +723,9 @@ module flash_ctrl_reg_top (
   logic bank1_info1_page_cfg_1_scramble_en_1_qs;
   logic bank1_info1_page_cfg_1_scramble_en_1_wd;
   logic bank1_info1_page_cfg_1_scramble_en_1_we;
+  logic bank1_info1_page_cfg_1_ecc_en_1_qs;
+  logic bank1_info1_page_cfg_1_ecc_en_1_wd;
+  logic bank1_info1_page_cfg_1_ecc_en_1_we;
   logic bank1_info1_page_cfg_2_en_2_qs;
   logic bank1_info1_page_cfg_2_en_2_wd;
   logic bank1_info1_page_cfg_2_en_2_we;
@@ -672,6 +741,9 @@ module flash_ctrl_reg_top (
   logic bank1_info1_page_cfg_2_scramble_en_2_qs;
   logic bank1_info1_page_cfg_2_scramble_en_2_wd;
   logic bank1_info1_page_cfg_2_scramble_en_2_we;
+  logic bank1_info1_page_cfg_2_ecc_en_2_qs;
+  logic bank1_info1_page_cfg_2_ecc_en_2_wd;
+  logic bank1_info1_page_cfg_2_ecc_en_2_we;
   logic bank1_info1_page_cfg_3_en_3_qs;
   logic bank1_info1_page_cfg_3_en_3_wd;
   logic bank1_info1_page_cfg_3_en_3_we;
@@ -687,6 +759,9 @@ module flash_ctrl_reg_top (
   logic bank1_info1_page_cfg_3_scramble_en_3_qs;
   logic bank1_info1_page_cfg_3_scramble_en_3_wd;
   logic bank1_info1_page_cfg_3_scramble_en_3_we;
+  logic bank1_info1_page_cfg_3_ecc_en_3_qs;
+  logic bank1_info1_page_cfg_3_ecc_en_3_wd;
+  logic bank1_info1_page_cfg_3_ecc_en_3_we;
   logic bank_cfg_regwen_qs;
   logic bank_cfg_regwen_wd;
   logic bank_cfg_regwen_we;
@@ -1712,6 +1787,32 @@ module flash_ctrl_reg_top (
   );
 
 
+  // F[ecc_en_0]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_mp_region_cfg_0_ecc_en_0 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (mp_region_cfg_0_ecc_en_0_we & region_cfg_regwen_0_qs),
+    .wd     (mp_region_cfg_0_ecc_en_0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.mp_region_cfg[0].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (mp_region_cfg_0_ecc_en_0_qs)
+  );
+
+
   // F[base_0]: 16:8
   prim_subreg #(
     .DW      (9),
@@ -1894,6 +1995,32 @@ module flash_ctrl_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_1_scramble_en_1_qs)
+  );
+
+
+  // F[ecc_en_1]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_mp_region_cfg_1_ecc_en_1 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (mp_region_cfg_1_ecc_en_1_we & region_cfg_regwen_1_qs),
+    .wd     (mp_region_cfg_1_ecc_en_1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.mp_region_cfg[1].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (mp_region_cfg_1_ecc_en_1_qs)
   );
 
 
@@ -2082,6 +2209,32 @@ module flash_ctrl_reg_top (
   );
 
 
+  // F[ecc_en_2]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_mp_region_cfg_2_ecc_en_2 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (mp_region_cfg_2_ecc_en_2_we & region_cfg_regwen_2_qs),
+    .wd     (mp_region_cfg_2_ecc_en_2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.mp_region_cfg[2].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (mp_region_cfg_2_ecc_en_2_qs)
+  );
+
+
   // F[base_2]: 16:8
   prim_subreg #(
     .DW      (9),
@@ -2264,6 +2417,32 @@ module flash_ctrl_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_3_scramble_en_3_qs)
+  );
+
+
+  // F[ecc_en_3]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_mp_region_cfg_3_ecc_en_3 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (mp_region_cfg_3_ecc_en_3_we & region_cfg_regwen_3_qs),
+    .wd     (mp_region_cfg_3_ecc_en_3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.mp_region_cfg[3].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (mp_region_cfg_3_ecc_en_3_qs)
   );
 
 
@@ -2452,6 +2631,32 @@ module flash_ctrl_reg_top (
   );
 
 
+  // F[ecc_en_4]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_mp_region_cfg_4_ecc_en_4 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (mp_region_cfg_4_ecc_en_4_we & region_cfg_regwen_4_qs),
+    .wd     (mp_region_cfg_4_ecc_en_4_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.mp_region_cfg[4].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (mp_region_cfg_4_ecc_en_4_qs)
+  );
+
+
   // F[base_4]: 16:8
   prim_subreg #(
     .DW      (9),
@@ -2634,6 +2839,32 @@ module flash_ctrl_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_5_scramble_en_5_qs)
+  );
+
+
+  // F[ecc_en_5]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_mp_region_cfg_5_ecc_en_5 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (mp_region_cfg_5_ecc_en_5_we & region_cfg_regwen_5_qs),
+    .wd     (mp_region_cfg_5_ecc_en_5_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.mp_region_cfg[5].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (mp_region_cfg_5_ecc_en_5_qs)
   );
 
 
@@ -2822,6 +3053,32 @@ module flash_ctrl_reg_top (
   );
 
 
+  // F[ecc_en_6]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_mp_region_cfg_6_ecc_en_6 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (mp_region_cfg_6_ecc_en_6_we & region_cfg_regwen_6_qs),
+    .wd     (mp_region_cfg_6_ecc_en_6_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.mp_region_cfg[6].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (mp_region_cfg_6_ecc_en_6_qs)
+  );
+
+
   // F[base_6]: 16:8
   prim_subreg #(
     .DW      (9),
@@ -3007,6 +3264,32 @@ module flash_ctrl_reg_top (
   );
 
 
+  // F[ecc_en_7]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_mp_region_cfg_7_ecc_en_7 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (mp_region_cfg_7_ecc_en_7_we & region_cfg_regwen_7_qs),
+    .wd     (mp_region_cfg_7_ecc_en_7_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.mp_region_cfg[7].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (mp_region_cfg_7_ecc_en_7_qs)
+  );
+
+
   // F[base_7]: 16:8
   prim_subreg #(
     .DW      (9),
@@ -3163,6 +3446,32 @@ module flash_ctrl_reg_top (
 
     // to register interface (read)
     .qs     (default_region_scramble_en_qs)
+  );
+
+
+  //   F[ecc_en]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_default_region_ecc_en (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (default_region_ecc_en_we),
+    .wd     (default_region_ecc_en_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.default_region.ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (default_region_ecc_en_qs)
   );
 
 
@@ -3410,6 +3719,32 @@ module flash_ctrl_reg_top (
   );
 
 
+  // F[ecc_en_0]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank0_info0_page_cfg_0_ecc_en_0 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank0_info0_page_cfg_0_ecc_en_0_we & bank0_info0_regwen_0_qs),
+    .wd     (bank0_info0_page_cfg_0_ecc_en_0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank0_info0_page_cfg[0].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (bank0_info0_page_cfg_0_ecc_en_0_qs)
+  );
+
+
   // Subregister 1 of Multireg bank0_info0_page_cfg
   // R[bank0_info0_page_cfg_1]: V(False)
 
@@ -3540,6 +3875,32 @@ module flash_ctrl_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_1_scramble_en_1_qs)
+  );
+
+
+  // F[ecc_en_1]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank0_info0_page_cfg_1_ecc_en_1 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank0_info0_page_cfg_1_ecc_en_1_we & bank0_info0_regwen_1_qs),
+    .wd     (bank0_info0_page_cfg_1_ecc_en_1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank0_info0_page_cfg[1].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (bank0_info0_page_cfg_1_ecc_en_1_qs)
   );
 
 
@@ -3676,6 +4037,32 @@ module flash_ctrl_reg_top (
   );
 
 
+  // F[ecc_en_2]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank0_info0_page_cfg_2_ecc_en_2 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank0_info0_page_cfg_2_ecc_en_2_we & bank0_info0_regwen_2_qs),
+    .wd     (bank0_info0_page_cfg_2_ecc_en_2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank0_info0_page_cfg[2].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (bank0_info0_page_cfg_2_ecc_en_2_qs)
+  );
+
+
   // Subregister 3 of Multireg bank0_info0_page_cfg
   // R[bank0_info0_page_cfg_3]: V(False)
 
@@ -3806,6 +4193,32 @@ module flash_ctrl_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_3_scramble_en_3_qs)
+  );
+
+
+  // F[ecc_en_3]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank0_info0_page_cfg_3_ecc_en_3 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank0_info0_page_cfg_3_ecc_en_3_we & bank0_info0_regwen_3_qs),
+    .wd     (bank0_info0_page_cfg_3_ecc_en_3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank0_info0_page_cfg[3].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (bank0_info0_page_cfg_3_ecc_en_3_qs)
   );
 
 
@@ -4054,6 +4467,32 @@ module flash_ctrl_reg_top (
   );
 
 
+  // F[ecc_en_0]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank0_info1_page_cfg_0_ecc_en_0 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank0_info1_page_cfg_0_ecc_en_0_we & bank0_info1_regwen_0_qs),
+    .wd     (bank0_info1_page_cfg_0_ecc_en_0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank0_info1_page_cfg[0].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (bank0_info1_page_cfg_0_ecc_en_0_qs)
+  );
+
+
   // Subregister 1 of Multireg bank0_info1_page_cfg
   // R[bank0_info1_page_cfg_1]: V(False)
 
@@ -4184,6 +4623,32 @@ module flash_ctrl_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info1_page_cfg_1_scramble_en_1_qs)
+  );
+
+
+  // F[ecc_en_1]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank0_info1_page_cfg_1_ecc_en_1 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank0_info1_page_cfg_1_ecc_en_1_we & bank0_info1_regwen_1_qs),
+    .wd     (bank0_info1_page_cfg_1_ecc_en_1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank0_info1_page_cfg[1].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (bank0_info1_page_cfg_1_ecc_en_1_qs)
   );
 
 
@@ -4320,6 +4785,32 @@ module flash_ctrl_reg_top (
   );
 
 
+  // F[ecc_en_2]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank0_info1_page_cfg_2_ecc_en_2 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank0_info1_page_cfg_2_ecc_en_2_we & bank0_info1_regwen_2_qs),
+    .wd     (bank0_info1_page_cfg_2_ecc_en_2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank0_info1_page_cfg[2].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (bank0_info1_page_cfg_2_ecc_en_2_qs)
+  );
+
+
   // Subregister 3 of Multireg bank0_info1_page_cfg
   // R[bank0_info1_page_cfg_3]: V(False)
 
@@ -4450,6 +4941,32 @@ module flash_ctrl_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info1_page_cfg_3_scramble_en_3_qs)
+  );
+
+
+  // F[ecc_en_3]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank0_info1_page_cfg_3_ecc_en_3 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank0_info1_page_cfg_3_ecc_en_3_we & bank0_info1_regwen_3_qs),
+    .wd     (bank0_info1_page_cfg_3_ecc_en_3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank0_info1_page_cfg[3].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (bank0_info1_page_cfg_3_ecc_en_3_qs)
   );
 
 
@@ -4698,6 +5215,32 @@ module flash_ctrl_reg_top (
   );
 
 
+  // F[ecc_en_0]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank1_info0_page_cfg_0_ecc_en_0 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank1_info0_page_cfg_0_ecc_en_0_we & bank1_info0_regwen_0_qs),
+    .wd     (bank1_info0_page_cfg_0_ecc_en_0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank1_info0_page_cfg[0].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (bank1_info0_page_cfg_0_ecc_en_0_qs)
+  );
+
+
   // Subregister 1 of Multireg bank1_info0_page_cfg
   // R[bank1_info0_page_cfg_1]: V(False)
 
@@ -4828,6 +5371,32 @@ module flash_ctrl_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_1_scramble_en_1_qs)
+  );
+
+
+  // F[ecc_en_1]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank1_info0_page_cfg_1_ecc_en_1 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank1_info0_page_cfg_1_ecc_en_1_we & bank1_info0_regwen_1_qs),
+    .wd     (bank1_info0_page_cfg_1_ecc_en_1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank1_info0_page_cfg[1].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (bank1_info0_page_cfg_1_ecc_en_1_qs)
   );
 
 
@@ -4964,6 +5533,32 @@ module flash_ctrl_reg_top (
   );
 
 
+  // F[ecc_en_2]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank1_info0_page_cfg_2_ecc_en_2 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank1_info0_page_cfg_2_ecc_en_2_we & bank1_info0_regwen_2_qs),
+    .wd     (bank1_info0_page_cfg_2_ecc_en_2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank1_info0_page_cfg[2].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (bank1_info0_page_cfg_2_ecc_en_2_qs)
+  );
+
+
   // Subregister 3 of Multireg bank1_info0_page_cfg
   // R[bank1_info0_page_cfg_3]: V(False)
 
@@ -5094,6 +5689,32 @@ module flash_ctrl_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_3_scramble_en_3_qs)
+  );
+
+
+  // F[ecc_en_3]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank1_info0_page_cfg_3_ecc_en_3 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank1_info0_page_cfg_3_ecc_en_3_we & bank1_info0_regwen_3_qs),
+    .wd     (bank1_info0_page_cfg_3_ecc_en_3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank1_info0_page_cfg[3].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (bank1_info0_page_cfg_3_ecc_en_3_qs)
   );
 
 
@@ -5342,6 +5963,32 @@ module flash_ctrl_reg_top (
   );
 
 
+  // F[ecc_en_0]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank1_info1_page_cfg_0_ecc_en_0 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank1_info1_page_cfg_0_ecc_en_0_we & bank1_info1_regwen_0_qs),
+    .wd     (bank1_info1_page_cfg_0_ecc_en_0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank1_info1_page_cfg[0].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (bank1_info1_page_cfg_0_ecc_en_0_qs)
+  );
+
+
   // Subregister 1 of Multireg bank1_info1_page_cfg
   // R[bank1_info1_page_cfg_1]: V(False)
 
@@ -5472,6 +6119,32 @@ module flash_ctrl_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info1_page_cfg_1_scramble_en_1_qs)
+  );
+
+
+  // F[ecc_en_1]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank1_info1_page_cfg_1_ecc_en_1 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank1_info1_page_cfg_1_ecc_en_1_we & bank1_info1_regwen_1_qs),
+    .wd     (bank1_info1_page_cfg_1_ecc_en_1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank1_info1_page_cfg[1].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (bank1_info1_page_cfg_1_ecc_en_1_qs)
   );
 
 
@@ -5608,6 +6281,32 @@ module flash_ctrl_reg_top (
   );
 
 
+  // F[ecc_en_2]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank1_info1_page_cfg_2_ecc_en_2 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank1_info1_page_cfg_2_ecc_en_2_we & bank1_info1_regwen_2_qs),
+    .wd     (bank1_info1_page_cfg_2_ecc_en_2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank1_info1_page_cfg[2].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (bank1_info1_page_cfg_2_ecc_en_2_qs)
+  );
+
+
   // Subregister 3 of Multireg bank1_info1_page_cfg
   // R[bank1_info1_page_cfg_3]: V(False)
 
@@ -5738,6 +6437,32 @@ module flash_ctrl_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info1_page_cfg_3_scramble_en_3_qs)
+  );
+
+
+  // F[ecc_en_3]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_bank1_info1_page_cfg_3_ecc_en_3 (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface (qualified with register enable)
+    .we     (bank1_info1_page_cfg_3_ecc_en_3_we & bank1_info1_regwen_3_qs),
+    .wd     (bank1_info1_page_cfg_3_ecc_en_3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.bank1_info1_page_cfg[3].ecc_en.q ),
+
+    // to register interface (read)
+    .qs     (bank1_info1_page_cfg_3_ecc_en_3_qs)
   );
 
 
@@ -6476,6 +7201,9 @@ module flash_ctrl_reg_top (
   assign mp_region_cfg_0_scramble_en_0_we = addr_hit[14] & reg_we & ~wr_err;
   assign mp_region_cfg_0_scramble_en_0_wd = reg_wdata[4];
 
+  assign mp_region_cfg_0_ecc_en_0_we = addr_hit[14] & reg_we & ~wr_err;
+  assign mp_region_cfg_0_ecc_en_0_wd = reg_wdata[5];
+
   assign mp_region_cfg_0_base_0_we = addr_hit[14] & reg_we & ~wr_err;
   assign mp_region_cfg_0_base_0_wd = reg_wdata[16:8];
 
@@ -6496,6 +7224,9 @@ module flash_ctrl_reg_top (
 
   assign mp_region_cfg_1_scramble_en_1_we = addr_hit[15] & reg_we & ~wr_err;
   assign mp_region_cfg_1_scramble_en_1_wd = reg_wdata[4];
+
+  assign mp_region_cfg_1_ecc_en_1_we = addr_hit[15] & reg_we & ~wr_err;
+  assign mp_region_cfg_1_ecc_en_1_wd = reg_wdata[5];
 
   assign mp_region_cfg_1_base_1_we = addr_hit[15] & reg_we & ~wr_err;
   assign mp_region_cfg_1_base_1_wd = reg_wdata[16:8];
@@ -6518,6 +7249,9 @@ module flash_ctrl_reg_top (
   assign mp_region_cfg_2_scramble_en_2_we = addr_hit[16] & reg_we & ~wr_err;
   assign mp_region_cfg_2_scramble_en_2_wd = reg_wdata[4];
 
+  assign mp_region_cfg_2_ecc_en_2_we = addr_hit[16] & reg_we & ~wr_err;
+  assign mp_region_cfg_2_ecc_en_2_wd = reg_wdata[5];
+
   assign mp_region_cfg_2_base_2_we = addr_hit[16] & reg_we & ~wr_err;
   assign mp_region_cfg_2_base_2_wd = reg_wdata[16:8];
 
@@ -6538,6 +7272,9 @@ module flash_ctrl_reg_top (
 
   assign mp_region_cfg_3_scramble_en_3_we = addr_hit[17] & reg_we & ~wr_err;
   assign mp_region_cfg_3_scramble_en_3_wd = reg_wdata[4];
+
+  assign mp_region_cfg_3_ecc_en_3_we = addr_hit[17] & reg_we & ~wr_err;
+  assign mp_region_cfg_3_ecc_en_3_wd = reg_wdata[5];
 
   assign mp_region_cfg_3_base_3_we = addr_hit[17] & reg_we & ~wr_err;
   assign mp_region_cfg_3_base_3_wd = reg_wdata[16:8];
@@ -6560,6 +7297,9 @@ module flash_ctrl_reg_top (
   assign mp_region_cfg_4_scramble_en_4_we = addr_hit[18] & reg_we & ~wr_err;
   assign mp_region_cfg_4_scramble_en_4_wd = reg_wdata[4];
 
+  assign mp_region_cfg_4_ecc_en_4_we = addr_hit[18] & reg_we & ~wr_err;
+  assign mp_region_cfg_4_ecc_en_4_wd = reg_wdata[5];
+
   assign mp_region_cfg_4_base_4_we = addr_hit[18] & reg_we & ~wr_err;
   assign mp_region_cfg_4_base_4_wd = reg_wdata[16:8];
 
@@ -6580,6 +7320,9 @@ module flash_ctrl_reg_top (
 
   assign mp_region_cfg_5_scramble_en_5_we = addr_hit[19] & reg_we & ~wr_err;
   assign mp_region_cfg_5_scramble_en_5_wd = reg_wdata[4];
+
+  assign mp_region_cfg_5_ecc_en_5_we = addr_hit[19] & reg_we & ~wr_err;
+  assign mp_region_cfg_5_ecc_en_5_wd = reg_wdata[5];
 
   assign mp_region_cfg_5_base_5_we = addr_hit[19] & reg_we & ~wr_err;
   assign mp_region_cfg_5_base_5_wd = reg_wdata[16:8];
@@ -6602,6 +7345,9 @@ module flash_ctrl_reg_top (
   assign mp_region_cfg_6_scramble_en_6_we = addr_hit[20] & reg_we & ~wr_err;
   assign mp_region_cfg_6_scramble_en_6_wd = reg_wdata[4];
 
+  assign mp_region_cfg_6_ecc_en_6_we = addr_hit[20] & reg_we & ~wr_err;
+  assign mp_region_cfg_6_ecc_en_6_wd = reg_wdata[5];
+
   assign mp_region_cfg_6_base_6_we = addr_hit[20] & reg_we & ~wr_err;
   assign mp_region_cfg_6_base_6_wd = reg_wdata[16:8];
 
@@ -6623,6 +7369,9 @@ module flash_ctrl_reg_top (
   assign mp_region_cfg_7_scramble_en_7_we = addr_hit[21] & reg_we & ~wr_err;
   assign mp_region_cfg_7_scramble_en_7_wd = reg_wdata[4];
 
+  assign mp_region_cfg_7_ecc_en_7_we = addr_hit[21] & reg_we & ~wr_err;
+  assign mp_region_cfg_7_ecc_en_7_wd = reg_wdata[5];
+
   assign mp_region_cfg_7_base_7_we = addr_hit[21] & reg_we & ~wr_err;
   assign mp_region_cfg_7_base_7_wd = reg_wdata[16:8];
 
@@ -6640,6 +7389,9 @@ module flash_ctrl_reg_top (
 
   assign default_region_scramble_en_we = addr_hit[22] & reg_we & ~wr_err;
   assign default_region_scramble_en_wd = reg_wdata[3];
+
+  assign default_region_ecc_en_we = addr_hit[22] & reg_we & ~wr_err;
+  assign default_region_ecc_en_wd = reg_wdata[4];
 
   assign bank0_info0_regwen_0_we = addr_hit[23] & reg_we & ~wr_err;
   assign bank0_info0_regwen_0_wd = reg_wdata[0];
@@ -6668,6 +7420,9 @@ module flash_ctrl_reg_top (
   assign bank0_info0_page_cfg_0_scramble_en_0_we = addr_hit[27] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
 
+  assign bank0_info0_page_cfg_0_ecc_en_0_we = addr_hit[27] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_0_ecc_en_0_wd = reg_wdata[5];
+
   assign bank0_info0_page_cfg_1_en_1_we = addr_hit[28] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_1_en_1_wd = reg_wdata[0];
 
@@ -6682,6 +7437,9 @@ module flash_ctrl_reg_top (
 
   assign bank0_info0_page_cfg_1_scramble_en_1_we = addr_hit[28] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
+
+  assign bank0_info0_page_cfg_1_ecc_en_1_we = addr_hit[28] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_1_ecc_en_1_wd = reg_wdata[5];
 
   assign bank0_info0_page_cfg_2_en_2_we = addr_hit[29] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_2_en_2_wd = reg_wdata[0];
@@ -6698,6 +7456,9 @@ module flash_ctrl_reg_top (
   assign bank0_info0_page_cfg_2_scramble_en_2_we = addr_hit[29] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_2_scramble_en_2_wd = reg_wdata[4];
 
+  assign bank0_info0_page_cfg_2_ecc_en_2_we = addr_hit[29] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_2_ecc_en_2_wd = reg_wdata[5];
+
   assign bank0_info0_page_cfg_3_en_3_we = addr_hit[30] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_3_en_3_wd = reg_wdata[0];
 
@@ -6712,6 +7473,9 @@ module flash_ctrl_reg_top (
 
   assign bank0_info0_page_cfg_3_scramble_en_3_we = addr_hit[30] & reg_we & ~wr_err;
   assign bank0_info0_page_cfg_3_scramble_en_3_wd = reg_wdata[4];
+
+  assign bank0_info0_page_cfg_3_ecc_en_3_we = addr_hit[30] & reg_we & ~wr_err;
+  assign bank0_info0_page_cfg_3_ecc_en_3_wd = reg_wdata[5];
 
   assign bank0_info1_regwen_0_we = addr_hit[31] & reg_we & ~wr_err;
   assign bank0_info1_regwen_0_wd = reg_wdata[0];
@@ -6740,6 +7504,9 @@ module flash_ctrl_reg_top (
   assign bank0_info1_page_cfg_0_scramble_en_0_we = addr_hit[35] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
 
+  assign bank0_info1_page_cfg_0_ecc_en_0_we = addr_hit[35] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_0_ecc_en_0_wd = reg_wdata[5];
+
   assign bank0_info1_page_cfg_1_en_1_we = addr_hit[36] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_1_en_1_wd = reg_wdata[0];
 
@@ -6754,6 +7521,9 @@ module flash_ctrl_reg_top (
 
   assign bank0_info1_page_cfg_1_scramble_en_1_we = addr_hit[36] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
+
+  assign bank0_info1_page_cfg_1_ecc_en_1_we = addr_hit[36] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_1_ecc_en_1_wd = reg_wdata[5];
 
   assign bank0_info1_page_cfg_2_en_2_we = addr_hit[37] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_2_en_2_wd = reg_wdata[0];
@@ -6770,6 +7540,9 @@ module flash_ctrl_reg_top (
   assign bank0_info1_page_cfg_2_scramble_en_2_we = addr_hit[37] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_2_scramble_en_2_wd = reg_wdata[4];
 
+  assign bank0_info1_page_cfg_2_ecc_en_2_we = addr_hit[37] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_2_ecc_en_2_wd = reg_wdata[5];
+
   assign bank0_info1_page_cfg_3_en_3_we = addr_hit[38] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_3_en_3_wd = reg_wdata[0];
 
@@ -6784,6 +7557,9 @@ module flash_ctrl_reg_top (
 
   assign bank0_info1_page_cfg_3_scramble_en_3_we = addr_hit[38] & reg_we & ~wr_err;
   assign bank0_info1_page_cfg_3_scramble_en_3_wd = reg_wdata[4];
+
+  assign bank0_info1_page_cfg_3_ecc_en_3_we = addr_hit[38] & reg_we & ~wr_err;
+  assign bank0_info1_page_cfg_3_ecc_en_3_wd = reg_wdata[5];
 
   assign bank1_info0_regwen_0_we = addr_hit[39] & reg_we & ~wr_err;
   assign bank1_info0_regwen_0_wd = reg_wdata[0];
@@ -6812,6 +7588,9 @@ module flash_ctrl_reg_top (
   assign bank1_info0_page_cfg_0_scramble_en_0_we = addr_hit[43] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
 
+  assign bank1_info0_page_cfg_0_ecc_en_0_we = addr_hit[43] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_0_ecc_en_0_wd = reg_wdata[5];
+
   assign bank1_info0_page_cfg_1_en_1_we = addr_hit[44] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_1_en_1_wd = reg_wdata[0];
 
@@ -6826,6 +7605,9 @@ module flash_ctrl_reg_top (
 
   assign bank1_info0_page_cfg_1_scramble_en_1_we = addr_hit[44] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
+
+  assign bank1_info0_page_cfg_1_ecc_en_1_we = addr_hit[44] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_1_ecc_en_1_wd = reg_wdata[5];
 
   assign bank1_info0_page_cfg_2_en_2_we = addr_hit[45] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_2_en_2_wd = reg_wdata[0];
@@ -6842,6 +7624,9 @@ module flash_ctrl_reg_top (
   assign bank1_info0_page_cfg_2_scramble_en_2_we = addr_hit[45] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_2_scramble_en_2_wd = reg_wdata[4];
 
+  assign bank1_info0_page_cfg_2_ecc_en_2_we = addr_hit[45] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_2_ecc_en_2_wd = reg_wdata[5];
+
   assign bank1_info0_page_cfg_3_en_3_we = addr_hit[46] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_3_en_3_wd = reg_wdata[0];
 
@@ -6856,6 +7641,9 @@ module flash_ctrl_reg_top (
 
   assign bank1_info0_page_cfg_3_scramble_en_3_we = addr_hit[46] & reg_we & ~wr_err;
   assign bank1_info0_page_cfg_3_scramble_en_3_wd = reg_wdata[4];
+
+  assign bank1_info0_page_cfg_3_ecc_en_3_we = addr_hit[46] & reg_we & ~wr_err;
+  assign bank1_info0_page_cfg_3_ecc_en_3_wd = reg_wdata[5];
 
   assign bank1_info1_regwen_0_we = addr_hit[47] & reg_we & ~wr_err;
   assign bank1_info1_regwen_0_wd = reg_wdata[0];
@@ -6884,6 +7672,9 @@ module flash_ctrl_reg_top (
   assign bank1_info1_page_cfg_0_scramble_en_0_we = addr_hit[51] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
 
+  assign bank1_info1_page_cfg_0_ecc_en_0_we = addr_hit[51] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_0_ecc_en_0_wd = reg_wdata[5];
+
   assign bank1_info1_page_cfg_1_en_1_we = addr_hit[52] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_1_en_1_wd = reg_wdata[0];
 
@@ -6898,6 +7689,9 @@ module flash_ctrl_reg_top (
 
   assign bank1_info1_page_cfg_1_scramble_en_1_we = addr_hit[52] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
+
+  assign bank1_info1_page_cfg_1_ecc_en_1_we = addr_hit[52] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_1_ecc_en_1_wd = reg_wdata[5];
 
   assign bank1_info1_page_cfg_2_en_2_we = addr_hit[53] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_2_en_2_wd = reg_wdata[0];
@@ -6914,6 +7708,9 @@ module flash_ctrl_reg_top (
   assign bank1_info1_page_cfg_2_scramble_en_2_we = addr_hit[53] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_2_scramble_en_2_wd = reg_wdata[4];
 
+  assign bank1_info1_page_cfg_2_ecc_en_2_we = addr_hit[53] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_2_ecc_en_2_wd = reg_wdata[5];
+
   assign bank1_info1_page_cfg_3_en_3_we = addr_hit[54] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_3_en_3_wd = reg_wdata[0];
 
@@ -6928,6 +7725,9 @@ module flash_ctrl_reg_top (
 
   assign bank1_info1_page_cfg_3_scramble_en_3_we = addr_hit[54] & reg_we & ~wr_err;
   assign bank1_info1_page_cfg_3_scramble_en_3_wd = reg_wdata[4];
+
+  assign bank1_info1_page_cfg_3_ecc_en_3_we = addr_hit[54] & reg_we & ~wr_err;
+  assign bank1_info1_page_cfg_3_ecc_en_3_wd = reg_wdata[5];
 
   assign bank_cfg_regwen_we = addr_hit[55] & reg_we & ~wr_err;
   assign bank_cfg_regwen_wd = reg_wdata[0];
@@ -7052,6 +7852,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = mp_region_cfg_0_prog_en_0_qs;
         reg_rdata_next[3] = mp_region_cfg_0_erase_en_0_qs;
         reg_rdata_next[4] = mp_region_cfg_0_scramble_en_0_qs;
+        reg_rdata_next[5] = mp_region_cfg_0_ecc_en_0_qs;
         reg_rdata_next[16:8] = mp_region_cfg_0_base_0_qs;
         reg_rdata_next[29:20] = mp_region_cfg_0_size_0_qs;
       end
@@ -7062,6 +7863,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = mp_region_cfg_1_prog_en_1_qs;
         reg_rdata_next[3] = mp_region_cfg_1_erase_en_1_qs;
         reg_rdata_next[4] = mp_region_cfg_1_scramble_en_1_qs;
+        reg_rdata_next[5] = mp_region_cfg_1_ecc_en_1_qs;
         reg_rdata_next[16:8] = mp_region_cfg_1_base_1_qs;
         reg_rdata_next[29:20] = mp_region_cfg_1_size_1_qs;
       end
@@ -7072,6 +7874,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = mp_region_cfg_2_prog_en_2_qs;
         reg_rdata_next[3] = mp_region_cfg_2_erase_en_2_qs;
         reg_rdata_next[4] = mp_region_cfg_2_scramble_en_2_qs;
+        reg_rdata_next[5] = mp_region_cfg_2_ecc_en_2_qs;
         reg_rdata_next[16:8] = mp_region_cfg_2_base_2_qs;
         reg_rdata_next[29:20] = mp_region_cfg_2_size_2_qs;
       end
@@ -7082,6 +7885,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = mp_region_cfg_3_prog_en_3_qs;
         reg_rdata_next[3] = mp_region_cfg_3_erase_en_3_qs;
         reg_rdata_next[4] = mp_region_cfg_3_scramble_en_3_qs;
+        reg_rdata_next[5] = mp_region_cfg_3_ecc_en_3_qs;
         reg_rdata_next[16:8] = mp_region_cfg_3_base_3_qs;
         reg_rdata_next[29:20] = mp_region_cfg_3_size_3_qs;
       end
@@ -7092,6 +7896,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = mp_region_cfg_4_prog_en_4_qs;
         reg_rdata_next[3] = mp_region_cfg_4_erase_en_4_qs;
         reg_rdata_next[4] = mp_region_cfg_4_scramble_en_4_qs;
+        reg_rdata_next[5] = mp_region_cfg_4_ecc_en_4_qs;
         reg_rdata_next[16:8] = mp_region_cfg_4_base_4_qs;
         reg_rdata_next[29:20] = mp_region_cfg_4_size_4_qs;
       end
@@ -7102,6 +7907,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = mp_region_cfg_5_prog_en_5_qs;
         reg_rdata_next[3] = mp_region_cfg_5_erase_en_5_qs;
         reg_rdata_next[4] = mp_region_cfg_5_scramble_en_5_qs;
+        reg_rdata_next[5] = mp_region_cfg_5_ecc_en_5_qs;
         reg_rdata_next[16:8] = mp_region_cfg_5_base_5_qs;
         reg_rdata_next[29:20] = mp_region_cfg_5_size_5_qs;
       end
@@ -7112,6 +7918,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = mp_region_cfg_6_prog_en_6_qs;
         reg_rdata_next[3] = mp_region_cfg_6_erase_en_6_qs;
         reg_rdata_next[4] = mp_region_cfg_6_scramble_en_6_qs;
+        reg_rdata_next[5] = mp_region_cfg_6_ecc_en_6_qs;
         reg_rdata_next[16:8] = mp_region_cfg_6_base_6_qs;
         reg_rdata_next[29:20] = mp_region_cfg_6_size_6_qs;
       end
@@ -7122,6 +7929,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = mp_region_cfg_7_prog_en_7_qs;
         reg_rdata_next[3] = mp_region_cfg_7_erase_en_7_qs;
         reg_rdata_next[4] = mp_region_cfg_7_scramble_en_7_qs;
+        reg_rdata_next[5] = mp_region_cfg_7_ecc_en_7_qs;
         reg_rdata_next[16:8] = mp_region_cfg_7_base_7_qs;
         reg_rdata_next[29:20] = mp_region_cfg_7_size_7_qs;
       end
@@ -7131,6 +7939,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[1] = default_region_prog_en_qs;
         reg_rdata_next[2] = default_region_erase_en_qs;
         reg_rdata_next[3] = default_region_scramble_en_qs;
+        reg_rdata_next[4] = default_region_ecc_en_qs;
       end
 
       addr_hit[23]: begin
@@ -7155,6 +7964,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = bank0_info0_page_cfg_0_prog_en_0_qs;
         reg_rdata_next[3] = bank0_info0_page_cfg_0_erase_en_0_qs;
         reg_rdata_next[4] = bank0_info0_page_cfg_0_scramble_en_0_qs;
+        reg_rdata_next[5] = bank0_info0_page_cfg_0_ecc_en_0_qs;
       end
 
       addr_hit[28]: begin
@@ -7163,6 +7973,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = bank0_info0_page_cfg_1_prog_en_1_qs;
         reg_rdata_next[3] = bank0_info0_page_cfg_1_erase_en_1_qs;
         reg_rdata_next[4] = bank0_info0_page_cfg_1_scramble_en_1_qs;
+        reg_rdata_next[5] = bank0_info0_page_cfg_1_ecc_en_1_qs;
       end
 
       addr_hit[29]: begin
@@ -7171,6 +7982,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = bank0_info0_page_cfg_2_prog_en_2_qs;
         reg_rdata_next[3] = bank0_info0_page_cfg_2_erase_en_2_qs;
         reg_rdata_next[4] = bank0_info0_page_cfg_2_scramble_en_2_qs;
+        reg_rdata_next[5] = bank0_info0_page_cfg_2_ecc_en_2_qs;
       end
 
       addr_hit[30]: begin
@@ -7179,6 +7991,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = bank0_info0_page_cfg_3_prog_en_3_qs;
         reg_rdata_next[3] = bank0_info0_page_cfg_3_erase_en_3_qs;
         reg_rdata_next[4] = bank0_info0_page_cfg_3_scramble_en_3_qs;
+        reg_rdata_next[5] = bank0_info0_page_cfg_3_ecc_en_3_qs;
       end
 
       addr_hit[31]: begin
@@ -7203,6 +8016,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = bank0_info1_page_cfg_0_prog_en_0_qs;
         reg_rdata_next[3] = bank0_info1_page_cfg_0_erase_en_0_qs;
         reg_rdata_next[4] = bank0_info1_page_cfg_0_scramble_en_0_qs;
+        reg_rdata_next[5] = bank0_info1_page_cfg_0_ecc_en_0_qs;
       end
 
       addr_hit[36]: begin
@@ -7211,6 +8025,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = bank0_info1_page_cfg_1_prog_en_1_qs;
         reg_rdata_next[3] = bank0_info1_page_cfg_1_erase_en_1_qs;
         reg_rdata_next[4] = bank0_info1_page_cfg_1_scramble_en_1_qs;
+        reg_rdata_next[5] = bank0_info1_page_cfg_1_ecc_en_1_qs;
       end
 
       addr_hit[37]: begin
@@ -7219,6 +8034,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = bank0_info1_page_cfg_2_prog_en_2_qs;
         reg_rdata_next[3] = bank0_info1_page_cfg_2_erase_en_2_qs;
         reg_rdata_next[4] = bank0_info1_page_cfg_2_scramble_en_2_qs;
+        reg_rdata_next[5] = bank0_info1_page_cfg_2_ecc_en_2_qs;
       end
 
       addr_hit[38]: begin
@@ -7227,6 +8043,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = bank0_info1_page_cfg_3_prog_en_3_qs;
         reg_rdata_next[3] = bank0_info1_page_cfg_3_erase_en_3_qs;
         reg_rdata_next[4] = bank0_info1_page_cfg_3_scramble_en_3_qs;
+        reg_rdata_next[5] = bank0_info1_page_cfg_3_ecc_en_3_qs;
       end
 
       addr_hit[39]: begin
@@ -7251,6 +8068,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = bank1_info0_page_cfg_0_prog_en_0_qs;
         reg_rdata_next[3] = bank1_info0_page_cfg_0_erase_en_0_qs;
         reg_rdata_next[4] = bank1_info0_page_cfg_0_scramble_en_0_qs;
+        reg_rdata_next[5] = bank1_info0_page_cfg_0_ecc_en_0_qs;
       end
 
       addr_hit[44]: begin
@@ -7259,6 +8077,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = bank1_info0_page_cfg_1_prog_en_1_qs;
         reg_rdata_next[3] = bank1_info0_page_cfg_1_erase_en_1_qs;
         reg_rdata_next[4] = bank1_info0_page_cfg_1_scramble_en_1_qs;
+        reg_rdata_next[5] = bank1_info0_page_cfg_1_ecc_en_1_qs;
       end
 
       addr_hit[45]: begin
@@ -7267,6 +8086,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = bank1_info0_page_cfg_2_prog_en_2_qs;
         reg_rdata_next[3] = bank1_info0_page_cfg_2_erase_en_2_qs;
         reg_rdata_next[4] = bank1_info0_page_cfg_2_scramble_en_2_qs;
+        reg_rdata_next[5] = bank1_info0_page_cfg_2_ecc_en_2_qs;
       end
 
       addr_hit[46]: begin
@@ -7275,6 +8095,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = bank1_info0_page_cfg_3_prog_en_3_qs;
         reg_rdata_next[3] = bank1_info0_page_cfg_3_erase_en_3_qs;
         reg_rdata_next[4] = bank1_info0_page_cfg_3_scramble_en_3_qs;
+        reg_rdata_next[5] = bank1_info0_page_cfg_3_ecc_en_3_qs;
       end
 
       addr_hit[47]: begin
@@ -7299,6 +8120,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = bank1_info1_page_cfg_0_prog_en_0_qs;
         reg_rdata_next[3] = bank1_info1_page_cfg_0_erase_en_0_qs;
         reg_rdata_next[4] = bank1_info1_page_cfg_0_scramble_en_0_qs;
+        reg_rdata_next[5] = bank1_info1_page_cfg_0_ecc_en_0_qs;
       end
 
       addr_hit[52]: begin
@@ -7307,6 +8129,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = bank1_info1_page_cfg_1_prog_en_1_qs;
         reg_rdata_next[3] = bank1_info1_page_cfg_1_erase_en_1_qs;
         reg_rdata_next[4] = bank1_info1_page_cfg_1_scramble_en_1_qs;
+        reg_rdata_next[5] = bank1_info1_page_cfg_1_ecc_en_1_qs;
       end
 
       addr_hit[53]: begin
@@ -7315,6 +8138,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = bank1_info1_page_cfg_2_prog_en_2_qs;
         reg_rdata_next[3] = bank1_info1_page_cfg_2_erase_en_2_qs;
         reg_rdata_next[4] = bank1_info1_page_cfg_2_scramble_en_2_qs;
+        reg_rdata_next[5] = bank1_info1_page_cfg_2_ecc_en_2_qs;
       end
 
       addr_hit[54]: begin
@@ -7323,6 +8147,7 @@ module flash_ctrl_reg_top (
         reg_rdata_next[2] = bank1_info1_page_cfg_3_prog_en_3_qs;
         reg_rdata_next[3] = bank1_info1_page_cfg_3_erase_en_3_qs;
         reg_rdata_next[4] = bank1_info1_page_cfg_3_scramble_en_3_qs;
+        reg_rdata_next[5] = bank1_info1_page_cfg_3_ecc_en_3_qs;
       end
 
       addr_hit[55]: begin


### PR DESCRIPTION
Allow scramble and ECC to be enabled separately.

This allows for high endurance non-secret data use cases.
Specifically, this allows the metadata for file systems to exist in at least 3 states -> all 1's, intermediate states (with overlapping ECCs) and all 0's. 

The docs have not been updated to reflect this change. 