### PR TITLE
[otbn] Support for an unbounded x1 call stack in otbn-rig

### DIFF
--- a/hw/ip/otbn/util/rig/gens/jump.py
+++ b/hw/ip/otbn/util/rig/gens/jump.py
@@ -143,7 +143,10 @@ class Jump(SnippetGen):
         # set that explicitly here.
         link_reg_optype = prog_insn.insn.operands[0].op_type
         assert isinstance(link_reg_optype, RegOperandType)
-        model.write_reg(link_reg_optype.reg_type, link_reg_idx, model.pc + 4)
+        model.write_reg(link_reg_optype.reg_type,
+                        link_reg_idx,
+                        model.pc + 4,
+                        True)
 
         # And update the PC, which is now tgt
         model.pc = new_pc


### PR DESCRIPTION
The random instruction generator now avoids reading (and popping) from
the call stack so many times that there's no architectural value.
Doing so will trigger an alert (not currently handled in either the
ISS or the RTL), so we don't want to do it by accident.
