### PR TITLE
[sw] Add Custom Target Dependencies

### DIFF
--- a/sw/device/benchmarks/coremark/meson.build
+++ b/sw/device/benchmarks/coremark/meson.build
@@ -38,7 +38,8 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
 
   coremark_top_earlgrey_embedded = custom_target(
     'coremark_top_earlgrey_' + device_name,
-    command: make_embedded_target,
+    command: make_embedded_target_command,
+    depend_files: [make_embedded_target_depend_files,],
     input: coremark_top_earlgrey_elf,
     output: make_embedded_target_outputs,
     build_by_default: true,
@@ -51,6 +52,7 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
       coremark_top_earlgrey_elf,
       coremark_top_earlgrey_embedded,
     ],
+    depend_files: [export_target_depend_files,],
     output: 'coremark_top_earlgrey_export_' + device_name,
     build_always_stale: true,
     build_by_default: true,

--- a/sw/device/boot_rom/meson.build
+++ b/sw/device/boot_rom/meson.build
@@ -9,10 +9,13 @@ chip_info_h = declare_dependency(
     output: 'chip_info.h',
     command: [
       prog_python,
-      '@SOURCE_DIR@/util/rom_chip_info.py',
+      meson.source_root() / 'util/rom_chip_info.py',
       '--outdir', '@OUTDIR@',
       '--ot_version', ot_version,
-    ]
+    ],
+    depend_files: [
+      meson.source_root() / 'util/rom_chip_info.py',
+    ],
   )],
 )
 
@@ -60,7 +63,8 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
 
   boot_rom_embedded = custom_target(
     'boot_rom_' + device_name,
-    command: make_embedded_target,
+    command: make_embedded_target_command,
+    depend_files: [make_embedded_target_depend_files,],
     input: boot_rom_elf,
     output: make_embedded_target_outputs,
     build_by_default: true,
@@ -69,6 +73,7 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
   custom_target(
     'boot_rom_export_' + device_name,
     command: export_target_command,
+    depend_files: [export_target_depend_files,],
     input: [boot_rom_elf, boot_rom_embedded],
     output: 'boot_rom_export_' + device_name,
     build_always_stale: true,

--- a/sw/device/examples/hello_usbdev/meson.build
+++ b/sw/device/examples/hello_usbdev/meson.build
@@ -29,7 +29,8 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
 
   hello_usbdev_embedded = custom_target(
     'hello_usbdev_' + device_name,
-    command: make_embedded_target,
+    command: make_embedded_target_command,
+    depend_files: [make_embedded_target_depend_files,],
     input: hello_usbdev_elf,
     output: make_embedded_target_outputs,
     build_by_default: true,
@@ -38,6 +39,7 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
   custom_target(
     'hello_usbdev_export_' + device_name,
     command: export_target_command,
+    depend_files: [export_target_depend_files,],
     input: [hello_usbdev_elf, hello_usbdev_embedded],
     output: 'hello_usbdev_export_' + device_name,
     build_always_stale: true,

--- a/sw/device/examples/hello_world/meson.build
+++ b/sw/device/examples/hello_world/meson.build
@@ -26,7 +26,8 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
 
   hello_world_embedded = custom_target(
     'hello_world_' + device_name,
-    command: make_embedded_target,
+    command: make_embedded_target_command,
+    depend_files: [make_embedded_target_depend_files,],
     input: hello_world_elf,
     output: make_embedded_target_outputs,
     build_by_default: true,
@@ -35,6 +36,7 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
   custom_target(
     'hello_world_export_' + device_name,
     command: export_target_command,
+    depend_files: [export_target_depend_files,],
     input: [hello_world_elf, hello_world_embedded],
     output: 'hello_world_export_' + device_name,
     build_always_stale: true,

--- a/sw/device/mask_rom/meson.build
+++ b/sw/device/mask_rom/meson.build
@@ -33,7 +33,8 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
 
   mask_rom_embedded = custom_target(
     'mask_rom_' + device_name,
-    command: make_embedded_target,
+    command: make_embedded_target_command,
+    depend_files: [make_embedded_target_depend_files,],
     input: mask_rom_elf,
     output: make_embedded_target_outputs,
     build_by_default: true,
@@ -42,6 +43,7 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
   custom_target(
     'mask_rom_export_' + device_name,
     command: export_target_command,
+    depend_files: [export_target_depend_files,],
     input: [mask_rom_elf, mask_rom_embedded],
     output: 'mask_rom_export_' + device_name,
     build_always_stale: true,

--- a/sw/device/meson.build
+++ b/sw/device/meson.build
@@ -10,14 +10,18 @@ subdir('exts')
 #
 # These definitions should only be available to directories which define executables.
 make_embedded_target_outputs = ['@BASENAME@.bin', '@BASENAME@.dis', '@BASENAME@.32.vmem', '@BASENAME@.64.vmem']
-make_embedded_target = [
-  prog_python, meson.source_root() / 'util/embedded_target.py',
+make_embedded_target_command = [
+  prog_python,
+  meson.source_root() / 'util/embedded_target.py',
   '--objcopy', prog_objcopy,
   '--srec_cat', prog_srec_cat,
   '--objdump', prog_objdump,
   '--input', '@INPUT@',
   '--basename', '@BASENAME@',
   '--outdir', '@OUTDIR@',
+]
+make_embedded_target_depend_files = [
+  meson.source_root() / 'util/embedded_target.py',
 ]
 
 embedded_target_extra_link_args = [

--- a/sw/device/riscv_compliance_support/meson.build
+++ b/sw/device/riscv_compliance_support/meson.build
@@ -29,6 +29,7 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
   custom_target(
     'riscv_compliance_support_export_' + device_name,
     command: export_target_command,
+    depend_files: [export_target_depend_files,],
     input: [riscv_compliance_support],
     output: 'riscv_compliance_support_export_' + device_name,
     build_always_stale: true,

--- a/sw/device/rom_exts/meson.build
+++ b/sw/device/rom_exts/meson.build
@@ -46,6 +46,7 @@ rom_exts_manifest_offsets_header = custom_target(
   depend_files: [
     'manifest.h.tpl',
     'manifest.hjson',
+    meson.source_root() / 'util/rom-ext-manifest-generator.py',
   ],
   command: [
     prog_python,
@@ -91,7 +92,8 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
 
     rom_ext_embedded = custom_target(
       slot + '_' + device_name,
-      command: make_embedded_target,
+      command: make_embedded_target_command,
+      depend_files: [make_embedded_target_depend_files,],
       input: rom_ext_elf,
       output: make_embedded_target_outputs,
       build_by_default: true,
@@ -100,6 +102,7 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
     custom_target(
       slot + '_export_' + device_name,
       command: export_target_command,
+      depend_files: [export_target_depend_files,],
       input: [rom_ext_elf, rom_ext_embedded],
       output: slot + '_export_' + device_name,
       build_always_stale: true,

--- a/sw/device/sca/aes_serial/meson.build
+++ b/sw/device/sca/aes_serial/meson.build
@@ -25,7 +25,8 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
 
   aes_serial_embedded = custom_target(
     'aes_serial_' + device_name,
-    command: make_embedded_target,
+    command: make_embedded_target_command,
+    depend_files: [make_embedded_target_depend_files,],
     input: aes_serial_elf,
     output: make_embedded_target_outputs,
     build_by_default: true,
@@ -34,6 +35,7 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
   custom_target(
     'aes_serial_export_' + device_name,
     command: export_target_command,
+    depend_files: [export_target_depend_files,],
     input: [aes_serial_elf, aes_serial_embedded],
     output: 'aes_serial_export_' + device_name,
     build_always_stale: true,

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -154,7 +154,8 @@ foreach sw_test_name, sw_test_info : sw_tests
 
     sw_test_embedded = custom_target(
       sw_test_name + '_' + device_name,
-      command: make_embedded_target,
+      command: make_embedded_target_command,
+      depend_files: [make_embedded_target_depend_files,],
       input: sw_test_elf,
       output: make_embedded_target_outputs,
       build_by_default: true,
@@ -179,6 +180,7 @@ foreach sw_test_name, sw_test_info : sw_tests
     custom_target(
       sw_test_name + '_export_' + device_name,
       command: export_target_command,
+      depend_files: [export_target_depend_files,],
       input: [sw_test_elf, sw_test_embedded, sw_test_dv_frames],
       output: sw_test_name + '_export_' + device_name,
       build_always_stale: true,
@@ -209,7 +211,8 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
 
   crt_test_embedded = custom_target(
     'crt_test_' + device_name,
-    command: make_embedded_target,
+    command: make_embedded_target_command,
+    depend_files: [make_embedded_target_depend_files,],
     input: crt_test_elf,
     output: make_embedded_target_outputs,
     build_by_default: true,
@@ -218,6 +221,7 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
   custom_target(
     'crt_test_export_' + device_name,
     command: export_target_command,
+    depend_files: [export_target_depend_files,],
     input: [crt_test_elf, crt_test_embedded],
     output: 'crt_test_export_' + device_name,
     build_always_stale: true,

--- a/sw/device/tock/meson.build
+++ b/sw/device/tock/meson.build
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-cargo = find_program('cargo', required: false)
+cargo = find_program('cargo', required: false, disabler: true)
 
 target = 'riscv32imc-unknown-none-elf'
 build_type = 'release'
@@ -33,6 +33,7 @@ tock_raw = custom_target(
   'tock_raw',
   command: [
     build_tock_cmd,
+    cargo,
     target,
     build_type,
     manifest_path,
@@ -41,6 +42,11 @@ tock_raw = custom_target(
     meson.source_root(),
     meson.build_root(),
     rust_flags,
+  ],
+  depend_files: [
+    build_tock_cmd,
+    manifest_path,
+    toolchain_file,
   ],
   output: target,
   console: true,
@@ -68,7 +74,6 @@ tock_bin = custom_target(
     '@INPUT@',
     '@OUTPUT@'
   ],
-  depends: tock_elf,
   input: tock_elf,
   output: 'opentitan.bin',
   build_always_stale: true,
@@ -78,8 +83,8 @@ tock_bin = custom_target(
 custom_target(
   'tock_export',
   command: export_target_command,
+  depend_files: [export_target_depend_files,],
   input: [tock_elf, tock_bin],
-  depends: [tock_elf, tock_bin],
   output: 'tock',
   build_always_stale: true,
   build_by_default: false,

--- a/sw/host/spiflash/meson.build
+++ b/sw/host/spiflash/meson.build
@@ -22,6 +22,7 @@ custom_target(
   'spiflash_export',
   output: 'spiflash_export',
   command: export_target_command,
+  depend_files: [export_target_depend_files,],
   input: spiflash_bin,
   build_always_stale: true,
   build_by_default: true,

--- a/sw/meson.build
+++ b/sw/meson.build
@@ -10,6 +10,9 @@ export_target_command = [
   '@OUTDIR@',
   '@INPUT@',
 ]
+export_target_depend_files = [
+  meson.source_root() / 'util/export_target.sh',
+]
 
 subdir('vendor')
 subdir('otbn')

--- a/sw/otbn/meson.build
+++ b/sw/otbn/meson.build
@@ -59,6 +59,14 @@ otbn_build_command = [
   '@OUTDIR@',
   '@INPUT@',
 ]
+otbn_build_depend_files = [
+  prog_otbn_as,
+  prog_otbn_ld,
+  prog_objcopy.path(),
+  prog_as.path(),
+  prog_ld.path(),
+  prog_otbn_build,
+]
 
 # Note on variable naming below: Variables in meson are global, we hence prefix
 # all variables with sw_otbn as "our namespace". Variables which are meant to be
@@ -78,6 +86,7 @@ foreach sw_otbn__app_name, sw_otbn__app_sources : sw_otbn_sources
     input: sw_otbn__app_sources,
     output: sw_otbn__app_output_files,
     command: otbn_build_command,
+    depend_files: [otbn_build_depend_files,],
   )
 
   # A library containing the OTBN application in a form embeddable into device
@@ -104,6 +113,7 @@ foreach sw_otbn__app_name, sw_otbn__app_sources : sw_otbn_sources
   custom_target(
     'sw_otbn_app_export_' + sw_otbn__app_name,
     command: export_target_command,
+    depend_files: [export_target_depend_files,],
     input: [sw_otbn__target[1]],
     output: 'sw_otbn_app_export_' + sw_otbn__app_name,
     build_always_stale: true,

--- a/util/build_tock.sh
+++ b/util/build_tock.sh
@@ -9,22 +9,23 @@ set -e
 # solution to read the rust-toolchain file from the Tock repository and set the
 # RUSTFLAGS environment variable.
 
-TARGET="${1}"
-MODE="${2}"
-MANIFEST_PATH="${3}"
-TARGET_DIR="${4}"
-TOOLCHAIN_FILE="${5}"
-export MESON_SOURCE_ROOT="${6}"
-export MESON_BUILD_ROOT="${7}"
-export RUSTFLAGS="${8}"
+CARGO="${1}"
+TARGET="${2}"
+MODE="${3}"
+MANIFEST_PATH="${4}"
+TARGET_DIR="${5}"
+TOOLCHAIN_FILE="${6}"
+export MESON_SOURCE_ROOT="${7}"
+export MESON_BUILD_ROOT="${8}"
+export RUSTFLAGS="${9}"
 
 if [[ "${MODE}" == "release" ]]; then
-	RELEASE_FLAG="--release"
+  RELEASE_FLAG="--release"
 fi
 
-cargo +"$(cat ${TOOLCHAIN_FILE})" build \
-	--target "${TARGET}" \
-	--manifest-path "${MANIFEST_PATH}" \
-	--target-dir "${TARGET_DIR}" \
-	--features="${TOCK_FEATURES}" \
-	${RELEASE_FLAG}
+"${CARGO}" +"$(cat ${TOOLCHAIN_FILE})" build \
+  --target "${TARGET}" \
+  --manifest-path "${MANIFEST_PATH}" \
+  --target-dir "${TARGET_DIR}" \
+  --features="${TOCK_FEATURES}" \
+  ${RELEASE_FLAG}


### PR DESCRIPTION
Many of our meson custom_targets depend on scripts inside the repo, but we
give them absolute paths when invoking them (usually via
`meson.source_root() / 'util/script.py'`), because meson does not cope
with relative paths including `..`. This broadly works fine,
until one of those scripts is changed, at which point meson doesn't
always realise the script will have to be re-run.

This change adds `depend_files:` configuration for each custom target
that uses an in-tree script. Where we have abstracted the definition of
the custom target, this defines a `_depend_files` variable, to go with
the `_command` variable.

One other major change is that `cargo` is now a disabler, so if meson
does not find `cargo`, you will not get any targets that depend on
cargo -- we also now ensure that we use the `cargo` that meson found,
rather than any other one that might be on the user's path.

---

Turns out this doesn't solve the `manifest.h` problem at all, but is overall an improvement, if a low-priority one. I'll post the PR to solve the `manifest.h` issue in a moment.

