### PR TITLE
[sw/rom_ext] Add manifest.h to dependency sources

### DIFF
--- a/sw/device/rom_exts/meson.build
+++ b/sw/device/rom_exts/meson.build
@@ -66,7 +66,10 @@ rom_ext_manifest_parser = declare_dependency(
     dependencies: [
       sw_lib_mmio,
     ],
-  )
+  ),
+  sources: [
+    rom_exts_manifest_offsets_header,
+  ],
 )
 
 foreach device_name, device_lib : sw_lib_arch_core_devices


### PR DESCRIPTION
`sw/device/lib/rom_exts.h` is used in both the header and the
implementation of the ROM_EXT Manifest parser. In this case, we need to
declare that the generated manifest.h is also a dependency of any
libraries that depend on the parser, not just of the parser itself, as
any dependencies will use the library's header, which uses manifest.h.

This solves an intermitent build error we've been seeing with
manifest.h.