### PR TITLE
[otp_ctrl/rtl] digest calculation fix

### DIFF
--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_dai.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_dai.sv
@@ -234,8 +234,9 @@ module otp_ctrl_dai
       IdleSt: begin
         dai_idle_o  = 1'b1;
         if (dai_req_i) begin
-          // This clears previous (recoverable) errors.
+          // This clears previous (recoverable) and reset the counter.
           error_d = NoError;
+          cnt_clr = 1'b1;
           unique case (dai_cmd_i)
             DaiRead:  begin
               state_d = ReadSt;

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_buf.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_buf.sv
@@ -422,6 +422,7 @@ module otp_ctrl_part_buf
               state_d = IntegDigFinSt;
             end else begin
               state_d = IntegDigPadSt;
+              cnt_en = 1'b0;
             end
           end else begin
             // Trigger digest round in case this is the second block in a row.
@@ -543,7 +544,8 @@ module otp_ctrl_part_buf
   // Always transfer 64bit blocks.
   assign otp_size_o = OtpSizeWidth'(unsigned'(ScrmblBlockWidth / OtpWidth) - 1);
 
-  assign scrmbl_data_o = data_o[{cnt_q, {$clog2(ScrmblBlockWidth){1'b0}}} +: ScrmblBlockWidth];
+  logic [Info.size*8-1:0] data;
+  assign scrmbl_data_o = data[{cnt_q, {$clog2(ScrmblBlockWidth){1'b0}}} +: ScrmblBlockWidth];
 
   assign data_mux = (data_sel == ScrmblData) ? scrmbl_data_i : otp_rdata_i;
 
@@ -551,7 +553,6 @@ module otp_ctrl_part_buf
   // Buffer Regs //
   /////////////////
 
-  logic [Info.size*8-1:0] data;
   otp_ctrl_ecc_reg #(
     .Width ( ScrmblBlockWidth ),
     .Depth ( NumScrmblBlocks  )


### PR DESCRIPTION
According to issue #4199, this PR implemented fix suggested by Michael.
1. A typo in scrmbl_data_o assigment that causes the digest calculation
to load incorrect input.
2. Disable counter when padding the zeros to the last digest
calculation.

Signed-off-by: Cindy Chen <chencindy@google.com>