### PR TITLE
[otp_ctrl] Add prim_lc_sync to OTP

### DIFF
--- a/hw/ip/otp_ctrl/otp_ctrl.core
+++ b/hw/ip/otp_ctrl/otp_ctrl.core
@@ -14,6 +14,7 @@ filesets:
       - lowrisc:prim:ram_1p
       - lowrisc:prim:otp
       - lowrisc:prim:lfsr
+      - lowrisc:prim:lc_sync
       - lowrisc:prim:secded
       - lowrisc:ip:pwrmgr_pkg
     files:


### PR DESCRIPTION
This adds the lc sync primitive to the lc signals in OTP.

Signed-off-by: Michael Schaffner <msf@opentitan.org>