### PR TITLE
[edn/rtl] add parameter

### DIFF
--- a/hw/ip/edn/rtl/edn.sv
+++ b/hw/ip/edn/rtl/edn.sv
@@ -47,6 +47,7 @@ module edn import edn_pkg::*; #(
   );
 
   edn_core #(
+    .NumEndPoints(NumEndPoints),
     .BootInsCmd(BootInsCmd),
     .BootGenCmd(BootGenCmd)
   ) u_edn_core (


### PR DESCRIPTION
Missing a parameter on the top level instantiation of edn_core.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>