### PR TITLE
[dv] Fix tpyo

### DIFF
--- a/hw/dv/tools/dvsim/vcs.hjson
+++ b/hw/dv/tools/dvsim/vcs.hjson
@@ -31,8 +31,10 @@
                // otherwise. The double-escaped quotes are because this needs to go inside a string
                // that gets passed to Make (stripping one level of quotes), and then needs to
                // result in an argument with an embedded space (the other one).
-               "-CFLAGS \\\"--std=c++11 -fno-extended-identifiers\\\"",
-               // This is required for dpi_memutil.cc
+               "-CFLAGS \\\"--std=c99 -fno-extended-identifiers\\\"",
+               // C++11 standard is enforced for all sources, including the DPI-C constructs.
+               // TODO, may need to update to c++14 to meet our requirements
+               // Refer to https://docs.opentitan.org/doc/ug/install_instructions
                "-CFLAGS --std=c++11",
                // Without this magic LDFLAGS argument below, we get compile time errors with
                // VCS on Google Linux machines that look like this:


### PR DESCRIPTION
Fix typo from #4222. `c99` should be kept
And update comments

Signed-off-by: Weicai Yang <weicai@google.com>