### PR TITLE
[dv/otp] support hw_cfg digest calculation

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.core
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.core
@@ -11,6 +11,7 @@ filesets:
       - lowrisc:dv:cip_lib
       - lowrisc:dv:mem_bkdr_if
       - lowrisc:dv:push_pull_agent
+      - lowrisc:dv:crypto_dpi_present
     files:
       - otp_ctrl_env_pkg.sv
       - otp_ctrl_output_data_if.sv

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
@@ -18,6 +18,8 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_reg_block));
   mem_bkdr_vif             mem_bkdr_vif;
   otp_ctrl_output_data_vif otp_ctrl_output_data_vif;
 
+  bit backdoor_clear_mem;
+
   `uvm_object_utils_begin(otp_ctrl_env_cfg)
   `uvm_object_utils_end
 

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -31,6 +31,8 @@ package otp_ctrl_env_pkg;
   parameter uint TEST_ACCESS_BASE_ADDR   = 'h2000;
   parameter uint SW_WINDOW_SIZE          = 512 * 4;
   parameter uint TEST_ACCESS_WINDOW_SIZE = 16 * 4;
+  // convert byte into TLUL width size
+  parameter uint HW_CFG_ARRAY_SIZE       = HwCfgContentSize / (TL_DW / 8);
 
   // sram rsp data has 1 bit for seed_valid, the rest are for key and nonce
   parameter uint SRAM_DATA_SIZE  = 1 + SramKeyWidth + SramNonceWidth;
@@ -41,14 +43,19 @@ package otp_ctrl_env_pkg;
   // edn rsp data are key width
   parameter uint EDN_DATA_SIZE   = EdnDataWidth;
 
+  // scramble related parameters
+  parameter uint SCRAMBLE_DATA_SIZE = 64;
+  parameter uint SCRAMBLE_KEY_SIZE  = 128;
+  parameter uint NUM_ROUND          = 31;
+
   // lc does not have digest
-  parameter bit[10:0] DIGESTS_ADDR [NumPart-1] = {
-      CreatorSwCfgDigestOffset,
-      OwnerSwCfgDigestOffset,
-      HwCfgDigestOffset,
-      Secret0DigestOffset,
-      Secret1DigestOffset,
-      Secret2DigestOffset
+  parameter int PART_BASE_ADDRS [NumPart-1] = {
+    CreatorSwCfgOffset,
+    OwnerSwCfgOffset,
+    HwCfgOffset,
+    Secret0Offset,
+    Secret1Offset,
+    Secret2Offset
   };
 
   // types

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -10,6 +10,10 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
   `uvm_component_utils(otp_ctrl_scoreboard)
 
   // local variables
+  bit [TL_DW-1:0] hw_cfg_a [HW_CFG_ARRAY_SIZE];
+
+  // LC partition does not have digest
+  bit [SCRAMBLE_DATA_SIZE-1:0] digests[NumPart-1];
 
   // TLM agent fifos
   uvm_tlm_analysis_fifo #(push_pull_item#(SRAM_DATA_SIZE))  sram_fifo[NumSramKeyReqSlots];
@@ -40,7 +44,21 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
   task run_phase(uvm_phase phase);
     super.run_phase(phase);
     fork
+      process_backdoor_mem_clear();
     join_none
+  endtask
+
+  virtual task process_backdoor_mem_clear();
+    forever begin
+      @(posedge cfg.pwr_otp_vif.pins[OtpPwrInitReq]) begin
+        if (cfg.backdoor_clear_mem) begin
+          hw_cfg_a = '{default:0};
+          digests  = '{default:0};
+          predict_digest_csrs();
+          `uvm_info(`gfn, "clear internal memory and digest", UVM_HIGH)
+        end
+      end
+    end
   endtask
 
   virtual task process_tl_access(tl_seq_item item, tl_channels_e channel = DataChannel);
@@ -89,6 +107,28 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
       "intr_test": begin
         // FIXME
       end
+      "direct_access_cmd": begin
+        if (addr_phase_write && ral.direct_access_regwen.get_mirrored_value()) begin
+          int dai_addr = ral.direct_access_address.get_mirrored_value();
+          case (item.a_data)
+            DaiDigest: begin
+              // TODO: temp if statement, take away when support all partitions
+              if (get_part_index(dai_addr) == HwCfgIdx) begin
+                cal_digest_val(HwCfgIdx);
+              end
+            end
+            DaiWrite: begin
+              if (get_part_index(dai_addr) == HwCfgIdx) begin
+                int cal_addr = (dai_addr - HwCfgOffset) >> 2;
+                hw_cfg_a[cal_addr] = ral.direct_access_wdata_0.get_mirrored_value();
+              end
+            end
+          endcase
+        end
+      end
+      // TODO: temp only enable this checking, should support all regs
+      "hw_cfg_digest_0": do_read_check = 1;
+      "hw_cfg_digest_1": do_read_check = 1;
       default: begin
         //`uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
       end
@@ -99,6 +139,8 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
       if (do_read_check) begin
         `DV_CHECK_EQ(csr.get_mirrored_value(), item.d_data,
                      $sformatf("reg name: %0s", csr.get_full_name()))
+        // TODO: temp disable check, right now only support hw_cfg_digest
+        do_read_check = 0;
       end
       void'(csr.predict(.value(item.d_data), .kind(UVM_PREDICT_READ)));
     end
@@ -107,6 +149,16 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
   virtual function void reset(string kind = "HARD");
     super.reset(kind);
     // reset local fifos queues and variables
+    // digest values are updated after a power cycle
+    predict_digest_csrs();
+  endfunction
+
+  // predict digest registers
+  virtual function void predict_digest_csrs();
+    void'(ral.hw_cfg_digest_0.predict(.value(digests[HwCfgIdx][31:0]),
+                                      .kind(UVM_PREDICT_DIRECT)));
+    void'(ral.hw_cfg_digest_1.predict(.value(digests[HwCfgIdx][63:32]),
+                                      .kind(UVM_PREDICT_DIRECT)));
   endfunction
 
   function void check_phase(uvm_phase phase);
@@ -114,4 +166,49 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
     // post test checks - ensure that all local fifos and queues are empty
   endfunction
 
+  // Calculate digest value for each partition
+  // According to the design spec, the calculation is based on 64-rounds of PRESENT cipher
+  // The 64-bit data_in state is initialized with a silicon creator constant, and each 128 bit
+  // chunk of partition data are fed in as keys
+  // The last 64-round PRESENT calculation will use a global digest constant as key input
+  function void cal_digest_val(int part_idx);
+    bit [NUM_ROUND-1:0] [SCRAMBLE_DATA_SIZE-1:0] enc_array;
+    bit [TL_DW-1:0] mem_q[$];
+    int             array_size;
+    int             key_factor  = SCRAMBLE_KEY_SIZE / TL_DW;
+    bit             key_size_80 = SCRAMBLE_KEY_SIZE == 80;
+
+    // TODO: currently only support HwCfg partition
+    case (part_idx)
+      HwCfgIdx: begin
+        array_size = HW_CFG_ARRAY_SIZE;
+        mem_q = hw_cfg_a;
+      end
+    endcase
+
+    for (int i = 0; i <= $ceil(array_size / key_factor); i++) begin
+      bit [SCRAMBLE_DATA_SIZE-1:0] input_data = (i == 0) ? RndCnstDigestIVDefault[0] :
+                                                           digests[part_idx];
+      bit [SCRAMBLE_KEY_SIZE-1:0] key;
+
+      // Pad 32-bit partition data into 128-bit key input
+      // Because the mem_q size is a multiple of 64-bit, so if the last round only has 64-bits key,
+      // it will repeat the last 64-bits twice
+      for (int j = 0; j < key_factor; j++) begin
+        int index = i * key_factor + j;
+        key |= ((index >= array_size ? mem_q[index-2] : mem_q[index]) << (j * TL_DW));
+      end
+
+      // Trigger 32 round of PRESENT encrypt
+      crypto_dpi_present_pkg::sv_dpi_present_encrypt(input_data, key, key_size_80, enc_array);
+      digests[part_idx] = enc_array[NUM_ROUND-1];
+    end
+
+    // Last 32 round of digest is calculated with a digest constant
+    crypto_dpi_present_pkg::sv_dpi_present_encrypt(digests[part_idx],
+                                                   RndCnstDigestConstDefault[0],
+                                                   key_size_80,
+                                                   enc_array);
+    digests[part_idx] = enc_array[NUM_ROUND-1];
+  endfunction
 endclass

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -103,7 +103,12 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
       `uvm_info(`gfn, "Trigger HW digest calculation", UVM_HIGH)
       cal_hw_digests();
       csr_rd_check(.ptr(ral.status), .compare_value(OtpDaiIdle));
+      dut_init();
+
+      // check digest
+      check_digests();
     end
+
   endtask : body
 
 endclass : otp_ctrl_smoke_vseq

--- a/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -31,8 +31,9 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/mem_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
+                "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson"]
+                // TODO: enable this test once support
+                //"{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
 
   // Add additional tops for simulation.
   sim_tops: ["-top otp_ctrl_bind"]


### PR DESCRIPTION
This PR edit:
1. SEQ: add sequence to lock partitions, and read out HW_CFG digest.
   Lock partition can only happen after DAI lock command + power init.

2. SCB: add logic to generate expected digest for HW_CFG

TODOs:
SCB predict digest for all partitions.

Signed-off-by: Cindy Chen <chencindy@google.com>