### PR TITLE
[otbn] Teach random instruction generator to generate bn.lid

### DIFF
--- a/hw/ip/otbn/data/bignum-insns.yml
+++ b/hw/ip/otbn/data/bignum-insns.yml
@@ -762,6 +762,10 @@
   synopsis: Load Word (indirect source, indirect destination)
   operands:
     - name: grd
+      # The grd register is read to pick the WDR that should be written, so
+      # it's sort of logically a destination (hence the name) but should be
+      # treated as a source by tools like the random instruction generator.
+      type: grs
       doc: Name of the GPR referencing the destination WDR
     - name: grs1
       doc: |

--- a/hw/ip/otbn/data/bignum-insns.yml
+++ b/hw/ip/otbn/data/bignum-insns.yml
@@ -29,7 +29,7 @@
       type: uimm1
       doc: Flag group to use. Defaults to 0.
   syntax: &bn-add-syntax |
-    <wrd>, <wrs1>, <wrs2>[<shift_type> <shift_bytes>B][, FG<flag_group>]
+    <wrd>, <wrs1>, <wrs2>[ <shift_type> <shift_bytes>B][, FG<flag_group>]
   doc: |
     Adds two WDR values, writes the result to the destination WDR and updates
     flags. The content of the second source WDR can be shifted by an unsigned
@@ -496,7 +496,7 @@
     - *bn-shift-bytes-operand
     - *bn-flag-group-operand
   syntax: &bn-and-syntax |
-    <wrd>, <wrs1>, <wrs2>[, <shift_type> <shift_bytes>B][, FG<flag_group>]
+    <wrd>, <wrs1>, <wrs2>[ <shift_type> <shift_bytes>B][, FG<flag_group>]
   doc: |
     Performs a bitwise and operation.
     Takes the values stored in registers referenced by `wrs1` and `wrs2` and stores the result in the register referenced by `wrd`.
@@ -567,7 +567,7 @@
     - *bn-shift-bytes-operand
     - *bn-flag-group-operand
   syntax: |
-    <wrd>, <wrs>[, <shift_type> <shift_bytes>B][, FG<flag_group>]
+    <wrd>, <wrs>[ <shift_type> <shift_bytes>B][, FG<flag_group>]
   doc: |
     Negates the value in `wrs` and stores the result in the register referenced by `wrd`.
     The source value can be shifted by an immediate before it is consumed by the operation.
@@ -710,7 +710,7 @@
     - *bn-shift-bytes-operand
     - *bn-flag-group-operand
   syntax: &bn-cmp-syntax |
-    <wrs1>, <wrs2>[, <shift_type> <shift_bytes>B][, FG<flag_group>]
+    <wrs1>, <wrs2>[ <shift_type> <shift_bytes>B][, FG<flag_group>]
   doc: |
     Subtracts the second WDR value from the first one and updates flags.
     This instruction is identical to BN.SUB, except that no result register is written.

--- a/hw/ip/otbn/dv/smoke/smoke_test.s
+++ b/hw/ip/otbn/dv/smoke/smoke_test.s
@@ -188,13 +188,13 @@ csrrs x24, 0x7c0, x0
 bn.add w18, w1, w2 << 17B
 
 # w19 = w1 & (w2 << 9B) = 0x18988800_00088990_89899109_88189108_81989801_09981800_00000000_00000000
-bn.and w19, w1, w2, << 9B
+bn.and w19, w1, w2 << 9B
 
 # w20 = w1 - (w2 >> 23B) = 0x78fccc06_2228e9d6_89c9b54f_887cf14e_c79af825_69be57d4_fecd21a1_b9dd0141
 bn.sub w20, w1, w2 >> 23B
 
 # w21 = w1 | (w2 >> 15B) = 0x78fccc06_2228e9d6_89c9b54f_887cf1df_df9bf9bd_f9bfd9ff_99ffbbbb_dbff9bdb
-bn.or  w21, w1, w2, >> 15B
+bn.or  w21, w1, w2 >> 15B
 
 # w22 = w21 + 0x1bd = 0x78fccc06_2228e9d6_89c9b54f_887cf1df_df9bf9bd_f9bfd9ff_99ffbbbb_dbff9d98
 bn.addi w22, w21, 0x1bd

--- a/hw/ip/otbn/util/otbn-ld
+++ b/hw/ip/otbn/util/otbn-ld
@@ -63,7 +63,11 @@ def mk_linker_script() -> Iterator[str]:
 def run_ld(ld_script: Optional[str], args: List[str]) -> int:
     '''Run the underlying linker and return the status code'''
     ld_name = find_tool('ld')
-    cmd = [ld_name]
+    # The --no-check-sections argument tells ld not to complain when we have
+    # more than one section with the same VMA. Since we have a Harvard
+    # architecture where data and instructions both start at zero, we expect
+    # that to happen.
+    cmd = [ld_name, '--no-check-sections']
     if ld_script is not None:
         cmd.append('--script={}'.format(ld_script))
     cmd += args

--- a/hw/ip/otbn/util/otbn-rig
+++ b/hw/ip/otbn/util/otbn-rig
@@ -18,6 +18,7 @@ from shared.insn_yaml import InsnsFile, load_insns_yaml
 # can import modules like "shared.foo" and get the OTBN shared code.
 sys.path.append(os.path.dirname(__file__))
 
+from rig.init_data import init_data_to_json, read_init_data  # noqa: E402
 from rig.rig import gen_program, snippets_to_program  # noqa: E402
 from rig.snippet import Snippet  # noqa: E402
 
@@ -40,13 +41,14 @@ def gen_main(args: argparse.Namespace) -> int:
         return 1
 
     # Run the generator
-    snippets, program = gen_program(args.start_addr, args.size, insns_file)
+    init_data, snippets = gen_program(args.start_addr, args.size, insns_file)
 
-    # Write out the snippets to a JSON file
+    # Write out the data and snippets to a JSON file
+    ser_data = init_data_to_json(init_data)
     ser_snippets = [snippet.to_json() for snippet in snippets]
     try:
         if args.output == '-':
-            json.dump(ser_snippets, sys.stdout)
+            json.dump([ser_data, ser_snippets], sys.stdout)
             # Add a newline at end of output: json.dump doesn't, and it makes a
             # bit of a mess of some consoles.
             sys.stdout.write('\n')
@@ -69,22 +71,24 @@ def asm_main(args: argparse.Namespace) -> int:
     if insns_file is None:
         return 1
 
-    # Load snippets JSON
+    # Load JSON
     try:
-        snippets_json = json.load(args.snippets)
+        json_data = json.load(args.snippets)
     except json.JSONDecodeError as err:
         print('Snippets file at {!r} is not valid JSON: {}.'
               .format(args.snippets.name, err),
               file=sys.stderr)
         return 1
 
-    # Parse these to proper snippet objects and then make a program by
-    # combining them
+    # Parse these to proper init data and snippet objects.
     try:
-        if not isinstance(snippets_json, list):
-            raise ValueError('Top-level structure should be a list.')
+        if not (isinstance(json_data, list) and len(json_data) == 2):
+            raise ValueError('Top-level structure should be a length 2 list.')
+
+        json_init_data, json_snippets = json_data
+        init_data = read_init_data(json_init_data)
         snippets = [Snippet.from_json(insns_file, idx, x)
-                    for idx, x in enumerate(snippets_json)]
+                    for idx, x in enumerate(json_snippets)]
     except ValueError as err:
         print('Failed to parse snippets from {!r}: {}'
               .format(args.snippets, err),
@@ -93,14 +97,15 @@ def asm_main(args: argparse.Namespace) -> int:
 
     program = snippets_to_program(snippets)
 
-    # Dump the assembly output.
+    # Dump the assembly output, and the linker script too if we're writing to
+    # something other than stdout.
     if args.output is None or args.output == '-':
-        program.dump_asm(sys.stdout)
+        program.dump_asm(sys.stdout, init_data)
     else:
         try:
             asm_path = args.output + '.s'
             with open(asm_path, 'w') as out_file:
-                program.dump_asm(out_file)
+                program.dump_asm(out_file, init_data)
         except OSError as err:
             print('Failed to open asm output file {!r}: {}.'
                   .format(args.output, err),
@@ -110,7 +115,7 @@ def asm_main(args: argparse.Namespace) -> int:
         try:
             ld_path = args.output + '.ld'
             with open(ld_path, 'w') as out_file:
-                program.dump_linker_script(out_file)
+                program.dump_linker_script(out_file, init_data)
         except OSError as err:
             print('Failed to open ld script output file {!r}: {}.'
                   .format(ld_path, err),

--- a/hw/ip/otbn/util/rig/init_data.py
+++ b/hw/ip/otbn/util/rig/init_data.py
@@ -1,0 +1,67 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import random
+from typing import Dict, List, Tuple
+
+
+def gen_init_data(dmem_size: int) -> Dict[int, int]:
+    '''Generate a dictionary with some initialised data
+
+    This will be inserted into the program as initialised data (pre-loaded).
+    The dictionary maps (word-aligned) byte addresses to u32 values.
+
+    '''
+    # Make sure to generate at least some 32-byte wide data for BN.LID calls,
+    # but also generate some 4-byte wide stuff to make sure we do the right
+    # thing from the start when loading a 4-byte word which has Xs above or
+    # below it.
+    assert dmem_size > 0
+
+    init_data = {}
+    for byte_width in [4, 32]:
+        word_width = byte_width // 4
+        hi_wword = dmem_size // byte_width - 1
+        for blob_idx in range(random.randint(1, 4)):
+            blob_wword = random.randint(0, hi_wword)
+            blob_addr = byte_width * blob_wword
+            for word_idx in range(word_width):
+                init_data[blob_addr + 4 * word_idx] = random.getrandbits(32)
+
+    return init_data
+
+
+def init_data_to_json(init_data: Dict[int, int]) -> List[Tuple[int, int]]:
+    '''Return init_data, as it should be serialized to json'''
+    return [(addr, data) for addr, data in init_data.items()]
+
+
+def read_init_data(parsed: object) -> Dict[int, int]:
+    '''Read init_data as parsed from json'''
+    if not isinstance(parsed, list):
+        raise ValueError('init_data is not a list.')
+    init_data = {}
+    for idx, item in enumerate(parsed):
+        if not (isinstance(item, list) and len(item) == 2):
+            raise ValueError('Item {} of init_data is not a length 2 list.'
+                             .format(item))
+        addr, value = item
+
+        if not (isinstance(addr, int) and isinstance(value, int)):
+            raise ValueError('Item {} of init_data has addr or value '
+                             'that is not an int.'
+                             .format(idx))
+
+        if addr < 0 or addr & 3:
+            raise ValueError('Item {} of init_data has '
+                             'an invalid address, 0x{:x}.'
+                             .format(idx, addr))
+        if not (0 <= value < (1 << 32)):
+            raise ValueError('Item {} of init_data has '
+                             'invalid data ({} is not a u32).'
+                             .format(idx, value))
+
+        init_data[addr] = value
+
+    return init_data

--- a/hw/ip/otbn/util/rig/model.py
+++ b/hw/ip/otbn/util/rig/model.py
@@ -288,8 +288,18 @@ class Model:
             # is going to be valid is 0.
             return 0
 
+        if isinstance(op_type, ImmOperandType):
+            shift = op_type.shift
+        else:
+            shift = 0
+
+        align = 1 << shift
+
         lo, hi = op_rng
-        op_val = random.randrange(lo, hi + 1)
+        sh_lo = (lo + align - 1) // align
+        sh_hi = hi // align
+
+        op_val = random.randint(sh_lo, sh_hi) << shift
         return op_type.op_val_to_enc_val(op_val, self.pc)
 
     def pick_reg_operand_value(self, op_type: RegOperandType) -> Optional[int]:

--- a/hw/ip/otbn/util/rig/rig.py
+++ b/hw/ip/otbn/util/rig/rig.py
@@ -2,11 +2,13 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import List, Tuple
+import random
+from typing import Dict, List, Tuple
 
 from shared.insn_yaml import InsnsFile
 from shared.mem_layout import get_memory_layout
 
+from .init_data import gen_init_data
 from .program import Program
 from .model import Model
 from .snippet_gens import SnippetGens
@@ -15,15 +17,18 @@ from .snippet import Snippet
 
 def gen_program(start_addr: int,
                 size: int,
-                insns_file: InsnsFile) -> Tuple[List[Snippet], Program]:
+                insns_file: InsnsFile) -> Tuple[Dict[int, int],
+                                                List[Snippet]]:
     '''Generate a random program for OTBN
 
     start_addr is the reset address (the value that should be programmed into
     the START_ADDR register). size gives a rough upper bound for the number of
     instructions that will be executed by the generated program.
 
-    Returns (snippets, program) where snippets is a list of instruction
-    snippets and program is the generated program.
+    Returns (init_data, snippets, program). init_data is a dict mapping (4-byte
+    aligned) address to u32s that should be loaded into data memory before
+    starting the program. snippets is a list of instruction snippets. program
+    is the generated program (from flattening them both).
 
     '''
 
@@ -32,13 +37,20 @@ def gen_program(start_addr: int,
     # for memory x, not the VMA)
     mems = get_memory_layout()
     imem_lma, imem_size = mems['IMEM']
-    dmem_size = mems['DMEM'][1]
+    dmem_lma, dmem_size = mems['DMEM']
 
     assert start_addr <= imem_size - 4
     assert start_addr & 3 == 0
 
-    program = Program(imem_lma, imem_size)
+    program = Program(imem_lma, imem_size, dmem_lma, dmem_size)
     model = Model(dmem_size, start_addr)
+
+    # Generate some initialised data to start with. Otherwise, it takes a while
+    # before we start issuing loads (because we need stores to happen first).
+    # Tell the model that we've done so.
+    init_data = gen_init_data(dmem_size)
+    for addr in init_data.keys():
+        model.touch_mem('dmem', addr, 4)
 
     generators = SnippetGens(insns_file)
     snippets = []
@@ -54,7 +66,7 @@ def gen_program(start_addr: int,
         assert new_size < size
         size = new_size
 
-    return snippets, program
+    return init_data, snippets
 
 
 def snippets_to_program(snippets: List[Snippet]) -> Program:
@@ -64,7 +76,8 @@ def snippets_to_program(snippets: List[Snippet]) -> Program:
     # for memory x, not the VMA)
     mems = get_memory_layout()
     imem_lma, imem_size = mems['IMEM']
-    program = Program(imem_lma, imem_size)
+    dmem_lma, dmem_size = mems['DMEM']
+    program = Program(imem_lma, imem_size, dmem_lma, dmem_size)
 
     for snippet in snippets:
         snippet.insert_into_program(program)


### PR DESCRIPTION
This unblocks a whole load of bignum instructions (because now we can get data into the wide register file). There are an impressive number of silly bugs that I had to fix to get this working, but now I get code like this:
```
bn.lid         x0, 64(x0++)
bn.subb        w2, w0, w0 << 12B
bn.mulqacc.wo  w3, w2.1, w0.1, 0
bn.not         w17, w2 >> 30B, FG1
bn.subb        w1, w0, w0 >> 20B, FG1
sw             x7, 1864(x0)
bn.not         w24, w1 >> 22B, FG1
sra            x6, x24, x5
or             x31, x28, x9
bn.sub         w30, w2, w17 >> 2B, FG1
bn.xor         w18, w3, w2 >> 6B
add            x7, x8, x9
bn.cmp         w2, w0 << 18B, FG1
bn.cmp         w3, w2 >> 4B
srl            x4, x3, x18
```
Woo!