### PR TITLE
[flash_ctrl] Flash isolated page update

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson
@@ -29,6 +29,13 @@
       package: "flash_ctrl_pkg"
     },
 
+    { struct: "lc_tx",
+      type: "uni",
+      name: "lc_provision_en",
+      act:  "rcv",
+      package: "lc_ctrl_pkg"
+    },
+
     { struct: "lc_flash",
       type: "req_rsp",
       name: "lc",

--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
@@ -29,6 +29,13 @@
       package: "flash_ctrl_pkg"
     },
 
+    { struct: "lc_tx",
+      type: "uni",
+      name: "lc_provision_en",
+      act:  "rcv",
+      package: "lc_ctrl_pkg"
+    },
+
     { struct: "lc_flash",
       type: "req_rsp",
       name: "lc",

--- a/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
@@ -12,6 +12,9 @@ module flash_ctrl import flash_ctrl_pkg::*; (
   input        clk_i,
   input        rst_ni,
 
+  // life cycle interface
+  lc_ctrl_pkg::lc_tx_t lc_provision_en_i,
+
   // Bus Interface
   input        tlul_pkg::tl_h2d_t tl_i,
   output       tlul_pkg::tl_d2h_t tl_o,
@@ -161,6 +164,19 @@ module flash_ctrl import flash_ctrl_pkg::*; (
   logic [31:0] rand_val;
   logic lfsr_en;
 
+  // life cycle connections
+  lc_ctrl_pkg::lc_tx_t [FlashLcLast-1:0] lc_provision_en;
+
+  // synchronize provision enable into local domain
+  prim_lc_sync #(
+    .NumCopies(int'(FlashLcLast))
+  ) u_lc_provision_en_sync (
+    .clk_i,
+    .rst_ni,
+    .lc_en_i(lc_provision_en_i),
+    .lc_en_o(lc_provision_en)
+  );
+
   prim_lfsr #(
     .DefaultSeed(),
     .EntropyDw(4),
@@ -264,10 +280,11 @@ module flash_ctrl import flash_ctrl_pkg::*; (
 
   // software only has privilege to change creator seed when provision enable is set and
   // before the the seed is set as valid in otp
-  assign creator_seed_priv = lc_i.provision_en & ~otp_i.seed_valid;
+  assign creator_seed_priv = lc_provision_en[FlashLcCreatorSeedPriv] == lc_ctrl_pkg::On &
+                             ~otp_i.seed_valid;
 
   // owner seed is under software control and can be modided whenever provision enable is set
-  assign owner_seed_priv = lc_i.provision_en;
+  assign owner_seed_priv = lc_provision_en[FlashLcOwnerSeedPriv] == lc_ctrl_pkg::On;
 
   flash_ctrl_lcmgr u_flash_hw_if (
     .clk_i,
@@ -275,7 +292,7 @@ module flash_ctrl import flash_ctrl_pkg::*; (
 
     .init_i(pwrmgr_i.flash_init),
     .init_done_o(pwrmgr_o.flash_done),
-    .provision_en_i(lc_i.provision_en),
+    .provision_en_i(lc_provision_en[FlashLcMgrIf] == lc_ctrl_pkg::On),
 
     // interface to ctrl arb control ports
     .ctrl_o(hw_ctrl),
@@ -544,6 +561,7 @@ module flash_ctrl import flash_ctrl_pkg::*; (
         .cfgs_i(reg2hw_info_page_cfgs[i][j]),
         .creator_seed_priv_i(creator_seed_priv),
         .owner_seed_priv_i(owner_seed_priv),
+        .provision_en_i(lc_provision_en[FlashLcInfoCfg] == lc_ctrl_pkg::On),
         .cfgs_o(info_page_cfgs[i][j])
       );
     end

--- a/hw/ip/flash_ctrl/data/flash_ctrl_pkg.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_pkg.sv.tpl
@@ -78,6 +78,15 @@ package flash_ctrl_pkg;
   // parameters for connected components
   parameter int SeedWidth = 256;
 
+  // life cycle provision enable usage
+  typedef enum logic [2:0] {
+    FlashLcCreatorSeedPriv,
+    FlashLcOwnerSeedPriv,
+    FlashLcMgrIf,
+    FlashLcInfoCfg,
+    FlashLcLast
+  } flash_lc_provision_en_e;
+
   // lcmgr phase enum
   typedef enum logic [1:0] {
     PhaseSeed,
@@ -110,6 +119,7 @@ package flash_ctrl_pkg;
   // flash life cycle / key manager management constants
   // One page for creator seeds
   // One page for owner seeds
+  // One page for isolated flash page
   parameter int NumSeeds = 2;
   parameter int SeedBank = 0;
   parameter int SeedInfoSel = 0;
@@ -117,8 +127,9 @@ package flash_ctrl_pkg;
   parameter int OwnerSeedIdx = 1;
   parameter int CreatorInfoPage = 1;
   parameter int OwnerInfoPage = 2;
+  parameter int IsolatedInfoPage = 3;
 
-  // which page of which info type of which bank
+  // which page of which info type of which bank for seed selection
   parameter page_addr_t SeedInfoPageSel [NumSeeds] = '{
     '{
       sel:  SeedInfoSel,
@@ -129,6 +140,12 @@ package flash_ctrl_pkg;
       sel:  SeedInfoSel,
       addr: {SeedBank, OwnerInfoPage}
      }
+  };
+
+  // which page of which info type of which bank for isolated partition
+  parameter page_addr_t IsolatedPageSel = '{
+    sel:  SeedInfoSel,
+    addr: {SeedBank, IsolatedInfoPage}
   };
 
   // hardware interface memory protection rules
@@ -314,7 +331,6 @@ package flash_ctrl_pkg;
     // TBD: this signal will become multi-bit in the future
     logic rma_req;
     logic [BusWidth-1:0] rma_req_token;
-    logic provision_en;
   } lc_flash_req_t;
 
   // flash_ctrl to lc
@@ -346,8 +362,7 @@ package flash_ctrl_pkg;
 
   parameter lc_flash_req_t LC_FLASH_REQ_DEFAULT = '{
     rma_req: 1'b0,
-    rma_req_token: '0,
-    provision_en: 1'b1
+    rma_req_token: '0
   };
 
   parameter edn_entropy_t EDN_ENTROPY_DEFAULT = '{

--- a/hw/ip/flash_ctrl/dv/tb/flash_ctrl_wrapper.sv
+++ b/hw/ip/flash_ctrl/dv/tb/flash_ctrl_wrapper.sv
@@ -16,6 +16,7 @@ module flash_ctrl_wrapper (
 
   // OTP interface
   input        flash_ctrl_pkg::otp_flash_t otp_i,
+  input        lc_ctrl_pkg::lc_tx_t lc_provision_en_i,
   input        flash_ctrl_pkg::lc_flash_req_t lc_i,
   output       pwrmgr_pkg::pwr_flash_rsp_t pwrmgr_o,
   input        pwrmgr_pkg::pwr_flash_req_t pwrmgr_i,
@@ -47,16 +48,17 @@ module flash_ctrl_wrapper (
     .intr_op_error_o  (intr_op_error_o),
 
     // Inter-module signals
-    .flash_o  (flash_ctrl_flash_req),
-    .flash_i  (flash_ctrl_flash_rsp),
-    .otp_i    (otp_i),
-    .lc_i     (lc_i),
-    .pwrmgr_i (pwrmgr_i),
-    .pwrmgr_o (pwrmgr_o),
-    .edn_i    (edn_i),
+    .flash_o           (flash_ctrl_flash_req),
+    .flash_i           (flash_ctrl_flash_rsp),
+    .otp_i             (otp_i),
+    .lc_provision_en_i (lc_provision_en_i),
+    .lc_i              (lc_i),
+    .pwrmgr_i          (pwrmgr_i),
+    .pwrmgr_o          (pwrmgr_o),
+    .edn_i             (edn_i),
 
-    .clk_i    (clk_i),
-    .rst_ni   (rst_ni)
+    .clk_i             (clk_i),
+    .rst_ni            (rst_ni)
   );
 
   // host to flash communication

--- a/hw/ip/flash_ctrl/dv/tb/tb.sv
+++ b/hw/ip/flash_ctrl/dv/tb/tb.sv
@@ -45,6 +45,7 @@ module tb;
 
     // TODO: create and hook this up to an interface.
     .otp_i              (flash_ctrl_pkg::OTP_FLASH_DEFAULT),
+    .lc_provision_en_i  (lc_ctrl_pkg::On),
     .lc_i               (flash_ctrl_pkg::LC_FLASH_REQ_DEFAULT),
     .pwrmgr_o           (pwrmgr_pkg::PWR_FLASH_RSP_DEFAULT),
     .pwrmgr_i           (pwrmgr_pkg::PWR_FLASH_REQ_DEFAULT),

--- a/hw/ip/flash_ctrl/flash_ctrl.core
+++ b/hw/ip/flash_ctrl/flash_ctrl.core
@@ -14,6 +14,7 @@ filesets:
       - lowrisc:prim:lfsr
       - lowrisc:prim:flash
       - lowrisc:prim:gf_mult
+      - lowrisc:prim:lc_sync
       - lowrisc:ip:flash_ctrl_pkg
       - "fileset_top ? (lowrisc:systems:flash_ctrl)"
     files:

--- a/hw/ip/flash_ctrl/flash_ctrl_pkg.core
+++ b/hw/ip/flash_ctrl/flash_ctrl_pkg.core
@@ -10,6 +10,7 @@ filesets:
     depend:
       - lowrisc:constants:top_pkg
       - lowrisc:prim:util
+      - lowrisc:ip:lc_ctrl_pkg
       - lowrisc:ip:pwrmgr_pkg
       - fileset_top ? (lowrisc:systems:flash_ctrl_pkg)
     files:

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -12,6 +12,9 @@ module flash_ctrl import flash_ctrl_pkg::*; (
   input        clk_i,
   input        rst_ni,
 
+  // life cycle interface
+  lc_ctrl_pkg::lc_tx_t lc_provision_en_i,
+
   // Bus Interface
   input        tlul_pkg::tl_h2d_t tl_i,
   output       tlul_pkg::tl_d2h_t tl_o,
@@ -161,6 +164,19 @@ module flash_ctrl import flash_ctrl_pkg::*; (
   logic [31:0] rand_val;
   logic lfsr_en;
 
+  // life cycle connections
+  lc_ctrl_pkg::lc_tx_t [FlashLcLast-1:0] lc_provision_en;
+
+  // synchronize provision enable into local domain
+  prim_lc_sync #(
+    .NumCopies(int'(FlashLcLast))
+  ) u_lc_provision_en_sync (
+    .clk_i,
+    .rst_ni,
+    .lc_en_i(lc_provision_en_i),
+    .lc_en_o(lc_provision_en)
+  );
+
   prim_lfsr #(
     .DefaultSeed(),
     .EntropyDw(4),
@@ -264,10 +280,11 @@ module flash_ctrl import flash_ctrl_pkg::*; (
 
   // software only has privilege to change creator seed when provision enable is set and
   // before the the seed is set as valid in otp
-  assign creator_seed_priv = lc_i.provision_en & ~otp_i.seed_valid;
+  assign creator_seed_priv = lc_provision_en[FlashLcCreatorSeedPriv] == lc_ctrl_pkg::On &
+                             ~otp_i.seed_valid;
 
   // owner seed is under software control and can be modided whenever provision enable is set
-  assign owner_seed_priv = lc_i.provision_en;
+  assign owner_seed_priv = lc_provision_en[FlashLcOwnerSeedPriv] == lc_ctrl_pkg::On;
 
   flash_ctrl_lcmgr u_flash_hw_if (
     .clk_i,
@@ -275,7 +292,7 @@ module flash_ctrl import flash_ctrl_pkg::*; (
 
     .init_i(pwrmgr_i.flash_init),
     .init_done_o(pwrmgr_o.flash_done),
-    .provision_en_i(lc_i.provision_en),
+    .provision_en_i(lc_provision_en[FlashLcMgrIf] == lc_ctrl_pkg::On),
 
     // interface to ctrl arb control ports
     .ctrl_o(hw_ctrl),
@@ -543,6 +560,7 @@ module flash_ctrl import flash_ctrl_pkg::*; (
         .cfgs_i(reg2hw_info_page_cfgs[i][j]),
         .creator_seed_priv_i(creator_seed_priv),
         .owner_seed_priv_i(owner_seed_priv),
+        .provision_en_i(lc_provision_en[FlashLcInfoCfg] == lc_ctrl_pkg::On),
         .cfgs_o(info_page_cfgs[i][j])
       );
     end

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
@@ -76,6 +76,15 @@ package flash_ctrl_pkg;
   // parameters for connected components
   parameter int SeedWidth = 256;
 
+  // life cycle provision enable usage
+  typedef enum logic [2:0] {
+    FlashLcCreatorSeedPriv,
+    FlashLcOwnerSeedPriv,
+    FlashLcMgrIf,
+    FlashLcInfoCfg,
+    FlashLcLast
+  } flash_lc_provision_en_e;
+
   // lcmgr phase enum
   typedef enum logic [1:0] {
     PhaseSeed,
@@ -108,6 +117,7 @@ package flash_ctrl_pkg;
   // flash life cycle / key manager management constants
   // One page for creator seeds
   // One page for owner seeds
+  // One page for isolated flash page
   parameter int NumSeeds = 2;
   parameter int SeedBank = 0;
   parameter int SeedInfoSel = 0;
@@ -115,8 +125,9 @@ package flash_ctrl_pkg;
   parameter int OwnerSeedIdx = 1;
   parameter int CreatorInfoPage = 1;
   parameter int OwnerInfoPage = 2;
+  parameter int IsolatedInfoPage = 3;
 
-  // which page of which info type of which bank
+  // which page of which info type of which bank for seed selection
   parameter page_addr_t SeedInfoPageSel [NumSeeds] = '{
     '{
       sel:  SeedInfoSel,
@@ -127,6 +138,12 @@ package flash_ctrl_pkg;
       sel:  SeedInfoSel,
       addr: {SeedBank, OwnerInfoPage}
      }
+  };
+
+  // which page of which info type of which bank for isolated partition
+  parameter page_addr_t IsolatedPageSel = '{
+    sel:  SeedInfoSel,
+    addr: {SeedBank, IsolatedInfoPage}
   };
 
   // hardware interface memory protection rules
@@ -312,7 +329,6 @@ package flash_ctrl_pkg;
     // TBD: this signal will become multi-bit in the future
     logic rma_req;
     logic [BusWidth-1:0] rma_req_token;
-    logic provision_en;
   } lc_flash_req_t;
 
   // flash_ctrl to lc
@@ -344,8 +360,7 @@ package flash_ctrl_pkg;
 
   parameter lc_flash_req_t LC_FLASH_REQ_DEFAULT = '{
     rma_req: 1'b0,
-    rma_req_token: '0,
-    provision_en: 1'b1
+    rma_req_token: '0
   };
 
   parameter edn_entropy_t EDN_ENTROPY_DEFAULT = '{

--- a/hw/ip/prim/rtl/prim_lc_sync.sv
+++ b/hw/ip/prim/rtl/prim_lc_sync.sv
@@ -28,7 +28,7 @@ module prim_lc_sync #(
   lc_ctrl_pkg::lc_tx_t lc_en;
   prim_flop_2sync #(
     .Width(lc_ctrl_pkg::TxWidth),
-    .ResetValue(lc_ctrl_pkg::Off)
+    .ResetValue(int'(lc_ctrl_pkg::Off))
   ) u_prim_flop_2sync (
     .clk_i,
     .rst_ni,

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -857,6 +857,15 @@
           index: -1
         }
         {
+          struct: lc_tx
+          type: uni
+          name: lc_provision_en
+          act: rcv
+          package: lc_ctrl_pkg
+          inst_name: flash_ctrl
+          index: -1
+        }
+        {
           struct: lc_flash
           type: req_rsp
           name: lc
@@ -6149,6 +6158,15 @@
         name: otp
         act: rcv
         package: flash_ctrl_pkg
+        inst_name: flash_ctrl
+        index: -1
+      }
+      {
+        struct: lc_tx
+        type: uni
+        name: lc_provision_en
+        act: rcv
+        package: lc_ctrl_pkg
         inst_name: flash_ctrl
         index: -1
       }

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
@@ -35,6 +35,13 @@
       package: "flash_ctrl_pkg"
     },
 
+    { struct: "lc_tx",
+      type: "uni",
+      name: "lc_provision_en",
+      act:  "rcv",
+      package: "lc_ctrl_pkg"
+    },
+
     { struct: "lc_flash",
       type: "req_rsp",
       name: "lc",

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_pkg.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_pkg.sv
@@ -82,6 +82,15 @@ package flash_ctrl_pkg;
   // parameters for connected components
   parameter int SeedWidth = 256;
 
+  // life cycle provision enable usage
+  typedef enum logic [2:0] {
+    FlashLcCreatorSeedPriv,
+    FlashLcOwnerSeedPriv,
+    FlashLcMgrIf,
+    FlashLcInfoCfg,
+    FlashLcLast
+  } flash_lc_provision_en_e;
+
   // lcmgr phase enum
   typedef enum logic [1:0] {
     PhaseSeed,
@@ -114,6 +123,7 @@ package flash_ctrl_pkg;
   // flash life cycle / key manager management constants
   // One page for creator seeds
   // One page for owner seeds
+  // One page for isolated flash page
   parameter int NumSeeds = 2;
   parameter int SeedBank = 0;
   parameter int SeedInfoSel = 0;
@@ -121,8 +131,9 @@ package flash_ctrl_pkg;
   parameter int OwnerSeedIdx = 1;
   parameter int CreatorInfoPage = 1;
   parameter int OwnerInfoPage = 2;
+  parameter int IsolatedInfoPage = 3;
 
-  // which page of which info type of which bank
+  // which page of which info type of which bank for seed selection
   parameter page_addr_t SeedInfoPageSel [NumSeeds] = '{
     '{
       sel:  SeedInfoSel,
@@ -133,6 +144,12 @@ package flash_ctrl_pkg;
       sel:  SeedInfoSel,
       addr: {SeedBank, OwnerInfoPage}
      }
+  };
+
+  // which page of which info type of which bank for isolated partition
+  parameter page_addr_t IsolatedPageSel = '{
+    sel:  SeedInfoSel,
+    addr: {SeedBank, IsolatedInfoPage}
   };
 
   // hardware interface memory protection rules
@@ -318,7 +335,6 @@ package flash_ctrl_pkg;
     // TBD: this signal will become multi-bit in the future
     logic rma_req;
     logic [BusWidth-1:0] rma_req_token;
-    logic provision_en;
   } lc_flash_req_t;
 
   // flash_ctrl to lc
@@ -350,8 +366,7 @@ package flash_ctrl_pkg;
 
   parameter lc_flash_req_t LC_FLASH_REQ_DEFAULT = '{
     rma_req: 1'b0,
-    rma_req_token: '0,
-    provision_en: 1'b1
+    rma_req_token: '0
   };
 
   parameter edn_entropy_t EDN_ENTROPY_DEFAULT = '{

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -713,6 +713,7 @@ module top_earlgrey #(
       .flash_o(flash_ctrl_flash_req),
       .flash_i(flash_ctrl_flash_rsp),
       .otp_i(flash_ctrl_pkg::OTP_FLASH_DEFAULT),
+      .lc_provision_en_i(lc_ctrl_pkg::LC_TX_DEFAULT),
       .lc_i(flash_ctrl_pkg::LC_FLASH_REQ_DEFAULT),
       .lc_o(),
       .edn_i(flash_ctrl_pkg::EDN_ENTROPY_DEFAULT),


### PR DESCRIPTION
Add an "isolated flash page" to flash.

This flash page has the unique property of being writeable ONLY during life cycle TEST states, and writeable / readable during life cycle production and rma states. 

This property I believe can be replicated using the PROVISION_EN signal (which means we would need to update both the `lc_ctrl` and `flash_ctrl` documentation).

The documentation is not yet updated, I will follow with another commit soon. 