### PR TITLE
[otbn] Document and implement (in the ISS) alerts for x1 underflows/overflows

### DIFF
--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -125,6 +125,7 @@
 
             - 0x0 (ErrCodeNoError):     No error occurred.
             - 0x1 (ErrCodeBadDataAddr): Load or store to invalid address
+            - 0x2 (ErrCodeCallStack):   Call stack underflow/overflow
           '''
         }
       ]

--- a/hw/ip/otbn/dv/otbnsim/sim/alert.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/alert.py
@@ -1,0 +1,26 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional
+
+# A copy of the list of error codes. This also appears in otbn.hjson and
+# otbn_pkg.sv: we should probably be generating them from the hjson every time.
+ERR_CODE_NO_ERROR = 0
+ERR_CODE_BAD_DATA_ADDR = 1
+ERR_CODE_CALL_STACK = 2
+
+
+class Alert(Exception):
+    '''An exception raised to signal that the program did something wrong
+
+    This maps onto alerts in the implementation. The err_code value is the
+    value that should be written to the ERR_CODE external register.
+
+    '''
+    # Subclasses should override this class field
+    err_code = None  # type: Optional[int]
+
+    def error_code(self) -> int:
+        assert self.err_code is not None
+        return self.err_code

--- a/hw/ip/otbn/dv/otbnsim/sim/dmem.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/dmem.py
@@ -203,3 +203,6 @@ class Dmem:
         for item in self.trace:
             self._commit_store(item)
         self.trace = []
+
+    def abort(self) -> None:
+        self.trace = []

--- a/hw/ip/otbn/dv/otbnsim/sim/ext_regs.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/ext_regs.py
@@ -94,6 +94,9 @@ class RGField:
     def commit(self) -> None:
         self.value = self.next_value
 
+    def abort(self) -> None:
+        self.next_value = self.value
+
 
 class RGReg:
     '''A wrapper around a register as parsed by reggen'''
@@ -142,6 +145,10 @@ class RGReg:
     def commit(self) -> None:
         for field in self.fields:
             field.commit()
+
+    def abort(self) -> None:
+        for field in self.fields:
+            field.abort()
 
 
 class OTBNExtRegs:
@@ -210,4 +217,9 @@ class OTBNExtRegs:
 
         for reg in self.regs.values():
             reg.commit()
+        self.trace = []
+
+    def abort(self) -> None:
+        for reg in self.regs.values():
+            reg.abort()
         self.trace = []

--- a/hw/ip/otbn/dv/otbnsim/sim/flags.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/flags.py
@@ -52,6 +52,9 @@ class FlagReg:
                 setattr(self, n, getattr(self._new_val, n))
         self._new_val = None
 
+    def abort(self) -> None:
+        self._new_val = None
+
     def read_unsigned(self) -> int:
         '''Return a 4-bit number with the flags as ZLMC'''
         return ((int(self.Z) << 3) |
@@ -110,6 +113,12 @@ class FlagGroups:
         if self._dirty:
             self._groups[0].commit()
             self._groups[1].commit()
+        self._dirty = False
+
+    def abort(self) -> None:
+        if self._dirty:
+            self._groups[0].abort()
+            self._groups[1].abort()
         self._dirty = False
 
     def read_unsigned(self) -> int:

--- a/hw/ip/otbn/dv/otbnsim/sim/gpr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/gpr.py
@@ -4,68 +4,98 @@
 
 from typing import List
 
+from .alert import Alert, ERR_CODE_CALL_STACK
 from .reg import Reg, RegFile
+
+
+class CallStackError(Alert):
+    '''Raised when under- or over-flowing the call stack'''
+
+    err_code = ERR_CODE_CALL_STACK
+
+    def __init__(self, is_overflow: bool):
+        self.is_overflow = is_overflow
+
+    def __str__(self) -> str:
+        xflow = 'overflow' if self.is_overflow else 'underflow'
+        return 'Instruction caused {} of x1 call stack.'.format(xflow)
+
+
+class CallStackReg(Reg):
+    '''A register used to represent x1'''
+
+    # The depth of the x1 call stack
+    stack_depth = 8
+
+    def __init__(self, parent: RegFile):
+        super().__init__(parent, 1, 32, 0)
+        self.stack = []  # type: List[int]
+        self.saw_read = False
+
+    # We overload read_unsigned here, to handle the read-sensitive behaviour
+    # without needing the base class to deal with it.
+    def read_unsigned(self, backdoor: bool = False) -> int:
+        if backdoor:
+            # If a backdoor access, don't take note of the read. If the stack
+            # turns out to be empty, return some "obviously bogus" value.
+            return self.stack[-1] if self.stack else 0xcafef00d
+
+        if not self.stack:
+            raise CallStackError(False)
+
+        # Mark that we've read something (so that we pop from the stack as part
+        # of commit) and return the top of the stack.
+        self.saw_read = True
+        return self.stack[-1]
+
+    def write_unsigned(self, uval: int, backdoor: bool = False) -> None:
+        super().write_unsigned(uval, backdoor)
+
+    def commit(self) -> None:
+        if self.saw_read:
+            assert self.stack
+            self.stack.pop()
+            self.saw_read = False
+
+        if self._next_uval is not None:
+            if len(self.stack) == 8:
+                raise CallStackError(True)
+            self.stack.append(self._next_uval)
+
+        super().commit()
+
+    def abort(self) -> None:
+        self.saw_read = False
+        super().abort()
 
 
 class GPRs(RegFile):
     '''The narrow OTBN register file'''
+
     def __init__(self) -> None:
         super().__init__('x', 32, 32)
-
-        # The call stack for x1 and its pending updates. self.callstack is
-        # never empty and (after commit) the tail always matches
-        # self._registers[1].read_unsigned() (pushing from the right)
-        self._callstack = [0]  # type: List[int]
-        self._callstack_pop = False
-
-    def mark_read(self, idx: int) -> None:
-        super().mark_read(idx)
-        if idx == 1:
-            self._callstack_pop = True
+        self._x1 = CallStackReg(self)
 
     def get_reg(self, idx: int) -> Reg:
-        # If idx == 0, this is a zeros register that should ignore writes.
-        # Return a fresh Reg with no parent, so writes to it have no effect.
         if idx == 0:
+            # If idx == 0, this is a zeros register that should ignore writes.
+            # Return a fresh Reg with no parent, so writes to it have no effect.
             return Reg(None, 0, 32, 0)
-        return super().get_reg(idx)
-
-    def post_insn(self) -> None:
-        '''Update call stack after instruction execution but before commit
-
-        This is not idempotent: call it exactly once.
-
-        '''
-        callstack_push = 1 in self._pending_writes
-
-        # If we read from the call stack, we have popped from it. (Even if the
-        # stack is empty, we treat this as a logical pop. We need to decide
-        # what happens here: see issue #3239).
-        if self._callstack_pop:
-            if len(self._callstack) > 1:
-                self._callstack.pop()
-
-            # Write the new head of the call stack to the relevant register,
-            # unless x1 has a pending write (which means that we had an
-            # instruction like "addi x1, x1, 0", so the pop happened logically
-            # before the push)
-            if not callstack_push:
-                self._registers[1].write_unsigned(self._callstack[-1])
-
-        # If there is a pending write to x1 (which wasn't caused by the
-        # callstack pop code just above) then callstack_push will be true. In
-        # that case, we should push the new value onto the call stack.
-        if callstack_push:
-            new_x1 = self._registers[1].read_next()
-            assert new_x1 is not None
-            self._callstack.append(new_x1)
+        elif idx == 1:
+            # If idx == 1, we return self._x1: element 1 of the underlying
+            # register file is not actually used.
+            return self._x1
+        else:
+            return super().get_reg(idx)
 
     def peek_call_stack(self) -> List[int]:
-        '''Get a list of values on the call stack'''
-        # _callstack is never empty and always contains 0 as the first element,
-        # so strip that off the returned value.
-        return self._callstack[1:]
+        '''Get the call stack, bottom-first.'''
+        return self._x1.stack
 
     def commit(self) -> None:
-        self._callstack_pop = False
+        self._x1.commit()
         super().commit()
+
+    def abort(self) -> None:
+        self._x1.abort()
+        super().abort()

--- a/hw/ip/otbn/dv/otbnsim/sim/insn.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/insn.py
@@ -308,15 +308,8 @@ class ECALL(OTBNInsn):
         pass
 
     def execute(self, state: OTBNState) -> None:
-        # INTR_STATE is the interrupt state register. Bit 0 (which is being
-        # set) is the 'done' flag.
-        state.ext_regs.set_bits('INTR_STATE', 1 << 0)
-        # STATUS is a status register. Bit 0 (being cleared) is the 'busy' flag
-        state.ext_regs.clear_bits('STATUS', 1 << 0)
-
-        # As well as the external register, clear an internal 'running' flag to
-        # tell the simulation to stop.
-        state.running = False
+        # Set INTR_STATE.done and STATUS, reflecting the fact we've stopped.
+        state.stop(None)
 
 
 class LOOP(OTBNInsn):

--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -73,7 +73,7 @@ class OTBNSim:
         self.state.commit()
 
         if verbose:
-            disasm = ('(stall)' if was_stalled
+            disasm = ('(stall)' if insn is None
                       else insn.disassemble(pc_before))
             self._print_trace(disasm, changes)
 

--- a/hw/ip/otbn/dv/otbnsim/sim/wsr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/wsr.py
@@ -44,6 +44,10 @@ class WSR:
         '''Commit pending changes'''
         return
 
+    def abort(self) -> None:
+        '''Abort pending changes'''
+        return
+
     def changes(self) -> List[TraceWSR]:
         '''Return list of pending architectural changes'''
         return []
@@ -66,6 +70,9 @@ class DumbWSR(WSR):
     def commit(self) -> None:
         if self._next_value is not None:
             self._value = self._next_value
+        self._next_value = None
+
+    def abort(self) -> None:
         self._next_value = None
 
     def changes(self) -> List[TraceWSR]:
@@ -130,6 +137,11 @@ class WSRFile:
         self.MOD.commit()
         self.RND.commit()
         self.ACC.commit()
+
+    def abort(self) -> None:
+        self.MOD.abort()
+        self.RND.abort()
+        self.ACC.abort()
 
     def changes(self) -> List[TraceWSR]:
         return self.MOD.changes() + self.RND.changes() + self.ACC.changes()

--- a/hw/ip/otbn/dv/otbnsim/stepped.py
+++ b/hw/ip/otbn/dv/otbnsim/stepped.py
@@ -168,13 +168,13 @@ def on_print_regs(sim: OTBNSim, args: List[str]) -> None:
 
 
 def on_print_call_stack(sim: OTBNSim, args: List[str]) -> None:
-    '''Print call stack to stdout first element is the bottom of the stack'''
+    '''Print call stack to stdout. First element is the bottom of the stack'''
     if len(args):
         raise ValueError('print_call_stack expects zero arguments. Got {}.'
                          .format(args))
 
     print('PRINT_CALL_STACK')
-    for value in sim.state.gprs.peek_call_stack():
+    for value in sim.state.peek_call_stack():
         print('0x{:08x}'.format(value))
 
 

--- a/hw/ip/otbn/dv/otbnsim/test/simple/x1-overflow/expected.txt
+++ b/hw/ip/otbn/dv/otbnsim/test/simple/x1-overflow/expected.txt
@@ -1,0 +1,6 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+x2  = 8
+x10 = 10

--- a/hw/ip/otbn/dv/otbnsim/test/simple/x1-overflow/overflow.s
+++ b/hw/ip/otbn/dv/otbnsim/test/simple/x1-overflow/overflow.s
@@ -1,0 +1,20 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/*
+  An example of overflowing the x1 stack. Make sure that we stop execution and
+  properly raise an alert. To avoid lots of copy-paste code, we just loop 100
+  times, incrementing a variable as we go. This variable will contain the call
+  stack depth when we stop.
+*/
+  addi x10, x0, 10
+  addi  x2, x0, 0
+
+  loopi 100, 2
+  addi  x1, x0, 0
+  addi  x2, x2, 1
+
+  /* We shouldn't get here */
+  addi x10, x0, 0
+  ecall

--- a/hw/ip/otbn/dv/otbnsim/test/simple/x1-underflow/expected.txt
+++ b/hw/ip/otbn/dv/otbnsim/test/simple/x1-underflow/expected.txt
@@ -1,0 +1,7 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+x2  = 123
+x3  = 246
+x10 = 10

--- a/hw/ip/otbn/dv/otbnsim/test/simple/x1-underflow/underflow.s
+++ b/hw/ip/otbn/dv/otbnsim/test/simple/x1-underflow/underflow.s
@@ -1,0 +1,26 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/*
+  An example of underflowing the x1 stack. Make sure that we stop execution and
+  properly raise an alert.
+*/
+  addi  x10, x0, 10
+
+  /* Push once onto the stack */
+  addi  x1, x0, 123
+  /* Pop once from the stack: this should be fine */
+  addi  x2, x1, 0
+
+  /* Push once onto the stack */
+  addi  x1, x0, 123
+  /* Pop once from the stack (but with both input operands) */
+  add   x3, x1, x1
+
+  /* Pop again from the stack. ERROR! */
+  addi  x0, x1, 0
+
+  /* We shouldn't get here */
+  addi x10, x0, 0
+  ecall

--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -45,7 +45,8 @@ package otbn_pkg;
   // Error codes
   typedef enum logic [31:0] {
     ErrCodeNoError     = 32'h 0000_0000,
-    ErrCodeBadDataAddr = 32'h 0000_0001
+    ErrCodeBadDataAddr = 32'h 0000_0001,
+    ErrCodeCallStack   = 32'h 0000_0002
   } err_code_e;
 
   // Constants =====================================================================================

--- a/sw/device/lib/dif/dif_otbn.c
+++ b/sw/device/lib/dif/dif_otbn.c
@@ -218,6 +218,7 @@ dif_otbn_result_t dif_otbn_get_err_code(const dif_otbn_t *otbn,
   switch (err_code_raw) {
     case kDifOtbnErrCodeNoError:
     case kDifOtbnErrCodeBadDataAddr:
+    case kDifOtbnErrCodeCallStack:
       *err_code = (dif_otbn_err_code_t)err_code_raw;
       return kDifOtbnOk;
 

--- a/sw/device/lib/dif/dif_otbn.h
+++ b/sw/device/lib/dif/dif_otbn.h
@@ -81,6 +81,8 @@ typedef enum dif_otbn_err_code {
   kDifOtbnErrCodeNoError = 0x0,
   /** Load or store to invalid address. */
   kDifOtbnErrCodeBadDataAddr = 0x1,
+  /** Call stack underflow or overflow. */
+  kDifOtbnErrCodeCallStack = 0x2,
 } dif_otbn_err_code_t;
 
 /**


### PR DESCRIPTION
This PR has three commits. The first is a tiny tidy-up, needed to get the mypy flow working for the ISS changes. The second commit slightly restructures our documentation for the GPRs, and tries to fully explain how `x1` works. The final commit teaches the ISS to generate this sort of error and adds a couple of tests to make sure it works.

This is the first two parts of #3239.