### PR TITLE
[otbn] Require a command in otbn-rig

### DIFF
--- a/hw/ip/otbn/util/otbn-rig
+++ b/hw/ip/otbn/util/otbn-rig
@@ -127,7 +127,8 @@ def asm_main(args: argparse.Namespace) -> int:
 
 def main() -> int:
     parser = argparse.ArgumentParser()
-    subparsers = parser.add_subparsers()
+    subparsers = parser.add_subparsers(dest='cmd')
+    subparsers.required = True
 
     gen = subparsers.add_parser('gen', help='Generate a random program')
     asm = subparsers.add_parser('asm', help='Convert snippets to assembly')


### PR DESCRIPTION
Calling `otbn-rig` without any additional argument resulted in an
exception, now it gives a nice error/help message.