### PR TITLE
[dv/alert_handler] support alert_class overflows into two registers

### DIFF
--- a/hw/ip/alert_handler/dv/env/alert_handler_scoreboard.sv
+++ b/hw/ip/alert_handler/dv/env/alert_handler_scoreboard.sv
@@ -150,10 +150,11 @@ class alert_handler_scoreboard extends cip_base_scoreboard #(
       begin
         cfg.clk_rst_vif.wait_n_clks(1);
         if (!under_reset) begin
-          bit [TL_DW-1:0] alert_class, intr_en, class_ctrl;
+          bit [TL_DW-1:0] intr_en, class_ctrl;
+          bit [NUM_ALERTS*2-1:0] alert_class;
           bit [NUM_ALERT_HANDLER_CLASS_MSB:0] class_i;
           if (!is_int_err) begin
-            alert_class = ral.alert_class.get_mirrored_value();
+            alert_class = get_alert_class_mirrored_val();
             // extract the two bits that indicates which intr class this alert will trigger
             class_i = (alert_class >> alert_i * 2) & 'b11;
             alert_cause_field = alert_cause_fields[alert_i];
@@ -550,6 +551,17 @@ class alert_handler_scoreboard extends cip_base_scoreboard #(
     class_timeout_rg = ral.get_reg_by_name($sformatf("class%s_timeout_cyc", class_name[class_i]));
     `DV_CHECK_NE_FATAL(class_timeout_rg, null)
     return class_timeout_rg.get_mirrored_value();
+  endfunction
+
+  // If num_alerts exceeds TL_DW/2, then alert_class will need more than one reg to hold its value
+  function bit [NUM_ALERTS*2-1:0] get_alert_class_mirrored_val();
+    for (int i = 0; i < $ceil(NUM_ALERTS * 2 / TL_DW); i++) begin
+      string alert_name = (NUM_ALERTS <= TL_DW / 2) ? "alert_class" :
+                                                      $sformatf("alert_class_%0d", i);
+      uvm_reg alert_class_csr = ral.get_reg_by_name(alert_name);
+      `DV_CHECK_NE_FATAL(alert_class_csr, null)
+      get_alert_class_mirrored_val =| (alert_class_csr.get_mirrored_value() << i * TL_DW);
+    end
   endfunction
 endclass
 

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
@@ -53,9 +53,16 @@ class alert_handler_base_vseq extends cip_base_vseq #(
                                   bit [TL_DW-1:0]                     loc_alert_class = 'h0);
     csr_wr(.csr(ral.intr_enable), .value(intr_en));
     csr_wr(.csr(ral.alert_en), .value(alert_en));
-    csr_wr(.csr(ral.alert_class), .value(alert_class));
     csr_wr(.csr(ral.loc_alert_en), .value(loc_alert_en));
     csr_wr(.csr(ral.loc_alert_class), .value(loc_alert_class));
+    for (int i = 0; i < $ceil(NUM_ALERTS * 2 / TL_DW); i++) begin
+      string alert_name = (NUM_ALERTS <= TL_DW / 2) ? "alert_class" :
+                                                      $sformatf("alert_class_%0d", i);
+      uvm_reg alert_class_csr = ral.get_reg_by_name(alert_name);
+      `DV_CHECK_NE_FATAL(alert_class_csr, null, alert_name)
+      csr_wr(.csr(alert_class_csr), .value(alert_class[i * TL_DW +: TL_DW]));
+    end
+
   endtask
 
   virtual task alert_handler_rand_wr_class_ctrl(bit [NUM_ALERT_HANDLER_CLASSES-1:0] lock_bit);


### PR DESCRIPTION
This is a temp fix for PR #4211 to pass private CI. The issue is by
adding one more alert (16 to 17 alerts), the `alert_class` register
overflows into `alert_class_0` and `alert_class_1` registers.

Next step I will make a generic function for this multi-reg overflow
issue.

Signed-off-by: Cindy Chen <chencindy@google.com>