### PR TITLE
[alert_handler/rv_core_ibex] Move alert handler to periphs and synchronize NMI signal

### DIFF
--- a/hw/ip/prim/rtl/prim_esc_pkg.sv
+++ b/hw/ip/prim/rtl/prim_esc_pkg.sv
@@ -9,6 +9,8 @@ package prim_esc_pkg;
     logic esc_n;
   } esc_tx_t;
 
+  parameter esc_tx_t ESC_TX_DEFAULT = 2'b01;
+
   typedef struct packed {
     logic resp_p;
     logic resp_n;

--- a/hw/ip/prim/rtl/prim_esc_pkg.sv
+++ b/hw/ip/prim/rtl/prim_esc_pkg.sv
@@ -9,8 +9,6 @@ package prim_esc_pkg;
     logic esc_n;
   } esc_tx_t;
 
-  parameter esc_tx_t ESC_TX_DEFAULT = 2'b01;
-
   typedef struct packed {
     logic resp_p;
     logic resp_n;

--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -32,6 +32,9 @@ module rv_core_ibex #(
   // Clock and Reset
   input  logic        clk_i,
   input  logic        rst_ni,
+  // Clock domain for escalation receiver
+  input  logic        clk_esc_i,
+  input  logic        rst_esc_ni,
 
   input  logic        test_en_i,     // enable all clock gates for testing
 
@@ -131,13 +134,24 @@ module rv_core_ibex #(
 
   // Escalation receiver that converts differential
   // protocol into single ended signal.
-  logic irq_nm;
-  prim_esc_receiver i_prim_esc_receiver (
-    .clk_i,
-    .rst_ni,
-    .esc_en_o ( irq_nm   ),
+  logic esc_irq_nm;
+  prim_esc_receiver u_prim_esc_receiver (
+    .clk_i    ( clk_esc_i  ),
+    .rst_ni   ( rst_esc_ni ),
+    .esc_en_o ( esc_irq_nm ),
     .esc_rx_o,
     .esc_tx_i
+  );
+
+  // Synchronize to fast Ibex clock domain.
+  logic irq_nm;
+  prim_flop_2sync #(
+    .Width(1)
+  ) u_prim_flop_2sync (
+    .clk_i,
+    .rst_ni,
+    .d_i(esc_irq_nm),
+    .q_o(irq_nm)
   );
 
   // Alert outputs

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -825,7 +825,7 @@
             0
           ]
           type: alert
-          async: 1
+          async: 0
         }
         {
           name: cg
@@ -838,7 +838,7 @@
             1
           ]
           type: alert
-          async: 1
+          async: 0
         }
         {
           name: gd
@@ -851,7 +851,7 @@
             2
           ]
           type: alert
-          async: 1
+          async: 0
         }
         {
           name: ts_hi
@@ -864,7 +864,7 @@
             3
           ]
           type: alert
-          async: 1
+          async: 0
         }
         {
           name: ts_lo
@@ -877,7 +877,7 @@
             4
           ]
           type: alert
-          async: 1
+          async: 0
         }
         {
           name: ls
@@ -890,7 +890,7 @@
             5
           ]
           type: alert
-          async: 1
+          async: 0
         }
         {
           name: ot
@@ -903,7 +903,7 @@
             6
           ]
           type: alert
-          async: 1
+          async: 0
         }
       ]
       wakeup_list: []
@@ -1092,7 +1092,7 @@
             0
           ]
           type: alert
-          async: 1
+          async: 0
         }
         {
           name: otp_check_failure
@@ -1105,7 +1105,7 @@
             1
           ]
           type: alert
-          async: 1
+          async: 0
         }
       ]
       wakeup_list: []
@@ -1398,7 +1398,7 @@
             0
           ]
           type: alert
-          async: 1
+          async: 0
         }
         {
           name: lc_state_failure
@@ -1411,7 +1411,7 @@
             1
           ]
           type: alert
-          async: 1
+          async: 0
         }
       ]
       wakeup_list: []
@@ -1747,6 +1747,262 @@
           width: 1
           default: ""
           top_signame: lc_ctrl_tl
+          index: -1
+        }
+      ]
+    }
+    {
+      name: alert_handler
+      type: alert_handler
+      clock_srcs:
+      {
+        clk_i: io_div4
+      }
+      clock_group: timers
+      reset_connections:
+      {
+        rst_ni: rstmgr_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]
+      }
+      base_addr: 0x40150000
+      generated: "true"
+      localparam:
+      {
+        EscCntDw: 32
+        AccuCntDw: 16
+        LfsrSeed: 0x7FFFFFFF
+      }
+      clock_reset_export: []
+      clock_connections:
+      {
+        clk_i: clkmgr_clocks.clk_io_div4_timers
+      }
+      domain: "0"
+      size: 0x1000
+      bus_device: tlul
+      bus_host: none
+      available_input_list: []
+      available_output_list: []
+      available_inout_list: []
+      param_list:
+      [
+        {
+          name: RndCnstLfsrSeed
+          desc: Compile-time random bits for initial LFSR seed
+          type: alert_pkg::lfsr_seed_t
+          randcount: "32"
+          randtype: data
+          local: "false"
+          default: 0x5def7861
+          expose: "false"
+          name_top: RndCnstAlertHandlerLfsrSeed
+          randwidth: 32
+        }
+        {
+          name: RndCnstLfsrPerm
+          desc: Compile-time random permutation for LFSR output
+          type: alert_pkg::lfsr_perm_t
+          randcount: "32"
+          randtype: perm
+          local: "false"
+          default: 0x5f00c4cafd73fc4ac479a61068375f38956d84b3
+          expose: "false"
+          name_top: RndCnstAlertHandlerLfsrPerm
+          randwidth: 160
+        }
+      ]
+      interrupt_list:
+      [
+        {
+          name: classa
+          width: 1
+          bits: "0"
+          bitinfo:
+          [
+            1
+            1
+            0
+          ]
+          type: interrupt
+        }
+        {
+          name: classb
+          width: 1
+          bits: "1"
+          bitinfo:
+          [
+            2
+            1
+            1
+          ]
+          type: interrupt
+        }
+        {
+          name: classc
+          width: 1
+          bits: "2"
+          bitinfo:
+          [
+            4
+            1
+            2
+          ]
+          type: interrupt
+        }
+        {
+          name: classd
+          width: 1
+          bits: "3"
+          bitinfo:
+          [
+            8
+            1
+            3
+          ]
+          type: interrupt
+        }
+      ]
+      alert_list: []
+      wakeup_list: []
+      reset_request_list: []
+      scan: "false"
+      scan_reset: "false"
+      inter_signal_list:
+      [
+        {
+          struct: alert_crashdump
+          type: uni
+          name: crashdump
+          act: req
+          package: alert_pkg
+          inst_name: alert_handler
+          width: 1
+          default: ""
+          top_type: broadcast
+          top_signame: alert_handler_crashdump
+          index: -1
+        }
+        {
+          struct: logic
+          type: uni
+          name: entropy
+          default: " 1'b0"
+          act: rcv
+          inst_name: alert_handler
+          index: -1
+        }
+        {
+          struct: tl
+          package: tlul_pkg
+          type: req_rsp
+          act: rsp
+          name: tl
+          inst_name: alert_handler
+          width: 1
+          default: ""
+          top_signame: alert_handler_tl
+          index: -1
+        }
+      ]
+    }
+    {
+      name: nmi_gen
+      type: nmi_gen
+      clock_srcs:
+      {
+        clk_i: io_div4
+      }
+      clock_group: timers
+      reset_connections:
+      {
+        rst_ni: rstmgr_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]
+      }
+      base_addr: 0x40160000
+      clock_reset_export: []
+      clock_connections:
+      {
+        clk_i: clkmgr_clocks.clk_io_div4_timers
+      }
+      domain: "0"
+      size: 0x1000
+      bus_device: tlul
+      bus_host: none
+      available_input_list: []
+      available_output_list: []
+      available_inout_list: []
+      param_list: []
+      interrupt_list:
+      [
+        {
+          name: esc0
+          width: 1
+          bits: "0"
+          bitinfo:
+          [
+            1
+            1
+            0
+          ]
+          type: interrupt
+        }
+        {
+          name: esc1
+          width: 1
+          bits: "1"
+          bitinfo:
+          [
+            2
+            1
+            1
+          ]
+          type: interrupt
+        }
+        {
+          name: esc2
+          width: 1
+          bits: "2"
+          bitinfo:
+          [
+            4
+            1
+            2
+          ]
+          type: interrupt
+        }
+      ]
+      alert_list: []
+      wakeup_list: []
+      reset_request_list:
+      [
+        {
+          name: nmi_rst_req
+        }
+      ]
+      scan: "false"
+      scan_reset: "false"
+      inter_signal_list:
+      [
+        {
+          struct: logic
+          type: uni
+          name: nmi_rst_req
+          act: req
+          package: ""
+          default: 1'b0
+          inst_name: nmi_gen
+          width: 1
+          top_signame: pwrmgr_rstreqs
+          index: -1
+        }
+        {
+          struct: tl
+          package: tlul_pkg
+          type: req_rsp
+          act: rsp
+          name: tl
+          inst_name: nmi_gen
+          width: 1
+          default: ""
+          top_signame: nmi_gen_tl
           index: -1
         }
       ]
@@ -3255,7 +3511,7 @@
             0
           ]
           type: alert
-          async: 0
+          async: 1
         }
         {
           name: ctrl_err_storage
@@ -3268,7 +3524,7 @@
             1
           ]
           type: alert
-          async: 0
+          async: 1
         }
       ]
       wakeup_list: []
@@ -3773,7 +4029,7 @@
             0
           ]
           type: alert
-          async: 0
+          async: 1
         }
         {
           name: operation_err
@@ -3786,7 +4042,7 @@
             1
           ]
           type: alert
-          async: 0
+          async: 1
         }
       ]
       wakeup_list: []
@@ -4152,7 +4408,7 @@
             0
           ]
           type: alert
-          async: 0
+          async: 1
         }
       ]
       wakeup_list: []
@@ -4426,262 +4682,6 @@
       ]
     }
     {
-      name: alert_handler
-      type: alert_handler
-      clock_srcs:
-      {
-        clk_i: main
-      }
-      clock_group: secure
-      reset_connections:
-      {
-        rst_ni: rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
-      }
-      base_addr: 0x411b0000
-      generated: "true"
-      localparam:
-      {
-        EscCntDw: 32
-        AccuCntDw: 16
-        LfsrSeed: 0x7FFFFFFF
-      }
-      clock_reset_export: []
-      clock_connections:
-      {
-        clk_i: clkmgr_clocks.clk_main_secure
-      }
-      domain: "0"
-      size: 0x1000
-      bus_device: tlul
-      bus_host: none
-      available_input_list: []
-      available_output_list: []
-      available_inout_list: []
-      param_list:
-      [
-        {
-          name: RndCnstLfsrSeed
-          desc: Compile-time random bits for initial LFSR seed
-          type: alert_pkg::lfsr_seed_t
-          randcount: "32"
-          randtype: data
-          local: "false"
-          default: 0x5def7861
-          expose: "false"
-          name_top: RndCnstAlertHandlerLfsrSeed
-          randwidth: 32
-        }
-        {
-          name: RndCnstLfsrPerm
-          desc: Compile-time random permutation for LFSR output
-          type: alert_pkg::lfsr_perm_t
-          randcount: "32"
-          randtype: perm
-          local: "false"
-          default: 0x5f00c4cafd73fc4ac479a61068375f38956d84b3
-          expose: "false"
-          name_top: RndCnstAlertHandlerLfsrPerm
-          randwidth: 160
-        }
-      ]
-      interrupt_list:
-      [
-        {
-          name: classa
-          width: 1
-          bits: "0"
-          bitinfo:
-          [
-            1
-            1
-            0
-          ]
-          type: interrupt
-        }
-        {
-          name: classb
-          width: 1
-          bits: "1"
-          bitinfo:
-          [
-            2
-            1
-            1
-          ]
-          type: interrupt
-        }
-        {
-          name: classc
-          width: 1
-          bits: "2"
-          bitinfo:
-          [
-            4
-            1
-            2
-          ]
-          type: interrupt
-        }
-        {
-          name: classd
-          width: 1
-          bits: "3"
-          bitinfo:
-          [
-            8
-            1
-            3
-          ]
-          type: interrupt
-        }
-      ]
-      alert_list: []
-      wakeup_list: []
-      reset_request_list: []
-      scan: "false"
-      scan_reset: "false"
-      inter_signal_list:
-      [
-        {
-          struct: alert_crashdump
-          type: uni
-          name: crashdump
-          act: req
-          package: alert_pkg
-          inst_name: alert_handler
-          width: 1
-          default: ""
-          top_type: broadcast
-          top_signame: alert_handler_crashdump
-          index: -1
-        }
-        {
-          struct: logic
-          type: uni
-          name: entropy
-          default: " 1'b0"
-          act: rcv
-          inst_name: alert_handler
-          index: -1
-        }
-        {
-          struct: tl
-          package: tlul_pkg
-          type: req_rsp
-          act: rsp
-          name: tl
-          inst_name: alert_handler
-          width: 1
-          default: ""
-          top_signame: alert_handler_tl
-          index: -1
-        }
-      ]
-    }
-    {
-      name: nmi_gen
-      type: nmi_gen
-      clock_srcs:
-      {
-        clk_i: main
-      }
-      clock_group: secure
-      reset_connections:
-      {
-        rst_ni: rstmgr_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
-      }
-      base_addr: 0x411c0000
-      clock_reset_export: []
-      clock_connections:
-      {
-        clk_i: clkmgr_clocks.clk_main_secure
-      }
-      domain: "0"
-      size: 0x1000
-      bus_device: tlul
-      bus_host: none
-      available_input_list: []
-      available_output_list: []
-      available_inout_list: []
-      param_list: []
-      interrupt_list:
-      [
-        {
-          name: esc0
-          width: 1
-          bits: "0"
-          bitinfo:
-          [
-            1
-            1
-            0
-          ]
-          type: interrupt
-        }
-        {
-          name: esc1
-          width: 1
-          bits: "1"
-          bitinfo:
-          [
-            2
-            1
-            1
-          ]
-          type: interrupt
-        }
-        {
-          name: esc2
-          width: 1
-          bits: "2"
-          bitinfo:
-          [
-            4
-            1
-            2
-          ]
-          type: interrupt
-        }
-      ]
-      alert_list: []
-      wakeup_list: []
-      reset_request_list:
-      [
-        {
-          name: nmi_rst_req
-        }
-      ]
-      scan: "false"
-      scan_reset: "false"
-      inter_signal_list:
-      [
-        {
-          struct: logic
-          type: uni
-          name: nmi_rst_req
-          act: req
-          package: ""
-          default: 1'b0
-          inst_name: nmi_gen
-          width: 1
-          top_signame: pwrmgr_rstreqs
-          index: -1
-        }
-        {
-          struct: tl
-          package: tlul_pkg
-          type: req_rsp
-          act: rsp
-          name: tl
-          inst_name: nmi_gen
-          width: 1
-          default: ""
-          top_signame: nmi_gen_tl
-          index: -1
-        }
-      ]
-    }
-    {
       name: otbn
       type: otbn
       clock_srcs:
@@ -4748,7 +4748,7 @@
             0
           ]
           type: alert
-          async: 0
+          async: 1
         }
         {
           name: recoverable
@@ -4761,7 +4761,7 @@
             1
           ]
           type: alert
-          async: 0
+          async: 1
         }
       ]
       wakeup_list: []
@@ -5242,14 +5242,6 @@
       [
         main.tl_padctrl
       ]
-      alert_handler.tl:
-      [
-        main.tl_alert_handler
-      ]
-      nmi_gen.tl:
-      [
-        main.tl_nmi_gen
-      ]
       otbn.tl:
       [
         main.tl_otbn
@@ -5305,6 +5297,14 @@
       sensor_ctrl.tl:
       [
         peri.tl_sensor_ctrl
+      ]
+      alert_handler.tl:
+      [
+        peri.tl_alert_handler
+      ]
+      nmi_gen.tl:
+      [
+        peri.tl_nmi_gen
       ]
     }
     top:
@@ -5390,8 +5390,6 @@
           rv_plic
           pinmux
           padctrl
-          alert_handler
-          nmi_gen
           otbn
           keymgr
           kmac
@@ -5412,8 +5410,6 @@
           rv_plic
           pinmux
           padctrl
-          alert_handler
-          nmi_gen
           otbn
           kmac
         ]
@@ -5749,40 +5745,6 @@
           pipeline: "true"
         }
         {
-          name: alert_handler
-          type: device
-          clock: clk_main_i
-          inst_type: alert_handler
-          pipeline_byp: "false"
-          addr_range:
-          [
-            {
-              base_addr: 0x411b0000
-              size_byte: 0x1000
-            }
-          ]
-          xbar: false
-          stub: false
-          pipeline: "true"
-        }
-        {
-          name: nmi_gen
-          type: device
-          clock: clk_main_i
-          inst_type: nmi_gen
-          pipeline_byp: "false"
-          addr_range:
-          [
-            {
-              base_addr: 0x411c0000
-              size_byte: 0x1000
-            }
-          ]
-          xbar: false
-          stub: false
-          pipeline: "true"
-        }
-        {
           name: otbn
           type: device
           clock: clk_main_i
@@ -6054,30 +6016,6 @@
         {
           struct: tl
           type: req_rsp
-          name: tl_alert_handler
-          act: req
-          package: tlul_pkg
-          inst_name: main
-          width: 1
-          default: ""
-          top_signame: alert_handler_tl
-          index: -1
-        }
-        {
-          struct: tl
-          type: req_rsp
-          name: tl_nmi_gen
-          act: req
-          package: tlul_pkg
-          inst_name: main
-          width: 1
-          default: ""
-          top_signame: nmi_gen_tl
-          index: -1
-        }
-        {
-          struct: tl
-          type: req_rsp
           name: tl_otbn
           act: req
           package: tlul_pkg
@@ -6135,6 +6073,8 @@
           otp_ctrl
           lc_ctrl
           sensor_ctrl
+          alert_handler
+          nmi_gen
           ast_wrapper
         ]
       }
@@ -6368,6 +6308,42 @@
           pipeline_byp: "true"
         }
         {
+          name: alert_handler
+          type: device
+          clock: clk_peri_i
+          reset: rst_peri_ni
+          pipeline: "false"
+          inst_type: alert_handler
+          addr_range:
+          [
+            {
+              base_addr: 0x40150000
+              size_byte: 0x1000
+            }
+          ]
+          xbar: false
+          stub: false
+          pipeline_byp: "true"
+        }
+        {
+          name: nmi_gen
+          type: device
+          clock: clk_peri_i
+          reset: rst_peri_ni
+          pipeline: "false"
+          inst_type: nmi_gen
+          addr_range:
+          [
+            {
+              base_addr: 0x40160000
+              size_byte: 0x1000
+            }
+          ]
+          xbar: false
+          stub: false
+          pipeline_byp: "true"
+        }
+        {
           name: ast_wrapper
           type: device
           clock: clk_peri_i
@@ -6543,6 +6519,30 @@
           width: 1
           default: ""
           top_signame: sensor_ctrl_tl
+          index: -1
+        }
+        {
+          struct: tl
+          type: req_rsp
+          name: tl_alert_handler
+          act: req
+          package: tlul_pkg
+          inst_name: peri
+          width: 1
+          default: ""
+          top_signame: alert_handler_tl
+          index: -1
+        }
+        {
+          struct: tl
+          type: req_rsp
+          name: tl_nmi_gen
+          act: req
+          package: tlul_pkg
+          inst_name: peri
+          width: 1
+          default: ""
+          top_signame: nmi_gen_tl
           index: -1
         }
         {
@@ -7478,7 +7478,7 @@
         0
       ]
       type: alert
-      async: 0
+      async: 1
       module_name: aes
     }
     {
@@ -7492,7 +7492,7 @@
         1
       ]
       type: alert
-      async: 0
+      async: 1
       module_name: aes
     }
     {
@@ -7506,7 +7506,7 @@
         0
       ]
       type: alert
-      async: 0
+      async: 1
       module_name: otbn
     }
     {
@@ -7520,7 +7520,7 @@
         1
       ]
       type: alert
-      async: 0
+      async: 1
       module_name: otbn
     }
     {
@@ -7534,7 +7534,7 @@
         0
       ]
       type: alert
-      async: 1
+      async: 0
       module_name: sensor_ctrl
     }
     {
@@ -7548,7 +7548,7 @@
         1
       ]
       type: alert
-      async: 1
+      async: 0
       module_name: sensor_ctrl
     }
     {
@@ -7562,7 +7562,7 @@
         2
       ]
       type: alert
-      async: 1
+      async: 0
       module_name: sensor_ctrl
     }
     {
@@ -7576,7 +7576,7 @@
         3
       ]
       type: alert
-      async: 1
+      async: 0
       module_name: sensor_ctrl
     }
     {
@@ -7590,7 +7590,7 @@
         4
       ]
       type: alert
-      async: 1
+      async: 0
       module_name: sensor_ctrl
     }
     {
@@ -7604,7 +7604,7 @@
         5
       ]
       type: alert
-      async: 1
+      async: 0
       module_name: sensor_ctrl
     }
     {
@@ -7618,7 +7618,7 @@
         6
       ]
       type: alert
-      async: 1
+      async: 0
       module_name: sensor_ctrl
     }
     {
@@ -7632,7 +7632,7 @@
         0
       ]
       type: alert
-      async: 0
+      async: 1
       module_name: keymgr
     }
     {
@@ -7646,7 +7646,7 @@
         1
       ]
       type: alert
-      async: 0
+      async: 1
       module_name: keymgr
     }
     {
@@ -7660,7 +7660,7 @@
         0
       ]
       type: alert
-      async: 1
+      async: 0
       module_name: otp_ctrl
     }
     {
@@ -7674,7 +7674,7 @@
         1
       ]
       type: alert
-      async: 1
+      async: 0
       module_name: otp_ctrl
     }
     {
@@ -7688,7 +7688,7 @@
         0
       ]
       type: alert
-      async: 1
+      async: 0
       module_name: lc_ctrl
     }
     {
@@ -7702,7 +7702,7 @@
         1
       ]
       type: alert
-      async: 1
+      async: 0
       module_name: lc_ctrl
     }
     {
@@ -7716,7 +7716,7 @@
         0
       ]
       type: alert
-      async: 0
+      async: 1
       module_name: entropy_src
     }
   ]
@@ -8687,6 +8687,64 @@
         width: 1
         default: ""
         top_signame: lc_ctrl_tl
+        index: -1
+      }
+      {
+        struct: alert_crashdump
+        type: uni
+        name: crashdump
+        act: req
+        package: alert_pkg
+        inst_name: alert_handler
+        width: 1
+        default: ""
+        top_type: broadcast
+        top_signame: alert_handler_crashdump
+        index: -1
+      }
+      {
+        struct: logic
+        type: uni
+        name: entropy
+        default: " 1'b0"
+        act: rcv
+        inst_name: alert_handler
+        index: -1
+      }
+      {
+        struct: tl
+        package: tlul_pkg
+        type: req_rsp
+        act: rsp
+        name: tl
+        inst_name: alert_handler
+        width: 1
+        default: ""
+        top_signame: alert_handler_tl
+        index: -1
+      }
+      {
+        struct: logic
+        type: uni
+        name: nmi_rst_req
+        act: req
+        package: ""
+        default: 1'b0
+        inst_name: nmi_gen
+        width: 1
+        top_signame: pwrmgr_rstreqs
+        index: -1
+      }
+      {
+        struct: tl
+        package: tlul_pkg
+        type: req_rsp
+        act: rsp
+        name: tl
+        inst_name: nmi_gen
+        width: 1
+        default: ""
+        top_signame: nmi_gen_tl
         index: -1
       }
       {
@@ -9721,64 +9779,6 @@
         index: -1
       }
       {
-        struct: alert_crashdump
-        type: uni
-        name: crashdump
-        act: req
-        package: alert_pkg
-        inst_name: alert_handler
-        width: 1
-        default: ""
-        top_type: broadcast
-        top_signame: alert_handler_crashdump
-        index: -1
-      }
-      {
-        struct: logic
-        type: uni
-        name: entropy
-        default: " 1'b0"
-        act: rcv
-        inst_name: alert_handler
-        index: -1
-      }
-      {
-        struct: tl
-        package: tlul_pkg
-        type: req_rsp
-        act: rsp
-        name: tl
-        inst_name: alert_handler
-        width: 1
-        default: ""
-        top_signame: alert_handler_tl
-        index: -1
-      }
-      {
-        struct: logic
-        type: uni
-        name: nmi_rst_req
-        act: req
-        package: ""
-        default: 1'b0
-        inst_name: nmi_gen
-        width: 1
-        top_signame: pwrmgr_rstreqs
-        index: -1
-      }
-      {
-        struct: tl
-        package: tlul_pkg
-        type: req_rsp
-        act: rsp
-        name: tl
-        inst_name: nmi_gen
-        width: 1
-        default: ""
-        top_signame: nmi_gen_tl
-        index: -1
-      }
-      {
         name: idle
         type: uni
         struct: logic
@@ -10157,30 +10157,6 @@
       {
         struct: tl
         type: req_rsp
-        name: tl_alert_handler
-        act: req
-        package: tlul_pkg
-        inst_name: main
-        width: 1
-        default: ""
-        top_signame: alert_handler_tl
-        index: -1
-      }
-      {
-        struct: tl
-        type: req_rsp
-        name: tl_nmi_gen
-        act: req
-        package: tlul_pkg
-        inst_name: main
-        width: 1
-        default: ""
-        top_signame: nmi_gen_tl
-        index: -1
-      }
-      {
-        struct: tl
-        type: req_rsp
         name: tl_otbn
         act: req
         package: tlul_pkg
@@ -10356,6 +10332,30 @@
         width: 1
         default: ""
         top_signame: sensor_ctrl_tl
+        index: -1
+      }
+      {
+        struct: tl
+        type: req_rsp
+        name: tl_alert_handler
+        act: req
+        package: tlul_pkg
+        inst_name: peri
+        width: 1
+        default: ""
+        top_signame: alert_handler_tl
+        index: -1
+      }
+      {
+        struct: tl
+        type: req_rsp
+        name: tl_nmi_gen
+        act: req
+        package: tlul_pkg
+        inst_name: peri
+        width: 1
+        default: ""
+        top_signame: nmi_gen_tl
         index: -1
       }
       {
@@ -11202,38 +11202,6 @@
       {
         package: tlul_pkg
         struct: tl_h2d
-        signame: alert_handler_tl_req
-        width: 1
-        type: req_rsp
-        default: ""
-      }
-      {
-        package: tlul_pkg
-        struct: tl_d2h
-        signame: alert_handler_tl_rsp
-        width: 1
-        type: req_rsp
-        default: ""
-      }
-      {
-        package: tlul_pkg
-        struct: tl_h2d
-        signame: nmi_gen_tl_req
-        width: 1
-        type: req_rsp
-        default: ""
-      }
-      {
-        package: tlul_pkg
-        struct: tl_d2h
-        signame: nmi_gen_tl_rsp
-        width: 1
-        type: req_rsp
-        default: ""
-      }
-      {
-        package: tlul_pkg
-        struct: tl_h2d
         signame: otbn_tl_req
         width: 1
         type: req_rsp
@@ -11451,6 +11419,38 @@
         package: tlul_pkg
         struct: tl_d2h
         signame: sensor_ctrl_tl_rsp
+        width: 1
+        type: req_rsp
+        default: ""
+      }
+      {
+        package: tlul_pkg
+        struct: tl_h2d
+        signame: alert_handler_tl_req
+        width: 1
+        type: req_rsp
+        default: ""
+      }
+      {
+        package: tlul_pkg
+        struct: tl_d2h
+        signame: alert_handler_tl_rsp
+        width: 1
+        type: req_rsp
+        default: ""
+      }
+      {
+        package: tlul_pkg
+        struct: tl_h2d
+        signame: nmi_gen_tl_req
+        width: 1
+        type: req_rsp
+        default: ""
+      }
+      {
+        package: tlul_pkg
+        struct: tl_d2h
+        signame: nmi_gen_tl_rsp
         width: 1
         type: req_rsp
         default: ""

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -82,7 +82,7 @@
     // The powerup and proc groups are unique.
     // The powerup group of clocks do not feed through the clock
     // controller as they manage clock controller behavior
-    // The proc group is not peripheral, and direclty hardwired
+    // The proc group is not peripheral, and directly hardwired
 
     groups: [
       // the powerup group is used exclusively by clk/pwr/rstmgr
@@ -228,6 +228,28 @@
       reset_connections: {rst_ni: "lc_io_div4"},
       base_addr: "0x40140000",
     },
+    { name: "alert_handler",
+      type: "alert_handler",
+      clock_srcs: {clk_i: "io_div4"},
+      clock_group: "timers",
+      reset_connections: {rst_ni: "sys_io_div4"},
+      base_addr: "0x40150000",
+      generated: "true"         // Indicate this module is generated in the topgen
+      localparam: {
+        EscCntDw:  32,
+        AccuCntDw: 16,
+        LfsrSeed:  "0x7FFFFFFF"
+      }
+    },
+    // dummy module to capture the alert handler escalation signals
+    // and test them by converting them into IRQs
+    { name: "nmi_gen",
+      type: "nmi_gen",
+      clock_srcs: {clk_i: "io_div4"},
+      clock_group: "timers",
+      reset_connections: {rst_ni: "sys_io_div4"},
+      base_addr: "0x40160000",
+    }
     { name: "pwrmgr",
       type: "pwrmgr",
       clock_srcs: {clk_i: "io_div4", clk_slow_i: "aon"},
@@ -361,28 +383,6 @@
       clock_group: "secure",
       reset_connections: {rst_ni: "sys"},
       base_addr: "0x41180000",
-    },
-    { name: "alert_handler",
-      type: "alert_handler",
-      clock_srcs: {clk_i: "main"},
-      clock_group: "secure",
-      reset_connections: {rst_ni: "sys"},
-      base_addr: "0x411b0000",
-      generated: "true"         // Indicate this module is generated in the topgen
-      localparam: {
-        EscCntDw:  32,
-        AccuCntDw: 16,
-        LfsrSeed:  "0x7FFFFFFF"
-      }
-    },
-    // dummy module to capture the alert handler escalation signals
-    // and test them by converting them into IRQs
-    { name: "nmi_gen",
-      type: "nmi_gen",
-      clock_srcs: {clk_i: "main"},
-      clock_group: "secure",
-      reset_connections: {rst_ni: "sys"},
-      base_addr: "0x411c0000",
     },
     { name: "otbn",
       type: "otbn",

--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -28,6 +28,8 @@ clks_attr = top['clocks']
 cpu_clk = top['clocks']['hier_paths']['top'] + "clk_proc_main"
 cpu_rst = top["reset_paths"]["sys"]
 dm_rst = top["reset_paths"]["lc"]
+esc_clk = top['clocks']['hier_paths']['top'] + "clk_io_div4_timers"
+esc_rst = top["reset_paths"]["sys_io_div4"]
 
 unused_resets = lib.get_unused_resets(top)
 %>\
@@ -226,6 +228,8 @@ module top_${top["name"]} #(
     // clock and reset
     .clk_i                (${cpu_clk}),
     .rst_ni               (${cpu_rst}[rstmgr_pkg::Domain0Sel]),
+    .clk_esc_i            (${esc_clk}),
+    .rst_esc_ni           (${esc_rst}[rstmgr_pkg::Domain0Sel]),
     .test_en_i            (1'b0),
     // static pinning
     .hart_id_i            (32'b0),
@@ -240,8 +244,6 @@ module top_${top["name"]} #(
     .irq_timer_i          (intr_rv_timer_timer_expired_0_0),
     .irq_external_i       (irq_plic),
     // escalation input from alert handler (NMI)
-    // TODO: need to put the escalation receiver
-    // into the alert handler clock domain.
     .esc_tx_i             (esc_tx[0]),
     .esc_rx_o             (esc_rx[0]),
     // debug interface

--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -240,6 +240,8 @@ module top_${top["name"]} #(
     .irq_timer_i          (intr_rv_timer_timer_expired_0_0),
     .irq_external_i       (irq_plic),
     // escalation input from alert handler (NMI)
+    // TODO: need to put the escalation receiver
+    // into the alert handler clock domain.
     .esc_tx_i             (esc_tx[0]),
     .esc_rx_o             (esc_rx[0]),
     // debug interface

--- a/hw/top_earlgrey/data/xbar_main.hjson
+++ b/hw/top_earlgrey/data/xbar_main.hjson
@@ -141,20 +141,6 @@
         }],
       pipeline_byp: "false"
     },
-    { name:      "alert_handler",
-      type:      "device",
-      clock:     "clk_main_i",
-      inst_type: "alert_handler",
-      pipeline_byp: "false"
-    },
-    // dummy module to capture the alert handler escalation signals
-    // and test them by converting them into IRQs
-    { name:      "nmi_gen",
-      type:      "device",
-      clock:     "clk_main_i",
-      inst_type: "nmi_gen",
-      pipeline_byp: "false"
-    }
     { name:      "otbn",
       type:      "device",
       clock:     "clk_main_i"
@@ -172,9 +158,9 @@
     corei:  ["rom", "debug_mem", "ram_main", "eflash"],
     cored:  ["rom", "debug_mem", "ram_main", "eflash", "peri", "flash_ctrl",
     "aes", "entropy_src", "csrng", "edn0", "edn1",
-    "hmac", "rv_plic", "pinmux", "padctrl", "alert_handler", "nmi_gen", "otbn", "keymgr", "kmac"],
+    "hmac", "rv_plic", "pinmux", "padctrl", "otbn", "keymgr", "kmac"],
     dm_sba: ["rom",              "ram_main", "eflash", "peri", "flash_ctrl",
     "aes", "entropy_src", "csrng", "edn0", "edn1",
-    "hmac", "rv_plic", "pinmux", "padctrl", "alert_handler", "nmi_gen", "otbn", "kmac"],
+    "hmac", "rv_plic", "pinmux", "padctrl", "otbn", "kmac"],
   },
 }

--- a/hw/top_earlgrey/data/xbar_peri.hjson
+++ b/hw/top_earlgrey/data/xbar_peri.hjson
@@ -87,6 +87,20 @@
       reset:     "rst_peri_ni",
       pipeline:  "false",
     },
+    { name:      "alert_handler",
+      type:      "device",
+      clock:     "clk_peri_i",
+      reset:     "rst_peri_ni",
+      pipeline:  "false",
+    },
+    // dummy module to capture the alert handler escalation signals
+    // and test them by converting them into IRQs
+    { name:      "nmi_gen",
+      type:      "device",
+      clock:     "clk_peri_i",
+      reset:     "rst_peri_ni",
+      pipeline:  "false",
+    }
     { name:      "ast_wrapper",
       type:      "device",
       clock:     "clk_peri_i",
@@ -104,6 +118,6 @@
   ],
   connections: {
     main:  ["uart", "gpio", "spi_device", "rv_timer", "usbdev", "pwrmgr", "rstmgr", "clkmgr",
-            "ram_ret", "otp_ctrl", "lc_ctrl", "sensor_ctrl", "ast_wrapper"],
+            "ram_ret", "otp_ctrl", "lc_ctrl", "sensor_ctrl", "alert_handler", "nmi_gen", "ast_wrapper"],
   },
 }

--- a/hw/top_earlgrey/dv/autogen/tb__xbar_connect.sv
+++ b/hw/top_earlgrey/dv/autogen/tb__xbar_connect.sv
@@ -48,8 +48,6 @@ tl_if edn1_tl_if(clk_main, rst_n);
 tl_if rv_plic_tl_if(clk_main, rst_n);
 tl_if pinmux_tl_if(clk_main, rst_n);
 tl_if padctrl_tl_if(clk_main, rst_n);
-tl_if alert_handler_tl_if(clk_main, rst_n);
-tl_if nmi_gen_tl_if(clk_main, rst_n);
 tl_if otbn_tl_if(clk_main, rst_n);
 tl_if keymgr_tl_if(clk_main, rst_n);
 tl_if uart_tl_if(clk_io_div4, rst_n);
@@ -64,6 +62,8 @@ tl_if ram_ret_tl_if(clk_io_div4, rst_n);
 tl_if otp_ctrl_tl_if(clk_io_div4, rst_n);
 tl_if lc_ctrl_tl_if(clk_io_div4, rst_n);
 tl_if sensor_ctrl_tl_if(clk_io_div4, rst_n);
+tl_if alert_handler_tl_if(clk_io_div4, rst_n);
+tl_if nmi_gen_tl_if(clk_io_div4, rst_n);
 tl_if ast_wrapper_tl_if(clk_io_div4, rst_n);
 
 initial begin
@@ -108,8 +108,6 @@ initial begin
     `DRIVE_CHIP_TL_DEVICE_IF(rv_plic, rv_plic, tl)
     `DRIVE_CHIP_TL_DEVICE_IF(pinmux, pinmux, tl)
     `DRIVE_CHIP_TL_DEVICE_IF(padctrl, padctrl, tl)
-    `DRIVE_CHIP_TL_DEVICE_IF(alert_handler, alert_handler, tl)
-    `DRIVE_CHIP_TL_DEVICE_IF(nmi_gen, nmi_gen, tl)
     `DRIVE_CHIP_TL_DEVICE_IF(otbn, otbn, tl)
     `DRIVE_CHIP_TL_DEVICE_IF(keymgr, keymgr, tl)
     `DRIVE_CHIP_TL_DEVICE_IF(uart, uart, tl)
@@ -124,6 +122,8 @@ initial begin
     `DRIVE_CHIP_TL_DEVICE_IF(otp_ctrl, otp_ctrl, tl)
     `DRIVE_CHIP_TL_DEVICE_IF(lc_ctrl, lc_ctrl, tl)
     `DRIVE_CHIP_TL_DEVICE_IF(sensor_ctrl, sensor_ctrl, tl)
+    `DRIVE_CHIP_TL_DEVICE_IF(alert_handler, alert_handler, tl)
+    `DRIVE_CHIP_TL_DEVICE_IF(nmi_gen, nmi_gen, tl)
     `DRIVE_CHIP_TL_EXT_DEVICE_IF(ast_wrapper, ast_tl)
   end
 end

--- a/hw/top_earlgrey/dv/autogen/xbar_env_pkg__params.sv
+++ b/hw/top_earlgrey/dv/autogen/xbar_env_pkg__params.sv
@@ -52,12 +52,6 @@ tl_device_t xbar_devices[$] = '{
     '{"padctrl", '{
         '{32'h40470000, 32'h40470fff}
     }},
-    '{"alert_handler", '{
-        '{32'h411b0000, 32'h411b0fff}
-    }},
-    '{"nmi_gen", '{
-        '{32'h411c0000, 32'h411c0fff}
-    }},
     '{"otbn", '{
         '{32'h411d0000, 32'h411dffff}
     }},
@@ -100,6 +94,12 @@ tl_device_t xbar_devices[$] = '{
     '{"sensor_ctrl", '{
         '{32'h40110000, 32'h40110fff}
     }},
+    '{"alert_handler", '{
+        '{32'h40150000, 32'h40150fff}
+    }},
+    '{"nmi_gen", '{
+        '{32'h40160000, 32'h40160fff}
+    }},
     '{"ast_wrapper", '{
         '{32'h40180000, 32'h40180fff}
     }}};
@@ -129,6 +129,8 @@ tl_host_t xbar_hosts[$] = '{
         "otp_ctrl",
         "lc_ctrl",
         "sensor_ctrl",
+        "alert_handler",
+        "nmi_gen",
         "ast_wrapper",
         "flash_ctrl",
         "aes",
@@ -140,8 +142,6 @@ tl_host_t xbar_hosts[$] = '{
         "rv_plic",
         "pinmux",
         "padctrl",
-        "alert_handler",
-        "nmi_gen",
         "otbn",
         "keymgr",
         "kmac"}}
@@ -162,6 +162,8 @@ tl_host_t xbar_hosts[$] = '{
         "otp_ctrl",
         "lc_ctrl",
         "sensor_ctrl",
+        "alert_handler",
+        "nmi_gen",
         "ast_wrapper",
         "flash_ctrl",
         "aes",
@@ -173,8 +175,6 @@ tl_host_t xbar_hosts[$] = '{
         "rv_plic",
         "pinmux",
         "padctrl",
-        "alert_handler",
-        "nmi_gen",
         "otbn",
         "kmac"}}
 };

--- a/hw/top_earlgrey/ip/alert_handler/data/autogen/alert_handler.hjson
+++ b/hw/top_earlgrey/ip/alert_handler/data/autogen/alert_handler.hjson
@@ -61,7 +61,7 @@
     { name: "AsyncOn",
       desc: "Number of peripheral outputs",
       type: "logic [NAlerts-1:0]",
-      default: "18'b011110011111110000",
+      default: "18'b100001100000001111",
       local: "true"
     },
     { name: "N_CLASSES",

--- a/hw/top_earlgrey/ip/alert_handler/dv/alert_handler_env_pkg__params.sv
+++ b/hw/top_earlgrey/ip/alert_handler/dv/alert_handler_env_pkg__params.sv
@@ -11,4 +11,4 @@
 // SPDX-License-Identifier: Apache-2.0
 
 parameter uint NUM_ALERTS = 18;
-parameter bit [NUM_ALERTS-1:0] ASYNC_ON = 18'b011110011111110000;
+parameter bit [NUM_ALERTS-1:0] ASYNC_ON = 18'b100001100000001111;

--- a/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_pkg.sv
@@ -10,7 +10,7 @@ package alert_handler_reg_pkg;
   parameter int NAlerts = 18;
   parameter int EscCntDw = 32;
   parameter int AccuCntDw = 16;
-  parameter logic [NAlerts-1:0] AsyncOn = 18'b011110011111110000;
+  parameter logic [NAlerts-1:0] AsyncOn = 18'b100001100000001111;
   parameter int N_CLASSES = 4;
   parameter int N_ESC_SEV = 4;
   parameter int N_PHASES = 4;

--- a/hw/top_earlgrey/ip/xbar_main/data/autogen/xbar_main.gen.hjson
+++ b/hw/top_earlgrey/ip/xbar_main/data/autogen/xbar_main.gen.hjson
@@ -53,8 +53,6 @@
       rv_plic
       pinmux
       padctrl
-      alert_handler
-      nmi_gen
       otbn
       keymgr
       kmac
@@ -75,8 +73,6 @@
       rv_plic
       pinmux
       padctrl
-      alert_handler
-      nmi_gen
       otbn
       kmac
     ]
@@ -407,40 +403,6 @@
         }
       ]
       pipeline_byp: "false"
-      xbar: false
-      stub: false
-      pipeline: "true"
-    }
-    {
-      name: alert_handler
-      type: device
-      clock: clk_main_i
-      inst_type: alert_handler
-      pipeline_byp: "false"
-      addr_range:
-      [
-        {
-          base_addr: 0x411b0000
-          size_byte: 0x1000
-        }
-      ]
-      xbar: false
-      stub: false
-      pipeline: "true"
-    }
-    {
-      name: nmi_gen
-      type: device
-      clock: clk_main_i
-      inst_type: nmi_gen
-      pipeline_byp: "false"
-      addr_range:
-      [
-        {
-          base_addr: 0x411c0000
-          size_byte: 0x1000
-        }
-      ]
       xbar: false
       stub: false
       pipeline: "true"

--- a/hw/top_earlgrey/ip/xbar_main/data/autogen/xbar_main.hjson
+++ b/hw/top_earlgrey/ip/xbar_main/data/autogen/xbar_main.hjson
@@ -129,18 +129,6 @@
     }
     { struct: "tl"
       type:   "req_rsp"
-      name:   "tl_alert_handler"
-      act:    "req"
-      package: "tlul_pkg"
-    }
-    { struct: "tl"
-      type:   "req_rsp"
-      name:   "tl_nmi_gen"
-      act:    "req"
-      package: "tlul_pkg"
-    }
-    { struct: "tl"
-      type:   "req_rsp"
       name:   "tl_otbn"
       act:    "req"
       package: "tlul_pkg"

--- a/hw/top_earlgrey/ip/xbar_main/dv/autogen/tb__xbar_connect.sv
+++ b/hw/top_earlgrey/ip/xbar_main/dv/autogen/tb__xbar_connect.sv
@@ -38,7 +38,5 @@ initial force dut.rst_fixed_ni = rst_n;
 `CONNECT_TL_DEVICE_IF(rv_plic, dut, clk_main_i, rst_n)
 `CONNECT_TL_DEVICE_IF(pinmux, dut, clk_main_i, rst_n)
 `CONNECT_TL_DEVICE_IF(padctrl, dut, clk_main_i, rst_n)
-`CONNECT_TL_DEVICE_IF(alert_handler, dut, clk_main_i, rst_n)
-`CONNECT_TL_DEVICE_IF(nmi_gen, dut, clk_main_i, rst_n)
 `CONNECT_TL_DEVICE_IF(otbn, dut, clk_main_i, rst_n)
 `CONNECT_TL_DEVICE_IF(keymgr, dut, clk_main_i, rst_n)

--- a/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_env_pkg__params.sv
+++ b/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_env_pkg__params.sv
@@ -57,12 +57,6 @@ tl_device_t xbar_devices[$] = '{
     '{"padctrl", '{
         '{32'h40470000, 32'h40470fff}
     }},
-    '{"alert_handler", '{
-        '{32'h411b0000, 32'h411b0fff}
-    }},
-    '{"nmi_gen", '{
-        '{32'h411c0000, 32'h411c0fff}
-    }},
     '{"otbn", '{
         '{32'h411d0000, 32'h411dffff}
     }},
@@ -94,8 +88,6 @@ tl_host_t xbar_hosts[$] = '{
         "rv_plic",
         "pinmux",
         "padctrl",
-        "alert_handler",
-        "nmi_gen",
         "otbn",
         "keymgr",
         "kmac"}}
@@ -115,8 +107,6 @@ tl_host_t xbar_hosts[$] = '{
         "rv_plic",
         "pinmux",
         "padctrl",
-        "alert_handler",
-        "nmi_gen",
         "otbn",
         "kmac"}}
 };

--- a/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_main_bind.sv
+++ b/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_main_bind.sv
@@ -122,18 +122,6 @@ module xbar_main_bind;
     .h2d    (tl_padctrl_o),
     .d2h    (tl_padctrl_i)
   );
-  bind xbar_main tlul_assert #(.EndpointType("Host")) tlul_assert_device_alert_handler (
-    .clk_i  (clk_main_i),
-    .rst_ni (rst_main_ni),
-    .h2d    (tl_alert_handler_o),
-    .d2h    (tl_alert_handler_i)
-  );
-  bind xbar_main tlul_assert #(.EndpointType("Host")) tlul_assert_device_nmi_gen (
-    .clk_i  (clk_main_i),
-    .rst_ni (rst_main_ni),
-    .h2d    (tl_nmi_gen_o),
-    .d2h    (tl_nmi_gen_i)
-  );
   bind xbar_main tlul_assert #(.EndpointType("Host")) tlul_assert_device_otbn (
     .clk_i  (clk_main_i),
     .rst_ni (rst_main_ni),

--- a/hw/top_earlgrey/ip/xbar_main/rtl/autogen/tl_main_pkg.sv
+++ b/hw/top_earlgrey/ip/xbar_main/rtl/autogen/tl_main_pkg.sv
@@ -6,58 +6,54 @@
 
 package tl_main_pkg;
 
-  localparam logic [31:0] ADDR_SPACE_ROM           = 32'h 00008000;
-  localparam logic [31:0] ADDR_SPACE_DEBUG_MEM     = 32'h 1a110000;
-  localparam logic [31:0] ADDR_SPACE_RAM_MAIN      = 32'h 10000000;
-  localparam logic [31:0] ADDR_SPACE_EFLASH        = 32'h 20000000;
-  localparam logic [2:0][31:0] ADDR_SPACE_PERI          = {
+  localparam logic [31:0] ADDR_SPACE_ROM         = 32'h 00008000;
+  localparam logic [31:0] ADDR_SPACE_DEBUG_MEM   = 32'h 1a110000;
+  localparam logic [31:0] ADDR_SPACE_RAM_MAIN    = 32'h 10000000;
+  localparam logic [31:0] ADDR_SPACE_EFLASH      = 32'h 20000000;
+  localparam logic [2:0][31:0] ADDR_SPACE_PERI        = {
     32'h 40500000,
     32'h 40000000,
     32'h 18000000
   };
-  localparam logic [31:0] ADDR_SPACE_FLASH_CTRL    = 32'h 41000000;
-  localparam logic [31:0] ADDR_SPACE_HMAC          = 32'h 41110000;
-  localparam logic [31:0] ADDR_SPACE_KMAC          = 32'h 41120000;
-  localparam logic [31:0] ADDR_SPACE_AES           = 32'h 41100000;
-  localparam logic [31:0] ADDR_SPACE_ENTROPY_SRC   = 32'h 41160000;
-  localparam logic [31:0] ADDR_SPACE_CSRNG         = 32'h 41150000;
-  localparam logic [31:0] ADDR_SPACE_EDN0          = 32'h 41170000;
-  localparam logic [31:0] ADDR_SPACE_EDN1          = 32'h 41180000;
-  localparam logic [31:0] ADDR_SPACE_RV_PLIC       = 32'h 41010000;
-  localparam logic [31:0] ADDR_SPACE_PINMUX        = 32'h 40460000;
-  localparam logic [31:0] ADDR_SPACE_PADCTRL       = 32'h 40470000;
-  localparam logic [31:0] ADDR_SPACE_ALERT_HANDLER = 32'h 411b0000;
-  localparam logic [31:0] ADDR_SPACE_NMI_GEN       = 32'h 411c0000;
-  localparam logic [31:0] ADDR_SPACE_OTBN          = 32'h 411d0000;
-  localparam logic [31:0] ADDR_SPACE_KEYMGR        = 32'h 41130000;
+  localparam logic [31:0] ADDR_SPACE_FLASH_CTRL  = 32'h 41000000;
+  localparam logic [31:0] ADDR_SPACE_HMAC        = 32'h 41110000;
+  localparam logic [31:0] ADDR_SPACE_KMAC        = 32'h 41120000;
+  localparam logic [31:0] ADDR_SPACE_AES         = 32'h 41100000;
+  localparam logic [31:0] ADDR_SPACE_ENTROPY_SRC = 32'h 41160000;
+  localparam logic [31:0] ADDR_SPACE_CSRNG       = 32'h 41150000;
+  localparam logic [31:0] ADDR_SPACE_EDN0        = 32'h 41170000;
+  localparam logic [31:0] ADDR_SPACE_EDN1        = 32'h 41180000;
+  localparam logic [31:0] ADDR_SPACE_RV_PLIC     = 32'h 41010000;
+  localparam logic [31:0] ADDR_SPACE_PINMUX      = 32'h 40460000;
+  localparam logic [31:0] ADDR_SPACE_PADCTRL     = 32'h 40470000;
+  localparam logic [31:0] ADDR_SPACE_OTBN        = 32'h 411d0000;
+  localparam logic [31:0] ADDR_SPACE_KEYMGR      = 32'h 41130000;
 
-  localparam logic [31:0] ADDR_MASK_ROM           = 32'h 00003fff;
-  localparam logic [31:0] ADDR_MASK_DEBUG_MEM     = 32'h 00000fff;
-  localparam logic [31:0] ADDR_MASK_RAM_MAIN      = 32'h 0000ffff;
-  localparam logic [31:0] ADDR_MASK_EFLASH        = 32'h 0007ffff;
-  localparam logic [2:0][31:0] ADDR_MASK_PERI          = {
+  localparam logic [31:0] ADDR_MASK_ROM         = 32'h 00003fff;
+  localparam logic [31:0] ADDR_MASK_DEBUG_MEM   = 32'h 00000fff;
+  localparam logic [31:0] ADDR_MASK_RAM_MAIN    = 32'h 0000ffff;
+  localparam logic [31:0] ADDR_MASK_EFLASH      = 32'h 0007ffff;
+  localparam logic [2:0][31:0] ADDR_MASK_PERI        = {
     32'h 00000fff,
     32'h 00420fff,
     32'h 00000fff
   };
-  localparam logic [31:0] ADDR_MASK_FLASH_CTRL    = 32'h 00000fff;
-  localparam logic [31:0] ADDR_MASK_HMAC          = 32'h 00000fff;
-  localparam logic [31:0] ADDR_MASK_KMAC          = 32'h 00000fff;
-  localparam logic [31:0] ADDR_MASK_AES           = 32'h 00000fff;
-  localparam logic [31:0] ADDR_MASK_ENTROPY_SRC   = 32'h 00000fff;
-  localparam logic [31:0] ADDR_MASK_CSRNG         = 32'h 00000fff;
-  localparam logic [31:0] ADDR_MASK_EDN0          = 32'h 00000fff;
-  localparam logic [31:0] ADDR_MASK_EDN1          = 32'h 00000fff;
-  localparam logic [31:0] ADDR_MASK_RV_PLIC       = 32'h 00000fff;
-  localparam logic [31:0] ADDR_MASK_PINMUX        = 32'h 00000fff;
-  localparam logic [31:0] ADDR_MASK_PADCTRL       = 32'h 00000fff;
-  localparam logic [31:0] ADDR_MASK_ALERT_HANDLER = 32'h 00000fff;
-  localparam logic [31:0] ADDR_MASK_NMI_GEN       = 32'h 00000fff;
-  localparam logic [31:0] ADDR_MASK_OTBN          = 32'h 0000ffff;
-  localparam logic [31:0] ADDR_MASK_KEYMGR        = 32'h 00000fff;
+  localparam logic [31:0] ADDR_MASK_FLASH_CTRL  = 32'h 00000fff;
+  localparam logic [31:0] ADDR_MASK_HMAC        = 32'h 00000fff;
+  localparam logic [31:0] ADDR_MASK_KMAC        = 32'h 00000fff;
+  localparam logic [31:0] ADDR_MASK_AES         = 32'h 00000fff;
+  localparam logic [31:0] ADDR_MASK_ENTROPY_SRC = 32'h 00000fff;
+  localparam logic [31:0] ADDR_MASK_CSRNG       = 32'h 00000fff;
+  localparam logic [31:0] ADDR_MASK_EDN0        = 32'h 00000fff;
+  localparam logic [31:0] ADDR_MASK_EDN1        = 32'h 00000fff;
+  localparam logic [31:0] ADDR_MASK_RV_PLIC     = 32'h 00000fff;
+  localparam logic [31:0] ADDR_MASK_PINMUX      = 32'h 00000fff;
+  localparam logic [31:0] ADDR_MASK_PADCTRL     = 32'h 00000fff;
+  localparam logic [31:0] ADDR_MASK_OTBN        = 32'h 0000ffff;
+  localparam logic [31:0] ADDR_MASK_KEYMGR      = 32'h 00000fff;
 
   localparam int N_HOST   = 3;
-  localparam int N_DEVICE = 20;
+  localparam int N_DEVICE = 18;
 
   typedef enum int {
     TlRom = 0,
@@ -76,10 +72,8 @@ package tl_main_pkg;
     TlRvPlic = 13,
     TlPinmux = 14,
     TlPadctrl = 15,
-    TlAlertHandler = 16,
-    TlNmiGen = 17,
-    TlOtbn = 18,
-    TlKeymgr = 19
+    TlOtbn = 16,
+    TlKeymgr = 17
   } tl_device_e;
 
   typedef enum int {

--- a/hw/top_earlgrey/ip/xbar_main/rtl/autogen/xbar_main.sv
+++ b/hw/top_earlgrey/ip/xbar_main/rtl/autogen/xbar_main.sv
@@ -7,95 +7,87 @@
 //
 // Interconnect
 // corei
-//   -> s1n_23
-//     -> sm1_24
+//   -> s1n_21
+//     -> sm1_22
 //       -> rom
-//     -> sm1_25
+//     -> sm1_23
 //       -> debug_mem
-//     -> sm1_26
+//     -> sm1_24
 //       -> ram_main
-//     -> sm1_27
+//     -> sm1_25
 //       -> eflash
 // cored
-//   -> s1n_28
-//     -> sm1_24
+//   -> s1n_26
+//     -> sm1_22
 //       -> rom
-//     -> sm1_25
+//     -> sm1_23
 //       -> debug_mem
-//     -> sm1_26
+//     -> sm1_24
 //       -> ram_main
-//     -> sm1_27
+//     -> sm1_25
 //       -> eflash
-//     -> sm1_30
-//       -> asf_29
+//     -> sm1_28
+//       -> asf_27
 //         -> peri
-//     -> sm1_31
+//     -> sm1_29
 //       -> flash_ctrl
-//     -> sm1_32
+//     -> sm1_30
 //       -> aes
-//     -> sm1_33
+//     -> sm1_31
 //       -> entropy_src
-//     -> sm1_34
+//     -> sm1_32
 //       -> csrng
-//     -> sm1_35
+//     -> sm1_33
 //       -> edn0
-//     -> sm1_36
+//     -> sm1_34
 //       -> edn1
-//     -> sm1_37
+//     -> sm1_35
 //       -> hmac
-//     -> sm1_38
+//     -> sm1_36
 //       -> rv_plic
-//     -> sm1_39
+//     -> sm1_37
 //       -> pinmux
-//     -> sm1_40
+//     -> sm1_38
 //       -> padctrl
-//     -> sm1_41
-//       -> alert_handler
-//     -> sm1_42
-//       -> nmi_gen
-//     -> sm1_43
+//     -> sm1_39
 //       -> otbn
 //     -> keymgr
-//     -> sm1_44
+//     -> sm1_40
 //       -> kmac
 // dm_sba
-//   -> s1n_45
-//     -> sm1_24
+//   -> s1n_41
+//     -> sm1_22
 //       -> rom
-//     -> sm1_26
+//     -> sm1_24
 //       -> ram_main
-//     -> sm1_27
+//     -> sm1_25
 //       -> eflash
-//     -> sm1_30
-//       -> asf_29
+//     -> sm1_28
+//       -> asf_27
 //         -> peri
-//     -> sm1_31
+//     -> sm1_29
 //       -> flash_ctrl
-//     -> sm1_32
+//     -> sm1_30
 //       -> aes
-//     -> sm1_33
+//     -> sm1_31
 //       -> entropy_src
-//     -> sm1_34
+//     -> sm1_32
 //       -> csrng
-//     -> sm1_35
+//     -> sm1_33
 //       -> edn0
-//     -> sm1_36
+//     -> sm1_34
 //       -> edn1
-//     -> sm1_37
+//     -> sm1_35
 //       -> hmac
-//     -> sm1_38
+//     -> sm1_36
 //       -> rv_plic
-//     -> sm1_39
+//     -> sm1_37
 //       -> pinmux
-//     -> sm1_40
+//     -> sm1_38
 //       -> padctrl
-//     -> sm1_41
-//       -> alert_handler
-//     -> sm1_42
-//       -> nmi_gen
-//     -> sm1_43
+//     -> sm1_39
 //       -> otbn
-//     -> sm1_44
+//     -> sm1_40
 //       -> kmac
 
 module xbar_main (
@@ -145,10 +137,6 @@ module xbar_main (
   input  tlul_pkg::tl_d2h_t tl_pinmux_i,
   output tlul_pkg::tl_h2d_t tl_padctrl_o,
   input  tlul_pkg::tl_d2h_t tl_padctrl_i,
-  output tlul_pkg::tl_h2d_t tl_alert_handler_o,
-  input  tlul_pkg::tl_d2h_t tl_alert_handler_i,
-  output tlul_pkg::tl_h2d_t tl_nmi_gen_o,
-  input  tlul_pkg::tl_d2h_t tl_nmi_gen_i,
   output tlul_pkg::tl_h2d_t tl_otbn_o,
   input  tlul_pkg::tl_d2h_t tl_otbn_i,
   output tlul_pkg::tl_h2d_t tl_keymgr_o,
@@ -165,15 +153,29 @@ module xbar_main (
   logic unused_scanmode;
   assign unused_scanmode = scanmode_i;
 
-  tl_h2d_t tl_s1n_23_us_h2d ;
-  tl_d2h_t tl_s1n_23_us_d2h ;
+  tl_h2d_t tl_s1n_21_us_h2d ;
+  tl_d2h_t tl_s1n_21_us_d2h ;
 
 
-  tl_h2d_t tl_s1n_23_ds_h2d [4];
-  tl_d2h_t tl_s1n_23_ds_d2h [4];
+  tl_h2d_t tl_s1n_21_ds_h2d [4];
+  tl_d2h_t tl_s1n_21_ds_d2h [4];
 
   // Create steering signal
-  logic [2:0] dev_sel_s1n_23;
+  logic [2:0] dev_sel_s1n_21;
+
+
+  tl_h2d_t tl_sm1_22_us_h2d [3];
+  tl_d2h_t tl_sm1_22_us_d2h [3];
+
+  tl_h2d_t tl_sm1_22_ds_h2d ;
+  tl_d2h_t tl_sm1_22_ds_d2h ;
+
+
+  tl_h2d_t tl_sm1_23_us_h2d [2];
+  tl_d2h_t tl_sm1_23_us_d2h [2];
+
+  tl_h2d_t tl_sm1_23_ds_h2d ;
+  tl_d2h_t tl_sm1_23_ds_d2h ;
 
 
   tl_h2d_t tl_sm1_24_us_h2d [3];
@@ -183,40 +185,40 @@ module xbar_main (
   tl_d2h_t tl_sm1_24_ds_d2h ;
 
 
-  tl_h2d_t tl_sm1_25_us_h2d [2];
-  tl_d2h_t tl_sm1_25_us_d2h [2];
+  tl_h2d_t tl_sm1_25_us_h2d [3];
+  tl_d2h_t tl_sm1_25_us_d2h [3];
 
   tl_h2d_t tl_sm1_25_ds_h2d ;
   tl_d2h_t tl_sm1_25_ds_d2h ;
 
-
-  tl_h2d_t tl_sm1_26_us_h2d [3];
-  tl_d2h_t tl_sm1_26_us_d2h [3];
-
-  tl_h2d_t tl_sm1_26_ds_h2d ;
-  tl_d2h_t tl_sm1_26_ds_d2h ;
+  tl_h2d_t tl_s1n_26_us_h2d ;
+  tl_d2h_t tl_s1n_26_us_d2h ;
 
 
-  tl_h2d_t tl_sm1_27_us_h2d [3];
-  tl_d2h_t tl_sm1_27_us_d2h [3];
-
-  tl_h2d_t tl_sm1_27_ds_h2d ;
-  tl_d2h_t tl_sm1_27_ds_d2h ;
-
-  tl_h2d_t tl_s1n_28_us_h2d ;
-  tl_d2h_t tl_s1n_28_us_d2h ;
-
-
-  tl_h2d_t tl_s1n_28_ds_h2d [20];
-  tl_d2h_t tl_s1n_28_ds_d2h [20];
+  tl_h2d_t tl_s1n_26_ds_h2d [18];
+  tl_d2h_t tl_s1n_26_ds_d2h [18];
 
   // Create steering signal
-  logic [4:0] dev_sel_s1n_28;
+  logic [4:0] dev_sel_s1n_26;
 
-  tl_h2d_t tl_asf_29_us_h2d ;
-  tl_d2h_t tl_asf_29_us_d2h ;
-  tl_h2d_t tl_asf_29_ds_h2d ;
-  tl_d2h_t tl_asf_29_ds_d2h ;
+  tl_h2d_t tl_asf_27_us_h2d ;
+  tl_d2h_t tl_asf_27_us_d2h ;
+  tl_h2d_t tl_asf_27_ds_h2d ;
+  tl_d2h_t tl_asf_27_ds_d2h ;
+
+
+  tl_h2d_t tl_sm1_28_us_h2d [2];
+  tl_d2h_t tl_sm1_28_us_d2h [2];
+
+  tl_h2d_t tl_sm1_28_ds_h2d ;
+  tl_d2h_t tl_sm1_28_ds_d2h ;
+
+
+  tl_h2d_t tl_sm1_29_us_h2d [2];
+  tl_d2h_t tl_sm1_29_us_d2h [2];
+
+  tl_h2d_t tl_sm1_29_ds_h2d ;
+  tl_d2h_t tl_sm1_29_ds_d2h ;
 
 
   tl_h2d_t tl_sm1_30_us_h2d [2];
@@ -295,391 +297,333 @@ module xbar_main (
   tl_h2d_t tl_sm1_40_ds_h2d ;
   tl_d2h_t tl_sm1_40_ds_d2h ;
 
-
-  tl_h2d_t tl_sm1_41_us_h2d [2];
-  tl_d2h_t tl_sm1_41_us_d2h [2];
-
-  tl_h2d_t tl_sm1_41_ds_h2d ;
-  tl_d2h_t tl_sm1_41_ds_d2h ;
+  tl_h2d_t tl_s1n_41_us_h2d ;
+  tl_d2h_t tl_s1n_41_us_d2h ;
 
 
-  tl_h2d_t tl_sm1_42_us_h2d [2];
-  tl_d2h_t tl_sm1_42_us_d2h [2];
-
-  tl_h2d_t tl_sm1_42_ds_h2d ;
-  tl_d2h_t tl_sm1_42_ds_d2h ;
-
-
-  tl_h2d_t tl_sm1_43_us_h2d [2];
-  tl_d2h_t tl_sm1_43_us_d2h [2];
-
-  tl_h2d_t tl_sm1_43_ds_h2d ;
-  tl_d2h_t tl_sm1_43_ds_d2h ;
-
-
-  tl_h2d_t tl_sm1_44_us_h2d [2];
-  tl_d2h_t tl_sm1_44_us_d2h [2];
-
-  tl_h2d_t tl_sm1_44_ds_h2d ;
-  tl_d2h_t tl_sm1_44_ds_d2h ;
-
-  tl_h2d_t tl_s1n_45_us_h2d ;
-  tl_d2h_t tl_s1n_45_us_d2h ;
-
-
-  tl_h2d_t tl_s1n_45_ds_h2d [18];
-  tl_d2h_t tl_s1n_45_ds_d2h [18];
+  tl_h2d_t tl_s1n_41_ds_h2d [16];
+  tl_d2h_t tl_s1n_41_ds_d2h [16];
 
   // Create steering signal
-  logic [4:0] dev_sel_s1n_45;
+  logic [4:0] dev_sel_s1n_41;
 
 
 
-  assign tl_sm1_24_us_h2d[0] = tl_s1n_23_ds_h2d[0];
-  assign tl_s1n_23_ds_d2h[0] = tl_sm1_24_us_d2h[0];
+  assign tl_sm1_22_us_h2d[0] = tl_s1n_21_ds_h2d[0];
+  assign tl_s1n_21_ds_d2h[0] = tl_sm1_22_us_d2h[0];
 
-  assign tl_sm1_25_us_h2d[0] = tl_s1n_23_ds_h2d[1];
-  assign tl_s1n_23_ds_d2h[1] = tl_sm1_25_us_d2h[0];
+  assign tl_sm1_23_us_h2d[0] = tl_s1n_21_ds_h2d[1];
+  assign tl_s1n_21_ds_d2h[1] = tl_sm1_23_us_d2h[0];
 
-  assign tl_sm1_26_us_h2d[0] = tl_s1n_23_ds_h2d[2];
-  assign tl_s1n_23_ds_d2h[2] = tl_sm1_26_us_d2h[0];
+  assign tl_sm1_24_us_h2d[0] = tl_s1n_21_ds_h2d[2];
+  assign tl_s1n_21_ds_d2h[2] = tl_sm1_24_us_d2h[0];
 
-  assign tl_sm1_27_us_h2d[0] = tl_s1n_23_ds_h2d[3];
-  assign tl_s1n_23_ds_d2h[3] = tl_sm1_27_us_d2h[0];
+  assign tl_sm1_25_us_h2d[0] = tl_s1n_21_ds_h2d[3];
+  assign tl_s1n_21_ds_d2h[3] = tl_sm1_25_us_d2h[0];
 
-  assign tl_sm1_24_us_h2d[1] = tl_s1n_28_ds_h2d[0];
-  assign tl_s1n_28_ds_d2h[0] = tl_sm1_24_us_d2h[1];
+  assign tl_sm1_22_us_h2d[1] = tl_s1n_26_ds_h2d[0];
+  assign tl_s1n_26_ds_d2h[0] = tl_sm1_22_us_d2h[1];
 
-  assign tl_sm1_25_us_h2d[1] = tl_s1n_28_ds_h2d[1];
-  assign tl_s1n_28_ds_d2h[1] = tl_sm1_25_us_d2h[1];
+  assign tl_sm1_23_us_h2d[1] = tl_s1n_26_ds_h2d[1];
+  assign tl_s1n_26_ds_d2h[1] = tl_sm1_23_us_d2h[1];
 
-  assign tl_sm1_26_us_h2d[1] = tl_s1n_28_ds_h2d[2];
-  assign tl_s1n_28_ds_d2h[2] = tl_sm1_26_us_d2h[1];
+  assign tl_sm1_24_us_h2d[1] = tl_s1n_26_ds_h2d[2];
+  assign tl_s1n_26_ds_d2h[2] = tl_sm1_24_us_d2h[1];
 
-  assign tl_sm1_27_us_h2d[1] = tl_s1n_28_ds_h2d[3];
-  assign tl_s1n_28_ds_d2h[3] = tl_sm1_27_us_d2h[1];
+  assign tl_sm1_25_us_h2d[1] = tl_s1n_26_ds_h2d[3];
+  assign tl_s1n_26_ds_d2h[3] = tl_sm1_25_us_d2h[1];
 
-  assign tl_sm1_30_us_h2d[0] = tl_s1n_28_ds_h2d[4];
-  assign tl_s1n_28_ds_d2h[4] = tl_sm1_30_us_d2h[0];
+  assign tl_sm1_28_us_h2d[0] = tl_s1n_26_ds_h2d[4];
+  assign tl_s1n_26_ds_d2h[4] = tl_sm1_28_us_d2h[0];
 
-  assign tl_sm1_31_us_h2d[0] = tl_s1n_28_ds_h2d[5];
-  assign tl_s1n_28_ds_d2h[5] = tl_sm1_31_us_d2h[0];
+  assign tl_sm1_29_us_h2d[0] = tl_s1n_26_ds_h2d[5];
+  assign tl_s1n_26_ds_d2h[5] = tl_sm1_29_us_d2h[0];
 
-  assign tl_sm1_32_us_h2d[0] = tl_s1n_28_ds_h2d[6];
-  assign tl_s1n_28_ds_d2h[6] = tl_sm1_32_us_d2h[0];
+  assign tl_sm1_30_us_h2d[0] = tl_s1n_26_ds_h2d[6];
+  assign tl_s1n_26_ds_d2h[6] = tl_sm1_30_us_d2h[0];
 
-  assign tl_sm1_33_us_h2d[0] = tl_s1n_28_ds_h2d[7];
-  assign tl_s1n_28_ds_d2h[7] = tl_sm1_33_us_d2h[0];
+  assign tl_sm1_31_us_h2d[0] = tl_s1n_26_ds_h2d[7];
+  assign tl_s1n_26_ds_d2h[7] = tl_sm1_31_us_d2h[0];
 
-  assign tl_sm1_34_us_h2d[0] = tl_s1n_28_ds_h2d[8];
-  assign tl_s1n_28_ds_d2h[8] = tl_sm1_34_us_d2h[0];
+  assign tl_sm1_32_us_h2d[0] = tl_s1n_26_ds_h2d[8];
+  assign tl_s1n_26_ds_d2h[8] = tl_sm1_32_us_d2h[0];
 
-  assign tl_sm1_35_us_h2d[0] = tl_s1n_28_ds_h2d[9];
-  assign tl_s1n_28_ds_d2h[9] = tl_sm1_35_us_d2h[0];
+  assign tl_sm1_33_us_h2d[0] = tl_s1n_26_ds_h2d[9];
+  assign tl_s1n_26_ds_d2h[9] = tl_sm1_33_us_d2h[0];
 
-  assign tl_sm1_36_us_h2d[0] = tl_s1n_28_ds_h2d[10];
-  assign tl_s1n_28_ds_d2h[10] = tl_sm1_36_us_d2h[0];
+  assign tl_sm1_34_us_h2d[0] = tl_s1n_26_ds_h2d[10];
+  assign tl_s1n_26_ds_d2h[10] = tl_sm1_34_us_d2h[0];
 
-  assign tl_sm1_37_us_h2d[0] = tl_s1n_28_ds_h2d[11];
-  assign tl_s1n_28_ds_d2h[11] = tl_sm1_37_us_d2h[0];
+  assign tl_sm1_35_us_h2d[0] = tl_s1n_26_ds_h2d[11];
+  assign tl_s1n_26_ds_d2h[11] = tl_sm1_35_us_d2h[0];
 
-  assign tl_sm1_38_us_h2d[0] = tl_s1n_28_ds_h2d[12];
-  assign tl_s1n_28_ds_d2h[12] = tl_sm1_38_us_d2h[0];
+  assign tl_sm1_36_us_h2d[0] = tl_s1n_26_ds_h2d[12];
+  assign tl_s1n_26_ds_d2h[12] = tl_sm1_36_us_d2h[0];
 
-  assign tl_sm1_39_us_h2d[0] = tl_s1n_28_ds_h2d[13];
-  assign tl_s1n_28_ds_d2h[13] = tl_sm1_39_us_d2h[0];
+  assign tl_sm1_37_us_h2d[0] = tl_s1n_26_ds_h2d[13];
+  assign tl_s1n_26_ds_d2h[13] = tl_sm1_37_us_d2h[0];
 
-  assign tl_sm1_40_us_h2d[0] = tl_s1n_28_ds_h2d[14];
-  assign tl_s1n_28_ds_d2h[14] = tl_sm1_40_us_d2h[0];
+  assign tl_sm1_38_us_h2d[0] = tl_s1n_26_ds_h2d[14];
+  assign tl_s1n_26_ds_d2h[14] = tl_sm1_38_us_d2h[0];
 
-  assign tl_sm1_41_us_h2d[0] = tl_s1n_28_ds_h2d[15];
-  assign tl_s1n_28_ds_d2h[15] = tl_sm1_41_us_d2h[0];
+  assign tl_sm1_39_us_h2d[0] = tl_s1n_26_ds_h2d[15];
+  assign tl_s1n_26_ds_d2h[15] = tl_sm1_39_us_d2h[0];
 
-  assign tl_sm1_42_us_h2d[0] = tl_s1n_28_ds_h2d[16];
-  assign tl_s1n_28_ds_d2h[16] = tl_sm1_42_us_d2h[0];
+  assign tl_keymgr_o = tl_s1n_26_ds_h2d[16];
+  assign tl_s1n_26_ds_d2h[16] = tl_keymgr_i;
 
-  assign tl_sm1_43_us_h2d[0] = tl_s1n_28_ds_h2d[17];
-  assign tl_s1n_28_ds_d2h[17] = tl_sm1_43_us_d2h[0];
+  assign tl_sm1_40_us_h2d[0] = tl_s1n_26_ds_h2d[17];
+  assign tl_s1n_26_ds_d2h[17] = tl_sm1_40_us_d2h[0];
 
-  assign tl_keymgr_o = tl_s1n_28_ds_h2d[18];
-  assign tl_s1n_28_ds_d2h[18] = tl_keymgr_i;
+  assign tl_sm1_22_us_h2d[2] = tl_s1n_41_ds_h2d[0];
+  assign tl_s1n_41_ds_d2h[0] = tl_sm1_22_us_d2h[2];
 
-  assign tl_sm1_44_us_h2d[0] = tl_s1n_28_ds_h2d[19];
-  assign tl_s1n_28_ds_d2h[19] = tl_sm1_44_us_d2h[0];
+  assign tl_sm1_24_us_h2d[2] = tl_s1n_41_ds_h2d[1];
+  assign tl_s1n_41_ds_d2h[1] = tl_sm1_24_us_d2h[2];
 
-  assign tl_sm1_24_us_h2d[2] = tl_s1n_45_ds_h2d[0];
-  assign tl_s1n_45_ds_d2h[0] = tl_sm1_24_us_d2h[2];
+  assign tl_sm1_25_us_h2d[2] = tl_s1n_41_ds_h2d[2];
+  assign tl_s1n_41_ds_d2h[2] = tl_sm1_25_us_d2h[2];
 
-  assign tl_sm1_26_us_h2d[2] = tl_s1n_45_ds_h2d[1];
-  assign tl_s1n_45_ds_d2h[1] = tl_sm1_26_us_d2h[2];
+  assign tl_sm1_28_us_h2d[1] = tl_s1n_41_ds_h2d[3];
+  assign tl_s1n_41_ds_d2h[3] = tl_sm1_28_us_d2h[1];
 
-  assign tl_sm1_27_us_h2d[2] = tl_s1n_45_ds_h2d[2];
-  assign tl_s1n_45_ds_d2h[2] = tl_sm1_27_us_d2h[2];
+  assign tl_sm1_29_us_h2d[1] = tl_s1n_41_ds_h2d[4];
+  assign tl_s1n_41_ds_d2h[4] = tl_sm1_29_us_d2h[1];
 
-  assign tl_sm1_30_us_h2d[1] = tl_s1n_45_ds_h2d[3];
-  assign tl_s1n_45_ds_d2h[3] = tl_sm1_30_us_d2h[1];
+  assign tl_sm1_30_us_h2d[1] = tl_s1n_41_ds_h2d[5];
+  assign tl_s1n_41_ds_d2h[5] = tl_sm1_30_us_d2h[1];
 
-  assign tl_sm1_31_us_h2d[1] = tl_s1n_45_ds_h2d[4];
-  assign tl_s1n_45_ds_d2h[4] = tl_sm1_31_us_d2h[1];
+  assign tl_sm1_31_us_h2d[1] = tl_s1n_41_ds_h2d[6];
+  assign tl_s1n_41_ds_d2h[6] = tl_sm1_31_us_d2h[1];
 
-  assign tl_sm1_32_us_h2d[1] = tl_s1n_45_ds_h2d[5];
-  assign tl_s1n_45_ds_d2h[5] = tl_sm1_32_us_d2h[1];
+  assign tl_sm1_32_us_h2d[1] = tl_s1n_41_ds_h2d[7];
+  assign tl_s1n_41_ds_d2h[7] = tl_sm1_32_us_d2h[1];
 
-  assign tl_sm1_33_us_h2d[1] = tl_s1n_45_ds_h2d[6];
-  assign tl_s1n_45_ds_d2h[6] = tl_sm1_33_us_d2h[1];
+  assign tl_sm1_33_us_h2d[1] = tl_s1n_41_ds_h2d[8];
+  assign tl_s1n_41_ds_d2h[8] = tl_sm1_33_us_d2h[1];
 
-  assign tl_sm1_34_us_h2d[1] = tl_s1n_45_ds_h2d[7];
-  assign tl_s1n_45_ds_d2h[7] = tl_sm1_34_us_d2h[1];
+  assign tl_sm1_34_us_h2d[1] = tl_s1n_41_ds_h2d[9];
+  assign tl_s1n_41_ds_d2h[9] = tl_sm1_34_us_d2h[1];
 
-  assign tl_sm1_35_us_h2d[1] = tl_s1n_45_ds_h2d[8];
-  assign tl_s1n_45_ds_d2h[8] = tl_sm1_35_us_d2h[1];
+  assign tl_sm1_35_us_h2d[1] = tl_s1n_41_ds_h2d[10];
+  assign tl_s1n_41_ds_d2h[10] = tl_sm1_35_us_d2h[1];
 
-  assign tl_sm1_36_us_h2d[1] = tl_s1n_45_ds_h2d[9];
-  assign tl_s1n_45_ds_d2h[9] = tl_sm1_36_us_d2h[1];
+  assign tl_sm1_36_us_h2d[1] = tl_s1n_41_ds_h2d[11];
+  assign tl_s1n_41_ds_d2h[11] = tl_sm1_36_us_d2h[1];
 
-  assign tl_sm1_37_us_h2d[1] = tl_s1n_45_ds_h2d[10];
-  assign tl_s1n_45_ds_d2h[10] = tl_sm1_37_us_d2h[1];
+  assign tl_sm1_37_us_h2d[1] = tl_s1n_41_ds_h2d[12];
+  assign tl_s1n_41_ds_d2h[12] = tl_sm1_37_us_d2h[1];
 
-  assign tl_sm1_38_us_h2d[1] = tl_s1n_45_ds_h2d[11];
-  assign tl_s1n_45_ds_d2h[11] = tl_sm1_38_us_d2h[1];
+  assign tl_sm1_38_us_h2d[1] = tl_s1n_41_ds_h2d[13];
+  assign tl_s1n_41_ds_d2h[13] = tl_sm1_38_us_d2h[1];
 
-  assign tl_sm1_39_us_h2d[1] = tl_s1n_45_ds_h2d[12];
-  assign tl_s1n_45_ds_d2h[12] = tl_sm1_39_us_d2h[1];
+  assign tl_sm1_39_us_h2d[1] = tl_s1n_41_ds_h2d[14];
+  assign tl_s1n_41_ds_d2h[14] = tl_sm1_39_us_d2h[1];
 
-  assign tl_sm1_40_us_h2d[1] = tl_s1n_45_ds_h2d[13];
-  assign tl_s1n_45_ds_d2h[13] = tl_sm1_40_us_d2h[1];
+  assign tl_sm1_40_us_h2d[1] = tl_s1n_41_ds_h2d[15];
+  assign tl_s1n_41_ds_d2h[15] = tl_sm1_40_us_d2h[1];
 
-  assign tl_sm1_41_us_h2d[1] = tl_s1n_45_ds_h2d[14];
-  assign tl_s1n_45_ds_d2h[14] = tl_sm1_41_us_d2h[1];
+  assign tl_s1n_21_us_h2d = tl_corei_i;
+  assign tl_corei_o = tl_s1n_21_us_d2h;
 
-  assign tl_sm1_42_us_h2d[1] = tl_s1n_45_ds_h2d[15];
-  assign tl_s1n_45_ds_d2h[15] = tl_sm1_42_us_d2h[1];
+  assign tl_rom_o = tl_sm1_22_ds_h2d;
+  assign tl_sm1_22_ds_d2h = tl_rom_i;
 
-  assign tl_sm1_43_us_h2d[1] = tl_s1n_45_ds_h2d[16];
-  assign tl_s1n_45_ds_d2h[16] = tl_sm1_43_us_d2h[1];
+  assign tl_debug_mem_o = tl_sm1_23_ds_h2d;
+  assign tl_sm1_23_ds_d2h = tl_debug_mem_i;
 
-  assign tl_sm1_44_us_h2d[1] = tl_s1n_45_ds_h2d[17];
-  assign tl_s1n_45_ds_d2h[17] = tl_sm1_44_us_d2h[1];
+  assign tl_ram_main_o = tl_sm1_24_ds_h2d;
+  assign tl_sm1_24_ds_d2h = tl_ram_main_i;
 
-  assign tl_s1n_23_us_h2d = tl_corei_i;
-  assign tl_corei_o = tl_s1n_23_us_d2h;
+  assign tl_eflash_o = tl_sm1_25_ds_h2d;
+  assign tl_sm1_25_ds_d2h = tl_eflash_i;
 
-  assign tl_rom_o = tl_sm1_24_ds_h2d;
-  assign tl_sm1_24_ds_d2h = tl_rom_i;
+  assign tl_s1n_26_us_h2d = tl_cored_i;
+  assign tl_cored_o = tl_s1n_26_us_d2h;
 
-  assign tl_debug_mem_o = tl_sm1_25_ds_h2d;
-  assign tl_sm1_25_ds_d2h = tl_debug_mem_i;
+  assign tl_peri_o = tl_asf_27_ds_h2d;
+  assign tl_asf_27_ds_d2h = tl_peri_i;
 
-  assign tl_ram_main_o = tl_sm1_26_ds_h2d;
-  assign tl_sm1_26_ds_d2h = tl_ram_main_i;
+  assign tl_asf_27_us_h2d = tl_sm1_28_ds_h2d;
+  assign tl_sm1_28_ds_d2h = tl_asf_27_us_d2h;
 
-  assign tl_eflash_o = tl_sm1_27_ds_h2d;
-  assign tl_sm1_27_ds_d2h = tl_eflash_i;
+  assign tl_flash_ctrl_o = tl_sm1_29_ds_h2d;
+  assign tl_sm1_29_ds_d2h = tl_flash_ctrl_i;
 
-  assign tl_s1n_28_us_h2d = tl_cored_i;
-  assign tl_cored_o = tl_s1n_28_us_d2h;
+  assign tl_aes_o = tl_sm1_30_ds_h2d;
+  assign tl_sm1_30_ds_d2h = tl_aes_i;
 
-  assign tl_peri_o = tl_asf_29_ds_h2d;
-  assign tl_asf_29_ds_d2h = tl_peri_i;
+  assign tl_entropy_src_o = tl_sm1_31_ds_h2d;
+  assign tl_sm1_31_ds_d2h = tl_entropy_src_i;
 
-  assign tl_asf_29_us_h2d = tl_sm1_30_ds_h2d;
-  assign tl_sm1_30_ds_d2h = tl_asf_29_us_d2h;
+  assign tl_csrng_o = tl_sm1_32_ds_h2d;
+  assign tl_sm1_32_ds_d2h = tl_csrng_i;
 
-  assign tl_flash_ctrl_o = tl_sm1_31_ds_h2d;
-  assign tl_sm1_31_ds_d2h = tl_flash_ctrl_i;
+  assign tl_edn0_o = tl_sm1_33_ds_h2d;
+  assign tl_sm1_33_ds_d2h = tl_edn0_i;
 
-  assign tl_aes_o = tl_sm1_32_ds_h2d;
-  assign tl_sm1_32_ds_d2h = tl_aes_i;
+  assign tl_edn1_o = tl_sm1_34_ds_h2d;
+  assign tl_sm1_34_ds_d2h = tl_edn1_i;
 
-  assign tl_entropy_src_o = tl_sm1_33_ds_h2d;
-  assign tl_sm1_33_ds_d2h = tl_entropy_src_i;
+  assign tl_hmac_o = tl_sm1_35_ds_h2d;
+  assign tl_sm1_35_ds_d2h = tl_hmac_i;
 
-  assign tl_csrng_o = tl_sm1_34_ds_h2d;
-  assign tl_sm1_34_ds_d2h = tl_csrng_i;
+  assign tl_rv_plic_o = tl_sm1_36_ds_h2d;
+  assign tl_sm1_36_ds_d2h = tl_rv_plic_i;
 
-  assign tl_edn0_o = tl_sm1_35_ds_h2d;
-  assign tl_sm1_35_ds_d2h = tl_edn0_i;
+  assign tl_pinmux_o = tl_sm1_37_ds_h2d;
+  assign tl_sm1_37_ds_d2h = tl_pinmux_i;
 
-  assign tl_edn1_o = tl_sm1_36_ds_h2d;
-  assign tl_sm1_36_ds_d2h = tl_edn1_i;
+  assign tl_padctrl_o = tl_sm1_38_ds_h2d;
+  assign tl_sm1_38_ds_d2h = tl_padctrl_i;
 
-  assign tl_hmac_o = tl_sm1_37_ds_h2d;
-  assign tl_sm1_37_ds_d2h = tl_hmac_i;
+  assign tl_otbn_o = tl_sm1_39_ds_h2d;
+  assign tl_sm1_39_ds_d2h = tl_otbn_i;
 
-  assign tl_rv_plic_o = tl_sm1_38_ds_h2d;
-  assign tl_sm1_38_ds_d2h = tl_rv_plic_i;
+  assign tl_kmac_o = tl_sm1_40_ds_h2d;
+  assign tl_sm1_40_ds_d2h = tl_kmac_i;
 
-  assign tl_pinmux_o = tl_sm1_39_ds_h2d;
-  assign tl_sm1_39_ds_d2h = tl_pinmux_i;
-
-  assign tl_padctrl_o = tl_sm1_40_ds_h2d;
-  assign tl_sm1_40_ds_d2h = tl_padctrl_i;
-
-  assign tl_alert_handler_o = tl_sm1_41_ds_h2d;
-  assign tl_sm1_41_ds_d2h = tl_alert_handler_i;
-
-  assign tl_nmi_gen_o = tl_sm1_42_ds_h2d;
-  assign tl_sm1_42_ds_d2h = tl_nmi_gen_i;
-
-  assign tl_otbn_o = tl_sm1_43_ds_h2d;
-  assign tl_sm1_43_ds_d2h = tl_otbn_i;
-
-  assign tl_kmac_o = tl_sm1_44_ds_h2d;
-  assign tl_sm1_44_ds_d2h = tl_kmac_i;
-
-  assign tl_s1n_45_us_h2d = tl_dm_sba_i;
-  assign tl_dm_sba_o = tl_s1n_45_us_d2h;
+  assign tl_s1n_41_us_h2d = tl_dm_sba_i;
+  assign tl_dm_sba_o = tl_s1n_41_us_d2h;
 
   always_comb begin
     // default steering to generate error response if address is not within the range
-    dev_sel_s1n_23 = 3'd4;
-    if ((tl_s1n_23_us_h2d.a_address & ~(ADDR_MASK_ROM)) == ADDR_SPACE_ROM) begin
-      dev_sel_s1n_23 = 3'd0;
+    dev_sel_s1n_21 = 3'd4;
+    if ((tl_s1n_21_us_h2d.a_address & ~(ADDR_MASK_ROM)) == ADDR_SPACE_ROM) begin
+      dev_sel_s1n_21 = 3'd0;
 
-    end else if ((tl_s1n_23_us_h2d.a_address & ~(ADDR_MASK_DEBUG_MEM)) == ADDR_SPACE_DEBUG_MEM) begin
-      dev_sel_s1n_23 = 3'd1;
+    end else if ((tl_s1n_21_us_h2d.a_address & ~(ADDR_MASK_DEBUG_MEM)) == ADDR_SPACE_DEBUG_MEM) begin
+      dev_sel_s1n_21 = 3'd1;
 
-    end else if ((tl_s1n_23_us_h2d.a_address & ~(ADDR_MASK_RAM_MAIN)) == ADDR_SPACE_RAM_MAIN) begin
-      dev_sel_s1n_23 = 3'd2;
+    end else if ((tl_s1n_21_us_h2d.a_address & ~(ADDR_MASK_RAM_MAIN)) == ADDR_SPACE_RAM_MAIN) begin
+      dev_sel_s1n_21 = 3'd2;
 
-    end else if ((tl_s1n_23_us_h2d.a_address & ~(ADDR_MASK_EFLASH)) == ADDR_SPACE_EFLASH) begin
-      dev_sel_s1n_23 = 3'd3;
+    end else if ((tl_s1n_21_us_h2d.a_address & ~(ADDR_MASK_EFLASH)) == ADDR_SPACE_EFLASH) begin
+      dev_sel_s1n_21 = 3'd3;
 end
   end
 
   always_comb begin
     // default steering to generate error response if address is not within the range
-    dev_sel_s1n_28 = 5'd20;
-    if ((tl_s1n_28_us_h2d.a_address & ~(ADDR_MASK_ROM)) == ADDR_SPACE_ROM) begin
-      dev_sel_s1n_28 = 5'd0;
+    dev_sel_s1n_26 = 5'd18;
+    if ((tl_s1n_26_us_h2d.a_address & ~(ADDR_MASK_ROM)) == ADDR_SPACE_ROM) begin
+      dev_sel_s1n_26 = 5'd0;
 
-    end else if ((tl_s1n_28_us_h2d.a_address & ~(ADDR_MASK_DEBUG_MEM)) == ADDR_SPACE_DEBUG_MEM) begin
-      dev_sel_s1n_28 = 5'd1;
+    end else if ((tl_s1n_26_us_h2d.a_address & ~(ADDR_MASK_DEBUG_MEM)) == ADDR_SPACE_DEBUG_MEM) begin
+      dev_sel_s1n_26 = 5'd1;
 
-    end else if ((tl_s1n_28_us_h2d.a_address & ~(ADDR_MASK_RAM_MAIN)) == ADDR_SPACE_RAM_MAIN) begin
-      dev_sel_s1n_28 = 5'd2;
+    end else if ((tl_s1n_26_us_h2d.a_address & ~(ADDR_MASK_RAM_MAIN)) == ADDR_SPACE_RAM_MAIN) begin
+      dev_sel_s1n_26 = 5'd2;
 
-    end else if ((tl_s1n_28_us_h2d.a_address & ~(ADDR_MASK_EFLASH)) == ADDR_SPACE_EFLASH) begin
-      dev_sel_s1n_28 = 5'd3;
+    end else if ((tl_s1n_26_us_h2d.a_address & ~(ADDR_MASK_EFLASH)) == ADDR_SPACE_EFLASH) begin
+      dev_sel_s1n_26 = 5'd3;
 
     end else if (
-      ((tl_s1n_28_us_h2d.a_address & ~(ADDR_MASK_PERI[0])) == ADDR_SPACE_PERI[0]) ||
-      ((tl_s1n_28_us_h2d.a_address <= (ADDR_MASK_PERI[1] + ADDR_SPACE_PERI[1])) &&
-       (tl_s1n_28_us_h2d.a_address >= ADDR_SPACE_PERI[1])) ||
-      ((tl_s1n_28_us_h2d.a_address <= (ADDR_MASK_PERI[2] + ADDR_SPACE_PERI[2])) &&
-       (tl_s1n_28_us_h2d.a_address >= ADDR_SPACE_PERI[2]))
+      ((tl_s1n_26_us_h2d.a_address & ~(ADDR_MASK_PERI[0])) == ADDR_SPACE_PERI[0]) ||
+      ((tl_s1n_26_us_h2d.a_address <= (ADDR_MASK_PERI[1] + ADDR_SPACE_PERI[1])) &&
+       (tl_s1n_26_us_h2d.a_address >= ADDR_SPACE_PERI[1])) ||
+      ((tl_s1n_26_us_h2d.a_address <= (ADDR_MASK_PERI[2] + ADDR_SPACE_PERI[2])) &&
+       (tl_s1n_26_us_h2d.a_address >= ADDR_SPACE_PERI[2]))
     ) begin
-      dev_sel_s1n_28 = 5'd4;
+      dev_sel_s1n_26 = 5'd4;
 
-    end else if ((tl_s1n_28_us_h2d.a_address & ~(ADDR_MASK_FLASH_CTRL)) == ADDR_SPACE_FLASH_CTRL) begin
-      dev_sel_s1n_28 = 5'd5;
+    end else if ((tl_s1n_26_us_h2d.a_address & ~(ADDR_MASK_FLASH_CTRL)) == ADDR_SPACE_FLASH_CTRL) begin
+      dev_sel_s1n_26 = 5'd5;
 
-    end else if ((tl_s1n_28_us_h2d.a_address & ~(ADDR_MASK_AES)) == ADDR_SPACE_AES) begin
-      dev_sel_s1n_28 = 5'd6;
+    end else if ((tl_s1n_26_us_h2d.a_address & ~(ADDR_MASK_AES)) == ADDR_SPACE_AES) begin
+      dev_sel_s1n_26 = 5'd6;
 
-    end else if ((tl_s1n_28_us_h2d.a_address & ~(ADDR_MASK_ENTROPY_SRC)) == ADDR_SPACE_ENTROPY_SRC) begin
-      dev_sel_s1n_28 = 5'd7;
+    end else if ((tl_s1n_26_us_h2d.a_address & ~(ADDR_MASK_ENTROPY_SRC)) == ADDR_SPACE_ENTROPY_SRC) begin
+      dev_sel_s1n_26 = 5'd7;
 
-    end else if ((tl_s1n_28_us_h2d.a_address & ~(ADDR_MASK_CSRNG)) == ADDR_SPACE_CSRNG) begin
-      dev_sel_s1n_28 = 5'd8;
+    end else if ((tl_s1n_26_us_h2d.a_address & ~(ADDR_MASK_CSRNG)) == ADDR_SPACE_CSRNG) begin
+      dev_sel_s1n_26 = 5'd8;
 
-    end else if ((tl_s1n_28_us_h2d.a_address & ~(ADDR_MASK_EDN0)) == ADDR_SPACE_EDN0) begin
-      dev_sel_s1n_28 = 5'd9;
+    end else if ((tl_s1n_26_us_h2d.a_address & ~(ADDR_MASK_EDN0)) == ADDR_SPACE_EDN0) begin
+      dev_sel_s1n_26 = 5'd9;
 
-    end else if ((tl_s1n_28_us_h2d.a_address & ~(ADDR_MASK_EDN1)) == ADDR_SPACE_EDN1) begin
-      dev_sel_s1n_28 = 5'd10;
+    end else if ((tl_s1n_26_us_h2d.a_address & ~(ADDR_MASK_EDN1)) == ADDR_SPACE_EDN1) begin
+      dev_sel_s1n_26 = 5'd10;
 
-    end else if ((tl_s1n_28_us_h2d.a_address & ~(ADDR_MASK_HMAC)) == ADDR_SPACE_HMAC) begin
-      dev_sel_s1n_28 = 5'd11;
+    end else if ((tl_s1n_26_us_h2d.a_address & ~(ADDR_MASK_HMAC)) == ADDR_SPACE_HMAC) begin
+      dev_sel_s1n_26 = 5'd11;
 
-    end else if ((tl_s1n_28_us_h2d.a_address & ~(ADDR_MASK_RV_PLIC)) == ADDR_SPACE_RV_PLIC) begin
-      dev_sel_s1n_28 = 5'd12;
+    end else if ((tl_s1n_26_us_h2d.a_address & ~(ADDR_MASK_RV_PLIC)) == ADDR_SPACE_RV_PLIC) begin
+      dev_sel_s1n_26 = 5'd12;
 
-    end else if ((tl_s1n_28_us_h2d.a_address & ~(ADDR_MASK_PINMUX)) == ADDR_SPACE_PINMUX) begin
-      dev_sel_s1n_28 = 5'd13;
+    end else if ((tl_s1n_26_us_h2d.a_address & ~(ADDR_MASK_PINMUX)) == ADDR_SPACE_PINMUX) begin
+      dev_sel_s1n_26 = 5'd13;
 
-    end else if ((tl_s1n_28_us_h2d.a_address & ~(ADDR_MASK_PADCTRL)) == ADDR_SPACE_PADCTRL) begin
-      dev_sel_s1n_28 = 5'd14;
+    end else if ((tl_s1n_26_us_h2d.a_address & ~(ADDR_MASK_PADCTRL)) == ADDR_SPACE_PADCTRL) begin
+      dev_sel_s1n_26 = 5'd14;
 
-    end else if ((tl_s1n_28_us_h2d.a_address & ~(ADDR_MASK_ALERT_HANDLER)) == ADDR_SPACE_ALERT_HANDLER) begin
-      dev_sel_s1n_28 = 5'd15;
+    end else if ((tl_s1n_26_us_h2d.a_address & ~(ADDR_MASK_OTBN)) == ADDR_SPACE_OTBN) begin
+      dev_sel_s1n_26 = 5'd15;
 
-    end else if ((tl_s1n_28_us_h2d.a_address & ~(ADDR_MASK_NMI_GEN)) == ADDR_SPACE_NMI_GEN) begin
-      dev_sel_s1n_28 = 5'd16;
+    end else if ((tl_s1n_26_us_h2d.a_address & ~(ADDR_MASK_KEYMGR)) == ADDR_SPACE_KEYMGR) begin
+      dev_sel_s1n_26 = 5'd16;
 
-    end else if ((tl_s1n_28_us_h2d.a_address & ~(ADDR_MASK_OTBN)) == ADDR_SPACE_OTBN) begin
-      dev_sel_s1n_28 = 5'd17;
-
-    end else if ((tl_s1n_28_us_h2d.a_address & ~(ADDR_MASK_KEYMGR)) == ADDR_SPACE_KEYMGR) begin
-      dev_sel_s1n_28 = 5'd18;
-
-    end else if ((tl_s1n_28_us_h2d.a_address & ~(ADDR_MASK_KMAC)) == ADDR_SPACE_KMAC) begin
-      dev_sel_s1n_28 = 5'd19;
+    end else if ((tl_s1n_26_us_h2d.a_address & ~(ADDR_MASK_KMAC)) == ADDR_SPACE_KMAC) begin
+      dev_sel_s1n_26 = 5'd17;
 end
   end
 
   always_comb begin
     // default steering to generate error response if address is not within the range
-    dev_sel_s1n_45 = 5'd18;
-    if ((tl_s1n_45_us_h2d.a_address & ~(ADDR_MASK_ROM)) == ADDR_SPACE_ROM) begin
-      dev_sel_s1n_45 = 5'd0;
+    dev_sel_s1n_41 = 5'd16;
+    if ((tl_s1n_41_us_h2d.a_address & ~(ADDR_MASK_ROM)) == ADDR_SPACE_ROM) begin
+      dev_sel_s1n_41 = 5'd0;
 
-    end else if ((tl_s1n_45_us_h2d.a_address & ~(ADDR_MASK_RAM_MAIN)) == ADDR_SPACE_RAM_MAIN) begin
-      dev_sel_s1n_45 = 5'd1;
+    end else if ((tl_s1n_41_us_h2d.a_address & ~(ADDR_MASK_RAM_MAIN)) == ADDR_SPACE_RAM_MAIN) begin
+      dev_sel_s1n_41 = 5'd1;
 
-    end else if ((tl_s1n_45_us_h2d.a_address & ~(ADDR_MASK_EFLASH)) == ADDR_SPACE_EFLASH) begin
-      dev_sel_s1n_45 = 5'd2;
+    end else if ((tl_s1n_41_us_h2d.a_address & ~(ADDR_MASK_EFLASH)) == ADDR_SPACE_EFLASH) begin
+      dev_sel_s1n_41 = 5'd2;
 
     end else if (
-      ((tl_s1n_45_us_h2d.a_address & ~(ADDR_MASK_PERI[0])) == ADDR_SPACE_PERI[0]) ||
-      ((tl_s1n_45_us_h2d.a_address <= (ADDR_MASK_PERI[1] + ADDR_SPACE_PERI[1])) &&
-       (tl_s1n_45_us_h2d.a_address >= ADDR_SPACE_PERI[1])) ||
-      ((tl_s1n_45_us_h2d.a_address <= (ADDR_MASK_PERI[2] + ADDR_SPACE_PERI[2])) &&
-       (tl_s1n_45_us_h2d.a_address >= ADDR_SPACE_PERI[2]))
+      ((tl_s1n_41_us_h2d.a_address & ~(ADDR_MASK_PERI[0])) == ADDR_SPACE_PERI[0]) ||
+      ((tl_s1n_41_us_h2d.a_address <= (ADDR_MASK_PERI[1] + ADDR_SPACE_PERI[1])) &&
+       (tl_s1n_41_us_h2d.a_address >= ADDR_SPACE_PERI[1])) ||
+      ((tl_s1n_41_us_h2d.a_address <= (ADDR_MASK_PERI[2] + ADDR_SPACE_PERI[2])) &&
+       (tl_s1n_41_us_h2d.a_address >= ADDR_SPACE_PERI[2]))
     ) begin
-      dev_sel_s1n_45 = 5'd3;
+      dev_sel_s1n_41 = 5'd3;
 
-    end else if ((tl_s1n_45_us_h2d.a_address & ~(ADDR_MASK_FLASH_CTRL)) == ADDR_SPACE_FLASH_CTRL) begin
-      dev_sel_s1n_45 = 5'd4;
+    end else if ((tl_s1n_41_us_h2d.a_address & ~(ADDR_MASK_FLASH_CTRL)) == ADDR_SPACE_FLASH_CTRL) begin
+      dev_sel_s1n_41 = 5'd4;
 
-    end else if ((tl_s1n_45_us_h2d.a_address & ~(ADDR_MASK_AES)) == ADDR_SPACE_AES) begin
-      dev_sel_s1n_45 = 5'd5;
+    end else if ((tl_s1n_41_us_h2d.a_address & ~(ADDR_MASK_AES)) == ADDR_SPACE_AES) begin
+      dev_sel_s1n_41 = 5'd5;
 
-    end else if ((tl_s1n_45_us_h2d.a_address & ~(ADDR_MASK_ENTROPY_SRC)) == ADDR_SPACE_ENTROPY_SRC) begin
-      dev_sel_s1n_45 = 5'd6;
+    end else if ((tl_s1n_41_us_h2d.a_address & ~(ADDR_MASK_ENTROPY_SRC)) == ADDR_SPACE_ENTROPY_SRC) begin
+      dev_sel_s1n_41 = 5'd6;
 
-    end else if ((tl_s1n_45_us_h2d.a_address & ~(ADDR_MASK_CSRNG)) == ADDR_SPACE_CSRNG) begin
-      dev_sel_s1n_45 = 5'd7;
+    end else if ((tl_s1n_41_us_h2d.a_address & ~(ADDR_MASK_CSRNG)) == ADDR_SPACE_CSRNG) begin
+      dev_sel_s1n_41 = 5'd7;
 
-    end else if ((tl_s1n_45_us_h2d.a_address & ~(ADDR_MASK_EDN0)) == ADDR_SPACE_EDN0) begin
-      dev_sel_s1n_45 = 5'd8;
+    end else if ((tl_s1n_41_us_h2d.a_address & ~(ADDR_MASK_EDN0)) == ADDR_SPACE_EDN0) begin
+      dev_sel_s1n_41 = 5'd8;
 
-    end else if ((tl_s1n_45_us_h2d.a_address & ~(ADDR_MASK_EDN1)) == ADDR_SPACE_EDN1) begin
-      dev_sel_s1n_45 = 5'd9;
+    end else if ((tl_s1n_41_us_h2d.a_address & ~(ADDR_MASK_EDN1)) == ADDR_SPACE_EDN1) begin
+      dev_sel_s1n_41 = 5'd9;
 
-    end else if ((tl_s1n_45_us_h2d.a_address & ~(ADDR_MASK_HMAC)) == ADDR_SPACE_HMAC) begin
-      dev_sel_s1n_45 = 5'd10;
+    end else if ((tl_s1n_41_us_h2d.a_address & ~(ADDR_MASK_HMAC)) == ADDR_SPACE_HMAC) begin
+      dev_sel_s1n_41 = 5'd10;
 
-    end else if ((tl_s1n_45_us_h2d.a_address & ~(ADDR_MASK_RV_PLIC)) == ADDR_SPACE_RV_PLIC) begin
-      dev_sel_s1n_45 = 5'd11;
+    end else if ((tl_s1n_41_us_h2d.a_address & ~(ADDR_MASK_RV_PLIC)) == ADDR_SPACE_RV_PLIC) begin
+      dev_sel_s1n_41 = 5'd11;
 
-    end else if ((tl_s1n_45_us_h2d.a_address & ~(ADDR_MASK_PINMUX)) == ADDR_SPACE_PINMUX) begin
-      dev_sel_s1n_45 = 5'd12;
+    end else if ((tl_s1n_41_us_h2d.a_address & ~(ADDR_MASK_PINMUX)) == ADDR_SPACE_PINMUX) begin
+      dev_sel_s1n_41 = 5'd12;
 
-    end else if ((tl_s1n_45_us_h2d.a_address & ~(ADDR_MASK_PADCTRL)) == ADDR_SPACE_PADCTRL) begin
-      dev_sel_s1n_45 = 5'd13;
+    end else if ((tl_s1n_41_us_h2d.a_address & ~(ADDR_MASK_PADCTRL)) == ADDR_SPACE_PADCTRL) begin
+      dev_sel_s1n_41 = 5'd13;
 
-    end else if ((tl_s1n_45_us_h2d.a_address & ~(ADDR_MASK_ALERT_HANDLER)) == ADDR_SPACE_ALERT_HANDLER) begin
-      dev_sel_s1n_45 = 5'd14;
+    end else if ((tl_s1n_41_us_h2d.a_address & ~(ADDR_MASK_OTBN)) == ADDR_SPACE_OTBN) begin
+      dev_sel_s1n_41 = 5'd14;
 
-    end else if ((tl_s1n_45_us_h2d.a_address & ~(ADDR_MASK_NMI_GEN)) == ADDR_SPACE_NMI_GEN) begin
-      dev_sel_s1n_45 = 5'd15;
-
-    end else if ((tl_s1n_45_us_h2d.a_address & ~(ADDR_MASK_OTBN)) == ADDR_SPACE_OTBN) begin
-      dev_sel_s1n_45 = 5'd16;
-
-    end else if ((tl_s1n_45_us_h2d.a_address & ~(ADDR_MASK_KMAC)) == ADDR_SPACE_KMAC) begin
-      dev_sel_s1n_45 = 5'd17;
+    end else if ((tl_s1n_41_us_h2d.a_address & ~(ADDR_MASK_KMAC)) == ADDR_SPACE_KMAC) begin
+      dev_sel_s1n_41 = 5'd15;
 end
   end
 
@@ -691,14 +635,42 @@ end
     .DReqDepth (16'h0),
     .DRspDepth (16'h0),
     .N         (4)
-  ) u_s1n_23 (
+  ) u_s1n_21 (
     .clk_i        (clk_main_i),
     .rst_ni       (rst_main_ni),
-    .tl_h_i       (tl_s1n_23_us_h2d),
-    .tl_h_o       (tl_s1n_23_us_d2h),
-    .tl_d_o       (tl_s1n_23_ds_h2d),
-    .tl_d_i       (tl_s1n_23_ds_d2h),
-    .dev_select_i (dev_sel_s1n_23)
+    .tl_h_i       (tl_s1n_21_us_h2d),
+    .tl_h_o       (tl_s1n_21_us_d2h),
+    .tl_d_o       (tl_s1n_21_ds_h2d),
+    .tl_d_i       (tl_s1n_21_ds_d2h),
+    .dev_select_i (dev_sel_s1n_21)
+  );
+  tlul_socket_m1 #(
+    .HReqDepth (12'h0),
+    .HRspDepth (12'h0),
+    .DReqDepth (4'h0),
+    .DRspDepth (4'h0),
+    .M         (3)
+  ) u_sm1_22 (
+    .clk_i        (clk_main_i),
+    .rst_ni       (rst_main_ni),
+    .tl_h_i       (tl_sm1_22_us_h2d),
+    .tl_h_o       (tl_sm1_22_us_d2h),
+    .tl_d_o       (tl_sm1_22_ds_h2d),
+    .tl_d_i       (tl_sm1_22_ds_d2h)
+  );
+  tlul_socket_m1 #(
+    .HReqDepth (8'h0),
+    .HRspDepth (8'h0),
+    .DReqPass  (1'b0),
+    .DRspPass  (1'b0),
+    .M         (2)
+  ) u_sm1_23 (
+    .clk_i        (clk_main_i),
+    .rst_ni       (rst_main_ni),
+    .tl_h_i       (tl_sm1_23_us_h2d),
+    .tl_h_o       (tl_sm1_23_us_d2h),
+    .tl_d_o       (tl_sm1_23_ds_h2d),
+    .tl_d_i       (tl_sm1_23_ds_d2h)
   );
   tlul_socket_m1 #(
     .HReqDepth (12'h0),
@@ -715,11 +687,11 @@ end
     .tl_d_i       (tl_sm1_24_ds_d2h)
   );
   tlul_socket_m1 #(
-    .HReqDepth (8'h0),
-    .HRspDepth (8'h0),
-    .DReqPass  (1'b0),
-    .DRspPass  (1'b0),
-    .M         (2)
+    .HReqDepth (12'h0),
+    .HRspDepth (12'h0),
+    .DReqDepth (4'h0),
+    .DRspDepth (4'h0),
+    .M         (3)
   ) u_sm1_25 (
     .clk_i        (clk_main_i),
     .rst_ni       (rst_main_ni),
@@ -728,69 +700,69 @@ end
     .tl_d_o       (tl_sm1_25_ds_h2d),
     .tl_d_i       (tl_sm1_25_ds_d2h)
   );
-  tlul_socket_m1 #(
-    .HReqDepth (12'h0),
-    .HRspDepth (12'h0),
-    .DReqDepth (4'h0),
-    .DRspDepth (4'h0),
-    .M         (3)
-  ) u_sm1_26 (
-    .clk_i        (clk_main_i),
-    .rst_ni       (rst_main_ni),
-    .tl_h_i       (tl_sm1_26_us_h2d),
-    .tl_h_o       (tl_sm1_26_us_d2h),
-    .tl_d_o       (tl_sm1_26_ds_h2d),
-    .tl_d_i       (tl_sm1_26_ds_d2h)
-  );
-  tlul_socket_m1 #(
-    .HReqDepth (12'h0),
-    .HRspDepth (12'h0),
-    .DReqDepth (4'h0),
-    .DRspDepth (4'h0),
-    .M         (3)
-  ) u_sm1_27 (
-    .clk_i        (clk_main_i),
-    .rst_ni       (rst_main_ni),
-    .tl_h_i       (tl_sm1_27_us_h2d),
-    .tl_h_o       (tl_sm1_27_us_d2h),
-    .tl_d_o       (tl_sm1_27_ds_h2d),
-    .tl_d_i       (tl_sm1_27_ds_d2h)
-  );
   tlul_socket_1n #(
     .HReqDepth (4'h0),
     .HRspDepth (4'h0),
-    .DReqPass  (20'hbffff),
-    .DRspPass  (20'hbffff),
-    .DReqDepth (80'h2000000000000000000),
-    .DRspDepth (80'h2000000000000000000),
-    .N         (20)
-  ) u_s1n_28 (
+    .DReqPass  (18'h2ffff),
+    .DRspPass  (18'h2ffff),
+    .DReqDepth (72'h20000000000000000),
+    .DRspDepth (72'h20000000000000000),
+    .N         (18)
+  ) u_s1n_26 (
     .clk_i        (clk_main_i),
     .rst_ni       (rst_main_ni),
-    .tl_h_i       (tl_s1n_28_us_h2d),
-    .tl_h_o       (tl_s1n_28_us_d2h),
-    .tl_d_o       (tl_s1n_28_ds_h2d),
-    .tl_d_i       (tl_s1n_28_ds_d2h),
-    .dev_select_i (dev_sel_s1n_28)
+    .tl_h_i       (tl_s1n_26_us_h2d),
+    .tl_h_o       (tl_s1n_26_us_d2h),
+    .tl_d_o       (tl_s1n_26_ds_h2d),
+    .tl_d_i       (tl_s1n_26_ds_d2h),
+    .dev_select_i (dev_sel_s1n_26)
   );
   tlul_fifo_async #(
     .ReqDepth        (3),// At least 3 to make async work
     .RspDepth        (3) // At least 3 to make async work
-  ) u_asf_29 (
+  ) u_asf_27 (
     .clk_h_i      (clk_main_i),
     .rst_h_ni     (rst_main_ni),
     .clk_d_i      (clk_fixed_i),
     .rst_d_ni     (rst_fixed_ni),
-    .tl_h_i       (tl_asf_29_us_h2d),
-    .tl_h_o       (tl_asf_29_us_d2h),
-    .tl_d_o       (tl_asf_29_ds_h2d),
-    .tl_d_i       (tl_asf_29_ds_d2h)
+    .tl_h_i       (tl_asf_27_us_h2d),
+    .tl_h_o       (tl_asf_27_us_d2h),
+    .tl_d_o       (tl_asf_27_ds_h2d),
+    .tl_d_i       (tl_asf_27_ds_d2h)
   );
   tlul_socket_m1 #(
     .HReqDepth (8'h0),
     .HRspDepth (8'h0),
     .DReqDepth (4'h0),
     .DRspDepth (4'h0),
+    .M         (2)
+  ) u_sm1_28 (
+    .clk_i        (clk_main_i),
+    .rst_ni       (rst_main_ni),
+    .tl_h_i       (tl_sm1_28_us_h2d),
+    .tl_h_o       (tl_sm1_28_us_d2h),
+    .tl_d_o       (tl_sm1_28_ds_h2d),
+    .tl_d_i       (tl_sm1_28_ds_d2h)
+  );
+  tlul_socket_m1 #(
+    .HReqDepth (8'h0),
+    .HRspDepth (8'h0),
+    .DReqPass  (1'b0),
+    .DRspPass  (1'b0),
+    .M         (2)
+  ) u_sm1_29 (
+    .clk_i        (clk_main_i),
+    .rst_ni       (rst_main_ni),
+    .tl_h_i       (tl_sm1_29_us_h2d),
+    .tl_h_o       (tl_sm1_29_us_d2h),
+    .tl_d_o       (tl_sm1_29_ds_h2d),
+    .tl_d_i       (tl_sm1_29_ds_d2h)
+  );
+  tlul_socket_m1 #(
+    .HReqDepth (8'h0),
+    .HRspDepth (8'h0),
+    .DReqPass  (1'b0),
+    .DRspPass  (1'b0),
     .M         (2)
   ) u_sm1_30 (
     .clk_i        (clk_main_i),
@@ -940,76 +912,20 @@ end
     .tl_d_o       (tl_sm1_40_ds_h2d),
     .tl_d_i       (tl_sm1_40_ds_d2h)
   );
-  tlul_socket_m1 #(
-    .HReqDepth (8'h0),
-    .HRspDepth (8'h0),
-    .DReqPass  (1'b0),
-    .DRspPass  (1'b0),
-    .M         (2)
-  ) u_sm1_41 (
-    .clk_i        (clk_main_i),
-    .rst_ni       (rst_main_ni),
-    .tl_h_i       (tl_sm1_41_us_h2d),
-    .tl_h_o       (tl_sm1_41_us_d2h),
-    .tl_d_o       (tl_sm1_41_ds_h2d),
-    .tl_d_i       (tl_sm1_41_ds_d2h)
-  );
-  tlul_socket_m1 #(
-    .HReqDepth (8'h0),
-    .HRspDepth (8'h0),
-    .DReqPass  (1'b0),
-    .DRspPass  (1'b0),
-    .M         (2)
-  ) u_sm1_42 (
-    .clk_i        (clk_main_i),
-    .rst_ni       (rst_main_ni),
-    .tl_h_i       (tl_sm1_42_us_h2d),
-    .tl_h_o       (tl_sm1_42_us_d2h),
-    .tl_d_o       (tl_sm1_42_ds_h2d),
-    .tl_d_i       (tl_sm1_42_ds_d2h)
-  );
-  tlul_socket_m1 #(
-    .HReqDepth (8'h0),
-    .HRspDepth (8'h0),
-    .DReqPass  (1'b0),
-    .DRspPass  (1'b0),
-    .M         (2)
-  ) u_sm1_43 (
-    .clk_i        (clk_main_i),
-    .rst_ni       (rst_main_ni),
-    .tl_h_i       (tl_sm1_43_us_h2d),
-    .tl_h_o       (tl_sm1_43_us_d2h),
-    .tl_d_o       (tl_sm1_43_ds_h2d),
-    .tl_d_i       (tl_sm1_43_ds_d2h)
-  );
-  tlul_socket_m1 #(
-    .HReqDepth (8'h0),
-    .HRspDepth (8'h0),
-    .DReqPass  (1'b0),
-    .DRspPass  (1'b0),
-    .M         (2)
-  ) u_sm1_44 (
-    .clk_i        (clk_main_i),
-    .rst_ni       (rst_main_ni),
-    .tl_h_i       (tl_sm1_44_us_h2d),
-    .tl_h_o       (tl_sm1_44_us_d2h),
-    .tl_d_o       (tl_sm1_44_ds_h2d),
-    .tl_d_i       (tl_sm1_44_ds_d2h)
-  );
   tlul_socket_1n #(
     .HReqPass  (1'b0),
     .HRspPass  (1'b0),
-    .DReqDepth (72'h0),
-    .DRspDepth (72'h0),
-    .N         (18)
-  ) u_s1n_45 (
+    .DReqDepth (64'h0),
+    .DRspDepth (64'h0),
+    .N         (16)
+  ) u_s1n_41 (
     .clk_i        (clk_main_i),
     .rst_ni       (rst_main_ni),
-    .tl_h_i       (tl_s1n_45_us_h2d),
-    .tl_h_o       (tl_s1n_45_us_d2h),
-    .tl_d_o       (tl_s1n_45_ds_h2d),
-    .tl_d_i       (tl_s1n_45_ds_d2h),
-    .dev_select_i (dev_sel_s1n_45)
+    .tl_h_i       (tl_s1n_41_us_h2d),
+    .tl_h_o       (tl_s1n_41_us_d2h),
+    .tl_d_o       (tl_s1n_41_ds_h2d),
+    .tl_d_i       (tl_s1n_41_ds_d2h),
+    .dev_select_i (dev_sel_s1n_41)
   );
 
 endmodule

--- a/hw/top_earlgrey/ip/xbar_peri/data/autogen/xbar_peri.gen.hjson
+++ b/hw/top_earlgrey/ip/xbar_peri/data/autogen/xbar_peri.gen.hjson
@@ -40,6 +40,8 @@
       otp_ctrl
       lc_ctrl
       sensor_ctrl
+      alert_handler
+      nmi_gen
       ast_wrapper
     ]
   }
@@ -265,6 +267,42 @@
       [
         {
           base_addr: 0x40110000
+          size_byte: 0x1000
+        }
+      ]
+      xbar: false
+      stub: false
+      pipeline_byp: "true"
+    }
+    {
+      name: alert_handler
+      type: device
+      clock: clk_peri_i
+      reset: rst_peri_ni
+      pipeline: "false"
+      inst_type: alert_handler
+      addr_range:
+      [
+        {
+          base_addr: 0x40150000
+          size_byte: 0x1000
+        }
+      ]
+      xbar: false
+      stub: false
+      pipeline_byp: "true"
+    }
+    {
+      name: nmi_gen
+      type: device
+      clock: clk_peri_i
+      reset: rst_peri_ni
+      pipeline: "false"
+      inst_type: nmi_gen
+      addr_range:
+      [
+        {
+          base_addr: 0x40160000
           size_byte: 0x1000
         }
       ]

--- a/hw/top_earlgrey/ip/xbar_peri/data/autogen/xbar_peri.hjson
+++ b/hw/top_earlgrey/ip/xbar_peri/data/autogen/xbar_peri.hjson
@@ -93,6 +93,18 @@
     }
     { struct: "tl"
       type:   "req_rsp"
+      name:   "tl_alert_handler"
+      act:    "req"
+      package: "tlul_pkg"
+    }
+    { struct: "tl"
+      type:   "req_rsp"
+      name:   "tl_nmi_gen"
+      act:    "req"
+      package: "tlul_pkg"
+    }
+    { struct: "tl"
+      type:   "req_rsp"
       name:   "tl_ast_wrapper"
       act:    "req"
       package: "tlul_pkg"

--- a/hw/top_earlgrey/ip/xbar_peri/dv/autogen/tb__xbar_connect.sv
+++ b/hw/top_earlgrey/ip/xbar_peri/dv/autogen/tb__xbar_connect.sv
@@ -29,4 +29,6 @@ initial force dut.rst_peri_ni = rst_n;
 `CONNECT_TL_DEVICE_IF(otp_ctrl, dut, clk_peri_i, rst_n)
 `CONNECT_TL_DEVICE_IF(lc_ctrl, dut, clk_peri_i, rst_n)
 `CONNECT_TL_DEVICE_IF(sensor_ctrl, dut, clk_peri_i, rst_n)
+`CONNECT_TL_DEVICE_IF(alert_handler, dut, clk_peri_i, rst_n)
+`CONNECT_TL_DEVICE_IF(nmi_gen, dut, clk_peri_i, rst_n)
 `CONNECT_TL_DEVICE_IF(ast_wrapper, dut, clk_peri_i, rst_n)

--- a/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_env_pkg__params.sv
+++ b/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_env_pkg__params.sv
@@ -43,6 +43,12 @@ tl_device_t xbar_devices[$] = '{
     '{"sensor_ctrl", '{
         '{32'h40110000, 32'h40110fff}
     }},
+    '{"alert_handler", '{
+        '{32'h40150000, 32'h40150fff}
+    }},
+    '{"nmi_gen", '{
+        '{32'h40160000, 32'h40160fff}
+    }},
     '{"ast_wrapper", '{
         '{32'h40180000, 32'h40180fff}
 }}};
@@ -62,5 +68,7 @@ tl_host_t xbar_hosts[$] = '{
         "otp_ctrl",
         "lc_ctrl",
         "sensor_ctrl",
+        "alert_handler",
+        "nmi_gen",
         "ast_wrapper"}}
 };

--- a/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_peri_bind.sv
+++ b/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_peri_bind.sv
@@ -86,6 +86,18 @@ module xbar_peri_bind;
     .h2d    (tl_sensor_ctrl_o),
     .d2h    (tl_sensor_ctrl_i)
   );
+  bind xbar_peri tlul_assert #(.EndpointType("Host")) tlul_assert_device_alert_handler (
+    .clk_i  (clk_peri_i),
+    .rst_ni (rst_peri_ni),
+    .h2d    (tl_alert_handler_o),
+    .d2h    (tl_alert_handler_i)
+  );
+  bind xbar_peri tlul_assert #(.EndpointType("Host")) tlul_assert_device_nmi_gen (
+    .clk_i  (clk_peri_i),
+    .rst_ni (rst_peri_ni),
+    .h2d    (tl_nmi_gen_o),
+    .d2h    (tl_nmi_gen_i)
+  );
   bind xbar_peri tlul_assert #(.EndpointType("Host")) tlul_assert_device_ast_wrapper (
     .clk_i  (clk_peri_i),
     .rst_ni (rst_peri_ni),

--- a/hw/top_earlgrey/ip/xbar_peri/rtl/autogen/tl_peri_pkg.sv
+++ b/hw/top_earlgrey/ip/xbar_peri/rtl/autogen/tl_peri_pkg.sv
@@ -6,36 +6,40 @@
 
 package tl_peri_pkg;
 
-  localparam logic [31:0] ADDR_SPACE_UART        = 32'h 40000000;
-  localparam logic [31:0] ADDR_SPACE_GPIO        = 32'h 40040000;
-  localparam logic [31:0] ADDR_SPACE_SPI_DEVICE  = 32'h 40050000;
-  localparam logic [31:0] ADDR_SPACE_RV_TIMER    = 32'h 40100000;
-  localparam logic [31:0] ADDR_SPACE_USBDEV      = 32'h 40500000;
-  localparam logic [31:0] ADDR_SPACE_PWRMGR      = 32'h 40400000;
-  localparam logic [31:0] ADDR_SPACE_RSTMGR      = 32'h 40410000;
-  localparam logic [31:0] ADDR_SPACE_CLKMGR      = 32'h 40420000;
-  localparam logic [31:0] ADDR_SPACE_RAM_RET     = 32'h 18000000;
-  localparam logic [31:0] ADDR_SPACE_OTP_CTRL    = 32'h 40130000;
-  localparam logic [31:0] ADDR_SPACE_LC_CTRL     = 32'h 40140000;
-  localparam logic [31:0] ADDR_SPACE_SENSOR_CTRL = 32'h 40110000;
-  localparam logic [31:0] ADDR_SPACE_AST_WRAPPER = 32'h 40180000;
+  localparam logic [31:0] ADDR_SPACE_UART          = 32'h 40000000;
+  localparam logic [31:0] ADDR_SPACE_GPIO          = 32'h 40040000;
+  localparam logic [31:0] ADDR_SPACE_SPI_DEVICE    = 32'h 40050000;
+  localparam logic [31:0] ADDR_SPACE_RV_TIMER      = 32'h 40100000;
+  localparam logic [31:0] ADDR_SPACE_USBDEV        = 32'h 40500000;
+  localparam logic [31:0] ADDR_SPACE_PWRMGR        = 32'h 40400000;
+  localparam logic [31:0] ADDR_SPACE_RSTMGR        = 32'h 40410000;
+  localparam logic [31:0] ADDR_SPACE_CLKMGR        = 32'h 40420000;
+  localparam logic [31:0] ADDR_SPACE_RAM_RET       = 32'h 18000000;
+  localparam logic [31:0] ADDR_SPACE_OTP_CTRL      = 32'h 40130000;
+  localparam logic [31:0] ADDR_SPACE_LC_CTRL       = 32'h 40140000;
+  localparam logic [31:0] ADDR_SPACE_SENSOR_CTRL   = 32'h 40110000;
+  localparam logic [31:0] ADDR_SPACE_ALERT_HANDLER = 32'h 40150000;
+  localparam logic [31:0] ADDR_SPACE_NMI_GEN       = 32'h 40160000;
+  localparam logic [31:0] ADDR_SPACE_AST_WRAPPER   = 32'h 40180000;
 
-  localparam logic [31:0] ADDR_MASK_UART        = 32'h 00000fff;
-  localparam logic [31:0] ADDR_MASK_GPIO        = 32'h 00000fff;
-  localparam logic [31:0] ADDR_MASK_SPI_DEVICE  = 32'h 00000fff;
-  localparam logic [31:0] ADDR_MASK_RV_TIMER    = 32'h 00000fff;
-  localparam logic [31:0] ADDR_MASK_USBDEV      = 32'h 00000fff;
-  localparam logic [31:0] ADDR_MASK_PWRMGR      = 32'h 00000fff;
-  localparam logic [31:0] ADDR_MASK_RSTMGR      = 32'h 00000fff;
-  localparam logic [31:0] ADDR_MASK_CLKMGR      = 32'h 00000fff;
-  localparam logic [31:0] ADDR_MASK_RAM_RET     = 32'h 00000fff;
-  localparam logic [31:0] ADDR_MASK_OTP_CTRL    = 32'h 00003fff;
-  localparam logic [31:0] ADDR_MASK_LC_CTRL     = 32'h 00000fff;
-  localparam logic [31:0] ADDR_MASK_SENSOR_CTRL = 32'h 00000fff;
-  localparam logic [31:0] ADDR_MASK_AST_WRAPPER = 32'h 00000fff;
+  localparam logic [31:0] ADDR_MASK_UART          = 32'h 00000fff;
+  localparam logic [31:0] ADDR_MASK_GPIO          = 32'h 00000fff;
+  localparam logic [31:0] ADDR_MASK_SPI_DEVICE    = 32'h 00000fff;
+  localparam logic [31:0] ADDR_MASK_RV_TIMER      = 32'h 00000fff;
+  localparam logic [31:0] ADDR_MASK_USBDEV        = 32'h 00000fff;
+  localparam logic [31:0] ADDR_MASK_PWRMGR        = 32'h 00000fff;
+  localparam logic [31:0] ADDR_MASK_RSTMGR        = 32'h 00000fff;
+  localparam logic [31:0] ADDR_MASK_CLKMGR        = 32'h 00000fff;
+  localparam logic [31:0] ADDR_MASK_RAM_RET       = 32'h 00000fff;
+  localparam logic [31:0] ADDR_MASK_OTP_CTRL      = 32'h 00003fff;
+  localparam logic [31:0] ADDR_MASK_LC_CTRL       = 32'h 00000fff;
+  localparam logic [31:0] ADDR_MASK_SENSOR_CTRL   = 32'h 00000fff;
+  localparam logic [31:0] ADDR_MASK_ALERT_HANDLER = 32'h 00000fff;
+  localparam logic [31:0] ADDR_MASK_NMI_GEN       = 32'h 00000fff;
+  localparam logic [31:0] ADDR_MASK_AST_WRAPPER   = 32'h 00000fff;
 
   localparam int N_HOST   = 1;
-  localparam int N_DEVICE = 13;
+  localparam int N_DEVICE = 15;
 
   typedef enum int {
     TlUart = 0,
@@ -50,7 +54,9 @@ package tl_peri_pkg;
     TlOtpCtrl = 9,
     TlLcCtrl = 10,
     TlSensorCtrl = 11,
-    TlAstWrapper = 12
+    TlAlertHandler = 12,
+    TlNmiGen = 13,
+    TlAstWrapper = 14
   } tl_device_e;
 
   typedef enum int {

--- a/hw/top_earlgrey/ip/xbar_peri/rtl/autogen/xbar_peri.sv
+++ b/hw/top_earlgrey/ip/xbar_peri/rtl/autogen/xbar_peri.sv
@@ -7,7 +7,7 @@
 //
 // Interconnect
 // main
-//   -> s1n_14
+//   -> s1n_16
 //     -> uart
 //     -> gpio
 //     -> spi_device
@@ -20,6 +20,8 @@
 //     -> otp_ctrl
 //     -> lc_ctrl
 //     -> sensor_ctrl
+//     -> alert_handler
+//     -> nmi_gen
 //     -> ast_wrapper
 
 module xbar_peri (
@@ -55,6 +57,10 @@ module xbar_peri (
   input  tlul_pkg::tl_d2h_t tl_lc_ctrl_i,
   output tlul_pkg::tl_h2d_t tl_sensor_ctrl_o,
   input  tlul_pkg::tl_d2h_t tl_sensor_ctrl_i,
+  output tlul_pkg::tl_h2d_t tl_alert_handler_o,
+  input  tlul_pkg::tl_d2h_t tl_alert_handler_i,
+  output tlul_pkg::tl_h2d_t tl_nmi_gen_o,
+  input  tlul_pkg::tl_d2h_t tl_nmi_gen_i,
   output tlul_pkg::tl_h2d_t tl_ast_wrapper_o,
   input  tlul_pkg::tl_d2h_t tl_ast_wrapper_i,
 
@@ -69,101 +75,113 @@ module xbar_peri (
   logic unused_scanmode;
   assign unused_scanmode = scanmode_i;
 
-  tl_h2d_t tl_s1n_14_us_h2d ;
-  tl_d2h_t tl_s1n_14_us_d2h ;
+  tl_h2d_t tl_s1n_16_us_h2d ;
+  tl_d2h_t tl_s1n_16_us_d2h ;
 
 
-  tl_h2d_t tl_s1n_14_ds_h2d [13];
-  tl_d2h_t tl_s1n_14_ds_d2h [13];
+  tl_h2d_t tl_s1n_16_ds_h2d [15];
+  tl_d2h_t tl_s1n_16_ds_d2h [15];
 
   // Create steering signal
-  logic [3:0] dev_sel_s1n_14;
+  logic [3:0] dev_sel_s1n_16;
 
 
 
-  assign tl_uart_o = tl_s1n_14_ds_h2d[0];
-  assign tl_s1n_14_ds_d2h[0] = tl_uart_i;
+  assign tl_uart_o = tl_s1n_16_ds_h2d[0];
+  assign tl_s1n_16_ds_d2h[0] = tl_uart_i;
 
-  assign tl_gpio_o = tl_s1n_14_ds_h2d[1];
-  assign tl_s1n_14_ds_d2h[1] = tl_gpio_i;
+  assign tl_gpio_o = tl_s1n_16_ds_h2d[1];
+  assign tl_s1n_16_ds_d2h[1] = tl_gpio_i;
 
-  assign tl_spi_device_o = tl_s1n_14_ds_h2d[2];
-  assign tl_s1n_14_ds_d2h[2] = tl_spi_device_i;
+  assign tl_spi_device_o = tl_s1n_16_ds_h2d[2];
+  assign tl_s1n_16_ds_d2h[2] = tl_spi_device_i;
 
-  assign tl_rv_timer_o = tl_s1n_14_ds_h2d[3];
-  assign tl_s1n_14_ds_d2h[3] = tl_rv_timer_i;
+  assign tl_rv_timer_o = tl_s1n_16_ds_h2d[3];
+  assign tl_s1n_16_ds_d2h[3] = tl_rv_timer_i;
 
-  assign tl_usbdev_o = tl_s1n_14_ds_h2d[4];
-  assign tl_s1n_14_ds_d2h[4] = tl_usbdev_i;
+  assign tl_usbdev_o = tl_s1n_16_ds_h2d[4];
+  assign tl_s1n_16_ds_d2h[4] = tl_usbdev_i;
 
-  assign tl_pwrmgr_o = tl_s1n_14_ds_h2d[5];
-  assign tl_s1n_14_ds_d2h[5] = tl_pwrmgr_i;
+  assign tl_pwrmgr_o = tl_s1n_16_ds_h2d[5];
+  assign tl_s1n_16_ds_d2h[5] = tl_pwrmgr_i;
 
-  assign tl_rstmgr_o = tl_s1n_14_ds_h2d[6];
-  assign tl_s1n_14_ds_d2h[6] = tl_rstmgr_i;
+  assign tl_rstmgr_o = tl_s1n_16_ds_h2d[6];
+  assign tl_s1n_16_ds_d2h[6] = tl_rstmgr_i;
 
-  assign tl_clkmgr_o = tl_s1n_14_ds_h2d[7];
-  assign tl_s1n_14_ds_d2h[7] = tl_clkmgr_i;
+  assign tl_clkmgr_o = tl_s1n_16_ds_h2d[7];
+  assign tl_s1n_16_ds_d2h[7] = tl_clkmgr_i;
 
-  assign tl_ram_ret_o = tl_s1n_14_ds_h2d[8];
-  assign tl_s1n_14_ds_d2h[8] = tl_ram_ret_i;
+  assign tl_ram_ret_o = tl_s1n_16_ds_h2d[8];
+  assign tl_s1n_16_ds_d2h[8] = tl_ram_ret_i;
 
-  assign tl_otp_ctrl_o = tl_s1n_14_ds_h2d[9];
-  assign tl_s1n_14_ds_d2h[9] = tl_otp_ctrl_i;
+  assign tl_otp_ctrl_o = tl_s1n_16_ds_h2d[9];
+  assign tl_s1n_16_ds_d2h[9] = tl_otp_ctrl_i;
 
-  assign tl_lc_ctrl_o = tl_s1n_14_ds_h2d[10];
-  assign tl_s1n_14_ds_d2h[10] = tl_lc_ctrl_i;
+  assign tl_lc_ctrl_o = tl_s1n_16_ds_h2d[10];
+  assign tl_s1n_16_ds_d2h[10] = tl_lc_ctrl_i;
 
-  assign tl_sensor_ctrl_o = tl_s1n_14_ds_h2d[11];
-  assign tl_s1n_14_ds_d2h[11] = tl_sensor_ctrl_i;
+  assign tl_sensor_ctrl_o = tl_s1n_16_ds_h2d[11];
+  assign tl_s1n_16_ds_d2h[11] = tl_sensor_ctrl_i;
 
-  assign tl_ast_wrapper_o = tl_s1n_14_ds_h2d[12];
-  assign tl_s1n_14_ds_d2h[12] = tl_ast_wrapper_i;
+  assign tl_alert_handler_o = tl_s1n_16_ds_h2d[12];
+  assign tl_s1n_16_ds_d2h[12] = tl_alert_handler_i;
 
-  assign tl_s1n_14_us_h2d = tl_main_i;
-  assign tl_main_o = tl_s1n_14_us_d2h;
+  assign tl_nmi_gen_o = tl_s1n_16_ds_h2d[13];
+  assign tl_s1n_16_ds_d2h[13] = tl_nmi_gen_i;
+
+  assign tl_ast_wrapper_o = tl_s1n_16_ds_h2d[14];
+  assign tl_s1n_16_ds_d2h[14] = tl_ast_wrapper_i;
+
+  assign tl_s1n_16_us_h2d = tl_main_i;
+  assign tl_main_o = tl_s1n_16_us_d2h;
 
   always_comb begin
     // default steering to generate error response if address is not within the range
-    dev_sel_s1n_14 = 4'd13;
-    if ((tl_s1n_14_us_h2d.a_address & ~(ADDR_MASK_UART)) == ADDR_SPACE_UART) begin
-      dev_sel_s1n_14 = 4'd0;
+    dev_sel_s1n_16 = 4'd15;
+    if ((tl_s1n_16_us_h2d.a_address & ~(ADDR_MASK_UART)) == ADDR_SPACE_UART) begin
+      dev_sel_s1n_16 = 4'd0;
 
-    end else if ((tl_s1n_14_us_h2d.a_address & ~(ADDR_MASK_GPIO)) == ADDR_SPACE_GPIO) begin
-      dev_sel_s1n_14 = 4'd1;
+    end else if ((tl_s1n_16_us_h2d.a_address & ~(ADDR_MASK_GPIO)) == ADDR_SPACE_GPIO) begin
+      dev_sel_s1n_16 = 4'd1;
 
-    end else if ((tl_s1n_14_us_h2d.a_address & ~(ADDR_MASK_SPI_DEVICE)) == ADDR_SPACE_SPI_DEVICE) begin
-      dev_sel_s1n_14 = 4'd2;
+    end else if ((tl_s1n_16_us_h2d.a_address & ~(ADDR_MASK_SPI_DEVICE)) == ADDR_SPACE_SPI_DEVICE) begin
+      dev_sel_s1n_16 = 4'd2;
 
-    end else if ((tl_s1n_14_us_h2d.a_address & ~(ADDR_MASK_RV_TIMER)) == ADDR_SPACE_RV_TIMER) begin
-      dev_sel_s1n_14 = 4'd3;
+    end else if ((tl_s1n_16_us_h2d.a_address & ~(ADDR_MASK_RV_TIMER)) == ADDR_SPACE_RV_TIMER) begin
+      dev_sel_s1n_16 = 4'd3;
 
-    end else if ((tl_s1n_14_us_h2d.a_address & ~(ADDR_MASK_USBDEV)) == ADDR_SPACE_USBDEV) begin
-      dev_sel_s1n_14 = 4'd4;
+    end else if ((tl_s1n_16_us_h2d.a_address & ~(ADDR_MASK_USBDEV)) == ADDR_SPACE_USBDEV) begin
+      dev_sel_s1n_16 = 4'd4;
 
-    end else if ((tl_s1n_14_us_h2d.a_address & ~(ADDR_MASK_PWRMGR)) == ADDR_SPACE_PWRMGR) begin
-      dev_sel_s1n_14 = 4'd5;
+    end else if ((tl_s1n_16_us_h2d.a_address & ~(ADDR_MASK_PWRMGR)) == ADDR_SPACE_PWRMGR) begin
+      dev_sel_s1n_16 = 4'd5;
 
-    end else if ((tl_s1n_14_us_h2d.a_address & ~(ADDR_MASK_RSTMGR)) == ADDR_SPACE_RSTMGR) begin
-      dev_sel_s1n_14 = 4'd6;
+    end else if ((tl_s1n_16_us_h2d.a_address & ~(ADDR_MASK_RSTMGR)) == ADDR_SPACE_RSTMGR) begin
+      dev_sel_s1n_16 = 4'd6;
 
-    end else if ((tl_s1n_14_us_h2d.a_address & ~(ADDR_MASK_CLKMGR)) == ADDR_SPACE_CLKMGR) begin
-      dev_sel_s1n_14 = 4'd7;
+    end else if ((tl_s1n_16_us_h2d.a_address & ~(ADDR_MASK_CLKMGR)) == ADDR_SPACE_CLKMGR) begin
+      dev_sel_s1n_16 = 4'd7;
 
-    end else if ((tl_s1n_14_us_h2d.a_address & ~(ADDR_MASK_RAM_RET)) == ADDR_SPACE_RAM_RET) begin
-      dev_sel_s1n_14 = 4'd8;
+    end else if ((tl_s1n_16_us_h2d.a_address & ~(ADDR_MASK_RAM_RET)) == ADDR_SPACE_RAM_RET) begin
+      dev_sel_s1n_16 = 4'd8;
 
-    end else if ((tl_s1n_14_us_h2d.a_address & ~(ADDR_MASK_OTP_CTRL)) == ADDR_SPACE_OTP_CTRL) begin
-      dev_sel_s1n_14 = 4'd9;
+    end else if ((tl_s1n_16_us_h2d.a_address & ~(ADDR_MASK_OTP_CTRL)) == ADDR_SPACE_OTP_CTRL) begin
+      dev_sel_s1n_16 = 4'd9;
 
-    end else if ((tl_s1n_14_us_h2d.a_address & ~(ADDR_MASK_LC_CTRL)) == ADDR_SPACE_LC_CTRL) begin
-      dev_sel_s1n_14 = 4'd10;
+    end else if ((tl_s1n_16_us_h2d.a_address & ~(ADDR_MASK_LC_CTRL)) == ADDR_SPACE_LC_CTRL) begin
+      dev_sel_s1n_16 = 4'd10;
 
-    end else if ((tl_s1n_14_us_h2d.a_address & ~(ADDR_MASK_SENSOR_CTRL)) == ADDR_SPACE_SENSOR_CTRL) begin
-      dev_sel_s1n_14 = 4'd11;
+    end else if ((tl_s1n_16_us_h2d.a_address & ~(ADDR_MASK_SENSOR_CTRL)) == ADDR_SPACE_SENSOR_CTRL) begin
+      dev_sel_s1n_16 = 4'd11;
 
-    end else if ((tl_s1n_14_us_h2d.a_address & ~(ADDR_MASK_AST_WRAPPER)) == ADDR_SPACE_AST_WRAPPER) begin
-      dev_sel_s1n_14 = 4'd12;
+    end else if ((tl_s1n_16_us_h2d.a_address & ~(ADDR_MASK_ALERT_HANDLER)) == ADDR_SPACE_ALERT_HANDLER) begin
+      dev_sel_s1n_16 = 4'd12;
+
+    end else if ((tl_s1n_16_us_h2d.a_address & ~(ADDR_MASK_NMI_GEN)) == ADDR_SPACE_NMI_GEN) begin
+      dev_sel_s1n_16 = 4'd13;
+
+    end else if ((tl_s1n_16_us_h2d.a_address & ~(ADDR_MASK_AST_WRAPPER)) == ADDR_SPACE_AST_WRAPPER) begin
+      dev_sel_s1n_16 = 4'd14;
 end
   end
 
@@ -172,17 +190,17 @@ end
   tlul_socket_1n #(
     .HReqDepth (4'h0),
     .HRspDepth (4'h0),
-    .DReqDepth (52'h0),
-    .DRspDepth (52'h0),
-    .N         (13)
-  ) u_s1n_14 (
+    .DReqDepth (60'h0),
+    .DRspDepth (60'h0),
+    .N         (15)
+  ) u_s1n_16 (
     .clk_i        (clk_peri_i),
     .rst_ni       (rst_peri_ni),
-    .tl_h_i       (tl_s1n_14_us_h2d),
-    .tl_h_o       (tl_s1n_14_us_d2h),
-    .tl_d_o       (tl_s1n_14_ds_h2d),
-    .tl_d_i       (tl_s1n_14_ds_d2h),
-    .dev_select_i (dev_sel_s1n_14)
+    .tl_h_i       (tl_s1n_16_us_h2d),
+    .tl_h_o       (tl_s1n_16_us_d2h),
+    .tl_d_o       (tl_s1n_16_ds_h2d),
+    .tl_d_i       (tl_s1n_16_ds_d2h),
+    .dev_select_i (dev_sel_s1n_16)
   );
 
 endmodule

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -447,6 +447,8 @@ module top_earlgrey #(
     .irq_timer_i          (intr_rv_timer_timer_expired_0_0),
     .irq_external_i       (irq_plic),
     // escalation input from alert handler (NMI)
+    // TODO: need to put the escalation receiver
+    // into the alert handler clock domain.
     .esc_tx_i             (esc_tx[0]),
     .esc_rx_o             (esc_rx[0]),
     // debug interface

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey_pkg.sv
@@ -82,6 +82,26 @@ package top_earlgrey_pkg;
   parameter int unsigned TOP_EARLGREY_LC_CTRL_SIZE_BYTES = 32'h1000;
 
   /**
+   * Peripheral base address for alert_handler in top earlgrey.
+   */
+  parameter int unsigned TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR = 32'h40150000;
+
+  /**
+   * Peripheral size in bytes for alert_handler in top earlgrey.
+   */
+  parameter int unsigned TOP_EARLGREY_ALERT_HANDLER_SIZE_BYTES = 32'h1000;
+
+  /**
+   * Peripheral base address for nmi_gen in top earlgrey.
+   */
+  parameter int unsigned TOP_EARLGREY_NMI_GEN_BASE_ADDR = 32'h40160000;
+
+  /**
+   * Peripheral size in bytes for nmi_gen in top earlgrey.
+   */
+  parameter int unsigned TOP_EARLGREY_NMI_GEN_SIZE_BYTES = 32'h1000;
+
+  /**
    * Peripheral base address for pwrmgr in top earlgrey.
    */
   parameter int unsigned TOP_EARLGREY_PWRMGR_BASE_ADDR = 32'h40400000;
@@ -240,26 +260,6 @@ package top_earlgrey_pkg;
    * Peripheral size in bytes for edn1 in top earlgrey.
    */
   parameter int unsigned TOP_EARLGREY_EDN1_SIZE_BYTES = 32'h1000;
-
-  /**
-   * Peripheral base address for alert_handler in top earlgrey.
-   */
-  parameter int unsigned TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR = 32'h411b0000;
-
-  /**
-   * Peripheral size in bytes for alert_handler in top earlgrey.
-   */
-  parameter int unsigned TOP_EARLGREY_ALERT_HANDLER_SIZE_BYTES = 32'h1000;
-
-  /**
-   * Peripheral base address for nmi_gen in top earlgrey.
-   */
-  parameter int unsigned TOP_EARLGREY_NMI_GEN_BASE_ADDR = 32'h411c0000;
-
-  /**
-   * Peripheral size in bytes for nmi_gen in top earlgrey.
-   */
-  parameter int unsigned TOP_EARLGREY_NMI_GEN_SIZE_BYTES = 32'h1000;
 
   /**
    * Peripheral base address for otbn in top earlgrey.

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
@@ -69,6 +69,19 @@ package top_earlgrey_rnd_cnst_pkg;
   };
 
   ////////////////////////////////////////////
+  // alert_handler
+  ////////////////////////////////////////////
+  // Compile-time random bits for initial LFSR seed
+  parameter alert_pkg::lfsr_seed_t RndCnstAlertHandlerLfsrSeed = {
+    32'h5DEF7861
+  };
+
+  // Compile-time random permutation for LFSR output
+  parameter alert_pkg::lfsr_perm_t RndCnstAlertHandlerLfsrPerm = {
+    160'h5F00C4CAFD73FC4AC479A61068375F38956D84B3
+  };
+
+  ////////////////////////////////////////////
   // flash_ctrl
   ////////////////////////////////////////////
   // Compile-time random bits for default address key
@@ -153,19 +166,6 @@ package top_earlgrey_rnd_cnst_pkg;
   // Compile-time random bits for generation seed when no destination selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrNoneSeed = {
     256'hEEC5E43D4B16446726A27B8F0B30AD5048BAE844C87B69111A24D5E4442BCFB7
-  };
-
-  ////////////////////////////////////////////
-  // alert_handler
-  ////////////////////////////////////////////
-  // Compile-time random bits for initial LFSR seed
-  parameter alert_pkg::lfsr_seed_t RndCnstAlertHandlerLfsrSeed = {
-    32'h5DEF7861
-  };
-
-  // Compile-time random permutation for LFSR output
-  parameter alert_pkg::lfsr_perm_t RndCnstAlertHandlerLfsrPerm = {
-    160'h5F00C4CAFD73FC4AC479A61068375F38956D84B3
   };
 
 endpackage : top_earlgrey_rnd_cnst_pkg

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -152,6 +152,42 @@ extern "C" {
 #define TOP_EARLGREY_LC_CTRL_SIZE_BYTES 0x1000u
 
 /**
+ * Peripheral base address for alert_handler in top earlgrey.
+ *
+ * This should be used with #mmio_region_from_addr to access the memory-mapped
+ * registers associated with the peripheral (usually via a DIF).
+ */
+#define TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR 0x40150000u
+
+/**
+ * Peripheral size for alert_handler in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR and
+ * `TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR + TOP_EARLGREY_ALERT_HANDLER_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_ALERT_HANDLER_SIZE_BYTES 0x1000u
+
+/**
+ * Peripheral base address for nmi_gen in top earlgrey.
+ *
+ * This should be used with #mmio_region_from_addr to access the memory-mapped
+ * registers associated with the peripheral (usually via a DIF).
+ */
+#define TOP_EARLGREY_NMI_GEN_BASE_ADDR 0x40160000u
+
+/**
+ * Peripheral size for nmi_gen in top earlgrey.
+ *
+ * This is the size (in bytes) of the peripheral's reserved memory area. All
+ * memory-mapped registers associated with this peripheral should have an
+ * address between #TOP_EARLGREY_NMI_GEN_BASE_ADDR and
+ * `TOP_EARLGREY_NMI_GEN_BASE_ADDR + TOP_EARLGREY_NMI_GEN_SIZE_BYTES`.
+ */
+#define TOP_EARLGREY_NMI_GEN_SIZE_BYTES 0x1000u
+
+/**
  * Peripheral base address for pwrmgr in top earlgrey.
  *
  * This should be used with #mmio_region_from_addr to access the memory-mapped
@@ -438,42 +474,6 @@ extern "C" {
  * `TOP_EARLGREY_EDN1_BASE_ADDR + TOP_EARLGREY_EDN1_SIZE_BYTES`.
  */
 #define TOP_EARLGREY_EDN1_SIZE_BYTES 0x1000u
-
-/**
- * Peripheral base address for alert_handler in top earlgrey.
- *
- * This should be used with #mmio_region_from_addr to access the memory-mapped
- * registers associated with the peripheral (usually via a DIF).
- */
-#define TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR 0x411b0000u
-
-/**
- * Peripheral size for alert_handler in top earlgrey.
- *
- * This is the size (in bytes) of the peripheral's reserved memory area. All
- * memory-mapped registers associated with this peripheral should have an
- * address between #TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR and
- * `TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR + TOP_EARLGREY_ALERT_HANDLER_SIZE_BYTES`.
- */
-#define TOP_EARLGREY_ALERT_HANDLER_SIZE_BYTES 0x1000u
-
-/**
- * Peripheral base address for nmi_gen in top earlgrey.
- *
- * This should be used with #mmio_region_from_addr to access the memory-mapped
- * registers associated with the peripheral (usually via a DIF).
- */
-#define TOP_EARLGREY_NMI_GEN_BASE_ADDR 0x411c0000u
-
-/**
- * Peripheral size for nmi_gen in top earlgrey.
- *
- * This is the size (in bytes) of the peripheral's reserved memory area. All
- * memory-mapped registers associated with this peripheral should have an
- * address between #TOP_EARLGREY_NMI_GEN_BASE_ADDR and
- * `TOP_EARLGREY_NMI_GEN_BASE_ADDR + TOP_EARLGREY_NMI_GEN_SIZE_BYTES`.
- */
-#define TOP_EARLGREY_NMI_GEN_SIZE_BYTES 0x1000u
 
 /**
  * Peripheral base address for otbn in top earlgrey.


### PR DESCRIPTION
Signed-off-by: Michael Schaffner <msf@opentitan.org>