### PR TITLE
[flash_ctrl] flash phy single hier

### DIFF
--- a/hw/ip/flash_ctrl/dv/tb/flash_ctrl_wrapper.sv
+++ b/hw/ip/flash_ctrl/dv/tb/flash_ctrl_wrapper.sv
@@ -14,6 +14,10 @@ module flash_ctrl_wrapper (
   input        tlul_pkg::tl_h2d_t eflash_tl_i,
   output       tlul_pkg::tl_d2h_t eflash_tl_o,
 
+  // Analog Interface
+  input        flash_power_ready_h_i,
+  input        flash_power_down_h_i,
+
   // OTP interface
   input        flash_ctrl_pkg::otp_flash_t otp_i,
   input        flash_ctrl_pkg::lc_flash_req_t lc_i,
@@ -99,7 +103,9 @@ module flash_ctrl_wrapper (
     .host_req_done_o (flash_host_req_done),
     .host_rdata_o    (flash_host_rdata),
     .flash_ctrl_i    (flash_ctrl_flash_req),
-    .flash_ctrl_o    (flash_ctrl_flash_rsp)
+    .flash_ctrl_o    (flash_ctrl_flash_rsp),
+    .flash_power_ready_h_i,
+    .flash_power_down_h_i
   );
 
 endmodule

--- a/hw/ip/flash_ctrl/dv/tb/tb.sv
+++ b/hw/ip/flash_ctrl/dv/tb/tb.sv
@@ -40,6 +40,9 @@ module tb;
     .flash_ctrl_tl_i    (tl_if.h2d),
     .flash_ctrl_tl_o    (tl_if.d2h),
 
+    .flash_power_ready_h_i (1'b1  ),
+    .flash_power_down_h_i  (1'b0  ),
+
     .eflash_tl_i        (eflash_tl_if.h2d),
     .eflash_tl_o        (eflash_tl_if.d2h),
 
@@ -60,10 +63,10 @@ module tb;
 
   // bind mem_bkdr_if
   `define FLASH_DATA_MEM_HIER(i) \
-      dut.u_flash_eflash.gen_flash_banks[``i``].i_core.i_flash.gen_generic.u_impl_generic.u_mem
+      dut.u_flash_eflash.u_flash.gen_generic.u_impl_generic.gen_prim_flash_banks[``i``].u_prim_flash_bank.u_mem
 
   `define FLASH_INFO_MEM_HIER(i) \
-      dut.u_flash_eflash.gen_flash_banks[``i``].i_core.i_flash.gen_generic.u_impl_generic.u_info_mem
+      dut.u_flash_eflash.u_flash.gen_generic.u_impl_generic.gen_prim_flash_banks[``i``].u_prim_flash_bank.u_info_mem
 
   generate
     for (genvar i = 0; i < flash_ctrl_pkg::NumBanks; i++) begin : mem_bkdr_if_i

--- a/hw/ip/flash_ctrl/rtl/flash_phy_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_pkg.sv
@@ -96,4 +96,23 @@ package flash_phy_pkg;
     DeScrambleOp = 1'b1
   } cipher_ops_e;
 
+  // Connections to prim_flash
+  typedef struct packed {
+    logic rd_req;
+    logic prog_req;
+    logic prog_last;
+    flash_ctrl_pkg::flash_prog_e prog_type;
+    logic pg_erase_req;
+    logic bk_erase_req;
+    logic [BankAddrW-1:0] addr;
+    flash_ctrl_pkg::flash_part_e part;
+    logic [FullDataWidth-1:0] prog_full_data;
+  } flash_phy_prim_flash_req_t;
+
+  typedef struct packed {
+    logic ack;
+    logic done;
+    logic [FullDataWidth-1:0] rdata;
+  } flash_phy_prim_flash_rsp_t;
+
 endpackage // flash_phy_pkg

--- a/hw/ip/prim_generic/prim_generic_flash.core
+++ b/hw/ip/prim_generic/prim_generic_flash.core
@@ -11,6 +11,7 @@ filesets:
       - lowrisc:prim:ram_1p
       - lowrisc:ip:flash_ctrl_pkg
     files:
+      - rtl/prim_generic_flash_bank.sv
       - rtl/prim_generic_flash.sv
     file_type: systemVerilogSource
 

--- a/hw/ip/prim_generic/rtl/prim_generic_flash.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_flash.sv
@@ -2,432 +2,86 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// prim flash module - Emulated using memory
+// Overall flash wrapper
 //
 
 module prim_generic_flash #(
+  parameter int NumBanks      = 2,   // number of banks
   parameter int InfosPerBank  = 1,   // info pages per bank
   parameter int PagesPerBank  = 256, // data pages per bank
   parameter int WordsPerPage  = 256, // words per page
   parameter int DataWidth     = 32,  // bits per word
-  parameter int MetaDataWidth = 12,  // this is a temporary parameter to work around ECC issues
-  parameter bit SkipInit      = 1,   // this is an option to reset flash to all F's at reset
-
-  // Derived parameters
-  localparam int PageW = $clog2(PagesPerBank),
-  localparam int WordW = $clog2(WordsPerPage),
-  localparam int AddrW = PageW + WordW
+  parameter int MetaDataWidth = 12,  // metadata such as ECC
+  parameter int TestModeWidth = 2
 ) (
-  input                              clk_i,
-  input                              rst_ni,
-  input                              rd_i,
-  input                              prog_i,
-  input                              prog_last_i,
-  // the generic model does not make use of program types
-  input flash_ctrl_pkg::flash_prog_e prog_type_i,
-  input                              pg_erase_i,
-  input                              bk_erase_i,
-  input [AddrW-1:0]                  addr_i,
-  input flash_ctrl_pkg::flash_part_e part_i,
-  input [DataWidth-1:0]              prog_data_i,
-  output logic [flash_ctrl_pkg::ProgTypes-1:0] prog_type_avail_o,
-  output logic                       ack_o,
-  output logic                       done_o,
-  output logic [DataWidth-1:0]       rd_data_o,
-  output logic                       init_busy_o,
-
-  input                              tck_i,
-  input                              tdi_i,
-  input                              tms_i,
-  output logic                       tdo_o,
-  input                              scanmode_i,
-  input                              scan_reset_ni,
-  input                              flash_power_ready_hi,
-  input                              flash_power_down_hi,
-  inout [3:0]                        flash_test_mode_ai,
-  inout                              flash_test_voltage_hi
+  input clk_i,
+  input rst_ni,
+  input flash_phy_pkg::flash_phy_prim_flash_req_t [NumBanks-1:0] flash_req_i,
+  output flash_phy_pkg::flash_phy_prim_flash_rsp_t [NumBanks-1:0] flash_rsp_o,
+  output logic [flash_phy_pkg::ProgTypes-1:0] prog_type_avail_o,
+  output init_busy_o,
+  input tck_i,
+  input tdi_i,
+  input tms_i,
+  output logic tdo_o,
+  input scanmode_i,
+  input scan_rst_ni,
+  input flash_power_ready_h_i,
+  input flash_power_down_h_i,
+  input [TestModeWidth-1:0] flash_test_mode_a_i,
+  input flash_test_voltage_h_i
 );
 
-  // Emulated flash macro values
-  localparam int ReadCycles = 1;
-  localparam int ProgCycles = 50;
-  localparam int PgEraseCycles = 200;
-  localparam int BkEraseCycles = 2000;
-
-  // Locally derived values
-  localparam int WordsPerBank  = PagesPerBank * WordsPerPage;
-  localparam int WordsPerInfoBank = InfosPerBank * WordsPerPage;
-  localparam int InfoAddrW = $clog2(WordsPerInfoBank);
-
-  typedef enum logic [2:0] {
-    StReset    = 'h0,
-    StInit     = 'h1,
-    StIdle     = 'h2,
-    StRead     = 'h3,
-    StProg     = 'h4,
-    StErase    = 'h5
-  } state_e;
-
-  state_e st_q, st_d;
-
-  logic [31:0]              time_cnt;
-  logic [31:0]              index_cnt;
-  logic                     time_cnt_inc ,time_cnt_clr, time_cnt_set1;
-  logic                     index_cnt_inc, index_cnt_clr;
-  logic [31:0]              index_limit_q, index_limit_d;
-  logic [31:0]              time_limit_q, time_limit_d;
-  logic                     prog_pend_q, prog_pend_d;
-  logic                     mem_req;
-  logic                     mem_wr;
-  logic [DataWidth-1:0]     mem_wdata;
-  logic [AddrW-1:0]         mem_addr;
-  flash_ctrl_pkg::flash_part_e mem_part;
-
-  // insert a fifo here to break the large fanout from inputs to memories on reads
-  typedef struct packed {
-    logic                        rd;
-    logic                        prog;
-    logic                        prog_last;
-    flash_ctrl_pkg::flash_prog_e prog_type;
-    logic                        pg_erase;
-    logic                        bk_erase;
-    logic [AddrW-1:0]            addr;
-    flash_ctrl_pkg::flash_part_e part;
-    logic [DataWidth-1:0]        prog_data;
-  } cmd_payload_t;
-
-  cmd_payload_t cmd_d, cmd_q;
-  logic cmd_valid;
-  logic pop_cmd;
-  logic mem_rd_q, mem_rd_d;
-
-  assign cmd_d = '{
-    rd :       rd_i,
-    prog:      prog_i,
-    prog_last: prog_last_i,
-    prog_type: prog_type_i,
-    pg_erase:  pg_erase_i,
-    bk_erase:  bk_erase_i,
-    addr:      addr_i,
-    part:      part_i,
-    prog_data: prog_data_i
-  };
-
-  // for read transactions, in order to reduce latency, the
-  // command fifo is popped early (before done_o).  This is to ensure that when
-  // the current transaction is complete, during the same cycle
-  // a new read can be issued. As a result, the command is popped
-  // immediately after the read is issued, rather than waiting for
-  // the read to be completed.  The same restrictions are not necessary
-  // for program / erase, which do not have the same performance
-  // requirements.
-
-  prim_fifo_sync #(
-    .Width   ($bits(cmd_payload_t)),
-    .Pass    (0),
-    .Depth   (2)
-  ) u_cmd_fifo (
-    .clk_i,
-    .rst_ni,
-    .clr_i   (1'b0),
-    .wvalid_i(rd_i | prog_i | pg_erase_i | bk_erase_i),
-    .wready_o(ack_o),
-    .wdata_i (cmd_d),
-    .depth_o (),
-    .rvalid_o(cmd_valid),
-    .rready_i(pop_cmd),
-    .rdata_o (cmd_q)
-  );
-
-  logic rd_req, prog_req, pg_erase_req, bk_erase_req;
-  assign rd_req = cmd_valid & cmd_q.rd;
-  assign prog_req = cmd_valid & cmd_q.prog;
-  assign pg_erase_req = cmd_valid & cmd_q.pg_erase;
-  assign bk_erase_req = cmd_valid & cmd_q.bk_erase;
-
-  // for read / program operations, the index cnt should be 0
-  assign mem_rd_d = mem_req & ~mem_wr;
-  assign mem_addr = cmd_q.addr + index_cnt[AddrW-1:0];
-  assign mem_part = cmd_q.part;
-
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) st_q <= StReset;
-    else st_q <= st_d;
-  end
-
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      time_limit_q  <= 'h0;
-      index_limit_q <= 'h0;
-      prog_pend_q   <= 'h0;
-      mem_rd_q      <= 'h0;
-    end else begin
-      time_limit_q  <= time_limit_d;
-      index_limit_q <= index_limit_d;
-      prog_pend_q   <= prog_pend_d;
-      mem_rd_q      <= mem_rd_d;
-    end
-  end
-
-  // latch read data from emulated memories the cycle after a read
-  logic [DataWidth-1:0] rd_data_q, rd_data_d;
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      rd_data_q <= '0;
-    end else if (mem_rd_q) begin
-      rd_data_q <= rd_data_d;
-    end
-  end
-
-  // latch partiton being read since the command fifo is popped early
-  flash_ctrl_pkg::flash_part_e rd_part_q;
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      rd_part_q <= flash_ctrl_pkg::FlashPartData;
-    end else if (mem_rd_d) begin
-      rd_part_q <= cmd_q.part;
-    end
-  end
-
-  // if read cycle is only 1, we can expose the unlatched data directly
-  if (ReadCycles == 1) begin : gen_fast_rd_data
-    assign rd_data_o = rd_data_d;
-  end else begin : gen_rd_data
-    assign rd_data_o = rd_data_q;
-  end
-
-  // prog_pend_q is necessary to emulate flash behavior that a bit written to 0 cannot be written
-  // back to 1 without an erase
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      time_cnt  <= 'h0;
-      index_cnt <= 'h0;
-    end else begin
-      if (time_cnt_inc) time_cnt <= time_cnt + 1'b1;
-      else if (time_cnt_set1) time_cnt <= 32'h1;
-      else if (time_cnt_clr) time_cnt <= 32'h0;
-
-      if (index_cnt_inc) index_cnt <= index_cnt + 1'b1;
-      else if (index_cnt_clr) index_cnt <= 32'h0;
-    end
-  end
-
-
-  always_comb begin
-    // state
-    st_d             = st_q;
-
-    // internally consumed signals
-    index_limit_d    = index_limit_q;
-    time_limit_d     = time_limit_q;
-    prog_pend_d      = prog_pend_q;
-    mem_req          = 'h0;
-    mem_wr           = 'h0;
-    mem_wdata        = 'h0;
-    time_cnt_inc     = 'h0;
-    time_cnt_clr     = 'h0;
-    time_cnt_set1    = 'h0;
-    index_cnt_inc    = 'h0;
-    index_cnt_clr    = 'h0;
-
-    // i/o
-    init_busy_o      = 'h0;
-    pop_cmd          = 'h0;
-    done_o           = 'h0;
-
-    unique case (st_q)
-      StReset: begin
-        init_busy_o = 1'h1;
-        st_d = StInit;
-      end
-      // Emulate flash power up to all 1's
-      // This implies this flash will not survive a reset
-      // Might need a different RESET for FPGA purposes
-      StInit: begin
-        init_busy_o = 1'h1;
-        if (index_cnt < WordsPerBank && !SkipInit) begin
-          st_d = StInit;
-          index_cnt_inc = 1'b1;
-          mem_req = 1'h0;
-          mem_wr  = 1'h0;
-          mem_wdata = {DataWidth{1'b1}};
-        end else begin
-          st_d = StIdle;
-          index_cnt_clr = 1'b1;
-        end
-      end
-
-      StIdle: begin
-        if (rd_req) begin
-          pop_cmd = 1'b1;
-          mem_req = 1'b1;
-          time_cnt_inc = 1'b1;
-          st_d = StRead;
-        end else if (prog_req) begin
-          mem_req = 1'b1;
-          prog_pend_d = 1'b1;
-          st_d = StRead;
-        end else if (pg_erase_req) begin
-          st_d = StErase;
-          index_limit_d = WordsPerPage;
-          time_limit_d = PgEraseCycles;
-        end else if (bk_erase_req) begin
-          st_d = StErase;
-          index_limit_d = WordsPerBank;
-          time_limit_d = BkEraseCycles;
-        end
-      end
-
-      StRead: begin
-        if (time_cnt < ReadCycles) begin
-          time_cnt_inc = 1'b1;
-
-        end else if (!prog_pend_q) begin
-          done_o = 1'b1;
-
-          // if another request already pending
-          if (rd_req) begin
-            pop_cmd = 1'b1;
-            mem_req = 1'b1;
-            time_cnt_set1 = 1'b1;
-            st_d = StRead;
-          end else begin
-            time_cnt_clr = 1'b1;
-            st_d = StIdle;
-          end
-
-        end else if (prog_pend_q) begin
-          // this is the read performed before a program operation
-          prog_pend_d = 1'b0;
-          time_cnt_clr = 1'b1;
-          st_d = StProg;
-        end
-      end
-
-      StProg: begin
-        // if data is already 0, cannot program to 1 without erase
-        mem_wdata = cmd_q.prog_data & rd_data_q;
-        if (time_cnt < ProgCycles) begin
-          mem_req = 1'b1;
-          mem_wr = 1'b1;
-          time_cnt_inc = 1'b1;
-        end else begin
-          st_d = StIdle;
-          pop_cmd = 1'b1;
-          done_o = cmd_q.prog_last;
-          time_cnt_clr = 1'b1;
-        end
-      end
-
-      StErase: begin
-        // Actual erasing of the page
-        if (index_cnt < index_limit_q || time_cnt < time_limit_q) begin
-          mem_req = 1'b1;
-          mem_wr = 1'b1;
-          mem_wdata = {DataWidth{1'b1}};
-          time_cnt_inc = (time_cnt < time_limit_q);
-          index_cnt_inc = (index_cnt < index_limit_q);
-        end else begin
-          st_d = StIdle;
-          pop_cmd = 1'b1;
-          done_o = 1'b1;
-          time_cnt_clr = 1'b1;
-          index_cnt_clr = 1'b1;
-        end
-      end
-      default: begin
-        st_d = StIdle;
-      end
-    endcase // unique case (st_q)
-  end // always_comb
-
-  localparam int MemWidth = DataWidth - MetaDataWidth;
-
-  logic [DataWidth-1:0] rd_data_main, rd_data_info;
-  logic [MemWidth-1:0] rd_nom_data_main, rd_nom_data_info;
-  logic [MetaDataWidth-1:0] rd_meta_data_main, rd_meta_data_info;
-
-  prim_ram_1p #(
-    .Width(MemWidth),
-    .Depth(WordsPerBank),
-    .DataBitsPerMask(MemWidth)
-  ) u_mem (
-    .clk_i,
-    .req_i    (mem_req & (mem_part == flash_ctrl_pkg::FlashPartData)),
-    .write_i  (mem_wr),
-    .addr_i   (mem_addr),
-    .wdata_i  (mem_wdata[MemWidth-1:0]),
-    .wmask_i  ({MemWidth{1'b1}}),
-    .rdata_o  (rd_nom_data_main)
-  );
-
-  prim_ram_1p #(
-    .Width(MetaDataWidth),
-    .Depth(WordsPerBank),
-    .DataBitsPerMask(MetaDataWidth)
-  ) u_mem_meta (
-    .clk_i,
-    .req_i    (mem_req & (mem_part == flash_ctrl_pkg::FlashPartData)),
-    .write_i  (mem_wr),
-    .addr_i   (mem_addr),
-    .wdata_i  (mem_wdata[MemWidth +: MetaDataWidth]),
-    .wmask_i  ({MetaDataWidth{1'b1}}),
-    .rdata_o  (rd_meta_data_main)
-  );
-
-  prim_ram_1p #(
-    .Width(MemWidth),
-    .Depth(WordsPerInfoBank),
-    .DataBitsPerMask(MemWidth)
-  ) u_info_mem (
-    .clk_i,
-    .req_i    (mem_req & (mem_part == flash_ctrl_pkg::FlashPartInfo)),
-    .write_i  (mem_wr),
-    .addr_i   (mem_addr[0 +: InfoAddrW]),
-    .wdata_i  (mem_wdata[MemWidth-1:0]),
-    .wmask_i  ({MemWidth{1'b1}}),
-    .rdata_o  (rd_nom_data_info)
-  );
-
-  prim_ram_1p #(
-    .Width(MetaDataWidth),
-    .Depth(WordsPerInfoBank),
-    .DataBitsPerMask(MetaDataWidth)
-  ) u_info_mem_meta (
-    .clk_i,
-    .req_i    (mem_req & (mem_part == flash_ctrl_pkg::FlashPartInfo)),
-    .write_i  (mem_wr),
-    .addr_i   (mem_addr[0 +: InfoAddrW]),
-    .wdata_i  (mem_wdata[MemWidth +: MetaDataWidth]),
-    .wmask_i  ({MetaDataWidth{1'b1}}),
-    .rdata_o  (rd_meta_data_info)
-  );
-
-  assign rd_data_main = {rd_meta_data_main, rd_nom_data_main};
-  assign rd_data_info = {rd_meta_data_info, rd_nom_data_info};
-  assign rd_data_d    = rd_part_q == flash_ctrl_pkg::FlashPartData ? rd_data_main : rd_data_info;
-
-  // hard-wire assignment for now
-  assign tdo_o = 1'b0;
+  logic [NumBanks-1:0] init_busy;
+  assign init_busy_o = |init_busy;
 
   // this represents the type of program operations that are supported
   assign prog_type_avail_o[flash_ctrl_pkg::FlashProgNormal] = 1'b1;
   assign prog_type_avail_o[flash_ctrl_pkg::FlashProgRepair] = 1'b1;
 
-  logic unused_flash_power_down_hi;
-  logic unused_flash_power_ready_hi;
-  logic unused_scan_reset_ni;
+  for (genvar bank = 0; bank < NumBanks; bank++) begin : gen_prim_flash_banks
+    prim_generic_flash_bank #(
+      .InfosPerBank(InfosPerBank),
+      .PagesPerBank(PagesPerBank),
+      .WordsPerPage(WordsPerPage),
+      .DataWidth(DataWidth),
+      .MetaDataWidth(MetaDataWidth)
+    ) u_prim_flash_bank (
+      .clk_i,
+      .rst_ni,
+      .rd_i(flash_req_i[bank].rd_req),
+      .prog_i(flash_req_i[bank].prog_req),
+      .prog_last_i(flash_req_i[bank].prog_last),
+      .prog_type_i(flash_req_i[bank].prog_type),
+      .pg_erase_i(flash_req_i[bank].pg_erase_req),
+      .bk_erase_i(flash_req_i[bank].bk_erase_req),
+      .addr_i(flash_req_i[bank].addr),
+      .part_i(flash_req_i[bank].part),
+      .prog_data_i(flash_req_i[bank].prog_full_data),
+      .ack_o(flash_rsp_o[bank].ack),
+      .done_o(flash_rsp_o[bank].done),
+      .rd_data_o(flash_rsp_o[bank].rdata),
+      .init_busy_o(init_busy[bank]),
+      .flash_power_ready_h_i,
+      .flash_power_down_h_i
+    );
+  end
+
+  logic unused_scanmode;
+  logic unused_scan_rst_n;
+  logic [TestModeWidth-1:0] unused_flash_test_mode;
+  logic unused_flash_test_voltage;
   logic unused_tck;
-  logic unused_tms;
   logic unused_tdi;
-  flash_ctrl_pkg::flash_prog_e unused_prog_type;
-  assign unused_prog_type = cmd_q.prog_type;
-  assign unused_flash_power_down_hi = flash_power_down_hi;
-  assign unused_flash_power_ready_hi = flash_power_ready_hi;
-  assign unused_scan_reset_ni = scan_reset_ni;
-  assign unused_scanmode_i = scanmode_i;
+  logic unused_tms;
+
+  assign unused_scanmode = scanmode_i;
+  assign unused_scan_rst_n = scan_rst_ni;
+  assign unused_flash_test_mode = flash_test_mode_a_i;
+  assign unused_flash_test_voltage = flash_test_voltage_h_i;
   assign unused_tck = tck_i;
   assign unused_tdi = tdi_i;
   assign unused_tms = tms_i;
+  assign tdo_o = '0;
 
 endmodule // prim_generic_flash

--- a/hw/ip/prim_generic/rtl/prim_generic_flash_bank.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_flash_bank.sv
@@ -1,0 +1,415 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Emulate a single generic flash bank
+//
+
+module prim_generic_flash_bank #(
+  parameter int InfosPerBank  = 1,   // info pages per bank
+  parameter int PagesPerBank  = 256, // data pages per bank
+  parameter int WordsPerPage  = 256, // words per page
+  parameter int DataWidth     = 32,  // bits per word
+  parameter int MetaDataWidth = 12,  // this is a temporary parameter to work around ECC issues
+
+  // Derived parameters
+  localparam int PageW = $clog2(PagesPerBank),
+  localparam int WordW = $clog2(WordsPerPage),
+  localparam int AddrW = PageW + WordW
+) (
+  input                              clk_i,
+  input                              rst_ni,
+  input                              rd_i,
+  input                              prog_i,
+  input                              prog_last_i,
+  // the generic model does not make use of program types
+  input flash_ctrl_pkg::flash_prog_e prog_type_i,
+  input                              pg_erase_i,
+  input                              bk_erase_i,
+  input [AddrW-1:0]                  addr_i,
+  input flash_ctrl_pkg::flash_part_e part_i,
+  input [DataWidth-1:0]              prog_data_i,
+  output logic                       ack_o,
+  output logic                       done_o,
+  output logic [DataWidth-1:0]       rd_data_o,
+  output logic                       init_busy_o,
+  input                              flash_power_ready_h_i,
+  input                              flash_power_down_h_i
+);
+
+  // Emulated flash macro values
+  localparam int ReadCycles = 1;
+  localparam int ProgCycles = 50;
+  localparam int PgEraseCycles = 200;
+  localparam int BkEraseCycles = 2000;
+  localparam int InitCycles = 100;
+
+  // Locally derived values
+  localparam int WordsPerBank  = PagesPerBank * WordsPerPage;
+  localparam int WordsPerInfoBank = InfosPerBank * WordsPerPage;
+  localparam int InfoAddrW = $clog2(WordsPerInfoBank);
+
+  typedef enum logic [2:0] {
+    StReset    = 'h0,
+    StInit     = 'h1,
+    StIdle     = 'h2,
+    StRead     = 'h3,
+    StProg     = 'h4,
+    StErase    = 'h5
+  } state_e;
+
+  state_e st_q, st_d;
+
+  logic [31:0]              time_cnt;
+  logic [31:0]              index_cnt;
+  logic                     time_cnt_inc ,time_cnt_clr, time_cnt_set1;
+  logic                     index_cnt_inc, index_cnt_clr;
+  logic [31:0]              index_limit_q, index_limit_d;
+  logic [31:0]              time_limit_q, time_limit_d;
+  logic                     prog_pend_q, prog_pend_d;
+  logic                     mem_req;
+  logic                     mem_wr;
+  logic [DataWidth-1:0]     mem_wdata;
+  logic [AddrW-1:0]         mem_addr;
+  flash_ctrl_pkg::flash_part_e mem_part;
+
+  // insert a fifo here to break the large fanout from inputs to memories on reads
+  typedef struct packed {
+    logic                        rd;
+    logic                        prog;
+    logic                        prog_last;
+    flash_ctrl_pkg::flash_prog_e prog_type;
+    logic                        pg_erase;
+    logic                        bk_erase;
+    logic [AddrW-1:0]            addr;
+    flash_ctrl_pkg::flash_part_e part;
+    logic [DataWidth-1:0]        prog_data;
+  } cmd_payload_t;
+
+  cmd_payload_t cmd_d, cmd_q;
+  logic cmd_valid;
+  logic pop_cmd;
+  logic mem_rd_q, mem_rd_d;
+
+  assign cmd_d = '{
+    rd :       rd_i,
+    prog:      prog_i,
+    prog_last: prog_last_i,
+    prog_type: prog_type_i,
+    pg_erase:  pg_erase_i,
+    bk_erase:  bk_erase_i,
+    addr:      addr_i,
+    part:      part_i,
+    prog_data: prog_data_i
+  };
+
+  // for read transactions, in order to reduce latency, the
+  // command fifo is popped early (before done_o).  This is to ensure that when
+  // the current transaction is complete, during the same cycle
+  // a new read can be issued. As a result, the command is popped
+  // immediately after the read is issued, rather than waiting for
+  // the read to be completed.  The same restrictions are not necessary
+  // for program / erase, which do not have the same performance
+  // requirements.
+
+  // when the flash is going through init, do not accept any transactions
+  logic wvalid;
+  logic ack;
+  assign wvalid = (rd_i | prog_i | pg_erase_i | bk_erase_i) & !init_busy_o;
+  assign ack_o = ack & !init_busy_o;
+
+  prim_fifo_sync #(
+    .Width   ($bits(cmd_payload_t)),
+    .Pass    (0),
+    .Depth   (2)
+  ) u_cmd_fifo (
+    .clk_i,
+    .rst_ni,
+    .clr_i   (1'b0),
+    .wvalid_i(wvalid),
+    .wready_o(ack),
+    .wdata_i (cmd_d),
+    .depth_o (),
+    .rvalid_o(cmd_valid),
+    .rready_i(pop_cmd),
+    .rdata_o (cmd_q)
+  );
+
+  logic rd_req, prog_req, pg_erase_req, bk_erase_req;
+  assign rd_req = cmd_valid & cmd_q.rd;
+  assign prog_req = cmd_valid & cmd_q.prog;
+  assign pg_erase_req = cmd_valid & cmd_q.pg_erase;
+  assign bk_erase_req = cmd_valid & cmd_q.bk_erase;
+
+  // for read / program operations, the index cnt should be 0
+  assign mem_rd_d = mem_req & ~mem_wr;
+  assign mem_addr = cmd_q.addr + index_cnt[AddrW-1:0];
+  assign mem_part = cmd_q.part;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) st_q <= StReset;
+    else st_q <= st_d;
+  end
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      time_limit_q  <= 'h0;
+      index_limit_q <= 'h0;
+      prog_pend_q   <= 'h0;
+      mem_rd_q      <= 'h0;
+    end else begin
+      time_limit_q  <= time_limit_d;
+      index_limit_q <= index_limit_d;
+      prog_pend_q   <= prog_pend_d;
+      mem_rd_q      <= mem_rd_d;
+    end
+  end
+
+  // latch read data from emulated memories the cycle after a read
+  logic [DataWidth-1:0] rd_data_q, rd_data_d;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      rd_data_q <= '0;
+    end else if (mem_rd_q) begin
+      rd_data_q <= rd_data_d;
+    end
+  end
+
+  // latch partiton being read since the command fifo is popped early
+  flash_ctrl_pkg::flash_part_e rd_part_q;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      rd_part_q <= flash_ctrl_pkg::FlashPartData;
+    end else if (mem_rd_d) begin
+      rd_part_q <= cmd_q.part;
+    end
+  end
+
+  // if read cycle is only 1, we can expose the unlatched data directly
+  if (ReadCycles == 1) begin : gen_fast_rd_data
+    assign rd_data_o = rd_data_d;
+  end else begin : gen_rd_data
+    assign rd_data_o = rd_data_q;
+  end
+
+  // prog_pend_q is necessary to emulate flash behavior that a bit written to 0 cannot be written
+  // back to 1 without an erase
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      time_cnt  <= 'h0;
+      index_cnt <= 'h0;
+    end else begin
+      if (time_cnt_inc) time_cnt <= time_cnt + 1'b1;
+      else if (time_cnt_set1) time_cnt <= 32'h1;
+      else if (time_cnt_clr) time_cnt <= 32'h0;
+
+      if (index_cnt_inc) index_cnt <= index_cnt + 1'b1;
+      else if (index_cnt_clr) index_cnt <= 32'h0;
+    end
+  end
+
+
+  always_comb begin
+    // state
+    st_d             = st_q;
+
+    // internally consumed signals
+    index_limit_d    = index_limit_q;
+    time_limit_d     = time_limit_q;
+    prog_pend_d      = prog_pend_q;
+    mem_req          = '0;
+    mem_wr           = '0;
+    mem_wdata        = '0;
+    time_cnt_inc     = '0;
+    time_cnt_clr     = '0;
+    time_cnt_set1    = '0;
+    index_cnt_inc    = '0;
+    index_cnt_clr    = '0;
+
+    // i/o
+    init_busy_o      = '0;
+    pop_cmd          = '0;
+    done_o           = '0;
+
+    unique case (st_q)
+      StReset: begin
+        init_busy_o = 1'b1;
+        if (flash_power_ready_h_i && !flash_power_down_h_i) begin
+          st_d = StInit;
+        end
+      end
+
+      // Emulate flash initilaization with a wait timer
+      StInit: begin
+        init_busy_o = 1'h1;
+        if (index_cnt < InitCycles) begin
+          st_d = StInit;
+          index_cnt_inc = 1'b1;
+        end else begin
+          st_d = StIdle;
+          index_cnt_clr = 1'b1;
+        end
+      end
+
+      StIdle: begin
+        if (rd_req) begin
+          pop_cmd = 1'b1;
+          mem_req = 1'b1;
+          time_cnt_inc = 1'b1;
+          st_d = StRead;
+        end else if (prog_req) begin
+          mem_req = 1'b1;
+          prog_pend_d = 1'b1;
+          st_d = StRead;
+        end else if (pg_erase_req) begin
+          st_d = StErase;
+          index_limit_d = WordsPerPage;
+          time_limit_d = PgEraseCycles;
+        end else if (bk_erase_req) begin
+          st_d = StErase;
+          index_limit_d = WordsPerBank;
+          time_limit_d = BkEraseCycles;
+        end
+      end
+
+      StRead: begin
+        if (time_cnt < ReadCycles) begin
+          time_cnt_inc = 1'b1;
+
+        end else if (!prog_pend_q) begin
+          done_o = 1'b1;
+
+          // if another request already pending
+          if (rd_req) begin
+            pop_cmd = 1'b1;
+            mem_req = 1'b1;
+            time_cnt_set1 = 1'b1;
+            st_d = StRead;
+          end else begin
+            time_cnt_clr = 1'b1;
+            st_d = StIdle;
+          end
+
+        end else if (prog_pend_q) begin
+          // this is the read performed before a program operation
+          prog_pend_d = 1'b0;
+          time_cnt_clr = 1'b1;
+          st_d = StProg;
+        end
+      end
+
+      StProg: begin
+        // if data is already 0, cannot program to 1 without erase
+        mem_wdata = cmd_q.prog_data & rd_data_q;
+        if (time_cnt < ProgCycles) begin
+          mem_req = 1'b1;
+          mem_wr = 1'b1;
+          time_cnt_inc = 1'b1;
+        end else begin
+          st_d = StIdle;
+          pop_cmd = 1'b1;
+          done_o = cmd_q.prog_last;
+          time_cnt_clr = 1'b1;
+        end
+      end
+
+      StErase: begin
+        // Actual erasing of the page
+        if (index_cnt < index_limit_q || time_cnt < time_limit_q) begin
+          mem_req = 1'b1;
+          mem_wr = 1'b1;
+          mem_wdata = {DataWidth{1'b1}};
+          time_cnt_inc = (time_cnt < time_limit_q);
+          index_cnt_inc = (index_cnt < index_limit_q);
+        end else begin
+          st_d = StIdle;
+          pop_cmd = 1'b1;
+          done_o = 1'b1;
+          time_cnt_clr = 1'b1;
+          index_cnt_clr = 1'b1;
+        end
+      end
+      default: begin
+        st_d = StIdle;
+      end
+
+    endcase // unique case (st_q)
+
+    // Emulate power down and power loss behavior
+    if (!flash_power_ready_h_i || flash_power_down_h_i) begin
+      st_d = StReset;
+    end
+
+  end // always_comb
+
+  localparam int MemWidth = DataWidth - MetaDataWidth;
+
+  logic [DataWidth-1:0] rd_data_main, rd_data_info;
+  logic [MemWidth-1:0] rd_nom_data_main, rd_nom_data_info;
+  logic [MetaDataWidth-1:0] rd_meta_data_main, rd_meta_data_info;
+
+  prim_ram_1p #(
+    .Width(MemWidth),
+    .Depth(WordsPerBank),
+    .DataBitsPerMask(MemWidth)
+  ) u_mem (
+    .clk_i,
+    .req_i    (mem_req & (mem_part == flash_ctrl_pkg::FlashPartData)),
+    .write_i  (mem_wr),
+    .addr_i   (mem_addr),
+    .wdata_i  (mem_wdata[MemWidth-1:0]),
+    .wmask_i  ({MemWidth{1'b1}}),
+    .rdata_o  (rd_nom_data_main)
+  );
+
+  prim_ram_1p #(
+    .Width(MetaDataWidth),
+    .Depth(WordsPerBank),
+    .DataBitsPerMask(MetaDataWidth)
+  ) u_mem_meta (
+    .clk_i,
+    .req_i    (mem_req & (mem_part == flash_ctrl_pkg::FlashPartData)),
+    .write_i  (mem_wr),
+    .addr_i   (mem_addr),
+    .wdata_i  (mem_wdata[MemWidth +: MetaDataWidth]),
+    .wmask_i  ({MetaDataWidth{1'b1}}),
+    .rdata_o  (rd_meta_data_main)
+  );
+
+  prim_ram_1p #(
+    .Width(MemWidth),
+    .Depth(WordsPerInfoBank),
+    .DataBitsPerMask(MemWidth)
+  ) u_info_mem (
+    .clk_i,
+    .req_i    (mem_req & (mem_part == flash_ctrl_pkg::FlashPartInfo)),
+    .write_i  (mem_wr),
+    .addr_i   (mem_addr[0 +: InfoAddrW]),
+    .wdata_i  (mem_wdata[MemWidth-1:0]),
+    .wmask_i  ({MemWidth{1'b1}}),
+    .rdata_o  (rd_nom_data_info)
+  );
+
+  prim_ram_1p #(
+    .Width(MetaDataWidth),
+    .Depth(WordsPerInfoBank),
+    .DataBitsPerMask(MetaDataWidth)
+  ) u_info_mem_meta (
+    .clk_i,
+    .req_i    (mem_req & (mem_part == flash_ctrl_pkg::FlashPartInfo)),
+    .write_i  (mem_wr),
+    .addr_i   (mem_addr[0 +: InfoAddrW]),
+    .wdata_i  (mem_wdata[MemWidth +: MetaDataWidth]),
+    .wmask_i  ({MetaDataWidth{1'b1}}),
+    .rdata_o  (rd_meta_data_info)
+  );
+
+  assign rd_data_main = {rd_meta_data_main, rd_nom_data_main};
+  assign rd_data_info = {rd_meta_data_info, rd_nom_data_info};
+  assign rd_data_d    = rd_part_q == flash_ctrl_pkg::FlashPartData ? rd_data_main : rd_data_info;
+
+  flash_ctrl_pkg::flash_prog_e unused_prog_type;
+  assign unused_prog_type = cmd_q.prog_type;
+
+
+endmodule // prim_generic_flash

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -3561,6 +3561,58 @@
           top_signame: eflash_tl
           index: -1
         }
+        {
+          struct: logic
+          package: ""
+          type: uni
+          act: rcv
+          name: flash_power_down_h
+          inst_name: eflash
+          width: 1
+          default: ""
+          external: true
+          top_signame: flash_power_down_h
+          index: -1
+        }
+        {
+          struct: logic
+          package: ""
+          type: uni
+          act: rcv
+          name: flash_power_ready_h
+          inst_name: eflash
+          width: 1
+          default: ""
+          external: true
+          top_signame: flash_power_ready_h
+          index: -1
+        }
+        {
+          struct: logic
+          package: ""
+          width: 2
+          type: uni
+          act: rcv
+          name: flash_test_mode_a
+          inst_name: eflash
+          default: ""
+          external: true
+          top_signame: flash_test_mode_a
+          index: -1
+        }
+        {
+          struct: logic
+          package: ""
+          type: uni
+          act: rcv
+          name: flash_test_voltage_h
+          inst_name: eflash
+          width: 1
+          default: ""
+          external: true
+          top_signame: flash_test_voltage_h
+          index: -1
+        }
       ]
       clock_reset_export: []
       clock_connections:
@@ -3767,6 +3819,10 @@
       peri.tl_ast_wrapper: ast_tl
       otp_ctrl.otp_ast_pwr_seq: ""
       otp_ctrl.otp_ast_pwr_seq_h: ""
+      eflash.flash_power_down_h: flash_power_down_h
+      eflash.flash_power_ready_h: flash_power_ready_h
+      eflash.flash_test_mode_a: flash_test_mode_a
+      eflash.flash_test_voltage_h: flash_test_voltage_h
       clkmgr.clocks_ast: clks_ast
       rstmgr.resets_ast: rsts_ast
     }
@@ -7189,6 +7245,58 @@
         index: -1
       }
       {
+        struct: logic
+        package: ""
+        type: uni
+        act: rcv
+        name: flash_power_down_h
+        inst_name: eflash
+        width: 1
+        default: ""
+        external: true
+        top_signame: flash_power_down_h
+        index: -1
+      }
+      {
+        struct: logic
+        package: ""
+        type: uni
+        act: rcv
+        name: flash_power_ready_h
+        inst_name: eflash
+        width: 1
+        default: ""
+        external: true
+        top_signame: flash_power_ready_h
+        index: -1
+      }
+      {
+        struct: logic
+        package: ""
+        width: 2
+        type: uni
+        act: rcv
+        name: flash_test_mode_a
+        inst_name: eflash
+        default: ""
+        external: true
+        top_signame: flash_test_mode_a
+        index: -1
+      }
+      {
+        struct: logic
+        package: ""
+        type: uni
+        act: rcv
+        name: flash_test_voltage_h
+        inst_name: eflash
+        width: 1
+        default: ""
+        external: true
+        top_signame: flash_test_voltage_h
+        index: -1
+      }
+      {
         struct: tl
         type: req_rsp
         name: tl_corei
@@ -7718,6 +7826,42 @@
         width: 1
         type: uni
         default: "'0"
+        direction: in
+      }
+      {
+        package: ""
+        struct: logic
+        signame: flash_power_down_h_i
+        width: 1
+        type: uni
+        default: ""
+        direction: in
+      }
+      {
+        package: ""
+        struct: logic
+        signame: flash_power_ready_h_i
+        width: 1
+        type: uni
+        default: ""
+        direction: in
+      }
+      {
+        package: ""
+        struct: logic
+        signame: flash_test_mode_a_i
+        width: 2
+        type: uni
+        default: ""
+        direction: in
+      }
+      {
+        package: ""
+        struct: logic
+        signame: flash_test_voltage_h_i
+        width: 1
+        type: uni
+        default: ""
         direction: in
       }
       {

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -434,7 +434,32 @@
           type: "req_rsp"
           act: "rsp"
           name: "tl"
-        }
+        },
+        { struct: "logic"
+          package: ""
+          type: "uni"
+          act: "rcv"
+          name: "flash_power_down_h"
+        },
+        { struct: "logic"
+          package: ""
+          type: "uni"
+          act: "rcv"
+          name: "flash_power_ready_h"
+        },
+        { struct: "logic",
+          package: "",
+          width: "2",
+          type: "uni"
+          act: "rcv"
+          name: "flash_test_mode_a"
+        },
+        { struct: "logic",
+          package: "",
+          type: "uni"
+          act: "rcv"
+          name: "flash_test_voltage_h"
+        },
       ],
     },
   ],
@@ -490,6 +515,10 @@
         'peri.tl_ast_wrapper': 'ast_tl',
         'otp_ctrl.otp_ast_pwr_seq': '',
         'otp_ctrl.otp_ast_pwr_seq_h': '',
+        'eflash.flash_power_down_h': 'flash_power_down_h',
+        'eflash.flash_power_ready_h': 'flash_power_ready_h',
+        'eflash.flash_test_mode_a': 'flash_test_mode_a',
+        'eflash.flash_test_voltage_h': 'flash_test_voltage_h',
     },
   },
 

--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -469,7 +469,13 @@ module top_${top["name"]} #(
     .host_rderr_o    (flash_host_rderr),
     .host_rdata_o    (flash_host_rdata),
     .flash_ctrl_i    (${m["inter_signal_list"][0]["top_signame"]}_req),
-    .flash_ctrl_o    (${m["inter_signal_list"][0]["top_signame"]}_rsp)
+    .flash_ctrl_o    (${m["inter_signal_list"][0]["top_signame"]}_rsp),
+    .flash_power_down_h_i,
+    .flash_power_ready_h_i,
+    .flash_test_mode_a_i,
+    .flash_test_voltage_h_i,
+    .scanmode_i,
+    .scan_rst_ni
   );
 
   % else:

--- a/hw/top_earlgrey/dv/tb/chip_hier_macros.svh
+++ b/hw/top_earlgrey/dv/tb/chip_hier_macros.svh
@@ -12,12 +12,12 @@
 `define RAM_MAIN_HIER      `CHIP_HIER.u_ram1p_ram_main.u_mem
 `define RAM_RET_HIER       `CHIP_HIER.u_ram1p_ram_ret.u_mem
 `define ROM_HIER           `CHIP_HIER.u_rom_rom.u_prim_rom
-`define FLASH_HIER         `CHIP_HIER.u_flash_eflash
+`define FLASH_HIER         `CHIP_HIER.u_flash_eflash.u_flash
 `define RSTMGR_HIER        `CHIP_HIER.u_rstmgr
 `define CLKMGR_HIER        `CHIP_HIER.u_clkmgr
 `define USBDEV_HIER        `CHIP_HIER.u_usbdev
-`define FLASH_BANK0        `FLASH_HIER.gen_flash_banks[0].i_core.i_flash.gen_generic.u_impl_generic
-`define FLASH_BANK1        `FLASH_HIER.gen_flash_banks[1].i_core.i_flash.gen_generic.u_impl_generic
+`define FLASH_BANK0        `FLASH_HIER.gen_generic.u_impl_generic.gen_prim_flash_banks[0].u_prim_flash_bank
+`define FLASH_BANK1        `FLASH_HIER.gen_generic.u_impl_generic.gen_prim_flash_banks[1].u_prim_flash_bank
 `define FLASH0_MEM_HIER    `FLASH_BANK0.u_mem
 `define FLASH1_MEM_HIER    `FLASH_BANK1.u_mem
 `define FLASH0_INFO_HIER   `FLASH_BANK0.u_info_mem

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -69,6 +69,10 @@ module top_earlgrey #(
   input  tlul_pkg::tl_d2h_t       ast_tl_rsp_i,
   output otp_ctrl_pkg::otp_ast_req_t       otp_ctrl_otp_ast_pwr_seq_o,
   input  otp_ctrl_pkg::otp_ast_rsp_t       otp_ctrl_otp_ast_pwr_seq_h_i,
+  input  logic       flash_power_down_h_i,
+  input  logic       flash_power_ready_h_i,
+  input  logic [1:0] flash_test_mode_a_i,
+  input  logic       flash_test_voltage_h_i,
   output clkmgr_pkg::clkmgr_ast_out_t       clks_ast_o,
   output rstmgr_pkg::rstmgr_ast_out_t       rsts_ast_o,
   input               scan_rst_ni, // reset used for test mode
@@ -622,7 +626,13 @@ module top_earlgrey #(
     .host_rderr_o    (flash_host_rderr),
     .host_rdata_o    (flash_host_rdata),
     .flash_ctrl_i    (flash_ctrl_flash_req),
-    .flash_ctrl_o    (flash_ctrl_flash_rsp)
+    .flash_ctrl_o    (flash_ctrl_flash_rsp),
+    .flash_power_down_h_i,
+    .flash_power_ready_h_i,
+    .flash_test_mode_a_i,
+    .flash_test_voltage_h_i,
+    .scanmode_i,
+    .scan_rst_ni
   );
 
 

--- a/hw/top_earlgrey/rtl/top_earlgrey_artys7.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_artys7.sv
@@ -214,6 +214,8 @@ module top_earlgrey_artys7  #(
     .ast_tl_rsp_i                 ( '0              ),
     .otp_ctrl_otp_ast_pwr_seq_o   (                 ),
     .otp_ctrl_otp_ast_pwr_seq_h_i ( '0              ),
+    .flash_power_down_h_i         ( '0              ),
+    .flash_power_ready_h_i        ( 1'b1            ),
 
     // JTAG
     .jtag_tck_i      ( jtag_tck_buf  ),

--- a/hw/top_earlgrey/rtl/top_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_asic.sv
@@ -238,7 +238,7 @@ module top_earlgrey_asic (
     .alert_o(ast_base_alerts),
     .status_o(ast_base_status),
     .usb_io_pu_cal_o(),
-    .ast_eflash_o(), // need to wait for flash integration update
+    .ast_eflash_o(ast_base_eflash),
     .scanmode_i(1'b0),
     .scan_reset_ni(1'b1)
   );
@@ -276,6 +276,8 @@ module top_earlgrey_asic (
     .ast_tl_rsp_i                 ( ast_base_bus               ),
     .otp_ctrl_otp_ast_pwr_seq_o   ( otp_ctrl_otp_ast_pwr_seq   ),
     .otp_ctrl_otp_ast_pwr_seq_h_i ( otp_ctrl_otp_ast_pwr_seq_h ),
+    .flash_power_down_h_i         ( ast_base_eflash.flash_power_down_h  ),
+    .flash_power_ready_h_i        ( ast_base_eflash.flash_power_ready_h ),
 
     // JTAG
     .jtag_tck_i      ( jtag_tck      ),

--- a/hw/top_earlgrey/rtl/top_earlgrey_cw305.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_cw305.sv
@@ -265,6 +265,8 @@ module top_earlgrey_cw305 #(
     .ast_tl_rsp_i                 ( '0              ),
     .otp_ctrl_otp_ast_pwr_seq_o   (                 ),
     .otp_ctrl_otp_ast_pwr_seq_h_i ( '0              ),
+    .flash_power_down_h_i         ( '0              ),
+    .flash_power_ready_h_i        ( 1'b1            ),
 
     // JTAG
     .jtag_tck_i      ( jtag_tck_buf  ),

--- a/hw/top_earlgrey/rtl/top_earlgrey_nexysvideo.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_nexysvideo.sv
@@ -330,6 +330,8 @@ module top_earlgrey_nexysvideo #(
     .ast_tl_rsp_i                 ( '0              ),
     .otp_ctrl_otp_ast_pwr_seq_o   (                 ),
     .otp_ctrl_otp_ast_pwr_seq_h_i ( '0              ),
+    .flash_power_down_h_i         ( '0              ),
+    .flash_power_ready_h_i        ( 1'b1            ),
 
     // JTAG
     .jtag_tck_i      ( jtag_tck_buf  ),

--- a/hw/top_earlgrey/rtl/top_earlgrey_verilator.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_verilator.sv
@@ -112,6 +112,8 @@ module top_earlgrey_verilator (
     .ast_tl_rsp_i                 ( '0              ),
     .otp_ctrl_otp_ast_pwr_seq_o   (                 ),
     .otp_ctrl_otp_ast_pwr_seq_h_i ( '0              ),
+    .flash_power_down_h_i         ( '0              ),
+    .flash_power_ready_h_i        ( 1'b1            ),
 
     .jtag_tck_i                 (cio_jtag_tck),
     .jtag_tms_i                 (cio_jtag_tms),

--- a/hw/top_earlgrey/top_earlgrey_verilator.cc
+++ b/hw/top_earlgrey/top_earlgrey_verilator.cc
@@ -25,8 +25,9 @@ int main(int argc, char **argv) {
       "gen_generic.u_impl_generic");
   memutil.RegisterMemoryArea(
       "flash",
-      ("TOP.top_earlgrey_verilator.top_earlgrey.u_flash_eflash."
-       "gen_flash_banks[0].i_core.i_flash.gen_generic.u_impl_generic.u_mem.gen_"
+      ("TOP.top_earlgrey_verilator.top_earlgrey.u_flash_eflash.u_flash."
+       "gen_generic.u_impl_generic.gen_prim_flash_banks[0].u_prim_flash_bank.u_"
+       "mem.gen_"
        "generic.u_impl_generic"),
       64, nullptr);
   simctrl.RegisterExtension(&memutil);


### PR DESCRIPTION
Merge the two separate prim_flash into one. 
This simplifies vendor integration and allows them to use one test interface to drive both functions. 

Also complete the ast - flash integration. 