### PR TITLE
[rv_dm/top] Add JTAG interface structs

### DIFF
--- a/hw/ip/rv_dm/rtl/rv_dm.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm.sv
@@ -12,34 +12,32 @@
 
 `include "prim_assert.sv"
 
-module rv_dm #(
-  parameter int                 NrHarts = 1,
-  parameter logic [31:0]        IdcodeValue = 32'h 0000_0001
+module rv_dm
+  import rv_dm_pkg::*;
+#(
+  parameter int              NrHarts = 1,
+  parameter logic [31:0]     IdcodeValue = 32'h 0000_0001
 ) (
-  input  logic                  clk_i,       // clock
-  input  logic                  rst_ni,      // asynchronous reset active low, connect PoR
-                                             // here, not the system reset
-  input  logic                  testmode_i,
-  output logic                  ndmreset_o,  // non-debug module reset
-  output logic                  dmactive_o,  // debug module is active
-  output logic [NrHarts-1:0]    debug_req_o, // async debug request
-  input  logic [NrHarts-1:0]    unavailable_i, // communicate whether the hart is unavailable
-                                               // (e.g.: power down)
+  input  logic               clk_i,       // clock
+  input  logic               rst_ni,      // asynchronous reset active low, connect PoR
+                                          // here, not the system reset
+  input  logic               testmode_i,
+  output logic               ndmreset_o,  // non-debug module reset
+  output logic               dmactive_o,  // debug module is active
+  output logic [NrHarts-1:0] debug_req_o, // async debug request
+  input  logic [NrHarts-1:0] unavailable_i, // communicate whether the hart is unavailable
+                                            // (e.g.: power down)
 
   // bus device with debug memory, for an execution based technique
-  input  tlul_pkg::tl_h2d_t tl_d_i,
-  output tlul_pkg::tl_d2h_t tl_d_o,
+  input  tlul_pkg::tl_h2d_t  tl_d_i,
+  output tlul_pkg::tl_d2h_t  tl_d_o,
 
   // bus host, for system bus accesses
   output tlul_pkg::tl_h2d_t  tl_h_o,
   input  tlul_pkg::tl_d2h_t  tl_h_i,
 
-  input  logic               tck_i,           // JTAG test clock pad
-  input  logic               tms_i,           // JTAG test mode select pad
-  input  logic               trst_ni,         // JTAG test reset pad
-  input  logic               td_i,            // JTAG test data input pad
-  output logic               td_o,            // JTAG test data output pad
-  output logic               tdo_oe_o         // Data out output enable
+  input  jtag_req_t          jtag_req_i,
+  output jtag_rsp_t          jtag_rsp_o
 );
 
   `ASSERT_INIT(paramCheckNrHarts, NrHarts > 0)
@@ -293,12 +291,12 @@ module rv_dm #(
     .dmi_resp_valid_i (dmi_rsp_valid),
 
     //JTAG
-    .tck_i,
-    .tms_i,
-    .trst_ni,
-    .td_i,
-    .td_o,
-    .tdo_oe_o
+    .tck_i            (jtag_req_i.tck),
+    .tms_i            (jtag_req_i.tms),
+    .trst_ni          (jtag_req_i.trst_n),
+    .td_i             (jtag_req_i.tdi),
+    .td_o             (jtag_rsp_o.tdo),
+    .tdo_oe_o         (jtag_rsp_o.tdo_oe)
   );
 `endif
 

--- a/hw/ip/rv_dm/rtl/rv_dm_pkg.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm_pkg.sv
@@ -1,0 +1,24 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package rv_dm_pkg;
+
+  typedef struct packed {
+    logic tck;
+    logic tms;
+    logic trst_n;
+    logic tdi;
+  } jtag_req_t;
+
+  parameter jtag_req_t JTAG_REQ_DEFAULT = '0;
+
+  typedef struct packed {
+    logic tdo;
+    logic tdo_oe;
+  } jtag_rsp_t;
+
+  parameter jtag_rsp_t JTAG_RSP_DEFAULT = '0;
+
+endpackage : rv_dm_pkg

--- a/hw/ip/rv_dm/rv_dm.core
+++ b/hw/ip/rv_dm/rv_dm.core
@@ -13,6 +13,7 @@ filesets:
       - lowrisc:tlul:adapter_host
       - pulp-platform:riscv-dbg:0.1
     files:
+      - rtl/rv_dm_pkg.sv
       - rtl/rv_dm.sv
     file_type: systemVerilogSource
 

--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -252,6 +252,19 @@ module top_${top["name"]} #(
   // Debug Module (RISC-V Debug Spec 0.13)
   //
 
+  // TODO: this will be routed to the pinmux for TAP selection
+  // based on straps and LC control signals.
+  rv_dm_pkg::jtag_req_t jtag_req;
+  rv_dm_pkg::jtag_rsp_t jtag_rsp;
+  logic unused_jtag_tdo_oe_o;
+
+  assign jtag_req.tck    = jtag_tck_i;
+  assign jtag_req.tms    = jtag_tms_i;
+  assign jtag_req.trst_n = jtag_trst_ni;
+  assign jtag_req.tdi    = jtag_tdi_i;
+  assign jtag_tdo_o      = jtag_rsp.tdo;
+  assign unused_jtag_tdo_oe_o = jtag_rsp.tdo_oe;
+
   rv_dm #(
     .NrHarts     (1),
     .IdcodeValue (JTAG_IDCODE)
@@ -273,12 +286,8 @@ module top_${top["name"]} #(
     .tl_h_i        (main_tl_dm_sba_rsp),
 
     //JTAG
-    .tck_i            (jtag_tck_i),
-    .tms_i            (jtag_tms_i),
-    .trst_ni          (jtag_trst_ni),
-    .td_i             (jtag_tdi_i),
-    .td_o             (jtag_tdo_o),
-    .tdo_oe_o         (       )
+    .jtag_req_i    (jtag_req),
+    .jtag_rsp_o    (jtag_rsp)
   );
 
   assign rstmgr_cpu.ndmreset_req = ndmreset_req;

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -400,6 +400,19 @@ module top_earlgrey #(
   // Debug Module (RISC-V Debug Spec 0.13)
   //
 
+  // TODO: this will be routed to the pinmux for TAP selection
+  // based on straps and LC control signals.
+  rv_dm_pkg::jtag_req_t jtag_req;
+  rv_dm_pkg::jtag_rsp_t jtag_rsp;
+  logic unused_jtag_tdo_oe_o;
+
+  assign jtag_req.tck    = jtag_tck_i;
+  assign jtag_req.tms    = jtag_tms_i;
+  assign jtag_req.trst_n = jtag_trst_ni;
+  assign jtag_req.tdi    = jtag_tdi_i;
+  assign jtag_tdo_o      = jtag_rsp.tdo;
+  assign unused_jtag_tdo_oe_o = jtag_rsp.tdo_oe;
+
   rv_dm #(
     .NrHarts     (1),
     .IdcodeValue (JTAG_IDCODE)
@@ -421,12 +434,8 @@ module top_earlgrey #(
     .tl_h_i        (main_tl_dm_sba_rsp),
 
     //JTAG
-    .tck_i            (jtag_tck_i),
-    .tms_i            (jtag_tms_i),
-    .trst_ni          (jtag_trst_ni),
-    .td_i             (jtag_tdi_i),
-    .td_o             (jtag_tdo_o),
-    .tdo_oe_o         (       )
+    .jtag_req_i    (jtag_req),
+    .jtag_rsp_o    (jtag_rsp)
   );
 
   assign rstmgr_cpu.ndmreset_req = ndmreset_req;


### PR DESCRIPTION
This basically just adds struct types for the JTAG signals and is a preparatory step to make adding multiple JTAG ports to the pinmux a bit more convenient later on using the intermodule feature from topgen (we will have 3-4 TAPs in our system). 

Signed-off-by: Michael Schaffner <msf@opentitan.org>