### PR TITLE
[otbn] Fix size check in operand.py

### DIFF
--- a/hw/ip/otbn/util/shared/operand.py
+++ b/hw/ip/otbn/util/shared/operand.py
@@ -335,7 +335,7 @@ class ImmOperandType(OperandType):
         assert rng is not None
         lo, hi = rng
 
-        if not (lo <= shifted <= hi):
+        if not (lo <= offset_val <= hi):
             shifted_msg = (', which shifts down to {}'.format(shifted)
                            if self.shift != 0 else '')
             raise ValueError('Cannot encode the value {}{} as a {}-bit '


### PR DESCRIPTION
The lo/hi range is for the value of the operand before it gets shifted
down, so should be compared with `offset_val`, rather than the shifted
value (called "`shifted`").

Getting this wrong meant we crashed into an assertion a few lines
later: hooray for belt-and-braces programming!
