### PR TITLE
[otbn] Simplify bn.wsrrs/bn.wsrrw to just bn.wsrr/bn.wsrw

### DIFF
--- a/hw/ip/otbn/data/bignum-insns.yml
+++ b/hw/ip/otbn/data/bignum-insns.yml
@@ -962,30 +962,49 @@
       spp: grs_inc
       dpp: grd_inc
 
-- mnemonic: bn.wsrrs
-  synopsis: Atomic Read and Set Bits in WSR
-  operands: [wrd, wsr, wrs]
+- mnemonic: bn.wsrr
+  synopsis: Read WSR to register
+  operands:
+    - name: wrd
+      doc: Destination WDR
+    - name: wsr
+      doc: The WSR to read
+  doc: |
+    Reads a WSR to a WDR.
+    If `wsr` isn't the index of a valid WSR, this halts with an error (TODO: Specify error code).
+  operation: |
+    WDR[wrd] = WSR[wsr]
   encoding:
     scheme: wcsr
     mapping:
       write: b0
       wcsr: wsr
-      wrs: wrs
+      wrs: bxxxxx
       wrd: wrd
   lsu:
-    type: wsr
+    type: wsr-load
     target: [wsr]
 
-- mnemonic: bn.wsrrw
-  synopsis: Atomic Read/Write WSR
-  operands: [wrd, wsr, wrs]
+- mnemonic: bn.wsrw
+  synopsis: Write WSR from register
+  operands: [wsr, wrs]
+  operands:
+    - name: wsr
+      doc: The WSR to read
+    - name: wrs
+      doc: Source WDR
+  doc: |
+    Writes a WDR to a WSR.
+    If `wsr` isn't the index of a valid WSR, this halts with an error (TODO: Specify error code).
+  operation: |
+    WSR[wsr] = WDR[wrs]
   encoding:
     scheme: wcsr
     mapping:
       write: b1
       wcsr: wsr
       wrs: wrs
-      wrd: wrd
+      wrd: bxxxxx
   lsu:
-    type: wsr
+    type: wsr-store
     target: [wsr]

--- a/hw/ip/otbn/data/insns.yml
+++ b/hw/ip/otbn/data/insns.yml
@@ -148,7 +148,7 @@ encoding-schemes: enc-schemes.yml
 # If specified, the lsu field for an instruction should be a dictionary with
 # the following fields:
 #
-#  type:    A string. "mem-load", "mem-store", "csr" or "wsr"
+#  type:    A string. "mem-load", "mem-store", "wsr-load", "wsr-store" or "csr"
 #
 #  target:  A string or list of strings, which should be operand names. If a
 #           single string, this means that the named operand contains the

--- a/hw/ip/otbn/dv/otbnsim/sim/insn.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/insn.py
@@ -865,39 +865,30 @@ class BNMOVR(OTBNInsn):
             state.gprs.get_reg(self.grs).write_unsigned(new_grs_val)
 
 
-class BNWSRRS(OTBNInsn):
-    insn = insn_for_mnemonic('bn.wsrrs', 3)
+class BNWSRR(OTBNInsn):
+    insn = insn_for_mnemonic('bn.wsrr', 2)
 
     def __init__(self, op_vals: Dict[str, int]):
         super().__init__(op_vals)
         self.wrd = op_vals['wrd']
         self.wsr = op_vals['wsr']
-        self.wrs = op_vals['wrs']
 
     def execute(self, state: OTBNState) -> None:
-        old_val = state.wsrs.read_at_idx(self.wsr)
-        bits_to_set = state.wdrs.get_reg(self.wrs).read_unsigned()
-        new_val = old_val | bits_to_set
-
-        state.wdrs.get_reg(self.wrd).write_unsigned(old_val)
-        state.wsrs.write_at_idx(self.wsr, new_val)
+        val = state.wsrs.read_at_idx(self.wsr)
+        state.wdrs.get_reg(self.wrd).write_unsigned(val)
 
 
-class BNWSRRW(OTBNInsn):
-    insn = insn_for_mnemonic('bn.wsrrw', 3)
+class BNWSRW(OTBNInsn):
+    insn = insn_for_mnemonic('bn.wsrw', 2)
 
     def __init__(self, op_vals: Dict[str, int]):
         super().__init__(op_vals)
-        self.wrd = op_vals['wrd']
         self.wsr = op_vals['wsr']
         self.wrs = op_vals['wrs']
 
     def execute(self, state: OTBNState) -> None:
-        old_val = state.wsrs.read_at_idx(self.wsr)
-        new_val = state.wdrs.get_reg(self.wrs).read_unsigned()
-
-        state.wdrs.get_reg(self.wrd).write_unsigned(old_val)
-        state.wsrs.write_at_idx(self.wsr, new_val)
+        val = state.wdrs.get_reg(self.wrs).read_unsigned()
+        state.wsrs.write_at_idx(self.wsr, val)
 
 
 INSN_CLASSES = [
@@ -918,5 +909,5 @@ INSN_CLASSES = [
     BNCMP, BNCMPB,
     BNLID, BNSID,
     BNMOV, BNMOVR,
-    BNWSRRS, BNWSRRW
+    BNWSRR, BNWSRW
 ]

--- a/hw/ip/otbn/dv/smoke/smoke_test.s
+++ b/hw/ip/otbn/dv/smoke/smoke_test.s
@@ -124,11 +124,11 @@ csrrs x23, 0x7d5, x0
 # can cascade into later instructions.
 
 # w1 = mod = 0x78fccc06_2228e9d6_89c9b54f_887cf14e_c79af825_69be586e_9866bb3b_53769ada
-bn.wsrrs w1, 0, w0
+bn.wsrr w1, 0
 
 # rnd WSR gives fixed value for now
 # w2 = rnd = 0x99999999_99999999_99999999_99999999_99999999_99999999_99999999_99999999
-bn.wsrrs w2, 1, w0
+bn.wsrr w2, 1
 
 # w3 = w1 + w2 = 0x1296659f_bbc28370_23634ee9_22168ae8_613491bf_0357f208_320054d4_ed103473
 bn.add w3, w1, w2
@@ -152,7 +152,7 @@ bn.not w8, w1
 bn.rshi w9, w1, w2 >> 117
 
 # mod = w4 = 0xdf63326c_888f503c_f0301bb5_eee357b5_2e015e8b_d024bed4_fecd21a1_b9dd0141
-bn.wsrrw w0, 0, w4
+bn.wsrw 0, w4
 
 # w0 = 0
 bn.xor w0, w0, w0
@@ -230,7 +230,7 @@ bn.cmpb w4, w3
 bn.sel w28, w7, w8, FG0.L
 
 # acc = w26 = 0x78fccc06_2228e9d6_89c9b54f_887cf1df_df9bf9bd_f9bfd9ff_99ffbbbb_dbff9bdb
-bn.wsrrw w0, 2, w26
+bn.wsrw 2, w26
 
 # {w30, w29} = (w28 * w27 + acc) =
 # 0x15a7cbef_a5f473e1_860c1110_6bcc33ed_1583aef1_8130f3df_1a806984_c4f3507e
@@ -259,7 +259,7 @@ bn.mulqacc         w27.1, w28.0, 64
 bn.mulqacc.wo w31, w27.1, w28.1, 128
 
 # w0 = acc = 0x2f97be14_a0c429f2_53b42730_953d7d2f_0873f36c_1a01de4e_17fe23d9_0f09b7c8
-bn.wsrrs w0, 2, w0
+bn.wsrr w0, 2
 
 # Nested loop testing, inner adds repeated a total of 3 * 5 = 15 times
 # x28 = 4, x29 = 3

--- a/hw/ip/otbn/dv/tracer/rtl/otbn_trace_intf.sv
+++ b/hw/ip/otbn/dv/tracer/rtl/otbn_trace_intf.sv
@@ -163,7 +163,7 @@ interface otbn_trace_intf #(
 
   logic any_ispr_read;
 
-  assign any_ispr_read = (insn_dec_shared.ispr_rw_insn | insn_dec_shared.ispr_rs_insn) & insn_fetch_resp_valid;
+  assign any_ispr_read = (insn_dec_shared.ispr_rd_insn | insn_dec_shared.ispr_rs_insn) & insn_fetch_resp_valid;
 
   assign ispr_write[IsprMod] = |u_otbn_alu_bignum.mod_wr_en;
 
@@ -182,7 +182,10 @@ interface otbn_trace_intf #(
   assign ispr_write_data[IsprAcc] = u_otbn_mac_bignum.acc_d;
 
   assign ispr_read[IsprAcc] = (any_ispr_read & (ispr_addr == IsprAcc)) | mac_bignum_en;
-  assign ispr_read_data[IsprAcc] = u_otbn_mac_bignum.acc;
+  // For ISPR reads look at the ACC flops directly. For other ACC reads look at the `acc` signal in
+  // order to read ACC as 0 for the BN.MULQACC.Z instruction variant.
+  assign ispr_read_data[IsprAcc] = (any_ispr_read & (ispr_addr == IsprAcc)) ? u_otbn_mac_bignum.acc_q :
+                                                                              u_otbn_mac_bignum.acc;
 
   assign ispr_write[IsprRnd] = 1'b0;
   assign ispr_write_data[IsprRnd] = '0;

--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -516,6 +516,13 @@ module otbn_controller
     endcase
   end
 
+  // ISPR RS (read and set) must not be combined with ISPR RD or WR (read or write). ISPR RD and
+  // WR (read and write) is allowed.
+  `ASSERT(NoIsprRorWAndRs, insn_valid_i |-> ~(insn_dec_shared_i.ispr_rs_insn   &
+                                              (insn_dec_shared_i.ispr_rd_insn |
+                                               insn_dec_shared_i.ispr_wr_insn)))
+
+
   assign wsr_addr = wsr_e'(insn_dec_bignum_i.i[WsrNumWidth-1:0]);
 
   always_comb begin
@@ -531,7 +538,7 @@ module otbn_controller
 
   assign wsr_wdata = insn_dec_shared_i.ispr_rs_insn ? ispr_rdata_i | rf_bignum_rd_data_a_i : rf_bignum_rd_data_a_i;
 
-  assign ispr_wr_insn = insn_dec_shared_i.ispr_rw_insn | insn_dec_shared_i.ispr_rs_insn;
+  assign ispr_wr_insn = insn_dec_shared_i.ispr_wr_insn | insn_dec_shared_i.ispr_rs_insn;
 
   assign ispr_addr_o         = insn_dec_shared_i.subset == InsnSubsetBase ? ispr_addr_base : ispr_addr_bignum;
   assign ispr_base_wdata_o   = csr_wdata;
@@ -563,5 +570,9 @@ module otbn_controller
   // TODO: Implement error handling
   logic [1:0] unused_lsu_rdata_err;
   assign unused_lsu_rdata_err = lsu_rdata_err_i;
+
+  // Unused for now, may be used in later security hardening work
+  logic unused_ispr_rd_insn;
+  assign unused_ispr_rd_insn = insn_dec_shared_i.ispr_rd_insn;
 
 endmodule

--- a/hw/ip/otbn/rtl/otbn_decoder.sv
+++ b/hw/ip/otbn/rtl/otbn_decoder.sv
@@ -167,7 +167,8 @@ module otbn_decoder
   logic branch_insn;
   logic jump_insn;
   logic loop_insn;
-  logic ispr_rw_insn;
+  logic ispr_rd_insn;
+  logic ispr_wr_insn;
   logic ispr_rs_insn;
 
   // Reduced main ALU immediate MUX for Operand B
@@ -255,7 +256,8 @@ module otbn_decoder
     branch_insn:   branch_insn,
     jump_insn:     jump_insn,
     loop_insn:     loop_insn,
-    ispr_rw_insn:  ispr_rw_insn,
+    ispr_rd_insn:  ispr_rd_insn,
+    ispr_wr_insn:  ispr_wr_insn,
     ispr_rs_insn:  ispr_rs_insn
   };
 
@@ -294,7 +296,8 @@ module otbn_decoder
     branch_insn            = 1'b0;
     jump_insn              = 1'b0;
     loop_insn              = 1'b0;
-    ispr_rw_insn           = 1'b0;
+    ispr_rd_insn           = 1'b0;
+    ispr_wr_insn           = 1'b0;
     ispr_rs_insn           = 1'b0;
 
     opcode                 = insn_opcode_e'(insn[6:0]);
@@ -457,7 +460,8 @@ module otbn_decoder
           rf_ren_a_base     = 1'b1;
 
           if (insn[14:12] == 3'b001) begin
-            ispr_rw_insn = 1'b1;
+            ispr_rd_insn = 1'b1;
+            ispr_wr_insn = 1'b1;
           end else if(insn[14:12] == 3'b010) begin
             ispr_rs_insn = 1'b1;
           end else begin
@@ -607,15 +611,14 @@ module otbn_decoder
               end
             end
           end
-          3'b111: begin //BN.WSRRS/BN.WSRRW
-            rf_we_bignum        = 1'b1;
-            rf_ren_a_bignum     = 1'b1;
-            rf_wdata_sel_bignum = RfWdSelIspr;
-
-            if (insn[31]) begin
-              ispr_rw_insn = 1'b1;
-            end else begin
-              ispr_rs_insn = 1'b1;
+          3'b111: begin
+            if (insn[31]) begin // BN.WSRW
+              rf_ren_a_bignum = 1'b1;
+              ispr_wr_insn    = 1'b1;
+            end else begin // BN.WSRR
+              rf_we_bignum        = 1'b1;
+              rf_wdata_sel_bignum = RfWdSelIspr;
+              ispr_rd_insn        = 1'b1;
             end
           end
           default: illegal_insn = 1'b1;

--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -232,7 +232,8 @@ package otbn_pkg;
     logic           branch_insn;
     logic           jump_insn;
     logic           loop_insn;
-    logic           ispr_rw_insn;
+    logic           ispr_rd_insn;
+    logic           ispr_wr_insn;
     logic           ispr_rs_insn;
   } insn_dec_shared_t;
 

--- a/hw/ip/otbn/util/rig/gens/straight_line_insn.py
+++ b/hw/ip/otbn/util/rig/gens/straight_line_insn.py
@@ -265,7 +265,8 @@ class StraightLineInsn(SnippetGen):
             'mem-load': ('dmem', True),
             'mem-store': ('dmem', False),
             'csr': ('csr', True),
-            'wsr': ('wsr', True)
+            'wsr-load': ('wsr', True),
+            'wsr-store': ('wsr', False)
         }
         assert set(lsu_type_to_info.keys()) == set(LSUDesc.TYPES)
         mem_type, loads_value = lsu_type_to_info[insn.lsu.lsu_type]

--- a/hw/ip/otbn/util/shared/lsu_desc.py
+++ b/hw/ip/otbn/util/shared/lsu_desc.py
@@ -16,7 +16,7 @@ class LSUDesc:
 
     '''
 
-    TYPES = ['mem-load', 'mem-store', 'csr', 'wsr']
+    TYPES = ['mem-load', 'mem-store', 'csr', 'wsr-load', 'wsr-store']
 
     def __init__(self,
                  lsu_type: str,

--- a/sw/otbn/code-snippets/p256.s
+++ b/sw/otbn/code-snippets/p256.s
@@ -22,8 +22,7 @@ SetupP256PandMuLow:
   sw x2, 540(x0)
   addi x2, x0, 29
   bn.lid x2, 512(x0)
-  bn.wsrrw w31, 0, w29
-  bn.xor w31, w31, w31
+  bn.wsrw 0, w29
   sw x0, 548(x0)
   sw x0, 572(x0)
   addi x2, x0, -1
@@ -379,7 +378,7 @@ ProjToAffine:
   jalr x0, x1, 0
 
 ModInv:
-  bn.wsrrs w2, 0, w31
+  bn.wsrr w2, 0
   bn.subi w2, w2, 2
   bn.mov w1, w30
   loopi 256, 14
@@ -401,7 +400,7 @@ ModInv:
   jalr x0, x1, 0
 
 FetchBandRandomize:
-  bn.wsrrs w2, 1, w31
+  bn.wsrr w2, 1
   bn.addm w26, w2, w31
   bn.lid x10, 0(x21)
   bn.mov w25, w26
@@ -441,8 +440,7 @@ SetupP256NandMuLow:
   sw x2, 620(x0)
   addi x2, x0, 29
   bn.lid x2, 608(x0)
-  bn.wsrrw w31, 0, w29
-  bn.xor w31, w31, w31
+  bn.wsrw 0, w29
   addi x2, x0, 0
   sw x2, 668(x0)
   addi x2, x0, -1
@@ -500,10 +498,10 @@ ScalarMult_internal:
   bn.sel w10, w13, w7, M
   bn.rshi w0, w0, w0 >> 255
   bn.rshi w1, w1, w1 >> 255
-  bn.wsrrs w11, 1, w31
-  bn.wsrrs w12, 1, w31
-  bn.wsrrs w13, 1, w31
-  bn.wsrrs w2, 1, w31
+  bn.wsrr w11, 1
+  bn.wsrr w12, 1
+  bn.wsrr w13, 1
+  bn.wsrr w2, 1
   bn.mov w24, w3
   bn.mov w25, w2
   jal x1, MulMod
@@ -654,8 +652,8 @@ p256scalarbasemult:
 ModInvVar:
   bn.mov w2, w31
   bn.mov w3, w30
-  bn.wsrrs w4, 0, w31
-  bn.wsrrs w7, 0, w31
+  bn.wsrr w4, 0
+  bn.wsrr w7, 0
   bn.mov w5, w0
 
 impvt_Loop:


### PR DESCRIPTION
~~**PARTIAL: This will definitely fail CI, since the smoke test and RTL don't match yet. I've pushed it up as a draft PR to make it easy for people to comment.**~~ (Edit: RTL is now done)

We've decided that our wide side doesn't need the full "bit set" and
"bit clear" functionality that RV32I defines (csrrs/csrrw) and we
initially copied across.

Instead, we're going to use simpler instructions, which are
essentially "read WSR" and "write WSR".

This commit updates the documentation and ISS accordingly: the RTL and
smoke test still need updating to match.