### PR TITLE
[build] Write environment configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ jgproject/
 # FPGA splice intermediate files
 *.jou
 
+# Environment configuration (produced by Meson)
+.env
+
 # Simulation Results
 *.log
 vdCovLog/

--- a/meson.build
+++ b/meson.build
@@ -207,3 +207,26 @@ top_earlgrey = declare_dependency(
 )
 
 subdir('sw')
+
+# Write environment file
+prog_meson_write_env = meson.source_root() / 'util/meson_write_env.py'
+r = run_command(
+  prog_python,
+  prog_meson_write_env,
+
+  '--out-file',
+  meson.current_build_dir() / '.env',
+
+  'PYTHON=@0@'.format(prog_python.path()),
+  'OTBN_AS=@0@'.format(prog_otbn_as),
+  'OTBN_LD=@0@'.format(prog_otbn_ld),
+  'RV32_TOOL_OBJCOPY=@0@'.format(prog_objcopy.path()),
+  'RV32_TOOL_AS=@0@'.format(prog_as.path()),
+  'RV32_TOOL_LD=@0@'.format(prog_ld.path()),
+  'RV32_TOOL_OBJDUMP=@0@'.format(prog_objdump.path()),
+  'RV32_TOOL_OBJCOPY=@0@'.format(prog_objcopy.path()),
+)
+assert(r.returncode() == 0, 'Error while calling meson_write_env.py.\n' +
+  'STDOUT:\n' + r.stdout().strip() + '\n' +
+  'STDERR:\n ' + r.stderr().strip())
+message(r.stdout().strip())

--- a/meson.build
+++ b/meson.build
@@ -155,12 +155,16 @@ add_project_arguments(
 
 # Common program references.
 prog_python = import('python').find_installation('python3')
+prog_env = find_program('env')
+prog_srec_cat = find_program('srec_cat')
+
 prog_ld = find_program('ld')
 prog_as = find_program('as')
 prog_objdump = find_program('objdump')
 prog_objcopy = find_program('objcopy')
-prog_srec_cat = find_program('srec_cat')
-prog_git = find_program('git')
+
+prog_otbn_as = meson.source_root() / 'hw/ip/otbn/util/otbn-as'
+prog_otbn_ld = meson.source_root() / 'hw/ip/otbn/util/otbn-ld'
 
 # Hardware register headers. These are generated from HJSON files, and accesible
 # in C via |#include "{IP_NAME}_regs.h"|.

--- a/sw/otbn/meson.build
+++ b/sw/otbn/meson.build
@@ -40,10 +40,6 @@ sw_otbn_sources = {}
 # dictionary.
 subdir('code-snippets')
 
-prog_otbn_as = meson.source_root() / 'hw/ip/otbn/util/otbn-as'
-prog_otbn_ld = meson.source_root() / 'hw/ip/otbn/util/otbn-ld'
-
-prog_env = find_program('env')
 prog_otbn_build = meson.source_root() / 'util/otbn_build.py'
 
 otbn_build_command = [

--- a/util/meson_write_env.py
+++ b/util/meson_write_env.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+r"""A helper used by Meson to write an environment file
+
+The environment file follows Docker's `.env` file structure with key=value
+pairs. See https://docs.docker.com/compose/env-file/#syntax-rules for details.
+"""
+
+import argparse
+import sys
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('--out-file',
+                        '-o',
+                        required=False,
+                        type=argparse.FileType('w'),
+                        default="env.txt",
+                        help="Output file (default: %(default)s)")
+    parser.add_argument('key_value_pairs',
+                        nargs='+',
+                        type=str,
+                        metavar='NAME=VALUE')
+    args = parser.parse_args()
+
+    for arg in args.key_value_pairs:
+        print(arg, file=args.out_file)
+
+    print("Wrote environment configuration to {!r}.".format(args.out_file.name))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
As part of Meson's configuration process initiated by `meson_init.sh` write
a file `.env` into the source directory (REPOTOP) containing environment
information as it is detected and used by Meson to build software. This
file can be used by other tools which build software to ensure that they
use the same tools as used by software built through Meson.

The `.env` file is a simple KEY=VALUE format.

Signed-off-by: Philipp Wagner <phw@lowrisc.org>