### PR TITLE
[sw, dif_uart] DIF_HW_USAGE_REVIEWED complete

### DIFF
--- a/sw/device/lib/dif/dif_uart.md
+++ b/sw/device/lib/dif/dif_uart.md
@@ -26,7 +26,7 @@ Tests          | [DIF_TEST_SMOKE][]   | Done        |
 Type           | Item                        | Resolution  | Note/Collaterals
 ---------------|-----------------------------|-------------|------------------
 Implementation | [DIF_FEATURES][]            | Not Started |
-Coordination   | [DIF_HW_USAGE_REVIEWED][]   | Not Started |
+Coordination   | [DIF_HW_USAGE_REVIEWED][]   | Done        |
 Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Not Started | [HW Dashboard]({{< relref "hw" >}})
 Implementation | [DIF_HW_PARAMS][]           | Not Started |
 Documentation  | [DIF_DOC_HW][]              | Not Started |
@@ -34,7 +34,7 @@ Documentation  | [DIF_DOC_API][]             | Not Started |
 Code Quality   | [DIF_CODE_STYLE][]          | Not Started |
 Coordination   | [DIF_DV_TESTS][]            | Not Started |
 Implementation | [DIF_USED_TOCK][]           | Not Started |
-Review         | HW IP Usage Reviewer(s)     | Not Started |
+Review         | HW IP Usage Reviewer(s)     | Not Started | @eunchan
 
 [DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
 [DIF_HW_USAGE_REVIEWED]:   {{< relref "/doc/project/checklist.md#dif_hw_usage_reviewed" >}}


### PR DESCRIPTION
As part of the DIF S2 signoff, we ensure that the peripheral is being used correctly by the DIF. This review happened with Eunchan Kim, Silvestrs Timofejevs, Sam Elliott and Garret Kelly.

We have identified the following TODOs:

- [x] uart.TIMEOUT_CTRL is required (uart.OVRD and uart.VAL is not required). For some background, please see:
https://github.com/lowRISC/opentitan/issues/2292

- [x] Should document the RX and TX FIFO reset semantics. Specifically that if a byte is in transit, the RX, TX FIFO reset will not cancel the operation (#4728). For some background please see:
https://github.com/lowRISC/opentitan/issues/2812

- FIFO size is hardcoded in the DIF, but it is fine as it is not expected to change (even with different parameterisation).

- Semantics of send and receive byte functions were deemed good.

- Static assert in the code should not be a problem, as it is unlikely that it would ever exceed 28 bits (requires very high clock frequency).

- [x] Bitwise operators where applicable should be changed to use the `bitfield` library (#4728).

- [x] RX and TX FIFO reset is duplicated in the reset and configuration functions. The consensus is to keep it in the reset function, but remove from the configure function (#4728).

- [x] ~~RX and TX FIFO reset functions must write `1' and then `0`. Should add `0` write following the `1` write in the reset function and FIFO reset API functions (#4728).~~ 