### PR TITLE
[dv/alert] add_alert_config_check

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
@@ -38,18 +38,73 @@ class cip_base_env_cfg #(type RAL_T = dv_base_reg_block) extends dv_base_env_cfg
     // host can't support device same cycle response and host may drive d_ready=0 when a_valid=1
     m_tl_agent_cfg.host_can_stall_rsp_when_a_valid_high = $urandom_range(0, 1);
 
-    // create alert_esc_agent_cfg if the module has alerts
-    foreach(list_of_alerts[i]) begin
-      string alert_name = list_of_alerts[i];
-      m_alert_agent_cfg[alert_name] = alert_esc_agent_cfg::type_id::create("m_alert_agent_cfg");
-      m_alert_agent_cfg[alert_name].if_mode = dv_utils_pkg::Device;
-      m_alert_agent_cfg[alert_name].is_async = 1; // default async_on, can override this
-      m_alert_agent_cfg[alert_name].en_ping_cov = 0;
-      if (zero_delays) begin
-        m_alert_agent_cfg[alert_name].alert_delay_min = 0;
-        m_alert_agent_cfg[alert_name].alert_delay_max = 0;
+    if (list_of_alerts.size() > 0) begin
+      check_alert_configs();
+
+      foreach(list_of_alerts[i]) begin
+        string alert_name = list_of_alerts[i];
+
+        // create alert_esc_agent_cfg if the module has alerts
+        m_alert_agent_cfg[alert_name] = alert_esc_agent_cfg::type_id::create("m_alert_agent_cfg");
+        m_alert_agent_cfg[alert_name].if_mode = dv_utils_pkg::Device;
+        m_alert_agent_cfg[alert_name].is_async = 1; // default async_on, can override this
+        m_alert_agent_cfg[alert_name].en_ping_cov = 0;
+        if (zero_delays) begin
+          m_alert_agent_cfg[alert_name].alert_delay_min = 0;
+          m_alert_agent_cfg[alert_name].alert_delay_max = 0;
+        end
       end
     end
   endfunction
 
+  virtual function void check_alert_configs();
+    dv_base_reg_block sub_blks[$];
+    ral.get_dv_base_reg_blocks(sub_blks);
+
+    // for top-level, check alert_configs by each sub-block that triggers alerts
+    if (sub_blks.size() > 0) begin
+      foreach(sub_blks[i]) begin
+        // top-level alert name is consist of ${block_name}_${alert_name}
+        // the following logic will take ${alert_name} in each block into a alerts_q and compare
+        // against the block's alert_test field names
+        string alerts_q[$];
+        string blk_name = sub_blks[i].get_name();
+        foreach (list_of_alerts[j]) begin
+          string alert_name = list_of_alerts[j];
+          if (alert_name.substr(0, blk_name.len() - 1) == blk_name) begin
+            alerts_q.push_back(alert_name.substr(blk_name.len() + 1, list_of_alerts[j].len() - 1));
+          end
+        end
+        if (alerts_q.size() > 0) check_alert_configs_by_block(sub_blks[i], alerts_q);
+      end
+    end else begin
+      // for IP level testbench, directly use ral as dv_base_reg_block object
+      string alerts_q[$] = list_of_alerts;
+      check_alert_configs_by_block(ral, alerts_q);
+    end
+  endfunction
+
+  // this function checks if hardcoded cfg.list_of_alerts array matches the information in
+  // corresponding alert_test register
+  virtual function void check_alert_configs_by_block(dv_base_reg_block blk,
+                                                     const ref string  alert_names[$]);
+    dv_base_reg alert_test_csr;
+    alert_test_csr = blk.get_dv_base_reg_by_name("alert_test");
+
+    // check alert_test csr exists
+    `DV_CHECK_NE_FATAL(alert_test_csr, null,
+                       $sformatf("cannot find alert_test csr in %0s", blk.get_name()))
+
+    // check number of field matches number of alert name in the list
+    `DV_CHECK_EQ(alert_test_csr.get_n_used_bits(), alert_names.size(),
+                 "alert_test field number and list_of_alerts size mismatch")
+
+    // check if alert name matches alert_test field name
+    foreach(alert_names[i]) begin
+      uvm_reg_field alert_test_field = blk.get_field_by_name(alert_names[i]);
+      `DV_CHECK_NE_FATAL(alert_test_field, null, $sformatf("cannot find field %s", alert_names[i]))
+      `DV_CHECK_EQ(alert_test_field.get_lsb_pos(), i,
+                   $sformatf("alert %0s position does not match", alert_names[i]))
+    end
+  endfunction
 endclass


### PR DESCRIPTION
In cip_base_env_cfg, after list_of_alerts is overwrite, this PR adds
checks to ensure list_of_alerts matches the information in alert_test
register

This PR is based on PR #4266 

Signed-off-by: Cindy Chen <chencindy@google.com>