### PR TITLE
[dv/common] Minor improvement for common drivers

### DIFF
--- a/hw/dv/sv/alert_esc_agent/seq_lib/alert_receiver_base_seq.sv
+++ b/hw/dv/sv/alert_esc_agent/seq_lib/alert_receiver_base_seq.sv
@@ -23,6 +23,7 @@ class alert_receiver_base_seq extends dv_base_seq #(
     `DV_CHECK_RANDOMIZE_WITH_FATAL(req,
         r_alert_ping_send == local::r_alert_ping_send;
         r_alert_rsp       == local::r_alert_rsp;
+        int_err           == 0; // TODO: current do not support alert_receiver int_err
     )
     `uvm_info(`gfn, $sformatf("seq_item: ping_send=%0b alert_rsp=%0b int_err=%0b",
                               req.r_alert_ping_send, req.r_alert_rsp, req.int_err), UVM_MEDIUM)

--- a/hw/dv/sv/tl_agent/tl_host_driver.sv
+++ b/hw/dv/sv/tl_agent/tl_host_driver.sv
@@ -25,8 +25,8 @@ class tl_host_driver extends tl_base_driver;
           if (req != null) begin
             send_a_channel_request(req);
           end else begin
-            // avoid zero delay loop and always align with clock edge to send item
-            if (reset_asserted) #1ns;
+            // wait for reset to deassert and always align with clock edge to send item
+            wait(cfg.vif.rst_n === 1'b1);
             `DV_SPINWAIT_EXIT(@(cfg.vif.host_cb);,
                               wait(reset_asserted);)
           end


### PR DESCRIPTION
1. tl_host_driver, the logic here is a little bit inefficient:
```
        forever begin
          seq_item_port.try_next_item(req);
          if (req != null) begin
            send_a_channel_request(req);
          end else begin
            // avoid zero delay loop and always align with clock edge to send item
            if (reset_asserted) #1ns;
            `DV_SPINWAIT_EXIT(@(cfg.vif.host_cb);,
                              wait(reset_asserted);)
          end
        end
```
If under reset, then the else statement basically checks every 1ns until
reset_deasserted. It would be much more efficient if just replace the if
statement with a wait reset done. (Thanks @weicaiyang for the suggestion)

2. alert_receiver_base_seq:
Current alert_receiver driver does not support sig_int_error. So I added
a temp constraint here in base sequence.

Signed-off-by: Cindy Chen <chencindy@google.com>