### PR TITLE
Update lowrisc_misc-linters to lowRISC/misc-linters@c751ca5

### DIFF
--- a/util/lowrisc_misc-linters.lock.hjson
+++ b/util/lowrisc_misc-linters.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/lowRISC/misc-linters.git
-    rev: 5c93cb0fe96c954ed02c4f6e1fdcadc4ce62b1c9
+    rev: c751ca54f7a328be52da91e391c6c5ea04f0f843
   }
 }

--- a/util/lowrisc_misc-linters/licence-checker/licence-checker.py
+++ b/util/lowrisc_misc-linters/licence-checker/licence-checker.py
@@ -136,7 +136,7 @@ COMMENT_CHARS = [
     ([".S"], [SLASH_SLASH, SLASH_STAR]),  # Assembly (With Preprocessing)
     ([".s"], SLASH_STAR),  # Assembly (Without Preprocessing)
     ([".ld", ".ld.tpl"], SLASH_STAR),  # Linker Scripts
-    ([".rs"], SLASH_SLASH),  # Rust
+    ([".rs", ".rs.tpl"], SLASH_SLASH),  # Rust
 
     # Software Build Systems
     (["meson.build", "toolchain.txt", "meson_options.txt"], HASH),  # Meson


### PR DESCRIPTION
Update code from upstream repository https://github.com/lowRISC/misc-
linters.git to revision c751ca54f7a328be52da91e391c6c5ea04f0f843

* [licence-checker] Add Mako-Templated Rust Support (Sam Elliott)

---

Fixes licence checker issue seen in #4148.