### PR TITLE
[dv/otp_ctrl] fix mem_walk uvm_not_ok error

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_common_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_common_vseq.sv
@@ -14,6 +14,8 @@ class otp_ctrl_common_vseq extends otp_ctrl_base_vseq;
     super.dut_init(reset_kind);
     // drive dft_en pins to access the test_access memory
     cfg.lc_dft_en_vif.drive(lc_ctrl_pkg::On);
+    // once turn on lc_dft_en regiser, will need some time to update the state register
+    cfg.clk_rst_vif.wait_clks(2);
   endtask
 
   task post_start();


### PR DESCRIPTION
In test_access mem_walk automation sequence, there are regression errors
saying UVM_STATUS is not okay.

This is because the testbench trying to read/write test_access memory
the same cycle as `lc_dft_en` is set to `ON`. However, the `lc_dft_en`
needs one clock cycle to update the FSM state register.

So the fix here adds some delay after drive `lc_dft_en` pin.

Signed-off-by: Cindy Chen <chencindy@google.com>