### PR TITLE
[topgen] Prepare for new top levels

### DIFF
--- a/util/topgen.py
+++ b/util/topgen.py
@@ -983,8 +983,12 @@ def main():
 
     for ip in generated_list:
         log.info("Appending {}".format(ip))
-        ip_hjson = hjson_dir.parent / "ip/{}/data/autogen/{}.hjson".format(
-            ip, ip)
+        if ip == 'clkmgr':
+            ip_hjson = Path(out_path) / "ip/{}/data/autogen/{}.hjson".format(
+                ip, ip)
+        else:
+            ip_hjson = hjson_dir.parent / "ip/{}/data/autogen/{}.hjson".format(
+                ip, ip)
         ips.append(ip_hjson)
 
     for ip in top_only_list:

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -1024,7 +1024,7 @@ def main():
         log.warning('Commandline override of rnd_cnst_seed with {}.'.format(
             args.rnd_cnst_seed))
         topcfg['rnd_cnst_seed'] = args.rnd_cnst_seed
-    # Otherwise, we either take it from the top_earlgrey.hjson if present, or
+    # Otherwise, we either take it from the top_{topname}.hjson if present, or
     # randomly generate a new seed if not.
     else:
         random.seed()
@@ -1122,20 +1122,20 @@ def main():
         # Header for SV files
         gencmd = warnhdr + '''//
 // util/topgen.py -t hw/top_{topname}/data/top_{topname}.hjson \\
-//                --tpl hw/top_earlgrey/data/ \\
+//                --tpl hw/top_{topname}/data/ \\
 //                -o hw/top_{topname}/ \\
 //                --rnd_cnst_seed {seed}
 '''.format(topname=topname, seed=topcfg['rnd_cnst_seed'])
 
         # SystemVerilog Top:
-        # 'top_earlgrey.sv.tpl' -> 'rtl/autogen/top_earlgrey.sv'
         render_template('top_%s.sv', 'rtl/autogen', gencmd=gencmd)
+        # 'top_{topname}.sv.tpl' -> 'rtl/autogen/top_{topname}.sv'
 
         # The C / SV file needs some complex information, so we initialize this
         # object to store it.
         c_helper = TopGenC(completecfg)
 
-        # 'top_earlgrey_pkg.sv.tpl' -> 'rtl/autogen/top_earlgrey_pkg.sv'
+        # 'top_{topname}_pkg.sv.tpl' -> 'rtl/autogen/top_{topname}_pkg.sv'
         render_template('top_%s_pkg.sv',
                         'rtl/autogen',
                         helper=c_helper,
@@ -1153,7 +1153,7 @@ def main():
         cformat_path = cformat_dir / '.clang-format'
         cformat_path.write_text(cformat_tplpath.read_text())
 
-        # 'top_earlgrey.h.tpl' -> 'sw/autogen/top_earlgrey.h'
+        # 'top_{topname}.h.tpl' -> 'sw/autogen/top_{topname}.h'
         cheader_path = render_template('top_%s.h',
                                        'sw/autogen',
                                        helper=c_helper)
@@ -1162,13 +1162,13 @@ def main():
         rel_header_path = cheader_path.relative_to(SRCTREE_TOP)
         c_helper.header_path = str(rel_header_path)
 
-        # 'top_earlgrey.c.tpl' -> 'sw/autogen/top_earlgrey.c'
+        # 'top_{topname}.c.tpl' -> 'sw/autogen/top_{topname}.c'
         render_template('top_%s.c', 'sw/autogen', helper=c_helper)
 
-        # 'top_earlgrey_memory.ld.tpl' -> 'sw/autogen/top_earlgrey_memory.ld'
+        # 'top_{topname}_memory.ld.tpl' -> 'sw/autogen/top_{topname}_memory.ld'
         render_template('top_%s_memory.ld', 'sw/autogen')
 
-        # 'top_earlgrey_memory.h.tpl' -> 'sw/autogen/top_earlgrey_memory.h'
+        # 'top_{topname}_memory.h.tpl' -> 'sw/autogen/top_{topname}_memory.h'
         memory_cheader_path = render_template('top_%s_memory.h', 'sw/autogen')
 
         # Fix the C header guards, which will have the wrong name

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -775,14 +775,16 @@ def generate_flash(topcfg, out_path):
     gen_rtl.gen_rtl(hjson_obj, str(rtl_path))
 
 
-def generate_top_only(top_only_list, out_path):
+def generate_top_only(top_only_list, out_path, topname):
     log.info("Generating top only modules")
 
     for ip in top_only_list:
-        rtl_path = out_path / "ip/{}/rtl".format(ip)
-        hjson_path = out_path / "ip/{}/data/{}.hjson".format(ip, ip)
+        hjson_path = Path(__file__).resolve().parent / "../hw/top_{}/ip/{}/data/{}.hjson".format(
+            topname, ip, ip)
+        genrtl_dir = out_path / "ip/{}/rtl".format(ip)
+        genrtl_dir.mkdir(parents=True, exist_ok=True)
         log.info("Generating top modules {}, hjson: {}, output: {}".format(
-            ip, hjson_path, rtl_path))
+            ip, hjson_path, genrtl_dir))
 
         # Generate reg files
         with open(str(hjson_path), 'r') as out:
@@ -790,7 +792,7 @@ def generate_top_only(top_only_list, out_path):
                                    use_decimal=True,
                                    object_pairs_hook=OrderedDict)
             validate.validate(hjson_obj)
-            gen_rtl.gen_rtl(hjson_obj, str(rtl_path))
+            gen_rtl.gen_rtl(hjson_obj, str(genrtl_dir))
 
 
 def generate_top_ral(top, ip_objs, out_path):
@@ -1087,7 +1089,7 @@ def main():
 
     # Generate top only modules
     # These modules are not templated, but are not in hw/ip
-    generate_top_only(top_only_list, out_path)
+    generate_top_only(top_only_list, out_path, topname)
 
     # Generate xbars
     if not args.no_xbar or args.xbar_only:

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -1210,7 +1210,7 @@ def main():
             template_contents = generate_top(completecfg,
                                              str(xbar_chip_data_path))
 
-            rendered_dir = tpl_path / '../dv/autogen'
+            rendered_dir = Path(out_path) / 'dv/autogen'
             rendered_dir.mkdir(parents=True, exist_ok=True)
             rendered_path = rendered_dir / fname
 
@@ -1223,7 +1223,7 @@ def main():
         template_contents = generate_top(completecfg,
                                          str(alert_handler_chip_data_path))
 
-        rendered_dir = tpl_path / '../dv/env/autogen'
+        rendered_dir = Path(out_path) / 'dv/env/autogen'
         rendered_dir.mkdir(parents=True, exist_ok=True)
         rendered_path = rendered_dir / 'alert_handler_env_pkg__params.sv'
 

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -158,7 +158,7 @@ def generate_alert_handler(top, out_path):
 
     # Generating IP top module script is not generalized yet.
     # So, topgen reads template files from alert_handler directory directly.
-    tpl_path = out_path / '../ip/alert_handler/data'
+    tpl_path = Path(__file__).resolve().parent / '../hw/ip/alert_handler/data'
     hjson_tpl_path = tpl_path / 'alert_handler.hjson.tpl'
     dv_tpl_path = tpl_path / 'alert_handler_env_pkg__params.sv.tpl'
 
@@ -237,7 +237,7 @@ def generate_plic(top, out_path):
     # Generating IP top module script is not generalized yet.
     # So, topgen reads template files from rv_plic directory directly.
     # Next, if the ip top gen tool is placed in util/ we can import the library.
-    tpl_path = out_path / '../ip/rv_plic/data'
+    tpl_path = Path(__file__).resolve().parent / '../hw/ip/rv_plic/data'
     hjson_tpl_path = tpl_path / 'rv_plic.hjson.tpl'
     rtl_tpl_path = tpl_path / 'rv_plic.sv.tpl'
 
@@ -379,7 +379,7 @@ def generate_pinmux_and_padctrl(top, out_path):
     data_path.mkdir(parents=True, exist_ok=True)
 
     # Template path
-    tpl_path = out_path / '../ip/pinmux/data/pinmux.hjson.tpl'
+    tpl_path = Path(__file__).resolve().parent / '../hw/ip/pinmux/data/pinmux.hjson.tpl'
 
     # Generate register package and RTLs
     gencmd = ("// util/topgen.py -t hw/top_{topname}/data/top_{topname}.hjson "
@@ -434,7 +434,7 @@ def generate_pinmux_and_padctrl(top, out_path):
     data_path.mkdir(parents=True, exist_ok=True)
 
     # Template path
-    tpl_path = out_path / '../ip/padctrl/data/padctrl.hjson.tpl'
+    tpl_path = Path(__file__).resolve().parent / '../hw/ip/padctrl/data/padctrl.hjson.tpl'
 
     # Generate register package and RTLs
     gencmd = ("// util/topgen.py -t hw/top_{topname}/data/top_{topname}.hjson "
@@ -596,7 +596,7 @@ def generate_pwrmgr(top, out_path):
     doc_path.mkdir(parents=True, exist_ok=True)
 
     # So, read template files from ip directory.
-    tpl_path = out_path / '../ip/pwrmgr/data'
+    tpl_path = Path(__file__).resolve().parent / '../hw/ip/pwrmgr/data'
     hjson_tpl_path = tpl_path / 'pwrmgr.hjson.tpl'
 
     # Render and write out hjson
@@ -636,7 +636,7 @@ def generate_rstmgr(topcfg, out_path):
     rtl_path.mkdir(parents=True, exist_ok=True)
     doc_path = out_path / 'ip/rstmgr/data/autogen'
     doc_path.mkdir(parents=True, exist_ok=True)
-    tpl_path = out_path / '../ip/rstmgr/data'
+    tpl_path = Path(__file__).resolve().parent / '../hw/ip/rstmgr/data'
 
     # Read template files from ip directory.
     tpls = []
@@ -725,7 +725,7 @@ def generate_flash(topcfg, out_path):
     rtl_path.mkdir(parents=True, exist_ok=True)
     doc_path = out_path / 'ip/flash_ctrl/data/autogen'
     doc_path.mkdir(parents=True, exist_ok=True)
-    tpl_path = out_path / '../ip/flash_ctrl/data'
+    tpl_path = Path(__file__).resolve().parent / '../hw/ip/flash_ctrl/data'
 
     # Read template files from ip directory.
     tpls = []

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -1006,7 +1006,19 @@ def main():
                          x.stem)
                 continue
 
-            obj = hjson.load(x.open('r'),
+            # The auto-generated hjson might not yet exist. It will be created
+            # later, see generate_{ip_name}() calls below. For the initial
+            # validation, use the template in hw/ip/{ip_name}/data .
+            if x.stem in generated_list and not x.is_file():
+                hjson_file = ip_dir / "{}/data/{}.hjson".format(x.stem, x.stem)
+                log.info("Auto-generated hjson %s does not yet exist. "
+                         % str(x) +
+                         "Falling back to template %s for initial validation."
+                         % str(hjson_file))
+            else:
+                hjson_file = x
+
+            obj = hjson.load(hjson_file.open('r'),
                              use_decimal=True,
                              object_pairs_hook=OrderedDict)
             if validate.validate(obj) != 0:

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -1103,9 +1103,9 @@ def main():
     top_name = completecfg["name"]
 
     # Generate top.gen.hjson right before rendering
-    hjson_dir = Path(args.topcfg).parent
-    genhjson_path = hjson_dir / ("autogen/top_%s.gen.hjson" %
-                                 completecfg["name"])
+    genhjson_dir = Path(out_path) / "data/autogen"
+    genhjson_dir.mkdir(parents=True, exist_ok=True)
+    genhjson_path = genhjson_dir / ("top_%s.gen.hjson" % completecfg["name"])
 
     # Header for HJSON
     gencmd = '''//


### PR DESCRIPTION
This PR contains a couple of commits that are needed for the generation of new top levels:
- Remove remaining hardcoded references to `top_earlgrey`.
- Solve a chicken egg problem around auto-generated IP hjson files (to be generated by topgen)
- Create directories if they do not yet exist.
- Change how paths are derived: previously, we were implicitly assuming that output and template paths are in the same directory.