### PR TITLE
[otbn] Fix circular dependency in gen-binaries.py

### DIFF
--- a/hw/ip/otbn/dv/uvm/gen-binaries.py
+++ b/hw/ip/otbn/dv/uvm/gen-binaries.py
@@ -209,7 +209,7 @@ def write_ninja(handle: TextIO, rig_count: int, start_seed: int,
     # Rules to build the smoke test.
     smoke_src = os.path.join(os.path.abspath(smoke_src_dir), 'smoke_test.s')
     handle.write('build smoke.o: as {smoke_src}\n'.format(smoke_src=smoke_src))
-    handle.write('build smoke.elf: ld1 smoke.elf\n\n')
+    handle.write('build smoke.elf: ld1 smoke.o\n\n')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Intriguingly, if you just run "ninja" on the result (without
specifying smoke.elf as the target), it silently skips the rule. Huh?!
