### PR TITLE
[sw,docs] Fix Links and Describe Software Tree Better

### DIFF
--- a/doc/security/specs/secure_boot/index.md
+++ b/doc/security/specs/secure_boot/index.md
@@ -26,7 +26,7 @@ firmware upgrade support.
 ## RISC-V Concepts:
 
 *   **PMP:** Physical Memory Protection unit from the
-    [RISC-V ISA Volume II: Privileged Architecture](rv-isa-priv) specification.
+    [RISC-V ISA Volume II: Privileged Architecture][rv-isa-priv] specification.
     Allows defining properties (RWX) for regions of physical memory. **Note
     that the use of ePMP is currently being considered and that this
     specification will change to accomodate it.**
@@ -44,7 +44,7 @@ The boot process flows as follows:
 
 1.  Power on.
     1.  Execution is restricted to the ROM region via
-        [OpenTitan Secure Boot HW Support](secure-boot-hw-support).
+        [OpenTitan Secure Boot HW Support][secure-boot-hw-support].
     2.  The last PMP region (region #15) is configured by reset logic to cover
         the entire flash region, with only the R and L bits set (that is, the
         region is **R**ead-only and **L**ocked, meaning the region is respected
@@ -61,11 +61,11 @@ The boot process flows as follows:
                 logic.
         2.  Using the Silicon Creator public key stored in ROM, verify the
             signature of the payload digest, using the process outlined in
-            [OpenTitan Secure Boot HW Support](secure-boot-hw-support).
+            [OpenTitan Secure Boot HW Support][secure-boot-hw-support].
             1.  If signature validation fails, enter boot failure logic.
         3.  Perform system state measurements and derive the CreatorRootKey
             identity (see [Identities and Root Keys][identities-keys]), which
-            will reside in the [key manager](key-manager), as an intermediate
+            will reside in the [key manager][key-manager], as an intermediate
             state.
         4.  Write PMP region #0: Read, Execute, Locked, covering the entirety of
             the `ROM_EXT` image from the active slot.
@@ -199,6 +199,6 @@ manifest format is required to support:
 [ot-flash]: #
 [ot-unlock-flow]: #
 [ownership-transfer]: {{< relref "/doc/security/specs/ownership_transfer" >}}
-[rv-isa-priv]: https://riscv.org/specifications/privileged-isa/
+[rv-isa-priv]: https://riscv.org/technical/specifications/
 [secure-boot-hw-support]: #
 [secure-boot-pmp]: #

--- a/sw/_index.md
+++ b/sw/_index.md
@@ -5,25 +5,104 @@ title: "OpenTitan Software"
 This is the landing spot for software documentation within the OpenTitan project.
 More description and information can be found within the [Reference Manual]({{< relref "doc/rm" >}}) and [User Guide]({{< relref "doc/ug" >}}) areas.
 
-There are two major parts to the OpenTitan software stack:
+There are three major parts to the OpenTitan software stack:
 
-* The _device_ software, which runs on the OpenTitan platform.
-* The _host_ software, which is run on a host device and interacts with an OpenTitan device.
+*   The _device_ software, which runs on the primary core within the OpenTitan platform chip.
+*   The _otbn_ software, which runs on the OTBN cryptographic co-processor within the OpenTitan platform chip.
+*   The _host_ software, which is run on a host device and interacts with an OpenTitan device.
 
-## OpenTitan Software API Documentation
+We use the term "image" to denote a complete, standalone executable which has been prepared for the OpenTitan platform chip.
+This is to differentiate from a "library", which is a collection of functions that are not complete enough to run on their own.
+
+# Device Software
+
+This software runs on the primary core within the OpenTitian platform chip itself.
+You can find all the device software in the `sw/device` directory of the repository.
+
+The device software is split into two parts:
+*   The reference firmware images, which is the project's reference implementation of the Secure Boot system.
+    Not all OpenTitan chips will use exactly the same firmware images.
+*   The firmware libraries, which can be used by any software built for the device.
+
+Device software must be written in C, Assembly, or Rust.
+
+## Reference Firmware Images
+
+The OpenTitan Reference Firmware Images together make up the Opentitan Reference Firmware Stack.
+Different images are used for different boot stages.
+
+The Reference Firmware Images are, in boot order:
+1.  The [Mask ROM]({{< relref "sw/device/mask_rom/docs" >}}) (in `sw/device/mask_rom`), executed at chip reset;
+2.  The ROM_EXT (in `sw/device/rom_exts`), the second stage Silicon Creator code, executed from flash; and
+3.  The [Tock Image]({{< relref "sw/device/tock/README.md" >}}) (in `sw/device/tock`), the Silicon Owner code, also executed from flash.
+
+### Testing-only Images
+
+There are also some other standalone firmware images in the repository, which are only used for testing.
+
+*   [`sw/device/tests`]({{< relref "sw/device/tests/README.md" >}}) contains many standalone smoke test images.
+    This directory also contains unit tests for software modules, which are executed on host (not device) systems using [GoogleTest](https://github.com/google/googletest).
+
+*   [`sw/device/benchmarks/coremark`]({{< relref "sw/device/benchmarks/coremark/README.md" >}}) contains infrastructure for running the [CoreMark](https://github.com/eembc/coremark) benchmark suite on the OpenTitan device.
+*   `sw/device/riscv_compliance_support` contains infrastructure so we can run the [RISC-V Compliance](https://github.com/riscv/riscv-compliance) tests on the OpenTitan core.
+*   `sw/device/sca` contains on-device software used for Side-Channel Analysis.
+*   `sw/device/prebuilt` contains pre-built Tock images, which may not be up-to-date.
+*   `sw/device/examples` contains example images, including a simple [Hello World]({{< relref "sw/device/examples/hello_world/README.md" >}}).
+
+There are also prototype versions of some of the boot stages, now only used for testing:
+*   [`sw/device/boot_rom`]({{< relref "sw/device/boot_rom/README.md" >}}) is a previous, testing-only version of the Mask ROM.
+*   `sw/device/exts` contains software for our prototype second boot stage images.
+
+## Firmware Libraries
+
+
+The OpenTitan repository also contains device libraries which are used within our Reference Firmware Images, and can (and should) be used by other OpenTitan device software.
+
+These are organised into the `sw/device/lib` directory.
+
+*   [`sw/device/lib/base`]({{< relref "sw/device/lib/base/README.md" >}}) contains the Base Libraries, including [freestanding C library headers]({{< relref "sw/device/lib/base/freestanding/README.md" >}}).
+    The Base Libraries are simple libraries that can be used by any other OpenTitan device software libraries.
+*   [`sw/device/lib/dif`]({{< relref "sw/device/lib/dif/README.md" >}}) contains the [Device Interface Functions]({{< relref "doc/rm/device_interface_functions.md" >}}).
+*   [`sw/device/lib/arch`]({{< relref "sw/device/lib/arch/README.md" >}}) contains the libraries to be used on specific device configurations (for instance FPGA, Simulation, etc.).
+*   [`sw/device/lib/runtime`]({{< relref "sw/device/lib/runtime/README.md" >}}) contains general libraries for more advanced on-device functionality (including logging, printing, and interacting with the RISC-V core).
+
+# OTBN Software
+
+This software runs on the OTBN cryptographic co-processor within the OpenTitan platform chip.
+You can find all the OTBN software in the `sw/otbn` directory of the repository.
+
+This software consists of a number of hand-written assembly routines which can be run on the OTBN co-processor.
+
+Normally, this software can not be run on its own, and the main processor has to set up the data and instructions for the OTBN co-processor before it triggers the start of execution.
+
+OTBN Software must only be written in Assembly.
+
+# Host Software
+
+This software is for host-side use, either in preparing images or interacting with a running OpenTitan platform chip.
+You can find all the device software in the `sw/host` directory of the repository.
+
+Host software must be written in C++ or Rust.
+
+## Testing-only Utilities
+
+There are some host-side utilities, which are only used for testing.
+*   `sw/host/spiflash` is a tool that can flash a testing image over SPI onto a chip that uses `sw/device/boot_rom` for its reset boot stage.
+
+# Other Documentation
+
+## OpenTitan Software API Documentation {#sw-api-docs}
 
 The [OpenTitan Software API Documentation](/sw/apis/) contains automatically generated documentation for the public software APIs.
 This includes the Device Interface Functions (DIFs).
 
 All DIFs are also documented on their respective [Hardware IP Specification]({{< relref "hw" >}})
 
-## Software READMEs
-
-{{% sectionContent %}}
-
-## Vendor in code see [HW vendor User Guide]({{< relref "doc/ug/vendor_hw.md" >}})
+## Vendored in Code see [Vendor Tool User Guide]({{< relref "doc/ug/vendor_hw.md" >}})
 
 * [CoreMark](https://github.com/eembc/coremark)
 * [RISC-V Compliance](https://github.com/riscv/riscv-compliance)
-* [Google Test](https://github.com/google/googletest)
+* [GoogleTest](https://github.com/google/googletest)
 * [Cryptoc](https://chromium.googlesource.com/chromiumos/third_party/cryptoc/)
+* [MPSSE from Chromium](https://chromium.googlesource.com/chromiumos/platform2/+/master/trunks/ftdi)
+* [LLVM's Compiler-RT Coverage Profiling Library](https://github.com/llvm/llvm-project/tree/master/compiler-rt)

--- a/sw/device/boot_rom/README.md
+++ b/sw/device/boot_rom/README.md
@@ -1,4 +1,8 @@
-## Boot ROM Overview
+# Boot ROM Overview
+
+The Boot ROM is a **testing-only** device image.
+The [Mask ROM]({{< relref "sw/device/mask_rom/docs/index.md" >}}) is the reference implementation of the OpenTitan Secure Boot specification.
+
 The boot ROM is always the first piece of code run in the system.
 At the moment, it serves 2 functions:
 
@@ -6,6 +10,7 @@ At the moment, it serves 2 functions:
 * Jump to embedded flash and begin execution.
 
 ## Bootstrap Overview
+
 The boot ROM bootstrap function differs between Verilator, DV and FPGA.
 
 In DV and in Verilator, embedded flash code can be backdoor loaded.

--- a/sw/device/mask_rom/docs/index.md
+++ b/sw/device/mask_rom/docs/index.md
@@ -7,7 +7,7 @@ aliases:
 <p style="text-align: right">
 Contributors(s):
   <a href="https://github.com/lenary">Sam Elliott</a>,
-  <a href="https://github.com/moidx">Garret Kelly</a>,
+  <a href="https://github.com/gkelly">Garret Kelly</a>,
   <a href="https://github.com/moidx">Miguel Osorio</a>
 </p>
 

--- a/sw/device/mask_rom/docs/index.md
+++ b/sw/device/mask_rom/docs/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Reference Mask ROM: Secure Boot Description"
 aliases:
-- /sw/device/mask_rom/boot/
+- /sw/device/mask_rom/boot
 ---
 
 <p style="text-align: right">
@@ -15,10 +15,14 @@ Contributors(s):
   Status: Draft
 </p>
 
+This describes how Mask ROM has chosen to implement the initial parts of the OpenTitan Secure Boot specification.
+
 This should be read in conjunction with the [Secure Boot specification][csm-secure-boot].
 References to that document are included.
 
-[csm-secure-boot]: {{< relref "doc/security/specs/secure_boot" >}}
+The Mask ROM is the first boot stage in the Reference Secure Boot implementation, and starts executing at device reset.
+The Mask ROM is programmed into the chip's ROM during manufacturing, and cannot be changed.
+The Mask ROM needs to prepare the OpenTitan chip for executing a ROM_EXT, including ensuring the loaded ROM_EXT is allowed to be executed on this chip.
 
 # Secure Boot Process
 
@@ -33,10 +37,10 @@ References to that document are included.
         *   Disable Interrupts and set well-defined exception handler.
             This should keep initial execution deterministic.
 
-        *   Clean Device State Part 1. (See "Cleaning Device State" below).
+        *   [Clean Device State Part 1](#clean-device-state-p1).
             This includes enabling SRAM Scrambling.
 
-        *   Setup structures for C execution (CRT: `.data`, `.bss` sections, stack).
+        *   Setup structures for C execution ([CRT](#crt-init): `.data`, `.bss` sections, stack).
 
         *   Jump into C code
 
@@ -218,7 +222,7 @@ read_boot_policy() {
 
 This manages reading and parsing ROM_EXT manifests.
 
-The manifest format is defined in [ROM_EXT Manifest Format](../rom_exts/manifest)
+The manifest format is defined in [ROM_EXT Manifest Format][rom-ext-manifest]
 
 DIFs Needed:
 
@@ -374,7 +378,7 @@ Milestone Expectations:
 *   *v0.5:* Software Binding Properties, OTP Bits.
 *   *v0.9:* Full `CreatorRootKey` derivation.
 
-### Cleaning Device State
+### Cleaning Device State {#clean-device-state-p1}
 
 Part of this process is done before we can execute any C code. In particular, we
 have to clear all registers and all of the main RAM before we setup the CRT
@@ -435,7 +439,7 @@ Milestone Expectations:
 *   *v0.5:* Can Execute C functions.
 *   *v0.9:* SRAM Scrambling.
 
-### CRT Initialization
+### CRT Initialization {#crt-init}
 
 Setting up the CRT involves: loading the `.data` and `.bss` sections, and
 setting up the stack and `gp` (`gp` may be used for referencing some data).
@@ -542,8 +546,6 @@ Accessed by:
 
 The manifest format is defined in [ROM_EXT Manifest Format][rom-ext-manifest].
 
-[rom-ext-manifest]: {{< relref "sw/device/rom_exts/manifest" >}}
-
 Stored in: Flash (at one of two fixed, memory-mapped, addresses)
 
 Extensibility:
@@ -553,3 +555,8 @@ Extensibility:
     *   Uses the Extension fields for additional read-only data if required.
         This is not interpreted by the Mask ROM, but may be used by ROM_EXT or
         BL0 if required.
+
+
+<!-- Links -->
+[csm-secure-boot]: {{< relref "doc/security/specs/secure_boot" >}}
+[rom-ext-manifest]: {{< relref "sw/device/rom_exts/docs/manifest" >}}

--- a/sw/device/mask_rom/docs/module.md.tpl
+++ b/sw/device/mask_rom/docs/module.md.tpl
@@ -5,7 +5,7 @@ title: "Reference Mask ROM: ${module} Module"
 <p style="text-align: right">
 Contributors(s):
   <a href="https://github.com/lenary">Sam Elliott</a>,
-  <a href="https://github.com/moidx">Garret Kelly</a>
+  <a href="https://github.com/gkelly">Garret Kelly</a>
 </p>
 
 <p style="color: red; text-align: right;">

--- a/sw/device/mask_rom/docs/module.md.tpl
+++ b/sw/device/mask_rom/docs/module.md.tpl
@@ -12,10 +12,12 @@ Contributors(s):
   Status: Draft
 </p>
 
-This should be read in conjunction with the [Reference Mask ROM Secure Boot Description][mask-rom-secure-boot] and the [Secure Boot][csm-secure-boot] specification.
+This should be read in conjunction with the [Reference Mask ROM Secure Boot Description][mask-rom-description] and the [Secure Boot][csm-secure-boot] specification.
 References to those documents are included.
 
-[mask-rom-secure-boot]: {{< relref "sw/device/mask_rom/docs" >}}
-[csm-secure-boot]: {{< relref "doc/security/specs/secure_boot" >}}
-
 <!-- Use # for Sections, and ## for Sub-sections. A ToC is generated automatically. -->
+${content}
+
+<!-- Links -->
+[csm-secure-boot]: {{< relref "doc/security/specs/secure_boot" >}}
+[mask-rom-description]: {{< relref "sw/device/mask_rom/docs" >}}

--- a/sw/device/rom_exts/docs/manifest.md
+++ b/sw/device/rom_exts/docs/manifest.md
@@ -1,6 +1,28 @@
-# ROM_EXT Manifest Format
+---
+title: Reference ROM_EXT Manifest Format
+aliases:
+- /sw/device/rom_exts/manifest
+---
 
-Based on the requirements outlined in [boot.md](./boot)
+<p style="text-align: right">
+Contributors(s):
+  <a href="https://github.com/lenary">Sam Elliott</a>,
+  <a href="https://github.com/gkelly">Garret Kelly</a>,
+  <a href="https://github.com/silvestrst">Silvestrs Timofejevs</a>,
+  <a href="https://github.com/moidx">Miguel Osorio</a>
+</p>
+
+<p style="color: red; text-align: right;">
+  Status: Draft
+</p>
+
+This describes the signed image format for a ROM_EXT image.
+This format is based on the requirements outlined in the [Reference Mask ROM Secure Boot Description][mask-rom-description].
+
+ROM_EXTs are the second boot stage in the Reference Secure Boot implementation.
+ROM_EXTs are supplied by the Silicon Creator.
+ROM_EXTs are programmed into the chip's flash.
+
 
 ```
  0                   1                   2                   3
@@ -121,7 +143,7 @@ Notes:
 
     Reserved fields have fixed size and unspecified alignment.
 
-## Field Descriptions
+# Field Descriptions
 
 1.  **ROM_EXT Manifest Identifier** This is a 32-bit enumeration value which is
     used by the Mask ROM to identify that an image with the above format is
@@ -282,7 +304,7 @@ Notes:
     could cause double fault issues if ROM_EXT is not unlocked by the comparator
     before the jump happens.
 
-### Data Not in the Header
+## Data Not in the Header
 
 *   `.data` + `.bss` section sizes, for establishing PMP regions. The PMP
     regions should be established by the ROM_EXT image as it sets up its own
@@ -308,7 +330,7 @@ Notes:
 
     This would have been used by the Mask ROM as an input for the key manager.
 
-## Development Versions (Subject to Change)
+# Development Versions (Subject to Change)
 
 **ROM_EXT Manifest Identifier**: `0x4552544F` (Reads "OTRE" when Disassembled --
 OpenTitan ROM_EXT)
@@ -331,7 +353,7 @@ development, but this will not be used in production software.
 
 
 
-## Software Deliverables
+# Software Deliverables
 
 *   A C Library for parsing/extracting this image format on-device.
 
@@ -371,7 +393,7 @@ from Slot A, and later we will add support ensuring these images are linked in
 a way that they can run from Slot B without modification.
 
 
-## How To Validate a ROM_EXT Image
+# How To Validate a ROM_EXT Image {#how-to-validate}
 
 Below we provide an abstract definition of how to sign and verify a ROM_EXT
 image. This description is provided so that there is a specification of what the
@@ -394,20 +416,18 @@ Notation:
 *   `||` - Denotes concatenation without a delimiter.
 *   `:=` - Denotes assignment.
 
-### Algorithms
+## Algorithms
 
-*   We primarily use
-    [`RSASSA-PKCS1-V1_5-SIGN`](https://tools.ietf.org/html/rfc3447#section-8.2.1)
-    and
-    [`RSASSA-PKCS1-V1_5-VERIFY`](https://tools.ietf.org/html/rfc3447#section-8.2.2)
-    for signatures and verification.
+*   We primarily use [`RSASSA-PKCS1-V1_5-SIGN`][RSASSA-PKCS1-V1_5-SIGN] and
+    [`RSASSA-PKCS1-V1_5-VERIFY`][RSASSA-PKCS1-V1_5-VERIFY] for signatures and
+    verification.
 *   RSA Signing and Verification is done with 3072-bit keys.
 *   The `Hash` operation may be done with SHA2-265, SHA3-256, SHA3-384, or
     SHA3-512, depending on the Signature Algorithm Identifier provided in the
     manifest. The `Hash` operation is required to provide a security level
     equivalent to that provided by the signature.
 
-### Signing
+## Signing
 
 This is usually done on a host machine, which does not have access to a real OT
 device. Thus there has to be a way for the host signer to predict the value of
@@ -424,7 +444,7 @@ message := system_state_value || device_usage_value || signed_area(rom_ext)
 signature := RSASSA-PKCS1-V1_5-SIGN(private_key, message)
 ```
 
-### Validation
+## Validation
 
 Usually, validation is done on-device, where `device_usage_value` and
 `system_state_value` can be calculated.
@@ -445,3 +465,8 @@ signature := rom_ext.signature
 message := system_state_value || device_usage_value || signed_area(rom_ext)
 result := RSASSA-PKCS1-V1_5-VERIFY(public_key, message, signature)
 ```
+
+
+[mask-rom-description]: {{< relref "sw/device/mask_rom/docs" >}}
+[RSASSA-PKCS1-V1_5-SIGN]: https://tools.ietf.org/html/rfc3447#section-8.2.1
+[RSASSA-PKCS1-V1_5-VERIFY]: https://tools.ietf.org/html/rfc3447#section-8.2.2


### PR DESCRIPTION
This is a pretty large set of changes.

The first commit fixes some links in the secure boot specification.

The second commit almost entirely rewrites the https://docs.opentitan.org/sw/ page to describe the existing software libraries and images that are available. It also moves the description of the ROM_EXT manifest to make it easier to link to in the Hugo documents. 