### PR TITLE
[kmac/dv] Add new sim_cfg and testplan Hjson files

### DIFF
--- a/hw/ip/kmac/data/kmac_base_testplan.hjson
+++ b/hw/ip/kmac/data/kmac_base_testplan.hjson
@@ -2,8 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  name: "kmac"
-  // TODO: remove the common testplans if not applicable
+  name: kmac_base
   import_testplans: ["hw/dv/tools/dvsim/testplans/csr_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson"]
@@ -20,7 +19,7 @@
             - TBD
             '''
       milestone: V1
-      tests: ["kmac_smoke"]
+      tests: ["{name}_smoke"]
     }
     {
       name: feature1

--- a/hw/ip/kmac/data/kmac_masked_testplan.hjson
+++ b/hw/ip/kmac/data/kmac_masked_testplan.hjson
@@ -1,0 +1,9 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// testplan for the masked version of KMAC
+{
+  name: "kmac_masked"
+  import_testplans: ["hw/ip/kmac/data/kmac_base_testplan.hjson"]
+}

--- a/hw/ip/kmac/data/kmac_unmasked_testplan.hjson
+++ b/hw/ip/kmac/data/kmac_unmasked_testplan.hjson
@@ -1,0 +1,9 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// testplan for the unmasked version of KMAC
+{
+  name: "kmac_unmasked"
+  import_testplans: ["hw/ip/kmac/data/kmac_base_testplan.hjson"]
+}

--- a/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
+++ b/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
@@ -2,10 +2,10 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  // Name of the sim cfg - typically same as the name of the DUT.
-  name: kmac
+  // The `name` field that provides the name of the sim_cfg
+  // should be set by the Hjson that imports this base config.
 
-  // Top level dut name (sv module).
+  // Top level dut name
   dut: kmac
 
   // Top level testbench name (sv module).
@@ -17,14 +17,13 @@
   // Fusesoc core file used for building the file list.
   fusesoc_core: lowrisc:dv:kmac_sim:0.1
 
-  // Testplan hjson file.
-  testplan: "{proj_root}/hw/ip/kmac/data/kmac_testplan.hjson"
+  // Testplan hjson file
+  testplan: "{proj_root}/hw/ip/kmac/data/{name}_testplan.hjson"
 
   // RAL spec - used to generate the RAL model.
   ral_spec: "{proj_root}/hw/ip/kmac/data/kmac.hjson"
 
   // Import additional common sim cfg files.
-  // TODO: remove imported cfgs that do not apply.
   import_cfgs: [// Project wide common sim cfg file
                 "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",
                 // Common CIP test lists
@@ -39,6 +38,27 @@
   // Default iterations for all tests - each test entry can override this.
   reseed: 50
 
+  // Need to override the default output directory
+  overrides: [
+    {
+      name: scratch_base_path
+      value: "{scratch_root}/{name}.{flow}.{tool}"
+    }
+  ]
+
+  build_modes: [
+    {
+      name: enable_mask_mode
+      build_opts: ["+define+EN_MASKING=1", "+define+REUSE_SHARE=0"]
+      run_opts: ["+enable_masking=1"]
+    }
+    {
+      name: disable_mask_mode
+      build_opts: ["+define+EN_MASKING=0", "+define+REUSE_SHARE=0"]
+      run_opts: ["+enable_masking=0"]
+    }
+  ]
+
   // Default UVM test and seq class name.
   uvm_test: kmac_base_test
   uvm_test_seq: kmac_base_vseq
@@ -46,7 +66,7 @@
   // List of test specifications.
   tests: [
     {
-      name: kmac_smoke
+      name: "{name}_smoke"
       uvm_test_seq: kmac_smoke_vseq
     }
 
@@ -57,7 +77,7 @@
   regressions: [
     {
       name: smoke
-      tests: ["kmac_smoke"]
+      tests: ["{name}_smoke"]
     }
   ]
 }

--- a/hw/ip/kmac/dv/kmac_masked_sim_cfg.hjson
+++ b/hw/ip/kmac/dv/kmac_masked_sim_cfg.hjson
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// sim cfg file for the masked version of KMAC
+{
+  // Name of the sim cfg
+  name: kmac_masked
+
+  // Import additional common sim cfg files.
+  import_cfgs: ["{proj_root}/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson"]
+
+  // Enable this build mode for all tests
+  en_build_modes: ["enable_mask_mode"]
+}

--- a/hw/ip/kmac/dv/kmac_unmasked_sim_cfg.hjson
+++ b/hw/ip/kmac/dv/kmac_unmasked_sim_cfg.hjson
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// sim cfg file for the unmasked version of KMAc
+{
+  // Name of the sim cfg
+  name: kmac_unmasked
+
+  // Import additional common sim cfg files.
+  import_cfgs: ["{proj_root}/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson"]
+
+  // Enable this build mode for all tests
+  en_build_modes: ["disable_mask_mode"]
+}

--- a/hw/ip/kmac/dv/tb.sv
+++ b/hw/ip/kmac/dv/tb.sv
@@ -37,7 +37,7 @@ module tb;
   kmac_sideload_if sideload_if();
 
   // dut
-  kmac dut (
+  kmac #(.EnMasking(`EN_MASKING), .ReuseShare(`REUSE_SHARE)) dut (
     .clk_i                (clk                      ),
     .rst_ni               (rst_n                    ),
 


### PR DESCRIPTION
For the KMAC HWIP, there are two parameter sets that should be tested,
one enabling internal data masking and one disabling the masking.

Since dvsim cannot support enabling multiple build modes per test a
workaround is to create two sets of Hjson files, one per parameter set.

Of course since all of the tests would be duplicated for each parameter
set, a base sim_cfg and testplan Hjson file is created to avoid having
to copy over all the information multiple times.

Signed-off-by: Udi Jonnalagadda <udij@google.com>