### PR TITLE
[usbdev] Fixes for pin config sims to pass

### DIFF
--- a/hw/dv/dpi/usbdpi/usbdpi.c
+++ b/hw/dv/dpi/usbdpi/usbdpi.c
@@ -877,9 +877,10 @@ char usbdpi_host_to_device(void *ctx_void, const svBitVecVal *usb_d2p) {
     char obuf[MAX_OBUF];
 
     n = snprintf(
-        obuf, MAX_OBUF, "%4x %8d              %s %s\n", ctx->frame, ctx->tick,
-        ctx->driving & P2D_SENSE ? "VBUS" : "    ",
-        (ctx->state != ST_IDLE) ? decode_usb[(ctx->driving >> 1) & 3] : "ZZ ");
+        obuf, MAX_OBUF, "%4x %8d              %s %s %s\n", ctx->frame,
+        ctx->tick, ctx->driving & P2D_SENSE ? "VBUS" : "    ",
+        (ctx->state != ST_IDLE) ? decode_usb[(ctx->driving >> 1) & 3] : "ZZ ",
+        (ctx->driving & P2D_D) ? "1" : "0");
     ssize_t written = fwrite(obuf, sizeof(char), (size_t)n, ctx->mon_file);
     assert(written == n);
   }

--- a/hw/dv/dpi/usbdpi/usbdpi.sv
+++ b/hw/dv/dpi/usbdpi/usbdpi.sv
@@ -64,10 +64,15 @@ module usbdpi #(
   logic       unused_clk = clk_i;
   logic       unused_rst = rst_ni;
   logic       dp_int, dn_int, d_int;
+  logic       flip_detect, pullup_detect;
+
+  // Detect a request to flip pins by the DN resistor being applied
+  assign flip_detect = pullupdn_d2p && pullupdn_en_d2p;
+  assign pullup_detect = (pullupdp_d2p && pullupdp_en_d2p) || (pullupdn_d2p && pullupdn_en_d2p);
 
   assign d2p = {dp_d2p, dp_en_d2p, dn_d2p, dn_en_d2p, d_d2p, d_en_d2p, se0_d2p, se0_en_d2p, pullupdp_d2p & pullupdp_en_d2p, pullupdn_d2p & pullupdn_en_d2p, txmode_d2p & txmode_en_d2p};
   always_ff @(posedge clk_48MHz_i) begin
-    if ((pullupdp_d2p && pullupdp_en_d2p) || (pullupdn_d2p && pullupdn_en_d2p)) begin
+    if (pullup_detect) begin
       automatic byte p2d = usbdpi_host_to_device(ctx, d2p);
       d_int <= p2d[3];
       dp_int <= p2d[2];
@@ -93,12 +98,20 @@ module usbdpi #(
       d_p2d = d_int;
     end
     if (dp_en_d2p) begin
-      dp_p2d = dp_d2p;
+      if (txmode_d2p) begin
+        dp_p2d = dp_d2p;
+      end else begin // decode differential and flip
+        dp_p2d = se0_d2p ? 1'b0 : flip_detect ^ d_d2p;
+      end
     end else begin
       dp_p2d = dp_int;
     end
     if (dn_en_d2p) begin
-      dn_p2d = dn_d2p;
+      if (txmode_d2p) begin
+        dn_p2d = dn_d2p;
+      end else begin // decode differential and flip
+        dn_p2d = se0_d2p ? 1'b0 : flip_detect ^ ~d_d2p;
+      end
     end else begin
       dn_p2d = dn_int;
     end

--- a/hw/ip/usbdev/rtl/usbdev_iomux.sv
+++ b/hw/ip/usbdev/rtl/usbdev_iomux.sv
@@ -183,8 +183,8 @@ module usbdev_iomux
           cio_usb_dp_o = 1'b0;
           cio_usb_dn_o = 1'b0;
         end else begin
-          cio_usb_dp_o = usb_tx_d_i;
-          cio_usb_dn_o = !usb_tx_d_i;
+          cio_usb_dp_o = cio_usb_d_flipped;
+          cio_usb_dn_o = ~cio_usb_d_flipped;
         end
       end
     end

--- a/hw/ip/usbdev/rtl/usbdev_linkstate.sv
+++ b/hw/ip/usbdev/rtl/usbdev_linkstate.sv
@@ -12,6 +12,7 @@ module usbdev_linkstate (
   input  logic usb_sense_i,
   input  logic usb_dp_i,
   input  logic usb_dn_i,
+  input  logic usb_oe_i,
   input  logic rx_jjj_det_i,
   input  logic sof_valid_i,
   output logic link_disconnect_o,  // level
@@ -81,8 +82,11 @@ module usbdev_linkstate (
   // Link state is stable, so we can output it to the register
   assign link_state_o      =  link_state_q;
 
+  // If the PHY reflects the line state on rx pins when the device is driving
+  // then the usb_oe_i check isn't needed here. But it seems best to do the check
+  // to be robust in the face of different PHY designs.
   logic see_se0, line_se0_raw;
-  assign line_se0_raw = (usb_dn_i == 1'b0) & (usb_dp_i == 1'b0);
+  assign line_se0_raw = (usb_dn_i == 1'b0) & (usb_dp_i == 1'b0) & (usb_oe_i == 1'b0);
 
   // four ticks is a bit time
   // Could completely filter out 2-cycle EOP SE0 here but

--- a/hw/ip/usbdev/rtl/usbdev_usbif.sv
+++ b/hw/ip/usbdev/rtl/usbdev_usbif.sv
@@ -361,6 +361,7 @@ module usbdev_usbif  #(
     .usb_sense_i       (usb_sense_i),
     .usb_dp_i          (usb_dp_i),
     .usb_dn_i          (usb_dn_i),
+    .usb_oe_i          (usb_oe_o),
     .rx_jjj_det_i      (rx_jjj_det),
     .sof_valid_i       (sof_valid),
     .link_disconnect_o (link_disconnect_o),

--- a/hw/top_earlgrey/util/opentitan_earlgrey_usbdev_expected-uart
+++ b/hw/top_earlgrey/util/opentitan_earlgrey_usbdev_expected-uart
@@ -1,0 +1,9 @@
+I00000 boot_rom.c:52] Version:    opentitan-snapshot-20191101-1-3257-g1690ca0
+Build Date: 2020-11-23, 17:36:40
+
+I00001 boot_rom.c:61] Boot ROM initialisation has completed, jump into flash!
+I00000 hello_usbdev.c:145] Hello, USB!
+I00001 hello_usbdev.c:146] Built at: Nov 23 2020, 17:36:42
+I00002 demos.c:18] Watch the LEDs!
+I00003 hello_usbdev.c:157] PHY settings: pinflip=0 differential=0
+Hi!Hi!I00004 hello_usbdev.c:205] PASS!

--- a/hw/top_earlgrey/util/opentitan_earlgrey_usbdev_expected-usb
+++ b/hw/top_earlgrey/util/opentitan_earlgrey_usbdev_expected-usb
@@ -1,0 +1,124 @@
+   0        1 Pullup change to DP Pulled up SingleEnded
+mon:     8224 --     8336: (H) SOP, PID SOF 001 (CRC5 1d OK), EOP
+mon:     8376 --     8488: (H) SOP, PID SETUP 0.0 (CRC5 02 OK), EOP
+mon:     8520 --     8892: (H) SOP, PID DATA0, EOP
+mon:     h->d: 00, 05, 02, 00, ff, 00, 00, 00, db, 02 CRCOK
+mon:     8928 --     8972: (D) SOP, PID ACK EOP
+mon:    11060 --    11172: (H) SOP, PID IN 0.0 (CRC5 02 OK), EOP
+mon:    11208 --    11316: (D) SOP, PID DATA1 00, 00 (NULL), EOP
+mon:    11360 --    11408: (H) SOP, PID ACK EOP
+mon:    16416 --    16528: (H) SOP, PID SOF 002 (CRC5 15 OK), EOP
+mon:    16568 --    16680: (H) SOP, PID SETUP 2.0 (CRC5 15 OK), EOP
+mon:    16712 --    17080: (H) SOP, PID DATA0, EOP
+mon:     h->d: 80, 06, 00, 01, 00, 00, 12, 00, e0, f4 CRCOK
+mon:    17116 --    17160: (D) SOP, PID ACK EOP
+mon:    19248 --    19360: (H) SOP, PID IN 2.0 (CRC5 15 OK), EOP
+mon:    19396 --    20080: (D) SOP, PID DATA1, EOP
+mon:     d->h: 12, 01, 00, 02, 00, 00, 00, 40, d1, 18, 3a, 50, 00, 01, 00, 00
+mon:           00, 01, 7d, 34 CRCOK
+mon:    20200 --    20248: (H) SOP, PID ACK EOP
+mon:    24608 --    24720: (H) SOP, PID SOF 003 (CRC5 0a OK), EOP
+mon:    32800 --    32912: (H) SOP, PID SOF 004 (CRC5 05 OK), EOP
+mon:    40992 --    41104: (H) SOP, PID SOF 005 (CRC5 1a OK), EOP
+mon:    41144 --    41256: (H) SOP, PID IN 2.1 (CRC5 03 OK), EOP
+mon:    41292 --    41336: (D) SOP, PID NAK EOP
+mon:    49184 --    49296: (H) SOP, PID SOF 006 (CRC5 12 OK), EOP
+mon:    49336 --    49448: (H) SOP, PID IN 2.1 (CRC5 03 OK), EOP
+mon:    49484 --    49528: (D) SOP, PID NAK EOP
+mon:    57376 --    57488: (H) SOP, PID SOF 007 (CRC5 0d OK), EOP
+mon:    57528 --    57640: (H) SOP, PID IN 2.1 (CRC5 03 OK), EOP
+mon:    57676 --    57720: (D) SOP, PID NAK EOP
+mon:    65568 --    65680: (H) SOP, PID SOF 008 (CRC5 0c OK), EOP
+mon:    65720 --    65832: (H) SOP, PID IN 2.1 (CRC5 03 OK), EOP
+mon:    65868 --    65912: (D) SOP, PID NAK EOP
+mon:    73760 --    73872: (H) SOP, PID SOF 009 (CRC5 13 OK), EOP
+mon:    73912 --    74024: (H) SOP, PID IN 2.1 (CRC5 03 OK), EOP
+mon:    74060 --    74104: (D) SOP, PID NAK EOP
+mon:    74280 --    74392: (H) SOP, PID OUT 2.1 (CRC5 03 OK), EOP
+mon:    74424 --    74632: (H) SOP, PID DATA0, EOP
+mon:     h->d: 48, 69, 21, e0, 61 CRCOK
+mon:          Hi!
+mon:    74668 --    74712: (D) SOP, PID ACK EOP
+mon:    81952 --    82064: (H) SOP, PID SOF 00a (CRC5 1b OK), EOP
+mon:    82104 --    82216: (H) SOP, PID SETUP 2.1 (CRC5 03 OK), EOP
+mon:    82248 --    82616: (H) SOP, PID DATA0, EOP
+mon:     h->d: c2, 02, 00, 00, 00, 00, 02, 00, 10, dd CRCOK
+mon:    82652 --    82696: (D) SOP, PID NAK EOP
+mon:    82784 --    82896: (H) SOP, PID IN 2.1 (CRC5 03 OK), EOP
+mon:    82932 --    83552: (D) SOP, PID DATA1, EOP
+mon:     d->h: 48, 65, 6c, 6c, 6f, 20, 55, 53, 42, 20, 57, 6f, 72, 6c, 64, 21
+mon:           a6, 9c CRCOK
+mon:          Hello USB World!
+mon:    83736 --    83784: (H) SOP, PID ACK EOP
+mon:    83824 --    83936: (H) SOP, PID OUT 2.1 (CRC5 03 OK), EOP
+mon:    83968 --    84080: (H) SOP, PID DATA1 00, 00 (NULL), EOP
+mon:    84112 --    84156: (D) SOP, PID ACK EOP
+mon:    90144 --    90256: (H) SOP, PID SOF 00b (CRC5 04 OK), EOP
+mon:    90296 --    90408: (H) SOP, PID IN 2.1 (CRC5 03 OK), EOP
+mon:    90444 --    90488: (D) SOP, PID NAK EOP
+mon:    98336 --    98448: (H) SOP, PID SOF 00c (CRC5 0b OK), EOP
+mon:    98488 --    98600: (H) SOP, PID IN 2.1 (CRC5 03 OK), EOP
+mon:    98636 --    98680: (D) SOP, PID NAK EOP
+mon:   106528 --   106640: (H) SOP, PID SOF 00d (CRC5 14 OK), EOP
+mon:   106680 --   106792: (H) SOP, PID IN 2.1 (CRC5 03 OK), EOP
+mon:   106828 --   106872: (D) SOP, PID NAK EOP
+mon:   114720 --   114832: (H) SOP, PID SOF 00e (CRC5 1c OK), EOP
+mon:   114872 --   114984: (H) SOP, PID IN 2.1 (CRC5 03 OK), EOP
+mon:   115020 --   115064: (D) SOP, PID NAK EOP
+mon:   115240 --   115352: (H) SOP, PID OUT 2.1 (CRC5 03 OK), EOP
+mon:   115384 --   115592: (H) SOP, PID DATA0, EOP
+mon:     h->d: 48, 69, 21, e0, 61 CRCOK
+mon:          Hi!
+mon:   115628 --   115672: (D) SOP, PID ACK EOP
+mon:   122912 --   123024: (H) SOP, PID SOF 00f (CRC5 03 OK), EOP
+mon:   123064 --   123176: (H) SOP, PID SETUP 2.1 (CRC5 03 OK), EOP
+mon:   123208 --   123576: (H) SOP, PID DATA0, EOP
+mon:     h->d: 42, 03, 60, 00, 00, 00, 00, 00, 00, bd CRCOK
+mon:   123612 --   123656: (D) SOP, PID NAK EOP
+mon:   123744 --   123856: (H) SOP, PID IN 2.1 (CRC5 03 OK), EOP
+mon:   123892 --   123936: (D) SOP, PID NAK EOP
+mon:   124056 --   124104: (H) SOP, PID ACK EOP
+mon:   131104 --   131216: (H) SOP, PID SOF 010 (CRC5 1e OK), EOP
+mon:   131256 --   131368: (H) SOP, PID IN 2.1 (CRC5 03 OK), EOP
+mon:   131404 --   131448: (D) SOP, PID NAK EOP
+mon:   139296 --   139408: (H) SOP, PID SOF 011 (CRC5 01 OK), EOP
+mon:   139448 --   139560: (H) SOP, PID OUT 2.3 (CRC5 06 OK), EOP
+mon:   139592 --   139960: (H) SOP, PID DATA0, EOP
+mon:     h->d: 42, 03, 60, 00, 00, 00, 00, 00, 00, bd CRCOK
+mon:   139996 --   140040: (D) SOP, PID NAK EOP
+mon:   140128 --   140240: (H) SOP, PID IN 2.3 (CRC5 06 OK), EOP
+mon:   140276 --   140320: (D) SOP, PID NAK EOP
+mon:   147488 --   147600: (H) SOP, PID SOF 012 (CRC5 09 OK), EOP
+mon:   147640 --   147752: (H) SOP, PID OUT 2.3 (CRC5 06 OK), EOP
+mon:   147784 --   148152: (H) SOP, PID DATA0, EOP
+mon:     h->d: 42, 03, 60, 00, 00, 00, 00, 00, 00, bd CRCOK
+mon:   148188 --   148232: (D) SOP, PID NAK EOP
+mon:   148320 --   148432: (H) SOP, PID IN 2.3 (CRC5 06 OK), EOP
+mon:   148468 --   148512: (D) SOP, PID NAK EOP
+mon:   155680 --   155792: (H) SOP, PID SOF 013 (CRC5 16 OK), EOP
+mon:   155832 --   155944: (H) SOP, PID IN 2.1 (CRC5 03 OK), EOP
+mon:   155980 --   156024: (D) SOP, PID NAK EOP
+mon:   163876 --   163988: (H) SOP, PID SETUP 2.15 (CRC5 18 OK), EOP
+mon:   164020 --   164392: (H) SOP, PID DATA0, EOP
+mon:     h->d: 00, 05, 02, 00, ff, 00, 00, 00, db, 02 CRCOK
+mon:   172068 --   172180: (H) SOP, PID OUT 2.15 (CRC5 18 OK), EOP
+mon:   172212 --   172584: (H) SOP, PID DATA0, EOP
+mon:     h->d: 00, 05, 02, 00, ff, 00, 00, 00, db, 02 CRCOK
+mon:   172620 --   172664: (D) SOP, PID STALL EOP
+mon:   180260 --   180372: (H) SOP, PID IN 2.15 (CRC5 18 OK), EOP
+mon:   180408 --   180452: (D) SOP, PID STALL EOP
+mon:   245792 --   245904: (H) SOP, PID SOF 01e (CRC5 00 OK), EOP
+mon:   253984 --   254100: (H) SOP, PID SOF 01f (CRC5 1f OK), EOP
+mon:   262176 --   262288: (H) SOP, PID SOF 020 (CRC5 13 OK), EOP
+mon:   270368 --   270480: (H) SOP, PID SOF 021 (CRC5 0c OK), EOP
+mon:   270520 --   270632: (H) SOP, PID IN 2.1 (CRC5 03 OK), EOP
+mon:   270668 --   270712: (D) SOP, PID NAK EOP
+mon:   278560 --   278672: (H) SOP, PID SOF 022 (CRC5 04 OK), EOP
+mon:   278712 --   278824: (H) SOP, PID IN 2.1 (CRC5 03 OK), EOP
+mon:   278860 --   279064: (D) SOP, PID DATA1, EOP
+mon:     d->h: 21, 21, 21, 06, 7d CRCOK
+mon:          !!!
+mon:   279236 --   279284: (H) SOP, PID ACK EOP
+mon:   286752 --   286864: (H) SOP, PID SOF 023 (CRC5 1b OK), EOP
+mon:   286904 --   287016: (H) SOP, PID IN 2.1 (CRC5 03 OK), EOP
+mon:   287052 --   287096: (D) SOP, PID NAK EOP

--- a/hw/top_earlgrey/util/opentitan_earlgrey_usbdev_pin_config_sim.sh
+++ b/hw/top_earlgrey/util/opentitan_earlgrey_usbdev_pin_config_sim.sh
@@ -14,12 +14,14 @@ FLASH=build-bin/sw/device/examples/hello_usbdev/hello_usbdev_sim_verilator.elf
 VFILE_DIR=.
 
 # How long to simulate
-SIM_CYCLES=700000
+SIM_CYCLES=757000
 
 # Expected output
-EXPECT_USB=hw/top_earlgrey/util/opentitan_earlgrey_usbdev_expected-usb.log
-EXPECT_UART=hw/top_earlgrey/util/opentitan_earlgrey_usbdev_expected-uart.log
+EXPECT_USB=hw/top_earlgrey/util/opentitan_earlgrey_usbdev_expected-usb
+EXPECT_UART=hw/top_earlgrey/util/opentitan_earlgrey_usbdev_expected-uart
 
+# Expected differences in output between expected and actual
+IGNORE_EX_UART="-I Build.Date -I Version -I Built.at"
 # Expected differences in output between noflip se and the others
 IGNORE_USB="-I Pullup.change"
 IGNORE_UART="-I PHY.settings"
@@ -55,7 +57,7 @@ cp $VFILE_DIR/uart0.log $VFILE_DIR/uart-flip-diff.log
 
 echo "Check No Flip Single Ended against expected logs"
 diff $VFILE_DIR/usb-noflip-se.log $EXPECT_USB
-diff $VFILE_DIR/uart-noflip-se.log $EXPECT_UART
+diff $IGNORE_EX_UART $VFILE_DIR/uart-noflip-se.log $EXPECT_UART
 
 echo "Check Flipped Single Ended against No Flip Single Ended"
 diff $IGNORE_USB $VFILE_DIR/usb-flip-se.log $VFILE_DIR/usb-noflip-se.log


### PR DESCRIPTION
Fix issues simulating usbdev with script in top_earlgrey/util

- Bug introduced in latest iomux changes in single-end flipping

- usbdpi fake phy not reflecting true line state when device driving
  This caused the rx to see SE0 when in differential mode thus reset

- Final !!! output has moved because program timing changes
  If the code misses push at frame 0x11 it skips to 0x21

- Line number changes in expected output

- Expected output renamed without .log to avoid gitignore

Signed-off-by: Mark Hayter <mark.hayter@gmail.com>