### PR TITLE
[otbn] Fix typo in SVA bindings

### DIFF
--- a/hw/ip/otbn/dv/uvm/sva/otbn_bind.sv
+++ b/hw/ip/otbn/dv/uvm/sva/otbn_bind.sv
@@ -20,7 +20,7 @@ module otbn_bind;
     .h2d    (tl_i),
     .d2h    (tl_o),
     .reg2hw (reg2hw),
-    .hw2reg (reg2hw)
+    .hw2reg (hw2reg)
   );
 
 endmodule


### PR DESCRIPTION
This took me ages to figure out. A real "forehead to desk" moment when I finally found the width mismatch error in the VCS build log. Sigh...