### PR TITLE
[dv] two small fix in dv

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
@@ -118,7 +118,8 @@
       milestone: V2
       tests: []
     }
-    { name: otp_ctrl_errors
+    {
+      name: otp_ctrl_errors
       desc: '''
             This test will randomly run the following OTP errors:
             - CheckFailError
@@ -141,7 +142,8 @@
       milestone: V2
       tests: []
     }
-    { name: stress_all
+    {
+      name: stress_all
       desc: '''
             - Combine above sequences in one test to run sequentially, except csr sequence
             - Randomly add reset between each sequence
@@ -149,6 +151,5 @@
       milestone: V2
       tests: []
     }
-
   ]
 }

--- a/hw/ip/otp_ctrl/doc/dv_plan/index.md
+++ b/hw/ip/otp_ctrl/doc/dv_plan/index.md
@@ -114,5 +114,4 @@ $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjs
 ```
 
 ## Testplan
-<!-- TODO: uncomment the line below after adding the testplan -->
-{{</* testplan "hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson" */>}}
+{{< testplan "hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson" >}}

--- a/util/build_docs.py
+++ b/util/build_docs.py
@@ -99,6 +99,7 @@ config = {
         "hw/ip/hmac/data/hmac_testplan.hjson",
         "hw/ip/i2c/data/i2c_testplan.hjson",
         "hw/ip/keymgr/data/keymgr_testplan.hjson",
+        "hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson",
         "hw/ip/padctrl/data/padctrl_fpv_testplan.hjson",
         "hw/ip/pattgen/data/pattgen_testplan.hjson",
         "hw/ip/pinmux/data/pinmux_fpv_testplan.hjson",

--- a/util/uvmdvgen/sim.core.tpl
+++ b/util/uvmdvgen/sim.core.tpl
@@ -25,6 +25,6 @@ targets:
       - files_dv
     default_tool: vcs
 
-  // TODO: add a lint check cfg in `hw/top_earlgrey/lint/top_earlgrey_dv_lint_cfgs.hjson`
+  # TODO: add a lint check cfg in `hw/top_earlgrey/lint/top_earlgrey_dv_lint_cfgs.hjson`
   lint:
     <<: *sim_target


### PR DESCRIPTION
1. Fix core file generate template comments: using `#` instead of `//`.
2. Enable OTP_CTRL dv testplan display.

Signed-off-by: Cindy Chen <chencindy@google.com>