### PR TITLE
[rtl/lc] Fix assertion typo

### DIFF
--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_fsm.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_fsm.sv
@@ -435,9 +435,9 @@ module lc_ctrl_fsm
   ////////////////
 
   `ASSERT(ClkBypStaysOnOnceAsserted_A,
-      lc_escalate_en_q == On
+      lc_escalate_en_o == On
       |=>
-      lc_escalate_en_q == On)
+      lc_escalate_en_o == On)
 
   `ASSERT(FlashRmaStaysOnOnceAsserted_A,
       lc_flash_rma_req_o == On


### PR DESCRIPTION
This PR fixes an assertion typo of a signal name mismatch.

Signed-off-by: Cindy Chen <chencindy@google.com>