### PR TITLE
[dv/doc] coverage exclusion label minor change

### DIFF
--- a/doc/ug/dv_methodology/index.md
+++ b/doc/ug/dv_methodology/index.md
@@ -424,7 +424,7 @@ The following are some of the best practices when adding exclusions:
 
    These categories are as follows:
 
-   *  **UNR**: Unreachable code due to constraints, or module inputs being tied off in a certain way will result in specific coverage items being unreachable.
+   *  **UNR**: Unreachable code due to design constraints, or module inputs being tied off in a certain way will result in specific coverage items being unreachable.
       Additional explanation is optional.
    *  **NON_RTL**: Simulation constructs in RTL that can be safely excluded in structural coverage collection.
       These include tasks and functions, initial / final blocks that are specifically used for simulation such as backdoor write and read functions for memory elements.


### PR DESCRIPTION
This PR updates the wording in coverage exclusion label to avoid
confusion in `design constraint` or `tb constraint`.

The original discussion is from PR #https://github.com/lowRISC/opentitan/pull/3766

Signed-off-by: Cindy Chen <chencindy@google.com>