### PR TITLE
[dv] Remove duplicated keys from common_sim_cfg.hjson

### DIFF
--- a/hw/dv/tools/dvsim/common_sim_cfg.hjson
+++ b/hw/dv/tools/dvsim/common_sim_cfg.hjson
@@ -2,10 +2,6 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  project:          opentitan
-  doc_server:       docs.opentitan.org
-  results_server:   reports.opentitan.org
-
   // Where to find DV code
   dv_root:          "{proj_root}/hw/dv"
 


### PR DESCRIPTION
These are also defined in common_project_cfg.hjson and setting them
here makes it harder to vendor this file into a different project.
