### PR TITLE
[dvsim] Allow dvsim.py to be run under Make

### DIFF
--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -256,6 +256,14 @@ class Deploy():
         exports = os.environ.copy()
         exports.update(self.exports)
 
+        # Clear the magic MAKEFLAGS variable from exports if necessary. This
+        # variable is used by recursive Make calls to pass variables from one
+        # level to the next. Here, self.cmd is a call to Make but it's
+        # logically a top-level invocation: we don't want to pollute the flow's
+        # Makefile with Make variables from any wrapper that called dvsim.
+        if 'MAKEFLAGS' in exports:
+            del exports['MAKEFLAGS']
+
         args = shlex.split(self.cmd)
         try:
             # If renew_odir flag is True - then move it.


### PR DESCRIPTION
This can be handy if you want to use a Makefile to gather together
commonly-used arguments, for example. Unfortunately, this causes all
sorts of confusion if the wrapping Makefile was called with VAR=VAL
arguments where VAR matches a name in the flow makefile. Clearing
MAKEFLAGS fixes such problems.

It's slightly surprising that Make doesn't have a "ignore any
MAKEFLAGS: you're at the top!" command line argument, but I can't find
one.

A note of explanation: I just spent half an hour trying to work out why my Ibex run wouldn't generate waves properly. The problem turned out to be that I was using Make as a wrapper around dvsim.py and I'd used "WAVES=0" or "WAVES=1" in that wrapper to control whether waves are generated. With my newly vendored OpenTitan code, this overrode the value that WAVES should have had in sim.mk ("vpd") and caused a very confusing error message from a TCL script. Fortunately, I'd delved into how MAKEFLAGS works in the past. If I hadn't it would have taken me *much* longer to figure out.

Even if we don't expect to run dvsim under Makefiles very often, this seems like a good way to avoid the next person wasting ages trying to figure out what's going wrong.