### PR TITLE
[rom_ext] Remove Signature Identifier

### DIFF
--- a/sw/device/rom_exts/docs/manifest.md
+++ b/sw/device/rom_exts/docs/manifest.md
@@ -62,9 +62,9 @@ At which point you can find the format in `${OUT_DIR}/manifest.txt`
 +                        image_timestamp                        +
 |                                                               |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                 signature_algorithm_identifier                |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                 signature_key_public_exponent                 |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                          - reserved -                         |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                                                               |
 +                                                               +
@@ -203,24 +203,6 @@ Notes:
 
     *Alignment* This is 64-bit aligned.
 
-1.  **Signature Algorithm Identifier** This identifies which algorithm has been
-    used to sign the ROM_EXT Image. This is a 32-bit enumeration value.
-
-    This is used when signing and validating the image. This happens in the
-    Mask ROM, as well as during firmware update.
-
-    `0x0` denotes an unsigned image. Unsigned images **must not** be booted.
-
-    The initial version of the Mask ROM will support the following message
-    digest algorithms:
-
-    *   SHA2-265
-    *   SHA2-384
-    *   SHA2-512
-
-    The specific signature scheme is as yet undefined, but will be based on
-    RSA-3072, and one of the message digest algorithms above.
-
 1.  **Signature Key Public Exponent** This is the RSA public exponent to be used
     during signature verification. This is a 32-bit numeric value.
 
@@ -344,7 +326,11 @@ Notes:
 
     This would have been used by the Mask ROM as an input for the key manager.
 
-# Development Versions (Subject to Change)
+*   **Signature Algorithm Identifier** We originally planned to have this field
+    in the ROM_EXT manifest, but with the padding scheme, it is redundant, so it
+    has been removed.
+
+## Development Versions (Subject to Change)
 
 **ROM_EXT Manifest Identifier**: `0x4552544F` (Reads "OTRE" when Disassembled --
 OpenTitan ROM_EXT)

--- a/sw/device/rom_exts/docs/manifest.md
+++ b/sw/device/rom_exts/docs/manifest.md
@@ -24,38 +24,52 @@ ROM_EXTs are supplied by the Silicon Creator.
 ROM_EXTs are programmed into the chip's flash.
 
 
+<!--
+The following ascii art diagram is generated with the following command,
+and changes are manually committed to this file.
+
+```
+$ util/rom-ext-manifest-generator.py \
+    --input-dir sw/device/rom_exts/ \
+    --output-dir ${OUT_DIR} \
+    --output-files=format
+```
+
+At which point you can find the format in `${OUT_DIR}/manifest.txt`
+-->
+
 ```
  0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                  ROM_EXT Manifest Identifier                  |
+|                      manifest_identifier                      |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                            Reserved                           |
+|                          - reserved -                         |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                                                               |
 +                                                               +
 |                                                               |
-+                  Image Signature (3072 bits)                  +
++                  image_signature (3072 bits)                  +
 |                                                               |
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  break  ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 |                                                               |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                          Image Length                         |
+|                          image_length                         |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                         Image Version                         |
+|                         image_version                         |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                                                               |
-+                        Image Timestamp                        +
++                        image_timestamp                        +
 |                                                               |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                 Signature Algorithm Identifier                |
+|                 signature_algorithm_identifier                |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                 Signature Key Public Exponent                 |
+|                 signature_key_public_exponent                 |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                                                               |
 +                                                               +
 |                                                               |
-+                  Usage Constraints (256 bits)                 +
++                  usage_constraints (256 bits)                 +
 |                                                               |
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  break  ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 |                                                               |
@@ -63,7 +77,7 @@ ROM_EXTs are programmed into the chip's flash.
 |                                                               |
 +                                                               +
 |                                                               |
-+                 Peripheral Lockdown Info (TBC)                +
++                    peripheral_lockdown_info                   +
 |                                                               |
 +                                                               +
 |                                                               |
@@ -71,31 +85,31 @@ ROM_EXTs are programmed into the chip's flash.
 |                                                               |
 +                                                               +
 |                                                               |
-+               Signature Key Modulus (3072 bits)               +
++               signature_key_modulus (3072 bits)               +
 |                                                               |
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  break  ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 |                                                               |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                       Extension0 Offset                       |
+|                       extension0_offset                       |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                      Extension0 Checksum                      |
+|                      extension0_checksum                      |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                       Extension1 Offset                       |
+|                       extension1_offset                       |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                      Extension1 Checksum                      |
+|                      extension1_checksum                      |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                       Extension2 Offset                       |
+|                       extension2_offset                       |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                      Extension2 Checksum                      |
+|                      extension2_checksum                      |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                       Extension3 Offset                       |
+|                       extension3_offset                       |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                      Extension3 Checksum                      |
+|                      extension3_checksum                      |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                                                               |
 +                                                               +
 |                                                               |
-+                           Code Image                          +
++                           code image                          +
 |                                                               |
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  break  ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 |                                                               |

--- a/sw/device/rom_exts/manifest.hjson
+++ b/sw/device/rom_exts/manifest.hjson
@@ -59,15 +59,6 @@
       alignment: 64,
     },
     {
-      name: "signature_algorithm_identifier",
-      desc: '''ROM_EXT Manifest signature algorithm identifier.
-
-            TODO
-            ''',
-      type: "field",
-      size: 32,
-    },
-    {
       name: "signature_key_public_exponent",
       desc: '''ROM_EXT Manifest Signature Key Public Exponent.
 
@@ -76,6 +67,10 @@
       type: "field",
       size: 32,
     },
+    {
+      type: "reserved",
+      size: 32,
+    }
     {
       name: "usage_constraints",
       desc: '''ROM_EXT Manifest usage constraints.

--- a/sw/device/rom_exts/rom_ext_manifest.S
+++ b/sw/device/rom_exts/rom_ext_manifest.S
@@ -23,6 +23,7 @@ image_signature:
   .endr
 
 // Everything beyond this point is signed.
+signed_area_start:
 
 // Calculated by linker
 image_length:
@@ -38,22 +39,20 @@ image_version:
 image_timestamp:
   .dword 0x0
 
-// Overridden by signing script
-image_signature_algorithm:
+// Overriden by signing script
+image_signature_key_public_exponent:
+  .word 0x0
+
+// reserved
   .word 0x0
 
 // Overriden by signing script
-image_signature_exponent:
-  .word 0x0
-
-// Maybe: Overriden by signing script?
 image_usage_constraints:
-  .word 0x0
+  .rept 32
+  .byte 0x0
+  .endr
 
-// Reserved
-  .word 0x0
-
-// Maybe: Overriden by signing script?
+// Overriden by signing script
 image_peripheral_lockdown_info:
   .rept 16
   .byte 0x0

--- a/sw/device/rom_exts/rom_ext_manifest_parser.c
+++ b/sw/device/rom_exts/rom_ext_manifest_parser.c
@@ -79,11 +79,6 @@ uint64_t rom_ext_get_timestamp(rom_ext_manifest_t params) {
   return ((uint64_t)timestamp_high << 32) | timestamp_low;
 }
 
-uint32_t rom_ext_get_algorithm_id(rom_ext_manifest_t params) {
-  return mmio_region_read32(params.base_addr,
-                            ROM_EXT_SIGNATURE_ALGORITHM_IDENTIFIER_OFFSET);
-}
-
 uint32_t rom_ext_get_signature_key_public_exponent(rom_ext_manifest_t params) {
   return mmio_region_read32(params.base_addr,
                             ROM_EXT_SIGNATURE_KEY_PUBLIC_EXPONENT_OFFSET);

--- a/sw/device/rom_exts/rom_ext_manifest_parser.h
+++ b/sw/device/rom_exts/rom_ext_manifest_parser.h
@@ -209,17 +209,6 @@ uint32_t rom_ext_get_version(rom_ext_manifest_t params);
 uint64_t rom_ext_get_timestamp(rom_ext_manifest_t params);
 
 /**
- * Retrieves the ROM_EXT signature algorithm identifier.
- *
- * The memory address where ROM_EXT signature algorithm identifier field
- * resides, is relative.
- *
- * @param params Parameters required for manifest parsing.
- * @return ROM_EXT signature algorithm identifier.
- */
-uint32_t rom_ext_get_algorithm_id(rom_ext_manifest_t params);
-
-/**
  * Retrieves the ROM_EXT Signature Key Public Exponent.
  *
  * The memory address where ROM_EXT exponent field resides, is relative.

--- a/sw/device/tests/rom_ext/rom_ext_parser_unittest.cc
+++ b/sw/device/tests/rom_ext/rom_ext_parser_unittest.cc
@@ -109,13 +109,6 @@ TEST_F(ImageTimestampGetTest, Success) {
   EXPECT_EQ(rom_ext_get_timestamp(params_), 0xababababcdcdcdcd);
 }
 
-class AlgorithmIdGetTest : public ParserTest {};
-
-TEST_F(AlgorithmIdGetTest, Success) {
-  EXPECT_READ32(ROM_EXT_SIGNATURE_ALGORITHM_IDENTIFIER_OFFSET, 0xa5a5a5a5);
-  EXPECT_EQ(rom_ext_get_algorithm_id(params_), 0xa5a5a5a5);
-}
-
 class SignatureKeyPublicExponentGetTest : public ParserTest {};
 
 TEST_F(SignatureKeyPublicExponentGetTest, Success) {

--- a/util/rom-ext-manifest-generator.py
+++ b/util/rom-ext-manifest-generator.py
@@ -36,12 +36,11 @@ directory):
 """
 
 import argparse
-from pathlib import Path
 import subprocess
+from pathlib import Path
 
 import hjson
 from mako.template import Template
-
 from topgen.c import MemoryRegion, Name
 
 DESC = """ROM_EXT manifest generator"""
@@ -60,6 +59,9 @@ USAGE = """
     c      - C header file
     rust   - Rust module file
     format - Format description file (plaintext)
+
+  rom-ext-manifest-generator --verbose:
+    Print extra information including resulting field offsets and alignment.
 """
 
 
@@ -72,7 +74,7 @@ class MemoryOffset(object):
         return self.name + Name(["offset"])
 
 
-def generate_defines(fields):
+def generate_defines(fields, verbose=False):
     """ Generates manifest defines.
 
     This produces two lists of tuples. One with a field name and the
@@ -80,6 +82,15 @@ def generate_defines(fields):
     description at the top for more information on the differences between these
     objects.
     """
+    def print_field_info(name, offset, size, alignment, required_alignment):
+        if verbose:
+            print("0x{:04x} - 0x{:04x}: {} (alignment: {} reqd: {})".format(
+                offset, offset + size, name, alignment, required_alignment))
+
+    def print_offset_info(name, offset, alignment, required_alignment):
+        if verbose:
+            print("       @ 0x{:04x}: {} (alignment: {} reqd: {})".format(
+                offset, name, alignment, required_alignment))
 
     base_name = Name.from_snake_case("ROM_EXT")
 
@@ -92,23 +103,46 @@ def generate_defines(fields):
         required_alignment_bytes = required_alignment_bits // 8
 
         # The 8-byte two-step https://zinascii.com/2014/the-8-byte-two-step.html
-        # This ends up aligning `current_offset_bytes` to `required_alignment_bytes`
+        # This ends up aligning `new_offset_bytes` to `required_alignment_bytes`
         # that is greater than or equal to `current_offset_bytes`.
-        current_offset_bytes = (current_offset_bytes + required_alignment_bytes - 1) \
+        new_offset_bytes = (current_offset_bytes + required_alignment_bytes - 1) \
             & ~(required_alignment_bytes - 1)
+
+        if new_offset_bytes != current_offset_bytes and verbose:
+            print("0x{:04x} - 0x{:04x}: - (realignment) -".format(
+                current_offset_bytes, new_offset_bytes))
+
+        current_offset_bytes = new_offset_bytes
+        # This works becuase e.g. 6 is `0b0...00110` and ~(6-1) is `0b1..11010`,
+        # giving a result of `0b0...010`, or 2.
+        current_offset_alignment = current_offset_bytes \
+            & ~(current_offset_bytes - 1)
 
         if field['type'] == "offset":
             offset_name = base_name + Name.from_snake_case(field['name'])
             offset = MemoryOffset(offset_name, current_offset_bytes)
             offsets.append((field['name'], offset))
 
+            print_offset_info(field['name'], current_offset_bytes,
+                              current_offset_alignment,
+                              required_alignment_bytes)
+
         else:
             assert field['size'] % 8 == 0
             size_bytes = field['size'] // 8
             if field['type'] == "field":
                 region_name = base_name + Name.from_snake_case(field['name'])
-                region = MemoryRegion(region_name, current_offset_bytes, size_bytes)
+                region = MemoryRegion(region_name, current_offset_bytes,
+                                      size_bytes)
                 regions.append((field['name'], region))
+
+                print_field_info(field['name'], current_offset_bytes,
+                                 size_bytes, current_offset_alignment,
+                                 required_alignment_bytes)
+            elif field['type'] == 'reserved' and verbose:
+                print_field_info('- reserved -', current_offset_bytes,
+                                 size_bytes, current_offset_alignment, 0)
+
             current_offset_bytes += size_bytes
 
     return (regions, offsets)
@@ -170,14 +204,14 @@ def generate_format_description(regions, output_dir):
 
     output_path = output_dir / 'manifest.txt'
 
-    truncate_length = 16 # bytes
+    truncate_length = 16  # bytes
     bits_in_byte = 8
 
     verbose_regions = []
-    current_offset = 0 # bytes
+    current_offset = 0  # bytes
 
     truncation_lines = []
-    current_truncation_delta = 0 # bytes
+    current_truncation_delta = 0  # bytes
 
     # We need to re-process this info to re-add reserved regions of the right
     # size, and also to truncate really long fields.
@@ -187,15 +221,18 @@ def generate_format_description(regions, output_dir):
 
         # Pad with a reserved field to get to new offset
         if new_offset != current_offset:
-            verbose_regions.append("- reserved -:{}".format((new_offset - current_offset) * bits_in_byte))
+            verbose_regions.append("- reserved -:{}".format(
+                (new_offset - current_offset) * bits_in_byte))
 
         current_offset = new_offset
 
         # Add a (potentially truncated) field
         if mem_region.size_bytes > truncate_length:
             # We only allow truncated regions at 4-byte offsets.
-            assert(current_offset % 4 == 0)
-            verbose_regions.append("{} ({} bits):{}".format(name, mem_region.size_bytes * bits_in_byte, truncate_length * bits_in_byte))
+            assert (current_offset % 4 == 0)
+            verbose_regions.append("{} ({} bits):{}".format(
+                name, mem_region.size_bytes * bits_in_byte,
+                truncate_length * bits_in_byte))
 
             # Save some information so we know where to insert the `~~ break ~~` line.
             data_line = (current_offset - current_truncation_delta) // 4
@@ -203,16 +240,21 @@ def generate_format_description(regions, output_dir):
             current_truncation_delta += mem_region.size_bytes - truncate_length
 
         else:
-            verbose_regions.append("{}:{}".format(name, mem_region.size_bytes * bits_in_byte))
+            verbose_regions.append("{}:{}".format(
+                name, mem_region.size_bytes * bits_in_byte))
 
         current_offset = new_offset + mem_region.size_bytes
 
     # Add a field for the image itself:
-    verbose_regions.append("code image:{}".format(truncate_length * bits_in_byte))
+    verbose_regions.append("code image:{}".format(truncate_length *
+                                                  bits_in_byte))
     truncation_lines.append((current_offset - current_truncation_delta) // 4)
 
     protocol_input = ",".join(verbose_regions)
-    protocol_result = subprocess.run(["protocol", "--bits", "32", protocol_input], universal_newlines=True, capture_output=True)
+    protocol_result = subprocess.run(
+        ["protocol", "--bits", "32", protocol_input],
+        universal_newlines=True,
+        capture_output=True)
     protocol_output = protocol_result.stdout
 
     truncation_mark = "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  break  ~~~~~~~~~~~~~~~~~~~~~~~~~~~\n"
@@ -231,7 +273,6 @@ def generate_format_description(regions, output_dir):
     print('Format description successfully written to {}.'.format(output_path))
 
 
-
 def main():
     ALL_PARTS = ["c", "rust", "format"]
 
@@ -239,6 +280,12 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         usage=USAGE,
         description=DESC)
+
+    parser.add_argument('-v',
+                        '--verbose',
+                        action='store_true',
+                        default=False,
+                        help='Print Extra Information.')
 
     parser.add_argument('--input-dir',
                         required=True,
@@ -268,7 +315,7 @@ def main():
     if 'all' in args.output_files:
         args.output_files += ALL_PARTS
 
-    regions, offsets = generate_defines(obj['fields'])
+    regions, offsets = generate_defines(obj['fields'], args.verbose)
 
     if "c" in args.output_files:
         generate_cheader(regions, offsets, args.input_dir, args.output_dir)


### PR DESCRIPTION
This was left over from https://github.com/lowRISC/opentitan/pull/3733#issuecomment-726928866.

There are three other changes:
- One adds verbose logging to the generator script, which makes it easier to understand how layout is being performed when the manifest is changed.
- One updates the `manifest.md` to use the format from #4305.
- One updates the assembly which is used for the skeleton of the ROM_EXT in the elf images (which we plan to auto-generate at some point).