### PR TITLE
Clarifications in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,14 +28,12 @@ involved.
 * Keep a clean commit history. This means no merge commits, and no long series
   of "fixup" patches (rebase or squash as appropriate). Structure work as a
   series of logically ordered, atomic patches. `git rebase -i` is your friend.
-* Changes should be made via pull request, with review. Do not commit until
-  you've had an explicit "looks good to me". We don't yet have, but plan to
-  create a policy describing code owners and the like. In the meantime use your
-  best judgement. If you're submitting a change against something that was 90%
-  authored by a single person, you'll want to get their ACK before committing.
+* Changes should be made via pull request, with review. A pull request will be
+  committed by a "committer" (an account listed in `COMMITTERS`) once it has
+  had an explicit positive review.
 * When changes are restricted to a specific area, you are recommended to add a
   tag to the beginning of the first line of the commit message in square
-  brackets. e.g. "[UART] Fix bug #157".
+  brackets. e.g. "[uart] Fix bug #157".
 * Code review is not design review and doesn't remove the need for discussing
   implementation options. If you would like to make a large-scale change or
   discuss multiple implementation options, discuss on the mailing list.


### PR DESCRIPTION
I've removed the text about when to commit. At least one potential
contributor has found it a bit confusing ("Of course I commit to my
local branch"). Since the only people that can merge code into
OpenTitan are committers, who hopefully understand how the project
works already, I don't think we need the text here.

I've also removed the discussion about code owners: yes, we should
probably decide how we track the notion of "code ownership", but I
don't think a new person to the project (a reader of this file) needs
to care about it.

Finally, I downcased the tag in the example commit message to match
what people seem to do.

This was prompted by issue #4331.