### PR TITLE
[otbn] Minor changes to what gets printed by tests

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/otbn_test_helpers.cc
+++ b/hw/ip/otbn/dv/uvm/env/otbn_test_helpers.cc
@@ -53,12 +53,8 @@ class OtbnTestHelper {
       if (entry->d_type != DT_REG)
         continue;
 
-      // Check the file name looks like an ELF file. If not, print a warning
-      // message to stderr saying that we're skipping the file.
+      // Only look at files ending in .elf
       if (!IsElfFileName(entry->d_name)) {
-        std::cerr << "WARNING: When searching for ELF files in `" << dir_path_
-                  << "', skipping file `" << entry->d_name
-                  << "', which doesn't end with `.elf'.\n";
         continue;
       }
 
@@ -85,8 +81,6 @@ class OtbnTestHelper {
       if (entry->d_type != DT_REG)
         continue;
 
-      // Skip files whose names don't look right. No warning message here: we
-      // already printed it in CountFilesInDir.
       if (!IsElfFileName(entry->d_name))
         continue;
 

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_single_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_single_vseq.sv
@@ -21,7 +21,7 @@ class otbn_single_vseq extends otbn_base_vseq;
     string elf_path = pick_elf_path();
 
     // Actually load the binary
-    `uvm_info(`gfn, $sformatf("|-- Loading binary from `%0s'", elf_path), UVM_MEDIUM)
+    `uvm_info(`gfn, $sformatf("Loading OTBN binary from `%0s'", elf_path), UVM_LOW)
     load_elf(elf_path, do_backdoor_load);
 
     // We've loaded the binary. Run the processor to see what happens!


### PR DESCRIPTION
Silence some warnings that turn out not to be very helpful with how we're running the tests. And always print the name of the binary that we're running.