### PR TITLE
[lc_ctrl] Fetch LC state vector one cycle earlier

### DIFF
--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_fsm.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_fsm.sv
@@ -140,6 +140,10 @@ module lc_ctrl_fsm
         init_done_o = 1'b0;
         if (init_req_i && lc_state_valid_q) begin
           fsm_state_d = IdleSt;
+          // Fetch LC state vector from OTP.
+          lc_state_d    = lc_state_i;
+          lc_cnt_d      = lc_cnt_i;
+          lc_id_state_d = lc_id_state_i;
         end
       end
       ///////////////////////////////////////////////////////////////////
@@ -148,7 +152,7 @@ module lc_ctrl_fsm
       // in the lc_ctrl_signal_decode submodule.
       IdleSt: begin
         idle_o = 1'b1;
-        // Continuously fetch LC state from OTP.
+        // Continuously fetch LC state vector from OTP.
         lc_state_d    = lc_state_i;
         lc_cnt_d      = lc_cnt_i;
         lc_id_state_d = lc_id_state_i;


### PR DESCRIPTION
Signed-off-by: Michael Schaffner <msf@opentitan.org>