### PR TITLE
Various documentation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenTitan
 
-![OpenTitan logo](doc/opentitan-logo.png)
+![OpenTitan logo](https://docs.opentitan.org/doc/opentitan-logo.png)
 
 ## About the project
 

--- a/doc/_index.md
+++ b/doc/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "General Documentation"
+title: "Documentation Index"
 ---
 
 {{% sectionContent %}}

--- a/doc/security/specs/firmware_update/index.md
+++ b/doc/security/specs/firmware_update/index.md
@@ -18,6 +18,10 @@ The purpose of this document is to capture the process by which Tock will
 perform a complete in-place B-slot update of the running firmware and request
 that the `ROM/ROM_EXT` code boot into it.
 
+*Note*: For certification reasons this document does not discuss detailed
+guidance for encrypted updates. Additional implementation details on both
+regular and encrypted updates to follow when possible.
+
 # Update Process
 
 1. A firmware update is initiated by a process external to the device.

--- a/site/docs/assets/scss/_menu.scss
+++ b/site/docs/assets/scss/_menu.scss
@@ -28,7 +28,6 @@
   a {
     color: $dark-purple;
     color: var(--text-color);
-    text-decoration: none;
     line-height: 1.2;
 
     &:hover,
@@ -56,7 +55,7 @@
   }
 
   a.section {
-    text-decoration: underline dotted;
+    text-decoration: underline;
   }
 
   a.ancestor {


### PR DESCRIPTION
This PR includes fixes for several things:
- The logo not rendering in README.md
- The menu using non-underlined text for links
- A change in title from "General Documentation" to "Documentation Index" for the top-level index.
- A minor copy update for the Firmware Update document regarding encrypted update.