### PR TITLE
[kmac/dv] add KMAC variants to nightly regression

### DIFF
--- a/hw/ip/kmac/doc/checklist.md
+++ b/hw/ip/kmac/doc/checklist.md
@@ -121,11 +121,11 @@ Testbench     | [TB_GEN_AUTOMATED][]                  | Done        |
 Tests         | [SIM_SMOKE_TEST_PASSING][]            | Not Started |
 Tests         | [SIM_CSR_MEM_TEST_SUITE_PASSING][]    | Done        |
 Tests         | [FPV_MAIN_ASSERTIONS_PROVEN][]        | Done        |
-Tool Setup    | [SIM_ALT_TOOL_SETUP][]                | Not Started |
-Regression    | [SIM_SMOKE_REGRESSION_SETUP][]        | Not Started |
-Regression    | [SIM_NIGHTLY_REGRESSION_SETUP][]      | Not Started |
+Tool Setup    | [SIM_ALT_TOOL_SETUP][]                | Done        |
+Regression    | [SIM_SMOKE_REGRESSION_SETUP][]        | Done        |
+Regression    | [SIM_NIGHTLY_REGRESSION_SETUP][]      | Done        |
 Regression    | [FPV_REGRESSION_SETUP][]              | Done        |
-Coverage      | [SIM_COVERAGE_MODEL_ADDED][]          | Not Started |
+Coverage      | [SIM_COVERAGE_MODEL_ADDED][]          | Done        |
 Code Quality  | [TB_LINT_SETUP][]                     | Done        |
 Integration   | [PRE_VERIFIED_SUB_MODULES_V1][]       | Done        |
 Review        | [DESIGN_SPEC_REVIEWED][]              | Done        |

--- a/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
+++ b/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   // The `name` field that provides the name of the sim_cfg
-  // should be set by the Hjson that imports this base config.
+  name: kmac
 
   // Top level dut name
   dut: kmac
@@ -18,7 +18,7 @@
   fusesoc_core: lowrisc:dv:kmac_sim:0.1
 
   // Testplan hjson file
-  testplan: "{proj_root}/hw/ip/kmac/data/{name}_testplan.hjson"
+  testplan: "{proj_root}/hw/ip/kmac/data/{variant}_testplan.hjson"
 
   // RAL spec - used to generate the RAL model.
   ral_spec: "{proj_root}/hw/ip/kmac/data/kmac.hjson"
@@ -42,7 +42,7 @@
   overrides: [
     {
       name: scratch_base_path
-      value: "{scratch_root}/{name}.{flow}.{tool}"
+      value: "{scratch_root}/{variant}.{flow}.{tool}"
     }
   ]
 
@@ -66,7 +66,7 @@
   // List of test specifications.
   tests: [
     {
-      name: "{name}_smoke"
+      name: "{variant}_smoke"
       uvm_test_seq: kmac_smoke_vseq
     }
 
@@ -77,7 +77,7 @@
   regressions: [
     {
       name: smoke
-      tests: ["{name}_smoke"]
+      tests: ["{variant}_smoke"]
     }
   ]
 }

--- a/hw/ip/kmac/dv/kmac_masked_sim_cfg.hjson
+++ b/hw/ip/kmac/dv/kmac_masked_sim_cfg.hjson
@@ -4,8 +4,8 @@
 
 // sim cfg file for the masked version of KMAC
 {
-  // Name of the sim cfg
-  name: kmac_masked
+  // Name of the sim cfg variant
+  variant: kmac_masked
 
   // Import additional common sim cfg files.
   import_cfgs: ["{proj_root}/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson"]

--- a/hw/ip/kmac/dv/kmac_unmasked_sim_cfg.hjson
+++ b/hw/ip/kmac/dv/kmac_unmasked_sim_cfg.hjson
@@ -4,8 +4,8 @@
 
 // sim cfg file for the unmasked version of KMAc
 {
-  // Name of the sim cfg
-  name: kmac_unmasked
+  // Name of the sim cfg variant
+  variant: kmac_unmasked
 
   // Import additional common sim cfg files.
   import_cfgs: ["{proj_root}/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson"]

--- a/hw/top_earlgrey/dv/top_earlgrey_sim_cfgs.hjson
+++ b/hw/top_earlgrey/dv/top_earlgrey_sim_cfgs.hjson
@@ -18,6 +18,8 @@
              "{proj_root}/hw/ip/i2c/dv/i2c_sim_cfg.hjson",
              "{proj_root}/hw/ip/pattgen/dv/pattgen_sim_cfg.hjson",
              "{proj_root}/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson",
+             "{proj_root}/hw/ip/kmac/dv/kmac_masked_sim_cfg.hjson",
+             "{proj_root}/hw/ip/kmac/dv/kmac_unmasked_sim_cfg.hjson",
              "{proj_root}/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson",
              "{proj_root}/hw/ip/rv_timer/dv/rv_timer_sim_cfg.hjson",
              "{proj_root}/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson",


### PR DESCRIPTION
This PR adds both KMAC variants (masked/unmasked) to nightly regression
runs, and updates the DV checklist accordingly.

Signed-off-by: Udi Jonnalagadda <udij@google.com>