### PR TITLE
[otbn] Add error codes to documentation

### DIFF
--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -119,13 +119,8 @@
             The error cause if an error occurred.
 
             Software should read this register before clearing the err
-            interrupt to avoid race conditions.
-
-            Possible values:
-
-            - 0x0 (ErrCodeNoError):     No error occurred.
-            - 0x1 (ErrCodeBadDataAddr): Load or store to invalid address
-            - 0x2 (ErrCodeCallStack):   Call stack underflow/overflow
+            interrupt to avoid race conditions. See 'Error conditions' in the
+            main OTBN documentation for the possible values.
           '''
         }
       ]

--- a/hw/ip/otbn/doc/_index.md
+++ b/hw/ip/otbn/doc/_index.md
@@ -426,11 +426,73 @@ Rough expected process:
 
 ## Error conditions
 
-<div class="bd-callout bd-callout-warning">
-  <h5>Note</h5>
-
-  To be filled in as we create the implementation.
-</div>
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Code</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>No Error</td>
+      <td>0x00</td>
+      <td>Execution was successful</td>
+    </tr>
+    <tr>
+      <td>Bad Data Address</td>
+      <td>0x01</td>
+      <td>
+      A Dmem read or write occurred with an out of bounds or unaligned address
+      </td>
+    </tr>
+    <tr>
+      <td>Bad Instruction Address</td>
+      <td>0x02</td>
+      <td>
+      An instruction fetch occurred with an out of bounds or unaligned address
+      </td>
+    </tr>
+    <tr>
+      <td>Call Stack over/underflow</td>
+      <td>0x03</td>
+      <td>
+      A push to the call stack when it was full or a pop from the call stack
+      when it was empty was attempted
+      </td>
+    </tr>
+    <tr>
+      <td>Illegal instruction</td>
+      <td>0x04</td>
+      <td><ul>
+        <li>An instruction being excuted had an invalid encoding</li>
+        <li>A CSR or WSR access occurred to an invalid CSR or WSR</li>
+        <li>
+          A CSR or WSR access occurred that is not permitted (e.g. writing to a
+          read-only CSR or WSR).
+        </li>
+      </ul></td>
+    </tr>
+    <tr>
+      <td>Loop error</td>
+      <td>0x05</td>
+      <td><ul>
+        <li>A loop was started with a 0 iteration count</li>
+        <li>The final instruction of a loop was a branch or another loop</li>
+        <li>The loop stack would overflow (loop nesting level too deep)</li>
+      </ul></td>
+    </tr>
+    <tr>
+      <td>Fatal Alert</td>
+      <td>0xFF</td>
+      <td>
+      A fatal alert was raised, see XXX for more details about what can cause
+      a fatal alert
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 ## Register Table
 


### PR DESCRIPTION
I've been putting together the error handling RTL. There are a number of error conditions that need to be assigned an error code. This is what I've put together so far.

This is a draft PR as there's still some questions around how things fall into alert categories, use of interrupt on error etc (see #4318), so I don't address them here. Once we've sorted those out I'll update this appropriately.