### PR TITLE
[dv/lc_ctrl] support CSR sequence

### DIFF
--- a/hw/ip/lc_ctrl/data/lc_ctrl.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl.hjson
@@ -219,6 +219,9 @@
       swaccess: "ro",
       hwaccess: "hwo",
       hwext:    "true",
+      tags: [ // Life cycle internal HW will update status so could not auto-predict its value,
+              // After reset, the field READY will be set to 1, so it is excluded from reset CSR test
+              "excl:CsrAllTests:CsrExclCheck"],
       fields: [
         { bits: "0"
           name: "READY"
@@ -375,6 +378,9 @@
         hwext:    "true",
         regwen:   "TRANSITION_REGWEN",
         cname:    "WORD",
+        tags: [ // To update this register, SW needs to claim the associated hardware mutex via
+                // CLAIM_TRANSITION_IF, so could not auto predict its value.
+                "excl:CsrNonInitTests:CsrExclCheck"],
         fields: [
           { bits: "31:0"
           }
@@ -396,6 +402,9 @@
                 In order to have exclusive access to this register, SW must first claim the associated
                 hardware mutex via !!CLAIM_TRANSITION_IF.
                 '''
+          tags: [ // To update this register, SW needs to claim the associated hardware mutex via
+                  // CLAIM_TRANSITION_IF, so could not auto predict its value.
+                  "excl:CsrNonInitTests:CsrExclCheck"],
           enum: [
             { value: "0",
               name:  "RAW",

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_base_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_base_vseq.sv
@@ -16,6 +16,12 @@ class lc_ctrl_base_vseq extends cip_base_vseq #(
 
   `uvm_object_new
 
+  virtual task pre_start();
+    // LC_CTRL does not have interrupts
+    do_clear_all_interrupts = 0;
+    super.pre_start();
+  endtask
+
   virtual task dut_init(string reset_kind = "HARD");
     super.dut_init();
     cfg.lc_ctrl_vif.init();


### PR DESCRIPTION
1. Add exclusions to CSR tests
2. Disable interrupt check in post_start because LC_CTRL does not have
interrupts

Signed-off-by: Cindy Chen <chencindy@google.com>