### PR TITLE
[kmac] Fix lint errors

### DIFF
--- a/hw/ip/kmac/lint/kmac.waiver
+++ b/hw/ip/kmac/lint/kmac.waiver
@@ -15,6 +15,6 @@ waive -rules {HIER_NET_NOT_READ NOT_READ INPUT_NOT_READ} \
     -location {kmac_msgfifo.sv} -regexp {'packer_wmask.* is not read} \
     -comment "MSG_FIFO uses only the first bit in a byte"
 
-waive -rules {HIER_NET_NOT_READ NOT_READ INPUT_NOT_READ} \
-    -location {kmac_staterd.sv} -regexp {'unused_.*} \
-    -comment "Ignore unused signals"
+waive -rules {TWO_STATE_TYPE} -location {kmac.sv} \
+    -regexp {'tl_window_e' is of two state type} \
+    -comment "Window enum is used to select, not synthesized"

--- a/hw/ip/kmac/lint/sha3.waiver
+++ b/hw/ip/kmac/lint/sha3.waiver
@@ -12,9 +12,6 @@ waive -rules {CLOCK_USE} -location {keccak_round.sv} -regexp {clk_i' is connecte
 waive -rules {RESET_USE} -location {keccak_round.sv} -regexp {'rst_ni' is connected to} \
       -comment "No reset is used if EnMasking = 0. connected to unused_* signal"
 
-waive -rules {HIER_NET_NOT_READ NOT_READ} -location {keccak_round.sv} \
-      -regexp {'sel_mux' in module .* is not read} \
-      -comment "Unmasked version does not use sel_mux signal"
-waive -rules {INPUT_NOT_READ} -location {keccak_2share.sv} \
-      -regexp {'sel_i' is not read from} \
-      -comment "Unmasked version does not use sel_mux signal"
+waive -rules {TWO_STATE_TYPE} -location {keccak_2share.sv} \
+      -regexp {'index_z' is of two state} \
+      -comment "index_z behaves as constant"

--- a/hw/ip/kmac/rtl/keccak_2share.sv
+++ b/hw/ip/kmac/rtl/keccak_2share.sv
@@ -63,9 +63,13 @@ module keccak_2share #(
   // clk_i, rst_ni, rand_valid_i are not used when EnMasking is 0. Tying them.
   if (EnMasking == 0) begin : gen_tie_unused
     logic unused_clk, unused_rst_n, unused_rand_valid;
+    logic [Width-1:0] unused_rand_data;
+    logic unused_sel;
     assign unused_clk = clk_i;
     assign unused_rst_n = rst_ni;
     assign unused_rand_valid = rand_valid_i;
+    assign unused_rand_data = rand_i;
+    assign unused_sel = sel_i;
   end
 
   ///////////////////////
@@ -99,7 +103,6 @@ module keccak_2share #(
       endcase
     end
   end else begin : g_single_data
-    // TODO: Handle unused sel_i signal
     assign phase1_in = state_in;
     assign phase2_in = phase1_out;
     assign state_out = phase2_out;
@@ -207,8 +210,6 @@ module keccak_2share #(
     end : g_chi_w
 
   end else begin : g_single_chi
-    // TODO: Handle unused clk_i, rst_ni (Lint waiver)
-    // TODO: Handle unused rand_i signal
     assign chi_data[0] = chi(phase2_in[0]);
   end
 

--- a/hw/ip/kmac/rtl/keccak_round.sv
+++ b/hw/ip/kmac/rtl/keccak_round.sv
@@ -105,7 +105,7 @@ module keccak_round #(
   logic [Width-1:0] keccak_out [Share];
 
   // Keccak Round indicator: range from 0 .. MaxRound
-  logic [RndW-1:0] round, round_d;
+  logic [RndW-1:0] round;
 
   // Random value and valid signal used in Keccak_p
   // There's plan to make random value generation configurable.
@@ -289,7 +289,7 @@ module keccak_round #(
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       storage <= '{default:'0};
-    end else if (clear_i) begin
+    end else if (rst_storage) begin
       storage <= '{default:'0};
     end else if (update_storage) begin
       storage <= storage_d;

--- a/hw/ip/kmac/rtl/kmac_keymgr.sv
+++ b/hw/ip/kmac/rtl/kmac_keymgr.sv
@@ -78,7 +78,10 @@ module kmac_keymgr
   // and re-initiate.
   // If error happens, regardless of SW-initiated or KeyMgr-initiated, the error
   // is reported to the ERR_CODE so that SW can look into.
-  input error_i
+  input error_i,
+
+  // error_o value is pushed to Error FIFO at KMAC/SHA3 top and reported to SW
+  output kmac_pkg::err_t error_o
 );
 
   /////////////////
@@ -143,7 +146,11 @@ module kmac_keymgr
     // SW Controlled
     // If start request comes from SW first, until the operation ends, all
     // requests from KeyMgr will be discarded.
-    StSw = 4'b 0100
+    StSw = 4'b 0100,
+
+    // Error KeyNotValid
+    // When KeyMgr operates, the secret key is not ready yet.
+    StKeyMgrErrKeyNotValid = 4'b 1111
   } keyctrl_st_e;
 
   typedef enum logic [2:0] {
@@ -204,12 +211,21 @@ module kmac_keymgr
     // Software output
     absorbed_o = 1'b 0;
 
+    // Error
+    error_o = '{valid: 1'b 0, code: ErrNone, info: '0};
+
     unique case (st)
       StIdle: begin
-        if (keymgr_data_i.valid) begin
+        if (keymgr_data_i.valid && keymgr_key_i.valid) begin
           st_d = StKeyMgrMsg;
           // KeyMgr initiates the data
           cmd_o = CmdStart;
+        end else if (keymgr_data_i.valid && !keymgr_key_i.valid) begin
+          st_d = StKeyMgrErrKeyNotValid;
+
+          error_o.valid = 1'b 1;
+          error_o.code = ErrKeyNotValid;
+          error_o.info = '0;
         end else if (sw_cmd_i == CmdStart) begin
           st_d = StSw;
           // Software initiates the sequence
@@ -266,6 +282,10 @@ module kmac_keymgr
         end else begin
           st_d = StSw;
         end
+      end
+
+      StKeyMgrErrKeyNotValid: begin
+        st_d = StKeyMgrErrKeyNotValid;
       end
 
       default: begin

--- a/hw/ip/kmac/rtl/kmac_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_pkg.sv
@@ -82,6 +82,30 @@ package kmac_pkg;
     CmdDone      = 4'b 1000
   } kmac_cmd_e;
 
+  ////////////////////
+  // Error Handling //
+  ////////////////////
+
+  // Error structure is same to the SHA3 one. The codes do not overlap.
+  typedef enum logic [7:0] {
+    ErrNone = 8'h 00,
+
+    // ErrSha3SwControl occurs when software sent wrong flow signal.
+    // e.g) Sw set `process_i` without `start_i`. The state machine ignores
+    //      the signal and report through the error FIFO.
+    //ErrSha3SwControl = 8'h 80
+
+    // ErrKeyNotValid: KeyMgr interface raises an error if the secret key is
+    // not valid when KeyMgr initiates KDF.
+    ErrKeyNotValid = 8'h 01
+  } err_code_e;
+
+  typedef struct packed {
+    logic        valid;
+    err_code_e   code; // Type of error
+    logic [23:0] info; // Additional Debug info
+  } err_t;
+
   ///////////////////////
   // Library Functions //
   ///////////////////////

--- a/hw/ip/kmac/rtl/kmac_staterd.sv
+++ b/hw/ip/kmac/rtl/kmac_staterd.sv
@@ -25,7 +25,6 @@ module kmac_staterd
   output tlul_pkg::tl_d2h_t tl_o,
 
   // State in
-  input valid_i,
   input [sha3_pkg::StateW-1:0] state_i [Share],
 
   // Config

--- a/hw/ip/kmac/rtl/sha3.sv
+++ b/hw/ip/kmac/rtl/sha3.sv
@@ -53,6 +53,7 @@ module sha3
   input done_i,    // see sha3pad for details
 
   output logic absorbed_o,
+  output logic squeezing_o,
 
   output sha3_st_e sha3_fsm_o,
 
@@ -126,6 +127,9 @@ module sha3
   // Absorb pulse output : used to generate interrupts
   assign absorbed_o = absorbed;
 
+  // Squeezing output
+  assign squeezing_o = squeezing;
+
   // State connection
   assign state_valid_o = state_valid;
   assign state_o = state_guarded;
@@ -157,6 +161,8 @@ module sha3
     sw_keccak_run = 1'b 0;
     keccak_done = 1'b 0;
 
+    squeezing = 1'b 0;
+
     state_valid = 1'b 0;
     mux_sel = MuxGuard ;
 
@@ -187,6 +193,8 @@ module sha3
       StSqueeze: begin
         state_valid = 1'b 1;
         mux_sel = MuxRelease; // Expose state to register interface
+
+        squeezing = 1'b 1;
 
         if (run_i) begin
           st_d = StManualRun;

--- a/hw/ip/kmac/rtl/sha3pad.sv
+++ b/hw/ip/kmac/rtl/sha3pad.sv
@@ -248,7 +248,7 @@ module sha3pad
   // TODO: Decide if it needs to compare with the FSM in {StPad, StPad01} or not
   logic end_of_block;
 
-  assign end_of_block = ((sent_message+1) == block_addr_limit) ? 1'b 1 : 1'b 0;
+  assign end_of_block = ((sent_message + 1'b1) == block_addr_limit) ? 1'b 1 : 1'b 0;
 
 
   // Next logic and output logic ==============================================

--- a/hw/lint/tools/ascentlint/common.waiver
+++ b/hw/lint/tools/ascentlint/common.waiver
@@ -6,6 +6,6 @@
 
 # waiver for unused_* signals for HIER_* rules (note that our policy file has a
 # similar exception list for rule NOT_READ)
-waive -rules {HIER_NET_NOT_READ HIER_BRANCH_NOT_READ} -pattern {unused_*}
-waive -rules {HIER_NET_NOT_READ HIER_BRANCH_NOT_READ} -pattern {gen_*.unused_*}
+waive -rules {HIER_NET_NOT_READ HIER_BRANCH_NOT_READ} -regexp {unused_.*}
+waive -rules {HIER_NET_NOT_READ HIER_BRANCH_NOT_READ} -regexp {gen_.*\.unused_.*}
 


### PR DESCRIPTION
Fixed lint errors (not all) for ascentlint tool.

Added two lint waivers for enum int error, which are used as constants
in the design.