### PR TITLE
[lc_ctrl] fix decode state_invalid_error

### DIFF
--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_state_decode.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_state_decode.sv
@@ -99,7 +99,7 @@ module lc_ctrl_state_decode
 
         // Require that any non-raw state has a valid, nonzero
         // transition count.
-        if (lc_state_i != LcStRaw && lc_cnt_i != LcCntRaw) begin
+        if (lc_state_i != LcStRaw && lc_cnt_i == LcCntRaw) begin
           state_invalid_error_o = 1'b1;
         end
 


### PR DESCRIPTION
In LC_state_decode, the logic for invalid error has some minor issue:
The code is trying to set state_invalid_error if state_i is not
RawState, and cnt_i is 0.

Signed-off-by: Cindy Chen <chencindy@google.com>