### PR TITLE
[DVSim] Add support for Verilator within DVSim

### DIFF
--- a/hw/dv/sv/dv_utils/dv_report_server.sv
+++ b/hw/dv/sv/dv_utils/dv_report_server.sv
@@ -33,24 +33,7 @@ class dv_report_server extends uvm_default_report_server;
 
     // Print final test pass-fail - external tool can use this signature for test status
     // Treat UVM_WARNINGs as a sign of test failure since it could silently result in false pass
-    if ((num_uvm_warning + num_uvm_error + num_uvm_fatal) == 0) begin
-      $display("\nTEST PASSED CHECKS");
-      $display(" _____         _                                  _ _ ");
-      $display("|_   _|__  ___| |_   _ __   __ _ ___ ___  ___  __| | |");
-      $display("  | |/ _ \\/ __| __| | '_ \\ / _` / __/ __|/ _ \\/ _` | |");
-      $display("  | |  __/\\__ \\ |_  | |_) | (_| \\__ \\__ \\  __/ (_| |_|");
-      $display("  |_|\\___||___/\\__| | .__/ \\__,_|___/___/\\___|\\__,_(_)");
-      $display("                    |_|                               \n");
-    end
-    else begin
-      $display("\nTEST FAILED CHECKS");
-      $display(" _____         _      __       _ _          _ _ ");
-      $display("|_   _|__  ___| |_   / _| __ _(_) | ___  __| | |");
-      $display("  | |/ _ \\/ __| __| | |_ / _` | | |/ _ \\/ _` | |");
-      $display("  | |  __/\\__ \\ |_  |  _| (_| | | |  __/ (_| |_|");
-      $display("  |_|\\___||___/\\__| |_|  \\__,_|_|_|\\___|\\__,_(_)\n");
-    end
-
+    dv_test_status_pkg::dv_test_status((num_uvm_warning + num_uvm_error + num_uvm_fatal) == 0);
   endfunction
 
   // Override default messaging format to standard "pretty" format for all testbenches

--- a/hw/dv/sv/dv_utils/dv_test_status.core
+++ b/hw/dv/sv/dv_utils/dv_test_status.core
@@ -1,0 +1,17 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:dv_test_status"
+description: "DV test status reporting utilities"
+
+filesets:
+  files_dv:
+    files:
+      - dv_test_status_pkg.sv
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_dv

--- a/hw/dv/sv/dv_utils/dv_test_status_pkg.sv
+++ b/hw/dv/sv/dv_utils/dv_test_status_pkg.sv
@@ -1,0 +1,32 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package dv_test_status_pkg;
+
+  // Prints the test status signature & banner.
+  //
+  // This function takes a boolean arg indicating whether the test passed or failed and prints the
+  // signature along with a banner. The signature can be used by external scripts to determine if
+  // the test passed or failed.
+  function automatic void dv_test_status(bit passed);
+    if (passed) begin
+      $display("\nTEST PASSED CHECKS");
+      $display(" _____         _                                  _ _ ");
+      $display("|_   _|__  ___| |_   _ __   __ _ ___ ___  ___  __| | |");
+      $display("  | |/ _ \\/ __| __| | '_ \\ / _` / __/ __|/ _ \\/ _` | |");
+      $display("  | |  __/\\__ \\ |_  | |_) | (_| \\__ \\__ \\  __/ (_| |_|");
+      $display("  |_|\\___||___/\\__| | .__/ \\__,_|___/___/\\___|\\__,_(_)");
+      $display("                    |_|                               \n");
+    end
+    else begin
+      $display("\nTEST FAILED CHECKS");
+      $display(" _____         _      __       _ _          _ _ ");
+      $display("|_   _|__  ___| |_   / _| __ _(_) | ___  __| | |");
+      $display("  | |/ _ \\/ __| __| | |_ / _` | | |/ _ \\/ _` | |");
+      $display("  | |  __/\\__ \\ |_  |  _| (_| | | |  __/ (_| |_|");
+      $display("  |_|\\___||___/\\__| |_|  \\__,_|_|_|\\___|\\__,_(_)\n");
+    end
+  endfunction
+
+endpackage

--- a/hw/dv/sv/dv_utils/dv_utils.core
+++ b/hw/dv/sv/dv_utils/dv_utils.core
@@ -13,6 +13,7 @@ filesets:
       - lowrisc:prim:assert:0.1
       - lowrisc:opentitan:bus_params_pkg
       - lowrisc:dv:str_utils
+      - lowrisc:dv:dv_test_status
     files:
       - dv_utils_pkg.sv
       - dv_report_server.sv: {is_include_file: true}

--- a/hw/dv/sv/dv_utils/dv_utils_pkg.sv
+++ b/hw/dv/sv/dv_utils/dv_utils_pkg.sv
@@ -6,11 +6,12 @@ package dv_utils_pkg;
   // dep packages
   import uvm_pkg::*;
   import bus_params_pkg::*;
-  import str_utils_pkg::*;
 
   // macro includes
   `include "dv_macros.svh"
+`ifdef UVM
   `include "uvm_macros.svh"
+`endif
 
   // common parameters used across all benches
   parameter int NUM_MAX_INTERRUPTS  = 32;

--- a/hw/dv/sv/sw_test_status/sw_test_status_if.sv
+++ b/hw/dv/sv/sw_test_status/sw_test_status_if.sv
@@ -31,21 +31,19 @@ interface sw_test_status_if #(
 
   // If the sw_test_status reaches the terminal states, assert that we are done.
   bit sw_test_done;
+  bit sw_test_passed;
 
   always @(posedge clk_i) begin
     if (data_valid) begin
       sw_test_status = sw_test_status_e'(data);
       sw_test_done = sw_test_done | sw_test_status inside {SwTestStatusPassed, SwTestStatusFailed};
+      sw_test_passed = sw_test_status == SwTestStatusPassed;
       if (sw_test_status == SwTestStatusPassed) begin
         `DV_INFO("==== SW TEST PASSED ====")
       end else if (sw_test_status == SwTestStatusFailed) begin
         `DV_ERROR("==== SW TEST FAILED ====")
       end else begin
-`ifdef VERILATOR
-        `DV_INFO($sformatf("SW test status changed: 0x%0h", sw_test_status))
-`else
         `DV_INFO($sformatf("SW test status changed: %0s", sw_test_status.name()))
-`endif
       end
     end
   end

--- a/hw/dv/tools/dvsim/sim.mk
+++ b/hw/dv/tools/dvsim/sim.mk
@@ -17,7 +17,9 @@ build: build_result
 prep_tool_srcs:
 	@echo "[make]: prep_tool_srcs"
 	mkdir -p ${tool_srcs_dir}
+ifneq (${tool_srcs},)
 	${LOCK_TOOL_SRCS_DIR} "cp -Ru ${tool_srcs} ${tool_srcs_dir}/."
+endif
 
 pre_build: prep_tool_srcs
 	@echo "[make]: pre_build"
@@ -28,7 +30,9 @@ endif
 
 gen_sv_flist: pre_build
 	@echo "[make]: gen_sv_flist"
+ifneq (${sv_flist_gen_cmd},)
 	cd ${build_dir} && ${sv_flist_gen_cmd} ${sv_flist_gen_opts}
+endif
 
 build_tb: gen_sv_flist
 	@echo "[make]: build the testbench"

--- a/hw/dv/tools/dvsim/verilator.hjson
+++ b/hw/dv/tools/dvsim/verilator.hjson
@@ -1,0 +1,144 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  // Replicate settings from `common_sim_cfg.hjson`.
+  //
+  // Unfortunately, that file assumes that the tools are invoked natively as
+  // opposed to via FuseSoC. Verilator is setup to be invoked via FuseSoC,
+  // which causes FuseSoC to fail due to unknown {build_opts}. Hence, contents
+  // from `common_sim_cfg.hjson` are replicated here as appropriate.
+  // -- START --
+  dv_root:          "{proj_root}/hw/dv"
+  flow:             sim
+  flow_makefile:    "{dv_root}/tools/dvsim/sim.mk"
+
+  import_cfgs:      ["{proj_root}/hw/data/common_project_cfg.hjson",
+                     "{dv_root}/tools/dvsim/common_modes.hjson",
+                     "{dv_root}/tools/dvsim/fusesoc.hjson",
+                     ]
+
+  // Default directory structure for the output
+  build_dir:          "{scratch_path}/{build_mode}"
+  run_dir_name:       "{index}.{test}"
+  run_dir:            "{scratch_path}/{run_dir_name}/out"
+  sw_build_dir:       "{scratch_path}"
+  sw_root_dir:        "{proj_root}/sw"
+
+  regressions: [
+    {
+      name: smoke
+      reseed: 1
+    }
+    {
+      name: all
+    }
+    {
+      name: all_once
+      reseed: 1
+    }
+    {
+      name: nightly
+    }
+  ]
+  // -- END --
+
+  build_cmd:  "fusesoc {fusesoc_cores_root_dirs} run"
+  ex_name:    "{eval_cmd} echo \"{fusesoc_core}\" | cut -d: -f3"
+  run_cmd:    "{build_dir}/sim-verilator/V{ex_name}"
+
+  // Indicate the tool specific helper sources - these are copied over to the
+  // {tool_srcs_dir} before running the simulation.
+  // TODO: none at the moment.
+  tool_srcs:  []
+
+  // TODO: Verilator has a few useful build switches. Need to figure out how to
+  // pass them via FuseSoC.
+
+  build_opts: ["--flag=fileset_{design_level}",
+               "--target=sim",
+               "--build-root={build_dir}",
+               "--setup",
+               "--build",
+               "{fusesoc_core}"
+               // "--timescale 1ns/1ps",
+               // Enable all assertions.
+               // "--assert",
+               // Flush streams immediately after all $displays.
+               // "--autoflush",
+               // Enable multi-threading.
+               // "--threads 4",
+               // Randomize all 2-state vars if driven to unknown 'X'.
+               // "--x-assign unique",
+               // "--x-initial unique",
+               ]
+
+  run_opts: [// Set random seed.
+             // "+verilator+seed+{seed}",
+             ]
+
+  // Supported wave dumping formats (in order of preference).
+  supported_wave_formats: ["fst"]
+
+  // Vars that need to exported to the env.
+  exports: [
+  ]
+
+  // pass and fail patterns
+  build_pass_patterns: []
+  build_fail_patterns: [// Verilator compile error.
+                        "^%Error.*?:",
+                        // FuseSoC build error.
+                        "^ERROR:.*$",
+                        ]
+  run_pass_patterns:   ["^TEST PASSED CHECKS$"]
+  run_fail_patterns:   [// $warning/error/fatal messages.
+                        "^\\[[0-9]+\\] %Warning.*?: ",
+                        "^\\[[0-9]+\\] %Error.*?: ",
+                        "^\\[[0-9]+\\] %Fatal.*?: ",
+                        // Ninja / SW compile failure.
+                        "^FAILED: ",
+                        " error: ",
+                        // Failure signature pattern.
+                        "^TEST FAILED CHECKS$"
+                        ]
+
+  // Coverage related.
+  cov_db_dir: ""
+  cov_db_test_dir: ""
+
+  build_modes: [
+    {
+      name: verilator_waves
+      is_sim_mode: 1
+      // build_opts: ["--trace",
+      //              "--trace-fst"
+      //              "--trace-structs",
+      //              "--trace-params",
+      //              "-CFLAGS \"-DVM_TRACE_FMT_FST\"",
+      //              ]
+      run_opts: ["--trace"]
+    }
+    // TODO: These need to be fine-tuned.
+    {
+      name: verilator_cov
+      is_sim_mode: 1
+      // build_opts: ["--coverage"]
+    }
+    {
+      name: verilator_xprop
+      is_sim_mode: 1
+    }
+    {
+      name: verilator_profile
+      is_sim_mode: 1
+      // build_opts: ["--prof-cfuncs",
+      //              "--prof-threads",
+      //             ]
+    }
+    {
+      name: verilator_loopdetect
+      is_sim_mode: 1
+    }
+  ]
+}

--- a/hw/top_earlgrey/dv/verilator_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/verilator_sim_cfg.hjson
@@ -1,0 +1,165 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  // Name of the sim cfg - typically same as the name of the DUT.
+  name: top_earlgrey_verilator
+
+  // Top level dut name (sv module).
+  dut: "{name}"
+
+  // Top level testbench name (sv module).
+  tb: "{name}"
+
+  // Default simulator used to sign off.
+  tool: verilator
+
+  // Fusesoc core file used for building the file list.
+  fusesoc_core: "lowrisc:systems:{name}:0.1"
+
+  // Testplan hjson file.
+  # testplan: "{proj_root}/hw/top_earlgrey/data/chip_testplan.hjson"
+
+  // Import additional common sim cfg files.
+  import_cfgs: [// Project wide common sim cfg file
+                "{proj_root}/hw/dv/tools/dvsim/verilator.hjson",
+               ]
+
+  overrides: [
+    // Use FuseSoC to build the Verilator executable. Skip the SV file list
+    // generation step entirely.
+    {
+      name: sv_flist_gen_cmd
+      value: ""
+    }
+    {
+      name: sv_flist_gen_opts
+      value: []
+    }
+    {
+      name: sv_flist_gen_dir
+      value: "{build_dir}"
+    }
+    // This defaults to 'ip' in `hw/data/common_project_cfg.hjson`. Override
+    // since we are building the top level.
+    {
+      name: design_level
+      value: top
+    }
+  ]
+
+  // Common run parameters. Each test entry can override any of these as needed.
+  reseed: 1
+  sw_build_device: sim_verilator
+
+  // Add run modes.
+  run_modes: [
+    {
+      name: sw_test_mode
+      sw_images: ["sw/device/boot_rom/boot_rom:0"]
+      run_opts: [
+        // The following shell snippet converts the SW images specification to what's
+        // needed as a run time switch to Verilator.
+        '''{eval_cmd} \
+        opts=;  \
+        types=(rom flash); \
+        images=`echo {sw_images}`; \
+        for image in $images; do \
+          path=`echo $image | cut -d: -f 1`;  \
+          index=`echo $image | cut -d: -f 2`; \
+          opts="$opts --meminit=${types[$index]},{sw_build_dir}/build-bin/$path""_{sw_build_device}.elf"; \
+        done; \
+        echo "$opts"''',
+      ]
+    }
+  ]
+
+  // All tests are SW based, so enable this by default.
+  en_run_modes: ["sw_test_mode"]
+
+  // List of test specifications.
+  //
+  // If you are adding a test that has been generated from the `sw_tests`
+  // dictionary declared in `sw/device/tests/meson.build`, the `sw_images` list
+  // below should contain `sw/device/tests/<sw_test_name>` (without any more
+  // subdirectories) because that is where the meson target is created. For
+  // example `dif_plic_smoketest` is added to `sw_tests` in
+  // `sw/device/tests/dif/meson.build`, but the final meson targets all start
+  // `sw/device/tests/dif_plic_smoketest_`.
+  //
+  // Each entry in `sw_images` is followed by an index separated with ':' which
+  // is used by the testbench to know what type of image is it:
+  // - 0 for boot_rom,
+  // - 1 for SW test,
+  // - 2 for OTBN and so on
+  // This allows an arbitrary number of SW images to be supplied to the TB.
+  tests: [
+    {
+      name: aes_test
+      sw_images: ["sw/device/tests/aes_test:1"]
+    }
+    {
+      name: crt_test
+      sw_images: ["sw/device/tests/crt_test:1"]
+    }
+    {
+      name: dif_otbn_smoketest_rtl
+      sw_images: ["sw/device/tests/dif_otbn_smoketest:1"]
+      run_opts: ['+OTBN_USE_MODEL=0']
+    }
+    // Using the model in CI isn't possible until #4097 is resolved.
+    //{
+    //  name: dif_otbn_smoketest_model
+    //  sw_images: ["sw/device/tests/dif_otbn_smoketest:1"]
+    //  run_opts: ['+OTBN_USE_MODEL=0']
+    //}
+    {
+      name: dif_otp_ctrl_smoketest
+      sw_images: ["sw/device/tests/dif_otp_ctrl_smoketest:1"]
+    }
+    {
+      name: dif_plic_smoketest
+      sw_images: ["sw/device/tests/dif_plic_smoketest:1"]
+    }
+    {
+      name: dif_rstmgr_smoketest
+      sw_images: ["sw/device/tests/dif_rstmgr_smoketest:1"]
+    }
+    {
+      name: dif_rv_timer_smoketest
+      sw_images: ["sw/device/tests/dif_rv_timer_smoketest:1"]
+    }
+    {
+      name: dif_uart_smoketest
+      sw_images: ["sw/device/tests/dif_uart_smoketest:1"]
+    }
+    {
+      name: flash_ctrl_test
+      sw_images: ["sw/device/tests/flash_ctrl_test:1"]
+    }
+    {
+      name: pmp_smoketest_napot
+      sw_images: ["sw/device/tests/pmp_smoketest_napot:1"]
+    }
+    {
+      name: pmp_smoketest_tor
+      sw_images: ["sw/device/tests/pmp_smoketest_tor:1"]
+    }
+    {
+      name: sha256_test
+      sw_images: ["sw/device/tests/sha256_test:1"]
+    }
+    {
+      name: usbdev_test
+      sw_images: ["sw/device/tests/usbdev_test:1"]
+    }
+  ]
+
+  // List of regressions.
+  regressions: [
+    {
+      name: smoke
+      tests: []
+    }
+  ]
+}

--- a/hw/top_earlgrey/rtl/top_earlgrey_verilator.sv
+++ b/hw/top_earlgrey/rtl/top_earlgrey_verilator.sv
@@ -274,6 +274,7 @@ module top_earlgrey_verilator (
     if (u_sw_test_status_if.sw_test_done) begin
       $display("Verilator sim termination requested");
       $display("Your simulation wrote to 0x%h", u_sw_test_status_if.sw_test_status_addr);
+      dv_test_status_pkg::dv_test_status(u_sw_test_status_if.sw_test_passed);
       $finish;
     end
   end

--- a/hw/top_earlgrey/top_earlgrey_verilator.core
+++ b/hw/top_earlgrey/top_earlgrey_verilator.core
@@ -20,6 +20,7 @@ filesets:
       - lowrisc:ibex:ibex_tracer
       - lowrisc:dv:sim_sram
       - lowrisc:dv:sw_test_status
+      - lowrisc:dv:dv_test_status
 
     files:
       - rtl/top_earlgrey_verilator.sv: { file_type: systemVerilogSource }

--- a/util/dvsim/Modes.py
+++ b/util/dvsim/Modes.py
@@ -263,11 +263,12 @@ class BuildModes(Modes):
         self.is_sim_mode = 0
         self.pre_build_cmds = []
         self.post_build_cmds = []
+        self.en_build_modes = []
+        self.build_opts = []
         self.pre_run_cmds = []
         self.post_run_cmds = []
-        self.build_opts = []
         self.run_opts = []
-        self.en_build_modes = []
+        self.sw_images = []
 
         super().__init__(bdict)
         self.en_build_modes = list(set(self.en_build_modes))
@@ -293,11 +294,11 @@ class RunModes(Modes):
         self.reseed = None
         self.pre_run_cmds = []
         self.post_run_cmds = []
+        self.en_run_modes = []
         self.run_opts = []
         self.uvm_test = ""
         self.uvm_test_seq = ""
         self.build_mode = ""
-        self.en_run_modes = []
         self.sw_images = []
         self.sw_build_device = ""
 
@@ -416,6 +417,7 @@ class Tests(RunModes):
             test_obj.pre_run_cmds.extend(test_obj.build_mode.pre_run_cmds)
             test_obj.post_run_cmds.extend(test_obj.build_mode.post_run_cmds)
             test_obj.run_opts.extend(test_obj.build_mode.run_opts)
+            test_obj.sw_images.extend(test_obj.build_mode.sw_images)
 
         # Return the list of tests
         return tests_objs
@@ -423,7 +425,7 @@ class Tests(RunModes):
     @staticmethod
     def merge_global_opts(tests, global_pre_build_cmds, global_post_build_cmds,
                           global_build_opts, global_pre_run_cmds,
-                          global_post_run_cmds, global_run_opts):
+                          global_post_run_cmds, global_run_opts, global_sw_images):
         processed_build_modes = []
         for test in tests:
             if test.build_mode.name not in processed_build_modes:
@@ -434,6 +436,7 @@ class Tests(RunModes):
             test.pre_run_cmds.extend(global_pre_run_cmds)
             test.post_run_cmds.extend(global_post_run_cmds)
             test.run_opts.extend(global_run_opts)
+            test.sw_images.extend(global_sw_images)
 
 
 class Regressions(Modes):

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -106,6 +106,7 @@ class SimCfg(FlowCfg):
         self.post_run_cmds = []
         self.run_dir = ""
         self.sw_build_dir = ""
+        self.sw_images = []
         self.pass_patterns = []
         self.fail_patterns = []
         self.name = ""
@@ -281,6 +282,7 @@ class SimCfg(FlowCfg):
                 self.pre_run_cmds.extend(build_mode_obj.pre_run_cmds)
                 self.post_run_cmds.extend(build_mode_obj.post_run_cmds)
                 self.run_opts.extend(build_mode_obj.run_opts)
+                self.sw_images.extend(build_mode_obj.sw_images)
             else:
                 log.error(
                     "Mode \"%s\" enabled on the the command line is not defined",
@@ -294,6 +296,7 @@ class SimCfg(FlowCfg):
                 self.pre_run_cmds.extend(run_mode_obj.pre_run_cmds)
                 self.post_run_cmds.extend(run_mode_obj.post_run_cmds)
                 self.run_opts.extend(run_mode_obj.run_opts)
+                self.sw_images.extend(run_mode_obj.sw_images)
             else:
                 log.error(
                     "Mode \"%s\" enabled on the the command line is not defined",
@@ -391,7 +394,7 @@ class SimCfg(FlowCfg):
         Tests.merge_global_opts(self.run_list, self.pre_build_cmds,
                                 self.post_build_cmds, self.build_opts,
                                 self.pre_run_cmds, self.post_run_cmds,
-                                self.run_opts)
+                                self.run_opts, self.sw_images)
 
         # Check if all items have been processed
         if items_list != []:


### PR DESCRIPTION
This change set adds support for running Verilator based simulations within DVSim. This arose from the discussion in #4326, with an aim to bring DVSim closer to being an overarching build system used for launching all ASIC tool flows for OpenTitan. 

The first 5 commits make some fixes and enhancements to various components that are common to DV and Verilator, in preparation for supporting Verilator within DVSim. 

The 6th commit adds the required DVSim HJSon cfg files used by DVSim to launch the tests. Aside from very minor fixes, no invasive updates were needed in the DVSim python codebase. Verilator tests can now be launched by running the following:
```console
$ ./util/dvsim/dvsim.py hw/top_earlgrey/dv/verilator_sim_cfg.hjson -i aes_test --max-parallel 1 [--waves] [--run-only]
```

This integrates all the steps required to run a Verilator simulation, in two phases. In the build phase, it builds the Verilated model of the design by invoking FuseSoC. In the run phase, tests are launched in parallel (only one at a time though for Verilator). Before launching the simulation in the run phase, it builds the boot_rom and the supplied SW test images by invoking meson. The root build dir is shared across all tests in the run phase, so each subsequent invocation of `ninja` only requires new dependencies to be build. Finally, the same DV test status reporting method used by UVM simulations is invoked in `top_earlgrey_verilator` which is used by DVSim to determine whether the test passed or failed.  

Once the verilated model of the design is built, the build phase can be skipped by passing `--run-only` for subsequent itertions, if no SV sources are being modified. This is useful during a SW test development sprint where the design sources are not touched.  

Fst waves can be generated for each test by passing the `--waves` switch. 

The `--max-parallel 1` ensures that only one test is launched at a time. This is because all tests connect to the same virtual UART port. Running multiple tests at the same time in parallel ends up clobbering it. 

The `--list tests` switch provides a way to lookup all available tests to run, which can be cherrypicked as needed and supplied to the `-i` switch. The `--list regressions` provides a list of regressions to run. For Verilator, the `-i all` is sufficient to run all tests. 

A full Verilator regression can be launched like this:
```console
$ ./util/dvsim/dvsim.py hw/top_earlgrey/dv/verilator_sim_cfg.hjson -i all --max-parallel 1
```

This is an alternative to launching `pytest test/systemtest/earlgrey/test_sim_verilator.py`.

Here's the result of the above command:
```console
INFO: [Deploy] [00:04:12]: [run]: [Q: 00, D: 01, P: 12, F: 00, K: 00, T: 13]
INFO: [Deploy] [00:04:20]: [run]: [Q: 00, D: 01, P: 12, F: 00, K: 00, T: 13]
INFO: [Deploy] [00:04:30]: [run]: [Q: 00, D: 01, P: 12, F: 00, K: 00, T: 13]
INFO: [Deploy] [00:04:39]: [run]: [Q: 00, D: 00, P: 13, F: 00, K: 00, T: 13]
INFO: [SimCfg] [results page]: [top_earlgrey_verilator] [/edascratch/sriyer-opentitan/scratch/top_earlgrey_verilator.sim.verilator/dvsim-verilator/results_Tue.12.01.20__10.09.33PM.md]
INFO: [FlowCfg] [results]: [top_earlgrey_verilator]:
## TOP_EARLGREY_VERILATOR Simulation Results
### Tuesday December 01 2020 10:09:33PM UTC
### Revision: [`24ab6ca6`](https://github.com/lowrisc/opentitan/tree/24ab6ca6e1d06d071213f4b1efa3d2653a060aa6) on `dvsim-verilator`
### Simulator: VERILATOR

|  Milestone  |      Name      | Tests                  |  Passing  |  Total  |  Pass Rate  |
|:-----------:|:--------------:|:-----------------------|:---------:|:-------:|:-----------:|
|             | Unmapped tests | aes_test               |     1     |    1    |  100.00 %   |
|             |                | crt_test               |     1     |    1    |  100.00 %   |
|             |                | dif_otbn_smoketest_rtl |     1     |    1    |  100.00 %   |
|             |                | dif_otp_ctrl_smoketest |     1     |    1    |  100.00 %   |
|             |                | dif_plic_smoketest     |     1     |    1    |  100.00 %   |
|             |                | dif_rstmgr_smoketest   |     1     |    1    |  100.00 %   |
|             |                | dif_rv_timer_smoketest |     1     |    1    |  100.00 %   |
|             |                | dif_uart_smoketest     |     1     |    1    |  100.00 %   |
|             |                | flash_ctrl_test        |     1     |    1    |  100.00 %   |
|             |                | pmp_smoketest_napot    |     1     |    1    |  100.00 %   |
|             |                | pmp_smoketest_tor      |     1     |    1    |  100.00 %   |
|             |                | sha256_test            |     1     |    1    |  100.00 %   |
|             |                | usbdev_test            |     1     |    1    |  100.00 %   |
|             |                | **TOTAL**              |    13     |   13    |  100.00 %   |
```

Note that this still does not entirely solve the problem outlined in #4326. The scratch path area needs to be re-organized a bit. That will be addressed in a future PR. 