### PR TITLE
[lc_ctrl] Minor documentation and interface updates

### DIFF
--- a/doc/security/specs/device_life_cycle/_index.md
+++ b/doc/security/specs/device_life_cycle/_index.md
@@ -23,6 +23,8 @@ trusted identity.
 Manufacturing refers to the process in which a device is tested and prepared for
 silicon correctness prior to production.
 
+The technical specification of the corresponding life cycle controller IP can be found [here]({{< relref "hw/ip/lc_ctrl/doc" >}}).
+
 ## Background
 
 First see [here]({{< relref "doc/security/logical_security_model" >}}) for

--- a/hw/ip/lc_ctrl/doc/lc_ctrl_encoding_table.md
+++ b/hw/ip/lc_ctrl/doc/lc_ctrl_encoding_table.md
@@ -115,7 +115,7 @@
     <td style="background:#dadce0">B3</td>
     <td style="background:#dadce0">B4</td>
     <td style="background:#dadce0">B5</td>
-    <td style="background:#dadce0">A6</td>
+    <td style="background:#c9daf8">A6</td>
     <td style="background:#c9daf8">A7</td>
     <td style="background:#c9daf8">A8</td>
     <td style="background:#c9daf8">A9</td>

--- a/hw/ip/lc_ctrl/doc/lc_ctrl_flash_accessibility.md
+++ b/hw/ip/lc_ctrl/doc/lc_ctrl_flash_accessibility.md
@@ -13,8 +13,9 @@
 <tbody>
 <tr>
 <td>CREATOR_DATA</td>
-<td colspan="3" style="text-align:center;vertical-align:middle">PROVISION_EN == ON</td>
-<td>Identical control to creator collateral in OTP.</td>
+<td colspan="2" style="text-align:center;vertical-align:middle">PROVISION_WR_EN == ON</td>
+<td style="text-align:center;vertical-align:middle">PROVISION_RD_EN == ON</td>
+<td>Similar control to creator collateral in OTP, with the difference that this item remains readable after personalization.</td>
 </tr>
 <tr>
 <td>OWNER_DATA</td>

--- a/hw/ip/lc_ctrl/doc/lc_ctrl_otp_accessibility.md
+++ b/hw/ip/lc_ctrl/doc/lc_ctrl_otp_accessibility.md
@@ -32,7 +32,7 @@
 </tr>
 <tr>
 <td>RMA_UNLOCK_TOKEN</td>
-<td rowspan="3" colspan="2" style="text-align:center;vertical-align:middle">PROVISION_EN == ON</td>
+<td rowspan="3" colspan="2" style="text-align:center;vertical-align:middle">PROVISION_WR_EN == ON</td>
 <td></td>
 </tr>
 <tr>

--- a/hw/ip/lc_ctrl/doc/lc_ctrl_signals_table.md
+++ b/hw/ip/lc_ctrl/doc/lc_ctrl_signals_table.md
@@ -8,58 +8,55 @@
     <td><strong>NVM_DEBUG_EN</strong></td>
     <td><strong>HW_DEBUG_EN</strong></td>
     <td><strong>CPU_EN</strong></td>
-    <td><strong>PROVISION_EN</strong></td>
+    <td><strong>PROVISION_(RD|WR)_EN</strong></td>
     <td><strong>KEYMGR_EN</strong></td>
-    <td><strong>CLK_BYP_EN</strong></td>
+    <td><strong>CLK_BYP_REQ</strong></td>
+    <td><strong>FLASH_RMA_REQ</strong></td>
     <td><strong>ESCALATE_EN</strong></td>
   </tr>
   <tr>
     <td style="text-align:left">RAW</td>
     <td rowspan = "9" colspan="4" style="text-align:center;vertical-align:middle"> See <a href="../../../../doc/security/specs/device_life_cycle/#manufacturing-states">life cycle definition table</a> </td>
-    <td colspan="2" style="background:#dadce0"> <td>Y</td><td>Y</td>
+    <td colspan="2" style="background:#dadce0"> <td>Y*</td><td style="background:#dadce0"></td><td>Y*</td>
   </tr>
   <tr>
    <td style="text-align:left">TEST_LOCKED</td>
-   <td colspan="2" style="background:#dadce0"> <td>Y</td><td>Y</td>
+   <td colspan="2" style="background:#dadce0"> <td>Y*</td><td style="background:#dadce0"></td><td>Y*</td>
   </tr>
   <tr>
     <td style="text-align:left">TEST_UNLOCKED</td>
-    <td colspan="3" style="background:#dadce0"><td>Y</td>
+    <td colspan="3" style="background:#dadce0"><td>Y*</td><td>Y*</td>
   </tr>
   <tr>
     <td style="text-align:left">DEV</td>
-    <td>Y</td><td>Y</td><td style="background:#dadce0"><td>Y</td>
+    <td>Y | Y*</td><td>Y</td><td style="background:#dadce0"><td>Y*</td><td>Y*</td>
   </tr>
   <tr>
     <td style="text-align:left">PROD</td>
-    <td>Y</td><td>Y</td><td style="background:#dadce0"><td>Y</td>
+    <td>Y | Y*</td><td>Y</td><td style="background:#dadce0"><td>Y*</td><td>Y*</td>
   </tr>
   <tr>
     <td style="text-align:left">PROD_END</td>
-    <td>Y</td><td>Y</td><td style="background:#dadce0"><td>Y</td>
+    <td>Y | Y*</td><td>Y</td><td colspan="2" style="background:#dadce0"></td><td>Y*</td>
   </tr>
   <tr>
     <td style="text-align:left">RMA</td>
-    <td>Y</td><td>Y</td><td style="background:#dadce0"><td>Y</td>
+    <td>Y | Y*</td><td>Y</td><td colspan="2" style="background:#dadce0"></td><td>Y*</td>
   </tr>
   <tr>
     <td style="text-align:left">SCRAP</td>
-    <td colspan="3" style="background:#dadce0"><td>Y</td>
-  </tr>
-  <tr>
-    <td style="text-align:left">INVALID</td>
-    <td colspan="3" style="background:#dadce0"><td>Y</td>
-  </tr>
-  <tr>
-    <td style="text-align:left;color:red">POST_TRANSITION</td>
-    <td colspan="7" style="background:#dadce0"> <td>Y</td>
-  </tr>
-  <tr>
-    <td style="text-align:left;color:red">ESCALATION</td>
-    <td colspan="7" style="background:#dadce0"> <td>Y</td>
+    <td colspan="4" style="background:#dadce0"><td>Y*</td>
   </tr>
   <tr>
     <td style="text-align:left;color:red">INVALID</td>
-    <td colspan="7" style="background:#dadce0"> <td>Y</td>
+    <td colspan="4" style="background:#dadce0"><td>Y*</td>
+  </tr>
+  <tr>
+    <td style="text-align:left;color:red">POST_TRANSITION</td>
+    <td colspan="8" style="background:#dadce0"><td>Y*</td>
+  </tr>
+  <tr>
+    <td style="text-align:left;color:red">ESCALATION</td>
+    <td colspan="8" style="background:#dadce0"><td>Y*</td>
   </tr>
 </table>

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
@@ -189,8 +189,7 @@ module lc_ctrl
   // Transition Interface and HW Mutex //
   ///////////////////////////////////////
 
-  // TODO: expose device ID
-  // TODO: expose other info to expose via CSRs / TAP?
+  // TODO: expose other info to via CSRs / TAP?
 
   // All registers are HWext
   logic          trans_success_d, trans_success_q;

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson
@@ -506,7 +506,7 @@
     }
     { struct:  "lc_tx"
       type:    "uni"
-      name:    "lc_provision_en"
+      name:    "lc_provision_wr_en"
       act:     "rcv"
       default: "lc_ctrl_pkg::Off"
       package: "lc_ctrl_pkg"

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
@@ -235,7 +235,7 @@
     }
     { struct:  "lc_tx"
       type:    "uni"
-      name:    "lc_provision_en"
+      name:    "lc_provision_wr_en"
       act:     "rcv"
       default: "lc_ctrl_pkg::Off"
       package: "lc_ctrl_pkg"

--- a/hw/ip/otp_ctrl/doc/_index.md
+++ b/hw/ip/otp_ctrl/doc/_index.md
@@ -320,7 +320,7 @@ Signal                     | Direction        | Type                        | De
 `lc_otp_token_i`           | `input`          | `lc_otp_token_req_t`        | Life cycle RAW unlock token hashing request.
 `lc_otp_token_o`           | `output`         | `lc_otp_token_rsp_t`        | Life cycle RAW unlock token hashing response.
 `lc_escalate_en_i`         | `input`          | `lc_ctrl_pkg::lc_tx_t`      | Life cycle escalation enable coming from life cycle controller. This signal moves all FSMs within OTP into the error state and triggers secret wiping mechanisms in the secret partitions.
-`lc_provision_en_i`        | `input`          | `lc_ctrl_pkg::lc_tx_t`      | Provision enable qualifier coming from life cycle controller. This signal enables read / write access to the RMA_TOKEN and CREATOR_ROOT_KEY_SHARE0 and CREATOR_ROOT_KEY_SHARE1.
+`lc_provision_wr_en_i`     | `input`          | `lc_ctrl_pkg::lc_tx_t`      | Provision enable qualifier coming from life cycle controller. This signal enables read / write access to the RMA_TOKEN and CREATOR_ROOT_KEY_SHARE0 and CREATOR_ROOT_KEY_SHARE1.
 `lc_dft_en_i`              | `input`          | `lc_ctrl_pkg::lc_tx_t`      | Test enable qualifier coming from from life cycle controller. This signals enables the TL-UL access port to the proprietary OTP IP.
 `otp_lc_data_o`            | `output`         | `otp_lc_data_t`             | life cycle state output holding the current life cycle state, the value of the transition counter and the tokens needed for life cycle transitions.
 `otp_keymgr_key_o`         | `output`         | `keymgr_key_t`              | Key output to the key manager holding CREATOR_ROOT_KEY_SHARE0 and CREATOR_ROOT_KEY_SHARE1.
@@ -364,7 +364,7 @@ See also [life cycle controller documentation]({{< relref "hw/ip/lc_ctrl/doc" >}
 
 After initialization, the life cycle partition contents, as well as the tokens and personalization status is output to the life cycle controller via the `otp_lc_data_o` struct.
 The life cycle controller uses this information to determine the life cycle state, and steer the appropriate qualifier signals.
-Some of these qualifier signals (`lc_dft_en_i`, `lc_provision_en_i` and `lc_escalate_en_i`) are fed back to the OTP controller in order to ungate testing logic to the OTP macro; enable write access to the `SECRET2` partition; or to push the OTP controller into escalation state.
+Some of these qualifier signals (`lc_dft_en_i`, `lc_provision_wr_en_i` and `lc_escalate_en_i`) are fed back to the OTP controller in order to ungate testing logic to the OTP macro; enable write access to the `SECRET2` partition; or to push the OTP controller into escalation state.
 
 A possible sequence for the signals described is illustrated below.
 {{< wavejson >}}
@@ -378,7 +378,7 @@ A possible sequence for the signals described is illustrated below.
   {name: 'otp_lc_data_o.id_state',          wave: '0.|.3.|...|...|...'},
   {name: 'otp_lc_data_o.rma_token',         wave: '0.|.3.|...|...|...'},
   {},
-  {name: 'lc_provision_en_i',               wave: '0.|...|...|.4.|...'},
+  {name: 'lc_provision_wr_en_i',            wave: '0.|...|...|.4.|...'},
   {name: 'lc_dft_en_i',                     wave: '0.|...|...|.4.|...'},
   {},
   {name: 'lc_escalate_en_i',                wave: '0.|...|...|...|.5.'},

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.sv
@@ -58,9 +58,9 @@ class otp_ctrl_env extends cip_base_env #(
     end
 
     // config lc pins
-    if (!uvm_config_db#(lc_provision_en_vif)::get(this, "", "lc_provision_en_vif",
-                                                  cfg.lc_provision_en_vif)) begin
-      `uvm_fatal(get_full_name(), "failed to get lc_provision_en_vif from uvm_config_db")
+    if (!uvm_config_db#(lc_provision_wr_en_vif)::get(this, "", "lc_provision_wr_en_vif",
+                                                     cfg.lc_provision_wr_en_vif)) begin
+      `uvm_fatal(get_full_name(), "failed to get lc_provision_wr_en_vif from uvm_config_db")
     end
     if (!uvm_config_db#(lc_dft_en_vif)::get(this, "", "lc_dft_en_vif", cfg.lc_dft_en_vif)) begin
       `uvm_fatal(get_full_name(), "failed to get lc_dft_en_vif from uvm_config_db")

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
@@ -13,7 +13,7 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_reg_block));
 
   // ext interfaces
   pwr_otp_vif              pwr_otp_vif;
-  lc_provision_en_vif      lc_provision_en_vif;
+  lc_provision_wr_en_vif   lc_provision_wr_en_vif;
   lc_dft_en_vif            lc_dft_en_vif;
   mem_bkdr_vif             mem_bkdr_vif;
   otp_ctrl_output_data_vif otp_ctrl_output_data_vif;

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -95,7 +95,7 @@ package otp_ctrl_env_pkg;
   } otp_pwr_if_e;
 
   typedef virtual pins_if #(OtpPwrIfWidth) pwr_otp_vif;
-  typedef virtual pins_if #(4)             lc_provision_en_vif;
+  typedef virtual pins_if #(4)             lc_provision_wr_en_vif;
   typedef virtual pins_if #(4)             lc_dft_en_vif;
   typedef virtual mem_bkdr_if              mem_bkdr_vif;
   typedef virtual otp_ctrl_output_data_if  otp_ctrl_output_data_vif;

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -23,7 +23,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     cfg.backdoor_clear_mem = 0;
     // reset power init pin and lc pins
     cfg.pwr_otp_vif.drive_pin(OtpPwrInitReq, 0);
-    cfg.lc_provision_en_vif.drive(lc_ctrl_pkg::Off);
+    cfg.lc_provision_wr_en_vif.drive(lc_ctrl_pkg::Off);
     cfg.lc_dft_en_vif.drive(lc_ctrl_pkg::Off);
     if (do_otp_ctrl_init) otp_ctrl_init();
     if (do_otp_pwr_init) otp_pwr_init();

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -38,7 +38,7 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
 
   virtual task dut_init(string reset_kind = "HARD");
     super.dut_init(reset_kind);
-    cfg.lc_provision_en_vif.drive(lc_ctrl_pkg::On);
+    cfg.lc_provision_wr_en_vif.drive(lc_ctrl_pkg::On);
     csr_wr(ral.intr_enable, en_intr);
   endtask
 

--- a/hw/ip/otp_ctrl/dv/tb.sv
+++ b/hw/ip/otp_ctrl/dv/tb.sv
@@ -18,8 +18,7 @@ module tb;
 
   wire clk, rst_n;
   wire devmode;
-  wire lc_ctrl_pkg::lc_tx_e lc_provision_en, lc_dft_en;
-
+  wire lc_ctrl_pkg::lc_tx_e lc_provision_wr_en, lc_dft_en;
   wire [OtpPwrIfWidth-1:0] pwr_otp;
   wire otp_ctrl_pkg::flash_otp_key_req_t flash_req;
   wire otp_ctrl_pkg::flash_otp_key_rsp_t flash_rsp;
@@ -50,7 +49,7 @@ module tb;
 
   pins_if #(OtpPwrIfWidth) pwr_otp_if(pwr_otp);
   // TODO: use standard req/rsp agent
-  pins_if #(4) lc_provision_en_if(lc_provision_en);
+  pins_if #(4) lc_provision_wr_en_if(lc_provision_wr_en);
   pins_if #(4) lc_dft_en_if(lc_dft_en);
 
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
@@ -87,7 +86,7 @@ module tb;
     .lc_otp_token_i            ('0),
     .lc_otp_token_o            (otp_token),
     .lc_escalate_en_i          (lc_ctrl_pkg::Off),
-    .lc_provision_en_i         (lc_provision_en),
+    .lc_provision_wr_en_i      (lc_provision_wr_en),
     .lc_dft_en_i               (lc_dft_en),
     .otp_lc_data_o             (otp_ctrl_output_data_if.lc_data),
     // keymgr
@@ -150,8 +149,8 @@ module tb;
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
     uvm_config_db#(pwr_otp_vif)::set(null, "*.env", "pwr_otp_vif", pwr_otp_if);
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
-    uvm_config_db#(lc_provision_en_vif)::set(null, "*.env", "lc_provision_en_vif",
-                                             lc_provision_en_if);
+    uvm_config_db#(lc_provision_wr_en_vif)::set(null, "*.env", "lc_provision_wr_en_vif",
+                                                lc_provision_wr_en_if);
     uvm_config_db#(lc_dft_en_vif)::set(null, "*.env", "lc_dft_en_vif", lc_dft_en_if);
     uvm_config_db#(mem_bkdr_vif)::set(null, "*.env", "mem_bkdr_vif",
                                       `OTP_CTRL_MEM_HIER.mem_bkdr_if);

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
@@ -49,7 +49,7 @@ module otp_ctrl
   output lc_otp_token_rsp_t                          lc_otp_token_o,
   // Lifecycle broadcast inputs
   input  lc_ctrl_pkg::lc_tx_t                        lc_escalate_en_i,
-  input  lc_ctrl_pkg::lc_tx_t                        lc_provision_en_i,
+  input  lc_ctrl_pkg::lc_tx_t                        lc_provision_wr_en_i,
   input  lc_ctrl_pkg::lc_tx_t                        lc_dft_en_i,
   // OTP broadcast outputs
   output otp_lc_data_t                               otp_lc_data_o,
@@ -100,7 +100,7 @@ module otp_ctrl
   // Life Cycle Signal Synchronization //
   ///////////////////////////////////////
 
-  lc_ctrl_pkg::lc_tx_t lc_escalate_en, lc_provision_en;
+  lc_ctrl_pkg::lc_tx_t lc_escalate_en, lc_provision_wr_en;
   lc_ctrl_pkg::lc_tx_t [1:0] lc_dft_en;
 
   prim_lc_sync #(
@@ -114,11 +114,11 @@ module otp_ctrl
 
   prim_lc_sync #(
     .NumCopies(1)
-  ) u_prim_lc_sync_provision_en (
+  ) u_prim_lc_sync_provision_wr_en (
     .clk_i,
     .rst_ni,
-    .lc_en_i(lc_provision_en_i),
-    .lc_en_o(lc_provision_en)
+    .lc_en_i(lc_provision_wr_en_i),
+    .lc_en_o(lc_provision_wr_en)
   );
 
   prim_lc_sync #(
@@ -259,7 +259,7 @@ module otp_ctrl
     if (!reg2hw.creator_sw_cfg_read_lock) part_access_csrs[CreatorSwCfgIdx].read_lock = Locked;
     if (!reg2hw.owner_sw_cfg_read_lock) part_access_csrs[OwnerSwCfgIdx].read_lock = Locked;
     // The SECRET2 partition can only be accessed (write&read) when provisioning is enabled.
-    if (lc_provision_en != lc_ctrl_pkg::On) part_access_csrs[Secret2Idx] = {2{Locked}};
+    if (lc_provision_wr_en != lc_ctrl_pkg::On) part_access_csrs[Secret2Idx] = {2{Locked}};
   end
 
   //////////////////////

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -3271,7 +3271,7 @@
         {
           struct: lc_tx
           type: uni
-          name: lc_provision_en
+          name: lc_provision_wr_en
           act: rcv
           default: lc_ctrl_pkg::Off
           package: lc_ctrl_pkg
@@ -7934,7 +7934,7 @@
       {
         struct: lc_tx
         type: uni
-        name: lc_provision_en
+        name: lc_provision_wr_en
         act: rcv
         default: lc_ctrl_pkg::Off
         package: lc_ctrl_pkg

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -1160,7 +1160,7 @@ module top_earlgrey #(
       .lc_otp_token_o(),
       .otp_lc_data_o(),
       .lc_escalate_en_i(lc_ctrl_pkg::Off),
-      .lc_provision_en_i(lc_ctrl_pkg::Off),
+      .lc_provision_wr_en_i(lc_ctrl_pkg::Off),
       .lc_dft_en_i(lc_ctrl_pkg::Off),
       .otp_keymgr_key_o(),
       .flash_otp_key_i('0),


### PR DESCRIPTION
In particular, this introduces the following updates

- Put a link into the life cycle architecture document that points to the life cycle controller technical specification.
- Update the life cycle signals table and add new signals that where missing.
- Update the documentation to reflect that the LC_PROVISION signal is now split into LC_PROVISION_WR_EN and LC_PROVISION_RD_EN. 
- Propagate the interface change to the OTP controller and the top-level.