### PR TITLE
[dv] Move sim_tops to {tool}.hjson

### DIFF
--- a/hw/dv/tools/dvsim/common_sim_cfg.hjson
+++ b/hw/dv/tools/dvsim/common_sim_cfg.hjson
@@ -53,12 +53,10 @@
   dut_instance: "{tb}.dut"
 
   // Top level simulation entities.
-  sim_tops: ["-top {tb}"]
+  sim_tops: ["{tb}"]
 
   // Default build and run opts
-  build_opts: [// List multiple tops for the simulation
-               "{sim_tops}",
-               // Standard UVM defines
+  build_opts: [// Standard UVM defines
                "+define+UVM",
                "+define+UVM_NO_DEPRECATED",
                "+define+UVM_REGEX_NO_DPI",
@@ -104,7 +102,7 @@
   // By default, two regressions are made available - "all" and "nightly". Both
   // run all available tests for the DUT. "nightly" enables coverage as well.
   // The 'tests' key is set to an empty list, which indicates "run everything".
-  // Test sets can enable sim modes, which are a set of build_opts and run_opts
+  // Regressions can enable sim modes, which are a set of build_opts and run_opts
   // that are grouped together. These are appended to the build modes used by the
   // tests.
   regressions: [

--- a/hw/dv/tools/dvsim/dsim.hjson
+++ b/hw/dv/tools/dvsim/dsim.hjson
@@ -23,6 +23,8 @@
                "-c-opts -I{DSIM_HOME}/include",
                "-timescale 1ns/1ps",
                "-f {sv_flist}",
+               // List multiple tops for the simulation. Prepend each top level with `-top`.
+               "{eval_cmd} echo {sim_tops} | sed -E 's/(\\S+)/-top \\1/g'",
                "+incdir+{build_dir}",
                // Suppress following DSim errors and warnings:
                //   EnumMustBePositive - UVM 1.2 violates this
@@ -89,8 +91,8 @@
   cov_metrics: ""
 
   // pass and fail patterns
-  build_fail_patterns: ["^Error-.*$"]
-  run_fail_patterns:   ["^Error-.*$"] // Null pointer error
+  build_fail_patterns: ["^=E:"]
+  run_fail_patterns:   ["^=E:"]
 
   // waveform
   probe_file: "dsim.probe"

--- a/hw/dv/tools/dvsim/riviera.hjson
+++ b/hw/dv/tools/dvsim/riviera.hjson
@@ -12,7 +12,10 @@
   build_opts: ["-sv",
                "-timescale 1ns/1ps",
                "-uvmver 1.2",
-               "-f {sv_flist}"]
+               "-f {sv_flist}",
+               // List multiple tops for the simulation. Prepend each top level with `-top`.
+               "{eval_cmd} echo {sim_tops} | sed -E 's/(\\S+)/-top \\1/g'",
+              ]
 
   run_opts:   ["-sv_seed={seed}",
                "-c",

--- a/hw/dv/tools/dvsim/vcs.hjson
+++ b/hw/dv/tools/dvsim/vcs.hjson
@@ -15,6 +15,8 @@
                "-Mdir={build_ex}.csrc",
                "-o {build_ex}",
                "-f {sv_flist}",
+               // List multiple tops for the simulation. Prepend each top level with `-top`.
+               "{eval_cmd} echo {sim_tops} | sed -E 's/(\\S+)/-top \\1/g'",
                "+incdir+{build_dir}",
                // Turn on warnings for non-void functions called with return values ignored
                "+warn=SV-NFIVC",
@@ -132,10 +134,7 @@
                      "-parallel",
                      "-parallel_split 20",
                      // Use cov_db_dirs var for dir args; append -dir in front of each
-                     '''{eval_cmd} dirs=`echo {cov_db_dirs}`; dir_args=; \
-                     for d in $dirs; do dir_args="$dir_args -dir $d"; done; \
-                     echo $dir_args
-                     ''',
+                     "{eval_cmd} echo {cov_db_dirs} | sed -E 's/(\\S+)/-dir \\1/g'",
                      "-dbname {cov_merge_db_dir}"]
 
   // Generate coverage reports in text as well as html.

--- a/hw/dv/tools/dvsim/xcelium.hjson
+++ b/hw/dv/tools/dvsim/xcelium.hjson
@@ -18,6 +18,8 @@
                "-f {sv_flist}",
                "-uvmhome CDNS-1.2",
                "-xmlibdirname {build_dir}/xcelium.d",
+               // List multiple tops for the simulation. Prepend each top level with `-top`.
+               "{eval_cmd} echo {sim_tops} | sed -E 's/(\\S+)/-top \\1/g'",
                // for uvm_hdl_* used by csr backdoor
                "-access +rw",
                // Use this to conditionally compile for Xcelium (example: LRM interpretations differ

--- a/hw/ip/aes/dv/aes_sim_cfg.hjson
+++ b/hw/ip/aes/dv/aes_sim_cfg.hjson
@@ -37,7 +37,7 @@
                 // "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
 
   // Add additional tops for simulation.
-  sim_tops: ["-top aes_bind"]
+  sim_tops: ["aes_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50

--- a/hw/ip/alert_handler/dv/alert_handler_generic_sim_cfg.hjson
+++ b/hw/ip/alert_handler/dv/alert_handler_generic_sim_cfg.hjson
@@ -30,7 +30,7 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
 
   // Add additional tops for simulation.
-  sim_tops: ["-top alert_handler_bind"]
+  sim_tops: ["alert_handler_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50

--- a/hw/ip/csrng/dv/csrng_sim_cfg.hjson
+++ b/hw/ip/csrng/dv/csrng_sim_cfg.hjson
@@ -35,7 +35,7 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
 
   // Add additional tops for simulation.
-  sim_tops: ["-top csrng_bind"]
+  sim_tops: ["csrng_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50

--- a/hw/ip/edn/dv/edn_sim_cfg.hjson
+++ b/hw/ip/edn/dv/edn_sim_cfg.hjson
@@ -35,7 +35,7 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
 
   // Add additional tops for simulation.
-  sim_tops: ["-top edn_bind"]
+  sim_tops: ["edn_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50

--- a/hw/ip/entropy_src/dv/entropy_src_sim_cfg.hjson
+++ b/hw/ip/entropy_src/dv/entropy_src_sim_cfg.hjson
@@ -35,7 +35,7 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
 
   // Add additional tops for simulation.
-  sim_tops: ["-top entropy_src_bind"]
+  sim_tops: ["entropy_src_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50

--- a/hw/ip/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson
@@ -39,7 +39,7 @@
   ]
 
   // Add additional tops for simulation.
-  sim_tops: ["-top flash_ctrl_bind"]
+  sim_tops: ["flash_ctrl_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50

--- a/hw/ip/gpio/dv/gpio_sim_cfg.hjson
+++ b/hw/ip/gpio/dv/gpio_sim_cfg.hjson
@@ -33,7 +33,7 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
 
   // Add additional tops for simulation.
-  sim_tops: ["-top gpio_bind"]
+  sim_tops: ["gpio_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50

--- a/hw/ip/hmac/dv/hmac_sim_cfg.hjson
+++ b/hw/ip/hmac/dv/hmac_sim_cfg.hjson
@@ -33,7 +33,7 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
 
   // Add additional tops for simulation.
-  sim_tops: ["-top hmac_bind"]
+  sim_tops: ["hmac_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -34,7 +34,7 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson"]
 
   // Add additional tops for simulation.
-  sim_tops: ["-top i2c_bind"]
+  sim_tops: ["i2c_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50

--- a/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson
+++ b/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson
@@ -38,7 +38,7 @@
                 ]
 
   // Add additional tops for simulation.
-  sim_tops: ["-top keymgr_bind"]
+  sim_tops: ["keymgr_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50

--- a/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
+++ b/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
@@ -33,7 +33,7 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
 
   // Add additional tops for simulation.
-  sim_tops: ["-top kmac_bind"]
+  sim_tops: ["kmac_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50

--- a/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
+++ b/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
@@ -40,7 +40,7 @@ name:
   en_build_modes: ["{tool}_otbn_memutil_build_opts"]
 
   // Add additional tops for simulation.
-  sim_tops: ["-top otbn_bind"]
+  sim_tops: ["otbn_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   //

--- a/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -37,7 +37,7 @@
                 //"{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
 
   // Add additional tops for simulation.
-  sim_tops: ["-top otp_ctrl_bind"]
+  sim_tops: ["otp_ctrl_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50

--- a/hw/ip/pattgen/dv/pattgen_sim_cfg.hjson
+++ b/hw/ip/pattgen/dv/pattgen_sim_cfg.hjson
@@ -35,7 +35,7 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson"]
 
   // Add additional tops for simulation.
-  sim_tops: ["-top pattgen_bind"]
+  sim_tops: ["pattgen_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50

--- a/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
+++ b/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
@@ -35,7 +35,7 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
 
   // Add additional tops for simulation.
-  sim_tops: ["-top rv_dm_bind"]
+  sim_tops: ["rv_dm_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50

--- a/hw/ip/rv_timer/dv/rv_timer_sim_cfg.hjson
+++ b/hw/ip/rv_timer/dv/rv_timer_sim_cfg.hjson
@@ -33,7 +33,7 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
 
   // Add additional tops for simulation.
-  sim_tops: ["-top rv_timer_bind"]
+  sim_tops: ["rv_timer_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50

--- a/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson
+++ b/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson
@@ -35,7 +35,7 @@
                 ]
 
   // Add additional tops for simulation.
-  sim_tops: ["-top spi_device_bind"]
+  sim_tops: ["spi_device_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50

--- a/hw/ip/tlul/generic_dv/xbar_sim_cfg.hjson
+++ b/hw/ip/tlul/generic_dv/xbar_sim_cfg.hjson
@@ -32,7 +32,7 @@
                 "{proj_root}/hw/ip/tlul/generic_dv/xbar_tests.hjson"]
 
   // Add additional tops for simulation.
-  sim_tops: ["-top {dut}_bind"]
+  sim_tops: ["{dut}_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50

--- a/hw/ip/uart/dv/uart_sim_cfg.hjson
+++ b/hw/ip/uart/dv/uart_sim_cfg.hjson
@@ -33,7 +33,7 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
 
   // Add additional tops for simulation.
-  sim_tops: ["-top uart_bind", "-top uart_cov_bind"]
+  sim_tops: ["uart_bind", "uart_cov_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -34,7 +34,7 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
 
   // Add additional tops for simulation.
-  sim_tops: ["-top usbdev_bind"]
+  sim_tops: ["usbdev_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -24,8 +24,8 @@
   ral_spec: "{proj_root}/hw/top_earlgrey/data/top_earlgrey.hjson"
 
   // Add additional tops for simulation.
-  sim_tops: ["-top xbar_main_bind",
-             "-top xbar_peri_bind"]
+  sim_tops: ["xbar_main_bind",
+             "xbar_peri_bind"]
 
   // Import additional common sim cfg files.
   import_cfgs: [// Project wide common sim cfg file

--- a/util/uvmdvgen/sim_cfg.hjson.tpl
+++ b/util/uvmdvgen/sim_cfg.hjson.tpl
@@ -50,7 +50,7 @@
 % endif
 
   // Add additional tops for simulation.
-  sim_tops: ["-top ${name}_bind"]
+  sim_tops: ["${name}_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50


### PR DESCRIPTION
Fixes #4340. 

This change factors `sim_tops` out of `common_sim_cfg.hjson` in favor of being placed in `{tool}.hjson` instead. This is done to support Questa (support for which will be added soon). 

The first commit fixes a bug in DVSim (prevent `${..}` constuct from being treated as a substitution var). 

The second moves `sim_tops` expansion out of the common hjson and moves it into individual tool-specific hjson. How tops are to be specified is also changed - there is no need to add `-top` prefix to each top level. This is factored in the tool hjson already.