### PR TITLE
[lc_ctrl] Make mutex claim register a multibit signal

### DIFF
--- a/hw/ip/lc_ctrl/data/lc_ctrl.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl.hjson
@@ -297,17 +297,15 @@
       hwaccess: "hrw",
       hwqe:     "true",
       hwext:    "true",
-      tags: [ // life cycle internal HW will set this enable register to 1 only when the hardware mutex
-              // claim was successful, which can cause readback failures when writing randomly
-              // to this register.
+      tags: [ // this register is only writable if the mutex has not been claimed already.
               "excl:CsrNonInitTests:CsrExclCheck"],
       fields: [
-        { bits: "0",
+        { bits: "7:0",
           name: "START",
           desc: '''
           In order to have exclusive access to the transition interface, SW must first claim the associated
-          hardware mutex by writing 1 to this register.
-          If the register reads back 1, the mutex claim has been successful, and !!TRANSITION_REGWEN
+          hardware mutex by writing 0xA5 to this register.
+          If the register reads back 0xA5, the mutex claim has been successful, and !!TRANSITION_REGWEN
           will be set automatically to 1 by HW.
           Write 0 to this register in order to release the HW mutex.
           '''
@@ -321,8 +319,8 @@
       swaccess: "ro",
       hwaccess: "hwo",
       hwext:    "true",
-      tags: [ // life cycle internal HW will set this enable register to 0 when the life cycle controller
-              // is busy and not ready to accept a transition command.
+      tags: [ // life cycle internal HW will set this enable register to 0 when the hardware mutex has not been claimed or
+              // when the life cycle controller is busy and not ready to accept a transition command.
               "excl:CsrNonInitTests:CsrExclCheck"],
       fields: [
         {

--- a/hw/ip/lc_ctrl/doc/_index.md
+++ b/hw/ip/lc_ctrl/doc/_index.md
@@ -349,8 +349,8 @@ See diagram below
 
 #### Hardware Mutex
 
-In order to claim the hardware mutex, a non-zero value must be written to the claim register ({{< regref "CLAIM_TRANSITION_IF" >}}).
-If the value written is read back, then the mutex is claimed, and the interface that won arbitration can continue operations.
+In order to claim the hardware mutex, the value 0xA5 must be written to the claim register ({{< regref "CLAIM_TRANSITION_IF" >}}).
+If the register reads back as 0xA5, then the mutex is claimed, and the interface that won arbitration can continue operations.
 If the value is not read back, then the requesting interface should wait and try again later.
 
 When an agent is done with the mutex, it releases the mutex by explicitly writing a 0 to the claim register.

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
@@ -200,8 +200,8 @@ module lc_ctrl
   logic          flash_rma_error_d, flash_rma_error_q;
   logic          otp_prog_error_d, otp_prog_error_q;
   logic          state_invalid_error_d, state_invalid_error_q;
-  logic          sw_claim_transition_if_d, sw_claim_transition_if_q;
-  logic          tap_claim_transition_if_d, tap_claim_transition_if_q;
+  logic [7:0]    sw_claim_transition_if_d, sw_claim_transition_if_q;
+  logic [7:0]    tap_claim_transition_if_d, tap_claim_transition_if_q;
   logic          transition_cmd;
   lc_token_t     transition_token_d, transition_token_q;
   dec_lc_state_e transition_target_d, transition_target_q;
@@ -231,13 +231,13 @@ module lc_ctrl
 
     // Assignments gated by mutex.
     hw2reg.claim_transition_if = sw_claim_transition_if_q;
-    if (sw_claim_transition_if_q) begin
+    if (sw_claim_transition_if_q == 8'hA5) begin
       hw2reg.transition_token  = transition_token_q;
       hw2reg.transition_target = transition_target_q;
     end
 
     tap_hw2reg.claim_transition_if = tap_claim_transition_if_q;
-    if (tap_claim_transition_if_q) begin
+    if (tap_claim_transition_if_q == 8'hA5) begin
       tap_hw2reg.transition_token  = transition_token_q;
       tap_hw2reg.transition_target = transition_target_q;
     end
@@ -251,19 +251,19 @@ module lc_ctrl
     transition_cmd            = 1'b0;
 
     // SW mutex claim.
-    if (!tap_claim_transition_if_q &&
+    if (tap_claim_transition_if_q != 8'hA5 &&
         reg2hw.claim_transition_if.qe) begin
       sw_claim_transition_if_d = reg2hw.claim_transition_if.q;
     end
     // TAP mutex claim. This has prio over SW above.
-    if (!sw_claim_transition_if_q &&
+    if (sw_claim_transition_if_q != 8'hA5 &&
         tap_reg2hw.claim_transition_if.qe) begin
       tap_claim_transition_if_d = tap_reg2hw.claim_transition_if.q;
     end
 
     // The idle signal serves as the REGWEN in this case.
     if (lc_idle_d) begin
-      if (tap_claim_transition_if_q) begin
+      if (tap_claim_transition_if_q == 8'hA5) begin
         transition_cmd = tap_reg2hw.transition_cmd.q &
                          tap_reg2hw.transition_cmd.qe;
 
@@ -276,7 +276,7 @@ module lc_ctrl
         if (tap_reg2hw.transition_target.qe) begin
           transition_target_d = tap_reg2hw.transition_target.q;
         end
-      end else if (sw_claim_transition_if_q) begin
+      end else if (sw_claim_transition_if_q == 8'hA5) begin
         transition_cmd = reg2hw.transition_cmd.q &
                          reg2hw.transition_cmd.qe;
 

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_pkg.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_pkg.sv
@@ -28,7 +28,7 @@ package lc_ctrl_reg_pkg;
   } lc_ctrl_reg2hw_alert_test_reg_t;
 
   typedef struct packed {
-    logic        q;
+    logic [7:0]  q;
     logic        qe;
   } lc_ctrl_reg2hw_claim_transition_if_reg_t;
 
@@ -76,7 +76,7 @@ package lc_ctrl_reg_pkg;
   } lc_ctrl_hw2reg_status_reg_t;
 
   typedef struct packed {
-    logic        d;
+    logic [7:0]  d;
   } lc_ctrl_hw2reg_claim_transition_if_reg_t;
 
   typedef struct packed {
@@ -108,8 +108,8 @@ package lc_ctrl_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    lc_ctrl_reg2hw_alert_test_reg_t alert_test; // [144:141]
-    lc_ctrl_reg2hw_claim_transition_if_reg_t claim_transition_if; // [140:139]
+    lc_ctrl_reg2hw_alert_test_reg_t alert_test; // [151:148]
+    lc_ctrl_reg2hw_claim_transition_if_reg_t claim_transition_if; // [147:139]
     lc_ctrl_reg2hw_transition_cmd_reg_t transition_cmd; // [138:137]
     lc_ctrl_reg2hw_transition_token_mreg_t [3:0] transition_token; // [136:5]
     lc_ctrl_reg2hw_transition_target_reg_t transition_target; // [4:0]
@@ -119,8 +119,8 @@ package lc_ctrl_reg_pkg;
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    lc_ctrl_hw2reg_status_reg_t status; // [152:153]
-    lc_ctrl_hw2reg_claim_transition_if_reg_t claim_transition_if; // [152:151]
+    lc_ctrl_hw2reg_status_reg_t status; // [159:160]
+    lc_ctrl_hw2reg_claim_transition_if_reg_t claim_transition_if; // [159:151]
     lc_ctrl_hw2reg_transition_regwen_reg_t transition_regwen; // [150:151]
     lc_ctrl_hw2reg_transition_token_mreg_t [3:0] transition_token; // [150:23]
     lc_ctrl_hw2reg_transition_target_reg_t transition_target; // [22:18]

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_top.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_top.sv
@@ -91,8 +91,8 @@ module lc_ctrl_reg_top (
   logic status_otp_error_re;
   logic status_state_error_qs;
   logic status_state_error_re;
-  logic claim_transition_if_qs;
-  logic claim_transition_if_wd;
+  logic [7:0] claim_transition_if_qs;
+  logic [7:0] claim_transition_if_wd;
   logic claim_transition_if_we;
   logic claim_transition_if_re;
   logic transition_regwen_qs;
@@ -284,7 +284,7 @@ module lc_ctrl_reg_top (
   // R[claim_transition_if]: V(True)
 
   prim_subreg_ext #(
-    .DW    (1)
+    .DW    (8)
   ) u_claim_transition_if (
     .re     (claim_transition_if_re),
     .we     (claim_transition_if_we),
@@ -528,7 +528,7 @@ module lc_ctrl_reg_top (
   assign status_state_error_re = addr_hit[1] && reg_re;
 
   assign claim_transition_if_we = addr_hit[2] & reg_we & ~wr_err;
-  assign claim_transition_if_wd = reg_wdata[0];
+  assign claim_transition_if_wd = reg_wdata[7:0];
   assign claim_transition_if_re = addr_hit[2] && reg_re;
 
   assign transition_regwen_re = addr_hit[3] && reg_re;
@@ -583,7 +583,7 @@ module lc_ctrl_reg_top (
       end
 
       addr_hit[2]: begin
-        reg_rdata_next[0] = claim_transition_if_qs;
+        reg_rdata_next[7:0] = claim_transition_if_qs;
       end
 
       addr_hit[3]: begin


### PR DESCRIPTION
Make the mutex claim register multibit to reduce the probability that spurious / erroneous writes can initiate a life cycle transition.

Signed-off-by: Michael Schaffner <msf@opentitan.org>