### PR TITLE
[otbn] Add DIF functions to documentation 

### DIFF
--- a/hw/ip/otbn/doc/_index.md
+++ b/hw/ip/otbn/doc/_index.md
@@ -432,6 +432,10 @@ Rough expected process:
   To be filled in as we create the implementation.
 </div>
 
+## Device Interface Functions (DIFs)
+
+{{< dif_listing "sw/device/lib/dif/dif_otbn.h" >}}
+
 ## Register Table
 
 {{< registers "hw/ip/otbn/data/otbn.hjson" >}}


### PR DESCRIPTION
Add the public DIF functions to the docs. 

Thanks @lenary for the nice tooling to make this a one-liner!

![grafik](https://user-images.githubusercontent.com/1467123/100856486-6385b800-3483-11eb-9c5e-a0a006b28db0.png)
