### PR TITLE
[otbn] Conflate correctable/uncorrectable ECC errors

### DIFF
--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -27,7 +27,8 @@ module otbn_top_sim (
   logic [ImemAddrWidth-1:0] imem_addr;
   logic [31:0]              imem_rdata;
   logic                     imem_rvalid;
-  logic [1:0]               imem_rerror;
+  logic [1:0]               imem_rerror_raw;
+  logic                     imem_rerror;
 
   // Data memory (DMEM) signals
   logic                     dmem_req;
@@ -37,8 +38,8 @@ module otbn_top_sim (
   logic [WLEN-1:0]          dmem_wmask;
   logic [WLEN-1:0]          dmem_rdata;
   logic                     dmem_rvalid;
-  logic [1:0]               dmem_rerror;
-
+  logic [1:0]               dmem_rerror_raw;
+  logic                     dmem_rerror;
 
   otbn_core #(
     .ImemSizeByte ( ImemSizeByte ),
@@ -102,18 +103,20 @@ module otbn_top_sim (
     .DataBitsPerMask ( 32            ),
     .CfgW            ( 8             )
   ) u_dmem (
-    .clk_i    ( IO_CLK      ),
-    .rst_ni   ( IO_RST_N    ),
-    .req_i    ( dmem_req    ),
-    .write_i  ( dmem_write  ),
-    .addr_i   ( dmem_index  ),
-    .wdata_i  ( dmem_wdata  ),
-    .wmask_i  ( dmem_wmask  ),
-    .rdata_o  ( dmem_rdata  ),
-    .rvalid_o ( dmem_rvalid ),
-    .rerror_o ( dmem_rerror ),
-    .cfg_i    ( '0          )
+    .clk_i    ( IO_CLK          ),
+    .rst_ni   ( IO_RST_N        ),
+    .req_i    ( dmem_req        ),
+    .write_i  ( dmem_write      ),
+    .addr_i   ( dmem_index      ),
+    .wdata_i  ( dmem_wdata      ),
+    .wmask_i  ( dmem_wmask      ),
+    .rdata_o  ( dmem_rdata      ),
+    .rvalid_o ( dmem_rvalid     ),
+    .rerror_o ( dmem_rerror_raw ),
+    .cfg_i    ( '0              )
   );
+
+  assign dmem_rerror = |dmem_rerror_raw;
 
   localparam int ImemSizeWords = ImemSizeByte / 4;
   localparam int ImemIndexWidth = prim_util_pkg::vbits(ImemSizeWords);
@@ -130,19 +133,20 @@ module otbn_top_sim (
     .DataBitsPerMask ( 32            ),
     .CfgW            ( 8             )
   ) u_imem (
-    .clk_i    ( IO_CLK      ),
-    .rst_ni   ( IO_RST_N    ),
-    .req_i    ( imem_req    ),
-    .write_i  ( 1'b0        ),
-    .addr_i   ( imem_index  ),
-    .wdata_i  ( '0          ),
-    .wmask_i  ( '0          ),
-    .rdata_o  ( imem_rdata  ),
-    .rvalid_o ( imem_rvalid ),
-    .rerror_o ( imem_rerror ),
-    .cfg_i    ( '0          )
+    .clk_i    ( IO_CLK          ),
+    .rst_ni   ( IO_RST_N        ),
+    .req_i    ( imem_req        ),
+    .write_i  ( 1'b0            ),
+    .addr_i   ( imem_index      ),
+    .wdata_i  ( '0              ),
+    .wmask_i  ( '0              ),
+    .rdata_o  ( imem_rdata      ),
+    .rvalid_o ( imem_rvalid     ),
+    .rerror_o ( imem_rerror_raw ),
+    .cfg_i    ( '0              )
   );
 
+  assign imem_rerror = |imem_rerror_raw;
 
   // When OTBN is done let a few more cycles run then finish simulation
   logic [1:0] finish_counter;

--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -90,7 +90,7 @@ module otbn_controller
 
   input  logic [31:0]              lsu_base_rdata_i,
   input  logic [WLEN-1:0]          lsu_bignum_rdata_i,
-  input  logic [1:0]               lsu_rdata_err_i, // Bit1: Uncorrectable, Bit0: Correctable
+  input  logic                     lsu_rdata_err_i,
 
   // Internal Special-Purpose Registers (ISPRs)
   output ispr_e                       ispr_addr_o,
@@ -570,7 +570,7 @@ module otbn_controller
   assign unused_rf_ren_b_bignum = insn_dec_bignum_i.rf_ren_b;
 
   // TODO: Implement error handling
-  logic [1:0] unused_lsu_rdata_err;
+  logic unused_lsu_rdata_err;
   assign unused_lsu_rdata_err = lsu_rdata_err_i;
 
   // Unused for now, may be used in later security hardening work

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -37,7 +37,7 @@ module otbn_core
   output logic [31:0]              imem_wdata_o,
   input  logic [31:0]              imem_rdata_i,
   input  logic                     imem_rvalid_i,
-  input  logic [1:0]               imem_rerror_i,
+  input  logic                     imem_rerror_i,
 
   // Data memory (DMEM)
   output logic                     dmem_req_o,
@@ -47,7 +47,7 @@ module otbn_core
   output logic [WLEN-1:0]          dmem_wmask_o,
   input  logic [WLEN-1:0]          dmem_rdata_i,
   input  logic                     dmem_rvalid_i,
-  input  logic [1:0]               dmem_rerror_i
+  input  logic                     dmem_rerror_i
 );
   // Random number
   // TODO: Hook up to RNG distribution network
@@ -102,7 +102,7 @@ module otbn_core
 
   logic [31:0]              lsu_base_rdata;
   logic [WLEN-1:0]          lsu_bignum_rdata;
-  logic [1:0]               lsu_rdata_err; // Bit1: Uncorrectable, Bit0: Correctable
+  logic                     lsu_rdata_err;
 
   logic [WdrAw-1:0] rf_bignum_wr_addr;
   logic [1:0]       rf_bignum_wr_en;

--- a/hw/ip/otbn/rtl/otbn_instruction_fetch.sv
+++ b/hw/ip/otbn/rtl/otbn_instruction_fetch.sv
@@ -24,7 +24,7 @@ module otbn_instruction_fetch
   output logic [ImemAddrWidth-1:0] imem_addr_o,
   input  logic [31:0]              imem_rdata_i,
   input  logic                     imem_rvalid_i,
-  input  logic [1:0]               imem_rerror_i, // Bit1: Uncorrectable, Bit0: Correctable
+  input  logic                     imem_rerror_i,
 
   // Next instruction selection (to instruction fetch)
   input  logic                     insn_fetch_req_valid_i,
@@ -48,7 +48,7 @@ module otbn_instruction_fetch
 
   // TODO: Need to handle imem_rerror somewhere, which need to be turned into alerts. Could be
   // handled either here or somewhere more up in the hierarchy.
-  logic [1:0] unused_imem_rerror;
+  logic unused_imem_rerror;
   assign unused_imem_rerror = imem_rerror_i;
 
   // Nothing is reset in this module so rst_ni is unused. Leaving it in so adding resettable flops

--- a/hw/ip/otbn/rtl/otbn_lsu.sv
+++ b/hw/ip/otbn/rtl/otbn_lsu.sv
@@ -32,7 +32,7 @@ module otbn_lsu
   output logic [WLEN-1:0]          dmem_wmask_o,
   input  logic [WLEN-1:0]          dmem_rdata_i,
   input  logic                     dmem_rvalid_i,
-  input  logic [1:0]               dmem_rerror_i, // Bit1: Uncorrectable, Bit0: Correctable
+  input  logic                     dmem_rerror_i,
 
   input  logic                     lsu_load_req_i,
   input  logic                     lsu_store_req_i,
@@ -44,7 +44,7 @@ module otbn_lsu
 
   output logic [31:0]              lsu_base_rdata_o,
   output logic [WLEN-1:0]          lsu_bignum_rdata_o,
-  output logic [1:0]               lsu_rdata_err_o // Bit1: Uncorrectable, Bit0: Correctable
+  output logic                     lsu_rdata_err_o
 );
   localparam int BaseWordsPerWLen = WLEN / 32;
   localparam int BaseWordAddrW = prim_util_pkg::vbits(WLEN/8);


### PR DESCRIPTION
We're treating both as a disaster, so there's no need to keep them
separate. Also qualify the alert signal with `imem_rvalid` or
`dmem_rvalid` - the error is only meaningful when the result is valid.
