### PR TITLE
[csrng/checklist] D1 signoff for csrng

### DIFF
--- a/hw/ip/csrng/data/csrng.prj.hjson
+++ b/hw/ip/csrng/data/csrng.prj.hjson
@@ -9,6 +9,6 @@
     hw_checklist:       "hw/ip/csrng/doc/checklist",
     version:            "0.5",
     life_stage:         "L1",
-    design_stage:       "D0",
+    design_stage:       "D1",
     verification_stage: "V0",
 }

--- a/hw/ip/csrng/doc/checklist.md
+++ b/hw/ip/csrng/doc/checklist.md
@@ -16,15 +16,15 @@ All checklist items refer to the content in the [Checklist.]({{< relref "/doc/pr
 
 Type          | Item                           | Resolution  | Note/Collaterals
 --------------|--------------------------------|-------------|------------------
-Documentation | [SPEC_COMPLETE][]              | Not Started | [CSRNG Design Spec]({{<relref "hw/ip/csrng/doc" >}})
-Documentation | [CSR_DEFINED][]                | Not Started |
-RTL           | [CLKRST_CONNECTED][]           | Not Started |
-RTL           | [IP_TOP][]                     | Not Started |
-RTL           | [IP_INSTANTIABLE][]            | Not Started |
-RTL           | [PHYSICAL_MACROS_DEFINED_80][] | Not Started |
-RTL           | [FUNC_IMPLEMENTED][]           | Not Started |
-RTL           | [ASSERT_KNOWN_ADDED][]         | Not Started |
-Code Quality  | [LINT_SETUP][]                 | Not Started |
+Documentation | [SPEC_COMPLETE][]              | Done        | [CSRNG Design Spec]({{<relref "hw/ip/csrng/doc" >}})
+Documentation | [CSR_DEFINED][]                | Done        |
+RTL           | [CLKRST_CONNECTED][]           | Done        |
+RTL           | [IP_TOP][]                     | Done        |
+RTL           | [IP_INSTANTIABLE][]            | Done        |
+RTL           | [PHYSICAL_MACROS_DEFINED_80][] | N/A         |
+RTL           | [FUNC_IMPLEMENTED][]           | Done        |
+RTL           | [ASSERT_KNOWN_ADDED][]         | Done        |
+Code Quality  | [LINT_SETUP][]                 | Done        |
 
 [SPEC_COMPLETE]:              {{<relref "/doc/project/checklist.md#spec_complete" >}}
 [CSR_DEFINED]:                {{<relref "/doc/project/checklist.md#csr_defined" >}}


### PR DESCRIPTION
Updated checklist and prj files for reflect D1 status.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>