### PR TITLE
[otbn] Alter LOOP bodysize encoding

### DIFF
--- a/hw/ip/otbn/data/base-insns.yml
+++ b/hw/ip/otbn/data/base-insns.yml
@@ -439,7 +439,7 @@
       doc: Name of the GPR containing the number of iterations
     - &bodysize-operand
       name: bodysize
-      type: uimm
+      type: uimm+1
       doc: Number of instructions in the loop body
   straight-line: false
   note: &loop-note |

--- a/hw/ip/otbn/rtl/otbn_loop_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_loop_controller.sv
@@ -59,14 +59,14 @@ module otbn_loop_controller
   // Determine end address of incoming loop from LOOP instruction (valid on loop_start_i and
   // specified by loop_bodysize_i and loop_iterations_i).
   if (ImemAddrWidth < 14) begin : g_new_loop_end_addr_small_imem
-    assign new_loop_end_addr = insn_addr_i + {loop_bodysize_i[ImemAddrWidth-3:0], 2'b00};
+    assign new_loop_end_addr = insn_addr_i + {loop_bodysize_i[ImemAddrWidth-3:0], 2'b00} + 'd4;
 
     // ISA has a fixed 12 bits for loop_bodysize. When IMEM size is less than 16 kB (ImemAddrWidth
     // < 14) some of these bits are ignored as a loop body cannot be greater than the IMEM size.
     logic [11:ImemAddrWidth-2] unused_loop_bodysize_bits;
     assign unused_loop_bodysize_bits = loop_bodysize_i[11:ImemAddrWidth-2];
   end else begin : g_new_loop_end_addr_big_imem
-    assign new_loop_end_addr = insn_addr_i + {loop_bodysize_i, 2'b00};
+    assign new_loop_end_addr = insn_addr_i + {loop_bodysize_i, 2'b00} + 'd4;
   end
 
   assign new_loop = '{


### PR DESCRIPTION
The new fixed offset turned out to be a little awkward as it's applied before the shift rather than after (like the PC offset).

I chose it this way as I figured it'd be more useful if we ever wanted to use it, e.g. say you wanted a MULQACC where the possible shifts were 64, 128, 196, 256 this would allow you do it (I tested this case out, looked good in terms of generated docs, binaries and disassembly).