### PR TITLE
[dv/otp] Support SW partition write lock (write digest)

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -33,10 +33,12 @@ package otp_ctrl_env_pkg;
   parameter uint TEST_ACCESS_WINDOW_SIZE = 16 * 4;
 
   // convert byte into TLUL width size
-  parameter uint HW_CFG_ARRAY_SIZE  = HwCfgContentSize / (TL_DW / 8);
-  parameter uint SECRET0_ARRAY_SIZE = (Secret0Size - DIGEST_SIZE) / (TL_DW / 8);
-  parameter uint SECRET1_ARRAY_SIZE = (Secret1Size - DIGEST_SIZE) / (TL_DW / 8);
-  parameter uint SECRET2_ARRAY_SIZE = (Secret2Size - DIGEST_SIZE) / (TL_DW / 8);
+  parameter uint CREATOR_SW_CFG_ARRAY_SIZE = CreatorSwCfgContentSize / (TL_DW / 8);
+  parameter uint OWNER_SW_CFG_ARRAY_SIZE   = OwnerSwCfgContentSize / (TL_DW / 8);
+  parameter uint HW_CFG_ARRAY_SIZE         = HwCfgContentSize / (TL_DW / 8);
+  parameter uint SECRET0_ARRAY_SIZE        = (Secret0Size - DIGEST_SIZE) / (TL_DW / 8);
+  parameter uint SECRET1_ARRAY_SIZE        = (Secret1Size - DIGEST_SIZE) / (TL_DW / 8);
+  parameter uint SECRET2_ARRAY_SIZE        = (Secret2Size - DIGEST_SIZE) / (TL_DW / 8);
 
   // sram rsp data has 1 bit for seed_valid, the rest are for key and nonce
   parameter uint SRAM_DATA_SIZE  = 1 + SramKeyWidth + SramNonceWidth;
@@ -114,8 +116,8 @@ package otp_ctrl_env_pkg;
 
   function automatic bit is_secret(bit [TL_DW-1:0] addr);
     int part_index = get_part_index(addr);
-    if (part_index inside {[Secret0Idx:Secret2Idx]}) return 0;
-    else return 1;
+    if (part_index inside {[Secret0Idx:Secret2Idx]}) return 1;
+    else return 0;
   endfunction
 
   // Resolve an offset within the software window as an offset within the whole otp_ctrl block.

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -81,7 +81,7 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
 
         // check read data
         `DV_CHECK_EQ(wdata0, rdata0, $sformatf("read data0 mismatch at addr %0h", dai_addr))
-        if (!is_secret(dai_addr)) begin
+        if (is_secret(dai_addr)) begin
           `DV_CHECK_EQ(wdata1, rdata1, $sformatf("read data1 mismatch at addr %0h", dai_addr))
         end
 
@@ -102,6 +102,7 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
       // lock HW digests
       `uvm_info(`gfn, "Trigger HW digest calculation", UVM_HIGH)
       cal_hw_digests();
+      write_sw_digests();
       csr_rd_check(.ptr(ral.status), .compare_value(OtpDaiIdle));
       dut_init();
 


### PR DESCRIPTION
This PR has two main changes:
1. Update function `is_secret`. Current is_secret function returns 1
when it is NOT secret partition. This logic is not correct and this PR
fixed it.
2. Support lock SW partitions by using DAI to write digest. Because the
digest check is depend on SW (OTP won't check if the digest is correct),
this PR writes random data to SW partition digests.
Also there is an issue related to this PR #4363, so in this PR, scb only
checks digest_0 for sw partitions.

Signed-off-by: Cindy Chen <chencindy@google.com>