### PR TITLE
[otp_ctrl] fix part_unbuf otp_size_o selection

### DIFF
--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
@@ -286,8 +286,8 @@ module otp_ctrl_part_unbuf
                                                      {tlul_addr_q, 2'b00} >> OtpAddrShift;
   // Request 32bit except in case of the digest.
   assign otp_size_o = (otp_addr_sel == DigestAddr) ?
-                      OtpSizeWidth'(unsigned'(32 / OtpWidth - 1)) :
-                      OtpSizeWidth'(unsigned'(ScrmblBlockWidth / OtpWidth - 1));
+                      OtpSizeWidth'(unsigned'(ScrmblBlockWidth / OtpWidth - 1)) :
+                      OtpSizeWidth'(unsigned'(32 / OtpWidth - 1));
 
   ////////////////
   // Digest Reg //


### PR DESCRIPTION
As Michael suggested in issue https://github.com/lowRISC/opentitan/issues/4363, this PR implemented the fix for
otp_size_o when SW partition uses DAI to write digest.

Signed-off-by: Cindy Chen <chencindy@google.com>