### PR TITLE
[keymgr/dv] Add random vseq

### DIFF
--- a/hw/ip/keymgr/dv/env/keymgr_env.core
+++ b/hw/ip/keymgr/dv/env/keymgr_env.core
@@ -22,6 +22,7 @@ filesets:
       - seq_lib/keymgr_base_vseq.sv: {is_include_file: true}
       - seq_lib/keymgr_common_vseq.sv: {is_include_file: true}
       - seq_lib/keymgr_smoke_vseq.sv: {is_include_file: true}
+      - seq_lib/keymgr_random_vseq.sv: {is_include_file: true}
       - seq_lib/keymgr_op_at_wipe_state_vseq.sv: {is_include_file: true}
       - seq_lib/keymgr_direct_to_disabled_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_base_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_base_vseq.sv
@@ -60,6 +60,9 @@ class keymgr_base_vseq extends cip_base_vseq #(
     // manually clear here since ral is not aware this bet is self-clearing
     ral.control.start.set(1'b0);
 
+    // Add 1 cycle delay for working_state to be updated, which makes scb less complicated
+    cfg.clk_rst_vif.wait_clks(1);
+
     if (do_wait_for_init_done) begin
       csr_spinwait(.ptr(ral.working_state), .exp_data(keymgr_pkg::StInit));
       current_state = keymgr_pkg::StInit;

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_direct_to_disabled_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_direct_to_disabled_vseq.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Issue operation OpDisable in any state and check it enters StDisabled correctly
-class keymgr_direct_to_disabled_vseq extends keymgr_base_vseq;
+class keymgr_direct_to_disabled_vseq extends keymgr_random_vseq;
   `uvm_object_utils(keymgr_direct_to_disabled_vseq)
   `uvm_object_new
 

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_op_at_wipe_state_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_op_at_wipe_state_vseq.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Test advance state and generate output at StWipe state
-class keymgr_op_at_wipe_state_vseq extends keymgr_smoke_vseq;
+class keymgr_op_at_wipe_state_vseq extends keymgr_random_vseq;
   `uvm_object_utils(keymgr_op_at_wipe_state_vseq)
   `uvm_object_new
 

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_random_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_random_vseq.sv
@@ -1,0 +1,72 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Randomize sw control content: version, rom_ext_desc, salt, binding.
+class keymgr_random_vseq extends keymgr_smoke_vseq;
+  `uvm_object_utils(keymgr_random_vseq)
+  `uvm_object_new
+
+  rand bit is_key_version_err;
+
+  constraint is_key_version_err_c {
+    is_key_version_err == 0;
+  }
+
+  task write_random_sw_content();
+    bit [TL_DW-1:0] key_version_val;
+    bit [TL_DW-1:0] max_creator_key_ver_val;
+    bit [TL_DW-1:0] max_owner_int_key_ver_val;
+    bit [TL_DW-1:0] max_owner_key_ver_val;
+    bit [TL_DW-1:0] max_key_ver_val;
+    uvm_reg         csr_update_q[$];
+
+    csr_random_n_add_to_q(ral.software_binding_0, csr_update_q);
+    csr_random_n_add_to_q(ral.software_binding_1, csr_update_q);
+    csr_random_n_add_to_q(ral.software_binding_2, csr_update_q);
+    csr_random_n_add_to_q(ral.software_binding_3, csr_update_q);
+    csr_random_n_add_to_q(ral.salt_0, csr_update_q);
+    csr_random_n_add_to_q(ral.salt_1, csr_update_q);
+    csr_random_n_add_to_q(ral.salt_2, csr_update_q);
+    csr_random_n_add_to_q(ral.salt_3, csr_update_q);
+
+    csr_random_n_add_to_q(ral.max_creator_key_ver, csr_update_q);
+    csr_random_n_add_to_q(ral.max_owner_int_key_ver, csr_update_q);
+    csr_random_n_add_to_q(ral.max_owner_key_ver, csr_update_q);
+
+    csr_random_n_add_to_q(ral.max_creator_key_ver_en, csr_update_q);
+    csr_random_n_add_to_q(ral.max_owner_int_key_ver_en, csr_update_q);
+    csr_random_n_add_to_q(ral.max_owner_key_ver_en, csr_update_q);
+
+    max_creator_key_ver_val   = ral.max_creator_key_ver.get();
+    max_owner_int_key_ver_val = ral.max_owner_int_key_ver.get();
+    max_owner_key_ver_val     = ral.max_owner_key_ver.get();
+    max_key_ver_val = (current_state == keymgr_pkg::StCreatorRootKey)
+        ? max_creator_key_ver_val : (current_state == keymgr_pkg::StOwnerIntKey)
+        ? max_owner_int_key_ver_val : (current_state == keymgr_pkg::StOwnerKey)
+        ? max_owner_key_ver_val : '1;
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(key_version_val,
+                                       !is_key_version_err -> key_version_val <= max_key_ver_val;)
+    csr_update_q.push_back(ral.key_version);
+
+    csr_update_q.shuffle();
+    foreach (csr_update_q[i]) csr_update(csr_update_q[i]);
+  endtask : write_random_sw_content
+
+  task csr_random_n_add_to_q(uvm_reg csr, ref uvm_reg csr_q[$]);
+    `DV_CHECK_RANDOMIZE_FATAL(csr)
+    csr_q.push_back(csr);
+  endtask
+
+  virtual task keymgr_operations(bit advance_state = $urandom_range(0, 1),
+                                 int num_gen_op    = $urandom_range(1, 4),
+                                 bit clr_output    = $urandom_range(0, 1),
+                                 bit wait_done     = 1);
+    if ($urandom_range(0, 1)) begin
+      `uvm_info(`gfn, "Write random SW content", UVM_MEDIUM)
+      write_random_sw_content();
+    end
+    super.keymgr_operations(advance_state, num_gen_op, clr_output, wait_done);
+  endtask : keymgr_operations
+
+endclass : keymgr_random_vseq

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_smoke_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_smoke_vseq.sv
@@ -7,11 +7,6 @@ class keymgr_smoke_vseq extends keymgr_base_vseq;
   `uvm_object_utils(keymgr_smoke_vseq)
   `uvm_object_new
 
-  // test op at StReset
-  constraint do_op_before_init_c {
-    do_op_before_init == 1;
-  }
-
   task body();
     `uvm_info(`gfn, "Key manager smoke check", UVM_HIGH)
     // check operation at StInit state

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_vseq_list.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_vseq_list.sv
@@ -6,4 +6,5 @@
 `include "keymgr_smoke_vseq.sv"
 `include "keymgr_common_vseq.sv"
 //`include "keymgr_op_at_wipe_state_vseq.sv"
+`include "keymgr_random_vseq.sv"
 `include "keymgr_direct_to_disabled_vseq.sv"

--- a/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson
+++ b/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson
@@ -55,6 +55,11 @@
     }
 
     {
+      name: keymgr_random
+      uvm_test_seq: keymgr_random_vseq
+    }
+
+    {
       name: keymgr_op_at_wipe_state
       uvm_test_seq: keymgr_op_at_wipe_state_vseq
       // StWipe only lasts for several cycles, don't add delay during CSR access


### PR DESCRIPTION
Randomize sw control content: version, rom_ext_desc, salt, binding
Change the other seq to extend from ranom_vseq instead of smoke

Signed-off-by: Weicai Yang <weicai@google.com>