### PR TITLE
[otbn] Fix trivial lint warnings

### DIFF
--- a/hw/ip/otbn/rtl/otbn_alu_base.sv
+++ b/hw/ip/otbn/rtl/otbn_alu_base.sv
@@ -45,7 +45,8 @@ module otbn_alu_base
   assign adder_op_b_negate = operation_i.op == AluOpBaseSub;
 
   assign adder_op_a = {operation_i.operand_a, 1'b1};
-  assign adder_op_b = adder_op_b_negate ? {~operation_i.operand_b, 1'b1} : {operation_i.operand_b, 1'b0};
+  assign adder_op_b = adder_op_b_negate ? {~operation_i.operand_b, 1'b1} :
+                                          { operation_i.operand_b, 1'b0};
 
   assign adder_result = adder_op_a + adder_op_b;
 
@@ -77,7 +78,8 @@ module otbn_alu_base
   // Shifter performs right arithmetic 33-bit shifts. Force top bit to 0 to get logical shifting
   // otherwise replicate top bit of shift_in. Left shifts performed by reversing the input and
   // output.
-  assign shift_in[31:0] = (operation_i.op == AluOpBaseSll) ? operand_a_reverse : operation_i.operand_a;
+  assign shift_in[31:0] = (operation_i.op == AluOpBaseSll) ? operand_a_reverse :
+                                                             operation_i.operand_a;
   assign shift_in[32] = (operation_i.op == AluOpBaseSra) ? operation_i.operand_a[31] : 1'b0;
 
   assign shift_out = signed'(shift_in) >>> shift_amt;

--- a/hw/ip/otbn/rtl/otbn_alu_bignum.sv
+++ b/hw/ip/otbn/rtl/otbn_alu_bignum.sv
@@ -245,7 +245,8 @@ module otbn_alu_bignum
 
   assign adder_x_res = adder_x_op_a + adder_x_op_b;
 
-  assign x_res_operand_a_mux_out = x_res_operand_a_sel ? adder_x_res[WLEN:1] : operation_i.operand_a;
+  assign x_res_operand_a_mux_out = x_res_operand_a_sel ? adder_x_res[WLEN:1] :
+                                                         operation_i.operand_a;
   assign shift_mod_mux_out = shift_mod_sel ? shifter_res : mod_q;
 
   assign adder_y_op_a = {x_res_operand_a_mux_out, 1'b1};
@@ -406,7 +407,8 @@ module otbn_alu_bignum
     endcase
   end
 
-  `ASSERT(SelFlagValid, operation_i.op == AluOpBignumSel |-> operation_i.sel_flag inside {FlagC, FlagL, FlagM, FlagZ})
+  `ASSERT(SelFlagValid,
+      operation_i.op == AluOpBignumSel |-> operation_i.sel_flag inside {FlagC, FlagL, FlagM, FlagZ})
 
   assign sel_res = (sel_flag || operation_i.op == AluOpBignumMov) ? operation_i.operand_a :
                                                                     operation_i.operand_b;

--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -172,8 +172,9 @@ module otbn_controller
 
   // Branch taken when there is a valid branch instruction and comparison passes or a valid jump
   // instruction (which is always taken)
-  assign branch_taken = insn_valid_i & ((insn_dec_shared_i.branch_insn & alu_base_comparison_result_i) |
-                                        insn_dec_shared_i.jump_insn);
+  assign branch_taken = insn_valid_i &
+                        ((insn_dec_shared_i.branch_insn & alu_base_comparison_result_i) |
+                         insn_dec_shared_i.jump_insn);
   // Branch target computed by base ALU (PC + imm)
   // TODO: Implement error on branch out of range
   assign branch_target = alu_base_operation_result_i[ImemAddrWidth-1:0];
@@ -228,10 +229,11 @@ module otbn_controller
     endcase
   end
 
-  `ASSERT(ControllerStateValid, state_q inside {OtbnStateHalt, OtbnStateRun, OtbnStateStall});
+  `ASSERT(ControllerStateValid, state_q inside {OtbnStateHalt, OtbnStateRun, OtbnStateStall})
   // Branch only takes effect in OtbnStateRun so must not go into stall state for branch
   // instructions.
-  `ASSERT(NoStallOnBranch, insn_valid_i & insn_dec_shared_i.branch_insn |-> state_q != OtbnStateStall);
+  `ASSERT(NoStallOnBranch,
+      insn_valid_i & insn_dec_shared_i.branch_insn |-> state_q != OtbnStateStall)
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
@@ -430,15 +432,15 @@ module otbn_controller
                                                                  insn_dec_bignum_i.d;
 
   // For the shift-out variant of BN.MULQACC the bottom half of the MAC result is written to one
-  // half of a desintation register specified by the instruction (mac_wr_hw_sel_upper). The bottom half of
-  // the MAC result must be placed in the appropriate half of the write data (the RF only accepts
-  // write data for the top half in the top half of the write data input). Otherwise (shift-out to
-  // bottom half and all other BN.MULQACC instructions) simply pass the MAC result through unchanged
-  // as write data.
+  // half of a desintation register specified by the instruction (mac_wr_hw_sel_upper). The bottom
+  // half of the MAC result must be placed in the appropriate half of the write data (the RF only
+  // accepts write data for the top half in the top half of the write data input). Otherwise
+  // (shift-out to bottom half and all other BN.MULQACC instructions) simply pass the MAC result
+  // through unchanged as write data.
   assign mac_bignum_rf_wr_data[WLEN-1:WLEN/2] =
-    insn_dec_bignum_i.mac_wr_hw_sel_upper &&
-    insn_dec_bignum_i.mac_shift_out         ? mac_bignum_operation_result_i[WLEN/2-1:0] :
-                                              mac_bignum_operation_result_i[WLEN-1:WLEN/2];
+      insn_dec_bignum_i.mac_wr_hw_sel_upper &&
+      insn_dec_bignum_i.mac_shift_out          ? mac_bignum_operation_result_i[WLEN/2-1:0] :
+                                                 mac_bignum_operation_result_i[WLEN-1:WLEN/2];
 
   assign mac_bignum_rf_wr_data[WLEN/2-1:0] = mac_bignum_operation_result_i[WLEN/2-1:0];
 
@@ -486,7 +488,8 @@ module otbn_controller
 
   for (genvar i_bit = 0; i_bit < 32; i_bit++) begin : g_csr_rdata_mux
     for (genvar i_word = 0; i_word < BaseWordsPerWLEN; i_word++) begin : g_csr_rdata_mux_inner
-      assign csr_rdata_mux[i_bit][i_word] = ispr_rdata_i[i_word*32 + i_bit] & ispr_word_sel_base[i_word];
+      assign csr_rdata_mux[i_bit][i_word] =
+          ispr_rdata_i[i_word*32 + i_bit] & ispr_word_sel_base[i_word];
     end
 
     assign csr_rdata_raw[i_bit] = |csr_rdata_mux[i_bit];
@@ -504,7 +507,8 @@ module otbn_controller
     endcase
   end
 
-  assign csr_wdata_raw = insn_dec_shared_i.ispr_rs_insn ? csr_rdata | rf_base_rd_data_a_i : rf_base_rd_data_a_i;
+  assign csr_wdata_raw = insn_dec_shared_i.ispr_rs_insn ? csr_rdata | rf_base_rd_data_a_i :
+                                                          rf_base_rd_data_a_i;
 
   // Specialised write data handling for CSR writes where raw write data needs modification.
   always_comb begin
@@ -538,11 +542,13 @@ module otbn_controller
     endcase
   end
 
-  assign wsr_wdata = insn_dec_shared_i.ispr_rs_insn ? ispr_rdata_i | rf_bignum_rd_data_a_i : rf_bignum_rd_data_a_i;
+  assign wsr_wdata = insn_dec_shared_i.ispr_rs_insn ? ispr_rdata_i | rf_bignum_rd_data_a_i :
+                                                      rf_bignum_rd_data_a_i;
 
   assign ispr_wr_insn = insn_dec_shared_i.ispr_wr_insn | insn_dec_shared_i.ispr_rs_insn;
 
-  assign ispr_addr_o         = insn_dec_shared_i.subset == InsnSubsetBase ? ispr_addr_base : ispr_addr_bignum;
+  assign ispr_addr_o         = insn_dec_shared_i.subset == InsnSubsetBase ? ispr_addr_base :
+                                                                            ispr_addr_bignum;
   assign ispr_base_wdata_o   = csr_wdata;
   assign ispr_base_wr_en_o   =
     {BaseWordsPerWLEN{(insn_dec_shared_i.subset == InsnSubsetBase) & ispr_wr_insn & insn_valid_i}}

--- a/hw/ip/otbn/rtl/otbn_decoder.sv
+++ b/hw/ip/otbn/rtl/otbn_decoder.sv
@@ -715,9 +715,9 @@ module otbn_decoder
 
           3'b101: begin
             if (insn_alu[31:27] == 5'b0_0000) begin
-              alu_operator_base = AluOpBaseSrl;               // Shift Right Logical by Immediate
+              alu_operator_base = AluOpBaseSrl; // Shift Right Logical by Immediate
             end else if (insn_alu[31:27] == 5'b0_1000) begin
-              alu_operator_base = AluOpBaseSra;               // Shift Right Arithmetically by Immediate
+              alu_operator_base = AluOpBaseSra; // Shift Right Arithmetically by Immediate
             end
           end
 
@@ -951,7 +951,7 @@ module otbn_decoder
   `ASSERT(BignumRegIncReq, rf_wdata_sel_base == RfWdSelIncr
       |-> $onehot({a_inc_bignum, a_wlen_word_inc_bignum, b_inc_bignum, d_inc_bignum}))
 
-  `ASSERT(BaseRenOnBignumIndirectA, insn_valid_o & rf_a_indirect_bignum |-> rf_ren_a_base);
-  `ASSERT(BaseRenOnBignumIndirectB, insn_valid_o & rf_b_indirect_bignum |-> rf_ren_b_base);
-  `ASSERT(BaseRenOnBignumIndirectD, insn_valid_o & rf_d_indirect_bignum |-> rf_ren_b_base);
+  `ASSERT(BaseRenOnBignumIndirectA, insn_valid_o & rf_a_indirect_bignum |-> rf_ren_a_base)
+  `ASSERT(BaseRenOnBignumIndirectB, insn_valid_o & rf_b_indirect_bignum |-> rf_ren_b_base)
+  `ASSERT(BaseRenOnBignumIndirectD, insn_valid_o & rf_d_indirect_bignum |-> rf_ren_b_base)
 endmodule

--- a/hw/ip/otbn/rtl/otbn_lsu.sv
+++ b/hw/ip/otbn/rtl/otbn_lsu.sv
@@ -95,11 +95,11 @@ module otbn_lsu
 
   // Data appears the cycle following the request, LSU assume lsu_addr_i is kept stable by the
   // controller to mux out the required 32-bit word.
-  `ASSERT(LsuLoadAddrStable, lsu_load_req_i |=> $stable(lsu_addr_i));
-  `ASSERT_KNOWN_IF(LsuAddrKnown, lsu_addr_i, lsu_load_req_i | lsu_store_req_i);
+  `ASSERT(LsuLoadAddrStable, lsu_load_req_i |=> $stable(lsu_addr_i))
+  `ASSERT_KNOWN_IF(LsuAddrKnown, lsu_addr_i, lsu_load_req_i | lsu_store_req_i)
 
   // TODO: Produce an error/alert if this doesn't hold?
-  `ASSERT(DMemRValidAfterReq, dmem_req_o & ~dmem_write_o |=> dmem_rvalid_i);
+  `ASSERT(DMemRValidAfterReq, dmem_req_o & ~dmem_write_o |=> dmem_rvalid_i)
 
   assign lsu_bignum_rdata_o = dmem_rdata_i;
   assign lsu_rdata_err_o    = dmem_rerror_i;

--- a/hw/ip/otbn/rtl/otbn_rf_base.sv
+++ b/hw/ip/otbn/rtl/otbn_rf_base.sv
@@ -64,7 +64,8 @@ module otbn_rf_base
 
   assign push_stack = wr_en_i & (wr_addr_i == CallStackRegIndex[4:0]);
 
-  assign call_stack_overflow_err_o = (push_stack & stack_full & ~pop_stack) | (pop_stack & ~stack_data_valid);
+  assign call_stack_overflow_err_o = (push_stack & stack_full & ~pop_stack) |
+                                     (pop_stack & ~stack_data_valid);
 
   // Prevent any write to the stack register from going to the register file,
   // all other writes are passed straight through


### PR DESCRIPTION
Fix some trivial lint warnings and style issues in OTBN:

* Line length
* ASSERT with semicolon at the end