### PR TITLE
[systemtest] Increase test timeout for self-checking apps

### DIFF
--- a/test/systemtest/earlgrey/test_sim_verilator.py
+++ b/test/systemtest/earlgrey/test_sim_verilator.py
@@ -222,7 +222,7 @@ def test_apps_selfchecking(tmp_path, bin_dir, app_selfchecking):
     log.debug("Waiting for pass string from device test")
 
     result_match = sim.find_in_uart0(re.compile(rb'^(PASS|FAIL)!$'),
-                                     timeout=240)
+                                     timeout=600)
     assert result_match is not None, "PASS/FAIL indication not found in test output."
 
     result_msg = result_match.group(1)


### PR DESCRIPTION
Increase the timeout to receive a PASS indication from self-checking
tests running under Verilator from 4 to 10 minutes to reduce the risk of
flaky tests.