### PR TITLE
[otbn] Rename some signals in otbn_top_sim.sv

### DIFF
--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -27,7 +27,7 @@ module otbn_top_sim (
   logic [ImemAddrWidth-1:0] imem_addr;
   logic [31:0]              imem_rdata;
   logic                     imem_rvalid;
-  logic [1:0]               imem_rerror_raw;
+  logic [1:0]               imem_rerror_vec;
   logic                     imem_rerror;
 
   // Data memory (DMEM) signals
@@ -38,7 +38,7 @@ module otbn_top_sim (
   logic [WLEN-1:0]          dmem_wmask;
   logic [WLEN-1:0]          dmem_rdata;
   logic                     dmem_rvalid;
-  logic [1:0]               dmem_rerror_raw;
+  logic [1:0]               dmem_rerror_vec;
   logic                     dmem_rerror;
 
   otbn_core #(
@@ -112,11 +112,12 @@ module otbn_top_sim (
     .wmask_i  ( dmem_wmask      ),
     .rdata_o  ( dmem_rdata      ),
     .rvalid_o ( dmem_rvalid     ),
-    .rerror_o ( dmem_rerror_raw ),
+    .rerror_o ( dmem_rerror_vec ),
     .cfg_i    ( '0              )
   );
 
-  assign dmem_rerror = |dmem_rerror_raw;
+  // Combine uncorrectable / correctable errors. See identical code in otbn.sv for details.
+  assign dmem_rerror = |dmem_rerror_vec;
 
   localparam int ImemSizeWords = ImemSizeByte / 4;
   localparam int ImemIndexWidth = prim_util_pkg::vbits(ImemSizeWords);
@@ -142,11 +143,12 @@ module otbn_top_sim (
     .wmask_i  ( '0              ),
     .rdata_o  ( imem_rdata      ),
     .rvalid_o ( imem_rvalid     ),
-    .rerror_o ( imem_rerror_raw ),
+    .rerror_o ( imem_rerror_vec ),
     .cfg_i    ( '0              )
   );
 
-  assign imem_rerror = |imem_rerror_raw;
+  // Combine uncorrectable / correctable errors. See identical code in otbn.sv for details.
+  assign imem_rerror = |imem_rerror_vec;
 
   // When OTBN is done let a few more cycles run then finish simulation
   logic [1:0] finish_counter;


### PR DESCRIPTION
I used the _raw naming scheme in an initial version of commit 40cd914,
but renamed it to _vec in otbn.sv after PR comments. Unfortunately, I
forgot to do the same rename in otbn_top_sim.sv.

This finishes addressing @imphil's review comments in #4369. Oops!