### PR TITLE
[otbn] Remove "err" interrupt

### DIFF
--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -18,9 +18,6 @@
     { name: "done"
       desc: "OTBN has completed the operation"
     }
-    { name: "err"
-      desc: "An error occurred. Read the ERR_CODE register for error details."
-    }
   ]
   alert_list: [
     { name: "imem_uncorrectable"
@@ -118,8 +115,9 @@
           desc: '''
             The error cause if an error occurred.
 
-            Software should read this register before clearing the err
-            interrupt to avoid race conditions.
+            This is set to zero (ErrCodeNoError) when OTBN successfully
+            completes an operation or a positive value when OTBN stops on an
+            error.
 
             Possible values:
 

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -17,7 +17,7 @@ module tb;
   `include "dv_macros.svh"
 
   wire clk, rst_n;
-  wire idle, intr_done, intr_err;
+  wire idle, intr_done;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
 
   // interfaces
@@ -25,7 +25,7 @@ module tb;
   tl_if                         tl_if      (.clk(clk), .rst_n(rst_n));
   pins_if #(1)                  idle_if    (idle);
   pins_if #(NUM_MAX_INTERRUPTS) intr_if    (interrupts);
-  assign interrupts[1:0] = {intr_err, intr_done};
+  assign interrupts[0] = {intr_done};
 
   otbn_model_if #(
     .ImemSizeByte (otbn_reg_pkg::OTBN_IMEM_SIZE)
@@ -47,7 +47,6 @@ module tb;
     .idle_o      (idle),
 
     .intr_done_o (intr_done),
-    .intr_err_o  (intr_err),
 
     .alert_rx_i  (alert_rx),
     .alert_tx_o  (alert_tx)

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -26,7 +26,6 @@ module otbn
 
   // Interrupts
   output logic intr_done_o,
-  output logic intr_err_o,
 
   // Alerts
   input  prim_alert_pkg::alert_rx_t [NumAlerts-1:0] alert_rx_i,
@@ -83,29 +82,14 @@ module otbn
     .clk_i,
     .rst_ni,
     .event_intr_i           (done),
-    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.done.q),
-    .reg2hw_intr_test_q_i   (reg2hw.intr_test.done.q),
-    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.done.qe),
-    .reg2hw_intr_state_q_i  (reg2hw.intr_state.done.q),
-    .hw2reg_intr_state_de_o (hw2reg.intr_state.done.de),
-    .hw2reg_intr_state_d_o  (hw2reg.intr_state.done.d),
+    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.q),
+    .reg2hw_intr_test_q_i   (reg2hw.intr_test.q),
+    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.qe),
+    .reg2hw_intr_state_q_i  (reg2hw.intr_state.q),
+    .hw2reg_intr_state_de_o (hw2reg.intr_state.de),
+    .hw2reg_intr_state_d_o  (hw2reg.intr_state.d),
     .intr_o                 (intr_done_o)
   );
-  prim_intr_hw #(
-    .Width(1)
-  ) u_intr_hw_err (
-    .clk_i,
-    .rst_ni,
-    .event_intr_i           (err_valid),
-    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.err.q),
-    .reg2hw_intr_test_q_i   (reg2hw.intr_test.err.q),
-    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.err.qe),
-    .reg2hw_intr_state_q_i  (reg2hw.intr_state.err.q),
-    .hw2reg_intr_state_de_o (hw2reg.intr_state.err.de),
-    .hw2reg_intr_state_d_o  (hw2reg.intr_state.err.d),
-    .intr_o                 (intr_err_o)
-  );
-
 
   // Registers =================================================================
 
@@ -131,7 +115,7 @@ module otbn
   assign hw2reg.status.dummy.d = 1'b0;
 
   // ERR_CODE register
-  assign hw2reg.err_code.de = err_valid;
+  assign hw2reg.err_code.de = done;
   assign hw2reg.err_code.d  = err_code;
 
   // START_ADDR register
@@ -139,14 +123,8 @@ module otbn
 
   // Errors ====================================================================
 
-  // err_valid goes high if there is a new error this cycle. This causes the
-  // register block to take a new error code (stored as ERR_CODE) and triggers
-  // an interrupt. To ensure software on the host CPU only sees the first event
-  // in a series, err_valid is squashed if there is an existing error. Software
-  // should read the ERR_CODE register before clearing the interrupt to avoid
-  // race conditions.
-  assign err_valid = ~reg2hw.intr_state.err.q &
-    (1'b0); // TODO: OR error signals here.
+  // The error code (stored as ERR_CODE) for an OTBN operation gets stored on the cycle that done is
+  // asserted. Software is expected to read out this value before starting the next operation.
 
   always_comb begin
     err_code = ErrCodeNoError;
@@ -563,7 +541,6 @@ module otbn
   `ASSERT_KNOWN(TlODValidKnown_A, tl_o.d_valid)
   `ASSERT_KNOWN(TlOAReadyKnown_A, tl_o.a_ready)
   `ASSERT_KNOWN(IntrDoneOKnown_A, intr_done_o)
-  `ASSERT_KNOWN(IntrErrOKnown_A, intr_err_o)
   `ASSERT_KNOWN(AlertTxOKnown_A, alert_tx_o)
   `ASSERT_KNOWN(IdleOKnown_A, idle_o)
 

--- a/hw/ip/otbn/rtl/otbn_reg_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_pkg.sv
@@ -13,32 +13,16 @@ package otbn_reg_pkg;
   // Typedefs for registers //
   ////////////////////////////
   typedef struct packed {
-    struct packed {
-      logic        q;
-    } done;
-    struct packed {
-      logic        q;
-    } err;
+    logic        q;
   } otbn_reg2hw_intr_state_reg_t;
 
   typedef struct packed {
-    struct packed {
-      logic        q;
-    } done;
-    struct packed {
-      logic        q;
-    } err;
+    logic        q;
   } otbn_reg2hw_intr_enable_reg_t;
 
   typedef struct packed {
-    struct packed {
-      logic        q;
-      logic        qe;
-    } done;
-    struct packed {
-      logic        q;
-      logic        qe;
-    } err;
+    logic        q;
+    logic        qe;
   } otbn_reg2hw_intr_test_reg_t;
 
   typedef struct packed {
@@ -73,14 +57,8 @@ package otbn_reg_pkg;
 
 
   typedef struct packed {
-    struct packed {
-      logic        d;
-      logic        de;
-    } done;
-    struct packed {
-      logic        d;
-      logic        de;
-    } err;
+    logic        d;
+    logic        de;
   } otbn_hw2reg_intr_state_reg_t;
 
   typedef struct packed {
@@ -102,9 +80,9 @@ package otbn_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    otbn_reg2hw_intr_state_reg_t intr_state; // [49:48]
-    otbn_reg2hw_intr_enable_reg_t intr_enable; // [47:46]
-    otbn_reg2hw_intr_test_reg_t intr_test; // [45:42]
+    otbn_reg2hw_intr_state_reg_t intr_state; // [45:45]
+    otbn_reg2hw_intr_enable_reg_t intr_enable; // [44:44]
+    otbn_reg2hw_intr_test_reg_t intr_test; // [43:42]
     otbn_reg2hw_alert_test_reg_t alert_test; // [41:36]
     otbn_reg2hw_cmd_reg_t cmd; // [35:32]
     otbn_reg2hw_start_addr_reg_t start_addr; // [31:0]
@@ -114,7 +92,7 @@ package otbn_reg_pkg;
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    otbn_hw2reg_intr_state_reg_t intr_state; // [38:35]
+    otbn_hw2reg_intr_state_reg_t intr_state; // [36:35]
     otbn_hw2reg_status_reg_t status; // [34:33]
     otbn_hw2reg_err_code_reg_t err_code; // [32:0]
   } otbn_hw2reg_t;

--- a/hw/ip/otbn/rtl/otbn_reg_top.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_top.sv
@@ -121,22 +121,14 @@ module otbn_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
-  logic intr_state_done_qs;
-  logic intr_state_done_wd;
-  logic intr_state_done_we;
-  logic intr_state_err_qs;
-  logic intr_state_err_wd;
-  logic intr_state_err_we;
-  logic intr_enable_done_qs;
-  logic intr_enable_done_wd;
-  logic intr_enable_done_we;
-  logic intr_enable_err_qs;
-  logic intr_enable_err_wd;
-  logic intr_enable_err_we;
-  logic intr_test_done_wd;
-  logic intr_test_done_we;
-  logic intr_test_err_wd;
-  logic intr_test_err_we;
+  logic intr_state_qs;
+  logic intr_state_wd;
+  logic intr_state_we;
+  logic intr_enable_qs;
+  logic intr_enable_wd;
+  logic intr_enable_we;
+  logic intr_test_wd;
+  logic intr_test_we;
   logic alert_test_imem_uncorrectable_wd;
   logic alert_test_imem_uncorrectable_we;
   logic alert_test_dmem_uncorrectable_wd;
@@ -158,72 +150,44 @@ module otbn_reg_top (
   // Register instances
   // R[intr_state]: V(False)
 
-  //   F[done]: 0:0
   prim_subreg #(
     .DW      (1),
     .SWACCESS("W1C"),
     .RESVAL  (1'h0)
-  ) u_intr_state_done (
+  ) u_intr_state (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (intr_state_done_we),
-    .wd     (intr_state_done_wd),
+    .we     (intr_state_we),
+    .wd     (intr_state_wd),
 
     // from internal hardware
-    .de     (hw2reg.intr_state.done.de),
-    .d      (hw2reg.intr_state.done.d ),
+    .de     (hw2reg.intr_state.de),
+    .d      (hw2reg.intr_state.d ),
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_state.done.q ),
+    .q      (reg2hw.intr_state.q ),
 
     // to register interface (read)
-    .qs     (intr_state_done_qs)
-  );
-
-
-  //   F[err]: 1:1
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("W1C"),
-    .RESVAL  (1'h0)
-  ) u_intr_state_err (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (intr_state_err_we),
-    .wd     (intr_state_err_wd),
-
-    // from internal hardware
-    .de     (hw2reg.intr_state.err.de),
-    .d      (hw2reg.intr_state.err.d ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.intr_state.err.q ),
-
-    // to register interface (read)
-    .qs     (intr_state_err_qs)
+    .qs     (intr_state_qs)
   );
 
 
   // R[intr_enable]: V(False)
 
-  //   F[done]: 0:0
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
     .RESVAL  (1'h0)
-  ) u_intr_enable_done (
+  ) u_intr_enable (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
 
     // from register interface
-    .we     (intr_enable_done_we),
-    .wd     (intr_enable_done_wd),
+    .we     (intr_enable_we),
+    .wd     (intr_enable_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -231,67 +195,25 @@ module otbn_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_enable.done.q ),
+    .q      (reg2hw.intr_enable.q ),
 
     // to register interface (read)
-    .qs     (intr_enable_done_qs)
-  );
-
-
-  //   F[err]: 1:1
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_intr_enable_err (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (intr_enable_err_we),
-    .wd     (intr_enable_err_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.intr_enable.err.q ),
-
-    // to register interface (read)
-    .qs     (intr_enable_err_qs)
+    .qs     (intr_enable_qs)
   );
 
 
   // R[intr_test]: V(True)
 
-  //   F[done]: 0:0
   prim_subreg_ext #(
     .DW    (1)
-  ) u_intr_test_done (
+  ) u_intr_test (
     .re     (1'b0),
-    .we     (intr_test_done_we),
-    .wd     (intr_test_done_wd),
+    .we     (intr_test_we),
+    .wd     (intr_test_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.done.qe),
-    .q      (reg2hw.intr_test.done.q ),
-    .qs     ()
-  );
-
-
-  //   F[err]: 1:1
-  prim_subreg_ext #(
-    .DW    (1)
-  ) u_intr_test_err (
-    .re     (1'b0),
-    .we     (intr_test_err_we),
-    .wd     (intr_test_err_wd),
-    .d      ('0),
-    .qre    (),
-    .qe     (reg2hw.intr_test.err.qe),
-    .q      (reg2hw.intr_test.err.q ),
+    .qe     (reg2hw.intr_test.qe),
+    .q      (reg2hw.intr_test.q ),
     .qs     ()
   );
 
@@ -489,23 +411,14 @@ module otbn_reg_top (
     if (addr_hit[7] && reg_we && (OTBN_PERMIT[7] != (OTBN_PERMIT[7] & reg_be))) wr_err = 1'b1 ;
   end
 
-  assign intr_state_done_we = addr_hit[0] & reg_we & ~wr_err;
-  assign intr_state_done_wd = reg_wdata[0];
+  assign intr_state_we = addr_hit[0] & reg_we & ~wr_err;
+  assign intr_state_wd = reg_wdata[0];
 
-  assign intr_state_err_we = addr_hit[0] & reg_we & ~wr_err;
-  assign intr_state_err_wd = reg_wdata[1];
+  assign intr_enable_we = addr_hit[1] & reg_we & ~wr_err;
+  assign intr_enable_wd = reg_wdata[0];
 
-  assign intr_enable_done_we = addr_hit[1] & reg_we & ~wr_err;
-  assign intr_enable_done_wd = reg_wdata[0];
-
-  assign intr_enable_err_we = addr_hit[1] & reg_we & ~wr_err;
-  assign intr_enable_err_wd = reg_wdata[1];
-
-  assign intr_test_done_we = addr_hit[2] & reg_we & ~wr_err;
-  assign intr_test_done_wd = reg_wdata[0];
-
-  assign intr_test_err_we = addr_hit[2] & reg_we & ~wr_err;
-  assign intr_test_err_wd = reg_wdata[1];
+  assign intr_test_we = addr_hit[2] & reg_we & ~wr_err;
+  assign intr_test_wd = reg_wdata[0];
 
   assign alert_test_imem_uncorrectable_we = addr_hit[3] & reg_we & ~wr_err;
   assign alert_test_imem_uncorrectable_wd = reg_wdata[0];
@@ -535,18 +448,15 @@ module otbn_reg_top (
     reg_rdata_next = '0;
     unique case (1'b1)
       addr_hit[0]: begin
-        reg_rdata_next[0] = intr_state_done_qs;
-        reg_rdata_next[1] = intr_state_err_qs;
+        reg_rdata_next[0] = intr_state_qs;
       end
 
       addr_hit[1]: begin
-        reg_rdata_next[0] = intr_enable_done_qs;
-        reg_rdata_next[1] = intr_enable_err_qs;
+        reg_rdata_next[0] = intr_enable_qs;
       end
 
       addr_hit[2]: begin
         reg_rdata_next[0] = '0;
-        reg_rdata_next[1] = '0;
       end
 
       addr_hit[3]: begin

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -3912,18 +3912,6 @@
           ]
           type: interrupt
         }
-        {
-          name: err
-          width: 1
-          bits: "1"
-          bitinfo:
-          [
-            2
-            1
-            1
-          ]
-          type: interrupt
-        }
       ]
       alert_list:
       [
@@ -6313,19 +6301,6 @@
         1
         1
         0
-      ]
-      type: interrupt
-      module_name: otbn
-    }
-    {
-      name: otbn_err
-      width: 1
-      bits: "1"
-      bitinfo:
-      [
-        2
-        1
-        1
       ]
       type: interrupt
       module_name: otbn

--- a/hw/top_earlgrey/ip/rv_plic/data/autogen/rv_plic.hjson
+++ b/hw/top_earlgrey/ip/rv_plic/data/autogen/rv_plic.hjson
@@ -25,7 +25,7 @@
     { name: "NumSrc",
       desc: "Number of interrupt sources",
       type: "int",
-      default: "88",
+      default: "87",
       local: "true"
     },
     { name: "NumTarget",
@@ -759,14 +759,6 @@
     }
     { name: "PRIO86",
       desc: "Interrupt Source 86 Priority",
-      swaccess: "rw",
-      hwaccess: "hro",
-      fields: [
-        { bits: "1:0" }
-      ],
-    }
-    { name: "PRIO87",
-      desc: "Interrupt Source 87 Priority",
       swaccess: "rw",
       hwaccess: "hro",
       fields: [

--- a/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic.sv
+++ b/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic.sv
@@ -181,12 +181,11 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   assign prio[84] = reg2hw.prio84.q;
   assign prio[85] = reg2hw.prio85.q;
   assign prio[86] = reg2hw.prio86.q;
-  assign prio[87] = reg2hw.prio87.q;
 
   //////////////////////
   // Interrupt Enable //
   //////////////////////
-  for (genvar s = 0; s < 88; s++) begin : gen_ie0
+  for (genvar s = 0; s < 87; s++) begin : gen_ie0
     assign ie[0][s] = reg2hw.ie0[s].q;
   end
 
@@ -212,7 +211,7 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   ////////
   // IP //
   ////////
-  for (genvar s = 0; s < 88; s++) begin : gen_ip
+  for (genvar s = 0; s < 87; s++) begin : gen_ip
     assign hw2reg.ip[s].de = 1'b1; // Always write
     assign hw2reg.ip[s].d  = ip[s];
   end
@@ -220,7 +219,7 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   ///////////////////////////////////
   // Detection:: 0: Level, 1: Edge //
   ///////////////////////////////////
-  for (genvar s = 0; s < 88; s++) begin : gen_le
+  for (genvar s = 0; s < 87; s++) begin : gen_le
     assign le[s] = reg2hw.le[s].q;
   end
 

--- a/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_pkg.sv
@@ -7,7 +7,7 @@
 package rv_plic_reg_pkg;
 
   // Param list
-  parameter int NumSrc = 88;
+  parameter int NumSrc = 87;
   parameter int NumTarget = 1;
   parameter int PrioWidth = 2;
 
@@ -367,10 +367,6 @@ package rv_plic_reg_pkg;
   } rv_plic_reg2hw_prio86_reg_t;
 
   typedef struct packed {
-    logic [1:0]  q;
-  } rv_plic_reg2hw_prio87_reg_t;
-
-  typedef struct packed {
     logic        q;
   } rv_plic_reg2hw_ie0_mreg_t;
 
@@ -403,96 +399,95 @@ package rv_plic_reg_pkg;
   // Register to internal design logic //
   ///////////////////////////////////////
   typedef struct packed {
-    rv_plic_reg2hw_le_mreg_t [87:0] le; // [363:276]
-    rv_plic_reg2hw_prio0_reg_t prio0; // [275:274]
-    rv_plic_reg2hw_prio1_reg_t prio1; // [273:272]
-    rv_plic_reg2hw_prio2_reg_t prio2; // [271:270]
-    rv_plic_reg2hw_prio3_reg_t prio3; // [269:268]
-    rv_plic_reg2hw_prio4_reg_t prio4; // [267:266]
-    rv_plic_reg2hw_prio5_reg_t prio5; // [265:264]
-    rv_plic_reg2hw_prio6_reg_t prio6; // [263:262]
-    rv_plic_reg2hw_prio7_reg_t prio7; // [261:260]
-    rv_plic_reg2hw_prio8_reg_t prio8; // [259:258]
-    rv_plic_reg2hw_prio9_reg_t prio9; // [257:256]
-    rv_plic_reg2hw_prio10_reg_t prio10; // [255:254]
-    rv_plic_reg2hw_prio11_reg_t prio11; // [253:252]
-    rv_plic_reg2hw_prio12_reg_t prio12; // [251:250]
-    rv_plic_reg2hw_prio13_reg_t prio13; // [249:248]
-    rv_plic_reg2hw_prio14_reg_t prio14; // [247:246]
-    rv_plic_reg2hw_prio15_reg_t prio15; // [245:244]
-    rv_plic_reg2hw_prio16_reg_t prio16; // [243:242]
-    rv_plic_reg2hw_prio17_reg_t prio17; // [241:240]
-    rv_plic_reg2hw_prio18_reg_t prio18; // [239:238]
-    rv_plic_reg2hw_prio19_reg_t prio19; // [237:236]
-    rv_plic_reg2hw_prio20_reg_t prio20; // [235:234]
-    rv_plic_reg2hw_prio21_reg_t prio21; // [233:232]
-    rv_plic_reg2hw_prio22_reg_t prio22; // [231:230]
-    rv_plic_reg2hw_prio23_reg_t prio23; // [229:228]
-    rv_plic_reg2hw_prio24_reg_t prio24; // [227:226]
-    rv_plic_reg2hw_prio25_reg_t prio25; // [225:224]
-    rv_plic_reg2hw_prio26_reg_t prio26; // [223:222]
-    rv_plic_reg2hw_prio27_reg_t prio27; // [221:220]
-    rv_plic_reg2hw_prio28_reg_t prio28; // [219:218]
-    rv_plic_reg2hw_prio29_reg_t prio29; // [217:216]
-    rv_plic_reg2hw_prio30_reg_t prio30; // [215:214]
-    rv_plic_reg2hw_prio31_reg_t prio31; // [213:212]
-    rv_plic_reg2hw_prio32_reg_t prio32; // [211:210]
-    rv_plic_reg2hw_prio33_reg_t prio33; // [209:208]
-    rv_plic_reg2hw_prio34_reg_t prio34; // [207:206]
-    rv_plic_reg2hw_prio35_reg_t prio35; // [205:204]
-    rv_plic_reg2hw_prio36_reg_t prio36; // [203:202]
-    rv_plic_reg2hw_prio37_reg_t prio37; // [201:200]
-    rv_plic_reg2hw_prio38_reg_t prio38; // [199:198]
-    rv_plic_reg2hw_prio39_reg_t prio39; // [197:196]
-    rv_plic_reg2hw_prio40_reg_t prio40; // [195:194]
-    rv_plic_reg2hw_prio41_reg_t prio41; // [193:192]
-    rv_plic_reg2hw_prio42_reg_t prio42; // [191:190]
-    rv_plic_reg2hw_prio43_reg_t prio43; // [189:188]
-    rv_plic_reg2hw_prio44_reg_t prio44; // [187:186]
-    rv_plic_reg2hw_prio45_reg_t prio45; // [185:184]
-    rv_plic_reg2hw_prio46_reg_t prio46; // [183:182]
-    rv_plic_reg2hw_prio47_reg_t prio47; // [181:180]
-    rv_plic_reg2hw_prio48_reg_t prio48; // [179:178]
-    rv_plic_reg2hw_prio49_reg_t prio49; // [177:176]
-    rv_plic_reg2hw_prio50_reg_t prio50; // [175:174]
-    rv_plic_reg2hw_prio51_reg_t prio51; // [173:172]
-    rv_plic_reg2hw_prio52_reg_t prio52; // [171:170]
-    rv_plic_reg2hw_prio53_reg_t prio53; // [169:168]
-    rv_plic_reg2hw_prio54_reg_t prio54; // [167:166]
-    rv_plic_reg2hw_prio55_reg_t prio55; // [165:164]
-    rv_plic_reg2hw_prio56_reg_t prio56; // [163:162]
-    rv_plic_reg2hw_prio57_reg_t prio57; // [161:160]
-    rv_plic_reg2hw_prio58_reg_t prio58; // [159:158]
-    rv_plic_reg2hw_prio59_reg_t prio59; // [157:156]
-    rv_plic_reg2hw_prio60_reg_t prio60; // [155:154]
-    rv_plic_reg2hw_prio61_reg_t prio61; // [153:152]
-    rv_plic_reg2hw_prio62_reg_t prio62; // [151:150]
-    rv_plic_reg2hw_prio63_reg_t prio63; // [149:148]
-    rv_plic_reg2hw_prio64_reg_t prio64; // [147:146]
-    rv_plic_reg2hw_prio65_reg_t prio65; // [145:144]
-    rv_plic_reg2hw_prio66_reg_t prio66; // [143:142]
-    rv_plic_reg2hw_prio67_reg_t prio67; // [141:140]
-    rv_plic_reg2hw_prio68_reg_t prio68; // [139:138]
-    rv_plic_reg2hw_prio69_reg_t prio69; // [137:136]
-    rv_plic_reg2hw_prio70_reg_t prio70; // [135:134]
-    rv_plic_reg2hw_prio71_reg_t prio71; // [133:132]
-    rv_plic_reg2hw_prio72_reg_t prio72; // [131:130]
-    rv_plic_reg2hw_prio73_reg_t prio73; // [129:128]
-    rv_plic_reg2hw_prio74_reg_t prio74; // [127:126]
-    rv_plic_reg2hw_prio75_reg_t prio75; // [125:124]
-    rv_plic_reg2hw_prio76_reg_t prio76; // [123:122]
-    rv_plic_reg2hw_prio77_reg_t prio77; // [121:120]
-    rv_plic_reg2hw_prio78_reg_t prio78; // [119:118]
-    rv_plic_reg2hw_prio79_reg_t prio79; // [117:116]
-    rv_plic_reg2hw_prio80_reg_t prio80; // [115:114]
-    rv_plic_reg2hw_prio81_reg_t prio81; // [113:112]
-    rv_plic_reg2hw_prio82_reg_t prio82; // [111:110]
-    rv_plic_reg2hw_prio83_reg_t prio83; // [109:108]
-    rv_plic_reg2hw_prio84_reg_t prio84; // [107:106]
-    rv_plic_reg2hw_prio85_reg_t prio85; // [105:104]
-    rv_plic_reg2hw_prio86_reg_t prio86; // [103:102]
-    rv_plic_reg2hw_prio87_reg_t prio87; // [101:100]
-    rv_plic_reg2hw_ie0_mreg_t [87:0] ie0; // [99:12]
+    rv_plic_reg2hw_le_mreg_t [86:0] le; // [359:273]
+    rv_plic_reg2hw_prio0_reg_t prio0; // [272:271]
+    rv_plic_reg2hw_prio1_reg_t prio1; // [270:269]
+    rv_plic_reg2hw_prio2_reg_t prio2; // [268:267]
+    rv_plic_reg2hw_prio3_reg_t prio3; // [266:265]
+    rv_plic_reg2hw_prio4_reg_t prio4; // [264:263]
+    rv_plic_reg2hw_prio5_reg_t prio5; // [262:261]
+    rv_plic_reg2hw_prio6_reg_t prio6; // [260:259]
+    rv_plic_reg2hw_prio7_reg_t prio7; // [258:257]
+    rv_plic_reg2hw_prio8_reg_t prio8; // [256:255]
+    rv_plic_reg2hw_prio9_reg_t prio9; // [254:253]
+    rv_plic_reg2hw_prio10_reg_t prio10; // [252:251]
+    rv_plic_reg2hw_prio11_reg_t prio11; // [250:249]
+    rv_plic_reg2hw_prio12_reg_t prio12; // [248:247]
+    rv_plic_reg2hw_prio13_reg_t prio13; // [246:245]
+    rv_plic_reg2hw_prio14_reg_t prio14; // [244:243]
+    rv_plic_reg2hw_prio15_reg_t prio15; // [242:241]
+    rv_plic_reg2hw_prio16_reg_t prio16; // [240:239]
+    rv_plic_reg2hw_prio17_reg_t prio17; // [238:237]
+    rv_plic_reg2hw_prio18_reg_t prio18; // [236:235]
+    rv_plic_reg2hw_prio19_reg_t prio19; // [234:233]
+    rv_plic_reg2hw_prio20_reg_t prio20; // [232:231]
+    rv_plic_reg2hw_prio21_reg_t prio21; // [230:229]
+    rv_plic_reg2hw_prio22_reg_t prio22; // [228:227]
+    rv_plic_reg2hw_prio23_reg_t prio23; // [226:225]
+    rv_plic_reg2hw_prio24_reg_t prio24; // [224:223]
+    rv_plic_reg2hw_prio25_reg_t prio25; // [222:221]
+    rv_plic_reg2hw_prio26_reg_t prio26; // [220:219]
+    rv_plic_reg2hw_prio27_reg_t prio27; // [218:217]
+    rv_plic_reg2hw_prio28_reg_t prio28; // [216:215]
+    rv_plic_reg2hw_prio29_reg_t prio29; // [214:213]
+    rv_plic_reg2hw_prio30_reg_t prio30; // [212:211]
+    rv_plic_reg2hw_prio31_reg_t prio31; // [210:209]
+    rv_plic_reg2hw_prio32_reg_t prio32; // [208:207]
+    rv_plic_reg2hw_prio33_reg_t prio33; // [206:205]
+    rv_plic_reg2hw_prio34_reg_t prio34; // [204:203]
+    rv_plic_reg2hw_prio35_reg_t prio35; // [202:201]
+    rv_plic_reg2hw_prio36_reg_t prio36; // [200:199]
+    rv_plic_reg2hw_prio37_reg_t prio37; // [198:197]
+    rv_plic_reg2hw_prio38_reg_t prio38; // [196:195]
+    rv_plic_reg2hw_prio39_reg_t prio39; // [194:193]
+    rv_plic_reg2hw_prio40_reg_t prio40; // [192:191]
+    rv_plic_reg2hw_prio41_reg_t prio41; // [190:189]
+    rv_plic_reg2hw_prio42_reg_t prio42; // [188:187]
+    rv_plic_reg2hw_prio43_reg_t prio43; // [186:185]
+    rv_plic_reg2hw_prio44_reg_t prio44; // [184:183]
+    rv_plic_reg2hw_prio45_reg_t prio45; // [182:181]
+    rv_plic_reg2hw_prio46_reg_t prio46; // [180:179]
+    rv_plic_reg2hw_prio47_reg_t prio47; // [178:177]
+    rv_plic_reg2hw_prio48_reg_t prio48; // [176:175]
+    rv_plic_reg2hw_prio49_reg_t prio49; // [174:173]
+    rv_plic_reg2hw_prio50_reg_t prio50; // [172:171]
+    rv_plic_reg2hw_prio51_reg_t prio51; // [170:169]
+    rv_plic_reg2hw_prio52_reg_t prio52; // [168:167]
+    rv_plic_reg2hw_prio53_reg_t prio53; // [166:165]
+    rv_plic_reg2hw_prio54_reg_t prio54; // [164:163]
+    rv_plic_reg2hw_prio55_reg_t prio55; // [162:161]
+    rv_plic_reg2hw_prio56_reg_t prio56; // [160:159]
+    rv_plic_reg2hw_prio57_reg_t prio57; // [158:157]
+    rv_plic_reg2hw_prio58_reg_t prio58; // [156:155]
+    rv_plic_reg2hw_prio59_reg_t prio59; // [154:153]
+    rv_plic_reg2hw_prio60_reg_t prio60; // [152:151]
+    rv_plic_reg2hw_prio61_reg_t prio61; // [150:149]
+    rv_plic_reg2hw_prio62_reg_t prio62; // [148:147]
+    rv_plic_reg2hw_prio63_reg_t prio63; // [146:145]
+    rv_plic_reg2hw_prio64_reg_t prio64; // [144:143]
+    rv_plic_reg2hw_prio65_reg_t prio65; // [142:141]
+    rv_plic_reg2hw_prio66_reg_t prio66; // [140:139]
+    rv_plic_reg2hw_prio67_reg_t prio67; // [138:137]
+    rv_plic_reg2hw_prio68_reg_t prio68; // [136:135]
+    rv_plic_reg2hw_prio69_reg_t prio69; // [134:133]
+    rv_plic_reg2hw_prio70_reg_t prio70; // [132:131]
+    rv_plic_reg2hw_prio71_reg_t prio71; // [130:129]
+    rv_plic_reg2hw_prio72_reg_t prio72; // [128:127]
+    rv_plic_reg2hw_prio73_reg_t prio73; // [126:125]
+    rv_plic_reg2hw_prio74_reg_t prio74; // [124:123]
+    rv_plic_reg2hw_prio75_reg_t prio75; // [122:121]
+    rv_plic_reg2hw_prio76_reg_t prio76; // [120:119]
+    rv_plic_reg2hw_prio77_reg_t prio77; // [118:117]
+    rv_plic_reg2hw_prio78_reg_t prio78; // [116:115]
+    rv_plic_reg2hw_prio79_reg_t prio79; // [114:113]
+    rv_plic_reg2hw_prio80_reg_t prio80; // [112:111]
+    rv_plic_reg2hw_prio81_reg_t prio81; // [110:109]
+    rv_plic_reg2hw_prio82_reg_t prio82; // [108:107]
+    rv_plic_reg2hw_prio83_reg_t prio83; // [106:105]
+    rv_plic_reg2hw_prio84_reg_t prio84; // [104:103]
+    rv_plic_reg2hw_prio85_reg_t prio85; // [102:101]
+    rv_plic_reg2hw_prio86_reg_t prio86; // [100:99]
+    rv_plic_reg2hw_ie0_mreg_t [86:0] ie0; // [98:12]
     rv_plic_reg2hw_threshold0_reg_t threshold0; // [11:10]
     rv_plic_reg2hw_cc0_reg_t cc0; // [9:1]
     rv_plic_reg2hw_msip0_reg_t msip0; // [0:0]
@@ -502,7 +497,7 @@ package rv_plic_reg_pkg;
   // Internal design logic to register //
   ///////////////////////////////////////
   typedef struct packed {
-    rv_plic_hw2reg_ip_mreg_t [87:0] ip; // [182:7]
+    rv_plic_hw2reg_ip_mreg_t [86:0] ip; // [180:7]
     rv_plic_hw2reg_cc0_reg_t cc0; // [6:0]
   } rv_plic_hw2reg_t;
 
@@ -600,7 +595,6 @@ package rv_plic_reg_pkg;
   parameter logic [9:0] RV_PLIC_PRIO84_OFFSET = 10'h 168;
   parameter logic [9:0] RV_PLIC_PRIO85_OFFSET = 10'h 16c;
   parameter logic [9:0] RV_PLIC_PRIO86_OFFSET = 10'h 170;
-  parameter logic [9:0] RV_PLIC_PRIO87_OFFSET = 10'h 174;
   parameter logic [9:0] RV_PLIC_IE0_0_OFFSET = 10'h 200;
   parameter logic [9:0] RV_PLIC_IE0_1_OFFSET = 10'h 204;
   parameter logic [9:0] RV_PLIC_IE0_2_OFFSET = 10'h 208;
@@ -704,7 +698,6 @@ package rv_plic_reg_pkg;
     RV_PLIC_PRIO84,
     RV_PLIC_PRIO85,
     RV_PLIC_PRIO86,
-    RV_PLIC_PRIO87,
     RV_PLIC_IE0_0,
     RV_PLIC_IE0_1,
     RV_PLIC_IE0_2,
@@ -714,7 +707,7 @@ package rv_plic_reg_pkg;
   } rv_plic_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] RV_PLIC_PERMIT [100] = '{
+  parameter logic [3:0] RV_PLIC_PERMIT [99] = '{
     4'b 1111, // index[ 0] RV_PLIC_IP_0
     4'b 1111, // index[ 1] RV_PLIC_IP_1
     4'b 0111, // index[ 2] RV_PLIC_IP_2
@@ -808,13 +801,12 @@ package rv_plic_reg_pkg;
     4'b 0001, // index[90] RV_PLIC_PRIO84
     4'b 0001, // index[91] RV_PLIC_PRIO85
     4'b 0001, // index[92] RV_PLIC_PRIO86
-    4'b 0001, // index[93] RV_PLIC_PRIO87
-    4'b 1111, // index[94] RV_PLIC_IE0_0
-    4'b 1111, // index[95] RV_PLIC_IE0_1
-    4'b 0111, // index[96] RV_PLIC_IE0_2
-    4'b 0001, // index[97] RV_PLIC_THRESHOLD0
-    4'b 0001, // index[98] RV_PLIC_CC0
-    4'b 0001  // index[99] RV_PLIC_MSIP0
+    4'b 1111, // index[93] RV_PLIC_IE0_0
+    4'b 1111, // index[94] RV_PLIC_IE0_1
+    4'b 0111, // index[95] RV_PLIC_IE0_2
+    4'b 0001, // index[96] RV_PLIC_THRESHOLD0
+    4'b 0001, // index[97] RV_PLIC_CC0
+    4'b 0001  // index[98] RV_PLIC_MSIP0
   };
 endpackage
 

--- a/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_top.sv
+++ b/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_top.sv
@@ -158,7 +158,6 @@ module rv_plic_reg_top (
   logic ip_2_p_84_qs;
   logic ip_2_p_85_qs;
   logic ip_2_p_86_qs;
-  logic ip_2_p_87_qs;
   logic le_0_le_0_qs;
   logic le_0_le_0_wd;
   logic le_0_le_0_we;
@@ -420,9 +419,6 @@ module rv_plic_reg_top (
   logic le_2_le_86_qs;
   logic le_2_le_86_wd;
   logic le_2_le_86_we;
-  logic le_2_le_87_qs;
-  logic le_2_le_87_wd;
-  logic le_2_le_87_we;
   logic [1:0] prio0_qs;
   logic [1:0] prio0_wd;
   logic prio0_we;
@@ -684,9 +680,6 @@ module rv_plic_reg_top (
   logic [1:0] prio86_qs;
   logic [1:0] prio86_wd;
   logic prio86_we;
-  logic [1:0] prio87_qs;
-  logic [1:0] prio87_wd;
-  logic prio87_we;
   logic ie0_0_e_0_qs;
   logic ie0_0_e_0_wd;
   logic ie0_0_e_0_we;
@@ -948,9 +941,6 @@ module rv_plic_reg_top (
   logic ie0_2_e_86_qs;
   logic ie0_2_e_86_wd;
   logic ie0_2_e_86_we;
-  logic ie0_2_e_87_qs;
-  logic ie0_2_e_87_wd;
-  logic ie0_2_e_87_we;
   logic [1:0] threshold0_qs;
   logic [1:0] threshold0_wd;
   logic threshold0_we;
@@ -3145,31 +3135,6 @@ module rv_plic_reg_top (
 
     // to register interface (read)
     .qs     (ip_2_p_86_qs)
-  );
-
-
-  // F[p_87]: 23:23
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RO"),
-    .RESVAL  (1'h0)
-  ) u_ip_2_p_87 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    .we     (1'b0),
-    .wd     ('0  ),
-
-    // from internal hardware
-    .de     (hw2reg.ip[87].de),
-    .d      (hw2reg.ip[87].d ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (ip_2_p_87_qs)
   );
 
 
@@ -5443,32 +5408,6 @@ module rv_plic_reg_top (
 
     // to register interface (read)
     .qs     (le_2_le_86_qs)
-  );
-
-
-  // F[le_87]: 23:23
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_le_2_le_87 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (le_2_le_87_we),
-    .wd     (le_2_le_87_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.le[87].q ),
-
-    // to register interface (read)
-    .qs     (le_2_le_87_qs)
   );
 
 
@@ -7822,33 +7761,6 @@ module rv_plic_reg_top (
   );
 
 
-  // R[prio87]: V(False)
-
-  prim_subreg #(
-    .DW      (2),
-    .SWACCESS("RW"),
-    .RESVAL  (2'h0)
-  ) u_prio87 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (prio87_we),
-    .wd     (prio87_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.prio87.q ),
-
-    // to register interface (read)
-    .qs     (prio87_qs)
-  );
-
-
 
   // Subregister 0 of Multireg ie0
   // R[ie0_0]: V(False)
@@ -10121,32 +10033,6 @@ module rv_plic_reg_top (
   );
 
 
-  // F[e_87]: 23:23
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_ie0_2_e_87 (
-    .clk_i   (clk_i    ),
-    .rst_ni  (rst_ni  ),
-
-    // from register interface
-    .we     (ie0_2_e_87_we),
-    .wd     (ie0_2_e_87_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0  ),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.ie0[87].q ),
-
-    // to register interface (read)
-    .qs     (ie0_2_e_87_qs)
-  );
-
-
 
   // R[threshold0]: V(False)
 
@@ -10220,7 +10106,7 @@ module rv_plic_reg_top (
 
 
 
-  logic [99:0] addr_hit;
+  logic [98:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == RV_PLIC_IP_0_OFFSET);
@@ -10316,13 +10202,12 @@ module rv_plic_reg_top (
     addr_hit[90] = (reg_addr == RV_PLIC_PRIO84_OFFSET);
     addr_hit[91] = (reg_addr == RV_PLIC_PRIO85_OFFSET);
     addr_hit[92] = (reg_addr == RV_PLIC_PRIO86_OFFSET);
-    addr_hit[93] = (reg_addr == RV_PLIC_PRIO87_OFFSET);
-    addr_hit[94] = (reg_addr == RV_PLIC_IE0_0_OFFSET);
-    addr_hit[95] = (reg_addr == RV_PLIC_IE0_1_OFFSET);
-    addr_hit[96] = (reg_addr == RV_PLIC_IE0_2_OFFSET);
-    addr_hit[97] = (reg_addr == RV_PLIC_THRESHOLD0_OFFSET);
-    addr_hit[98] = (reg_addr == RV_PLIC_CC0_OFFSET);
-    addr_hit[99] = (reg_addr == RV_PLIC_MSIP0_OFFSET);
+    addr_hit[93] = (reg_addr == RV_PLIC_IE0_0_OFFSET);
+    addr_hit[94] = (reg_addr == RV_PLIC_IE0_1_OFFSET);
+    addr_hit[95] = (reg_addr == RV_PLIC_IE0_2_OFFSET);
+    addr_hit[96] = (reg_addr == RV_PLIC_THRESHOLD0_OFFSET);
+    addr_hit[97] = (reg_addr == RV_PLIC_CC0_OFFSET);
+    addr_hit[98] = (reg_addr == RV_PLIC_MSIP0_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -10429,9 +10314,7 @@ module rv_plic_reg_top (
     if (addr_hit[96] && reg_we && (RV_PLIC_PERMIT[96] != (RV_PLIC_PERMIT[96] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[97] && reg_we && (RV_PLIC_PERMIT[97] != (RV_PLIC_PERMIT[97] & reg_be))) wr_err = 1'b1 ;
     if (addr_hit[98] && reg_we && (RV_PLIC_PERMIT[98] != (RV_PLIC_PERMIT[98] & reg_be))) wr_err = 1'b1 ;
-    if (addr_hit[99] && reg_we && (RV_PLIC_PERMIT[99] != (RV_PLIC_PERMIT[99] & reg_be))) wr_err = 1'b1 ;
   end
-
 
 
 
@@ -10781,9 +10664,6 @@ module rv_plic_reg_top (
   assign le_2_le_86_we = addr_hit[5] & reg_we & ~wr_err;
   assign le_2_le_86_wd = reg_wdata[22];
 
-  assign le_2_le_87_we = addr_hit[5] & reg_we & ~wr_err;
-  assign le_2_le_87_wd = reg_wdata[23];
-
   assign prio0_we = addr_hit[6] & reg_we & ~wr_err;
   assign prio0_wd = reg_wdata[1:0];
 
@@ -11045,281 +10925,275 @@ module rv_plic_reg_top (
   assign prio86_we = addr_hit[92] & reg_we & ~wr_err;
   assign prio86_wd = reg_wdata[1:0];
 
-  assign prio87_we = addr_hit[93] & reg_we & ~wr_err;
-  assign prio87_wd = reg_wdata[1:0];
-
-  assign ie0_0_e_0_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_0_e_0_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_0_wd = reg_wdata[0];
 
-  assign ie0_0_e_1_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_0_e_1_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_1_wd = reg_wdata[1];
 
-  assign ie0_0_e_2_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_0_e_2_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_2_wd = reg_wdata[2];
 
-  assign ie0_0_e_3_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_0_e_3_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_3_wd = reg_wdata[3];
 
-  assign ie0_0_e_4_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_0_e_4_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_4_wd = reg_wdata[4];
 
-  assign ie0_0_e_5_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_0_e_5_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_5_wd = reg_wdata[5];
 
-  assign ie0_0_e_6_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_0_e_6_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_6_wd = reg_wdata[6];
 
-  assign ie0_0_e_7_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_0_e_7_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_7_wd = reg_wdata[7];
 
-  assign ie0_0_e_8_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_0_e_8_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_8_wd = reg_wdata[8];
 
-  assign ie0_0_e_9_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_0_e_9_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_9_wd = reg_wdata[9];
 
-  assign ie0_0_e_10_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_0_e_10_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_10_wd = reg_wdata[10];
 
-  assign ie0_0_e_11_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_0_e_11_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_11_wd = reg_wdata[11];
 
-  assign ie0_0_e_12_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_0_e_12_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_12_wd = reg_wdata[12];
 
-  assign ie0_0_e_13_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_0_e_13_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_13_wd = reg_wdata[13];
 
-  assign ie0_0_e_14_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_0_e_14_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_14_wd = reg_wdata[14];
 
-  assign ie0_0_e_15_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_0_e_15_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_15_wd = reg_wdata[15];
 
-  assign ie0_0_e_16_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_0_e_16_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_16_wd = reg_wdata[16];
 
-  assign ie0_0_e_17_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_0_e_17_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_17_wd = reg_wdata[17];
 
-  assign ie0_0_e_18_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_0_e_18_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_18_wd = reg_wdata[18];
 
-  assign ie0_0_e_19_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_0_e_19_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_19_wd = reg_wdata[19];
 
-  assign ie0_0_e_20_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_0_e_20_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_20_wd = reg_wdata[20];
 
-  assign ie0_0_e_21_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_0_e_21_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_21_wd = reg_wdata[21];
 
-  assign ie0_0_e_22_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_0_e_22_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_22_wd = reg_wdata[22];
 
-  assign ie0_0_e_23_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_0_e_23_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_23_wd = reg_wdata[23];
 
-  assign ie0_0_e_24_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_0_e_24_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_24_wd = reg_wdata[24];
 
-  assign ie0_0_e_25_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_0_e_25_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_25_wd = reg_wdata[25];
 
-  assign ie0_0_e_26_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_0_e_26_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_26_wd = reg_wdata[26];
 
-  assign ie0_0_e_27_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_0_e_27_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_27_wd = reg_wdata[27];
 
-  assign ie0_0_e_28_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_0_e_28_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_28_wd = reg_wdata[28];
 
-  assign ie0_0_e_29_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_0_e_29_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_29_wd = reg_wdata[29];
 
-  assign ie0_0_e_30_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_0_e_30_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_30_wd = reg_wdata[30];
 
-  assign ie0_0_e_31_we = addr_hit[94] & reg_we & ~wr_err;
+  assign ie0_0_e_31_we = addr_hit[93] & reg_we & ~wr_err;
   assign ie0_0_e_31_wd = reg_wdata[31];
 
-  assign ie0_1_e_32_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_1_e_32_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_32_wd = reg_wdata[0];
 
-  assign ie0_1_e_33_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_1_e_33_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_33_wd = reg_wdata[1];
 
-  assign ie0_1_e_34_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_1_e_34_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_34_wd = reg_wdata[2];
 
-  assign ie0_1_e_35_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_1_e_35_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_35_wd = reg_wdata[3];
 
-  assign ie0_1_e_36_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_1_e_36_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_36_wd = reg_wdata[4];
 
-  assign ie0_1_e_37_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_1_e_37_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_37_wd = reg_wdata[5];
 
-  assign ie0_1_e_38_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_1_e_38_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_38_wd = reg_wdata[6];
 
-  assign ie0_1_e_39_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_1_e_39_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_39_wd = reg_wdata[7];
 
-  assign ie0_1_e_40_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_1_e_40_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_40_wd = reg_wdata[8];
 
-  assign ie0_1_e_41_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_1_e_41_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_41_wd = reg_wdata[9];
 
-  assign ie0_1_e_42_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_1_e_42_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_42_wd = reg_wdata[10];
 
-  assign ie0_1_e_43_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_1_e_43_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_43_wd = reg_wdata[11];
 
-  assign ie0_1_e_44_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_1_e_44_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_44_wd = reg_wdata[12];
 
-  assign ie0_1_e_45_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_1_e_45_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_45_wd = reg_wdata[13];
 
-  assign ie0_1_e_46_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_1_e_46_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_46_wd = reg_wdata[14];
 
-  assign ie0_1_e_47_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_1_e_47_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_47_wd = reg_wdata[15];
 
-  assign ie0_1_e_48_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_1_e_48_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_48_wd = reg_wdata[16];
 
-  assign ie0_1_e_49_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_1_e_49_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_49_wd = reg_wdata[17];
 
-  assign ie0_1_e_50_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_1_e_50_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_50_wd = reg_wdata[18];
 
-  assign ie0_1_e_51_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_1_e_51_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_51_wd = reg_wdata[19];
 
-  assign ie0_1_e_52_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_1_e_52_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_52_wd = reg_wdata[20];
 
-  assign ie0_1_e_53_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_1_e_53_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_53_wd = reg_wdata[21];
 
-  assign ie0_1_e_54_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_1_e_54_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_54_wd = reg_wdata[22];
 
-  assign ie0_1_e_55_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_1_e_55_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_55_wd = reg_wdata[23];
 
-  assign ie0_1_e_56_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_1_e_56_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_56_wd = reg_wdata[24];
 
-  assign ie0_1_e_57_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_1_e_57_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_57_wd = reg_wdata[25];
 
-  assign ie0_1_e_58_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_1_e_58_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_58_wd = reg_wdata[26];
 
-  assign ie0_1_e_59_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_1_e_59_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_59_wd = reg_wdata[27];
 
-  assign ie0_1_e_60_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_1_e_60_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_60_wd = reg_wdata[28];
 
-  assign ie0_1_e_61_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_1_e_61_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_61_wd = reg_wdata[29];
 
-  assign ie0_1_e_62_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_1_e_62_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_62_wd = reg_wdata[30];
 
-  assign ie0_1_e_63_we = addr_hit[95] & reg_we & ~wr_err;
+  assign ie0_1_e_63_we = addr_hit[94] & reg_we & ~wr_err;
   assign ie0_1_e_63_wd = reg_wdata[31];
 
-  assign ie0_2_e_64_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_2_e_64_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_64_wd = reg_wdata[0];
 
-  assign ie0_2_e_65_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_2_e_65_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_65_wd = reg_wdata[1];
 
-  assign ie0_2_e_66_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_2_e_66_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_66_wd = reg_wdata[2];
 
-  assign ie0_2_e_67_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_2_e_67_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_67_wd = reg_wdata[3];
 
-  assign ie0_2_e_68_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_2_e_68_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_68_wd = reg_wdata[4];
 
-  assign ie0_2_e_69_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_2_e_69_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_69_wd = reg_wdata[5];
 
-  assign ie0_2_e_70_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_2_e_70_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_70_wd = reg_wdata[6];
 
-  assign ie0_2_e_71_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_2_e_71_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_71_wd = reg_wdata[7];
 
-  assign ie0_2_e_72_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_2_e_72_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_72_wd = reg_wdata[8];
 
-  assign ie0_2_e_73_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_2_e_73_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_73_wd = reg_wdata[9];
 
-  assign ie0_2_e_74_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_2_e_74_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_74_wd = reg_wdata[10];
 
-  assign ie0_2_e_75_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_2_e_75_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_75_wd = reg_wdata[11];
 
-  assign ie0_2_e_76_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_2_e_76_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_76_wd = reg_wdata[12];
 
-  assign ie0_2_e_77_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_2_e_77_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_77_wd = reg_wdata[13];
 
-  assign ie0_2_e_78_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_2_e_78_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_78_wd = reg_wdata[14];
 
-  assign ie0_2_e_79_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_2_e_79_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_79_wd = reg_wdata[15];
 
-  assign ie0_2_e_80_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_2_e_80_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_80_wd = reg_wdata[16];
 
-  assign ie0_2_e_81_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_2_e_81_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_81_wd = reg_wdata[17];
 
-  assign ie0_2_e_82_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_2_e_82_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_82_wd = reg_wdata[18];
 
-  assign ie0_2_e_83_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_2_e_83_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_83_wd = reg_wdata[19];
 
-  assign ie0_2_e_84_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_2_e_84_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_84_wd = reg_wdata[20];
 
-  assign ie0_2_e_85_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_2_e_85_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_85_wd = reg_wdata[21];
 
-  assign ie0_2_e_86_we = addr_hit[96] & reg_we & ~wr_err;
+  assign ie0_2_e_86_we = addr_hit[95] & reg_we & ~wr_err;
   assign ie0_2_e_86_wd = reg_wdata[22];
 
-  assign ie0_2_e_87_we = addr_hit[96] & reg_we & ~wr_err;
-  assign ie0_2_e_87_wd = reg_wdata[23];
-
-  assign threshold0_we = addr_hit[97] & reg_we & ~wr_err;
+  assign threshold0_we = addr_hit[96] & reg_we & ~wr_err;
   assign threshold0_wd = reg_wdata[1:0];
 
-  assign cc0_we = addr_hit[98] & reg_we & ~wr_err;
+  assign cc0_we = addr_hit[97] & reg_we & ~wr_err;
   assign cc0_wd = reg_wdata[6:0];
-  assign cc0_re = addr_hit[98] && reg_re;
+  assign cc0_re = addr_hit[97] && reg_re;
 
-  assign msip0_we = addr_hit[99] & reg_we & ~wr_err;
+  assign msip0_we = addr_hit[98] & reg_we & ~wr_err;
   assign msip0_wd = reg_wdata[0];
 
   // Read data return
@@ -11420,7 +11294,6 @@ module rv_plic_reg_top (
         reg_rdata_next[20] = ip_2_p_84_qs;
         reg_rdata_next[21] = ip_2_p_85_qs;
         reg_rdata_next[22] = ip_2_p_86_qs;
-        reg_rdata_next[23] = ip_2_p_87_qs;
       end
 
       addr_hit[3]: begin
@@ -11517,7 +11390,6 @@ module rv_plic_reg_top (
         reg_rdata_next[20] = le_2_le_84_qs;
         reg_rdata_next[21] = le_2_le_85_qs;
         reg_rdata_next[22] = le_2_le_86_qs;
-        reg_rdata_next[23] = le_2_le_87_qs;
       end
 
       addr_hit[6]: begin
@@ -11869,10 +11741,6 @@ module rv_plic_reg_top (
       end
 
       addr_hit[93]: begin
-        reg_rdata_next[1:0] = prio87_qs;
-      end
-
-      addr_hit[94]: begin
         reg_rdata_next[0] = ie0_0_e_0_qs;
         reg_rdata_next[1] = ie0_0_e_1_qs;
         reg_rdata_next[2] = ie0_0_e_2_qs;
@@ -11907,7 +11775,7 @@ module rv_plic_reg_top (
         reg_rdata_next[31] = ie0_0_e_31_qs;
       end
 
-      addr_hit[95]: begin
+      addr_hit[94]: begin
         reg_rdata_next[0] = ie0_1_e_32_qs;
         reg_rdata_next[1] = ie0_1_e_33_qs;
         reg_rdata_next[2] = ie0_1_e_34_qs;
@@ -11942,7 +11810,7 @@ module rv_plic_reg_top (
         reg_rdata_next[31] = ie0_1_e_63_qs;
       end
 
-      addr_hit[96]: begin
+      addr_hit[95]: begin
         reg_rdata_next[0] = ie0_2_e_64_qs;
         reg_rdata_next[1] = ie0_2_e_65_qs;
         reg_rdata_next[2] = ie0_2_e_66_qs;
@@ -11966,18 +11834,17 @@ module rv_plic_reg_top (
         reg_rdata_next[20] = ie0_2_e_84_qs;
         reg_rdata_next[21] = ie0_2_e_85_qs;
         reg_rdata_next[22] = ie0_2_e_86_qs;
-        reg_rdata_next[23] = ie0_2_e_87_qs;
       end
 
-      addr_hit[97]: begin
+      addr_hit[96]: begin
         reg_rdata_next[1:0] = threshold0_qs;
       end
 
-      addr_hit[98]: begin
+      addr_hit[97]: begin
         reg_rdata_next[6:0] = cc0_qs;
       end
 
-      addr_hit[99]: begin
+      addr_hit[98]: begin
         reg_rdata_next[0] = msip0_qs;
       end
 

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -163,7 +163,7 @@ module top_earlgrey #(
   // otbn
 
 
-  logic [87:0]  intr_vector;
+  logic [86:0]  intr_vector;
   // Interrupt source list
   logic intr_uart_tx_watermark;
   logic intr_uart_rx_watermark;
@@ -234,7 +234,6 @@ module top_earlgrey #(
   logic intr_edn1_edn_cmd_req_done;
   logic intr_edn1_edn_fifo_err;
   logic intr_otbn_done;
-  logic intr_otbn_err;
 
 
 
@@ -1264,7 +1263,6 @@ module top_earlgrey #(
 
       // Interrupt
       .intr_done_o (intr_otbn_done),
-      .intr_err_o  (intr_otbn_err),
 
       // [14]: imem_uncorrectable
       // [15]: dmem_uncorrectable
@@ -1287,7 +1285,6 @@ module top_earlgrey #(
       intr_kmac_kmac_done,
       intr_keymgr_err,
       intr_keymgr_op_done,
-      intr_otbn_err,
       intr_otbn_done,
       intr_pwrmgr_wakeup,
       intr_usbdev_link_out_err,

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.c
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.c
@@ -11,7 +11,7 @@
  * `top_earlgrey_plic_peripheral_t`.
  */
 const top_earlgrey_plic_peripheral_t
-    top_earlgrey_plic_interrupt_for_peripheral[88] = {
+    top_earlgrey_plic_interrupt_for_peripheral[87] = {
   [kTopEarlgreyPlicIrqIdNone] = kTopEarlgreyPlicPeripheralUnknown,
   [kTopEarlgreyPlicIrqIdGpioGpio0] = kTopEarlgreyPlicPeripheralGpio,
   [kTopEarlgreyPlicIrqIdGpioGpio1] = kTopEarlgreyPlicPeripheralGpio,
@@ -94,7 +94,6 @@ const top_earlgrey_plic_peripheral_t
   [kTopEarlgreyPlicIrqIdUsbdevLinkOutErr] = kTopEarlgreyPlicPeripheralUsbdev,
   [kTopEarlgreyPlicIrqIdPwrmgrWakeup] = kTopEarlgreyPlicPeripheralPwrmgr,
   [kTopEarlgreyPlicIrqIdOtbnDone] = kTopEarlgreyPlicPeripheralOtbn,
-  [kTopEarlgreyPlicIrqIdOtbnErr] = kTopEarlgreyPlicPeripheralOtbn,
   [kTopEarlgreyPlicIrqIdKeymgrOpDone] = kTopEarlgreyPlicPeripheralKeymgr,
   [kTopEarlgreyPlicIrqIdKeymgrErr] = kTopEarlgreyPlicPeripheralKeymgr,
   [kTopEarlgreyPlicIrqIdKmacKmacDone] = kTopEarlgreyPlicPeripheralKmac,

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -629,13 +629,12 @@ typedef enum top_earlgrey_plic_irq_id {
   kTopEarlgreyPlicIrqIdUsbdevLinkOutErr = 79, /**< usbdev_link_out_err */
   kTopEarlgreyPlicIrqIdPwrmgrWakeup = 80, /**< pwrmgr_wakeup */
   kTopEarlgreyPlicIrqIdOtbnDone = 81, /**< otbn_done */
-  kTopEarlgreyPlicIrqIdOtbnErr = 82, /**< otbn_err */
-  kTopEarlgreyPlicIrqIdKeymgrOpDone = 83, /**< keymgr_op_done */
-  kTopEarlgreyPlicIrqIdKeymgrErr = 84, /**< keymgr_err */
-  kTopEarlgreyPlicIrqIdKmacKmacDone = 85, /**< kmac_kmac_done */
-  kTopEarlgreyPlicIrqIdKmacFifoEmpty = 86, /**< kmac_fifo_empty */
-  kTopEarlgreyPlicIrqIdKmacKmacErr = 87, /**< kmac_kmac_err */
-  kTopEarlgreyPlicIrqIdLast = 87, /**< \internal The Last Valid Interrupt ID. */
+  kTopEarlgreyPlicIrqIdKeymgrOpDone = 82, /**< keymgr_op_done */
+  kTopEarlgreyPlicIrqIdKeymgrErr = 83, /**< keymgr_err */
+  kTopEarlgreyPlicIrqIdKmacKmacDone = 84, /**< kmac_kmac_done */
+  kTopEarlgreyPlicIrqIdKmacFifoEmpty = 85, /**< kmac_fifo_empty */
+  kTopEarlgreyPlicIrqIdKmacKmacErr = 86, /**< kmac_kmac_err */
+  kTopEarlgreyPlicIrqIdLast = 86, /**< \internal The Last Valid Interrupt ID. */
 } top_earlgrey_plic_irq_id_t;
 
 /**
@@ -645,7 +644,7 @@ typedef enum top_earlgrey_plic_irq_id {
  * `top_earlgrey_plic_peripheral_t`.
  */
 extern const top_earlgrey_plic_peripheral_t
-    top_earlgrey_plic_interrupt_for_peripheral[88];
+    top_earlgrey_plic_interrupt_for_peripheral[87];
 
 /**
  * PLIC Interrupt Target.

--- a/sw/device/lib/dif/dif_otbn.c
+++ b/sw/device/lib/dif/dif_otbn.c
@@ -25,9 +25,6 @@ static bool irq_bit_index_get(dif_otbn_interrupt_t irq_type,
     case kDifOtbnInterruptDone:
       offset = OTBN_INTR_COMMON_DONE_BIT;
       break;
-    case kDifOtbnInterruptErr:
-      offset = OTBN_INTR_COMMON_ERR_BIT;
-      break;
     default:
       return false;
   }

--- a/sw/device/lib/dif/dif_otbn.h
+++ b/sw/device/lib/dif/dif_otbn.h
@@ -100,14 +100,6 @@ typedef enum dif_otbn_interrupt {
    */
   kDifOtbnInterruptDone = 0,
 
-  /**
-   * An error occurred.
-   *
-   * The error cause can be determined by calling dif_otbn_get_err_code().
-   *
-   * Associated with the `otbn.INTR_STATE.err` hardware interrupt.
-   */
-  kDifOtbnInterruptErr = 1,
 } dif_otbn_interrupt_t;
 
 /**

--- a/sw/device/lib/dif/dif_plic.c
+++ b/sw/device/lib/dif/dif_plic.c
@@ -16,7 +16,7 @@
 // If either of these static assertions fail, then the assumptions in this DIF
 // implementation should be revisited. In particular, `kPlicTargets`
 // may need updating,
-_Static_assert(RV_PLIC_PARAM_NUMSRC == 88,
+_Static_assert(RV_PLIC_PARAM_NUMSRC == 87,
                "PLIC instantiation parameters have changed.");
 _Static_assert(RV_PLIC_PARAM_NUMTARGET == 1,
                "PLIC instantiation parameters have changed.");

--- a/sw/device/tests/dif/dif_otbn_unittest.cc
+++ b/sw/device/tests/dif/dif_otbn_unittest.cc
@@ -92,7 +92,7 @@ TEST_F(IrqStateGetTest, NullArgs) {
 }
 
 TEST_F(IrqStateGetTest, Success) {
-  // Get the first IRQ state.
+  // Get the (only) IRQ state.
   EXPECT_READ32(OTBN_INTR_STATE_REG_OFFSET, {{OTBN_INTR_STATE_DONE_BIT, true}});
 
   dif_otbn_enable_t done_state = kDifOtbnDisable;
@@ -100,14 +100,6 @@ TEST_F(IrqStateGetTest, Success) {
       dif_otbn_irq_state_get(&dif_otbn_, kDifOtbnInterruptDone, &done_state);
   EXPECT_EQ(result, kDifOtbnOk);
   EXPECT_EQ(done_state, kDifOtbnEnable);
-
-  // Get the last IRQ state.
-  EXPECT_READ32(OTBN_INTR_STATE_REG_OFFSET, {{OTBN_INTR_STATE_ERR_BIT, false}});
-
-  dif_otbn_enable_t err_state = kDifOtbnEnable;
-  result = dif_otbn_irq_state_get(&dif_otbn_, kDifOtbnInterruptErr, &err_state);
-  EXPECT_EQ(result, kDifOtbnOk);
-  EXPECT_EQ(err_state, kDifOtbnDisable);
 }
 
 class IrqStateClearTest : public OtbnTest {};
@@ -119,17 +111,11 @@ TEST_F(IrqStateClearTest, NullArgs) {
 }
 
 TEST_F(IrqStateClearTest, Success) {
-  // Clear the first IRQ state.
+  // Clear the (only) IRQ state.
   EXPECT_WRITE32(OTBN_INTR_STATE_REG_OFFSET, {{OTBN_INTR_STATE_DONE_BIT, 1}});
 
   dif_otbn_result_t result =
       dif_otbn_irq_state_clear(&dif_otbn_, kDifOtbnInterruptDone);
-  EXPECT_EQ(result, kDifOtbnOk);
-
-  // Clear the last IRQ state.
-  EXPECT_WRITE32(OTBN_INTR_STATE_REG_OFFSET, {{OTBN_INTR_STATE_ERR_BIT, 1}});
-
-  result = dif_otbn_irq_state_clear(&dif_otbn_, kDifOtbnInterruptErr);
   EXPECT_EQ(result, kDifOtbnOk);
 }
 
@@ -209,20 +195,12 @@ TEST_F(IrqControlTest, NullArgs) {
 }
 
 TEST_F(IrqControlTest, Success) {
-  // Enable first IRQ.
+  // Enable (only) IRQ.
   EXPECT_MASK32(OTBN_INTR_ENABLE_REG_OFFSET,
                 {{OTBN_INTR_ENABLE_DONE_BIT, 0x1, true}});
 
   dif_otbn_result_t result =
       dif_otbn_irq_control(&dif_otbn_, kDifOtbnInterruptDone, kDifOtbnEnable);
-  EXPECT_EQ(result, kDifOtbnOk);
-
-  // Disable last IRQ.
-  EXPECT_MASK32(OTBN_INTR_ENABLE_REG_OFFSET,
-                {{OTBN_INTR_ENABLE_ERR_BIT, 0x1, false}});
-
-  result =
-      dif_otbn_irq_control(&dif_otbn_, kDifOtbnInterruptErr, kDifOtbnDisable);
   EXPECT_EQ(result, kDifOtbnOk);
 }
 
@@ -234,19 +212,12 @@ TEST_F(IrqForceTest, NullArgs) {
 }
 
 TEST_F(IrqForceTest, Success) {
-  // Force first IRQ.
+  // Force (only) IRQ.
   EXPECT_MASK32(OTBN_INTR_TEST_REG_OFFSET,
                 {{OTBN_INTR_TEST_DONE_BIT, 0x1, true}});
 
   dif_otbn_result_t result =
       dif_otbn_irq_force(&dif_otbn_, kDifOtbnInterruptDone);
-  EXPECT_EQ(result, kDifOtbnOk);
-
-  // Force last IRQ.
-  EXPECT_MASK32(OTBN_INTR_TEST_REG_OFFSET,
-                {{OTBN_INTR_TEST_ERR_BIT, 0x1, true}});
-
-  result = dif_otbn_irq_force(&dif_otbn_, kDifOtbnInterruptErr);
   EXPECT_EQ(result, kDifOtbnOk);
 }
 

--- a/sw/device/tests/dif/dif_plic_unittest.cc
+++ b/sw/device/tests/dif/dif_plic_unittest.cc
@@ -95,19 +95,19 @@ class IrqTest : public PlicTest {
       kEnableRegisters{{
           {RV_PLIC_IE0_0_REG_OFFSET, RV_PLIC_IE0_0_E_31_BIT},
           {RV_PLIC_IE0_1_REG_OFFSET, RV_PLIC_IE0_1_E_63_BIT},
-          {RV_PLIC_IE0_2_REG_OFFSET, RV_PLIC_IE0_2_E_87_BIT},
+          {RV_PLIC_IE0_2_REG_OFFSET, RV_PLIC_IE0_2_E_86_BIT},
       }};
   static constexpr std::array<Register, RV_PLIC_LE_MULTIREG_COUNT>
       kTriggerRegisters{{
           {RV_PLIC_LE_0_REG_OFFSET, RV_PLIC_LE_0_LE_31_BIT},
           {RV_PLIC_LE_1_REG_OFFSET, RV_PLIC_LE_1_LE_63_BIT},
-          {RV_PLIC_LE_2_REG_OFFSET, RV_PLIC_LE_2_LE_87_BIT},
+          {RV_PLIC_LE_2_REG_OFFSET, RV_PLIC_LE_2_LE_86_BIT},
       }};
   static constexpr std::array<Register, RV_PLIC_IP_MULTIREG_COUNT>
       kPendingRegisters{{
           {RV_PLIC_IP_0_REG_OFFSET, RV_PLIC_IP_0_P_31_BIT},
           {RV_PLIC_IP_1_REG_OFFSET, RV_PLIC_IP_1_P_63_BIT},
-          {RV_PLIC_IP_2_REG_OFFSET, RV_PLIC_IP_2_P_87_BIT},
+          {RV_PLIC_IP_2_REG_OFFSET, RV_PLIC_IP_2_P_86_BIT},
       }};
 
   // Set enable/disable multireg expectations, one bit per call.


### PR DESCRIPTION
We're going to consolidate these interrupts, so the only one is the
`done` interrupt. To spot errors, the host software can use the
`ERR_CODE` status register.

This patch looks big because of auto-generated code, but the only manual
changes to hardware are:

  - `otbn.hjson`: Remove the interrupt
  - `otbn.sv`:    Remove the interrupt and tidy up the error code logic
  - `tb.sv`:      Remove a top-level connection

The manual changes to software are also small: although we've now just
got one interrupt type, the DIF style is to keep an explicit index, so
all we really do is remove an entry from the enum. There's also a
manually entered count of interrupts in `dif_plic.c` which needs
updating.

In software test code, we remove various entries from
`dif_otbn_unittest.cc`. The interrupt tests try the first and last
interrupts, which doesn't make sense when there's just one, so this
patch removes the "last" part each time. Finally, we have to change an
interrupt count in `dif_plic_unittest.cc`.

(EDIT: The original version of this patch stripped out much more of the DIF code before @lenary pointed out that this violated the agreed-on DIF style).