### PR TITLE
[dv/push-pull-agent] fix xcelium hanging issue

### DIFF
--- a/hw/dv/sv/push_pull_agent/push_pull_monitor.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_monitor.sv
@@ -21,8 +21,6 @@ class push_pull_monitor #(parameter int HostDataWidth = 32,
 
   `uvm_component_new
 
-  bit valid_txn;
-
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
     req_port = new("req_port", this);
@@ -53,6 +51,7 @@ class push_pull_monitor #(parameter int HostDataWidth = 32,
   // TODO : sample covergroups
   virtual protected task collect_valid_trans();
     push_pull_item#(HostDataWidth, DeviceDataWidth) item;
+    bit valid_txn;
     forever begin
       @(cfg.vif.mon_cb);
       if (cfg.agent_type == PushAgent) begin
@@ -97,7 +96,7 @@ class push_pull_monitor #(parameter int HostDataWidth = 32,
         req_port.write(item);
         // After picking up a request, wait until a response is sent before
         // detecting another request, as this is not a pipelined protocol.
-        @(negedge valid_txn);
+        while (!cfg.vif.mon_cb.ack) @(cfg.vif.mon_cb);
       end
     end
   endtask


### PR DESCRIPTION
In push-pull agent monitor, we set `valid_txn` to 1 and to 0
sequentially without any timing delay, then in a separate thread we are
looking for a negedge for `valid_txn`.
It works fine for VCS, but for xcelim, it could not detect the negedge.
This PR fix it by using design signal `req` and `ack` instead of `valid_txn`.
Thanks @weicaiyang for the suggestion and review.

Signed-off-by: Cindy Chen <chencindy@google.com>