### PR TITLE
[csrng/rtl] fix assentlint errors

### DIFF
--- a/hw/ip/csrng/data/csrng.hjson
+++ b/hw/ip/csrng/data/csrng.hjson
@@ -114,6 +114,8 @@
       desc: "Summary status register",
       swaccess: "ro",
       hwaccess: "hwo",
+      tags: [// Internal HW can modify status register
+             "excl:CsrAllTests:CsrExclCheck"]
       fields: [
         { bits: "23:0",
           name: "FIFO_DEPTH_STS",

--- a/hw/ip/csrng/rtl/csrng.sv
+++ b/hw/ip/csrng/rtl/csrng.sv
@@ -90,12 +90,12 @@ module csrng import csrng_pkg::*; #(
 
   // Application Interface Asserts
   for (genvar i = 0; i < NHwApps; i = i+1) begin : gen_app_if_asserts
-    `ASSERT_KNOWN(CsrngReqReady0KnownO_A, csrng_cmd_o[i].csrng_req_ready)
-    `ASSERT_KNOWN(CsrngRspAck0KnownO_A, csrng_cmd_o[i].csrng_rsp_ack)
-    `ASSERT_KNOWN(CsrngRspSts0KnownO_A, csrng_cmd_o[i].csrng_rsp_sts)
-    `ASSERT_KNOWN(CsrngGenbitsValid0KnownO_A, csrng_cmd_o[i].genbits_valid)
-    `ASSERT_KNOWN(CsrngGenbitsFips0KnownO_A, csrng_cmd_o[i].genbits_fips)
-    `ASSERT_KNOWN(CsrngGenbitsBus0KnownO_A, csrng_cmd_o[i].genbits_bus)
+    `ASSERT_KNOWN(CsrngReqReadyKnownO_A, csrng_cmd_o[i].csrng_req_ready)
+    `ASSERT_KNOWN(CsrngRspAckKnownO_A, csrng_cmd_o[i].csrng_rsp_ack)
+    `ASSERT_KNOWN(CsrngRspStsKnownO_A, csrng_cmd_o[i].csrng_rsp_sts)
+    `ASSERT_KNOWN(CsrngGenbitsValidKnownO_A, csrng_cmd_o[i].genbits_valid)
+    `ASSERT_KNOWN(CsrngGenbitsFipsKnownO_A, csrng_cmd_o[i].genbits_fips)
+    `ASSERT_KNOWN(CsrngGenbitsBusKnownO_A, csrng_cmd_o[i].genbits_bus)
   end : gen_app_if_asserts
 
   `ASSERT_KNOWN(IntrCsCmdReqDoneKnownO_A, intr_cs_cmd_req_done_o)

--- a/hw/ip/csrng/rtl/csrng_core.sv
+++ b/hw/ip/csrng/rtl/csrng_core.sv
@@ -1117,15 +1117,14 @@ module csrng_core import csrng_pkg::*; #(
   assign hw2reg.hw_exc_sts.de = cs_enable;
   assign hw2reg.hw_exc_sts.d  = hw_exception_sts;
 
+  // TODO: add depths or remove
   assign hw2reg.sum_sts.fifo_depth_sts.de = cs_enable;
   assign hw2reg.sum_sts.fifo_depth_sts.d  =
          (fifo_sel == 4'h0) ? 24'b0 :
          24'b0;
 
-
   assign hw2reg.sum_sts.diag.de = !cs_enable;
   assign hw2reg.sum_sts.diag.d  =
-         1'b0                    &&
          (reg2hw.regen.q)        && // not used
          (|reg2hw.genbits.q);       // not used
 


### PR DESCRIPTION
Also adding a tag to not check a status register.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>