### PR TITLE
[otp/dv] improve DAI access in TB

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -127,7 +127,10 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
       end
       "direct_access_cmd": begin
         if (addr_phase_write && ral.direct_access_regwen.get_mirrored_value()) begin
-          int dai_addr = ral.direct_access_address.get_mirrored_value();
+          int rand_digit = is_secret(dai_addr) ? 3 : 2;
+          int dai_addr = ral.direct_access_address.get_mirrored_value() >>
+                         rand_digit << rand_digit;
+
           case (item.a_data)
             DaiDigest: cal_digest_val(get_part_index(dai_addr));
             DaiWrite: begin

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -15,6 +15,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
   bit do_otp_pwr_init  = 1'b1;
 
   rand bit [NumOtpCtrlIntr-1:0] en_intr;
+  bit [TL_AW-1:0] used_dai_addr_q[$];
 
   `uvm_object_new
 
@@ -46,6 +47,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     // reset memory to avoid readout X
     cfg.mem_bkdr_vif.clear_mem();
     cfg.backdoor_clear_mem = 1;
+    used_dai_addr_q.delete();
   endtask
 
   // some registers won't set to default value until otp_init is done

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -11,17 +11,18 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
 
   `uvm_object_new
 
-  randc bit [TL_AW-1:0]          dai_addr;
-  rand  bit [TL_DW-1:0]          wdata0, wdata1;
-  rand  int                      num_dai_wr;
-  rand  otp_ctrl_part_pkg::part_idx_e part_idx;
+  rand bit [TL_AW-1:0]               dai_addr;
+  rand bit [TL_DW-1:0]               wdata0, wdata1;
+  rand int                           num_dai_wr;
+  rand otp_ctrl_part_pkg::part_idx_e part_idx;
 
-  // TODO: temp -> no life-cycle partition involved
+  // LC partition does not allow DAI access
   constraint partition_index_c {
     part_idx inside {[CreatorSwCfgIdx:Secret2Idx]};
   }
 
   constraint dai_addr_c {
+    dai_addr inside {used_dai_addr_q} == 0;
     if (part_idx == CreatorSwCfgIdx) dai_addr inside `PART_ADDR_RANGE(CreatorSwCfgIdx);
     if (part_idx == OwnerSwCfgIdx)   dai_addr inside `PART_ADDR_RANGE(OwnerSwCfgIdx);
     if (part_idx == HwCfgIdx)        dai_addr inside `PART_ADDR_RANGE(HwCfgIdx);
@@ -75,6 +76,8 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
 
         // OTP write via DAI
         dai_wr(dai_addr, wdata0, wdata1);
+
+        used_dai_addr_q.push_back(dai_addr);
 
         // OTP read via DAI
         dai_rd(dai_addr, rdata0, rdata1);


### PR DESCRIPTION
There are two commits related to this PR:
1. Remove the randc for dai_addr, instead use a queue of used address. This gives more control over used dai_address, later will be more useful for error case testing.

2. This commits have two changes:
  1). Randomly choose to readout via DAI to create the case for back to back write.
  2). Randomize the last 2 bits for non-secret partitions, and last 3 bits for secret partitions.