### PR TITLE
[kmac] Revise to release MsgFIFO access when Idle

### DIFF
--- a/hw/ip/kmac/lint/kmac.waiver
+++ b/hw/ip/kmac/lint/kmac.waiver
@@ -18,3 +18,7 @@ waive -rules {HIER_NET_NOT_READ NOT_READ INPUT_NOT_READ} \
 waive -rules {TWO_STATE_TYPE} -location {kmac.sv} \
     -regexp {'tl_window_e' is of two state type} \
     -comment "Window enum is used to select, not synthesized"
+
+waive -rules {TAG_OVERLAP} -location {kmac_keymgr.sv} \
+    -regexp {Case tag expression '2'b1.* overlaps with previous tag} \
+    -comment "priority casez makes the condition check explicitly"

--- a/hw/ip/kmac/rtl/kmac_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_pkg.sv
@@ -97,7 +97,18 @@ package kmac_pkg;
 
     // ErrKeyNotValid: KeyMgr interface raises an error if the secret key is
     // not valid when KeyMgr initiates KDF.
-    ErrKeyNotValid = 8'h 01
+    ErrKeyNotValid = 8'h 01,
+
+    // ErrSwPushMsgFifo: Sw writes data into Msg FIFO abruptly.
+    // This error occurs in below scenario:
+    //   - Sw does not send "Start" command to KMAC then writes data into
+    //     Msg FIFO
+    //   - Sw writes data into Msg FIFO when KeyMgr is in operating
+    ErrSwPushedMsgFifo = 8'h 02,
+
+    // ErrSwPushWrongCmd
+    //  - Sw writes any command except CmdStart when Idle.
+    ErrSwPushedWrongCmd = 8'h 03
   } err_code_e;
 
   typedef struct packed {


### PR DESCRIPTION
Problem:

    When Idle or KeyMgr is in operation (KDF), Sw access to MsgFIFO
    hangs the interconnect.

`kmac_keymgr` drops the `sw_ready_o` if `mux_sel` is not `SelSw`. The
mux is switched to the software when KeyMgr is not operating and the
software issues `CmdStart`.

In this case when the mux is not switched to the software, if the
software writes data into the Msg FIFO, the keymgr interface module
never asserts the ready. So, there's no way for software to release this
condition, as the software cannot issue CmdStart.

This commit is to fix the behavior by asserting the ready always. Then
it also creates an error code for this scenario so that the software
knows what it did wrong.

This is related to issue #4409