### PR TITLE
[lc_ctrl dv] Remove -top in sim_tops

### DIFF
--- a/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
+++ b/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
@@ -35,7 +35,7 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
 
   // Add additional tops for simulation.
-  sim_tops: ["-top lc_ctrl_bind"]
+  sim_tops: ["lc_ctrl_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50


### PR DESCRIPTION
This removes the `-top` switch with the recent changes in #4366.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>