### PR TITLE
[keymgr/dv] Add cfgen vseq

### DIFF
--- a/hw/ip/keymgr/dv/env/keymgr_env.core
+++ b/hw/ip/keymgr/dv/env/keymgr_env.core
@@ -23,7 +23,7 @@ filesets:
       - seq_lib/keymgr_common_vseq.sv: {is_include_file: true}
       - seq_lib/keymgr_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/keymgr_random_vseq.sv: {is_include_file: true}
-      - seq_lib/keymgr_op_at_wipe_state_vseq.sv: {is_include_file: true}
+      - seq_lib/keymgr_cfgen_vseq.sv: {is_include_file: true}
       - seq_lib/keymgr_direct_to_disabled_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_base_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_base_vseq.sv
@@ -112,7 +112,7 @@ class keymgr_base_vseq extends cip_base_vseq #(
 
     // wait for status to get out of OpWip and check
     csr_spinwait(.ptr(ral.op_status.status), .exp_data(keymgr_pkg::OpWip),
-                 .compare_op(CompareOpNe));
+                 .compare_op(CompareOpNe), .spinwait_delay_ns($urandom_range(0, 100)));
     exp_status = is_good_op ? keymgr_pkg::OpDoneSuccess : keymgr_pkg::OpDoneFail;
     `DV_CHECK_EQ(ral.op_status.status.get_mirrored_value(), exp_status)
 

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_cfgen_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_cfgen_vseq.sv
@@ -1,0 +1,77 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// SW starts operation and HW will set cfgen=0 to prevent write to registers gated by cfgen
+// Test those registers can't be written during OpWip
+// Also check cfgen value is updated by design correctly
+class keymgr_cfgen_vseq extends keymgr_smoke_vseq;
+  `uvm_object_utils(keymgr_cfgen_vseq)
+  `uvm_object_new
+
+  virtual task body();
+    bit regular_vseq_done;
+    fork
+      write_cfgen_gate_regs_during_op_wip(regular_vseq_done);
+      begin
+        super.body();
+        // let the unblocking thread finish before ending this seq
+        regular_vseq_done = 1;
+      end
+    join
+  endtask : body
+
+  task write_cfgen_gate_regs_during_op_wip(ref bit regular_vseq_done);
+    // since it's very timing sensitive, backdoor wait op_status.
+    // randomly add 0-100 cycle delay, backdoor check op_status again
+    // When status is still OpWip, call write_cfgen_gated_reg and the write will be ignored
+    while (!regular_vseq_done) begin
+      bit [TL_DW-1] op_status_val, cfgen_val;
+      uint delay;
+
+      forever begin
+        csr_rd(ral.op_status, op_status_val, .backdoor(1));
+
+        if (op_status_val == keymgr_pkg::OpWip) break;
+        else if (regular_vseq_done) return;
+
+        cfg.clk_rst_vif.wait_clks(1);
+      end
+
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(delay,
+                                         delay dist {[0:1]    :/ 1,
+                                                     [2:10]   :/ 1,
+                                                     [11:100] :/ 1};)
+      cfg.clk_rst_vif.wait_clks(delay);
+
+      // 50% to read cfgen and check in scb
+      if ($urandom_range(0, 1)) csr_rd(ral.cfgen, cfgen_val);
+
+      // writing during cfgen is timing sensitive
+      // 1. make sure no other thread is accessing register
+      // 2. use backdoor check op_status again in case it's not OpWip after front-door read
+      wait_no_outstanding_access();
+      csr_rd(ral.op_status, op_status_val, .backdoor(1));
+      if (op_status_val == keymgr_pkg::OpWip) write_cfgen_gated_reg();
+    end
+  endtask
+
+  virtual task write_cfgen_gated_reg();
+    bit [TL_DW-1] val = $urandom;
+
+    `uvm_info(`gfn, "Write cfgen gated reg, and this write should be ignored", UVM_HIGH)
+    // since it's timing sensitive, only write one of these reg
+    randcase
+      1: csr_wr(ral.control,            val);
+      1: csr_wr(ral.key_version,        val);
+      1: csr_wr(ral.sw_binding_0,       val);
+      1: csr_wr(ral.sw_binding_1,       val);
+      1: csr_wr(ral.sw_binding_2,       val);
+      1: csr_wr(ral.sw_binding_3,       val);
+      1: csr_wr(ral.salt_0,             val);
+      1: csr_wr(ral.salt_1,             val);
+      1: csr_wr(ral.salt_2,             val);
+      1: csr_wr(ral.salt_3,             val);
+    endcase
+  endtask : write_cfgen_gated_reg
+endclass : keymgr_cfgen_vseq

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_vseq_list.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_vseq_list.sv
@@ -5,6 +5,6 @@
 `include "keymgr_base_vseq.sv"
 `include "keymgr_smoke_vseq.sv"
 `include "keymgr_common_vseq.sv"
-//`include "keymgr_op_at_wipe_state_vseq.sv"
 `include "keymgr_random_vseq.sv"
+`include "keymgr_cfgen_vseq.sv"
 `include "keymgr_direct_to_disabled_vseq.sv"

--- a/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson
+++ b/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson
@@ -60,9 +60,9 @@
     }
 
     {
-      name: keymgr_op_at_wipe_state
-      uvm_test_seq: keymgr_op_at_wipe_state_vseq
-      // StWipe only lasts for several cycles, don't add delay during CSR access
+      name: keymgr_cfgen
+      uvm_test_seq: keymgr_cfgen_vseq
+      // This test is to check reg programming is gated when cfgen=0, it's timing sensitive
       run_opts: ["+zero_delays=1"]
     }
 


### PR DESCRIPTION
Remove keymgr_op_at_wipe_state_vseq and add cfgen vseq to cover 2 test
items:
1. cfgen_during_op
2. cfgen_at_stRandom_state

Signed-off-by: Weicai Yang <weicai@google.com>