### PR TITLE
[dv common] Enable DV macros in non-UVM components

### DIFF
--- a/hw/dv/sv/dv_utils/dv_macros.svh
+++ b/hw/dv/sv/dv_utils/dv_macros.svh
@@ -11,8 +11,13 @@
 
 // UVM speficic macros
 `ifndef gfn
+`ifdef UVM
   // verilog_lint: waive macro-name-style
   `define gfn get_full_name()
+`else
+  // verilog_lint: waive macro-name-style
+  `define gfn $sformatf("%m")
+`endif
 `endif
 
 `ifndef gtn
@@ -37,9 +42,9 @@
   `define downcast(EXT_, BASE_, MSG_="", SEV_=fatal, ID_=`gfn) \
     begin \
       if (!$cast(EXT_, BASE_)) begin \
-        `uvm_``SEV_(ID_, $sformatf({"Cast failed: base class variable %0s ", \
-                                    "does not hold extended class %0s handle %s"}, \
-                                    `"BASE_`", `"EXT_`", MSG_)) \
+        `dv_``SEV_($sformatf({"Cast failed: base class variable %0s ", \
+                              "does not hold extended class %0s handle %s"}, \
+                              `"BASE_`", `"EXT_`", MSG_), ID_) \
       end \
     end
 `endif
@@ -80,7 +85,7 @@
   `define DV_CHECK(T_, MSG_="", SEV_=error, ID_=`gfn) \
     begin \
       if (!(T_)) begin \
-        `uvm_``SEV_(ID_, $sformatf("Check failed (%s) %s ", `"T_`", MSG_)) \
+        `dv_``SEV_($sformatf("Check failed (%s) %s ", `"T_`", MSG_), ID_) \
       end \
     end
 `endif
@@ -89,8 +94,8 @@
   `define DV_CHECK_EQ(ACT_, EXP_, MSG_="", SEV_=error, ID_=`gfn) \
     begin \
       if (!((ACT_) == (EXP_))) begin \
-        `uvm_``SEV_(ID_, $sformatf("Check failed %s == %s (%0d [0x%0h] vs %0d [0x%0h]) %s", \
-                                    `"ACT_`", `"EXP_`", ACT_, ACT_, EXP_, EXP_, MSG_)) \
+        `dv_``SEV_($sformatf("Check failed %s == %s (%0d [0x%0h] vs %0d [0x%0h]) %s", \
+                             `"ACT_`", `"EXP_`", ACT_, ACT_, EXP_, EXP_, MSG_), ID_) \
       end \
     end
 `endif
@@ -99,8 +104,8 @@
   `define DV_CHECK_NE(ACT_, EXP_, MSG_="", SEV_=error, ID_=`gfn) \
     begin \
       if (!((ACT_) != (EXP_))) begin \
-        `uvm_``SEV_(ID_, $sformatf("Check failed %s != %s (%0d [0x%0h] vs %0d [0x%0h]) %s", \
-                                    `"ACT_`", `"EXP_`", ACT_, ACT_, EXP_, EXP_, MSG_)) \
+        `dv_``SEV_($sformatf("Check failed %s != %s (%0d [0x%0h] vs %0d [0x%0h]) %s", \
+                             `"ACT_`", `"EXP_`", ACT_, ACT_, EXP_, EXP_, MSG_), ID_) \
       end \
     end
 `endif
@@ -109,8 +114,8 @@
   `define DV_CHECK_CASE_EQ(ACT_, EXP_, MSG_="", SEV_=error, ID_=`gfn) \
     begin \
       if (!((ACT_) === (EXP_))) begin \
-        `uvm_``SEV_(ID_, $sformatf("Check failed %s === %s (0x%0h [%0b] vs 0x%0h [%0b]) %s", \
-                                    `"ACT_`", `"EXP_`", ACT_, ACT_, EXP_, EXP_, MSG_)) \
+        `dv_``SEV_($sformatf("Check failed %s === %s (0x%0h [%0b] vs 0x%0h [%0b]) %s", \
+                             `"ACT_`", `"EXP_`", ACT_, ACT_, EXP_, EXP_, MSG_), ID_) \
       end \
     end
 `endif
@@ -119,8 +124,8 @@
   `define DV_CHECK_CASE_NE(ACT_, EXP_, MSG_="", SEV_=error, ID_=`gfn) \
     begin \
       if (!((ACT_) !== (EXP_))) begin \
-        `uvm_``SEV_(ID_, $sformatf("Check failed %s !== %s (%0d [0x%0h] vs %0d [0x%0h]) %s", \
-                                    `"ACT_`", `"EXP_`", ACT_, ACT_, EXP_, EXP_, MSG_)) \
+        `dv_``SEV_($sformatf("Check failed %s !== %s (%0d [0x%0h] vs %0d [0x%0h]) %s", \
+                             `"ACT_`", `"EXP_`", ACT_, ACT_, EXP_, EXP_, MSG_), ID_) \
       end \
     end
 `endif
@@ -129,8 +134,8 @@
   `define DV_CHECK_LT(ACT_, EXP_, MSG_="", SEV_=error, ID_=`gfn) \
     begin \
       if (!((ACT_) < (EXP_))) begin \
-        `uvm_``SEV_(ID_, $sformatf("Check failed %s < %s (%0d [0x%0h] vs %0d [0x%0h]) %s", \
-                                    `"ACT_`", `"EXP_`", ACT_, ACT_, EXP_, EXP_, MSG_)) \
+        `dv_``SEV_($sformatf("Check failed %s < %s (%0d [0x%0h] vs %0d [0x%0h]) %s", \
+                             `"ACT_`", `"EXP_`", ACT_, ACT_, EXP_, EXP_, MSG_), ID_) \
       end \
     end
 `endif
@@ -139,8 +144,8 @@
   `define DV_CHECK_GT(ACT_, EXP_, MSG_="", SEV_=error, ID_=`gfn) \
     begin \
       if (!((ACT_) > (EXP_))) begin \
-        `uvm_``SEV_(ID_, $sformatf("Check failed %s > %s (%0d [0x%0h] vs %0d [0x%0h]) %s", \
-                                    `"ACT_`", `"EXP_`", ACT_, ACT_, EXP_, EXP_, MSG_)) \
+        `dv_``SEV_($sformatf("Check failed %s > %s (%0d [0x%0h] vs %0d [0x%0h]) %s", \
+                             `"ACT_`", `"EXP_`", ACT_, ACT_, EXP_, EXP_, MSG_), ID_) \
       end \
     end
 `endif
@@ -149,8 +154,8 @@
   `define DV_CHECK_LE(ACT_, EXP_, MSG_="", SEV_=error, ID_=`gfn) \
     begin \
       if (!((ACT_) <= (EXP_))) begin \
-        `uvm_``SEV_(ID_, $sformatf("Check failed %s <= %s (%0d [0x%0h] vs %0d [0x%0h]) %s", \
-                                    `"ACT_`", `"EXP_`", ACT_, ACT_, EXP_, EXP_, MSG_)) \
+        `dv_``SEV_($sformatf("Check failed %s <= %s (%0d [0x%0h] vs %0d [0x%0h]) %s", \
+                             `"ACT_`", `"EXP_`", ACT_, ACT_, EXP_, EXP_, MSG_), ID_) \
       end \
     end
 `endif
@@ -159,8 +164,8 @@
   `define DV_CHECK_GE(ACT_, EXP_, MSG_="", SEV_=error, ID_=`gfn) \
     begin \
       if (!((ACT_) >= (EXP_))) begin \
-        `uvm_``SEV_(ID_, $sformatf("Check failed %s >= %s (%0d [0x%0h] vs %0d [0x%0h]) %s", \
-                                    `"ACT_`", `"EXP_`", ACT_, ACT_, EXP_, EXP_, MSG_)) \
+        `dv_``SEV_($sformatf("Check failed %s >= %s (%0d [0x%0h] vs %0d [0x%0h]) %s", \
+                             `"ACT_`", `"EXP_`", ACT_, ACT_, EXP_, EXP_, MSG_), ID_) \
       end \
     end
 `endif
@@ -168,14 +173,14 @@
 `ifndef DV_CHECK_STREQ
   `define DV_CHECK_STREQ(ACT_, EXP_, MSG_="", SEV_=error, ID_=`gfn) \
     if (!((ACT_) == (EXP_))) begin \
-      `uvm_``SEV_(ID_, $sformatf("Check failed \"%s\" == \"%s\" %s", ACT_, EXP_, MSG_)); \
+      `dv_``SEV_($sformatf("Check failed \"%s\" == \"%s\" %s", ACT_, EXP_, MSG_), ID_) \
     end
 `endif
 
 `ifndef DV_CHECK_STRNE
   `define DV_CHECK_STRNE(ACT_, EXP_, MSG_="", SEV_=error, ID_=`gfn) \
     if (!((ACT_) != (EXP_))) begin \
-      `uvm_``SEV_(ID_, $sformatf("Check failed \"%s\" != \"%s\" %s", ACT_, EXP_, MSG_)); \
+      `dv_``SEV_($sformatf("Check failed \"%s\" != \"%s\" %s", ACT_, EXP_, MSG_), ID_) \
     end
 `endif
 
@@ -268,7 +273,7 @@
 `define DV_PRINT_ARR_CONTENTS(ARR_, V_=UVM_MEDIUM, ID_=`gfn) \
   begin \
     foreach (ARR_[i]) begin \
-      `uvm_info(ID_, $sformatf("%s[%0d] = 0x%0d[0x%0h]", `"ARR_`", i, ARR_[i], ARR_[i]), V_) \
+      `dv_info($sformatf("%s[%0d] = 0x%0d[0x%0h]", `"ARR_`", i, ARR_[i], ARR_[i]), V_, ID_) \
     end \
   end
 `endif
@@ -280,7 +285,7 @@
     while (!FIFO_.is_empty()) begin \
       TYP_ item; \
       void'(FIFO_.try_get(item)); \
-      `uvm_``SEV_(ID_, $sformatf("%s item uncompared:\n%s", `"FIFO_`", item.sprint())) \
+      `dv_``SEV_($sformatf("%s item uncompared:\n%s", `"FIFO_`", item.sprint()), ID_) \
     end \
   end
 `endif
@@ -293,7 +298,7 @@
       while (!FIFO_[i].is_empty()) begin \
         TYP_ item; \
         void'(FIFO_[i].try_get(item)); \
-        `uvm_``SEV_(ID_, $sformatf("%s[%0d] item uncompared:\n%s", `"FIFO_`", i, item.sprint())) \
+        `dv_``SEV_($sformatf("%s[%0d] item uncompared:\n%s", `"FIFO_`", i, item.sprint()), ID_) \
       end \
     end \
   end
@@ -305,7 +310,7 @@
   begin \
     while (Q_.size() != 0) begin \
       TYP_ item = Q_.pop_front(); \
-      `uvm_``SEV_(ID_, $sformatf("%s item uncompared:\n%s", `"Q_`", item.sprint())) \
+      `dv_``SEV_($sformatf("%s item uncompared:\n%s", `"Q_`", item.sprint()), ID_) \
     end \
   end
 `endif
@@ -317,7 +322,7 @@
     foreach (Q_[i]) begin \
       while (Q_[i].size() != 0) begin \
         TYP_ item = Q_[i].pop_front(); \
-        `uvm_``SEV_(ID_, $sformatf("%s[%0d] item uncompared:\n%s", `"Q_`", i, item.sprint())) \
+        `dv_``SEV_($sformatf("%s[%0d] item uncompared:\n%s", `"Q_`", i, item.sprint()), ID_) \
       end \
     end \
   end
@@ -330,7 +335,7 @@
     while (MAILBOX_.num() != 0) begin \
       TYP_ item; \
       void'(MAILBOX_.try_get(item)); \
-      `uvm_``SEV_(ID_, $sformatf("%s item uncompared:\n%s", `"MAILBOX_`", item.sprint())) \
+      `dv_``SEV_($sformatf("%s item uncompared:\n%s", `"MAILBOX_`", item.sprint()), ID_) \
     end \
   end
 `endif
@@ -359,7 +364,7 @@
         begin \
           EXIT_ \
           if (MSG_ != "") begin \
-            `uvm_info(ID_, MSG_, UVM_HIGH) \
+            `dv_info(MSG_, UVM_HIGH, ID_) \
           end \
         end \
       join_any \
@@ -428,47 +433,64 @@
 // Macros for logging (info, warning, error and fatal severities).
 //
 // These are meant to be invoked in modules and interfaces that are shared between DV and Verilator
-// testbenches.
+// testbenches. We waive the lint requirement for these to be in uppercase, since they are
+// UVM-adjacent.
 `ifdef UVM
-`ifndef DV_INFO
-  `define DV_INFO(MSG_,  VERBOSITY_ = UVM_LOW, ID_ = $sformatf("%m")) \
-    `uvm_info(ID_, MSG_, VERBOSITY_)
+`ifndef dv_info
+  // verilog_lint: waive macro-name-style
+  `define dv_info(MSG_,  VERBOSITY_ = UVM_LOW, ID_ = $sformatf("%m")) \
+    if (uvm_pkg::uvm_report_enabled(VERBOSITY_, uvm_pkg::UVM_INFO, ID_)) begin \
+        uvm_pkg::uvm_report_info(ID_, MSG_, VERBOSITY_, `uvm_file, `uvm_line, "", 1); \
+    end
 `endif
 
-`ifndef DV_WARNING
-  `define DV_WARNING(MSG_, ID_ = $sformatf("%m")) \
-    `uvm_warning(ID_, MSG_)
+`ifndef dv_warning
+  // verilog_lint: waive macro-name-style
+  `define dv_warning(MSG_, ID_ = $sformatf("%m")) \
+    if (uvm_pkg::uvm_report_enabled(uvm_pkg::UVM_NONE, uvm_pkg::UVM_WARNING, ID_)) begin \
+        uvm_pkg::uvm_report_warning(ID_, MSG_, uvm_pkg::UVM_NONE, `uvm_file, `uvm_line, "", 1); \
+    end
 `endif
 
-`ifndef DV_ERROR
-  `define DV_ERROR(MSG_, ID_ = $sformatf("%m")) \
-    `uvm_error(ID_, MSG_)
+`ifndef dv_error
+  // verilog_lint: waive macro-name-style
+  `define dv_error(MSG_, ID_ = $sformatf("%m")) \
+    if (uvm_pkg::uvm_report_enabled(uvm_pkg::UVM_NONE, uvm_pkg::UVM_ERROR, ID_)) begin \
+        uvm_pkg::uvm_report_error(ID_, MSG_, uvm_pkg::UVM_NONE, `uvm_file, `uvm_line, "", 1); \
+    end
 `endif
 
-`ifndef DV_FATAL
-  `define DV_FATAL(MSG_, ID_ = $sformatf("%m")) \
-    `uvm_fatal(ID_, MSG_)
+`ifndef dv_fatal
+  // verilog_lint: waive macro-name-style
+  `define dv_fatal(MSG_, ID_ = $sformatf("%m")) \
+    if (uvm_pkg::uvm_report_enabled(uvm_pkg::UVM_NONE, uvm_pkg::UVM_FATAL, ID_)) begin \
+        uvm_pkg::uvm_report_fatal(ID_, MSG_, uvm_pkg::UVM_NONE, `uvm_file, `uvm_line, "", 1); \
+    end
 `endif
 
 `else // UVM
 
-`ifndef DV_INFO
-  `define DV_INFO(MSG_, VERBOSITY = DUMMY_, ID_ = $sformatf("%m")) \
+`ifndef dv_info
+  // verilog_lint: waive macro-name-style
+  `define dv_info(MSG_, VERBOSITY = DUMMY_, ID_ = $sformatf("%m")) \
     $display("%0t: (%0s:%0d) [%0s] %0s", $time, `__FILE__, `__LINE__, ID_, MSG_);
 `endif
 
-`ifndef DV_WARNING
-  `define DV_WARNING(MSG_, ID_ = $sformatf("%m")) \
+`ifndef dv_warning
+  // verilog_lint: waive macro-name-style
+  `define dv_warning(MSG_, ID_ = $sformatf("%m")) \
     $warning("%0t: (%0s:%0d) [%0s] %0s", $time, `__FILE__, `__LINE__, ID_, MSG_);
 `endif
 
-`ifndef DV_ERROR
-  `define DV_ERROR(MSG_, ID_ = $sformatf("%m")) \
+`ifndef dv_error
+  // verilog_lint: waive macro-name-style
+  `define dv_error(MSG_, ID_ = $sformatf("%m")) \
     $error("%0t: (%0s:%0d) [%0s] %0s", $time, `__FILE__, `__LINE__, ID_, MSG_);
 `endif
 
-`ifndef DV_FATAL
-  `define DV_FATAL(MSG_, ID_ = $sformatf("%m")) \
+`ifndef dv_fatal
+  // verilog_lint: waive macro-name-style
+  `define dv_fatal(MSG_, ID_ = $sformatf("%m")) \
     $fatal("%0t: (%0s:%0d) [%0s] %0s", $time, `__FILE__, `__LINE__, ID_, MSG_);
 `endif
 
@@ -511,7 +533,7 @@
     /* The #1 delay below allows any part of the tb to control the conditions first at t = 0. */ \
     #1; \
     if ((en_``__CG_NAME) || (__COND)) begin \
-      `DV_INFO({"Creating covergroup ", `"__CG_NAME`"}, UVM_MEDIUM) \
+      `dv_info({"Creating covergroup ", `"__CG_NAME`"}, UVM_MEDIUM) \
       __CG_NAME``_inst = new``__CG_ARGS; \
     end \
   end

--- a/hw/dv/sv/sw_logger_if/sw_logger_if.sv
+++ b/hw/dv/sv/sw_logger_if/sw_logger_if.sv
@@ -136,7 +136,7 @@ interface sw_logger_if #(
   function automatic void add_sw_log_db(string sw_image);
     string sw_dir;
     string sw_basename;
-    if (_ready) `DV_FATAL("This function cannot be called after calling ready()")
+    if (_ready) `dv_fatal("This function cannot be called after calling ready()")
     sw_dir = str_utils_pkg::str_path_dirname(sw_image);
     sw_basename = str_utils_pkg::str_path_basename(.filename(sw_image), .drop_extn(1'b1));
     sw_log_db_files[sw_basename] = {sw_dir, "/", sw_basename, ".logs.txt"};
@@ -217,7 +217,7 @@ interface sw_logger_if #(
         end
 
         if (sw_logs.exists(sw) && sw_logs[sw].exists(addr)) begin
-          `DV_WARNING($sformatf("Log entry for addr %0x already exists:\nOld: %p\nNew: %p",
+          `dv_warning($sformatf("Log entry for addr %0x already exists:\nOld: %p\nNew: %p",
                                 addr, sw_logs[sw][addr], sw_log))
         end
         sw_logs[sw][addr] = sw_log;
@@ -232,7 +232,7 @@ interface sw_logger_if #(
 
     // print parsed logs
     foreach (sw_logs[sw, addr]) begin
-      `DV_INFO($sformatf("sw_logs[%0s][%0h] = %p", sw, addr, sw_logs[sw][addr]), UVM_HIGH)
+      `dv_info($sformatf("sw_logs[%0s][%0h] = %p", sw, addr, sw_logs[sw][addr]), UVM_HIGH)
     end
 
     return result;
@@ -255,7 +255,7 @@ interface sw_logger_if #(
       void'(get_sw_log_field(fd, "string", field));
 
       if (sw_rodata.exists(sw) && sw_rodata[sw].exists(addr)) begin
-        `DV_WARNING($sformatf("Rodata entry for addr %0x already exists:\nOld: %s\nNew: %s",
+        `dv_warning($sformatf("Rodata entry for addr %0x already exists:\nOld: %s\nNew: %s",
                               addr, sw_rodata[sw][addr], field))
       end
       // Replace CRs in the middle of the string with NLs.
@@ -265,7 +265,7 @@ interface sw_logger_if #(
 
     // print parsed rodata
     foreach (sw_rodata[sw, addr]) begin
-      `DV_INFO($sformatf("sw_rodata[%0s][%0h] = %p", sw, addr, sw_rodata[sw][addr]), UVM_HIGH)
+      `dv_info($sformatf("sw_rodata[%0s][%0h] = %p", sw, addr, sw_rodata[sw][addr]), UVM_HIGH)
     end
 
     return (sw_rodata[sw].size() > 0);
@@ -394,7 +394,7 @@ interface sw_logger_if #(
                   if (sw_logs[sw][addr].str_arg.exists(i)) begin
                     // The arg[i] received is the addr in rodata where the string resides.
                     sw_logs[sw][addr].str_arg[i] = get_str_at_addr(sw, sw_logs[sw][addr].arg[i]);
-                    `DV_INFO($sformatf("String arg at addr %0h: %0s", sw_logs[sw][addr].arg[i],
+                    `dv_info($sformatf("String arg at addr %0h: %0s", sw_logs[sw][addr].arg[i],
                                        sw_logs[sw][addr].str_arg[i]), UVM_DEBUG)
                   end
                 end
@@ -458,7 +458,7 @@ interface sw_logger_if #(
       30: sw_log.format = $sformatf(sw_log.format, `_ADD_ARGS(30));
       31: sw_log.format = $sformatf(sw_log.format, `_ADD_ARGS(31));
       32: sw_log.format = $sformatf(sw_log.format, `_ADD_ARGS(32));
-      default: `DV_FATAL($sformatf("UNSUPPORTED: nargs = %0d (only 0:32 allowed)", sw_log.nargs))
+      default: `dv_fatal($sformatf("UNSUPPORTED: nargs = %0d (only 0:32 allowed)", sw_log.nargs))
     endcase
 
     begin
@@ -475,11 +475,11 @@ interface sw_logger_if #(
       endcase
 `endif
       case (sw_log.severity)
-        LogSeverityInfo:    `DV_INFO(sw_log.format, level, log_header)
-        LogSeverityWarning: `DV_WARNING(sw_log.format, log_header)
-        LogSeverityError:   `DV_ERROR(sw_log.format, log_header)
-        LogSeverityFatal:   `DV_FATAL(sw_log.format, log_header)
-        default:            `DV_INFO(sw_log.format, level, log_header)
+        LogSeverityInfo:    `dv_info(sw_log.format, level, log_header)
+        LogSeverityWarning: `dv_warning(sw_log.format, log_header)
+        LogSeverityError:   `dv_error(sw_log.format, log_header)
+        LogSeverityFatal:   `dv_fatal(sw_log.format, log_header)
+        default:            `dv_info(sw_log.format, level, log_header)
       endcase
     end
 

--- a/hw/dv/sv/sw_test_status/sw_test_status_if.sv
+++ b/hw/dv/sv/sw_test_status/sw_test_status_if.sv
@@ -39,11 +39,11 @@ interface sw_test_status_if #(
       sw_test_done = sw_test_done | sw_test_status inside {SwTestStatusPassed, SwTestStatusFailed};
       sw_test_passed = sw_test_status == SwTestStatusPassed;
       if (sw_test_status == SwTestStatusPassed) begin
-        `DV_INFO("==== SW TEST PASSED ====")
+        `dv_info("==== SW TEST PASSED ====")
       end else if (sw_test_status == SwTestStatusFailed) begin
-        `DV_ERROR("==== SW TEST FAILED ====")
+        `dv_error("==== SW TEST FAILED ====")
       end else begin
-        `DV_INFO($sformatf("SW test status changed: %0s", sw_test_status.name()))
+        `dv_info($sformatf("SW test status changed: %0s", sw_test_status.name()))
       end
     end
   end


### PR DESCRIPTION
This change enables most of the DV macros to be used in non-UVM
testbenches, by replacing calls to UVM logging macros with our
platform-agnostic ones.

It also updates the platform-agnostic logging macros (for the
UVM-enabled case) to invoke UVM report functions directly underneath,
scoped with `uvm_pkg::` so that uvm_pkp does not have to be manually
imported in the madule / interface where they are invoked.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>