### PR TITLE
[dv/otp] enable do_read_check in scb

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -33,12 +33,33 @@ package otp_ctrl_env_pkg;
   parameter uint TEST_ACCESS_WINDOW_SIZE = 16 * 4;
 
   // convert byte into TLUL width size
-  parameter uint CREATOR_SW_CFG_ARRAY_SIZE = CreatorSwCfgContentSize / (TL_DW / 8);
-  parameter uint OWNER_SW_CFG_ARRAY_SIZE   = OwnerSwCfgContentSize / (TL_DW / 8);
-  parameter uint HW_CFG_ARRAY_SIZE         = HwCfgContentSize / (TL_DW / 8);
-  parameter uint SECRET0_ARRAY_SIZE        = (Secret0Size - DIGEST_SIZE) / (TL_DW / 8);
-  parameter uint SECRET1_ARRAY_SIZE        = (Secret1Size - DIGEST_SIZE) / (TL_DW / 8);
-  parameter uint SECRET2_ARRAY_SIZE        = (Secret2Size - DIGEST_SIZE) / (TL_DW / 8);
+  parameter uint CREATOR_SW_CFG_START_ADDR  = CreatorSwCfgOffset / (TL_DW / 8);
+  parameter uint CREATOR_SW_CFG_DIGEST_ADDR = CreatorSwCfgDigestOffset / (TL_DW / 8);
+  parameter uint CREATOR_SW_CFG_END_ADDR    = CREATOR_SW_CFG_DIGEST_ADDR - 1;
+
+  parameter uint OWNER_SW_CFG_START_ADDR  = OwnerSwCfgOffset / (TL_DW / 8);
+  parameter uint OWNER_SW_CFG_DIGEST_ADDR = OwnerSwCfgDigestOffset / (TL_DW / 8);
+  parameter uint OWNER_SW_CFG_END_ADDR    = OWNER_SW_CFG_DIGEST_ADDR - 1;
+
+  parameter uint HW_CFG_START_ADDR  = HwCfgOffset / (TL_DW / 8);
+  parameter uint HW_CFG_DIGEST_ADDR = HwCfgDigestOffset / (TL_DW / 8);
+  parameter uint HW_CFG_END_ADDR    = HW_CFG_DIGEST_ADDR - 1;
+
+  parameter uint SECRET0_START_ADDR  = Secret0Offset / (TL_DW / 8);
+  parameter uint SECRET0_DIGEST_ADDR = Secret0DigestOffset / (TL_DW / 8);
+  parameter uint SECRET0_END_ADDR    = SECRET0_DIGEST_ADDR - 1;
+
+  parameter uint SECRET1_START_ADDR  = Secret1Offset / (TL_DW / 8);
+  parameter uint SECRET1_DIGEST_ADDR = Secret1DigestOffset / (TL_DW / 8);
+  parameter uint SECRET1_END_ADDR    = SECRET1_DIGEST_ADDR - 1;
+
+  parameter uint SECRET2_START_ADDR  = Secret2Offset / (TL_DW / 8);
+  parameter uint SECRET2_DIGEST_ADDR = Secret2DigestOffset / (TL_DW / 8);
+  parameter uint SECRET2_END_ADDR    = SECRET2_DIGEST_ADDR - 1;
+
+  // TODO: did not count for LC partition
+  parameter uint OTP_ARRAY_SIZE = (CreatorSwCfgSize + OwnerSwCfgSize + HwCfgSize + Secret0Size +
+                                   Secret1Size + Secret2Size)/ (TL_DW / 8);
 
   // sram rsp data has 1 bit for seed_valid, the rest are for key and nonce
   parameter uint SRAM_DATA_SIZE  = 1 + SramKeyWidth + SramNonceWidth;

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -10,12 +10,7 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
   `uvm_component_utils(otp_ctrl_scoreboard)
 
   // local variables
-  bit [TL_DW-1:0] creator_sw_cfg_a [CREATOR_SW_CFG_ARRAY_SIZE];
-  bit [TL_DW-1:0] owner_sw_cfg_a   [OWNER_SW_CFG_ARRAY_SIZE];
-  bit [TL_DW-1:0] hw_cfg_a         [HW_CFG_ARRAY_SIZE];
-  bit [TL_DW-1:0] secret0_a        [SECRET0_ARRAY_SIZE];
-  bit [TL_DW-1:0] secret1_a        [SECRET1_ARRAY_SIZE];
-  bit [TL_DW-1:0] secret2_a        [SECRET2_ARRAY_SIZE];
+  bit [TL_DW-1:0] otp_a [OTP_ARRAY_SIZE];
   bit key_size_80 = SCRAMBLE_KEY_SIZE == 80;
 
   // LC partition does not have digest
@@ -60,19 +55,24 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
       @(posedge cfg.pwr_otp_vif.pins[OtpPwrInitReq]) begin
         if (cfg.backdoor_clear_mem) begin
           bit [SCRAMBLE_DATA_SIZE-1:0] data = descramble_data(0, 0);
-          foreach(secret0_a[i]) begin
-            secret0_a[i] = (i % 2) ? data[SCRAMBLE_DATA_SIZE-1:TL_DW] : data[TL_DW-1:0];
+          otp_a   = '{default:0};
+          digests = '{default:0};
+          // secret partitions have been scrambled before writing to OTP.
+          // here calculate the pre-srambled raw data when clearing internal OTP to all 0s.
+          for (int i = SECRET0_START_ADDR; i <= SECRET0_END_ADDR; i++) begin
+            otp_a[i] = ((i - SECRET0_START_ADDR) % 2) ? data[SCRAMBLE_DATA_SIZE-1:TL_DW] :
+                                                        data[TL_DW-1:0];
           end
           data = descramble_data(0, 1);
-          foreach(secret1_a[i]) begin
-            secret1_a[i] = (i % 2) ? data[SCRAMBLE_DATA_SIZE-1:TL_DW] : data[TL_DW-1:0];
+          for (int i = SECRET1_START_ADDR; i <= SECRET1_END_ADDR; i++) begin
+            otp_a[i] = ((i - SECRET1_START_ADDR) % 2) ? data[SCRAMBLE_DATA_SIZE-1:TL_DW] :
+                                                        data[TL_DW-1:0];
           end
           data = descramble_data(0, 2);
-          foreach(secret2_a[i]) begin
-            secret2_a[i] = (i % 2) ? data[SCRAMBLE_DATA_SIZE-1:TL_DW] : data[TL_DW-1:0];
+          for (int i = SECRET2_START_ADDR; i <= SECRET2_END_ADDR; i++) begin
+            otp_a[i] = ((i - SECRET2_START_ADDR) % 2) ? data[SCRAMBLE_DATA_SIZE-1:TL_DW] :
+                                                        data[TL_DW-1:0];
           end
-          hw_cfg_a  = '{default:0};
-          digests   = '{default:0};
           predict_digest_csrs();
           `uvm_info(`gfn, "clear internal memory and digest", UVM_HIGH)
         end
@@ -82,7 +82,7 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
 
   virtual task process_tl_access(tl_seq_item item, tl_channels_e channel = DataChannel);
     uvm_reg csr;
-    bit     do_read_check     = 1'b0;
+    bit     do_read_check     = 1'b1;
     bit     write             = item.is_write();
     uvm_reg_addr_t csr_addr   = ral.get_word_aligned_addr(item.a_addr);
     bit [TL_AW-1:0] addr_mask = ral.get_addr_mask();
@@ -96,10 +96,18 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
     if (csr_addr inside {cfg.csr_addrs}) begin
       csr = ral.default_map.get_reg_by_offset(csr_addr);
       `DV_CHECK_NE_FATAL(csr, null)
-    // memories
+    // SW CFG window
     end else if ((csr_addr & addr_mask) inside
-        {[SW_WINDOW_BASE_ADDR : SW_WINDOW_BASE_ADDR + SW_WINDOW_SIZE],
-         [TEST_ACCESS_BASE_ADDR : TEST_ACCESS_BASE_ADDR + TEST_ACCESS_WINDOW_SIZE]}) begin
+        {[SW_WINDOW_BASE_ADDR : SW_WINDOW_BASE_ADDR + SW_WINDOW_SIZE]}) begin
+      if (data_phase_read) begin
+        bit [TL_AW-1:0] dai_addr = (csr_addr & addr_mask - SW_WINDOW_BASE_ADDR) >> 2;
+        `DV_CHECK_EQ(item.d_data, otp_a[dai_addr],
+                     $sformatf("mem read mismatch at addr %0h", dai_addr))
+      end
+      return;
+    // TEST ACCESS window
+    end else if ((csr_addr & addr_mask) inside
+         {[TEST_ACCESS_BASE_ADDR : TEST_ACCESS_BASE_ADDR + TEST_ACCESS_WINDOW_SIZE]}) begin
       return;
     end else begin
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
@@ -120,76 +128,72 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
         do_read_check = 1'b0;
       end
       "intr_enable": begin
+        do_read_check = 1'b0;
         // FIXME
       end
       "intr_test": begin
+        do_read_check = 1'b0;
         // FIXME
       end
+      // FIXME
+      "status": do_read_check = 1'b0;
       "direct_access_cmd": begin
         if (addr_phase_write && ral.direct_access_regwen.get_mirrored_value()) begin
-          int rand_digit = is_secret(dai_addr) ? 3 : 2;
-          int dai_addr = ral.direct_access_address.get_mirrored_value() >>
-                         rand_digit << rand_digit;
-
+          // here only normalize to 2 lsb, if is secret, will be reduced further
+          bit [TL_AW-1:0] dai_addr = ral.direct_access_address.get_mirrored_value() >> 2 << 2;
           case (item.a_data)
             DaiDigest: cal_digest_val(get_part_index(dai_addr));
+            DaiRead: begin
+              // TODO: currently do nothing
+            end
             DaiWrite: begin
-              case (get_part_index(dai_addr))
-                CreatorSwCfgIdx: begin
-                  if (dai_addr < CreatorSwCfgDigestOffset) begin
-                    // write OTP
-                    int cal_addr = (dai_addr - CreatorSwCfgOffset) >> 2;
-                    creator_sw_cfg_a[cal_addr] = ral.direct_access_wdata_0.get_mirrored_value();
-                  end else begin
-                    // write digest
-                    digests[CreatorSwCfgIdx] = {ral.direct_access_wdata_1.get_mirrored_value(),
-                                                ral.direct_access_wdata_0.get_mirrored_value()};
-                  end
+              // write digest
+              if (dai_addr inside {CreatorSwCfgDigestOffset, OwnerSwCfgDigestOffset}) begin
+                digests[get_part_index(dai_addr)] =
+                        {ral.direct_access_wdata_1.get_mirrored_value(),
+                         ral.direct_access_wdata_0.get_mirrored_value()};
+              // write OTP memory
+              end else begin
+                bit[TL_AW-1:0] normalized_dai_addr = get_normalized_dai_addr();
+                otp_a[normalized_dai_addr] = ral.direct_access_wdata_0.get_mirrored_value();
+                if (is_secret(dai_addr)) begin
+                  otp_a[normalized_dai_addr + 1] = ral.direct_access_wdata_1.get_mirrored_value();
                 end
-                OwnerSwCfgIdx: begin
-                  if (dai_addr < OwnerSwCfgDigestOffset) begin
-                    // write OTP
-                    int cal_addr = (dai_addr - OwnerSwCfgOffset) >> 2;
-                    owner_sw_cfg_a[cal_addr] = ral.direct_access_wdata_0.get_mirrored_value();
-                  end else begin
-                    // write digest
-                    digests[OwnerSwCfgIdx] = {ral.direct_access_wdata_1.get_mirrored_value(),
-                                              ral.direct_access_wdata_0.get_mirrored_value()};
-                  end
-                end
-                HwCfgIdx: begin
-                  int cal_addr = (dai_addr - HwCfgOffset) >> 2;
-                  hw_cfg_a[cal_addr] = ral.direct_access_wdata_0.get_mirrored_value();
-                end
-                Secret0Idx: begin
-                  int cal_addr = (dai_addr - Secret0Offset) >> 3 << 1;
-                  secret0_a[cal_addr]   = ral.direct_access_wdata_0.get_mirrored_value();
-                  secret0_a[cal_addr+1] = ral.direct_access_wdata_1.get_mirrored_value();
-                end
-                Secret1Idx: begin
-                  int cal_addr = (dai_addr - Secret1Offset) >> 3 << 1;
-                  secret1_a[cal_addr]   = ral.direct_access_wdata_0.get_mirrored_value();
-                  secret1_a[cal_addr+1] = ral.direct_access_wdata_1.get_mirrored_value();
-                end
-                Secret2Idx: begin
-                  int cal_addr = (dai_addr - Secret2Offset) >> 3 << 1;
-                  secret2_a[cal_addr]   = ral.direct_access_wdata_0.get_mirrored_value();
-                  secret2_a[cal_addr+1] = ral.direct_access_wdata_1.get_mirrored_value();
-                end
-              endcase
+                // TODO: LC partition, raise status error
+              end
+            end
+            default: begin
+              `uvm_fatal(`gfn, $sformatf("invalid cmd: %0d", item.a_data))
             end
           endcase
         end
       end
-      // TODO: temp only enable this checking, should support all regs
+      "direct_access_rdata_0", "direct_access_rdata_1": begin
+        // TODO: need to check last cmd is READ
+        if (data_phase_read && ral.direct_access_regwen.get_mirrored_value()) begin
+          bit [TL_AW-1:0] dai_addr = get_normalized_dai_addr();
+          if (csr.get_name() == "direct_access_rdata_0") begin
+            `DV_CHECK_EQ(item.d_data, otp_a[dai_addr],
+                         $sformatf("DAI read mismatch at addr %0h", dai_addr))
+            do_read_check = 0;
+          end else begin
+            if (is_secret(ral.direct_access_address.get_mirrored_value())) begin
+            `DV_CHECK_EQ(item.d_data, otp_a[dai_addr + 1],
+                         $sformatf("DAI read mismatch at addr %0h", dai_addr + 1))
+              do_read_check = 0;
+            end
+          end
+        end
+      end
       "hw_cfg_digest_0", "hw_cfg_digest_1", "", "secret0_digest_0", "secret0_digest_1",
       "secret1_digest_0", "secret1_digest_1", "secret2_digest_0", "secret2_digest_1",
       "creator_sw_cfg_digest_0", "creator_sw_cfg_digest_1", "owner_sw_cfg_digest_0",
-      "owner_sw_cfg_digest_1": begin
-        do_read_check = 1;
+      "owner_sw_cfg_digest_1", "direct_access_regwen", "direct_access_wdata_0",
+      "direct_access_wdata_1", "direct_access_address": begin
+        // Do nothing
       end
       default: begin
-        //`uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
+        `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
       end
     endcase
 
@@ -198,8 +202,6 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
       if (do_read_check) begin
         `DV_CHECK_EQ(csr.get_mirrored_value(), item.d_data,
                      $sformatf("reg name: %0s", csr.get_full_name()))
-        // TODO: temp disable check, right now only support hw_cfg_digest
-        do_read_check = 0;
       end
       void'(csr.predict(.value(item.d_data), .kind(UVM_PREDICT_READ)));
     end
@@ -258,22 +260,10 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
     real            key_factor  = SCRAMBLE_KEY_SIZE / TL_DW;
 
     case (part_idx)
-      HwCfgIdx: begin
-        array_size = HW_CFG_ARRAY_SIZE;
-        mem_q = hw_cfg_a;
-      end
-      Secret0Idx: begin
-        array_size = SECRET0_ARRAY_SIZE;
-        mem_q = secret0_a;
-      end
-      Secret1Idx: begin
-        array_size = SECRET1_ARRAY_SIZE;
-        mem_q = secret1_a;
-      end
-      Secret2Idx: begin
-        array_size = SECRET2_ARRAY_SIZE;
-        mem_q = secret2_a;
-      end
+      HwCfgIdx:   mem_q = otp_a[HW_CFG_START_ADDR:HW_CFG_END_ADDR];
+      Secret0Idx: mem_q = otp_a[SECRET0_START_ADDR:SECRET0_END_ADDR];
+      Secret1Idx: mem_q = otp_a[SECRET1_START_ADDR:SECRET1_END_ADDR];
+      Secret2Idx: mem_q = otp_a[SECRET2_START_ADDR:SECRET2_END_ADDR];
       CreatorSwCfgIdx, OwnerSwCfgIdx, LifeCycleIdx: begin
         // access error
         bit [TL_DW-1:0] status_val = OtpDaiErr || (1'b1 << part_idx);
@@ -283,6 +273,8 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
         `uvm_fatal(`gfn, $sformatf("Access unexpected partition %0d", part_idx))
       end
     endcase
+
+    array_size = mem_q.size();
 
     // for secret partitions, need to use otp scrambled value as data input
     if (part_idx inside {[Secret0Idx:Secret2Idx]}) begin
@@ -341,5 +333,10 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
                                                    key_size_80,
                                                    output_data);
     descramble_data = output_data[NUM_ROUND-1];
+  endfunction
+
+  function bit [TL_AW-1:0] get_normalized_dai_addr();
+    bit [TL_DW-1:0] dai_addr = ral.direct_access_address.get_mirrored_value();
+    get_normalized_dai_addr = is_secret(dai_addr) ? dai_addr >> 3 << 1 : dai_addr >> 2;
   endfunction
 endclass

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -13,12 +13,13 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
 
   rand bit [TL_AW-1:0]               dai_addr;
   rand bit [TL_DW-1:0]               wdata0, wdata1;
-  rand int                           num_dai_wr;
+  rand int                           num_dai_op;
   rand otp_ctrl_part_pkg::part_idx_e part_idx;
 
   // LC partition does not allow DAI access
   constraint partition_index_c {
     part_idx inside {[CreatorSwCfgIdx:Secret2Idx]};
+    part_idx != HwCfgIdx;
   }
 
   constraint dai_addr_c {
@@ -35,7 +36,9 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
     if (part_idx inside {[Secret0Idx:Secret2Idx]}) dai_addr % 8 == 0;
   }
 
-  constraint num_dai_wr_c {num_dai_wr inside {[1:20]};}
+  constraint num_dai_op_c {num_dai_op inside {[1:50]};}
+
+  constraint num_trans_c {num_trans inside {[1:20]};}
 
   virtual task dut_init(string reset_kind = "HARD");
     super.dut_init(reset_kind);
@@ -45,15 +48,14 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
 
   virtual task pre_start();
     super.pre_start();
-    num_dai_wr.rand_mode(0);
+    num_dai_op.rand_mode(0);
   endtask
 
   task body();
     for (int i = 1; i <= num_trans; i++) begin
-      bit [TL_DW-1:0] rdata, tlul_rdata;
       `uvm_info(`gfn, $sformatf("starting seq %0d/%0d", i, num_trans), UVM_MEDIUM)
       do_otp_ctrl_init = 1;
-      dut_init();
+      if (i > 1) dut_init();
       do_otp_ctrl_init = 0;
 
       // after otp-init done, check status
@@ -70,24 +72,20 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
       req_flash_addr();
       req_flash_data();
 
-      for (int i = 0; i < num_dai_wr; i++) begin
-        bit [TL_DW-1:0] rdata0, rdata1;
+      for (int i = 0; i < num_dai_op; i++) begin
+        bit [TL_DW-1:0] rdata0, rdata1, tlul_rdata;
+        `uvm_info(`gfn, $sformatf("starting dai access seq %0d/%0d", i, num_dai_op), UVM_DEBUG)
         `DV_CHECK_RANDOMIZE_FATAL(this)
 
         // OTP write via DAI
-        dai_wr(dai_addr, wdata0, wdata1);
-
-        used_dai_addr_q.push_back(dai_addr);
+        if ($urandom_range(0, 1)) begin
+          dai_wr(dai_addr, wdata0, wdata1);
+          used_dai_addr_q.push_back(dai_addr);
+        end
 
         if ($urandom_range(0, 1)) begin
-          // OTP read via DAI
+          // OTP read via DAI, check data in scb
           dai_rd(dai_addr, rdata0, rdata1);
-
-          // check read data
-          `DV_CHECK_EQ(wdata0, rdata0, $sformatf("read data0 mismatch at addr %0h", dai_addr))
-          if (is_secret(dai_addr)) begin
-            `DV_CHECK_EQ(wdata1, rdata1, $sformatf("read data1 mismatch at addr %0h", dai_addr))
-          end
         end
 
         // if write sw partitions, check tlul window
@@ -97,7 +95,6 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
           // random issue reset, OTP content should not be cleared
           if ($urandom_range(0, 1)) dut_init();
           tl_access(.addr(tlul_addr), .write(0), .data(tlul_rdata), .blocking(1));
-          `DV_CHECK_EQ(tlul_rdata, wdata0, $sformatf("mem read out mismatch at addr %0h", tlul_addr))
         end
       end
 


### PR DESCRIPTION
This PR enables `do_read_check` flag in scb to predict and check CSRs.

Following changes in this PR:
1. No need to check data in sanity sequence.
2. Previously in scb, each partition has its own data storage array, but
converting address is a bit messy, this PR merged with one big array and
uses the original address from DAI read/write.
3. Add dai read checkings and TLUL window checking in SCB.

Signed-off-by: Cindy Chen <chencindy@google.com>