### PR TITLE
[boot_rom] use generated header for spi device address

### DIFF
--- a/sw/device/boot_rom/bootstrap.c
+++ b/sw/device/boot_rom/bootstrap.c
@@ -156,7 +156,8 @@ int bootstrap(void) {
   dif_spi_device_t spi;
   CHECK(dif_spi_device_init(
             (dif_spi_device_params_t){
-                .base_addr = mmio_region_from_addr(0x40020000),
+                .base_addr =
+                    mmio_region_from_addr(TOP_EARLGREY_SPI_DEVICE_BASE_ADDR),
             },
             &spi) == kDifSpiDeviceOk,
         "Failed to initialize SPI.");


### PR DESCRIPTION
#4163 broke fpga spi-flashing in CI since the address was hard coded.
Change to use header definition. 