### PR TITLE
[otbn] Remove dependency on riscv-python-sim

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/decode.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/decode.py
@@ -4,10 +4,6 @@
 
 '''Code to load instruction words into a simulator'''
 
-# Lots of this probably belongs in the upstream riscv-python-sim simulator, but
-# let's get everything working first and then try to push anything sensible
-# afterwards.
-
 import struct
 from typing import List, Optional, Tuple, Type
 

--- a/hw/ip/otbn/dv/otbnsim/sim/dmem.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/dmem.py
@@ -3,20 +3,20 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import struct
-from typing import List
+from typing import List, Sequence
 
 from shared.mem_layout import get_memory_layout
 
-from riscvmodel.types import Trace  # type: ignore
+from .trace import Trace
 
 
-class TraceDmemStore(Trace):  # type: ignore
+class TraceDmemStore(Trace):
     def __init__(self, addr: int, value: int, is_wide: bool):
         self.addr = addr
         self.value = value
         self.is_wide = is_wide
 
-    def __str__(self) -> str:
+    def trace(self) -> str:
         num_bytes = 32 if self.is_wide else 4
         top = self.addr + num_bytes - 1
         return 'dmem[{:#x}..{:#x}] = {:#x}'.format(self.addr, top, self.value)
@@ -58,7 +58,7 @@ class Dmem:
             uninit = (uninit << 32) | 0xdeadbeef
 
         self.data = [uninit] * num_words
-        self.trace = []  # type: List[Trace]
+        self.trace = []  # type: List[TraceDmemStore]
 
     def _get_u32s(self, idx: int) -> List[int]:
         '''Return the value at idx as 8 uint32's
@@ -175,7 +175,7 @@ class Dmem:
         assert 0 <= value <= (1 << 32) - 1
         self.trace.append(TraceDmemStore(addr, value, False))
 
-    def changes(self) -> List[Trace]:
+    def changes(self) -> Sequence[Trace]:
         return self.trace
 
     def _commit_store(self, item: TraceDmemStore) -> None:

--- a/hw/ip/otbn/dv/otbnsim/sim/ext_regs.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/ext_regs.py
@@ -2,13 +2,14 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, Sequence
 
 from shared.otbn_reggen import HjsonDict, load_registers
-from riscvmodel.types import Trace  # type: ignore
+
+from .trace import Trace
 
 
-class TraceExtRegChange(Trace):  # type: ignore
+class TraceExtRegChange(Trace):
     def __init__(self, name: str, op: str, written: int, from_hw: bool, new_value: int):
         self.name = name
         self.op = op
@@ -16,7 +17,7 @@ class TraceExtRegChange(Trace):  # type: ignore
         self.from_hw = from_hw
         self.new_value = new_value
 
-    def __str__(self) -> str:
+    def trace(self) -> str:
         return ("otbn.{} {} {:#08x}{} (now {:#08x})"
                 .format(self.name,
                         self.op,
@@ -206,7 +207,7 @@ class OTBNExtRegs:
             raise ValueError('Unknown register name: {!r}.'.format(reg_name))
         return reg.read(from_hw)
 
-    def changes(self) -> List[Trace]:
+    def changes(self) -> Sequence[Trace]:
         return self.trace
 
     def commit(self) -> None:

--- a/hw/ip/otbn/dv/otbnsim/sim/flags.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/flags.py
@@ -4,16 +4,16 @@
 
 from typing import List, Optional, cast
 
-from riscvmodel.types import Trace  # type: ignore
+from .trace import Trace
 
 
-class TraceFlag(Trace):  # type: ignore
+class TraceFlag(Trace):
     def __init__(self, group_name: str, flag_name: str, value: bool):
         self.group_name = group_name
         self.flag_name = flag_name
         self.value = value
 
-    def __str__(self) -> str:
+    def trace(self) -> str:
         return '{}.{} = {}'.format(self.group_name, self.flag_name, int(self.value))
 
 

--- a/hw/ip/otbn/dv/otbnsim/sim/reg.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/reg.py
@@ -4,16 +4,16 @@
 
 from typing import List, Optional, Set
 
-from riscvmodel.types import Trace  # type: ignore
+from .trace import Trace
 
 
-class TraceRegister(Trace):  # type: ignore
+class TraceRegister(Trace):
     def __init__(self, name: str, width: int, new_value: int):
         self.name = name
         self.width = width
         self.new_value = new_value
 
-    def __str__(self) -> str:
+    def trace(self) -> str:
         fmt_str = '{{}} = 0x{{:0{}x}}'.format(self.width // 4)
         return fmt_str.format(self.name, self.new_value)
 

--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -7,6 +7,7 @@ from typing import List, Optional, Tuple
 from .alert import Alert
 from .isa import OTBNInsn
 from .state import OTBNState
+from .trace import Trace
 
 
 class OTBNSim:
@@ -33,7 +34,7 @@ class OTBNSim:
 
         return insn_count
 
-    def step(self, verbose: bool) -> Tuple[Optional[OTBNInsn], List[str]]:
+    def step(self, verbose: bool) -> Tuple[Optional[OTBNInsn], List[Trace]]:
         '''Run a single instruction.
 
         Returns the instruction, together with a list of the architectural
@@ -97,7 +98,7 @@ class OTBNSim:
     def dump_data(self) -> bytes:
         return self.state.dmem.dump_le_words()
 
-    def _print_trace(self, pc: int, disasm: str, changes: List[str]) -> None:
+    def _print_trace(self, pc: int, disasm: str, changes: List[Trace]) -> None:
         '''Print a trace of the current instruction to verbose_file'''
-        changes_str = ', '.join([str(t) for t in changes])
+        changes_str = ', '.join([t.trace() for t in changes])
         print('{:08x} | {:35} | [{}]'.format(pc, disasm, changes_str))

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -4,35 +4,32 @@
 
 from typing import List, Optional, Tuple
 
-from riscvmodel.types import Trace, TracePC  # type: ignore
-
-
-from .alert import Alert
 from .csr import CSRFile
 from .dmem import Dmem
 from .ext_regs import OTBNExtRegs
 from .flags import FlagReg
 from .gpr import GPRs
 from .reg import RegFile
+from .trace import Trace, TracePC
 from .wsr import WSRFile
 
 
-class TraceLoopStart(Trace):  # type: ignore
+class TraceLoopStart(Trace):
     def __init__(self, iterations: int, bodysize: int):
         self.iterations = iterations
         self.bodysize = bodysize
 
-    def __str__(self) -> str:
+    def trace(self) -> str:
         return "Start LOOP, {} iterations, bodysize: {}".format(
             self.iterations, self.bodysize)
 
 
-class TraceLoopIteration(Trace):  # type: ignore
+class TraceLoopIteration(Trace):
     def __init__(self, iteration: int, total: int):
         self.iteration = iteration
         self.total = total
 
-    def __str__(self) -> str:
+    def trace(self) -> str:
         return "LOOP iteration {}/{}".format(self.iteration, self.total)
 
 
@@ -164,7 +161,8 @@ class OTBNState:
             self.pc_next = back_pc
 
     def changes(self) -> List[Trace]:
-        c = self.gprs.changes()
+        c = []  # type: List[Trace]
+        c += self.gprs.changes()
         if self.pc_next is not None:
             c.append(TracePC(self.pc_next))
         c += self.dmem.changes()

--- a/hw/ip/otbn/dv/otbnsim/sim/trace.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/trace.py
@@ -1,0 +1,23 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+
+class Trace:
+    '''An object that can cause a trace entry'''
+
+    def trace(self) -> str:
+        '''Return a representation of the entry for tracing
+
+        This is used by things like the standalone ISS with -v
+
+        '''
+        raise NotImplementedError()
+
+
+class TracePC(Trace):
+    def __init__(self, pc: int):
+        self.pc = pc
+
+    def trace(self) -> str:
+        return "pc = {:#x}".format(self.pc)

--- a/hw/ip/otbn/dv/otbnsim/sim/wsr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/wsr.py
@@ -4,15 +4,15 @@
 
 from typing import List, Optional
 
-from riscvmodel.types import Trace  # type: ignore
+from .trace import Trace
 
 
-class TraceWSR(Trace):  # type: ignore
+class TraceWSR(Trace):
     def __init__(self, wsr_name: str, new_value: int):
         self.wsr_name = wsr_name
         self.new_value = new_value
 
-    def __str__(self) -> str:
+    def trace(self) -> str:
         return '{} = {:#x}'.format(self.wsr_name, self.new_value)
 
 

--- a/hw/ip/otbn/dv/otbnsim/stepped.py
+++ b/hw/ip/otbn/dv/otbnsim/stepped.py
@@ -94,7 +94,7 @@ def on_step(sim: OTBNSim, args: List[str]) -> None:
     disasm = '(not running)' if insn is None else insn.disassemble(pc)
     print('EXEC {:#08x}:     {}'.format(pc, disasm))
     for trace in changes:
-        print('  {}'.format(trace))
+        print('  {}'.format(trace.trace()))
 
 
 def on_run(sim: OTBNSim, args: List[str]) -> None:

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -23,9 +23,6 @@ pyyaml >= 5.1
 tabulate
 yapf
 
-# Used by OTBN simulator
-riscv-model == 0.6.5
-
 # Development version with OT-specific changes
 git+https://github.com/lowRISC/fusesoc.git@ot#egg=fusesoc >= 1.11.0
 


### PR DESCRIPTION
We were just using this for the `Trace` and `TracePC` classes, which
contain almost nothing. Define our own `Trace`/`TracePC` classes, remove
the `# type: ignore` hacks and fix the typing bugs that they hid.

Finally define an explicit `Trace.trace` function, rather than relying
on `__str__` to generate trace output. We'll need this soon when we
start comparing with the RTL (because we'll want a different format
for different output types).
