### PR TITLE
[entropy_src/dv] dv parameter, add agent queues/fifos/sequencers

### DIFF
--- a/hw/ip/entropy_src/dv/env/entropy_src_env.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env.sv
@@ -10,8 +10,8 @@ class entropy_src_env extends cip_base_env #(
   );
   `uvm_component_utils(entropy_src_env)
 
-   push_pull_agent#(.HostDataWidth(entropy_src_pkg::RNG_BUS_WIDTH))         m_rng_agent;
-   push_pull_agent#(.HostDataWidth(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH))  m_csrng_agent;
+   push_pull_agent#(.HostDataWidth(entropy_src_pkg::RNG_BUS_WIDTH))  m_rng_agent;
+   push_pull_agent#(.HostDataWidth(FIPS_CSRNG_BUS_WIDTH))  m_csrng_agent;
 
   `uvm_component_new
 
@@ -25,10 +25,10 @@ class entropy_src_env extends cip_base_env #(
     cfg.m_rng_agent_cfg.agent_type = push_pull_agent_pkg::PushAgent;
     cfg.m_rng_agent_cfg.if_mode    = dv_utils_pkg::Host;
 
-    m_csrng_agent = push_pull_agent#(.HostDataWidth(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH))::
-                    type_id::create("m_csrng_agent", this);
-    uvm_config_db#(push_pull_agent_cfg#(.HostDataWidth(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH)))::
-                  set(this, "m_csrng_agent*", "cfg", cfg.m_csrng_agent_cfg);
+    m_csrng_agent = push_pull_agent#(.HostDataWidth(FIPS_CSRNG_BUS_WIDTH))::type_id::
+                    create("m_csrng_agent", this);
+    uvm_config_db#(push_pull_agent_cfg#(.HostDataWidth(FIPS_CSRNG_BUS_WIDTH)))::set
+                  (this, "m_csrng_agent*", "cfg", cfg.m_csrng_agent_cfg);
     cfg.m_csrng_agent_cfg.agent_type = push_pull_agent_pkg::PullAgent;
     cfg.m_csrng_agent_cfg.if_mode    = dv_utils_pkg::Host;
 

--- a/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
@@ -8,10 +8,8 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
   `uvm_object_utils_end
 
   // ext component cfgs
-  rand push_pull_agent_cfg#(.HostDataWidth(entropy_src_pkg::RNG_BUS_WIDTH))
-    m_rng_agent_cfg;
-  rand push_pull_agent_cfg#(.HostDataWidth(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH))
-    m_csrng_agent_cfg;
+  rand push_pull_agent_cfg#(.HostDataWidth(entropy_src_pkg::RNG_BUS_WIDTH))  m_rng_agent_cfg;
+  rand push_pull_agent_cfg#(.HostDataWidth(FIPS_CSRNG_BUS_WIDTH))  m_csrng_agent_cfg;
 
   virtual pins_if  efuse_es_sw_reg_en_vif;
 
@@ -24,7 +22,7 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
     // create agent config objs
     m_rng_agent_cfg   = push_pull_agent_cfg#(.HostDataWidth(entropy_src_pkg::RNG_BUS_WIDTH))::
                         type_id::create("m_rng_agent_cfg");
-    m_csrng_agent_cfg = push_pull_agent_cfg#(.HostDataWidth(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH))::
+    m_csrng_agent_cfg = push_pull_agent_cfg#(.HostDataWidth(FIPS_CSRNG_BUS_WIDTH))::
                         type_id::create("m_csrng_agent_cfg");
 
     // set num_interrupts & num_alerts

--- a/hw/ip/entropy_src/dv/env/entropy_src_env_pkg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_pkg.sv
@@ -14,6 +14,8 @@ package entropy_src_env_pkg;
   import entropy_src_ral_pkg::*;
   import push_pull_agent_pkg::*;
 
+  parameter int  FIPS_CSRNG_BUS_WIDTH = entropy_src_pkg::FIPS_BUS_WIDTH + entropy_src_pkg::CSRNG_BUS_WIDTH;
+
   // macro includes
   `include "uvm_macros.svh"
   `include "dv_macros.svh"

--- a/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
@@ -12,8 +12,12 @@ class entropy_src_scoreboard extends cip_base_scoreboard #(
   // local variables
 
   // TLM agent fifos
+  uvm_tlm_analysis_fifo#(push_pull_item#(.HostDataWidth(FIPS_CSRNG_BUS_WIDTH)))  csrng_fifo;
+  uvm_tlm_analysis_fifo#(push_pull_item#(.HostDataWidth(entropy_src_pkg::RNG_BUS_WIDTH)))  rng_fifo;
 
   // local queues to hold incoming packets pending comparison
+  push_pull_item#(.HostDataWidth(FIPS_CSRNG_BUS_WIDTH))  csrng_q[$];
+  push_pull_item#(.HostDataWidth(entropy_src_pkg::RNG_BUS_WIDTH))  rng_q[$];
 
   `uvm_component_new
 

--- a/hw/ip/entropy_src/dv/env/entropy_src_virtual_sequencer.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_virtual_sequencer.sv
@@ -8,6 +8,8 @@ class entropy_src_virtual_sequencer extends cip_base_virtual_sequencer #(
   );
   `uvm_component_utils(entropy_src_virtual_sequencer)
 
+  push_pull_sequencer#(.HostDataWidth(entropy_src_pkg::RNG_BUS_WIDTH))  rng_sequencer_h;
+  push_pull_sequencer#(.HostDataWidth(FIPS_CSRNG_BUS_WIDTH))  csrng_sequencer_h;
 
   `uvm_component_new
 

--- a/hw/ip/entropy_src/dv/tb/tb.sv
+++ b/hw/ip/entropy_src/dv/tb/tb.sv
@@ -26,7 +26,7 @@ module tb;
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
   push_pull_if#(.HostDataWidth(entropy_src_pkg::RNG_BUS_WIDTH))
     rng_if(.clk(clk), .rst_n(rst_n));
-  push_pull_if#(.HostDataWidth(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH))
+  push_pull_if#(.HostDataWidth(FIPS_CSRNG_BUS_WIDTH))
     csrng_if(.clk(clk), .rst_n(rst_n));
 
   `DV_ALERT_IF_CONNECT
@@ -76,7 +76,7 @@ module tb;
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
     uvm_config_db#(virtual push_pull_if#(.HostDataWidth(entropy_src_pkg::RNG_BUS_WIDTH)))::set
                                         (null, "*.env.m_rng_agent*", "vif", rng_if);
-    uvm_config_db#(virtual push_pull_if#(.HostDataWidth(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH)))::set
+    uvm_config_db#(virtual push_pull_if#(.HostDataWidth(FIPS_CSRNG_BUS_WIDTH)))::set
                                         (null, "*.env.m_csrng_agent*", "vif", csrng_if);
     $timeformat(-12, 0, " ps", 12);
     run_test();

--- a/hw/ip/entropy_src/rtl/entropy_src_pkg.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_pkg.sv
@@ -10,16 +10,15 @@ package entropy_src_pkg;
   // Entropy Interface
   //-------------------------
 
-  parameter int  RNG_BUS_WIDTH        = 4;
-  parameter int  CSRNG_BUS_WIDTH      = 384;
-  parameter int  FIPS_BUS_WIDTH       = 1;
-  parameter int  FIPS_CSRNG_BUS_WIDTH = CSRNG_BUS_WIDTH + FIPS_BUS_WIDTH;
+  parameter int  RNG_BUS_WIDTH   = 4;
+  parameter int  CSRNG_BUS_WIDTH = 384;
+  parameter int  FIPS_BUS_WIDTH  = 1;
 
   // es entropy i/f
   typedef struct packed {
     logic es_ack;
     logic [CSRNG_BUS_WIDTH-1:0] es_bits;
-    logic es_fips;
+    logic [FIPS_BUS_WIDTH-1:0] es_fips;
   } entropy_src_hw_if_rsp_t;
 
   typedef struct packed {
@@ -45,7 +44,7 @@ package entropy_src_pkg;
 
   // external health test i/f
   typedef struct packed {
-    logic [3:0] entropy_bit;
+    logic [RNG_BUS_WIDTH-1:0] entropy_bit;
     logic entropy_bit_valid;
     logic clear;
     logic active;


### PR DESCRIPTION
Signed-off-by: Steve Nelson <steve.nelson@wdc.com>

Moved parameter to env pkg since it's only used for dv, added agent stuff to scoreboard/sequencer.