### PR TITLE
[rv_dm/jtag] Split JTAG type into separate jtag_pkg

### DIFF
--- a/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
@@ -22,8 +22,8 @@ module lc_ctrl
   input  tlul_pkg::tl_h2d_t                          tl_i,
   output tlul_pkg::tl_d2h_t                          tl_o,
   // JTAG TAP.
-  input  rv_dm_pkg::jtag_req_t                       jtag_req_i,
-  output rv_dm_pkg::jtag_rsp_t                       jtag_rsp_o,
+  input  jtag_pkg::jtag_req_t                        jtag_req_i,
+  output jtag_pkg::jtag_rsp_t                        jtag_rsp_o,
   // This bypasses the clock inverter inside the JTAG TAP for scanmmode.
   input                                              scanmode_i,
   // Alert outputs.

--- a/hw/ip/rv_dm/jtag_pkg.core
+++ b/hw/ip/rv_dm/jtag_pkg.core
@@ -1,0 +1,18 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:ip:jtag_pkg:0.1"
+description: "JTAG package with interface types"
+
+filesets:
+  files_rtl:
+    depend:
+    files:
+      - rtl/jtag_pkg.sv
+    file_type: systemVerilogSource
+
+targets:
+  default: &default_target
+    filesets:
+      - files_rtl

--- a/hw/ip/rv_dm/rtl/jtag_pkg.sv
+++ b/hw/ip/rv_dm/rtl/jtag_pkg.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-package rv_dm_pkg;
+package jtag_pkg;
 
   typedef struct packed {
     logic tck;
@@ -21,4 +21,4 @@ package rv_dm_pkg;
 
   parameter jtag_rsp_t JTAG_RSP_DEFAULT = '0;
 
-endpackage : rv_dm_pkg
+endpackage : jtag_pkg

--- a/hw/ip/rv_dm/rtl/rv_dm.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm.sv
@@ -12,9 +12,7 @@
 
 `include "prim_assert.sv"
 
-module rv_dm
-  import rv_dm_pkg::*;
-#(
+module rv_dm #(
   parameter int              NrHarts = 1,
   parameter logic [31:0]     IdcodeValue = 32'h 0000_0001
 ) (
@@ -36,8 +34,8 @@ module rv_dm
   output tlul_pkg::tl_h2d_t  tl_h_o,
   input  tlul_pkg::tl_d2h_t  tl_h_i,
 
-  input  jtag_req_t          jtag_req_i,
-  output jtag_rsp_t          jtag_rsp_o
+  input  jtag_pkg::jtag_req_t jtag_req_i,
+  output jtag_pkg::jtag_rsp_t jtag_rsp_o
 );
 
   `ASSERT_INIT(paramCheckNrHarts, NrHarts > 0)

--- a/hw/ip/rv_dm/rv_dm.core
+++ b/hw/ip/rv_dm/rv_dm.core
@@ -8,12 +8,12 @@ description: "RISC-V debug module"
 filesets:
   files_rtl:
     depend:
+      - lowrisc:ip:jtag_pkg
       - lowrisc:ip:tlul
       - lowrisc:prim:all
       - lowrisc:tlul:adapter_host
       - pulp-platform:riscv-dbg:0.1
     files:
-      - rtl/rv_dm_pkg.sv
       - rtl/rv_dm.sv
     file_type: systemVerilogSource
 

--- a/hw/top_earlgrey/data/top_earlgrey.sv.tpl
+++ b/hw/top_earlgrey/data/top_earlgrey.sv.tpl
@@ -254,8 +254,8 @@ module top_${top["name"]} #(
 
   // TODO: this will be routed to the pinmux for TAP selection
   // based on straps and LC control signals.
-  rv_dm_pkg::jtag_req_t jtag_req;
-  rv_dm_pkg::jtag_rsp_t jtag_rsp;
+  jtag_pkg::jtag_req_t jtag_req;
+  jtag_pkg::jtag_rsp_t jtag_rsp;
   logic unused_jtag_tdo_oe_o;
 
   assign jtag_req.tck    = jtag_tck_i;

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -433,8 +433,8 @@ module top_earlgrey #(
 
   // TODO: this will be routed to the pinmux for TAP selection
   // based on straps and LC control signals.
-  rv_dm_pkg::jtag_req_t jtag_req;
-  rv_dm_pkg::jtag_rsp_t jtag_rsp;
+  jtag_pkg::jtag_req_t jtag_req;
+  jtag_pkg::jtag_rsp_t jtag_rsp;
   logic unused_jtag_tdo_oe_o;
 
   assign jtag_req.tck    = jtag_tck_i;


### PR DESCRIPTION
This moves the JTAG interface structs into a dedicated `jtag_pkg`.

Signed-off-by: Michael Schaffner <msf@opentitan.org>