### PR TITLE
[dv] Fix push_pull_agent

### DIFF
--- a/hw/dv/sv/push_pull_agent/push_pull_agent.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_agent.sv
@@ -33,7 +33,7 @@ class push_pull_agent #(parameter int HostDataWidth = 32,
   function void connect_phase(uvm_phase phase);
     super.connect_phase(phase);
     if (cfg.if_mode == dv_utils_pkg::Device) begin
-      monitor.req_port.connect(sequencer.req_fifo.analysis_export);
+      monitor.req_port.connect(sequencer.push_pull_req_fifo.analysis_export);
     end
   endfunction
 

--- a/hw/dv/sv/push_pull_agent/push_pull_sequencer.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_sequencer.sv
@@ -12,14 +12,14 @@ class push_pull_sequencer #(parameter int HostDataWidth = 32,
 
   // Analysis port through which device monitors can send transactions
   // to the sequencer.
-  uvm_tlm_analysis_fifo #(push_pull_item#(HostDataWidth, DeviceDataWidth)) req_fifo;
+  uvm_tlm_analysis_fifo #(push_pull_item#(HostDataWidth, DeviceDataWidth)) push_pull_req_fifo;
 
   `uvm_component_new
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
     if (cfg.if_mode == dv_utils_pkg::Device) begin
-      req_fifo = new("req_fifo");
+      push_pull_req_fifo = new("push_pull_req_fifo", this);
     end
   endfunction : build_phase
 

--- a/hw/dv/sv/push_pull_agent/seq_lib/push_pull_device_seq.sv
+++ b/hw/dv/sv/push_pull_agent/seq_lib/push_pull_device_seq.sv
@@ -44,7 +44,7 @@ class push_pull_device_seq #(parameter int HostDataWidth = 32,
       fork
         forever begin : collect_req
           // We indefinitely poll for any traffic sent from the monitor and store it to a mailbox.
-          p_sequencer.req_fifo.get(req);
+          p_sequencer.push_pull_req_fifo.get(req);
           req_mailbox.put(req);
         end : collect_req
         forever begin : send_req


### PR DESCRIPTION
Found 2 interesting issues. Related to #4448
1. without `this` when we create analysis_fifo, it will be created under
root and if we create 2 of them (like create 2 device agents), will see this error
UVM_FATAL @         0 ps: (uvm_component.svh:1897) req_fifo [CLDEXT] Name 'req_fifo' is not unique to other top-level instances. If parent is a module, build a unique name by combining the the module name and component name: $sformatf("%m.%s","req_fifo").

2. `req_fifo` is the name which is already used in
[uvm_sequencer_param_base](https://verificationacademy.com/verification-methodology-reference/uvm/docs_1.2/html/src/seq/uvm_sequencer_param_base.svh), So have to rename it

Signed-off-by: Weicai Yang <weicai@google.com>