### PR TITLE
[lc_ctrl] Two minor fixes

### DIFF
--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_pkg.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_pkg.sv
@@ -281,7 +281,7 @@ package lc_ctrl_pkg;
     ZeroTokenIdx,          // -> SCRAP
     RmaTokenIdx,           // -> RMA
     {11{InvalidTokenIdx}}, // -> TEST_LOCKED0-2, TEST_UNLOCKED0-3, DEV, PROD, PROD_END
-    // TEST_UNLOCKED2
+    // TEST_UNLOCKED3
     {2{ZeroTokenIdx}},     // -> SCRAP, RMA
     {3{TestExitTokenIdx}}, // -> PROD, PROD_END, DEV
     {8{InvalidTokenIdx}},  // -> TEST_LOCKED0-2, TEST_UNLOCKED0-3, RAW

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_signal_decode.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_signal_decode.sv
@@ -189,16 +189,16 @@ module lc_ctrl_signal_decode
 
   // Need to make sure that the random netlist constants
   // are unique.
-  `ASSERT_INIT(LcKeymgrDivUnique0_A, !(RndCnstLcKeymgrDivInvalid inside {RndCnstLcKeymgrDivTest,
-                                                                         RndCnstLcKeymgrDivProd,
-                                                                         RndCnstLcKeymgrDivDev,
-                                                                         RndCnstLcKeymgrDivRma}))
-  `ASSERT_INIT(LcKeymgrDivUnique1_A, !(RndCnstLcKeymgrDivTest    inside {RndCnstLcKeymgrDivProd,
-                                                                         RndCnstLcKeymgrDivDev,
-                                                                         RndCnstLcKeymgrDivRma}))
-  `ASSERT_INIT(LcKeymgrDivUnique2_A, !(RndCnstLcKeymgrDivProd    inside {RndCnstLcKeymgrDivDev,
-                                                                         RndCnstLcKeymgrDivRma}))
-  `ASSERT_INIT(LcKeymgrDivUnique3_A, !(RndCnstLcKeymgrDivDev     inside {RndCnstLcKeymgrDivRma}))
+  `ASSERT_INIT(LcKeymgrDivUnique0_A, !(RndCnstLcKeymgrDivInv  inside {RndCnstLcKeymgrDivTest,
+                                                                      RndCnstLcKeymgrDivProd,
+                                                                      RndCnstLcKeymgrDivDev,
+                                                                      RndCnstLcKeymgrDivRma}))
+  `ASSERT_INIT(LcKeymgrDivUnique1_A, !(RndCnstLcKeymgrDivTest inside {RndCnstLcKeymgrDivProd,
+                                                                      RndCnstLcKeymgrDivDev,
+                                                                      RndCnstLcKeymgrDivRma}))
+  `ASSERT_INIT(LcKeymgrDivUnique2_A, !(RndCnstLcKeymgrDivProd inside {RndCnstLcKeymgrDivDev,
+                                                                      RndCnstLcKeymgrDivRma}))
+  `ASSERT_INIT(LcKeymgrDivUnique3_A, !(RndCnstLcKeymgrDivDev  inside {RndCnstLcKeymgrDivRma}))
 
   `ASSERT(SignalsAreOffWhenNotEnabled_A,
       !lc_state_valid_i


### PR DESCRIPTION
1. Fix assertion naming typo.
2. Fix comment naming `TEST_UNLOCK_TOKEN2` -> `TEST_UNLOCK_TOKEN3`

Signed-off-by: Cindy Chen <chencindy@google.com>