### PR TITLE
[otbn] Shift by bits, not bytes in big number instructions

### DIFF
--- a/hw/ip/otbn/data/bignum-insns.yml
+++ b/hw/ip/otbn/data/bignum-insns.yml
@@ -19,17 +19,17 @@
       type: enum(<<, >>)
       doc: |
         The direction of an optional shift applied to `<wrs2>`.
-    - &bn-shift-bytes-operand
-      name: shift_bytes
-      type: uimm5
+    - &bn-shift-bits-operand
+      name: shift_bits
+      type: uimm5<<3
       doc: |
-        Number of bytes by which to shift `<wrs2>`. Defaults to 0.
+        Number of bits by which to shift `<wrs2>`. Defaults to 0.
     - &bn-flag-group-operand
       name: flag_group
       type: uimm1
       doc: Flag group to use. Defaults to 0.
   syntax: &bn-add-syntax |
-    <wrd>, <wrs1>, <wrs2>[ <shift_type> <shift_bytes>B][, FG<flag_group>]
+    <wrd>, <wrs1>, <wrs2>[ <shift_type> <shift_bits>][, FG<flag_group>]
   doc: |
     Adds two WDR values, writes the result to the destination WDR and updates
     flags. The content of the second source WDR can be shifted by an unsigned
@@ -40,7 +40,7 @@
     b = UInt(wrs2)
 
     fg = DecodeFlagGroup(flag_group)
-    sb = UInt(shift_bytes)
+    sb = UInt(shift_bits) // 8
     st = DecodeShiftType(shift_type)
   operation: |
     b_shifted = ShiftReg(b, st, sb)
@@ -53,7 +53,7 @@
     mapping:
       fg: flag_group
       shift_type: shift_type
-      shift_bytes: shift_bytes
+      shift_bits: shift_bits
       wrs2: wrs2
       wrs1: wrs1
       funct3: b000
@@ -74,7 +74,7 @@
     b = UInt(wrs2)
 
     fg = DecodeFlagGroup(flag_group)
-    sb = UInt(shift_bytes)
+    sb = UInt(shift_bits) // 8
     st = DecodeShiftType(shift_type)
   operation: |
     b_shifted = ShiftReg(b, st, sb)
@@ -87,7 +87,7 @@
     mapping:
       fg: flag_group
       shift_type: shift_type
-      shift_bytes: shift_bytes
+      shift_bits: shift_bits
       wrs2: wrs2
       wrs1: wrs1
       funct3: b010
@@ -398,7 +398,7 @@
     - name: wrs2
       doc: Name of the second source WDR
     - *bn-shift-type-operand
-    - *bn-shift-bytes-operand
+    - *bn-shift-bits-operand
     - *bn-flag-group-operand
   syntax: *bn-add-syntax
   doc: |
@@ -410,7 +410,7 @@
     b = UInt(wrs2)
 
     fg = DecodeFlagGroup(flag_group)
-    sb = UInt(shift_bytes)
+    sb = UInt(shift_bits) // 8
     st = DecodeShiftType(shift_type)
   operation: |
     b_shifted = ShiftReg(b, st, sb)
@@ -423,7 +423,7 @@
     mapping:
       fg: flag_group
       shift_type: shift_type
-      shift_bytes: shift_bytes
+      shift_bits: shift_bits
       wrs2: wrs2
       wrs1: wrs1
       funct3: b001
@@ -448,7 +448,7 @@
     mapping:
       fg: flag_group
       shift_type: shift_type
-      shift_bytes: shift_bytes
+      shift_bits: shift_bits
       wrs2: wrs2
       wrs1: wrs1
       funct3: b011
@@ -534,10 +534,10 @@
     - name: wrs2
       doc: Name of the second source WDR
     - *bn-shift-type-operand
-    - *bn-shift-bytes-operand
+    - *bn-shift-bits-operand
     - *bn-flag-group-operand
   syntax: &bn-and-syntax |
-    <wrd>, <wrs1>, <wrs2>[ <shift_type> <shift_bytes>B][, FG<flag_group>]
+    <wrd>, <wrs1>, <wrs2>[ <shift_type> <shift_bits>][, FG<flag_group>]
   doc: |
     Performs a bitwise and operation.
     Takes the values stored in registers referenced by `wrs1` and `wrs2` and stores the result in the register referenced by `wrd`.
@@ -548,7 +548,7 @@
     a = UInt(wrs1)
     b = UInt(wrs2)
 
-    sb = UInt(shift_bytes)
+    sb = UInt(shift_bits) // 8
     st = DecodeShiftType(shift_type)
     fg = DecodeFlagGroup(flag_group)
   operation: |
@@ -563,7 +563,7 @@
     mapping:
       fg: flag_group
       shift_type: shift_type
-      shift_bytes: shift_bytes
+      shift_bits: shift_bits
       wrs2: wrs2
       wrs1: wrs1
       funct3: b010
@@ -591,7 +591,7 @@
     mapping:
       fg: flag_group
       shift_type: shift_type
-      shift_bytes: shift_bytes
+      shift_bits: shift_bits
       wrs2: wrs2
       wrs1: wrs1
       funct3: b100
@@ -605,10 +605,10 @@
     - name: wrs
       doc: Name of the source WDR
     - *bn-shift-type-operand
-    - *bn-shift-bytes-operand
+    - *bn-shift-bits-operand
     - *bn-flag-group-operand
   syntax: |
-    <wrd>, <wrs>[ <shift_type> <shift_bytes>B][, FG<flag_group>]
+    <wrd>, <wrs>[ <shift_type> <shift_bits>][, FG<flag_group>]
   doc: |
     Negates the value in `wrs` and stores the result in the register referenced by `wrd`.
     The source value can be shifted by an immediate before it is consumed by the operation.
@@ -617,7 +617,7 @@
     d = UInt(wrd)
     a = UInt(wrs1)
 
-    sb = UInt(shift_bytes)
+    sb = UInt(shift_bits) // 8
     st = DecodeShiftType(shift_type)
     fg = DecodeFlagGroup(flag_group)
   operation: |
@@ -632,7 +632,7 @@
     mapping:
       fg: flag_group
       shift_type: shift_type
-      shift_bytes: shift_bytes
+      shift_bits: shift_bits
       wrs1: wrs
       funct3: b101
       wrd: wrd
@@ -659,7 +659,7 @@
     mapping:
       fg: flag_group
       shift_type: shift_type
-      shift_bytes: shift_bytes
+      shift_bits: shift_bits
       wrs2: wrs2
       wrs1: wrs1
       funct3: b110
@@ -748,10 +748,10 @@
     - name: wrs2
       doc: Name of the second source WDR
     - *bn-shift-type-operand
-    - *bn-shift-bytes-operand
+    - *bn-shift-bits-operand
     - *bn-flag-group-operand
   syntax: &bn-cmp-syntax |
-    <wrs1>, <wrs2>[ <shift_type> <shift_bytes>B][, FG<flag_group>]
+    <wrs1>, <wrs2>[ <shift_type> <shift_bits>][, FG<flag_group>]
   doc: |
     Subtracts the second WDR value from the first one and updates flags.
     This instruction is identical to BN.SUB, except that no result register is written.
@@ -760,7 +760,7 @@
     b = UInt(wrs2)
 
     fg = DecodeFlagGroup(flag_group)
-    sb = UInt(shift_bytes)
+    sb = UInt(shift_bits) // 8
     st = DecodeShiftType(shift_type)
   operation: |
     b_shifted = ShiftReg(b, st, sb)
@@ -772,7 +772,7 @@
     mapping:
       fg: flag_group
       shift_type: shift_type
-      shift_bytes: shift_bytes
+      shift_bits: shift_bits
       wrs2: wrs2
       wrs1: wrs1
       funct3: b001
@@ -794,7 +794,7 @@
     mapping:
       fg: flag_group
       shift_type: shift_type
-      shift_bytes: shift_bytes
+      shift_bits: shift_bits
       wrs2: wrs2
       wrs1: wrs1
       funct3: b011

--- a/hw/ip/otbn/data/enc-schemes.yml
+++ b/hw/ip/otbn/data/enc-schemes.yml
@@ -170,7 +170,7 @@ fg:
 shift:
   fields:
     shift_type: 30
-    shift_bytes: 29-25
+    shift_bits: 29-25
 
 # A partial scheme for specialized 2 bit function field, we need a reduced
 # size in the lower two bits of funct3 as RSHI spills over 1 bit from its

--- a/hw/ip/otbn/dv/otbnsim/sim/insn.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/insn.py
@@ -347,7 +347,7 @@ class BNADD(OTBNInsn):
         self.wrs1 = op_vals['wrs1']
         self.wrs2 = op_vals['wrs2']
         self.shift_type = op_vals['shift_type']
-        self.shift_bytes = op_vals['shift_bytes']
+        self.shift_bytes = op_vals['shift_bits'] // 8
         self.flag_group = op_vals['flag_group']
 
     def execute(self, state: OTBNState) -> None:
@@ -369,7 +369,7 @@ class BNADDC(OTBNInsn):
         self.wrs1 = op_vals['wrs1']
         self.wrs2 = op_vals['wrs2']
         self.shift_type = op_vals['shift_type']
-        self.shift_bytes = op_vals['shift_bytes']
+        self.shift_bytes = op_vals['shift_bits'] // 8
         self.flag_group = op_vals['flag_group']
 
     def execute(self, state: OTBNState) -> None:
@@ -540,7 +540,7 @@ class BNSUB(OTBNInsn):
         self.wrs1 = op_vals['wrs1']
         self.wrs2 = op_vals['wrs2']
         self.shift_type = op_vals['shift_type']
-        self.shift_bytes = op_vals['shift_bytes']
+        self.shift_bytes = op_vals['shift_bits'] // 8
         self.flag_group = op_vals['flag_group']
 
     def execute(self, state: OTBNState) -> None:
@@ -562,7 +562,7 @@ class BNSUBB(OTBNInsn):
         self.wrs1 = op_vals['wrs1']
         self.wrs2 = op_vals['wrs2']
         self.shift_type = op_vals['shift_type']
-        self.shift_bytes = op_vals['shift_bytes']
+        self.shift_bytes = op_vals['shift_bits'] // 8
         self.flag_group = op_vals['flag_group']
 
     def execute(self, state: OTBNState) -> None:
@@ -627,7 +627,7 @@ class BNAND(OTBNInsn):
         self.wrs1 = op_vals['wrs1']
         self.wrs2 = op_vals['wrs2']
         self.shift_type = op_vals['shift_type']
-        self.shift_bytes = op_vals['shift_bytes']
+        self.shift_bytes = op_vals['shift_bits'] // 8
         self.flag_group = op_vals['flag_group']
 
     def execute(self, state: OTBNState) -> None:
@@ -649,7 +649,7 @@ class BNOR(OTBNInsn):
         self.wrs1 = op_vals['wrs1']
         self.wrs2 = op_vals['wrs2']
         self.shift_type = op_vals['shift_type']
-        self.shift_bytes = op_vals['shift_bytes']
+        self.shift_bytes = op_vals['shift_bits'] // 8
         self.flag_group = op_vals['flag_group']
 
     def execute(self, state: OTBNState) -> None:
@@ -670,7 +670,7 @@ class BNNOT(OTBNInsn):
         self.wrd = op_vals['wrd']
         self.wrs = op_vals['wrs']
         self.shift_type = op_vals['shift_type']
-        self.shift_bytes = op_vals['shift_bytes']
+        self.shift_bytes = op_vals['shift_bits'] // 8
         self.flag_group = op_vals['flag_group']
 
     def execute(self, state: OTBNState) -> None:
@@ -691,7 +691,7 @@ class BNXOR(OTBNInsn):
         self.wrs1 = op_vals['wrs1']
         self.wrs2 = op_vals['wrs2']
         self.shift_type = op_vals['shift_type']
-        self.shift_bytes = op_vals['shift_bytes']
+        self.shift_bytes = op_vals['shift_bits'] // 8
         self.flag_group = op_vals['flag_group']
 
     def execute(self, state: OTBNState) -> None:
@@ -748,7 +748,7 @@ class BNCMP(OTBNInsn):
         self.wrs1 = op_vals['wrs1']
         self.wrs2 = op_vals['wrs2']
         self.shift_type = op_vals['shift_type']
-        self.shift_bytes = op_vals['shift_bytes']
+        self.shift_bytes = op_vals['shift_bits'] // 8
         self.flag_group = op_vals['flag_group']
 
     def execute(self, state: OTBNState) -> None:
@@ -768,7 +768,7 @@ class BNCMPB(OTBNInsn):
         self.wrs1 = op_vals['wrs1']
         self.wrs2 = op_vals['wrs2']
         self.shift_type = op_vals['shift_type']
-        self.shift_bytes = op_vals['shift_bytes']
+        self.shift_bytes = op_vals['shift_bits'] // 8
         self.flag_group = op_vals['flag_group']
 
     def execute(self, state: OTBNState) -> None:

--- a/hw/ip/otbn/dv/smoke/smoke_test.s
+++ b/hw/ip/otbn/dv/smoke/smoke_test.s
@@ -184,17 +184,17 @@ bn.subb w17, w3, w4, FG1
 # x24 = {fg1, fg0} = 0x55
 csrrs x24, 0x7c8, x0
 
-# w18 = w1 + (w2 << 17B) = 0x1296659f_bbc28370_23634ee9_22168a4e_c79af825_69be586e_9866bb3b_53769ada
-bn.add w18, w1, w2 << 17B
+# w18 = w1 + (w2 << 136) = 0x1296659f_bbc28370_23634ee9_22168a4e_c79af825_69be586e_9866bb3b_53769ada
+bn.add w18, w1, w2 << 136
 
-# w19 = w1 & (w2 << 9B) = 0x18988800_00088990_89899109_88189108_81989801_09981800_00000000_00000000
-bn.and w19, w1, w2 << 9B
+# w19 = w1 & (w2 << 72) = 0x18988800_00088990_89899109_88189108_81989801_09981800_00000000_00000000
+bn.and w19, w1, w2 << 72
 
-# w20 = w1 - (w2 >> 23B) = 0x78fccc06_2228e9d6_89c9b54f_887cf14e_c79af825_69be57d4_fecd21a1_b9dd0141
-bn.sub w20, w1, w2 >> 23B
+# w20 = w1 - (w2 >> 184) = 0x78fccc06_2228e9d6_89c9b54f_887cf14e_c79af825_69be57d4_fecd21a1_b9dd0141
+bn.sub w20, w1, w2 >> 184
 
-# w21 = w1 | (w2 >> 15B) = 0x78fccc06_2228e9d6_89c9b54f_887cf1df_df9bf9bd_f9bfd9ff_99ffbbbb_dbff9bdb
-bn.or  w21, w1, w2 >> 15B
+# w21 = w1 | (w2 >> 120) = 0x78fccc06_2228e9d6_89c9b54f_887cf1df_df9bf9bd_f9bfd9ff_99ffbbbb_dbff9bdb
+bn.or  w21, w1, w2 >> 120
 
 # w22 = w21 + 0x1bd = 0x78fccc06_2228e9d6_89c9b54f_887cf1df_df9bf9bd_f9bfd9ff_99ffbbbb_dbff9d98
 bn.addi w22, w21, 0x1bd


### PR DESCRIPTION
The encoding is actually unchanged (because we're encoding the number
of bits, shifted down by 3, which *is* the number of bytes), but the
syntax changes from

    bn.add w0, w1, w2 << 2B, FG0

to

    bn.add w0, w1, w2 << 16, FG0

Fixes #3271.

(@felixmiller: I don't think we actually have any code checked in that uses the shift syntax at the moment, but I'm tagging you as a heads-up in case you're working on some)