### PR TITLE
Update landing site to point at latest blog post

### DIFF
--- a/site/landing/config.toml
+++ b/site/landing/config.toml
@@ -11,7 +11,8 @@ disableKinds = ["taxonomy", "taxonomyTerm", "RSS", "sitemap", "categories"]
 [params]
 description = "The first open source project building a transparent, high-quality reference design and integration guidelines for silicon root of trust (RoT) chips"
 github_repo = "https://github.com/lowRISC/opentitan"
-blogpost = "https://security.googleblog.com/2019/11/opentitan-open-sourcing-transparent.html"
+one_year_url = "https://security.googleblog.com/2020/12/opentitan-at-one-year-open-source.html"
+announce_url = "https://security.googleblog.com/2019/11/opentitan-open-sourcing-transparent.html"
 contact_email = "pilots@opentitan.org"
 get_involved_email = "get-involved@opentitan.org"
 

--- a/site/landing/layouts/index.html
+++ b/site/landing/layouts/index.html
@@ -47,7 +47,7 @@
           <a href="{{ .Site.Params.github_repo }}">Source</a>
         </li>
         <li class="main-nav__item">
-          <a href="{{ .Site.Params.blogpost }}">Blog</a>
+          <a href="{{ .Site.Params.one_year_url }}">Blog</a>
         </li>
         <li class="main-nav__item user-toggle">
           <button class="[ toggle-button ] [ js-mode-toggle ]" aria-label="Switch light and dark theme">
@@ -162,7 +162,7 @@
         OpenTitan helps to make the silicon root of trust (RoT) more transparent,
         trustworthy, and ultimately, secure.
       </p>
-      <a href="{{ .Site.Params.blogpost }}" class="btn" aria-label="Learn more about OpenTitan">Learn more</a>
+      <a href="{{ .Site.Params.announce_url }}" class="btn" aria-label="Learn more about OpenTitan">Learn more</a>
     </section>
 
     <section id="features" class="features light-bg">
@@ -210,7 +210,7 @@
             actively mediating access to the first-stage boot firmware. It is
             built upon the quality constructs and security principles used to
             create
-            <a href="{{ .Site.Params.blogpost }}">Google's Titan chips</a>.
+            <a href="{{ .Site.Params.announce_url }}">Google's Titan chips</a>.
           </p>
         </li>
         <li class="feature-list__item">
@@ -315,7 +315,7 @@
           <a href="{{ .Site.Params.github_repo }}">Source</a>
         </li>
         <li class="footer-nav__item">
-          <a href="{{ .Site.Params.blogpost }}">Blog</a>
+          <a href="{{ .Site.Params.one_year_url }}">Blog</a>
         </li>
         <li class="footer-nav__item footer-nav__item--icons">
           <a href="{{ .Site.Params.github_repo }}" aria-label="View on Github">


### PR DESCRIPTION
This changes the "blogpost" parameter to be called "announce_url":
there are some other places we use this which we probably want to keep
pointing at the announcement. Then I've used "one_year_url" for the
latest "it's been a year" blog post.
